### PR TITLE
drivers: i3c: add i3c v1.0 support

### DIFF
--- a/drivers/i3c/i3c_ccc.c
+++ b/drivers/i3c/i3c_ccc.c
@@ -137,6 +137,26 @@ int i3c_ccc_do_rstact(const struct i3c_device_desc *target,
 	return i3c_do_ccc(target->bus, &ccc_payload);
 }
 
+int i3c_ccc_do_rstdaa(struct i3c_device_desc *target)
+{
+	struct i3c_ccc_payload ccc_payload;
+	struct i3c_ccc_target_payload ccc_tgt_payload;
+
+	__ASSERT_NO_MSG(target != NULL);
+	__ASSERT_NO_MSG(target->bus != NULL);
+
+	ccc_tgt_payload.addr = target->dynamic_addr;
+	ccc_tgt_payload.rnw = 1;
+	ccc_tgt_payload.data_len = 0;
+
+	memset(&ccc_payload, 0, sizeof(ccc_payload));
+	ccc_payload.ccc.id = I3C_CCC_RSTDAA_DC;
+	ccc_payload.targets.payloads = &ccc_tgt_payload;
+	ccc_payload.targets.num_targets = 1;
+
+	return i3c_do_ccc(target->bus, &ccc_payload);
+}
+
 int i3c_ccc_do_rstdaa_all(const struct device *controller)
 {
 	struct i3c_ccc_payload ccc_payload;

--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -776,28 +776,28 @@ int i3c_device_adv_info_get(struct i3c_device_desc *target)
 	/* GETMRL */
 	if (i3c_ccc_do_getmrl(target, &mrl) != 0) {
 		/* GETMRL may be optionally supported if no settable limit */
-		LOG_DBG("No settable limit for GETMRL");
+		LOG_DBG("%s: No settable limit for GETMRL", target->dev->name);
 	}
 
 	/* GETMWL */
 	if (i3c_ccc_do_getmwl(target, &mwl) != 0) {
 		/* GETMWL may be optionally supported if no settable limit */
-		LOG_DBG("No settable limit for GETMWL");
+		LOG_DBG("%s: No settable limit for GETMWL", target->dev->name);
 	}
 
 	/* GETCAPS */
-	ret = i3c_ccc_do_getcaps_fmt1(target, &caps);
-	/*
-	 * GETCAPS (GETHDRCAP) is required to be supported for I3C v1.0 targets that support HDR
-	 * modes and required if the Target's I3C version is v1.1 or later, but which the version it
-	 * supports it can't be known ahead of time. So if the BCR bit for Advanced capabilities is
-	 * set, then it is expected for GETCAPS to always be supported. Otherwise, then it's a I3C
-	 * v1.0 device without any HDR modes so do not treat as an error if no valid response.
-	 */
-	if ((ret != 0) && (target->bcr & I3C_BCR_ADV_CAPABILITIES)) {
-		return ret;
-	} else {
-		ret = 0;
+	if (((target->flags & I3C_V1P0_SUPPORT) && (target->bcr & I3C_BCR_ADV_CAPABILITIES)) ||
+	    (!(target->flags & I3C_V1P0_SUPPORT))) {
+		/*
+		 * GETCAPS (GETHDRCAP) is required to be supported for I3C v1.0 targets that support
+		 * HDR modes and required if the Target's I3C version is v1.1 or later.
+		 * It is also possible for this function to be called on an 'unknown' device such as
+		 * from a secondary controller gathering info about a target it found about through
+		 * DEFTGTS, and it can't be known ahead of time if it is a v1.0 or v1.1 device.
+		 */
+		if (i3c_ccc_do_getcaps_fmt1(target, &caps) != 0) {
+			LOG_DBG("%s: GETCAPS not received", target->dev->name);
+		}
 	}
 
 	/* CRCAPS */
@@ -872,8 +872,9 @@ static int i3c_bus_setdasa(const struct device *dev, const struct i3c_dev_list *
 		 * address as its static address if a different dynamic address
 		 * is not requested
 		 */
-		if ((desc->supports_setaasa) && ((desc->init_dynamic_addr == 0) ||
-						 desc->init_dynamic_addr == desc->static_addr)) {
+		if ((desc->flags & I3C_SUPPORTS_SETAASA) &&
+		    ((desc->init_dynamic_addr == 0) ||
+		     desc->init_dynamic_addr == desc->static_addr)) {
 			*need_aasa = true;
 			continue;
 		}
@@ -1078,7 +1079,8 @@ int i3c_bus_init(const struct device *dev, const struct i3c_dev_list *dev_list)
 				 * Only set for devices that support SETAASA and do not
 				 * request a different dynamic address than its SA
 				 */
-				if ((desc->supports_setaasa) && (desc->static_addr != 0) &&
+				if ((desc->flags & I3C_SUPPORTS_SETAASA) &&
+				    (desc->static_addr != 0) &&
 				    ((desc->init_dynamic_addr == 0) ||
 				     desc->init_dynamic_addr == desc->static_addr)) {
 					desc->dynamic_addr = desc->static_addr;

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -638,7 +638,7 @@ static int cmd_i3c_ccc_setaasa(const struct shell *sh, size_t argc, char **argv)
 
 	/* set all devices DA to SA */
 	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
-		if ((desc->supports_setaasa) && (desc->dynamic_addr == 0) &&
+		if (((desc->flags) & I3C_SUPPORTS_SETAASA) && (desc->dynamic_addr == 0) &&
 		    (desc->static_addr != 0)) {
 			desc->dynamic_addr = desc->static_addr;
 		}

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -575,6 +575,36 @@ static int cmd_i3c_hdr_ddr_read(const struct shell *sh, size_t argc, char **argv
 	return ret;
 }
 
+/* i3c ccc rstdaa_dc <device> <target> */
+static int cmd_i3c_ccc_rstdaa_dc(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev, *tdev;
+	struct i3c_device_desc *desc;
+	int ret;
+
+	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
+	if (ret != 0) {
+		return ret;
+	}
+
+	if (!(desc->flags & I3C_V1P0_SUPPORT)) {
+		shell_error(sh, "I3C: %s does not support RSTDAA_DC.", tdev->name);
+		return -ENOTSUP;
+	}
+
+	ret = i3c_ccc_do_rstdaa(desc);
+	if (ret < 0) {
+		shell_error(sh, "I3C: unable to send CCC RSTDAA.");
+		return ret;
+	}
+
+	/* reset device DA */
+	desc->dynamic_addr = 0;
+	shell_print(sh, "Reset dynamic address for device %s", desc->dev->name);
+
+	return ret;
+}
+
 /* i3c ccc rstdaa <device> */
 static int cmd_i3c_ccc_rstdaa(const struct shell *sh, size_t argc, char **argv)
 {
@@ -2243,6 +2273,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 /* L2 I3C CCC Shell Commands*/
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_i3c_ccc_cmds,
+	SHELL_CMD_ARG(rstdaa_dc, &dsub_i3c_device_attached_name,
+		      "Send CCC RSTDAA\n"
+		      "Usage: ccc rstdaa_dc <device> <target>",
+		      cmd_i3c_ccc_rstdaa_dc, 3, 0),
 	SHELL_CMD_ARG(rstdaa, &dsub_i3c_device_name,
 		      "Send CCC RSTDAA\n"
 		      "Usage: ccc rstdaa <device>",

--- a/dts/bindings/i3c/i3c-device.yaml
+++ b/dts/bindings/i3c/i3c-device.yaml
@@ -67,3 +67,8 @@ properties:
     description: |
       Indicates if the device supports the CCC SETAASA. If true, it will
       be used as an optimization for bus initialization.
+
+  v1p0-support:
+    type: boolean
+    description: |
+      Indicates if the device compiles to I3C v1.0.

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -924,12 +924,13 @@ struct i3c_device_desc {
 	const uint8_t init_dynamic_addr;
 
 	/**
-	 * Device support for SETAASA
+	 * Device Flags
 	 *
-	 * This will be used as an optimization for bus initializtion if the
+	 * BIT[0]: This shall be used as an optimization for bus initializtion if the
 	 * device supports SETAASA.
+	 * BIT[1]: This shall be used to indicate if the device is a I3C v1.0 device
 	 */
-	const bool supports_setaasa;
+	const uint8_t flags;
 
 	/**
 	 * Dynamic Address for this target device used for communication.

--- a/include/zephyr/drivers/i3c/ccc.h
+++ b/include/zephyr/drivers/i3c/ccc.h
@@ -179,6 +179,14 @@ extern "C" {
  */
 #define I3C_CCC_VENDOR(broadcast, id)		((id) + ((broadcast) ? 0x61U : 0xE0U))
 
+/**
+ * Reset Dynamic Address (Direct)
+ *
+ * @note This should not be used by devices that support I3C v1.0 and this
+ * shall not be used for devices that support I3C v1.1 or later.
+ */
+#define I3C_CCC_RSTDAA_DC			0x86U
+
 /** Set Dynamic Address from Static Address (Direct) */
 #define I3C_CCC_SETDASA				0x87U
 
@@ -1503,6 +1511,21 @@ static inline int i3c_ccc_do_rstact_fmt3(const struct i3c_device_desc *target,
 }
 
 /**
+ * @brief Reset dynamic addresses for a targets.
+ *
+ * Helper function to reset a dynamic addresses of a targets.
+ *
+ * @note This should not be used by devices that support I3C v1.0 and this
+ * shall not be used for devices that support I3C v1.1 or later.
+ *
+ * @param[in] target Pointer to the target device descriptor where
+ *                   the device is configured with a dynamic address.
+ *
+ * @return @see i3c_do_ccc
+ */
+int i3c_ccc_do_rstdaa(struct i3c_device_desc *target);
+
+/**
  * @brief Broadcast RSTDAA to reset dynamic addresses for all targets.
  *
  * Helper function to reset dynamic addresses of all connected targets.
@@ -1538,7 +1561,7 @@ int i3c_ccc_do_setdasa(const struct i3c_device_desc *target,
  * Note this does not update @p target with the new dynamic address.
  *
  * @param[in] target Pointer to the target device descriptor where
- *                   the device is configured with a static address.
+ *                   the device is configured with a dynamic address.
  * @param[in] new_da Struct of the Dynamic address
  *
  * @return @see i3c_do_ccc

--- a/include/zephyr/drivers/i3c/devicetree.h
+++ b/include/zephyr/drivers/i3c/devicetree.h
@@ -53,6 +53,19 @@ extern "C" {
 	I3C_DEVICE_ID_DT(DT_DRV_INST(inst))
 
 /**
+ * @name I3C device flags.
+ * @anchor I3C_DEVICE_FLAGS
+ * @{
+ */
+
+/** Device supports SETAASA CCC */
+#define I3C_SUPPORTS_SETAASA		BIT(0)
+/** Device supports I3C v1.0 */
+#define I3C_V1P0_SUPPORT		BIT(1)
+
+/** @} */
+
+/**
  * @brief Structure initializer for i3c_device_desc from devicetree
  *
  * This helper macro expands to a static initializer for a <tt>struct
@@ -62,16 +75,16 @@ extern "C" {
  * @param node_id Devicetree node identifier for the I3C device whose
  *                struct i3c_device_desc to create an initializer for
  */
-#define I3C_DEVICE_DESC_DT(node_id)					\
-	{								\
-		.bus = DEVICE_DT_GET(DT_BUS(node_id)),			\
-		.dev = DEVICE_DT_GET(node_id),				\
-		.static_addr = DT_PROP_BY_IDX(node_id, reg, 0),		\
-		.pid = ((uint64_t)DT_PROP_BY_IDX(node_id, reg, 1) << 32)\
-		       | DT_PROP_BY_IDX(node_id, reg, 2),		\
-		.init_dynamic_addr =					\
-			DT_PROP_OR(node_id, assigned_address, 0),	\
-		.supports_setaasa = DT_PROP(node_id, supports_setaasa), \
+#define I3C_DEVICE_DESC_DT(node_id)                                                                \
+	{                                                                                          \
+		.bus = DEVICE_DT_GET(DT_BUS(node_id)),                                             \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
+		.static_addr = DT_PROP_BY_IDX(node_id, reg, 0),                                    \
+		.pid = ((uint64_t)DT_PROP_BY_IDX(node_id, reg, 1) << 32) |                         \
+		       DT_PROP_BY_IDX(node_id, reg, 2),                                            \
+		.init_dynamic_addr = DT_PROP_OR(node_id, assigned_address, 0),                     \
+		.flags = FIELD_PREP(I3C_SUPPORTS_SETAASA, DT_PROP(node_id, supports_setaasa)) |    \
+			 FIELD_PREP(I3C_V1P0_SUPPORT, DT_PROP(node_id, v1p0_support)),             \
 	},
 
 /**


### PR DESCRIPTION
I3C v1.0 does have few quirks with it. Such as supporting a direct RSTDAA as well as using GETHDRCAP.

This adds a devicetree flag to indicate support of v1.0. This resuses the same "bool" that support_setaasa used and turns it in to a flag byte.