### PR TITLE
drivers: i3c: add primary controller da property

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -458,9 +458,6 @@
  * Local Constants Definition
  ******************************************************************************/
 
-/* TODO: this needs to be configurable in the dts...somehow */
-#define I3C_CONTROLLER_ADDR 0x08
-
 /* Maximum i3c devices that the IP can be built with */
 #define I3C_MAX_DEVS                     11
 #define I3C_MAX_MSGS                     10
@@ -1016,13 +1013,22 @@ static void cdns_i3c_program_controller_retaining_reg(const struct device *dev)
 {
 	const struct cdns_i3c_config *config = dev->config;
 	struct cdns_i3c_data *data = dev->data;
-	/* Set controller retaining register */
-	uint8_t controller_da = I3C_CONTROLLER_ADDR;
+	uint8_t controller_da;
 
-	if (!i3c_addr_slots_is_free(&data->common.attached_dev.addr_slots, controller_da)) {
+	/* Set controller retaining register */
+	if (config->common.primary_controller_da) {
+		if (!i3c_addr_slots_is_free(&data->common.attached_dev.addr_slots,
+					    config->common.primary_controller_da)) {
+			controller_da = i3c_addr_slots_next_free_find(
+				&data->common.attached_dev.addr_slots, 0);
+			LOG_WRN("%s: 0x%02x DA selected for controller as 0x%02x is unavailable",
+				dev->name, controller_da, config->common.primary_controller_da);
+		} else {
+			controller_da = config->common.primary_controller_da;
+		}
+	} else {
 		controller_da =
 			i3c_addr_slots_next_free_find(&data->common.attached_dev.addr_slots, 0);
-		LOG_DBG("%s: 0x%02x DA selected for controller", dev->name, controller_da);
 	}
 	sys_write32(prepare_rr0_dev_address(controller_da) | DEV_ID_RR0_IS_I3C,
 		    config->base + DEV_ID_RR0(0));
@@ -3661,6 +3667,7 @@ static DEVICE_API(i3c, api) = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(cdns_i3c_device_array_##n),                  \
 		.common.dev_list.i2c = cdns_i3c_i2c_device_array_##n,                              \
 		.common.dev_list.num_i2c = ARRAY_SIZE(cdns_i3c_i2c_device_array_##n),              \
+		.common.primary_controller_da = DT_INST_PROP_OR(n, primary_controller_da, 0x00),   \
 	};                                                                                         \
 	static struct cdns_i3c_data i3c_data_##n = {                                               \
 		.common.ctrl_config.scl.i3c = DT_INST_PROP_OR(n, i3c_scl_hz, 0),                   \

--- a/drivers/i3c/i3c_dw.c
+++ b/drivers/i3c/i3c_dw.c
@@ -1587,10 +1587,22 @@ static int set_controller_info(const struct device *dev)
 {
 	const struct dw_i3c_config *config = dev->config;
 	struct dw_i3c_data *data = dev->data;
+	uint8_t controller_da;
 
-	uint8_t controller_da =
-		i3c_addr_slots_next_free_find(&data->common.attached_dev.addr_slots, 0);
-	LOG_DBG("%s: 0x%02x DA selected for controller", dev->name, controller_da);
+	if (config->common.primary_controller_da) {
+		if (!i3c_addr_slots_is_free(&data->common.attached_dev.addr_slots,
+					    config->common.primary_controller_da)) {
+			controller_da = i3c_addr_slots_next_free_find(
+				&data->common.attached_dev.addr_slots, 0);
+			LOG_WRN("%s: 0x%02x DA selected for controller as 0x%02x is unavailable",
+				dev->name, controller_da, config->common.primary_controller_da);
+		} else {
+			controller_da = config->common.primary_controller_da;
+		}
+	} else {
+		controller_da =
+			i3c_addr_slots_next_free_find(&data->common.attached_dev.addr_slots, 0);
+	}
 
 	sys_write32(DEVICE_ADDR_DYNAMIC_ADDR_VALID | DEVICE_ADDR_DYNAMIC(controller_da),
 		    config->regs + DEVICE_ADDR);
@@ -2416,6 +2428,7 @@ static DEVICE_API(i3c, dw_i3c_api) = {
 		.common.dev_list.num_i3c = ARRAY_SIZE(dw_i3c_device_array_##n),                    \
 		.common.dev_list.i2c = dw_i3c_i2c_device_array_##n,                                \
 		.common.dev_list.num_i2c = ARRAY_SIZE(dw_i3c_i2c_device_array_##n),                \
+		.common.primary_controller_da = DT_INST_PROP_OR(n, primary_controller_da, 0x00),   \
 		I3C_DW_PINCTRL_INIT(n)};                                                           \
 	PM_DEVICE_DT_INST_DEFINE(n, dw_i3c_pm_action);                                             \
 	DEVICE_DT_INST_DEFINE(n, dw_i3c_init, PM_DEVICE_DT_INST_GET(n), &dw_i3c_data_##n,          \

--- a/dts/bindings/i3c/i3c-controller.yaml
+++ b/dts/bindings/i3c/i3c-controller.yaml
@@ -30,3 +30,11 @@ properties:
       and there are I2C devices attached to the bus, look at the Legacy
       Virtual Register (LVR) of all connected I2C devices to determine
       the maximum allowed frequency.
+
+  primary-controller-da:
+    type: int
+    description: |
+      This is the self assigned dynamic address of the I3C controller. This
+      is the address is used to communicate with itself after a handoff by
+      a secondary controller. This is only used if the controller is a primary
+      controller.

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -1191,6 +1191,9 @@ struct i3c_dev_list {
 struct i3c_driver_config {
 	/** I3C/I2C device list struct. */
 	struct i3c_dev_list dev_list;
+
+	/** I3C Primary Controller Dynamic Address */
+	uint8_t primary_controller_da;
 };
 
 /**


### PR DESCRIPTION
Add a way to assign the dynamic address for a primary controller. This is the address that is broadcasted out with the ccc DEFTGTS, and is the address that secondary controllers use to communicate with the primary controller.