### PR TITLE
boards: nordic: nrf54l15dk: Fix flashing with XIP board variant

### DIFF
--- a/boards/nordic/nrf54l15dk/board.yml
+++ b/boards/nordic/nrf54l15dk/board.yml
@@ -3,11 +3,45 @@ board:
   full_name: nRF54L15 DK
   vendor: nordic
   socs:
-  - name: nrf54l05
-  - name: nrf54l10
-  - name: nrf54l15
-    variants:
-    - name: xip
-      cpucluster: cpuflpr
-    - name: ns
-      cpucluster: cpuapp
+    - name: nrf54l05
+    - name: nrf54l10
+    - name: nrf54l15
+      variants:
+        - name: xip
+          cpucluster: cpuflpr
+        - name: ns
+          cpucluster: cpuapp
+runners:
+  run_once:
+    '--recover':
+      - runners:
+          - nrfjprog
+          - nrfutil
+        run: first
+        groups:
+          - boards:
+              - nrf54l15dk/nrf54l15/cpuapp
+              - nrf54l15dk/nrf54l15/cpuflpr
+              - nrf54l15dk/nrf54l15/cpuflpr/xip
+    '--erase':
+      - runners:
+          - nrfjprog
+          - jlink
+          - nrfutil
+        run: first
+        groups:
+          - boards:
+              - nrf54l15dk/nrf54l15/cpuapp
+              - nrf54l15dk/nrf54l15/cpuflpr
+              - nrf54l15dk/nrf54l15/cpuflpr/xip
+    '--reset':
+      - runners:
+          - nrfjprog
+          - jlink
+          - nrfutil
+        run: last
+        groups:
+          - boards:
+              - nrf54l15dk/nrf54l15/cpuapp
+              - nrf54l15dk/nrf54l15/cpuflpr
+              - nrf54l15dk/nrf54l15/cpuflpr/xip


### PR DESCRIPTION
Fixes an issue whereby flashing would fail when using --erase since it would erase the cores twice rather than once, by adding a flash runner run once board configuration