### PR TITLE
boards: nordic: nrf54h20: disable sec ipc

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -143,14 +143,9 @@
 };
 
 &cpusec_cpuapp_ipc {
-	status = "okay";
 	mbox-names = "tx", "rx";
 	tx-region = <&cpuapp_cpusec_ipc_shm>;
 	rx-region = <&cpusec_cpuapp_ipc_shm>;
-};
-
-&cpusec_bellboard {
-	status = "okay";
 };
 
 ipc0: &cpuapp_cpurad_ipc {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -59,14 +59,9 @@
 };
 
 &cpusec_cpurad_ipc {
-	status = "okay";
 	mbox-names = "tx", "rx";
 	tx-region = <&cpurad_cpusec_ipc_shm>;
 	rx-region = <&cpusec_cpurad_ipc_shm>;
-};
-
-&cpusec_bellboard {
-	status = "okay";
 };
 
 ipc0: &cpuapp_cpurad_ipc {


### PR DESCRIPTION
The secure domain IPC node statuses are being used to generate UICRs which tell the secure domain to attempt connecting to the app and radio cores. secure domain should only be enabled if used, so the nodes should default to disabled.

Without this change, the H20 is unable to go to sleep since secure domain stays awake, persistanly trying to connect to both cores.