### PR TITLE
[Backport v3.7-branch] net: core: Free packet properly if TTL/hop limit is 0

### DIFF
--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -398,6 +398,7 @@ int net_send_data(struct net_pkt *pkt)
 		 * we just silently drop the packet by returning 0.
 		 */
 		if (status == -ENOMSG) {
+			net_pkt_unref(pkt);
 			return 0;
 		}
 


### PR DESCRIPTION
We drop the packet if TTL or hop limit is 0, but we should also unref the packet in this case because we return 0 to the caller which is not then able to free the packet because it thinks that the packet was sent properly.

Backport https://github.com/zephyrproject-rtos/zephyr/commit/2f1a134f813cfe2b83fc896cd07a2df5d27fb2b6 from https://github.com/zephyrproject-rtos/zephyr/pull/87325.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/87323