### PR TITLE
samples: code_relocation_nocopy: update macro to get flash size

### DIFF
--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -31,21 +31,21 @@
 
 #define EXTFLASH_NODE	DT_INST(0, st_stm32_ospi_nor)
 #define EXTFLASH_ADDR	DT_REG_ADDR(DT_INST(0, st_stm32_ospi_nor))
-#define EXTFLASH_SIZE	DT_REG_ADDR_BY_IDX(DT_INST(0, st_stm32_ospi_nor), 1)
+#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_ospi_nor))
 
 #elif defined(CONFIG_STM32_MEMMAP) && DT_NODE_EXISTS(DT_INST(0, st_stm32_qspi_nor))
 /* On stm32 QSPI, external flash is mapped in XIP region at address given by the reg property. */
 
 #define EXTFLASH_NODE	DT_INST(0, st_stm32_qspi_nor)
 #define EXTFLASH_ADDR	DT_REG_ADDR(DT_INST(0, st_stm32_qspi_nor))
-#define EXTFLASH_SIZE	DT_REG_ADDR_BY_IDX(DT_INST(0, st_stm32_qspi_nor), 1)
+#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_ospi_nor))
 
 #elif defined(CONFIG_STM32_MEMMAP) && DT_NODE_EXISTS(DT_INST(0, st_stm32_xspi_nor))
 /* On stm32 XSPI, external flash is mapped in XIP region at address given by the reg property. */
 
 #define EXTFLASH_NODE	DT_INST(0, st_stm32_xspi_nor)
 #define EXTFLASH_ADDR	DT_REG_ADDR(DT_INST(0, st_stm32_xspi_nor))
-#define EXTFLASH_SIZE	DT_REG_ADDR_BY_IDX(DT_INST(0, st_stm32_xspi_nor), 1)
+#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_ospi_nor))
 
 #elif defined(CONFIG_FLASH_MSPI_NOR) && defined(CONFIG_SOC_NRF54H20_CPUAPP)
 


### PR DESCRIPTION
This PR brings changes to fix a regression introduced by this PR https://github.com/zephyrproject-rtos/zephyr/pull/76735  on the code_relocation_nocopy sample for stm32 boards.

The macro `DT_REG_SIZE` is now used instead of `DT_REG_ADDR_BY_IDX` to get a node's only register block size.

 This PR will avoid the following CI failure : 
 
```
[157/162] Linking C executable zephyr/zephyr_pre0.elf
../zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: invalid length for memory region EXTFLASH
[162/162] Linking C executable zephyr/zephyr.elf
../zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: invalid length for memory region EXTFLASH
```