### PR TITLE
ci: Add codeql workflow for python, actions, js

### DIFF
--- a/.github/codeql/codeql-actions-config.yml
+++ b/.github/codeql/codeql-actions-config.yml
@@ -1,0 +1,2 @@
+paths:
+  - .github

--- a/.github/codeql/codeql-js-config.yml
+++ b/.github/codeql/codeql-js-config.yml
@@ -1,0 +1,2 @@
+paths:
+  - doc

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: '34 16 * * 3'
+permissions:
+  contents: read
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+            config: ./.github/codeql/codeql-actions-config.yml
+          - language: javascript-typescript
+            build-mode: none
+            config: ./.github/codeql/codeql-js-config.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+          config-file: ${{ matrix.config }}
+
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo "nothing yet"
+          exit 0
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Integrate codeql code scanning from github to do basic static code
analysis on python, actions, js.

c/cpp to be added later.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
