### PR TITLE
sensors: lsm6dsv16x: fix double-promotion warning

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.c
@@ -66,7 +66,7 @@ static const uint32_t sflp_period_ns[] = {
  * Expand val to q31_t according to its range; this is achieved multiplying by 2^31/2^range.
  */
 #define Q31_SHIFT_VAL(val, range) \
-	(q31_t) (round((val) * ((int64_t)1 << (31 - (range)))))
+	(q31_t) (roundf((val) * ((int64_t)1 << (31 - (range)))))
 
 /*
  * Expand micro_val (a generic micro unit) to q31_t according to its range; this is achieved


### PR DESCRIPTION
use roundf instead of round in Q31_SHIFT_VAL macro to avoid
    double-promotion warning


```
/__w/zephyr/zephyr/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.c:459:29: error: implicit conversion increases floating-point precision: 'float32_t' (aka 'float') to 'double' [-Werror,-Wdouble-promotion]
                        out->readings[count].x = Q31_SHIFT_VAL(x.f, out->shift);
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```