### PR TITLE
drivers: stepper: Added fault event

### DIFF
--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -95,6 +95,8 @@ enum stepper_event {
 	STEPPER_EVENT_RIGHT_END_STOP_DETECTED = 3,
 	/** Stepper has stopped */
 	STEPPER_EVENT_STOPPED = 4,
+	/** Fault with the stepper controller detected */
+	STEPPER_FAULT_EVENT = 5,
 };
 
 /**


### PR DESCRIPTION
The stepper api currently lacks an event for issues unrelated to motor stalls, e.g. power supply issues or thermal shutdown. This PR adds a corresponding fault event.