### PR TITLE
drivers: usb: udc: Reduce unnecessary ep config lookups

### DIFF
--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -95,13 +95,14 @@ static int usbd_ctrl_feed_dout(const struct device *dev, const size_t length)
 static int udc_ambiq_tx(const struct device *dev, uint8_t ep, struct net_buf *buf)
 {
 	const struct udc_ambiq_data *priv = udc_get_private(dev);
+	struct udc_ep_config *cfg = udc_get_ep_cfg(dev, ep);
 	uint32_t status;
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(cfg)) {
 		LOG_WRN("ep 0x%02x is busy!", ep);
 		return 0;
 	}
-	udc_ep_set_busy(dev, ep, true);
+	udc_ep_set_busy(cfg, true);
 
 	/* buf equals NULL is used as indication of ZLP request */
 	if (buf == NULL) {
@@ -111,7 +112,7 @@ static int udc_ambiq_tx(const struct device *dev, uint8_t ep, struct net_buf *bu
 	}
 
 	if (status != AM_HAL_STATUS_SUCCESS) {
-		udc_ep_set_busy(dev, ep, false);
+		udc_ep_set_busy(cfg, false);
 		LOG_ERR("am_hal_usb_ep_xfer write failed(0x%02x), %d", ep, (int)status);
 		return -EIO;
 	}
@@ -122,15 +123,16 @@ static int udc_ambiq_tx(const struct device *dev, uint8_t ep, struct net_buf *bu
 static int udc_ambiq_rx(const struct device *dev, uint8_t ep, struct net_buf *buf)
 {
 	struct udc_ambiq_data *priv = udc_get_private(dev);
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep);
 	struct udc_ep_config *cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
 	uint32_t status;
 	uint16_t rx_size = buf->size;
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(ep_cfg)) {
 		LOG_WRN("ep 0x%02x is busy!", ep);
 		return 0;
 	}
-	udc_ep_set_busy(dev, ep, true);
+	udc_ep_set_busy(ep_cfg, true);
 
 	/* Make sure that OUT transaction size triggered doesn't exceed EP's MPS */
 	if ((ep != USB_CONTROL_EP_OUT) && (cfg->mps < rx_size)) {
@@ -139,7 +141,7 @@ static int udc_ambiq_rx(const struct device *dev, uint8_t ep, struct net_buf *bu
 
 	status = am_hal_usb_ep_xfer(priv->usb_handle, ep, buf->data, rx_size);
 	if (status != AM_HAL_STATUS_SUCCESS) {
-		udc_ep_set_busy(dev, ep, false);
+		udc_ep_set_busy(ep_cfg, false);
 		LOG_ERR("am_hal_usb_ep_xfer read(rx) failed(0x%02x), %d", ep, (int)status);
 		return -EIO;
 	}
@@ -222,7 +224,9 @@ static void udc_ambiq_ep_xfer_complete_callback(const struct device *dev, uint8_
 	if (USB_EP_DIR_IS_IN(ep_addr)) {
 		evt.type = UDC_AMBIQ_EVT_HAL_IN_CMP;
 	} else {
-		buf = udc_buf_peek(dev, ep_addr);
+		struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep_addr);
+
+		buf = udc_buf_peek(ep_cfg);
 		if (buf == NULL) {
 			LOG_ERR("No buffer for ep 0x%02x", ep_addr);
 			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
@@ -280,12 +284,12 @@ static int udc_ambiq_ep_dequeue(const struct device *dev, struct udc_ep_config *
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(dev, ep_cfg->addr);
+	buf = udc_buf_get_all(ep_cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
 
-	udc_ep_set_busy(dev, ep_cfg->addr, false);
+	udc_ep_set_busy(ep_cfg, false);
 	am_hal_usb_ep_state_reset(priv->usb_handle, ep_cfg->addr);
 	irq_unlock(lock_key);
 
@@ -319,7 +323,7 @@ static int udc_ambiq_ep_clear_halt(const struct device *dev, struct udc_ep_confi
 	ep_cfg->stat.halted = false;
 
 	/* Resume queued transfer if any */
-	if (udc_buf_peek(dev, ep_cfg->addr)) {
+	if (udc_buf_peek(ep_cfg)) {
 		struct udc_ambiq_event evt = {
 			.ep = ep_cfg->addr,
 			.type = UDC_AMBIQ_EVT_XFER,
@@ -646,14 +650,14 @@ static inline void ambiq_handle_evt_dout(const struct device *dev, struct udc_ep
 	struct net_buf *buf;
 
 	/* retrieve endpoint buffer */
-	buf = udc_buf_get(dev, cfg->addr);
+	buf = udc_buf_get(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer queued for control ep");
 		return;
 	}
 
 	/* Clear endpoint busy status */
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 
 	/* Handle transfer complete event */
 	if (cfg->addr == USB_CONTROL_EP_OUT) {
@@ -685,9 +689,9 @@ static void ambiq_handle_evt_din(const struct device *dev, struct udc_ep_config 
 	bool udc_ambiq_rx_status_in_completed = false;
 
 	/* Clear endpoint busy status */
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 	/* Check and Handle ZLP flag */
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (cfg->addr != USB_CONTROL_EP_IN) {
 		if (udc_ep_buf_has_zlp(buf)) {
 			udc_ep_buf_clear_zlp(buf);
@@ -698,7 +702,7 @@ static void ambiq_handle_evt_din(const struct device *dev, struct udc_ep_config 
 	}
 
 	/* retrieve endpoint buffer */
-	buf = udc_buf_get(dev, cfg->addr);
+	buf = udc_buf_get(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer queued for control ep");
 		return;
@@ -753,7 +757,7 @@ static void udc_event_xfer(const struct device *dev, struct udc_ep_config *const
 {
 	struct net_buf *buf;
 
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", cfg->addr);
 		return;

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -78,22 +78,13 @@ struct udc_ep_config *udc_get_ep_cfg(const struct device *dev, const uint8_t ep)
 	return data->ep_lut[USB_EP_LUT_IDX(ep)];
 }
 
-bool udc_ep_is_busy(const struct device *dev, const uint8_t ep)
+bool udc_ep_is_busy(const struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	__ASSERT(ep_cfg != NULL, "ep 0x%02x is not available", ep);
-
 	return ep_cfg->stat.busy;
 }
 
-void udc_ep_set_busy(const struct device *dev, const uint8_t ep, const bool busy)
+void udc_ep_set_busy(struct udc_ep_config *const ep_cfg, const bool busy)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	__ASSERT(ep_cfg != NULL, "ep 0x%02x is not available", ep);
 	ep_cfg->stat.busy = busy;
 }
 
@@ -115,34 +106,21 @@ int udc_register_ep(const struct device *dev, struct udc_ep_config *const cfg)
 	return 0;
 }
 
-struct net_buf *udc_buf_get(const struct device *dev, const uint8_t ep)
+struct net_buf *udc_buf_get(struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	if (ep_cfg == NULL) {
-		return NULL;
-	}
-
 	return k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
 }
 
-struct net_buf *udc_buf_get_all(const struct device *dev, const uint8_t ep)
+struct net_buf *udc_buf_get_all(struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
 	struct net_buf *buf;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	if (ep_cfg == NULL) {
-		return NULL;
-	}
 
 	buf = k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
 	if (!buf) {
 		return NULL;
 	}
 
-	LOG_DBG("ep 0x%02x dequeue %p", ep, buf);
+	LOG_DBG("ep 0x%02x dequeue %p", ep_cfg->addr, buf);
 	for (struct net_buf *n = buf; !k_fifo_is_empty(&ep_cfg->fifo); n = n->frags) {
 		n->frags = k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
 		LOG_DBG("|-> %p ", n->frags);
@@ -154,15 +132,8 @@ struct net_buf *udc_buf_get_all(const struct device *dev, const uint8_t ep)
 	return buf;
 }
 
-struct net_buf *udc_buf_peek(const struct device *dev, const uint8_t ep)
+struct net_buf *udc_buf_peek(struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	if (ep_cfg == NULL) {
-		return NULL;
-	}
-
 	return k_fifo_peek_head(&ep_cfg->fifo);
 }
 

--- a/drivers/usb/udc/udc_common.h
+++ b/drivers/usb/udc/udc_common.h
@@ -61,21 +61,19 @@ struct udc_ep_config *udc_get_ep_cfg(const struct device *dev,
 /**
  * @brief Checks if the endpoint is busy
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] ep     Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return true if endpoint is busy
  */
-bool udc_ep_is_busy(const struct device *dev, const uint8_t ep);
+bool udc_ep_is_busy(const struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Helper function to set endpoint busy state
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] ep     Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  * @param[in] busy   Busy state
  */
-void udc_ep_set_busy(const struct device *dev, const uint8_t ep,
+void udc_ep_set_busy(struct udc_ep_config *const ep_cfg,
 		     const bool busy);
 
 /**
@@ -85,13 +83,11 @@ void udc_ep_set_busy(const struct device *dev, const uint8_t ep,
  * Use it when transfer is finished and request should
  * be passed to the higher level.
  *
- * @param[in] dev     Pointer to device struct of the driver instance
- * @param[in] ep      Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return pointer to UDC request or NULL on error.
  */
-struct net_buf *udc_buf_get(const struct device *dev,
-			    const uint8_t ep);
+struct net_buf *udc_buf_get(struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Get all UDC request from endpoint FIFO.
@@ -100,13 +96,11 @@ struct net_buf *udc_buf_get(const struct device *dev,
  * This function removes all request from endpoint FIFO and
  * is typically used to dequeue endpoint FIFO.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] ep     Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return pointer to UDC request or NULL on error.
  */
-struct net_buf *udc_buf_get_all(const struct device *dev,
-				const uint8_t ep);
+struct net_buf *udc_buf_get_all(struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Peek request at the head of endpoint FIFO.
@@ -114,13 +108,11 @@ struct net_buf *udc_buf_get_all(const struct device *dev,
  * Return request from the head of endpoint FIFO without removing.
  * Use it when request buffer is required for a transfer.
  *
- * @param[in] dev     Pointer to device struct of the driver instance
- * @param[in] ep      Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return pointer to request or NULL on error.
  */
-struct net_buf *udc_buf_peek(const struct device *dev,
-			     const uint8_t ep);
+struct net_buf *udc_buf_peek(struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Put request at the tail of endpoint FIFO.

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -278,14 +278,16 @@ static int rpi_pico_ctrl_feed_dout(const struct device *dev, const size_t length
 
 static void drop_control_transfers(const struct device *dev)
 {
+	struct udc_ep_config *cfg_out = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	struct udc_ep_config *cfg_in = udc_get_ep_cfg(dev, USB_CONTROL_EP_IN);
 	struct net_buf *buf;
 
-	buf = udc_buf_get_all(dev, USB_CONTROL_EP_OUT);
+	buf = udc_buf_get_all(cfg_out);
 	if (buf != NULL) {
 		net_buf_unref(buf);
 	}
 
-	buf = udc_buf_get_all(dev, USB_CONTROL_EP_IN);
+	buf = udc_buf_get_all(cfg_in);
 	if (buf != NULL) {
 		net_buf_unref(buf);
 	}
@@ -337,14 +339,14 @@ static inline int rpi_pico_handle_evt_dout(const struct device *dev,
 	struct net_buf *buf;
 	int err = 0;
 
-	buf = udc_buf_get(dev, cfg->addr);
+	buf = udc_buf_get(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for OUT ep 0x%02x", cfg->addr);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENODATA;
 	}
 
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 
 	if (cfg->addr == USB_CONTROL_EP_OUT) {
 		if (udc_ctrl_stage_is_status_out(dev)) {
@@ -373,15 +375,15 @@ static int rpi_pico_handle_evt_din(const struct device *dev,
 	struct net_buf *buf;
 	int err;
 
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", cfg->addr);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 
-	buf = udc_buf_get(dev, cfg->addr);
-	udc_ep_set_busy(dev, cfg->addr, false);
+	buf = udc_buf_get(cfg);
+	udc_ep_set_busy(cfg, false);
 
 	if (cfg->addr == USB_CONTROL_EP_IN) {
 		if (udc_ctrl_stage_is_status_in(dev) ||
@@ -415,7 +417,7 @@ static void rpi_pico_handle_xfer_next(const struct device *dev,
 	struct net_buf *buf;
 	int err;
 
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
 		return;
 	}
@@ -429,7 +431,7 @@ static void rpi_pico_handle_xfer_next(const struct device *dev,
 	if (err != 0) {
 		udc_submit_ep_event(dev, buf, -ECONNREFUSED);
 	} else {
-		udc_ep_set_busy(dev, cfg->addr, true);
+		udc_ep_set_busy(cfg, true);
 	}
 }
 
@@ -460,7 +462,7 @@ static ALWAYS_INLINE void rpi_pico_thread_handler(void *const arg)
 		break;
 	}
 
-	if (ep_cfg->addr != USB_CONTROL_EP_OUT && !udc_ep_is_busy(dev, ep_cfg->addr)) {
+	if (ep_cfg->addr != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ep_cfg)) {
 		rpi_pico_handle_xfer_next(dev, ep_cfg);
 	}
 }
@@ -503,7 +505,7 @@ static void rpi_pico_handle_buff_status_in(const struct device *dev, const uint8
 	struct net_buf *buf;
 	size_t len;
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", ep);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
@@ -538,7 +540,7 @@ static void rpi_pico_handle_buff_status_out(const struct device *dev, const uint
 	struct net_buf *buf;
 	size_t len;
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", ep);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
@@ -739,7 +741,7 @@ static int udc_rpi_pico_ep_dequeue(const struct device *dev,
 	lock_key = irq_lock();
 
 	rpi_pico_ep_cancel(dev, cfg->addr);
-	buf = udc_buf_get_all(dev, cfg->addr);
+	buf = udc_buf_get_all(cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
@@ -856,7 +858,7 @@ static int udc_rpi_pico_ep_clear_halt(const struct device *dev,
 		arch_nop();
 		rpi_pico_bit_clr(buf_ctrl_reg, USB_BUF_CTRL_STALL);
 
-		if (udc_buf_peek(dev, cfg->addr)) {
+		if (udc_buf_peek(cfg)) {
 			k_msgq_put(&drv_msgq, &evt, K_NO_WAIT);
 		}
 	}

--- a/drivers/usb/udc/udc_skeleton.c
+++ b/drivers/usb/udc/udc_skeleton.c
@@ -119,7 +119,7 @@ static int udc_skeleton_ep_dequeue(const struct device *dev,
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(dev, cfg->addr);
+	buf = udc_buf_get_all(cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -172,7 +172,7 @@ static int vrt_handle_out(const struct device *dev,
 		return vrt_request_reply(dev, pkt, UVB_REPLY_STALL);
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_DBG("reply NACK ep 0x%02x", ep);
 		return vrt_request_reply(dev, pkt, UVB_REPLY_NACK);
@@ -184,7 +184,7 @@ static int vrt_handle_out(const struct device *dev,
 	LOG_DBG("Handle data OUT, %zu | %zu", pkt->length, net_buf_tailroom(buf));
 
 	if (net_buf_tailroom(buf) == 0 || pkt->length < udc_mps_ep_size(ep_cfg)) {
-		buf = udc_buf_get(dev, ep);
+		buf = udc_buf_get(ep_cfg);
 
 		if (ep == USB_CONTROL_EP_OUT) {
 			err = vrt_handle_ctrl_out(dev, buf);
@@ -239,7 +239,7 @@ static int vrt_handle_in(const struct device *dev,
 		return vrt_request_reply(dev, pkt, UVB_REPLY_STALL);
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_DBG("reply NACK ep 0x%02x", ep);
 		return vrt_request_reply(dev, pkt, UVB_REPLY_NACK);
@@ -259,7 +259,7 @@ static int vrt_handle_in(const struct device *dev,
 		}
 
 		LOG_DBG("Finish data IN %zu | %u", pkt->length, buf->len);
-		buf = udc_buf_get(dev, ep);
+		buf = udc_buf_get(ep_cfg);
 
 		if (ep == USB_CONTROL_EP_IN) {
 			err = isr_handle_ctrl_in(dev, buf);
@@ -411,7 +411,7 @@ static int udc_vrt_ep_dequeue(const struct device *dev,
 
 	lock_key = irq_lock();
 	/* Draft dequeue implementation */
-	buf = udc_buf_get_all(dev, cfg->addr);
+	buf = udc_buf_get_all(cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}


### PR DESCRIPTION
UDC API passes struct udc_ep_config to all functions. Some UDC functions were using endpoint config structure while some were using device and endpoint number. This API inconsistency led to completely unnecessary endpoint structure lookups. Remove unnecessary lookups by using endpoint config structure pointer where it makes sense.