### PR TITLE
modbus: serial: Allow custom stop-bit settings in server mode

### DIFF
--- a/drivers/sensor/pzem004t/Kconfig
+++ b/drivers/sensor/pzem004t/Kconfig
@@ -10,6 +10,7 @@ config PZEM004T
 	depends on MODBUS
 	depends on MODBUS_SERIAL
 	depends on MODBUS_RAW_ADU
+	select MODBUS_NONCOMPLIANT_SERIAL_MODE
 	help
 	  Enable the driver for the Peacefair PZEM004T Multifunction AC Meter.
 

--- a/drivers/sensor/pzem004t/pzem004t.c
+++ b/drivers/sensor/pzem004t/pzem004t.c
@@ -325,7 +325,7 @@ static const struct pzem004t_config pzem004t_config_##inst = {                  
 				{                                                          \
 					.baud = 9600,                                      \
 					.parity = UART_CFG_PARITY_NONE,                    \
-					.stop_bits_client = UART_CFG_STOP_BITS_1,          \
+					.stop_bits = UART_CFG_STOP_BITS_1,                 \
 				},                                                         \
 		},                                                                         \
 };                                                                                         \

--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -484,13 +484,13 @@ struct modbus_serial_param {
 	 *    UART_CFG_PARITY_ODD
 	 */
 	enum uart_config_parity parity;
-	/** stop_bits_client UART's stop bits setting if in client mode:
+	/** stop_bits UART's stop bits setting in non-compliant mode:
 	 *    UART_CFG_STOP_BITS_0_5,
 	 *    UART_CFG_STOP_BITS_1,
 	 *    UART_CFG_STOP_BITS_1_5,
 	 *    UART_CFG_STOP_BITS_2,
 	 */
-	enum uart_config_stop_bits stop_bits_client;
+	enum uart_config_stop_bits stop_bits;
 };
 
 /**

--- a/samples/subsys/modbus/rtu_client/src/main.c
+++ b/samples/subsys/modbus/rtu_client/src/main.c
@@ -19,7 +19,6 @@ const static struct modbus_iface_param client_param = {
 	.serial = {
 		.baud = 19200,
 		.parity = UART_CFG_PARITY_NONE,
-		.stop_bits_client = UART_CFG_STOP_BITS_2,
 	},
 };
 

--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -79,6 +79,12 @@ config MODBUS_FC08_DIAGNOSTIC
 	help
 	  Enable function code 08 Diagnostic support
 
+config MODBUS_NONCOMPLIANT_SERIAL_MODE
+	bool "Non-compliant serial mode"
+	depends on MODBUS_SERIAL
+	help
+	  Allow non-compliant stop and parity bit settings.
+
 module = MODBUS
 module-str = Modbus Support
 module-help = Sets log level for Modbus support

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -477,14 +477,14 @@ static inline int configure_uart(struct modbus_context *ctx,
 		return -EINVAL;
 	}
 
-	if (ctx->client) {
-		/* Allow custom stop bit settings only in client mode */
-		switch (param->serial.stop_bits_client) {
+	if (IS_ENABLED(CONFIG_MODBUS_NONCOMPLIANT_SERIAL_MODE)) {
+		/* Allow custom stop bit settings only in non-compliant mode */
+		switch (param->serial.stop_bits) {
 		case UART_CFG_STOP_BITS_0_5:
 		case UART_CFG_STOP_BITS_1:
 		case UART_CFG_STOP_BITS_1_5:
 		case UART_CFG_STOP_BITS_2:
-			uart_cfg.stop_bits = param->serial.stop_bits_client;
+			uart_cfg.stop_bits = param->serial.stop_bits;
 			break;
 		default:
 			return -EINVAL;

--- a/tests/subsys/modbus/src/test_modbus_client.c
+++ b/tests/subsys/modbus/src/test_modbus_client.c
@@ -216,7 +216,6 @@ static struct modbus_iface_param client_param = {
 	.serial = {
 		.baud = MB_TEST_BAUDRATE_LOW,
 		.parity = UART_CFG_PARITY_ODD,
-		.stop_bits_client = UART_CFG_STOP_BITS_1,
 	},
 };
 
@@ -241,7 +240,6 @@ void test_client_setup_low_none(void)
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	client_param.serial.parity = UART_CFG_PARITY_NONE;
-	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_2;
 
 	err = modbus_init_client(client_iface, client_param);
 	zassert_equal(err, 0, "Failed to configure RTU client");
@@ -255,7 +253,6 @@ void test_client_setup_low_odd(void)
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	client_param.serial.parity = UART_CFG_PARITY_ODD;
-	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_1;
 
 	err = modbus_init_client(client_iface, client_param);
 	zassert_equal(err, 0, "Failed to configure RTU client");
@@ -269,7 +266,6 @@ void test_client_setup_high_even(void)
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	client_param.serial.parity = UART_CFG_PARITY_EVEN;
-	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_1;
 
 	err = modbus_init_client(client_iface, client_param);
 	zassert_equal(err, 0, "Failed to configure RTU client");
@@ -283,7 +279,6 @@ void test_client_setup_ascii(void)
 	client_param.mode = MODBUS_MODE_ASCII;
 	client_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	client_param.serial.parity = UART_CFG_PARITY_EVEN;
-	client_param.serial.stop_bits_client = UART_CFG_STOP_BITS_1;
 
 	err = modbus_init_client(client_iface, client_param);
 


### PR DESCRIPTION
A Modbus server should be able to operate with the same settings as a client. Stop-bits -is the only setting not available in server mode.

The change makes it possible to override default stop-bits settings in backwards compatible way. The feature is disabled by default.