### PR TITLE
ci: github: Add workflow to ensure all GH actions are pinned

### DIFF
--- a/.github/workflows/pinned-gh-actions.yml
+++ b/.github/workflows/pinned-gh-actions.yml
@@ -1,0 +1,19 @@
+name: Check SHA-pinned GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check-sha-pinned-actions:
+    name: Verify GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3.0.22


### PR DESCRIPTION
This commit introduces a new workflow that checks all GitHub Actions in our workflows are SHA-pinned.