### PR TITLE
net: mdns_responder: Replace pragma with TOOLCHAIN_DISABLE macro

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -693,7 +693,8 @@ do {                                                                    \
 
 /* GCC-specific warnings that aren't in clang. */
 #if defined(__GNUC__) && !defined(__clang__)
-#define TOOLCHAIN_WARNING_POINTER_ARITH "-Wpointer-arith"
+#define TOOLCHAIN_WARNING_POINTER_ARITH     "-Wpointer-arith"
+#define TOOLCHAIN_WARNING_STRINGOP_OVERREAD "-Wstringop-overread"
 #endif
 
 #define _TOOLCHAIN_DISABLE_WARNING(compiler, warning)                                              \

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -44,12 +44,8 @@ LOG_MODULE_REGISTER(net_mdns_responder, CONFIG_MDNS_RESPONDER_LOG_LEVEL);
  * address-family-specific variants being of differing sizes. Let's not
  * mess with code (which looks correct), just silence the compiler.
  */
-#ifdef __GNUC__
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wunknown-warning-option"
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#pragma GCC diagnostic ignored "-Wstringop-overread"
-#endif
+TOOLCHAIN_DISABLE_GCC_WARNING(TOOLCHAIN_WARNING_ARRAY_BOUNDS);
+TOOLCHAIN_DISABLE_GCC_WARNING(TOOLCHAIN_WARNING_STRINGOP_OVERREAD);
 
 extern void dns_dispatcher_svc_handler(struct net_socket_service_event *pev);
 


### PR DESCRIPTION
These macros were recently introduced and replaced everywhere (#84065),
but this was missed.