### PR TITLE
compiler_flags: Change optimization_fast from '-Ofast' to '-O3'

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -21,7 +21,7 @@ endif()
 set_compiler_property(PROPERTY optimization_speed -O2)
 set_compiler_property(PROPERTY optimization_size  -Os)
 set_compiler_property(PROPERTY optimization_size_aggressive -Oz)
-set_compiler_property(PROPERTY optimization_fast -Ofast)
+set_compiler_property(PROPERTY optimization_fast -O3)
 
 if(CMAKE_C_COMPILER_VERSION GREATER_EQUAL "4.5.0")
   set_compiler_property(PROPERTY optimization_lto -flto=auto)


### PR DESCRIPTION
'-Ofast' enables optimizations that are not standards compliant, which can
produce unexpected results unless used carefully.

When building with clang 19 and newer, it warns:

clang: error: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for
the same behavior, or '-O3' to enable only conforming optimizations
[-Werror,-Wdeprecated-ofast]

Relevant discussion:

* https://github.com/llvm/llvm-project/pull/98736
* https://discourse.llvm.org/t/rfc-deprecate-ofast/78687/109
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115990