### PR TITLE
Disable erroneous warnings from clang

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -30,7 +30,8 @@
 
 #include <zephyr/toolchain/gcc.h>
 
-#define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY "-Wsizeof-array-decay"
+#define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY            "-Wsizeof-array-decay"
+#define TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION "-Wunneeded-internal-declaration"
 
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning) _TOOLCHAIN_DISABLE_WARNING(clang, warning)
 #define TOOLCHAIN_ENABLE_CLANG_WARNING(warning)  _TOOLCHAIN_ENABLE_WARNING(clang, warning)

--- a/tests/subsys/mgmt/mcumgr/settings_mgmt/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/settings_mgmt/src/main.c
@@ -66,6 +66,8 @@ static const uint8_t test_response_error_data[8] = {
 	0xbf, 0x62, 0x72, 0x63, 0x19, 0x01, 0x00, 0xff
 };
 
+/* Disable erroneous clang warning: https://github.com/llvm/llvm-project/issues/25458. */
+TOOLCHAIN_DISABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION)
 static const uint8_t test_response_read_data_start[5] = {
 	0xbf, 0x63, 0x76, 0x61, 0x6c
 };
@@ -73,6 +75,7 @@ static const uint8_t test_response_read_data_start[5] = {
 static const uint8_t test_response_read_data_end[1] = {
 	0xff
 };
+TOOLCHAIN_ENABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION)
 
 static void cleanup_test(void *p)
 {

--- a/tests/subsys/usb/bos/src/test_bos.c
+++ b/tests/subsys/usb/bos/src/test_bos.c
@@ -21,9 +21,12 @@ LOG_MODULE_REGISTER(test_main, LOG_LEVEL_DBG);
  * Compare old style USB BOS definition with section aligned
  */
 
+/* Disable erroneous clang warning: https://github.com/llvm/llvm-project/issues/25458. */
+TOOLCHAIN_DISABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION)
 static const uint8_t dummy_descriptor[] = {
 	0x00, 0x01, 0x02
 };
+TOOLCHAIN_ENABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION)
 
 static struct webusb_bos_desc {
 	struct usb_bos_descriptor bos;


### PR DESCRIPTION
When building with `clang`, a few files are emitting warnings such as:

```
tests/subsys/usb/bos/src/test_bos.c:24:22: error: variable
'dummy_descriptor' is not needed and will not be emitted
[-Werror,-Wunneeded-internal-declaration]
static const uint8_t dummy_descriptor[] = {
                     ^
```

However, this variable is needed at compile-time since it's referenced
via `sizeof()`. This appears to be the same as this clang bug:
https://github.com/llvm/llvm-project/issues/25458.

This warning only started being emitted when I re-enabled the
`-Wunused-function` warning for clang.