### PR TITLE
MAINTAINERS: Add VynDragon to relevants

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -975,6 +975,7 @@ Display drivers:
   collaborators:
     - jfischer-no
     - danieldegrasse
+    - VynDragon
   files:
     - drivers/display/
     - dts/bindings/display/
@@ -3267,6 +3268,7 @@ RISCV arch:
     - carlocaione
     - npitre
     - ycsin
+    - VynDragon
   files:
     - arch/riscv/
     - boards/enjoydigital/litex_vexriscv/
@@ -5125,6 +5127,8 @@ West:
   maintainers:
     - nzmichaelh
     - kholia
+  collaborators:
+    - VynDragon
   files:
     - modules/hal_wch/
 


### PR DESCRIPTION
Adding myself to zones I want to help support.

Related to https://github.com/zephyrproject-rtos/zephyr/issues/86877, not sure if it should've been done before or after this but it hasn't moved in some time so i suppose it must be before the badge?

@nzmichaelh @kholia ~~Is this okay with you for the WCH maintainership?~~ I'm planning to introduce https://github.com/zephyrproject-rtos/zephyr/pull/87499 afterwards