### PR TITLE
usb: device_next: alsways reset endpoints to defaults on SetInterface

### DIFF
--- a/subsys/usb/device_next/usbd_interface.c
+++ b/subsys/usb/device_next/usbd_interface.c
@@ -184,9 +184,10 @@ int usbd_interface_set(struct usbd_context *const uds_ctx,
 	}
 
 	LOG_INF("Set Interfaces %u, alternate %u -> %u", iface, cur_alt, alt);
-	if (alt == cur_alt) {
-		return 0;
-	}
+	/*
+	 * Disable/enable endpoints even if the new alternate is the same as
+	 * the current one, forcing the endpoint to reset to defaults.
+	 */
 
 	/* Test if interface or interface alternate exist */
 	ret = usbd_interface_modify(uds_ctx, class, EP_OP_TEST, iface, alt);


### PR DESCRIPTION
This fixes an incompliant behavior of not resetting the endpoint to defaults, e.g. DATA PID, on SetInterface. Observed with the testusb tool when testing some UDC drivers.