### PR TITLE
drivers: udc_rpi_pico: replace message queue with k_events and minor fixes

### DIFF
--- a/drivers/usb/udc/Kconfig.rpi_pico
+++ b/drivers/usb/udc/Kconfig.rpi_pico
@@ -6,6 +6,7 @@ config UDC_RPI_PICO
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_USBD_ENABLED
 	select SYS_MEM_BLOCKS
+	select EVENTS
 	help
 	  Driver for an Raspberry PI Pico USB device controller.
 

--- a/drivers/usb/udc/Kconfig.rpi_pico
+++ b/drivers/usb/udc/Kconfig.rpi_pico
@@ -7,6 +7,7 @@ config UDC_RPI_PICO
 	depends on DT_HAS_RASPBERRYPI_PICO_USBD_ENABLED
 	select SYS_MEM_BLOCKS
 	select EVENTS
+	imply PINCTRL
 	help
 	  Driver for an Raspberry PI Pico USB device controller.
 

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -633,6 +633,7 @@ static void rpi_pico_isr_handler(const struct device *dev)
 		sie_status_clr(dev, USB_SIE_STATUS_RESUME_BITS);
 
 		priv->rwu_pending = false;
+		udc_set_suspended(dev, false);
 		udc_submit_event(dev, UDC_EVT_RESUME, 0);
 	}
 
@@ -640,6 +641,7 @@ static void rpi_pico_isr_handler(const struct device *dev)
 		handled |= USB_INTS_DEV_SUSPEND_BITS;
 		sie_status_clr(dev, USB_SIE_STATUS_SUSPENDED_BITS);
 
+		udc_set_suspended(dev, true);
 		udc_submit_event(dev, UDC_EVT_SUSPEND, 0);
 	}
 

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -628,8 +628,7 @@ static void rpi_pico_handle_buff_status_out(const struct device *dev, const uint
 	len = read_buf_ctrl_reg(dev, ep) & USB_BUF_CTRL_LEN_MASK;
 	net_buf_add_mem(buf, ep_data->buf, MIN(len, net_buf_tailroom(buf)));
 
-	if (net_buf_tailroom(buf) >= udc_mps_ep_size(ep_cfg) &&
-	    len == udc_mps_ep_size(ep_cfg)) {
+	if (net_buf_tailroom(buf) && len == udc_mps_ep_size(ep_cfg)) {
 		__unused int err;
 
 		err = rpi_pico_prep_rx(dev, buf, ep_cfg);

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -653,6 +653,7 @@ static void rpi_pico_handle_buff_status(const struct device *dev)
 			continue;
 		}
 
+		rpi_pico_bit_clr((mm_reg_t)&base->buf_status, BIT(i));
 		/* Odd bits in the register correspond to OUT endpoints */
 		if (i & 1U) {
 			ep = USB_EP_DIR_OUT | (i >> 1U);
@@ -662,7 +663,6 @@ static void rpi_pico_handle_buff_status(const struct device *dev)
 			rpi_pico_handle_buff_status_in(dev, ep);
 		}
 
-		rpi_pico_bit_clr((mm_reg_t)&base->buf_status, BIT(i));
 		buf_status &= ~BIT(i);
 	}
 }

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -203,6 +203,7 @@ static void write_ep_ctrl_reg(const struct device *dev, const uint8_t ep,
 static void rpi_pico_ep_cancel(const struct device *dev, const uint8_t ep)
 {
 	bool abort_handshake_supported = rp2040_chip_version() >= 2;
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep);
 	const struct rpi_pico_config *config = dev->config;
 	usb_hw_t *base = config->base;
 	mm_reg_t abort_done_reg = (mm_reg_t)&base->abort_done;
@@ -213,6 +214,7 @@ static void rpi_pico_ep_cancel(const struct device *dev, const uint8_t ep)
 	buf_ctrl = read_buf_ctrl_reg(dev, ep);
 	if (!(buf_ctrl & USB_BUF_CTRL_AVAIL)) {
 		/* The buffer is not used by the controller */
+		udc_ep_set_busy(ep_cfg, false);
 		return;
 	}
 
@@ -229,6 +231,7 @@ static void rpi_pico_ep_cancel(const struct device *dev, const uint8_t ep)
 		rpi_pico_bit_clr(abort_reg, ep_mask);
 	}
 
+	udc_ep_set_busy(ep_cfg, false);
 	LOG_INF("Canceled ep 0x%02x transaction", ep);
 }
 


### PR DESCRIPTION
Replace message queue with k_events, support VBUS state change detection, fix clear/set endpoint halt.