### PR TITLE
west: update renesas hal to include a build fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -219,7 +219,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: cbaf9b554988614ce11805a9b2f03f6bb0310b8b
+      revision: a959f1bbfc3ee7f99326e14b1f8e0aca8b9947eb
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Apply fix that leaks HAL code into each build.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>


we are seeing:

```
CMake Warning at /home/nashif/zephyrproject/zephyr/CMakeLists.txt:1011 (message):
  No SOURCES given to Zephyr library: ..__modules__hal__renesas__drivers

  Excluding target from build.
```
everywhere now


fixes #87454