### PR TITLE
ci: use gh managed tokens in workflows

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Run assignment script
       env:
-        GITHUB_TOKEN: ${{ secrets.ZB_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         FLAGS="-v"
         FLAGS+=" -o ${{ github.event.repository.owner.login }}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Backport
         uses: zephyrproject-rtos/action-backport@7e74f601d11eaca577742445e87775b5651a965f # v2.0.3-3
         with:
-          github_token: ${{ secrets.ZB_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           issue_labels: Backport
           labels_template: '["Backport"]'

--- a/.github/workflows/backport_issue_check.yml
+++ b/.github/workflows/backport_issue_check.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run backport issue checker
         env:
-          GITHUB_TOKEN: ${{ secrets.ZB_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/release/list_backports.py \
             -o ${{ github.event.repository.owner.login }} \

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@cb8f6fba6f20b5f8649bd573e80a7583a239894c # v1.7.0
         with:
-          github-token: ${{ secrets.ZB_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'zephyrproject/zephyr'
           use-tree-checkout: 'true'


### PR DESCRIPTION
Do not use custom tokens, rely on GH provided and managed tokens.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
