### PR TITLE
ci: doc: bump sphinx from 8.1.3 to 8.2.3 in /doc in the doc-deps group

### DIFF
--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -1,6 +1,6 @@
 # DOC: used to generate docs
 
-sphinx<8.2.0
+sphinx<8.3.0
 sphinx_rtd_theme~=3.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -462,6 +462,10 @@ requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via sphinx
+roman-numerals-py==3.1.0 \
+    --hash=sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c \
+    --hash=sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d
+    # via sphinx
 ruamel-yaml==0.18.10 \
     --hash=sha256:20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58 \
     --hash=sha256:30f22513ab2301b3d2b577adc121c6471f28734d3d9728581245f1e76468b4f1
@@ -529,9 +533,9 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via sphinx
-sphinx==8.1.3 \
-    --hash=sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2 \
-    --hash=sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927
+sphinx==8.2.3 \
+    --hash=sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348 \
+    --hash=sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3
     # via
     #   -r requirements.in
     #   sphinx-autobuild


### PR DESCRIPTION
Regression in PDF that forced us to do efbe277d203f8d25f11818662abad6ea0316bfa4 seems to be a thing of the past so use next Sphinx minor version.

Updates `sphinx` from 8.1.3 to 8.2.3
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/sphinx-doc/sphinx/releases">sphinx's releases</a>.</em></p>
<blockquote>
<h2>Sphinx 8.2.3</h2>
<p>Changelog: <a href="https://www.sphinx-doc.org/en/master/changes/8.2.html">https://www.sphinx-doc.org/en/master/changes/8.2.html</a></p>
<h2>Sphinx 8.2.2</h2>
<p>Changelog: <a href="https://www.sphinx-doc.org/en/master/changes/8.2.html">https://www.sphinx-doc.org/en/master/changes/8.2.html</a></p>
<h2>Sphinx 8.2.1</h2>
<p>Changelog: <a href="https://www.sphinx-doc.org/en/master/changes/8.2.html">https://www.sphinx-doc.org/en/master/changes/8.2.html</a></p>
<h2>Sphinx 8.2.0</h2>
<p>Changelog: <a href="https://www.sphinx-doc.org/en/master/changes/8.2.html">https://www.sphinx-doc.org/en/master/changes/8.2.html</a></p>
<h2>Dependencies</h2>
<ul>
<li><a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13000">#13000</a>: Drop Python 3.10 support.</li>
</ul>
<h2>Incompatible changes</h2>
<ul>
<li><a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13044">#13044</a>: Remove the internal and undocumented <code>has_equations</code> data
from the <code>MathDomain</code> domain.
The undocumented <code>MathDomain.has_equations</code> method
now unconditionally returns <code>True</code>.
These are replaced by the <code>has_maths_elements</code> key of the page context dict.
Patch by Adam Turner.</li>
<li><a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13227">#13227</a>: HTML output for sequences of keys in the <code>kbd</code> role
no longer uses a <code>&lt;kbd class=&quot;kbd compound&quot;&gt;</code> element to wrap
the keys and separators, but places them directly in the relevant parent node.
This means that CSS rulesets targeting <code>kbd.compound</code> or <code>.kbd.compound</code>
will no longer have any effect.
Patch by Adam Turner.</li>
</ul>
<h2>Deprecated</h2>
<ul>
<li><a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13037">#13037</a>: Deprecate the <code>SingleHTMLBuilder.fix_refuris</code> method.
Patch by James Addison.</li>
<li><a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13083">#13083</a>, <a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13330">#13330</a>: Un-deprecate <code>sphinx.util.import_object</code>.
Patch by Matthias Geier.</li>
</ul>
<h2>Features added</h2>
<ul>
<li><a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13173">#13173</a>: Add a new <code>duplicate_declaration</code> warning type,
with <code>duplicate_declaration.c</code> and <code>duplicate_declaration.cpp</code> subtypes.
Patch by Julien Lecomte and Adam Turner.</li>
<li><a href="https://redirect.github.com/sphinx-doc/sphinx/issues/11824">#11824</a>: linkcode: Allow extensions to add support for a domain by defining
the keys that should be present.</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/847ad0c991e21db9daa02fec09acbd456f353300"><code>847ad0c</code></a> Bump to 8.2.3 final</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/4091fe335444236181f765adaf9e9bf0a2bcc735"><code>4091fe3</code></a> Add CHANGES for Sphinx 8.2.3</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/c84c21ff935e840f67413e9397fc6a75cb87e529"><code>c84c21f</code></a> Correct the date for Sphinx 8.2.2</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/b3881bb23471584d3999ecbb03cb20184da22738"><code>b3881bb</code></a> Fix _CurrentDocument membership testing with '{c,cpp}:parent_symbol'</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/92b5303219101dee99ca50c245c5eb65257d4580"><code>92b5303</code></a> Define <code>_StrPath.__radd__()</code></li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/5739a9d58d2e5005259718d615d4c8ec3971173a"><code>5739a9d</code></a> Bump version</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/ee96ef304265d9969488f7bcd09b37826ac7c43c"><code>ee96ef3</code></a> Bump to 8.2.2 final</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/3e0021c7aa4e1f1b91d035d10b5f0b3a66b4f206"><code>3e0021c</code></a> Move Sphinx 8.2.2 CHANGES to doc/changes</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/1a62f3170ad7f2fe3f1f1bfc1d22e0e402e8e274"><code>1a62f31</code></a> Fix apidoc extension not setting default header/package name (<a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13391">#13391</a>)</li>
<li><a href="https://github.com/sphinx-doc/sphinx/commit/13d2899666c9e492809adb690b9a66f7f7064ce6"><code>13d2899</code></a> Replace <code>None</code> filename with <code>''</code> in <code>Sphinx.add_js_file()</code> (<a href="https://redirect.github.com/sphinx-doc/sphinx/issues/13402">#13402</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/sphinx-doc/sphinx/compare/v8.1.3...v8.2.3">compare view</a></li>
</ul>
</details>
<br />

