### PR TITLE
manifest: hal_rpi_pico: Update to SDK 2.1.1

### DIFF
--- a/dts/bindings/clock/raspberrypi,pico-xosc.yaml
+++ b/dts/bindings/clock/raspberrypi,pico-xosc.yaml
@@ -11,6 +11,7 @@ include: raspberrypi,pico-clock.yaml
 properties:
   startup-delay-multiplier:
     type: int
-    default: 1
+    default: 6
     description: |
-      Startup delay multiplier. The default value matches the Pico SDK.
+      Startup delay multiplier. The default value matches the Pico SDK used
+      as the basis for hal_rpi_pico (currently v2.1.1).

--- a/west.yml
+++ b/west.yml
@@ -224,7 +224,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: 7b57b24588797e6e7bf18b6bda168e6b96374264
+      revision: pull/10/head
       groups:
         - hal
     - name: hal_silabs


### PR DESCRIPTION
Update the Raspberry Pi Pico HAL to be based on the latest release of
the upstream SDK (v2.1.1).

This PR also changes the default delay multiplier for the external oscillator to match the SDK's default.