### PR TITLE
drivers: i3c: remove group addr definition

### DIFF
--- a/doc/hardware/peripherals/i3c.rst
+++ b/doc/hardware/peripherals/i3c.rst
@@ -347,7 +347,6 @@ Configuration Options
 Related configuration options:
 
 * :kconfig:option:`CONFIG_I3C`
-* :kconfig:option:`CONFIG_I3C_USE_GROUP_ADDR`
 * :kconfig:option:`CONFIG_I3C_USE_IBI`
 * :kconfig:option:`CONFIG_I3C_IBI_MAX_PAYLOAD_SIZE`
 * :kconfig:option:`CONFIG_I3C_CONTROLLER_INIT_PRIORITY`

--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -24,15 +24,6 @@ config I3C_SHELL
 	  The I3C shell supports info, bus recovery, CCC, I3C read and
 	  write operations.
 
-config I3C_USE_GROUP_ADDR
-	bool "Use Group Addresses"
-	default y
-	help
-	  Enable this to use group addresses if supported
-	  by the controllers and target devices.
-
-	  Says Y if unsure.
-
 config I3C_TARGET_BUFFER_MODE
 	bool "I3C target driver for buffer mode"
 	help

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -200,9 +200,6 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 						    "\tpid: 0x%012llx\n"
 						    "\tstatic_addr: 0x%02x\n"
 						    "\tdynamic_addr: 0x%02x\n"
-#if defined(CONFIG_I3C_USE_GROUP_ADDR)
-						    "\tgroup_addr: 0x%02x\n"
-#endif
 						    "\tbcr: 0x%02x\n"
 						    "\tdcr: 0x%02x\n"
 						    "\tmaxrd: 0x%02x\n"
@@ -216,9 +213,6 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 						    "\tcrcaps: 0x%02x; 0x%02x",
 						    desc->dev->name, (uint64_t)desc->pid,
 						    desc->static_addr, desc->dynamic_addr,
-#if defined(CONFIG_I3C_USE_GROUP_ADDR)
-						    desc->group_addr,
-#endif
 						    desc->bcr, desc->dcr, desc->data_speed.maxrd,
 						    desc->data_speed.maxwr,
 						    desc->data_speed.max_read_turnaround,
@@ -249,9 +243,6 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 					    "\tpid: 0x%012llx\n"
 					    "\tstatic_addr: 0x%02x\n"
 					    "\tdynamic_addr: 0x%02x\n"
-#if defined(CONFIG_I3C_USE_GROUP_ADDR)
-					    "\tgroup_addr: 0x%02x\n"
-#endif
 					    "\tbcr: 0x%02x\n"
 					    "\tdcr: 0x%02x\n"
 					    "\tmaxrd: 0x%02x\n"
@@ -265,9 +256,6 @@ static int cmd_i3c_info(const struct shell *sh, size_t argc, char **argv)
 					    "\tcrcaps: 0x%02x; 0x%02x",
 					    desc->dev->name, (uint64_t)desc->pid, desc->static_addr,
 					    desc->dynamic_addr,
-#if defined(CONFIG_I3C_USE_GROUP_ADDR)
-					    desc->group_addr,
-#endif
 					    desc->bcr, desc->dcr, desc->data_speed.maxrd,
 					    desc->data_speed.maxwr,
 					    desc->data_speed.max_read_turnaround,

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -946,18 +946,6 @@ struct i3c_device_desc {
 	 */
 	uint8_t dynamic_addr;
 
-#if defined(CONFIG_I3C_USE_GROUP_ADDR) || defined(__DOXYGEN__)
-	/**
-	 * Group address for this target device. Set during:
-	 * - Reset Group Address(es) (RSTGRPA)
-	 * - Set Group Address (SETGRPA)
-	 *
-	 * 0 if group address has not been assigned.
-	 * Only available if @kconfig{CONFIG_I3C_USE_GROUP_ADDR} is set.
-	 */
-	uint8_t group_addr;
-#endif /* CONFIG_I3C_USE_GROUP_ADDR */
-
 	/**
 	 * Bus Characteristic Register (BCR)
 	 * @see @ref I3C_BCR


### PR DESCRIPTION
The i3c group address support is rather very incomplete here. Remove references to it. This could all easily come back when/if group support comes in.