### PR TITLE
kernel: system_work_q: make `k_work_queue_config cfg` as `static const`

### DIFF
--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -21,7 +21,7 @@ struct k_work_q k_sys_work_q;
 
 static int k_sys_work_q_init(void)
 {
-	struct k_work_queue_config cfg = {
+	static const struct k_work_queue_config cfg = {
 		.name = "sysworkq",
 		.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
 		.essential = true,


### PR DESCRIPTION
Make `k_work_queue_config cfg` as `static const` to enable compile-time instantiation instead of runtime allocation.
This modification saves substantial flash memory but has system-wide effects that should be considered.