### PR TITLE
tests: lwm2m: add ignored vulnerabilities for CoAPthon3

### DIFF
--- a/tests/net/lib/lwm2m/interop/osv-scanner.toml
+++ b/tests/net/lib/lwm2m/interop/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "PYSEC-2019-166"
+reason = "CoAPthon3 is only used for testing purposes."


### PR DESCRIPTION
CoAPthon3 is only used for testing, ignore PYSEC-2019-166.

Addressed the remaining warning in "Vulnerabilities" section of OpenSSF scorecard (see https://scorecard.dev/viewer/?uri=github.com/kartben/zephyr)