### PR TITLE
System workqueue: Prevent blocking API calls

### DIFF
--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -109,6 +109,9 @@ its queue until the handler function finishes executing.
    potentially blocking, as there is no guarantee that work items submitted to
    it do not depend on subsequent work items in the queue to unblock them.
 
+   :kconfig:option:`CONFIG_SYSTEM_WORKQUEUE_NO_BLOCK` enforces that no work
+   items submitted to the system workqueue perform any blocking operations.
+
 The single argument that is passed to a handler function can be ignored if it
 is not required. If the handler function requires additional information about
 the work it is to perform, the work item can be embedded in a larger data

--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -103,6 +103,12 @@ operations that are potentially blocking (e.g. taking a semaphore) must be
 used with care, since the workqueue cannot process subsequent work items in
 its queue until the handler function finishes executing.
 
+.. warning::
+
+   The system workqueue can not safely be used to perform operations which are
+   potentially blocking, as there is no guarantee that work items submitted to
+   it do not depend on subsequent work items in the queue to unblock them.
+
 The single argument that is passed to a handler function can be ignored if it
 is not required. If the handler function requires additional information about
 the work it is to perform, the work item can be embedded in a larger data

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1182,6 +1182,19 @@ void k_thread_time_slice_set(struct k_thread *th, int32_t slice_ticks,
 bool k_is_in_isr(void);
 
 /**
+ * @brief Determine if code is running from system work item
+ *
+ * This routine allows the caller to customize its actions, depending on
+ * whether it is running from a system workqueue item.
+ *
+ * @funcprops \isr_ok
+ *
+ * @return false if not invoked from a system workqueue item.
+ * @return true if invoked from a system workqueue item.
+ */
+bool k_is_in_sys_work(void);
+
+/**
  * @brief Determine if code is running in a preemptible thread.
  *
  * This routine allows the caller to customize its actions, depending on

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -600,6 +600,14 @@ config SYSTEM_WORKQUEUE_NO_YIELD
 	  cooperative and a sequence of work items is expected to complete
 	  without yielding.
 
+config SYSTEM_WORKQUEUE_NO_BLOCK
+	bool "Select whether system work queue enforces non-blocking work items"
+	help
+	  By default, the system work queue does not enforce work items
+	  passed to it to not perform blocking operations. Selecting this
+	  enforces that blocking operations are not performed by invoking
+	  a kernel oops if such operations are attempted.
+
 endmenu
 
 menu "Barrier Operations"

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -523,6 +523,10 @@ static inline void z_vrfy_k_thread_resume(k_tid_t thread)
 
 static void unready_thread(struct k_thread *thread)
 {
+	if (IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_BLOCK) && k_is_in_sys_work()) {
+		k_oops();
+	}
+
 	if (z_is_thread_queued(thread)) {
 		dequeue_thread(thread);
 	}

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -1175,3 +1175,9 @@ bool k_work_flush_delayable(struct k_work_delayable *dwork,
 }
 
 #endif /* CONFIG_SYS_CLOCK_EXISTS */
+
+bool k_is_in_sys_work(void)
+{
+	return k_current_get() == k_work_queue_thread_get(&k_sys_work_q) &&
+	       flag_test(&k_sys_work_q.flags, K_WORK_QUEUE_BUSY_BIT);
+}

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -732,7 +732,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 	default: {
 		k_tid_t current_thread = k_current_get();
 
-		if (current_thread == k_work_queue_thread_get(&k_sys_work_q)) {
+		if (k_is_in_sys_work()) {
 			/* No blocking in the sysqueue. */
 			timeout = K_NO_WAIT;
 		} else if (current_thread == att_handle_rsp_thread) {

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -215,7 +215,7 @@ static struct bt_ag_tx *bt_ag_tx_alloc(void)
 	 * so if we're in the same workqueue but there are no immediate
 	 * contexts available, there's no chance we'll get one by waiting.
 	 */
-	if (k_current_get() == &k_sys_work_q.thread) {
+	if (k_is_in_sys_work()) {
 		return k_fifo_get(&ag_tx_free, K_NO_WAIT);
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1606,8 +1606,7 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 	 */
 	__ASSERT_NO_MSG(!k_is_in_isr());
 
-	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
-	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) && k_is_in_sys_work()) {
 		LOG_WRN("Timeout discarded. No blocking in syswq.");
 		timeout = K_NO_WAIT;
 	}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -410,7 +410,7 @@ int bt_hci_cmd_send_sync(uint16_t opcode, struct net_buf *buf,
 	/* Since the commands are now processed in the syswq, we cannot suspend
 	 * and wait. We have to send the command from the current context.
 	 */
-	if (k_current_get() == &k_sys_work_q.thread) {
+	if (k_is_in_sys_work()) {
 		/* drain the command queue until we get to send the command of interest. */
 		struct net_buf *cmd = NULL;
 

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -674,8 +674,7 @@ struct net_buf *bt_l2cap_create_pdu_timeout(struct net_buf_pool *pool,
 					    size_t reserve,
 					    k_timeout_t timeout)
 {
-	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
-	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) && k_is_in_sys_work()) {
 		timeout = K_NO_WAIT;
 	}
 

--- a/subsys/input/input.c
+++ b/subsys/input/input.c
@@ -52,8 +52,7 @@ int input_report(const struct device *dev,
 #ifdef CONFIG_INPUT_MODE_THREAD
 	int ret;
 
-	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
-	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
+	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) && k_is_in_sys_work()) {
 		LOG_DBG("Timeout discarded. No blocking in syswq.");
 		timeout = K_NO_WAIT;
 	}

--- a/tests/bluetooth/host/conn/mocks/kernel.c
+++ b/tests/bluetooth/host/conn/mocks/kernel.c
@@ -31,5 +31,6 @@ DEFINE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout_
 DEFINE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
 DEFINE_FAKE_VOID_FUNC(k_sched_lock);
 DEFINE_FAKE_VOID_FUNC(k_sched_unlock);
+DEFINE_FAKE_VALUE_FUNC(bool, k_is_in_sys_work);
 
 struct k_work_q k_sys_work_q;

--- a/tests/bluetooth/host/conn/mocks/kernel.h
+++ b/tests/bluetooth/host/conn/mocks/kernel.h
@@ -32,6 +32,7 @@
 	FAKE(k_heap_free)                                                                          \
 	FAKE(k_sched_lock)                                                                         \
 	FAKE(k_sched_unlock)                                                                       \
+	FAKE(k_is_in_sys_work)                                                                     \
 
 DECLARE_FAKE_VALUE_FUNC(bool, k_is_in_isr);
 DECLARE_FAKE_VALUE_FUNC(int, k_poll_signal_raise, struct k_poll_signal *, int);
@@ -56,3 +57,4 @@ DECLARE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout
 DECLARE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
 DECLARE_FAKE_VOID_FUNC(k_sched_lock);
 DECLARE_FAKE_VOID_FUNC(k_sched_unlock);
+DECLARE_FAKE_VALUE_FUNC(bool, k_is_in_sys_work);

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -33,6 +33,13 @@ LOG_MODULE_REGISTER(test);
 	k_ticks_to_ms_floor64(k_ms_to_ticks_ceil32(WORK_ITEM_WAIT) + _TICK_ALIGN)
 
 /*
+ * System work queue is not allowed to unready threads. k_busy_wait() is
+ * used to simulate work. It is higly inprecise, use way lower wait to
+ * account for this.
+ */
+#define WORK_ITEM_BUSY_WAIT ((WORK_ITEM_WAIT * USEC_PER_MSEC) / 4)
+
+/*
  * Wait 50ms between work submissions, to ensure co-op and prempt
  * preempt thread submit alternatively.
  */
@@ -97,7 +104,7 @@ static void work_handler(struct k_work *work)
 			CONTAINER_OF(dwork, struct delayed_test_item, work);
 
 	LOG_DBG(" - Running test item %d", ti->key);
-	k_msleep(WORK_ITEM_WAIT);
+	k_busy_wait(WORK_ITEM_BUSY_WAIT);
 
 	results[num_results++] = ti->key;
 }
@@ -211,7 +218,7 @@ static void resubmit_work_handler(struct k_work *work)
 	struct delayed_test_item *ti =
 			CONTAINER_OF(dwork, struct delayed_test_item, work);
 
-	k_msleep(WORK_ITEM_WAIT);
+	k_busy_wait(WORK_ITEM_BUSY_WAIT);
 
 	results[num_results++] = ti->key;
 


### PR DESCRIPTION
It is inherently unsafe to call blocking APIs from the system work queue, as it is shared opaquely between modules which may use the system work queue internally to unblock the blocking API call (deadlock).

This particular deadlock is extraordinarily hard to hunt down, given there is no hard fault, and it affects seemingly random parts of the system. Drivers and subsystems just "stop responding" from a seemingly arbitrary, unrelated API call.

Subsystems which rely heavily on the system workqueue already adhere to the fact that blocking API calls are unsafe, and have implemented their own workarounds to address this.

This PR addresses the issue by extending the documentation to state that it is inherently unsafe to use the system work queue for blocking API calls, and introduces an optional check similar to a stack sentinal or spinlock verify, which invokes a kernel oops if a work item passed to the system work queue attempts a blocking call. Lastly, the new kernel API `k_is_in_sys_work()` for checking if a calling context is within a work item handler passed to the system workqueue is added.

**Note** the new API is `k_is_in_sys_work()`, not `k_is_in_sys_workqueue_thread()`. The thread is allowed to unready when it is not busy, between items for example, it is only while executing a work item handler it is not allowed to unready :)