### PR TITLE
ci: codeql: enable on PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,18 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+      - v*-branch
+      - collab-*
   schedule:
     - cron: '34 16 * * 3'
+  pull_request:
+    branches:
+      - main
+      - v*-branch
+      - collab-*
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Enable CodeQL on PRs to catch issues before they are merged.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>


example check: https://github.com/zephyrproject-rtos/zephyr-testing/pull/319
