### PR TITLE
posix: net: Fix undefined behavior

### DIFF
--- a/lib/posix/options/net.c
+++ b/lib/posix/options/net.c
@@ -19,7 +19,7 @@
 
 in_addr_t inet_addr(const char *cp)
 {
-	int val = 0;
+	unsigned int val = 0;
 	int len = 0;
 	int dots = 0;
 	int digits = 0;


### PR DESCRIPTION
The signedness of the variable caused undefined behavior because the sign bit is modified when it gets left-shifted.

This fixes that by changing it to an unsigned variable.