### PR TITLE
json: Fix calculation of object size

### DIFF
--- a/lib/utils/json.c
+++ b/lib/utils/json.c
@@ -635,11 +635,15 @@ static ptrdiff_t get_elem_size(const struct json_obj_descr *descr)
 		size_t i;
 
 		for (i = 0; i < descr->object.sub_descr_len; i++) {
-			total += get_elem_size(&descr->object.sub_descr[i]);
-
 			if (descr->object.sub_descr[i].align_shift > align_shift) {
 				align_shift = descr->object.sub_descr[i].align_shift;
 			}
+		}
+
+		i = descr->object.sub_descr_len;
+		if (i > 0) {
+			total = descr->object.sub_descr[i - 1].offset +
+				get_elem_size(&descr->object.sub_descr[i - 1]);
 		}
 
 		return ROUND_UP(total, 1 << align_shift);


### PR DESCRIPTION
The calculation of the object size may be incorrect when the size of a field is smaller than the struct alignment. When such a struct is used in an array field, the decoded object contains wrong values.

The alignment influences the object size. For example the following struct has a calculated object size of 8 bytes, however due to alignment the real size of the struct is 12 bytes:

```
struct test_bool {
  bool b1; /* offset 0, size 1 */
           /* 3-byte padding */
  int i1;  /* offset 4, size 4 */
  bool b2; /* offset 8, size 1 */
           /* 3-byte padding */
};
```

This commit changes the object size calculation and computes the size with the offset and size of the last field in the struct (rounded up by the struct alignment).

Fixes: #85121