### PR TITLE
i2c: stm32: add missing DMA configuration fields

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -595,6 +595,32 @@ static void i2c_stm32_irq_config_func_##index(const struct device *dev)	\
 				(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1)),\
 		},
 
+void i2c_stm32_dma_tx_cb(const struct device *dma_dev, void *user_data,
+			uint32_t channel, int status)
+{
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(channel);
+
+	/* log DMA TX error */
+	if (status != 0) {
+		LOG_ERR("DMA error %d", status);
+	}
+}
+
+void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
+			uint32_t channel, int status)
+{
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(user_data);
+	ARG_UNUSED(channel);
+
+	/* log DMA RX error */
+	if (status != 0) {
+		LOG_ERR("DMA error %d", status);
+	}
+}
+
 #define I2C_DMA_DATA_INIT(index, dir, src, dest)			\
 	.dma_##dir##_cfg = {						\
 		.dma_slot = STM32_DMA_SLOT(index, dir, slot),		\
@@ -610,6 +636,7 @@ static void i2c_stm32_irq_config_func_##index(const struct device *dev)	\
 				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
 		.source_burst_length = 1,				\
 		.dest_burst_length = 1,					\
+		.dma_callback = i2c_stm32_dma_##dir##_cb,		\
 	},								\
 
 #else

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -587,15 +587,35 @@ static void i2c_stm32_irq_config_func_##index(const struct device *dev)	\
 
 #ifdef CONFIG_I2C_STM32_V2_DMA
 
-#define I2C_DMA_INIT(index, dir)                                                                   \
-	.dir##_dma = {.dev_dma = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),                    \
-				(DEVICE_DT_GET(STM32_DMA_CTLR(index, dir))), (NULL)),              \
-			       .dma_channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),       \
-					(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1))},
+#define I2C_DMA_INIT(index, dir)					\
+	.dir##_dma = {							\
+		.dev_dma = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),\
+				(DEVICE_DT_GET(STM32_DMA_CTLR(index, dir))), (NULL)),\
+		.dma_channel = COND_CODE_1(DT_INST_DMAS_HAS_NAME(index, dir),\
+				(DT_INST_DMAS_CELL_BY_NAME(index, dir, channel)), (-1)),\
+		},
+
+#define I2C_DMA_DATA_INIT(index, dir, src, dest)			\
+	.dma_##dir##_cfg = {						\
+		.dma_slot = STM32_DMA_SLOT(index, dir, slot),		\
+		.channel_direction = STM32_DMA_CONFIG_DIRECTION(	\
+					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
+		.cyclic =  STM32_DMA_CONFIG_CYCLIC(			\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+		.channel_priority = STM32_DMA_CONFIG_PRIORITY(		\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+		.source_data_size = STM32_DMA_CONFIG_##src##_DATA_SIZE(	\
+					STM32_DMA_CHANNEL_CONFIG(index, dir)),\
+		.dest_data_size = STM32_DMA_CONFIG_##dest##_DATA_SIZE(	\
+				STM32_DMA_CHANNEL_CONFIG(index, dir)),	\
+		.source_burst_length = 1,				\
+		.dest_burst_length = 1,					\
+	},								\
 
 #else
 
 #define I2C_DMA_INIT(index, dir)
+#define I2C_DMA_DATA_INIT(index, dir, src, dest)
 
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 
@@ -624,11 +644,14 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##index = {		\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),		\
 		(.timings = (const struct i2c_config_timing *) i2c_timings_##index,\
 		 .n_timings = ARRAY_SIZE(i2c_timings_##index),))	\
-	I2C_DMA_INIT(index, tx) \
-	I2C_DMA_INIT(index, rx) \
+	I2C_DMA_INIT(index, tx)						\
+	I2C_DMA_INIT(index, rx)						\
 };									\
 									\
-static struct i2c_stm32_data i2c_stm32_dev_data_##index;		\
+static struct i2c_stm32_data i2c_stm32_dev_data_##index = {		\
+	I2C_DMA_DATA_INIT(index, tx, MEMORY, PERIPHERAL)		\
+	I2C_DMA_DATA_INIT(index, rx, PERIPHERAL, MEMORY)		\
+};									\
 									\
 PM_DEVICE_DT_INST_DEFINE(index, i2c_stm32_pm_action);			\
 									\

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -105,7 +105,8 @@ struct i2c_stm32_data {
 	const struct device *smbalert_cb_dev;
 #endif
 #ifdef CONFIG_I2C_STM32_V2_DMA
-	struct dma_config dma_cfg;
+	struct dma_config dma_tx_cfg;
+	struct dma_config dma_rx_cfg;
 	struct dma_block_config dma_blk_cfg;
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 };

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -195,10 +195,12 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 				/* Configure RX DMA */
 				data->dma_blk_cfg.source_address = LL_I2C_DMA_GetRegAddr(
 					cfg->i2c, LL_I2C_DMA_REG_DATA_RECEIVE);
+				data->dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 				data->dma_blk_cfg.dest_address = (uint32_t)msg->buf;
+				data->dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 				data->dma_blk_cfg.block_size = msg->len;
 
-				if (configure_dma(&cfg->rx_dma, &data->dma_cfg,
+				if (configure_dma(&cfg->rx_dma, &data->dma_rx_cfg,
 						  &data->dma_blk_cfg) != 0) {
 					LOG_ERR("Problem setting up RX DMA");
 					return;
@@ -211,10 +213,13 @@ static inline void msg_init(const struct device *dev, struct i2c_msg *msg,
 					/* Configure TX DMA */
 					data->dma_blk_cfg.source_address =
 						(uint32_t)data->current.buf;
+					data->dma_blk_cfg.source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
 					data->dma_blk_cfg.dest_address = LL_I2C_DMA_GetRegAddr(
 						cfg->i2c, LL_I2C_DMA_REG_DATA_TRANSMIT);
+					data->dma_blk_cfg.dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 					data->dma_blk_cfg.block_size = msg->len;
-					if (configure_dma(&cfg->tx_dma, &data->dma_cfg,
+
+					if (configure_dma(&cfg->tx_dma, &data->dma_tx_cfg,
 							  &data->dma_blk_cfg) != 0) {
 						LOG_ERR("Problem setting up TX DMA");
 						return;


### PR DESCRIPTION
Add missing fields for DMA tx and rx configuration macros

fix #87516

Tested on stm32h735-Discovery and STM32H747i-Discovery board