### PR TITLE
Bluetooth: Controller: Fix incorrect CIS payload count at CIS Estab

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6053,7 +6053,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 		uint64_t pkt_seq_num;
 
 		/* Catch up local pkt_seq_num with internal pkt_seq_num */
-		event_count = cis->lll.event_count + event_offset;
+		event_count = cis->lll.event_count_prepare + event_offset;
 		pkt_seq_num = event_count + 1U;
 
 		/* If pb_flag is BT_ISO_START (0b00) or BT_ISO_SINGLE (0b10)
@@ -6096,7 +6096,7 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 						   ISO_INT_UNIT_US));
 
 #else /* !CONFIG_BT_CTLR_ISOAL_PSN_IGNORE */
-		sdu_frag_tx.target_event = cis->lll.event_count + event_offset;
+		sdu_frag_tx.target_event = cis->lll.event_count_prepare + event_offset;
 		sdu_frag_tx.grp_ref_point =
 			isoal_get_wrapped_time_us(cig->cig_ref_point,
 						  (event_offset *

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -58,11 +58,14 @@ struct lll_conn_iso_stream {
 	uint8_t datapath_ready_rx:1;/* 1 if datapath for RX is ready */
 
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	/* A CIS LLL is active and established in a CIG radio event when ACL instant has passed
-	 * which set the `active` flag and then when CIG event prepare has picked up the set
+	/* A CIS LLL is active and prepared in a CIG radio event when ACL instant has passed
+	 * which set the `active` flag and then when CIG event prepare in LLL has picked up the set
 	 * `active` flag.
+	 * FIXME: There is suspected possibility that ACL ULL Prepare that is processing LLCP could
+	 *        execute between CIG ULL Prepare and deferred CIG LLL Prepare say when there is
+	 *        already another state/role that the CIG tries to pre-empt.
 	 */
-	uint8_t established:1;
+	uint8_t prepared:1;
 	/* Lazy at CIS active. Number of previously skipped CIG events that is
 	 * determined when CIS is made active and subtracted from total CIG
 	 * events that where skipped when this CIS gets to use radio for the

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -58,6 +58,11 @@ struct lll_conn_iso_stream {
 	uint8_t datapath_ready_rx:1;/* 1 if datapath for RX is ready */
 
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	/* A CIS LLL is active and established in a CIG radio event when ACL instant has passed
+	 * which set the `active` flag and then when CIG event prepare has picked up the set
+	 * `active` flag.
+	 */
+	uint8_t established:1;
 	/* Lazy at CIS active. Number of previously skipped CIG events that is
 	 * determined when CIS is made active and subtracted from total CIG
 	 * events that where skipped when this CIS gets to use radio for the

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -144,11 +144,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	LL_ASSERT(cis_lll);
 
-	/* Unconditionally set the established flag.
+	/* Unconditionally set the prepared flag.
 	 * This flag ensures current CIG event does not pick up a new CIS becoming active when the
 	 * ACL overlaps at the instant with this already started CIG events.
 	 */
-	cis_lll->established = 1U;
+	cis_lll->prepared = 1U;
 
 	/* Save first active CIS offset */
 	cis_offset_first = cis_lll->offset;
@@ -366,12 +366,12 @@ static int prepare_cb(struct lll_prepare_param *p)
 	do {
 		cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
 		if (cis_lll && cis_lll->active) {
-			/* Unconditionally set the established flag.
+			/* Unconditionally set the prepared flag.
 			 * This flag ensures current CIG event does not pick up a new CIS becoming
 			 * active when the ACL overlaps at the instant with this already started
 			 * CIG events.
 			 */
-			cis_lll->established = 1U;
+			cis_lll->prepared = 1U;
 
 			/* Pick the event_count calculated in the ULL prepare */
 			cis_lll->event_count = cis_lll->event_count_prepare;
@@ -417,7 +417,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 		do {
 			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll,
 									    &cis_handle_curr);
-			if (next_cis_lll && next_cis_lll->established) {
+			if (next_cis_lll && next_cis_lll->prepared) {
 				payload_count_flush_or_inc_on_close(next_cis_lll);
 			}
 		} while (next_cis_lll);
@@ -599,7 +599,7 @@ static void isr_tx(void *param)
 		cis_handle = cis_handle_curr;
 		do {
 			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
-		} while (next_cis_lll && !next_cis_lll->established);
+		} while (next_cis_lll && !next_cis_lll->prepared);
 
 		if (!next_cis_lll) {
 			return;
@@ -843,7 +843,7 @@ isr_rx_next_subevent:
 		do {
 			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll,
 									    &cis_handle_curr);
-		} while (next_cis_lll && !next_cis_lll->established);
+		} while (next_cis_lll && !next_cis_lll->prepared);
 
 		if (!next_cis_lll) {
 			goto isr_rx_done;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -144,6 +144,12 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	LL_ASSERT(cis_lll);
 
+	/* Unconditionally set the established flag.
+	 * This flag ensures current CIG event does not pick up a new CIS becoming active when the
+	 * ACL overlaps at the instant with this already started CIG events.
+	 */
+	cis_lll->established = 1U;
+
 	/* Save first active CIS offset */
 	cis_offset_first = cis_lll->offset;
 
@@ -360,6 +366,13 @@ static int prepare_cb(struct lll_prepare_param *p)
 	do {
 		cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
 		if (cis_lll && cis_lll->active) {
+			/* Unconditionally set the established flag.
+			 * This flag ensures current CIG event does not pick up a new CIS becoming
+			 * active when the ACL overlaps at the instant with this already started
+			 * CIG events.
+			 */
+			cis_lll->established = 1U;
+
 			/* Pick the event_count calculated in the ULL prepare */
 			cis_lll->event_count = cis_lll->event_count_prepare;
 
@@ -404,7 +417,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 		do {
 			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll,
 									    &cis_handle_curr);
-			if (next_cis_lll && next_cis_lll->active) {
+			if (next_cis_lll && next_cis_lll->established) {
 				payload_count_flush_or_inc_on_close(next_cis_lll);
 			}
 		} while (next_cis_lll);
@@ -586,7 +599,7 @@ static void isr_tx(void *param)
 		cis_handle = cis_handle_curr;
 		do {
 			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll, &cis_handle);
-		} while (next_cis_lll && !next_cis_lll->active);
+		} while (next_cis_lll && !next_cis_lll->established);
 
 		if (!next_cis_lll) {
 			return;
@@ -830,7 +843,7 @@ isr_rx_next_subevent:
 		do {
 			next_cis_lll = ull_conn_iso_lll_stream_get_by_group(cig_lll,
 									    &cis_handle_curr);
-		} while (next_cis_lll && !next_cis_lll->active);
+		} while (next_cis_lll && !next_cis_lll->established);
 
 		if (!next_cis_lll) {
 			goto isr_rx_done;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -158,11 +158,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	LL_ASSERT(cis_lll);
 
-	/* Unconditionally set the established flag.
+	/* Unconditionally set the prepared flag.
 	 * This flag ensures current CIG event does not pick up a new CIS becoming active when the
 	 * ACL overlaps at the instant with this already started CIG events.
 	 */
-	cis_lll->established = 1U;
+	cis_lll->prepared = 1U;
 
 	/* Save first active CIS offset */
 	cis_offset_first = cis_lll->offset;
@@ -383,11 +383,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 			break;
 		}
 
-		/* Unconditionally set the established flag.
+		/* Unconditionally set the prepared flag.
 		 * This flag ensures current CIG event does not pick up a new CIS becoming active
 		 * when the ACL overlaps at the instant with this already started CIG events.
 		 */
-		cis_lll->established = 1U;
+		cis_lll->prepared = 1U;
 
 		/* Pick the event_count calculated in the ULL prepare */
 		cis_lll->event_count = cis_lll->event_count_prepare;
@@ -433,7 +433,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 			next_cis_lll =
 				ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll,
 									    &cis_handle_curr);
-			if (next_cis_lll && next_cis_lll->established) {
+			if (next_cis_lll && next_cis_lll->prepared) {
 				payload_count_rx_flush_or_txrx_inc(next_cis_lll);
 			}
 		} while (next_cis_lll);
@@ -794,7 +794,7 @@ static void isr_rx(void *param)
 		do {
 			next_cis_lll =
 				ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle);
-		} while (next_cis_lll && !next_cis_lll->established);
+		} while (next_cis_lll && !next_cis_lll->prepared);
 
 		if (!next_cis_lll) {
 			/* ISO Event Done */
@@ -1006,7 +1006,7 @@ static void next_cis_prepare(void *param)
 	cis_handle = cis_handle_curr;
 	do {
 		next_cis_lll = ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle);
-	} while (next_cis_lll && !next_cis_lll->established);
+	} while (next_cis_lll && !next_cis_lll->prepared);
 
 	if (!next_cis_lll) {
 		/* ISO Event Done */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -158,6 +158,12 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	LL_ASSERT(cis_lll);
 
+	/* Unconditionally set the established flag.
+	 * This flag ensures current CIG event does not pick up a new CIS becoming active when the
+	 * ACL overlaps at the instant with this already started CIG events.
+	 */
+	cis_lll->established = 1U;
+
 	/* Save first active CIS offset */
 	cis_offset_first = cis_lll->offset;
 
@@ -377,6 +383,12 @@ static int prepare_cb(struct lll_prepare_param *p)
 			break;
 		}
 
+		/* Unconditionally set the established flag.
+		 * This flag ensures current CIG event does not pick up a new CIS becoming active
+		 * when the ACL overlaps at the instant with this already started CIG events.
+		 */
+		cis_lll->established = 1U;
+
 		/* Pick the event_count calculated in the ULL prepare */
 		cis_lll->event_count = cis_lll->event_count_prepare;
 
@@ -421,7 +433,7 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 			next_cis_lll =
 				ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll,
 									    &cis_handle_curr);
-			if (next_cis_lll && next_cis_lll->active) {
+			if (next_cis_lll && next_cis_lll->established) {
 				payload_count_rx_flush_or_txrx_inc(next_cis_lll);
 			}
 		} while (next_cis_lll);
@@ -782,7 +794,7 @@ static void isr_rx(void *param)
 		do {
 			next_cis_lll =
 				ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle);
-		} while (next_cis_lll && !next_cis_lll->active);
+		} while (next_cis_lll && !next_cis_lll->established);
 
 		if (!next_cis_lll) {
 			/* ISO Event Done */
@@ -994,7 +1006,7 @@ static void next_cis_prepare(void *param)
 	cis_handle = cis_handle_curr;
 	do {
 		next_cis_lll = ull_conn_iso_lll_stream_sorted_get_by_group(cig_lll, &cis_handle);
-	} while (next_cis_lll && !next_cis_lll->active);
+	} while (next_cis_lll && !next_cis_lll->established);
 
 	if (!next_cis_lll) {
 		/* ISO Event Done */

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -836,7 +836,6 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 {
 	struct ll_conn_iso_stream *cis;
 	struct ll_conn_iso_group *cig;
-	uint16_t event_counter;
 	struct ll_conn *conn;
 	uint16_t instant;
 
@@ -852,11 +851,13 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 
 	/* ACL connection of the new CIS */
 	conn = ll_conn_get(cis->lll.acl_handle);
-	event_counter = ull_conn_event_counter(conn);
-	instant = MAX(*conn_event_count, event_counter + 1);
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	uint16_t event_counter;
 	uint32_t cis_offset;
+
+	event_counter = ull_conn_event_counter(conn);
+	instant = MAX(*conn_event_count, event_counter + 1);
 
 	cis_offset = *cis_offset_min;
 
@@ -896,6 +897,8 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 	cis->offset = cis_offset;
 
 #else /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
+
+	instant = *conn_event_count;
 
 	if (false) {
 

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -918,6 +918,8 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 	} else {
 		cis->offset = *cis_offset_min;
 	}
+
+	cis->lll.established = 0U;
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	cis->central.instant = instant;

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -1196,7 +1196,7 @@ static void mfy_cis_offset_get(void *param)
 	 * CIG interval.
 	 */
 	if (offset_min_us > cig_interval_us) {
-		cis->lll.event_count--;
+		cis->lll.event_count_prepare--;
 	}
 
 	ull_cp_cc_offset_calc_reply(conn, offset_min_us, offset_min_us);

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -922,7 +922,7 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 		cis->offset = *cis_offset_min;
 	}
 
-	cis->lll.established = 0U;
+	cis->lll.prepared = 0U;
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	cis->central.instant = instant;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -1079,6 +1079,7 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 
 	/* Initialize CIS event lazy at CIS create */
 	cis->lll.lazy_active = 0U;
+	cis->lll.established = 0U;
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	/* Start CIS peripheral CIG ticker */
@@ -1182,6 +1183,7 @@ static void mfy_cis_lazy_fill(void *param)
 	 * CIG before the CIS gets active that be decremented when event_count
 	 * is incremented in ull_conn_iso_ticker_cb().
 	 */
+	cis->lll.established = 0U;
 	cis->lll.active = 1U;
 	cis->lll.lazy_active = lazy;
 }
@@ -1371,6 +1373,11 @@ static void cis_tx_lll_flush(void *param)
 
 	lll = param;
 	lll->active = 0U;
+
+#if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	lll->established = 0U;
+#endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
+
 
 	cis = ll_conn_iso_stream_get(lll->handle);
 	cig = cis->group;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -1079,7 +1079,7 @@ void ull_conn_iso_start(struct ll_conn *conn, uint16_t cis_handle,
 
 	/* Initialize CIS event lazy at CIS create */
 	cis->lll.lazy_active = 0U;
-	cis->lll.established = 0U;
+	cis->lll.prepared = 0U;
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	/* Start CIS peripheral CIG ticker */
@@ -1183,7 +1183,7 @@ static void mfy_cis_lazy_fill(void *param)
 	 * CIG before the CIS gets active that be decremented when event_count
 	 * is incremented in ull_conn_iso_ticker_cb().
 	 */
-	cis->lll.established = 0U;
+	cis->lll.prepared = 0U;
 	cis->lll.active = 1U;
 	cis->lll.lazy_active = lazy;
 }
@@ -1375,7 +1375,7 @@ static void cis_tx_lll_flush(void *param)
 	lll->active = 0U;
 
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	lll->established = 0U;
+	lll->prepared = 0U;
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -311,6 +311,7 @@ ull_conn_iso_lll_stream_sorted_get_by_group(struct lll_conn_iso_group *cig_lll,
 					    uint16_t *handle_iter)
 {
 	struct ll_conn_iso_stream *cis_next = NULL;
+	struct ll_conn_iso_stream *cis_curr;
 	struct ll_conn_iso_group *cig;
 	uint32_t cis_offset_curr;
 	uint32_t cis_offset_next;
@@ -322,16 +323,15 @@ ull_conn_iso_lll_stream_sorted_get_by_group(struct lll_conn_iso_group *cig_lll,
 		/* First in the iteration, start with a minimum offset value and
 		 * find the first CIS offset of the active CIS.
 		 */
+		cis_curr = NULL;
 		cis_offset_curr = 0U;
 	} else {
 		/* Subsequent iteration, get reference to current CIS and use
 		 * its CIS offset to find the next active CIS with offset
 		 * greater than the current CIS.
 		 */
-		struct ll_conn_iso_stream *cis_curr;
-
 		cis_curr = ll_conn_iso_stream_get(*handle_iter);
-		cis_offset_curr = cis_curr->offset;
+		cis_offset_curr = cis_curr->lll.offset;
 	}
 
 	cis_offset_next = UINT32_MAX;
@@ -346,7 +346,7 @@ ull_conn_iso_lll_stream_sorted_get_by_group(struct lll_conn_iso_group *cig_lll,
 
 		/* Match CIS contexts associated with the CIG */
 		if (cis->group == cig) {
-			if (cis->offset <= cis_offset_curr) {
+			if (cis_curr && (cis->lll.offset <= cis_offset_curr)) {
 				/* Skip already returned CISes with offsets less
 				 * than the current CIS.
 				 */
@@ -357,9 +357,9 @@ ull_conn_iso_lll_stream_sorted_get_by_group(struct lll_conn_iso_group *cig_lll,
 			 * lower than previous that we remember as the next CIS
 			 * in ascending order.
 			 */
-			if (cis->offset < cis_offset_next) {
+			if (cis->lll.offset < cis_offset_next) {
 				cis_next = cis;
-				cis_offset_next = cis_next->offset;
+				cis_offset_next = cis_next->lll.offset;
 
 				if (handle_iter) {
 					(*handle_iter) = handle;

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -1165,7 +1165,7 @@ void ll_iso_transmit_test_send_sdu(uint16_t handle, uint32_t ticks_at_expire)
 		sdu.grp_ref_point = isoal_get_wrapped_time_us(cig->cig_ref_point,
 						(event_offset * cig->iso_interval *
 							ISO_INT_UNIT_US));
-		sdu.target_event = cis->lll.event_count + event_offset;
+		sdu.target_event = cis->lll.event_count_prepare + event_offset;
 		sdu.iso_sdu_length = remaining_tx;
 
 		/* Send all SDU fragments */
@@ -1595,7 +1595,7 @@ static void iso_rx_cig_ref_point_update(struct ll_conn_iso_group *cig,
 	cig_sync_delay = cig->sync_delay;
 	cis_sync_delay = cis->sync_delay;
 	burst_number = cis->lll.rx.bn;
-	event_count = cis->lll.event_count;
+	event_count = cis->lll.event_count_prepare;
 
 	if (role) {
 		/* Peripheral */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -901,8 +901,15 @@ void llcp_pdu_decode_cis_rsp(struct proc_ctx *ctx, struct pdu_data *pdu)
 		ctx->data.cis_create.cis_offset_max = cis_offset_max;
 	}
 
+	/* FIXME: We do not pick the instant from the response; if we do, then
+	 *        we need to calculate again a new offset because the ACL and
+	 *        ISO intervals can be dissimilar and hence will be a different
+	 *        CIS offset when sending the CIS_IND PDU at this instant.
+	 *
+
 	ctx->data.cis_create.conn_event_count =
 		sys_le16_to_cpu(pdu->llctrl.cis_rsp.conn_event_count);
+	 */
 }
 
 void llcp_pdu_encode_cis_ind(struct proc_ctx *ctx, struct pdu_data *pdu)

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -259,7 +259,7 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.active = 0U;
 
 #if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
-	cis->lll.established = 0U;
+	cis->lll.prepared = 0U;
 #endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
 
 	cis->lll.handle = LLL_HANDLE_INVALID;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -257,6 +257,11 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 				    req->p_max_sdu[0];
 
 	cis->lll.active = 0U;
+
+#if !defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
+	cis->lll.established = 0U;
+#endif /* !CONFIG_BT_CTLR_JIT_SCHEDULING */
+
 	cis->lll.handle = LLL_HANDLE_INVALID;
 	cis->lll.acl_handle = acl->lll.handle;
 	cis->lll.sub_interval = sys_get_le24(req->sub_interval);

--- a/tests/bluetooth/controller/ctrl_cis_create/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_create/src/main.c
@@ -127,7 +127,7 @@ static struct pdu_data_llctrl_cis_ind local_cis_ind = {
 	.cig_sync_delay = { 0, 0, 0},
 	.cis_offset = { 0, 0, 0},
 	.cis_sync_delay = { 0, 0, 0},
-	.conn_event_count = 13
+	.conn_event_count = 0
 };
 
 #define ERROR_CODE 0x17

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_11_i.sh
@@ -32,21 +32,13 @@ function Execute_AC_11_I() {
 
 set -e # Exit on error
 
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_11_I 8_1_1 8_1_1
+Execute_AC_11_I 8_1_1 8_1_1
 Execute_AC_11_I 8_2_1 8_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_11_I 16_1_1 16_1_1
+Execute_AC_11_I 16_1_1 16_1_1
 Execute_AC_11_I 16_2_1 16_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_11_I 24_1_1 24_1_1
+Execute_AC_11_I 24_1_1 24_1_1
 Execute_AC_11_I 24_2_1 24_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_11_I 32_1_1 32_1_1
+Execute_AC_11_I 32_1_1 32_1_1
 Execute_AC_11_I 32_2_1 32_2_1
 # ASSERTION FAIL [err == ((isoal_status_t) 0x00)] @
 # zephyr/subsys/bluetooth/controller/hci/hci_driver.c:489
@@ -56,15 +48,9 @@ Execute_AC_11_I 32_2_1 32_2_1
 # zephyr/subsys/bluetooth/controller/hci/hci_driver.c:489
 # https://github.com/zephyrproject-rtos/zephyr/issues/83586
 # Execute_AC_11_I 441_2_1 441_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_11_I 48_1_1 48_1_1
+Execute_AC_11_I 48_1_1 48_1_1
 Execute_AC_11_I 48_2_1 48_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_11_I 48_3_1 48_3_1
+Execute_AC_11_I 48_3_1 48_3_1
 Execute_AC_11_I 48_4_1 48_4_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_11_I 48_5_1 48_5_1
+Execute_AC_11_I 48_5_1 48_5_1
 Execute_AC_11_I 48_6_1 48_6_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_6_i.sh
@@ -45,15 +45,9 @@ Execute_AC_6_I 32_2_1
 # zephyr/subsys/bluetooth/controller/hci/hci_driver.c:489
 # https://github.com/zephyrproject-rtos/zephyr/issues/83586
 # Execute_AC_6_I 441_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_6_I 48_1_1
+Execute_AC_6_I 48_1_1
 Execute_AC_6_I 48_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_6_I 48_3_1
+Execute_AC_6_I 48_3_1
 Execute_AC_6_I 48_4_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_6_I 48_5_1
+Execute_AC_6_I 48_5_1
 Execute_AC_6_I 48_6_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_8_i.sh
@@ -32,21 +32,13 @@ function Execute_AC_8_I() {
 
 set -e # Exit on error
 
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_8_I 8_1_1 8_1_1
+Execute_AC_8_I 8_1_1 8_1_1
 Execute_AC_8_I 8_2_1 8_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_8_I 16_1_1 16_1_1
+Execute_AC_8_I 16_1_1 16_1_1
 Execute_AC_8_I 16_2_1 16_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_8_I 24_1_1 24_1_1
+Execute_AC_8_I 24_1_1 24_1_1
 Execute_AC_8_I 24_2_1 24_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_8_I 32_1_1 32_1_1
+Execute_AC_8_I 32_1_1 32_1_1
 Execute_AC_8_I 32_2_1 32_2_1
 # ASSERTION FAIL [err == ((isoal_status_t) 0x00)] @
 # zephyr/subsys/bluetooth/controller/hci/hci_driver.c:489
@@ -56,15 +48,9 @@ Execute_AC_8_I 32_2_1 32_2_1
 # zephyr/subsys/bluetooth/controller/hci/hci_driver.c:489
 # https://github.com/zephyrproject-rtos/zephyr/issues/83586
 # Execute_AC_8_I 441_2_1 441_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_8_I 48_1_1 48_1_1
+Execute_AC_8_I 48_1_1 48_1_1
 Execute_AC_8_I 48_2_1 48_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_8_I 48_3_1 48_3_1
+Execute_AC_8_I 48_3_1 48_3_1
 Execute_AC_8_I 48_4_1 48_4_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_8_I 48_5_1 48_5_1
+Execute_AC_8_I 48_5_1 48_5_1
 Execute_AC_8_I 48_6_1 48_6_1

--- a/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/cap_unicast_ac_9_i.sh
@@ -48,15 +48,9 @@ Execute_AC_9_I 32_2_1
 # zephyr/subsys/bluetooth/controller/hci/hci_driver.c:489
 # https://github.com/zephyrproject-rtos/zephyr/issues/83586
 # Execute_AC_9_I 441_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_9_I 48_1_1
+Execute_AC_9_I 48_1_1
 Execute_AC_9_I 48_2_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_9_I 48_3_1
+Execute_AC_9_I 48_3_1
 Execute_AC_9_I 48_4_1
-# bt_iso_chan_disconnected: 0x8570cc0, reason 0x3d
-# https://github.com/zephyrproject-rtos/zephyr/issues/83584
-# Execute_AC_9_I 48_5_1
+Execute_AC_9_I 48_5_1
 Execute_AC_9_I 48_6_1


### PR DESCRIPTION
Fix incorrect payload count at CIS Establish due to existing
CIG event overlapping the ACL event at the instant when the
CIS gets the active flag set.

The overlapping CIG event picked up the new CIS that had its
active flag set in the current CIG event instead of at the
actual CIS offset which is in the next CIG event.

Fix incorrect CIS offset in use if instant is picked from
the peer sent CIS RSP PDU. Instead, keep the instant that
was sent in the CIS REQ PDU as the instant to send in the
CIS IND PDU.

This fixes CIS failed to be established when dissimilar
ACL and ISO intervals are in use.

Fix Peripheral CIS sorted by CIG implemenation to use CIS
offset stored in LLL context which is the correct offset
from the CIG anchor point. CIS offset in the ULL context
is the offset from the ACL anchor point at the time of
the CIS establishment.

Fix CIS event_count_prepare use missed as part of fixes
related to commit https://github.com/zephyrproject-rtos/zephyr/commit/be91cfedfb54f9022dc0aa02c577b57b35f887a4 ("Bluetooth: Controller: Fix
incorrect event_count when CIG overlaps").

Fixes #83584.