### PR TITLE
boards: nucleo_h755zi_q: add CAN support

### DIFF
--- a/boards/st/nucleo_h755zi_q/doc/index.rst
+++ b/boards/st/nucleo_h755zi_q/doc/index.rst
@@ -93,6 +93,7 @@ and a ST morpho connector. Board is configured as follows:
 - LD2 : PE1
 - LD3 : PB14
 - I2C : PB8, PB9
+- CAN/CANFD : PD0, PD1
 
 System Clock
 ------------
@@ -106,6 +107,11 @@ Serial Port
 
 Nucleo H755ZI-Q board has 4 UARTs and 4 USARTs. The Zephyr console output is
 assigned to USART3. Default settings are 115200 8N1.
+
+CAN, CANFD
+----------
+
+Requires an external CAN or CANFD transceiver.
 
 Resources sharing
 -----------------

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -26,6 +26,7 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,canbus = &fdcan1;
 	};
 
 	pwmleds {
@@ -65,6 +66,24 @@
 	div-q = <8>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&pll2 {
+	div-m = <4>;
+	mul-n = <120>;
+	div-p = <2>;
+	div-q = <3>; /* gives 80MHz to the FDCAN */
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&fdcan1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000100>,
+		 <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+	pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.yaml
@@ -17,4 +17,5 @@ supported:
   - pwm
   - netif:eth
   - usb_device
+  - can
 vendor: st


### PR DESCRIPTION
This adds CAN support to the nucleo_h755zi_q board by turning on the respective features in the device tree.