### PR TITLE
boards: nucleo_h755zi_q: fix debugging

### DIFF
--- a/boards/st/nucleo_h755zi_q/support/openocd.cfg
+++ b/boards/st/nucleo_h755zi_q/support/openocd.cfg
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Borrow the nucleo_h745zi openocd configuration as no config exists for the h755 yet.
-source [find board/st_nucleo_h745zi.cfg]
+# Borrow the stm32h745i-disco openocd configuration as no config exists for the h755 yet.
+source [find board/stm32h745i-disco.cfg]
 
 # Use connect_assert_srst here to be able to program
 # even when core is in sleep mode


### PR DESCRIPTION
This fixes the problem of debugging not being possible on the nucleo_h755zi_q board. The debugger would not allow to single step and continue after break. See https://github.com/zephyrproject-rtos/zephyr/issues/87293