### PR TITLE
net: lib: coap: Use eventfd instead of socket pair

### DIFF
--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -166,7 +166,8 @@ config COAP_SERVER
 	bool "CoAP server support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	select NET_SOCKETS
-	select NET_SOCKETPAIR
+	select ZVFS
+	select ZVFS_EVENTFD
 	help
 	  This option enables the API for CoAP-services to register resources.
 


### PR DESCRIPTION
Convert the socket poll logic to use a more lightweight eventfd file descriptor instead of a socket pair.