### PR TITLE
dts: arm: nuvoton: add spi nodes for numaker m55m1x

### DIFF
--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -291,6 +291,50 @@
 			clocks = <&pcc NUMAKER_RTC0_MODULE 0 0>;
 			alarms-count = <1>;
 		};
+
+		spi0: spi@4024b000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x4024b000 0x1000>;
+			interrupts = <66 0>;
+			resets = <&rst NUMAKER_SYS_SPI0RST>;
+			clocks = <&pcc NUMAKER_SPI0_MODULE NUMAKER_CLK_SPISEL_SPI0SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi1: spi@4028b000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x4028b000 0x1000>;
+			interrupts = <67 0>;
+			resets = <&rst NUMAKER_SYS_SPI1RST>;
+			clocks = <&pcc NUMAKER_SPI1_MODULE NUMAKER_CLK_SPISEL_SPI1SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi2: spi@4024c000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x4024c000 0x1000>;
+			interrupts = <68 0>;
+			resets = <&rst NUMAKER_SYS_SPI2RST>;
+			clocks = <&pcc NUMAKER_SPI2_MODULE NUMAKER_CLK_SPISEL_SPI2SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		spi3: spi@4028c000 {
+			compatible = "nuvoton,numaker-spi";
+			reg = <0x4028c000 0x1000>;
+			interrupts = <69 0>;
+			resets = <&rst NUMAKER_SYS_SPI3RST>;
+			clocks = <&pcc NUMAKER_SPI3_MODULE NUMAKER_CLK_SPISEL_SPI3SEL_HIRC 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.conf
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.conf
@@ -1,0 +1,1 @@
+CONFIG_SPI_ASYNC=n

--- a/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/numaker_m55m1.overlay
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+/* EVB's NU5: SS/CLK/MISO/MOSI */
+	spi2_default: spi2_default {
+		group0 {
+			pinmux = <PA11MFP_SPI2_SS>,
+				 <PA10MFP_SPI2_CLK>,
+				 <PA9MFP_SPI2_MISO>,
+				 <PA8MFP_SPI2_MOSI>;
+		};
+	};
+};
+
+&spi2 {
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_K(500)>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
+	};
+	status = "okay";
+	pinctrl-0 = <&spi2_default>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
This PR is to add SPI nodes for Nuvoton NuMaker M55M1X series.
Also add support of Nuvoton numaker board numaker_m55m1 in spi_loopback test.

Test result of spi_loopback on numaker_m55m1 board as:

```
===================================================================
TESTSUITE spi_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [spi_extra_api_features]: pass = 1, fail = 0, skip = 0, total = 1 duration = 0.001 seconds
 - PASS - [spi_extra_api_features.test_spi_lock_release] duration = 0.001 seconds

SUITE PASS - 100.00% [spi_loopback]: pass = 8, fail = 0, skip = 0, total = 8 duration = 0.058 seconds
 - PASS - [spi_loopback.test_spi_complete_large_transfers] duration = 0.051 seconds
 - PASS - [spi_loopback.test_spi_complete_loop] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_complete_multiple] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_null_tx_buf] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_bigger_than_tx] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_every_4] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_end] duration = 0.001 seconds
 - PASS - [spi_loopback.test_spi_rx_half_start] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
```