### PR TITLE
LPSPI Fix Timeout waiting for transfer complete 

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, 2024 NXP
+ * Copyright 2018, 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -130,6 +130,7 @@ int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cf
 
 int spi_nxp_init_common(const struct device *dev)
 {
+	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 	const struct spi_mcux_config *config = dev->config;
 	struct spi_mcux_data *data = dev->data;
 	int err = 0;
@@ -152,6 +153,8 @@ int spi_nxp_init_common(const struct device *dev)
 	if (err) {
 		return err;
 	}
+
+	LPSPI_Reset(base);
 
 	config->irq_config_func(dev);
 

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
@@ -224,7 +224,7 @@ static int transceive_dma(const struct device *dev, const struct spi_config *spi
 
 	ret = spi_mcux_dma_next_fill(dev);
 	if (ret) {
-		return ret;
+		goto out;
 	}
 
 	LPSPI_FlushFifo(base, true, true);


### PR DESCRIPTION
In certain usecases SPI tranceive would trigger the following error and would be blocking the bus as well.
```
[00:00:00.222,000] <err> spi_mcux_lpspi: Timeout waiting for transfer complete
```
This PR fixes that by changing the ISR logic to ensure that on TX a NOP will be transmitted fixing this timeout race condition.
Also it checks now the output `spi_context_wait_for_completion` so when a timeout occurs it will release spi lock fixing a locking issue as well.

Also we reset the LPSPI peripheral now on startup to ensure the LPSPI in POR state when starting zephyr.

Tested on
 - VMU_RT1170
 - IMX95_EVK