### PR TITLE
drivers: serial/sensor: kconfig: Fix unsorted additions

### DIFF
--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -118,13 +118,15 @@ source "drivers/sensor/vishay/Kconfig"
 source "drivers/sensor/wsen/Kconfig"
 # zephyr-keep-sorted-stop
 
+# zephyr-keep-sorted-start
 source "drivers/sensor/a01nyub/Kconfig"
 source "drivers/sensor/amd_sb_tsi/Kconfig"
 source "drivers/sensor/amg88xx/Kconfig"
 source "drivers/sensor/apds9253/Kconfig"
-source "drivers/sensor/apds9960/Kconfig"
 source "drivers/sensor/apds9306/Kconfig"
+source "drivers/sensor/apds9960/Kconfig"
 source "drivers/sensor/current_amp/Kconfig"
+source "drivers/sensor/ene_tach_kb1200/Kconfig"
 source "drivers/sensor/ens160/Kconfig"
 source "drivers/sensor/explorir_m/Kconfig"
 source "drivers/sensor/f75303/Kconfig"
@@ -151,6 +153,6 @@ source "drivers/sensor/tsic_xx6/Kconfig"
 source "drivers/sensor/veaa_x_3/Kconfig"
 source "drivers/sensor/voltage_divider/Kconfig"
 source "drivers/sensor/xbr818/Kconfig"
-source "drivers/sensor/ene_tach_kb1200/Kconfig"
+# zephyr-keep-sorted-stop
 
 endif # SENSOR

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -205,6 +205,7 @@ rsource "Kconfig.pl011"
 rsource "Kconfig.psoc6"
 rsource "Kconfig.ql_usbserialport_s3b"
 rsource "Kconfig.rcar"
+rsource "Kconfig.realtek_rts5912"
 rsource "Kconfig.renesas_ra"
 rsource "Kconfig.renesas_ra8"
 rsource "Kconfig.renesas_rz"
@@ -214,6 +215,7 @@ rsource "Kconfig.rv32m1_lpuart"
 rsource "Kconfig.rzt2m"
 rsource "Kconfig.sam0"
 rsource "Kconfig.sedi"
+rsource "Kconfig.si32"
 rsource "Kconfig.sifive"
 rsource "Kconfig.silabs_eusart"
 rsource "Kconfig.silabs_usart"
@@ -224,16 +226,11 @@ rsource "Kconfig.sy1xx"
 rsource "Kconfig.test"
 rsource "Kconfig.uart_sam"
 rsource "Kconfig.usart_sam"
+rsource "Kconfig.wch_usart"
 rsource "Kconfig.xec"
 rsource "Kconfig.xen"
 rsource "Kconfig.xlnx"
 rsource "Kconfig.xmc4xxx"
 # zephyr-keep-sorted-stop
-
-source "drivers/serial/Kconfig.si32"
-
-source "drivers/serial/Kconfig.wch_usart"
-
-source "drivers/serial/Kconfig.realtek_rts5912"
 
 endif # SERIAL


### PR DESCRIPTION
    Fixes Kconfig files that have not been added in the right place
