### PR TITLE
driver: sleeptimer: siwx917: Add siwx91x Sleeptimer driver

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -113,3 +113,7 @@
 &wifi0 {
 	status = "okay";
 };
+
+&sysrtc0 {
+     status = "okay";
+ };

--- a/drivers/timer/Kconfig.silabs
+++ b/drivers/timer/Kconfig.silabs
@@ -3,7 +3,7 @@
 
 config SILABS_SLEEPTIMER_TIMER
 	bool "Silabs Sleeptimer system clock driver"
-	depends on SOC_FAMILY_SILABS_S2
+	depends on SOC_FAMILY_SILABS_S2 || SOC_FAMILY_SILABS_SIWX91X
 	depends on DT_HAS_SILABS_GECKO_STIMER_ENABLED
 	select SOC_SILABS_SLEEPTIMER
 	select TICKLESS_CAPABLE

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -121,9 +121,15 @@ static int sleeptimer_init(void)
 	sl_status_t status = SL_STATUS_OK;
 	struct sleeptimer_timer_data *timer = &g_sleeptimer_timer_data;
 
+#ifdef CONFIG_SOC_FAMILY_SILABS_SIWX91X	
+	IRQ_CONNECT(DT_IRQ(DT_RTC, irq), DT_IRQ(DT_RTC, priority),
+		    CONCAT(DT_STRING_UPPER_TOKEN_BY_IDX(DT_RTC, interrupt_names, 0), _Handler),
+		    0, 0);
+#else			
 	IRQ_CONNECT(DT_IRQ(DT_RTC, irq), DT_IRQ(DT_RTC, priority),
 		    CONCAT(DT_STRING_UPPER_TOKEN_BY_IDX(DT_RTC, interrupt_names, 0), _IRQHandler),
 		    0, 0);
+#endif
 
 	sl_sleeptimer_init();
 

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -285,6 +285,17 @@
 			clocks = <&clock0 SIWX91X_CLK_WATCHDOG>;
 			status = "disabled";
 		};
+
+		sysrtc0: sysrtc@24048c00 {
+ 			compatible = "silabs,gecko-stimer";
+ 			reg = <0x24048c00 0x78>;
+ 			interrupts = <22 0>; 
+ 			interrupt-parent = <&nvic>;
+ 			interrupt-names = "irq022";
+ 			clock-frequency = <32768>;
+ 			prescaler = <1>;
+ 			status = "disabled";
+ 		};		
 	};
 };
 

--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_compile_definitions(
   SLI_SI91X_MCU_INTERFACE
   SLI_SI917
   SLI_SI917B0
+  SLI_SI91X_ENABLE_OS
   CLOCK_ROMDRIVER_PRESENT
 )
 
@@ -150,6 +151,35 @@ if(CONFIG_WISECONNECT_NETWORK_STACK)
     ${WISECONNECT_DIR}/components/protocol/wifi/src/sl_wifi_callback_framework.c
   )
 endif() # CONFIG_WISECONNECT_NETWORK_STACK
+
+# Sleeptimer for 917 devices
+if(CONFIG_SOC_SILABS_SLEEPTIMER)
+zephyr_include_directories(
+  ${SISDK_DIR}/platform/service/sleeptimer/inc
+  ${SISDK_DIR}/platform/service/sleeptimer/src
+  ${SISDK_DIR}/platform/service/sleeptimer/config
+)
+
+zephyr_library_sources(
+  ${SISDK_DIR}/platform/service/sleeptimer/src/sl_sleeptimer.c
+  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c
+)
+zephyr_code_relocate(FILES
+  ${ZEPHYR_BASE}/arch/arm/core/cortex_m/isr_wrapper.c
+  ${SISDK_DIR}/platform/service/sleeptimer/src/sl_sleeptimer.c
+  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c
+  ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c
+  LOCATION RAM
+  FILTER ".*"
+)
+
+zephyr_compile_definitions(
+  SL_CATALOG_SLEEPTIMER_PRESENT
+  SL_CODE_COMPONENT_SLEEPTIMER=sleeptimer
+  SL_CODE_COMPONENT_HAL_SYSRTC=hal_sysrtc
+)
+  
+endif() # CONFIG_SOC_SILABS_SLEEPTIMER
 
 zephyr_linker_sources(ROM_SECTIONS linker/code_classification_text.ld)
 zephyr_linker_sources(RAMFUNC_SECTION linker/code_classification_ramfunc.ld)

--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -4,6 +4,10 @@
 
 rsource "*/Kconfig"
 
+if SOC_FAMILY_SILABS_SIWX91X
+    source "soc/silabs/Kconfig.siwx91x"
+endif
+
 if SOC_FAMILY_SILABS_S0 || SOC_FAMILY_SILABS_S1 || SOC_FAMILY_SILABS_S2
 
 config SOC_GECKO_SDID

--- a/soc/silabs/Kconfig.siwx91x
+++ b/soc/silabs/Kconfig.siwx91x
@@ -1,0 +1,7 @@
+# Kconfig entries for SOC_FAMILY_SILABS_SIWX91X
+
+config SOC_SILABS_SLEEPTIMER
+	bool
+	select CODE_DATA_RELOCATION
+	help
+	  Set if the Sleeptimer HAL module is used for SIWX91X.

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -3,6 +3,15 @@
 
 if SOC_FAMILY_SILABS_SIWX91X
 
+configdefault SILABS_SLEEPTIMER_TIMER
+ 	default y
+ 
+configdefault CORTEX_M_SYSTICK
+ 	default n if SILABS_SLEEPTIMER_TIMER
+ 
+configdefault SYS_CLOCK_TICKS_PER_SEC
+ 	default 1024 if SILABS_SLEEPTIMER_TIMER
+
 config WISECONNECT_NETWORK_STACK
 	bool
 	select CMSIS_RTOS_V2

--- a/west.yml
+++ b/west.yml
@@ -228,7 +228,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 9d32354344f6c816410e2642c2f81677f8a60e96
+      revision: pull/93/head
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This commit enables the Sleeptimer driver support for the siwx917 device.