### PR TITLE
include: zephyr: sys: time_units: Type cast CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC

### DIFF
--- a/drivers/clock_control/clock_control_smartbond.c
+++ b/drivers/clock_control/clock_control_smartbond.c
@@ -39,7 +39,7 @@ struct lpc_clock_state {
 #define CALIBRATION_INTERVAL CONFIG_SMARTBOND_LP_OSC_CALIBRATION_INTERVAL
 
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-extern int z_clock_hw_cycles_per_sec;
+extern unsigned int z_clock_hw_cycles_per_sec;
 #endif
 
 static void calibration_work_cb(struct k_work *work);

--- a/drivers/timer/gecko_burtc_timer.c
+++ b/drivers/timer/gecko_burtc_timer.c
@@ -54,7 +54,7 @@ const int32_t z_sys_timer_irq_for_test = TIMER_IRQ;
 /* With CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME, that's where we
  * should write hw_cycles timer clock frequency upon init
  */
-extern int z_clock_hw_cycles_per_sec;
+extern unsigned int z_clock_hw_cycles_per_sec;
 
 /* Number of hw_cycles clocks per 1 kernel tick */
 static uint32_t g_cyc_per_tick;

--- a/drivers/timer/hpet.c
+++ b/drivers/timer/hpet.c
@@ -415,7 +415,7 @@ void sys_clock_idle_exit(void)
 __boot_func
 static int sys_clock_driver_init(void)
 {
-	extern int z_clock_hw_cycles_per_sec;
+	extern unsigned int z_clock_hw_cycles_per_sec;
 	uint32_t hz, reg;
 
 	ARG_UNUSED(hz);

--- a/drivers/timer/silabs_sleeptimer_timer.c
+++ b/drivers/timer/silabs_sleeptimer_timer.c
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(silabs_sleeptimer_timer);
 /* With CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME, this global variable holds the clock frequency,
  * and must be written by the driver at init.
  */
-extern int z_clock_hw_cycles_per_sec;
+extern unsigned int z_clock_hw_cycles_per_sec;
 
 /* Global timer state */
 struct sleeptimer_timer_data {

--- a/include/zephyr/arch/arm64/timer.h
+++ b/include/zephyr/arch/arm64/timer.h
@@ -26,11 +26,11 @@ extern "C" {
 static ALWAYS_INLINE void arm_arch_timer_init(void)
 {
 #ifdef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-	extern int z_clock_hw_cycles_per_sec;
+	extern unsigned int z_clock_hw_cycles_per_sec;
 	uint64_t cntfrq_el0 = read_cntfrq_el0();
 
-	__ASSERT(cntfrq_el0 < INT_MAX, "cntfrq_el0 cannot fit in system 'int'");
-	z_clock_hw_cycles_per_sec = (int) cntfrq_el0;
+	__ASSERT(cntfrq_el0 < UINT_MAX, "cntfrq_el0 cannot fit in system 'unsigned int'");
+	z_clock_hw_cycles_per_sec = (unsigned int) cntfrq_el0;
 #endif
 }
 

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -79,7 +79,7 @@ static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
 #define sys_clock_hw_cycles_per_sec() sys_clock_hw_cycles_per_sec_runtime_get()
 #else
-#define sys_clock_hw_cycles_per_sec() CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
+#define sys_clock_hw_cycles_per_sec() (uint32_t)CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
 #endif
 
 /** @internal

--- a/include/zephyr/sys/time_units.h
+++ b/include/zephyr/sys/time_units.h
@@ -52,11 +52,11 @@ extern "C" {
 /* Exhaustively enumerated, highly optimized time unit conversion API */
 
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
-__syscall int sys_clock_hw_cycles_per_sec_runtime_get(void);
+__syscall unsigned int sys_clock_hw_cycles_per_sec_runtime_get(void);
 
-static inline int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
+static inline unsigned int z_impl_sys_clock_hw_cycles_per_sec_runtime_get(void)
 {
-	extern int z_clock_hw_cycles_per_sec;
+	extern unsigned int z_clock_hw_cycles_per_sec;
 
 	return z_clock_hw_cycles_per_sec;
 }

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -29,10 +29,10 @@ static struct k_spinlock timeout_lock;
 static int announce_remaining;
 
 #if defined(CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME)
-int z_clock_hw_cycles_per_sec = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
+unsigned int z_clock_hw_cycles_per_sec = CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
 
 #ifdef CONFIG_USERSPACE
-static inline int z_vrfy_sys_clock_hw_cycles_per_sec_runtime_get(void)
+static inline unsigned int z_vrfy_sys_clock_hw_cycles_per_sec_runtime_get(void)
 {
 	return z_impl_sys_clock_hw_cycles_per_sec_runtime_get();
 }

--- a/soc/neorv32/soc.c
+++ b/soc/neorv32/soc.c
@@ -8,7 +8,7 @@
 #include <soc.h>
 
 #ifdef CONFIG_SOC_NEORV32_READ_FREQUENCY_AT_RUNTIME
-extern int z_clock_hw_cycles_per_sec;
+extern unsigned int z_clock_hw_cycles_per_sec;
 
 void soc_early_init_hook(void)
 {

--- a/tests/arch/x86/info/src/timer.c
+++ b/tests/arch/x86/info/src/timer.c
@@ -44,7 +44,7 @@ void timer(void)
 	printk("TIMER: unknown");
 #endif
 
-	printk(", configured frequency = %dHz\n",
+	printk(", configured frequency = %uHz\n",
 		sys_clock_hw_cycles_per_sec());
 
 #if defined(CONFIG_COUNTER_CMOS)

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -240,7 +240,7 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 	/* If max stddev is lower than a single clock cycle then round it up. */
 	uint32_t max_stddev = MAX(k_cyc_to_us_ceil32(1), CONFIG_TIMER_TEST_MAX_STDDEV);
 
-	TC_PRINT("timer clock rate %d, kernel tick rate %d\n",
+	TC_PRINT("timer clock rate %u, kernel tick rate %d\n",
 		 sys_clock_hw_cycles_per_sec(), CONFIG_SYS_CLOCK_TICKS_PER_SEC);
 	if ((USEC_PER_SEC / CONFIG_TIMER_TEST_PERIOD) > CONFIG_SYS_CLOCK_TICKS_PER_SEC) {
 		TC_PRINT("test timer period (%u us) is smaller than "
@@ -282,8 +282,8 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		 ", \"total_drift_us\":%.6f"
 		 ", \"expected_period_cycles\":%.0f"
 		 ", \"expected_period_drift_us\":%.6f"
-		 ", \"sys_clock_hw_cycles_per_sec\":%d"
-		 ", \"CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC\":%d"
+		 ", \"sys_clock_hw_cycles_per_sec\":%u"
+		 ", \"CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC\":%u"
 		 ", \"CONFIG_SYS_CLOCK_TICKS_PER_SEC\":%d"
 		 ", \"CONFIG_TIMER_TEST_PERIOD\":%d"
 		 ", \"CONFIG_TIMER_TEST_SAMPLES\":%d"
@@ -304,7 +304,7 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		 expected_period,
 		 expected_period_drift,
 		 sys_clock_hw_cycles_per_sec(),
-		 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+		 (uint32_t)CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
 		 CONFIG_SYS_CLOCK_TICKS_PER_SEC,
 		 CONFIG_TIMER_TEST_PERIOD,
 		 CONFIG_TIMER_TEST_SAMPLES,

--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -58,7 +58,7 @@ ZTEST(timer_fn, test_timer)
 
 	TC_PRINT("k_ticks_to_cyc_floor32(1) = %d\n",
 		 k_ticks_to_cyc_floor32(1));
-	TC_PRINT("sys_clock_hw_cycles_per_sec() = %d\n",
+	TC_PRINT("sys_clock_hw_cycles_per_sec() = %u\n",
 		 sys_clock_hw_cycles_per_sec());
 
 	t_last = k_cycle_get_32();


### PR DESCRIPTION
Type case CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC to uint32_t while defining sys_clock_hw_cycles_per_sec_runtime_get() to extend the range of frequency to 0xffffffff.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>

