### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Skip erased sectors when erasing

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -216,6 +216,23 @@ config MCUMGR_GRP_IMG_SLOT_INFO_HOOKS
 	  This will enable the slot info function hooks which can be used to add additional
 	  information to responses.
 
+config MCUMGR_GRP_IMG_IMAGE_SKIP_ERASED_SECTORS
+	bool "Skip erasing sectors that are already erased"
+	default y
+	help
+	  If enabled, will skip erasing already erased sectors in the flash area when an image
+	  upload command or slot erase command is issued.
+
+config MCUMGR_GRP_IMG_IMAGE_SKIP_ERASED_SECTORS_BUFFER_SIZE
+	int "Skip erasing sectors buffer size"
+	depends on MCUMGR_GRP_IMG_IMAGE_SKIP_ERASED_SECTORS
+	range 8 32768
+	default 64
+	help
+	  The size of the on-stack buffer which is used for checking if data in flash is erased.
+	  This much data will be read from the flash at a time, a higher value will increase
+	  performance at cost of higher stack usage. This value must be a multiple of 4.
+
 module = MCUMGR_GRP_IMG
 module-str = mcumgr_grp_img
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
- * Copyright (c) 2022-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -200,6 +200,13 @@ void img_mgmt_take_lock(void);
  *		other threads to use image management operations.
  */
 void img_mgmt_release_lock(void);
+
+/**
+ * @brief	Performs an erase of the pending upload slot but skips erasing sectors that are
+ *		already erased. Requires @CONFIG_MCUMGR_GRP_IMG_IMAGE_SKIP_ERASED_SECTORS be
+ *		enabled.
+ */
+int img_mgmt_erase_pending_upload_slot(void);
 
 #define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
 int img_mgmt_erased_val(int slot, uint8_t *erased_val);

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -892,9 +892,13 @@ defined(CONFIG_MCUMGR_SMP_COMMAND_STATUS_HOOKS)
 #endif
 
 #ifndef CONFIG_IMG_ERASE_PROGRESSIVELY
-		/* erase the entire req.size all at once */
+		/* Erase the entire req.size or flash slot all at once */
 		if (action.erase) {
+#if defined(CONFIG_MCUMGR_GRP_IMG_IMAGE_SKIP_ERASED_SECTORS)
+			rc = img_mgmt_erase_pending_upload_slot();
+#else
 			rc = img_mgmt_erase_image_data(0, req.size);
+#endif
 			if (rc != 0) {
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(&action,
 					img_mgmt_err_str_flash_erase_failed);


### PR DESCRIPTION
Skips erasing sectors that are already erased in a slot erase or image upload command