### PR TITLE
Bluetooth: BAP: Fix repeated broadcast code request

### DIFF
--- a/subsys/bluetooth/audio/bap_scan_delegator.c
+++ b/subsys/bluetooth/audio/bap_scan_delegator.c
@@ -932,6 +932,7 @@ static int scan_delegator_broadcast_code(struct bt_conn *conn,
 					 struct net_buf_simple *buf)
 {
 	struct bass_recv_state_internal *internal_state;
+	struct bt_bap_scan_delegator_recv_state *state;
 	uint8_t src_id;
 	const uint8_t *broadcast_code;
 
@@ -956,6 +957,12 @@ static int scan_delegator_broadcast_code(struct bt_conn *conn,
 
 	LOG_DBG("Index %u: broadcast code added: %s", internal_state->index,
 		bt_hex(internal_state->broadcast_code, sizeof(internal_state->broadcast_code)));
+
+	state = &internal_state->state;
+
+	if (state->encrypt_state == BT_BAP_BIG_ENC_STATE_BCODE_REQ) {
+		state->encrypt_state = BT_BAP_BIG_ENC_STATE_DEC;
+	}
 
 	if (scan_delegator_cbs != NULL &&
 	    scan_delegator_cbs->broadcast_code != NULL) {


### PR DESCRIPTION
The issue occurs when, even after the Phone sends
the broadcast code, the peripheral sends a receive state notification requesting the broadcast code again.

The fix ensures that the encryption state is
immediately updated from broadcast required to
decrypting as soon as the Phone provides the
broadcast code.

Fixes: #87543 