### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -318,7 +318,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: b84bd7314a239f818e78f6927f5673247816df53
+      revision: fe4ff0e191a52de4f85ecc3475f0253eca6fc5bf
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 662ed74dce955e6c243f91c45a66768f5971e3cb


### PR DESCRIPTION
Update the HW models module to:
fe4ff0e191a52de4f85ecc3475f0253eca6fc5bf

Including the following:
fe4ff0e CLOCK: Support having or not LFCLK
22f1642 54L CLOCK: Add option to control instantiation of POWER registers