### PR TITLE
STM32N6: Add SDMMC support

### DIFF
--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -87,6 +87,12 @@ Default Zephyr Peripheral Mapping:
 - I2C4_SDA : PE14
 - LD1 : PO1
 - LD2 : PG10
+- SDMMC2_CK : PC2
+- SDMMC2_CMD : PC3
+- SDMMC2_D0 : PC4
+- SDMMC2_D1 : PC5
+- SDMMC2_D2 : PC0
+- SDMMC2_D3 : PE4
 - SPI5_SCK : PE15
 - SPI5_MOSI : PG2
 - SPI5_MISO : PH8

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -59,6 +59,15 @@
 	status = "okay";
 };
 
+&pll2 {
+	clocks = <&clk_hsi>;
+	div-m = <4>;
+	mul-n = <24>;
+	div-p1 = <2>;
+	div-p2 = <2>;
+	status = "okay";
+};
+
 &ic1 {
 	pll-src = <1>;
 	ic-div = <2>;
@@ -68,6 +77,12 @@
 &ic2 {
 	pll-src = <1>;
 	ic-div = <3>;
+	status = "okay";
+};
+
+&ic4 {
+	pll-src = <2>;
+	ic-div = <2>;
 	status = "okay";
 };
 
@@ -138,6 +153,19 @@
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
+};
+
+&sdmmc2 {
+	status = "okay";
+	clocks = <&rcc STM32_CLOCK(AHB5, 7)>,
+		 <&rcc STM32_SRC_IC4 SDMMC2_SEL(2)>;
+	pinctrl-0 = <&sdmmc2_d0_pc4 &sdmmc2_d1_pc5
+			&sdmmc2_d2_pc0 &sdmmc2_d3_pe4
+			&sdmmc2_ck_pc2 &sdmmc2_cmd_pc3>;
+	pinctrl-names = "default";
+	bus-width = <4>;
+	cd-gpios = <&gpion 8 GPIO_ACTIVE_HIGH>;
+	pwr-gpios = <&gpioq 7 GPIO_ACTIVE_HIGH>;
 };
 
 &spi5 {

--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -51,7 +51,8 @@ config SDMMC_STM32_HWFC
 		   SOC_SERIES_STM32H7X || \
 		   SOC_SERIES_STM32F7X || \
 		   SOC_SERIES_STM32L4X || \
-		   SOC_SERIES_STM32L5X
+		   SOC_SERIES_STM32L5X || \
+		   SOC_SERIES_STM32N6X
 	help
 	  Enable SDMMC Hardware Flow Control to avoid FIFO underrun (TX mode) and
 	  overrun (RX mode) errors.

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -663,6 +663,24 @@
 			};
 		};
 
+		sdmmc1: sdmmc@58027000 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x58027000 0x1000>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 8)>;
+			resets = <&rctl STM32_RESET(AHB5, 8)>;
+			interrupts = <174 0>;
+			status = "disabled";
+		};
+
+		sdmmc2: sdmmc@58026800 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x58026800 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 7)>;
+			resets = <&rctl STM32_RESET(AHB5, 7)>;
+			interrupts = <175 0>;
+			status = "disabled";
+		};
+
 		xspi1: xspi@58025000 {
 			compatible = "st,stm32-xspi";
 			reg = <0x58025000 0x1000>;


### PR DESCRIPTION
Add SDMMC support for STM32N6. Enable SDMMC on STM32N6570-DK.