### PR TITLE
 dts: renesas: smartbond: Add DA14697 dtsi

### DIFF
--- a/dts/arm/renesas/smartbond/da14697.dtsi
+++ b/dts/arm/renesas/smartbond/da14697.dtsi
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "da1469x.dtsi"
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(512)>;
+};

--- a/soc/renesas/smartbond/da1469x/Kconfig.soc
+++ b/soc/renesas/smartbond/da1469x/Kconfig.soc
@@ -13,6 +13,12 @@ config SOC_DA14695
 	help
 	  DA14695
 
+config SOC_DA14697
+	bool
+	select SOC_SERIES_DA1469X
+	help
+	  DA14697
+
 config SOC_DA14699
 	bool
 	select SOC_SERIES_DA1469X
@@ -24,4 +30,5 @@ config SOC_SERIES
 
 config SOC
 	default "da14695" if SOC_DA14695
+	default "da14697" if SOC_DA14697
 	default "da14699" if SOC_DA14699

--- a/soc/renesas/smartbond/soc.yml
+++ b/soc/renesas/smartbond/soc.yml
@@ -4,4 +4,5 @@ family:
       - name: da1469x
         socs:
           - name: da14695
+          - name: da14697
           - name: da14699


### PR DESCRIPTION
- Add new device tree source include file for DA14697 SoC
- Update Kconfig and soc.yml to support the new device

![image](https://github.com/user-attachments/assets/1d0bd638-c063-4981-ab92-aeb63b4ec5eb)
