### PR TITLE
net: buf: deprecate net_buf_slist_get, net_buf_slist_put

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -60,6 +60,9 @@ Removed APIs and options
 
 Deprecated APIs and options
 
+* Deprecated the ``net_buf_slist_put()`` and ``net_buf_slist_get()`` API functions,
+  as they are no longer needed. Use ``sys_slist_get()``/``sys_slist_append()``.
+
 * The scheduler Kconfig options CONFIG_SCHED_DUMB and CONFIG_WAITQ_DUMB were
   renamed and deprecated. Use :kconfig:option:`CONFIG_SCHED_SIMPLE` and
   :kconfig:option:`CONFIG_WAITQ_SIMPLE` instead.

--- a/doc/services/net_buf/index.rst
+++ b/doc/services/net_buf/index.rst
@@ -53,11 +53,6 @@ The buffers have native support for being passed through k_fifo kernel
 objects. Use :c:func:`k_fifo_put` and :c:func:`k_fifo_get` to pass buffer
 from one thread to another.
 
-Special functions exist for dealing with buffers in single linked lists,
-where the :c:func:`net_buf_slist_put` and :c:func:`net_buf_slist_get`
-functions must be used instead of :c:func:`sys_slist_append` and
-:c:func:`sys_slist_get`.
-
 Common Operations
 *****************
 

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -1468,19 +1468,23 @@ void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve);
 /**
  * @brief Put a buffer into a list
  *
+ * @deprecated No longer necessary, use sys_slist_append() instead.
+ *
  * @param list Which list to append the buffer to.
  * @param buf Buffer.
  */
-void net_buf_slist_put(sys_slist_t *list, struct net_buf *buf);
+__deprecated void net_buf_slist_put(sys_slist_t *list, struct net_buf *buf);
 
 /**
  * @brief Get a buffer from a list.
+ *
+ * @deprecated No longer necessary, use sys_slist_get() instead.
  *
  * @param list Which list to take the buffer from.
  *
  * @return New buffer or NULL if the FIFO is empty.
  */
-struct net_buf * __must_check net_buf_slist_get(sys_slist_t *list);
+__deprecated struct net_buf *__must_check net_buf_slist_get(sys_slist_t *list);
 
 /**
  * @brief Decrements the reference count of a buffer.

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -58,7 +58,7 @@ static struct net_buf *alloc_reassembly_buf(uint16_t conn_handle)
 		(struct reassembly_buf_meta_data *)buf->user_data;
 
 	buf_meta_data->conn_handle = conn_handle;
-	net_buf_slist_put(&reassembly_bufs, buf);
+	sys_slist_append(&reassembly_bufs, &buf->node);
 
 	LOG_DBG("Allocated new reassembly buffer for conn handle %d", conn_handle);
 	return buf;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4100,7 +4100,7 @@ void hci_event_prio(struct net_buf *buf)
 
 static void rx_queue_put(struct net_buf *buf)
 {
-	net_buf_slist_put(&bt_dev.rx_queue, buf);
+	sys_slist_append(&bt_dev.rx_queue, &buf->node);
 
 #if defined(CONFIG_BT_RECV_WORKQ_SYS)
 	const int err = k_work_submit(&rx_work);
@@ -4227,10 +4227,10 @@ static void rx_work_handler(struct k_work *work)
 	struct net_buf *buf;
 
 	LOG_DBG("Getting net_buf from queue");
-	buf = net_buf_slist_get(&bt_dev.rx_queue);
-	if (!buf) {
+	if (sys_slist_is_empty(&bt_dev.rx_queue)) {
 		return;
 	}
+	buf = CONTAINER_OF(sys_slist_get_not_empty(&bt_dev.rx_queue), struct net_buf, node);
 
 	LOG_DBG("buf %p type %u len %u", buf, bt_buf_get_type(buf), buf->len);
 

--- a/tests/bluetooth/host/cs/mocks/net_buf.c
+++ b/tests/bluetooth/host/cs/mocks/net_buf.c
@@ -13,5 +13,4 @@ const struct net_buf_data_cb net_buf_fixed_cb;
 
 DEFINE_FAKE_VOID_FUNC(net_buf_unref, struct net_buf *);
 DEFINE_FAKE_VOID_FUNC(net_buf_reset, struct net_buf *);
-DEFINE_FAKE_VOID_FUNC(net_buf_slist_put, sys_slist_t *, struct net_buf *);
 DEFINE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_alloc_fixed, struct net_buf_pool *, k_timeout_t);

--- a/tests/bluetooth/host/cs/mocks/net_buf.h
+++ b/tests/bluetooth/host/cs/mocks/net_buf.h
@@ -12,10 +12,8 @@
 #define NET_BUF_FFF_FAKES_LIST(FAKE)                                                               \
 	FAKE(net_buf_unref)                                                                        \
 	FAKE(net_buf_reset)                                                                        \
-	FAKE(net_buf_slist_put)                                                                    \
 	FAKE(net_buf_alloc_fixed)
 
 DECLARE_FAKE_VOID_FUNC(net_buf_unref, struct net_buf *);
 DECLARE_FAKE_VOID_FUNC(net_buf_reset, struct net_buf *);
-DECLARE_FAKE_VOID_FUNC(net_buf_slist_put, sys_slist_t *, struct net_buf *);
 DECLARE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_alloc_fixed, struct net_buf_pool *, k_timeout_t);


### PR DESCRIPTION
Deprecate `net_buf_slist_get()` and `net_buf_slist_put()`. 
Commit 3d306c1 back in December 2022 removed the need for these helper functions, by storing the fragments separately from nodes. 
Also removed the part of the docs stating these must be used when storing `net_buf`s in `slist`s instead of `sys_slist_get()`/`sys_slist_append()`.