### PR TITLE
tests: Bluetooth: tester: Audio: Fix wrong wrong rsp sizes

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_aics.c
+++ b/tests/bluetooth/tester/src/audio/btp_aics.c
@@ -60,7 +60,7 @@ static uint8_t aics_supported_commands(const void *cmd, uint16_t cmd_len, void *
 	/* octet 2 */
 	tester_set_bit(rp->data, BTP_AICS_DESCRIPTION_GET);
 
-	*rsp_len = sizeof(*rp) + 2;
+	*rsp_len = sizeof(*rp) + 3;
 
 	return BTP_STATUS_SUCCESS;
 }

--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -474,7 +474,7 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 
 	rp->gap_settings = gap_settings;
 	sys_put_le24(broadcast_id, rp->broadcast_id);
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp);
 
 	return BTP_STATUS_SUCCESS;
 }
@@ -589,7 +589,7 @@ uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len,
 	}
 
 	rp->gap_settings = gap_settings;
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp);
 
 	return BTP_STATUS_SUCCESS;
 }

--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -722,7 +722,7 @@ static uint8_t btp_cap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 
 	rp->gap_settings = gap_settings;
 	sys_put_le24(source->broadcast_id, rp->broadcast_id);
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp);
 
 	return BTP_STATUS_SUCCESS;
 }

--- a/tests/bluetooth/tester/src/audio/btp_ccp.c
+++ b/tests/bluetooth/tester/src/audio/btp_ccp.c
@@ -59,7 +59,7 @@ static uint8_t ccp_supported_commands(const void *cmd, uint16_t cmd_len,
 	tester_set_bit(rp->data, BTP_CCP_RETRIEVE_CALL);
 	tester_set_bit(rp->data, BTP_CCP_JOIN_CALLS);
 
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp) + 4;
 
 	return BTP_STATUS_SUCCESS;
 }

--- a/tests/bluetooth/tester/src/audio/btp_hap.c
+++ b/tests/bluetooth/tester/src/audio/btp_hap.c
@@ -23,15 +23,18 @@ static uint8_t read_supported_commands(const void *cmd, uint16_t cmd_len, void *
 {
 	struct btp_hap_read_supported_commands_rp *rp = rsp;
 
+	/* Octet 0 */
 	tester_set_bit(rp->data, BTP_HAP_READ_SUPPORTED_COMMANDS);
 	tester_set_bit(rp->data, BTP_HAP_HA_INIT);
 	tester_set_bit(rp->data, BTP_HAP_HAUC_INIT);
 	tester_set_bit(rp->data, BTP_HAP_IAC_INIT);
 	tester_set_bit(rp->data, BTP_HAP_IAC_DISCOVER);
 	tester_set_bit(rp->data, BTP_HAP_IAC_SET_ALERT);
+
+	/* Octet 1 */
 	tester_set_bit(rp->data, BTP_HAP_HAUC_DISCOVER);
 
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp) + 2;
 
 	return BTP_STATUS_SUCCESS;
 }

--- a/tests/bluetooth/tester/src/audio/btp_mcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_mcp.c
@@ -695,7 +695,7 @@ static uint8_t mcp_supported_commands(const void *cmd, uint16_t cmd_len, void *r
 	tester_set_bit(rp->data, BTP_MCP_CMD_SEND);
 	tester_set_bit(rp->data, BTP_MCP_CMD_SEARCH);
 
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp) + 4;
 
 	return BTP_STATUS_SUCCESS;
 }

--- a/tests/bluetooth/tester/src/audio/btp_vcp.c
+++ b/tests/bluetooth/tester/src/audio/btp_vcp.c
@@ -638,7 +638,7 @@ static uint8_t vcp_supported_commands(const void *cmd, uint16_t cmd_len,
 	tester_set_bit(rp->data, BTP_VCP_VOL_CTLR_UNMUTE);
 	tester_set_bit(rp->data, BTP_VCP_VOL_CTLR_MUTE);
 
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp) + 2;
 
 	return BTP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Several responses had incorrect sizes, which this commit fixes.