### PR TITLE
RA family changes to support Arduino Portenta C33

### DIFF
--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -17,6 +17,8 @@
 /delete-node/ &adc1;
 /delete-node/ &usbfs;
 /delete-node/ &usbfs_phy;
+/delete-node/ &eth;
+/delete-node/ &mdio;
 
 / {
 	soc {

--- a/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm33-common.dtsi
@@ -536,6 +536,22 @@
 			clocks = <&pclkb 0 0>;
 			status = "disabled";
 		};
+
+		eth: ethernet@40114100 {
+			compatible = "renesas,ra-ethernet";
+			reg = <0x40114100 0xfc>;
+			interrupts = <51 12>;
+			local-mac-address = [00 11 22 33 44 55];
+			phy-connection-type = "rmii";
+			status = "disabled";
+		};
+
+		mdio: mdio {
+			compatible = "renesas,ra-mdio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
 	};
 
 	usbfs_phy: usbfs-phy {

--- a/soc/renesas/ra/ra2a1/sections.ld
+++ b/soc/renesas/ra/ra2a1/sections.ld
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(id_code), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
 
 SECTION_PROLOGUE(.id_code,,)
 {
@@ -13,7 +13,7 @@ SECTION_PROLOGUE(.id_code,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_ofs), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
 
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
@@ -28,7 +28,7 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_sas), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
 
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
@@ -39,7 +39,7 @@ SECTION_PROLOGUE(.option_setting_sas,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_ns), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ns))
 
 SECTION_PROLOGUE(.option_setting_ns,,)
 {
@@ -70,7 +70,7 @@ SECTION_PROLOGUE(.option_setting_ns,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_s), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {

--- a/soc/renesas/ra/ra4e1/sections.ld
+++ b/soc/renesas/ra/ra4e1/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra4e2/sections.ld
+++ b/soc/renesas/ra/ra4e2/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -70,7 +80,13 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
+
 SECTION_PROLOGUE(.id_code,,)
 {
     KEEP(*(.id_code*))
 } GROUP_LINK_IN(ID_CODE)
+
+#endif

--- a/soc/renesas/ra/ra4m1/sections.ld
+++ b/soc/renesas/ra/ra4m1/sections.ld
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(id_code), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
 
 SECTION_PROLOGUE(.id_code,,)
 {
@@ -13,7 +13,7 @@ SECTION_PROLOGUE(.id_code,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_ofs), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
 
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
@@ -28,7 +28,7 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_sas), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
 
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
@@ -39,7 +39,7 @@ SECTION_PROLOGUE(.option_setting_sas,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_ns), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ns))
 
 SECTION_PROLOGUE(.option_setting_ns,,)
 {
@@ -70,7 +70,7 @@ SECTION_PROLOGUE(.option_setting_ns,,)
 
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(option_setting_s), okay)
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {

--- a/soc/renesas/ra/ra4m2/sections.ld
+++ b/soc/renesas/ra/ra4m2/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra4m3/sections.ld
+++ b/soc/renesas/ra/ra4m3/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra4w1/sections.ld
+++ b/soc/renesas/ra/ra4w1/sections.ld
@@ -19,7 +19,11 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
+
 SECTION_PROLOGUE(.id_code,,)
 {
     KEEP(*(.id_code*))
 } GROUP_LINK_IN(ID_CODE)
+
+#endif

--- a/soc/renesas/ra/ra6e1/sections.ld
+++ b/soc/renesas/ra/ra6e1/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra6e2/sections.ld
+++ b/soc/renesas/ra/ra6e2/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -70,7 +80,13 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
+
 SECTION_PROLOGUE(.id_code,,)
 {
     KEEP(*(.id_code*))
 } GROUP_LINK_IN(ID_CODE)
+
+#endif

--- a/soc/renesas/ra/ra6m1/sections.ld
+++ b/soc/renesas/ra/ra6m1/sections.ld
@@ -11,7 +11,11 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
+
 SECTION_PROLOGUE(.id_code,,)
 {
     KEEP(*(.id_code*))
 } GROUP_LINK_IN(ID_CODE)
+
+#endif

--- a/soc/renesas/ra/ra6m2/sections.ld
+++ b/soc/renesas/ra/ra6m2/sections.ld
@@ -11,7 +11,11 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
+
 SECTION_PROLOGUE(.id_code,,)
 {
     KEEP(*(.id_code*))
 } GROUP_LINK_IN(ID_CODE)
+
+#endif

--- a/soc/renesas/ra/ra6m3/sections.ld
+++ b/soc/renesas/ra/ra6m3/sections.ld
@@ -11,7 +11,11 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(id_code))
+
 SECTION_PROLOGUE(.id_code,,)
 {
     KEEP(*(.id_code*))
 } GROUP_LINK_IN(ID_CODE)
+
+#endif

--- a/soc/renesas/ra/ra6m4/sections.ld
+++ b/soc/renesas/ra/ra6m4/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra6m5/sections.ld
+++ b/soc/renesas/ra/ra6m5/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra6m5/soc.c
+++ b/soc/renesas/ra/ra6m5/soc.c
@@ -57,9 +57,16 @@ void soc_early_init_hook(void)
 	R_PSCU->PSARD = 0;
 	R_PSCU->PSARE = 0;
 
-	R_CPSCU->ICUSARG = 0;
-	R_CPSCU->ICUSARH = 0;
-	R_CPSCU->ICUSARI = 0;
+	/* The secure Attribute managed within the ARM CPU NVIC must match the
+	 * security attribution of IELSEn registers (Reference section 13.2.9
+	 * in the RA6M4 manual R01UH0890EJ0050).
+	 */
+	uint32_t volatile *p_icusarg = &R_CPSCU->ICUSARG;
+
+	for (int i = 0; i < BSP_ICU_VECTOR_MAX_ENTRIES / NUM_BITS(uint32_t); i++) {
+		p_icusarg[i] = 0;
+		NVIC->ITNS[i] = 0;
+	}
 
 	/* Enable protection using PRCR register. */
 	R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_SAR);

--- a/soc/renesas/ra/ra8d1/sections.ld
+++ b/soc/renesas/ra/ra8d1/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra8m1/sections.ld
+++ b/soc/renesas/ra/ra8m1/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif

--- a/soc/renesas/ra/ra8t1/sections.ld
+++ b/soc/renesas/ra/ra8t1/sections.ld
@@ -11,6 +11,8 @@ SECTION_DATA_PROLOGUE(.fsp_dtc_vector_table,(NOLOAD),)
 	*(.fsp_dtc_vector_table)
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_ofs))
+
 SECTION_PROLOGUE(.option_setting_ofs,,)
 {
 	__OPTION_SETTING_OFS_Start = .;
@@ -22,12 +24,20 @@ SECTION_PROLOGUE(.option_setting_ofs,,)
 	__OPTION_SETTING_OFS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_OFS) = 0xFF
 
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_sas))
+
 SECTION_PROLOGUE(.option_setting_sas,,)
 {
 	__OPTION_SETTING_SAS_Start = .;
 	KEEP(*(.option_setting_sas))
 	__OPTION_SETTING_SAS_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_SAS) = 0xFF
+
+#endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(option_setting_s))
 
 SECTION_PROLOGUE(.option_setting_s,,)
 {
@@ -69,3 +79,5 @@ SECTION_PROLOGUE(.option_setting_s,,)
 	KEEP(*(.option_setting_bps_sel3))
 	__OPTION_SETTING_S_End = .;
 } GROUP_LINK_IN(OPTION_SETTING_S) = 0xFF
+
+#endif


### PR DESCRIPTION
This pull request includes multiple DTS and linker script updates for Renesas RA microcontrollers, cleaned up and taken from #85337. The following changes are included:

* RA6M5: Clear all matching NVIC and ICU registers to avoid issues on interrupts
* RA*: Allow skipping `option_bits` sections in the final Zephyr ELF if they are not defined by the build
* RA6: Added support for Ethernet and MDIO nodes in DTS
