### PR TITLE
tests: net: lib: http_server: Check response

### DIFF
--- a/tests/net/lib/http_server/core/src/main.c
+++ b/tests/net/lib/http_server/core/src/main.c
@@ -1431,6 +1431,8 @@ static void test_http1_header_capture_common(const char *request)
 	zassert_not_equal(ret, -1, "send() failed (%d)", errno);
 
 	test_read_data(&offset, sizeof(http1_header_capture_common_response) - 1);
+	zassert_mem_equal(buf, http1_header_capture_common_response,
+			  sizeof(http1_header_capture_common_response) - 1);
 }
 
 ZTEST(server_function_tests, test_http1_header_capture)


### PR DESCRIPTION
Building with clang, it warns:

tests/net/lib/http_server/core/src/main.c:1400:19: error: variable
'http1_header_capture_common_response' is not needed and will not be
emitted [-Werror,-Wunneeded-internal-declaration]
static const char http1_header_capture_common_response[]
                  ^                             = "HTTP/1.1 200\r\n"

Add a check to make sure the response actually matches the expected
response.