### PR TITLE
mgmt: mcumgr: transport: Remove duplicate call to smp_reassembly_init for LoRaWAN

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_lorawan.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_lorawan.c
@@ -249,10 +249,6 @@ static void smp_lorawan_start(void)
 		LOG_ERR("Failed to init LoRaWAN MCUmgr SMP transport: %d", rc);
 	}
 
-#ifdef CONFIG_MCUMGR_TRANSPORT_LORAWAN_REASSEMBLY
-	smp_reassembly_init(&smp_lorawan_transport);
-#endif
-
 #ifdef CONFIG_MCUMGR_TRANSPORT_LORAWAN_POLL_FOR_DATA
 	k_thread_create(&smp_lorawan_thread, smp_lorawan_stack,
 			K_KERNEL_STACK_SIZEOF(smp_lorawan_stack),


### PR DESCRIPTION
The LoRaWAN SMP transport uses MCUMGR_TRANSPORT_LORAWAN_REASSEMBLY to enable reassembly. It selects MCUMGR_TRANSPORT_REASSEMBLY, which causes smp_transport_init to call smp_reassembly_init on the passed transport. This makes the subsequent call to smp_reassembly_init in the LoRaWAN transport initialization redundant.

Ref: https://github.com/zephyrproject-rtos/zephyr/blob/2587bc2aa34a499664a2fe23fd736e884c98d8bf/subsys/mgmt/mcumgr/transport/src/smp.c#L153-L155