### PR TITLE
tests: mgmt: mcumgr: Disable clang warning

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -30,7 +30,8 @@
 
 #include <zephyr/toolchain/gcc.h>
 
-#define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY "-Wsizeof-array-decay"
+#define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY            "-Wsizeof-array-decay"
+#define TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION "-Wunneeded-internal-declaration"
 
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning) _TOOLCHAIN_DISABLE_WARNING(clang, warning)
 #define TOOLCHAIN_ENABLE_CLANG_WARNING(warning)  _TOOLCHAIN_ENABLE_WARNING(clang, warning)

--- a/tests/subsys/mgmt/mcumgr/settings_mgmt/src/main.c
+++ b/tests/subsys/mgmt/mcumgr/settings_mgmt/src/main.c
@@ -66,6 +66,12 @@ static const uint8_t test_response_error_data[8] = {
 	0xbf, 0x62, 0x72, 0x63, 0x19, 0x01, 0x00, 0xff
 };
 
+/*
+ * TODO: The contents of these structs are not used, which is why clang complains.
+ * The test should be updated to use these values. See discussion in
+ * https://github.com/zephyrproject-rtos/zephyr/pull/87592.
+ */
+TOOLCHAIN_DISABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION)
 static const uint8_t test_response_read_data_start[5] = {
 	0xbf, 0x63, 0x76, 0x61, 0x6c
 };
@@ -73,6 +79,7 @@ static const uint8_t test_response_read_data_start[5] = {
 static const uint8_t test_response_read_data_end[1] = {
 	0xff
 };
+TOOLCHAIN_ENABLE_CLANG_WARNING(TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION)
 
 static void cleanup_test(void *p)
 {


### PR DESCRIPTION
When building with clang it reports:

tests/subsys/mgmt/mcumgr/settings_mgmt/src/main.c:69:22: error: variable
'test_response_read_data_start' is not needed and will not be emitted
[-Werror,-Wunneeded-internal-declaration]
static const uint8_t test_response_read_data_start[5] = {
                     ^
tests/subsys/mgmt/mcumgr/settings_mgmt/src/main.c:73:22: error: variable
'test_response_read_data_end' is not needed and will not be emitted
[-Werror,-Wunneeded-internal-declaration]
static const uint8_t test_response_read_data_end[1] = {
                     ^

The values of test_response_read_data_start and
test_response_read_data_end are not actually used anywhere in the tests.