### PR TITLE
drivers: ethernet: stm32: remove phy specific code

### DIFF
--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
@@ -108,6 +108,7 @@ zephyr_udc0: &usbotg_fs {
 	>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 	status = "okay";
 };
 
@@ -116,9 +117,8 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	status = "okay";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -223,6 +223,7 @@
 		      &eth_txd0_pg13 >;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 	status = "okay";
 };
 
@@ -231,10 +232,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/olimex/stm32_e407/olimex_stm32_e407.dts
+++ b/boards/olimex/stm32_e407/olimex_stm32_e407.dts
@@ -116,11 +116,9 @@ zephyr_udc0: &usbotg_hs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_col_pa3
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
@@ -128,4 +126,16 @@ zephyr_udc0: &usbotg_hs {
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -179,17 +179,27 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &flash0 {

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -176,17 +176,27 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &flash0 {

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.dts
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.dts
@@ -180,17 +180,27 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &flash0 {

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -197,17 +197,27 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &backup_sram {

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -141,18 +141,29 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
+};
+
 
 &flash0 {
 	partitions {

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -188,17 +188,27 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &flash0 {

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.dts
@@ -50,6 +50,7 @@
 		     &eth_txd1_pb15>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -57,9 +58,8 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -179,6 +179,7 @@
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -186,10 +187,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	phy: ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -204,6 +204,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -211,10 +212,9 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -116,6 +116,7 @@
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -123,10 +124,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -183,6 +183,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -190,10 +191,9 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -134,6 +134,7 @@
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -141,10 +142,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -188,6 +188,7 @@
 		     &eth1_rmii_txd1_pf13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -195,10 +196,9 @@
 	pinctrl-0 = <&eth1_mdio_pf4 &eth1_mdc_pg11>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x0>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -177,17 +177,27 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &quadspi {

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -164,17 +164,27 @@ zephyr_udc0: &usbotg_fs {
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &quadspi {

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -151,17 +151,27 @@ arduino_serial: &usart6 {};
 
 &mac {
 	status = "okay";
-	pinctrl-0 = <&eth_mdc_pc1
-		     &eth_rxd0_pc4
+	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
-		     &eth_mdio_pa2
 		     &eth_crs_dv_pa7
 		     &eth_tx_en_pg11
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
+	pinctrl-names = "default";
+
+	eth_phy: ethernet-phy@0 {
+		compatible = "ethernet-phy";
+		reg = <0x00>;
+	};
 };
 
 &sdmmc2 {

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -167,6 +167,7 @@
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -174,10 +175,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -139,6 +139,7 @@
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 	status = "okay";
 };
 
@@ -147,10 +148,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/stm32h745i_disco/Kconfig.defconfig
+++ b/boards/st/stm32h745i_disco/Kconfig.defconfig
@@ -11,10 +11,6 @@ if NETWORKING
 config NET_L2_ETHERNET
 	default y
 
-# STM32H745I-DISCO have PHY connected to address 1
-config ETH_STM32_HAL_PHY_ADDRESS
-	default 1
-
 endif # NETWORKING
 
 config MEMC

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -145,6 +145,7 @@
 		     &eth_rx_er_pi10>;
 	pinctrl-names = "default";
 	phy-connection-type = "mii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -152,10 +153,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@1 {
+	eth_phy: ethernet-phy@1 {
 		compatible = "ethernet-phy";
 		reg = <0x01>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -145,6 +145,7 @@
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -152,10 +153,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -161,6 +161,7 @@
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -168,10 +169,9 @@
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
 		reg = <0x00>;
-		status = "okay";
 	};
 };
 

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -239,6 +239,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
+	phy-handle = <&eth_phy>;
 };
 
 &mdio {
@@ -246,10 +247,9 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
 
-	ethernet-phy@0 {
+	eth_phy: ethernet-phy@0 {
 		compatible = "microchip,ksz8081";
 		reg = <0x00>;
-		status = "okay";
 		microchip,interface-type = "rmii-25MHz";
 	};
 };

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -120,6 +120,15 @@ Ethernet
 * Removed Kconfig option ``ETH_STM32_HAL_MII`` (:github:`86074`).
   PHY interface type is now selected via the ``phy-connection-type`` property in the device tree.
 
+* The :dtcompatible:`st,stm32-ethernet` driver now requires the ``phy-handle`` phandle to be
+  set to the according PHY node in the device tree (:github:`87593`).
+
+* The Kconfig options ``ETH_STM32_HAL_PHY_ADDRESS``, ``ETH_STM32_CARRIER_CHECK``,
+  ``ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS``, ``ETH_STM32_AUTO_NEGOTIATION_ENABLE``,
+  ``ETH_STM32_SPEED_10M``, ``ETH_STM32_MODE_HALFDUPLEX`` have been removed, as they are no longer
+  needed, and the driver now uses the ethernet phy api to communicate with the phy driver, which
+  is resposible for configuring the phy settings (:github:`87593`).
+
 * ``ethernet_native_posix`` has been renamed ``ethernet_native_tap``, and with it its
   kconfig options: :kconfig:option:`CONFIG_ETH_NATIVE_POSIX` and its related options have been
   deprecated in favor of :kconfig:option:`CONFIG_ETH_NATIVE_TAP` (:github:`86578`).

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -74,34 +74,6 @@ config ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER
 	  When this option is activated, the buffers for DMA transfer are
 	  moved from SRAM to the DTCM (Data Tightly Coupled Memory).
 
-config ETH_STM32_HAL_PHY_ADDRESS
-	int "Phy address"
-	default 0
-	help
-	  The phy address to use.
-
-config ETH_STM32_CARRIER_CHECK
-	bool "Check PHY carrier periodically"
-	default y
-	help
-	  Enables or disables checking of the PHY's carrier status.
-	  See also CONFIG_ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
-
-config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
-	int "Carrier check timeout period (ms)"
-	depends on ETH_STM32_CARRIER_CHECK
-	default 500
-	range 100 30000
-	help
-	  Set the RX idle timeout period in milliseconds after which the
-	  PHY's carrier status is re-evaluated.
-
-config ETH_STM32_AUTO_NEGOTIATION_ENABLE
-	bool "Autonegotiation mode"
-	default y
-	help
-	  Enable this if using autonegotiation
-
 config ETH_STM32_HW_CHECKSUM
 	bool "Use TX and RX hardware checksum"
 	depends on !SOC_SERIES_STM32H5X
@@ -109,22 +81,6 @@ config ETH_STM32_HW_CHECKSUM
 	  Enable receive and transmit checksum offload to enhance throughput
 	  performances.
 	  See reference manual for more information on this feature.
-
-if !ETH_STM32_AUTO_NEGOTIATION_ENABLE
-
-config ETH_STM32_SPEED_10M
-	bool "Set speed to 10 Mbps when autonegotiation is disabled"
-	help
-	  Set this if using 10 Mbps and when autonegotiation is disabled, otherwise speed
-	  is 100 Mbps
-
-config ETH_STM32_MODE_HALFDUPLEX
-	bool "Half duplex mode"
-	help
-	  Set this if using half duplex when autonegotiation is disabled otherwise
-	  duplex mode is full duplex
-
-endif # !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
 if SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
 

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -33,8 +33,8 @@ static const struct pinctrl_dev_config *eth0_pcfg =
 	PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
 static const struct stm32_pclken pclken = {
-	.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, stmmaceth, bus),
-	.enr = DT_INST_CLOCKS_CELL_BY_NAME(0, stmmaceth, bits),
+	.bus = DT_CLOCKS_CELL_BY_NAME(DT_INST_PARENT(0), stm_eth, bus),
+	.enr = DT_CLOCKS_CELL_BY_NAME(DT_INST_PARENT(0), stm_eth, bits),
 };
 static const struct stm32_pclken pclken_tx = {
 	.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_tx, bus),
@@ -81,7 +81,7 @@ int dwmac_bus_init(struct dwmac_priv *p)
 	reg_val = sys_read32(reg_addr);
 	sys_write32(reg_val | 0x03800000, reg_addr);
 
-	p->base_addr = DT_INST_REG_ADDR(0);
+	p->base_addr = DT_REG_ADDR(DT_INST_PARENT(0));
 	return 0;
 }
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1585,7 +1585,7 @@ BUILD_ASSERT(DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, mii) ||
 
 static struct eth_stm32_hal_dev_data eth0_data = {
 	.heth = {
-		.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(0),
+		.Instance = (ETH_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(0)),
 		.Init = {
 #if !defined(CONFIG_ETH_STM32_HAL_API_V2)
 #if defined(CONFIG_ETH_STM32_AUTO_NEGOTIATION_ENABLE)

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1566,8 +1566,8 @@ PINCTRL_DT_INST_DEFINE(0);
 
 static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.config_func = eth0_irq_config,
-	.pclken = {.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, stmmaceth, bus),
-		   .enr = DT_INST_CLOCKS_CELL_BY_NAME(0, stmmaceth, bits)},
+	.pclken = {.bus = DT_CLOCKS_CELL_BY_NAME(DT_INST_PARENT(0), stm_eth, bus),
+		   .enr = DT_CLOCKS_CELL_BY_NAME(DT_INST_PARENT(0), stm_eth, bits)},
 	.pclken_tx = {.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_tx, bus),
 		      .enr = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_tx, bits)},
 	.pclken_rx = {.bus = DT_INST_CLOCKS_CELL_BY_NAME(0, mac_clk_rx, bus),

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -56,7 +56,6 @@ struct eth_stm32_hal_dev_data {
 	K_KERNEL_STACK_MEMBER(rx_thread_stack,
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);
 	struct k_thread rx_thread;
-	bool link_up;
 #if defined(CONFIG_ETH_STM32_MULTICAST_FILTER)
 	uint8_t hash_index_cnt[64];
 #endif /* CONFIG_ETH_STM32_MULTICAST_FILTER */

--- a/drivers/mdio/Kconfig.stm32_hal
+++ b/drivers/mdio/Kconfig.stm32_hal
@@ -5,8 +5,8 @@
 config MDIO_ST_STM32_HAL
 	bool "STM32 MDIO controller driver"
 	default y
-	depends on ETH_STM32_HAL_API_V2
 	depends on DT_HAS_ST_STM32_MDIO_ENABLED
+	depends on ETH_STM32_HAL
 	select PINCTRL
 	help
 	  Enable STM32 MDIO support.

--- a/drivers/mdio/mdio_stm32_hal.c
+++ b/drivers/mdio/mdio_stm32_hal.c
@@ -9,6 +9,8 @@
 #include <errno.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/mdio.h>
 #include <zephyr/net/ethernet.h>
@@ -28,6 +30,7 @@ struct mdio_stm32_data {
 
 struct mdio_stm32_config {
 	const struct pinctrl_dev_config *pincfg;
+	struct stm32_pclken pclken;
 };
 
 static int mdio_stm32_read(const struct device *dev, uint8_t prtad,
@@ -91,6 +94,14 @@ static int mdio_stm32_init(const struct device *dev)
 	const struct mdio_stm32_config *const config = dev->config;
 	int ret;
 
+	/* enable clock */
+	ret = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			       (clock_control_subsys_t)&config->pclken);
+	if (ret < 0) {
+		LOG_ERR("Failed to enable ethernet clock needed for MDIO (%d)", ret);
+		return ret;
+	}
+
 	ret = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		return ret;
@@ -106,18 +117,19 @@ static DEVICE_API(mdio, mdio_stm32_api) = {
 	.write = mdio_stm32_write,
 };
 
-#define MDIO_STM32_HAL_DEVICE(inst)								\
-	PINCTRL_DT_INST_DEFINE(inst);								\
-												\
-	static struct mdio_stm32_data mdio_stm32_data_##inst = {				\
-		.heth = {.Instance = (ETH_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(inst))},		\
-	};											\
-	static struct mdio_stm32_config mdio_stm32_config_##inst = {				\
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),					\
-	};											\
-	DEVICE_DT_INST_DEFINE(inst, &mdio_stm32_init, NULL,					\
-				&mdio_stm32_data_##inst, &mdio_stm32_config_##inst,		\
-				POST_KERNEL, CONFIG_ETH_INIT_PRIORITY,				\
-				&mdio_stm32_api);
+#define MDIO_STM32_HAL_DEVICE(inst)                                                                \
+	PINCTRL_DT_INST_DEFINE(inst);                                                              \
+                                                                                                   \
+	static struct mdio_stm32_data mdio_stm32_data_##inst = {                                   \
+		.heth = {.Instance = (ETH_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(inst))},            \
+	};                                                                                         \
+	static struct mdio_stm32_config mdio_stm32_config_##inst = {                               \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                    \
+		.pclken = {.bus = DT_CLOCKS_CELL_BY_NAME(DT_INST_PARENT(inst), stm_eth, bus),      \
+			   .enr = DT_CLOCKS_CELL_BY_NAME(DT_INST_PARENT(inst), stm_eth, bits)},    \
+	};                                                                                         \
+	DEVICE_DT_INST_DEFINE(inst, &mdio_stm32_init, NULL, &mdio_stm32_data_##inst,               \
+			      &mdio_stm32_config_##inst, POST_KERNEL, CONFIG_MDIO_INIT_PRIORITY,   \
+			      &mdio_stm32_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MDIO_STM32_HAL_DEVICE)

--- a/drivers/mdio/mdio_stm32_hal.c
+++ b/drivers/mdio/mdio_stm32_hal.c
@@ -85,16 +85,6 @@ static int mdio_stm32_write(const struct device *dev, uint8_t prtad,
 	return ret;
 }
 
-static void mdio_stm32_bus_enable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-
-static void mdio_stm32_bus_disable(const struct device *dev)
-{
-	ARG_UNUSED(dev);
-}
-
 static int mdio_stm32_init(const struct device *dev)
 {
 	struct mdio_stm32_data *const dev_data = dev->data;
@@ -114,8 +104,6 @@ static int mdio_stm32_init(const struct device *dev)
 static DEVICE_API(mdio, mdio_stm32_api) = {
 	.read = mdio_stm32_read,
 	.write = mdio_stm32_write,
-	.bus_enable = mdio_stm32_bus_enable,
-	.bus_disable = mdio_stm32_bus_disable,
 };
 
 #define MDIO_STM32_HAL_DEVICE(inst)								\

--- a/drivers/mdio/mdio_stm32_hal.c
+++ b/drivers/mdio/mdio_stm32_hal.c
@@ -107,6 +107,10 @@ static int mdio_stm32_init(const struct device *dev)
 		return ret;
 	}
 
+#ifdef CONFIG_ETH_STM32_HAL_API_V2
+	HAL_ETH_SetMDIOClockRange(&dev_data->heth);
+#endif
+
 	k_sem_init(&dev_data->sem, 1, 1);
 
 	return 0;

--- a/drivers/mdio/mdio_stm32_hal.c
+++ b/drivers/mdio/mdio_stm32_hal.c
@@ -40,7 +40,13 @@ static int mdio_stm32_read(const struct device *dev, uint8_t prtad,
 
 	k_sem_take(&dev_data->sem, K_FOREVER);
 
+#ifdef CONFIG_ETH_STM32_HAL_API_V2
 	ret = HAL_ETH_ReadPHYRegister(heth, prtad, regad, &read);
+#else
+	heth->Init.PhyAddress = prtad;
+
+	ret = HAL_ETH_ReadPHYRegister(heth, regad, &read);
+#endif
 
 	k_sem_give(&dev_data->sem);
 
@@ -62,7 +68,13 @@ static int mdio_stm32_write(const struct device *dev, uint8_t prtad,
 
 	k_sem_take(&dev_data->sem, K_FOREVER);
 
+#ifdef CONFIG_ETH_STM32_HAL_API_V2
 	ret = HAL_ETH_WritePHYRegister(heth, prtad, regad, data);
+#else
+	heth->Init.PhyAddress = prtad;
+
+	ret = HAL_ETH_WritePHYRegister(heth, regad, data);
+#endif
 
 	k_sem_give(&dev_data->sem);
 

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -29,6 +29,13 @@
 				 <&rcc STM32_CLOCK(AHB1, 15U)>,
 				 <&rcc STM32_CLOCK(AHB1, 16U)>;
 			status = "disabled";
+
+			mdio: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -19,16 +19,18 @@
 			status = "disabled";
 		};
 
-		mac: ethernet@40028000 {
-			compatible = "st,stm32-ethernet";
+		ethernet@40028000 {
 			reg = <0x40028000 0x2000>;
-			interrupts = <61 0>;
-			clock-names = "stmmaceth", "mac-clk-tx",
-				      "mac-clk-rx";
-			clocks = <&rcc STM32_CLOCK(AHB1, 14U)>,
-				 <&rcc STM32_CLOCK(AHB1, 15U)>,
-				 <&rcc STM32_CLOCK(AHB1, 16U)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32-ethernet";
+				interrupts = <61 0>;
+				clock-names = "stmmaceth", "mac-clk-tx",
+					      "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 14)>,
+					 <&rcc STM32_CLOCK(AHB1, 15)>,
+					 <&rcc STM32_CLOCK(AHB1, 16)>;
+				status = "disabled";
+			};
 
 			mdio: mdio {
 				compatible = "st,stm32-mdio";

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -21,13 +21,14 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x2000>;
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 14)>;
+
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "stmmaceth", "mac-clk-tx",
-					      "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 14)>,
-					 <&rcc STM32_CLOCK(AHB1, 15)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
 					 <&rcc STM32_CLOCK(AHB1, 16)>;
 				status = "disabled";
 			};

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -12,13 +12,16 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "stmmaceth", "mac-clk-tx",
-					      "mac-clk-rx", "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
-					 <&rcc STM32_CLOCK(AHB1, 26)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx",
+					      "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
 					 <&rcc STM32_CLOCK(AHB1, 27)>,
 					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -10,17 +10,19 @@
 	soc {
 		compatible = "st,stm32f207", "st,stm32f2", "simple-bus";
 
-		mac: ethernet@40028000 {
-			compatible = "st,stm32-ethernet";
+		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
-			interrupts = <61 0>;
-			clock-names = "stmmaceth", "mac-clk-tx",
-				      "mac-clk-rx", "mac-clk-ptp";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25U)>,
-				 <&rcc STM32_CLOCK(AHB1, 26U)>,
-				 <&rcc STM32_CLOCK(AHB1, 27U)>,
-				 <&rcc STM32_CLOCK(AHB1, 28U)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32-ethernet";
+				interrupts = <61 0>;
+				clock-names = "stmmaceth", "mac-clk-tx",
+					      "mac-clk-rx", "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+					 <&rcc STM32_CLOCK(AHB1, 26)>,
+					 <&rcc STM32_CLOCK(AHB1, 27)>,
+					 <&rcc STM32_CLOCK(AHB1, 28)>;
+				status = "disabled";
+			};
 
 			mdio: mdio {
 				compatible = "st,stm32-mdio";

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -21,6 +21,13 @@
 				 <&rcc STM32_CLOCK(AHB1, 27U)>,
 				 <&rcc STM32_CLOCK(AHB1, 28U)>;
 			status = "disabled";
+
+			mdio: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -10,17 +10,19 @@
 	soc {
 		compatible = "st,stm32f407", "st,stm32f4", "simple-bus";
 
-		mac: ethernet@40028000 {
-			compatible = "st,stm32-ethernet";
+		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
-			interrupts = <61 0>;
-			clock-names = "stmmaceth", "mac-clk-tx",
-				      "mac-clk-rx", "mac-clk-ptp";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25U)>,
-				 <&rcc STM32_CLOCK(AHB1, 26U)>,
-				 <&rcc STM32_CLOCK(AHB1, 27U)>,
-				 <&rcc STM32_CLOCK(AHB1, 28U)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32-ethernet";
+				interrupts = <61 0>;
+				clock-names = "stmmaceth", "mac-clk-tx",
+					      "mac-clk-rx", "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+					 <&rcc STM32_CLOCK(AHB1, 26)>,
+					 <&rcc STM32_CLOCK(AHB1, 27)>,
+					 <&rcc STM32_CLOCK(AHB1, 28)>;
+				status = "disabled";
+			};
 
 			mdio: mdio {
 				compatible = "st,stm32-mdio";

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -12,13 +12,16 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "stmmaceth", "mac-clk-tx",
-					      "mac-clk-rx", "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
-					 <&rcc STM32_CLOCK(AHB1, 26)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx",
+					      "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
 					 <&rcc STM32_CLOCK(AHB1, 27)>,
 					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";

--- a/dts/arm/st/f4/stm32f407.dtsi
+++ b/dts/arm/st/f4/stm32f407.dtsi
@@ -21,6 +21,13 @@
 				 <&rcc STM32_CLOCK(AHB1, 27U)>,
 				 <&rcc STM32_CLOCK(AHB1, 28U)>;
 			status = "disabled";
+
+			mdio: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -86,6 +86,13 @@
 				 <&rcc STM32_CLOCK(AHB1, 27U)>,
 				 <&rcc STM32_CLOCK(AHB1, 28U)>;
 			status = "disabled";
+
+			mdio: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 	};
 

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -75,17 +75,19 @@
 			status = "disabled";
 		};
 
-		mac: ethernet@40028000 {
-			compatible = "st,stm32-ethernet";
+		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
-			interrupts = <61 0>;
-			clock-names = "stmmaceth", "mac-clk-tx",
-				      "mac-clk-rx", "mac-clk-ptp";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25U)>,
-				 <&rcc STM32_CLOCK(AHB1, 26U)>,
-				 <&rcc STM32_CLOCK(AHB1, 27U)>,
-				 <&rcc STM32_CLOCK(AHB1, 28U)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32-ethernet";
+				interrupts = <61 0>;
+				clock-names = "stmmaceth", "mac-clk-tx",
+					      "mac-clk-rx", "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+					 <&rcc STM32_CLOCK(AHB1, 26)>,
+					 <&rcc STM32_CLOCK(AHB1, 27)>,
+					 <&rcc STM32_CLOCK(AHB1, 28)>;
+				status = "disabled";
+			};
 
 			mdio: mdio {
 				compatible = "st,stm32-mdio";

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -77,13 +77,16 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "stmmaceth", "mac-clk-tx",
-					      "mac-clk-rx", "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
-					 <&rcc STM32_CLOCK(AHB1, 26)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx",
+					      "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
 					 <&rcc STM32_CLOCK(AHB1, 27)>,
 					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -70,13 +70,16 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>;
+
 			mac: ethernet {
 				compatible = "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "stmmaceth", "mac-clk-tx",
-					      "mac-clk-rx", "mac-clk-ptp";
-				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
-					 <&rcc STM32_CLOCK(AHB1, 26)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx",
+					      "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 26)>,
 					 <&rcc STM32_CLOCK(AHB1, 27)>,
 					 <&rcc STM32_CLOCK(AHB1, 28)>;
 				status = "disabled";

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -68,17 +68,26 @@
 			status = "disabled";
 		};
 
-		mac: ethernet@40028000 {
-			compatible = "st,stm32-ethernet";
+		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
-			interrupts = <61 0>;
-			clock-names = "stmmaceth", "mac-clk-tx",
-				      "mac-clk-rx", "mac-clk-ptp";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25U)>,
-				 <&rcc STM32_CLOCK(AHB1, 26U)>,
-				 <&rcc STM32_CLOCK(AHB1, 27U)>,
-				 <&rcc STM32_CLOCK(AHB1, 28U)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32-ethernet";
+				interrupts = <61 0>;
+				clock-names = "stmmaceth", "mac-clk-tx",
+					      "mac-clk-rx", "mac-clk-ptp";
+				clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
+					 <&rcc STM32_CLOCK(AHB1, 26)>,
+					 <&rcc STM32_CLOCK(AHB1, 27)>,
+					 <&rcc STM32_CLOCK(AHB1, 28)>;
+				status = "disabled";
+			};
+
+			mdio: mdio {
+				compatible = "st,stm32-mdio";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
 		};
 
 		sdmmc2: sdmmc@40011c00 {

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -538,15 +538,17 @@
 			status = "disabled";
 		};
 
-		mac: ethernet@40028000 {
-			compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
+		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
-			interrupts = <106 0>;
-			clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
-			clocks = <&rcc STM32_CLOCK(AHB1, 19U)>,
-				 <&rcc STM32_CLOCK(AHB1, 20U)>,
-				 <&rcc STM32_CLOCK(AHB1, 21U)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
+				interrupts = <106 0>;
+				clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 19)>,
+					 <&rcc STM32_CLOCK(AHB1, 20)>,
+					 <&rcc STM32_CLOCK(AHB1, 21)>;
+				status = "disabled";
+			};
 
 			mdio: mdio {
 				compatible = "st,stm32-mdio";

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -540,12 +540,15 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 19)>;
+
 			mac: ethernet {
 				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
 				interrupts = <106 0>;
-				clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 19)>,
-					 <&rcc STM32_CLOCK(AHB1, 20)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 20)>,
 					 <&rcc STM32_CLOCK(AHB1, 21)>;
 				status = "disabled";
 			};

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1025,15 +1025,17 @@
 			status = "disabled";
 		};
 
-		mac: ethernet@40028000 {
-			compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
+		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
-			interrupts = <61 0>;
-			clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
-			clocks = <&rcc STM32_CLOCK(AHB1, 15U)>,
-				 <&rcc STM32_CLOCK(AHB1, 16U)>,
-				 <&rcc STM32_CLOCK(AHB1, 17U)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
+				interrupts = <61 0>;
+				clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
+					 <&rcc STM32_CLOCK(AHB1, 16)>,
+					 <&rcc STM32_CLOCK(AHB1, 17)>;
+				status = "disabled";
+			};
 
 			mdio: mdio {
 				compatible = "st,stm32-mdio";

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1027,12 +1027,15 @@
 
 		ethernet@40028000 {
 			reg = <0x40028000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB1, 15)>;
+
 			mac: ethernet {
 				compatible = "st,stm32h7-ethernet", "st,stm32-ethernet";
 				interrupts = <61 0>;
-				clock-names = "stmmaceth", "mac-clk-tx", "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB1, 15)>,
-					 <&rcc STM32_CLOCK(AHB1, 16)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB1, 16)>,
 					 <&rcc STM32_CLOCK(AHB1, 17)>;
 				status = "disabled";
 			};

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -645,14 +645,16 @@
 
 		ethernet@58036000 {
 			reg = <0x58036000 0x8000>;
+			compatible = "st,stm32-ethernet-controller";
+			clock-names = "stm-eth";
+			clocks = <&rcc STM32_CLOCK(AHB5, 22)>;
+
 			mac: ethernet {
 				compatible = "st,stm32n6-ethernet", "st,stm32h7-ethernet",
 					"st,stm32-ethernet";
 				interrupts = <179 0>;
-				clock-names = "stmmaceth", "mac-clk-tx",
-					      "mac-clk-rx";
-				clocks = <&rcc STM32_CLOCK(AHB5, 22)>,
-					 <&rcc STM32_CLOCK(AHB5, 23)>,
+				clock-names = "mac-clk-tx", "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB5, 23)>,
 					 <&rcc STM32_CLOCK(AHB5, 24)>;
 				status = "disabled";
 			};

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -643,17 +643,19 @@
 			status = "disabled";
 		};
 
-		mac: ethernet@58036000 {
-			compatible = "st,stm32n6-ethernet", "st,stm32h7-ethernet",
-				"st,stm32-ethernet";
+		ethernet@58036000 {
 			reg = <0x58036000 0x8000>;
-			interrupts = <179 0>;
-			clock-names = "stmmaceth", "mac-clk-tx",
-				"mac-clk-rx";
-			clocks = <&rcc STM32_CLOCK(AHB5, 22)>,
-				 <&rcc STM32_CLOCK(AHB5, 23)>,
-				 <&rcc STM32_CLOCK(AHB5, 24)>;
-			status = "disabled";
+			mac: ethernet {
+				compatible = "st,stm32n6-ethernet", "st,stm32h7-ethernet",
+					"st,stm32-ethernet";
+				interrupts = <179 0>;
+				clock-names = "stmmaceth", "mac-clk-tx",
+					      "mac-clk-rx";
+				clocks = <&rcc STM32_CLOCK(AHB5, 22)>,
+					 <&rcc STM32_CLOCK(AHB5, 23)>,
+					 <&rcc STM32_CLOCK(AHB5, 24)>;
+				status = "disabled";
+			};
 
 			mdio: mdio {
 				compatible = "st,stm32-mdio";

--- a/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
@@ -6,8 +6,6 @@
 include: [ethernet-controller.yaml, pinctrl-device.yaml]
 
 properties:
-  reg:
-    required: true
   interrupts:
     required: true
   clocks:

--- a/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
@@ -18,3 +18,5 @@ properties:
     required: true
   phy-connection-type:
     required: true
+  phy-handle:
+    required: true

--- a/dts/bindings/ethernet/st,stm32-ethernet-controller.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet-controller.yaml
@@ -1,0 +1,18 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  ST STM32 Ethernet controller, contains the Ethernet MAC
+  and the MDIO as a child nodes.
+
+compatible: "st,stm32-ethernet-controller"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+  clocks:
+    required: true
+  clock-names:
+    required: true

--- a/dts/bindings/ethernet/st,stm32-ethernet.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet.yaml
@@ -2,7 +2,8 @@
 # Copyright (c) 2024, STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST STM32 Ethernet
+description: |
+  ST STM32 Ethernet MAC, a child node of the Ethernet controller.
 
 compatible: "st,stm32-ethernet"
 

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -63,10 +63,6 @@ config CLOCK_CONTROL_INIT_PRIORITY
 	default 1
 	depends on CLOCK_CONTROL
 
-config PHY_INIT_PRIORITY
-	default 81
-	depends on NET_L2_ETHERNET && ETH_DRIVER
-
 # Get flash configuration for NS image from dts flash partition
 config USE_DT_CODE_PARTITION
 	default y if TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
- enable mdio also on legacy devices
- remove phy specific code from stm32 ethernet driver
- setting the phy-handle of the ethernac mac is now mandatory
- phys, that don't use mdio or the standard registers can now be used.