### PR TITLE
RW612: Add power init code for PM3 support

### DIFF
--- a/boards/nxp/frdm_rw612/CMakeLists.txt
+++ b/boards/nxp/frdm_rw612/CMakeLists.txt
@@ -1,15 +1,23 @@
 #
-# Copyright 2022-2023 NXP
+# Copyright 2022-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
+zephyr_library()
+zephyr_library_sources(init.c)
+
 if(CONFIG_NXP_RW6XX_BOOT_HEADER)
   zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
-  zephyr_library()
   # This FCB is specific to the flash on this board, it won't work
   # for boards with different flash chips. If you flash this FCB
   # onto a board with a different flash chip you may break it.
   # See MCUXpresso config tools for making a correct one.
   zephyr_library_sources(W25Q512JVFIQ_FCB.c)
+endif()
+
+if (CONFIG_DT_HAS_NXP_ENET_MAC_ENABLED AND CONFIG_XTAL32K)
+	message(FATAL_ERROR "Ethernet and external 32K clock source are "
+		"mutually exclusive on FRDM_RW612 due to shared PCB nets "
+		"between the ethernet PHY and the external oscillator")
 endif()

--- a/boards/nxp/frdm_rw612/Kconfig
+++ b/boards/nxp/frdm_rw612/Kconfig
@@ -1,0 +1,5 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_FRDM_RW612
+	select BOARD_EARLY_INIT_HOOK

--- a/boards/nxp/frdm_rw612/Kconfig.defconfig
+++ b/boards/nxp/frdm_rw612/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # FRDM_RW612 board
 
-# Copyright 2024 NXP
+# Copyright 2024-25 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_FRDM_RW612
@@ -24,5 +24,12 @@ config LV_Z_FLUSH_THREAD
 	default y
 
 endif # LVGL
+
+if COUNTER_MCUX_LPC_RTC_1HZ
+
+config XTAL32K
+	default y
+
+endif # COUNTER_MCUX_LPC_RTC_1HZ
 
 endif # BOARD_FRDM_RW612

--- a/boards/nxp/frdm_rw612/doc/index.rst
+++ b/boards/nxp/frdm_rw612/doc/index.rst
@@ -25,6 +25,10 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+.. note::
+
+   Power modes 1, 2 and 3 are supported when using System Power Management.
+
 Programming and Debugging
 *************************
 
@@ -134,8 +138,22 @@ frdm_rw612 platform supports the monolithic feature. The required binary blob
 ``<zephyr workspace>/modules/hal/nxp/zephyr/blobs/rw61x_sb_wifi_a2.bin`` will be linked
 with the application image directly, forming one single monolithic image.
 
+RTC Sub-Second Counter
+======================
+
+To use the RTC sub-second counter which is clocked at a 32kHZ rate, make the
+following modifications to the board hardware:
+
+1. Move the short on SJ21 from 1 and 2 to short 2 and 3.
+2. Move the short on SJ22 from 1 and 2 to short 2 and 3.
+
+After this change, the ENET will stop functioning on the board.
+
 .. include:: ../../common/board-footer.rst
    :start-after: nxp-board-footer
+
+Resources
+*********
 
 .. _RW612 Website:
    https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/wireless-mcu-with-integrated-tri-radiobr1x1-wi-fi-6-plus-bluetooth-low-energy-5-3-802-15-4:RW612

--- a/boards/nxp/frdm_rw612/init.c
+++ b/boards/nxp/frdm_rw612/init.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022, 2024-25 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/pm/pm.h>
+#include <fsl_power.h>
+
+static void frdm_rw612_power_init_config(void)
+{
+	power_init_config_t initCfg = {
+		/* VCORE AVDD18 supplied from iBuck on FRDM board. */
+		.iBuck = true,
+		/* CAU_SOC_SLP_REF_CLK is needed for LPOSC. */
+		.gateCauRefClk = false,
+	};
+
+	POWER_InitPowerConfig(&initCfg);
+}
+
+#if CONFIG_PM
+static void frdm_rw612_pm_state_exit(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_STANDBY:
+		frdm_rw612_power_init_config();
+		break;
+	default:
+		break;
+	}
+}
+#endif
+
+void board_early_init_hook(void)
+{
+	frdm_rw612_power_init_config();
+
+#if CONFIG_PM
+	static struct pm_notifier frdm_rw612_pm_notifier = {
+		.state_exit = frdm_rw612_pm_state_exit,
+	};
+
+	pm_notifier_register(&frdm_rw612_pm_notifier);
+#endif
+}

--- a/boards/nxp/rd_rw612_bga/CMakeLists.txt
+++ b/boards/nxp/rd_rw612_bga/CMakeLists.txt
@@ -1,8 +1,11 @@
 #
-# Copyright 2022-2023 NXP
+# Copyright 2022-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+zephyr_library()
+zephyr_library_sources(init.c)
 
 if(CONFIG_NXP_RW6XX_BOOT_HEADER)
   if(NOT DEFINED CONFIG_BOARD_RD_RW612_BGA)
@@ -12,6 +15,11 @@ if(CONFIG_NXP_RW6XX_BOOT_HEADER)
   endif()
   zephyr_compile_definitions(BOOT_HEADER_ENABLE=1)
   zephyr_compile_definitions(BOARD_FLASH_SIZE=CONFIG_FLASH_SIZE*1024)
-  zephyr_library()
   zephyr_library_sources(MX25U51245GZ4I00_FCB.c)
+endif()
+
+if (CONFIG_DT_HAS_NXP_ENET_MAC_ENABLED AND CONFIG_XTAL32K)
+	message(FATAL_ERROR "Ethernet and external 32K clock source are "
+		"mutually exclusive on RD_RW612_BGA due to shared PCB nets "
+		"between the ethernet PHY and the external oscillator")
 endif()

--- a/boards/nxp/rd_rw612_bga/Kconfig
+++ b/boards/nxp/rd_rw612_bga/Kconfig
@@ -1,0 +1,5 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_RD_RW612_BGA
+	select BOARD_EARLY_INIT_HOOK

--- a/boards/nxp/rd_rw612_bga/Kconfig.defconfig
+++ b/boards/nxp/rd_rw612_bga/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # RD_RW612_BGA board
 
-# Copyright 2022-2024 NXP
+# Copyright 2022-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_RD_RW612_BGA
@@ -36,5 +36,12 @@ config NET_L2_ETHERNET
 	default y
 
 endif # DT_HAS_NXP_ENET_MAC_ENABLED && NETWORKING
+
+if COUNTER_MCUX_LPC_RTC_1HZ
+
+config XTAL32K
+	default y
+
+endif # COUNTER_MCUX_LPC_RTC_1HZ
 
 endif # BOARD_RD_RW612_BGA

--- a/boards/nxp/rd_rw612_bga/doc/index.rst
+++ b/boards/nxp/rd_rw612_bga/doc/index.rst
@@ -25,6 +25,10 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+.. note::
+
+   Power modes 1, 2 and 3 are supported when using System Power Management.
+
 Display Support
 ***************
 

--- a/boards/nxp/rd_rw612_bga/init.c
+++ b/boards/nxp/rd_rw612_bga/init.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022, 2024-25 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/pm/pm.h>
+#include <fsl_power.h>
+
+static void rdrw61x_power_init_config(void)
+{
+	power_init_config_t initCfg = {
+		/* VCORE AVDD18 supplied from iBuck on RD board. */
+		.iBuck = true,
+		/* CAU_SOC_SLP_REF_CLK is needed for LPOSC. */
+		.gateCauRefClk = false,
+	};
+
+	POWER_InitPowerConfig(&initCfg);
+}
+
+#if CONFIG_PM
+static void rdrw61x_pm_state_exit(enum pm_state state)
+{
+	switch (state) {
+	case PM_STATE_STANDBY:
+		rdrw61x_power_init_config();
+		break;
+	default:
+		break;
+	}
+}
+#endif
+
+void board_early_init_hook(void)
+{
+	rdrw61x_power_init_config();
+
+#if CONFIG_PM
+	static struct pm_notifier rdrw61x_pm_notifier = {
+		.state_exit = rdrw61x_pm_state_exit,
+	};
+
+	pm_notifier_register(&rdrw61x_pm_notifier);
+#endif
+}


### PR DESCRIPTION
1. Add the power init code.
2. Add code to support Low Power Mode support from the RTC 1HZ clock.
