### PR TITLE
drivers: Fix declaration after label compile error

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -416,6 +416,8 @@ static int gpio_mcux_lpc_manage_cb(const struct device *port,
 
 static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
 {
+	const struct gpio_mcux_lpc_config *config = dev->config;
+
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
 		break;
@@ -424,8 +426,6 @@ static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_acti
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
-		const struct gpio_mcux_lpc_config *config = dev->config;
-
 		GPIO_PortInit(config->gpio_base, config->port_no);
 		break;
 	default:

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -1121,6 +1121,7 @@ static uint32_t usart_intenset;
 static int mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	const struct mcux_flexcomm_config *config = dev->config;
+	int ret;
 
 	usart_intenset = USART_GetEnabledInterrupts(config->base);
 
@@ -1132,8 +1133,7 @@ static int mcux_flexcomm_pm_action(const struct device *dev, enum pm_device_acti
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
-		int ret = mcux_flexcomm_init_common(dev);
-
+		ret = mcux_flexcomm_init_common(dev);
 		if (ret) {
 			return ret;
 		}


### PR DESCRIPTION
Fix two instances where switch-case labels were followed immediately by a declaration, which is generally invalid and can cause compilation failure. To work around this, add braces around the entire case.