### PR TITLE
fs: update module logging registration

### DIFF
--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -16,10 +16,8 @@
 #include <zephyr/fs/fs_sys.h>
 #include <zephyr/sys/check.h>
 
-
-#define LOG_LEVEL CONFIG_FS_LOG_LEVEL
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(fs);
+LOG_MODULE_REGISTER(fs, CONFIG_FS_LOG_LEVEL);
 
 /* list of mounted file systems */
 static sys_dlist_t fs_mnt_list = SYS_DLIST_STATIC_INIT(&fs_mnt_list);


### PR DESCRIPTION
All modules registered in fs subsystem uses:

LOG_MODULE_REGISTER(<module>, <log level>)

Lets update fs to follow same logic.