### PR TITLE
subsys: sd: correct mismatched comment for CONFIG_SDMMC_STACK

### DIFF
--- a/subsys/sd/sd.c
+++ b/subsys/sd/sd.c
@@ -215,7 +215,7 @@ static int sd_command_init(struct sd_card *card)
 	if (!sdmmc_card_init(card)) {
 		return 0;
 	}
-#endif /* CONFIG_SDIO_STACK */
+#endif /* CONFIG_SDMMC_STACK */
 #ifdef CONFIG_MMC_STACK
 	ret = sd_idle(card);
 	if (ret) {


### PR DESCRIPTION
The closing comment for CONFIG_SDMMC_STACK #ifdef directive was incorrectly labeled as CONFIG_SDIO_STACK. This commit corrects the comment to reflect the correct configuration macro and improve code clarity.