### PR TITLE
west.yml: Update hal_silabs revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -228,7 +228,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 9d32354344f6c816410e2642c2f81677f8a60e96
+      revision: 40a0237e4812241de677441e02131d6c75830636
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This PR updates the `hal_silabs `pointer in west.yml to pull/92/head, enabling Zephyr CI to run and validate the changes in `hal_silabs`.