### PR TITLE
tests: drivers: flash: Add non-Quad mode test for nrf52 and nrf53

### DIFF
--- a/tests/drivers/flash/common/boards/mx25r64_non_quad.overlay
+++ b/tests/drivers/flash/common/boards/mx25r64_non_quad.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+	writeoc = "pp";
+	readoc = "fastread";
+};

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -116,3 +116,12 @@ tests:
     extra_configs:
       - CONFIG_DMA=y
       - CONFIG_SOC_FLASH_SILABS_S2_DMA_READ=y
+  drivers.flash.common.non_quad_mode:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE=boards/mx25r64_non_quad.overlay
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
QSPI NOR driver non-Quad mode was not tested before. Add configuration that uses driver in the non-Quad mode.