### PR TITLE
bluetooth: host: fix hang issue caused by 2 consecutive bt disable co…

### DIFF
--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -85,7 +85,8 @@ enum {
 
 /* Flags which should not be cleared upon HCI_Reset */
 #define BT_DEV_PERSISTENT_FLAGS (BIT(BT_DEV_ENABLE) | \
-				 BIT(BT_DEV_PRESET_ID))
+				 BIT(BT_DEV_PRESET_ID) | \
+				 BIT(BT_DEV_DISABLE))
 
 #if defined(CONFIG_BT_EXT_ADV_LEGACY_SUPPORT)
 /* Check the feature bit for extended or legacy advertising commands */


### PR DESCRIPTION
the bt_dev.flags will be reset to  BT_DEV_ENABLE in hci_reset_complete() API which among bt_disable() API, it will clear the previously set  BT_DEV_DISABLE flag in the begining of bt_disable() API, and resulting 2nd bt_disable go ahead to execute without BT_DEV_DISABLE flag protection, finally device hang at failed to receive HCI_Reset event in 2nd bt_disable() due to hci->recv was cleared at 1st time bt_disable() called.