### PR TITLE
samples: blinky: add support for non-standard led displays

### DIFF
--- a/boards/bbc/microbit_v2/bbc_microbit_v2.dts
+++ b/boards/bbc/microbit_v2/bbc_microbit_v2.dts
@@ -20,6 +20,8 @@
 		magn0 = &lsm303agr_magn;
 		accel0 = &lsm303agr_accel;
 		watchdog0 = &wdt0;
+		led0 = &led_row_1;
+		led1 = &led_col_1;
 	};
 
 	chosen {
@@ -98,6 +100,18 @@
 			   <16 0 &gpio1 2 0>,	/* P16 */
 			   <19 0 &gpio0 26 0>,	/* P19 */
 			   <20 0 &gpio1 0 0>;	/* P20 */
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_col_1: ledcol1 {
+			gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+			label = "BLINK_LED";
+		};
+		led_row_1: ledrow1 {
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+			label = "BLINK_LED";
+		};
 	};
 };
 

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -9,36 +9,60 @@
 #include <zephyr/drivers/gpio.h>
 
 /* 1000 msec = 1 sec */
-#define SLEEP_TIME_MS   1000
+#define SLEEP_TIME_MS 1000
 
 /* The devicetree node identifier for the "led0" alias. */
 #define LED0_NODE DT_ALIAS(led0)
+#define LED1_NODE DT_ALIAS(led1)
+
+/* Check if LED1_NODE is defined in cases such as with matrix displays. */
+#define LED1_IS_DEFINED DT_NODE_EXISTS(LED1_NODE)
 
 /*
  * A build error on this line means your board is unsupported.
  * See the sample documentation for information on how to fix this.
  */
-static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+static const struct gpio_dt_spec led0 = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+/* Extended support for matrix displays. */
+#if LED1_IS_DEFINED
+static const struct gpio_dt_spec led1 = GPIO_DT_SPEC_GET(LED1_NODE, gpios);
+#endif
 
 int main(void)
 {
 	int ret;
 	bool led_state = true;
 
-	if (!gpio_is_ready_dt(&led)) {
+	if (!gpio_is_ready_dt(&led0)) {
 		return 0;
 	}
-
-	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+	ret = gpio_pin_configure_dt(&led0, GPIO_OUTPUT_ACTIVE);
 	if (ret < 0) {
 		return 0;
 	}
 
+#if LED1_IS_DEFINED
+	if (!gpio_is_ready_dt(&led1)) {
+		return 0;
+	}
+	ret = gpio_pin_configure_dt(&led1, GPIO_OUTPUT_ACTIVE);
+	if (ret < 0) {
+		return 0;
+	}
+#endif
+
 	while (1) {
-		ret = gpio_pin_toggle_dt(&led);
+		ret = gpio_pin_toggle_dt(&led0);
 		if (ret < 0) {
 			return 0;
 		}
+#if LED1_IS_DEFINED
+		ret = gpio_pin_toggle_dt(&led1);
+		if (ret < 0) {
+			return 0;
+		}
+#endif
 
 		led_state = !led_state;
 		printf("LED state: %s\n", led_state ? "ON" : "OFF");


### PR DESCRIPTION
This is a change to enable the blinky sample to work on matrix displays such as the common learner board MicroBit v2.