### PR TITLE
tests: drivers: spi: Add NULL spi_buf_set tests

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -321,6 +321,30 @@ ZTEST(spi_loopback, test_spi_complete_large_transfers)
 			"Large Buffer contents are different");
 }
 
+ZTEST(spi_loopback, test_spi_null_tx_buf_set)
+{
+	struct spi_dt_spec *spec = loopback_specs[spec_idx];
+	static const uint8_t expected_nop_return_buf[BUF_SIZE] = { 0 };
+	const struct spi_buf_set rx = spi_loopback_setup_xfer(rx_bufs_pool, 1,
+							      buffer_rx, BUF_SIZE);
+
+	(void)memset(buffer_rx, 0x77, BUF_SIZE);
+
+	spi_loopback_transceive(spec, NULL, &rx);
+
+	spi_loopback_compare_bufs(expected_nop_return_buf, buffer_rx, BUF_SIZE,
+				  buffer_print_rx, buffer_print_rx);
+}
+
+ZTEST(spi_loopback, test_spi_null_rx_buf_set)
+{
+	struct spi_dt_spec *spec = loopback_specs[spec_idx];
+	const struct spi_buf_set tx = spi_loopback_setup_xfer(tx_bufs_pool, 1,
+							      NULL, BUF_SIZE);
+
+	spi_loopback_transceive(spec, &tx, NULL);
+}
+
 ZTEST(spi_loopback, test_nop_nil_bufs)
 {
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];


### PR DESCRIPTION
Add test cases where spi_transceive gets NULL spi_buf_set, once for tx and once for rx.