### PR TITLE
Bluetooth: Mesh: Fix proxy after board reboot

### DIFF
--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -983,6 +983,8 @@ int bt_mesh_proxy_gatt_enable(void)
 		}
 	}
 
+	bt_mesh_adv_gatt_update();
+
 	return 0;
 }
 


### PR DESCRIPTION
When the board has been provisioned and the board is rebooted it was not possible to connect to the board through the proxy servcie. This fixes that the Mesh Proxy servive is restarted after the board is rebooted.