### PR TITLE
MAINTAINERS: add new maintainers for Nuvoton NPCX platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3521,9 +3521,9 @@ Nuvoton NPCX Platforms:
   maintainers:
     - MulinChao
     - ChiHuaL
-  collaborators:
     - TomChang19
     - alvsun
+  collaborators:
     - sjg20
     - keith-zephyr
     - jackrosenthal


### PR DESCRIPTION
Add Nuvoton guys, TomChang19 and Alvsun, in maintainers of Nuvoton NPCX platforms and remove them from collaborators.