### PR TITLE
Bluetooth: Classic: SMP: Fix LTK derivation issue

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -809,10 +809,17 @@ static void sc_derive_link_key(struct bt_smp *smp)
 
 static void smp_br_reset(struct bt_smp_br *smp)
 {
+	bool br_smp_connected;
+
+	br_smp_connected = atomic_test_bit(smp->flags, SMP_FLAG_BR_CONNECTED);
+
 	/* Clear flags first in case canceling of timeout fails. The SMP context
 	 * shall be marked as timed out in that case.
 	 */
 	atomic_set(smp->flags, 0);
+
+	/* Set back the status of the flag SMP_FLAG_BR_CONNECTED. */
+	atomic_set_bit_to(smp->flags, SMP_FLAG_BR_CONNECTED, br_smp_connected);
 
 	/* If canceling fails the timeout handler will set the timeout flag and
 	 * mark the it as timed out. No new pairing procedures shall be started
@@ -964,10 +971,17 @@ static void bt_smp_br_disconnected(struct bt_l2cap_chan *chan)
 
 static void smp_br_init(struct bt_smp_br *smp)
 {
+	bool br_smp_connected;
+
+	br_smp_connected = atomic_test_bit(smp->flags, SMP_FLAG_BR_CONNECTED);
+
 	/* Initialize SMP context excluding L2CAP channel context and anything
 	 * else declared after.
 	 */
 	(void)memset(smp, 0, offsetof(struct bt_smp_br, chan));
+
+	/* Set back the status of the flag SMP_FLAG_BR_CONNECTED. */
+	atomic_set_bit_to(smp->flags, SMP_FLAG_BR_CONNECTED, br_smp_connected);
 
 	atomic_set_bit(smp->allowed_cmds, BT_SMP_CMD_PAIRING_FAIL);
 }

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -829,6 +829,11 @@ static void smp_br_id_add_replace(struct bt_keys *keys)
 {
 	struct bt_keys *conflict;
 
+	/* Check whether key has been added to resolving list. */
+	if (keys->state & BT_KEYS_ID_ADDED) {
+		bt_id_del(keys);
+	}
+
 	conflict = bt_id_find_conflict(keys);
 	if (conflict != NULL) {
 		int err;
@@ -994,6 +999,12 @@ static void smp_br_derive_ltk(struct bt_smp_br *smp)
 	 */
 	bt_addr_copy(&addr.a, &conn->br.dst);
 	addr.type = BT_ADDR_LE_PUBLIC;
+
+	keys = bt_keys_find_addr(conn->id, &addr);
+	if (keys != NULL) {
+		LOG_DBG("Clear the current keys for %s", bt_addr_le_str(&addr));
+		bt_keys_clear(keys);
+	}
 
 	keys = bt_keys_get_type(BT_KEYS_LTK_P256, conn->id, &addr);
 	if (!keys) {

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -1048,6 +1048,12 @@ static void smp_br_derive_ltk(struct bt_smp_br *smp)
 		keys->flags &= ~BT_KEYS_AUTHENTICATED;
 	}
 
+	if (conn->encrypt == BT_HCI_ENCRYPTION_ON_BR_AES_CCM) {
+		keys->flags |= BT_KEYS_SC;
+	} else {
+		keys->flags &= ~BT_KEYS_SC;
+	}
+
 	LOG_DBG("LTK derived from LinkKey");
 }
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -262,6 +262,9 @@ struct bt_smp_br {
 	/* Remote key distribution */
 	uint8_t			remote_dist;
 
+	/* Local keys have been distributed */
+	uint8_t			local_distributed;
+
 	/* Encryption Key Size used for connection */
 	uint8_t 			enc_key_size;
 
@@ -1089,12 +1092,13 @@ static void smp_br_distribute_keys(struct bt_smp_br *smp)
 	}
 
 #if defined(CONFIG_BT_PRIVACY)
-	if (smp->local_dist & BT_SMP_DIST_ID_KEY) {
+	if ((smp->local_dist & BT_SMP_DIST_ID_KEY) &&
+	    ((smp->local_distributed & BT_SMP_DIST_ID_KEY) == 0)) {
 		struct bt_smp_ident_info *id_info;
 		struct bt_smp_ident_addr_info *id_addr_info;
 		struct net_buf *buf;
 
-		smp->local_dist &= ~BT_SMP_DIST_ID_KEY;
+		smp->local_distributed |= BT_SMP_DIST_ID_KEY;
 
 		buf = smp_br_create_pdu(smp, BT_SMP_CMD_IDENT_INFO,
 					sizeof(*id_info));
@@ -1123,11 +1127,12 @@ static void smp_br_distribute_keys(struct bt_smp_br *smp)
 #endif /* CONFIG_BT_PRIVACY */
 
 #if defined(CONFIG_BT_SIGNING)
-	if (smp->local_dist & BT_SMP_DIST_SIGN) {
+	if ((smp->local_dist & BT_SMP_DIST_SIGN) &&
+	    ((smp->local_distributed & BT_SMP_DIST_SIGN) == 0)) {
 		struct bt_smp_signing_info *info;
 		struct net_buf *buf;
 
-		smp->local_dist &= ~BT_SMP_DIST_SIGN;
+		smp->local_distributed |= BT_SMP_DIST_SIGN;
 
 		buf = smp_br_create_pdu(smp, BT_SMP_CMD_SIGNING_INFO,
 					sizeof(*info));


### PR DESCRIPTION
**Bluetooth: Classic: SMP: Derived LE keys are not handled correctly**

The derived LE keys are not saved to NVM. And the IRK is not added to controller resolving list. It causes two issues,
Issue 1, the LE connection connection cannot be established if the adv address of peer is RPA.
Issue 2, the LE keys are missing after the power reset.

For issue 1, add a function `smp_br_id_add_replace` to add LE keys.
For issue 2, check the BR bondable flag `BT_CONN_BR_NOBOND` instead of `SMP_FLAG_BOND`.

**Bluetooth: Classic: SMP: Avoid derived LE keys be added multiple times**

In current implementation, the flag `local_dist` will be cleared when the distributed key frame is performed if the local is the SMP initiator. After the distributed key is sent out, the function `smp_pairing_br_complete()` will be called if all bits of `local_dist` are cleared.

It causes the function `smp_pairing_br_complete()` will be called multiple times.

Add a flag `local_distributed` to flag the all sent keys. Add only the flag `local_distributed` is not set, preform the key distribution frame.

**Bluetooth: Classic: SMP: Remove old LE keys before upgrading keys**

Remove the old LE keys from resolving list and NVM before upgrading the keys.

**Bluetooth: Classic: SMP: Set secure connection for derived LTK**

If the encrypt value of classic connection is `BT_HCI_ENCRYPTION_ON_BR_AES_CCM`, set the flag `BT_KEYS_SC` for the derived LTK.
Or, clear the flag `BT_KEYS_SC` for the derived LTK.

**Bluetooth: Classic: SMP: Recovery flag SMP_FLAG_BR_CONNECTED**

The flag `SMP_FLAG_BR_CONNECTED` is cleared by the function `smp_br_reset()` and `smp_br_init`. But the flag 
`SMP_FLAG_BR_CONNECTED` should not be cleared at this time.

Recovery the flag `SMP_FLAG_BR_CONNECTED` after the all flags of SMP cleared.

