### PR TITLE
scripts/build: improve whitespace / empty parameter handling in syscall scripts

### DIFF
--- a/scripts/build/gen_syscalls.py
+++ b/scripts/build/gen_syscalls.py
@@ -198,7 +198,6 @@ class SyscallParseException(Exception):
 
 
 def typename_split(item):
-    item = item.strip().replace("\n", " ")
     if "[" in item:
         raise SyscallParseException(
             f"Please pass arrays to syscalls as pointers, unable to process '{item}'"
@@ -431,7 +430,7 @@ def analyze_fn(match_group, fn, userspace_only):
         if args == "void":
             args = []
         else:
-            args = [typename_split(a) for a in args.split(",")]
+            args = [typename_split(a.strip()) for a in args.split(",")]
 
         func_type, func_name = typename_split(func)
     except SyscallParseException:

--- a/scripts/build/parse_syscalls.py
+++ b/scripts/build/parse_syscalls.py
@@ -130,7 +130,11 @@ def analyze_headers(include_dir, scan_dir, file_list):
         try:
             to_emit = syscall_files[one_file]["emit"] | args.emit_all_syscalls
 
-            syscall_result = [(mo.groups(), fn, to_emit) for mo in syscall_regex.finditer(contents)]
+            syscall_result = []
+            for mo in syscall_regex.finditer(contents):
+                groups = mo.groups()
+                groups = [re.sub(r'\s+', ' ', group) for group in groups]
+                syscall_result.append((groups, fn, to_emit))
             for tag in struct_tags:
                 tagged_struct_update(tagged_ret[tag], tag, contents)
         except Exception as e:

--- a/tests/cmake/syscalls/CMakeLists.txt
+++ b/tests/cmake/syscalls/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.20)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(app C)
+target_sources(app PRIVATE main.c)

--- a/tests/cmake/syscalls/main.c
+++ b/tests/cmake/syscalls/main.c
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "main.h"
+
+int main(void) { return 0; }

--- a/tests/cmake/syscalls/main.h
+++ b/tests/cmake/syscalls/main.h
@@ -1,0 +1,16 @@
+#pragma once
+
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/syscall.h>
+
+/* Newline between return type and function name */
+/* clang-format off */
+__syscall void
+test_wrapped(int foo);
+/* clang-format on */
+
+#include <zephyr/syscalls/main.h>

--- a/tests/cmake/syscalls/prj.conf
+++ b/tests/cmake/syscalls/prj.conf
@@ -1,0 +1,3 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_APPLICATION_DEFINED_SYSCALL=y

--- a/tests/cmake/syscalls/testcase.yaml
+++ b/tests/cmake/syscalls/testcase.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+tests:
+  buildsystem.syscalls:
+    build_only: true
+    platform_allow: native_sim


### PR DESCRIPTION
Syscall regex matches may include whitespace characters other than space (i.e. `\n` or `\t`), which causes `gen_syscalls.py` to fail. This mainly affects long system call signatures wrapped onto multiple lines (e.g. by code formatter). This change replaces all successive whitespace in the regex match groups with a single space.