### PR TITLE
Bluetooth: Host: Doc: Name enums in gap.h

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1745,7 +1745,7 @@ int bt_le_ext_adv_get_info(const struct bt_le_ext_adv *adv,
  * @param addr Advertiser LE address and type.
  * @param rssi Strength of advertiser signal.
  * @param adv_type Type of advertising response from advertiser.
- *                 Uses the BT_GAP_ADV_TYPE_* values.
+ *                 Uses the @ref bt_gap_adv_type values.
  * @param buf Buffer containing advertiser data.
  */
 typedef void bt_le_scan_cb_t(const bt_addr_le_t *addr, int8_t rssi,
@@ -2588,7 +2588,7 @@ struct bt_le_scan_recv_info {
 	/**
 	 * @brief Advertising packet type.
 	 *
-	 * Uses the BT_GAP_ADV_TYPE_* value.
+	 * Uses the @ref bt_gap_adv_type value.
 	 *
 	 * May indicate that this is a scan response if the type is
 	 * @ref BT_GAP_ADV_TYPE_SCAN_RSP.
@@ -2598,7 +2598,7 @@ struct bt_le_scan_recv_info {
 	/**
 	 * @brief Advertising packet properties bitfield.
 	 *
-	 * Uses the BT_GAP_ADV_PROP_* values.
+	 * Uses the @ref bt_gap_adv_prop values.
 	 * May indicate that this is a scan response if the value contains the
 	 * @ref BT_GAP_ADV_PROP_SCAN_RESPONSE bit.
 	 *

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -740,7 +740,7 @@ extern "C" {
  */
 
 /** LE PHY types */
-enum {
+enum bt_gap_le_phy {
 	/** Convenience macro for when no PHY is set. */
 	BT_GAP_LE_PHY_NONE                    = 0,
 	/** LE 1M PHY */
@@ -760,7 +760,7 @@ enum {
 };
 
 /** Advertising PDU types */
-enum {
+enum bt_gap_adv_type {
 	/** Scannable and connectable advertising. */
 	BT_GAP_ADV_TYPE_ADV_IND               = 0x00,
 	/** Directed connectable advertising. */
@@ -776,7 +776,7 @@ enum {
 };
 
 /** Advertising PDU properties */
-enum {
+enum bt_gap_adv_prop {
 	/** Connectable advertising. */
 	BT_GAP_ADV_PROP_CONNECTABLE           = BIT(0),
 	/** Scannable advertising. */
@@ -1054,7 +1054,7 @@ enum {
 	(BT_GAP_US_TO_CONN_EVENT_LEN((_event_len) * USEC_PER_MSEC))
 
 /** Constant Tone Extension (CTE) types */
-enum {
+enum bt_gap_cte {
 	/** Angle of Arrival */
 	BT_GAP_CTE_AOA = 0x00,
 	/** Angle of Departure with 1 us slots */
@@ -1066,7 +1066,7 @@ enum {
 };
 
 /** @brief Peripheral sleep clock accuracy (SCA) in ppm (parts per million) */
-enum {
+enum bt_gap_sca {
 	BT_GAP_SCA_UNKNOWN = 0,   /**< Unknown */
 	BT_GAP_SCA_251_500 = 0,   /**< 251 ppm to 500 ppm */
 	BT_GAP_SCA_151_250 = 1,   /**< 151 ppm to 250 ppm */

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -228,7 +228,7 @@ struct bt_iso_chan_io_qos {
 	 */
 	uint16_t			sdu;
 	/**
-	 * @brief Channel PHY - See the BT_GAP_LE_PHY_* values.
+	 * @brief Channel PHY - See the @ref bt_gap_le_phy values.
 	 *
 	 * Setting @ref BT_GAP_LE_PHY_NONE is invalid.
 	 */
@@ -432,7 +432,7 @@ struct bt_iso_cig_param {
 	 * @brief Channel peripherals sleep clock accuracy Only for CIS
 	 *
 	 * Shall be worst case sleep clock accuracy of all the peripherals.
-	 * For possible values see the BT_GAP_SCA_* values.
+	 * For possible values, see @ref bt_gap_sca.
 	 * If unknown for the peripherals, this should be set to @ref BT_GAP_SCA_UNKNOWN.
 	 */
 	uint8_t sca;


### PR DESCRIPTION
Names the enums declared in `gap.h` and replaces references to them with Doxygen references (ref).