### PR TITLE
enable SDHC support on imx93 Cortex-A Core platform

### DIFF
--- a/boards/nxp/imx93_evk/Kconfig.defconfig
+++ b/boards/nxp/imx93_evk/Kconfig.defconfig
@@ -67,4 +67,11 @@ endif # NETWORKING
 
 endif # BOARD_IMX93_EVK_MIMX9352_A55
 
+if IMX_USDHC
+
+config GPIO
+	default y
+
+endif # IMX_USDHC
+
 endif # BOARD_IMX93_EVK

--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -62,6 +62,37 @@ Serial Port
 This board configuration uses a single serial communication channel with the
 CPU's UART2 for A55 core and M33 core.
 
+uSDHC (SD or eMMC Interface on A55)
+-----------------------------------
+
+i.MX 93 processor has three ultra secured digital host controller (uSDHC) modules
+for SD/eMMC interface support. On the MCIMX93-EVK board, the uSDHC2 interface of
+the processor connects to the MicroSD card slot (J1002), and uSDHC1 interface connects
+to the eMMC memory (located at the SOM board). DTS overlay file "usdhc1.overlay" and
+"usdhc2.overlay" are provided to enable specified the uSDHC controller.
+
+Currently it rely on U-boot or Linux to boot Zephyr on Cortex-A Core, so Zephyr need
+to use different uSDHC controller from U-boot or Linux to avoid resource conflict.
+For example, if EVK board boots from SD Card which uses uSDHC2, Zephyr can use MMC
+which uses uSDHC1 for testing:
+
+.. zephyr-app-commands::
+   :zephyr-app: tests/subsys/sd/mmc
+   :host-os: unix
+   :board: imx93_evk/mimx9352/a55
+   :goals: build
+   :gen-args: -DEXTRA_DTC_OVERLAY_FILE=usdhc1.overlay
+
+And if EVK board boots from MMC which uses uSDHC1, Zephyr can use SD Card which uses
+uSDHC2 for testing:
+
+.. zephyr-app-commands::
+   :zephyr-app: tests/subsys/sd/sdmmc
+   :host-os: unix
+   :board: imx93_evk/mimx9352/a55
+   :goals: build
+   :gen-args: -DEXTRA_DTC_OVERLAY_FILE=usdhc2.overlay
+
 Board MUX Control
 -----------------
 

--- a/boards/nxp/imx93_evk/dts/usdhc1.overlay
+++ b/boards/nxp/imx93_evk/dts/usdhc1.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &usdhc1;
+	};
+};
+
+&usdhc1 {
+	status = "okay";
+	sdmmc {
+		status = "okay";
+	};
+};

--- a/boards/nxp/imx93_evk/dts/usdhc2.overlay
+++ b/boards/nxp/imx93_evk/dts/usdhc2.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sdhc0 = &usdhc2;
+	};
+};
+
+&usdhc2 {
+	status = "okay";
+	sdmmc {
+		status = "okay";
+	};
+};

--- a/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
+++ b/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
@@ -129,4 +129,198 @@
 
 	};
 
+	pinmux_usdhc1: pinmux_usdhc1 {
+		group0 {
+			pinmux = <&iomuxc1_sd1_clk_usdhc_clk_usdhc1_clk>,
+				<&iomuxc1_sd1_strobe_usdhc_strobe_usdhc1_strobe>;
+			drive-strength = "x1";
+			bias-pull-down;
+			slew-rate = "fast";
+			input-schmitt-enable;
+		};
+
+		group1 {
+			pinmux = <&iomuxc1_sd1_cmd_usdhc_cmd_usdhc1_cmd>,
+				<&iomuxc1_sd1_data0_usdhc_data_usdhc1_data0>,
+				<&iomuxc1_sd1_data1_usdhc_data_usdhc1_data1>,
+				<&iomuxc1_sd1_data2_usdhc_data_usdhc1_data2>,
+				<&iomuxc1_sd1_data3_usdhc_data_usdhc1_data3>,
+				<&iomuxc1_sd1_data4_usdhc_data_usdhc1_data4>,
+				<&iomuxc1_sd1_data5_usdhc_data_usdhc1_data5>,
+				<&iomuxc1_sd1_data6_usdhc_data_usdhc1_data6>,
+				<&iomuxc1_sd1_data7_usdhc_data_usdhc1_data7>;
+			drive-strength = "x1";
+			slew-rate = "fast";
+			input-schmitt-enable;
+			bias-pull-up;
+			input-enable;
+		};
+	};
+
+	pinmux_usdhc1_100mhz: pinmux_usdhc1_100mhz {
+		group0 {
+			pinmux = <&iomuxc1_sd1_clk_usdhc_clk_usdhc1_clk>,
+				<&iomuxc1_sd1_strobe_usdhc_strobe_usdhc1_strobe>;
+			drive-strength = "x3";
+			bias-pull-down;
+			slew-rate = "fast";
+			input-schmitt-enable;
+		};
+
+		group1 {
+			pinmux = <&iomuxc1_sd1_cmd_usdhc_cmd_usdhc1_cmd>,
+				<&iomuxc1_sd1_data0_usdhc_data_usdhc1_data0>,
+				<&iomuxc1_sd1_data1_usdhc_data_usdhc1_data1>,
+				<&iomuxc1_sd1_data2_usdhc_data_usdhc1_data2>,
+				<&iomuxc1_sd1_data3_usdhc_data_usdhc1_data3>,
+				<&iomuxc1_sd1_data4_usdhc_data_usdhc1_data4>,
+				<&iomuxc1_sd1_data5_usdhc_data_usdhc1_data5>,
+				<&iomuxc1_sd1_data6_usdhc_data_usdhc1_data6>,
+				<&iomuxc1_sd1_data7_usdhc_data_usdhc1_data7>;
+			drive-strength = "x3";
+			slew-rate = "fast";
+			input-schmitt-enable;
+			bias-pull-up;
+			input-enable;
+		};
+	};
+
+	pinmux_usdhc1_200mhz: pinmux_usdhc1_200mhz {
+		group0 {
+			pinmux = <&iomuxc1_sd1_clk_usdhc_clk_usdhc1_clk>,
+				<&iomuxc1_sd1_strobe_usdhc_strobe_usdhc1_strobe>;
+			drive-strength = "x6";
+			bias-pull-down;
+			slew-rate = "fast";
+			input-schmitt-enable;
+		};
+
+		group1 {
+			pinmux = <&iomuxc1_sd1_cmd_usdhc_cmd_usdhc1_cmd>,
+				<&iomuxc1_sd1_data0_usdhc_data_usdhc1_data0>,
+				<&iomuxc1_sd1_data1_usdhc_data_usdhc1_data1>,
+				<&iomuxc1_sd1_data2_usdhc_data_usdhc1_data2>,
+				<&iomuxc1_sd1_data3_usdhc_data_usdhc1_data3>,
+				<&iomuxc1_sd1_data4_usdhc_data_usdhc1_data4>,
+				<&iomuxc1_sd1_data5_usdhc_data_usdhc1_data5>,
+				<&iomuxc1_sd1_data6_usdhc_data_usdhc1_data6>,
+				<&iomuxc1_sd1_data7_usdhc_data_usdhc1_data7>;
+			drive-strength = "x6";
+			slew-rate = "fast";
+			input-schmitt-enable;
+			bias-pull-up;
+			input-enable;
+		};
+	};
+
+	pinmux_usdhc2: pinmux_usdhc2 {
+		group0 {
+			pinmux = <&iomuxc1_sd2_clk_usdhc_clk_usdhc2_clk>;
+			drive-strength = "x1";
+			bias-pull-down;
+			slew-rate = "fast";
+			input-schmitt-enable;
+		};
+
+		group1 {
+			pinmux = <&iomuxc1_sd2_cmd_usdhc_cmd_usdhc2_cmd>,
+				<&iomuxc1_sd2_data0_usdhc_data_usdhc2_data0>,
+				<&iomuxc1_sd2_data1_usdhc_data_usdhc2_data1>,
+				<&iomuxc1_sd2_data2_usdhc_data_usdhc2_data2>,
+				<&iomuxc1_sd2_data3_usdhc_data_usdhc2_data3>;
+			drive-strength = "x1";
+			slew-rate = "fast";
+			input-schmitt-enable;
+			bias-pull-up;
+			input-enable;
+		};
+
+		group2 {
+			pinmux = <&iomuxc1_sd2_vselect_usdhc_vselect_usdhc2_vselect>;
+			drive-strength = "x4";
+			slew-rate = "slightly_fast";
+		};
+
+		group3 {
+			pinmux = <&iomuxc1_sd2_cd_b_gpio_io_gpio3_io00>,
+				<&iomuxc1_sd2_reset_b_gpio_io_gpio3_io07>;
+			drive-strength = "x4";
+			slew-rate = "slightly_fast";
+			bias-pull-up;
+		};
+	};
+
+	pinmux_usdhc2_100mhz: pinmux_usdhc2_100mhz {
+		group0 {
+			pinmux = <&iomuxc1_sd2_clk_usdhc_clk_usdhc2_clk>;
+			drive-strength = "x3";
+			bias-pull-down;
+			slew-rate = "fast";
+			input-schmitt-enable;
+		};
+
+		group1 {
+			pinmux = <&iomuxc1_sd2_cmd_usdhc_cmd_usdhc2_cmd>,
+				<&iomuxc1_sd2_data0_usdhc_data_usdhc2_data0>,
+				<&iomuxc1_sd2_data1_usdhc_data_usdhc2_data1>,
+				<&iomuxc1_sd2_data2_usdhc_data_usdhc2_data2>,
+				<&iomuxc1_sd2_data3_usdhc_data_usdhc2_data3>;
+			drive-strength = "x3";
+			slew-rate = "fast";
+			input-schmitt-enable;
+			bias-pull-up;
+			input-enable;
+		};
+
+		group2 {
+			pinmux = <&iomuxc1_sd2_vselect_usdhc_vselect_usdhc2_vselect>;
+			drive-strength = "x4";
+			slew-rate = "slightly_fast";
+		};
+
+		group3 {
+			pinmux = <&iomuxc1_sd2_cd_b_gpio_io_gpio3_io00>,
+				<&iomuxc1_sd2_reset_b_gpio_io_gpio3_io07>;
+			drive-strength = "x4";
+			slew-rate = "slightly_fast";
+			bias-pull-up;
+		};
+	};
+
+	pinmux_usdhc2_200mhz: pinmux_usdhc2_200mhz {
+		group0 {
+			pinmux = <&iomuxc1_sd2_clk_usdhc_clk_usdhc2_clk>;
+			drive-strength = "x6";
+			bias-pull-down;
+			slew-rate = "fast";
+			input-schmitt-enable;
+		};
+
+		group1 {
+			pinmux = <&iomuxc1_sd2_cmd_usdhc_cmd_usdhc2_cmd>,
+				<&iomuxc1_sd2_data0_usdhc_data_usdhc2_data0>,
+				<&iomuxc1_sd2_data1_usdhc_data_usdhc2_data1>,
+				<&iomuxc1_sd2_data2_usdhc_data_usdhc2_data2>,
+				<&iomuxc1_sd2_data3_usdhc_data_usdhc2_data3>;
+			drive-strength = "x6";
+			slew-rate = "fast";
+			input-schmitt-enable;
+			bias-pull-up;
+			input-enable;
+		};
+
+		group2 {
+			pinmux = <&iomuxc1_sd2_vselect_usdhc_vselect_usdhc2_vselect>;
+			drive-strength = "x4";
+			slew-rate = "slightly_fast";
+		};
+
+		group3 {
+			pinmux = <&iomuxc1_sd2_cd_b_gpio_io_gpio3_io00>,
+				<&iomuxc1_sd2_reset_b_gpio_io_gpio3_io07>;
+			drive-strength = "x4";
+			slew-rate = "slightly_fast";
+			bias-pull-up;
+		};
+	};
 };

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.dts
@@ -203,3 +203,40 @@
 	phys = <&can_phy0>;
 	status = "okay";
 };
+
+&usdhc1 {
+	pinctrl-0 = <&pinmux_usdhc1>;
+	pinctrl-1 = <&pinmux_usdhc1_100mhz>;
+	pinctrl-2 = <&pinmux_usdhc1_200mhz>;
+	pinctrl-names = "default", "med", "fast";
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	read-watermark = <0x10>;
+	write-watermark = <0x80>;
+	status = "disabled";
+	sdmmc {
+		compatible = "zephyr,mmc-disk";
+		disk-name = "SD2";
+		status = "disabled";
+	};
+};
+
+&usdhc2 {
+	pinctrl-0 = <&pinmux_usdhc2>;
+	pinctrl-1 = <&pinmux_usdhc2_100mhz>;
+	pinctrl-2 = <&pinmux_usdhc2_200mhz>;
+	pinctrl-names = "default", "med", "fast";
+	pwr-gpios = <&gpio3 7 GPIO_ACTIVE_HIGH>;
+	cd-gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+	power-delay-ms = <20>;
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	read-watermark = <0x10>;
+	write-watermark = <0x80>;
+	status = "disabled";
+	sdmmc {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "disabled";
+	};
+};

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #define DT_DRV_COMPAT nxp_imx_usdhc
 
 #include <zephyr/kernel.h>
@@ -16,9 +15,9 @@
 #include <zephyr/logging/log.h>
 #include <soc.h>
 #include <zephyr/drivers/pinctrl.h>
-#define PINCTRL_STATE_SLOW PINCTRL_STATE_PRIV_START
-#define PINCTRL_STATE_MED (PINCTRL_STATE_PRIV_START + 1U)
-#define PINCTRL_STATE_FAST (PINCTRL_STATE_PRIV_START + 2U)
+#define PINCTRL_STATE_SLOW   PINCTRL_STATE_PRIV_START
+#define PINCTRL_STATE_MED    (PINCTRL_STATE_PRIV_START + 1U)
+#define PINCTRL_STATE_FAST   (PINCTRL_STATE_PRIV_START + 2U)
 #define PINCTRL_STATE_NOPULL (PINCTRL_STATE_PRIV_START + 3U)
 
 LOG_MODULE_REGISTER(usdhc, CONFIG_SDHC_LOG_LEVEL);
@@ -34,15 +33,15 @@ enum transfer_callback_status {
 	TRANSFER_DATA_FAILED = BIT(3),
 };
 
-#define TRANSFER_CMD_FLAGS (TRANSFER_CMD_COMPLETE | TRANSFER_CMD_FAILED)
+#define TRANSFER_CMD_FLAGS  (TRANSFER_CMD_COMPLETE | TRANSFER_CMD_FAILED)
 #define TRANSFER_DATA_FLAGS (TRANSFER_DATA_COMPLETE | TRANSFER_DATA_FAILED)
 
 /* USDHC tuning constants */
-#define IMX_USDHC_STANDARD_TUNING_START (10U)
-#define IMX_USDHC_TUNING_STEP (2U)
+#define IMX_USDHC_STANDARD_TUNING_START   (10U)
+#define IMX_USDHC_TUNING_STEP             (2U)
 #define IMX_USDHC_STANDARD_TUNING_COUNTER (60U)
 /* Default transfer timeout in ms for tuning */
-#define IMX_USDHC_DEFAULT_TIMEOUT (5000U)
+#define IMX_USDHC_DEFAULT_TIMEOUT         (5000U)
 
 struct usdhc_host_transfer {
 	usdhc_transfer_t *transfer;
@@ -90,12 +89,12 @@ struct usdhc_data {
 	uint8_t usdhc_rx_dummy[128] __aligned(32);
 #ifdef CONFIG_IMX_USDHC_DMA_SUPPORT
 	uint32_t *usdhc_dma_descriptor; /* ADMA descriptor table (noncachable) */
-	uint32_t dma_descriptor_len; /* DMA descriptor table length in words */
+	uint32_t dma_descriptor_len;    /* DMA descriptor table length in words */
 #endif
 };
 
-static void transfer_complete_cb(USDHC_Type *usdhc, usdhc_handle_t *handle,
-	status_t status, void *user_data)
+static void transfer_complete_cb(USDHC_Type *usdhc, usdhc_handle_t *handle, status_t status,
+				 void *user_data)
 {
 	const struct device *dev = (const struct device *)user_data;
 	struct usdhc_data *data = dev->data;
@@ -111,7 +110,6 @@ static void transfer_complete_cb(USDHC_Type *usdhc, usdhc_handle_t *handle,
 	}
 	k_sem_give(&data->transfer_sem);
 }
-
 
 static void sdio_interrupt_cb(USDHC_Type *usdhc, void *user_data)
 {
@@ -143,8 +141,7 @@ static void card_removed_cb(USDHC_Type *usdhc, void *user_data)
 	}
 }
 
-static void card_detect_gpio_cb(const struct device *port,
-				struct gpio_callback *cb,
+static void card_detect_gpio_cb(const struct device *port, struct gpio_callback *cb,
 				gpio_port_pins_t pins)
 {
 	struct usdhc_data *data = CONTAINER_OF(cb, struct usdhc_data, cd_callback);
@@ -162,12 +159,10 @@ static void card_detect_gpio_cb(const struct device *port,
 
 static void imx_usdhc_select_1_8v(USDHC_Type *base, bool enable_1_8v)
 {
-#if !(defined(FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT) && \
-	(FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT))
+#if !(defined(FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT) && (FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT))
 	UDSHC_SelectVoltage(base, enable_1_8v);
 #endif
 }
-
 
 static int imx_usdhc_dat3_pull(const struct usdhc_config *cfg, bool pullup)
 {
@@ -213,7 +208,7 @@ static void imx_usdhc_error_recovery(const struct device *dev)
 		USDHC_Reset(cfg->base, kUSDHC_ResetCommand, 100U);
 	}
 	if (((status & (uint32_t)kUSDHC_DataInhibitFlag) != 0U) ||
-		(USDHC_GetAdmaErrorStatusFlags(cfg->base) != 0U)) {
+	    (USDHC_GetAdmaErrorStatusFlags(cfg->base) != 0U)) {
 		/* Reset data line */
 		USDHC_Reset(cfg->base, kUSDHC_DataInhibitFlag, 100U);
 	}
@@ -293,16 +288,11 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 	uint32_t src_clk_hz, bus_clk;
 	struct sdhc_io *host_io = &data->host_io;
 
-	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, voltage %s",
-		ios->bus_width,
-		ios->clock,
-		ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
-		ios->signal_voltage == SD_VOL_1_8_V ? "1.8V" : "3.3V"
-		);
+	LOG_DBG("SDHC I/O: bus width %d, clock %dHz, card power %s, voltage %s", ios->bus_width,
+		ios->clock, ios->power_mode == SDHC_POWER_ON ? "ON" : "OFF",
+		ios->signal_voltage == SD_VOL_1_8_V ? "1.8V" : "3.3V");
 
-	if (clock_control_get_rate(cfg->clock_dev,
-				cfg->clock_subsys,
-				&src_clk_hz)) {
+	if (clock_control_get_rate(cfg->clock_dev, cfg->clock_subsys, &src_clk_hz)) {
 		return -EINVAL;
 	}
 
@@ -322,7 +312,6 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 		}
 		host_io->clock = ios->clock;
 	}
-
 
 	/* Set bus width */
 	if (host_io->bus_width != ios->bus_width) {
@@ -432,8 +421,7 @@ static int imx_usdhc_set_io(const struct device *dev, struct sdhc_io *ios)
 /*
  * Internal transfer function, used by tuning and request apis
  */
-static int imx_usdhc_transfer(const struct device *dev,
-	struct usdhc_host_transfer *request)
+static int imx_usdhc_transfer(const struct device *dev, struct usdhc_host_transfer *request)
 {
 	const struct usdhc_config *cfg = dev->config;
 	struct usdhc_data *dev_data = dev->data;
@@ -455,11 +443,11 @@ static int imx_usdhc_transfer(const struct device *dev,
 	/* Reset semaphore */
 	k_sem_reset(&dev_data->transfer_sem);
 #ifdef CONFIG_IMX_USDHC_DMA_SUPPORT
-	error = USDHC_TransferNonBlocking(cfg->base, &dev_data->transfer_handle,
-			&dma_config, request->transfer);
+	error = USDHC_TransferNonBlocking(cfg->base, &dev_data->transfer_handle, &dma_config,
+					  request->transfer);
 #else
-	error = USDHC_TransferNonBlocking(cfg->base, &dev_data->transfer_handle,
-			NULL, request->transfer);
+	error = USDHC_TransferNonBlocking(cfg->base, &dev_data->transfer_handle, NULL,
+					  request->transfer);
 #endif
 	if (error == kStatus_USDHC_ReTuningRequest) {
 		return -EAGAIN;
@@ -518,12 +506,11 @@ static int imx_usdhc_card_busy(const struct device *dev)
 {
 	const struct usdhc_config *cfg = dev->config;
 
-	return (USDHC_GetPresentStatusFlags(cfg->base)
-		& (kUSDHC_Data0LineLevelFlag |
-		kUSDHC_Data1LineLevelFlag |
-		kUSDHC_Data2LineLevelFlag |
-		kUSDHC_Data3LineLevelFlag))
-		? 0 : 1;
+	return (USDHC_GetPresentStatusFlags(cfg->base) &
+		(kUSDHC_Data0LineLevelFlag | kUSDHC_Data1LineLevelFlag | kUSDHC_Data2LineLevelFlag |
+		 kUSDHC_Data3LineLevelFlag))
+		       ? 0
+		       : 1;
 }
 
 /*
@@ -541,7 +528,7 @@ static int imx_usdhc_execute_tuning(const struct device *dev)
 	bool retry_tuning = true;
 
 	if ((dev_data->host_io.timing == SDHC_TIMING_HS200) ||
-		       (dev_data->host_io.timing == SDHC_TIMING_HS400)) {
+	    (dev_data->host_io.timing == SDHC_TIMING_HS400)) {
 		/*Currently only reaches here when MMC */
 		cmd.index = MMC_SEND_TUNING_BLOCK;
 	} else {
@@ -566,7 +553,7 @@ static int imx_usdhc_execute_tuning(const struct device *dev)
 	USDHC_Reset(cfg->base, kUSDHC_ResetTuning, 100U);
 	/* Disable standard tuning */
 	USDHC_EnableStandardTuning(cfg->base, IMX_USDHC_STANDARD_TUNING_START,
-		IMX_USDHC_TUNING_STEP, false);
+				   IMX_USDHC_TUNING_STEP, false);
 	USDHC_ForceClockOn(cfg->base, true);
 	/*
 	 * Tuning fail found on some SOCs is caused by the different of delay
@@ -576,7 +563,7 @@ static int imx_usdhc_execute_tuning(const struct device *dev)
 	USDHC_SetStandardTuningCounter(cfg->base, IMX_USDHC_STANDARD_TUNING_COUNTER);
 	/* Reenable standard tuning */
 	USDHC_EnableStandardTuning(cfg->base, IMX_USDHC_STANDARD_TUNING_START,
-		IMX_USDHC_TUNING_STEP, true);
+				   IMX_USDHC_TUNING_STEP, true);
 
 	request.command_timeout = K_MSEC(IMX_USDHC_DEFAULT_TIMEOUT);
 	request.data_timeout = K_MSEC(IMX_USDHC_DEFAULT_TIMEOUT);
@@ -598,11 +585,9 @@ static int imx_usdhc_execute_tuning(const struct device *dev)
 		if ((USDHC_CheckTuningError(cfg->base) != 0U) && retry_tuning) {
 			retry_tuning = false;
 			/* Enable standard tuning */
-			USDHC_EnableStandardTuning(cfg->base,
-				IMX_USDHC_STANDARD_TUNING_START,
-				IMX_USDHC_TUNING_STEP, true);
-			USDHC_SetTuningDelay(cfg->base,
-				IMX_USDHC_STANDARD_TUNING_START, 0U, 0U);
+			USDHC_EnableStandardTuning(cfg->base, IMX_USDHC_STANDARD_TUNING_START,
+						   IMX_USDHC_TUNING_STEP, true);
+			USDHC_SetTuningDelay(cfg->base, IMX_USDHC_STANDARD_TUNING_START, 0U, 0U);
 		} else {
 			break;
 		}
@@ -623,7 +608,7 @@ static int imx_usdhc_execute_tuning(const struct device *dev)
  * Send CMD or CMD/DATA via SDHC
  */
 static int imx_usdhc_request(const struct device *dev, struct sdhc_command *cmd,
-	struct sdhc_data *data)
+			     struct sdhc_data *data)
 {
 	const struct usdhc_config *cfg = dev->config;
 	struct usdhc_data *dev_data = dev->data;
@@ -703,7 +688,6 @@ static int imx_usdhc_request(const struct device *dev, struct sdhc_command *cmd,
 			break;
 		default:
 			return -ENOTSUP;
-
 		}
 		transfer.data = &host_data;
 		if (data->timeout_ms == SDHC_TIMEOUT_FOREVER) {
@@ -731,9 +715,11 @@ static int imx_usdhc_request(const struct device *dev, struct sdhc_command *cmd,
 			 * current transmission, but CMD12 does not contain data
 			 */
 			USDHC_DisableInterruptSignal(cfg->base, kUSDHC_CommandFlag |
-				kUSDHC_DataFlag | kUSDHC_DataDMAFlag);
+									kUSDHC_DataFlag |
+									kUSDHC_DataDMAFlag);
 			USDHC_ClearInterruptStatusFlags(cfg->base, kUSDHC_CommandFlag |
-				kUSDHC_DataFlag | kUSDHC_DataDMAFlag);
+									   kUSDHC_DataFlag |
+									   kUSDHC_DataDMAFlag);
 			/* Stop transmission with CMD12 in case of data error */
 			imx_usdhc_stop_transmission(dev);
 			/* Wait for card to go idle */
@@ -754,9 +740,9 @@ static int imx_usdhc_request(const struct device *dev, struct sdhc_command *cmd,
 		if (ret == -EAGAIN) {
 			/* Retry, card made a tuning request */
 			if (dev_data->host_io.timing == SDHC_TIMING_SDR50 ||
-				dev_data->host_io.timing == SDHC_TIMING_SDR104 ||
-				dev_data->host_io.timing == SDHC_TIMING_HS200 ||
-				dev_data->host_io.timing == SDHC_TIMING_HS400) {
+			    dev_data->host_io.timing == SDHC_TIMING_SDR104 ||
+			    dev_data->host_io.timing == SDHC_TIMING_HS200 ||
+			    dev_data->host_io.timing == SDHC_TIMING_HS400) {
 				/* Retune card */
 				LOG_DBG("Card made tuning request, retune");
 				ret = imx_usdhc_execute_tuning(dev);
@@ -829,8 +815,7 @@ static int imx_usdhc_get_card_present(const struct device *dev)
 /*
  * Get host properties
  */
-static int imx_usdhc_get_host_props(const struct device *dev,
-	struct sdhc_host_props *props)
+static int imx_usdhc_get_host_props(const struct device *dev, struct sdhc_host_props *props)
 {
 	struct usdhc_data *data = dev->data;
 
@@ -841,8 +826,7 @@ static int imx_usdhc_get_host_props(const struct device *dev,
 /*
  * Enable SDHC card interrupt
  */
-static int imx_usdhc_enable_interrupt(const struct device *dev,
-				      sdhc_interrupt_cb_t callback,
+static int imx_usdhc_enable_interrupt(const struct device *dev, sdhc_interrupt_cb_t callback,
 				      int sources, void *user_data)
 {
 	const struct usdhc_config *cfg = dev->config;
@@ -857,8 +841,7 @@ static int imx_usdhc_enable_interrupt(const struct device *dev,
 	USDHC_DisableInterruptStatus(cfg->base, kUSDHC_CardInterruptFlag);
 	USDHC_DisableInterruptSignal(cfg->base, kUSDHC_CardInterruptFlag);
 	if (cfg->detect_gpio.port) {
-		ret = gpio_pin_interrupt_configure_dt(&cfg->detect_gpio,
-						      GPIO_INT_DISABLE);
+		ret = gpio_pin_interrupt_configure_dt(&cfg->detect_gpio, GPIO_INT_DISABLE);
 		if (ret) {
 			return ret;
 		}
@@ -884,10 +867,8 @@ static int imx_usdhc_enable_interrupt(const struct device *dev,
 			}
 		} else {
 			/* Enable card insertion interrupt */
-			USDHC_EnableInterruptStatus(cfg->base,
-						    kUSDHC_CardInsertionFlag);
-			USDHC_EnableInterruptSignal(cfg->base,
-						    kUSDHC_CardInsertionFlag);
+			USDHC_EnableInterruptStatus(cfg->base, kUSDHC_CardInsertionFlag);
+			USDHC_EnableInterruptSignal(cfg->base, kUSDHC_CardInsertionFlag);
 		}
 	}
 	if (sources & SDHC_INT_REMOVED) {
@@ -900,10 +881,8 @@ static int imx_usdhc_enable_interrupt(const struct device *dev,
 			}
 		} else {
 			/* Enable card removal interrupt */
-			USDHC_EnableInterruptStatus(cfg->base,
-						    kUSDHC_CardRemovalFlag);
-			USDHC_EnableInterruptSignal(cfg->base,
-						    kUSDHC_CardRemovalFlag);
+			USDHC_EnableInterruptStatus(cfg->base, kUSDHC_CardRemovalFlag);
+			USDHC_EnableInterruptSignal(cfg->base, kUSDHC_CardRemovalFlag);
 		}
 	}
 
@@ -916,7 +895,6 @@ static int imx_usdhc_disable_interrupt(const struct device *dev, int sources)
 	struct usdhc_data *data = dev->data;
 	int ret;
 
-
 	if (sources & SDHC_INT_SDIO) {
 		/* Disable SDIO card interrupt */
 		USDHC_DisableInterruptStatus(cfg->base, kUSDHC_CardInterruptFlag);
@@ -924,39 +902,32 @@ static int imx_usdhc_disable_interrupt(const struct device *dev, int sources)
 	}
 	if (sources & SDHC_INT_INSERTED) {
 		if (cfg->detect_gpio.port) {
-			ret = gpio_pin_interrupt_configure_dt(&cfg->detect_gpio,
-							      GPIO_INT_DISABLE);
+			ret = gpio_pin_interrupt_configure_dt(&cfg->detect_gpio, GPIO_INT_DISABLE);
 			if (ret) {
 				return ret;
 			}
 		} else {
 			/* Disable card insertion interrupt */
-			USDHC_DisableInterruptStatus(cfg->base,
-						     kUSDHC_CardInsertionFlag);
-			USDHC_DisableInterruptSignal(cfg->base,
-						     kUSDHC_CardInsertionFlag);
+			USDHC_DisableInterruptStatus(cfg->base, kUSDHC_CardInsertionFlag);
+			USDHC_DisableInterruptSignal(cfg->base, kUSDHC_CardInsertionFlag);
 		}
 	}
 	if (sources & SDHC_INT_REMOVED) {
 		if (cfg->detect_gpio.port) {
-			ret = gpio_pin_interrupt_configure_dt(&cfg->detect_gpio,
-							      GPIO_INT_DISABLE);
+			ret = gpio_pin_interrupt_configure_dt(&cfg->detect_gpio, GPIO_INT_DISABLE);
 			if (ret) {
 				return ret;
 			}
 		} else {
 			/* Disable card removal interrupt */
-			USDHC_DisableInterruptStatus(cfg->base,
-						     kUSDHC_CardRemovalFlag);
-			USDHC_DisableInterruptSignal(cfg->base,
-						     kUSDHC_CardRemovalFlag);
+			USDHC_DisableInterruptStatus(cfg->base, kUSDHC_CardRemovalFlag);
+			USDHC_DisableInterruptSignal(cfg->base, kUSDHC_CardRemovalFlag);
 		}
 	}
 
 	/* If all interrupt flags are disabled, remove callback */
 	if ((USDHC_GetEnabledInterruptStatusFlags(cfg->base) &
-	    (kUSDHC_CardInterruptFlag | kUSDHC_CardInsertionFlag |
-	     kUSDHC_CardRemovalFlag)) == 0) {
+	     (kUSDHC_CardInterruptFlag | kUSDHC_CardInsertionFlag | kUSDHC_CardRemovalFlag)) == 0) {
 		data->sdhc_cb = NULL;
 		data->sdhc_cb_user_data = NULL;
 	}
@@ -998,10 +969,8 @@ static int imx_usdhc_init(const struct device *dev)
 	if (ret) {
 		return ret;
 	}
-	USDHC_TransferCreateHandle(cfg->base, &data->transfer_handle,
-		&callbacks, (void *)dev);
+	USDHC_TransferCreateHandle(cfg->base, &data->transfer_handle, &callbacks, (void *)dev);
 	cfg->irq_config_func(dev);
-
 
 	host_config.dataTimeout = cfg->data_timeout;
 	host_config.endianMode = kUSDHC_EndianModeLittle;
@@ -1065,70 +1034,57 @@ static DEVICE_API(sdhc, usdhc_api) = {
 #endif
 
 #ifdef CONFIG_IMX_USDHC_DMA_SUPPORT
-#define IMX_USDHC_DMA_BUFFER_DEFINE(n)						\
-	static uint32_t	__aligned(32)						\
-		usdhc_##n##_dma_descriptor[CONFIG_IMX_USDHC_DMA_BUFFER_SIZE / 4]\
-		IMX_USDHC_NOCACHE_TAG;
-#define IMX_USDHC_DMA_BUFFER_INIT(n)						\
-	.usdhc_dma_descriptor = usdhc_##n##_dma_descriptor,			\
+#define IMX_USDHC_DMA_BUFFER_DEFINE(n)                                                             \
+	static uint32_t __aligned(32)                                                              \
+	usdhc_##n##_dma_descriptor[CONFIG_IMX_USDHC_DMA_BUFFER_SIZE / 4] IMX_USDHC_NOCACHE_TAG;
+#define IMX_USDHC_DMA_BUFFER_INIT(n)                                                               \
+	.usdhc_dma_descriptor = usdhc_##n##_dma_descriptor,                                        \
 	.dma_descriptor_len = CONFIG_IMX_USDHC_DMA_BUFFER_SIZE / 4,
 #else
 #define IMX_USDHC_DMA_BUFFER_DEFINE(n)
 #define IMX_USDHC_DMA_BUFFER_INIT(n)
 #endif /* CONFIG_IMX_USDHC_DMA_SUPPORT */
 
-
-
-#define IMX_USDHC_INIT(n)							\
-	static void usdhc_##n##_irq_config_func(const struct device *dev)	\
-	{									\
-		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority),		\
-			imx_usdhc_isr, DEVICE_DT_INST_GET(n), 0);		\
-		irq_enable(DT_INST_IRQN(n));					\
-	}									\
-										\
-	PINCTRL_DT_INST_DEFINE(n);						\
-										\
-	static const struct usdhc_config usdhc_##n##_config = {			\
-		.base = (USDHC_Type *) DT_INST_REG_ADDR(n),			\
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-		.clock_subsys =							\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
-		.nusdhc = n,							\
-		.pwr_gpio = GPIO_DT_SPEC_INST_GET_OR(n, pwr_gpios, {0}),	\
-		.detect_gpio = GPIO_DT_SPEC_INST_GET_OR(n, cd_gpios, {0}),	\
-		.data_timeout = DT_INST_PROP(n, data_timeout),			\
-		.detect_dat3 = DT_INST_PROP(n, detect_dat3),			\
-		.detect_cd = DT_INST_PROP(n, detect_cd),			\
-		.no_180_vol = DT_INST_PROP(n, no_1_8_v),			\
-		.read_watermark = DT_INST_PROP(n, read_watermark),		\
-		.write_watermark = DT_INST_PROP(n, write_watermark),		\
-		.max_current_330 = DT_INST_PROP(n, max_current_330),		\
-		.max_current_180 = DT_INST_PROP(n, max_current_180),		\
-		.min_bus_freq = DT_INST_PROP(n, min_bus_freq),			\
-		.max_bus_freq = DT_INST_PROP(n, max_bus_freq),			\
-		.power_delay_ms = DT_INST_PROP(n, power_delay_ms),		\
-		.mmc_hs200_1_8v = DT_INST_PROP(n, mmc_hs200_1_8v),		\
-		.mmc_hs400_1_8v = DT_INST_PROP(n, mmc_hs400_1_8v),              \
-		.irq_config_func = usdhc_##n##_irq_config_func,			\
-		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
-	};									\
-										\
-										\
-	IMX_USDHC_DMA_BUFFER_DEFINE(n)						\
-										\
-	static struct usdhc_data usdhc_##n##_data = {				\
-		.card_present = false,						\
-		IMX_USDHC_DMA_BUFFER_INIT(n)					\
-	};									\
-										\
-	DEVICE_DT_INST_DEFINE(n,						\
-			&imx_usdhc_init,					\
-			NULL,							\
-			&usdhc_##n##_data,					\
-			&usdhc_##n##_config,					\
-			POST_KERNEL,						\
-			CONFIG_SDHC_INIT_PRIORITY,				\
-			&usdhc_api);
+#define IMX_USDHC_INIT(n)                                                                          \
+	static void usdhc_##n##_irq_config_func(const struct device *dev)                          \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), imx_usdhc_isr,              \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}                                                                                          \
+                                                                                                   \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
+                                                                                                   \
+	static const struct usdhc_config usdhc_##n##_config = {                                    \
+		.base = (USDHC_Type *)DT_INST_REG_ADDR(n),                                         \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),              \
+		.nusdhc = n,                                                                       \
+		.pwr_gpio = GPIO_DT_SPEC_INST_GET_OR(n, pwr_gpios, {0}),                           \
+		.detect_gpio = GPIO_DT_SPEC_INST_GET_OR(n, cd_gpios, {0}),                         \
+		.data_timeout = DT_INST_PROP(n, data_timeout),                                     \
+		.detect_dat3 = DT_INST_PROP(n, detect_dat3),                                       \
+		.detect_cd = DT_INST_PROP(n, detect_cd),                                           \
+		.no_180_vol = DT_INST_PROP(n, no_1_8_v),                                           \
+		.read_watermark = DT_INST_PROP(n, read_watermark),                                 \
+		.write_watermark = DT_INST_PROP(n, write_watermark),                               \
+		.max_current_330 = DT_INST_PROP(n, max_current_330),                               \
+		.max_current_180 = DT_INST_PROP(n, max_current_180),                               \
+		.min_bus_freq = DT_INST_PROP(n, min_bus_freq),                                     \
+		.max_bus_freq = DT_INST_PROP(n, max_bus_freq),                                     \
+		.power_delay_ms = DT_INST_PROP(n, power_delay_ms),                                 \
+		.mmc_hs200_1_8v = DT_INST_PROP(n, mmc_hs200_1_8v),                                 \
+		.mmc_hs400_1_8v = DT_INST_PROP(n, mmc_hs400_1_8v),                                 \
+		.irq_config_func = usdhc_##n##_irq_config_func,                                    \
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                       \
+	};                                                                                         \
+                                                                                                   \
+	IMX_USDHC_DMA_BUFFER_DEFINE(n)                                                             \
+                                                                                                   \
+	static struct usdhc_data usdhc_##n##_data = {.card_present = false,                        \
+						     IMX_USDHC_DMA_BUFFER_INIT(n)};                \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, &imx_usdhc_init, NULL, &usdhc_##n##_data, &usdhc_##n##_config,    \
+			      POST_KERNEL, CONFIG_SDHC_INIT_PRIORITY, &usdhc_api);
 
 DT_INST_FOREACH_STATUS_OKAY(IMX_USDHC_INIT)

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -375,6 +375,32 @@
 		status = "disabled";
 	};
 
+	usdhc1: usdhc@42850000 {
+		compatible = "nxp,imx-usdhc";
+		reg = <0x42850000 0x10000>;
+		interrupts = <GIC_SPI 86 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_USDHC1_CLK 0 0>;
+		max-current-330 = <1020>;
+		max-current-180 = <1020>;
+		max-bus-freq = <208000000>;
+		min-bus-freq = <400000>;
+		status = "disabled";
+	};
+
+	usdhc2: usdhc@42860000 {
+		compatible = "nxp,imx-usdhc";
+		reg = <0x42860000 0x10000>;
+		interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clocks = <&ccm IMX_CCM_USDHC2_CLK 0 0>;
+		max-current-330 = <1020>;
+		max-current-180 = <1020>;
+		max-bus-freq = <208000000>;
+		min-bus-freq = <400000>;
+		status = "disabled";
+	};
+
 	enet: enet@42890000 {
 		compatible = "nxp,enet1g";
 		reg = <0x42890000 DT_SIZE_K(64)>;

--- a/soc/nxp/imx/imx9/imx93/a55/soc.h
+++ b/soc/nxp/imx/imx9/imx93/a55/soc.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC_NXP_IMX_IMX93_A55_SOC_H_
+#define _SOC_NXP_IMX_IMX93_A55_SOC_H_
+
+
+#endif /* _SOC_NXP_IMX_IMX93_A55_SOC_H_ */


### PR DESCRIPTION
> imx usdhc driver updates: 

1. clang format the driver
2. include soc.h conditionally
3. enable MMIP mapping

> Enable USDHC support for imx93 Cortex-A Core platform

Depend on https://github.com/zephyrproject-rtos/hal_nxp/pull/524, it has been merged.
