### PR TITLE
modules: mbedtls: update to 3.6.3

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -70,10 +70,8 @@ The following sections provide detailed lists of changes by component.
 
 Security Vulnerability Related
 ******************************
-The following CVEs are addressed by this release:
 
-More detailed information can be found in:
-https://docs.zephyrproject.org/latest/security/vulnerabilities.html
+The following CVEs are addressed by this release:
 
 * :cve:`2025-1673` `Zephyr project bug tracker GHSA-jjhx-rrh4-j8mx
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-jjhx-rrh4-j8mx>`_
@@ -83,6 +81,9 @@ https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 
 * :cve:`2025-1675` `Zephyr project bug tracker GHSA-2m84-5hfw-m8v4
   <https://github.com/zephyrproject-rtos/zephyr/security/advisories/GHSA-2m84-5hfw-m8v4>`_
+
+More detailed information can be found in:
+https://docs.zephyrproject.org/latest/security/vulnerabilities.html
 
 API Changes
 ***********

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -40,7 +40,13 @@ The following sections provide detailed lists of changes by component.
 
 Security Vulnerability Related
 ******************************
+
 The following CVEs are addressed by this release:
+
+* :cve:`2025-27809` `TLS clients may unwittingly skip server authentication
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/>`_
+* :cve:`2025-27810` `Potential authentication bypass in TLS handshake
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-2/>`_
 
 More detailed information can be found in:
 https://docs.zephyrproject.org/latest/security/vulnerabilities.html
@@ -383,3 +389,6 @@ Other notable changes
 * Removed support for Nucleo WBA52CG board (``nucleo_wba52cg``) since it is NRND (Not Recommended
   for New Design) and it is not supported anymore in the STM32CubeWBA from version 1.1.0 (July 2023).
   The migration to :zephyr:board:`nucleo_wba55cg` (``nucleo_wba55cg``) is recommended instead.
+
+* Updated Mbed TLS to version 3.6.3 (from 3.6.2). The release notes can be found at:
+  https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3

--- a/west.yml
+++ b/west.yml
@@ -298,7 +298,7 @@ manifest:
       revision: 1ed1ddd881c3784049a92bb9fe37c38c6c74d998
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 3bc59adb8ca1ad0780192f206c5dc1cfad635c2b
+      revision: 5f889934359deccf421554c7045a8381ef75298f
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Pull in Mbed TLS 3.6.3, updated from 3.6.2.

More details regarding the Mbed TLS 3.6.3 release at: https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3