### PR TITLE
tests: Bluetooth: Tester: Add missing checks for tx in bcast

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -25,6 +25,7 @@
 #define LOG_MODULE_NAME bttester_bap_broadcast
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_BTTESTER_LOG_LEVEL);
 #include "btp/btp.h"
+#include "btp_bap_audio_stream.h"
 #include "btp_bap_broadcast.h"
 
 static K_SEM_DEFINE(sem_stream_stopped, 0U,
@@ -37,15 +38,14 @@ static struct btp_bap_broadcast_remote_source *broadcast_source_to_sync;
 /* A mask for the maximum BIS we can sync to. +1 since the BIS indexes start from 1. */
 static const uint32_t bis_index_mask = BIT_MASK(CONFIG_BT_BAP_BROADCAST_SNK_STREAM_COUNT + 1);
 #define PA_SYNC_INTERVAL_TO_TIMEOUT_RATIO 20 /* Set the timeout relative to interval */
-#define PA_SYNC_SKIP              5
-static struct bt_bap_bass_subgroup
-	delegator_subgroups[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
+#define PA_SYNC_SKIP                      5
+static struct bt_bap_bass_subgroup delegator_subgroups[CONFIG_BT_BAP_BASS_MAX_SUBGROUPS];
 
 static inline struct btp_bap_broadcast_stream *stream_bap_to_broadcast(struct bt_bap_stream *stream)
 {
 	return CONTAINER_OF(CONTAINER_OF(CONTAINER_OF(stream, struct bt_cap_stream, bap_stream),
-		struct btp_bap_audio_stream, cap_stream), struct btp_bap_broadcast_stream,
-		audio_stream);
+					 struct btp_bap_audio_stream, cap_stream),
+			    struct btp_bap_broadcast_stream, audio_stream);
 }
 
 static inline struct bt_bap_stream *stream_broadcast_to_bap(struct btp_bap_broadcast_stream *stream)
@@ -58,8 +58,8 @@ uint8_t btp_bap_broadcast_local_source_idx_get(struct btp_bap_broadcast_local_so
 	return ARRAY_INDEX(local_sources, source);
 }
 
-struct btp_bap_broadcast_local_source *btp_bap_broadcast_local_source_allocate(
-	uint32_t broadcast_id)
+struct btp_bap_broadcast_local_source *
+btp_bap_broadcast_local_source_allocate(uint32_t broadcast_id)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
 		if (local_sources[i].broadcast_id == broadcast_id) {
@@ -93,8 +93,8 @@ static int btp_bap_broadcast_local_source_free(struct btp_bap_broadcast_local_so
 	return 0;
 }
 
-struct btp_bap_broadcast_local_source *btp_bap_broadcast_local_source_from_src_id_get(
-	uint32_t source_id)
+struct btp_bap_broadcast_local_source *
+btp_bap_broadcast_local_source_from_src_id_get(uint32_t source_id)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
 		if (local_sources[i].source_id == source_id) {
@@ -107,8 +107,8 @@ struct btp_bap_broadcast_local_source *btp_bap_broadcast_local_source_from_src_i
 	return NULL;
 }
 
-static struct btp_bap_broadcast_local_source *btp_bap_broadcast_local_source_from_brcst_id_get(
-	uint32_t broadcast_id)
+static struct btp_bap_broadcast_local_source *
+btp_bap_broadcast_local_source_from_brcst_id_get(uint32_t broadcast_id)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(local_sources); i++) {
 		if (local_sources[i].broadcast_id == broadcast_id) {
@@ -135,7 +135,7 @@ static struct btp_bap_broadcast_remote_source *remote_broadcaster_alloc(void)
 }
 
 static struct btp_bap_broadcast_remote_source *remote_broadcaster_find(const bt_addr_le_t *addr,
-							       uint32_t broadcast_id)
+								       uint32_t broadcast_id)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
 		struct btp_bap_broadcast_remote_source *broadcaster = &remote_broadcast_sources[i];
@@ -149,8 +149,8 @@ static struct btp_bap_broadcast_remote_source *remote_broadcaster_find(const bt_
 	return NULL;
 }
 
-static struct btp_bap_broadcast_remote_source *remote_broadcaster_find_by_sink(
-	struct bt_bap_broadcast_sink *sink)
+static struct btp_bap_broadcast_remote_source *
+remote_broadcaster_find_by_sink(struct bt_bap_broadcast_sink *sink)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(remote_broadcast_sources); i++) {
 		struct btp_bap_broadcast_remote_source *broadcaster = &remote_broadcast_sources[i];
@@ -179,38 +179,44 @@ static void stream_started(struct bt_bap_stream *stream)
 {
 	struct btp_bap_broadcast_remote_source *broadcaster;
 	struct btp_bap_broadcast_stream *b_stream = stream_bap_to_broadcast(stream);
-	int err;
 
 	/* Callback called on transition to Streaming state */
 
 	LOG_DBG("Started stream %p", stream);
 
-	/* Start TX */
-	err = btp_bap_audio_stream_tx_register(&b_stream->audio_stream);
-	if (err != 0) {
-		LOG_ERR("Failed to register stream: %d", err);
+	if (btp_bap_audio_stream_can_send(&b_stream->audio_stream)) {
+		int err;
+		/* Start TX */
+
+		err = btp_bap_audio_stream_tx_register(&b_stream->audio_stream);
+		if (err != 0) {
+			LOG_ERR("Failed to register stream: %d", err);
+		}
+	} else {
+		b_stream->bis_synced = true;
+		broadcaster = &remote_broadcast_sources[b_stream->source_id];
+
+		btp_send_bis_synced_ev(&broadcaster->address, broadcaster->broadcast_id,
+				       b_stream->bis_id);
 	}
-
-	b_stream->bis_synced = true;
-	broadcaster = &remote_broadcast_sources[b_stream->source_id];
-
-	btp_send_bis_synced_ev(&broadcaster->address, broadcaster->broadcast_id, b_stream->bis_id);
 }
 
 static void stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 {
 	struct btp_bap_broadcast_stream *b_stream = stream_bap_to_broadcast(stream);
-	int err;
 
 	LOG_DBG("Stopped stream %p with reason 0x%02X", stream, reason);
 
-	/* Stop TX */
-	err = btp_bap_audio_stream_tx_unregister(&b_stream->audio_stream);
-	if (err != 0) {
-		LOG_ERR("Failed to unregister stream: %d", err);
+	if (btp_bap_audio_stream_can_send(&b_stream->audio_stream)) {
+		int err;
+		/* Stop TX */
+		err = btp_bap_audio_stream_tx_unregister(&b_stream->audio_stream);
+		if (err != 0) {
+			LOG_ERR("Failed to unregister stream: %d", err);
+		}
+	} else {
+		b_stream->bis_synced = false;
 	}
-
-	b_stream->bis_synced = false;
 
 	k_sem_give(&sem_stream_stopped);
 }
@@ -238,8 +244,7 @@ static void send_bis_stream_received_ev(const bt_addr_le_t *address, uint32_t br
 	tester_rsp_buffer_unlock();
 }
 
-static void stream_recv(struct bt_bap_stream *stream,
-			const struct bt_iso_recv_info *info,
+static void stream_recv(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
 			struct net_buf *buf)
 {
 	struct btp_bap_broadcast_remote_source *broadcaster;
@@ -269,8 +274,8 @@ static struct bt_bap_stream_ops stream_ops = {
 	.sent = btp_bap_audio_stream_sent_cb,
 };
 
-struct btp_bap_broadcast_stream *btp_bap_broadcast_stream_alloc(
-	struct btp_bap_broadcast_local_source *source)
+struct btp_bap_broadcast_stream *
+btp_bap_broadcast_stream_alloc(struct btp_bap_broadcast_local_source *source)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(source->streams); i++) {
 		struct btp_bap_broadcast_stream *stream = &source->streams[i];
@@ -298,7 +303,7 @@ static void remote_broadcaster_free(struct btp_bap_broadcast_remote_source *broa
 	}
 }
 
-static int setup_broadcast_source(uint8_t streams_per_subgroup,	uint8_t subgroups,
+static int setup_broadcast_source(uint8_t streams_per_subgroup, uint8_t subgroups,
 				  struct btp_bap_broadcast_local_source *source,
 				  struct bt_audio_codec_cfg *codec_cfg)
 {
@@ -310,7 +315,7 @@ static int setup_broadcast_source(uint8_t streams_per_subgroup,	uint8_t subgroup
 	struct bt_bap_broadcast_source_param create_param;
 
 	if (streams_per_subgroup * subgroups > CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT ||
-	    subgroups >	CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT) {
+	    subgroups > CONFIG_BT_BAP_BROADCAST_SRC_SUBGROUP_COUNT) {
 		return -EINVAL;
 	}
 
@@ -347,15 +352,13 @@ static int setup_broadcast_source(uint8_t streams_per_subgroup,	uint8_t subgroup
 		source->source_id, subgroups, subgroups * streams_per_subgroup);
 
 	if (source->bap_broadcast == NULL) {
-		err = bt_bap_broadcast_source_create(&create_param,
-						     &source->bap_broadcast);
+		err = bt_bap_broadcast_source_create(&create_param, &source->bap_broadcast);
 		if (err != 0) {
 			LOG_DBG("Unable to create broadcast source: %d", err);
 			return err;
 		}
 	} else {
-		err = bt_bap_broadcast_source_reconfig(source->bap_broadcast,
-						       &create_param);
+		err = bt_bap_broadcast_source_reconfig(source->bap_broadcast, &create_param);
 		if (err != 0) {
 			LOG_DBG("Unable to reconfig broadcast source: %d", err);
 			return err;
@@ -365,8 +368,8 @@ static int setup_broadcast_source(uint8_t streams_per_subgroup,	uint8_t subgroup
 	return 0;
 }
 
-uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
-				       void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len, void *rsp,
+				       uint16_t *rsp_len)
 {
 	struct bt_le_per_adv_param per_adv_param = *BT_BAP_PER_ADV_PARAM_BROADCAST_SLOW;
 	struct bt_le_adv_param ext_adv_param = *BT_BAP_ADV_PARAM_BROADCAST_SLOW;
@@ -384,8 +387,8 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 
 	struct btp_bap_broadcast_local_source *source;
 
-	uint32_t gap_settings = BIT(BTP_GAP_SETTINGS_DISCOVERABLE) |
-				BIT(BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
+	uint32_t gap_settings =
+		BIT(BTP_GAP_SETTINGS_DISCOVERABLE) | BIT(BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
 
 	NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
@@ -443,8 +446,8 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	base_ad[1].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
 	base_ad[1].data = CONFIG_BT_DEVICE_NAME;
 
-	err = tester_gap_create_adv_instance(&ext_adv_param, BTP_GAP_ADDR_TYPE_IDENTITY,
-					     base_ad, ARRAY_SIZE(base_ad), NULL, 0, &gap_settings,
+	err = tester_gap_create_adv_instance(&ext_adv_param, BTP_GAP_ADDR_TYPE_IDENTITY, base_ad,
+					     ARRAY_SIZE(base_ad), NULL, 0, &gap_settings,
 					     &source->ext_adv);
 	if (err != 0) {
 		LOG_DBG("Failed to create extended advertising instance: %d", err);
@@ -479,8 +482,8 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len,
-					  void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len, void *rsp,
+					  uint16_t *rsp_len)
 {
 	struct bt_le_per_adv_param per_adv_param =
 		*BT_LE_PER_ADV_PARAM(BT_GAP_MS_TO_PER_ADV_INTERVAL(150),
@@ -498,8 +501,7 @@ uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len,
 	const struct btp_bap_broadcast_source_setup_v2_cmd *cp = cmd;
 	struct btp_bap_broadcast_source_setup_v2_rp *rp = rsp;
 
-	if ((cmd_len < sizeof(*cp)) ||
-	    (cmd_len != sizeof(*cp) + cp->cc_ltvs_len)) {
+	if ((cmd_len < sizeof(*cp)) || (cmd_len != sizeof(*cp) + cp->cc_ltvs_len)) {
 		return BTP_STATUS_FAILED;
 	}
 
@@ -507,8 +509,8 @@ uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len,
 
 	struct btp_bap_broadcast_local_source *source;
 
-	uint32_t gap_settings = BIT(BTP_GAP_SETTINGS_DISCOVERABLE) |
-				BIT(BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
+	uint32_t gap_settings =
+		BIT(BTP_GAP_SETTINGS_DISCOVERABLE) | BIT(BTP_GAP_SETTINGS_EXTENDED_ADVERTISING);
 
 	NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 	NET_BUF_SIMPLE_DEFINE(base_buf, 128);
@@ -558,8 +560,8 @@ uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len,
 	base_ad[1].data_len = sizeof(CONFIG_BT_DEVICE_NAME) - 1;
 	base_ad[1].data = CONFIG_BT_DEVICE_NAME;
 
-	err = tester_gap_create_adv_instance(&ext_adv_param, BTP_GAP_ADDR_TYPE_IDENTITY,
-					     base_ad, ARRAY_SIZE(base_ad), NULL, 0, &gap_settings,
+	err = tester_gap_create_adv_instance(&ext_adv_param, BTP_GAP_ADDR_TYPE_IDENTITY, base_ad,
+					     ARRAY_SIZE(base_ad), NULL, 0, &gap_settings,
 					     &source->ext_adv);
 	if (err != 0) {
 		LOG_DBG("Failed to create extended advertising instance: %d", err);
@@ -594,8 +596,8 @@ uint8_t btp_bap_broadcast_source_setup_v2(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_source_release(const void *cmd, uint16_t cmd_len,
-					 void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_source_release(const void *cmd, uint16_t cmd_len, void *rsp,
+					 uint16_t *rsp_len)
 {
 	int err;
 	const struct btp_bap_broadcast_source_release_cmd *cp = cmd;
@@ -621,8 +623,7 @@ uint8_t btp_bap_broadcast_source_release(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_adv_start(const void *cmd, uint16_t cmd_len,
-				    void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_adv_start(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
 	const struct btp_bap_broadcast_adv_start_cmd *cp = cmd;
@@ -655,8 +656,7 @@ uint8_t btp_bap_broadcast_adv_start(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_adv_stop(const void *cmd, uint16_t cmd_len,
-				   void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_adv_stop(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
 	const struct btp_bap_broadcast_adv_stop_cmd *cp = cmd;
@@ -680,8 +680,8 @@ uint8_t btp_bap_broadcast_adv_stop(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_VAL(err);
 }
 
-uint8_t btp_bap_broadcast_source_start(const void *cmd, uint16_t cmd_len,
-				       void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_source_start(const void *cmd, uint16_t cmd_len, void *rsp,
+				       uint16_t *rsp_len)
 {
 	int err;
 	const struct btp_bap_broadcast_source_start_cmd *cp = cmd;
@@ -709,8 +709,8 @@ uint8_t btp_bap_broadcast_source_start(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_source_stop(const void *cmd, uint16_t cmd_len,
-				      void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_source_stop(const void *cmd, uint16_t cmd_len, void *rsp,
+				      uint16_t *rsp_len)
 {
 	int err;
 	const struct btp_bap_broadcast_source_stop_cmd *cp = cmd;
@@ -754,8 +754,8 @@ static int broadcast_sink_reset(void)
 	return 0;
 }
 
-static void btp_send_baa_found_ev(const bt_addr_le_t *address, uint32_t broadcast_id,
-				  uint8_t sid, uint16_t interval)
+static void btp_send_baa_found_ev(const bt_addr_le_t *address, uint32_t broadcast_id, uint8_t sid,
+				  uint16_t interval)
 {
 	struct btp_bap_baa_found_ev ev;
 
@@ -796,8 +796,8 @@ static bool baa_check(struct bt_data *data, void *user_data)
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 
-	LOG_DBG("Found BAA with ID 0x%06X, addr %s, sid 0x%02X, interval 0x%04X",
-		broadcast_id, le_addr, info->sid, info->interval);
+	LOG_DBG("Found BAA with ID 0x%06X, addr %s, sid 0x%02X, interval 0x%04X", broadcast_id,
+		le_addr, info->sid, info->interval);
 
 	btp_send_baa_found_ev(info->addr, broadcast_id, info->sid, info->interval);
 
@@ -838,8 +838,7 @@ static void btp_send_bis_found_ev(const bt_addr_le_t *address, uint32_t broadcas
 	ev->cc_ltvs_len = codec_cfg->data_len;
 	memcpy(ev->cc_ltvs, codec_cfg->data, ev->cc_ltvs_len);
 
-	tester_event(BTP_SERVICE_ID_BAP, BTP_BAP_EV_BIS_FOUND, ev,
-		     sizeof(*ev) + ev->cc_ltvs_len);
+	tester_event(BTP_SERVICE_ID_BAP, BTP_BAP_EV_BIS_FOUND, ev, sizeof(*ev) + ev->cc_ltvs_len);
 
 	tester_rsp_buffer_free();
 	tester_rsp_buffer_unlock();
@@ -912,8 +911,8 @@ static void base_recv_cb(struct bt_bap_broadcast_sink *sink, const struct bt_bap
 		return;
 	}
 
-	LOG_DBG("Received BASE: broadcast sink %p subgroups %u",
-		sink, bt_bap_base_get_subgroup_count(base));
+	LOG_DBG("Received BASE: broadcast sink %p subgroups %u", sink,
+		bt_bap_base_get_subgroup_count(base));
 
 	ret = bt_bap_base_get_pres_delay(base);
 	if (ret < 0) {
@@ -1031,9 +1030,8 @@ static struct bt_le_per_adv_sync_cb bap_pa_sync_cb = {
 	.synced = bap_pa_sync_synced_cb,
 };
 
-static void btp_send_pas_sync_req_ev(struct bt_conn *conn, uint8_t src_id,
-				     uint8_t advertiser_sid, uint32_t broadcast_id,
-				     bool past_avail, uint16_t pa_interval)
+static void btp_send_pas_sync_req_ev(struct bt_conn *conn, uint8_t src_id, uint8_t advertiser_sid,
+				     uint32_t broadcast_id, bool past_avail, uint16_t pa_interval)
 {
 	struct btp_bap_pa_sync_req_ev ev;
 
@@ -1056,8 +1054,9 @@ static void btp_send_scan_delegator_found_ev(struct bt_conn *conn)
 	tester_event(BTP_SERVICE_ID_BAP, BTP_BAP_EV_SCAN_DELEGATOR_FOUND, &ev, sizeof(ev));
 }
 
-static void btp_send_broadcast_receive_state_ev(struct bt_conn *conn,
-	const struct bt_bap_scan_delegator_recv_state *state)
+static void
+btp_send_broadcast_receive_state_ev(struct bt_conn *conn,
+				    const struct bt_bap_scan_delegator_recv_state *state)
 {
 	struct btp_bap_broadcast_receive_state_ev *ev;
 	size_t len;
@@ -1065,7 +1064,8 @@ static void btp_send_broadcast_receive_state_ev(struct bt_conn *conn,
 
 	tester_rsp_buffer_lock();
 	tester_rsp_buffer_allocate(sizeof(*ev) + CONFIG_BT_BAP_BASS_MAX_SUBGROUPS *
-		sizeof(struct bt_bap_bass_subgroup), (uint8_t **)&ev);
+							 sizeof(struct bt_bap_bass_subgroup),
+				   (uint8_t **)&ev);
 
 	if (conn) {
 		bt_addr_le_copy(&ev->address, bt_conn_get_dst(conn));
@@ -1102,7 +1102,7 @@ static void btp_send_broadcast_receive_state_ev(struct bt_conn *conn,
 
 static int pa_sync_past(struct bt_conn *conn, uint16_t sync_timeout)
 {
-	struct bt_le_per_adv_sync_transfer_param param = { 0 };
+	struct bt_le_per_adv_sync_transfer_param param = {0};
 	int err;
 
 	param.skip = PA_SYNC_SKIP;
@@ -1270,8 +1270,8 @@ static struct bt_bap_scan_delegator_cb scan_delegator_cbs = {
 	.bis_sync_req = bis_sync_req_cb,
 };
 
-uint8_t btp_bap_broadcast_sink_setup(const void *cmd, uint16_t cmd_len,
-				     void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_sink_setup(const void *cmd, uint16_t cmd_len, void *rsp,
+				     uint16_t *rsp_len)
 {
 	int err;
 
@@ -1298,8 +1298,8 @@ uint8_t btp_bap_broadcast_sink_setup(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_sink_release(const void *cmd, uint16_t cmd_len,
-				       void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_sink_release(const void *cmd, uint16_t cmd_len, void *rsp,
+				       uint16_t *rsp_len)
 {
 	int err;
 
@@ -1310,8 +1310,8 @@ uint8_t btp_bap_broadcast_sink_release(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_VAL(err);
 }
 
-uint8_t btp_bap_broadcast_scan_start(const void *cmd, uint16_t cmd_len,
-				     void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_scan_start(const void *cmd, uint16_t cmd_len, void *rsp,
+				     uint16_t *rsp_len)
 {
 	int err;
 
@@ -1327,8 +1327,7 @@ uint8_t btp_bap_broadcast_scan_start(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_scan_stop(const void *cmd, uint16_t cmd_len,
-				    void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_scan_stop(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
 
@@ -1344,8 +1343,7 @@ uint8_t btp_bap_broadcast_scan_stop(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_sink_sync(const void *cmd, uint16_t cmd_len,
-				    void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_sink_sync(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
 	struct bt_conn *conn;
@@ -1409,8 +1407,7 @@ uint8_t btp_bap_broadcast_sink_sync(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_sink_stop(const void *cmd, uint16_t cmd_len,
-				    void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_sink_stop(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
 {
 	int err;
 	struct btp_bap_broadcast_remote_source *broadcaster;
@@ -1445,8 +1442,8 @@ uint8_t btp_bap_broadcast_sink_stop(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_sink_bis_sync(const void *cmd, uint16_t cmd_len,
-					void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_sink_bis_sync(const void *cmd, uint16_t cmd_len, void *rsp,
+					uint16_t *rsp_len)
 {
 	int err;
 	struct btp_bap_broadcast_remote_source *broadcaster;
@@ -1501,8 +1498,9 @@ static void bap_broadcast_assistant_scan_cb(const struct bt_le_scan_recv_info *i
 		info->interval, info->sid, info->rssi);
 }
 
-static void bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
-	const struct bt_bap_scan_delegator_recv_state *state)
+static void
+bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
+				      const struct bt_bap_scan_delegator_recv_state *state)
 {
 	LOG_DBG("err: %d", err);
 
@@ -1561,8 +1559,8 @@ static struct bt_bap_broadcast_assistant_cb broadcast_assistant_cb = {
 	.rem_src = bap_broadcast_assistant_rem_src_cb,
 };
 
-uint8_t btp_bap_broadcast_discover_scan_delegators(const void *cmd, uint16_t cmd_len,
-						   void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_discover_scan_delegators(const void *cmd, uint16_t cmd_len, void *rsp,
+						   uint16_t *rsp_len)
 {
 	int err;
 	struct bt_conn *conn;
@@ -1580,8 +1578,8 @@ uint8_t btp_bap_broadcast_discover_scan_delegators(const void *cmd, uint16_t cmd
 	return BTP_STATUS_VAL(err);
 }
 
-uint8_t btp_bap_broadcast_assistant_scan_start(const void *cmd, uint16_t cmd_len,
-					       void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_assistant_scan_start(const void *cmd, uint16_t cmd_len, void *rsp,
+					       uint16_t *rsp_len)
 {
 	int err;
 	struct bt_conn *conn;
@@ -1599,8 +1597,8 @@ uint8_t btp_bap_broadcast_assistant_scan_start(const void *cmd, uint16_t cmd_len
 	return BTP_STATUS_VAL(err);
 }
 
-uint8_t btp_bap_broadcast_assistant_scan_stop(const void *cmd, uint16_t cmd_len,
-					      void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_assistant_scan_stop(const void *cmd, uint16_t cmd_len, void *rsp,
+					      uint16_t *rsp_len)
 {
 	int err;
 	struct bt_conn *conn;
@@ -1618,14 +1616,14 @@ uint8_t btp_bap_broadcast_assistant_scan_stop(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_VAL(err);
 }
 
-uint8_t btp_bap_broadcast_assistant_add_src(const void *cmd, uint16_t cmd_len,
-					    void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_assistant_add_src(const void *cmd, uint16_t cmd_len, void *rsp,
+					    uint16_t *rsp_len)
 {
 	int err;
 	const uint8_t *ptr;
 	struct bt_conn *conn;
 	const struct btp_bap_add_broadcast_src_cmd *cp = cmd;
-	struct bt_bap_broadcast_assistant_add_src_param param = { 0 };
+	struct bt_bap_broadcast_assistant_add_src_param param = {0};
 
 	LOG_DBG("");
 
@@ -1672,8 +1670,8 @@ uint8_t btp_bap_broadcast_assistant_add_src(const void *cmd, uint16_t cmd_len,
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_assistant_remove_src(const void *cmd, uint16_t cmd_len,
-					       void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_assistant_remove_src(const void *cmd, uint16_t cmd_len, void *rsp,
+					       uint16_t *rsp_len)
 {
 	int err;
 	struct bt_conn *conn;
@@ -1691,14 +1689,14 @@ uint8_t btp_bap_broadcast_assistant_remove_src(const void *cmd, uint16_t cmd_len
 	return BTP_STATUS_VAL(err);
 }
 
-uint8_t btp_bap_broadcast_assistant_modify_src(const void *cmd, uint16_t cmd_len,
-					       void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_assistant_modify_src(const void *cmd, uint16_t cmd_len, void *rsp,
+					       uint16_t *rsp_len)
 {
 	int err;
 	const uint8_t *ptr;
 	struct bt_conn *conn;
 	const struct btp_bap_modify_broadcast_src_cmd *cp = cmd;
-	struct bt_bap_broadcast_assistant_mod_src_param param = { 0 };
+	struct bt_bap_broadcast_assistant_mod_src_param param = {0};
 
 	LOG_DBG("");
 
@@ -1738,8 +1736,8 @@ uint8_t btp_bap_broadcast_assistant_modify_src(const void *cmd, uint16_t cmd_len
 	return BTP_STATUS_VAL(err);
 }
 
-uint8_t btp_bap_broadcast_assistant_set_broadcast_code(const void *cmd, uint16_t cmd_len,
-						       void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_assistant_set_broadcast_code(const void *cmd, uint16_t cmd_len, void *rsp,
+						       uint16_t *rsp_len)
 {
 	int err;
 	struct bt_conn *conn;
@@ -1761,8 +1759,8 @@ uint8_t btp_bap_broadcast_assistant_set_broadcast_code(const void *cmd, uint16_t
 	return BTP_STATUS_SUCCESS;
 }
 
-uint8_t btp_bap_broadcast_assistant_send_past(const void *cmd, uint16_t cmd_len,
-					      void *rsp, uint16_t *rsp_len)
+uint8_t btp_bap_broadcast_assistant_send_past(const void *cmd, uint16_t cmd_len, void *rsp,
+					      uint16_t *rsp_len)
 {
 	int err;
 	uint16_t service_data;


### PR DESCRIPTION
The stream_started and stream_stopped callbacks are called for both broadcast sink and source in the BT Tester, and thus they should check if the stream can send before attempting to register it for TX (which would otherwise fail).