### PR TITLE
lib: tls_credentials: return size even if too big

### DIFF
--- a/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials_trusted.c
@@ -401,6 +401,7 @@ int tls_credential_get(sec_tag_t tag, enum tls_credential_type type,
 
 	if (info.size > *credlen) {
 		ret = -EFBIG;
+		*credlen = info.size;
 		goto cleanup;
 	}
 


### PR DESCRIPTION
The simple backend returns the size of the credential, even if it is too big.
The secure backend should do the same,
our libraries depend on this behaviour.