### PR TITLE
Add board target selector to only show one table of "supported features" at a time

### DIFF
--- a/doc/_extensions/zephyr/domain/static/css/board.css
+++ b/doc/_extensions/zephyr/domain/static/css/board.css
@@ -105,6 +105,79 @@
     }
 }
 
+.board-target-selector {
+    margin-bottom: 1em;
+    padding: 15px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    position: relative;
+}
+
+.board-target-selector > div {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.static-value {
+    padding: 5px 0px;
+    color: var(--body-color);
+    font-family: var(--monospace-font-family);
+    font-size: 0.9em;
+}
+
+.separator {
+    font-size: 16px;
+    font-weight: bold;
+    margin: 0 4px;
+}
+
+.board-target-selector select {
+    background-color: var(--input-background-color);
+    color: var(--body-color);
+    border-radius: 4px;
+    font-family: var(--monospace-font-family);
+    font-size: 0.9em;
+    box-shadow: none;
+    transition: none;
+}
+
+.board-target-selector select:focus {
+    border-color: var(--input-focus-border-color);
+}
+
+.copy-button {
+    background: transparent;
+    border: 1px solid var(--input-border-color);
+    border-radius: 4px;
+    padding: 4px 8px;
+    cursor: pointer;
+    font-size: 0.8em;
+    color: var(--body-color);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    transition: all 0.2s ease;
+}
+
+.copy-button:hover {
+    background: var(--input-background-color);
+    border-color: var(--input-focus-border-color);
+}
+
+.copy-button.copied {
+    background: var(--admonition-note-title-background-color);
+    color: var(--admonition-note-title-color);
+    border-color: var(--admonition-note-title-color);
+}
+
+.copy-button svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
 
 .hardware-features {
     th {

--- a/doc/_extensions/zephyr/domain/static/js/board.js
+++ b/doc/_extensions/zephyr/domain/static/js/board.js
@@ -3,4 +3,246 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* file intentionally left blank */
+(() => {
+  // SVG icons for copy button
+  const COPY_ICON = `<svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>`;
+  const CHECK_ICON = `<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>`;
+
+  // DOM element creation helper
+  const createElement = (tag, className, text) => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    if (text) element.textContent = text;
+    return element;
+  };
+
+  // Target parsing helper
+  const parseTargetString = (targetString) => {
+    const [boardWithRev, ...qualifiers] = targetString.split('/');
+    const [board, revision] = boardWithRev.split('@');
+    return {
+      board: board || '',
+      revision: revision || '',
+      qualifier: qualifiers.join('/') || ''
+    };
+  };
+
+  // Select element creation helper
+  const createSelect = (options, selectedValue) => {
+    const select = createElement('select');
+    options.sort().forEach(value => {
+      const option = createElement('option', null, value);
+      option.value = value;
+      option.selected = (value === selectedValue);
+      select.appendChild(option);
+    });
+    return select;
+  };
+
+  // Main initialization function
+  const initializeBoardSelector = () => {
+    const container = document.querySelector('.container[id$="-hw-features"]');
+    if (!container) return console.error('Container element not found');
+
+    const components = {
+      boards: new Set([board_data.board_name]),
+      revisions: new Set(),
+      qualifiers: new Set()
+    };
+
+    board_data.targets.forEach(target => {
+      const { revision, qualifier } = parseTargetString(target);
+      if (revision) components.revisions.add(revision);
+      if (qualifier) components.qualifiers.add(qualifier);
+    });
+
+    const initialValues = parseTargetString(board_data.targets[0]);
+    if (board_data.revision_default) {
+      initialValues.revision = board_data.revision_default;
+    }
+
+    const selector = createElement('div', 'board-target-selector');
+    selector.appendChild(createElement('div', 'static-value', initialValues.board));
+
+    // Add revision selector if needed
+    let revisionSelect;
+    if (components.revisions.size > 0) {
+      selector.appendChild(createElement('div', 'separator', '@'));
+      revisionSelect = createSelect(
+        Array.from(components.revisions),
+        initialValues.revision
+      );
+      selector.appendChild(revisionSelect);
+    }
+
+    // Add qualifier selector or static value
+    let qualifierSelect;
+    if (components.qualifiers.size > 0) {
+      selector.appendChild(createElement('div', 'separator', '/'));
+      if (components.qualifiers.size === 1) {
+        selector.appendChild(createElement('div', 'static-value', initialValues.qualifier));
+      } else {
+        qualifierSelect = createSelect(
+          Array.from(components.qualifiers),
+          null
+        );
+        selector.appendChild(qualifierSelect);
+      }
+    }
+
+    // Add copy button
+    const copyButton = createElement('button', 'copy-button');
+    copyButton.innerHTML = COPY_ICON;
+    copyButton.addEventListener('click', handleCopyButtonClick(
+      initialValues,
+      revisionSelect,
+      qualifierSelect,
+      copyButton
+    ));
+    selector.appendChild(copyButton);
+
+    // Insert selector into DOM and set up event listeners
+    container.parentNode.insertBefore(selector, container);
+    selector.querySelectorAll('select').forEach(select => {
+      select.addEventListener('change', () => {
+        updateSelectOptions(initialValues, revisionSelect, qualifierSelect);
+        updateDisplayedTable(revisionSelect, qualifierSelect);
+
+      });
+    });
+
+    // Initial display setup
+    initializeDisplay();
+    // updateDisplayedTable(revisionSelect, qualifierSelect);
+  };
+
+  // Copy button click handler
+  const handleCopyButtonClick = (initialValues, revisionSelect, qualifierSelect, button) => async () => {
+    try {
+      const target = buildTargetString(initialValues, revisionSelect, qualifierSelect);
+      await navigator.clipboard.writeText(target);
+
+      button.classList.add('copied');
+      button.innerHTML = CHECK_ICON;
+
+      setTimeout(() => {
+        button.classList.remove('copied');
+        button.innerHTML = COPY_ICON;
+      }, 1000);
+    } catch (error) {
+      console.error('Failed to copy text:', error);
+    }
+  };
+
+  // Build target string from current selections
+  const buildTargetString = (initialValues, revisionSelect, qualifierSelect) => {
+    const parts = [initialValues.board];
+
+    if (revisionSelect) {
+      parts.push(`@${revisionSelect.value}`);
+    } else if (initialValues.revision) {
+      parts.push(`@${initialValues.revision}`);
+    }
+
+    if (qualifierSelect) {
+      parts.push(`/${qualifierSelect.value}`);
+    } else if (initialValues.qualifier) {
+      parts.push(`/${initialValues.qualifier}`);
+    }
+
+    return parts.join('');
+  };
+
+  // Update displayed table based on selections
+  const updateDisplayedTable = (revisionSelect, qualifierSelect) => {
+    const currentTarget = buildTargetString(
+      parseTargetString(board_data.targets[0]),
+      revisionSelect,
+      qualifierSelect
+    );
+
+    console.log(currentTarget);
+
+    document.querySelectorAll('section[id$="-hw-features-section"]').forEach(section => {
+      // Find the matching target in board_data.targets
+      const isMatch = section.id.replace(/${board_data.name}/).replace(/-hw-features-section$/, '').endsWith(currentTarget);
+
+      const table = document.querySelector(`table[id="${section.id.replace('-section', '-table')}"]`);
+      const wrapper = table?.closest('.wy-table-responsive');
+
+
+      if (table) table.style.display = isMatch ? 'table' : 'none';
+      if (wrapper) wrapper.style.display = isMatch ? 'block' : 'none';
+    });
+  };
+
+  // Initial display setup
+  const initializeDisplay = () => {
+    document.querySelectorAll('section[id$="-hw-features-section"]').forEach(section => section.style.display = 'none');
+    document.querySelectorAll('table.hardware-features').forEach((table, index) => {
+      const wrapper = table.closest('.wy-table-responsive');
+      table.style.display = index === 0 ? 'table' : 'none';
+      if (wrapper) wrapper.style.display = index === 0 ? 'block' : 'none';
+    });
+    updateDisplayedTable(revisionSelect, qualifierSelect);
+  };
+
+  // Update select options based on valid combinations
+  const updateSelectOptions = (initialValues, revisionSelect, qualifierSelect) => {
+    if (revisionSelect) {
+      const currentBoard = initialValues.board;
+      const validRevisions = new Set();
+
+      // Find valid revisions for current board
+      board_data.targets.forEach(target => {
+        const { board, revision } = parseTargetString(target);
+        if (board === currentBoard && revision) {
+          validRevisions.add(revision);
+        }
+      });
+
+      // Update revision select options
+      Array.from(revisionSelect.options).forEach(option => {
+        option.disabled = !validRevisions.has(option.value);
+        if (option.disabled && option.selected) {
+          // If current selection is invalid, select first valid option
+          const firstValid = Array.from(revisionSelect.options).find(opt => !opt.disabled);
+          if (firstValid) firstValid.selected = true;
+        }
+      });
+    }
+
+    if (qualifierSelect) {
+      const currentBoard = initialValues.board;
+      const currentRevision = revisionSelect ? revisionSelect.value : initialValues.revision;
+      const validQualifiers = new Set();
+
+      // Find valid qualifiers for current board and revision
+      board_data.targets.forEach(target => {
+        const { board, revision, qualifier } = parseTargetString(target);
+        if (board === currentBoard &&
+          (!revision || revision === currentRevision) &&
+          qualifier) {
+          validQualifiers.add(qualifier);
+        }
+      });
+
+      // Update qualifier select options
+      Array.from(qualifierSelect.options).forEach(option => {
+        option.disabled = !validQualifiers.has(option.value);
+        if (option.disabled && option.selected) {
+          // If current selection is invalid, select first valid option
+          const firstValid = Array.from(qualifierSelect.options).find(opt => !opt.disabled);
+          if (firstValid) firstValid.selected = true;
+        }
+      });
+    }
+  };
+
+  // Start initialization when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeBoardSelector);
+  } else {
+    initializeBoardSelector();
+  }
+})();

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -325,6 +325,7 @@ def get_catalog(generate_hw_features=False):
             "vendor": vendor,
             "archs": list(archs),
             "socs": list(socs),
+            "revision_default": board.revision_default,
             "supported_features": supported_features,
             "image": guess_image(board),
         }

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -138,7 +138,7 @@ def gather_board_devicetrees(twister_out_dir):
                 revision = board_info.get('revision', '')
 
                 board_target = board_name
-                if revision:
+                if revision is not None:
                     board_target = f"{board_target}@{revision}"
                 if qualifier:
                     board_target = f"{board_target}/{qualifier}"

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -138,10 +138,10 @@ def gather_board_devicetrees(twister_out_dir):
                 revision = board_info.get('revision', '')
 
                 board_target = board_name
-                if qualifier:
-                    board_target = f"{board_name}/{qualifier}"
                 if revision:
                     board_target = f"{board_target}@{revision}"
+                if qualifier:
+                    board_target = f"{board_target}/{qualifier}"
 
                 with open(edt_pickle_file, 'rb') as f:
                     edt = pickle.load(f)

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -12,6 +12,7 @@
      /* Use system font stacks for better performance (no Web fonts required) */
      --system-font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
      --header-font-family: Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif;
+     --monospace-font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace;
  }
 
 body,


### PR DESCRIPTION
This show a nice widget to switch between the various board targets and see their respective list of supported features.

The original HTML content of the page is preserved and JavaScript code "patches" the page on-the-fly. This is so that the actual HTML content (that e.g. search engines see) is complete and indexable (as well as to provide useful information for folks who might have JavaScript disabled altogether).

https://github.com/user-attachments/assets/41f03782-0d38-4b58-9855-97618d66fc3d

https://builds.zephyrproject.io/zephyr/pr/87725/docs/boards/index.html --> this is the preview for this PR (done in a different branch as it requires patching the doc build process so as to have a "full" catalog)