### PR TITLE
drivers: udc_ambiq: fix compilation issue after dwc2 header removal

### DIFF
--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -403,16 +403,16 @@ static int udc_ambiq_test_mode(const struct device *dev, const uint8_t mode, con
 	struct udc_ambiq_data *priv = udc_get_private(dev);
 
 	switch (mode) {
-	case USB_DWC2_DCTL_TSTCTL_TESTJ:
+	case USB_SFS_TEST_MODE_J:
 		am_usb_test_mode = AM_HAL_USB_TEST_J;
 		break;
-	case USB_DWC2_DCTL_TSTCTL_TESTK:
+	case USB_SFS_TEST_MODE_K:
 		am_usb_test_mode = AM_HAL_USB_TEST_K;
 		break;
-	case USB_DWC2_DCTL_TSTCTL_TESTSN:
+	case USB_SFS_TEST_MODE_SE0_NAK:
 		am_usb_test_mode = AM_HAL_USB_TEST_SE0_NAK;
 		break;
-	case USB_DWC2_DCTL_TSTCTL_TESTPM:
+	case USB_SFS_TEST_MODE_PACKET:
 		am_usb_test_mode = AM_HAL_USB_TEST_PACKET;
 		break;
 	default:

--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -136,6 +136,13 @@ static inline bool usb_reqtype_is_to_device(const struct usb_setup_packet *setup
 #define USB_SFS_REMOTE_WAKEUP		0x01
 #define USB_SFS_TEST_MODE		0x02
 
+/** USB Test Mode Selectors defined in spec. Table 9-7 */
+#define USB_SFS_TEST_MODE_J		0x01
+#define USB_SFS_TEST_MODE_K		0x02
+#define USB_SFS_TEST_MODE_SE0_NAK	0x03
+#define USB_SFS_TEST_MODE_PACKET	0x04
+#define USB_SFS_TEST_MODE_FORCE_ENABLE	0x05
+
 /** Bits used for GetStatus response defined in spec. Figure 9-4 */
 #define USB_GET_STATUS_SELF_POWERED	BIT(0)
 #define USB_GET_STATUS_REMOTE_WAKEUP	BIT(1)


### PR DESCRIPTION
udc_ambiq was using USB test mode definition in dwc2 header, which the include was removed, hence compilation now fails.
This PR is to fix the compilation error for udc_ambiq.c