### PR TITLE
bluetooth: classic: Fix remote name resolving with multiple devices

### DIFF
--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -48,7 +48,7 @@ struct bt_br_discovery_priv {
 	/** Page scan repetition mode */
 	uint8_t pscan_rep_mode;
 	/** Resolving remote name*/
-	bool resolving;
+	uint8_t resolve_state;
 };
 
 /** @brief BR/EDR discovery result structure */

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -24,6 +24,12 @@ LOG_MODULE_REGISTER(bt_br);
 
 #define RSSI_INVALID 127
 
+enum __packed resolve_name_state {
+	RESOLVE_REMOTE_NAME_PENDING,
+	RESOLVE_REMOTE_NAME_RESOLVING,
+	RESOLVE_REMOTE_NAME_RESOLVED,
+};
+
 struct bt_br_discovery_result *discovery_results;
 static size_t discovery_results_size;
 static size_t discovery_results_count;
@@ -327,11 +333,10 @@ void bt_br_discovery_reset(void)
 	discovery_results_count = 0;
 }
 
-static void report_discovery_results(void)
+static bool check_request_name(void)
 {
-	bool resolving_names = false;
 	int i;
-	struct bt_br_discovery_cb *listener, *next;
+	bool resolving_names = false;
 
 	for (i = 0; i < discovery_results_count; i++) {
 		struct bt_br_discovery_priv *priv;
@@ -342,16 +347,37 @@ static void report_discovery_results(void)
 			continue;
 		}
 
-		if (request_name(&discovery_results[i].addr, priv->pscan_rep_mode,
-				 priv->clock_offset)) {
+		if (priv->resolve_state != RESOLVE_REMOTE_NAME_PENDING) {
 			continue;
 		}
 
-		priv->resolving = true;
+		if (request_name(&discovery_results[i].addr, priv->pscan_rep_mode,
+				 priv->clock_offset)) {
+			priv->resolve_state = RESOLVE_REMOTE_NAME_RESOLVED;
+			continue;
+		}
+
+		priv->resolve_state = RESOLVE_REMOTE_NAME_RESOLVING;
 		resolving_names = true;
+		break;
 	}
 
-	if (resolving_names) {
+	return resolving_names;
+}
+
+static void report_discovery_results(void)
+{
+	int i;
+	struct bt_br_discovery_cb *listener, *next;
+
+	for (i = 0; i < discovery_results_count; i++) {
+		struct bt_br_discovery_priv *priv;
+
+		priv = &discovery_results[i]._priv;
+		priv->resolve_state = RESOLVE_REMOTE_NAME_PENDING;
+	}
+
+	if (check_request_name()) {
 		return;
 	}
 
@@ -511,7 +537,6 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf)
 	struct bt_br_discovery_priv *priv;
 	int eir_len = 240;
 	uint8_t *eir;
-	int i;
 	struct bt_br_discovery_cb *listener, *next;
 
 	result = get_result_slot(&evt->bdaddr, RSSI_INVALID);
@@ -520,7 +545,7 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf)
 	}
 
 	priv = &result->_priv;
-	priv->resolving = false;
+	priv->resolve_state = RESOLVE_REMOTE_NAME_RESOLVED;
 
 	if (evt->status) {
 		goto check_names;
@@ -572,15 +597,9 @@ void bt_hci_remote_name_request_complete(struct net_buf *buf)
 	}
 
 check_names:
-	/* if still waiting for names */
-	for (i = 0; i < discovery_results_count; i++) {
-		struct bt_br_discovery_priv *dpriv;
-
-		dpriv = &discovery_results[i]._priv;
-
-		if (dpriv->resolving) {
-			return;
-		}
+	/* if still need to request name */
+	if (check_request_name()) {
+		return;
 	}
 
 	/* all names resolved, report discovery results */
@@ -982,7 +1001,7 @@ int bt_br_discovery_stop(void)
 
 		priv = &discovery_results[i]._priv;
 
-		if (!priv->resolving) {
+		if (priv->resolve_state != RESOLVE_REMOTE_NAME_RESOLVING) {
 			continue;
 		}
 


### PR DESCRIPTION
The error occur when discoverying br devices and need to send request_name for many found devices.
In system work queue task, bt_hci_inquiry_complete-> report_discovery_results is called, then request_name is called for all the found devices. The controller gives HCI_Remote_Name_Request_Complete event for every name request result and one buf is allocated from hci_rx_pool to save HCI_Remote_Name_Request_Complete. When system work queue task is blocked to call request_name for every device, many HCI_Remote_Name_Request_Complete are received for the already sent request_name, it uses up all the buf of hci_rx_pool, then the bt_rx_thread task is blocked to get buf from hci_rx_pool when next HCI_Remote_Name_Request_Complete is received, meanwhile the next request_name send hci cmd and wait the result, but the hci status/complete event can't be received because the bt_rx_thread is blocked and bt_uart_isr is kept in the state to receive last
HCI_Remote_Name_Request_Complete, then bt_dev.ncmd_sem is not released, then the next request_name send hci cmd again, but the bt_dev.ncmd_sem is invalid, then bt_hci_cmd_send_sync fail and assert.

resolve it by requesting name one by one.