### PR TITLE
drivers: bluetooth: h4: Free RX buffer upon reset

### DIFF
--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -193,6 +193,11 @@ static inline void copy_hdr(struct h4_data *h4)
 
 static void reset_rx(struct h4_data *h4)
 {
+	if (h4->rx.buf) {
+		net_buf_unref(h4->rx.buf);
+		h4->rx.buf = NULL;
+	}
+
 	h4->rx.type = BT_HCI_H4_NONE;
 	h4->rx.remaining = 0U;
 	h4->rx.have_hdr = false;


### PR DESCRIPTION
There are cases where reset_rx() is called when rx.buf is set (e.g. when the buffer was too small to receive the incoming packet). Be sure to free the buffer, so that it wont get reused for the next packet (which might require a buffer from a different pool).