### PR TITLE
scripts: west: sign: Add support for image signing for Silabs SiWx91x

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4338a/board.cmake
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/board.cmake
@@ -1,8 +1,14 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
+# Set the flash file based on signing is enabled or not.
 
+if(CONFIG_SIWX91X_SILABS_OTA_SIGN_ENABLE OR CONFIG_SIWX91X_SILABS_OTA_MIC_ENABLE OR CONFIG_SIWX91X_SILABS_OTA_ENCRYPT_ENABLE)
+    set(FLASH_FILE ${PROJECT_BINARY_DIR}/${KERNEL_NAME}_secure.bin.rps)
+else()
+    set(FLASH_FILE ${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME}.rps)
+endif()
 board_runner_args(silabs_commander "--device=SiWG917M111GTBA" "--file-type=bin"
-    "--file=${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME}.rps")
+    "--file=${FLASH_FILE}")
 include(${ZEPHYR_BASE}/boards/common/silabs_commander.board.cmake)
 
 # It is not possible to load/flash a firmware using JLink, but it is possible to

--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -58,3 +58,58 @@ both are used, the command-line arguments go last.
 
 .. _rimage:
    https://github.com/thesofproject/rimage
+
+silabs_commander
+***************
+
+Signing involves a number of "wrapper" scripts stacked on top of each other: ``west
+flash`` invokes ``west build`` which invokes ``cmake`` and ``ninja`` which invokes
+``west sign`` which invokes ``imgtool`` or ``rimage`` or `silabs_commander`_.
+
+The ``silabs_commander`` tool is used to apply sign or MIC or encrypt binaries for Silicon
+Labs devices. It is invoked by ``west sign`` or ``west build`` when the ``sign.tool``
+configuration is set to ``silabs_commander``. The tool requires a configuration file
+that specifies the signing parameters, such as the key files. The configuration file
+can be specified in the ``project config`` file and defined in the ``soc Kconfig``
+file. Here is an example of a ``samples/example/prj.conf`` file for signing with 
+``silabs_commander``:
+.. code-block:: ini
+
+   # Configuration for enabling MIC with silabs_commander
+   CONFIG_SIWX91X_SILABS_OTA_MIC_ENABLE = n or y
+
+   # Configuration for enabling encryption with silabs_commander
+   CONFIG_SIWX91X_SILABS_OTA_ENCRYPT_ENABLE = n or y
+
+   # Configuration for enabling signing with silabs_commander
+   CONFIG_SIWX91X_SILABS_OTA_SIGN_ENABLE = n or y
+
+   # Configuration for OTA encryption key with silabs_commander
+   CONFIG_SIWX91X_OTA_ENCRYPT_KEY = "ota_encryption_key in hex format"
+
+   # Configuration for OTA signing key with silabs_commander
+   CONFIG_SIWX91X_OTA_SIGN_KEY = "ota_signing_key file path"
+
+The ``silabs_commander`` tool will read the configuration file and use the specified
+parameters to sign or MIC or encrypt the binary. The secured binary will be saved to the
+specified output file. When using ``west sign``, the tool will automatically read the 
+configuration file and use the specified parameters to sign or MIC or encrypt the binary.
+The command can be run as follows:
+.. code-block:: console
+
+   west sign --tool silabs_commander or
+   west build -b <board> example/path --pristine
+
+This will invoke the ``silabs_commander`` tool with the specified configuration file and
+sign or MIC or encrypt the binary according to the parameters defined in the configuration file.
+.. note::
+   The ``silabs_commander`` tool is specific to Silicon Labs devices and may not be
+   applicable for other platforms. Ensure that you are using the correct signing tool
+   for your target device.
+.. note::
+   The ``silabs_commander`` tool supports various options for security, such as MIC,
+   encryption, and signing. You can specify these options in the configuration file
+   to customize the signing process according to your requirements. Refer to the
+   ``silabs_commander`` documentation for more details on the available options and
+   how to use them effectively.
+   "https://www.silabs.com/documents/public/user-guides/ug574-siwx917-soc-manufacturing-utility-user-guide.pdf"

--- a/soc/silabs/silabs_siwx91x/CMakeLists.txt
+++ b/soc/silabs/silabs_siwx91x/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+include(west)  # Add this at the top or before using ${WEST}
+
 add_subdirectory(siwg917)
 
 # Necessary to not overwrite NWP Firmware
@@ -12,3 +14,12 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     ${KERNEL_BIN_NAME}
     ${KERNEL_BIN_NAME}.rps
 )
+
+# Custom signing with Silicon Labs Commander
+if(CONFIG_SIWX91X_SILABS_OTA_SIGN_ENABLE OR CONFIG_SIWX91X_SILABS_OTA_MIC_ENABLE OR CONFIG_SIWX91X_SILABS_OTA_ENCRYPT_ENABLE)
+    # Necessary to invoke west sign after build
+    set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+        COMMAND ${WEST} sign -t silabs_commander --build-dir ${CMAKE_BINARY_DIR} --sbin ${PROJECT_BINARY_DIR}/${KERNEL_NAME}_signed.bin.rps
+        DEPENDS zephyr_final
+    )
+endif()

--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -28,3 +28,39 @@ config SIWX91X_NWP_INIT_PRIORITY
 	  Wi-Fi and crypto.
 
 endif # SOC_FAMILY_SILABS_SIWX91X
+
+if SOC_FAMILY_SILABS_SIWX91X
+config SIWX91X_SILABS_OTA_SIGN_ENABLE
+	bool "Silicon Labs Commander Signing Support"
+	depends on BUILD_OUTPUT_BIN
+	help
+	  Activates signing of Zephyr binary with Silicon Labs Commander during build process.
+	  For more information refer this
+	  "https://www.silabs.com/documents/public/user-guides/ug574-siwx917-soc-manufacturing-utility-user-guide.pdf"
+
+config SIWX91X_SILABS_OTA_MIC_ENABLE
+	bool "Silicon Labs Commander MIC Support"
+	depends on BUILD_OUTPUT_BIN
+	help
+	  Activates mic of Zephyr binary with Silicon Labs Commander during build process.
+	  For more information refer this
+	  "https://www.silabs.com/documents/public/user-guides/ug574-siwx917-soc-manufacturing-utility-user-guide.pdf"
+
+config SIWX91X_SILABS_OTA_ENCRYPT_ENABLE
+	bool "Silicon Labs Commander Encryption Support"
+	depends on BUILD_OUTPUT_BIN
+	help
+	  Activates encryption of Zephyr binary with Silicon Labs Commander during build process.
+	  For more information refer this
+	  "https://www.silabs.com/documents/public/user-guides/ug574-siwx917-soc-manufacturing-utility-user-guide.pdf"
+
+config SIWX91X_OTA_ENCRYPT_KEY
+	string "OTA Key for Encryption."
+	help
+	  Specifies Over the Air key (hex) for encryption with Silicon Labs Commander.
+
+config SIWX91X_OTA_SIGN_KEY
+	string "Private Key Path for Signing."
+	help
+	  Path to private key file for signing with Silicon Labs Commander.
+endif


### PR DESCRIPTION
Added changes to automate the signing of zephyr security using customtool during the west build process.