### PR TITLE
tests: coredump: Call k_panic() directly for mpfs_icicle board

### DIFF
--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -32,6 +32,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *pEsf)
  */
 __no_optimization void func_3(uint32_t *addr)
 {
+	/* clang-format off */
 #if defined(CONFIG_BOARD_M2GL025_MIV) || \
 	defined(CONFIG_BOARD_HIFIVE1) || \
 	defined(CONFIG_BOARD_HIFIVE_UNLEASHED) || \
@@ -42,6 +43,7 @@ __no_optimization void func_3(uint32_t *addr)
 	defined(CONFIG_SOC_FAMILY_INTEL_ISH) || \
 	defined(CONFIG_SOC_FAMILY_INTEL_ADSP) || \
 	defined(CONFIG_SOC_FAMILY_OPENHWGROUP_CVA6)
+	/* clang-format on */
 	ARG_UNUSED(addr);
 	/* Call k_panic() directly so Renode doesn't pause execution.
 	 * Needed on ADSP as well, since null pointer derefence doesn't

--- a/tests/subsys/debug/coredump/src/main.c
+++ b/tests/subsys/debug/coredump/src/main.c
@@ -37,6 +37,7 @@ __no_optimization void func_3(uint32_t *addr)
 	defined(CONFIG_BOARD_HIFIVE1) || \
 	defined(CONFIG_BOARD_HIFIVE_UNLEASHED) || \
 	defined(CONFIG_BOARD_HIFIVE_UNMATCHED) || \
+	defined(CONFIG_BOARD_MPFS_ICICLE) || \
 	defined(CONFIG_BOARD_LONGAN_NANO) || \
 	defined(CONFIG_BOARD_QEMU_XTENSA) || \
 	defined(CONFIG_BOARD_RISCV32_VIRTUAL) || \


### PR DESCRIPTION
`mpfs_icicle` timeouts on this test similarly to other boards simulated in Renode. Null pointer dereference doesn't trigger a CPU fault during simulation. Instead, call k_panic() directly.

See also https://github.com/zephyrproject-rtos/zephyr/commit/a28d5df5c643614042ca04caf65fcb274c1e956a.

It is necessary for https://github.com/zephyrproject-rtos/zephyr/pull/87676 which enables mpfs_icicle simulation in Renode.