### PR TITLE
bluetooth: host: smp: define a new option to allow unauthenticated pairing

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -585,6 +585,17 @@ config BT_SMP_DISABLE_LEGACY_JW_PASSKEY
 	  This option disables Just Works and Passkey legacy pairing methods to
 	  increase security.
 
+config BT_SMP_ALLOW_UNAUTH_OVERWRITE_AUTHENTICATED
+	bool "Allow unauthenticated pairing for previous authenticated paired device"
+	help
+	  This option allows all unauthenticated pairing attempts made by the
+	  peer where an authenticated bond already exists.
+	  This would enable cases where an attacker could copy the peer device
+	  address to connect and start an unauthenticated pairing procedure
+	  to replace the existing bond. When this option is disabled in order
+	  to create a new bond the old bond has to be explicitly deleted with
+	  bt_unpair.
+
 config BT_SMP_ALLOW_UNAUTH_OVERWRITE
 	bool "Allow unauthenticated pairing for paired device"
 	help

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -647,7 +647,10 @@ static bool update_keys_check(struct bt_smp *smp, struct bt_keys *keys)
 	}
 
 	if ((keys->flags & BT_KEYS_AUTHENTICATED) &&
-	     smp->method == JUST_WORKS) {
+		smp->method == JUST_WORKS) {
+		if (IS_ENABLED(CONFIG_BT_SMP_ALLOW_UNAUTH_OVERWRITE_AUTHENTICATED)) {
+			return true;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
The new option BT_SMP_ALLOW_UNAUTH_OVERWRITE_AUTHENTICATED allows all unauthenticated pairing attempts made by the peer where an authenticated bond already exists.