### PR TITLE
Bluetooth: Classic: L2CAP: support reject response

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -215,7 +215,6 @@ NET_BUF_POOL_FIXED_DEFINE(br_tx_pool, CONFIG_BT_L2CAP_TX_BUF_COUNT,
 struct bt_l2cap_br {
 	/* The channel this context is associated with */
 	struct bt_l2cap_br_chan	chan;
-	uint8_t			info_ident;
 	/*
 	 * 2.1 CHANNEL IDENTIFIERS in
 	 * BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part A.
@@ -1646,11 +1645,11 @@ static void l2cap_br_get_info(struct bt_l2cap_br *l2cap, uint16_t info_type)
 	buf = bt_l2cap_create_pdu(&br_sig_pool, 0);
 
 	atomic_set_bit(l2cap->chan.flags, L2CAP_FLAG_SIG_INFO_PENDING);
-	l2cap->info_ident = l2cap_br_get_ident();
+	l2cap->chan.ident = l2cap_br_get_ident();
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
 	hdr->code = BT_L2CAP_INFO_REQ;
-	hdr->ident = l2cap->info_ident;
+	hdr->ident = l2cap->chan.ident;
 	hdr->len = sys_cpu_to_le16(sizeof(*info));
 
 	info = net_buf_add(buf, sizeof(*info));
@@ -1710,7 +1709,7 @@ static int l2cap_br_info_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 		goto done;
 	}
 
-	if (ident != l2cap->info_ident) {
+	if (ident != l2cap->chan.ident) {
 		LOG_WRN("Idents mismatch");
 		err = -EINVAL;
 		goto done;
@@ -1769,7 +1768,7 @@ static int l2cap_br_info_rsp(struct bt_l2cap_br *l2cap, uint8_t ident,
 	}
 done:
 	atomic_set_bit(l2cap->chan.flags, L2CAP_FLAG_SIG_INFO_DONE);
-	l2cap->info_ident = 0U;
+	l2cap->chan.ident = 0U;
 	return err;
 }
 
@@ -2198,6 +2197,8 @@ static void l2cap_br_conf(struct bt_l2cap_chan *chan, bool init)
 	(void)memset(conf, 0, sizeof(*conf));
 
 	conf->dcid = sys_cpu_to_le16(BR_CHAN(chan)->tx.cid);
+	/* Set the ident for the signaling request */
+	BR_CHAN(chan)->ident = hdr->ident;
 	/*
 	 * Add MTU option if app set non default BR/EDR L2CAP MTU,
 	 * otherwise sent empty configuration data meaning default MTU
@@ -3507,6 +3508,11 @@ static void l2cap_br_conf_rsp(struct bt_l2cap_br *l2cap, uint8_t ident, uint16_t
 	}
 
 	br_chan = BR_CHAN(chan);
+	if (br_chan->ident != ident) {
+		LOG_WRN("ident mismatch (%u != %u)!", br_chan->ident, ident);
+		return;
+	}
+	br_chan->ident = 0;
 
 	/* Release RTX work since got the response */
 	k_work_cancel_delayable(&br_chan->rtx_work);
@@ -4495,6 +4501,9 @@ int bt_l2cap_br_chan_disconnect(struct bt_l2cap_chan *chan)
 	req->dcid = sys_cpu_to_le16(br_chan->tx.cid);
 	req->scid = sys_cpu_to_le16(br_chan->rx.cid);
 
+	/* Set the ident for the signaling request */
+	br_chan->ident = hdr->ident;
+
 	l2cap_br_chan_send_req(br_chan, buf, L2CAP_BR_DISCONN_TIMEOUT);
 	bt_l2cap_br_chan_set_state(chan, BT_L2CAP_DISCONNECTING);
 
@@ -4523,6 +4532,12 @@ static void l2cap_br_disconn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident, struc
 		LOG_WRN("No dcid 0x%04x channel found", dcid);
 		return;
 	}
+
+	if (chan->ident != ident) {
+		LOG_WRN("ident mismatch (%u != %u)!", chan->ident, ident);
+		return;
+	}
+	chan->ident = 0;
 
 	bt_l2cap_br_chan_del(&chan->chan);
 }
@@ -4611,6 +4626,9 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan, u
 	req->psm = sys_cpu_to_le16(psm);
 	req->scid = sys_cpu_to_le16(BR_CHAN(chan)->rx.cid);
 
+	/* Set the ident for the signaling request */
+	BR_CHAN(chan)->ident = hdr->ident;
+
 	l2cap_br_chan_send_req(BR_CHAN(chan), buf, L2CAP_BR_CONN_TIMEOUT);
 
 	return 0;
@@ -4643,6 +4661,11 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident, struct n
 	}
 
 	br_chan = BR_CHAN(chan);
+	if (br_chan->ident != ident) {
+		LOG_WRN("ident mismatch (%u != %u)!", br_chan->ident, ident);
+		return;
+	}
+	br_chan->ident = 0;
 
 	/* Release RTX work since got the response */
 	k_work_cancel_delayable(&br_chan->rtx_work);
@@ -4837,6 +4860,9 @@ static void l2cap_br_conn_pend(struct bt_l2cap_chan *chan, uint8_t status)
 		req = net_buf_add(buf, sizeof(*req));
 		req->psm = sys_cpu_to_le16(BR_CHAN(chan)->psm);
 		req->scid = sys_cpu_to_le16(BR_CHAN(chan)->rx.cid);
+
+		/* Set the ident for the signaling request */
+		BR_CHAN(chan)->ident = hdr->ident;
 
 		l2cap_br_chan_send_req(BR_CHAN(chan), buf, L2CAP_BR_CONN_TIMEOUT);
 	}


### PR DESCRIPTION
* Bluetooth: Classic: L2CAP: Discard the response with a invalid `ident`

In current implementation, the `ident` of the command response is not checked whether it is same as the `ident` sent by the L2CAP command.

Keep the `ident` of the command. If the received `ident` of the command response is not aligned with the `ident` of the command, discard the response silently. Or, clear the saved `ident`.

* Bluetooth: Classic: L2CAP: Support `L2CAP_COMMAND_REJECT_RSP`

In current implementation, when receiving the L2CAP frame `L2CAP_COMMAND_REJECT_RSP` if the L2CAP is working as client role, the L2CAP frame `L2CAP_COMMAND_REJECT_RSP` will be sent by the L2CAP client incorrectly.

When the command response `L2CAP_COMMAND_REJECT_RSP` is received, find the channel of the command request according to the received `ident`. If the channel is found, try to disconnect the channel. If fail to disconnect the channel, remove and delete the channel.
