### PR TITLE
doc: tests: drivers: spi_loopback: frdm_rw612 add comment

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/frdm_rw612.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_rw612.overlay
@@ -1,9 +1,10 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Short MOSI and MISO externally using header J1 pins 2 and 4 */
 &flexcomm1 {
 	slow@0 {
 		compatible = "test-spi-loopback-slow";


### PR DESCRIPTION
Document the signals to short to pass this test.