### PR TITLE
samples: drivers: mbox: Add comment to check IRQ configuration

### DIFF
--- a/samples/drivers/mbox/boards/nrf54h20dk_nrf54h20_cpuapp_cpuflpr.overlay
+++ b/samples/drivers/mbox/boards/nrf54h20dk_nrf54h20_cpuapp_cpuflpr.overlay
@@ -13,6 +13,10 @@
 
 &cpuapp_bellboard {
 	status = "okay";
+	/* When other cpuapp_bellboard channel is selected for RX,
+	 * make sure it's enabled in the interrupt mask.
+	 * See `nordic,interrupt-mapping` property.
+	 */
 };
 
 &cpuflpr_vevif {

--- a/samples/drivers/mbox/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.overlay
+++ b/samples/drivers/mbox/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.overlay
@@ -13,6 +13,10 @@
 
 &cpuapp_bellboard {
 	status = "okay";
+	/* When other cpuapp_bellboard channel is selected for RX,
+	 * make sure it's enabled in the interrupt mask.
+	 * See `nordic,interrupt-mapping` property.
+	 */
 };
 
 &cpuppr_vevif {

--- a/samples/drivers/mbox/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/samples/drivers/mbox/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -17,4 +17,8 @@
 
 &cpurad_bellboard {
 	status = "okay";
+	/* When other cpurad_bellboard channel is selected for RX,
+	 * make sure it's enabled in the interrupt mask.
+	 * See `nordic,interrupt-mapping` property.
+	 */
 };

--- a/samples/drivers/mbox/remote/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/mbox/remote/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -13,6 +13,10 @@
 
 &cpuapp_bellboard {
 	status = "okay";
+	/* When other cpurad_bellboard channel is selected for RX,
+	 * make sure it's enabled in the interrupt mask.
+	 * See `nordic,interrupt-mapping` property.
+	 */
 };
 
 &cpurad_bellboard {


### PR DESCRIPTION
The mbox sample uses bellboard events enabled by default in the nRF54H20dk board definition.
Thus, it's not easily obvious that IRQ bitmask must be aligned when other mbox/bellboard channel is used.

Add comment to the nRF54H20 overlays.
Inform that bellboard channel used for RX must be enabled in the 'nordic,interrupt-mapping' property.