### PR TITLE
samples: code_relocation_nocopy: fix stm32 flash size info

### DIFF
--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -38,14 +38,14 @@
 
 #define EXTFLASH_NODE	DT_INST(0, st_stm32_qspi_nor)
 #define EXTFLASH_ADDR	DT_REG_ADDR(DT_INST(0, st_stm32_qspi_nor))
-#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_ospi_nor))
+#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_qspi_nor))
 
 #elif defined(CONFIG_STM32_MEMMAP) && DT_NODE_EXISTS(DT_INST(0, st_stm32_xspi_nor))
 /* On stm32 XSPI, external flash is mapped in XIP region at address given by the reg property. */
 
 #define EXTFLASH_NODE	DT_INST(0, st_stm32_xspi_nor)
 #define EXTFLASH_ADDR	DT_REG_ADDR(DT_INST(0, st_stm32_xspi_nor))
-#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_ospi_nor))
+#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_xspi_nor))
 
 #elif defined(CONFIG_FLASH_MSPI_NOR) && defined(CONFIG_SOC_NRF54H20_CPUAPP)
 


### PR DESCRIPTION
Fix typos in stm32 flash sizes value introduced by commit 0e1ffc7bebb8 ("samples: code_relocation_nocopy: update macro to get flash size").

Fixes: 0e1ffc7bebb80d55ed5cd4b4cc22c221a2c36298