### PR TITLE
drivers: ethernet: stm32: remove hal api v1 ptp code

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -82,19 +82,20 @@ config ETH_STM32_HW_CHECKSUM
 	  performances.
 	  See reference manual for more information on this feature.
 
-if SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
-
-config PTP_CLOCK_STM32_HAL
+menuconfig PTP_CLOCK_STM32_HAL
 	bool "STM32 HAL PTP clock driver support"
 	default y
 	depends on PTP_CLOCK || NET_L2_PTP
+	depends on ETH_STM32_HAL_API_V2
+	depends on SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
 	help
 	  Enable STM32 PTP clock support.
+
+if PTP_CLOCK_STM32_HAL
 
 config ETH_STM32_HAL_PTP_CLOCK_SRC_HZ
 	int "Frequency of the clock source for the PTP timer"
 	default 50000000
-	depends on PTP_CLOCK_STM32_HAL
 	help
 	  Set the frequency in Hz sourced to the PTP timer.
 	  If the value is set properly, the timer will be accurate.
@@ -102,27 +103,24 @@ config ETH_STM32_HAL_PTP_CLOCK_SRC_HZ
 config ETH_STM32_HAL_PTP_CLOCK_ADJ_MIN_PCT
 	int "Lower bound of clock frequency adjustment (in percent)"
 	default 90
-	depends on PTP_CLOCK_STM32_HAL
 	help
 	  Specifies lower bound of PTP clock rate adjustment.
 
 config ETH_STM32_HAL_PTP_CLOCK_ADJ_MAX_PCT
 	int "Upper bound of clock frequency adjustment (in percent)"
 	default 110
-	depends on PTP_CLOCK_STM32_HAL
 	help
 	  Specifies upper bound of PTP clock rate adjustment.
 
 config ETH_STM32_HAL_PTP_CLOCK_INIT_PRIO
 	int
 	default 85
-	depends on PTP_CLOCK_STM32_HAL
 	help
 	  STM32 PTP Clock initialization priority level. There is
 	  a dependency from the network stack that this device
 	  initializes before network stack (NET_INIT_PRIO).
 
-endif # SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || SOC_SERIES_STM32H5X
+endif # PTP_CLOCK_STM32_HAL
 
 config ETH_STM32_MULTICAST_FILTER
 	bool "Multicast hash filter support"


### PR DESCRIPTION
Only STM32F1X and STM32F2X are using the hal api v1,
both of these soc don't support ptp, so ptp support
for hal api v1 can be dropped.