### PR TITLE
boards: arduino: add twister file for Portenta rev 4.10

### DIFF
--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_1_0_0.yaml
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_1_0_0.yaml
@@ -1,0 +1,18 @@
+identifier: arduino_portenta_h7@1.0.0/stm32h747xx/m7
+name: Arduino Portenta H7 (M7) rev. 1.0.0
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+ram: 512
+flash: 1024
+supported:
+  - gpio
+  - netif:eth
+  - i2c
+  - spi
+  - qspi
+  - memc
+  - usb_device
+vendor: arduino

--- a/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_4_10_0.yaml
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7_stm32h747xx_m7_4_10_0.yaml
@@ -1,5 +1,5 @@
-identifier: arduino_portenta_h7/stm32h747xx/m7
-name: Arduino Portenta H7 (M7)
+identifier: arduino_portenta_h7@4.10.0/stm32h747xx/m7
+name: Arduino Portenta H7 (M7) rev. 4.10.0
 type: mcu
 arch: arm
 toolchain:
@@ -14,5 +14,6 @@ supported:
   - spi
   - qspi
   - memc
+  - usb_cdc
   - usb_device
 vendor: arduino


### PR DESCRIPTION
Add ability to target rev 4.10 of the M7 core of Arduino Portenta in Twister