### PR TITLE
MPS3 Corstone update and armfvp support for non secure images

### DIFF
--- a/boards/arm/mps2/board.cmake
+++ b/boards/arm/mps2/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 
 if(CONFIG_BOARD_MPS2_AN385)
   set(SUPPORTED_EMU_PLATFORMS qemu armfvp)
@@ -48,6 +48,8 @@ elseif(CONFIG_BOARD_MPS2_AN521_CPU0 OR CONFIG_BOARD_MPS2_AN521_CPU0_NS OR CONFIG
     # TF-M (Secure) & Zephyr (Non Secure) image (when running
     # in-tree tests).
     set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex")
+
+    set(ARMFVP_FLAGS ${ARMFVP_FLAGS} -a ${APPLICATION_BINARY_DIR}/zephyr/tfm_merged.hex)
   elseif(CONFIG_OPENAMP)
     set(QEMU_EXTRA_FLAGS "-device;loader,file=${REMOTE_ZEPHYR_DIR}/zephyr.elf")
   elseif(CONFIG_BOARD_MPS2_AN521_CPU1)

--- a/boards/arm/mps3/Kconfig.defconfig
+++ b/boards/arm/mps3/Kconfig.defconfig
@@ -1,5 +1,5 @@
 # Copyright (c) 2018-2021 Linaro Limited
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_MPS3_CORSTONE300_AN547 || BOARD_MPS3_CORSTONE300_AN552 || BOARD_MPS3_CORSTONE300_FVP || BOARD_MPS3_CORSTONE310_AN555 || BOARD_MPS3_CORSTONE310_FVP
@@ -18,5 +18,15 @@ config UART_INTERRUPT_DRIVEN
 	default y
 
 endif # SERIAL
+
+if ROMSTART_RELOCATION_ROM && (BOARD_MPS3_CORSTONE310_AN555 || BOARD_MPS3_CORSTONE310_FVP)
+
+config ROMSTART_REGION_ADDRESS
+	default $(dt_nodelabel_reg_addr_hex,itcm)
+
+config ROMSTART_REGION_SIZE
+	default $(dt_nodelabel_reg_size_hex,itcm,0,k)
+
+endif
 
 endif

--- a/boards/arm/mps3/board.cmake
+++ b/boards/arm/mps3/board.cmake
@@ -1,5 +1,5 @@
 # Copyright (c) 2021 Linaro
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 # The FVP variant must be used to enable Ethos-U55 NPU support, but QEMU also
@@ -52,6 +52,8 @@ if (CONFIG_BUILD_WITH_TFM)
   # TF-M (Secure) & Zephyr (Non Secure) image (when running
   # in-tree tests).
   set(QEMU_KERNEL_OPTION "-device;loader,file=${CMAKE_BINARY_DIR}/zephyr/tfm_merged.hex")
+
+  set(ARMFVP_FLAGS ${ARMFVP_FLAGS} -a ${APPLICATION_BINARY_DIR}/zephyr/tfm_merged.hex)
 endif()
 
 # FVP Parameters

--- a/boards/arm/mps3/board.cmake
+++ b/boards/arm/mps3/board.cmake
@@ -37,6 +37,10 @@ elseif(CONFIG_BOARD_MPS3_CORSTONE310_FVP OR CONFIG_BOARD_MPS3_CORSTONE310_FVP_NS
     set(ARMFVP_FLAGS
       # default is '0x11000000' but should match cpu<i>.INITSVTOR which is 0.
       -C mps3_board.sse300.iotss3_systemcontrol.INITSVTOR_RST=0
+      # default is 0x8, this change is needed since we split flash into itcm
+      # and sram and it reduces the number of available mpu regions causing a
+      # few MPU tests to fail.
+      -C cpu0.MPU_S=16
     )
   endif()
 endif()

--- a/boards/arm/mps3/mps3_corstone300_an547.yaml
+++ b/boards/arm/mps3/mps3_corstone300_an547.yaml
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2019-2021 Linaro Limited
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,6 +20,7 @@ toolchain:
 supported:
   - gpio
 testing:
+  default: true
   ignore_tags:
     - drivers
     - bluetooth

--- a/boards/arm/mps3/mps3_corstone300_fvp.yaml
+++ b/boards/arm/mps3/mps3_corstone300_fvp.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: mps3/corstone300/fvp
@@ -16,6 +16,7 @@ toolchain:
 supported:
   - gpio
 testing:
+  default: true
   ignore_tags:
     - bluetooth
     - net

--- a/boards/arm/mps3/mps3_corstone310_an555.dts
+++ b/boards/arm/mps3/mps3_corstone310_an555.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,8 +20,8 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram = &dtcm;
-		zephyr,flash = &itcm;
+		zephyr,sram = &sram;
+		zephyr,flash = &isram;
 	};
 
 	cpus {

--- a/boards/arm/mps3/mps3_corstone310_an555_defconfig
+++ b/boards/arm/mps3/mps3_corstone310_an555_defconfig
@@ -1,4 +1,4 @@
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_RUNTIME_NMI=y
@@ -15,3 +15,5 @@ CONFIG_SERIAL=y
 
 # Build a Secure firmware image
 CONFIG_TRUSTED_EXECUTION_SECURE=y
+# ROMSTART_REGION address and size are defined in Kconfig.defconfig
+CONFIG_ROMSTART_RELOCATION_ROM=y

--- a/boards/arm/mps3/mps3_corstone310_fvp.dts
+++ b/boards/arm/mps3/mps3_corstone310_fvp.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,8 +20,8 @@
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
-		zephyr,sram = &dtcm;
-		zephyr,flash = &itcm;
+		zephyr,sram = &sram;
+		zephyr,flash = &isram;
 	};
 
 	cpus {

--- a/boards/arm/mps3/mps3_corstone310_fvp.yaml
+++ b/boards/arm/mps3/mps3_corstone310_fvp.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: mps3/corstone310/fvp
@@ -16,6 +16,7 @@ toolchain:
 supported:
   - gpio
 testing:
+  default: true
   ignore_tags:
     - drivers
     - bluetooth

--- a/boards/arm/mps3/mps3_corstone310_fvp_defconfig
+++ b/boards/arm/mps3/mps3_corstone310_fvp_defconfig
@@ -1,4 +1,4 @@
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_RUNTIME_NMI=y
@@ -15,3 +15,5 @@ CONFIG_SERIAL=y
 
 # Build a Secure firmware image
 CONFIG_TRUSTED_EXECUTION_SECURE=y
+# ROMSTART_REGION address and size are defined in Kconfig.defconfig
+CONFIG_ROMSTART_RELOCATION_ROM=y

--- a/cmake/emu/armfvp.cmake
+++ b/cmake/emu/armfvp.cmake
@@ -53,9 +53,12 @@ elseif(CONFIG_ARMV8_A_NS)
     --data cluster0.cpu0="${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}"@0x88000000
     )
 else()
-  set(ARMFVP_FLAGS ${ARMFVP_FLAGS}
-    -a ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
+  string(FIND "${ARMFVP_FLAGS}" " -a " ARMFVP_APPARG_POS)
+  if(${ARMFVP_APPARG_POS} EQUAL -1)
+    set(ARMFVP_FLAGS ${ARMFVP_FLAGS}
+      -a ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}
     )
+  endif()
 endif()
 
 if(CONFIG_ETH_SMSC91X)

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -119,6 +119,15 @@ ZTEST(vector_table, test_arm_irq_vector_table)
 #endif
 	}
 
+	/*
+	 * It is recommended to have a DSB followed by ISB while
+	 * enabling interrupts using NVIC. Also without this, the
+	 * test fails in scenarios where CONFIG_ROMSTART_RELOCATION_ROM is
+	 * enabled e.g. MPS3 Corstone310.
+	 */
+	__DSB(); /* Ensure write to NVIC completes before continuing */
+	__ISB(); /* Ensure that IRQ is executed */
+
 	zassert_false((k_sem_take(&sem[0], K_NO_WAIT) || k_sem_take(&sem[1], K_NO_WAIT) ||
 		       k_sem_take(&sem[2], K_NO_WAIT)),
 		      NULL);

--- a/tests/arch/arm/arm_mpu_pxn/testcase.yaml
+++ b/tests/arch/arm/arm_mpu_pxn/testcase.yaml
@@ -6,8 +6,7 @@ common:
   platform_allow:
     - mps3/corstone300/an547
     - mps3/corstone300/fvp
-    # TODO: enable this after CONFIG_USERSPACE is supported for mps3/corstone310
-    # - mps3/corstone310/fvp
+    - mps3/corstone310/fvp
 tests:
   # To verify that region marked with PXN attribute can be executed from unprivileged code
   # and cannot be executed from privileged code


### PR DESCRIPTION
### What is the change?

- MPS3 Corstone310 can now be built with CONFIG_USERSPACE as well.
- Enabled testing by default for MPS3 Corstone300 and Corstone310.
- Non secure build variants can now be used with ARMFVPs.

### Why is this change needed?

- MPS3 Corstone310 had smaller ITCM and DTCM which does not allow it to build with CONFIG_USERSPACE. Splitting the flash and moving to a bigger  ram was needed to be able to do this.
- Running non secure variant of a build doesn't work with FVPs previous to version 11.27. The newer version of FVP added the support to run the tfm_merged.hex files.