### PR TITLE
boards: silabs: siwx91x: Fix compatibility with BTP

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -20,6 +20,7 @@
 		zephyr,code-partition = &code_partition;
 		zephyr,console = &ulpuart;
 		zephyr,shell-uart = &ulpuart;
+		zephyr,uart-pipe = &ulpuart;
 		zephyr,bt-hci = &bt_hci0;
 	};
 


### PR DESCRIPTION
The serial pipe driver is required when the Zephyr device acts as the remote of a host application. Especially, frameworks like BTP rely on this driver.

Until now, the "zephyr,uart-pipe" attribute was missing. So the serial pipe driver was unable to start.