### PR TITLE
drivers: ethernet: position phy_link_callback_set() right

### DIFF
--- a/drivers/ethernet/eth_esp32.c
+++ b/drivers/ethernet/eth_esp32.c
@@ -375,14 +375,14 @@ static void eth_esp32_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 
 	if (device_is_ready(eth_esp32_phy_dev)) {
+		/* Do not start the interface until PHY link is up */
+		net_if_carrier_off(iface);
+
 		phy_link_callback_set(eth_esp32_phy_dev, phy_link_state_changed,
 				      (void *)dev);
 	} else {
 		LOG_ERR("PHY device not ready");
 	}
-
-	/* Do not start the interface until PHY link is up */
-	net_if_carrier_off(iface);
 }
 
 static const struct ethernet_api eth_esp32_api = {

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1901,16 +1901,13 @@ static void eth0_iface_init(struct net_if *iface)
 #endif
 #endif
 	if (device_is_ready(cfg->phy_dev)) {
+		net_if_carrier_off(iface);
+
 		phy_link_callback_set(cfg->phy_dev, &phy_link_state_changed,
 				      (void *)dev);
 
 	} else {
 		LOG_ERR("PHY device not ready");
-	}
-
-	/* Do not start the interface until PHY link is up */
-	if (!(dev_data->link_up)) {
-		net_if_carrier_off(iface);
 	}
 
 	init_done = true;

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -93,10 +93,10 @@ static void netc_eth_iface_init(struct net_if *iface)
 		LOG_ERR("PHY device (%p) is not ready, cannot init iface", cfg->phy_dev);
 		return;
 	}
-	phy_link_callback_set(cfg->phy_dev, &netc_eth_phylink_callback, (void *)dev);
-
 	/* Do not start the interface until PHY link is up */
 	net_if_carrier_off(iface);
+
+	phy_link_callback_set(cfg->phy_dev, &netc_eth_phylink_callback, (void *)dev);
 }
 
 static int netc_eth_init(const struct device *dev)

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -167,7 +167,9 @@ __subsystem struct ethphy_driver_api {
 	/** Configure link */
 	int (*cfg_link)(const struct device *dev, enum phy_link_speed adv_speeds);
 
-	/** Set callback to be invoked when link state changes. */
+	/** Set callback to be invoked when link state changes. Driver has to invoke
+	 * callback once after setting it, even if link state has not changed.
+	 */
 	int (*link_cb_set)(const struct device *dev, phy_callback_t cb, void *user_data);
 
 	/** Read PHY register */
@@ -247,7 +249,11 @@ static inline int phy_get_link_state(const struct device *dev, struct phy_link_s
  *
  * Sets a callback that is invoked when link state changes. This is the
  * preferred method for ethernet drivers to be notified of the PHY link
- * state change.
+ * state change. The callback will be invoked once after setting it,
+ * even if link state has not changed. There can only one callback
+ * function set and active at a time. This function is mainly used
+ * by ethernet drivers to register a callback to be notified of
+ * link state changes and should therefore not be used by applications.
  *
  * @param[in]  dev        PHY device structure
  * @param      callback   Callback handler


### PR DESCRIPTION
This pull request includes several changes to the initialization and configuration of Ethernet interfaces across multiple drivers. The main focus is on ensuring that the network interface carrier is turned off until the PHY link is confirmed to be up, and on improving the handling of PHY link state changes.