### PR TITLE
doc: services: shell: add reference to west rtt

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -122,6 +122,27 @@ To configure Segger RTT backend, add the following configurations to your build:
 Details on additional configuration settings are captured in:
 :zephyr_file:`samples/subsys/shell/shell_module/prj_minimal_rtt.conf`.
 
+.. _shell_rtt_west:
+
+Using west
+-----------
+
+Attach to and configure RTT with:
+
+.. code-block:: console
+
+   $ west rtt
+
+.. note::
+
+   If your default runner does not have support for RTT, check your board's documentation page for
+   any other runners that support RTT. You may then use the ``--runner`` option to specify a
+   different runner.
+
+  .. code-block:: console
+
+     $ west rtt --runner <runner>
+
 .. _shell_rtt_putty:
 
 Using PuTTY


### PR DESCRIPTION
Adds a reference to west rtt as alternative to using putty. Also provides
a command that prints supported rtt runners for the specific build.

This issue is encountered now with the nRF54L15, for example, because
the nrfutil runner does not support RTT at this time.

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
