### PR TITLE
nrf70: Implement SPI clock switching

### DIFF
--- a/boards/shields/nrf7002ek/nrf7002ek.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek.overlay
@@ -18,7 +18,7 @@
 		compatible = "nordic,nrf7002-spi";
 		status = "okay";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(16)>;
 
 		/* Include common nRF70 overlays */
 		#include "nrf7002ek_common.dtsi"


### PR DESCRIPTION
If the SPI clock is > 8MHz, then we need to implement clock switching to handle special case of waking up nRF70 only with 8MHz frequency.