### PR TITLE
doc: wemos: adopt zephyr:board-supported-hw directive

### DIFF
--- a/boards/wemos/esp32s2_lolin_mini/doc/index.rst
+++ b/boards/wemos/esp32s2_lolin_mini/doc/index.rst
@@ -27,6 +27,14 @@ The features include the following:
   - DAC
   - LED PWM with up to 8 channels
 
+Hardware
+********
+
+Supported Features
+------------------
+
+.. zephyr:board-supported-hw::
+
 System requirements
 *******************
 

--- a/boards/wemos/esp32s2_lolin_mini/doc/index.rst
+++ b/boards/wemos/esp32s2_lolin_mini/doc/index.rst
@@ -31,7 +31,7 @@ Hardware
 ********
 
 Supported Features
-------------------
+==================
 
 .. zephyr:board-supported-hw::
 
@@ -39,7 +39,7 @@ System requirements
 *******************
 
 Prerequisites
--------------
+=============
 
 Espressif HAL requires WiFi and Bluetooth binary blobs in order work. Run the command
 below to retrieve those files.
@@ -53,7 +53,7 @@ below to retrieve those files.
    It is recommended running the command above after :file:`west update`.
 
 Building & Flashing
--------------------
+===================
 
 Build and flash applications as usual (see :ref:`build_an_application` and
 :ref:`application_run` for more details).


### PR DESCRIPTION
Add hardware features table for Wemos boards

https://builds.zephyrproject.io/zephyr/pr/87707/docs/boards/wemos/esp32s2_lolin_mini/doc/index.html