### PR TITLE
samples: ipm_esp32: do not skip CI test

### DIFF
--- a/samples/drivers/ipm/ipm_esp32/sample.yaml
+++ b/samples/drivers/ipm/ipm_esp32/sample.yaml
@@ -8,4 +8,3 @@ tests:
     tags:
       - samples
       - ipm
-    skip: true


### PR DESCRIPTION
This sample was skipped during hwmv2 bring up. Turn in back on.