### PR TITLE
boards: arduino: uno_r4: Add ADC mapping

### DIFF
--- a/boards/arduino/uno_r4/arduino_uno_r4_minima.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_minima.overlay
@@ -61,6 +61,17 @@
 			   <20 0 &ioport1 1 0>,   /* D14 */
 			   <21 0 &ioport1 0 0>;   /* D15 */
 	};
+
+	arduino_adc: analog-connector {
+		compatible = "arduino,uno-adc";
+		#io-channel-cells = <1>;
+		io-channel-map = <0 &adc0 9>,    /* A0 = P009 = CH09 */
+				 <1 &adc0 0>,    /* A1 = P000 = CH00 */
+				 <2 &adc0 1>,    /* A2 = P001 = CH01 */
+				 <3 &adc0 2>,    /* A3 = P002 = CH02 */
+				 <4 &adc0 21>,   /* A4 = P101 = CH21 */
+				 <5 &adc0 22>;   /* A5 = P100 = CH22 */
+	};
 };
 
 &spi1 {

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -61,6 +61,17 @@
 			   <20 0 &ioport1 1 0>,   /* D14 */
 			   <21 0 &ioport1 0 0>;   /* D15 */
 	};
+
+	arduino_adc: analog-connector {
+		compatible = "arduino,uno-adc";
+		#io-channel-cells = <1>;
+		io-channel-map = <0 &adc0 9>,    /* A0 = P009 = CH09 */
+				 <1 &adc0 0>,    /* A1 = P000 = CH00 */
+				 <2 &adc0 1>,    /* A2 = P001 = CH01 */
+				 <3 &adc0 2>,    /* A3 = P002 = CH02 */
+				 <4 &adc0 21>,   /* A4 = P101 = CH21 */
+				 <5 &adc0 22>;   /* A5 = P100 = CH22 */
+	};
 };
 
 &spi0 {

--- a/samples/drivers/adc/adc_dt/boards/arduino_uno_r4.overlay
+++ b/samples/drivers/adc/adc_dt/boards/arduino_uno_r4.overlay
@@ -6,7 +6,8 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc0 0>, <&adc0 1>, <&adc0 2>, <&adc0 9>;
+		io-channels = <&arduino_adc 0>, <&arduino_adc 1>, <&arduino_adc 2>,
+			      <&arduino_adc 3>, <&arduino_adc 4>, <&arduino_adc 5>;
 	};
 };
 
@@ -44,6 +45,24 @@
 
 	channel@9 {
 		reg = <9>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <5000>;
+	};
+
+	channel@21 {
+		reg = <21>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,vref-mv = <5000>;
+	};
+
+	channel@22 {
+		reg = <22>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,resolution = <12>;


### PR DESCRIPTION
Add `arduino,uno-adc` node to add ADC mapping.

And use this to change the `adc_dt` sample settings for easier understanding.
Also, we improve the configuration for using the available A4 and A5 pins.