### PR TITLE
toolchain: llvm: Use clang's __INTN_C/__UINTN_C macros for clang 20+

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -41,6 +41,12 @@
  */
 #ifdef CONFIG_MINIMAL_LIBC
 
+/*
+ * Predefined __INTN_C/__UINTN_C macros are provided by clang starting in version 20.
+ * Avoid redefining these macros if a sufficiently modern clang is being used.
+ */
+#if __clang_major__ < 20
+
 #define __int_c(v, suffix) v ## suffix
 #define int_c(v, suffix) __int_c(v, suffix)
 #define uint_c(v, suffix) __int_c(v ## U, suffix)
@@ -131,6 +137,8 @@
 
 #define __INTMAX_C(x)	int_c(x, __INTMAX_C_SUFFIX__)
 #define __UINTMAX_C(x)	int_c(x, __UINTMAX_C_SUFFIX__)
+
+#endif /* __clang_major__ < 20 */
 
 #endif /* CONFIG_MINIMAL_LIBC */
 


### PR DESCRIPTION
clang recently began providing predefined __INTN_C/__UINTN_C macros resulting in macro redefinition warnings in toolchain/llvm.h. This change was landed in clang in late Jan. 2025 and clang/LLVM 20 is the first official release that has this support (see the PR linked below).

Prefer the definitions provided by clang and avoid redefining these macros for clang versions 20 and later to avoid said warnings.

Link: https://github.com/llvm/llvm-project/pull/123514