### PR TITLE
drivers: sensor: tmp112: add support for setting ALERT thresholds

### DIFF
--- a/drivers/sensor/ti/tmp112/tmp112.c
+++ b/drivers/sensor/ti/tmp112/tmp112.c
@@ -18,8 +18,7 @@
 
 LOG_MODULE_REGISTER(TMP112, CONFIG_SENSOR_LOG_LEVEL);
 
-static int tmp112_reg_read(const struct tmp112_config *cfg,
-			   uint8_t reg, uint16_t *val)
+static int tmp112_reg_read(const struct tmp112_config *cfg, uint8_t reg, uint16_t *val)
 {
 	if (i2c_burst_read_dt(&cfg->bus, reg, (uint8_t *)val, sizeof(*val)) < 0) {
 		return -EIO;
@@ -30,8 +29,7 @@ static int tmp112_reg_read(const struct tmp112_config *cfg,
 	return 0;
 }
 
-static int tmp112_reg_write(const struct tmp112_config *cfg,
-			    uint8_t reg, uint16_t val)
+static int tmp112_reg_write(const struct tmp112_config *cfg, uint8_t reg, uint16_t val)
 {
 	uint8_t buf[3];
 
@@ -41,14 +39,12 @@ static int tmp112_reg_write(const struct tmp112_config *cfg,
 	return i2c_write_dt(&cfg->bus, buf, sizeof(buf));
 }
 
-static uint16_t set_config_flags(struct tmp112_data *data, uint16_t mask,
-				 uint16_t value)
+static uint16_t set_config_flags(struct tmp112_data *data, uint16_t mask, uint16_t value)
 {
 	return (data->config_reg & ~mask) | (value & mask);
 }
 
-static int tmp112_update_config(const struct device *dev, uint16_t mask,
-				uint16_t val)
+static int tmp112_update_config(const struct device *dev, uint16_t mask, uint16_t val)
 {
 	int rc;
 	struct tmp112_data *data = dev->data;
@@ -62,10 +58,8 @@ static int tmp112_update_config(const struct device *dev, uint16_t mask,
 	return rc;
 }
 
-static int tmp112_attr_set(const struct device *dev,
-			   enum sensor_channel chan,
-			   enum sensor_attribute attr,
-			   const struct sensor_value *val)
+static int tmp112_attr_set(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, const struct sensor_value *val)
 {
 	uint16_t value;
 	uint16_t cr;
@@ -136,8 +130,7 @@ static int tmp112_attr_set(const struct device *dev,
 	return 0;
 }
 
-static int tmp112_sample_fetch(const struct device *dev,
-			       enum sensor_channel chan)
+static int tmp112_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct tmp112_data *drv_data = dev->data;
 	const struct tmp112_config *cfg = dev->config;
@@ -150,18 +143,15 @@ static int tmp112_sample_fetch(const struct device *dev,
 	}
 
 	if (val & TMP112_DATA_EXTENDED) {
-		drv_data->sample = arithmetic_shift_right((int16_t)val,
-							  TMP112_DATA_EXTENDED_SHIFT);
+		drv_data->sample = arithmetic_shift_right((int16_t)val, TMP112_DATA_EXTENDED_SHIFT);
 	} else {
-		drv_data->sample = arithmetic_shift_right((int16_t)val,
-							  TMP112_DATA_NORMAL_SHIFT);
+		drv_data->sample = arithmetic_shift_right((int16_t)val, TMP112_DATA_NORMAL_SHIFT);
 	}
 
 	return 0;
 }
 
-static int tmp112_channel_get(const struct device *dev,
-			      enum sensor_channel chan,
+static int tmp112_channel_get(const struct device *dev, enum sensor_channel chan,
 			      struct sensor_value *val)
 {
 	struct tmp112_data *drv_data = dev->data;
@@ -194,23 +184,22 @@ int tmp112_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	data->config_reg = TMP112_CONV_RATE(cfg->cr) | TMP112_CONV_RES_MASK
-			   | (cfg->extended_mode ? TMP112_CONFIG_EM : 0);
+	data->config_reg = TMP112_CONV_RATE(cfg->cr) | TMP112_CONV_RES_MASK |
+			   (cfg->extended_mode ? TMP112_CONFIG_EM : 0);
 
 	return tmp112_update_config(dev, 0, 0);
 }
 
-
-#define TMP112_INST(inst)						    \
-	static struct tmp112_data tmp112_data_##inst;			    \
-	static const struct tmp112_config tmp112_config_##inst = {	    \
-		.bus = I2C_DT_SPEC_INST_GET(inst),			    \
-		.cr = DT_INST_ENUM_IDX(inst, conversion_rate),		    \
-		.extended_mode = DT_INST_PROP(inst, extended_mode),	    \
-	};								    \
-									    \
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, tmp112_init, NULL, &tmp112_data_##inst, \
-			      &tmp112_config_##inst, POST_KERNEL,	    \
-			      CONFIG_SENSOR_INIT_PRIORITY, &tmp112_driver_api);
+#define TMP112_INST(inst)                                                                          \
+	static struct tmp112_data tmp112_data_##inst;                                              \
+	static const struct tmp112_config tmp112_config_##inst = {                                 \
+		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.cr = DT_INST_ENUM_IDX(inst, conversion_rate),                                     \
+		.extended_mode = DT_INST_PROP(inst, extended_mode),                                \
+	};                                                                                         \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, tmp112_init, NULL, &tmp112_data_##inst,                 \
+				     &tmp112_config_##inst, POST_KERNEL,                           \
+				     CONFIG_SENSOR_INIT_PRIORITY, &tmp112_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(TMP112_INST)

--- a/drivers/sensor/ti/tmp112/tmp112.c
+++ b/drivers/sensor/ti/tmp112/tmp112.c
@@ -58,6 +58,29 @@ static int tmp112_update_config(const struct device *dev, uint16_t mask, uint16_
 	return rc;
 }
 
+static int tmp112_set_threshold(const struct device *dev, uint8_t reg, int64_t micro_c)
+{
+	struct tmp112_data *drv_data = dev->data;
+	int64_t v;
+	uint16_t reg_value;
+
+	v = DIV_ROUND_CLOSEST(micro_c, TMP112_TEMP_SCALE);
+
+	if (drv_data->config_reg & TMP112_CONFIG_EM) {
+		if (!IN_RANGE(v, TMP112_TEMP_MIN_EM, TMP112_TEMP_MAX_EM)) {
+			return -EINVAL;
+		}
+		reg_value = (uint16_t)v << TMP112_DATA_EXTENDED_SHIFT;
+	} else {
+		if (!IN_RANGE(v, TMP112_TEMP_MIN, TMP112_TEMP_MAX)) {
+			return -EINVAL;
+		}
+		reg_value = (uint16_t)v << TMP112_DATA_NORMAL_SHIFT;
+	}
+
+	return tmp112_reg_write(dev->config, reg, reg_value);
+}
+
 static int tmp112_attr_set(const struct device *dev, enum sensor_channel chan,
 			   enum sensor_attribute attr, const struct sensor_value *val)
 {
@@ -87,8 +110,9 @@ static int tmp112_attr_set(const struct device *dev, enum sensor_channel chan,
 		}
 		break;
 #endif
-	case SENSOR_ATTR_SAMPLING_FREQUENCY:
+
 #if CONFIG_TMP112_SAMPLING_FREQUENCY_RUNTIME
+	case SENSOR_ATTR_SAMPLING_FREQUENCY:
 		/* conversion rate in mHz */
 		cr = val->val1 * 1000 + val->val2 / 1000;
 
@@ -123,6 +147,12 @@ static int tmp112_attr_set(const struct device *dev, enum sensor_channel chan,
 		break;
 #endif
 
+	case SENSOR_ATTR_LOWER_THRESH:
+		return tmp112_set_threshold(dev, TMP112_REG_TLOW, sensor_value_to_micro(val));
+
+	case SENSOR_ATTR_UPPER_THRESH:
+		return tmp112_set_threshold(dev, TMP112_REG_THIGH, sensor_value_to_micro(val));
+
 	default:
 		return -ENOTSUP;
 	}
@@ -155,17 +185,12 @@ static int tmp112_channel_get(const struct device *dev, enum sensor_channel chan
 			      struct sensor_value *val)
 {
 	struct tmp112_data *drv_data = dev->data;
-	int32_t uval;
 
 	if (chan != SENSOR_CHAN_AMBIENT_TEMP) {
 		return -ENOTSUP;
 	}
 
-	uval = (int32_t)drv_data->sample * TMP112_TEMP_SCALE;
-	val->val1 = uval / 1000000;
-	val->val2 = uval % 1000000;
-
-	return 0;
+	return sensor_value_from_micro(val, (int32_t)drv_data->sample * TMP112_TEMP_SCALE);
 }
 
 static DEVICE_API(sensor, tmp112_driver_api) = {
@@ -178,6 +203,7 @@ int tmp112_init(const struct device *dev)
 {
 	const struct tmp112_config *cfg = dev->config;
 	struct tmp112_data *data = dev->data;
+	int ret;
 
 	if (!device_is_ready(cfg->bus.bus)) {
 		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
@@ -187,7 +213,25 @@ int tmp112_init(const struct device *dev)
 	data->config_reg = TMP112_CONV_RATE(cfg->cr) | TMP112_CONV_RES_MASK |
 			   (cfg->extended_mode ? TMP112_CONFIG_EM : 0);
 
-	return tmp112_update_config(dev, 0, 0);
+	ret = tmp112_update_config(dev, 0, 0);
+	if (ret) {
+		LOG_ERR("Failed to set configuration (%d)", ret);
+		return ret;
+	}
+
+	ret = tmp112_set_threshold(dev, TMP112_REG_TLOW, cfg->t_low_micro_c);
+	if (ret) {
+		LOG_ERR("Failed to set tLow threshold (%d)", ret);
+		return ret;
+	}
+
+	ret = tmp112_set_threshold(dev, TMP112_REG_THIGH, cfg->t_high_micro_c);
+	if (ret) {
+		LOG_ERR("Failed to set tHigh threshold (%d)", ret);
+		return ret;
+	}
+
+	return 0;
 }
 
 #define TMP112_INST(inst)                                                                          \
@@ -195,6 +239,8 @@ int tmp112_init(const struct device *dev)
 	static const struct tmp112_config tmp112_config_##inst = {                                 \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.cr = DT_INST_ENUM_IDX(inst, conversion_rate),                                     \
+		.t_low_micro_c = DT_INST_PROP(inst, t_low_micro_c),                                \
+		.t_high_micro_c = DT_INST_PROP(inst, t_high_micro_c),                              \
 		.extended_mode = DT_INST_PROP(inst, extended_mode),                                \
 	};                                                                                         \
                                                                                                    \

--- a/drivers/sensor/ti/tmp112/tmp112.h
+++ b/drivers/sensor/ti/tmp112/tmp112.h
@@ -41,6 +41,16 @@
 /* scale in micro degrees Celsius */
 #define TMP112_TEMP_SCALE       62500
 
+/* RAW min/max temperature values - LSB=TMP112_TEMP_SCALE */
+/* 128C */
+#define TMP112_TEMP_MAX    2047
+/* -55C */
+#define TMP112_TEMP_MIN    -880
+/* 150C */
+#define TMP112_TEMP_MAX_EM 2400
+/* -55C */
+#define TMP112_TEMP_MIN_EM TMP112_TEMP_MIN
+
 struct tmp112_data {
 	int16_t sample;
 	uint16_t config_reg;
@@ -49,6 +59,8 @@ struct tmp112_data {
 struct tmp112_config {
 	const struct i2c_dt_spec bus;
 	uint8_t cr;
+	int32_t t_low_micro_c;
+	int32_t t_high_micro_c;
 	bool extended_mode : 1;
 };
 

--- a/dts/bindings/sensor/ti,tmp112.yaml
+++ b/dts/bindings/sensor/ti,tmp112.yaml
@@ -19,6 +19,21 @@ properties:
       - 1000
       - 4000
       - 8000
+
   extended-mode:
-    description: When true use 13-bit data format allowing measuring temperature up to 128°C
+    description: When true use 13-bit data format allowing measuring temperature up to 150°C
     type: boolean
+
+  t-low-micro-c:
+    description: |
+      Sets the default tLow threshold in micro-Celsius. The default value is the chip reset
+      value.
+    type: int
+    default: 75000000
+
+  t-high-micro-c:
+    description: |
+      Sets the default tHigh threshold in micro-Celsius. The default value is the chip reset
+      value.
+    type: int
+    default: 85000000


### PR DESCRIPTION
Allows setting tLow/tHigh threasholds via the SENSOR_ATTR_LOWER_THRESH/SENSOR_ATTR_UPPER_THRESH attributes.