### PR TITLE
boards: renesas: Support Ethernet for Renesas ek_ra6m3

### DIFF
--- a/boards/renesas/ek_ra6m3/Kconfig.defconfig
+++ b/boards/renesas/ek_ra6m3/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_EK_RA6M3
+
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+endif # NETWORKING
+
+endif # BOARD_EK_RA6M3

--- a/boards/renesas/ek_ra6m3/ek_ra6m3-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3-pinctrl.dtsi
@@ -69,4 +69,20 @@
 			drive-strength = "high";
 		};
 	};
+
+	ether_default: ether_default {
+		group1 {
+			psels = <RA_PSEL(RA_PSEL_ETH_RMII, 4, 1)>, /* ET0_MDC */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 4, 2)>, /* ET0_MDIO */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 4, 5)>, /* RMII0_TXD_EN_B */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 4, 6)>, /* RMII0_TXD1_BR */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 7, 0)>, /* RMII0_TXD0_B */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 7, 1)>, /* REF50CK0_B */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 7, 2)>, /* RMII0_RXD0_B */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 7, 3)>, /* RMII0_RXD1_B */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 7, 4)>, /* RMII0_RX_ER_B */
+				<RA_PSEL(RA_PSEL_ETH_RMII, 7, 5)>; /* RMII0_CRS_DV_B */
+			drive-strength = "high";
+		};
+	};
 };

--- a/boards/renesas/ek_ra6m3/ek_ra6m3-pinctrl.dtsi
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3-pinctrl.dtsi
@@ -54,11 +54,11 @@
 		};
 	};
 
-	pwm1_default: pwm1_default {
+	pwm0_default: pwm0_default {
 		group1 {
-			/* GTIOC1A GTIOC1B */
-			psels = <RA_PSEL(RA_PSEL_GPT1, 4, 5)>,
-				<RA_PSEL(RA_PSEL_GPT1, 4, 6)>;
+			/* GTIOC0A GTIOC0B */
+			psels = <RA_PSEL(RA_PSEL_GPT1, 4, 15)>,
+				<RA_PSEL(RA_PSEL_GPT1, 4, 14)>;
 		};
 	};
 

--- a/boards/renesas/ek_ra6m3/ek_ra6m3.dts
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3.dts
@@ -196,3 +196,21 @@
 &wdt {
 	status = "okay";
 };
+
+&eth {
+	local-mac-address = [00 11 22 33 44 57];
+	status = "okay";
+	phy-handle = <&phy>;
+};
+
+&mdio {
+	pinctrl-0 = <&ether_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	phy: ethernet-phy@5 {
+		compatible = "ethernet-phy";
+		reg = <0>;
+		status = "okay";
+	};
+};

--- a/boards/renesas/ek_ra6m3/ek_ra6m3.dts
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3.dts
@@ -166,8 +166,8 @@
 	status = "okay";
 };
 
-&pwm1 {
-	pinctrl-0 = <&pwm1_default>;
+&pwm0 {
+	pinctrl-0 = <&pwm0_default>;
 	pinctrl-names = "default";
 	interrupts = <63 1>, <64 1>;
 	interrupt-names = "gtioca", "overflow";

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -7,6 +7,9 @@
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <arm/renesas/ra/ra6/ra6-cm4-common.dtsi>
 
+/delete-node/ &eth;
+/delete-node/ &mdio;
+
 / {
 	soc {
 		sram0: memory@1ffe0000 {

--- a/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2ax.dtsi
@@ -8,6 +8,9 @@
 #include <zephyr/dt-bindings/clock/ra_clock.h>
 #include <zephyr/dt-bindings/pwm/ra_pwm.h>
 
+/delete-node/ &eth;
+/delete-node/ &mdio;
+
 / {
 	soc {
 		sram0: memory@1ffe0000 {

--- a/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
+++ b/dts/arm/renesas/ra/ra6/ra6-cm4-common.dtsi
@@ -616,6 +616,22 @@
 			status = "disabled";
 		};
 
+		eth: ethernet@40064100 {
+			compatible = "renesas,ra-ethernet";
+			reg = <0x40064100 0xfc>;
+			interrupts = <51 0>;
+			local-mac-address = [00 11 22 33 44 55];
+			phy-connection-type = "rmii";
+			status = "disabled";
+		};
+
+		mdio: mdio {
+			compatible = "renesas,ra-mdio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
 		flash: flash-controller@407e0000 {
 			compatible = "renesas,ra-flash-hp-controller";
 			reg = <0x407e0000 0x10000>;

--- a/tests/drivers/pwm/pwm_loopback/boards/ek_ra6m3.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/ek_ra6m3.overlay
@@ -11,7 +11,7 @@
 	pwm_loopback_0 {
 		compatible = "test-pwm-loopback";
 		/* first index must be a 32-Bit timer */
-		pwms = <&pwm1 0 0 PWM_POLARITY_NORMAL>,
+		pwms = <&pwm0 0 0 PWM_POLARITY_NORMAL>,
 			<&pwm4 0 0 PWM_POLARITY_NORMAL>;
 	};
 };


### PR DESCRIPTION
- Modify the default PWM node on the ek_ra6m3 (`pwm1` → `pwm0`) to avoid a pin selection conflict with the Ethernet PHY.
- Add Ethernet support for the Renesas ek_ra6m3 board.