### PR TITLE
dts: boards: st, stm32f3_disco: update user button logic

### DIFF
--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -61,7 +61,7 @@
 		compatible = "gpio-keys";
 		user_button: button {
 			label = "User";
-			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};


### PR DESCRIPTION
Updated the stm32f3_disco board user button logic from active low to active high as per datasheet.

![image](https://github.com/user-attachments/assets/f642eaf1-baef-4d81-826c-49988daa90a4)
Reference: https://docs.rs-online.com/5192/0900766b814876f9.pdf