### PR TITLE
Bluetooth: Classic: SMP: Fix LK derivation issue

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -807,6 +807,12 @@ static void sc_derive_link_key(struct bt_smp *smp)
 		return;
 	}
 
+	/* Remove the bonding information */
+	link_key = bt_keys_find_link_key(&conn->le.dst.a);
+	if (link_key != NULL) {
+		bt_keys_link_key_clear(link_key);
+	}
+
 	/*
 	 * At this point remote device identity is known so we can use
 	 * destination address here
@@ -851,6 +857,11 @@ static void sc_derive_link_key(struct bt_smp *smp)
 		link_key->flags |= BT_LINK_KEY_AUTHENTICATED;
 	} else {
 		link_key->flags &= ~BT_LINK_KEY_AUTHENTICATED;
+	}
+
+	if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
+		/* Store the link key */
+		bt_keys_link_key_store(link_key);
 	}
 }
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -749,6 +749,47 @@ static void smp_sign_info_sent(struct bt_conn *conn, void *user_data, int err)
 #endif /* CONFIG_BT_SIGNING */
 
 #if defined(CONFIG_BT_CLASSIC)
+static bool ltk_derive_link_key_allowed(struct bt_smp *smp)
+{
+	struct bt_conn *conn;
+	struct bt_keys_link_key *link_key;
+	struct bt_keys *keys;
+
+	if (!smp->chan.chan.conn) {
+		return false;
+	}
+
+	conn = smp->chan.chan.conn;
+	keys = conn->le.keys;
+	if (keys == NULL) {
+		return false;
+	}
+
+	/* Check whether it is has been bonded */
+	link_key = bt_keys_find_link_key(&conn->le.dst.a);
+	if (link_key == NULL) {
+		return true;
+	}
+
+	if (link_key->flags & BT_LINK_KEY_DEBUG) {
+		LOG_DBG("Debug LK can be overwrote");
+		return true;
+	}
+
+	if ((link_key->flags & BT_LINK_KEY_AUTHENTICATED) &&
+	    ((keys->flags & BT_KEYS_AUTHENTICATED) == 0)) {
+		LOG_DBG("Stronger LK (MITM) cannot be overwrote by weaker LTK");
+		return false;
+	}
+
+	if ((link_key->flags & BT_LINK_KEY_SC) && ((keys->flags & BT_KEYS_SC) == 0)) {
+		LOG_DBG("Stronger LK (SC) cannot be overwrote by weaker LTK");
+		return false;
+	}
+
+	return true;
+}
+
 static void sc_derive_link_key(struct bt_smp *smp)
 {
 	/* constants as specified in Core Spec Vol.3 Part H 2.4.2.4 */
@@ -760,6 +801,11 @@ static void sc_derive_link_key(struct bt_smp *smp)
 	LOG_DBG("");
 
 	/* TODO handle errors? */
+
+	if (!ltk_derive_link_key_allowed(smp)) {
+		LOG_DBG("LK cannot be derived by LTK");
+		return;
+	}
 
 	/*
 	 * At this point remote device identity is known so we can use

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -841,7 +841,11 @@ static void sc_derive_link_key(struct bt_smp *smp)
 		bt_keys_link_key_clear(link_key);
 	}
 
-	link_key->flags |= BT_LINK_KEY_SC;
+	if (conn->le.keys->flags & BT_KEYS_SC) {
+		link_key->flags |= BT_LINK_KEY_SC;
+	} else {
+		link_key->flags &= ~BT_LINK_KEY_SC;
+	}
 
 	if (conn->le.keys->flags & BT_KEYS_AUTHENTICATED) {
 		link_key->flags |= BT_LINK_KEY_AUTHENTICATED;


### PR DESCRIPTION
* Bluetooth: Classic: SMP: Avoid stronger LK be overwrote by weaker LTK

Add the function `ltk_derive_link_key_allowed()` to check whether the LK can be overwrote by the LTK.

* Bluetooth: Classic: SMP: Set BT_LINK_KEY_SC only if BT_KEYS_SC is set

The flag `BT_LINK_KEY_SC` of LK will also be set when derive LK from LTK. It is a incorrect behavior.

The flag `BT_LINK_KEY_SC` should only be set if the flag `BT_KEYS_SC` of LTK has been set.

* Bluetooth: Classic: SMP: Store derived LK if `SMP_FLAG_BOND` is set

When deriving the new LK, remove the old LK if it exists.

Store the derived LK if the flag `SMP_FLAG_BOND` of LE SMP is set.

