### PR TITLE
Bluetooth: Classic: Refactor query and deletion bonding information

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -120,6 +120,10 @@ New APIs and options
     * :c:func:`bt_conn_lookup_addr_br`
     * :c:func:`bt_conn_get_dst_br`
     * LE Connection Subrating is no longer experimental.
+    * Remove deletion of the classic bonding information from :c:func:`bt_unpair`, and add
+      :c:func:`bt_br_unpair`.
+    * Remove query of the classic bonding information from :c:func:`bt_foreach_bond`, and add
+      :c:func:`bt_br_foreach_bond`.
 
 * Display
 

--- a/include/zephyr/bluetooth/classic/classic.h
+++ b/include/zephyr/bluetooth/classic/classic.h
@@ -210,6 +210,30 @@ int bt_br_set_connectable(bool enable);
 bool bt_br_bond_exists(const bt_addr_t *addr);
 
 /**
+ * @brief Clear classic pairing information .
+ *
+ * @param addr  Remote address, NULL or BT_ADDR_ANY to clear all remote devices.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int bt_br_unpair(const bt_addr_t *addr);
+
+/** Information about a bond with a remote device. */
+struct bt_br_bond_info {
+	/** Address of the remote device. */
+	bt_addr_t addr;
+};
+
+/**
+ * @brief Iterate through all existing bonds of Classic.
+ *
+ * @param func       Function to call for each bond.
+ * @param user_data  Data to pass to the callback function.
+ */
+void bt_br_foreach_bond(void (*func)(const struct bt_br_bond_info *info, void *user_data),
+			void *user_data);
+
+/**
  * @}
  */
 

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2442,6 +2442,17 @@ struct bt_conn_auth_info_cb {
 	 */
 	void (*bond_deleted)(uint8_t id, const bt_addr_le_t *peer);
 
+#if defined(CONFIG_BT_CLASSIC)
+	/** @brief Notify that bond of classic has been deleted.
+	 *
+	 *  This callback notifies the application that the bond information of classic
+	 *  for the remote peer has been deleted
+	 *
+	 *  @param peer Remote address.
+	 */
+	void (*br_bond_deleted)(const bt_addr_t *peer);
+#endif /* CONFIG_BT_CLASSIC */
+
 	/** Internally used field for list handling */
 	sys_snode_t node;
 };

--- a/subsys/bluetooth/host/classic/keys_br.c
+++ b/subsys/bluetooth/host/classic/keys_br.c
@@ -146,7 +146,7 @@ void bt_keys_link_key_store(struct bt_keys_link_key *link_key)
 	}
 }
 
-void bt_foreach_bond_br(void (*func)(const struct bt_bond_info *info, void *user_data),
+void bt_br_foreach_bond(void (*func)(const struct bt_br_bond_info *info, void *user_data),
 			void *user_data)
 {
 	__ASSERT_NO_MSG(func != NULL);
@@ -155,10 +155,9 @@ void bt_foreach_bond_br(void (*func)(const struct bt_bond_info *info, void *user
 		const struct bt_keys_link_key *key = &key_pool[i];
 
 		if (!bt_addr_eq(&key->addr, BT_ADDR_ANY)) {
-			struct bt_bond_info info;
+			struct bt_br_bond_info info;
 
-			info.addr.type = BT_ADDR_LE_PUBLIC;
-			bt_addr_copy(&info.addr.a, &key->addr);
+			bt_addr_copy(&info.addr, &key->addr);
 			func(&info, user_data);
 		}
 	}

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -859,6 +859,38 @@ static int cmd_sdp_find_record(const struct shell *sh, size_t argc, char *argv[]
 	return 0;
 }
 
+static int cmd_clear(const struct shell *sh, size_t argc, char *argv[])
+{
+	bt_addr_t addr;
+	int err;
+
+	if (strcmp(argv[1], "all") == 0) {
+		err = bt_br_unpair(NULL);
+		if (err) {
+			shell_error(sh, "Failed to clear pairings (err %d)", err);
+			return err;
+		}
+
+		shell_print(sh, "Pairings successfully cleared");
+		return 0;
+	}
+
+	err = bt_addr_from_str(argv[1], &addr);
+	if (err) {
+		shell_print(sh, "Invalid address");
+		return err;
+	}
+
+	err = bt_br_unpair(&addr);
+	if (err) {
+		shell_error(sh, "Failed to clear pairing (err %d)", err);
+	} else {
+		shell_print(sh, "Pairing successfully cleared");
+	}
+
+	return err;
+}
+
 static int cmd_default_handler(const struct shell *sh, size_t argc, char **argv)
 {
 	if (argc == 1) {
@@ -872,7 +904,7 @@ static int cmd_default_handler(const struct shell *sh, size_t argc, char **argv)
 }
 
 #define HELP_NONE "[none]"
-#define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
+#define HELP_ADDR "<address: XX:XX:XX:XX:XX:XX>"
 #define HELP_REG                                                      \
 	"<psm> <mode: none, ret, fc, eret, stream> [hold_credit] "    \
 	"[mode_optional] [extended_control]"
@@ -901,6 +933,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(l2cap_cmds,
 SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD_ARG(auth-pincode, NULL, "<pincode>", cmd_auth_pincode, 2, 0),
 	SHELL_CMD_ARG(connect, NULL, "<address>", cmd_connect, 2, 0),
+	SHELL_CMD_ARG(clear, NULL, "[all] ["HELP_ADDR"]", cmd_clear, 2, 0),
 	SHELL_CMD_ARG(discovery, NULL, "<value: on, off> [length: 1-48] [mode: limited]",
 		      cmd_discovery, 2, 2),
 	SHELL_CMD_ARG(iscan, NULL, "<value: on, off> [mode: limited]",

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -859,6 +859,27 @@ static int cmd_sdp_find_record(const struct shell *sh, size_t argc, char *argv[]
 	return 0;
 }
 
+static void bond_info(const struct bt_br_bond_info *info, void *user_data)
+{
+	char addr[BT_ADDR_STR_LEN];
+	int *bond_count = user_data;
+
+	bt_addr_to_str(&info->addr, addr, sizeof(addr));
+	bt_shell_print("Remote Identity: %s", addr);
+	(*bond_count)++;
+}
+
+static int cmd_bonds(const struct shell *sh, size_t argc, char *argv[])
+{
+	int bond_count = 0;
+
+	shell_print(sh, "Bonded devices:");
+	bt_br_foreach_bond(bond_info, &bond_count);
+	shell_print(sh, "Total %d", bond_count);
+
+	return 0;
+}
+
 static int cmd_clear(const struct shell *sh, size_t argc, char *argv[])
 {
 	bt_addr_t addr;
@@ -933,6 +954,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(l2cap_cmds,
 SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD_ARG(auth-pincode, NULL, "<pincode>", cmd_auth_pincode, 2, 0),
 	SHELL_CMD_ARG(connect, NULL, "<address>", cmd_connect, 2, 0),
+	SHELL_CMD_ARG(bonds, NULL, HELP_NONE, cmd_bonds, 1, 0),
 	SHELL_CMD_ARG(clear, NULL, "[all] ["HELP_ADDR"]", cmd_clear, 2, 0),
 	SHELL_CMD_ARG(discovery, NULL, "<value: on, off> [length: 1-48] [mode: limited]",
 		      cmd_discovery, 2, 2),

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2041,13 +2041,6 @@ static void unpair(uint8_t id, const bt_addr_le_t *addr)
 		bt_conn_unref(conn);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
-		/* LE Public may indicate BR/EDR as well */
-		if (addr->type == BT_ADDR_LE_PUBLIC) {
-			bt_keys_link_key_clear_addr(&addr->a);
-		}
-	}
-
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
 		if (!keys) {
 			keys = bt_keys_find_addr(id, addr);

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -174,10 +174,6 @@ void bt_foreach_bond(uint8_t id, void (*func)(const struct bt_bond_info *info,
 			func(&info, user_data);
 		}
 	}
-
-	if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
-		bt_foreach_bond_br(func, user_data);
-	}
 }
 
 void bt_keys_foreach_type(enum bt_keys_type type, void (*func)(struct bt_keys *keys, void *data),

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -226,8 +226,6 @@ struct bt_keys_link_key *bt_keys_find_link_key(const bt_addr_t *addr);
 void bt_keys_link_key_clear(struct bt_keys_link_key *link_key);
 void bt_keys_link_key_clear_addr(const bt_addr_t *addr);
 void bt_keys_link_key_store(struct bt_keys_link_key *link_key);
-void bt_foreach_bond_br(void (*func)(const struct bt_bond_info *info, void *user_data),
-			void *user_data);
 
 /* This function is used to signal that the key has been used for paring */
 /* It updates the aging counter and saves it to flash if configuration option */

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -3774,13 +3774,8 @@ static int cmd_clear(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (argc < 3) {
-#if defined(CONFIG_BT_CLASSIC)
-		addr.type = BT_ADDR_LE_PUBLIC;
-		err = bt_addr_from_str(argv[1], &addr.a);
-#else
 		shell_print(sh, "Both address and address type needed");
 		return -ENOEXEC;
-#endif
 	} else {
 		err = bt_addr_le_from_str(argv[1], argv[2], &addr);
 	}
@@ -4217,6 +4212,16 @@ void bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 	bt_shell_print("Bond deleted for %s, id %u", addr, id);
 }
 
+#if defined(CONFIG_BT_CLASSIC)
+static void br_bond_deleted(const bt_addr_t *peer)
+{
+	char addr[BT_ADDR_STR_LEN];
+
+	bt_addr_to_str(peer, addr, sizeof(addr));
+	bt_shell_print("Classic bond deleted for %s", addr);
+}
+#endif /* CONFIG_BT_CLASSIC */
+
 static struct bt_conn_auth_cb auth_cb_display = {
 	.passkey_display = auth_passkey_display,
 #if defined(CONFIG_BT_PASSKEY_KEYPRESS)
@@ -4317,6 +4322,9 @@ static struct bt_conn_auth_info_cb auth_info_cb = {
 	.pairing_failed = auth_pairing_failed,
 	.pairing_complete = auth_pairing_complete,
 	.bond_deleted = bond_deleted,
+#if defined(CONFIG_BT_CLASSIC)
+	.br_bond_deleted = br_bond_deleted,
+#endif /* CONFIG_BT_CLASSIC */
 };
 
 static int cmd_auth(const struct shell *sh, size_t argc, char *argv[])


### PR DESCRIPTION
* Bluetooth: Classic: Refactor query and deletion of bonding information

In current implementation, the bonding information of classic is queried by calling the function `bt_foreach_bond()`. And the bonding information of classic is deleted by calling `bt_unpair()`.

There are two issues if the LE and classic are bonded at same time for dual mode peer device.
Issue 1, for the function `bt_foreach_bond()`, there are two bonding information will be found. But there is no way to find which bonding information belongs to LE or classic.
Issue 2, For the function `bt_unpair()`, all bonding information will be deleted if the passed address is the public address. But there is no way to delete the bonding information of LE or classic.

Remove the calling of function `bt_foreach_bond_br()` from the function `bt_foreach_bond()`. And rename it to `bt_br_foreach_bond()`, and public it as an API to query the bonding information of classic. 
Remove the calling of function `bt_keys_link_key_clear_addr()` from the function `bt_unpair()`. Add an API `bt_br_unpair()` to delete the bonding information of classic.

Add a `br_bond_deleted` to structure `bt_conn_auth_info_cb` for classic. The callback will be triggered if the bonding information has been deleted by the function `bt_br_unpair()`.

Add a `clear` shell command for classic to delete the bonding information.


* Bluetooth: Classic: shell: Add command `bonds`

Add shell command `bonds` to list all the bonding information of classic.
