### PR TITLE
drivers: flash: nrf: Add possibility to add custom context

### DIFF
--- a/drivers/flash/Kconfig.nrf
+++ b/drivers/flash/Kconfig.nrf
@@ -7,6 +7,13 @@ config FLASH_NRF_FORCE_ALT
 	  This option can be enabled to force an alternative implementation
 	  of the flash driver.
 
+config SOC_FLASH_NRF_CUSTOM_CONTEXT
+	bool "Nordic nRFx flash driver operation custom context"
+	depends on SOC_COMPATIBLE_NRF
+	help
+	  Enable pointer to custom context, for drivers that need to store additional data,
+	  not covered by the structure.
+
 menuconfig SOC_FLASH_NRF
 	bool "Nordic Semiconductor nRF flash driver"
 	default y

--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -25,6 +25,9 @@ struct flash_context {
 #if defined(CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE)
 	uint32_t flash_addr_next;
 #endif /* CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE */
+#if defined(CONFIG_SOC_FLASH_NRF_CUSTOM_CONTEXT)
+	void *custom_context;
+#endif
 }; /*< Context type for f. @ref write_op @ref erase_op */
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE


### PR DESCRIPTION
This commit adds the possibility to add additional custom context for flash operations for usage by non-standard flash drivers.