### PR TITLE
cmake: yaml: fix handling of special chars in strings

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3049,7 +3049,7 @@ endfunction()
 #
 # Zephyr string function extension.
 # This function extends the CMake string function by providing additional
-# manipulation arguments to CMake string.
+# manipulation options for the <mode> argument:
 #
 # ESCAPE:   Ensure that any single '\', except '\"', in the input string is
 #           escaped with the escape char '\'. For example the string 'foo\bar'
@@ -3063,14 +3063,15 @@ endfunction()
 #
 # SANITIZE: Ensure that the output string does not contain any special
 #           characters. Special characters, such as -, +, =, $, etc. are
-#           converted to underscores '_'.
+#           converted to underscores '_'. Multiple arguments are concatenated.
 #
 # SANITIZE TOUPPER: Ensure that the output string does not contain any special
-#                   characters. Special characters, such as -, +, =, $, etc. are
-#                   converted to underscores '_'.
+#                   characters. Special characters, such as -, +, =, $, etc.
+#                   are converted to underscores '_'. Multiple arguments are
+#                   concatenated.
 #                   The sanitized string will be returned in UPPER case.
 #
-# returns the updated string
+# Returns the updated string in <out-var>.
 function(zephyr_string)
   set(options SANITIZE TOUPPER ESCAPE)
   cmake_parse_arguments(ZEPHYR_STRING "${options}" "" "" ${ARGN})
@@ -3084,17 +3085,13 @@ function(zephyr_string)
   list(GET ZEPHYR_STRING_UNPARSED_ARGUMENTS 0 return_arg)
   list(REMOVE_AT ZEPHYR_STRING_UNPARSED_ARGUMENTS 0)
 
-  list(JOIN ZEPHYR_STRING_UNPARSED_ARGUMENTS "" work_string)
-
   if(ZEPHYR_STRING_SANITIZE)
+    list(JOIN ZEPHYR_STRING_UNPARSED_ARGUMENTS "" work_string)
     string(REGEX REPLACE "[^a-zA-Z0-9_]" "_" work_string ${work_string})
-  endif()
-
-  if(ZEPHYR_STRING_TOUPPER)
-    string(TOUPPER ${work_string} work_string)
-  endif()
-
-  if(ZEPHYR_STRING_ESCAPE)
+    if(ZEPHYR_STRING_TOUPPER)
+      string(TOUPPER ${work_string} work_string)
+    endif()
+  elseif(ZEPHYR_STRING_ESCAPE)
     # If a single '\' is discovered, such as 'foo\bar', then it must be escaped like: 'foo\\bar'
     # \\1 and \\2 are keeping the match patterns, the \\\\ --> \\ meaning an escaped '\',
     # which then becomes a single '\' in the final string.

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3051,15 +3051,14 @@ endfunction()
 # This function extends the CMake string function by providing additional
 # manipulation options for the <mode> argument:
 #
-# ESCAPE:   Ensure that any single '\', except '\"', in the input string is
-#           escaped with the escape char '\'. For example the string 'foo\bar'
-#           will be escaped so that it becomes 'foo\\bar'.
-#           Backslashes which are already escaped will not be escaped further,
-#           for example 'foo\\bar' will not be modified.
-#           This is useful for handling of windows path separator in strings or
-#           when strings contains newline escapes such as '\n' and this can
-#           cause issues when writing to a file where a '\n' is desired in the
-#           string instead of a newline.
+# ESCAPE: Ensure that every character of the input arguments is considered
+#         by CMake as a literal by prefixing the escape character '\' where
+#         appropriate. This is useful for handling Windows path separators in
+#         strings, or when it is desired to write "\n" as an actual string of
+#         four characters instead of a single newline.
+#         Note that this operation must be performed exactly once during the
+#         lifetime of a string, or previous escape characters will be treated
+#         as literals and escaped further.
 #
 # SANITIZE: Ensure that the output string does not contain any special
 #           characters. Special characters, such as -, +, =, $, etc. are
@@ -3092,10 +3091,13 @@ function(zephyr_string)
       string(TOUPPER ${work_string} work_string)
     endif()
   elseif(ZEPHYR_STRING_ESCAPE)
-    # If a single '\' is discovered, such as 'foo\bar', then it must be escaped like: 'foo\\bar'
-    # \\1 and \\2 are keeping the match patterns, the \\\\ --> \\ meaning an escaped '\',
-    # which then becomes a single '\' in the final string.
-    string(REGEX REPLACE "([^\\][\\])([^\\\"])" "\\1\\\\\\2" work_string "${ZEPHYR_STRING_UNPARSED_ARGUMENTS}")
+    # Escape every instance of '\' or '"' in the <input> arguments.
+    # Note that:
+    #  - backslashes must be replaced first to avoid duplicating the '\' in \"
+    #  - "\\\\" is seen by CMake as \\, meaning an escaped '\', which then
+    #    becomes a single '\' in the final string.
+    string(REGEX REPLACE "\\\\" "\\\\\\\\" work_string "${ZEPHYR_STRING_UNPARSED_ARGUMENTS}")
+    string(REGEX REPLACE "\"" "\\\\\"" work_string "${work_string}")
   endif()
 
   set(${return_arg} ${work_string} PARENT_SCOPE)

--- a/cmake/modules/yaml.cmake
+++ b/cmake/modules/yaml.cmake
@@ -96,13 +96,6 @@ function(internal_yaml_list_append var genex key)
       internal_yaml_list_initializer(subjson TRUE)
       if(${arraylength} GREATER 0)
         math(EXPR arraystop "${arraylength} - 1")
-        list(GET ARG_YAML_LIST 0 entry_0)
-        if(entry_0 STREQUAL MAP)
-          message(FATAL_ERROR "${function}(GENEX ${argument} ) is not valid at this position.\n"
-                    "Syntax is 'LIST MAP \"key1: value1.1, ...\" MAP \"key1: value1.2, ...\""
-            )
-        endif()
-
         foreach(i RANGE 0 ${arraystop})
           string(JSON item GET "${json_content}" ${key} ${i})
           list(APPEND subjson ${item})
@@ -544,9 +537,7 @@ function(yaml_save)
   endif()
 endfunction()
 
-function(to_yaml in_json level yaml mode)
-  zephyr_string(ESCAPE json "${in_json}")
-
+function(to_yaml json level yaml mode)
   if(mode STREQUAL "DIRECT")
     # Direct output mode, no genexes: write a standard YAML
     set(expand_lists TRUE)
@@ -569,7 +560,10 @@ function(to_yaml in_json level yaml mode)
     message(FATAL_ERROR "to_yaml(... ${mode} ) is malformed.")
   endif()
 
-  if(level GREATER 0)
+  if(level EQUAL 0)
+    # Top-level call, initialize the YAML output variable
+    set(${yaml} "" PARENT_SCOPE)
+  else()
     math(EXPR level_dec "${level} - 1")
     set(indent_${level} "${indent_${level_dec}}  ")
   endif()

--- a/cmake/yaml-filter.cmake
+++ b/cmake/yaml-filter.cmake
@@ -6,9 +6,9 @@
 # YAML needs to happen after cmake has completed processing.
 #
 # This scripts expects as input:
-# - JSON_FILE: the name of the input file, in JSON format, that contains
+# - EXPANDED_FILE: the name of the input file, in JSON format, that contains
 #              the expanded generator expressions.
-# - YAML_FILE: the name of the final output YAML file.
+# - OUTPUT_FILE: the name of the final output YAML file.
 # - TEMP_FILES: a list of temporary files that need to be removed after
 #               the conversion is done.
 #
@@ -23,13 +23,13 @@ set(ZEPHYR_BASE ${CMAKE_CURRENT_LIST_DIR}/../)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
 include(yaml)
 
-file(READ ${JSON_FILE} json_content)
+file(READ ${EXPANDED_FILE} json_content)
 to_yaml("${json_content}" 0 yaml_out TRUE)
-file(WRITE ${YAML_FILE} "${yaml_out}")
+file(WRITE ${OUTPUT_FILE} "${yaml_out}")
 
-# Remove unused temporary files. JSON_FILE needs to be kept, or the
+# Remove unused temporary files. EXPANDED_FILE needs to be kept, or the
 # build system will complain there is no rule to rebuild it
-list(REMOVE_ITEM TEMP_FILES ${JSON_FILE})
+list(REMOVE_ITEM TEMP_FILES ${EXPANDED_FILE})
 foreach(file ${TEMP_FILES})
   file(REMOVE ${file})
 endforeach()

--- a/cmake/yaml-filter.cmake
+++ b/cmake/yaml-filter.cmake
@@ -1,21 +1,28 @@
 # Copyright (c) 2024 Arduino SA
 # SPDX-License-Identifier: Apache-2.0
 
-# Simple second stage filter for YAML generation, used when generator
-# expressions have been used for some of the data and the conversion to
-# YAML needs to happen after cmake has completed processing.
+# Second stage filter for YAML generation, called when generator expressions
+# have been used in some of the data and cleanup needs to happen after CMake
+# has completed processing.
 #
-# This scripts expects as input:
-# - EXPANDED_FILE: the name of the input file, in JSON format, that contains
-#              the expanded generator expressions.
+# Two issues are addressed here:
+#
+#  - the intermediate YAML may have non-escaped single quotes in its strings.
+#    These may have been introduced directly via yaml_set() in the main CMake
+#    script or by some generator expressions; at this stage they are however
+#    finalized and can be escaped in one single pass.
+#
+#  - in the input YAML, lists have been stored as a CMake-format string to
+#    allow generator expressions to seamlessly expand into multiple items.
+#    These now need to be converted back into a proper YAML list.
+#
+# This scripts expects as input the following variables:
+#
+# - EXPANDED_FILE: the name of the file that contains the expanded generator
+#                  expressions.
 # - OUTPUT_FILE: the name of the final output YAML file.
 # - TEMP_FILES: a list of temporary files that need to be removed after
 #               the conversion is done.
-#
-# This script loads the Zephyr yaml module and reuses its `to_yaml()`
-# function to convert the fully expanded JSON content to YAML, taking
-# into account the special format that was used to store lists.
-# Temporary files are then removed.
 
 cmake_minimum_required(VERSION 3.20.0)
 
@@ -23,13 +30,40 @@ set(ZEPHYR_BASE ${CMAKE_CURRENT_LIST_DIR}/../)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
 include(yaml)
 
-file(READ ${EXPANDED_FILE} json_content)
-to_yaml("${json_content}" 0 yaml_out TRUE)
+# Fix all quotes in the input YAML file. Strings in it will be in one of the
+# following formats:
+#
+#   name: 'string with 'single quotes' in it'
+#       - 'string with 'single quotes' in it'
+#
+# To address this, every single quote is duplicated, then the first and last
+# occurrences of two single quotes are removed (they are the string beginning
+# and end markers). The result is written to a temporary file.
+file(STRINGS ${EXPANDED_FILE} yaml_content)
+foreach(line ${yaml_content})
+  string(REPLACE "'" "''" line "${line}") # escape every single quote in the string
+  string(REGEX REPLACE "^([^']* )''" "\\1'" line "${line}") # fix opening quote
+  string(REGEX REPLACE "''$" "'" line "${line}") # fix closing quote
+  # semicolons in the string are not to be confused with string separators
+  string(REPLACE ";" "\\;" line "${line}")
+  list(APPEND tmp_content "${line}")
+endforeach()
+list(JOIN tmp_content "\n" tmp_content)
+file(WRITE ${EXPANDED_FILE}.tmp "${tmp_content}")
+
+# Load the now-fixed YAML file and convert the CMake-format lists back into
+# proper YAML format using the to_yaml() function. The result is written to
+# the final destination file.
+yaml_load(FILE ${EXPANDED_FILE}.tmp NAME yaml_saved)
+zephyr_get_scoped(json_content yaml_saved JSON)
+to_yaml("${json_content}" 0 yaml_out FINAL_GENEX)
 file(WRITE ${OUTPUT_FILE} "${yaml_out}")
 
 # Remove unused temporary files. EXPANDED_FILE needs to be kept, or the
-# build system will complain there is no rule to rebuild it
+# build system will complain there is no rule to rebuild it, but the
+# .tmp file that was just created can be removed.
 list(REMOVE_ITEM TEMP_FILES ${EXPANDED_FILE})
+list(APPEND TEMP_FILES ${EXPANDED_FILE}.tmp)
 foreach(file ${TEMP_FILES})
   file(REMOVE ${file})
 endforeach()

--- a/tests/cmake/yaml/CMakeLists.txt
+++ b/tests/cmake/yaml/CMakeLists.txt
@@ -242,6 +242,46 @@ function(test_setting_list_strings)
   endforeach()
 endfunction()
 
+function(test_setting_list_escaped_strings)
+  yaml_create(FILE ${CMAKE_BINARY_DIR}/${CMAKE_CURRENT_FUNCTION}_test_create.yaml
+              NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create
+  )
+
+  set(new_value "back\\slash" "dou\"ble" "sin'gle" "co:lon" "win:\\path")
+  yaml_set(NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create
+           KEY cmake test set key-list-string LIST ${new_value}
+  )
+
+  yaml_save(NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create)
+
+  # Read-back the yaml and verify the value.
+  yaml_load(FILE ${CMAKE_BINARY_DIR}/${CMAKE_CURRENT_FUNCTION}_test_create.yaml
+            NAME ${CMAKE_CURRENT_FUNCTION}_readback
+  )
+
+  yaml_length(readback NAME ${CMAKE_CURRENT_FUNCTION}_readback KEY cmake test set key-list-string)
+
+  test_assert(TEST 5 EQUAL ${readback}
+              COMMENT "readback yaml list length does not match original."
+  )
+
+  yaml_get(readback NAME ${CMAKE_CURRENT_FUNCTION}_readback KEY cmake test set key-list-string)
+
+  foreach(a e IN ZIP_LISTS readback new_value)
+    # cmake_parse_arguments() breaks horribly when given strings that include
+    # escapes, making it impossible to use test_assert() here. Or, for that
+    # matter, even trying to print them in message(). Thanks, CMake!
+    if("${e}" STREQUAL "${a}")
+      message("${CMAKE_CURRENT_FUNCTION}(): Passed")
+    else()
+      message(FATAL_ERROR
+        "${CMAKE_CURRENT_FUNCTION}(): Failed\n"
+        "Test: list values mismatch."
+      )
+    endif()
+  endforeach()
+endfunction()
+
 function(test_append_list_strings)
   yaml_create(FILE ${CMAKE_BINARY_DIR}/${CMAKE_CURRENT_FUNCTION}_test_create.yaml
               NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create
@@ -653,6 +693,51 @@ function(test_verify_genexes)
   endforeach()
 endfunction()
 
+function(test_setting_escaped_genexes)
+  set(file ${CMAKE_BINARY_DIR}/test_setting_escaped_genexes.yaml)
+  yaml_create(FILE ${file}
+              NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create
+  )
+
+  set_property(TARGET app PROPERTY escaped_list
+               "back\\slash" "dou\"ble" "sin'gle" "co:lon" "win:\\path")
+  yaml_set(NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create
+           KEY cmake test set key-list-string-genex
+           GENEX LIST "$<TARGET_PROPERTY:app,escaped_list>"
+  )
+
+  yaml_save(NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create)
+endfunction()
+
+function(test_verify_escaped_genexes)
+  set(file ${CMAKE_BINARY_DIR}/test_setting_escaped_genexes.yaml)
+  yaml_load(FILE ${file}
+      NAME ${CMAKE_CURRENT_FUNCTION}_readback
+  )
+
+  set(expected "back\\slash" "dou\"ble" "sin'gle" "co:lon" "win:\\path")
+  list(LENGTH expected exp_len)
+
+  yaml_get(readback NAME ${CMAKE_CURRENT_FUNCTION}_readback KEY cmake test set key-list-string-genex)
+  yaml_length(act_len NAME ${CMAKE_CURRENT_FUNCTION}_readback KEY cmake test set key-list-string-genex)
+
+  test_assert(TEST ${exp_len} EQUAL ${act_len}
+              COMMENT "yaml list length does not match expectation."
+  )
+
+  foreach(a e IN ZIP_LISTS readback expected)
+    # See comment in test_setting_list_escaped_strings() for why test_assert() is not used here.
+    if("${e}" STREQUAL "${a}")
+      message("${CMAKE_CURRENT_FUNCTION}(): Passed")
+    else()
+      message(FATAL_ERROR
+        "${CMAKE_CURRENT_FUNCTION}(): Failed\n"
+        "Test: key-list-string-genex list values mismatch."
+      )
+    endif()
+  endforeach()
+endfunction()
+
 function(test_set_remove_int)
   yaml_create(FILE ${CMAKE_BINARY_DIR}/${CMAKE_CURRENT_FUNCTION}_test_create.yaml
               NAME ${CMAKE_CURRENT_FUNCTION}_yaml-create
@@ -728,6 +813,7 @@ test_save_new_file()
 test_setting_int()
 test_setting_string()
 test_setting_list_strings()
+test_setting_list_escaped_strings()
 test_setting_list_int()
 test_setting_map_list_entry()
 test_setting_map_list_entry_windows()
@@ -749,6 +835,7 @@ test_fail_missing_filename()
 if(NOT CMAKE_SCRIPT_MODE_FILE)
   # create a file containing genexes
   test_setting_genexes()
+  test_setting_escaped_genexes()
 
   # Spawn a new CMake instance to re-run the whole test suite in script mode
   # and verify the genex values once the associated target is built.
@@ -756,6 +843,7 @@ if(NOT CMAKE_SCRIPT_MODE_FILE)
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_FILE}
   )
 else()
-  # verify the contents of the created genex file
+  # verify the contents of the created genex files
   test_verify_genexes()
+  test_verify_escaped_genexes()
 endif()

--- a/tests/cmake/yaml/CMakeLists.txt
+++ b/tests/cmake/yaml/CMakeLists.txt
@@ -475,7 +475,7 @@ function(test_setting_map_list_entry_commas)
     test_assert(TEST "${readback_name}" STREQUAL "${new_entry_name_${index}}"
                 COMMENT "list values mismatch."
     )
-    test_assert(TEST "'${readback_str}'" STREQUAL "${new_entry_str_${index}}"
+    test_assert(TEST "${readback_str}" STREQUAL "${new_entry_str_${index}}"
                 COMMENT "list values mismatch."
     )
   endforeach()


### PR DESCRIPTION
The current YAML export has problems dealing with strings that include special characters such as single/double quotes or backslashes. This is evident when enabling the LLEXT EDK on certain targets / applications, as described in #87765. 

This PR addresses these issues by enclosing generated YAML strings in single quotes to simplify escaping. The intermediate genex file is also switched to YAML to achieve the same result.

The `to_yaml` internal function and `yaml-filter.cmake` have been improved to output the correct "flavor" of YAML depending on the current export stage.  

Finally, a new test case is added to verify that `'`, `"` and `\` are now properly processed, both when passed directly to `yaml_set()` or after genex expansion.

### Known limitations

These special characters are still not supported in the `LIST MAP` implementation. 

### Review notes
 
The first two commits in the PR series introduce no functional changes but do several renames / refactors. The rationale behind the other changes is detailed in each commit description.