### PR TITLE
Bluetooth: Controller: Single recv thread for HCI-only builds

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -116,10 +116,27 @@ config BT_CTLR_TIFS_HW_SUPPORT
 config BT_CTLR_ULL_LLL_PRIO_SUPPORT
 	bool
 
+config BT_CTLR_RX_POLL
+	# Hidden, Enable Async I/O Framework, i.e. k_poll
+	bool
+	depends on BT_HCI_RAW || BT_HCI_ACL_FLOW_CONTROL
+	select POLL
+	default y
+
 config BT_CTLR_RX_PRIO_STACK_SIZE
-	# Hidden, Controller's Co-Operative high priority Rx thread stack size.
+	# Hidden
 	int
+	depends on !BT_HCI_RAW
 	default 448
+	help
+	  Controller's Co-Operative high priority Rx thread stack size.
+
+	  Rx priority thread is used in Combined Host plus Controller builds to
+	  prioritize Number of Completed Packets event and Disconnect Event
+	  towards the Host while already enqueued ACL and ISO Data are blocked
+	  in the normal Rx thread waiting for free Tx buffer be available.
+
+	  Rx priority thread is redundant in a Controller-only build.
 
 config BT_CTLR_RX_STACK_SIZE
 	# Hidden, Controller's Co-Operative Rx thread stack size.

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -8791,6 +8791,15 @@ static void encode_control(struct node_rx_pdu *node_rx,
 
 	case NODE_RX_TYPE_TERMINATE:
 		hci_disconn_complete_encode(pdu_data, handle, buf);
+
+#if !defined(CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE)
+		/* Similar to the design of processing the termination when using Rx priority
+		 * thread, we process the termination event to handle Controller to Host data
+		 * flowcontrol in the Controller here.
+		 */
+		hci_disconn_complete_process(handle);
+#endif /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
+
 		break;
 
 	case NODE_RX_TYPE_CONN_UPDATE:


### PR DESCRIPTION
Updated implementation to use single receive thread to enqueue HCI ISO data, ACL data and events towards Host when building HCI-Only samples/applications, i.e. when building hci_uart, hci_spi or hci_ipc samples (CONFIG_BT_HCI_RAW=y).

This implementation will serialize HCI events and data as they occur corresponding to on-air timelines of their occurrences which is how they are generated by the Link Layer.