### PR TITLE
stm32 uart/spi/adc: support DMA when CONFIG_MEM_ATTR=n

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -18,6 +18,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/toolchain.h>
 #include <soc.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
@@ -53,12 +54,7 @@ LOG_MODULE_REGISTER(adc_stm32);
 #include <stm32_ll_system.h>
 #endif
 
-#ifdef CONFIG_NOCACHE_MEMORY
 #include <zephyr/linker/linker-defs.h>
-#elif defined(CONFIG_CACHE_MANAGEMENT)
-#include <zephyr/arch/cache.h>
-#endif /* CONFIG_NOCACHE_MEMORY */
-
 
 /* Here are some redefinitions of ADC versions for better readability */
 #if defined(CONFIG_SOC_SERIES_STM32F3X)
@@ -281,7 +277,7 @@ static int adc_stm32_dma_start(const struct device *dev,
  *		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) | ... )>;
  *	};
  */
-static bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
+static bool buf_in_nocache(uintptr_t buf __maybe_unused, size_t len_bytes __maybe_unused)
 {
 	bool buf_within_nocache = false;
 
@@ -293,8 +289,10 @@ static bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
 	}
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+#ifdef CONFIG_MEM_ATTR
 	buf_within_nocache = mem_attr_check_buf(
 		(void *)buf, len_bytes, DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)) == 0;
+#endif /* CONFIG_MEM_ATTR */
 
 	return buf_within_nocache;
 }

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -21,12 +21,10 @@
 #include <zephyr/pm/device_runtime.h>
 #include "i2c_ll_stm32.h"
 
-#if defined(CONFIG_DCACHE) && defined(CONFIG_I2C_STM32_V2_DMA)
 #include <zephyr/cache.h>
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-#endif
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -697,12 +695,14 @@ static bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
 	}
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+#ifdef CONFIG_MEM_ATTR
 	/* Check if buffer is in nocache memory region defined in DT */
 	buf_within_nocache = mem_attr_check_buf(
 		(void *)buf, len_bytes, DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)) == 0;
 	if (buf_within_nocache) {
 		return true;
 	}
+#endif /* CONFIG_MEM_ATTR */
 
 	/* Check if buffer is in RO region (Flash..) */
 	buf_within_nocache = (buf >= ((uintptr_t)__rodata_region_start)) &&

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -39,11 +39,9 @@
 #include <stm32_ll_exti.h>
 #endif /* CONFIG_PM */
 
-#ifdef CONFIG_DCACHE
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-#endif /* CONFIG_DCACHE */
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -1396,11 +1394,13 @@ static bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
 	}
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+#ifdef CONFIG_MEM_ATTR
 	buf_within_nocache = mem_attr_check_buf(
 		(void *)buf, len_bytes, DT_MEM_ARM_MPU_RAM_NOCACHE) == 0;
 	if (buf_within_nocache) {
 		return true;
 	}
+#endif /* CONFIG_MEM_ATTR */
 
 	buf_within_nocache = (buf >= ((uintptr_t)__rodata_region_start)) &&
 		((buf + len_bytes - 1) <= ((uintptr_t)__rodata_region_end));

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -30,16 +30,9 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
-
-#ifdef CONFIG_DCACHE
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
-#endif /* CONFIG_DCACHE */
-
-#ifdef CONFIG_NOCACHE_MEMORY
 #include <zephyr/linker/linker-defs.h>
-#elif defined(CONFIG_CACHE_MANAGEMENT)
 #include <zephyr/arch/cache.h>
-#endif /* CONFIG_NOCACHE_MEMORY */
 
 #include "spi_ll_stm32.h"
 
@@ -1082,7 +1075,7 @@ static int wait_dma_rx_tx_done(const struct device *dev)
 }
 
 #ifdef CONFIG_DCACHE
-static bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
+static bool buf_in_nocache(uintptr_t buf __maybe_unused, size_t len_bytes __maybe_unused)
 {
 	bool buf_within_nocache = false;
 
@@ -1095,9 +1088,11 @@ static bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
 	}
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+#ifdef CONFIG_MEM_ATTR
 	/* Check if buffer is in nocache memory region defined in DT */
 	buf_within_nocache = mem_attr_check_buf(
 		(void *)buf, len_bytes, DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)) == 0;
+#endif /* CONFIG_MEM_ATTR */
 
 	return buf_within_nocache;
 }


### PR DESCRIPTION
~~Explicit that some configurations of the STM32 ADC, SPI and UART drivers require `CONFIG_MEM_ATTR=y`.~~

(edited)
Allow STM32 SPI/ADC/UART/I2C drivers to operate with DMA support even when `CONFIG_MEM_ATTR` is disabled which happen when `CONFIG_ARM_MPU` is intentionally disabled despite the CPU supports MPU.
By the way, remove some #ifdef directive on header files inclusion that add noise in the header file inclusion section without any benefit.


These changes do not fix existing issues but are proposed to prevent later issues, as mentioned in https://github.com/zephyrproject-rtos/zephyr/pull/87681#issuecomment-2754737646.