### PR TITLE
dts: rp2350: Fix USB controller base address

### DIFF
--- a/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
@@ -413,9 +413,9 @@
 			#dma-cells = <3>;
 		};
 
-		usbd: usbd@50100000 {
+		usbd: usbd@50110000 {
 			compatible = "raspberrypi,pico-usbd";
-			reg = <0x50100000 0x10000>;
+			reg = <0x50110000 0x10000>;
 			resets = <&reset RPI_PICO_RESETS_RESET_USBCTRL>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_USB>;
 			interrupts = <14 RPI_PICO_DEFAULT_IRQ_PRIORITY>;


### PR DESCRIPTION
Fix USB controller base address.
rp2040 was fixed in a10f2e8 and the rp2350 uses the same base address.