### PR TITLE
tests: Bluetooth: Tester: HAP BSIM test

### DIFF
--- a/tests/bsim/bluetooth/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/tester/CMakeLists.txt
@@ -24,6 +24,8 @@ zephyr_include_directories(
 target_sources(app PRIVATE
   src/bsim_btp.c
   src/test_main.c
+  src/audio/hap_central.c
+  src/audio/hap_peripheral.c
   src/audio/micp_central.c
   src/audio/micp_peripheral.c
   src/audio/vcp_central.c

--- a/tests/bsim/bluetooth/tester/src/audio/hap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/hap_central.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_hap_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_hap_central(void)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t remote_addr;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_HAP);
+
+	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
+	bsim_btp_wait_for_gap_device_found(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Found remote device %s", addr_str);
+
+	bsim_btp_gap_stop_discovery();
+	bsim_btp_gap_connect(&remote_addr, BTP_GAP_ADDR_TYPE_IDENTITY);
+	bsim_btp_wait_for_gap_device_connected(NULL);
+	LOG_INF("Device %s connected", addr_str);
+
+	bsim_btp_gap_pair(&remote_addr);
+	bsim_btp_wait_for_gap_sec_level_changed(NULL, NULL);
+
+	bsim_btp_hauc_init();
+	bsim_btp_hauc_discover(&remote_addr);
+	bsim_btp_wait_for_hauc_discovery_complete(NULL);
+
+	bsim_btp_gap_disconnect(&remote_addr);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "hap_central",
+		.test_descr = "Smoketest for the HAP central BT Tester behavior",
+		.test_main_f = test_hap_central,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_hap_central_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/hap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/hap_peripheral.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/has.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_hap_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_hap_peripheral(void)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t remote_addr;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_HAS);
+
+	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
+	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
+	bsim_btp_wait_for_gap_device_connected(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Device %s connected", addr_str);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "hap_peripheral",
+		.test_descr = "Smoketest for the HAP peripheral BT Tester behavior",
+		.test_main_f = test_hap_peripheral,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_hap_peripheral_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -244,6 +244,60 @@ static inline void bsim_btp_wait_for_gap_sec_level_changed(bt_addr_le_t *address
 	net_buf_unref(buf);
 }
 
+static inline void bsim_btp_hauc_init(void)
+{
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_HAP;
+	cmd_hdr->opcode = BTP_HAP_HAUC_INIT;
+	cmd_hdr->index = BTP_INDEX;
+
+	/* command is empty */
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_hauc_discover(const bt_addr_le_t *address)
+{
+	struct btp_hap_hauc_discover_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_HAP;
+	cmd_hdr->opcode = BTP_HAP_HAUC_DISCOVER;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_wait_for_hauc_discovery_complete(bt_addr_le_t *address)
+{
+	struct btp_hap_hauc_discovery_complete_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_HAP, BT_HAP_EV_HAUC_DISCOVERY_COMPLETE, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	TEST_ASSERT(ev->status == BT_ATT_ERR_SUCCESS);
+
+	if (address != NULL) {
+		bt_addr_le_copy(address, &ev->address);
+	}
+
+	net_buf_unref(buf);
+}
+
 static inline void bsim_btp_vcp_discover(const bt_addr_le_t *address)
 {
 	struct btp_vcp_discover_cmd *cmd;

--- a/tests/bsim/bluetooth/tester/src/test_main.c
+++ b/tests/bsim/bluetooth/tester/src/test_main.c
@@ -9,6 +9,8 @@
 
 extern struct bst_test_list *test_gap_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_gap_peripheral_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_hap_central_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_hap_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_micp_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_micp_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_vcp_central_install(struct bst_test_list *tests);
@@ -17,6 +19,8 @@ extern struct bst_test_list *test_vcp_peripheral_install(struct bst_test_list *t
 bst_test_install_t test_installers[] = {
 	test_gap_central_install,
 	test_gap_peripheral_install,
+	test_hap_central_install,
+	test_hap_peripheral_install,
 	test_micp_central_install,
 	test_micp_peripheral_install,
 	test_vcp_central_install,

--- a/tests/bsim/bluetooth/tester/tests_scripts/hap.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/hap.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoketest for HAP BTP commands with the BT tester
+
+simulation_id="tester_hap"
+verbosity_level=2
+EXECUTE_TIMEOUT=100
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+UART_DIR=/tmp/bs_${USER}/${simulation_id}/
+UART_PER=${UART_DIR}/peripheral
+UART_CEN=${UART_DIR}/central
+
+# Central BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=10 -d=0 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_CEN}.tx -uart0_fifob_txfile=${UART_CEN}.rx
+
+# Central Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=21 -d=10 -RealEncryption=1 -testid=hap_central \
+  -nosim -uart0_fifob_rxfile=${UART_CEN}.rx -uart0_fifob_txfile=${UART_CEN}.tx
+
+# Peripheral BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=32 -d=1 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_PER}.tx -uart0_fifob_txfile=${UART_PER}.rx
+
+# Peripheral Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=43 -d=11 -RealEncryption=1 -testid=hap_peripheral \
+  -nosim -uart0_fifob_rxfile=${UART_PER}.rx -uart0_fifob_txfile=${UART_PER}.tx
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs # Wait for all programs in background and return != 0 if any fails


### PR DESCRIPTION
Adds BSIM testing of the HAP features of the BT Tester.


Part of https://github.com/zephyrproject-rtos/zephyr/issues/86073