### PR TITLE
MAINTAINERS: Recursive globbing is not supported

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3615,9 +3615,11 @@ Silabs Platforms:
     - boards/silabs/
     - dts/arm/silabs/
     - dts/bindings/*/silabs*
-    - drivers/**/*gecko*
-    - drivers/**/*silabs*
-    - drivers/**/*siwx91x*
+    - drivers/*/*gecko*
+    - drivers/*/*silabs*
+    - drivers/*/*siwx91x*
+    - drivers/*/*/*silabs*
+    - drivers/*/*/*siwx91x*
     - tests/boards/silabs/
   labels:
     - "platform: Silabs"
@@ -5681,8 +5683,8 @@ Testing with Renode:
     - cmake/emu/renode.cmake
     - soc/renode/
     - boards/renode/
-    - boards/**/*/support/*.repl
-    - boards/**/*/support/*.resc
+    - boards/*/*/support/*.repl
+    - boards/*/*/support/*.resc
   labels:
     - "area: Renode"
 


### PR DESCRIPTION
get_maintainer.py does not support recursive glob.

In the future, get_maintainer.pl could take advantage of [`glob.translate()`][1]. Unfortunately, `glob.translate()` is only supported from Python 3.14 which is not yet widely adopted.

Meanwhile, just avoid to use recursive globs.

[1]: https://docs.python.org/3/library/glob.html#glob.translate