### PR TITLE
west: runners: openocd: Fix version format regression

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -233,7 +233,7 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                                 stderr=subprocess.STDOUT).decode()
 
         # Account for version info format of ADI fork of OpenOCD as well
-        version_match = re.search(r"Open On-Chip Debugger.* v?(\d+.\d+.\d+)[ \n]", out)
+        version_match = re.search(r"Open On-Chip Debugger.* v?(\d+.\d+.\d+)", out)
         version = version_match.group(1).split('.')
 
         return [to_num(i) for i in version]


### PR DESCRIPTION
Change OpenOCD version regex to be compatible again with format strings not having a space or newline immediately after the version nr.

Modified regex has been verified with the strings listed below.

Ubuntu:
"Open On-Chip Debugger 0.11.0"

ADI:
"Open On-Chip Debugger (Analog Devices 0.12.0-1.1.1)  OpenOCD 0.12.0 (2024-08-27-17:25)"

Zephyr SDK:
"Open On-Chip Debugger 0.11.0+dev-00728-gb6f95a16c (2024-02-17-23:51)"

Infineon:
"Open On-Chip Debugger 0.12.0+dev-5.2.1.3248 (2024-08-08-17:29)"

Espressif:
"Open On-Chip Debugger v0.12.0-esp32-20240318 (2024-03-18-18:25)"

Fixes: 1c05f2121cc7 ("west: runners: openocd: Handle ADI OpenOCD fork version format")