### PR TITLE
tests: Bluetooth: Tester: Update README to rst and add text

### DIFF
--- a/tests/bluetooth/tester/README.rst
+++ b/tests/bluetooth/tester/README.rst
@@ -1,8 +1,7 @@
-Title: Bluetooth tester application
+Bluetooth Tester application
+############################
 
-Description:
-
-Tester application uses binary protocol to control Zephyr stack and is aimed at
+The Tester application uses binary protocol to control Zephyr stack and is aimed at
 automated testing. It requires two serial ports to operate.
 The first serial is used by Bluetooth Testing Protocol (BTP) to drive Bluetooth
 stack. BTP commands and events are received and buffered for further processing
@@ -16,14 +15,53 @@ by Bluetooth SIG.
 See https://docs.zephyrproject.org/latest/guides/bluetooth/index.html for full
 documentation about how to use this test.
 
---------------------------------------------------------------------------------
 
-Supported Profiles:
+Supported Profiles and Services
+*******************************
 
-GAP, GATT, SM
---------------------------------------------------------------------------------
+Host/Core
+=========
 
-Building and running on QEMU:
+* GAP
+* GATT
+* IAS
+* L2CAP
+* OTS
+* SM
+
+LE Audio
+========
+
+* AICS
+* ASCS
+* BAP
+* CAP
+* CAS
+* CCP
+* CSIP
+* CSIS
+* HAP
+* HAS
+* MCP
+* MCS
+* MCIP
+* MICS
+* PACS
+* PBP
+* TBS
+* TMAP
+* VCP
+* VCS
+* VOCS
+
+Mesh
+====
+
+* Mesh Node
+* Mesh Model
+
+Building and running on QEMU
+****************************
 
 QEMU should have connection with the external host Bluetooth hardware.
 The btproxy tool from BlueZ can be used to give access to a Bluetooth controller
@@ -43,7 +81,6 @@ Note: Target board have to support enough UARTs for BTP and controller.
 
 'bt-stack-tester' UNIX socket (previously set in Makefile) can be used for now
 to control tester application.
---------------------------------------------------------------------------------
 
 Next, build and flash tester application by employing the "flash" build
 target.
@@ -51,3 +88,12 @@ target.
 Use serial client, e.g. PUTTY to communicate over the serial port
 (typically /dev/ttyUSBx) with the tester using BTP.
 
+Building for LE Audio
+*********************
+
+The tester application can be built with support for BT LE Audio by applying the
+the ``overlay-le-audio.conf`` and ``hci_ipc.conf`` with ``--sysbuild`` for the supported boards,
+e.g.:
+
+    west build -b nrf5340dk/nrf5340/cpuapp --sysbuild \
+        -- -DEXTRA_CONF_FILE=overlay-le-audio.conf;hci_ipc.conf


### PR DESCRIPTION
Update the README file to be .rst instead of (implied) .md and update the text w.r.t. supported profiles and services, and how to build for LE Audio.