### PR TITLE
samples: boards: st: uart: update code sample reference to be unique

### DIFF
--- a/samples/boards/st/uart/circular_dma/README.rst
+++ b/samples/boards/st/uart/circular_dma/README.rst
@@ -1,8 +1,8 @@
-.. zephyr:code-sample:: uart
+.. zephyr:code-sample:: uart-circular-dma
    :name: UART circular mode
    :relevant-api: uart_interface
 
-   Read data from the console and echo it back using a circular dma configuration.
+   Read data from the console and echo it back using a circular DMA configuration.
 
 Overview
 ********


### PR DESCRIPTION
Not sure why this wasn't caught before but this sample needs a unique name (conflicts with drivers/uart/echo_bot/README.rst otherwise)

This is causing scheduled build of the documentation to fail at the moment.