### PR TITLE
shell: mqtt: optimize `sh_mqtt` variable access and improve `rx_rb` flushing

### DIFF
--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -91,19 +91,19 @@ bool __weak shell_mqtt_get_devid(char *id, int id_max_len)
 	return length > 0;
 }
 
-static void prepare_fds(void)
+static void prepare_fds(struct shell_mqtt *sh)
 {
-	if (sh_mqtt->mqtt_cli.transport.type == MQTT_TRANSPORT_NON_SECURE) {
-		sh_mqtt->fds[0].fd = sh_mqtt->mqtt_cli.transport.tcp.sock;
+	if (sh->mqtt_cli.transport.type == MQTT_TRANSPORT_NON_SECURE) {
+		sh->fds[0].fd = sh->mqtt_cli.transport.tcp.sock;
 	}
 
-	sh_mqtt->fds[0].events = ZSOCK_POLLIN;
-	sh_mqtt->nfds = 1;
+	sh->fds[0].events = ZSOCK_POLLIN;
+	sh->nfds = 1;
 }
 
-static void clear_fds(void)
+static void clear_fds(struct shell_mqtt *sh)
 {
-	sh_mqtt->nfds = 0;
+	sh->nfds = 0;
 }
 
 /*
@@ -113,12 +113,12 @@ static void clear_fds(void)
  * descriptors have been selected. Upon failure, poll() shall return -1 and set errno to indicate
  * the error.
  */
-static int wait(int timeout)
+static int wait(struct shell_mqtt *sh, int timeout)
 {
 	int rc = 0;
 
-	if (sh_mqtt->nfds > 0) {
-		rc = zsock_poll(sh_mqtt->fds, sh_mqtt->nfds, timeout);
+	if (sh->nfds > 0) {
+		rc = zsock_poll(sh->fds, sh->nfds, timeout);
 		if (rc < 0) {
 			LOG_ERR("poll error: %d", errno);
 		}
@@ -128,19 +128,19 @@ static int wait(int timeout)
 }
 
 /* Query IP address for the broker URL */
-static int get_mqtt_broker_addrinfo(void)
+static int get_mqtt_broker_addrinfo(struct shell_mqtt *sh)
 {
 	int rc;
 	struct zsock_addrinfo hints = { .ai_family = AF_INET,
 					.ai_socktype = SOCK_STREAM,
 					.ai_protocol = 0 };
 
-	if (sh_mqtt->haddr != NULL) {
-		zsock_freeaddrinfo(sh_mqtt->haddr);
+	if (sh->haddr != NULL) {
+		zsock_freeaddrinfo(sh->haddr);
 	}
 
 	rc = zsock_getaddrinfo(CONFIG_SHELL_MQTT_SERVER_ADDR,
-			       STRINGIFY(CONFIG_SHELL_MQTT_SERVER_PORT), &hints, &sh_mqtt->haddr);
+			       STRINGIFY(CONFIG_SHELL_MQTT_SERVER_PORT), &hints, &sh->haddr);
 	if (rc == 0) {
 		LOG_INF("DNS%s resolved for %s:%d", "", CONFIG_SHELL_MQTT_SERVER_ADDR,
 			CONFIG_SHELL_MQTT_SERVER_PORT);
@@ -155,7 +155,7 @@ static int get_mqtt_broker_addrinfo(void)
 }
 
 /* Close MQTT connection properly and cleanup socket */
-static void sh_mqtt_close_and_cleanup(void)
+static void sh_mqtt_close_and_cleanup(struct shell_mqtt *sh)
 {
 	/* Initialize to negative value so that the mqtt_abort case can run */
 	int rc = -1;
@@ -164,9 +164,9 @@ static void sh_mqtt_close_and_cleanup(void)
 	 * disconnection packet to the broker, it will invoke
 	 * mqtt_evt_handler:MQTT_EVT_DISCONNECT if success
 	 */
-	if ((sh_mqtt->network_state == SHELL_MQTT_NETWORK_CONNECTED) &&
-	    (sh_mqtt->transport_state == SHELL_MQTT_TRANSPORT_CONNECTED)) {
-		rc = mqtt_disconnect(&sh_mqtt->mqtt_cli, NULL);
+	if ((sh->network_state == SHELL_MQTT_NETWORK_CONNECTED) &&
+	    (sh->transport_state == SHELL_MQTT_TRANSPORT_CONNECTED)) {
+		rc = mqtt_disconnect(&sh->mqtt_cli, NULL);
 	}
 
 	/* If network/mqtt disconnected, or mqtt_disconnect failed, do mqtt_abort */
@@ -175,24 +175,24 @@ static void sh_mqtt_close_and_cleanup(void)
 		 * makes sure that the MQTT connection is aborted locally and will
 		 * always invoke mqtt_evt_handler:MQTT_EVT_DISCONNECT
 		 */
-		(void)mqtt_abort(&sh_mqtt->mqtt_cli);
+		(void)mqtt_abort(&sh->mqtt_cli);
 	}
 
 	/* Cleanup socket */
-	clear_fds();
+	clear_fds(sh);
 }
 
-static void broker_init(void)
+static void broker_init(struct shell_mqtt *sh)
 {
-	struct sockaddr_in *broker4 = (struct sockaddr_in *)&sh_mqtt->broker;
+	struct sockaddr_in *broker4 = (struct sockaddr_in *)&sh->broker;
 
 	broker4->sin_family = AF_INET;
 	broker4->sin_port = htons(CONFIG_SHELL_MQTT_SERVER_PORT);
 
-	net_ipaddr_copy(&broker4->sin_addr, &net_sin(sh_mqtt->haddr->ai_addr)->sin_addr);
+	net_ipaddr_copy(&broker4->sin_addr, &net_sin(sh->haddr->ai_addr)->sin_addr);
 }
 
-static void client_init(void)
+static void client_init(struct shell_mqtt *sh)
 {
 	static struct mqtt_utf8 password;
 	static struct mqtt_utf8 username;
@@ -202,36 +202,37 @@ static void client_init(void)
 	username.utf8 = (uint8_t *)MQTT_USERNAME;
 	username.size = strlen(MQTT_USERNAME);
 
-	mqtt_client_init(&sh_mqtt->mqtt_cli);
+	mqtt_client_init(&sh->mqtt_cli);
 
 	/* MQTT client configuration */
-	sh_mqtt->mqtt_cli.broker = &sh_mqtt->broker;
-	sh_mqtt->mqtt_cli.evt_cb = mqtt_evt_handler;
-	sh_mqtt->mqtt_cli.client_id.utf8 = (uint8_t *)sh_mqtt->device_id;
-	sh_mqtt->mqtt_cli.client_id.size = strlen(sh_mqtt->device_id);
-	sh_mqtt->mqtt_cli.password = &password;
-	sh_mqtt->mqtt_cli.user_name = &username;
-	sh_mqtt->mqtt_cli.protocol_version = MQTT_VERSION_3_1_1;
+	sh->mqtt_cli.broker = &sh->broker;
+	sh->mqtt_cli.evt_cb = mqtt_evt_handler;
+	sh->mqtt_cli.client_id.utf8 = (uint8_t *)sh->device_id;
+	sh->mqtt_cli.client_id.size = strlen(sh->device_id);
+	sh->mqtt_cli.password = &password;
+	sh->mqtt_cli.user_name = &username;
+	sh->mqtt_cli.protocol_version = MQTT_VERSION_3_1_1;
 
 	/* MQTT buffers configuration */
-	sh_mqtt->mqtt_cli.rx_buf = sh_mqtt->buf.rx;
-	sh_mqtt->mqtt_cli.rx_buf_size = sizeof(sh_mqtt->buf.rx);
-	sh_mqtt->mqtt_cli.tx_buf = sh_mqtt->buf.tx;
-	sh_mqtt->mqtt_cli.tx_buf_size = sizeof(sh_mqtt->buf.tx);
+	sh->mqtt_cli.rx_buf = sh->buf.rx;
+	sh->mqtt_cli.rx_buf_size = sizeof(sh->buf.rx);
+	sh->mqtt_cli.tx_buf = sh->buf.tx;
+	sh->mqtt_cli.tx_buf_size = sizeof(sh->buf.tx);
 
 	/* MQTT transport configuration */
-	sh_mqtt->mqtt_cli.transport.type = MQTT_TRANSPORT_NON_SECURE;
+	sh->mqtt_cli.transport.type = MQTT_TRANSPORT_NON_SECURE;
 }
 
 /* Work routine to process MQTT packet and keep alive MQTT connection */
 static void sh_mqtt_process_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
+	struct shell_mqtt *sh = sh_mqtt;
 	int rc;
 	int64_t remaining = LISTEN_TIMEOUT_MS;
 	int64_t start_time = k_uptime_get();
 
-	if (sh_mqtt->network_state != SHELL_MQTT_NETWORK_CONNECTED) {
+	if (sh->network_state != SHELL_MQTT_NETWORK_CONNECTED) {
 		LOG_DBG("%s_work while %s", "process", "network disconnected");
 		return;
 	}
@@ -243,26 +244,26 @@ static void sh_mqtt_process_handler(struct k_work *work)
 		return;
 	}
 
-	if (sh_mqtt->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
+	if (sh->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
 		LOG_DBG("MQTT %s", "not connected");
 		goto process_error;
 	}
 
-	if (sh_mqtt->subscribe_state != SHELL_MQTT_SUBSCRIBED) {
+	if (sh->subscribe_state != SHELL_MQTT_SUBSCRIBED) {
 		LOG_DBG("%s_work while %s", "process", "MQTT not subscribed");
 		goto process_error;
 	}
 
 	LOG_DBG("MQTT %s", "Processing");
 	/* Listen to the port for a duration defined by LISTEN_TIMEOUT_MS */
-	while ((remaining > 0) && (sh_mqtt->network_state == SHELL_MQTT_NETWORK_CONNECTED) &&
-	       (sh_mqtt->transport_state == SHELL_MQTT_TRANSPORT_CONNECTED) &&
-	       (sh_mqtt->subscribe_state == SHELL_MQTT_SUBSCRIBED)) {
+	while ((remaining > 0) && (sh->network_state == SHELL_MQTT_NETWORK_CONNECTED) &&
+	       (sh->transport_state == SHELL_MQTT_TRANSPORT_CONNECTED) &&
+	       (sh->subscribe_state == SHELL_MQTT_SUBSCRIBED)) {
 		LOG_DBG("Listening to socket");
-		rc = wait(remaining);
+		rc = wait(sh, remaining);
 		if (rc > 0) {
 			LOG_DBG("Process socket for MQTT packet");
-			rc = mqtt_input(&sh_mqtt->mqtt_cli);
+			rc = mqtt_input(&sh->mqtt_cli);
 			if (rc != 0) {
 				LOG_ERR("%s error: %d", "processed: mqtt_input", rc);
 				goto process_error;
@@ -272,7 +273,7 @@ static void sh_mqtt_process_handler(struct k_work *work)
 		}
 
 		LOG_DBG("MQTT %s", "Keepalive");
-		rc = mqtt_live(&sh_mqtt->mqtt_cli);
+		rc = mqtt_live(&sh->mqtt_cli);
 		if ((rc != 0) && (rc != -EAGAIN)) {
 			LOG_ERR("%s error: %d", "mqtt_live", rc);
 			goto process_error;
@@ -283,30 +284,32 @@ static void sh_mqtt_process_handler(struct k_work *work)
 
 	/* Reschedule the process work */
 	LOG_DBG("Scheduling %s work", "process");
-	(void)sh_mqtt_work_reschedule(&sh_mqtt->process_dwork, K_SECONDS(2));
+	(void)sh_mqtt_work_reschedule(&sh->process_dwork, K_SECONDS(2));
 	sh_mqtt_context_unlock();
 	return;
 
 process_error:
 	LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "connect");
-	sh_mqtt_close_and_cleanup();
-	(void)sh_mqtt_work_reschedule(&sh_mqtt->connect_dwork, K_SECONDS(1));
+	sh_mqtt_close_and_cleanup(sh);
+	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(1));
 	sh_mqtt_context_unlock();
 }
 
 static void sh_mqtt_subscribe_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
+	struct shell_mqtt *sh = sh_mqtt;
+
 	/* Subscribe config information */
-	struct mqtt_topic subs_topic = { .topic = { .utf8 = sh_mqtt->sub_topic,
-						    .size = strlen(sh_mqtt->sub_topic) },
+	struct mqtt_topic subs_topic = { .topic = { .utf8 = sh->sub_topic,
+						    .size = strlen(sh->sub_topic) },
 					 .qos = MQTT_QOS_1_AT_LEAST_ONCE };
 	const struct mqtt_subscription_list subs_list = { .list = &subs_topic,
 							  .list_count = 1U,
 							  .message_id = 1U };
 	int rc;
 
-	if (sh_mqtt->network_state != SHELL_MQTT_NETWORK_CONNECTED) {
+	if (sh->network_state != SHELL_MQTT_NETWORK_CONNECTED) {
 		LOG_DBG("%s_work while %s", "subscribe", "network disconnected");
 		return;
 	}
@@ -318,19 +321,19 @@ static void sh_mqtt_subscribe_handler(struct k_work *work)
 		return;
 	}
 
-	if (sh_mqtt->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
+	if (sh->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
 		LOG_DBG("%s_work while %s", "subscribe", "transport disconnected");
 		goto subscribe_error;
 	}
 
-	rc = mqtt_subscribe(&sh_mqtt->mqtt_cli, &subs_list);
+	rc = mqtt_subscribe(&sh->mqtt_cli, &subs_list);
 	if (rc == 0) {
 		/* Wait for mqtt's connack */
 		LOG_DBG("Listening to socket");
-		rc = wait(CONNECT_TIMEOUT_MS);
+		rc = wait(sh, CONNECT_TIMEOUT_MS);
 		if (rc > 0) {
 			LOG_DBG("Process socket for MQTT packet");
-			rc = mqtt_input(&sh_mqtt->mqtt_cli);
+			rc = mqtt_input(&sh->mqtt_cli);
 			if (rc != 0) {
 				LOG_ERR("%s error: %d", "subscribe: mqtt_input", rc);
 				goto subscribe_error;
@@ -340,24 +343,24 @@ static void sh_mqtt_subscribe_handler(struct k_work *work)
 		}
 
 		/* No suback, fail */
-		if (sh_mqtt->subscribe_state != SHELL_MQTT_SUBSCRIBED) {
+		if (sh->subscribe_state != SHELL_MQTT_SUBSCRIBED) {
 			goto subscribe_error;
 		}
 
 		LOG_DBG("Scheduling MQTT process work");
-		(void)sh_mqtt_work_reschedule(&sh_mqtt->process_dwork, PROCESS_INTERVAL);
+		(void)sh_mqtt_work_reschedule(&sh->process_dwork, PROCESS_INTERVAL);
 		sh_mqtt_context_unlock();
 
-		LOG_INF("Logs will be published to: %s", sh_mqtt->pub_topic);
-		LOG_INF("Subscribing shell cmds from: %s", sh_mqtt->sub_topic);
+		LOG_INF("Logs will be published to: %s", sh->pub_topic);
+		LOG_INF("Subscribing shell cmds from: %s", sh->sub_topic);
 
 		return;
 	}
 
 subscribe_error:
 	LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "subscribe");
-	sh_mqtt_close_and_cleanup();
-	(void)sh_mqtt_work_reschedule(&sh_mqtt->connect_dwork, K_SECONDS(2));
+	sh_mqtt_close_and_cleanup(sh);
+	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(2));
 	sh_mqtt_context_unlock();
 }
 
@@ -365,9 +368,10 @@ subscribe_error:
 static void sh_mqtt_connect_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
+	struct shell_mqtt *sh = sh_mqtt;
 	int rc;
 
-	if (sh_mqtt->network_state != SHELL_MQTT_NETWORK_CONNECTED) {
+	if (sh->network_state != SHELL_MQTT_NETWORK_CONNECTED) {
 		LOG_DBG("%s_work while %s", "connect", "network disconnected");
 		return;
 	}
@@ -379,7 +383,7 @@ static void sh_mqtt_connect_handler(struct k_work *work)
 		return;
 	}
 
-	if (sh_mqtt->transport_state == SHELL_MQTT_TRANSPORT_CONNECTED) {
+	if (sh->transport_state == SHELL_MQTT_TRANSPORT_CONNECTED) {
 		__ASSERT(0, "MQTT shouldn't be already connected");
 		LOG_ERR("MQTT shouldn't be already connected");
 		goto connect_error;
@@ -387,20 +391,20 @@ static void sh_mqtt_connect_handler(struct k_work *work)
 
 	/* Resolve the broker URL */
 	LOG_DBG("Resolving DNS");
-	rc = get_mqtt_broker_addrinfo();
+	rc = get_mqtt_broker_addrinfo(sh);
 	if (rc != 0) {
-		(void)sh_mqtt_work_reschedule(&sh_mqtt->connect_dwork, K_SECONDS(1));
+		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(1));
 		sh_mqtt_context_unlock();
 		return;
 	}
 
 	LOG_DBG("Initializing MQTT client");
-	broker_init();
-	client_init();
+	broker_init(sh);
+	client_init(sh);
 
 	/* Try to connect to mqtt */
 	LOG_DBG("Connecting to MQTT broker");
-	rc = mqtt_connect(&sh_mqtt->mqtt_cli);
+	rc = mqtt_connect(&sh->mqtt_cli);
 	if (rc != 0) {
 		LOG_ERR("%s error: %d", "mqtt_connect", rc);
 		goto connect_error;
@@ -408,14 +412,14 @@ static void sh_mqtt_connect_handler(struct k_work *work)
 
 	/* Prepare port config */
 	LOG_DBG("Preparing socket");
-	prepare_fds();
+	prepare_fds(sh);
 
 	/* Wait for mqtt's connack */
 	LOG_DBG("Listening to socket");
-	rc = wait(CONNECT_TIMEOUT_MS);
+	rc = wait(sh, CONNECT_TIMEOUT_MS);
 	if (rc > 0) {
 		LOG_DBG("Process socket for MQTT packet");
-		rc = mqtt_input(&sh_mqtt->mqtt_cli);
+		rc = mqtt_input(&sh->mqtt_cli);
 		if (rc != 0) {
 			LOG_ERR("%s error: %d", "connect: mqtt_input", rc);
 			goto connect_error;
@@ -425,37 +429,37 @@ static void sh_mqtt_connect_handler(struct k_work *work)
 	}
 
 	/* No connack, fail */
-	if (sh_mqtt->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
+	if (sh->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
 		goto connect_error;
 	}
 
 	LOG_DBG("Scheduling %s work", "subscribe");
-	(void)sh_mqtt_work_reschedule(&sh_mqtt->subscribe_dwork, K_SECONDS(2));
+	(void)sh_mqtt_work_reschedule(&sh->subscribe_dwork, K_SECONDS(2));
 	sh_mqtt_context_unlock();
 	return;
 
 connect_error:
 	LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "connect");
-	sh_mqtt_close_and_cleanup();
-	(void)sh_mqtt_work_reschedule(&sh_mqtt->connect_dwork, K_SECONDS(2));
+	sh_mqtt_close_and_cleanup(sh);
+	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(2));
 	sh_mqtt_context_unlock();
 }
 
-static int sh_mqtt_publish(uint8_t *data, uint32_t len)
+static int sh_mqtt_publish(struct shell_mqtt *sh, uint8_t *data, uint32_t len)
 {
-	sh_mqtt->pub_data.message.payload.data = data;
-	sh_mqtt->pub_data.message.payload.len = len;
-	sh_mqtt->pub_data.message_id++;
+	sh->pub_data.message.payload.data = data;
+	sh->pub_data.message.payload.len = len;
+	sh->pub_data.message_id++;
 
-	return mqtt_publish(&sh_mqtt->mqtt_cli, &sh_mqtt->pub_data);
+	return mqtt_publish(&sh->mqtt_cli, &sh->pub_data);
 }
 
-static int sh_mqtt_publish_tx_buf(bool is_work)
+static int sh_mqtt_publish_tx_buf(struct shell_mqtt *sh, bool is_work)
 {
 	int rc;
 
-	rc = sh_mqtt_publish(&sh_mqtt->tx_buf.buf[0], sh_mqtt->tx_buf.len);
-	memset(&sh_mqtt->tx_buf, 0, sizeof(sh_mqtt->tx_buf));
+	rc = sh_mqtt_publish(sh, &sh->tx_buf.buf[0], sh->tx_buf.len);
+	memset(&sh->tx_buf, 0, sizeof(sh->tx_buf));
 	if (rc != 0) {
 		LOG_ERR("MQTT publish error: %d", rc);
 		return rc;
@@ -472,39 +476,41 @@ static int sh_mqtt_publish_tx_buf(bool is_work)
 static void sh_mqtt_publish_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
+	struct shell_mqtt *sh = sh_mqtt;
 	int rc;
 
 	(void)sh_mqtt_context_lock(K_FOREVER);
 
-	rc = sh_mqtt_publish_tx_buf(true);
+	rc = sh_mqtt_publish_tx_buf(sh, true);
 	if (rc != 0) {
 		LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "publish");
-		sh_mqtt_close_and_cleanup();
-		(void)sh_mqtt_work_reschedule(&sh_mqtt->connect_dwork, K_SECONDS(2));
+		sh_mqtt_close_and_cleanup(sh);
+		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(2));
 	}
 
 	sh_mqtt_context_unlock();
 }
 
-static void cancel_dworks_and_cleanup(void)
+static void cancel_dworks_and_cleanup(struct shell_mqtt *sh)
 {
-	(void)k_work_cancel_delayable(&sh_mqtt->connect_dwork);
-	(void)k_work_cancel_delayable(&sh_mqtt->subscribe_dwork);
-	(void)k_work_cancel_delayable(&sh_mqtt->process_dwork);
-	(void)k_work_cancel_delayable(&sh_mqtt->publish_dwork);
-	sh_mqtt_close_and_cleanup();
+	(void)k_work_cancel_delayable(&sh->connect_dwork);
+	(void)k_work_cancel_delayable(&sh->subscribe_dwork);
+	(void)k_work_cancel_delayable(&sh->process_dwork);
+	(void)k_work_cancel_delayable(&sh->publish_dwork);
+	sh_mqtt_close_and_cleanup(sh);
 }
 
 static void net_disconnect_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
+	struct shell_mqtt *sh = sh_mqtt;
 
 	LOG_WRN("Network %s", "disconnected");
-	sh_mqtt->network_state = SHELL_MQTT_NETWORK_DISCONNECTED;
+	sh->network_state = SHELL_MQTT_NETWORK_DISCONNECTED;
 
 	/* Stop all possible work */
 	(void)sh_mqtt_context_lock(K_FOREVER);
-	cancel_dworks_and_cleanup();
+	cancel_dworks_and_cleanup(sh);
 	sh_mqtt_context_unlock();
 	/* If the transport was requested, the connect work will be rescheduled
 	 * when internet is connected again
@@ -515,51 +521,55 @@ static void net_disconnect_handler(struct k_work *work)
 static void network_evt_handler(struct net_mgmt_event_callback *cb, uint32_t mgmt_event,
 				struct net_if *iface)
 {
+	struct shell_mqtt *sh = sh_mqtt;
+
 	if ((mgmt_event == NET_EVENT_L4_CONNECTED) &&
-	    (sh_mqtt->network_state == SHELL_MQTT_NETWORK_DISCONNECTED)) {
+	    (sh->network_state == SHELL_MQTT_NETWORK_DISCONNECTED)) {
 		LOG_WRN("Network %s", "connected");
-		sh_mqtt->network_state = SHELL_MQTT_NETWORK_CONNECTED;
-		(void)sh_mqtt_work_reschedule(&sh_mqtt->connect_dwork, K_SECONDS(1));
+		sh->network_state = SHELL_MQTT_NETWORK_CONNECTED;
+		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(1));
 	} else if ((mgmt_event == NET_EVENT_L4_DISCONNECTED) &&
-		   (sh_mqtt->network_state == SHELL_MQTT_NETWORK_CONNECTED)) {
-		(void)sh_mqtt_work_submit(&sh_mqtt->net_disconnected_work);
+		   (sh->network_state == SHELL_MQTT_NETWORK_CONNECTED)) {
+		(void)sh_mqtt_work_submit(&sh->net_disconnected_work);
 	}
 }
 
 static void mqtt_evt_handler(struct mqtt_client *const client, const struct mqtt_evt *evt)
 {
+	struct shell_mqtt *sh = sh_mqtt;
+
 	switch (evt->type) {
 	case MQTT_EVT_CONNACK:
 		if (evt->result != 0) {
-			sh_mqtt->transport_state = SHELL_MQTT_TRANSPORT_DISCONNECTED;
+			sh->transport_state = SHELL_MQTT_TRANSPORT_DISCONNECTED;
 			LOG_ERR("MQTT %s %d", "connect failed", evt->result);
 			break;
 		}
 
-		sh_mqtt->transport_state = SHELL_MQTT_TRANSPORT_CONNECTED;
+		sh->transport_state = SHELL_MQTT_TRANSPORT_CONNECTED;
 		LOG_WRN("MQTT %s", "client connected!");
-
 		break;
+
 	case MQTT_EVT_SUBACK:
 		if (evt->result != 0) {
 			LOG_ERR("MQTT subscribe: %s", "error");
-			sh_mqtt->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
+			sh->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
 			break;
 		}
 
 		LOG_WRN("MQTT subscribe: %s", "ok");
-		sh_mqtt->subscribe_state = SHELL_MQTT_SUBSCRIBED;
+		sh->subscribe_state = SHELL_MQTT_SUBSCRIBED;
 		break;
 
 	case MQTT_EVT_UNSUBACK:
 		LOG_DBG("UNSUBACK packet id: %u", evt->param.suback.message_id);
-		sh_mqtt->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
+		sh->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
 		break;
 
 	case MQTT_EVT_DISCONNECT:
 		LOG_WRN("MQTT disconnected: %d", evt->result);
-		sh_mqtt->transport_state = SHELL_MQTT_TRANSPORT_DISCONNECTED;
-		sh_mqtt->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
+		sh->transport_state = SHELL_MQTT_TRANSPORT_DISCONNECTED;
+		sh->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
 		break;
 
 	case MQTT_EVT_PUBLISH: {
@@ -583,25 +593,25 @@ static void mqtt_evt_handler(struct mqtt_client *const client, const struct mqtt
 
 		while (payload_left > 0) {
 			/* Attempt to claim `payload_left` bytes of buffer in rb */
-			size = (size_t)ring_buf_put_claim(&sh_mqtt->rx_rb, &sh_mqtt->rx_rb_ptr,
+			size = (size_t)ring_buf_put_claim(&sh->rx_rb, &sh->rx_rb_ptr,
 							  payload_left);
 			/* Read `size` bytes of payload from mqtt */
-			rc = mqtt_read_publish_payload_blocking(client, sh_mqtt->rx_rb_ptr, size);
+			rc = mqtt_read_publish_payload_blocking(client, sh->rx_rb_ptr, size);
 
 			/* errno value, return */
 			if (rc < 0) {
-				(void)ring_buf_put_finish(&sh_mqtt->rx_rb, 0U);
+				(void)ring_buf_put_finish(&sh->rx_rb, 0U);
 				sh_mqtt_rx_rb_flush();
 				return;
 			}
 
 			size = (size_t)rc;
 			/* Indicate that `size` bytes of payload has been written into rb */
-			(void)ring_buf_put_finish(&sh_mqtt->rx_rb, size);
+			(void)ring_buf_put_finish(&sh->rx_rb, size);
 			/* Update `payload_left` */
 			payload_left -= size;
 			/* Tells the shell that we have new data for it */
-			sh_mqtt->shell_handler(SHELL_TRANSPORT_EVT_RX_RDY, sh_mqtt->shell_context);
+			sh->shell_handler(SHELL_TRANSPORT_EVT_RX_RDY, sh->shell_context);
 			/* Arbitrary sleep for the shell to do its thing */
 			(void)k_msleep(100);
 		}
@@ -609,16 +619,16 @@ static void mqtt_evt_handler(struct mqtt_client *const client, const struct mqtt
 		/* Shell won't execute the cmds without \r\n */
 		while (true) {
 			/* Check if rb's free space is enough to fit in \r\n */
-			size = ring_buf_space_get(&sh_mqtt->rx_rb);
+			size = ring_buf_space_get(&sh->rx_rb);
 			if (size >= sizeof("\r\n")) {
-				(void)ring_buf_put(&sh_mqtt->rx_rb, "\r\n", sizeof("\r\n"));
+				(void)ring_buf_put(&sh->rx_rb, "\r\n", sizeof("\r\n"));
 				break;
 			}
 			/* Arbitrary sleep for the shell to do its thing */
 			(void)k_msleep(100);
 		}
 
-		sh_mqtt->shell_handler(SHELL_TRANSPORT_EVT_RX_RDY, sh_mqtt->shell_context);
+		sh->shell_handler(SHELL_TRANSPORT_EVT_RX_RDY, sh->shell_context);
 		break;
 	}
 
@@ -645,52 +655,53 @@ static int init(const struct shell_transport *transport, const void *config,
 		shell_transport_handler_t evt_handler, void *context)
 {
 	sh_mqtt = (struct shell_mqtt *)transport->ctx;
+	struct shell_mqtt *sh = sh_mqtt;
 
-	(void)memset(sh_mqtt, 0, sizeof(struct shell_mqtt));
+	(void)memset(sh, 0, sizeof(struct shell_mqtt));
 
-	(void)k_mutex_init(&sh_mqtt->lock);
+	(void)k_mutex_init(&sh->lock);
 
-	if (!shell_mqtt_get_devid(sh_mqtt->device_id, DEVICE_ID_HEX_MAX_SIZE)) {
+	if (!shell_mqtt_get_devid(sh->device_id, DEVICE_ID_HEX_MAX_SIZE)) {
 		LOG_ERR("Unable to get device identity, using dummy value");
-		(void)snprintf(sh_mqtt->device_id, sizeof("dummy"), "dummy");
+		(void)snprintf(sh->device_id, sizeof("dummy"), "dummy");
 	}
 
-	LOG_DBG("Client ID is %s", sh_mqtt->device_id);
+	LOG_DBG("Client ID is %s", sh->device_id);
 
-	(void)snprintf(sh_mqtt->pub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_tx", sh_mqtt->device_id);
-	(void)snprintf(sh_mqtt->sub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_rx", sh_mqtt->device_id);
+	(void)snprintf(sh->pub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_tx", sh->device_id);
+	(void)snprintf(sh->sub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_rx", sh->device_id);
 
-	ring_buf_init(&sh_mqtt->rx_rb, RX_RB_SIZE, sh_mqtt->rx_rb_buf);
+	ring_buf_init(&sh->rx_rb, RX_RB_SIZE, sh->rx_rb_buf);
 
 	LOG_DBG("Initializing shell MQTT backend");
 
-	sh_mqtt->shell_handler = evt_handler;
-	sh_mqtt->shell_context = context;
+	sh->shell_handler = evt_handler;
+	sh->shell_context = context;
 
-	sh_mqtt->pub_data.message.topic.qos = MQTT_QOS_0_AT_MOST_ONCE;
-	sh_mqtt->pub_data.message.topic.topic.utf8 = (uint8_t *)sh_mqtt->pub_topic;
-	sh_mqtt->pub_data.message.topic.topic.size =
-		strlen(sh_mqtt->pub_data.message.topic.topic.utf8);
-	sh_mqtt->pub_data.dup_flag = 0U;
-	sh_mqtt->pub_data.retain_flag = 0U;
+	sh->pub_data.message.topic.qos = MQTT_QOS_0_AT_MOST_ONCE;
+	sh->pub_data.message.topic.topic.utf8 = (uint8_t *)sh->pub_topic;
+	sh->pub_data.message.topic.topic.size =
+		strlen(sh->pub_data.message.topic.topic.utf8);
+	sh->pub_data.dup_flag = 0U;
+	sh->pub_data.retain_flag = 0U;
 
 	/* Initialize the work queue */
-	k_work_queue_init(&sh_mqtt->workq);
-	k_work_queue_start(&sh_mqtt->workq, sh_mqtt_workq_stack,
+	k_work_queue_init(&sh->workq);
+	k_work_queue_start(&sh->workq, sh_mqtt_workq_stack,
 			   K_KERNEL_STACK_SIZEOF(sh_mqtt_workq_stack), K_PRIO_COOP(7), NULL);
-	(void)k_thread_name_set(&sh_mqtt->workq.thread, "sh_mqtt_workq");
-	k_work_init(&sh_mqtt->net_disconnected_work, net_disconnect_handler);
-	k_work_init_delayable(&sh_mqtt->connect_dwork, sh_mqtt_connect_handler);
-	k_work_init_delayable(&sh_mqtt->subscribe_dwork, sh_mqtt_subscribe_handler);
-	k_work_init_delayable(&sh_mqtt->process_dwork, sh_mqtt_process_handler);
-	k_work_init_delayable(&sh_mqtt->publish_dwork, sh_mqtt_publish_handler);
+	(void)k_thread_name_set(&sh->workq.thread, "sh_mqtt_workq");
+	k_work_init(&sh->net_disconnected_work, net_disconnect_handler);
+	k_work_init_delayable(&sh->connect_dwork, sh_mqtt_connect_handler);
+	k_work_init_delayable(&sh->subscribe_dwork, sh_mqtt_subscribe_handler);
+	k_work_init_delayable(&sh->process_dwork, sh_mqtt_process_handler);
+	k_work_init_delayable(&sh->publish_dwork, sh_mqtt_publish_handler);
 
 	LOG_DBG("Initializing listener for network");
-	net_mgmt_init_event_callback(&sh_mqtt->mgmt_cb, network_evt_handler, NET_EVENT_MASK);
+	net_mgmt_init_event_callback(&sh->mgmt_cb, network_evt_handler, NET_EVENT_MASK);
 
-	sh_mqtt->network_state = SHELL_MQTT_NETWORK_DISCONNECTED;
-	sh_mqtt->transport_state = SHELL_MQTT_TRANSPORT_DISCONNECTED;
-	sh_mqtt->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
+	sh->network_state = SHELL_MQTT_NETWORK_DISCONNECTED;
+	sh->transport_state = SHELL_MQTT_TRANSPORT_DISCONNECTED;
+	sh->subscribe_state = SHELL_MQTT_NOT_SUBSCRIBED;
 
 	return 0;
 }
@@ -698,9 +709,10 @@ static int init(const struct shell_transport *transport, const void *config,
 static int uninit(const struct shell_transport *transport)
 {
 	ARG_UNUSED(transport);
+	struct shell_mqtt *sh = sh_mqtt;
 
 	/* Not initialized yet */
-	if (sh_mqtt == NULL) {
+	if (sh == NULL) {
 		return -ENODEV;
 	}
 
@@ -711,14 +723,15 @@ static int enable(const struct shell_transport *transport, bool blocking)
 {
 	ARG_UNUSED(transport);
 	ARG_UNUSED(blocking);
+	struct shell_mqtt *sh = sh_mqtt;
 
 	/* Not initialized yet */
-	if (sh_mqtt == NULL) {
+	if (sh == NULL) {
 		return -ENODEV;
 	}
 
 	/* Listen for network connection status */
-	net_mgmt_add_event_callback(&sh_mqtt->mgmt_cb);
+	net_mgmt_add_event_callback(&sh->mgmt_cb);
 	conn_mgr_mon_resend_status();
 
 	return 0;
@@ -728,6 +741,7 @@ static int write_data(const struct shell_transport *transport, const void *data,
 		      size_t *cnt)
 {
 	ARG_UNUSED(transport);
+	struct shell_mqtt *sh = sh_mqtt;
 	int rc = 0;
 	struct k_work_sync ws;
 	size_t copy_len;
@@ -735,33 +749,33 @@ static int write_data(const struct shell_transport *transport, const void *data,
 	*cnt = 0;
 
 	/* Not initialized yet */
-	if (sh_mqtt == NULL) {
+	if (sh == NULL) {
 		return -ENODEV;
 	}
 
 	/* Not connected to broker */
-	if (sh_mqtt->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
+	if (sh->transport_state != SHELL_MQTT_TRANSPORT_CONNECTED) {
 		goto out;
 	}
 
-	(void)k_work_cancel_delayable_sync(&sh_mqtt->publish_dwork, &ws);
+	(void)k_work_cancel_delayable_sync(&sh->publish_dwork, &ws);
 
 	do {
-		if ((sh_mqtt->tx_buf.len + length - *cnt) > TX_BUF_SIZE) {
-			copy_len = TX_BUF_SIZE - sh_mqtt->tx_buf.len;
+		if ((sh->tx_buf.len + length - *cnt) > TX_BUF_SIZE) {
+			copy_len = TX_BUF_SIZE - sh->tx_buf.len;
 		} else {
 			copy_len = length - *cnt;
 		}
 
-		memcpy(sh_mqtt->tx_buf.buf + sh_mqtt->tx_buf.len, (uint8_t *)data + *cnt, copy_len);
-		sh_mqtt->tx_buf.len += copy_len;
+		memcpy(sh->tx_buf.buf + sh->tx_buf.len, (uint8_t *)data + *cnt, copy_len);
+		sh->tx_buf.len += copy_len;
 
 		/* Send the data immediately if the buffer is full */
-		if (sh_mqtt->tx_buf.len == TX_BUF_SIZE) {
-			rc = sh_mqtt_publish_tx_buf(false);
+		if (sh->tx_buf.len == TX_BUF_SIZE) {
+			rc = sh_mqtt_publish_tx_buf(sh, false);
 			if (rc != 0) {
-				sh_mqtt_close_and_cleanup();
-				(void)sh_mqtt_work_reschedule(&sh_mqtt->connect_dwork,
+				sh_mqtt_close_and_cleanup(sh);
+				(void)sh_mqtt_work_reschedule(&sh->connect_dwork,
 							      K_SECONDS(2));
 				*cnt = length;
 				return rc;
@@ -771,12 +785,12 @@ static int write_data(const struct shell_transport *transport, const void *data,
 		*cnt += copy_len;
 	} while (*cnt < length);
 
-	if (sh_mqtt->tx_buf.len > 0) {
-		(void)sh_mqtt_work_reschedule(&sh_mqtt->publish_dwork, MQTT_SEND_DELAY_MS);
+	if (sh->tx_buf.len > 0) {
+		(void)sh_mqtt_work_reschedule(&sh->publish_dwork, MQTT_SEND_DELAY_MS);
 	}
 
 	/* Inform shell that it is ready for next TX */
-	sh_mqtt->shell_handler(SHELL_TRANSPORT_EVT_TX_RDY, sh_mqtt->shell_context);
+	sh->shell_handler(SHELL_TRANSPORT_EVT_TX_RDY, sh->shell_context);
 
 out:
 	/* We will always assume that we sent everything */
@@ -788,23 +802,24 @@ static int read_data(const struct shell_transport *transport, void *data, size_t
 		     size_t *cnt)
 {
 	ARG_UNUSED(transport);
+	struct shell_mqtt *sh = sh_mqtt;
 
 	/* Not initialized yet */
-	if (sh_mqtt == NULL) {
+	if (sh == NULL) {
 		return -ENODEV;
 	}
 
 	/* Not subscribed yet */
-	if (sh_mqtt->subscribe_state != SHELL_MQTT_SUBSCRIBED) {
+	if (sh->subscribe_state != SHELL_MQTT_SUBSCRIBED) {
 		*cnt = 0;
 		return 0;
 	}
 
-	*cnt = ring_buf_get(&sh_mqtt->rx_rb, data, length);
+	*cnt = ring_buf_get(&sh->rx_rb, data, length);
 
 	/* Inform the shell if there are still data in the rb */
-	if (ring_buf_size_get(&sh_mqtt->rx_rb) > 0) {
-		sh_mqtt->shell_handler(SHELL_TRANSPORT_EVT_RX_RDY, sh_mqtt->shell_context);
+	if (ring_buf_size_get(&sh->rx_rb) > 0) {
+		sh->shell_handler(SHELL_TRANSPORT_EVT_RX_RDY, sh->shell_context);
 	}
 
 	return 0;

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -65,16 +65,6 @@ static inline void sh_mqtt_context_unlock(void)
 	(void)k_mutex_unlock(&sh_mqtt->lock);
 }
 
-static void sh_mqtt_rx_rb_flush(void)
-{
-	uint8_t c;
-	uint32_t size = ring_buf_size_get(&sh_mqtt->rx_rb);
-
-	while (size > 0) {
-		size = ring_buf_get(&sh_mqtt->rx_rb, &c, 1U);
-	}
-}
-
 bool __weak shell_mqtt_get_devid(char *id, int id_max_len)
 {
 	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
@@ -600,8 +590,7 @@ static void mqtt_evt_handler(struct mqtt_client *const client, const struct mqtt
 
 			/* errno value, return */
 			if (rc < 0) {
-				(void)ring_buf_put_finish(&sh->rx_rb, 0U);
-				sh_mqtt_rx_rb_flush();
+				ring_buf_reset(&sh->rx_rb);
 				return;
 			}
 


### PR DESCRIPTION
Streamline code in `shell_mqtt.c` as follows:

- Optimize module-scoped `sh_mqtt` variable access
- Use `ring_buf_reset` to flush `rx_rb`