### PR TITLE
manifest: nrf_wifi: Pull fix for nRF91 series build

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: fe4ff0e191a52de4f85ecc3475f0253eca6fc5bf
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 0d0c08e89b50d566285c661e886bf5db3ebaa077
+      revision: pull/38/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: 52bb1783521c62c019451cee9b05b8eda9d7425f


### PR DESCRIPTION
nRF91 series (esp. nRF9151) needs FPU to be enabled, else linked of OSAL and Zephyr native driver fails.