### PR TITLE
Coredump: Allow passing multiple elfs to debug script

### DIFF
--- a/scripts/coredump/coredump_parser/elf_parser.py
+++ b/scripts/coredump/coredump_parser/elf_parser.py
@@ -52,8 +52,9 @@ class CoredumpElfFile():
     and can be retrieved from the ELF file.
     """
 
-    def __init__(self, elffile):
+    def __init__(self, elffile, textaddr=None):
         self.elffile = elffile
+        self.textaddr = textaddr
         self.fd = None
         self.elf = None
         self.memory_regions = list()
@@ -119,6 +120,9 @@ class CoredumpElfFile():
                     # Text section
                     store = True
                     sect_desc = "text"
+                    if self.textaddr is not None:
+                        sec_start += self.textaddr
+                        sec_end += self.textaddr
                 elif (flags & SHF_WRITE_ALLOC) == SHF_WRITE_ALLOC:
                     # Data section
                     #

--- a/scripts/coredump/gdbstubs/__init__.py
+++ b/scripts/coredump/gdbstubs/__init__.py
@@ -22,22 +22,22 @@ class TgtCode:
     ARM64 = 6
 
 
-def get_gdbstub(logfile, elffile):
+def get_gdbstub(logfile, elffiles):
     stub = None
 
     tgt_code = logfile.log_hdr['tgt_code']
 
     if tgt_code == TgtCode.X86:
-        stub = GdbStub_x86(logfile=logfile, elffile=elffile)
+        stub = GdbStub_x86(logfile=logfile, elffiles=elffiles)
     elif tgt_code == TgtCode.X86_64:
-        stub = GdbStub_x86_64(logfile=logfile, elffile=elffile)
+        stub = GdbStub_x86_64(logfile=logfile, elffiles=elffiles)
     elif tgt_code == TgtCode.ARM_CORTEX_M:
-        stub = GdbStub_ARM_CortexM(logfile=logfile, elffile=elffile)
+        stub = GdbStub_ARM_CortexM(logfile=logfile, elffiles=elffiles)
     elif tgt_code == TgtCode.RISC_V:
-        stub = GdbStub_RISC_V(logfile=logfile, elffile=elffile)
+        stub = GdbStub_RISC_V(logfile=logfile, elffiles=elffiles)
     elif tgt_code == TgtCode.XTENSA:
-        stub = GdbStub_Xtensa(logfile=logfile, elffile=elffile)
+        stub = GdbStub_Xtensa(logfile=logfile, elffiles=elffiles)
     elif tgt_code == TgtCode.ARM64:
-        stub = GdbStub_ARM64(logfile=logfile, elffile=elffile)
+        stub = GdbStub_ARM64(logfile=logfile, elffiles=elffiles)
 
     return stub

--- a/scripts/coredump/gdbstubs/arch/arm64.py
+++ b/scripts/coredump/gdbstubs/arch/arm64.py
@@ -60,8 +60,8 @@ class GdbStub_ARM64(GdbStub):
     GDB_G_PKT_NUM_REGS = 33
 
 
-    def __init__(self, logfile, elffile):
-        super().__init__(logfile=logfile, elffile=elffile)
+    def __init__(self, logfile, elffiles):
+        super().__init__(logfile=logfile, elffiles=elffiles)
         self.registers = None
         self.gdb_signal = self.GDB_SIGNAL_DEFAULT
 

--- a/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
+++ b/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
@@ -43,8 +43,8 @@ class GdbStub_ARM_CortexM(GdbStub):
 
     GDB_G_PKT_NUM_REGS = 17
 
-    def __init__(self, logfile, elffile):
-        super().__init__(logfile=logfile, elffile=elffile)
+    def __init__(self, logfile, elffiles):
+        super().__init__(logfile=logfile, elffiles=elffiles)
         self.registers = None
         self.gdb_signal = self.GDB_SIGNAL_DEFAULT
 

--- a/scripts/coredump/gdbstubs/arch/risc_v.py
+++ b/scripts/coredump/gdbstubs/arch/risc_v.py
@@ -57,8 +57,8 @@ class GdbStub_RISC_V(GdbStub):
 
     GDB_G_PKT_NUM_REGS = 33
 
-    def __init__(self, logfile, elffile):
-        super().__init__(logfile=logfile, elffile=elffile)
+    def __init__(self, logfile, elffiles):
+        super().__init__(logfile=logfile, elffiles=elffiles)
         self.registers = None
         self.gdb_signal = self.GDB_SIGNAL_DEFAULT
 

--- a/scripts/coredump/gdbstubs/arch/x86.py
+++ b/scripts/coredump/gdbstubs/arch/x86.py
@@ -9,6 +9,7 @@ import logging
 import struct
 
 from gdbstubs.gdbstub import GdbStub
+from x86_shared import ExceptionVectors
 
 
 logger = logging.getLogger("gdbstub")
@@ -32,32 +33,6 @@ class RegNum():
     ES = 13
     FS = 14
     GS = 15
-
-
-class ExceptionVectors():
-    # Matches arch/x86/include/kernel_arch_data.h
-    IV_DIVIDE_ERROR = 0
-    IV_DEBUG = 1
-    IV_NON_MASKABLE_INTERRUPT = 2
-    IV_BREAKPOINT = 3
-    IV_OVERFLOW = 4
-    IV_BOUND_RANGE = 5
-    IV_INVALID_OPCODE = 6
-    IV_DEVICE_NOT_AVAILABLE = 7
-    IV_DOUBLE_FAULT = 8
-    IV_COPROC_SEGMENT_OVERRUN = 9
-    IV_INVALID_TSS = 10
-    IV_SEGMENT_NOT_PRESENT = 11
-    IV_STACK_FAULT = 12
-    IV_GENERAL_PROTECTION = 13
-    IV_PAGE_FAULT = 14
-    IV_RESERVED = 15
-    IV_X87_FPU_FP_ERROR = 16
-    IV_ALIGNMENT_CHECK = 17
-    IV_MACHINE_CHECK = 18
-    IV_SIMD_FP = 19
-    IV_VIRT_EXCEPTION = 20
-    IV_SECURITY_EXCEPTION = 30
 
 
 class GdbStub_x86(GdbStub):

--- a/scripts/coredump/gdbstubs/arch/x86.py
+++ b/scripts/coredump/gdbstubs/arch/x86.py
@@ -86,8 +86,8 @@ class GdbStub_x86(GdbStub):
 
     GDB_G_PKT_NUM_REGS = 16
 
-    def __init__(self, logfile, elffile):
-        super().__init__(logfile=logfile, elffile=elffile)
+    def __init__(self, logfile, elffiles):
+        super().__init__(logfile=logfile, elffiles=elffiles)
         self.registers = None
         self.exception_vector = None
         self.exception_code = None

--- a/scripts/coredump/gdbstubs/arch/x86_64.py
+++ b/scripts/coredump/gdbstubs/arch/x86_64.py
@@ -9,6 +9,7 @@ import logging
 import struct
 
 from gdbstubs.gdbstub import GdbStub
+from x86_shared import ExceptionVectors
 
 
 logger = logging.getLogger("gdbstub")
@@ -43,32 +44,6 @@ class RegNum():
     FS_BASE = 24
     GS_BASE = 25
     K_GS_BASE = 26
-
-
-class ExceptionVectors():
-    # Matches arch/x86/include/kernel_arch_data.h
-    IV_DIVIDE_ERROR = 0
-    IV_DEBUG = 1
-    IV_NON_MASKABLE_INTERRUPT = 2
-    IV_BREAKPOINT = 3
-    IV_OVERFLOW = 4
-    IV_BOUND_RANGE = 5
-    IV_INVALID_OPCODE = 6
-    IV_DEVICE_NOT_AVAILABLE = 7
-    IV_DOUBLE_FAULT = 8
-    IV_COPROC_SEGMENT_OVERRUN = 9
-    IV_INVALID_TSS = 10
-    IV_SEGMENT_NOT_PRESENT = 11
-    IV_STACK_FAULT = 12
-    IV_GENERAL_PROTECTION = 13
-    IV_PAGE_FAULT = 14
-    IV_RESERVED = 15
-    IV_X87_FPU_FP_ERROR = 16
-    IV_ALIGNMENT_CHECK = 17
-    IV_MACHINE_CHECK = 18
-    IV_SIMD_FP = 19
-    IV_VIRT_EXCEPTION = 20
-    IV_SECURITY_EXCEPTION = 30
 
 
 class GdbStub_x86_64(GdbStub):

--- a/scripts/coredump/gdbstubs/arch/x86_64.py
+++ b/scripts/coredump/gdbstubs/arch/x86_64.py
@@ -105,8 +105,8 @@ class GdbStub_x86_64(GdbStub):
         RegNum.GS,
     }
 
-    def __init__(self, logfile, elffile):
-        super().__init__(logfile=logfile, elffile=elffile)
+    def __init__(self, logfile, elffiles):
+        super().__init__(logfile=logfile, elffiles=elffiles)
         self.registers = None
         self.exception_vector = None
         self.exception_code = None

--- a/scripts/coredump/gdbstubs/arch/x86_shared.py
+++ b/scripts/coredump/gdbstubs/arch/x86_shared.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#
+# Copyright Meta Platforms, Inc. and its affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+class ExceptionVectors:
+    # Matches arch/x86/include/kernel_arch_data.h
+    IV_DIVIDE_ERROR = 0
+    IV_DEBUG = 1
+    IV_NON_MASKABLE_INTERRUPT = 2
+    IV_BREAKPOINT = 3
+    IV_OVERFLOW = 4
+    IV_BOUND_RANGE = 5
+    IV_INVALID_OPCODE = 6
+    IV_DEVICE_NOT_AVAILABLE = 7
+    IV_DOUBLE_FAULT = 8
+    IV_COPROC_SEGMENT_OVERRUN = 9
+    IV_INVALID_TSS = 10
+    IV_SEGMENT_NOT_PRESENT = 11
+    IV_STACK_FAULT = 12
+    IV_GENERAL_PROTECTION = 13
+    IV_PAGE_FAULT = 14
+    IV_RESERVED = 15
+    IV_X87_FPU_FP_ERROR = 16
+    IV_ALIGNMENT_CHECK = 17
+    IV_MACHINE_CHECK = 18
+    IV_SIMD_FP = 19
+    IV_VIRT_EXCEPTION = 20
+    IV_SECURITY_EXCEPTION = 30

--- a/scripts/coredump/gdbstubs/arch/xtensa.py
+++ b/scripts/coredump/gdbstubs/arch/xtensa.py
@@ -139,8 +139,8 @@ class GdbStub_Xtensa(GdbStub):
 
     reg_fmt = "<I"
 
-    def __init__(self, logfile, elffile):
-        super().__init__(logfile=logfile, elffile=elffile)
+    def __init__(self, logfile, elffiles):
+        super().__init__(logfile=logfile, elffiles=elffiles)
 
         self.registers = None
         self.exception_code = None

--- a/scripts/coredump/gdbstubs/gdbstub.py
+++ b/scripts/coredump/gdbstubs/gdbstub.py
@@ -15,9 +15,9 @@ logger = logging.getLogger("gdbstub")
 
 
 class GdbStub(abc.ABC):
-    def __init__(self, logfile, elffile):
+    def __init__(self, logfile, elffiles):
         self.logfile = logfile
-        self.elffile = elffile
+        self.elffile = elffiles[0]
         self.socket = None
         self.gdb_signal = None
         self.thread_ptrs = list()
@@ -28,8 +28,9 @@ class GdbStub(abc.ABC):
         for r in logfile.get_memory_regions():
             mem_regions.append(r)
 
-        for r in elffile.get_memory_regions():
-            mem_regions.append(r)
+        for elffile in elffiles:
+            for r in elffile.get_memory_regions():
+                mem_regions.append(r)
 
         self.mem_regions = mem_regions
 


### PR DESCRIPTION
Add new parameters to allow passing multiple elf files (and optionally a textaddress where each additional elf is loaded).

Parse the memory regions for the additional elfs.