### PR TITLE
tests: Bluetooth: Tester: Fix typo in PBP announcement

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp/btp_pbp.h
+++ b/tests/bluetooth/tester/src/audio/btp/btp_pbp.h
@@ -34,8 +34,8 @@ struct btp_pbp_broadcast_scan_start_cmd {
 struct btp_pbp_broadcast_scan_stop_cmd {
 } __packed;
 
-#define BTP_PBP_EV_PUBLIC_BROADCAST_ANOUNCEMENT_FOUND 0x80
-struct btp_pbp_ev_public_broadcast_anouncement_found_rp {
+#define BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND 0x80
+struct btp_pbp_ev_public_broadcast_announcement_found_ev {
 	bt_addr_le_t address;
 	uint8_t broadcast_id[BT_AUDIO_BROADCAST_ID_SIZE];
 	uint8_t advertiser_sid;

--- a/tests/bluetooth/tester/src/audio/btp_pbp.c
+++ b/tests/bluetooth/tester/src/audio/btp_pbp.c
@@ -45,7 +45,7 @@ static bool scan_get_data(struct bt_data *data, void *user_data)
 	uint32_t broadcast_id;
 	uint8_t *metadata;
 	struct bt_uuid_16 adv_uuid;
-	struct btp_pbp_ev_public_broadcast_anouncement_found_rp *ev = user_data;
+	struct btp_pbp_ev_public_broadcast_announcement_found_ev *ev = user_data;
 
 	switch (data->type) {
 	case BT_DATA_BROADCAST_NAME:
@@ -89,7 +89,7 @@ static void pbp_scan_recv(const struct bt_le_scan_recv_info *info, struct net_bu
 	net_buf_simple_clone(ad, &ad_copy);
 	bt_data_parse(&ad_copy, scan_get_broadcast_name_len, &broadcast_name_len);
 
-	struct btp_pbp_ev_public_broadcast_anouncement_found_rp *ev_ptr;
+	struct btp_pbp_ev_public_broadcast_announcement_found_ev *ev_ptr;
 
 	tester_rsp_buffer_lock();
 	tester_rsp_buffer_allocate(sizeof(*ev_ptr) + broadcast_name_len, (uint8_t **)&ev_ptr);
@@ -105,7 +105,7 @@ static void pbp_scan_recv(const struct bt_le_scan_recv_info *info, struct net_bu
 
 	if (sys_get_le24(ev_ptr->broadcast_id) != BT_BAP_INVALID_BROADCAST_ID &&
 	    ev_ptr->pba_features != 0U && ev_ptr->broadcast_name_len > 0) {
-		tester_event(BTP_SERVICE_ID_PBP, BTP_PBP_EV_PUBLIC_BROADCAST_ANOUNCEMENT_FOUND,
+		tester_event(BTP_SERVICE_ID_PBP, BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND,
 			     ev_ptr, sizeof(*ev_ptr) + broadcast_name_len);
 	}
 


### PR DESCRIPTION
Fixes typo in the event name.
Changes the struct to also use _ev instead of _rp as it is an event and not a response.