### PR TITLE
Bluetooth: Mesh: Shell: fix publication period calculation

### DIFF
--- a/subsys/bluetooth/mesh/shell/cfg.c
+++ b/subsys/bluetooth/mesh/shell/cfg.c
@@ -1561,7 +1561,7 @@ static int mod_pub_set(const struct shell *sh, uint16_t addr, bool is_va, uint16
 		return -EINVAL;
 	}
 
-	pub.period = (steps << 2) + res_step;
+	pub.period = steps + (res_step << 6);
 	count = shell_strtoul(argv[6], 0, &err);
 	if (count > 7) {
 		shell_print(sh, "Invalid retransmit count");


### PR DESCRIPTION
The publication period is defined by Steps and Resolution. At BLE Mesh protocol level, the period is encoded in a byte where first LSB 6 bits correspond to PerSteps and the last two to PerRes. There is an issue on how the code at `subsys/bluetooth/mesh/shell/cfg.c:model_pub_set` is encoding these two values into the publication period byte.
Fixes #87780