### PR TITLE
NXP LPSPI: Fixing word sizes, SPI_HOLD_ON_CS flag and optimizing interrupts in CPU-based transfers

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -96,68 +96,105 @@ static inline void lpspi_handle_rx_irq(const struct device *dev)
 	}
 }
 
-static inline uint32_t lpspi_next_tx_word(const struct device *dev, int offset)
+/* constructs the next word from the buffer */
+static inline uint32_t lpspi_next_tx_word(const struct device *dev, const uint8_t *buf,
+					  int offset, size_t max_bytes)
 {
-	struct lpspi_data *data = dev->data;
-	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
-	struct spi_context *ctx = &data->ctx;
-	const uint8_t *byte = ctx->tx_buf + offset;
-	uint32_t num_bytes = MIN(lpspi_data->word_size_bytes, ctx->tx_len);
+	const uint8_t *byte = buf + offset;
 	uint32_t next_word = 0;
 
-	for (uint8_t i = 0; i < num_bytes; i++) {
+	for (uint8_t i = 0; i < max_bytes; i++) {
 		next_word |= byte[i] << (BITS_PER_BYTE * i);
 	}
 
 	return next_word;
 }
 
-static inline void lpspi_fill_tx_fifo(const struct device *dev)
+/* fills the TX fifo with specified amount of data from the specified buffer */
+static inline void lpspi_fill_tx_fifo(const struct device *dev, const uint8_t *buf,
+				      size_t buf_len, size_t fill_len)
 {
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 	struct lpspi_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
-	size_t bytes_in_xfer = lpspi_data->fill_len * lpspi_data->word_size_bytes;
-	size_t offset;
+	uint8_t word_size = lpspi_data->word_size_bytes;
+	size_t buf_remaining_bytes = buf_len * word_size;
+	size_t offset = 0;
+	uint32_t next_word;
+	uint32_t next_word_bytes;
 
-	for (offset = 0; offset < bytes_in_xfer; offset += lpspi_data->word_size_bytes) {
-		base->TDR = lpspi_next_tx_word(dev, offset);
+	for (int word_count = 0; word_count < fill_len; word_count++) {
+		next_word_bytes = MIN(word_size, buf_remaining_bytes);
+		next_word = lpspi_next_tx_word(dev, buf, offset, next_word_bytes);
+		base->TDR = next_word;
+		offset += word_size;
+		buf_remaining_bytes -= word_size;
 	}
 
 	LOG_DBG("Filled TX FIFO to %d words (%d bytes)", lpspi_data->fill_len, offset);
 }
 
-static void lpspi_fill_tx_fifo_nop(const struct device *dev)
+/* just fills TX fifo with the specified amount of NOPS */
+static void lpspi_fill_tx_fifo_nop(const struct device *dev, size_t fill_len)
 {
 	LPSPI_Type *base = (LPSPI_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
-	struct lpspi_data *data = dev->data;
-	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 
-	for (int i = 0; i < lpspi_data->fill_len; i++) {
+	for (int i = 0; i < fill_len; i++) {
 		base->TDR = 0;
 	}
 
-	LOG_DBG("Filled TX fifo with %d NOPs", lpspi_data->fill_len);
+	LOG_DBG("Filled TX fifo with %d NOPs", fill_len);
 }
 
+/* handles refilling the TX fifo from empty */
 static void lpspi_next_tx_fill(const struct device *dev)
 {
 	const struct lpspi_config *config = dev->config;
 	struct lpspi_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 	struct spi_context *ctx = &data->ctx;
-	size_t max_chunk;
+	size_t fill_len;
+	size_t actual_filled = 0;
 
 	/* Convert bytes to words for this xfer */
-	max_chunk = DIV_ROUND_UP(ctx->tx_len, lpspi_data->word_size_bytes);
-	max_chunk = MIN(max_chunk, config->tx_fifo_size);
-	lpspi_data->fill_len = max_chunk;
+	fill_len = DIV_ROUND_UP(spi_context_tx_len_left(ctx), lpspi_data->word_size_bytes);
+	fill_len = MIN(fill_len, config->tx_fifo_size);
 
-	if (spi_context_tx_buf_on(ctx)) {
-		lpspi_fill_tx_fifo(dev);
-	} else {
-		lpspi_fill_tx_fifo_nop(dev);
+	const struct spi_buf *current_buf = ctx->current_tx;
+	const uint8_t *cur_buf_pos = ctx->tx_buf;
+	size_t cur_buf_len_left = ctx->tx_len;
+	size_t bufs_left = ctx->tx_count;
+
+	while (fill_len > 0) {
+		size_t next_buf_fill = MIN(cur_buf_len_left, fill_len);
+
+		if (cur_buf_pos == NULL) {
+			lpspi_fill_tx_fifo_nop(dev, next_buf_fill);
+		} else {
+			lpspi_fill_tx_fifo(dev, cur_buf_pos,
+						current_buf->len, next_buf_fill);
+		}
+
+		fill_len -= next_buf_fill;
+		cur_buf_pos += next_buf_fill;
+
+		/* in the case where we just filled as much as we could from the current buffer,
+		 * this logic while wrong should have no effect, since fill_len will be 0,
+		 * so I choose not to make the code extra complex
+		 */
+		bufs_left--;
+		if (bufs_left > 0) {
+			current_buf += 1;
+			cur_buf_len_left = current_buf->len;
+			cur_buf_pos = current_buf->buf;
+		} else {
+			fill_len = 0;
+		}
+
+		actual_filled += next_buf_fill;
 	}
+
+	lpspi_data->fill_len = actual_filled;
 }
 
 static inline void lpspi_handle_tx_irq(const struct device *dev)
@@ -167,7 +204,12 @@ static inline void lpspi_handle_tx_irq(const struct device *dev)
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 	struct spi_context *ctx = &data->ctx;
 
-	spi_context_update_tx(ctx, lpspi_data->word_size_bytes, lpspi_data->fill_len);
+	while (spi_context_tx_on(ctx) && lpspi_data->fill_len > 0) {
+		size_t this_buf_words_sent = MIN(lpspi_data->fill_len, ctx->tx_len);
+
+		spi_context_update_tx(ctx, lpspi_data->word_size_bytes, this_buf_words_sent);
+		lpspi_data->fill_len -= this_buf_words_sent;
+	}
 
 	base->SR = LPSPI_SR_TDF_MASK;
 
@@ -206,10 +248,11 @@ static void lpspi_isr(const struct device *dev)
 		size_t max_fill = MIN(expected_rx_left, config->rx_fifo_size);
 		size_t tx_current_fifo_len = tx_fifo_cur_len(base);
 
-		lpspi_data->fill_len = tx_current_fifo_len < ctx->rx_len ?
+		size_t fill_len = tx_current_fifo_len < ctx->rx_len ?
 					max_fill - tx_current_fifo_len : 0;
 
-		lpspi_fill_tx_fifo_nop(dev);
+		lpspi_fill_tx_fifo_nop(dev, fill_len);
+		lpspi_data->fill_len = fill_len;
 	}
 
 	if (spi_context_rx_len_left(ctx) == 1) {

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -279,7 +279,8 @@ static int transceive(const struct device *dev, const struct spi_config *spi_cfg
 
 	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
-	lpspi_data->word_size_bytes = SPI_WORD_SIZE_GET(spi_cfg->operation) / BITS_PER_BYTE;
+	lpspi_data->word_size_bytes =
+		DIV_ROUND_UP(SPI_WORD_SIZE_GET(spi_cfg->operation), BITS_PER_BYTE);
 	if (lpspi_data->word_size_bytes > 4) {
 		LOG_ERR("Maximum 4 byte word size");
 		ret = -EINVAL;

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -33,7 +33,7 @@ static inline void lpspi_rx_word_write_bytes(const struct device *dev, size_t of
 	struct lpspi_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 	struct spi_context *ctx = &data->ctx;
-	uint8_t num_bytes = MIN(lpspi_data->word_size_bytes, ctx->rx_len);
+	uint8_t num_bytes = lpspi_data->word_size_bytes;
 	uint8_t *buf = ctx->rx_buf + offset;
 	uint32_t word = base->RDR;
 
@@ -53,7 +53,7 @@ static inline size_t lpspi_rx_buf_write_words(const struct device *dev, uint8_t 
 	struct lpspi_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 	struct spi_context *ctx = &data->ctx;
-	size_t buf_len = DIV_ROUND_UP(ctx->rx_len, lpspi_data->word_size_bytes);
+	size_t buf_len = ctx->rx_len;
 	uint8_t words_read = 0;
 	size_t offset = 0;
 
@@ -156,9 +156,7 @@ static void lpspi_next_tx_fill(const struct device *dev)
 	size_t fill_len;
 	size_t actual_filled = 0;
 
-	/* Convert bytes to words for this xfer */
-	fill_len = DIV_ROUND_UP(spi_context_tx_len_left(ctx), lpspi_data->word_size_bytes);
-	fill_len = MIN(fill_len, config->tx_fifo_size);
+	fill_len = MIN(ctx->tx_len, config->tx_fifo_size);
 
 	const struct spi_buf *current_buf = ctx->current_tx;
 	const uint8_t *cur_buf_pos = ctx->tx_buf;

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT nxp_lpspi
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(spi_lpspi, CONFIG_SPI_LOG_LEVEL);
+LOG_MODULE_DECLARE(spi_lpspi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_nxp_lpspi_priv.h"
 

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -81,7 +81,7 @@ static inline int lpspi_validate_xfer_args(const struct spi_config *spi_cfg)
 		return -ENOTSUP;
 	}
 
-	if (word_size < 8 || (word_size % 32 == 1)) {
+	if (word_size < 2 || (word_size % 32 == 1)) {
 		/* Zephyr word size == hardware FRAME size (not word size)
 		 * Max frame size: 4096 bits
 		 *   (zephyr field is 6 bit wide for max 64 bit size, no need to check)
@@ -154,7 +154,7 @@ int spi_mcux_configure(const struct device *dev, const struct spi_config *spi_cf
 
 	LPSPI_MasterGetDefaultConfig(&master_config);
 
-	master_config.bitsPerFrame = word_size;
+	master_config.bitsPerFrame = word_size < 8 ? 8 : word_size; /* minimum FRAMSZ is 8 */
 	master_config.cpol = (SPI_MODE_GET(spi_cfg->operation) & SPI_MODE_CPOL)
 				     ? kLPSPI_ClockPolarityActiveLow
 				     : kLPSPI_ClockPolarityActiveHigh;

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(spi_lpspi_common, CONFIG_SPI_LOG_LEVEL);
+LOG_MODULE_REGISTER(spi_lpspi, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_nxp_lpspi_priv.h"
 #include <fsl_lpspi.h>

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_dma.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT nxp_lpspi
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(spi_lpspi_dma, CONFIG_SPI_LOG_LEVEL);
+LOG_MODULE_DECLARE(spi_lpspi, CONFIG_SPI_LOG_LEVEL);
 
 #include <zephyr/drivers/dma.h>
 #include "spi_nxp_lpspi_priv.h"


### PR DESCRIPTION
Fix word sizes other than 8 bits on LPSPI driver and optimize for less interrupts.  Fixes bugs that I find while working on https://github.com/zephyrproject-rtos/zephyr/pull/87838 .  Also combines the logging modules