### PR TITLE
net: virtual: Clear multicast bit when generating link address

### DIFF
--- a/subsys/net/l2/virtual/virtual.c
+++ b/subsys/net/l2/virtual/virtual.c
@@ -212,7 +212,8 @@ static void random_linkaddr(uint8_t *linkaddr, size_t len)
 {
 	sys_rand_get(linkaddr, len);
 
-	linkaddr[0] |= 0x02; /* force LAA bit */
+	linkaddr[0] |= 0x02;  /* force LAA bit */
+	linkaddr[0] &= ~0x01; /* clear multicast bit */
 }
 
 int net_virtual_interface_attach(struct net_if *virtual_iface,


### PR DESCRIPTION
The least significant bit of the first octet of a MAC address is a [unicast/multicast bit](https://en.wikipedia.org/wiki/MAC_address#Unicast_vs._multicast_(I/G_bit)).

When generating a random link address for a virtual interface - the bit should be cleared.
Otherwise, there is a ~50% chance that it will be set.
Any frames from such interface/address will be dropped by the network as invalid.