### PR TITLE
kernel: ALWAYS_INLINE z_swap_irqlock()

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -195,12 +195,12 @@ static inline void z_swap_unlocked(void)
 
 extern int arch_swap(unsigned int key);
 
-static inline void z_sched_switch_spin(struct k_thread *thread)
+static ALWAYS_INLINE void z_sched_switch_spin(struct k_thread *thread)
 {
 	ARG_UNUSED(thread);
 }
 
-static inline int z_swap_irqlock(unsigned int key)
+static ALWAYS_INLINE int z_swap_irqlock(unsigned int key)
 {
 	int ret;
 	z_check_stack_sentinel();


### PR DESCRIPTION
With !CONFIG_USE_SWITCH:

z_swap_irqlock() sits on the thread switching path. GCC inlines it anyways, but unfortunately the iar toolchain does not.

For the sake of uniformity I changed (the essentially empty) z_sched_switch_spin() to ALWAYS_INLINE too.

This gives a nice performance improvement on thread_metrrics for iar.