### PR TITLE
iar: toolchain: Enable TOOLCHAIN_HAS_BUILTIN_FFS

### DIFF
--- a/cmake/toolchain/iar/Kconfig.defconfig
+++ b/cmake/toolchain/iar/Kconfig.defconfig
@@ -8,9 +8,6 @@ config TOOLCHAIN_SUPPORTS_VLA_IN_STATEMENTS
 config PICOLIBC_SUPPORTED
 	default n
 
-config TOOLCHAIN_HAS_BUILTIN_FFS
-	default n
-
 config IAR_LIBC_SUPPORTED
 	default y
 


### PR DESCRIPTION
icc has support for __builtin_ffs() and its friends, but it was disabled in the toolchain files.

This gives a slight boost to benchmarks.thread_metrics