### PR TITLE
tests: zms: decrease verbosity

### DIFF
--- a/tests/subsys/fs/zms/prj.conf
+++ b/tests/subsys/fs/zms/prj.conf
@@ -6,4 +6,6 @@ CONFIG_FLASH_MAP=y
 
 CONFIG_ZMS=y
 CONFIG_LOG=y
-CONFIG_ZMS_LOG_LEVEL_DBG=y
+
+#Uncomment below line to see more debug logs
+#CONFIG_ZMS_LOG_LEVEL_DBG=y


### PR DESCRIPTION
disable by default the LOG_DBG messages