### PR TITLE
zms: fix the detection of gc_done ATE

### DIFF
--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1259,6 +1259,7 @@ static int zms_init(struct zms_fs *fs)
 			}
 
 			if (zms_gc_done_ate_valid(fs, &gc_done_ate)) {
+				gc_done_marker = true;
 				break;
 			}
 			addr += fs->ate_size;


### PR DESCRIPTION
Previously, when detecting the GC_done ATE the gc_done_marker boolean variable was not set.
Fix this by setting it to true if the GC_done ATE is found.