### PR TITLE
Bluetooth: LE: HCI: Added bt_le_set_default_phy command

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1226,6 +1226,20 @@ int bt_conn_le_data_len_update(struct bt_conn *conn,
 int bt_conn_le_phy_update(struct bt_conn *conn,
 			  const struct bt_conn_le_phy_param *param);
 
+/** @brief Update the default PHY parameters to be used for all subsequent
+ * connections over the LE transport.
+ *
+ *  Update the preferred transmit and receive PHYs of LE transport.
+ *  Use @ref BT_GAP_LE_PHY_NONE to indicate no preference.
+ *  For possible PHY values see @ref bt_gap_le_phy.
+ *
+ *  @param pref_tx_phy  Preferred transmitter phy prarameters.
+ *  @param pref_rx_phy  Preferred receiver phy prameters.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ */
+int bt_conn_le_set_default_phy(uint8_t pref_tx_phy, uint8_t pref_rx_phy);
+
 /** @brief Disconnect from a remote device or cancel pending connection.
  *
  *  Disconnect an active connection with the specified reason code or cancel

--- a/samples/bluetooth/central_gatt_write/src/central_gatt_write.c
+++ b/samples/bluetooth/central_gatt_write/src/central_gatt_write.c
@@ -95,6 +95,14 @@ uint32_t central_gatt_write(uint32_t count)
 	conn_connected = NULL;
 	last_write_rate = 0U;
 
+#if defined(CONFIG_BT_USER_PHY_UPDATE)
+	err = bt_conn_le_set_default_phy(BT_GAP_LE_PHY_1M, BT_GAP_LE_PHY_1M);
+	if (err) {
+		printk("Failed to set default PHY (err %d)\n", err);
+		return 0U;
+	}
+#endif /* CONFIG_BT_USER_PHY_UPDATE */
+
 	start_scan_func = start_scan;
 	start_scan_func();
 

--- a/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
+++ b/samples/bluetooth/peripheral_gatt_write/src/peripheral_gatt_write.c
@@ -67,6 +67,14 @@ uint32_t peripheral_gatt_write(uint32_t count)
 	(void)bt_conn_auth_cb_register(&auth_callbacks);
 #endif /* CONFIG_BT_SMP */
 
+#if defined(CONFIG_BT_USER_PHY_UPDATE)
+	err = bt_conn_le_set_default_phy(BT_GAP_LE_PHY_1M, BT_GAP_LE_PHY_1M);
+	if (err) {
+		printk("Failed to set default PHY (err %d)\n", err);
+		return 0U;
+	}
+#endif /* CONFIG_BT_USER_PHY_UPDATE */
+
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3532,6 +3532,21 @@ int bt_conn_le_phy_update(struct bt_conn *conn,
 	return bt_le_set_phy(conn, all_phys, param->pref_tx_phy,
 			     param->pref_rx_phy, phy_opts);
 }
+
+int bt_conn_le_set_default_phy(uint8_t pref_tx_phy, uint8_t pref_rx_phy)
+{
+	uint8_t all_phys = 0U;
+
+	if (pref_tx_phy == BT_GAP_LE_PHY_NONE) {
+		all_phys |= BT_HCI_LE_PHY_TX_ANY;
+	}
+
+	if (pref_rx_phy == BT_GAP_LE_PHY_NONE) {
+		all_phys |= BT_HCI_LE_PHY_RX_ANY;
+	}
+
+	return bt_le_set_default_phy(all_phys, pref_tx_phy, pref_rx_phy);
+}
 #endif
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1194,6 +1194,24 @@ static int hci_le_read_phy(struct bt_conn *conn)
 }
 #endif /* defined(CONFIG_BT_USER_PHY_UPDATE) */
 
+int bt_le_set_default_phy(uint8_t all_phys, uint8_t pref_tx_phy, uint8_t pref_rx_phy)
+{
+	struct bt_hci_cp_le_set_default_phy *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->all_phys = all_phys;
+	cp->tx_phys = pref_tx_phy;
+	cp->rx_phys = pref_rx_phy;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_DEFAULT_PHY, buf, NULL);
+}
+
 int bt_le_set_phy(struct bt_conn *conn, uint8_t all_phys,
 		  uint8_t pref_tx_phy, uint8_t pref_rx_phy, uint8_t phy_opts)
 {

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -474,6 +474,7 @@ int bt_hci_disconnect(uint16_t handle, uint8_t reason);
 
 bool bt_le_conn_params_valid(const struct bt_le_conn_param *param);
 int bt_le_set_data_len(struct bt_conn *conn, uint16_t tx_octets, uint16_t tx_time);
+int bt_le_set_default_phy(uint8_t all_phys, uint8_t pref_tx_phy, uint8_t pref_rx_phy);
 int bt_le_set_phy(struct bt_conn *conn, uint8_t all_phys,
 		  uint8_t pref_tx_phy, uint8_t pref_rx_phy, uint8_t phy_opts);
 uint8_t bt_get_phy(uint8_t hci_phy);


### PR DESCRIPTION
Added bt_le_set_default_phy in hci. This handles the HCI_LE_Set_Default_PHY HCI command.

BLUETOOTH CORE SPECIFICATION Version 6.0 | Vol 4, Part E
7.8.48 LE Set Default PHY command

Signed-off-by: Ravinder Singh <ravinder.singh2@infineon.com>

Fixes #89889
