### PR TITLE
Bluetooth: Controller: Fix an error code in ll_adv_sync_ad_data_set

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -278,7 +278,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	/* Check if periodic advertising is associated with advertising set */
 	lll_sync = adv->lll.sync;
 	if (!lll_sync) {
-		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
+		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
 	sync = HDR_LLL2ULL(lll_sync);


### PR DESCRIPTION
When an advertising set is not configured for periodic advertising, the correct error to return is BT_HCI_ERR_CMD_DISALLOWED

Fixes EBQ test failure of HCI/DDI/BI-70-C