### PR TITLE
tests: littlefs: fix false negative test_lfs_basic

### DIFF
--- a/tests/subsys/fs/littlefs/src/test_lfs_basic.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_basic.c
@@ -57,12 +57,8 @@ static int clean_statvfs(const struct fs_mount_t *mp)
 	TC_PRINT("%s: bsize %lu ; frsize %lu ; blocks %lu ; bfree %lu\n",
 		 mp->mnt_point,
 		 stat.f_bsize, stat.f_frsize, stat.f_blocks, stat.f_bfree);
-	zassert_equal(stat.f_bsize, 16,
+	zassert_equal(stat.f_bsize, CONFIG_FS_LITTLEFS_PROG_SIZE,
 		      "bsize fail");
-	zassert_equal(stat.f_frsize, 4096,
-		      "frsize fail");
-	zassert_equal(stat.f_blocks, 16,
-		      "blocks fail");
 	zassert_equal(stat.f_bfree, stat.f_blocks - 2U,
 		      "bfree fail");
 


### PR DESCRIPTION
Fixes the false negative littlefs.test_lfs_basic test that can occur if the small_partition size > 64KB, and for
platforms with CONFIG_FS_LITTLEFS_PROG_SIZE > 64 (e.g. lpc55s, mcxn).