### PR TITLE
Optimize timings around k_sleep

### DIFF
--- a/kernel/include/timeout_q.h
+++ b/kernel/include/timeout_q.h
@@ -30,8 +30,11 @@ static inline void z_init_timeout(struct _timeout *to)
 	sys_dnode_init(&to->node);
 }
 
-void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
-		   k_timeout_t timeout);
+/* Adds the timeout to the queue.
+ *
+ * @return Absolute tick value when timeout will expire.
+ */
+k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout);
 
 int z_abort_timeout(struct _timeout *to);
 
@@ -53,9 +56,9 @@ static inline void z_init_thread_timeout(struct _thread_base *thread_base)
 
 extern void z_thread_timeout(struct _timeout *timeout);
 
-static inline void z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)
+static inline k_ticks_t z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)
 {
-	z_add_timeout(&thread->base.timeout, z_thread_timeout, ticks);
+	return z_add_timeout(&thread->base.timeout, z_thread_timeout, ticks);
 }
 
 static inline void z_abort_thread_timeout(struct k_thread *thread)
@@ -84,10 +87,11 @@ k_ticks_t z_timeout_remaining(const struct _timeout *timeout);
 #define z_get_next_timeout_expiry() ((int32_t) K_TICKS_FOREVER)
 #define z_set_timeout_expiry(ticks, is_idle) do {} while (false)
 
-static inline void z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)
+static inline k_ticks_t z_add_thread_timeout(struct k_thread *thread, k_timeout_t ticks)
 {
 	ARG_UNUSED(thread);
 	ARG_UNUSED(ticks);
+	return 0;
 }
 
 #endif /* CONFIG_SYS_CLOCK_EXISTS */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1108,6 +1108,10 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 
 	(void)z_swap(&_sched_spinlock, key);
 
+	if (!z_is_aborted_thread_timeout(_current)) {
+		return 0;
+	}
+
 	/* We require a 32 bit unsigned subtraction to care a wraparound */
 	uint32_t left_ticks = expected_wakeup_ticks - sys_clock_tick_get_32();
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1091,19 +1091,13 @@ static int32_t z_tick_sleep(k_timeout_t timeout)
 		return 0;
 	}
 
-	if (Z_IS_TIMEOUT_RELATIVE(timeout)) {
-		expected_wakeup_ticks = timeout.ticks + sys_clock_tick_get_32();
-	} else {
-		expected_wakeup_ticks = Z_TICK_ABS(timeout.ticks);
-	}
-
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);
 
 #if defined(CONFIG_TIMESLICING) && defined(CONFIG_SWAP_NONATOMIC)
 	pending_current = _current;
 #endif /* CONFIG_TIMESLICING && CONFIG_SWAP_NONATOMIC */
 	unready_thread(_current);
-	z_add_thread_timeout(_current, timeout);
+	expected_wakeup_ticks = (uint32_t)z_add_thread_timeout(_current, timeout);
 	z_mark_thread_as_sleeping(_current);
 
 	(void)z_swap(&_sched_spinlock, key);

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -99,11 +99,12 @@ static int32_t next_timeout(int32_t ticks_elapsed)
 	return ret;
 }
 
-void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
-		   k_timeout_t timeout)
+k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout)
 {
+	k_ticks_t ticks = 0;
+
 	if (K_TIMEOUT_EQ(timeout, K_FOREVER)) {
-		return;
+		return 0;
 	}
 
 #ifdef CONFIG_KERNEL_COHERENCE
@@ -122,10 +123,12 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 			ticks_elapsed = elapsed();
 			has_elapsed = true;
 			to->dticks = timeout.ticks + 1 + ticks_elapsed;
+			ticks = curr_tick + to->dticks;
 		} else {
-			k_ticks_t ticks = Z_TICK_ABS(timeout.ticks) - curr_tick;
+			k_ticks_t dticks = Z_TICK_ABS(timeout.ticks) - curr_tick;
 
-			to->dticks = MAX(1, ticks);
+			to->dticks = MAX(1, dticks);
+			ticks = timeout.ticks;
 		}
 
 		for (t = first(); t != NULL; t = next(t)) {
@@ -151,6 +154,8 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 			sys_clock_set_timeout(next_timeout(ticks_elapsed), false);
 		}
 	}
+
+	return ticks;
 }
 
 int z_abort_timeout(struct _timeout *to)

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -162,6 +162,7 @@ int z_abort_timeout(struct _timeout *to)
 			bool is_first = (to == first());
 
 			remove_timeout(to);
+			to->dticks = TIMEOUT_DTICKS_ABORTED;
 			ret = 0;
 			if (is_first) {
 				sys_clock_set_timeout(next_timeout(elapsed()), false);

--- a/tests/kernel/timer/timer_error_case/src/main.c
+++ b/tests/kernel/timer/timer_error_case/src/main.c
@@ -325,8 +325,8 @@ ZTEST_USER(timer_api_error, test_timer_user_data_set_null)
 	k_thread_join(tid, K_FOREVER);
 }
 
-extern void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
-			  k_timeout_t timeout);
+extern k_ticks_t z_add_timeout(struct _timeout *to, _timeout_func_t fn, k_timeout_t timeout);
+
 static void test_timer_handle(struct _timeout *t)
 {
 	/**do nothing here**/


### PR DESCRIPTION
In embedded devices it's often costly to access peripheral registers (compared to accessing RAM memory). For example in nrf54h20 which runs at 320 MHz reading register in a peripheral takes 160 cycles and system clock counter has 64 bits which requires 2 reads. It is that high because peripherals are in low power domain which runs at much lower frequency. It should be avoided if possible. The peripheral that is the most often accessed is the system clock. In case of `k_sleep` system clock is accessed multiple times since call returns number of ticks left (valid only if thead is waken up prematurely). Current implemention is doing following:
- read the system clock to calculate expected expiration tick
- sets timeout
- swaps the context
- read the system clock to compare it against expected expiration tick

Those reads are redundant and PR proposes following improvements:
- Extend `z_add_timeout` to return tick when timeout will expire. It is calculated anyway so there is no additional cost. It removes the need for reading the system clock to calculate expected expiration tick
- Add internal API to detect if timer was aborted and use that to determine if thread was waken up prematurely so that system clock read is needed only in case of premature wake up.

Those changes removes 2 reads.
Following changes has almost no impact on code size (+28 bytes on qemu_cortex_m3, +22 bytes on qemu_riscv32) but significantly reduces time spent in `z_tick_sleep`. I've measured time spent in that function excluding `z_add_timeout` and `z_swap` and got following results:

| target     | before | after |
| ----------- | -------- | ------ | 
| nrf52      | 7.7 us | 3.5 us |
| nrf54l15 | 4us | 1.3 us |
| nrf54h20| 4 us | 1.5 us| 
| stm32    | 3.6 us| 1.6 us|

In all cases there is 2-3 times reduction.

It reduces core active time in case when there are short periodic operations:

```
while (1) {
  k_msleep(1);
  // short op
}
```