### PR TITLE
secure_storage: its: store: settings: allow using custom setting names

### DIFF
--- a/subsys/secure_storage/CMakeLists.txt
+++ b/subsys/secure_storage/CMakeLists.txt
@@ -12,10 +12,10 @@ zephyr_include_directories(
 
 # Make the secure_storage headers available to the application only when it's implementing the relevant APIs.
 function(make_available header)
-  if (NOT header STREQUAL "common.h")
+  if(NOT header STREQUAL "common.h")
     make_available(common.h)
   endif()
-  if ((header MATCHES "^its") AND NOT (header STREQUAL "its/common.h"))
+  if((header MATCHES "^its") AND NOT (header STREQUAL "its/common.h"))
     make_available(its/common.h)
   endif()
   configure_file(include/internal/zephyr/secure_storage/${header}
@@ -23,25 +23,25 @@ function(make_available header)
                  COPYONLY)
 endfunction()
 
-if (CONFIG_SECURE_STORAGE_ITS_IMPLEMENTATION_CUSTOM)
+if(CONFIG_SECURE_STORAGE_ITS_IMPLEMENTATION_CUSTOM)
   make_available(its.h)
 endif()
 
-if (CONFIG_SECURE_STORAGE_PS_IMPLEMENTATION_CUSTOM)
+if(CONFIG_SECURE_STORAGE_PS_IMPLEMENTATION_CUSTOM)
   make_available(ps.h)
 endif()
 
-if (CONFIG_SECURE_STORAGE_ITS_TRANSFORM_IMPLEMENTATION_CUSTOM
+if(CONFIG_SECURE_STORAGE_ITS_TRANSFORM_IMPLEMENTATION_CUSTOM
     OR (CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_CUSTOM
         AND CONFIG_SECURE_STORAGE_ITS_TRANSFORM_MODULE))
   make_available(its/transform.h)
 endif()
 
-if (CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_CUSTOM)
+if(CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_CUSTOM)
   make_available(its/store.h)
 endif()
 
-if (CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_SCHEME_CUSTOM
+if(CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_SCHEME_CUSTOM
  OR CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_CUSTOM
  OR CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_PROVIDER_CUSTOM)
   make_available(its/transform/aead_get.h)

--- a/subsys/secure_storage/CMakeLists.txt
+++ b/subsys/secure_storage/CMakeLists.txt
@@ -46,3 +46,7 @@ if(CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_SCHEME_CUSTOM
  OR CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NONCE_PROVIDER_CUSTOM)
   make_available(its/transform/aead_get.h)
 endif()
+
+if(CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_CUSTOM)
+  make_available(its/store/settings_get.h)
+endif()

--- a/subsys/secure_storage/Kconfig.its_store
+++ b/subsys/secure_storage/Kconfig.its_store
@@ -60,8 +60,25 @@ endif # SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_ZMS
 
 if SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_SETTINGS
 
+config SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_CUSTOM
+	bool "Custom naming scheme for the stored settings"
+	help
+	  This allows to use custom names for the settings that the implementation uses
+	  instead of the default naming scheme.
+	  When enabling this, implement the secure_storage_its_store_settings_get_name()
+	  function declared in <zephyr/secure_storage/its/store/settings_get.h>
+	  and set CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_MAX_LEN appropriately.
+	  The header file is made available when this Kconfig option is enabled.
+
 config SECURE_STORAGE_ITS_STORE_SETTINGS_PREFIX
 	string "Subtree in which to store the settings, with a trailing slash. Can be empty."
 	default "its/"
+	depends on !SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_CUSTOM
+
+config SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_MAX_LEN
+	int "Maximum setting name length"
+	range 2 64
+	default 22 if !SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_CUSTOM
+	default 0
 
 endif # SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_SETTINGS

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/store/settings_get.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2024 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef SECURE_STORAGE_ITS_STORE_SETTINGS_GET_H
+#define SECURE_STORAGE_ITS_STORE_SETTINGS_GET_H
+
+/** @file zephyr/secure_storage/its/store/settings_get.h The settings ITS store module API.
+ *
+ * The functions declared in this header allow customization
+ * of the settings implementation of the ITS store module.
+ * They are not meant to be called directly other than by the settings ITS store module.
+ * This header file may and must be included when providing a custom implementation of one
+ * or more of these functions (@kconfig{CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_*_CUSTOM}).
+ */
+#include <zephyr/secure_storage/its/common.h>
+
+enum { SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_BUF_SIZE
+	= CONFIG_SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_MAX_LEN + 1 };
+
+/** @brief Returns the setting name to use for an ITS entry.
+ *
+ * @param[in]  uid  The UID of the ITS entry for which the setting name is used.
+ * @param[out] name The setting name.
+ */
+void secure_storage_its_store_settings_get_name(
+	secure_storage_its_uid_t uid,
+	char name[static SECURE_STORAGE_ITS_STORE_SETTINGS_NAME_BUF_SIZE]);
+
+#endif

--- a/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
+++ b/subsys/secure_storage/include/internal/zephyr/secure_storage/its/transform/aead_get.h
@@ -9,7 +9,7 @@
  * The functions declared in this header allow customization
  * of the AEAD implementation of the ITS transform module.
  * They are not meant to be called directly other than by the AEAD ITS transform module.
- * This header may be included when providing a custom implementation of one
+ * This header file may and must be included when providing a custom implementation of one
  * or more of these functions (@kconfig{CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_*_CUSTOM}).
  */
 #include <zephyr/secure_storage/its/common.h>
@@ -24,7 +24,7 @@ void secure_storage_its_transform_aead_get_scheme(psa_key_type_t *key_type, psa_
 
 /** @brief Returns the encryption key to use for an ITS entry's AEAD operations.
  *
- * @param[in]  uid The UID of the ITS entry for whom the returned key is used.
+ * @param[in]  uid The UID of the ITS entry for which the key is used.
  * @param[out] key The encryption key.
  *
  * @return `PSA_SUCCESS` on success, anything else on failure.

--- a/subsys/secure_storage/src/its/CMakeLists.txt
+++ b/subsys/secure_storage/src/its/CMakeLists.txt
@@ -8,8 +8,8 @@ zephyr_library_sources_ifdef(CONFIG_SECURE_STORAGE_ITS_TRANSFORM_IMPLEMENTATION_
   transform/aead.c
   transform/aead_get.c
 )
-if (NOT CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NO_INSECURE_KEY_WARNING)
-  if (CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_DEVICE_ID_HASH)
+if(NOT CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_NO_INSECURE_KEY_WARNING)
+  if(CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_DEVICE_ID_HASH)
     message(WARNING "
       The PSA ITS encryption key provider in use generates keys by hashing the device ID
       retrieved through the HW info API. This is not necessarily secure as the device ID may be
@@ -30,7 +30,7 @@ zephyr_library_sources_ifdef(CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_ZMS
 zephyr_library_sources_ifdef(CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_SETTINGS
   store/settings.c
 )
-if (CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_NONE)
+if(CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_NONE)
   message(ERROR "
     The secure storage ITS module is enabled but has no implementation.
     (CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_NONE)


### PR DESCRIPTION
Allow replacing the default naming scheme of the stored settings by providing a custom function that fills a name buffer based on the ITS entry UID.