### PR TITLE
cmake: modules: pre_dt: Handle BOARD_DIRECTORIES

### DIFF
--- a/cmake/modules/pre_dt.cmake
+++ b/cmake/modules/pre_dt.cmake
@@ -28,6 +28,12 @@ include(extensions)
 # - ZEPHYR_BASE: path to zephyr repository (added to DTS_ROOT)
 # - SHIELD_DIRS: paths to shield definitions (added to DTS_ROOT)
 
+# Include board specific device-tree flags before parsing.
+foreach(dir ${BOARD_DIRECTORIES})
+  include(${dir}/pre_dt_board.cmake OPTIONAL)
+endforeach()
+set(dir)
+
 # Using a function avoids polluting the parent scope unnecessarily.
 function(pre_dt_module_run)
   # Convert relative paths to absolute paths relative to the application

--- a/cmake/modules/pre_dt.cmake
+++ b/cmake/modules/pre_dt.cmake
@@ -39,7 +39,7 @@ function(pre_dt_module_run)
   list(APPEND
     DTS_ROOT
     ${APPLICATION_SOURCE_DIR}
-    ${BOARD_DIR}
+    ${BOARD_DIRECTORIES}
     ${SHIELD_DIRS}
     ${ZEPHYR_BASE}
     )

--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -101,10 +101,6 @@ list(APPEND zephyr_cmake_modules hwm_v2)
 list(APPEND zephyr_cmake_modules configuration_files)
 list(APPEND zephyr_cmake_modules generated_file_directories)
 
-# Include board specific device-tree flags before parsing.
-set(pre_dt_board "\${BOARD_DIR}/pre_dt_board.cmake" OPTIONAL)
-list(APPEND zephyr_cmake_modules "\${pre_dt_board}")
-
 # DTS should be close to kconfig because CONFIG_ variables from
 # kconfig and dts should be available at the same time.
 list(APPEND zephyr_cmake_modules dts)
@@ -122,12 +118,6 @@ foreach(component ${SUB_COMPONENTS})
 endforeach()
 
 foreach(module IN LISTS zephyr_cmake_modules)
-  # Ensures any module of type `${module}` are properly expanded to list before
-  # passed on the `include(${module})`.
-  # This is done twice to support cases where the content of `${module}` itself
-  # contains a variable, like `${BOARD_DIR}`.
-  string(CONFIGURE "${module}" module)
-  string(CONFIGURE "${module}" module)
   include(${module})
 
   list(REMOVE_ITEM SUB_COMPONENTS ${module})

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -1291,8 +1291,8 @@ Devicetree Definitions
 ======================
 
 Devicetree directory trees are found in ``APPLICATION_SOURCE_DIR``,
-``BOARD_DIR``, and ``ZEPHYR_BASE``, but additional trees, or DTS_ROOTs,
-can be added by creating this directory tree::
+``BOARD_DIRECTORIES``, ``SHIELD_DIRS``, and ``ZEPHYR_BASE``. Any additional
+trees, or DTS_ROOTs, can be added by creating this directory tree::
 
     include/
     dts/common/


### PR DESCRIPTION
Two tiny patches which concern the use of `BOARD_DIRECTORIES` in place of `BOARD_DIR`.