### PR TITLE
subsys: lorawan: add link check support.

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -172,6 +172,9 @@ New APIs and options
   * :c:func:`util_eq`
   * :c:func:`util_memeq`
 
+* LoRaWAN
+   * :c:func:`lorawan_request_link_check`
+
 New Boards
 **********
 

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -218,6 +218,14 @@ typedef uint8_t (*lorawan_battery_level_cb_t)(void);
 typedef void (*lorawan_dr_changed_cb_t)(enum lorawan_datarate dr);
 
 /**
+ * @brief Defines the link check answer handler function signature.
+ *
+ * @param demod_margin The demodulation margin in db.
+ * @param nb_gateways The number of gateways the device is connected to.
+ */
+typedef void (*lorawan_link_check_ans_cb_t)(uint8_t demod_margin, uint8_t nb_gateways);
+
+/**
  * @brief Defines the user's descriptor callback handler function signature.
  *
  * The use of this callback is optional. When Fragmented Data Block Transport
@@ -266,6 +274,14 @@ void lorawan_register_downlink_callback(struct lorawan_downlink_cb *cb);
  * @param cb Pointer to datarate update callback
  */
 void lorawan_register_dr_changed_callback(lorawan_dr_changed_cb_t cb);
+
+/**
+ * @brief Register a callback to be called when getting answer
+ * a to check link request.
+ *
+ * @param cb Pointer to link check ans callback
+ */
+void lorawan_register_link_check_ans_callback(lorawan_link_check_ans_cb_t cb);
 
 /**
  * @brief Join the LoRaWAN network
@@ -425,6 +441,18 @@ int lorawan_request_device_time(bool force_request);
  * @return 0 if successful, -EAGAIN if the clock is not yet synchronized.
  */
 int lorawan_device_time_get(uint32_t *gps_time);
+
+/**
+ * @brief Request for link check according to LinkCheckReq MAC cmd
+ *
+ * Append MAC LinkCheckReq command. It will be processed on next send
+ * message or force sending empty message to request time immediately.
+ *
+ * @param force_request Immediately send an empty message to execute the request
+ *
+ * @return 0 if successful, negative errno otherwise
+ */
+int lorawan_request_link_check(bool force_request);
 
 #ifdef CONFIG_LORAWAN_APP_CLOCK_SYNC
 


### PR DESCRIPTION
According to LoRaWAN™ 1.0.3 Specification chapter  5.1 Link Check commands.

 Add link check support, by adding:
- link check callback in response of LinkCheckAns.
- link check request function using LinkCheckReq.