### PR TITLE
net: lwm2m: Fix send empty ACK

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -799,7 +799,8 @@ int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid)
 		goto cleanup;
 	}
 
-	ret = zsock_send(client_ctx->sock_fd, msg->cpkt.data, msg->cpkt.offset, 0);
+	ret = zsock_sendto(msg->ctx->sock_fd, msg->cpkt.data, msg->cpkt.offset, 0,
+			   &msg->ctx->remote_addr, NET_SOCKADDR_MAX_SIZE);
 
 	if (ret < 0) {
 		LOG_ERR("Failed to send packet, err %d", errno);


### PR DESCRIPTION
Use `zsock_sendto` instead of `zsock_send`, because if no destination/remote_addr is set, a `lwm2m_send_empty_ack` call could lead to an `EDESTADDRREQ` error.


**Background**

Depending on the configuration, `net_context_send` is executed in `lwm2m_send_empty_ack` and this cannot work because there is a check of the remote address which is always false and leads to an error.

_subsys/net/ip/net_context.c_
```
int net_context_send(
{
        //...

	if (!(context->flags & NET_CONTEXT_REMOTE_ADDR_SET) ||
	    !net_sin(&context->remote)->sin_port) {
		ret = -EDESTADDRREQ;
		goto unlock;
	}
```