### PR TITLE
boards: wch: update linkW documentation

### DIFF
--- a/boards/wch/linkw/doc/index.rst
+++ b/boards/wch/linkw/doc/index.rst
@@ -25,23 +25,7 @@ CAN, 2 USB Device, USB Host, OPA, ETH with PHY, several timers, and BLE 5.3.
 Supported Features
 ==================
 
-The ``linkw`` board target supports the following hardware features:
-
-+-----------+------------+----------------------+
-| Interface | Controller | Driver/Component     |
-+===========+============+======================+
-| CLOCK     | on-chip    | clock_control        |
-+-----------+------------+----------------------+
-| GPIO      | on-chip    | gpio                 |
-+-----------+------------+----------------------+
-| PINCTRL   | on-chip    | pinctrl              |
-+-----------+------------+----------------------+
-| TIMER     | on-chip    | timer                |
-+-----------+------------+----------------------+
-| UART      | on-chip    | uart                 |
-+-----------+------------+----------------------+
-
-Other hardware features have not been enabled yet for this board.
+.. zephyr:board-supported-hw::
 
 Connections and IOs
 ===================
@@ -92,20 +76,6 @@ Debugging
 =========
 
 This board can be debugged via OpenOCD or ``minichlink``.
-
-Testing the LED on the WCH linkw
-**************************************
-
-There is 1 sample program that allow you to test that the LED on the board is
-working properly with Zephyr:
-
-.. code-block:: console
-
-   samples/basic/blinky
-
-You can build and flash the examples to make sure Zephyr is running
-correctly on your board. The button and LED definitions can be found
-in :zephyr_file:`boards/wch/linkw/linkw.dts`.
 
 References
 **********


### PR DESCRIPTION
Removed somewhat duplicated section and replace supported features table with new automatic table.