### PR TITLE
drivers: sensor: current_amp: add calibration option

### DIFF
--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -152,7 +152,7 @@ static int current_init(const struct device *dev)
 
 	data->sequence.buffer = &data->raw;
 	data->sequence.buffer_size = sizeof(data->raw);
-	data->sequence.calibrate = true;
+	data->sequence.calibrate = config->enable_calibration;
 
 	return 0;
 }

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -45,3 +45,9 @@ properties:
 
       If present the corresponding GPIO must be set to an active level
       to enable the current amplifier.
+
+  enable-calibration:
+    type: boolean
+    description: |
+      Enable calibration of the current sense amplifier.
+      This is used to calibrate the ADC prior to taking measurements.

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -16,6 +16,7 @@ struct current_sense_amplifier_dt_spec {
 	uint16_t sense_gain_mult;
 	uint16_t sense_gain_div;
 	struct gpio_dt_spec power_gpio;
+	bool enable_calibration;
 };
 
 /**
@@ -35,6 +36,7 @@ struct current_sense_amplifier_dt_spec {
 		.sense_gain_mult = DT_PROP(node_id, sense_gain_mult),                              \
 		.sense_gain_div = DT_PROP(node_id, sense_gain_div),                                \
 		.power_gpio = GPIO_DT_SPEC_GET_OR(node_id, power_gpios, {0}),                      \
+		.enable_calibration = DT_PROP_OR(node_id, enable_calibration, false),              \
 	}
 
 /**


### PR DESCRIPTION
Allow the option to enable calibration of the ADC. Currently, this breaks functionality of the `current_amp` with devices such as the STM32F4 where calibration is not available.