### PR TITLE
serial: stm32: unconditional policy locks for async TX

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1359,9 +1359,8 @@ static void uart_stm32_isr(const struct device *dev)
 		LL_USART_DisableIT_TC(usart);
 		/* Generate TX_DONE event when transmission is done */
 		async_evt_tx_done(data);
-
 #ifdef CONFIG_PM
-		uart_stm32_pm_policy_state_lock_put(dev);
+		uart_stm32_pm_policy_state_lock_put_unconditional();
 #endif
 	} else if (LL_USART_IsEnabledIT_RXNE(usart) &&
 			LL_USART_IsActiveFlag_RXNE(usart)) {
@@ -1674,7 +1673,7 @@ static int uart_stm32_async_tx(const struct device *dev,
 #ifdef CONFIG_PM
 
 	/* Do not allow system to suspend until transmission has completed */
-	uart_stm32_pm_policy_state_lock_get(dev);
+	uart_stm32_pm_policy_state_lock_get_unconditional();
 #endif
 
 	/* Enable TX DMA requests */


### PR DESCRIPTION
When using the asynchronous TX API, skip the `data->pm_policy_state_on` checks for PM policy updates. This fixes two issues:
 * State conflicts with the `poll_out` implementation when both APIs are used on the same port, resulting in the SoC sleeping while transmissions are running.
 * Scheduling a TX from the `TX_DONE` callback resulting in the PM policy not being applied, resulting in TX errors.

Every call to `uart_tx` should have a corresponding `TX_DONE` event generated, which makes the raw (reference counted) calls to `pm_policy_state_lock_put/get` the correct API to use here.