### PR TITLE
Bluetooth: Controller: Fix Central CIS offset for dissimilar intervals

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -34,7 +34,6 @@ struct ll_conn_iso_stream {
 		struct {
 			uint8_t  c_rtn;
 			uint8_t  p_rtn;
-			uint16_t instant;
 		} central;
 	};
 


### PR DESCRIPTION
Fix Central CIS offset calculation for dissimilar ACL and ISO intervals in use.