### PR TITLE
serial: cmsdk_apb: fix `irq_is_pending`

### DIFF
--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -401,9 +401,7 @@ static void uart_cmsdk_apb_irq_err_disable(const struct device *dev)
  */
 static int uart_cmsdk_apb_irq_is_pending(const struct device *dev)
 {
-	const struct uart_cmsdk_apb_config *dev_cfg = dev->config;
-
-	return (dev_cfg->uart->intstatus & (UART_RX_IN | UART_TX_IN));
+	return uart_cmsdk_apb_irq_rx_ready(dev) || uart_cmsdk_apb_irq_tx_ready(dev);
 }
 
 /**


### PR DESCRIPTION
Implement `irq_is_pending` in terms of the `irq_rx_ready` and `irq_tx_ready` function calls.

Using `intstatus` directly results in an implementation that does not conform to the interrupt driven UART API. Since `intstatus` bits are only only set when a buffer transitions from full to empty, any calls to `irq_is_pending` before any bytes have been sent will return 0. This is problematic since the documented implementation for the API IRQ handler is:
```
while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
    if (uart_irq_rx_ready(dev)) {
        ...
    }
    if (uart_irq_tx_ready(dev)) {
        uart_fifo_fill(dev, ...);
    }
}
```
If `uart_irq_is_pending` does not return 1 until the first byte is sent, we never end up pushing data to be transmitted into the `uart_fifo_full` function.