### PR TITLE
drivers: sensor: meas: ms5837 supporting 02 and 30 variants via dt

### DIFF
--- a/drivers/sensor/meas/ms5837/Kconfig
+++ b/drivers/sensor/meas/ms5837/Kconfig
@@ -1,12 +1,13 @@
 # MS5837 pressure sensor configuration options
 
 # Copyright (c) 2018 Jan Van Winkel <jan.van_winkel@dxplore.eu>
+# Copyright (c) 2025 Ivan Wagner <ivan.wagner@tecinvent.ch>
 # SPDX-License-Identifier: Apache-2.0
 
 config MS5837
 	bool "MS5837 pressure and temperature sensor"
 	default y
-	depends on DT_HAS_MEAS_MS5837_ENABLED
+	depends on DT_HAS_MEAS_MS5837_02BA_ENABLED || DT_HAS_MEAS_MS5837_30BA_ENABLED
 	select I2C
 	help
 	  Enable driver for MS5837 pressure and temperature sensor.

--- a/drivers/sensor/meas/ms5837/ms5837.h
+++ b/drivers/sensor/meas/ms5837/ms5837.h
@@ -44,12 +44,6 @@
 #define MS5837_ADC_READ_DELAY_4086 10
 #define MS5837_ADC_READ_DELAY_8129 20
 
-enum ms5837_type {
-	MS5837_02BA01 = 0x00,
-	MS5837_02BA21 = 0x15,
-	MS5837_30BA26 = 0x1A
-};
-
 typedef void (*ms5837_compensate_func)(const struct device *dev,
 				       const int32_t adc_temperature,
 				       const int32_t adc_pressure);
@@ -76,11 +70,11 @@ struct ms5837_data {
 	uint8_t presure_conv_delay;
 	uint8_t temperature_conv_delay;
 
-	ms5837_compensate_func comp_func;
 };
 
 struct ms5837_config {
 	struct i2c_dt_spec i2c;
+	ms5837_compensate_func comp_func;
 };
 
 #endif /* __SENSOR_MS5837_H__ */

--- a/dts/bindings/sensor/meas,ms5837-02ba.yaml
+++ b/dts/bindings/sensor/meas,ms5837-02ba.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Ivan Wagner <ivan.wagner@tecinvent.ch>
+# SPDX-License-Identifier: Apache-2.0
+
+description: TE Connectivity MS5837-02BA digital pressure sensor
+
+compatible: "meas,ms5837-02ba"
+
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/meas,ms5837-30ba.yaml
+++ b/dts/bindings/sensor/meas,ms5837-30ba.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Ivan Wagner <ivan.wagner@tecinvent.ch>
+# SPDX-License-Identifier: Apache-2.0
+
+description: TE Connectivity MS5837-30BA digital pressure sensor
+
+compatible: "meas,ms5837-30ba"
+
+include: [sensor-device.yaml, i2c-device.yaml]

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -1,8 +1,0 @@
-# Copyright (c) 2018, Jan Van Winkel <jan.van_winkel@dxplore.eu>
-# SPDX-License-Identifier: Apache-2.0
-
-description: TE Connectivity MS5837 digital pressure sensor
-
-compatible: "meas,ms5837"
-
-include: [sensor-device.yaml, i2c-device.yaml]

--- a/samples/sensor/ms5837/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/ms5837/boards/nrf52840dk_nrf52840.overlay
@@ -8,7 +8,8 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	ms5837@76 {
-		compatible = "meas,ms5837";
+		compatible = "meas,ms5837-30ba";
 		reg = <0x76>;
+		status = "okay";
 	};
 };

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -178,9 +178,10 @@ test_i2c_ms5607: ms5607@17 {
 	reg = <0x17>;
 };
 
-test_i2c_ms5837: ms5837@18 {
-	compatible = "meas,ms5837";
+test_i2c_ms5837_02ba: ms5837@18 {
+	compatible = "meas,ms5837-02ba";
 	reg = <0x18>;
+	status = "okay";
 };
 
 test_i2c_jc42: jc42@19 {
@@ -1268,4 +1269,10 @@ test_i2c_bmm350: bmm350@ac {
 test_i2c_ltr329: ltr329@aa {
 	compatible = "liteon,ltr329";
 	reg = <0xad>;
+};
+
+test_i2c_ms5837_30ba: ms5837@ae {
+	compatible = "meas,ms5837-30ba";
+	reg = <0xae>;
+	status = "okay";
 };


### PR DESCRIPTION
This patch adds support via dt compatible property.

Fixes #87870 