### PR TITLE
boards: mikroe: clicker_ra4m1: added mikrobus labels

### DIFF
--- a/boards/mikroe/clicker_ra4m1/mikroe_clicker_ra4m1-pinctrl.dtsi
+++ b/boards/mikroe/clicker_ra4m1/mikroe_clicker_ra4m1-pinctrl.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Ian Morris
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	sci0_default: sci0_default {
+		group1 {
+			/* tx */
+			psels = <RA_PSEL(RA_PSEL_SCI_0, 4, 11)>;
+		};
+
+		group2 {
+			/* rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_0, 4, 10)>;
+		};
+	};
+
+	iic1_default: iic1_default {
+		group1 {
+			/* SCL1 SDA1 */
+			psels = <RA_PSEL(RA_PSEL_I2C, 2, 5)>,
+			<RA_PSEL(RA_PSEL_I2C, 2, 6)>;
+			drive-strength = "medium";
+		};
+	};
+
+	spi0_default: spi0_default {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+			<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+			<RA_PSEL(RA_PSEL_SPI, 1, 2)>,
+			<RA_PSEL(RA_PSEL_SPI, 1, 3)>;
+		};
+	};
+};

--- a/boards/mikroe/clicker_ra4m1/mikroe_clicker_ra4m1.dts
+++ b/boards/mikroe/clicker_ra4m1/mikroe_clicker_ra4m1.dts
@@ -9,6 +9,8 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
+#include "mikroe_clicker_ra4m1-pinctrl.dtsi"
+
 / {
 	model = "Mikroe Clicker RA4M1";
 	compatible = "renesas,ra4m1", "renesas,ra";
@@ -26,6 +28,7 @@
 			gpios = <&ioport4 9 GPIO_ACTIVE_HIGH>;
 			label = "User LED 1";
 		};
+
 		ld2: led_2 {
 			gpios = <&ioport4 8 GPIO_ACTIVE_HIGH>;
 			label = "User LED 2";
@@ -38,6 +41,12 @@
 			gpios = <&ioport3 4 GPIO_ACTIVE_LOW>;
 			label = "User Button 1";
 			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		btn2: button_2 {
+			gpios = <&ioport3 1 GPIO_ACTIVE_LOW>;
+			label = "User Button 2";
+			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
 
@@ -68,19 +77,7 @@
 		led0 = &ld1;
 		led1 = &ld2;
 		sw0 = &btn1;
-	};
-};
-
-&pinctrl {
-	sci0_default: sci0_default {
-		group1 {
-			/* tx */
-			psels = <RA_PSEL(RA_PSEL_SCI_0, 4, 11)>;
-		};
-		group2 {
-			/* rx */
-			psels = <RA_PSEL(RA_PSEL_SCI_0, 4, 10)>;
-		};
+		sw1 = &btn2;
 	};
 };
 
@@ -92,6 +89,25 @@
 		current-speed = <115200>;
 		status = "okay";
 	};
+};
+
+&iic1 {
+	pinctrl-0 = <&iic1_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <DT_FREQ_K(400)>;
+	interrupts = <10 1>, <11 1>, <12 1>, <13 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-names = "default";
+	interrupts = <23 1>, <24 1>, <25 1>, <26 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+	status = "okay";
 };
 
 &ioport0 {
@@ -111,6 +127,11 @@
 };
 
 &ioport4 {
+	status = "okay";
+};
+
+&port_irq6 {
+	interrupts = <28 12>;
 	status = "okay";
 };
 
@@ -152,3 +173,7 @@
 &fclk {
 	div = <2>;
 };
+
+mikrobus_serial: &uart0 {};
+mikrobus_i2c: &iic1 {};
+mikrobus_spi: &spi0 {};


### PR DESCRIPTION
Added mikrobus_i2c, mikrobus_spi and mikrobus_serial node labels to device tree board definition, allowing compatible shield boards to be used. Also added User Button 2 definition and refactored pinctrl defintions into separate file.