### PR TITLE
tests: kernel/sleep: exclude npcx platforms from the test

### DIFF
--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -3,6 +3,10 @@ tests:
     tags:
       - kernel
       - sleep
+    platform_exclude:
+      - npcx4m8f_evb
+      - npcx7m6fb_evb
+      - npcx9m6f_evb
   kernel.common.timing.minimallibc:
     filter: CONFIG_MINIMAL_LIBC_SUPPORTED
     tags:


### PR DESCRIPTION
According the specification, in extreme cases, the deviation of the APB clock and LFCLK clock can reach up to +/-1% (+/- 10ms). Therefore, exclude npcx platforms from the test because it required 1ms accuracy.

fixes: #66185