### PR TITLE
dts: silabs: interrupt levels corrected

### DIFF
--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -29,7 +29,7 @@
 };
 
 &cmu {
-	interrupts = <46 0>;
+	interrupts = <46 2>;
 };
 
 &hfxo {
@@ -93,43 +93,43 @@
 };
 
 &i2c0 {
-	interrupts = <27 0>;
+	interrupts = <27 2>;
 	clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
 };
 
 &i2c1 {
-	interrupts = <28 0>;
+	interrupts = <28 2>;
 	clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
 };
 
 &usart0 {
-	interrupts = <13 0>, <14 0>;
+	interrupts = <13 2>, <14 2>;
 	clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
 };
 
 &usart1 {
-	interrupts = <15 0>, <16 0>;
+	interrupts = <15 2>, <16 2>;
 	clocks = <&cmu CLOCK_USART1 CLOCK_BRANCH_PCLK>;
 };
 
 &burtc0 {
-	interrupts = <18 0>;
+	interrupts = <18 2>;
 	clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
 };
 
 &rtcc0 {
-	interrupts = <12 0>;
+	interrupts = <12 2>;
 	interrupt-names = "rtcc";
 	clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;
 };
 
 &dcdc {
-	interrupts = <61 0>;
+	interrupts = <61 2>;
 };
 
 &radio {
-	interrupts = <31 0>, <32 0>, <33 0>, <34 0>, <35 0>, <36 0>,
-		     <37 0>, <38 0>, <39 0>, <40 0>, <41 0>, <42 0>;
+	interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
+		     <37 1>, <38 1>, <39 1>, <40 1>, <41 1>, <42 1>;
 	interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 		     "rac_rsm", "rac_seq", "rdmailbox", "rfsense", "prortc",
 		     "synth";

--- a/dts/arm/silabs/efr32bg27.dtsi
+++ b/dts/arm/silabs/efr32bg27.dtsi
@@ -38,7 +38,7 @@
 		acmp0: acmp@5a008000 {
 			compatible = "silabs,acmp";
 			reg = <0x5a008000 0x4000>;
-			interrupts = <48 0>;
+			interrupts = <48 2>;
 			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
@@ -46,11 +46,11 @@
 };
 
 &cmu {
-	interrupts = <52 0>;
+	interrupts = <52 2>;
 };
 
 &hfxo {
-	interrupts = <50 0>;
+	interrupts = <50 2>;
 	interrupt-names = "hfxo";
 };
 
@@ -106,43 +106,43 @@
 };
 
 &i2c0 {
-	interrupts = <32 0>;
+	interrupts = <32 2>;
 	clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
 };
 
 &i2c1 {
-	interrupts = <33 0>;
+	interrupts = <33 2>;
 	clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
 };
 
 &usart0 {
-	interrupts = <16 0>, <17 0>;
+	interrupts = <16 2>, <17 2>;
 	clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
 };
 
 &usart1 {
-	interrupts = <18 0>, <19 0>;
+	interrupts = <18 2>, <19 2>;
 	clocks = <&cmu CLOCK_USART1 CLOCK_BRANCH_PCLK>;
 };
 
 &burtc0 {
-	interrupts = <23 0>;
+	interrupts = <23 2>;
 	clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
 };
 
 &rtcc0 {
-	interrupts = <15 0>;
+	interrupts = <15 2>;
 	interrupt-names = "rtcc";
 	clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;
 };
 
 &adc0 {
-	interrupts = <54 0>;
+	interrupts = <54 2>;
 	clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
 };
 
 &dcdc {
-	interrupts = <8 0>;
+	interrupts = <8 2>;
 };
 
 &dma0 {
@@ -150,8 +150,8 @@
 };
 
 &radio {
-	interrupts = <36 0>, <37 0>, <38 0>, <39 0>, <40 0>, <41 0>,
-		     <42 0>, <43 0>, <44 0>, <45 0>, <46 0>, <47 0>;
+	interrupts = <36 1>, <37 1>, <38 1>, <39 1>, <40 1>, <41 1>,
+		     <42 1>, <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
 	interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 		     "rac_rsm", "rac_seq", "rdmailbox", "rfsense", "synth",
 		     "prortc";

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -223,7 +223,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0xC69>;
-			interrupts = <49 0>;
+			interrupts = <49 2>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -263,7 +263,7 @@
 			compatible = "silabs,gecko-trng";
 			reg = <0x4C021000 0x1000>;
 			status = "disabled";
-			interrupts = <0x1 0x0>;
+			interrupts = <0x1 0x2>;
 		};
 
 		i2c0: i2c@5a010000 {
@@ -310,14 +310,14 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x4A018000 0x3028>;
 			peripheral-id = <0>;
-			interrupts = <43 0>;
+			interrupts = <43 2>;
 			status = "disabled";
 		};
 
 		adc0: adc@5a004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x5a004000 0x4000>;
-			interrupts = <48 0>;
+			interrupts = <48 2>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/silabs/efr32mg21.dtsi
+++ b/dts/arm/silabs/efr32mg21.dtsi
@@ -121,7 +121,7 @@
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <48 0>;
+			interrupts = <48 2>;
 			interrupt-names = "cmu";
 			status = "okay";
 			#clock-cells = <2>;
@@ -218,7 +218,7 @@
 		usart1: usart@5005c000 { /* USART1 */
 			compatible = "silabs,usart-uart";
 			reg = <0x5005c000 0x400>;
-			interrupts = <13 0>, <14 0>;
+			interrupts = <13 2>, <14 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_PCLK>;
 			status = "disabled";
@@ -227,7 +227,7 @@
 		usart2: usart@50060000 { /* USART2 */
 			compatible = "silabs,usart-uart";
 			reg = <0x50060000 0x400>;
-			interrupts = <15 0>, <16 0>;
+			interrupts = <15 2>, <16 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_PCLK>;
 			status = "disabled";
@@ -239,7 +239,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x5a010000 0x400>;
-			interrupts = <27 0>;
+			interrupts = <27 2>;
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_LSPCLK>;
 			status = "disabled";
 		};
@@ -250,7 +250,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x50068000 0x400>;
-			interrupts = <28 0>;
+			interrupts = <28 2>;
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_PCLK>;
 			status = "disabled";
 		};
@@ -258,7 +258,7 @@
 		rtcc0: rtcc@58000000 {
 			compatible = "silabs,gecko-stimer";
 			reg = <0x58000000 0x400>;
-			interrupts = <10 0>;
+			interrupts = <10 2>;
 			interrupt-names = "rtcc";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -341,7 +341,7 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x5a018000 0x2C>;
 			peripheral-id = <0>;
-			interrupts = <43 0>;
+			interrupts = <43 2>;
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_WDOG0CLK>;
 			status = "disabled";
 		};
@@ -350,7 +350,7 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x5a01c000 0x2C>;
 			peripheral-id = <1>;
-			interrupts = <44 0>;
+			interrupts = <44 2>;
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_WDOG1CLK>;
 			status = "disabled";
 		};
@@ -366,8 +366,8 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x1000000>;
-			interrupts = <31 0>, <32 0>, <33 0>, <34 0>, <35 0>, <36 0>,
-				     <37 0>, <38 0>, <39 0>, <40 0>;
+			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
+				     <37 1>, <38 1>, <39 1>, <40 1>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "prortc", "synth";
 			pa-initial-power-dbm = <10>;

--- a/dts/arm/silabs/efr32mg24.dtsi
+++ b/dts/arm/silabs/efr32mg24.dtsi
@@ -188,7 +188,7 @@
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <47 0>;
+			interrupts = <47 2>;
 			interrupt-names = "cmu";
 			status = "okay";
 			#clock-cells = <2>;
@@ -262,7 +262,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x3148>;
-			interrupts = <50 0>;
+			interrupts = <50 2>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -277,7 +277,7 @@
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-uart";
 			reg = <0x5005C000 0x306c>;
-			interrupts = <9 0>, <10 0>;
+			interrupts = <9 2>, <10 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
 			status = "disabled";
@@ -286,7 +286,7 @@
 		eusart0: eusart@5b010000 {
 			compatible = "silabs,eusart-spi";
 			reg = <0x5B010000 0x4000>;
-			interrupts = <11 0>, <12 0>;
+			interrupts = <11 2>, <12 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
 			status = "disabled";
@@ -295,7 +295,7 @@
 		eusart1: eusart@500a0000 {
 			compatible = "silabs,eusart-spi";
 			reg = <0x500A0000 0x4000>;
-			interrupts = <13 0>, <14 0>;
+			interrupts = <13 2>, <14 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
 			status = "disabled";
@@ -304,7 +304,7 @@
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
 			reg = <0x50064000 0x3034>;
-			interrupts = <17 0>;
+			interrupts = <17 2>;
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
 			status = "disabled";
 		};
@@ -323,7 +323,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x5b000000 0x3044>;
-			interrupts = <27 0>;
+			interrupts = <27 2>;
 			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
 			status = "disabled";
 		};
@@ -331,7 +331,7 @@
 		sysrtc0: stimer0: sysrtc@500a8000 {
 			compatible = "silabs,gecko-stimer";
 			reg = <0x500a8000 0x3054>;
-			interrupts = <67 0>, <68 0>;
+			interrupts = <67 2>, <68 2>;
 			interrupt-names = "sysrtc_app", "sysrtc_seq";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -406,7 +406,7 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x5b004000 0x2C>;
 			peripheral-id = <0>;
-			interrupts = <42 0>;
+			interrupts = <42 2>;
 			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
 			status = "disabled";
 		};
@@ -415,7 +415,7 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x5b008000 0x2C>;
 			peripheral-id = <1>;
-			interrupts = <43 0>;
+			interrupts = <43 2>;
 			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
 			status = "disabled";
 		};
@@ -423,7 +423,7 @@
 		adc0: adc@59004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x59004000 0x4000>;
-			interrupts = <49 0>;
+			interrupts = <49 2>;
 			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -432,14 +432,14 @@
 		dcdc: dcdc@50094000 {
 			compatible = "silabs,series2-dcdc";
 			reg = <0x50094000 0x4000>;
-			interrupts = <53 0>;
+			interrupts = <53 2>;
 			status = "disabled";
 		};
 
 		acmp0: acmp@59008000 {
 			compatible = "silabs,acmp";
 			reg = <0x59008000 0x4000>;
-			interrupts = <40 0>;
+			interrupts = <40 2>;
 			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
@@ -447,8 +447,8 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x1000000>;
-			interrupts = <30 0>, <31 0>, <32 0>, <33 0>, <34 0>, <35 0>,
-				     <36 0>, <37 0>, <38 0>, <39 0>, <70 0>, <71 0>;
+			interrupts = <30 1>, <31 1>, <32 1>, <33 1>, <34 1>, <35 1>,
+				     <36 1>, <37 1>, <38 1>, <39 1>, <70 1>, <71 1>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "hostmailbox", "synth",
 					  "rfeca0", "rfeca1";

--- a/dts/arm/silabs/efr32xg23.dtsi
+++ b/dts/arm/silabs/efr32xg23.dtsi
@@ -198,7 +198,7 @@
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <48 0>;
+			interrupts = <48 2>;
 			interrupt-names = "cmu";
 			status = "okay";
 			#clock-cells = <2>;
@@ -272,7 +272,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
-			interrupts = <51 0>;
+			interrupts = <51 2>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -287,7 +287,7 @@
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-uart";
 			reg = <0x5005C000 0x4000>;
-			interrupts = <9 0>, <10 0>;
+			interrupts = <9 2>, <10 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
 			status = "disabled";
@@ -296,7 +296,7 @@
 		eusart0: eusart@5b010000 {
 			compatible = "silabs,eusart-spi";
 			reg = <0x5B010000 0x4000>;
-			interrupts = <11 0>, <12 0>;
+			interrupts = <11 2>, <12 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
 			status = "disabled";
@@ -305,7 +305,7 @@
 		eusart1: eusart@500a0000 {
 			compatible = "silabs,eusart-spi";
 			reg = <0x500A0000 0x4000>;
-			interrupts = <13 0>, <14 0>;
+			interrupts = <13 2>, <14 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
 			status = "disabled";
@@ -314,7 +314,7 @@
 		eusart2: eusart@500a4000 {
 			compatible = "silabs,eusart-spi";
 			reg = <0x500A4000 0x4000>;
-			interrupts = <15 0>, <16 0>;
+			interrupts = <15 2>, <16 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_EUSART2 CLOCK_BRANCH_EM01GRPCCLK>;
 			status = "disabled";
@@ -323,7 +323,7 @@
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
 			reg = <0x50064000 0x4000>;
-			interrupts = <18 0>;
+			interrupts = <18 2>;
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
 			status = "disabled";
 		};
@@ -342,7 +342,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x5b000000 0x4000>;
-			interrupts = <28 0>;
+			interrupts = <28 2>;
 			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
 			status = "disabled";
 		};
@@ -353,7 +353,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x50068000 0x4000>;
-			interrupts = <29 0>;
+			interrupts = <29 2>;
 			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
 			status = "disabled";
 		};
@@ -361,7 +361,7 @@
 		sysrtc0: stimer0: sysrtc@500a8000 {
 			compatible = "silabs,gecko-stimer";
 			reg = <0x500a8000 0x4000>;
-			interrupts = <70 0>, <71 0>;
+			interrupts = <70 2>, <71 2>;
 			interrupt-names = "sysrtc_app", "sysrtc_seq";
 			clock-frequency = <32768>;
 			prescaler = <1>;
@@ -436,7 +436,7 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x5b004000 0x4000>;
 			peripheral-id = <0>;
-			interrupts = <43 0>;
+			interrupts = <43 2>;
 			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
 			status = "disabled";
 		};
@@ -445,7 +445,7 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x5b008000 0x4000>;
 			peripheral-id = <1>;
-			interrupts = <44 0>;
+			interrupts = <44 2>;
 			clocks = <&cmu CLOCK_WDOG1 CLOCK_BRANCH_WDOG1CLK>;
 			status = "disabled";
 		};
@@ -453,7 +453,7 @@
 		adc0: adc@59004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x59004000 0x4000>;
-			interrupts = <50 0>;
+			interrupts = <50 2>;
 			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -462,14 +462,14 @@
 		dcdc: dcdc@50094000 {
 			compatible = "silabs,series2-dcdc";
 			reg = <0x50094000 0x4000>;
-			interrupts = <54 0>;
+			interrupts = <54 2>;
 			status = "disabled";
 		};
 
 		acmp0: acmp@59008000 {
 			compatible = "silabs,acmp";
 			reg = <0x59008000 0x4000>;
-			interrupts = <41 0>;
+			interrupts = <41 2>;
 			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
@@ -477,8 +477,8 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x1000000>;
-			interrupts = <31 0>, <32 0>, <33 0>, <34 0>, <35 0>, <36 0>,
-				     <37 0>, <38 0>, <39 0>, <40 0>, <74 0>, <75 0>;
+			interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
+				     <37 1>, <38 1>, <39 1>, <40 1>, <74 1>, <75 1>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "hostmailbox", "synth",
 					  "rfeca0", "rfeca1";

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -184,7 +184,7 @@
 		cmu: clock@50008000 {
 			compatible = "silabs,series-clock";
 			reg = <0x50008000 0x4000>;
-			interrupts = <52 0>;
+			interrupts = <52 2>;
 			interrupt-names = "cmu";
 			status = "okay";
 			#clock-cells = <2>;
@@ -222,7 +222,7 @@
 			#clock-cells = <0>;
 			compatible = "silabs,series2-lfxo";
 			reg = <0x50020000 0x4000>;
-			interrupts = <27 0>;
+			interrupts = <27 2>;
 			interrupt-names = "lfxo";
 			clock-frequency = <32768>;
 			ctune = <63>;
@@ -235,7 +235,7 @@
 			#clock-cells = <0>;
 			compatible = "silabs,series2-lfrco";
 			reg = <0x50024000 0x4000>;
-			interrupts = <28 0>;
+			interrupts = <28 2>;
 			interrupt-names = "lfrco";
 			clock-frequency = <32768>;
 		};
@@ -244,7 +244,7 @@
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
 			reg = <0x50028000 0x4000>;
-			interrupts = <29 0>;
+			interrupts = <29 2>;
 			interrupt-names = "ulfrco";
 			clock-frequency = <1000>;
 		};
@@ -259,7 +259,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
-			interrupts = <55 0>;
+			interrupts = <55 1>;
 			interrupt-names = "msc";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -274,7 +274,7 @@
 		gpio: gpio@5003c000 {
 			compatible = "silabs,gecko-gpio";
 			reg = <0x5003C000 0x440>;
-			interrupts = <31 0>, <30 0>;
+			interrupts = <31 2>, <30 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
 			clocks = <&cmu CLOCK_GPIO CLOCK_BRANCH_PCLK>;
 			ranges;
@@ -333,7 +333,7 @@
 		usart0: usart@5005c000 {
 			compatible = "silabs,usart-uart";
 			reg = <0x5005C000 0x400>;
-			interrupts = <16 0>, <17 0>;
+			interrupts = <16 2>, <17 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_USART0 CLOCK_BRANCH_PCLK>;
 			status = "disabled";
@@ -342,7 +342,7 @@
 		usart1: usart@50060000 {
 			compatible = "silabs,usart-uart";
 			reg = <0x50060000 0x400>;
-			interrupts = <18 0>, <19 0>;
+			interrupts = <18 2>, <19 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_USART1 CLOCK_BRANCH_PCLK>;
 			status = "disabled";
@@ -351,7 +351,7 @@
 		burtc0: burtc@50064000 {
 			compatible = "silabs,gecko-burtc";
 			reg = <0x50064000 0x4000>;
-			interrupts = <23 0>;
+			interrupts = <23 2>;
 			interrupt-names = "burtc";
 			clocks = <&cmu CLOCK_BURTC CLOCK_BRANCH_EM4GRPACLK>;
 			status = "disabled";
@@ -361,7 +361,7 @@
 			compatible = "silabs,gecko-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x5a010000 0x4000>;
-			interrupts = <32 0>;
+			interrupts = <32 2>;
 			interrupt-names = "i2c0";
 			clocks = <&cmu CLOCK_I2C0 CLOCK_BRANCH_LSPCLK>;
 			#address-cells = <1>;
@@ -373,7 +373,7 @@
 			compatible = "silabs,gecko-i2c";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x50068000 0x4000>;
-			interrupts = <33 0>;
+			interrupts = <33 2>;
 			interrupt-names = "i2c1";
 			clocks = <&cmu CLOCK_I2C1 CLOCK_BRANCH_PCLK>;
 			#address-cells = <1>;
@@ -384,7 +384,7 @@
 		dcdc: dcdc@50094000 {
 			compatible = "silabs,series2-dcdc";
 			reg = <0x50094000 0x4000>;
-			interrupts = <8 0>;
+			interrupts = <8 2>;
 			interrupt-names = "dcdc";
 			status = "disabled";
 		};
@@ -392,7 +392,7 @@
 		eusart0: eusart@5a040000 {
 			compatible = "silabs,eusart-spi";
 			reg = <0x5A040000 0x4000>;
-			interrupts = <20 0>, <21 0>;
+			interrupts = <20 2>, <21 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_EUSART0 CLOCK_BRANCH_EUSART0CLK>;
 			status = "disabled";
@@ -401,7 +401,7 @@
 		eusart1: eusart@500b4000 {
 			compatible = "silabs,eusart-spi";
 			reg = <0x500B4000 0x4000>;
-			interrupts = <68 0>, <69 0>;
+			interrupts = <68 2>, <69 2>;
 			interrupt-names = "rx", "tx";
 			clocks = <&cmu CLOCK_EUSART1 CLOCK_BRANCH_EM01GRPCCLK>;
 			status = "disabled";
@@ -410,7 +410,7 @@
 		rtcc0: rtcc@58000000 {
 			compatible = "silabs,gecko-stimer";
 			reg = <0x58000000 0x4000>;
-			interrupts = <15 0>;
+			interrupts = <15 2>;
 			interrupt-names = "rtcc";
 			clocks = <&cmu CLOCK_RTCC CLOCK_BRANCH_RTCCCLK>;
 			clock-frequency = <32768>;
@@ -422,7 +422,7 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x58018000 0x4000>;
 			peripheral-id = <0>;
-			interrupts = <49 0>;
+			interrupts = <49 2>;
 			interrupt-names = "wdog0";
 			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
 			status = "disabled";
@@ -431,7 +431,7 @@
 		adc0: adc@5a004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x5a004000 0x4000>;
-			interrupts = <54 0>;
+			interrupts = <54 2>;
 			interrupt-names = "iadc0";
 			clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
 			status = "disabled";
@@ -441,7 +441,7 @@
 		acmp0: acmp@5a008000 {
 			compatible = "silabs,acmp";
 			reg = <0x5a008000 0x4000>;
-			interrupts = <48 0>;
+			interrupts = <48 2>;
 			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
@@ -457,8 +457,8 @@
 		radio: radio@b0000000 {
 			compatible = "silabs,series2-radio";
 			reg = <0xb0000000 0x1000000>;
-			interrupts = <36 0>, <37 0>, <38 0>, <39 0>, <40 0>, <41 0>,
-				     <42 0>, <43 0>, <44 0>, <45 0>, <46 0>, <47 0>;
+			interrupts = <36 1>, <37 1>, <38 1>, <39 1>, <40 1>, <41 1>,
+				     <42 1>, <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;
 			interrupt-names = "agc", "bufc", "frc_pri", "frc", "modem", "protimer",
 					  "rac_rsm", "rac_seq", "rdmailbox", "rfsense", "synth",
 					  "prortc";


### PR DESCRIPTION
Downgrading interrupt priority for non critical interrupts for the supported SOCs.

Previously almost all interrupts were at level 0 i.e. meaning no interrupt had priority over the others. In reality only radio interrupts are critical while others can be served with less haste.

Now the level zero is reserved for system interrupts. level 1 for radio and level 2 and 3 for rest of the services.