### PR TITLE
drivers: counter: migrate AGT counter to use FSP function

### DIFF
--- a/boards/renesas/ek_ra2a1/ek_ra2a1.yaml
+++ b/boards/renesas/ek_ra2a1/ek_ra2a1.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - uart
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra2l1/ek_ra2l1.yaml
+++ b/boards/renesas/ek_ra2l1/ek_ra2l1.yaml
@@ -10,6 +10,7 @@ toolchain:
 supported:
   - flash
   - watchdog
+  - counter
 vendor: renesas
 testing:
   ignore_tags:

--- a/boards/renesas/ek_ra4e2/ek_ra4e2.yaml
+++ b/boards/renesas/ek_ra4e2/ek_ra4e2.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - uart
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra4l1/ek_ra4l1.yaml
+++ b/boards/renesas/ek_ra4l1/ek_ra4l1.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - uart
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra4m1/ek_ra4m1.yaml
+++ b/boards/renesas/ek_ra4m1/ek_ra4m1.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - uart
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra4m2/ek_ra4m2.yaml
+++ b/boards/renesas/ek_ra4m2/ek_ra4m2.yaml
@@ -12,4 +12,5 @@ supported:
   - uart
   - usbd
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra4m3/ek_ra4m3.yaml
+++ b/boards/renesas/ek_ra4m3/ek_ra4m3.yaml
@@ -12,4 +12,5 @@ supported:
   - uart
   - usbd
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra4w1/ek_ra4w1.yaml
+++ b/boards/renesas/ek_ra4w1/ek_ra4w1.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - uart
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra6e2/ek_ra6e2.yaml
+++ b/boards/renesas/ek_ra6e2/ek_ra6e2.yaml
@@ -10,4 +10,5 @@ toolchain:
 supported:
   - gpio
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra6m1/ek_ra6m1.yaml
+++ b/boards/renesas/ek_ra6m1/ek_ra6m1.yaml
@@ -12,4 +12,5 @@ supported:
   - uart
   - usbd
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra6m2/ek_ra6m2.yaml
+++ b/boards/renesas/ek_ra6m2/ek_ra6m2.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - usbd
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra6m3/ek_ra6m3.yaml
+++ b/boards/renesas/ek_ra6m3/ek_ra6m3.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - usbd
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra6m4/ek_ra6m4.yaml
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - usbd
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra6m5/ek_ra6m5.yaml
+++ b/boards/renesas/ek_ra6m5/ek_ra6m5.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - usbd
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.yaml
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.yaml
@@ -13,4 +13,5 @@ supported:
   - watchdog
   - usbd
   - display
+  - counter
 vendor: renesas

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.yaml
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.yaml
@@ -12,4 +12,5 @@ supported:
   - uart
   - watchdog
   - usbd
+  - counter
 vendor: renesas

--- a/boards/renesas/fpb_ra4e1/fpb_ra4e1.yaml
+++ b/boards/renesas/fpb_ra4e1/fpb_ra4e1.yaml
@@ -11,4 +11,5 @@ supported:
   - gpio
   - uart
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/fpb_ra6e1/fpb_ra6e1.yaml
+++ b/boards/renesas/fpb_ra6e1/fpb_ra6e1.yaml
@@ -10,4 +10,5 @@ toolchain:
 supported:
   - gpio
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/fpb_ra6e2/fpb_ra6e2.yaml
+++ b/boards/renesas/fpb_ra6e2/fpb_ra6e2.yaml
@@ -10,4 +10,5 @@ toolchain:
 supported:
   - gpio
   - watchdog
+  - counter
 vendor: renesas

--- a/boards/renesas/mck_ra8t1/mck_ra8t1.yaml
+++ b/boards/renesas/mck_ra8t1/mck_ra8t1.yaml
@@ -12,4 +12,5 @@ supported:
   - uart
   - watchdog
   - usbd
+  - counter
 vendor: renesas

--- a/drivers/counter/Kconfig.renesas_ra
+++ b/drivers/counter/Kconfig.renesas_ra
@@ -7,5 +7,6 @@ config COUNTER_RA_AGT
 	bool "Renesas RA AGT driver"
 	default y
 	depends on DT_HAS_RENESAS_RA_AGT_COUNTER_ENABLED
+	select USE_RA_FSP_AGT
 	help
 	  Enable support for Renesas Low Power Asynchronous General Purpose Timer (AGT) driver.

--- a/drivers/counter/counter_renesas_ra_agt.c
+++ b/drivers/counter/counter_renesas_ra_agt.c
@@ -6,510 +6,234 @@
 
 #define DT_DRV_COMPAT renesas_ra_agt_counter
 
-#include <zephyr/devicetree.h>
-#include <zephyr/drivers/counter.h>
+#include <soc.h>
+#include <zephyr/kernel.h>
 #include <zephyr/irq.h>
-#include <r_agt.h>
+#include <zephyr/drivers/counter.h>
+
+#include "r_agt.h"
+#include "rp_agt.h"
+
 #include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(counter_renesas_ra_agt, CONFIG_COUNTER_LOG_LEVEL);
 
-#define FSUB_FREQUENCY_HZ (32768U)
-typedef volatile R_AGTX0_AGT16_CTRL_Type agt_reg_ctrl_t;
-#define AGT_AGTCR_STOP_TIMER  0xF0U /* 1111 0000 */
-#define AGT_AGTCR_START_TIMER 0xF1U /* 1111 0001 */
-#define AGT_AGTCR_FLAGS_MASK  0xF0U /* 1111 0000 */
-
-#define AGT_PRV_MIN_CLOCK_FREQ      (0U)
-#define AGT_SOURCE_CLOCK_PCLKB_BITS (0x3U)
-
-LOG_MODULE_REGISTER(ra_agt_counter, CONFIG_COUNTER_LOG_LEVEL);
-
-struct counter_ra_agt_config {
-	/* info must be first element */
-	struct counter_config_info info; /* Counter Config info struct */
-	uint32_t channel;                /* Channel no */
-	uint32_t cycle_end_irq;          /* Underflow interrupt*/
-	uint32_t cycle_end_ipl;          /* Underflow interrupt priority */
-	uint32_t channel_ipl;            /* IPL channel no. */
-	uint32_t channel_irq;            /* IRQ channel no. */
-	/* Device tree data */
-	timer_source_div_t source_div;   /* Clock source divider */
-	agt_agtio_filter_t agtio_filter; /* Input filter for AGTIO */
-	agt_measure_t measurement_mode;  /* Measurement mode */
-	agt_clock_t count_source;        /* AGT channel clock source */
-	uint32_t resolution;             /* AGT node resolution */
-	uint32_t dt_reg;                 /* Reg address from device tree */
+struct counter_renesas_ra_agt_config {
+	struct counter_config_info info;
+	void (*irq_config_func)(void);
 };
 
-struct counter_ra_agt_alarm {
-	counter_alarm_callback_t callback;
-	void *data;
+struct counter_renesas_ra_agt_data {
+	struct st_agt_instance_ctrl agt_ctrl;
+	struct st_timer_cfg agt_cfg;
+	struct st_agt_extended_cfg agt_extend_cfg;
+	IRQn_Type agtcmai_irq;
+	uint8_t agtcmai_ipl;
+	uint32_t guard_period;
+	counter_alarm_callback_t alarm_cb;
+	counter_top_callback_t top_cb;
+	void *alarm_data;
+	void *top_data;
+	struct k_spinlock lock;
 };
 
-struct counter_ra_agt_data {
-	/* Common data */
-	R_AGTX0_Type *agt_reg;   /* AGT register base address */
-	uint32_t period;         /* Current timer period (counts) */
-	uint32_t period_counts;  /* Period in raw timer counts */
-	uint32_t cycle_end_ipl;  /* Cycle end interrupt priority */
-	IRQn_Type cycle_end_irq; /* Cycle end interrupt */
-	/* Alarm-related data */
-	struct counter_ra_agt_alarm alarm; /* Counter alarm config struct */
-	counter_top_callback_t top_cb;     /* Top level callback */
-	void *top_cb_data;                 /* Top level callback data */
-	uint32_t guard_period;             /* Absolute counter alarm's guard period */
-};
+extern void agt_int_isr(void);
+extern void agtcmai_isr(void);
 
-static void r_agt_hardware_cfg(const struct device *dev);
-static void r_agt_period_register_set(const struct device *dev, uint32_t period_counts);
-static uint32_t r_agt_clock_frequency_get(agt_reg_ctrl_t *p_reg);
-static fsp_err_t r_agt_common_preamble(agt_reg_ctrl_t *p_reg);
-static agt_reg_ctrl_t *r_agt_reg_ctrl_get(const struct device *dev);
-static uint32_t r_agt_ticks_sub(uint32_t val, uint32_t old, uint32_t top);
-
-static int counter_ra_agt_start(const struct device *dev)
+static inline bool renesas_ra_agt_is_running(const struct device *dev)
 {
-	agt_reg_ctrl_t *const reg = r_agt_reg_ctrl_get(dev);
-	uint32_t timeout = UINT32_MAX;
+	struct counter_renesas_ra_agt_data *data = dev->data;
 
-	reg->AGTCR = AGT_AGTCR_START_TIMER;
+	return data->agt_ctrl.is_agtw ? (data->agt_ctrl.p_reg->AGT32.CTRL.AGTCR_b.TCSTF == 1)
+				      : (data->agt_ctrl.p_reg->AGT16.CTRL.AGTCR_b.TCSTF == 1);
+}
 
-	while (!(reg->AGTCR & BIT(R_AGTX0_AGT16_CTRL_AGTCR_TCSTF_Pos)) && likely(--timeout)) {
+static inline int renesas_ra_agt_period_set(const struct device *dev, uint32_t period)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	const bool counting = renesas_ra_agt_is_running(dev);
+	fsp_err_t err;
+
+	if (counting) {
+		err = R_AGT_Stop(&data->agt_ctrl);
+		if (err != FSP_SUCCESS) {
+			return -EIO;
+		}
 	}
 
-	return timeout > 0 ? 0 : -EIO;
-}
-
-static int counter_ra_agt_stop(const struct device *dev)
-{
-	agt_reg_ctrl_t *const reg = r_agt_reg_ctrl_get(dev);
-	uint32_t timeout = UINT32_MAX;
-
-	reg->AGTCR = AGT_AGTCR_STOP_TIMER;
-
-	while ((reg->AGTCR & BIT(R_AGTX0_AGT16_CTRL_AGTCR_TCSTF_Pos)) && likely(--timeout)) {
+	err = R_AGT_PeriodSet(&data->agt_ctrl, period);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
 	}
 
-	return timeout > 0 ? 0 : -EIO;
-}
+	if (counting) {
+		err = R_AGT_Start(&data->agt_ctrl);
+		if (err != FSP_SUCCESS) {
+			return -EIO;
+		}
+	}
 
-static inline int counter_ra_agt_read(const struct device *dev)
-{
-	struct counter_ra_agt_data *data = dev->data;
-
-	return data->agt_reg->AGT16.AGT;
-}
-static int counter_ra_agt_get_value(const struct device *dev, uint32_t *ticks)
-{
-	*ticks = counter_ra_agt_read(dev);
 	return 0;
 }
 
-static uint32_t counter_ra_agt_get_top_value(const struct device *dev)
+static inline int renesas_ra_agt_compare_match_set(const struct device *dev, uint32_t val)
 {
-	const struct counter_ra_agt_config *config = dev->config;
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	const bool counting = renesas_ra_agt_is_running(dev);
+	fsp_err_t err;
 
-	return config->info.max_top_value;
-}
-
-static int counter_ra_agt_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
-{
-	const struct counter_ra_agt_config *config = dev->config;
-	struct counter_ra_agt_data *data = dev->data;
-	agt_reg_ctrl_t *p_reg_ctrl = r_agt_reg_ctrl_get(dev);
-
-	if (cfg->ticks != config->info.max_top_value) {
-		return -ENOTSUP;
+	if (counting) {
+		err = R_AGT_Stop(&data->agt_ctrl);
+		if (err != FSP_SUCCESS) {
+			return -EIO;
+		}
 	}
 
-	if (cfg->callback == NULL) {
-		/* Disable Match Register A if callback is NULL */
-		p_reg_ctrl->AGTCR_b.TCMAF = 0;
+	err = RP_AGT_CompareMatchSet(&data->agt_ctrl, val, TIMER_COMPARE_MATCH_A);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	if (counting) {
+		err = R_AGT_Start(&data->agt_ctrl);
+		if (err != FSP_SUCCESS) {
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+static inline k_spinlock_key_t counter_renesas_ra_agt_lock(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+
+	return k_spin_lock(&data->lock);
+}
+
+static inline void counter_renesas_ra_agt_unlock(const struct device *dev, k_spinlock_key_t key)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+
+	k_spin_unlock(&data->lock, key);
+}
+
+static int counter_renesas_ra_agt_start(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	fsp_err_t err;
+
+	err = R_AGT_Start(&data->agt_ctrl);
+	if (err != FSP_SUCCESS) {
+		LOG_DBG("Counter start failed");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int counter_renesas_ra_agt_stop(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	fsp_err_t err;
+
+	err = R_AGT_Stop(&data->agt_ctrl);
+	if (err != FSP_SUCCESS) {
+		LOG_DBG("Counter stop failed");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int counter_renesas_ra_agt_get_value(const struct device *dev, uint32_t *ticks)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	timer_status_t status;
+	fsp_err_t err;
+
+	err = R_AGT_StatusGet(&data->agt_ctrl, &status);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	*ticks = status.counter;
+
+	return 0;
+}
+
+static uint32_t counter_renesas_ra_agt_get_top_value(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+
+	return data->agt_ctrl.period;
+}
+
+static int counter_renesas_ra_agt_set_top_value(const struct device *dev,
+						const struct counter_top_cfg *cfg)
+{
+	const struct counter_renesas_ra_agt_config *config = dev->config;
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	k_spinlock_key_t key = counter_renesas_ra_agt_lock(dev);
+	bool reset = false;
+	uint32_t now = 0;
+	fsp_err_t err;
+	int ret = 0;
+
+	if (cfg->ticks > config->info.max_top_value) {
+		LOG_DBG("Top value exceed maximum value");
+		ret = -EINVAL;
+		goto out;
+	}
+
+	ret = renesas_ra_agt_period_set(dev, cfg->ticks);
+	if (ret != 0) {
+		LOG_DBG("Counter period set failed");
+		goto out;
+	}
+
+	if (cfg->callback != NULL) {
+		if (data->agt_cfg.cycle_end_irq == BSP_IRQ_DISABLED) {
+			ret = -ENOTSUP;
+			goto out;
+		}
+
+		irq_enable(data->agt_cfg.cycle_end_irq);
 	} else {
-		/* Enable Match Register A */
-		p_reg_ctrl->AGTCR_b.TCMAF = 1;
+		if (data->agt_cfg.cycle_end_ipl != BSP_IRQ_DISABLED) {
+			irq_disable(data->agt_cfg.cycle_end_irq);
+		}
 	}
 
 	data->top_cb = cfg->callback;
-	data->top_cb_data = cfg->user_data;
+	data->top_data = cfg->user_data;
 
-	return 0;
-}
+	if ((cfg->flags & COUNTER_TOP_CFG_DONT_RESET) == 0) {
+		reset = true;
+	} else if ((cfg->flags & COUNTER_TOP_CFG_RESET_WHEN_LATE) != 0) {
+		ret = counter_renesas_ra_agt_get_value(dev, &now);
+		if (ret != 0) {
+			goto out;
+		}
 
-static inline void counter_ra_agt_set_compare_value(const struct device *dev, uint8_t chan,
-						    uint32_t value)
-{
-	struct counter_ra_agt_data *data = dev->data;
-
-	data->agt_reg->AGT16.AGTCMA = value;
-}
-
-static inline void counter_ra_agt_enable_channel_irq(const struct device *dev)
-{
-	const struct counter_ra_agt_config *config = dev->config;
-	agt_reg_ctrl_t *p_reg_ctrl = r_agt_reg_ctrl_get(dev);
-
-	/* Enable AGT compare match A */
-	p_reg_ctrl->AGTCMSR |= BIT(R_AGTX0_AGT16_CTRL_AGTCMSR_TCMEA_Pos);
-	irq_enable(config->channel_irq);
-}
-
-static inline void counter_ra_agt_clear_channel_irq(const struct device *dev)
-{
-	const struct counter_ra_agt_config *config = dev->config;
-	agt_reg_ctrl_t *const reg_ctrl = r_agt_reg_ctrl_get(dev);
-
-	reg_ctrl->AGTCR_b.TCMAF = 0;
-	R_BSP_IrqStatusClear(config->channel_irq);
-	NVIC_ClearPendingIRQ(config->channel_irq);
-}
-
-static int counter_ra_agt_set_alarm(const struct device *dev, uint8_t chan,
-				    const struct counter_alarm_cfg *alarm_cfg)
-{
-	struct counter_ra_agt_data *data = dev->data;
-	const struct counter_ra_agt_config *config = dev->config;
-
-	const bool absolute = alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE;
-	const uint32_t top = counter_ra_agt_get_top_value(dev);
-	struct counter_ra_agt_alarm *const alarm = &data->alarm;
-	uint16_t val = alarm_cfg->ticks;
-	uint32_t now;
-	uint32_t max_rel_val;
-	bool irq_on_late;
-	int32_t diff = 0;
-	int err = 0;
-
-	if (alarm_cfg->ticks > counter_ra_agt_get_top_value(dev)) {
-		LOG_ERR("%s: alarm ticks is larger than top value", __func__);
-		return -EINVAL;
-	}
-
-	if (alarm->callback) {
-		LOG_ERR("%s: Device busy. Callback is still available.", __func__);
-		return -EBUSY;
-	}
-	alarm->callback = alarm_cfg->callback;
-	alarm->data = alarm_cfg->user_data;
-
-	/*
-	 * stop AGT for writing the match register directly instead of sync when underflow event
-	 * occur reference: RA6M5 User manual - 22.3.2 Reload Register and AGT Compare Match A/B
-	 * Register Rewrite Operation
-	 */
-	counter_ra_agt_stop(dev);
-	now = counter_ra_agt_read(dev);
-
-	if (absolute) {
-		/* Acceptable alarm value range, counting from current tick (now) */
-		max_rel_val = top - data->guard_period;
-		irq_on_late = alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE;
+		reset = cfg->ticks < now;
 	} else {
-		/* If relative value is smaller than half of the counter range
-		 * it is assumed that there is a risk of setting value too late
-		 * and late detection algorithm must be applied. When late
-		 * setting is detected, interrupt shall be triggered for
-		 * immediate expiration of the timer. Detection is performed
-		 * by limiting relative distance between CC and counter.
-		 *
-		 * Note that half of counter range is an arbitrary value.
-		 */
-		irq_on_late = (val < (top / 2U));
-		/* Limit max to detect short relative being set too late */
-		max_rel_val = irq_on_late ? top / 2U : top;
-		/* Recalculate alarm tick timestamp based on current tick (now) */
-		val = r_agt_ticks_sub(now, val, top);
+		;
 	}
 
-	counter_ra_agt_set_compare_value(dev, chan, val);
-
-	/* Decrement value to detect also case when val == counter_ra_agt_read(dev).
-	 * Otherwise, condition would need to include comparing diff against 0.
-	 */
-	diff = r_agt_ticks_sub(now, val - 1, top);
-
-	if (diff > max_rel_val) {
-		if (absolute) {
-			err = -ETIME;
-		}
-
-		/* Interrupt is triggered always for relative alarm and
-		 * for absolute depending on the flag.
-		 */
-		if (irq_on_late) {
-			/* Set pending IRQ */
-			counter_ra_agt_enable_channel_irq(dev);
-			NVIC_SetPendingIRQ(config->channel_irq);
-		} else {
-			alarm->callback = NULL;
-			alarm->data = NULL;
+	if (reset) {
+		err = R_AGT_Reset(&data->agt_ctrl);
+		if (err != FSP_SUCCESS) {
+			LOG_DBG("Counter reset failed");
+			ret = -EIO;
+			goto out;
 		}
 	}
-
-	counter_ra_agt_clear_channel_irq(dev);
-	counter_ra_agt_enable_channel_irq(dev);
-	counter_ra_agt_start(dev);
-
-	return err;
+out:
+	counter_renesas_ra_agt_unlock(dev, key);
+	return ret;
 }
 
-static int counter_ra_agt_cancel_alarm(const struct device *dev, uint8_t chan)
-{
-	struct counter_ra_agt_data *data = dev->data;
-
-	agt_reg_ctrl_t *p_reg_ctrl = r_agt_reg_ctrl_get(dev);
-
-	/* Disable AGT compare match A */
-	p_reg_ctrl->AGTCMSR &= ~BIT(R_AGTX0_AGT16_CTRL_AGTCMSR_TCMEA_Pos);
-
-	data->alarm.callback = NULL;
-	data->alarm.data = NULL;
-
-	return 0;
-}
-
-static uint32_t counter_ra_agt_get_pending_int(const struct device *dev)
-{
-	agt_reg_ctrl_t *const reg = r_agt_reg_ctrl_get(dev);
-
-	return (reg->AGTCR & AGT_AGTCR_FLAGS_MASK) != 0;
-}
-
-static uint32_t counter_ra_agt_get_freq(const struct device *dev)
-{
-	struct counter_ra_agt_data *data = dev->data;
-	timer_info_t info;
-
-	agt_reg_ctrl_t *p_reg = r_agt_reg_ctrl_get(dev);
-
-	r_agt_common_preamble(p_reg);
-
-	/* Get and store period */
-	info.period_counts = data->period;
-	info.clock_frequency = r_agt_clock_frequency_get(p_reg);
-
-	/* AGT supports only counting down direction */
-	info.count_direction = TIMER_DIRECTION_DOWN;
-
-	return info.clock_frequency;
-}
-
-static void counter_ra_agt_agti_isr(const struct device *dev)
-{
-	const struct counter_ra_agt_config *config = dev->config;
-	struct counter_ra_agt_data *data = dev->data;
-	agt_reg_ctrl_t *const reg_ctrl = r_agt_reg_ctrl_get(dev);
-
-	R_BSP_IrqStatusClear(config->cycle_end_irq);
-
-	const uint32_t agtcr = reg_ctrl->AGTCR;
-
-	if (agtcr & BIT(R_AGTX0_AGT16_CTRL_AGTCR_TUNDF_Pos)) {
-		if (data->top_cb) {
-			data->top_cb(dev, data->top_cb_data);
-		}
-	}
-
-	reg_ctrl->AGTCR = (uint8_t)(agtcr & ~(BIT(R_AGTX0_AGT16_CTRL_AGTCR_TUNDF_Pos) |
-					      BIT(R_AGTX0_AGT16_CTRL_AGTCR_TEDGF_Pos)));
-}
-
-static void counter_ra_agt_agtcmai_isr(const struct device *dev)
-{
-	const struct counter_ra_agt_config *config = dev->config;
-	struct counter_ra_agt_data *data = dev->data;
-	agt_reg_ctrl_t *const reg_ctrl = r_agt_reg_ctrl_get(dev);
-	struct counter_ra_agt_alarm *const alarm = &data->alarm;
-
-	const uint32_t val = data->agt_reg->AGT16.AGTCMA;
-
-	const counter_alarm_callback_t cb = alarm->callback;
-	void *cb_data = alarm->data;
-
-	alarm->callback = NULL;
-	alarm->data = NULL;
-
-	/* Disable AGT compare match A */
-	reg_ctrl->AGTCMSR &= ~BIT(R_AGTX0_AGT16_CTRL_AGTCMSR_TCMEA_Pos);
-
-	R_BSP_IrqStatusClear(config->channel_irq);
-
-	if (cb) {
-		cb(dev, config->channel, val, cb_data);
-	}
-
-	reg_ctrl->AGTCR_b.TCMAF = 0;
-}
-
-static uint32_t counter_ra_agt_get_guard_period(const struct device *dev, uint32_t flags)
-{
-	struct counter_ra_agt_data *data = dev->data;
-
-	return data->guard_period;
-}
-
-static int counter_ra_agt_set_guard_period(const struct device *dev, uint32_t guard, uint32_t flags)
-{
-	struct counter_ra_agt_data *data = dev->data;
-
-	if (counter_ra_agt_get_top_value(dev) < guard) {
-		LOG_ERR("%s: Invalid guard rate", __func__);
-		return -EINVAL;
-	}
-
-	data->guard_period = guard;
-
-	return 0;
-}
-
-static int counter_ra_agt_init(const struct device *dev)
-{
-	const struct counter_ra_agt_config *config = dev->config;
-	struct counter_ra_agt_data *data = dev->data;
-
-	data->agt_reg = (R_AGTX0_Type *)config->dt_reg;
-
-	agt_reg_ctrl_t *p_reg_ctrl = r_agt_reg_ctrl_get(dev);
-
-	/* Power on the AGT channel */
-	R_BSP_MODULE_START(FSP_IP_AGT, config->channel);
-
-	/* Clear AGTCR. This stops the timer if it is running and clears the flags */
-	p_reg_ctrl->AGTCR = 0U;
-
-	/* The timer is stopped in sync with the count clock, or in sync with PCLK in event and
-	 * external count modes.
-	 */
-	FSP_HARDWARE_REGISTER_WAIT(0U, p_reg_ctrl->AGTCR_b.TCSTF);
-
-	/* Clear AGTMR2 before AGTMR1 is set. Reference Note 3 in section 25.2.6 "AGT Mode Register
-	 * 2 (AGTMR2)" of the RA6M3 manual R01UH0886EJ0100.
-	 */
-	p_reg_ctrl->AGTMR2 = 0U;
-
-	/* Set count source and divider and configure pins */
-	r_agt_hardware_cfg(dev);
-
-	/* Set period register and update duty cycle if output mode is used for one-shot or periodic
-	 * mode.
-	 */
-	r_agt_period_register_set(dev, data->period_counts);
-
-	/* 22.3.1 Reload Register and Counter Rewrite Operation */
-	p_reg_ctrl->AGTCMSR |= BIT(R_AGTX0_AGT16_CTRL_AGTCMSR_TCMEA_Pos);
-
-	return 0;
-}
-
-static agt_reg_ctrl_t *r_agt_reg_ctrl_get(const struct device *dev)
-{
-	struct counter_ra_agt_data *data = dev->data;
-	agt_reg_ctrl_t *p_reg_ctrl = &data->agt_reg->AGT16.CTRL;
-
-	return p_reg_ctrl;
-}
-
-static void r_agt_hardware_cfg(const struct device *dev)
-{
-	const struct counter_ra_agt_config *config = dev->config;
-
-	/* Update the divider for PCLKB */
-	agt_reg_ctrl_t *p_reg_ctrl = r_agt_reg_ctrl_get(dev);
-	uint32_t count_source_int = (uint32_t)config->count_source;
-	uint32_t agtmr2 = 0U;
-	uint32_t agtcmsr = 0U;
-	uint32_t tedgsel = 0U;
-	uint32_t agtioc = config->agtio_filter;
-	uint32_t mode = config->measurement_mode & R_AGTX0_AGT16_CTRL_AGTMR1_TMOD_Msk;
-	uint32_t edge = 0U;
-
-	if (AGT_CLOCK_PCLKB == config->count_source) {
-		if (TIMER_SOURCE_DIV_1 != config->source_div) {
-			/* Toggle the second bit if the count_source_int is not 0 to map PCLKB / 8
-			 * to 1 and PCLKB / 2 to 3.
-			 */
-			count_source_int = config->source_div ^ 2U;
-			count_source_int <<= R_AGTX0_AGT16_CTRL_AGTMR1_TCK_Pos;
-		}
-	}
-
-	else if (AGT_CLOCK_AGT_UNDERFLOW != config->count_source) {
-		/* Update the divider for LOCO/subclock */
-		agtmr2 = config->source_div;
-	} else {
-		/* No divider can be used when count source is AGT_CLOCK_AGT_UNDERFLOW */
-	}
-
-	uint32_t agtmr1 = (count_source_int | edge) | mode;
-
-	/* Configure output settings */
-
-	agtioc |= tedgsel;
-
-	p_reg_ctrl->AGTIOC = (uint8_t)agtioc;
-	p_reg_ctrl->AGTCMSR = (uint8_t)agtcmsr;
-	p_reg_ctrl->AGTMR1 = (uint8_t)agtmr1;
-	p_reg_ctrl->AGTMR2 = (uint8_t)agtmr2;
-}
-
-static void r_agt_period_register_set(const struct device *dev, uint32_t period_counts)
-{
-	struct counter_ra_agt_data *data = dev->data;
-
-	/* Store the period value so it can be retrieved later */
-	data->period = period_counts;
-
-	/* Set counter to period minus one */
-	uint32_t period_reg = (period_counts - 1U);
-
-	data->agt_reg->AGT16.AGT = (uint16_t)period_reg;
-}
-
-static uint32_t r_agt_clock_frequency_get(agt_reg_ctrl_t *p_reg)
-{
-	uint32_t clock_freq_hz = 0U;
-	uint8_t count_source_int = p_reg->AGTMR1_b.TCK;
-	timer_source_div_t divider = TIMER_SOURCE_DIV_1;
-
-	if (0U == (count_source_int & (~AGT_SOURCE_CLOCK_PCLKB_BITS))) {
-		/* Call CGC function to obtain current PCLKB clock frequency */
-		clock_freq_hz = R_FSP_SystemClockHzGet(FSP_PRIV_CLOCK_PCLKB);
-
-		/* If Clock source is PCLKB or derived from PCLKB */
-		divider = (timer_source_div_t)count_source_int;
-
-		if (divider != 0U) {
-			/* Set divider to 3 to divide by 8 when AGTMR1.TCK is 1 (PCLKB / 8). Set
-			 * divider to 1 to divide by 2 when AGTMR1.TCK is 3 (PCLKB / 2). XOR with 2
-			 * to convert 1 to 3 and 3 to 1.
-			 */
-			divider ^= 2U;
-		}
-	} else {
-		/* Else either fSUB clock or LOCO clock is used. The frequency is set to 32Khz
-		 * (32768). This function does not support AGT0 underflow as count source.
-		 */
-		clock_freq_hz = FSUB_FREQUENCY_HZ;
-		divider = (timer_source_div_t)p_reg->AGTMR2_b.CKS;
-	}
-
-	clock_freq_hz >>= divider;
-
-	return clock_freq_hz;
-}
-
-static fsp_err_t r_agt_common_preamble(agt_reg_ctrl_t *p_reg)
-{
-	/* Ensure timer state reflects expected status. Reference section 25.4.1 "Count Operation
-	 * Start and Stop Control" in the RA6M3 manual R01UH0886EJ0100.
-	 */
-	uint32_t agtcr_tstart = p_reg->AGTCR_b.TSTART;
-
-	FSP_HARDWARE_REGISTER_WAIT(agtcr_tstart, p_reg->AGTCR_b.TCSTF);
-
-	return FSP_SUCCESS;
-}
-
-static uint32_t r_agt_ticks_sub(uint32_t val, uint32_t old, uint32_t top)
+static inline uint32_t ticks_sub(uint32_t val, uint32_t old, uint32_t top)
 {
 	if (likely(IS_BIT_MASK(top))) {
 		return (val - old) & top;
@@ -519,18 +243,285 @@ static uint32_t r_agt_ticks_sub(uint32_t val, uint32_t old, uint32_t top)
 	return (val >= old) ? (val - old) : val + top + 1 - old;
 }
 
-static DEVICE_API(counter, ra_agt_driver_api) = {
-	.start = counter_ra_agt_start,
-	.stop = counter_ra_agt_stop,
-	.get_value = counter_ra_agt_get_value,
-	.set_alarm = counter_ra_agt_set_alarm,
-	.cancel_alarm = counter_ra_agt_cancel_alarm,
-	.set_top_value = counter_ra_agt_set_top_value,
-	.get_pending_int = counter_ra_agt_get_pending_int,
-	.get_top_value = counter_ra_agt_get_top_value,
-	.get_freq = counter_ra_agt_get_freq,
-	.get_guard_period = counter_ra_agt_get_guard_period,
-	.set_guard_period = counter_ra_agt_set_guard_period,
+static int renesas_ra_agt_abs_alarm_set(const struct device *dev, uint32_t val, uint32_t top,
+					bool irq_on_late)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	uint32_t max_val;
+	uint32_t read_again;
+	fsp_err_t err;
+	int ret;
+
+	ret = renesas_ra_agt_compare_match_set(dev, val);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = counter_renesas_ra_agt_get_value(dev, &read_again);
+	if (ret != 0) {
+		return ret;
+	}
+
+	max_val = ticks_sub(read_again + top, data->guard_period, top);
+	if (val > max_val) {
+		if (irq_on_late) {
+			NVIC_SetPendingIRQ(data->agtcmai_irq);
+		} else {
+			data->alarm_cb = NULL;
+		}
+
+		ret = -ETIME;
+	}
+
+	err = RP_AGT_EventSet(&data->agt_ctrl, TIMER_AGT_AGTCMAI, true);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	irq_enable(data->agtcmai_irq);
+
+	return ret;
+}
+
+static int renesas_ra_agt_rel_alarm_set(const struct device *dev, uint32_t val, uint32_t top,
+					bool irq_on_late)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	uint32_t max_rel_val = irq_on_late ? (top / 2) : top;
+	uint32_t diff;
+	uint32_t now;
+	fsp_err_t err;
+	int ret;
+
+	ret = counter_renesas_ra_agt_get_value(dev, &now);
+	if (ret != 0) {
+		return ret;
+	}
+
+	val = ticks_sub(now, val, top);
+
+	ret = renesas_ra_agt_compare_match_set(dev, val);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = counter_renesas_ra_agt_get_value(dev, &now);
+	if (ret != 0) {
+		return ret;
+	}
+
+	diff = ticks_sub(now, val, top);
+
+	if (diff > max_rel_val || diff == 0) {
+		if (irq_on_late) {
+			NVIC_SetPendingIRQ(data->agtcmai_irq);
+		} else {
+			data->alarm_cb = NULL;
+		}
+	}
+
+	err = RP_AGT_EventSet(&data->agt_ctrl, TIMER_AGT_AGTCMAI, true);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	irq_enable(data->agtcmai_irq);
+
+	return 0;
+}
+
+static int counter_renesas_ra_agt_set_alarm(const struct device *dev, uint8_t chan,
+					    const struct counter_alarm_cfg *alarm_cfg)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	const uint32_t top = counter_renesas_ra_agt_get_top_value(dev);
+	const bool absolute = (alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) != 0;
+	const bool irq_on_late =
+		absolute ? (alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE) != 0
+			 : alarm_cfg->ticks < (top / 2);
+	int ret = 0;
+
+	if (chan != 0) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (alarm_cfg->ticks > top) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (data->alarm_cb != NULL) {
+		ret = -EBUSY;
+		goto out;
+	}
+
+	if (data->agtcmai_irq == BSP_IRQ_DISABLED) {
+		return -ENOTSUP;
+	}
+
+	data->alarm_cb = alarm_cfg->callback;
+	data->alarm_data = alarm_cfg->user_data;
+
+	if (absolute) {
+		ret = renesas_ra_agt_abs_alarm_set(dev, alarm_cfg->ticks, top, irq_on_late);
+	} else {
+		ret = renesas_ra_agt_rel_alarm_set(dev, alarm_cfg->ticks, top, irq_on_late);
+	}
+out:
+	return ret;
+}
+
+static int counter_renesas_ra_agt_cancel_alarm(const struct device *dev, uint8_t chan)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	k_spinlock_key_t key = counter_renesas_ra_agt_lock(dev);
+	fsp_err_t err;
+	int ret = 0;
+
+	if (data->agtcmai_irq == BSP_IRQ_DISABLED) {
+		return -ENOTSUP;
+	}
+
+	err = RP_AGT_EventSet(&data->agt_ctrl, TIMER_AGT_AGTCMAI, false);
+	if (err != FSP_SUCCESS) {
+		ret = -EIO;
+		goto out;
+	}
+
+	irq_disable(data->agtcmai_irq);
+	NVIC_ClearPendingIRQ(data->agtcmai_irq);
+	data->alarm_cb = NULL;
+	data->alarm_data = NULL;
+out:
+	counter_renesas_ra_agt_unlock(dev, key);
+	return 0;
+}
+
+static uint32_t counter_renesas_ra_agt_get_guard_period(const struct device *dev, uint32_t flags)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+
+	return data->guard_period;
+}
+
+static int counter_renesas_ra_agt_set_guard_period(const struct device *dev, uint32_t guard,
+						   uint32_t flags)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	k_spinlock_key_t key = counter_renesas_ra_agt_lock(dev);
+	int ret = 0;
+
+	if (counter_renesas_ra_agt_get_top_value(dev) < guard) {
+		LOG_DBG("Invalid guard rate");
+		ret = -EINVAL;
+		goto out;
+	}
+
+	data->guard_period = guard;
+out:
+	counter_renesas_ra_agt_unlock(dev, key);
+	return 0;
+}
+
+static uint32_t counter_renesas_ra_agt_get_pending_int(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	uint8_t event = 0;
+	fsp_err_t err;
+
+	err = RP_AGT_EventGet(&data->agt_ctrl, &event);
+	if (err != FSP_SUCCESS) {
+		LOG_DBG("Counter get status failed");
+		return 0;
+	}
+
+	return (uint32_t)!!(
+		event & (R_AGTX0_AGT16_CTRL_AGTCR_TCMAF_Msk | R_AGTX0_AGT16_CTRL_AGTCR_TUNDF_Msk));
+}
+
+static uint32_t counter_renesas_ra_agt_get_freq(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	timer_info_t info;
+	fsp_err_t err;
+
+	err = R_AGT_InfoGet(&data->agt_ctrl, &info);
+	if (err != FSP_SUCCESS) {
+		LOG_DBG("Counter get freq failed");
+		return -EIO;
+	}
+
+	return info.clock_frequency;
+}
+
+static int counter_renesas_ra_agt_init(const struct device *dev)
+{
+	const struct counter_renesas_ra_agt_config *cfg = dev->config;
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	fsp_err_t err;
+
+	err = R_AGT_Open(&data->agt_ctrl, &data->agt_cfg);
+	if (err != FSP_SUCCESS) {
+		return -EIO;
+	}
+
+	if (data->agtcmai_irq != BSP_IRQ_DISABLED) {
+		R_FSP_IsrContextSet(data->agtcmai_irq, &data->agt_ctrl);
+	}
+
+	cfg->irq_config_func();
+
+	return 0;
+}
+
+static void counter_renesas_ra_agt_agti_isr(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	counter_top_callback_t cb = data->top_cb;
+	void *usr_data = data->top_data;
+
+	if (cb != NULL) {
+		cb(dev, usr_data);
+	}
+
+	agt_int_isr();
+}
+
+static void counter_renesas_ra_agt_agtcmai_isr(const struct device *dev)
+{
+	struct counter_renesas_ra_agt_data *data = dev->data;
+	counter_alarm_callback_t cb = data->alarm_cb;
+	void *usr_data = data->alarm_data;
+	uint32_t now;
+
+	if (cb != NULL) {
+		data->alarm_cb = NULL;
+		data->alarm_data = NULL;
+
+		if (counter_renesas_ra_agt_get_value(dev, &now) != 0) {
+			LOG_DBG("Error in counter alarm");
+			return;
+		}
+
+		cb(dev, 0, now, usr_data);
+	}
+
+	agtcmai_isr();
+}
+
+static DEVICE_API(counter, agt_renesas_ra_driver_api) = {
+	.start = counter_renesas_ra_agt_start,
+	.stop = counter_renesas_ra_agt_stop,
+	.get_value = counter_renesas_ra_agt_get_value,
+	.set_alarm = counter_renesas_ra_agt_set_alarm,
+	.cancel_alarm = counter_renesas_ra_agt_cancel_alarm,
+	.set_top_value = counter_renesas_ra_agt_set_top_value,
+	.get_pending_int = counter_renesas_ra_agt_get_pending_int,
+	.get_top_value = counter_renesas_ra_agt_get_top_value,
+	.get_freq = counter_renesas_ra_agt_get_freq,
+	.get_guard_period = counter_renesas_ra_agt_get_guard_period,
+	.set_guard_period = counter_renesas_ra_agt_set_guard_period,
 };
 
 #define TIMER(idx) DT_INST_PARENT(idx)
@@ -538,53 +529,71 @@ static DEVICE_API(counter, ra_agt_driver_api) = {
 #define EVENT_AGT_INT(channel)       BSP_PRV_IELS_ENUM(CONCAT(EVENT_AGT, channel, _INT))
 #define EVENT_AGT_COMPARE_A(channel) BSP_PRV_IELS_ENUM(CONCAT(EVENT_AGT, channel, _COMPARE_A))
 
-#define AGT_DEVICE_INIT_RA(n)                                                                      \
-	static const struct counter_ra_agt_config ra_agt_config_##n = {                            \
-		.info =                                                                            \
-			{                                                                          \
-				.max_top_value = UINT16_MAX,                                       \
-				.freq = 0,                                                         \
-				.channels = 1,                                                     \
-				.flags = 0,                                                        \
-			},                                                                         \
-		.agtio_filter = AGT_AGTIO_FILTER_NONE,                                             \
-		.measurement_mode = 0U,                                                            \
-		.source_div = DT_PROP(TIMER(n), renesas_prescaler),                                \
-		.count_source = DT_STRING_TOKEN(TIMER(n), renesas_count_source),                   \
-		.channel = DT_PROP(TIMER(n), channel),                                             \
-		.channel_irq = DT_IRQ_BY_NAME(TIMER(n), agtcmai, irq),                             \
-		.channel_ipl = DT_IRQ_BY_NAME(TIMER(n), agtcmai, priority),                        \
-		.cycle_end_irq = DT_IRQ_BY_NAME(TIMER(n), agti, irq),                              \
-		.cycle_end_ipl = DT_IRQ_BY_NAME(TIMER(n), agti, priority),                         \
-		.resolution = DT_PROP(TIMER(n), renesas_resolution),                               \
-		.dt_reg = DT_REG_ADDR(TIMER(n)),                                                   \
-	};                                                                                         \
-                                                                                                   \
-	static struct counter_ra_agt_data counter_ra_agt_data_##n = {                              \
-		.period_counts = 0,                                                                \
-	};                                                                                         \
-                                                                                                   \
-	static int counter_ra_agt_##n##_init(const struct device *dev)                             \
+#define AGT_IRQ_GET_BY_NAME(inst, name, cell)                                                      \
+	COND_CODE_1(DT_IRQ_HAS_NAME(TIMER(inst), name), (DT_IRQ_BY_NAME(TIMER(inst), name, cell)), \
+		    ((IRQn_Type) BSP_IRQ_DISABLED))
+
+#define AGT_IRQ_CONFIG(inst, name, event, isr)                                                     \
+	IF_ENABLED(DT_IRQ_HAS_NAME(TIMER(inst), name),                                             \
+		   (R_ICU->IELSR[DT_IRQ_BY_NAME(TIMER(inst), name, irq)] = event;                  \
+		    IRQ_CONNECT(DT_IRQ_BY_NAME(TIMER(inst), name, irq),                            \
+				DT_IRQ_BY_NAME(TIMER(inst), name, priority),                       \
+				isr, DEVICE_DT_INST_GET(inst), 0);                                 \
+				irq_disable(DT_IRQ_BY_NAME(TIMER(inst), name, irq));))
+
+#define COUNTER_AGT_DEVICE_INIT(inst)                                                              \
+	static void counter_renesas_ra_agt##inst##_irq_config_func(void)                           \
 	{                                                                                          \
-		R_ICU->IELSR[DT_IRQ_BY_NAME(TIMER(n), agti, irq)] =                                \
-			EVENT_AGT_INT(DT_PROP(TIMER(n), channel));                                 \
-		IRQ_CONNECT(DT_IRQ_BY_NAME(TIMER(n), agti, irq),                                   \
-			    DT_IRQ_BY_NAME(TIMER(n), agti, priority), counter_ra_agt_agti_isr,     \
-			    DEVICE_DT_INST_GET(n), 0);                                             \
-		irq_enable(DT_IRQ_BY_NAME(TIMER(n), agti, irq));                                   \
-                                                                                                   \
-		R_ICU->IELSR[DT_IRQ_BY_NAME(TIMER(n), agtcmai, irq)] =                             \
-			EVENT_AGT_COMPARE_A(DT_PROP(TIMER(n), channel));                           \
-		IRQ_CONNECT(DT_IRQ_BY_NAME(TIMER(n), agtcmai, irq),                                \
-			    DT_IRQ_BY_NAME(TIMER(n), agtcmai, priority),                           \
-			    counter_ra_agt_agtcmai_isr, DEVICE_DT_INST_GET(n), 0);                 \
-		irq_disable(DT_IRQ_BY_NAME(TIMER(n), agtcmai, irq));                               \
-                                                                                                   \
-		return counter_ra_agt_init(dev);                                                   \
+		AGT_IRQ_CONFIG(inst, agti, EVENT_AGT_INT(DT_PROP(TIMER(inst), channel)),           \
+			       counter_renesas_ra_agt_agti_isr);                                   \
+		AGT_IRQ_CONFIG(inst, agtcmai, EVENT_AGT_COMPARE_A(DT_PROP(TIMER(inst), channel)),  \
+			       counter_renesas_ra_agt_agtcmai_isr);                                \
 	}                                                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, counter_ra_agt_##n##_init, NULL, &counter_ra_agt_data_##n,        \
-			      &ra_agt_config_##n, POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY,       \
-			      &ra_agt_driver_api);
+	struct counter_renesas_ra_agt_config counter_renesas_ra_agt_config##inst = {               \
+		.info.max_top_value =                                                              \
+			DT_PROP(TIMER(inst), renesas_resolution) >= 32                             \
+				? UINT32_MAX                                                       \
+				: BIT_MASK(DT_PROP(TIMER(inst), renesas_resolution)),              \
+		.info.flags = (uint8_t)0U,                                                         \
+		.info.channels = 1,                                                                \
+		.irq_config_func = counter_renesas_ra_agt##inst##_irq_config_func,                 \
+	};                                                                                         \
+                                                                                                   \
+	static struct counter_renesas_ra_agt_data counter_renesas_ra_agt_data##inst = {            \
+		.agt_cfg =                                                                         \
+			{                                                                          \
+				.mode = TIMER_MODE_PERIODIC,                                       \
+				.period_counts = DT_PROP(TIMER(inst), renesas_resolution) >= 32    \
+							 ? UINT32_MAX                              \
+							 : BIT_MASK(DT_PROP(TIMER(inst),           \
+									    renesas_resolution)),  \
+				.source_div = DT_PROP(TIMER(inst), renesas_prescaler),             \
+				.channel = DT_PROP(TIMER(inst), channel),                          \
+				.cycle_end_irq = AGT_IRQ_GET_BY_NAME(inst, agti, irq),             \
+				.cycle_end_ipl = AGT_IRQ_GET_BY_NAME(inst, agti, priority),        \
+				.p_extend = &counter_renesas_ra_agt_data##inst.agt_extend_cfg,     \
+			},                                                                         \
+		.agt_extend_cfg =                                                                  \
+			{                                                                          \
+				.count_source = DT_STRING_TOKEN_OR(                                \
+					TIMER(inst), renesas_count_source, AGT_CLOCK_LOCO),        \
+				.agtoab_settings_b.agtoa = AGT_PIN_CFG_DISABLED,                   \
+				.agtoab_settings_b.agtob = AGT_PIN_CFG_DISABLED,                   \
+				.agto = AGT_PIN_CFG_DISABLED,                                      \
+				.measurement_mode = AGT_MEASURE_DISABLED,                          \
+				.agtio_filter = AGT_AGTIO_FILTER_NONE,                             \
+				.enable_pin = AGT_ENABLE_PIN_NOT_USED,                             \
+				.trigger_edge = AGT_TRIGGER_EDGE_RISING,                           \
+			},                                                                         \
+		.agtcmai_irq = AGT_IRQ_GET_BY_NAME(inst, agtcmai, irq),                            \
+		.agtcmai_ipl = AGT_IRQ_GET_BY_NAME(inst, agtcmai, priority),                       \
+		.guard_period = 0,                                                                 \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, counter_renesas_ra_agt_init, NULL,                             \
+			      &counter_renesas_ra_agt_data##inst,                                  \
+			      &counter_renesas_ra_agt_config##inst, POST_KERNEL,                   \
+			      CONFIG_COUNTER_INIT_PRIORITY, &agt_renesas_ra_driver_api);
 
-DT_INST_FOREACH_STATUS_OKAY(AGT_DEVICE_INIT_RA)
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_AGT_DEVICE_INIT)

--- a/dts/arm/renesas/ra/ra2/ra2l1.dtsi
+++ b/dts/arm/renesas/ra/ra2/ra2l1.dtsi
@@ -233,6 +233,36 @@
 			clocks = <&pclkb 0 0>;
 			status = "disabled";
 		};
+
+		agt0: agt@40084000 {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x40084000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agt@40084100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x40084100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <16>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -97,6 +97,36 @@
 			compatible = "renesas,ra-trng";
 			status = "disabled";
 		};
+
+		agt0: agtw@400e8000 {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x400e8000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <32>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agtw@400e8100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x400e8100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <32>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4l1bx.dtsi
@@ -517,6 +517,36 @@
 			clocks = <&pclkb 0 0>;
 			status = "disabled";
 		};
+
+		agt0: agtw@400e8000 {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x400e8000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <32>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agtw@400e8100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x400e8100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <32>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
 	};
 
 	clocks: clocks {

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bx.dtsi
@@ -93,6 +93,36 @@
 			compatible = "renesas,ra-trng";
 			status = "disabled";
 		};
+
+		agt0: agtw@400e8000 {
+			compatible = "renesas,ra-agt";
+			channel = <0>;
+			reg = <0x400e8000 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <32>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
+
+		agt1: agtw@400e8100 {
+			compatible = "renesas,ra-agt";
+			channel = <1>;
+			reg = <0x400e8100 0x100>;
+			renesas,count-source = "AGT_CLOCK_LOCO";
+			renesas,prescaler = <0>;
+			renesas,resolution = <32>;
+			status = "disabled";
+
+			counter {
+				compatible = "renesas,ra-agt-counter";
+				status = "disabled";
+			};
+		};
 	};
 
 	clocks: clocks {

--- a/dts/bindings/misc/renesas,ra-agt.yaml
+++ b/dts/bindings/misc/renesas,ra-agt.yaml
@@ -22,6 +22,7 @@ properties:
     enum:
       - "AGT_CLOCK_PCLKB"
       - "AGT_CLOCK_LOCO"
+      - "AGT_CLOCK_SUBCLOCK"
 
   renesas,prescaler:
     description: |
@@ -42,6 +43,7 @@ properties:
 
   renesas,resolution:
     type: int
+    enum: [16, 32]
     required: true
 
   interrupts:

--- a/samples/drivers/counter/alarm/boards/ek_ra2l1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra2l1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <27 1>, <24 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <4>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra4e2.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra4e2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <4>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra4l1.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra4l1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <62 1>, <63 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <4>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/ek_ra6e2.overlay
+++ b/samples/drivers/counter/alarm/boards/ek_ra6e2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <4>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/fpb_ra6e2.overlay
+++ b/samples/drivers/counter/alarm/boards/fpb_ra6e2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <4>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -16,32 +16,8 @@ common:
   depends_on: counter
 tests:
   sample.drivers.counter.alarm:
-    platform_allow:
-      - nucleo_f746zg
-      - nrf51dk/nrf51822
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-      - nrf9160dk/nrf9160
-      - samd20_xpro
-      - bl5340_dvk/nrf5340/cpuapp
-      - gd32e103v_eval
-      - gd32e507z_eval
-      - gd32f403z_eval
-      - gd32f450i_eval
-      - gd32f450z_eval
-      - gd32e507v_start
-      - gd32f407v_start
-      - gd32f450v_start
-      - gd32f470i_eval
-      - stm32h735g_disco
-      - stm32h573i_dk
-      - rpi_pico
-      - mr_canhubk3
-      - s32z2xxdc2/s32z270/rtu0
-      - s32z2xxdc2/s32z270/rtu1
-      - s32z2xxdc2@D/s32z270/rtu0
-      - s32z2xxdc2@D/s32z270/rtu1
-      - lp_em_cc2340r5
+    platform_exclude:
+      - mps2/an385
     integration_platforms:
       - nucleo_f746zg
   sample.drivers.counter.alarm.stm32_rtc:

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra2a1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra2a1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <30 1>, <31 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra2l1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra2l1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <27 1>, <24 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra4e2.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra4e2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra4l1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra4l1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <62 1>, <63 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra4m1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra4m1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <30 1>, <31 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra4m2.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra4m2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra4m3.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra4m3.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra4w1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra4w1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <30 1>, <31 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra6e2.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra6e2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra6m1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra6m1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra6m2.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra6m2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra6m3.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra6m3.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra6m4.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra6m4.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra6m5.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra6m5.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra8d1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra8d1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/ek_ra8m1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/ek_ra8m1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/fpb_ra4e1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/fpb_ra4e1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/fpb_ra6e1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/fpb_ra6e1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/fpb_ra6e2.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/mck_ra8t1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mck_ra8t1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/voice_ra4e1.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/voice_ra4e1.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&agt0 {
+	interrupts = <94 1>, <95 1>;
+	interrupt-names = "agti", "agtcmai";
+	renesas,count-source = "AGT_CLOCK_LOCO";
+	renesas,prescaler = <0>;
+	status = "okay";
+
+	counter0: counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -135,6 +135,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_NEORV32_GPTMR
 	DEVS_FOR_DT_COMPAT(neorv32_gptmr)
 #endif
+#ifdef CONFIG_COUNTER_RA_AGT
+	DEVS_FOR_DT_COMPAT(renesas_ra_agt_counter)
+#endif
 };
 
 static const struct device *const period_devs[] = {

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -814,7 +814,7 @@ static void test_late_alarm_instance(const struct device *dev)
 
 	k_busy_wait(2*tick_us);
 
-	alarm_cfg.ticks = 0;
+	alarm_cfg.ticks = counter_is_counting_up(dev) ? 0 : counter_get_top_value(dev);
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 	zassert_equal(-ETIME, err, "%s: Unexpected error (%d)", dev->name, err);
 
@@ -865,7 +865,7 @@ static void test_late_alarm_error_instance(const struct device *dev)
 
 	k_busy_wait(2*tick_us);
 
-	alarm_cfg.ticks = 0;
+	alarm_cfg.ticks = counter_get_top_value(dev);
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 	zassert_equal(-ETIME, err,
 			"%s: Failed to detect late setting (err: %d)",


### PR DESCRIPTION
- Migrate the AGT counter implementation to use FSP r_agt APIs
- Add support for AGT 32bit
- Add ztests/samples support for Renesas RA boards