### PR TITLE
drivers: display: sdl: Ensure draw is performed from init thread

### DIFF
--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -80,4 +80,10 @@ config SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_2
 	help
 	  The color of the even cells in the transparency grid.
 
+config SDL_DISPLAY_THREAD_PRIORITY
+	int "SDL display thread priority"
+	default NUM_PREEMPT_PRIORITIES
+	help
+	  Drawing thread priority.
+
 endif # SDL_DISPLAY


### PR DESCRIPTION
Add a thread to the SDL display driver to ensure that init and renderer calls are performed from the same thread.

Fixes #71410.

Ping @Finomnis @PetervdPerk-NXP 