### PR TITLE
samples: sysbuild: with_mcuboot: fix typo in CMakeLists.txt comment

### DIFF
--- a/samples/sysbuild/with_mcuboot/CMakeLists.txt
+++ b/samples/sysbuild/with_mcuboot/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sample_with_mcuboot)
 
-# Verify that this samnple is built through sysbuild to ensure MCUboot is
+# Verify that this sample is built through sysbuild to ensure MCUboot is
 # automatically included and that sample specific MCUboot configurations are
 # used when building MCUboot.
 test_sysbuild()


### PR DESCRIPTION
samples: sysbuild: with_mcuboot: fix typo in CMakeLists.txt comment
Signed-off-by: Shan Pen <bricle031@gmail.com>