### PR TITLE
Bluetooth: Classic: Check LK before clearing it

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1013,7 +1013,7 @@ static void hci_disconn_complete(struct net_buf *buf)
 		 * If only for one connection session bond was set, clear keys
 		 * database row for this connection.
 		 */
-		if (conn->type == BT_CONN_TYPE_BR &&
+		if (conn->type == BT_CONN_TYPE_BR && conn->br.link_key != NULL &&
 		    atomic_test_and_clear_bit(conn->flags, BT_CONN_BR_NOBOND)) {
 			bt_keys_link_key_clear(conn->br.link_key);
 		}


### PR DESCRIPTION
After SSP has been completed and before LK event notification, the link key may be invalid when handling the ACL disconnection event.

Check `conn->br.link_key` before calling the function `bt_keys_link_key_clear()` to clear it.

Fixes #87880.