### PR TITLE
RTIO: Introduce `RTIO_OP_AWAIT`

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -59,12 +59,20 @@ static bool i2c_nrfx_twi_rtio_msg_start(const struct device *dev, uint8_t flags,
 	return false;
 }
 
+static void i2c_nrfx_twi_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, void *userdata)
+{
+	const struct device *dev = userdata;
+
+	i2c_nrfx_twi_rtio_complete(dev, 0);
+}
+
 static bool i2c_nrfx_twi_rtio_start(const struct device *dev)
 {
 	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
 	struct i2c_rtio *ctx = dev_data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
+	struct rtio_iodev_sqe *iodev_sqe;
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
@@ -83,6 +91,11 @@ static bool i2c_nrfx_twi_rtio_start(const struct device *dev)
 		return false;
 	case RTIO_OP_I2C_RECOVER:
 		(void)i2c_nrfx_twi_recover_bus(dev);
+		return false;
+	case RTIO_OP_AWAIT:
+		iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
+		rtio_iodev_sqe_await_signal(iodev_sqe, i2c_nrfx_twi_rtio_sqe_signaled,
+					    (void *)dev);
 		return false;
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -46,6 +46,15 @@ static bool i2c_nrfx_twim_rtio_msg_start(const struct device *dev, uint8_t flags
 	return false;
 }
 
+static void i2c_nrfx_twim_rtio_complete(const struct device *dev, int status);
+
+static void i2c_nrfx_twim_rtio_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, void *userdata)
+{
+	const struct device *dev = userdata;
+
+	(void)i2c_nrfx_twim_rtio_complete(dev, 0);
+}
+
 static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 {
 	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
@@ -53,6 +62,7 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 	struct i2c_rtio *ctx = config->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
+	struct rtio_iodev_sqe *iodev_sqe;
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
@@ -103,6 +113,11 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 		return false;
 	case RTIO_OP_I2C_RECOVER:
 		(void)i2c_nrfx_twim_recover_bus(dev);
+		return false;
+	case RTIO_OP_AWAIT:
+		iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
+		rtio_iodev_sqe_await_signal(iodev_sqe, i2c_nrfx_twim_rtio_sqe_signaled,
+					    (void *)dev);
 		return false;
 	default:
 		LOG_ERR("Invalid op code %d for submission %p\n", sqe->op, (void *)sqe);


### PR DESCRIPTION
Introduce await operation which is used to block RTIO IODEV execution until a user signals the execution to continue. This is required for short, very time critical transactions, which have to occur within an exact time window, where any competing transactions could block the time critical section. This can replace SPI APIs `SPI_LOCK_BIT` and `spi_release()` API, while providing the same functionality to I2C and I3C if implemented.

It works like this:
1. Prepare SQE with `rtio_sqe_prep_await()`
2. Submit to RTIO with `rtio_submit()`
3. RTIO will stop all bus transactions once await SQE is executed
4. Signal SQE to allow transactions to continue with `rtio_sqe_signal()`

