### PR TITLE
cmsis: modules: PR for broken CMSIS for ARMv8.1M

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       groups:
         - babblesim
     - name: cmsis
-      revision: d1b8b20b6278615b00e136374540eb1c00dcabe7
+      revision: pull/26/head
       path: modules/hal/cmsis
       groups:
         - hal


### PR DESCRIPTION
Currently cmsis has a missing file.
This makes __ARM_FEATURE_PAUTH being defined
causing compilation issues.