### PR TITLE
Bluetooth: Mesh: pts fixes for prb

### DIFF
--- a/subsys/bluetooth/mesh/proxy_srv.c
+++ b/subsys/bluetooth/mesh/proxy_srv.c
@@ -897,10 +897,13 @@ static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)
 		if (sub == beacon_sub) {
 			beacon_sub = NULL;
 		}
+
+		bt_mesh_proxy_identity_stop(sub);
 	} else {
 		bt_mesh_proxy_beacon_send(sub);
-		bt_mesh_adv_gatt_update();
 	}
+
+	bt_mesh_adv_gatt_update();
 }
 
 BT_MESH_SUBNET_CB_DEFINE(gatt_services) = {

--- a/tests/bluetooth/tester/src/btp/btp_mesh.h
+++ b/tests/bluetooth/tester/src/btp/btp_mesh.h
@@ -1060,6 +1060,9 @@ struct btp_priv_node_id_set_cmd {
 } __packed;
 
 #define BTP_MESH_PROXY_PRIVATE_IDENTITY		0x72
+struct btp_proxy_priv_identity_cmd {
+	uint8_t enabled;
+} __packed;
 
 #define BTP_MESH_OD_PRIV_PROXY_GET		0x73
 struct btp_od_priv_proxy_get_cmd {


### PR DESCRIPTION
Bluetooth Mesh:
- Private Node Identity advertisement on a subnet should stop as soon as the network is removed.

Bluetooth: Tester:
- Private node identity advertisements must stop immediately when ordered by PTS. To do so; adding enabled parameter to btp_priv_node_id_get_cmd.

Related AutoPTS changes: https://github.com/auto-pts/auto-pts/pull/1432