### PR TITLE
scripts: support quoted sysbuild Kconfig settings in twister

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1666,8 +1666,8 @@ class ProjectBuilder(FilterBuilder):
                             extra_dtc_overlay_files, cmake_extra_args,
                             build_dir):
         # Retain quotes around config options
-        config_options = [arg for arg in extra_args if arg.startswith("CONFIG_")]
-        args = [arg for arg in extra_args if not arg.startswith("CONFIG_")]
+        config_options = [arg for arg in extra_args if arg.startswith(("CONFIG_", "SB_CONFIG_"))]
+        args = [arg for arg in extra_args if not arg.startswith(("CONFIG_", "SB_CONFIG_"))]
 
         args_expanded = ["-D{}".format(a.replace('"', '\"')) for a in config_options]
 


### PR DESCRIPTION
Kconfig settings of string type is passed to CMake with quotes to ensure they are properly handled, for example when specified in testcase.yml as
```
   extra_args:
    - CONFIG_FOO="bar"
```

Support sysbuild Kconfig settings `SB_CONFIG` by performing the same quoting for settings starting with `SB_CONFIG_`.