### PR TITLE
ci: github: bump action-first-interaction to v1.1.1+zephyr.6

### DIFF
--- a/.github/workflows/greet_first_time_contributor.yml
+++ b/.github/workflows/greet_first_time_contributor.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: zephyrproject-rtos/action-first-interaction@7e6446f8439d8b4399169880c36a3a12b5747699 # v1.1.1-zephyr-5
+      - uses: zephyrproject-rtos/action-first-interaction@58853996b1ac504b8e0f6964301f369d2bb22e5c # v1.1.1+zephyr.6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
No functional change. This is only so as to adopt a versioning scheme where the Zephyr version of the action is considered more recent than the upstream version (here, v1.1.1) by means of using dots instead of dashes.

points to https://github.com/zephyrproject-rtos/action-first-interaction/releases/tag/v1.1.1%2Bzephyr.6