### PR TITLE
ci: bsim-tests: Exclude .rst files from path patterns

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -27,6 +27,7 @@ on:
       - "include/zephyr/net/ieee802154*"
       - "drivers/serial/*nrfx*"
       - "tests/drivers/uart/**"
+      - '!**.rst'
 
 permissions:
   contents: read


### PR DESCRIPTION
Updated the bsim-tests workflow to exclude all .rst files.

As per GitHub docs:

> The order that you define paths patterns matters:
> 
> A matching negative pattern (prefixed with !) after a positive match will exclude the path.
> A matching positive pattern after a negative match will include the path again.
