### PR TITLE
Drivers: bluetooth: siwx917: Remove default flow control disabling flag

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -174,10 +174,6 @@ config BT_SILABS_SIWX91X
 	help
 	  Use Silicon Labs Wiseconnect 3.x Bluetooth library to connect to the controller.
 
-	# SiWx917 BLE controller currently does not support HCI Command: Host Number of Completed Packets
-	configdefault BT_HCI_ACL_FLOW_CONTROL
-		default n if BT_SILABS_SIWX91X
-
 config BT_USERCHAN
 	bool
 	depends on BOARD_NATIVE_SIM


### PR DESCRIPTION
This change was added to fix issue of SMP in PR #86075. Which is not required, without this change all the applications are working fine.