### PR TITLE
gitlint: Add ignored rules for dependabot

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -59,3 +59,7 @@ ignore-merge-commits=false
 # By specifying this rule, developers can only change the file when they explicitly reference
 # it in the commit message.
 #files=gitlint/rules.py,README.md
+
+[ignore-by-author-name]
+regex=dependabot
+ignore=body-requires-signed-off-by, max-line-length-with-exceptions


### PR DESCRIPTION
Dependabot will have an auto-generated body and is likely to fail the max line length check.
The bot also does not use a full name for the signed-of-by line.