### PR TITLE
cmake: treat warnings as errors for assembly stage

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -156,7 +156,7 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp23 "-std=c++23"
 set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)
 
 # Extra warning options
-set_property(TARGET compiler PROPERTY warnings_as_errors -Werror)
+set_property(TARGET compiler PROPERTY warnings_as_errors -Werror -Wa,--fatal-warnings)
 set_property(TARGET asm PROPERTY warnings_as_errors -Werror -Wa,--fatal-warnings)
 
 # Deprecation warning


### PR DESCRIPTION
CONFIG_COMPILER_WARNINGS_AS_ERRORS=y promotes compiler warnings to errors.
However, on GCC warnings generated by the assembler during the assembly step requires `-Wa,--fatal-warnings` in order to be correctly treated as errors.

Specify `-Wa,--fatal-warnings` in addition to `-Werror` for GCC.

Fixes: #87705