### PR TITLE
samples: smp: pi: use K_SEM_DEFINE() for simplicity

### DIFF
--- a/samples/arch/smp/pi/src/main.c
+++ b/samples/arch/smp/pi/src/main.c
@@ -30,7 +30,7 @@ static struct k_thread tthread[THREADS_NUM];
 static char th_buffer[THREADS_NUM][DIGITS_NUM + 1];
 static atomic_t th_counter = THREADS_NUM;
 
-struct k_sem main_sem;
+K_SEM_DEFINE(main_sem, 0, 1);
 
 void test_thread(void *arg1, void *arg2, void *arg3)
 {
@@ -85,11 +85,6 @@ int main(void)
 {
 	uint32_t start_time, stop_time, cycles_spent, nanoseconds_spent;
 	int i;
-
-	if (k_sem_init(&main_sem, 0, 1)) {
-		printk("Failed initialization!\n");
-		return -1;
-	}
 
 	printk("Calculate first %d digits of Pi independently by %d threads.\n",
 	       DIGITS_NUM, THREADS_NUM);


### PR DESCRIPTION
This change uses K_SEM_DEFINE() instead of calling k_sem_init() and having to check for its return value.

It makes the smp pi sample a bit simpler to go through.

