### PR TITLE
modules/zcbor: Added building of zcbor_print.c to zcbor module

### DIFF
--- a/modules/zcbor/CMakeLists.txt
+++ b/modules/zcbor/CMakeLists.txt
@@ -8,6 +8,7 @@ if(CONFIG_ZCBOR)
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_common.c
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_decode.c
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_encode.c
+    ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_print.c
   )
 
   zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)


### PR DESCRIPTION
Some utilities function implementations were moved to their own implementation file in zcbor 0.9.0 (see [60af955](https://github.com/NordicSemiconductor/zcbor/commit/60af955961dd5575f3a4e78eb7af4f297bda7c6a#diff-13a75d0944d62e530340c1aed5ef9248883d1c002f5e569703444bf3785ac06c)). This commit is simply to compile those functions so that users can still have access to them without using the --output-cmake functionality provided by the zcbor python script.