### PR TITLE
Add persistent partition to RPi Pico Flash

### DIFF
--- a/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
+++ b/boards/raspberrypi/rpi_pico/rpi_pico-common.dtsi
@@ -78,13 +78,24 @@
 		};
 
 		/*
-		 * Usable flash. Starts at 0x100, after the bootloader. The partition
-		 * size is 2MB minus the 0x100 bytes taken by the bootloader.
+		 * Usable flash. Starts at 0x100, after the bootloader. The code partition
+		 * size is flash size minus the 0x100 bytes taken by the bootloader, and
+		 * minus the size of the storage partition.
 		 */
 		code_partition: partition@100 {
 			label = "code-partition";
-			reg = <0x100 (DT_SIZE_M(2) - 0x100)>;
+			reg = <0x100 (DT_SIZE_M(2) - 0x100 - DT_SIZE_K(16))>;
 			read-only;
+		};
+
+		/*
+		 * Area for placing a file system for persistent storage. Starts at the end
+		 * of the code partition. The persistent storage size is chosen to have the
+		 * capacity for a minimal 'littlefs' file system with 4 blocks.
+		 */
+		storage_partition: partition@1fc000 {
+			label = "storage-partition";
+			reg = <0x1fc000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/samples/subsys/usb/mass/boards/rpi_pico.overlay
+++ b/samples/subsys/usb/mass/boards/rpi_pico.overlay
@@ -5,6 +5,7 @@
  */
 
 /delete-node/ &code_partition;
+/delete-node/ &storage_partition;
 
 &flash0 {
 	partitions {


### PR DESCRIPTION
### Updated Summary ###
The added partition ```storage_partition``` can be used for the littelfs sample application. It is sized to have enough capacity for the created files in this sample code.

### Details ###
The changed file ```rpi_pico-common.dtsi``` now contains a third partition, that describes "storage" are for a file system. The "code" partition was reduced in size to make room for this area. The new partition has a capacity of 16 kB, which is enough for the littelfs sample to store two files.

### Tests ###

#### Compilation ####
The compile step for each platform succeeds:
```
$ west build --pristine -b rpi_pico samples/subsys/fs/littlefs
...
[160/160] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
      BOOT_FLASH:         256 B        256 B    100.00%
           FLASH:       52616 B    2080512 B      2.53%
             RAM:       11072 B       264 KB      4.10%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /home/awolf/zephyrproject-fork/zephyr/build/zephyr/zephyr.elf for board: rpi_pico
Converted to uf2, output size: 105984, start address: 0x10000000
Wrote 105984 bytes to zephyr.uf2
```
```
$ west build --pristine -b rpi_pico/rp2040/w samples/subsys/fs/littlefs
...
[164/164] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
      BOOT_FLASH:         256 B        256 B    100.00%
           FLASH:       52756 B    2080512 B      2.54%
             RAM:       11072 B       264 KB      4.10%
        IDT_LIST:          0 GB        32 KB      0.00%
Generating files from /home/awolf/zephyrproject-fork/zephyr/build/zephyr/zephyr.elf for board: rpi_pico
Converted to uf2, output size: 106496, start address: 0x10000000
Wrote 106496 bytes to zephyr.uf2
```

#### Test Run ####
The test were run in a Pico-W device.

##### First Run On Device #####
Log after flashing the littlefs sample:
```
Sample program to r/w files on littlefs
Area 2 at 0x1fc000 on flash-controller@18000000 for 16384 bytes
I: LittleFS version 2.10, disk version 2.1
I: FS at flash-controller@18000000:0x1fc000 is 4 0x1000-byte blocks with 512 cycle
I: partition sizes: rd 16 ; pr 16 ; ca 64 ; la 32
E: WEST_TOPDIR/modules/fs/littlefs/lfs.c:4604: Invalid block count (1 != 4)
W: can't mount (LFS -22); formatting
I: /lfs mounted
/lfs mount: 0
/lfs: bsize = 16 ; frsize = 4096 ; blocks = 4 ; bfree = 2

Listing dir /lfs ...
/lfs/boot_count read count:0 (bytes: 0)
/lfs/boot_count write new boot count 1: [wr:1]
I: Test file: /lfs/pattern.bin not found, create one!
------ FILE: /lfs/pattern.bin ------
01 55 55 55 55 55 55 55 02 55 55 55 55 55 55 55
...
45 55 aa 
I: /lfs unmounted
/lfs unmount: 0
```

After performing a power cycle:

```
Sample program to r/w files on littlefs
Area 2 at 0x1fc000 on flash-controller@18000000 for 16384 bytes
I: LittleFS version 2.10, disk version 2.1
I: FS at flash-controller@18000000:0x1fc000 is 4 0x1000-byte blocks with 512 cycle
I: partition sizes: rd 16 ; pr 16 ; ca 64 ; la 32
/lfs mount: 0
/lfs: bsize = 16 ; frsize = 4096 ; blocks = 4 ; bfree = 1

Listing dir /lfs ...
[FILE] boot_count (size = 1)
[FILE] pattern.bin (size = 547)
/lfs/boot_count read count:1 (bytes: 1)
/lfs/boot_count write new boot count 2: [wr:1]
------ FILE: /lfs/pattern.bin ------
02 55 55 55 55 55 55 55 03 55 55 55 55 55 55 55
...
46 55 ab 
I: /lfs unmounted
/lfs unmount: 0
```


## Old Text ##
The below text is kept to document previous changes to make the littlefs sample work.

**IGNORE TEXT BELOW** 
### Summary ###
The added overlay files support the compilation for the Pico and Pico_w of the sample for the littlefs filesystem.

### Details ###
The file ```rpi_pico.overlay``` reduces the size of the "code" partition and adds another partition at the end.
This partition has a capacity of 64 kB.

### Tests ###
#### Compilation ####
The compile step for each platform succeeds:
```
$ west build -b rpi_pico samples/subsys/fs/littlefs
...
-- Found BOARD.dts: /home/awolf/zephyrproject-fork/zephyr/boards/raspberrypi/rpi_pico/rpi_pico.dts
-- Found devicetree overlay: /home/awolf/zephyrproject-fork/zephyr/samples/subsys/fs/littlefs/boards/rpi_pico.overlay
-- Generated zephyr.dts: /home/awolf/zephyrproject-fork/zephyr/build/zephyr/zephyr.dts
...
Converted to uf2, output size: 105984, start address: 0x10000000
Wrote 105984 bytes to zephyr.uf2
```

```
$ west build -b rpi_pico/rp2040/w samples/subsys/fs/littlefs
...
-- Found BOARD.dts: /home/awolf/zephyrproject-fork/zephyr/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_w.dts
-- Found devicetree overlay: /home/awolf/zephyrproject-fork/zephyr/samples/subsys/fs/littlefs/boards/rpi_pico_rp2040_w.overlay
-- Generated zephyr.dts: /home/awolf/zephyrproject-fork/zephyr/build/zephyr/zephyr.dts
...
Converted to uf2, output size: 106496, start address: 0x10000000
Wrote 106496 bytes to zephyr.uf2
```

#### Test Run ####
The code was run on the Pico_w test platform

1. First run included a flash erase (per config)
```
*** Booting Zephyr OS build v4.1.0-1562-g478212efc4e1 ***
Sample program to r/w files on littlefs
Area 2 at 0x1f0000 on flash-controller@18000000 for 65536 bytes
E: Erasing flash area ... 0
I: LittleFS version 2.10, disk version 2.1
I: FS at flash-controller@18000000:0x1f0000 is 16 0x1000-byte blocks with 512 cycle
I: partition sizes: rd 16 ; pr 16 ; ca 64 ; la 32
E: WEST_TOPDIR/modules/fs/littlefs/lfs.c:1389: Corrupted dir pair at {0x0, 0x1}
W: can't mount (LFS -84); formatting
I: /lfs mounted
/lfs mount: 0
/lfs: bsize = 16 ; frsize = 4096 ; blocks = 16 ; bfree = 14

Listing dir /lfs ...
/lfs/boot_count read count:0 (bytes: 0)
/lfs/boot_count write new boot count 1: [wr:1]
I: Test file: /lfs/pattern.bin not found, create one!
```
2. The second run read the per-existing files:
```
*** Booting Zephyr OS build v4.1.0-1562-g478212efc4e1 ***
Sample program to r/w files on littlefs
Area 2 at 0x1f0000 on flash-controller@18000000 for 65536 bytes
I: LittleFS version 2.10, disk version 2.1
I: FS at flash-controller@18000000:0x1f0000 is 16 0x1000-byte blocks with 512 cycle
I: partition sizes: rd 16 ; pr 16 ; ca 64 ; la 32
/lfs mount: 0
/lfs: bsize = 16 ; frsize = 4096 ; blocks = 16 ; bfree = 13

Listing dir /lfs ...
[FILE] boot_count (size = 1)
[FILE] pattern.bin (size = 547)
/lfs/boot_count read count:1 (bytes: 1)
/lfs/boot_count write new boot count 2: [wr:1]
```

