### PR TITLE
modules: optional: ci-fix and feature update for rust

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: 37dc7fac3fb0372bc0e78e022bef87fcce68c48d
+      revision: d4f9036a88e53080bf2b186afa5289f9c77a0f73
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
Apply the following patches to the v4.1-branch of rust.  This fixes an
issue with CI.

349164d630a samples: blinky: Remove incorrect integration platform
b0866632d42 samples/tests: Ensure test/sample names are unique