### PR TITLE
sensor: dts: Add sensor-device.yaml to all instances

### DIFF
--- a/dts/bindings/sensor/ams,as6212.yaml
+++ b/dts/bindings/sensor/ams,as6212.yaml
@@ -7,7 +7,7 @@ description: |
 
 compatible: "ams,as6212"
 
-include: i2c-device.yaml
+include: [sensor-device.yaml, i2c-device.yaml]
 
 properties:
   alert-gpios:

--- a/dts/bindings/sensor/ist,tsic-xx6.yaml
+++ b/dts/bindings/sensor/ist,tsic-xx6.yaml
@@ -17,6 +17,8 @@ description: |
 
 compatible: "ist,tsic-xx6"
 
+include: sensor-device.yaml
+
 properties:
   pwms:
     required: true

--- a/dts/bindings/sensor/nordic,nrf-temp-nrfs.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp-nrfs.yaml
@@ -6,4 +6,4 @@ description: |
 
 compatible: "nordic,nrf-temp-nrfs"
 
-include: base.yaml
+include: [base.yaml, sensor-device.yaml]

--- a/dts/bindings/sensor/nxp,p3t1755-common.yaml
+++ b/dts/bindings/sensor/nxp,p3t1755-common.yaml
@@ -4,6 +4,8 @@
 description: |
     NXP P3T1755 digital temperature sensor.
 
+include: sensor-device.yaml
+
 properties:
   oneshot-mode:
     type: boolean

--- a/dts/bindings/sensor/pixart,paa3905.yaml
+++ b/dts/bindings/sensor/pixart,paa3905.yaml
@@ -6,7 +6,7 @@ description: PA3905 optical flow sensor
 
 compatible: "pixart,paa3905"
 
-include: spi-device.yaml
+include: [sensor-device.yaml, spi-device.yaml]
 
 properties:
   resolution:

--- a/dts/bindings/sensor/st,stm32-digi-temp.yaml
+++ b/dts/bindings/sensor/st,stm32-digi-temp.yaml
@@ -5,7 +5,7 @@ description: STM32 Digital Temperature Sensor.
 
 compatible: "st,stm32-digi-temp"
 
-include: base.yaml
+include: [sensor-device.yaml, base.yaml]
 
 properties:
   reg:

--- a/dts/bindings/sensor/st,stm32-qdec.yaml
+++ b/dts/bindings/sensor/st,stm32-qdec.yaml
@@ -8,6 +8,7 @@ compatible: "st,stm32-qdec"
 include:
   - name: base.yaml
   - name: pinctrl-device.yaml
+  - name: sensor-device.yaml
 
 properties:
   pinctrl-0:


### PR DESCRIPTION
Some were missing them, as pointed out on #86747.