### PR TITLE
manifest: hal_atmel: bump hash for missing macro

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -157,7 +157,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: cd0ddbbcdb67e8b5198a94b94ab40c1e866da050
+      revision: ca7e4c6920f44b9d677ed5995ffa169f18a54cdf
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The ADC_MR_STARTUP and ADC_MR_SETTLING macros are required by SAM ADC driver, and is missing for sam3x variants.