### PR TITLE
lvgl: Add config to disable monochrome pixel software inversion

### DIFF
--- a/boards/shields/ssd1306/Kconfig.defconfig
+++ b/boards/shields/ssd1306/Kconfig.defconfig
@@ -17,6 +17,9 @@ config LV_DPI_DEF
 config LV_Z_BITS_PER_PIXEL
 	default 1
 
+config LV_Z_COLOR_MONO_HW_INVERSION
+	default y
+
 choice LV_COLOR_DEPTH
 	default LV_COLOR_DEPTH_1
 endchoice

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -212,6 +212,10 @@ New APIs and options
 
    * :kconfig:option:`CONFIG_NVME_PRP_PAGE_SIZE`
 
+* Other
+
+  * :kconfig:option:`CONFIG_LV_Z_COLOR_MONO_HW_INVERSION`
+
 New Boards
 **********
 

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -94,6 +94,10 @@ config LV_COLOR_16_SWAP
 	bool "Swap the 2 bytes of RGB565 color."
 	depends on LV_COLOR_DEPTH_16
 
+config LV_Z_COLOR_MONO_HW_INVERSION
+	bool "Hardware pixel inversion (disables software pixel inversion)."
+	depends on LV_COLOR_DEPTH_1
+
 config LV_Z_FLUSH_THREAD
 	bool "Flush LVGL frames in a separate thread"
 	help

--- a/modules/lvgl/lvgl_display_mono.c
+++ b/modules/lvgl/lvgl_display_mono.c
@@ -38,17 +38,25 @@ static ALWAYS_INLINE void set_px_at_pos(uint8_t *dst_buf, uint32_t x, uint32_t y
 		}
 	}
 
+#ifdef CONFIG_LV_Z_COLOR_MONO_HW_INVERSION
+	*buf |= BIT(bit);
+#else
 	if (caps->current_pixel_format == PIXEL_FORMAT_MONO10) {
 		*buf |= BIT(bit);
 	} else {
 		*buf &= ~BIT(bit);
 	}
+#endif
 }
 
 static void lvgl_transform_buffer(uint8_t **px_map, uint32_t width, uint32_t height,
 				  const struct display_capabilities *caps)
 {
+#ifdef CONFIG_LV_Z_COLOR_MONO_HW_INVERSION
+	uint8_t clear_color = 0x00;
+#else
 	uint8_t clear_color = caps->current_pixel_format == PIXEL_FORMAT_MONO10 ? 0x00 : 0xFF;
+#endif
 
 	memset(mono_conv_buf, clear_color, mono_conv_buf_size);
 


### PR DESCRIPTION
In some cases, pixel inversion is managed by the display hardware (e.g. SSD1306) and software inversion is not required (as it disables the hardware inversion). This PR adds a configuration to disable this inversion.