### PR TITLE
soc: nxp: Fix boot header placement when using lld

### DIFF
--- a/soc/nxp/imxrt/boot_header.ld
+++ b/soc/nxp/imxrt/boot_header.ld
@@ -10,9 +10,9 @@ __Vectors = __VECTOR_TABLE;
 #endif
 
 #if defined(CONFIG_BOOT_XSPI_NOR)
-. = CONFIG_XSPI_CONFIG_BLOCK_OFFSET;
+. += CONFIG_XSPI_CONFIG_BLOCK_OFFSET - (. - __rom_start_address);
 #else
-. = CONFIG_FLEXSPI_CONFIG_BLOCK_OFFSET;
+. += CONFIG_FLEXSPI_CONFIG_BLOCK_OFFSET - (. - __rom_start_address);
 #endif
 #if defined(CONFIG_SOC_SERIES_IMXRT11XX) || defined(CONFIG_SOC_SERIES_IMXRT10XX) || defined(CONFIG_SOC_SERIES_IMXRT118X)
 KEEP(*(.boot_hdr.conf))
@@ -22,13 +22,13 @@ KEEP(*(.flash_conf))
 #endif
 #if defined(CONFIG_SOC_SERIES_IMXRT118X)
 #ifdef CONFIG_EXTERNAL_MEM_CONFIG_DATA
-	. = CONFIG_EXTERNAL_MEM_CONFIG_OFFSET;
+	. += CONFIG_EXTERNAL_MEM_CONFIG_OFFSET - (. - __rom_start_address);
 	KEEP(*(.boot_hdr.xmcd_data))
 #endif
-. = CONFIG_IMAGE_CONTAINER_OFFSET;
+. += CONFIG_IMAGE_CONTAINER_OFFSET - (. - __rom_start_address);
 KEEP(*(.boot_hdr.container))
 #else
-. = CONFIG_IMAGE_VECTOR_TABLE_OFFSET;
+. += CONFIG_IMAGE_VECTOR_TABLE_OFFSET - (. - __rom_start_address);
 KEEP(*(.boot_hdr.ivt))
 #endif
 #if defined(CONFIG_SOC_SERIES_IMXRT11XX) || defined(CONFIG_SOC_SERIES_IMXRT10XX)
@@ -37,7 +37,7 @@ KEEP(*(.boot_hdr.data))
 	KEEP(*(.boot_hdr.dcd_data))
 #endif /* CONFIG_DEVICE_CONFIGURATION_DATA */
 #ifdef CONFIG_EXTERNAL_MEM_CONFIG_DATA
-	. = CONFIG_EXTERNAL_MEM_CONFIG_OFFSET;
+	. += CONFIG_EXTERNAL_MEM_CONFIG_OFFSET - (. - __rom_start_address);
 	KEEP(*(.boot_hdr.xmcd_data))
 #endif
 #endif /* CONFIG_SOC_SERIES_IMXRT10XX || CONFIG_SOC_SERIES_IMXRT11XX */

--- a/soc/nxp/rw/boot_header.ld
+++ b/soc/nxp/rw/boot_header.ld
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-. = CONFIG_FLASH_CONFIG_OFFSET;
+. += CONFIG_FLASH_CONFIG_OFFSET - (. - __rom_start_address);
 KEEP(*(.flash_conf))
-. = CONFIG_IMAGE_VECTOR_TABLE_OFFSET;
+. += CONFIG_IMAGE_VECTOR_TABLE_OFFSET - (. - __rom_start_address);
 KEEP(*(.boot_hdr.ivt))


### PR DESCRIPTION
As well described in https://github.com/zephyrproject-rtos/zephyr/pull/58315, the GNU ld and LLVM lld linkers treat the location counter (`.`) differently. lld always inteprets the location counter as an absolute address whereas ld interprets it as an offset from the start of the current object.

The NXP boot header linker script files use `.` assignment to specify an offset within the `rom_start` output section, which is fine for ld. However, lld errors out, as it sees the offset as an absolute address, which would require it to move the location counter backwards.

To fix this, re-use the idea from https://github.com/zephyrproject-rtos/zephyr/pull/58315: replace `. = FOO_OFFSET` with `. += FOO_OFFSET - (. - __rom_start_address)`. Given that `__rom_start_address` is already set up to be at the very start of the `rom_start` output section, this sets the location counter in a way that works with both ld and lld.