### PR TITLE
dts: atmel: add adc node to due

### DIFF
--- a/boards/arduino/due/arduino_due-pinctrl.dtsi
+++ b/boards/arduino/due/arduino_due-pinctrl.dtsi
@@ -67,4 +67,11 @@
 				 <PC5B_PWM_PWMH1>;
 		};
 	};
+
+	adc0_default: adc0_default {
+		group1 {
+			pinmux = <PA24X_ADC_AD6>,
+				 <PA16X_ADC_AD7>;
+		};
+	};
 };

--- a/boards/arduino/due/arduino_due.yaml
+++ b/boards/arduino/due/arduino_due.yaml
@@ -8,6 +8,7 @@ toolchain:
 flash: 512
 ram: 96
 supported:
+  - adc
   - arduino_i2c
   - gpio
   - watchdog

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/clock/atmel_sam_pmc.h>
@@ -255,6 +256,17 @@
 			clocks = <&pmc PMC_TYPE_PERIPHERAL 33>,
 				 <&pmc PMC_TYPE_PERIPHERAL 34>,
 				 <&pmc PMC_TYPE_PERIPHERAL 35>;
+			status = "disabled";
+		};
+
+		adc0: adc@400c0000 {
+			compatible = "atmel,sam-adc";
+			reg = <0x400c0000 0x4000>;
+			interrupts = <37 1>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 37>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#io-channel-cells = <1>;
 			status = "disabled";
 		};
 

--- a/samples/drivers/adc/adc_sequence/boards/arduino_due.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/arduino_due.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Centro de Inovacao EDGE
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc0 = &adc0;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+
+	prescaler = <9>;
+	startup-time = <64>;
+	settling-time = <3>;
+	tracking-time = <2>;
+
+	/* External ADC(+) */
+	channel@6 { // Connector A1
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <6>;
+		zephyr,vref-mv = <3300>;
+	};
+	channel@7 { // Connector A0
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <7>;
+		zephyr,vref-mv = <3300>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/arduino_due.overlay
+++ b/tests/drivers/adc/adc_api/boards/arduino_due.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Centro de Inovacao EDGE
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>, <&adc0 1>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+
+	prescaler = <9>;
+	startup-time = <64>;
+	settling-time = <3>;
+	tracking-time = <2>;
+
+	/* External ADC(+) */
+	channel@6 { // Connector A1
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <6>;
+		zephyr,vref-mv = <3300>;
+	};
+	channel@7 { // Connector A0
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_EXTERNAL0";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,input-positive = <7>;
+		zephyr,vref-mv = <3300>;
+	};
+};


### PR DESCRIPTION
Add ADC0 node and associated pincontrols in sam3x and Arduino Due device trees.
Depends on PR #87927