### PR TITLE
picolibc: #define __lock as k_mutex for picolibc

### DIFF
--- a/lib/libc/picolibc/locks.c
+++ b/lib/libc/picolibc/locks.c
@@ -7,7 +7,6 @@
 #include "picolibc-hooks.h"
 
 #ifdef CONFIG_MULTITHREADING
-#define _LOCK_T void *
 K_MUTEX_DEFINE(__lock___libc_recursive_mutex);
 
 #ifdef CONFIG_USERSPACE
@@ -38,7 +37,7 @@ void __retarget_lock_init_recursive(_LOCK_T *lock)
 #endif /* !CONFIG_USERSPACE */
 	__ASSERT(*lock != NULL, "recursive lock allocation failed");
 
-	k_mutex_init((struct k_mutex *)*lock);
+	k_mutex_init(*lock);
 }
 
 /* Create a new dynamic non-recursive lock */
@@ -68,7 +67,7 @@ void __retarget_lock_close(_LOCK_T lock)
 void __retarget_lock_acquire_recursive(_LOCK_T lock)
 {
 	__ASSERT_NO_MSG(lock != NULL);
-	k_mutex_lock((struct k_mutex *)lock, K_FOREVER);
+	k_mutex_lock(lock, K_FOREVER);
 }
 
 /* Acquiure non-recursive lock */
@@ -81,7 +80,7 @@ void __retarget_lock_acquire(_LOCK_T lock)
 int __retarget_lock_try_acquire_recursive(_LOCK_T lock)
 {
 	__ASSERT_NO_MSG(lock != NULL);
-	return !k_mutex_lock((struct k_mutex *)lock, K_NO_WAIT);
+	return !k_mutex_lock(lock, K_NO_WAIT);
 }
 
 /* Try acquiring non-recursive lock */
@@ -94,7 +93,7 @@ int __retarget_lock_try_acquire(_LOCK_T lock)
 void __retarget_lock_release_recursive(_LOCK_T lock)
 {
 	__ASSERT_NO_MSG(lock != NULL);
-	k_mutex_unlock((struct k_mutex *)lock);
+	k_mutex_unlock(lock);
 }
 
 /* Release non-recursive lock */

--- a/lib/libc/picolibc/picolibc-hooks.h
+++ b/lib/libc/picolibc/picolibc-hooks.h
@@ -7,6 +7,8 @@
 #ifndef _PICOLIBC_HOOKS_H_
 #define _PICOLIBC_HOOKS_H_
 
+#define __lock k_mutex
+#include <sys/lock.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Instead of trying to redefine _LOCK_T in locks.c, which doesn't work anymore after https://github.com/picolibc/picolibc/pull/825, define __lock as k_mutex before including picolibc headers.

Remove (now) unnecessary casts to help validate that struct __lock becomes struct k_mutex.