### PR TITLE
toolchain: llvm: Use clang's __INTN_C/__UINTN_C macros for clang 20.1+

### DIFF
--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -42,10 +42,10 @@
 #ifdef CONFIG_MINIMAL_LIBC
 
 /*
- * Predefined __INTN_C/__UINTN_C macros are provided by clang starting in version 20.
+ * Predefined __INTN_C/__UINTN_C macros are provided by clang starting in version 20.1.
  * Avoid redefining these macros if a sufficiently modern clang is being used.
  */
-#if __clang_major__ < 20
+#if TOOLCHAIN_CLANG_VERSION < 200100
 
 #define __int_c(v, suffix) v ## suffix
 #define int_c(v, suffix) __int_c(v, suffix)
@@ -138,7 +138,7 @@
 #define __INTMAX_C(x)	int_c(x, __INTMAX_C_SUFFIX__)
 #define __UINTMAX_C(x)	int_c(x, __UINTMAX_C_SUFFIX__)
 
-#endif /* __clang_major__ < 20 */
+#endif /* TOOLCHAIN_CLANG_VERSION < 200100 */
 
 #endif /* CONFIG_MINIMAL_LIBC */
 


### PR DESCRIPTION
Use the builtin intn macros for 20.1+, as 20.0 doesn't include them. 20.0 wasn't an official release.