### PR TITLE
dp: add option to keep reset deasserted

### DIFF
--- a/drivers/dp/Kconfig
+++ b/drivers/dp/Kconfig
@@ -28,4 +28,10 @@ config SWDP_BITBANG_DRIVER
 	help
 	  Serial Wire Debug Port bit-bang driver.
 
+config SWDP_MAINTAIN_RESET_DEASSERTED
+	bool "Serial Wire Debug Port keeps RESET deasserted even when inactive"
+	depends on SWDP_BITBANG_DRIVER
+	help
+	  Serial Wire Debug Port keeps RESET deasserted even when inactive
+
 endif # DP_DRIVER

--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -668,7 +668,10 @@ static int sw_port_off(const struct device *dev)
 	}
 
 	if (config->reset.port) {
-		ret = gpio_pin_configure_dt(&config->reset, GPIO_DISCONNECTED);
+		ret = gpio_pin_configure_dt(&config->reset,
+					    IS_ENABLED(CONFIG_SWDP_MAINTAIN_RESET_DEASSERTED)
+						    ? GPIO_OUTPUT_ACTIVE
+						    : GPIO_DISCONNECTED);
 		if (ret) {
 			return ret;
 		}


### PR DESCRIPTION
Adds a Kconfig to keep reset deasserted even when the SWD port is
disconnected.

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>
