### PR TITLE
subsys: tracing: add core_id to CTF tracing for SMP configuration

### DIFF
--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -50,17 +50,36 @@
 	}
 
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
+#ifdef CONFIG_SMP
+#define CTF_EVENT(...)                                                         \
+	{                                                                      \
+		const uint32_t tstamp = k_cyc_to_ns_floor64(k_cycle_get_32()); \
+		const uint32_t core_id =arch_proc_id(); \
+										\
+		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__, core_id)                         \
+	}
+#else
 #define CTF_EVENT(...)                                                         \
 	{                                                                      \
 		const uint32_t tstamp = k_cyc_to_ns_floor64(k_cycle_get_32()); \
 									       \
 		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                         \
 	}
+#endif
+#else
+#ifdef CONFIG_SMP
+#define CTF_EVENT(...)                                                         \
+	{                                                                      \
+		const uint32_t core_id =arch_proc_id(); \
+											\
+		CTF_GATHER_FIELDS(__VA_ARGS__, core_id)                                 \
+	}
 #else
 #define CTF_EVENT(...)                                                         \
 	{                                                                      \
 		CTF_GATHER_FIELDS(__VA_ARGS__)                                 \
 	}
+#endif
 #endif
 
 /* Anonymous compound literal with 1 member. Legal since C99.

--- a/subsys/tracing/ctf/tsdl/metadata_smp
+++ b/subsys/tracing/ctf/tsdl/metadata_smp
@@ -1,0 +1,1166 @@
+/* CTF 1.8 */
+typealias integer { size = 8; align = 8; signed = true; } := int8_t;
+typealias integer { size = 8; align = 8; signed = false; } := uint8_t;
+typealias integer { size = 16; align = 8; signed = false; } := uint16_t;
+typealias integer { size = 32; align = 8; signed = false; } := uint32_t;
+typealias integer { size = 32; align = 8; signed = true; } := int32_t;
+typealias integer { size = 64; align = 8; signed = false; } := uint64_t;
+typealias integer { size = 8; align = 8; signed = false; encoding = ASCII; } := ctf_bounded_string_t;
+
+struct event_header {
+	uint32_t timestamp;
+	uint8_t id;
+};
+
+trace {
+	major = 1;
+	minor = 8;
+	byte_order = le;
+};
+
+stream {
+	event.header := struct event_header;
+};
+
+event {
+	name = thread_switched_out;
+	id = 0x10;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+	};
+};
+
+event {
+	name = thread_switched_in;
+	id = 0x11;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+	    uint32_t core_id;
+    };
+};
+
+event {
+	name = thread_priority_set;
+	id = 0x12;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+		int8_t prio;
+	    uint32_t core_id;
+    };
+
+};
+
+event {
+	name = thread_create;
+	id = 0x13;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = thread_abort;
+	id = 0x14;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = thread_suspend;
+	id = 0x15;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = thread_resume;
+	id = 0x16;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+event {
+	name = thread_ready;
+	id = 0x17;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+	};
+};
+
+event {
+	name = thread_pending;
+	id = 0x18;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = thread_info;
+	id = 0x19;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+		uint32_t stack_base;
+		uint32_t stack_size;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = thread_name_set;
+	id = 0x1a;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = isr_enter;
+	id = 0x1B;
+	fields := struct {
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = isr_exit;
+	id = 0x1C;
+	fields := struct {
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = isr_exit_to_scheduler;
+	id = 0x1D;
+	fields := struct {
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = idle;
+	id = 0x1E;
+	fields := struct {
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = semaphore_init;
+	id = 0x21;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = semaphore_give_enter;
+	id = 0x22;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = semaphore_give_exit;
+	id = 0x23;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = semaphore_take_enter;
+	id = 0x24;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = semaphore_take_exit;
+	id = 0x26;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+        uint32_t core_id;
+    };
+};
+
+
+event {
+	name = semaphore_take_blocking;
+	id = 0x25;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+        uint32_t core_id;
+    };
+};
+
+
+event {
+	name = semaphore_reset;
+	id = 0x27;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = mutex_init;
+	id = 0x28;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = mutex_lock_enter;
+	id = 0x29;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = mutex_lock_blocking;
+	id = 0x2A;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = mutex_lock_exit;
+	id = 0x2B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = mutex_unlock_enter;
+	id = 0x2C;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = mutex_unlock_exit;
+	id = 0x2D;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = timer_init;
+	id = 0x2E;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = timer_start;
+	id = 0x2F;
+	fields := struct {
+		uint32_t id;
+		uint32_t duration;
+		uint32_t period;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = timer_stop;
+	id = 0x30;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = timer_status_sync_enter;
+	id = 0x31;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = timer_status_sync_blocking;
+	id = 0x32;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = timer_status_sync_exit;
+	id = 0x33;
+	fields := struct {
+		uint32_t id;
+		uint32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = user_mode_enter;
+	id = 0x34;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = thread_wakeup;
+	id = 0x35;
+	fields := struct {
+		uint32_t thread_id;
+		ctf_bounded_string_t name[20];
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_init;
+	id = 0x36;
+	fields := struct {
+		uint32_t id;
+		uint32_t family;
+		uint32_t type;
+		uint32_t proto;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_close_enter;
+	id = 0x37;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_close_exit;
+	id = 0x38;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_shutdown_enter;
+	id = 0x39;
+	fields := struct {
+		uint32_t id;
+		uint32_t how;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_shutdown_exit;
+	id = 0x3A;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_bind_enter;
+	id = 0x3B;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		uint16_t port;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_bind_exit;
+	id = 0x3C;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_connect_enter;
+	id = 0x3D;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_connect_exit;
+	id = 0x3E;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_listen_enter;
+	id = 0x3F;
+	fields := struct {
+		uint32_t id;
+		uint32_t backlog;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_listen_exit;
+	id = 0x40;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_accept_enter;
+	id = 0x41;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_accept_exit;
+	id = 0x42;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		uint16_t port;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_sendto_enter;
+	id = 0x43;
+	fields := struct {
+		uint32_t id;
+		uint32_t data_length;
+		uint32_t flags;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_sendto_exit;
+	id = 0x44;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_sendmsg_enter;
+	id = 0x45;
+	fields := struct {
+		uint32_t id;
+		uint32_t flags;
+		uint32_t msghdr;
+		ctf_bounded_string_t address[46];
+		uint32_t data_length;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_sendmsg_exit;
+	id = 0x46;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_recvfrom_enter;
+	id = 0x47;
+	fields := struct {
+		uint32_t id;
+		uint32_t max_length;
+		uint32_t flags;
+		uint32_t address;
+		uint32_t address_length;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_recvfrom_exit;
+	id = 0x48;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_recvmsg_enter;
+	id = 0x49;
+	fields := struct {
+		uint32_t id;
+		uint32_t msg;
+		uint32_t max_msg_length;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_recvmsg_exit;
+	id = 0x4A;
+	fields := struct {
+		uint32_t id;
+		uint32_t msg_length;
+		ctf_bounded_string_t address[46];
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_fcntl_enter;
+	id = 0x4B;
+	fields := struct {
+		uint32_t id;
+		uint32_t cmd;
+		uint32_t flags;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_fcntl_exit;
+	id = 0x4C;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_ioctl_enter;
+	id = 0x4D;
+	fields := struct {
+		uint32_t id;
+		uint32_t request;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_ioctl_exit;
+	id = 0x4E;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_poll_enter;
+	id = 0x4F;
+	fields := struct {
+		uint32_t fds;
+		uint32_t num_fds;
+		int32_t timeout;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_poll_value;
+	id = 0x50;
+	fields := struct {
+		int32_t fd;
+		uint16_t events;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_poll_exit;
+	id = 0x51;
+	fields := struct {
+		uint32_t fds;
+		uint32_t num_fds;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_getsockopt_enter;
+	id = 0x52;
+	fields := struct {
+		uint32_t id;
+		uint32_t level;
+		uint32_t optname;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_getsockopt_exit;
+	id = 0x53;
+	fields := struct {
+		uint32_t id;
+		uint32_t level;
+		uint32_t optname;
+		uint32_t optval;
+		uint32_t optlen;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_setsockopt_enter;
+	id = 0x54;
+	fields := struct {
+		uint32_t id;
+		uint32_t level;
+		uint32_t optname;
+		uint32_t optval;
+		uint32_t optlen;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_setsockopt_exit;
+	id = 0x55;
+	fields := struct {
+		uint32_t id;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_getpeername_enter;
+	id = 0x56;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_getpeername_exit;
+	id = 0x57;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_getsockname_enter;
+	id = 0x58;
+	fields := struct {
+		uint32_t id;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_getsockname_exit;
+	id = 0x59;
+	fields := struct {
+		uint32_t id;
+		ctf_bounded_string_t address[46];
+		uint32_t address_length;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_socketpair_enter;
+	id = 0x5A;
+	fields := struct {
+		uint32_t family;
+		uint32_t type;
+		uint32_t proto;
+		uint32_t sv;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = socket_socketpair_exit;
+	id = 0x5B;
+	fields := struct {
+		int32_t socket0;
+		int32_t socket1;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = net_recv_data_enter;
+	id = 0x5C;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t pkt_len;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = net_recv_data_exit;
+	id = 0x5D;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = net_send_data_enter;
+	id = 0x5E;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t pkt_len;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = net_send_data_exit;
+	id = 0x5F;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		int32_t result;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = net_rx_time;
+	id = 0x60;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t priority;
+		uint32_t traffic_class;
+		uint32_t duration_us;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = net_tx_time;
+	id = 0x61;
+	fields := struct {
+		int32_t if_index;
+		uint32_t iface;
+		uint32_t pkt;
+		uint32_t priority;
+		uint32_t traffic_class;
+		uint32_t duration_us;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = named_event;
+	id = 0x62;
+	fields := struct {
+		ctf_bounded_string_t name[20];
+		uint32_t arg0;
+		uint32_t arg1;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = gpio_pin_configure_interrupt_enter;
+	id = 0x63;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t flags;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = gpio_pin_configure_interrupt_exit;
+	id = 0x64;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = gpio_pin_configure_enter;
+	id = 0x65;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t flags;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = gpio_pin_configure_exit;
+	id = 0x66;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = gpio_port_get_direction_enter;
+	id = 0x67;
+	fields := struct {
+		uint32_t port;
+		uint32_t map;
+		uint32_t inputs;
+		uint32_t outputs;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = gpio_port_get_direction_exit;
+	id = 0x68;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name = gpio_pin_get_config_enter;
+	id = 0x69;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_pin_get_config_exit;
+	id = 0x6A;
+	fields := struct {
+		uint32_t port;
+		uint32_t pin;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_get_raw_enter;
+	id = 0x6B;
+	fields := struct {
+		uint32_t port;
+		uint32_t value;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_get_raw_exit;
+	id = 0x6C;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_set_masked_raw_enter;
+	id = 0x6D;
+	fields := struct {
+		uint32_t port;
+		uint32_t mask;
+		uint32_t value;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_set_masked_raw_exit;
+	id = 0x6E;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_set_bits_raw_enter;
+	id = 0x6F;
+	fields := struct {
+		uint32_t port;
+		uint32_t pins;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_set_bits_raw_exit;
+	id = 0x70;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_clear_bits_raw_enter;
+	id = 0x71;
+	fields := struct {
+		uint32_t port;
+		uint32_t pins;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_clear_bits_raw_exit;
+	id = 0x72;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_toggle_bits_enter;
+	id = 0x73;
+	fields := struct {
+		uint32_t port;
+		uint32_t pins;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_port_toggle_bits_exit;
+	id = 0x74;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_init_callback_enter;
+	id = 0x75;
+	fields := struct {
+		uint32_t callback;
+		uint32_t handler;
+		uint32_t pin_mask;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_init_callback_exit;
+	id = 0x76;
+	fields := struct {
+		uint32_t callback;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_add_callback_enter;
+	id = 0x77;
+	fields := struct {
+		uint32_t port;
+		uint32_t callback;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_add_callback_exit;
+	id = 0x78;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_remove_callback_enter;
+	id = 0x79;
+	fields := struct {
+		uint32_t port;
+		uint32_t callback;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_remove_callback_exit;
+	id = 0x7A;
+	fields := struct {
+		uint32_t port;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_get_pending_int_enter;
+	id = 0x7B;
+	fields := struct {
+		uint32_t dev;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_get_pending_int_exit;
+	id = 0x7C;
+	fields := struct {
+		uint32_t dev;
+		uint32_t ret;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_fire_callbacks_enter;
+	id = 0x7D;
+	fields := struct {
+		uint32_t list;
+		uint32_t port;
+		uint32_t pins;
+        uint32_t core_id;
+    };
+};
+
+event {
+	name =  gpio_fire_callback;
+	id = 0x7E;
+	fields := struct {
+		uint32_t port;
+		uint32_t cb;
+        uint32_t core_id;
+    };
+};


### PR DESCRIPTION
Add core_id record into CTF trace and modify the metadata to the new file tsdl/metadata_smp as needed.