### PR TITLE
(backport v3.7) modules: mbedtls: update to 3.6.3

### DIFF
--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -9,11 +9,34 @@ Zephyr 3.7.2
 
 This is an LTS maintenance release with fixes.
 
+Security Vulnerability Related
+******************************
+
+The following CVEs are addressed by this release:
+
+* `CVE-2025-27809 <https://www.cve.org/CVERecord?id=CVE-2025-27809>`_
+  `TLS clients may unwittingly skip server authentication
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/>`_
+* `CVE-2025-27810 <https://www.cve.org/CVERecord?id=CVE-2025-27810>`_
+  `Potential authentication bypass in TLS handshake
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-2/>`_
+
+More detailed information can be found in:
+https://docs.zephyrproject.org/latest/security/vulnerabilities.html
+
 Issues fixed
 ************
 
 These GitHub issues were addressed since the previous 3.7.1 tagged release:
 
+Mbed TLS
+********
+
+Mbed TLS was updated to version 3.6.3 (from 3.6.2). The release notes can be found at:
+https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3
+
+Mbed TLS 3.6 is an LTS release that will be supported
+with security and bug fixes until at least March 2027.
 
 .. _zephyr_3.7.1:
 

--- a/doc/releases/release-notes-3.7.rst
+++ b/doc/releases/release-notes-3.7.rst
@@ -2,6 +2,19 @@
 
 .. _zephyr_3.7:
 
+.. _zephyr_3.7.2:
+
+Zephyr 3.7.2
+############
+
+This is an LTS maintenance release with fixes.
+
+Issues fixed
+************
+
+These GitHub issues were addressed since the previous 3.7.1 tagged release:
+
+
 .. _zephyr_3.7.1:
 
 Zephyr 3.7.1

--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: a78176c6ff0733ba08018cba4447bd3f20de7978
+      revision: 5f889934359deccf421554c7045a8381ef75298f
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
Backport the Mbed TLS 3.6.3 update to the v3.7 branch.

Fixes #88229