### PR TITLE
tests: logging: logging.thread: fix Ztest log corruption

### DIFF
--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -278,7 +278,7 @@ ZTEST(test_log_core_additional, test_log_early_logging)
 		LOG_WRN("log warn before backend active");
 		LOG_ERR("log error before backend active");
 
-		TC_PRINT("Activate backend with context");
+		TC_PRINT("Activate backend with context\n");
 		memset(&backend1_cb, 0, sizeof(backend1_cb));
 		backend1_cb.total_logs = 3;
 		log_backend_enable(&backend1, &backend1_cb, LOG_LEVEL_DBG);
@@ -382,7 +382,7 @@ ZTEST(test_log_core_additional, test_multiple_backends)
 {
 	int cnt;
 
-	TC_PRINT("Test multiple backends");
+	TC_PRINT("Test multiple backends\n");
 	/* enable both backend1 and backend2 */
 	log_setup(true);
 	STRUCT_SECTION_COUNT(log_backend, &cnt);

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -171,6 +171,7 @@ static void log_setup(bool backend2_enable)
 static bool log_test_process(void)
 {
 	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
+		log_flush();
 		/* waiting for all logs have been handled */
 		k_sem_take(&log_sem, K_FOREVER);
 		return false;

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) 2020-2025 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -95,13 +95,6 @@ static void process(const struct log_backend *const backend,
 			      "Unexpected log severity");
 	}
 
-	cb->counter++;
-	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
-		if (cb->counter == cb->total_logs) {
-			k_sem_give(&log_sem);
-		}
-	}
-
 	if (k_is_user_context()) {
 		zassert_equal(log_msg_get_domain(&(msg->log)), domain,
 				"Unexpected domain id");
@@ -112,6 +105,13 @@ static void process(const struct log_backend *const backend,
 
 	flags = log_backend_std_get_flags();
 	log_output_msg_process(&log_output, &msg->log, flags);
+
+	cb->counter++;
+	if (IS_ENABLED(CONFIG_LOG_PROCESS_THREAD)) {
+		if (cb->counter == cb->total_logs) {
+			k_sem_give(&log_sem);
+		}
+	}
 }
 
 static void panic(const struct log_backend *const backend)


### PR DESCRIPTION
Fix race condition and Ztest log corruptions in `tests/subsys/logging/log_core_additional` test suite's `logging.thread` test configuration.

Fixes #87625 (partially, for this test suite).

For example, before:
```
twister - DEBUG - DEVICE: PASS - test_log_domain_id in 0[00:00:00.701,000] <inf> log_test: info message for domain id test
twister - DEBUG - DEVICE: .201 seconds
...
twister - DEBUG - DEVICE: Activate backend with context PASS - test_log_early_logging in 0.001 seconds
```
 after
```
twister - DEBUG - DEVICE: START - test_log_domain_id
twister - DEBUG - DEVICE: [00:00:00.701,000] <inf> log_test: info message for domain id test
twister - DEBUG - DEVICE: PASS - test_log_domain_id in 0.011 seconds
...
twister - DEBUG - DEVICE: Activate backend with context
twister - DEBUG - DEVICE: PASS - test_log_early_logging in 0.011 seconds
```
