### PR TITLE
drivers: ethernet: support for numaker m55m1x series

### DIFF
--- a/boards/nuvoton/numaker_m55m1/Kconfig.defconfig
+++ b/boards/nuvoton/numaker_m55m1/Kconfig.defconfig
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Nuvoton NuMaker M55M1 board configuration
+#
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+
+if BOARD_NUMAKER_M55M1
+
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y if !MODEM
+
+endif # NETWORKING
+
+endif # BOARD_NUMAKER_M55M1

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
@@ -24,4 +24,23 @@
 				 <PC9MFP_GPIO>;
 		};
 	};
+
+	/* EMAC multi-function pins for MDIO, TX, REFCLK, RX pins */
+	emac_default: emac_default {
+		group0 {
+			pinmux = <PE8MFP_EMAC0_RMII_MDC>,
+				 <PE9MFP_EMAC0_RMII_MDIO>,
+				 <PC8MFP_EMAC0_RMII_REFCLK>,
+				 <PC7MFP_EMAC0_RMII_RXD0>,
+				 <PC6MFP_EMAC0_RMII_RXD1>,
+				 <PA7MFP_EMAC0_RMII_CRSDV>,
+				 <PA6MFP_EMAC0_RMII_RXERR>;
+		};
+		group1 {
+			pinmux = <PE10MFP_EMAC0_RMII_TXD0>,
+				 <PE11MFP_EMAC0_RMII_TXD1>,
+				 <PE12MFP_EMAC0_RMII_TXEN>;
+				 slew-rate = "fast";
+		};
+	};
 };

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
@@ -86,3 +86,9 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&emac {
+	pinctrl-0 = <&emac_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -133,6 +133,9 @@ Ethernet
   kconfig options: :kconfig:option:`CONFIG_ETH_NATIVE_POSIX` and its related options have been
   deprecated in favor of :kconfig:option:`CONFIG_ETH_NATIVE_TAP` (:github:`86578`).
 
+* NuMaker Ethernet driver ``eth_numaker.c`` now supports ``gen_random_mac``,
+  and the EMAC data flash feature has been removed (:github:`87953`).
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/drivers/ethernet/Kconfig.numaker
+++ b/drivers/ethernet/Kconfig.numaker
@@ -9,6 +9,7 @@ config ETH_NUMAKER
 	select HAS_NUMAKER_ETH
 	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_ETHERNET_ENABLED
+	select NOCACHE_MEMORY if ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	help
 	  This option enables the Ethernet driver for Nuvoton NuMaker family of
 	  processors.

--- a/drivers/ethernet/eth_numaker_priv.h
+++ b/drivers/ethernet/eth_numaker_priv.h
@@ -15,4 +15,9 @@
 
 #define NU_ETH_MTU_SIZE              1500
 
+/* NuMaker chip's OUI*/
+#define NUMAKER_OUI_B0 0xDA
+#define NUMAKER_OUI_B1 0x00
+#define NUMAKER_OUI_B2 0x53
+
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_NUMAKER_PRIV_H_ */

--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -335,6 +335,16 @@
 			#size-cells = <0>;
 			status = "disabled";
 		};
+
+		emac: ethernet@40208000 {
+			compatible = "nuvoton,numaker-ethernet";
+			reg = <0x40208000 0x2000>;
+			interrupts = <63 0>;
+			resets = <&rst NUMAKER_SYS_EMAC0RST>;
+			phy-addr = <0>;
+			clocks = <&pcc NUMAKER_EMAC0_MODULE 0 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       groups:
         - hal
     - name: hal_nuvoton
-      revision: 8eec051270fe45c3f9a1a12de60220e1ab26b579
+      revision: be1042dc8a96ebe9ea4c5d714f07c617539106d6
       path: modules/hal/nuvoton
       groups:
         - hal


### PR DESCRIPTION
Add support for Nuvoton numaker m55m1x series EMAC controller. Also include NOCACHE_MEMORY allocation.