### PR TITLE
dts: dma: Simplify the description of the binding

### DIFF
--- a/dts/bindings/dma/infineon,cat1-dma.yaml
+++ b/dts/bindings/dma/infineon,cat1-dma.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-description: Infineon CAT1 DMA node
+description: Infineon CAT1 DMA
 
 compatible: "infineon,cat1-dma"
 

--- a/dts/bindings/dma/intel,adsp-gpdma.yaml
+++ b/dts/bindings/dma/intel,adsp-gpdma.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Intel ADSP Designware based General Purpose DMA Controller node
+description: Intel ADSP Designware based General Purpose DMA Controller
 
 compatible: "intel,adsp-gpdma"
 

--- a/dts/bindings/dma/intel,lpss.yaml
+++ b/dts/bindings/dma/intel,lpss.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: LPSS DMA Controller node
+description: LPSS DMA Controller
 
 compatible: "intel,lpss"
 

--- a/dts/bindings/dma/nxp,edma.yaml
+++ b/dts/bindings/dma/nxp,edma.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP enhanced Direct Memory Access (eDMA) node
+description: NXP enhanced Direct Memory Access (eDMA)
 
 compatible: "nxp,edma"
 

--- a/dts/bindings/dma/nxp,sdma.yaml
+++ b/dts/bindings/dma/nxp,sdma.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP SDMA node
+description: NXP SDMA
 
 compatible: "nxp,sdma"
 

--- a/dts/bindings/dma/nxp,sof-host-dma.yaml
+++ b/dts/bindings/dma/nxp,sof-host-dma.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: NXP SOF host DMA node
+description: NXP SOF host DMA
 
 compatible: "nxp,sof-host-dma"
 

--- a/dts/bindings/dma/silabs,siwx91x-dma.yaml
+++ b/dts/bindings/dma/silabs,siwx91x-dma.yaml
@@ -1,4 +1,4 @@
-description: Silabs SiWx91x DMA node
+description: Silabs SiWx91x DMA
 
 compatible: "silabs,siwx91x-dma"
 

--- a/dts/bindings/dma/snps,designware-dma-axi.yaml
+++ b/dts/bindings/dma/snps,designware-dma-axi.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Synopsys Designware axi DMA Controller node
+description: Synopsys Designware axi DMA Controller
 
 compatible: "snps,designware-dma-axi"
 

--- a/dts/bindings/dma/snps,designware-dma.yaml
+++ b/dts/bindings/dma/snps,designware-dma.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Synopsys Designware DMA Controller node
+description: Synopsys Designware DMA Controller
 
 compatible: "snps,designware-dma"
 


### PR DESCRIPTION
Remove redundant descriptions in DMA bindings, such as "... node".