### PR TITLE
manifest: update libmetal to pull cmake min version update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -282,7 +282,7 @@ manifest:
       revision: b97860e78998551af99931ece149eeffc538bdb1
       path: modules/lib/libmctp
     - name: libmetal
-      revision: 3e8781aae9d7285203118c05bc01d4eb0ca565a7
+      revision: pull/28/head
       path: modules/hal/libmetal
       groups:
         - hal


### PR DESCRIPTION
libmetal has a really old cmake_minimum_required version which makes it error out on CMake 4.0 -- pull in module change that sets min version to 3.20 like many other places in Zephyr