### PR TITLE
dts: bindings: spi: Fix "nordic,nrf-spis" binding

### DIFF
--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -3,7 +3,9 @@
 
 # Common fields for Nordic nRF family SPI peripherals
 
-include: [spi-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
+include:
+  - pinctrl-device.yaml
+  - nordic-clockpin.yaml
 
 properties:
   reg:
@@ -26,8 +28,11 @@ properties:
       property must be set at SoC level DTS files.
 
   overrun-character:
+    type: int
     default: 0xff
     description: |
+      The overrun character (ORC) is used when all bytes from the TX buffer
+      are sent, but the transfer continues due to RX.
       Configurable, defaults to 0xff (line high), the most common value used
       in SPI transfers.
 

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -5,4 +5,6 @@ description: Nordic nRF family SPI (SPI master)
 
 compatible: "nordic,nrf-spi"
 
-include: nordic,nrf-spi-common.yaml
+include:
+  - spi-controller.yaml
+  - nordic,nrf-spi-common.yaml

--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -5,7 +5,10 @@ description: Nordic nRF family SPIM (SPI master with EasyDMA)
 
 compatible: "nordic,nrf-spim"
 
-include: ["nordic,nrf-spi-common.yaml", "memory-region.yaml"]
+include:
+  - spi-controller.yaml
+  - nordic,nrf-spi-common.yaml
+  - memory-region.yaml
 
 properties:
   anomaly-58-workaround:

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -5,7 +5,10 @@ description: Nordic nRF family SPIS (SPI slave with EasyDMA)
 
 compatible: "nordic,nrf-spis"
 
-include: ["nordic,nrf-spi-common.yaml", "memory-region.yaml"]
+include:
+  - base.yaml
+  - nordic,nrf-spi-common.yaml
+  - memory-region.yaml
 
 properties:
   def-char:


### PR DESCRIPTION
The nRF SPIS peripheral is not an SPI controller but an SPI target device, so its binding should not include "spi-controller.yaml" (and so far it did, through "nordic,nrf-spi-common.yaml"). Fix this so that it is no longer possible to incorrectly add child DT nodes as "devices" on the SPIS "bus" and then for example misuse the SPI_CONFIG_DT() macro for such constructs.

Since this requires a small correction in the "overrun-character" property in "nordic,nrf-spi-common.yaml", improve also its description by adding there information from the corresponding property from "spi-controller.yaml".