### PR TITLE
soc: renesas: rz: Fix loader program

### DIFF
--- a/soc/renesas/rz/common/loader_program.S
+++ b/soc/renesas/rz/common/loader_program.S
@@ -7,9 +7,10 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/linker/sections.h>
 
+/* Require CONFIG_XIP=n */
 #define ROM_START	(CONFIG_FLASH_BASE_ADDRESS + DT_REG_ADDR(DT_CHOSEN(zephyr_code_partition)))
-#define RAM_START	_image_ram_start // Require CONFIG_XIP=n
-#define APP_SIZE	_image_ram_size
+#define RAM_START	CONFIG_SRAM_BASE_ADDRESS
+#define APP_SIZE	_flash_used
 
 _ASM_FILE_PROLOGUE
 


### PR DESCRIPTION
Due to a change in linker script cortex_a_r/scripts/linker.ld , the _image_ram_start has been changed so the Renesas loader program cannot copy the Zephyr image from flash to ram as expected and cannot run properly on RZ/T2L and RZ/N2L.

It is replaced by CONFIG_SRAM_BASE_ADDRESS, the _image_ram_size is also replaced by _flash_used as a preventive measure.