### PR TITLE
twister: testplan: raise error on unknown test level

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -410,8 +410,9 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
     )
 
     parser.add_argument("--level", action="store",
-        help="Test level to be used. By default, no levels are used for filtering "
-             "and do the selection based on existing filters.")
+        help="Test level defined in --test-config to choose. "
+             "By default, test level is not used for filtering "
+             "and test selection is based on other filters.")
 
     parser.add_argument(
         "--device-serial-baud", action="store", default=None,

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -163,9 +163,9 @@ class TestPlan:
             inherit = level.get('inherits', [])
             _level = self.get_level(level['name'])
             if inherit:
-                for inherted_level in inherit:
-                    _inherited = self.get_level(inherted_level)
-                    assert _inherited, "Unknown inherited level {inherted_level}"
+                for inherited_level in inherit:
+                    _inherited = self.get_level(inherited_level)
+                    assert _inherited, "Unknown inherited level {inherited_level}"
                     _inherited_scenarios = _inherited.scenarios
                     level_scenarios = _level.scenarios if _level else []
                     level_scenarios.extend(_inherited_scenarios)

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # vim: set syntax=python ts=4 :
 #
-# Copyright (c) 2018-2024 Intel Corporation
+# Copyright (c) 2018-2025 Intel Corporation
 # Copyright (c) 2024 Arm Limited (or its affiliates). All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -856,10 +856,7 @@ class TestPlan:
                 if self.options.level:
                     tl = self.get_level(self.options.level)
                     if tl is None:
-                        instance.add_filter(
-                            f"Unknown test level '{self.options.level}'",
-                            Filters.TESTPLAN
-                        )
+                        raise TwisterRuntimeError(f"Unknown test level '{self.options.level}'")
                     else:
                         planned_scenarios = tl.scenarios
                         if (

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -112,7 +112,6 @@ TESTDATA_PART1 = [
     ("min_ram", "500", "ram", "256", "Not enough RAM"),
     ("None", "None", "env", ['BSIM_OUT_PATH', 'demo_env'], "Environment (BSIM_OUT_PATH, demo_env) not satisfied"),
     ("build_on_all", True, None, None, "Platform is excluded on command line."),
-    ("build_on_all", True, "level", "foobar", "Unknown test level 'foobar'"),
     (None, None, "supported_toolchains", ['gcc', 'xcc', 'xt-clang'], "Not supported by the toolchain"),
 ]
 


### PR DESCRIPTION
Twister TestPlan to stop and raise error if test level given at the command line (`--level`) is not found in the currently processed test plan. Without that, the missing (or mistyped) test level will make test configurations filtered out almost silently, with just debug log.