### PR TITLE
cmake: fix Zephyr module ext order

### DIFF
--- a/cmake/modules/zephyr_module.cmake
+++ b/cmake/modules/zephyr_module.cmake
@@ -85,9 +85,6 @@ if(WEST OR ZEPHYR_MODULES)
     endforeach()
   endif()
 
-  # Append ZEPHYR_BASE as a default ext root at lowest priority
-  list(APPEND MODULE_EXT_ROOT ${ZEPHYR_BASE})
-
   if(EXISTS ${cmake_modules_file})
     file(STRINGS ${cmake_modules_file} zephyr_modules_txt ENCODING UTF-8)
   endif()
@@ -114,9 +111,12 @@ if(WEST OR ZEPHYR_MODULES)
     list(APPEND SYSBUILD_MODULE_NAMES ${module_name})
   endforeach()
 
+  # Prepend ZEPHYR_BASE as a default ext root at lowest priority
+  list(PREPEND MODULE_EXT_ROOT ${ZEPHYR_BASE})
+
   # MODULE_EXT_ROOT is process order which means Zephyr module roots processed
-  # later wins. therefore we reverse the list before processing.
-  list(REVERSE MODULE_EXT_ROOT)
+  # later wins. Thus processing Zephyr first, and modules thereafter allows them
+  # to overrule default glue folder settings provided by higher level modules.cmake.
   foreach(root ${MODULE_EXT_ROOT})
     set(module_cmake_file_path modules/modules.cmake)
     if(NOT EXISTS ${root}/${module_cmake_file_path})


### PR DESCRIPTION
MODULE_EXT_ROOT allows Zephyr modules to provide glue code for Zephyr modules using `cmake-ext: True` and/or `kconfig-ext:True`.

A module ext root provides a `modules.cmake` file which defines variables like: `set(ZEPHYR_FOO_CMAKE_DIR  <glue-code-path>/foo)`

It is intended that a downstream module can replace Zephyr's default glue code, which again can be replaced further downstream.

Setting values in first modules.cmake (Zephyr's) are replaced by later processed modules.cmake (downstream) when the setting name is identical.

Therefore the module ext root list should not be reversed, and Zephyr itself should be placed as first entry in the list.