### PR TITLE
manifest: update hal_nordic revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 7440d573d36953b80cb6fb6438b147acb21bf753
+      revision: pull/287/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
The hal_nordic was updated to bring the new open source revision of the nrf-802154 radio driver.