### PR TITLE
drivers: ieee802154: nrf5: new RX window cancels previous RX 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 7440d573d36953b80cb6fb6438b147acb21bf753
+      revision: pull/287/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
According to the documentation of IEEE802154_CONFIG_RX_SLOT,
if the previous RX slot hasn't begun yet, but a new one is scheduled,
then the previous RX slot must be cancelled. The new RX slot effectively
replaces the old one.

If the previous slot is currently ongoing, then it is not affected. The
new RX slot can be scheduled while the previous slot is still ongoing.