### PR TITLE
soc: Add support for STM32F479

### DIFF
--- a/dts/arm/st/f4/stm32f479.dtsi
+++ b/dts/arm/st/f4/stm32f479.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2025 Christopher Cichiwskyj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/f4/stm32f469.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32f479", "st,stm32f4", "simple-bus";
+
+		cryp: cryp@50060000 {
+			compatible = "st,stm32-cryp";
+			reg = <0x50060000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
+			interrupts = <79 0>;
+			status = "disabled";
+		};
+	};
+};

--- a/dts/arm/st/f4/stm32f479Xi.dtsi
+++ b/dts/arm/st/f4/stm32f479Xi.dtsi
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Christopher Cichiwskyj
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/f4/stm32f479.dtsi>
+
+/ {
+	ccm0: memory@10000000 {
+		compatible = "zephyr,memory-region", "st,stm32-ccm";
+		reg = <0x10000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "CCM";
+	};
+
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(320)>;
+	};
+
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(2048)>;
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -62,6 +62,7 @@ family:
     - name: stm32f439xx
     - name: stm32f446xx
     - name: stm32f469xx
+    - name: stm32f479xx
   - name: stm32f7x
     socs:
     - name: stm32f722xx

--- a/soc/st/stm32/stm32f4x/Kconfig.defconfig.stm32f479xx
+++ b/soc/st/stm32/stm32f4x/Kconfig.defconfig.stm32f479xx
@@ -1,0 +1,11 @@
+# ST STM32F479XI MCU configuration options
+
+# Copyright (c) 2025 Christopher Cichiwskyj
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F479XX
+
+config NUM_IRQS
+	default 93
+
+endif # SOC_STM32F479XX

--- a/soc/st/stm32/stm32f4x/Kconfig.soc
+++ b/soc/st/stm32/stm32f4x/Kconfig.soc
@@ -94,6 +94,10 @@ config SOC_STM32F469XX
 	bool
 	select SOC_SERIES_STM32F4X
 
+config SOC_STM32F479XX
+	bool
+	select SOC_SERIES_STM32F4X
+
 config SOC
 	default "stm32f401xc" if SOC_STM32F401XC
 	default "stm32f401xe" if SOC_STM32F401XE
@@ -116,3 +120,4 @@ config SOC
 	default "stm32f439xx" if SOC_STM32F439XX
 	default "stm32f446xx" if SOC_STM32F446XX
 	default "stm32f469xx" if SOC_STM32F469XX
+	default "stm32f479xx" if SOC_STM32F479XX


### PR DESCRIPTION
Added base files and descriptions for the SoC addressed in Issue #83899.