### PR TITLE
boards: native_sim: add reboot for native sim

### DIFF
--- a/boards/native/native_sim/CMakeLists.txt
+++ b/boards/native/native_sim/CMakeLists.txt
@@ -13,6 +13,15 @@ zephyr_library_sources(
 	posix_arch_if.c
 	)
 
+if(CONFIG_NATIVE_SIM_REBOOT)
+  zephyr_library_sources(reboot.c)
+  if(CONFIG_NATIVE_LIBRARY)
+    target_sources(native_simulator INTERFACE reboot_bottom.c)
+  else()
+    zephyr_library_sources(reboot_bottom.c)
+  endif()
+endif()
+
 zephyr_include_directories(
   ${NSI_DIR}/common/src/include
   ${NSI_DIR}/native/src/include

--- a/boards/native/native_sim/Kconfig
+++ b/boards/native/native_sim/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2023 Nordic Semiconductor ASA
+# Copyright (c) 2025 GARDENA GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_NATIVE_SIM
@@ -49,6 +50,12 @@ config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	help
 	  Transitional option which allows applications which targeted native_posix
 	  to set the correct native_sim option (CONFIG_NATIVE_SIM_SLOWDOWN_TO_REAL_TIME)
+
+config NATIVE_SIM_REBOOT
+	bool "Reboot support"
+	depends on REBOOT
+	help
+	  Enables the reboot implementation for the native sim executable.
 
 source "boards/native/common/sdl/Kconfig"
 source "boards/native/common/extra_args/Kconfig"

--- a/boards/native/native_sim/reboot.c
+++ b/boards/native/native_sim/reboot.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 GARDENA GmbH
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "reboot_bottom.h"
+#include "posix_board_if.h"
+
+void sys_arch_reboot(int type)
+{
+	(void)type;
+	native_set_reboot_on_exit();
+	posix_exit(0);
+}

--- a/boards/native/native_sim/reboot_bottom.c
+++ b/boards/native/native_sim/reboot_bottom.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 GARDENA GmbH
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <nsi_main.h>
+#include <nsi_tasks.h>
+#include <nsi_tracing.h>
+#include <nsi_cmdline.h>
+
+static const char module[] = "native_sim_reboot";
+
+static long close_open_fds(void)
+{
+	/* close all open file descriptors except 0-2 */
+	errno = 0;
+
+	long max_fd = sysconf(_SC_OPEN_MAX);
+
+	if (max_fd < 0) {
+		if (errno != 0) {
+			nsi_print_error_and_exit("%s: %s\n", module, strerror(errno));
+		} else {
+			nsi_print_warning("%s: Cannot determine maximum number of file descriptors"
+					  "\n",
+					  module);
+		}
+		return max_fd;
+	}
+	for (int fd = 3; fd < max_fd; fd++) {
+		(void)close(fd);
+	}
+	return 0;
+}
+
+static bool reboot_on_exit;
+
+void native_set_reboot_on_exit(void)
+{
+	reboot_on_exit = true;
+}
+
+void maybe_reboot(void)
+{
+	char **argv;
+	int argc;
+
+	if (!reboot_on_exit) {
+		return;
+	}
+
+	reboot_on_exit = false; /* If we reenter it means we failed to reboot */
+
+	nsi_get_cmd_line_args(&argc, &argv);
+
+	if (close_open_fds() < 0) {
+		nsi_exit(1);
+	}
+
+	nsi_print_warning("%s: Restarting process.\n", module);
+
+	(void)execv("/proc/self/exe", argv);
+
+	nsi_print_error_and_exit("%s: Failed to restart process, exiting (%s)\n", module,
+				 strerror(errno));
+}
+
+NSI_TASK(maybe_reboot, ON_EXIT_POST, 999);

--- a/boards/native/native_sim/reboot_bottom.h
+++ b/boards/native/native_sim/reboot_bottom.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 GARDENA GmbH
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef BOARDS_NATIVE_NATIVE_SIM_REBOOT_BOTTOM_H
+#define BOARDS_NATIVE_NATIVE_SIM_REBOOT_BOTTOM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void native_set_reboot_on_exit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARDS_NATIVE_NATIVE_SIM_REBOOT_BOTTOM_H */


### PR DESCRIPTION
Add a reboot implementation for the native sim which restarts the current executable keeping the command line arguments after closing all open file descriptors.

Test it for example with: `west build -p -b native_sim samples/subsys/shell/shell_module -t run -DCONFIG_REBOOT=y -DCONFIG_POSIX_API=n` and then enter in the zephyr shell `kernel reboot`.

Note: The pseudotty disconnects while the application restarts.

I could not get it working with CONFIG_POSIX_API enabled.

Probably only works on Linux because it relies on the proc filesystem.