### PR TITLE
drivers: current_sense: add offset binding

### DIFF
--- a/drivers/sensor/current_amp/current_amp.c
+++ b/drivers/sensor/current_amp/current_amp.c
@@ -173,6 +173,10 @@ static int current_init(const struct device *dev)
                                                                                                    \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, &current_init, PM_DEVICE_DT_INST_GET(inst),             \
 				     &current_amp_##inst##_data, &current_amp_##inst##_config,     \
-				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &current_api);
+				     POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &current_api);      \
+                                                                                                   \
+	BUILD_ASSERT((DT_INST_PROP(inst, zero_current_voltage_mv) == 0) ||                         \
+			     (DT_INST_PROP(inst, sense_resistor_milli_ohms) == 1),                 \
+		     "zero_current_voltage_mv requires sense_resistor_milli_ohms == 1");
 
 DT_INST_FOREACH_STATUS_OKAY(CURRENT_SENSE_AMPLIFIER_INIT)

--- a/dts/bindings/iio/afe/current-sense-amplifier.yaml
+++ b/dts/bindings/iio/afe/current-sense-amplifier.yaml
@@ -38,6 +38,18 @@ properties:
     description: |
       Amplifier gain divider. The default is <1>. The maximum value is <65535>.
 
+  zero-current-voltage-mv:
+    type: int
+    default: 0
+    description: |
+      The zero-current voltage in millivolts. Defaults to <0>, with a range of <-32768> to <32767>.
+
+      Some current sense amplifiers output a voltage proportional to current, independent of a
+      current sense resistor (e.g., Hall-effect current sensors). These sensors often have a
+      nonzero offset voltage that corresponds to zero current.
+
+      To use this binding with such sensors, `sense-resistor-milli-ohms` should be set to 1.
+
   power-gpios:
     type: phandle-array
     description: |

--- a/include/zephyr/drivers/adc/current_sense_amplifier.h
+++ b/include/zephyr/drivers/adc/current_sense_amplifier.h
@@ -17,6 +17,7 @@ struct current_sense_amplifier_dt_spec {
 	uint16_t sense_gain_mult;
 	uint16_t sense_gain_div;
 	uint16_t noise_threshold;
+	int16_t zero_current_voltage_mv;
 	bool enable_calibration;
 };
 
@@ -38,6 +39,7 @@ struct current_sense_amplifier_dt_spec {
 		.sense_gain_mult = DT_PROP(node_id, sense_gain_mult),                              \
 		.sense_gain_div = DT_PROP(node_id, sense_gain_div),                                \
 		.noise_threshold = DT_PROP(node_id, zephyr_noise_threshold),                       \
+		.zero_current_voltage_mv = DT_PROP(node_id, zero_current_voltage_mv),              \
 		.enable_calibration = DT_PROP_OR(node_id, enable_calibration, false),              \
 	}
 
@@ -58,6 +60,7 @@ current_sense_amplifier_scale_dt(const struct current_sense_amplifier_dt_spec *s
 	/* (INT32_MAX * 1000 * UINT16_MAX) < INT64_MAX
 	 * Therefore all multiplications can be done before divisions, preserving resolution.
 	 */
+	tmp = tmp - spec->zero_current_voltage_mv;
 	tmp = tmp * 1000 * spec->sense_gain_div / spec->sense_milli_ohms / spec->sense_gain_mult;
 
 	*v_to_i = (int32_t)tmp;

--- a/tests/drivers/adc/adc_rescale/boards/native_sim.overlay
+++ b/tests/drivers/adc/adc_rescale/boards/native_sim.overlay
@@ -27,6 +27,14 @@
 		sense-gain-mult = <100>;
 	};
 
+	sensor3: tmcs1108A2B {
+		compatible = "current-sense-amplifier";
+		io-channels = <&adc0 2>;
+		sense-resistor-milli-ohms = <1>;
+		sense-gain-mult = <100>;
+		zero-current-voltage-mv = <1650>;
+	};
+
 	adc0: adc {
 		compatible = "zephyr,adc-emul";
 		nchannels = <3>;

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -34,6 +34,7 @@ test_current: current_amp {
 	sense-resistor-milli-ohms = <1>;
 	sense-gain-mult = <1>;
 	sense-gain-div = <1>;
+	zero-current-voltage-mv = <0>;
 };
 
 test_composite_fuel_gauge: composite_fuel_gauge {


### PR DESCRIPTION
some current sense amplifiers have a non zero offset voltage
that correlates to zero current. adding this offset voltage binding
allows the driver to be used with this type of circuitry.

Signed-off-by: Brandon Allen <brandon.allen@exacttechnology.com>
