### PR TITLE
Update Rust to 'main' since 4.1

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: d4f9036a88e53080bf2b186afa5289f9c77a0f73
+      revision: pull/94/head
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
Bring in the following changes to the Rust module, updating since the rev 4.1.  This includes the ci fix that was included in v4.1-branch.

22b81389b4b Add rust-toolchain file
349164d630a samples: blinky: Remove incorrect integration platform b0866632d42 samples/tests: Ensure test/sample names are unique 7395ae4f486 zephyr-build: fix DTS parser for Windows a341bc50041 samples: philosophers: Migrate Mutex to const constructor 5000f459f26 samples: bench: Clean up formatting
6020ab7db36 zephyr: Run rustfmt
c1d74e1d5df samples: bench: Make Semaphores static 37754d29e0b samples: bench: Reduce benchmark iterations 11067823e53 samples: bench: Remove the 'basesem' prototype 3a4f08ba1ea zepyr: sys: sync: Mutex/Condvar
64605eb89cf samples: bench: fix for API change
8d7ca493801 zephyr: Convert `Queue` to new atomic initializer up 3a0016dace2 zephyr: sys: sync: Make Semaphore constructors `const` 5ceccc155c2 zephyr: object: Implement new ZephyrObject wrapper 2790674bb7f docgen: Enable async features for doc generation 1b475b7a9a8 tests: drivers: gpio-async: Test the async gpio operations 0347eac6882 zephyr: Add async 'wait_for_high' and 'wait_for_low' to gpio b60408c54ef zephyr: device: Add a possible static element with each device 28f7ec6b515 zephyr: device: gpio: Add a few more methods bcc9ee433bd zephyr: embassy: Add Default implementation a458d8e33eb zephyr: embassy: Eliminate unused printkln import dea64363115 samples: embassy: Detect proper end to the test 04d9e5714e6 samples: embassy: Increase task pool size eae89bc4d2b samples: embassy: Fix test name
758a2c264c7 samples: embassy: Update formatting
ac0eaac9d8b zephyr: Update rustfmt
db93ee7978e samples: embassy: Update Embassy Demo for Zephyr executor a9958395985 zephyr: Implement `executor-zephyr` to use with Embassy 60d7c5396ac samples: embassy: Start of an embassy demo 1540e9ab785 zephyr: Add initial support for embassy 1503a982e00 docs: Update top-level index
c58d1f20024 zephyr: Expand top-level crate docs