### PR TITLE
soc: espressif: update restart procedure

### DIFF
--- a/soc/espressif/esp32/soc.c
+++ b/soc/espressif/esp32/soc.c
@@ -63,5 +63,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/soc/espressif/esp32/soc_appcpu.c
+++ b/soc/espressif/esp32/soc_appcpu.c
@@ -102,5 +102,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/soc/espressif/esp32c2/soc.c
+++ b/soc/espressif/esp32c2/soc.c
@@ -50,5 +50,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/soc/espressif/esp32c3/soc.c
+++ b/soc/espressif/esp32c3/soc.c
@@ -51,5 +51,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/soc/espressif/esp32c6/soc.c
+++ b/soc/espressif/esp32c6/soc.c
@@ -50,5 +50,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/soc/espressif/esp32s2/soc.c
+++ b/soc/espressif/esp32s2/soc.c
@@ -78,5 +78,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/soc/espressif/esp32s3/soc.c
+++ b/soc/espressif/esp32s3/soc.c
@@ -90,5 +90,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/soc/espressif/esp32s3/soc_appcpu.c
+++ b/soc/espressif/esp32s3/soc_appcpu.c
@@ -87,5 +87,5 @@ int IRAM_ATTR arch_printk_char_out(int c)
 
 void sys_arch_reboot(int type)
 {
-	esp_restart_noos();
+	esp_restart();
 }

--- a/west.yml
+++ b/west.yml
@@ -162,7 +162,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: c33e522158d69417c4a66d07b5009b35c52481f8
+      revision: dbc28ad4c1bdcdb25e79ca225cb5528a75d8dc91
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Use esp_restart call to guarantee and registered
shutdown handlers will be triggered before rebooting. This guarantees that subsystems like Wi-Fi and BLE will deinit correctly.

Fixes #87932