### PR TITLE
drivers: spi: esp32: add relevant deinit functions

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -274,6 +274,30 @@ static inline int spi_context_cs_configure_all(struct spi_context *ctx)
 	return 0;
 }
 
+/*
+ * This function deinitializes all the chip select GPIOs associated with a spi controller.
+ */
+static inline int spi_context_cs_deconfigure_all(struct spi_context *ctx)
+{
+	int ret;
+	const struct gpio_dt_spec *cs_gpio;
+
+	for (cs_gpio = ctx->cs_gpios; cs_gpio < &ctx->cs_gpios[ctx->num_cs_gpios]; cs_gpio++) {
+		if (!device_is_ready(cs_gpio->port)) {
+			LOG_ERR("CS GPIO port %s pin %d is not ready", cs_gpio->port->name,
+				cs_gpio->pin);
+			return -ENODEV;
+		}
+
+		ret = gpio_pin_configure_dt(cs_gpio, GPIO_DISCONNECTED);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
 /* Helper function to control the GPIO CS, not meant to be used directly by drivers */
 static inline void _spi_context_cs_control(struct spi_context *ctx,
 					   bool on, bool force_off)

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -580,51 +580,45 @@ static DEVICE_API(spi, spi_api) = {
 #define GET_AS_CS(idx)
 #endif
 
-#define ESP32_SPI_INIT(idx)	\
-				\
-	PINCTRL_DT_INST_DEFINE(idx);	\
-										\
-	static struct spi_esp32_data spi_data_##idx = {	\
-		SPI_CONTEXT_INIT_LOCK(spi_data_##idx, ctx),	\
-		SPI_CONTEXT_INIT_SYNC(spi_data_##idx, ctx),	\
-		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx)	\
-		.hal = {	\
-			.hw = (spi_dev_t *)DT_INST_REG_ADDR(idx),	\
-		},	\
-		.dev_config = {	\
-			.half_duplex = DT_INST_PROP(idx, half_duplex),	\
-			GET_AS_CS(idx)							\
-			.positive_cs = DT_INST_PROP(idx, positive_cs),	\
-			.no_compensate = DT_INST_PROP(idx, dummy_comp),	\
-			.sio = DT_INST_PROP(idx, sio)	\
-		}	\
-	};	\
-		\
-	static const struct spi_esp32_config spi_config_##idx = {	\
-		.spi = (spi_dev_t *)DT_INST_REG_ADDR(idx),	\
-			\
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),	\
-		.duty_cycle = 0, \
-		.input_delay_ns = 0, \
-		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq), \
-		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority), \
-		.irq_flags = DT_INST_IRQ_BY_IDX(idx, 0, flags), \
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),	\
-		.clock_subsys =	\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),	\
-		.use_iomux = DT_INST_PROP(idx, use_iomux),	\
-		.dma_enabled = DT_INST_PROP(idx, dma_enabled),	\
-		.dma_clk_src = DT_INST_PROP(idx, dma_clk),	\
-		.dma_host = DT_INST_PROP(idx, dma_host),	\
-		.cs_setup = DT_INST_PROP_OR(idx, cs_setup_time, 0), \
-		.cs_hold = DT_INST_PROP_OR(idx, cs_hold_time, 0), \
-		.line_idle_low = DT_INST_PROP(idx, line_idle_low), \
-		.clock_source = SPI_CLK_SRC_DEFAULT,	\
-	};	\
-		\
-	SPI_DEVICE_DT_INST_DEINIT_DEFINE(idx, spi_esp32_init, spi_esp32_deinit, \
-			      NULL, &spi_data_##idx,	\
-			      &spi_config_##idx, POST_KERNEL,	\
-			      CONFIG_SPI_INIT_PRIORITY, &spi_api);
+#define ESP32_SPI_INIT(idx)                                                                        \
+                                                                                                   \
+	PINCTRL_DT_INST_DEFINE(idx);                                                               \
+                                                                                                   \
+	static struct spi_esp32_data spi_data_##idx = {                                            \
+		SPI_CONTEXT_INIT_LOCK(spi_data_##idx, ctx),                                        \
+		SPI_CONTEXT_INIT_SYNC(spi_data_##idx, ctx),                                        \
+		SPI_CONTEXT_CS_GPIOS_INITIALIZE(DT_DRV_INST(idx), ctx).hal =                       \
+			{                                                                          \
+				.hw = (spi_dev_t *)DT_INST_REG_ADDR(idx),                          \
+			},                                                                         \
+		.dev_config = {.half_duplex = DT_INST_PROP(idx, half_duplex),                      \
+			       GET_AS_CS(idx).positive_cs = DT_INST_PROP(idx, positive_cs),        \
+			       .no_compensate = DT_INST_PROP(idx, dummy_comp),                     \
+			       .sio = DT_INST_PROP(idx, sio)}};                                    \
+                                                                                                   \
+	static const struct spi_esp32_config spi_config_##idx = {                                  \
+		.spi = (spi_dev_t *)DT_INST_REG_ADDR(idx),                                         \
+                                                                                                   \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                              \
+		.duty_cycle = 0,                                                                   \
+		.input_delay_ns = 0,                                                               \
+		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),                                     \
+		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority),                              \
+		.irq_flags = DT_INST_IRQ_BY_IDX(idx, 0, flags),                                    \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                       \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),          \
+		.use_iomux = DT_INST_PROP(idx, use_iomux),                                         \
+		.dma_enabled = DT_INST_PROP(idx, dma_enabled),                                     \
+		.dma_clk_src = DT_INST_PROP(idx, dma_clk),                                         \
+		.dma_host = DT_INST_PROP(idx, dma_host),                                           \
+		.cs_setup = DT_INST_PROP_OR(idx, cs_setup_time, 0),                                \
+		.cs_hold = DT_INST_PROP_OR(idx, cs_hold_time, 0),                                  \
+		.line_idle_low = DT_INST_PROP(idx, line_idle_low),                                 \
+		.clock_source = SPI_CLK_SRC_DEFAULT,                                               \
+	};                                                                                         \
+                                                                                                   \
+	SPI_DEVICE_DT_INST_DEINIT_DEFINE(idx, spi_esp32_init, spi_esp32_deinit, NULL,              \
+					 &spi_data_##idx, &spi_config_##idx, POST_KERNEL,          \
+					 CONFIG_SPI_INIT_PRIORITY, &spi_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ESP32_SPI_INIT)

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -672,6 +672,16 @@ struct spi_device_state {
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
 
+#define SPI_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn, pm_device, data_ptr, cfg_ptr,     \
+				    level, prio, api_ptr, ...)                                     \
+	Z_SPI_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));                                    \
+	Z_SPI_INIT_FN(Z_DEVICE_DT_DEV_ID(node_id), init_fn)                                        \
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id), DEVICE_DT_NAME(node_id),             \
+			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init), deinit_fn,                  \
+			Z_DEVICE_DT_FLAGS(node_id), pm_device, data_ptr, cfg_ptr, level, prio,     \
+			api_ptr, &(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate),     \
+			__VA_ARGS__)
+
 static inline void spi_transceive_stats(const struct device *dev, int error,
 					const struct spi_buf_set *tx_bufs,
 					const struct spi_buf_set *rx_bufs)
@@ -731,6 +741,31 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 			level, prio, api,					\
 			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)),	\
 			__VA_ARGS__)
+
+/**
+ * @brief Like DEVICE_DT_DEINIT_DEFINE() with SPI specifics.
+ *
+ * @details Defines a device which implements the SPI API. May generate a custom device_state
+ * container struct and init_fn wrapper when needed depending on SPI @kconfig{CONFIG_SPI_STATS}.
+ *
+ * @param node_id The devicetree node identifier.
+ * @param init_fn Name of the init function of the driver.
+ * @param deinit_fn Name of the deinit function of the driver.
+ * @param pm PM device resources reference (NULL if device does not use PM).
+ * @param data Pointer to the device's private data.
+ * @param config The address to the structure containing the configuration information for this
+ * instance of the driver.
+ * @param level The initialization level. See SYS_INIT() for details.
+ * @param prio Priority within the selected initialization level. See SYS_INIT() for details.
+ * @param api Provides an initial pointer to the API function struct used by the driver. Can be
+ * NULL.
+ */
+#define SPI_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn, pm, data, config, level, prio,    \
+				    api, ...)                                                      \
+	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));                                        \
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id), DEVICE_DT_NAME(node_id), init_fn,    \
+			deinit_fn, NULL, Z_DEVICE_DT_FLAGS(node_id), pm, data, config, level,      \
+			prio, api, &Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)), __VA_ARGS__)
 /** @} */
 
 #define SPI_STATS_RX_BYTES_INC(dev_)
@@ -740,7 +775,6 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
 #define spi_transceive_stats(dev, error, tx_bufs, rx_bufs)
 
 #endif /*CONFIG_SPI_STATS*/
-
 
 /**
  * @brief Like SPI_DEVICE_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
@@ -753,6 +787,19 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
  */
 #define SPI_DEVICE_DT_INST_DEFINE(inst, ...)                                       \
 	SPI_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+
+/**
+ * @brief Like SPI_DEVICE_DT_DEINIT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * compatible instead of a node identifier.
+ *
+ * @addtogroup spi_dt_dev
+ *
+ * @param inst Instance number. The `node_id` argument to SPI_DEVICE_DT_DEINIT_DEFINE() is
+ * set to `DT_DRV_INST(inst)`.
+ * @param ... Other parameters as expected by SPI_DEVICE_DT_DEINIT_DEFINE().
+ */
+#define SPI_DEVICE_DT_INST_DEINIT_DEFINE(inst, ...)                                                \
+	SPI_DEVICE_DT_DEINIT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
  * @typedef spi_api_io


### PR DESCRIPTION
Add deinit capability to the esp32 SPI driver and relevant deinit helper functions and macros to the  SPI driver API.

WIP for now.