### PR TITLE
net: dns-sd: allow empty instances

### DIFF
--- a/include/zephyr/net/dns_sd.h
+++ b/include/zephyr/net/dns_sd.h
@@ -36,8 +36,6 @@ extern "C" {
  * @{
  */
 
-/** RFC 1034 Section 3.1 */
-#define DNS_SD_INSTANCE_MIN_SIZE 1
 /** RFC 1034 Section 3.1, RFC 6763 Section 7.2 */
 #define DNS_SD_INSTANCE_MAX_SIZE 63
 /** RFC 6763 Section 7.2 - inclusive of underscore */

--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -149,18 +149,11 @@ static bool instance_is_valid(const char *instance)
 	size_t instance_size;
 
 	if (instance == NULL) {
-		NET_DBG("instance is NULL");
-		return false;
+		/* Instance can be empty in case of query */
+		return true;
 	}
 
 	instance_size = strlen(instance);
-	if (instance_size < DNS_SD_INSTANCE_MIN_SIZE) {
-		NET_DBG("instance '%s' is too small (%zu, min: %u)",
-			instance, instance_size,
-			DNS_SD_INSTANCE_MIN_SIZE);
-		return false;
-	}
-
 	if (instance_size > DNS_SD_INSTANCE_MAX_SIZE) {
 		NET_DBG("instance '%s' is too big (%zu, max: %u)",
 			instance, instance_size,
@@ -179,7 +172,7 @@ static bool instance_is_valid(const char *instance)
 		}
 	}
 
-	return instance_size;
+	return true;
 }
 
 static bool service_is_valid(const char *service)

--- a/tests/net/lib/dns_sd/src/main.c
+++ b/tests/net/lib/dns_sd/src/main.c
@@ -304,16 +304,30 @@ ZTEST(dns_sd, test_add_ptr_record)
 	zassert_mem_equal(actual_buf, expected_buf,
 			  MIN(actual_int, expected_int), "");
 
-	/* dns_sd_rec_is_valid failure */
-	DNS_SD_REGISTER_TCP_SERVICE(null_label,
+	/* empty instance should pass */
+	DNS_SD_REGISTER_TCP_SERVICE(null_instance,
 				NULL,
 				"_x",
 				"xx",
 				DNS_SD_EMPTY_TXT,
 				CONST_PORT);
-	zassert_equal(-EINVAL, add_ptr_record(&null_label, ttl,
+	zassert_equal(56, add_ptr_record(&null_instance, ttl,
 					      actual_buf, offset,
-					      actual_int,
+					      BUFSZ,
+					      &service_offset,
+					      &instance_offset,
+					      &domain_offset), "");
+
+	/* dns_sd_rec_is_valid failure, service should not be NULL */
+	DNS_SD_REGISTER_TCP_SERVICE(null_service,
+				"x",
+				NULL,
+				"xx",
+				DNS_SD_EMPTY_TXT,
+				CONST_PORT);
+	zassert_equal(-EINVAL, add_ptr_record(&null_service, ttl,
+					      actual_buf, offset,
+					      BUFSZ,
 					      &service_offset,
 					      &instance_offset,
 					      &domain_offset), "");


### PR DESCRIPTION
when receiving DNS SD queries, the instance field can be empty, so they should be allowed.

With 
```
CONFIG_DNS_SD_LOG_LEVEL_DBG=y
```
enabled, and if you are connected to a local network with some mDNS activity, you can see that a lot of queries are unnecessarily dropped because they don't have an instance field:
```
[00:42:36.768,187] <dbg> net_dns_sd: instance_is_valid: (net_socket_service): instance is NULL
[00:42:36.768,192] <dbg> net_dns_sd: dns_sd_rec_match: DNS SD record at 0x10090810 is invalid
[00:42:36.768,215] <dbg> net_dns_sd: instance_is_valid: (net_socket_service): instance '' is too small (0, min: 1)
[00:42:36.768,231] <dbg> net_dns_sd: dns_sd_rec_match: DNS SD record at 0x180b5dec is invalid
```