### PR TITLE
soc: st: stm32f4: add support for sys_poweroff

### DIFF
--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -18,6 +18,7 @@
 #include <zephyr/dt-bindings/adc/stm32f4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
+#include <zephyr/dt-bindings/power/stm32_pwr.h>
 #include <freq.h>
 
 / {
@@ -583,6 +584,22 @@
 			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
 			status = "disabled";
+		};
+	};
+
+	pwr: power@40007000 {
+		compatible = "st,stm32-pwr";
+		reg = <0x40007000 0x400>; /* PWR register bank */
+		status = "disabled";
+
+		wkup-pins-nb = <1>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		wkup-pin@1 {
+			reg = <0x1>;
+			wkup-gpios = <&gpioa 0 STM32_PWR_WKUP_PIN_NOT_MUXED>;
 		};
 	};
 

--- a/soc/st/stm32/stm32f4x/CMakeLists.txt
+++ b/soc/st/stm32/stm32f4x/CMakeLists.txt
@@ -12,3 +12,4 @@ set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/li
 zephyr_sources_ifdef(CONFIG_PM
   power.c
   )
+zephyr_sources_ifdef(CONFIG_POWEROFF poweroff.c)

--- a/soc/st/stm32/stm32f4x/Kconfig
+++ b/soc/st/stm32/stm32f4x/Kconfig
@@ -12,4 +12,5 @@ config SOC_SERIES_STM32F4X
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
 	select HAS_PM
+	select HAS_POWEROFF
 	select SOC_EARLY_INIT_HOOK

--- a/soc/st/stm32/stm32f4x/poweroff.c
+++ b/soc/st/stm32/stm32f4x/poweroff.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2024 STMicroelectronics
+ * Copyright (c) 2025 Tomas Jurena
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
+
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
+
+void z_sys_poweroff(void)
+{
+#ifdef CONFIG_STM32_WKUP_PINS
+	LL_PWR_ClearFlag_WU();
+#endif /* CONFIG_STM32_WKUP_PINS */
+
+	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+	LL_LPM_EnableDeepSleep();
+
+	k_cpu_idle();
+
+	CODE_UNREACHABLE;
+}


### PR DESCRIPTION
Allows F4-based boards enter the poweroff state.