### PR TITLE
usb: device_next: avoid false error logging in CDC ACM

### DIFF
--- a/subsys/usb/device_next/class/usbd_cdc_acm.c
+++ b/subsys/usb/device_next/class/usbd_cdc_acm.c
@@ -506,7 +506,7 @@ static int usbd_cdc_acm_init(struct usbd_class_data *const c_data)
 	desc->if0_union.bControlInterface = desc->if0.bInterfaceNumber;
 	desc->if0_union.bSubordinateInterface0 = desc->if1.bInterfaceNumber;
 
-	if (cfg->if_desc_data != NULL) {
+	if (cfg->if_desc_data != NULL && desc->if0.iInterface == 0) {
 		if (usbd_add_descriptor(uds_ctx, cfg->if_desc_data)) {
 			LOG_ERR("Failed to add interface string descriptor");
 		} else {


### PR DESCRIPTION
The interface descriptor and its associated string descriptor are shared between different speed configurations. Do not try to add a string descriptor if it has already been added and the index is not zero.

Fixes: #86718