### PR TITLE
Raspberry Pi: Tidy up some documentation

### DIFF
--- a/boards/raspberrypi/rpi_pico/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico/doc/index.rst
@@ -205,7 +205,7 @@ The Raspberry Pi Pico has an SWD interface that can be used to program
 and debug the onboard SoC. This interface can be used with OpenOCD.
 To use it, OpenOCD version 0.12.0 or later is needed.
 
-If you are using a Debian based system (including RaspberryPi OS, Ubuntu. and more),
+If you are using a Debian based system (including Raspberry Pi OS, Ubuntu. and more),
 using the `pico_setup.sh`_ script is a convenient way to set up the forked version of OpenOCD.
 
 Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.

--- a/boards/raspberrypi/rpi_pico/rpi_pico.yaml
+++ b/boards/raspberrypi/rpi_pico/rpi_pico.yaml
@@ -1,5 +1,5 @@
 identifier: rpi_pico
-name: RaspberryPi-Pico
+name: Raspberry Pi Pico
 type: mcu
 arch: arm
 flash: 2048

--- a/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_w.yaml
+++ b/boards/raspberrypi/rpi_pico/rpi_pico_rp2040_w.yaml
@@ -1,5 +1,5 @@
 identifier: rpi_pico/rp2040/w
-name: RaspberryPi-Pico-w
+name: Raspberry Pi Pico W
 type: mcu
 arch: arm
 flash: 2048

--- a/boards/shields/rpi_pico_uno_flexypin/doc/index.rst
+++ b/boards/shields/rpi_pico_uno_flexypin/doc/index.rst
@@ -1,7 +1,7 @@
 .. _rpi_pico_uno_flexypin:
 
-RaspberryPi Pico to UNO FlexyPin Adapter
-########################################
+Raspberry Pi Pico to UNO FlexyPin Adapter
+#########################################
 
 Overview
 ********
@@ -16,10 +16,10 @@ to the Arduino UNO form factor.
 
 .. image:: img/rpi_pico_uno_flexypin.png
      :align: center
-     :alt: RaspberryPi Pico to UNO FlexyPin Adapter
+     :alt: Raspberry Pi Pico to UNO FlexyPin Adapter
 
-Pins Assignment of the RaspberryPi Pico to UNO FlexyPin Adapter
-===============================================================
+Pins Assignment of the Raspberry Pi Pico to UNO FlexyPin Adapter
+================================================================
 
 +---------------------+------------+
 | Rpi-Pico Pin        | UNO Header |

--- a/boards/wiznet/w5500_evb_pico/doc/index.rst
+++ b/boards/wiznet/w5500_evb_pico/doc/index.rst
@@ -112,7 +112,7 @@ interface that can be used to program and debug the on board RP2040. This
 interface can be utilized by OpenOCD. To use it with the RP2040, OpenOCD
 version 0.12.0 or later is needed.
 
-If you are using a Debian based system (including RaspberryPi OS, Ubuntu. and
+If you are using a Debian based system (including Raspberry Pi OS, Ubuntu, and
 more), using the `pico_setup.sh`_ script is a convenient way to set up the
 forked version of OpenOCD.
 

--- a/boards/wiznet/w5500_evb_pico2/doc/index.rst
+++ b/boards/wiznet/w5500_evb_pico2/doc/index.rst
@@ -86,7 +86,7 @@ The overall explanation regarding flashing and debugging is the same as or
 See :ref:`rpi_pico_flashing_using_openocd`. in ``rpi_pico`` documentation.
 
 A typical build command for w5500_evb_pico2 is as follows.
-This assumes a CMSIS-DAP adapter such as the RaspberryPi Debug Probe,
+This assumes a CMSIS-DAP adapter such as the Raspberry Pi Debug Probe,
 but if you are using something else, specify ``RPI_PICO_DEBUG_ADAPTER``.
 
 .. zephyr-app-commands::

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -130,7 +130,7 @@ Enhanced Serial Peripheral Interface (eSPI)
 GPIO
 ====
 
-* To support the RP2350B, which has many pins, the RaspberryPi-GPIO configuration has
+* To support the RP2350B, which has many pins, the Raspberry Pi-GPIO configuration has
   been changed. The previous role of :dtcompatible:`raspberrypi,rpi-gpio` has been migrated to
   :dtcompatible:`raspberrypi,rpi-gpio-port`, and :dtcompatible:`raspberrypi,rpi-gpio` is
   now left as a placeholder and mapper.

--- a/drivers/adc/adc_rpi_pico.c
+++ b/drivers/adc/adc_rpi_pico.c
@@ -27,9 +27,9 @@ LOG_MODULE_REGISTER(adc_rpi, CONFIG_ADC_LOG_LEVEL);
 #define ADC_RPI_CHANNEL_NUM (ADC_CS_RROBIN_MSB - ADC_CS_RROBIN_LSB + 1)
 
 /**
- * @brief RaspberryPi Pico ADC config
+ * @brief Raspberry Pi Pico ADC config
  *
- * This structure contains constant data for given instance of RaspberryPi Pico ADC.
+ * This structure contains constant data for given instance of Raspberry Pi Pico ADC.
  */
 struct adc_rpi_config {
 	/** Number of supported channels */
@@ -47,14 +47,14 @@ struct adc_rpi_config {
 };
 
 /**
- * @brief RaspberryPi Pico ADC data
+ * @brief Raspberry Pi Pico ADC data
  *
- * This structure contains data structures used by a RaspberryPi Pico ADC.
+ * This structure contains data structures used by a Raspberry Pi Pico ADC.
  */
 struct adc_rpi_data {
 	/** Structure that handle state of ongoing read operation */
 	struct adc_context ctx;
-	/** Pointer to RaspberryPi Pico ADC own device structure */
+	/** Pointer to Raspberry Pi Pico ADC own device structure */
 	const struct device *dev;
 	/** Pointer to memory where next sample will be written */
 	uint16_t *buf;
@@ -127,7 +127,7 @@ static int adc_rpi_channel_setup(const struct device *dev,
 /**
  * @brief Check if buffer in @p sequence is big enough to hold all ADC samples
  *
- * @param dev RaspberryPi Pico ADC device
+ * @param dev Raspberry Pi Pico ADC device
  * @param sequence ADC sequence description
  *
  * @return 0 on success
@@ -162,7 +162,7 @@ static int adc_rpi_check_buffer_size(const struct device *dev,
 /**
  * @brief Start processing read request
  *
- * @param dev RaspberryPi Pico ADC device
+ * @param dev Raspberry Pi Pico ADC device
  * @param sequence ADC sequence description
  *
  * @return 0 on success
@@ -290,10 +290,10 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 }
 
 /**
- * @brief Function called on init for each RaspberryPi Pico ADC device. It setups all
+ * @brief Function called on init for each Raspberry Pi Pico ADC device. It setups all
  *        channels to return constant 0 mV and create acquisition thread.
  *
- * @param dev RaspberryPi Pico ADC device
+ * @param dev Raspberry Pi Pico ADC device
  *
  * @return 0 on success
  */

--- a/drivers/dma/Kconfig.rpi_pico
+++ b/drivers/dma/Kconfig.rpi_pico
@@ -9,4 +9,4 @@ config DMA_RPI_PICO
 	select PICOSDK_USE_CLAIM
 	depends on RESET
 	help
-	  DMA driver for RaspberryPi Pico.
+	  DMA driver for Raspberry Pi Pico.

--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -99,4 +99,4 @@ config WS2812_STRIP_RPI_PICO_PIO
 	select PICOSDK_USE_PIO
 	help
 	  Enable driver for WS2812 (and compatibles) LED strip using
-	  the RaspberryPi Pico's PIO.
+	  the Raspberry Pi Pico's PIO.

--- a/drivers/misc/pio_rpi_pico/Kconfig
+++ b/drivers/misc/pio_rpi_pico/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config PIO_RPI_PICO
-	bool "RaspberryPi Pico PIO"
+	bool "Raspberry Pi Pico PIO"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_PIO_ENABLED
 	depends on RESET

--- a/drivers/pinctrl/Kconfig.rpi_pico
+++ b/drivers/pinctrl/Kconfig.rpi_pico
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config PINCTRL_RPI_PICO
-	bool "RaspberryPi Pico pin controller driver"
+	bool "Raspberry Pi Pico pin controller driver"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_PINCTRL_ENABLED
 	select PICOSDK_USE_GPIO
 	help
-	  RaspberryPi Pico pinctrl driver
+	  Raspberry Pi Pico pinctrl driver

--- a/drivers/regulator/Kconfig.rpi_pico
+++ b/drivers/regulator/Kconfig.rpi_pico
@@ -2,18 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config REGULATOR_RPI_PICO
-	bool "RaspberryPi Pico regulator driver"
+	bool "Raspberry Pi Pico regulator driver"
 	default y
 	depends on DT_HAS_RASPBERRYPI_CORE_SUPPLY_REGULATOR_ENABLED
 	help
-	  Enable support for the RaspberryPi Pico regulator.
+	  Enable support for the Raspberry Pi Pico regulator.
 
 if REGULATOR_RPI_PICO
 
 config REGULATOR_RPI_PICO_INIT_PRIORITY
-	int "RaspberryPi Pico regulator driver init priority"
+	int "Raspberry Pi Pico regulator driver init priority"
 	default KERNEL_INIT_PRIORITY_DEVICE
 	help
-	  Init priority for the RaspberryPi Pico regulator driver.
+	  Init priority for the Raspberry Pi Pico regulator driver.
 
 endif

--- a/drivers/spi/Kconfig.rpi_pico
+++ b/drivers/spi/Kconfig.rpi_pico
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SPI_RPI_PICO_PIO
-	bool "Raspberry Pi PICO PIO SPI controller driver"
+	bool "Raspberry Pi Pico PIO SPI controller driver"
 	default y
 	depends on DT_HAS_RASPBERRYPI_PICO_SPI_PIO_ENABLED
 	select PICOSDK_USE_PIO
 	select PICOSDK_USE_CLAIM
 	select PINCTRL
 	help
-	  Enable driving SPI via PIO on the PICO
+	  Enable driving SPI via PIO on the Pico

--- a/dts/bindings/adc/raspberrypi,pico-adc.yaml
+++ b/dts/bindings/adc/raspberrypi,pico-adc.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 TOKTIA Hrioshi <tokita.hiroshi@fujitsu.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: RaspberryPi Pico ADC
+description: Raspberry Pi Pico ADC
 
 compatible: "raspberrypi,pico-adc"
 

--- a/dts/bindings/counter/raspberrypi,pico-timer.yaml
+++ b/dts/bindings/counter/raspberrypi,pico-timer.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 TOKITA Hiroshi
 # SPDX-License-Identifier: Apache-2.0
 
-description: RaspberryPi Pico timer
+description: Raspberry Pi Pico timer
 
 compatible: "raspberrypi,pico-timer"
 

--- a/dts/bindings/led_strip/worldsemi,ws2812-rpi_pico-pio.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812-rpi_pico-pio.yaml
@@ -44,7 +44,7 @@ properties:
 
 child-binding:
   description: |
-    Worldsemi WS2812 or compatible LED strip driver based on RaspberryPi Pico's PIO
+    Worldsemi WS2812 or compatible LED strip driver based on Raspberry Pi Pico's PIO
     The LED strip node can put up to 4 instances under a single PIO node.
 
   include: ws2812-gpio.yaml

--- a/dts/bindings/regulator/raspberrypi,core-supply-regulator.yaml
+++ b/dts/bindings/regulator/raspberrypi,core-supply-regulator.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  RaspberryPi Pico core supply regurator
+  Raspberry Pi Pico core supply regurator
 
 compatible: "raspberrypi,core-supply-regulator"
 

--- a/dts/bindings/rtc/raspberrypi,pico-rtc.yaml
+++ b/dts/bindings/rtc/raspberrypi,pico-rtc.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Andrew Featherstone <andrew.featherstone@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: RaspberryPi Pico RTC
+description: Raspberry Pi Pico RTC
 
 compatible: "raspberrypi,pico-rtc"
 

--- a/dts/bindings/sensor/raspberrrypi,pico-temp.yaml
+++ b/dts/bindings/sensor/raspberrrypi,pico-temp.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2023 TOKITA Hiroshi
 # SPDX-License-Identifier: Apache-2.0
 
-description: RaspberryPi Pico family temperature sensor node
+description: Raspberry Pi Pico family temperature sensor node
 
 compatible: "raspberrypi,pico-temp"
 

--- a/dts/bindings/usb/raspberrypi,pico-usbd.yaml
+++ b/dts/bindings/usb/raspberrypi,pico-usbd.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  RaspberryPi Pico USB Device Controller.
+  Raspberry Pi Pico USB Device Controller.
 
   Example of enabling the controller with vbus detection:
 

--- a/tests/drivers/gpio/gpio_api_1pin/boards/pico_plus2_rp2350b_m33.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/pico_plus2_rp2350b_m33.overlay
@@ -4,5 +4,5 @@
  * Copyright (c) 2024 TOKITA Hiroshi
  */
 
-/* Pico Plus2 is pin-compatible with the RPi-Pico2, so reuse. */
+/* Pico Plus2 is pin-compatible with the Raspberry Pi Pico 2, so reuse. */
 #include "rpi_pico2_rp2350a_m33.overlay"

--- a/tests/drivers/gpio/gpio_basic_api/boards/pico_plus2_rp2350b_m33.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/pico_plus2_rp2350b_m33.overlay
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Pico Plus2 is pin-compatible with the RPi-Pico, so reuse. */
+/* Pico Plus2 is pin-compatible with the Raspberry Pi Pico, so reuse. */
 #include "rpi_pico.overlay"


### PR DESCRIPTION
Following on from a prompt in https://github.com/zephyrproject-rtos/zephyr/pull/86688#issuecomment-2702509484 , address some documentation niggles focused on Raspberry Pi products.

N.b. I've not changed any old release notes, on the assumption that they should be considered read-only.
