### PR TITLE
bluetooth: make long stack size configurable

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -12,9 +12,8 @@ config BT_LONG_WQ
 
 if BT_LONG_WQ
 config BT_LONG_WQ_STACK_SIZE
-	# Hidden: Long workqueue stack size. Should be derived from system
-	# requirements.
 	int
+	prompt "BT Long WQ thread stack size"
 	default 1400 if BT_ECC
 	default 1300 if BT_GATT_CACHING
 	default 1024


### PR DESCRIPTION
when using CONFIG_NO_OPTIMIZATIONS, the user needs to be able to increase stack sizes to avoid crashes. This commit makes the bluetooth long work queue thread stack size configurable.