### PR TITLE
drivers: i3c: create i3c bus helpers

### DIFF
--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -604,7 +604,6 @@ static int cmd_i3c_ccc_rstdaa_dc(const struct shell *sh, size_t argc, char **arg
 static int cmd_i3c_ccc_rstdaa(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
-	struct i3c_device_desc *desc;
 	int ret;
 
 	dev = shell_device_get_binding(argv[ARGV_DEV]);
@@ -613,16 +612,9 @@ static int cmd_i3c_ccc_rstdaa(const struct shell *sh, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	ret = i3c_ccc_do_rstdaa_all(dev);
+	ret = i3c_bus_rstdaa_all(dev);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC RSTDAA.");
-		return ret;
-	}
-
-	/* reset all devices DA */
-	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
-		desc->dynamic_addr = 0;
-		shell_print(sh, "Reset dynamic address for device %s", desc->dev->name);
 	}
 
 	return ret;
@@ -646,7 +638,6 @@ static int cmd_i3c_ccc_entdaa(const struct shell *sh, size_t argc, char **argv)
 static int cmd_i3c_ccc_setaasa(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
-	struct i3c_device_desc *desc;
 	int ret;
 
 	dev = shell_device_get_binding(argv[ARGV_DEV]);
@@ -655,18 +646,10 @@ static int cmd_i3c_ccc_setaasa(const struct shell *sh, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	ret = i3c_ccc_do_setaasa_all(dev);
+	ret = i3c_bus_setaasa(dev);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC SETAASA.");
 		return ret;
-	}
-
-	/* set all devices DA to SA */
-	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
-		if (((desc->flags) & I3C_SUPPORTS_SETAASA) && (desc->dynamic_addr == 0) &&
-		    (desc->static_addr != 0)) {
-			desc->dynamic_addr = desc->static_addr;
-		}
 	}
 
 	return ret;
@@ -678,7 +661,6 @@ static int cmd_i3c_ccc_setdasa(const struct shell *sh, size_t argc, char **argv)
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
 	struct i3c_driver_data *data;
-	struct i3c_ccc_address da;
 	uint8_t dynamic_addr;
 	int ret;
 
@@ -689,27 +671,14 @@ static int cmd_i3c_ccc_setdasa(const struct shell *sh, size_t argc, char **argv)
 
 	data = (struct i3c_driver_data *)dev->data;
 	dynamic_addr = strtol(argv[3], NULL, 16);
-	da.addr = dynamic_addr << 1;
-	/* check if the addressed is free */
-	if (!i3c_addr_slots_is_free(&data->attached_dev.addr_slots, dynamic_addr)) {
-		shell_error(sh, "I3C: Address 0x%02x is already in use.", dynamic_addr);
-		return -EINVAL;
-	}
-	ret = i3c_ccc_do_setdasa(desc, da);
+
+	ret = i3c_bus_setdasa(desc, dynamic_addr);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC SETDASA.");
 		return ret;
 	}
 
-	/* update the target's dynamic address */
-	desc->dynamic_addr = dynamic_addr;
-	if (desc->dynamic_addr != desc->static_addr) {
-		ret = i3c_reattach_i3c_device(desc, desc->static_addr);
-		if (ret < 0) {
-			shell_error(sh, "I3C: unable to reattach device");
-			return ret;
-		}
-	}
+	shell_print(sh, "I3C: Dynamic address set to 0x%02x", desc->dynamic_addr);
 
 	return ret;
 }
@@ -720,7 +689,6 @@ static int cmd_i3c_ccc_setnewda(const struct shell *sh, size_t argc, char **argv
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
 	struct i3c_driver_data *data;
-	struct i3c_ccc_address new_da;
 	uint8_t dynamic_addr;
 	uint8_t old_da;
 	int ret;
@@ -732,27 +700,16 @@ static int cmd_i3c_ccc_setnewda(const struct shell *sh, size_t argc, char **argv
 
 	data = (struct i3c_driver_data *)dev->data;
 	dynamic_addr = strtol(argv[3], NULL, 16);
-	new_da.addr = dynamic_addr << 1;
-	/* check if the addressed is free */
-	if (!i3c_addr_slots_is_free(&data->attached_dev.addr_slots, dynamic_addr)) {
-		shell_error(sh, "I3C: Address 0x%02x is already in use.", dynamic_addr);
-		return -EINVAL;
-	}
-
-	ret = i3c_ccc_do_setnewda(desc, new_da);
-	if (ret < 0) {
-		shell_error(sh, "I3C: unable to send CCC SETDASA.");
-		return ret;
-	}
-
-	/* reattach device address */
 	old_da = desc->dynamic_addr;
-	desc->dynamic_addr = dynamic_addr;
-	ret = i3c_reattach_i3c_device(desc, old_da);
+
+	ret = i3c_bus_setnewda(desc, dynamic_addr);
 	if (ret < 0) {
-		shell_error(sh, "I3C: unable to reattach device");
+		shell_error(sh, "I3C: unable to send CCC SETNEWDA.");
 		return ret;
 	}
+
+	shell_print(sh, "I3C: Dynamic address changed from 0x%02x to 0x%02x", old_da,
+		    desc->dynamic_addr);
 
 	return ret;
 }
@@ -762,7 +719,6 @@ static int cmd_i3c_ccc_getbcr(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_getbcr bcr;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -770,14 +726,13 @@ static int cmd_i3c_ccc_getbcr(const struct shell *sh, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = i3c_ccc_do_getbcr(desc, &bcr);
+	ret = i3c_bus_getbcr(desc);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC GETBCR.");
 		return ret;
 	}
 
-	shell_print(sh, "BCR: 0x%02x", bcr.bcr);
-	desc->bcr = bcr.bcr;
+	shell_print(sh, "I3C: BCR: 0x%02x", desc->bcr);
 
 	return ret;
 }
@@ -787,7 +742,6 @@ static int cmd_i3c_ccc_getdcr(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_getdcr dcr;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -795,14 +749,13 @@ static int cmd_i3c_ccc_getdcr(const struct shell *sh, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = i3c_ccc_do_getdcr(desc, &dcr);
+	ret = i3c_bus_getdcr(desc);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC GETDCR.");
 		return ret;
 	}
 
-	shell_print(sh, "DCR: 0x%02x", dcr.dcr);
-	desc->dcr = dcr.dcr;
+	shell_print(sh, "I3C: DCR: 0x%02x", desc->dcr);
 
 	return ret;
 }
@@ -812,7 +765,6 @@ static int cmd_i3c_ccc_getpid(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_getpid pid;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -820,13 +772,13 @@ static int cmd_i3c_ccc_getpid(const struct shell *sh, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = i3c_ccc_do_getpid(desc, &pid);
+	ret = i3c_bus_getpid(desc);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC GETPID.");
 		return ret;
 	}
 
-	shell_print(sh, "PID: 0x%012llx", sys_get_be48(pid.pid));
+	shell_print(sh, "I3C: PID: 0x%012llx", desc->pid);
 
 	return ret;
 }
@@ -836,7 +788,6 @@ static int cmd_i3c_ccc_getmrl(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_mrl mrl;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -844,19 +795,17 @@ static int cmd_i3c_ccc_getmrl(const struct shell *sh, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = i3c_ccc_do_getmrl(desc, &mrl);
+	ret = i3c_bus_getmrl(desc);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC GETMRL.");
 		return ret;
 	}
 
-	desc->data_length.mrl = mrl.len;
 	if (desc->bcr & I3C_BCR_IBI_PAYLOAD_HAS_DATA_BYTE) {
-		shell_print(sh, "MRL: 0x%04x; IBI Length:0x%02x", mrl.len, mrl.ibi_len);
-		desc->data_length.max_ibi = mrl.ibi_len;
+		shell_print(sh, "I3C: MRL: 0x%04x; IBI Length:0x%02x", desc->data_length.mrl,
+			    desc->data_length.max_ibi);
 	} else {
-		shell_print(sh, "MRL: 0x%04x", mrl.len);
-		desc->data_length.max_ibi = 0;
+		shell_print(sh, "I3C: MRL: 0x%04x", desc->data_length.mrl);
 	}
 
 	return ret;
@@ -867,7 +816,6 @@ static int cmd_i3c_ccc_getmwl(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_mwl mwl;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -875,14 +823,13 @@ static int cmd_i3c_ccc_getmwl(const struct shell *sh, size_t argc, char **argv)
 		return ret;
 	}
 
-	ret = i3c_ccc_do_getmwl(desc, &mwl);
+	ret = i3c_bus_getmwl(desc);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC GETMWL.");
 		return ret;
 	}
 
-	shell_print(sh, "MWL: 0x%04x", mwl.len);
-	desc->data_length.mwl = mwl.len;
+	shell_print(sh, "I3C: MWL: 0x%04x", desc->data_length.mwl);
 
 	return ret;
 }
@@ -892,7 +839,8 @@ static int cmd_i3c_ccc_setmrl(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_mrl mrl;
+	uint16_t mrl;
+	uint8_t ibi_len = 0;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -906,20 +854,20 @@ static int cmd_i3c_ccc_setmrl(const struct shell *sh, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	mrl.len = strtol(argv[3], NULL, 16);
+	mrl = strtol(argv[3], NULL, 16);
 	if (argc > 4) {
-		mrl.ibi_len = strtol(argv[4], NULL, 16);
+		ibi_len = strtol(argv[4], NULL, 16);
 	}
 
-	ret = i3c_ccc_do_setmrl(desc, &mrl);
+	ret = i3c_bus_setmrl(desc, mrl, ibi_len);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC SETMRL.");
-		return ret;
-	}
-
-	desc->data_length.mrl = mrl.len;
-	if (argc > 4) {
-		desc->data_length.max_ibi = mrl.ibi_len;
+	} else {
+		if (desc->bcr & I3C_BCR_IBI_PAYLOAD_HAS_DATA_BYTE) {
+			shell_print(sh, "I3C: MRL: 0x%04x; IBI Length:0x%02x", mrl, ibi_len);
+		} else {
+			shell_print(sh, "I3C: MRL: 0x%04x", mrl);
+		}
 	}
 
 	return ret;
@@ -930,7 +878,7 @@ static int cmd_i3c_ccc_setmwl(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_mwl mwl;
+	uint16_t mwl;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -938,15 +886,15 @@ static int cmd_i3c_ccc_setmwl(const struct shell *sh, size_t argc, char **argv)
 		return ret;
 	}
 
-	mwl.len = strtol(argv[3], NULL, 16);
+	mwl = strtol(argv[3], NULL, 16);
 
-	ret = i3c_ccc_do_setmwl(desc, &mwl);
+	ret = i3c_bus_setmwl(desc, mwl);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC SETMWL.");
 		return ret;
 	}
 
-	desc->data_length.mwl = mwl.len;
+	shell_print(sh, "I3C: SETMWL: 0x%04x", mwl);
 
 	return ret;
 }
@@ -955,8 +903,8 @@ static int cmd_i3c_ccc_setmwl(const struct shell *sh, size_t argc, char **argv)
 static int cmd_i3c_ccc_setmrl_bc(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
-	struct i3c_device_desc *desc;
-	struct i3c_ccc_mrl mrl;
+	uint16_t mrl;
+	uint8_t ibi_len = 0;
 	int ret;
 
 	dev = shell_device_get_binding(argv[ARGV_DEV]);
@@ -965,23 +913,18 @@ static int cmd_i3c_ccc_setmrl_bc(const struct shell *sh, size_t argc, char **arg
 		return -ENODEV;
 	}
 
-	mrl.len = strtol(argv[2], NULL, 16);
+	mrl = strtol(argv[2], NULL, 16);
 	if (argc > 3) {
-		mrl.ibi_len = strtol(argv[3], NULL, 16);
+		ibi_len = strtol(argv[3], NULL, 16);
 	}
 
-	ret = i3c_ccc_do_setmrl_all(dev, &mrl, argc > 3);
+	ret = i3c_bus_setmrl_all(dev, mrl, ibi_len, argc > 3);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC SETMRL BC.");
 		return ret;
 	}
 
-	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
-		desc->data_length.mrl = mrl.len;
-		if ((argc > 3) && (desc->bcr & I3C_BCR_IBI_PAYLOAD_HAS_DATA_BYTE)) {
-			desc->data_length.max_ibi = mrl.ibi_len;
-		}
-	}
+	shell_print(sh, "I3C: SETMRL BC Sent");
 
 	return ret;
 }
@@ -990,8 +933,7 @@ static int cmd_i3c_ccc_setmrl_bc(const struct shell *sh, size_t argc, char **arg
 static int cmd_i3c_ccc_setmwl_bc(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
-	struct i3c_device_desc *desc;
-	struct i3c_ccc_mwl mwl;
+	uint16_t mwl;
 	int ret;
 
 	dev = shell_device_get_binding(argv[ARGV_DEV]);
@@ -1000,17 +942,15 @@ static int cmd_i3c_ccc_setmwl_bc(const struct shell *sh, size_t argc, char **arg
 		return -ENODEV;
 	}
 
-	mwl.len = strtol(argv[2], NULL, 16);
+	mwl = strtol(argv[2], NULL, 16);
 
-	ret = i3c_ccc_do_setmwl_all(dev, &mwl);
+	ret = i3c_bus_setmwl_all(dev, mwl);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC SETMWL BC.");
 		return ret;
 	}
 
-	I3C_BUS_FOR_EACH_I3CDEV(dev, desc) {
-		desc->data_length.mwl = mwl.len;
-	}
+	shell_print(sh, "I3C: SETMWL BC Sent");
 
 	return ret;
 }
@@ -1037,6 +977,8 @@ static int cmd_i3c_ccc_deftgts(const struct shell *sh, size_t argc, char **argv)
 		shell_error(sh, "I3C: unable to send CCC DEFTGTS.");
 		return ret;
 	}
+
+	shell_print(sh, "I3C: DEFTGTS sent");
 
 	return ret;
 }
@@ -1070,7 +1012,6 @@ static int cmd_i3c_ccc_getacccr(const struct shell *sh, size_t argc, char **argv
 {
 	const struct device *dev, *tdev;
 	struct i3c_device_desc *desc;
-	struct i3c_ccc_address handoff_address;
 	int ret;
 
 	ret = i3c_parse_args(sh, argv, &dev, &tdev, &desc);
@@ -1083,18 +1024,10 @@ static int cmd_i3c_ccc_getacccr(const struct shell *sh, size_t argc, char **argv
 		return -EINVAL;
 	}
 
-	ret = i3c_ccc_do_getacccr(desc, &handoff_address);
+	ret = i3c_bus_getacccr(desc);
 	if (ret < 0) {
 		shell_error(sh, "I3C: unable to send CCC GETACCCR.");
 		return ret;
-	}
-
-	/* Verify Odd Parity and Correct Dynamic Address Reply */
-	if ((i3c_odd_parity(handoff_address.addr >> 1) != (handoff_address.addr & BIT(0))) ||
-	    (handoff_address.addr >> 1 != desc->dynamic_addr)) {
-		shell_error(sh, "I3C: invalid returned address 0x%02x; expected 0x%02x",
-			    handoff_address.addr, desc->dynamic_addr);
-		return -EIO;
 	}
 
 	shell_print(sh, "I3C: Controller Handoff successful");
@@ -1162,7 +1095,6 @@ static int cmd_i3c_ccc_rstact(const struct shell *sh, size_t argc, char **argv)
 
 	return ret;
 }
-
 
 /* i3c ccc enec_bc <device> <defining byte> */
 static int cmd_i3c_ccc_enec_bc(const struct shell *sh, size_t argc, char **argv)

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -2320,6 +2320,186 @@ static inline int i3c_device_info_get(struct i3c_device_desc *target)
 bool i3c_bus_has_sec_controller(const struct device *dev);
 
 /**
+ * @brief Reset all devices on the bus and clear their dynamic addresses.
+ *
+ * Sends the RSTDAA (Reset Dynamic Address Assignment) CCC to all devices on the bus.
+ *
+ * @param dev Pointer to the controller device driver instance.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_rstdaa_all(const struct device *dev);
+
+/**
+ * @brief Assign a dynamic address to a device using its static address.
+ *
+ * Sends the SETDASA (Set Dynamic Address from Static Address) CCC to the target device.
+ *
+ * @param desc Pointer to the target device descriptor.
+ * @param dynamic_addr The dynamic address to assign to the device.
+ *
+ * @retval 0 If successful.
+ * @retval -EADDRNOTAVAIL If the address is not available.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_setdasa(struct i3c_device_desc *desc, uint8_t dynamic_addr);
+
+/**
+ * @brief Assign a new dynamic address to a device.
+ *
+ * Sends the SETNEWDA (Set New Dynamic Address) CCC to the target device.
+ *
+ * @param desc Pointer to the target device descriptor.
+ * @param dynamic_addr The new dynamic address to assign to the device.
+ *
+ * @retval 0 If successful.
+ * @retval -EADDRNOTAVAIL If the address is not available.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_setnewda(struct i3c_device_desc *desc, uint8_t dynamic_addr);
+
+/**
+ * @brief Assign static addresses as dynamic addresses for all devices on the bus.
+ *
+ * Sends the SETAASA (Set All Addresses to Static Address) CCC to all devices on the bus.
+ *
+ * @param dev Pointer to the controller device driver instance.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_setaasa(const struct device *dev);
+
+/**
+ * @brief Retrieve the Bus Characteristics Register (BCR) of a device.
+ *
+ * Sends the GETBCR CCC to the target device and updates its descriptor.
+ *
+ * @param desc Pointer to the target device descriptor.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_getbcr(struct i3c_device_desc *desc);
+
+/**
+ * @brief Retrieve the Device Characteristics Register (DCR) of a device.
+ *
+ * Sends the GETDCR CCC to the target device and updates its descriptor.
+ *
+ * @param desc Pointer to the target device descriptor.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_getdcr(struct i3c_device_desc *desc);
+
+/**
+ * @brief Retrieve the Provisional ID (PID) of a device.
+ *
+ * Sends the GETPID CCC to the target device and updates its descriptor.
+ *
+ * @param desc Pointer to the target device descriptor.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_getpid(struct i3c_device_desc *desc);
+
+/**
+ * @brief Retrieve the Maximum Read Length (MRL) of a device.
+ *
+ * Sends the GETMRL CCC to the target device and updates its descriptor.
+ *
+ * @param desc Pointer to the target device descriptor.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_getmrl(struct i3c_device_desc *desc);
+
+/**
+ * @brief Retrieve the Maximum Write Length (MWL) of a device.
+ *
+ * Sends the GETMWL CCC to the target device and updates its descriptor.
+ *
+ * @param desc Pointer to the target device descriptor.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_getmwl(struct i3c_device_desc *desc);
+
+/**
+ * @brief Set the Maximum Read Length (MRL) for a device.
+ *
+ * Sends the SETMRL CCC to the target device.
+ *
+ * @param desc Pointer to the target device descriptor.
+ * @param mrl Maximum read length to set.
+ * @param ibi_len Maximum IBI length to set.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_setmrl(struct i3c_device_desc *desc, uint16_t mrl, uint8_t ibi_len);
+
+/**
+ * @brief Set the Maximum Write Length (MWL) for a device.
+ *
+ * Sends the SETMWL CCC to the target device.
+ *
+ * @param desc Pointer to the target device descriptor.
+ * @param mwl Maximum write length to set.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_setmwl(struct i3c_device_desc *desc, uint16_t mwl);
+
+/**
+ * @brief Set the Maximum Read Length (MRL) for all devices on the bus.
+ *
+ * Sends the SETMRL CCC to all devices on the bus.
+ *
+ * @param dev Pointer to the controller device driver instance.
+ * @param mrl Maximum read length to set.
+ * @param ibi_len Maximum IBI length to set.
+ * @param has_ibi_size True if to transmit max ibi len
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_setmrl_all(const struct device *dev, uint16_t mrl, uint8_t ibi_len, bool has_ibi_size);
+
+/**
+ * @brief Set the Maximum Write Length (MWL) for all devices on the bus.
+ *
+ * Sends the SETMWL CCC to all devices on the bus.
+ *
+ * @param dev Pointer to the controller device driver instance.
+ * @param mwl Maximum write length to set.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_setmwl_all(const struct device *dev, uint16_t mwl);
+
+#if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
+/**
+ * @brief Retrieve the Active Controller's Dynamic Address (ACCCR).
+ *
+ * Sends the GETACCCR CCC to the target device and verifies the response.
+ *
+ * @param desc Pointer to the target device descriptor.
+ *
+ * @retval 0 If successful.
+ * @retval -EIO General Input/Output error.
+ */
+int i3c_bus_getacccr(struct i3c_device_desc *desc);
+
+/**
  * @brief Send the CCC DEFTGTS
  *
  * This builds the payload required for DEFTGTS and transmits it out
@@ -2331,6 +2511,7 @@ bool i3c_bus_has_sec_controller(const struct device *dev);
  * @retval -EIO General Input/Output error.
  */
 int i3c_bus_deftgts(const struct device *dev);
+#endif /* CONFIG_I3C_TARGET */
 
 /**
  * @brief Calculate odd parity
@@ -2357,7 +2538,7 @@ uint8_t i3c_odd_parity(uint8_t p);
  * @retval -EIO General Input/Output error.
  * @retval -EBUSY Target cannot accept Controller Handoff
  */
-int i3c_device_controller_handoff(const struct i3c_device_desc *target, bool requested);
+int i3c_device_controller_handoff(struct i3c_device_desc *target, bool requested);
 #endif /* CONFIG_I3C_CONTROLLER */
 
 #if defined(CONFIG_I3C_USE_IBI) || defined(__DOXYGEN__)


### PR DESCRIPTION
Create bus helpers that will send ccc commands as well as update
items within the i3c descriptor. These are different than the
direct ccc functions as these can give a bit of convenience to also
updating the descriptor.