### PR TITLE
tests: spi_controller_peripheral: fix CTRLSEL conflict

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast_spis.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpuapp_fast_spis.overlay
@@ -78,6 +78,10 @@
 	};
 };
 
+&exmif{
+	status = "disabled";
+};
+
 &gpio0 {
 	status = "okay";
 };


### PR DESCRIPTION
Both EXMIF and SPIS peripherals are claiming GPIO port 6 pin 0, but with different CTRLSEL values. This will trigger a build error with nrf-regtool 9.0.0 as it is not possible to apply this configuration to hardware.

Fix the issue by disabling the EXMIF node that is enabled by default.