### PR TITLE
soc: intel_adsp: ace30: set MMU permissions for rom_ext

### DIFF
--- a/soc/intel/intel_adsp/ace/include/adsp_memory.h
+++ b/soc/intel/intel_adsp/ace/include/adsp_memory.h
@@ -68,6 +68,13 @@
 #define IMR_BOOT_LDR_STACK_BASE		(IMR_BOOT_LDR_BSS_BASE + IMR_BOOT_LDR_BSS_SIZE)
 #define IMR_BOOT_LDR_STACK_SIZE		0x1000
 
+/* ROM_EXT sections, used only for MMU mapping */
+#define IMR_ROM_EXT_OFFSET		0xB000
+#define IMR_ROM_EXT_CODE_BASE		(L3_MEM_BASE_ADDR + IMR_ROM_EXT_OFFSET)
+#define IMR_ROM_EXT_CODE_SIZE		0xD000
+#define IMR_ROM_EXT_DATABSS_BASE	(IMR_ROM_EXT_CODE_BASE + IMR_ROM_EXT_CODE_SIZE)
+#define IMR_ROM_EXT_DATABSS_SIZE	0x18000
+
 /* position of L3 heap, size of L3 heap - till end of the L3 memory */
 /* !!! FIXME: L3 heap base MUST be automatically calculated. !!! */
 #define IMR_L3_HEAP_BASE		(IMR_BOOT_LDR_STACK_BASE + IMR_BOOT_LDR_STACK_SIZE)

--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -76,6 +76,18 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	},
 	/* Map IMR */
 	{
+		.start = (uint32_t)IMR_ROM_EXT_CODE_BASE,
+		.end   = (uint32_t)(IMR_ROM_EXT_CODE_BASE + IMR_ROM_EXT_CODE_SIZE),
+		.attrs = XTENSA_MMU_PERM_X,
+		.name = "IMR_rom_ext_code",
+	},
+	{
+		.start = (uint32_t)IMR_ROM_EXT_DATABSS_BASE,
+		.end   = (uint32_t)(IMR_ROM_EXT_DATABSS_BASE + IMR_ROM_EXT_DATABSS_SIZE),
+		.attrs = XTENSA_MMU_PERM_W,
+		.name = "IMR_rom_ext_data_bss",
+	},
+	{
 		.start = (uint32_t)(IMR_BOOT_LDR_MANIFEST_BASE - IMR_BOOT_LDR_MANIFEST_SIZE),
 		.end   = (uint32_t)IMR_BOOT_LDR_MANIFEST_BASE,
 		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB,

--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -148,7 +148,7 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	},
 	{
 		/* FIXME: definitely need more refinements... */
-		.start = (uint32_t)0x170000,
+		.start = (uint32_t)0x160000,
 		.end   = (uint32_t)0x180000,
 		.attrs = XTENSA_MMU_PERM_W,
 		.name = "hwreg1",


### PR DESCRIPTION
This patch adds MMU mapping for rom_ext sections.
It is possible to call the rom_ext code located in IMR