### PR TITLE
modules: nrf_wifi: Remove unnecessary check

### DIFF
--- a/modules/nrf_wifi/bus/CMakeLists.txt
+++ b/modules/nrf_wifi/bus/CMakeLists.txt
@@ -4,11 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Check if ZEPHYR_BASE is set
-if(NOT DEFINED ENV{ZEPHYR_BASE})
-    message(FATAL_ERROR "ZEPHYR_BASE environment variable is not set. Please set it to the Zephyr base directory.")
-endif()
-
 set(NRF_WIFI_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
 if (CONFIG_NRF70_BUSLIB)


### PR DESCRIPTION
The Zephyr base variable is not used below and also is deprecated and not needed to be set.

Fixes #87950.