### PR TITLE
Add edtlib helpers for gpio-reserved-ranges

### DIFF
--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -29,18 +29,26 @@ extern "C" {
  *
  * Example devicetree fragment:
  *
- *     gpio1: gpio@... { };
+ * @code{.dts}
+ *     gpio1: gpio@... {
+ *             gpio-controller;
+ *     };
  *
- *     gpio2: gpio@... { };
+ *     gpio2: gpio@... {
+ *             gpio-controller;
+ *     };
  *
  *     n: node {
  *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
  *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
  *     };
+ * @endcode
  *
  * Example usage:
  *
+ * @code{.c}
  *     DT_GPIO_CTLR_BY_IDX(DT_NODELABEL(n), gpios, 1) // DT_NODELABEL(gpio2)
+ * @endcode
  *
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
@@ -73,13 +81,16 @@ extern "C" {
  *
  * Example devicetree fragment:
  *
+ * @code{.dts}
  *     gpio1: gpio@... {
  *             compatible = "vnd,gpio";
+ *             gpio-controller;
  *             #gpio-cells = <2>;
  *     };
  *
  *     gpio2: gpio@... {
  *             compatible = "vnd,gpio";
+ *             gpio-controller;
  *             #gpio-cells = <2>;
  *     };
  *
@@ -87,17 +98,22 @@ extern "C" {
  *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
  *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
  *     };
+ * @endcode
  *
  * Bindings fragment for the vnd,gpio compatible:
  *
+ * @code{.yaml}
  *     gpio-cells:
  *       - pin
  *       - flags
+ * @endcode
  *
  * Example usage:
  *
+ * @code{.c}
  *     DT_GPIO_PIN_BY_IDX(DT_NODELABEL(n), gpios, 0) // 10
  *     DT_GPIO_PIN_BY_IDX(DT_NODELABEL(n), gpios, 1) // 30
+ * @endcode
  *
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
@@ -129,13 +145,16 @@ extern "C" {
  *
  * Example devicetree fragment:
  *
+ * @code{.dts}
  *     gpio1: gpio@... {
  *             compatible = "vnd,gpio";
+ *             gpio-controller;
  *             #gpio-cells = <2>;
  *     };
  *
  *     gpio2: gpio@... {
  *             compatible = "vnd,gpio";
+ *             gpio-controller;
  *             #gpio-cells = <2>;
  *     };
  *
@@ -143,17 +162,22 @@ extern "C" {
  *             gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
  *                     <&gpio2 30 GPIO_ACTIVE_HIGH>;
  *     };
+ * @endcode
  *
  * Bindings fragment for the vnd,gpio compatible:
  *
+ * @code{.yaml}
  *     gpio-cells:
  *       - pin
  *       - flags
+ * @endcode
  *
  * Example usage:
  *
+ * @code{.c}
  *     DT_GPIO_FLAGS_BY_IDX(DT_NODELABEL(n), gpios, 0) // GPIO_ACTIVE_LOW
  *     DT_GPIO_FLAGS_BY_IDX(DT_NODELABEL(n), gpios, 1) // GPIO_ACTIVE_HIGH
+ * @endcode
  *
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
@@ -183,8 +207,10 @@ extern "C" {
  *
  * Example devicetree fragment:
  *
+ * @code{.dts}
  *     gpio1: gpio@... {
  *       compatible = "vnd,gpio";
+ *       gpio-controller;
  *       #gpio-cells = <2>;
  *
  *       n1: node-1 {
@@ -199,17 +225,22 @@ extern "C" {
  *               output-low;
  *       };
  *     };
+ * @endcode
  *
  * Bindings fragment for the vnd,gpio compatible:
  *
+ * @code{.yaml}
  *     gpio-cells:
  *       - pin
  *       - flags
+ * @endcode
  *
  * Example usage:
  *
+ * @code{.c}
  *     DT_NUM_GPIO_HOGS(DT_NODELABEL(n1)) // 2
  *     DT_NUM_GPIO_HOGS(DT_NODELABEL(n2)) // 1
+ * @endcode
  *
  * @param node_id node identifier; may or may not be a GPIO hog node.
  * @return number of hogged GPIOs in the node
@@ -226,8 +257,10 @@ extern "C" {
  *
  * Example devicetree fragment:
  *
+ * @code{.dts}
  *     gpio1: gpio@... {
  *       compatible = "vnd,gpio";
+ *       gpio-controller;
  *       #gpio-cells = <2>;
  *
  *       n1: node-1 {
@@ -242,18 +275,23 @@ extern "C" {
  *               output-low;
  *       };
  *     };
+ * @endcode
  *
  * Bindings fragment for the vnd,gpio compatible:
  *
+ * @code{.yaml}
  *     gpio-cells:
  *       - pin
  *       - flags
+ * @endcode
  *
  * Example usage:
  *
+ * @code{.c}
  *     DT_GPIO_HOG_PIN_BY_IDX(DT_NODELABEL(n1), 0) // 0
  *     DT_GPIO_HOG_PIN_BY_IDX(DT_NODELABEL(n1), 1) // 1
  *     DT_GPIO_HOG_PIN_BY_IDX(DT_NODELABEL(n2), 0) // 3
+ * @endcode
  *
  * @param node_id node identifier
  * @param idx logical index into "gpios"
@@ -271,8 +309,10 @@ extern "C" {
  *
  * Example devicetree fragment:
  *
+ * @code{.dts}
  *     gpio1: gpio@... {
  *       compatible = "vnd,gpio";
+ *       gpio-controller;
  *       #gpio-cells = <2>;
  *
  *       n1: node-1 {
@@ -287,18 +327,23 @@ extern "C" {
  *               output-low;
  *       };
  *     };
+ * @endcode
  *
  * Bindings fragment for the vnd,gpio compatible:
  *
+ * @code{.yaml}
  *     gpio-cells:
  *       - pin
  *       - flags
+ * @endcode
  *
  * Example usage:
  *
+ * @code{.c}
  *     DT_GPIO_HOG_FLAGS_BY_IDX(DT_NODELABEL(n1), 0) // GPIO_ACTIVE_HIGH
  *     DT_GPIO_HOG_FLAGS_BY_IDX(DT_NODELABEL(n1), 1) // GPIO_ACTIVE_LOW
  *     DT_GPIO_HOG_FLAGS_BY_IDX(DT_NODELABEL(n2), 0) // GPIO_ACTIVE_HIGH
+ * @endcode
  *
  * @param node_id node identifier
  * @param idx logical index into "gpios"

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -503,14 +503,14 @@ struct gpio_dt_spec {
  * Example devicetree fragment:
  *
  * @code{.dts}
- *	a {
+ *	a: gpio-controller-1 {
  *		compatible = "some,gpio-controller";
  *		ngpios = <32>;
  *		gpio-reserved-ranges = <0  4>, <5  3>, <9  5>, <11 2>, <15 2>,
  *					<18 2>, <21 1>, <23 1>, <25 4>, <30 2>;
  *	};
  *
- *	b {
+ *	b: gpio-controller-2 {
  *		compatible = "some,gpio-controller";
  *		ngpios = <18>;
  *		gpio-reserved-ranges = <3 2>, <10 1>;
@@ -527,15 +527,15 @@ struct gpio_dt_spec {
  *	};
  *
  *	static const struct some_config dev_cfg_a = {
- *		.ngpios = DT_PROP_OR(DT_LABEL(a), ngpios, 0),
- *		.gpios_reserved = GPIO_DT_RESERVED_RANGES_NGPIOS(DT_LABEL(a),
- *					DT_PROP(DT_LABEL(a), ngpios)),
+ *		.ngpios = DT_PROP(DT_NODELABEL(a), ngpios),
+ *		.gpios_reserved = GPIO_DT_RESERVED_RANGES_NGPIOS(DT_NODELABEL(a),
+ *					DT_PROP(DT_NODELABEL(a), ngpios)),
  *	};
  *
  *	static const struct some_config dev_cfg_b = {
- *		.ngpios = DT_PROP_OR(DT_LABEL(b), ngpios, 0),
- *		.gpios_reserved = GPIO_DT_RESERVED_RANGES_NGPIOS(DT_LABEL(b),
- *					DT_PROP(DT_LABEL(b), ngpios)),
+ *		.ngpios = DT_PROP(DT_NODELABEL(b), ngpios),
+ *		.gpios_reserved = GPIO_DT_RESERVED_RANGES_NGPIOS(DT_NODELABEL(b),
+ *					DT_PROP(DT_NODELABEL(b), ngpios)),
  *	};
  *@endcode
  *
@@ -617,7 +617,7 @@ struct gpio_dt_spec {
  * Example devicetree fragment:
  *
  * @code{.dts}
- *	a {
+ *	a: gpio-controller-1 {
  *		compatible = "some,gpio-controller";
  *		ngpios = <32>;
  *		gpio-reserved-ranges = <0 8>, <9 5>, <15 16>;
@@ -634,7 +634,7 @@ struct gpio_dt_spec {
  *
  *	static const struct some_config dev_cfg = {
  *		.port_pin_mask = GPIO_DT_PORT_PIN_MASK_NGPIOS_EXC(
- *					DT_LABEL(a), 32),
+ *					DT_NODELABEL(a), 32),
  *	};
  * @endcode
  *

--- a/scripts/dts/python-devicetree/tests/test-bindings/gpio-controller.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/gpio-controller.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: GPIO controller for bindings tests
+
+compatible: "gpio-controller"
+
+# The property definitions for gpio-controller and #gpio-cells are
+# intentionally omitted from here. The behavior of a GPIO controller
+# is defined in dt-schema and the #gpio-cells property is implicitly
+# defined in the DT Spec itself, so we want the devicetree package to
+# behave appropriately regardless of what may or may not be in the
+# Zephyr-specific bindings.

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -291,6 +291,34 @@
 	};
 
 	//
+	// GPIO controllers
+	//
+
+	gpio-1 {
+		compatible = "gpio-controller";
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+
+	gpio-2 {
+		compatible = "gpio-controller";
+		gpio-controller;
+		/*
+		 * #gpio-cells values other than 2 are strongly discouraged,
+		 * but not forbidden, so include coverage for them.
+		 */
+		#gpio-cells = <3>;
+		gpio-reserved-ranges = <3 1>;
+	};
+
+	gpio-3 {
+		compatible = "gpio-controller";
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-reserved-ranges = <3 1>, <10 2>;
+	};
+
+	//
 	// 'pinctrl-<index>'
 	//
 

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -223,6 +223,34 @@ def test_pinctrl():
         edtlib.PinCtrl(node=node, name='two', conf_nodes=[state_1, state_2])
     ]
 
+def test_gpio():
+    '''Test GPIO controllers.'''
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    assert not isinstance(edt.get_node("/"), edtlib.GpioController)
+
+    gpio_1 = edt.get_node("/gpio-1")
+    assert isinstance(gpio_1, edtlib.GpioController)
+    assert gpio_1.n_cells == 2
+    assert gpio_1.reserved_ranges == []
+    assert gpio_1.reserved_gpios == []
+
+    gpio_2 = edt.get_node("/gpio-2")
+    assert isinstance(gpio_2, edtlib.GpioController)
+    assert gpio_2.n_cells == 3
+    assert gpio_2.reserved_ranges == [edtlib.GpioReservedRange(node=gpio_2, start=3, size=1)]
+    assert gpio_2.reserved_gpios == [3]
+
+    gpio_3 = edt.get_node("/gpio-3")
+    assert isinstance(gpio_3, edtlib.GpioController)
+    assert gpio_3.n_cells == 2
+    assert gpio_3.reserved_ranges == [
+        edtlib.GpioReservedRange(node=gpio_3, start=3, size=1),
+        edtlib.GpioReservedRange(node=gpio_3, start=10, size=2)
+    ]
+    assert gpio_3.reserved_gpios == [3, 10, 11]
+
 def test_hierarchy():
     '''Test Node.parent and Node.children'''
     with from_here():


### PR DESCRIPTION
This is the first step towards resolving #88022. It is a standalone enhancement in its own right. Please see the detailed description in the issue for the overall justification of the changes. (I'm trying to split this up into the smallest pieces possible since I expect the overall issue will take a while.)