### PR TITLE
scripts: ci: compliance: Check .pyi files with ruff

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1763,7 +1763,7 @@ class Ruff(ComplianceTest):
 
     def run(self):
         for file in get_files(filter="d"):
-            if not file.endswith(".py"):
+            if not file.endswith((".py", ".pyi")):
                 continue
 
             try:


### PR DESCRIPTION
Add pyi stub files to be checked by the ruff CI compliance rule.