### PR TITLE
scripts: ci: check_compliance: Disallow board hooks in defconfigs

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -704,6 +704,8 @@ class KconfigCheck(ComplianceTest):
 
         disallowed_symbols = {
             "PINCTRL": "Drivers requiring PINCTRL must SELECT it instead.",
+            "BOARD_EARLY_INIT_HOOK": "Boards requiring hooks must SELECT them instead.",
+            "BOARD_LATE_INIT_HOOK": "Boards requiring hooks must SELECT them instead.",
         }
 
         disallowed_regex = "(" + "|".join(disallowed_symbols.keys()) + ")$"


### PR DESCRIPTION
Adds board hooks to the disallowed defconfig symbol list as these should be selected, not put in a defconfig