### PR TITLE
drivers: udc: fix it82xx2 and numaker drivers compilation

### DIFF
--- a/drivers/usb/udc/udc_it82xx2.c
+++ b/drivers/usb/udc/udc_it82xx2.c
@@ -1215,7 +1215,7 @@ static void xfer_work_handler(const struct device *dev)
 		}
 
 		if (evt.ep != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ep_cfg)) {
-			if (work_handler_xfer_next(ep_cfg) == 0) {
+			if (work_handler_xfer_next(dev, ep_cfg) == 0) {
 				udc_ep_set_busy(ep_cfg, true);
 			}
 		}

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -961,7 +961,7 @@ static int numaker_usbd_msg_handle_out(const struct device *dev, struct numaker_
 	__ASSERT_NO_MSG(msg->type == NUMAKER_USBD_MSG_TYPE_OUT);
 
 	ep = msg->out.ep;
-	ep_cfg = udc_get_ep_cfg(ep);
+	ep_cfg = udc_get_ep_cfg(dev, ep);
 
 	udc_ep_set_busy(ep_cfg, false);
 


### PR DESCRIPTION
The dev argument is missing.
Introduced in the commit 1cccf28d5e51
("drivers: usb: udc: Reduce unnecessary ep config lookups").