### PR TITLE
openthread: map Thread network interface state

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -353,4 +353,14 @@ config OPENTHREAD_PLATFORM_KEYS_EXPORTABLE_ENABLE
 	help
 	  Enable the creation of exportable MAC keys in the OpenThread Key Manager.
 
+config OPENTHREAD_INTERFACE_EARLY_UP
+	bool "Make OpenThread interface ready as soon as Thread is enabled"
+	help
+	  When enabled, OpenThread interface will be marked ready (operational
+	  UP) as soon as Thread has been enabled. This means the interface will
+	  be ready to transmit application packets during the Mesh Link
+	  Establishment phase.
+	  Otherwise, OpenThread interface will be marked operational UP only
+	  after the device joins a Thread network.
+
 endif # NET_L2_OPENTHREAD_IMPLEMENTATION_ZEPHYR


### PR DESCRIPTION
The current mapping gets the network interface into dormant state when Thread is not attached. While the node is not capable of doing multi-hop communication when it's not attached, it should be able to do link-local communication. This commit changes the mapping to look at OpenThread's own network interface state instead without further checking Thread's device role, so that link-local communication is supported when a node in detached state.