### PR TITLE
Revert "drivers: dma: intel_adsp_hda: change L1_EXIT defaults"

### DIFF
--- a/drivers/dma/Kconfig.intel_adsp_hda
+++ b/drivers/dma/Kconfig.intel_adsp_hda
@@ -44,7 +44,7 @@ config DMA_INTEL_ADSP_HDA
 
 config DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT
 	bool "Intel ADSP HDA Host L1 Exit Interrupt"
-	default y if SOC_INTEL_ACE15_MTPM || SOC_INTEL_ACE20_LNL || SOC_INTEL_ACE30
+	default y if SOC_SERIES_INTEL_ADSP_ACE
 	depends on DMA_INTEL_ADSP_HDA_HOST_IN || DMA_INTEL_ADSP_HDA_HOST_OUT
 	help
 	  Intel ADSP HDA Host Interrupt for L1 exit.


### PR DESCRIPTION
This reverts commit c2f02533a6ad287d0f24a01abb05be0095398154.

DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT should be enabled for all ACE platforms. Any new platform in the ACE series will likely need it as well.

This reverts https://github.com/zephyrproject-rtos/zephyr/pull/81593.