### PR TITLE
STM32C0: Add USB support

### DIFF
--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -165,3 +165,9 @@
 &dmamux1 {
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.yaml
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.yaml
@@ -16,6 +16,8 @@ supported:
   - rtc
   - spi
   - watchdog
+  - usb_device
+  - usbd
 ram: 24
 flash: 128
 vendor: st

--- a/dts/arm/st/c0/stm32c071.dtsi
+++ b/dts/arm/st/c0/stm32c071.dtsi
@@ -44,6 +44,20 @@
 			status = "disabled";
 		};
 
+		usb: usb@40005c00 {
+			compatible = "st,stm32-usb";
+			reg = <0x40005c00 0x400>;
+			interrupts = <8 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <2048>;
+			maximum-speed = "full-speed";
+			phys = <&usb_fs_phy>;
+			clocks = <&rcc STM32_CLOCK(APB1, 13)>,
+				 <&rcc STM32_SRC_HSE USB_SEL(1)>;
+			status = "disabled";
+		};
+
 		spi2: spi@40003800 {
 			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
@@ -63,5 +77,10 @@
 		dmamux1: dmamux@40020800 {
 			dma-channels = <5>;
 		};
+	};
+
+	usb_fs_phy: usbphy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 };

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -31,6 +31,7 @@
 
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x54
+#define CCIPR2_REG		0x58
 
 /** @brief RCC_CSR1 register offset */
 #define CSR1_REG		0x5C
@@ -44,6 +45,8 @@
 #define I2C1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 12, CCIPR_REG)
 #define I2C2_I2S1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 3, 14, CCIPR_REG)
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 30, CCIPR_REG)
+/** CCIPR2 devices */
+#define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 12, CCIPR2_REG)
 /** CSR1 devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 8, CSR1_REG)
 


### PR DESCRIPTION
- Defined CCIPR2_REG offset.
- Added USB_SEL(val) macro to support USB clock selection using CCIPR2_REG.
- Added USB device node.
- Added usb_fs_phy node.
- Enable the USB node of the nucleo_c071rb board
