### PR TITLE
Tests: Bluetooth: Classic: Bumble `power_on()` will fail on Linux

### DIFF
--- a/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
+++ b/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
@@ -338,6 +338,15 @@ async def wait_for_shell_response(dut, message):
     return found, lines
 
 
+async def device_power_on(device) -> None:
+    while True:
+        try:
+            await device.power_on()
+            break
+        except Exception:
+            continue
+
+
 async def sdp_ssa_discover_no_record(hci_port, shell, dut, address) -> None:
     logger.info('<<< SDP Discovery ...')
     async with await open_transport_or_link(hci_port) as hci_transport:
@@ -353,7 +362,7 @@ async def sdp_ssa_discover_no_record(hci_port, shell, dut, address) -> None:
         # device.sdp_service_records = SDP_SERVICE_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -386,7 +395,7 @@ async def sdp_ssa_discover_one_record(hci_port, shell, dut, address) -> None:
         device.sdp_service_records = SDP_SERVICE_ONE_RECORD
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -443,7 +452,7 @@ async def sdp_ssa_discover_two_records(hci_port, shell, dut, address) -> None:
         device.sdp_service_records = SDP_SERVICE_TWO_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -513,7 +522,7 @@ async def sdp_ssa_discover_multiple_records(hci_port, shell, dut, address) -> No
         device.sdp_service_records = SDP_SERVICE_MULTIPLE_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -547,7 +556,7 @@ async def sdp_ss_discover_no_record(hci_port, shell, dut, address) -> None:
         # device.sdp_service_records = SDP_SERVICE_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -580,7 +589,7 @@ async def sdp_ss_discover_one_record(hci_port, shell, dut, address) -> None:
         device.sdp_service_records = SDP_SERVICE_ONE_RECORD
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -623,7 +632,7 @@ async def sdp_ss_discover_two_records(hci_port, shell, dut, address) -> None:
         device.sdp_service_records = SDP_SERVICE_TWO_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -666,7 +675,7 @@ async def sdp_ss_discover_multiple_records(hci_port, shell, dut, address) -> Non
         device.sdp_service_records = SDP_SERVICE_MULTIPLE_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -710,7 +719,7 @@ async def sdp_sa_discover_no_record(hci_port, shell, dut, address) -> None:
         # device.sdp_service_records = SDP_SERVICE_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -743,7 +752,7 @@ async def sdp_sa_discover_one_record(hci_port, shell, dut, address) -> None:
         device.sdp_service_records = SDP_SERVICE_ONE_RECORD
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -797,7 +806,7 @@ async def sdp_sa_discover_two_records(hci_port, shell, dut, address) -> None:
         device.sdp_service_records = SDP_SERVICE_TWO_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]
@@ -860,7 +869,7 @@ async def sdp_sa_discover_multiple_records(hci_port, shell, dut, address) -> Non
         device.sdp_service_records = SDP_SERVICE_MULTIPLE_RECORDS
         with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
             device.host.snooper = BtSnooper(snoop_file)
-            await device.power_on()
+            await device_power_on(device)
             await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
 
             target_address = address.split(" ")[0]

--- a/tests/bluetooth/classic/sdp_s/pytest/test_sdp.py
+++ b/tests/bluetooth/classic/sdp_s/pytest/test_sdp.py
@@ -22,6 +22,15 @@ from twister_harness import DeviceAdapter, Shell
 logger = logging.getLogger(__name__)
 
 
+async def device_power_on(device) -> None:
+    while True:
+        try:
+            await device.power_on()
+            break
+        except Exception:
+            continue
+
+
 class discovery_listener(Device.Listener):
     def __init__(self, address: str, event, **kwargs):
         self._address = address
@@ -67,7 +76,8 @@ async def start_discovery(hci_port, address) -> None:
             hci_transport.sink,
         )
         device.listener = discovery_listener(address, event)
-        await device.power_on()
+        await device_power_on(device)
+
         logger.info('Starting discovery')
         await device.start_discovery()
         await event.wait()
@@ -84,7 +94,7 @@ async def br_connect(hci_port, shell, address) -> None:
         )
         device.classic_enabled = True
         device.le_enabled = False
-        await device.power_on()
+        await device_power_on(device)
 
         target_address = address.split(" ")[0]
         logger.info(f'=== Connecting to {target_address}...')


### PR DESCRIPTION
On Linux, the function `power_on()` of Bumble will fail when executing even-numbered test cases.

From the `btmon` log, the controller will not reply the `HCI Command: Reset` when the issue occurs.

Add a try-except to catch the exception of the function `power_on()`, and retry to calling the function `power_on()` until issue no longer occurs. Or, the test will fail due to the timeout.