### PR TITLE
drivers: clock_control: nrf2_lfclk: Fix selecting lowest power clock

### DIFF
--- a/drivers/clock_control/clock_control_nrf2_lfclk.c
+++ b/drivers/clock_control/clock_control_nrf2_lfclk.c
@@ -19,14 +19,13 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 
 #define LFCLK_HFXO_NODE DT_INST_PHANDLE_BY_NAME(0, clocks, hfxo)
 
-#define LFCLK_LFLPRC_ACCURACY DT_INST_PROP(0, lflprc_accuracy_ppm)
 #define LFCLK_LFRC_ACCURACY DT_INST_PROP(0, lfrc_accuracy_ppm)
 #define LFCLK_HFXO_ACCURACY DT_PROP(LFCLK_HFXO_NODE, accuracy_ppm)
 #define LFCLK_LFLPRC_STARTUP_TIME_US DT_INST_PROP(0, lflprc_startup_time_us)
 #define LFCLK_LFRC_STARTUP_TIME_US DT_INST_PROP(0, lfrc_startup_time_us)
 
-#define LFCLK_MAX_OPTS 5
-#define LFCLK_DEF_OPTS 3
+#define LFCLK_MAX_OPTS 4
+#define LFCLK_DEF_OPTS 2
 
 #define NRFS_CLOCK_TIMEOUT K_MSEC(CONFIG_CLOCK_CONTROL_NRF2_NRFS_CLOCK_TIMEOUT_MS)
 
@@ -35,7 +34,6 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 /* Clock options sorted from highest to lowest power consumption.
  * - Clock synthesized from a high frequency clock
  * - Internal RC oscillator
- * - Internal low power RC oscillator
  * - External clock. These are inserted into the list at driver initialization.
  *   Set to one of the following:
  *   - XTAL. Low or High precision
@@ -56,12 +54,6 @@ static struct clock_options {
 		.accuracy = LFCLK_LFRC_ACCURACY,
 		.precision = 0,
 		.src = NRFS_CLOCK_SRC_LFCLK_LFRC,
-	},
-	{
-		/* NRFS will request FLL16M use HFXO in bypass mode if SYNTH src is used */
-		.accuracy = LFCLK_LFLPRC_ACCURACY,
-		.precision = 0,
-		.src = NRFS_CLOCK_SRC_LFCLK_LFLPRC,
 	},
 	/* Remaining options are populated on lfclk_init */
 };


### PR DESCRIPTION
The application or drivers can request the LFCLK with a given precision and accuracy.
The driver should select the clock source which has the lowest power consumption and still satisfies the requested accuracy and precision.

Before this commit, this was not the case.
Consider the case where the BICR has configured the system to have LFXO with accuracy of 20 ppm.
The existing code would have ordered the clock options as following:
```
[0] = {LFLPRC, 1000 ppm},
[1] = {LFRC, 500 ppm},
[2] = {SYNTH, 30 ppm},
[3] = {LFXO_PIERCE, 20 ppm},
[4] = {LFXO_PIERCE_HP, 20 ppm}
```

**Example 1**: The user requests the clock with an accuracy of 30 ppm. The existing code would request the power hungry "SYNTH".

**Example 2**: The user requests a clock with an accuracy of 500 ppm. The existing code would request the LFRC which consumes more power than the LFXO.

This commit fixes this issue by ordering the clock sources according to power consumption.
For the examples above we user request would result in requesting the 20 ppm LFXO.