### PR TITLE
net: websocket: fix masked data when server sends close

### DIFF
--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -421,7 +421,7 @@ static int websocket_interal_disconnect(struct websocket_context *ctx)
 	NET_DBG("[%p] Disconnecting", ctx);
 
 	ret = websocket_send_msg(ctx->sock, NULL, 0, WEBSOCKET_OPCODE_CLOSE,
-				 true, true, SYS_FOREVER_MS);
+				 ctx->is_client, true, SYS_FOREVER_MS);
 	if (ret < 0) {
 		NET_DBG("[%p] Failed to send close message (err %d).", ctx, ret);
 	}


### PR DESCRIPTION
When sending the close command as a server, the data is incorrectly masked which violates RFC6455 section 5.1.

Use the is_client flag to avoid masking if the close is for a websocket server.