### PR TITLE
net: coap_client: Fix CoAP client thread priority

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1139,6 +1139,10 @@ bool coap_client_has_ongoing_exchange(struct coap_client *client)
 	return has_ongoing_exchange(client);
 }
 
+#define COAP_CLIENT_THREAD_PRIORITY CLAMP(CONFIG_COAP_CLIENT_THREAD_PRIORITY, \
+					  K_HIGHEST_APPLICATION_THREAD_PRIO, \
+					  K_LOWEST_APPLICATION_THREAD_PRIO)
+
 K_THREAD_DEFINE(coap_client_recv_thread, CONFIG_COAP_CLIENT_STACK_SIZE,
 		coap_client_recv, NULL, NULL, NULL,
-		CONFIG_COAP_CLIENT_THREAD_PRIORITY, 0, 0);
+		COAP_CLIENT_THREAD_PRIORITY, 0, 0);


### PR DESCRIPTION
The default thread priority for the CoAP client thread is set to NUM_PREEMPT_PRIORITIES which is not a valid thread priority, as the lowest application thread priority is actually NUM_PREEMPT_PRIORITIES - 1. Because of this, CoAP client library gave an assert on boot if assertions were enabled.

Kconfig does not allow for arithmetics when setting integer defaults, therefore handle this at the preprocessor stage by limiting the actual priority assigned to the CoAP client thread to a valid range.