### PR TITLE
stm32h7rs xspi  Node with domain clock for peripheral clock configuration

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -85,6 +85,19 @@
 	status = "okay";
 };
 
+/* PLL2 for clocking the xspi peripheral */
+&pll2 {
+	div-m = <12>;
+	mul-n = <200>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	div-s = <2>;
+	div-t = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &rcc {
 	clocks = <&pll>;
 	clock-frequency = <DT_FREQ_M(200)>;
@@ -138,4 +151,63 @@
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set the partitions with first MB to make use of the whole Bank1 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+	};
+};
+
+&xspi2 {
+	pinctrl-0 = <&xspim_p2_clk_pn6 &xspim_p2_ncs1_pn1
+		     &xspim_p2_io0_pn2 &xspim_p2_io1_pn3
+		     &xspim_p2_io2_pn4 &xspim_p2_io3_pn5
+		     &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
+		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11
+		     &xspim_p2_dqs0_pn0>;
+	pinctrl-names = "default";
+
+	status = "okay";
+
+	mx25uw25645: xspi-nor-flash@0 {
+		compatible = "st,stm32-xspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(256)>; /* 256Mbits */
+		ospi-max-frequency = <DT_FREQ_M(50)>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_partition: partition@0 {
+				label = "image-0";
+				reg = <0x00000000 DT_SIZE_K(512)>;
+			};
+			slot1_partition: partition@80000 {
+				label = "image-1";
+				reg = <0x0080000 DT_SIZE_K(512)>;
+			};
+			scratch_partition: partition@100000 {
+				label = "image-scratch";
+				reg = <0x00100000 DT_SIZE_K(64)>;
+			};
+			storage_partition: partition@110000 {
+				label = "storage";
+				reg = <0x00110000 DT_SIZE_K(64)>;
+			};
+		};
+	};
 };

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.yaml
@@ -12,4 +12,5 @@ supported:
   - watchdog
   - entropy
   - adc
+  - octospi
 vendor: st

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -207,6 +207,65 @@
 	};
 };
 
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set the partitions with first MB to make use of the whole Bank1 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+	};
+};
+
+&xspi2 {
+	pinctrl-0 = <&xspim_p2_clk_pn6 &xspim_p2_ncs1_pn1
+		     &xspim_p2_io0_pn2 &xspim_p2_io1_pn3
+		     &xspim_p2_io2_pn4 &xspim_p2_io3_pn5
+		     &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
+		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11
+		     &xspim_p2_dqs0_pn0>;
+	pinctrl-names = "default";
+
+	status = "okay";
+
+	mx66uw1g45: xspi-nor-flash@0 {
+		compatible = "st,stm32-xspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(1024)>; /* 1 Gbits */
+		ospi-max-frequency = <DT_FREQ_M(50)>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_partition: partition@0 {
+				label = "image-0";
+				reg = <0x00000000 DT_SIZE_K(512)>;
+			};
+			slot1_partition: partition@80000 {
+				label = "image-1";
+				reg = <0x0080000 DT_SIZE_K(512)>;
+			};
+			scratch_partition: partition@100000 {
+				label = "image-scratch";
+				reg = <0x00100000 DT_SIZE_K(64)>;
+			};
+			storage_partition: partition@110000 {
+				label = "storage";
+				reg = <0x00110000 DT_SIZE_K(64)>;
+			};
+		};
+	};
+};
+
 &die_temp {
 	status = "okay";
 };

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
@@ -13,7 +13,7 @@ supported:
   - watchdog
   - entropy
   - adc
-  - usb_device
+  - octospi
   - usbd
   - memc
 vendor: st

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -337,6 +337,16 @@ int enabled_clock(uint32_t src_clk)
 	    ((src_clk == STM32_SRC_PLL2_R) && IS_ENABLED(STM32_PLL2_R_ENABLED)) ||
 	    ((src_clk == STM32_SRC_PLL3_P) && IS_ENABLED(STM32_PLL3_P_ENABLED)) ||
 	    ((src_clk == STM32_SRC_PLL3_Q) && IS_ENABLED(STM32_PLL3_Q_ENABLED)) ||
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	    (src_clk == STM32_SRC_HCLK1) ||
+	    (src_clk == STM32_SRC_HCLK2) ||
+	    (src_clk == STM32_SRC_HCLK3) ||
+	    (src_clk == STM32_SRC_HCLK4) ||
+	    (src_clk == STM32_SRC_HCLK5) ||
+	    ((src_clk == STM32_SRC_PLL2_S) && IS_ENABLED(STM32_PLL2_S_ENABLED)) ||
+	    ((src_clk == STM32_SRC_PLL2_T) && IS_ENABLED(STM32_PLL2_T_ENABLED)) ||
+	    ((src_clk == STM32_SRC_PLL3_S) && IS_ENABLED(STM32_PLL3_S_ENABLED)) ||
+#endif
 	    ((src_clk == STM32_SRC_PLL3_R) && IS_ENABLED(STM32_PLL3_R_ENABLED))) {
 		return 0;
 	}
@@ -460,6 +470,14 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 	case STM32_CLOCK_BUS_AHB2:
 	case STM32_CLOCK_BUS_AHB3:
 	case STM32_CLOCK_BUS_AHB4:
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	/* HCLKn is a possible source clock for some peripherals */
+	case STM32_SRC_HCLK1:
+	case STM32_SRC_HCLK2:
+	case STM32_SRC_HCLK3:
+	case STM32_SRC_HCLK4:
+	case STM32_SRC_HCLK5:
+#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 		*rate = ahb_clock;
 		break;
 	case STM32_CLOCK_BUS_APB1:
@@ -544,7 +562,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 					      STM32_PLL_N_MULTIPLIER,
 					      STM32_PLL_S_DIVISOR);
 		break;
-	/* PLL 1  has no T-divider */
+	/* PLL 1 has no T-divider */
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 #endif /* STM32_PLL_ENABLED */
 #if defined(STM32_PLL2_ENABLED)

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -42,8 +42,6 @@ LOG_MODULE_REGISTER(flash_stm32_xspi, CONFIG_FLASH_LOG_LEVEL);
 
 #define STM32_XSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
-#define STM32_XSPI_DLYB_BYPASSED DT_PROP(STM32_XSPI_NODE, dlyb_bypass)
-
 #define STM32_XSPI_USE_DMA DT_NODE_HAS_PROP(STM32_XSPI_NODE, dmas)
 
 #if STM32_XSPI_USE_DMA
@@ -2149,17 +2147,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	if (dev_cfg->data_rate == XSPI_DTR_TRANSFER) {
 		dev_data->hxspi.Init.MemoryType = HAL_XSPI_MEMTYPE_MACRONIX;
 		dev_data->hxspi.Init.DelayHoldQuarterCycle = HAL_XSPI_DHQC_ENABLE;
-	} else {
-
 	}
-#if defined(XSPI_DCR1_DLYBYP)
-#if STM32_XSPI_DLYB_BYPASSED
-	dev_data->hxspi.Init.DelayBlockBypass = HAL_XSPI_DELAY_BLOCK_BYPASS;
-#else
-	dev_data->hxspi.Init.DelayBlockBypass = HAL_XSPI_DELAY_BLOCK_ON;
-#endif /* STM32_XSPI_DLYB_BYPASSED */
-#endif /* XSPI_DCR1_DLYBYP */
-
 
 	if (HAL_XSPI_Init(&dev_data->hxspi) != HAL_OK) {
 		LOG_ERR("XSPI Init failed");
@@ -2482,6 +2470,11 @@ static struct flash_stm32_xspi_data flash_stm32_xspi_dev_data = {
 					: HAL_XSPI_CSSEL_NCS2),
 #endif
 			.FreeRunningClock = HAL_XSPI_FREERUNCLK_DISABLE,
+#if defined(XSPI_DCR1_DLYBYP)
+			.DelayBlockBypass = (DT_PROP(STM32_XSPI_NODE, dlyb_bypass)
+					? HAL_XSPI_DELAY_BLOCK_BYPASS
+					: HAL_XSPI_DELAY_BLOCK_ON),
+#endif /* XSPI_DCR1_DLYBYP */
 #if defined(XSPI_DCR3_MAXTRAN)
 			.MaxTran = 0,
 #endif /* XSPI_DCR3_MAXTRAN */

--- a/drivers/flash/flash_stm32_xspi.h
+++ b/drivers/flash/flash_stm32_xspi.h
@@ -67,8 +67,9 @@ struct stream {
 typedef void (*irq_config_func_t)(const struct device *dev);
 
 struct flash_stm32_xspi_config {
-	const struct stm32_pclken *pclken;
-	size_t pclk_len;
+	const struct stm32_pclken pclken;
+	const struct stm32_pclken pclken_ker;
+	const struct stm32_pclken pclken_mgr;
 	irq_config_func_t irq_config;
 	size_t flash_size;
 	uint32_t max_frequency;

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -15,6 +15,7 @@
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
 #include <freq.h>
 
 /*
@@ -81,7 +82,8 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x70000000 DT_SIZE_M(256)>;
 		zephyr,memory-region = "EXTMEM";
-		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_EXTMEM) )>;
+		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
 	};
 
 	clocks {

--- a/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
@@ -38,6 +38,11 @@
 
 /** Clock muxes */
 #define STM32_SRC_CKPER		(STM32_SRC_PLL3_S + 1)
+#define STM32_SRC_HCLK1		(STM32_SRC_CKPER + 1)
+#define STM32_SRC_HCLK2		(STM32_SRC_HCLK1 + 1)
+#define STM32_SRC_HCLK3		(STM32_SRC_HCLK2 + 1)
+#define STM32_SRC_HCLK4		(STM32_SRC_HCLK3 + 1)
+#define STM32_SRC_HCLK5		(STM32_SRC_HCLK4 + 1)
 /** Others: Not yet supported */
 
 /** Bus clocks */

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -26,6 +26,13 @@ DT_STM32_RCC_CLOCK_FREQ := $(dt_node_int_prop_int,$(DT_STM32_RCC_PATH),clock-fre
 DT_ST_PRESCALER := st,prescaler
 DT_STM32_LPTIM_PATH := $(dt_nodelabel_path,stm32_lp_tick_source)
 
+DT_CHOSEN_Z_FLASH := zephyr,flash
+DT_COMPAT_XSPI := st,stm32-xspi
+
+DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
+DT_CHOSEN_FLASH_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
+DT_FLASH_PARENT_IS_XSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_XSPI))
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default "$(DT_STM32_RCC_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,rcc)"
 
@@ -72,5 +79,10 @@ config USE_DT_CODE_PARTITION
 
 config BUILD_WITH_TFM
 	default y if TRUSTED_EXECUTION_NONSECURE
+
+config FLASH_BASE_ADDRESS
+	default $(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1) \
+		if $(DT_FLASH_PARENT_IS_XSPI)
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 endif # SOC_FAMILY_STM32


### PR DESCRIPTION
This PR is adding the xspi nodes to the stm32h7rs serie with domain clock configuration for the peripheral clock  and the XSPIMgr clock
The XSPI peripheral is clocked by the STM32_SRC_PLL2_S and the PLL2 is enabled in the board device tree
```
			clock-names = "xspix", "xspi-ker", "xspi-mgr";
			clocks = <&rcc STM32_CLOCK(AHB5, 5U)>,
				<&rcc STM32_SRC_PLL2_S XSPI2_SEL(1)>,
				<&rcc STM32_CLOCK(AHB5, 14U)>;
```
