### PR TITLE
drivers: sensors: bma4xx: add I2C_RTIO Kconfig for I2C

### DIFF
--- a/drivers/sensor/bosch/bma4xx/Kconfig
+++ b/drivers/sensor/bosch/bma4xx/Kconfig
@@ -12,6 +12,7 @@ menuconfig BMA4XX
 	depends on DT_HAS_BOSCH_BMA4XX_ENABLED
 	depends on SENSOR_ASYNC_API
 	select I2C
+	select I2C_RTIO
 	select RTIO_WORKQ
 	help
 	  Enable driver for Bosch BMA4XX (I2C-based)


### PR DESCRIPTION
Since #83575 bma4xx driver relies on RTIO to work. This means that CONFIG_I2C_RTIO should be defined together with CONFIG_I2C in the Kconfig, otherwise I2C_DT_IODEV_DEFINE() won't be available at build time.

Without this fix I get this failure at build time:
```
zephyr/drivers/sensor/bosch/bma4xx/bma4xx.c:326:9: warning: data definition has no type or storage class
  326 |         I2C_DT_IODEV_DEFINE(bma4xx_iodev_##inst, DT_DRV_INST(inst));
```