### PR TITLE
STM32WB0: update debugging to provide instructions / work with SDK OpenOCD

### DIFF
--- a/boards/st/nucleo_wb05kz/board.cmake
+++ b/boards/st/nucleo_wb05kz/board.cmake
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw" "--start-address=0x10000000")
+board_runner_args(pyocd "--target=stm32wb05kzvx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/nucleo_wb05kz/doc/index.rst
+++ b/boards/st/nucleo_wb05kz/doc/index.rst
@@ -106,6 +106,13 @@ You should see the following message on the console:
 
    Hello World! nucleo_wb05kz/stm32wb05
 
+Usage of the pyOCD runner requires installation of an additional target pack.
+This can be done using the following commands:
+
+.. code-block:: console
+
+   $ pyocd pack update
+   $ pyocd pack install stm32wb0
 
 Debugging
 =========

--- a/boards/st/nucleo_wb05kz/support/openocd.cfg
+++ b/boards/st/nucleo_wb05kz/support/openocd.cfg
@@ -1,5 +1,3 @@
+set CHIPNAME bluenrg-lps
 source [find interface/stlink-dap.cfg]
-
-transport select "dapdirect_swd"
-
-source [find target/stm32wb0x.cfg]
+source [find target/bluenrg-x.cfg]

--- a/boards/st/nucleo_wb07cc/board.cmake
+++ b/boards/st/nucleo_wb07cc/board.cmake
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw" "--start-address=0x10000000")
+board_runner_args(pyocd "--target=stm32wb07ccvx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/nucleo_wb07cc/doc/index.rst
+++ b/boards/st/nucleo_wb07cc/doc/index.rst
@@ -106,6 +106,13 @@ You should see the following message on the console:
 
    Hello World! nucleo_wb07cc/stm32wb07
 
+Usage of the pyOCD runner requires installation of an additional target pack.
+This can be done using the following commands:
+
+.. code-block:: console
+
+   $ pyocd pack update
+   $ pyocd pack install stm32wb0
 
 Debugging
 =========

--- a/boards/st/nucleo_wb07cc/support/openocd.cfg
+++ b/boards/st/nucleo_wb07cc/support/openocd.cfg
@@ -1,5 +1,3 @@
+set CHIPNAME bluenrg-lp
 source [find interface/stlink-dap.cfg]
-
-transport select "dapdirect_swd"
-
-source [find target/stm32wb0x.cfg]
+source [find target/bluenrg-x.cfg]

--- a/boards/st/nucleo_wb09ke/board.cmake
+++ b/boards/st/nucleo_wb09ke/board.cmake
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=sw" "--start-address=0x10000000")
+board_runner_args(pyocd "--target=stm32wb09kevx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/nucleo_wb09ke/doc/index.rst
+++ b/boards/st/nucleo_wb09ke/doc/index.rst
@@ -119,6 +119,15 @@ You can debug an application in the usual way.  Here is an example for the
    :maybe-skip-config:
    :goals: debug
 
+.. warning::
+   Application debugging on this board uses the pyOCD runner, which requires an additional pack
+   to be installed beforehand. This can be performed using the following commands:
+
+   .. code-block:: console
+
+      $ pyocd pack update
+      $ pyocd pack install stm32wb0
+
 .. _`Nucleo WB09KE webpage`:
    https://www.st.com/en/evaluation-tools/nucleo-wb09ke.html
 

--- a/boards/st/nucleo_wb09ke/support/openocd.cfg
+++ b/boards/st/nucleo_wb09ke/support/openocd.cfg
@@ -1,5 +1,0 @@
-source [find interface/stlink-dap.cfg]
-
-transport select "dapdirect_swd"
-
-source [find target/stm32wb0x.cfg]


### PR DESCRIPTION
OpenOCD support snippets (`<board>/support/openocd.cfg`) for Nucleo-WB05KZ and Nucleo-WB07CC were written with the expectation that ST OpenOCD was being used, but upstream and the Zephyr fork have everything needed to support STM32WB05 and STM32WB06/07 SoCs (a.k.a. BlueNRG-LPS and BlueNRG-LP respectively). Modify these boards' snippets so that they work out of the box with the SDK.

Support for STM32WB09 (a.k.a. BlueNRG-LPF) is only available on the [STMicroelectronics OpenOCD fork], with binaries shipped as part of STM32CubeIDE. Add warning about this and instructions on how to use CubeIDE's binaries to debug applications in the Nucleo-WB09KE board's documentation.

New support snippets tested OK on Linux with Zephyr SDK 0.17.0 and Windows using [official OpenOCD 0.12.0 release from GitHub](https://github.com/openocd-org/openocd/releases/tag/v0.12.0).