### PR TITLE
dma: nxp: sdma: Initialize channel capacity with zero

### DIFF
--- a/drivers/dma/dma_nxp_sdma.c
+++ b/drivers/dma/dma_nxp_sdma.c
@@ -432,6 +432,7 @@ static bool sdma_channel_filter(const struct device *dev, int chan_id, void *par
 
 	dev_data->chan[chan_id].event_source = *((int *)param);
 	dev_data->chan[chan_id].index = chan_id;
+	dev_data->chan[chan_id].capacity = 0;
 
 	return true;
 }


### PR DESCRIPTION
DMA channel capacity wasn't properly initialized and the computation relies on it being zeroed.

This only works fine only when requesting channel the first time causing problems when we have multiple cycles of channel request/release.

Fix this by properly initializing the capacity when requesting the channel.

Fixes 43a48d4630ea ("drivers: dma: sdma: Update buffer descriptor")
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>