### PR TITLE
kernel: add `K_TIMEOUT_ABS_SEC`

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -86,6 +86,10 @@ Deprecated APIs and options
 New APIs and options
 ====================
 
+* Kernel
+
+ * :c:macro:`K_TIMEOUT_ABS_SEC`
+
 * I2C
 
   * :c:func:`i2c_configure_dt`.

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1484,6 +1484,19 @@ const char *k_thread_state_str(k_tid_t thread_id, char *buf, size_t buf_size);
 	Z_TIMEOUT_TICKS(Z_TICK_ABS((k_ticks_t)MAX(t, 0)))
 
 /**
+ * @brief Generates an absolute/uptime timeout value from seconds
+ *
+ * This macro generates a timeout delay that represents an expiration
+ * at the absolute uptime value specified, in seconds.  That is, the
+ * timeout will expire immediately after the system uptime reaches the
+ * specified tick count.
+ *
+ * @param t Second uptime value
+ * @return Timeout delay value
+ */
+#define K_TIMEOUT_ABS_SEC(t) K_TIMEOUT_ABS_TICKS(k_sec_to_ticks_ceil64(t))
+
+/**
  * @brief Generates an absolute/uptime timeout value from milliseconds
  *
  * This macro generates a timeout delay that represents an expiration

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -749,16 +749,22 @@ ZTEST_USER(timer_api, test_timeout_abs)
 	k_timeout_t t = K_TIMEOUT_ABS_TICKS(exp_ticks), t2;
 	uint64_t t0, t1;
 
+	/* Ensure second alignment for K_TIMEOUT_ABS_SEC */
+	zassert_true(exp_ms % MSEC_PER_SEC == 0);
+
 	/* Check the other generator macros to make sure they produce
 	 * the same (whiteboxed) converted values
 	 */
+	t2 = K_TIMEOUT_ABS_SEC(exp_ms / MSEC_PER_SEC);
+	zassert_true(t2.ticks == t.ticks);
+
 	t2 = K_TIMEOUT_ABS_MS(exp_ms);
 	zassert_true(t2.ticks == t.ticks);
 
-	t2 = K_TIMEOUT_ABS_US(1000 * exp_ms);
+	t2 = K_TIMEOUT_ABS_US(USEC_PER_MSEC * exp_ms);
 	zassert_true(t2.ticks == t.ticks);
 
-	t2 = K_TIMEOUT_ABS_NS(1000 * 1000 * exp_ms);
+	t2 = K_TIMEOUT_ABS_NS(NSEC_PER_MSEC * exp_ms);
 	zassert_true(t2.ticks == t.ticks);
 
 	t2 = K_TIMEOUT_ABS_CYC(k_ms_to_cyc_ceil64(exp_ms));


### PR DESCRIPTION
Add a new absolute timeout construction macro that operates on seconds. It has the same semantics as `K_TIMEOUT_ABS_MS`, `K_TIMEOUT_ABS_US`, etc.