### PR TITLE
tests: Bluetooth: Classic: Add dedicated test case for no_blobs

### DIFF
--- a/tests/bluetooth/classic/sdp_c/testcase.yaml
+++ b/tests/bluetooth/classic/sdp_c/testcase.yaml
@@ -2,7 +2,6 @@ tests:
   bluetooth.classic.sdp.client:
     platform_allow:
       - native_sim
-      - mimxrt1170_evk@B/mimxrt1176/cm7
     integration_platforms:
       - native_sim
     tags:
@@ -13,3 +12,13 @@ tests:
       pytest_dut_scope: session
       fixture: usb_hci
     timeout: 180
+  bluetooth.classic.sdp.client.no_blobs:
+    platform_allow:
+      - mimxrt1170_evk@B/mimxrt1176/cm7
+    tags:
+      - bluetooth
+      - sdp
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    timeout: 180
+    build_only: true

--- a/tests/bluetooth/classic/sdp_s/testcase.yaml
+++ b/tests/bluetooth/classic/sdp_s/testcase.yaml
@@ -2,7 +2,6 @@ tests:
   bluetooth.classic.sdp.server:
     platform_allow:
       - native_sim
-      - mimxrt1170_evk@B/mimxrt1176/cm7
     integration_platforms:
       - native_sim
     tags:
@@ -13,3 +12,13 @@ tests:
       pytest_dut_scope: session
       fixture: usb_hci
     timeout: 60
+  bluetooth.classic.sdp.server.no_blobs:
+    platform_allow:
+      - mimxrt1170_evk@B/mimxrt1176/cm7
+    tags:
+      - bluetooth
+      - sdp
+    extra_args:
+      - CONFIG_BUILD_ONLY_NO_BLOBS=y
+    timeout: 60
+    build_only: true


### PR DESCRIPTION
Add dedicated test case `bluetooth.classic.sdp.server.no_blobs` and `bluetooth.classic.sdp.client.no_blobs` with the extra argument `CONFIG_BUILD_ONLY_NO_BLOBS=y` and `build_only: true` to make sure the tests sdp_s and sdp_c can be passed by Zephyr CI.

Fixes #88060.