### PR TITLE
drivers: gpio: rz: Fix a build error

### DIFF
--- a/drivers/gpio/gpio_renesas_rz.h
+++ b/drivers/gpio/gpio_renesas_rz.h
@@ -82,9 +82,6 @@ static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {
 #define GPIO_RZ_PIN_CONFIGURE_INPUT_OUTPUT_RESET (~(0x3 << 2))
 #define GPIO_RZ_PIN_SPECIAL_FLAG_GET(flag)       GPIO_RZ_PIN_CONFIGURE_GET_FILTER(flag)
 
-static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {0,  4,  9,  13, 17, 23, 28, 33, 38, 43,
-							  47, 52, 56, 58, 63, 66, 70, 72, 76};
-
 #elif defined(CONFIG_SOC_SERIES_RZN2L) || defined(CONFIG_SOC_SERIES_RZT2L) ||                      \
 	defined(CONFIG_SOC_SERIES_RZT2M)
 #include <zephyr/dt-bindings/gpio/renesas-rztn-gpio.h>


### PR DESCRIPTION
Fix a build error of G3S, A3UL, V2L due to a redefinition of a variable in gpio_renesas_rz.h.
It causes CI failure https://github.com/zephyrproject-rtos/zephyr/actions/runs/14233155040/job/39887714556?pr=83773

Build command:

`west build -p -b rzg3s_smarc/r9a08g045s33gbg/cm33 tests/drivers/gpio/gpio_api_1pin`

```
zephyr/drivers/gpio/gpio_renesas_rz.h:85:22: error: redefinition of 'gpio_rz_int'
   85 | static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {0,  4,  9,  13, 17, 23, 28, 33, 38, 43,
      |                      ^~~~~~~~~~~
zephyr/drivers/gpio/gpio_renesas_rz.h:35:22: note: previous definition of 'gpio_rz_int' with type 'const uint8_t[19]' {aka 'const unsigned char[19]'}
   35 | static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {0,  4,  9,  13, 17, 23, 28, 33, 38, 43,
      |                      ^~~~~~~~~~~
ninja: build stopped: subcommand failed.

