### PR TITLE
bluetooth: classic: hfp: sco_conn is null in hfp sco_disconnected callback

### DIFF
--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -120,11 +120,11 @@ void bt_sco_disconnected(struct bt_conn *sco)
 
 	bt_sco_cleanup_acl(sco);
 
-	chan->sco = NULL;
-
 	if (chan->ops && chan->ops->disconnected) {
 		chan->ops->disconnected(chan, sco->err);
 	}
+
+	chan->sco = NULL;
 }
 
 static uint8_t sco_server_check_security(struct bt_conn *conn)


### PR DESCRIPTION
In bt_sco_disconnected, chan->sco is set as NULL before callback. Then hfp disconnection callback use it to callback to application in hfp_hf_sco_disconnected.