### PR TITLE
boards: *: Fix wrong feature identifier for usb_device

### DIFF
--- a/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.yaml
+++ b/boards/antmicro/myra_sip_baseboard/myra_sip_baseboard.yaml
@@ -12,7 +12,6 @@ supported:
   - pwm
   - i2c
   - gpio
-  - usb device
   - spi
   - watchdog
   - dma

--- a/boards/st/nucleo_g431rb/nucleo_g431rb.yaml
+++ b/boards/st/nucleo_g431rb/nucleo_g431rb.yaml
@@ -15,7 +15,6 @@ supported:
   - pwm
   - i2c
   - gpio
-  - usb device
   - counter
   - spi
   - rng

--- a/boards/st/nucleo_g474re/nucleo_g474re.yaml
+++ b/boards/st/nucleo_g474re/nucleo_g474re.yaml
@@ -15,7 +15,6 @@ supported:
   - pwm
   - i2c
   - gpio
-  - usb device
   - counter
   - spi
   - watchdog

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.yaml
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.yaml
@@ -13,7 +13,7 @@ supported:
   - spi
   - i2c
   - gpio
-  - usb device
+  - usbd
   - nvs
   - counter
   - adc

--- a/boards/st/sensortile_box/sensortile_box.yaml
+++ b/boards/st/sensortile_box/sensortile_box.yaml
@@ -11,7 +11,7 @@ supported:
   - ble
   - i2c
   - gpio
-  - usb device
+  - usbd
   - nvs
   - counter
 ram: 640

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.yaml
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.yaml
@@ -11,7 +11,7 @@ supported:
   - ble
   - i2c
   - gpio
-  - usb device
+  - usbd
   - nvs
   - counter
 ram: 640


### PR DESCRIPTION
`usb device` isn't a valid feature name.
