### PR TITLE
ci: Run all Blackbox tests

### DIFF
--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -62,4 +62,4 @@ jobs:
         export ZEPHYR_SDK_INSTALL_DIR=${{ github.workspace }}/zephyr-sdk
         echo "Run twister tests"
         source zephyr-env.sh
-        PYTHONPATH="./scripts/tests" pytest ./scripts/tests/twister_blackbox/test_output.py
+        PYTHONPATH="./scripts/tests" pytest ./scripts/tests/twister_blackbox/


### PR DESCRIPTION
We've previously restricted Blackbox test runs to just one test file - test_output.py.
That seems to be a mistake.

This commit makes the relevant workflow run all of the blackbox test files again.

Fixes #88087 