### PR TITLE
Bluetooth: Classic: HFP_AG: Update the callback `sco_disconnected()`

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -227,6 +227,13 @@ Bluetooth Host
   each role may be different. Any existing uses/checks for ``BT_ISO_CHAN_TYPE_CONNECTED``
   can be replaced with an ``||`` of the two. (:github:`75549`)
 
+Bluetooth Classic
+=================
+
+* The parameters of HFP AG callback ``sco_disconnected`` of the struct :c:struct:`bt_hfp_ag_cb`
+  have been changed to SCO connection object ``struct bt_conn *sco_conn`` and the disconnection
+  reason of the SCO connection ``uint8_t reason``.
+
 Networking
 **********
 

--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -111,10 +111,10 @@ struct bt_hfp_ag_cb {
 	 *  If this callback is provided it will be called whenever the
 	 *  SCO/eSCO connection gets disconnected.
 	 *
-	 *  @param ag HFP AG object.
-	 *  @param sco_conn SCO/eSCO Connection object.
+	 *  @param conn SCO/eSCO Connection object.
+	 *  @param reason BT_HCI_ERR_* reason for the disconnection.
 	 */
-	void (*sco_disconnected)(struct bt_hfp_ag *ag);
+	void (*sco_disconnected)(struct bt_conn *sco_conn, uint8_t reason);
 
 	/** HF memory dialing request Callback
 	 *

--- a/samples/bluetooth/handsfree_ag/src/main.c
+++ b/samples/bluetooth/handsfree_ag/src/main.c
@@ -63,9 +63,9 @@ static void ag_sco_connected(struct bt_hfp_ag *ag, struct bt_conn *sco_conn)
 	printk("HFP AG SCO connected!\n");
 }
 
-static void ag_sco_disconnected(struct bt_hfp_ag *ag)
+static void ag_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
 {
-	printk("HFP AG SCO disconnected!\n");
+	printk("HFP AG SCO disconnected %u!\n", reason);
 }
 
 static void ag_ringing(struct bt_hfp_ag_call *call, bool in_band)

--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -2029,8 +2029,8 @@ static void hfp_ag_sco_disconnected(struct bt_sco_chan *chan, uint8_t reason)
 
 	call = get_call_with_flag(ag, BT_HFP_AG_CALL_OPEN_SCO, true);
 
-	if ((bt_ag) && bt_ag->sco_disconnected) {
-		bt_ag->sco_disconnected(ag);
+	if ((bt_ag != NULL) && bt_ag->sco_disconnected) {
+		bt_ag->sco_disconnected(chan->sco, reason);
 	}
 
 	if (!call) {

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -1000,12 +1000,12 @@ static void ag_connected(struct bt_conn *conn, struct bt_hfp_ag *ag)
 		bt_shell_warn("The conn %p is not aligned with ACL conn %p", conn, default_conn);
 	}
 	hfp_ag = ag;
-	bt_shell_print("ag connected");
+	bt_shell_print("AG connected");
 }
 
 static void ag_disconnected(struct bt_hfp_ag *ag)
 {
-	bt_shell_print("ag disconnected");
+	bt_shell_print("AG disconnected");
 }
 
 static void ag_sco_connected(struct bt_hfp_ag *ag, struct bt_conn *sco_conn)
@@ -1040,7 +1040,7 @@ static int ag_memory_dial(struct bt_hfp_ag *ag, const char *location, char **num
 		return -ENOTSUP;
 	}
 
-	bt_shell_print("ag memory dial");
+	bt_shell_print("AG memory dial");
 
 	*number = phone;
 
@@ -1051,7 +1051,7 @@ static int ag_number_call(struct bt_hfp_ag *ag, const char *number)
 {
 	static char *phone = "123456789";
 
-	bt_shell_print("ag number call");
+	bt_shell_print("AG number call");
 
 	if (strcmp(number, phone)) {
 		return -ENOTSUP;
@@ -1062,71 +1062,71 @@ static int ag_number_call(struct bt_hfp_ag *ag, const char *number)
 
 static void ag_outgoing(struct bt_hfp_ag *ag, struct bt_hfp_ag_call *call, const char *number)
 {
-	bt_shell_print("ag outgoing call %p, number %s", call, number);
+	bt_shell_print("AG outgoing call %p, number %s", call, number);
 	ag_add_a_call(call);
 }
 
 static void ag_incoming(struct bt_hfp_ag *ag, struct bt_hfp_ag_call *call, const char *number)
 {
-	bt_shell_print("ag incoming call %p, number %s", call, number);
+	bt_shell_print("AG incoming call %p, number %s", call, number);
 	ag_add_a_call(call);
 }
 
 static void ag_incoming_held(struct bt_hfp_ag_call *call)
 {
-	bt_shell_print("ag incoming call %p is held", call);
+	bt_shell_print("AG incoming call %p is held", call);
 }
 
 static void ag_ringing(struct bt_hfp_ag_call *call, bool in_band)
 {
-	bt_shell_print("ag call %p start ringing mode %d", call, in_band);
+	bt_shell_print("AG call %p start ringing mode %d", call, in_band);
 }
 
 static void ag_accept(struct bt_hfp_ag_call *call)
 {
-	bt_shell_print("ag call %p accept", call);
+	bt_shell_print("AG call %p accept", call);
 }
 
 static void ag_held(struct bt_hfp_ag_call *call)
 {
-	bt_shell_print("ag call %p held", call);
+	bt_shell_print("AG call %p held", call);
 }
 
 static void ag_retrieve(struct bt_hfp_ag_call *call)
 {
-	bt_shell_print("ag call %p retrieved", call);
+	bt_shell_print("AG call %p retrieved", call);
 }
 
 static void ag_reject(struct bt_hfp_ag_call *call)
 {
-	bt_shell_print("ag call %p reject", call);
+	bt_shell_print("AG call %p reject", call);
 	ag_remove_a_call(call);
 }
 
 static void ag_terminate(struct bt_hfp_ag_call *call)
 {
-	bt_shell_print("ag call %p terminate", call);
+	bt_shell_print("AG call %p terminate", call);
 	ag_remove_a_call(call);
 }
 
 static void ag_codec(struct bt_hfp_ag *ag, uint32_t ids)
 {
-	bt_shell_print("ag received codec id bit map %x", ids);
+	bt_shell_print("AG received codec id bit map %x", ids);
 }
 
 void ag_vgm(struct bt_hfp_ag *ag, uint8_t gain)
 {
-	bt_shell_print("ag received vgm %d", gain);
+	bt_shell_print("AG received vgm %d", gain);
 }
 
 void ag_vgs(struct bt_hfp_ag *ag, uint8_t gain)
 {
-	bt_shell_print("ag received vgs %d", gain);
+	bt_shell_print("AG received vgs %d", gain);
 }
 
 void ag_codec_negotiate(struct bt_hfp_ag *ag, int err)
 {
-	bt_shell_print("ag codec negotiation result %d", err);
+	bt_shell_print("AG codec negotiation result %d", err);
 }
 
 void ag_audio_connect_req(struct bt_hfp_ag *ag)

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -73,14 +73,26 @@ static void hf_disconnected(struct bt_hfp_hf *hf)
 
 static void hf_sco_connected(struct bt_hfp_hf *hf, struct bt_conn *sco_conn)
 {
-	bt_shell_print("HF SCO connected");
-	hf_sco_conn = sco_conn;
+	bt_shell_print("HF SCO connected %p", sco_conn);
+
+	if (hf_sco_conn != NULL) {
+		bt_shell_warn("HF SCO conn %p exists", hf_sco_conn);
+		return;
+	}
+
+	hf_sco_conn = bt_conn_ref(sco_conn);
 }
 
 static void hf_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
 {
-	bt_shell_print("HF SCO disconnected");
-	hf_sco_conn = NULL;
+	bt_shell_print("HF SCO disconnected %p (reason %u)", sco_conn, reason);
+
+	if (hf_sco_conn == sco_conn) {
+		bt_conn_unref(hf_sco_conn);
+		hf_sco_conn = NULL;
+	} else {
+		bt_shell_warn("Unknown SCO disconnected (%p != %p)", hf_sco_conn, sco_conn);
+	}
 }
 
 void hf_service(struct bt_hfp_hf *hf, uint32_t value)
@@ -998,14 +1010,26 @@ static void ag_disconnected(struct bt_hfp_ag *ag)
 
 static void ag_sco_connected(struct bt_hfp_ag *ag, struct bt_conn *sco_conn)
 {
-	bt_shell_print("ag sco connected");
-	hfp_ag_sco_conn = sco_conn;
+	bt_shell_print("AG SCO connected %p", sco_conn);
+
+	if (hfp_ag_sco_conn != NULL) {
+		bt_shell_warn("AG SCO conn %p exists", hfp_ag_sco_conn);
+		return;
+	}
+
+	hfp_ag_sco_conn = bt_conn_ref(sco_conn);
 }
 
-static void ag_sco_disconnected(struct bt_hfp_ag *ag)
+static void ag_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
 {
-	bt_shell_print("ag sco disconnected");
-	hfp_ag_sco_conn = NULL;
+	bt_shell_print("AG SCO disconnected %p (reason %u)", sco_conn, reason);
+
+	if (hfp_ag_sco_conn == sco_conn) {
+		bt_conn_unref(hfp_ag_sco_conn);
+		hfp_ag_sco_conn = NULL;
+	} else {
+		bt_shell_warn("Unknown SCO disconnected (%p != %p)", hfp_ag_sco_conn, sco_conn);
+	}
 }
 
 static int ag_memory_dial(struct bt_hfp_ag *ag, const char *location, char **number)


### PR DESCRIPTION
Change the arguments of HFP AG callback `sco_disconnected()` to SCO conn and disconnection reason.