### PR TITLE
drivers: serial: silabs: add __maybe_unused to eusart dma callback

### DIFF
--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -435,8 +435,8 @@ static void eusart_dma_rx_flush(struct eusart_data *data)
 	}
 }
 
-static void eusart_dma_rx_cb(const struct device *dma_dev, void *user_data, uint32_t channel,
-			     int status)
+__maybe_unused static void eusart_dma_rx_cb(const struct device *dma_dev, void *user_data,
+					    uint32_t channel, int status)
 {
 	const struct device *uart_dev = user_data;
 	struct eusart_data *data = uart_dev->data;
@@ -466,8 +466,8 @@ static void eusart_dma_rx_cb(const struct device *dma_dev, void *user_data, uint
 	}
 }
 
-static void eusart_dma_tx_cb(const struct device *dma_dev, void *user_data, uint32_t channel,
-			     int status)
+__maybe_unused static void eusart_dma_tx_cb(const struct device *dma_dev, void *user_data,
+					    uint32_t channel, int status)
 {
 	const struct device *uart_dev = user_data;
 	struct eusart_data *data = uart_dev->data;


### PR DESCRIPTION
The goal of this PR is to fix compilation warning. The callback function for the DMA is not used in the case where the EUSART driver is compiled with DMA support but no DMA properties are given in the EUSART node in the device tree.

Ci failing block PR like this one : https://github.com/zephyrproject-rtos/zephyr/pull/88054