### PR TITLE
doc: Fix html-live doc command

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -190,7 +190,7 @@ add_dependencies(html devicetree)
 
 add_doc_target(
   html-live
-  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV}
+  COMMAND ${CMAKE_COMMAND} -E env ${SPHINX_ENV} OUTPUT_DIR=${DOCS_HTML_DIR}
   ${SPHINXAUTOBUILD}
     --watch ${DOCS_CFG_DIR}
     --ignore ${DOCS_BUILD_DIR}


### PR DESCRIPTION
OUTPUT_DIR was not passed to the html-live target, causing a Python exception:

```
TypeError: argument should be a str or an os.PathLike object
           where __fspath__ returns a str, not 'NoneType'
```

This issue was seemingly introduced with #78870, when OUTPUT_DIR was introduced for the other targets.