### PR TITLE
doc: Regenerate board doc if supported hardware data changes

### DIFF
--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -985,6 +985,12 @@ class BoardSupportedHardwareDirective(SphinxDirective):
 
                     tbody += row
 
+                    # Declare the dts and binding files as dependencies of the board doc page,
+                    # ensuring that the page is rerendered if the files change.
+                    for node in okay_nodes + disabled_nodes:
+                        env.note_dependency(node["dts_path"])
+                        env.note_dependency(node["binding_path"])
+
             tgroup += tbody
             table += tgroup
             tables_container += table

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -292,7 +292,12 @@ def get_catalog(generate_hw_features=False):
                         node.matching_compat
                     )
 
-                    node_info = {"filename": str(filename), "lineno": lineno}
+                    node_info = {
+                        "filename": str(filename),
+                        "lineno": lineno,
+                        "dts_path": Path(node.filename),
+                        "binding_path": Path(node.binding_path),
+                    }
                     node_list_key = "okay_nodes" if node.status == "okay" else "disabled_nodes"
 
                     if existing_feature:


### PR DESCRIPTION
Declare the dts and binding files used for the supported hardware directive as dependencies of doc pages that use them.

This change makes incremental doc rebuilds pick up changes to the supported hardware table. Without the change, board pages aren't updated unless a full doc rebuild is performed.