### PR TITLE
drivers: flash: flash_hp_ra: perform blank check before reading

### DIFF
--- a/drivers/flash/Kconfig.renesas_ra
+++ b/drivers/flash/Kconfig.renesas_ra
@@ -31,4 +31,13 @@ config FLASH_RENESAS_RA_HP_BGO
 	help
 	  Enable Background operations (BGOs)
 
+config FLASH_RENESAS_RA_HP_CHECK_BEFORE_READING
+	bool "Verify area before reading it"
+	default $(dt_nodelabel_bool_prop,flash1,erase-value-undefined)
+	help
+	  Do a blank check flash command before reading an area.
+	  This feature prevents erroneous reading. Values read from an
+	  area of the data flash that has been erased but not programmed
+	  are undefined.
+
 endif # SOC_FLASH_RENESAS_RA_HP

--- a/drivers/flash/soc_flash_renesas_ra_hp.h
+++ b/drivers/flash/soc_flash_renesas_ra_hp.h
@@ -90,6 +90,12 @@ enum flash_region {
 #define FLASH_FLAG_ERASE_COMPLETE BIT(0)
 #define FLASH_FLAG_WRITE_COMPLETE BIT(1)
 #define FLASH_FLAG_GET_ERROR      BIT(2)
+
+#if defined(CONFIG_FLASH_RENESAS_RA_HP_CHECK_BEFORE_READING)
+#define FLASH_FLAG_BLANK          BIT(3)
+#define FLASH_FLAG_NOT_BLANK      BIT(4)
+#endif /* CONFIG_FLASH_RENESAS_RA_HP_CHECK_BEFORE_READING */
+
 #endif /* CONFIG_FLASH_RENESAS_RA_HP_BGO */
 
 struct flash_hp_ra_controller {

--- a/dts/arm/renesas/ra/ra4/r7fa4e10d2cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10d2cfm.dtsi
@@ -28,6 +28,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra4/r7fa4e10d2cne.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e10d2cne.dtsi
@@ -28,6 +28,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4e2b93cfm.dtsi
@@ -57,6 +57,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 

--- a/dts/arm/renesas/ra/ra4/r7fa4m2ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m2ad3cfp.dtsi
@@ -28,6 +28,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra4/r7fa4m3af3cfb.dtsi
+++ b/dts/arm/renesas/ra/ra4/r7fa4m3af3cfb.dtsi
@@ -28,6 +28,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra6/r7fa6e10f2cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e10f2cfp.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra6/r7fa6e2bb3cfm.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6e2bb3cfm.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m1ad3cfp.dtsi
@@ -36,6 +36,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m2af3cfb.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m2af3cfb.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m3ah3cfc.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m3ah3cfc.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 

--- a/dts/arm/renesas/ra/ra6/r7fa6m4af3cfb.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m4af3cfb.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra6/r7fa6m5bh3cfc.dtsi
+++ b/dts/arm/renesas/ra/ra6/r7fa6m5bh3cfc.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra8/r7fa8d1bhecbd.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8d1bhecbd.dtsi
@@ -28,6 +28,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra8/r7fa8m1ahecbd.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8m1ahecbd.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/arm/renesas/ra/ra8/r7fa8t1ahecbd.dtsi
+++ b/dts/arm/renesas/ra/ra8/r7fa8t1ahecbd.dtsi
@@ -27,6 +27,7 @@
 				write-block-size = <4>;
 				erase-block-size = <64>;
 				programming-enable;
+				erase-value-undefined;
 			};
 		};
 	};

--- a/dts/bindings/mtd/renesas,ra-nv-data-flash.yaml
+++ b/dts/bindings/mtd/renesas,ra-nv-data-flash.yaml
@@ -13,3 +13,7 @@ properties:
     type: boolean
     description: |
       Enable data flash programming configuration
+
+  erase-value-undefined:
+    type: boolean
+    description: Areas of flash that are in an erased state will read back undefined values.


### PR DESCRIPTION
The value read from unwritten areas of Renesas RAxxx SoCs data flash is undefined. To prevent reading unwritten areas a blank check command is performed first. If the area is blank, we return dummy data so it behaves the same as other flash devices.