### PR TITLE
Add mailbox nodes for TI J7x devices

### DIFF
--- a/dts/arm/ti/j721e_main_r5.dtsi
+++ b/dts/arm/ti/j721e_main_r5.dtsi
@@ -152,6 +152,17 @@
 		status = "disabled";
 	};
 
+	mbox1: mailbox@31f81000 {
+		compatible = "ti,omap-mailbox";
+		reg = <0x31f81000 0x200>;
+		/* TODO: Use interrupt router to map this */
+		interrupts = <0 256 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&vim>;
+		usr-id = <2>;
+		#mbox-cells = <1>;
+		status = "okay";
+	};
+
 	systick_timer: timer@24c0000 {
 		compatible = "ti,am654-timer";
 		reg = <0x24c0000 0x70>;

--- a/dts/arm/ti/j722s_main_r5.dtsi
+++ b/dts/arm/ti/j722s_main_r5.dtsi
@@ -58,4 +58,14 @@
 		interrupt-parent = <&vim>;
 		status = "disabled";
 	};
+
+	mbox3: mailbox@29030000 {
+		compatible = "ti,omap-mailbox";
+		reg = <0x29030000 0x200>;
+		interrupts = <0 116 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&vim>;
+		usr-id = <3>;
+		#mbox-cells = <1>;
+		status = "okay";
+	};
 };

--- a/dts/arm/ti/j722s_mcu_r5.dtsi
+++ b/dts/arm/ti/j722s_mcu_r5.dtsi
@@ -58,4 +58,14 @@
 		interrupt-parent = <&vim>;
 		status = "disabled";
 	};
+
+	mbox1: mailbox@29010000 {
+		compatible = "ti,omap-mailbox";
+		reg = <0x29010000 0x200>;
+		interrupts = <0 241 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&vim>;
+		usr-id = <2>;
+		#mbox-cells = <1>;
+		status = "okay";
+	};
 };


### PR DESCRIPTION
Now that we have a driver for the TI Mailbox IP, add in the missing mailbox nodes in J7x DTs.