### PR TITLE
ci: Remove "Building C object" from blackbox inline logs test.

### DIFF
--- a/scripts/tests/twister_blackbox/test_output.py
+++ b/scripts/tests/twister_blackbox/test_output.py
@@ -82,7 +82,7 @@ class TestOutput:
             assert all([(tc_name.count('.') == 1) for _, _, tc_name in filtered_j])
 
 
-    def xtest_inline_logs(self, out_path):
+    def test_inline_logs(self, out_path):
         test_platforms = ['qemu_x86', 'intel_adl_crb']
         path = os.path.join(TEST_DATA, 'tests', 'always_build_error', 'dummy')
         args = ['--outdir', out_path, '-T', path] + \
@@ -132,7 +132,11 @@ class TestOutput:
             r'-- Configuring done \([0-9.]+s\)',
             r'-- Generating done \([0-9.]+s\)',
             # Cache location may vary between CI runs
-            r'^.*-- Cache files will be written to:.*$'
+            r'^.*-- Cache files will be written to:.*$',
+            # List of built C object may differ between runs.
+            # See: Issue #87769.
+            # Probable culprits: the cache mechanism, build error
+            r'^Building C object .*$'
         ]
         for pattern in removal_patterns:
             c_pattern = re.compile(pattern, flags=re.MULTILINE)


### PR DESCRIPTION
Disable `Building C object` lines for the inline log test scope.

Fixes #87769 