### PR TITLE
boards: ti: sk_am64: Fix M4 DRAM memory offset

### DIFF
--- a/boards/ti/sk_am64/doc/index.rst
+++ b/boards/ti/sk_am64/doc/index.rst
@@ -46,7 +46,11 @@ DDR RAM
 -------
 
 The board has 2GB of DDR RAM available. This board configuration
-allocates Zephyr 4kB of RAM (only for resource table: 0xa4100000 to 0xa4100400).
+allocates Zephyr:
+
+- 1MB for IPC (VirtIO / Vrings)
+- 4KB for Linux RemoteProc resource table
+- 15MB for general usage
 
 Serial Port
 -----------

--- a/boards/ti/sk_am64/sk_am64_am6442_m4.dts
+++ b/boards/ti/sk_am64/sk_am64_am6442_m4.dts
@@ -44,10 +44,10 @@
 		zephyr,memory-region = "RSC_TABLE";
 	};
 
-	ddr1: memory@a4200000 {
+	ddr1: memory@a4101000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0xa4200000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
-		zephyr,memory-region = "DDR";
+		reg = <0xa4101000 (DT_SIZE_M(15) - DT_SIZE_K(4))>;
+		zephyr,memory-region = "DRAM";
 	};
 
 	leds: leds {


### PR DESCRIPTION
The memory offset starts the second DRAM memory area as if the resource table took a whole 1MB, but it only takes 1KB. Shift the region start address back to the right spot.

Update the docs to make the memory sizes more clear.