### PR TITLE
add mdm-wake-gpios to Sequans Monarch 2 GM02S, use it in DPTechnics Walter

### DIFF
--- a/boards/dptechnics/walter/walter_esp32s3_procpu.dts
+++ b/boards/dptechnics/walter/walter_esp32s3_procpu.dts
@@ -49,6 +49,7 @@
 		status = "okay";
 		compatible = "sqn,gm02s";
 		mdm-reset-gpios = <&gpio1 13 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
+		mdm-wake-gpios = <&gpio1 14 (GPIO_OPEN_SOURCE | GPIO_ACTIVE_HIGH)>;
 	};
 };
 

--- a/dts/bindings/modem/sqn,gm02s.yaml
+++ b/dts/bindings/modem/sqn,gm02s.yaml
@@ -11,3 +11,6 @@ properties:
   mdm-reset-gpios:
     type: phandle-array
     required: true
+
+  mdm-wake-gpios:
+    type: phandle-array


### PR DESCRIPTION
Add support for Sequans Monarch 2 GM02S wake-up pin.

@vThibo @daanpape please have a look