### PR TITLE
Revert "dts: bindings: spi: Fix "nordic,nrf-spis" binding"

### DIFF
--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -3,9 +3,7 @@
 
 # Common fields for Nordic nRF family SPI peripherals
 
-include:
-  - pinctrl-device.yaml
-  - nordic-clockpin.yaml
+include: [spi-controller.yaml, pinctrl-device.yaml, nordic-clockpin.yaml]
 
 properties:
   reg:
@@ -28,11 +26,8 @@ properties:
       property must be set at SoC level DTS files.
 
   overrun-character:
-    type: int
     default: 0xff
     description: |
-      The overrun character (ORC) is used when all bytes from the TX buffer
-      are sent, but the transfer continues due to RX.
       Configurable, defaults to 0xff (line high), the most common value used
       in SPI transfers.
 

--- a/dts/bindings/spi/nordic,nrf-spi.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi.yaml
@@ -5,6 +5,4 @@ description: Nordic nRF family SPI (SPI master)
 
 compatible: "nordic,nrf-spi"
 
-include:
-  - spi-controller.yaml
-  - nordic,nrf-spi-common.yaml
+include: nordic,nrf-spi-common.yaml

--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -5,10 +5,7 @@ description: Nordic nRF family SPIM (SPI master with EasyDMA)
 
 compatible: "nordic,nrf-spim"
 
-include:
-  - spi-controller.yaml
-  - nordic,nrf-spi-common.yaml
-  - memory-region.yaml
+include: ["nordic,nrf-spi-common.yaml", "memory-region.yaml"]
 
 properties:
   anomaly-58-workaround:

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -5,10 +5,7 @@ description: Nordic nRF family SPIS (SPI slave with EasyDMA)
 
 compatible: "nordic,nrf-spis"
 
-include:
-  - base.yaml
-  - nordic,nrf-spi-common.yaml
-  - memory-region.yaml
+include: ["nordic,nrf-spi-common.yaml", "memory-region.yaml"]
 
 properties:
   def-char:


### PR DESCRIPTION
This reverts commit 7072460c743376bb21c1e1d7c91a91da515e290b.

Revert changes from #87957 that are causing failures in main
https://github.com/zephyrproject-rtos/zephyr/actions/runs/14241647470