### PR TITLE
tests: uart: add extra_conf to disable CONFIG_USERSPACE

### DIFF
--- a/tests/drivers/uart/uart_async_api/testcase.yaml
+++ b/tests/drivers/uart/uart_async_api/testcase.yaml
@@ -52,6 +52,9 @@ tests:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_MCUX_LPUART and not CONFIG_CPU_HAS_DCACHE
     harness: ztest
     depends_on: dma
+    extra_configs:
+      - CONFIG_USERSPACE=n
+      - CONFIG_TEST_USERSPACE=n
   drivers.uart.async_api.lpuart.rt_nocache:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_UART_MCUX_LPUART and CONFIG_CPU_HAS_DCACHE
     harness: ztest
@@ -60,6 +63,7 @@ tests:
       - CONFIG_DCACHE=y
       - CONFIG_NOCACHE_MEMORY=y
       - CONFIG_USERSPACE=n
+      - CONFIG_TEST_USERSPACE=n
   drivers.uart.async_api.sam0:
     filter: CONFIG_SERIAL_SUPPORT_ASYNC and CONFIG_SOC_FAMILY_ATMEL_SAM0
     platform_allow:


### PR DESCRIPTION
while disable USERSPACE we need set
CONFIG_TEST_ENABLE_USERSPACE=n

fixes: #82758