### PR TITLE
doc: Use dt binding title property for board supported hardware table

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -294,6 +294,7 @@ def get_catalog(generate_hw_features=False):
                         continue
 
                     description = DeviceTreeUtils.get_cached_description(node)
+                    title = node.title
                     filename = node.filename
                     lineno = node.lineno
                     locations = set()
@@ -318,6 +319,7 @@ def get_catalog(generate_hw_features=False):
 
                     feature_data = {
                         "description": description,
+                        "title": title,
                         "custom_binding": is_custom_binding,
                         "locations": locations,
                         "okay_nodes": [],

--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -73,8 +73,18 @@ These keys are explained in the following sections.
 Title
 *****
 
-Short description of the bound device, typically the hardware model.
-(It's optional.)
+Short description of the bound device, typically the hardware model. It should
+typically be on the format "Vendor Family Model". If acronyms are used, they
+should be spelled out in parentheses. The naming should stay as close to the
+vendor datasheet as possible.
+
+Titles should not exceed 100 characters. The description field should be used
+for longer descriptions. The words "binding", "schema" or "driver" should not
+be used in the title, everything is a binding.
+
+.. code-block:: YAML
+
+   title: Acme Foo UART (Universal Asynchronous Receiver/Transmitter)
 
 .. _dt-bindings-description:
 

--- a/dts/bindings/adc/silabs,gecko-iadc.yaml
+++ b/dts/bindings/adc/silabs,gecko-iadc.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silicon Labs Gecko Family IADC
+title: Silicon Labs Series 2 IADC (Incremental Analog to Digital Converter)
+
+description: |
+  Incremental ADC peripheral for Silicon Labs Series 2 SoCs.
 
 compatible: "silabs,gecko-iadc"
 

--- a/dts/bindings/bluetooth/silabs,bt-hci-efr32.yaml
+++ b/dts/bindings/bluetooth/silabs,bt-hci-efr32.yaml
@@ -1,4 +1,7 @@
-description: Bluetooth HCI on Silabs boards
+title: Silicon Labs Series 2 Bluetooth HCI (Host-Controller Interface)
+
+description: |
+  Bluetooth Host-Controller Interface for Silicon Labs Series 2 SoCs.
 
 compatible: "silabs,bt-hci-efr32"
 

--- a/dts/bindings/clock/silabs,hfxo.yaml
+++ b/dts/bindings/clock/silabs,hfxo.yaml
@@ -1,5 +1,10 @@
 compatible: "silabs,hfxo"
 
+title: Silicon Labs Series 2 HFXO (High-Frequency Crystal Oscillator)
+
+description: |
+  High-Frequency Crystal Oscillator peripheral on Silicon Labs SoCs.
+
 include: fixed-clock.yaml
 
 properties:

--- a/dts/bindings/clock/silabs,series-clock.yaml
+++ b/dts/bindings/clock/silabs,series-clock.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silicon Labs Series 2+ clock control node
+title: Silicon Labs Series 2 CMU (Clock Management Unit)
+
+description: |
+  Clock Management Unit for Silicon Labs Series 2+ SoCs.
 
 compatible: "silabs,series-clock"
 

--- a/dts/bindings/clock/silabs,series2-hfrcodpll.yaml
+++ b/dts/bindings/clock/silabs,series2-hfrcodpll.yaml
@@ -1,8 +1,10 @@
 compatible: "silabs,series2-hfrcodpll"
 
+title: Silicon Labs Series 2 HFRCODPLL (High-Frequency RC Oscillator with Digital Phase-Locked Loop)
+
 description: |
-  Silicon Labs HFRCODPLL peripheral (high-frequency RC oscillator with digital phase-locked loop).
-  Can be used as a free-running RC oscillator or with PLL lock to the crystal oscillators HFXO
+  High-Frequency RC Oscillator with Digital Phase-Locked Loop peripheral on Silicon Labs Series 2
+  SoCs. Can be used as a free-running RC oscillator or with PLL lock to the crystal oscillators HFXO
   or LFXO. To enable PLL, set the `clocks` property to the source crystal oscillator, and set
   the `dpll-*` options to desired values.
 

--- a/dts/bindings/clock/silabs,series2-hfrcoem23.yaml
+++ b/dts/bindings/clock/silabs,series2-hfrcoem23.yaml
@@ -2,9 +2,11 @@ compatible: "silabs,series2-hfrcoem23"
 
 include: fixed-clock.yaml
 
+title: Silicon Labs Series 2 HFRCOEM23 (High-Frequency RC Oscillator for Energy Mode 2 and 3)
+
 description: |
-  Silicon Labs HFRCOEM23 peripheral (high-frequency RC oscillator with energy mode 2 and 3
-  capability). `clock-frequency` represents the HFRCO band to use.
+  High-Frequency RC Oscillator with Energy Mode 2 and 3 capability.
+  `clock-frequency` represents the HFRCO band to use.
 
 properties:
   clock-frequency:

--- a/dts/bindings/clock/silabs,series2-lfrco.yaml
+++ b/dts/bindings/clock/silabs,series2-lfrco.yaml
@@ -1,7 +1,9 @@
 compatible: "silabs,series2-lfrco"
 
+title: Silicon Labs Series 2 LFRCO (Low-Frequency RC Oscillator)
+
 description: |
-  Silicon Labs LFRCO peripheral (low-frequency RC oscillator).
+  Low-Frequency RC Oscillator peripheral.
 
 include: fixed-clock.yaml
 

--- a/dts/bindings/clock/silabs,series2-lfxo.yaml
+++ b/dts/bindings/clock/silabs,series2-lfxo.yaml
@@ -1,7 +1,9 @@
 compatible: "silabs,series2-lfxo"
 
+title: Silicon Labs Series 2 LFXO (Low-Frequency Crystal Oscillator)
+
 description: |
-  Silicon Labs LFXO peripheral (low-frequency crystal oscillator).
+  Low-Frequency Crystal Oscillator peripheral.
 
 include: fixed-clock.yaml
 

--- a/dts/bindings/comparator/silabs,acmp.yaml
+++ b/dts/bindings/comparator/silabs,acmp.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2025 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+title: Silicon Labs Series 2 ACMP (Analog Comparator)
+
 description: |
-  Silabs ACMP (Analog Comparator)
+  Analog Comparator peripheral.
 
   The minimal default configuration for the silabs acmp node is as follows:
 

--- a/dts/bindings/crypto/silabs,gecko-semailbox.yaml
+++ b/dts/bindings/crypto/silabs,gecko-semailbox.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2021 Safran Passenger Innovations Germany GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silicon Labs Secure Element mailbox node
+title: Silicon Labs Series 2 SE (Secure Engine) Mailbox
+
+description: |
+  Mailbox interface for the Secure Engine on Silicon Labs Series 2 devices
+  with Hardware Secure Element.
 
 compatible: "silabs,gecko-semailbox"
 

--- a/dts/bindings/dma/silabs,ldma.yaml
+++ b/dts/bindings/dma/silabs,ldma.yaml
@@ -1,8 +1,10 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+title: Silicon Labs Series 2 LDMA (Linked Direct Memory Access)
+
 description: |
-  Silabs LDMA controller
+  Linked Direct Memory Access controller peripheral.
 
   The Silabs LDMA is a general-purpose direct memory access controller
   capable of supporting 8 independent DMA channels. It supports specific

--- a/dts/bindings/flash_controller/silabs,series2-flash-controller.yaml
+++ b/dts/bindings/flash_controller/silabs,series2-flash-controller.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2025 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silicon Labs Series 2 flash controller
+title: Silicon Labs Series 2 MSC (Memory System Controller)
+
+description: |
+  Memory System Controller for Silicon Labs Series 2 SoCs.
 
 compatible: "silabs,series2-flash-controller"
 

--- a/dts/bindings/gpio/silabs,gecko-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,gecko-gpio-port.yaml
@@ -1,4 +1,7 @@
-description: SiLabs Gecko GPIO Port
+title: Silicon Labs Series 0-2 GPIO (General Purpose Input/Output) Port
+
+description: |
+  Single GPIO port on Silicon Labs EFM32 and EFR32 Series 0, 1 and 2.
 
 compatible: "silabs,gecko-gpio-port"
 

--- a/dts/bindings/gpio/silabs,gecko-gpio.yaml
+++ b/dts/bindings/gpio/silabs,gecko-gpio.yaml
@@ -1,4 +1,7 @@
-description: SiLabs Gecko GPIO
+title: Silicon Labs Series 0-2 GPIO (General Purpose Input/Output) Peripheral
+
+description: |
+  GPIO peripheral for Silicon Labs EFM32 and EFR32 Series 0, 1 and 2.
 
 compatible: "silabs,gecko-gpio"
 

--- a/dts/bindings/i2c/silabs,gecko-i2c.yaml
+++ b/dts/bindings/i2c/silabs,gecko-i2c.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2018 Diego Sueiro <diego.sueiro@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silabs Gecko I2C
+title: Silicon Labs Series 0-2 I2C (Inter-Integrated Circuit)
+
+description: |
+  I2C peripheral on Silicon Labs EFM32 and EFR32 Series 0, 1 and 2.
 
 compatible: "silabs,gecko-i2c"
 

--- a/dts/bindings/net/wireless/silabs,series2-radio.yaml
+++ b/dts/bindings/net/wireless/silabs,series2-radio.yaml
@@ -1,11 +1,10 @@
 # Copyright (c) 2025 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    Silicon Labs Series 2 radio interface.
+title: Silicon Labs Series 2 Radio Interface
 
-    This controls the radio transceiver on Silicon Labs Series 2
-    SoCs.
+description: |
+  Controls the radio transceiver on Silicon Labs Series 2 SoCs.
 
 compatible: "silabs,series2-radio"
 

--- a/dts/bindings/pinctrl/silabs,dbus-pinctrl.yaml
+++ b/dts/bindings/pinctrl/silabs,dbus-pinctrl.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2024 Silicon Labs
 # SPDX-License-Identifier: Apache-2.0
 
+title: Silicon Labs Series 2 DBUS (Digital Bus) Pin Controller
+
 description: |
     The Silabs pin controller is a singleton node responsible for controlling
     pin function selection and pin properties. For example, you can use this

--- a/dts/bindings/regulator/silabs,series2-dcdc.yaml
+++ b/dts/bindings/regulator/silabs,series2-dcdc.yaml
@@ -1,9 +1,9 @@
 # Copyright (c) 2024 Silicon Laboratories Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-  Silicon Labs Series 2 DC-DC converter.
+title: Silicon Labs Series 2 DC-DC converter
 
+description: |
   Include the bindings header file <zephyr/dt-bindings/regulator/silabs_dcdc.h> to get
   access to relevant symbols for configuration.
 

--- a/dts/bindings/rtc/silabs,gecko-stimer.yaml
+++ b/dts/bindings/rtc/silabs,gecko-stimer.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2021, Sateesh Kotapati
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silabs Gecko Sleep Timer (Real-Time Counter)
+title: Silicon Labs Series 2 Sleeptimer
+
+description: |
+  Generic interface for low-frequency timers using the Sleeptimer HAL on
+  Silicon Labs Series 2 SoCs.
 
 compatible: "silabs,gecko-stimer"
 

--- a/dts/bindings/sensor/silabs,si7006.yaml
+++ b/dts/bindings/sensor/silabs,si7006.yaml
@@ -2,6 +2,8 @@
 # Copyright (c) 2023, Trent Piepho <tpiepho@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+title: Silicon Labs Si7006/13/21 RHT (Relative Humidity and Temperature) Sensor
+
 description: |
   Silicon Labs Si7006 Humidity and Temperature Sensor
 

--- a/dts/bindings/serial/silabs,eusart-uart.yaml
+++ b/dts/bindings/serial/silabs,eusart-uart.yaml
@@ -1,4 +1,9 @@
-description: Silabs EUSART UART
+title: |
+  Silicon Labs Series 2 EUSART (Enhanced Universal Synchronous/Asynchronous Receiver/Transmitter)
+
+description: |
+  EUSART (Enhanced Universal Synchronous/Asynchronous Receiver/Transmitter) peripheral for
+  Silicon Labs Series 2 SoCs used in UART mode.
 
 compatible: "silabs,eusart-uart"
 

--- a/dts/bindings/serial/silabs,usart-uart.yaml
+++ b/dts/bindings/serial/silabs,usart-uart.yaml
@@ -1,4 +1,8 @@
-description: Silabs USART UART
+title: Silicon Labs Series 2 USART (Universal Synchronous/Asynchronous Receiver/Transmitter)
+
+description: |
+  USART (Universal Synchronous/Asynchronous Receiver/Transmitter) peripheral for
+  Silicon Labs Series 2 SoCs used in UART mode.
 
 compatible: "silabs,usart-uart"
 

--- a/dts/bindings/spi/silabs,eusart-spi.yaml
+++ b/dts/bindings/spi/silabs,eusart-spi.yaml
@@ -1,4 +1,9 @@
-description: Silabs EUSART SPI
+title: |
+  Silicon Labs Series 2 EUSART (Enhanced Universal Synchronous/Asynchronous Receiver/Transmitter)
+
+description: |
+  EUSART (Enhanced Universal Synchronous/Asynchronous Receiver/Transmitter) peripheral for
+  Silicon Labs Series 2 SoCs used in SPI mode.
 
 compatible: "silabs,eusart-spi"
 

--- a/dts/bindings/spi/silabs,usart-spi.yaml
+++ b/dts/bindings/spi/silabs,usart-spi.yaml
@@ -1,4 +1,8 @@
-description: Silabs USART SPI
+title: Silicon Labs Series 2 USART (Universal Synchronous/Asynchronous Receiver/Transmitter)
+
+description: |
+  USART (Universal Synchronous/Asynchronous Receiver/Transmitter) peripheral for
+  Silicon Labs Series 2 SoCs used in SPI mode.
 
 compatible: "silabs,usart-spi"
 

--- a/dts/bindings/timer/silabs,gecko-burtc.yaml
+++ b/dts/bindings/timer/silabs,gecko-burtc.yaml
@@ -1,7 +1,10 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: SiLabs Gecko BURTC timer
+title: Silicon Labs Series 2 BURTC (Backup Real Time Counter)
+
+description: |
+  Backup RTC timer for Silicon Labs Series 2 SoCs.
 
 compatible: "silabs,gecko-burtc"
 

--- a/dts/bindings/watchdog/silabs,gecko-wdog.yaml
+++ b/dts/bindings/watchdog/silabs,gecko-wdog.yaml
@@ -2,7 +2,9 @@
 # Copyright (c) Oane Kingma
 # SPDX-License-Identifier: Apache-2.0
 
-description: Silicon Labs Gecko Family Watchdog driver
+title: Silicon Labs Series 1-2 WDOG (Watchdog)
+
+description: Watchdog timer for Silicon Labs Series 1-2 SoCs.
 
 compatible: "silabs,gecko-wdog"
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -920,6 +920,10 @@ class Node:
       node name format ...@<dev>,<func> or ...@<dev> (e.g. "pcie@1,0"), in
       this case None is returned.
 
+    title:
+      The title string from the binding for the node, or None if the node
+      has no binding.
+
     description:
       The description string from the binding for the node, or None if the node
       has no binding. Leading and trailing whitespace (including newlines) is
@@ -1113,6 +1117,13 @@ class Node:
             _err(f"{self!r} has non-hex unit address")
 
         return _translate(addr, self._node)
+
+    @property
+    def title(self) -> Optional[str]:
+        "See the class docstring."
+        if self._binding:
+            return self._binding.title
+        return None
 
     @property
     def description(self) -> Optional[str]:


### PR DESCRIPTION
The `title` property was added to dt bindings in #86533. Expose it on the Node class similar to how `description` is propagated, and make use of it for the `zephyr:board-supported-hw` directive in the documentation.

Leverage `title` to improve how supported hardware peripherals appear in board documentation for Silicon Labs boards.