### PR TITLE
modules: hal_nxp: mcux-sdk-ng: fix set_variable_ifdef()

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/CMakeLists.txt
@@ -28,9 +28,16 @@ if((${MCUX_DEVICE} MATCHES "RW61") AND (NOT DEFINED CONFIG_MINIMAL_LIBC))
   zephyr_library_sources(${ZEPHYR_CURRENT_MODULE_DIR}/mcux/mcux-sdk-ng/components/misc_utilities/fsl_memcpy.S)
 endif()
 
+add_subdirectory(drivers)
+
+get_property(global_vars GLOBAL PROPERTY GLOBAL_VARS_LIST)
+foreach(var IN LISTS global_vars)
+  get_property(value GLOBAL PROPERTY GV_${var})
+  set(${var} ${value})
+endforeach()
+
 add_subdirectory(middleware)
 add_subdirectory(components)
-add_subdirectory(drivers)
 add_subdirectory(device)
 
 # Expose the driver header include path, so that the shim driver can use them.

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/CMakeLists.txt
@@ -4,7 +4,9 @@
 
 function(set_variable_ifdef feature_toggle variable)
   if(${${feature_toggle}})
-    set(${variable} ON CACHE INTERNAL "global variable")
+    set(${variable} ON PARENT_SCOPE)
+    set_property(GLOBAL PROPERTY GV_${variable} ON)
+    set_property(GLOBAL APPEND PROPERTY GLOBAL_VARS_LIST ${variable})
   endif()
 endfunction()
 


### PR DESCRIPTION
Variables are not cached.

Resolves https://github.com/zephyrproject-rtos/zephyr/issues/88135

Preferred resolution is https://github.com/zephyrproject-rtos/zephyr/pull/88207, keeping this as a draft for now