### PR TITLE
dts: arm: silabs: Fix clock and interrupt definitions for xg22

### DIFF
--- a/dts/arm/silabs/efr32bg22.dtsi
+++ b/dts/arm/silabs/efr32bg22.dtsi
@@ -127,6 +127,16 @@
 	interrupts = <61 2>;
 };
 
+&adc0 {
+	interrupts = <48 2>;
+	clocks = <&cmu CLOCK_IADC0 CLOCK_BRANCH_IADCCLK>;
+};
+
+&wdog0 {
+	interrupts = <43 2>;
+	clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
+};
+
 &radio {
 	interrupts = <31 1>, <32 1>, <33 1>, <34 1>, <35 1>, <36 1>,
 		     <37 1>, <38 1>, <39 1>, <40 1>, <41 1>, <42 1>;

--- a/dts/arm/silabs/efr32bg27.dtsi
+++ b/dts/arm/silabs/efr32bg27.dtsi
@@ -149,6 +149,11 @@
 	interrupts = <26 0>;
 };
 
+&wdog0 {
+	interrupts = <49 2>;
+	clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
+};
+
 &radio {
 	interrupts = <36 1>, <37 1>, <38 1>, <39 1>, <40 1>, <41 1>,
 		     <42 1>, <43 1>, <44 1>, <45 1>, <46 1>, <47 1>;

--- a/dts/arm/silabs/efr32bg2x.dtsi
+++ b/dts/arm/silabs/efr32bg2x.dtsi
@@ -310,14 +310,12 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x4A018000 0x3028>;
 			peripheral-id = <0>;
-			interrupts = <43 2>;
 			status = "disabled";
 		};
 
 		adc0: adc@5a004000 {
 			compatible = "silabs,gecko-iadc";
 			reg = <0x5a004000 0x4000>;
-			interrupts = <48 2>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};


### PR DESCRIPTION
The WDOG and IADC clock node definitions were missing for xg22, and interrupt numbers were wrong for WDOG on xg27.

This caused build failures for #88054:

```
libraries.devicetree.api_ext on sltb010a@2/efr32bg22c224f512im40 error (Build failure - error: '__device_dts_ord_DT_N_S_soc_S_adc_5a004000_P_clocks_IDX_0_PH_ORD' undeclared here (not in a function))
```
