### PR TITLE
tests: drivers: build_all: sensor: i2c.dtsi fix address typo

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1265,7 +1265,7 @@ test_i2c_bmm350: bmm350@ac {
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
-test_i2c_ltr329: ltr329@aa {
+test_i2c_ltr329: ltr329@ad {
 	compatible = "liteon,ltr329";
 	reg = <0xad>;
 };


### PR DESCRIPTION
The address of the last i2c device in the build all test has a wrong address. This fixes that typo.