### PR TITLE
pm: Use fixed cpu id in single core case

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(gpio_esp32, CONFIG_LOG_DEFAULT_LEVEL);
 #define out_w1ts out_w1ts.val
 #define out_w1tc out_w1tc.val
 /* arch_curr_cpu() is not available for riscv based chips */
-#define CPU_ID()  0
+#define ESP32_CPU_ID()  0
 #elif CONFIG_SOC_SERIES_ESP32C3
 /* gpio structs in esp32c3 series are different from xtensa ones */
 #define out out.data
@@ -43,7 +43,7 @@ LOG_MODULE_REGISTER(gpio_esp32, CONFIG_LOG_DEFAULT_LEVEL);
 #define out_w1ts out_w1ts.val
 #define out_w1tc out_w1tc.val
 /* arch_curr_cpu() is not available for riscv based chips */
-#define CPU_ID()  0
+#define ESP32_CPU_ID()  0
 #elif defined(CONFIG_SOC_SERIES_ESP32C6)
 /* gpio structs in esp32c6 are also different */
 #define out out.out_data_orig
@@ -51,9 +51,9 @@ LOG_MODULE_REGISTER(gpio_esp32, CONFIG_LOG_DEFAULT_LEVEL);
 #define out_w1ts out_w1ts.val
 #define out_w1tc out_w1tc.val
 /* arch_curr_cpu() is not available for riscv based chips */
-#define CPU_ID()  0
+#define ESP32_CPU_ID()  0
 #else
-#define CPU_ID() arch_curr_cpu()->id
+#define ESP32_CPU_ID() arch_curr_cpu()->id
 #endif
 
 #ifndef SOC_GPIO_SUPPORT_RTC_INDEPENDENT
@@ -413,7 +413,7 @@ static int gpio_esp32_pin_interrupt_configure(const struct device *port,
 	}
 
 	gpio_ll_set_intr_type(cfg->gpio_base, io_pin, intr_trig_mode);
-	gpio_ll_intr_enable_on_core(cfg->gpio_base, CPU_ID(), io_pin);
+	gpio_ll_intr_enable_on_core(cfg->gpio_base, ESP32_CPU_ID(), io_pin);
 	irq_unlock(key);
 
 	return 0;
@@ -432,7 +432,7 @@ static uint32_t gpio_esp32_get_pending_int(const struct device *dev)
 {
 	const struct gpio_esp32_config *const cfg = dev->config;
 	uint32_t irq_status;
-	uint32_t const core_id = CPU_ID();
+	uint32_t const core_id = ESP32_CPU_ID();
 
 	if (cfg->gpio_port == 0) {
 		gpio_ll_get_intr_status(cfg->gpio_base, core_id, &irq_status);
@@ -448,7 +448,7 @@ static void IRAM_ATTR gpio_esp32_fire_callbacks(const struct device *dev)
 	const struct gpio_esp32_config *const cfg = dev->config;
 	struct gpio_esp32_data *data = dev->data;
 	uint32_t irq_status;
-	uint32_t const core_id = CPU_ID();
+	uint32_t const core_id = ESP32_CPU_ID();
 
 	if (cfg->gpio_port == 0) {
 		gpio_ll_get_intr_status(cfg->gpio_base, core_id, &irq_status);

--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -257,6 +257,8 @@ __attribute_const__ struct k_thread *z_smp_current_get(void);
 #define _current _kernel.cpus[0].current
 #endif
 
+#define CPU_ID ((CONFIG_MP_MAX_NUM_CPUS == 1) ? 0 : _current_cpu->id)
+
 /* This is always invoked from a context where preemption is disabled */
 #define z_current_thread_set(thread) ({ _current_cpu->current = (thread); })
 

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -62,7 +62,7 @@ static inline void pm_state_notify(bool entering_state)
 		}
 
 		if (callback) {
-			callback(z_cpus_pm_state[_current_cpu->id].state);
+			callback(z_cpus_pm_state[CPU_ID].state);
 		}
 	}
 	k_spin_unlock(&pm_notifier_lock, pm_notifier_key);
@@ -93,7 +93,7 @@ static inline int32_t ticks_expiring_sooner(int32_t ticks1, int32_t ticks2)
 
 void pm_system_resume(void)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = CPU_ID;
 
 	/*
 	 * This notification is called from the ISR of the event
@@ -142,7 +142,7 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 
 bool pm_system_suspend(int32_t kernel_ticks)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = CPU_ID;
 	k_spinlock_key_t key;
 	int32_t ticks, events_ticks;
 

--- a/subsys/pm/pm_stats.c
+++ b/subsys/pm/pm_stats.c
@@ -53,17 +53,17 @@ SYS_INIT(pm_stats_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 void pm_stats_start(void)
 {
-	time_start[_current_cpu->id] = k_cycle_get_32();
+	time_start[CPU_ID] = k_cycle_get_32();
 }
 
 void pm_stats_stop(void)
 {
-	time_stop[_current_cpu->id] = k_cycle_get_32();
+	time_stop[CPU_ID] = k_cycle_get_32();
 }
 
 void pm_stats_update(enum pm_state state)
 {
-	uint8_t cpu = _current_cpu->id;
+	uint8_t cpu = CPU_ID;
 	uint32_t time_total = time_stop[cpu] - time_start[cpu];
 
 	STATS_INC(stats[cpu][state], state_count);


### PR DESCRIPTION
When there are no multiple cores than fixing id to 0 saves few cycles.

Do not call ticks_expiring_sooner if not needed.

This small improvement saves few cycles but surprisingly significantly reduces `pm.c` code size 416 to 316 bytes in the sample that I've checked.