### PR TITLE
bluetooth: host: Disabled warning for misaligned access

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -282,8 +282,8 @@ static void bt_a2dp_media_data_callback(struct bt_avdtp_sep *sep, struct net_buf
 	stream = ep->stream;
 	media_hdr = net_buf_pull_mem(buf, sizeof(*media_hdr));
 
-	stream->ops->recv(stream, buf, sys_get_be16((uint8_t *)&media_hdr->sequence_number),
-			  sys_get_be32((uint8_t *)&media_hdr->time_stamp));
+	stream->ops->recv(stream, buf, sys_be16_to_cpu(media_hdr->sequence_number),
+			  sys_be32_to_cpu(media_hdr->time_stamp));
 }
 #endif
 


### PR DESCRIPTION
Rewrote places in the bluetooth code that converts objects
larger than one byte by taking the address of an unaligned struct
member and changed it to a function that takes the value directly
and converts it to big endian.

