### PR TITLE
board: sensry: ganymed_bob_sy120 - doc update

### DIFF
--- a/boards/sensry/ganymed_bob/doc/index.rst
+++ b/boards/sensry/ganymed_bob/doc/index.rst
@@ -93,7 +93,7 @@ Flash the zephyr image:
    :tool: west
    :zephyr-app: samples/hello_world
    :goals: flash
-   :west-args: --serial /dev/ttyUSB0
+   :west-args: --dev-id /dev/ttyUSB0
    :compact:
 
 


### PR DESCRIPTION
The west flash arg in the docs was incorrect. It is `--dev-id` instead of `--serial`.

