### PR TITLE
sensor: bme280: clamp humidity to non-negative

### DIFF
--- a/drivers/sensor/bosch/bme280/bme280.c
+++ b/drivers/sensor/bosch/bme280/bme280.c
@@ -126,6 +126,7 @@ static uint32_t bme280_compensate_humidity(struct bme280_data *data,
 	h = (h - (((((h >> 15) * (h >> 15)) >> 7) *
 		((int32_t)data->dig_h1)) >> 4));
 	h = (h > 419430400 ? 419430400 : h);
+	h = (h < 0 ? 0 : h);
 
 	return (uint32_t)(h >> 12);
 }


### PR DESCRIPTION
Clamp the returned humidity to a non-negative value. This ensure that the return value is always within the expected range, even if the calibration parameters are read out incorrectly or corrupted.

This check is applied in the example Bosch driver for the float conversion case, so there are situations that warrant it.