### PR TITLE
USB STM32: correct compilation error for USB clean speed configuration

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -96,7 +96,11 @@ static const struct gpio_dt_spec ulpi_reset =
 #define HIGH_SPEED             USB_OTG_SPEED_HIGH
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
+#define FULL_SPEED             PCD_SPEED_FULL
+#else
 #define FULL_SPEED             USB_OTG_SPEED_FULL
+#endif
 /*
  * USB, USB_OTG_FS and USB_DRD_FS are defined in STM32Cube HAL and allows to
  * distinguish between two kind of USB DC. STM32 F0, F3, L0 and G4 series

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -50,7 +50,11 @@ LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
 #define HIGH_SPEED             USB_OTG_SPEED_HIGH
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
+#define FULL_SPEED             PCD_SPEED_FULL
+#else
 #define FULL_SPEED             USB_OTG_SPEED_FULL
+#endif
 
 struct udc_stm32_data  {
 	PCD_HandleTypeDef pcd;


### PR DESCRIPTION
This pull request fix the USB speed configuration by leveraging the device tree's status, ensuring the correct full-speed setting is applied dynamically.