### PR TITLE
Enable ble host tests on 53bsim

### DIFF
--- a/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/encrypted/css_sample_data/testcase.yaml
@@ -5,6 +5,7 @@ tests:
       - bluetooth
     platform_allow:
       - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_encrypted_css_sample_data_prj_conf

--- a/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/encrypted/ead_sample/testcase.yaml
@@ -5,6 +5,7 @@ tests:
       - bluetooth
     platform_allow:
       - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_encrypted_ead_sample_prj_conf

--- a/tests/bsim/bluetooth/host/adv/long_ad/testcase.yaml
+++ b/tests/bsim/bluetooth/host/adv/long_ad/testcase.yaml
@@ -5,6 +5,7 @@ tests:
       - bluetooth
     platform_allow:
       - nrf52_bsim/native
+      - nrf5340bsim/nrf5340/cpunet
     harness: bsim
     harness_config:
       bsim_exe_name: tests_bsim_bluetooth_host_adv_long_ad_prj_conf

--- a/tests/bsim/bluetooth/host/att/eatt/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/eatt/testcase.yaml
@@ -4,6 +4,7 @@ common:
     - bluetooth
   platform_allow:
     - nrf52_bsim/native
+    - nrf5340bsim/nrf5340/cpunet
   harness: bsim
 
 tests:

--- a/tests/bsim/bluetooth/host/att/long_read/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/long_read/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/mtu_update/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/mtu_update/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/att/open_close/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/open_close/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/pipeline/dut/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/pipeline/dut/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/att/pipeline/tester/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/pipeline/tester/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/client/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/client/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/read_fill_buf/server/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/read_fill_buf/server/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/client/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/retry_on_sec_err/server/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/sequential/dut/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/sequential/dut/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/sequential/tester/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/sequential/tester/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/att/timeout/testcase.yaml
+++ b/tests/bsim/bluetooth/host/att/timeout/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/gatt/ccc_store/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/ccc_store/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/gatt/device_name/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/device_name/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/gatt/notify/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/gatt/notify_multiple/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/notify_multiple/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/gatt/sc_indicate/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/sc_indicate/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/gatt/settings/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/settings/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/gatt/settings_clear/testcase.yaml
+++ b/tests/bsim/bluetooth/host/gatt/settings_clear/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/id/settings/testcase.yaml
+++ b/tests/bsim/bluetooth/host/id/settings/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/iso/bis/testcase.yaml
+++ b/tests/bsim/bluetooth/host/iso/bis/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/iso/cis/testcase.yaml
+++ b/tests/bsim/bluetooth/host/iso/cis/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/iso/frag/testcase.yaml
+++ b/tests/bsim/bluetooth/host/iso/frag/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/iso/frag_2/testcase.yaml
+++ b/tests/bsim/bluetooth/host/iso/frag_2/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/credits/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/credits/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/credits_seg_recv/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/l2cap/ecred/dut/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/dut/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/ecred/peer/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/ecred/peer/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/einprogress/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/einprogress/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/general/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/general/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/multilink_peripheral/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/dut/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/dut/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/split/dut/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/split/dut/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/l2cap/stress/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/stress/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/l2cap/userdata/testcase.yaml
+++ b/tests/bsim/bluetooth/host/l2cap/userdata/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/acl_tx_frag/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/acl_tx_frag/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/conn_stress/central/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/central/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/conn_stress/peripheral/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/disconnect/dut/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/disconnect/dut/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/hfc/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/dut/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/misc/sample_test/testcase.yaml
+++ b/tests/bsim/bluetooth/host/misc/sample_test/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/privacy/device/testcase.yaml
+++ b/tests/bsim/bluetooth/host/privacy/device/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/privacy/legacy/testcase.yaml
+++ b/tests/bsim/bluetooth/host/privacy/legacy/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/privacy/peripheral/testcase.yaml
+++ b/tests/bsim/bluetooth/host/privacy/peripheral/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/scan/slow/testcase.yaml
+++ b/tests/bsim/bluetooth/host/scan/slow/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/scan/start_stop/testcase.yaml
+++ b/tests/bsim/bluetooth/host/scan/start_stop/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_allowed/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/security/bond_overwrite_denied/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_overwrite_denied/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/security/bond_per_connection/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/bond_per_connection/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/security/ccc_update/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/ccc_update/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - bluetooth
   platform_allow:
+    - nrf5340bsim/nrf5340/cpunet
     - nrf52_bsim/native
   harness: bsim
 

--- a/tests/bsim/bluetooth/host/security/id_addr_update/central/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/central/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/id_addr_update/peripheral/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:

--- a/tests/bsim/bluetooth/host/security/security_changed_callback/testcase.yaml
+++ b/tests/bsim/bluetooth/host/security/security_changed_callback/testcase.yaml
@@ -4,6 +4,7 @@ tests:
     tags:
       - bluetooth
     platform_allow:
+      - nrf5340bsim/nrf5340/cpunet
       - nrf52_bsim/native
     harness: bsim
     harness_config:


### PR DESCRIPTION
All host tests are now able to build and run on nrf5340bsim/nrf5340/cpunet.