### PR TITLE
drivers: entropy: stm32: don't waste generated random data

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -6,6 +6,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stddef.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
@@ -313,7 +314,7 @@ static int recover_seed_error(RNG_TypeDef *rng)
 }
 #endif /* !STM32_CONDRST_SUPPORT */
 
-static int random_byte_get(void)
+static int random_sample_get(rng_sample_t *rnd_sample)
 {
 	int retval = -EAGAIN;
 	unsigned int key;
@@ -343,8 +344,8 @@ static int random_byte_get(void)
 			goto out;
 		}
 
-		retval = ll_rng_read_rand_data(rng);
-		if (retval == 0) {
+		*rnd_sample = ll_rng_read_rand_data(rng);
+		if (*rnd_sample == 0) {
 			/* A seed error could have occurred between RNG_SR
 			 * polling and RND_DR output reading.
 			 */
@@ -352,7 +353,7 @@ static int random_byte_get(void)
 			goto out;
 		}
 
-		retval &= 0xFF;
+		retval = 0;
 	}
 
 out:
@@ -365,6 +366,8 @@ out:
 static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 {
 	uint16_t remaining_len = len;
+	rng_sample_t rnd_sample;
+	int ret;
 
 #if !IRQLESS_TRNG
 	__ASSERT_NO_MSG(!irq_is_enabled(IRQN));
@@ -378,7 +381,7 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 	if (ll_rng_is_active_secs(entropy_stm32_rng_data.rng) ||
 		ll_rng_is_active_seis(entropy_stm32_rng_data.rng)) {
 
-		(void)random_byte_get(); /* this will recover the error */
+		(void)random_sample_get(&rnd_sample); /* this will recover the error */
 
 		return 0; /* return cnt is null : no random data available */
 	}
@@ -393,8 +396,6 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 #endif /* !IRQLESS_TRNG */
 
 	do {
-		int byte;
-
 		while (ll_rng_is_active_drdy(
 				entropy_stm32_rng_data.rng) != 1) {
 #if !IRQLESS_TRNG
@@ -416,16 +417,23 @@ static uint16_t generate_from_isr(uint8_t *buf, uint16_t len)
 #endif /* !IRQLESS_TRNG */
 		}
 
-		byte = random_byte_get();
+		ret = random_sample_get(&rnd_sample);
 #if !IRQLESS_TRNG
 		NVIC_ClearPendingIRQ(IRQN);
 #endif /* IRQLESS_TRNG */
 
-		if (byte < 0) {
+		if (ret < 0) {
 			continue;
 		}
 
-		buf[--remaining_len] = byte;
+		/* push each byte of the RNG sample in buffer */
+		size_t i = sizeof(rnd_sample);
+
+		while (remaining_len && i) {
+			buf[--remaining_len] = (uint8_t)(rnd_sample & 0xFFu);
+			rnd_sample >>= 8;
+			i--;
+		}
 	} while (remaining_len);
 
 	return len;
@@ -579,31 +587,47 @@ static void rng_pool_init(struct rng_pool *rngp, uint16_t size,
 
 static int perform_pool_refill(void)
 {
-	int byte, ret;
+	rng_sample_t rnd_sample;
+	bool refilled_thr = false;
+	int ret;
 
-	byte = random_byte_get();
-	if (byte < 0) {
-		return -EIO;
+	ret = random_sample_get(&rnd_sample);
+	if (ret < 0) {
+		return ret;
 	}
 
-	ret = rng_pool_put((struct rng_pool *)(entropy_stm32_rng_data.isr),
-				byte);
-	if (ret < 0) {
-		ret = rng_pool_put(
-				(struct rng_pool *)(entropy_stm32_rng_data.thr),
-				byte);
-		if (ret < 0) {
-#if !IRQLESS_TRNG
-			irq_disable(IRQN);
-#endif /* !IRQLESS_TRNG */
-			release_rng();
-			pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
-			if (IS_ENABLED(CONFIG_PM_S2RAM)) {
-				pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM, PM_ALL_SUBSTATES);
-			}
-			entropy_stm32_rng_data.filling_pools = false;
-		}
+	/* push each byte of the RNG sample in pools */
+	for (size_t i = 0; i < sizeof(rnd_sample); i++, rnd_sample >>= 8) {
+		uint8_t byte = rnd_sample & 0xFFu;
 
+		ret = rng_pool_put((struct rng_pool *)(entropy_stm32_rng_data.isr), byte);
+		if (ret < 0) {
+			/* Take note that data has been added to thread pool */
+			refilled_thr = true;
+
+			ret = rng_pool_put((struct rng_pool *)(entropy_stm32_rng_data.thr), byte);
+			if (ret < 0) {
+#if !IRQLESS_TRNG
+				irq_disable(IRQN);
+#endif /* !IRQLESS_TRNG */
+				release_rng();
+				pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE,
+					PM_ALL_SUBSTATES);
+				if (IS_ENABLED(CONFIG_PM_S2RAM)) {
+					pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_RAM,
+						PM_ALL_SUBSTATES);
+				}
+				entropy_stm32_rng_data.filling_pools = false;
+				break;
+			}
+		}
+	}
+
+	if (refilled_thr) {
+		/**
+		 * Wake up threads that may be waiting for new data to be
+		 * available in thread pool if we added entropy in it.
+		 */
 		k_sem_give(&entropy_stm32_rng_data.sem_sync);
 	}
 
@@ -620,7 +644,8 @@ static void trng_poll_work_item(struct k_work *work)
 	if (ll_rng_is_active_secs(entropy_stm32_rng_data.rng) ||
 		ll_rng_is_active_seis(entropy_stm32_rng_data.rng)) {
 
-		(void)random_byte_get(); /* this will recover the error */
+		rng_sample_t dummy;
+		(void)random_sample_get(&dummy); /* this will recover the error */
 	} else if (ll_rng_is_active_drdy(rng)) {
 		/* Entropy available: read it and fill pools */
 		int res = perform_pool_refill();

--- a/drivers/entropy/entropy_stm32.h
+++ b/drivers/entropy/entropy_stm32.h
@@ -88,10 +88,18 @@ static inline uint32_t ll_rng_is_active_drdy(RNG_TypeDef *RNGx)
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
 }
 
-static inline uint16_t ll_rng_read_rand_data(RNG_TypeDef *RNGx)
+#if defined(CONFIG_SOC_SERIES_STM32WB0X) && !defined(CONFIG_SOC_STM32WB09XX)
+/* STM32WB05, STM32WB06 and STM32WB07 have 16-bit data register */
+typedef uint16_t rng_sample_t;
+#else
+/* All other TRNG IPs have 32-bit data register */
+typedef uint32_t rng_sample_t;
+#endif
+
+static inline rng_sample_t ll_rng_read_rand_data(RNG_TypeDef *RNGx)
 {
 #if defined(CONFIG_SOC_STM32WB09XX)
-	uint16_t rnd = (uint16_t)LL_RNG_GetRndVal(RNGx);
+	rng_sample_t rnd = LL_RNG_GetRndVal(RNGx);
 
 	/**
 	 * STM32WB09 TRNG does not clear IRQ flags in hardware.
@@ -108,6 +116,6 @@ static inline uint16_t ll_rng_read_rand_data(RNG_TypeDef *RNGx)
 	/* STM32WB05 / STM32WB06 / STM32WB07 */
 	return LL_RNG_ReadRandData16(RNGx);
 #else
-	return (uint16_t)LL_RNG_ReadRandData32(RNGx);
+	return LL_RNG_ReadRandData32(RNGx);
 #endif /* CONFIG_SOC_SERIES_STM32WB0X */
 }


### PR DESCRIPTION
Even though the STM32 TRNG hardware produces 2- or 4-byte sized words of random data before triggering an interrupt, the driver currently discards all but the bottom byte: 50/75% of the produced entropy goes to waste!

Make sure we consume all the random data from each word we read to improve the entropy generation rate seen by users of the driver.

Tested using a modified `tests/drivers/entropy/api` that measures time taken by `entropy_get_entropy_isr(BUSYWAIT)` (~75% improvement on 32-bit sized TRNG with 1024-byte sized buffer):
* `stm32f4_disco`: ~900µs -> ~230µs
* `nucleo_wb09ke`: ~7900ms -> ~1995ms