### PR TITLE
Bluetooth: pacs: Fixed pacs_get_available_context

### DIFF
--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -1553,12 +1553,12 @@ enum bt_audio_context bt_pacs_get_available_contexts(enum bt_audio_dir dir)
 		if (atomic_test_bit(pacs.flags, PACS_FLAG_SNK_PAC)) {
 			return snk_available_contexts;
 		}
-		return -EINVAL;
+		break;
 	case BT_AUDIO_DIR_SOURCE:
 		if (atomic_test_bit(pacs.flags, PACS_FLAG_SRC_PAC)) {
 			return src_available_contexts;
 		}
-		return -EINVAL;
+		break;
 	}
 
 	return BT_AUDIO_CONTEXT_TYPE_PROHIBITED;


### PR DESCRIPTION
Fixed the bt_pacs_get_available_context API to return values of type bt_audio_context instead of an error type.