### PR TITLE
Bluetooth: HFP_AG: Initialize variable to avoid warning

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -3062,7 +3062,7 @@ static int bt_hfp_ag_binp_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 static int bt_hfp_ag_vts_handler(struct bt_hfp_ag *ag, struct net_buf *buf)
 {
 	int err;
-	char code;
+	char code = 0;
 
 	if (!is_char(buf, '=')) {
 		return -ENOTSUP;


### PR DESCRIPTION
```
gcc 11.4.0, seems to believe this variable may be used uninitialized, and warns about it
(causing a test build failure due to warnings being treated as errors).
Let's just initialize the variable to 0 to avoid the issue, as the cost is trivial.

subsys/bluetooth/host/classic/hfp_ag.c: In function
  ‘bt_hfp_ag_vts_handler’:
1095
subsys/bluetooth/host/classic/hfp_ag.c:3091:17: error: ‘code’ may be
  used uninitialized in this function [-Werror=maybe-uninitialized]
1096
 3091 |                 bt_ag->transmit_dtmf_code(ag, code);
1097
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1098

The issue can be reproduced for ex. with:
$ mkdir build ; cd build
$ cmake -GNinja -DBOARD=native_sim/native/64 ../tests/bluetooth/shell \
 -DCONF_FILE="prj_br.conf"
$ ninja
```

Can be seen failing in CI here: 
https://github.com/zephyrproject-rtos/zephyr/actions/runs/14261603624/job/39974559922?pr=87987#step:12:1096

Issue seems to have been introduced in https://github.com/zephyrproject-rtos/zephyr/pull/77694/