### PR TITLE
soc: nxp: rw61x: enable USB clock for UDC

### DIFF
--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -268,7 +268,8 @@ __weak __ramfunc void clock_init(void)
 #endif
 #endif /* CONFIG_COUNTER_MCUX_CTIMER */
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb_otg)) && CONFIG_USB_DC_NXP_EHCI
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb_otg)) && \
+	(CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
 	/* Enable system xtal from Analog */
 	SYSCTL2->ANA_GRP_CTRL |= SYSCTL2_ANA_GRP_CTRL_PU_AG_MASK;
 	/* reset USB */


### PR DESCRIPTION
When using USB Next stack and UDC driver, enable USB clock

resolves https://github.com/zephyrproject-rtos/zephyr/issues/86409

Tested with:
```
west build -b frdm_rw612 samples/subsys/usb/cdc_acm/ --pristine -- -DCONF_FILE=usbd_next_prj.conf
```