### PR TITLE
net: openthread: Add missing error checks

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -338,7 +338,11 @@ static void ot_joiner_start_handler(otError error, void *context)
 	switch (error) {
 	case OT_ERROR_NONE:
 		NET_INFO("Join success");
-		otThreadSetEnabled(ot_context->instance, true);
+		error = otThreadSetEnabled(ot_context->instance, true);
+		if (error != OT_ERROR_NONE) {
+			NET_ERR("Failed to start the OpenThread network [%d]", error);
+		}
+
 		break;
 	default:
 		NET_ERR("Join failed [%d]", error);
@@ -439,7 +443,11 @@ int openthread_start(struct openthread_context *ot_context)
 		goto exit;
 	}
 
-	otIp6SetEnabled(ot_context->instance, true);
+	error = otIp6SetEnabled(ot_context->instance, true);
+	if (error != OT_ERROR_NONE) {
+		NET_ERR("Failed to set %s [%d]", "IPv6 support", error);
+		goto exit;
+	}
 
 	/* Sleepy End Device specific configuration. */
 	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {
@@ -450,8 +458,17 @@ int openthread_start(struct openthread_context *ot_context)
 		 */
 		ot_mode.mRxOnWhenIdle = false;
 
-		otThreadSetLinkMode(ot_context->instance, ot_mode);
-		otLinkSetPollPeriod(ot_context->instance, OT_POLL_PERIOD);
+		error = otThreadSetLinkMode(ot_context->instance, ot_mode);
+		if (error != OT_ERROR_NONE) {
+			NET_ERR("Failed to set %s [%d]", "link mode", error);
+			goto exit;
+		}
+
+		error = otLinkSetPollPeriod(ot_context->instance, OT_POLL_PERIOD);
+		if (error != OT_ERROR_NONE) {
+			NET_ERR("Failed to set %s [%d]", "poll period", error);
+			goto exit;
+		}
 	}
 
 	/* Configure Child Supervision and MLE Child timeouts. */
@@ -486,16 +503,39 @@ int openthread_start(struct openthread_context *ot_context)
 		otExtendedPanId xpanid;
 		otNetworkKey    networkKey;
 
-		otThreadSetNetworkName(ot_instance, OT_NETWORK_NAME);
-		otLinkSetChannel(ot_instance, OT_CHANNEL);
-		otLinkSetPanId(ot_instance, OT_PANID);
+		error = otThreadSetNetworkName(ot_instance, OT_NETWORK_NAME);
+		if (error != OT_ERROR_NONE) {
+			NET_ERR("Failed to set %s [%d]", "network name", error);
+			goto exit;
+		}
+
+		error = otLinkSetChannel(ot_instance, OT_CHANNEL);
+		if (error != OT_ERROR_NONE) {
+			NET_ERR("Failed to set %s [%d]", "channel", error);
+			goto exit;
+		}
+
+		error = otLinkSetPanId(ot_instance, OT_PANID);
+		if (error != OT_ERROR_NONE) {
+			NET_ERR("Failed to set %s [%d]", "PAN ID", error);
+			goto exit;
+		}
+
 		net_bytes_from_str(xpanid.m8, 8, (char *)OT_XPANID);
-		otThreadSetExtendedPanId(ot_instance, &xpanid);
+		error = otThreadSetExtendedPanId(ot_instance, &xpanid);
+		if (error != OT_ERROR_NONE) {
+			NET_ERR("Failed to set %s [%d]", "ext PAN ID", error);
+			goto exit;
+		}
 
 		if (strlen(OT_NETWORKKEY)) {
 			net_bytes_from_str(networkKey.m8, OT_NETWORK_KEY_SIZE,
 					   (char *)OT_NETWORKKEY);
-			otThreadSetNetworkKey(ot_instance, &networkKey);
+			error = otThreadSetNetworkKey(ot_instance, &networkKey);
+			if (error != OT_ERROR_NONE) {
+				NET_ERR("Failed to set %s [%d]", "network key", error);
+				goto exit;
+			}
 		}
 	}
 
@@ -542,7 +582,7 @@ static int openthread_init(struct net_if *iface)
 		.name = "openthread",
 		.no_yield = true,
 	};
-	otError err;
+	otError err = OT_ERROR_NONE;
 
 	NET_DBG("openthread_init");
 
@@ -565,7 +605,11 @@ static int openthread_init(struct net_if *iface)
 	}
 
 	if (IS_ENABLED(CONFIG_OPENTHREAD_COPROCESSOR)) {
-		otPlatUartEnable();
+		err = otPlatUartEnable();
+		if (err != OT_ERROR_NONE) {
+			NET_ERR("Failed to enable UART: [%d]", err);
+		}
+
 		otNcpHdlcInit(ot_context->instance, ncp_hdlc_send);
 	} else {
 		otIp6SetReceiveFilterEnabled(ot_context->instance, true);
@@ -613,7 +657,7 @@ static int openthread_init(struct net_if *iface)
 
 	(void)k_work_submit_to_queue(&ot_context->work_q, &ot_context->api_work);
 
-	return 0;
+	return (err == OT_ERROR_NONE) ? 0 : -EIO;
 }
 
 void ieee802154_init(struct net_if *iface)


### PR DESCRIPTION
Some OpenThread functions were called without verifying the return value, which not only is not the best practice, but also could lead to build warnings with llvm. This commit fixes it.

Fixes #88158