### PR TITLE
dts: bindings: nrf-vpr: Allow specifying pins and not using launcher

### DIFF
--- a/drivers/misc/nordic_vpr_launcher/Kconfig
+++ b/drivers/misc/nordic_vpr_launcher/Kconfig
@@ -4,7 +4,8 @@
 config NORDIC_VPR_LAUNCHER
 	bool "Nordic VPR coprocessor launcher"
 	default y
-	depends on DT_HAS_NORDIC_NRF_VPR_COPROCESSOR_ENABLED
+	depends on DT_HAS_NORDIC_NRF_VPR_COPROCESSOR_ENABLED && \
+		   $(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_VPR_COPROCESSOR),execution-memory)
 	help
 	  When enabled, the VPR coprocessors will be automatically launched
 	  during system initialization.

--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -34,6 +34,11 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 {
 	const struct nordic_vpr_launcher_config *config = dev->config;
 
+	/* Do nothing if execution memory is not specified for a given VPR. */
+	if (config->exec_addr == 0) {
+		return 0;
+	}
+
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
 	if (config->size > 0U) {
 		LOG_DBG("Loading VPR (%p) from %p to %p (%zu bytes)", config->vpr,
@@ -63,16 +68,20 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	(DT_REG_ADDR(node_id) +                                                                    \
 	 COND_CODE_0(DT_FIXED_PARTITION_EXISTS(node_id), (0), (DT_REG_ADDR(DT_GPARENT(node_id)))))
 
+#define NEEDS_COPYING(inst) UTIL_AND(DT_INST_NODE_HAS_PROP(inst, execution_memory),                \
+				     DT_INST_NODE_HAS_PROP(inst, source_memory))
+
 #define NORDIC_VPR_LAUNCHER_DEFINE(inst)                                                           \
-	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, source_memory),                                     \
+	IF_ENABLED(NEEDS_COPYING(inst),                                                            \
 		   (BUILD_ASSERT((DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)) <=          \
 				  DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory))),              \
 				 "Execution memory exceeds source memory size");))                 \
                                                                                                    \
 	static const struct nordic_vpr_launcher_config config##inst = {                            \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
-		.exec_addr = VPR_ADDR(DT_INST_PHANDLE(inst, execution_memory)),                    \
-		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, source_memory),                             \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, execution_memory),                          \
+			   (.exec_addr = VPR_ADDR(DT_INST_PHANDLE(inst, execution_memory)),))      \
+		IF_ENABLED(NEEDS_COPYING(inst),                                                    \
 			   (.src_addr = VPR_ADDR(DT_INST_PHANDLE(inst, source_memory)),            \
 			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))};      \
                                                                                                    \

--- a/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
+++ b/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml
@@ -9,14 +9,17 @@ description: |
   VPR is a RISC-V CPU implementation. VPR instances are exposed to other CPUs as
   peripherals.
 
-include: base.yaml
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
   execution-memory:
     type: phandle
-    required: true
     description: |
-      Memory area from which the VPR core will execute.
+      Memory area from which the VPR code will execute.
+      If not specified, the VPR coprocessor will not be launched automatically
+      by the nordic_vpr_launcher driver when the node is enabled. In such case,
+      the launching is supposed to be done explicitly by the user code, in some
+      custom way presumably.
 
   source-memory:
     type: phandle


### PR DESCRIPTION
Add possibility to use pinctrl to configure pins that should be assigned to nRF VPR coprocessors and also provide a way of preventing activation of the nordic_vpr_launcher driver for an enabled VPR so that it can be supplied with the code to execute and launched in a custom way.