### PR TITLE
driver: dma: stm32u5 Optimize stack usage in dma_stm32_configure

### DIFF
--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -44,6 +44,9 @@ struct dma_stm32_config {
 	uint8_t offset; /* position in the list of dmamux channel list */
 #endif
 	struct dma_stm32_stream *streams;
+#ifdef CONFIG_DMA_STM32U5
+	volatile uint32_t *linked_list_buffer;
+#endif
 };
 
 uint32_t dma_stm32_id_to_stream(uint32_t id);

--- a/samples/boards/st/uart/circular_dma/boards/nucleo_u575zi_q.overlay
+++ b/samples/boards/st/uart/circular_dma/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart1 {
+	dmas = <&gpdma1 0 25 (STM32_DMA_PERIPH_TX)
+		&gpdma1 1 24 (STM32_DMA_MODE_CYCLIC | STM32_DMA_PERIPH_RX | STM32_DMA_MEM_8BITS)>;
+	dma-names = "tx", "rx";
+	fifo-enable;
+};
+
+&gpdma1 {
+	status = "okay";
+};


### PR DESCRIPTION
## Problem
1. When calling `dma_stm32_configure`, the function allocates quite a lot of data on stack and can cause stack overflow. In my case I observed 300 bytes being used by the function
2. The structure used for linked list (circular mode) is allocated as "static" inside function. This will not work with multiple instances.

## Solution
1. Use only basic calls from STM32 LL library
2. For linked list, dedicated buffer is allocated in DMA controller instance. This buffer can also be non-cacheable on platforms that require this, such as STM32N6.
Also, we don't need to update only address registers in linked-list mode. So, 2x 32-bit words are sufficient for single DMA stream.