### PR TITLE
net: nsos_sockets: Fix incorrect connect() return code on ECONNREFUSED

### DIFF
--- a/drivers/net/nsos_sockets.c
+++ b/drivers/net/nsos_sockets.c
@@ -677,7 +677,7 @@ static int nsos_connect_blocking(struct nsos_socket *sock,
 			goto clear_nonblock;
 		}
 
-		ret = so_err;
+		ret = -nsi_errno_to_mid(so_err);
 	}
 
 clear_nonblock:


### PR DESCRIPTION
`nsos_connect_blocking()` is not returning the error as expected. It is
expected to return a negative `NSI_ERRNO_MID_...` value, but it is
returning a positive errno value. `nsos_connect_blocking()` should map
the errno value to a negative `NSI_ERRNO_MID_...`, which `nsos_connect()`
maps back to a -1 return with errno=`ECONNREFUSED`.

the current sequence of events:
- `ECONNREFUSED` occurs during connection
- `nsos_connect_blocking()` returns positive `ECONNREFUSED`
- `nsos_connect()` returns positive `ECONNREFUSED`
- `zsock_connect()` returns positive `ECONNREFUSED`

the expected sequence of events:
- `ECONNREFUSED` occurs during connection
- `nsos_connect_blocking()` returns negative `NSI_ERRNO_MID_ECONNREFUSED`
- `nsos_connect()` returns -1, errno=`ECONNREFUSED`
- `zsock_connect()` returns -1, errno=`ECONNREFUSED`

