### PR TITLE
scripts: twisterlib: extend testcase schema for reboots

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -734,6 +734,11 @@ required_snippets: <list of needed snippets>
               - cdc-acm-console
               - user-snippet-example
 
+expect_reboot: <True|False> (default False)
+    Notify twister that the test scenario is expected to reboot while executing.
+    When enabled, twister will suppress warnings about unexpected multiple runs
+    of a testsuite or testcase.
+
 The set of test scenarios that actually run depends on directives in the test scenario
 filed and options passed in on the command line. If there is any confusion,
 running with ``-v`` or examining the discard report

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -91,6 +91,7 @@ class Harness:
         config = instance.testsuite.harness_config
         self.id = instance.testsuite.id
         self.run_id = instance.run_id
+        self.expect_reboot = getattr(instance.testsuite, 'expect_reboot', False)
         if instance.testsuite.ignore_faults:
             self.fail_on_fault = False
 
@@ -845,7 +846,7 @@ class Test(Harness):
             logger.debug(f"{phase}: unexpected Ztest suite '{suite_name}' is "
                          f"not present among: {self.instance.testsuite.ztest_suite_names}")
         if suite_name in self.started_suites:
-            if self.started_suites[suite_name]['count'] > 0:
+            if self.started_suites[suite_name]['count'] > 0 and not self.expect_reboot:
                 # Either the suite restarts itself or unexpected state transition.
                 logger.warning(f"{phase}: already STARTED '{suite_name}':"
                                f"{self.started_suites[suite_name]}")
@@ -875,7 +876,7 @@ class Test(Harness):
 
     def start_case(self, tc_name, phase='TC_START'):
         if tc_name in self.started_cases:
-            if self.started_cases[tc_name]['count'] > 0:
+            if self.started_cases[tc_name]['count'] > 0 and not self.expect_reboot:
                 logger.warning(f"{phase}: already STARTED case "
                                f"'{tc_name}':{self.started_cases[tc_name]}")
             self.started_cases[tc_name]['count'] += 1

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -70,6 +70,9 @@ schema;scenario-schema:
     "extra_sections":
       type: any
       required: false
+    "expect_reboot":
+      type: bool
+      required: false
     "required_snippets":
       type: seq
       required: false

--- a/tests/drivers/flash_simulator/flash_sim_reboot/testcase.yaml
+++ b/tests/drivers/flash_simulator/flash_sim_reboot/testcase.yaml
@@ -5,6 +5,7 @@ common:
 tests:
   drivers.flash.flash_simulator.boot_no_erase:
     timeout: 5
+    expect_reboot: true
     platform_allow: mps2/an385
     integration_platforms:
       - mps2/an385

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -1,5 +1,6 @@
 common:
   depends_on: watchdog
+  expect_reboot: true
   tags:
     - drivers
     - watchdog


### PR DESCRIPTION
Extend the testcase schema to provide a way to communicate that a given
test is expected to reboot during execution. The generic harness takes
that information and suppresses `already STARTED` warnings if the
restart is expected.

Fixes #85841