### PR TITLE
Bluetooth:Controller:Flash: correct the ticker id

### DIFF
--- a/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
+++ b/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
@@ -136,7 +136,7 @@ static void time_slot_delay(uint32_t ticks_at_expire, uint32_t ticks_delay,
 		_ticker_sync_context.result = 0;
 
 		/* Abort flash prepare ticker, from ULL_HIGH context */
-		ret = ticker_stop(instance_index, 1U, ticker_id,
+		ret = ticker_stop(instance_index, 1U, (ticker_id + 1),
 				  ticker_stop_prepare_cb, NULL);
 		__ASSERT((ret == TICKER_STATUS_SUCCESS ||
 			  ret == TICKER_STATUS_BUSY),


### PR DESCRIPTION
Bluetooth:Controller:Flash: the ticker id of the ticker_stop() should be the same id with ticker_start()