### PR TITLE
ci: twister: set number of jobs to use

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -110,7 +110,7 @@ jobs:
           export ZEPHYR_TOOLCHAIN_VARIANT=llvm
 
           ./scripts/twister -p native_sim --no-detailed-test-id --force-color --inline-logs -M -N -v --retry-failed 2 \
-            -T tests --subset ${{matrix.subset}}/2
+            -T tests --subset ${{matrix.subset}}/2 -j 16
 
       - name: Print ccache stats
         if: always()

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -143,9 +143,9 @@ jobs:
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
       TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
-      WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered'
-      PR_OPTIONS: ' --clobber-output --integration'
-      PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered'
+      WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered -j 32'
+      PR_OPTIONS: ' --clobber-output --integration -j 16'
+      PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
       LLVM_TOOLCHAIN_PATH: /usr/lib/llvm-16


### PR DESCRIPTION
We want to control the number of jobs we run in parallel. Detection on
some runners can be wrong.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
