### PR TITLE
drivers: eeprom: stm32: simplify write error handling

### DIFF
--- a/drivers/eeprom/eeprom_stm32.c
+++ b/drivers/eeprom/eeprom_stm32.c
@@ -91,8 +91,6 @@ static int eeprom_stm32_write(const struct device *dev, off_t offset,
 	ret = HAL_FLASHEx_DATAEEPROM_Lock();
 	if (ret) {
 		LOG_ERR("failed to lock EEPROM (err %d)", ret);
-		k_mutex_unlock(&lock);
-		return ret;
 	}
 
 	k_mutex_unlock(&lock);


### PR DESCRIPTION
Remove the extra unlock and value return, just print the error code when failed to do DATAEEPROM_Lock().