### PR TITLE
test: posix: c_lib_ext: reduce memory requirements for testsuite

### DIFF
--- a/tests/posix/c_lib_ext/testcase.yaml
+++ b/tests/posix/c_lib_ext/testcase.yaml
@@ -10,8 +10,6 @@ common:
     - simulation
   integration_platforms:
     - qemu_cortex_m0
-  min_flash: 64
-  min_ram: 32
 tests:
   portability.posix.c_lib_ext:
     extra_configs:


### PR DESCRIPTION
Previously, these tests were part of tests/posix/common. In an effort to tie feature tests to specific POSIX features (Option Groups), these tests were moved to a separate suite in #81441.

However, the memory requirements for the legacy `tests/posix/common` testsuite were significantly higher while the memory requirements for tests in `tests/posix/c_lib_ext` are significantly lower.

Remove the minimum flash and ram requirements to run the test so that it passes tests on the integration platform `qemu_cortex_m0`.

Fixes #87561

Testing Done:
```shell
west twister --integration -T tests/posix/c_lib_ext
...
INFO    - Total complete:    4/   4  100%  built (not run):    0, filtered:    2, failed:    0, error:    0
INFO    - 6 test scenarios (6 configurations) selected, 2 configurations filtered (2 by static filter, 0 at runtime).
INFO    - 4 of 4 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 13.88 seconds.
INFO    - 36 of 36 executed test cases passed (100.00%) on 1 out of total 991 platforms (0.10%).
INFO    - 4 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```