### PR TITLE
boards: st: add support for JLink in STM32G4 Nucleo board.cmake files

### DIFF
--- a/boards/st/nucleo_g431kb/board.cmake
+++ b/boards/st/nucleo_g431kb/board.cmake
@@ -3,8 +3,10 @@
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(pyocd "--target=stm32g431kbtx")
+board_runner_args(jlink "--device=STM32G431KB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g431rb/board.cmake
+++ b/boards/st/nucleo_g431rb/board.cmake
@@ -3,8 +3,10 @@
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(pyocd "--target=stm32g431rbtx")
+board_runner_args(jlink "--device=STM32G431RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g474re/board.cmake
+++ b/boards/st/nucleo_g474re/board.cmake
@@ -3,8 +3,10 @@
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(pyocd "--target=stm32g474retx")
+board_runner_args(jlink "--device=STM32G474RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
While trying to flash my STM32 Nucleo G474RE with JLink i noticed that is not added to board.cmake. G4 series is supported by JLink so i think it might be worth to add this missing configuration. 