### PR TITLE
Fix for pm policy bug resulting in incorrect final latency request

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -33,7 +33,7 @@ extern "C" {
  * microseconds. SYS_FOREVER_US value lifts the latency constraint. Other values
  * are forbidden.
  */
-typedef void (*pm_policy_latency_changed_cb_t)(int32_t latency);
+typedef void (*pm_policy_latency_changed_cb_t)(uint32_t latency);
 
 /**
  * @brief Latency change subscription.

--- a/samples/subsys/pm/latency/src/main.c
+++ b/samples/subsys/pm/latency/src/main.c
@@ -13,7 +13,7 @@
 
 LOG_MODULE_REGISTER(app, CONFIG_APP_LOG_LEVEL);
 
-static void on_latency_changed(int32_t latency)
+static void on_latency_changed(uint32_t latency)
 {
 	if (latency == SYS_FOREVER_US) {
 		LOG_INF("Latency constraint changed: none");

--- a/subsys/pm/policy/policy_latency.c
+++ b/subsys/pm/policy/policy_latency.c
@@ -16,35 +16,34 @@ static struct k_spinlock latency_lock;
 /** List of maximum latency requests. */
 static sys_slist_t latency_reqs;
 /** Maximum CPU latency in us */
-static int32_t max_latency_us = SYS_FOREVER_US;
+static uint32_t max_latency_us = SYS_FOREVER_US;
 /** Maximum CPU latency in cycles */
-int32_t max_latency_cyc = -1;
+uint32_t max_latency_cyc = -1;
 /** List of latency change subscribers. */
 static sys_slist_t latency_subs;
 
 /** @brief Update maximum allowed latency. */
 static void update_max_latency(void)
 {
-	int32_t new_max_latency_us = SYS_FOREVER_US;
+	uint32_t new_max_latency_us = SYS_FOREVER_US;
 	struct pm_policy_latency_request *req;
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&latency_reqs, req, node) {
-		if ((new_max_latency_us == SYS_FOREVER_US) ||
-		    ((int32_t)req->value_us < new_max_latency_us)) {
-			new_max_latency_us = (int32_t)req->value_us;
+		if (req->value_us < new_max_latency_us) {
+			new_max_latency_us = req->value_us;
 		}
 	}
 
 	if (max_latency_us != new_max_latency_us) {
 		struct pm_policy_latency_subscription *sreq;
-		int32_t new_max_latency_cyc = -1;
+		uint32_t new_max_latency_cyc = -1;
 
 		SYS_SLIST_FOR_EACH_CONTAINER(&latency_subs, sreq, node) {
 			sreq->cb(new_max_latency_us);
 		}
 
 		if (new_max_latency_us != SYS_FOREVER_US) {
-			new_max_latency_cyc = (int32_t)k_us_to_cyc_ceil32(new_max_latency_us);
+			new_max_latency_cyc = k_us_to_cyc_ceil32(new_max_latency_us);
 		}
 
 		max_latency_us = new_max_latency_us;

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -146,12 +146,12 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 /** Flag to indicate number of times callback has been called */
 static uint8_t latency_cb_call_cnt;
 /** Flag to indicate expected latency */
-static int32_t expected_latency;
+static uint32_t expected_latency;
 
 /**
  * Callback to notify when state allowed status changes.
  */
-static void on_pm_policy_latency_changed(int32_t latency)
+static void on_pm_policy_latency_changed(uint32_t latency)
 {
 	TC_PRINT("Latency changed to %d\n", latency);
 


### PR DESCRIPTION
Wanted to reopen a stale PR from last year which I got too lazy to merge the last time: #71748 

The next event subscription list doesn't seem that important and will mostly be unused by anything so just want to fix the bug in the pm subsystem.