### PR TITLE
boards: nordic: thingy53: specify `ble` support

### DIFF
--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.yaml
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.yaml
@@ -8,6 +8,7 @@ toolchain:
 ram: 448
 flash: 1024
 supported:
+  - ble
   - gpio
   - i2c
   - pwm


### PR DESCRIPTION
Notify twister that the thingy53 supports Bluetooth Low Energy.