### PR TITLE
samples: tflite_ethosu: fix compile errors

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -300,6 +300,19 @@ __weak void _exit(int status)
 	}
 }
 
+/* Address undefined _fini for the exit call
+ *
+ * With gcc command-line options -nostartfiles or -nostdlib, the gcc
+ * built-in object files crti.o/crtn.o which implement _init/_fini
+ * won't get linked in automatically and will cause undefined reference
+ * to _fini error when exit is invoked.
+ *
+ * This is fixed by providing one dummey _fini to let linker pass.
+ */
+__weak void _fini(void)
+{
+}
+
 #ifndef CONFIG_NEWLIB_LIBC_CUSTOM_SBRK
 void *_sbrk(intptr_t count)
 {

--- a/samples/modules/tflite-micro/tflm_ethosu/src/inference_process.hpp
+++ b/samples/modules/tflite-micro/tflm_ethosu/src/inference_process.hpp
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 namespace InferenceProcess
 {

--- a/samples/modules/tflite-micro/tflm_ethosu/src/main.cpp
+++ b/samples/modules/tflite-micro/tflm_ethosu/src/main.cpp
@@ -225,18 +225,15 @@ int main()
 	k_queue_init(&inferenceQueue);
 
 	/* inferenceSender tasks to create and queue the jobs */
+	const size_t inferenceSenderStackSize = 2048;
+	static K_THREAD_STACK_ARRAY_DEFINE(inferenceSenderStacks, NUM_JOB_TASKS,
+					   inferenceSenderStackSize);
 	for (int n = 0; n < NUM_JOB_TASKS; n++) {
-		const size_t stackSize = 2048;
-		k_thread_stack_t *stack = static_cast<k_thread_stack_t *>(k_malloc(stackSize));
-		if (stack == nullptr) {
-			printf("Failed to allocate stack to 'inferenceSenderTask%i'\n", n);
-			exit(1);
-		}
-
 		auto &thread = threads[nthreads];
 		string *name = new string("sender " + to_string(n));
 
-		thread.id = k_thread_create(&thread.thread, stack, stackSize, inferenceSenderTask,
+		thread.id = k_thread_create(&thread.thread, inferenceSenderStacks[n],
+					    inferenceSenderStackSize, inferenceSenderTask,
 					    name, heapPtr, &inferenceQueue, 3, 0, K_FOREVER);
 		if (thread.id == 0) {
 			printf("Failed to create 'inferenceSenderTask%i'\n", n);
@@ -248,21 +245,18 @@ int main()
 
 	/* Create inferenceProcess tasks to process the queued jobs */
 	InferenceProcessParams taskParams[NUM_INFERENCE_TASKS];
+	const size_t inferenceProcessStackSize = 8192;
+	static K_THREAD_STACK_ARRAY_DEFINE(inferenceProcessStacks, NUM_INFERENCE_TASKS,
+					   inferenceProcessStackSize);
 	for (int n = 0; n < NUM_INFERENCE_TASKS; n++) {
-		const size_t stackSize = 8192;
-		k_thread_stack_t *stack = static_cast<k_thread_stack_t *>(k_malloc(stackSize));
-		if (stack == nullptr) {
-			printf("Failed to allocate stack to 'inferenceSenderTask%i'\n", n);
-			exit(1);
-		}
-
 		auto &thread = threads[nthreads];
 		auto &taskParam = taskParams[n];
 		taskParam = InferenceProcessParams(&inferenceQueue, inferenceProcessTensorArena[n],
 						   arenaSize);
 		string *name = new string("runner " + to_string(n));
 
-		thread.id = k_thread_create(&thread.thread, stack, stackSize, inferenceProcessTask,
+		thread.id = k_thread_create(&thread.thread, inferenceProcessStacks[n],
+					    inferenceProcessStackSize, inferenceProcessTask,
 					    name, heapPtr, &taskParam, 2, 0, K_FOREVER);
 		if (thread.id == 0) {
 			printf("Failed to create 'inferenceProcessTask%i'\n", n);


### PR DESCRIPTION
This tries to fix some compile errors in the `tflite_ethosu` sample, including:
1. Fix undefined `_fini` symbol on invoking exit() for newlib libc
2. Add missing inclusion of stdint.h for e.g. `uint8_t` type
3. Fix unsafe thread stack allocation.  Use canonical
    `K_THREAD_STACK_DEFINE` or friends instead of raw buffer