### PR TITLE
gitlint: Fix dependabot exception

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -61,5 +61,5 @@ ignore-merge-commits=false
 #files=gitlint/rules.py,README.md
 
 [ignore-by-author-name]
-regex=dependabot
-ignore=body-requires-signed-off-by, max-line-length-with-exceptions
+regex=^dependabot\[bot\]$
+ignore=all


### PR DESCRIPTION
Match the full dependabot author name and ignore all (including user) rules.

Tested locally by cherry-picking the commit from #88188 and running:

```shell
$ ./scripts/ci/check_compliance.py --annotate -m Gitlint -c zephyr/main..
Running Gitlint          tests in /home/pdgendt/zephyrproject/zephyr ...

Complete results in compliance.xml
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites tests="1" failures="0" errors="0" skipped="0" time="0.0">
        <testsuite name="Compliance" tests="1" errors="0" failures="0" skipped="0" time="0">
                <testcase name="Gitlint" classname="Guidelines"/>
        </testsuite>
</testsuites>
```