### PR TITLE
Bluetooth: Classic: Fix assert when aborting initiating SCO connection

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1883,6 +1883,9 @@ int bt_conn_disconnect(struct bt_conn *conn, uint8_t reason)
 #if defined(CONFIG_BT_CLASSIC)
 		else if (conn->type == BT_CONN_TYPE_BR) {
 			return bt_hci_connect_br_cancel(conn);
+		} else if (conn->type == BT_CONN_TYPE_SCO) {
+			/* There is no HCI cmd to cancel SCO connecting from spec */
+			return -EPROTONOSUPPORT;
 		}
 #endif /* CONFIG_BT_CLASSIC */
 		else {


### PR DESCRIPTION
disconnecting assert while sco is in initiating state, return an error instead of assert.