### PR TITLE
drivers: sensor: meas: ms5837 release notes and migration guide for 4.2

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -174,6 +174,10 @@ Sensors
 * :dtcompatible:`ti,tmp116` has been renamed to :dtcompatible:`ti,tmp11x` because it supports
   tmp116, tmp117 and tmp119.
 
+* :dtcompatible:`meas,ms5837` has been replaced by :dtcompatible:`meas,ms5837-30ba`
+  and :dtcompatible:`meas,ms5837-02ba`. In order to use one of the two variants, the
+  status property needs to be used as well.
+
 Serial
 =======
 

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -66,6 +66,9 @@ Removed APIs and options
 
 * Removed the deprecated ``kscan`` subsystem.
 
+* Removed :dtcompatible:`meas,ms5837` and replaced with :dtcompatible:`meas,ms5837-30ba`
+  and :dtcompatible:`meas,ms5837-02ba`.
+
 Deprecated APIs and options
 ===========================
 


### PR DESCRIPTION
The meas,ms5837 compat has been removed and replaced with two variants hence the documentation in order to migrate to the new ones.