### PR TITLE
[Backport v4.1-branch] net: coap_client: Fix CoAP client thread priority

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -1121,6 +1121,10 @@ struct coap_client_option coap_client_option_initial_block2(void)
 	return block2;
 }
 
+#define COAP_CLIENT_THREAD_PRIORITY CLAMP(CONFIG_COAP_CLIENT_THREAD_PRIORITY, \
+					  K_HIGHEST_APPLICATION_THREAD_PRIO, \
+					  K_LOWEST_APPLICATION_THREAD_PRIO)
+
 K_THREAD_DEFINE(coap_client_recv_thread, CONFIG_COAP_CLIENT_STACK_SIZE,
 		coap_client_recv, NULL, NULL, NULL,
-		CONFIG_COAP_CLIENT_THREAD_PRIORITY, 0, 0);
+		COAP_CLIENT_THREAD_PRIORITY, 0, 0);


### PR DESCRIPTION
Backport https://github.com/zephyrproject-rtos/zephyr/commit/cf0b6068d2d20c7dcd937fcfb2cc3569894e1c0d from https://github.com/zephyrproject-rtos/zephyr/pull/88050.

Fixes #88233