### PR TITLE
drivers: udc_dwc2: Mark endpoint idle on disable while hibernated

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1553,6 +1553,7 @@ static void udc_dwc2_ep_disable(const struct device *dev,
 			priv->pending_tx_flush |= BIT(usb_dwc2_get_depctl_txfnum(dxepctl));
 		}
 
+		udc_ep_set_busy(cfg, false);
 		return;
 	}
 


### PR DESCRIPTION
When endpoint is disabled while hibernated, the UDC endpoint state has to be reset. Set the busy to false to keep UDC endpoint state in sync with peripheral register state.

Fixes: 2be960ad2b33 ("drivers: udc_dwc2: Disable endpoint while hibernated")