### PR TITLE
arch: arm: mpu: Fix alignment check for iccarm

### DIFF
--- a/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
+++ b/include/zephyr/arch/arm/mpu/arm_mpu_v8.h
@@ -419,9 +419,20 @@ typedef struct {
 
 #endif /* _ASMLANGUAGE */
 
+
+/* Some compilers do not handle casts on pointers in constant expressions */
+#if defined(__IAR_SYSTEMS_ICC__)
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
+	BUILD_ASSERT(                                                                              \
+		(size > 0) &&                                                                      \
+			((size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0),                  \
+		"The start and size of the partition must align with the minimum MPU "             \
+		"region size.")
+#else
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
 	BUILD_ASSERT((size > 0) &&                                                                 \
 			     ((uint32_t)start % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0U) && \
 			     ((size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0),             \
 		     "The start and size of the partition must align with the minimum MPU "        \
 		     "region size.")
+#endif /* defined(__IAR_SYSTEMS_ICC__) */

--- a/include/zephyr/arch/arm/mpu/nxp_mpu.h
+++ b/include/zephyr/arch/arm/mpu/nxp_mpu.h
@@ -232,6 +232,16 @@ extern const struct nxp_mpu_config mpu_config;
 
 #endif /* _ASMLANGUAGE */
 
+/* Some compilers do not handle casts on pointers in constant expressions */
+#if defined(__IAR_SYSTEMS_ICC__)
+#define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
+	BUILD_ASSERT(                                                                              \
+		(size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0 &&                          \
+		(size) >= CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE,                                \
+		"The size of the partition must align with minimum MPU region size"                \
+		" and greater than or equal to minimum MPU region size.\n"                         \
+		"The start address of the partition must align with minimum MPU region size.")
+#else
 #define _ARCH_MEM_PARTITION_ALIGN_CHECK(start, size)                                               \
 	BUILD_ASSERT(                                                                              \
 		(size) % CONFIG_ARM_MPU_REGION_MIN_ALIGN_AND_SIZE == 0 &&                          \
@@ -240,5 +250,6 @@ extern const struct nxp_mpu_config mpu_config;
 		"The size of the partition must align with minimum MPU region size"                \
 		" and greater than or equal to minimum MPU region size.\n"                         \
 		"The start address of the partition must align with minimum MPU region size.")
+#endif
 
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_MPU_NXP_MPU_H_ */


### PR DESCRIPTION
The IAR C/C++ compiler can't resolve a cast on a pointer to a constant expression. This is used in the
_ARCH_MEM_PARTITION_ALIGN_CHECK macro.

This fix checks if an IAR compiler is used and disables the start-alignment check if it is.

This was already fixed for v7 in rev d34d554d.