### PR TITLE
USB STM32: Correct USB build error due to wrong speed macro values

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -91,12 +91,16 @@ static const struct gpio_dt_spec ulpi_reset =
  */
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(USB_OTG_HS_EMB_PHYC) || \
 	defined(USB_OTG_HS_EMB_PHY)
-#define HIGH_SPEED             USB_OTG_SPEED_HIGH_IN_FULL
+#define USB_DC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH_IN_FULL
 #else
-#define HIGH_SPEED             USB_OTG_SPEED_HIGH
+#define USB_DC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH
 #endif
 
-#define FULL_SPEED             USB_OTG_SPEED_FULL
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
+#define USB_DC_STM32_FULL_SPEED             PCD_SPEED_FULL
+#else
+#define USB_DC_STM32_FULL_SPEED             USB_OTG_SPEED_FULL
+#endif
 /*
  * USB, USB_OTG_FS and USB_DRD_FS are defined in STM32Cube HAL and allows to
  * distinguish between two kind of USB DC. STM32 F0, F3, L0 and G4 series
@@ -446,7 +450,9 @@ static int usb_dc_stm32_init(void)
 	int ret;
 	unsigned int i;
 
-	usb_dc_stm32_state.pcd.Init.speed = DT_INST_STRING_UPPER_TOKEN(0, maximum_speed);
+	usb_dc_stm32_state.pcd.Init.speed =
+			UTIL_CAT(USB_DC_STM32_, DT_INST_STRING_UPPER_TOKEN(0, maximum_speed));
+
 #if defined(USB) || defined(USB_DRD_FS)
 #ifdef USB
 	usb_dc_stm32_state.pcd.Instance = USB;

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -45,12 +45,16 @@ LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
  * DT property to the corresponding definition used by the STM32 HAL.
  */
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(USB_OTG_HS_EMB_PHY)
-#define HIGH_SPEED             USB_OTG_SPEED_HIGH_IN_FULL
+#define UDC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH_IN_FULL
 #else
-#define HIGH_SPEED             USB_OTG_SPEED_HIGH
+#define UDC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH
 #endif
 
-#define FULL_SPEED             USB_OTG_SPEED_FULL
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usb)
+#define UDC_STM32_FULL_SPEED             PCD_SPEED_FULL
+#else
+#define UDC_STM32_FULL_SPEED             USB_OTG_SPEED_FULL
+#endif
 
 struct udc_stm32_data  {
 	PCD_HandleTypeDef pcd;
@@ -990,7 +994,7 @@ static void priv_pcd_prepare(const struct device *dev)
 	/* Default values */
 	priv->pcd.Init.dev_endpoints = cfg->num_endpoints;
 	priv->pcd.Init.ep0_mps = cfg->ep0_mps;
-	priv->pcd.Init.speed = DT_INST_STRING_UPPER_TOKEN(0, maximum_speed);
+	priv->pcd.Init.speed = UTIL_CAT(UDC_STM32_, DT_INST_STRING_UPPER_TOKEN(0, maximum_speed));
 
 	/* Per controller/Phy values */
 #if defined(USB)


### PR DESCRIPTION
Added conditional checks for full-speed definitions using DT_HAS_COMPAT_STATUS_OKAY for st_stm32_usb.
Updated USB/UDC speed definition macros for STM32 series to handle different speed configurations
based on the SoC compatibility.

Replaced the PR https://github.com/zephyrproject-rtos/zephyr/pull/88152