### PR TITLE
Added KConfig config CONFIG_TRACING_CTF_IDLE

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -68,6 +68,15 @@ config TRACING_USER
 endchoice
 
 
+config TRACING_CTF_IDLE
+	bool "CTF idle events"
+	default y
+	depends on TRACING_CTF
+	help
+	  If enabled, sys_trace_idle events are added to CTF buffer. Consider
+	  disabling this option if you are not interested in idle events or
+	  if idle events flood your CTF buffer.
+
 config TRACING_CTF_TIMESTAMP
 	bool "CTF internal timestamp"
 	default y

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -189,7 +189,9 @@ void sys_trace_isr_exit_to_scheduler(void)
 
 void sys_trace_idle(void)
 {
-	ctf_top_idle();
+	if (IS_ENABLED(CONFIG_TRACING_CTF_IDLE)) {
+		ctf_top_idle();
+	}
 	if (IS_ENABLED(CONFIG_CPU_LOAD)) {
 		cpu_load_on_enter_idle();
 	}


### PR DESCRIPTION
While using CTF tracing with backend RAM, our buffer was flooded with IDLE events. The buffer went full after only few seconds.
Therefore a new KConfig config `CONFIG_TRACING_CTF_IDLE` is added.
 
If this config is enabled (default), `sys_trace_idle()` events are added to CTF buffer. 

Consider disabling this option if you are not interested in idle events or if idle events flood your CTF buffer.