### PR TITLE
drivers: serial: uart_mcux_lpuart: RX IRQ Enable RxOverrun flag

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -337,7 +337,7 @@ static int mcux_lpuart_irq_tx_ready(const struct device *dev)
 static void mcux_lpuart_irq_rx_enable(const struct device *dev)
 {
 	const struct mcux_lpuart_config *config = dev->config;
-	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
+	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable | kLPUART_RxOverrunInterruptEnable;
 
 	LPUART_EnableInterrupts(config->base, mask);
 }
@@ -345,7 +345,7 @@ static void mcux_lpuart_irq_rx_enable(const struct device *dev)
 static void mcux_lpuart_irq_rx_disable(const struct device *dev)
 {
 	const struct mcux_lpuart_config *config = dev->config;
-	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable;
+	uint32_t mask = kLPUART_RxDataRegFullInterruptEnable | kLPUART_RxOverrunInterruptEnable;
 
 	LPUART_DisableInterrupts(config->base, mask);
 }


### PR DESCRIPTION
If the RX FIFO buffer is full and there's nothing being transmitted no LPUART interrupt will fire anymore. Thus the application will not receive any bytes anymore. By enabling kLPUART_RxOverrunInterruptEnable we will receive interrupts even though RX FIFO is full so we can recover from this.