### PR TITLE
bluetooth: gatt: Add BT_GATT_CCC_WITH_WRITE_CB()

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1167,6 +1167,20 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 	BT_GATT_CCC_MANAGED(((struct _bt_gatt_ccc[])			\
 		{BT_GATT_CCC_INITIALIZER(_changed, NULL, NULL)}), _perm)
 
+/**
+ *  @brief Client Characteristic Configuration Declaration Macro with write callback.
+ *
+ *  Helper macro to declare a CCC attribute with a write callback.
+ *
+ *  @param _changed Configuration changed callback.
+ *  @param _write Configuration write callback.
+ *  @param _perm CCC access permissions,
+ *               a bitmap of @ref bt_gatt_perm values.
+ */
+#define BT_GATT_CCC_WITH_WRITE_CB(_changed, _write, _perm)		\
+	BT_GATT_CCC_MANAGED(((struct _bt_gatt_ccc[])			\
+		{BT_GATT_CCC_INITIALIZER(_changed, _write, NULL) }), _perm)
+
 /** @brief Read Characteristic Extended Properties Attribute helper
  *
  *  Read CEP attribute value from local database storing the result into buffer


### PR DESCRIPTION
Add simple helper macro so users can define a CCCD with a write cb without having to combine BT_GATT_CCC_MANAGED() and BT_GATT_CCC_INITIALIZER() themselves.

Unlike the changed callback the write callback has a return value that can be used to reject the write request.