### PR TITLE
drivers: timer: ti_dmtimer: Do not require systick_timer node label

### DIFF
--- a/drivers/timer/ti_dmtimer.c
+++ b/drivers/timer/ti_dmtimer.c
@@ -153,7 +153,7 @@ static int sys_clock_driver_init(void)
 {
 	struct ti_dm_timer_data *data;
 
-	systick_timer_dev = DEVICE_DT_GET(DT_NODELABEL(systick_timer));
+	systick_timer_dev = DEVICE_DT_GET(DT_DRV_INST(0));
 
 	data = systick_timer_dev->data;
 


### PR DESCRIPTION
This driver currently only supports one instance of this timer and uses it as the system clock. The instance is selected by being the first one listed in DT in all places except sys_clock_driver_init() where it uses the node label "systick_timer".

This driver should be fixed to correctly support multiple instances of this timer, and the one used for the system timer should be selected based on a flag or alias, not based on label.

For now simply use the 0th instance like everywhere else which removes the need to have this node labeled a special way and makes no functional changes to current users.