### PR TITLE
arch: arm: pm_s2ram: fix compatibility with ARMv6-M again

### DIFF
--- a/arch/arm/core/cortex_m/pm_s2ram.S
+++ b/arch/arm/core/cortex_m/pm_s2ram.S
@@ -219,13 +219,17 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_resume)
 	push    {r0, lr}
 	bl      pm_s2ram_mark_check_and_clear
 	cmp	r0, #0x1
-	pop     {r0, lr}
 	beq	.L_resume
-	bx	lr
+	pop	{r0, pc}
 
 .L_resume:
 	/*
-	 * Restore the CPU context
+	 * Switch to the stack used to execute "arch_pm_s2ram_suspend"
+	 * and restore CPU context backed up by that function, then
+	 * return to the call site of "arch_pm_s2ram_suspend".
+	 *
+	 * Note: the "push {r0, lr}" performed earlier doesn't
+	 * need to be balanced out since we are switching stacks.
 	 */
 	ldr	r0, =_cpu_context
 


### PR DESCRIPTION
Commit b4fb5d38ebe5604696978af49a1b143a776a6222 added a `pop {r0, lr}` to `arch_pm_s2ram_resume` but this instruction is not valid on ARMv6-M or ARMv8-M Baseline.

Modify the sequence to use `pop {r0, pc}` which is supported on all ARM M-profile implementations (v6/v7/v8 Baseline/v8 Mainline), and add comments to (hopefully) prevent this issue from re-appearing.