### PR TITLE
drivers: entropy: stm32: configure prescaler on STM32WB09

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -177,6 +177,14 @@ static int entropy_stm32_resume(void)
 
 	res = clock_control_on(dev_data->clock,
 			(clock_control_subsys_t)&dev_cfg->pclken[0]);
+#if defined(CONFIG_SOC_STM32WB09XX)
+	/**
+	 * STM32WB09 RNG clock domain runs at (16 MHz / CLKDIV).
+	 * CLKDIV is 256 after reset which makes the RNG runs VERY slow.
+	 * Configure CLKDIV=1 to ensure RNG runs at an acceptable speed.
+	 */
+	LL_RNG_SetSamplingClockEnableDivider(rng, 0);
+#endif
 	LL_RNG_Enable(rng);
 	ll_rng_enable_it(rng);
 


### PR DESCRIPTION
The STM32WB09 TRNG has a prescaler that defaults (on reset) to 256, making the entropy generation process unbearably slow. Change the prescaler value to 1 instead, in order to make the IP about as fast as other STM32's.