### PR TITLE
drivers: sensor: icp201xx: fix channel check logic

### DIFF
--- a/drivers/sensor/tdk/icp201xx/icp201xx_drv.c
+++ b/drivers/sensor/tdk/icp201xx/icp201xx_drv.c
@@ -216,8 +216,8 @@ static int icp201xx_channel_get(const struct device *dev, enum sensor_channel ch
 {
 	struct icp201xx_data *data = (struct icp201xx_data *)dev->data;
 
-	if (chan != SENSOR_CHAN_AMBIENT_TEMP && chan != SENSOR_CHAN_PRESS &&
-	    chan != SENSOR_CHAN_ALTITUDE) {
+	if (!(chan == SENSOR_CHAN_AMBIENT_TEMP || chan == SENSOR_CHAN_PRESS ||
+	      chan == SENSOR_CHAN_ALTITUDE)) {
 		return -ENOTSUP;
 	}
 	icp201xx_mutex_lock(dev);

--- a/drivers/sensor/tdk/icp201xx/icp201xx_drv.c
+++ b/drivers/sensor/tdk/icp201xx/icp201xx_drv.c
@@ -216,8 +216,8 @@ static int icp201xx_channel_get(const struct device *dev, enum sensor_channel ch
 {
 	struct icp201xx_data *data = (struct icp201xx_data *)dev->data;
 
-	if (!(chan == SENSOR_CHAN_AMBIENT_TEMP || chan == SENSOR_CHAN_PRESS ||
-	      SENSOR_CHAN_ALTITUDE)) {
+	if (chan != SENSOR_CHAN_AMBIENT_TEMP && chan != SENSOR_CHAN_PRESS &&
+	    chan != SENSOR_CHAN_ALTITUDE) {
 		return -ENOTSUP;
 	}
 	icp201xx_mutex_lock(dev);


### PR DESCRIPTION
Update the channel validation logic to avoid using enum constants as boolean values.
Fixes clang warning "converting the enum constant to a boolean" observed in main https://github.com/zephyrproject-rtos/zephyr/actions/runs/14310267206/job/40103313166