### PR TITLE
drivers: gpio: gpio_mcux_igpio: add pull strength configuration

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -17,6 +17,7 @@
 #include <fsl_gpio.h>
 
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/dt-bindings/gpio/nxp-imx-igpio.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
@@ -90,8 +91,13 @@ static int mcux_igpio_configure(const struct device *dev,
 	if (((flags & GPIO_PULL_UP) != 0) || ((flags & GPIO_PULL_DOWN) != 0)) {
 		reg |= IOMUXC_SW_PAD_CTL_PAD_PUE_MASK;
 		if (((flags & GPIO_PULL_UP) != 0)) {
-			/* Use 100K pullup */
-			reg |= IOMUXC_SW_PAD_CTL_PAD_PUS(2);
+			if ((flags & NXP_IGPIO_PULL_STRONG) != 0) {
+				/* Use 22K pullup */
+				reg |= IOMUXC_SW_PAD_CTL_PAD_PUS(3);
+			} else {
+				/* Use 100K pullup */
+				reg |= IOMUXC_SW_PAD_CTL_PAD_PUS(2);
+			}
 		} else {
 			/* 100K pulldown */
 			reg &= ~IOMUXC_SW_PAD_CTL_PAD_PUS_MASK;

--- a/include/zephyr/dt-bindings/gpio/nxp-imx-igpio.h
+++ b/include/zephyr/dt-bindings/gpio/nxp-imx-igpio.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Feniex Industries Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_IMX_IGPIO_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_IMX_IGPIO_H_
+
+/**
+ * @name GPIO pull strength flags
+ *
+ * The pull strength flags are a Zephyr specific extension of the standard GPIO
+ * flags specified by the Linux GPIO binding. Only applicable for NXP IMX
+ * SoCs.
+ *
+ * The interface supports two different pull strengths:
+ * `WEAK` - The lowest pull strength supported by the HW
+ * `STRONG` - The highest pull strength supported by the HW
+ *
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
+#define NXP_IGPIO_PULL_STRENGTH_POS 8
+#define NXP_IGPIO_PULL_STRENGTH_MASK (0x1U << NXP_IGPIO_PULL_STRENGTH_POS)
+/** @endcond */
+
+/** pull up/down strengths (only applies to CONFIG_SOC_SERIES_IMXRT10XX) */
+#define NXP_IGPIO_PULL_WEAK (0x0U << NXP_IGPIO_PULL_STRENGTH_POS)
+#define NXP_IGPIO_PULL_STRONG (0x1U << NXP_IGPIO_PULL_STRENGTH_POS)
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_GPIO_NXP_IMX_IGPIO_H_ */


### PR DESCRIPTION
The i.MXRT10xx series have configurable GPIO pull strengths.

These are available for configuration in the pinctrl system, but not for regular GPIO use.

This commit adds SOC-series specific GPIO configuration bits for selecting weak or strong GPIO pulls, similar to drive strengths available from other GPIO pin configuration examples.

This has been tested on a custom i.MXRT1062 product.