### PR TITLE
tests: spi_loopback: fix RTIO fallback messages config to 5

### DIFF
--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -30,6 +30,7 @@ tests:
   drivers.spi.loopback.rtio:
     extra_configs:
       - CONFIG_SPI_RTIO=y
+      - CONFIG_SPI_RTIO_FALLBACK_MSGS=5
     platform_allow:
       - robokit1
       - mimxrt1170_evk/mimxrt1176/cm7


### PR DESCRIPTION
Loopback test requires this in order to properly execute half transactions. Otherwise, testsuite fails.

It was overlooked when fixing #85894.

Fixes #87108

Tested on:
- `nrf52840dk/nrf52840`
- `mimxrt1170@B/mimxrt1176/cm7`