### PR TITLE
drivers: stepper: step_dir: Adjust toggeling speed of step pin

### DIFF
--- a/drivers/stepper/step_dir/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.h
@@ -74,6 +74,7 @@ struct step_dir_stepper_common_data {
 	int32_t actual_position;
 	uint64_t microstep_interval_ns;
 	int32_t step_count;
+	bool step_performed;
 	stepper_event_callback_t callback;
 	void *event_cb_user_data;
 

--- a/drivers/stepper/step_dir/step_dir_stepper_work_timing.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_work_timing.c
@@ -9,12 +9,17 @@
 static k_timeout_t stepper_movement_delay(const struct device *dev)
 {
 	const struct step_dir_stepper_common_data *data = dev->data;
+	const struct step_dir_stepper_common_config *config = dev->config;
 
 	if (data->microstep_interval_ns == 0) {
 		return K_FOREVER;
 	}
 
-	return K_NSEC(data->microstep_interval_ns);
+	if (config->dual_edge) {
+		return K_NSEC(data->microstep_interval_ns);
+	} else {
+		return K_NSEC(data->microstep_interval_ns / 2);
+	}
 }
 
 static void stepper_work_step_handler(struct k_work *work)


### PR DESCRIPTION
Changes the timing source to perform the stepping in half of the given frequency to space out the toggeling of the step pin more. This fixes misstepping for configurations where the speed of successive toggeling exceeds what the stepper driver can handle.

Fixes #87698.