### PR TITLE
 scripts: twister: fix regenerate serial device with unknown platform for stm32 boards 

### DIFF
--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -382,6 +382,9 @@ class HardwareMap:
                 logger.warning(f"Unsupported device ({d.manufacturer}): {d}")
 
     def save(self, hwm_file):
+        # list of board ids with boot-serial sequence
+        boot_ids = []
+
         # use existing map
         self.detected = natsorted(self.detected, key=lambda x: x.serial or '')
         if os.path.exists(hwm_file):
@@ -390,10 +393,13 @@ class HardwareMap:
                 if hwm:
                     hwm.sort(key=lambda x: x.get('id', ''))
 
-                    # disconnect everything
+                    # disconnect everything except boards with boot-serial sequence
                     for h in hwm:
-                        h['connected'] = False
-                        h['serial'] = None
+                        if h['product'] != 'BOOT-SERIAL' :
+                            h['connected'] = False
+                            h['serial'] = None
+                        else :
+                            boot_ids.append(h['id'])
 
                     for _detected in self.detected:
                         for h in hwm:
@@ -417,6 +423,11 @@ class HardwareMap:
                     hwm = hwm + new
                 else:
                     hwm = new
+
+            #remove duplicated devices with unknown platform names before saving the file
+            for h in hwm :
+                if h['id'] in boot_ids and h['platform'] == 'unknown':
+                    hwm.remove(h)
 
             with open(hwm_file, 'w') as yaml_file:
                 yaml.dump(hwm, yaml_file, Dumper=Dumper, default_flow_style=False)


### PR DESCRIPTION
This PR is an addition to the changes introduced by #84869, specifically in commit b859423.

Twister will avoid generating a new serial device with an unknown platform name when the `map.yaml` file contains a platform with the product name `BOOT-SERIAL`.