### PR TITLE
lib: open-amp: fix OPENAMP_COPY_RSC_TABLE dependancy

### DIFF
--- a/lib/open-amp/Kconfig
+++ b/lib/open-amp/Kconfig
@@ -37,6 +37,7 @@ config OPENAMP_RSC_TABLE_IPM_TX_ID
 
 config OPENAMP_COPY_RSC_TABLE
 	bool "Copy resource table section"
+	depends on OPENAMP_RSC_TABLE
 	help
 	  The .resource_table section must be placed in a specific location
 	  known by both this core and the remote core. If this is not taken


### PR DESCRIPTION
The config item OPENAMP_COPY_RSC_TABLE is only applicable when OPENAMP_RSC_TABLE is enabled