### PR TITLE
soc: ite: ilm: it51xxx: Support RAM code size up to 4K

### DIFF
--- a/soc/ite/ec/it51xxx/chip_chipregs.h
+++ b/soc/ite/ec/it51xxx/chip_chipregs.h
@@ -307,6 +307,8 @@ struct gctrl_it51xxx_regs {
 #define IT51XXX_GCTRL_LRSIPGWR    BIT(0)
 /* 0x38: Special Control 9 */
 #define IT51XXX_GCTRL_ALTIE       BIT(4)
+/* 0x47: Scratch SRAM0 Base Address */
+#define IT51XXX_SEL_SRAM0_BASE_4K 0x04
 /* 0x48: Scratch ROM 0 Size */
 #define IT51XXX_GCTRL_SCRSIZE_4K  0x03
 

--- a/soc/ite/ec/it51xxx/ilm_wrapper.c
+++ b/soc/ite/ec/it51xxx/ilm_wrapper.c
@@ -10,10 +10,6 @@
 
 void __soc_ram_code custom_reset_instr_cache(void)
 {
-	struct gctrl_it51xxx_regs *const gctrl_regs = GCTRL_IT51XXX_REGS_BASE;
-
-	/* I-Cache tag sram reset */
-	gctrl_regs->GCTRL_SCR0BAR = 0;
 	/* Make sure the I-Cache is reset */
 	__asm__ volatile("fence.i" ::: "memory");
 }

--- a/soc/ite/ec/it51xxx/linker.ld
+++ b/soc/ite/ec/it51xxx/linker.ld
@@ -257,6 +257,8 @@ SECTIONS
     /* Claim RAM for ILM mappings; must be 4k-aligned and each mapping is 4k in size */
     SECTION_PROLOGUE(ilm_ram,(NOLOAD),ALIGN(0x1000))
 	{
+		/* On IT51XXX chip, scratch RAM must start at RAM_BASE+0x1000 */
+		. += 0x1000;
 		__ilm_ram_start = .;
 		. += __ilm_flash_end - __ilm_flash_start;
 		__ilm_ram_end = .;

--- a/soc/ite/ec/it51xxx/soc.c
+++ b/soc/ite/ec/it51xxx/soc.c
@@ -102,11 +102,8 @@ void soc_prep_hook(void)
 	struct gpio_ite_ec_regs *const gpio_regs = GPIO_ITE_EC_REGS_BASE;
 	struct gctrl_ite_ec_regs *const gctrl_regs = GCTRL_ITE_EC_REGS_BASE;
 
-	/* Scratch ROM0 is 4kb size */
-	gctrl_regs->GCTRL_SCR0SZR = IT51XXX_GCTRL_SCRSIZE_4K;
-
-	/* Scratch ROM0 is 4kb size */
-	gctrl_regs->GCTRL_SCR0SZR = IT51XXX_GCTRL_SCRSIZE_4K;
+	/* Scratch SRAM0 uses the 4KB based form 0x801000h */
+	gctrl_regs->GCTRL_SCR0BAR = IT51XXX_SEL_SRAM0_BASE_4K;
 
 	/* bit4: wake up CPU if it is in low power mode and an interrupt is pending. */
 	gctrl_regs->GCTRL_SPCTRL9 |= IT51XXX_GCTRL_ALTIE;


### PR DESCRIPTION
Previously, the RAM code size was limited to 1K, causing issues when the code exceeded this limit. This update modifies the implementation to support RAM code sizes up to 4K

test: zephyrproject/zephyr/tests/drivers/flash/common --> pass