### PR TITLE
drivers: clock_control: Add missing dependency in Kconfig

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -75,9 +75,9 @@ config CLOCK_CONTROL_NRF_DRIVER_CALIBRATION
 
 config CLOCK_CONTROL_NRF_CALIBRATION_LF_ALWAYS_ON
 	bool "LF clock is always on"
-	default y if NRF_RTC_TIMER
+	default y if NRF_RTC_TIMER || NRF_GRTC_TIMER
 	help
-	  If RTC is used as system timer then LF clock is always on and handling
+	  If RTC or GRTC is used as system timer then LF clock is always on and handling
 	  can be simplified.
 
 config CLOCK_CONTROL_NRF_CALIBRATION_PERIOD


### PR DESCRIPTION
Calibration process can be simplified if LF clock is always on. Kconfig was depending on RTC being used as system clock because that indicates LF clock being always on. Same can be done for case when GRTC is used as system clock.