### PR TITLE
drivers: ssp: unify clock selection flow across ACE platforms

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1937,9 +1937,7 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 	struct ssp_intel_ext_ctl *ext;
 #if SSP_IP_VER >= SSP_IP_VER_1_5
 	struct ssp_intel_link_ctl *link;
-#if SSP_IP_VER > SSP_IP_VER_1_5
 	struct dai_intel_ssp_plat_data *ssp = dai_get_plat_data(dp);
-#endif
 #endif
 
 	for (i = 0; i < aux_len; i += hop) {
@@ -1987,13 +1985,13 @@ static int dai_ssp_parse_tlv(struct dai_intel_ssp *dp, const uint8_t *aux_ptr, s
 		case SSP_LINK_CLK_SOURCE:
 #if SSP_IP_VER >= SSP_IP_VER_1_5
 			link = (struct ssp_intel_link_ctl *)&aux_tlv->val;
+			ssp->link_clock = link->clock_source;
 #if SSP_IP_VER < SSP_IP_VER_2_0
 			sys_write32((sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) &
 				    ~I2CLCTL_MLCS(0x7)) |
 				    I2CLCTL_MLCS(link->clock_source), dai_ip_base(dp) +
 				    I2SLCTL_OFFSET);
 #elif SSP_IP_VER > SSP_IP_VER_1_5
-			ssp->link_clock = link->clock_source;
 			sys_write32((sys_read32(dai_i2svss_base(dp) + I2SLCTL_OFFSET) &
 				    ~I2CLCTL_MLCS(0x7)) |
 				    I2CLCTL_MLCS(link->clock_source),
@@ -2563,6 +2561,11 @@ static void ssp_acquire_ip(struct dai_intel_ssp *dp)
 			    ~I2CLCTL_MLCS(0x7)) |
 			    I2CLCTL_MLCS(ssp->link_clock),
 			    dai_i2svss_base(dp) + I2SLCTL_OFFSET);
+#elif SSP_IP_VER == SSP_IP_VER_1_5
+		sys_write32((sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) &
+			    ~I2CLCTL_MLCS(0x7)) |
+			    I2CLCTL_MLCS(ssp->link_clock), dai_ip_base(dp) +
+			    I2SLCTL_OFFSET);
 #endif
 	}
 }
@@ -2595,6 +2598,11 @@ static void ssp_release_ip(struct dai_intel_ssp *dp)
 			    ~I2CLCTL_MLCS(0x7)) |
 			    I2CLCTL_MLCS(DAI_INTEL_SSP_CLOCK_XTAL_OSCILLATOR),
 			    dai_i2svss_base(dp) + I2SLCTL_OFFSET);
+#elif SSP_IP_VER == SSP_IP_VER_1_5
+		sys_write32((sys_read32(dai_ip_base(dp) + I2SLCTL_OFFSET) &
+			   ~I2CLCTL_MLCS(0x7)) |
+			   I2CLCTL_MLCS(DAI_INTEL_SSP_CLOCK_XTAL_OSCILLATOR),
+			   dai_ip_base(dp) + I2SLCTL_OFFSET);
 #endif
 
 		dai_ssp_pm_runtime_en_ssp_clk_gating(dp, ssp->ssp_index);

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -136,6 +136,8 @@ struct dai_intel_ssp_plat_data {
 #if SSP_IP_VER > SSP_IP_VER_1_5
 	uint32_t hdamlssp_base;
 	uint32_t i2svss_base;
+#endif
+#if SSP_IP_VER >= SSP_IP_VER_1_5
 	uint32_t link_clock;
 #endif
 	int irq;


### PR DESCRIPTION
During intensive testing, it was found that the clock should be set the same way on all ACE platforms (SSP_IP_VER >= 1.5)