### PR TITLE
sensor: lsm6dsv16x: fix building in rtio config

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -222,7 +222,9 @@ void lsm6dsv16x_submit_stream(const struct device *dev, struct rtio_iodev_sqe *i
 static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
 {
 	const struct device *dev = arg;
+#if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	const struct lsm6dsv16x_config *config = dev->config;
+#endif
 	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
 
 	/*
@@ -238,9 +240,7 @@ static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe
 static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
 {
 	const struct device *dev = arg;
-#if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	const struct lsm6dsv16x_config *config = dev->config;
-#endif
 	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
 	struct gpio_dt_spec *irq_gpio = lsm6dsv16x->drdy_gpio;
 	struct rtio_iodev *iodev = lsm6dsv16x->iodev;


### PR DESCRIPTION
Fix build error which happens when LSM6DSV16X_STREAM=y and there are no lsm6dsv16x driver instances on i3c bus.
To reproduce it:
west build -b nucleo_h503rb samples/sensor/stream_fifo/

In file included from /local/home/visconti/Projects/GIT/FW/zephyrproject/zephyr/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c:12:
/local/home/visconti/Projects/GIT/FW/zephyrproject/zephyr/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c: In function 'lsm6dsv16x_read_fifo_cb':
/local/home/visconti/Projects/GIT/FW/zephyrproject/zephyr/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c:407:33: error: 'config' undeclared (first use in this function)
  407 |                                 config->accel_fs_map[lsm6dsv16x->accel_fs]),
      |                                 ^~~~~~
/local/home/visconti/Projects/GIT/FW/zephyrproject/zephyr/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.h:19:61: note: in definition of macro 'LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX'
   19 | #define LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX(x) (__builtin_clz(x) - 1)
      |                                                             ^
/local/home/visconti/Projects/GIT/FW/zephyrproject/zephyr/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c:407:33: note: each undeclared identifier is reported only once for each function it appears in
  407 |                                 config->accel_fs_map[lsm6dsv16x->accel_fs]),
      |                                 ^~~~~~
/local/home/visconti/Projects/GIT/FW/zephyrproject/zephyr/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.h:19:61: note: in definition of macro 'LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX'
   19 | #define LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX(x) (__builtin_clz(x) - 1)
      |                                                             ^
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /local/home/visconti/.local/bin/cmake --build /local/home/visconti/Projects/GIT/FW/zephyrproject/zephyr/build


Fixes: #87907
