### PR TITLE
net: lib: wifi_credentials: Fix security type check while storing cre…

### DIFF
--- a/subsys/net/lib/wifi_credentials/wifi_credentials.c
+++ b/subsys/net/lib/wifi_credentials/wifi_credentials.c
@@ -132,12 +132,7 @@ int wifi_credentials_get_by_ssid_personal_struct(const char *ssid, size_t ssid_l
 		goto exit;
 	}
 
-	if (buf->header.type != WIFI_SECURITY_TYPE_NONE &&
-	    buf->header.type != WIFI_SECURITY_TYPE_PSK &&
-	    buf->header.type != WIFI_SECURITY_TYPE_PSK_SHA256 &&
-	    buf->header.type != WIFI_SECURITY_TYPE_SAE &&
-	    buf->header.type != WIFI_SECURITY_TYPE_EAP_TLS &&
-	    buf->header.type != WIFI_SECURITY_TYPE_WPA_PSK) {
+	if (buf->header.type < 0 || buf->header.type > WIFI_SECURITY_TYPE_MAX) {
 		LOG_ERR("Requested WiFi credentials entry is corrupted");
 		ret = -EPROTO;
 		goto exit;


### PR DESCRIPTION
…dentials

Fix credential store corruption issue caused by missing security type checks. Add support for all valid security types to ensure credentials are parsed correctly.

Fixes #88261.