### PR TITLE
doc: shell: fix typo of Segger

### DIFF
--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -110,7 +110,7 @@ Details on the configuration settings are captured in the following files:
 - :zephyr_file:`snippets/nus-console/nus-console.conf`.
 - :zephyr_file:`snippets/nus-console/nus-console.overlay`.
 
-Segget RTT
+Segger RTT
 ==========
 
 To configure Segger RTT backend, add the following configurations to your build:


### PR DESCRIPTION
Fixes Segger typo in shell Segger RTT backend docs.