### PR TITLE
soc/nuvoton/npcx/npcx4: Proper ROM_START_OFFSET when using MCUboot

### DIFF
--- a/soc/nuvoton/npcx/npcx4/Kconfig.defconfig
+++ b/soc/nuvoton/npcx/npcx4/Kconfig.defconfig
@@ -8,6 +8,9 @@ if SOC_SERIES_NPCX4
 config NUM_IRQS
 	default 128
 
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 config CORTEX_M_SYSTICK
 	default !NPCX_ITIM_TIMER
 


### PR DESCRIPTION
This SoC has enough HW interrupts to require a 0x400 alignment, so the 0x200 default ROM_START_OFFSET used for MCUboot is not enough.