### PR TITLE
Simics environment variable usage

### DIFF
--- a/cmake/emu/simics.cmake
+++ b/cmake/emu/simics.cmake
@@ -11,7 +11,7 @@ find_program(
   )
 
 if(SIMICS STREQUAL SIMICS-NOTFOUND)
-  message(WARNING "Simics simulator environment is not found at SIMICS_PROJECT:'${SIMICS_PROJECT}'")
+  message(WARNING "Simics simulator environment is not found at SIMICS_PROJECT:'$ENV{SIMICS_PROJECT}'")
 else()
   message(STATUS "Found Simics: ${SIMICS}")
 

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -30,6 +30,9 @@ class Simulator:
         self.exec = data.get("exec")
 
     def is_runnable(self) -> bool:
+        if self.name == "simics":
+            return shutil.which(self.exec, path=os.environ.get("SIMICS_PROJECT")) is not None
+
         return not bool(self.exec) or bool(shutil.which(self.exec))
 
     def __str__(self):


### PR DESCRIPTION
`SIMICS_PROJECT` environment variable to being consistently used:
  - An error message about it didn't show its value;
  - twister not using it to find simics executable.