### PR TITLE
drivers: disk: nvme: fix build issues

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -202,6 +202,10 @@ New APIs and options
   * :c:func:`video_query_ctrl`
   * :c:func:`video_print_ctrl`
 
+* PCIe
+
+   * :kconfig:option:`CONFIG_NVME_PRP_PAGE_SIZE`
+
 New Boards
 **********
 

--- a/drivers/disk/nvme/Kconfig
+++ b/drivers/disk/nvme/Kconfig
@@ -52,6 +52,13 @@ config NVME_REQUEST_TIMEOUT
 	  This sets the waiting time for a request to succeed.
 	  Do not touch this unless you know what you are doing.
 
+config NVME_PRP_PAGE_SIZE
+	hex "NVMe PRP Page Size"
+	default MMU_PAGE_SIZE if MMU
+	default 0x1000
+	help
+	  Set the PRP page size. If MMU is enabled, this will default to the MMU page size.
+
 config NVME_PRP_LIST_AMOUNT
 	int "Number of allocated PRP list"
 	default 2

--- a/drivers/disk/nvme/nvme_cmd.c
+++ b/drivers/disk/nvme/nvme_cmd.c
@@ -576,13 +576,13 @@ static int compute_n_prp(uintptr_t addr, uint32_t size)
 
 	/* See Common Command Format, Data Pointer (DPTR) field */
 
-	n_prp = size / CONFIG_MMU_PAGE_SIZE;
+	n_prp = size / CONFIG_NVME_PRP_PAGE_SIZE;
 	if (n_prp == 0) {
 		n_prp = 1;
 	}
 
-	if (size != CONFIG_MMU_PAGE_SIZE) {
-		size = size % CONFIG_MMU_PAGE_SIZE;
+	if (size != CONFIG_NVME_PRP_PAGE_SIZE) {
+		size = size % CONFIG_NVME_PRP_PAGE_SIZE;
 	}
 
 	if (n_prp == 1) {

--- a/drivers/disk/nvme/nvme_cmd.c
+++ b/drivers/disk/nvme/nvme_cmd.c
@@ -555,9 +555,9 @@ static int nvme_cmd_qpair_fill_prp_list(struct nvme_cmd_qpair *qpair,
 
 	p_addr = (uintptr_t)request->payload;
 	request->cmd.dptr.prp1 =
-		(uint64_t)sys_cpu_to_le64(p_addr);
+		sys_cpu_to_le64((uint64_t)p_addr);
 	request->cmd.dptr.prp2 =
-		(uint64_t)sys_cpu_to_le64(&prp_list->prp);
+		sys_cpu_to_le64((uint64_t)(uintptr_t)&prp_list->prp);
 	p_addr = NVME_PRP_NEXT_PAGE(p_addr);
 
 	for (idx = 0; idx < n_prp; idx++) {
@@ -602,7 +602,7 @@ static int nvme_cmd_qpair_fill_dptr(struct nvme_cmd_qpair *qpair,
 	switch (request->type) {
 	case NVME_REQUEST_NULL:
 		break;
-	case NVME_REQUEST_VADDR:
+	case NVME_REQUEST_VADDR: {
 		int n_prp;
 
 		if (request->payload_size > qpair->ctrlr->max_xfer_size) {
@@ -614,7 +614,7 @@ static int nvme_cmd_qpair_fill_dptr(struct nvme_cmd_qpair *qpair,
 				      request->payload_size);
 		if (n_prp <= 2) {
 			request->cmd.dptr.prp1 =
-				(uint64_t)sys_cpu_to_le64(request->payload);
+				sys_cpu_to_le64((uint64_t)(uintptr_t)request->payload);
 			if (n_prp == 2) {
 				request->cmd.dptr.prp2 = (uint64_t)sys_cpu_to_le64(
 					NVME_PRP_NEXT_PAGE(
@@ -627,6 +627,7 @@ static int nvme_cmd_qpair_fill_dptr(struct nvme_cmd_qpair *qpair,
 		}
 
 		return nvme_cmd_qpair_fill_prp_list(qpair, request, n_prp);
+	}
 	default:
 		break;
 	}

--- a/drivers/disk/nvme/nvme_cmd.h
+++ b/drivers/disk/nvme/nvme_cmd.h
@@ -309,14 +309,14 @@ enum nvme_feature {
 #define CACHE_LINE_SIZE				CONFIG_DCACHE_LINE_SIZE
 #endif
 
-#define NVME_PBAO_MASK (CONFIG_MMU_PAGE_SIZE - 1)
+#define NVME_PBAO_MASK (CONFIG_NVME_PRP_PAGE_SIZE - 1)
 
 #define NVME_PRP_NEXT_PAGE(_addr)				\
-	((_addr & ~NVME_PBAO_MASK) + CONFIG_MMU_PAGE_SIZE)
+	((_addr & ~NVME_PBAO_MASK) + CONFIG_NVME_PRP_PAGE_SIZE)
 
 struct nvme_prp_list {
-	uintptr_t prp[CONFIG_MMU_PAGE_SIZE / sizeof(uintptr_t)]
-						__aligned(CONFIG_MMU_PAGE_SIZE);
+	uintptr_t prp[CONFIG_NVME_PRP_PAGE_SIZE / sizeof(uintptr_t)]
+						__aligned(CONFIG_NVME_PRP_PAGE_SIZE);
 	sys_dnode_t node;
 };
 


### PR DESCRIPTION
Some SoCs do not have MMUs. Create a new KConfig that `NVME_PRP_PAGE_SIZE`
that will define the PRP page size, and will default to `MMU_PAGE_SIZE` if
there is a MMU. Otherwise, it defaults to 0x1000.

There are warnings generated within NVMe. `prp` is a `void *` which
is 32bits wide on 32bit systems. This adds a cast to first cast it
to a `uintptr_t` and then casts it to a `uint64_t` to supress the
warning.
    
This also fix an issue where `int n_prp` is defined under a case
statement. This adds the { } around the block underneath it.