### PR TITLE
drivers: Update MCUX I2C RTIO driver with SDK changes

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -280,7 +280,11 @@ static void mcux_lpi2c_isr(const struct device *dev)
 	struct mcux_lpi2c_data *data = dev->data;
 	LPI2C_Type *base = (LPI2C_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
 
+#if CONFIG_HAS_MCUX_FLEXCOMM
+	LPI2C_MasterTransferHandleIRQ(LPI2C_GetInstance(base), &data->handle);
+#else
 	LPI2C_MasterTransferHandleIRQ(base, &data->handle);
+#endif
 }
 
 static int mcux_lpi2c_init(const struct device *dev)

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -350,6 +350,19 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 #define I2C_MCUX_LPI2C_SDA_INIT(n)
 #endif /* CONFIG_I2C_MCUX_LPI2C_BUS_RECOVERY */
 
+#define I2C_MCUX_LPI2C_MODULE_IRQ_CONNECT(n)				\
+	do {								\
+		IRQ_CONNECT(DT_INST_IRQN(n),				\
+			DT_INST_IRQ(n, priority),			\
+			mcux_lpi2c_isr,					\
+			DEVICE_DT_INST_GET(n), 0);			\
+		irq_enable(DT_INST_IRQN(n));				\
+	} while (false)
+
+#define I2C_MCUX_LPI2C_MODULE_IRQ(n)					\
+	IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0),				\
+		(I2C_MCUX_LPI2C_MODULE_IRQ_CONNECT(n)))
+
 #define I2C_MCUX_LPI2C_INIT(n)						\
 	PINCTRL_DT_INST_DEFINE(n);					\
 									\
@@ -386,12 +399,7 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 									\
 	static void mcux_lpi2c_config_func_##n(const struct device *dev)\
 	{								\
-		IRQ_CONNECT(DT_INST_IRQN(n),				\
-				DT_INST_IRQ(n, priority),		\
-				mcux_lpi2c_isr,				\
-				DEVICE_DT_INST_GET(n), 0);		\
-									\
-		irq_enable(DT_INST_IRQN(n));				\
+		I2C_MCUX_LPI2C_MODULE_IRQ(n);				\
 	}
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_MCUX_LPI2C_INIT)

--- a/drivers/i2c/i2c_mcux_lpi2c_rtio.c
+++ b/drivers/i2c/i2c_mcux_lpi2c_rtio.c
@@ -43,9 +43,6 @@ LOG_MODULE_REGISTER(mcux_lpi2c);
 
 struct mcux_lpi2c_config {
 	DEVICE_MMIO_NAMED_ROM(reg_base);
-#ifdef CONFIG_NXP_LP_FLEXCOMM
-	const struct device *parent_dev;
-#endif
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
@@ -335,15 +332,7 @@ static int mcux_lpi2c_init(const struct device *dev)
 		return error;
 	}
 
-#if CONFIG_NXP_LP_FLEXCOMM
-	/* When using LP Flexcomm driver, register the interrupt handler
-	 * so we receive notification from the LP Flexcomm interrupt handler.
-	 */
-	nxp_lp_flexcomm_setirqhandler(config->parent_dev, dev,
-				      LP_FLEXCOMM_PERIPH_LPI2C, mcux_lpi2c_isr);
-#else
 	config->irq_config_func(dev);
-#endif
 
 	i2c_rtio_init(data->ctx, dev);
 
@@ -377,21 +366,31 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 	IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0),				\
 		(I2C_MCUX_LPI2C_MODULE_IRQ_CONNECT(n)))
 
-#ifdef CONFIG_NXP_LP_FLEXCOMM
-#define PARENT_DEV(n)							\
-	.parent_dev = DEVICE_DT_GET(DT_INST_PARENT(n)),
-#else
-#define PARENT_DEV(n)
-#endif /* CONFIG_NXP_LP_FLEXCOMM */
+/* When using LP Flexcomm driver, register the interrupt handler
+ * so we receive notification from the LP Flexcomm interrupt handler.
+ */
+#define I2C_MCUX_LPI2C_LPFLEXCOMM_IRQ_FUNC(n)				\
+	nxp_lp_flexcomm_setirqhandler(DEVICE_DT_GET(DT_INST_PARENT(n)), \
+					DEVICE_DT_INST_GET(n),		\
+					LP_FLEXCOMM_PERIPH_LPI2C,	\
+					mcux_lpi2c_isr)
+
+#define I2C_MCUX_LPI2C_IRQ_SETUP_FUNC(n)				\
+	COND_CODE_1(DT_NODE_HAS_COMPAT(DT_INST_PARENT(n),		\
+					nxp_lp_flexcomm),		\
+		    (I2C_MCUX_LPI2C_LPFLEXCOMM_IRQ_FUNC(n)),		\
+		    (I2C_MCUX_LPI2C_MODULE_IRQ(n)))
 
 #define I2C_MCUX_LPI2C_INIT(n)						\
 	PINCTRL_DT_INST_DEFINE(n);					\
 									\
-	static void mcux_lpi2c_config_func_##n(const struct device *dev); \
+	static void mcux_lpi2c_config_func_##n(const struct device *dev)\
+	{								\
+		I2C_MCUX_LPI2C_IRQ_SETUP_FUNC(n);			\
+	}								\
 									\
 	static const struct mcux_lpi2c_config mcux_lpi2c_config_##n = {	\
 		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),	\
-		PARENT_DEV(n)						\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
 		.clock_subsys =						\
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
@@ -417,11 +416,6 @@ static DEVICE_API(i2c, mcux_lpi2c_driver_api) = {
 				&mcux_lpi2c_data_##n,			\
 				&mcux_lpi2c_config_##n, POST_KERNEL,	\
 				CONFIG_I2C_INIT_PRIORITY,		\
-				&mcux_lpi2c_driver_api);		\
-									\
-	static void mcux_lpi2c_config_func_##n(const struct device *dev)\
-	{								\
-		I2C_MCUX_LPI2C_MODULE_IRQ(n);				\
-	}
+				&mcux_lpi2c_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_MCUX_LPI2C_INIT)


### PR DESCRIPTION
### Description
Update the driver to account for variations in the SDK driver
when it uses the instance number instead of the base address.

Changes come from #70866 and #83704 applied to I2C RTIO.

Fixes #88319.

### Testing

Built for MCXN947 and tested I2C commands work.

```
west build -b frdm_mcxn947/mcxn947/cpu0 samples/subsys/shell/shell_module -- -DCONFIG_I2C=y -DCONFIG_I2C_SHELL=y -DCONFIG_I2C_RTIO=y
```

Output:
```
uart:~$ i2c scan lpi2c@
  lpi2c@b7800  lpi2c@94800  
uart:~$ i2c scan lpi2c@94800 
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- 53 -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: -- -- -- -- -- -- -- --                         
1 devices found on lpi2c@94800
uart:~$ 
```
