### PR TITLE
boards: ct: ctcc: remove unused peripherals

### DIFF
--- a/boards/ct/ctcc/ctcc_nrf9161-pinctrl.dtsi
+++ b/boards/ct/ctcc/ctcc_nrf9161-pinctrl.dtsi
@@ -25,28 +25,6 @@
 		};
 	};
 
-	uart1_default: uart1_default {
-		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 27)>,
-				<NRF_PSEL(UART_RTS, 0, 16)>;
-		};
-		group2 {
-			psels = <NRF_PSEL(UART_RX, 0, 26)>,
-				<NRF_PSEL(UART_CTS, 0, 17)>;
-			bias-pull-up;
-		};
-	};
-
-	uart1_sleep: uart1_sleep {
-		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 27)>,
-				<NRF_PSEL(UART_RX, 0, 26)>,
-				<NRF_PSEL(UART_RTS, 0, 16)>,
-				<NRF_PSEL(UART_CTS, 0, 17)>;
-			low-power-enable;
-		};
-	};
-
 	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 3)>,

--- a/boards/ct/ctcc/ctcc_nrf9161_common.dtsi
+++ b/boards/ct/ctcc/ctcc_nrf9161_common.dtsi
@@ -39,10 +39,6 @@
 	};
 };
 
-&adc {
-	status = "okay";
-};
-
 &gpiote {
 	status = "okay";
 };
@@ -56,14 +52,6 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_default>;
 	pinctrl-1 = <&uart0_sleep>;
-	pinctrl-names = "default", "sleep";
-};
-
-&uart1 {
-	status = "okay";
-	current-speed = <115200>;
-	pinctrl-0 = <&uart1_default>;
-	pinctrl-1 = <&uart1_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 


### PR DESCRIPTION
uart1 and adc are not physically routed to any pins in ctcc/nrf9161