### PR TITLE
drivers: sensors: lsm6dsv16x: Fix bug in decoder

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_decoder.h
@@ -16,7 +16,7 @@
  * This macro converts the Accelerometer full-scale range value (which should be a power of 2) to
  * an index value used by the decoder. Note: this index is not the same as the RAW register value.
  */
-#define LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX(x) (__builtin_clz(x) - 1)
+#define LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX(x) (__builtin_ctz(x) - 1)
 
 struct lsm6dsv16x_decoder_header {
 	uint64_t timestamp;


### PR DESCRIPTION
The lsm6dsv16x driver is using an incorrect value for the index into the acceleration range. This results in using the wrong range. The issue was found to be a bug in a MACRO in lsm6dsv16x_decoder.h that was used to find the index in the acceleration range. The MACRO was improperly counting zeros from the leading edge, instead of the trailing edge.