### PR TITLE
drivers: i3c: shell: fix the argv index for broadcast setwml ccc

### DIFF
--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -963,7 +963,7 @@ static int cmd_i3c_ccc_setmwl_bc(const struct shell *sh, size_t argc, char **arg
 		return -ENODEV;
 	}
 
-	mwl.len = strtol(argv[3], NULL, 16);
+	mwl.len = strtol(argv[2], NULL, 16);
 
 	ret = i3c_ccc_do_setmwl_all(dev, &mwl);
 	if (ret < 0) {


### PR DESCRIPTION
For the broadcast setwml ccc, the argument vector index of the input length is 2 instead of 3. This pr fixs this issue.