### PR TITLE
drivers: espi: npcx: ensure the host receives the value from eSPI VW

### DIFF
--- a/drivers/espi/Kconfig.npcx
+++ b/drivers/espi/Kconfig.npcx
@@ -60,6 +60,19 @@ config ESPI_NPCX_PERIPHERAL_DEBUG_PORT_80_RING_BUF_SIZE
 	  The size of the ring buffer in byte used by the Port80 ISR to store
 	  Postcodes from Host.
 
+config ESPI_NPCX_VWIRE_ENABLE_SEND_CHECK
+	bool "Check the value was read by host after wire bits changed"
+	help
+	  This option enables the function to check whether the host has read the value
+	  after the wire data changes.
+
+config ESPI_NPCX_WIRE_SEND_TIMEOUT_US
+	int "eSPI virtual wire send timeout count"
+	default 1000
+	help
+	  The times to check status after sending the eSPI virtual wire signal. The unit
+	  is microseconds (µs).
+
 config ESPI_TAF_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) ESPI TAF driver"
 	depends on SOC_SERIES_NPCX4

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -859,9 +859,25 @@ static int espi_npcx_send_vwire(const struct device *dev,
 	if (signal >= ESPI_VWIRE_SIGNAL_TARGET_GPIO_0) {
 		SET_FIELD(inst->VWGPSM[reg_idx], NPCX_VWEVSM_WIRE, val);
 		reg_val = inst->VWGPSM[reg_idx];
+
+		if (IS_ENABLED(CONFIG_ESPI_NPCX_VWIRE_ENABLE_SEND_CHECK)) {
+			if (!WAIT_FOR(!IS_BIT_SET(inst->VWGPSM[reg_idx], NPCX_VWEVSM_DIRTY),
+				      CONFIG_ESPI_NPCX_WIRE_SEND_TIMEOUT_US, NULL)) {
+				LOG_ERR("%s signal %d timeout", __func__, signal);
+				return -ETIMEDOUT;
+			}
+		}
 	} else {
 		SET_FIELD(inst->VWEVSM[reg_idx], NPCX_VWEVSM_WIRE, val);
 		reg_val = inst->VWEVSM[reg_idx];
+
+		if (IS_ENABLED(CONFIG_ESPI_NPCX_VWIRE_ENABLE_SEND_CHECK)) {
+			if (!WAIT_FOR(!IS_BIT_SET(inst->VWEVSM[reg_idx], NPCX_VWEVSM_DIRTY),
+				      CONFIG_ESPI_NPCX_WIRE_SEND_TIMEOUT_US, NULL)) {
+				LOG_ERR("%s signal %d timeout", __func__, signal);
+				return -ETIMEDOUT;
+			}
+		}
 	}
 
 	LOG_DBG("Send VW: %s%d 0x%08X", reg_name, reg_idx, reg_val);

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -727,6 +727,7 @@ struct espi_reg {
 #define NPCX_VWEVSM_INDEX                FIELD(8, 7)
 #define NPCX_VWEVSM_INDEX_EN             15
 #define NPCX_VWEVSM_BIT_VALID(n)         (4+n)
+#define NPCX_VWEVSM_DIRTY                16
 #define NPCX_VWEVSM_HW_WIRE              FIELD(24, 4)
 #define NPCX_VWGPSM_INDEX_EN             15
 #define NPCX_OOBCTL_OOB_FREE             0


### PR DESCRIPTION
Currently, the implementation of the eSPI virtual wire send function does not verify whether the host has received the data. Thus, this commit adds an option to check whether the host has read the value after the wire 3-0 bits have been updated. 