### PR TITLE
Bluetooth: Classic: HFP: Support ongoing calls before SLC established

### DIFF
--- a/include/zephyr/bluetooth/classic/hfp_ag.h
+++ b/include/zephyr/bluetooth/classic/hfp_ag.h
@@ -149,19 +149,23 @@ struct bt_hfp_ag_cb {
 
 	/** Get ongoing call information Callback
 	 *
-	 *  If this callback is provided it will be called whenever the response
-	 *  of the AT command `AT+CIND=?` from HF has been sent. It is used to get all
-	 *  ongoing calls one bye one from the upper layer.
-	 *  Then set the `Call`, `Call Setup`, and `Held Call` indicators and report the
-	 *  values int the response of AT command `AT+CIND?`. Then report all ongoing
-	 *  calls in the `+CLCC` response.
+	 *  If this callback is provided it will be called whenever the AT command `AT+CIND?` is
+	 *  received from HF has been sent.
+	 *  After the callback notified, the ongoing calls should be set via function
+	 *  `bt_hfp_ag_ongoing_calls()` within the timeout
+	 *  @kconfig{CONFIG_BT_HFP_AG_GET_ONGOING_CALL_TIMEOUT}.
 	 *
 	 *  @param ag HFP AG object.
-	 *  @param call Pointer to store the ongoing call information.
 	 *
-	 *  @return 0 in case of success and will get next one or negative value in case of error.
+	 *  @note The AG is in SLC establishment phase. The AG callback `connected()` is not
+	 *        notified at this time.
+	 *
+	 *  @return 0 in case of success. The response `+CIND` will be sent after the function
+	 *          `bt_hfp_ag_ongoing_calls()` called or after the time exceeds
+	 *          @kconfig{CONFIG_BT_HFP_AG_GET_ONGOING_CALL_TIMEOUT}. Or negative value in case
+	 *          of error. The response `+CIND` will be replied immediately.
 	 */
-	int (*get_ongoing_call)(struct bt_hfp_ag *ag, struct bt_hfp_ag_ongoing_call *call);
+	int (*get_ongoing_call)(struct bt_hfp_ag *ag);
 
 	/** HF memory dialing request Callback
 	 *
@@ -837,6 +841,19 @@ int bt_hfp_ag_service_availability(struct bt_hfp_ag *ag, bool available);
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_hfp_ag_hf_indicator(struct bt_hfp_ag *ag, enum hfp_ag_hf_indicators indicator, bool enable);
+
+/** @brief Set the ongoing calls
+ *
+ *  It is used to set the ongoing calls when AT command `AT+CIND?` is received.
+ *
+ *  @param ag HFP AG object.
+ *  @param calls Ongoing calls.
+ *  @param count Ongoing call count.
+ *
+ *  @return 0 in case of success or negative value in case of error.
+ */
+int bt_hfp_ag_ongoing_calls(struct bt_hfp_ag *ag, struct bt_hfp_ag_ongoing_call *calls,
+			    size_t count);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -419,6 +419,13 @@ config BT_HFP_AG_REJECT_CALL
 	help
 	  This option enables ability to reject a call for HFP AG
 
+config BT_HFP_AG_GET_ONGOING_CALL_TIMEOUT
+	int "Timeout after the get ongoing calls callback notified (milliseconds) [EXPERIMENTAL]"
+	default 10000
+	range 1000 10000
+	help
+	  This option sets the timeout after the get ongoing calls callback notified
+
 endif # BT_HFP_AG
 
 config BT_AVDTP

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -149,6 +149,7 @@ enum {
 	BT_HFP_AG_CALL_OPEN_SCO,      /* Open SCO */
 	BT_HFP_AG_CALL_OUTGOING_3WAY, /* Outgoing 3 way call */
 	BT_HFP_AG_CALL_INCOMING_3WAY, /* Incoming 3 way call */
+	BT_HFP_AG_CALL_ALERTING,      /* Pending for alerting */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_CALL_NUM_FLAGS,
@@ -234,6 +235,10 @@ struct bt_hfp_ag {
 
 	/* calls */
 	struct bt_hfp_ag_call calls[CONFIG_BT_HFP_AG_MAX_CALLS];
+
+	/* ongoing calls */
+	struct bt_hfp_ag_ongoing_call ongoing_calls[CONFIG_BT_HFP_AG_MAX_CALLS];
+	size_t ongoing_call_count;
 
 	/* last dialing number and type */
 	char last_number[CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN + 1];

--- a/subsys/bluetooth/host/classic/hfp_ag_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_ag_internal.h
@@ -136,6 +136,7 @@ enum {
 	BT_HFP_AG_CREATING_SCO,  /* SCO is creating */
 	BT_HFP_AG_VRE_ACTIVATE,  /* VRE is activated */
 	BT_HFP_AG_VRE_R2A,       /* HF is ready to accept audio */
+	BT_HGP_AG_ONGOING_CALLS, /* Waiting ongoing calls */
 
 	/* Total number of flags - must be at the end of the enum */
 	BT_HFP_AG_NUM_FLAGS,
@@ -239,6 +240,8 @@ struct bt_hfp_ag {
 	/* ongoing calls */
 	struct bt_hfp_ag_ongoing_call ongoing_calls[CONFIG_BT_HFP_AG_MAX_CALLS];
 	size_t ongoing_call_count;
+	/* ongoing calls work */
+	struct k_work_delayable ongoing_call_work;
 
 	/* last dialing number and type */
 	char last_number[CONFIG_BT_HFP_AG_PHONE_NUMBER_MAX_LEN + 1];

--- a/subsys/bluetooth/host/classic/hfp_internal.h
+++ b/subsys/bluetooth/host/classic/hfp_internal.h
@@ -136,6 +136,12 @@
 /* Call held by Response and Hold */
 #define BT_HFP_CLCC_STATUS_CALL_HELD_HOLD 6
 
+/* CLCC direction */
+/* CLCC direction: incoming */
+#define BT_HFP_CLCC_DIR_INCOMING 1
+/* CLCC direction: outgoing */
+#define BT_HFP_CLCC_DIR_OUTGOING 0
+
 /* BVRA Value */
 /* BVRA Deactivation */
 #define BT_HFP_BVRA_DEACTIVATION    0


### PR DESCRIPTION
* Bluetooth: Classic: HFP_AG: Support ongoing calls before SLC

Support the case that there are some calls existed before SLC established.

Add a callback to get the ongoing calls one by one from upper layer when the response of the AT command `AT+CIND=?` from HF has been sent.

And set the Call, Call Setup, and Held Call indicators and report the values int the response of AT command `AT+CIND?`. Then report all ongoing calls in the `+CLCC` response.

* Bluetooth: Classic: HFP_HF: Support ongoing calls before SLC

If the any value of Call, Call Setup, and Held Call indicators is not zero in the response of `AT+CIND?`, get all calls via `AT+CLCC`.

* Bluetooth: Classic: Shell: Add command `ongoing_calls`

Add shell command `ongoing_calls` to set the ongoing calls.

* Bluetooth: Classic: HGP_AG: change `get_ongoing_call()` to async mode

Change the callback `get_ongoing_call()` of the AG from synchronous to asynchronous mode. It will help to avoid the Bluetooth host stack be blocked in the context of callback `get_ongoing_call()`.

Add a function `bt_hfp_ag_ongoing_calls()` to set the ongoing calls and reply the AT command `AT+CIND?` after the callback `get_ongoing_call()` has been notified.

Add a delayable worker to avoid the AT command `AT+CIND?` never being replied. After the time exceeds @kconfig{CONFIG_BT_HFP_AG_GET_ONGOING_CALL_TIMEOUT}, the response of the AT command `AT+CIND?` will be replied.
