### PR TITLE
mgmt: hawkbit: deprecate HAWKBIT_DDI_NO_SECURITY

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -92,6 +92,10 @@ Deprecated APIs and options
 * ``xiao_esp32c6`` board target has been deprecated and renamed to
   ``xiao_esp32c6/esp32c6/hpcore``.
 
+* :kconfig:option:`CONFIG_HAWKBIT_DDI_NO_SECURITY` Kconfig option has been
+  deprecated, because support for anonymous authentication had been removed from the
+  hawkBit server in version 0.8.0.
+
 New APIs and options
 ====================
 

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -83,11 +83,18 @@ config HAWKBIT_DDI_TARGET_SECURITY
 	bool "Use target security token authentication"
 	help
 	  Use target security token authentication for the hawkBit DDI API.
+	  Here the security token is unique for each device and is generated
+	  during the device registration process. The device has to be registered
+	  in the hawkBit server before using this authentication mode.
 
 config HAWKBIT_DDI_GATEWAY_SECURITY
 	bool "Use gateway security token authentication"
 	help
 	  Use gateway security token authentication for the hawkBit DDI API.
+	  Here the security token is shared between all devices in the same
+	  tenant. The device can register itself in the hawkBit server on
+	  first connection to the server. The device does not need to be registered
+	  in the hawkBit server before using this authentication mode.
 
 endchoice
 

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -76,8 +76,11 @@ choice HAWKBIT_DDI_SECURITY
 
 config HAWKBIT_DDI_NO_SECURITY
 	bool "No authentication security"
+	select DEPRECATED
 	help
-	  No authentication security for the hawkBit DDI API.
+	  No authentication security for the hawkBit DDI API. Support for this
+	  had been removed from the hawkBit server in version 0.8.0. Use gateway
+	  security token authentication instead, if you want something similar.
 
 config HAWKBIT_DDI_TARGET_SECURITY
 	bool "Use target security token authentication"


### PR DESCRIPTION
anonymous/no authentication mode had been removed
from the last hawkBit server release, so mention it and
deprecate CONFIG_HAWKBIT_DDI_NO_SECURITY.

removed in hawkBit server: https://github.com/eclipse-hawkbit/hawkbit/pull/2285