### PR TITLE
tests: drivers: flash: common: Fixing the overlapping case

### DIFF
--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -462,8 +462,8 @@ ZTEST(flash_driver, test_flash_copy)
 
 	/* copy with overlapping ranges should fail */
 	test_flash_copy_inner(flash_dev, page_info.start_offset, flash_dev,
-			      page_info.start_offset + 32, page_info.size - 32, buf, sizeof(buf),
-			      -EINVAL);
+			      page_info.start_offset + (page_info.size / 4),
+			      page_info.size - (page_info.size / 4), buf, sizeof(buf), -EINVAL);
 }
 
 ZTEST_SUITE(flash_driver, NULL, NULL, flash_driver_before, NULL, NULL);


### PR DESCRIPTION
For the flash with the block size equal to or smaller than 64 bytes, using a specific "32" bytes for adding for destination_offset and "32" bytes for subtracting the size that needs to copy is not correct.

As a solution, I will add one-fourth of a block size for the destination_offset and modify the size that needs to copy to [block size + one-fourth of a block size].