### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: c8470fb145f8aff92696d05396fb77c3b8068b32
+      revision: 20f98e0a975c24864872e0df5701eb1082e9c957
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  20f98e0a975c24864872e0df5701eb1082e9c957

  - 20f98e0a Updates for 2.2.0-rc1 release
  - 7a33bcaa boot: bootutil: loader: Add include for flash function
  - 8a9627d9 boot/zephyr/boards: nrf54h20dk 'iron' board configuration
  - de7a9dc5 zephyr: Disable SPI_NOR by default for nrf7002dk/nrf5340/cpuapp
  - 5aed4245 swap_move: correct appsize calcs and warning
  - 454c033f bootutil: swap-scratch: Fix conflicts after support of devices w/o erase
  - 572b8fb2 boot: zephyr: flash_map_extended: Add pointless workaround for clang
  - 091af82e boot/zephyr: nrf54h20dk adaptations
  - ed434f33 boot: bootutil: Fix clash of STRUCT_PACKED definition
  - 33ad4973 boot: zephyr: add support for mcx_n9xx_evk
  - 881608eb boot/zephyr: Use MCUBOOT_RAM_LOAD instead of CONFIG_BOOT_RAM_LOAD
  - 993c2ff8 boot/bootutil/ram_load: Add flash area pointer to bootloader state
  - 8b7c7cc9 zephyr: flash map: fix comparison signedness
  - b92d4dd7 boot: zephyr: Only supply MBEDTLS config file path if set
  - 9fa0c6b5 zephyr: Fix translation of PSA Kconfig to MCUboot config
  - 2d681da4 bootutil: Fix ed25519 pure signature verification

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.