### PR TITLE
kernel: workq: introduce work timeout:

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4219,6 +4219,16 @@ struct k_work_queue_config {
 	 * essential thread.
 	 */
 	bool essential;
+
+	/** Controls whether work queue monitors work timeouts.
+	 *
+	 * If non-zero, and CONFIG_WORKQUEUE_WORK_TIMEOUT is enabled,
+	 * the work queue will monitor the duration of each work item.
+	 * If the work item handler takes longer than the specified
+	 * time to execute, the work queue thread will be aborted, and
+	 * an error will be logged if CONFIG_LOG is enabled.
+	 */
+	uint32_t work_timeout_ms;
 };
 
 /** @brief A structure used to hold work until it can be processed. */
@@ -4246,6 +4256,12 @@ struct k_work_q {
 
 	/* Flags describing queue state. */
 	uint32_t flags;
+
+#if defined(CONFIG_WORKQUEUE_WORK_TIMEOUT)
+	struct _timeout work_timeout_record;
+	struct k_work *work;
+	k_timeout_t work_timeout;
+#endif /* defined(CONFIG_WORKQUEUE_WORK_TIMEOUT) */
 };
 
 /* Provide the implementation for inline functions declared above */

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -574,6 +574,14 @@ endmenu
 
 rsource "Kconfig.obj_core"
 
+config WORKQUEUE_WORK_TIMEOUT
+	bool "Support workqueue work timeout monitoring"
+	help
+	  If enabled, the workqueue will monitor the duration of each work item.
+	  If the work item handler takes longer than the specified time to
+	  execute, the work queue thread will be aborted, and an error will be
+	  logged.
+
 menu "System Work Queue Options"
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int "System workqueue stack size"
@@ -599,6 +607,14 @@ config SYSTEM_WORKQUEUE_NO_YIELD
 	  this yield, which may be useful if the work queue thread is
 	  cooperative and a sequence of work items is expected to complete
 	  without yielding.
+
+config SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS
+	int "Select system work queue work timeout in milliseconds"
+	default 5000 if ASSERT
+	default 0
+	help
+	  Set to 0 to disable work timeout for system workqueue. Option
+	  has no effect if WORKQUEUE_WORK_TIMEOUT is not enabled.
 
 endmenu
 

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -25,6 +25,7 @@ static int k_sys_work_q_init(void)
 		.name = "sysworkq",
 		.no_yield = IS_ENABLED(CONFIG_SYSTEM_WORKQUEUE_NO_YIELD),
 		.essential = true,
+		.work_timeout_ms = CONFIG_SYSTEM_WORKQUEUE_WORK_TIMEOUT_MS,
 	};
 
 	k_work_queue_start(&k_sys_work_q,

--- a/tests/kernel/workq/work_queue/src/work_timeout.c
+++ b/tests/kernel/workq/work_queue/src/work_timeout.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#define TEST_WORK_TIMEOUT_MS     100
+#define TEST_WORK_DURATION_MS    (TEST_WORK_TIMEOUT_MS / 2)
+#define TEST_WORK_DELAY          K_MSEC(TEST_WORK_DURATION_MS * 6)
+#define TEST_WORK_BLOCKING_DELAY K_MSEC(TEST_WORK_TIMEOUT_MS * 2)
+
+static struct k_work_q test_workq;
+static K_KERNEL_STACK_DEFINE(test_workq_stack, CONFIG_MAIN_STACK_SIZE);
+
+static void test_work_handler(struct k_work *work)
+{
+	k_msleep(TEST_WORK_DURATION_MS);
+}
+
+static K_WORK_DEFINE(test_work0, test_work_handler);
+static K_WORK_DEFINE(test_work1, test_work_handler);
+static K_WORK_DEFINE(test_work2, test_work_handler);
+static K_WORK_DEFINE(test_work3, test_work_handler);
+
+static void test_work_handler_blocking(struct k_work *work)
+{
+	k_sleep(K_FOREVER);
+}
+
+static K_WORK_DEFINE(test_work_blocking, test_work_handler_blocking);
+
+static void *test_setup(void)
+{
+	const struct k_work_queue_config config = {
+		.name = "sysworkq",
+		.no_yield = false,
+		.essential = false,
+		.work_timeout_ms = TEST_WORK_TIMEOUT_MS,
+	};
+
+	k_work_queue_start(&test_workq,
+			   test_workq_stack,
+			   K_KERNEL_STACK_SIZEOF(test_workq_stack),
+			   0,
+			   &config);
+
+	return NULL;
+}
+
+ZTEST_SUITE(workqueue_work_timeout, NULL, test_setup, NULL, NULL, NULL);
+
+ZTEST(workqueue_work_timeout, test_work)
+{
+	int ret;
+
+	/* Submit multiple items which take less time than TEST_WORK_TIMEOUT_MS each */
+	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work0), 1);
+	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work1), 1);
+	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work2), 1);
+	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work3), 1);
+
+	/*
+	 * Submitted items takes longer than TEST_WORK_TIMEOUT_MS, but each item takes
+	 * less time than TEST_WORK_DELAY so workqueue thread will not be aborted.
+	 */
+	zassert_equal(k_thread_join(&test_workq.thread, TEST_WORK_DELAY), -EAGAIN);
+
+	/* Submit single item which takes longer than TEST_WORK_TIMEOUT_MS */
+	zassert_equal(k_work_submit_to_queue(&test_workq, &test_work_blocking), 1);
+
+	/*
+	 * Submitted item shall cause the work to time out and the workqueue thread be
+	 * aborted if CONFIG_WORKQUEUE_WORK_TIMEOUT is enabled.
+	 */
+	ret = k_thread_join(&test_workq.thread, TEST_WORK_BLOCKING_DELAY);
+	if (IS_ENABLED(CONFIG_WORKQUEUE_WORK_TIMEOUT)) {
+		zassert_equal(ret, 0);
+	} else {
+		zassert_equal(ret, -EAGAIN);
+	}
+}

--- a/tests/kernel/workq/work_queue/testcase.yaml
+++ b/tests/kernel/workq/work_queue/testcase.yaml
@@ -4,3 +4,10 @@ tests:
     tags:
       - kernel
       - workqueue
+  kernel.workqueue.work_timeout:
+    min_flash: 34
+    tags:
+      - kernel
+      - workqueue
+    extra_configs:
+      - CONFIG_WORKQUEUE_WORK_TIMEOUT=y


### PR DESCRIPTION
Introduce work timeout, which is an optional workqueue configuration which enables monitoring for work items which take longer than expected. This could be due to long running or deadlocked handlers.

This is a far more permissive alternative to #87522. It allows blocking items, as long as they don't take longer than specified. Feature works on a per workqueue basis. If the workqueue is blocked, an ERR log will be printed and the work queue thread will be aborted.

Example output from test suite
```
[00:00:01.010,000] <wrn> os: queue sysworkq blocked by work 0x805a0e0 with handler 0x80494a6
```

if the aborted thread is the essential system workqueue thread, kernel explodes.
