### PR TITLE
soc: stm32: common: wkup_pins: fix log output

### DIFF
--- a/soc/st/stm32/common/stm32_wkup_pins.c
+++ b/soc/st/stm32/common/stm32_wkup_pins.c
@@ -275,9 +275,8 @@ int stm32_pwr_wkup_pin_cfg_gpio(const struct gpio_dt_spec *gpio)
 	}
 
 	if (!found_gpio) {
-		LOG_DBG("Couldn't find a wake-up event corresponding to GPIO %s pin %d\n",
+		LOG_DBG("Couldn't find a wake-up event corresponding to GPIO %s pin %d",
 			gpio->port->name, gpio->pin);
-		LOG_DBG("=> It cannot be used as a wake-up source\n");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Two small fixes in STM32 wake-up pin configuration.

The relevant line of code where this leads to a bug is below. Bit-wise `&` with `0` is always `false`.

https://github.com/zephyrproject-rtos/zephyr/blob/6061deba555d148786ca2fd8193df7d6d6e1d0fc/soc/st/stm32/common/stm32_wkup_pins.c#L228