### PR TITLE
tests: Bluetooth: Tester: Fix bad check for valid RX

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.c
@@ -252,7 +252,7 @@ static void stream_recv(struct bt_bap_stream *stream,
 		LOG_DBG("Incoming audio on stream %p len %u flags 0x%02X seq_num %u and ts %u",
 			stream, buf->len, info->flags, info->seq_num, info->ts);
 
-		if ((info->flags & BT_ISO_FLAGS_VALID) == 0) {
+		if ((info->flags & BT_ISO_FLAGS_VALID) != 0) {
 			b_stream->already_sent = true;
 			broadcaster = &remote_broadcast_sources[b_stream->source_id];
 			send_bis_stream_received_ev(&broadcaster->address,

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -715,7 +715,7 @@ static void stream_recv(struct bt_bap_stream *stream,
 		LOG_DBG("Incoming audio on stream %p len %u flags 0x%02X seq_num %u and ts %u",
 			stream, buf->len, info->flags, info->seq_num, info->ts);
 
-		if ((info->flags & BT_ISO_FLAGS_VALID) == 0) {
+		if ((info->flags & BT_ISO_FLAGS_VALID) != 0) {
 			u_stream->already_sent = true;
 			send_stream_received_ev(stream->conn, stream->ep, buf->len, buf->data);
 		}


### PR DESCRIPTION
The check was incorrect, and only reported invalid ISO packages instead of valid.