### PR TITLE
task_wdt: do not try to start timer with INT64_MAX timeout

### DIFF
--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -77,9 +77,14 @@ static void schedule_next_timeout(int64_t current_ticks)
 		}
 	}
 
-	/* update task wdt kernel timer */
-	k_timer_user_data_set(&timer, (void *)next_channel_id);
-	k_timer_start(&timer, K_TIMEOUT_ABS_TICKS(next_timeout), K_FOREVER);
+	if (!IS_ENABLED(CONFIG_TASK_WDT_HW_FALLBACK) &&
+		next_timeout == INT64_MAX) {
+		k_timer_stop(&timer);
+	} else {
+		/* update task wdt kernel timer */
+		k_timer_user_data_set(&timer, (void *)next_channel_id);
+		k_timer_start(&timer, K_TIMEOUT_ABS_TICKS(next_timeout), K_FOREVER);
+	}
 
 #ifdef CONFIG_TASK_WDT_HW_FALLBACK
 	if (hw_wdt_started) {


### PR DESCRIPTION
When initializing or scheduling next timeout, the task_wdt tries to set timeout to `INT64_MAX` when `CONFIG_TASK_WDT_HW_FALLBACK` is not enabled. That causes ubsan to report runtime failure. For instance:

```
zephyr/subsys/task_wdt/task_wdt.c:79:24: runtime error: signed integer overflow: -2 - 9223372036854775807 cannot be represented in type 'long long int'
zephyr/kernel/timer.c:169:6: runtime error: signed integer overflow: -2 - 9223372036854775807 cannot be represented in type 'long long int'
zephyr/kernel/timeout.c:117:8: runtime error: signed integer overflow: -2 - 9223372036854775807 cannot be represented in type 'long long int'
```
Fix this by stopping the timer if there's not timeout. `k_timer_stop` is no-op when the timer is running.