### PR TITLE
net: openthread: Fix ignored return values in OT utils

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -158,11 +158,6 @@ static void reset_pending_event(enum pending_events event)
 	atomic_clear_bit(pending_events, event);
 }
 
-static inline void clear_pending_events(void)
-{
-	atomic_clear(pending_events);
-}
-
 void energy_detected(const struct device *dev, int16_t max_ed)
 {
 	if (dev == radio_dev) {

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -14,6 +14,7 @@ LOG_MODULE_DECLARE(net_l2_openthread, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #include <openthread/ip6.h>
 #include <openthread/thread.h>
 
+#include "net_private.h"
 #include "openthread_utils.h"
 
 #define ALOC16_MASK 0xfc
@@ -167,6 +168,7 @@ void add_ipv6_addr_to_ot(struct openthread_context *context,
 	struct otNetifAddress addr = { 0 };
 	struct net_if_ipv6 *ipv6;
 	struct net_if_addr *if_addr = NULL;
+	otError error;
 	int i;
 
 	/* IPv6 struct should've already been allocated when we get an
@@ -214,14 +216,14 @@ void add_ipv6_addr_to_ot(struct openthread_context *context,
 	}
 
 	openthread_api_mutex_lock(context);
-	otIp6AddUnicastAddress(context->instance, &addr);
+	error = otIp6AddUnicastAddress(context->instance, &addr);
 	openthread_api_mutex_unlock(context);
 
-	if (CONFIG_OPENTHREAD_L2_LOG_LEVEL == LOG_LEVEL_DBG) {
-		char buf[NET_IPV6_ADDR_LEN];
-
-		NET_DBG("Added %s",
-			net_addr_ntop(AF_INET6, &addr.mAddress, buf, sizeof(buf)));
+	if (error != OT_ERROR_NONE) {
+		NET_ERR("Failed to add IPv6 unicast address %s [%d]",
+			net_sprint_ipv6_addr(addr6), error);
+	} else {
+		NET_DBG("Added %s", net_sprint_ipv6_addr(addr6));
 	}
 }
 
@@ -229,18 +231,19 @@ void add_ipv6_maddr_to_ot(struct openthread_context *context,
 			  const struct in6_addr *addr6)
 {
 	struct otIp6Address addr;
+	otError error;
 
 	memcpy(&addr, addr6, sizeof(addr));
 
 	openthread_api_mutex_lock(context);
-	otIp6SubscribeMulticastAddress(context->instance, &addr);
+	error = otIp6SubscribeMulticastAddress(context->instance, &addr);
 	openthread_api_mutex_unlock(context);
 
-	if (CONFIG_OPENTHREAD_L2_LOG_LEVEL == LOG_LEVEL_DBG) {
-		char buf[NET_IPV6_ADDR_LEN];
-
-		NET_DBG("Added multicast %s",
-			net_addr_ntop(AF_INET6, &addr, buf, sizeof(buf)));
+	if (error != OT_ERROR_NONE) {
+		NET_ERR("Failed to add IPv6 multicast address %s [%d]",
+			net_sprint_ipv6_addr(addr6), error);
+	} else {
+		NET_DBG("Added %s", net_sprint_ipv6_addr(addr6));
 	}
 }
 


### PR DESCRIPTION
Do not ignore return values of OT functions registering IPv6 addresses. As this is called from the net_mgmt callback context, which returns void, there's not much that can be done, other than logging the error.

To simplify the logging code and avoid the need to use extra buffer, use net_sprint_ipv6_addr() networking utility function within the log message to convert binary address to string.