### PR TITLE
bluetooth: sdp: fix the corner cases for the sdp discover

### DIFF
--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -582,7 +582,7 @@ struct bt_sdp_discover_params {
  */
 
 int bt_sdp_discover(struct bt_conn *conn,
-		    const struct bt_sdp_discover_params *params);
+		    struct bt_sdp_discover_params *params);
 
 /** @brief Release waiting SDP discovery request.
  *

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -2221,6 +2221,14 @@ static void sdp_client_disconnected(struct bt_l2cap_chan *chan)
 
 	LOG_DBG("session %p chan %p disconnected", session, chan);
 
+	/* callback all the sdp reqs */
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->reqs, param, tmp, _node) {
+		session->param = param;
+		sdp_client_notify_result(session, UUID_NOT_RESOLVED);
+		/* Remove already callbacked UUID node */
+		sys_slist_find_and_remove(&session->reqs, &param->_node);
+	}
+
 	if (session->rec_buf) {
 		net_buf_unref(session->rec_buf);
 	}

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -80,8 +80,19 @@ NET_BUF_POOL_FIXED_DEFINE(sdp_pool, CONFIG_BT_MAX_CONN, BT_L2CAP_BUF_SIZE(SDP_MT
 
 #define SDP_CLIENT_MTU 64
 
+enum __packed sdp_client_state {
+	SDP_CLIENT_RELEASED,
+	SDP_CLIENT_CONNECTING,
+	SDP_CLIENT_CONNECTED,
+	SDP_CLIENT_DISCONNECTING,
+};
+
 struct bt_sdp_client {
+	/* semaphore for lock/unlock */
+	struct k_sem                         sem_lock;
 	struct bt_l2cap_br_chan              chan;
+	/* list of waiting to create sdp connection again */
+	sys_slist_t                          reqs_next;
 	/* list of waiting to be resolved UUID params */
 	sys_slist_t                          reqs;
 	/* required SDP transaction ID */
@@ -96,6 +107,8 @@ struct bt_sdp_client {
 	uint32_t                             total_len;
 	/* Received data length */
 	uint32_t                             recv_len;
+	/* client state */
+	enum sdp_client_state                state;
 };
 
 static struct bt_sdp_client bt_sdp_client_pool[CONFIG_BT_MAX_CONN];
@@ -150,6 +163,8 @@ typedef uint8_t (*bt_sdp_attr_func_t)(struct bt_sdp_attribute *attr,
  */
 typedef uint8_t (*bt_sdp_svc_func_t)(struct bt_sdp_record *rec,
 				  void *user_data);
+
+static int sdp_client_new_session(struct bt_conn *conn, struct bt_sdp_client *session);
 
 /* @brief Callback for SDP connection
  *
@@ -1450,6 +1465,11 @@ void bt_sdp_init(void)
 	if (res) {
 		LOG_ERR("L2CAP server registration failed with error %d", res);
 	}
+
+	ARRAY_FOR_EACH(bt_sdp_client_pool, i) {
+		/* Locking semaphore initialized to 1 (unlocked) */
+		k_sem_init(&bt_sdp_client_pool[i].sem_lock, 1, 1);
+	}
 }
 
 int bt_sdp_register_service(struct bt_sdp_record *service)
@@ -1684,13 +1704,17 @@ static void sdp_client_params_iterator(struct bt_sdp_client *session)
 		/* Clear received length */
 		session->recv_len = 0;
 
+		k_sem_take(&session->sem_lock, K_FOREVER);
 		/* Check if there's valid next UUID */
 		if (!sys_slist_is_empty(&session->reqs)) {
+			k_sem_give(&session->sem_lock);
 			sdp_client_discover(session);
 			return;
 		}
 
 		/* No UUID items, disconnect channel */
+		session->state = SDP_CLIENT_DISCONNECTING;
+		k_sem_give(&session->sem_lock);
 		bt_l2cap_chan_disconnect(chan);
 		break;
 	}
@@ -1873,6 +1897,7 @@ static int sdp_client_discover(struct bt_sdp_client *session)
 	 * the context is in a middle of partial SDP PDU responses and cached
 	 * value from context can be used.
 	 */
+	k_sem_take(&session->sem_lock, K_FOREVER);
 	if (!session->param) {
 		param = GET_PARAM(sys_slist_peek_head(&session->reqs));
 	} else {
@@ -1882,10 +1907,13 @@ static int sdp_client_discover(struct bt_sdp_client *session)
 	if (!param) {
 		struct bt_l2cap_chan *chan = &session->chan.chan;
 
+		session->state = SDP_CLIENT_DISCONNECTING;
+		k_sem_give(&session->sem_lock);
 		LOG_WRN("No more request, disconnect channel");
 		/* No UUID items, disconnect channel */
 		return bt_l2cap_chan_disconnect(chan);
 	}
+	k_sem_give(&session->sem_lock);
 
 	switch (param->type) {
 	case BT_SDP_DISCOVER_SERVICE_SEARCH:
@@ -2206,20 +2234,64 @@ static void sdp_client_connected(struct bt_l2cap_chan *chan)
 
 	LOG_DBG("session %p chan %p connected", session, chan);
 
+	k_sem_take(&session->sem_lock, K_FOREVER);
 	session->rec_buf = chan->ops->alloc_buf(chan);
 	if (!session->rec_buf) {
+		session->state = SDP_CLIENT_DISCONNECTING;
+		k_sem_give(&session->sem_lock);
 		bt_l2cap_chan_disconnect(chan);
 		return;
 	}
+	k_sem_give(&session->sem_lock);
 
 	sdp_client_discover(session);
 }
 
+static void sdp_client_clean_after_disconnect(struct bt_sdp_client *session)
+{
+	/*
+	 * keep the follow fields:
+	 * sem_lock - it is always valid to protect the session, never clean it after bt_sdp_init.
+	 * state - the session's state.
+	 * chan - it is still used before released callback.
+	 * reqs_next - the pending reqs in the disconnecting phase.
+	 */
+	sys_slist_init(&session->reqs);
+	session->tid = 0U;
+	session->param = NULL;
+	memset(&session->cstate, 0, sizeof(session->cstate));
+	if (session->rec_buf) {
+		net_buf_unref(session->rec_buf);
+		session->rec_buf = NULL;
+	}
+	session->total_len = 0U;
+	session->recv_len = 0U;
+}
+
+static void sdp_client_clean_after_release(struct bt_sdp_client *session)
+{
+	/*
+	 * keep the follow fields:
+	 * sem_lock - it is always valid to protect the session, never clean it after bt_sdp_init.
+	 * chan - it is maintained by l2cap layer.
+	 */
+	session->state = SDP_CLIENT_RELEASED;
+	sys_slist_init(&session->reqs_next);
+	sdp_client_clean_after_disconnect(session);
+}
+
 static void sdp_client_disconnected(struct bt_l2cap_chan *chan)
 {
+	struct bt_sdp_discover_params *param, *tmp;
+
 	struct bt_sdp_client *session = SDP_CLIENT_CHAN(chan);
 
 	LOG_DBG("session %p chan %p disconnected", session, chan);
+
+	/* The disconnecting may be triggered by acl disconnection or failed sdp connecting */
+	k_sem_take(&session->sem_lock, K_FOREVER);
+	session->state = SDP_CLIENT_DISCONNECTING;
+	k_sem_give(&session->sem_lock);
 
 	/* callback all the sdp reqs */
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->reqs, param, tmp, _node) {
@@ -2231,91 +2303,132 @@ static void sdp_client_disconnected(struct bt_l2cap_chan *chan)
 
 	if (session->rec_buf) {
 		net_buf_unref(session->rec_buf);
+		session->rec_buf = NULL;
 	}
 
-	/*
-	 * Reset session excluding L2CAP channel member. Let's the channel
-	 * resets autonomous.
-	 */
-	(void)memset(&session->reqs, 0,
-		     sizeof(*session) - sizeof(session->chan));
+	sdp_client_clean_after_disconnect(session);
+}
+
+void sdp_client_released(struct bt_l2cap_chan *chan)
+{
+	struct bt_sdp_client *session = SDP_CLIENT_CHAN(chan);
+	struct bt_sdp_discover_params *param, *tmp;
+	struct bt_conn *conn;
+	sys_slist_t cb_reqs;
+	int err;
+
+	k_sem_take(&session->sem_lock, K_FOREVER);
+	if (!sys_slist_is_empty(&session->reqs_next)) {
+		/* put the reqs_next to reqs */
+		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->reqs_next, param, tmp, _node) {
+			sys_slist_append(&session->reqs, (sys_snode_t *)&param->_node);
+			/* Remove already proccessed node */
+			sys_slist_remove(&session->reqs_next, NULL, &param->_node);
+		}
+
+		conn = bt_conn_lookup_index(ARRAY_INDEX(bt_sdp_client_pool, session));
+		err = sdp_client_new_session(conn, session);
+
+		if (err) {
+			sys_slist_init(&cb_reqs);
+			SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&session->reqs, param, tmp, _node) {
+				sys_slist_append(&cb_reqs, (sys_snode_t *)&param->_node);
+			}
+
+			sdp_client_clean_after_release(session);
+		}
+		k_sem_give(&session->sem_lock);
+
+		if (err) {
+			struct bt_sdp_client_result result;
+
+			result.resp_buf = NULL;
+			result.next_record_hint = false;
+
+			SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&cb_reqs, param, tmp, _node) {
+				param->func(conn, &result, param);
+			}
+		}
+		bt_conn_unref(conn);
+	} else {
+		sdp_client_clean_after_release(session);
+		k_sem_give(&session->sem_lock);
+	}
 }
 
 static const struct bt_l2cap_chan_ops sdp_client_chan_ops = {
 		.connected = sdp_client_connected,
 		.disconnected = sdp_client_disconnected,
+		.released = sdp_client_released,
 		.recv = sdp_client_receive,
 		.alloc_buf = sdp_client_alloc_buf,
 };
 
-static struct bt_sdp_client *sdp_client_new_session(struct bt_conn *conn)
+static int sdp_client_new_session(struct bt_conn *conn, struct bt_sdp_client *session)
 {
-	int i;
+	int err;
 
-	for (i = 0; i < ARRAY_SIZE(bt_sdp_client_pool); i++) {
-		struct bt_sdp_client *session = &bt_sdp_client_pool[i];
-		int err;
+	session->chan.chan.ops = &sdp_client_chan_ops;
+	session->chan.chan.conn = conn;
+	session->chan.rx.mtu = SDP_CLIENT_MTU;
 
-		if (session->chan.chan.conn) {
-			continue;
-		}
-
-		sys_slist_init(&session->reqs);
-
-		session->chan.chan.ops = &sdp_client_chan_ops;
-		session->chan.chan.conn = conn;
-		session->chan.rx.mtu = SDP_CLIENT_MTU;
-
-		err = sdp_client_chan_connect(session);
-		if (err) {
-			(void)memset(session, 0, sizeof(*session));
-			LOG_ERR("Cannot connect %d", err);
-			return NULL;
-		}
-
-		return session;
+	err = sdp_client_chan_connect(session);
+	if (err) {
+		LOG_ERR("Cannot connect %d", err);
+		return err;
 	}
 
-	LOG_ERR("No available SDP client context");
-
-	return NULL;
+	session->state = SDP_CLIENT_CONNECTING;
+	return err;
 }
 
-static struct bt_sdp_client *sdp_client_get_session(struct bt_conn *conn)
+static int sdp_client_discovery_start(struct bt_conn *conn,
+				      struct bt_sdp_discover_params *params)
 {
-	int i;
+	int err;
+	struct bt_sdp_client *session;
 
-	for (i = 0; i < ARRAY_SIZE(bt_sdp_client_pool); i++) {
-		if (bt_sdp_client_pool[i].chan.chan.conn == conn) {
-			return &bt_sdp_client_pool[i];
-		}
+	session = &bt_sdp_client_pool[bt_conn_index(conn)];
+	k_sem_take(&session->sem_lock, K_FOREVER);
+	if (session->state == SDP_CLIENT_CONNECTING ||
+	    session->state == SDP_CLIENT_CONNECTED) {
+		sys_slist_append(&session->reqs, (sys_snode_t *)&params->_node);
+		k_sem_give(&session->sem_lock);
+		return 0;
+	}
+
+	/* put in `reqs_next` for next round after disconnected */
+	if (session->state == SDP_CLIENT_DISCONNECTING) {
+		sys_slist_append(&session->reqs_next, (sys_snode_t *)&params->_node);
+		k_sem_give(&session->sem_lock);
+		return 0;
 	}
 
 	/*
 	 * Try to allocate session context since not found in pool and attempt
 	 * connect to remote SDP endpoint.
 	 */
-	return sdp_client_new_session(conn);
+	sys_slist_init(&session->reqs);
+	sys_slist_init(&session->reqs_next);
+	sys_slist_append(&session->reqs, (sys_snode_t *)&params->_node);
+	err = sdp_client_new_session(conn, session);
+	if (err) {
+		sdp_client_clean_after_release(session);
+	}
+	k_sem_give(&session->sem_lock);
+
+	return err;
 }
 
 int bt_sdp_discover(struct bt_conn *conn,
 		    const struct bt_sdp_discover_params *params)
 {
-	struct bt_sdp_client *session;
-
 	if (!params || !params->uuid || !params->func || !params->pool) {
 		LOG_WRN("Invalid user params");
 		return -EINVAL;
 	}
 
-	session = sdp_client_get_session(conn);
-	if (!session) {
-		return -ENOMEM;
-	}
-
-	sys_slist_append(&session->reqs, (sys_snode_t *)&params->_node);
-
-	return 0;
+	return sdp_client_discovery_start(conn, params);
 }
 
 /* Helper getting length of data determined by DTD for integers */


### PR DESCRIPTION
1. bt_sdp_discover may be called in two tasks at the same time: (1) If the 2 calls are for 2 acl conns,
the same session may be new allocated to two acl conns without protection. (2) If the 2 calls are for the same acl conn, the same session should be used.
2. fix that bt_sdp_discover may use one session that is disconnecting.
3. If the sdp l2cap connecting fail, the pending reqs need callback.