### PR TITLE
drivers: dma: remove '&' when assigning `dma_xxx_init`

### DIFF
--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -105,7 +105,7 @@ static DEVICE_API(dma, dw_dma_driver_api) = {
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
-			    &dw_dma_init,				\
+			    dw_dma_init,				\
 			    NULL,					\
 			    &dw_dma##inst##_data,			\
 			    &dw_dma##inst##_config, POST_KERNEL,	\

--- a/drivers/dma/dma_dw_axi.c
+++ b/drivers/dma/dma_dw_axi.c
@@ -897,7 +897,7 @@ static DEVICE_API(dma, dma_dw_axi_driver_api) = {
 	};										\
 											\
 	DEVICE_DT_INST_DEFINE(inst,							\
-				&dma_dw_axi_init,					\
+				dma_dw_axi_init,					\
 				NULL,							\
 				&dma_dw_axi_data_##inst,				\
 				&dma_dw_axi_config_##inst, POST_KERNEL,			\

--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -702,7 +702,7 @@ static void *irq_handlers[] = {
 			},                                                                         \
 	};                                                                                         \
 												   \
-	DEVICE_DT_INST_DEFINE(idx, &dma_esp32_init, NULL, &dma_data_##idx, &dma_config_##idx,      \
+	DEVICE_DT_INST_DEFINE(idx, dma_esp32_init, NULL, &dma_data_##idx, &dma_config_##idx,       \
 			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY, &dma_esp32_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DMA_ESP32_INIT)

--- a/drivers/dma/dma_gd32.c
+++ b/drivers/dma/dma_gd32.c
@@ -696,7 +696,7 @@ static DEVICE_API(dma, dma_gd32_driver_api) = {
 		.channels = dma_gd32##inst##_channels,                         \
 	};                                                                     \
                                                                                \
-	DEVICE_DT_INST_DEFINE(inst, &dma_gd32_init, NULL,                      \
+	DEVICE_DT_INST_DEFINE(inst, dma_gd32_init, NULL,                       \
 			      &dma_gd32##inst##_data,                          \
 			      &dma_gd32##inst##_config, POST_KERNEL,           \
 			      CONFIG_DMA_INIT_PRIORITY, &dma_gd32_driver_api);

--- a/drivers/dma/dma_ifx_cat1.c
+++ b/drivers/dma/dma_ifx_cat1.c
@@ -742,7 +742,7 @@ static DEVICE_API(dma, ifx_cat1_dma_api) = {
 		CONFIGURE_ALL_IRQS(n, DT_NUM_IRQS(DT_DRV_INST(n)));                                \
 	}                                                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &ifx_cat1_dma_init, NULL, &ifx_cat1_dma_data##n,                  \
+	DEVICE_DT_INST_DEFINE(n, ifx_cat1_dma_init, NULL, &ifx_cat1_dma_data##n,                   \
 			      &ifx_cat1_dma_config##n, PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,     \
 			      &ifx_cat1_dma_api);
 

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -544,7 +544,7 @@ static DEVICE_API(dma, intel_adsp_gpdma_driver_api) = {
 	PM_DEVICE_DT_INST_DEFINE(inst, gpdma_pm_action);		\
 									\
 	DEVICE_DT_INST_DEFINE(inst,					\
-			      &intel_adsp_gpdma_init,			\
+			      intel_adsp_gpdma_init,			\
 			      PM_DEVICE_DT_INST_GET(inst),		\
 			      &intel_adsp_gpdma##inst##_data,		\
 			      &intel_adsp_gpdma##inst##_config, POST_KERNEL,\

--- a/drivers/dma/dma_intel_adsp_hda_host_in.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_in.c
@@ -35,7 +35,7 @@ static DEVICE_API(dma, intel_adsp_hda_dma_host_in_api) = {
 												   \
 	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+	DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_init,					   \
 			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,                                    \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,                     \

--- a/drivers/dma/dma_intel_adsp_hda_host_out.c
+++ b/drivers/dma/dma_intel_adsp_hda_host_out.c
@@ -39,7 +39,7 @@ static DEVICE_API(dma, intel_adsp_hda_dma_host_out_api) = {
 												   \
 	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+	DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_init,					   \
 			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,                                    \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,                     \

--- a/drivers/dma/dma_intel_adsp_hda_link_in.c
+++ b/drivers/dma/dma_intel_adsp_hda_link_in.c
@@ -37,7 +37,7 @@ static DEVICE_API(dma, intel_adsp_hda_dma_link_in_api) = {
 												   \
 	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+	DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_init,					   \
 			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,                                    \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,                     \

--- a/drivers/dma/dma_intel_adsp_hda_link_out.c
+++ b/drivers/dma/dma_intel_adsp_hda_link_out.c
@@ -37,7 +37,7 @@ static DEVICE_API(dma, intel_adsp_hda_dma_link_out_api) = {
 												   \
 	PM_DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_pm_action);				   \
 												   \
-	DEVICE_DT_INST_DEFINE(inst, &intel_adsp_hda_dma_init,					   \
+	DEVICE_DT_INST_DEFINE(inst, intel_adsp_hda_dma_init,					   \
 			      PM_DEVICE_DT_INST_GET(inst),					   \
 			      &intel_adsp_hda_dma##inst##_data,					   \
 			      &intel_adsp_hda_dma##inst##_config, POST_KERNEL,			   \

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -982,7 +982,7 @@ static const struct dma_iproc_pax_cfg pax_dma_cfg = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &dma_iproc_pax_init,
+		    dma_iproc_pax_init,
 		    NULL,
 		    &pax_dma_data,
 		    &pax_dma_cfg,

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -1098,7 +1098,7 @@ static const struct dma_iproc_pax_cfg pax_dma_cfg = {
 };
 
 DEVICE_DT_INST_DEFINE(0,
-		    &dma_iproc_pax_init,
+		    dma_iproc_pax_init,
 		    NULL,
 		    &pax_dma_data,
 		    &pax_dma_cfg,

--- a/drivers/dma/dma_max32.c
+++ b/drivers/dma/dma_max32.c
@@ -347,7 +347,7 @@ static DEVICE_API(dma, max32_dma_driver_api) = {
 		.channels = DT_INST_PROP(inst, dma_channels),                                      \
 		.irq_configure = max32_dma##inst##_irq_configure,                                  \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, &max32_dma_init, NULL, &dma##inst##_data, &dma##inst##_cfg,    \
+	DEVICE_DT_INST_DEFINE(inst, max32_dma_init, NULL, &dma##inst##_data, &dma##inst##_cfg,     \
 			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY, &max32_dma_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MAX32_DMA_INIT)

--- a/drivers/dma/dma_mchp_xec.c
+++ b/drivers/dma/dma_mchp_xec.c
@@ -833,7 +833,7 @@ static int dma_xec_init(const struct device *dev)
 		.irq_connect = dma_xec_irq_connect##i,					\
 	};										\
 	PM_DEVICE_DT_DEFINE(i, dmac_xec_pm_action);					\
-	DEVICE_DT_INST_DEFINE(i, &dma_xec_init,						\
+	DEVICE_DT_INST_DEFINE(i, dma_xec_init,						\
 		PM_DEVICE_DT_GET(i),							\
 		&dma_xec_data##i, &dma_xec_cfg##i,					\
 		PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,					\

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -986,7 +986,7 @@ static int dma_mcux_edma_init(const struct device *dev)
 	};									\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
-			      &dma_mcux_edma_init, NULL,			\
+			      dma_mcux_edma_init, NULL,				\
 			      &dma_data_##n, &dma_config_##n,			\
 			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,		\
 			      &dma_mcux_edma_api);				\

--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -914,7 +914,7 @@ static const struct dma_mcux_lpc_config dma_##n##_config = {		\
 	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
-			    &dma_mcux_lpc_init,				\
+			    dma_mcux_lpc_init,				\
 			    NULL,					\
 			    &dma_data_##n, &dma_##n##_config,		\
 			    PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,	\

--- a/drivers/dma/dma_mcux_pxp.c
+++ b/drivers/dma/dma_mcux_pxp.c
@@ -218,7 +218,7 @@ static int dma_mcux_pxp_init(const struct device *dev)
                                                                                                    \
 	static struct dma_mcux_pxp_data dma_data_##n;                                              \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(n, &dma_mcux_pxp_init, NULL, &dma_data_##n, &dma_config_##n,         \
+	DEVICE_DT_INST_DEFINE(n, dma_mcux_pxp_init, NULL, &dma_data_##n, &dma_config_##n,          \
 			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY, &dma_mcux_pxp_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DMA_INIT)

--- a/drivers/dma/dma_mcux_smartdma.c
+++ b/drivers/dma/dma_mcux_smartdma.c
@@ -152,7 +152,7 @@ static DEVICE_API(dma, dma_mcux_smartdma_api) = {
 	static struct dma_mcux_smartdma_data smartdma_##n##_data;		\
 										\
 	DEVICE_DT_INST_DEFINE(n,						\
-				&dma_mcux_smartdma_init,			\
+				dma_mcux_smartdma_init,				\
 				NULL,						\
 				&smartdma_##n##_data, &smartdma_##n##_config,	\
 				POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,		\

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -229,6 +229,6 @@ static struct nios2_msgdma_dev_data dma0_nios2_data = {
 	.msgdma_dev = &msgdma_dev0,
 };
 
-DEVICE_DT_INST_DEFINE(0, &nios2_msgdma0_initialize,
+DEVICE_DT_INST_DEFINE(0, nios2_msgdma0_initialize,
 		NULL, &dma0_nios2_data, NULL, POST_KERNEL,
 		CONFIG_DMA_INIT_PRIORITY, &nios2_msgdma_driver_api);

--- a/drivers/dma/dma_nxp_edma.c
+++ b/drivers/dma/dma_nxp_edma.c
@@ -768,7 +768,7 @@ static struct edma_data edma_data_##inst = {					\
 	.ctx.magic = DMA_MAGIC,							\
 };										\
 										\
-DEVICE_DT_INST_DEFINE(inst, &edma_init, NULL,					\
+DEVICE_DT_INST_DEFINE(inst, edma_init, NULL,					\
 		      &edma_data_##inst, &edma_config_##inst,			\
 		      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,			\
 		      &edma_api);						\

--- a/drivers/dma/dma_nxp_sdma.c
+++ b/drivers/dma/dma_nxp_sdma.c
@@ -488,7 +488,7 @@ static int dma_nxp_sdma_init(const struct device *dev)
 			    dma_nxp_sdma_isr, DEVICE_DT_INST_GET(inst), 0);	\
 		irq_enable(DT_INST_IRQN(inst));				\
 	}								\
-	DEVICE_DT_INST_DEFINE(inst, &dma_nxp_sdma_init, NULL,		\
+	DEVICE_DT_INST_DEFINE(inst, dma_nxp_sdma_init, NULL,		\
 			      &sdma_data_##inst, &sdma_cfg_##inst,	\
 			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,	\
 			      &sdma_api);				\

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -581,7 +581,7 @@ static const struct dma_pl330_config pl330_config = {
 
 static struct dma_pl330_dev_data pl330_data;
 
-DEVICE_DT_INST_DEFINE(0, &dma_pl330_initialize, NULL,
+DEVICE_DT_INST_DEFINE(0, dma_pl330_initialize, NULL,
 		    &pl330_data, &pl330_config,
 		    POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,
 		    &pl330_driver_api);

--- a/drivers/dma/dma_rpi_pico.c
+++ b/drivers/dma/dma_rpi_pico.c
@@ -380,7 +380,7 @@ static DEVICE_API(dma, dma_rpi_pico_driver_api) = {
 		.channels = dma_rpi_pico##inst##_channels,                                         \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &dma_rpi_pico_init, NULL, &dma_rpi_pico##inst##_data,          \
+	DEVICE_DT_INST_DEFINE(inst, dma_rpi_pico_init, NULL, &dma_rpi_pico##inst##_data,           \
 			      &dma_rpi_pico##inst##_config, POST_KERNEL, CONFIG_DMA_INIT_PRIORITY, \
 			      &dma_rpi_pico_driver_api);
 

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -463,6 +463,6 @@ static DEVICE_API(dma, dma_sam0_api) = {
 	.get_status = dma_sam0_get_status,
 };
 
-DEVICE_DT_INST_DEFINE(0, &dma_sam0_init, NULL,
+DEVICE_DT_INST_DEFINE(0, dma_sam0_init, NULL,
 		    &dmac_data, NULL, PRE_KERNEL_1,
 		    CONFIG_DMA_INIT_PRIORITY, &dma_sam0_api);

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -424,6 +424,6 @@ static const struct sam_xdmac_dev_cfg dma0_sam_config = {
 
 static struct sam_xdmac_dev_data dma0_sam_data;
 
-DEVICE_DT_INST_DEFINE(0, &sam_xdmac_initialize, NULL,
+DEVICE_DT_INST_DEFINE(0, sam_xdmac_initialize, NULL,
 		    &dma0_sam_data, &dma0_sam_config, POST_KERNEL,
 		    CONFIG_DMA_INIT_PRIORITY, &sam_xdmac_driver_api);

--- a/drivers/dma/dma_sedi.c
+++ b/drivers/dma/dma_sedi.c
@@ -376,7 +376,7 @@ static int dma_sedi_init(const struct device *dev)
 		.chn_num = DT_INST_PROP(inst, dma_channels), \
 		.irq_config = dma_sedi_##inst##_irq_config \
 	}; \
-	DEVICE_DT_INST_DEFINE(inst, &dma_sedi_init, \
+	DEVICE_DT_INST_DEFINE(inst, dma_sedi_init, \
 	      NULL, &dma_sedi_dev_data_##inst, &dma_sedi_config_data_##inst, PRE_KERNEL_2, \
 	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, (void *)&dma_funcs); \
 									\

--- a/drivers/dma/dma_si32.c
+++ b/drivers/dma/dma_si32.c
@@ -423,5 +423,5 @@ static DEVICE_API(dma, dma_si32_driver_api) = {
 	.stop = dma_si32_stop,
 };
 
-DEVICE_DT_INST_DEFINE(0, &dma_si32_init, NULL, NULL, NULL, POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,
+DEVICE_DT_INST_DEFINE(0, dma_si32_init, NULL, NULL, NULL, POST_KERNEL, CONFIG_DMA_INIT_PRIORITY,
 		      &dma_si32_driver_api);

--- a/drivers/dma/dma_silabs_ldma.c
+++ b/drivers/dma/dma_silabs_ldma.c
@@ -611,7 +611,7 @@ int silabs_ldma_append_block(const struct device *dev, uint32_t channel, struct 
 		.dma_desc_pool = &desc_pool_##inst                                                 \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &dma_silabs_init, NULL, &dma_silabs_data_##inst,               \
+	DEVICE_DT_INST_DEFINE(inst, dma_silabs_init, NULL, &dma_silabs_data_##inst,                \
 			      &dma_silabs_config_##inst, PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,   \
 			      &dma_funcs);
 

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -699,7 +699,7 @@ static DEVICE_API(dma, siwx91x_dma_api) = {
 					      (siwx91x_dma_chan_desc##inst)),                      \
 		.irq_configure = siwx91x_dma_irq_configure_##inst,                                 \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, &siwx91x_dma_init, NULL, &dma_data_##inst, &dma_cfg_##inst,    \
+	DEVICE_DT_INST_DEFINE(inst, siwx91x_dma_init, NULL, &dma_data_##inst, &dma_cfg_##inst,     \
 			      POST_KERNEL, CONFIG_DMA_INIT_PRIORITY, &siwx91x_dma_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SIWX91X_DMA_INIT)

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -715,7 +715,7 @@ static struct dma_stm32_data dma_stm32_data_##index = {			\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
-		    &dma_stm32_init,					\
+		    dma_stm32_init,					\
 		    NULL,						\
 		    &dma_stm32_data_##index, &dma_stm32_config_##index,	\
 		    PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,		\

--- a/drivers/dma/dma_stm32_bdma.c
+++ b/drivers/dma/dma_stm32_bdma.c
@@ -883,7 +883,7 @@ static struct bdma_stm32_data bdma_stm32_data_##index = {		\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(index,							\
-		    &bdma_stm32_init,						\
+		    bdma_stm32_init,						\
 		    NULL,							\
 		    &bdma_stm32_data_##index, &bdma_stm32_config_##index,	\
 		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,		\

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -823,7 +823,7 @@ static struct dma_stm32_data dma_stm32_data_##index = {			\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
-		    &dma_stm32_init,					\
+		    dma_stm32_init,					\
 		    NULL,						\
 		    &dma_stm32_data_##index, &dma_stm32_config_##index,	\
 		    PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,		\

--- a/drivers/dma/dma_ti_cc23x0.c
+++ b/drivers/dma/dma_ti_cc23x0.c
@@ -376,7 +376,7 @@ static DEVICE_API(dma, dma_cc23x0_api) = {
 	.get_status = dma_cc23x0_get_status,
 };
 
-DEVICE_DT_INST_DEFINE(0, &dma_cc23x0_init, NULL,
+DEVICE_DT_INST_DEFINE(0, dma_cc23x0_init, NULL,
 		      &cc23x0_data, NULL,
 		      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,
 		      &dma_cc23x0_api);

--- a/drivers/dma/dma_wch.c
+++ b/drivers/dma/dma_wch.c
@@ -492,7 +492,7 @@ LISTIFY(DMA_WCH_MAX_CHAN, GENERATE_ISR, ())
 		.channels = dma_wch##idx##_channels,                                               \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(idx, &dma_wch_init, NULL, &dma_wch##idx##_data,                      \
+	DEVICE_DT_INST_DEFINE(idx, dma_wch_init, NULL, &dma_wch##idx##_data,                       \
 			      &dma_wch##idx##_config, PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,      \
 			      &dma_wch_driver_api);
 

--- a/drivers/dma/dma_xilinx_axi_dma.c
+++ b/drivers/dma/dma_xilinx_axi_dma.c
@@ -1109,7 +1109,7 @@ static int dma_xilinx_axi_dma_init(const struct device *dev)
 		.channels = dma_xilinx_axi_dma##inst##_channels,                                   \
 	};                                                                                         \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(inst, &dma_xilinx_axi_dma_init, NULL,                                \
+	DEVICE_DT_INST_DEFINE(inst, dma_xilinx_axi_dma_init, NULL,                                 \
 			      &dma_xilinx_axi_dma##inst##_data,                                    \
 			      &dma_xilinx_axi_dma##inst##_config, POST_KERNEL,                     \
 			      CONFIG_DMA_INIT_PRIORITY, &dma_xilinx_axi_dma_driver_api);

--- a/drivers/dma/dma_xmc4xxx.c
+++ b/drivers/dma/dma_xmc4xxx.c
@@ -663,7 +663,7 @@ static DEVICE_API(dma, dma_xmc4xxx_driver_api) = {
 		.channels = dma_xmc4xxx##inst##_channels,                       \
 	};                                                                      \
 										\
-	DEVICE_DT_INST_DEFINE(inst, &dma_xmc4xxx_init, NULL,                    \
+	DEVICE_DT_INST_DEFINE(inst, dma_xmc4xxx_init, NULL,                     \
 			      &dma_xmc4xxx##inst##_data,                        \
 			      &dma_xmc4xxx##inst##_config, PRE_KERNEL_1,        \
 			      CONFIG_DMA_INIT_PRIORITY, &dma_xmc4xxx_driver_api);

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -389,7 +389,7 @@ const struct dmamux_stm32_config dmamux_stm32_config_##index = {	\
 static struct dmamux_stm32_data dmamux_stm32_data_##index;		\
 									\
 DEVICE_DT_INST_DEFINE(index,						\
-		    &dmamux_stm32_init,					\
+		    dmamux_stm32_init,					\
 		    NULL,						\
 		    &dmamux_stm32_data_##index, &dmamux_stm32_config_##index,\
 		    PRE_KERNEL_1, CONFIG_DMAMUX_STM32_INIT_PRIORITY,	\


### PR DESCRIPTION
Remove address-of operator ('&') when assigning `dma_xxx_init` function pointer in `DEVICE_DT_INST_DEFINE` macro.

This change aims to maintain consistency among the drivers in `drivers/dma`, ensuring that all function pointer assignments follow the same pattern.