### PR TITLE
drivers: display: elcdif: remove backlight enable pin dependency

### DIFF
--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -223,16 +223,26 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x, const u
 
 static int mcux_elcdif_display_blanking_off(const struct device *dev)
 {
+	#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(backlight_gpio)
 	const struct mcux_elcdif_config *config = dev->config;
+	if (config->backlight_gpio.port) {
+		return gpio_pin_set_dt(&config->backlight_gpio, 1);
+	}
+	#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(backlight_gpio) */
 
-	return gpio_pin_set_dt(&config->backlight_gpio, 1);
+	return -ENOSYS;
 }
 
 static int mcux_elcdif_display_blanking_on(const struct device *dev)
 {
+	#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(backlight_gpio)
 	const struct mcux_elcdif_config *config = dev->config;
+	if (config->backlight_gpio.port) {
+		return gpio_pin_set_dt(&config->backlight_gpio, 0);
+	}
+	#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(backlight_gpio) */
 
-	return gpio_pin_set_dt(&config->backlight_gpio, 0);
+	return -ENOSYS;
 }
 
 static int mcux_elcdif_set_pixel_format(const struct device *dev,
@@ -327,10 +337,14 @@ static int mcux_elcdif_init(const struct device *dev)
 		return err;
 	}
 
-	err = gpio_pin_configure_dt(&config->backlight_gpio, GPIO_OUTPUT_ACTIVE);
-	if (err) {
-		return err;
+	#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(backlight_gpio)
+	if (config->backlight_gpio.port) {
+		err = gpio_pin_configure_dt(&config->backlight_gpio, GPIO_OUTPUT_ACTIVE);
+		if (err) {
+			return err;
+		}
 	}
+	#endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios) */
 
 	k_sem_init(&dev_data->sem, 0, 1);
 #ifdef CONFIG_MCUX_ELCDIF_PXP
@@ -397,9 +411,9 @@ static DEVICE_API(display, mcux_elcdif_api) = {
 					DT_INST_ENUM_IDX(id, data_bus_width)),                     \
 			},                                                                         \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),                                      \
-		.backlight_gpio = GPIO_DT_SPEC_INST_GET(id, backlight_gpios),                      \
+		.backlight_gpio = GPIO_DT_SPEC_INST_GET_OR(id, backlight_gpios, {0}),              \
 		IF_ENABLED(CONFIG_MCUX_ELCDIF_PXP,                                                 \
-			   (.pxp = DEVICE_DT_GET(DT_INST_PHANDLE(id, nxp_pxp)),))};               \
+			   (.pxp = DEVICE_DT_GET(DT_INST_PHANDLE(id, nxp_pxp)),))};                \
 	static struct mcux_elcdif_data mcux_elcdif_data_##id = {                                   \
 		.next_idx = 0,                                                                     \
 		.pixel_format = DT_INST_PROP(id, pixel_format),                                    \

--- a/dts/bindings/display/nxp,imx-elcdif.yaml
+++ b/dts/bindings/display/nxp,imx-elcdif.yaml
@@ -27,7 +27,6 @@ properties:
 
   backlight-gpios:
     type: phandle-array
-    required: true
     description:
       LCB backlight control gpio. Driver will initialize this GPIO to active high
 


### PR DESCRIPTION
The driver no longer requires a backlight enable GPIO pin to be defined, which allows compatibility with displays that do not provide such a pin.