### PR TITLE
boards: nxp: unify NXP board naming in board.yml

### DIFF
--- a/boards/nxp/frdm_rw612/board.yml
+++ b/boards/nxp/frdm_rw612/board.yml
@@ -1,6 +1,6 @@
 board:
   name: frdm_rw612
-  full_name: FRDM_RW612
+  full_name: FRDM-RW612
   vendor: nxp
   socs:
     - name: rw612

--- a/boards/nxp/imx8mm_evk/board.yml
+++ b/boards/nxp/imx8mm_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx8mm_evk
-  full_name: i.MX8MM EVK
+  full_name: 8MMINILPD4-EVK
   vendor: nxp
   socs:
   - name: mimx8mm6

--- a/boards/nxp/imx8mn_evk/board.yml
+++ b/boards/nxp/imx8mn_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx8mn_evk
-  full_name: i.MX8MN EVK (Cortex-A53)
+  full_name: 8MNANOLPD4-EVK
   vendor: nxp
   socs:
   - name: mimx8mn6

--- a/boards/nxp/imx8mp_evk/board.yml
+++ b/boards/nxp/imx8mp_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx8mp_evk
-  full_name: i.MX8MP EVK
+  full_name: 8MPLUSLPD4-EVK
   vendor: nxp
   socs:
   - name: mimx8ml8

--- a/boards/nxp/imx8mq_evk/board.yml
+++ b/boards/nxp/imx8mq_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx8mq_evk
-  full_name: MIMX8MQ EVK
+  full_name: MCIMX8M-EVK
   vendor: nxp
   socs:
   - name: mimx8mq6

--- a/boards/nxp/imx8qm_mek/board.yml
+++ b/boards/nxp/imx8qm_mek/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx8qm_mek
-  full_name: i.MX 8QuadMax Multisensory Enablement Kit (MEK)
+  full_name: i.MX8QM-MEK
   vendor: nxp
   socs:
     - name: mimx8qm6

--- a/boards/nxp/imx8qxp_mek/board.yml
+++ b/boards/nxp/imx8qxp_mek/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx8qxp_mek
-  full_name: i.MX 8QuadXPlus Multisensory Enablement Kit (MEK)
+  full_name: i.MX8QXP-MEK
   vendor: nxp
   socs:
     - name: mimx8qx6

--- a/boards/nxp/imx8ulp_evk/board.yml
+++ b/boards/nxp/imx8ulp_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx8ulp_evk
-  full_name: i.MX 8ULP Evaluation Kit
+  full_name: i.MX8ULP-EVK
   vendor: nxp
   socs:
     - name: mimx8ud7

--- a/boards/nxp/imx91_evk/board.yml
+++ b/boards/nxp/imx91_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx91_evk
-  full_name: i.MX91 EVK
+  full_name: i.MX91-EVK
   vendor: nxp
   socs:
   - name: mimx9131

--- a/boards/nxp/imx93_evk/board.yml
+++ b/boards/nxp/imx93_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx93_evk
-  full_name: i.MX93 EVK
+  full_name: i.MX93-EVK
   vendor: nxp
   socs:
   - name: mimx9352

--- a/boards/nxp/imx95_evk/board.yml
+++ b/boards/nxp/imx95_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: imx95_evk
-  full_name: i.MX95 EVK
+  full_name: i.MX95-EVK
   vendor: nxp
   socs:
   - name: mimx9596

--- a/boards/nxp/ls1046ardb/board.yml
+++ b/boards/nxp/ls1046ardb/board.yml
@@ -1,6 +1,6 @@
 board:
   name: ls1046ardb
-  full_name: LS1046A RDB
+  full_name: LS1046A-RDB
   vendor: nxp
   socs:
   - name: ls1046a

--- a/boards/nxp/mimxrt1170_evk/board.yml
+++ b/boards/nxp/mimxrt1170_evk/board.yml
@@ -1,6 +1,6 @@
 board:
   name: mimxrt1170_evk
-  full_name: MIMXRT1170-EVK/EVKB
+  full_name: MIMXRT1170-EVK
   vendor: nxp
   socs:
     - name: mimxrt1176

--- a/boards/nxp/vmu_rt1170/board.yml
+++ b/boards/nxp/vmu_rt1170/board.yml
@@ -1,6 +1,6 @@
 board:
   name: vmu_rt1170
-  full_name: VMU RT1170
+  full_name: MR-VMU-RT1176
   vendor: nxp
   socs:
     - name: mimxrt1176


### PR DESCRIPTION
Unify full_name content in NXP board.yml to be consistent with the rest of NXP boards.