### PR TITLE
sensor: lsm6dsv16x: add SENSOR_TRIG_DATA_READY trigger

### DIFF
--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x.h
@@ -126,6 +126,12 @@ struct lsm6dsv16x_ibi_payload {
 	uint8_t mlc_status;
 } __packed;
 
+struct trigger_config {
+	uint8_t int_fifo_th : 1;
+	uint8_t int_fifo_full : 1;
+	uint8_t int_drdy : 1;
+};
+
 struct lsm6dsv16x_data {
 	const struct device *dev;
 	int16_t acc[3];
@@ -159,16 +165,17 @@ struct lsm6dsv16x_data {
 	struct rtio_iodev_sqe *streaming_sqe;
 	struct rtio *rtio_ctx;
 	struct rtio_iodev *iodev;
-	uint64_t fifo_timestamp;
+	uint64_t timestamp;
+	uint8_t status;
 	uint8_t fifo_status[2];
 	uint16_t fifo_count;
-	uint8_t fifo_irq;
-	uint8_t accel_batch_odr : 4;
-	uint8_t gyro_batch_odr : 4;
-	uint8_t temp_batch_odr : 2;
-	uint8_t bus_type : 2; /* I2C is 0, SPI is 1, I3C is 2 */
-	uint8_t sflp_batch_odr : 3;
-	uint8_t reserved : 1;
+	struct trigger_config trig_cfg;
+	uint16_t accel_batch_odr : 4;
+	uint16_t gyro_batch_odr : 4;
+	uint16_t temp_batch_odr : 2;
+	uint16_t bus_type : 2; /* I2C is 0, SPI is 1, I3C is 2 */
+	uint16_t sflp_batch_odr : 3;
+	uint16_t reserved : 1;
 	int32_t gbias_x_udps;
 	int32_t gbias_y_udps;
 	int32_t gbias_z_udps;

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -16,8 +16,67 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(LSM6DSV16X_RTIO);
 
-#define FIFO_TH 1
-#define FIFO_FULL 2
+/*
+ * Create a chain of SQEs representing a bus transaction to read a reg.
+ * The RTIO-enabled bus driver will:
+ *
+ *     - write "reg" address
+ *     - read "len" data bytes into "buf".
+ *     - call complete_op callback
+ *
+ * If drdy_xl is active it reads XL data (6 bytes) from LSM6DSV16X_OUTX_L_A reg.
+ */
+static void lsm6dsv16x_rtio_rw_transaction(const struct device *dev, uint8_t reg,
+					   uint8_t *buf, uint32_t len,
+					   rtio_callback_t complete_op_cb)
+{
+	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
+	struct rtio *rtio = lsm6dsv16x->rtio_ctx;
+	struct rtio_iodev *iodev = lsm6dsv16x->iodev;
+	struct rtio_sqe *write_addr = rtio_sqe_acquire(rtio);
+	struct rtio_sqe *read_reg = rtio_sqe_acquire(rtio);
+	struct rtio_sqe *complete_op = rtio_sqe_acquire(rtio);
+	struct rtio_iodev_sqe *sqe = lsm6dsv16x->streaming_sqe;
+	uint8_t reg_bus = lsm6dsv16x_bus_reg(lsm6dsv16x, reg);
+
+	/* check we have been able to acquire sqe */
+	if (write_addr == NULL || read_reg == NULL || complete_op == NULL) {
+		return;
+	}
+
+	rtio_sqe_prep_tiny_write(write_addr, iodev, RTIO_PRIO_NORM, &reg_bus, 1, NULL);
+	write_addr->flags = RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_reg, iodev, RTIO_PRIO_NORM, buf, len, NULL);
+	read_reg->flags = RTIO_SQE_CHAINED;
+	if (lsm6dsv16x->bus_type == BUS_I2C) {
+		read_reg->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	} else if (lsm6dsv16x->bus_type == BUS_I3C) {
+		read_reg->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
+	}
+
+	rtio_sqe_prep_callback_no_cqe(complete_op, complete_op_cb, (void *)dev, sqe);
+	rtio_submit(rtio, 0);
+}
+
+static void lsm6dsv16x_config_drdy(const struct device *dev, struct trigger_config trig_cfg)
+{
+	const struct lsm6dsv16x_config *config = dev->config;
+	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&config->ctx;
+	lsm6dsv16x_pin_int_route_t pin_int = { 0 };
+	int16_t buf[3];
+
+	/* dummy read: re-trigger interrupt */
+	lsm6dsv16x_acceleration_raw_get(ctx, buf);
+
+	pin_int.drdy_xl = PROPERTY_ENABLE;
+
+	/* Set pin interrupt */
+	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {
+		lsm6dsv16x_pin_int1_route_set(ctx, &pin_int);
+	} else {
+		lsm6dsv16x_pin_int2_route_set(ctx, &pin_int);
+	}
+}
 
 int lsm6dsv16x_gbias_config(const struct device *dev, enum sensor_channel chan,
 			    enum sensor_attribute attr,
@@ -58,7 +117,7 @@ int lsm6dsv16x_gbias_get_config(const struct device *dev, enum sensor_channel ch
 	return 0;
 }
 
-static void lsm6dsv16x_config_fifo(const struct device *dev, uint8_t fifo_irq)
+static void lsm6dsv16x_config_fifo(const struct device *dev, struct trigger_config trig_cfg)
 {
 	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
 	const struct lsm6dsv16x_config *config = dev->config;
@@ -79,9 +138,9 @@ static void lsm6dsv16x_config_fifo(const struct device *dev, uint8_t fifo_irq)
 	pin_int.fifo_th = PROPERTY_DISABLE;
 	pin_int.fifo_full = PROPERTY_DISABLE;
 
-	if (fifo_irq != 0) {
-		pin_int.fifo_th = (fifo_irq & FIFO_TH) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
-		pin_int.fifo_full = (fifo_irq & FIFO_FULL) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
+	if (trig_cfg.int_fifo_th || trig_cfg.int_fifo_full) {
+		pin_int.fifo_th = (trig_cfg.int_fifo_th) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
+		pin_int.fifo_full = (trig_cfg.int_fifo_full) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 
 		xl_batch = config->accel_batch;
 		gy_batch = config->gyro_batch;
@@ -178,7 +237,7 @@ static void lsm6dsv16x_config_fifo(const struct device *dev, uint8_t fifo_irq)
 	/* Set pin interrupt (fifo_th could be on or off) */
 	if ((config->drdy_pin == 1) || (ON_I3C_BUS(config) && (!I3C_INT_PIN(config)))) {
 		lsm6dsv16x_pin_int1_route_set(ctx, &pin_int);
-	}  else {
+	} else {
 		lsm6dsv16x_pin_int2_route_set(ctx, &pin_int);
 	}
 }
@@ -190,7 +249,7 @@ void lsm6dsv16x_submit_stream(const struct device *dev, struct rtio_iodev_sqe *i
 	const struct lsm6dsv16x_config *config = dev->config;
 #endif
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
-	uint8_t fifo_irq = 0;
+	struct trigger_config trig_cfg = { 0 };
 
 	if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
 		gpio_pin_interrupt_configure_dt(lsm6dsv16x->drdy_gpio, GPIO_INT_DISABLE);
@@ -198,18 +257,30 @@ void lsm6dsv16x_submit_stream(const struct device *dev, struct rtio_iodev_sqe *i
 
 	for (size_t i = 0; i < cfg->count; i++) {
 		if (cfg->triggers[i].trigger == SENSOR_TRIG_FIFO_WATERMARK) {
-			fifo_irq = FIFO_TH;
+			trig_cfg.int_fifo_th = 1;
 		} else if (cfg->triggers[i].trigger == SENSOR_TRIG_FIFO_FULL) {
-			fifo_irq = FIFO_FULL;
+			trig_cfg.int_fifo_full = 1;
+		} else if (cfg->triggers[i].trigger == SENSOR_TRIG_DATA_READY) {
+			trig_cfg.int_drdy = 1;
 		}
 	}
 
-	/* if any change in fifo irq */
-	if (fifo_irq != lsm6dsv16x->fifo_irq) {
-		lsm6dsv16x->fifo_irq = fifo_irq;
+	/* if any change in trig_cfg for FIFO triggers */
+	if (trig_cfg.int_fifo_th != lsm6dsv16x->trig_cfg.int_fifo_th ||
+	    trig_cfg.int_fifo_full != lsm6dsv16x->trig_cfg.int_fifo_full) {
+		lsm6dsv16x->trig_cfg.int_fifo_th = trig_cfg.int_fifo_th;
+		lsm6dsv16x->trig_cfg.int_fifo_full = trig_cfg.int_fifo_full;
 
 		/* enable/disable the FIFO */
-		lsm6dsv16x_config_fifo(dev, fifo_irq);
+		lsm6dsv16x_config_fifo(dev, trig_cfg);
+	}
+
+	/* if any change in trig_cfg for DRDY triggers */
+	if (trig_cfg.int_drdy != lsm6dsv16x->trig_cfg.int_drdy) {
+		lsm6dsv16x->trig_cfg.int_drdy = trig_cfg.int_drdy;
+
+		/* enable/disable drdy events */
+		lsm6dsv16x_config_drdy(dev, trig_cfg);
 	}
 
 	lsm6dsv16x->streaming_sqe = iodev_sqe;
@@ -219,6 +290,9 @@ void lsm6dsv16x_submit_stream(const struct device *dev, struct rtio_iodev_sqe *i
 	}
 }
 
+/*
+ * Called by bus driver to complete the sqe.
+ */
 static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
 {
 	const struct device *dev = arg;
@@ -235,6 +309,10 @@ static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe
 	}
 }
 
+/*
+ * Called by bus driver to complete the LSM6DSV16X_FIFO_STATUS read op (2 bytes).
+ * If FIFO threshold or FIFO full events are active it reads all FIFO entries.
+ */
 static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
 {
 	const struct device *dev = arg;
@@ -242,6 +320,7 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
 	const struct lsm6dsv16x_config *config = dev->config;
 #endif
 	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
+	struct rtio *rtio = lsm6dsv16x->rtio_ctx;
 	struct gpio_dt_spec *irq_gpio = lsm6dsv16x->drdy_gpio;
 	struct rtio_iodev *iodev = lsm6dsv16x->iodev;
 	struct sensor_read_config *read_config;
@@ -293,17 +372,18 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
 		return;
 	}
 
+	/* flush completion */
 	struct rtio_cqe *cqe;
 	int res = 0;
 
 	do {
-		cqe = rtio_cqe_consume(lsm6dsv16x->rtio_ctx);
+		cqe = rtio_cqe_consume(rtio);
 		if (cqe != NULL) {
 			if ((cqe->result < 0) && (res == 0)) {
 				LOG_ERR("Bus error: %d", cqe->result);
 				res = cqe->result;
 			}
-			rtio_cqe_release(lsm6dsv16x->rtio_ctx, cqe);
+			rtio_cqe_release(rtio, cqe);
 		}
 	} while (cqe != NULL);
 
@@ -346,7 +426,7 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
 
 		memset(buf, 0, buf_len);
 		rx_data->header.is_fifo = 1;
-		rx_data->header.timestamp = lsm6dsv16x->fifo_timestamp;
+		rx_data->header.timestamp = lsm6dsv16x->timestamp;
 		rx_data->int_status = lsm6dsv16x->fifo_status[1];
 		rx_data->fifo_count = 0;
 
@@ -366,7 +446,7 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
 			 *
 			 *   lsm6dsv16x_fifo_mode_set(ctx, LSM6DSV16X_BYPASS_MODE);
 			 */
-			struct rtio_sqe *write_fifo_mode = rtio_sqe_acquire(lsm6dsv16x->rtio_ctx);
+			struct rtio_sqe *write_fifo_mode = rtio_sqe_acquire(rtio);
 			uint8_t lsm6dsv16x_fifo_mode_set[] = {
 				LSM6DSV16X_FIFO_CTRL4,
 				LSM6DSV16X_BYPASS_MODE,
@@ -377,7 +457,7 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
 						 RTIO_PRIO_NORM, lsm6dsv16x_fifo_mode_set,
 						 ARRAY_SIZE(lsm6dsv16x_fifo_mode_set), NULL);
 
-			rtio_submit(lsm6dsv16x->rtio_ctx, 0);
+			rtio_submit(rtio, 0);
 		}
 
 		return;
@@ -404,7 +484,7 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
 			.accel_fs_idx = LSM6DSV16X_ACCEL_FS_VAL_TO_FS_IDX(
 				config->accel_fs_map[lsm6dsv16x->accel_fs]),
 			.gyro_fs = lsm6dsv16x->gyro_fs,
-			.timestamp = lsm6dsv16x->fifo_timestamp,
+			.timestamp = lsm6dsv16x->timestamp,
 		},
 		.fifo_count = fifo_count,
 		.accel_batch_odr = lsm6dsv16x->accel_batch_odr,
@@ -435,33 +515,163 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
 	 *     lsm6dsv16x_fifo_out_raw_get(&dev_ctx, &f_data);
 	 *   }
 	 */
-	struct rtio_sqe *write_fifo_dout_addr = rtio_sqe_acquire(lsm6dsv16x->rtio_ctx);
-	struct rtio_sqe *read_fifo_dout_reg = rtio_sqe_acquire(lsm6dsv16x->rtio_ctx);
-	struct rtio_sqe *complete_op = rtio_sqe_acquire(lsm6dsv16x->rtio_ctx);
-	uint8_t reg = lsm6dsv16x_bus_reg(lsm6dsv16x, LSM6DSV16X_FIFO_DATA_OUT_TAG);
-
-	rtio_sqe_prep_tiny_write(write_fifo_dout_addr, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
-	write_fifo_dout_addr->flags = RTIO_SQE_TRANSACTION;
-	rtio_sqe_prep_read(read_fifo_dout_reg, iodev, RTIO_PRIO_NORM,
-			   read_buf, buf_avail, lsm6dsv16x->streaming_sqe);
-	read_fifo_dout_reg->flags = RTIO_SQE_CHAINED;
-	if (lsm6dsv16x->bus_type == BUS_I2C) {
-		read_fifo_dout_reg->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
-	} else if (lsm6dsv16x->bus_type == BUS_I3C) {
-		read_fifo_dout_reg->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
-	}
-	rtio_sqe_prep_callback_no_cqe(complete_op, lsm6dsv16x_complete_op_cb, (void *)dev,
-				      lsm6dsv16x->streaming_sqe);
-
-	rtio_submit(lsm6dsv16x->rtio_ctx, 0);
+	lsm6dsv16x_rtio_rw_transaction(dev, LSM6DSV16X_FIFO_DATA_OUT_TAG,
+				       read_buf, buf_avail, lsm6dsv16x_complete_op_cb);
 }
 
+/*
+ * Called by bus driver to complete the LSM6DSV16X_STATUS_REG read op.
+ * If drdy_xl is active it reads XL data (6 bytes) from LSM6DSV16X_OUTX_L_A reg.
+ */
+static void lsm6dsv16x_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+{
+	const struct device *dev = arg;
+#if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+	const struct lsm6dsv16x_config *config = dev->config;
+#endif
+	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
+	struct rtio *rtio = lsm6dsv16x->rtio_ctx;
+	struct gpio_dt_spec *irq_gpio = lsm6dsv16x->drdy_gpio;
+	struct sensor_read_config *read_config;
+
+	/* At this point, no sqe request is queued should be considered as a bug */
+	__ASSERT_NO_MSG(lsm6dsv16x->streaming_sqe != NULL);
+
+	read_config = (struct sensor_read_config *)lsm6dsv16x->streaming_sqe->sqe.iodev->data;
+	__ASSERT_NO_MSG(read_config != NULL);
+	__ASSERT_NO_MSG(read_config->is_streaming == true);
+
+	/* parse the configuration in search for any configured trigger */
+	struct sensor_stream_trigger *data_ready = NULL;
+
+	for (int i = 0; i < read_config->count; ++i) {
+		if (read_config->triggers[i].trigger == SENSOR_TRIG_DATA_READY) {
+			data_ready = &read_config->triggers[i];
+			break;
+		}
+	}
+
+	/* flush completion */
+	struct rtio_cqe *cqe;
+	int res = 0;
+
+	do {
+		cqe = rtio_cqe_consume(rtio);
+		if (cqe != NULL) {
+			if ((cqe->result < 0) && (res == 0)) {
+				LOG_ERR("Bus error: %d", cqe->result);
+				res = cqe->result;
+			}
+			rtio_cqe_release(rtio, cqe);
+		}
+	} while (cqe != NULL);
+
+	/* Bail/cancel attempt to read sensor on any error */
+	if (res != 0) {
+		rtio_iodev_sqe_err(lsm6dsv16x->streaming_sqe, res);
+		lsm6dsv16x->streaming_sqe = NULL;
+		return;
+	}
+
+	if (data_ready->opt == SENSOR_STREAM_DATA_NOP ||
+	    data_ready->opt == SENSOR_STREAM_DATA_DROP) {
+		uint8_t *buf;
+		uint32_t buf_len;
+
+		/* Clear streaming_sqe since we're done with the call */
+		if (rtio_sqe_rx_buf(lsm6dsv16x->streaming_sqe, sizeof(struct lsm6dsv16x_rtio_data),
+				    sizeof(struct lsm6dsv16x_rtio_data), &buf, &buf_len) != 0) {
+			rtio_iodev_sqe_err(lsm6dsv16x->streaming_sqe, -ENOMEM);
+			lsm6dsv16x->streaming_sqe = NULL;
+			if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
+				gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+			}
+			return;
+		}
+
+		struct lsm6dsv16x_rtio_data *rx_data = (struct lsm6dsv16x_rtio_data *)buf;
+
+		memset(buf, 0, buf_len);
+		rx_data->header.is_fifo = 0;
+		rx_data->header.timestamp = lsm6dsv16x->timestamp;
+		rx_data->has_accel = 0;
+		rx_data->has_gyro = 0;
+		rx_data->has_temp = 0;
+
+		/* complete request with ok */
+		rtio_iodev_sqe_ok(lsm6dsv16x->streaming_sqe, 0);
+		lsm6dsv16x->streaming_sqe = NULL;
+		if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
+			gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+		}
+	}
+
+	/*
+	 * Read XL data
+	 *
+	 * lsm6dsv16x_data_ready_t drdy;
+	 * if (drdy.drdy_xl) {
+	 */
+	if (lsm6dsv16x->status & 0x1) {
+		uint8_t *buf, *read_buf;
+		uint32_t buf_len;
+		uint32_t req_len = 6 + sizeof(struct lsm6dsv16x_rtio_data);
+
+		if (rtio_sqe_rx_buf(lsm6dsv16x->streaming_sqe,
+				    req_len, req_len, &buf, &buf_len) != 0) {
+			LOG_ERR("Failed to get buffer");
+			rtio_iodev_sqe_err(lsm6dsv16x->streaming_sqe, -ENOMEM);
+			lsm6dsv16x->streaming_sqe = NULL;
+			if (!ON_I3C_BUS(config) || (I3C_INT_PIN(config))) {
+				gpio_pin_interrupt_configure_dt(irq_gpio, GPIO_INT_EDGE_TO_ACTIVE);
+			}
+			return;
+		}
+
+		struct lsm6dsv16x_rtio_data hdr = {
+			.header = {
+				.is_fifo = false,
+				.accel_fs_idx = lsm6dsv16x->accel_fs,
+				.gyro_fs = lsm6dsv16x->gyro_fs,
+				.timestamp = lsm6dsv16x->timestamp,
+			},
+			.has_accel = 1,
+			.has_gyro = 0,
+			.has_temp = 0,
+		};
+
+		memcpy(buf, &hdr, sizeof(hdr));
+		read_buf = (uint8_t *)&((struct lsm6dsv16x_rtio_data *)buf)->acc[0];
+
+		/*
+		 * Prepare rtio enabled bus to read LSM6DSV16X_OUTX_L_A register
+		 * where accelerometer data is available.
+		 * Then lsm6dsv16x_complete_op_cb callback will be invoked.
+		 *
+		 * STMEMSC API equivalent code:
+		 *
+		 *   uint8_t accel_raw[6];
+		 *
+		 *   lsm6dsv16x_acceleration_raw_get(&dev_ctx, accel_raw);
+		 */
+		lsm6dsv16x_rtio_rw_transaction(dev, LSM6DSV16X_OUTX_L_A,
+					       read_buf, 6, lsm6dsv16x_complete_op_cb);
+	}
+}
+
+/*
+ * Called when one of the following trigger is active:
+ *
+ *     - int_fifo_th (SENSOR_TRIG_FIFO_WATERMARK)
+ *     - int_fifo_full (SENSOR_TRIG_FIFO_FULL)
+ *     - int_drdy (SENSOR_TRIG_DATA_READY)
+ */
 void lsm6dsv16x_stream_irq_handler(const struct device *dev)
 {
 	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
-	struct rtio_iodev *iodev = lsm6dsv16x->iodev;
 #if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	const struct lsm6dsv16x_config *config = dev->config;
+	struct rtio *rtio = lsm6dsv16x->rtio_ctx;
 #endif
 	uint64_t cycles;
 	int rc;
@@ -478,53 +688,64 @@ void lsm6dsv16x_stream_irq_handler(const struct device *dev)
 	}
 
 	/* get timestamp as soon as the irq is served */
-	lsm6dsv16x->fifo_timestamp = sensor_clock_cycles_to_ns(cycles);
+	lsm6dsv16x->timestamp = sensor_clock_cycles_to_ns(cycles);
 
+	/* handle FIFO triggers */
+	if (lsm6dsv16x->trig_cfg.int_fifo_th || lsm6dsv16x->trig_cfg.int_fifo_full) {
 #if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
-	if (ON_I3C_BUS(config) && (!I3C_INT_PIN(config))) {
-		/*
-		 * If we are on an I3C bus, then it should be expected that the fifo status was
-		 * already received in the IBI payload and we don't need to read it again.
-		 */
-		lsm6dsv16x->fifo_status[0] = lsm6dsv16x->ibi_payload.fifo_status1;
-		lsm6dsv16x->fifo_status[1] = lsm6dsv16x->ibi_payload.fifo_status2;
-	} else
+		if (ON_I3C_BUS(config) && (!I3C_INT_PIN(config))) {
+			/*
+			 * If we are on an I3C bus, then it should be expected that the fifo status
+			 * was already received in the IBI payload and we don't need to read it
+			 * again.
+			 */
+			lsm6dsv16x->fifo_status[0] = lsm6dsv16x->ibi_payload.fifo_status1;
+			lsm6dsv16x->fifo_status[1] = lsm6dsv16x->ibi_payload.fifo_status2;
+
+			struct rtio_sqe *check_fifo_status_reg = rtio_sqe_acquire(rtio);
+
+			rtio_sqe_prep_callback_no_cqe(check_fifo_status_reg,
+					      lsm6dsv16x_read_fifo_cb, (void *)dev, NULL);
+			rtio_submit(rtio, 0);
+		} else {
 #endif
-	{
-		lsm6dsv16x->fifo_status[0] = lsm6dsv16x->fifo_status[1] = 0;
+			lsm6dsv16x->fifo_status[0] = lsm6dsv16x->fifo_status[1] = 0;
+
+			/*
+			 * Prepare rtio enabled bus to read LSM6DSV16X_FIFO_STATUS1 and
+			 * LSM6DSV16X_FIFO_STATUS2 registers where FIFO threshold condition and
+			 * count are reported. Then lsm6dsv16x_read_fifo_cb callback will be
+			 * invoked.
+			 *
+			 * STMEMSC API equivalent code:
+			 *
+			 *   lsm6dsv16x_fifo_status_t fifo_status;
+			 *
+			 *   lsm6dsv16x_fifo_status_get(&dev_ctx, &fifo_status);
+			 */
+			lsm6dsv16x_rtio_rw_transaction(dev, LSM6DSV16X_FIFO_STATUS1,
+					lsm6dsv16x->fifo_status, 2, lsm6dsv16x_read_fifo_cb);
+#if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
+		}
+#endif
+	}
+
+	/* handle drdy trigger */
+	if (lsm6dsv16x->trig_cfg.int_drdy) {
+		lsm6dsv16x->status = 0;
 
 		/*
-		 * Prepare rtio enabled bus to read LSM6DSV16X_FIFO_STATUS1 and
-		 * LSM6DSV16X_FIFO_STATUS2 registers where FIFO threshold condition and count are
-		 * reported. Then lsm6dsv16x_read_fifo_cb callback will be invoked.
+		 * Prepare rtio enabled bus to read LSM6DSV16X_STATUS_REG register
+		 * where accelerometer and gyroscope data ready status is available.
+		 * Then lsm6dsv16x_read_status_cb callback will be invoked.
 		 *
 		 * STMEMSC API equivalent code:
 		 *
-		 *   lsm6dsv16x_fifo_status_t fifo_status;
+		 *   lsm6dsv16x_data_ready_t drdy;
 		 *
-		 *   lsm6dsv16x_fifo_status_get(&dev_ctx, &fifo_status);
+		 *   lsm6dsv16x_flag_data_ready_get(&dev_ctx, &drdy);
 		 */
-		struct rtio_sqe *write_fifo_status_addr = rtio_sqe_acquire(lsm6dsv16x->rtio_ctx);
-		struct rtio_sqe *read_fifo_status_reg = rtio_sqe_acquire(lsm6dsv16x->rtio_ctx);
-		uint8_t reg = lsm6dsv16x_bus_reg(lsm6dsv16x, LSM6DSV16X_FIFO_STATUS1);
-
-		rtio_sqe_prep_tiny_write(write_fifo_status_addr, iodev, RTIO_PRIO_NORM, &reg, 1,
-					 NULL);
-		write_fifo_status_addr->flags = RTIO_SQE_TRANSACTION;
-		rtio_sqe_prep_read(read_fifo_status_reg, iodev, RTIO_PRIO_NORM,
-				   lsm6dsv16x->fifo_status, 2, NULL);
-		read_fifo_status_reg->flags = RTIO_SQE_CHAINED;
-		if (lsm6dsv16x->bus_type == BUS_I2C) {
-			read_fifo_status_reg->iodev_flags |=
-				RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
-		} else if (lsm6dsv16x->bus_type == BUS_I3C) {
-			read_fifo_status_reg->iodev_flags |=
-				RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
-		}
+		lsm6dsv16x_rtio_rw_transaction(dev, LSM6DSV16X_STATUS_REG,
+					       &lsm6dsv16x->status, 1, lsm6dsv16x_read_status_cb);
 	}
-	struct rtio_sqe *check_fifo_status_reg = rtio_sqe_acquire(lsm6dsv16x->rtio_ctx);
-
-	rtio_sqe_prep_callback_no_cqe(check_fifo_status_reg,
-				      lsm6dsv16x_read_fifo_cb, (void *)dev, NULL);
-	rtio_submit(lsm6dsv16x->rtio_ctx, 0);
 }

--- a/samples/sensor/stream_drdy/CMakeLists.txt
+++ b/samples/sensor/stream_drdy/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(stream_drdy)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/sensor/stream_drdy/README.rst
+++ b/samples/sensor/stream_drdy/README.rst
@@ -1,0 +1,113 @@
+.. zephyr:code-sample:: stream_drdy
+   :name: Generic device sample streaming using Data Ready trigger
+   :relevant-api: sensor_interface
+
+   Get accelerometer data frames from a sensor using SENSOR_TRIG_DATA_READY.
+
+Overview
+********
+
+This sample application demonstrates how to stream accel data using the
+:ref:`RTIO framework <rtio>` based :ref:`Read and Decode method <sensor-read-and-decode>`.
+
+The streaming is started using the sensor_stream() API and it is self-sustained by the
+SENSOR_TRIG_DATA_READY trigger.
+
+Currently the sample gets/prints data only for the accel sensor channel:
+
+        - SENSOR_CHAN_ACCEL_XYZ
+
+Building and Running
+********************
+
+This sample supports up to 10 streaming devices. Each device needs
+to be aliased as ``streamN`` where ``N`` goes from ``0`` to ``9``. For example:
+
+.. code-block:: devicetree
+
+  / {
+      aliases {
+                   stream0 = &lsm6dsv16x_6b_x_nucleo_iks4a1;
+              };
+      };
+
+Example devicetree overlays and configurations are already available for sensortile_box_pro,
+nucleo_f401re and nucleo_h503rb in the boards directory:
+
+- :zephyr_file:`samples/sensor/stream_drdy/boards/sensortile_box_pro.overlay`
+
+  DT overlay file for the sensortile_box_pro board.
+
+- :zephyr_file:`samples/sensor/stream_drdy/boards/sensortile_box_pro.conf`
+
+  Configuration file for the sensortile_box_pro board.
+
+- :zephyr_file:`samples/sensor/stream_drdy/boards/nucleo_f401re.overlay`
+
+  DT overlay file for the nucleo_f401re board.
+
+- :zephyr_file:`samples/sensor/stream_drdy/boards/nucleo_f401re.conf`
+
+  Configuration file for the nucleo_f401re board.
+
+- :zephyr_file:`samples/sensor/stream_drdy/boards/nucleo_h503rb.overlay`
+
+  DT overlay file for the nucleo_h503rb board.
+
+- :zephyr_file:`samples/sensor/stream_drdy/boards/nucleo_h503rb.conf`
+
+  Configuration file for the nucleo_h503rb board.
+
+For example, build and run sample for sensortile_box_pro with:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/stream_drdy
+   :board: sensortile_box_pro
+   :goals: build flash
+   :compact:
+
+Sample Output
+=============
+
+The following example output is for a lsm6dsv16x IMU device with accelerometer sensor.
+The board used is a sensortile_box_pro.
+
+.. code-block:: console
+
+XL data for lsm6dsv16x@0 7320515312ns (-0.387584, 0.224894, 9.766184)
+XL data for lsm6dsv16x@0 7321538600ns (-0.363659, 0.282314, 9.948014)
+XL data for lsm6dsv16x@0 7322561362ns (-0.301454, 0.172259, 9.775754)
+XL data for lsm6dsv16x@0 7323584881ns (-0.210539, 0.153119, 9.857099)
+XL data for lsm6dsv16x@0 7324608368ns (-0.287099, 0.167474, 9.852314)
+XL data for lsm6dsv16x@0 7325631281ns (-0.306239, 0.181829, 9.847529)
+XL data for lsm6dsv16x@0 7326654425ns (-0.272744, 0.167474, 9.842744)
+XL data for lsm6dsv16x@0 7327677993ns (-0.296669, 0.224894, 9.981509)
+XL data for lsm6dsv16x@0 7328701506ns (-0.282314, 0.210539, 9.828389)
+XL data for lsm6dsv16x@0 7329724306ns (-0.244034, 0.153119, 9.866669)
+XL data for lsm6dsv16x@0 7330747556ns (-0.234464, 0.119624, 9.780539)
+XL data for lsm6dsv16x@0 7331771000ns (-0.239249, 0.148334, 9.933659)
+XL data for lsm6dsv16x@0 7332794575ns (-0.220109, 0.119624, 9.833174)
+XL data for lsm6dsv16x@0 7333817437ns (-0.205754, 0.119624, 9.823604)
+XL data for lsm6dsv16x@0 7334840643ns (-0.205754, 0.148334, 9.866669)
+XL data for lsm6dsv16x@0 7335864162ns (-0.186614, 0.129194, 9.861884)
+XL data for lsm6dsv16x@0 7336887593ns (-0.196184, 0.110054, 9.804464)
+XL data for lsm6dsv16x@0 7337910356ns (-0.181829, 0.133979, 9.938444)
+XL data for lsm6dsv16x@0 7338933650ns (-0.215324, 0.081344, 9.536504)
+XL data for lsm6dsv16x@0 7339957075ns (-0.157904, 0.119624, 9.995864)
+XL data for lsm6dsv16x@0 7340980675ns (-0.205754, 0.110054, 9.809249)
+XL data for lsm6dsv16x@0 7342003487ns (-0.177044, 0.143549, 9.971939)
+XL data for lsm6dsv16x@0 7343026593ns (-0.172259, 0.100484, 9.794894)
+XL data for lsm6dsv16x@0 7344050168ns (-0.177044, 0.124409, 9.881024)
+XL data for lsm6dsv16x@0 7345073643ns (-0.191399, 0.124409, 9.986294)
+XL data for lsm6dsv16x@0 7346096587ns (-0.191399, 0.105269, 9.790109)
+
+References
+==========
+
+.. target-notes::
+
+.. _RTIO framework:
+   https://docs.zephyrproject.org/latest/services/rtio/index.html
+
+.. _x-nucleo-iks4a1:
+   http://www.st.com/en/ecosystems/x-nucleo-iks4a1.html

--- a/samples/sensor/stream_drdy/boards/nucleo_f401re.conf
+++ b/samples/sensor/stream_drdy/boards/nucleo_f401re.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_RTIO=y
+CONFIG_LSM6DSV16X_STREAM=y
+CONFIG_LSM6DSV16X_ENABLE_TEMP=y

--- a/samples/sensor/stream_drdy/boards/nucleo_f401re.overlay
+++ b/samples/sensor/stream_drdy/boards/nucleo_f401re.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
+
+
+/*
+ * Nucleo F401RE board + shield iks4a1
+ *
+ * This devicetree overlay file will be automatically picked by the Zephyr
+ * build system when building the sample for the nucleo_f401re board.
+ */
+
+/ {
+	aliases {
+		stream0 = &lsm6dsv16x_6b_x_nucleo_iks4a1;
+	};
+};
+
+&arduino_i2c {
+	lsm6dsv16x_6b_x_nucleo_iks4a1: lsm6dsv16x@6b {
+		compatible = "st,lsm6dsv16x";
+		reg = <0x6b>;
+		accel-odr = <LSM6DSV16X_DT_ODR_AT_120Hz>;
+		accel-range = <LSM6DSV16X_DT_FS_16G>;
+		int2-gpios =  <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 (PB5) */
+		drdy-pin = <2>;
+		drdy-pulsed;
+	};
+};

--- a/samples/sensor/stream_drdy/boards/nucleo_h503rb.conf
+++ b/samples/sensor/stream_drdy/boards/nucleo_h503rb.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_I2C_RTIO=y
+CONFIG_LSM6DSV16X_STREAM=y
+CONFIG_LSM6DSV16X_ENABLE_TEMP=y

--- a/samples/sensor/stream_drdy/boards/nucleo_h503rb.overlay
+++ b/samples/sensor/stream_drdy/boards/nucleo_h503rb.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
+
+
+/*
+ * Nucleo F401RE board + shield iks4a1
+ *
+ * This devicetree overlay file will be automatically picked by the Zephyr
+ * build system when building the sample for the nucleo_f401re board.
+ */
+
+/ {
+	aliases {
+		stream0 = &lsm6dsv16x_6b_x_nucleo_iks4a1;
+	};
+};
+
+&arduino_i2c {
+	lsm6dsv16x_6b_x_nucleo_iks4a1: lsm6dsv16x@6b {
+		compatible = "st,lsm6dsv16x";
+		reg = <0x6b>;
+		accel-odr = <LSM6DSV16X_DT_ODR_AT_120Hz>;
+		accel-range = <LSM6DSV16X_DT_FS_16G>;
+		int2-gpios =  <&arduino_header 10 GPIO_ACTIVE_HIGH>; /* D4 (PB5) */
+		drdy-pin = <2>;
+		drdy-pulsed;
+	};
+};

--- a/samples/sensor/stream_drdy/boards/sensortile_box_pro.conf
+++ b/samples/sensor/stream_drdy/boards/sensortile_box_pro.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_RTIO=y
+CONFIG_LSM6DSV16X_STREAM=y
+CONFIG_LSM6DSV16X_ENABLE_TEMP=y

--- a/samples/sensor/stream_drdy/boards/sensortile_box_pro.overlay
+++ b/samples/sensor/stream_drdy/boards/sensortile_box_pro.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/dt-bindings/sensor/lsm6dsv16x.h>
+
+
+/*
+ * This devicetree overlay file will be automatically picked by the Zephyr
+ * build system when building the sample for the sensortile_box_pro board.
+ */
+
+/ {
+	aliases {
+		stream0 = &lsm6dsv16x_0;
+	};
+};
+
+&spi2 {
+	lsm6dsv16x_0: lsm6dsv16x@0 {
+		compatible = "st,lsm6dsv16x";
+
+		accel-odr = <LSM6DSV16X_DT_ODR_AT_960Hz>;
+		accel-range = <LSM6DSV16X_DT_FS_16G>;
+	};
+};

--- a/samples/sensor/stream_drdy/prj.conf
+++ b/samples/sensor/stream_drdy/prj.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_STDOUT_CONSOLE=y
+CONFIG_SENSOR=y
+CONFIG_SENSOR_ASYNC_API=y
+CONFIG_CBPRINTF_FP_SUPPORT=y

--- a/samples/sensor/stream_drdy/sample.yaml
+++ b/samples/sensor/stream_drdy/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: Stream sample on Data Ready trigger
+tests:
+  sample.sensor.stream_drdy:
+    harness: console
+    tags: sensors
+    filter: dt_alias_exists("stream0")
+    harness_config:
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+           \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"

--- a/samples/sensor/stream_drdy/src/main.c
+++ b/samples/sensor/stream_drdy/src/main.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/kernel.h>
+#include <zephyr/rtio/rtio.h>
+#include <zephyr/drivers/sensor.h>
+
+#define STREAMDEV_ALIAS(i) DT_ALIAS(_CONCAT(stream, i))
+#define STREAMDEV_DEVICE(i, _) \
+	IF_ENABLED(DT_NODE_EXISTS(STREAMDEV_ALIAS(i)), (DEVICE_DT_GET(STREAMDEV_ALIAS(i)),))
+#define NUM_SENSORS 1
+
+/* support up to 10 sensors */
+static const struct device *const sensors[] = { LISTIFY(10, STREAMDEV_DEVICE, ()) };
+
+#define STREAM_IODEV_SYM(id) CONCAT(accel_iodev, id)
+#define STREAM_IODEV_PTR(id, _) &STREAM_IODEV_SYM(id)
+
+#define STREAM_TRIGGERS					   \
+	{ SENSOR_TRIG_DATA_READY, SENSOR_STREAM_DATA_INCLUDE }
+
+#define STREAM_DEFINE_IODEV(id, _)    \
+	SENSOR_DT_STREAM_IODEV(	      \
+		STREAM_IODEV_SYM(id), \
+		STREAMDEV_ALIAS(id),  \
+		STREAM_TRIGGERS);
+
+LISTIFY(NUM_SENSORS, STREAM_DEFINE_IODEV, (;));
+
+struct rtio_iodev *iodevs[NUM_SENSORS] = { LISTIFY(NUM_SENSORS, STREAM_IODEV_PTR, (,)) };
+
+RTIO_DEFINE_WITH_MEMPOOL(stream_ctx, NUM_SENSORS, NUM_SENSORS,
+			 NUM_SENSORS * 20, 256, sizeof(void *));
+
+struct sensor_chan_spec accel_chan = { SENSOR_CHAN_ACCEL_XYZ, 0 };
+
+static uint8_t accel_buf[128] = { 0 };
+
+static int print_accels_stream(const struct device *dev, struct rtio_iodev *iodev)
+{
+	int rc = 0;
+	const struct sensor_decoder_api *decoder;
+	struct rtio_cqe *cqe;
+	uint8_t *buf;
+	uint32_t buf_len;
+	struct rtio_sqe *handles[NUM_SENSORS];
+	struct sensor_three_axis_data *accel_data = (struct sensor_three_axis_data *)accel_buf;
+
+	/* Start the streams */
+	for (int i = 0; i < NUM_SENSORS; i++) {
+		printk("sensor_stream\n");
+		sensor_stream(iodevs[i], &stream_ctx, NULL, &handles[i]);
+	}
+
+	while (1) {
+		cqe = rtio_cqe_consume_block(&stream_ctx);
+
+		if (cqe->result != 0) {
+			printk("async read failed %d\n", cqe->result);
+			return cqe->result;
+		}
+
+		rc = rtio_cqe_get_mempool_buffer(&stream_ctx, cqe, &buf, &buf_len);
+
+		if (rc != 0) {
+			printk("get mempool buffer failed %d\n", rc);
+			return rc;
+		}
+
+		const struct device *sensor = dev;
+
+		rtio_cqe_release(&stream_ctx, cqe);
+
+		rc = sensor_get_decoder(sensor, &decoder);
+
+		if (rc != 0) {
+			printk("sensor_get_decoder failed %d\n", rc);
+			return rc;
+		}
+
+		/* Frame iterator values */
+		uint32_t accel_fit = 0;
+
+		/* Number of sensor data frames */
+		uint16_t xl_count, frame_count;
+
+		rc = decoder->get_frame_count(buf, accel_chan, &xl_count);
+
+		if (rc != 0) {
+			printk("sensor_get_frame failed %d\n", rc);
+			return rc;
+		}
+
+		frame_count = xl_count;
+
+		/* If a tap has occurred lets print it out */
+		if (decoder->has_trigger(buf, SENSOR_TRIG_TAP)) {
+			printk("Tap! Sensor %s\n", dev->name);
+		}
+
+
+		int8_t c = 0;
+
+		/* decode and print Accelerometer frames */
+		c = decoder->decode(buf, accel_chan, &accel_fit, 1, accel_data);
+
+		printk("XL data for %s %lluns (%" PRIq(6) ", %" PRIq(6)
+		       ", %" PRIq(6) ")\n", dev->name,
+		       PRIsensor_three_axis_data_arg(*accel_data, 0));
+
+		rtio_release_buffer(&stream_ctx, buf, buf_len);
+	}
+
+	return rc;
+}
+
+static int check_sensor_is_off(const struct device *dev)
+{
+	int ret;
+	struct sensor_value odr;
+
+	ret = sensor_attr_get(dev, SENSOR_CHAN_ACCEL_XYZ, SENSOR_ATTR_SAMPLING_FREQUENCY, &odr);
+
+	/* Check if accel is off */
+	if (ret != 0 || (odr.val1 == 0 && odr.val2 == 0)) {
+		printk("%s WRN : accelerometer device is off\n", dev->name);
+	}
+
+	return 0;
+}
+
+int main(void)
+{
+	int ret;
+
+	for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
+		if (!device_is_ready(sensors[i])) {
+			printk("sensor: device %s not ready.\n", sensors[i]->name);
+			return 0;
+		}
+		check_sensor_is_off(sensors[i]);
+	}
+
+	while (1) {
+		for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
+			ret = print_accels_stream(sensors[i], iodevs[i]);
+
+			if (ret < 0) {
+				return 0;
+			}
+		}
+		k_msleep(1000);
+	}
+	return 0;
+}

--- a/samples/sensor/stream_fifo/README.rst
+++ b/samples/sensor/stream_fifo/README.rst
@@ -8,7 +8,8 @@
 Overview
 ********
 
-This sample application demonstrates how to stream FIFO data using the :ref:`RTIO framework <rtio>`.
+This sample application demonstrates how to stream FIFO data using the
+:ref:`RTIO framework <rtio>` based :ref:`Read and Decode method <sensor-read-and-decode>`.
 
 The streaming is started using the sensor_stream() API and it is self-sustained by the
 SENSOR_TRIG_FIFO_WATERMARK trigger.
@@ -39,8 +40,16 @@ to be aliased as :samp:`stream{N}` where ``N`` goes from ``0`` to ``9``. For exa
 .. note::
     Note that NUM_SENSORS defined in main.c must match ``N`` and should be set accordingly.
 
-Example devicetree overlays and configurations are already available for nucleo_f401re and
-nucleo_h503rb in the boards directory:
+Example devicetree overlays and configurations are already available for sensortile_box_pro,
+nucleo_f401re and nucleo_h503rb in the boards directory:
+
+- :zephyr_file:`samples/sensor/stream_fifo/boards/sensortile_box_pro.overlay`
+
+  DT overlay file for the sensortile_box_pro board.
+
+- :zephyr_file:`samples/sensor/stream_fifo/boards/sensortile_box_pro.conf`
+
+  Configuration file for the sensortile_box_pro board.
 
 - :zephyr_file:`samples/sensor/stream_fifo/boards/nucleo_f401re.overlay`
 


### PR DESCRIPTION
Added SENSOR_TRIG_DATA_READY trigger support to RTIO streaming.
Currently it just handle XL drdy.

Added also stream_drdy sample to exercise it.
Tested on sensortile_box_pro:

west build -b sensortile_box_pro samples/sensor/stream_drdy/
west flash

XL data for lsm6dsv16x@0 75420309764ns (0.913934, 0.401939, 9.943229)
XL data for lsm6dsv16x@0 75421332908ns (0.990494, 0.382799, 9.962369)
XL data for lsm6dsv16x@0 75422356101ns (1.023989, 0.392369, 9.943229)
XL data for lsm6dsv16x@0 75423379283ns (1.019204, 0.411509, 9.895379)
XL data for lsm6dsv16x@0 75424402739ns (1.100549, 0.449789, 9.861884)
XL data for lsm6dsv16x@0 75425426308ns (1.129259, 0.449789, 9.790109)
[...]