### PR TITLE
drivers: i2c_nrfx_twi_rtio: Fix missing completion on i2c_configure

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -80,7 +80,11 @@ static bool i2c_nrfx_twi_rtio_start(const struct device *dev)
 						   sqe->tx.buf_len, dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		(void)i2c_nrfx_twi_configure(dev, sqe->i2c_config);
-		return false;
+		/** This request will not generate an event therefore, this
+		 * code immediately submits a CQE in order to unblock
+		 * i2c_rtio_configure.
+		 */
+		return i2c_rtio_complete(ctx, 0);
 	case RTIO_OP_I2C_RECOVER:
 		(void)i2c_nrfx_twi_recover_bus(dev);
 		return false;

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -100,7 +100,11 @@ static bool i2c_nrfx_twim_rtio_start(const struct device *dev)
 						    dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		(void)i2c_nrfx_twim_configure(dev, sqe->i2c_config);
-		return false;
+		/** This request will not generate an event therefore, this
+		 * code immediately submits a CQE in order to unblock
+		 * i2c_rtio_configure.
+		 */
+		return i2c_rtio_complete(ctx, 0);
 	case RTIO_OP_I2C_RECOVER:
 		(void)i2c_nrfx_twim_recover_bus(dev);
 		return false;


### PR DESCRIPTION
### Description
This patch adds the missing completion call to the RTIO_OP_I2C_CONFIGURE OPs. Without this, the drivers will lock when calling i2c_configure().

### Testing

Run i2c_ram test both with i2c_nrfx_twi_rtio and i2c_nrfx_twim_rtio drivers and confirm the test passes (previously would lock up)

Build command:
``` console
west build -b nrf52840dk/nrf52840 tests/drivers/i2c/i2c_ram/ -- -DCONFIG_I2C_RTIO=y
```

Output after the fix:
``` console
*** Booting Zephyr OS build v4.1.0-2109-g4925e22a6798 ***
Running TESTSUITE i2c_ram
===================================================================
START - test_ram_rtio
submitting write from thread 0x20000868 addr 7
 PASS - test_ram_rtio in 0.007 seconds
===================================================================
START - test_ram_rtio_isr
timer submitting write, addr e
timer checking write result, submitting read
read command complete
read data complete
 PASS - test_ram_rtio_isr in 0.015 seconds
===================================================================
START - test_ram_transfer
ram using i2c_transfer from thread 0x20000868 addr 15
 PASS - test_ram_transfer in 0.008 seconds
===================================================================
START - test_ram_write_read
ram using i2c_write and i2c_write_read from thread 0x20000868 addr 1c
 PASS - test_ram_write_read in 0.009 seconds
===================================================================
TESTSUITE i2c_ram succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [i2c_ram]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.039 seconds
 - PASS - [i2c_ram.test_ram_rtio] duration = 0.007 seconds
 - PASS - [i2c_ram.test_ram_rtio_isr] duration = 0.015 seconds
 - PASS - [i2c_ram.test_ram_transfer] duration = 0.008 seconds
 - PASS - [i2c_ram.test_ram_write_read] duration = 0.009 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```