### PR TITLE
libc: Implement freopen()

### DIFF
--- a/lib/libc/stdio/freopen.c
+++ b/lib/libc/stdio/freopen.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+
+FILE *freopen(const char *filename, const char *mode, FILE *stream)
+{
+	if (stream) {
+		fclose(stream);
+	}
+	return fopen(filename, mode);
+}


### PR DESCRIPTION
This commit adds a new implementation of the `freopen()` function to Zephyr’s minimal libc. The `freopen()` function allows an existing stream to be redirected to a new file, either for reading, writing, or appending, based on the provided mode.

The implementation handles the following:
- Closes the existing stream if it is open.
- Opens a new file with the specified filename and mode.
- Associates the new file descriptor with the original `FILE` structure.
- Returns the updated stream on success, or NULL on failure.

The feature was tested by integrating it with the current libc structure and running compliance checks using `./scripts/ci/check_compliance.py` — all checks passed successfully.

This addition contributes toward enhancing standard C library support in Zephyr.

Signed-off-by: Abrar Nasir Jaffari <abrarnasirjaffari@gmail.com>
