### PR TITLE
devicetree: Add descriptive error for DT_DRV_COMPAT failure

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -4982,11 +4982,20 @@
  * @param fn Macro to call for each enabled node. Must accept an
  *           instance number as its only parameter.
  */
-#define DT_INST_FOREACH_STATUS_OKAY(fn) \
+#if defined(DT_DRV_COMPAT)
+#define DT_INST_FOREACH_STATUS_OKAY(fn)                         \
 	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT),	\
 		    (UTIL_CAT(DT_FOREACH_OKAY_INST_,		\
 			      DT_DRV_COMPAT)(fn)),		\
-		    ())
+		())
+#else
+#define DT_INST_FOREACH_STATUS_OKAY(fn)                         \
+	COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT),	\
+		    (UTIL_CAT(DT_FOREACH_OKAY_INST_,		\
+			      DT_DRV_COMPAT)(fn)),		\
+		(BUILD_ASSERT(0, "DT_DRV_COMPAT check failed! "	\
+			"- are there any compatible nodes enabled in the devicetree?");))
+#endif
 
 /**
  * @brief Call @p fn on all nodes with compatible `DT_DRV_COMPAT`


### PR DESCRIPTION
Add a descriptive error in the case that a user attempts to use DT_INST_FOREACH_STATUS_OKAY when DT_DRV_COMPAT has not been defined, a common pitfall when developing a device driver.

The original error message resulting from this makes reference to a missing devicetree node, but does not give any hints as to the root of the error. An updated BUILT_ASSERT message could help point the developer in the right direction.

Error Before:
```
[143/148] Linking C executable zephyr/zephyr_pre0.elf
FAILED: zephyr/zephyr_pre0.elf zephyr/zephyr_pre0.map /home/skyer/zephyrproject/zephyr/build/zephyr/zephyr_pre0.map 
: && ccache /home/skyer/zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc  -gdwarf-4 zephyr/CMakeFiles/zephyr_pre0.dir/misc/empty_file.c.obj -o zephyr/zephyr_pre0.elf  zephyr/CMakeFiles/offsets.dir/./arch/arm/core/offsets/offsets.c.obj  -T  zephyr/linker_zephyr_pre0.cmd  -Wl,-Map=/home/skyer/zephyrproject/zephyr/build/zephyr/zephyr_pre0.map  -Wl,--whole-archive  app/libapp.a  zephyr/libzephyr.a  zephyr/arch/common/libarch__common.a  zephyr/arch/arch/arm/core/libarch__arm__core.a  zephyr/arch/arch/arm/core/cortex_m/libarch__arm__core__cortex_m.a  zephyr/lib/libc/picolibc/liblib__libc__picolibc.a  zephyr/lib/libc/common/liblib__libc__common.a  zephyr/drivers/clock_control/libdrivers__clock_control.a  zephyr/drivers/console/libdrivers__console.a  zephyr/drivers/gpio/libdrivers__gpio.a  zephyr/drivers/pinctrl/libdrivers__pinctrl.a  zephyr/drivers/serial/libdrivers__serial.a  zephyr/drivers/timer/libdrivers__timer.a  -Wl,--no-whole-archive  zephyr/kernel/libkernel.a  -L/home/skyer/zephyrproject/zephyr/build/zephyr  zephyr/arch/common/libisr_tables.a  -mcpu=cortex-m4  -mthumb  -mabi=aapcs  -mfp16-format=ieee  -mtp=soft  -fuse-ld=bfd  -Wl,--gc-sections  -Wl,--build-id=none  -Wl,--sort-common=descending  -Wl,--sort-section=alignment  -Wl,-u,_OffsetAbsSyms  -Wl,-u,_ConfigAbsSyms  -nostdlib  -static  -Wl,-X  -Wl,-N  -Wl,--orphan-handling=warn  -Wl,-no-pie  -specs=picolibc.specs  -DPICOLIBC_LONG_LONG_PRINTF_SCANF -L"/home/skyer/zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/thumb/v7e-m/nofp" -lc -lgcc && cd /home/skyer/zephyrproject/zephyr/build/zephyr && /usr/bin/cmake -E true
/home/skyer/zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/drivers/console/libdrivers__console.a(uart_console.c.obj): in function `uart_console_init':
/home/skyer/zephyrproject/zephyr/drivers/console/uart_console.c:609: undefined reference to `__device_dts_ord_39'
/home/skyer/zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/drivers/console/libdrivers__console.a(uart_console.c.obj): in function `console_out':
/home/skyer/zephyrproject/zephyr/drivers/console/uart_console.c:111: undefined reference to `__device_dts_ord_39'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/skyer/zephyrproject/zephyr/build
```

Error After:
```
In file included from /home/skyer/zephyrproject/zephyr/include/zephyr/sys/util_macro.h:34,
                 from /home/skyer/zephyrproject/zephyr/include/zephyr/irq_multilevel.h:16,
                 from /home/skyer/zephyrproject/zephyr/include/zephyr/devicetree.h:20,
                 from /home/skyer/zephyrproject/zephyr/include/zephyr/device.h:12,
                 from /home/skyer/zephyrproject/zephyr/include/zephyr/drivers/pinctrl.h:25,
                 from /home/skyer/zephyrproject/zephyr/drivers/serial/uart_max32.c:11:
/home/skyer/zephyrproject/zephyr/include/zephyr/toolchain/gcc.h:87:36: error: static assertion failed: "DT_DRV_COMPAT check failed! - are there any compatible nodes enabled in the devicetree?"
   87 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert((EXPR), "" MSG)
      |                                    ^~~~~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:72:26: note: in definition of macro '__DEBRACKET'
   72 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/include/zephyr/sys/util_internal.h:59:9: note: in expansion of macro '__COND_CODE'
   59 |         __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/include/zephyr/sys/util_macro.h:204:9: note: in expansion of macro 'Z_COND_CODE_1'
  204 |         Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/include/zephyr/devicetree.h:4986:9: note: in expansion of macro 'COND_CODE_1'
 4986 |         COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT),   \
      |         ^~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/include/zephyr/devicetree.h:4989:22: note: in expansion of macro 'BUILD_ASSERT'
 4989 |                     (BUILD_ASSERT(0, L"DT_DRV_COMPAT check failed! - are there any compatible nodes enabled in the devicetree?");))
      |                      ^~~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/drivers/serial/uart_max32.c:1058:1: note: in expansion of macro 'DT_INST_FOREACH_STATUS_OKAY'
 1058 | DT_INST_FOREACH_STATUS_OKAY(MAX32_UART_INIT)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/skyer/zephyrproject/zephyr/drivers/serial/uart_max32.c:271:12: warning: 'uart_max32_init' defined but not used [-Wunused-function]
  271 | static int uart_max32_init(const struct device *dev)
      |            ^~~~~~~~~~~~~~~
[134/148] Building C object zephyr/kernel/CMakeFiles/kernel.dir/sched.c.obj
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/skyer/zephyrproject/zephyr/build
```


(when removing `#define DT_DRV_COMPAT adi_max32_uart` and trying to build `hello-world`)