### PR TITLE
fix: i2c_nrfx_twi_rtio: Fix Multi-write transactions

### DIFF
--- a/drivers/i2c/i2c_nrfx_twi_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twi_rtio.c
@@ -41,6 +41,8 @@ static bool i2c_nrfx_twi_rtio_msg_start(const struct device *dev, uint8_t flags,
 	struct i2c_nrfx_twi_rtio_data *const dev_data = dev->data;
 	struct i2c_rtio *ctx = dev_data->ctx;
 	int ret = 0;
+	bool more_msgs = (rtio_txn_next(ctx->txn_curr) != NULL) &&
+			 ((ctx->txn_curr->next->sqe.iodev_flags & RTIO_IODEV_I2C_RESTART) == 0);
 
 	/** Enabling while already enabled ends up in a failed assertion: skip it. */
 	if (!dev_data->twi_enabled) {
@@ -48,7 +50,7 @@ static bool i2c_nrfx_twi_rtio_msg_start(const struct device *dev, uint8_t flags,
 		dev_data->twi_enabled = true;
 	}
 
-	ret = i2c_nrfx_twi_msg_transfer(dev, flags, buf, buf_len, i2c_addr, false);
+	ret = i2c_nrfx_twi_msg_transfer(dev, flags, buf, buf_len, i2c_addr, more_msgs);
 	if (ret != 0) {
 		nrfx_twi_disable(&config->twi);
 		dev_data->twi_enabled = false;


### PR DESCRIPTION
### Description

This PR fixes i2c_nrfx_twi_rtio driver to properly handle I2C transfers consisting of multiple write commands, as in the following example:
``` console
	/** Specify Reg addr to write */
	rtio_sqe_prep_write(wraddr_sqe, ...);
	wraddr_sqe->flags |= RTIO_SQE_TRANSACTION;

	/** Register data buffer to write starting at that address */
	rtio_sqe_prep_write(wrdata_sqe, ...);
```
Furthermore, this scenario is captured as a separate testcase under i2c_ram tests, so that this can be validated on other implementations.

> [!NOTE]
> Depends on #88380. Marking as DNM until that PR lands.

### Testing
Ran i2c_ram RTIO tests with nRF52840 DK, validating passing.
The following scope captures display the fix:
- Before the fix (Transfer is restarted between both requests):
![image](https://github.com/user-attachments/assets/b885cbc2-c734-4624-bc36-61270ddb9074)
- After the fix (Both requests are handled without a restart):
![image](https://github.com/user-attachments/assets/ab3221b6-c488-42da-8e4c-350e98f8c699)
- Build:
``` console
west build -b nrf52840dk/nrf52840 tests/drivers/i2c/i2c_ram -- -DCONFIG_I2C_RTIO=y
```
- Console output (after the fix):
``` console
*** Booting Zephyr OS build v4.1.0-2211-gb7199632d2c7 ***
Running TESTSUITE i2c_ram
===================================================================
START - test_ram_rtio
submitting write from thread 0x20000870 addr 7
 PASS - test_ram_rtio in 0.007 seconds
===================================================================
START - test_ram_rtio_isr
timer submitting write, addr e
timer checking write result, submitting read
read command complete
read data complete
 PASS - test_ram_rtio_isr in 0.016 seconds
===================================================================
START - test_ram_rtio_write_with_transaction
submitting write from thread 0x20000870 addr 15
 PASS - test_ram_rtio_write_with_transaction in 0.007 seconds
===================================================================
START - test_ram_transfer
ram using i2c_transfer from thread 0x20000870 addr 1c
 PASS - test_ram_transfer in 0.008 seconds
===================================================================
START - test_ram_write_read
ram using i2c_write and i2c_write_read from thread 0x20000870 addr 23
 PASS - test_ram_write_read in 0.009 seconds
===================================================================
TESTSUITE i2c_ram succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [i2c_ram]: pass = 5, fail = 0, skip = 0, total = 5 duration = 0.047 seconds
 - PASS - [i2c_ram.test_ram_rtio] duration = 0.007 seconds
 - PASS - [i2c_ram.test_ram_rtio_isr] duration = 0.016 seconds
 - PASS - [i2c_ram.test_ram_rtio_write_with_transaction] duration = 0.007 seconds
 - PASS - [i2c_ram.test_ram_transfer] duration = 0.008 seconds
 - PASS - [i2c_ram.test_ram_write_read] duration = 0.009 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
