### PR TITLE
drivers: flash: flexspi: Fix XIP during flash write

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -431,6 +431,7 @@ static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset
 		 * code and data accessed must reside in ram.
 		 */
 		key = irq_lock();
+		memc_flexspi_wait_bus_idle(&data->controller);
 	}
 
 	/* Clock FlexSPI at 84 MHZ (42MHz SCLK in DDR mode) */
@@ -447,6 +448,12 @@ static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_HYPERFLASH_WRITE_BUFFER
 		for (j = 0; j < i; j++) {
 			hyperflash_write_buf[j] = src[j];
+		}
+		/* As memcpy could cause an XIP access,
+		 * we need to wait for XIP prefetch to be finished again
+		 */
+		if (memc_flexspi_is_running_xip(&data->controller)) {
+			memc_flexspi_wait_bus_idle(&data->controller);
 		}
 #endif
 		ret = flash_flexspi_hyperflash_write_enable(dev, offset);
@@ -527,6 +534,7 @@ static int flash_flexspi_hyperflash_erase(const struct device *dev, off_t offset
 		 * code and data accessed must reside in ram.
 		 */
 		key = irq_lock();
+		memc_flexspi_wait_bus_idle(&data->controller);
 	}
 
 	for (i = 0; i < num_sectors; i++) {

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -390,6 +390,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		 * code and data accessed must reside in ram.
 		 */
 		key = irq_lock();
+		memc_flexspi_wait_bus_idle(data->controller);
 	}
 	if (IS_ENABLED(CONFIG_FLASH_MCUX_FLEXSPI_MX25UM51345G_OPI_DTR)) {
 		/* Check that write size and length are even */
@@ -406,6 +407,12 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		i = MIN(SPI_NOR_PAGE_SIZE - (offset % SPI_NOR_PAGE_SIZE), len);
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
 		memcpy(nor_write_buf, src, i);
+		/* As memcpy could cause an XIP access,
+		 * we need to wait for XIP prefetch to be finished again
+		 */
+		if (memc_flexspi_is_running_xip(data->controller)) {
+			memc_flexspi_wait_bus_idle(data->controller);
+		}
 #endif
 		flash_flexspi_nor_write_enable(dev, true);
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_NOR_WRITE_BUFFER
@@ -461,6 +468,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		 * code and data accessed must reside in ram.
 		 */
 		key = irq_lock();
+		memc_flexspi_wait_bus_idle(data->controller);
 	}
 
 	if ((offset == 0) && (size == data->config.flashSize * KB(1))) {


### PR DESCRIPTION
Commit 857e5793f1b15c5517ef85e0041fe248d39ac777 fixes the `flash_mcux_flexspi_nor.c` driver to wait for the FlexSPI to be idle before performing write/erase operations. Add a similar check to these drivers that also use the FlexSPI NOR block.