### PR TITLE
drivers: spi: nxp: fix PCS broken issue during SPI transfer and PCS_HOLD_ON support

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Short J17-pin4 and J17-pin5, populate R356, R350,R346, R362 to enable Pins for SPI1. */
 &lpspi1 {
 	slow@0 {
 		compatible = "test-spi-loopback-slow";

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -1,9 +1,10 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Short J10-pin8 and J10-pin10. */
 &lpspi1 {
 	dmas = <&edma0 0 36>, <&edma0 1 37>;
 	dma-names = "rx", "tx";


### PR DESCRIPTION
 drivers: spi: nxp: fix PCS broken issue during SPI transfer and PCS_HOLD_ON support


Different LPSPI IPs are used for RT11xx and MCXN. On a older version of LPSPI, a transmit command or a TX data need to be issued to end a frame. On a new version, no such requirement.

Based on above information, we have to make DMA transfers "cascade" in the DMA ISR to keep CS asserted during the whole SPI transfer.

PCS_HOLD_ON is a feature to keep CS asserted during multi SPI transfers. It is implemented and supported on new LPSPI IP but it is impossible to be supported on an older version like RT11xx.

This patch did not add PCS_HOLD_ON support for cpu mode driver, will introduce another PR to complete it.
This patch has been verified on RT1170 EVK board and MCXN947 FRD board with spi_loopback test.