### PR TITLE
sensor: additional conversion functions

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -156,6 +156,11 @@ New APIs and options
 
     * :kconfig:option:`CONFIG_NET_SOCKETS_INET_RAW`
 
+* Sensor
+
+  * :c:func:`sensor_value_to_deci`
+  * :c:func:`sensor_value_to_centi`
+
 * Stepper
 
   * :c:func:`stepper_stop()`

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1469,6 +1469,28 @@ struct sensor_info {
 	SENSOR_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
+ * @brief Helper function for converting struct sensor_value to integer deci units.
+ *
+ * @param val A pointer to a sensor_value struct.
+ * @return The converted value.
+ */
+static inline int64_t sensor_value_to_deci(const struct sensor_value *val)
+{
+	return ((int64_t)val->val1 * 10) + val->val2 / 100000;
+}
+
+/**
+ * @brief Helper function for converting struct sensor_value to integer centi units.
+ *
+ * @param val A pointer to a sensor_value struct.
+ * @return The converted value.
+ */
+static inline int64_t sensor_value_to_centi(const struct sensor_value *val)
+{
+	return ((int64_t)val->val1 * 100) + val->val2 / 10000;
+}
+
+/**
  * @brief Helper function for converting struct sensor_value to integer milli units.
  *
  * @param val A pointer to a sensor_value struct.

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -329,6 +329,10 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 	/* reset test data to positive value */
 	data.val1 = 3;
 	data.val2 = 300000;
+	zassert_equal(sensor_value_to_deci(&data), 33LL,
+			"the result does not match");
+	zassert_equal(sensor_value_to_centi(&data), 330LL,
+			"the result does not match");
 	zassert_equal(sensor_value_to_milli(&data), 3300LL,
 			"the result does not match");
 	zassert_equal(sensor_value_to_micro(&data), 3300000LL,
@@ -336,11 +340,21 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 	/* reset test data to negative value */
 	data.val1 = -data.val1;
 	data.val2 = -data.val2;
+	zassert_equal(sensor_value_to_deci(&data), -33LL,
+		"the result does not match");
+	zassert_equal(sensor_value_to_centi(&data), -330LL,
+		"the result does not match");
 	zassert_equal(sensor_value_to_milli(&data), -3300LL,
 			"the result does not match");
 	zassert_equal(sensor_value_to_micro(&data), -3300000LL,
 			"the result does not match");
 	/* Test when result is greater than 32-bit wide */
+	data.val1 = 2123456789;
+	data.val2 = 876543;
+	zassert_equal(sensor_value_to_deci(&data), 21234567898LL,
+			"the result does not match");
+	zassert_equal(sensor_value_to_centi(&data), 212345678987LL,
+			"the result does not match");
 	data.val1 = 5432109;
 	data.val2 = 876543;
 	zassert_equal(sensor_value_to_milli(&data), 5432109876LL,


### PR DESCRIPTION
Add additional conversion helpers for `deci` (0.1) and `centi` (0.01) output units.