### PR TITLE
fuel_gauge: composite: more flexible data sourcing and channel querying

### DIFF
--- a/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
@@ -101,7 +101,7 @@
 
 	fuel_gauge: fuel_gauge {
 		compatible = "zephyr,fuel-gauge-composite";
-		battery-voltage = <&vbatt>;
+		source-primary = <&vbatt>;
 		device-chemistry = "lithium-ion-polymer";
 		ocv-capacity-table-0 = <BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT>;
 		charge-full-design-microamp-hours = <1350000>;

--- a/drivers/fuel_gauge/composite/Kconfig
+++ b/drivers/fuel_gauge/composite/Kconfig
@@ -9,3 +9,12 @@ config FUEL_GAUGE_COMPOSITE
 	depends on DT_HAS_ZEPHYR_FUEL_GAUGE_COMPOSITE_ENABLED
 	help
 	  Enable driver for the Zephyr composite fuel gauge device.
+
+config FUEL_GAUGE_COMPOSITE_DATA_VALIDITY_MS
+	int "Data from sensor_fetch is cached for this long"
+	depends on FUEL_GAUGE_COMPOSITE
+	default 150
+	help
+	  To ensure that data is consistent across multiple calls to
+	  fuel_gauge_get_prop, sensor_fetch is only called if at least
+	  this long has passed since the previous call.

--- a/drivers/fuel_gauge/composite/fuel_gauge_composite.c
+++ b/drivers/fuel_gauge/composite/fuel_gauge_composite.c
@@ -21,9 +21,12 @@ struct composite_config {
 	enum battery_chemistry chemistry;
 };
 
-static int composite_read_micro(const struct device *dev, enum sensor_channel chan, int *val)
+struct composite_data {
+	k_ticks_t next_reading;
+};
+
+static int composite_fetch(const struct device *dev)
 {
-	struct sensor_value sensor_val;
 	int rc;
 
 	rc = pm_device_runtime_get(dev);
@@ -34,23 +37,41 @@ static int composite_read_micro(const struct device *dev, enum sensor_channel ch
 	if (rc < 0) {
 		return rc;
 	}
-	rc = sensor_channel_get(dev, chan, &sensor_val);
-	if (rc < 0) {
-		return rc;
-	}
-	rc = pm_device_runtime_put(dev);
-	if (rc < 0) {
-		return rc;
-	}
-	*val = sensor_value_to_micro(&sensor_val);
-	return 0;
+	return pm_device_runtime_put(dev);
 }
 
 static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 			      union fuel_gauge_prop_val *val)
 {
 	const struct composite_config *config = dev->config;
-	int voltage, rc = 0;
+	struct composite_data *data = dev->data;
+	k_ticks_t now = k_uptime_ticks();
+	struct sensor_value sensor_val;
+	int64_t voltage;
+	int rc = 0;
+
+	/* Validate at build time that equivalent channel output fields still match */
+	BUILD_ASSERT(sizeof(val->absolute_state_of_charge) ==
+		     sizeof(val->relative_state_of_charge));
+	BUILD_ASSERT(offsetof(union fuel_gauge_prop_val, absolute_state_of_charge) ==
+		     offsetof(union fuel_gauge_prop_val, relative_state_of_charge));
+	BUILD_ASSERT(sizeof(val->current) == sizeof(val->avg_current));
+	BUILD_ASSERT(offsetof(union fuel_gauge_prop_val, current) ==
+			offsetof(union fuel_gauge_prop_val, avg_current));
+
+	if (now >= data->next_reading) {
+		/* Trigger a sample on the input devices */
+		rc = composite_fetch(config->battery_voltage);
+		if ((rc == 0) && config->battery_current) {
+			rc = composite_fetch(config->battery_current);
+		}
+		if (rc != 0) {
+			return rc;
+		}
+		/* Update timestamp for next reading */
+		data->next_reading =
+			now + k_ms_to_ticks_near64(CONFIG_FUEL_GAUGE_COMPOSITE_DATA_VALIDITY_MS);
+	}
 
 	switch (prop) {
 	case FUEL_GAUGE_FULL_CHARGE_CAPACITY:
@@ -66,30 +87,36 @@ static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		val->full_charge_capacity = config->charge_capacity_microamp_hours / 1000;
 		break;
 	case FUEL_GAUGE_VOLTAGE:
-		rc = composite_read_micro(config->battery_voltage, SENSOR_CHAN_VOLTAGE,
-					  &val->voltage);
+		rc = sensor_channel_get(config->battery_voltage, SENSOR_CHAN_VOLTAGE, &sensor_val);
+		val->voltage = sensor_value_to_micro(&sensor_val);
 		break;
 	case FUEL_GAUGE_ABSOLUTE_STATE_OF_CHARGE:
 	case FUEL_GAUGE_RELATIVE_STATE_OF_CHARGE:
 		if (config->ocv_lookup_table[0] == -1) {
 			return -ENOTSUP;
 		}
-		rc = composite_read_micro(config->battery_voltage, SENSOR_CHAN_VOLTAGE, &voltage);
-		val->relative_state_of_charge =
-			battery_soc_lookup(config->ocv_lookup_table, voltage) / 1000;
+		/* Fetch the voltage from the sensor */
+		rc = sensor_channel_get(config->battery_voltage, SENSOR_CHAN_VOLTAGE, &sensor_val);
+		voltage = sensor_value_to_micro(&sensor_val);
+		if (rc == 0) {
+			/* Convert voltage to state of charge */
+			val->relative_state_of_charge =
+				battery_soc_lookup(config->ocv_lookup_table, voltage) / 1000;
+		}
 		break;
 	case FUEL_GAUGE_CURRENT:
+	case FUEL_GAUGE_AVG_CURRENT:
 		if (config->battery_current == NULL) {
 			return -ENOTSUP;
 		}
-		rc = composite_read_micro(config->battery_current, SENSOR_CHAN_CURRENT,
-					  &val->current);
+		rc = sensor_channel_get(config->battery_current, SENSOR_CHAN_CURRENT, &sensor_val);
+		val->current = sensor_value_to_micro(&sensor_val);
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return rc;
 }
 
 static DEVICE_API(fuel_gauge, composite_api) = {
@@ -106,7 +133,9 @@ static DEVICE_API(fuel_gauge, composite_api) = {
 			DT_INST_PROP_OR(inst, charge_full_design_microamp_hours, 0),               \
 		.chemistry = BATTERY_CHEMISTRY_DT_GET(inst),                                       \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, NULL, &composite_##inst##_config, POST_KERNEL,     \
+	static struct composite_data composite_##inst##_data;                                      \
+	DEVICE_DT_INST_DEFINE(inst, NULL, NULL, &composite_##inst##_data,                          \
+			      &composite_##inst##_config, POST_KERNEL,                             \
 			      CONFIG_SENSOR_INIT_PRIORITY, &composite_api);
 
 DT_INST_FOREACH_STATUS_OKAY(COMPOSITE_INIT)

--- a/drivers/fuel_gauge/composite/fuel_gauge_composite.c
+++ b/drivers/fuel_gauge/composite/fuel_gauge_composite.c
@@ -128,6 +128,12 @@ static int composite_get_prop(const struct device *dev, fuel_gauge_prop_t prop,
 		rc = composite_channel_get(dev, sensor_chan, &sensor_val);
 		val->current = sensor_value_to_micro(&sensor_val);
 		break;
+	case FUEL_GAUGE_TEMPERATURE:
+		sensor_chan = config->fg_channels ? SENSOR_CHAN_GAUGE_TEMP : SENSOR_CHAN_DIE_TEMP;
+		rc = composite_channel_get(dev, sensor_chan, &sensor_val);
+		/* Output unit = 0.1K (10x increase + 273.0) */
+		val->temperature = sensor_value_to_deci(&sensor_val) + 2730;
+		break;
 	default:
 		return -ENOTSUP;
 	}

--- a/dts/bindings/fuel-gauge/zephyr,fuel-gauge-composite.yaml
+++ b/dts/bindings/fuel-gauge/zephyr,fuel-gauge-composite.yaml
@@ -31,9 +31,3 @@ properties:
       Sources should be queried by the sensor API fuel gauge
       channels (SENSOR_CHAN_GAUGE_*), instead of the generic
       channels (SENSOR_CHAN_VOLTAGE, etc).
-
-  device-chemistry:
-    required: true
-
-  ocv-capacity-table-0:
-    required: true

--- a/dts/bindings/fuel-gauge/zephyr,fuel-gauge-composite.yaml
+++ b/dts/bindings/fuel-gauge/zephyr,fuel-gauge-composite.yaml
@@ -2,29 +2,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-  Composite fuel-gauge constructed from analog input values
+  Composite fuel-gauge constructed from sensor devices
 
 compatible: "zephyr,fuel-gauge-composite"
 
 include: [fuel-gauge.yaml, battery.yaml]
 
 properties:
-  battery-voltage:
+  source-primary:
     type: phandle
     required: true
     description: |
-      Device to read battery voltage from.
+      Primary device to read sensor data from.
+      Device must implement the sensor API.
 
-      Device must implement the sensor API and provide the
-      `SENSOR_CHAN_VOLTAGE` channel.
-
-  battery-current:
+  source-secondary:
     type: phandle
     description: |
-      Device to read battery current from.
+      Secondary device to read sensor data from.
+      This device will be used if input-primary does not expose
+      a channel.
 
-      Device must implement the sensor API and provide the
-      `SENSOR_CHAN_CURRENT` channel.
+      Device must implement the sensor API.
 
   device-chemistry:
     required: true

--- a/dts/bindings/fuel-gauge/zephyr,fuel-gauge-composite.yaml
+++ b/dts/bindings/fuel-gauge/zephyr,fuel-gauge-composite.yaml
@@ -25,6 +25,13 @@ properties:
 
       Device must implement the sensor API.
 
+  fuel-gauge-channels:
+    type: boolean
+    description: |
+      Sources should be queried by the sensor API fuel gauge
+      channels (SENSOR_CHAN_GAUGE_*), instead of the generic
+      channels (SENSOR_CHAN_VOLTAGE, etc).
+
   device-chemistry:
     required: true
 

--- a/tests/drivers/build_all/fuel_gauge/app.overlay
+++ b/tests/drivers/build_all/fuel_gauge/app.overlay
@@ -56,7 +56,7 @@
 		test_fuel_gauge: fuel_gauge {
 			compatible = "zephyr,fuel-gauge-composite";
 			status = "okay";
-			battery-voltage = <&test_vbatt>;
+			source-primary = <&test_vbatt>;
 			device-chemistry = "lithium-ion-polymer";
 			ocv-capacity-table-0 = <0>;
 			charge-full-design-microamp-hours = <1350000>;

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -39,8 +39,8 @@ test_current: current_amp {
 test_composite_fuel_gauge: composite_fuel_gauge {
 	compatible = "zephyr,fuel-gauge-composite";
 	status = "okay";
-	battery-voltage = <&test_voltage>;
-	battery-current = <&test_current>;
+	source-primary = <&test_voltage>;
+	source-secondary = <&test_current>;
 	device-chemistry = "lithium-ion-polymer";
 	ocv-capacity-table-0 = <BATTERY_OCV_CURVE_LITHIUM_ION_POLYMER_DEFAULT>;
 	charge-full-design-microamp-hours = <1000000>;


### PR DESCRIPTION
To ensure that data is consistent across multiple sequential calls to `fuel_gauge_get_prop`, sensor_fetch is only called if a certain time period has passed since the previous sampling. This emulates the tick-based sampling of most dedicated fuel-gauge devices.

Instead of explicitly specifying the source for the voltage and current channels, specify primary and secondary data sources. If the requested sensor channel does not exist on the primary source, the secondary source will be tried.

Choose whether the data sources should be queried by the generic sensor channels (`SENSOR_CHAN_VOLTAGE`, etc), or the fuel gauge specific channels (`SENSOR_CHAN_GAUGE_*`).

Add support for the `FUEL_GAUGE_TEMPERATURE` property.

More flexible alternative to #83859.

The motivation for this PR is the desire to access core functionality of the existing in-tree nPM1300 driver (which implements the sensor API using `SENSOR_CHAN_GAUGE_*` channels) through the fuel gauge API, together with extending it to support SoC lookup.