### PR TITLE
drivers: gpio: rz: Mass renaming

### DIFF
--- a/drivers/gpio/gpio_renesas_rz.c
+++ b/drivers/gpio/gpio_renesas_rz.c
@@ -31,10 +31,10 @@ struct gpio_rz_config {
 	bsp_io_port_t fsp_port;
 	const ioport_cfg_t *fsp_cfg;
 	const ioport_api_t *fsp_api;
-	const struct device *int_dev;
+	const struct device *gpio_int_dev;
 	uint8_t int_num[GPIO_RZ_MAX_INT_NUM];
 #if defined(CONFIG_RENESAS_RZ_EXT_IRQ)
-	const struct device *eirq_dev[GPIO_RZ_MAX_INT_NUM];
+	const struct device *ext_irq_dev[GPIO_RZ_MAX_INT_NUM];
 
 	void (*cb_list[GPIO_RZ_MAX_INT_NUM])(void *arg);
 #endif
@@ -60,39 +60,39 @@ struct gpio_rz_int_data {
 	uint32_t irq_set_edge;
 };
 
-struct gpio_rz_hw_config {
-	gpio_flags_t p_pm;
+struct gpio_rz_flags {
+	gpio_flags_t gpio_flags;
 	uint8_t pfc;
 };
 
-struct gpio_rz_tint_config {
+struct gpio_rz_int_config {
 	void (*gpio_int_init)(void);
 };
 
-static int gpio_rz_pin_config_get_raw(bsp_io_port_pin_t port_pin, struct gpio_rz_hw_config *flags);
+static int gpio_rz_pin_config_get_raw(bsp_io_port_pin_t port_pin, struct gpio_rz_flags *rz_flags);
 
 #ifdef CONFIG_GPIO_GET_CONFIG
 static int gpio_rz_pin_get_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t *flags)
 {
 	const struct gpio_rz_config *config = dev->config;
 	bsp_io_port_pin_t port_pin = config->fsp_port | pin;
-	struct gpio_rz_hw_config hw_flags;
+	struct gpio_rz_flags rz_flags;
 
-	gpio_rz_pin_config_get_raw(port_pin, &hw_flags);
-	*flags = hw_flags.p_pm;
+	gpio_rz_pin_config_get_raw(port_pin, &rz_flags);
+	*flags = rz_flags.gpio_flags;
 
 	return 0;
 }
 #endif
 
 /* Get previous pin's configuration, used by pin_configure/pin_interrupt_configure api */
-static int gpio_rz_pin_config_get_raw(bsp_io_port_pin_t port_pin, struct gpio_rz_hw_config *flags)
+static int gpio_rz_pin_config_get_raw(bsp_io_port_pin_t port_pin, struct gpio_rz_flags *rz_flags)
 {
 	bsp_io_port_t port = (port_pin >> 8U) & 0xFF;
 	gpio_pin_t pin = port_pin & 0xFF;
-	volatile uint8_t *p_p = GPIO_RZ_IOPORT_P_REG_GET(port, pin);
-	volatile uint16_t *p_pm = GPIO_RZ_IOPORT_PM_REG_GET(port, pin);
-	volatile uint32_t *p_pfc = GPIO_RZ_IOPORT_PFC_REG_GET(port, pin);
+	volatile uint8_t *p_p = GPIO_RZ_P_REG_GET(port, pin);
+	volatile uint16_t *p_pm = GPIO_RZ_PM_REG_GET(port, pin);
+	volatile uint32_t *p_pfc = GPIO_RZ_PFC_REG_GET(port, pin);
 
 	uint8_t p_value;
 	uint16_t pm_value;
@@ -102,17 +102,15 @@ static int gpio_rz_pin_config_get_raw(bsp_io_port_pin_t port_pin, struct gpio_rz
 	pm_value = GPIO_RZ_PM_VALUE_GET(*p_pm, pin);
 	pfc_value = GPIO_RZ_PFC_VALUE_GET(*p_pfc, pin);
 
-	flags->p_pm = 0;
-	flags->pfc = 0;
-
 	if (p_value) {
-		flags->p_pm |= GPIO_OUTPUT_INIT_HIGH;
+		rz_flags->gpio_flags = GPIO_OUTPUT_INIT_HIGH;
 	} else {
-		flags->p_pm |= GPIO_OUTPUT_INIT_LOW;
+		rz_flags->gpio_flags = GPIO_OUTPUT_INIT_LOW;
 	}
 
-	flags->p_pm |= (pm_value << 16);
-	flags->pfc |= pfc_value;
+	rz_flags->gpio_flags |= (pm_value << 16);
+	rz_flags->pfc = pfc_value;
+
 	return 0;
 }
 
@@ -122,17 +120,16 @@ static int gpio_rz_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_
 	struct gpio_rz_data *data = dev->data;
 	bsp_io_port_pin_t port_pin = config->fsp_port | pin;
 	uint32_t ioport_config_data = 0;
-	struct gpio_rz_hw_config pre_flags;
+	struct gpio_rz_flags rz_flags;
 	fsp_err_t err;
 
-	gpio_rz_pin_config_get_raw(port_pin, &pre_flags);
+	gpio_rz_pin_config_get_raw(port_pin, &rz_flags);
 
 	if (!flags) {
 		/* Disconnect mode */
 		GPIO_RZ_PIN_DISCONNECT(config->fsp_port, pin);
 	} else if (!(flags & GPIO_OPEN_DRAIN)) {
 		/* PM register */
-		ioport_config_data &= GPIO_RZ_PIN_CONFIGURE_INPUT_OUTPUT_RESET;
 		if (flags & GPIO_INPUT) {
 			if (flags & GPIO_OUTPUT) {
 				ioport_config_data |= IOPORT_CFG_PORT_DIRECTION_OUTPUT_INPUT;
@@ -140,12 +137,12 @@ static int gpio_rz_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_
 				ioport_config_data |= IOPORT_CFG_PORT_DIRECTION_INPUT;
 			}
 		} else if (flags & GPIO_OUTPUT) {
-			ioport_config_data &= GPIO_RZ_PIN_CONFIGURE_INPUT_OUTPUT_RESET;
 			ioport_config_data |= IOPORT_CFG_PORT_DIRECTION_OUTPUT;
 		}
 		/* P register */
 		if (!(flags & (GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOW))) {
-			flags |= pre_flags.p_pm & (GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOW);
+			flags |= rz_flags.gpio_flags &
+				 (GPIO_OUTPUT_INIT_HIGH | GPIO_OUTPUT_INIT_LOW);
 		}
 
 		if (flags & GPIO_OUTPUT_INIT_HIGH) {
@@ -162,31 +159,31 @@ static int gpio_rz_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_
 
 		/*
 		 * Interrupt register
-		 * RZG: ISEL
-		 * RZTN: PMC
+		 * RZ/A,G,V: ISEL
+		 * RZ/T,N: PMC
 		 */
 		if (flags & GPIO_INT_ENABLE) {
-			ioport_config_data |= GPIO_RZ_PIN_CONFIGURE_INT_ENABLE;
+			ioport_config_data |= GPIO_RZ_INT_ENABLE;
 		} else if (flags & GPIO_INT_DISABLE) {
-			ioport_config_data &= GPIO_RZ_PIN_CONFIGURE_INT_DISABLE;
+			ioport_config_data &= GPIO_RZ_INT_DISABLE;
 		}
 
 		/*
 		 * Drive ability register
-		 * RZG: IOLH
-		 * RZTN: DRCTL
+		 * RZ/A,G,V: IOLH
+		 * RZ/T,N: DRCTL
 		 */
-		ioport_config_data |= GPIO_RZ_PIN_CONFIGURE_GET(flags);
+		ioport_config_data |= GPIO_RZ_FLAG_GET_CONFIG(flags);
 
 		/* PFC register */
-		ioport_config_data |= GPIO_RZ_IOPORT_PFC_SET(pre_flags.pfc);
+		ioport_config_data |= GPIO_RZ_FLAG_SET_PFC(rz_flags.pfc);
 
 		/*
 		 * Specific register
-		 * RZG: FILONOFF, FILNUM, FILCLKSEL
-		 * RZTN: RSELP
+		 * RZ/A,G,V: FILONOFF, FILNUM, FILCLKSEL
+		 * RZ/T,N: RSELP
 		 */
-		ioport_config_data |= GPIO_RZ_PIN_SPECIAL_FLAG_GET(flags);
+		ioport_config_data |= GPIO_RZ_FLAG_GET_SPECIFIC(flags);
 	} else {
 		return -ENOTSUP;
 	}
@@ -195,6 +192,7 @@ static int gpio_rz_pin_configure(const struct device *dev, gpio_pin_t pin, gpio_
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
+
 	return 0;
 }
 
@@ -210,6 +208,7 @@ static int gpio_rz_port_get_raw(const struct device *dev, gpio_port_value_t *val
 		return -EIO;
 	}
 	*value = (gpio_port_value_t)port_value;
+
 	return 0;
 }
 
@@ -226,6 +225,7 @@ static int gpio_rz_port_set_masked_raw(const struct device *dev, gpio_port_pins_
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
+
 	return 0;
 }
 
@@ -241,6 +241,7 @@ static int gpio_rz_port_set_bits_raw(const struct device *dev, gpio_port_pins_t 
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
+
 	return 0;
 }
 
@@ -256,6 +257,7 @@ static int gpio_rz_port_clear_bits_raw(const struct device *dev, gpio_port_pins_
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
+
 	return 0;
 }
 
@@ -264,17 +266,17 @@ static int gpio_rz_port_toggle_bits(const struct device *dev, gpio_port_pins_t p
 	const struct gpio_rz_config *config = dev->config;
 	struct gpio_rz_data *data = dev->data;
 	bsp_io_port_pin_t port_pin;
-	struct gpio_rz_hw_config pre_flags;
+	struct gpio_rz_flags rz_flags;
 	ioport_size_t value = 0;
 	fsp_err_t err;
 
 	for (uint8_t idx = 0; idx < config->ngpios; idx++) {
 		if (pins & (1U << idx)) {
 			port_pin = config->fsp_port | idx;
-			gpio_rz_pin_config_get_raw(port_pin, &pre_flags);
-			if (pre_flags.p_pm & GPIO_OUTPUT_INIT_HIGH) {
+			gpio_rz_pin_config_get_raw(port_pin, &rz_flags);
+			if (rz_flags.gpio_flags & GPIO_OUTPUT_INIT_HIGH) {
 				value &= (1U << idx);
-			} else if (pre_flags.p_pm & GPIO_OUTPUT_INIT_LOW) {
+			} else if (rz_flags.gpio_flags & GPIO_OUTPUT_INIT_LOW) {
 				value |= (1U << idx);
 			}
 		}
@@ -284,6 +286,7 @@ static int gpio_rz_port_toggle_bits(const struct device *dev, gpio_port_pins_t p
 	if (err != FSP_SUCCESS) {
 		return -EIO;
 	}
+
 	return 0;
 }
 
@@ -317,17 +320,17 @@ static int gpio_rz_int_disable(const struct device *dev, const struct device *gp
 	data->gpio_mapping[int_num].pin = UINT8_MAX;
 #elif defined(CONFIG_RENESAS_RZ_EXT_IRQ)
 	const struct gpio_rz_config *gpio_config = gpio_dev->config;
-	const struct device *eirq_dev = gpio_config->eirq_dev[pin];
+	const struct device *ext_irq_dev = gpio_config->ext_irq_dev[pin];
 
-	if (device_is_ready(eirq_dev)) {
-		intc_rz_ext_irq_disable(eirq_dev);
+	if (device_is_ready(ext_irq_dev)) {
+		intc_rz_ext_irq_disable(ext_irq_dev);
 	}
 #endif /* CONFIG_RENESAS_RZ_EXT_IRQ */
 
 	return 0;
 }
 
-static int gpio_rz_int_enable(const struct device *int_dev, const struct device *gpio_dev,
+static int gpio_rz_int_enable(const struct device *gpio_int_dev, const struct device *gpio_dev,
 			      uint8_t int_num, uint8_t irq_type, gpio_pin_t pin)
 {
 	if (irq_type == GPIO_RZ_INT_UNSUPPORTED) {
@@ -339,7 +342,7 @@ static int gpio_rz_int_enable(const struct device *int_dev, const struct device 
 #if defined(CONFIG_GPIO_RENESAS_RZ_HAS_GPIO_INTERRUPT)
 	volatile uint32_t *tssr = &R_INTC->TSSR0;
 	volatile uint32_t *titsr = &R_INTC->TITSR0;
-	struct gpio_rz_int_data *int_data = int_dev->data;
+	struct gpio_rz_int_data *gpio_int_data = gpio_int_dev->data;
 
 	tssr = &tssr[int_num / 4];
 	titsr = &titsr[int_num / 16];
@@ -350,22 +353,22 @@ static int gpio_rz_int_enable(const struct device *int_dev, const struct device 
 	*tssr |= (GPIO_RZ_TSSR_VAL(gpio_config->port_num, pin)) << GPIO_RZ_TSSR_OFFSET(int_num);
 
 	if (irq_type == GPIO_RZ_INT_EDGE_RISING || irq_type == GPIO_RZ_INT_EDGE_FALLING) {
-		int_data->irq_set_edge |= BIT(int_num);
+		gpio_int_data->irq_set_edge |= BIT(int_num);
 		/* Clear interrupt status. */
 		R_INTC->TSCR &= ~BIT(int_num);
 	}
 	irq_enable(GPIO_RZ_TINT_IRQ_GET(int_num));
-	int_data->gpio_mapping[int_num].gpio_dev = gpio_dev;
-	int_data->gpio_mapping[int_num].pin = pin;
+	gpio_int_data->gpio_mapping[int_num].gpio_dev = gpio_dev;
+	gpio_int_data->gpio_mapping[int_num].pin = pin;
 #elif defined(CONFIG_RENESAS_RZ_EXT_IRQ)
-	const struct device *eirq_dev = gpio_config->eirq_dev[pin];
+	const struct device *ext_irq_dev = gpio_config->ext_irq_dev[pin];
 	struct gpio_rz_data *gpio_data = gpio_dev->data;
 
 	gpio_data->pin[int_num] = pin;
-	if (device_is_ready(eirq_dev)) {
-		intc_rz_ext_irq_set_type(eirq_dev, irq_type);
-		intc_rz_ext_irq_enable(eirq_dev);
-		intc_rz_ext_irq_set_callback(eirq_dev, gpio_config->cb_list[int_num],
+	if (device_is_ready(ext_irq_dev)) {
+		intc_rz_ext_irq_set_type(ext_irq_dev, irq_type);
+		intc_rz_ext_irq_enable(ext_irq_dev);
+		intc_rz_ext_irq_set_callback(ext_irq_dev, gpio_config->cb_list[int_num],
 					     (void *)gpio_dev);
 	}
 #endif /* CONFIG_GPIO_RENESAS_RZ_HAS_GPIO_INTERRUPT */
@@ -381,7 +384,7 @@ static int gpio_rz_pin_interrupt_configure(const struct device *dev, gpio_pin_t 
 	bsp_io_port_pin_t port_pin = config->fsp_port | pin;
 	uint8_t int_num = config->int_num[pin];
 	uint8_t irq_type = 0;
-	struct gpio_rz_hw_config pre_flags;
+	struct gpio_rz_flags rz_flags;
 	k_spinlock_key_t key;
 	int ret = 0;
 
@@ -396,10 +399,10 @@ static int gpio_rz_pin_interrupt_configure(const struct device *dev, gpio_pin_t 
 	key = k_spin_lock(&data->lock);
 
 	if (mode == GPIO_INT_MODE_DISABLED) {
-		gpio_rz_pin_config_get_raw(port_pin, &pre_flags);
-		pre_flags.p_pm |= GPIO_INT_DISABLE;
-		gpio_rz_pin_configure(dev, pin, pre_flags.p_pm);
-		gpio_rz_int_disable(config->int_dev, dev, int_num, pin);
+		gpio_rz_pin_config_get_raw(port_pin, &rz_flags);
+		rz_flags.gpio_flags |= GPIO_INT_DISABLE;
+		gpio_rz_pin_configure(dev, pin, rz_flags.gpio_flags);
+		gpio_rz_int_disable(config->gpio_int_dev, dev, int_num, pin);
 		goto exit_unlock;
 	}
 
@@ -419,15 +422,16 @@ static int gpio_rz_pin_interrupt_configure(const struct device *dev, gpio_pin_t 
 		}
 	}
 
-	ret = gpio_rz_int_enable(config->int_dev, dev, int_num, irq_type, pin);
+	ret = gpio_rz_int_enable(config->gpio_int_dev, dev, int_num, irq_type, pin);
 	if (ret == 0) {
-		gpio_rz_pin_config_get_raw(port_pin, &pre_flags);
-		pre_flags.p_pm |= GPIO_INT_ENABLE;
-		gpio_rz_pin_configure(dev, pin, pre_flags.p_pm);
+		gpio_rz_pin_config_get_raw(port_pin, &rz_flags);
+		rz_flags.gpio_flags |= GPIO_INT_ENABLE;
+		gpio_rz_pin_configure(dev, pin, rz_flags.gpio_flags);
 	}
 
 exit_unlock:
 	k_spin_unlock(&data->lock, key);
+
 	return ret;
 }
 
@@ -443,7 +447,7 @@ static void gpio_rz_isr(uint16_t irq, void *param)
 {
 #if defined(CONFIG_GPIO_RENESAS_RZ_HAS_GPIO_INTERRUPT)
 	const struct device *dev = param;
-	struct gpio_rz_int_data *int_data = dev->data;
+	struct gpio_rz_int_data *gpio_int_data = dev->data;
 	volatile uint32_t *tscr = &R_INTC->TSCR;
 
 	if (!(*tscr & BIT(irq))) {
@@ -451,12 +455,12 @@ static void gpio_rz_isr(uint16_t irq, void *param)
 		return;
 	}
 
-	if (int_data->irq_set_edge & BIT(irq)) {
+	if (gpio_int_data->irq_set_edge & BIT(irq)) {
 		*tscr &= ~BIT(irq);
 	}
 
-	uint8_t pin = int_data->gpio_mapping[irq].pin;
-	const struct device *gpio_dev = int_data->gpio_mapping[irq].gpio_dev;
+	uint8_t pin = gpio_int_data->gpio_mapping[irq].pin;
+	const struct device *gpio_dev = gpio_int_data->gpio_mapping[irq].gpio_dev;
 	struct gpio_rz_data *gpio_data = gpio_dev->data;
 
 	gpio_fire_callbacks(&gpio_data->cb, gpio_dev, BIT(pin));
@@ -488,10 +492,10 @@ static DEVICE_API(gpio, gpio_rz_driver_api) = {
 };
 
 /* Initialize GPIO interrupt device */
-#define GPIO_RZ_ISR_DEFINE(irq_num, _)                                                             \
-	static void rz_gpio_isr##irq_num(void *param)                                              \
+#define GPIO_RZ_ISR_DEFINE(idx, _)                                                                 \
+	static void rz_gpio_isr##idx(void *param)                                                  \
 	{                                                                                          \
-		gpio_rz_isr(irq_num, param);                                                       \
+		gpio_rz_isr(idx, param);                                                           \
 	}
 
 #define GPIO_RZ_ALL_ISR_DEFINE(irq_num) LISTIFY(irq_num, GPIO_RZ_ISR_DEFINE, ())
@@ -499,38 +503,39 @@ static DEVICE_API(gpio, gpio_rz_driver_api) = {
 #if defined(CONFIG_GPIO_RENESAS_RZ_HAS_GPIO_INTERRUPT) || defined(CONFIG_RENESAS_RZ_EXT_IRQ)
 #if defined(CONFIG_GPIO_RENESAS_RZ_HAS_GPIO_INTERRUPT)
 
-#define GPIO_RZ_INT_DEFINE(inst) .int_dev = DEVICE_DT_GET_OR_NULL(DT_INST(0, renesas_rz_gpio_int))
+#define GPIO_RZ_INT_DEFINE(inst)                                                                   \
+	.gpio_int_dev = DEVICE_DT_GET_OR_NULL(DT_INST(0, renesas_rz_gpio_int))
 
 static int gpio_rz_int_init(const struct device *dev)
 {
-	const struct gpio_rz_tint_config *config = dev->config;
+	const struct gpio_rz_int_config *config = dev->config;
 
 	config->gpio_int_init();
+
 	return 0;
 }
 
-#define GPIO_RZ_TINT_CONNECT(irq_num, node_id)                                                     \
-	IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, irq_num, irq),                                          \
-		    DT_IRQ_BY_IDX(node_id, irq_num, priority), rz_gpio_isr##irq_num,               \
-		    DEVICE_DT_GET(node_id), 0);
+#define GPIO_RZ_INT_CONNECT(idx, node_id)                                                          \
+	IRQ_CONNECT(DT_IRQ_BY_IDX(node_id, idx, irq), DT_IRQ_BY_IDX(node_id, idx, priority),       \
+		    rz_gpio_isr##idx, DEVICE_DT_GET(node_id), 0);
 
-#define GPIO_RZ_TINT_CONNECT_FUNC(node_id)                                                         \
-	static void rz_gpio_tint_connect_func##node_id(void)                                       \
+#define GPIO_RZ_INT_CONNECT_FUNC(node_id)                                                          \
+	static void rz_gpio_int_connect_func##node_id(void)                                        \
 	{                                                                                          \
 		LISTIFY(DT_NUM_IRQS(node_id),                    \
-			GPIO_RZ_TINT_CONNECT, (;),               \
+			GPIO_RZ_INT_CONNECT, (;),                \
 			node_id)                                 \
 	}
 /* Initialize GPIO device */
 #define GPIO_RZ_INT_INIT(node_id)                                                                  \
 	GPIO_RZ_ALL_ISR_DEFINE(DT_NUM_IRQS(node_id))                                               \
-	GPIO_RZ_TINT_CONNECT_FUNC(node_id)                                                         \
-	static const struct gpio_rz_tint_config rz_gpio_tint_cfg_##node_id = {                     \
-		.gpio_int_init = rz_gpio_tint_connect_func##node_id,                               \
+	GPIO_RZ_INT_CONNECT_FUNC(node_id)                                                          \
+	static const struct gpio_rz_int_config rz_gpio_int_cfg_##node_id = {                       \
+		.gpio_int_init = rz_gpio_int_connect_func##node_id,                                \
 	};                                                                                         \
-	static struct gpio_rz_int_data rz_gpio_tint_data_##node_id = {};                           \
-	DEVICE_DT_DEFINE(node_id, gpio_rz_int_init, NULL, &rz_gpio_tint_data_##node_id,            \
-			 &rz_gpio_tint_cfg_##node_id, POST_KERNEL,                                 \
+	static struct gpio_rz_int_data rz_gpio_int_data_##node_id = {};                            \
+	DEVICE_DT_DEFINE(node_id, gpio_rz_int_init, NULL, &rz_gpio_int_data_##node_id,             \
+			 &rz_gpio_int_cfg_##node_id, POST_KERNEL,                                  \
 			 UTIL_DEC(CONFIG_GPIO_INIT_PRIORITY), NULL);
 DT_FOREACH_STATUS_OKAY(renesas_rz_gpio_int, GPIO_RZ_INT_INIT)
 
@@ -538,23 +543,23 @@ DT_FOREACH_STATUS_OKAY(renesas_rz_gpio_int, GPIO_RZ_INT_INIT)
 
 GPIO_RZ_ALL_ISR_DEFINE(GPIO_RZ_MAX_INT_NUM)
 
-#define EIRQ_CB_GET(eirq_line, _) [eirq_line] = rz_gpio_isr##eirq_line
+#define EXT_IRQ_CB_GET(ext_irq, _) [ext_irq] = rz_gpio_isr##ext_irq
 
-#define EIRQ_DEV_LABEL_GET(inst, idx) CONCAT(irq, DT_INST_PROP_BY_IDX(inst, irqs, UTIL_INC(idx)))
+#define EXT_IRQ_DEV_LABEL_GET(inst, idx) CONCAT(irq, DT_INST_PROP_BY_IDX(inst, irqs, UTIL_INC(idx)))
 
-#define EIRQ_DEV_GET(idx, inst)                                                                    \
+#define EXT_IRQ_DEV_GET(idx, inst)                                                                 \
 	COND_CODE_1(DT_INST_PROP_HAS_IDX(inst, irqs, idx),                                         \
 		    ([DT_INST_PROP_BY_IDX(inst, irqs, idx)] =                                      \
-			     DEVICE_DT_GET_OR_NULL(DT_NODELABEL(EIRQ_DEV_LABEL_GET(inst, idx))),), \
+			DEVICE_DT_GET_OR_NULL(DT_NODELABEL(EXT_IRQ_DEV_LABEL_GET(inst, idx))),),   \
 		    ())
 
-#define ALL_EIRQ_DEV_GET(inst)                                                                     \
-	FOR_EACH_FIXED_ARG(EIRQ_DEV_GET, (), inst,                                                 \
+#define ALL_EXT_IRQ_DEV_GET(inst)                                                                  \
+	FOR_EACH_FIXED_ARG(EXT_IRQ_DEV_GET, (), inst,                                              \
 			   LISTIFY(DT_INST_PROP_LEN_OR(inst, irqs, 0), VALUE_2X, (,)))
 
 #define GPIO_RZ_INT_DEFINE(inst)                                                                   \
-	.eirq_dev = {ALL_EIRQ_DEV_GET(inst)},                                                      \
-	.cb_list = {LISTIFY(GPIO_RZ_MAX_INT_NUM, EIRQ_CB_GET, (,))}
+	.ext_irq_dev = {ALL_EXT_IRQ_DEV_GET(inst)},                                                \
+	.cb_list = {LISTIFY(GPIO_RZ_MAX_INT_NUM, EXT_IRQ_CB_GET, (,))}
 
 #endif /* CONFIG_GPIO_RENESAS_RZ_HAS_GPIO_INTERRUPT */
 

--- a/drivers/gpio/gpio_renesas_rz.h
+++ b/drivers/gpio/gpio_renesas_rz.h
@@ -16,47 +16,45 @@
 #include <zephyr/dt-bindings/gpio/renesas-rz-gpio.h>
 
 #if defined(CONFIG_SOC_SERIES_RZG3S)
-#define GPIO_RZ_IOPORT_P_REG_BASE_GET   (&R_GPIO->P_20)
-#define GPIO_RZ_IOPORT_PM_REG_BASE_GET  (&R_GPIO->PM_20)
-#define GPIO_RZ_IOPORT_PFC_REG_BASE_GET (&R_GPIO->PFC_20)
-#define GPIO_RZ_MAX_PORT_NUM            19
-#define GPIO_RZ_TINT_IRQ_OFFSET         429
-#define R_INTC                          R_INTC_IM33
+#define GPIO_RZ_P_REG_BASE_GET   (&R_GPIO->P_20)
+#define GPIO_RZ_PM_REG_BASE_GET  (&R_GPIO->PM_20)
+#define GPIO_RZ_PFC_REG_BASE_GET (&R_GPIO->PFC_20)
+#define GPIO_RZ_MAX_PORT_NUM     19
+#define GPIO_RZ_TINT_IRQ_OFFSET  429
+#define R_INTC                   R_INTC_IM33
 static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {0,  4,  9,  13, 17, 23, 28, 33, 38, 43,
 							  47, 52, 56, 58, 63, 66, 70, 72, 76};
 
 #elif defined(CONFIG_SOC_SERIES_RZA3UL)
-#define GPIO_RZ_IOPORT_P_REG_BASE_GET   (&R_GPIO->P10)
-#define GPIO_RZ_IOPORT_PM_REG_BASE_GET  (&R_GPIO->PM10)
-#define GPIO_RZ_IOPORT_PFC_REG_BASE_GET (&R_GPIO->PFC10)
-#define GPIO_RZ_MAX_PORT_NUM            19
-#define GPIO_RZ_TINT_IRQ_OFFSET         476
-#define R_INTC                          R_INTC_IA55
+#define GPIO_RZ_P_REG_BASE_GET   (&R_GPIO->P10)
+#define GPIO_RZ_PM_REG_BASE_GET  (&R_GPIO->PM10)
+#define GPIO_RZ_PFC_REG_BASE_GET (&R_GPIO->PFC10)
+#define GPIO_RZ_MAX_PORT_NUM     19
+#define GPIO_RZ_TINT_IRQ_OFFSET  476
+#define R_INTC                   R_INTC_IA55
 static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {0,  4,  9,  13, 17, 23, 28, 33, 38, 43,
 							  47, 52, 56, 58, 63, 66, 70, 72, 76};
 
 #elif defined(CONFIG_SOC_SERIES_RZV2L) || defined(CONFIG_SOC_SERIES_RZG2L)
-#define GPIO_RZ_IOPORT_P_REG_BASE_GET   (&R_GPIO->P10)
-#define GPIO_RZ_IOPORT_PM_REG_BASE_GET  (&R_GPIO->PM10)
-#define GPIO_RZ_IOPORT_PFC_REG_BASE_GET (&R_GPIO->PFC10)
-#define GPIO_RZ_MAX_PORT_NUM            49
-#define GPIO_RZ_TINT_IRQ_OFFSET         444
-#define R_INTC                          R_INTC_IM33
+#define GPIO_RZ_P_REG_BASE_GET   (&R_GPIO->P10)
+#define GPIO_RZ_PM_REG_BASE_GET  (&R_GPIO->PM10)
+#define GPIO_RZ_PFC_REG_BASE_GET (&R_GPIO->PFC10)
+#define GPIO_RZ_MAX_PORT_NUM     49
+#define GPIO_RZ_TINT_IRQ_OFFSET  444
+#define R_INTC                   R_INTC_IM33
 static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {
 	0,  2,  4,  6,  8,  10, 13, 15, 18, 21, 24,  25,  27,  29,  32, 34, 36,
 	38, 41, 43, 45, 48, 50, 52, 54, 56, 58, 60,  62,  64,  66,  68, 70, 72,
 	74, 76, 78, 80, 83, 85, 88, 91, 93, 98, 102, 106, 110, 114, 118};
 #endif
 
-#define GPIO_RZ_IOPORT_P_REG_GET(port, pin)   (&GPIO_RZ_IOPORT_P_REG_BASE_GET[port])
-#define GPIO_RZ_IOPORT_PM_REG_GET(port, pin)  (&GPIO_RZ_IOPORT_PM_REG_BASE_GET[port])
-#define GPIO_RZ_IOPORT_PFC_REG_GET(port, pin) (&GPIO_RZ_IOPORT_PFC_REG_BASE_GET[port])
+#define GPIO_RZ_P_REG_GET(port, pin)   (&GPIO_RZ_P_REG_BASE_GET[port])
+#define GPIO_RZ_PM_REG_GET(port, pin)  (&GPIO_RZ_PM_REG_BASE_GET[port])
+#define GPIO_RZ_PFC_REG_GET(port, pin) (&GPIO_RZ_PFC_REG_BASE_GET[port])
 
 #define GPIO_RZ_P_VALUE_GET(value, pin)   ((value >> pin) & 1U)
 #define GPIO_RZ_PM_VALUE_GET(value, pin)  ((value >> (pin * 2)) & 3U)
 #define GPIO_RZ_PFC_VALUE_GET(value, pin) ((value >> (pin * 4)) & 0xF)
-
-#define GPIO_RZ_IOPORT_PFC_SET(value) (value << 24)
 
 #define GPIO_RZ_PIN_DISCONNECT(port, pin) /* do nothing */
 
@@ -69,48 +67,45 @@ static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {
 #define GPIO_RZ_INT_LEVEL_HIGH   0x2
 #define GPIO_RZ_INT_LEVEL_LOW    0x3
 #define GPIO_RZ_INT_BOTH_EDGE    GPIO_RZ_INT_UNSUPPORTED
+#define GPIO_RZ_INT_ENABLE       IOPORT_CFG_TINT_ENABLE
+#define GPIO_RZ_INT_DISABLE      (~(IOPORT_CFG_TINT_ENABLE))
 
 #define GPIO_RZ_TSSR_VAL(port, pin) (0x80 | (gpio_rz_int[port] + pin))
 #define GPIO_RZ_TSSR_OFFSET(irq)    ((irq % 4) * 8)
 #define GPIO_RZ_TITSR_OFFSET(irq)   ((irq % 16) * 2)
 
-#define GPIO_RZ_PIN_CONFIGURE_GET_FILTER(flag) (((flags >> RZ_GPIO_FILTER_SHIFT) & 0x1F) << 19U)
-#define GPIO_RZ_PIN_CONFIGURE_GET(flag)        (((flag >> RZ_GPIO_IOLH_SHIFT) & 0x3) << 10U)
-
-#define GPIO_RZ_PIN_CONFIGURE_INT_ENABLE         IOPORT_CFG_TINT_ENABLE
-#define GPIO_RZ_PIN_CONFIGURE_INT_DISABLE        (~(IOPORT_CFG_TINT_ENABLE))
-#define GPIO_RZ_PIN_CONFIGURE_INPUT_OUTPUT_RESET (~(0x3 << 2))
-#define GPIO_RZ_PIN_SPECIAL_FLAG_GET(flag)       GPIO_RZ_PIN_CONFIGURE_GET_FILTER(flag)
+#define GPIO_RZ_FLAG_GET_CONFIG(flag)   (((flag >> RZ_GPIO_IOLH_SHIFT) & 0x3) << 10U)
+#define GPIO_RZ_FLAG_GET_FILTER(flag)   (((flags >> RZ_GPIO_FILTER_SHIFT) & 0x1F) << 19U)
+#define GPIO_RZ_FLAG_SET_PFC(value)     (value << 24)
+#define GPIO_RZ_FLAG_GET_SPECIFIC(flag) GPIO_RZ_FLAG_GET_FILTER(flag)
 
 #elif defined(CONFIG_SOC_SERIES_RZN2L) || defined(CONFIG_SOC_SERIES_RZT2L) ||                      \
 	defined(CONFIG_SOC_SERIES_RZT2M)
 #include <zephyr/dt-bindings/gpio/renesas-rztn-gpio.h>
-#define GPIO_RZ_IOPORT_REG_REGION_GET(p) (R_BSP_IoRegionGet(p) == BSP_IO_REGION_NOT_SAFE ? 1 : 0)
+#define GPIO_RZ_REG_REGION_GET(p) (R_BSP_IoRegionGet(p) == BSP_IO_REGION_NOT_SAFE ? 1 : 0)
 
-#define GPIO_RZ_IOPORT_P_REG_BASE_GET(port, pin)                                                   \
-	(GPIO_RZ_IOPORT_REG_REGION_GET((port << 8U) | pin) == 1 ? &R_PORT_NSR->P[port]             \
-								: &R_PORT_SR->P[port])
+#define GPIO_RZ_P_REG_BASE_GET(port, pin)                                                          \
+	(GPIO_RZ_REG_REGION_GET((port << 8U) | pin) == 1 ? &R_PORT_NSR->P[port]                    \
+							 : &R_PORT_SR->P[port])
 
-#define GPIO_RZ_IOPORT_PM_REG_BASE_GET(port, pin)                                                  \
-	(GPIO_RZ_IOPORT_REG_REGION_GET((port << 8U) | pin) == 1 ? &R_PORT_NSR->PM[port]            \
-								: &R_PORT_SR->PM[port])
+#define GPIO_RZ_PM_REG_BASE_GET(port, pin)                                                         \
+	(GPIO_RZ_REG_REGION_GET((port << 8U) | pin) == 1 ? &R_PORT_NSR->PM[port]                   \
+							 : &R_PORT_SR->PM[port])
 
-#define GPIO_RZ_IOPORT_PFC_REG_BASE_GET(port, pin)                                                 \
-	(GPIO_RZ_IOPORT_REG_REGION_GET((port << 8U) | pin) == 1 ? &R_PORT_NSR->PFC[port]           \
-								: &R_PORT_SR->PFC[port])
+#define GPIO_RZ_PFC_REG_BASE_GET(port, pin)                                                        \
+	(GPIO_RZ_REG_REGION_GET((port << 8U) | pin) == 1 ? &R_PORT_NSR->PFC[port]                  \
+							 : &R_PORT_SR->PFC[port])
 
-#define GPIO_RZ_IOPORT_P_REG_GET(port, pin)   (GPIO_RZ_IOPORT_P_REG_BASE_GET(port, pin))
-#define GPIO_RZ_IOPORT_PM_REG_GET(port, pin)  (GPIO_RZ_IOPORT_PM_REG_BASE_GET(port, pin))
-#define GPIO_RZ_IOPORT_PFC_REG_GET(port, pin) (GPIO_RZ_IOPORT_PFC_REG_BASE_GET(port, pin))
+#define GPIO_RZ_P_REG_GET(port, pin)   (GPIO_RZ_P_REG_BASE_GET(port, pin))
+#define GPIO_RZ_PM_REG_GET(port, pin)  (GPIO_RZ_PM_REG_BASE_GET(port, pin))
+#define GPIO_RZ_PFC_REG_GET(port, pin) (GPIO_RZ_PFC_REG_BASE_GET(port, pin))
 
 #define GPIO_RZ_P_VALUE_GET(value, pin)   ((value >> pin) & 1U)
 #define GPIO_RZ_PM_VALUE_GET(value, pin)  ((value >> (pin * 2)) & 3U)
 #define GPIO_RZ_PFC_VALUE_GET(value, pin) ((value >> (pin * 4)) & 0xF)
 
-#define GPIO_RZ_IOPORT_PFC_SET(value) (value << 4)
-
 #define GPIO_RZ_PIN_DISCONNECT(port, pin)                                                          \
-	*GPIO_RZ_IOPORT_PM_REG_GET((port >> 8U), pin) &= ~(3U << (pin * 2))
+	*GPIO_RZ_PM_REG_GET((port >> 8U), pin) &= ~(3U << (pin * 2))
 
 #define GPIO_RZ_MAX_INT_NUM 16
 
@@ -119,13 +114,12 @@ static const uint8_t gpio_rz_int[GPIO_RZ_MAX_PORT_NUM] = {
 #define GPIO_RZ_INT_BOTH_EDGE    0x2
 #define GPIO_RZ_INT_LEVEL_LOW    0x3
 #define GPIO_RZ_INT_LEVEL_HIGH   GPIO_RZ_INT_UNSUPPORTED
+#define GPIO_RZ_INT_ENABLE       (1U << 3)
+#define GPIO_RZ_INT_DISABLE      (~(1U << 3))
 
-#define GPIO_RZ_PIN_CONFIGURE_GET(flag) (((flag >> RZTN_GPIO_DRCTL_SHIFT) & 0x33) << 8U)
-
-#define GPIO_RZ_PIN_CONFIGURE_INT_ENABLE         (1U << 3)
-#define GPIO_RZ_PIN_CONFIGURE_INT_DISABLE        (~(1U << 3))
-#define GPIO_RZ_PIN_CONFIGURE_INPUT_OUTPUT_RESET (~(0x3 << 2))
-#define GPIO_RZ_PIN_SPECIAL_FLAG_GET(flag)       IOPORT_CFG_REGION_NSAFETY
+#define GPIO_RZ_FLAG_GET_CONFIG(flag)   (((flag >> RZTN_GPIO_DRCTL_SHIFT) & 0x33) << 8U)
+#define GPIO_RZ_FLAG_SET_PFC(value)     (value << 4)
+#define GPIO_RZ_FLAG_GET_SPECIFIC(flag) IOPORT_CFG_REGION_NSAFETY
 
 #endif /* CONFIG_SOC_* */
 


### PR DESCRIPTION
The RZ GPIO driver now can supports all RZ devices and has entered the maintenance stage.
Mass renaming is carried out first to unify some prefixes and shorten some macros, making the code easier to read and maintain. There is no impact on functionality.

- Rename `int_dev` to `gpio_int_dev` for gpio interrupt
- Rename `eirq` to `ext_irq` for external interrupt
- Rename `gpio_rz_hw_config` to `gpio_rz_flags`
- Rename `p_pm` to `gpio_flags`
- Rename `pre_flags` to `rz_flags`
- Remove `_IOPORT` and `_PIN_CONFIGURE` in some macros
- Rename `GPIO_RZ_PIN_CONFIGURE_GET_FILTER`, `GPIO_RZ_PIN_CONFIGURE_GET`, `GPIO_RZ_PIN_SPECIAL_FLAG_GET` to `GPIO_RZ_FLAG_GET_FILTER`, `GPIO_RZ_FLAG_GET_CONFIG`, `GPIO_RZ_FLAG_GET_SPECIFIC` respectively