### PR TITLE
dts: silabs: xg29 flash controller int level fix

### DIFF
--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -266,7 +266,7 @@
 		msc: flash-controller@50030000 {
 			compatible = "silabs,series2-flash-controller";
 			reg = <0x50030000 0x4000>;
-			interrupts = <55 1>;
+			interrupts = <55 2>;
 			interrupt-names = "msc";
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
Accidentall chosen wrong interrup level for flash controller fixed to be inline with other devices flash controller level