### PR TITLE
mgmt: hawkbit: also clear in the call of hawkbit_autohandler()

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit_autohandler.c
+++ b/subsys/mgmt/hawkbit/hawkbit_autohandler.c
@@ -115,6 +115,8 @@ int hawkbit_autohandler_set_delay(k_timeout_t timeout, bool if_bigger)
 
 void hawkbit_autohandler(bool auto_reschedule)
 {
+	k_event_clear(&hawkbit_autohandler_event, UINT32_MAX);
+
 	if (auto_reschedule) {
 		k_work_reschedule(&hawkbit_work_handle, K_NO_WAIT);
 	} else {


### PR DESCRIPTION
the k_event_clear in the work might be to late sometimes, when
hawkbit_autohandler_wait() is executed directly after
hawkbit_autohandler(). This leads to getting the events
of the former execution and also not waiting until the
current autohandler run is finished.