### PR TITLE
fs: shell: fix maybe-uninitialized warning

### DIFF
--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -403,7 +403,7 @@ static int cmd_read(const struct shell *sh, size_t argc, char **argv)
 		}
 	}
 
-	ssize_t read;
+	ssize_t read = 0;
 	while (count > 0) {
 		uint8_t buf[16];
 		int i;


### PR DESCRIPTION
`read` may have been used uninitialized.

OK it can't, cause count can't be <= 0 but the compiler is complaining about it.