### PR TITLE
cmake: yaml: update timestamp on intermediate file save

### DIFF
--- a/cmake/modules/yaml.cmake
+++ b/cmake/modules/yaml.cmake
@@ -534,6 +534,7 @@ function(yaml_save)
 
     to_yaml("${json_content}" 0 yaml_out TEMP_GENEX)
     FILE(GENERATE OUTPUT ${expanded_file} CONTENT "${yaml_out}")
+    FILE(TOUCH ${expanded_file}) # ensure timestamp is updated even if nothing changed
   endif()
 endfunction()
 


### PR DESCRIPTION
`file(GENERATE ...)` does not update the output file if the content is unchanged. Since the metadata in `build_info.yml` mostly depends on the build configuration, the timestamp of the intermediate file does not get updated on most rebuilds, while the final file does, due to immediate `file(WRITE ...)` calls. Since the latter is newer, no post-process step is executed and the file is left with commented genexes.

Touching the intermediate file ensures that the post-process step is performed every time, even if the content is unchanged, restoring the expected behavior.

Fixes #88324.