### PR TITLE
driver: interrupt-controller: vim: Fix address and check configured number of interrupts

### DIFF
--- a/drivers/interrupt_controller/intc_vim.c
+++ b/drivers/interrupt_controller/intc_vim.c
@@ -1,5 +1,6 @@
 /* Copyright (C) 2023 BeagleBoard.org Foundation
  * Copyright (C) 2023 S Prashanth
+ * Copyright (C) 2025 Siemens Mobility GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,8 +57,7 @@ void z_vim_irq_eoi(unsigned int irq)
 
 void z_vim_irq_init(void)
 {
-	uint32_t num_of_irqs = sys_read32(VIM_INFO_INTERRUPTS_MASK);
-
+	uint32_t num_of_irqs = sys_read32(VIM_INFO) & VIM_INFO_INTERRUPTS_MASK;
 	LOG_DBG("VIM: Number of IRQs = %u\n", num_of_irqs);
 }
 

--- a/drivers/interrupt_controller/intc_vim.c
+++ b/drivers/interrupt_controller/intc_vim.c
@@ -15,6 +15,7 @@
 #include <zephyr/drivers/interrupt_controller/intc_vim.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include "zephyr/sys/__assert.h"
 #include <zephyr/sys/util_macro.h>
 
 LOG_MODULE_REGISTER(vim);
@@ -58,6 +59,11 @@ void z_vim_irq_eoi(unsigned int irq)
 void z_vim_irq_init(void)
 {
 	uint32_t num_of_irqs = sys_read32(VIM_INFO) & VIM_INFO_INTERRUPTS_MASK;
+
+	__ASSERT(CONFIG_NUM_IRQS == num_of_irqs,
+		 "Number of configured interrupts (%d) doesn't match reported "
+		 "(%" PRIu32 ") interrupts",
+		 CONFIG_NUM_IRQS, num_of_irqs);
 	LOG_DBG("VIM: Number of IRQs = %u\n", num_of_irqs);
 }
 


### PR DESCRIPTION
This PR fixes a wrong address in the VIM interrupt controller and adds an assert that verfies the amount of reported interrupts from the VIM with the amount of configured interrupts in the Kconfig