### PR TITLE
dts: nxp: wifi: nxp,wifi is not an SD device

### DIFF
--- a/dts/bindings/wifi/nxp,wifi.yaml
+++ b/dts/bindings/wifi/nxp,wifi.yaml
@@ -7,4 +7,4 @@ description: |
 
 compatible: "nxp,wifi"
 
-include: [sd-device.yaml, pinctrl-device.yaml]
+include: [base.yaml, pinctrl-device.yaml]

--- a/dts/bindings/wifi/nxp,wifi.yaml
+++ b/dts/bindings/wifi/nxp,wifi.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    NXP Wifi Module
+    NXP Wi-Fi Module
 
 compatible: "nxp,wifi"
 


### PR DESCRIPTION
inherit from base.yaml instead of sd-device.yaml since this device is not meant to be used on an SD bus.