### PR TITLE
arm64: reset: flush D-Cache before it is disabled

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -364,4 +364,13 @@ config ARM64_DCACHE_ALL_OPS
 	  Enable this option to provide the data cache APIs to flush or
 	  invalidate all data caches.
 
+config ARM64_BOOT_DISABLE_DCACHE
+	bool "Disable data cache before enable MMU when booting from EL2"
+	depends on ARM64_DCACHE_ALL_OPS
+	help
+	  To make it safe, if data cache is enabled in case of Zephyr is booting
+	  from EL2, enable this option, it will clean and invalidate all data
+	  cache and then disable data cache, it will will be re-enabled after
+	  MMU is configured and enabled.
+
 endif # CPU_CORTEX_A || CPU_AARCH64_CORTEX_R

--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -357,4 +357,11 @@ config MAX_XLAT_TABLES
 
 endif # ARM_MMU
 
+config ARM64_DCACHE_ALL_OPS
+	bool "Provide data cache APIs to operate all data caches"
+	depends on CACHE_MANAGEMENT && DCACHE
+	help
+	  Enable this option to provide the data cache APIs to flush or
+	  invalidate all data caches.
+
 endif # CPU_CORTEX_A || CPU_AARCH64_CORTEX_R

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -58,10 +58,9 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset_prep_c)
 	b	out
 #endif /* CONFIG_ARMV8_R */
 2:
-	/* Disable alignment fault checking, disable D-Cache, I-Cache, MMU for safety */
+	/* Disable alignment fault checking */
 	mrs	x0, sctlr_el2
-	mov	x1, #(SCTLR_A_BIT | SCTLR_C_BIT | SCTLR_M_BIT | SCTLR_I_BIT)
-	bic	x0, x0, x1
+	bic	x0, x0, SCTLR_A_BIT
 	msr	sctlr_el2, x0
 	isb
 

--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -139,6 +139,8 @@ done:
 	return 0;
 }
 
+#ifdef CONFIG_ARM64_DCACHE_ALL_OPS
+
 /*
  * operation for all data cache
  * ops:  K_CACHE_INVD: invalidate
@@ -226,6 +228,25 @@ static ALWAYS_INLINE int arch_dcache_flush_and_invd_all(void)
 {
 	return arm64_dcache_all(K_CACHE_WB_INVD);
 }
+
+#else
+
+static ALWAYS_INLINE int arch_dcache_flush_all(void)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_dcache_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
+static ALWAYS_INLINE int arch_dcache_flush_and_invd_all(void)
+{
+	return -ENOTSUP;
+}
+
+#endif /* CONFIG_ARM64_DCACHE_ALL_OPS */
 
 static ALWAYS_INLINE int arch_dcache_flush_range(void *addr, size_t size)
 {

--- a/include/zephyr/arch/arm64/cache.h
+++ b/include/zephyr/arch/arm64/cache.h
@@ -139,19 +139,92 @@ done:
 	return 0;
 }
 
+/*
+ * operation for all data cache
+ * ops:  K_CACHE_INVD: invalidate
+ *	 K_CACHE_WB: clean
+ *	 K_CACHE_WB_INVD: clean and invalidate
+ */
+static ALWAYS_INLINE int arm64_dcache_all(int op)
+{
+	uint32_t clidr_el1, csselr_el1, ccsidr_el1;
+	uint8_t loc, ctype, cache_level, line_size, way_pos;
+	uint32_t max_ways, max_sets, dc_val, set, way;
+
+	if (op != K_CACHE_INVD && op != K_CACHE_WB && op != K_CACHE_WB_INVD) {
+		return -ENOTSUP;
+	}
+
+	/* Data barrier before start */
+	barrier_dsync_fence_full();
+
+	clidr_el1 = read_clidr_el1();
+
+	loc = (clidr_el1 >> CLIDR_EL1_LOC_SHIFT) & CLIDR_EL1_LOC_MASK;
+	if (!loc) {
+		return 0;
+	}
+
+	for (cache_level = 0; cache_level < loc; cache_level++) {
+		ctype = (clidr_el1 >> CLIDR_EL1_CTYPE_SHIFT(cache_level)) & CLIDR_EL1_CTYPE_MASK;
+		/* No data cache, continue */
+		if (ctype < 2) {
+			continue;
+		}
+
+		/* select cache level */
+		csselr_el1 = cache_level << 1;
+		write_csselr_el1(csselr_el1);
+		barrier_isync_fence_full();
+
+		ccsidr_el1 = read_ccsidr_el1();
+		line_size = (ccsidr_el1 >> CCSIDR_EL1_LN_SZ_SHIFT & CCSIDR_EL1_LN_SZ_MASK) + 4;
+		max_ways = (ccsidr_el1 >> CCSIDR_EL1_WAYS_SHIFT) & CCSIDR_EL1_WAYS_MASK;
+		max_sets = (ccsidr_el1 >> CCSIDR_EL1_SETS_SHIFT) & CCSIDR_EL1_SETS_MASK;
+		/* 32-log2(ways), bit position of way in DC operand */
+		way_pos = __builtin_clz(max_ways);
+
+		for (set = 0; set <= max_sets; set++) {
+			for (way = 0; way <= max_ways; way++) {
+				/* way number, aligned to pos in DC operand */
+				dc_val = way << way_pos;
+				/* cache level, aligned to pos in DC operand */
+				dc_val |= csselr_el1;
+				/* set number, aligned to pos in DC operand */
+				dc_val |= set << line_size;
+
+				if (op == K_CACHE_INVD) {
+					dc_ops("isw", dc_val);
+				} else if (op == K_CACHE_WB_INVD) {
+					dc_ops("cisw", dc_val);
+				} else if (op == K_CACHE_WB) {
+					dc_ops("csw", dc_val);
+				}
+			}
+		}
+	}
+
+	/* Restore csselr_el1 to level 0 */
+	write_csselr_el1(0);
+	barrier_dsync_fence_full();
+	barrier_isync_fence_full();
+
+	return 0;
+}
+
 static ALWAYS_INLINE int arch_dcache_flush_all(void)
 {
-	return -ENOTSUP;
+	return arm64_dcache_all(K_CACHE_WB);
 }
 
 static ALWAYS_INLINE int arch_dcache_invd_all(void)
 {
-	return -ENOTSUP;
+	return arm64_dcache_all(K_CACHE_INVD);
 }
 
 static ALWAYS_INLINE int arch_dcache_flush_and_invd_all(void)
 {
-	return -ENOTSUP;
+	return arm64_dcache_all(K_CACHE_WB_INVD);
 }
 
 static ALWAYS_INLINE int arch_dcache_flush_range(void *addr, size_t size)

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8ml8_a53
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 NXP
+# Copyright 2021-2023, 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX8ML8_A53
@@ -14,6 +14,12 @@ config FLASH_BASE_ADDRESS
 
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
+	default y
+
+# Disable data cache until MMU is enabled when booting from EL2
+config ARM64_DCACHE_ALL_OPS
+	default y
+config ARM64_BOOT_DISABLE_DCACHE
 	default y
 
 config NUM_IRQS

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mm6_a53
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 NXP
+# Copyright 2020-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX8MM6_A53
@@ -14,6 +14,12 @@ config FLASH_BASE_ADDRESS
 
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
+	default y
+
+# Disable data cache until MMU is enabled when booting from EL2
+config ARM64_DCACHE_ALL_OPS
+	default y
+config ARM64_BOOT_DISABLE_DCACHE
 	default y
 
 config NUM_IRQS

--- a/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
+++ b/soc/nxp/imx/imx8m/Kconfig.defconfig.mimx8mn6_a53
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 NXP
+# Copyright 2022-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX8MN6_A53
@@ -14,6 +14,12 @@ config FLASH_BASE_ADDRESS
 
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
+	default y
+
+# Disable data cache until MMU is enabled when booting from EL2
+config ARM64_DCACHE_ALL_OPS
+	default y
+config ARM64_BOOT_DISABLE_DCACHE
 	default y
 
 config NUM_IRQS

--- a/soc/nxp/imx/imx9/imx91/Kconfig.defconfig.mimx91
+++ b/soc/nxp/imx/imx9/imx91/Kconfig.defconfig.mimx91
@@ -18,4 +18,10 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 24000000
 
+# Disable data cache until MMU is enabled when booting from EL2
+config ARM64_DCACHE_ALL_OPS
+	default y
+config ARM64_BOOT_DISABLE_DCACHE
+	default y
+
 endif

--- a/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
+++ b/soc/nxp/imx/imx9/imx93/Kconfig.defconfig.mimx93.a55
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 NXP
+# Copyright 2022-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX9352_A55
@@ -14,6 +14,12 @@ config FLASH_BASE_ADDRESS
 
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
+	default y
+
+# Disable data cache until MMU is enabled when booting from EL2
+config ARM64_DCACHE_ALL_OPS
+	default y
+config ARM64_BOOT_DISABLE_DCACHE
 	default y
 
 config NUM_IRQS

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.a55
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 if SOC_MIMX9596_A55
@@ -14,6 +14,12 @@ config FLASH_BASE_ADDRESS
 
 # Enable GIC Safe Configuration to run multiple OSes on Cortex-A Cores
 config GIC_SAFE_CONFIG
+	default y
+
+# Disable data cache until MMU is enabled when booting from EL2
+config ARM64_DCACHE_ALL_OPS
+	default y
+config ARM64_BOOT_DISABLE_DCACHE
 	default y
 
 config NUM_IRQS


### PR DESCRIPTION
In the commit 573a712bed06d984aab4a0b7424fc146e72c0921 patch "arm64: reset: disable cache and MMU for safety", it disables D-Cache and MMU for safety, but in some cases, for example the code is loaded into memory by hardware debugger, we need to flush D-Cache before disable it in order to make sure the data is coherent in the system, otherwise it will report "Synchronous Abort" when D-Cache is disabled.

So in this PR need to revert commit 867ba172b46ccc528f2f9f1d3fb532e50e30ceb4 "arch: arm64: cache: delete arm64_dcache_all" in order to flush all d-cache, although it can't broadcast the flush operation to other CPU Cores, but it is safety and depend on hardware to make sure it is safe for all CPU Cores. Even for SMP OS, one thread want to flush all the Cores, there is no software notification to other Cores, it up to system bus to make sure it is safe.