### PR TITLE
boards: imx93_evk: add jlink runner support for a55 core

### DIFF
--- a/boards/nxp/imx93_evk/CMakeLists.txt
+++ b/boards/nxp/imx93_evk/CMakeLists.txt
@@ -1,4 +1,16 @@
+#
+# Copyright 2025 NXP
+#
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
 zephyr_library_sources(board.c)
+
+if(CONFIG_SOC_MIMX9352_A55)
+  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/runner.jlinkscript
+    "LE
+    loadfile "${CMAKE_BINARY_DIR}/zephyr/zephyr.bin" ${CONFIG_SRAM_BASE_ADDRESS}
+    WReg PC ${CONFIG_SRAM_BASE_ADDRESS}
+    g
+    q")
+endif()

--- a/boards/nxp/imx93_evk/board.cmake
+++ b/boards/nxp/imx93_evk/board.cmake
@@ -1,1 +1,12 @@
+#
+# Copyright 2025 NXP
+#
 # SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_MIMX9352_A55)
+
+board_runner_args(jlink "--device=MIMX9352_A55_0" "--no-reset" "--flash-script=${CMAKE_BINARY_DIR}/zephyr/runner.jlinkscript")
+
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+
+endif()

--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -118,8 +118,60 @@ Programming and Debugging (A55)
 
 .. zephyr:board-supported-runners::
 
-U-Boot "cpu" command is used to load and kick Zephyr to Cortex-A secondary Core, Currently
-it is supported in : `Real-Time Edge U-Boot`_ (use the branch "uboot_vxxxx.xx-y.y.y,
+There are multiple method to program and debug Zephyr on the A55 core:
+
+Option 1. Boot Zephyr by Using JLink Runner
+===========================================
+
+The default runner for the board is JLink, connect the EVK board's JTAG connector to
+the host computer using a J-Link debugger, power up the board and stop the board at
+U-Boot command line, execute the following U-boot command to disable D-Cache:
+
+.. code-block:: console
+
+    dcache off
+
+then use "west flash" or "west debug" command to load the zephyr.bin
+image from the host computer and start the Zephyr application on A55 core0.
+
+Flash and Run
+-------------
+
+Here is an example for the :zephyr:code-sample:`synchronization` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/synchronization
+   :host-os: unix
+   :board: imx93_evk/mimx9352/a55
+   :goals: flash
+
+Then the following log could be found on UART2 console:
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build Booting Zephyr OS build v3.7.0-2055-g630f27a5a867  ***
+    thread_a: Hello World from cpu 0 on imx93_evk!
+    thread_b: Hello World from cpu 0 on imx93_evk!
+    thread_a: Hello World from cpu 0 on imx93_evk!
+    thread_b: Hello World from cpu 0 on imx93_evk!
+
+Debug
+-----
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: imx93_evk/mimx9352/a55
+   :goals: debug
+
+Option 2. Boot Zephyr by Using U-Boot Command
+=============================================
+
+U-Boot "go" command can be used to start Zephyr on A55 core0 and U-Boot "cpu" command
+is used to load and kick Zephyr to the other A55 secondary Cores. Currently "cpu" command
+is supported in : `Real-Time Edge U-Boot`_ (use the branch "uboot_vxxxx.xx-y.y.y,
 xxxx.xx is uboot version and y.y.y is Real-Time Edge Software version, for example
 "uboot_v2023.04-2.9.0" branch is U-Boot v2023.04 used in Real-Time Edge Software release
 v2.9.0), and pre-build images and user guide can be found at `Real-Time Edge Software`_.
@@ -129,23 +181,45 @@ v2.9.0), and pre-build images and user guide can be found at `Real-Time Edge Sof
 .. _Real-Time Edge Software:
    https://www.nxp.com/rtedge
 
-Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
-plug the SD card into the board. Power it up and stop the u-boot execution at
-prompt.
+Step 1: Download Zephyr Image into DDR Memory
+---------------------------------------------
 
-Use U-Boot to load and kick zephyr.bin to Cortex-A55 Core1:
-
-.. code-block:: console
-
-    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; cpu 1 release 0xd0000000
-
-
-Or use the following command to kick zephyr.bin to Cortex-A55 Core0:
+Firstly need to download Zephyr binary image into DDR memory, it can use tftp:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0xd0000000 zephyr.bin; dcache flush; icache flush; go 0xd0000000
+    tftp 0xd0000000 zephyr.bin
 
+Or copy the Zephyr image ``zephyr.bin`` SD card and plug the card into the board, for example
+if copy to the FAT partition of the SD card, use the following U-Boot command to load the image
+into DDR memory (assuming the SD card is dev 1, fat partition ID is 1, they could be changed
+based on actual setup):
+
+.. code-block:: console
+
+    fatload mmc 1:1 0xd0000000 zephyr.bin;
+
+Step 2: Boot Zephyr
+-------------------
+
+Then use the following command to boot Zephyr on the core0:
+
+.. code-block:: console
+
+    dcache off; icache flush; go 0xd0000000;
+
+Or use "cpu" command to boot from secondary Core, for example Core1:
+
+.. code-block:: console
+
+    dcache flush; icache flush; cpu 1 release 0xd0000000
+
+Option 3. Boot Zephyr by Using Remoteproc under Linux
+=====================================================
+
+When running Linux on the A55 core, it can use the remoteproc framework to load and boot Zephyr,
+refer to Real-Time Edge user guide for more details. Pre-build images and user guide can be found
+at `Real-Time Edge Software`_.
 
 Use this configuration to run basic Zephyr applications and kernel tests,
 for example, with the :zephyr:code-sample:`synchronization` sample:


### PR DESCRIPTION
Added jlink runner support for A-core platform on i.MX93 EVK board, so that can use "west flash" to download zephyr.bin to DDR memory and then boot the Zephyr on Cortex-A55 Core0.