### PR TITLE
libc: Add support for ferror() in common libc

### DIFF
--- a/lib/libc/CMakeLists.txt
+++ b/lib/libc/CMakeLists.txt
@@ -12,3 +12,6 @@ add_subdirectory_ifdef(CONFIG_NEWLIB_LIBC       newlib)
 add_subdirectory_ifdef(CONFIG_PICOLIBC          picolibc)
 
 add_subdirectory(common)
+
+# Additional libraries or modules can be added here as needed
+

--- a/lib/libc/common/CMakeLists.txt
+++ b/lib/libc/common/CMakeLists.txt
@@ -21,5 +21,9 @@ zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_THRD
     )
 zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_REMOVE source/stdio/remove.c)
 
+# Add the ferror implementation here
+zephyr_library_sources_ifdef(CONFIG_COMMON_LIBC_FERROR source/stdio/ferror.c)
+
 # Prevent compiler from optimizing calloc into an infinite recursive call
 zephyr_library_compile_options($<TARGET_PROPERTY:compiler,no_builtin_malloc>)
+

--- a/lib/libc/common/Kconfig
+++ b/lib/libc/common/Kconfig
@@ -120,3 +120,10 @@ config COMMON_LIBC_REMOVE
 	default y if FILE_SYSTEM
 	help
 	  Common implementation of remove().
+
+
+config COMMON_LIBC_FERROR
+	bool "Support for ferror"
+	default y
+	help
+	  Enable the common implementation of ferror() in libc.

--- a/lib/libc/common/source/stdio/ferror.c
+++ b/lib/libc/common/source/stdio/ferror.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int ferror(FILE *stream)
+{
+    if (stream == NULL) {
+        return 0;
+    }
+
+    return stream->err;
+}


### PR DESCRIPTION
### Description

This PR adds support for the `ferror()` function in Zephyr's common C library implementation. The `ferror()` function is used to check for errors on a file stream, providing an essential part of the standard I/O error handling functionality.

The implementation includes the creation of a new source file to define the `ferror()` function, updates to the CMake build system to include the new source, and a Kconfig option to enable or disable this feature. This enhancement improves compatibility with applications relying on standard error handling for file operations, making Zephyr's libc more robust.
