### PR TITLE
tests: json: fix tests involving double numbers

### DIFF
--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -745,10 +745,10 @@ ZTEST(lib_json_test, test_json_double_nan)
 			 "}";
 
 	struct test_double doubles = {
-		.some_double = NAN,
-		.another_double = NAN,
-		.some_array[0] = NAN,
-		.some_array[1] = NAN,
+		.some_double = (double)NAN,
+		.another_double = (double)NAN,
+		.some_array[0] = (double)NAN,
+		.some_array[1] = (double)NAN,
 		.some_array_len = 2,
 	};
 
@@ -775,10 +775,10 @@ ZTEST(lib_json_test, test_json_double_infinity)
 			 "}";
 
 	struct test_double doubles = {
-		.some_double = INFINITY,
-		.another_double = -INFINITY,
-		.some_array[0] = INFINITY,
-		.some_array[1] = -INFINITY,
+		.some_double = (double)INFINITY,
+		.another_double = (double)-INFINITY,
+		.some_array[0] = (double)INFINITY,
+		.some_array[1] = (double)-INFINITY,
 		.some_array_len = 2,
 	};
 


### PR DESCRIPTION
Update the JSON test cases to explicitly cast NAN and INFINITY to double type to avoid implicit promotion.

fixes CI issue with clang -- https://github.com/zephyrproject-rtos/zephyr/actions/runs/14366010960/job/40279000138#step:11:1