### PR TITLE
soc: stm32h7r/s: smps is supported on all SoCs

### DIFF
--- a/soc/st/stm32/stm32h7rsx/soc.c
+++ b/soc/st/stm32/stm32h7rsx/soc.c
@@ -36,16 +36,6 @@ void soc_early_init_hook(void)
 	SystemCoreClock = 64000000;
 
 	/* Power Configuration */
-#if !defined(SMPS) && \
-		(defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT_AND_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT_AND_LDO) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_EXT) || \
-		defined(CONFIG_POWER_SUPPLY_SMPS_2V5_SUPPLIES_EXT))
-#error Unsupported configuration: Selected SoC do not support SMPS
-#endif
 #if defined(CONFIG_POWER_SUPPLY_DIRECT_SMPS)
 	LL_PWR_ConfigSupply(LL_PWR_DIRECT_SMPS_SUPPLY);
 #elif defined(CONFIG_POWER_SUPPLY_SMPS_1V8_SUPPLIES_LDO)

--- a/west.yml
+++ b/west.yml
@@ -238,7 +238,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: f467d8e039216b4f5f9b55dd8a1ffa8582fc516d
+      revision: c17bcab857dbf2ec3100b2d0c3123957fcd42e78
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Remove the sanity check between Cube HAL SMPS symbol and Kconfig SMPS configuration.
SMPS is available on all STM32H7R/S SoC, so misalignment isn't possible.

Additionally, point to the hal commit which reverts the fix which was done on hal_stm32 to add this symbol.