### PR TITLE
soc: ti: k3: am6x: do not override KERNEL_ENTRY

### DIFF
--- a/soc/ti/k3/am6x/Kconfig.defconfig
+++ b/soc/ti/k3/am6x/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_SERIES_AM6X
 
 config KERNEL_ENTRY
-	default "_vector_table"
+	default "_vector_table" if SOC_SERIES_AM6X_R5
 
 # Workaround for not being able to have commas in macro arguments
 DT_CHOSEN_Z_FLASH := zephyr,flash


### PR DESCRIPTION
The SOC defconfig overrides `CONFIG_KERNEL_ENTRY` from the default value of `__start` to `_vector_table`. This is undesirable for cores such as M4 where the `_vector_table` symbol has just raw addresses and no instructions. The default `__start` symbol is sensible for all the cores so don't override it.

Tested on AM64x/AM243x EVM's M4 and R5 cores with SBL bootloader. 

Can someone who boots zephyr on M4 via remoteproc on Linux confirm if this does not cause any issues?