### PR TITLE
modules: hal_nxp: Fix bt_controller cmake load issue

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/middleware.cmake
@@ -40,6 +40,4 @@ add_subdirectory(${MCUX_SDK_NG_DIR}/middleware/usb
   ${CMAKE_CURRENT_BINARY_DIR}/usb
 )
 
-if(CONFIG_BT_H4_NXP_CTLR)
-  add_subdirectory(bt_controller)
-endif()
+add_subdirectory_ifdef(CONFIG_BT_H4_NXP_CTLR ${CMAKE_CURRENT_LIST_DIR}/bt_controller)


### PR DESCRIPTION
In middleware/CMakeLists.txt, using `add_subdirectory()` to load the cmakelists.txt under bt_controller will result in the bt_controller directory not being found correctly, because the starting point of the query is mcux-sdk-ng/CMakeLists.txt. Need to add `${CMAKE_CURRENT_LIST_DIR}` to bt_controller to correctly locate the folder.