### PR TITLE
doc: releases: Intermediate update for new 4.2 boards/samples/drivers

### DIFF
--- a/boards/intel/btl/doc/index.rst
+++ b/boards/intel/btl/doc/index.rst
@@ -1,7 +1,4 @@
-.. _intel_btl_s:
-
-Bartlett Lake S
-###############
+.. zephyr:board:: intel_btl_s_crb
 
 Overview
 ********
@@ -19,6 +16,8 @@ This board configuration enables kernel support for the Bartlett Lake S boards.
 
 Hardware
 ********
+
+.. zephyr:board-supported-hw::
 
 General information about the board can be found at the `BTL`_ website.
 

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -175,20 +175,65 @@ New Boards
 
 * Adafruit Industries, LLC
 
-   * :zephyr:board:`adafruit_feather_esp32s3_tft` (``adafruit_feather_esp32s3_tft``)
+   * :zephyr:board:`adafruit_feather_esp32s2` (``adafruit_feather_esp32s2``)
+   * :zephyr:board:`adafruit_feather_esp32s2_tft` (``adafruit_feather_esp32s2_tft``)
+   * :zephyr:board:`adafruit_feather_esp32s2_tft_reverse` (``adafruit_feather_esp32s2_tft_reverse``)
    * :zephyr:board:`adafruit_feather_esp32s3` (``adafruit_feather_esp32s3``)
+   * :zephyr:board:`adafruit_feather_esp32s3_tft` (``adafruit_feather_esp32s3_tft``)
+
+* Advanced Micro Devices (AMD), Inc.
+
+   * :zephyr:board:`versalnet_rpu` (``versalnet_rpu``)
+
+* Blues Wireless
+
+   * :zephyr:board:`cygnet` (``cygnet``)
 
 * FANKE Technology Co., Ltd.
 
    * :zephyr:board:`fk743m5_xih6` (``fk743m5_xih6``)
 
+* IAR Systems AB
+
+   * :zephyr:board:`stm32f429ii_aca` (``stm32f429ii_aca``)
+
+* Intel Corporation
+
+   * :zephyr:board:`intel_btl_s_crb` (``intel_btl_s_crb``)
+
+* ITE Tech. Inc.
+
+   * :zephyr:board:`it515xx_evb` (``it515xx_evb``)
+
+* KWS Computersysteme Gmbh
+
+   * :zephyr:board:`pico2_spe` (``pico2_spe``)
+   * :zephyr:board:`pico_spe` (``pico_spe``)
+
+* Lilygo Shenzhen Xinyuan Electronic Technology Co., Ltd
+
+   * :zephyr:board:`tdongle_s3` (``tdongle_s3``)
+   * :zephyr:board:`ttgo_tbeam` (``ttgo_tbeam``)
+   * :zephyr:board:`ttgo_toiplus` (``ttgo_toiplus``)
+   * :zephyr:board:`twatch_s3` (``twatch_s3``)
+
 * Nuvoton Technology Corporation
 
    * :zephyr:board:`numaker_m55m1` (``numaker_m55m1``)
 
+* NXP Semiconductors
+
+   * :zephyr:board:`frdm_mcxa166` (``frdm_mcxa166``)
+   * :zephyr:board:`frdm_mcxa276` (``frdm_mcxa276``)
+
 * Octavo Systems LLC
 
    * :zephyr:board:`osd32mp1_brk` (``osd32mp1_brk``)
+
+* OpenHW Group
+
+   * :zephyr:board:`cv32a6_genesys_2` (``cv32a6_genesys_2``)
+   * :zephyr:board:`cv64a6_genesys_2` (``cv64a6_genesys_2``)
 
 * Pimoroni Ltd.
 
@@ -197,8 +242,20 @@ New Boards
 * Renesas Electronics Corporation
 
    * :zephyr:board:`rza3ul_smarc` (``rza3ul_smarc``)
+   * :zephyr:board:`rzg2l_smarc` (``rzg2l_smarc``)
    * :zephyr:board:`rzn2l_rsk` (``rzn2l_rsk``)
    * :zephyr:board:`rzt2l_rsk` (``rzt2l_rsk``)
+   * :zephyr:board:`rzt2m_rsk` (``rzt2m_rsk``)
+   * :zephyr:board:`rzv2l_smarc` (``rzv2l_smarc``)
+
+* Seeed Technology Co., Ltd
+
+   * :zephyr:board:`xiao_mg24` (``xiao_mg24``)
+   * :zephyr:board:`xiao_ra4m1` (``xiao_ra4m1``)
+
+* sensry.io
+
+   * :zephyr:board:`ganymed_sk` (``ganymed_sk``)
 
 * Silicon Laboratories
 
@@ -206,7 +263,9 @@ New Boards
 
 * STMicroelectronics
 
+   * :zephyr:board:`nucleo_f439zi` (``nucleo_f439zi``)
    * :zephyr:board:`stm32h757i_eval` (``stm32h757i_eval``)
+   * :zephyr:board:`stm32mp135f_dk` (``stm32mp135f_dk``)
 
 * Texas Instruments
 
@@ -221,6 +280,10 @@ New Boards
 
    * :zephyr:board:`w5500_evb_pico2` (``w5500_evb_pico2``)
 
+* Würth Elektronik GmbH.
+
+   * :zephyr:board:`ophelia4ev` (``ophelia4ev``)
+
 New Drivers
 ***********
 
@@ -232,10 +295,23 @@ New Drivers
 
    * :dtcompatible:`adi,ad4050-adc`
    * :dtcompatible:`adi,ad4052-adc`
+   * :dtcompatible:`adi,ad4130-adc`
    * :dtcompatible:`renesas,rz-adc`
+
+* Audio
+
+   * :dtcompatible:`ti,tlv320aic3110`
+
+* Charger
+
+   * :dtcompatible:`ti,bq25713`
 
 * Clock control
 
+   * :dtcompatible:`ite,it51xxx-ecpm`
+   * :dtcompatible:`nordic,nrfs-audiopll`
+   * :dtcompatible:`st,stm32mp13-cpu-clock-mux`
+   * :dtcompatible:`st,stm32mp13-pll-clock`
    * :dtcompatible:`wch,ch32v20x_30x-pll-clock`
 
 * Comparator
@@ -245,10 +321,12 @@ New Drivers
 
 * Counter
 
+   * :dtcompatible:`ite,it8xxx2-counter`
    * :dtcompatible:`zephyr,native-sim-counter`
 
 * CPU
 
+   * :dtcompatible:`intel,bartlett-lake`
    * :dtcompatible:`wch,qingke-v4c`
    * :dtcompatible:`zephyr,native-sim-cpu`
 
@@ -256,17 +334,24 @@ New Drivers
 
    * :dtcompatible:`ti,cc23x0-aes`
 
+* :abbr:`DAC (Digital to Analog Converter)`
+
+   * :dtcompatible:`ti,dac161s997`
+
 * Display
 
    * :dtcompatible:`sitronix,st7567`
+   * :dtcompatible:`sitronix,st7701`
 
 * :abbr:`DMA (Direct Memory Access)`
 
    * :dtcompatible:`renesas,rz-dma`
+   * :dtcompatible:`ti,cc23x0-dma`
    * :dtcompatible:`wch,wch-dma`
 
 * Ethernet
 
+   * :dtcompatible:`st,stm32-ethernet-controller`
    * :dtcompatible:`st,stm32n6-ethernet`
    * :dtcompatible:`ti,dp83867`
    * :dtcompatible:`xlnx,axi-ethernet-1.00.a`
@@ -282,6 +367,9 @@ New Drivers
 * :abbr:`GPIO (General Purpose Input/Output)` and Headers
 
    * :dtcompatible:`adi,max14915-gpio`
+   * :dtcompatible:`adi,max14917-gpio`
+   * :dtcompatible:`adi,max22199-gpio`
+   * :dtcompatible:`ite,it51xxx-gpio`
    * :dtcompatible:`nxp,lcd-pmod`
    * :dtcompatible:`raspberrypi,pico-gpio-port`
    * :dtcompatible:`renesas,ra-parallel-graphics-header`
@@ -289,6 +377,8 @@ New Drivers
 * :abbr:`I2C (Inter-Integrated Circuit)`
 
    * :dtcompatible:`cdns,i2c`
+   * :dtcompatible:`litex,litei2c`
+   * :dtcompatible:`renesas,ra-i2c-sci-b`
    * :dtcompatible:`renesas,rz-riic`
    * :dtcompatible:`sensry,sy1xx-i2c`
 
@@ -298,8 +388,15 @@ New Drivers
    * :dtcompatible:`st,stm32-tsc`
    * :dtcompatible:`tsc-keys`
 
+* Interrupt controller
+
+   * :dtcompatible:`ite,it51xxx-intc`
+   * :dtcompatible:`ite,it51xxx-wuc`
+   * :dtcompatible:`ite,it51xxx-wuc-map`
+
 * Mailbox
 
+   * :dtcompatible:`arm,mhuv3`
    * :dtcompatible:`renesas,rz-mhu-mbox`
 
 * :abbr:`MDIO (Management Data Input/Output)`
@@ -309,14 +406,18 @@ New Drivers
 * Memory controller
 
    * :dtcompatible:`realtek,rts5912-bbram`
+   * :dtcompatible:`st,stm32-xspi-psram`
 
 * :abbr:`MFD (Multi-Function Device)`
 
    * :dtcompatible:`adi,maxq10xx`
+   * :dtcompatible:`ambiq,iom`
    * :dtcompatible:`x-powers,axp2101`
 
 * Miscellaneous
 
+   * :dtcompatible:`nordic,nrf-mpc`
+   * :dtcompatible:`renesas,ra-ulpt`
    * :dtcompatible:`renesas,rz-sci`
 
 * Multi-bit SPI
@@ -333,18 +434,27 @@ New Drivers
 
 * Pin control
 
+   * :dtcompatible:`arm,mps2-pinctrl`
+   * :dtcompatible:`arm,mps3-pinctrl`
+   * :dtcompatible:`arm,v2m_beetle-pinctrl`
    * :dtcompatible:`renesas,rza-pinctrl`
    * :dtcompatible:`renesas,rzn-pinctrl`
    * :dtcompatible:`renesas,rzt-pinctrl`
+   * :dtcompatible:`renesas,rzv-pinctrl`
    * :dtcompatible:`wch,20x_30x-afio`
 
 * :abbr:`PWM (Pulse Width Modulation)`
 
+   * :dtcompatible:`arduino-header-pwm`
    * :dtcompatible:`silabs,siwx91x-pwm`
 
 * Regulator
 
    * :dtcompatible:`x-powers,axp2101-regulator`
+
+* Reset controller
+
+   * :dtcompatible:`reset-mmio`
 
 * :abbr:`RNG (Random Number Generator)`
 
@@ -353,19 +463,45 @@ New Drivers
 
 * :abbr:`RTC (Real Time Clock)`
 
+   * :dtcompatible:`nxp,pcf2123`
    * :dtcompatible:`realtek,rts5912-rtc`
+
+* SDHC
+
+   * :dtcompatible:`ambiq,sdio`
 
 * Sensors
 
    * :dtcompatible:`bosch,bmm350`
+   * :dtcompatible:`everlight,als-pt19`
    * :dtcompatible:`invensense,icm45686`
+   * :dtcompatible:`invensense,icp201xx`
+   * :dtcompatible:`liteon,ltr329`
+   * :dtcompatible:`meas,ms5837-02ba`
+   * :dtcompatible:`meas,ms5837-30ba`
    * :dtcompatible:`pixart,paa3905`
+   * :dtcompatible:`pixart,pat9136`
+   * :dtcompatible:`st,lsm6dsv32x`
    * :dtcompatible:`vishay,veml6031`
 
 * Serial controller
 
+   * :dtcompatible:`ite,it51xxx-uart`
    * :dtcompatible:`renesas,rz-sci-uart`
    * :dtcompatible:`zephyr,native-pty-uart`
+
+* :abbr:`SPI (Serial Peripheral Interface)`
+
+   * :dtcompatible:`cdns,spi`
+
+* Timer
+
+   * :dtcompatible:`ite,it51xxx-timer`
+   * :dtcompatible:`renesas,ra-ulpt-timer`
+
+* USB
+
+   * :dtcompatible:`adi,max32-usbhs`
 
 * Watchdog
 
@@ -382,9 +518,13 @@ New Samples
 
 * :zephyr:code-sample:`bmg160`
 * :zephyr:code-sample:`debug-ulp`
+* :zephyr:code-sample:`echo-ulp`
 * :zephyr:code-sample:`fatfs-fstab`
+* :zephyr:code-sample:`pressure_interrupt`
+* :zephyr:code-sample:`pressure_polling`
 * :zephyr:code-sample:`renesas_comparator`
 * :zephyr:code-sample:`rz-openamp-linux-zephyr`
+* :zephyr:code-sample:`spis-wakeup`
 * :zephyr:code-sample:`stepper`
 * :zephyr:code-sample:`veml6031`
 

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -200,26 +200,26 @@ New Boards
    * :zephyr:board:`rzn2l_rsk` (``rzn2l_rsk``)
    * :zephyr:board:`rzt2l_rsk` (``rzt2l_rsk``)
 
-* STMicroelectronics
-
-   * :zephyr:board:`stm32h757i_eval` (``stm32h757i_eval``)
-
 * Silicon Laboratories
 
    * :zephyr:board:`slwrb4180b` (``slwrb4180b``)
+
+* STMicroelectronics
+
+   * :zephyr:board:`stm32h757i_eval` (``stm32h757i_eval``)
 
 * Texas Instruments
 
    * :zephyr:board:`sk_am64` (``sk_am64``)
 
-* WIZnet Co., Ltd.
-
-   * :zephyr:board:`w5500_evb_pico2` (``w5500_evb_pico2``)
-
 * WinChipHead
 
    * :zephyr:board:`ch32v003f4p6_dev_board` (``ch32v003f4p6_dev_board``)
    * :zephyr:board:`linkw` (``linkw``)
+
+* WIZnet Co., Ltd.
+
+   * :zephyr:board:`w5500_evb_pico2` (``w5500_evb_pico2``)
 
 New Drivers
 ***********


### PR DESCRIPTION
New boards, drivers, samples since March 24, 2025.

https://builds.zephyrproject.io/zephyr/pr/88431/docs/releases/release-notes-4.2.html#new-boards
https://builds.zephyrproject.io/zephyr/pr/88431/docs/releases/release-notes-4.2.html#new-drivers
https://builds.zephyrproject.io/zephyr/pr/88431/docs/releases/release-notes-4.2.html#new-samples

Also updates a newly added Intel board that didn't use the fancy zephyr-board directives