### PR TITLE
sys: Remove static modifier

### DIFF
--- a/include/zephyr/sys/spsc_lockfree.h
+++ b/include/zephyr/sys/spsc_lockfree.h
@@ -99,7 +99,7 @@ struct spsc {
  * @param type Type stored in the spsc
  */
 #define SPSC_DECLARE(name, type)                                                                   \
-	static struct spsc_##name {                                                                \
+	struct spsc_##name {                                                                       \
 		struct spsc _spsc;                                                                 \
 		type * const buffer;                                                               \
 	}


### PR DESCRIPTION
Remove static struct modifier from `SPSC_DECLARE` macro. This solves a warning emitted when compiling for native_sim.