### PR TITLE
(backport 87637/88593 to 4.1) modules: mbedtls: update to 3.6.3 and tf-m to 2.1.2

### DIFF
--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -26,6 +26,42 @@
 
 .. _zephyr_4.1:
 
+.. _zephyr_4.1.1:
+
+Zephyr 4.1.1
+############
+
+This is an LTS maintenance release with fixes.
+
+Security Vulnerability Related
+******************************
+
+The following CVEs are addressed by this release:
+
+* :cve:`2025-27809` `TLS clients may unwittingly skip server authentication
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/>`_
+* :cve:`2025-27810` `Potential authentication bypass in TLS handshake
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-2/>`_
+
+More detailed information can be found in:
+https://docs.zephyrproject.org/latest/security/vulnerabilities.html
+
+Issues fixed
+************
+
+These GitHub issues were addressed since the previous 4.1.0 tagged release:
+
+Mbed TLS
+********
+
+Mbed TLS was updated to version 3.6.3 (from 3.6.2). The release notes can be found at:
+https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3
+
+Mbed TLS 3.6 is an LTS release that will be supported
+with security and bug fixes until at least March 2027.
+
+.. _zephyr_4.1.0:
+
 Zephyr 4.1.0
 ############
 

--- a/doc/releases/release-notes-4.1.rst
+++ b/doc/releases/release-notes-4.1.rst
@@ -60,6 +60,12 @@ https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3
 Mbed TLS 3.6 is an LTS release that will be supported
 with security and bug fixes until at least March 2027.
 
+Trusted Firmware-M (TF-M)
+*************************
+
+TF-M was updated to version 2.1.2 (from 2.1.1). The release notes can be found at:
+https://trustedfirmware-m.readthedocs.io/en/tf-mv2.1.2/releases/2.1.2.html
+
 .. _zephyr_4.1.0:
 
 Zephyr 4.1.0

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -41,7 +41,7 @@ manifest:
       groups:
         - optional
     - name: tf-m-tests
-      revision: 502ea90105ee18f20c78f710e2ba2ded0fc0756e
+      revision: c712761dd5391bf3f38033643d28a736cae89a19
       path: modules/tee/tf-m/tf-m-tests
       remote: upstream
       groups:

--- a/west.yml
+++ b/west.yml
@@ -298,7 +298,7 @@ manifest:
       revision: 1ed1ddd881c3784049a92bb9fe37c38c6c74d998
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 4952e1328529ee549d412b498ea71c54f30aa3b1
+      revision: 5f889934359deccf421554c7045a8381ef75298f
       path: modules/crypto/mbedtls
       groups:
         - crypto

--- a/west.yml
+++ b/west.yml
@@ -353,7 +353,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 918f32d9fce5e0ee59fc33844b5317b7626ce37a
+      revision: e2288c13ee0abc16163186523897e7910b03dd31
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update Mbed TLS to 3.6.3 as it has CVE fixes.
Fixes #88434
Related to #87637