### PR TITLE
drivers: hwinfo: siwx91x: add hwinfo device id

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -34,6 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_HWINFO_SAM0        hwinfo_sam0.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SAM4L       hwinfo_sam4l.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SAM_RSTC    hwinfo_sam_rstc.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SILABS_S2   hwinfo_silabs_series2.c)
+zephyr_library_sources_ifdef(CONFIG_HWINFO_SIWX91X     hwinfo_siwx91x.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SMARTBOND   hwinfo_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_STM32       hwinfo_stm32.c)
 # zephyr-keep-sorted-stop

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -281,4 +281,12 @@ config HWINFO_RENESAS_RA
 	help
 	  Enable RENESAS RA hwinfo driver
 
+config HWINFO_SIWX91X
+	bool "Silabs SiWx91x hwinfo"
+	default y
+	depends on SOC_FAMILY_SILABS_SIWX91X
+	select HWINFO_HAS_DRIVER
+	help
+	  Enable Silabs SiWx91x hwinfo driver.
+
 endif

--- a/drivers/hwinfo/hwinfo_siwx91x.c
+++ b/drivers/hwinfo/hwinfo_siwx91x.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Noah Pendleton
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <soc.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/sys/util.h>
+
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	/*
+	 * The SiWX91x chips include an undocumented memory-mapped "efusecopy"
+	 * region that contains the factory programmed BLE and WiFi MAC values. The
+	 * offsets for these values were experimentally derived by using the SiLabs
+	 * "Simplicity Commander" utility on an siwx917_rb4338a board, specifically
+	 * these commands:
+
+	 * Read device info:
+	 * $ commander device info
+	 *   Part Number    : SiWG917M111MGTBA
+	 *   Product Rev    : B0
+	 *   Flash Size     : 8192 kB
+	 *   SRAM Size      : 672 kB
+	 *   Unique ID      : 0000d448671c1504
+	 *   DONE
+
+	 * Dump the manufacturing data, which includes the "efusecopy" region:
+	 * $ commander mfg917 dump data.zip
+	 */
+	uint8_t *wifi_mac = (uint8_t *)(0x040003E0 + 0x22);
+	const ssize_t id_length = MIN(6, length);
+
+	memcpy(buffer, wifi_mac, id_length);
+
+	return id_length;
+}


### PR DESCRIPTION
Add basic support for device id, using the factory-programmed Wi-Fi MAC
address.

The reference manual:

https://www.silabs.com/documents/public/reference-manuals/siw917x-family-rm.pdf

And manufacturing programming manual:

https://www.silabs.com/documents/public/user-guides/ug574-siwx917-soc-manufacturing-utility-user-guide.pdf

Both do not have information about retrieving a unique chip ID on device.

This thread on the silicon labs help forum did not reveal much, but gave me
enough clues to locate where the factory-programmed MAC addresses (Wi-Fi +
BLE) are memory-mapped:

https://siliconlabs.my.site.com/community/s/question/0D5Vm00000YBTDPKA5/unique-silicon-id-for-siwg917-soc?language=en_US

I investigated adding reset cause support, but it's not simple, requires
coupling with `SOC_EARLY_INIT_HOOK` to cache the reset bits. So leaving
that out of this patch.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>