### PR TITLE
(backport 87637/88593 to 4.0) modules: mbedtls: update to 3.6.3 and tf-m to 2.1.2

### DIFF
--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -2,6 +2,42 @@
 
 .. _zephyr_4.0:
 
+.. _zephyr_4.0.1:
+
+Zephyr 4.0.1
+############
+
+This is an LTS maintenance release with fixes.
+
+Security Vulnerability Related
+******************************
+
+The following CVEs are addressed by this release:
+
+* :cve:`2025-27809` `TLS clients may unwittingly skip server authentication
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/>`_
+* :cve:`2025-27810` `Potential authentication bypass in TLS handshake
+  <https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-2/>`_
+
+More detailed information can be found in:
+https://docs.zephyrproject.org/latest/security/vulnerabilities.html
+
+Issues fixed
+************
+
+These GitHub issues were addressed since the previous 4.0.0 tagged release:
+
+Mbed TLS
+********
+
+Mbed TLS was updated to version 3.6.3 (from 3.6.2). The release notes can be found at:
+https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3
+
+Mbed TLS 3.6 is an LTS release that will be supported
+with security and bug fixes until at least March 2027.
+
+.. _zephyr_4.0.0:
+
 Zephyr 4.0.0
 ############
 

--- a/doc/releases/release-notes-4.0.rst
+++ b/doc/releases/release-notes-4.0.rst
@@ -36,6 +36,12 @@ https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3
 Mbed TLS 3.6 is an LTS release that will be supported
 with security and bug fixes until at least March 2027.
 
+Trusted Firmware-M (TF-M)
+*************************
+
+TF-M was updated to version 2.1.2 (from 2.1.1). The release notes can be found at:
+https://trustedfirmware-m.readthedocs.io/en/tf-mv2.1.2/releases/2.1.2.html
+
 .. _zephyr_4.0.0:
 
 Zephyr 4.0.0

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -46,7 +46,7 @@ manifest:
       groups:
         - optional
     - name: tf-m-tests
-      revision: 502ea90105ee18f20c78f710e2ba2ded0fc0756e
+      revision: c712761dd5391bf3f38033643d28a736cae89a19
       path: modules/tee/tf-m/tf-m-tests
       remote: upstream
       groups:

--- a/west.yml
+++ b/west.yml
@@ -280,7 +280,7 @@ manifest:
       revision: 2b498e6f36d6b82ae1da12c8b7742e318624ecf5
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: a78176c6ff0733ba08018cba4447bd3f20de7978
+      revision: 5f889934359deccf421554c7045a8381ef75298f
       path: modules/crypto/mbedtls
       groups:
         - crypto

--- a/west.yml
+++ b/west.yml
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 8134106ef9cb3df60e8bd22b172532558e936bd2
+      revision: e2288c13ee0abc16163186523897e7910b03dd31
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Update Mbed TLS to 3.6.3 as it has CVE fixes.
Fixes #88435.
Related to #87637 .