### PR TITLE
tests: Bluetooth: Tester: CAP BSIM test

### DIFF
--- a/tests/bsim/bluetooth/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/tester/CMakeLists.txt
@@ -28,6 +28,8 @@ target_sources(app PRIVATE
   src/audio/bap_broadcast_source.c
   src/audio/bap_central.c
   src/audio/bap_peripheral.c
+  src/audio/cap_central.c
+  src/audio/cap_peripheral.c
   src/audio/ccp_central.c
   src/audio/ccp_peripheral.c
   src/audio/csip_central.c

--- a/tests/bsim/bluetooth/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/tester/CMakeLists.txt
@@ -28,6 +28,8 @@ target_sources(app PRIVATE
   src/audio/bap_broadcast_source.c
   src/audio/bap_central.c
   src/audio/bap_peripheral.c
+  src/audio/cap_broadcast_sink.c
+  src/audio/cap_broadcast_source.c
   src/audio/cap_central.c
   src/audio/cap_peripheral.c
   src/audio/ccp_central.c

--- a/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_sink.c
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -20,9 +19,9 @@
 #include "btp/btp.h"
 #include "bsim_btp.h"
 
-LOG_MODULE_REGISTER(bsim_bap_broadcast_sink, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+LOG_MODULE_REGISTER(bsim_cap_broadcast_sink, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
 
-static void test_bap_broadcast_sink(void)
+static void test_cap_broadcast_sink(void)
 {
 	const uint16_t pa_sync_timeout = BT_GAP_PER_ADV_MAX_TIMEOUT;
 	char addr_str[BT_ADDR_LE_STR_LEN];
@@ -39,6 +38,7 @@ static void test_bap_broadcast_sink(void)
 
 	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
 	bsim_btp_core_register(BTP_SERVICE_ID_BAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_CAS);
 	bsim_btp_core_register(BTP_SERVICE_ID_PACS);
 
 	bsim_btp_bap_broadcast_sink_setup();
@@ -64,14 +64,14 @@ static void test_bap_broadcast_sink(void)
 
 static const struct bst_test_instance test_sample[] = {
 	{
-		.test_id = "bap_broadcast_sink",
-		.test_descr = "Smoketest for the BAP Broadcast Sink BT Tester behavior",
-		.test_main_f = test_bap_broadcast_sink,
+		.test_id = "cap_broadcast_sink",
+		.test_descr = "Smoketest for the CAP Broadcast Sink BT Tester behavior",
+		.test_main_f = test_cap_broadcast_sink,
 	},
 	BSTEST_END_MARKER,
 };
 
-struct bst_test_list *test_bap_broadcast_sink_install(struct bst_test_list *tests)
+struct bst_test_list *test_cap_broadcast_sink_install(struct bst_test_list *tests)
 {
 	return bst_add_tests(tests, test_sample);
 }

--- a/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_source.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_broadcast_source.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/lc3.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_cap_broadcast_source, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_cap_broadcast_source(void)
+{
+	const uint8_t metadata[] = BT_AUDIO_CODEC_CFG_LC3_META(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	const uint8_t cc_data_16_2_1[] = BT_AUDIO_CODEC_CFG_LC3_DATA(
+		BT_AUDIO_CODEC_CFG_FREQ_16KHZ, BT_AUDIO_CODEC_CFG_DURATION_10,
+		BT_AUDIO_LOCATION_FRONT_LEFT, 40U, 1U);
+	const uint8_t coding_format = BT_HCI_CODING_FORMAT_LC3;
+	const uint8_t framing = BT_ISO_FRAMING_UNFRAMED;
+	const uint32_t presentation_delay = 40000U;
+	const uint32_t broadcast_id = 0x123456U;
+	const uint32_t sdu_interval = 10000U;
+	const uint16_t max_latency = 10U;
+	const uint8_t subgroup_id = 0U;
+	const uint16_t max_sdu = 40U;
+	const uint8_t source_id = 0U;
+	const uint16_t vid = 0x0000U; /* shall be 0x0000 for LC3 */
+	const uint16_t cid = 0x0000U; /* shall be 0x0000 for LC3 */
+	const uint8_t flags = 0U;
+	const uint8_t rtn = 2U;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP); /* required to start the TX thread */
+	bsim_btp_core_register(BTP_SERVICE_ID_CAP);
+
+	bsim_btp_cap_broadcast_source_setup_stream(source_id, subgroup_id, coding_format, vid, cid,
+						   0, NULL, 0, NULL);
+	bsim_btp_cap_broadcast_source_setup_subgroup(
+		source_id, subgroup_id, coding_format, vid, cid, ARRAY_SIZE(cc_data_16_2_1),
+		cc_data_16_2_1, ARRAY_SIZE(metadata), metadata);
+	bsim_btp_cap_broadcast_source_setup(source_id, broadcast_id, sdu_interval, framing, max_sdu,
+					    rtn, max_latency, presentation_delay, flags);
+	bsim_btp_cap_broadcast_adv_start(source_id);
+	bsim_btp_cap_broadcast_source_start(source_id);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "cap_broadcast_source",
+		.test_descr = "Smoketest for the CAP broadcast source BT Tester behavior",
+		.test_main_f = test_cap_broadcast_source,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_cap_broadcast_source_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/cap_central.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_central.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/cap.h>
+#include <zephyr/bluetooth/audio/lc3.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_cap_central, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_cap_central(void)
+{
+	const uint8_t metadata[] = BT_AUDIO_CODEC_CFG_LC3_META(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	const uint8_t cc_data_16_2_1[] = BT_AUDIO_CODEC_CFG_LC3_DATA(
+		BT_AUDIO_CODEC_CFG_FREQ_16KHZ, BT_AUDIO_CODEC_CFG_DURATION_10,
+		BT_AUDIO_LOCATION_FRONT_LEFT, 40U, 1U);
+	const enum bt_cap_set_type set_type = BT_CAP_SET_TYPE_AD_HOC;
+	const uint8_t coding_format = BT_HCI_CODING_FORMAT_LC3;
+	const uint8_t framing = BT_ISO_FRAMING_UNFRAMED;
+	const uint32_t presentation_delay = 40000U;
+	const uint32_t sdu_interval = 10000U;
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	const uint16_t max_latency = 10U;
+	const uint16_t max_sdu = 40U;
+	const uint16_t vid = 0x0000; /* shall be 0x0000 for LC3 */
+	const uint16_t cid = 0x0000; /* shall be 0x0000 for LC3 */
+	const uint8_t cig_id = 0U;
+	const uint8_t cis_id = 0U;
+	bt_addr_le_t remote_addr;
+	const uint8_t rtn = 2U;
+	uint8_t ase_id;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_CAP);
+
+	bsim_btp_gap_start_discovery(BTP_GAP_DISCOVERY_FLAG_LE);
+	bsim_btp_wait_for_gap_device_found(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Found remote device %s", addr_str);
+
+	bsim_btp_gap_stop_discovery();
+	bsim_btp_gap_connect(&remote_addr, BTP_GAP_ADDR_TYPE_IDENTITY);
+	bsim_btp_wait_for_gap_device_connected(NULL);
+	LOG_INF("Device %s connected", addr_str);
+
+	bsim_btp_gap_pair(&remote_addr);
+	bsim_btp_wait_for_gap_sec_level_changed(NULL, NULL);
+
+	bsim_btp_bap_discover(&remote_addr);
+	bsim_btp_wait_for_bap_ase_found(&ase_id);
+	bsim_btp_wait_for_bap_discovered();
+
+	bsim_btp_cap_discover(&remote_addr);
+	bsim_btp_wait_for_cap_discovered();
+
+	bsim_btp_cap_unicast_setup_ase_cmd(&remote_addr, ase_id, cis_id, cig_id, coding_format, vid,
+					   cid, sdu_interval, framing, max_sdu, rtn, max_latency,
+					   presentation_delay, ARRAY_SIZE(cc_data_16_2_1),
+					   cc_data_16_2_1, ARRAY_SIZE(metadata), metadata);
+
+	bsim_btp_cap_unicast_audio_start(cig_id, (uint8_t)set_type);
+	bsim_btp_wait_for_cap_unicast_start_completed();
+
+	bsim_btp_gap_disconnect(&remote_addr);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "cap_central",
+		.test_descr = "Smoketest for the CAP central BT Tester behavior",
+		.test_main_f = test_cap_central,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_cap_central_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/cap_peripheral.c
+++ b/tests/bsim/bluetooth/tester/src/audio/cap_peripheral.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_cap_peripheral, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_cap_peripheral(void)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t remote_addr;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_CAS);
+	bsim_btp_core_register(BTP_SERVICE_ID_ASCS);
+	bsim_btp_core_register(BTP_SERVICE_ID_PACS);
+
+	bsim_btp_gap_set_discoverable(BTP_GAP_GENERAL_DISCOVERABLE);
+	bsim_btp_gap_start_advertising(0U, 0U, NULL, BT_HCI_OWN_ADDR_PUBLIC);
+	bsim_btp_wait_for_gap_device_connected(&remote_addr);
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Device %s connected", addr_str);
+	bsim_btp_wait_for_gap_device_disconnected(NULL);
+	LOG_INF("Device %s disconnected", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "cap_peripheral",
+		.test_descr = "Smoketest for the CAP peripheral BT Tester behavior",
+		.test_main_f = test_cap_peripheral,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_cap_peripheral_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -585,6 +585,115 @@ static inline void bsim_btp_wait_for_bap_bis_stream_received(void)
 	net_buf_unref(buf);
 }
 
+static inline void bsim_btp_cap_discover(const bt_addr_le_t *address)
+{
+	struct btp_cap_discover_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_DISCOVER;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_cap_unicast_setup_ase_cmd(
+	const bt_addr_le_t *address, uint8_t ase_id, uint8_t cis_id, uint8_t cig_id,
+	uint8_t coding_format, uint16_t vid, uint16_t cid, uint32_t sdu_interval, uint8_t framing,
+	uint16_t max_sdu, uint8_t rtn, uint16_t max_latency, uint32_t presentation_delay,
+	uint8_t cc_ltvs_len, const uint8_t cc_ltvs[], uint8_t metadata_ltvs_len,
+	const uint8_t metadata_ltvs[])
+{
+	struct btp_cap_unicast_setup_ase_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_UNICAST_SETUP_ASE;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	bt_addr_le_copy(&cmd->address, address);
+	cmd->ase_id = ase_id;
+	cmd->cig_id = cig_id;
+	cmd->cis_id = cis_id;
+	cmd->coding_format = coding_format;
+	cmd->vid = sys_cpu_to_le16(vid);
+	cmd->cid = sys_cpu_to_le16(cid);
+	sys_put_le24(sdu_interval, cmd->sdu_interval);
+	cmd->framing = framing;
+	cmd->max_sdu = sys_cpu_to_le16(max_sdu);
+	cmd->retransmission_num = rtn;
+	cmd->max_transport_latency = sys_cpu_to_le16(max_latency);
+	sys_put_le24(presentation_delay, cmd->presentation_delay);
+	cmd->cc_ltvs_len = cc_ltvs_len;
+	if (cc_ltvs_len > 0U) {
+		net_buf_simple_add_mem(&cmd_buffer, cc_ltvs, cc_ltvs_len);
+	}
+	cmd->metadata_ltvs_len = metadata_ltvs_len;
+	if (metadata_ltvs_len > 0U) {
+		net_buf_simple_add_mem(&cmd_buffer, metadata_ltvs, metadata_ltvs_len);
+	}
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_cap_unicast_audio_start(uint8_t cig_id, uint8_t set_type)
+{
+	struct btp_cap_unicast_audio_start_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_UNICAST_AUDIO_START;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->cig_id = cig_id;
+	cmd->set_type = set_type;
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_wait_for_cap_discovered(void)
+{
+	struct btp_cap_discovery_completed_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CAP, BTP_CAP_EV_DISCOVERY_COMPLETED, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	TEST_ASSERT(ev->status == BTP_CAP_DISCOVERY_STATUS_SUCCESS);
+
+	net_buf_unref(buf);
+}
+
+static inline void bsim_btp_wait_for_cap_unicast_start_completed(void)
+{
+	struct btp_cap_unicast_start_completed_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CAP, BTP_CAP_EV_UNICAST_START_COMPLETED, &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	TEST_ASSERT(ev->status == BTP_CAP_UNICAST_START_STATUS_SUCCESS);
+
+	net_buf_unref(buf);
+}
+
 static inline void bsim_btp_ccp_discover(const bt_addr_le_t *address)
 {
 	struct btp_ccp_discover_tbs_cmd *cmd;

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -668,6 +668,144 @@ static inline void bsim_btp_cap_unicast_audio_start(uint8_t cig_id, uint8_t set_
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
 }
 
+static inline void
+bsim_btp_cap_broadcast_source_setup_stream(uint8_t source_id, uint8_t subgroup_id,
+					   uint8_t coding_format, uint16_t vid, uint16_t cid,
+					   uint8_t cc_ltvs_len, const uint8_t cc_ltvs[],
+					   uint8_t metadata_ltvs_len, const uint8_t metadata_ltvs[])
+{
+	struct btp_cap_broadcast_source_setup_stream_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_BROADCAST_SOURCE_SETUP_STREAM;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->source_id = source_id;
+	cmd->subgroup_id = subgroup_id;
+	cmd->coding_format = coding_format;
+	cmd->vid = sys_cpu_to_le16(vid);
+	cmd->cid = sys_cpu_to_le16(cid);
+	cmd->cc_ltvs_len = cc_ltvs_len;
+	if (cc_ltvs_len > 0U) {
+		net_buf_simple_add_mem(&cmd_buffer, cc_ltvs, cc_ltvs_len);
+	}
+	cmd->metadata_ltvs_len = metadata_ltvs_len;
+	if (metadata_ltvs_len > 0U) {
+		net_buf_simple_add_mem(&cmd_buffer, metadata_ltvs, metadata_ltvs_len);
+	}
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_cap_broadcast_source_setup_subgroup(
+	uint8_t source_id, uint8_t subgroup_id, uint8_t coding_format, uint16_t vid, uint16_t cid,
+	uint8_t cc_ltvs_len, const uint8_t cc_ltvs[], uint8_t metadata_ltvs_len,
+	const uint8_t metadata_ltvs[])
+{
+	struct btp_cap_broadcast_source_setup_subgroup_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_BROADCAST_SOURCE_SETUP_SUBGROUP;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->source_id = source_id;
+	cmd->subgroup_id = subgroup_id;
+	cmd->coding_format = coding_format;
+	cmd->vid = sys_cpu_to_le16(vid);
+	cmd->cid = sys_cpu_to_le16(cid);
+	cmd->cc_ltvs_len = cc_ltvs_len;
+	if (cc_ltvs_len > 0U) {
+		net_buf_simple_add_mem(&cmd_buffer, cc_ltvs, cc_ltvs_len);
+	}
+	cmd->metadata_ltvs_len = metadata_ltvs_len;
+	if (metadata_ltvs_len > 0U) {
+		net_buf_simple_add_mem(&cmd_buffer, metadata_ltvs, metadata_ltvs_len);
+	}
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_cap_broadcast_source_setup(uint8_t source_id, uint32_t broadcast_id,
+						       uint32_t sdu_interval, uint8_t framing,
+						       uint16_t max_sdu, uint8_t rtn,
+						       uint16_t max_latency,
+						       uint32_t presentation_delay, uint8_t flags)
+{
+	struct btp_cap_broadcast_source_setup_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_BROADCAST_SOURCE_SETUP;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->source_id = source_id;
+	sys_put_le24(broadcast_id, cmd->broadcast_id);
+	sys_put_le24(sdu_interval, cmd->sdu_interval);
+	cmd->framing = framing;
+	cmd->max_sdu = sys_cpu_to_le16(max_sdu);
+	cmd->retransmission_num = rtn;
+	cmd->max_transport_latency = sys_cpu_to_le16(max_latency);
+	sys_put_le24(presentation_delay, cmd->presentation_delay);
+	cmd->flags = flags;
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_cap_broadcast_adv_start(uint8_t source_id)
+{
+	struct btp_cap_broadcast_adv_start_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_BROADCAST_ADV_START;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->source_id = source_id;
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_cap_broadcast_source_start(uint8_t source_id)
+{
+	struct btp_cap_broadcast_source_start_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_CAP;
+	cmd_hdr->opcode = BTP_CAP_BROADCAST_SOURCE_START;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->source_id = source_id;
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
 static inline void bsim_btp_wait_for_cap_discovered(void)
 {
 	struct btp_cap_discovery_completed_ev *ev;

--- a/tests/bsim/bluetooth/tester/src/test_main.c
+++ b/tests/bsim/bluetooth/tester/src/test_main.c
@@ -11,6 +11,8 @@ extern struct bst_test_list *test_bap_broadcast_sink_install(struct bst_test_lis
 extern struct bst_test_list *test_bap_broadcast_source_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_bap_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_bap_peripheral_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_cap_broadcast_sink_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_cap_broadcast_source_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_cap_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_cap_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_ccp_central_install(struct bst_test_list *tests);
@@ -37,6 +39,8 @@ bst_test_install_t test_installers[] = {
 	test_bap_broadcast_source_install,
 	test_bap_central_install,
 	test_bap_peripheral_install,
+	test_cap_broadcast_sink_install,
+	test_cap_broadcast_source_install,
 	test_cap_central_install,
 	test_cap_peripheral_install,
 	test_ccp_central_install,

--- a/tests/bsim/bluetooth/tester/src/test_main.c
+++ b/tests/bsim/bluetooth/tester/src/test_main.c
@@ -11,6 +11,8 @@ extern struct bst_test_list *test_bap_broadcast_sink_install(struct bst_test_lis
 extern struct bst_test_list *test_bap_broadcast_source_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_bap_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_bap_peripheral_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_cap_central_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_cap_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_ccp_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_ccp_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_csip_central_install(struct bst_test_list *tests);
@@ -35,6 +37,8 @@ bst_test_install_t test_installers[] = {
 	test_bap_broadcast_source_install,
 	test_bap_central_install,
 	test_bap_peripheral_install,
+	test_cap_central_install,
+	test_cap_peripheral_install,
 	test_ccp_central_install,
 	test_ccp_peripheral_install,
 	test_csip_central_install,

--- a/tests/bsim/bluetooth/tester/tests_scripts/cap_broadcast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/cap_broadcast.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoketest for CAP BTP commands with the BT tester
+
+simulation_id="tester_cap_broadcast"
+verbosity_level=2
+EXECUTE_TIMEOUT=100
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+UART_DIR=/tmp/bs_${USER}/${simulation_id}/
+UART_SNK=${UART_DIR}/sink
+UART_BCST=${UART_DIR}/broadcaster
+
+# Broadcaster BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=10 -d=0 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_BCST}.tx -uart0_fifob_txfile=${UART_BCST}.rx
+
+# Broadcaster Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=21 -d=10 -RealEncryption=1 \
+  -testid=cap_broadcast_source \
+  -nosim -uart0_fifob_rxfile=${UART_BCST}.rx -uart0_fifob_txfile=${UART_BCST}.tx
+
+# Sink BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=32 -d=1 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_SNK}.tx -uart0_fifob_txfile=${UART_SNK}.rx
+
+# Sink Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=43 -d=11 -RealEncryption=1 \
+  -testid=cap_broadcast_sink \
+  -nosim -uart0_fifob_rxfile=${UART_SNK}.rx -uart0_fifob_txfile=${UART_SNK}.tx
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs # Wait for all programs in background and return != 0 if any fails

--- a/tests/bsim/bluetooth/tester/tests_scripts/cap_unicast.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/cap_unicast.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoketest for CAP BTP commands with the BT tester
+
+simulation_id="tester_cap_unicast"
+verbosity_level=2
+EXECUTE_TIMEOUT=100
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+UART_DIR=/tmp/bs_${USER}/${simulation_id}/
+UART_PER=${UART_DIR}/peripheral
+UART_CEN=${UART_DIR}/central
+
+# Central BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=10 -d=0 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_CEN}.tx -uart0_fifob_txfile=${UART_CEN}.rx
+
+# Central Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=21 -d=10 -RealEncryption=1 -testid=cap_central \
+  -nosim -uart0_fifob_rxfile=${UART_CEN}.rx -uart0_fifob_txfile=${UART_CEN}.tx
+
+# Peripheral BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=32 -d=1 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_PER}.tx -uart0_fifob_txfile=${UART_PER}.rx
+
+# Peripheral Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=43 -d=11 -RealEncryption=1 -testid=cap_peripheral \
+  -nosim -uart0_fifob_rxfile=${UART_PER}.rx -uart0_fifob_txfile=${UART_PER}.tx
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs # Wait for all programs in background and return != 0 if any fails


### PR DESCRIPTION
Adds BSIM testing of the CAP features of the BT Tester.

Part of https://github.com/zephyrproject-rtos/zephyr/issues/86073