### PR TITLE
ethernet: stm32: cleanup

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -875,18 +875,10 @@ static void RISAF_Config(void)
 
 static int eth_initialize(const struct device *dev)
 {
-	struct eth_stm32_hal_dev_data *dev_data;
-	const struct eth_stm32_hal_dev_cfg *cfg;
-	ETH_HandleTypeDef *heth;
+	struct eth_stm32_hal_dev_data *dev_data = dev->data;
+	const struct eth_stm32_hal_dev_cfg *cfg = dev->config;
+	ETH_HandleTypeDef *heth = &dev_data->heth;
 	int ret = 0;
-
-	__ASSERT_NO_MSG(dev != NULL);
-
-	dev_data = dev->data;
-	cfg = dev->config;
-
-	__ASSERT_NO_MSG(dev_data != NULL);
-	__ASSERT_NO_MSG(cfg != NULL);
 
 	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
 		LOG_ERR("clock control device not ready");
@@ -921,8 +913,6 @@ static int eth_initialize(const struct device *dev)
 		LOG_ERR("Could not configure ethernet pins");
 		return ret;
 	}
-
-	heth = &dev_data->heth;
 
 	generate_mac(dev_data->mac_addr);
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -890,9 +890,7 @@ static int eth_initialize(const struct device *dev)
 	__ASSERT_NO_MSG(dev_data != NULL);
 	__ASSERT_NO_MSG(cfg != NULL);
 
-	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
-
-	if (!device_is_ready(dev_data->clock)) {
+	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
 		LOG_ERR("clock control device not ready");
 		return -ENODEV;
 	}
@@ -903,14 +901,14 @@ static int eth_initialize(const struct device *dev)
 #endif
 
 	/* enable clock */
-	ret = clock_control_on(dev_data->clock,
+	ret = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken);
-	ret |= clock_control_on(dev_data->clock,
+	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken_tx);
-	ret |= clock_control_on(dev_data->clock,
+	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken_rx);
 #if DT_INST_CLOCKS_HAS_NAME(0, mac_clk_ptp)
-	ret |= clock_control_on(dev_data->clock,
+	ret |= clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 		(clock_control_subsys_t)&cfg->pclken_ptp);
 #endif
 
@@ -1685,7 +1683,7 @@ static int ptp_stm32_init(const struct device *port)
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
 
 	/* Query ethernet clock rate */
-	ret = clock_control_get_rate(eth_dev_data->clock,
+	ret = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
 				     (clock_control_subsys_t)&eth_cfg->pclken,
 #else

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -88,17 +88,15 @@ static const struct device *eth_stm32_phy_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0,
 #define ETH_RMII_MODE	ETH_MEDIA_INTERFACE_RMII
 #endif
 
-#define MAC_NODE DT_NODELABEL(mac)
-
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet)
-#define STM32_ETH_PHY_MODE(node_id) \
-	((DT_ENUM_HAS_VALUE(node_id, phy_connection_type, rgmii) ? ETH_RGMII_MODE : \
-	 (DT_ENUM_HAS_VALUE(node_id, phy_connection_type, gmii) ? ETH_GMII_MODE : \
-	 (DT_ENUM_HAS_VALUE(node_id, phy_connection_type, mii) ? ETH_MII_MODE : \
+#define STM32_ETH_PHY_MODE(inst) \
+	((DT_INST_ENUM_HAS_VALUE(inst, phy_connection_type, rgmii) ? ETH_RGMII_MODE : \
+	 (DT_INST_ENUM_HAS_VALUE(inst, phy_connection_type, gmii) ? ETH_GMII_MODE : \
+	 (DT_INST_ENUM_HAS_VALUE(inst, phy_connection_type, mii) ? ETH_MII_MODE : \
 		 ETH_RMII_MODE))))
 #else
-#define STM32_ETH_PHY_MODE(node_id) \
-	(DT_ENUM_HAS_VALUE(node_id, phy_connection_type, mii) ? \
+#define STM32_ETH_PHY_MODE(inst) \
+	(DT_INST_ENUM_HAS_VALUE(inst, phy_connection_type, mii) ? \
 		ETH_MII_MODE : ETH_RMII_MODE)
 #endif
 
@@ -1453,11 +1451,11 @@ static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 
-BUILD_ASSERT(DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, mii)
-	|| DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, rmii)
+BUILD_ASSERT(DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, mii)
+	|| DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rmii)
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_ethernet),
-	(|| DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, rgmii)
-	 || DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, gmii))),
+	(|| DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, rgmii)
+	 || DT_INST_ENUM_HAS_VALUE(0, phy_connection_type, gmii))),
 			"Unsupported PHY connection type");
 
 static struct eth_stm32_hal_dev_data eth0_data = {
@@ -1472,7 +1470,7 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 			.ChecksumMode = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
 					ETH_CHECKSUM_BY_HARDWARE : ETH_CHECKSUM_BY_SOFTWARE,
 #endif /* CONFIG_ETH_STM32_HAL_API_V1 */
-			.MediaInterface = STM32_ETH_PHY_MODE(MAC_NODE),
+			.MediaInterface = STM32_ETH_PHY_MODE(0),
 		},
 	},
 };

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -46,8 +46,6 @@ struct eth_stm32_hal_dev_data {
 	struct net_if *iface;
 	uint8_t mac_addr[6];
 	ETH_HandleTypeDef heth;
-	/* clock device */
-	const struct device *clock;
 	struct k_mutex tx_mutex;
 	struct k_sem rx_int_sem;
 #if defined(CONFIG_ETH_STM32_HAL_API_V2)


### PR DESCRIPTION
Improvements to PHY mode handling:

* Changed `STM32_ETH_PHY_MODE` macro to use `DT_INST_ENUM_HAS_VALUE` instead of `DT_ENUM_HAS_VALUE` for better compatibility with device tree instances. [[1]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL91-R99) [[2]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL1452-R1442) [[3]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL1471-R1457)

Simplification of MAC filter setup:

* Replaced conditional compilation checks with `IS_ENABLED` macro in `setup_mac_filter` function to simplify the code and improve readability. [[1]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL263-R275) [[2]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL304-R300)

Initialization process improvements:

* Combined variable declarations and assignments in `eth_initialize` function to reduce redundancy and improve clarity. [[1]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL882-R883) [[2]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL908-R901) [[3]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL931-L932)

Promiscuous mode configuration updates:

* Updated the `eth_stm32_hal_get_config` and `eth_stm32_hal_set_config` functions to use `HAL_ETH_GetMACFilterConfig` and `HAL_ETH_SetMACFilterConfig` for handling promiscuous mode when `CONFIG_ETH_STM32_HAL_API_V2` is defined. [[1]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL1307-R1303) [[2]](diffhunk://#diff-0d2e5611dcfdafb92af335bba5c381139ed9ce88182b5fe03d9655f7984725bcL1357-R1355)

Removal of unused clock device member:

* Removed the `clock` member from the `eth_stm32_hal_dev_data` structure as it is no longer needed.