### PR TITLE
zbus: add the ability to submit delyabled msgs

### DIFF
--- a/samples/subsys/zbus/hello_world/README.rst
+++ b/samples/subsys/zbus/hello_world/README.rst
@@ -46,5 +46,9 @@ Sample Output
     D: From listener -> Acc x=2, y=2, z=2
     D: FINISH processing channel acc_data change
     D: From subscriber -> Acc x=2, y=2, z=2
+    I: From subscriber -> simple_msg = HEARTBEAT_EVENT
+    I: From subscriber -> simple_msg = HEARTBEAT_EVENT
+    I: From subscriber -> simple_msg = HEARTBEAT_EVENT
+    I: From subscriber -> simple_msg = HEARTBEAT_EVENT
 
 Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/subsys/zbus/zbus.c
+++ b/subsys/zbus/zbus.c
@@ -619,3 +619,13 @@ int zbus_obs_set_enable(const struct zbus_observer *obs, bool enabled)
 
 	return 0;
 }
+
+void zbus_delayed_publish_work_handler(struct k_work *work)
+{
+	int err;
+
+	struct zbus_delayable_msg *msg = CONTAINER_OF(work, struct zbus_delayable_msg, work.work);
+	err = zbus_chan_pub(msg->chan, msg->data, K_FOREVER);
+
+	__ASSERT(err != 0, "failed to publish");
+}


### PR DESCRIPTION
Add struct zbus_delayable_msg as a method for setting up
scheduled publishes to wake up an observer after a scheduled delay. This
allows developers to easily schedule a thread that is
blocking on a zbus channel to wake up and perform arbitrary
work at a future scheduled time.