### PR TITLE
clang-format: add line at eof

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -99,6 +99,7 @@ IndentCaseLabels: false
 IndentGotoLabels: false
 IndentWidth: 8
 InsertBraces: true
+InsertNewlineAtEOF: true
 SpaceBeforeInheritanceColon: False
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never


### PR DESCRIPTION
Compliance [failed](https://github.com/zephyrproject-rtos/zephyr/actions/runs/14385873436/job/40341049066?pr=88447#step:10:59) for not having a new line
at EOF yet I ran `git clang-format`. Adding
this to the clang-format file will auto fix
this in the future.

Signed-off-by: Brandon Allen <brandon.allen@exacttechnology.com>
