### PR TITLE
tests: Bluetooth: Tester: Fix bad rsp len of CAP broadcast setup

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -719,7 +719,7 @@ static uint8_t btp_cap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 
 	rp->gap_settings = gap_settings;
 	sys_put_le24(source->broadcast_id, rp->broadcast_id);
-	*rsp_len = sizeof(*rp) + 1;
+	*rsp_len = sizeof(*rp);
 
 	return BTP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
The btp_cap_broadcast_source_setup_rp was reported with an invalid length.