### PR TITLE
docs: stepper: required and optional functions

### DIFF
--- a/doc/hardware/peripherals/stepper.rst
+++ b/doc/hardware/peripherals/stepper.rst
@@ -7,24 +7,45 @@ The stepper driver API provides a set of functions for controlling and configuri
 
 Configure Stepper Driver
 ========================
+.. table::
 
-- Configure **micro-stepping resolution** using :c:func:`stepper_set_micro_step_res`
-  and :c:func:`stepper_get_micro_step_res`.
-- Configure **reference position** in microsteps using :c:func:`stepper_set_reference_position`
-  and :c:func:`stepper_get_actual_position`.
-- Set **step interval** in nanoseconds between steps using :c:func:`stepper_set_microstep_interval`
-- **Enable** the stepper driver using :c:func:`stepper_enable`.
-- **Disable** the stepper driver using :c:func:`stepper_disable`.
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | Function                                 | Description                                             | Notes    |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_set_micro_step_res`     | Set the micro-stepping resolution of the stepper driver | Optional |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_get_micro_step_res`     | Get the micro-stepping resolution of the stepper driver | Optional |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_set_reference_position` | Set the reference position of the stepper motor         | Required |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_get_actual_position`    | Get the actual position of the stepper motor            | Required |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_set_microstep_interval` | Set the micro-step interval in nanoseconds              | Optional |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_enable`                 | Enable the stepper driver                               | Required |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_disable`                | Disable the stepper driver                              | Required |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_stop`                   | Stop the stepper motor                                  | Required |
+   +------------------------------------------+---------------------------------------------------------+----------+
 
 Control Stepper
 ===============
+.. table::
 
-- **Move by** +/- micro-steps also known as **relative movement** using :c:func:`stepper_move_by`.
-- **Move to** a specific position also known as **absolute movement** using :c:func:`stepper_move_to`.
-- Run continuously with a **constant step interval** in a specific direction until
-  a stop is detected using :c:func:`stepper_run`.
-- Check if the stepper is **moving** using :c:func:`stepper_is_moving`.
-- Register an **event callback** using :c:func:`stepper_set_event_callback`.
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | Function                                 | Description                                             | Notes    |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_move_by`                | Move the stepper by a specific motor of micro-steps     | Required |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_move_to`                | Move the stepper to a specific position in micro-steps  | Required |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_run`                    | Run the stepper continuously with a fixed step interval | Optional |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_is_moving`              | Check if the stepper is currently moving                | Optional |
+   +------------------------------------------+---------------------------------------------------------+----------+
+   | :c:func:`stepper_set_event_callback`     | Set an event callback with :c:enum:`stepper_event`      | Optional |
+   +------------------------------------------+---------------------------------------------------------+----------+
 
 Device Tree
 ===========

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -338,9 +338,6 @@ static inline int z_impl_stepper_set_reference_position(const struct device *dev
 {
 	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
-	if (api->set_reference_position == NULL) {
-		return -ENOSYS;
-	}
 	return api->set_reference_position(dev, value);
 }
 
@@ -360,9 +357,6 @@ static inline int z_impl_stepper_get_actual_position(const struct device *dev, i
 {
 	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
-	if (api->get_actual_position == NULL) {
-		return -ENOSYS;
-	}
 	return api->get_actual_position(dev, value);
 }
 
@@ -462,9 +456,6 @@ static inline int z_impl_stepper_move_to(const struct device *dev, const int32_t
 {
 	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
 
-	if (api->move_to == NULL) {
-		return -ENOSYS;
-	}
 	return api->move_to(dev, micro_steps);
 }
 


### PR DESCRIPTION
make following functions required for a stepper driver
- stepper_set_reference_position
- stepper_get_actual_position
- stepper_move_to