### PR TITLE
Added Flash Dependency on OpenAmp Sample

### DIFF
--- a/samples/subsys/ipc/openamp/sysbuild.cmake
+++ b/samples/subsys/ipc/openamp/sysbuild.cmake
@@ -14,6 +14,7 @@ ExternalZephyrProject_Add(
 # remote core's build, such as the output image's LMA
 add_dependencies(${DEFAULT_IMAGE} openamp_remote)
 sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} openamp_remote)
+sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} openamp_remote)
 
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
   # Make sure MCUboot is flashed first


### PR DESCRIPTION
Adds Flash dependency on project to contain full image before the load occurs.
Fixes #88453 