### PR TITLE
tests: Bluetooth: Tester: PBP BSIM test

### DIFF
--- a/tests/bsim/bluetooth/tester/CMakeLists.txt
+++ b/tests/bsim/bluetooth/tester/CMakeLists.txt
@@ -42,6 +42,8 @@ target_sources(app PRIVATE
   src/audio/mcp_peripheral.c
   src/audio/micp_central.c
   src/audio/micp_peripheral.c
+  src/audio/pbp_sink.c
+  src/audio/pbp_source.c
   src/audio/tmap_central.c
   src/audio/tmap_peripheral.c
   src/audio/vcp_central.c

--- a/tests/bsim/bluetooth/tester/src/audio/pbp_sink.c
+++ b/tests/bsim/bluetooth/tester/src/audio/pbp_sink.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_pbp_sink, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_pbp_sink(void)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	bt_addr_le_t remote_addr;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_PBP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_CAS);
+	bsim_btp_core_register(BTP_SERVICE_ID_PACS);
+
+	bsim_btp_pbp_broadcast_scan_start();
+	bsim_btp_wait_for_pbp_public_broadcast_announcement_found(&remote_addr);
+
+	bt_addr_le_to_str(&remote_addr, addr_str, sizeof(addr_str));
+	LOG_INF("Found remote device %s", addr_str);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "pbp_sink",
+		.test_descr = "Smoketest for the PBP broadcast sink BT Tester behavior",
+		.test_main_f = test_pbp_sink,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_pbp_sink_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/audio/pbp_source.c
+++ b/tests/bsim/bluetooth/tester/src/audio/pbp_source.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/lc3.h>
+#include <zephyr/bluetooth/audio/pbp.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+
+#include "babblekit/testcase.h"
+#include "bstests.h"
+
+#include "btp/btp.h"
+#include "bsim_btp.h"
+
+LOG_MODULE_REGISTER(bsim_pbp_source, CONFIG_BSIM_BTTESTER_LOG_LEVEL);
+
+static void test_pbp_source(void)
+{
+	const uint8_t metadata[] = BT_AUDIO_CODEC_CFG_LC3_META(BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+	const uint8_t cc_data_16_2_1[] = BT_AUDIO_CODEC_CFG_LC3_DATA(
+		BT_AUDIO_CODEC_CFG_FREQ_16KHZ, BT_AUDIO_CODEC_CFG_DURATION_10,
+		BT_AUDIO_LOCATION_FRONT_LEFT, 40U, 1U);
+	const enum bt_pbp_announcement_feature features =
+		BT_PBP_ANNOUNCEMENT_FEATURE_STANDARD_QUALITY;
+	const uint8_t coding_format = BT_HCI_CODING_FORMAT_LC3;
+	const uint8_t framing = BT_ISO_FRAMING_UNFRAMED;
+	const char *broadcast_name = "broadcast_name";
+	const uint32_t presentation_delay = 40000U;
+	const uint32_t broadcast_id = 0x123456U;
+	const uint32_t sdu_interval = 10000U;
+	const uint16_t max_latency = 10U;
+	const uint8_t subgroup_id = 0U;
+	const uint16_t max_sdu = 40U;
+	const uint8_t source_id = 0U;
+	const uint16_t vid = 0x0000U; /* shall be 0x0000 for LC3 */
+	const uint16_t cid = 0x0000U; /* shall be 0x0000 for LC3 */
+	const uint8_t flags = 0U;
+	const uint8_t rtn = 2U;
+
+	bsim_btp_uart_init();
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_CORE, BTP_CORE_EV_IUT_READY, NULL);
+
+	bsim_btp_core_register(BTP_SERVICE_ID_GAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_BAP); /* required to start the TX thread */
+	bsim_btp_core_register(BTP_SERVICE_ID_CAP);
+	bsim_btp_core_register(BTP_SERVICE_ID_PBP);
+
+	bsim_btp_cap_broadcast_source_setup_stream(source_id, subgroup_id, coding_format, vid, cid,
+						   0, NULL, 0, NULL);
+	bsim_btp_cap_broadcast_source_setup_subgroup(
+		source_id, subgroup_id, coding_format, vid, cid, ARRAY_SIZE(cc_data_16_2_1),
+		cc_data_16_2_1, ARRAY_SIZE(metadata), metadata);
+	bsim_btp_cap_broadcast_source_setup(source_id, broadcast_id, sdu_interval, framing, max_sdu,
+					    rtn, max_latency, presentation_delay, flags);
+
+	bsim_btp_pbp_set_public_broadcast_announcement((uint8_t)features);
+	bsim_btp_pbp_set_broadcast_name(broadcast_name);
+
+	bsim_btp_cap_broadcast_adv_start(source_id);
+	bsim_btp_cap_broadcast_source_start(source_id);
+
+	TEST_PASS("PASSED\n");
+}
+
+static const struct bst_test_instance test_sample[] = {
+	{
+		.test_id = "pbp_source",
+		.test_descr = "Smoketest for the PBP broadcast source BT Tester behavior",
+		.test_main_f = test_pbp_source,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_pbp_source_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_sample);
+}

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.c
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.c
@@ -1731,8 +1731,15 @@ static bool is_valid_pbp_packet_len(const struct btp_hdr *hdr, struct net_buf_si
 
 	/* events */
 	case BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND:
-		return buf_simple->len ==
-		       sizeof(struct btp_pbp_ev_public_broadcast_announcement_found_ev);
+		if (hdr->len >= sizeof(struct btp_pbp_ev_public_broadcast_announcement_found_ev)) {
+			const struct btp_pbp_ev_public_broadcast_announcement_found_ev *ev;
+
+			ev = net_buf_simple_pull_mem(buf_simple, sizeof(*ev));
+
+			return ev->broadcast_name_len == buf_simple->len;
+		} else {
+			return false;
+		}
 	default:
 		LOG_ERR("Unhandled opcode 0x%02X", hdr->opcode);
 		return false;

--- a/tests/bsim/bluetooth/tester/src/bsim_btp.h
+++ b/tests/bsim/bluetooth/tester/src/bsim_btp.h
@@ -1366,9 +1366,82 @@ static inline void bsim_btp_tbs_register_bearer(
 	net_buf_simple_add_mem(&cmd_buffer, uci, cmd->uci_len);
 	net_buf_simple_add_mem(&cmd_buffer, uri_scheme_list, cmd->uri_scheme_list_len);
 
-	cmd_hdr->len = sys_cpu_to_le16(cmd_buffer.len - sizeof(*cmd_hdr));
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
 
 	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_pbp_set_public_broadcast_announcement(uint8_t features)
+{
+	struct btp_pbp_set_public_broadcast_announcement_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_PBP;
+	cmd_hdr->opcode = BTP_PBP_SET_PUBLIC_BROADCAST_ANNOUNCEMENT;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->features = features;
+	cmd->metadata_len = 0U;
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_pbp_set_broadcast_name(const char *broadcast_name)
+{
+	struct btp_pbp_set_broadcast_name_cmd *cmd;
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_PBP;
+	cmd_hdr->opcode = BTP_PBP_SET_BROADCAST_NAME;
+	cmd_hdr->index = BTP_INDEX;
+	cmd = net_buf_simple_add(&cmd_buffer, sizeof(*cmd));
+	cmd->name_len = strlen(broadcast_name) + 1 /* NULL terminator */;
+	net_buf_simple_add_mem(&cmd_buffer, broadcast_name, cmd->name_len);
+
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_pbp_broadcast_scan_start(void)
+{
+	struct btp_hdr *cmd_hdr;
+
+	NET_BUF_SIMPLE_DEFINE(cmd_buffer, BTP_MTU);
+
+	cmd_hdr = net_buf_simple_add(&cmd_buffer, sizeof(*cmd_hdr));
+	cmd_hdr->service = BTP_SERVICE_ID_PBP;
+	cmd_hdr->opcode = BTP_PBP_BROADCAST_SCAN_START;
+	cmd_hdr->index = BTP_INDEX;
+
+	/* The command for this is empty */
+	cmd_hdr->len = cmd_buffer.len - sizeof(*cmd_hdr);
+
+	bsim_btp_send_to_tester(cmd_buffer.data, cmd_buffer.len);
+}
+
+static inline void bsim_btp_wait_for_pbp_public_broadcast_announcement_found(bt_addr_le_t *address)
+{
+	struct btp_pbp_ev_public_broadcast_announcement_found_ev *ev;
+	struct net_buf *buf;
+
+	bsim_btp_wait_for_evt(BTP_SERVICE_ID_PBP, BTP_PBP_EV_PUBLIC_BROADCAST_ANNOUNCEMENT_FOUND,
+			      &buf);
+	ev = net_buf_pull_mem(buf, sizeof(*ev));
+
+	if (address != NULL) {
+		bt_addr_le_copy(address, &ev->address);
+	}
+
+	net_buf_unref(buf);
 }
 
 static inline void bsim_btp_tmap_discover(const bt_addr_le_t *address)

--- a/tests/bsim/bluetooth/tester/src/test_main.c
+++ b/tests/bsim/bluetooth/tester/src/test_main.c
@@ -27,6 +27,8 @@ extern struct bst_test_list *test_mcp_central_install(struct bst_test_list *test
 extern struct bst_test_list *test_mcp_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_micp_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_micp_peripheral_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_pbp_sink_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_pbp_source_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_tmap_central_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_tmap_peripheral_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_vcp_central_install(struct bst_test_list *tests);
@@ -55,6 +57,8 @@ bst_test_install_t test_installers[] = {
 	test_mcp_peripheral_install,
 	test_micp_central_install,
 	test_micp_peripheral_install,
+	test_pbp_sink_install,
+	test_pbp_source_install,
 	test_tmap_central_install,
 	test_tmap_peripheral_install,
 	test_vcp_central_install,

--- a/tests/bsim/bluetooth/tester/tests_scripts/pbp.sh
+++ b/tests/bsim/bluetooth/tester/tests_scripts/pbp.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoketest for PBP BTP commands with the BT tester
+
+simulation_id="tester_pbp"
+verbosity_level=2
+EXECUTE_TIMEOUT=100
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+cd ${BSIM_OUT_PATH}/bin
+
+UART_DIR=/tmp/bs_${USER}/${simulation_id}/
+UART_SNK=${UART_DIR}/sink
+UART_BCST=${UART_DIR}/broadcaster
+
+# Broadcaster BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=10 -d=0 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_BCST}.tx -uart0_fifob_txfile=${UART_BCST}.rx
+
+# Broadcaster Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=21 -d=10 -RealEncryption=1 -testid=pbp_source \
+  -nosim -uart0_fifob_rxfile=${UART_BCST}.rx -uart0_fifob_txfile=${UART_BCST}.tx
+
+# Sink BT Tester
+Execute ./bs_${BOARD_TS}_tests_bluetooth_tester_le_audio_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=32 -d=1 -RealEncryption=1 \
+  -uart0_fifob_rxfile=${UART_SNK}.tx -uart0_fifob_txfile=${UART_SNK}.rx
+
+# Sink Upper Tester
+Execute ./bs_nrf52_bsim_native_tests_bsim_bluetooth_tester_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -rs=43 -d=11 -RealEncryption=1 -testid=pbp_sink \
+  -nosim -uart0_fifob_rxfile=${UART_SNK}.rx -uart0_fifob_txfile=${UART_SNK}.tx
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} -D=2 -sim_length=20e6 $@
+
+wait_for_background_jobs # Wait for all programs in background and return != 0 if any fails


### PR DESCRIPTION
Adds BSIM testing of the PBP features of the BT Tester.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/86073