### PR TITLE
wifi: nrf_wifi: Add control pool specific APIs

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -564,7 +564,8 @@ config NRF_WIFI_CTRL_HEAP_SIZE
 
 config NRF_WIFI_DATA_HEAP_SIZE
 	int "Dedicated memory pool for data plane"
-	default 8000 if NRF70_SCAN_ONLY || NRF70_RADIO_TEST #TODO: Need to optimize this.
+	default 0 if NRF70_RADIO_TEST || NRF70_OFFLOADED_RAW_TX
+	default 8000 if NRF70_SCAN_ONLY
 	default 110000 if !SOC_FAMILY_NORDIC_NRF
 	default 130000
 

--- a/modules/nrf_wifi/os/shim.c
+++ b/modules/nrf_wifi/os/shim.c
@@ -575,9 +575,30 @@ static void *zep_shim_llist_node_alloc(void)
 	return llist_node;
 }
 
+static void *zep_shim_ctrl_llist_node_alloc(void)
+{
+	struct zep_shim_llist_node *llist_node = NULL;
+
+	llist_node = zep_shim_mem_zalloc(sizeof(*llist_node));
+
+	if (!llist_node) {
+		LOG_ERR("%s: Unable to allocate memory for linked list node", __func__);
+		return NULL;
+	}
+
+	sys_dnode_init(&llist_node->head);
+
+	return llist_node;
+}
+
 static void zep_shim_llist_node_free(void *llist_node)
 {
 	zep_shim_data_mem_free(llist_node);
+}
+
+static void zep_shim_ctrl_llist_node_free(void *llist_node)
+{
+	zep_shim_mem_free(llist_node);
 }
 
 static void *zep_shim_llist_node_data_get(void *llist_node)
@@ -1071,7 +1092,9 @@ const struct nrf_wifi_osal_ops nrf_wifi_os_zep_ops = {
 	.log_err = zep_shim_pr_err,
 
 	.llist_node_alloc = zep_shim_llist_node_alloc,
+	.ctrl_llist_node_alloc = zep_shim_ctrl_llist_node_alloc,
 	.llist_node_free = zep_shim_llist_node_free,
+	.ctrl_llist_node_free = zep_shim_ctrl_llist_node_free,
 	.llist_node_data_get = zep_shim_llist_node_data_get,
 	.llist_node_data_set = zep_shim_llist_node_data_set,
 

--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: fe4ff0e191a52de4f85ecc3475f0253eca6fc5bf
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: pull/46/head
+      revision: eeceee739252cf2d56a5ad9356553d87aae8c57d
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: f7f4d083c7909a39d86e217376c69b416ec4faf3


### PR DESCRIPTION
Memory allocations in HAL are using data pool. These operations are in control plane. Add APIs for allocation/free operations on control pool.