### PR TITLE
Revert "shields: nrf7002ek: Increase default frequency to 16MHz"

### DIFF
--- a/boards/shields/nrf7002ek/nrf7002ek.overlay
+++ b/boards/shields/nrf7002ek/nrf7002ek.overlay
@@ -18,7 +18,7 @@
 		compatible = "nordic,nrf7002-spi";
 		status = "okay";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(16)>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 
 		/* Include common nRF70 overlays */
 		#include "nrf7002ek_common.dtsi"


### PR DESCRIPTION
This reverts commit fe32d059af1d49cc1a82d66c81de82b8dd2dce7d.

A supported host, 52840 does not support 16MHz SPI (though it falls back to 8M) but prioritize interoperability over performance.