### PR TITLE
tests: kernel/pending: fix incorrect test names

### DIFF
--- a/tests/kernel/pending/testcase.yaml
+++ b/tests/kernel/pending/testcase.yaml
@@ -1,7 +1,7 @@
 tests:
-  kernel.objects:
+  kernel.pending:
     tags: kernel
-  kernel.objects.minimallibc:
+  kernel.pending.minimallibc:
     filter: CONFIG_MINIMAL_LIBC_SUPPORTED
     tags:
       - kernel


### PR DESCRIPTION
These tests should be named "kernel.pending" instead of "kernel.objects".