### PR TITLE
drivers: flash: spi_nor: optimizations and better Micron flash support

### DIFF
--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -15,6 +15,15 @@
 #define SPI_NOR_WIP_BIT         BIT(0)  /* Write in progress */
 #define SPI_NOR_WEL_BIT         BIT(1)  /* Write enable latch */
 
+/* Flag status register bits */
+#define SPI_NOR_FLSR_READY           BIT(7) /* Ready (program/erase not in progress) */
+#define SPI_NOR_FLSR_ERASE_SUSPEND   BIT(6) /* Erase suspend active */
+#define SPI_NOR_FLSR_ERASE_FAIL      BIT(5) /* Last erase failed */
+#define SPI_NOR_FLSR_PROGRAM_FAIL    BIT(4) /* Last program failed */
+#define SPI_NOR_FLSR_PROGRAM_SUSPEND BIT(2) /* Program suspend active */
+#define SPI_NOR_FLSR_PROT_ERROR      BIT(1) /* Protection violation */
+#define SPI_NOR_FLSR_4BA             BIT(0) /* 4-byte address mode active */
+
 /* Flash opcodes */
 #define SPI_NOR_CMD_WRSR        0x01    /* Write status register */
 #define SPI_NOR_CMD_RDSR        0x05    /* Read status register */
@@ -60,6 +69,8 @@
 #define SPI_NOR_CMD_PP_4B        0x12  /* Page Program 4 Byte Address */
 #define SPI_NOR_CMD_PP_1_1_4_4B  0x34  /* Quad Page program (1-1-4) 4 Byte Address */
 #define SPI_NOR_CMD_PP_1_4_4_4B  0x3e  /* Quad Page program (1-4-4) 4 Byte Address */
+#define SPI_NOR_CMD_RDFLSR       0x70  /* Read Flag Status Register */
+#define SPI_NOR_CMD_CLRFLSR      0x50  /* Clear Flag Status Register */
 
 /* Flash octal opcodes */
 #define SPI_NOR_OCMD_SE         0x21DE  /* Octal Sector erase */

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -123,3 +123,13 @@ properties:
       which indicates more details on the status of program or erase operations.
       In some cases, program operations will not function properly if the flag
       status register is not read after the operation.
+
+  use-fast-read:
+    type: boolean
+    description: |
+      Indicates the device supports fast read.
+
+      Most SPI NOR devices support a fast read command that allows the device to
+      output data at a higher clock rate than the standard read command.  This
+      property indicates that the device supports the fast read command with
+      8 dummy cycles after the address phase of the command.

--- a/dts/bindings/mtd/jedec,spi-nor-common.yaml
+++ b/dts/bindings/mtd/jedec,spi-nor-common.yaml
@@ -113,3 +113,13 @@ properties:
       Some devices support 4-byte address opcodes for read/write/erase
       operations.  Use this property to indicate that the device supports
       4-byte address opcodes.
+
+  use-flag-status-register:
+    type: boolean
+    description: |
+      Indicates the device supports a flag status register.
+
+      Some devices (Micron and possibly others) support a flag status register
+      which indicates more details on the status of program or erase operations.
+      In some cases, program operations will not function properly if the flag
+      status register is not read after the operation.


### PR DESCRIPTION
- Avoid providing redundant TX buffers to the SPI driver for the data portion of read commands where the TX data is not used. This is more efficient and also avoids passing uninitialized data to an external device.
- Add support for the flag status register used on some Micron flash devices, which improves error detection and in some cases must be read for the flash device to function properly.
- Add support for fast read commands using a dummy byte between the address and data phases, which often allows the flash device to operate at a higher SPI clock rate.

Note, there might be a compliance error raised, as I wasn't able to satisfy both clang-format and checkpatch with regard to how one line was formatted..