### PR TITLE
drivers: serial: ns16550: Fix FIFO detection on Xilinx 16550

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -708,6 +708,11 @@ static int uart_ns16550_configure(const struct device *dev,
 #endif
 			);
 
+	/* Xilinx 16550 core (at least) needs a dummy read of IIR here in order for the
+	 * following read to return valid data (instead of reading back FCR).
+	 */
+	ns16550_inbyte(dev_cfg, IIR(dev));
+
 	if ((ns16550_inbyte(dev_cfg, IIR(dev)) & IIR_FE) == IIR_FE) {
 #ifdef CONFIG_UART_NS16550_VARIANT_NS16750
 		dev_data->fifo_size = 64;


### PR DESCRIPTION
The Xilinx AXI UART16550 FPGA IP core seems to have a quirk where the first read of the combined FCR/IIR register, after FCR is written when configuring the port, just reads back FCR (which is only supposed to happen when the DLAB bit in LCR is set) rather than reading the IIR register. This causes the code using the IIR register for detecting FIFO support to misbehave and not detect that a FIFO is present.

Add a dummy read of the IIR register before the real one to avoid this problem. This is expected to be harmless on other implementations.