### PR TITLE
manifest: nrf_wifi: feature flag check for raw mode firmware

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: fe4ff0e191a52de4f85ecc3475f0253eca6fc5bf
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 8fd3cd7b088d62f145b8b9f5ecc985dd73bd9e77
+      revision: 69fef1c2e3dfb2c9a26b9b28a79c55f1ccb7a602
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: f7f4d083c7909a39d86e217376c69b416ec4faf3


### PR DESCRIPTION
Raw mode is now made a subset of system mode.
Place the check such that feature flag is checked
for raw mode as well as system mode when the feature flag is checked before loading firmware.