### PR TITLE
boards: intel: rpl: Added revisions for RPL-s board

### DIFF
--- a/boards/intel/rpl/board.yml
+++ b/boards/intel/rpl/board.yml
@@ -7,5 +7,11 @@ boards:
   - name: intel_rpl_s_crb
     full_name: Raptor Lake S CRB
     vendor: intel
+    revision:
+      format: number
+      default: "600"
+      revisions:
+        - name: "600"
+        - name: "700"
     socs:
       - name: raptor_lake

--- a/boards/intel/rpl/doc/index.rst
+++ b/boards/intel/rpl/doc/index.rst
@@ -12,7 +12,10 @@ architecture, utilizing P-cores for performance and E-Cores for efficiency.
 Raptor Lake S and Raptor Lake P processor lines are supported.
 
 The S-Processor line is a 2-Chip Platform that includes the Processor Die and
-Platform Controller Hub (PCH-S) Die in the Package.
+Platform Controller Hub (PCH-S) Die in the Package. There are 2 PCH-s versions
+supported for S-Processor line 600 series (ADL) and 700 series (RPL). Default
+600 series revision is selected, to select 700 series revision the board name
+during build should be ``intel_rpl_s_crb@700``.
 
 The P-Processor line is a 2-Die Multi Chip Package (MCP) that includes the
 Processor Die and Platform Controller Hub (PCH-P) Die on the same package as

--- a/boards/intel/rpl/intel_rpl_s_crb_700.overlay
+++ b/boards/intel/rpl/intel_rpl_s_crb_700.overlay
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <intel/raptor_lake_s.dtsi>
+
+&smbus0 {
+	device-id = <0x7a23>;
+};
+
+&i2c0 {
+	device-id = <0x7a4c>;
+};
+
+&i2c1 {
+	device-id = <0x7a4c>;
+};
+
+&i2c2 {
+	device-id = <0x7a4d>;
+};
+
+&i2c3 {
+	device-id = <0x7a4e>;
+};
+
+&i2c4 {
+	device-id = <0x7a7c>;
+};
+
+&i2c5 {
+	device-id = <0x7a7d>;
+};
+
+&spi0 {
+	device-id = <0x7a2a>;
+};
+
+&spi1 {
+	device-id = <0x7a2b>;
+};
+
+&spi2 {
+	device-id = <0x7a7b>;
+};
+
+&uart0 {
+	device-id = <0x7a28>;
+};
+
+&uart1 {
+	device-id = <0x7a29>;
+};
+
+&uart2 {
+	device-id = <0x7a7e>;
+};

--- a/dts/x86/intel/raptor_lake_s.dtsi
+++ b/dts/x86/intel/raptor_lake_s.dtsi
@@ -56,7 +56,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			vendor-id = <0x8086>;
-			device-id = <0x7a23>;
+			device-id = <0x7aa3>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 


### PR DESCRIPTION
The PR introduces two different revisions for the RPL-s board, each supporting two PCH options: 600 series and 700 series. It also includes a correction to the device ID of SMBUS for the 600 series. 

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>