### PR TITLE
modules: littlefs: update to v2.11.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -290,7 +290,7 @@ manifest:
       path: modules/fs/littlefs
       groups:
         - fs
-      revision: ed0531d59ee37f5fb2762bcf2fc8ba4efaf82656
+      revision: 8f5ca347843363882619d8f96c00d8dbd88a8e79
     - name: loramac-node
       revision: fb00b383072518c918e2258b0916c996f2d4eebe
       path: modules/lib/loramac-node


### PR DESCRIPTION
Update LittleFS to version 2.11.0.

See https://github.com/zephyrproject-rtos/littlefs/pull/19
