### PR TITLE
regulator: npm1300: convert regulator GPIOs to array

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -96,6 +96,15 @@ DMA
 * Renamed the devicetree property ``nxp,a_on`` to ``nxp,a-on``.
 * Renamed the devicetree property ``dma_channels`` to ``dma-channels``.
 
+Regulator
+=========
+
+* :dtcompatible:`nordic,npm1300-regulator` BUCK and LDO node GPIO properties are now specified as an
+  integer array without a GPIO controller, removing the requirement for a
+  :dtcompatible:`nordic,npm1300-gpio` node to be present and enabled for GPIO control of the output
+  rails. For example, ``enable-gpios = <&pmic_gpios 3 GPIO_ACTIVE_LOW>;`` is now specified as
+  ``enable-gpio-config = <3 GPIO_ACTIVE_LOW>;``.
+
 Counter
 =======
 

--- a/dts/bindings/regulator/nordic,npm1300-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm1300-regulator.yaml
@@ -70,22 +70,22 @@ child-binding:
       description: |
         Retention mode voltage in microvolts.
 
-    enable-gpios:
-      type: phandle-array
+    enable-gpio-config:
+      type: array
       description: |
-        Regulator enable controlled by specified regulator GPIO pin.
+        Regulator enable controlled by specified GPIO pin <idx flags>.
         When set regulator must be enabled/disabled using set_dvs_mode.
 
-    pwm-gpios:
-      type: phandle-array
+    pwm-gpio-config:
+      type: array
       description: |
-        Regulator enable controlled by specified regulator GPIO pin.
+        Regulator enable controlled by specified GPIO pin <idx flags>.
         When set regulator must be enabled/disabled using set_dvs_mode.
 
-    retention-gpios:
-      type: phandle-array
+    retention-gpio-config:
+      type: array
       description: |
-        Retention mode controlled by specified regulator GPIO pin.
+        Retention mode controlled by specified GPIO pin <idx flags>.
 
     soft-start-microamp:
       type: int

--- a/samples/shields/npm1300_ek/nrf52dk_nrf52832.overlay
+++ b/samples/shields/npm1300_ek/nrf52dk_nrf52832.overlay
@@ -20,19 +20,19 @@
 &npm1300_ek_buck2 {
 	regulator-init-microvolt = <3300000>;
 	retention-microvolt = <2500000>;
-	enable-gpios = <&npm1300_ek_gpio 1 GPIO_ACTIVE_LOW>;
-	retention-gpios = <&npm1300_ek_gpio 2 GPIO_ACTIVE_HIGH>;
-	pwm-gpios = <&npm1300_ek_gpio 2 GPIO_ACTIVE_LOW>;
+	enable-gpio-config = <1 GPIO_ACTIVE_LOW>;
+	retention-gpio-config = <2 GPIO_ACTIVE_HIGH>;
+	pwm-gpio-config = <2 GPIO_ACTIVE_LOW>;
 };
 
 &npm1300_ek_ldo1 {
 	regulator-initial-mode = <NPM1300_LDSW_MODE_LDO>;
-	enable-gpios = <&npm1300_ek_gpio 2 GPIO_ACTIVE_LOW>;
+	enable-gpio-config = <2 GPIO_ACTIVE_LOW>;
 };
 
 &npm1300_ek_ldo2 {
 	regulator-initial-mode = <NPM1300_LDSW_MODE_LDSW>;
-	enable-gpios = <&npm1300_ek_gpio 2 GPIO_ACTIVE_LOW>;
+	enable-gpio-config = <2 GPIO_ACTIVE_LOW>;
 };
 
 &npm1300_ek_pmic {


### PR DESCRIPTION
Convert the enable, pwm, and retention `gpios` properties away from the GPIO specifier space to an integer array.
While this is a less specific type than the GPIO property, it has the advantage of not requiring the PMIC gpios node to be both present and enabled.

This is intended to support the use-case where the only use of the nPM1300 GPIOs is as control lines for the voltage outputs.

Using the GPIO space in the first place was unfortunate, since the property was never referring to a pin which could be driven to a state, or an input value read. It appears to have simply been a convenient way to hold a pin number and `GPIO_ACTIVE_LOW/HIGH`.