### PR TITLE
wifi: nrf_wifi: add alignment requirement to buffers

### DIFF
--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -75,6 +75,11 @@ BUILD_ASSERT(RPU_PKTRAM_SIZE - TOTAL_RX_SIZE >= TOTAL_TX_SIZE,
 BUILD_ASSERT(CONFIG_NRF70_TX_MAX_DATA_SIZE >= MAX_TX_FRAME_SIZE,
 	"TX buffer size must be at least as big as the MTU and headroom");
 
+BUILD_ASSERT(CONFIG_NRF70_TX_MAX_DATA_SIZE % 4 == 0,
+	"TX buffer size must be a multiple of 4");
+BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE % 4 == 0,
+	"RX buffer size must be a multiple of 4");
+
 static const unsigned char aggregation = 1;
 static const unsigned char max_num_tx_agg_sessions = 4;
 static const unsigned char max_num_rx_agg_sessions = 8;


### PR DESCRIPTION
The nRF lower levels (`spim_addr_check` and `qspi_addr_check`) do address alignment validation before sending or receiving data. If the buffer sizes are not aligned, errors like this are printed to the console when the interface is powered up.

```
<err> : spim_addr_check : Unaligned address ee0b2 2002b020 1 0 0
<err> : spim_addr_check : Unaligned address eeb3e 2002bb40 1 0 0
<err> : spim_addr_check : Unaligned address ef5ca 2002c660 1 0 0
<err> : spim_addr_check : Unaligned address f0056 2002d180 1 0 0
```