### PR TITLE
manifest: nrf_wifi: cleanup logging newlines

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -321,7 +321,7 @@ manifest:
       revision: fe4ff0e191a52de4f85ecc3475f0253eca6fc5bf
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 8fd3cd7b088d62f145b8b9f5ecc985dd73bd9e77
+      revision: pull/46/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: f7f4d083c7909a39d86e217376c69b416ec4faf3


### PR DESCRIPTION
Update WiFi driver to cleanup extra logging newlines for consistency.