### PR TITLE
wifi: nrf70: configurable IOVDD settling delay

### DIFF
--- a/dts/bindings/wifi/nordic,nrf70.yaml
+++ b/dts/bindings/wifi/nordic,nrf70.yaml
@@ -22,3 +22,10 @@ properties:
     description: |
       GPIO of the RF Switch to control SR RF output to either SR Antenna
       or shared Antenna with Wi-Fi
+
+  iovdd-power-up-delay-ms:
+    type: int
+    default: 1
+    description: |
+      Duration to wait after enabling IOVDD before attempting communications.
+      Default value of 1 comes from the nRF7002 DK/EK switch (TCK106AG): ~600us

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -239,8 +239,8 @@ static int rpu_pwron(void)
 		gpio_pin_set_dt(&bucken_spec, 0);
 		return ret;
 	}
-	/* Settling time for iovdd nRF7002 DK/EK - switch (TCK106AG): ~600us */
-	k_msleep(1);
+	/* Settling time for IOVDD */
+	k_msleep(DT_PROP(NRF7002_NODE, iovdd_power_up_delay_ms));
 
 	if ((bucken_spec.port == iovdd_ctrl_spec.port) &&
 	    (bucken_spec.pin == iovdd_ctrl_spec.pin)) {


### PR DESCRIPTION
Make the IOVDD settling delay configurable, instead of hardcoding a delay that happens to work for the dev kits.
For example, the nPM1300 load switches have a soft-start time of 1.8 ms.