### PR TITLE
ethernet: stm32: add a alternative HAL_ETH_Init for V1 api

### DIFF
--- a/drivers/ethernet/eth_stm32_hal_common.c
+++ b/drivers/ethernet/eth_stm32_hal_common.c
@@ -460,9 +460,6 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 		.Instance = (ETH_TypeDef *)DT_REG_ADDR(DT_INST_PARENT(0)),
 		.Init = {
 #if defined(CONFIG_ETH_STM32_HAL_API_V1)
-			.AutoNegotiation = ETH_STM32_AUTO_NEGOTIATION_ENABLE ?
-					   ETH_AUTONEGOTIATION_ENABLE : ETH_AUTONEGOTIATION_DISABLE,
-			.PhyAddress = DT_REG_ADDR(DT_INST_PHANDLE(0, phy_handle)),
 			.RxMode = ETH_RXINTERRUPT_MODE,
 			.ChecksumMode = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
 					ETH_CHECKSUM_BY_HARDWARE : ETH_CHECKSUM_BY_SOFTWARE,

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -55,9 +55,6 @@ extern const struct device *eth_stm32_phy_dev;
 #define ETH_MII_MODE	ETH_MEDIA_INTERFACE_MII
 #define ETH_RMII_MODE	ETH_MEDIA_INTERFACE_RMII
 
-#define ETH_STM32_AUTO_NEGOTIATION_ENABLE                                                          \
-	UTIL_NOT(DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, phy_handle), fixed_link))
-
 #else /* CONFIG_ETH_STM32_HAL_API_V2 */
 
 #define ETH_MII_MODE	HAL_ETH_MII_MODE

--- a/drivers/ethernet/eth_stm32_hal_v1.c
+++ b/drivers/ethernet/eth_stm32_hal_v1.c
@@ -188,28 +188,12 @@ int eth_stm32_hal_init(const struct device *dev)
 {
 	struct eth_stm32_hal_dev_data *dev_data = dev->data;
 	ETH_HandleTypeDef *heth = &dev_data->heth;
-	HAL_StatusTypeDef hal_ret = HAL_OK;
-
-	if (!ETH_STM32_AUTO_NEGOTIATION_ENABLE) {
-		struct phy_link_state state;
-
-		phy_get_link_state(eth_stm32_phy_dev, &state);
-
-		heth->Init.DuplexMode = PHY_LINK_IS_FULL_DUPLEX(state.speed) ? ETH_MODE_FULLDUPLEX
-									     : ETH_MODE_HALFDUPLEX;
-		heth->Init.Speed =
-			PHY_LINK_IS_SPEED_100M(state.speed) ? ETH_SPEED_100M : ETH_SPEED_10M;
-	}
+	HAL_StatusTypeDef hal_ret;
 
 	hal_ret = HAL_ETH_Init(heth);
-	if (hal_ret == HAL_TIMEOUT) {
-		/* HAL Init time out. This could be linked to */
-		/* a recoverable error. Log the issue and continue */
-		/* driver initialisation */
-		LOG_WRN("HAL_ETH_Init timed out (cable not connected?)");
-	} else if (hal_ret != HAL_OK) {
+	if (hal_ret != HAL_OK) {
 		LOG_ERR("HAL_ETH_Init failed: %d", hal_ret);
-		return -EINVAL;
+		return -EIO;
 	}
 
 	/* Initialize semaphores */

--- a/west.yml
+++ b/west.yml
@@ -250,7 +250,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 2c18f2b49d66d23cabfbd20dd7dbbaef8ee9520b
+      revision: 9d05ebdff47b5071fa092de243a1244e7c27f518
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
~~add a alternative HAL_ETH_Init for V1 api without phy
configuration, as this is already been done outside of
the ethernet driver.~~

Deactivates the phy config and init in the hal code, because the phy driver in zephyr is already responsible for it.