### PR TITLE
Add Disconnection locally generated info

### DIFF
--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -396,6 +396,10 @@ void nrf_wifi_wpa_supp_event_proc_deauth(void *if_priv,
 		event.deauth_info.ie_len = (frame + frame_len - mgmt->u.deauth.variable);
 	}
 
+	if (!(deauth->valid_fields & NRF_WIFI_EVENT_MLME_RXDEAUTH_FROM_AP)) {
+		event.deauth_info.locally_generated = 1;
+	}
+
 	if (vif_ctx_zep->supp_drv_if_ctx && vif_ctx_zep->supp_callbk_fns.deauth) {
 		vif_ctx_zep->supp_callbk_fns.deauth(vif_ctx_zep->supp_drv_if_ctx,
 			&event, mgmt);


### PR DESCRIPTION
Add locally generated info for deauth process. If deauthentication frame is coming from AP it will be set, in other cases (Beacon loss, new connection from user in connected state, disconnection from user) flag will not be set.

Manifest will be update with https://github.com/zephyrproject-rtos/zephyr/pull/88457