### PR TITLE
include: arch: ffs: include toolchain/common.h

### DIFF
--- a/include/zephyr/arch/common/ffs.h
+++ b/include/zephyr/arch/common/ffs.h
@@ -11,6 +11,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/types.h>
+#include <zephyr/toolchain/common.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Add an include of toolchain/common.h for the ALWAYS_INLINE macro.

This is a general issue in many files across Zephyr, specifically for the ALWAYS_INLINE macro, but for simplicity this commit only includes it for this file as that has been shown to cause compilaion issues without it.