### PR TITLE
boards: shields: Fix EVAL-AD4052-ARDZ adc shield conversion pin

### DIFF
--- a/boards/shields/eval_ad4052_ardz/eval_ad4052_ardz.overlay
+++ b/boards/shields/eval_ad4052_ardz/eval_ad4052_ardz.overlay
@@ -12,7 +12,7 @@
 		spi-max-frequency = <DT_FREQ_M(2)>;
 		gp1-gpios = <&arduino_header 14 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 		gp0-gpios = <&arduino_header 15 (GPIO_PULL_DOWN)>;
-		conversion-gpios = <&arduino_header 13 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
+		conversion-gpios = <&arduino_header 12 (GPIO_ACTIVE_HIGH | MAX32_GPIO_VSEL_VDDIOH)>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		#io-channel-cells = <1>;


### PR DESCRIPTION
Changed conversion gpio to correct arudino header number.

Signed-off-by: Dimitrije Lilic dimitrije.lilic@orioninc.com