### PR TITLE
boards: openhwgroup: add Twister files for genesys 2

### DIFF
--- a/boards/openhwgroup/cv32a6_genesys_2/cv32a6_genesys_2.yaml
+++ b/boards/openhwgroup/cv32a6_genesys_2/cv32a6_genesys_2.yaml
@@ -1,0 +1,14 @@
+identifier: cv32a6_genesys_2
+name: OpenHWGroup CV32A6 on Genesys 2
+type: mcu
+arch: riscv
+toolchain:
+  - zephyr
+  - gnuarmemb
+ram: 1048576
+supported:
+  - gpio
+  - uart
+  - spi
+  - ethernet
+vendor: openhwgroup

--- a/boards/openhwgroup/cv64a6_genesys_2/cv64a6_genesys_2.yaml
+++ b/boards/openhwgroup/cv64a6_genesys_2/cv64a6_genesys_2.yaml
@@ -1,0 +1,14 @@
+identifier: cv64a6_genesys_2
+name: OpenHWGroup CV64A6 on Genesys 2
+type: mcu
+arch: riscv
+toolchain:
+  - zephyr
+  - gnuarmemb
+ram: 1048576
+supported:
+  - gpio
+  - uart
+  - spi
+  - ethernet
+vendor: openhwgroup

--- a/soc/openhwgroup/cva6/Kconfig.defconfig
+++ b/soc/openhwgroup/cva6/Kconfig.defconfig
@@ -7,6 +7,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int
 	default $(dt_node_int_prop_int,/cpus/cpu@0,timebase-frequency)
 
+config SYS_CLOCK_EXISTS
+	default n
+
 config RISCV_SOC_INTERRUPT_INIT
 	default y
 


### PR DESCRIPTION
This was missed during code review when boards were introduced. Allows to run tests on the genesys 2 boards as well a get a proper table of supported features in the docs.