### PR TITLE
manifest: update TF-M for Mbed TLS 3.6.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -353,7 +353,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 25dff7328c77b51e314ef9d4625044072040c96d
+      revision: pull/127/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Pull in TF-M updates to align with Mbed TLS 3.6.3.

fixes #88398