### PR TITLE
Fix include issues related to mmu on stm32mp13 platform

### DIFF
--- a/include/zephyr/arch/arm/mmu/arm_mmu.h
+++ b/include/zephyr/arch/arm/mmu/arm_mmu.h
@@ -10,6 +10,9 @@
 
 #ifndef _ASMLANGUAGE
 
+#include <stdint.h>
+#include <stdlib.h>
+
 /*
  * Comp.:
  * ARM Architecture Reference Manual, ARMv7-A and ARMv7-R edition,

--- a/soc/st/stm32/stm32mp13x/soc.c
+++ b/soc/st/stm32/stm32mp13x/soc.c
@@ -9,6 +9,7 @@
  * @brief System/hardware module for STM32MP13 processor
  */
 
+#include <zephyr/arch/arm/mmu/arm_mmu.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>


### PR DESCRIPTION
Fix issues reported by following command

` west twister -p  stm32mp135f_dk/stm32mp135fxx -T samples/subsys/llext/shell_loader/`