### PR TITLE
net: gPTP: Fix pointer type in gptp_add_port

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -586,7 +586,7 @@ static void gptp_thread(void *p1, void *p2, void *p3)
 
 static void gptp_add_port(struct net_if *iface, void *user_data)
 {
-	int *num_ports = user_data;
+	uint8_t *num_ports = user_data;
 	const struct device *clk;
 
 	if (*num_ports >= CONFIG_NET_GPTP_NUM_PORTS) {


### PR DESCRIPTION
The number of ports in `gptp_domain.default_ds.nb_ports` is a `uint8_t`. A pointer to it is passed to `gptp_add_port`.

However, in this method, the pointer is cast to an int pointer. The C compiler generates an `int`-size store for this. In addition to potentially overwriting adjacent attributes, on platforms such as RISC-V that do not support unaligned accesses, this causes an exception on access.

This commit casts `num_ports` to the correct type, `uint8_t`.