### PR TITLE
cmake: toolchain/xcc,xt-clang: LD flag for multi-core env vars

### DIFF
--- a/cmake/toolchain/xcc/common.cmake
+++ b/cmake/toolchain/xcc/common.cmake
@@ -23,6 +23,7 @@ zephyr_get(XTENSA_CORE_${NORMALIZED_BOARD_TARGET})
 if(DEFINED XTENSA_CORE_${NORMALIZED_BOARD_TARGET})
   set(XTENSA_CORE_LOCAL_C_FLAG "--xtensa-core=${XTENSA_CORE_${NORMALIZED_BOARD_TARGET}}")
   list(APPEND TOOLCHAIN_C_FLAGS "--xtensa-core=${XTENSA_CORE_${NORMALIZED_BOARD_TARGET}}")
+  list(APPEND TOOLCHAIN_LD_FLAGS "--xtensa-core=${XTENSA_CORE_${NORMALIZED_BOARD_TARGET}}")
 else()
   # Not having XTENSA_CORE is not necessarily fatal as
   # the toolchain can have a default core configuration to use.


### PR DESCRIPTION
When using one set of environment variables for multiple cores compilation, we also need to supply the core name in linker flags. So add that to TOOLCHAIN_LD_FLAGS.