### PR TITLE
boards: nxp: frdm_mcxn947: enable GPIO in all modes

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024  NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/init.h>
@@ -83,6 +83,19 @@ __ramfunc static void enable_cache64(void)
 	__DSB();
 }
 #endif
+
+static void unsecure_gpio(GPIO_Type * base)
+{
+	/* Enables CPU1 to access GPIO registers
+	 * Pins and interrupts can be configured in non-secure access
+	 */
+	base->PCNS = 0xFFFFFFFFU;
+	base->ICNS = GPIO_ICNS_NSE1_MASK | GPIO_ICNS_NSE0_MASK;
+
+	/* Pins and interrupts can be configured in non-privilege access */
+	base->PCNP = 0xFFFFFFFFU;
+	base->ICNP = GPIO_ICNP_NPE1_MASK | GPIO_ICNP_NPE0_MASK;
+}
 
 void board_early_init_hook(void)
 {
@@ -177,22 +190,27 @@ void board_early_init_hook(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio0))
 	CLOCK_EnableClock(kCLOCK_Gpio0);
+	unsecure_gpio(GPIO0);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio1))
 	CLOCK_EnableClock(kCLOCK_Gpio1);
+	unsecure_gpio(GPIO1);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio2))
 	CLOCK_EnableClock(kCLOCK_Gpio2);
+	unsecure_gpio(GPIO2);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio3))
 	CLOCK_EnableClock(kCLOCK_Gpio3);
+	unsecure_gpio(GPIO3);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio4))
 	CLOCK_EnableClock(kCLOCK_Gpio4);
+	unsecure_gpio(GPIO4);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dac0))


### PR DESCRIPTION
For CPU1 access, enable GPIO access in non-secure and non-privilege modes.

Resolves #88521.

This update enables the blinky sample to run on CPU1 using the following commands:
```
west build -b frdm_mcxn947//cpu1 samples/basic/blinky -d blinky_cpu1 -p -- -DCONFIG_SECOND_CORE_MCUX=y
west flash -d blinky_cpu1
west build -b frdm_mcxn947//cpu0 samples/hello_world/  -d hello_cpu0_loader -p -- -DCONFIG_SECOND_CORE_MCUX=y
west flash -d hello_cpu0_loader
```