### PR TITLE
include: linker: Add missing symbols needed for LLVM's libunwind

### DIFF
--- a/include/zephyr/linker/cplusplus-rom.ld
+++ b/include/zephyr/linker/cplusplus-rom.ld
@@ -13,13 +13,17 @@
 #if defined (CONFIG_CPP_EXCEPTIONS)
 	SECTION_PROLOGUE(.eh_frame_hdr,,)
 	{
+	PROVIDE(__eh_frame_hdr_start = SIZEOF(.eh_frame_hdr) > 0 ? ADDR(.eh_frame_hdr) : 0);
 	*(.eh_frame_hdr)
+	PROVIDE(__eh_frame_hdr_end = SIZEOF(.eh_frame_hdr) > 0 ? . : 0);
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	SECTION_PROLOGUE(.eh_frame,,)
 	{
+        PROVIDE (__eh_frame_start = .);
 	KEEP (*(SORT_NONE(EXCLUDE_FILE (*crtend.o) .eh_frame)))
 	KEEP (*(SORT_NONE(.eh_frame)))
+        PROVIDE (__eh_frame_end = .);
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* CONFIG_CPP_EXCEPTIONS */
 


### PR DESCRIPTION
LLVM's libunwind needs eh_frame_start/eh_frame_end and
eh_frame_hdr_start/eh_frame_hdr_end symbols.

See
https://github.com/llvm/llvm-project/blob/80267f81482486977b3bdecf3855fc6a3096f912/libunwind/src/AddressSpace.hpp#L73-L103