### PR TITLE
Bluetooth: Add missing includes

### DIFF
--- a/include/zephyr/bluetooth/att.h
+++ b/include/zephyr/bluetooth/att.h
@@ -17,8 +17,12 @@
  * @{
  */
 
-#include <zephyr/sys/slist.h>
+#include <stdint.h>
+#include <stddef.h>
+
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,6 +122,8 @@ extern "C" {
 #if defined(CONFIG_BT_ATT_ERR_TO_STR)
 const char *bt_att_err_to_str(uint8_t att_err);
 #else
+#include <zephyr/toolchain.h>
+
 static inline const char *bt_att_err_to_str(uint8_t att_err)
 {
 	ARG_UNUSED(att_err);
@@ -143,7 +149,7 @@ int bt_eatt_reconfigure(struct bt_conn *conn, uint16_t mtu);
  * may be created.
  *
  * @param conn The connection to send the request on
- * @param num_channels The number of Enhanced ATT beares to request.
+ * @param num_channels The number of Enhanced ATT bearers to request.
  * Must be in the range 1 - @kconfig{CONFIG_BT_EATT_MAX}, inclusive.
  *
  * @return 0 in case of success or negative value in case of error.

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -31,12 +31,15 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/sys/util.h>
-#include <zephyr/net_buf.h>
 #include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/crypto.h>
 #include <zephyr/bluetooth/classic/classic.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -241,7 +244,7 @@ struct bt_le_ext_adv_cb {
 	 *
 	 * This callback notifies the application that the RPA validity of the advertising set has
 	 * expired. The user can use this callback to synchronize the advertising payload update
-	 * with the RPA rotation by for example envoking @ref bt_le_ext_adv_set_data upon callback.
+	 * with the RPA rotation by for example invoking @ref bt_le_ext_adv_set_data upon callback.
 	 *
 	 * If RPA sharing is enabled (see @kconfig{CONFIG_BT_RPA_SHARING}) and this RPA expired
 	 * callback of any adv-sets belonging to same adv id returns false, then adv-sets will

--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -18,11 +18,17 @@
  * @{
  */
 
+#include <stddef.h>
 #include <stdint.h>
 
-#include <zephyr/net_buf.h>
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -21,12 +21,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/addr.h>
-#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/direction.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1559,7 +1563,7 @@ enum bt_conn_le_cs_procedure_enable_state {
 	BT_CONN_LE_CS_PROCEDURES_ENABLED = BT_HCI_OP_LE_CS_PROCEDURES_ENABLED,
 };
 
-/** CS Test Tone Antennna Config Selection.
+/** CS Test Tone Antenna Config Selection.
  *
  *  These enum values are indices in the following table, where N_AP is the maximum
  *  number of antenna paths (in the range [1, 4]).

--- a/include/zephyr/bluetooth/crypto.h
+++ b/include/zephyr/bluetooth/crypto.h
@@ -19,6 +19,7 @@
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/cs.h
+++ b/include/zephyr/bluetooth/cs.h
@@ -22,6 +22,8 @@
 
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/direction.h
+++ b/include/zephyr/bluetooth/direction.h
@@ -9,6 +9,9 @@
 
 #include <stdint.h>
 
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/sys/util_macro.h>
+
 /** Constant Tone Extension (CTE) types. */
 enum bt_df_cte_type {
 	/** Convenience value for purposes where non of CTE types is allowed. */

--- a/include/zephyr/bluetooth/ead.h
+++ b/include/zephyr/bluetooth/ead.h
@@ -8,8 +8,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_EAD_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_EAD_H_
 
-#include <zephyr/kernel.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/gap.h
+++ b/include/zephyr/bluetooth/gap.h
@@ -11,8 +11,8 @@
 #ifndef ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_
 #define ZEPHYR_INCLUDE_BLUETOOTH_GAP_H_
 
-#include <zephyr/sys/util_macro.h>
 #include <zephyr/bluetooth/byteorder.h>
+#include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -22,15 +22,21 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
 
 #include <sys/types.h>
 
-#include <zephyr/sys/slist.h>
-#include <zephyr/sys/util.h>
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/att.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -229,7 +235,7 @@ struct bt_gatt_attr {
 	 *  GATT Characteristic Presentation Format descriptor as
 	 *  specified in Core Specification 3.G.3.3.3.5.
 	 *
-	 *  You can define a new Attirubute Type for your application specific
+	 *  You can define a new Attribute Type for your application specific
 	 *  use by generating a new UUID for it.
 	 */
 	const struct bt_uuid *uuid;
@@ -956,7 +962,7 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
 			       const struct bt_gatt_attr *attr, void *buf,
 			       uint16_t len, uint16_t offset);
 
-/** @brief Gatt Characterisitc Initialization Macro.
+/** @brief Gatt Characteristic Initialization Macro.
  *
  *  Helper macro used within the @ref BT_GATT_CHARACTERISTIC macro in the GATT attribute declaration
  *  to set the attribute user data.

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -9,8 +9,10 @@
 #define ZEPHYR_INCLUDE_BLUETOOTH_HCI_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
+#include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/conn.h>
@@ -37,6 +39,8 @@ extern "C" {
 #if defined(CONFIG_BT_HCI_ERR_TO_STR)
 const char *bt_hci_err_to_str(uint8_t hci_err);
 #else
+#include <zephyr/toolchain.h>
+
 static inline const char *bt_hci_err_to_str(uint8_t hci_err)
 {
 	ARG_UNUSED(hci_err);

--- a/include/zephyr/bluetooth/hci_raw.h
+++ b/include/zephyr/bluetooth/hci_raw.h
@@ -18,6 +18,10 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -11,12 +11,12 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
 
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
-#include <zephyr/sys/util.h>
-#include <zephyr/bluetooth/addr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/hci_vs.h
+++ b/include/zephyr/bluetooth/hci_vs.h
@@ -11,7 +11,10 @@
 
 #include <stdint.h>
 
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/net_buf.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -24,6 +24,7 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -18,13 +18,18 @@
  * @{
  */
 
+#include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
 
-#include <zephyr/sys/atomic.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -17,6 +17,7 @@
  * @{
  */
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <zephyr/sys/util.h>

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -20,7 +20,7 @@ config BT_LONG_WQ_STACK_SIZE
 	default 1024
 
 config BT_LONG_WQ_PRIO
-	int "Long workqueue priority. Should be pre-emptible."
+	int "Long workqueue priority. Should be preemptible."
 	default 10
 	range 0 NUM_PREEMPT_PRIORITIES
 
@@ -978,7 +978,7 @@ config BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES
 	bool "Use 16 bits signed integer IQ samples in connectionless IQ reports"
 	depends on BT_DF_CONNECTIONLESS_CTE_RX && BT_HCI_VS
 	help
-	  Direction Finging connectionless IQ reports provide a set of IQ samples collected during
+	  Direction Finding connectionless IQ reports provide a set of IQ samples collected during
 	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
 	  integer, see Vol 4, Part E section 7.7.65.21. This option enables a vendor specific Host
 	  extension to handle connectionless IQ reports with samples that are in 16 bit signed
@@ -988,7 +988,7 @@ config BT_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES
 	bool "Use 16 bits signed integer IQ samples in connection IQ reports"
 	depends on BT_DF_CONNECTION_CTE_RX && BT_HCI_VS
 	help
-	  Direction Finging connection IQ reports provide a set of IQ samples collected during
+	  Direction Finding connection IQ reports provide a set of IQ samples collected during
 	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
 	  integer, see Vol 4, Part E sections 7.7.65.22. This option enables a vendor specific Host
 	  extension to handle connection IQ report with samples that are in 16 bit signed integer

--- a/subsys/bluetooth/host/addr.c
+++ b/subsys/bluetooth/host/addr.c
@@ -5,14 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
 #include <stdbool.h>
 #include <string.h>
-#include <errno.h>
-
-#include <zephyr/sys/util.h>
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/crypto.h>
+#include <zephyr/sys/util.h>
 
 #define ADDR_RESOLVED_BITMASK (0x02)
 

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -4,25 +4,38 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 #include <sys/types.h>
 
-#include <zephyr/sys/byteorder.h>
-
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/hci.h>
-#include <zephyr/bluetooth/buf.h>
-#include <zephyr/sys/check.h>
-
 #include "addr_internal.h"
-#include "hci_core.h"
+#include "common/bt_str.h"
 #include "conn_internal.h"
+#include "hci_core.h"
 #include "id.h"
 #include "scan.h"
 
-#include "common/bt_str.h"
-
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_adv);
 
 enum adv_name_type {

--- a/subsys/bluetooth/host/adv.h
+++ b/subsys/bluetooth/host/adv.h
@@ -5,6 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+
 void bt_le_adv_resume(void);
 
 struct bt_le_ext_adv *bt_le_adv_lookup_legacy(void);

--- a/subsys/bluetooth/host/aes_ccm.c
+++ b/subsys/bluetooth/host/aes_ccm.c
@@ -5,16 +5,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+#include <stdint.h>
 #include <string.h>
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/byteorder.h>
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/crypto.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
 
 #include "common/bt_str.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_aes_ccm);
 
 static inline void xor16(uint8_t *dst, const uint8_t *a, const uint8_t *b)

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -5,34 +5,44 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#include <zephyr/bluetooth/addr.h>
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/kernel.h>
-#include <string.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel/thread.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
+#include <sys/types.h>
 
-#include <zephyr/bluetooth/hci.h>
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/uuid.h>
-#include <zephyr/bluetooth/att.h>
-#include <zephyr/bluetooth/gatt.h>
-
+#include "att_internal.h"
 #include "common/bt_str.h"
-
-#include "hci_core.h"
 #include "conn_internal.h"
+#include "gatt_internal.h"
+#include "hci_core.h"
 #include "l2cap_internal.h"
 #include "smp.h"
-#include "att_internal.h"
-#include "gatt_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_ATT_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_att);
 
 #define ATT_CHAN(_ch) CONTAINER_OF(_ch, struct bt_att_chan, chan.chan)

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -1,6 +1,16 @@
 /* att_internal.h - Attribute protocol handling */
 
+#include <stdint.h>
+#include <stddef.h>
+
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys_clock.h>
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -5,18 +5,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/l2cap.h>
-
-#include "common/hci_common_internal.h"
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
 
 #include "buf_view.h"
-#include "hci_core.h"
+#include "common/hci_common_internal.h"
 #include "conn_internal.h"
+#include "hci_core.h"
 #include "iso_internal.h"
 
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_buf, CONFIG_BT_LOG_LEVEL);
 
 /* Events have a length field of 1 byte. This size fits all events.

--- a/subsys/bluetooth/host/buf_view.h
+++ b/subsys/bluetooth/host/buf_view.h
@@ -11,6 +11,8 @@
 #ifndef ZEPHYR_SUBSYS_BLUETOOTH_HOST_BUF_VIEW_H_
 #define ZEPHYR_SUBSYS_BLUETOOTH_HOST_BUF_VIEW_H_
 
+#include <stddef.h>
+
 #include <zephyr/net_buf.h>
 
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -6,12 +6,29 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#include <zephyr/bluetooth/iso.h>
-#include <zephyr/kernel.h>
-#include <string.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/direction.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/hci_vs.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/irq.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/check.h>
@@ -21,36 +38,29 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
-#include <zephyr/bluetooth/hci.h>
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/direction.h>
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/hci_vs.h>
-#include <zephyr/bluetooth/att.h>
-
+#include "addr_internal.h"
+#include "adv.h"
+#include "att_internal.h"
+#include "buf_view.h"
+#include "classic/conn_br_internal.h"
+#include "classic/sco_internal.h"
+#include "classic/ssp.h"
 #include "common/assert.h"
 #include "common/bt_str.h"
-
-#include "buf_view.h"
-#include "addr_internal.h"
+#include "conn_internal.h"
+#include "direction_internal.h"
 #include "hci_core.h"
 #include "id.h"
-#include "adv.h"
-#include "scan.h"
-#include "conn_internal.h"
-#include "l2cap_internal.h"
-#include "keys.h"
-#include "smp.h"
-#include "classic/ssp.h"
-#include "att_internal.h"
 #include "iso_internal.h"
-#include "direction_internal.h"
-#include "classic/sco_internal.h"
-#include "classic/conn_br_internal.h"
+#include "keys.h"
+#include "l2cap_internal.h"
+#include "scan.h"
+#include "smp.h"
 
 #define LOG_LEVEL CONFIG_BT_CONN_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_conn);
 
 K_FIFO_DEFINE(free_tx);

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -9,7 +9,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 typedef enum __packed {
 	BT_CONN_DISCONNECTED,         /* Disconnected, conn is completely down */

--- a/subsys/bluetooth/host/crypto_psa.c
+++ b/subsys/bluetooth/host/crypto_psa.c
@@ -5,26 +5,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <string.h>
 #include <errno.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
-
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/crypto.h>
-
-#include "psa/crypto.h"
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/check.h>
+#include <psa/crypto.h>
+#include <psa/crypto_struct.h>
+#include <psa/crypto_types.h>
+#include <psa/crypto_values.h>
 
 #include "common/bt_str.h"
-
 #include "hci_core.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_host_crypto);
 
 int bt_crypto_init(void)

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -5,16 +5,28 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <zephyr/sys/byteorder.h>
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/cs.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "conn_internal.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_cs);
 
 #if defined(CONFIG_BT_CHANNEL_SOUNDING)

--- a/subsys/bluetooth/host/data.c
+++ b/subsys/bluetooth/host/data.c
@@ -4,13 +4,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/check.h>
 
-#include <zephyr/bluetooth/bluetooth.h>
-
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_data);
 
 void bt_data_parse(struct net_buf_simple *ad,

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -3,23 +3,29 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <errno.h>
+#include <stdbool.h>
 #include <stdint.h>
-#include <assert.h>
-#include <zephyr/sys/check.h>
-#include <zephyr/sys/byteorder.h>
+#include <string.h>
 
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/l2cap.h>
-#include <zephyr/bluetooth/hci.h>
-#include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/bluetooth/direction.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/hci_vs.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/check.h>
 
 #include "hci_core.h"
 #include "conn_internal.h"
 #include "direction_internal.h"
-
-#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(bt_df, CONFIG_BT_DF_LOG_LEVEL);
 
@@ -181,9 +187,9 @@ static int hci_df_read_ant_info(uint8_t *switch_sample_rates,
 
 	rp = (void *)rsp->data;
 
-	LOG_DBG("DF: sw. sampl rates: %x ant num: %u , max sw. pattern len: %u,"
-	       "max CTE len %d", rp->switch_sample_rates, rp->num_ant,
-	       rp->max_switch_pattern_len, rp->max_cte_len);
+	LOG_DBG("DF: sw. sample rates: %x ant num: %u , max sw. pattern len: %u,"
+		"max CTE len %d",
+		rp->switch_sample_rates, rp->num_ant, rp->max_switch_pattern_len, rp->max_cte_len);
 
 	*switch_sample_rates = rp->switch_sample_rates;
 	*num_ant = rp->num_ant;

--- a/subsys/bluetooth/host/direction_internal.h
+++ b/subsys/bluetooth/host/direction_internal.h
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/direction.h>
+#include <zephyr/net_buf.h>
+
 /* Performs initialization of Direction Finding in Host */
 int le_df_init(void);
 

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -5,20 +5,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/bluetooth/hci.h>
-
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util_macro.h>
 #include <psa/crypto.h>
+#include <psa/crypto_struct.h>
+#include <psa/crypto_types.h>
+#include <psa/crypto_values.h>
 
 #include "long_wq.h"
 #include "ecc.h"
 #include "hci_core.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_ecc);
 
 static uint8_t pub_key[BT_PUB_KEY_LEN];

--- a/subsys/bluetooth/host/ecc.h
+++ b/subsys/bluetooth/host/ecc.h
@@ -6,6 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/sys/slist.h>
+
 /** Key size used in Bluetooth's ECC domain. */
 #define BT_ECC_KEY_SIZE            32
 /** Length of a Bluetooth ECC public key coordinate. */
@@ -46,7 +51,7 @@ bool bt_pub_key_is_debug(uint8_t *cmp_pub_key);
 
 /*  @brief Check if public key is valid.
  *
- *  Verify that the public key is valid, e.g. that its coordinates lie on the eliptic curve.
+ *  Verify that the public key is valid, e.g. that its coordinates lie on the elliptic curve.
  *
  *  @param key The public key to validate.
  *

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -7,46 +7,57 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdint.h>
-
-#include <zephyr/bluetooth/att.h>
-#include <zephyr/kernel.h>
-#include <string.h>
+#include "sys/types.h"
 #include <errno.h>
+#include <inttypes.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
-#include <zephyr/sys/atomic.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/iterable_sections.h>
-#include <zephyr/sys/util.h>
-#include <zephyr/sys/check.h>
+#include <string.h>
 
-#include <zephyr/settings/settings.h>
-
-#if defined(CONFIG_BT_GATT_CACHING)
-#include "psa/crypto.h"
-#endif /* CONFIG_BT_GATT_CACHING */
-
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
-#include "common/bt_str.h"
+#if defined(CONFIG_BT_GATT_CACHING)
+#include <psa/crypto.h>
+#include <psa/crypto_struct.h>
+#include <psa/crypto_types.h>
+#include <psa/crypto_values.h>
+#endif /* CONFIG_BT_GATT_CACHING */
 
-#include "hci_core.h"
-#include "conn_internal.h"
-#include "keys.h"
-#include "l2cap_internal.h"
 #include "att_internal.h"
-#include "smp.h"
-#include "settings.h"
+#include "conn_internal.h"
+#include "common/bt_str.h"
 #include "gatt_internal.h"
+#include "hci_core.h"
+#include "keys.h"
 #include "long_wq.h"
+#include "l2cap_internal.h"
+#include "settings.h"
+#include "smp.h"
 
 #define LOG_LEVEL CONFIG_BT_GATT_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_gatt);
 
 #define SC_TIMEOUT	K_MSEC(10)
@@ -3471,7 +3482,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 			LOG_ERR("Read method not set");
 			return false;
 		}
-		/* The charactestic properties is the first byte of the attribute value */
+		/* The characterstic properties is the first byte of the attribute value */
 		len = attr->read(NULL, attr, &properties, sizeof(properties), 0);
 		if (len < 0) {
 			LOG_ERR("Failed to read attribute %p (err %zd)", attr, len);

--- a/subsys/bluetooth/host/gatt_internal.h
+++ b/subsys/bluetooth/host/gatt_internal.h
@@ -8,6 +8,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/conn.h>
+
 #define BT_GATT_CENTRAL_ADDR_RES_NOT_SUPP	0
 #define BT_GATT_CENTRAL_ADDR_RES_SUPP		1
 

--- a/subsys/bluetooth/host/hci_common.c
+++ b/subsys/bluetooth/host/hci_common.c
@@ -4,9 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
 #include <stdint.h>
-#include <zephyr/sys/byteorder.h>
+
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/drivers/bluetooth.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+
 #include "common/assert.h"
 
 struct net_buf *bt_hci_evt_create(uint8_t evt, uint8_t len)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -6,10 +6,20 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdbool.h>
 #include <stdint.h>
 
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util_macro.h>
 
 /* LL connection parameters */
 #define LE_CONN_LATENCY		0x0000

--- a/subsys/bluetooth/host/hci_raw.c
+++ b/subsys/bluetooth/host/hci_raw.c
@@ -7,25 +7,33 @@
  */
 
 #include <errno.h>
-#include <zephyr/sys/atomic.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/devicetree.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
-#include <zephyr/drivers/bluetooth.h>
 #include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/iso.h>
-
-#include <zephyr/bluetooth/hci.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/bluetooth.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "common/hci_common_internal.h"
-
-#include "monitor.h"
 #include "hci_raw_internal.h"
+#include "monitor.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_hci_raw);
 
 static struct k_fifo *raw_rx;

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -7,36 +7,41 @@
 
 #include <errno.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/hci_types.h>
-#include <zephyr/settings/settings.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
-
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/hci_vs.h>
 #include <zephyr/bluetooth/buf.h>
-#include <zephyr/sys/__assert.h>
-
-#include "hci_core.h"
-#include "id.h"
-#include "scan.h"
-#include "adv.h"
-#include "smp.h"
-#include "conn_internal.h"
-#include "keys.h"
-#include "common/rpa.h"
-
-#include "settings.h"
-
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/crypto.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/hci_vs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/toolchain.h>
 
+#include "adv.h"
 #include "common/bt_str.h"
+#include "common/rpa.h"
+#include "conn_internal.h"
+#include "hci_core.h"
+#include "id.h"
+#include "keys.h"
+#include "scan.h"
+#include "settings.h"
+#include "smp.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/host/id.h
+++ b/subsys/bluetooth/host/id.h
@@ -4,6 +4,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys_clock.h>
 
 #include "keys.h"
 
@@ -12,6 +20,9 @@
 static inline bool bt_id_rpa_is_new(void)
 {
 #if defined(CONFIG_BT_PRIVACY)
+	/* TODO: To get bt_dev we should include "hci_core.h" but that gives redefinitions
+	 * Should we have an API to get the rpa_update value?
+	 */
 	uint32_t remaining_ms = k_ticks_to_ms_floor32(
 		k_work_delayable_remaining_get(&bt_dev.rpa_update));
 	/* RPA is considered new if there is less than half a second since the

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -5,34 +5,38 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#include <zephyr/kernel.h>
-#include <string.h>
+#include <errno.h>
+#include <stdbool.h>
 #include <stdlib.h>
-#include <zephyr/sys/atomic.h>
-#include <zephyr/sys/util.h>
-#include <zephyr/sys/byteorder.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <zephyr/settings/settings.h>
-
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "common/bt_str.h"
-
 #include "common/rpa.h"
 #include "conn_internal.h"
 #include "gatt_internal.h"
 #include "hci_core.h"
-#include "smp.h"
-#include "settings.h"
 #include "id.h"
 #include "keys.h"
+#include "settings.h"
+#include "smp.h"
+#include "sys/types.h"
 
 #define LOG_LEVEL CONFIG_BT_KEYS_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_keys);
 
 static struct bt_keys key_pool[CONFIG_BT_MAX_PAIRED];

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -9,48 +9,54 @@
 #ifndef ZEPHYR_SUBSYS_BLUETOOTH_HOST_KEYS_H_
 #define ZEPHYR_SUBSYS_BLUETOOTH_HOST_KEYS_H_
 
-#include <zephyr/sys/util.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 /** @cond INTERNAL_HIDDEN */
 
 enum bt_keys_type {
-	BT_KEYS_PERIPH_LTK     = BIT(0),
-	BT_KEYS_IRK            = BIT(1),
-	BT_KEYS_LTK            = BIT(2),
-	BT_KEYS_LOCAL_CSRK     = BIT(3),
-	BT_KEYS_REMOTE_CSRK    = BIT(4),
-	BT_KEYS_LTK_P256       = BIT(5),
+	BT_KEYS_PERIPH_LTK = BIT(0),
+	BT_KEYS_IRK = BIT(1),
+	BT_KEYS_LTK = BIT(2),
+	BT_KEYS_LOCAL_CSRK = BIT(3),
+	BT_KEYS_REMOTE_CSRK = BIT(4),
+	BT_KEYS_LTK_P256 = BIT(5),
 
-	BT_KEYS_ALL            = (BT_KEYS_PERIPH_LTK | BT_KEYS_IRK |
-				  BT_KEYS_LTK | BT_KEYS_LOCAL_CSRK |
-				  BT_KEYS_REMOTE_CSRK | BT_KEYS_LTK_P256),
+	BT_KEYS_ALL = (BT_KEYS_PERIPH_LTK | BT_KEYS_IRK | BT_KEYS_LTK | BT_KEYS_LOCAL_CSRK |
+		       BT_KEYS_REMOTE_CSRK | BT_KEYS_LTK_P256),
 };
 
 enum {
-	BT_KEYS_ID_PENDING_ADD  = BIT(0),
-	BT_KEYS_ID_PENDING_DEL  = BIT(1),
-	BT_KEYS_ID_ADDED        = BIT(2),
+	BT_KEYS_ID_PENDING_ADD = BIT(0),
+	BT_KEYS_ID_PENDING_DEL = BIT(1),
+	BT_KEYS_ID_ADDED = BIT(2),
 };
 
 enum {
-	BT_KEYS_AUTHENTICATED   = BIT(0),
-	BT_KEYS_DEBUG           = BIT(1),
+	BT_KEYS_AUTHENTICATED = BIT(0),
+	BT_KEYS_DEBUG = BIT(1),
 	/* Bit 2 and 3 might accidentally exist in old stored keys */
-	BT_KEYS_SC              = BIT(4),
-	BT_KEYS_OOB             = BIT(5),
+	BT_KEYS_SC = BIT(4),
+	BT_KEYS_OOB = BIT(5),
 };
 
 struct bt_ltk {
-	uint8_t                    rand[8];
-	uint8_t                    ediv[2];
-	uint8_t                    val[16];
+	uint8_t rand[8];
+	uint8_t ediv[2];
+	uint8_t val[16];
 };
 
 struct bt_irk {
-	uint8_t                    val[16];
+	uint8_t val[16];
 	/* Cache for `bt_keys_find_irk`. Not reliable as "current RPA"! */
-	bt_addr_t               rpa;
+	bt_addr_t rpa;
 };
 
 static inline bool bt_irk_eq(struct bt_irk const *a, struct bt_irk const *b)
@@ -59,34 +65,33 @@ static inline bool bt_irk_eq(struct bt_irk const *a, struct bt_irk const *b)
 }
 
 struct bt_csrk {
-	uint8_t                    val[16];
-	uint32_t                   cnt;
+	uint8_t val[16];
+	uint32_t cnt;
 };
 
 struct bt_keys {
-	uint8_t                    id;
-	bt_addr_le_t            addr;
-	uint8_t                    state;
-	uint8_t                    storage_start[0] __aligned(sizeof(void *));
-	uint8_t                    enc_size;
-	uint8_t                    flags;
-	uint16_t                   keys;
-	struct bt_ltk           ltk;
-	struct bt_irk           irk;
+	uint8_t id;
+	bt_addr_le_t addr;
+	uint8_t state;
+	uint8_t storage_start[0] __aligned(sizeof(void *));
+	uint8_t enc_size;
+	uint8_t flags;
+	uint16_t keys;
+	struct bt_ltk ltk;
+	struct bt_irk irk;
 #if defined(CONFIG_BT_SIGNING)
-	struct bt_csrk          local_csrk;
-	struct bt_csrk          remote_csrk;
+	struct bt_csrk local_csrk;
+	struct bt_csrk remote_csrk;
 #endif /* BT_SIGNING */
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
-	struct bt_ltk           periph_ltk;
+	struct bt_ltk periph_ltk;
 #endif /* CONFIG_BT_SMP_SC_PAIR_ONLY */
 #if (defined(CONFIG_BT_KEYS_OVERWRITE_OLDEST))
-	uint32_t                   aging_counter;
+	uint32_t aging_counter;
 #endif /* CONFIG_BT_KEYS_OVERWRITE_OLDEST */
 };
 
-#define BT_KEYS_STORAGE_LEN     (sizeof(struct bt_keys) - \
-				 offsetof(struct bt_keys, storage_start))
+#define BT_KEYS_STORAGE_LEN (sizeof(struct bt_keys) - offsetof(struct bt_keys, storage_start))
 
 /** Clears all keys.
  *
@@ -205,22 +210,22 @@ static inline int bt_keys_store(struct bt_keys *keys)
 #endif
 
 enum {
-	BT_LINK_KEY_AUTHENTICATED  = BIT(0),
-	BT_LINK_KEY_DEBUG          = BIT(1),
-	BT_LINK_KEY_SC             = BIT(2),
+	BT_LINK_KEY_AUTHENTICATED = BIT(0),
+	BT_LINK_KEY_DEBUG = BIT(1),
+	BT_LINK_KEY_SC = BIT(2),
 };
 
 struct bt_keys_link_key {
-	bt_addr_t               addr;
-	uint8_t                 storage_start[0]  __aligned(sizeof(void *));
-	uint8_t                 flags;
-	uint8_t                 val[16];
+	bt_addr_t addr;
+	uint8_t storage_start[0] __aligned(sizeof(void *));
+	uint8_t flags;
+	uint8_t val[16];
 #if (defined(CONFIG_BT_KEYS_OVERWRITE_OLDEST))
-	uint32_t                aging_counter;
+	uint32_t aging_counter;
 #endif /* CONFIG_BT_KEYS_OVERWRITE_OLDEST */
 };
-#define BT_KEYS_LINK_KEY_STORAGE_LEN     (sizeof(struct bt_keys_link_key) - \
-	offsetof(struct bt_keys_link_key, storage_start))
+#define BT_KEYS_LINK_KEY_STORAGE_LEN                                                               \
+	(sizeof(struct bt_keys_link_key) - offsetof(struct bt_keys_link_key, storage_start))
 
 struct bt_keys_link_key *bt_keys_get_link_key(const bt_addr_t *addr);
 struct bt_keys_link_key *bt_keys_find_link_key(const bt_addr_t *addr);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -6,33 +6,39 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#include <zephyr/kernel.h>
-#include <string.h>
 #include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/check.h>
 #include <zephyr/sys/iterable_sections.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/net_buf.h>
-
-#include <zephyr/bluetooth/hci.h>
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/l2cap.h>
-
-#define LOG_DBG_ENABLED IS_ENABLED(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
 #include "buf_view.h"
 #include "hci_core.h"
 #include "conn_internal.h"
 #include "l2cap_internal.h"
-#include "keys.h"
 
-#include <zephyr/logging/log.h>
+#define LOG_DBG_ENABLED IS_ENABLED(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
 LOG_MODULE_REGISTER(bt_l2cap, CONFIG_BT_L2CAP_LOG_LEVEL);
 
 #define LE_CHAN_RTX(_w) CONTAINER_OF(k_work_delayable_from_work(_w), \

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -7,10 +7,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
 #include <zephyr/sys/iterable_sections.h>
+#include <zephyr/sys_clock.h>
+
 #include "host/classic/l2cap_br_interface.h"
+/* TODO: we should include conn_internal.h for bt_conn_tx_cb_t but that causes redefinitions */
 
 enum l2cap_conn_list_action {
 	BT_L2CAP_CHAN_LOOKUP,

--- a/subsys/bluetooth/host/long_wq.c
+++ b/subsys/bluetooth/host/long_wq.c
@@ -5,8 +5,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <zephyr/autoconf.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
+#include <zephyr/kernel/thread_stack.h>
+#include <zephyr/sys_clock.h>
 
 K_THREAD_STACK_DEFINE(bt_lw_stack_area, CONFIG_BT_LONG_WQ_STACK_SIZE);
 static struct k_work_q bt_long_wq;

--- a/subsys/bluetooth/host/long_wq.h
+++ b/subsys/bluetooth/host/long_wq.h
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+
 int bt_long_wq_schedule(struct k_work_delayable *dwork, k_timeout_t timeout);
 int bt_long_wq_reschedule(struct k_work_delayable *dwork, k_timeout_t timeout);
 int bt_long_wq_submit(struct k_work *dwork);

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -8,24 +8,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <zephyr/kernel.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/buf.h>
 #include <zephyr/device.h>
-#include <zephyr/init.h>
 #include <zephyr/drivers/uart_pipe.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log_msg.h>
+#include <zephyr/logging/log_output.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk-hooks.h>
 #include <zephyr/sys/libc-hooks.h>
 #include <zephyr/drivers/uart.h>
-
-#include <zephyr/logging/log_backend.h>
-#include <zephyr/logging/log_output.h>
-#include <zephyr/logging/log_ctrl.h>
-#include <zephyr/logging/log.h>
-
-#include <zephyr/bluetooth/buf.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "monitor.h"
 

--- a/subsys/bluetooth/host/monitor.h
+++ b/subsys/bluetooth/host/monitor.h
@@ -7,8 +7,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdint.h>
 
-#if defined(CONFIG_BT_MONITOR)
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/net_buf.h>
 
 #define BT_MONITOR_NEW_INDEX    0
 #define BT_MONITOR_DEL_INDEX    1
@@ -95,6 +97,8 @@ static inline uint8_t bt_monitor_opcode(struct net_buf *buf)
 	}
 }
 
+/* TODO: Remove guard and replace with IS_ENABLED(CONFIG_BT_MONITOR) */
+#if defined(CONFIG_BT_MONITOR)
 void bt_monitor_send(uint16_t opcode, const void *data, size_t len);
 
 void bt_monitor_new_index(uint8_t type, uint8_t bus, const bt_addr_t *addr,

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -4,31 +4,42 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/types.h>
+#include <errno.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
-#include <zephyr/sys/atomic.h>
-#include <zephyr/kernel.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/check.h>
-
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/direction.h>
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
+
+#include <sys/types.h>
 
 #include "addr_internal.h"
-#include "hci_core.h"
+#include "common/bt_str.h"
 #include "conn_internal.h"
 #include "direction_internal.h"
+#include "hci_core.h"
 #include "id.h"
-
-#include "common/bt_str.h"
 #include "scan.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
@@ -908,7 +919,7 @@ void bt_hci_le_adv_ext_report(struct net_buf *buf)
 		}
 
 		if (evt->length + ext_scan_buf.len > ext_scan_buf.size) {
-			/* The report does not fit in the reassemby buffer
+			/* The report does not fit in the reassembly buffer
 			 * Discard this and future reports from the advertiser.
 			 */
 			reassembling_advertiser.state = FRAG_ADV_DISCARDING;
@@ -1419,7 +1430,7 @@ void bt_hci_le_per_adv_sync_lost(struct net_buf *buf)
 	per_adv_sync = bt_hci_per_adv_sync_lookup_handle(sys_le16_to_cpu(evt->handle));
 
 	if (!per_adv_sync) {
-		LOG_ERR("Unknown handle 0x%04Xfor periodic adv sync lost",
+		LOG_ERR("Unknown handle 0x%04X for periodic adv sync lost",
 			sys_le16_to_cpu(evt->handle));
 		return;
 	}

--- a/subsys/bluetooth/host/scan.h
+++ b/subsys/bluetooth/host/scan.h
@@ -8,10 +8,12 @@
 #ifndef SUBSYS_BLUETOOTH_HOST_SCAN_H_
 #define SUBSYS_BLUETOOTH_HOST_SCAN_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
-#include <zephyr/sys/atomic.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/sys/atomic.h>
 
 /**
  * Reasons why a scanner can be running.

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -5,19 +5,28 @@
  */
 
 #include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <zephyr/kernel.h>
-#include <zephyr/settings/settings.h>
-#include <common/bt_settings_commit.h>
-
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
+#include "common/bt_settings_commit.h"
 #include "common/bt_str.h"
-
 #include "hci_core.h"
 #include "settings.h"
+#include "sys/types.h"
 
 #define LOG_LEVEL CONFIG_BT_SETTINGS_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/subsys/bluetooth/host/settings.h
+++ b/subsys/bluetooth/host/settings.h
@@ -8,9 +8,8 @@
 #include <stdint.h>
 
 #include <zephyr/bluetooth/addr.h>
-
 #include <zephyr/settings/settings.h>
-#include <common/bt_settings_commit.h>
+#include "common/bt_settings_commit.h"
 
 /* Max settings key length (with all components) */
 #define BT_SETTINGS_KEY_MAX 36

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -12,36 +12,46 @@
  */
 
 #include <errno.h>
-#include <zephyr/autoconf.h>
-#include <zephyr/bluetooth/audio/bap.h>
-#include <zephyr/bluetooth/gap.h>
-#include <zephyr/types.h>
-#include <ctype.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <sys/types.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/audio/bap.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/classic/rfcomm.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/ead.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/shell/shell_types.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
-#include <zephyr/kernel.h>
-
-#include <zephyr/settings/settings.h>
-
-#include <zephyr/bluetooth/hci.h>
-#include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/classic/rfcomm.h>
-#include <zephyr/bluetooth/classic/sdp.h>
-#include <zephyr/bluetooth/iso.h>
-#include <zephyr/bluetooth/ead.h>
-
-#include <zephyr/shell/shell.h>
-#include "common/bt_shell_private.h"
+#include <zephyr/toolchain.h>
+#include <zephyr/types.h>
 
 #include "audio/shell/audio.h"
+#include "common/bt_shell_private.h"
+#if defined(CONFIG_BT_LL_SW_SPLIT)
 #include "controller/ll_sw/shell/ll.h"
+#endif /* CONFIG_BT_LL_SW_SPLIT */
 #include "host/shell/bt.h"
 #include "mesh/shell/hci.h"
 

--- a/subsys/bluetooth/host/shell/bt.h
+++ b/subsys/bluetooth/host/shell/bt.h
@@ -12,8 +12,12 @@
 
 #ifndef __BT_H
 #define __BT_H
+#include <stddef.h>
+#include <stdint.h>
 
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/net_buf.h>
 #include <sys/types.h>
 
 extern struct bt_conn *default_conn;

--- a/subsys/bluetooth/host/shell/cs.c
+++ b/subsys/bluetooth/host/shell/cs.c
@@ -9,23 +9,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <zephyr/kernel.h>
-#include <zephyr/shell/shell.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/util.h>
+#include <string.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
 #include <zephyr/bluetooth/cs.h>
-#include <errno.h>
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
-#include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
+#include "host/shell/bt.h"
 
 static int check_cs_sync_antenna_selection_input(uint16_t input)
 {

--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -10,24 +10,28 @@
  */
 
 #include <errno.h>
-#include <zephyr/types.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr/shell/shell_string_conv.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/util.h>
-#include <zephyr/kernel.h>
 
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
-
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
+#include <sys/types.h>
 
-#include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
+#include "host/shell/bt.h"
 
 #if defined(CONFIG_BT_GATT_CLIENT) || defined(CONFIG_BT_GATT_DYNAMIC_DB)
 extern uint8_t selected_id;
@@ -1013,7 +1017,7 @@ static void notify_cb(struct bt_conn *conn, void *user_data)
 {
 	const struct shell *sh = user_data;
 
-	shell_print(sh, "Nofication sent to conn %p", conn);
+	shell_print(sh, "Notification sent to conn %p", conn);
 }
 static int cmd_notify_mult(const struct shell *sh, size_t argc, char *argv[])
 {

--- a/subsys/bluetooth/host/shell/iso.c
+++ b/subsys/bluetooth/host/shell/iso.c
@@ -9,20 +9,26 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
+#include <errno.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
-#include <ctype.h>
-#include <zephyr/bluetooth/hci_types.h>
-#include <zephyr/kernel.h>
-#include <zephyr/shell/shell.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/util.h>
+#include <string.h>
 
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/iso.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "host/shell/bt.h"
 #include "common/bt_shell_private.h"

--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -11,26 +11,30 @@
  */
 
 #include <errno.h>
-#include <zephyr/types.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/kernel.h>
-
-#include <zephyr/settings/settings.h>
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/classic/rfcomm.h>
 #include <zephyr/bluetooth/classic/sdp.h>
-
+#include <zephyr/net_buf.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_string_conv.h>
+#include <zephyr/sys/atomic_types.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
 
-#include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
+#include "host/shell/bt.h"
 
 #define CREDITS			10
 #define DATA_MTU		(23 * CREDITS)

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -11,13 +11,19 @@
  */
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/crypto.h>
 #include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
@@ -25,17 +31,18 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/check.h>
+#include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/toolchain.h>
 
-
-#include "common/bt_str.h"
-
-#include "crypto/bt_crypto.h"
-
-#include "hci_core.h"
-#include "ecc.h"
-#include "keys.h"
 #include "conn_internal.h"
+#include "common/bt_str.h"
+#include "crypto/bt_crypto.h"
+#include "ecc.h"
+#include "hci_core.h"
+#include "keys.h"
 #include "l2cap_internal.h"
 #include "smp.h"
 
@@ -4390,7 +4397,7 @@ static uint8_t smp_public_key_periph(struct bt_smp *smp)
 
 	if (!atomic_test_bit(smp->flags, SMP_FLAG_SC_DEBUG_KEY) &&
 	    memcmp(smp->pkey, sc_public_key, BT_PUB_KEY_COORD_LEN) == 0) {
-		/* Deny public key with identitcal X coordinate unless it is the
+		/* Deny public key with identical X coordinate unless it is the
 		 * debug public key.
 		 */
 		LOG_WRN("Remote public key rejected");
@@ -4476,7 +4483,7 @@ static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 	    smp->chan.chan.conn->role == BT_HCI_ROLE_CENTRAL) {
 		if (!atomic_test_bit(smp->flags, SMP_FLAG_SC_DEBUG_KEY) &&
 		    memcmp(smp->pkey, sc_public_key, BT_PUB_KEY_COORD_LEN) == 0) {
-			/* Deny public key with identitcal X coordinate unless
+			/* Deny public key with identical X coordinate unless
 			 * it is the debug public key.
 			 */
 			LOG_WRN("Remote public key rejected");

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -9,6 +9,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/toolchain.h>
+
 struct bt_smp_hdr {
 	uint8_t  code;
 } __packed;

--- a/subsys/bluetooth/host/smp_null.c
+++ b/subsys/bluetooth/host/smp_null.c
@@ -9,22 +9,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
 #include <errno.h>
-#include <zephyr/sys/atomic.h>
-#include <zephyr/sys/util.h>
+#include <stddef.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
-#include "hci_core.h"
 #include "conn_internal.h"
+#include "hci_core.h"
 #include "l2cap_internal.h"
 #include "smp.h"
 
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_smp);
 
 static struct bt_l2cap_le_chan bt_smp_pool[CONFIG_BT_MAX_CONN];

--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -6,12 +6,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <string.h>
 #include <errno.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/sys/printk.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
 
 #include <zephyr/bluetooth/uuid.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
 
 #define UUID_16_BASE_OFFSET 12
 


### PR DESCRIPTION
This PR adds missing includes in all Bluetooth host files, as well as fixing some typos found during the same lookthrough. 

The purpose of this is to help enforce IWYU (include what you use) and avoid any possible compilation issues if you include things in a way that hasn't been otherwise tested. 

There were 2 circular dependencies found that should get fixed in a followed (see TODOs in the commits). 