### PR TITLE
soc: andestech: linker.ld: Handle symtab/strtab/shstrtab to fix warnings

### DIFF
--- a/soc/andestech/ae350/linker.ld
+++ b/soc/andestech/ae350/linker.ld
@@ -405,6 +405,15 @@ GROUP_END(DTCM)
 	KEEP(*(.gnu.attributes))
 	}
 
+/* Output section descriptions are needed for these sections to suppress
+ * warnings when "--orphan-handling=warn" is set for lld.
+ */
+#if defined(CONFIG_LLVM_USE_LLD)
+    SECTION_PROLOGUE(.symtab, 0,) { *(.symtab) }
+    SECTION_PROLOGUE(.strtab, 0,) { *(.strtab) }
+    SECTION_PROLOGUE(.shstrtab, 0,) { *(.shstrtab) }
+#endif
+
     /* Sections generated from 'zephyr,memory-region' nodes */
     LINKER_DT_SECTIONS()
 


### PR DESCRIPTION
lld will produce warnings for the symtab, strtab, and shstrtab sections
if --orphan-handling=warn is specified and there are no matching rules
in the linker script for these sections. Handle these sections when
building with lld to prevent the warnings.

This is exactly the same as commit
c420733c335a10f71cef888dfc80640349c611dd, but for the AE350 linker
script.