### PR TITLE
zbus: add zbus_chan_publisher for scheduling messages

### DIFF
--- a/include/zephyr/zbus/zbus_publisher.h
+++ b/include/zephyr/zbus/zbus_publisher.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 EXACT Technology
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ZBUS_PUBLISHER_H_
+#define ZEPHYR_INCLUDE_ZBUS_PUBLISHER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+
+void zbus_publisher_work_handler(struct k_work *work);
+extern struct k_work_q *const zbus_workq;
+
+/** @endcond */
+
+struct zbus_publisher {
+	struct k_work_delayable work;
+	volatile k_timeout_t period;
+	void *data;
+	struct zbus_channel *chan;
+};
+
+/**
+ * @brief Zbus publisher definition.
+ *
+ * @param      _name    The publisher's name.
+ * @param      _p_chan  The channel the publisher publishes to.
+ * @param      _p_msg   A pointer to the publisher's message.
+ */
+#define ZBUS_CHANNEL_PUBLISHER_DEFINE(_name, _p_chan, _p_msg)                                      \
+	static struct zbus_publisher _name = {                                                     \
+		.work = Z_WORK_DELAYABLE_INITIALIZER(zbus_publisher_work_handler),                 \
+		.data = (void *)_p_msg,                                                            \
+		.chan = (struct zbus_channel *)_p_chan,                                            \
+		.period = K_NO_WAIT,                                                               \
+	}
+
+/**
+ * @brief      Schedule a publisher to publish its message after a delay.
+ *
+ * @param      publisher  The publisher
+ * @param[in]  delay      The delay
+ *
+ * @warning Care should be taken when using publisher's on channels with subscribers. If multiple
+ * messages are delivered on the same tick one will be missed unless the subscriber thread has a
+ * higher priority.
+ *
+ * @return as with k_work_schedule_for_queue().
+ */
+static inline int zbus_chan_publisher_schedule(struct zbus_publisher *publisher, k_timeout_t delay)
+{
+	return k_work_schedule_for_queue(zbus_workq, &publisher->work, delay);
+}
+
+/**
+ * @brief      Reschedule a publisher to publish its message after a delay.
+ *
+ * @param      publisher  The publisher
+ * @param[in]  delay      The delay
+ *
+ * @warning Care should be taken when using publisher's on channels with subscribers. If multiple
+ * messages are delivered on the same tick one will be missed unless the subscriber thread has a
+ * higher priority.
+ *
+ * @return as with k_work_schedule_for_queue().
+ */
+static inline int zbus_chan_publisher_reschedule(struct zbus_publisher *publisher,
+						 k_timeout_t delay)
+{
+	return k_work_reschedule_for_queue(zbus_workq, &publisher->work, delay);
+}
+
+/**
+ * @brief      Cancel a publisher's queued message.
+ *
+ * @param      publisher  The publisher
+ *
+ * @return as with k_work_cancel_delayable().
+ */
+static inline int zbus_chan_publisher_cancel(struct zbus_publisher *publisher)
+{
+	return k_work_cancel_delayable(&publisher->work);
+}
+
+/**
+ * @brief      Synchronously cancel a publisher's queued message.
+ *
+ * @param      publisher  The publisher
+ *
+ * @return as with k_work_cancel_delayable_sync().
+ */
+static inline int zbus_chan_publisher_cancel_sync(struct zbus_publisher *publisher)
+{
+	_ZBUS_ASSERT(!k_is_in_isr(), "cannot cancel work synchronously from ISR");
+	_ZBUS_ASSERT(k_current_get() != k_work_queue_thread_get(zbus_workq),
+		     "cannot cancel publisher synchronously from work queue running the publisher");
+
+	struct k_work_sync sync;
+
+	return k_work_cancel_delayable_sync(&publisher->work, &sync);
+}
+
+/**
+ * @brief      Reschedules a publisher and configures it to reschedule itself at the provided period
+ * provided.
+ *
+ * @param      publisher  The publisher
+ * @param[in]  delay      The delay
+ * @param[in]  period     The period
+ *
+ * @return as with k_work_reschedule_for_queue().
+ */
+static inline int zbus_chan_publisher_start(struct zbus_publisher *publisher, k_timeout_t delay,
+					    k_timeout_t period)
+{
+	publisher->period = period;
+	return zbus_chan_publisher_reschedule(publisher, delay);
+}
+
+/**
+ * @brief      Cancel a publisher's queued message and disables it from rescheduling itself.
+ *
+ * @param      publisher  The publisher
+ *
+ * @return as with k_work_cancel_delayable().
+ */
+static inline int zbus_chan_publisher_stop(struct zbus_publisher *publisher)
+{
+	publisher->period = K_NO_WAIT;
+	return zbus_chan_publisher_cancel(publisher);
+}
+
+/**
+ * @brief      Synchronously cancel a publisher's queued message and disables it from rescheduling
+ * itself.
+ *
+ * @param      publisher  The publisher
+ *
+ * @return as with k_work_cancel_delayable_sync().
+ */
+static inline int zbus_chan_publisher_stop_sync(struct zbus_publisher *publisher)
+{
+	publisher->period = K_NO_WAIT;
+	return zbus_chan_publisher_cancel_sync(publisher);
+}
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_ZBUS_PUBLISHER_H_ */

--- a/subsys/zbus/Kconfig
+++ b/subsys/zbus/Kconfig
@@ -114,6 +114,31 @@ config HEAP_MEM_POOL_ADD_SIZE_ZBUS
 	default 1024 if !ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC && ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_DYNAMIC
 	default 3072 if ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC && ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_DYNAMIC
 
+config ZBUS_PUBLISHER_MAX_WAIT_MS
+	int "Max delay a publisher will wait on a channel in milliseconds"
+	default -1
+	help
+	  Defaults to -1 (K_FOREVER)
+
+config ZBUS_WQ_ENABLE
+	bool "Use to enable zbus to use its own workqueue instead of the system work queue"
+
+if ZBUS_WQ_ENABLE
+
+config ZBUS_WQ_STACK_SIZE
+	int "Size of zbus work queue stack"
+	default 1024
+	help
+	  Size of stack used for the zbus work queue thread.
+
+config ZBUS_WQ_PRIORITY
+	int "Priority of RX work queue thread"
+	default 5
+	range -256 15
+	help
+	  Priority of the zbus work queue thread.
+
+endif # ZBUS_WQ_ENABLE
 
 module = ZBUS
 module-str = zbus


### PR DESCRIPTION
this PR introduces the concept of zbus publishers, a async method of calling zbus_chan_pub() from a work queue at a scheduled time. under the hood, it is very simple and leverages the k_work api. an example of how it could be used:
```
int event1 = SAMPLE_SENSOR_A;
int event2 = SAMPLE_SENSOR_B;
int event3 = SAMPLE_SENSOR_c;

ZBUS_CHANNEL_PUBLISHER_DEFINE(pub1, &simple_chan, &event1);
ZBUS_CHANNEL_PUBLISHER_DEFINE(pub2, &simple_chan, &event2);
ZBUS_CHANNEL_PUBLISHER_DEFINE(pub2, &simple_chan, &event3);

void my_thread() {
    int msg;

   /* zbus_chan_publisher_start(struct zbus_publisher *publisher, k_timeout_t delay, k_timeout_t period) */
	zbus_chan_publisher_start(&pub1, K_NO_WAIT, K_MSEC(10));
	zbus_chan_publisher_start(&pub2, K_NO_WAIT, K_MINUTES(2));
	zbus_chan_publisher_start(&pub3, K_NO_WAIT, K_HOURS(1));

	while (1) {

		zbus_sub_wait_msg(zbus_obs, &chan, &msg, K_FOREVER);

		if (msg == SAMPLE_SENSOR_A) {
			/* take sensor A sample */
		} 
		if (msg == SAMPLE_SENSOR_B) {
			/* take sensor B sample */
		} 
		if (msg == SAMPLE_SENSOR_C) {
			/* take sensor C sample */
		} 	
	}
}
```
another way this can be leveraged is directly from a ISR...
```
int isr_msg = DATA_READY_MSG;
ZBUS_CHANNEL_PUBLISHER_DEFINE(isr_pub, &simple_chan, &isr_msg);

void my_isr( ... )
{
   /* process ISR */
   
   /* alert application */
   zbus_chan_publisher_reschedule(&isr_pub, K_NO_WAIT);
}