### PR TITLE
net: ip: net_context: louder warning for no src address

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1257,7 +1257,7 @@ int net_context_create_ipv4_new(struct net_context *context,
 						  (struct in_addr *)dst);
 		/* If src address is still unspecified, do not create pkt */
 		if (net_ipv4_is_addr_unspecified(src)) {
-			NET_DBG("DROP: src addr is unspecified");
+			NET_WARN("DROP: src addr is unspecified");
 			return -EINVAL;
 		}
 	}


### PR DESCRIPTION
Increase the verbosity of the message when there is no source address in `net_context_create_ipv4_new`. This is likely the first failure point when attempting to send data on an interface that has not yet been assigned an IP address. Burying the fault at the DBG level makes it much more time consuming to determine the root cause of this error.