### PR TITLE
socketpair: fix allocated number of buffers

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -344,7 +344,7 @@ config NET_SOCKETPAIR_BUFFER_SIZE
 	help
 	  Buffer size for socketpair(2)
 
-choice
+choice NET_SOCKETPAIR_ALLOCATION_STRATEGY
 	prompt "Memory management for socketpair"
 	default NET_SOCKETPAIR_HEAP if KERNEL_MEM_POOL
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -360,7 +360,8 @@ if NET_SOCKETPAIR_STATIC
 
 config NET_SOCKETPAIR_MAX
 	int "How many socketpairs to pre-allocate"
-	default 6 if WIFI_NM_WPA_SUPPLICANT
+	default 6 if WIFI_NM_HOSTAPD_AP
+	default 4 if WIFI_NM_WPA_SUPPLICANT
 	default 1
 
 endif # NET_SOCKETPAIR_STATIC


### PR DESCRIPTION
According to f9901e8e and validated by testing, the supplicant only use case only requires 4 socket pairs. 6 pairs are required for the `hostapd` use case.