### PR TITLE
posix: options: don't imply `POSIX_MESSAGE_PASSING`

### DIFF
--- a/lib/posix/options/Kconfig.profile
+++ b/lib/posix/options/Kconfig.profile
@@ -11,7 +11,6 @@ config POSIX_API
 	select POSIX_NETWORKING if NETWORKING # inet_ntoa(), socket(), etc
 	imply EVENTFD # eventfd(), eventfd_read(), eventfd_write()
 	imply POSIX_FD_MGMT # open(), close(), read(), write()
-	imply POSIX_MESSAGE_PASSING # mq_open(), etc
 	imply POSIX_MULTI_PROCESS # sleep(), getpid(), etc
 	help
 	  This option enables the required POSIX System Interfaces (base definitions), all of PSE51,

--- a/lib/posix/options/Kconfig.pthread
+++ b/lib/posix/options/Kconfig.pthread
@@ -15,6 +15,9 @@ menuconfig POSIX_THREADS
 
 if POSIX_THREADS
 
+config HEAP_MEM_POOL_ADD_SIZE_POSIX_THREADS
+	def_int 256
+
 config POSIX_THREAD_THREADS_MAX
 	int "Maximum number of POSIX threads"
 	default 5


### PR DESCRIPTION
Don't `imply POSIX_MESSAGE_PASSING` when `POSIX_API=y` as this option has a non-trivial RAM implication in `HEAP_MEM_POOL_ADD_SIZE_MQUEUE`.

The `mq_*` API is minimally used in-tree, with all users already enabling the symbol directly.

`POSIX_API` is selected by `WIFI_NM_WPA_SUPPLICANT`, and since the Wi-Fi supplicant users are huge RAM hogs, any savings are appreciated.