### PR TITLE
doc: posix: option groups: add c_lang_support_r section.

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -72,6 +72,25 @@ Group.
 For more information on developing Zephyr applications in the C programming language, please refer
 to :ref:`details<language_support>`.
 
+.. _posix_option_group_c_lang_support_r:
+
+POSIX_C_LANG_SUPPORT_R
+++++++++++++++++++++++
+
+Enable this option group with :kconfig:option:`CONFIG_POSIX_C_LANG_SUPPORT_R`.
+
+.. csv-table:: POSIX_C_LANG_SUPPORT_R
+   :header: API, Supported
+   :widths: 50,10
+
+    asctime_r(),yes
+    ctime_r(),yes
+    gmtime_r(),yes
+    localtime_r(),yes
+    rand_r(),yes
+    strerror_r(),yes
+    strtok_r(),yes
+
 .. _posix_option_group_c_lib_ext:
 
 POSIX_C_LIB_EXT


### PR DESCRIPTION
Document that the `POSIX_C_LANG_SUPPORT_R` Option Group is already complete.