### PR TITLE
posix: separate kconfig for adding to the default search path

### DIFF
--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -4,7 +4,7 @@ set(GEN_DIR ${ZEPHYR_BINARY_DIR}/include/generated)
 
 zephyr_syscall_header_ifdef(CONFIG_POSIX_TIMERS posix_clock.h)
 
-if(CONFIG_POSIX_API)
+if(CONFIG_POSIX_HEADERS_IN_DEFAULT_SEARCH_PATH)
   zephyr_include_directories(${ZEPHYR_BASE}/include/zephyr/posix)
 endif()
 

--- a/lib/posix/options/Kconfig
+++ b/lib/posix/options/Kconfig
@@ -6,6 +6,8 @@
 
 menu "POSIX Options"
 
+rsource "Kconfig.build"
+
 rsource "Kconfig.profile"
 
 rsource "Kconfig.aio"

--- a/lib/posix/options/Kconfig.build
+++ b/lib/posix/options/Kconfig.build
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+menu "POSIX build options"
+
+config POSIX_HEADERS_IN_DEFAULT_SEARCH_PATH
+	bool "POSIX headers in default search path"
+	help
+	  Select 'y' here and Zephyr's POSIX headers will be included in the default search path.
+
+endmenu

--- a/lib/posix/options/Kconfig.profile
+++ b/lib/posix/options/Kconfig.profile
@@ -9,6 +9,7 @@ config POSIX_API
 	select POSIX_BASE_DEFINITIONS # clock_gettime(), pthread_create(), sem_get(), etc
 	select POSIX_AEP_REALTIME_MINIMAL # CLOCK_MONOTONIC, pthread_attr_setstack(), etc
 	select POSIX_NETWORKING if NETWORKING # inet_ntoa(), socket(), etc
+	select POSIX_HEADERS_IN_DEFAULT_SEARCH_PATH
 	imply EVENTFD # eventfd(), eventfd_read(), eventfd_write()
 	imply POSIX_FD_MGMT # open(), close(), read(), write()
 	imply POSIX_MESSAGE_PASSING # mq_open(), etc


### PR DESCRIPTION
In preparation for deprecating `CONFIG_POSIX_API`, create a separate Kconfig option to include posix headers in the default path.