### PR TITLE
drivers: i2s: i2s_mcux_sai: control MCLK direction with DT property

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -163,6 +163,12 @@ GPIO
   now left as a placeholder and mapper.
   The labels have also been changed along, so no changes are necessary for regular use.
 
+I2S
+===
+* The :dtcompatible:`nxp,mcux-i2s` driver added property ``mclk-output``. Set this property to
+* configure the MCLK signal as an output.  Older driver versions used the macro
+* ``I2S_OPT_BIT_CLK_SLAVE`` to configure the MCLK signal direction. (:github:`88554`)
+
 Sensors
 =======
 

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021,2023-2024 NXP Semiconductor INC.
+ * Copyright 2021,2023-2025 NXP Semiconductor INC.
  * All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -97,6 +97,7 @@ struct i2s_mcux_config {
 	uint32_t mclk_control_base;
 	uint32_t mclk_pin_mask;
 	uint32_t mclk_pin_offset;
+	bool mclk_output;
 	uint32_t tx_channel;
 	clock_control_subsys_t clk_sub_sys;
 	const struct device *ccm_dev;
@@ -487,9 +488,7 @@ static int i2s_mcux_config(const struct device *dev, enum i2s_dir dir,
 
 	memset(&config, 0, sizeof(config));
 
-	const bool is_mclk_slave = i2s_cfg->options & I2S_OPT_BIT_CLK_SLAVE;
-
-	enable_mclk_direction(dev, !is_mclk_slave);
+	enable_mclk_direction(dev, dev_cfg->mclk_output);
 
 	get_mclk_rate(dev, &mclk);
 	LOG_DBG("mclk is %d", mclk);
@@ -1185,6 +1184,7 @@ static DEVICE_API(i2s, i2s_mcux_driver_api) = {
 		.mclk_control_base = DT_REG_ADDR(DT_PHANDLE(DT_DRV_INST(i2s_id), pinmuxes)),       \
 		.mclk_pin_mask = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, mask),            \
 		.mclk_pin_offset = DT_PHA_BY_IDX(DT_DRV_INST(i2s_id), pinmuxes, 0, offset),        \
+		.mclk_output = DT_INST_PROP_OR(i2s_id, mclk_output, 0),                            \
 		.clk_sub_sys =                                                                     \
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, name),       \
 		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i2s_id)),                             \

--- a/dts/bindings/i2s/nxp,mcux-i2s.yaml
+++ b/dts/bindings/i2s/nxp,mcux-i2s.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021,2023-2024 NXP
+# Copyright 2021,2023-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP mcux SAI-I2S controller
@@ -64,6 +64,11 @@ properties:
   clock-mux:
     type: int
     description: Clock mux source for SAI root clock
+
+  mclk-output:
+    type: boolean
+    description: |
+      Set if MCLK signal is an output.  Hardware default sets MCLK signal as input.
 
 pinmux-cells:
   - offset

--- a/tests/drivers/i2s/i2s_speed/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -9,3 +9,7 @@
 		i2s-node1 = &sai0;
 	};
 };
+
+&sai0 {
+	mclk-output;
+};


### PR DESCRIPTION
For the SAI peripheral, the MCLK signal input/output direction is independent from the TX or RX bit clocks directions (TCR2[BCD] and RCR2[BCD]). Introduces mclk-output property.

i2s_speed test passes on these platforms:
- frdm_mcxn947//cpu0
- mcx_n9xx_evk//cpu0 (using https://github.com/zephyrproject-rtos/zephyr/pull/87639)
- mimxrt1060_evk@B
- mimxrt1170_evk@A//cm7
- mimxrt1170_evk@B//cm7