### PR TITLE
boards: nucleo_h753zi: add die_temp support

### DIFF
--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -54,6 +54,7 @@
 	};
 
 	aliases {
+		die-temp0 = &die_temp;
 		led0 = &green_led;
 		led1 = &yellow_led;
 		pwm-led0 = &red_pwm_led;
@@ -149,6 +150,18 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+&adc3 {
+	pinctrl-0 = <&adc3_inp5_pf3>;
+	pinctrl-names = "default";
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };
 


### PR DESCRIPTION
This commit enables die_temp support by configuring ADC3 and adding the die_temp0 alias to the devicetree of the nucleo_h753zi board.

This change has been tested using the die_temp_polling sample.