### PR TITLE
boards: disco_l475_iot1: fix arduino_i2c assignment

### DIFF
--- a/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
+++ b/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
@@ -35,6 +35,6 @@
 	};
 };
 
-arduino_i2c: &i2c3 {};
+arduino_i2c: &i2c1 {};
 arduino_spi: &spi1 {};
 arduino_serial: &uart4 {};


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/commit/0f05f58bf51b1fa74413cac4522306321a1ecd2e assigned the `arduino_i2c` to the incorrect pins for the Arduino UNO connector. This assigns them back.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/88558