### PR TITLE
dts: nordic: nrf54l20: Add CS radio capability

### DIFF
--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -240,6 +240,7 @@
 				ieee802154-supported;
 				ble-2mbps-supported;
 				ble-coded-phy-supported;
+				cs-supported;
 
 				ieee802154: ieee802154 {
 					compatible = "nordic,nrf-ieee802154";


### PR DESCRIPTION
Like other nRF54L series products, the radio on 54l20 supports CS.