### PR TITLE
boards: shields: adafruit_pca9685: added pwm binding include

### DIFF
--- a/boards/shields/adafruit_pca9685/adafruit_pca9685.overlay
+++ b/boards/shields/adafruit_pca9685/adafruit_pca9685.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <dt-bindings/pwm/pwm.h>
+
 &arduino_i2c {
 	status = "okay";
 


### PR DESCRIPTION
Lack of PWM binding include causes some examples using this shield not to build if the base board used did not already include this binding.