### PR TITLE
drivers: interrupt_controller: intc_clic: Support both rv32 and rv64 clic based riscv CPUs

### DIFF
--- a/drivers/interrupt_controller/intc_clic.S
+++ b/drivers/interrupt_controller/intc_clic.S
@@ -11,6 +11,29 @@
 #include <zephyr/arch/cpu.h>
 #include "intc_clic.h"
 
+#ifdef CONFIG_64BIT
+	/* register-wide load/store based on ld/sd (XLEN = 64) */
+
+	.macro lr, rd, mem
+	ld \rd, \mem
+	.endm
+
+	.macro sr, rs, mem
+	sd \rs, \mem
+	.endm
+
+#else
+	/* register-wide load/store based on lw/sw (XLEN = 32) */
+
+	.macro lr, rd, mem
+	lw \rd, \mem
+	.endm
+
+	.macro sr, rs, mem
+	sw \rs, \mem
+	.endm
+
+#endif
 
 GTEXT(__soc_handle_irq)
 /*
@@ -36,7 +59,7 @@ GTEXT(sys_trace_isr_exit)
  */
 SECTION_FUNC(exception.other, __soc_handle_all_irqs)
 	addi sp, sp, -16
-	sw ra, 0(sp)
+	sr ra, 0(sp)
 
 	/* Read and clear mnxti to get highest current interrupt and enable interrupts. Will return
 	 * original interrupt if no others appear. */
@@ -58,10 +81,10 @@ irq_loop:
 	add t0, t0, a0
 
 	/* Load argument in a0 register */
-	lw a0, 0(t0)
+	lr a0, 0(t0)
 
 	/* Load ISR function address in register t1 */
-	lw t1, RV_REGSIZE(t0)
+	lr t1, RV_REGSIZE(t0)
 
 	/* Call ISR function */
 	jalr ra, t1, 0
@@ -75,6 +98,6 @@ irq_loop:
 	bnez a0, irq_loop
 
 irq_done:
-	lw ra, 0(sp)
+	lr ra, 0(sp)
 	addi sp, sp, 16
 	ret

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr/interrupt_util.h>
 #include <zephyr/sys/barrier.h>
 
-extern uint32_t _irq_vector_table[];
+extern uintptr_t _irq_vector_table[];
 
 #if defined(ARCH_IRQ_DIRECT_CONNECT) && defined(CONFIG_GEN_IRQ_VECTOR_TABLE)
 #define HAS_DIRECT_IRQS
@@ -226,7 +226,7 @@ static int check_vector(void *isr, int offset)
 	TC_PRINT("Checking _irq_vector_table entry %d for irq %d\n",
 		 TABLE_INDEX(offset), IRQ_LINE(offset));
 
-	if (_irq_vector_table[TABLE_INDEX(offset)] != (uint32_t)isr) {
+	if (_irq_vector_table[TABLE_INDEX(offset)] != (uintptr_t)isr) {
 		TC_PRINT("bad entry %d in vector table\n", TABLE_INDEX(offset));
 		return -1;
 	}


### PR DESCRIPTION
This PR enhances RISC-V CLIC/ECLIC interrupt controller support for 64-bit CPU targets.

**Key changes include:**

1. **Architecture-Agnostic IRQ Table Handling**  
   Adjusts `_irq_vector_table` element size to match target CPU word width (32-bit for RV32, 64-bit for RV64). This ensures proper alignment and memory access patterns for interrupt vector tables across different RISC-V implementations.

2. **64-bit CLIC IRQ Entry Support**  
   Modifies `intc_clic` driver to use `ld`/`sd` instructions for 64-bit IRQ entry loading/storing on RV64 targets, maintaining compatibility with legacy RV32 implementations through conditional compilation.

3. **Test Infrastructure Updates**  
   Fixes kernel IRQ tests to properly handle 64-bit vector table entries, ensuring consistent behavior across RISC-V variants.

These changes have been validated on RV32/RV64 emulation platforms and maintain backward compatibility with existing CLIC/ECLIC implementations.