### PR TITLE
Add missing i2c3 node to STM32F303xD/E

### DIFF
--- a/dts/arm/st/f3/stm32f303Xe.dtsi
+++ b/dts/arm/st/f3/stm32f303Xe.dtsi
@@ -41,5 +41,21 @@
 				status = "disabled";
 			};
 		};
+
+		i2c3: i2c@4007800 {
+			compatible = "st,stm32-i2c-v2";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40007800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>,
+				 /* I2C clock source should always be defined,
+				  * even for the default value
+				  */
+				 <&rcc STM32_SRC_SYSCLK I2C3_SEL(1)>;
+			interrupts = <72 0>, <73 0>;
+			interrupt-names = "event", "error";
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
The STM32F303RE definition does not have the I2C3 node.

The datasheet shows that I2C3 is available but the [devicetree file](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/arm/st/f3/stm32f303.dtsi) only shows two i2c. The pinctrl file has pinctrl definitions for the i2c3 pins, though.