### PR TITLE
soc: silabs: siwx91x: Allow alternative memory partition

### DIFF
--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -649,6 +649,10 @@ static DEVICE_API(dma, siwx91x_dma_api) = {
 	static UDMA_Channel_Info dma_channel_info_##inst[DT_INST_PROP(inst, dma_channels)];        \
 	SYS_MEM_BLOCKS_DEFINE_STATIC(desc_pool_##inst, sizeof(RSI_UDMA_DESC_T),                    \
 				     CONFIG_DMA_SILABS_SIWX91X_SG_BUFFER_COUNT, 4);                \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, silabs_sram_region),                               \
+		    (),                                                                            \
+		    (static __aligned(512) RSI_UDMA_DESC_T                                         \
+			     siwx91x_dma_chan_desc##inst[DT_INST_PROP(inst, dma_channels) * 2];))  \
 	static struct dma_siwx91x_channel_info                                                     \
 		zephyr_channel_info_##inst[DT_INST_PROP(inst, dma_channels)];                      \
 	static struct dma_siwx91x_data dma_data_##inst = {                                         \
@@ -670,7 +674,9 @@ static DEVICE_API(dma, siwx91x_dma_api) = {
 		.clock_subsys = (clock_control_subsys_t)DT_INST_PHA(inst, clocks, clkid),          \
 		.reg = (UDMA0_Type *)DT_INST_REG_ADDR(inst),                                       \
 		.irq_number = DT_INST_PROP_BY_IDX(inst, interrupts, 0),                            \
-		.sram_desc_addr = DT_REG_ADDR(DT_INST_PHANDLE(inst, silabs_sram_region)),          \
+		.sram_desc_addr = COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, silabs_sram_region),     \
+					      ((RSI_UDMA_DESC_T *)DT_REG_ADDR(DT_INST_PHANDLE(inst, silabs_sram_region))), \
+					      (siwx91x_dma_chan_desc##inst)),                      \
 		.irq_configure = siwx91x_dma_irq_configure_##inst,                                 \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, &siwx91x_dma_init, NULL, &dma_data_##inst, &dma_cfg_##inst,    \

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -674,6 +674,6 @@ static DEVICE_API(dma, siwx91x_dma_api) = {
 		.irq_configure = siwx91x_dma_irq_configure_##inst,                                 \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, &siwx91x_dma_init, NULL, &dma_data_##inst, &dma_cfg_##inst,    \
-			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY, &siwx91x_dma_api);
+			      POST_KERNEL, CONFIG_DMA_INIT_PRIORITY, &siwx91x_dma_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SIWX91X_DMA_INIT)

--- a/drivers/dma/dma_silabs_siwx91x.c
+++ b/drivers/dma/dma_silabs_siwx91x.c
@@ -670,7 +670,7 @@ static DEVICE_API(dma, siwx91x_dma_api) = {
 		.clock_subsys = (clock_control_subsys_t)DT_INST_PHA(inst, clocks, clkid),          \
 		.reg = (UDMA0_Type *)DT_INST_REG_ADDR(inst),                                       \
 		.irq_number = DT_INST_PROP_BY_IDX(inst, interrupts, 0),                            \
-		.sram_desc_addr = (RSI_UDMA_DESC_T *)DT_INST_PROP(inst, silabs_sram_desc_addr),    \
+		.sram_desc_addr = DT_REG_ADDR(DT_INST_PHANDLE(inst, silabs_sram_region)),          \
 		.irq_configure = siwx91x_dma_irq_configure_##inst,                                 \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, &siwx91x_dma_init, NULL, &dma_data_##inst, &dma_cfg_##inst,    \

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -39,7 +39,7 @@
 		 * Less memory is allocated to Zephyr, more memory is allocated
 		 * to NWP, better are the WiFi and BLE performances.
 		 */
-		reg = <0x00000000 DT_SIZE_K(196)>;
+		reg = <0x00000000 DT_SIZE_K(256)>;
 	};
 
 	sram_dma1: memory-dma@24061c00 {

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -36,14 +36,14 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x0002fc00 DT_SIZE_K(1)>;
 		zephyr,memory-region = "dma0";
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	sram_dma1: memory-dma@24061c00 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x24061c00 DT_SIZE_K(1)>;
 		zephyr,memory-region = "dma1";
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
 	};
 
 	bt_hci0: bt_hci {

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <zephyr/dt-bindings/clock/silabs/siwx91x-clock.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 #include <freq.h>
 
 / {
@@ -27,7 +28,22 @@
 
 	sram0: memory@0 {
 		compatible = "mmio-sram";
+		/* remove sram_dma0 region at the end of the sram */
 		reg = <0x00000000 DT_SIZE_K(191)>;
+	};
+
+	sram_dma0: memory-dma@2fc00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x0002fc00 DT_SIZE_K(1)>;
+		zephyr,memory-region = "dma0";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
+	};
+
+	sram_dma1: memory-dma@24061c00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x24061c00 DT_SIZE_K(1)>;
+		zephyr,memory-region = "dma1";
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM)>;
 	};
 
 	bt_hci0: bt_hci {
@@ -243,7 +259,7 @@
 			interrupts = <33 0>;
 			interrupt-names = "dma0";
 			clocks = <&clock0 SIWX91X_CLK_DMA0>;
-			silabs,sram-desc-addr = <0x2fc00>;
+			silabs,sram-region = <&sram_dma0>;
 			#dma-cells = < 1>;
 			dma-channels = <32>;
 			status = "disabled";
@@ -257,7 +273,7 @@
 			interrupts = <10 0>;
 			interrupt-names = "ulpdma";
 			clocks = <&clock0 SIWX91X_CLK_ULP_DMA>;
-			silabs,sram-desc-addr = <0x24061c00>;
+			silabs,sram-region = <&sram_dma1>;
 			#dma-cells = < 1>;
 			dma-channels = <12>;
 			status = "disabled";

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -11,6 +11,7 @@
 
 / {
 	chosen {
+		zephyr,sram = &sram0;
 		zephyr,entropy = &rng0;
 		zephyr,flash = &flash0;
 		zephyr,flash-controller = &flashctrl0;
@@ -28,8 +29,17 @@
 
 	sram0: memory@0 {
 		compatible = "mmio-sram";
-		/* remove sram_dma0 region at the end of the sram */
-		reg = <0x00000000 DT_SIZE_K(191)>;
+		/* siwx91x has 672kB of SRAM shared between the Cortex-M4
+		 * (Zephyr) and the NWP (Network Processor). 3 memory
+		 * configurations are
+		 * possible:
+		 *  - 196kB
+		 *  - 256kB
+		 *  - 320kB
+		 * Less memory is allocated to Zephyr, more memory is allocated
+		 * to NWP, better are the WiFi and BLE performances.
+		 */
+		reg = <0x00000000 DT_SIZE_K(196)>;
 	};
 
 	sram_dma1: memory-dma@24061c00 {

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -32,13 +32,6 @@
 		reg = <0x00000000 DT_SIZE_K(191)>;
 	};
 
-	sram_dma0: memory-dma@2fc00 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x0002fc00 DT_SIZE_K(1)>;
-		zephyr,memory-region = "dma0";
-		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE)>;
-	};
-
 	sram_dma1: memory-dma@24061c00 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x24061c00 DT_SIZE_K(1)>;
@@ -259,7 +252,6 @@
 			interrupts = <33 0>;
 			interrupt-names = "dma0";
 			clocks = <&clock0 SIWX91X_CLK_DMA0>;
-			silabs,sram-region = <&sram_dma0>;
 			#dma-cells = < 1>;
 			dma-channels = <32>;
 			status = "disabled";

--- a/dts/bindings/dma/silabs,siwx91x-dma.yaml
+++ b/dts/bindings/dma/silabs,siwx91x-dma.yaml
@@ -10,10 +10,11 @@ properties:
 
   silabs,sram-region:
     type: phandle
-    required: true
     description: |
-        SRAM Address for UDMA Descriptor Storage. This address must match to the
-        location used by the hardware.
+        SRAM Address for UDMA Descriptor Storage. Some instance require this
+        buffer to be placed in a specific area. If the instance doesn't have
+        this requirement, this attribute is not required and the memory will
+        will be automatically allocated.
 
   "#dma-cells":
     const: 1

--- a/dts/bindings/dma/silabs,siwx91x-dma.yaml
+++ b/dts/bindings/dma/silabs,siwx91x-dma.yaml
@@ -8,15 +8,12 @@ properties:
   reg:
     required: true
 
-  silabs,sram-desc-addr:
-    type: int
+  silabs,sram-region:
+    type: phandle
     required: true
     description: |
-        SRAM Address for UDMA Descriptor Storage. This address must correspond to the location
-        of the udma_addr0 section in the linker script for the dma0 node, and the udma_addr1
-        section for the ulpdma node. Ensure that the value specified for the SRAM address matches
-        the respective section defined in the linker file for each UDMA node, as this alignment
-        is critical for proper descriptor management and data transfer.
+        SRAM Address for UDMA Descriptor Storage. This address must match to the
+        location used by the hardware.
 
   "#dma-cells":
     const: 1

--- a/soc/silabs/silabs_siwx91x/siwg917/linker.ld
+++ b/soc/silabs/silabs_siwx91x/siwg917/linker.ld
@@ -5,29 +5,10 @@
  */
 #include <zephyr/arch/arm/cortex_m/scripts/linker.ld>
 
-MEMORY
-{
-	udma0   (rwx)  : ORIGIN = 0x0002fc00, LENGTH = 0x00000400
-	udma1   (rwx)  : ORIGIN = 0x24061c00, LENGTH = 0x00000400
-}
-
 SECTIONS
 {
 	.common_tcm_code :
 	{
 		*(.common_tcm_code*)
 	} > FLASH
-
-	/* These regions of SRAM is where the UDMA descriptors are stored. The corresponding
-	   section must be properly declared in the linker script to ensure correct data transfer
-	   and proper functioning of the UDMA module */
-	.udma_addr0 :
-	{
-		*(.udma_addr0*)
-	} > udma0 AT> FLASH
-
-	.udma_addr1 :
-	{
-		*(.udma_addr1*)
-	} > udma1 AT> FLASH
 }


### PR DESCRIPTION
Chip siwx91x has 672kB of SRAM shared between the Cortex-M4 (Zephyr) and the NWP (Network Processor). 3 memory configurations are possible for the Cortex-M4:
      - 196kB
      - 256kB
      - 320kB

Less memory is allocated to Zephyr, more memory is allocated to NWP, better are the WiFi and BLE performances.

This PR increase the memory allocated to Zephyr.