### PR TITLE
(backport 3.7) manifest: update TF-M for Mbed TLS 3.6.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 60ebade5d3d381a210af90191e475d8870b8adbc
+      revision: pull/129/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Pull in the needed changes to work with Mbed TLS 3.6.3.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/88229