### PR TITLE
soc: da1469x: Drop CONFIG_SRAM_VECTOR_TABLE from default configuration

### DIFF
--- a/soc/renesas/smartbond/da1469x/Kconfig.defconfig
+++ b/soc/renesas/smartbond/da1469x/Kconfig.defconfig
@@ -22,9 +22,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config SYS_CLOCK_TICKS_PER_SEC
 	default $(dt_node_int_prop_int,$(DT_CLOCK_SRC_PATH),clock-frequency) if SMARTBOND_TIMER
 
-config SRAM_VECTOR_TABLE
-	default y
-
 config USE_DT_CODE_PARTITION
 	default y if MCUBOOT
 


### PR DESCRIPTION
Drop unused CONFIG_SRAM_VECTOR_TABLE from default configuration.