### PR TITLE
Doc: Release Notes: Add `util_memeq` and `util_eq`

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -164,6 +164,11 @@ New APIs and options
 
   * :c:func:`counter_reset`
 
+* Sys
+
+  * :c:func:`util_eq`
+  * :c:func:`util_memeq`
+
 New Boards
 **********
 


### PR DESCRIPTION
Add the two new function `util_memeq` and `util_eq` recently added in `sys/util.h` to the release notes for 4.2.

~DNM until https://github.com/zephyrproject-rtos/zephyr/pull/84159 is merged.~