### PR TITLE
bluetooth: increase stack size for NO_OPTIMIZATIONS

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -15,6 +15,7 @@ config BT_LONG_WQ_STACK_SIZE
 	# Hidden: Long workqueue stack size. Should be derived from system
 	# requirements.
 	int
+	default 4096 if NO_OPTIMIZATIONS
 	default 1400 if BT_ECC
 	default 1300 if BT_GATT_CACHING
 	default 1024


### PR DESCRIPTION
when building without optimizations, the bt long thread needs more space to not crash