### PR TITLE
scripts: Fix esptool.py path resolution for cross-platform compatibility

### DIFF
--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -91,9 +91,8 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
         if args.esp_tool:
             espidf = args.esp_tool
         else:
-            espidf = path.join(args.esp_idf_path, 'tools', 'esptool_py',
-                               'esptool.py')
-
+            espidf = os.path.normpath(path.join(args.esp_idf_path, 'tools', 'esptool_py',
+                                                'esptool.py')).replace('\\', '/')
         return Esp32BinaryRunner(
             cfg, args.esp_device, boot_address=args.esp_boot_address,
             part_table_address=args.esp_partition_table_address,
@@ -105,7 +104,10 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             encrypt=args.esp_encrypt, no_stub=args.esp_no_stub)
 
     def do_run(self, command, **kwargs):
-        self.require(self.espidf)
+        if not os.path.exists(self.espidf):
+            self.logger.error(f"Expected esptool.py at: {self.espidf}")
+            raise RuntimeError("Cannot continue without esptool.py")
+
 
         # Add Python interpreter
         cmd_flash = [sys.executable, self.espidf, '--chip', 'auto']


### PR DESCRIPTION
This PR ensures the espidf path to esptool.py is correctly resolved and works on both Windows and Linux platforms by:

- Normalizing the path using os.path.normpath()

- Replacing backslashes (\) with forward slashes (/) to avoid issues with subprocess calls and string formatting

- Adding a safe os.path.exists() check with a clear error message if the tool is missing

These changes improve the reliability of the esp32 runner logic and prevent false negatives when using West-based flashing on Windows.