### PR TITLE
boards: stm32: Add zephyr_udc0 to nucleo_h503rb

### DIFF
--- a/boards/st/nucleo_h503rb/nucleo_h503rb.dts
+++ b/boards/st/nucleo_h503rb/nucleo_h503rb.dts
@@ -114,3 +114,9 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/st/nucleo_h503rb/nucleo_h503rb.yaml
+++ b/boards/st/nucleo_h503rb/nucleo_h503rb.yaml
@@ -14,4 +14,5 @@ supported:
   - uart
   - i2c
   - watchdog
+  - usb_device
 vendor: st


### PR DESCRIPTION
Added config of USB peripheral  for Nucleo H503RB. Examples using USB now compile and work correctly.

When I tried to run USB examples for this board turned out that USB pins are not defined in .dts file. After adding configuration I was able to successfully compile and run code from examples.