### PR TITLE
doc: _scripts: boards: fix for boards without revisions

### DIFF
--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -163,7 +163,7 @@ def gather_board_build_info(twister_out_dir):
                 revision = board_info.get('revision', '')
 
                 board_target = board_name
-                if revision is not None:
+                if revision != '':
                     board_target = f"{board_target}@{revision}"
                 if qualifier:
                     board_target = f"{board_target}/{qualifier}"


### PR DESCRIPTION
Commit 38b8790 introduced a pretty bad regression for boards without revisions (not allowing to properly switch from one board target to the other when using the board target selector in list of supported HW features).
Fix by correctly checking for undefined revisions.