### PR TITLE
drivers: pinctrl: rp2040: output override config

### DIFF
--- a/drivers/pinctrl/pinctrl_rpi_pico.c
+++ b/drivers/pinctrl/pinctrl_rpi_pico.c
@@ -20,6 +20,9 @@ static void pinctrl_configure_pin(const pinctrl_soc_pin_t *pin)
 	gpio_set_input_hysteresis_enabled(pin->pin_num, pin->schmitt_enable);
 	gpio_set_input_enabled(pin->pin_num, pin->input_enable);
 	gpio_set_oeover(pin->pin_num, pin->oe_override);
+	gpio_set_outover(pin->pin_num, pin->out_override);
+	gpio_set_inover(pin->pin_num, pin->in_override);
+	gpio_set_irqover(pin->pin_num, pin->irq_override);
 }
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,

--- a/dts/bindings/pinctrl/raspberrypi,pico-pinctrl.yaml
+++ b/dts/bindings/pinctrl/raspberrypi,pico-pinctrl.yaml
@@ -140,3 +140,60 @@ child-binding:
           - 3 (RP2_GPIO_OVERRIDE_HIGH) - enable output.
 
           The default value is 0, as this is the power on reset value.
+      raspberrypi,out-override:
+        type: int
+        enum:
+          - 0
+          - 1
+          - 2
+          - 3
+        default: 0
+        description: |
+          Override output for a pin.
+
+          - 0 (RP2_GPIO_OVERRIDE_NORMAL) - drive output from selected
+              peripheral signal.
+          - 1 (RP2_GPIO_OVERRIDE_INVERT) - drive output from inverse of
+              selected peripheral signal.
+          - 2 (RP2_GPIO_OVERRIDE_LOW) - drive output low.
+          - 3 (RP2_GPIO_OVERRIDE_HIGH) - drive output high.
+
+          The default value is 0, as this is the power on reset value.
+      raspberrypi,in-override:
+        type: int
+        enum:
+          - 0
+          - 1
+          - 2
+          - 3
+        default: 0
+        description: |
+          Override input for a pin.
+
+          - 0 (RP2_GPIO_OVERRIDE_NORMAL) - drive input from selected
+              pin.
+          - 1 (RP2_GPIO_OVERRIDE_INVERT) - drive input from inverse of
+              selected pin.
+          - 2 (RP2_GPIO_OVERRIDE_LOW) - drive input low.
+          - 3 (RP2_GPIO_OVERRIDE_HIGH) - drive input high.
+
+          The default value is 0, as this is the power on reset value.
+      raspberrypi,irq-override:
+        type: int
+        enum:
+          - 0
+          - 1
+          - 2
+          - 3
+        default: 0
+        description: |
+          Override interrupt signal for a pin.
+
+          - 0 (RP2_GPIO_OVERRIDE_NORMAL) - drive interrupt signal to selected
+              peripheral.
+          - 1 (RP2_GPIO_OVERRIDE_INVERT) - drive interrupt signal from inverse to
+              selected peripheral.
+          - 2 (RP2_GPIO_OVERRIDE_LOW) - drive interrupt signal low.
+          - 3 (RP2_GPIO_OVERRIDE_HIGH) - drive interrupt signal high.
+
+          The default value is 0, as this is the power on reset value.

--- a/soc/raspberrypi/rpi_pico/common/pinctrl_soc.h
+++ b/soc/raspberrypi/rpi_pico/common/pinctrl_soc.h
@@ -31,6 +31,12 @@ struct rpi_pinctrl_soc_pin {
 	uint32_t schmitt_enable : 1;
 	/** Output-enable override */
 	uint32_t oe_override : 2;
+	/** Output override */
+	uint32_t out_override : 2;
+	/** Input override */
+	uint32_t in_override : 2;
+	/** Interrupt override */
+	uint32_t irq_override : 2;
 };
 
 typedef struct rpi_pinctrl_soc_pin pinctrl_soc_pin_t;
@@ -52,7 +58,10 @@ typedef struct rpi_pinctrl_soc_pin pinctrl_soc_pin_t;
 		DT_PROP(node_id, bias_pull_down),				\
 		DT_PROP(node_id, input_enable),					\
 		DT_PROP(node_id, input_schmitt_enable),				\
-		DT_PROP(node_id, raspberrypi_oe_override),				\
+		DT_PROP(node_id, raspberrypi_oe_override),			\
+		DT_PROP(node_id, raspberrypi_out_override),			\
+		DT_PROP(node_id, raspberrypi_in_override),			\
+		DT_PROP(node_id, raspberrypi_irq_override),			\
 	},
 
 /**

--- a/soc/raspberrypi/rpi_pico/common/pinctrl_soc.h
+++ b/soc/raspberrypi/rpi_pico/common/pinctrl_soc.h
@@ -14,29 +14,29 @@
  */
 struct rpi_pinctrl_soc_pin {
 	/** Pin number 0..29 */
-	uint32_t pin_num : 5;
+	uint32_t pin_num: 5;
 	/** Alternative function (UART, SPI, etc.) */
-	uint32_t alt_func : 5;
+	uint32_t alt_func: 5;
 	/** Maximum current used by a pin, in mA */
-	uint32_t drive_strength : 4;
+	uint32_t drive_strength: 4;
 	/** Slew rate, may be either false (slow) or true (fast) */
-	uint32_t slew_rate : 1;
+	uint32_t slew_rate: 1;
 	/** Enable the internal pull up resistor */
-	uint32_t pullup : 1;
+	uint32_t pullup: 1;
 	/** Enable the internal pull down resistor */
-	uint32_t pulldown : 1;
+	uint32_t pulldown: 1;
 	/** Enable the pin as an input */
-	uint32_t input_enable : 1;
+	uint32_t input_enable: 1;
 	/** Enable the internal schmitt trigger */
-	uint32_t schmitt_enable : 1;
+	uint32_t schmitt_enable: 1;
 	/** Output-enable override */
-	uint32_t oe_override : 2;
+	uint32_t oe_override: 2;
 	/** Output override */
-	uint32_t out_override : 2;
+	uint32_t out_override: 2;
 	/** Input override */
-	uint32_t in_override : 2;
+	uint32_t in_override: 2;
 	/** Interrupt override */
-	uint32_t irq_override : 2;
+	uint32_t irq_override: 2;
 };
 
 typedef struct rpi_pinctrl_soc_pin pinctrl_soc_pin_t;
@@ -48,20 +48,20 @@ typedef struct rpi_pinctrl_soc_pin pinctrl_soc_pin_t;
  * @param prop Property name.
  * @param idx Property entry index.
  */
-#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)				\
-	{									\
-		RP2_GET_PIN_NUM(DT_PROP_BY_IDX(node_id, prop, idx)),		\
-		RP2_GET_PIN_ALT_FUNC(DT_PROP_BY_IDX(node_id, prop, idx)),	\
-		DT_ENUM_IDX(node_id, drive_strength),				\
-		DT_ENUM_IDX(node_id, slew_rate),				\
-		DT_PROP(node_id, bias_pull_up),					\
-		DT_PROP(node_id, bias_pull_down),				\
-		DT_PROP(node_id, input_enable),					\
-		DT_PROP(node_id, input_schmitt_enable),				\
-		DT_PROP(node_id, raspberrypi_oe_override),			\
-		DT_PROP(node_id, raspberrypi_out_override),			\
-		DT_PROP(node_id, raspberrypi_in_override),			\
-		DT_PROP(node_id, raspberrypi_irq_override),			\
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)                                               \
+	{                                                                                          \
+		RP2_GET_PIN_NUM(DT_PROP_BY_IDX(node_id, prop, idx)),                               \
+		RP2_GET_PIN_ALT_FUNC(DT_PROP_BY_IDX(node_id, prop, idx)),                          \
+		DT_ENUM_IDX(node_id, drive_strength),                                              \
+		DT_ENUM_IDX(node_id, slew_rate),                                                   \
+		DT_PROP(node_id, bias_pull_up),                                                    \
+		DT_PROP(node_id, bias_pull_down),                                                  \
+		DT_PROP(node_id, input_enable),                                                    \
+		DT_PROP(node_id, input_schmitt_enable),                                            \
+		DT_PROP(node_id, raspberrypi_oe_override),                                         \
+		DT_PROP(node_id, raspberrypi_out_override),                                        \
+		DT_PROP(node_id, raspberrypi_in_override),                                         \
+		DT_PROP(node_id, raspberrypi_irq_override),                                        \
 	},
 
 /**
@@ -70,14 +70,11 @@ typedef struct rpi_pinctrl_soc_pin pinctrl_soc_pin_t;
  * @param node_id Node identifier.
  * @param prop Property name describing state pins.
  */
-#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)				\
-	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),			\
-				DT_FOREACH_PROP_ELEM, pinmux,			\
+#define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)                                                   \
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop), DT_FOREACH_PROP_ELEM, pinmux,           \
 				Z_PINCTRL_STATE_PIN_INIT)}
 
-#define RP2_GET_PIN_NUM(pinctrl) \
-	(((pinctrl) >> RP2_PIN_NUM_POS) & RP2_PIN_NUM_MASK)
-#define RP2_GET_PIN_ALT_FUNC(pinctrl) \
-	(((pinctrl) >> RP2_ALT_FUNC_POS) & RP2_ALT_FUNC_MASK)
+#define RP2_GET_PIN_NUM(pinctrl)      (((pinctrl) >> RP2_PIN_NUM_POS) & RP2_PIN_NUM_MASK)
+#define RP2_GET_PIN_ALT_FUNC(pinctrl) (((pinctrl) >> RP2_ALT_FUNC_POS) & RP2_ALT_FUNC_MASK)
 
 #endif /* ZEPHYR_SOC_ARM_RPI_PICO_RP2_PINCTRL_SOC_H_ */


### PR DESCRIPTION
Add a device-tree property to configure the output override functionnality of RP2040 GPIO pins.
