### PR TITLE
Adjusted timeout value for eSPI send_vwire 

### DIFF
--- a/drivers/espi/espi_mchp_xec.c
+++ b/drivers/espi/espi_mchp_xec.c
@@ -19,9 +19,9 @@
 #define ESPI_XEC_VWIRE_ACK_DELAY    10ul
 
 /* Maximum timeout to transmit a virtual wire packet.
- * 10 ms expressed in multiples of 100us
+ * 1 ms expressed in multiples of 1us
  */
-#define ESPI_XEC_VWIRE_SEND_TIMEOUT 100ul
+#define ESPI_XEC_VWIRE_SEND_TIMEOUT 1000ul
 
 #define VW_MAX_GIRQS                2ul
 
@@ -461,10 +461,15 @@ static int espi_xec_send_vwire(const struct device *dev,
 		/* Ensure eSPI virtual wire packet is transmitted
 		 * There is no interrupt, so need to poll register
 		 */
-		uint8_t rd_cnt = ESPI_XEC_VWIRE_SEND_TIMEOUT;
+		uint16_t rd_cnt = ESPI_XEC_VWIRE_SEND_TIMEOUT;
 
 		while (reg->SRC_CHG && rd_cnt--) {
-			k_busy_wait(100);
+			k_busy_wait(1);
+		}
+
+		if (rd_cnt == 0) {
+			LOG_ERR("VW %d send timeout", signal);
+			return -ETIMEDOUT;
 		}
 	}
 

--- a/drivers/espi/espi_mchp_xec_v2.c
+++ b/drivers/espi/espi_mchp_xec_v2.c
@@ -25,9 +25,9 @@
 #define ESPI_XEC_VWIRE_ACK_DELAY	10ul
 
 /* Maximum timeout to transmit a virtual wire packet.
- * 10 ms expressed in multiples of 100us
+ * 1 ms expressed in multiples of 1us
  */
-#define ESPI_XEC_VWIRE_SEND_TIMEOUT	100ul
+#define ESPI_XEC_VWIRE_SEND_TIMEOUT	1000ul
 
 #define VW_MAX_GIRQS			2ul
 
@@ -325,10 +325,15 @@ static int espi_xec_send_vwire(const struct device *dev,
 		/* Ensure eSPI virtual wire packet is transmitted
 		 * There is no interrupt, so need to poll register
 		 */
-		uint8_t rd_cnt = ESPI_XEC_VWIRE_SEND_TIMEOUT;
+		uint16_t rd_cnt = ESPI_XEC_VWIRE_SEND_TIMEOUT;
 
 		while (sys_read8(regaddr + SMVW_BI_SRC_CHG) && rd_cnt--) {
-			k_busy_wait(100);
+			k_busy_wait(1);
+		}
+
+		if (rd_cnt == 0) {
+			LOG_ERR("VW %d send timeout", signal);
+			return -ETIMEDOUT;
 		}
 	}
 

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -728,6 +728,8 @@ static inline int z_impl_espi_write_lpc_request(const struct device *dev,
  *
  * @retval 0 If successful.
  * @retval -EIO General input / output error, failed to send over the bus.
+ * @retval -EINVAL invalid signal.
+ * @retval -ETIMEDOUT timeout waiting for eSPI controller to process the VW.
  */
 __syscall int espi_send_vwire(const struct device *dev,
 			      enum espi_vwire_signal signal,


### PR DESCRIPTION
Adjusted timeout value for eSPI send_vwire API such that, driver waits for up to 1 mSec to assure the VW packet is fetched by the controller.
Driver also returns the -ETIMEDOUT error upon failure to do so.
Changing the polling frequency from 100 uSec to 1 uSec helps to optimize the runtime SCI pulse width to the shortest possible value.