### PR TITLE
drivers: timer: Clean up Cortex-M systick Kconfig

### DIFF
--- a/drivers/timer/Kconfig.cortex_m_systick
+++ b/drivers/timer/Kconfig.cortex_m_systick
@@ -45,6 +45,7 @@ config CORTEX_M_SYSTICK_64BIT_CYCLE_COUNTER
 
 choice CORTEX_M_SYSTICK_LPM_TIMER
 	prompt "SysTick companion low-power mode timer"
+	depends on CORTEX_M_SYSTICK
 	# If all dependencies are enabled, and /chosen/cortex-m-idle-timer
 	# is enabled, default to using the Counter API-based LPM timer.
 	# Otherwise, the first choice (LPM_TIMER_NONE) will be selected


### PR DESCRIPTION
Makes the choice CORTEX_M_SYSTICK_LPM dependent upon CORTEX_M_SYSTICK to prevent its default from showing up in the .config of projects that do not use the CORTEX_M_SYSTICK timer driver.