### PR TITLE
soc: npcx: update the NUM_IRQS value for npcx4

### DIFF
--- a/soc/nuvoton/npcx/npcx4/Kconfig.defconfig
+++ b/soc/nuvoton/npcx/npcx4/Kconfig.defconfig
@@ -6,7 +6,7 @@
 if SOC_SERIES_NPCX4
 
 config NUM_IRQS
-	default 128
+	default 86
 
 config CORTEX_M_SYSTICK
 	default !NPCX_ITIM_TIMER


### PR DESCRIPTION
The npcx4 SoC only uses 86 NVIC IRQ numbers.
This commit updates the `NUM_IRQS` value from 128 to 86 to reduce the memory usage.