### PR TITLE
pm: Enable PM3 mode for RW612 in wifi example and set IMU as wakeup s…

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -238,6 +238,11 @@
 	wakeup-source;
 };
 
+&imu {
+	status = "okay";
+	wakeup-source;
+};
+
 zephyr_udc0: &usb_otg {
 	status = "okay";
 };

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -311,3 +311,8 @@ nxp_8080_touch_panel_i2c: &arduino_i2c {
 	status = "okay";
 	wakeup-source;
 };
+
+&imu {
+	status = "okay";
+	wakeup-source;
+};

--- a/samples/net/wifi/shell/boards/frdm_rw612.overlay
+++ b/samples/net/wifi/shell/boards/frdm_rw612.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&standby {
+	status = "okay";
+};

--- a/samples/net/wifi/shell/boards/rd_rw612_bga.overlay
+++ b/samples/net/wifi/shell/boards/rd_rw612_bga.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&standby {
+	status = "okay";
+};


### PR DESCRIPTION
…ource

Added overlay file for RW612 in wifi example to enable standby mode (PM3). Set IMU as wakeup source.