### PR TITLE
Apds9960 polling without interrupt pin

### DIFF
--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -32,6 +32,26 @@ endchoice
 config APDS9960_TRIGGER
 	bool
 
+choice APDS9960_FETCH_MODE
+	prompt "Fetching Mode"
+	default APDS9960_FETCH_MODE_INTERRUPT
+	help
+	  Specify whether to wait for interrupt
+
+config APDS9960_FETCH_MODE_POLL
+	bool "Poll without interrupt pin"
+	help
+	  Uses I2C to check sample
+
+config APDS9960_FETCH_MODE_INTERRUPT
+	bool "Wait for interrupt"
+	depends on GPIO
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_AVAGO_APDS9960),int-gpios)
+	help
+	  Wait for interrupt before reading
+
+endchoice
+
 config APDS9960_ENABLE_ALS
 	bool "Ambient Light Sense"
 	default y

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -83,6 +83,24 @@ static int apds9960_sample_fetch(const struct device *dev,
 		return -EIO;
 	}
 
+#ifdef CONFIG_APDS9960_FETCH_MODE_POLL
+#ifdef CONFIG_APDS9960_ENABLE_ALS
+	while (!(tmp & APDS9960_STATUS_AINT)) {
+		k_sleep(K_MSEC(APDS9960_DEFAULT_WAIT_TIME));
+		if (i2c_reg_read_byte_dt(&config->i2c, APDS9960_STATUS_REG, &tmp)) {
+			return -EIO;
+		}
+	}
+#else
+	while (!(tmp & APDS9960_STATUS_PINT)) {
+		k_sleep(K_MSEC(APDS9960_DEFAULT_WAIT_TIME));
+		if (i2c_reg_read_byte_dt(&config->i2c, APDS9960_STATUS_REG, &tmp)) {
+			return -EIO;
+		}
+	}
+#endif
+#endif
+
 	LOG_DBG("status: 0x%x", tmp);
 	if (tmp & APDS9960_STATUS_PINT) {
 		if (i2c_reg_read_byte_dt(&config->i2c,

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -26,6 +26,7 @@
 
 LOG_MODULE_REGISTER(APDS9960, CONFIG_SENSOR_LOG_LEVEL);
 
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 static void apds9960_handle_cb(struct apds9960_data *drv_data)
 {
 	apds9960_setup_int(drv_data->dev->config, false);
@@ -45,6 +46,7 @@ static void apds9960_gpio_callback(const struct device *dev,
 
 	apds9960_handle_cb(drv_data);
 }
+#endif
 
 static int apds9960_sample_fetch(const struct device *dev,
 				 enum sensor_channel chan)
@@ -59,6 +61,7 @@ static int apds9960_sample_fetch(const struct device *dev,
 	}
 
 #ifndef CONFIG_APDS9960_TRIGGER
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 	apds9960_setup_int(config, true);
 
 #ifdef CONFIG_APDS9960_ENABLE_ALS
@@ -71,8 +74,8 @@ static int apds9960_sample_fetch(const struct device *dev,
 		LOG_ERR("Power on bit not set.");
 		return -EIO;
 	}
-
 	k_sem_take(&data->data_sem, K_FOREVER);
+#endif
 #endif
 
 	if (i2c_reg_read_byte_dt(&config->i2c,
@@ -99,12 +102,14 @@ static int apds9960_sample_fetch(const struct device *dev,
 	}
 
 #ifndef CONFIG_APDS9960_TRIGGER
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_ENABLE_REG,
 				APDS9960_ENABLE_PON,
 				0)) {
 		return -EIO;
 	}
+#endif
 #endif
 
 	if (i2c_reg_write_byte_dt(&config->i2c,
@@ -352,9 +357,18 @@ static int apds9960_sensor_setup(const struct device *dev)
 	}
 #endif
 
+#ifdef CONFIG_APDS9960_FETCH_MODE_POLL
+	if (i2c_reg_update_byte_dt(&config->i2c, APDS9960_ENABLE_REG, APDS9960_ENABLE_PON,
+				   APDS9960_ENABLE_PON)) {
+		LOG_ERR("Power on bit not set.");
+		return -EIO;
+	}
+#endif
+
 	return 0;
 }
 
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 static int apds9960_init_interrupt(const struct device *dev)
 {
 	const struct apds9960_config *config = dev->config;
@@ -400,6 +414,7 @@ static int apds9960_init_interrupt(const struct device *dev)
 
 	return 0;
 }
+#endif
 
 #ifdef CONFIG_PM_DEVICE
 static int apds9960_pm_action(const struct device *dev,
@@ -458,10 +473,12 @@ static int apds9960_init(const struct device *dev)
 		return -EIO;
 	}
 
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 	if (apds9960_init_interrupt(dev) < 0) {
 		LOG_ERR("Failed to initialize interrupt!");
 		return -EIO;
 	}
+#endif
 
 	return 0;
 }
@@ -477,7 +494,9 @@ static DEVICE_API(sensor, apds9960_driver_api) = {
 
 static const struct apds9960_config apds9960_config = {
 	.i2c = I2C_DT_SPEC_INST_GET(0),
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 	.int_gpio = GPIO_DT_SPEC_INST_GET(0, int_gpios),
+#endif
 #if CONFIG_APDS9960_PGAIN_8X
 	.pgain = APDS9960_PGAIN_8X,
 #elif CONFIG_APDS9960_PGAIN_4X

--- a/drivers/sensor/apds9960/apds9960.h
+++ b/drivers/sensor/apds9960/apds9960.h
@@ -212,6 +212,9 @@
 #define APDS9960_DEFAULT_GPULSE		0xC9
 #define APDS9960_DEFAULT_GCONF3		0
 
+/* Polling Wait Times (ms) */
+#define APDS9960_DEFAULT_WAIT_TIME      2.78
+
 struct apds9960_config {
 	struct i2c_dt_spec i2c;
 #ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT

--- a/drivers/sensor/apds9960/apds9960.h
+++ b/drivers/sensor/apds9960/apds9960.h
@@ -214,7 +214,9 @@
 
 struct apds9960_config {
 	struct i2c_dt_spec i2c;
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 	struct gpio_dt_spec int_gpio;
+#endif
 	uint8_t pgain;
 	uint8_t again;
 	uint8_t ppcount;
@@ -231,11 +233,12 @@ struct apds9960_data {
 #ifdef CONFIG_APDS9960_TRIGGER
 	sensor_trigger_handler_t p_th_handler;
 	const struct sensor_trigger *p_th_trigger;
-#else
+#elif CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 	struct k_sem data_sem;
 #endif
 };
 
+#ifdef CONFIG_APDS9960_FETCH_MODE_INTERRUPT
 static inline void apds9960_setup_int(const struct apds9960_config *cfg,
 				      bool enable)
 {
@@ -245,6 +248,7 @@ static inline void apds9960_setup_int(const struct apds9960_config *cfg,
 
 	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, flags);
 }
+#endif
 
 #ifdef CONFIG_APDS9960_TRIGGER
 void apds9960_work_cb(struct k_work *work);

--- a/drivers/sensor/apds9960/apds9960.h
+++ b/drivers/sensor/apds9960/apds9960.h
@@ -214,6 +214,7 @@
 
 /* Polling Wait Times (ms) */
 #define APDS9960_DEFAULT_WAIT_TIME      2.78
+#define APDS9960_MAX_WAIT_TIME          10000
 
 struct apds9960_config {
 	struct i2c_dt_spec i2c;

--- a/dts/bindings/sensor/avago,apds9960.yaml
+++ b/dts/bindings/sensor/avago,apds9960.yaml
@@ -10,7 +10,6 @@ include: [sensor-device.yaml, i2c-device.yaml]
 properties:
   int-gpios:
     type: phandle-array
-    required: true
     description: Interrupt pin.
 
       The interrupt pin of APDS9960 is open-drain, active low.


### PR DESCRIPTION
**Description**
This change allows for I2C communication with APDS9960 sensor without using the interrupt pin. If a sample is not available, it will block for the default amount of time between samples (2.78ms) before trying again. This allows it to work with boards like the Adafruit APDS9960 breakout with a QWIIC connector.

Specific Changes:
- Made interrupt pin assignment optional
- Added new configuration option to disable the interrupt
- Use status register to determine whether a sample is ready or not
- Sleep if a sample is not ready, and try again in non interrupt mode

By default, interrupt pin is enabled when the int-gpios property is provided so older projects are not effected.

**Testing**
Build the sample APDS9960 sensor code with CONFIG_APDS9960_INTERRUPT_PIN set to n and CONFIG_APDS9960_TRIGGER_GLOBAL_THREAD set to n, or alternatively delete the property int-gpios from the devicetree overlay.

Logic analyzer shows i2c checking status, and waiting if a sample is not ready
<img width="468" alt="i2c_wait" src="https://github.com/user-attachments/assets/0064c1cc-2073-404c-9e45-dcb03abe2691" />

RTT viewer shows the proximity and ambient light data being printed (same as before behavior)
<img width="468" alt="rtt_viewer" src="https://github.com/user-attachments/assets/dc6ca7f5-55fd-4972-a43e-af37576fc015" />
