### PR TITLE
boards: frdm_mcxa166, frdm_mcxa276: add watchdog support

### DIFF
--- a/boards/nxp/frdm_mcxa166/board.c
+++ b/boards/nxp/frdm_mcxa166/board.c
@@ -153,6 +153,11 @@ void board_early_init_hook(void)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(edma0))
 	RESET_ReleasePeripheralReset(kDMA0_RST_SHIFT_RSTn);
 #endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0))
+	CLOCK_SetClockDiv(kCLOCK_DivWWDT0, 1u);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa166/frdm_mcxa166.dts
+++ b/boards/nxp/frdm_mcxa166/frdm_mcxa166.dts
@@ -20,6 +20,7 @@
 		led2 = &red_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		watchdog0 = &wwdt0;
 	};
 
 	chosen {
@@ -139,4 +140,8 @@
 			reg = <0x000d8000 DT_SIZE_K(112)>;
 		};
 	};
+};
+
+&wwdt0 {
+	status = "okay";
 };

--- a/boards/nxp/frdm_mcxa166/frdm_mcxa166.yaml
+++ b/boards/nxp/frdm_mcxa166/frdm_mcxa166.yaml
@@ -17,4 +17,5 @@ supported:
   - gpio
   - uart
   - flash
+  - watchdog
 vendor: nxp

--- a/boards/nxp/frdm_mcxa276/board.c
+++ b/boards/nxp/frdm_mcxa276/board.c
@@ -153,6 +153,11 @@ void board_early_init_hook(void)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(edma0))
 	RESET_ReleasePeripheralReset(kDMA0_RST_SHIFT_RSTn);
 #endif
+
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(wwdt0))
+	CLOCK_SetClockDiv(kCLOCK_DivWWDT0, 1u);
+#endif
+
 	/* Set SystemCoreClock variable. */
 	SystemCoreClock = CLOCK_INIT_CORE_CLOCK;
 }

--- a/boards/nxp/frdm_mcxa276/frdm_mcxa276.dts
+++ b/boards/nxp/frdm_mcxa276/frdm_mcxa276.dts
@@ -20,6 +20,7 @@
 		led2 = &red_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
+		watchdog0 = &wwdt0;
 	};
 
 	chosen {
@@ -139,4 +140,8 @@
 			reg = <0x000d8000 DT_SIZE_K(112)>;
 		};
 	};
+};
+
+&wwdt0 {
+	status = "okay";
 };

--- a/boards/nxp/frdm_mcxa276/frdm_mcxa276.yaml
+++ b/boards/nxp/frdm_mcxa276/frdm_mcxa276.yaml
@@ -17,4 +17,5 @@ supported:
   - gpio
   - uart
   - flash
+  - watchdog
 vendor: nxp

--- a/dts/arm/nxp/nxp_mcxa166.dtsi
+++ b/dts/arm/nxp/nxp_mcxa166.dtsi
@@ -214,6 +214,14 @@
 			no-error-irq;
 			status = "disabled";
 		};
+
+		wwdt0: watchdog@4000c000 {
+			compatible = "nxp,lpc-wwdt";
+			reg = <0x4000c000 0x1000>;
+			interrupts = <60 0>;
+			status = "disabled";
+			clk-divider = <1>;
+		};
 	};
 };
 

--- a/dts/arm/nxp/nxp_mcxa276.dtsi
+++ b/dts/arm/nxp/nxp_mcxa276.dtsi
@@ -214,6 +214,14 @@
 			no-error-irq;
 			status = "disabled";
 		};
+
+		wwdt0: watchdog@4000c000 {
+			compatible = "nxp,lpc-wwdt";
+			reg = <0x4000c000 0x1000>;
+			interrupts = <60 0>;
+			status = "disabled";
+			clk-divider = <1>;
+		};
 	};
 };
 


### PR DESCRIPTION
1. enable watchdog support
2. verified tests/drivers/watchdog/wdt_basic_api