### PR TITLE
docs: releases: mention `flash_area_copy()`

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -163,6 +163,10 @@ New APIs and options
 
   * :c:func:`stepper_stop()`
 
+* Storage
+
+  * :c:func:`flash_area_copy()`
+
 * Counter
 
   * :c:func:`counter_reset`


### PR DESCRIPTION
mention `flash_area_copy()` in release notes.

of  #84604