### PR TITLE
regulator: npm1300: configure active discharge

### DIFF
--- a/dts/bindings/regulator/nordic,npm1300-regulator.yaml
+++ b/dts/bindings/regulator/nordic,npm1300-regulator.yaml
@@ -97,6 +97,11 @@ child-binding:
       description: |
         Soft start current limit in microamps.
 
+    active-discharge:
+      type: boolean
+      description: |
+        Enable active-discharge on the BUCK/LDO/LDSW output when disabled.
+
     nordic,anomaly38-disable-workaround:
       type: boolean
       description: |


### PR DESCRIPTION
Configure the active discharge feature for both the BUCK and LDO/LDSW blocks through the appropriate registers.