### PR TITLE
boards: nordic: Add sysbuild for NS boards

### DIFF
--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.yaml
@@ -15,3 +15,4 @@ supported:
   - watchdog
   - usb_device
 vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_ns.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_ns.yaml
@@ -19,3 +19,5 @@ supported:
   - watchdog
   - adc
   - i2s
+vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_ns.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_ns.yaml
@@ -19,3 +19,5 @@ supported:
   - watchdog
   - adc
   - i2s
+vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_ns.yaml
+++ b/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_ns.yaml
@@ -12,3 +12,5 @@ supported:
   - pwm
   - watchdog
   - netif:modem
+vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_ns.yaml
+++ b/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_ns.yaml
@@ -17,3 +17,4 @@ supported:
   - watchdog
   - netif:modem
 vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_7_0.yaml
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_7_0.yaml
@@ -17,3 +17,4 @@ supported:
   - watchdog
   - netif:modem
 vendor: nordic
+sysbuild: true

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_9_0.yaml
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_ns_0_9_0.yaml
@@ -17,3 +17,4 @@ supported:
   - watchdog
   - netif:modem
 vendor: nordic
+sysbuild: true

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.yaml
@@ -15,3 +15,4 @@ supported:
   - usb_device
   - netif:openthread
 vendor: nordic
+sysbuild: true


### PR DESCRIPTION
-This commit adds "sysbuild: true" for ns build-targets for the
 following nordic boards:
  - nrf5340_audio_dk
  - nrf54l15dk
  - nrf9131ek
  - nrf9151dk
  - nrf9161dks (multiple versions)
  - thingy53 -Added missing vendor: nordic for some boards for consistency