### PR TITLE
Add support for Target Mode on cadence i2c

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/boards/kv260_r5.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/kv260_r5.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Note: To test this sample, connect SCL, SDA pins of I2C0 and I2C1 in loopback */
+
+#include <zephyr/dt-bindings/i2c/i2c.h>
+
+/delete-node/ &eeprom0;
+/delete-node/ &eeprom1;
+
+&i2c0 {
+	status = "okay";
+	clocks = <&i2c_ref_clk>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	eeprom0: eeprom@54 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x54>;
+		size = <256>;
+	};
+};
+
+&i2c1 {
+	eeprom1: eeprom@56 {
+		compatible = "zephyr,i2c-target-eeprom";
+		reg = <0x56>;
+		size = <256>;
+	};
+};


### PR DESCRIPTION
This pull request
- Adds support for Target Mode on cadence i2c
- Adds support to test i2c_target_api on kv260_r5