### PR TITLE
boards: shields: Add EVAL-ADXL367-ARDZ accelerometer shield and streaming configuration

### DIFF
--- a/boards/shields/eval_adxl367_ardz/Kconfig.shield
+++ b/boards/shields/eval_adxl367_ardz/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_EVAL_ADXL367_ARDZ
+	def_bool $(shields_list_contains,eval_adxl367_ardz)

--- a/boards/shields/eval_adxl367_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl367_ardz/doc/index.rst
@@ -1,0 +1,40 @@
+.. _eval_adxl367_ardz:
+
+EVAL-ADXL367-ARDZ
+#################
+
+Overview
+********
+
+The EVAL-ADXL367-ARDZ is a 3-axis digital accelerometer Arduino shield powered
+by the Analog Devices ADXL367.
+
+Programming
+***********
+
+Set ``--shield eval_adxl367_ardz`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/sensor_shell
+   :board: apard32690/max32690/m4
+   :shield: eval_adxl367_ardz
+   :goals: build
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration for
+Arduino connectors and defines node aliases for SPI and GPIO interfaces (see
+:ref:`shields` for more details).
+
+References
+**********
+
+- `ADXL367 product page`_
+- `ADXL367 data sheet`_
+
+.. _ADXL367 product page:
+   https://www.analog.com/en/products/adxl367.html
+
+.. _ADXL367 data sheet:
+   https://www.analog.com/media/en/technical-documentation/data-sheets/adxl367.pdf

--- a/boards/shields/eval_adxl367_ardz/eval_adxl367_ardz.overlay
+++ b/boards/shields/eval_adxl367_ardz/eval_adxl367_ardz.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/sensor/adxl367.h>
+
+/ {
+	aliases {
+		accel0 = &adxl367_eval_adxl367_ardz;
+	};
+};
+
+&arduino_spi {
+	status = "okay";
+
+	adxl367_eval_adxl367_ardz: adxl367@0 {
+		compatible = "adi,adxl367";
+		reg = <0x0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+		fifo-mode = <ADXL367_FIFO_MODE_STREAM>;
+		status = "okay";
+	};
+};

--- a/drivers/sensor/adi/adxl367/adxl367.c
+++ b/drivers/sensor/adi/adxl367/adxl367.c
@@ -1097,7 +1097,7 @@ static int adxl367_init(const struct device *dev)
 #define ADXL367_CFG_IRQ(inst)
 #endif /* CONFIG_ADXL367_TRIGGER */
 
-#define ADXL367_CONFIG(inst, chipid)								\
+#define ADXL367_CONFIG(inst, chipid)							\
 		.odr = DT_INST_PROP(inst, odr),						\
 		.autosleep = false,							\
 		.low_noise = false,							\
@@ -1115,7 +1115,8 @@ static int adxl367_init(const struct device *dev)
 		.inactivity_th.enable =							\
 			IS_ENABLED(CONFIG_ADXL367_INACTIVITY_DETECTION_MODE),		\
 		.inactivity_time = CONFIG_ADXL367_INACTIVITY_TIME,			\
-		.fifo_config.fifo_mode = ADXL367_FIFO_DISABLED,				\
+		.fifo_config.fifo_mode =						\
+		DT_INST_PROP_OR(inst, fifo_mode, ADXL367_FIFO_DISABLED),		\
 		.fifo_config.fifo_format = ADXL367_FIFO_FORMAT_XYZ,			\
 		.fifo_config.fifo_samples = 128,					\
 		.fifo_config.fifo_read_mode = ADXL367_14B_CHID,				\

--- a/drivers/sensor/adi/adxl367/adxl367.h
+++ b/drivers/sensor/adi/adxl367/adxl367.h
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/dt-bindings/sensor/adxl367.h>
 
 #define DT_DRV_COMPAT  adi_adxl367
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
@@ -280,10 +281,10 @@ enum adxl367_fifo_format {
 };
 
 enum adxl367_fifo_mode {
-	ADXL367_FIFO_DISABLED,
-	ADXL367_OLDEST_SAVED,
-	ADXL367_STREAM_MODE,
-	ADXL367_TRIGGERED_MODE
+	ADXL367_FIFO_DISABLED = ADXL367_FIFO_MODE_DISABLED,
+	ADXL367_OLDEST_SAVED = ADXL367_FIFO_MODE_OLDEST_SAVED,
+	ADXL367_STREAM_MODE = ADXL367_FIFO_MODE_STREAM,
+	ADXL367_TRIGGERED_MODE = ADXL367_FIFO_MODE_TRIGGERED
 };
 
 enum adxl367_fifo_read_mode {

--- a/dts/bindings/sensor/adi,adxl367-common.yaml
+++ b/dts/bindings/sensor/adi,adxl367-common.yaml
@@ -1,6 +1,22 @@
 # Copyright (c) 2023 Analog Devices Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+description: |
+  ADXL367 3-axis accelerometer
+  When setting the accelerometer DTS properties and want to use
+  streaming funcionality, make sure to include adxl367.h and
+  use the macros defined there for fifo-mode property.
+
+  Example:
+  #include <zephyr/dt-bindings/sensor/adxl367.h>
+
+  adxl367: adxl367@0 {
+    ...
+
+    fifo-mode = <ADXL367_FIFO_MODE_STREAM>;
+  };
+
+
 include: sensor-device.yaml
 
 properties:
@@ -29,3 +45,17 @@ properties:
       The INT1 signal defaults to active high as produced by the
       sensor.  The property value should ensure the flags properly
       describe the signal that is presented to the driver.
+
+  fifo-mode:
+    type: int
+    description: |
+          Accelerometer FIFO Mode.
+          0 # ADXL367_FIFO_MODE_DISABLED
+          1 # ADXL367_FIFO_MODE_OLDEST_SAVED
+          2 # ADXL367_FIFO_MODE_STREAM
+          3 # ADXL367_FIFO_MODE_TRIGGERED
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3

--- a/include/zephyr/dt-bindings/sensor/adxl367.h
+++ b/include/zephyr/dt-bindings/sensor/adxl367.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX367_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX367_H_
+
+/**
+ * @defgroup ADXL367 ADI DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @defgroup ADXL367_FIFO_MODE FIFO mode options
+ * @{
+ */
+#define ADXL367_FIFO_MODE_DISABLED        0x0
+#define ADXL367_FIFO_MODE_OLDEST_SAVED    0x1
+#define ADXL367_FIFO_MODE_STREAM          0x2
+#define ADXL367_FIFO_MODE_TRIGGERED       0x3
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX367_H_ */

--- a/samples/sensor/accel_polling/adxl367-stream.conf
+++ b/samples/sensor/accel_polling/adxl367-stream.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_RTIO=y
+CONFIG_SENSOR_ASYNC_API=y
+CONFIG_ADXL367_STREAM=y

--- a/samples/sensor/accel_polling/sample.yaml
+++ b/samples/sensor/accel_polling/sample.yaml
@@ -34,3 +34,10 @@ tests:
       - SNIPPET=rtt-tracing;rtt-console
     platform_allow:
       - apard32690/max32690/m4
+  sample.sensor.accel_polling.adxl367-stream:
+    extra_args:
+      - SHIELD="eval_adxl367_ardz"
+      - EXTRA_CONF_FILE="adxl367-stream.conf"
+      - SNIPPET="rtt-tracing;rtt-console"
+    platform_allow:
+      - apard32690/max32690/m4


### PR DESCRIPTION
Add a new shield definition for the Analog Devices EVAL-ADXL367-ARDZ
accelerometer shield. This shield provides support for an ADI ADXL367
accelerometer over an Arduino SPI connector.
Also adds adxl367 streaming configuration to accelerometer samples.

Signed-off-by: Vladislav Pejic vladislav.pejic@orioninc.com