### PR TITLE
kernel: init: bss clear nocache memory as well

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -247,6 +247,11 @@ void z_bss_zero(void)
 	z_early_memset(&__gcov_bss_start, 0,
 		       ((uintptr_t) &__gcov_bss_end - (uintptr_t) &__gcov_bss_start));
 #endif /* CONFIG_COVERAGE_GCOV */
+#ifdef CONFIG_NOCACHE_MEMORY
+z_early_memset(&_nocache_ram_start, 0,
+		   (uintptr_t) &_nocache_ram_end
+		   - (uintptr_t) &_nocache_ram_start);
+#endif
 }
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION


### PR DESCRIPTION
If a variable is tagged as nocache it didn't got zeroed on boot, which could lead some weird behaviour where bss memory is non-zero.

This PR zeroes the nocache region if `CONFIG_NOCACHE_MEMORY` is enabled

More particurly this fixes peripheral intitialization the S32K344 when doing a functional reset.