### PR TITLE
 stm32 xspi bindings fixes dtc warnings

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -235,9 +235,10 @@ zephyr_udc0: &usbotg_hs1 {
 		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
-	mx25um51245g: ospi-nor-flash@70000000 {
+	mx25um51245g: ospi-nor-flash@0 {
 		compatible = "st,stm32-xspi-nor";
-		reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(200)>;
 		spi-bus-width = <XSPI_OCTO_MODE>;
 		data-rate = <XSPI_DTR_TRANSFER>;

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -273,9 +273,10 @@
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@90000000 {
+	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-xspi-nor";
-		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		spi-bus-width = <XSPI_OCTO_MODE>;
 		data-rate = <XSPI_DTR_TRANSFER>;

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -250,9 +250,10 @@ zephyr_udc0: &usbotg_hs1 {
 		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
-	memc: aps256xxn_obr: memory@90000000 {
+	memc: aps256xxn_obr: memory@0 {
 		compatible = "st,stm32-xspi-psram";
-		reg = <0x90000000 DT_SIZE_M(32)>; /* 256 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(256)>; /* 256 Mbits */
 		fixed-latency;
 		io-x16-mode;
 		read-latency = <4>;
@@ -273,9 +274,10 @@ zephyr_udc0: &usbotg_hs1 {
 		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
-	mx66uw1g45g: ospi-nor-flash@70000000 {
+	mx66uw1g45g: ospi-nor-flash@0 {
 		compatible = "st,stm32-xspi-nor";
-		reg = <0x70000000 DT_SIZE_M(128)>; /* 1 Gbits */
+		reg = <0>;
+		size = <DT_SIZE_M(1024)>; /* 1Gbits */
 		ospi-max-frequency = <DT_FREQ_M(200)>;
 		spi-bus-width = <XSPI_OCTO_MODE>;
 		data-rate = <XSPI_DTR_TRANSFER>;

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -360,6 +360,19 @@ SPI
 * Renamed the device tree property ``port_sel`` to ``port-sel``.
 * Renamed the device tree property ``chip_select`` to ``chip-select``.
 
+xSPI
+====
+
+* On STM32 devices, external memories device tree descriptions for size and address are now split
+  in two separate properties to comply with specification recommendations.
+
+  For instance, following external flash description ``reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits /``
+  is changed to ``reg = <0>;`` ``size = <DT_SIZE_M(512)>; / 512 Mbits */``.
+
+  Note that the property gives the actual size of the memory device in bits.
+  Previous mapping address information is now described in xspi node at SoC dtsi level.
+
+
 Other subsystems
 ****************
 

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -37,8 +37,8 @@ LOG_MODULE_REGISTER(flash_stm32_xspi, CONFIG_FLASH_LOG_LEVEL);
 		    (_CONCAT(HAL_XSPIM_, DT_STRING_TOKEN(STM32_XSPI_NODE, prop))),	\
 		    ((default_value)))
 
-/* Get the base address of the flash from the DTS node */
-#define STM32_XSPI_BASE_ADDRESS DT_INST_REG_ADDR(0)
+/* Get the base address of the flash from the DTS st,stm32-xspi node */
+#define STM32_XSPI_BASE_ADDRESS DT_REG_ADDR_BY_IDX(STM32_XSPI_NODE, 1)
 
 #define STM32_XSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
@@ -2413,7 +2413,7 @@ static const struct flash_stm32_xspi_config flash_stm32_xspi_cfg = {
 	.pclken = pclken,
 	.pclk_len = DT_NUM_CLOCKS(STM32_XSPI_NODE),
 	.irq_config = flash_stm32_xspi_irq_config_func,
-	.flash_size = DT_INST_REG_SIZE(0),
+	.flash_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
 	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),
 	.data_mode = DT_INST_PROP(0, spi_bus_width), /* SPI or OPI */
 	.data_rate = DT_INST_PROP(0, data_rate), /* DTR or STR */

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -338,7 +338,7 @@ static const struct memc_stm32_xspi_psram_config memc_stm32_xspi_cfg = {
 	.pclken_mgr = {.bus = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspi_mgr, bus),
 		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspi_mgr, bits)},
 #endif
-	.memory_size = DT_INST_REG_ADDR_BY_IDX(0, 1),
+	.memory_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
 };
 
 static struct memc_stm32_xspi_psram_data memc_stm32_xspi_data = {

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -260,13 +260,13 @@
 
 		xspi1: spi@47001400 {
 			compatible = "st,stm32-xspi";
-			reg = <0x47001400 0x400>;
+			reg = <0x47001400 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <78 0>;
 			clock-names = "xspix", "xspi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB4, 20U)>,
 				<&rcc STM32_SRC_PLL1_Q OCTOSPI1_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -687,27 +687,27 @@
 
 		xspi1: xspi@58025000 {
 			compatible = "st,stm32-xspi";
-			reg = <0x58025000 0x1000>;
+			reg = <0x58025000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <170 0>;
 			clock-names = "xspix", "xspi-ker", "xspi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB5, 5)>,
 				 <&rcc STM32_SRC_HCLK5 XSPI1_SEL(0)>,
 				 <&rcc STM32_CLOCK(AHB5, 13)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 
 		xspi2: spi@5802a000 {
 			compatible = "st,stm32-xspi";
-			reg = <0x5802A000 0x1000>;
+			reg = <0x5802A000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <171 0>;
 			clock-names = "xspix", "xspi-ker", "xspi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
 				 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>,
 				 <&rcc STM32_CLOCK(AHB5, 13)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
@@ -23,6 +23,9 @@ include:
       - spi-bus-width
       - data-rate
 properties:
+  size:
+    required: true
+    description: Flash Memory size in bits
   spi-bus-width:
     type: int
     required: true

--- a/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
@@ -12,6 +12,11 @@ properties:
   reg:
     required: true
 
+  size:
+    type: int
+    required: true
+    description: Flash Memory size in bits
+
   fixed-latency:
     type: boolean
     description: |

--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -44,8 +44,8 @@
 /* On stm32 XSPI, external flash is mapped in XIP region at address given by the reg property. */
 
 #define EXTFLASH_NODE	DT_INST(0, st_stm32_xspi_nor)
-#define EXTFLASH_ADDR	DT_REG_ADDR(DT_INST(0, st_stm32_xspi_nor))
-#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_xspi_nor))
+#define EXTFLASH_ADDR	DT_REG_ADDR_BY_IDX(DT_PARENT(EXTFLASH_NODE), 1)
+#define EXTFLASH_SIZE	DT_PROP(EXTFLASH_NODE, size) / 8
 
 #elif defined(CONFIG_FLASH_MSPI_NOR) && defined(CONFIG_SOC_NRF54H20_CPUAPP)
 


### PR DESCRIPTION
This PR is for fixing the https://github.com/zephyrproject-rtos/zephyr/issues/88404  for the XSPI compatible

It changes the way the "st,stm32-xspi-nor" compatible declares the external flash base address and size.

The **"st,stm32-xspi"** node, gives the external memory base address and maximum allocated space (in bytes):
```
		xspi1: spi@47001400 {
			compatible = "st,stm32-xspi";
			reg = <0x47001400 0x400>, <0x90000000 0x10000000>;
```
The **"st,stm32-xspi-nor"** node, gives the external NOR device size in Bits through the `size` property
```
	mx25lm51245: ospi-nor-flash@0 {
		compatible = "st,stm32-xspi-nor";
		reg = <0>;
		size = <0x20000000>; /* 512 Mbits */
```

 