### PR TITLE
drivers: sensor: adxl362: FIFO mode from DT

### DIFF
--- a/boards/shields/eval_adxl362_ardz/eval_adxl362_ardz.overlay
+++ b/boards/shields/eval_adxl362_ardz/eval_adxl362_ardz.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/sensor/adxl362.h>
+
 &arduino_spi {
 	status = "okay";
 
@@ -12,6 +14,8 @@
 		reg = <0x0>;
 		spi-max-frequency = <DT_FREQ_M(1)>;
 		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_HIGH>;
+		fifo-mode = <ADXL362_FIFO_MODE_STREAM>;
+		fifo-watermark = <0x80>;
 		status = "okay";
 	};
 };

--- a/drivers/sensor/adi/adxl362/adxl362.c
+++ b/drivers/sensor/adi/adxl362/adxl362.c
@@ -717,7 +717,7 @@ static int adxl362_chip_init(const struct device *dev)
 	}
 
 	/* Configures the FIFO feature. */
-	ret = adxl362_fifo_setup(dev, ADXL362_FIFO_DISABLE, 0, 0);
+	ret = adxl362_fifo_setup(dev, config->fifo_mode, config->water_mark_lvl, 0);
 	if (ret) {
 		return ret;
 	}
@@ -821,7 +821,7 @@ static int adxl362_init(const struct device *dev)
 						ADXL362_SPI_CFG, 0U);                        \
 	RTIO_DEFINE(adxl362_rtio_ctx_##inst, 8, 8);
 
-#define ADXL362_DEFINE(inst)					\
+#define ADXL362_DEFINE(inst)\
 	IF_ENABLED(CONFIG_ADXL362_STREAM, (ADXL362_RTIO_DEFINE(inst)));                          \
 	static struct adxl362_data adxl362_data_##inst = {			\
 	IF_ENABLED(CONFIG_ADXL362_STREAM, (.rtio_ctx = &adxl362_rtio_ctx_##inst,                  \
@@ -832,6 +832,8 @@ static int adxl362_init(const struct device *dev)
 		.power_ctl = ADXL362_POWER_CTL_MEASURE(ADXL362_MEASURE_ON) |			\
 			(DT_INST_PROP(inst, wakeup_mode) * ADXL362_POWER_CTL_WAKEUP) |		\
 			(DT_INST_PROP(inst, autosleep) * ADXL362_POWER_CTL_AUTOSLEEP),		\
+		.fifo_mode = DT_INST_PROP_OR(inst, fifo_mode, ADXL362_FIFO_DISABLE),	\
+		.water_mark_lvl = DT_INST_PROP_OR(inst, fifo_watermark, 0x80),	\
 		IF_ENABLED(CONFIG_ADXL362_TRIGGER,						\
 			   (.interrupt = GPIO_DT_SPEC_INST_GET_OR(inst, int1_gpios, { 0 }),))	\
 	};											\

--- a/drivers/sensor/adi/adxl362/adxl362.h
+++ b/drivers/sensor/adi/adxl362/adxl362.h
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/drivers/sensor.h>
+#include <zephyr/dt-bindings/sensor/adxl362.h>
 
 #define ADXL362_SLAVE_ID    1
 
@@ -84,10 +85,10 @@
 #define ADXL362_FIFO_CTL_FIFO_MODE(x)       (((x) & 0x3) << 0)
 
 /* ADXL362_FIFO_CTL_FIFO_MODE(x) options */
-#define ADXL362_FIFO_DISABLE              0
-#define ADXL362_FIFO_OLDEST_SAVED         1
-#define ADXL362_FIFO_STREAM               2
-#define ADXL362_FIFO_TRIGGERED            3
+#define ADXL362_FIFO_DISABLE              ADXL362_FIFO_MODE_DISABLED
+#define ADXL362_FIFO_OLDEST_SAVED         ADXL362_FIFO_MODE_OLDEST_SAVED
+#define ADXL362_FIFO_STREAM               ADXL362_FIFO_MODE_STREAM
+#define ADXL362_FIFO_TRIGGERED            ADXL362_FIFO_MODE_TRIGGERED
 
 /* ADXL362_REG_INTMAP1 */
 #define ADXL362_INTMAP1_INT_LOW             (1 << 7)
@@ -188,6 +189,8 @@ struct adxl362_config {
 	uint8_t int2_config;
 #endif
 	uint8_t power_ctl;
+	uint8_t fifo_mode;
+	uint16_t water_mark_lvl;
 };
 
 struct adxl362_data {

--- a/drivers/sensor/adi/adxl362/adxl362_stream.c
+++ b/drivers/sensor/adi/adxl362/adxl362_stream.c
@@ -107,7 +107,8 @@ void adxl362_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 		}
 
 		if (fifo_mode == ADXL362_FIFO_DISABLE) {
-			fifo_mode = ADXL362_FIFO_STREAM;
+			LOG_ERR("ERROR: FIFO DISABLED");
+			return;
 		}
 
 		if (en_temp_read == 0) {

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -1,7 +1,20 @@
 # Copyright (c) 2018, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: ADXL362 3-axis SPI accelerometer
+description: |
+  ADXL362 3-axis SPI accelerometer
+  When setting the accelerometer DTS properties and want to use
+  streaming funcionality, make sure to include adxl362.h and
+  use the macros defined there for fifo-mode and fifo-watermark properties.
+
+  Example:
+  #include <zephyr/dt-bindings/sensor/adxl362.h>
+
+  adxl362: adxl362@0 {
+    ...
+    fifo-mode = <ADXL362_FIFO_MODE_STREAM>;
+    fifo-watermark = <0x80>;
+  };
 
 compatible: "adi,adxl362"
 
@@ -27,3 +40,23 @@ properties:
       Enter Wake-Up mode when inactivity is detected,
       reenter Measurement mode when activity is detected.
       Only applies for Linked and Loop mode, ignored otherwise.
+
+  fifo-mode:
+    type: int
+    description: |
+          Accelerometer FIFO Mode.
+          0 # ADXL362_FIFO_MODE_DISABLED
+          1 # ADXL362_FIFO_MODE_OLDEST_SAVED
+          2 # ADXL362_FIFO_MODE_STREAM
+          3 # ADXL362_FIFO_MODE_TRIGGERED
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  fifo-watermark:
+    type: int
+    description: |
+      Specify the FIFO watermark level in frame count.
+      Valid range: 0 - 511

--- a/include/zephyr/dt-bindings/sensor/adxl362.h
+++ b/include/zephyr/dt-bindings/sensor/adxl362.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX362_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX362_H_
+
+/**
+ * @defgroup ADXL362 ADI DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @defgroup ADXL362_FIFO_MODE FIFO mode options
+ * @{
+ */
+#define ADXL362_FIFO_MODE_DISABLED        0x0
+#define ADXL362_FIFO_MODE_OLDEST_SAVED    0x1
+#define ADXL362_FIFO_MODE_STREAM          0x2
+#define ADXL362_FIFO_MODE_TRIGGERED       0x3
+
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX362_H_ */


### PR DESCRIPTION
Adds support for setting FIFO mode from DT.

Signed-off-by: Vladislav Pejic vladislav.pejic@orioninc.com