### PR TITLE
drivers: sensor: adxl372: FIFO mode and watermark from DT and add streaming configuration

### DIFF
--- a/boards/shields/eval_adxl372_ardz/eval_adxl372_ardz.overlay
+++ b/boards/shields/eval_adxl372_ardz/eval_adxl372_ardz.overlay
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/sensor/adxl372.h>
+
+
 &arduino_spi {
 	status = "okay";
 
@@ -12,6 +15,8 @@
 		reg = <0x0>;
 		spi-max-frequency = <DT_FREQ_M(1)>;
 		int1-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;
+		fifo-mode = <ADXL372_FIFO_MODE_STREAMED>;
+		fifo-watermark = <0x80>;
 		status = "okay";
 	};
 };

--- a/drivers/sensor/adi/adxl372/adxl372.c
+++ b/drivers/sensor/adi/adxl372/adxl372.c
@@ -900,9 +900,11 @@ static int adxl372_init(const struct device *dev)
 		.inactivity_th.enable = 1,						\
 		.inactivity_time = CONFIG_ADXL372_INACTIVITY_TIME,			\
 		.filter_settle = ADXL372_FILTER_SETTLE_370,				\
-		.fifo_config.fifo_mode = ADXL372_FIFO_STREAMED,				\
-		.fifo_config.fifo_format = ADXL372_XYZ_PEAK_FIFO,			\
-		.fifo_config.fifo_samples = 128,					\
+		.fifo_config.fifo_mode =						\
+			DT_INST_PROP_OR(inst, fifo_mode, ADXL372_FIFO_BYPASSED),	\
+		.fifo_config.fifo_format = ADXL372_XYZ_FIFO,				\
+		.fifo_config.fifo_samples =						\
+			DT_INST_PROP_OR(inst, fifo_watermark, 0x80),			\
 		.op_mode = ADXL372_FULL_BW_MEASUREMENT,					\
 
 #define ADXL372_CONFIG_SPI(inst)					\

--- a/drivers/sensor/adi/adxl372/adxl372.h
+++ b/drivers/sensor/adi/adxl372/adxl372.h
@@ -13,6 +13,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/dt-bindings/sensor/adxl372.h>
 
 #ifdef CONFIG_ADXL372_STREAM
 #include <zephyr/rtio/rtio.h>
@@ -268,10 +269,10 @@ enum adxl372_fifo_format {
 };
 
 enum adxl372_fifo_mode {
-	ADXL372_FIFO_BYPASSED,
-	ADXL372_FIFO_STREAMED,
-	ADXL372_FIFO_TRIGGERED,
-	ADXL372_FIFO_OLD_SAVED
+	ADXL372_FIFO_BYPASSED = ADXL372_FIFO_MODE_BYPASSED,
+	ADXL372_FIFO_STREAMED = ADXL372_FIFO_MODE_STREAMED,
+	ADXL372_FIFO_TRIGGERED = ADXL372_FIFO_MODE_TRIGGERED,
+	ADXL372_FIFO_OLD_SAVED = ADXL372_FIFO_MODE_OLD_SAVED
 };
 
 struct adxl372_fifo_config {

--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -107,7 +107,8 @@ void adxl372_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 					data->fifo_config.fifo_samples);
 
 		if (current_fifo_mode == ADXL372_FIFO_BYPASSED) {
-			current_fifo_mode = ADXL372_FIFO_STREAMED;
+			LOG_ERR("ERROR: FIFO BYPASSED");
+			return;
 		}
 
 		adxl372_configure_fifo(dev, current_fifo_mode, data->fifo_config.fifo_format,

--- a/dts/bindings/sensor/adi,adxl372-common.yaml
+++ b/dts/bindings/sensor/adi,adxl372-common.yaml
@@ -3,6 +3,20 @@
 
 include: sensor-device.yaml
 
+description: |
+  ADXL372 3-axis SPI accelerometer
+  When setting the accelerometer DTS properties and want to use
+  streaming funcionality, make sure to include adxl372.h and
+  use the macros defined there for fifo-mode properties.
+
+  Example:
+  #include <zephyr/dt-bindings/sensor/adxl372.h>
+
+  adxl372: adxl372@0 {
+    ...
+    fifo-mode = <ADXL372_FIFO_MODE_STREAMED>;
+  };
+
 properties:
   odr:
     type: int
@@ -63,3 +77,23 @@ properties:
       The INT1 signal defaults to active high as produced by the
       sensor.  The property value should ensure the flags properly
       describe the signal that is presented to the driver.
+
+  fifo-mode:
+    type: int
+    description: |
+          Accelerometer FIFO Mode.
+          0 # ADXL372_FIFO_MODE_BYPASSED
+          1 # ADXL372_FIFO_MODE_STREAMED
+          2 # ADXL372_FIFO_MODE_TRIGGERED
+          3 # ADXL372_FIFO_MODE_OLD_SAVED
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  fifo-watermark:
+    type: int
+    description: |
+      Specify the FIFO watermark level in frame count.
+      Valid range: 0 - 512

--- a/include/zephyr/dt-bindings/sensor/adxl372.h
+++ b/include/zephyr/dt-bindings/sensor/adxl372.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Analog Devices Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX372_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX372_H_
+
+/**
+ * @defgroup ADXL372 ADI DT Options
+ * @ingroup sensor_interface
+ * @{
+ */
+
+/**
+ * @defgroup ADXL372_FIFO_MODE FIFO mode options
+ * @{
+ */
+
+#define ADXL372_FIFO_MODE_BYPASSED        0x0
+#define ADXL372_FIFO_MODE_STREAMED        0x1
+#define ADXL372_FIFO_MODE_TRIGGERED       0x2
+#define ADXL372_FIFO_MODE_OLD_SAVED       0x3
+
+/** @} */
+
+/** @} */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX372_H_ */

--- a/samples/sensor/accel_polling/adxl372-stream.conf
+++ b/samples/sensor/accel_polling/adxl372-stream.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_RTIO=y
+CONFIG_SENSOR_ASYNC_API=y
+CONFIG_ADXL372_STREAM=y

--- a/samples/sensor/accel_polling/sample.yaml
+++ b/samples/sensor/accel_polling/sample.yaml
@@ -41,3 +41,10 @@ tests:
       - SNIPPET="rtt-tracing;rtt-console"
     platform_allow:
       - apard32690/max32690/m4
+  sample.sensor.accel_polling.adxl372-stream:
+    extra_args:
+      - SHIELD="eval_adxl372_ardz"
+      - EXTRA_CONF_FILE="adxl372-stream.conf"
+      - SNIPPET="rtt-tracing;rtt-console"
+    platform_allow:
+      - apard32690/max32690/m4


### PR DESCRIPTION
Adds support for setting FIFO mode and watermark from DT.
Also adds adxl372 streaming configuration to accelerometer samples.

Signed-off-by: Vladislav Pejic vladislav.pejic@orioninc.com