### PR TITLE
samples: bluetooth: Increase number of buffers for avoiding deadlocks

### DIFF
--- a/samples/bluetooth/central_multilink/prj.conf
+++ b/samples/bluetooth/central_multilink/prj.conf
@@ -5,6 +5,9 @@ CONFIG_BT_PRIVACY=y
 
 CONFIG_BT_MAX_CONN=62
 
+# Increase the number of buffers to avoid deadlock when running out of buffers
+CONFIG_BT_BUF_CMD_TX_COUNT=2
+
 # CONFIG_BT_GATT_CLIENT=y
 
 # CONFIG_BT_SMP=y


### PR DESCRIPTION
The central_multilink sample issues various API calls (in particular because it does some from the system workqueue) this results in a deadlock since there are not enough HCI command buffers available,this is causing deadlocks on hardware that do not support BT_HCI_ACL_FLOW_CONTROL.