### PR TITLE
STM32N6:  Fix USB and UART build error

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -180,6 +180,7 @@
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
 };
 
 zephyr_udc0: &usbotg_hs1 {

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -197,6 +197,7 @@
 	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pf6>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
 };
 
 zephyr_udc0: &usbotg_hs1 {

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -459,7 +459,6 @@ static int usb_dc_stm32_clock_disable(void)
 static int usb_dc_stm32_init(void)
 {
 	HAL_StatusTypeDef status;
-	int ret;
 	unsigned int i;
 
 	usb_dc_stm32_state.pcd.Init.speed =
@@ -521,7 +520,7 @@ static int usb_dc_stm32_init(void)
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)
 	LOG_DBG("Pinctrl signals configuration");
-	ret = pinctrl_apply_state(usb_pcfg, PINCTRL_STATE_DEFAULT);
+	int ret = pinctrl_apply_state(usb_pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
 		LOG_ERR("USB pinctrl setup failed (%d)", ret);
 		return ret;


### PR DESCRIPTION
- Resolved the build error caused by the unused variable 'ret' for STM32N6 in usb_dc_stm32.c. The variable 'ret' was declared but not used, leading to an unused-variable warning treated as an error.
- Add missing USART status for nucleo_n657x0_q and stm32n6570_dk.