### PR TITLE
drivers: i2c: max32: fix i2c_configure to return 0 on success

### DIFF
--- a/drivers/i2c/i2c_max32.c
+++ b/drivers/i2c/i2c_max32.c
@@ -100,7 +100,7 @@ static int api_configure(const struct device *dev, uint32_t dev_cfg)
 		return -ENOTSUP;
 	}
 
-	return ret;
+	return ((ret > 0) ? 0 : -EIO);
 }
 
 #ifdef CONFIG_I2C_TARGET

--- a/drivers/i2c/i2c_max32_rtio.c
+++ b/drivers/i2c/i2c_max32_rtio.c
@@ -97,7 +97,7 @@ static int max32_do_configure(const struct device *dev, uint32_t dev_cfg)
 		return -ENOTSUP;
 	}
 
-	return ret;
+	return ((ret > 0) ? 0 : -EIO);
 }
 
 static void max32_complete(const struct device *dev, int status);


### PR DESCRIPTION
### Description
Enforce i2c_configure API return value so it complies with its definition (zero on success). This was caught by running i2c_ram test.

### Testing

- Setup
    - MAX32655 FTHR wired to a I2C FRAM (e.g: Adafruit's MB85RC256 breakout board: https://www.digikey.com/short/njtzwq2f)

- Build command
``` console
west build -b max32655fthr/max32655/m4 tests/drivers/i2c/i2c_ram/
```

- Overlay (`boards/max32655fthr_max32655_m4.overlay`)

``` dts
/ {
	aliases {
		i2c-ram = &i2c2;
	};
};
```

- Console Output
``` console
*** Booting Zephyr OS build v4.1.0-2421-gc86f7caa6188 ***
Running TESTSUITE i2c_ram
===================================================================
START - test_ram_transfer
ram using i2c_transfer from thread 0x20010048 addr 7
 PASS - test_ram_transfer in 0.007 seconds
===================================================================
START - test_ram_write_read
ram using i2c_write and i2c_write_read from thread 0x20010048 addr e
 PASS - test_ram_write_read in 0.009 seconds
===================================================================
TESTSUITE i2c_ram succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [i2c_ram]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.016 seconds
 - PASS - [i2c_ram.test_ram_transfer] duration = 0.007 seconds
 - PASS - [i2c_ram.test_ram_write_read] duration = 0.009 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```