### PR TITLE
NXP drivers: i2c_mcux_flexcomm: adds PM TURN_ON low-power recovery support

### DIFF
--- a/samples/sensor/thermometer/boards/frdm_rw612.conf
+++ b/samples/sensor/thermometer/boards/frdm_rw612.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_PM=y
+CONFIG_PM_DEVICE=y

--- a/samples/sensor/thermometer/boards/frdm_rw612.overlay
+++ b/samples/sensor/thermometer/boards/frdm_rw612.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Enable standby low power mode (AKA PM3, or Sleep mode) */
+&standby {
+	status = "okay";
+};


### PR DESCRIPTION
Enables Sleep mode (PM3) in RW61x.

Tested samples/sensor/thermometer on FRDM-RW612, I2C transfers continue every 1s, entering PM3 mode in between readings.