### PR TITLE
drivers: pwm: add support for enabling DMA requests

### DIFF
--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -1,6 +1,7 @@
 # PWM configuration options
 
 # Copyright (c) 2015 Intel Corporation
+# Copyright (c) 2025 Siemens SA
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PWM
@@ -38,6 +39,12 @@ config PWM_EVENT
 	help
 	  This option extends the Zephyr PWM API with the ability to configure
 	  and receive PWM events.
+
+config PWM_WITH_DMA
+	bool "Provide API for using PWM with DMA"
+	help
+	  This option extends the Zephyr PWM API with the ability to trigger DMA
+	  requests from PWM channels.
 
 # zephyr-keep-sorted-start
 source "drivers/pwm/Kconfig.ambiq_timer"

--- a/drivers/pwm/pwm_handlers.c
+++ b/drivers/pwm/pwm_handlers.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Intel Corporation
  * Copyright (c) 2020-2021 Vestas Wind Systems A/S
+ * Copyright (c) 2025 Siemens SA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -78,3 +79,22 @@ static inline int z_vrfy_pwm_capture_cycles(const struct device *dev,
 #include <zephyr/syscalls/pwm_capture_cycles_mrsh.c>
 
 #endif /* CONFIG_PWM_CAPTURE */
+
+#ifdef CONFIG_PWM_WITH_DMA
+static inline int z_vrfy_pwm_enable_dma(const struct device *dev,
+						uint32_t channel)
+{
+K_OOPS(K_SYSCALL_DRIVER_PWM(dev, enable_dma));
+return z_impl_pwm_enable_dma((const struct device *)dev, channel);
+}
+#include <zephyr/syscalls/pwm_enable_dma_mrsh.c>
+
+static inline int z_vrfy_pwm_disable_dma(const struct device *dev,
+						uint32_t channel)
+{
+K_OOPS(K_SYSCALL_DRIVER_PWM(dev, disable_dma));
+return z_impl_pwm_disable_dma((const struct device *)dev, channel);
+}
+#include <zephyr/syscalls/pwm_disable_dma_mrsh.c>
+
+#endif /* CONFIG_PWM_WITH_DMA */

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016 Linaro Limited.
  * Copyright (c) 2020 Teslabs Engineering S.L.
  * Copyright (c) 2023 Nobleo Technology
+ * Copyright (c) 2025 Siemens SA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -191,6 +192,18 @@ static uint32_t __maybe_unused (*const is_capture_active[])(TIM_TypeDef *) = {
 static void __maybe_unused (*const clear_capture_interrupt[])(TIM_TypeDef *) = {
 	LL_TIM_ClearFlag_CC1, LL_TIM_ClearFlag_CC2,
 	LL_TIM_ClearFlag_CC3, LL_TIM_ClearFlag_CC4
+};
+
+/* Channel to enable DMA request flag mapping. */
+static void __maybe_unused (*const enable_dma_interrupt[])(TIM_TypeDef *) = {
+	LL_TIM_EnableDMAReq_CC1, LL_TIM_EnableDMAReq_CC2,
+	LL_TIM_EnableDMAReq_CC3, LL_TIM_EnableDMAReq_CC4
+};
+
+/* Channel to disable DMA request flag mapping. */
+static void __maybe_unused (*const disable_dma_interrupt[])(TIM_TypeDef *) = {
+	LL_TIM_DisableDMAReq_CC1, LL_TIM_DisableDMAReq_CC2,
+	LL_TIM_DisableDMAReq_CC3, LL_TIM_DisableDMAReq_CC4
 };
 
 /**
@@ -630,6 +643,51 @@ static void pwm_stm32_isr(const struct device *dev)
 
 #endif /* CONFIG_PWM_CAPTURE */
 
+#ifdef CONFIG_PWM_WITH_DMA
+static int pwm_stm32_enable_dma(const struct device *dev,
+					uint32_t channel)
+{
+	const struct pwm_stm32_config *cfg = dev->config;
+
+	/* DMA requests are only supported on Capture/Compare channels.
+	 * However, these DMA request can also be used in PWM output mode to
+	 * dynamically update the duty cycle once per period. Therefore, enabling
+	 * or disabling DMA requests on PWM channels should not be limited to
+	 * Capture/Compare driver functions.
+	 */
+	if ((channel < 1u) || (channel > 4u)) {
+		LOG_ERR("DMA for PWM only exists on channels 1, 2, 3 and 4.");
+		return -ENOTSUP;
+	}
+
+	enable_dma_interrupt[channel - 1](cfg->timer);
+
+	return 0;
+}
+
+static int pwm_stm32_disable_dma(const struct device *dev,
+					uint32_t channel)
+{
+	const struct pwm_stm32_config *cfg = dev->config;
+
+	/* DMA requests are only supported on Capture/Compare channels.
+	 * However, these DMA requests can also be used in PWM output mode to
+	 * dynamically update the duty cycle once per period. Therefore, enabling
+	 * or disabling DMA requests on PWM channels should not be limited to
+	 * Capture/Compare driver functions.
+	 */
+	if ((channel < 1u) || (channel > 4u)) {
+		LOG_ERR("DMA for PWM only exists on channels 1, 2, 3 and 4.");
+		return -ENOTSUP;
+	}
+
+	disable_dma_interrupt[channel - 1](cfg->timer);
+
+	return 0;
+}
+
+#endif /* CONFIG_PWM_WITH_DMA */
+
 static int pwm_stm32_get_cycles_per_sec(const struct device *dev,
 					uint32_t channel, uint64_t *cycles)
 {
@@ -649,6 +707,10 @@ static DEVICE_API(pwm, pwm_stm32_driver_api) = {
 	.enable_capture = pwm_stm32_enable_capture,
 	.disable_capture = pwm_stm32_disable_capture,
 #endif /* CONFIG_PWM_CAPTURE */
+#ifdef CONFIG_PWM_WITH_DMA
+	.enable_dma = pwm_stm32_enable_dma,
+	.disable_dma = pwm_stm32_disable_dma,
+#endif /* CONFIG_PWM_WITH_DMA */
 };
 
 static int pwm_stm32_init(const struct device *dev)

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016 Intel Corporation.
  * Copyright (c) 2020-2021 Vestas Wind Systems A/S
  * Copyright (c) 2025 Basalte bv
+ * Copyright (c) 2025 Siemens SA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,7 +20,7 @@
  * @brief Interfaces for Pulse Width Modulation (PWM) controllers.
  * @defgroup pwm_interface PWM
  * @since 1.0
- * @version 1.0.0
+ * @version 1.1.0
  * @ingroup io_interfaces
  * @{
  *
@@ -527,6 +528,20 @@ typedef int (*pwm_manage_event_callback_t)(const struct device *dev,
 					   struct pwm_event_callback *callback, bool set);
 #endif /* CONFIG_PWM_EVENT */
 
+#ifdef CONFIG_PWM_WITH_DMA
+/**
+ * @brief PWM driver API call to enable PWM DMA requests.
+ * @see pwm_enable_dma() for argument description
+ */
+typedef int (*pwm_enable_dma_t)(const struct device *dev, uint32_t channel);
+
+/**
+ * @brief PWM driver API call to disable PWM DMA requests.
+ * @see pwm_disable_dma() for argument description
+ */
+typedef int (*pwm_disable_dma_t)(const struct device *dev, uint32_t channel);
+#endif /* CONFIG_PWM_WITH_DMA */
+
 /** @brief PWM driver API definition. */
 __subsystem struct pwm_driver_api {
 	pwm_set_cycles_t set_cycles;
@@ -539,6 +554,10 @@ __subsystem struct pwm_driver_api {
 #ifdef CONFIG_PWM_EVENT
 	pwm_manage_event_callback_t manage_event_callback;
 #endif /* CONFIG_PWM_EVENT */
+#ifdef CONFIG_PWM_WITH_DMA
+	pwm_enable_dma_t enable_dma;
+	pwm_disable_dma_t disable_dma;
+#endif /* CONFIG_PWM_WITH_DMA */
 };
 /** @endcond */
 
@@ -881,6 +900,56 @@ static inline int z_impl_pwm_disable_capture(const struct device *dev,
 	return api->disable_capture(dev, channel);
 }
 #endif /* CONFIG_PWM_CAPTURE */
+
+#if defined(CONFIG_PWM_WITH_DMA) || defined(__DOXYGEN__)
+/**
+ * @brief Enable DMA requests triggered by PWM cycles for a single PWM channel.
+ *
+ * @param[in] dev PWM device instance.
+ * @param channel PWM channel.
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL if invalid function parameters were given
+ * @retval -ENOSYS if DMA for PWM is not supported
+ * @retval -ENOTSUP if the PWM channel does not support DMA
+ */
+__syscall int pwm_enable_dma(const struct device *dev, uint32_t channel);
+
+static inline int z_impl_pwm_enable_dma(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_driver_api *api = (const struct pwm_driver_api *)dev->api;
+
+	if (api->enable_dma == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->enable_dma(dev, channel);
+}
+
+/**
+ * @brief Disable DMA requests triggered by PWM cycles for a single PWM channel.
+ *
+ * @param[in] dev PWM device instance.
+ * @param channel PWM channel.
+ *
+ * @retval 0 If successful.
+ * @retval -EINVAL if invalid function parameters were given
+ * @retval -ENOSYS if DMA for PWM is not supported
+ * @retval -ENOTSUP if the PWM channel does not support DMA
+ */
+__syscall int pwm_disable_dma(const struct device *dev, uint32_t channel);
+
+static inline int z_impl_pwm_disable_dma(const struct device *dev, uint32_t channel)
+{
+	const struct pwm_driver_api *api = (const struct pwm_driver_api *)dev->api;
+
+	if (api->disable_dma == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->disable_dma(dev, channel);
+}
+#endif /* CONFIG_PWM_WITH_DMA */
 
 /**
  * @brief Capture a single PWM period/pulse width in clock cycles for a single


### PR DESCRIPTION
Extends the PWM API with optional API functions for enabling DMA requests triggered by a given PWM channel.

Possible solution for #88670

Tested and verified on NUCLEO-WB55RG development board