### PR TITLE
Bluetooth: testlib: Fix includes (IWYU)

### DIFF
--- a/tests/bluetooth/common/testlib/include/testlib/addr.h
+++ b/tests/bluetooth/common/testlib/include/testlib/addr.h
@@ -6,7 +6,6 @@
 #define ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_ADDR_H_
 
 #include <stdint.h>
-
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/byteorder.h>
 

--- a/tests/bluetooth/common/testlib/include/testlib/att_read.h
+++ b/tests/bluetooth/common/testlib/include/testlib/att_read.h
@@ -6,7 +6,11 @@
 #define ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_ATT_READ_H_
 
 #include <stdint.h>
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/net_buf.h>
 
 /** Perform a single ATT_READ_BY_TYPE_REQ. */
 int bt_testlib_att_read_by_type_sync(struct net_buf_simple *result_data, uint16_t *result_size,

--- a/tests/bluetooth/common/testlib/include/testlib/att_write.h
+++ b/tests/bluetooth/common/testlib/include/testlib/att_write.h
@@ -6,6 +6,8 @@
 #define ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_ATT_WRITE_H_
 
 #include <stdint.h>
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/gatt.h>
 
 int bt_testlib_att_write(struct bt_conn *conn, enum bt_att_chan_opt bearer, uint16_t handle,

--- a/tests/bluetooth/common/testlib/include/testlib/conn.h
+++ b/tests/bluetooth/common/testlib/include/testlib/conn.h
@@ -5,6 +5,8 @@
 #ifndef ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_CONN_H_
 #define ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_CONN_H_
 
+#include <stdint.h>
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/conn.h>
 
 /**

--- a/tests/bluetooth/common/testlib/include/testlib/log_utils.h
+++ b/tests/bluetooth/common/testlib/include/testlib/log_utils.h
@@ -5,8 +5,13 @@
 #ifndef ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_LOG_UTILS_H_
 #define ZEPHYR_TESTS_BLUETOOTH_COMMON_TESTLIB_INCLUDE_TESTLIB_LOG_UTILS_H_
 
+#include <stddef.h>
+#include <stdint.h>
+#include <zephyr/autoconf.h>
+#include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util_macro.h>
 
 static inline void bt_testlib_log_level_set(char *module, uint32_t new_level)
 {

--- a/tests/bluetooth/common/testlib/src/adv.c
+++ b/tests/bluetooth/common/testlib/src/adv.c
@@ -2,14 +2,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/uuid.h>
-#include <zephyr/kernel.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/__assert.h>
 

--- a/tests/bluetooth/common/testlib/src/att.c
+++ b/tests/bluetooth/common/testlib/src/att.c
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-
+#include <stddef.h>
+#include <stdint.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
-#include <zephyr/bluetooth/att.h>
-
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 
 LOG_MODULE_REGISTER(bt_testlib_att, LOG_LEVEL_DBG);
 

--- a/tests/bluetooth/common/testlib/src/att_read.c
+++ b/tests/bluetooth/common/testlib/src/att_read.c
@@ -3,17 +3,21 @@
  */
 
 #include <stdint.h>
+#include <testlib/att_read.h>
+#include <zephyr/autoconf.h>
+#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
-#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/__assert.h>
-
-#include <testlib/att_read.h>
+#include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(bt_testlib_att_read, LOG_LEVEL_DBG);
 

--- a/tests/bluetooth/common/testlib/src/att_write.c
+++ b/tests/bluetooth/common/testlib/src/att_write.c
@@ -3,16 +3,18 @@
  */
 
 #include <stdint.h>
+#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
-#include <zephyr/bluetooth/att.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/__assert.h>
-
+#include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
+
 LOG_MODULE_REGISTER(bt_testlib_att_write, LOG_LEVEL_DBG);
 
 struct bt_testlib_att_write_closure {

--- a/tests/bluetooth/common/testlib/src/conn_ref.c
+++ b/tests/bluetooth/common/testlib/src/conn_ref.c
@@ -3,11 +3,11 @@
  */
 
 #include <stddef.h>
-
-#include <zephyr/bluetooth/conn.h>
-#include <zephyr/sys/atomic_builtin.h>
-
+#include <stdint.h>
 #include <testlib/conn.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic_builtin.h>
 
 /**
  * @file

--- a/tests/bluetooth/common/testlib/src/conn_wait.c
+++ b/tests/bluetooth/common/testlib/src/conn_wait.c
@@ -2,21 +2,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
 #include <stdint.h>
+#include <testlib/conn.h>
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
-#include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
-#include <zephyr/kernel.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util_macro.h>
 
-#include <testlib/conn.h>
-
-#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bt_testlib_conn_wait, LOG_LEVEL_DBG);
 
 static K_MUTEX_DEFINE(conn_wait_mutex);

--- a/tests/bluetooth/common/testlib/src/connect.c
+++ b/tests/bluetooth/common/testlib/src/connect.c
@@ -2,12 +2,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <errno.h>
+#include <stddef.h>
 #include <stdint.h>
-#include <zephyr/bluetooth/gatt.h>
-#include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
-
 #include <testlib/conn.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 
 LOG_MODULE_REGISTER(bt_testlib_connect, LOG_LEVEL_INF);
 

--- a/tests/bluetooth/common/testlib/src/disconnect.c
+++ b/tests/bluetooth/common/testlib/src/disconnect.c
@@ -2,14 +2,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "zephyr/sys/__assert.h"
 #include <stdint.h>
+#include <testlib/conn.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-
-#include <testlib/conn.h>
-
+#include <zephyr/sys/__assert.h>
 
 int bt_testlib_disconnect(struct bt_conn **connp, uint8_t reason)
 {

--- a/tests/bluetooth/common/testlib/src/scan.c
+++ b/tests/bluetooth/common/testlib/src/scan.c
@@ -2,13 +2,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+#include <testlib/scan.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gap.h>
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/__assert.h>
+#include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log.h>
-
-#include <testlib/scan.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
 
 LOG_MODULE_REGISTER(bt_testlib_scan, LOG_LEVEL_INF);
 

--- a/tests/bluetooth/common/testlib/src/security.c
+++ b/tests/bluetooth/common/testlib/src/security.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
 #include <stdint.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/conn.h>
@@ -9,8 +10,9 @@
 #include <zephyr/bluetooth/l2cap.h>
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/__assert.h>
+#include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
 
 LOG_MODULE_REGISTER(bt_testlib_security, LOG_LEVEL_INF);
 


### PR DESCRIPTION
This commit fixes all includes in testlib according to IWYU rules and sorts all includes in ascending order by name.