### PR TITLE
ci: bsim-tests: Add missing path to trigger BT tests

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -121,9 +121,10 @@ jobs:
         id: check-bluetooth-files
         with:
           files: |
-            tests/bsim/bluetooth/
             samples/bluetooth/
             subsys/bluetooth/
+            tests/bluetooth/common/testlib/
+            tests/bsim/bluetooth/
 
       - name: Check if Networking files changed
         uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 # v46.0.3


### PR DESCRIPTION
Also trigger the bluetooth tests if tests/bluetooth/common/testlib/ is changed.