### PR TITLE
manifest: hostap: Pull fix for certificate verify failure

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -274,7 +274,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 86044b5f2487a6c5e4a78e469eafa75bc61ef2e6
+      revision: fb6452c246b441434172235b2070259945ca9d44
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Disable hostname validation as a WAR for certificate verification failure for now.