### PR TITLE
boards: nordic: nrf7002dk: Fix LFXO configuration

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -134,6 +134,11 @@
 	status = "okay";
 };
 
+&lfxo {
+	load-capacitors = "internal";
+	load-capacitance-picofarad = <7>;
+};
+
 &adc {
 	status = "okay";
 };


### PR DESCRIPTION
Commit 6a2cbc7c875 ("boards: nrf53*: add L|HFXO configurations") missed the fix for nRF7002DK which is also based on nRF53 SoC.