### PR TITLE
sensor: icm45686: Add I2C-bus support

### DIFF
--- a/drivers/sensor/tdk/icm45686/Kconfig
+++ b/drivers/sensor/tdk/icm45686/Kconfig
@@ -6,8 +6,10 @@ menuconfig ICM45686
 	bool "ICM45686 High-precision 6-Axis Motion Tracking Device"
 	default y
 	depends on DT_HAS_INVENSENSE_ICM45686_ENABLED
-	select SPI
-	select SPI_RTIO
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),spi)
+	select SPI_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),spi)
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c)
+	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c)
 	help
 	  Enable driver for ICM45686 High-precision 6-axis motion
 	  tracking device.

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -183,7 +183,7 @@ static inline void icm45686_submit_one_shot(const struct device *dev,
 		return;
 	}
 
-	uint8_t val = REG_ACCEL_DATA_X1_UI | REG_SPI_READ_BIT;
+	uint8_t val = REG_ACCEL_DATA_X1_UI | REG_READ_BIT;
 
 	rtio_sqe_prep_tiny_write(write_sqe,
 				 data->rtio.iodev,

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -130,10 +130,16 @@ struct icm45686_stream {
 	} data;
 };
 
+enum icm45686_bus_type {
+	ICM45686_BUS_SPI,
+	ICM45686_BUS_I2C,
+};
+
 struct icm45686_data {
 	struct {
 		struct rtio_iodev *iodev;
 		struct rtio *ctx;
+		enum icm45686_bus_type type;
 	} rtio;
 	/** Single-shot encoded data instance to support fetch/get API */
 	struct icm45686_encoded_data edata;

--- a/drivers/sensor/tdk/icm45686/icm45686_bus.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_bus.h
@@ -36,6 +36,9 @@ static inline int icm45686_bus_read(const struct device *dev,
 	rtio_sqe_prep_write(write_sqe, iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
 	write_sqe->flags |= RTIO_SQE_TRANSACTION;
 	rtio_sqe_prep_read(read_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+	if (data->rtio.type == ICM45686_BUS_I2C) {
+		read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	}
 
 	err = rtio_submit(ctx, 2);
 	if (err) {
@@ -73,6 +76,9 @@ static inline int icm45686_bus_write(const struct device *dev,
 	rtio_sqe_prep_write(write_reg_sqe, iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
 	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
 	rtio_sqe_prep_write(write_buf_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
+	if (data->rtio.type == ICM45686_BUS_I2C) {
+		write_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+	}
 
 	err = rtio_submit(ctx, 2);
 	if (err) {

--- a/drivers/sensor/tdk/icm45686/icm45686_bus.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_bus.h
@@ -31,7 +31,7 @@ static inline int icm45686_bus_read(const struct device *dev,
 		return -ENOMEM;
 	}
 
-	reg = reg | REG_SPI_READ_BIT;
+	reg = reg | REG_READ_BIT;
 
 	rtio_sqe_prep_write(write_sqe, iodev, RTIO_PRIO_HIGH, &reg, 1, NULL);
 	write_sqe->flags |= RTIO_SQE_TRANSACTION;

--- a/drivers/sensor/tdk/icm45686/icm45686_reg.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_reg.h
@@ -13,7 +13,7 @@
 #include <zephyr/sys/byteorder.h>
 
 /* Address value has a read bit */
-#define REG_SPI_READ_BIT BIT(7)
+#define REG_READ_BIT BIT(7)
 
 /* Registers */
 /* Register Bank 0 */

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -188,7 +188,7 @@ static void icm45686_handle_event_actions(struct rtio *ctx,
 		buf->header.channels = 0x7F; /* Signal all channels are available */
 		buf->header.fifo_count = data->stream.data.fifo_count;
 
-		read_reg = REG_FIFO_DATA | REG_SPI_READ_BIT;
+		read_reg = REG_FIFO_DATA | REG_READ_BIT;
 		rtio_sqe_prep_tiny_write(data_wr_sqe,
 					 data->rtio.iodev,
 					 RTIO_PRIO_HIGH,
@@ -253,7 +253,7 @@ static void icm45686_handle_event_actions(struct rtio *ctx,
 			return;
 		}
 
-		uint8_t read_reg = REG_ACCEL_DATA_X1_UI | REG_SPI_READ_BIT;
+		uint8_t read_reg = REG_ACCEL_DATA_X1_UI | REG_READ_BIT;
 
 		rtio_sqe_prep_tiny_write(write_sqe,
 					 data->rtio.iodev,
@@ -360,7 +360,7 @@ static void icm45686_event_handler(const struct device *dev)
 	}
 
 	/** Directly read Status Register to determine what triggered the event */
-	val = REG_INT1_STATUS0 | REG_SPI_READ_BIT;
+	val = REG_INT1_STATUS0 | REG_READ_BIT;
 	rtio_sqe_prep_tiny_write(write_sqe,
 				 data->rtio.iodev,
 				 RTIO_PRIO_HIGH,
@@ -380,7 +380,7 @@ static void icm45686_event_handler(const struct device *dev)
 	/** Preemptively read FIFO count so we can decide on the next callback
 	 * how much FIFO data we'd read (if needed).
 	 */
-	val = REG_FIFO_COUNT_0 | REG_SPI_READ_BIT;
+	val = REG_FIFO_COUNT_0 | REG_READ_BIT;
 	rtio_sqe_prep_tiny_write(write_fifo_ct_sqe,
 				 data->rtio.iodev,
 				 RTIO_PRIO_HIGH,

--- a/dts/bindings/sensor/invensense,icm45686-common.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-common.yaml
@@ -3,28 +3,7 @@
 # Copyright (c) 2025 CogniPilot Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-    ICM45686 High-precision 6-axis motion tracking device
-    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
-    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
-    and use the macros defined there.
-
-    Example:
-    #include <zephyr/dt-bindings/sensor/icm45686.h>
-
-    icm42688: icm45686@0 {
-      ...
-
-      accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
-      accel-fs = <ICM45686_DT_ACCEL_FS_32>;
-      accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
-      gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
-      gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
-      gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
-    };
-
-compatible: "invensense,icm45686"
-include: [sensor-device.yaml, spi-device.yaml]
+include: sensor-device.yaml
 
 properties:
   int-gpios:

--- a/dts/bindings/sensor/invensense,icm45686-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-i2c.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 Croxel Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45686 High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i2c0 {
+      ...
+
+      icm42688: icm45686@68 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45686"
+
+include: ["i2c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/dts/bindings/sensor/invensense,icm45686-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-spi.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 Croxel Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45686 High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &spi0 {
+      ...
+
+      icm42688: icm45686@0 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45686"
+
+include: ["spi-device.yaml", "invensense,icm45686-common.yaml"]

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1290,3 +1290,9 @@ test_i2c_paj7620: paj7620@b0 {
 	reg = <0xb0>;
 	int-gpios = <&test_gpio 0 0>;
 };
+
+test_i2c_icm45686: icm45686@b1 {
+	compatible = "invensense,icm45686";
+	reg = <0xb1>;
+	int-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
### Description
This PR adds I2C bus support to ICM45686 driver, making it compatible with all existing driver functionality:
- Read/Decode.
- Trigger Support.
- Streaming Mode.

### Testing
- Run Shell sample on FRDM MCXN947 with Streaming mode enabled and validate sensor interaction:

- Build command:
``` console
west build -b frdm_mcxn947/mcxn947/cpu0 samples/subsys/shell/shell_module -- -DCONFIG_SENSOR=y -DCONFIG_SENSOR_SHELL=y -DCONFIG_ICM45686_STREAM=y -DCONFIG_SENSOR_SHELL_STREAM=y
```

- Overlay (`boards/frdm_mcxn947_mcxn947_cpu0.overlay`):
``` dts
#include <zephyr/dt-bindings/sensor/icm45686.h>

&flexcomm2_lpi2c2 {
	status = "okay";

	icm45686: icm45686@68 {
		compatible = "invensense,icm45686";
		reg = <0x68>;
		int-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;

		accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
		accel-fs = <ICM45686_DT_ACCEL_FS_2>;
		accel-odr = <ICM45686_DT_ACCEL_ODR_25>;
		accel-lpf = <ICM45686_DT_ACCEL_LPF_BW_1_32>;
		
		gyro-pwr-mode = <ICM45686_DT_GYRO_LN>;
		gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
		gyro-odr = <ICM45686_DT_GYRO_ODR_25>;
		gyro-lpf = <ICM45686_DT_GYRO_LPF_BW_1_32>;

		fifo-watermark = <25>;
	};
};
```

- Console output:
``` console
# Read/Decode validation
uart:~$ sensor get icm45686@68 
channel type=0(accel_x) index=0 shift=5 num_samples=1 value=55430013257ns (0.073022)
channel type=1(accel_y) index=0 shift=5 num_samples=1 value=55430013257ns (-0.195126)
channel type=2(accel_z) index=0 shift=5 num_samples=1 value=55430013257ns (9.810240)
channel type=3(accel_xyz) index=0 shift=5 num_samples=1 value=55430013257ns, (0.073022, -0.195126, 9.810240)
channel type=4(gyro_x) index=0 shift=12 num_samples=1 value=55430013257ns (0.000000)
channel type=5(gyro_y) index=0 shift=12 num_samples=1 value=55430013257ns (0.000000)
channel type=6(gyro_z) index=0 shift=12 num_samples=1 value=55430013257ns (0.000000)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=1 value=55430013257ns, (0.000000, 0.000000, 0.000000)
channel type=12(die_temp) index=0 shift=9 num_samples=1 value=55430013257ns (25.000000)
uart:~$ 

# Streaming validation
uart:~$ sensor stream icm45686@68 on fifo_wm incl
Disabling existing stream
Enabling stream...
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=95403523897ns, (0.076470, -0.191008, 9.810528)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=95403523897ns, (0.000429, -0.000871, -0.000247)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=95403523897ns (24.946859)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=96401679064ns, (0.075368, -0.188806, 9.809762)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=96401679064ns, (0.000471, -0.000669, -0.000291)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=96401679064ns (24.956521)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=97399794957ns, (0.086477, -0.190529, 9.809618)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=97399794957ns, (0.000051, -0.002565, -0.000268)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=97399794957ns (24.934782)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=98397860331ns, (0.093324, -0.190673, 9.809570)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=98397860331ns, (0.000286, -0.000797, -0.000226)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=98397860331ns (24.913042)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=99395940484ns, (0.093324, -0.191487, 9.808948)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=99395940484ns, (0.000343, -0.000722, -0.000238)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=99395940484ns (24.934782)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=100394029104ns, (0.093516, -0.191487, 9.808756)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=100394029104ns, (0.000333, -0.000791, -0.000242)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=100394029104ns (24.968598)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=101392128157ns, (0.092080, -0.191679, 9.811725)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=101392128157ns, (0.000482, 0.000495, -0.000291)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=101392128157ns (24.958936)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=102390202224ns, (0.076278, -0.189620, 9.808947)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=102390202224ns, (0.000137, -0.000169, -0.000322)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=102390202224ns (24.903381)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=103388262137ns, (0.076470, -0.190865, 9.810240)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=103388262137ns, (0.000307, -0.000827, -0.000280)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=103388262137ns (24.929950)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=104386362624ns, (0.076422, -0.191247, 9.809857)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=104386362624ns, (0.000322, -0.000684, -0.000188)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=104386362624ns (24.913042)
uart:~$ sensor stream icm45686@68 off
Disabling existing stream
[00:09:54.434,000] <wrn> ICM45686_STREAM: Callback triggered with no streaming submission - Disabling interrupts
uart:~$ 
```

- Scope capture of I2C bus with Streaming mode enabled. Interrupts every 1 sec (Watermark at 25, 25 HZ ODR):
![image](https://github.com/user-attachments/assets/6ef8ec02-4a76-4fe0-9c8a-6db84001dfd6)
