### PR TITLE
zbus: `ZBUS_WAITER_DEFINE`

### DIFF
--- a/include/zephyr/zbus/zbus.h
+++ b/include/zephyr/zbus/zbus.h
@@ -538,6 +538,30 @@ struct zbus_channel_observation {
 		.data = &_CONCAT(_zbus_obs_data_, _name),                                          \
 		.sem = (_sem)                                                                      \
 	}
+
+/**
+ * @brief Define and initialize a waiter on the stack.
+ *
+ * This macro defines an observer of waiter type that can exist on the stack and attached to
+ * a channel with @ref zbus_chan_add_obs.
+ *
+ * @param[in] _name The waiter's name.
+ * @param[in] _sem The semaphore given on channel publish.
+ */
+#define ZBUS_RUNTIME_WAITER_DEFINE(_name, _sem) \
+	struct zbus_observer_data _CONCAT(_zbus_obs_data_, _name) = {                              \
+		.enabled = true,                                                                   \
+		IF_ENABLED(CONFIG_ZBUS_PRIORITY_BOOST, (                                           \
+			.priority = ZBUS_MIN_THREAD_PRIORITY,                                      \
+		))                                                                                 \
+	};                                                                                         \
+	const struct zbus_observer _name = {                                                       \
+		ZBUS_OBSERVER_NAME_INIT(_name) /* Name field */                                    \
+		.type = ZBUS_OBSERVER_WAITER_TYPE,                                                 \
+		.data = &_CONCAT(_zbus_obs_data_, _name),                                          \
+		.sem = (_sem)                                                                      \
+	}
+
 /* clang-format on */
 
 /**

--- a/subsys/zbus/zbus.c
+++ b/subsys/zbus/zbus.c
@@ -134,6 +134,10 @@ static inline int _zbus_notify_observer(const struct zbus_channel *chan,
 	case ZBUS_OBSERVER_SUBSCRIBER_TYPE: {
 		return k_msgq_put(obs->queue, &chan, sys_timepoint_timeout(end_time));
 	}
+	case ZBUS_OBSERVER_WAITER_TYPE: {
+		k_sem_give(obs->sem);
+		break;
+	}
 #if defined(CONFIG_ZBUS_MSG_SUBSCRIBER)
 	case ZBUS_OBSERVER_MSG_SUBSCRIBER_TYPE: {
 		struct net_buf *cloned_buf = net_buf_clone(buf, sys_timepoint_timeout(end_time));

--- a/tests/subsys/zbus/unittests/src/main.c
+++ b/tests/subsys/zbus/unittests/src/main.c
@@ -86,6 +86,14 @@ ZBUS_CHAN_DEFINE(stuck_chan,      /* Name */
 		 ZBUS_MSG_INIT(0)      /* Initial value major 0, minor 1, build 1023 */
 );
 
+ZBUS_CHAN_DEFINE(msg_obs_sem,                      /* Name */
+		 int,                              /* Message type */
+		 NULL,                             /* Validator */
+		 NULL,                             /* User data */
+		 ZBUS_OBSERVERS(waiter1, waiter2), /* observers */
+		 ZBUS_MSG_INIT(0)                  /* Initial value 0 */
+);
+
 ZBUS_CHAN_DEFINE(msg_sub_fail_chan,                        /* Name */
 		 int,                                      /* Message type */
 		 NULL,                                     /* Validator */
@@ -224,6 +232,11 @@ static void wq_dh_cb(struct k_work *item)
 ZBUS_SUBSCRIBER_DEFINE(sub1, 1);
 ZBUS_MSG_SUBSCRIBER_DEFINE_WITH_ENABLE(foo_msg_sub, false);
 ZBUS_MSG_SUBSCRIBER_DEFINE_WITH_ENABLE(foo2_msg_sub, false);
+
+static K_SEM_DEFINE(sem1, 0, 2);
+static K_SEM_DEFINE(sem2, 0, 1);
+ZBUS_WAITER_DEFINE(waiter1, &sem1);
+ZBUS_WAITER_DEFINE_WITH_ENABLE(waiter2, &sem2, false);
 
 static K_FIFO_DEFINE(_zbus_observer_fifo_invalid_obs);
 
@@ -413,17 +426,21 @@ static bool check_chan_iterator(const struct zbus_channel *chan, void *user_data
 		zassert_mem_equal__(zbus_chan_name(chan), "hard_chan", 9, "Must be equal");
 		break;
 	case 5:
+		zassert_mem_equal__(zbus_chan_name(chan), "msg_obs_sem", sizeof("msg_obs_sem"),
+				    "Must be equal");
+		break;
+	case 6:
 		zassert_mem_equal__(zbus_chan_name(chan), "msg_sub_fail_chan",
 				    sizeof("msg_sub_fail_chan"), "Must be equal");
 		break;
-	case 6:
+	case 7:
 		zassert_mem_equal__(zbus_chan_name(chan), "msg_sub_no_pool_chan",
 				    sizeof("msg_sub_no_pool_chan"), "Must be equal");
 		break;
-	case 7:
+	case 8:
 		zassert_mem_equal__(zbus_chan_name(chan), "stuck_chan", 10, "Must be equal");
 		break;
-	case 8:
+	case 9:
 		zassert_mem_equal__(zbus_chan_name(chan), "version_chan", 12, "Must be equal");
 		break;
 	default:
@@ -474,6 +491,12 @@ static bool check_obs_iterator(const struct zbus_observer *obs, void *user_data)
 		break;
 	case 9:
 		zassert_mem_equal__(zbus_obs_name(obs), "sub1", 4, "Must be equal");
+		break;
+	case 10:
+		zassert_mem_equal__(zbus_obs_name(obs), "waiter1", 7, "Must be equal");
+		break;
+	case 11:
+		zassert_mem_equal__(zbus_obs_name(obs), "waiter2", 7, "Must be equal");
 		break;
 	default:
 		zassert_unreachable(NULL);
@@ -787,6 +810,45 @@ ZTEST(basic, test_specification_based__zbus_sub_wait_msg)
 	zassert_equal(-ENOMSG, zbus_sub_wait_msg(&foo_msg_sub, &chan, &a, K_MSEC(200)), NULL);
 
 	irq_offload(isr_sub_wait_msg, NULL);
+}
+
+ZTEST(basic, test_specification_based__zbus_obs_waiter)
+{
+	int data = 0;
+
+	/* Semaphores not given by default */
+	zassert_equal(-EBUSY, k_sem_take(&sem1, K_NO_WAIT));
+	zassert_equal(-EBUSY, k_sem_take(&sem2, K_NO_WAIT));
+
+	/* Publish to channel */
+	zassert_equal(0, zbus_chan_pub(&msg_obs_sem, &data, K_FOREVER));
+
+	/* First semaphore available, second waiter is not enabled */
+	zassert_equal(0, k_sem_take(&sem1, K_NO_WAIT));
+	zassert_equal(-EBUSY, k_sem_take(&sem2, K_NO_WAIT));
+
+	/* Enable second waiter */
+	zbus_obs_set_enable(&waiter2, true);
+
+	/* Publish again to channel */
+	zassert_equal(0, zbus_chan_pub(&msg_obs_sem, &data, K_FOREVER));
+
+	/* Both semaphores given */
+	zassert_equal(0, k_sem_take(&sem1, K_NO_WAIT));
+	zassert_equal(0, k_sem_take(&sem2, K_NO_WAIT));
+	zassert_equal(-EBUSY, k_sem_take(&sem1, K_NO_WAIT));
+	zassert_equal(-EBUSY, k_sem_take(&sem2, K_NO_WAIT));
+
+	/* Publish twice */
+	zassert_equal(0, zbus_chan_pub(&msg_obs_sem, &data, K_FOREVER));
+	zassert_equal(0, zbus_chan_pub(&msg_obs_sem, &data, K_FOREVER));
+
+	/* First semaphore should have 2 takes available due to its max_count value */
+	zassert_equal(0, k_sem_take(&sem1, K_NO_WAIT));
+	zassert_equal(0, k_sem_take(&sem1, K_NO_WAIT));
+	zassert_equal(0, k_sem_take(&sem2, K_NO_WAIT));
+	zassert_equal(-EBUSY, k_sem_take(&sem1, K_NO_WAIT));
+	zassert_equal(-EBUSY, k_sem_take(&sem2, K_NO_WAIT));
 }
 
 #if defined(CONFIG_ZBUS_PRIORITY_BOOST)


### PR DESCRIPTION
Add a new type of observer that can be used to wait on a channel until data is published.

### Is your enhancement proposal related to a problem? Please describe.

Waiting until new data is published on a channel currently requires polling in a loop or defining an observer of a different type that gives a semaphore in a dedicated  callback. This is verbose for such a simple use case.

### Describe the solution you'd like

This PR

### Describe alternatives you've considered

Static observers can use this pattern.
```
static K_SEM_DEFINE(chan_published, 0, 1);
static void callback1(const struct zbus_channel *chan)
{
   k_sem_give(&chan_published);
}
ZBUS_LISTENER_DEFINE(lis1, callback1);
```
Which is more verbose than:
```
static K_SEM_DEFINE(chan_published, 0, 1);
ZBUS_WAITER_DEFINE(waiter, &chan_published);
```
Runtime observers don't have a clear alternative, as there is no easy way to map the semaphore handle into the callback.