### PR TITLE
modules: fatfs: volume strings from DTS

### DIFF
--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -239,6 +239,7 @@ zephyr_udc0: &usbotg_hs {
 			&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };
 
 &quadspi {

--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -8,6 +8,8 @@
 #error "Configuration version mismatch"
 #endif
 
+#include <zephyr/devicetree.h>
+
 /*
  * Overrides of FF_ options from ffconf.h
  */
@@ -100,13 +102,21 @@
 #define FF_STR_VOLUME_ID 1
 
 /* By default FF_STR_VOLUME_ID in ffconf.h is 0, which means that
- * FF_VOLUME_STRS is not used. Zephyr uses FF_VOLUME_STRS, which
- * by default holds 8 possible strings representing mount points,
- * and FF_VOLUMES needs to reflect that, which means that dolt
- * value of 1 is overridden here with 8.
+ * FF_VOLUME_STRS is not used. Zephyr uses FF_VOLUME_STRS.
+ * The array of volume strings is automatically generated from devicetree.
  */
+
+#define _FF_DISK_NAME(node) DT_PROP(node, disk_name),
+
+#undef FF_VOLUME_STRS
+#define FF_VOLUME_STRS \
+	DT_FOREACH_STATUS_OKAY(zephyr_flash_disk, _FF_DISK_NAME) \
+	DT_FOREACH_STATUS_OKAY(zephyr_ram_disk, _FF_DISK_NAME) \
+	DT_FOREACH_STATUS_OKAY(zephyr_sdmmc_disk, _FF_DISK_NAME) \
+	DT_FOREACH_STATUS_OKAY(st_stm32_sdmmc, _FF_DISK_NAME)
+
 #undef FF_VOLUMES
-#define FF_VOLUMES 8
+#define FF_VOLUMES NUM_VA_ARGS_LESS_1(FF_VOLUME_STRS _)
 
 #if defined(CONFIG_FS_FATFS_EXTRA_NATIVE_API)
 #undef FF_USE_LABEL

--- a/tests/subsys/fs/lib_link/app.overlay
+++ b/tests/subsys/fs/lib_link/app.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	ramdisk0 {
+		compatible = "zephyr,ram-disk";
+		disk-name = "RAM";
+		sector-size = <512>;
+		sector-count = <80>;
+	};
+};


### PR DESCRIPTION
Instead of relying on a hardcoded list of valid strings, automatically create a perfectly sized array of disk names from devicetree.