### PR TITLE
tests: drivers: spi: Add support spi_controller_peripheral for Renesas RA

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra2a1.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra2a1.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra2a1.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra2a1.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 3, 4)>,
+				<RA_PSEL(RA_PSEL_SPI, 3, 3)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 11)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 2, 5)>,
+				<RA_PSEL(RA_PSEL_SPI, 2, 4)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 3)>;
+		};
+	};
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport1 12 GPIO_ACTIVE_LOW>;
+	interrupts = <24 1>, <25 1>, <26 1>, <27 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport2 6 GPIO_ACTIVE_LOW>;
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra4m1.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra4m1.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra4m1.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra4m1.overlay
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 4, 10)>,
+				<RA_PSEL(RA_PSEL_SPI, 4, 11)>,
+				<RA_PSEL(RA_PSEL_SPI, 4, 12)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 10)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 9)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 11)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 8)>;
+		};
+	};
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport4 13 GPIO_ACTIVE_LOW>;
+	interrupts = <23 1>, <24 1>, <25 1>, <26 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6e2.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6e2.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6e2.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6e2.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 2, 6)>,
+				<RA_PSEL(RA_PSEL_SPI, 2, 7)>,
+				<RA_PSEL(RA_PSEL_SPI, 3, 2)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 3)>;
+		};
+	};
+};
+
+&ioport1 {
+	status = "okay";
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport3 1 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m1.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m1.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m1.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m1.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 10)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 9)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 11)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 8)>;
+		};
+	};
+};
+
+&ioport1 {
+	status = "okay";
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport1 3 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m2.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m2.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m2.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m2.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 10)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 9)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 11)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 8)>;
+		};
+	};
+};
+
+&ioport1 {
+	status = "okay";
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport1 3 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m3.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m3.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m3.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m3.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 2, 2)>,
+				<RA_PSEL(RA_PSEL_SPI, 2, 3)>,
+				<RA_PSEL(RA_PSEL_SPI, 2, 4)>,
+				<RA_PSEL(RA_PSEL_SPI, 2, 5)>;
+		};
+	};
+};
+
+&ioport1 {
+	status = "okay";
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport1 3 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+	interrupts = <92 1>, <93 1>, <94 1>, <95 1>;
+	interrupt-names = "rxi", "txi", "tei", "eri";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m4.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m4.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m4.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m4.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 10)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 9)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 11)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 3)>;
+		};
+	};
+};
+
+&ioport1 {
+	status = "okay";
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport1 8 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m5.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m5.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m5.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/ek_ra6m5.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 10)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 9)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 11)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 3)>;
+		};
+	};
+};
+
+&ioport1 {
+	status = "okay";
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport1 8 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/fpb_ra6e2.conf
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/fpb_ra6e2.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI_INTERRUPT=y
+CONFIG_SPI_RA_DTC=y
+CONFIG_TESTED_SPI_MODE=1

--- a/tests/drivers/spi/spi_controller_peripheral/boards/fpb_ra6e2.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/fpb_ra6e2.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi0_default_alt: spi0_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK */
+			psels = <RA_PSEL(RA_PSEL_SPI, 2, 6)>,
+				<RA_PSEL(RA_PSEL_SPI, 2, 7)>,
+				<RA_PSEL(RA_PSEL_SPI, 3, 2)>;
+		};
+	};
+
+	spi1_default_alt: spi1_default_alt {
+		group1 {
+			/* MISO MOSI RSPCK SSL */
+			psels = <RA_PSEL(RA_PSEL_SPI, 1, 0)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 1)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 2)>,
+				<RA_PSEL(RA_PSEL_SPI, 1, 3)>;
+		};
+	};
+};
+
+&ioport1 {
+	status = "okay";
+};
+
+&spi0 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi0_default_alt>;
+	pinctrl-names = "default";
+	cs-gpios = <&ioport3 1 GPIO_ACTIVE_LOW>;
+
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+	};
+};
+
+dut_spis: &spi1 {
+	rx-dtc;
+	tx-dtc;
+	status = "okay";
+	pinctrl-0 = <&spi1_default_alt>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
Add support test app support `spi_controller_peripheral` for Renesas RA boards:
- RA6: ek_ra6m5, ek_ra6m4, ek_ra6m3, ek_ra6m2, ek_ra6m1, ek_ra6e2, fpb_ra6e2
- RA4: ek_ra4m1
- RA2: ek_ra2a1