### PR TITLE
tests: kernel: mslab: extend k_mem_slab_alloc() timeout

### DIFF
--- a/tests/kernel/mem_slab/mslab/src/main.c
+++ b/tests/kernel/mem_slab/mslab/src/main.c
@@ -247,7 +247,7 @@ ZTEST(memory_slab_1cpu, test_mslab)
 
 	TC_PRINT("%s: start to wait for block\n", __func__);
 	k_sem_give(&SEM_REGRESSDONE);    /* Allow helper thread to run part 4 */
-	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(50));
+	ret_value = k_mem_slab_alloc(&map_lgblks, &b, K_MSEC(180));
 	zassert_equal(0, ret_value,
 		      "Failed k_mem_slab_alloc, ret_value %d\n", ret_value);
 


### PR DESCRIPTION
Extend timeout on `k_mem_slab_alloc()` for `kernel.memory_slabs.memory_slab_1cpu.mslab` test suite as a workaround to allow its run on slow platforms, e.g. simulated intel_ish_5_8_0.

Alternative implementation for #58863 