### PR TITLE
manifest: Remove wrong remote

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -23,8 +23,6 @@ manifest:
       url-base: https://github.com/zephyrproject-rtos
     - name: babblesim
       url-base: https://github.com/BabbleSim
-    - name: nordicjm
-      url-base: https://github.com/nordicjm
 
   group-filter: [-babblesim, -optional]
 
@@ -291,7 +289,6 @@ manifest:
     - name: mcuboot
       revision: 58538ddfe21843edb39d7e7502812e61696e55c4
       path: bootloader/mcuboot
-      remote: nordicjm
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t
       groups:


### PR DESCRIPTION
Removes a remote which was accidentally included