### PR TITLE
drivers: timer: siwx91x: Remove sleeptimer as default soc timer

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_FAMILY_SILABS_SIWX91X
 
 configdefault SILABS_SLEEPTIMER_TIMER
-	default y
+	default y if PM
 
 configdefault CORTEX_M_SYSTICK
 	default n if SILABS_SLEEPTIMER_TIMER


### PR DESCRIPTION
Remove sleeptimer as default soc timer and it should be only used as soc timer if PM is enabled.