### PR TITLE
tests: robot: renode: Use precise pause for UART keywords

### DIFF
--- a/samples/subsys/shell/shell_module/shell_module.robot
+++ b/samples/subsys/shell/shell_module/shell_module.robot
@@ -7,7 +7,6 @@ Resource                      ${KEYWORDS}
 Should Read Version From Shell
     # `Prepare Machine` keyword comes from $ZEPHYR_BASE/tests/robot/common.robot file, which is imported as a resource
     Prepare Machine
-    Start Emulation
     Wait For Prompt On Uart   uart:~$
     Write Line To Uart        version
     Wait For Line On Uart     Zephyr version

--- a/tests/drivers/console/line_splitting/line_splitting.robot
+++ b/tests/drivers/console/line_splitting/line_splitting.robot
@@ -6,7 +6,6 @@ Resource                      ${KEYWORDS}
 *** Test Cases ***
 Should Split Lines
     Prepare Machine
-    Start Emulation
     Wait For Next Line On Uart
     Write Line To Uart          \rabc\nd\n               waitForEcho=false
     Wait For Line On Uart       getline: abc;

--- a/tests/robot/common.robot
+++ b/tests/robot/common.robot
@@ -4,4 +4,5 @@
 Prepare Machine
     Execute Command           $elf = ${ELF}
     Execute Command           include ${RESC}
-    Create Terminal Tester    ${UART}
+    Create Terminal Tester    ${UART}  defaultPauseEmulation=True
+    Write Char Delay          0.01


### PR DESCRIPTION
Remove the source of non-determinism during emulation by keeping terminal events reproducible between runs. By using the mechanism of precise pause in Renode emulator every interaction with terminal happens at the same virtual time from the perspective of an emulated system, hence makes it independent of the host. Otherwise the result of a test is susceptible to the load on the host and robot process keywords' timing.

Renode emulator supports precise pausing when specified sequence of characters is received on a terminal. Besides that, char delay parameter is specified to set time interval between consecutive characters entered in the terminal.
'Start Emulation' keyword is redundant, because 'Wait For' keywords automatically continue emulation up to the nearest pause event (e.g. matched pattern on the terminal).

Instability of `line_splitting.robot` test was observed on CI and mentioned in the issue below.
Fixes: #88396.