### PR TITLE
posix arch: Change kconfig menu prompt to be a bit clearer

### DIFF
--- a/arch/posix/Kconfig
+++ b/arch/posix/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2017 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-menu "POSIX (native) Options"
+menu "Native (POSIX) Architecture Options"
 	depends on ARCH_POSIX
 
 config ARCH


### PR DESCRIPTION
To avoid confusion with the POSIX OS compatibility shim layer.