### PR TITLE
doc: doxygen: cleanup root and move APIs into corrosponding groups

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -39,6 +39,12 @@
 @{
 @}
 
+@brief Debug Services
+@defgroup debug Debug
+@ingroup os_services
+@{
+@}
+
 @brief Connectivity
 @defgroup connectivity Connectivity
 @{

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1039,7 +1039,8 @@ RECURSIVE              = YES
 # run.
 
 EXCLUDE                = @ZEPHYR_BASE@/include/zephyr/portability/cmsis_os.h \
-                         @ZEPHYR_BASE@/include/zephyr/portability/cmsis_os2.h
+                         @ZEPHYR_BASE@/include/zephyr/portability/cmsis_os2.h \
+                         @ZEPHYR_BASE@/include/zephyr/drivers/wifi/nrf_wifi
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -1259,6 +1259,7 @@ void arch_spin_relax(void);
 /**
  * @defgroup arch-stackwalk Architecture-specific Stack Walk APIs
  * @ingroup arch-interface
+ * @brief Architecture-specific Stack Walk APIs
  *
  * To add API support to an architecture, `arch_stack_walk()` should be implemented and a non-user
  * configurable Kconfig `ARCH_HAS_STACKWALK` that is default to `y` should be created in the

--- a/include/zephyr/debug/coredump.h
+++ b/include/zephyr/debug/coredump.h
@@ -29,7 +29,7 @@
  * @file
  *
  * @defgroup coredump_apis Coredump APIs
- * @ingroup os_services
+ * @ingroup debug
  * @brief Coredump APIs
  * @{
  */

--- a/include/zephyr/debug/coresight/cs_trace_defmt.h
+++ b/include/zephyr/debug/coresight/cs_trace_defmt.h
@@ -14,6 +14,7 @@ extern "C" {
 
 /**
  * @defgroup coresight_apis Coresight APIs
+ * @ingroup debug
  * @{
  * @}
  * @defgroup cs_trace_defmt Coresight Trace Deformatter

--- a/include/zephyr/debug/cpu_load.h
+++ b/include/zephyr/debug/cpu_load.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif
 
 /** @defgroup cpu_load CPU load monitor
- *  @ingroup os_services
+ *  @ingroup debug
  *  @brief Module for monitoring CPU Load
  *
  *  This module allow monitoring of the CPU load.

--- a/include/zephyr/debug/mipi_stp_decoder.h
+++ b/include/zephyr/debug/mipi_stp_decoder.h
@@ -15,7 +15,7 @@ extern "C" {
 
 /**
  * @defgroup mipi_stp_decoder_apis STP Decoder API
- * @ingroup os_services
+ * @ingroup debug
  * @{
  */
 

--- a/include/zephyr/debug/symtab.h
+++ b/include/zephyr/debug/symtab.h
@@ -15,7 +15,7 @@ extern "C" {
 
 /**
  * @defgroup symtab_apis Symbol Table API
- * @ingroup os_services
+ * @ingroup debug
  * @{
  */
 

--- a/include/zephyr/debug/thread_analyzer.h
+++ b/include/zephyr/debug/thread_analyzer.h
@@ -15,7 +15,7 @@ extern "C" {
 #endif
 
 /** @defgroup thread_analyzer Thread analyzer
- *  @ingroup os_services
+ *  @ingroup debug
  *  @brief Module for analyzing threads
  *
  *  This module implements functions and the configuration that simplifies

--- a/include/zephyr/drivers/sensor/battery.h
+++ b/include/zephyr/drivers/sensor/battery.h
@@ -19,8 +19,9 @@ extern "C" {
 #endif
 
 /**
- * @brief battery API
- * @defgroup battery_apis battery APIs
+ * @brief Battery API
+ * @defgroup battery_apis Battery APIs
+ * @ingroup sensor_interface
  * @{
  */
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5801,6 +5801,7 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 
 /**
  * @defgroup heap_apis Heap APIs
+ * @brief Memory allocation from the Heap
  * @ingroup kernel_apis
  * @{
  */
@@ -5958,6 +5959,8 @@ enum _poll_states_bits {
 
 /**
  * @defgroup poll_apis Async polling APIs
+ * @brief An API to wait concurrently for any one of multiple conditions to be
+ *        fulfilled
  * @ingroup kernel_apis
  * @{
  */

--- a/include/zephyr/kernel_version.h
+++ b/include/zephyr/kernel_version.h
@@ -18,6 +18,8 @@ extern "C" {
  * @ingroup kernel_apis
  * @{
  *
+ * @brief Kernel Version APIs
+ *
  * The kernel version has been converted from a string to a four-byte
  * quantity that is divided into two parts.
  *

--- a/include/zephyr/logging/log_frontend_stmesp_demux.h
+++ b/include/zephyr/logging/log_frontend_stmesp_demux.h
@@ -16,6 +16,7 @@ extern "C" {
 
 /**
  * @defgroup log_frontend_stmesp_apis Trace and Debug Domain APIs
+ * @ingroup logging
  * @{
  * @}
  * @defgroup log_frontend_stpesp_demux_apis Logging frontend STMESP Demultiplexer API

--- a/include/zephyr/sys/mutex.h
+++ b/include/zephyr/sys/mutex.h
@@ -35,7 +35,7 @@ struct sys_mutex {
 
 /**
  * @defgroup user_mutex_apis User mode mutex APIs
- * @ingroup kernel_apis
+ * @ingroup usermode_apis
  * @{
  */
 

--- a/include/zephyr/sys/notify.h
+++ b/include/zephyr/sys/notify.h
@@ -73,7 +73,7 @@ struct sys_notify;
 
 /**
  * @defgroup sys_notify_apis Asynchronous Notification APIs
- * @ingroup kernel_apis
+ * @ingroup os_services
  * @{
  */
 

--- a/include/zephyr/sys/onoff.h
+++ b/include/zephyr/sys/onoff.h
@@ -18,7 +18,7 @@ extern "C" {
 
 /**
  * @defgroup resource_mgmt_onoff_apis On-Off Service APIs
- * @ingroup kernel_apis
+ * @ingroup os_services
  * @{
  */
 

--- a/include/zephyr/sys/sem.h
+++ b/include/zephyr/sys/sem.h
@@ -43,7 +43,7 @@ struct sys_sem {
 
 /**
  * @defgroup user_semaphore_apis User mode semaphore APIs
- * @ingroup kernel_apis
+ * @ingroup usermode_apis
  * @{
  */
 


### PR DESCRIPTION
doxygen group cleanup and fixes

https://builds.zephyrproject.io/zephyr/pr/88712/docs/doxygen/html/