### PR TITLE
tests: drivers: display: display_read_write: controlling execution with fixture

### DIFF
--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -5,7 +5,9 @@ common:
   tags:
     - drivers
     - display
-  harness: display
+  harness: ztest
+  harness_config:
+    fixture: display
 tests:
   drivers.display.read_write.sdl.argb8888:
     platform_allow:


### PR DESCRIPTION
Currently, test execution can be suppressed by `harness: display`, but since the display harness does not exist, there is no way to run tests.
Using a fixture, it will be possible only to build if not specified, and run tests if specified.

---

It is known that if we introduce this and run the test, it will fail. I have created a separate #88714 for this.