### PR TITLE
drivers: stm32_hal: stm32_rng Fix compile errors for stm32l4 rng.

### DIFF
--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -232,10 +232,17 @@ static void configure_rng(void)
 		LL_RNG_SetHealthConfig(rng, desired_htcr);
 #endif /* health_test_config */
 
+#if defined(CONFIG_SOC_SERIES_STM32L4X)
+		LL_RNG_ResetConditioningResetBit(rng);
+		/* Wait for conditioning reset process to be completed */
+		while (LL_RNG_IsResetConditioningBitSet(rng) == 1) {
+		}
+#else
 		LL_RNG_DisableCondReset(rng);
 		/* Wait for conditioning reset process to be completed */
 		while (LL_RNG_IsEnabledCondReset(rng) == 1) {
 		}
+#endif /* CONFIG_SOC_SERIES_STM32L4X */
 	}
 #endif /* STM32_CONDRST_SUPPORT */
 
@@ -285,13 +292,23 @@ static int recover_seed_error(RNG_TypeDef *rng)
 {
 	uint32_t count_timeout = 0;
 
-	LL_RNG_EnableCondReset(rng);
-	LL_RNG_DisableCondReset(rng);
+#if defined(CONFIG_SOC_SERIES_STM32L4X)
+		LL_RNG_SetConditioningResetBit(rng);
+		LL_RNG_ResetConditioningResetBit(rng);
+#else
+		LL_RNG_EnableCondReset(rng);
+		LL_RNG_DisableCondReset(rng);
+#endif /* CONFIG_SOC_SERIES_STM32L4X */
+
 	/* When reset process is done cond reset bit is read 0
 	 * This typically takes: 2 AHB clock cycles + 2 RNG clock cycles.
 	 */
 
+#if defined(CONFIG_SOC_SERIES_STM32L4X)
+	while (LL_RNG_IsResetConditioningBitSet(rng) ||
+#else
 	while (LL_RNG_IsEnabledCondReset(rng) ||
+#endif /* CONFIG_SOC_SERIES_STM32L4X */
 		ll_rng_is_active_seis(rng) ||
 		ll_rng_is_active_secs(rng)) {
 		count_timeout++;


### PR DESCRIPTION
The low level function names in the stm32l4xx low level driver are different than all the other stm32's even though the functionality is the same. This breaks the entropy module for these parts. This patch fixes the build and has been tested on a custom stm32l4p5 board.

Fixes: #88621