### PR TITLE
drivers: sensor: qdec_stm32: add sensor channel for raw encoder counts

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -116,6 +116,7 @@ static const char *const sensor_channel_name[SENSOR_CHAN_COMMON_COUNT] = {
 	[SENSOR_CHAN_GAME_ROTATION_VECTOR] = "game_rotation_vector",
 	[SENSOR_CHAN_GRAVITY_VECTOR] = "gravity_vector",
 	[SENSOR_CHAN_GBIAS_XYZ] = "gbias_xyz",
+	[SENSOR_CHAN_ENCODER_COUNT] = "encoder_count",
 	[SENSOR_CHAN_ALL] = "all",
 };
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -210,6 +210,9 @@ enum sensor_channel {
 	/** Gyroscope bias (X/Y/Z components in radians/s) */
 	SENSOR_CHAN_GBIAS_XYZ,
 
+	/** Raw quadrature decoder count, in counts */
+	SENSOR_CHAN_ENCODER_COUNT,
+
 	/** All channels. */
 	SENSOR_CHAN_ALL,
 


### PR DESCRIPTION
Add a sensor channel for the encoder counts. This is useful for reading the encoder counts and calculating an absolute position of a linear actuator.