### PR TITLE
net: lib: zperf: fix internal UDP header definition

### DIFF
--- a/doc/connectivity/networking/api/zperf.rst
+++ b/doc/connectivity/networking/api/zperf.rst
@@ -13,13 +13,8 @@ Overview
 zperf is a shell utility which allows to generate network traffic in Zephyr. The
 tool may be used to evaluate network bandwidth.
 
-zperf is compatible with iPerf_2.0.5. Note that in newer iPerf versions,
-an error message like this is printed and the server reported statistics
-are missing.
-
-.. code-block:: console
-
-   LAST PACKET NOT RECEIVED!!!
+zperf is compatible with iPerf 2.0.10 and newer. For compatability with older versions,
+enable :kconfig:option:`CONFIG_NET_ZPERF_LEGACY_HEADER_COMPAT`.
 
 zperf can be enabled in any application, a dedicated sample is also present
 in Zephyr. See :zephyr:code-sample:`zperf sample application <zperf>` for details.

--- a/samples/net/zperf/README.rst
+++ b/samples/net/zperf/README.rst
@@ -13,13 +13,8 @@ allows to evaluate network bandwidth.
 Features
 *********
 
-- Compatible with iPerf_2.0.5. Note that in newer iPerf versions,
-  an error message like this is printed and the server reported statistics
-  are missing.
-
-.. code-block:: console
-
-   LAST PACKET NOT RECEIVED!!!
+- Compatible with iPerf v2.0.10 and newer. For older versions, enable
+  :kconfig:option:`CONFIG_NET_ZPERF_LEGACY_HEADER_COMPAT`.
 
 - Client or server mode allowed without need to modify the source code.
 
@@ -50,7 +45,7 @@ sample does not fit into target platform RAM, reduce the following configs:
 Requirements
 ************
 
-- iPerf 2.0.5 installed on the host machine
+- iPerf 2.0.10 or newer installed on the host machine
 - Supported board
 
 Depending on the network technology chosen, extra steps may be required

--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -13,6 +13,14 @@ menuconfig NET_ZPERF
 
 if NET_ZPERF
 
+config NET_ZPERF_LEGACY_HEADER_COMPAT
+	bool "Legacy iperf UDP header format"
+	help
+	  iperf 2.0.10 (2017) updated the UDP header format in a
+	  backwards incompatible manner that cannot be automatically
+	  detected. This option reverts the header format for use with
+	  iperf version 2.0.9 and earlier.
+
 config ZPERF_WORK_Q_THREAD_PRIORITY
 	int "zperf work queue thread priority"
 	default NUM_PREEMPT_PRIORITIES

--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -64,6 +64,11 @@ struct zperf_udp_datagram {
 
 BUILD_ASSERT(sizeof(struct zperf_udp_datagram) <= PACKET_SIZE_MAX, "Invalid PACKET_SIZE_MAX");
 
+#define ZPERF_FLAGS_VERSION1      0x80000000
+#define ZPERF_FLAGS_EXTEND        0x40000000
+#define ZPERF_FLAGS_UDPTESTS      0x20000000
+#define ZPERF_FLAGS_SEQNO64B      0x08000000
+
 struct zperf_client_hdr_v1 {
 	int32_t flags;
 	int32_t num_of_threads;

--- a/subsys/net/lib/zperf/zperf_internal.h
+++ b/subsys/net/lib/zperf/zperf_internal.h
@@ -54,9 +54,12 @@
 #define ZPERF_VERSION "1.1"
 
 struct zperf_udp_datagram {
-	int32_t id;
+	uint32_t id;
 	uint32_t tv_sec;
 	uint32_t tv_usec;
+#ifndef CONFIG_NET_ZPERF_LEGACY_HEADER_COMPAT
+	uint32_t id2;
+#endif
 } __packed;
 
 BUILD_ASSERT(sizeof(struct zperf_udp_datagram) <= PACKET_SIZE_MAX, "Invalid PACKET_SIZE_MAX");

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -25,6 +25,7 @@ static inline void zperf_upload_decode_stat(const uint8_t *data,
 					    struct zperf_results *results)
 {
 	struct zperf_server_hdr *stat;
+	uint32_t flags;
 
 	if (datalen < sizeof(struct zperf_udp_datagram) +
 		      sizeof(struct zperf_server_hdr)) {
@@ -33,6 +34,10 @@ static inline void zperf_upload_decode_stat(const uint8_t *data,
 
 	stat = (struct zperf_server_hdr *)
 			(data + sizeof(struct zperf_udp_datagram));
+	flags = ntohl(UNALIGNED_GET(&stat->flags));
+	if (!(flags & ZPERF_FLAGS_VERSION1)) {
+		NET_WARN("Unexpected response flags");
+	}
 
 	results->nb_packets_rcvd = ntohl(UNALIGNED_GET(&stat->datagrams));
 	results->nb_packets_lost = ntohl(UNALIGNED_GET(&stat->error_cnt));


### PR DESCRIPTION
Fix the zperf UDP datagram header definition, which has had the following definition in the `iperf` repo since at least October 2019. https://sourceforge.net/p/iperf2/code/ci/master/tree/include/payloads.h#l165
```
struct UDP_datagram {
// used to reference the 4 byte ID number we place in UDP datagrams
// Support 64 bit seqno on machines that support them
    uint32_t id;
    uint32_t tv_sec;
    uint32_t tv_usec;
    uint32_t id2;
};
```
The response decoding was testd with a nRF7002 client and `iperf-2.2.1-win64.exe` server, with the output statistics struct now containing the same information as reported on the PC server.

Output a warning if the server response does not have the expected header flag set.

Powershell server:
![image](https://github.com/user-attachments/assets/71ee00f0-99dd-473e-9a61-21b737facd35)
Embedded decoding response:
![image](https://github.com/user-attachments/assets/ee96cc92-1d0f-4be7-af7f-9319ce585559)


