### PR TITLE
dts: common: nordic: nrf52840_partitions: Use equal partitions

### DIFF
--- a/dts/common/nordic/nrf52840_partition.dtsi
+++ b/dts/common/nordic/nrf52840_partition.dtsi
@@ -25,12 +25,12 @@
 
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00077000>;
+			reg = <0x0000C000 0x00076000>;
 		};
 
-		slot1_partition: partition@83000 {
+		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x00083000 0x00075000>;
+			reg = <0x00082000 0x00076000>;
 		};
 
 		/*


### PR DESCRIPTION
Switches back to equal sized partitions, this fixes an issue whereby the number of overhead sectors for a swap mode was incorrectly listed as 2 when it should have been 1, and also allows using any swap mode. This means that when using swap using mode, 1 sector in the secondary partition will be unusable, and when using swap using offset, 1 sector in the primary partition will be unusable