### PR TITLE
shell: backends: uart: Fix case when needs to be re-enabled

### DIFF
--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -70,6 +70,7 @@ struct shell_uart_async {
 	struct uart_async_rx async_rx;
 	struct uart_async_rx_config async_rx_config;
 	atomic_t pending_rx_req;
+	bool rx_enabled;
 	uint8_t rx_data[ASYNC_RX_BUF_SIZE];
 };
 

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -33,6 +33,19 @@ NET_BUF_POOL_DEFINE(smp_shell_rx_pool, CONFIG_MCUMGR_TRANSPORT_SHELL_RX_BUF_COUN
 		    SMP_SHELL_RX_BUF_SIZE, 0, NULL);
 #endif /* CONFIG_MCUMGR_TRANSPORT_SHELL */
 
+static int rx_enable(const struct device *dev, struct shell_uart_async *sh_uart,
+		     uint8_t *buf, size_t len)
+{
+	int err = uart_rx_enable(dev, buf, len, CONFIG_SHELL_BACKEND_SERIAL_ASYNC_RX_TIMEOUT);
+
+	if (err == 0) {
+		sh_uart->rx_enabled = true;
+		sh_uart->pending_rx_req = 0;
+	}
+
+	return err;
+}
+
 static void async_callback(const struct device *dev, struct uart_event *evt, void *user_data)
 {
 	struct shell_uart_async *sh_uart = (struct shell_uart_async *)user_data;
@@ -66,7 +79,21 @@ static void async_callback(const struct device *dev, struct uart_event *evt, voi
 		uart_async_rx_on_buf_rel(&sh_uart->async_rx, evt->data.rx_buf.buf);
 		break;
 	case  UART_RX_DISABLED:
+	{
+		uint8_t *buf = uart_async_rx_buf_req(&sh_uart->async_rx);
+		size_t len;
+		int err;
+
+		sh_uart->rx_enabled = false;
+		if (buf) {
+			len = uart_async_rx_get_buf_len(&sh_uart->async_rx);
+			err = rx_enable(dev, sh_uart, buf, len);
+			(void)err;
+			__ASSERT_NO_MSG(err == 0);
+		}
+
 		break;
+	}
 	default:
 		break;
 	};
@@ -231,12 +258,6 @@ static void irq_init(struct shell_uart_int_driven *sh_uart)
 	}
 }
 
-static int rx_enable(const struct device *dev, uint8_t *buf, size_t len)
-{
-	return uart_rx_enable(dev, buf, len,
-			      CONFIG_SHELL_BACKEND_SERIAL_ASYNC_RX_TIMEOUT);
-}
-
 static void async_init(struct shell_uart_async *sh_uart)
 {
 	const struct device *dev = sh_uart->common.dev;
@@ -261,7 +282,7 @@ static void async_init(struct shell_uart_async *sh_uart)
 	(void)err;
 	__ASSERT_NO_MSG(err == 0);
 
-	err = rx_enable(dev, buf, uart_async_rx_get_buf_len(async_rx));
+	err = rx_enable(dev, sh_uart, buf, uart_async_rx_get_buf_len(async_rx));
 	(void)err;
 	__ASSERT_NO_MSG(err == 0);
 }
@@ -297,6 +318,7 @@ static int init(const struct shell_transport *transport,
 	int ret;
 
 	common->dev = (const struct device *)config;
+
 	common->handler = evt_handler;
 	common->context = context;
 
@@ -490,22 +512,31 @@ static int async_read(struct shell_uart_async *sh_uart,
 	buf_available = uart_async_rx_data_consume(async_rx, blen);
 #endif
 
-	if (sh_uart->pending_rx_req && buf_available) {
-		uint8_t *buf = uart_async_rx_buf_req(async_rx);
-		size_t len = uart_async_rx_get_buf_len(async_rx);
+	if (!buf_available) {
+		return 0;
+	}
+
+	buf = uart_async_rx_buf_req(async_rx);
+	blen = uart_async_rx_get_buf_len(async_rx);
+
+	__ASSERT_NO_MSG(buf != NULL);
+
+	if (!sh_uart->rx_enabled) {
+		/* If it is too late and RX is disabled then re-enable it. */
+		return rx_enable(sh_uart->common.dev, sh_uart, buf, blen);
+	}
+
+	if (sh_uart->pending_rx_req) {
 		int err;
 
-		__ASSERT_NO_MSG(buf != NULL);
 		atomic_dec(&sh_uart->pending_rx_req);
-		err = uart_rx_buf_rsp(sh_uart->common.dev, buf, len);
-		/* If it is too late and RX is disabled then re-enable it. */
+		err = uart_rx_buf_rsp(sh_uart->common.dev, buf, blen);
 		if (err < 0) {
-			if (err == -EACCES) {
-				sh_uart->pending_rx_req = 0;
-				err = rx_enable(sh_uart->common.dev, buf, len);
-			} else {
-				return err;
-			}
+			/* Release allocated buffer. UART will be enabled after UART_RX_DISABLED. */
+			uart_async_rx_on_rdy(async_rx, buf, 0);
+			uart_async_rx_on_buf_rel(async_rx, buf);
+			sh_uart->pending_rx_req = 0;
+			return (err == -EACCES) ? 0 : err;
 		}
 	}
 


### PR DESCRIPTION
If RX buffers are not provided on time it may be possible that device enters disabling phase. Code was attempting to re-enable the UART immediately when that is detected but it fails if UART is not yet disabled. If providing next buffer fails then just release that buffer and wait for UART_RX_DISABLED event. Re-enable UART from that event.