### PR TITLE
drivers: i2c_rtio: max32: Inform the rtio executor if an error occurs

### DIFF
--- a/drivers/i2c/i2c_max32_rtio.c
+++ b/drivers/i2c/i2c_max32_rtio.c
@@ -199,6 +199,7 @@ static void i2c_max32_isr_controller(const struct device *dev, mxc_i2c_regs_t *i
 	if (int_fl0 & ADI_MAX32_I2C_INT_FL0_ERR) {
 		data->err = -EIO;
 		Wrap_MXC_I2C_SetIntEn(i2c, 0, 0);
+		max32_complete(dev, data->err);
 		return;
 	}
 
@@ -303,7 +304,6 @@ static void max32_complete(const struct device *dev, int status)
 	struct max32_i2c_data *data = dev->data;
 	struct i2c_rtio *const ctx = data->ctx;
 	const struct max32_i2c_config *const cfg = dev->config;
-	int ret = 0;
 
 	if (cfg->regs->clkhi == I2C_STANDAR_BITRATE_CLKHI) {
 		/* When I2C is configured in Standard Bitrate 100KHz
@@ -319,9 +319,12 @@ static void max32_complete(const struct device *dev, int status)
 		LOG_ERR("For Standard speed HW needs more time to run");
 		return;
 	}
-	if (i2c_rtio_complete(ctx, ret)) {
+
+	if (i2c_rtio_complete(ctx, status)) {
 		data->second_msg_flag = 1;
 		max32_start(dev);
+	} else {
+		data->second_msg_flag = 0;
 	}
 }
 

--- a/tests/drivers/i2c/i2c_ram/src/test_i2c_ram.c
+++ b/tests/drivers/i2c/i2c_ram/src/test_i2c_ram.c
@@ -35,6 +35,10 @@ uint8_t rx_data[7];
 
 const struct device *i2c_dev = DEVICE_DT_GET(I2C_DEV_NODE);
 
+#ifdef CONFIG_I2C_RTIO
+static void i2c_ram_rtio_before(void);
+#endif
+
 /* Address from datasheet is 0b1010xxxr where x bits are additional
  * memory address bits and r is the r/w i2c bit.
  *
@@ -74,6 +78,10 @@ static void i2c_ram_before(void *f)
 	rx_cmd[1] = (addr) & 0xFF;
 	addr += ARRAY_SIZE(tx_data) - TX_DATA_OFFSET;
 	memset(rx_data, 0, ARRAY_SIZE(rx_data));
+
+#ifdef CONFIG_I2C_RTIO
+	i2c_ram_rtio_before();
+#endif
 
 #ifdef CONFIG_PM_DEVICE_RUNTIME
 	pm_device_runtime_get(i2c_dev);
@@ -178,6 +186,26 @@ ZTEST(i2c_ram, test_ram_transfer_cb)
 I2C_IODEV_DEFINE(i2c_iodev, I2C_DEV_NODE, RAM_ADDR);
 RTIO_DEFINE(i2c_rtio, 2, 2);
 
+static void i2c_ram_rtio_before(void)
+{
+	struct rtio_cqe *cqe;
+
+	while ((cqe = rtio_cqe_consume(&i2c_rtio))) {
+		rtio_cqe_release(&i2c_rtio, cqe);
+	}
+}
+
+static void check_completion(struct rtio_cqe *cqe, const char *msg)
+{
+	int32_t result;
+
+	result = cqe->result;
+	rtio_cqe_release(&i2c_rtio, cqe);
+	if (result) {
+		zassert_ok(result, msg);
+	}
+}
+
 ZTEST(i2c_ram, test_ram_rtio)
 {
 	struct rtio_sqe *wr_sqe, *rd_sqe;
@@ -190,8 +218,7 @@ ZTEST(i2c_ram, test_ram_rtio)
 	zassert_ok(rtio_submit(&i2c_rtio, 1), "submit should succeed");
 
 	wr_cqe = rtio_cqe_consume(&i2c_rtio);
-	zassert_ok(wr_cqe->result, "i2c write should succeed");
-	rtio_cqe_release(&i2c_rtio, wr_cqe);
+	check_completion(wr_cqe, "i2c write should succeed");
 
 	/* Write the address and read the data back */
 	msgs[0].len = ARRAY_SIZE(rx_cmd);
@@ -209,11 +236,9 @@ ZTEST(i2c_ram, test_ram_rtio)
 	zassert_ok(rtio_submit(&i2c_rtio, 2), "submit should succeed");
 
 	wr_cqe = rtio_cqe_consume(&i2c_rtio);
+	check_completion(wr_cqe, "i2c write should succeed");
 	rd_cqe = rtio_cqe_consume(&i2c_rtio);
-	zassert_ok(wr_cqe->result, "i2c write should succeed");
-	zassert_ok(rd_cqe->result, "i2c read should succeed");
-	rtio_cqe_release(&i2c_rtio, wr_cqe);
-	rtio_cqe_release(&i2c_rtio, rd_cqe);
+	check_completion(rd_cqe, "i2c read should succeed");
 
 	zassert_equal(memcmp(&tx_data[TX_DATA_OFFSET], &rx_data[0], ARRAY_SIZE(rx_data)), 0,
 		      "Written and Read data should match");
@@ -242,11 +267,9 @@ ZTEST(i2c_ram, test_ram_rtio_write_with_transaction)
 	zassert_ok(rtio_submit(&i2c_rtio, 2), "submit should succeed");
 
 	wr_cqe = rtio_cqe_consume(&i2c_rtio);
-	zassert_ok(wr_cqe->result, "i2c write should succeed");
-	rtio_cqe_release(&i2c_rtio, wr_cqe);
+	check_completion(wr_cqe, "i2c write should succeed");
 	wr_cqe = rtio_cqe_consume(&i2c_rtio);
-	zassert_ok(wr_cqe->result, "i2c write should succeed");
-	rtio_cqe_release(&i2c_rtio, wr_cqe);
+	check_completion(wr_cqe, "i2c write should succeed");
 
 	/** Now read the register address to confirm the write was performed */
 	wr_sqe = rtio_sqe_acquire(&i2c_rtio);
@@ -258,11 +281,9 @@ ZTEST(i2c_ram, test_ram_rtio_write_with_transaction)
 	zassert_ok(rtio_submit(&i2c_rtio, 2), "submit should succeed");
 
 	wr_cqe = rtio_cqe_consume(&i2c_rtio);
+	check_completion(wr_cqe, "i2c write should succeed");
 	rd_cqe = rtio_cqe_consume(&i2c_rtio);
-	zassert_ok(wr_cqe->result, "i2c write should succeed");
-	zassert_ok(rd_cqe->result, "i2c read should succeed");
-	rtio_cqe_release(&i2c_rtio, wr_cqe);
-	rtio_cqe_release(&i2c_rtio, rd_cqe);
+	check_completion(rd_cqe, "i2c read should succeed");
 
 	zassert_equal(memcmp(&reg_data[0], &rx_data[0], ARRAY_SIZE(reg_data)), 0,
 		      "Written and Read data should match");
@@ -296,8 +317,7 @@ void ram_rtio_isr(struct k_timer *tid)
 		wr_cqe = rtio_cqe_consume(&i2c_rtio);
 		if (wr_cqe) {
 			TC_PRINT("timer checking write result, submitting read\n");
-			zassert_ok(wr_cqe->result, "i2c write should succeed");
-			rtio_cqe_release(&i2c_rtio, wr_cqe);
+			check_completion(wr_cqe, "i2c write should succeed");
 
 			/* Write the address and read the data back */
 			msgs[0].len = ARRAY_SIZE(rx_cmd);
@@ -322,8 +342,7 @@ void ram_rtio_isr(struct k_timer *tid)
 		wr_cqe = rtio_cqe_consume(&i2c_rtio);
 		if (wr_cqe) {
 			TC_PRINT("read command complete\n");
-			zassert_ok(wr_cqe->result, "i2c read command should succeed");
-			rtio_cqe_release(&i2c_rtio, wr_cqe);
+			check_completion(wr_cqe, "i2c read command should succeed");
 			isr_state += 1;
 		}
 		break;
@@ -331,8 +350,7 @@ void ram_rtio_isr(struct k_timer *tid)
 		rd_cqe = rtio_cqe_consume(&i2c_rtio);
 		if (rd_cqe) {
 			TC_PRINT("read data complete\n");
-			zassert_ok(rd_cqe->result, "i2c read data should succeed");
-			rtio_cqe_release(&i2c_rtio, rd_cqe);
+			check_completion(rd_cqe, "i2c read data should succeed");
 			isr_state += 1;
 			k_sem_give(&ram_rtio_isr_sem);
 			k_timer_stop(tid);


### PR DESCRIPTION
Call `i2c_rtio_complete` even if the rtio operation fails so that the application does not end up waiting forever for the completion queue event.

Modify the `i2c_rtio` test to release all consumed events before `z_assert` calls. Otherwise no space may be left in the completion queue for subsequent cqes. Also release all non-consumed cqes before each test.

Fixes #88668.

https://github.com/zephyrproject-rtos/zephyr/pull/88664 is still required.