### PR TITLE
boards: mimxrt1180_evk: Fix documentation of cores

### DIFF
--- a/boards/nxp/mimxrt1180_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1180_evk/doc/index.rst
@@ -13,8 +13,9 @@ Hardware
 
 - MIMXRT1189CVM8B MCU
 
-  - 240MHz Cortex-M33 & 792Mhz Cortex-M7
-  - 1.5MB SRAM with 512KB of TCM for Cortex-M7 and 256KB of TCM for Cortex-M4
+  - 240MHz Cortex-M33 with 256KB TCM and 16 KB caches
+  - 792Mhz Cortex-M7 with 512KB TCM and 32 KB caches
+  - 1.5MB SRAM
 
 - Memory
 


### PR DESCRIPTION
The wrong cortex M cores are described in the documentation. There is no CM4. Describe the cores and memories assigned to them correctly.