### PR TITLE
drivers: spi: cdns: fix missing fifo config

### DIFF
--- a/drivers/spi/Kconfig.cdns
+++ b/drivers/spi/Kconfig.cdns
@@ -3,6 +3,7 @@
 
 config SPI_CDNS
 	bool "Cadence SPI controller driver"
+	default y
 	depends on DT_HAS_CDNS_SPI_ENABLED
 	help
 	  Enable the SPI peripherals based on Cadence IP6524

--- a/drivers/spi/spi_cdns.c
+++ b/drivers/spi/spi_cdns.c
@@ -837,10 +837,13 @@ static DEVICE_API(spi, spi_cdns_api) = {
 	.transceive_async = spi_cdns_transceive_async,
 #endif /* CONFIG_SPI_ASYNC */
 	.release = spi_cdns_release,
+#ifdef CONFIG_SPI_RTIO
+	.iodev_submit = spi_rtio_iodev_default_submit,
+#endif /* CONFIG_SPI_RTIO */
 };
 
 /* Set clock-frequency-ext to pclk / 5 if there is no clock-frequency-ext */
-#define SPI_CLOCK_FREQUENCY_EXT(n)                                                                 \
+#define SPI_CLOCK_FREQUENCY_EXT(n)                                 \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clock_frequency_ext), \
 		(DT_INST_PROP(n, clock_frequency_ext)),            \
 		(DT_INST_PROP(n, clock_frequency) / 5))
@@ -856,6 +859,9 @@ static DEVICE_API(spi, spi_cdns_api) = {
 		.irq_config = spi_cdns_irq_config_##n,                                             \
 		.clock_frequency = DT_INST_PROP(n, clock_frequency),                               \
 		.ext_clock = SPI_CLOCK_FREQUENCY_EXT(n),                                           \
+		.fifo_width = DT_INST_PROP(n, fifo_width),                                         \
+		.tx_fifo_depth = DT_INST_PROP(n, tx_fifo_depth),                                   \
+		.rx_fifo_depth = DT_INST_PROP(n, rx_fifo_depth),                                   \
 	};                                                                                         \
 	SPI_DEVICE_DT_INST_DEFINE(n, spi_cdns_init, spi_cdns_pm_action, &spi_cdns_data_##n,        \
 				  &spi_cdns_cfg_##n, POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,        \


### PR DESCRIPTION
This adds the missing fifo config from the dts which was missed in the initial revision. This also adds the spi rtio fallback api, and fixes an issue with calculating the spi clock divisor