### PR TITLE
Bluetooth: Classic: L2CAP: Set the BR chan identifier for PENDING Case

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -4685,6 +4685,7 @@ static void l2cap_br_conn_rsp(struct bt_l2cap_br *l2cap, uint8_t ident, struct n
 		atomic_clear_bit(BR_CHAN(chan)->flags, L2CAP_FLAG_CONN_PENDING);
 		break;
 	case BT_L2CAP_BR_PENDING:
+		br_chan->ident = ident;
 		k_work_reschedule(&br_chan->rtx_work, L2CAP_BR_CONN_TIMEOUT);
 		break;
 	default:


### PR DESCRIPTION
When the connection status is "PENDING", need reset the br channel identifier to the correct value before resend the connection response, otherwise these is in an "ident mismatch" error being reported.