### PR TITLE
boards: st: n6_dk: fix sdmmc cd pin

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -170,7 +170,7 @@
 			&sdmmc2_ck_pc2 &sdmmc2_cmd_pc3>;
 	pinctrl-names = "default";
 	bus-width = <4>;
-	cd-gpios = <&gpion 8 GPIO_ACTIVE_HIGH>;
+	cd-gpios = <&gpion 12 GPIO_ACTIVE_HIGH>;
 	pwr-gpios = <&gpioq 7 GPIO_ACTIVE_HIGH>;
 };
 


### PR DESCRIPTION
CD pin of the SDMMC on the STM32N6570-DK board was incorrectly set as PN8. Fixes the pin to PN12 as per the schematic.