### PR TITLE
dts: arm: st: n6: fix axisram1 size

### DIFF
--- a/dts/arm/st/n6/stm32n657X0.dtsi
+++ b/dts/arm/st/n6/stm32n657X0.dtsi
@@ -8,7 +8,8 @@
 
 / {
 	axisram1: memory@34000000 {
-		reg = <0x34000000 DT_SIZE_K(624)>;
+		/* 400 kB of FLEXRAM followed by 624 kB of AXISRAM1 */
+		reg = <0x34000000 (DT_SIZE_K(400) + DT_SIZE_K(624))>;
 	};
 
 	axisram2: memory@34180400 {


### PR DESCRIPTION
In STM32N6, AXISRAM1 is next to the 400kB FLEXRAM. By default, the FLEXRAM is configured to extend the AXISRAM1 which put its total size to 1024kB.