### PR TITLE
STM32N6: Add missing Kconfig

### DIFF
--- a/soc/st/stm32/stm32n6x/Kconfig
+++ b/soc/st/stm32/stm32n6x/Kconfig
@@ -11,6 +11,8 @@ config SOC_SERIES_STM32N6X
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
+	select ARMV8_1_M_MVEI
+	select ARMV8_1_M_MVEF
 	select CPU_CORTEX_M_HAS_DWT
 	select HAS_STM32CUBE
 	select INIT_ARCH_HW_AT_BOOT


### PR DESCRIPTION
This PR adds some ARM Kconfig extension for STM32N6 ~~and update the CMakeLists to remove the signed binary before generating a new one (preventing `west build auto` to be stuck because the old binary can't be overwritten)~~

