### PR TITLE
STM32N6: Adjust clocks to use max frequency

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -97,6 +97,12 @@
 	status = "okay";
 };
 
+&ic3 {
+	pll-src = <1>;
+	ic-div = <6>;
+	status = "okay";
+};
+
 &ic6 {
 	pll-src = <3>;
 	ic-div = <2>;
@@ -224,6 +230,9 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io3_pn5 &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
+		 <&rcc STM32_SRC_IC3 XSPI1_SEL(2)>,
+		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
 	mx25um51245g: ospi-nor-flash@70000000 {

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -68,9 +68,18 @@
 };
 
 &pll1 {
-	clocks = <&clk_hsi>;
-	div-m = <4>;
-	mul-n = <75>;
+	clocks = <&clk_hse>;
+	div-m = <3>;
+	mul-n = <150>;
+	div-p1 = <1>;
+	div-p2 = <1>;
+	status = "okay";
+};
+
+&pll3 {
+	clocks = <&clk_hse>;
+	div-m = <3>;
+	mul-n = <125>;
 	div-p1 = <1>;
 	div-p2 = <1>;
 	status = "okay";
@@ -78,18 +87,18 @@
 
 &ic1 {
 	pll-src = <1>;
-	ic-div = <2>;
+	ic-div = <3>;
 	status = "okay";
 };
 
 &ic2 {
 	pll-src = <1>;
-	ic-div = <3>;
+	ic-div = <6>;
 	status = "okay";
 };
 
 &ic6 {
-	pll-src = <1>;
+	pll-src = <3>;
 	ic-div = <2>;
 	status = "okay";
 };
@@ -107,7 +116,7 @@
 
 &cpusw {
 	clocks = <&rcc STM32_SRC_IC1 CPU_SEL(3)>;
-	clock-frequency = <DT_FREQ_M(600)>;
+	clock-frequency = <DT_FREQ_M(800)>;
 	status = "okay";
 };
 
@@ -116,10 +125,7 @@
 	clocks = <&ic2>;
 	clock-frequency = <DT_FREQ_M(400)>;
 	ahb-prescaler = <2>;
-	apb1-prescaler = <1>;
-	apb2-prescaler = <1>;
-	apb4-prescaler = <1>;
-	apb5-prescaler = <1>;
+	timg-prescaler = <2>;
 };
 
 &adc1 {

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -95,6 +95,12 @@
 	status = "okay";
 };
 
+&ic3 {
+	pll-src = <1>;
+	ic-div = <6>;
+	status = "okay";
+};
+
 &ic4 {
 	pll-src = <2>;
 	ic-div = <32>;
@@ -220,6 +226,9 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p1_io12_pp12 &xspim_p1_io13_pp13 &xspim_p1_io14_pp14
 		     &xspim_p1_io15_pp15>;
 	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK(AHB5, 5)>,
+		 <&rcc STM32_SRC_IC3 XSPI1_SEL(2)>,
+		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
 	memc: aps256xxn_obr: memory@90000000 {
@@ -240,6 +249,9 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io3_pn5 &xspim_p2_io4_pn8 &xspim_p2_io5_pn9
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
+	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
+		 <&rcc STM32_SRC_IC3 XSPI1_SEL(2)>,
+		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 
 	mx66uw1g45g: ospi-nor-flash@70000000 {

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -57,9 +57,9 @@
 };
 
 &pll1 {
-	clocks = <&clk_hsi>;
-	div-m = <4>;
-	mul-n = <75>;
+	clocks = <&clk_hse>;
+	div-m = <3>;
+	mul-n = <150>;
 	div-p1 = <1>;
 	div-p2 = <1>;
 	status = "okay";
@@ -67,33 +67,42 @@
 
 &pll2 {
 	clocks = <&clk_hsi>;
-	div-m = <4>;
-	mul-n = <24>;
-	div-p1 = <2>;
-	div-p2 = <2>;
+	div-m = <2>;
+	mul-n = <48>;
+	div-p1 = <1>;
+	div-p2 = <1>;
+	status = "okay";
+};
+
+&pll3 {
+	clocks = <&clk_hse>;
+	div-m = <3>;
+	mul-n = <125>;
+	div-p1 = <1>;
+	div-p2 = <1>;
 	status = "okay";
 };
 
 &ic1 {
 	pll-src = <1>;
-	ic-div = <2>;
+	ic-div = <3>;
 	status = "okay";
 };
 
 &ic2 {
 	pll-src = <1>;
-	ic-div = <3>;
+	ic-div = <6>;
 	status = "okay";
 };
 
 &ic4 {
 	pll-src = <2>;
-	ic-div = <2>;
+	ic-div = <32>;
 	status = "okay";
 };
 
 &ic6 {
-	pll-src = <1>;
+	pll-src = <3>;
 	ic-div = <2>;
 	status = "okay";
 };
@@ -111,7 +120,7 @@
 
 &cpusw {
 	clocks = <&rcc STM32_SRC_IC1 CPU_SEL(3)>;
-	clock-frequency = <DT_FREQ_M(600)>;
+	clock-frequency = <DT_FREQ_M(800)>;
 	status = "okay";
 };
 
@@ -120,10 +129,7 @@
 	clocks = <&ic2>;
 	clock-frequency = <DT_FREQ_M(400)>;
 	ahb-prescaler = <2>;
-	apb1-prescaler = <1>;
-	apb2-prescaler = <1>;
-	apb4-prescaler = <1>;
-	apb5-prescaler = <1>;
+	timg-prescaler = <2>;
 };
 
 &adc1 {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -691,7 +691,7 @@
 			interrupts = <170 0>;
 			clock-names = "xspix", "xspi-ker", "xspi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB5, 5)>,
-				 <&rcc STM32_SRC_CKPER XSPI1_SEL(1)>,
+				 <&rcc STM32_SRC_HCLK5 XSPI1_SEL(0)>,
 				 <&rcc STM32_CLOCK(AHB5, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -704,7 +704,7 @@
 			interrupts = <171 0>;
 			clock-names = "xspix", "xspi-ker", "xspi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-				 <&rcc STM32_SRC_CKPER XSPI2_SEL(1)>,
+				 <&rcc STM32_SRC_HCLK5 XSPI2_SEL(0)>,
 				 <&rcc STM32_CLOCK(AHB5, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/bindings/clock/st,stm32n6-rcc.yaml
+++ b/dts/bindings/clock/st,stm32n6-rcc.yaml
@@ -62,63 +62,35 @@ properties:
 
   apb1-prescaler:
     type: int
-    required: true
+    default: 1
+    const: 1
     description: |
         CPU domain APB1 prescaler
-    enum:
-      - 1
-      - 2
-      - 4
-      - 8
-      - 16
-      - 32
-      - 64
-      - 128
+        Fixed to 1 as APB prescalers cannot be modified (See Errata sheet ES0620 §2.2.1)
 
   apb2-prescaler:
     type: int
-    required: true
+    default: 1
+    const: 1
     description: |
         CPU domain APB2 prescaler
-    enum:
-      - 1
-      - 2
-      - 4
-      - 8
-      - 16
-      - 32
-      - 64
-      - 128
+        Fixed to 1 as APB prescalers cannot be modified (See Errata sheet ES0620 §2.2.1)
 
   apb4-prescaler:
     type: int
-    required: true
+    default: 1
+    const: 1
     description: |
         CPU domain APB4 prescaler
-    enum:
-      - 1
-      - 2
-      - 4
-      - 8
-      - 16
-      - 32
-      - 64
-      - 128
+        Fixed to 1 as APB prescalers cannot be modified (See Errata sheet ES0620 §2.2.1)
 
   apb5-prescaler:
     type: int
-    required: true
+    default: 1
+    const: 1
     description: |
         CPU domain APB5 prescaler
-    enum:
-      - 1
-      - 2
-      - 4
-      - 8
-      - 16
-      - 32
-      - 64
-      - 128
+        Fixed to 1 as APB prescalers cannot be modified (See Errata sheet ES0620 §2.2.1)
 
   timg-prescaler:
     type: int

--- a/soc/st/stm32/stm32n6x/soc.c
+++ b/soc/st/stm32/stm32n6x/soc.c
@@ -54,6 +54,9 @@ void soc_early_init_hook(void)
 	/* Enable PWR */
 	LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_PWR);
 
+	/* Set the main internal Regulator output voltage for best performance */
+	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
+
 	/* Enable IOs */
 	LL_PWR_EnableVddIO2();
 	LL_PWR_EnableVddIO3();


### PR DESCRIPTION
This PR reconfigures the clock values in device tree to set the CPU and systems clock to the maximal frequencies.
Also change the XSPI kernel clock to use IC3 instead of peripheral clock.