### PR TITLE
STM32N6: XSPI PSRAM: Configure prescaler value automatically

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -254,6 +254,7 @@ zephyr_udc0: &usbotg_hs1 {
 		compatible = "st,stm32-xspi-psram";
 		reg = <0>;
 		size = <DT_SIZE_M(256)>; /* 256 Mbits */
+		max-frequency = <DT_FREQ_M(200)>;
 		fixed-latency;
 		io-x16-mode;
 		read-latency = <4>;

--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2131,8 +2131,11 @@ static int flash_stm32_xspi_init(const struct device *dev)
 			break;
 		}
 	}
-	__ASSERT_NO_MSG(prescaler >= STM32_XSPI_CLOCK_PRESCALER_MIN &&
-			prescaler <= STM32_XSPI_CLOCK_PRESCALER_MAX);
+
+	if (prescaler > STM32_XSPI_CLOCK_PRESCALER_MAX) {
+		LOG_ERR("XSPI could not find valid prescaler value");
+		return -EINVAL;
+	}
 
 	/* Initialize XSPI HAL structure completely */
 	dev_data->hxspi.Init.ClockPrescaler = prescaler;

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -40,12 +40,17 @@ LOG_MODULE_REGISTER(memc_stm32_xspi_psram, CONFIG_MEMC_LOG_LEVEL);
 #define DUMMY_CLK_CYCLES_READ	6U
 #define DUMMY_CLK_CYCLES_WRITE	6U
 
+#define STM32_XSPI_CLOCK_PRESCALER_MIN  0U
+#define STM32_XSPI_CLOCK_PRESCALER_MAX  255U
+#define STM32_XSPI_CLOCK_COMPUTE(bus_freq, prescaler) ((bus_freq) / ((prescaler) + 1U))
+
 struct memc_stm32_xspi_psram_config {
 	const struct pinctrl_dev_config *pcfg;
 	const struct stm32_pclken pclken;
 	const struct stm32_pclken pclken_ker;
 	const struct stm32_pclken pclken_mgr;
 	size_t memory_size;
+	uint32_t max_frequency;
 };
 
 struct memc_stm32_xspi_psram_data {
@@ -206,6 +211,7 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 	XSPIM_CfgTypeDef cfg = {0};
 	XSPI_RegularCmdTypeDef cmd = {0};
 	XSPI_MemoryMappedTypeDef mem_mapped_cfg = {0};
+	uint32_t prescaler = STM32_XSPI_CLOCK_PRESCALER_MIN;
 	int ret;
 
 	/* Signals configuration */
@@ -259,6 +265,20 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 	}
 #endif
 
+	for (; prescaler <= STM32_XSPI_CLOCK_PRESCALER_MAX; prescaler++) {
+		uint32_t clk = STM32_XSPI_CLOCK_COMPUTE(ahb_clock_freq, prescaler);
+
+		if (clk <= dev_cfg->max_frequency) {
+			break;
+		}
+	}
+
+	if (prescaler > STM32_XSPI_CLOCK_PRESCALER_MAX) {
+		LOG_ERR("XSPI could not find valid prescaler value");
+		return -EINVAL;
+	}
+
+	hxspi.Init.ClockPrescaler = prescaler;
 	hxspi.Init.MemorySize = find_msb_set(dev_cfg->memory_size) - 2;
 
 	if (HAL_XSPI_Init(&hxspi) != HAL_OK) {
@@ -339,6 +359,7 @@ static const struct memc_stm32_xspi_psram_config memc_stm32_xspi_cfg = {
 		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_XSPI_NODE, xspi_mgr, bits)},
 #endif
 	.memory_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
+	.max_frequency = DT_INST_PROP(0, max_frequency),
 };
 
 static struct memc_stm32_xspi_psram_data memc_stm32_xspi_data = {
@@ -354,7 +375,6 @@ static struct memc_stm32_xspi_psram_data memc_stm32_xspi_data = {
 			.FreeRunningClock = HAL_XSPI_FREERUNCLK_DISABLE,
 			.ClockMode = HAL_XSPI_CLOCK_MODE_0,
 			.WrapSize = HAL_XSPI_WRAP_NOT_SUPPORTED,
-			.ClockPrescaler = 3U,
 			.SampleShifting = HAL_XSPI_SAMPLE_SHIFT_NONE,
 			.DelayHoldQuarterCycle = HAL_XSPI_DHQC_ENABLE,
 			.ChipSelectBoundary = HAL_XSPI_BONDARYOF_16KB,

--- a/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-xspi-psram.yaml
@@ -17,6 +17,11 @@ properties:
     required: true
     description: Flash Memory size in bits
 
+  max-frequency:
+    type: int
+    required: true
+    description: Maximum clock frequency of device's xSPI interface in Hz
+
   fixed-latency:
     type: boolean
     description: |


### PR DESCRIPTION
Add the automatic computation / configuration of the XSPI prescaler for the XSPI PSRAM driver.