### PR TITLE
STM32N6: Add XSPI Flash memory map support

### DIFF
--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -7,13 +7,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config STM32_MEMMAP
-	bool "NOR Flash in MemoryMapped for XiP"
-	depends on XIP && \
-		    (DT_HAS_ST_STM32_OSPI_NOR_ENABLED || \
-		     DT_HAS_ST_STM32_QSPI_NOR_ENABLED || \
-		     DT_HAS_ST_STM32_XSPI_NOR_ENABLED)
+	bool "NOR Flash in MemoryMapped"
+	depends on DT_HAS_ST_STM32_QSPI_NOR_ENABLED || \
+		   DT_HAS_ST_STM32_OSPI_NOR_ENABLED || \
+		   DT_HAS_ST_STM32_XSPI_NOR_ENABLED
 	help
-	  This option enables the XIP mode for the external NOR flash
+	  This option enables the MemoryMapped mode for the external NOR flash
 	  mounted on STM32 boards.
 
 menuconfig SOC_FLASH_STM32


### PR DESCRIPTION
Add the support of the XSPI Flash memory map support for STM32N6