### PR TITLE
boards: shields: x_nucleo_wb05kn1: Update documentation

### DIFF
--- a/boards/shields/x_nucleo_wb05kn1/doc/index.rst
+++ b/boards/shields/x_nucleo_wb05kn1/doc/index.rst
@@ -11,6 +11,14 @@ The RF module is FCC (FCC ID: YCP-MB203202) and IC certified (IC: 8976A-MB203202
 
 The X-NUCLEO-WB05KN1 is compatible out of the box with the Arduino UNO R3 connector.
 The board interfaces with the host microcontroller via UART (default) or SPI peripheral.
+However, the out-of-the-box firmware is not compatible with Zephyr; therefore, a controller-only
+image should be flashed on the board using CN8 pin headers.
+For more information about how to change the firmware, please refer to `UM3406`_ section 3.3.
+
+.. note::
+   The `X-CUBE-WB05N`_ package provided by ST contains firmware compatible with Zephyr
+   in the ``Utilities/BLE_Transparent_Mode_STM32WB05_controller_only`` directory
+   (``SPI`` or ``UART`` subdirectories depending on which interface you want to use).
 
 .. image:: img/x-nucleo-wb05kn1.webp
      :align: center
@@ -38,9 +46,14 @@ The UART default settings are:
 | TX       | D1                    |
 +----------+-----------------------+
 
-.. note::
-   Please, bear in mind in order to use SPI interface you need to change the shield firmware
-   to ``DTM_SPI_WITH_UPDATER_CONTROLLER`` according to the SDK provided by ST at `X-CUBE-WB05N`_.
+The SPI default settings are:
+
+* Mode: Full-duplex slave
+* Frame format: Motorola
+* Data size: 8 bits, MSB first
+* Clock Polarity: High (CPOL=1)
+* Clock Phase: 2 Edge (CPHA=1)
+* CS type: Software-controlled
 
 IRQ and reset pins are also necessary in addition to SPI pins.
 
@@ -76,7 +89,7 @@ Activate the presence of the shield for the project build by adding the
     :shield: x_nucleo_wb05kn1_uart
     :goals: build
 
-or
+Or
 
  .. zephyr-app-commands::
     :app: your_app
@@ -89,11 +102,14 @@ References
 
 .. target-notes::
 
-.. _X-NUCLEO-WB05KN1 website:
-   https://www.st.com/en/evaluation-tools/x-nucleo-wb05kn1.html
+.. _UM3406:
+   https://www.st.com/resource/en/user_manual/um3406-getting-started-with-the-xcubewb05n-bluetooth-low-energy-software-expansion-for-stm32cube-stmicroelectronics.pdf
 
 .. _X-CUBE-WB05N:
    https://www.st.com/en/embedded-software/x-cube-wb05n.html
+
+.. _X-NUCLEO-WB05KN1 website:
+   https://www.st.com/en/evaluation-tools/x-nucleo-wb05kn1.html
 
 .. _X-NUCLEO-WB05KN1 datasheet:
    https://www.st.com/resource/en/datasheet/stm32wb05kn.pdf


### PR DESCRIPTION
The documentation is updated to give more information regarding the SPI default settings and the necessity to change the out-of-the-box firmware to be compatible with Zephyr.