### PR TITLE
tests: kernel: various doxygen fixes/cleanups

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -85,14 +85,4 @@
 @{
 @}
 
-@brief Tests
-@defgroup all_tests Tests
-@{
-@}
-
-@defgroup kernel_memprotect_tests Memory Protection
-@ingroup all_tests
-@{
-@}
-
 */

--- a/tests/arch/arm/arm_custom_interrupt/src/arm_custom_interrupt.c
+++ b/tests/arch/arm/arm_custom_interrupt/src/arm_custom_interrupt.c
@@ -120,7 +120,7 @@ void arm_isr_handler(const void *args)
  * @{
  */
 
-ZTEST(arm_custom_interrupt, test_arm_interrupt)
+ZTEST(arm_custom_interrupt, test_arm_custom_interrupt)
 {
 	zassert_true(custom_init_called, "Custom IRQ init not called\n");
 

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -142,6 +142,10 @@ void set_regs_with_known_pattern(void *p1, void *p2, void *p3)
 			 "udf #90\n");
 }
 
+/**
+ * @brief Test to verify code fault handling in ISR execution context
+ * @ingroup kernel_fatal_tests
+ */
 ZTEST(arm_interrupt, test_arm_esf_collection)
 {
 	int test_validation_rv;
@@ -222,6 +226,10 @@ void arm_isr_handler(const void *args)
 	}
 }
 
+/**
+ * @brief Test ARM Interrupt handling
+ * @ingroup kernel_arch_interrupt_tests
+ */
 ZTEST(arm_interrupt, test_arm_interrupt)
 {
 	/* Determine an NVIC IRQ line that is not currently in use. */
@@ -390,6 +398,10 @@ static inline void z_vrfy_test_arm_user_interrupt_syscall(void)
 }
 #include <zephyr/syscalls/test_arm_user_interrupt_syscall_mrsh.c>
 
+/**
+ * @brief Test ARM Interrupt handling in user mode
+ * @ingroup kernel_arch_interrupt_tests
+ */
 ZTEST_USER(arm_interrupt, test_arm_user_interrupt)
 {
 	/* Test thread executing in user mode */
@@ -434,6 +446,11 @@ ZTEST_USER(arm_interrupt, test_arm_user_interrupt)
 #pragma GCC push_options
 #pragma GCC optimize("O0")
 /* Avoid compiler optimizing null pointer de-referencing. */
+
+/**
+ * @brief Test ARM Null Pointer Exception handling
+ * @ingroup kernel_arch_interrupt_tests
+ */
 ZTEST(arm_interrupt, test_arm_null_pointer_exception)
 {
 	Z_TEST_SKIP_IFNDEF(CONFIG_CORTEX_M_NULL_POINTER_EXCEPTION);
@@ -454,7 +471,3 @@ ZTEST(arm_interrupt, test_arm_null_pointer_exception)
 	zassert_equal(reason, -1, "expected_reason has not been reset (%d)\n", reason);
 }
 #pragma GCC pop_options
-
-/**
- * @}
- */

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_dynamic_direct_interrupts.c
@@ -28,6 +28,10 @@ void arm_direct_isr_handler_1(const void *args)
 	test_flag = 2;
 }
 
+/**
+ * @brief Test the ARM Dynamic Direct Interrupts functionality.
+ * @ingroup kernel_arch_interrupt_tests
+ */
 ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 {
 	int post_flag = 0;
@@ -81,6 +85,3 @@ ZTEST(arm_irq_advanced_features, test_arm_dynamic_direct_interrupts)
 	post_flag = test_flag;
 	zassert_true(post_flag == 2, "Test flag not set by ISR1\n");
 }
-/**
- * @}
- */

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_irq_target_state.c
@@ -13,6 +13,10 @@
 extern irq_target_state_t irq_target_state_set(unsigned int irq, irq_target_state_t target_state);
 extern int irq_target_state_is_secure(unsigned int irq);
 
+/**
+ * @brief Test the ARM IRQ target state functionality.
+ * @ingroup kernel_arch_interrupt_tests
+ */
 ZTEST(arm_irq_advanced_features, test_arm_irq_target_state)
 {
 	/* Determine an NVIC IRQ line that is implemented
@@ -82,6 +86,3 @@ ZTEST(arm_irq_advanced_features, test_arm_irq_target_state)
 	TC_PRINT("Skipped (TrustZone-M-enabled Cortex-M Mainline only)\n");
 }
 #endif /* CONFIG_ZERO_LATENCY_IRQS */
-/**
- * @}
- */

--- a/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
+++ b/tests/arch/arm/arm_irq_advanced_features/src/arm_zero_latency_irqs.c
@@ -18,6 +18,10 @@ void arm_zero_latency_isr_handler(const void *args)
 	test_flag = 1;
 }
 
+/**
+ * @brief Test ARM Zero latency Interrupt functionality.
+ * @ingroup kernel_arch_interrupt_tests
+ */
 ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 {
 
@@ -101,7 +105,3 @@ ZTEST(arm_irq_advanced_features, test_arm_zero_latency_irqs)
 
 	irq_unlock(key);
 }
-
-/**
- * @}
- */

--- a/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
+++ b/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
@@ -15,6 +15,13 @@ extern uint32_t _vector_table;
 extern uint32_t __vector_relay_handler;
 extern uint32_t _vector_table_pointer;
 
+
+/**
+ * @brief Test the ARM Software Vector Relay functionality.
+ *
+ * This test verifies the correctness of the ARM software vector relay mechanism.
+ * @ingroup kernel_arch_interrupt_tests
+ */
 ZTEST(arm_sw_vector_relay, test_arm_sw_vector_relay)
 {
 	uint32_t vector_relay_table_addr = (uint32_t)&__vector_relay_table;
@@ -61,6 +68,3 @@ ZTEST(arm_sw_vector_relay, test_arm_sw_vector_relay)
 		     _vector_table_pointer, _vector_start);
 #endif
 }
-/**
- * @}
- */

--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -143,7 +143,10 @@ static void user_thread_entry(void *p1, void *p2, void *p3)
 	barrier_isync_fence_full();
 #endif
 }
-
+/**
+ * @brief Test ARM thread swap mechanism
+ * @ingroup kernel_arch_sched_tests
+ */
 ZTEST(arm_thread_swap, test_arm_syscalls)
 {
 	int i = 0;
@@ -288,6 +291,3 @@ ZTEST(arm_thread_swap, test_arm_syscalls)
 }
 
 #endif /* CONFIG_USERSPACE */
-/**
- * @}
- */

--- a/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_thread_arch.c
@@ -370,6 +370,10 @@ static int __noinline arch_swap_wrapper(void)
 }
 #endif
 
+/**
+ * @brief Test the ARM thread swap mechanism
+ * @ingroup kernel_arch_sched_tests
+ */
 ZTEST(arm_thread_swap, test_arm_thread_swap)
 {
 	int test_flag;
@@ -662,6 +666,3 @@ ZTEST(arm_thread_swap, test_arm_thread_swap)
 #endif
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 }
-/**
- * @}
- */

--- a/tests/arch/common/ramfunc/src/ramfunc.c
+++ b/tests/arch/common/ramfunc/src/ramfunc.c
@@ -53,6 +53,3 @@ ZTEST(ramfunc, test_ramfunc)
 	zassert_true(post_flag == 1,
 		"ram_function() execution failed.");
 }
-/**
- * @}
- */

--- a/tests/kernel/common/src/atomic.c
+++ b/tests/kernel/common/src/atomic.c
@@ -28,7 +28,12 @@ static struct k_thread thread[THREADS_NUM];
 atomic_t total_atomic;
 
 /**
- * @addtogroup kernel_common_tests
+ * @defgroup kernel_atomic_ops_tests Atomic Operations
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_atomic_ops_tests
  * @{
  */
 
@@ -92,7 +97,6 @@ atomic_t total_atomic;
  * atomic_test_and_set_bit(), atomic_clear_bit(), atomic_set_bit(),
  * ATOMIC_DEFINE
  *
- * @ingroup kernel_common_tests
  */
 ZTEST_USER(atomic, test_atomic)
 {
@@ -312,7 +316,6 @@ void atomic_handler(void *p1, void *p2, void *p3)
  * In this time, the two sub threads will be scheduled separately
  * according to the time slice.
  *
- * @ingroup kernel_common_tests
  */
 ZTEST(atomic, test_threads_access_atomic)
 {
@@ -349,7 +352,6 @@ ZTEST(atomic, test_threads_access_atomic)
  *	in a non-atomic manner (as long as it is logically safe)
  *	and expect its value to match the result of the similar atomic increment.
  *
- * @ingroup kernel_common_tests
  */
 ZTEST(atomic, test_atomic_overflow)
 {
@@ -383,8 +385,8 @@ ZTEST(atomic, test_atomic_overflow)
 		atomic_value);
 }
 
-extern void *common_setup(void);
-ZTEST_SUITE(atomic, NULL, common_setup, NULL, NULL, NULL);
 /**
  * @}
  */
+extern void *common_setup(void);
+ZTEST_SUITE(atomic, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -22,7 +22,12 @@
 #define BITFIELD_SIZE   512
 
 /**
- * @addtogroup kernel_common_tests
+ * @defgroup kernel_bitarray_tests Bit Arrays
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_bitarray_tests
  * @{
  */
 
@@ -1058,9 +1063,8 @@ ZTEST(bitarray, test_ffs)
 		zassert_equal(find_lsb_set(value), bit + 1, "LSB is not matched");
 	}
 }
-extern void *common_setup(void);
-ZTEST_SUITE(bitarray, NULL, common_setup, NULL, NULL, NULL);
-
 /**
  * @}
  */
+extern void *common_setup(void);
+ZTEST_SUITE(bitarray, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/bitfield.c
+++ b/tests/kernel/common/src/bitfield.c
@@ -19,7 +19,12 @@
 #define BITFIELD_SIZE   512
 
 /**
- * @addtogroup kernel_common_tests
+ * @defgroup kernel_bitfield_tests Bit Fields
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_bitfield_tests
  * @{
  */
 
@@ -131,10 +136,10 @@ ZTEST(bitfield, test_bitfield)
 
 }
 
-extern void *common_setup(void);
-
-ZTEST_SUITE(bitfield, NULL, common_setup, NULL, NULL, NULL);
-
 /**
  * @}
  */
+
+extern void *common_setup(void);
+
+ZTEST_SUITE(bitfield, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/boot_delay.c
+++ b/tests/kernel/common/src/boot_delay.c
@@ -6,10 +6,14 @@
 
 #include <zephyr/ztest.h>
 
+
 /**
- * @brief Test delay during boot
- * @defgroup kernel_init_tests Init
+ * @defgroup kernel_init_tests Kernel Initialization
  * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_init_tests
  * @{
  */
 
@@ -39,9 +43,9 @@ ZTEST(boot_delay, test_bootdelay)
 			(NSEC_PER_MSEC * CONFIG_BOOT_DELAY));
 }
 
-extern void *common_setup(void);
-ZTEST_SUITE(boot_delay, NULL, common_setup, NULL, NULL, NULL);
-
 /**
  * @}
  */
+
+extern void *common_setup(void);
+ZTEST_SUITE(boot_delay, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/byteorder.c
+++ b/tests/kernel/common/src/byteorder.c
@@ -10,9 +10,15 @@
 #include <zephyr/sys/byteorder.h>
 
 /**
- * @addtogroup kernel_common_tests
+ * @defgroup kernel_byteorder_tests Byteorder Operations
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_byteorder_tests
  * @{
  */
+
 /**
  * @brief Test swapping for memory contents
  *
@@ -704,9 +710,10 @@ ZTEST(byteorder, test_sys_get_be)
 	zassert_mem_equal(host, exp, sizeof(exp), "sys_get_be() failed");
 }
 
-extern void *common_setup(void);
-ZTEST_SUITE(byteorder, NULL, common_setup, NULL, NULL, NULL);
-
 /**
  * @}
  */
+
+
+extern void *common_setup(void);
+ZTEST_SUITE(byteorder, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -29,7 +29,12 @@ static ZTEST_BMEM struct timer_data tdata;
 #define LESS_DURATION 70
 
 /**
- * @addtogroup kernel_common_tests
+ * @defgroup kernel_clock_tests Clock Operations
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_clock_tests
  * @{
  */
 
@@ -231,9 +236,9 @@ ZTEST(clock, test_ms_time_duration)
 	k_timer_stop(&ktimer);
 }
 
-extern void *common_setup(void);
-ZTEST_SUITE(clock, NULL, common_setup, NULL, NULL, NULL);
-
 /**
  * @}
  */
+
+ extern void *common_setup(void);
+ ZTEST_SUITE(clock, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/constructor.c
+++ b/tests/kernel/common/src/constructor.c
@@ -8,14 +8,15 @@
 #include <errno.h>
 #include <zephyr/tc_util.h>
 #include <zephyr/ztest.h>
-/**
- * @addtogroup kernel_common_tests
- * @{
- */
 
 /**
- * @brief Test if constructors work
+ * @defgroup kernel_constructor_tests Constructors
+ * @ingroup all_tests
+ * @{
+ * @}
  *
+ * @addtogroup kernel_constructor_tests
+ * @{
  */
 
 static int constructor_number;
@@ -35,7 +36,10 @@ void __attribute__((__constructor__(1000))) __constructor_init_priority_1000(voi
 {
 	constructor_values[constructor_number++] = 1000;
 }
-
+/**
+ * @brief Test if constructors work
+ *
+ */
 ZTEST(constructor, test_constructor)
 {
 	zassert_equal(constructor_number, 3,
@@ -51,9 +55,9 @@ ZTEST(constructor, test_constructor)
 		      "constructor without priority not called last");
 }
 
-extern void *common_setup(void);
-ZTEST_SUITE(constructor, NULL, common_setup, NULL, NULL, NULL);
-
 /**
  * @}
  */
+
+ extern void *common_setup(void);
+ ZTEST_SUITE(constructor, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/errno.c
+++ b/tests/kernel/common/src/errno.c
@@ -9,16 +9,7 @@
 #include <errno.h>
 #include <zephyr/sys/errno_private.h>
 
-/**
- * @brief Test the thread context
- *
- * @defgroup kernel_threadcontext_tests Thread Context Tests
- *
- * @ingroup all_tests
- *
- * @{
- * @}
- */
+
 #define N_THREADS 2
 #define STACK_SIZE (384 + CONFIG_TEST_EXTRA_STACK_SIZE)
 
@@ -59,11 +50,17 @@ static void errno_thread(void *_n, void *_my_errno, void *_unused)
 
 	k_fifo_put(&fifo, &result[n]);
 }
-
+/**
+ * @defgroup kernel_errno_tests Error Number
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_errno_tests
+ * @{
+ */
 /**
  * @brief Verify thread context
- *
- * @ingroup kernel_threadcontext_tests
  *
  * @details Check whether variable value per-thread are saved during
  *	context switch
@@ -140,8 +137,6 @@ void thread_entry_user(void *p1, void *p2, void *p3)
  *
  * @details Check whether a C standard errno can be stored successfully,
  *  no matter it is using tls or not.
- *
- * @ingroup kernel_threadcontext_tests
  */
 ZTEST_USER(common_errno, test_errno)
 {
@@ -160,6 +155,8 @@ ZTEST_USER(common_errno, test_errno)
 	k_thread_join(tid, K_FOREVER);
 }
 
+/**
+ * @}
+ */
 extern void *common_setup(void);
-
 ZTEST_SUITE(common_errno, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -140,7 +140,7 @@ ZTEST(common_1cpu, test_nested_irq_offload)
 	k_thread_abort(&offload_thread);
 }
 /**
- *
+ * @}
  */
 extern void *common_setup(void);
 ZTEST_SUITE(irq_offload, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/irq_offload.c
+++ b/tests/kernel/common/src/irq_offload.c
@@ -17,6 +17,16 @@
 #include <zephyr/kernel_structs.h>
 #include <zephyr/irq_offload.h>
 
+/**
+ * @defgroup kernel_irq_offload_tests IRQ Offload
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_irq_offload_tests
+ * @{
+ */
+
 volatile uint32_t sentinel;
 #define SENTINEL_VALUE 0xDEADBEEF
 
@@ -35,8 +45,6 @@ static void offload_function(const void *param)
 
 /**
  * @brief Verify thread context
- *
- * @ingroup kernel_interrupt_tests
  *
  * @details Check whether offloaded running function is in interrupt
  * context, on the IRQ stack or not.
@@ -97,7 +105,8 @@ static void offload_thread_fn(void *p0, void *p1, void *p2)
 	}
 }
 
-/* Invoke irq_offload() from an interrupt and verify that the
+/**
+ * @brief Invoke irq_offload from an interrupt and verify that the
  * resulting nested interrupt doesn't explode
  */
 ZTEST(common_1cpu, test_nested_irq_offload)
@@ -130,6 +139,8 @@ ZTEST(common_1cpu, test_nested_irq_offload)
 
 	k_thread_abort(&offload_thread);
 }
-
+/**
+ *
+ */
 extern void *common_setup(void);
 ZTEST_SUITE(irq_offload, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -181,8 +181,14 @@ static int ram_console_out(int character)
 	pos = (pos + 1) % BUF_SZ;
 	return _old_char_out(character);
 }
+
 /**
- * @addtogroup kernel_common_tests
+ * @defgroup kernel_printk_tests Printk
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_printk_tests
  * @{
  */
 
@@ -253,9 +259,9 @@ ZTEST(printk, test_printk)
 	zassert_str_equal(pk_console, expected, "snprintk failed");
 }
 
-extern void *common_setup(void);
-ZTEST_SUITE(printk, NULL, common_setup, NULL, NULL, NULL);
 
 /**
  * @}
  */
+extern void *common_setup(void);
+ZTEST_SUITE(printk, NULL, common_setup, NULL, NULL, NULL);

--- a/tests/kernel/common/src/timeout_order.c
+++ b/tests/kernel/common/src/timeout_order.c
@@ -36,7 +36,12 @@ static K_THREAD_STACK_ARRAY_DEFINE(stacks, NUM_TIMEOUTS, STACKSIZE);
 static struct k_thread threads[NUM_TIMEOUTS];
 
 /**
- * @addtogroup kernel_common_tests
+ * @defgroup kernel_timeout_tests Timeout Order
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_timeout_tests
  * @{
  */
 
@@ -88,10 +93,9 @@ ZTEST(common_1cpu, test_timeout_order)
 	}
 }
 
-extern void *common_setup(void);
-ZTEST_SUITE(common_1cpu, NULL, common_setup,
-		ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);
-
 /**
  * @}
  */
+extern void *common_setup(void);
+ZTEST_SUITE(common_1cpu, NULL, common_setup,
+		ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);

--- a/tests/kernel/condvar/condvar_api/src/main.c
+++ b/tests/kernel/condvar/condvar_api/src/main.c
@@ -133,7 +133,15 @@ void condvar_wait_wake_task(void *p1, void *p2, void *p3)
 
 	k_mutex_unlock(&test_mutex);
 }
-
+/**
+ * @defgroup kernel_condvar_tests Condition Variables
+ * @ingroup all_tests
+ * @{
+ * @}
+ *
+ * @addtogroup kernel_condvar_tests
+ * @{
+ */
 /**
  * @brief Test k_condvar_wait() and k_condvar_wake()
  */
@@ -163,7 +171,9 @@ ZTEST_USER(condvar_tests, test_condvar_wait_forever_wake)
 	k_thread_abort(&condvar_tid);
 }
 
-
+/**
+ * @brief Test k_condvar_wait() and k_condvar_wake() with timeout
+ */
 ZTEST_USER(condvar_tests, test_condvar_wait_timeout_wake)
 {
 	woken = 1;
@@ -191,6 +201,9 @@ ZTEST_USER(condvar_tests, test_condvar_wait_timeout_wake)
 	k_thread_abort(&condvar_tid);
 }
 
+/**
+ * @brief Test k_condvar_wait() and k_condvar_wake() with timeout
+ */
 ZTEST_USER(condvar_tests, test_condvar_wait_timeout)
 {
 	timeout = k_ms_to_ticks_ceil32(50);
@@ -224,7 +237,9 @@ ZTEST_USER(condvar_tests, test_condvar_wait_forever)
 	k_thread_abort(&condvar_tid);
 }
 
-
+/**
+ * @brief Test k_condvar_wait() with no wait
+ */
 ZTEST_USER(condvar_tests, test_condvar_wait_nowait)
 {
 	timeout = 0;
@@ -240,6 +255,12 @@ ZTEST_USER(condvar_tests, test_condvar_wait_nowait)
 }
 
 
+/**
+ * @brief Test case for conditional variable wait and wake functionality.
+ *
+ * This test validates the behavior of conditional variables when a thread
+ * waits on a condition and another thread wakes it up.
+ */
 ZTEST_USER(condvar_tests, test_condvar_wait_nowait_wake)
 {
 	woken = 0;
@@ -266,6 +287,13 @@ ZTEST_USER(condvar_tests, test_condvar_wait_nowait_wake)
 }
 
 
+/**
+ * @brief Test case for condition variable wait and wake functionality.
+ *
+ * This test verifies the behavior of a thread waiting on a condition variable
+ * with an infinite timeout and being woken up from an interrupt service routine (ISR).
+ *
+ */
 ZTEST(condvar_tests, test_condvar_wait_forever_wake_from_isr)
 {
 	timeout = K_TICKS_FOREVER;
@@ -285,6 +313,15 @@ ZTEST(condvar_tests, test_condvar_wait_forever_wake_from_isr)
 	k_thread_abort(&condvar_tid);
 }
 
+/**
+ * @brief Test case for multiple threads waiting and waking on a condition variable.
+ *
+ * This test initializes a condition variable and creates multiple threads that
+ * wait on the condition variable. Another thread is created to wake up the
+ * waiting threads. The test ensures proper synchronization and behavior of
+ * threads waiting and waking on the condition variable.
+
+ */
 ZTEST_USER(condvar_tests, test_condvar_multiple_threads_wait_wake)
 {
 	timeout = K_TICKS_FOREVER;
@@ -353,6 +390,15 @@ void condvar_multiple_wake_task(void *p1, void *p2, void *p3)
 		     ret_value, woken_num);
 }
 
+
+/**
+ * @brief Test multiple threads waiting and waking on a condition variable.
+ *
+ * This test creates multiple threads that wait on a condition variable and
+ * another set of threads that wake them up. It ensures that the condition
+ * variable mechanism works correctly when multiple threads are involved.
+
+ */
 ZTEST_USER(condvar_tests, test_multiple_condvar_wait_wake)
 {
 	woken = 1;
@@ -404,6 +450,14 @@ static void cond_init_null(void *p1, void *p2, void *p3)
 	ztest_test_fail();
 }
 
+
+/**
+ * @brief Test case for conditional variable initialization with a null parameter.
+ *
+ * This test verifies the behavior of the conditional variable initialization
+ * when a null parameter is passed. It creates a thread to execute the
+ * `cond_init_null` function and ensures the thread completes execution.
+ */
 ZTEST_USER(condvar_tests, test_condvar_init_null)
 {
 	k_tid_t tid = k_thread_create(&condvar_tid, stack_1, STACK_SIZE,
@@ -460,7 +514,13 @@ static void cond_wait_null(void *p1, void *p2, void *p3)
 	/* should not go here*/
 	ztest_test_fail();
 }
-
+/**
+ * @brief Test case for signaling a condition variable with a NULL parameter.
+ *
+ * This test creates a thread that attempts to signal a condition variable
+ * with a NULL parameter. It ensures that the system handles this scenario
+ * gracefully without causing unexpected behavior or crashes.
+ */
 ZTEST_USER(condvar_tests, test_condvar_signal_null)
 {
 	k_tid_t tid = k_thread_create(&condvar_tid, stack_1, STACK_SIZE,
@@ -470,6 +530,14 @@ ZTEST_USER(condvar_tests, test_condvar_signal_null)
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 	k_thread_join(tid, K_FOREVER);
 }
+
+/**
+ * @brief Test case for broadcasting a condition variable with a NULL parameter.
+ *
+ * This test creates a thread that attempts to broadcast a condition variable
+ * with a NULL parameter. It verifies that the system can handle this edge case
+ * correctly and does not result in undefined behavior.
+ */
 ZTEST_USER(condvar_tests, test_condvar_broadcast_null)
 {
 	k_tid_t tid = k_thread_create(&condvar_tid, stack_1, STACK_SIZE,
@@ -480,6 +548,14 @@ ZTEST_USER(condvar_tests, test_condvar_broadcast_null)
 
 	k_thread_join(tid, K_FOREVER);
 }
+
+/**
+ * @brief Test case for waiting on a condition variable with a NULL parameter.
+ *
+ * This test creates a thread that attempts to wait on a condition variable
+ * with a NULL parameter. It ensures that the system properly handles this
+ * invalid operation and maintains stability.
+ */
 ZTEST_USER(condvar_tests, test_condvar_wait_null)
 {
 	k_tid_t tid = k_thread_create(&condvar_tid, stack_1, STACK_SIZE,
@@ -575,10 +651,19 @@ void _condvar_usecase(long multi)
 
 }
 
+
+/**
+ * @brief Test case for conditional variable use case with signal
+ *
+ * This test verifies the behavior of a conditional variable in a specific
+ * use case where a signal is used. It ensures that the conditional variable
+ * operates correctly when signaled, validating synchronization mechanisms.
+ */
 ZTEST_USER(condvar_tests, test_condvar_usecase_signal)
 {
 	_condvar_usecase(0);
 }
+
 
 ZTEST_USER(condvar_tests, test_condvar_usecase_broadcast)
 {
@@ -603,5 +688,9 @@ static void *condvar_tests_setup(void)
 #endif
 	return NULL;
 }
+
+/**
+ * @}
+ */
 
 ZTEST_SUITE(condvar_tests, NULL, condvar_tests_setup, NULL, NULL, NULL);

--- a/tests/kernel/early_sleep/src/main.c
+++ b/tests/kernel/early_sleep/src/main.c
@@ -4,25 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * @file
- * @brief Test early sleep functionality
- *
- * @defgroup kernel_earlysleep_tests Early Sleep Tests
- *
- * @ingroup all_tests
- *
- * This test verifies that k_sleep() can be used to put the calling thread to
- * sleep for a specified number of ticks during system initialization.  In this
- * test we are calling k_sleep() at POST_KERNEL and APPLICATION level
- * initialization sequence.
- *
- * Note: We can not call k_sleep() during PRE_KERNEL1 or PRE_KERNEL2 level
- * because the core kernel objects and devices initialization happens at these
- * levels.
- * @{
- * @}
- */
+
 
 #include <zephyr/init.h>
 #include <zephyr/arch/cpu.h>
@@ -82,12 +64,19 @@ static int test_early_sleep_app(void)
 
 SYS_INIT(test_early_sleep_app, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
 
-/**
- * @brief Test early sleep
+/*
+ * @brief Test early sleep functionality
  *
- * @ingroup kernel_earlysleep_tests
+ * @ingroup kernel_sleep_tests
  *
- * @see k_sleep()
+ * This test verifies that k_sleep() can be used to put the calling thread to
+ * sleep for a specified number of ticks during system initialization.  In this
+ * test we are calling k_sleep() at POST_KERNEL and APPLICATION level
+ * initialization sequence.
+ *
+ * Note: We can not call k_sleep() during PRE_KERNEL1 or PRE_KERNEL2 level
+ * because the core kernel objects and devices initialization happens at these
+ * levels.
  */
 ZTEST(earlysleep, test_early_sleep)
 {

--- a/tests/kernel/events/event_api/src/main.c
+++ b/tests/kernel/events/event_api/src/main.c
@@ -17,7 +17,7 @@
  *   -# k_event_wait_all
  *   -# k_event_test
  *
- * @defgroup kernel_event_tests events
+ * @defgroup kernel_event_tests Events
  * @ingroup all_tests
  * @{
  * @}

--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -46,6 +46,10 @@ static void entry_extra2(void *p1, void *p2, void *p3)
 
 	k_event_post(&test_event, events);
 }
+/**
+* @ingroup kernel_event_tests
+* @{
+*/
 
 /**
  * Test the k_event_init() API.
@@ -53,7 +57,6 @@ static void entry_extra2(void *p1, void *p2, void *p3)
  * This is a white-box test to verify that the k_event_init() API initializes
  * the fields of a k_event structure as expected.
  */
-
 ZTEST(events_api, test_k_event_init)
 {
 	static struct k_event  event;
@@ -431,3 +434,6 @@ ZTEST(events_api, test_event_receive)
 
 	test_wake_multiple_threads();
 }
+/**
+ * @}
+ */

--- a/tests/kernel/events/sys_event/src/main.c
+++ b/tests/kernel/events/sys_event/src/main.c
@@ -34,10 +34,8 @@ static K_SEM_DEFINE(sync_sem, 0, 1);
 volatile static uint32_t test_events;
 
 /**
- * @defgroup kernel_sys_events_tests Semaphore
- * @ingroup all_tests
+ * @ingroup kernel_event_tests
  * @{
- * @}
  */
 
 static void entry_extra1(void *p1, void *p2, void *p3)
@@ -404,5 +402,8 @@ void *sys_events_setup(void)
 	return NULL;
 }
 
+/**
+ * @}
+ */
 ZTEST_SUITE(sys_events, NULL, sys_events_setup,
 		ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);

--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -300,7 +300,7 @@ void check_stack_overflow(k_thread_entry_t handler, uint32_t flags)
  * should match. Check for stack sentinel feature by overflowing the
  * thread's stack and check for the exception.
  *
- * @ingroup kernel_common_tests
+ * @ingroup kernel_fatal_tests
  */
 ZTEST(fatal_exception, test_fatal)
 {

--- a/tests/kernel/fatal/no-multithreading/src/main.c
+++ b/tests/kernel/fatal/no-multithreading/src/main.c
@@ -117,14 +117,14 @@ static const exc_trigger_func_t exc_trigger_func[] = {
 };
 
 /**
- * @brief Test the kernel fatal error handling works correctly
+ * @brief Verify the kernel fatal error handling works correctly
  * @details Manually trigger the crash with various ways and check
  * that the kernel is handling that properly or not. Also the crash reason
  * should match.
  *
- * @ingroup kernel_common_tests
+ * @ingroup kernel_fatal_tests
  */
-ZTEST(fatal_no_mt, test_fatal)
+ZTEST(fatal_no_mt, test_fatal_no_mt)
 {
 #ifdef VIA_TWISTER
 #define EXC_TRIGGER_FUNC_IDX VIA_TWISTER

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -417,13 +417,32 @@ static void tmbox(struct k_mbox *pmbox)
 	k_thread_abort(receiver_tid);
 }
 
-/*test cases*/
+/**
+ * @addtogroup kernel_mbox_api
+ * @{
+ */
+
+
+/**
+ * @brief Test mailbox initialization
+ */
 ZTEST(mbox_api, test_mbox_kinit)
 {
 	/**TESTPOINT: init via k_mbox_init*/
 	k_mbox_init(&mbox);
 }
 
+/**
+ * @brief Test mailbox definition
+ *
+ * @details
+ * - Define a mailbox and verify the mailbox whether as expected
+ * - Verify the mailbox can be used
+ *
+ * @ingroup kernel_mbox_api
+ *
+ * @see k_mbox_init() k_mbox_put() k_mbox_get()
+ */
 ZTEST(mbox_api, test_mbox_kdefine)
 {
 	info_type = PUT_GET_NULL;
@@ -434,7 +453,7 @@ static ZTEST_BMEM char __aligned(4) buffer[8];
 
 /**
  *
- * @brief Test mailbox enhance capabilities
+ * @brief Test mailbox enhanced capabilities
  *
  * @details
  * - Define and initialized a message queue and a mailbox
@@ -445,7 +464,7 @@ static ZTEST_BMEM char __aligned(4) buffer[8];
  *
  * @see k_msgq_init() k_msgq_put() k_mbox_async_put() k_mbox_get()
  */
-ZTEST(mbox_api, test_enhance_capability)
+ZTEST(mbox_api, test_mbox_enhanced_capabilities)
 {
 	info_type = ASYNC_PUT_GET_BUFFER;
 	struct k_msgq msgq;
@@ -460,15 +479,13 @@ ZTEST(mbox_api, test_enhance_capability)
 	tmbox(&mbox);
 }
 
-/*
- *
- * @brife Test any number of mailbox can be defined
+/**
+ * @brief Test that multiple mailboxs can be defined
  *
  * @details
- * - Define multi mailbox and verify the mailbox whether as
+ * - Define multiple mailbox and verify the mailbox whether as
  *   expected
  * - Verify the mailbox can be used
- *
  */
 ZTEST(mbox_api, test_define_multi_mbox)
 {
@@ -486,84 +503,129 @@ ZTEST(mbox_api, test_define_multi_mbox)
 	tmbox(&mbox3);
 }
 
+/**
+ * @brief Test case for mailbox put and get operations with null data.
+ */
 ZTEST(mbox_api, test_mbox_put_get_null)
 {
 	info_type = PUT_GET_NULL;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox put and get operations with buffer.
+ *
+ */
 ZTEST(mbox_api, test_mbox_put_get_buffer)
 {
 	info_type = PUT_GET_BUFFER;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox asynchronous put and get operations with buffer.
+ *
+ */
 ZTEST(mbox_api, test_mbox_async_put_get_buffer)
 {
 	info_type = ASYNC_PUT_GET_BUFFER;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox asynchronous put and get operations with block.
+ *
+ */
 ZTEST(mbox_api, test_mbox_async_put_get_block)
 {
 	info_type = ASYNC_PUT_GET_BLOCK;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox target/source thread buffer operations.
+ */
 ZTEST(mbox_api, test_mbox_target_source_thread_buffer)
 {
 	info_type = TARGET_SOURCE_THREAD_BUFFER;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox incorrect receiver thread ID.
+ */
 ZTEST(mbox_api, test_mbox_incorrect_receiver_tid)
 {
 	info_type = INCORRECT_RECEIVER_TID;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox incorrect transmit thread ID.
+ */
 ZTEST(mbox_api, test_mbox_incorrect_transmit_tid)
 {
 	info_type = INCORRECT_TRANSMIT_TID;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox timed out get operation.
+ */
 ZTEST(mbox_api, test_mbox_timed_out_mbox_get)
 {
 	info_type = TIMED_OUT_MBOX_GET;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox message thread ID mismatch.
+ */
 ZTEST(mbox_api, test_mbox_msg_tid_mismatch)
 {
 	info_type = MSG_TID_MISMATCH;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox dispose size 0 message.
+ */
 ZTEST(mbox_api, test_mbox_dispose_size_0_msg)
 {
 	info_type = DISPOSE_SIZE_0_MSG;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox asynchronous put to waiting get operation.
+ */
 ZTEST(mbox_api, test_mbox_async_put_to_waiting_get)
 {
 	info_type = ASYNC_PUT_TO_WAITING_GET;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox get waiting put with incorrect thread ID.
+ */
 ZTEST(mbox_api, test_mbox_get_waiting_put_incorrect_tid)
 {
 	info_type = GET_WAITING_PUT_INCORRECT_TID;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox asynchronous multiple put operation.
+ */
 ZTEST(mbox_api, test_mbox_async_multiple_put)
 {
 	info_type = ASYNC_MULTIPLE_PUT;
 	tmbox(&mbox);
 }
 
+/**
+ * @brief Test case for mailbox multiple waiting get operation.
+ */
 ZTEST(mbox_api, test_mbox_multiple_waiting_get)
 {
 	info_type = MULTIPLE_WAITING_GET;
@@ -583,5 +645,9 @@ void *setup_mbox_api(void)
 
 	return NULL;
 }
+
+/**
+ * @}
+ */
 
 ZTEST_SUITE(mbox_api, NULL, setup_mbox_api, NULL, NULL, NULL);

--- a/tests/kernel/mem_heap/k_heap_api/src/main.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/main.c
@@ -7,9 +7,9 @@
 #include <zephyr/ztest.h>
 
 /**
- * @brief k heap api tests
+ * @brief Kernel Heap API Tests
  *
- * @defgroup k_heap api Tests
+ * @defgroup k_heap_api_tests Kernel Heap Tests
  *
  * @ingroup all_tests
  * @{

--- a/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
@@ -72,7 +72,7 @@ K_HEAP_DEFINE(tiny_heap, 1);
 volatile uint32_t heap_guard1;
 
 /** @brief Test a minimum-size static k_heap
- *  @ingroup kernel_kheap_api_tests
+ *  @ingroup k_heap_api_tests
  *
  * @details Create a minimum size (1-byte) static heap, verify that it
  * works to allocate that byte at runtime and that it doesn't overflow
@@ -105,7 +105,7 @@ ZTEST(k_heap_api, test_k_heap_min_size)
 /**
  * @brief Test to demonstrate k_heap_alloc() and k_heap_free() API usage
  *
- * @ingroup kernel_kheap_api_tests
+ * @ingroup k_heap_api_tests
  *
  * @details The test allocates 1024 bytes from 2048 byte heap,
  * and checks if allocation is successful or not
@@ -129,7 +129,7 @@ ZTEST(k_heap_api, test_k_heap_alloc)
 /**
  * @brief Test to demonstrate k_heap_alloc() and k_heap_free() API usage
  *
- * @ingroup kernel_kheap_api_tests
+ * @ingroup k_heap_api_tests
  *
  * @details The test allocates 2049 bytes, which is greater than the heap
  * size(2048 bytes), and checks for NULL return from k_heap_alloc
@@ -151,7 +151,7 @@ ZTEST(k_heap_api, test_k_heap_alloc_fail)
 /**
  * @brief Test to demonstrate k_heap_free() API functionality.
  *
- * @ingroup kernel_kheap_api_tests
+ * @ingroup k_heap_api_tests
  *
  * @details The test validates k_heap_free()
  * API, by using below steps
@@ -184,7 +184,7 @@ ZTEST(k_heap_api, test_k_heap_free)
  * @details The test validates k_heap_alloc() in isr context, the timeout
  * param should be K_NO_WAIT, because this situation isn't allow to wait.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  */
 ZTEST(k_heap_api, test_kheap_alloc_in_isr_nowait)
 {
@@ -198,7 +198,7 @@ ZTEST(k_heap_api, test_kheap_alloc_in_isr_nowait)
  * child thread. If there isn't enough space in the heap, the child thread
  * will wait timeout long until main thread free the buffer to heap.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  */
 ZTEST(k_heap_api, test_k_heap_alloc_pending)
 {
@@ -235,7 +235,7 @@ ZTEST(k_heap_api, test_k_heap_alloc_pending)
  * will wait timeout long until main thread free one of the buffer to heap, space in
  * the heap is still not enough and then return null after timeout.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  */
 ZTEST(k_heap_api, test_k_heap_alloc_pending_null)
 {
@@ -271,7 +271,7 @@ ZTEST(k_heap_api, test_k_heap_alloc_pending_null)
 /**
  * @brief Test to demonstrate k_heap_calloc() and k_heap_free() API usage
  *
- * @ingroup kernel_kheap_api_tests
+ * @ingroup k_heap_api_tests
  *
  * @details The test allocates 256 unsigned integers of 4 bytes for a
  * total of 1024 bytes from the 2048 byte heap. It checks if allocation

--- a/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_domain.c
@@ -176,7 +176,7 @@ ZTEST(mem_protect_domain, test_mem_domain_invalid_access)
 /**
  * @brief Show that a read-only partition can't be written to
  *
- * @ingroup kernel_memgroup_tests
+ * @ingroup kernel_memprotect_tests
  */
 ZTEST(mem_protect_domain, test_mem_domain_no_writes_to_ro)
 {

--- a/tests/kernel/semaphore/sys_sem/src/main.c
+++ b/tests/kernel/semaphore/sys_sem/src/main.c
@@ -27,7 +27,6 @@ static ZTEST_DMEM int flag;
 static ZTEST_DMEM atomic_t atomic_count;
 
 /**
- * @defgroup kernel_sys_sem_tests Semaphore
  * @ingroup all_tests
  * @{
  * @}
@@ -73,7 +72,7 @@ static void thread_high_prio_sem_take(void *p1, void *p2, void *p3)
  * - Use semaphore normally
  * - Use semaphore with different priority threads
  *
- * @ingroup kernel_sys_sem_tests
+ * @ingroup kernel_semaphore_tests
  */
 ZTEST_USER(kernel_sys_sem, test_multiple_thread_sem_usage)
 {
@@ -168,7 +167,7 @@ static void multi_thread_sem_take(void *p1, void *p2, void *p3)
  * - Verify more than max count about semaphore can reach.
  * - Take sem by multiple threads and verify if sem count is correct.
  *
- * @ingroup kernel_sys_sem_tests
+ * @ingroup kernel_semaphore_tests
  */
 ZTEST_USER(kernel_sys_sem, test_multi_thread_sem_limit)
 {

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -78,7 +78,7 @@ static void customdata_entry(void *p1, void *p2, void *p3)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief test thread custom data get/set from coop thread
+ * @brief Test thread custom data get/set from coop thread
  *
  * @see k_thread_custom_data_get(), k_thread_custom_data_set()
  */
@@ -101,7 +101,7 @@ static void thread_name_entry(void *p1, void *p2, void *p3)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief test thread name get/set from supervisor thread
+ * @brief Test thread name get/set from supervisor thread
  * @see k_thread_name_get(), k_thread_name_copy(), k_thread_name_set()
  */
 ZTEST(threads_lifecycle, test_thread_name_get_set)
@@ -142,7 +142,7 @@ struct k_sem sem;
 
 /**
  * @ingroup kernel_thread_tests
- * @brief test thread name get/set from user thread
+ * @brief Test thread name get/set from user thread
  * @see k_thread_name_copy(), k_thread_name_set()
  */
 ZTEST_USER(threads_lifecycle, test_thread_name_user_get_set)
@@ -211,7 +211,7 @@ ZTEST_USER(threads_lifecycle, test_thread_name_user_get_set)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief test thread custom data get/set from preempt thread
+ * @brief Test thread custom data get/set from preempt thread
  * @see k_thread_custom_data_get(), k_thread_custom_data_set()
  */
 ZTEST_USER(threads_lifecycle_1cpu, test_customdata_get_set_preempt)
@@ -243,7 +243,7 @@ static void umode_entry(void *thread_id, void *p2, void *p3)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief Test k_thread_user_mode_enter() to cover when userspace
+ * @brief Test k_thread_user_mode_enter to cover when userspace
  * is not supported/enabled
  * @see k_thread_user_mode_enter()
  */
@@ -392,6 +392,11 @@ static inline int join_scenario(enum control_method m)
 	return join_scenario_interval(m, NULL);
 }
 
+/**
+ * @ingroup kernel_thread_tests
+ * @brief Test thread join
+ *
+ */
 ZTEST_USER(threads_lifecycle, test_thread_join)
 {
 	int64_t interval;
@@ -415,6 +420,13 @@ ZTEST_USER(threads_lifecycle, test_thread_join)
 
 }
 
+/**
+ * @ingroup kernel_thread_tests
+ * @brief Test thread join from ISR
+ *
+ * @see k_thread_join()
+ * @see k_thread_abort()
+ */
 ZTEST(threads_lifecycle, test_thread_join_isr)
 {
 	zassert_equal(join_scenario(ISR_RUNNING), -EBUSY, "failed isr running");
@@ -447,6 +459,21 @@ static void deadlock2_entry(void *p1, void *p2, void *p3)
 	zassert_equal(ret, 0, "couldn't join deadlock2_thread");
 }
 
+
+
+/**
+ * @brief Test case for thread join deadlock scenarios.
+ *
+ * This test verifies the behavior of the `k_thread_join` API in scenarios
+ * that could lead to deadlocks. It includes the following checks:
+ *
+ * - Ensures that a thread cannot join itself, which would result in a
+ *   self-deadlock. The API should return `-EDEADLK` in this case.
+ * - Creates two threads (`deadlock1_thread` and `deadlock2_thread`) and
+ *   verifies that they can be joined successfully without causing a deadlock.
+ *
+ * @ingroup kernel_thread_tests
+ */
 ZTEST_USER(threads_lifecycle, test_thread_join_deadlock)
 {
 	/* Deadlock scenarios */
@@ -476,6 +503,11 @@ static void user_start_thread(void *p1, void *p2, void *p3)
 {
 	/* do nothing */
 }
+/**
+ * @brief Test case for verifying thread timeout expiration and remaining time.
+ *
+ * @ingroup kernel_thread_tests
+ */
 
 ZTEST_USER(threads_lifecycle, test_thread_timeout_remaining_expires)
 {
@@ -528,10 +560,16 @@ static void foreach_callback(const struct k_thread *thread, void *user_data)
 		stats.execution_cycles;
 }
 
-/* This case accumulates every thread's execution_cycles first, then
+/**
+ * @brief Test case for thread runtime statistics retrieval in Zephyr kernel
+ *
+ * This case accumulates every thread's execution_cycles first, then
  * get the total execution_cycles from a global
  * k_thread_runtime_stats_t to see that all time is reflected in the
  * total.
+ *
+ * @ingroup kernel_thread_tests
+ * @see k_thread_runtime_stats_get()
  */
 ZTEST(threads_lifecycle, test_thread_runtime_stats_get)
 {
@@ -551,6 +589,13 @@ ZTEST(threads_lifecycle, test_thread_runtime_stats_get)
 	zassert_true(stats.execution_cycles <= stats_all.execution_cycles);
 }
 
+
+/**
+ * @brief Test the behavior of k_busy_wait with thread runtime statistics.
+ *
+ * This test verifies the accuracy of the `k_busy_wait` function by checking
+ * the thread's execution cycle statistics before and after calling the function.
+ */
 ZTEST(threads_lifecycle, test_k_busy_wait)
 {
 	uint64_t cycles, dt;
@@ -589,6 +634,12 @@ static void tp_entry(void *p1, void *p2, void *p3)
 	tp = 100;
 }
 
+/**
+ * @brief Test the behavior of k_busy_wait with thread runtime statistics
+ *        in user mode.
+ *
+ * @ingroup kernel_thread_tests
+ */
 ZTEST_USER(threads_lifecycle_1cpu, test_k_busy_wait_user)
 {
 
@@ -624,9 +675,14 @@ static int small_stack(size_t *space)
 	return k_thread_stack_space_get(k_current_get(), space);
 }
 
-/* test k_thread_stack_sapce_get(), unused stack space in large_stack_space()
+/**
+ * @brief Test k_thread_stack_sapce_get
+ *
+ * Test k_thread_stack_sapce_get unused stack space in large_stack_space()
  * is smaller than that in small_stack() because the former function has a
  * large local variable
+ *
+ * @ingroup kernel_thread_tests
  */
 ZTEST_USER(threads_lifecycle, test_k_thread_stack_space_get_user)
 {

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -114,6 +114,16 @@ ZTEST(threads_lifecycle, test_essential_thread_abort)
 	zassert_true(fatal_error_signaled, "fatal error was not signaled");
 }
 
+/**
+ * @brief Abort an essential thread from itself
+ *
+ * @details The kernel shall raise a fatal system error if an essential thread
+ *          aborts, implement k_sys_fatal_error_handler to handle this error.
+ *
+ * @ingroup kernel_thread_tests
+ *
+ * @see #K_ESSENTIAL(x)
+ */
 ZTEST(threads_lifecycle, test_essential_thread_abort_self)
 {
 	/* This test case needs to be able to handle a k_panic() call

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -32,7 +32,7 @@ static void thread_entry_abort(void *p1, void *p2, void *p3)
 }
 /**
  * @ingroup kernel_thread_tests
- * @brief Validate k_thread_abort() when called by current thread
+ * @brief Validate aborting a thread when called by current thread
  *
  * @details Create a user thread and let the thread execute.
  * Then call k_thread_abort() and check if the thread is terminated.
@@ -52,7 +52,7 @@ ZTEST_USER(threads_lifecycle, test_threads_abort_self)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief Validate k_thread_abort() when called by other thread
+ * @brief Validate aborting a thread when called by other thread
  *
  * @details Create a user thread and abort the thread before its
  * execution. Create a another user thread and abort the thread
@@ -85,7 +85,7 @@ ZTEST_USER(threads_lifecycle, test_threads_abort_others)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief Test abort on a terminated thread
+ * @brief Test abort on an already terminated thread
  *
  * @see k_thread_abort()
  */

--- a/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cpu_mask.c
@@ -22,6 +22,19 @@ void child_fn(void *a, void *b, void *c)
 	child_has_run = true;
 }
 
+
+/**
+ * @brief Test the CPU mask APIs for thread lifecycle management
+ *
+ * This test verifies the behavior of the CPU mask APIs in the Zephyr kernel
+ * for thread lifecycle management. It ensures that the APIs behave as expected
+ * when operating on both running and non-running threads.
+ *
+ * @note This test is only executed if `CONFIG_SCHED_CPU_MASK` is enabled.
+ *       Otherwise, the test is skipped.
+ *
+ * @ingroup kernel_thread_tests
+ */
 ZTEST(threads_lifecycle_1cpu, test_threads_cpu_mask)
 {
 #ifdef CONFIG_SCHED_CPU_MASK

--- a/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
@@ -129,7 +129,7 @@ ZTEST(threads_lifecycle, test_threads_spawn_forever)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief Validate behavior of multiple calls to k_thread_start()
+ * @brief Validate behavior of multiple calls to k_thread_start
  *
  * @details Call k_thread_start() on an already terminated thread
  *

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -86,7 +86,7 @@ void suspend_myself(void *arg0, void *arg1, void *arg2)
 /**
  * @ingroup kernel_thread_tests
  *
- * @brief Check that k_thread_suspend() is a schedule point when
+ * @brief Check that suspending a thread is a schedule point when
  * called on the current thread.
  */
 ZTEST(threads_lifecycle, test_threads_suspend)
@@ -121,7 +121,7 @@ void sleep_suspended(void *arg0, void *arg1, void *arg2)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief Check that k_thread_suspend() cancels a preexisting thread timeout
+ * @brief Check that suspending a thread cancels a preexisting thread timeout
  *
  * @details Suspended threads should not wake up unexpectedly if they
  * happened to have been sleeping when suspended.
@@ -149,7 +149,7 @@ ZTEST(threads_lifecycle, test_threads_suspend_timeout)
 
 /**
  * @ingroup kernel_thread_tests
- * @brief Check resume an unsuspend thread
+ * @brief Check resuming a thread that is not suspended
  *
  * @details Use k_thread_state_str() to get thread state.
  * Resume an unsuspend thread will not change the thread state.

--- a/tests/lib/c_lib/common/src/main.c
+++ b/tests/lib/c_lib/common/src/main.c
@@ -65,17 +65,17 @@ volatile long long_max = LONG_MAX;
 volatile long long_one = 1L;
 
 /**
- *
  * @brief Test implementation-defined constants library
- * @defgroup libc_api
+ * @defgroup libc_api C Library APIs
  * @ingroup all_tests
  * @{
  *
  */
-
+/**
+ * @brief Test c library limits
+ */
 ZTEST(libc_common, test_limits)
 {
-
 	zassert_true((long_max + long_one == LONG_MIN));
 }
 
@@ -84,13 +84,15 @@ static ssize_t foobar(void)
 	return -1;
 }
 
+/**
+ * @brief Test C library ssize_t
+ */
 ZTEST(libc_common, test_ssize_t)
 {
 	zassert_true(foobar() < 0);
 }
 
 /**
- *
  * @brief Test boolean types and values library
  *
  */
@@ -110,7 +112,6 @@ volatile long long_variable;
 volatile size_t size_of_long_variable = sizeof(long_variable);
 
 /**
- *
  * @brief Test standard type definitions library
  *
  */
@@ -132,7 +133,6 @@ volatile uint8_t unsigned_byte = 0xff;
 volatile uint32_t unsigned_int = 0xffffff00;
 
 /**
- *
  * @brief Test integer types library
  *
  */
@@ -157,7 +157,6 @@ ZTEST(libc_common, test_stdint)
 }
 
 /**
- *
  * @brief Test time_t to make sure it is at least 64 bits
  *
  */
@@ -179,7 +178,6 @@ ZTEST(libc_common, test_time_t)
 char buffer[BUFSIZE];
 
 /**
- *
  * @brief Test string memset
  *
  */
@@ -199,7 +197,6 @@ ZTEST(libc_common, test_memset)
 }
 
 /**
- *
  * @brief Test string length function
  *
  * @see strlen(), strnlen().
@@ -216,7 +213,6 @@ ZTEST(libc_common, test_strlen)
 }
 
 /**
- *
  * @brief Test string compare function
  *
  * @see strcmp(), strncasecmp().
@@ -669,7 +665,7 @@ ZTEST(libc_common, test_str_operate)
  *
  * @brief test strtol function
  *
- * @detail   in 32bit system:
+ * @details   in 32bit system:
  *	when base is 10, [-2147483648..2147483647]
  *		   in 64bit system:
  *	when base is 10,
@@ -1330,3 +1326,6 @@ ZTEST(libc_common, test_exit)
 	zassert_equal(a, 0, "exit failed");
 #endif
 }
+/**
+ * @}
+ */

--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -35,8 +35,7 @@ TOOLCHAIN_DISABLE_GCC_WARNING(TOOLCHAIN_WARNING_ALLOC_SIZE_LARGER_THAN)
 /**
  *
  * @brief Test implementation-defined constants library
- * @defgroup libc_api
- * @ingroup all_tests
+ * @ingroup libc_api
  * @{
  *
  */
@@ -350,10 +349,6 @@ ZTEST(c_lib_dynamic_memalloc, test_memalloc_all)
 }
 
 /**
- * @}
- */
-
-/**
  *
  * @brief Test dynamic memory allocation upto maximum size
  * Negative test case
@@ -374,5 +369,9 @@ ZTEST(c_lib_dynamic_memalloc, test_memalloc_max)
 	_test_memalloc_max();
 }
 #endif
+
+/**
+ * @}
+ */
 
 ZTEST_SUITE(c_lib_dynamic_memalloc, NULL, NULL, NULL, NULL, NULL);

--- a/tests/lib/multi_heap/src/test_mheap_api.c
+++ b/tests/lib/multi_heap/src/test_mheap_api.c
@@ -180,7 +180,7 @@ static void realloc_handler(void *p1, void *p2, void *p3)
 /**
  * @brief Test to demonstrate k_malloc() and k_free() API usage
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  *
  * @details The test allocates 4 blocks from heap memory pool
  * using k_malloc() API. It also tries to allocate a block of size
@@ -225,7 +225,7 @@ ZTEST(mheap_api, test_mheap_realloc)
 /**
  * @brief Test to demonstrate k_calloc() API functionality.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  *
  * @details The test validates k_calloc() API. When requesting a
  * huge size of space or a space larger than heap memory,
@@ -299,7 +299,7 @@ ZTEST(mheap_api, test_k_aligned_alloc)
  * a block of memory smaller than the pool and will fail when alloc
  * a block of memory larger than the pool.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  *
  * @see k_thread_system_pool_assign(), z_thread_malloc(), k_free()
  */
@@ -328,7 +328,7 @@ ZTEST(mheap_api, test_sys_heap_mem_pool_assign)
  * memory because in this situation, the kernel will assign the heap memory
  * as resource pool.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  *
  * @see z_thread_malloc(), k_free()
  */
@@ -347,7 +347,7 @@ ZTEST(mheap_api, test_malloc_in_isr)
  *
  * @details When a thread's resource pool is not assigned, alloc memory will fail.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  *
  * @see z_thread_malloc()
  */

--- a/tests/lib/multi_heap/src/test_mheap_concept.c
+++ b/tests/lib/multi_heap/src/test_mheap_concept.c
@@ -49,7 +49,7 @@ static void tmheap_malloc_align4_handler(void *p1, void *p2, void *p3)
 /**
  * @brief The test validates k_calloc() API.
  *
- * @ingroup kernel_heap_tests
+ * @ingroup k_heap_api_tests
  *
  * @details The 8 blocks of memory of size 16 bytes are allocated
  * by k_calloc() API. When allocated using k_calloc() the memory buffers

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -19,8 +19,7 @@
 /**
  *
  * @brief Test implementation-defined constants library
- * @defgroup libc_api
- * @ingroup all_tests
+ * @ingroup libc_api
  * @{
  *
  */

--- a/tests/tests.dox
+++ b/tests/tests.dox
@@ -1,0 +1,18 @@
+/**
+
+@brief Tests
+@defgroup all_tests Tests
+@{
+@}
+
+@defgroup kernel_fatal_tests Fatal Handling
+@ingroup all_tests
+@{
+@}
+
+@defgroup kernel_memprotect_tests Memory Protection
+@ingroup all_tests
+@{
+@}
+
+*/

--- a/tests/tests.dox
+++ b/tests/tests.dox
@@ -10,6 +10,16 @@
 @{
 @}
 
+@defgroup kernel_arch_sched_tests Architecture Context Switching / Swap
+@ingroup all_tests
+@{
+@}
+
+@defgroup kernel_arch_interrupt_tests Architecture Interrupt Handling
+@ingroup all_tests
+@{
+@}
+
 @defgroup kernel_memprotect_tests Memory Protection
 @ingroup all_tests
 @{


### PR DESCRIPTION
- **tests: kernel: threads: improve doxygen comments, layout**
- **tests: kernel: fix kheap doxygen groups**
- **tests: kernel/common: cleanup doxygen**
- **tests: kernel: fix doxygen comments/groups for condition variables**
- **tests: semaphore: fix doxygen groups**
- **tests: events: fix doxygen groups**
- **tests: kernel: mbox: fix doxygen grouping**
