### PR TITLE
drivers: stepper: tmc_spi: remove print_status_byte

### DIFF
--- a/drivers/stepper/adi_tmc/adi_tmc_spi.c
+++ b/drivers/stepper/adi_tmc/adi_tmc_spi.c
@@ -4,33 +4,9 @@
  */
 
 #include <zephyr/sys/util.h>
-
 #include "adi_tmc_spi.h"
 
 #define BUFFER_SIZE 5U
-
-#include <zephyr/logging/log.h>
-
-LOG_MODULE_REGISTER(tmc_spi, CONFIG_SPI_LOG_LEVEL);
-
-static void parse_tmc_spi_status(const uint8_t status_byte)
-{
-	if ((status_byte & BIT_MASK(0)) != 0) {
-		LOG_WRN("spi dataframe: reset_flag detected");
-	}
-	if ((status_byte & BIT_MASK(1)) != 0) {
-		LOG_WRN("spi dataframe: driver_error(1) detected");
-	}
-	if ((status_byte & BIT_MASK(2)) != 0) {
-		LOG_WRN("spi dataframe: driver_error(2) detected");
-	}
-}
-
-static void print_tx_rx_buffer(const uint8_t *const tx_buffer, const uint8_t *const rx_buffer)
-{
-	LOG_HEXDUMP_DBG(tx_buffer, BUFFER_SIZE, "TX: ");
-	LOG_HEXDUMP_DBG(rx_buffer, BUFFER_SIZE, "RX: ");
-}
 
 int tmc_spi_read_register(const struct spi_dt_spec *bus, const uint8_t read_address_mask,
 			  const uint8_t register_address, uint32_t *data)
@@ -63,9 +39,6 @@ int tmc_spi_read_register(const struct spi_dt_spec *bus, const uint8_t read_addr
 		return status;
 	}
 
-	print_tx_rx_buffer(tx_buffer, rx_buffer);
-	parse_tmc_spi_status(rx_buffer[0]);
-
 	/** read the value from the address */
 	status = spi_transceive_dt(bus, &spi_buffer_array_tx, &spi_buffer_array_rx);
 	if (status < 0) {
@@ -75,8 +48,6 @@ int tmc_spi_read_register(const struct spi_dt_spec *bus, const uint8_t read_addr
 	*data = ((uint32_t)rx_buffer[1] << 24) + ((uint32_t)rx_buffer[2] << 16) +
 		((uint32_t)rx_buffer[3] << 8) + (uint32_t)rx_buffer[4];
 
-	print_tx_rx_buffer(tx_buffer, rx_buffer);
-	parse_tmc_spi_status(rx_buffer[0]);
 	return status;
 }
 
@@ -110,9 +81,6 @@ int tmc_spi_write_register(const struct spi_dt_spec *bus, const uint8_t write_bi
 	if (status < 0) {
 		return status;
 	}
-
-	print_tx_rx_buffer(tx_buffer, rx_buffer);
-	parse_tmc_spi_status(rx_buffer[0]);
 
 	return status;
 }


### PR DESCRIPTION
print_status_byte is specific to tmc50xx and hence shoud not be placeed in common tmc_spi.c which is supposed to be reused by a variety of drivers

This print of status byte should rather be part of driver code