### PR TITLE
drivers: stepper: unify msx-gpios

### DIFF
--- a/drivers/stepper/adi_tmc/tmc22xx.c
+++ b/drivers/stepper/adi_tmc/tmc22xx.c
@@ -14,7 +14,6 @@ LOG_MODULE_REGISTER(tmc22xx, CONFIG_STEPPER_LOG_LEVEL);
 struct tmc22xx_config {
 	struct step_dir_stepper_common_config common;
 	const struct gpio_dt_spec enable_pin;
-	const struct gpio_dt_spec *msx_pins;
 	enum stepper_micro_step_resolution *msx_resolutions;
 };
 
@@ -48,7 +47,7 @@ static int tmc22xx_stepper_set_micro_step_res(const struct device *dev,
 	const struct tmc22xx_config *config = dev->config;
 	int ret;
 
-	if (!config->msx_pins) {
+	if (!config->common.msx_pins) {
 		LOG_ERR("Microstep resolution pins are not configured");
 		return -ENODEV;
 	}
@@ -58,13 +57,13 @@ static int tmc22xx_stepper_set_micro_step_res(const struct device *dev,
 			continue;
 		}
 
-		ret = gpio_pin_set_dt(&config->msx_pins[0], i & 0x01);
+		ret = gpio_pin_set_dt(&config->common.msx_pins[0], i & 0x01);
 		if (ret < 0) {
 			LOG_ERR("Failed to set MS1 pin: %d", ret);
 			return ret;
 		}
 
-		ret = gpio_pin_set_dt(&config->msx_pins[1], (i & 0x02) >> 1);
+		ret = gpio_pin_set_dt(&config->common.msx_pins[1], (i & 0x02) >> 1);
 		if (ret < 0) {
 			LOG_ERR("Failed to set MS2 pin: %d", ret);
 			return ret;
@@ -93,12 +92,12 @@ static int tmc22xx_stepper_configure_msx_pins(const struct device *dev)
 	int ret;
 
 	for (uint8_t i = 0; i < MSX_PIN_COUNT; i++) {
-		if (!gpio_is_ready_dt(&config->msx_pins[i])) {
+		if (!gpio_is_ready_dt(&config->common.msx_pins[i])) {
 			LOG_ERR("MSX pin %u are not ready", i);
 			return -ENODEV;
 		}
 
-		ret = gpio_pin_configure_dt(&config->msx_pins[i], GPIO_OUTPUT);
+		ret = gpio_pin_configure_dt(&config->common.msx_pins[i], GPIO_OUTPUT);
 		if (ret < 0) {
 			LOG_ERR("Failed to configure msx pin %u", i);
 			return ret;
@@ -124,7 +123,7 @@ static int tmc22xx_stepper_init(const struct device *dev)
 		return ret;
 	}
 
-	if (config->msx_pins) {
+	if (config->common.msx_pins) {
 		ret = tmc22xx_stepper_configure_msx_pins(dev);
 		if (ret < 0) {
 			LOG_ERR("Failed to configure MSX pins: %d", ret);
@@ -176,11 +175,10 @@ static DEVICE_API(stepper, tmc22xx_stepper_api) = {
 	))                                                                                         \
                                                                                                    \
 	static const struct tmc22xx_config tmc22xx_config_##inst = {                               \
-		.common = STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst),                       \
+		.common = STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(				   \
+			inst, tmc22xx_stepper_msx_pins_##inst),					   \
 		.enable_pin = GPIO_DT_SPEC_INST_GET(inst, en_gpios),	                           \
 		.msx_resolutions = msx_table,                                                      \
-		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, msx_gpios),				   \
-		(.msx_pins = tmc22xx_stepper_msx_pins_##inst))					   \
 	};                                                                                         \
 	static struct tmc22xx_data tmc22xx_data_##inst = {                                         \
 		.common = STEP_DIR_STEPPER_DT_INST_COMMON_DATA_INIT(inst),                         \

--- a/drivers/stepper/step_dir/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.h
@@ -29,6 +29,7 @@
 struct step_dir_stepper_common_config {
 	const struct gpio_dt_spec step_pin;
 	const struct gpio_dt_spec dir_pin;
+	const struct gpio_dt_spec *msx_pins;
 	bool dual_edge;
 	const struct stepper_timing_source_api *timing_source;
 	const struct device *counter;
@@ -42,8 +43,9 @@ struct step_dir_stepper_common_config {
  *
  * @param node_id The devicetree node identifier.
  */
-#define STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(node_id)                                            \
-	{                                                                                          \
+#define STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(node_id, msx_gpio_array)				   \
+	{											   \
+		IF_ENABLED(DT_NODE_HAS_PROP(node_id, msx_gpios), (.msx_pins = msx_gpio_array,))    \
 		.step_pin = GPIO_DT_SPEC_GET(node_id, step_gpios),                                 \
 		.dir_pin = GPIO_DT_SPEC_GET(node_id, dir_gpios),                                   \
 		.dual_edge = DT_PROP_OR(node_id, dual_edge_step, false),                           \
@@ -51,15 +53,15 @@ struct step_dir_stepper_common_config {
 		.invert_direction = DT_PROP(node_id, invert_direction),                            \
 		.timing_source = COND_CODE_1(DT_NODE_HAS_PROP(node_id, counter),                   \
 						(&step_counter_timing_source_api),                 \
-						(&step_work_timing_source_api)),                   \
+						(&step_work_timing_source_api)),		   \
 	}
 
 /**
  * @brief Initialize common step direction stepper config from devicetree instance.
  * @param inst Instance.
  */
-#define STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst)                                          \
-	STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(DT_DRV_INST(inst))
+#define STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst, msx_gpio_array)                          \
+	STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(DT_DRV_INST(inst), msx_gpio_array)
 
 /**
  * @brief Common step direction stepper data.

--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -21,14 +21,6 @@ include:
   - name: stepper-controller.yaml
 
 properties:
-  msx-gpios:
-    type: phandle-array
-    description: |
-      An array of GPIO pins for configuring the microstep resolution of the driver.
-      The pins should be listed in the following order:
-      - MS1
-      - MS2
-
   dual-edge-step:
     type: boolean
     description: |

--- a/dts/bindings/stepper/allegro/allegro,a4979.yml
+++ b/dts/bindings/stepper/allegro/allegro,a4979.yml
@@ -16,8 +16,8 @@ description: |
       dir-gpios = <&gpiod 14 GPIO_ACTIVE_HIGH>;
       step-gpios = <&gpiod 15 GPIO_ACTIVE_HIGH>;
       en-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
-      m0-gpios = <&gpiod 13 0>;
-      m1-gpios = <&gpiod 12 0>;
+      msx-gpios = <&gpiod 13 0>,
+                  <&gpiod 12 0>;
       counter = <&counter5>;
   };
 
@@ -27,16 +27,6 @@ include:
   - name: stepper-controller.yaml
 
 properties:
-  m0-gpios:
-    required: true
-    type: phandle-array
-    description: Microstep configuration pin 0.
-
-  m1-gpios:
-    required: true
-    type: phandle-array
-    description: Microstep configuration pin 1.
-
   reset-gpios:
     type: phandle-array
     required: true

--- a/dts/bindings/stepper/stepper-controller.yaml
+++ b/dts/bindings/stepper/stepper-controller.yaml
@@ -41,6 +41,15 @@ properties:
       The GPIO pins used to send direction signals to the stepper motor.
       Pin will be driven high for forward direction and low for reverse direction.
 
+  msx-gpios:
+    type: phandle-array
+    description: |
+      An array of GPIO pins for configuring the microstep resolution of the driver.
+      The pins should be listed in the following order:
+      - MS1
+      - MS2
+      - MS3
+
   counter:
     type: phandle
     description: Counter used for generating step-accurate pulse signals.

--- a/dts/bindings/stepper/ti/ti,drv84xx.yaml
+++ b/dts/bindings/stepper/ti/ti,drv84xx.yaml
@@ -21,8 +21,8 @@ description: |
     fault-gpios = <&arduino_header 16 0>;
     sleep-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;
     en-gpios  = <&arduino_header 14 0>;
-    m0-gpios = <&mikroe_stepper_gpios 0 0>;
-    m1-gpios = <&mikroe_stepper_gpios 1 0>;
+    msx-gpios = <&mikroe_stepper_gpios 0 0>,
+                <&mikroe_stepper_gpios 1 0>;
     counter = <&counter2>;
   };
 
@@ -40,11 +40,3 @@ properties:
   sleep-gpios:
     type: phandle-array
     description: Sleep pin (active low).
-
-  m0-gpios:
-    type: phandle-array
-    description: Microstep configuration pin 0.
-
-  m1-gpios:
-    type: phandle-array
-    description: Microstep configuration pin 1.

--- a/tests/drivers/build_all/stepper/gpio.dtsi
+++ b/tests/drivers/build_all/stepper/gpio.dtsi
@@ -27,8 +27,8 @@ allegro_a4979: allegro_a4979 {
 	dir-gpios = <&test_gpio 0 0>;
 	step-gpios = <&test_gpio 0 0>;
 	en-gpios = <&test_gpio 0 0>;
-	m0-gpios = <&test_gpio 0 0>;
-	m1-gpios = <&test_gpio 0 0>;
+	msx-gpios = <&test_gpio 0 0>,
+		    <&test_gpio 0 0>;
 	counter = <&counter0>;
 };
 
@@ -40,8 +40,8 @@ ti_drv84xx: ti_drv84xx {
 	step-gpios = <&test_gpio 0 0>;
 	sleep-gpios = <&test_gpio 0 0>;
 	en-gpios  = <&test_gpio 0 0>;
-	m0-gpios = <&test_gpio 0 0>;
-	m1-gpios = <&test_gpio 0 0>;
+	msx-gpios = <&test_gpio 0 0>,
+		    <&test_gpio 0 0>;
 	counter = <&counter0>;
 };
 

--- a/tests/drivers/stepper/drv84xx/api/boards/native_sim.overlay
+++ b/tests/drivers/stepper/drv84xx/api/boards/native_sim.overlay
@@ -20,8 +20,7 @@
 		step-gpios = <&gpio1 1 0>; /* D4 */
 		sleep-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>; /* D2 */
 		en-gpios = <&gpio2 1 0>; /* 5 */
-		m0-gpios = <&gpio3 0 0>;
-		m1-gpios = <&gpio3 1 0>;
+		msx-gpios = <&gpio3 0 0>, <&gpio3 1 0>;
 		counter = <&counter0>;
 
 		#address-cells = <1>;

--- a/tests/drivers/stepper/drv84xx/emul/boards/native_sim.overlay
+++ b/tests/drivers/stepper/drv84xx/emul/boards/native_sim.overlay
@@ -15,8 +15,7 @@
 		step-gpios = <&gpio1 1 0>; /* D4 */
 		sleep-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>; /* D2 */
 		en-gpios = <&gpio2 1 0>; /* 5 */
-		m0-gpios = <&gpio3 0 0>;
-		m1-gpios = <&gpio3 1 0>;
+		msx-gpios = <&gpio3 0 0>, <&gpio3 1 0>;
 		counter = <&counter0>;
 
 		#address-cells = <1>;

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979.overlay
@@ -20,8 +20,7 @@
 		dir-gpios = <&gpio1 0 0>;
 		step-gpios = <&gpio1 1 0>;
 		en-gpios = <&gpio2 1 0>;
-		m0-gpios = <&gpio3 0 0>;
-		m1-gpios = <&gpio3 1 0>;
+		msx-gpios = <&gpio3 0 0>, <&gpio3 1 0>;
 		counter = <&counter0>;
 	};
 };

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx.overlay
@@ -20,8 +20,7 @@
 		step-gpios = <&gpio1 1 0>;
 		sleep-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 		en-gpios = <&gpio2 1 0>;
-		m0-gpios = <&gpio3 0 0>;
-		m1-gpios = <&gpio3 1 0>;
+		msx-gpios = <&gpio3 0 0>, <&gpio3 1 0>;
 		counter = <&counter0>;
 	};
 };


### PR DESCRIPTION
currently there are two different ways how microstepping gpios are handled in step/dir drivers. This PR aims to unify the two different approaches.

This resolves the issue: https://github.com/zephyrproject-rtos/zephyr/issues/88066