### PR TITLE
dts: stm32h5: Add DCMI device information

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -655,6 +655,15 @@
 			clocks = <&rcc STM32_CLOCK(APB1_2, 3U)>;
 			status = "disabled";
 		};
+
+		dcmi: dcmi@4202c000 {
+			compatible = "st,stm32-dcmi";
+			reg = <0x4202c000 0x400>;
+			interrupts = <108 0>;
+			interrupt-names = "dcmi";
+			clocks = <&rcc STM32_CLOCK(AHB2, 12U)>;
+			status = "disabled";
+		};
 	};
 
 	die_temp: dietemp {

--- a/dts/arm/st/h5/stm32h503.dtsi
+++ b/dts/arm/st/h5/stm32h503.dtsi
@@ -6,6 +6,8 @@
 
 #include <st/h5/stm32h5.dtsi>
 
+/delete-node/ &dcmi;
+
 / {
 	soc {
 		compatible = "st,stm32h503", "st,stm32h5", "simple-bus";


### PR DESCRIPTION
The STM32H5 dtsi file lacked DCMI device driver information, despite this SoC family containing a DCMI device driver. This adds device support for DCMI on the STM32H5.