### PR TITLE
rtio: Introduce OP_DELAY as a valid SQE operation

### DIFF
--- a/subsys/rtio/CMakeLists.txt
+++ b/subsys/rtio/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CONFIG_RTIO)
 
 	zephyr_library_sources(rtio_executor.c)
 	zephyr_library_sources(rtio_init.c)
+	zephyr_library_sources(rtio_sched.c)
 	zephyr_library_sources_ifdef(CONFIG_USERSPACE rtio_handlers.c)
 endif()
 

--- a/subsys/rtio/rtio_executor.c
+++ b/subsys/rtio/rtio_executor.c
@@ -7,6 +7,8 @@
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/kernel.h>
 
+#include "rtio_sched.h"
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(rtio_executor, CONFIG_RTIO_LOG_LEVEL);
 
@@ -21,6 +23,9 @@ static void rtio_executor_op(struct rtio_iodev_sqe *iodev_sqe)
 	case RTIO_OP_CALLBACK:
 		sqe->callback.callback(iodev_sqe->r, sqe, sqe->callback.arg0);
 		rtio_iodev_sqe_ok(iodev_sqe, 0);
+		break;
+	case RTIO_OP_DELAY:
+		rtio_sched_alarm(iodev_sqe, sqe->delay.timeout);
 		break;
 	default:
 		rtio_iodev_sqe_err(iodev_sqe, -EINVAL);

--- a/subsys/rtio/rtio_sched.c
+++ b/subsys/rtio/rtio_sched.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/rtio/rtio.h>
+
+/** Required to access Timeout Queue APIs, which are used instead of the
+ * Timer APIs because of concerns on size on rtio_sqe (k_timer is more
+ * than double the size of _timeout). Users will have to instantiate a
+ * pool of SQE objects, thus its size directly impacts memory footprint
+ * of RTIO applications.
+ */
+#include <../kernel/include/timeout_q.h>
+
+#include "rtio_sched.h"
+
+static void rtio_sched_alarm_expired(struct _timeout *t)
+{
+	struct rtio_sqe *sqe = CONTAINER_OF(t, struct rtio_sqe, delay.to);
+	struct rtio_iodev_sqe *iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+}
+
+void rtio_sched_alarm(struct rtio_iodev_sqe *iodev_sqe, k_timeout_t timeout)
+{
+	struct rtio_sqe *sqe = &iodev_sqe->sqe;
+
+	z_init_timeout(&sqe->delay.to);
+	z_add_timeout(&sqe->delay.to, rtio_sched_alarm_expired, timeout);
+}

--- a/subsys/rtio/rtio_sched.h
+++ b/subsys/rtio/rtio_sched.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Croxel Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#ifndef ZEPHYR_SUBSYS_RTIO_SCHED_H_
+#define ZEPHYR_SUBSYS_RTIO_SCHED_H_
+
+void rtio_sched_alarm(struct rtio_iodev_sqe *iodev_sqe, k_timeout_t timeout);
+
+#endif /* ZEPHYR_SUBSYS_RTIO_SCHED_H_ */


### PR DESCRIPTION
### Description
This PR introduces OP_DELAY operation, which allows SQE items to take a specified amount of time (asynchronously) before completing. This allows to serve as an asynchronous delay in between SQE items (e.g: A sensor measurement requested, which requires 50-ms before having the result available).

Fixes #77100 

### Testing
A test-case has been added under the rtio_api testsuite. I ran this test on native_sim, and passes all checks.