### PR TITLE
axp192/axp2101: Add exclusive control of I2C

### DIFF
--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -31,6 +31,7 @@
 		watchdog0 = &wdt0;
 		rtc = &bm8563_rtc;
 		sdhc0 = &sd0;
+		led0 = &axp2101_led;
 	};
 
 	lvgl_pointer {
@@ -77,6 +78,18 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+
+	axp2101@34 {
+		compatible = "x-powers,axp2101";
+		reg = <0x34>;
+		status = "okay";
+
+		axp2101_led: axp2101_led {
+			compatible = "x-powers,axp2101-led";
+			status = "okay";
+			x-powers,mode = "by-reg";
+		};
+	};
 
 	bm8563_rtc: bm8563@51 {
 		compatible = "nxp,pcf8563";

--- a/drivers/gpio/gpio_axp192.c
+++ b/drivers/gpio/gpio_axp192.c
@@ -17,32 +17,300 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/mfd/axp192.h>
 
+/* AXP192 GPIO register addresses */
+#define AXP192_EXTEN_DCDC2_CONTROL_REG 0x10U
+#define AXP192_GPIO012_PINVAL_REG      0x94U
+#define AXP192_GPIO34_PINVAL_REG       0x96U
+#define AXP192_GPIO012_PULLDOWN_REG    0x97U
+
+#define AXP192_EXTEN_ENA  0x04U
+#define AXP192_EXTEN_MASK 0x04U
+
+/* Pull-Down enable parameters */
+#define AXP192_GPIO0_PULLDOWN_ENABLE 0x01U
+#define AXP192_GPIO1_PULLDOWN_ENABLE 0x02U
+#define AXP192_GPIO2_PULLDOWN_ENABLE 0x04U
+
+/* GPIO Value parameters */
+#define AXP192_GPIO0_INPUT_VAL      0x10U
+#define AXP192_GPIO1_INPUT_VAL      0x20U
+#define AXP192_GPIO2_INPUT_VAL      0x40U
+#define AXP192_GPIO012_INTPUT_SHIFT 4U
+#define AXP192_GPIO012_INTPUT_MASK                                                                 \
+	(AXP192_GPIO0_INPUT_VAL | AXP192_GPIO1_INPUT_VAL | AXP192_GPIO2_INPUT_VAL)
+#define AXP192_GPIO3_INPUT_VAL     0x10U
+#define AXP192_GPIO4_INPUT_VAL     0x20U
+#define AXP192_GPIO34_INTPUT_SHIFT 4U
+#define AXP192_GPIO34_INTPUT_MASK  (AXP192_GPIO3_INPUT_VAL | AXP192_GPIO4_INPUT_VAL)
+
+#define AXP192_GPIO0_OUTPUT_VAL 0x01U
+#define AXP192_GPIO1_OUTPUT_VAL 0x02U
+#define AXP192_GPIO2_OUTPUT_VAL 0x04U
+#define AXP192_GPIO012_OUTPUT_MASK                                                                 \
+	(AXP192_GPIO0_OUTPUT_VAL | AXP192_GPIO1_OUTPUT_VAL | AXP192_GPIO2_OUTPUT_VAL)
+
+#define AXP192_GPIO3_OUTPUT_VAL   0x01U
+#define AXP192_GPIO4_OUTPUT_VAL   0x02U
+#define AXP192_GPIO34_OUTPUT_MASK (AXP192_GPIO3_OUTPUT_VAL | AXP192_GPIO4_OUTPUT_VAL)
+
+#define AXP192_GPIO5_OUTPUT_MASK  0x04U
+#define AXP192_GPIO5_OUTPUT_VAL   0x04U
+#define AXP192_GPIO5_OUTPUT_SHIFT 3U
+
 LOG_MODULE_REGISTER(gpio_axp192, CONFIG_GPIO_LOG_LEVEL);
 
 struct gpio_axp192_config {
 	struct gpio_driver_config common;
-	struct i2c_dt_spec i2c;
 	const struct device *mfd;
 	uint32_t ngpios;
 };
 
 struct gpio_axp192_data {
 	struct gpio_driver_data common;
-	struct k_mutex mutex;
 	sys_slist_t cb_list_gpio;
 };
+
+/**
+ * @brief Read out the current pull-down configuration of a specific GPIO.
+ *
+ * @param dev axp192 mfd device
+ * @param gpio GPIO to control pull-downs
+ * @param enabled Pointer to current pull-down configuration (true: pull-down
+ * enabled/ false: pull-down disabled)
+ * @retval -EINVAL if an invalid argument is given (e.g. invalid GPIO number)
+ * @retval -ENOTSUP if pull-down is not supported by the givenn GPIO
+ * @retval -errno in case of any bus error
+ */
+__maybe_unused static int gpio_axp192_pd_get(const struct device *dev, uint8_t gpio, bool *enabled)
+{
+	const struct gpio_axp192_config *config = dev->config;
+	uint8_t gpio_val;
+	uint8_t pd_reg_mask = 0;
+	int ret = 0;
+
+	switch (gpio) {
+	case 0U:
+		pd_reg_mask = AXP192_GPIO0_PULLDOWN_ENABLE;
+		break;
+	case 1U:
+		pd_reg_mask = AXP192_GPIO1_PULLDOWN_ENABLE;
+		break;
+	case 2U:
+		pd_reg_mask = AXP192_GPIO2_PULLDOWN_ENABLE;
+		break;
+
+	case 3U:
+		__fallthrough;
+	case 4U:
+		__fallthrough;
+	case 5U:
+		LOG_DBG("Pull-Down not support on gpio %d", gpio);
+		return -ENOTSUP;
+
+	default:
+		LOG_ERR("Invalid gpio (%d)", gpio);
+		return -EINVAL;
+	}
+
+	ret = i2c_reg_read_byte_dt(axp192_get_i2c_dt_spec(config->mfd), AXP192_GPIO012_PULLDOWN_REG,
+				   &gpio_val);
+
+	if (ret == 0) {
+		*enabled = ((gpio_val & pd_reg_mask) != 0);
+		LOG_DBG("Pull-Down stats of gpio %d: %d", gpio, *enabled);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Enable pull-down on specified GPIO pin. AXP192 only supports
+ * pull-down on GPIO3..5. Pull-ups are not supported.
+ *
+ * @param dev axp192 mfd device
+ * @param gpio GPIO to control pull-downs
+ * @param enable true to enable, false to disable pull-down
+ * @retval 0 on success
+ * @retval -EINVAL if an invalid argument is given (e.g. invalid GPIO number)
+ * @retval -ENOTSUP if pull-down is not supported by the givenn GPIO
+ * @retval -errno in case of any bus error
+ */
+static int gpio_axp192_pd_ctrl(const struct device *dev, uint8_t gpio, bool enable)
+{
+	const struct gpio_axp192_config *config = dev->config;
+	uint8_t reg_pd_val = 0;
+	uint8_t reg_pd_mask = 0;
+	int ret = 0;
+
+	/* Configure pull-down. Pull-down is only supported by GPIO3 and GPIO4 */
+	switch (gpio) {
+	case 0U:
+		reg_pd_mask = AXP192_GPIO0_PULLDOWN_ENABLE;
+		if (enable) {
+			reg_pd_val = AXP192_GPIO0_PULLDOWN_ENABLE;
+		}
+		break;
+
+	case 1U:
+		reg_pd_mask = AXP192_GPIO1_PULLDOWN_ENABLE;
+		if (enable) {
+			reg_pd_val = AXP192_GPIO1_PULLDOWN_ENABLE;
+		}
+		break;
+
+	case 2U:
+		reg_pd_mask = AXP192_GPIO2_PULLDOWN_ENABLE;
+		if (enable) {
+			reg_pd_val = AXP192_GPIO2_PULLDOWN_ENABLE;
+		}
+		break;
+
+	case 3U:
+		__fallthrough;
+	case 4U:
+		__fallthrough;
+	case 5U:
+		LOG_ERR("Pull-Down not support on gpio %d", gpio);
+		return -ENOTSUP;
+
+	default:
+		LOG_ERR("Invalid gpio (%d)", gpio);
+		return -EINVAL;
+	}
+
+	ret = i2c_reg_update_byte_dt(axp192_get_i2c_dt_spec(config->mfd),
+				     AXP192_GPIO012_PULLDOWN_REG, reg_pd_mask, reg_pd_val);
+
+	return ret;
+}
+
+/**
+ * @brief Read GPIO port.
+ *
+ * @param dev axp192 mfd device
+ * @param value Pointer to port value
+ * @retval 0 on success
+ * @retval -errno in case of any bus error
+ */
+static int gpio_axp192_read_port(const struct device *dev, uint8_t *value)
+{
+	const struct gpio_axp192_config *config = dev->config;
+	uint8_t gpio012_val;
+	uint8_t gpio34_val;
+	uint8_t gpio5_val;
+	uint8_t gpio_input_val;
+	uint8_t gpio_output_val;
+	int ret;
+
+	/* read gpio0-2 */
+	ret = i2c_reg_read_byte_dt(axp192_get_i2c_dt_spec(config->mfd), AXP192_GPIO012_PINVAL_REG,
+				   &gpio012_val);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* read gpio3-4 */
+	ret = i2c_reg_read_byte_dt(axp192_get_i2c_dt_spec(config->mfd), AXP192_GPIO34_PINVAL_REG,
+				   &gpio34_val);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* read gpio5 */
+	ret = i2c_reg_read_byte_dt(axp192_get_i2c_dt_spec(config->mfd),
+				   AXP192_EXTEN_DCDC2_CONTROL_REG, &gpio5_val);
+	if (ret != 0) {
+		return ret;
+	}
+
+	LOG_DBG("GPIO012 pinval-reg=0x%x", gpio012_val);
+	LOG_DBG("GPIO34 pinval-reg =0x%x", gpio34_val);
+	LOG_DBG("GPIO5 pinval-reg =0x%x", gpio5_val);
+	LOG_DBG("Output-Mask       =0x%x", axp192_get_gpio_mask_output(config->mfd));
+
+	gpio_input_val =
+		((gpio012_val & AXP192_GPIO012_INTPUT_MASK) >> AXP192_GPIO012_INTPUT_SHIFT);
+	gpio_input_val |=
+		(((gpio34_val & AXP192_GPIO34_INTPUT_MASK) >> AXP192_GPIO34_INTPUT_SHIFT) << 3u);
+
+	gpio_output_val = (gpio012_val & AXP192_GPIO012_OUTPUT_MASK);
+	gpio_output_val |= ((gpio34_val & AXP192_GPIO34_OUTPUT_MASK) << 3u);
+	gpio_output_val |=
+		(((gpio5_val & AXP192_GPIO5_OUTPUT_MASK) >> AXP192_GPIO5_OUTPUT_SHIFT) << 5u);
+
+	*value = gpio_input_val & ~axp192_get_gpio_mask_output(config->mfd);
+	*value |= (gpio_output_val & axp192_get_gpio_mask_output(config->mfd));
+
+	return 0;
+}
+
+/**
+ * @brief Write GPIO port.
+ *
+ * @param dev axp192 mfd device
+ * @param value port value
+ * @param mask pin mask within the port
+ * @retval 0 on success
+ * @retval -errno in case of any bus error
+ */
+static int gpio_axp192_write_port(const struct device *dev, uint8_t value, uint8_t mask)
+{
+	const struct gpio_axp192_config *config = dev->config;
+	uint8_t gpio_reg_val;
+	uint8_t gpio_reg_mask;
+	int ret;
+
+	/* Write gpio0-2. Mask out other port pins */
+	gpio_reg_val = (value & AXP192_GPIO012_OUTPUT_MASK);
+	gpio_reg_mask = (mask & AXP192_GPIO012_OUTPUT_MASK);
+	if (gpio_reg_mask != 0) {
+		ret = i2c_reg_update_byte_dt(axp192_get_i2c_dt_spec(config->mfd),
+					     AXP192_GPIO012_PINVAL_REG, gpio_reg_mask,
+					     gpio_reg_val);
+		if (ret != 0) {
+			return ret;
+		}
+		LOG_DBG("GPIO012 pinval-reg=0x%x mask=0x%x", gpio_reg_val, gpio_reg_mask);
+	}
+
+	/* Write gpio3-4. Mask out other port pins */
+	gpio_reg_val = value >> 3U;
+	gpio_reg_mask = (mask >> 3U) & AXP192_GPIO34_OUTPUT_MASK;
+	if (gpio_reg_mask != 0) {
+		ret = i2c_reg_update_byte_dt(axp192_get_i2c_dt_spec(config->mfd),
+					     AXP192_GPIO34_PINVAL_REG, gpio_reg_mask, gpio_reg_val);
+		if (ret != 0) {
+			return ret;
+		}
+		LOG_DBG("GPIO34 pinval-reg =0x%x mask=0x%x", gpio_reg_val, gpio_reg_mask);
+	}
+
+	/* Write gpio5. Mask out other port pins */
+	if ((mask & BIT(5)) != 0) {
+		gpio_reg_mask = AXP192_EXTEN_MASK;
+		gpio_reg_val = (value & BIT(5)) ? AXP192_EXTEN_ENA : 0U;
+		ret = i2c_reg_update_byte_dt(axp192_get_i2c_dt_spec(config->mfd),
+					     AXP192_EXTEN_DCDC2_CONTROL_REG, gpio_reg_mask,
+					     gpio_reg_val);
+		if (ret != 0) {
+			return ret;
+		}
+		LOG_DBG("GPIO5 pinval-reg =0x%x mask=0x%x\n", gpio_reg_val, gpio_reg_mask);
+	}
+
+	return 0;
+}
 
 static int gpio_axp192_port_get_raw(const struct device *dev, uint32_t *value)
 {
 	int ret;
 	uint8_t port_val;
-	const struct gpio_axp192_config *config = dev->config;
 
 	if (k_is_in_isr()) {
 		return -EWOULDBLOCK;
 	}
 
-	ret = mfd_axp192_gpio_read_port(config->mfd, &port_val);
+	ret = gpio_axp192_read_port(dev, &port_val);
 	if (ret == 0) {
 		*value = port_val;
 	}
@@ -54,13 +322,12 @@ static int gpio_axp192_port_set_masked_raw(const struct device *dev, gpio_port_p
 					   gpio_port_value_t value)
 {
 	int ret;
-	const struct gpio_axp192_config *config = dev->config;
 
 	if (k_is_in_isr()) {
 		return -EWOULDBLOCK;
 	}
 
-	ret = mfd_axp192_gpio_write_port(config->mfd, value, mask);
+	ret = gpio_axp192_write_port(dev, value, mask);
 
 	return ret;
 }
@@ -106,9 +373,9 @@ static int gpio_axp192_configure(const struct device *dev, gpio_pin_t pin, gpio_
 
 		/* Set init value */
 		if ((flags & GPIO_OUTPUT_INIT_LOW) != 0) {
-			ret = mfd_axp192_gpio_write_port(config->mfd, BIT(pin), 0);
+			ret = gpio_axp192_write_port(dev, BIT(pin), 0);
 		} else if ((flags & GPIO_OUTPUT_INIT_HIGH) != 0) {
-			ret = mfd_axp192_gpio_write_port(config->mfd, BIT(pin), BIT(pin));
+			ret = gpio_axp192_write_port(dev, BIT(pin), BIT(pin));
 		}
 	} else if ((flags & GPIO_INPUT) != 0) {
 
@@ -127,9 +394,9 @@ static int gpio_axp192_configure(const struct device *dev, gpio_pin_t pin, gpio_
 			ret = -ENOTSUP;
 		} else if ((flags & GPIO_PULL_DOWN) != 0) {
 			/* out = 0 means pull-down*/
-			ret = mfd_axp192_gpio_pd_ctrl(config->mfd, pin, true);
+			ret = gpio_axp192_pd_ctrl(dev, pin, true);
 		} else {
-			ret = mfd_axp192_gpio_pd_ctrl(config->mfd, pin, false);
+			ret = gpio_axp192_pd_ctrl(dev, pin, false);
 		}
 	} else {
 		/* Neither input nor output mode is selected */
@@ -142,18 +409,18 @@ static int gpio_axp192_configure(const struct device *dev, gpio_pin_t pin, gpio_
 
 static int gpio_axp192_port_toggle_bits(const struct device *dev, gpio_port_pins_t pins)
 {
-	struct gpio_axp192_data *data = dev->data;
+	const struct gpio_axp192_config *config = dev->config;
 	int ret;
 	uint32_t value;
 
-	k_mutex_lock(&data->mutex, K_FOREVER);
+	k_sem_take(axp192_get_lock(config->mfd), K_FOREVER);
 
 	ret = gpio_axp192_port_get_raw(dev, &value);
 	if (ret == 0) {
 		ret = gpio_axp192_port_set_masked_raw(dev, pins, ~value);
 	}
 
-	k_mutex_unlock(&data->mutex);
+	k_sem_give(axp192_get_lock(config->mfd));
 
 	return ret;
 }
@@ -211,7 +478,7 @@ static int gpio_axp192_get_config(const struct device *dev, gpio_pin_t pin, gpio
 	}
 
 	/* Query pull-down config status  */
-	ret = mfd_axp192_gpio_pd_get(config->mfd, pin, &pd_enabled);
+	ret = gpio_axp192_pd_get(config->mfd, pin, &pd_enabled);
 	if (ret != 0) {
 		return ret;
 	}
@@ -288,16 +555,20 @@ static DEVICE_API(gpio, gpio_axp192_api) = {
 static int gpio_axp192_init(const struct device *dev)
 {
 	const struct gpio_axp192_config *config = dev->config;
-	struct gpio_axp192_data *data = dev->data;
+	int ret = 0;
 
 	LOG_DBG("Initializing");
 
-	if (!i2c_is_ready_dt(&config->i2c)) {
+	k_sem_take(axp192_get_lock(config->mfd), K_FOREVER);
+
+	if (!i2c_is_ready_dt(axp192_get_i2c_dt_spec(config->mfd))) {
 		LOG_ERR("device not ready");
-		return -ENODEV;
+		ret = -ENODEV;
 	}
 
-	return k_mutex_init(&data->mutex);
+	k_sem_give(axp192_get_lock(config->mfd));
+
+	return ret;
 }
 
 #define GPIO_AXP192_DEFINE(inst)                                                                   \
@@ -306,7 +577,6 @@ static int gpio_axp192_init(const struct device *dev)
 			{                                                                          \
 				.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst),            \
 			},                                                                         \
-		.i2c = I2C_DT_SPEC_GET(DT_INST_PARENT(inst)),                                      \
 		.mfd = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                        \
 		.ngpios = DT_INST_PROP(inst, ngpios),                                              \
 	};                                                                                         \

--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -4,8 +4,12 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/led.h)
 
 zephyr_library()
 
+# zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_HT16K33 ht16k33.c)
+zephyr_library_sources_ifdef(CONFIG_IS31FL3194 is31fl3194.c)
 zephyr_library_sources_ifdef(CONFIG_IS31FL3216A is31fl3216a.c)
+zephyr_library_sources_ifdef(CONFIG_IS31FL3733 is31fl3733.c)
+zephyr_library_sources_ifdef(CONFIG_LED_AXP192_AXP2101 led_axp192.c)
 zephyr_library_sources_ifdef(CONFIG_LED_GPIO led_gpio.c)
 zephyr_library_sources_ifdef(CONFIG_LED_NPM1300 led_npm1300.c)
 zephyr_library_sources_ifdef(CONFIG_LED_PWM led_pwm.c)
@@ -17,8 +21,7 @@ zephyr_library_sources_ifdef(CONFIG_LP5569 lp5569.c)
 zephyr_library_sources_ifdef(CONFIG_NCP5623 ncp5623.c)
 zephyr_library_sources_ifdef(CONFIG_PCA9633 pca9633.c)
 zephyr_library_sources_ifdef(CONFIG_TLC59108 tlc59108.c)
-zephyr_library_sources_ifdef(CONFIG_IS31FL3733 is31fl3733.c)
-zephyr_library_sources_ifdef(CONFIG_IS31FL3194 is31fl3194.c)
+# zephyr-keep-sorted-stop
 
 zephyr_library_sources_ifdef(CONFIG_LED_SHELL   led_shell.c)
 

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -26,9 +26,13 @@ config LED_SHELL
 	help
 	  Enable LED shell for testing.
 
+# zephyr-keep-sorted-start
+source "drivers/led/Kconfig.axp192"
 source "drivers/led/Kconfig.gpio"
 source "drivers/led/Kconfig.ht16k33"
+source "drivers/led/Kconfig.is31fl3194"
 source "drivers/led/Kconfig.is31fl3216a"
+source "drivers/led/Kconfig.is31fl3733"
 source "drivers/led/Kconfig.lp3943"
 source "drivers/led/Kconfig.lp50xx"
 source "drivers/led/Kconfig.lp5562"
@@ -39,7 +43,6 @@ source "drivers/led/Kconfig.pca9633"
 source "drivers/led/Kconfig.pwm"
 source "drivers/led/Kconfig.tlc59108"
 source "drivers/led/Kconfig.xec"
-source "drivers/led/Kconfig.is31fl3733"
-source "drivers/led/Kconfig.is31fl3194"
+# zephyr-keep-sorted-stop
 
 endif # LED

--- a/drivers/led/Kconfig.axp192
+++ b/drivers/led/Kconfig.axp192
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+config LED_AXP192_AXP2101
+	bool "X-Powers AXP192/AXP2101 LED driver"
+	default y
+	depends on DT_HAS_X_POWERS_AXP192_LED_ENABLED || DT_HAS_X_POWERS_AXP2101_LED_ENABLED
+	depends on DT_HAS_X_POWERS_AXP192_ENABLED || DT_HAS_X_POWERS_AXP2101_ENABLED
+	select I2C
+	select MFD
+	help
+	  Enable the AXP192/AXP2101 LED driver.
+
+	  AXP192 and AXP2101 are multi-functional integrated Power Management IC (PMIC).
+	  This driver is for its LED controller feature.
+	  This LED controller can control the lighting using a register,
+	  and can also light up in response to the charging status.

--- a/drivers/led/led_axp192.c
+++ b/drivers/led/led_axp192.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/led.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(led_axp192, CONFIG_LED_LOG_LEVEL);
+
+#define CHGLED_OUTPUT_HIZ        0x0
+#define CHGLED_OUTPUT_SLOW_BLINK 0x1
+#define CHGLED_OUTPUT_FAST_BLINK 0x2
+#define CHGLED_OUTPUT_DRIVE_LOW  0x3
+
+#define CHGLED_OUTPUT_OFFSET 4
+
+#define CHGLED_ON          (CHGLED_OUTPUT_DRIVE_LOW << CHGLED_OUTPUT_OFFSET)
+#define CHGLED_OFF         (CHGLED_OUTPUT_HIZ << CHGLED_OUTPUT_OFFSET)
+#define CHGLED_BLINK_SLOW  (CHGLED_OUTPUT_SLOW_BLINK << CHGLED_OUTPUT_OFFSET)
+#define CHGLED_BLINK_FAST  (CHGLED_OUTPUT_FAST_BLINK << CHGLED_OUTPUT_OFFSET)
+#define CHGLED_OUTPUT_MASK (BIT_MASK(2) << CHGLED_OUTPUT_OFFSET)
+
+#define SLOW_BLINK_DELAY_ON  (((1000 / 4) / 1) * 1)
+#define SLOW_BLINK_DELAY_OFF (((1000 / 4) / 1) * 3)
+#define FAST_BLINK_DELAY_ON  (((1000 / 4) / 4) * 1)
+#define FAST_BLINK_DELAY_OFF (((1000 / 4) / 4) * 3)
+
+#define CHGLED_CTRL_TYPE_A    0x0
+#define CHGLED_CTRL_TYPE_B    0x1
+#define CHGLED_CTRL_BY_REG    0x2
+#define CHGLED_CTRL_BY_CHARGE 0x3
+
+#define AXP192_REG_PWROFF_BATTCHK_CHGLED 0x32
+#define AXP192_REG_CHGLED                AXP192_REG_PWROFF_BATTCHK_CHGLED
+#define AXP192_CHGLED_CTRL_MASK          0x2
+#define AXP192_CHGLED_CTRL_OFFSET        2
+
+#define AXP2101_REG_CHGLED         0x69
+#define AXP2101_CHGLED_CTRL_MASK   0x3
+#define AXP2101_CHGLED_CTRL_OFFSET 1
+
+struct led_axp192_config {
+	struct i2c_dt_spec i2c;
+	uint8_t addr;
+	uint8_t mode;
+	uint8_t mode_mask;
+	uint8_t mode_offset;
+};
+
+static int led_axp192_on(const struct device *dev, uint32_t led)
+{
+	const struct led_axp192_config *config = dev->config;
+
+	ARG_UNUSED(led);
+
+	if (config->mode != CHGLED_CTRL_BY_REG) {
+		return -EINVAL;
+	}
+
+	return i2c_reg_update_byte_dt(&config->i2c, config->addr, CHGLED_OUTPUT_MASK, CHGLED_ON);
+}
+
+static int led_axp192_off(const struct device *dev, uint32_t led)
+{
+	const struct led_axp192_config *config = dev->config;
+
+	ARG_UNUSED(led);
+
+	if (config->mode != CHGLED_CTRL_BY_REG) {
+		return -EINVAL;
+	}
+
+	return i2c_reg_update_byte_dt(&config->i2c, config->addr, CHGLED_OUTPUT_MASK, CHGLED_OFF);
+}
+
+static int led_axp192_blink(const struct device *dev, uint32_t led, uint32_t delay_on,
+			    uint32_t delay_off)
+{
+	const struct led_axp192_config *config = dev->config;
+
+	ARG_UNUSED(led);
+
+	if (config->mode != CHGLED_CTRL_BY_REG) {
+		return -EINVAL;
+	}
+
+	if ((delay_on == SLOW_BLINK_DELAY_ON) && (delay_off == SLOW_BLINK_DELAY_OFF)) {
+		return i2c_reg_update_byte_dt(&config->i2c, config->addr, CHGLED_OUTPUT_MASK,
+					      CHGLED_BLINK_SLOW);
+	} else if ((delay_on == FAST_BLINK_DELAY_ON) && (delay_off == FAST_BLINK_DELAY_OFF)) {
+		return i2c_reg_update_byte_dt(&config->i2c, config->addr, CHGLED_OUTPUT_MASK,
+					      CHGLED_BLINK_FAST);
+	} else {
+		LOG_ERR("The AXP192 blink setting can only %d/%d or %d/%d. (%d/%d)",
+			SLOW_BLINK_DELAY_ON, SLOW_BLINK_DELAY_OFF, FAST_BLINK_DELAY_ON,
+			FAST_BLINK_DELAY_OFF, delay_on, delay_off);
+	}
+
+	return -ENOTSUP;
+}
+
+static DEVICE_API(led, led_axp192_api) = {
+	.on = led_axp192_on,
+	.off = led_axp192_off,
+	.blink = led_axp192_blink,
+};
+
+static int led_axp192_init(const struct device *dev)
+{
+	const struct led_axp192_config *config = dev->config;
+
+	switch (config->mode) {
+	case CHGLED_CTRL_TYPE_A:
+	case CHGLED_CTRL_TYPE_B:
+	case CHGLED_CTRL_BY_REG:
+	case CHGLED_CTRL_BY_CHARGE:
+		return i2c_reg_update_byte_dt(&config->i2c, config->addr,
+					      config->mode_mask << config->mode_offset,
+					      config->mode << config->mode_offset);
+	}
+
+	return -EINVAL;
+}
+
+#define LED_AXPXXXX_DEFINE(n, model, compat)                                                       \
+	static const struct led_axp192_config led_axp_config_##model##_##n = {                     \
+		.i2c = I2C_DT_SPEC_GET(DT_PARENT(n)),                                              \
+		.addr = AXP##model##_REG_CHGLED,                                                   \
+		.mode = UTIL_CAT(CHGLED_CTRL_, DT_STRING_UPPER_TOKEN(n, x_powers_mode)),           \
+		.mode_mask = AXP##model##_CHGLED_CTRL_MASK,                                        \
+		.mode_offset = AXP##model##_CHGLED_CTRL_OFFSET,                                    \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_DEFINE(n, led_axp192_init, NULL, NULL, &led_axp_config_##model##_##n,            \
+			 POST_KERNEL, CONFIG_LED_INIT_PRIORITY, &led_axp192_api);
+
+#define LED_AXP192_DEFINE(n)  LED_AXPXXXX_DEFINE(n, 192, x_powers_axp192_led)
+#define LED_AXP2101_DEFINE(n) LED_AXPXXXX_DEFINE(n, 2101, x_powers_axp2101_led)
+
+DT_FOREACH_STATUS_OKAY(x_powers_axp192_led, LED_AXP192_DEFINE)
+DT_FOREACH_STATUS_OKAY(x_powers_axp2101_led, LED_AXP2101_DEFINE)

--- a/dts/bindings/charger/x-powers,axp2101-charger.yaml
+++ b/dts/bindings/charger/x-powers,axp2101-charger.yaml
@@ -23,6 +23,8 @@ description: |
 
 compatible: "x-powers,axp2101-charger"
 
+on-bus: axp2101
+
 include:
   - base.yaml
   - battery.yaml

--- a/dts/bindings/gpio/x-powers,axp192-gpio.yaml
+++ b/dts/bindings/gpio/x-powers,axp192-gpio.yaml
@@ -18,6 +18,8 @@ compatible: "x-powers,axp192-gpio"
 
 include: gpio-controller.yaml
 
+on-bus: axp192
+
 properties:
   "#gpio-cells":
     const: 2

--- a/dts/bindings/led/x-powers,axp192-led.yaml
+++ b/dts/bindings/led/x-powers,axp192-led.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  AXP192 LED controller
+
+  The AXP192 has one LED can automatically display error or charging status,
+  or be controlled by software.
+
+compatible: "x-powers,axp192-led"
+
+on-bus: axp192
+
+properties:
+  x-powers,mode:
+    type: string
+    enum:
+      - "by-reg"
+      - "by-charge"
+    description:
+      Select the LED control method.
+      If you select "by-reg", you can control it from software.
+      Please refer to the datasheet for details on "by-charge".

--- a/dts/bindings/led/x-powers,axp2101-led.yaml
+++ b/dts/bindings/led/x-powers,axp2101-led.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 TOKITA Hiroshi
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  AXP2101 LED controller
+
+  The AXP2101 has one LED can automatically display error or charging status,
+  or be controlled by software.
+
+compatible: "x-powers,axp2101-led"
+
+on-bus: axp2101
+
+properties:
+  x-powers,mode:
+    type: string
+    enum:
+      - "type-a"
+      - "type-b"
+      - "by-reg"
+    description:
+      Select the LED control method.
+      If you select "by-reg", you can control it from software.
+      Please refer to the datasheet for details on "type-a" and "type-b".

--- a/dts/bindings/mfd/x-powers,axp192.yaml
+++ b/dts/bindings/mfd/x-powers,axp192.yaml
@@ -7,6 +7,8 @@ compatible: "x-powers,axp192"
 
 include: i2c-device.yaml
 
+bus: axp192
+
 properties:
   reg:
     required: true

--- a/dts/bindings/mfd/x-powers,axp2101.yaml
+++ b/dts/bindings/mfd/x-powers,axp2101.yaml
@@ -7,6 +7,8 @@ compatible: "x-powers,axp2101"
 
 include: i2c-device.yaml
 
+bus: axp2101
+
 properties:
   reg:
     required: true

--- a/dts/bindings/regulator/x-powers,axp192-regulator.yaml
+++ b/dts/bindings/regulator/x-powers,axp192-regulator.yaml
@@ -40,6 +40,8 @@ description: |
 
 compatible: "x-powers,axp192-regulator"
 
+on-bus: axp192
+
 include: base.yaml
 
 child-binding:

--- a/dts/bindings/regulator/x-powers,axp2101-regulator.yaml
+++ b/dts/bindings/regulator/x-powers,axp2101-regulator.yaml
@@ -67,6 +67,8 @@ compatible: "x-powers,axp2101-regulator"
 
 include: base.yaml
 
+on-bus: axp2101
+
 child-binding:
   include:
     - name: regulator.yaml

--- a/include/zephyr/drivers/mfd/axp192.h
+++ b/include/zephyr/drivers/mfd/axp192.h
@@ -91,52 +91,31 @@ int mfd_axp192_gpio_func_ctrl(const struct device *dev, const struct device *cli
 int mfd_axp192_gpio_func_get(const struct device *dev, uint8_t gpio, enum axp192_gpio_func *func);
 
 /**
- * @brief Enable pull-down on specified GPIO pin. AXP192 only supports
- * pull-down on GPIO3..5. Pull-ups are not supported.
+ * @brief Get the gpio_mask_output value
  *
  * @param dev axp192 mfd device
- * @param gpio GPIO to control pull-downs
- * @param enable true to enable, false to disable pull-down
- * @retval 0 on success
- * @retval -EINVAL if an invalid argument is given (e.g. invalid GPIO number)
- * @retval -ENOTSUP if pull-down is not supported by the givenn GPIO
- * @retval -errno in case of any bus error
+ *
+ * @return gpio_mask_output value
  */
-int mfd_axp192_gpio_pd_ctrl(const struct device *dev, uint8_t gpio, bool enable);
+uint8_t axp192_get_gpio_mask_output(const struct device *dev);
 
 /**
- * @brief Read out the current pull-down configuration of a specific GPIO.
+ * @brief Get the semaphore reference for a AXP192 MFD instance.
  *
  * @param dev axp192 mfd device
- * @param gpio GPIO to control pull-downs
- * @param enabled Pointer to current pull-down configuration (true: pull-down
- * enabled/ false: pull-down disabled)
- * @retval -EINVAL if an invalid argument is given (e.g. invalid GPIO number)
- * @retval -ENOTSUP if pull-down is not supported by the givenn GPIO
- * @retval -errno in case of any bus error
+ *
+ * @return Address of the semaphore
  */
-int mfd_axp192_gpio_pd_get(const struct device *dev, uint8_t gpio, bool *enabled);
+struct k_sem *axp192_get_lock(const struct device *dev);
 
 /**
- * @brief Read GPIO port.
+ * @brief Get the I2C DT spec reference for a AXP192 MFD instance.
  *
  * @param dev axp192 mfd device
- * @param value Pointer to port value
- * @retval 0 on success
- * @retval -errno in case of any bus error
- */
-int mfd_axp192_gpio_read_port(const struct device *dev, uint8_t *value);
-
-/**
- * @brief Write GPIO port.
  *
- * @param dev axp192 mfd device
- * @param value port value
- * @param mask pin mask within the port
- * @retval 0 on success
- * @retval -errno in case of any bus error
+ * @return Address of the I2C DT spec
  */
-int mfd_axp192_gpio_write_port(const struct device *dev, uint8_t value, uint8_t mask);
+const struct i2c_dt_spec *axp192_get_i2c_dt_spec(const struct device *dev);
 
 /**
  * @}

--- a/tests/drivers/build_all/led/app.overlay
+++ b/tests/drivers/build_all/led/app.overlay
@@ -124,6 +124,30 @@
 				compatible = "issi,is31fl3733";
 				reg = <0x10>;
 			};
+
+			axp192@11 {
+				compatible = "x-powers,axp192";
+				reg = <0x11>;
+				status = "okay";
+
+				pwr_led {
+					compatible = "x-powers,axp192-led";
+					status = "okay";
+					x-powers,mode = "by-reg";
+				};
+			};
+
+			axp2101@12 {
+				compatible = "x-powers,axp2101";
+				reg = <0x12>;
+				status = "okay";
+
+				pwr_led {
+					compatible = "x-powers,axp2101-led";
+					status = "okay";
+					x-powers,mode = "by-reg";
+				};
+			};
 		};
 	};
 };


### PR DESCRIPTION
Perform exclusive control to prevent conflicts with other functions
during I2C communication.