### PR TITLE
boards: m5stack: cores3: Add AXP2101 regulator configuration

### DIFF
--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu.dts
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu.dts
@@ -30,3 +30,20 @@
 		reg = <0x10>;
 	};
 };
+
+&regulator {
+	vddcam_3v3: ALDO3 {
+		regulator-min-microvolt  = <3000000>;
+		/* regulator-init-microvolt = <3300000>; */
+		regulator-max-microvolt  = <3500000>;
+		regulator-boot-on;
+		status = "okay";
+	};
+
+	avdd: BLDO1 {
+		regulator-min-microvolt = <2700000>;
+		/* regulator-init-microvolt = <2800000>; */
+		regulator-max-microvolt = <3300000>;
+		status = "okay";
+	};
+};

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -78,6 +78,81 @@
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 
+	axp2101@34 {
+		compatible = "x-powers,axp2101";
+		reg = <0x34>;
+		status = "okay";
+
+		regulator: regulator {
+			compatible = "x-powers,axp2101-regulator";
+			status = "okay";
+
+			/*
+			 * Typically, no initialization is performed since non-volatile
+			 * values are used.
+			 * If you remove the commenting, initialization will be performed
+			 * with the default value.
+			 */
+
+			vdd_3v3: DCDC1 {
+				regulator-min-microvolt  = <3000000>;
+				/* regulator-init-microvolt = <3300000>; */
+				regulator-max-microvolt  = <3300000>;
+				regulator-boot-on;
+				regulator-always-on;
+				status = "okay";
+			};
+
+			vcc_3v3: DCDC3 {
+				regulator-min-microvolt  = <3100000>;
+				/* regulator-init-microvolt = <3300000>; */
+				regulator-max-microvolt  = <3500000>;
+				regulator-boot-on;
+				regulator-always-on;
+				status = "okay";
+			};
+
+			vdd_1v8: ALDO1 {
+				regulator-min-microvolt  = <1700000>;
+				/* regulator-init-microvolt = <1800000>; */
+				regulator-max-microvolt  = <1900000>;
+				regulator-boot-on;
+				status = "okay";
+			};
+
+			vdda_3v3: ALDO2 {
+				regulator-min-microvolt  = <3100000>;
+				/* regulator-init-microvolt = <3300000>; */
+				regulator-max-microvolt  = <3500000>;
+				regulator-boot-on;
+				status = "okay";
+			};
+
+			vdd_3v3_sd: ALDO4 {
+				regulator-min-microvolt  = <3100000>;
+				/* regulator-init-microvolt = <3300000>; */
+				regulator-max-microvolt  = <3500000>;
+				regulator-boot-on;
+				status = "okay";
+			};
+
+			dvdd: BLDO2 {
+				regulator-min-microvolt = <3100000>;
+				/* regulator-init-microvolt = <3300000>; */
+				regulator-max-microvolt = <3500000>;
+				status = "okay";
+			};
+
+			vcc_bl: DLDO1 {
+				regulator-min-microvolt = <2500000>;
+				/* regulator-init-microvolt = <3300000>; */
+				regulator-max-microvolt = <3300000>;
+				regulator-boot-on;
+				status = "okay";
+			};
+		};
+	};
+
 	bm8563_rtc: bm8563@51 {
 		compatible = "nxp,pcf8563";
 		reg = <0x51>;


### PR DESCRIPTION
Adding configuration for enabling AXP2101 regulator.