### PR TITLE
fix: add missing compile time log level to `drivers/sensor/tdk/icm42688/icm42688_rtio_stream.c`

### DIFF
--- a/drivers/sensor/tdk/icm42688/icm42688_rtio_stream.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_rtio_stream.c
@@ -11,7 +11,7 @@
 #include "icm42688_reg.h"
 #include "icm42688_rtio.h"
 
-LOG_MODULE_DECLARE(ICM42688_RTIO);
+LOG_MODULE_DECLARE(ICM42688_RTIO, CONFIG_SENSOR_LOG_LEVEL);
 
 void icm42688_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe)
 {


### PR DESCRIPTION
The icm42688 driver RTIO stream module does not specify a compile time log level. Thus, CONFIG_SENSOR_LOG_LEVEL_DBG is ignored. Fixed by specifying log level on log module declaration.