### PR TITLE
Video: addition of more Bayer / RGB / YUV PIX formats

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1223,6 +1223,56 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
 #define VIDEO_PIX_FMT_RGB565 VIDEO_FOURCC('R', 'G', 'B', 'P')
 
 /**
+ * 24 bit RGB format with 8 bit per component
+ *
+ * @code{.unparsed}
+ * | Bbbbbbbb Gggggggg Rggggggg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_BGR24 VIDEO_FOURCC('B', 'G', 'R', '3')
+
+/**
+ * 24 bit RGB format with 8 bit per component
+ *
+ * @code{.unparsed}
+ * | Rggggggg Gggggggg Bbbbbbbb | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_RGB24 VIDEO_FOURCC('R', 'G', 'B', '3')
+
+/**
+ * @code{.unparsed}
+ * | Aaaaaaaa Rrrrrrrr Gggggggg Bbbbbbbb | ...
+ * @endcode
+ */
+
+#define VIDEO_PIX_FMT_ARGB32 VIDEO_FOURCC('B', 'A', '2', '4')
+
+/**
+ * @code{.unparsed}
+ * | Bbbbbbbb Gggggggg Rrrrrrrr Aaaaaaaa | ...
+ * @endcode
+ */
+
+#define VIDEO_PIX_FMT_ABGR32 VIDEO_FOURCC('A', 'R', '2', '4')
+
+/**
+ * @code{.unparsed}
+ * | Rrrrrrrr Gggggggg Bbbbbbbb Aaaaaaaa | ...
+ * @endcode
+ */
+
+#define VIDEO_PIX_FMT_RGBA32 VIDEO_FOURCC('A', 'B', '2', '4')
+
+/**
+ * @code{.unparsed}
+ * | Aaaaaaaa Bbbbbbbb Gggggggg Rrrrrrrr | ...
+ * @endcode
+ */
+
+#define VIDEO_PIX_FMT_BGRA32 VIDEO_FOURCC('R', 'A', '2', '4')
+
+/**
  * The first byte is empty (X) for each pixel.
  *
  * @code{.unparsed}
@@ -1250,6 +1300,27 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
  * @endcode
  */
 #define VIDEO_PIX_FMT_YUYV VIDEO_FOURCC('Y', 'U', 'Y', 'V')
+
+/**
+ * @code{.unparsed}
+ * | Yyyyyyyy Vvvvvvvv | Yyyyyyyy Uuuuuuuu | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_YVYU VIDEO_FOURCC('Y', 'V', 'Y', 'U')
+
+/**
+ * @code{.unparsed}
+ * | Vvvvvvvv Yyyyyyyy | Uuuuuuuu Yyyyyyyy | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_VYUY VIDEO_FOURCC('V', 'Y', 'U', 'Y')
+
+/**
+ * @code{.unparsed}
+ * | Uuuuuuuu Yyyyyyyy | Vvvvvvvv Yyyyyyyy | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_UYVY VIDEO_FOURCC('U', 'Y', 'V', 'Y')
 
 /**
  * The first byte is empty (X) for each pixel.
@@ -1315,6 +1386,9 @@ static inline unsigned int video_bits_per_pixel(uint32_t pixfmt)
 		return 14;
 	case VIDEO_PIX_FMT_RGB565:
 	case VIDEO_PIX_FMT_YUYV:
+	case VIDEO_PIX_FMT_YVYU:
+	case VIDEO_PIX_FMT_UYVY:
+	case VIDEO_PIX_FMT_VYUY:
 	case VIDEO_PIX_FMT_SBGGR10:
 	case VIDEO_PIX_FMT_SGBRG10:
 	case VIDEO_PIX_FMT_SGRBG10:
@@ -1332,8 +1406,15 @@ static inline unsigned int video_bits_per_pixel(uint32_t pixfmt)
 	case VIDEO_PIX_FMT_SGRBG16:
 	case VIDEO_PIX_FMT_SRGGB16:
 		return 16;
+	case VIDEO_PIX_FMT_BGR24:
+	case VIDEO_PIX_FMT_RGB24:
+		return 24;
 	case VIDEO_PIX_FMT_XRGB32:
 	case VIDEO_PIX_FMT_XYUV32:
+	case VIDEO_PIX_FMT_ARGB32:
+	case VIDEO_PIX_FMT_ABGR32:
+	case VIDEO_PIX_FMT_RGBA32:
+	case VIDEO_PIX_FMT_BGRA32:
 		return 32;
 	default:
 		/* Variable number of bits per pixel or unknown format */

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1010,6 +1010,134 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
 #define VIDEO_PIX_FMT_SRGGB14P VIDEO_FOURCC('p', 'R', 'E', 'E')
 
 /**
+ * @code{.unparsed}
+ * | bbbbbbbb 000000Bb | gggggggg 000000Gg | bbbbbbbb 000000Bb | gggggggg 000000Gg | ...
+ * | gggggggg 000000Gg | rrrrrrrr 000000Rr | gggggggg 000000Gg | rrrrrrrr 000000Rr | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SBGGR10 VIDEO_FOURCC('B', 'G', '1', '0')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg 000000Gg | bbbbbbbb 000000Bb | gggggggg 000000Gg | bbbbbbbb 000000Bb | ...
+ * | rrrrrrrr 000000Rr | gggggggg 000000Gg | rrrrrrrr 000000Rr | gggggggg 000000Gg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGBRG10 VIDEO_FOURCC('G', 'B', '1', '0')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg 000000Gg | rrrrrrrr 000000Rr | gggggggg 000000Gg | rrrrrrrr 000000Rr | ...
+ * | bbbbbbbb 000000Bb | gggggggg 000000Gg | bbbbbbbb 000000Bb | gggggggg 000000Gg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGRBG10 VIDEO_FOURCC('B', 'A', '1', '0')
+
+/**
+ * @code{.unparsed}
+ * | rrrrrrrr 000000Rr | gggggggg 000000Gg | rrrrrrrr 000000Rr | gggggggg 000000Gg | ...
+ * | gggggggg 000000Gg | bbbbbbbb 000000Bb | gggggggg 000000Gg | bbbbbbbb 000000Bb | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SRGGB10 VIDEO_FOURCC('R', 'G', '1', '0')
+
+/**
+ * @code{.unparsed}
+ * | bbbbbbbb 0000Bbbb | gggggggg 0000Gggg | bbbbbbbb 0000Bbbb | gggggggg 0000Gggg | ...
+ * | gggggggg 0000Gggg | rrrrrrrr 0000Rrrr | gggggggg 0000Gggg | rrrrrrrr 0000Rrrr | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SBGGR12 VIDEO_FOURCC('B', 'G', '1', '2')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg 0000Gggg | bbbbbbbb 0000Bbbb | gggggggg 0000Gggg | bbbbbbbb 0000Bbbb | ...
+ * | rrrrrrrr 0000Rrrr | gggggggg 0000Gggg | rrrrrrrr 0000Rrrr | gggggggg 0000Gggg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGBRG12 VIDEO_FOURCC('G', 'B', '1', '2')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg 0000Gggg | rrrrrrrr 0000Rrrr | gggggggg 0000Gggg | rrrrrrrr 0000Rrrr | ...
+ * | bbbbbbbb 0000Bbbb | gggggggg 0000Gggg | bbbbbbbb 0000Bbbb | gggggggg 0000Gggg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGRBG12 VIDEO_FOURCC('B', 'A', '1', '2')
+
+/**
+ * @code{.unparsed}
+ * | rrrrrrrr 0000Rrrr | gggggggg 0000Gggg | rrrrrrrr 0000Rrrr | gggggggg 0000Gggg | ...
+ * | gggggggg 0000Gggg | bbbbbbbb 0000Bbbb | gggggggg 0000Gggg | bbbbbbbb 0000Bbbb | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SRGGB12 VIDEO_FOURCC('R', 'G', '1', '2')
+
+/**
+ * @code{.unparsed}
+ * | bbbbbbbb 00Bbbbbb | gggggggg 00Gggggg | bbbbbbbb 00Bbbbbb | gggggggg 00Gggggg | ...
+ * | gggggggg 00Gggggg | rrrrrrrr 00Rrrrrr | gggggggg 00Gggggg | rrrrrrrr 00Rrrrrr | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SBGGR14 VIDEO_FOURCC('B', 'G', '1', '4')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg 00Gggggg | bbbbbbbb 00Bbbbbb | gggggggg 00Gggggg | bbbbbbbb 00Bbbbbb | ...
+ * | rrrrrrrr 00Rrrrrr | gggggggg 00Gggggg | rrrrrrrr 00Rrrrrr | gggggggg 00Gggggg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGBRG14 VIDEO_FOURCC('G', 'B', '1', '4')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg 00Gggggg | rrrrrrrr 00Rrrrrr | gggggggg 00Gggggg | rrrrrrrr 00Rrrrrr | ...
+ * | bbbbbbbb 00Bbbbbb | gggggggg 00Gggggg | bbbbbbbb 00Bbbbbb | gggggggg 00Gggggg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGRBG14 VIDEO_FOURCC('G', 'R', '1', '4')
+
+/**
+ * @code{.unparsed}
+ * | rrrrrrrr 00Rrrrrr | gggggggg 00Gggggg | rrrrrrrr 00Rrrrrr | gggggggg 00Gggggg | ...
+ * | gggggggg 00Gggggg | bbbbbbbb 00Bbbbbb | gggggggg 00Gggggg | bbbbbbbb 00Bbbbbb | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SRGGB14 VIDEO_FOURCC('R', 'G', '1', '4')
+
+/**
+ * @code{.unparsed}
+ * | bbbbbbbb Bbbbbbbb | gggggggg Gggggggg | bbbbbbbb Bbbbbbbb | gggggggg Gggggggg | ...
+ * | gggggggg Gggggggg | rrrrrrrr Rrrrrrrr | gggggggg Gggggggg | rrrrrrrr Rrrrrrrr | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SBGGR16 VIDEO_FOURCC('B', 'Y', 'R', '2')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg Gggggggg | bbbbbbbb Bbbbbbbb | gggggggg Gggggggg | bbbbbbbb Bbbbbbbb | ...
+ * | rrrrrrrr Rrrrrrrr | gggggggg Gggggggg | rrrrrrrr Rrrrrrrr | gggggggg Gggggggg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGBRG16 VIDEO_FOURCC('G', 'B', '1', '6')
+
+/**
+ * @code{.unparsed}
+ * | gggggggg Gggggggg | rrrrrrrr Rrrrrrrr | gggggggg Gggggggg | rrrrrrrr Rrrrrrrr | ...
+ * | bbbbbbbb Bbbbbbbb | gggggggg Gggggggg | bbbbbbbb Bbbbbbbb | gggggggg Gggggggg | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SGRBG16 VIDEO_FOURCC('G', 'R', '1', '6')
+
+/**
+ * @code{.unparsed}
+ * | rrrrrrrr Rrrrrrrr | gggggggg Gggggggg | rrrrrrrr Rrrrrrrr | gggggggg Gggggggg | ...
+ * | gggggggg Gggggggg | bbbbbbbb Bbbbbbbb | gggggggg Gggggggg | bbbbbbbb Bbbbbbbb | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_SRGGB16 VIDEO_FOURCC('R', 'G', '1', '6')
+
+/**
  * @}
  */
 
@@ -1187,6 +1315,22 @@ static inline unsigned int video_bits_per_pixel(uint32_t pixfmt)
 		return 14;
 	case VIDEO_PIX_FMT_RGB565:
 	case VIDEO_PIX_FMT_YUYV:
+	case VIDEO_PIX_FMT_SBGGR10:
+	case VIDEO_PIX_FMT_SGBRG10:
+	case VIDEO_PIX_FMT_SGRBG10:
+	case VIDEO_PIX_FMT_SRGGB10:
+	case VIDEO_PIX_FMT_SBGGR12:
+	case VIDEO_PIX_FMT_SGBRG12:
+	case VIDEO_PIX_FMT_SGRBG12:
+	case VIDEO_PIX_FMT_SRGGB12:
+	case VIDEO_PIX_FMT_SBGGR14:
+	case VIDEO_PIX_FMT_SGBRG14:
+	case VIDEO_PIX_FMT_SGRBG14:
+	case VIDEO_PIX_FMT_SRGGB14:
+	case VIDEO_PIX_FMT_SBGGR16:
+	case VIDEO_PIX_FMT_SGBRG16:
+	case VIDEO_PIX_FMT_SGRBG16:
+	case VIDEO_PIX_FMT_SRGGB16:
 		return 16;
 	case VIDEO_PIX_FMT_XRGB32:
 	case VIDEO_PIX_FMT_XYUV32:


### PR DESCRIPTION
In preparation of the DCMIPP pull-request, add some more formats that can be output such as unpacked bayer formats or RGB24 / 32 formats as well as more 16bit YUV variants.