### PR TITLE
zephyr-env.sh: Use $XDG_CONFIG_HOME/zephry/zephyrrc if present

### DIFF
--- a/doc/develop/env_vars.rst
+++ b/doc/develop/env_vars.rst
@@ -88,8 +88,16 @@ your environment when you are using Zephyr.
 
    .. group-tab:: Linux/macOS
 
-      Create a file named :file:`~/.zephyrrc` if it doesn't exist, then add this
-      line to it:
+      Zephyr supports multiple locations for your :file:`zephyrrc` file,
+      following the XDG Base Directory Specification when possible. Create a
+      zephyrrc file in one of the following locations (they will be checked in
+      order):
+
+      #. :file:`$XDG_CONFIG_HOME/zephyr/zephyrrc`
+      #. :file:`$HOME/.config/zephyr/zephyrrc`
+      #. :file:`$HOME/.zephyrrc`
+
+      Add this line to the file in your preferred location:
 
       .. code-block:: console
 
@@ -97,7 +105,8 @@ your environment when you are using Zephyr.
 
       To get this value back into your current terminal environment, **you must
       run** ``source zephyr-env.sh`` from the main ``zephyr`` repository. Among
-      other things, this script sources :file:`~/.zephyrrc`.
+      other things, this script sources your :file:`zephyrrc` (the first one it
+      finds from the list of locations above).
 
       The value will be lost if you close the window, etc.; run ``source
       zephyr-env.sh`` again to get it back.

--- a/zephyr-env.sh
+++ b/zephyr-env.sh
@@ -64,6 +64,14 @@ zephyr_answer_file=~/zephyr-env_install.bash
 	. ${zephyr_answer_file}
 }
 unset zephyr_answer_file
-zephyr_answer_file=~/.zephyrrc
-[ -f ${zephyr_answer_file} ] &&  . ${zephyr_answer_file}
-unset zephyr_answer_file
+xdg_config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"
+zephyr_xdg_rc="${xdg_config_home}/zephyr/zephyrrc"
+if [ -f "${zephyr_xdg_rc}" ]; then
+    . "${zephyr_xdg_rc}"
+else
+    zephyr_answer_file=~/.zephyrrc
+    [ -f "${zephyr_answer_file}" ] && . "${zephyr_answer_file}"
+    unset zephyr_answer_file
+fi
+unset zephyr_xdg_rc
+unset xdg_config_home


### PR DESCRIPTION
According to the [XDG Base Directory Specification] there is a single base directory in which user configuration files should be stored. This helps users to keep their home directory uncluttered. This base directory can be set in the environment variable `$XDG_CONFIG_HOME` and defaults to ${HOME}/.config if $XDG_CONFIG_HOME is not set.

This commit adjusts the zephyr-env.sh script to look for a user configuration file in the following locations:

- $XDG_CONFIG_HOME/zephyr/zephyrrc
- $HOME/zephyrrc
- $HOME/.zephyrrc

The first one that is found will be used.

[XDG Base Directory Specification]: (https://specifications.freedesktop.org/basedir-spec/latest/)