### PR TITLE
boards: raspberrypi: Aggregate debugging info to rpi_pico docs

### DIFF
--- a/boards/kws/pico2_spe/doc/index.rst
+++ b/boards/kws/pico2_spe/doc/index.rst
@@ -44,8 +44,19 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-As with the Pico-SPE, the SWD interface can be used to program and debug the
-device, e.g. using OpenOCD with the `Raspberry Pi Debug Probe <https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html>`_ .
+As with the Pico-SPE, the SWD interface can be used to program and debug the device,
+e.g. using OpenOCD with the `Raspberry Pi Debug Probe <https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html>`_ .
+
+The overall explanation regarding flashing and debugging is the same as for :zephyr:board:`rpi_pico`.
+Refer to :ref:`rpi_pico_programming_and_debugging` for more information. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
+
+Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: pico2_spe/rp2350a/m33
+   :goals: build flash
+   :flash-args: --openocd /usr/local/bin/openocd
 
 References
 **********

--- a/boards/kws/pico_spe/doc/index.rst
+++ b/boards/kws/pico_spe/doc/index.rst
@@ -84,144 +84,19 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-Flashing
-========
+The SWD interface can be used to program and debug the device,
+e.g. using OpenOCD with the `Raspberry Pi Debug Probe <https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html>`_ .
 
-Using SEGGER JLink
-------------------
+The overall explanation regarding flashing and debugging is the same as for :zephyr:board:`rpi_pico`.
+Refer to :ref:`rpi_pico_programming_and_debugging` for more information. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
 
-You can Flash the pico_spe with a SEGGER JLink debug probe as described in
-:ref:`Building, Flashing and Debugging <west-flashing>`.
-
-Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: pico_spe
-   :goals: build
-
-.. code-block:: bash
-
-  west flash --runner jlink
-
-Using OpenOCD
--------------
-
-To use CMSIS-DAP, you must configure **udev**.
-
-Create a file in /etc/udev.rules.d with any name, and write the line below.
-
-.. code-block:: bash
-
-   ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000c", MODE="660", GROUP="plugdev", TAG+="uaccess"
-
-This example is valid for the case that the user joins to ``plugdev`` groups.
-
-The Pico-SPE has an SWD interface that can be used to program
-and debug the on board RP2040. This interface can be utilized by OpenOCD.
-To use it with the RP2040, OpenOCD version 0.12.0 or later is needed.
-
-If you are using a Debian based system (including RaspberryPi OS, Ubuntu. and more),
-using the `pico_setup.sh`_ script is a convenient way to set up the forked version of OpenOCD.
-
-Depending on the interface used (such as JLink), you might need to
-checkout to a branch that supports this interface, before proceeding.
-Build and install OpenOCD as described in the README.
-
-Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.
+Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
    :board: pico_spe
    :goals: build flash
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd -DOPENOCD_DEFAULT_PATH=/usr/local/share/openocd/scripts -DRPI_PICO_DEBUG_ADAPTER=cmsis-dap
-
-Set the environment variables **OPENOCD** to :file:`/usr/local/bin/openocd`
-and **OPENOCD_DEFAULT_PATH** to :file:`/usr/local/share/openocd/scripts`. This should work
-with the OpenOCD that was installed with the default configuration.
-This configuration also works with an environment that is set up by the `pico_setup.sh`_ script.
-
-**RPI_PICO_DEBUG_ADAPTER** specifies what debug adapter is used for debugging.
-
-If **RPI_PICO_DEBUG_ADAPTER** was not assigned, ``cmsis-dap`` is used by default.
-The other supported adapters are ``raspberrypi-swd``, ``jlink`` and ``blackmagicprobe``.
-How to connect ``cmsis-dap`` and ``raspberrypi-swd`` is described in `Getting Started with Pico-SPE-Series`_.
-Any other SWD debug adapter maybe also work with this configuration.
-
-The value of **RPI_PICO_DEBUG_ADAPTER** is cached, so it can be omitted from
-``west flash`` and ``west debug`` if it was previously set while running
-``west build``.
-
-**RPI_PICO_DEBUG_ADAPTER** is used in an argument to OpenOCD as ``"source [find interface/${RPI_PICO_DEBUG_ADAPTER}.cfg]"``.
-Thus, **RPI_PICO_DEBUG_ADAPTER** needs to be assigned the file name of the debug adapter.
-
-You can also flash the board with the following
-command that directly calls OpenOCD (assuming a SEGGER JLink adapter is used):
-
-.. code-block:: console
-
-   $ openocd -f interface/jlink.cfg -c 'transport select swd' -f target/rp2040.cfg -c "adapter speed 2000" -c 'targets rp2040.core0' -c 'program path/to/zephyr.elf verify reset exit'
-
-Using UF2
----------
-
-If you don't have an SWD adapter, you can flash the Pico-SPE with
-a UF2 file. By default, building an app for this board will generate a
-:file:`build/zephyr/zephyr.uf2` file. If the Pico is powered on with the ``BOOTSEL``
-button pressed, it will appear on the host as a mass storage device. The
-UF2 file should be drag-and-dropped to the device, which will flash the Pico.
-
-Debugging
-=========
-
-The SWD interface can also be used to debug the board. To achieve this, you can
-either use SEGGER JLink or OpenOCD.
-
-Using SEGGER JLink
-------------------
-
-Use a SEGGER JLink debug probe and follow the instruction in
-:ref:`Building, Flashing and Debugging<west-debugging>`.
-
-
-Using OpenOCD
--------------
-
-Install OpenOCD as described for flashing the board.
-
-Here is an example for debugging the :zephyr:code-sample:`blinky` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: pico_spe
-   :maybe-skip-config:
-   :goals: debug
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd -DOPENOCD_DEFAULT_PATH=/usr/local/share/openocd/scripts -DRPI_PICO_DEBUG_ADAPTER=raspberrypi-swd
-
-As with flashing, you can specify the debug adapter by specifying **RPI_PICO_DEBUG_ADAPTER**
-at ``west build`` time. No needs to specify it at ``west debug`` time.
-
-You can also debug with OpenOCD and gdb launching from command-line.
-Run the following command:
-
-.. code-block:: console
-
-   $ openocd -f interface/jlink.cfg -c 'transport select swd' -f target/rp2040.cfg -c "adapter speed 2000" -c 'targets rp2040.core0'
-
-On another terminal, run:
-
-.. code-block:: console
-
-   $ gdb-multiarch
-
-Inside gdb, run:
-
-.. code-block:: console
-
-   (gdb) tar ext :3333
-   (gdb) file path/to/zephyr.elf
-
-You can then start debugging the board.
+   :flash-args: --openocd /usr/local/bin/openocd
 
 .. target-notes::
 

--- a/boards/pimoroni/pico_plus2/doc/index.rst
+++ b/boards/pimoroni/pico_plus2/doc/index.rst
@@ -42,15 +42,16 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-The overall explanation regarding flashing and debugging is the same as or ``rpi_pico``.
-See :ref:`rpi_pico_flashing_using_openocd` and :ref:`rpi_pico_flashing_using_uf2`
-in ``rpi_pico`` documentation.
+The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
+See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
+
+Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
-   :board: pico_plus2
+   :board: pico_plus2/rp2350b/m33
    :goals: build flash
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd
+   :flash-args: --openocd /usr/local/bin/openocd
 
 .. target-notes::
 

--- a/boards/raspberrypi/rpi_pico/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico/doc/index.rst
@@ -130,20 +130,11 @@ Raspberry Pi Pico's PIO is a programmable chip that can implement a variety of p
      - :kconfig:option:`CONFIG_LED_STRIP`
      - :dtcompatible:`worldsemi,ws2812-rpi_pico-pio`
 
-Programming and Debugging
-*************************
-
-.. zephyr:board-supported-runners::
-
-Applications for the ``rpi_pico`` board configuration can be built and
-flashed in the usual way (see :ref:`build_an_application` and
-:ref:`application_run` for more details).
-
 System requirements
-===================
+*******************
 
 Prerequisites for the Pico W
-----------------------------
+============================
 
 Building for the Raspberry Pi Pico W requires the AIROC binary blobs
 provided by Infineon. Run the command below to retrieve those files:
@@ -156,46 +147,29 @@ provided by Infineon. Run the command below to retrieve those files:
 
    It is recommended running the command above after :file:`west update`.
 
-Debug Probe and Host Tools
---------------------------
+.. _rpi_pico_programming_and_debugging:
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+Applications for the ``rpi_pico`` board configuration can be built and
+flashed in the usual way (see :ref:`build_an_application` and
+:ref:`application_run` for more details).
 
 Several debugging tools support the Raspberry Pi Pico.
 The `Raspberry Pi Debug Probe`_ is an easy-to-obtain CMSIS-DAP adapter
 officially provided by the Raspberry Pi Foundation,
 making it a convenient choice for debugging ``rpi_pico``.
+It can be used with ``openocd`` or ``pyocd``.
 
-It can be used with
-
-- :ref:`openocd-debug-host-tools`
-- :ref:`pyocd-debug-host-tools`
-
-OpenOCD is the default for ``rpi_pico``.
-
-- `SEGGER J-Link`_
-- `Black Magic Debug Probe <Black Magic Debug>`_
-
-can also be used.
-These are used with dedicated probes.
 
 Flashing
 ========
 
 The ``rpi_pico`` can flash with Zephyr's standard method.
 See also :ref:`Building, Flashing and Debugging<west-flashing>`.
-
-Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: rpi_pico
-   :goals: build
-
-.. code-block:: console
-
-  west flash --runner jlink
-
-
-.. _rpi_pico_flashing_using_openocd:
 
 Using OpenOCD
 -------------
@@ -216,13 +190,14 @@ Here is an example of building and flashing the :zephyr:code-sample:`blinky` app
    :zephyr-app: samples/basic/blinky
    :board: rpi_pico
    :goals: build flash
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd -DRPI_PICO_DEBUG_ADAPTER=cmsis-dap
+   :gen-args: -DRPI_PICO_DEBUG_ADAPTER=cmsis-dap
+   :flash-args: --openocd /usr/local/bin/openocd
 
-Set the CMake option **OPENOCD** to :file:`/usr/local/bin/openocd`. This should work
+Set the flash runner option **--openocd** to :file:`/usr/local/bin/openocd`. This should work
 with the OpenOCD that was installed with the default configuration.
 This configuration also works with an environment that is set up by the `pico_setup.sh`_ script.
 
-**RPI_PICO_DEBUG_ADAPTER** specifies what debug adapter is used for debugging.
+In this sample, **RPI_PICO_DEBUG_ADAPTER** specifies which debug adapter is used for debugging.
 
 If **RPI_PICO_DEBUG_ADAPTER** was not set, ``cmsis-dap`` is used by default.
 The ``raspberrypi-swd`` and ``jlink`` are verified to work.
@@ -236,7 +211,24 @@ The value of **RPI_PICO_DEBUG_ADAPTER** is cached, so it can be omitted from
 **RPI_PICO_DEBUG_ADAPTER** is used in an argument to OpenOCD as ``"source [find interface/${RPI_PICO_DEBUG_ADAPTER}.cfg]"``.
 Thus, **RPI_PICO_DEBUG_ADAPTER** needs to be assigned the file name of the debug adapter.
 
-.. _rpi_pico_flashing_using_uf2:
+
+Using JLink or other supported tools
+------------------------------------
+
+You can Flash with a `SEGGER J-Link`_ debug probe as described in
+:ref:`Building, Flashing and Debugging <west-flashing>`.
+
+Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: rpi_pico
+   :goals: build flash
+   :flash-args: --runner jlink
+
+You can also use other supported tools, such as `Black Magic Probe`_,
+by changing the ``-- runner`` option.
+
 
 Using UF2
 ---------
@@ -244,8 +236,15 @@ Using UF2
 If you don't have an SWD adapter, you can flash the Raspberry Pi Pico with
 a UF2 file. By default, building an app for this board will generate a
 :file:`build/zephyr/zephyr.uf2` file. If the Pico is powered on with the ``BOOTSEL``
-button pressed, it will appear on the host as a mass storage device. The
-UF2 file should be drag-and-dropped to the device, which will flash the Pico.
+button pressed, it will appear on the host as a mass storage device.
+Run the following command, or drag-and-drop the uf2 file to the device,
+which will flash the Pico.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: rpi_pico
+   :goals: flash
+   :flash-args: --runner uf2
 
 Debugging
 =========
@@ -260,14 +259,11 @@ the `Raspberry Pi Debug Probe`_.
    :board: rpi_pico
    :maybe-skip-config:
    :goals: debug
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd -DRPI_PICO_DEBUG_ADAPTER=cmsis-dap
+   :debug-args: --openocd /usr/local/bin/openocd
 
 The default debugging tool is ``openocd``.
 If you use a different tool, specify it with the ``--runner``,
 such as ``jlink``.
-
-If you use OpenOCD, see also the description about flashing :ref:`rpi_pico_flashing_using_uf2`
-for more information.
 
 
 .. target-notes::
@@ -293,5 +289,5 @@ for more information.
 .. _SEGGER J-Link:
    https://www.segger.com/products/debug-probes/j-link/
 
-.. _Black Magic Debug:
+.. _Black Magic Probe:
    https://black-magic.org/

--- a/boards/raspberrypi/rpi_pico2/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico2/doc/index.rst
@@ -42,8 +42,16 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-As with the Pico 1, the SWD interface can be used to program and debug the
-device, e.g. using OpenOCD with the `Raspberry Pi Debug Probe <https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html>`_ .
+The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
+See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
+
+Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: rpi_pico2/rp2350a/m33
+   :goals: build flash
+   :flash-args: --openocd /usr/local/bin/openocd
 
 References
 **********

--- a/boards/wiznet/w5500_evb_pico/doc/index.rst
+++ b/boards/wiznet/w5500_evb_pico/doc/index.rst
@@ -76,152 +76,16 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-Flashing
-========
+The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
+See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
 
-Using SEGGER JLink
-------------------
-
-You can Flash the w5500_evb_pico with a SEGGER JLink debug probe as described in
-:ref:`Building, Flashing and Debugging <west-flashing>`.
-
-Here is an example of building and flashing the :zephyr:code-sample:`blinky` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: w5500_evb_pico
-   :goals: build
-
-.. code-block:: bash
-
-  west flash --runner jlink
-
-Using OpenOCD
--------------
-
-To use PicoProbe, You must configure **udev**.
-
-Create a file in /etc/udev.rules.d with any name, and write the line below.
-
-.. code-block:: bash
-
-   ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000c", MODE="660", GROUP="plugdev", TAG+="uaccess"
-
-This example is valid for the case that the user joins to ``plugdev`` groups.
-
-The Raspberry Pi Pico, and thus the W55500 Evaluation Board, has an SWD
-interface that can be used to program and debug the on board RP2040. This
-interface can be utilized by OpenOCD. To use it with the RP2040, OpenOCD
-version 0.12.0 or later is needed.
-
-If you are using a Debian based system (including Raspberry Pi OS, Ubuntu, and
-more), using the `pico_setup.sh`_ script is a convenient way to set up the
-forked version of OpenOCD.
-
-Depending on the interface used (such as JLink), you might need to
-checkout to a branch that supports this interface, before proceeding.
-Build and install OpenOCD as described in the README.
-
-Here is an example of building and flashing the :zephyr:code-sample:`blinky`
-application.
+Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
    :board: w5500_evb_pico
    :goals: build flash
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd -DOPENOCD_DEFAULT_PATH=/usr/local/share/openocd/scripts -DRPI_PICO_DEBUG_ADAPTER=picoprobe
-
-Set the environment variables **OPENOCD** to :file:`/usr/local/bin/openocd` and
-**OPENOCD_DEFAULT_PATH** to :file:`/usr/local/share/openocd/scripts`. This should
-work with the OpenOCD that was installed with the default configuration. This
-configuration also works with an environment that is set up by the
-`pico_setup.sh`_ script.
-
-**RPI_PICO_DEBUG_ADAPTER** specifies what debug adapter is used for debugging.
-
-If **RPI_PICO_DEBUG_ADAPTER** was not assigned, ``picoprobe`` is used by default.
-The other supported adapters are ``raspberrypi-swd``, ``jlink`` and
-``blackmagicprobe``. How to connect ``picoprobe`` and ``raspberrypi-swd`` is
-described in `Getting Started with Raspberry Pi Pico`_. Any other SWD debug
-adapter maybe also work with this configuration.
-
-The value of **RPI_PICO_DEBUG_ADAPTER** is cached, so it can be omitted from
-``west flash`` and ``west debug`` if it was previously set while running
-``west build``.
-
-**RPI_PICO_DEBUG_ADAPTER** is used in an argument to OpenOCD as
-``"source [find interface/${RPI_PICO_DEBUG_ADAPTER}.cfg]"``. Thus,
-**RPI_PICO_DEBUG_ADAPTER** needs to be assigned the file name of the debug
-adapter.
-
-You can also flash the board with the following
-command that directly calls OpenOCD (assuming a SEGGER JLink adapter is used):
-
-.. code-block:: console
-
-   $ openocd -f interface/jlink.cfg -c 'transport select swd' -f target/rp2040.cfg -c "adapter speed 2000" -c 'targets rp2040.core0' -c 'program path/to/zephyr.elf verify reset exit'
-
-Using UF2
----------
-
-If you don't have an SWD adapter, you can flash the Raspberry Pi Pico with
-a UF2 file. By default, building an app for this board will generate a
-:file:`build/zephyr/zephyr.uf2` file. If the Pico is powered on with the ``BOOTSEL``
-button pressed, it will appear on the host as a mass storage device. The
-UF2 file should be drag-and-dropped to the device, which will flash the Pico.
-
-Debugging
-=========
-
-The SWD interface can also be used to debug the board. To achieve this, you can
-either use SEGGER JLink or OpenOCD.
-
-Using SEGGER JLink
-------------------
-
-Use a SEGGER JLink debug probe and follow the instruction in
-:ref:`Building, Flashing and Debugging<west-debugging>`.
-
-
-Using OpenOCD
--------------
-
-Install OpenOCD as described for flashing the board.
-
-Here is an example for debugging the :zephyr:code-sample:`blinky` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: w5500_evb_pico
-   :maybe-skip-config:
-   :goals: debug
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd -DOPENOCD_DEFAULT_PATH=/usr/local/share/openocd/scripts -DRPI_PICO_DEBUG_ADAPTER=raspberrypi-swd
-
-As with flashing, you can specify the debug adapter by specifying
-**RPI_PICO_DEBUG_ADAPTER** at ``west build`` time. No needs to specify it at
-``west debug`` time.
-
-You can also debug with OpenOCD and gdb launching from command-line.
-Run the following command:
-
-.. code-block:: console
-
-   $ openocd -f interface/jlink.cfg -c 'transport select swd' -f target/rp2040.cfg -c "adapter speed 2000" -c 'targets rp2040.core0'
-
-On another terminal, run:
-
-.. code-block:: console
-
-   $ gdb-multiarch
-
-Inside gdb, run:
-
-.. code-block:: console
-
-   (gdb) tar ext :3333
-   (gdb) file path/to/zephyr.elf
-
-You can then start debugging the board.
+   :flash-args: --openocd /usr/local/bin/openocd
 
 .. target-notes::
 

--- a/boards/wiznet/w5500_evb_pico2/doc/index.rst
+++ b/boards/wiznet/w5500_evb_pico2/doc/index.rst
@@ -77,54 +77,16 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-Flashing
-========
+The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
+See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
 
-Using OpenOCD
--------------
-
-The overall explanation regarding flashing and debugging is the same as or
-``rpi_pico``.
-See :ref:`rpi_pico_flashing_using_openocd`. in ``rpi_pico`` documentation.
-
-A typical build command for w5500_evb_pico2 is as follows.
-This assumes a CMSIS-DAP adapter such as the Raspberry Pi Debug Probe,
-but if you are using something else, specify ``RPI_PICO_DEBUG_ADAPTER``.
+Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/basic/blinky
-   :board: w5500_evb_pico2
+   :board: w5500_evb_pico2/rp2350a/m33
    :goals: build flash
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd
-
-Using UF2
----------
-
-If you don't have an SWD adapter, you can flash the Raspberry Pi Pico with
-a UF2 file. By default, building an app for this board will generate a
-:file:`build/zephyr/zephyr.uf2` file. If the Pico is powered on with the ``BOOTSEL``
-button pressed, it will appear on the host as a mass storage device. The
-UF2 file should be drag-and-dropped to the device, which will flash the Pico.
-
-Debugging
-=========
-
-The SWD interface can also be used to debug the board. To achieve this, you can
-either use SEGGER JLink or OpenOCD.
-
-Using OpenOCD
--------------
-
-Install OpenOCD as described for flashing the board.
-
-Here is an example for debugging the :zephyr:code-sample:`blinky` application.
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/basic/blinky
-   :board: w5500_evb_pico2
-   :maybe-skip-config:
-   :goals: debug
-   :gen-args: -DOPENOCD=/usr/local/bin/openocd
+   :flash-args: --openocd /usr/local/bin/openocd
 
 .. target-notes::
 

--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -12,6 +12,19 @@ hardware supports them and your Zephyr board directory's :file:`board.cmake`
 file declares that support properly. See :ref:`west-build-flash-debug` for
 more information on these commands.
 
+.. _runner_blackmagicprobe:
+
+Black Magic Probe
+*****************
+
+Black Magic Probe (BMP) is an open-source debugging hardware incorporating GDB debug
+server functionality into the firmware.
+There is no need for a GDB server program, so there is no program equivalent
+to host-tool.
+
+For more details, including usage instructions and supported targets,
+see :ref:`black-magic-probe`.
+
 .. _atmel_sam_ba_bootloader:
 .. _runner_bossac:
 
@@ -561,6 +574,28 @@ It can be used through the ``west flash`` command to flash Zephyr applications.
 
 For advanced usage via the GUI or CLI, check out the `STM32CubeProgrammer User Manual`_.
 
+.. _runner_uf2:
+
+UF2 Uploader
+************
+
+The uf2 runner supports flashing some boards using the UF2 (USB Flashing Format).
+UF2 is a user-friendly file format designed for drag-and-drop programming via a USB mass storage device.
+
+It relies on the target device entering a special bootloader mode where it appears to the host
+as a USB mass storage device.
+Once in this mode, the application image can be uploaded by copying a ``.uf2`` file to the
+mounted volume.
+
+.. code-block:: console
+
+   west flash --runner uf2
+
+If the UF2 volume is not automatically detected, you may need to manually specify the mount point
+using the ``--device`` option:
+
+For more about the UF2 format and its tooling, see `USB Flashing Format (UF2)`_.
+
 .. _J-Link Software and Documentation Pack:
    https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack
 
@@ -632,3 +667,6 @@ For advanced usage via the GUI or CLI, check out the `STM32CubeProgrammer User M
 
 .. _STLINK-V3PWR:
    https://www.st.com/en/development-tools/stlink-v3pwr.html
+
+.. _USB Flashing Format (UF2):
+   https://github.com/microsoft/uf2

--- a/doc/develop/flash_debug/probes.rst
+++ b/doc/develop/flash_debug/probes.rst
@@ -488,6 +488,19 @@ NXP S32 Debug Probe is designed to work in conjunction with NXP S32 Design Studi
 host tools as in indicated in :ref:`nxp-s32-debug-host-tools` before you program
 the firmware.
 
+.. _black-magic-probe:
+
+Black Magic Probe
+*****************
+
+The Black Magic Probe is an open-source hardware for debugging that is designed
+to be used with `Black Magic Debug`_ firmware.
+The firmware incorporates GDB Server so that you can connect directly from ``gdb``
+to the target device.
+
+Some of the STM32F103-based boards can run the `Black Magic Debug`_ firmware.
+See `Black Magic Debug supported hardware`_.
+
 .. _LPCScrypt:
    https://www.nxp.com/lpcscrypt
 
@@ -526,3 +539,9 @@ the firmware.
 
 .. _DAPLink Bootloader Update:
    https://os.mbed.com/blog/entry/DAPLink-bootloader-update/
+
+.. _Black Magic Debug:
+   https://black-magic.org/index.html
+
+.. _Black Magic Debug supported hardware:
+   https://black-magic.org/hardware.html


### PR DESCRIPTION
I've consolidated the debugging procedures for rpi_pico derived boards into the rpi_pico documentation.

I've written about the blackmagicprobe and uf2 runner.
I hope that this will be linked from the automatically generated table, but this cannot be confirmed as it is not generated in local builds.

- Added information about UF2 and BlackMagic Probe.
- Centralize flash/debug instructions under rpi_pico docs.

Fix #88333