### PR TITLE
cmake: ensure -fstack-protector-explicit is applied to C++ targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ elseif(CONFIG_STACK_CANARIES_ALL)
   zephyr_compile_options("$<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,security_canaries_all>>")
 elseif(CONFIG_STACK_CANARIES_EXPLICIT)
   zephyr_compile_options("$<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,security_canaries_explicit>>")
-  zephyr_compile_options("$<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,security_canaries_explitic>>")
+  zephyr_compile_options("$<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,security_canaries_explicit>>")
 endif()
 
 # @Intent: Obtain compiler optimizations flags and store in variables


### PR DESCRIPTION
cmake: ensure -fstack-protector-explicit is applied to C++ targets

A typo in the top-level CMakeLists.txt prevented C++ targets from
receiving -fstack-protector-explicit when CONFIG_STACK_CANARIES_EXPLICIT=y.

Signed-off-by: Mirai SHINJO <oss@mshinjo.com>