### PR TITLE
drivers: stepper: Fix stepper callbacks when using work_q

### DIFF
--- a/drivers/stepper/step_dir/step_dir_stepper_common.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.c
@@ -145,11 +145,11 @@ static void position_mode_task(const struct device *dev)
 		(void)step_dir_stepper_perform_step(dev);
 	}
 
-	update_remaining_steps(dev->data);
-
 	if (config->timing_source->needs_reschedule(dev) && data->step_count != 0) {
 		(void)config->timing_source->start(dev);
 	}
+
+	update_remaining_steps(dev->data);
 }
 
 static void velocity_mode_task(const struct device *dev)

--- a/tests/drivers/stepper/stepper_api/Kconfig
+++ b/tests/drivers/stepper/stepper_api/Kconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 Josselin Bunt
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Stepper API Test"
+
+source "Kconfig.zephyr"
+
+config STEPPER_TEST_TIMING_TIMEOUT_TOLERANCE_PCT
+	int "Stepper timing tolerance percentage"
+	default 20
+	help
+	  Additional margin (%) added to step timing during test timeouts.
+	  Accounts for execution and scheduling jitter.

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_adi_tmc2209_work_q.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_adi_tmc2209_work_q.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Josselin Bunt
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"
+
+/ {
+	aliases {
+		stepper =  &adi_tmc2209;
+	};
+};
+
+/ {
+	adi_tmc2209: adi_tmc2209 {
+		status = "okay";
+		compatible = "adi,tmc2209";
+		micro-step-res = <32>;
+		dir-gpios = <&gpio1 0 0>;
+		step-gpios = <&gpio1 1 0>;
+		en-gpios = <&gpio2 1 0>;
+		msx-gpios = <&gpio3 0 0>, <&gpio4 1 0>;
+	};
+};

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979_work_q.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979_work_q.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Josselin Bunt
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"
+
+/ {
+	aliases {
+		stepper =  &allegro_a4979;
+	};
+};
+
+/ {
+	allegro_a4979: allegro_a4979 {
+		status = "okay";
+		compatible = "allegro,a4979";
+		micro-step-res = <1>;
+		reset-gpios = <&gpio4 0 0>;
+		dir-gpios = <&gpio1 0 0>;
+		step-gpios = <&gpio1 1 0>;
+		en-gpios = <&gpio2 1 0>;
+		m0-gpios = <&gpio3 0 0>;
+		m1-gpios = <&gpio3 1 0>;
+	};
+};

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx_work_q.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx_work_q.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Josselin Bunt
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "native_sim.overlay"
+
+/ {
+	aliases {
+		stepper =  &ti_drv84xx;
+	};
+};
+
+/ {
+	ti_drv84xx: ti_drv84xx {
+		status = "okay";
+		compatible = "ti,drv84xx";
+		micro-step-res = <8>;
+		dir-gpios = <&gpio1 0 0>;
+		step-gpios = <&gpio1 1 0>;
+		sleep-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		en-gpios = <&gpio2 1 0>;
+		m0-gpios = <&gpio3 0 0>;
+		m1-gpios = <&gpio3 1 0>;
+	};
+};

--- a/tests/drivers/stepper/stepper_api/testcase.yaml
+++ b/tests/drivers/stepper/stepper_api/testcase.yaml
@@ -16,6 +16,15 @@ tests:
       - CONFIG_STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS=y
     platform_allow:
       - native_sim/native/64
+  drivers.stepper.stepper_api.adi_tmc2209_work_q:
+    extra_args:
+      - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_adi_tmc2209_work_q.overlay"
+    extra_configs:
+      - CONFIG_GPIO=y
+      - CONFIG_STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS=y
+      - CONFIG_STEPPER_TEST_TIMING_TIMEOUT_TOLERANCE_PCT=30
+    platform_allow:
+      - native_sim/native/64
   drivers.stepper.stepper_api.allegro_a4979:
     extra_args:
       - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_allegro_a4979.overlay"
@@ -25,6 +34,15 @@ tests:
       - CONFIG_STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS=y
     platform_allow:
       - native_sim/native/64
+  drivers.stepper.stepper_api.allegro_a4979_work_q:
+    extra_args:
+      - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_allegro_a4979_work_q.overlay"
+    extra_configs:
+      - CONFIG_GPIO=y
+      - CONFIG_STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS=y
+      - CONFIG_STEPPER_TEST_TIMING_TIMEOUT_TOLERANCE_PCT=30
+    platform_allow:
+      - native_sim/native/64
   drivers.stepper.stepper_api.ti_drv84xx:
     extra_args:
       - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_ti_drv84xx.overlay"
@@ -32,6 +50,15 @@ tests:
       - CONFIG_GPIO=y
       - CONFIG_COUNTER=y
       - CONFIG_STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS=y
+    platform_allow:
+      - native_sim/native/64
+  drivers.stepper.stepper_api.ti_drv84xx_work_q:
+    extra_args:
+      - platform:native_sim/native/64:DTC_OVERLAY_FILE="boards/native_sim_ti_drv84xx_work_q.overlay"
+    extra_configs:
+      - CONFIG_GPIO=y
+      - CONFIG_STEPPER_STEP_DIR_GENERATE_ISR_SAFE_EVENTS=y
+      - CONFIG_STEPPER_TEST_TIMING_TIMEOUT_TOLERANCE_PCT=30
     platform_allow:
       - native_sim/native/64
   drivers.stepper.stepper_api.zephyr_gpio_stepper:


### PR DESCRIPTION
Fix issue where stepper callbacks were not being called when using work_q. This was due to the steps being counted down before the work_q was rescheduled.

Added additional unit tests to stepper_api to verify the fix. Needed to increase the tolerance to 30% because of the timing of the work_q.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/88821