### PR TITLE
driver: serial: rz: Fix serial issue with sci and scif

### DIFF
--- a/drivers/serial/uart_renesas_rz_sci.c
+++ b/drivers/serial/uart_renesas_rz_sci.c
@@ -385,7 +385,13 @@ static void uart_rz_sci_txi_isr(const struct device *dev)
 
 static void uart_rz_sci_tei_isr(const struct device *dev)
 {
+	struct uart_rz_sci_data *data = dev->data;
+
 	SCI_TEI_ISR();
+
+	if (data->callback) {
+		data->callback(dev, data->callback_data);
+	}
 }
 
 static void uart_rz_sci_eri_isr(const struct device *dev)

--- a/drivers/serial/uart_renesas_rz_scif.c
+++ b/drivers/serial/uart_renesas_rz_scif.c
@@ -356,9 +356,10 @@ static void uart_rz_scif_tei_isr(const struct device *dev)
 	} else {
 		data->int_data.rxi_flag = false;
 		data->int_data.rx_fifo_busy = true;
-		if (data->callback) {
-			data->callback(dev, data->callback_data);
-		}
+	}
+
+	if (data->callback) {
+		data->callback(dev, data->callback_data);
 	}
 }
 


### PR DESCRIPTION
Fix issues that Renesas RZ boards cannot run the below serial samples properly with sci and scif since some characters cannot be outputted to console when running those samples

- `samples/subsys/console/echo`
- `samples/subsys/shell/shell_module`

Fixed by invoking the callback in TEI (Transmit End Interrupt) isr.