### PR TITLE
net: l2: ethernet: handle ARP queuing packets

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -261,6 +261,9 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 		net_if_tx_lock(iface);
 		status = net_if_l2(iface)->send(iface, pkt);
 		net_if_tx_unlock(iface);
+		if (status < 0) {
+			NET_WARN("iface %p pkt %p send failure status %d", iface, pkt, status);
+		}
 
 		if (IS_ENABLED(CONFIG_NET_PKT_TXTIME_STATS) ||
 		    IS_ENABLED(CONFIG_TRACING_NET_CORE)) {


### PR DESCRIPTION
When `CONFIG_ARP=y`, `ethernet_ll_prepare_on_ipv4` returning `NULL` is not an error condition, but instead a sign that the provided packet has been queued for later transmission due to an ongoing ARP procedure.

Since this is not an error and the packet will be queued upon receiving the ARP response, the only thing to do is immediately return 0.

Print a warning if sending a packet on the L2 interface fails. Currently this is completely silent unless `NET_DBG` is enabled and the `context` parameter is provided.

Both problems were observed while debugging `zperf` performance using a nRF7002. The nRF7002 driver in general is pretty silent on the logging front when things go wrong, making it important that the higher levels provide some sort of indication.