### PR TITLE
Bluetooth: Shell: BR: Add disconnect command for BR/EDR connections

### DIFF
--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -102,6 +102,25 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_disconnect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!default_conn) {
+		shell_print(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_conn_disconnect(default_conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+	if (err) {
+		shell_print(sh, "Disconnection failed (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "Disconnection request sent");
+	return 0;
+}
+
 static void br_device_found(const bt_addr_t *addr, int8_t rssi, const uint8_t cod[3],
 			    const uint8_t eir[240])
 {
@@ -1015,6 +1034,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(l2cap_cmds,
 SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD_ARG(auth-pincode, NULL, "<pincode>", cmd_auth_pincode, 2, 0),
 	SHELL_CMD_ARG(connect, NULL, "<address>", cmd_connect, 2, 0),
+	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
 	SHELL_CMD_ARG(bonds, NULL, HELP_NONE, cmd_bonds, 1, 0),
 	SHELL_CMD_ARG(clear, NULL, "[all] ["HELP_ADDR"]", cmd_clear, 2, 0),
 	SHELL_CMD_ARG(discovery, NULL, "<value: on, off> [length: 1-48] [mode: limited]",


### PR DESCRIPTION
Add a command disconnect to the BR/EDR shell interface to allow disconnecting active Bluetooth BR/EDR connections.

The command implementation:
- Checks if there is an active default connection
- Uses bt_conn_disconnect() to terminate the connection with BT_HCI_ERR_REMOTE_USER_TERM_CONN reason code
- Provides appropriate error messaging if the connection doesn't exist or if disconnection fails
- Returns success message when disconnection request is sent successfully This provides a convenient way to terminate BR/EDR connections from the shell interface for testing and development purposes.