### PR TITLE
Add Support for NPCX K3 SoC

### DIFF
--- a/dts/arm/nuvoton/npck/npck-alts-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck-alts-map.dtsi
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	npcx-alts-map {
+		compatible = "nuvoton,npcx-pinctrl-conf";
+
+		/* SCFG device alternative table */
+		/* SCFG DEVALT 0 */
+		alt0_sp1i_sl: alt00 {
+			alts = <&scfg 0x00 0x0 0>;
+		};
+
+		alt0_sp1o_sl: alt01 {
+			alts = <&scfg 0x00 0x1 0>;
+		};
+
+		alt0_ckout_sl: alt02 {
+			alts = <&scfg 0x00 0x2 0>;
+		};
+
+		alt0_spip1_sl: alt03 {
+			alts = <&scfg 0x00 0x3 0>;
+		};
+
+		alt0_sp2ctl_sl: alt04 {
+			alts = <&scfg 0x00 0x4 0>;
+		};
+
+		alt0_pvt_spi_sl: alt05 {
+			alts = <&scfg 0x00 0x5 0>;
+		};
+
+		alt0_shd_bkp_spi_sl: alt05-inv {
+			alts = <&scfg 0x00 0x5 1>;
+		};
+
+		alt0_shdf_spi_quad: alt06 {
+			alts = <&scfg 0x00 0x6 0>;
+		};
+
+		alt0_shd1_spi: alt07 {
+			alts = <&scfg 0x00 0x7 0>;
+		};
+
+		/* SCFG DEVALT 1 */
+		alt1_ovt_sl: alt10 {
+			alts = <&scfg 0x01 0x0 0>;
+		};
+
+		alt1_urti_sl: alt11 {
+			alts = <&scfg 0x01 0x1 0>;
+		};
+
+		alt1_urto1_sl: alt12 {
+			alts = <&scfg 0x01 0x2 0>;
+		};
+
+		alt1_sp1ctl_sl: alt14 {
+			alts = <&scfg 0x01 0x4 0>;
+		};
+
+		alt1_dpwrok_sl_def: alt15 {
+			alts = <&scfg 0x01 0x5 0>;
+		};
+
+		alt1_vcc_pwrgd_sl_def: alt16 {
+			alts = <&scfg 0x01 0x6 0>;
+		};
+
+		alt1_lpc_espi_def: alt17 {
+			alts = <&scfg 0x01 0x7 0>;
+		};
+
+		/* SCFG DEVALT 2 */
+		alt2_lpcpd_sl: alt21 {
+			alts = <&scfg 0x02 0x1 0>;
+		};
+
+		alt2_clkrun_sl: alt22 {
+			alts = <&scfg 0x02 0x2 0>;
+		};
+
+		alt2_smi_sl: alt23 {
+			alts = <&scfg 0x02 0x3 0>;
+		};
+
+		alt2_serirq_sl: alt24 {
+			alts = <&scfg 0x02 0x4 0>;
+		};
+
+		alt2_ecsci_sl_def: alt25 {
+			alts = <&scfg 0x02 0x5 0>;
+		};
+
+		alt2_smb1a_sl: alt26 {
+			alts = <&scfg 0x02 0x6 0>;
+		};
+
+		alt2_smb1b_sl: alt27 {
+			alts = <&scfg 0x02 0x7 0>;
+		};
+
+		/* SCFG DEVALT 3 */
+		alt3_ta1_1_sl: alt30 {
+			alts = <&scfg 0x03 0x0 0>;
+		};
+
+		alt3_ta2_1_sl: alt31 {
+			alts = <&scfg 0x03 0x1 0>;
+		};
+
+		alt3_tb1_1_sl: alt32 {
+			alts = <&scfg 0x03 0x2 0>;
+		};
+
+		alt3_tb2_1_sl: alt33 {
+			alts = <&scfg 0x03 0x3 0>;
+		};
+
+		alt3_ta3_1_sl: alt34 {
+			alts = <&scfg 0x03 0x4 0>;
+		};
+
+		alt3_tb3_1_sl: alt35 {
+			alts = <&scfg 0x03 0x5 0>;
+		};
+
+		alt3_tb1_2_sl: alt36 {
+			alts = <&scfg 0x03 0x6 0>;
+		};
+
+		alt3_ta1_2_sl: alt37 {
+			alts = <&scfg 0x03 0x7 0>;
+		};
+
+		/* SCFG DEVALT 4 */
+		alt4_shd2_spi: alt40 {
+			alts = <&scfg 0x04 0x0 0>;
+		};
+
+		alt4_noshd2_spi: alt40-inv {
+			alts = <&scfg 0x04 0x0 1>;
+		};
+
+		alt4_ckout2_sl: alt41 {
+			alts = <&scfg 0x04 0x1 0>;
+		};
+
+		alt4_clk24m_in2_sl: alt42 {
+			alts = <&scfg 0x04 0x2 0>;
+		};
+
+		alt4_clk24m_in1_sl: alt43 {
+			alts = <&scfg 0x04 0x3 0>;
+		};
+
+		alt4_ps2_3_sl: alt44 {
+			alts = <&scfg 0x04 0x4 0>;
+		};
+
+		alt4_ps2_2_sl: alt46 {
+			alts = <&scfg 0x04 0x6 0>;
+		};
+
+		/* SCFG DEVALT 5 */
+		alt5_a_pwm_sl: alt50 {
+			alts = <&scfg 0x05 0x0 0>;
+		};
+
+		alt5_b_pwm_sl: alt51 {
+			alts = <&scfg 0x05 0x1 0>;
+		};
+
+		alt5_c_pwm_sl: alt52 {
+			alts = <&scfg 0x05 0x2 0>;
+		};
+
+		alt5_d_pwm_sl: alt53 {
+			alts = <&scfg 0x05 0x3 0>;
+		};
+
+		alt5_f_pwm_sl: alt55 {
+			alts = <&scfg 0x05 0x5 0>;
+		};
+
+		/* SCFG DEVALT 6 */
+		alt6_adc0_sl: alt60 {
+			alts = <&scfg 0x06 0x0 0>;
+		};
+
+		alt6_adc1_sl: alt61 {
+			alts = <&scfg 0x06 0x1 0>;
+		};
+
+		alt6_adc2_sl: alt62 {
+			alts = <&scfg 0x06 0x2 0>;
+		};
+
+		alt6_adc3_sl: alt63 {
+			alts = <&scfg 0x06 0x3 0>;
+		};
+
+		alt6_adc4_sl: alt64 {
+			alts = <&scfg 0x06 0x4 0>;
+		};
+
+		alt6_adc5_sl: alt65 {
+			alts = <&scfg 0x06 0x5 0>;
+		};
+
+		alt6_adc6_sl: alt66 {
+			alts = <&scfg 0x06 0x6 0>;
+		};
+
+		alt6_adc7_sl: alt67 {
+			alts = <&scfg 0x06 0x7 0>;
+		};
+
+		/* SCFG DEVALT 7 */
+		alt7_kso12_sl_def: alt72 {
+			alts = <&scfg 0x07 0x2 0>;
+		};
+
+		alt7_kso13_sl_def: alt73 {
+			alts = <&scfg 0x07 0x3 0>;
+		};
+
+		alt7_kso14_sl_def: alt74 {
+			alts = <&scfg 0x07 0x4 0>;
+		};
+
+		alt7_kso15_sl_def: alt75 {
+			alts = <&scfg 0x07 0x5 0>;
+		};
+
+		alt7_kso16_sl: alt76 {
+			alts = <&scfg 0x07 0x6 0>;
+		};
+
+		alt7_kso17_sl: alt77 {
+			alts = <&scfg 0x07 0x7 0>;
+		};
+
+		/* SCFG DEVALT 8 */
+		alt8_ga20_sl: alt81 {
+			alts = <&scfg 0x08 0x1 0>;
+		};
+
+		alt8_kbrst_sl_def: alt82 {
+			alts = <&scfg 0x08 0x2 0>;
+		};
+
+		alt8_k_pwm_sl: alt85 {
+			alts = <&scfg 0x08 0x5 0>;
+		};
+
+		alt8_j_pwm_sl: alt86 {
+			alts = <&scfg 0x08 0x6 0>;
+		};
+
+		alt8_i_pwm_sl: alt87 {
+			alts = <&scfg 0x08 0x7 0>;
+		};
+
+		/* SCFG DEVALT 9 */
+		alt9_no_ksi0_ksi1_ksi2_ksi3_sl: alt90-inv {
+			alts = <&scfg 0x09 0x0 1>;
+		};
+
+		alt9_no_ksi4_ksi5_sl: alt92-inv {
+			alts = <&scfg 0x09 0x2 1>;
+		};
+
+		alt9_no_ksi6_ksi7_sl: alt93-inv {
+			alts = <&scfg 0x09 0x3 1>;
+		};
+
+		alt9_no_kso0_kso1_kso2_kso3_sl: alt94-inv {
+			alts = <&scfg 0x09 0x4 1>;
+		};
+
+		alt9_no_kso4_kso5_kso6_kso7_sl: alt95-inv {
+			alts = <&scfg 0x09 0x5 1>;
+		};
+
+		alt9_no_kso8_kso9_sl: alt96-inv {
+			alts = <&scfg 0x09 0x6 1>;
+		};
+
+		alt9_no_kso10_kso11_sl: alt97-inv {
+			alts = <&scfg 0x09 0x7 1>;
+		};
+
+		/* SCFG DEVALT A */
+		alta_shi_sl: alta0 {
+			alts = <&scfg 0x0a 0x0 0>;
+		};
+
+		alta_smb6a_sl: alta1 {
+			alts = <&scfg 0x0a 0x1 0>;
+		};
+
+		alta_smb5a_sl: alta2 {
+			alts = <&scfg 0x0a 0x2 0>;
+		};
+
+		alta_13c1a_sl: alta4 {
+			alts = <&scfg 0x0a 0x4 0>;
+		};
+
+		alta_13c1b_sl: alta5 {
+			alts = <&scfg 0x0a 0x5 0>;
+		};
+
+		alta_smb3a_sl: alta6 {
+			alts = <&scfg 0x0a 0x6 0>;
+		};
+
+		alta_smb4a_sl: alta7 {
+			alts = <&scfg 0x0a 0x7 0>;
+		};
+
+		/* SCFG DEVALT B */
+		altb_sp2i_sl: altb0 {
+			alts = <&scfg 0x0b 0x0 0>;
+		};
+
+		altb_sp2o_sl: altb1 {
+			alts = <&scfg 0x0b 0x1 0>;
+		};
+
+		altb_ri1_sl: altb2 {
+			alts = <&scfg 0x0b 0x2 0>;
+		};
+
+		altb_cts1_sl: altb3 {
+			alts = <&scfg 0x0b 0x3 0>;
+		};
+
+		altb_rts1_sl: altb4 {
+			alts = <&scfg 0x0b 0x4 0>;
+		};
+
+		altb_ri2_sl: altb5 {
+			alts = <&scfg 0x0b 0x5 0>;
+		};
+
+		altb_cts2_sl: altb6 {
+			alts = <&scfg 0x0b 0x6 0>;
+		};
+
+		altb_rts2_sl: altb7 {
+			alts = <&scfg 0x0b 0x7 0>;
+		};
+
+		/* SCFG DEVALT C */
+		altc_smb4b_sl: altc4 {
+			alts = <&scfg 0x0C 0x4 0>;
+		};
+
+		altc_smb3b_sl: altc5 {
+			alts = <&scfg 0x0C 0x5 0>;
+		};
+
+		altc_smb2b_sl: altc6 {
+			alts = <&scfg 0x0C 0x6 0>;
+		};
+
+		altc_smb2a_sl: altc7 {
+			alts = <&scfg 0x0C 0x7 0>;
+		};
+
+		/* SCFG DEVALT D */
+		altd_gpstby0_out_in_sby: altd0 {
+			alts = <&scfg 0x0d 0x0 0>;
+		};
+
+		altd_gpstby1_out_in_sby: altd1 {
+			alts = <&scfg 0x0d 0x1 0>;
+		};
+
+		altd_psl_in0_en_out_def: altd2 {
+			alts = <&scfg 0x0d 0x2 0>;
+		};
+
+		altd_psl_in1_en_out_def: altd3 {
+			alts = <&scfg 0x0d 0x3 0>;
+		};
+
+		altd_psl_in2_en_out_def: altd4 {
+			alts = <&scfg 0x0d 0x4 0>;
+		};
+
+		altd_psl_in3_en_out_def: altd5 {
+			alts = <&scfg 0x0d 0x5 0>;
+		};
+
+		altd_psl_in4_en_out_def: altd6 {
+			alts = <&scfg 0x0d 0x6 0>;
+		};
+
+		altd_psl_in5_en_out_def: altd7 {
+			alts = <&scfg 0x0d 0x7 0>;
+		};
+
+		/* SCFG DEVALT E */
+		alte_spip2_sl: alte5 {
+			alts = <&scfg 0x0e 0x5 0>;
+		};
+
+		/* SCFG DEVALT F */
+		altf_psl_in0_en_def: altf1 {
+			alts = <&scfg 0x0f 0x1 0>;
+		};
+
+		altf_psl_in1_en_def: altf2 {
+			alts = <&scfg 0x0f 0x2 0>;
+		};
+
+		altf_psl_in2_en: altf3 {
+			alts = <&scfg 0x0f 0x3 0>;
+		};
+
+		altf_psl_in3_en: altf4 {
+			alts = <&scfg 0x0f 0x4 0>;
+		};
+
+		altf_psl_in4_en: altf5 {
+			alts = <&scfg 0x0f 0x5 0>;
+		};
+
+		altf_psl_in5_en: altf6 {
+			alts = <&scfg 0x0f 0x6 0>;
+		};
+
+		altf_psl_out_en_def: altf7 {
+			alts = <&scfg 0x0f 0x7 0>;
+		};
+
+		/* SCFG DEVALT 10 */
+		alt10_tb5_sl: alt100 {
+			alts = <&scfg 0x10 0x0 0>;
+		};
+
+		alt10_ta5_sl: alt101 {
+			alts = <&scfg 0x10 0x1 0>;
+		};
+
+		alt10_tb4_sl: alt102 {
+			alts = <&scfg 0x10 0x2 0>;
+		};
+
+		alt10_ta4_sl: alt103 {
+			alts = <&scfg 0x10 0x3 0>;
+		};
+
+		alt10_tb3_2_sl: alt104 {
+			alts = <&scfg 0x10 0x4 0>;
+		};
+
+		alt10_ta3_2_sl: alt105 {
+			alts = <&scfg 0x10 0x5 0>;
+		};
+
+		alt10_tb2_2_sl: alt106 {
+			alts = <&scfg 0x10 0x6 0>;
+		};
+
+		alt10_ta2_2_sl: alt107 {
+			alts = <&scfg 0x10 0x7 0>;
+		};
+
+		/* SCFG DEVALT 11 */
+		alt11_adc8_sl: alt110 {
+			alts = <&scfg 0x11 0x0 0>;
+		};
+
+		alt11_adc9_sl: alt111 {
+			alts = <&scfg 0x11 0x1 0>;
+		};
+
+		alt11_adc10_sl: alt112 {
+			alts = <&scfg 0x11 0x2 0>;
+		};
+
+		alt11_adc11_sl: alt113 {
+			alts = <&scfg 0x11 0x3 0>;
+		};
+
+		/* SCFG DEVALT 12 */
+		smb1a_pu_sl: alt120 {
+			alts = <&scfg 0x12 0x0 0>;
+		};
+
+		smb1b_pu_sl: alt121 {
+			alts = <&scfg 0x12 0x1 0>;
+		};
+
+		smb2a_pu_sl: alt122 {
+			alts = <&scfg 0x12 0x2 0>;
+		};
+
+		smb2b_pu_sl: alt123 {
+			alts = <&scfg 0x12 0x3 0>;
+		};
+
+		smb3a_pu_sl: alt124 {
+			alts = <&scfg 0x12 0x4 0>;
+		};
+
+		smb3b_pu_sl: alt125 {
+			alts = <&scfg 0x12 0x5 0>;
+		};
+
+		smb4a_pu_sl: alt126 {
+			alts = <&scfg 0x12 0x6 0>;
+		};
+
+		smb4b_pu_sl: alt127 {
+			alts = <&scfg 0x12 0x7 0>;
+		};
+
+		/* SCFG DEVALT CX */
+		altcx_psl_in0_ahi: alt131 {
+			alts = <&scfg 0x13 0x1 0>;
+		};
+
+		altcx_psl_in1_ahi: alt132 {
+			alts = <&scfg 0x13 0x2 0>;
+		};
+
+		altcx_psl_in2_ahi: alt133 {
+			alts = <&scfg 0x13 0x3 0>;
+		};
+
+		altcx_psl_in3_ahi: alt134 {
+			alts = <&scfg 0x13 0x4 0>;
+		};
+
+		altcx_psl_in4_ahi: alt135 {
+			alts = <&scfg 0x13 0x5 0>;
+		};
+
+		altcx_psl_in5_ahi: alt136 {
+			alts = <&scfg 0x13 0x6 0>;
+		};
+
+		altcx_gpio_out_pullen: alt137 {
+			alts = <&scfg 0x13 0x7 0>;
+		};
+
+		/* SCFG DEVALT DX */
+		altdx_psl_out_gpo: alt140 {
+			alts = <&scfg 0x14 0x0 0>;
+		};
+
+		altdx_psl_fw_ctl_high: alt141 {
+			alts = <&scfg 0x14 0x1 0>;
+		};
+
+		altdx_psl_fw_ctl_low: alt141-inv {
+			alts = <&scfg 0x14 0x1 1>;
+		};
+
+		altdx_gpstby_rst_bit: alt147 {
+			alts = <&scfg 0x14 0x7 0>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npck/npck-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck-espi-vws-map.dtsi
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/espi/npcx_espi.h>
+
+/*
+ *                Nuvoton NPCK3 eSPI Virtual Wires Mapping Table
+ * |--------------------------------------------------------------------------|
+ * | VW idx | SLV reg | Wire Bit 3   | Wire Bit 2   | Wire Bit 1| Wire Bit 0  |
+ * |--------------------------------------------------------------------------|
+ * |                 Input (Master-to-Slave) Virtual Wires                    |
+ * |--------------------------------------------------------------------------|
+ * | 02h[S] | VWEVMS0 | Reserved     | SLP_S5#      | SLP_S4#   | SLP_S3#     |
+ * | 03h[S] | VWEVMS1 | Reserved     | OOB_RST_WARN | PLTRST#   | SUS_STAT#   |
+ * | 07h[S] | VWEVMS2 | Reserved     | Reserved     | Reserved  | HOS_RST_WARN|
+ * | 41h[P] | VWEVMS3 | SLP_A#       | Reserved     | SUS_PDNACK| SUS_WARN#   |
+ * | 42h[P] | VWEVMS4 | Reserved     | Reserved     | SLP_WLAN# | SLP_LAN#    |
+ * |--------------------------------------------------------------------------|
+ * |                Output (Slave-to-Master) Virtual Wires                    |
+ * |--------------------------------------------------------------------------|
+ * | 04h[S] | VWEVSM0 | PME#         | WAKE#        | Reserved  | OOB_RST_ACK |
+ * | 05h[S] | VWEVSM1 | SLV_BOOT_STS | ERR_NONFATAL | ERR_FATAL | SLV_BT_DONE |
+ * | 06h[S] | VWEVSM2 | HOST_RST_ACK | Reserved     | SMI#      | SCI#        |
+ * | 40h[P] | VWEVSM3 | Reserved     | Reserved     | Reserved  | SUS_ACK#    |
+ * |--------------------------------------------------------------------------|
+ *  [S] System-/[P] Platform-Specific Virtual Wires
+ */
+
+/ {
+	npcx-espi-vws-map {
+		compatible = "nuvoton,npcx-espi-vw-conf";
+
+		/* eSPI Virtual Vire (VW) input configuration */
+		/* index 02h (In) */
+		vw-slp-s3 {
+			vw-reg = <NPCX_VWEVMS0 0x01>;
+			vw-wui = <&wui_vw_slp_s3>;
+		};
+
+		vw-slp-s4 {
+			vw-reg = <NPCX_VWEVMS0 0x02>;
+			vw-wui = <&wui_vw_slp_s4>;
+		};
+
+		vw-slp-s5 {
+			vw-reg = <NPCX_VWEVMS0 0x04>;
+			vw-wui = <&wui_vw_slp_s5>;
+		};
+
+		/* index 03h (In) */
+		vw-sus-stat {
+			vw-reg = <NPCX_VWEVMS1 0x01>;
+			vw-wui = <&wui_vw_sus_stat>;
+		};
+
+		vw-plt-rst {
+			vw-reg = <NPCX_VWEVMS1 0x02>;
+			vw-wui = <&wui_vw_plt_rst>;
+		};
+
+		vw-oob-rst-warn {
+			vw-reg = <NPCX_VWEVMS1 0x04>;
+			vw-wui = <&wui_vw_oob_rst_warn>;
+		};
+
+		/* index 07h (In) */
+		vw-host-rst-warn {
+			vw-reg = <NPCX_VWEVMS2 0x01>;
+			vw-wui = <&wui_vw_host_rst_warn>;
+		};
+
+		/* index 41h (In) */
+		vw-sus-warn {
+			vw-reg = <NPCX_VWEVMS3 0x01>;
+			vw-wui = <&wui_vw_sus_warn>;
+		};
+
+		vw-sus-pwrdn-ack {
+			vw-reg = <NPCX_VWEVMS3 0x02>;
+			vw-wui = <&wui_vw_sus_pwrdn_ack>;
+		};
+
+		vw-slp-a {
+			vw-reg = <NPCX_VWEVMS3 0x08>;
+			vw-wui = <&wui_vw_slp_a>;
+		};
+
+		/* index 42h (In) */
+		vw-slp-lan {
+			vw-reg = <NPCX_VWEVMS4 0x01>;
+			vw-wui = <&wui_vw_slp_lan>;
+		};
+
+		vw-slp-wlan {
+			vw-reg = <NPCX_VWEVMS4 0x02>;
+			vw-wui = <&wui_vw_slp_wlan>;
+		};
+
+		/* eSPI Virtual Vire (VW) output configuration */
+		/* index 04h (Out) */
+		vw-oob-rst-ack {
+			vw-reg = <NPCX_VWEVSM0 0x01>;
+		};
+
+		vw-wake {
+			vw-reg = <NPCX_VWEVSM0 0x04>;
+		};
+
+		vw-pme {
+			vw-reg = <NPCX_VWEVSM0 0x08>;
+		};
+
+		/* index 05h (Out) */
+		vw-slv-boot-done {
+			vw-reg = <NPCX_VWEVSM1 0x01>;
+		};
+
+		vw-err-fatal {
+			vw-reg = <NPCX_VWEVSM1 0x02>;
+		};
+
+		vw-err-non-fatal {
+			vw-reg = <NPCX_VWEVSM1 0x04>;
+		};
+
+		vw-slv-boot-sts-with-done {
+			/*
+			 * SLAVE_BOOT_DONE & SLAVE_LOAD_STS bits (bit 0 & bit 3)
+			 * have to be sent together. Hence its bitmask is 0x09.
+			 */
+			vw-reg = <NPCX_VWEVSM1 0x09>;
+		};
+
+		/* index 06h (Out) */
+		vw-sci {
+			vw-reg = <NPCX_VWEVSM2 0x01>;
+		};
+
+		vw-smi {
+			vw-reg = <NPCX_VWEVSM2 0x02>;
+		};
+
+		vw-host-rst-ack {
+			vw-reg = <NPCX_VWEVSM2 0x08>;
+		};
+
+		/* index 40h (Out) */
+		vw-sus-ack {
+			vw-reg = <NPCX_VWEVSM3 0x01>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npck/npck-lvol-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck-lvol-ctrl-map.dtsi
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	def-lvol-conf-list {
+		compatible = "nuvoton,npcx-lvolctrl-conf";
+
+		/* Low-Voltage IO Control 0 */
+		lvol_io20: lvol00 {
+			lvols = <&scfg 0 0>;
+		};
+
+		lvol_io21: lvol01 {
+			lvols = <&scfg 0 1>;
+		};
+
+		lvol_io40: lvol02 {
+			lvols = <&scfg 0 2>;
+		};
+
+		lvol_io54: lvol03 {
+			lvols = <&scfg 0 3>;
+		};
+
+		lvol_io85: lvol05 {
+			lvols = <&scfg 0 5>;
+		};
+
+		lvol_io86: lvol06 {
+			lvols = <&scfg 0 6>;
+		};
+
+		lvol_io94: lvol07 {
+			lvols = <&scfg 0 7>;
+		};
+
+		/* Low-Voltage IO Control 1 */
+		lvol_iod5: lvol10 {
+			lvols = <&scfg 1 0>;
+		};
+
+		lvol_iod6: lvol11 {
+			lvols = <&scfg 1 1>;
+		};
+
+		lvol_io46: lvol12 {
+			lvols = <&scfg 1 2>;
+		};
+
+		lvol_io44: lvol13 {
+			lvols = <&scfg 1 3>;
+		};
+
+		lvol_io50: lvol14 {
+			lvols = <&scfg 1 4>;
+		};
+
+		lvol_io52: lvol15 {
+			lvols = <&scfg 1 5>;
+		};
+
+		lvol_ioe1: lvol16 {
+			lvols = <&scfg 1 6>;
+		};
+
+		lvol_ioe2: lvol17 {
+			lvols = <&scfg 1 7>;
+		};
+
+		/* Low-Voltage IO Control 2 */
+		lvol_io01: lvol20 {
+			lvols = <&scfg 2 0>;
+		};
+
+		lvol_io03: lvol21 {
+			lvols = <&scfg 2 1>;
+		};
+
+		lvol_io13: lvol22 {
+			lvols = <&scfg 2 2>;
+		};
+
+		lvol_io15: lvol23 {
+			lvols = <&scfg 2 3>;
+		};
+
+		lvol_io45: lvol24 {
+			lvols = <&scfg 2 4>;
+		};
+
+		lvol_io51: lvol25 {
+			lvols = <&scfg 2 5>;
+		};
+
+		lvol_ioe3: lvol26 {
+			lvols = <&scfg 2 6>;
+		};
+
+		lvol_ioe4: lvol27 {
+			lvols = <&scfg 2 7>;
+		};
+
+		/* Low-Voltage IO Control 3 */
+		lvol_io22: lvol30 {
+			lvols = <&scfg 3 0>;
+		};
+
+		lvol_io17: lvol31 {
+			lvols = <&scfg 3 1>;
+		};
+
+		lvol_io74: lvol32 {
+			lvols = <&scfg 3 2>;
+		};
+
+		lvol_io73: lvol33 {
+			lvols = <&scfg 3 3>;
+		};
+
+		lvol_io31: lvol34 {
+			lvols = <&scfg 3 4>;
+		};
+
+		lvol_io23: lvol35 {
+			lvols = <&scfg 3 5>;
+		};
+
+		lvol_io53: lvol36 {
+			lvols = <&scfg 3 6>;
+		};
+
+		lvol_io47: lvol37 {
+			lvols = <&scfg 3 7>;
+		};
+
+		/* Low-Voltage IO Control 4 */
+		lvol_io25: lvol40 {
+			lvols = <&scfg 4 0>;
+		};
+
+		lvol_ioe6: lvol41 {
+			lvols = <&scfg 4 1>;
+		};
+
+		lvol_ioc0: lvol42 {
+			lvols = <&scfg 4 2>;
+		};
+
+		lvol_iob7: lvol43 {
+			lvols = <&scfg 4 3>;
+		};
+
+		/*
+		 * Pseudo Low-Voltage IO Control (i.e. IO pad doesn't support
+		 * low voltage detection.)
+		 */
+		lvol_none: lvol-pseudo {
+			lvols = <&scfg 31 0>;
+		};
+	};
+};

--- a/dts/arm/nuvoton/npck/npck-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck-miwus-int-map.dtsi
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* Mapping between MIWU group and interrupts */
+	npcx-miwus-int-map {
+		map_miwu0_groups: map-miwu0-groups {
+			compatible = "nuvoton,npcx-miwu-int-map";
+			parent = <&miwu0>;
+
+			group_a0: group-a0-map {
+				irq = <40>;
+				irq-prio = <2>;
+				group-mask = <0x01>;
+			};
+
+			group_b0: group-b0-map {
+				irq = <41>;
+				irq-prio = <2>;
+				group-mask = <0x02>;
+			};
+
+			group_c0: group-c0-map {
+				irq = <42>;
+				irq-prio = <2>;
+				group-mask = <0x04>;
+			};
+
+			group_d0: group-d0-map {
+				irq = <43>;
+				irq-prio = <2>;
+				group-mask = <0x08>;
+			};
+
+			group_e0: group-e0-map {
+				irq = <44>;
+				irq-prio = <2>;
+				group-mask = <0x10>;
+			};
+
+			group_f0: group-f0-map {
+				irq = <45>;
+				irq-prio = <2>;
+				group-mask = <0x20>;
+			};
+
+			group_g0: group-g0-map {
+				irq = <46>;
+				irq-prio = <2>;
+				group-mask = <0x40>;
+			};
+
+			group_h0: group-h0-map {
+				irq = <47>;
+				irq-prio = <2>;
+				group-mask = <0x80>;
+			};
+		};
+
+		map_miwu1_groups: map-miwu1-groups {
+			compatible = "nuvoton,npcx-miwu-int-map";
+			parent = <&miwu1>;
+
+			group_a1: group-a1-map {
+				irq = <48>;
+				irq-prio = <2>;
+				group-mask = <0x01>;
+			};
+
+			group_b1: group-b1-map {
+				irq = <49>;
+				irq-prio = <2>;
+				group-mask = <0x02>;
+			};
+
+			group_c1: group-c1-map {
+				irq = <50>;
+				irq-prio = <2>;
+				group-mask = <0x04>;
+			};
+
+			group_d1: group-d1-map {
+				irq = <51>;
+				irq-prio = <2>;
+				group-mask = <0x08>;
+			};
+
+			group_e1: group-e1-map {
+				irq = <12>;
+				irq-prio = <2>;
+				group-mask = <0x10>;
+			};
+
+			group_f1: group-f1-map {
+				irq = <53>;
+				irq-prio = <2>;
+				group-mask = <0x20>;
+			};
+
+			group_g1: group-g1-map {
+				irq = <54>;
+				irq-prio = <2>;
+				group-mask = <0x40>;
+			};
+
+			group_h1: group-h1-map {
+				irq = <55>;
+				irq-prio = <2>;
+				group-mask = <0x80>;
+			};
+		};
+
+		map_miwu2_groups: map-miwu2-groups {
+			compatible = "nuvoton,npcx-miwu-int-map";
+			parent = <&miwu2>;
+
+			group_a2: group-a2-map {
+				irq = <60>;
+				irq-prio = <2>;
+				group-mask = <0x01>;
+			};
+
+			group_b2: group-b2-map {
+				irq = <61>;
+				irq-prio = <2>;
+				group-mask = <0x02>;
+			};
+
+			group_c2: group-c2-map {
+				irq = <62>;
+				irq-prio = <2>;
+				group-mask = <0x04>;
+			};
+
+			group_d2: group-d2-map {
+				irq = <63>;
+				irq-prio = <2>;
+				group-mask = <0x08>;
+			};
+
+			group_e2: group-e2-map {
+				irq = <56>;
+				irq-prio = <2>;
+				group-mask = <0x10>;
+			};
+
+			group_f2: group-f2-map {
+				irq = <57>;
+				irq-prio = <2>;
+				group-mask = <0x20>;
+			};
+
+			group_g2: group-g2-map {
+				irq = <58>;
+				irq-prio = <2>;
+				group-mask = <0x40>;
+			};
+
+			group_h2: group-h2-map {
+				irq = <59>;
+				irq-prio = <2>;
+				group-mask = <0x80>;
+			};
+		};
+	};
+};

--- a/dts/arm/nuvoton/npck/npck-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck-miwus-wui-map.dtsi
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* Mapping between MIWU wui bits and source device */
+	npcx-miwus-wui-map {
+		compatible = "nuvoton,npcx-miwu-wui-map";
+
+		/* MIWU table 0 */
+		/* MIWU group A */
+		wui_io01: wui0-1-1 {
+			miwus = <&miwu0 0 1>; /* GPIO01 */
+		};
+
+		wui_io02: wui0-1-2 {
+			miwus = <&miwu0 0 2>; /* GPIO02 */
+		};
+
+		wui_io03: wui0-1-3 {
+			miwus = <&miwu0 0 3>; /* GPIO03 */
+		};
+
+		wui_io04: wui0-1-4 {
+			miwus = <&miwu0 0 4>; /* GPIO04 */
+		};
+
+		wui_io05: wui0-1-5 {
+			miwus = <&miwu0 0 5>; /* GPIO05 */
+		};
+
+		wui_io07: wui0-1-7 {
+			miwus = <&miwu0 0 7>; /* GPIO07 */
+		};
+
+		/* MIWU group B */
+		wui_io10: wui0-2-0 {
+			miwus = <&miwu0 1 0>; /* GPIO10 */
+		};
+
+		wui_io11: wui0-2-1 {
+			miwus = <&miwu0 1 1>; /* GPIO11 */
+		};
+
+		wui_io13: wui0-2-3 {
+			miwus = <&miwu0 1 3>; /* GPIO13 */
+		};
+
+		wui_io14: wui0-2-4 {
+			miwus = <&miwu0 1 4>; /* GPIO14 */
+		};
+
+		wui_io15: wui0-2-5 {
+			miwus = <&miwu0 1 5>; /* GPIO15 */
+		};
+
+		wui_io17: wui0-2-7 {
+			miwus = <&miwu0 1 7>; /* GPIO17 */
+		};
+
+		/* MIWU group C */
+		wui_io20: wui0-3-0 {
+			miwus = <&miwu0 2 0>; /* GPIO20 */
+		};
+
+		wui_io21: wui0-3-1 {
+			miwus = <&miwu0 2 1>; /* GPIO21 */
+		};
+
+		wui_io22: wui0-3-2 {
+			miwus = <&miwu0 2 2>; /* GPIO22 */
+		};
+
+		wui_io23: wui0-3-3 {
+			miwus = <&miwu0 2 3>; /* GPIO23 */
+		};
+
+		wui_io25: wui0-3-5 {
+			miwus = <&miwu0 2 5>; /* GPIO25 */
+		};
+
+		wui_io26: wui0-3-6 {
+			miwus = <&miwu0 2 6>; /* GPIO26 */
+		};
+
+		wui_io27: wui0-3-7 {
+			miwus = <&miwu0 2 7>; /* GPIO27 */
+		};
+
+		/* MIWU group D */
+		wui_io30: wui0-4-0 {
+			miwus = <&miwu0 3 0>; /* GPIO30 */
+		};
+
+		wui_io31: wui0-4-1 {
+			miwus = <&miwu0 3 1>; /* GPIO31 */
+		};
+
+		wui_io32: wui0-4-2 {
+			miwus = <&miwu0 3 2>; /* GPIO32 */
+		};
+
+		wui_io33: wui0-4-3 {
+			miwus = <&miwu0 3 3>; /* GPIO33 */
+		};
+
+		wui_io34: wui0-4-4 {
+			miwus = <&miwu0 3 4>; /* GPIO34 */
+		};
+
+		wui_io36: wui0-4-6 {
+			miwus = <&miwu0 3 6>; /* GPIO36 */
+		};
+
+		/* MIWU group E */
+		wui_io40: wui0-5-0 {
+			miwus = <&miwu0 4 0>; /* GPIO40 */
+		};
+
+		wui_io44: wui0-5-4 {
+			miwus = <&miwu0 4 4>; /* GPIO44 */
+		};
+
+		wui_io45: wui0-5-5 {
+			miwus = <&miwu0 4 5>; /* GPIO45 */
+		};
+
+		wui_io46: wui0-5-6 {
+			miwus = <&miwu0 4 6>; /* GPIO46 */
+		};
+
+		wui_io47: wui0-5-7 {
+			miwus = <&miwu0 4 7>; /* GPIO47 */
+		};
+
+		/* MIWU group F */
+		wui_io50: wui0-6-0 {
+			miwus = <&miwu0 5 0>; /* GPIO50 */
+		};
+
+		wui_io51: wui0-6-1 {
+			miwus = <&miwu0 5 1>; /* GPIO51 */
+		};
+
+		wui_io52: wui0-6-2 {
+			miwus = <&miwu0 5 2>; /* GPIO52 */
+		};
+
+		wui_io53: wui0-6-3 {
+			miwus = <&miwu0 5 3>; /* GPIO53 */
+		};
+
+		wui_io54: wui0-6-4 {
+			miwus = <&miwu0 5 4>; /* GPIO54 */
+		};
+
+		wui_io55: wui0-6-5 {
+			miwus = <&miwu0 5 5>; /* GPIO55 */
+		};
+
+		wui_io56: wui0-6-6 {
+			miwus = <&miwu0 5 6>; /* GPIO56 */
+		};
+
+		wui_io57: wui0-6-7 {
+			miwus = <&miwu0 5 7>; /* GPIO57 */
+		};
+
+		/* MIWU group G */
+		wui_io60: wui0-7-0 {
+			miwus = <&miwu0 6 0>; /* GPIO60 */
+		};
+
+		wui_io61: wui0-7-1 {
+			miwus = <&miwu0 6 1>; /* GPIO61 */
+		};
+
+		wui_io62: wui0-7-2 {
+			miwus = <&miwu0 6 2>; /* GPIO62 */
+		};
+
+		wui_io63: wui0-7-3 {
+			miwus = <&miwu0 6 3>; /* GPIO63 */
+		};
+
+		wui_io64: wui0-7-4 {
+			miwus = <&miwu0 6 4>; /* GPIO64 */
+		};
+
+		wui_io65: wui0-7-5 {
+			miwus = <&miwu0 6 5>; /* GPIO65 */
+		};
+
+		wui_io66: wui0-7-6 {
+			miwus = <&miwu0 6 6>; /* GPIO66 */
+		};
+
+		wui_io67: wui0-7-7 {
+			miwus = <&miwu0 6 7>; /* GPIO67 */
+		};
+
+		/* MIWU group H */
+		wui_io70: wui0-8-0 {
+			miwus = <&miwu0 7 0>; /* GPIO70 */
+		};
+
+		wui_io72: wui0-8-2 {
+			miwus = <&miwu0 7 2>; /* GPIO72 */
+		};
+
+		wui_io73: wui0-8-3 {
+			miwus = <&miwu0 7 3>; /* GPIO73 */
+		};
+
+		wui_io74: wui0-8-4 {
+			miwus = <&miwu0 7 4>; /* GPIO74 */
+		};
+
+		wui_io75: wui0-8-5 {
+			miwus = <&miwu0 7 5>; /* GPIO75 */
+		};
+
+		wui_io76: wui0-8-6 {
+			miwus = <&miwu0 7 6>; /* GPIO76 */
+		};
+
+		wui_io77: wui0-8-7 {
+			miwus = <&miwu0 7 7>; /* GPIO77 */
+		};
+
+		/* MIWU table 1 */
+		/* MIWU group A */
+		wui_io81: wui1-1-1 {
+			miwus = <&miwu1 0 1>; /* GPIO81 */
+		};
+
+		wui_io83: wui1-1-3 {
+			miwus = <&miwu1 0 3>; /* GPIO83 */
+		};
+
+		wui_io85: wui1-1-5 {
+			miwus = <&miwu1 0 5>; /* GPIO85 */
+		};
+
+		wui_io86: wui1-1-6 {
+			miwus = <&miwu1 0 6>; /* GPIO86 */
+		};
+
+		wui_io87: wui1-1-7 {
+			miwus = <&miwu1 0 7>; /* GPIO87 */
+		};
+
+		wui_cr_sin1: wui1-1-7-1 {
+			miwus = <&miwu1 0 7>; /* CR_SIN */
+		};
+
+		/* MIWU group B */
+		wui_io90: wui1-2-0 {
+			miwus = <&miwu1 1 0>; /* GPIO90 */
+		};
+
+		wui_io91: wui1-2-1 {
+			miwus = <&miwu1 1 1>; /* GPIO91 */
+		};
+
+		wui_io92: wui1-2-2 {
+			miwus = <&miwu1 1 2>; /* GPIO92 */
+		};
+
+		wui_io93: wui1-2-3 {
+			miwus = <&miwu1 1 3>; /* GPIO93 */
+		};
+
+		wui_io94: wui1-2-4 {
+			miwus = <&miwu1 1 4>; /* GPIO94 */
+		};
+
+		/* MIWU group C */
+		wui_ioa0: wui1-3-0 {
+			miwus = <&miwu1 2 0>; /* GPIOA0 */
+		};
+
+		wui_ioa1: wui1-3-1 {
+			miwus = <&miwu1 2 1>; /* GPIOA1 */
+		};
+
+		wui_ioa2: wui1-3-2 {
+			miwus = <&miwu1 2 2>; /* GPIOA2 */
+		};
+
+		wui_ioa3: wui1-3-3 {
+			miwus = <&miwu1 2 3>; /* GPIOA3 */
+		};
+
+		wui_ioa4: wui1-3-4 {
+			miwus = <&miwu1 2 4>; /* GPIOA4 */
+		};
+
+		wui_ioa5: wui1-3-5 {
+			miwus = <&miwu1 2 5>; /* GPIOA5 */
+		};
+
+		wui_ioa6: wui1-3-6 {
+			miwus = <&miwu1 2 6>; /* GPIOA6 */
+		};
+
+		wui_ioa7: wui1-3-7 {
+			miwus = <&miwu1 2 7>; /* GPIOA7 */
+		};
+
+		/* MIWU group D */
+		wui_iob0: wui1-4-0 {
+			miwus = <&miwu1 3 0>; /* GPIOB0 */
+		};
+
+		wui_shi_cs: wui1-4-3 {
+			miwus = <&miwu1 3 3>; /* SHI_CS */
+		};
+
+		wui_cdbgpwrupreq: wui1-4-4 {
+			miwus = <&miwu1 3 4>; /* CDBGPWRUPREQ */
+		};
+
+		wui_lpc_ev_wkup: wui1-4-5 {
+			miwus = <&miwu1 3 5>; /* LPC_EV_WKUP */
+		};
+
+		wui_host_acc: wui1-4-6 {
+			miwus = <&miwu1 3 6>; /* HOST_ACC */
+		};
+
+		wui_espi_rst: wui1-4-7 {
+			miwus = <&miwu1 3 7>; /* ESPI_RST */
+		};
+
+		/* MIWU group E */
+		wui_mswc: wui1-5-2 {
+			miwus = <&miwu1 4 2>; /* MSWC */
+		};
+
+		wui_t0out: wui1-5-3 {
+			miwus = <&miwu1 4 3>; /* T0OUT */
+		};
+
+		/* MIWU group F */
+		wui_iod0: wui1-6-0 {
+			miwus = <&miwu1 5 0>; /* GPIOD0 */
+		};
+
+		wui_iod3: wui1-6-3 {
+			miwus = <&miwu1 5 3>; /* GPIOD3 */
+		};
+
+		wui_iod4: wui1-6-4 {
+			miwus = <&miwu1 5 4>; /* GPIOD4 */
+		};
+
+		wui_iod5: wui1-6-5 {
+			miwus = <&miwu1 5 5>; /* GPIOD5 */
+		};
+
+		wui_iod6: wui1-6-6 {
+			miwus = <&miwu1 5 6>; /* GPIOD6 */
+		};
+
+		wui_iod7: wui1-6-7 {
+			miwus = <&miwu1 5 7>; /* GPIOD7 */
+		};
+
+		/* MIWU group G */
+		wui_ioe0: wui1-7-0 {
+			miwus = <&miwu1 6 0>; /* GPIOE0 */
+		};
+
+		wui_ioe1: wui1-7-1 {
+			miwus = <&miwu1 6 1>; /* GPIOE1 */
+		};
+
+		wui_ioe2: wui1-7-2 {
+			miwus = <&miwu1 6 2>; /* GPIOE2 */
+		};
+
+		wui_ioe3: wui1-7-3 {
+			miwus = <&miwu1 6 3>; /* GPIOE3 */
+		};
+
+		wui_ioe4: wui1-7-4 {
+			miwus = <&miwu1 6 4>; /* GPIOE4 */
+		};
+
+		wui_ioe5: wui1-7-5 {
+			miwus = <&miwu1 6 5>; /* GPIOE5 */
+		};
+
+		wui_ioe6: wui1-7-6 {
+			miwus = <&miwu1 6 6>; /* GPIOE6 */
+		};
+
+		/* MIWU group H */
+		wui_mtc: wui1-8-0 {
+			miwus = <&miwu1 7 0>; /* MTC */
+		};
+
+		wui_smb1: wui1-8-1 {
+			miwus = <&miwu1 7 1>; /* SMB1 */
+		};
+
+		wui_smb2: wui1-8-2 {
+			miwus = <&miwu1 7 2>; /* SMB2 */
+		};
+
+		wui_smb3: wui1-8-3 {
+			miwus = <&miwu1 7 3>; /* SMB3 */
+		};
+
+		wui_smb4: wui1-8-4 {
+			miwus = <&miwu1 7 4>; /* SMB4 */
+		};
+
+		wui_smb5: wui1-8-5 {
+			miwus = <&miwu1 7 5>; /* SMB5 */
+		};
+
+		wui_smb6: wui1-8-6 {
+			miwus = <&miwu1 7 6>; /* SMB6 */
+		};
+
+		/* MIWU table 2 */
+		/* MIWU group A */
+		wui_vw_slp_s3: wui2-1-0 {
+			miwus = <&miwu2 0 0>; /* SLP_S3_L */
+		};
+
+		wui_vw_slp_s4: wui2-1-1 {
+			miwus = <&miwu2 0 1>; /* SLP_S4_L */
+		};
+
+		wui_vw_slp_s5: wui2-1-2 {
+			miwus = <&miwu2 0 2>; /* SLP_S5_L */
+		};
+
+		wui_vw_sus_stat: wui2-1-4 {
+			miwus = <&miwu2 0 4>; /* SUS_STAT_L */
+		};
+
+		wui_vw_plt_rst: wui2-1-5 {
+			miwus = <&miwu2 0 5>; /* PLTRST_L */
+		};
+
+		wui_vw_oob_rst_warn: wui2-1-6 {
+			miwus = <&miwu2 0 6>; /* OOB_RST_WARN */
+		};
+
+		/* MIWU group B */
+		wui_vw_host_rst_warn: wui2-2-0 {
+			miwus = <&miwu2 1 0>; /* HOST_RST_WARN */
+		};
+
+		wui_vw_sus_warn: wui2-2-4 {
+			miwus = <&miwu2 1 4>; /* SUS_WARN_L */
+		};
+
+		wui_vw_sus_pwrdn_ack: wui2-2-5 {
+			miwus = <&miwu2 1 5>; /* SUS_PWRDN_ACK */
+		};
+
+		wui_vw_slp_a: wui2-2-7 {
+			miwus = <&miwu2 1 7>; /* SLP_A_L */
+		};
+
+		/* MIWU group C */
+		wui_vw_slp_lan: wui2-3-0 {
+			miwus = <&miwu2 2 0>; /* SLP_LAN_L */
+		};
+
+		wui_vw_slp_wlan: wui2-3-1 {
+			miwus = <&miwu2 2 1>; /* SLP_WLAN_L */
+		};
+
+		wui_vw_pch_to_ec_gen_0: wui2-3-4 {
+			miwus = <&miwu2 2 4>; /* PCH_TO_EC_GENERIC_0 */
+		};
+
+		wui_vw_pch_to_ec_gen_1: wui2-3-5 {
+			miwus = <&miwu2 2 5>; /* PCH_TO_EC_GENERIC_1 */
+		};
+
+		wui_vw_pch_to_ec_gen_2: wui2-3-6 {
+			miwus = <&miwu2 2 6>; /* PCH_TO_EC_GENERIC_2 */
+		};
+
+		wui_vw_pch_to_ec_gen_3: wui2-3-7 {
+			miwus = <&miwu2 2 7>; /* PCH_TO_EC_GENERIC_3 */
+		};
+
+		/* MIWU group D */
+		wui_vw_pch_to_ec_gen_4: wui2-4-0 {
+			miwus = <&miwu2 3 0>; /* PCH_TO_EC_GENERIC_4 */
+		};
+
+		wui_vw_pch_to_ec_gen_5: wui2-4-1 {
+			miwus = <&miwu2 3 1>; /* PCH_TO_EC_GENERIC_5 */
+		};
+
+		wui_vw_pch_to_ec_gen_6: wui2-4-2 {
+			miwus = <&miwu2 3 2>; /* PCH_TO_EC_GENERIC_6 */
+		};
+
+		wui_vw_pch_to_ec_gen_7: wui2-4-3 {
+			miwus = <&miwu2 3 3>; /* PCH_TO_EC_GENERIC_7 */
+		};
+
+		wui_vw_host_c10: wui2-4-4 {
+			miwus = <&miwu2 3 4>; /* HOST_C10 */
+		};
+
+		/* MIWU group E */
+		wui_iog5: wui2-5-5 {
+			miwus = <&miwu2 4 5>; /* GPIOG5 */
+		};
+
+		wui_iog6: wui2-5-6 {
+			miwus = <&miwu2 4 6>; /* GPIOG6 */
+		};
+
+		wui_iog7: wui2-5-7 {
+			miwus = <&miwu2 4 7>; /* GPIOG7 */
+		};
+
+		/* MIWU group F */
+		wui_ioh0: wui2-6-0 {
+			miwus = <&miwu2 5 0>; /* GPIOH0 */
+		};
+
+		wui_ioh1: wui2-6-1 {
+			miwus = <&miwu2 5 1>; /* GPIOH1 */
+		};
+
+		wui_ioh2: wui2-6-2 {
+			miwus = <&miwu2 5 2>; /* GPIOH2 */
+		};
+
+		wui_ioh4: wui2-6-4 {
+			miwus = <&miwu2 5 4>; /* GPIOH4 */
+		};
+
+		/* MIWU group G */
+		wui_io_stb00: wui2-7-0 {
+			miwus = <&miwu2 6 0>; /* GPIO_STB00 */
+		};
+
+		wui_io_stb01: wui2-7-1 {
+			miwus = <&miwu2 6 1>; /* GPIO_STB01 */
+		};
+
+		wui_io_stb02: wui2-7-2 {
+			miwus = <&miwu2 6 2>; /* GPIO_STB02 */
+		};
+
+		wui_io_stb03: wui2-7-3 {
+			miwus = <&miwu2 6 3>; /* GPIO_STB03 */
+		};
+
+		wui_io_stb04: wui2-7-4 {
+			miwus = <&miwu2 6 4>; /* GPIO_STB04 */
+		};
+
+		/* MIWU group H */
+		wui_io_stb11_psl_in0: wui2-8-1 {
+			miwus = <&miwu2 7 1>; /* GPIO_STB11/PSL_IN0 */
+		};
+
+		wui_io_stb12_psl_in1: wui2-8-2 {
+			miwus = <&miwu2 7 2>; /* GPIO_STB12/PSL_IN1 */
+		};
+
+		wui_io_stb13_psl_in2: wui2-8-3 {
+			miwus = <&miwu2 7 3>; /* GPIO_STB13/PSL_IN2 */
+		};
+
+		wui_io_stb14_psl_in3: wui2-8-4 {
+			miwus = <&miwu2 7 4>; /* GPIO_STB14/PSL_IN3 */
+		};
+
+		wui_io_stb15_psl_in4: wui2-8-5 {
+			miwus = <&miwu2 7 5>; /* GPIO_STB15/PSL_IN4 */
+		};
+
+		wui_io_stb16_psl_in5: wui2-8-6 {
+			miwus = <&miwu2 7 6>; /* GPIO_STB16/PSL_IN5 */
+		};
+
+		/* Pseudo wui item means no mapping between source and wui */
+		wui_none: wui-pseudo {
+			miwus = <&miwu_none 7 7>;
+		};
+	};
+
+	/* Pseudo MIWU device to present no mapping relationship */
+	miwu_none: miwu-pseudo {
+		compatible = "nuvoton,npcx-miwu";
+		index = <3>;
+		#miwu-cells = <2>;
+		status = "disabled";
+	};
+};

--- a/dts/arm/nuvoton/npck/npck.dtsi
+++ b/dts/arm/nuvoton/npck/npck.dtsi
@@ -1,0 +1,693 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <arm/armv7-m.dtsi>
+
+/* Macros for device tree declarations of npcx soc family */
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/npcx_clock.h>
+#include <zephyr/dt-bindings/flash_controller/npcx_fiu_qspi.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/npcx-i2c.h>
+#include <zephyr/dt-bindings/pinctrl/npcx-pinctrl.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/sensor/npcx_tach.h>
+#include <freq.h>
+
+/ {
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m4f";
+			reg = <0>;
+		};
+
+		power-states {
+			suspend_to_idle0: suspend-to-idle0 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <0>;
+				min-residency-us = <1000>;
+			};
+
+			suspend_to_idle1: suspend-to-idle1 {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				substate-id = <1>;
+				min-residency-us = <201000>;
+			};
+		};
+	};
+
+	def-io-conf-list {
+		compatible = "nuvoton,npcx-pinctrl-def";
+		/* Change default functional pads to GPIOs here. */
+		pinmux = <>;
+	};
+
+	/** Dummy pinctrl node. It will be initialized with defaults based on the SoC series.
+	 *  Then, the user can override the pin control options at the board level.
+	 */
+	pinctrl: pinctrl {
+		compatible = "nuvoton,npcx-pinctrl";
+		status = "okay";
+	};
+
+	/* Dummy node of IOs that have leakage current. The user can override
+	 * 'leak-gpios' prop. at board DT file to save more power consumption.
+	 */
+	power_leakage_io: power-leakage-io {
+		compatible = "nuvoton,npcx-leakage-io";
+		status = "okay";
+	};
+
+	soc {
+		bbram: bb-ram@400af000 {
+			compatible = "nuvoton,npcx-bbram";
+			reg = <0x400af000 0x100
+			       0x400af100 0x1>;
+			reg-names = "memory", "status";
+		};
+
+		pcc: clock-controller@4000d000 {
+			compatible = "nuvoton,npcx-pcc";
+			/* Cells for bus type, clock control reg and bit */
+			#clock-cells = <3>;
+			/* First reg region is Power Management Controller */
+			/* Second reg region is Core Domain Clock Generator */
+			reg = <0x4000d000 0x2000
+			       0x400b5000 0x2000>;
+			reg-names = "pmc", "cdcg";
+		};
+
+		scfg: scfg@400c3000 {
+			compatible = "nuvoton,npcx-scfg";
+			/* First reg region is System Configuration Device */
+			/* Second reg region is Debugger Interface Device */
+			/* Third reg region is System Glue Device */
+			reg = <0x400c3000 0x70
+			       0x400c3070 0x30
+			       0x400a5000 0x2000>;
+			reg-names = "scfg", "dbg", "glue";
+			#alt-cells = <3>;
+			#lvol-cells = <2>;
+		};
+
+		mdc: mdc@4000c000 {
+			compatible = "syscon";
+			reg = <0x4000c000 0xa>;
+			reg-io-width = <1>;
+		};
+
+		mdc_header: mdc@4000c00a {
+			compatible = "syscon";
+			reg = <0x4000c00a 0x4>;
+			reg-io-width = <2>;
+		};
+
+		miwu0: miwu@400bb000 {
+			compatible = "nuvoton,npcx-miwu";
+			reg = <0x400bb000 0x2000>;
+			index = <0>;
+			#miwu-cells = <2>;
+		};
+
+		miwu1: miwu@400bd000 {
+			compatible = "nuvoton,npcx-miwu";
+			reg = <0x400bd000 0x2000>;
+			index = <1>;
+			#miwu-cells = <2>;
+		};
+
+		miwu2: miwu@400bf000 {
+			compatible = "nuvoton,npcx-miwu";
+			reg = <0x400bf000 0x2000>;
+			index = <2>;
+			#miwu-cells = <2>;
+		};
+
+		gpio0: gpio@40081000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40081000 0x2000>;
+			gpio-controller;
+			index = <0x0>;
+			#gpio-cells = <2>;
+		};
+
+		gpio1: gpio@40083000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40083000 0x2000>;
+			gpio-controller;
+			index = <0x1>;
+			#gpio-cells = <2>;
+		};
+
+		gpio2: gpio@40085000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40085000 0x2000>;
+			gpio-controller;
+			index = <0x2>;
+			#gpio-cells = <2>;
+		};
+
+		gpio3: gpio@40087000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40087000 0x2000>;
+			gpio-controller;
+			index = <0x3>;
+			#gpio-cells = <2>;
+		};
+
+		gpio4: gpio@40089000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40089000 0x2000>;
+			gpio-controller;
+			index = <0x4>;
+			#gpio-cells = <2>;
+		};
+
+		gpio5: gpio@4008b000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x4008b000 0x2000>;
+			gpio-controller;
+			index = <0x5>;
+			#gpio-cells = <2>;
+		};
+
+		gpio6: gpio@4008d000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x4008d000 0x2000>;
+			gpio-controller;
+			index = <0x6>;
+			#gpio-cells = <2>;
+		};
+
+		gpio7: gpio@4008f000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x4008f000 0x2000>;
+			gpio-controller;
+			index = <0x7>;
+			#gpio-cells = <2>;
+		};
+
+		gpio8: gpio@40091000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40091000 0x2000>;
+			gpio-controller;
+			index = <0x8>;
+			#gpio-cells = <2>;
+		};
+
+		gpio9: gpio@40093000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40093000 0x2000>;
+			gpio-controller;
+			index = <0x9>;
+			#gpio-cells = <2>;
+		};
+
+		gpioa: gpio@40095000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40095000 0x2000>;
+			gpio-controller;
+			index = <0xA>;
+			#gpio-cells = <2>;
+		};
+
+		gpiob: gpio@40097000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40097000 0x2000>;
+			gpio-controller;
+			index = <0xB>;
+			#gpio-cells = <2>;
+		};
+
+		gpioc: gpio@40099000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x40099000 0x2000>;
+			gpio-controller;
+			index = <0xC>;
+			#gpio-cells = <2>;
+		};
+
+		gpiod: gpio@4009b000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x4009b000 0x2000>;
+			gpio-controller;
+			index = <0xD>;
+			#gpio-cells = <2>;
+		};
+
+		gpioe: gpio@4009d000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x4009d000 0x2000>;
+			gpio-controller;
+			index = <0xE>;
+			#gpio-cells = <2>;
+		};
+
+		gpiof: gpio@4009f000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x4009f000 0x2000>;
+			gpio-controller;
+			index = <0xF>;
+			#gpio-cells = <2>;
+		};
+
+		gpiog: gpio@400a7000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x400a7000 0x2000>;
+			gpio-controller;
+			index = <0x10>;
+			#gpio-cells = <2>;
+		};
+
+		gpioh: gpio@400a9000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x400a9000 0x2000>;
+			gpio-controller;
+			index = <0x11>;
+			#gpio-cells = <2>;
+		};
+
+		gpiostb0: gpio@400ab000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x400ab000 0x2000>;
+			gpio-controller;
+			index = <0x12>;
+			#gpio-cells = <2>;
+		};
+
+		gpiostb1: gpio@400ad000 {
+			compatible = "nuvoton,npcx-gpio";
+			reg = <0x400ad000 0x2000>;
+			gpio-controller;
+			index = <0x13>;
+			#gpio-cells = <2>;
+		};
+
+		pwma: pwm@40080000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40080000 0x2000>;
+			pwm-channel = <0>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwmb: pwm@40082000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40082000 0x2000>;
+			pwm-channel = <1>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 1>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwmc: pwm@40084000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40084000 0x2000>;
+			pwm-channel = <2>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 2>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwmd: pwm@40086000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40086000 0x2000>;
+			pwm-channel = <3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 3>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwmf: pwm@4008a000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x4008a000 0x2000>;
+			pwm-channel = <5>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 5>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwmi: pwm@40090000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40090000 0x2000>;
+			pwm-channel = <9>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL0 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwmj: pwm@40092000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40092000 0x2000>;
+			pwm-channel = <10>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL0 1>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwmk: pwm@40094000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40094000 0x2000>;
+			pwm-channel = <11>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL0 2>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		adc0: adc@400d1000 {
+			compatible = "nuvoton,npcx-adc";
+			#io-channel-cells = <1>;
+			reg = <0x400d1000 0x2000>;
+			interrupts = <21 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL4 4>;
+			vref-mv = <3300>;
+			status = "disabled";
+		};
+
+		twd0: watchdog@400d8000 {
+			compatible = "nuvoton,npcx-watchdog";
+			reg = <0x400d8000 0x2000>;
+			t0-out = <&wui_t0out>;
+		};
+
+		espi0: espi@4000a000 {
+			compatible = "nuvoton,npcx-espi";
+			reg = <0x4000a000 0x2000>;
+			interrupts = <11 3>; /* Interrupt for eSPI Bus */
+
+			/* clocks for eSPI modules */
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL6 7>;
+			/* WUI maps for eSPI signals */
+			espi-rst-wui = <&wui_espi_rst>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			#vw-cells = <3>;
+			status = "disabled";
+		};
+
+		host_sub: lpc@400c1000 {
+			compatible = "nuvoton,npcx-host-sub";
+			/* host sub-module register address & size */
+			reg = <0x400c1000 0x2000
+			       0x40010000 0x2000
+			       0x4000e000 0x2000
+			       0x400c7000 0x2000
+			       0x400c9000 0x2000
+			       0x400cb000 0x2000
+			       0x400a1000 0x2000>;
+			reg-names = "mswc", "shm", "c2h", "kbc", "pm_acpi",
+				    "pm_hcmd", "mbi";
+
+			/* host sub-module IRQ and priority */
+			interrupts = <6 3>, /* KBC Input-Buf-Full (IBF) */
+				     <5 3>, /* KBC Output-Buf-Empty (OBE) */
+				     <4 3>, /* PMCH Input-Buf-Full (IBF) */
+				     <3 3>,  /* PMCH Output-Buf-Empty (OBE) */
+				     <10 3>, /* Port80 FIFO Not Empty */
+				     <7 3>; /* SHM/MBI interrupts */
+
+			interrupt-names = "kbc_ibf", "kbc_obe", "pmch_ibf",
+					  "pmch_obe", "p80_fifo", "shm_mbi";
+
+			/* WUI map for accessing host sub-modules */
+			host-acc-wui = <&wui_host_acc>;
+
+			/* clocks for host sub-modules */
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 3>,
+				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 4>,
+				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 5>,
+				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 6>,
+				<&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL5 7>;
+		};
+
+		/* I2c Controllers - Do not use them as i2c node directly */
+		i2c_ctrl1: i2c@40003000 {
+			compatible = "nuvoton,npcx-i2c-ctrl";
+			reg = <0x40003000 0x1000>;
+			interrupts = <35 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
+			smb-wui = <&wui_smb1>;
+			status = "disabled";
+		};
+
+		i2c_ctrl2: i2c@40004000 {
+			compatible = "nuvoton,npcx-i2c-ctrl";
+			reg = <0x40004000 0x1000>;
+			interrupts = <36 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
+			smb-wui = <&wui_smb2>;
+			status = "disabled";
+		};
+
+		i2c_ctrl3: i2c@40005000 {
+			compatible = "nuvoton,npcx-i2c-ctrl";
+			reg = <0x40005000 0x1000>;
+			interrupts = <37 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 2>;
+			smb-wui = <&wui_smb3>;
+			status = "disabled";
+		};
+
+		i2c_ctrl4: i2c@40006000 {
+			compatible = "nuvoton,npcx-i2c-ctrl";
+			reg = <0x40006000 0x1000>;
+			interrupts = <38 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 3>;
+			smb-wui = <&wui_smb4>;
+			status = "disabled";
+		};
+
+		i2c_ctrl5: i2c@40007000 {
+			compatible = "nuvoton,npcx-i2c-ctrl";
+			reg = <0x40007000 0x1000>;
+			interrupts = <39 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
+			smb-wui = <&wui_smb5>;
+			status = "disabled";
+		};
+
+		i2c_ctrl6: i2c@40008000 {
+			compatible = "nuvoton,npcx-i2c-ctrl";
+			reg = <0x40008000 0x1000>;
+			interrupts = <20 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 5>;
+			smb-wui = <&wui_smb6>;
+			status = "disabled";
+		};
+
+		tach1: tach@400e1000 {
+			compatible = "nuvoton,npcx-tach";
+			reg = <0x400e1000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL1 5>;
+			status = "disabled";
+		};
+
+		tach2: tach@400e3000 {
+			compatible = "nuvoton,npcx-tach";
+			reg = <0x400e3000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL1 6>;
+			status = "disabled";
+		};
+
+		tach3: tach@400e5000 {
+			compatible = "nuvoton,npcx-tach";
+			reg = <0x400e5000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL1 7>;
+			status = "disabled";
+		};
+
+		tach4: tach@400e7000 {
+			compatible = "nuvoton,npcx-tach";
+			reg = <0x400e7000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL0 5>;
+			status = "disabled";
+		};
+
+		tach5: tach@400e9000 {
+			compatible = "nuvoton,npcx-tach";
+			reg = <0x400e9000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL0 6>;
+			status = "disabled";
+		};
+
+		ps2_ctrl0: ps2@400b1000 {
+			compatible = "nuvoton,npcx-ps2-ctrl";
+			reg = <0x400b1000 0x1000>;
+			interrupts = <8 4>;
+			clocks = <&pcc NPCX_CLOCK_BUS_FREERUN NPCX_PWDWN_CTL1 3>;
+
+			/* PS2 Channels - Please use them as PS2 node */
+			ps2_channel2: io_ps2_channel2 {
+				compatible = "nuvoton,npcx-ps2-channel";
+				channel = <0x01>;
+				status = "disabled";
+			};
+
+			ps2_channel3: io_ps2_channel3 {
+				compatible = "nuvoton,npcx-ps2-channel";
+				channel = <0x02>;
+				status = "disabled";
+			};
+		};
+
+		/* Dedicated SPI interface to access SPI flashes */
+		qspi_fiu0: quadspi@40020000 {
+			compatible = "nuvoton,npcx-fiu-qspi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40020000 0x1000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_FIU NPCX_PWDWN_CTL1 2>;
+		};
+
+		peci0: peci@400d4000 {
+			compatible = "nuvoton,npcx-peci";
+			reg = <0x400d4000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupts = <9 4>;
+			clocks = <&pcc NPCX_CLOCK_BUS_FMCLK NPCX_PWDWN_CTL4 5>;
+			status = "disabled";
+		};
+
+		kbd: kscan@400a3000 {
+			compatible = "nuvoton,npcx-kbd";
+			reg = <0x400a3000 0x2000>;
+			interrupts = <50 4>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL1 0>;
+			wui-maps = <&wui_ioa0 &wui_ioa1 &wui_ioa2 &wui_ioa3
+				    &wui_ioa4 &wui_ioa5 &wui_ioa6 &wui_ioa7>;
+			status = "disabled";
+		};
+	};
+
+	soc-if {
+		/* Soc specific peripheral interface phandles which don't contain
+		 * 'reg' prop. Please overwrite 'status' prop. to 'okay' if you
+		 * want to switch the interface from io to specific peripheral.
+		 */
+		host_uart: io_host_uart {
+			compatible = "nuvoton,npcx-host-uart";
+			status = "disabled";
+		};
+
+		i2c1_a: io_i2c_ctrl1_porta {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(0, 0)>;
+			controller = <&i2c_ctrl1>;
+			status = "disabled";
+		};
+
+		i2c1_b: io_i2c_ctrl1_portb {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(0, 1)>;
+			controller = <&i2c_ctrl1>;
+			status = "disabled";
+		};
+
+		i2c2_a: io_i2c_ctrl2_porta {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(1, 0)>;
+			controller = <&i2c_ctrl2>;
+			status = "disabled";
+		};
+
+		i2c2_b: io_i2c_ctrl2_portb {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(1, 1)>;
+			controller = <&i2c_ctrl2>;
+			status = "disabled";
+		};
+
+		i2c3_a: io_i2c_ctrl3_porta {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(2, 0)>;
+			controller = <&i2c_ctrl3>;
+			status = "disabled";
+		};
+
+		i2c3_b: io_i2c_ctrl3_portb {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(2, 1)>;
+			controller = <&i2c_ctrl3>;
+			status = "disabled";
+		};
+
+		i2c4_a: io_i2c_ctrl4_porta {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(3, 0)>;
+			controller = <&i2c_ctrl4>;
+			status = "disabled";
+		};
+
+		i2c4_b: io_i2c_ctrl4_portb {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(3, 1)>;
+			controller = <&i2c_ctrl4>;
+			status = "disabled";
+		};
+
+		i2c5_a: io_i2c_ctrl5_porta {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port = <NPCX_I2C_CTRL_PORT(4, 0)>;
+			controller = <&i2c_ctrl5>;
+			status = "disabled";
+		};
+
+		i2c6_a: io_i2c_ctrl6_porta {
+			compatible = "nuvoton,npcx-i2c-port";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			controller = <&i2c_ctrl6>;
+			port = <NPCX_I2C_CTRL_PORT(5, 0)>;
+			status = "disabled";
+		};
+
+		power_ctrl_psl: power-ctrl-psl {
+			compatible = "nuvoton,npcx-power-psl";
+			status = "disabled";
+		};
+	};
+
+	soc-id {
+		compatible = "nuvoton,npcx-soc-id";
+		family-id = <0x20>;
+	};
+
+	booter-variant {
+		compatible = "nuvoton,npcx-booter-variant";
+	};
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <3>;
+};

--- a/dts/arm/nuvoton/npck/npck3.dtsi
+++ b/dts/arm/nuvoton/npck/npck3.dtsi
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* NPCK3 series pinmux mapping table */
+#include "npck3/npck3-alts-map.dtsi"
+/* NPCK3 series mapping table between MIWU wui bits and source device */
+#include "npck3/npck3-miwus-wui-map.dtsi"
+/* NPCK3 series mapping table between MIWU groups and interrupts */
+#include "npck3/npck3-miwus-int-map.dtsi"
+/* NPCK3 series eSPI VW mapping table */
+#include "npck3/npck3-espi-vws-map.dtsi"
+/* NPCK3 series low-voltage io controls mapping table */
+#include "npck3/npck3-lvol-ctrl-map.dtsi"
+
+/* Device tree declarations of npcx soc family */
+#include "npck.dtsi"
+
+/ {
+	def-io-conf-list {
+		pinmux = <&alt1_dpwrok_sl_def
+			  &alt1_vcc_pwrgd_sl_def
+			  &alt1_lpc_espi_def
+			  &alt2_ecsci_sl_def
+			  &alt7_kso12_sl_def
+			  &alt7_kso13_sl_def
+			  &alt7_kso14_sl_def
+			  &alt7_kso15_sl_def
+			  &alt8_kbrst_sl_def
+			  &alt9_no_ksi0_ksi1_ksi2_ksi3_sl
+			  &alt9_no_ksi4_ksi5_sl
+			  &alt9_no_ksi6_ksi7_sl
+			  &alt9_no_kso0_kso1_kso2_kso3_sl
+			  &alt9_no_kso4_kso5_kso6_kso7_sl
+			  &alt9_no_kso8_kso9_sl
+			  &alt9_no_kso10_kso11_sl
+			  &altf_psl_in0_en_def
+			  &altf_psl_in1_en_def>;
+	};
+
+	soc {
+		/* Specific soc devices in npck3 series */
+		itims: timer@400b0000 {
+			compatible = "nuvoton,npcx-itim-timer";
+			reg = <0x400b0000 0x2000
+			       0x400bc000 0x2000>;
+			reg-names = "evt_itim", "sys_itim";
+			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL4 0
+				  &pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 6>;
+			interrupts = <29 1>; /* Event timer interrupt */
+		};
+
+		uart1: serial@400c4000 {
+			compatible = "nuvoton,npcx-uart";
+			reg = <0x400C4000 0x2000>;
+			interrupts = <23 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL1 4>;
+			uart-rx = <&wui_cr_sin1>;
+			status = "disabled";
+		};
+
+		/* Default clock and power settings in npck3 series */
+		pcc: clock-controller@4000d000 {
+			clock-frequency = <DT_FREQ_M(90)>; /* OFMCLK runs at 90MHz */
+			core-prescaler = <6>; /* CORE_CLK runs at 15MHz */
+			apb1-prescaler = <6>; /* APB1_CLK runs at 15MHz */
+			apb2-prescaler = <6>; /* APB2_CLK runs at 15MHz */
+			apb3-prescaler = <6>; /* APB3_CLK runs at 15MHz */
+			ram-pd-depth = <15>; /* Valid bit-depth of RAM_PDn reg */
+			pwdwn-ctl-val = <0xe7 /* Start with PWDWN_CTL0 */
+					 0xfb /* No FIU_PD */
+					 0xff
+					 0x7f /* No GDMA */
+					 0xb7 /* No N2JTAG/SMB_DMA */
+					 0xfa /* No CCD/PSL */
+					 0x7f>; /* No eSPI */
+		};
+
+		/* Wake-up input source mapping for GPIOs in npck3 series */
+		gpio0: gpio@40081000 {
+			wui-maps = <&wui_none &wui_io01 &wui_io02 &wui_io03
+				    &wui_io04 &wui_io05 &wui_none &wui_io07>;
+
+			lvol-maps = <&lvol_none &lvol_io01 &lvol_none &lvol_io03
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpio1: gpio@40083000 {
+			wui-maps = <&wui_io10 &wui_io11 &wui_none &wui_io13
+				    &wui_io14 &wui_io15 &wui_none &wui_io17>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_io13
+				     &lvol_none &lvol_io15 &lvol_none &lvol_io17>;
+		};
+
+		gpio2: gpio@40085000 {
+			wui-maps = <&wui_io20 &wui_io21 &wui_io22 &wui_io23
+				    &wui_none &wui_io25 &wui_io26 &wui_io27>;
+
+			lvol-maps = <&lvol_io20 &lvol_io21 &lvol_io22 &lvol_io23
+				     &lvol_none &lvol_io25 &lvol_none &lvol_none>;
+		};
+
+		gpio3: gpio@40087000 {
+			wui-maps = <&wui_io30 &wui_io31 &wui_io32 &wui_io33
+				    &wui_io34 &wui_none &wui_io36 &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_io31 &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpio4: gpio@40089000 {
+			wui-maps = <&wui_io40 &wui_none &wui_none &wui_none
+				    &wui_io44 &wui_io45 &wui_io46 &wui_io47>;
+
+			lvol-maps = <&lvol_io40 &lvol_none &lvol_none &lvol_none
+				     &lvol_io44 &lvol_io45 &lvol_io46 &lvol_io47>;
+		};
+
+		gpio5: gpio@4008b000 {
+			wui-maps = <&wui_io50 &wui_io51 &wui_io52 &wui_io53
+				    &wui_io54 &wui_io55 &wui_io56 &wui_io57>;
+
+			lvol-maps = <&lvol_io50 &lvol_io51 &lvol_io52 &lvol_io53
+				     &lvol_io54 &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpio6: gpio@4008d000 {
+			wui-maps = <&wui_io60 &wui_io61 &wui_io62 &wui_io63
+				    &wui_io64 &wui_io65 &wui_io66 &wui_io67>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpio7: gpio@4008f000 {
+			wui-maps = <&wui_io70 &wui_none &wui_io72 &wui_io73
+				    &wui_io74 &wui_io75 &wui_io76 &wui_io77>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_io73
+				     &lvol_io74 &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpio8: gpio@40091000 {
+			wui-maps = <&wui_none &wui_io81 &wui_none &wui_io83
+				    &wui_none &wui_io85 &wui_io86 &wui_io87>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_io85 &lvol_io86 &lvol_none>;
+		};
+
+		gpio9: gpio@40093000 {
+			wui-maps = <&wui_io90 &wui_io91 &wui_io92 &wui_io93
+				    &wui_io94 &wui_none &wui_none &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_io94 &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpioa: gpio@40095000 {
+			wui-maps = <&wui_ioa0 &wui_ioa1 &wui_ioa2 &wui_ioa3
+				    &wui_ioa4 &wui_ioa5 &wui_ioa6 &wui_ioa7>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpiob: gpio@40097000 {
+			wui-maps = <&wui_iob0 &wui_none &wui_none &wui_none
+				    &wui_none &wui_none &wui_none &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_iob7>;
+		};
+
+		gpioc: gpio@40099000 {
+			wui-maps = <&wui_none &wui_none &wui_none &wui_none
+				    &wui_none &wui_none &wui_none &wui_none>;
+
+			lvol-maps = <&lvol_ioc0 &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpiod: gpio@4009b000 {
+			wui-maps = <&wui_iod0 &wui_none &wui_none &wui_iod3
+				    &wui_iod4 &wui_iod5 &wui_iod6 &wui_iod7>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_iod5 &lvol_iod6 &lvol_none>;
+		};
+
+		gpioe: gpio@4009d000 {
+			wui-maps = <&wui_ioe0 &wui_ioe1 &wui_ioe2 &wui_ioe3
+				    &wui_ioe4 &wui_ioe5 &wui_ioe6 &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_ioe1 &lvol_ioe2 &lvol_ioe3
+				     &lvol_ioe4 &lvol_none &lvol_ioe6 &lvol_none>;
+		};
+
+		gpiof: gpio@4009f000 {
+			wui-maps = <&wui_none &wui_none &wui_none &wui_none
+				    &wui_none &wui_none &wui_none &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpiog: gpio@400a7000 {
+			wui-maps = <&wui_none &wui_none &wui_none &wui_none
+				    &wui_none &wui_iog5 &wui_iog6 &wui_iog7>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpioh: gpio@400a9000 {
+			wui-maps = <&wui_ioh0 &wui_ioh1 &wui_ioh2 &wui_none
+				    &wui_ioh4 &wui_none &wui_none &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpiostb0: gpio@400ab000 {
+			wui-maps = <&wui_io_stb00 &wui_io_stb01 &wui_io_stb02 &wui_io_stb03
+				    &wui_io_stb04 &wui_none &wui_none &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		gpiostb1: gpio@400ad000 {
+			wui-maps = <&wui_none &wui_io_stb11_psl_in0
+				    &wui_io_stb12_psl_in1 &wui_io_stb13_psl_in2
+				    &wui_io_stb14_psl_in3 &wui_io_stb15_psl_in4
+				    &wui_io_stb16_psl_in5 &wui_none>;
+
+			lvol-maps = <&lvol_none &lvol_none &lvol_none &lvol_none
+				     &lvol_none &lvol_none &lvol_none &lvol_none>;
+		};
+
+		/* ADC0 comparator configuration in npck3 series */
+		adc0: adc@400d1000 {
+			channel-count = <12>;
+			threshold-count = <6>;
+		};
+
+		espi0: espi@4000a000 {
+			rx-plsize = <64>;
+			tx-plsize = <64>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			espi_taf: espitaf@4000a000 {
+				compatible = "nuvoton,npcx-espi-taf";
+				reg = <0x4000a000 0x2000>,
+				      <0x40021000 0x2000>;
+				reg-names = "saf", "fiu1";
+				status = "disabled";
+			};
+		};
+	};
+
+	soc-id {
+		chip-id = <0x09>;
+		revision-reg = <0x0000FFFC 4>;
+	};
+};

--- a/dts/arm/nuvoton/npck/npck3/npck3-alts-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck3/npck3-alts-map.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common pin-mux configurations in npck */
+#include <nuvoton/npck/npck-alts-map.dtsi>
+
+/* Specific pin-mux configurations in npck3 series */
+/ {
+	npcx-alts-map {
+		compatible = "nuvoton,npcx-pinctrl-conf";
+	};
+};

--- a/dts/arm/nuvoton/npck/npck3/npck3-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck3/npck3-espi-vws-map.dtsi
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common eSPI Virtual Wire (VW) mapping configurations in npck */
+#include <nuvoton/npck/npck-espi-vws-map.dtsi>
+
+/* Specific eSPI Virtual Wire (VW) mapping configurations in npck3 series */

--- a/dts/arm/nuvoton/npck/npck3/npck3-lvol-ctrl-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck3/npck3-lvol-ctrl-map.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common Low-Voltage level configurations in npck */
+#include <nuvoton/npck/npck-lvol-ctrl-map.dtsi>
+
+/* Specific Low-Voltage level configurations in npck3 series */
+/ {
+	def-lvol-conf-list {
+		compatible = "nuvoton,npcx-lvolctrl-conf";
+	};
+};

--- a/dts/arm/nuvoton/npck/npck3/npck3-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck3/npck3-miwus-int-map.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common MIWU group-interrupt mapping configurations in npck */
+#include <nuvoton/npck/npck-miwus-int-map.dtsi>
+
+/* Specific MIWU group-interrupt mapping configurations in npck3 series */
+/ {
+	/* Mapping between MIWU group and interrupts */
+	npcx-miwus-int-map {
+	};
+};

--- a/dts/arm/nuvoton/npck/npck3/npck3-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npck/npck3/npck3-miwus-wui-map.dtsi
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common Wake-Up Unit Input (WUI) mapping configurations in npck */
+#include <nuvoton/npck/npck-miwus-wui-map.dtsi>
+
+/* Specific Wake-Up Unit Input (WUI) mapping configurations in npck3 series */
+/ {
+	/* Mapping between MIWU wui bits and source device */
+	npcx-miwus-wui-map {
+		compatible = "nuvoton,npcx-miwu-wui-map";
+	};
+};

--- a/dts/arm/nuvoton/npck/npck3/npck3-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npck/npck3/npck3-pinctrl.dtsi
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	/* Prebuild nodes for peripheral device's characteristics (Optional) */
+	/omit-if-no-ref/ shd_bkp_flash_tris_off: devctl-fiu-ext-tris-off {
+		dev-ctl = <0x0 6 1 0x00>;
+	};
+
+	/omit-if-no-ref/ shd_bkp_flash_tris_on: devctl-fiu-ext-tris-on {
+		dev-ctl = <0x0 6 1 0x01>;
+	};
+
+	/omit-if-no-ref/ pvt_flash_tris_off: devctl-fiu-int-tris-off {
+		dev-ctl = <0x0 7 1 0x00>;
+	};
+
+	/omit-if-no-ref/ pvt_flash_tris_on: devctl-fiu-int-tris-on {
+		dev-ctl = <0x0 7 1 0x01>;
+	};
+
+	/omit-if-no-ref/ peci_en: devctl-peci-en {
+		dev-ctl = <0x6 7 1 0x01>;
+	};
+
+	/* Prebuild nodes for peripheral device's pin-muxing and pad properties */
+	/* Flash Interface Unit (FIU) */
+	/omit-if-no-ref/ fiu_shd_io0_io1_clk_cs_gpc5_c4_c7_c6: periph-fiu-shd {
+		pinmux = <&alt0_shd1_spi>;
+	};
+
+	/omit-if-no-ref/ fiu_pvt_flash_sl: periph-fiu-int {
+		pinmux = <&alt0_pvt_spi_sl>;
+	};
+
+	/omit-if-no-ref/ fiu_shd_bkp_flash_sl: periph-fiu-ext {
+		pinmux = <&alt0_shd_bkp_spi_sl>;
+	};
+
+	/omit-if-no-ref/ fiu_shd_quad_io2_io3_gp81_77: periph-fiu-shd-quad {
+		pinmux = <&alt0_shdf_spi_quad>;
+	};
+
+	/omit-if-no-ref/ fiu_pvt_quad_sl: periph-fiu-pvt-quad {
+		pinmux = <&alt0_shdf_spi_quad>;
+	};
+
+	/omit-if-no-ref/ fiu_shd_cs_gpc6_sl: periph-fiu-shd-cs1 {
+		pinmux = <&alt4_noshd2_spi>;
+	};
+
+	/omit-if-no-ref/ fiu_bkp_cs_gp94_sl: periph-fiu-shd-cs2 {
+		pinmux = <&alt4_shd2_spi>;
+	};
+
+	/* Host peripheral interfaces */
+	/omit-if-no-ref/ espi_lpc_gp10_f7: periph-lpc-espi {
+		pinmux = <&alt1_lpc_espi_def>;
+	};
+
+	/* I2C peripheral interfaces */
+	/omit-if-no-ref/ i2c1_a_sda_scl_gp22_17: periph-i2c1-a {
+		pinmux = <&alt2_smb1a_sl>;
+		periph-pupd = <0x00 0>;
+	};
+
+	/omit-if-no-ref/ i2c1_b_sda_scl_gp74_73: periph-i2c1-b {
+		pinmux = <&alt2_smb1b_sl>;
+		periph-pupd = <0x00 1>;
+	};
+
+	/omit-if-no-ref/ i2c2_a_sda_scl_gp50_52: periph-i2c2-a {
+		pinmux = <&altc_smb2a_sl>;
+		periph-pupd = <0x00 2>;
+	};
+
+	/omit-if-no-ref/ i2c2_b_sda_scl_gpd5_d6: periph-i2c2-b {
+		pinmux = <&altc_smb2b_sl>;
+		periph-pupd = <0x00 3>;
+	};
+
+	/omit-if-no-ref/ i2c3_a_sda_scl_gp31_23: periph-i2c3-a {
+		pinmux = <&alta_smb3a_sl>;
+		periph-pupd = <0x00 4>;
+	};
+
+	/omit-if-no-ref/ i2c3_b_sda_scl_gpe1_e2: periph-i2c3-b {
+		pinmux = <&altc_smb3b_sl>;
+		periph-pupd = <0x00 5>;
+	};
+
+	/omit-if-no-ref/ i2c4_a_sda_scl_gp53_47: periph-i2c4-a {
+		pinmux = <&alta_smb4a_sl>;
+		periph-pupd = <0x00 6>;
+	};
+
+	/omit-if-no-ref/ i2c4_b_sda_scl_gp46_44: periph-i2c4-b {
+		pinmux = <&altc_smb4b_sl>;
+		periph-pupd = <0x00 7>;
+	};
+
+	/omit-if-no-ref/ i2c5_a_sda_scl_gpe3_e4: periph-i2c5-a {
+		pinmux = <&alta_smb5a_sl>;
+		periph-pupd = <0x01 0>;
+	};
+
+	/omit-if-no-ref/ i2c6_a_sda_scl_gpe6_25: periph-i2c6-a {
+		pinmux = <&alta_smb6a_sl>;
+		periph-pupd = <0x01 1>;
+	};
+
+	/* PWM peripheral interfaces */
+	/omit-if-no-ref/ pwma_gp15: periph-pwm0 {
+		pinmux = <&alt5_a_pwm_sl>;
+	};
+
+	/omit-if-no-ref/ pwmb_gp21: periph-pwm1 {
+		pinmux = <&alt5_b_pwm_sl>;
+	};
+
+	/omit-if-no-ref/ pwmc_gp13: periph-pwm2 {
+		pinmux = <&alt5_c_pwm_sl>;
+	};
+
+	/omit-if-no-ref/ pwmd_gp32: periph-pwm3 {
+		pinmux = <&alt5_d_pwm_sl>;
+	};
+
+	/omit-if-no-ref/ pwmf_gp40: periph-pwm5 {
+		pinmux = <&alt5_f_pwm_sl>;
+	};
+
+	/omit-if-no-ref/ pwmi_gp72: periph-pwm8 {
+		pinmux = <&alt8_i_pwm_sl>;
+	};
+
+	/omit-if-no-ref/ pwmj_gpd3: periph-pwm9 {
+		pinmux = <&alt8_j_pwm_sl>;
+	};
+
+	/omit-if-no-ref/ pwmk_gp55: periph-pwm10 {
+		pinmux = <&alt8_k_pwm_sl>;
+	};
+
+	/* ADC peripheral interfaces. */
+	/omit-if-no-ref/ adc0_chan0_gp90: periph-adc0-0 {
+		pinmux = <&alt6_adc0_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan1_gp91: periph-adc0-1 {
+		pinmux = <&alt6_adc1_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan2_gp92: periph-adc0-2 {
+		pinmux = <&alt6_adc2_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan3_gp93: periph-adc0-3 {
+		pinmux = <&alt6_adc3_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan4_gp05: periph-adc0-4 {
+		pinmux = <&alt6_adc4_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan5_gp04: periph-adc0-5 {
+		pinmux = <&alt6_adc5_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan6_gp03: periph-adc0-6 {
+		pinmux = <&alt6_adc6_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan7_gp07: periph-adc0-7 {
+		pinmux = <&alt6_adc7_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan8_gph2: periph-adc0-8 {
+		pinmux = <&alt11_adc8_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan9_gph1: periph-adc0-9 {
+		pinmux = <&alt11_adc9_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan10_gph0: periph-adc0-10 {
+		pinmux = <&alt11_adc10_sl>;
+	};
+
+	/omit-if-no-ref/ adc0_chan11_gpg7: periph-adc0-11 {
+		pinmux = <&alt11_adc11_sl>;
+	};
+
+	/* UART peripheral interfaces */
+	/omit-if-no-ref/ uart1_sin_gp87: periph-uart1-sin {
+		pinmux = <&alt1_urti_sl>;
+	};
+
+	/omit-if-no-ref/ uart1_sout_gp83: periph-uart1-sout {
+		pinmux = <&alt1_urto1_sl>;
+	};
+
+	/* PS2 peripheral interfaces */
+	/omit-if-no-ref/ ps2_2_dat_clk_gp26_27: periph-ps2-2 {
+		pinmux = <&alt4_ps2_2_sl>;
+	};
+
+	/omit-if-no-ref/ ps2_3_dat_clk_gp50_52: periph-ps2-3 {
+		pinmux = <&alt4_ps2_3_sl>;
+	};
+
+	/* Tachometer peripheral interfaces */
+	/omit-if-no-ref/ ta1_1_in_gp56: periph-ta1-1 {
+		pinmux = <&alt3_ta1_1_sl>;
+	};
+
+	/omit-if-no-ref/ ta1_2_in_gpa0: periph-ta1-2 {
+		pinmux = <&alt3_ta1_2_sl>;
+	};
+
+	/omit-if-no-ref/ tb1_1_in_gp14: periph-tb1-1 {
+		pinmux = <&alt3_tb1_1_sl>;
+	};
+
+	/omit-if-no-ref/ tb1_2_in_gpa3: periph-tb1-2 {
+		pinmux = <&alt3_tb1_2_sl>;
+	};
+
+	/omit-if-no-ref/ ta2_1_in_gp20: periph-ta2-1 {
+		pinmux = <&alt3_ta2_1_sl>;
+	};
+
+	/omit-if-no-ref/ ta2_2_in_gpa4: periph-ta2-2 {
+		pinmux = <&alt10_ta2_2_sl>;
+	};
+
+	/omit-if-no-ref/ tb2_1_in_gp01: periph-tb2-1 {
+		pinmux = <&alt3_tb2_1_sl>;
+	};
+
+	/omit-if-no-ref/ tb2_2_in_gpa5: periph-tb2-2 {
+		pinmux = <&alt10_tb2_2_sl>;
+	};
+
+	/omit-if-no-ref/ ta3_1_in_gp51: periph-ta3-1 {
+		pinmux = <&alt3_ta3_1_sl>;
+	};
+
+	/omit-if-no-ref/ ta3_2_in_gpa6: periph-ta3-2 {
+		pinmux = <&alt10_ta3_2_sl>;
+	};
+
+	/omit-if-no-ref/ tb3_1_in_gp36: periph-tb3-1 {
+		pinmux = <&alt3_tb3_1_sl>;
+	};
+
+	/omit-if-no-ref/ tb3_2_in_gpa7: periph-tb3-2 {
+		pinmux = <&alt10_tb3_2_sl>;
+	};
+
+	/omit-if-no-ref/ ta4_in_gpe0: periph-ta4 {
+		pinmux = <&alt10_ta4_sl>;
+	};
+
+	/omit-if-no-ref/ tb4_in_gp60: periph-tb4 {
+		pinmux = <&alt10_tb4_sl>;
+	};
+
+	/omit-if-no-ref/ ta5_in_gpb0: periph-ta5 {
+		pinmux = <&alt10_ta5_sl>;
+	};
+
+	/omit-if-no-ref/ tb5_in_gp61: periph-tb5 {
+		pinmux = <&alt10_tb5_sl>;
+	};
+
+	/* Keyboard peripheral interfaces. */
+	/omit-if-no-ref/ ksi0_1_2_3_gpa0_a1_a2_a3: periph-kbscan-ksi0_1_2_3 {
+		pinmux = <&alt9_no_ksi0_ksi1_ksi2_ksi3_sl>;
+	};
+
+	/omit-if-no-ref/ ksi4_5_gpa4_a5: periph-kbscan-ksi4_5 {
+		pinmux = <&alt9_no_ksi4_ksi5_sl>;
+	};
+
+	/omit-if-no-ref/ ksi6_7_gpa6_a7: periph-kbscan-ksi6_7 {
+		pinmux = <&alt9_no_ksi6_ksi7_sl>;
+	};
+
+	/omit-if-no-ref/ kso00_01_02_03_gpb0_b1_b2_b3: periph-kbscan-kso00_01_02_03 {
+		pinmux = <&alt9_no_kso0_kso1_kso2_kso3_sl>;
+	};
+
+	/omit-if-no-ref/ kso04_05_06_07_gpb4_b5_b6_b7: periph-kbscan-kso04_05_06_07 {
+		pinmux = <&alt9_no_kso4_kso5_kso6_kso7_sl>;
+	};
+
+	/omit-if-no-ref/ kso08_09_gpc0_c1: periph-kbscan-kso08_09 {
+		pinmux = <&alt9_no_kso8_kso9_sl>;
+	};
+
+	/omit-if-no-ref/ kso10_11_gpc2_c3: periph-kbscan-kso10_11 {
+		pinmux = <&alt9_no_kso10_kso11_sl>;
+	};
+
+	/omit-if-no-ref/ kso12_gp64: periph-kbscan-kso12 {
+		pinmux = <&alt7_kso12_sl_def>;
+	};
+
+	/omit-if-no-ref/ kso13_gp63: periph-kbscan-kso13 {
+		pinmux = <&alt7_kso13_sl_def>;
+	};
+
+	/omit-if-no-ref/ kso14_gp62: periph-kbscan-kso14 {
+		pinmux = <&alt7_kso14_sl_def>;
+	};
+
+	/omit-if-no-ref/ kso15_gp61: periph-kbscan-kso15 {
+		pinmux = <&alt7_kso15_sl_def>;
+	};
+
+	/omit-if-no-ref/ kso16_gp60: periph-kbscan-kso16 {
+		pinmux = <&alt7_kso16_sl>;
+	};
+
+	/omit-if-no-ref/ kso17_gp57: periph-kbscan-kso17 {
+		pinmux = <&alt7_kso17_sl>;
+	};
+
+	/* PSL peripheral interfaces */
+	/omit-if-no-ref/ psl_in0_gpstb11: periph-psl-in0 {
+		pinmux = <&altf_psl_in0_en_def>;
+		psl-offset = <1>;
+		psl-polarity = <&altcx_psl_in0_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in1_gpstb12: periph-psl-in1 {
+		pinmux = <&altf_psl_in1_en_def>;
+		psl-offset = <2>;
+		psl-polarity = <&altcx_psl_in1_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in2_gpstb13: periph-psl-in2 {
+		pinmux = <&altf_psl_in2_en>;
+		psl-offset = <3>;
+		psl-polarity = <&altcx_psl_in2_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in3_gpstb14: periph-psl-in3 {
+		pinmux = <&altf_psl_in3_en>;
+		psl-offset = <4>;
+		psl-polarity = <&altcx_psl_in3_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in4_gpstb15: periph-psl-in4 {
+		pinmux = <&altf_psl_in4_en>;
+		psl-offset = <5>;
+		psl-polarity = <&altcx_psl_in4_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_in5_gpstb16: periph-psl-in5 {
+		pinmux = <&altf_psl_in5_en>;
+		psl-offset = <6>;
+		psl-polarity = <&altcx_psl_in5_ahi>;
+	};
+
+	/omit-if-no-ref/ psl_out_gpstb17: periph-psl-out {
+		pinmux = <&altf_psl_out_en_def>;
+	};
+
+	/omit-if-no-ref/ psl_out_fw_high: periph-psl-out-inactive-high {
+		pinmux = <&altdx_psl_fw_ctl_high>;
+	};
+
+	/omit-if-no-ref/ psl_out_fw_low: periph-psl-out-inactive-low {
+		pinmux = <&altdx_psl_fw_ctl_low>;
+	};
+
+	/omit-if-no-ref/ psl_out_fw_ctl_en: periph-psl-out-fw-ctl {
+		pinmux = <&altdx_psl_out_gpo>;
+	};
+
+	/* Miscellaneous peripheral interfaces */
+	/omit-if-no-ref/ clkout_gp55: periph-clkout {
+		pinmux = <&alt0_ckout_sl>;
+	};
+
+	/* Serial UART peripheral interfaces  */
+	/omit-if-no-ref/ huart_sin1_gp34: periph-host-uart_sin1 {
+		pinmux = <&alt0_sp1i_sl>;
+	};
+
+	/omit-if-no-ref/ huart_sout1_gp67: periph-host-uart_sout1 {
+		pinmux = <&alt0_sp1o_sl>;
+	};
+
+	/omit-if-no-ref/ huart_sin2_gp87: periph-host-uart_sin2 {
+		pinmux = <&altb_sp2i_sl>;
+	};
+
+	/omit-if-no-ref/ huart_sout2_gp83: periph-host-uart_sout2 {
+		pinmux = <&altb_sp2o_sl>;
+	};
+};

--- a/dts/arm/nuvoton/npck3m8k.dtsi
+++ b/dts/arm/nuvoton/npck3m8k.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include "npck/npck3.dtsi"
+
+/ {
+	flash0: flash@10058000 {
+		reg = <0x10058000 DT_SIZE_K(416)>;
+	};
+
+	flash1: flash@60000000 {
+		reg = <0x60000000 DT_SIZE_K(512)>;
+	};
+
+	sram0: memory@200c0000 {
+		compatible = "mmio-sram";
+		reg = <0x200C0000 DT_SIZE_K(62)>;
+	};
+
+	/* RAM space used by Booter */
+	bootloader_ram: memory@200c7800 {
+		compatible = "mmio-sram";
+		reg = <0x200C7800 DT_SIZE_K(2)>;
+	};
+
+	soc-id {
+		device-id = <0x22>;
+	};
+};

--- a/include/zephyr/dt-bindings/clock/npcx_clock.h
+++ b/include/zephyr/dt-bindings/clock/npcx_clock.h
@@ -23,15 +23,16 @@
 #define NPCX_CLOCK_BUS_MCLKD       12
 
 /* clock enable/disable references */
-#define NPCX_PWDWN_CTL1            0
-#define NPCX_PWDWN_CTL2            1
-#define NPCX_PWDWN_CTL3            2
-#define NPCX_PWDWN_CTL4            3
-#define NPCX_PWDWN_CTL5            4
-#define NPCX_PWDWN_CTL6            5
-#define NPCX_PWDWN_CTL7            6
-#define NPCX_PWDWN_CTL8            7
-#define NPCX_PWDWN_CTL9            8
-#define NPCX_PWDWN_CTL_COUNT       9
+#define NPCX_PWDWN_CTL0            0
+#define NPCX_PWDWN_CTL1            1
+#define NPCX_PWDWN_CTL2            2
+#define NPCX_PWDWN_CTL3            3
+#define NPCX_PWDWN_CTL4            4
+#define NPCX_PWDWN_CTL5            5
+#define NPCX_PWDWN_CTL6            6
+#define NPCX_PWDWN_CTL7            7
+#define NPCX_PWDWN_CTL8            8
+#define NPCX_PWDWN_CTL9            9
+#define NPCX_PWDWN_CTL_COUNT       10
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_NPCX_CLOCK_H_ */

--- a/soc/nuvoton/npcx/Kconfig
+++ b/soc/nuvoton/npcx/Kconfig
@@ -31,6 +31,7 @@ config NPCX_IMAGE_OUTPUT_HEX
 
 config NPCX_HEADER_CHIP
 	string
+	default "npck3m8" if SOC_NPCK3M8K
 	default "npcx7m6" if SOC_NPCX7M6FB || SOC_NPCX7M6FC
 	default "npcx7m7" if SOC_NPCX7M7FC
 	default "npcx9m3" if SOC_NPCX9M3F
@@ -136,7 +137,8 @@ config NPCX_HEADER_ENABLE_FIRMWARE_CRC
 choice NPCX_HEADER_FLASH_SIZE_CHOICE
 	prompt "Flash size"
 	default NPCX_HEADER_FLASH_SIZE_0P5M_1M if SOC_SERIES_NPCX7 || \
-						  SOC_SERIES_NPCX9
+						  SOC_SERIES_NPCX9 || \
+						  SOC_SERIES_NPCK3
 	default NPCX_HEADER_FLASH_SIZE_16M
 	help
 	  This sets the SPI flash size.

--- a/soc/nuvoton/npcx/common/ecst/ecst.py
+++ b/soc/nuvoton/npcx/common/ecst/ecst.py
@@ -214,7 +214,7 @@ def _check_chip(output, ecst_args):
     if ecst_args.chip_name == INVALID_INPUT:
         message = f'Invalid chip name, '
         message += "should be npcx4m3, npcx4m8, npcx9m8, npcx9m7, npcx9m6, " \
-                   "npcx7m7, npcx7m6, npcx7m5."
+                   "npcx7m7, npcx7m6, npcx7m5, npck3m8k."
         _exit_with_failure_delete_file(output, message)
 
 def _set_anchor(output, ecst_args):

--- a/soc/nuvoton/npcx/common/ecst/ecst_args.py
+++ b/soc/nuvoton/npcx/common/ecst/ecst_args.py
@@ -47,6 +47,7 @@ POINTER_OFFSET_DEFAULT = 0x0
 
 # Chips: convert from name to index.
 CHIPS_INFO = {
+    'npck3m8': {'ram_address': 0x10058000, 'ram_size': 0x68000},
     'npcx7m5': {'ram_address': 0x100a8000, 'ram_size': 0x20000},
     'npcx7m6': {'ram_address': 0x10090000, 'ram_size': 0x40000},
     'npcx7m7': {'ram_address': 0x10070000, 'ram_size': 0x60000},

--- a/soc/nuvoton/npcx/common/npckn/include/clock_def.h
+++ b/soc/nuvoton/npcx/common/npckn/include/clock_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nuvoton Technology Corporation.
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -47,11 +47,11 @@
 
 /* I3C clock divider */
 #if (OFMCLK == MHZ(120)) /* MCLkD must between 40 mhz to 50 mhz*/
-#define MCLKD_SL 2       /* I3C_CLK = (MCLK / 3) */
+#define MCLKD_SL 2    /* I3C_CLK = (MCLK / 3) */
 #elif (OFMCLK <= MHZ(100) && OFMCLK >= MHZ(80))
-#define MCLKD_SL 1 /* I3C_CLK = (MCLK / 2) */
+#define MCLKD_SL 1    /* I3C_CLK = (MCLK / 2) */
 #else
-#define MCLKD_SL 0 /* I3C_CLK = MCLK */
+#define MCLKD_SL 0    /* I3C_CLK = MCLK */
 #endif
 
 /* Get APB clock freq */
@@ -62,34 +62,34 @@
  * OFMCLK (Unit:Hz).
  */
 #if (OFMCLK > (MAX_OFMCLK / 2))
-#define HFCGN_VAL 0x82 /* Set XF_RANGE as 1 */
+#define HFCGN_VAL    0x82 /* Set XF_RANGE as 1 */
 #else
-#define HFCGN_VAL 0x02
+#define HFCGN_VAL    0x02
 #endif
-#if (OFMCLK == 120000000)
-#define HFCGMH_VAL 0x0E
-#define HFCGML_VAL 0x4E
+#if   (OFMCLK == 120000000)
+#define HFCGMH_VAL   0x0E
+#define HFCGML_VAL   0x4E
 #elif (OFMCLK == 100000000)
-#define HFCGMH_VAL 0x0B
-#define HFCGML_VAL 0xEC
+#define HFCGMH_VAL   0x0B
+#define HFCGML_VAL   0xEC
 #elif (OFMCLK == 96000000)
-#define HFCGMH_VAL 0x0B
-#define HFCGML_VAL 0x72
+#define HFCGMH_VAL   0x0B
+#define HFCGML_VAL   0x72
 #elif (OFMCLK == 90000000)
-#define HFCGMH_VAL 0x0A
-#define HFCGML_VAL 0xBA
+#define HFCGMH_VAL   0x0A
+#define HFCGML_VAL   0xBA
 #elif (OFMCLK == 80000000)
-#define HFCGMH_VAL 0x09
-#define HFCGML_VAL 0x89
+#define HFCGMH_VAL   0x09
+#define HFCGML_VAL   0x89
 #elif (OFMCLK == 66000000)
-#define HFCGMH_VAL 0x07
-#define HFCGML_VAL 0xDE
+#define HFCGMH_VAL   0x07
+#define HFCGML_VAL   0xDE
 #elif (OFMCLK == 50000000)
-#define HFCGMH_VAL 0x0B
-#define HFCGML_VAL 0xEC
+#define HFCGMH_VAL   0x0B
+#define HFCGML_VAL   0xEC
 #elif (OFMCLK == 48000000)
-#define HFCGMH_VAL 0x0B
-#define HFCGML_VAL 0x72
+#define HFCGMH_VAL   0x0B
+#define HFCGML_VAL   0x72
 #else
 #error "Unsupported OFMCLK Frequency"
 #endif

--- a/soc/nuvoton/npcx/common/npckn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npckn/include/reg_def.h
@@ -1,0 +1,1958 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _NUVOTON_NPCX_REG_DEF_H
+#define _NUVOTON_NPCX_REG_DEF_H
+
+#include <reg_access.h>
+
+/*
+ * Core Domain Clock Generator (CDCG) device registers
+ */
+struct cdcg_reg {
+	/* High Frequency Clock Generator (HFCG) registers */
+	/* 0x000: HFCG Control */
+	volatile uint8_t HFCGCTRL;
+	volatile uint8_t reserved1;
+	/* 0x002: HFCG M Low Byte Value */
+	volatile uint8_t HFCGML;
+	volatile uint8_t reserved2;
+	/* 0x004: HFCG M High Byte Value */
+	volatile uint8_t HFCGMH;
+	volatile uint8_t reserved3;
+	/* 0x006: HFCG N Value */
+	volatile uint8_t HFCGN;
+	volatile uint8_t reserved4;
+	/* 0x008: HFCG Prescaler */
+	volatile uint8_t HFCGP;
+	volatile uint8_t reserved5[7];
+	/* 0x010: HFCG Bus Clock Dividers */
+	volatile uint8_t HFCBCD;
+	volatile uint8_t reserved6;
+	/* 0x012: HFCG Bus Clock Dividers */
+	volatile uint8_t HFCBCD1;
+	volatile uint8_t reserved7;
+	/* 0x014: HFCG Bus Clock Dividers */
+	volatile uint8_t HFCBCD2;
+	volatile uint8_t reserved8[8];
+	/* 0x01d: HFCG Bus Clock Dividers */
+	volatile uint8_t reserved9[227];
+
+	/* Low Frequency Clock Generator (LFCG) registers */
+	/* 0x100: LFCG Control */
+	volatile uint16_t  LFCGCTL;
+	/* 0x102: High-Frequency Reference Divisor I */
+	volatile uint16_t HFRDI;
+	/* 0x104: High-Frequency Reference Divisor F */
+	volatile uint16_t HFRDF;
+	/* 0x106: FRCLK Clock Divisor */
+	volatile uint16_t FRCDIV;
+	/* 0x108: Divisor Correction Value 1 */
+	volatile uint16_t DIVCOR1;
+	/* 0x10A: Divisor Correction Value 2 */
+	volatile uint16_t DIVCOR2;
+	volatile uint8_t reserved10[8];
+	/* 0x114: LFCG Control 2 */
+	volatile uint8_t  LFCGCTL2;
+	volatile uint8_t  reserved11;
+};
+
+/* CDCG register fields */
+#define NPCX_HFCGCTRL_LOAD                    0
+#define NPCX_HFCGCTRL_LOCK                    2
+#define NPCX_HFCGCTRL_CLK_CHNG                7
+
+/*
+ * Power Management Controller (PMC) device registers
+ */
+struct pmc_reg {
+	/* 0x000: Power Management Controller */
+	volatile uint8_t PMCSR;
+	volatile uint8_t reserved1[2];
+	/* 0x003: Enable in Sleep Control */
+	volatile uint8_t ENIDL_CTL;
+	/* 0x004: Disable in Idle Control */
+	volatile uint8_t DISIDL_CTL;
+	/* 0x005: Disable in Idle Control 1 */
+	volatile uint8_t DISIDL_CTL1;
+	volatile uint8_t reserved2[1];
+	/* 0x007 - 0D: Power-Down Control 0 - 6 */
+	volatile uint8_t PWDWN_CTL0[7];
+	volatile uint8_t reserved3[3];
+	/* 0x011 - 12: RAM Power-Down Control 1 - 2 */
+	volatile uint8_t RAM_PD[2];
+};
+
+/* Macro functions for PMC multi-registers */
+#define NPCX_PWDWN_CTL(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_PWDWN_CTL_OFFSET(n)))
+
+/* PMC register fields */
+#define NPCX_PMCSR_DI_INSTW                   0
+#define NPCX_PMCSR_DHF                        1
+#define NPCX_PMCSR_IDLE                       2
+#define NPCX_PMCSR_NWBI                       3
+#define NPCX_PMCSR_OHFC                       6
+#define NPCX_PMCSR_OLFC                       7
+#define NPCX_DISIDL_CTL_RAM_DID               5
+#define NPCX_ENIDL_CTL_ADC_ACC_DIS            1
+#define NPCX_ENIDL_CTL_PECI_ENI               2
+#define NPCX_ENIDL_CTL_LP_WK_CTL              6
+#define NPCX_ENIDL_CTL_ADC_LFSL               7
+
+/* Macro functions for Development and Debugger Interface (DDI) registers */
+#define NPCX_DBGCTRL(base)   (*(volatile uint8_t *)(base + 0x004))
+#define NPCX_DBGFRZEN1(base) (*(volatile uint8_t *)(base + 0x006))
+#define NPCX_DBGFRZEN2(base) (*(volatile uint8_t *)(base + 0x007))
+#define NPCX_DBGFRZEN3(base) (*(volatile uint8_t *)(base + 0x008))
+#define NPCX_DBGFRZEN4(base) (*(volatile uint8_t *)(base + 0x009))
+
+/* DDI register fields */
+#define NPCX_DBGCTRL_CCDEV_SEL		FIELD(6, 2)
+#define NPCX_DBGCTRL_CCDEV_DIR		5
+#define NPCX_DBGCTRL_SEQ_WK_EN		4
+#define NPCX_DBGCTRL_FRCLK_SEL_DIS	3
+#define NPCX_DBGFRZEN1_SPIFEN		7
+#define NPCX_DBGFRZEN1_HIFEN		6
+#define NPCX_DBGFRZEN1_ESPISEN		5
+#define NPCX_DBGFRZEN1_UART1FEN		4
+#define NPCX_DBGFRZEN1_SMB3FEN		3
+#define NPCX_DBGFRZEN1_SMB2FEN		2
+#define NPCX_DBGFRZEN1_MFT2FEN		1
+#define NPCX_DBGFRZEN1_MFT1FEN		0
+#define NPCX_DBGFRZEN2_ITIM6FEN		7
+#define NPCX_DBGFRZEN2_ITIM5FEN		6
+#define NPCX_DBGFRZEN2_ITIM4FEN		5
+#define NPCX_DBGFRZEN2_ITIM64FEN	3
+#define NPCX_DBGFRZEN2_SMB1FEN		2
+#define NPCX_DBGFRZEN2_SMB0FEN		1
+#define NPCX_DBGFRZEN2_MFT3FEN		0
+#define NPCX_DBGFRZEN3_GLBL_FRZ_DIS	7
+#define NPCX_DBGFRZEN3_ITIM3FEN		6
+#define NPCX_DBGFRZEN3_ITIM2FEN		5
+#define NPCX_DBGFRZEN3_ITIM1FEN		4
+#define NPCX_DBGFRZEN3_I3CFEN		2
+#define NPCX_DBGFRZEN3_SMB4FEN		1
+#define NPCX_DBGFRZEN3_SHMFEN		0
+#define NPCX_DBGFRZEN4_UART2FEN		6
+#define NPCX_DBGFRZEN4_UART3FEN		5
+#define NPCX_DBGFRZEN4_UART4FEN		4
+#define NPCX_DBGFRZEN4_LCTFEN		3
+#define NPCX_DBGFRZEN4_SMB7FEN		2
+#define NPCX_DBGFRZEN4_SMB6FEN		1
+#define NPCX_DBGFRZEN4_SMB5FEN		0
+
+/*
+ * System Configuration (SCFG) device registers
+ */
+struct scfg_reg {
+	/* 0x000: Device Control */
+	volatile uint8_t DEVCNT;
+	/* 0x001: Straps Status */
+	volatile uint8_t STRPST;
+	/* 0x002: Reset Control and Status */
+	volatile uint8_t RSTCTL;
+	/* 0x003: Device control 2 */
+	volatile uint8_t DEV_CTL2;
+	/* 0x004: Device control 3 */
+	volatile uint8_t DEV_CTL3;
+	volatile uint8_t reserved1;
+	/* 0x006: Device Control 4 */
+	volatile uint8_t DEV_CTL4;
+	volatile uint8_t reserved2[9];
+	/* 0x010 - 1F: Device Alternate Function 0 - F */
+	volatile uint8_t DEVALT0[16];
+};
+
+/* Macro functions for SCFG multi-registers */
+#define NPCX_DEV_CTL(base, n) \
+	(*(volatile uint8_t *)(base + n))
+#define NPCX_DEVALT(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_DEVALT_OFFSET(n)))
+#define NPCX_DEVALT_LK(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_DEVALT_LK_OFFSET(n)))
+#define NPCX_PUPD_EN(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_PUPD_EN_OFFSET(n)))
+#define NPCX_LV_GPIO_CTL(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_LV_GPIO_CTL_OFFSET(n)))
+
+/* SCFG register fields */
+#define NPCX_DEVCNT_HIF_TYP_SEL_FIELD         FIELD(2, 2)
+#define NPCX_DEVCNT_JEN0_HEN                  4
+#define NPCX_DEVCNT_JENK_HEN                  5
+#define NPCX_DEVCNT_F_SPI_TRIS                6
+#define NPCX_STRPST_JEN0Z                     1
+#define NPCX_STRPST_TRISTZ_STRAP              2
+#define NPCX_STRPST_JENKZ                     5
+#define NPCX_RSTCTL_VCC1_RST_STS              0
+#define NPCX_RSTCTL_DBGRST_STS                1
+#define NPCX_RSTCTL_LRESET_PLTRST_MODE        5
+#define NPCX_RSTCTL_HIPRST_MODE               6
+#define NPCX_DEV_CTL3_WP_IF                   3
+
+/* Supported host interface type for HIF_TYP_SEL FILED in DEVCNT register. */
+enum npcx_hif_type {
+	NPCX_HIF_TYPE_NONE,
+	NPCX_HIF_TYPE_LPC,
+	NPCX_HIF_TYPE_ESPI_SHI,
+};
+
+/*
+ * System Glue (GLUE) device registers
+ */
+struct glue_reg {
+	volatile uint8_t reserved1[2];
+	/* 0x002: SMBus Start Bit Detection */
+	volatile uint8_t SMB_SBD;
+	/* 0x003: SMBus Event Enable */
+	volatile uint8_t SMB_EEN;
+	volatile uint8_t reserved2[12];
+	/* 0x010: Simple Debug Port Data 0 */
+	volatile uint8_t SDPD0;
+	volatile uint8_t reserved3;
+	/* 0x012: Simple Debug Port Data 1 */
+	volatile uint8_t SDPD1;
+	volatile uint8_t reserved4;
+	/* 0x014: Simple Debug Port Control and Status */
+	volatile uint8_t SDP_CTS;
+	volatile uint8_t reserved5[12];
+	/* 0x021: SMBus Bus Select */
+	volatile uint8_t SMB_SEL;
+	volatile uint8_t reserved6[5];
+	/* 0x027: PSL Control and Status (PSL_CTS2 in NPCK) */
+	volatile uint8_t PSL_CTS;
+	/* 0x028: PSL IN Posetive Edge Status */
+	volatile uint8_t PSL_IN_POS;
+	/* 0x029: PSL IN Negative Edge Status */
+	volatile uint8_t PSL_IN_NEG;
+	/* 0x02a: Voltage Detection Down Threshold */
+	volatile uint8_t VD_THD;
+	/* 0x02b: Voltage Detection Up Threshold */
+	volatile uint8_t VD_THU;
+	/* 0x02c: Voltage Detection Control */
+	volatile uint8_t VD_CTL;
+	/* 0x02d: Voltage Detection Control and Status */
+	volatile uint8_t VD_CTS;
+	volatile uint8_t reserved7[2];
+	/* 0x030: Exteral Power-Up Reset Control */
+	volatile uint8_t EPURST_CTL;
+	volatile uint8_t reserved8[7];
+	/* 0x038: PSL Control and Status 3 */
+	volatile uint8_t PSL_CTS3;
+	/* 0x039: PSL Control and Status 3 */
+	volatile uint8_t PSL_CTS4;
+	/* 0x03a: I3CI maxRd value */
+	volatile uint8_t I3CI_MAXRD;
+};
+
+/*
+ * Universal Asynchronous Receiver-Transmitter (UART) device registers
+ */
+struct uart_reg {
+	/* 0x000: Transmit Data Buffer */
+	volatile uint8_t UTBUF;
+	volatile uint8_t reserved1;
+	/* 0x002: Receive Data Buffer */
+	volatile uint8_t URBUF;
+	volatile uint8_t reserved2;
+	/* 0x004: Interrupt Control */
+	volatile uint8_t UICTRL;
+	volatile uint8_t reserved3;
+	/* 0x006: Status */
+	volatile uint8_t USTAT;
+	volatile uint8_t reserved4;
+	/* 0x008: Frame Select */
+	volatile uint8_t UFRS;
+	volatile uint8_t reserved5;
+	/* 0x00A: Mode Select */
+	volatile uint8_t UMDSL;
+	volatile uint8_t reserved6;
+	/* 0x00C: Baud Rate Divisor */
+	volatile uint8_t UBAUD;
+	volatile uint8_t reserved7;
+	/* 0x00E: Baud Rate Prescaler */
+	volatile uint8_t UPSR;
+	volatile uint8_t reserved8[7];
+	/* 0x16: FIFO Control */
+	volatile uint8_t UFCTRL;
+	volatile uint8_t reserved9;
+	/* 0x18: TX FIFO Current Level */
+	volatile uint8_t UTXFLV;
+	volatile uint8_t reserved10;
+	/* 0x1A: RX FIFO Current Level Byte */
+	volatile uint8_t URXFLV;
+	volatile uint8_t reserved11[12];
+};
+
+/* UART register fields */
+#define NPCX_UICTRL_TBE                       0
+#define NPCX_UICTRL_RBF                       1
+#define NPCX_UICTRL_ETI                       5
+#define NPCX_UICTRL_ERI                       6
+#define NPCX_UICTRL_EEI                       7
+#define NPCX_USTAT_PE                         0
+#define NPCX_USTAT_FE                         1
+#define NPCX_USTAT_DOE                        2
+#define NPCX_USTAT_ERR                        3
+#define NPCX_USTAT_BKD                        4
+#define NPCX_USTAT_RB9                        5
+#define NPCX_USTAT_XMIP                       6
+#define NPCX_UFRS_CHAR_FIELD                  FIELD(0, 2)
+#define NPCX_UFRS_STP                         2
+#define NPCX_UFRS_XB9                         3
+#define NPCX_UFRS_PSEL_FIELD                  FIELD(4, 2)
+#define NPCX_UFRS_PEN                         6
+#define NPCX_UMDSL_FIFO_MD                    0
+#define NPCX_UMDSL_ETD                        4
+#define NPCX_UMDSL_ERD                        5
+
+#define NPCX_UFTSTS_TEMPTY_LVL                FIELD(0, 5)
+#define NPCX_UFTSTS_TEMPTY_LVL_STS            5
+#define NPCX_UFTSTS_TFIFO_EMPTY_STS           6
+#define NPCX_UFTSTS_NXMIP                     7
+#define NPCX_UFRSTS_RFULL_LVL_STS             5
+#define NPCX_UFRSTS_RFIFO_NEMPTY_STS          6
+#define NPCX_UFRSTS_ERR                       7
+#define NPCX_UFTCTL_TEMPTY_LVL_SEL            FIELD(0, 5)
+#define NPCX_UFTCTL_TEMPTY_LVL_EN             5
+#define NPCX_UFTCTL_TEMPTY_EN                 6
+#define NPCX_UFTCTL_NXMIP_EN                  7
+#define NPCX_UFRCTL_RFULL_LVL_SEL             FIELD(0, 5)
+#define NPCX_UFRCTL_RFULL_LVL_EN              5
+#define NPCX_UFRCTL_RNEMPTY_EN                6
+#define NPCX_UFRCTL_ERR_EN                    7
+
+/* Macro functions for MIWU multi-registers */
+#define NPCX_WKEDG(base, group) \
+	(*(volatile uint8_t *)(base +  NPCX_WKEDG_OFFSET(group)))
+#define NPCX_WKAEDG(base, group) \
+	(*(volatile uint8_t *)(base + NPCX_WKAEDG_OFFSET(group)))
+#define NPCX_WKPND(base, group) \
+	(*(volatile uint8_t *)(base + NPCX_WKPND_OFFSET(group)))
+#define NPCX_WKPCL(base, group) \
+	(*(volatile uint8_t *)(base + NPCX_WKPCL_OFFSET(group)))
+#define NPCX_WKEN(base, group) \
+	(*(volatile uint8_t *)(base + NPCX_WKEN_OFFSET(group)))
+#define NPCX_WKINEN(base, group) \
+	(*(volatile uint8_t *)(base + NPCX_WKINEN_OFFSET(group)))
+#define NPCX_WKMOD(base, group) \
+	(*(volatile uint8_t *)(base + NPCX_WKMOD_OFFSET(group)))
+#define NPCX_WKST(base, group) \
+	(*(volatile uint8_t *)(base + NPCX_WKST_OFFSET(group)))
+
+/*
+ * General-Purpose I/O (GPIO) device registers
+ */
+struct gpio_reg {
+	/* 0x000: Port GPIOx Data Out */
+	volatile uint8_t PDOUT;
+	/* 0x001: Port GPIOx Data In */
+	volatile uint8_t PDIN;
+	/* 0x002: Port GPIOx Direction */
+	volatile uint8_t PDIR;
+	/* 0x003: Port GPIOx Pull-Up or Pull-Down Enable */
+	volatile uint8_t PPULL;
+	/* 0x004: Port GPIOx Pull-Up/Down Selection */
+	volatile uint8_t PPUD;
+	/* 0x005: Port GPIOx Drive Enable by VDD Present */
+	volatile uint8_t reserved1;
+	/* 0x006: Port GPIOx Output Type */
+	volatile uint8_t PTYPE;
+	/* 0x007: Port GPIOx Lock Control */
+	volatile uint8_t reserved2;
+};
+
+/*
+ * Pulse Width Modulator (PWM) device registers
+ */
+struct pwm_reg {
+	union {
+		/* Bank 0 */
+		struct {
+			/* 0x000: Clock Prescaler */
+			volatile uint16_t PRSC;
+			/* 0x002: Cycle Time */
+			volatile uint16_t CTR;
+			/* 0x004: PWM Control */
+			volatile uint8_t PWMCTL;
+			volatile uint8_t reserved1;
+			/* 0x006: Duty Cycle */
+			volatile uint16_t DCR;
+			volatile uint8_t reserved2[4];
+			/* 0x00C: PWM Control Extended */
+			volatile uint8_t PWMCTLEX;
+			volatile uint8_t reserved3;
+		};
+		/* Bank 1 */
+		struct {
+			/* 0x000: PRSC, already defined in Bank 0 */
+			volatile uint16_t reserved01;
+			/* 0x002: Cycle Time for Rise Duty Cycle */
+			volatile uint16_t CTR_RS;
+			/* 0x004: PWMCTL, already defined in Bank 0 */
+			volatile uint8_t reserved02;
+			/* 0x005: Number of Steps for Rise Duty Cycle */
+			volatile uint8_t N_STEP_RS;
+			/* 0x006: Max Duty Cycle Rise */
+			volatile uint16_t MAX_DC_RS;
+			/* 0x008: Cycle Time for Fail Duty Cycle */
+			volatile uint16_t CTR_FL;
+			/* 0x00A: Max Duty Cycle Fail */
+			volatile uint16_t MAX_DC_FL;
+			/* 0x00C: PWMCTLEX, already defined in Bank 0 */
+			volatile uint8_t reserved03;
+			/* 0x00D: Number of Steps for Fail Duty Cycle */
+			volatile uint8_t N_STEP_FL;
+			/* 0x00E: Extended ON Time */
+			volatile uint8_t EXT_ON;
+			/* 0x00F: Extended OFF Time */
+			volatile uint8_t EXT_OFF;
+			/* 0x010: Minimum Duty Cycle Rise/Fail */
+			volatile uint16_t MIN_DC_RSFL;
+		};
+	};
+};
+
+/* PWM register fields */
+#define NPCX_PWMCTL_INVP                      0
+#define NPCX_PWMCTL_CKSEL                     1
+#define NPCX_PWMCTL_HB_DC_CTL_FIELD           FIELD(2, 2)
+#define NPCX_PWMCTL_PWR                       7
+#define NPCX_PWMCTLEX_FCK_SEL_FIELD           FIELD(4, 2)
+#define NPCX_PWMCTLEX_OD_OUT                  7
+
+/*
+ * Analog-To-Digital Converter (ADC) device registers
+ */
+struct adc_reg {
+	/* 0x000: ADC Status */
+	volatile uint16_t ADCSTS;
+	/* 0x002: ADC Configuration */
+	volatile uint16_t ADCCNF;
+	/* 0x004: ADC Timing Control */
+	volatile uint16_t ATCTL;
+	/* 0x006: ADC Single Channel Address */
+	volatile uint16_t ASCADD;
+	/* 0x008: ADC Scan Channels Select */
+	volatile uint16_t ADCCS;
+	volatile uint8_t reserved1[16];
+	/* 0x01A:  Threshold Status */
+	volatile uint16_t THRCTS;
+	volatile uint8_t reserved2[4];
+	/* 0x020: Internal register 1 for ADC Speed */
+	volatile uint16_t ADCCNF2;
+	/* 0x022: Internal register 2 for ADC Speed */
+	volatile uint16_t GENDLY;
+	volatile uint8_t reserved3[2];
+	/* 0x026: Internal register 3 for ADC Speed */
+	volatile uint16_t MEAST;
+	/* 0x028 */
+	volatile uint8_t reserved4[216];
+	/* 0x100: ADC voltage to temperature control */
+	volatile uint16_t V2T_CTRL;
+	/* 0x102:  ADC voltage to temperature channel enable */
+	volatile uint16_t TEMP_CH;
+	/* 0x104 */
+	volatile uint16_t reserved5;
+	/* 0x106: ADC over temperature status */
+	volatile uint16_t OVS_STS;
+};
+
+/* ADC internal inline functions for multi-registers */
+#define CHNDAT(base, ch) \
+	(*(volatile uint16_t *)((base) + NPCX_CHNDAT_OFFSET(ch)))
+#define THRCTL(base, ctrl) \
+	(*(volatile uint16_t *)(base + NPCX_THRCTL_OFFSET(ctrl)))
+
+/* ADC-V2T internal inline functions for multi-registers */
+#define TCHNDAT(base, ch) \
+	(*(volatile uint16_t *)((base) + NPCX_TCHNDAT_OFFSET(ch)))
+#define TEMP_THRCTL(base, ctrl) \
+	(*(volatile uint16_t *)(base + NPCX_TEMP_THRCTL_OFFSET(ctrl)))
+#define TEMP_THR_DCTL(base, ctrl) \
+	(*(volatile uint16_t *)(base + NPCX_TEMP_THR_DCTL_OFFSET(ctrl)))
+
+/* ADC register fields */
+#define NPCX_ATCTL_SCLKDIV_FIELD              FIELD(0, 6)
+#define NPCX_ATCTL_DLY_FIELD                  FIELD(8, 3)
+#define NPCX_ASCADD_SADDR_FIELD               FIELD(0, 5)
+#define NPCX_ADCSTS_EOCEV                     0
+#define NPCX_ADCSTS_EOCCEV                    1
+#define NPCX_ADCSTS_TEOCEV                    4
+#define NPCX_ADCSTS_TEOCCEV                   5
+#define NPCX_ADCCNF_ADCEN                     0
+#define NPCX_ADCCNF_ADCMD_FIELD               FIELD(1, 2)
+#define NPCX_ADCCNF_ADCRPTC                   3
+#define NPCX_ADCCNF_START                     4
+#define NPCX_ADCCNF_ADCTTE                    5
+#define NPCX_ADCCNF_INTECEN                   6
+#define NPCX_ADCCNF_INTECCEN                  7
+#define NPCX_ADCCNF_INTETCEN                  8
+#define NPCX_ADCCNF_INTOVFEN                  9
+#define NPCX_ADCCNF_STOP                      11
+#define NPCX_CHNDAT_CHDAT_FIELD               FIELD(0, 10)
+#define NPCX_CHNDAT_NEW                       15
+#define NPCX_THRCTS_ADC_WKEN                  15
+#define NPCX_THRCTS_THR3_IEN                  10
+#define NPCX_THRCTS_THR2_IEN                  9
+#define NPCX_THRCTS_THR1_IEN                  8
+#define NPCX_THRCTS_ADC_EVENT                 7
+#define NPCX_THRCTS_THR3_STS                  2
+#define NPCX_THRCTS_THR2_STS                  1
+#define NPCX_THRCTS_THR1_STS                  0
+#define NPCX_THR_DCTL_THRD_EN                 15
+#define NPCX_THR_DCTL_THR_DVAL                FIELD(0, 10)
+#define NPCX_V2T_CTRL_TEMP_EN                 0
+#define NPCX_V2T_CTRL_OVT_EN                  1
+#define NPCX_V2T_CTRL_TINTC_EN                2
+#define NPCX_V2T_CTRL_TINTCC_EN               3
+#define NPCX_V2T_CTRL_TINTT_EN                4
+#define NPCX_V2T_CTRL_TINTO_EN                5
+#define NPCX_V2T_CTRL_OVT_MODE                6
+#define NPCX_V2T_TCHNDAT_DAT_FRACION       FIELD(0, 3)
+#define NPCX_V2T_TCHNDAT_DAT               FIELD(3, 8)
+#define NPCX_V2T_TCHNDAT_DAT_FULL          FIELD(0, 11) /* Data(8 bit) + Fraction (3 bit) */
+
+/*
+ * Timer Watchdog (TWD) device registers
+ */
+struct twd_reg {
+	/* 0x000: Timer and Watchdog Configuration */
+	volatile uint8_t TWCFG;
+	volatile uint8_t reserved1;
+	/* 0x002: Timer and Watchdog Clock Prescaler */
+	volatile uint8_t TWCP;
+	volatile uint8_t reserved2;
+	/* 0x004: TWD Timer 0 */
+	volatile uint16_t TWDT0;
+	/* 0x006: TWDT0 Control and Status */
+	volatile uint8_t T0CSR;
+	volatile uint8_t reserved3;
+	/* 0x008: Watchdog Count */
+	volatile uint8_t WDCNT;
+	volatile uint8_t reserved4;
+	/* 0x00A: Watchdog Service Data Match */
+	volatile uint8_t WDSDM;
+	volatile uint8_t reserved5;
+	/* 0x00C: TWD Timer 0 Counter */
+	volatile uint16_t TWMT0;
+	/* 0x00E: Watchdog Counter */
+	volatile uint8_t TWMWD;
+	volatile uint8_t reserved6;
+	/* 0x010: Watchdog Clock Prescaler */
+	volatile uint8_t WDCP;
+	volatile uint8_t reserved7;
+};
+
+/* TWD register fields */
+#define NPCX_TWCFG_LTWCFG                      0
+#define NPCX_TWCFG_LTWCP                       1
+#define NPCX_TWCFG_LTWDT0                      2
+#define NPCX_TWCFG_LWDCNT                      3
+#define NPCX_TWCFG_WDCT0I                      4
+#define NPCX_TWCFG_WDSDME                      5
+#define NPCX_T0CSR_RST                         0
+#define NPCX_T0CSR_TC                          1
+#define NPCX_T0CSR_WDLTD                       3
+#define NPCX_T0CSR_WDRST_STS                   4
+#define NPCX_T0CSR_WD_RUN                      5
+#define NPCX_T0CSR_TESDIS                      7
+
+/*
+ * Enhanced Serial Peripheral Interface (eSPI) device registers
+ */
+struct espi_reg {
+	/* 0x000: eSPI Identification */
+	volatile uint32_t ESPIID;
+	/* 0x004: eSPI Configuration */
+	volatile uint32_t ESPICFG;
+	/* 0x008: eSPI Status */
+	volatile uint32_t ESPISTS;
+	/* 0x00C: eSPI Interrupt Enable */
+	volatile uint32_t ESPIIE;
+	/* 0x010: eSPI Wake-Up Enable */
+	volatile uint32_t ESPIWE;
+	/* 0x014: Virtual Wire Register Index */
+	volatile uint32_t VWREGIDX;
+	/* 0x018: Virtual Wire Register Data */
+	volatile uint32_t VWREGDATA;
+	/* 0x01C: OOB Receive Buffer Read Head */
+	volatile uint32_t OOBRXRDHEAD;
+	/* 0x020: OOB Transmit Buffer Write Head */
+	volatile uint32_t OOBTXWRHEAD;
+	/* 0x024: OOB Channel Control */
+	volatile uint32_t OOBCTL;
+	/* 0x028: Flash Receive Buffer Read Head */
+	volatile uint32_t FLASHRXRDHEAD;
+	/* 0x02C: Flash Transmit Buffer Write Head */
+	volatile uint32_t FLASHTXWRHEAD;
+	volatile uint32_t reserved1;
+	/* 0x034: Flash Channel Configuration */
+	volatile uint32_t FLASHCFG;
+	/* 0x038: Flash Channel Control */
+	volatile uint32_t FLASHCTL;
+	/* 0x03C: eSPI Error Status */
+	volatile uint32_t ESPIERR;
+	/* 0x040: Peripheral Bus Master Receive Buffer Read Head */
+	volatile uint32_t PBMRXRDHEAD;
+	/* 0x044: Peripheral Bus Master Transmit Buffer Write Head */
+	volatile uint32_t PBMTXWRHEAD;
+	/* 0x048: Peripheral Channel Configuration */
+	volatile uint32_t PERCFG;
+	/* 0x04C: Peripheral Channel Control */
+	volatile uint32_t PERCTL;
+	/* 0x050: Status Image Register */
+	volatile uint16_t STATUS_IMG;
+	volatile uint16_t reserved2[79];
+	/* 0x0F0: NPCX specific eSPI Register1 */
+	volatile uint8_t NPCX_ONLY_ESPI_REG1;
+	/* 0x0F1: NPCX specific eSPI Register2 */
+	volatile uint8_t NPCX_ONLY_ESPI_REG2;
+	volatile uint16_t reserved3[7];
+	/* 0x100 - 127: Virtual Wire Event Slave-to-Master 0 - 9 */
+	volatile uint32_t VWEVSM[10];
+	volatile uint32_t reserved4[6];
+	/* 0x140 - 16F: Virtual Wire Event Master-to-Slave 0 - 11 */
+	volatile uint32_t VWEVMS[12];
+	volatile uint32_t reserved5[4];
+	/* 0x180 - 1BF: Virtual Wire GPIO Event Master-to-Slave 0 - 15 */
+	volatile uint32_t VWGPSM[16];
+	volatile uint32_t reserved6_1[16];
+	/* 0x200: Virtual Wire Event Master-to-Slave Status */
+	volatile uint32_t VWEVMSSTS;
+	volatile uint32_t reserved6_2;
+	/* 0x208: Virtual Wire Event Slave-to-Master Type */
+	volatile uint32_t VWEVSMTYPE;
+	volatile uint32_t reserved6_3[60];
+	/* 0x2FC: Virtual Wire Channel Control */
+	volatile uint32_t VWCTL;
+	/* 0x300 - 34F: OOB Receive Buffer 0 - 19 */
+	volatile uint32_t OOBRXBUF[20];
+	volatile uint32_t reserved7[12];
+	/* 0x380 - 3CF: OOB Transmit Buffer 0-19 */
+	volatile uint32_t OOBTXBUF[20];
+	volatile uint32_t reserved8[11];
+	/* 0x3FC: OOB Channel Control used in 'direct' mode */
+	volatile uint32_t OOBCTL_DIRECT;
+	/* 0x400 - 447: Flash Receive Buffer 0-17 */
+	volatile uint32_t FLASHRXBUF[18];
+	volatile uint32_t reserved9[14];
+	/* 0x480 - 4C7: Flash Transmit Buffer 0-16 */
+	volatile uint32_t FLASHTXBUF[18];
+	volatile uint32_t reserved10[6];
+	/* 0x4E0 */
+	volatile uint32_t FLASHCFG2;
+	/* 0x4E4 */
+	volatile uint32_t FLASHCFG3;
+	/* 0x4E8 */
+	volatile uint32_t FLASHCFG4;
+	volatile uint32_t reserved11;
+	/* 0x4F0 */
+	volatile uint32_t FLASHBASE;
+	volatile uint32_t reserved12[2];
+	/* 0x4FC */
+	volatile uint32_t FLASHCTL_DIRECT;
+	volatile uint32_t reserved13[64];
+	/* 0x600 - 64F */
+	volatile uint32_t FLASH_PRTR_BADDR[20];
+	/* 0x650 - 69F */
+	volatile uint32_t FLASH_PRTR_HADDR[20];
+	/* 0x6A0 - 6EF */
+	volatile uint32_t FLASH_RGN_TAG_OVR[20];
+	volatile uint32_t reserved14[132];
+};
+
+/* eSPI register fields */
+#define NPCX_ESPICFG_PCHANEN             0
+#define NPCX_ESPICFG_VWCHANEN            1
+#define NPCX_ESPICFG_OOBCHANEN           2
+#define NPCX_ESPICFG_FLASHCHANEN         3
+#define NPCX_ESPICFG_HPCHANEN            4
+#define NPCX_ESPICFG_HVWCHANEN           5
+#define NPCX_ESPICFG_HOOBCHANEN          6
+#define NPCX_ESPICFG_HFLASHCHANEN        7
+#define NPCX_ESPICFG_CHANS_FIELD         FIELD(0, 4)
+#define NPCX_ESPICFG_HCHANS_FIELD        FIELD(4, 4)
+#define NPCX_ESPICFG_IOMODE_FIELD        FIELD(8, 2)
+#define NPCX_ESPICFG_MAXFREQ_FIELD       FIELD(10, 3)
+#define NPCX_ESPICFG_FLCHANMODE          16
+#define NPCX_ESPICFG_PCCHN_SUPP          24
+#define NPCX_ESPICFG_VWCHN_SUPP          25
+#define NPCX_ESPICFG_OOBCHN_SUPP         26
+#define NPCX_ESPICFG_FLASHCHN_SUPP       27
+#define NPCX_ESPIIE_IBRSTIE              0
+#define NPCX_ESPIIE_CFGUPDIE             1
+#define NPCX_ESPIIE_BERRIE               2
+#define NPCX_ESPIIE_OOBRXIE              3
+#define NPCX_ESPIIE_FLASHRXIE            4
+#define NPCX_ESPIIE_FLNACSIE             5
+#define NPCX_ESPIIE_PERACCIE             6
+#define NPCX_ESPIIE_DFRDIE               7
+#define NPCX_ESPIIE_VWUPDIE              8
+#define NPCX_ESPIIE_ESPIRSTIE            9
+#define NPCX_ESPIIE_PLTRSTIE             10
+#define NPCX_ESPIIE_AMERRIE              15
+#define NPCX_ESPIIE_AMDONEIE             16
+#define NPCX_ESPIIE_BMTXDONEIE           19
+#define NPCX_ESPIIE_PBMRXIE              20
+#define NPCX_ESPIIE_PMSGRXIE             21
+#define NPCX_ESPIIE_BMBURSTERRIE         22
+#define NPCX_ESPIIE_BMBURSTDONEIE        23
+#define NPCX_ESPIWE_IBRSTWE              0
+#define NPCX_ESPIWE_CFGUPDWE             1
+#define NPCX_ESPIWE_BERRWE               2
+#define NPCX_ESPIWE_OOBRXWE              3
+#define NPCX_ESPIWE_FLASHRXWE            4
+#define NPCX_ESPIWE_FLNACSWE             5
+#define NPCX_ESPIWE_PERACCWE             6
+#define NPCX_ESPIWE_DFRDWE               7
+#define NPCX_ESPIWE_VWUPDWE              8
+#define NPCX_ESPIWE_ESPIRSTWE            9
+#define NPCX_ESPIWE_PBMRXWE              20
+#define NPCX_ESPIWE_PMSGRXWE             21
+#define NPCX_ESPISTS_IBRST               0
+#define NPCX_ESPISTS_CFGUPD              1
+#define NPCX_ESPISTS_BERR                2
+#define NPCX_ESPISTS_OOBRX               3
+#define NPCX_ESPISTS_FLASHRX             4
+#define NPCX_ESPISTS_FLNACS              5
+#define NPCX_ESPISTS_PERACC              6
+#define NPCX_ESPISTS_DFRD                7
+#define NPCX_ESPISTS_VWUPD               8
+#define NPCX_ESPISTS_ESPIRST             9
+#define NPCX_ESPISTS_PLTRST              10
+#define NPCX_ESPISTS_AMERR               15
+#define NPCX_ESPISTS_AMDONE              16
+#define NPCX_ESPISTS_VWUPDW              27
+#define NPCX_ESPISTS_BMTXDONE            19
+#define NPCX_ESPISTS_PBMRX               20
+#define NPCX_ESPISTS_PMSGRX              21
+#define NPCX_ESPISTS_BMBURSTERR          22
+#define NPCX_ESPISTS_BMBURSTDONE         23
+#define NPCX_VWSWIRQ_IRQ_NUM             FIELD(0, 7)
+#define NPCX_VWSWIRQ_IRQ_LVL             7
+#define NPCX_VWSWIRQ_INDEX               FIELD(8, 7)
+#define NPCX_VWSWIRQ_INDEX_EN            15
+#define NPCX_VWSWIRQ_DIRTY               16
+#define NPCX_VWSWIRQ_ENPLTRST            17
+#define NPCX_VWSWIRQ_ENCDRST             19
+#define NPCX_VWSWIRQ_EDGE_IRQ            28
+#define NPCX_VWEVMS_WIRE                 FIELD(0, 4)
+#define NPCX_VWEVMS_VALID                FIELD(4, 4)
+#define NPCX_VWEVMS_IE                   18
+#define NPCX_VWEVMS_WE                   20
+#define NPCX_VWEVSM_WIRE                 FIELD(0, 4)
+#define NPCX_VWEVSM_VALID                FIELD(4, 4)
+#define NPCX_VWEVSM_BIT_VALID(n)         (4+n)
+#define NPCX_VWEVSM_HW_WIRE              FIELD(24, 4)
+#define NPCX_VWGPSM_INDEX_EN             15
+#define NPCX_OOBCTL_OOB_FREE             0
+#define NPCX_OOBCTL_OOB_AVAIL            1
+#define NPCX_OOBCTL_RSTBUFHEADS          2
+#define NPCX_OOBCTL_OOBPLSIZE            FIELD(10, 3)
+#define NPCX_FLASHCFG_FLASHBLERSSIZE     FIELD(7, 3)
+#define NPCX_FLASHCFG_FLASHPLSIZE        FIELD(10, 3)
+#define NPCX_FLASHCFG_FLASHREQSIZE       FIELD(13, 3)
+#define NPCX_FLASHCFG_FLCAPA             FIELD(16, 2)
+#define NPCX_FLASHCFG_TRGFLEBLKSIZE      FIELD(18, 8)
+#define NPCX_FLASHCFG_FLREQSUP           FIELD(0, 3)
+#define NPCX_FLASHCTL_FLASH_NP_FREE      0
+#define NPCX_FLASHCTL_FLASH_TX_AVAIL     1
+#define NPCX_FLASHCTL_STRPHDR            2
+#define NPCX_FLASHCTL_DMATHRESH          FIELD(3, 2)
+#define NPCX_FLASHCTL_AMTSIZE            FIELD(5, 8)
+#define NPCX_FLASHCTL_RSTBUFHEADS        13
+#define NPCX_FLASHCTL_CRCEN              14
+#define NPCX_FLASHCTL_CHKSUMSEL          15
+#define NPCX_FLASHCTL_AMTEN              16
+#define NPCX_FLASHCTL_SAF_AUTO_READ      18
+#define NPCX_FLASHCTL_SAF_PROT_LOCK      19
+#define NPCX_FRGN_WPR                    31
+#define NPCX_FRGN_RPR                    30
+#define NPCX_FLASHBASE_FLBASE_ADDR       FIELD(16, 11)
+#define NPCX_FLASH_PRTR_BADDR            FIELD(12, 17)
+#define NPCX_FLASH_PRTR_HADDR            FIELD(12, 17)
+#define NPCX_FLASH_TAG_OVR_RPR           FIELD(16, 16)
+#define NPCX_FLASH_TAG_OVR_WPR           FIELD(0, 16)
+#define NPCX_ONLY_ESPI_REG1_UNLOCK_REG2         0x55
+#define NPCX_ONLY_ESPI_REG1_LOCK_REG2           0
+#define NPCX_ONLY_ESPI_REG2_TRANS_END_CONFIG    4
+
+/*
+ * Mobile System Wake-Up Control (MSWC) device registers
+ */
+struct mswc_reg {
+	/* 0x000: MSWC Control Status 1 */
+	volatile uint8_t MSWCTL1;
+	volatile uint8_t reserved1;
+	/* 0x002: MSWC Control Status 2 */
+	volatile uint8_t MSWCTL2;
+	volatile uint8_t reserved2[5];
+	/* 0x008: Host Configuration Base Address Low */
+	volatile uint8_t HCBAL;
+	volatile uint8_t reserved3;
+	/* 0x00A: Host Configuration Base Address High */
+	volatile uint8_t HCBAH;
+	volatile uint8_t reserved4;
+	/* 0X00C: MSWC INTERRUPT ENABLE 2 */
+	volatile uint8_t MSIEN2;
+	volatile uint8_t reserved5;
+	/* 0x00E: MSWC Host Event Status 0 */
+	volatile uint8_t MSHES0;
+	volatile uint8_t reserved6;
+	/* 0x010: MSWC Host Event Interrupt Enable */
+	volatile uint8_t MSHEIE0;
+	volatile uint8_t reserved7;
+	/* 0x012: Host Control */
+	volatile uint8_t HOST_CTL;
+	volatile uint8_t reserved8;
+	/* 0x014: SMI Pulse Length */
+	volatile uint8_t SMIP_LEN;
+	volatile uint8_t reserved9;
+	/* 0x016: SCI Pulse Length */
+	volatile uint8_t SCIP_LEN;
+	volatile uint8_t reserved10[5];
+	/* 0x01C: SRID Core Access */
+	volatile uint8_t SRID_CR;
+	volatile uint8_t reserved11[3];
+	/* 0x020: SID Core Access */
+	volatile uint8_t SID_CR;
+	volatile uint8_t reserved12;
+	/* 0x022: DEVICE_ID Core Access */
+	volatile uint8_t DEVICE_ID_CR;
+	volatile uint8_t reserved13[5];
+	/* 0x028: Chip Revision Core Access */
+	volatile uint8_t CHPREV_CR;
+	volatile uint8_t reserved14[5];
+	/* 0x02E: Virtual Wire Sleep States */
+	volatile uint8_t VW_SLPST1;
+	volatile uint8_t reserved15;
+};
+
+/* MSWC register fields */
+#define NPCX_MSWCTL1_HRSTOB              0
+#define NPCS_MSWCTL1_HWPRON              1
+#define NPCX_MSWCTL1_PLTRST_ACT          2
+#define NPCX_MSWCTL1_VHCFGA              3
+#define NPCX_MSWCTL1_HCFGLK              4
+#define NPCX_MSWCTL1_PWROFFB             6
+#define NPCX_MSWCTL1_A20MB               7
+
+/*
+ * Shared Memory (SHM) device registers
+ */
+struct shm_reg {
+	/* 0x000: Shared Memory Core Status */
+	volatile uint8_t SMC_STS;
+	/* 0x001: Shared Memory Core Control */
+	volatile uint8_t SMC_CTL;
+	/* 0x002: Shared Memory Host Control */
+	volatile uint8_t SHM_CTL;
+	volatile uint8_t reserved1[2];
+	/* 0x005: Indirect Memory Access Window Size */
+	volatile uint8_t IMA_WIN_SIZE;
+	volatile uint8_t reserved2;
+	/* 0x007: Shared Access Windows Size */
+	volatile uint8_t WIN_SIZE;
+	/* 0x008: Shared Access Window 1, Semaphore */
+	volatile uint8_t SHAW1_SEM;
+	/* 0x009: Shared Access Window 2, Semaphore */
+	volatile uint8_t SHAW2_SEM;
+	volatile uint8_t reserved3;
+	/* 0x00B: Indirect Memory Access, Semaphore */
+	volatile uint8_t IMA_SEM;
+	volatile uint8_t reserved4[2];
+	/* 0x00E: Shared Memory Configuration */
+	volatile uint16_t SHCFG;
+	/* 0x010: Shared Access Window 1 Write Protect */
+	volatile uint8_t WIN1_WR_PROT;
+	/* 0x011: Shared Access Window 1 Read Protect */
+	volatile uint8_t WIN1_RD_PROT;
+	/* 0x012: Shared Access Window 2 Write Protect */
+	volatile uint8_t WIN2_WR_PROT;
+	/* 0x013: Shared Access Window 2 Read Protect */
+	volatile uint8_t WIN2_RD_PROT;
+	volatile uint8_t reserved5[2];
+	/* 0x016: Indirect Memory Access Write Protect */
+	volatile uint8_t IMA_WR_PROT;
+	/* 0x017: Indirect Memory Access Read Protect */
+	volatile uint8_t IMA_RD_PROT;
+	volatile uint8_t reserved6[8];
+	/* 0x020: Shared Access Window 1 Base */
+	volatile uint32_t WIN_BASE1;
+	/* 0x024: Shared Access Window 2 Base */
+	volatile uint32_t WIN_BASE2;
+	volatile uint32_t reserved7;
+	/* 0x02C: Indirect Memory Access Base */
+	volatile uint32_t IMA_BASE;
+	volatile uint8_t reserved8[10];
+	/* 0x03A: Reset Configuration */
+	volatile uint8_t RST_CFG;
+	volatile uint8_t reserved9;
+	/* 0x03B: Debug Port 80 Buffered Data 1 */
+	volatile uint32_t DP80BUF1;
+	/* 0x040: Debug Port 80 Buffered Data */
+	volatile uint16_t DP80BUF;
+	/* 0x042: Debug Port 80 Status */
+	volatile uint8_t DP80STS;
+	volatile uint8_t reserved10;
+	/* 0x044: Debug Port 80 Control */
+	volatile uint8_t DP80CTL;
+	volatile uint8_t reserved11[3];
+	/* 0x048: Host_Offset in Windows 1, 2 Status */
+	volatile uint8_t HOFS_STS;
+	/* 0x049: Host_Offset in Windows 1, 2 Control */
+	volatile uint8_t HOFS_CTL;
+	/* 0x04A: Core_Offset in Window 2 Address */
+	volatile uint16_t COFS2;
+	/* 0x04C: Core_Offset in Window 1 Address */
+	volatile uint16_t COFS1;
+	/* 0x04E: Shared Memory Host Control 2 */
+	volatile uint8_t SHM_CTL2;
+	volatile uint8_t reserved12[5];
+	/* 0x054: Shared Access Window 1, Semaphore */
+	volatile uint8_t SHAW3_SEM;
+	/* 0x055: Shared Access Window 1, Semaphore */
+	volatile uint8_t SHAW4_SEM;
+	/* 0x056: Shared Access Window 3 Write Protect */
+	volatile uint8_t WIN3_WR_PROT;
+	/* 0x057: Shared Access Window 3 Read Protect */
+	volatile uint8_t WIN3_RD_PROT;
+	/* 0x058: Shared Access Window 4 Write Protect */
+	volatile uint8_t WIN4_WR_PROT;
+	/* 0x059: Shared Access Window 4 Read Protect */
+	volatile uint8_t WIN4_RD_PROT;
+	/* 0x05A: Shared Access Windows Size 2 */
+	volatile uint8_t WIN_SIZE2;
+	/* 0x05C: Shared Access Window 3 Base */
+	volatile uint32_t WIN_BASE3;
+	/* 0x060: Shared Access Window 4 Base */
+	volatile uint32_t WIN_BASE4;
+	/* 0x064: Core_Offset in Window 3 Address */
+	volatile uint16_t COFS3;
+	/* 0x066: Core_Offset in Window 4 Address */
+	volatile uint16_t COFS4;
+	volatile uint8_t reserved13[4];
+	/* 0x06C: Shared Memory Core Status 2 */
+	volatile uint8_t SMC_STS2;
+	/* 0x06D: Indirect Memory Access 2, Semaphore */
+	volatile uint8_t IMA2_SEM;
+	/* 0x06E: Indirect Memory Access 2, Write Protect */
+	volatile uint8_t IMA2_WR_PROT;
+	/* 0x06F: Indirect Memory Access 2, Read Protect */
+	volatile uint8_t IMA2_RD_PROT;
+	/* 0x070: Indirect Memory Access 2 Base */
+	volatile uint32_t IMA2_BASE;
+	/* 0x074: Additional Indirect Memory Access, Semaphore */
+	volatile uint8_t AIMA_SEM;
+	/* 0x075: Host_Offset in Windows 5 Status */
+	volatile uint8_t HOFS_STS2;
+	/* 0x076: Host_Offset in Windows 5 Control */
+	volatile uint8_t HOFS_CTL2;
+	volatile uint8_t reserved14[1];
+	/* 0x078: Additional Indirect Memory Access Base */
+	volatile uint32_t AIMA_BASE;
+	/* 0x07C: Core_Offset in Window 5 Address */
+	volatile uint16_t COFS5;
+	volatile uint8_t reserved15[2];
+	/* 0x080: Shared Access Window 5 Write Protect */
+	volatile uint8_t WIN5_WR_PROT;
+	/* 0x081: Shared Access Window 5 Read Protect */
+	volatile uint8_t WIN5_RD_PROT;
+	/* 0x082: Shared Access Window 5, Semaphore */
+	volatile uint8_t SHAW5_SEM;
+	/* 0x083: Shared Access Windows Size 3 */
+	volatile uint8_t WIN_SIZE3;
+	/* 0x084: Shared Access Window 5 Base */
+	volatile uint32_t WIN_BASE5;
+};
+
+/* SHM register fields */
+#define NPCX_SMC_STS_HRERR               0
+#define NPCX_SMC_STS_HWERR               1
+#define NPCX_SMC_STS_HSEM1W              4
+#define NPCX_SMC_STS_HSEM2W              5
+#define NPCX_SMC_STS_SHM_ACC             6
+#define NPCX_SMC_CTL_HERR_IE             2
+#define NPCX_SMC_CTL_HSEM1_IE            3
+#define NPCX_SMC_CTL_HSEM2_IE            4
+#define NPCX_SMC_CTL_ACC_IE              5
+#define NPCX_SMC_CTL_PREF_EN             6
+#define NPCX_SMC_CTL_HOSTWAIT            7
+#define NPCX_FLASH_SIZE_STALL_HOST       6
+#define NPCX_FLASH_SIZE_RD_BURST         7
+#define NPCX_WIN_SIZE_RWIN1_SIZE_FIELD   FIELD(0, 4)
+#define NPCX_WIN_SIZE_RWIN2_SIZE_FIELD   FIELD(4, 4)
+#define NPCX_WIN_SIZE_RWIN3_SIZE_FIELD   FIELD(0, 4)
+#define NPCX_WIN_SIZE_RWIN4_SIZE_FIELD   FIELD(4, 4)
+#define NPCX_WIN_PROT_RW1L_RP            0
+#define NPCX_WIN_PROT_RW1L_WP            1
+#define NPCX_WIN_PROT_RW1H_RP            2
+#define NPCX_WIN_PROT_RW1H_WP            3
+#define NPCX_WIN_PROT_RW2L_RP            4
+#define NPCX_WIN_PROT_RW2L_WP            5
+#define NPCX_WIN_PROT_RW2H_RP            6
+#define NPCX_WIN_PROT_RW2H_WP            7
+#define NPCX_PWIN_SIZEI_RPROT            13
+#define NPCX_PWIN_SIZEI_WPROT            14
+#define NPCX_CSEM2                       6
+#define NPCX_CSEM3                       7
+#define NPCX_DP80STS_FWR                 5
+#define NPCX_DP80STS_FNE                 6
+#define NPCX_DP80STS_FOR                 7
+#define NPCX_DP80CTL_DP80EN              0
+#define NPCX_DP80CTL_SYNCEN              1
+#define NPCX_DP80CTL_ADV                 2
+#define NPCX_DP80CTL_RAA                 3
+#define NPCX_DP80CTL_RFIFO               4
+#define NPCX_DP80CTL_CIEN                5
+#define NPCX_DP80CTL_DP80_HF_CFG         7
+#define NPCX_DP80BUF_OFFS_FIELD          FIELD(8, 3)
+#define NPCX_DP80BUF_RNG                 11
+#define NPCX_DP80BUF_BYTE_LEN_FIELD      FIELD(12, 2)
+
+
+/*
+ * Keyboard and Mouse Controller (KBC) device registers
+ */
+struct kbc_reg {
+	/* 0x000h: Host Interface Control */
+	volatile uint8_t HICTRL;
+	volatile uint8_t reserved1;
+	/* 0x002h: Host Interface IRQ Control */
+	volatile uint8_t HIIRQC;
+	volatile uint8_t reserved2;
+	/* 0x004h: Host Interface Keyboard/Mouse Status */
+	volatile uint8_t HIKMST;
+	volatile uint8_t reserved3;
+	/* 0x006h: Host Interface Keyboard Data Out Buffer */
+	volatile uint8_t HIKDO;
+	volatile uint8_t reserved4;
+	/* 0x008h: Host Interface Mouse Data Out Buffer */
+	volatile uint8_t HIMDO;
+	volatile uint8_t reserved5;
+	/* 0x00Ah: Host Interface Keyboard/Mouse Data In Buffer */
+	volatile uint8_t HIKMDI;
+	/* 0x00Bh: Host Interface Keyboard/Mouse Shadow Data In Buffer */
+	volatile uint8_t SHIKMDI;
+};
+
+/* KBC register field */
+#define NPCX_HICTRL_OBFKIE               0
+#define NPCX_HICTRL_OBFMIE               1
+#define NPCX_HICTRL_OBECIE               2
+#define NPCX_HICTRL_IBFCIE               3
+#define NPCX_HICTRL_PMIHIE               4
+#define NPCX_HICTRL_PMIOCIE              5
+#define NPCX_HICTRL_PMICIE               6
+#define NPCX_HICTRL_FW_OBF               7
+#define NPCX_HIKMST_OBF                  0
+#define NPCX_HIKMST_IBF                  1
+#define NPCX_HIKMST_F0                   2
+#define NPCX_HIKMST_A2                   3
+#define NPCX_HIKMST_ST0                  4
+#define NPCX_HIKMST_ST1                  5
+#define NPCX_HIKMST_ST2                  6
+#define NPCX_HIKMST_ST3                  7
+
+/*
+ * Power Management Channel (PMCH) device registers
+ */
+
+struct pmch_reg {
+	/* 0x000: Host Interface PM Status */
+	volatile uint8_t HIPMST;
+	volatile uint8_t reserved1;
+	/* 0x002: Host Interface PM Data Out Buffer */
+	volatile uint8_t HIPMDO;
+	volatile uint8_t reserved2;
+	/* 0x004: Host Interface PM Data In Buffer */
+	volatile uint8_t HIPMDI;
+	/* 0x005: Host Interface PM Shadow Data In Buffer */
+	volatile uint8_t SHIPMDI;
+	/* 0x006: Host Interface PM Data Out Buffer with SCI */
+	volatile uint8_t HIPMDOC;
+	volatile uint8_t reserved3;
+	/* 0x008: Host Interface PM Data Out Buffer with SMI */
+	volatile uint8_t HIPMDOM;
+	volatile uint8_t reserved4;
+	/* 0x00A: Host Interface PM Data In Buffer with SCI */
+	volatile uint8_t HIPMDIC;
+	volatile uint8_t reserved5;
+	/* 0x00C: Host Interface PM Control */
+	volatile uint8_t HIPMCTL;
+	/* 0x00D: Host Interface PM Control 2 */
+	volatile uint8_t HIPMCTL2;
+	/* 0x00E: Host Interface PM Interrupt Control */
+	volatile uint8_t HIPMIC;
+	volatile uint8_t reserved6;
+	/* 0x010: Host Interface PM Interrupt Enable */
+	volatile uint8_t HIPMIE;
+	volatile uint8_t reserved7;
+};
+
+/* PMCH register field */
+#define NPCX_HIPMIE_SCIE                 1
+#define NPCX_HIPMIE_SMIE                 2
+#define NPCX_HIPMCTL_IBFIE               0
+#define NPCX_HIPMCTL_OBEIE               1
+#define NPCX_HIPMCTL_SCIPOL              6
+#define NPCX_HIPMST_OBF                  0
+#define NPCX_HIPMST_IBF                  1
+#define NPCX_HIPMST_F0                   2
+#define NPCX_HIPMST_CMD                  3
+#define NPCX_HIPMST_ST0                  4
+#define NPCX_HIPMST_ST1                  5
+#define NPCX_HIPMST_ST2                  6
+#define NPCX_HIPMIC_SMIB                 1
+#define NPCX_HIPMIC_SCIB                 2
+#define NPCX_HIPMIC_SMIPOL               6
+
+/*
+ * Core Access to Host (C2H) device registers
+ */
+struct c2h_reg {
+	/* 0x000: Indirect Host I/O Address */
+	volatile uint16_t IHIOA;
+	/* 0x002: Indirect Host Data */
+	volatile uint8_t IHD;
+	volatile uint8_t reserved1;
+	/* 0x004: Lock Host Access */
+	volatile uint16_t LKSIOHA;
+	/* 0x006: Access Lock Violation */
+	volatile uint16_t SIOLV;
+	/* 0x008: Core-to-Host Modules Access Enable */
+	volatile uint16_t CRSMAE;
+	/* 0x00A: Module Control */
+	volatile uint8_t SIBCTRL;
+	volatile uint8_t reserved3;
+};
+
+/* C2H register fields */
+#define NPCX_LKSIOHA_LKCFG               0
+#define NPCX_LKSIOHA_LKSPHA              2
+#define NPCX_LKSIOHA_LKHIKBD             11
+#define NPCX_CRSMAE_CFGAE                0
+#define NPCX_CRSMAE_HIKBDAE              11
+#define NPCX_SIOLV_SPLV                  2
+#define NPCX_SIBCTRL_CSAE                0
+#define NPCX_SIBCTRL_CSRD                1
+#define NPCX_SIBCTRL_CSWR                2
+
+/*
+ * SMBUS (SMB) device registers
+ */
+struct smb_reg {
+	/* 0x000: SMB Serial Data */
+	volatile uint8_t SMBSDA;
+	volatile uint8_t reserved1;
+	/* 0x002: SMB Status */
+	volatile uint8_t SMBST;
+	volatile uint8_t reserved2;
+	/* 0x004: SMB Control Status */
+	volatile uint8_t SMBCST;
+	volatile uint8_t reserved3;
+	/* 0x006: SMB Control 1 */
+	volatile uint8_t SMBCTL1;
+	volatile uint8_t reserved4;
+	/* 0x008: SMB Own Address */
+	volatile uint8_t SMBADDR1;
+	volatile uint8_t reserved5;
+	/* 0x00A: SMB Control 2 */
+	volatile uint8_t SMBCTL2;
+	volatile uint8_t reserved6;
+	/* 0x00C: SMB Own Address */
+	volatile uint8_t SMBADDR2;
+	volatile uint8_t reserved7;
+	/* 0x00E: SMB Control 3 */
+	volatile uint8_t SMBCTL3;
+	/* 0x00F: DMA Control */
+	volatile uint8_t DMA_CTRL;
+
+	union {
+		/* Bank 0 */
+		struct {
+			/* 0x010: SMB Own Address 3 */
+			volatile uint8_t SMBADDR3;
+			/* 0x011: SMB Own Address 7 */
+			volatile uint8_t SMBADDR7;
+			/* 0x012: SMB Own Address 4 */
+			volatile uint8_t SMBADDR4;
+			/* 0x013: SMB Own Address 8 */
+			volatile uint8_t SMBADDR8;
+			/* 0x014: SMB Own Address 5 */
+			volatile uint8_t SMBADDR5;
+			volatile uint8_t reserved8;
+			/* 0x016: SMB Own Address 6 */
+			volatile uint8_t SMBADDR6;
+			volatile uint8_t reserved9;
+			/* 0x018: SMB Control Status 2 */
+			volatile uint8_t SMBCST2;
+			/* 0x019: SMB Control Status 3 */
+			volatile uint8_t SMBCST3;
+			/* 0x01A: SMB Control 4 */
+			volatile uint8_t SMBCTL4;
+			volatile uint8_t reserved10;
+			/* 0x01C: SMB SCL Low Time */
+			volatile uint8_t SMBSCLLT;
+			/* 0x01D: SMB FIFO Control */
+			volatile uint8_t SMBFIF_CTL;
+			/* 0x01E: SMB SCL High Time */
+			volatile uint8_t SMBSCLHT;
+			volatile uint8_t reserved11;
+			/* 0x20h DMA Address Byte 1 */
+			volatile uint8_t DMA_ADDR1;
+			/* 0x21h DMA Address Byte 2 */
+			volatile uint8_t DMA_ADDR2;
+			/* 0x22h DMA Address Byte 3 */
+			volatile uint8_t DMA_ADDR3;
+			/* 0x23h DMA Address Byte 4 */
+			volatile uint8_t DMA_ADDR4;
+			/* 0x24h Data Length Byte 1 */
+			volatile uint8_t DATA_LEN1;
+			/* 0x25h Data Length Byte 2 */
+			volatile uint8_t DATA_LEN2;
+			/* 0x26h Data Counter Byte 1 */
+			volatile uint8_t DATA_CNT1;
+			/* 0x27h Data Counter Byte 2 */
+			volatile uint8_t DATA_CNT2;
+			volatile uint8_t reserved18;
+			/* 0x29h Timeout Control 1 Byte */
+			volatile uint8_t TIMEOUT_CTL1;
+			/* 0x2Ah Timeout Control 2 Byte */
+			volatile uint8_t TIMEOUT_CTL2;
+			/* 0x2Bh SMB PEC Data */
+			volatile uint8_t SMBnPEC;
+			volatile uint8_t reserved19[4];
+		};
+		/* Bank 1 */
+		struct {
+			/* 0x010: SMB FIFO Control */
+			volatile uint8_t SMBFIF_CTS;
+			volatile uint8_t reserved12;
+			/* 0x012: SMB Tx-FIFO Control */
+			volatile uint8_t SMBTXF_CTL;
+			volatile uint8_t reserved13;
+			/* 0x014: SMB Bus Timeout */
+			volatile uint8_t SMB_T_OUT;
+			volatile uint8_t reserved14[3];
+			/* 0x018: SMB Control Status 2 (FIFO) */
+			volatile uint8_t SMBCST2_FIFO;
+			/* 0x019: SMB Control Status 3 (FIFO) */
+			volatile uint8_t SMBCST3_FIFO;
+			/* 0x01A: SMB Tx-FIFO Status */
+			volatile uint8_t SMBTXF_STS;
+			volatile uint8_t reserved15;
+			/* 0x01C: SMB Rx-FIFO Status */
+			volatile uint8_t SMBRXF_STS;
+			volatile uint8_t reserved16;
+			/* 0x01E: SMB Rx-FIFO Control */
+			volatile uint8_t SMBRXF_CTL;
+			volatile uint8_t reserved17[1];
+		};
+	};
+};
+
+/* SMB register fields */
+#define NPCX_SMBST_XMIT                  0
+#define NPCX_SMBST_MASTER                1
+#define NPCX_SMBST_NMATCH                2
+#define NPCX_SMBST_STASTR                3
+#define NPCX_SMBST_NEGACK                4
+#define NPCX_SMBST_BER                   5
+#define NPCX_SMBST_SDAST                 6
+#define NPCX_SMBST_SLVSTP                7
+#define NPCX_SMBCST_BUSY                 0
+#define NPCX_SMBCST_BB                   1
+#define NPCX_SMBCST_MATCH                2
+#define NPCX_SMBCST_GCMATCH              3
+#define NPCX_SMBCST_TSDA                 4
+#define NPCX_SMBCST_TGSCL                5
+#define NPCX_SMBCST_MATCHAF              6
+#define NPCX_SMBCST_ARPMATCH             7
+#define NPCX_SMBCST2_MATCHA1F            0
+#define NPCX_SMBCST2_MATCHA2F            1
+#define NPCX_SMBCST2_MATCHA3F            2
+#define NPCX_SMBCST2_MATCHA4F            3
+#define NPCX_SMBCST2_MATCHA5F            4
+#define NPCX_SMBCST2_MATCHA6F            5
+#define NPCX_SMBCST2_MATCHA7F            6
+#define NPCX_SMBCST2_INTSTS              7
+#define NPCX_SMBCST3_MATCHA8F            0
+#define NPCX_SMBCST3_MATCHA9F            1
+#define NPCX_SMBCST3_MATCHA10F           2
+#define NPCX_SMBCTL1_START               0
+#define NPCX_SMBCTL1_STOP                1
+#define NPCX_SMBCTL1_INTEN               2
+#define NPCX_SMBCTL1_ACK                 4
+#define NPCX_SMBCTL1_GCMEN               5
+#define NPCX_SMBCTL1_NMINTE              6
+#define NPCX_SMBCTL1_STASTRE             7
+#define NPCX_SMBCTL2_ENABLE              0
+#define NPCX_SMBCTL2_SCLFRQ0_6_FIELD     FIELD(1, 7)
+#define NPCX_SMBCTL3_ARPMEN              2
+#define NPCX_SMBCTL3_SCLFRQ7_8_FIELD     FIELD(0, 2)
+#define NPCX_SMBCTL3_IDL_START           3
+#define NPCX_SMBCTL3_400K                4
+#define NPCX_SMBCTL3_BNK_SEL             5
+#define NPCX_SMBCTL3_SDA_LVL             6
+#define NPCX_SMBCTL3_SCL_LVL             7
+#define NPCX_SMBCTL4_HLDT_FIELD          FIELD(0, 6)
+#define NPCX_SMBCTL4_LVL_WE              7
+#define NPCX_SMBADDR1_SAEN               7
+#define NPCX_SMBADDR2_SAEN               7
+#define NPCX_SMBADDR3_SAEN               7
+#define NPCX_SMBADDR4_SAEN               7
+#define NPCX_SMBADDR5_SAEN               7
+#define NPCX_SMBADDR6_SAEN               7
+#define NPCX_SMBADDR7_SAEN               7
+#define NPCX_SMBADDR8_SAEN               7
+#define NPCX_SMBSEL_SMB4SEL              4
+#define NPCX_SMBSEL_SMB5SEL              5
+#define NPCX_SMBSEL_SMB6SEL              6
+#define NPCX_SMBFIF_CTS_RXF_TXE          1
+#define NPCX_SMBFIF_CTS_CLR_FIFO         6
+#define NPCX_SMBFIF_CTL_FIFO_EN          4
+#define NPCX_SMBRXF_STS_RX_THST          6
+
+/* DMA_CTRL  register fields */
+#define NPCX_DMA_CTL_INTCLR              0
+#define NPCX_DMA_CTL_ENABLE              1
+#define NPCX_DMA_CTL_LAST_PEC            2
+#define NPCX_DMA_CTL_DMA_STALL           3
+#define NPCX_DMA_CTL_IRQSTS              7
+
+/* RX FIFO threshold */
+#define NPCX_SMBRXF_CTL_RX_THR           FIELD(0, 6)
+#define NPCX_SMBRXF_CTL_LAST             7
+
+/*
+ * Internal 32-bit Timer (ITIM32) device registers
+ */
+struct itim32_reg {
+	volatile uint8_t reserved1;
+	/* 0x001: Internal 32-bit Timer Prescaler */
+	volatile uint8_t ITPRE32;
+	volatile uint8_t reserved2[2];
+	/* 0x004: Internal 32-bit Timer Control and Status */
+	volatile uint8_t ITCTS32;
+	volatile uint8_t reserved3[3];
+	/* 0x008: Internal 32-Bit Timer Counter */
+	volatile uint32_t ITCNT32;
+};
+
+/*
+ * Internal 64-bit Timer (ITIM54) device registers
+ */
+struct itim64_reg {
+	volatile uint8_t reserved1;
+	/* 0x001: Internal 64-bit Timer Prescaler */
+	volatile uint8_t ITPRE64;
+	volatile uint8_t reserved2[2];
+	/* 0x004: Internal 64-bit Timer Control and Status */
+	volatile uint8_t ITCTS64;
+	volatile uint8_t reserved3[3];
+	/* 0x008: Internal 32-Bit Timer Counter */
+	volatile uint32_t ITCNT64L;
+	/* 0x00C: Internal 32-Bit Timer Counter */
+	volatile uint32_t ITCNT64H;
+};
+
+/* ITIM register fields */
+#define NPCX_ITCTSXX_TO_STS              0
+#define NPCX_ITCTSXX_TO_IE               2
+#define NPCX_ITCTSXX_TO_WUE              3
+#define NPCX_ITCTSXX_CKSEL               4
+#define NPCX_ITCTSXX_ITEN                7
+
+/*
+ * Tachometer (TACH) Sensor device registers
+ */
+struct tach_reg {
+	/* 0x000: Timer/Counter 1 */
+	volatile uint16_t TCNT1;
+	/* 0x002: Reload/Capture A */
+	volatile uint16_t TCRA;
+	/* 0x004: Reload/Capture B */
+	volatile uint16_t TCRB;
+	/* 0x006: Timer/Counter 2 */
+	volatile uint16_t TCNT2;
+	/* 0x008: Clock Prescaler */
+	volatile uint8_t TPRSC;
+	volatile uint8_t reserved1;
+	/* 0x00A: Clock Unit Control */
+	volatile uint8_t TCKC;
+	volatile uint8_t reserved2;
+	/* 0x00C: Timer Mode Control */
+	volatile uint8_t TMCTRL;
+	volatile uint8_t reserved3;
+	/* 0x00E: Timer Event Control */
+	volatile uint8_t TECTRL;
+	volatile uint8_t reserved4;
+	/* 0x010: Timer Event Clear */
+	volatile uint8_t TECLR;
+	volatile uint8_t reserved5;
+	/* 0x012: Timer Interrupt Enable */
+	volatile uint8_t TIEN;
+	volatile uint8_t reserved6;
+	/* 0x014: Compare A */
+	volatile uint16_t TCPA;
+	/* 0x016: Compare B */
+	volatile uint16_t TCPB;
+	/* 0x018: Compare Configuration */
+	volatile uint8_t TCPCFG;
+	volatile uint8_t reserved7;
+	/* 0x01A: Timer Wake-Up Enable */
+	volatile uint8_t TWUEN;
+	volatile uint8_t reserved8;
+	/* 0x01C: Timer Configuration */
+	volatile uint8_t TCFG;
+	volatile uint8_t reserved9;
+};
+
+/* TACH register fields */
+#define NPCX_TCKC_LOW_PWR                7
+#define NPCX_TCKC_PLS_ACC_CLK            6
+#define NPCX_TCKC_C1CSEL_FIELD           FIELD(0, 3)
+#define NPCX_TCKC_C2CSEL_FIELD           FIELD(3, 3)
+#define NPCX_TMCTRL_MDSEL_FIELD          FIELD(0, 3)
+#define NPCX_TMCTRL_TAEN                 5
+#define NPCX_TMCTRL_TBEN                 6
+#define NPCX_TMCTRL_TAEDG                3
+#define NPCX_TMCTRL_TBEDG                4
+#define NPCX_TCFG_TADBEN                 6
+#define NPCX_TCFG_TBDBEN                 7
+#define NPCX_TECTRL_TAPND                0
+#define NPCX_TECTRL_TBPND                1
+#define NPCX_TECTRL_TCPND                2
+#define NPCX_TECTRL_TDPND                3
+#define NPCX_TECLR_TACLR                 0
+#define NPCX_TECLR_TBCLR                 1
+#define NPCX_TECLR_TCCLR                 2
+#define NPCX_TECLR_TDCLR                 3
+#define NPCX_TIEN_TAIEN                  0
+#define NPCX_TIEN_TBIEN                  1
+#define NPCX_TIEN_TCIEN                  2
+#define NPCX_TIEN_TDIEN                  3
+#define NPCX_TWUEN_TAWEN                 0
+#define NPCX_TWUEN_TBWEN                 1
+#define NPCX_TWUEN_TCWEN                 2
+#define NPCX_TWUEN_TDWEN                 3
+
+/* Debug Interface registers fields */
+#define NPCX_DBGFRZEN3_GLBL_FRZ_DIS      7
+
+/* PS/2 Interface registers */
+struct ps2_reg {
+	/* 0x000: PS/2 Data */
+	volatile uint8_t PSDAT;
+	volatile uint8_t reserved1;
+	/* 0x002: PS/2 Status */
+	volatile uint8_t PSTAT;
+	volatile uint8_t reserved2;
+	/* 0x004: PS/2 Control */
+	volatile uint8_t PSCON;
+	volatile uint8_t reserved3;
+	/* 0x006: PS/2 Output Signal */
+	volatile uint8_t PSOSIG;
+	volatile uint8_t reserved4;
+	/* 0x008: PS/2 Input Signal */
+	volatile uint8_t PSISIG;
+	volatile uint8_t reserved5;
+	/* 0x00A: PS/2 Interrupt Enable */
+	volatile uint8_t PSIEN;
+	volatile uint8_t reserved6;
+};
+
+/* PS/2 Interface registers fields */
+#define NPCX_PSTAT_SOT                   0
+#define NPCX_PSTAT_EOT                   1
+#define NPCX_PSTAT_PERR                  2
+#define NPCX_PSTAT_ACH                   FIELD(3, 3)
+#define NPCX_PSTAT_RFERR                 6
+
+#define NPCX_PSCON_EN                    0
+#define NPCX_PSCON_XMT                   1
+#define NPCX_PSCON_HDRV                  FIELD(2, 2)
+#define NPCX_PSCON_IDB                   FIELD(4, 3)
+#define NPCX_PSCON_WPUED                 7
+
+#define NPCX_PSOSIG_WDAT0                0
+#define NPCX_PSOSIG_WDAT1                1
+#define NPCX_PSOSIG_WDAT2                2
+#define NPCX_PSOSIG_CLK0                 3
+#define NPCX_PSOSIG_CLK1                 4
+#define NPCX_PSOSIG_CLK2                 5
+#define NPCX_PSOSIG_WDAT3                6
+#define NPCX_PSOSIG_CLK3                 7
+#define NPCX_PSOSIG_CLK(n)               (((n) < 3) ? ((n) + 3) : 7)
+#define NPCX_PSOSIG_WDAT(n)              (((n) < 3) ? ((n) + 0) : 6)
+#define NPCX_PSOSIG_CLK_MASK_ALL \
+					 (BIT(NPCX_PSOSIG_CLK0) | \
+					  BIT(NPCX_PSOSIG_CLK1) | \
+					  BIT(NPCX_PSOSIG_CLK2) | \
+					  BIT(NPCX_PSOSIG_CLK3))
+
+#define NPCX_PSIEN_SOTIE                 0
+#define NPCX_PSIEN_EOTIE                 1
+#define NPCX_PSIEN_PS2_WUE               4
+#define NPCX_PSIEN_PS2_CLK_SEL           7
+
+/* Flash Interface Unit (FIU) device registers */
+struct fiu_reg {
+	volatile uint8_t reserved1;
+	/* 0x001: Burst Configuration */
+	volatile uint8_t BURST_CFG;
+	/* 0x002: FIU Response Configuration */
+	volatile uint8_t RESP_CFG;
+	volatile uint8_t reserved2[17];
+	/* 0x014: SPI Flash Configuration */
+	volatile uint8_t SPI_FL_CFG;
+	volatile uint8_t reserved3;
+	/* 0x016: UMA Code Byte */
+	volatile uint8_t UMA_CODE;
+	/* 0x017: UMA Address Byte 0 */
+	volatile uint8_t UMA_AB0;
+	/* 0x018: UMA Address Byte 1 */
+	volatile uint8_t UMA_AB1;
+	/* 0x019: UMA Address Byte 2 */
+	volatile uint8_t UMA_AB2;
+	/* 0x01A: UMA Data Byte 0 */
+	volatile uint8_t UMA_DB0;
+	/* 0x01B: UMA Data Byte 1 */
+	volatile uint8_t UMA_DB1;
+	/* 0x01C: UMA Data Byte 2 */
+	volatile uint8_t UMA_DB2;
+	/* 0x01D: UMA Data Byte 3 */
+	volatile uint8_t UMA_DB3;
+	/* 0x01E: UMA Control and Status */
+	volatile uint8_t UMA_CTS;
+	/* 0x01F: UMA Extended Control and Status */
+	volatile uint8_t UMA_ECTS;
+	/* 0x020: UMA Data Bytes 0-3 */
+	volatile uint32_t UMA_DB0_3;
+	volatile uint8_t reserved4[2];
+	/* 0x026: CRC Control Register */
+	volatile uint8_t CRCCON;
+	/* 0x027: CRC Entry Register */
+	volatile uint8_t CRCENT;
+	/* 0x028: CRC Initialization and Result Register */
+	volatile uint32_t CRCRSLT;
+	volatile uint8_t reserved5[2];
+	/* 0x02E: FIU Read Command for back-up flash */
+	volatile uint8_t FIU_RD_CMD_BACK;
+	volatile uint8_t reserved6;
+	/* 0x030: FIU Read Command for private flash */
+	volatile uint8_t FIU_RD_CMD_PVT;
+	/* 0x031: FIU Read Command for shared flash */
+	volatile uint8_t FIU_RD_CMD_SHD;
+	volatile uint8_t reserved7;
+	/* 0x033: FIU Extended Configuration */
+	volatile uint8_t FIU_EXT_CFG;
+	/* 0x034: UMA address byte 0-3 */
+	volatile uint32_t UMA_AB0_3;
+	volatile uint8_t reserved8[4];
+	/* 0x03C: Set command enable in 4 byte address mode */
+	volatile uint8_t SET_CMD_EN;
+	/* 0x03D: 4 byte address mode enable */
+	volatile uint8_t FIU_4B_EN;
+	/* 0x03E-0x040*/
+	volatile uint8_t reserved9[3];
+	/* 0x041: Master Inactive Counter Threshold */
+	volatile uint8_t MI_CNT_THRSH;
+	/* 0x042: FIU Matser Status */
+	volatile uint8_t FIU_MSR_STS;
+	/* 0x043: FIU Master Interrupt Enable and Configuration */
+	volatile uint8_t FIU_MSR_IE_CFG;
+};
+
+/* FIU register fields */
+#define NPCX_BURST_CFG_R_BURST	         FIELD(0, 2)
+#define NPCX_BURST_CFG_UNLIM_BURST	 3
+#define NPCX_BURST_CFG_SPI_DEV_SEL       FIELD(4, 2)
+#define NPCX_RESP_CFG_IAD_EN             0
+#define NPCX_RESP_CFG_DEV_SIZE_EX        2
+#define NPCX_RESP_CFG_QUAD_EN            3
+#define NPCX_SPI_FL_CFG_RD_MODE          FIELD(6, 2)
+#define NPCX_UMA_CTS_A_SIZE              3
+#define NPCX_UMA_CTS_C_SIZE              4
+#define NPCX_UMA_CTS_RD_WR               5
+#define NPCX_UMA_CTS_DEV_NUM             6
+#define NPCX_UMA_CTS_EXEC_DONE           7
+#define NPCX_UMA_ECTS_SW_CS0             0
+#define NPCX_UMA_ECTS_SW_CS1             1
+#define NPCX_UMA_ECTS_SEC_CS             2
+#define NPCX_UMA_ECTS_UMA_LOCK           3
+#define NPCX_UMA_ECTS_UMA_ADDR_SIZE      FIELD(4, 3)
+#define NPCX_FIU_EXT_CFG_SET_DMM_EN      2
+#define NPCX_FIU_EXT_CFG_SET_CMD_EN      1
+#define NPCX_FIU_SET_PVT_CMD_EN          4
+#define NPCX_FIU_SET_SHD_CMD_EN          5
+#define NPCX_FIU_SET_BACK_CMD_EN         6
+
+#define NPCX_UMA_ECTS_UMA_DEV_BKP        3
+#define NPCX_MSR_IE_CFG_UMA_BLOCK        3
+
+#define NPCX_MSR_FIU_4B_EN_PVT_4B        4
+#define NPCX_MSR_FIU_4B_EN_SHD_4B        5
+#define NPCX_MSR_FIU_4B_EN_BKP_4B        6
+
+/* UMA fields selections */
+#define UMA_FLD_ADDR     BIT(NPCX_UMA_CTS_A_SIZE)  /* 3-bytes ADR field */
+#define UMA_FLD_NO_CMD   BIT(NPCX_UMA_CTS_C_SIZE)  /* No 1-Byte CMD field */
+#define UMA_FLD_WRITE    BIT(NPCX_UMA_CTS_RD_WR)   /* Write transaction */
+#define UMA_FLD_SHD_SL   BIT(NPCX_UMA_CTS_DEV_NUM) /* Shared flash selected */
+#define UMA_FLD_EXEC     BIT(NPCX_UMA_CTS_EXEC_DONE)
+
+#define UMA_FIELD_DATA_1 0x01
+#define UMA_FIELD_DATA_2 0x02
+#define UMA_FIELD_DATA_3 0x03
+#define UMA_FIELD_DATA_4 0x04
+
+/* UMA code for transaction */
+#define UMA_CODE_CMD_ONLY       (UMA_FLD_EXEC | UMA_FLD_SHD_SL)
+#define UMA_CODE_CMD_ADR        (UMA_FLD_EXEC | UMA_FLD_ADDR | \
+					UMA_FLD_SHD_SL)
+#define UMA_CODE_CMD_RD_BYTE(n) (UMA_FLD_EXEC | UMA_FIELD_DATA_##n | \
+					UMA_FLD_SHD_SL)
+#define UMA_CODE_RD_BYTE(n)     (UMA_FLD_EXEC | UMA_FLD_NO_CMD | \
+					UMA_FIELD_DATA_##n | UMA_FLD_SHD_SL)
+#define UMA_CODE_CMD_WR_ONLY    (UMA_FLD_EXEC | UMA_FLD_WRITE | \
+					UMA_FLD_SHD_SL)
+#define UMA_CODE_CMD_WR_BYTE(n) (UMA_FLD_EXEC | UMA_FLD_WRITE | \
+					UMA_FIELD_DATA_##n | UMA_FLD_SHD_SL)
+#define UMA_CODE_CMD_WR_ADR     (UMA_FLD_EXEC | UMA_FLD_WRITE | UMA_FLD_ADDR | \
+				UMA_FLD_SHD_SL)
+
+#define UMA_CODE_CMD_ADR_WR_BYTE(n) (UMA_FLD_EXEC | UMA_FLD_WRITE | \
+					UMA_FLD_ADDR | UMA_FIELD_DATA_##n | \
+					UMA_FLD_SHD_SL)
+
+/* Platform Environment Control Interface (PECI) device registers */
+struct peci_reg {
+	/* 0x000: PECI Control Status */
+	volatile uint8_t PECI_CTL_STS;
+	/* 0x001: PECI Read Length */
+	volatile uint8_t PECI_RD_LENGTH;
+	/* 0x002: PECI Address */
+	volatile uint8_t PECI_ADDR;
+	/* 0x003: PECI Command */
+	volatile uint8_t PECI_CMD;
+	/* 0x004: PECI Control 2 */
+	volatile uint8_t PECI_CTL2;
+	/* 0x005: PECI Index */
+	volatile uint8_t PECI_INDEX;
+	/* 0x006: PECI Index Data */
+	volatile uint8_t PECI_IDATA;
+	/* 0x007: PECI Write Length */
+	volatile uint8_t PECI_WR_LENGTH;
+	volatile uint8_t reserved1[3];
+	/* 0x00B: PECI Write FCS */
+	volatile uint8_t PECI_WR_FCS;
+	/* 0x00C: PECI Read FCS */
+	volatile uint8_t PECI_RD_FCS;
+	/* 0x00D: PECI Assured Write FCS */
+	volatile uint8_t PECI_AW_FCS;
+	volatile uint8_t reserved2;
+	/* 0x00F: PECI Transfer Rate */
+	volatile uint8_t PECI_RATE;
+	/* 0x010 - 0x04F: PECI Data In/Out */
+	union {
+		volatile uint8_t PECI_DATA_IN[64];
+		volatile uint8_t PECI_DATA_OUT[64];
+	};
+};
+
+/* PECI register fields */
+#define NPCX_PECI_CTL_STS_START_BUSY     0
+#define NPCX_PECI_CTL_STS_DONE           1
+#define NPCX_PECI_CTL_STS_CRC_ERR        3
+#define NPCX_PECI_CTL_STS_ABRT_ERR       4
+#define NPCX_PECI_CTL_STS_AWFCS_EB       5
+#define NPCX_PECI_CTL_STS_DONE_EN        6
+#define NPCX_PECI_RATE_MAX_BIT_RATE      FIELD(0, 5)
+#define NPCX_PECI_RATE_MAX_BIT_RATE_MASK 0x1F
+/* The minimal valid value of NPCX_PECI_RATE_MAX_BIT_RATE field */
+#define PECI_MAX_BIT_RATE_VALID_MIN      0x05
+#define PECI_HIGH_SPEED_MIN_VAL          0x07
+
+#define NPCX_PECI_RATE_EHSP              6
+
+/* KBS (Keyboard Scan) device registers */
+struct kbs_reg {
+	volatile uint8_t reserved1[4];
+	/* 0x004: Keyboard Scan In */
+	volatile uint8_t KBSIN;
+	/* 0x005: Keyboard Scan In Pull-Up Enable */
+	volatile uint8_t KBSINPU;
+	/* 0x006: Keyboard Scan Out 0 */
+	volatile uint16_t KBSOUT0;
+	/* 0x008: Keyboard Scan Out 1 */
+	volatile uint16_t KBSOUT1;
+	/* 0x00A: Keyboard Scan Buffer Index */
+	volatile uint8_t KBS_BUF_INDX;
+	/* 0x00B: Keyboard Scan Buffer Data */
+	volatile uint8_t KBS_BUF_DATA;
+	/* 0x00C: Keyboard Scan Event */
+	volatile uint8_t KBSEVT;
+	/* 0x00D: Keyboard Scan Control */
+	volatile uint8_t KBSCTL;
+	/* 0x00E: Keyboard Scan Configuration Index */
+	volatile uint8_t KBS_CFG_INDX;
+	/* 0x00F: Keyboard Scan Configuration Data */
+	volatile uint8_t KBS_CFG_DATA;
+};
+
+/* KBS register fields */
+#define NPCX_KBSBUFINDX                  0
+#define NPCX_KBSEVT_KBSDONE              0
+#define NPCX_KBSEVT_KBSERR               1
+#define NPCX_KBSCTL_START                0
+#define NPCX_KBSCTL_KBSMODE              1
+#define NPCX_KBSCTL_KBSIEN               2
+#define NPCX_KBSCTL_KBSINC               3
+#define NPCX_KBSCTL_KBHDRV_FIELD         FIELD(6, 2)
+#define NPCX_KBSCFGINDX                  0
+/* Index of 'Automatic Scan' configuration register */
+#define KBS_CFG_INDX_DLY1                0 /* Keyboard Scan Delay T1 Byte */
+#define KBS_CFG_INDX_DLY2                1 /* Keyboard Scan Delay T2 Byte */
+#define KBS_CFG_INDX_RTYTO               2 /* Keyboard Scan Retry Timeout */
+#define KBS_CFG_INDX_CNUM                3 /* Keyboard Scan Columns Number */
+#define KBS_CFG_INDX_CDIV                4 /* Keyboard Scan Clock Divisor */
+
+/* SHI (Serial Host Interface) registers */
+struct shi_reg {
+	volatile uint8_t reserved1;
+	/* 0x001: SHI Configuration 1 */
+	volatile uint8_t SHICFG1;
+	/* 0x002: SHI Configuration 2 */
+	volatile uint8_t SHICFG2;
+	volatile uint8_t reserved2[2];
+	/* 0x005: Event Enable */
+	volatile uint8_t EVENABLE;
+	/* 0x006: Event Status */
+	volatile uint8_t EVSTAT;
+	/* 0x007: SHI Capabilities */
+	volatile uint8_t CAPABILITY;
+	/* 0x008: Status */
+	volatile uint8_t STATUS;
+	volatile uint8_t reserved3;
+	/* 0x00A: Input Buffer Status */
+	volatile uint8_t IBUFSTAT;
+	/* 0x00B: Output Buffer Status */
+	volatile uint8_t OBUFSTAT;
+	/* 0x00C: SHI Configuration 3 */
+	volatile uint8_t SHICFG3;
+	/* 0x00D: SHI Configuration 4 */
+	volatile uint8_t SHICFG4;
+	/* 0x00E: SHI Configuration 5 */
+	volatile uint8_t SHICFG5;
+	/* 0x00F: Event Status 2 */
+	volatile uint8_t EVSTAT2;
+	/* 0x010: Event Enable 2 */
+	volatile uint8_t EVENABLE2;
+	/* 0x011: SHI Configuration 6 - only in chips which support enhanced buffer mode */
+	volatile uint8_t SHICFG6;
+	/* 0x012: Single Byte Output Buffer - only in chips which support enhanced buffer mode */
+	volatile uint8_t SBOBUF;
+	volatile uint8_t reserved4[13];
+	/* 0x20~0x9F: Output Buffer */
+	volatile uint8_t OBUF[128];
+	/* 0xA0~0x11F: Input Buffer */
+	volatile uint8_t IBUF[128];
+};
+
+/* SHI register fields */
+#define NPCX_SHICFG1_EN                  0
+#define NPCX_SHICFG1_MODE                1
+#define NPCX_SHICFG1_WEN                 2
+#define NPCX_SHICFG1_AUTIBF              3
+#define NPCX_SHICFG1_AUTOBE              4
+#define NPCX_SHICFG1_DAS                 5
+#define NPCX_SHICFG1_CPOL                6
+#define NPCX_SHICFG1_IWRAP               7
+#define NPCX_SHICFG2_SIMUL               0
+#define NPCX_SHICFG2_BUSY                1
+#define NPCX_SHICFG2_ONESHOT             2
+#define NPCX_SHICFG2_SLWU                3
+#define NPCX_SHICFG2_REEN                4
+#define NPCX_SHICFG2_RESTART             5
+#define NPCX_SHICFG2_REEVEN              6
+#define NPCX_EVENABLE_OBEEN              0
+#define NPCX_EVENABLE_OBHEEN             1
+#define NPCX_EVENABLE_IBFEN              2
+#define NPCX_EVENABLE_IBHFEN             3
+#define NPCX_EVENABLE_EOREN              4
+#define NPCX_EVENABLE_EOWEN              5
+#define NPCX_EVENABLE_STSREN             6
+#define NPCX_EVENABLE_IBOREN             7
+#define NPCX_EVSTAT_OBE                  0
+#define NPCX_EVSTAT_OBHE                 1
+#define NPCX_EVSTAT_IBF                  2
+#define NPCX_EVSTAT_IBHF                 3
+#define NPCX_EVSTAT_EOR                  4
+#define NPCX_EVSTAT_EOW                  5
+#define NPCX_EVSTAT_STSR                 6
+#define NPCX_EVSTAT_IBOR                 7
+#define NPCX_STATUS_OBES                 6
+#define NPCX_STATUS_IBFS                 7
+#define NPCX_SHICFG3_OBUFLVLDIS          7
+#define NPCX_SHICFG4_IBUFLVLDIS          7
+#define NPCX_SHICFG5_IBUFLVL2            FIELD(0, 6)
+#define NPCX_SHICFG5_IBUFLVL2DIS         7
+#define NPCX_EVSTAT2_IBHF2               0
+#define NPCX_EVSTAT2_CSNRE               1
+#define NPCX_EVSTAT2_CSNFE               2
+#define NPCX_EVENABLE2_IBHF2EN           0
+#define NPCX_EVENABLE2_CSNREEN           1
+#define NPCX_EVENABLE2_CSNFEEN           2
+#define NPCX_SHICFG6_EBUFMD              0
+#define NPCX_SHICFG6_OBUF_SL             1
+
+#define IBF_IBHF_EN_MASK                 (BIT(NPCX_EVENABLE_IBFEN) | BIT(NPCX_EVENABLE_IBHFEN))
+
+/* Software-triggered Pheripheral Reset Controller Register */
+struct swrst_reg {
+	/* 0x000: Software Reset Trigger */
+	volatile uint16_t SWRST_TRG;
+	volatile uint8_t reserved1[2];
+	volatile uint32_t SWRST_CTL[4];
+};
+
+/* LCT (Long Countdown Timer) registers */
+struct lct_reg {
+	/* 0x000-0x001 */
+	volatile uint8_t reserved1[2];
+	/* 0x002: LCT Control */
+	volatile uint8_t LCTCONT;
+	/* 0x003 */
+	volatile uint8_t reserved2;
+	/* 0x004: LCT Status */
+	volatile uint8_t LCTSTAT;
+	/* 0x005: LCT Seconds */
+	volatile uint8_t LCTSECOND;
+	/* 0x006: LCT Minutes */
+	volatile uint8_t LCTMINUTE;
+	/* 0x007 */
+	volatile uint8_t reserved3;
+	/* 0x008: LCT Hours */
+	volatile uint8_t LCTHOUR;
+	/* 0x009 */
+	volatile uint8_t reserved4;
+	/* 0x00A: LCT Days */
+	volatile uint8_t LCTDAY;
+	/* 0x00B */
+	volatile uint8_t reserved5;
+	/* 0x00C: LCT Weeks */
+	volatile uint8_t LCTWEEK;
+#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v2)
+	/* 0x00D: LCT Weeks MSB */
+	volatile uint8_t LCTWEEKM;
+#endif
+};
+
+#define NPCX_LCTCONT_LCTEN        0
+#define NPCX_LCTCONT_LCTEVEN      1
+#define NPCX_LCTCONT_LCTPSLEN     2
+#define NPCX_LCTCONT_LCT_CLK_EN   6
+#define NPCX_LCTCONT_LCT_VSBY_PWR 7
+
+#define NPCX_LCTSTAT_LCTEVST      0
+
+/*
+ * MailBox Interface (MBI) device registers
+ */
+struct mbi_reg {
+	/* 0x000: Host-to-EC register */
+	volatile uint8_t HER;
+	/* 0x001: EC-to-Host register */
+	volatile uint8_t EHR;
+	volatile uint8_t reserved1[14];
+	/* 0x010: General Purpose Data registers */
+	volatile uint8_t GPD[48];
+	volatile uint8_t reserved2[16];
+	/* 0x050: Host write indicator registers */
+	volatile uint8_t DINMR[6];
+	volatile uint8_t reserved3[2];
+	/* 0x058: Core write indicator registers */
+	volatile uint8_t DINMRC[6];
+	volatile uint8_t reserved4[2];
+	/* 0x060: Mailbox Host Write Protect register */
+	volatile uint8_t MBIHWP[6];
+	volatile uint8_t reserved5[10];
+	/* 0x070: Mailbox Core Control */
+	volatile uint8_t MBICCON;
+	/* 0x071: Mailbox General Control */
+	volatile uint8_t MGENCTRL;
+	/* 0x072: Mailbox General Control 2 */
+	volatile uint8_t MGENCTRL2;
+	/* 0x073: Mailbox Interface Status register */
+	volatile uint8_t MBISTS;
+	/* 0x074: Mailbox Status Register Clear Enable register */
+	volatile uint8_t MBISTSCLEN;
+	volatile uint8_t reserved6;
+};
+
+/* MBI register fields */
+#define NPCX_MBICCON_MBIRQEN             0
+#define NPCX_MBICCON_HHECST              1
+#define NPCX_MBICCON_HIRQE               2
+#define NPCX_MBICCON_IRQB                3
+#define NPCX_MBICCON_IRQB_FW_CLR         4
+#define NPCX_MBICCON_IBF                 5
+#define NPCX_MBICCON_OBE                 6
+#define NPCX_MBICCON_MBISTSACLR          7
+#define NPCX_MGENCTRL_COM                0
+#define NPCX_MGENCTRL_IBFIE              1
+#define NPCX_MGENCTRL_OBEIE              2
+#define NPCX_MGENCTRL_INTTYPE            FIELD(3, 2)
+#define NPCX_MGENCTRL_MBITV1             5
+#define NPCX_MGENCTRL_HEHWST             6
+#define NPCX_MGENCTRL_MSTNOTR1           7
+#define NPCX_MGENCTRL2_HHECSTIE          0
+#define NPCX_MGENCTRL2_HEHWSTIE          1
+#define NPCX_MGENCTRL2_INTIE             FIELD(0, 2)
+#define NPCX_MGENCTRL2_MBISTSEN          2
+
+/* GDMA registers */
+struct gdma_reg {
+	/* 0x000: Channel Control */
+	volatile uint32_t CONTROL;
+	/* 0x004: Channel Source Base Address */
+	volatile uint32_t SRCB;
+	/* 0x008: Channel Destination Base Address */
+	volatile uint32_t DSTB;
+	/* 0x00C: Channel Transfer Count */
+	volatile uint32_t TCNT;
+	/* 0x010: Channel Current Source */
+	volatile uint32_t CSRC;
+	/* 0x014: Channel Current Destination */
+	volatile uint32_t CDST;
+	/* 0x018: Channel Current Transfer Count */
+	volatile uint32_t CTCNT;
+	/* 0x01C: Reserved */
+	volatile uint32_t reserved1;
+};
+
+/* DMA register fields */
+#define NPCX_DMACTL_GDMAEN               0
+#define NPCX_DMACTL_GPD                  1
+#define NPCX_DMACTL_GDMAMS               FIELD(2, 2)
+#define NPCX_DMACTL_DADIR                4
+#define NPCX_DMACTL_SADIR                5
+#define NPCX_DMACTL_DAFIX                6
+#define NPCX_DMACTL_SAFIX                7
+#define NPCX_DMACTL_SIEN                 8
+#define NPCX_DMACTL_BME                  9
+#define NPCX_DMACTL_TWS                  FIELD(12, 2)
+#define NPCX_DMACTL_GPS                  14
+#define NPCX_DMACTL_DM                   15
+#define NPCX_DMACTL_SOFTREQ              16
+#define NPCX_DMACTL_TC                   18
+#define NPCX_DMACTL_GDMAERR              20
+#define NPCX_DMACTL_BUSY_EN              23
+
+#endif /* _NUVOTON_NPCX_REG_DEF_H */

--- a/soc/nuvoton/npcx/common/npckn/registers.c
+++ b/soc/nuvoton/npcx/common/npckn/registers.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <soc.h>
+#include "reg_def.h"
+
+/* CDCG register structure check */
+NPCX_REG_SIZE_CHECK(cdcg_reg, 0x116);
+NPCX_REG_OFFSET_CHECK(cdcg_reg, HFCBCD, 0x010);
+NPCX_REG_OFFSET_CHECK(cdcg_reg, HFCBCD2, 0x014);
+NPCX_REG_OFFSET_CHECK(cdcg_reg, LFCGCTL, 0x100);
+NPCX_REG_OFFSET_CHECK(cdcg_reg, LFCGCTL2, 0x114);
+
+/* PMC register structure check */
+NPCX_REG_SIZE_CHECK(pmc_reg, 0x013);
+NPCX_REG_OFFSET_CHECK(pmc_reg, ENIDL_CTL, 0x003);
+NPCX_REG_OFFSET_CHECK(pmc_reg, PWDWN_CTL0, 0x007);
+
+
+/* SCFG register structure check */
+NPCX_REG_SIZE_CHECK(scfg_reg, 0x020);
+NPCX_REG_OFFSET_CHECK(scfg_reg, DEV_CTL4, 0x006);
+NPCX_REG_OFFSET_CHECK(scfg_reg, DEVALT0, 0x010);
+
+
+/* GLUE register structure check */
+NPCX_REG_SIZE_CHECK(glue_reg, 0x03b);
+NPCX_REG_OFFSET_CHECK(glue_reg, SMB_EEN, 0x003);
+NPCX_REG_OFFSET_CHECK(glue_reg, SDPD0, 0x010);
+NPCX_REG_OFFSET_CHECK(glue_reg, SMB_SEL, 0x021);
+NPCX_REG_OFFSET_CHECK(glue_reg, PSL_CTS, 0x027);
+NPCX_REG_OFFSET_CHECK(glue_reg, EPURST_CTL, 0x030);
+NPCX_REG_OFFSET_CHECK(glue_reg, PSL_CTS3, 0x038);
+
+/* UART register structure check */
+NPCX_REG_SIZE_CHECK(uart_reg, 0x027);
+NPCX_REG_OFFSET_CHECK(uart_reg, UPSR, 0x00e);
+NPCX_REG_OFFSET_CHECK(uart_reg, UFCTRL, 0x016);
+NPCX_REG_OFFSET_CHECK(uart_reg, URXFLV, 0x01A);
+
+/* GPIO register structure check */
+NPCX_REG_SIZE_CHECK(gpio_reg, 0x008);
+NPCX_REG_OFFSET_CHECK(gpio_reg, PTYPE, 0x006);
+
+/* PWM register structure check */
+NPCX_REG_SIZE_CHECK(pwm_reg, 0x012);
+NPCX_REG_OFFSET_CHECK(pwm_reg, PWMCTL, 0x004);
+NPCX_REG_OFFSET_CHECK(pwm_reg, DCR, 0x006);
+NPCX_REG_OFFSET_CHECK(pwm_reg, PWMCTLEX, 0x00c);
+NPCX_REG_OFFSET_CHECK(pwm_reg, N_STEP_RS, 0x005);
+NPCX_REG_OFFSET_CHECK(pwm_reg, N_STEP_FL, 0x00D);
+NPCX_REG_OFFSET_CHECK(pwm_reg, EXT_OFF, 0x00F);
+
+/* ADC register structure check */
+NPCX_REG_SIZE_CHECK(adc_reg, 0x108);
+NPCX_REG_OFFSET_CHECK(adc_reg, THRCTS, 0x01a);
+NPCX_REG_OFFSET_CHECK(adc_reg, ADCCNF2, 0x020);
+NPCX_REG_OFFSET_CHECK(adc_reg, MEAST, 0x026);
+
+/* TWD register structure check */
+NPCX_REG_SIZE_CHECK(twd_reg, 0x012);
+NPCX_REG_OFFSET_CHECK(twd_reg, T0CSR, 0x006);
+NPCX_REG_OFFSET_CHECK(twd_reg, TWMWD, 0x00e);
+NPCX_REG_OFFSET_CHECK(twd_reg, WDCP, 0x010);
+
+/* ESPI register structure check */
+NPCX_REG_SIZE_CHECK(espi_reg, 0x900);
+NPCX_REG_OFFSET_CHECK(espi_reg, FLASHCFG, 0x034);
+NPCX_REG_OFFSET_CHECK(espi_reg, NPCX_ONLY_ESPI_REG1, 0x0f0);
+NPCX_REG_OFFSET_CHECK(espi_reg, VWEVMS, 0x140);
+NPCX_REG_OFFSET_CHECK(espi_reg, VWGPSM, 0x180);
+NPCX_REG_OFFSET_CHECK(espi_reg, VWCTL, 0x2fc);
+NPCX_REG_OFFSET_CHECK(espi_reg, OOBTXBUF, 0x380);
+NPCX_REG_OFFSET_CHECK(espi_reg, OOBCTL_DIRECT, 0x3fc);
+NPCX_REG_OFFSET_CHECK(espi_reg, FLASHTXBUF, 0x480);
+NPCX_REG_OFFSET_CHECK(espi_reg, FLASHCTL_DIRECT, 0x4fc);
+
+/* MSWC register structure check */
+NPCX_REG_SIZE_CHECK(mswc_reg, 0x030);
+NPCX_REG_OFFSET_CHECK(mswc_reg, HCBAL, 0x008);
+NPCX_REG_OFFSET_CHECK(mswc_reg, HCBAH, 0x00a);
+NPCX_REG_OFFSET_CHECK(mswc_reg, SRID_CR, 0x01c);
+NPCX_REG_OFFSET_CHECK(mswc_reg, SID_CR, 0x020);
+NPCX_REG_OFFSET_CHECK(mswc_reg, VW_SLPST1, 0x02e);
+
+/* SHM register structure check */
+NPCX_REG_SIZE_CHECK(shm_reg, 0x088);
+NPCX_REG_OFFSET_CHECK(shm_reg, IMA_WIN_SIZE, 0x005);
+NPCX_REG_OFFSET_CHECK(shm_reg, WIN_SIZE, 0x007);
+NPCX_REG_OFFSET_CHECK(shm_reg, IMA_SEM, 0x00b);
+NPCX_REG_OFFSET_CHECK(shm_reg, SHCFG, 0x00e);
+NPCX_REG_OFFSET_CHECK(shm_reg, WIN1_WR_PROT, 0x010);
+NPCX_REG_OFFSET_CHECK(shm_reg, IMA_WR_PROT, 0x016);
+NPCX_REG_OFFSET_CHECK(shm_reg, WIN_BASE1, 0x020);
+NPCX_REG_OFFSET_CHECK(shm_reg, WIN_BASE2, 0x024);
+NPCX_REG_OFFSET_CHECK(shm_reg, RST_CFG, 0x03a);
+NPCX_REG_OFFSET_CHECK(shm_reg, DP80BUF, 0x040);
+NPCX_REG_OFFSET_CHECK(shm_reg, DP80CTL, 0x044);
+NPCX_REG_OFFSET_CHECK(shm_reg, HOFS_STS, 0x048);
+NPCX_REG_OFFSET_CHECK(shm_reg, COFS1, 0x04c);
+#if defined(CONFIG_SOC_SERIES_NPCK3)
+NPCX_REG_OFFSET_CHECK(shm_reg, SHM_CTL2, 0x04e);
+#endif
+
+/* KBC register structure check */
+NPCX_REG_SIZE_CHECK(kbc_reg, 0x00c);
+NPCX_REG_OFFSET_CHECK(kbc_reg, HIKMDI, 0x00a);
+NPCX_REG_OFFSET_CHECK(kbc_reg, SHIKMDI, 0x00b);
+
+/* PMCH register structure check */
+NPCX_REG_SIZE_CHECK(pmch_reg, 0x012);
+NPCX_REG_OFFSET_CHECK(pmch_reg, HIPMDO, 0x002);
+NPCX_REG_OFFSET_CHECK(pmch_reg, HIPMDOC, 0x006);
+NPCX_REG_OFFSET_CHECK(pmch_reg, HIPMDOM, 0x008);
+NPCX_REG_OFFSET_CHECK(pmch_reg, HIPMDIC, 0x00a);
+NPCX_REG_OFFSET_CHECK(pmch_reg, HIPMIE, 0x010);
+
+/* C2H register structure check */
+NPCX_REG_SIZE_CHECK(c2h_reg, 0x00c);
+NPCX_REG_OFFSET_CHECK(c2h_reg, LKSIOHA, 0x004);
+NPCX_REG_OFFSET_CHECK(c2h_reg, CRSMAE, 0x008);
+NPCX_REG_OFFSET_CHECK(c2h_reg, SIBCTRL, 0x00a);
+
+/* SMB register structure check */
+NPCX_REG_SIZE_CHECK(smb_reg, 0x030);
+NPCX_REG_OFFSET_CHECK(smb_reg, SMBCTL1, 0x006);
+NPCX_REG_OFFSET_CHECK(smb_reg, SMBADDR6, 0x016);
+NPCX_REG_OFFSET_CHECK(smb_reg, SMBCST2, 0x018);
+NPCX_REG_OFFSET_CHECK(smb_reg, SMBTXF_STS, 0x01a);
+NPCX_REG_OFFSET_CHECK(smb_reg, SMBSCLHT, 0x01e);
+NPCX_REG_OFFSET_CHECK(smb_reg, SMBRXF_CTL, 0x01e);
+NPCX_REG_OFFSET_CHECK(smb_reg, DMA_CTRL, 0x00f);
+NPCX_REG_OFFSET_CHECK(smb_reg, DMA_ADDR3, 0x022);
+NPCX_REG_OFFSET_CHECK(smb_reg, TIMEOUT_CTL1, 0x029);
+
+
+/* ITIM register structure check */
+NPCX_REG_SIZE_CHECK(itim32_reg, 0x00c);
+NPCX_REG_OFFSET_CHECK(itim32_reg, ITPRE32, 0x001);
+NPCX_REG_OFFSET_CHECK(itim32_reg, ITCTS32, 0x004);
+NPCX_REG_OFFSET_CHECK(itim32_reg, ITCNT32, 0x008);
+
+NPCX_REG_SIZE_CHECK(itim64_reg, 0x010);
+NPCX_REG_OFFSET_CHECK(itim64_reg, ITPRE64, 0x001);
+NPCX_REG_OFFSET_CHECK(itim64_reg, ITCTS64, 0x004);
+NPCX_REG_OFFSET_CHECK(itim64_reg, ITCNT64L, 0x008);
+NPCX_REG_OFFSET_CHECK(itim64_reg, ITCNT64H, 0x00c);
+
+/* TACH register structure check */
+NPCX_REG_SIZE_CHECK(tach_reg, 0x01e);
+NPCX_REG_OFFSET_CHECK(tach_reg, TPRSC, 0x008);
+NPCX_REG_OFFSET_CHECK(tach_reg, TECLR, 0x010);
+NPCX_REG_OFFSET_CHECK(tach_reg, TCPA, 0x014);
+NPCX_REG_OFFSET_CHECK(tach_reg, TCPCFG, 0x018);
+NPCX_REG_OFFSET_CHECK(tach_reg, TCFG, 0x01c);
+
+/* PS/2 Interface register structure check */
+NPCX_REG_SIZE_CHECK(ps2_reg, 0x00c);
+NPCX_REG_OFFSET_CHECK(ps2_reg, PSDAT, 0x000);
+NPCX_REG_OFFSET_CHECK(ps2_reg, PSTAT, 0x002);
+NPCX_REG_OFFSET_CHECK(ps2_reg, PSCON, 0x004);
+NPCX_REG_OFFSET_CHECK(ps2_reg, PSOSIG, 0x006);
+NPCX_REG_OFFSET_CHECK(ps2_reg, PSISIG, 0x008);
+NPCX_REG_OFFSET_CHECK(ps2_reg, PSIEN, 0x00a);
+
+/* FIU register structure check */
+#if defined(CONFIG_SOC_SERIES_NPCX9) || defined(CONFIG_SOC_SERIES_NPCX4)
+NPCX_REG_SIZE_CHECK(fiu_reg, 0x040);
+#elif defined(CONFIG_SOC_SERIES_NPCK3)
+NPCX_REG_SIZE_CHECK(fiu_reg, 0x044);
+#else
+NPCX_REG_SIZE_CHECK(fiu_reg, 0x034);
+#endif
+NPCX_REG_OFFSET_CHECK(fiu_reg, BURST_CFG, 0x001);
+NPCX_REG_OFFSET_CHECK(fiu_reg, SPI_FL_CFG, 0x014);
+NPCX_REG_OFFSET_CHECK(fiu_reg, UMA_CTS, 0x01e);
+NPCX_REG_OFFSET_CHECK(fiu_reg, CRCCON, 0x026);
+#if defined(CONFIG_SOC_SERIES_NPCK3)
+NPCX_REG_OFFSET_CHECK(fiu_reg, FIU_RD_CMD_BACK, 0x02E);
+NPCX_REG_OFFSET_CHECK(fiu_reg, FIU_RD_CMD_PVT, 0x030);
+NPCX_REG_OFFSET_CHECK(fiu_reg, FIU_RD_CMD_SHD, 0x031);
+#else
+NPCX_REG_OFFSET_CHECK(fiu_reg, FIU_RD_CMD, 0x030);
+#endif
+NPCX_REG_OFFSET_CHECK(fiu_reg, FIU_EXT_CFG, 0x033);
+
+/* PECI register structure check */
+NPCX_REG_SIZE_CHECK(peci_reg, 0x050);
+NPCX_REG_OFFSET_CHECK(peci_reg, PECI_ADDR, 0x002);
+NPCX_REG_OFFSET_CHECK(peci_reg, PECI_WR_LENGTH, 0x007);
+NPCX_REG_OFFSET_CHECK(peci_reg, PECI_WR_FCS, 0x00b);
+
+/* KBS register structure check */
+NPCX_REG_SIZE_CHECK(kbs_reg, 0x010);
+NPCX_REG_OFFSET_CHECK(kbs_reg, KBSIN, 0x004);
+NPCX_REG_OFFSET_CHECK(kbs_reg, KBSOUT0, 0x006);
+NPCX_REG_OFFSET_CHECK(kbs_reg, KBS_BUF_INDX, 0x00a);
+
+/* SWRST register structure check */
+NPCX_REG_SIZE_CHECK(swrst_reg, 0x014);
+NPCX_REG_OFFSET_CHECK(swrst_reg, SWRST_TRG, 0x000);
+NPCX_REG_OFFSET_CHECK(swrst_reg, SWRST_CTL[0], 0x004);
+NPCX_REG_OFFSET_CHECK(swrst_reg, SWRST_CTL[1], 0x008);
+NPCX_REG_OFFSET_CHECK(swrst_reg, SWRST_CTL[2], 0x00c);
+NPCX_REG_OFFSET_CHECK(swrst_reg, SWRST_CTL[3], 0x010);
+
+/* MBI register structure check */
+NPCX_REG_SIZE_CHECK(mbi_reg, 0x076);
+NPCX_REG_OFFSET_CHECK(mbi_reg, GPD, 0x010);
+NPCX_REG_OFFSET_CHECK(mbi_reg, DINMR, 0x050);
+NPCX_REG_OFFSET_CHECK(mbi_reg, MBIHWP, 0x060);
+NPCX_REG_OFFSET_CHECK(mbi_reg, MBICCON, 0x070);
+
+/* LCT register structure check */
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTCONT, 0x002);
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTHOUR, 0x008);
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTWEEK, 0x00c);
+#if DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_lct_v2)
+NPCX_REG_OFFSET_CHECK(lct_reg, LCTWEEKM, 0x00d);
+NPCX_REG_SIZE_CHECK(lct_reg, 0x00e);
+#else
+NPCX_REG_SIZE_CHECK(lct_reg, 0x00d);
+#endif
+
+/* GDMA register structure check */
+NPCX_REG_SIZE_CHECK(gdma_reg, 0x020);
+NPCX_REG_OFFSET_CHECK(gdma_reg, CONTROL, 0x000);
+NPCX_REG_OFFSET_CHECK(gdma_reg, SRCB, 0x004);
+NPCX_REG_OFFSET_CHECK(gdma_reg, DSTB, 0x008);
+NPCX_REG_OFFSET_CHECK(gdma_reg, TCNT, 0x00C);

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -93,18 +93,9 @@ struct pmc_reg {
 	volatile uint8_t PWDWN_CTL7[1];
 };
 
-/* PMC internal inline functions for multi-registers */
-static inline uint32_t npcx_pwdwn_ctl_offset(uint32_t ctl_no)
-{
-	if (ctl_no < 6) {
-		return 0x008 + ctl_no;
-	} else {
-		return 0x024 + ctl_no - 6;
-	}
-}
-
 /* Macro functions for PMC multi-registers */
-#define NPCX_PWDWN_CTL(base, n) (*(volatile uint8_t *)(base + npcx_pwdwn_ctl_offset(n)))
+#define NPCX_PWDWN_CTL(base, n) \
+	(*(volatile uint8_t *)(base + NPCX_PWDWN_CTL_OFFSET(n)))
 
 /* PMC register fields */
 #define NPCX_PMCSR_DI_INSTW        0

--- a/soc/nuvoton/npcx/npck3/CMakeLists.txt
+++ b/soc/nuvoton/npcx/npck3/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(
+  .
+  ${ZEPHYR_BASE}/drivers
+)
+
+zephyr_sources(
+  soc.c
+)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/nuvoton/npcx/npck3/Kconfig
+++ b/soc/nuvoton/npcx/npck3/Kconfig
@@ -1,0 +1,30 @@
+# Nuvoton NPCK3 EC series
+
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NPCK3
+	select ARM
+	select CPU_CORTEX_M4
+	select CPU_CORTEX_M_HAS_DWT
+	select CPU_HAS_FPU
+	select CPU_HAS_ARM_MPU
+	select HAS_PM
+	select HAS_SWO
+
+if SOC_SERIES_NPCK3
+
+config SOC_NPCK_EPURST_DISABLE
+	bool "Disable all External Power-Up Reset Inputs"
+	default y
+	help
+	  Disable all External Power-Up Reset Inputs during initialization. All
+	  signals such as EXT_PURST# are disabled by default. The users can
+	  enable it if needed.
+
+config SOC_NPCK_DEBUG_DISABLE
+	bool "Disable all K3 debug interfaces"
+	help
+	  Disable all K3 debug interface during initialization.
+
+endif # SOC_SERIES_NPCK3

--- a/soc/nuvoton/npcx/npck3/Kconfig.defconfig
+++ b/soc/nuvoton/npcx/npck3/Kconfig.defconfig
@@ -1,0 +1,18 @@
+# Nuvoton Cortex-M4 Embedded Controller
+
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NPCK3
+
+config NUM_IRQS
+	default 64
+
+config CORTEX_M_SYSTICK
+	default !NPCX_ITIM_TIMER
+
+config ESPI_TAF_NPCX
+	default y
+	depends on ESPI_TAF
+
+endif # SOC_SERIES_NPCK3

--- a/soc/nuvoton/npcx/npck3/Kconfig.soc
+++ b/soc/nuvoton/npcx/npck3/Kconfig.soc
@@ -1,0 +1,22 @@
+# Nuvoton NPCK3 EC series
+
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NPCK3
+	bool
+	select NPCX_SOC_VARIANT_NPCKN
+	help
+	  Enable support for Nuvoton NPCK3 series
+
+config SOC_NPCK3M8K
+	bool
+	select SOC_SERIES_NPCK3
+	help
+	  NPCK3M8K
+
+config SOC_SERIES
+	default "npck3" if SOC_SERIES_NPCK3
+
+config SOC
+	default "npck3m8k" if SOC_NPCK3M8K

--- a/soc/nuvoton/npcx/npck3/soc.c
+++ b/soc/nuvoton/npcx/npck3/soc.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <soc.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
+
+void soc_early_init_hook(void)
+{
+	struct glue_reg *inst_glue = (struct glue_reg *)
+			DT_REG_ADDR_BY_NAME(DT_NODELABEL(scfg), glue);
+
+	struct scfg_reg *inst_scfg = (struct scfg_reg *)
+			DT_REG_ADDR_BY_NAME(DT_NODELABEL(scfg), scfg);
+
+	if (IS_ENABLED(CONFIG_SOC_NPCK_EPURST_DISABLE)) {
+		/* EXT_PURST# signal is not selected to the pin by default */
+		inst_glue->EPURST_CTL &= ~BIT(NPCX_EPURST_CTL_EPUR2_EN);
+	}
+
+	if (IS_ENABLED(CONFIG_SOC_NPCK_DEBUG_DISABLE)) {
+		/* Core debugging interface is disabled */
+		inst_scfg->DEVCNT |= BIT(1);
+	}
+}

--- a/soc/nuvoton/npcx/npck3/soc.h
+++ b/soc/nuvoton/npcx/npck3/soc.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Nuvoton Technology Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _NUVOTON_NPCX_SOC_H_
+#define _NUVOTON_NPCX_SOC_H_
+
+#include <cmsis_core_m_defaults.h>
+
+/* NPCK3 SCFG multi-registers */
+#define NPCX_DEVALT_OFFSET(n)		((n < 0x10) ? (0x010 + n) : \
+					((n < 0x13) ? (0x0b + (n - 0x10)) : \
+					(0x024 + (n - 0x13))))
+#define NPCX_PUPD_EN_OFFSET(n)		(0x028 + n)
+#define NPCX_LV_GPIO_CTL_OFFSET(n)	(0x02a + n)
+#define NPCX_DEVALT_LK_OFFSET(n)	(0)
+
+/* NPCK3 MIWU multi-registers */
+#define NPCX_WKEDG_OFFSET(n)		(0x000 + (n * 2) + ((n < 5) ? 0 : 0x01e))
+#define NPCX_WKAEDG_OFFSET(n)		(0x001 + (n * 2) + ((n < 5) ? 0 : 0x01e))
+#define NPCX_WKMOD_OFFSET(n)		(0x070 + n)
+#define NPCX_WKPND_OFFSET(n)		(0x00a + (n * 4) + ((n < 5) ? 0 : 0x010))
+#define NPCX_WKPCL_OFFSET(n)		(0x00c + (n * 4) + ((n < 5) ? 0 : 0x010))
+#define NPCX_WKEN_OFFSET(n)		(0x01e + (n * 2) + ((n < 5) ? 0 : 0x012))
+#define NPCX_WKINEN_OFFSET(n)		(0x01f + (n * 2) + ((n < 5) ? 0 : 0x012))
+
+/* NPCK3 PMC multi-registers */
+#define NPCX_PWDWN_CTL_OFFSET(n)	(0x007 + n)
+
+/* NPCK3 ADC multi-registers */
+#define NPCX_CHNDAT_OFFSET(n)		(0x040 + n * 2)
+#define NPCX_THRCTL_OFFSET(n)		(0x014 + n * 2)
+#define NPCX_TCHNDAT_OFFSET(n)		(0x10E + n * 2)
+#define NPCX_TEMP_THRCTL_OFFSET(n)	(0x180 + n * 2)
+#define NPCX_TEMP_THR_DCTL_OFFSET(n)	(0x1A0 + n * 2)
+
+/* NPCK3 ADC register fields */
+#define NPCX_THRCTL_THEN		15
+#define NPCX_THRCTL_L_H			14
+#define NPCX_THRCTL_CHNSEL		FIELD(10, 4)
+#define NPCX_THRCTL_THRVAL		FIELD(0, 10)
+
+/* NPCK3 FIU register fields */
+#define NPCK_FIFO_EN			0
+#define NPCK_RX_FIFO_LEVEL		FIELD(6, 2)
+#define NPCK_SZ_UART_FIFO		16
+#define NPCX_FIU_EXT_CFG_SPI1_2DEV	0
+
+/* NPCK3 GLUE register fields */
+#define NPCX_EPURST_CTL_EPUR1_AHI	0
+#define NPCX_EPURST_CTL_EPUR1_EN	1
+#define NPCX_EPURST_CTL_EPUR2_AHI	2
+#define NPCX_EPURST_CTL_EPUR2_EN	3
+#define NPCX_EPURST_CTL_EPUR_LK		7
+
+/* NPCK3 TWD register fields */
+#define NPCX_T0CSR_T0EN			6
+
+/* No DEVALT_LK mechanism in NPCK3 series */
+#define NPCX_DEVALT_LK_GROUP_MASK	0x00000000
+
+/* NPCK3 Clock configuration and limitation */
+#define MAX_OFMCLK 100000000
+
+#include "reg_def.h"
+#include "clock_def.h"
+#include <soc_dt.h>
+#include <soc_espi_taf.h>
+#include <soc_pins.h>
+#include <soc_power.h>
+
+/* NPCK3 Clock prescaler configurations */
+#define VAL_HFCGP   ((FPRED_VAL << 4) | AHB6DIV_VAL)
+#define VAL_HFCBCD  (APB1DIV_VAL | (APB2DIV_VAL << 4))
+#define VAL_HFCBCD1 0 /* Keep the same as reset value 0*/
+#define VAL_HFCBCD2 (APB3DIV_VAL | (FIUDIV_VAL << 4))
+
+#endif /* _NUVOTON_NPCX_SOC_H_ */

--- a/soc/nuvoton/npcx/npcx4/soc.h
+++ b/soc/nuvoton/npcx/npcx4/soc.h
@@ -25,6 +25,9 @@
 #define NPCX_WKST_OFFSET(n)		(0x006 + (n * 0x010))
 #define NPCX_WKINEN_OFFSET(n)		(0x007 + (n * 0x010))
 
+/* NPCX4 PMC multi-registers */
+#define NPCX_PWDWN_CTL_OFFSET(n)	(((n - 1) < 6) ? (0x008 + (n - 1)) : (0x01e + (n - 1)))
+
 /* NPCX4 ADC multi-registers */
 #define NPCX_CHNDAT_OFFSET(n)		(0x040 + n * 2)
 #define NPCX_THRCTL_OFFSET(n)		(0x080 + n * 2)
@@ -56,5 +59,12 @@
 #include <soc_espi_taf.h>
 #include <soc_pins.h>
 #include <soc_power.h>
+
+/* NPCX4 Clock prescaler configurations */
+#define VAL_HFCGP   ((FPRED_VAL << 4) | AHB6DIV_VAL)
+#define VAL_HFCBCD  ((FIU1DIV_VAL << 4) | (FIUDIV_VAL << 2))
+#define VAL_HFCBCD1 (APB1DIV_VAL | (APB2DIV_VAL << 4))
+#define VAL_HFCBCD2 (APB3DIV_VAL | (APB4DIV_VAL << 4))
+#define VAL_HFCBCD3 MCLKD_SL /* Used by I3C1/2/3 modules */
 
 #endif /* _NUVOTON_NPCX_SOC_H_ */

--- a/soc/nuvoton/npcx/npcx7/soc.h
+++ b/soc/nuvoton/npcx/npcx7/soc.h
@@ -24,6 +24,9 @@
 #define NPCX_WKEN_OFFSET(n)		(0x01e + (n * 2) + ((n < 5) ? 0 : 0x012))
 #define NPCX_WKINEN_OFFSET(n)		(0x01f + (n * 2) + ((n < 5) ? 0 : 0x012))
 
+/* NPCX7 PMC multi-registers */
+#define NPCX_PWDWN_CTL_OFFSET(n)	(((n - 1) < 6) ? (0x008 + (n - 1)) : (0x01e + (n - 1)))
+
 /* NPCX7 ADC multi-registers offset */
 #define NPCX_CHNDAT_OFFSET(n)		(0x040 + (n * 2))
 #define NPCX_THRCTL_OFFSET(n)		(0x014 + (n * 2))
@@ -47,5 +50,11 @@
 #include <soc_dt.h>
 #include <soc_pins.h>
 #include <soc_power.h>
+
+/* NPCX7 Clock prescaler configurations */
+#define VAL_HFCGP   ((FPRED_VAL << 4) | AHB6DIV_VAL)
+#define VAL_HFCBCD  (FIUDIV_VAL << 4)
+#define VAL_HFCBCD1 (APB1DIV_VAL | (APB2DIV_VAL << 4))
+#define VAL_HFCBCD2 APB3DIV_VAL
 
 #endif /* _NUVOTON_NPCX_SOC_H_ */

--- a/soc/nuvoton/npcx/npcx9/soc.h
+++ b/soc/nuvoton/npcx/npcx9/soc.h
@@ -25,6 +25,9 @@
 #define NPCX_WKST_OFFSET(n)		(0x006 + (n * 0x010))
 #define NPCX_WKINEN_OFFSET(n)		(0x007 + (n * 0x010))
 
+/* NPCX9 PMC multi-registers */
+#define NPCX_PWDWN_CTL_OFFSET(n)	(((n - 1) < 6) ? (0x008 + (n - 1)) : (0x01e + (n - 1)))
+
 /* NPCX9 ADC multi-registers */
 #define NPCX_CHNDAT_OFFSET(n)		(0x040 + (n * 2))
 #define NPCX_THRCTL_OFFSET(n)		(0x060 + (n * 2))
@@ -52,5 +55,11 @@
 #include <soc_dt.h>
 #include <soc_pins.h>
 #include <soc_power.h>
+
+/* NPCX9 Clock prescaler configurations */
+#define VAL_HFCGP   ((FPRED_VAL << 4) | AHB6DIV_VAL)
+#define VAL_HFCBCD  (FIUDIV_VAL << 4)
+#define VAL_HFCBCD1 (APB1DIV_VAL | (APB2DIV_VAL << 4))
+#define VAL_HFCBCD2 (APB3DIV_VAL | (APB4DIV_VAL << 4))
 
 #endif /* _NUVOTON_NPCX_SOC_H_ */

--- a/soc/nuvoton/npcx/soc.yml
+++ b/soc/nuvoton/npcx/soc.yml
@@ -1,6 +1,9 @@
 family:
 - name: npcx
   series:
+  - name: npck3
+    socs:
+    - name: npck3m8k
   - name: npcx4
     socs:
     - name: npcx4m3f


### PR DESCRIPTION
This PR introduces support for the NPCX K3 System-on-Chip (SoC). 
The changes include essential updates and additions to enable functionality, compatibility, and integration of the NPCX K3 SoC into the Zephyr RTOS.

Changes
- Added initial support for the NPCX K3 SoC
- Implemented drivers for key peripherals of the NPCX K3 SoC.
-  Integrated build system updates to recognize and compile NPCX K3-specific files.
