### PR TITLE
net: l2: ethernet: arp: explicit error codes

### DIFF
--- a/subsys/net/ip/ipv4_acd.c
+++ b/subsys/net/ip/ipv4_acd.c
@@ -74,7 +74,8 @@ static struct net_pkt *ipv4_acd_prepare_arp(struct net_if *iface,
 					    struct in_addr *sender_ip,
 					    struct in_addr *target_ip)
 {
-	struct net_pkt *pkt;
+	struct net_pkt *pkt, *arp;
+	int ret;
 
 	/* We provide AF_UNSPEC to the allocator: this packet does not
 	 * need space for any IPv4 header.
@@ -88,7 +89,13 @@ static struct net_pkt *ipv4_acd_prepare_arp(struct net_if *iface,
 	net_pkt_set_family(pkt, AF_INET);
 	net_pkt_set_ipv4_acd(pkt, true);
 
-	return net_arp_prepare(pkt, target_ip, sender_ip);
+	ret = net_arp_prepare(pkt, target_ip, sender_ip, &arp);
+	if (ret == NET_ARP_PKT_REPLACED) {
+		pkt = arp;
+	} else if (ret < 0)  {
+		pkt = NULL;
+	}
+	return pkt;
 }
 
 static void ipv4_acd_send_probe(struct net_if_addr *ifaddr)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -302,7 +302,7 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 
 	} else {
 		/* Drop packet if interface is not up */
-		NET_WARN("iface %p is down", iface);
+		NET_WARN("iface %d is down", net_if_get_by_iface(iface));
 		status = -ENETDOWN;
 	}
 
@@ -438,7 +438,7 @@ static inline void init_iface(struct net_if *iface)
 
 	net_virtual_init(iface);
 
-	NET_DBG("On iface %p", iface);
+	NET_DBG("On iface %d", net_if_get_by_iface(iface));
 
 #ifdef CONFIG_USERSPACE
 	k_object_init(iface);
@@ -465,7 +465,7 @@ enum net_verdict net_if_try_send_data(struct net_if *iface, struct net_pkt *pkt,
 	if (!net_if_flag_is_set(iface, NET_IF_LOWER_UP) ||
 	    net_if_flag_is_set(iface, NET_IF_SUSPENDED)) {
 		/* Drop packet if interface is not up */
-		NET_WARN("iface %p is down", iface);
+		NET_WARN("iface %d is down", net_if_get_by_iface(iface));
 		verdict = NET_DROP;
 		status = -ENETDOWN;
 		goto done;
@@ -478,14 +478,15 @@ enum net_verdict net_if_try_send_data(struct net_if *iface, struct net_pkt *pkt,
 		l2 = net_if_l2(iface);
 		if (l2 == NULL) {
 			/* Offloaded ifaces may choose not to use an L2 at all. */
-			NET_WARN("no l2 for iface %p, discard pkt", iface);
+			NET_WARN("no l2 for iface %d, discard pkt", net_if_get_by_iface(iface));
 			verdict = NET_DROP;
 			goto done;
 		} else if (l2->send == NULL) {
 			/* Or, their chosen L2 (for example, OFFLOADED_NETDEV_L2)
 			 * might simply not implement send.
 			 */
-			NET_WARN("l2 for iface %p cannot send, discard pkt", iface);
+			NET_WARN("l2 for iface %d cannot send, discard pkt",
+				 net_if_get_by_iface(iface));
 			verdict = NET_DROP;
 			goto done;
 		}
@@ -1339,7 +1340,7 @@ void net_if_start_dad(struct net_if *iface)
 
 	net_if_lock(iface);
 
-	NET_DBG("Starting DAD for iface %p", iface);
+	NET_DBG("Starting DAD for iface %d", net_if_get_by_iface(iface));
 
 	ret = net_if_config_ipv6_get(iface, &ipv6);
 	if (ret < 0) {
@@ -1532,8 +1533,8 @@ static void rs_timeout(struct k_work *work)
 		}
 
 		if (iface) {
-			NET_DBG("RS no respond iface %p count %d",
-				iface, ipv6->rs_count);
+			NET_DBG("RS no respond iface %d count %d",
+				net_if_get_by_iface(iface), ipv6->rs_count);
 			if (ipv6->rs_count < RS_COUNT) {
 				net_if_start_rs(iface);
 			}
@@ -1560,7 +1561,7 @@ void net_if_start_rs(struct net_if *iface)
 
 	net_if_unlock(iface);
 
-	NET_DBG("Starting ND/RS for iface %p", iface);
+	NET_DBG("Starting ND/RS for iface %d", net_if_get_by_iface(iface));
 
 	if (!net_ipv6_start_rs(iface)) {
 		ipv6->rs_start = k_uptime_get_32();
@@ -1591,7 +1592,7 @@ void net_if_stop_rs(struct net_if *iface)
 		goto out;
 	}
 
-	NET_DBG("Stopping ND/RS for iface %p", iface);
+	NET_DBG("Stopping ND/RS for iface %d", net_if_get_by_iface(iface));
 
 	k_mutex_lock(&lock, K_FOREVER);
 	sys_slist_find_and_remove(&active_rs_timers, &ipv6->rs_node);
@@ -4357,9 +4358,9 @@ void net_if_ipv4_start_acd(struct net_if *iface, struct net_if_addr *ifaddr)
 			net_sprint_ipv4_addr(&ifaddr->address.in_addr));
 
 		if (net_ipv4_acd_start(iface, ifaddr) != 0) {
-			NET_DBG("Failed to start ACD for %s on iface %p.",
+			NET_DBG("Failed to start ACD for %s on iface %d.",
 				net_sprint_ipv4_addr(&ifaddr->address.in_addr),
-				iface);
+				net_if_get_by_iface(iface));
 
 			/* Just act as if no conflict was detected. */
 			net_if_ipv4_acd_succeeded(iface, ifaddr);
@@ -4379,7 +4380,7 @@ void net_if_start_acd(struct net_if *iface)
 
 	net_if_lock(iface);
 
-	NET_DBG("Starting ACD for iface %p", iface);
+	NET_DBG("Starting ACD for iface %d", net_if_get_by_iface(iface));
 
 	ret = net_if_config_ipv4_get(iface, &ipv4);
 	if (ret < 0) {
@@ -5835,7 +5836,7 @@ int net_if_down(struct net_if *iface)
 {
 	int status = 0;
 
-	NET_DBG("iface %p", iface);
+	NET_DBG("iface %d", net_if_get_by_iface(iface));
 
 	net_if_lock(iface);
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -261,6 +261,10 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 		net_if_tx_lock(iface);
 		status = net_if_l2(iface)->send(iface, pkt);
 		net_if_tx_unlock(iface);
+		if (status < 0) {
+			NET_WARN("iface %d pkt %p send failure status %d",
+				 net_if_get_by_iface(iface), pkt, status);
+		}
 
 		if (IS_ENABLED(CONFIG_NET_PKT_TXTIME_STATS) ||
 		    IS_ENABLED(CONFIG_TRACING_NET_CORE)) {

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -352,21 +352,23 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	return pkt;
 }
 
-struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
-				struct in_addr *request_ip,
-				struct in_addr *current_ip)
+int net_arp_prepare(struct net_pkt *pkt,
+		    struct in_addr *request_ip,
+		    struct in_addr *current_ip,
+		    struct net_pkt **arp_pkt)
 {
 	bool is_ipv4_ll_used = false;
 	struct arp_entry *entry;
 	struct in_addr *addr;
 
 	if (!pkt || !pkt->buffer) {
-		return NULL;
+		return -EINVAL;
 	}
 
 	if (net_pkt_ipv4_acd(pkt)) {
-		return arp_prepare(net_pkt_iface(pkt), request_ip, NULL,
-				   pkt, current_ip);
+		*arp_pkt = arp_prepare(net_pkt_iface(pkt), request_ip, NULL,
+				       pkt, current_ip);
+		return *arp_pkt ? NET_ARP_PKT_REPLACED : -ENOMEM;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4_AUTO)) {
@@ -391,7 +393,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 					net_if_get_by_iface(net_pkt_iface(pkt)),
 					net_sprint_ipv4_addr(request_ip));
 
-				return NULL;
+				return -EINVAL;
 			}
 		} else {
 			addr = request_ip;
@@ -427,7 +429,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 				NET_DBG("Pending ARP request for %s, queuing pkt %p",
 					net_sprint_ipv4_addr(addr), pkt);
 				k_mutex_unlock(&arp_mutex);
-				return NULL;
+				return NET_ARP_PKT_QUEUED;
 			}
 
 			entry = NULL;
@@ -452,7 +454,8 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 		}
 
 		k_mutex_unlock(&arp_mutex);
-		return req;
+		*arp_pkt = req;
+		return req ? NET_ARP_PKT_REPLACED : -ENOMEM;
 	}
 
 	k_mutex_unlock(&arp_mutex);
@@ -469,7 +472,7 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 				   sizeof(struct net_eth_addr)),
 		net_sprint_ipv4_addr(NET_IPV4_HDR(pkt)->dst));
 
-	return pkt;
+	return NET_ARP_COMPLETE;
 }
 
 static void arp_gratuitous(struct net_if *iface,

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -7,8 +7,6 @@
 #ifndef __ARP_H
 #define __ARP_H
 
-#if defined(CONFIG_NET_ARP) && defined(CONFIG_NET_NATIVE)
-
 #include <zephyr/sys/slist.h>
 #include <zephyr/net/ethernet.h>
 
@@ -22,6 +20,15 @@ extern "C" {
  * @ingroup networking
  * @{
  */
+
+/** @brief Address resolution complete, destination link address injected */
+#define NET_ARP_COMPLETE     0
+/** @brief Destination link address unknown, ARP request to be sent instead */
+#define NET_ARP_PKT_REPLACED 1
+/** @brief Destination link address unknown, ARP request pending, packet queued */
+#define NET_ARP_PKT_QUEUED   2
+
+#if defined(CONFIG_NET_ARP) && defined(CONFIG_NET_NATIVE)
 
 #define NET_ARP_HDR(pkt) ((struct net_arp_hdr *)net_pkt_data(pkt))
 
@@ -43,9 +50,23 @@ struct net_arp_hdr {
 #define NET_ARP_REQUEST 1
 #define NET_ARP_REPLY   2
 
-struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
-				struct in_addr *request_ip,
-				struct in_addr *current_ip);
+/**
+ * @brief Prepare an ARP request, if required
+ *
+ * @param pkt Packet that wants to be sent
+ * @param request_ip Destination address of the packet
+ * @param current_ip Sending IP (Can be NULL)
+ * @param arp_pkt ARP packet that should be sent in place of @a pkt, if not NULL
+ *
+ * @retval NET_ARP_COMPLETE ARP information populated in @a pkt
+ * @retval NET_ARP_PKT_REPLACED ARP request to be sent existing in @a arp_pkt
+ * @retval NET_ARP_PKT_QUEUED @a pkt was queued for transmission on ARP resolution
+ * @retval <0 on failure
+ */
+int net_arp_prepare(struct net_pkt *pkt,
+			struct in_addr *request_ip,
+			struct in_addr *current_ip,
+			struct net_pkt **arp_pkt);
 enum net_verdict net_arp_input(struct net_pkt *pkt,
 			       struct net_eth_addr *src,
 			       struct net_eth_addr *dst);
@@ -72,16 +93,9 @@ void net_arp_update(struct net_if *iface, struct in_addr *src,
 		    struct net_eth_addr *hwaddr, bool gratuitous,
 		    bool force);
 
-/**
- * @}
- */
-
-#ifdef __cplusplus
-}
-#endif
 
 #else /* CONFIG_NET_ARP */
-#define net_arp_prepare(_kt, _u1, _u2) _kt
+#define net_arp_prepare(_kt, _u1, _u2, _arp) NET_ARP_COMPLETE
 #define net_arp_input(...) NET_OK
 #define net_arp_clear_cache(...)
 #define net_arp_foreach(...) 0
@@ -90,5 +104,13 @@ void net_arp_update(struct net_if *iface, struct in_addr *src,
 #define net_arp_update(...)
 
 #endif /* CONFIG_NET_ARP */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ARP_H */

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -489,8 +489,9 @@ static bool ethernet_fill_in_dst_on_ipv4_mcast(struct net_pkt *pkt,
 	return false;
 }
 
-static struct net_pkt *ethernet_ll_prepare_on_ipv4(struct net_if *iface,
-						   struct net_pkt *pkt)
+static int ethernet_ll_prepare_on_ipv4(struct net_if *iface,
+				       struct net_pkt *pkt,
+				       struct net_pkt **out)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 
@@ -503,36 +504,19 @@ static struct net_pkt *ethernet_ll_prepare_on_ipv4(struct net_if *iface,
 	}
 
 	if (ethernet_ipv4_dst_is_broadcast_or_mcast(pkt)) {
-		return pkt;
+		return NET_ARP_COMPLETE;
 	}
 
 	if (IS_ENABLED(CONFIG_NET_ARP)) {
-		struct net_pkt *arp_pkt;
-		int ret;
-
-		ret = net_arp_prepare(pkt, (struct in_addr *)NET_IPV4_HDR(pkt)->dst, NULL, &arp_pkt);
-		if (ret == NET_ARP_COMPLETE) {
-			NET_DBG("Found ARP entry, sending pkt %p to iface %d (%p)",
-				pkt, net_if_get_by_iface(iface), iface);
-		} else if (ret == NET_ARP_PKT_REPLACED) {
-			NET_DBG("Sending arp pkt %p (orig %p) to iface %d (%p)",
-				arp_pkt, pkt, net_if_get_by_iface(iface), iface);
-			return arp_pkt;
-		} else if (ret == NET_ARP_PKT_QUEUED) {
-			NET_DBG("Pending ARP request, pkt %p queued", pkt);
-			return NULL;
-		} else {
-			NET_WARN("ARP failure (%d)", ret);
-			return NULL;
-		}
+		return net_arp_prepare(pkt, (struct in_addr *)NET_IPV4_HDR(pkt)->dst, NULL, out);
 	}
 
-	return pkt;
+	return NET_ARP_COMPLETE;
 }
 #else
 #define ethernet_ipv4_dst_is_broadcast_or_mcast(...) false
 #define ethernet_fill_in_dst_on_ipv4_mcast(...) false
-#define ethernet_ll_prepare_on_ipv4(...) NULL
+#define ethernet_ll_prepare_on_ipv4(...) NET_ARP_COMPLETE
 #endif /* CONFIG_NET_IPV4 */
 
 #ifdef CONFIG_NET_IPV6
@@ -727,18 +711,33 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET &&
 	    net_pkt_ll_proto_type(pkt) == NET_ETH_PTYPE_IP) {
 		if (!net_pkt_ipv4_acd(pkt)) {
-			struct net_pkt *tmp;
+			struct net_pkt *arp;
 
-			tmp = ethernet_ll_prepare_on_ipv4(iface, pkt);
-			if (tmp == NULL) {
-				ret = -ENOMEM;
-				goto error;
-			} else if (IS_ENABLED(CONFIG_NET_ARP) && tmp != pkt) {
+			ret = ethernet_ll_prepare_on_ipv4(iface, pkt, &arp);
+			if (ret == NET_ARP_COMPLETE) {
+				/* ARP resolution complete, packet ready to send */
+				NET_DBG("Found ARP entry, sending pkt %p to iface %d (%p)",
+					pkt, net_if_get_by_iface(iface), iface);
+			} else if (ret == NET_ARP_PKT_REPLACED) {
 				/* Original pkt got queued and is replaced
 				 * by an ARP request packet.
 				 */
-				pkt = tmp;
+				NET_DBG("Sending arp pkt %p (orig %p) to iface %d (%p)",
+					arp, pkt, net_if_get_by_iface(iface), iface);
+				net_pkt_unref(pkt);
+				pkt = arp;
 				ptype = htons(net_pkt_ll_proto_type(pkt));
+			} else if (ret == NET_ARP_PKT_QUEUED) {
+				/* Original pkt got queued, pending resolution
+				 * of an ongoing ARP request.
+				 */
+				NET_DBG("Pending ARP request, pkt %p queued", pkt);
+				net_pkt_unref(pkt);
+				ret = 0;
+				goto error;
+			} else {
+				__ASSERT_NO_MSG(ret < 0);
+				goto error;
 			}
 		}
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET) &&

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -316,6 +316,7 @@ ZTEST(arp_fn_tests, test_arp)
 	struct net_eth_addr dst_lladdr;
 	struct net_pkt *pkt;
 	struct net_pkt *pkt2;
+	struct net_pkt *pkt_arp;
 	struct net_if *iface;
 	struct net_if_addr *ifaddr;
 	struct net_arp_hdr *arp_hdr;
@@ -367,25 +368,30 @@ ZTEST(arp_fn_tests, test_arp)
 
 	memcpy(net_buf_add(pkt->buffer, len), app_data, len);
 
-	ret = net_arp_prepare(pkt, &dst, NULL, &pkt2);
+	/* Duplicate packet */
+	pkt2 = net_pkt_clone(pkt, K_SECONDS(1));
+	zassert_not_null(pkt2, "out of mem");
+
+	/* First ARP request */
+	ret = net_arp_prepare(pkt, &dst, NULL, &pkt_arp);
 
 	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
-	/* pkt2 is the ARP packet and pkt is the IPv4 packet and it was
+	/* pkt_arp is the ARP packet and pkt is the IPv4 packet and it was
 	 * stored in ARP table.
 	 */
 
-	zassert_equal(net_pkt_ll_proto_type(pkt2), NET_ETH_PTYPE_ARP,
+	zassert_equal(net_pkt_ll_proto_type(pkt_arp), NET_ETH_PTYPE_ARP,
 		      "ARP packet type is wrong");
 
 	/**TESTPOINTS: Check packets*/
-	zassert_not_equal((void *)(pkt2), (void *)(pkt),
+	zassert_not_equal((void *)(pkt_arp), (void *)(pkt),
 		/* The packets cannot be the same as the ARP cache has
 		 * still room for the pkt.
 		 */
 		"ARP cache should still have free space");
 
-	zassert_not_null(pkt2, "ARP pkt is empty");
+	zassert_not_null(pkt_arp, "ARP pkt is empty");
 
 	/* The ARP cache should now have a link to pending net_pkt
 	 * that is to be sent after we have got an ARP reply.
@@ -395,8 +401,8 @@ ZTEST(arp_fn_tests, test_arp)
 
 	pending_pkt = pkt;
 
-	/* pkt2 should contain the arp header, verify it */
-	arp_hdr = NET_ARP_HDR(pkt2);
+	/* pkt_arp should contain the arp header, verify it */
+	arp_hdr = NET_ARP_HDR(pkt_arp);
 
 	if (arp_hdr->hwtype != htons(NET_ARP_HTYPE_ETH)) {
 		printk("ARP hwtype 0x%x, should be 0x%x\n",
@@ -447,26 +453,41 @@ ZTEST(arp_fn_tests, test_arp)
 	/* We could have send the new ARP request but for this test we
 	 * just free it.
 	 */
-	net_pkt_unref(pkt2);
+	net_pkt_unref(pkt_arp);
 
 	zassert_equal(atomic_get(&pkt->atomic_ref), 2,
 		"ARP cache should own the original packet");
 
+
+	/* A second packet going to the same destination */
+	pkt_arp = NULL;
+	ret = net_arp_prepare(pkt2, &dst, NULL, &pkt_arp);
+
+	/* Packet should have been queued, not generating an ARP request */
+	zassert_equal(NET_ARP_PKT_QUEUED, ret);
+	zassert_is_null(pkt_arp, "ARP packet should not have been generated");
+
+	zassert_equal(atomic_get(&pkt2->atomic_ref), 2,
+		"ARP cache should own the original packet");
+
+	/* Done with the duplicate packet */
+	net_pkt_unref(pkt2);
+
 	/* Then a case where target is not in the same subnet */
 	net_ipv4_addr_copy_raw(ipv4->dst, (uint8_t *)&dst_far);
 
-	ret = net_arp_prepare(pkt, &dst_far, NULL, &pkt2);
+	ret = net_arp_prepare(pkt, &dst_far, NULL, &pkt_arp);
 
 	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
-	zassert_not_equal((void *)(pkt2), (void *)(pkt),
+	zassert_not_equal((void *)(pkt_arp), (void *)(pkt),
 		"ARP cache should not find anything");
 
 	/**TESTPOINTS: Check if packets not empty*/
-	zassert_not_null(pkt2,
-		"ARP pkt2 is empty");
+	zassert_not_null(pkt_arp,
+		"ARP pkt_arp is empty");
 
-	arp_hdr = NET_ARP_HDR(pkt2);
+	arp_hdr = NET_ARP_HDR(pkt_arp);
 
 	if (!net_ipv4_addr_cmp_raw(arp_hdr->dst_ipaddr,
 				   (uint8_t *)&iface->config.ip.ipv4->gw)) {
@@ -476,7 +497,7 @@ ZTEST(arp_fn_tests, test_arp)
 		zassert_true(0, "exiting");
 	}
 
-	net_pkt_unref(pkt2);
+	net_pkt_unref(pkt_arp);
 
 	/* Try to find the same destination again, this should fail as there
 	 * is a pending request in ARP cache.
@@ -488,14 +509,23 @@ ZTEST(arp_fn_tests, test_arp)
 	 */
 	net_pkt_ref(pkt);
 
-	ret = net_arp_prepare(pkt, &dst_far, NULL, &pkt2);
+	ret = net_arp_prepare(pkt, &dst_far, NULL, &pkt_arp);
 
 	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
-	zassert_not_null(pkt2,
+	zassert_not_null(pkt_arp,
 		"ARP cache is not sending the request again");
 
-	net_pkt_unref(pkt2);
+	net_pkt_unref(pkt_arp);
+
+	ret = net_arp_prepare(pkt, &dst_far, NULL, &pkt_arp);
+
+	zassert_equal(NET_ARP_PKT_REPLACED, ret);
+
+	zassert_not_null(pkt_arp,
+		"ARP cache is not sending the request again");
+
+	net_pkt_unref(pkt_arp);
 
 	/* Try to find the different destination, this should fail too
 	 * as the cache table should be full.
@@ -507,11 +537,11 @@ ZTEST(arp_fn_tests, test_arp)
 	 */
 	net_pkt_ref(pkt);
 
-	ret = net_arp_prepare(pkt, &dst_far2, NULL, &pkt2);
+	ret = net_arp_prepare(pkt, &dst_far2, NULL, &pkt_arp);
 
 	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
-	zassert_not_null(pkt2,
+	zassert_not_null(pkt_arp,
 		"ARP cache did not send a req");
 
 	/* Restore the original address so that following test case can
@@ -535,13 +565,13 @@ ZTEST(arp_fn_tests, test_arp)
 
 	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_ARP);
 
-	pkt2 = prepare_arp_reply(iface, pkt, &eth_hwaddr, &eth_hdr);
+	pkt_arp = prepare_arp_reply(iface, pkt, &eth_hwaddr, &eth_hdr);
 
-	zassert_not_null(pkt2, "ARP reply generation failed.");
+	zassert_not_null(pkt_arp, "ARP reply generation failed.");
 
 	/* The pending packet should now be sent */
-	switch (net_arp_input(pkt2,
-			      (struct net_eth_addr *)net_pkt_lladdr_src(pkt2)->addr,
+	switch (net_arp_input(pkt_arp,
+			      (struct net_eth_addr *)net_pkt_lladdr_src(pkt_arp)->addr,
 			      &dst_lladdr)) {
 	case NET_OK:
 	case NET_CONTINUE:
@@ -580,15 +610,15 @@ ZTEST(arp_fn_tests, test_arp)
 
 	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_ARP);
 
-	pkt2 = prepare_arp_request(iface, pkt, &eth_hwaddr, &eth_hdr);
+	pkt_arp = prepare_arp_request(iface, pkt, &eth_hwaddr, &eth_hdr);
 
 	/**TESTPOINT: Check if ARP request generation failed*/
-	zassert_not_null(pkt2, "ARP request generation failed.");
+	zassert_not_null(pkt_arp, "ARP request generation failed.");
 
 	req_test = true;
 
-	switch (net_arp_input(pkt2,
-			      (struct net_eth_addr *)net_pkt_lladdr_src(pkt2)->addr,
+	switch (net_arp_input(pkt_arp,
+			      (struct net_eth_addr *)net_pkt_lladdr_src(pkt_arp)->addr,
 			      &dst_lladdr)) {
 	case NET_OK:
 	case NET_CONTINUE:

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -320,7 +320,7 @@ ZTEST(arp_fn_tests, test_arp)
 	struct net_if_addr *ifaddr;
 	struct net_arp_hdr *arp_hdr;
 	struct net_ipv4_hdr *ipv4;
-	int len;
+	int len, ret;
 
 	struct in_addr dst = { { { 192, 0, 2, 2 } } };
 	struct in_addr dst_far = { { { 10, 11, 12, 13 } } };
@@ -367,7 +367,9 @@ ZTEST(arp_fn_tests, test_arp)
 
 	memcpy(net_buf_add(pkt->buffer, len), app_data, len);
 
-	pkt2 = net_arp_prepare(pkt, &dst, NULL);
+	ret = net_arp_prepare(pkt, &dst, NULL, &pkt2);
+
+	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
 	/* pkt2 is the ARP packet and pkt is the IPv4 packet and it was
 	 * stored in ARP table.
@@ -453,7 +455,9 @@ ZTEST(arp_fn_tests, test_arp)
 	/* Then a case where target is not in the same subnet */
 	net_ipv4_addr_copy_raw(ipv4->dst, (uint8_t *)&dst_far);
 
-	pkt2 = net_arp_prepare(pkt, &dst_far, NULL);
+	ret = net_arp_prepare(pkt, &dst_far, NULL, &pkt2);
+
+	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
 	zassert_not_equal((void *)(pkt2), (void *)(pkt),
 		"ARP cache should not find anything");
@@ -484,7 +488,9 @@ ZTEST(arp_fn_tests, test_arp)
 	 */
 	net_pkt_ref(pkt);
 
-	pkt2 = net_arp_prepare(pkt, &dst_far, NULL);
+	ret = net_arp_prepare(pkt, &dst_far, NULL, &pkt2);
+
+	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
 	zassert_not_null(pkt2,
 		"ARP cache is not sending the request again");
@@ -501,7 +507,9 @@ ZTEST(arp_fn_tests, test_arp)
 	 */
 	net_pkt_ref(pkt);
 
-	pkt2 = net_arp_prepare(pkt, &dst_far2, NULL);
+	ret = net_arp_prepare(pkt, &dst_far2, NULL, &pkt2);
+
+	zassert_equal(NET_ARP_PKT_REPLACED, ret);
 
 	zassert_not_null(pkt2,
 		"ARP cache did not send a req");


### PR DESCRIPTION
Update `net_arp_prepare` to return a return code instead of a pointer, so that the various results of the function can be differentiated.

The differentiated return codes are then used by `ethernet_send` to properly handle the case where the packet is queued for later transmission because the ARP request is in progress, instead of returning an error.