### PR TITLE
boards:rakwireless:rak3172: Fix RF controller pins

### DIFF
--- a/boards/rakwireless/rak3172/rak3172.dts
+++ b/boards/rakwireless/rak3172/rak3172.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 #include <st/wl/stm32wle5Xc.dtsi>
 #include <st/wl/stm32wle5ccux-pinctrl.dtsi>
+#include <arm/rakwireless/rak3172.dtsi>
 
 / {
 	model = "RAKWireless RAK3172 WisDuo LPWAN Module with a STM32WLE5CC SoC";
@@ -114,24 +115,8 @@
 	status = "okay";
 };
 
-&clk_lse {
-	clock-frequency = <32768>;
-};
-
 &clk_hsi {
 	status = "okay";
-};
-
-&subghzspi {
-	status = "okay";
-
-	lora: radio@0 {
-		status = "okay";
-		tx-enable-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>; /* FE_CTRL1 */
-		rx-enable-gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;  /* FE_CTRL2 */
-		power-amplifier-output = "rfo-lp";
-		rfo-lp-max-power = <14>;
-	};
 };
 
 &flash0 {

--- a/dts/arm/rakwireless/rak3172.dtsi
+++ b/dts/arm/rakwireless/rak3172.dtsi
@@ -18,8 +18,8 @@
 	status = "okay";
 	lora: radio@0 {
 		status = "okay";
-		tx-enable-gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
-		rx-enable-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+		tx-enable-gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+		rx-enable-gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 		power-amplifier-output = "rfo-hp";
 		rfo-hp-max-power = <22>;
 	};


### PR DESCRIPTION
Fixing wrongly defined tx-enable and rx-enable pins.