### PR TITLE
boards: nxp: frdm_mcxn947: add RTC to supported features

### DIFF
--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -26,6 +26,7 @@ supported:
   - i3c
   - pwm
   - regulator
+  - rtc
   - sdhc
   - spi
   - usb_device

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -25,6 +25,7 @@ supported:
   - i3c
   - pwm
   - regulator
+  - rtc
   - sdhc
   - spi
   - usb_device


### PR DESCRIPTION
Enable Twister to test RTC feature on this board.

tests/drivers/rtc passes using Twister