### PR TITLE
Adds support for STM32F401XD variants

### DIFF
--- a/dts/arm/st/f4/stm32f401Xd.dtsi
+++ b/dts/arm/st/f4/stm32f401Xd.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Cirrus Logic, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/f4/stm32f401.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(96)>;
+	};
+
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(384)>;
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -43,6 +43,7 @@ family:
   - name: stm32f4x
     socs:
     - name: stm32f401xc
+    - name: stm32f401xd
     - name: stm32f401xe
     - name: stm32f405xx
     - name: stm32f407xx

--- a/soc/st/stm32/stm32f4x/Kconfig.defconfig.stm32f401xd
+++ b/soc/st/stm32/stm32f4x/Kconfig.defconfig.stm32f401xd
@@ -1,0 +1,11 @@
+# ST STM32F401xD MCU configuration options
+
+# Copyright (c) 2025 Cirrus Logic, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32F401XD
+
+config NUM_IRQS
+	default 85
+
+endif # SOC_STM32F401XD

--- a/soc/st/stm32/stm32f4x/Kconfig.soc
+++ b/soc/st/stm32/stm32f4x/Kconfig.soc
@@ -14,6 +14,10 @@ config SOC_STM32F401XC
 	bool
 	select SOC_SERIES_STM32F4X
 
+config SOC_STM32F401XD
+	bool
+	select SOC_SERIES_STM32F4X
+
 config SOC_STM32F401XE
 	bool
 	select SOC_SERIES_STM32F4X
@@ -100,6 +104,7 @@ config SOC_STM32F479XX
 
 config SOC
 	default "stm32f401xc" if SOC_STM32F401XC
+	default "stm32f401xd" if SOC_STM32F401XD
 	default "stm32f401xe" if SOC_STM32F401XE
 	default "stm32f405xx" if SOC_STM32F405XX
 	default "stm32f407xx" if SOC_STM32F407XE


### PR DESCRIPTION
This PR adds support for the STM32F401XD family of SoCs. This family is closely related to the STM32F401XE family of devices and share a common datasheet.

The STM32F401XD family has a smaller flash memory of 384 kB versus the 512 kB of flash memory in the STM32F401XE family.