### PR TITLE
drivers: clock_control_mcux_syscon: confine RTC code to SOC_SERIES_MCXN

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -122,11 +122,9 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(rtc), okay)
-#if CONFIG_SOC_SERIES_IMXRT5XX
+#if defined(CONFIG_SOC_SERIES_IMXRT5XX) || defined(CONFIG_SOC_SERIES_IMXRT6XX)
 	CLOCK_EnableOsc32K(true);
-#elif CONFIG_SOC_SERIES_IMXRT6XX
-	/* No configuration */
-#else /* !CONFIG_SOC_SERIES_IMXRT5XX | !CONFIG_SOC_SERIES_IMXRT6XX */
+#elif CONFIG_SOC_SERIES_MCXN
 /* 0x0 Clock Select Value Set IRTC to use FRO 16K Clk */
 #if DT_PROP(DT_NODELABEL(rtc), clock_select) == 0x0
 	CLOCK_SetupClk16KClocking(kCLOCK_Clk16KToVbat | kCLOCK_Clk16KToMain);
@@ -135,7 +133,7 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 	CLOCK_SetupOsc32KClocking(kCLOCK_Osc32kToVbat | kCLOCK_Osc32kToMain);
 #endif /* DT_PROP(DT_NODELABEL(rtc), clock_select) */
 	CLOCK_EnableClock(kCLOCK_Rtc0);
-#endif /* CONFIG_SOC_SERIES_IMXRT5XX */
+#endif /* CONFIG_SOC_SERIES_MCXN */
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(rtc), okay) */
 
 	return 0;


### PR DESCRIPTION
Some RTC clock code introduced is specific to SOC_SERIES_MCXN, and causes build failures on other SOCs.

Resolves #88872 