### PR TITLE
driver: pwm: Infineon: pwm_ifx_cat1: Use PWM buffer registers for updates

### DIFF
--- a/samples/basic/blinky_pwm/boards/cyw920829m2evk_02.overlay
+++ b/samples/basic/blinky_pwm/boards/cyw920829m2evk_02.overlay
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm_ifx_cat1.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm0_0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM MB1";
+		};
+	};
+};
+
+&pwm0_0 {
+	status        = "okay";
+	pinctrl-0     = <&p1_1_pwm0_0>;
+	pinctrl-names = "default";
+	divider-type  = <CY_SYSCLK_DIV_16_BIT>;
+	divider-sel   = <1>;
+	divider-val   = <9599>;
+};
+
+
+&pinctrl {
+	p1_1_pwm0_0: p1_1_pwm0_0 {
+		drive-push-pull;
+	};
+};


### PR DESCRIPTION
The current PWM driver updates the PWM period and compare values directly.  If the new period value is lower than the current timer count value, the counter is never reset and the PWM stops functioning.  This occurs when running the blinky_pwm sample causing the LED to stop blinking.  

If the compare value is changed to a new value lower than the current count value, the compare event is missed resulting in an pulse longer than expected.  This can be seen occasionally in the fade_led sample causing the LED to flicker bright occasionally.  

This patch addresses both of these issues by writing the new period and compare values to the PWM buffer registers and triggering a switch event.  This will cause the new period and compare values to take effect at the next timer TC event.  