### PR TITLE
boards: qemu_xtensa/sample_controller32/mpu: enable twister

### DIFF
--- a/boards/qemu/xtensa/qemu_xtensa_sample_controller32_mpu.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_sample_controller32_mpu.yaml
@@ -4,6 +4,8 @@ type: qemu
 simulation:
   - name: qemu
 arch: xtensa
+toolchain:
+  - zephyr
 testing:
   default: true
   ignore_tags:

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -23,6 +23,10 @@
 #include <zephyr/kernel/mm.h>
 #include <sys/time.h>
 
+#ifdef CONFIG_XTENSA
+#include <xtensa/config/core-isa.h>
+#endif
+
 int _fstat(int fd, struct stat *st);
 int _read(int fd, void *buf, int nbytes);
 int _write(int fd, const void *buf, int nbytes);
@@ -88,6 +92,9 @@ int _getpid(void);
 		#elif defined(CONFIG_ARC)
 			#define HEAP_BASE	ROUND_UP(USED_RAM_END_ADDR, \
 							  Z_ARC_MPU_ALIGN)
+		#elif defined(CONFIG_XTENSA)
+			#define HEAP_BASE	ROUND_UP(USED_RAM_END_ADDR, \
+							  XCHAL_MPU_ALIGN)
 		#else
 			#error "Unsupported platform"
 		#endif /* CONFIG_<arch> */

--- a/subsys/logging/backends/Kconfig.xtensa_sim
+++ b/subsys/logging/backends/Kconfig.xtensa_sim
@@ -4,7 +4,7 @@
 config LOG_BACKEND_XTENSA_SIM
 	bool "Xtensa simulator backend"
 	depends on SIMULATOR_XTENSA
-	default y if SOC_XTENSA_SAMPLE_CONTROLLER || SOC_XTENSA_DC233C
+	default y if SIMULATOR_XTENSA
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  Enable backend in xtensa simulator


### PR DESCRIPTION
Since Zephyr SDK 0.16.9, it has support for building the board `qemu_xtensa/sample_controller32/mpu`. Addd the corresponding toolchain entry in the YAML file so it can built with twister without forcing toolchain.

This also includes some changes on logging and newlib hooks to enable running twister and passing.