### PR TITLE
Flexio SPI loopback test failed on fast speed(16Mbps)

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -225,11 +225,8 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 #endif
 
 #ifdef CONFIG_MCUX_FLEXIO
-	case IMX_CCM_FLEXIO1_CLK:
-		clock_root = kCLOCK_Root_Flexio1;
-		break;
-	case IMX_CCM_FLEXIO2_CLK:
-		clock_root = kCLOCK_Root_Flexio2;
+	case IMX_CCM_FLEXIO_CLK:
+		clock_root = kCLOCK_Root_Flexio1 + instance;
 		break;
 #endif
 

--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -206,6 +206,24 @@ static void spi_flexio_master_init(FLEXIO_SPI_Type *base, flexio_spi_master_conf
 	timerConfig.timerStart      = kFLEXIO_TimerStartBitEnabled;
 	/* Low 8-bits are used to configure baudrate. */
 	timerDiv = (uint16_t)(srcClock_Hz / masterConfig->baudRate_Bps);
+
+	/* Add protection if the required band rate overflows.
+	 * FLEXIO input freq can't meet required band rate. Max band rate can
+	 * not exceed 1/4 of input freq. You can raise input freq or lower
+	 * bandrate required to remove this warning.
+	 */
+	if (timerDiv < 4) {
+		timerDiv = 4;
+	}
+	/* If timeDiv is odd, get it to even. */
+	timerDiv += timerDiv & 1UL;
+
+	if (masterConfig->baudRate_Bps != (srcClock_Hz / timerDiv)) {
+		LOG_WRN("Bandrate req:%uKbps, got:%uKbps",
+			(uint32_t)(masterConfig->baudRate_Bps / 1000),
+			(uint32_t)(srcClock_Hz / (timerDiv*1000)));
+	}
+
 	timerDiv = timerDiv / 2U - 1U;
 	/* High 8-bits are used to configure shift clock edges(transfer width). */
 	timerCmp = ((uint16_t)masterConfig->dataMode * 2U - 1U) << 8U;

--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -204,13 +204,13 @@ static void spi_flexio_master_init(FLEXIO_SPI_Type *base, flexio_spi_master_conf
 	timerConfig.timerEnable     = kFLEXIO_TimerEnableOnTriggerHigh;
 	timerConfig.timerStop       = kFLEXIO_TimerStopBitEnableOnTimerDisable;
 	timerConfig.timerStart      = kFLEXIO_TimerStartBitEnabled;
-	/* Low 8-bits are used to configure baudrate. */
+	/* Low 8-bits are used to configure baud rate. */
 	timerDiv = (uint16_t)(srcClock_Hz / masterConfig->baudRate_Bps);
 
-	/* Add protection if the required band rate overflows.
-	 * FLEXIO input freq can't meet required band rate. Max band rate can
+	/* Add protection if the required baud rate overflows.
+	 * FLEXIO input freq can't meet required baud rate. Max baud rate can
 	 * not exceed 1/4 of input freq. You can raise input freq or lower
-	 * bandrate required to remove this warning.
+	 * baud rate required to remove this warning.
 	 */
 	if (timerDiv < 4) {
 		timerDiv = 4;
@@ -219,7 +219,7 @@ static void spi_flexio_master_init(FLEXIO_SPI_Type *base, flexio_spi_master_conf
 	timerDiv += timerDiv & 1UL;
 
 	if (masterConfig->baudRate_Bps != (srcClock_Hz / timerDiv)) {
-		LOG_WRN("Bandrate req:%uKbps, got:%uKbps",
+		LOG_WRN("baud rate req:%uKbps, got:%uKbps",
 			(uint32_t)(masterConfig->baudRate_Bps / 1000),
 			(uint32_t)(srcClock_Hz / (timerDiv*1000)));
 	}

--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -215,6 +215,18 @@ __weak void clock_init(void)
 	CLOCK_SetDiv(kCLOCK_LpspiDiv, 0); /* Set SPI divider to 1 */
 #endif
 
+#ifdef CONFIG_MCUX_FLEXIO
+	/* Configure input clock to be able to reach the datasheet specified baud rate.
+	 * FLEXIO can reach to 120MHz. Select USB pll(480M) as source and divide by 2.
+	 * pre divider by default is 1 which means divide by 2.
+	 */
+	CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+	CLOCK_SetDiv(kCLOCK_Flexio1Div, 1);
+
+	CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+	CLOCK_SetDiv(kCLOCK_Flexio2Div, 1);
+#endif
+
 #ifdef CONFIG_DISPLAY_MCUX_ELCDIF
 	/* MUX selects video PLL, which is initialized to 93MHz */
 	CLOCK_SetMux(kCLOCK_LcdifPreMux, 2);

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -391,6 +391,18 @@ __weak void clock_init(void)
 	CLOCK_SetRootClock(kCLOCK_Root_Lpuart2, &rootCfg);
 #endif
 
+#ifdef CONFIG_MCUX_FLEXIO
+	/* Configure flexio1 with oscRC400M */
+	rootCfg.mux = kCLOCK_FLEXIO1_ClockRoot_MuxOscRc400M;
+	rootCfg.div = 2;
+	CLOCK_SetRootClock(kCLOCK_Root_Flexio1, &rootCfg);
+
+	/* Configure flexio2 using oscRC400M */
+	rootCfg.mux = kCLOCK_FLEXIO2_ClockRoot_MuxOscRc400M;
+	rootCfg.div = 2;
+	CLOCK_SetRootClock(kCLOCK_Root_Flexio2, &rootCfg);
+#endif
+
 #ifdef CONFIG_I2C_MCUX_LPI2C
 	/* Configure Lpi2c1 using Osc48MDiv2 */
 	rootCfg.mux = kCLOCK_LPI2C1_ClockRoot_MuxOscRc48MDiv2;

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_flexio_spi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_flexio_spi.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpspi1 {
+	dmas = <&edma0 0 36>, <&edma0 1 37>;
+	dma-names = "rx", "tx";
+	status = "disabled";
+};
+
+
+&pinctrl {
+	pinmux_flexio2spi1: pinmux_flexio2spi1 {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_29_gpio9_io28>, /* cs */
+				 <&iomuxc_gpio_ad_28_flexio2_flexio28>, /* sck */
+				 <&iomuxc_gpio_ad_30_flexio2_flexio30>, /* sdo */
+				 <&iomuxc_gpio_ad_31_flexio2_flexio31>; /* sdi */
+			drive-strength = "high";
+			slew-rate = "slow";
+
+		};
+	};
+};
+
+
+&flexio2 {
+	status = "okay";
+
+	flexio2spi1: flexio2spi1 {
+		compatible = "nxp,flexio-spi";
+		cs-gpios = <&gpio9 28 GPIO_ACTIVE_LOW>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		sdo-pin = <30>;
+		sdi-pin = <31>;
+		sck-pin = <28>;
+		pinctrl-0 = <&pinmux_flexio2spi1>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		slow@0 {
+			compatible = "test-spi-loopback-slow";
+			reg = <0>;
+			spi-max-frequency = <500000>;
+		};
+		fast@0 {
+			compatible = "test-spi-loopback-fast";
+			reg = <0>;
+			spi-max-frequency = <16000000>;
+		};
+	};
+};

--- a/tests/drivers/spi/spi_loopback/overlay-mcux-flexio-spi.overlay
+++ b/tests/drivers/spi/spi_loopback/overlay-mcux-flexio-spi.overlay
@@ -1,8 +1,13 @@
 /*
  * Copyright (c) 2024, STRIM, ALC
+ * Copyright (c) 2025, NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+ /* On RT1060 EVKC, SPI loopback test, short J17-9 and J17-10
+  * On RT1064 EVK,  SPI loopback test, short J24-9 and J24-10
+  */
 
 &pinctrl {
 	pinmux_flexio3spi0: pinmux_flexio3spi0 {
@@ -10,25 +15,14 @@
 			pinmux =
 				<&iomuxc_gpio_ad_b0_03_gpio1_io03>, /* cs */
 				<&iomuxc_gpio_ad_b1_10_flexio3_flexio10>, /* sck */
-				<&iomuxc_gpio_ad_b1_01_flexio3_flexio01>, /* sdo */
-				<&iomuxc_gpio_ad_b1_04_flexio3_flexio04>; /* sdi */
-			drive-strength = "r0-6";
-			slew-rate = "slow";
-			nxp,speed = "150-mhz";
-		};
-	};
-	pinmux_flexio3spi1: pinmux_flexio3spi1 {
-		group0 {
-			pinmux =
-				<&iomuxc_gpio_ad_b0_02_gpio1_io02>, /* cs */
-				<&iomuxc_gpio_ad_b1_11_flexio3_flexio11>, /* sck */
 				<&iomuxc_gpio_ad_b1_00_flexio3_flexio00>, /* sdo */
-				<&iomuxc_gpio_ad_b1_05_flexio3_flexio05>; /* sdi */
+				<&iomuxc_gpio_ad_b1_01_flexio3_flexio01>; /* sdi */
 			drive-strength = "r0-6";
 			slew-rate = "slow";
 			nxp,speed = "150-mhz";
 		};
 	};
+
 };
 
 &flexio3 {
@@ -39,8 +33,8 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		cs-gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
-		sdo-pin = <1>;
-		sdi-pin = <4>;
+		sdo-pin = <0>;
+		sdi-pin = <1>;
 		sck-pin = <10>;
 		pinctrl-0 = <&pinmux_flexio3spi0>;
 		pinctrl-names = "default";
@@ -50,28 +44,13 @@
 			reg = <0>;
 			spi-max-frequency = <500000>;
 		};
-	};
-	flexio3_spi1: flexio3_spi1 {
-		compatible = "nxp,flexio-spi";
-		status = "okay";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		cs-gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
-		sdo-pin = <0>;
-		sdi-pin = <5>;
-		sck-pin = <11>;
-		pinctrl-0 = <&pinmux_flexio3spi1>;
-		pinctrl-names = "default";
+
 		fast@0 {
 			status = "okay";
 			compatible = "test-spi-loopback-fast";
 			reg = <0>;
-			spi-max-frequency = <4000000>;
+			spi-max-frequency = <16000000>;
 		};
 	};
-};
 
-/* pinmux_lpspi3 overlaps pinmux_flexio3spi1 */
-&lpspi3 {
-	status = "disabled";
 };

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -228,12 +228,21 @@ tests:
     extra_args: DTC_OVERLAY_FILE="overlay-mcux-flexio-spi.overlay"
     filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
             CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
-    platform_allow: mimxrt1064_evk
+    platform_allow:
+      - mimxrt1064_evk
+      - mimxrt1060_evk/mimxrt1062/qspi
+  drivers.spi.mimxrt1170_evk_mimxrt1176_cm7_flexio_spi.loopback:
+    extra_args: DTC_OVERLAY_FILE="boards/mimxrt1170_evk_mimxrt1176_cm7_flexio_spi.overlay"
+    filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
+            CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
+    platform_allow:
+      - mimxrt1170_evk/mimxrt1176/cm7
   drivers.spi.mimxrt1040evk_flexio_spi.loopback:
     extra_args: DTC_OVERLAY_FILE="boards/mimxrt1040_evk_flexio_spi.overlay"
     filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
             CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
-    platform_allow: mimxrt1040_evk
+    platform_allow:
+      - mimxrt1040_evk
   drivers.spi.nrf54h_fast_2mhz:
     extra_args:
       - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"


### PR DESCRIPTION
    drivers: spi: nxp: flexiospi spi_loopback test failed on flexio spi

    Several reason cause loopback test failed:
    a) FlexIO input frequency is not correct, on RT11xx, input freq is 24M,
    while max bandrate can reach 1/4 of input freq, so it can only support
    6Mbps.
    b) Flexio shift register depend on correct timer output to triggger TX
    and TX, if timer comparison value is not accurate, RX error happens on
    high band rate. This is the reason why test fails on RT1060.

    also fix a error on FlexIO clock ID calculation.

test: drivers: spi_loopback: Flexio spi support for RT1060 EVKC and RT1170 EVK

    Add overlay file for RT1170 EVK and simply existing flexio spi overlay
    file for RT1060 and RT1064 EVK. One flexio-spi interface for both slow
    and fast tests. Fast bandrate set to 16Mbps now.

fix this issue: https://github.com/zephyrproject-rtos/zephyr/issues/77992