### PR TITLE
tests: drivers: uart: async_api: Fix chain write

### DIFF
--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -17,7 +17,7 @@
 #define NOCACHE_MEM 0
 #endif /* CONFIG_NOCACHE_MEMORY */
 
-K_SEM_DEFINE(tx_done, 0, 1);
+K_SEM_DEFINE(tx_done, 0, 2);
 K_SEM_DEFINE(tx_aborted, 0, 1);
 K_SEM_DEFINE(rx_rdy, 0, 1);
 K_SEM_DEFINE(rx_buf_coherency, 0, 255);
@@ -834,8 +834,8 @@ static void test_chained_write_callback(const struct device *dev,
 	switch (evt->type) {
 	case UART_TX_DONE:
 		if (chained_write_next_buf) {
-			uart_tx(dev, chained_write_tx_bufs[1], 10, 100 * USEC_PER_MSEC);
 			chained_write_next_buf = false;
+			uart_tx(dev, chained_write_tx_bufs[1], 10, 100 * USEC_PER_MSEC);
 		}
 		tx_sent = 1;
 		k_sem_give(&tx_done);


### PR DESCRIPTION
This fixes the case where uart_tx() called from tx callback fill UART output fifo and immediately execute callback again. This can happen when hardware does not have interrupt for output FIFO empty and there is no non-blocking way to tell that transfer finished.
For such case as soon as output FIFO is filled there is interrupt that informs that more data can be transmitted. For hardware with 32 byte fifo callback was seen to be executed recursively 3 times.
That would not be a problem if chained_write_next_buf was set BEFORE next call uart_tx().

Additionally semaphore max value is increased to 2 to accommodate such case.