### PR TITLE
drivers: display: sdl: Ensure task thread is run once on init

### DIFF
--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -90,7 +90,7 @@ config SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_2
 
 config SDL_DISPLAY_THREAD_PRIORITY
 	int "SDL display thread priority"
-	default NUM_PREEMPT_PRIORITIES
+	default MAIN_THREAD_PRIORITY
 	help
 	  Drawing thread priority.
 

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -125,6 +125,8 @@ static void sdl_task_thread(void *p1, void *p2, void *p3)
 					 CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_2,
 					 CONFIG_SDL_DISPLAY_TRANSPARENCY_GRID_CELL_SIZE);
 
+	k_sem_give(&disp_data->task_sem);
+
 	if (rc != 0) {
 		nsi_print_error_and_exit("Failed to create SDL display");
 		return;
@@ -169,6 +171,8 @@ static int sdl_display_init(const struct device *dev)
 			K_KERNEL_STACK_SIZEOF(disp_data->sdl_thread_stack),
 			sdl_task_thread, (void *)dev, NULL, NULL,
 			CONFIG_SDL_DISPLAY_THREAD_PRIORITY, 0, K_NO_WAIT);
+	/* Ensure task thread has performed the init */
+	k_sem_take(&disp_data->task_sem, K_FOREVER);
 
 	return 0;
 }


### PR DESCRIPTION
Adds a yield after creating the display thread to ensure that the thread is run once, executing the SDL init.

Resolves #88818 