### PR TITLE
 drivers: serial: uart_mcux_lpuart: Restore lpuart CTRL register.

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1249,6 +1249,7 @@ static int mcux_lpuart_configure(const struct device *dev,
 static void mcux_lpuart_line_ctrl_set_rts(const struct device *dev, uint32_t val)
 {
 	const struct mcux_lpuart_config *config = dev->config;
+	uint32_t old_ctrl = config->base->CTRL;
 
 	/* Disable Transmitter and Receiver */
 	config->base->CTRL &= ~(LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK);
@@ -1262,6 +1263,9 @@ static void mcux_lpuart_line_ctrl_set_rts(const struct device *dev, uint32_t val
 		config->base->MODIR &= ~(LPUART_MODIR_RXRTSE_MASK);
 		config->base->MODIR |= (LPUART_MODIR_TXRTSPOL_MASK | LPUART_MODIR_TXRTSE_MASK);
 	}
+
+	/* Restore Transmitter and Receiver */
+	config->base->CTRL = old_ctrl;
 }
 #else
 #define mcux_lpuart_line_ctrl_set_rts(dev, val) ret = -ENOTSUP


### PR DESCRIPTION
When RTS/CTS is toggled it disables the receiver and transmitter bits to be 
able to change the flow control bits in the MODIR register.

After it has done so, it should restore the original value of the CTRL register
to re-enable the transmitter and/or receiver if they were enabled before
calling the mcux_lpuart_line_ctrl_set_rts()  function.