### PR TITLE
drivers: video: emul_rx: hotfix: force use of constant value

### DIFF
--- a/drivers/video/video_emul_rx.c
+++ b/drivers/video/video_emul_rx.c
@@ -269,10 +269,11 @@ int emul_rx_init(const struct device *dev)
 	return 0;
 }
 
+#define SOURCE_DEV(n) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 0, 0)))
+
 #define EMUL_RX_DEFINE(n)                                                                          \
 	static const struct emul_rx_config emul_rx_cfg_##n = {                                     \
-		.source_dev =                                                                      \
-			DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 0, 0))),     \
+		.source_dev = SOURCE_DEV(n),                                                       \
 	};                                                                                         \
                                                                                                    \
 	static struct emul_rx_data emul_rx_data_##n = {                                            \
@@ -282,6 +283,6 @@ int emul_rx_init(const struct device *dev)
 	DEVICE_DT_INST_DEFINE(n, &emul_rx_init, NULL, &emul_rx_data_##n, &emul_rx_cfg_##n,         \
 			      POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY, &emul_rx_driver_api);       \
                                                                                                    \
-	VIDEO_DEVICE_DEFINE(emul_rx_##n, DEVICE_DT_INST_GET(n), emul_rx_cfg_##n.source_dev);
+	VIDEO_DEVICE_DEFINE(emul_rx_##n, DEVICE_DT_INST_GET(n), SOURCE_DEV(n));
 
 DT_INST_FOREACH_STATUS_OKAY(EMUL_RX_DEFINE)

--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -428,9 +428,11 @@ static DEVICE_API(video, esp32_driver_api) = {
 
 PINCTRL_DT_INST_DEFINE(0);
 
+#define SOURCE_DEV(n) DEVICE_DT_GET(DT_INST_PHANDLE(n, source))
+
 static const struct video_esp32_config esp32_config = {
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-	.source_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, source)),
+	.source_dev = SOURCE_DEV(0),
 	.dma_dev = ESP32_DT_INST_DMA_CTLR(0, rx),
 	.rx_dma_channel = DT_INST_DMAS_CELL_BY_NAME(0, rx, channel),
 	.data_width = DT_INST_PROP_OR(0, data_width, 8),
@@ -450,7 +452,7 @@ static struct video_esp32_data esp32_data = {0};
 DEVICE_DT_INST_DEFINE(0, video_esp32_init, NULL, &esp32_data, &esp32_config, POST_KERNEL,
 		      CONFIG_VIDEO_INIT_PRIORITY, &esp32_driver_api);
 
-VIDEO_DEVICE_DEFINE(esp32, DEVICE_DT_INST_GET(0), esp32_config.source_dev);
+VIDEO_DEVICE_DEFINE(esp32, DEVICE_DT_INST_GET(0), SOURCE_DEV(0));
 
 static int video_esp32_cam_init_master_clock(void)
 {

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -456,9 +456,11 @@ static DEVICE_API(video, video_mcux_csi_driver_api) = {
 #if 1 /* Unique Instance */
 PINCTRL_DT_INST_DEFINE(0);
 
+#define SOURCE_DEV(n) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 0, 0)))
+
 static const struct video_mcux_csi_config video_mcux_csi_config_0 = {
 	.base = (CSI_Type *)DT_INST_REG_ADDR(0),
-	.source_dev = DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(0, 0, 0))),
+	.source_dev = SOURCE_DEV(0),
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 
@@ -481,6 +483,6 @@ DEVICE_DT_INST_DEFINE(0, &video_mcux_csi_init_0, NULL, &video_mcux_csi_data_0,
 		      &video_mcux_csi_config_0, POST_KERNEL, CONFIG_VIDEO_MCUX_CSI_INIT_PRIORITY,
 		      &video_mcux_csi_driver_api);
 
-VIDEO_DEVICE_DEFINE(csi, DEVICE_DT_INST_GET(0), video_mcux_csi_config_0.source_dev);
+VIDEO_DEVICE_DEFINE(csi, DEVICE_DT_INST_GET(0), SOURCE_DEV(0));
 
 #endif

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -320,6 +320,8 @@ static int mipi_csi2rx_init(const struct device *dev)
 	return mipi_csi2rx_update_settings(dev, VIDEO_EP_ALL);
 }
 
+#define SOURCE_DEV(n) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 1, 0)))
+
 #define MIPI_CSI2RX_INIT(n)                                                                        \
 	static struct mipi_csi2rx_data mipi_csi2rx_data_##n = {                                    \
 		.csi2rxConfig.laneNum = DT_PROP_LEN(DT_INST_ENDPOINT_BY_ID(n, 1, 0), data_lanes),  \
@@ -331,15 +333,13 @@ static int mipi_csi2rx_init(const struct device *dev)
                                                                                                    \
 	static const struct mipi_csi2rx_config mipi_csi2rx_config_##n = {                          \
 		.base = (MIPI_CSI2RX_Type *)DT_INST_REG_ADDR(n),                                   \
-		.sensor_dev =                                                                      \
-			DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 1, 0))),     \
+		.sensor_dev = SOURCE_DEV(n),                                                       \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, &mipi_csi2rx_init, NULL, &mipi_csi2rx_data_##n,                   \
 			      &mipi_csi2rx_config_##n, POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,    \
 			      &mipi_csi2rx_driver_api);                                            \
                                                                                                    \
-	VIDEO_DEVICE_DEFINE(mipi_csi2rx_##n, DEVICE_DT_INST_GET(n),                                \
-			    mipi_csi2rx_config_##n.sensor_dev);
+	VIDEO_DEVICE_DEFINE(mipi_csi2rx_##n, DEVICE_DT_INST_GET(n), SOURCE_DEV(n));
 
 DT_INST_FOREACH_STATUS_OKAY(MIPI_CSI2RX_INIT)

--- a/drivers/video/video_mcux_smartdma.c
+++ b/drivers/video/video_mcux_smartdma.c
@@ -365,11 +365,13 @@ static DEVICE_API(video, nxp_video_sdma_api) = {
 	.flush = nxp_video_sdma_flush
 };
 
+#define SOURCE_DEV(inst) DEVICE_DT_GET(DT_INST_PHANDLE(inst, sensor))
+
 #define NXP_VIDEO_SDMA_INIT(inst)                                                                  \
 	PINCTRL_DT_INST_DEFINE(inst);                                                              \
 	const struct nxp_video_sdma_config sdma_config_##inst = {                                  \
 		.dma_dev = DEVICE_DT_GET(DT_INST_PARENT(inst)),                                    \
-		.sensor_dev = DEVICE_DT_GET(DT_INST_PHANDLE(inst, sensor)),                        \
+		.sensor_dev = SOURCE_DEV(n),                                                       \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                    \
 		.vsync_pin = DT_INST_PROP(inst, vsync_pin),                                        \
 		.hsync_pin = DT_INST_PROP(inst, hsync_pin),                                        \
@@ -383,6 +385,6 @@ static DEVICE_API(video, nxp_video_sdma_api) = {
 			      &sdma_config_##inst, POST_KERNEL,                                    \
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &nxp_video_sdma_api);            \
                                                                                                    \
-	VIDEO_DEVICE_DEFINE(sdma_##inst, DEVICE_DT_INST_GET(inst), sdma_config_##inst.sensor_dev);
+	VIDEO_DEVICE_DEFINE(sdma_##inst, DEVICE_DT_INST_GET(inst), SOURCE_DEV(inst));
 
 DT_INST_FOREACH_STATUS_OKAY(NXP_VIDEO_SDMA_INIT)

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -436,6 +436,8 @@ static struct video_stm32_dcmi_data video_stm32_dcmi_data_0 = {
 	},
 };
 
+#define SOURCE_DEV(n) DEVICE_DT_GET(DT_INST_PHANDLE(n, sensor))
+
 static const struct video_stm32_dcmi_config video_stm32_dcmi_config_0 = {
 	.pclken = {
 		.enr = DT_INST_CLOCKS_CELL(0, bits),
@@ -443,7 +445,7 @@ static const struct video_stm32_dcmi_config video_stm32_dcmi_config_0 = {
 	},
 	.irq_config = video_stm32_dcmi_irq_config_func,
 	.pctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
-	.sensor_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, sensor)),
+	.sensor_dev = SOURCE_DEV(0),
 	DCMI_DMA_CHANNEL(0, PERIPHERAL, MEMORY)
 };
 
@@ -500,4 +502,4 @@ DEVICE_DT_INST_DEFINE(0, &video_stm32_dcmi_init,
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,
 		    &video_stm32_dcmi_driver_api);
 
-VIDEO_DEVICE_DEFINE(dcmi, DEVICE_DT_INST_GET(0), video_stm32_dcmi_config_0.sensor_dev);
+VIDEO_DEVICE_DEFINE(dcmi, DEVICE_DT_INST_GET(0), SOURCE_DEV(0));


### PR DESCRIPTION
In some compilation attempts, the compiler did not accept a static const variable as initializer. This caused build errors in only some contexts. Always use the devicetree macros to access it.

**Note: this has not yet been tested: PR open to check if it fixes it in the actual Zephyr CI**