### PR TITLE
nrf70: Fix QSPI anomalies handling

### DIFF
--- a/drivers/wifi/nrf_wifi/CMakeLists.txt
+++ b/drivers/wifi/nrf_wifi/CMakeLists.txt
@@ -70,17 +70,6 @@ zephyr_library_sources_ifdef(CONFIG_NRF70_DEBUG_SHELL
   src/debug_shell.c
 )
 
-zephyr_compile_definitions_ifdef(CONFIG_NRF70_ON_QSPI
-# These are XIP related anomalies and aren't applicable for nRF7002 and cause
-# throughput issues.
-  -DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
-  -DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
-# nRF70 QSPI doesn't use 192MHz clock and most samples use 128MHz, this can cause anomaly 159
-# but as its rare and not seen in most cases, we can disable it.
-# Alternative is 128MHz CPU should be disabled that impacts Wi-Fi performance.
-  -DNRF53_ERRATA_159_ENABLE_WORKAROUND=0
-)
-
 zephyr_library_link_libraries(nrf70-buslib nrf-wifi-shim)
 
 if (CONFIG_NRF_WIFI_PATCHES_BUILTIN)

--- a/modules/nrf_wifi/bus/CMakeLists.txt
+++ b/modules/nrf_wifi/bus/CMakeLists.txt
@@ -8,16 +8,18 @@ set(NRF_WIFI_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
 if (CONFIG_NRF70_BUSLIB)
 
-  zephyr_compile_definitions_ifdef(CONFIG_NRF70_ON_QSPI
-  # These are XIP related anomalies and aren't applicable for nRF7002 and cause
-  # throughput issues.
-    -DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
-    -DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
-  # nRF70 QSPI doesn't use 192MHz clock and most samples use 128MHz, this can cause anomaly 159
-  # but as its rare and not seen in most cases, we can disable it.
-  # Alternative is 128MHz CPU should be disabled that impacts Wi-Fi performance.
-    -DNRF53_ERRATA_159_ENABLE_WORKAROUND=0
-  )
+  if(CONFIG_NRF70_ON_QSPI OR CONFIG_NORDIC_QSPI_NOR)
+    zephyr_compile_definitions(
+    # These are XIP related anomalies and aren't applicable for nRF7002 and cause
+    # throughput issues.
+      -DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
+      -DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
+    # nRF70 QSPI doesn't use 192MHz clock and most samples use 128MHz, this can cause anomaly 159
+    # but as its rare and not seen in most cases, we can disable it.
+    # Alternative is 128MHz CPU should be disabled that impacts Wi-Fi performance.
+      -DNRF53_ERRATA_159_ENABLE_WORKAROUND=0
+    )
+  endif()
 
   zephyr_library_named(nrf70-buslib)
   zephyr_library_include_directories(

--- a/modules/nrf_wifi/bus/CMakeLists.txt
+++ b/modules/nrf_wifi/bus/CMakeLists.txt
@@ -7,6 +7,18 @@
 set(NRF_WIFI_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
 if (CONFIG_NRF70_BUSLIB)
+
+  zephyr_compile_definitions_ifdef(CONFIG_NRF70_ON_QSPI
+  # These are XIP related anomalies and aren't applicable for nRF7002 and cause
+  # throughput issues.
+    -DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
+    -DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
+  # nRF70 QSPI doesn't use 192MHz clock and most samples use 128MHz, this can cause anomaly 159
+  # but as its rare and not seen in most cases, we can disable it.
+  # Alternative is 128MHz CPU should be disabled that impacts Wi-Fi performance.
+    -DNRF53_ERRATA_159_ENABLE_WORKAROUND=0
+  )
+
   zephyr_library_named(nrf70-buslib)
   zephyr_library_include_directories(
     inc


### PR DESCRIPTION
* Move QSPI anomalies to bus layer
* Fix QSPI anomalies handling to cover both Wi-Fi over QSPI (nRF7002DK) or Flash over QSPI  (nRF52/53 + nRF7002EK)