### PR TITLE
modules: hal_nordic: bump regtool to 9.1.0

### DIFF
--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 9.0.1
+  find_package(nrf-regtool 9.1.0
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH


### PR DESCRIPTION
Changes for this package version:

* CTRLSEL is now set appropriately for the SPIS121 pins.
* DPPI.LINK configuration is now skipped when processing the 'dppic130' devicetree node.