### PR TITLE
sys: slist/sflist/dlist: Add const qualifier to immutable API functions

### DIFF
--- a/include/zephyr/sys/dlist.h
+++ b/include/zephyr/sys/dlist.h
@@ -244,7 +244,7 @@ static inline bool sys_dnode_is_linked(const sys_dnode_t *node)
  * @return true if node is the head, false otherwise
  */
 
-static inline bool sys_dlist_is_head(sys_dlist_t *list, sys_dnode_t *node)
+static inline bool sys_dlist_is_head(const sys_dlist_t *list, const sys_dnode_t *node)
 {
 	return list->head == node;
 }
@@ -258,7 +258,7 @@ static inline bool sys_dlist_is_head(sys_dlist_t *list, sys_dnode_t *node)
  * @return true if node is the tail, false otherwise
  */
 
-static inline bool sys_dlist_is_tail(sys_dlist_t *list, sys_dnode_t *node)
+static inline bool sys_dlist_is_tail(const sys_dlist_t *list, const sys_dnode_t *node)
 {
 	return list->tail == node;
 }
@@ -271,7 +271,7 @@ static inline bool sys_dlist_is_tail(sys_dlist_t *list, sys_dnode_t *node)
  * @return true if empty, false otherwise
  */
 
-static inline bool sys_dlist_is_empty(sys_dlist_t *list)
+static inline bool sys_dlist_is_empty(const sys_dlist_t *list)
 {
 	return list->head == list;
 }
@@ -286,7 +286,7 @@ static inline bool sys_dlist_is_empty(sys_dlist_t *list)
  * @return true if multiple nodes, false otherwise
  */
 
-static inline bool sys_dlist_has_multiple_nodes(sys_dlist_t *list)
+static inline bool sys_dlist_has_multiple_nodes(const sys_dlist_t *list)
 {
 	return list->head != list->tail;
 }
@@ -299,7 +299,7 @@ static inline bool sys_dlist_has_multiple_nodes(sys_dlist_t *list)
  * @return a pointer to the head element, NULL if list is empty
  */
 
-static inline sys_dnode_t *sys_dlist_peek_head(sys_dlist_t *list)
+static inline sys_dnode_t *sys_dlist_peek_head(const sys_dlist_t *list)
 {
 	return sys_dlist_is_empty(list) ? NULL : list->head;
 }
@@ -314,7 +314,7 @@ static inline sys_dnode_t *sys_dlist_peek_head(sys_dlist_t *list)
  * @return a pointer to the head element
  */
 
-static inline sys_dnode_t *sys_dlist_peek_head_not_empty(sys_dlist_t *list)
+static inline sys_dnode_t *sys_dlist_peek_head_not_empty(const sys_dlist_t *list)
 {
 	return list->head;
 }
@@ -330,8 +330,8 @@ static inline sys_dnode_t *sys_dlist_peek_head_not_empty(sys_dlist_t *list)
  * @return a pointer to the next element from a node, NULL if node is the tail
  */
 
-static inline sys_dnode_t *sys_dlist_peek_next_no_check(sys_dlist_t *list,
-							sys_dnode_t *node)
+static inline sys_dnode_t *sys_dlist_peek_next_no_check(const sys_dlist_t *list,
+							const sys_dnode_t *node)
 {
 	return (node == list->tail) ? NULL : node->next;
 }
@@ -346,8 +346,8 @@ static inline sys_dnode_t *sys_dlist_peek_next_no_check(sys_dlist_t *list,
  * or NULL (when node comes from reading the head of an empty list).
  */
 
-static inline sys_dnode_t *sys_dlist_peek_next(sys_dlist_t *list,
-					       sys_dnode_t *node)
+static inline sys_dnode_t *sys_dlist_peek_next(const sys_dlist_t *list,
+					       const sys_dnode_t *node)
 {
 	return (node != NULL) ? sys_dlist_peek_next_no_check(list, node) : NULL;
 }
@@ -364,8 +364,8 @@ static inline sys_dnode_t *sys_dlist_peek_next(sys_dlist_t *list,
  *	   tail
  */
 
-static inline sys_dnode_t *sys_dlist_peek_prev_no_check(sys_dlist_t *list,
-							sys_dnode_t *node)
+static inline sys_dnode_t *sys_dlist_peek_prev_no_check(const sys_dlist_t *list,
+							const sys_dnode_t *node)
 {
 	return (node == list->head) ? NULL : node->prev;
 }
@@ -381,8 +381,8 @@ static inline sys_dnode_t *sys_dlist_peek_prev_no_check(sys_dlist_t *list,
  * 	   list).
  */
 
-static inline sys_dnode_t *sys_dlist_peek_prev(sys_dlist_t *list,
-					       sys_dnode_t *node)
+static inline sys_dnode_t *sys_dlist_peek_prev(const sys_dlist_t *list,
+					       const sys_dnode_t *node)
 {
 	return (node != NULL) ? sys_dlist_peek_prev_no_check(list, node) : NULL;
 }
@@ -395,7 +395,7 @@ static inline sys_dnode_t *sys_dlist_peek_prev(sys_dlist_t *list,
  * @return a pointer to the tail element, NULL if list is empty
  */
 
-static inline sys_dnode_t *sys_dlist_peek_tail(sys_dlist_t *list)
+static inline sys_dnode_t *sys_dlist_peek_tail(const sys_dlist_t *list)
 {
 	return sys_dlist_is_empty(list) ? NULL : list->tail;
 }
@@ -563,7 +563,7 @@ static inline sys_dnode_t *sys_dlist_get(sys_dlist_t *list)
  *
  * @return an integer equal to the size of the list, or 0 if empty
  */
-static inline size_t sys_dlist_len(sys_dlist_t *list)
+static inline size_t sys_dlist_len(const sys_dlist_t *list)
 {
 	size_t len = 0;
 	sys_dnode_t *node = NULL;

--- a/include/zephyr/sys/list_gen.h
+++ b/include/zephyr/sys/list_gen.h
@@ -56,21 +56,21 @@
 
 #define Z_GENLIST_IS_EMPTY(__lname)					\
 	static inline bool						\
-	sys_ ## __lname ## _is_empty(sys_ ## __lname ## _t *list)	\
+	sys_ ## __lname ## _is_empty(const sys_ ## __lname ## _t *list)	\
 	{								\
 		return (sys_ ## __lname ## _peek_head(list) == NULL);	\
 	}
 
 #define Z_GENLIST_PEEK_NEXT_NO_CHECK(__lname, __nname)			    \
 	static inline sys_ ## __nname ## _t *				    \
-	sys_ ## __lname ## _peek_next_no_check(sys_ ## __nname ## _t *node) \
+	sys_ ## __lname ## _peek_next_no_check(const sys_ ## __nname ## _t *node) \
 	{								    \
 		return z_ ## __nname ## _next_peek(node);		    \
 	}
 
 #define Z_GENLIST_PEEK_NEXT(__lname, __nname)				     \
 	static inline sys_ ## __nname ## _t *				     \
-	sys_ ## __lname ## _peek_next(sys_ ## __nname ## _t *node)	     \
+	sys_ ## __lname ## _peek_next(const sys_ ## __nname ## _t *node)     \
 	{								     \
 		return (node != NULL) ?                                        \
 			sys_ ## __lname ## _peek_next_no_check(node) :       \
@@ -236,7 +236,8 @@
 
 #define Z_GENLIST_FIND(__lname, __nname)                                                 \
 	static inline bool sys_##__lname##_find(                                         \
-		sys_##__lname##_t *list, sys_##__nname##_t *node, sys_##__nname##_t **prev)        \
+		const sys_##__lname##_t *list, const sys_##__nname##_t *node,                      \
+		sys_##__nname##_t **prev)                                                          \
 	{                                                                                          \
 		sys_##__nname##_t *current = NULL;                                                 \
 		sys_##__nname##_t *previous = NULL;                                                \
@@ -260,7 +261,7 @@
 	}
 
 #define Z_GENLIST_LEN(__lname, __nname)                                                            \
-	static inline size_t sys_##__lname##_len(sys_##__lname##_t * list)                         \
+	static inline size_t sys_##__lname##_len(const sys_##__lname##_t * list)                   \
 	{                                                                                          \
 		size_t len = 0;                                                                    \
 		static sys_##__nname##_t * node;                                                   \

--- a/include/zephyr/sys/sflist.h
+++ b/include/zephyr/sys/sflist.h
@@ -218,12 +218,12 @@ static inline void sys_sflist_init(sys_sflist_t *list)
 /* At least 2 available flag bits are expected */
 BUILD_ASSERT(SYS_SFLIST_FLAGS_MASK >= 0x3);
 
-static inline sys_sfnode_t *z_sfnode_next_peek(sys_sfnode_t *node)
+static inline sys_sfnode_t *z_sfnode_next_peek(const sys_sfnode_t *node)
 {
 	return (sys_sfnode_t *)(node->next_and_flags & ~SYS_SFLIST_FLAGS_MASK);
 }
 
-static inline uint8_t sys_sfnode_flags_get(sys_sfnode_t *node);
+static inline uint8_t sys_sfnode_flags_get(const sys_sfnode_t *node);
 
 static inline void z_sfnode_next_set(sys_sfnode_t *parent,
 				       sys_sfnode_t *child)
@@ -250,7 +250,7 @@ static inline void z_sflist_tail_set(sys_sflist_t *list, sys_sfnode_t *node)
  *
  * @return A pointer on the first node of the list (or NULL if none)
  */
-static inline sys_sfnode_t *sys_sflist_peek_head(sys_sflist_t *list)
+static inline sys_sfnode_t *sys_sflist_peek_head(const sys_sflist_t *list)
 {
 	return list->head;
 }
@@ -262,7 +262,7 @@ static inline sys_sfnode_t *sys_sflist_peek_head(sys_sflist_t *list)
  *
  * @return A pointer on the last node of the list (or NULL if none)
  */
-static inline sys_sfnode_t *sys_sflist_peek_tail(sys_sflist_t *list)
+static inline sys_sfnode_t *sys_sflist_peek_tail(const sys_sflist_t *list)
 {
 	return list->tail;
 }
@@ -278,7 +278,7 @@ static inline sys_sfnode_t *sys_sflist_peek_tail(sys_sflist_t *list)
  * @return The value of flags, which will be between 0 and 3 on 32-bit
  *         architectures, or between 0 and 7 on 64-bit architectures
  */
-static inline uint8_t sys_sfnode_flags_get(sys_sfnode_t *node)
+static inline uint8_t sys_sfnode_flags_get(const sys_sfnode_t *node)
 {
 	return node->next_and_flags & SYS_SFLIST_FLAGS_MASK;
 }
@@ -331,7 +331,7 @@ static inline void sys_sfnode_flags_set(sys_sfnode_t *node, uint8_t flags)
  *
  * @return a boolean, true if it's empty, false otherwise
  */
-static inline bool sys_sflist_is_empty(sys_sflist_t *list);
+static inline bool sys_sflist_is_empty(const sys_sflist_t *list);
 
 Z_GENLIST_IS_EMPTY(sflist)
 
@@ -344,7 +344,7 @@ Z_GENLIST_IS_EMPTY(sflist)
  *
  * @return a pointer on the next node (or NULL if none)
  */
-static inline sys_sfnode_t *sys_sflist_peek_next_no_check(sys_sfnode_t *node);
+static inline sys_sfnode_t *sys_sflist_peek_next_no_check(const sys_sfnode_t *node);
 
 Z_GENLIST_PEEK_NEXT_NO_CHECK(sflist, sfnode)
 
@@ -355,7 +355,7 @@ Z_GENLIST_PEEK_NEXT_NO_CHECK(sflist, sfnode)
  *
  * @return a pointer on the next node (or NULL if none)
  */
-static inline sys_sfnode_t *sys_sflist_peek_next(sys_sfnode_t *node);
+static inline sys_sfnode_t *sys_sflist_peek_next(const sys_sfnode_t *node);
 
 Z_GENLIST_PEEK_NEXT(sflist, sfnode)
 
@@ -497,7 +497,7 @@ Z_GENLIST_FIND_AND_REMOVE(sflist, sfnode)
  *
  * @return an integer equal to the size of the list, or 0 if empty
  */
-static inline size_t sys_sflist_len(sys_sflist_t *list);
+static inline size_t sys_sflist_len(const sys_sflist_t *list);
 
 Z_GENLIST_LEN(sflist, sfnode)
 

--- a/include/zephyr/sys/slist.h
+++ b/include/zephyr/sys/slist.h
@@ -208,7 +208,7 @@ static inline void sys_slist_init(sys_slist_t *list)
  */
 #define SYS_SLIST_STATIC_INIT(ptr_to_list) {NULL, NULL}
 
-static inline sys_snode_t *z_snode_next_peek(sys_snode_t *node)
+static inline sys_snode_t *z_snode_next_peek(const sys_snode_t *node)
 {
 	return node->next;
 }
@@ -235,7 +235,7 @@ static inline void z_slist_tail_set(sys_slist_t *list, sys_snode_t *node)
  *
  * @return A pointer on the first node of the list (or NULL if none)
  */
-static inline sys_snode_t *sys_slist_peek_head(sys_slist_t *list)
+static inline sys_snode_t *sys_slist_peek_head(const sys_slist_t *list)
 {
 	return list->head;
 }
@@ -247,7 +247,7 @@ static inline sys_snode_t *sys_slist_peek_head(sys_slist_t *list)
  *
  * @return A pointer on the last node of the list (or NULL if none)
  */
-static inline sys_snode_t *sys_slist_peek_tail(sys_slist_t *list)
+static inline sys_snode_t *sys_slist_peek_tail(const sys_slist_t *list)
 {
 	return list->tail;
 }
@@ -263,7 +263,7 @@ static inline sys_snode_t *sys_slist_peek_tail(sys_slist_t *list)
  *
  * @return a boolean, true if it's empty, false otherwise
  */
-static inline bool sys_slist_is_empty(sys_slist_t *list);
+static inline bool sys_slist_is_empty(const sys_slist_t *list);
 
 Z_GENLIST_IS_EMPTY(slist)
 
@@ -276,7 +276,7 @@ Z_GENLIST_IS_EMPTY(slist)
  *
  * @return a pointer on the next node (or NULL if none)
  */
-static inline sys_snode_t *sys_slist_peek_next_no_check(sys_snode_t *node);
+static inline sys_snode_t *sys_slist_peek_next_no_check(const sys_snode_t *node);
 
 Z_GENLIST_PEEK_NEXT_NO_CHECK(slist, snode)
 
@@ -287,7 +287,7 @@ Z_GENLIST_PEEK_NEXT_NO_CHECK(slist, snode)
  *
  * @return a pointer on the next node (or NULL if none)
  */
-static inline sys_snode_t *sys_slist_peek_next(sys_snode_t *node);
+static inline sys_snode_t *sys_slist_peek_next(const sys_snode_t *node);
 
 Z_GENLIST_PEEK_NEXT(slist, snode)
 
@@ -431,7 +431,7 @@ static inline bool sys_slist_find_and_remove(sys_slist_t *list,
  *
  * @return true if node was found in the list, false otherwise
  */
-static inline bool sys_slist_find(sys_slist_t *list, sys_snode_t *node,
+static inline bool sys_slist_find(const sys_slist_t *list, const sys_snode_t *node,
 					    sys_snode_t **prev);
 Z_GENLIST_FIND(slist, snode)
 
@@ -442,7 +442,7 @@ Z_GENLIST_FIND(slist, snode)
  *
  * @return an integer equal to the size of the list, or 0 if empty
  */
-static inline size_t sys_slist_len(sys_slist_t *list);
+static inline size_t sys_slist_len(const sys_slist_t *list);
 
 Z_GENLIST_LEN(slist, snode)
 


### PR DESCRIPTION
Allow passing structs with `sys_slist_t/sys_sfliist_t/sys_dlist_t` members as `const` without discarding qualifiers if the slist API is used without modifying it.