### PR TITLE
Revert "scripts: ci: check_compliance: use git-top to check modules"

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -75,7 +75,7 @@ def get_files(filter=None, paths=None):
     out = git('diff', '--name-only', *filter_arg, COMMIT_RANGE, *paths_arg)
     files = out.splitlines()
     for file in list(files):
-        if not (GIT_TOP / file).exists():
+        if not os.path.isfile(os.path.join(GIT_TOP, file)):
             # Drop submodule directories from the list.
             files.remove(file)
     return files
@@ -207,8 +207,8 @@ class CheckPatch(ComplianceTest):
     path_hint = "<git-top>"
 
     def run(self):
-        checkpatch = ZEPHYR_BASE / 'scripts' / 'checkpatch.pl'
-        if not checkpatch.exists():
+        checkpatch = os.path.join(ZEPHYR_BASE, 'scripts', 'checkpatch.pl')
+        if not os.path.exists(checkpatch):
             self.skip(f'{checkpatch} not found')
 
         # check for Perl installation on Windows
@@ -411,7 +411,8 @@ class KconfigCheck(ComplianceTest):
         """
         # Invoke the script directly using the Python executable since this is
         # not a module nor a pip-installed Python utility
-        zephyr_module_path = ZEPHYR_BASE / "scripts" / "zephyr_module.py"
+        zephyr_module_path = os.path.join(ZEPHYR_BASE, "scripts",
+                                          "zephyr_module.py")
         cmd = [sys.executable, zephyr_module_path,
                '--kconfig-out', modules_file,
                '--sysbuild-kconfig-out', sysbuild_modules_file,
@@ -422,9 +423,9 @@ class KconfigCheck(ComplianceTest):
         except subprocess.CalledProcessError as ex:
             self.error(ex.output.decode("utf-8"))
 
-        modules_dir = ZEPHYR_BASE / 'modules'
+        modules_dir = ZEPHYR_BASE + '/modules'
         modules = [name for name in os.listdir(modules_dir) if
-                   modules_dir / name / 'Kconfig']
+                   os.path.exists(os.path.join(modules_dir, name, 'Kconfig'))]
 
         with open(modules_file, 'r') as fp_module_file:
             content = fp_module_file.read()
@@ -433,7 +434,7 @@ class KconfigCheck(ComplianceTest):
             for module in modules:
                 fp_module_file.write("ZEPHYR_{}_KCONFIG = {}\n".format(
                     re.sub('[^a-zA-Z0-9]', '_', module).upper(),
-                    modules_dir / module / 'Kconfig'
+                    modules_dir + '/' + module + '/Kconfig'
                 ))
             fp_module_file.write(content)
 
@@ -467,11 +468,12 @@ class KconfigCheck(ComplianceTest):
         """
         # Invoke the script directly using the Python executable since this is
         # not a module nor a pip-installed Python utility
-        zephyr_drv_kconfig_path = ZEPHYR_BASE / "scripts" / "dts" / "gen_driver_kconfig_dts.py"
+        zephyr_drv_kconfig_path = os.path.join(ZEPHYR_BASE, "scripts", "dts",
+                                               "gen_driver_kconfig_dts.py")
         binding_paths = []
-        binding_paths.append(ZEPHYR_BASE / "dts" / "bindings")
+        binding_paths.append(os.path.join(ZEPHYR_BASE, "dts", "bindings"))
 
-        dts_root_paths = get_module_setting_root('dts', settings_file)
+        dts_root_paths = self.get_module_setting_root('dts', settings_file)
         for p in dts_root_paths:
             binding_paths.append(p / "dts" / "bindings")
 
@@ -504,10 +506,10 @@ class KconfigCheck(ComplianceTest):
         kconfig_sysbuild_file = os.path.join(kconfig_dir, 'boards', 'Kconfig.sysbuild')
         kconfig_defconfig_file = os.path.join(kconfig_dir, 'boards', 'Kconfig.defconfig')
 
-        board_roots = get_module_setting_root('board', settings_file)
-        board_roots.insert(0, ZEPHYR_BASE)
-        soc_roots = get_module_setting_root('soc', settings_file)
-        soc_roots.insert(0, ZEPHYR_BASE)
+        board_roots = self.get_module_setting_root('board', settings_file)
+        board_roots.insert(0, Path(ZEPHYR_BASE))
+        soc_roots = self.get_module_setting_root('soc', settings_file)
+        soc_roots.insert(0, Path(ZEPHYR_BASE))
         root_args = argparse.Namespace(**{'board_roots': board_roots,
                                           'soc_roots': soc_roots, 'board': None,
                                           'board_dir': []})
@@ -570,7 +572,7 @@ class KconfigCheck(ComplianceTest):
 
         kconfig_file = os.path.join(kconfig_dir, 'arch', 'Kconfig')
 
-        root_args = argparse.Namespace(**{'arch_roots': [ZEPHYR_BASE], 'arch': None})
+        root_args = argparse.Namespace(**{'arch_roots': [Path(ZEPHYR_BASE)], 'arch': None})
         v2_archs = list_hardware.find_v2_archs(root_args)
 
         with open(kconfig_file, 'w') as fp:
@@ -584,20 +586,20 @@ class KconfigCheck(ComplianceTest):
         """
         # Put the Kconfiglib path first to make sure no local Kconfiglib version is
         # used
-        kconfig_path = ZEPHYR_BASE / "scripts" / "kconfig"
-        if not kconfig_path.exists():
+        kconfig_path = os.path.join(ZEPHYR_BASE, "scripts", "kconfig")
+        if not os.path.exists(kconfig_path):
             self.error(kconfig_path + " not found")
 
         kconfiglib_dir = tempfile.mkdtemp(prefix="kconfiglib_")
 
-        sys.path.insert(0, str(kconfig_path))
+        sys.path.insert(0, kconfig_path)
         # Import globally so that e.g. kconfiglib.Symbol can be referenced in
         # tests
         global kconfiglib
         import kconfiglib
 
         # Look up Kconfig files relative to ZEPHYR_BASE
-        os.environ["srctree"] = str(ZEPHYR_BASE)
+        os.environ["srctree"] = ZEPHYR_BASE
 
         # Parse the entire Kconfig tree, to make sure we see all symbols
         os.environ["SOC_DIR"] = "soc/"
@@ -879,7 +881,7 @@ https://docs.zephyrproject.org/latest/build/kconfig/tips.html#menuconfig-symbols
             self.failure(f"Undefined Kconfig symbols:\n\n {undef_ref_warnings}")
 
     def check_soc_name_sync(self, kconf):
-        root_args = argparse.Namespace(**{'soc_roots': [ZEPHYR_BASE]})
+        root_args = argparse.Namespace(**{'soc_roots': [Path(ZEPHYR_BASE)]})
         v2_systems = list_hardware.find_v2_systems(root_args)
 
         soc_names = {soc.name for soc in v2_systems.get_socs()}
@@ -948,7 +950,7 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
         grep_stdout = git("grep", "--line-number", "-I", "--null",
                           "--perl-regexp", regex, "--", ":!/doc/releases",
                           ":!/doc/security/vulnerabilities.rst",
-                          cwd=GIT_TOP)
+                          cwd=Path(GIT_TOP))
 
         # splitlines() supports various line terminators
         for grep_line in grep_stdout.splitlines():
@@ -1245,7 +1247,7 @@ class Nits(ComplianceTest):
     def check_kconfig_header(self, fname):
         # Checks for a spammy copy-pasted header format
 
-        with open(GIT_TOP / fname, encoding="utf-8") as f:
+        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
             contents = f.read()
 
         # 'Kconfig - yada yada' has a copy-pasted redundant filename at the
@@ -1271,7 +1273,7 @@ failure.
         # Checks for 'source "$(ZEPHYR_BASE)/Kconfig[.zephyr]"', which can be
         # be simplified to 'source "Kconfig[.zephyr]"'
 
-        with open(GIT_TOP / fname, encoding="utf-8") as f:
+        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
             # Look for e.g. rsource as well, for completeness
             match = re.search(
                 r'^\s*(?:o|r|or)?source\s*"\$\(?ZEPHYR_BASE\)?/(Kconfig(?:\.zephyr)?)"',
@@ -1286,7 +1288,7 @@ and all 'source's are relative to it.""".format(match.group(1), fname))
     def check_redundant_document_separator(self, fname):
         # Looks for redundant '...' document separators in bindings
 
-        with open(GIT_TOP / fname, encoding="utf-8") as f:
+        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
             if re.search(r"^\.\.\.", f.read(), re.MULTILINE):
                 self.failure(f"""\
 Redundant '...' document separator in {fname}. Binding YAML files are never
@@ -1295,7 +1297,7 @@ concatenated together, so no document separators are needed.""")
     def check_source_file(self, fname):
         # Generic nits related to various source files
 
-        with open(GIT_TOP / fname, encoding="utf-8") as f:
+        with open(os.path.join(GIT_TOP, fname), encoding="utf-8") as f:
             contents = f.read()
 
         if not contents.endswith("\n"):
@@ -1514,7 +1516,7 @@ class ImageSize(ComplianceTest):
         BOARD_SIZE_LIMIT = 100 << 10
 
         for file in get_files(filter="d"):
-            full_path = GIT_TOP / file
+            full_path = os.path.join(GIT_TOP, file)
             mime_type = magic.from_file(full_path, mime=True)
 
             if not mime_type.startswith("image/"):
@@ -1595,7 +1597,7 @@ class YAMLLint(ComplianceTest):
     path_hint = "<git-top>"
 
     def run(self):
-        config_file = ZEPHYR_BASE / ".yamllint"
+        config_file = os.path.join(ZEPHYR_BASE, ".yamllint")
 
         for file in get_files(filter="d"):
             if Path(file).suffix not in ['.yaml', '.yml']:
@@ -1817,7 +1819,7 @@ class TextEncoding(ComplianceTest):
         m = magic.Magic(mime=True, mime_encoding=True)
 
         for file in get_files(filter="d"):
-            full_path = GIT_TOP / file
+            full_path = os.path.join(GIT_TOP, file)
             mime_type = m.from_file(full_path)
 
             if not mime_type.startswith("text/"):
@@ -1927,12 +1929,11 @@ def _main(args):
 
         # Propagate this decision to child processes.
         os.environ['ZEPHYR_BASE'] = ZEPHYR_BASE
-    ZEPHYR_BASE = Path(ZEPHYR_BASE)
 
     # The absolute path of the top-level git directory. Initialize it here so
     # that issues running Git can be reported to GitHub.
     global GIT_TOP
-    GIT_TOP = Path(git("rev-parse", "--show-toplevel"))
+    GIT_TOP = git("rev-parse", "--show-toplevel")
 
     # The commit range passed in --commit, e.g. "HEAD~3"
     global COMMIT_RANGE

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1077,7 +1077,6 @@ flagged.
         "MCUBOOT_CLEANUP_ARM_CORE", # Used in (sysbuild-based) test
         "MCUBOOT_DOWNGRADE_PREVENTION", # but symbols are defined in MCUboot
                                         # itself.
-        "MCUBOOT_LOG_LEVEL_DBG",
         "MCUBOOT_LOG_LEVEL_INF",
         "MCUBOOT_LOG_LEVEL_WRN",        # Used in example adjusting MCUboot
                                         # config,

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -224,7 +224,7 @@ class CheckPatch(ComplianceTest):
             cmd = [checkpatch]
 
         cmd.extend(['--mailback', '--no-tree', '-'])
-        diff = subprocess.Popen(('git', 'diff', '--no-ext-diff', '--', ':!*.diff', ':!*.patch', COMMIT_RANGE),
+        diff = subprocess.Popen(('git', 'diff', '--no-ext-diff', COMMIT_RANGE),
                                 stdout=subprocess.PIPE,
                                 cwd=GIT_TOP)
         try:
@@ -1327,7 +1327,7 @@ class GitDiffCheck(ComplianceTest):
         for shaidx in get_shas(COMMIT_RANGE):
             # Ignore non-zero return status code
             # Reason: `git diff --check` sets the return code to the number of offending lines
-            diff = git("diff", f"{shaidx}^!", "--check", "--", ":!*.diff", ":!*.patch", ignore_non_zero=True)
+            diff = git("diff", f"{shaidx}^!", "--check", ignore_non_zero=True)
 
             lines = p.findall(diff)
             lines = map(lambda x: f"{shaidx}: {x}", lines)

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -80,42 +80,6 @@ def get_files(filter=None, paths=None):
             files.remove(file)
     return files
 
-def get_module_setting_root(root, settings_file):
-    """
-    Parse the Zephyr module generated settings file given by 'settings_file'
-    and return all root settings defined by 'root'.
-    """
-    # Invoke the script directly using the Python executable since this is
-    # not a module nor a pip-installed Python utility
-    root_paths = []
-
-    if os.path.exists(settings_file):
-        with open(settings_file, 'r') as fp_setting_file:
-            content = fp_setting_file.read()
-
-        lines = content.strip().split('\n')
-        for line in lines:
-            root = root.upper()
-            if line.startswith(f'"{root}_ROOT":'):
-                _, root_path = line.split(":", 1)
-                root_paths.append(Path(root_path.strip('"')))
-    return root_paths
-
-def get_vendor_prefixes(path, errfn = print) -> set[str]:
-    vendor_prefixes = set()
-    with open(path) as fp:
-        for line in fp.readlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            try:
-                vendor, _ = line.split("\t", 2)
-                vendor_prefixes.add(vendor)
-            except ValueError:
-                errfn(f"Invalid line in {path}:\"{line}\".")
-                errfn("Did you forget the tab character?")
-    return vendor_prefixes
-
 class FmtdFailure(Failure):
     def __init__(
         self, severity, title, file, line=None, col=None, desc="", end_line=None, end_col=None
@@ -156,21 +120,19 @@ class ComplianceTest:
       Link to documentation related to what's being tested
 
     path_hint:
-      The path the test runs itself in. By default it uses the magic string
-      "<git-top>" which refers to the top-level repository directory.
+      The path the test runs itself in. This is just informative and used in
+      the message that gets printed when running the test.
 
-      This avoids running 'git' to find the top-level directory before main()
-      runs (class variable assignments run when the 'class ...' statement
-      runs). That avoids swallowing errors, because main() reports them to
-      GitHub.
-
-      Subclasses may override the default with a specific path or one of the
-      magic strings below:
-      - "<zephyr-base>" can be used to refer to the environment variable
-        ZEPHYR_BASE or, when missing, the calculated base of the zephyr tree.
+      There are two magic strings that can be used instead of a path:
+      - The magic string "<zephyr-base>" can be used to refer to the
+      environment variable ZEPHYR_BASE or, when missing, the calculated base of
+      the zephyr tree
+      - The magic string "<git-top>" refers to the top-level repository
+      directory. This avoids running 'git' to find the top-level directory
+      before main() runs (class variable assignments run when the 'class ...'
+      statement runs). That avoids swallowing errors, because main() reports
+      them to GitHub
     """
-    path_hint = "<git-top>"
-
     def __init__(self):
         self.case = TestCase(type(self).name, "Guidelines")
         # This is necessary because Failure can be subclassed, but since it is
@@ -242,6 +204,7 @@ class CheckPatch(ComplianceTest):
     """
     name = "Checkpatch"
     doc = "See https://docs.zephyrproject.org/latest/contribute/guidelines.html#coding-style for more details."
+    path_hint = "<git-top>"
 
     def run(self):
         checkpatch = ZEPHYR_BASE / 'scripts' / 'checkpatch.pl'
@@ -300,6 +263,7 @@ class BoardYmlCheck(ComplianceTest):
     """
     name = "BoardYml"
     doc = "Check the board.yml file format"
+    path_hint = "<zephyr-base>"
 
     def check_board_file(self, file, vendor_prefixes):
         """Validate a single board file."""
@@ -314,19 +278,20 @@ class BoardYmlCheck(ComplianceTest):
                                           desc=desc)
 
     def run(self):
-        path = resolve_path_hint(self.path_hint)
+        vendor_prefixes = ["others"]
+        with open(os.path.join(ZEPHYR_BASE, "dts", "bindings", "vendor-prefixes.txt")) as fp:
+            for line in fp.readlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                try:
+                    vendor, _ = line.split("\t", 2)
+                    vendor_prefixes.append(vendor)
+                except ValueError:
+                    self.error(f"Invalid line in vendor-prefixes.txt:\"{line}\".")
+                    self.error("Did you forget the tab character?")
 
-        vendor_prefixes = {"others"}
-        # add vendor prefixes from the main zephyr repo
-        vendor_prefixes |= get_vendor_prefixes(ZEPHYR_BASE / "dts" / "bindings" / "vendor-prefixes.txt", self.error)
-
-        # add vendor prefixes from the current repo
-        dts_roots = get_module_setting_root('dts', path / "zephyr" / "module.yml")
-        for dts_root in dts_roots:
-            vendor_prefix_file = dts_root / "dts" / "bindings" / "vendor-prefixes.txt"
-            if vendor_prefix_file.exists():
-                vendor_prefixes |= get_vendor_prefixes(vendor_prefix_file, self.error)
-
+        path = Path(ZEPHYR_BASE)
         for file in path.glob("**/board.yml"):
             self.check_board_file(file, vendor_prefixes)
 
@@ -337,6 +302,7 @@ class ClangFormatCheck(ComplianceTest):
     """
     name = "ClangFormat"
     doc = "See https://docs.zephyrproject.org/latest/contribute/guidelines.html#clang-format for more details."
+    path_hint = "<git-top>"
 
     def run(self):
         exe = f"clang-format-diff.{'exe' if platform.system() == 'Windows' else 'py'}"
@@ -378,6 +344,7 @@ class DevicetreeBindingsCheck(ComplianceTest):
     """
     name = "DevicetreeBindings"
     doc = "See https://docs.zephyrproject.org/latest/build/dts/bindings.html for more details."
+    path_hint = "<zephyr-base>"
 
     def run(self, full=True):
         dts_bindings = self.parse_dt_bindings()
@@ -414,6 +381,7 @@ class KconfigCheck(ComplianceTest):
     """
     name = "Kconfig"
     doc = "See https://docs.zephyrproject.org/latest/build/kconfig/tips.html for more details."
+    path_hint = "<zephyr-base>"
 
     # Top-level Kconfig file. The path can be relative to srctree (ZEPHYR_BASE).
     FILENAME = "Kconfig"
@@ -468,6 +436,27 @@ class KconfigCheck(ComplianceTest):
                     modules_dir / module / 'Kconfig'
                 ))
             fp_module_file.write(content)
+
+    def get_module_setting_root(self, root, settings_file):
+        """
+        Parse the Zephyr module generated settings file given by 'settings_file'
+        and return all root settings defined by 'root'.
+        """
+        # Invoke the script directly using the Python executable since this is
+        # not a module nor a pip-installed Python utility
+        root_paths = []
+
+        if os.path.exists(settings_file):
+            with open(settings_file, 'r') as fp_setting_file:
+                content = fp_setting_file.read()
+
+            lines = content.strip().split('\n')
+            for line in lines:
+                root = root.upper()
+                if line.startswith(f'"{root}_ROOT":'):
+                    _, root_path = line.split(":", 1)
+                    root_paths.append(Path(root_path.strip('"')))
+        return root_paths
 
     def get_kconfig_dts(self, kconfig_dts_file, settings_file):
         """
@@ -1157,7 +1146,6 @@ class KconfigBasicNoModulesCheck(KconfigBasicCheck):
     defined only in a module.
     """
     name = "KconfigBasicNoModules"
-    path_hint = "<zephyr-base>"
 
     def get_modules(self, modules_file, sysbuild_modules_file, settings_file):
         with open(modules_file, 'w') as fp_module_file:
@@ -1224,7 +1212,6 @@ class SysbuildKconfigBasicNoModulesCheck(SysbuildKconfigCheck, KconfigBasicNoMod
     but defined only in a module.
     """
     name = "SysbuildKconfigBasicNoModules"
-    path_hint = "<zephyr-base>"
 
 
 class Nits(ComplianceTest):
@@ -1234,6 +1221,7 @@ class Nits(ComplianceTest):
     """
     name = "Nits"
     doc = "See https://docs.zephyrproject.org/latest/contribute/guidelines.html#coding-style for more details."
+    path_hint = "<git-top>"
 
     def run(self):
         # Loop through added/modified files
@@ -1327,6 +1315,7 @@ class GitDiffCheck(ComplianceTest):
     """
     name = "GitDiffCheck"
     doc = "Git conflict markers and whitespace errors are not allowed in added changes"
+    path_hint = "<git-top>"
 
     def run(self):
         offending_lines = []
@@ -1354,6 +1343,7 @@ class GitLint(ComplianceTest):
     """
     name = "Gitlint"
     doc = "See https://docs.zephyrproject.org/latest/contribute/guidelines.html#commit-guidelines for more details"
+    path_hint = "<git-top>"
 
     def run(self):
         # By default gitlint looks for .gitlint configuration only in
@@ -1376,6 +1366,7 @@ class PyLint(ComplianceTest):
     """
     name = "Pylint"
     doc = "See https://www.pylint.org/ for more details"
+    path_hint = "<git-top>"
 
     def run(self):
         # Path to pylint configuration file
@@ -1450,6 +1441,9 @@ class Identity(ComplianceTest):
     """
     name = "Identity"
     doc = "See https://docs.zephyrproject.org/latest/contribute/guidelines.html#commit-guidelines for more details"
+    # git rev-list and git log don't depend on the current (sub)directory
+    # unless explicited
+    path_hint = "<git-top>"
 
     def run(self):
         for shaidx in get_shas(COMMIT_RANGE):
@@ -1490,6 +1484,7 @@ class BinaryFiles(ComplianceTest):
     """
     name = "BinaryFiles"
     doc = "No binary files allowed."
+    path_hint = "<git-top>"
 
     def run(self):
         BINARY_ALLOW_PATHS = ("doc/", "boards/", "samples/")
@@ -1512,6 +1507,7 @@ class ImageSize(ComplianceTest):
     """
     name = "ImageSize"
     doc = "Check the size of image files."
+    path_hint = "<git-top>"
 
     def run(self):
         SIZE_LIMIT = 250 << 10
@@ -1541,6 +1537,7 @@ class MaintainersFormat(ComplianceTest):
     """
     name = "MaintainersFormat"
     doc = "Check that MAINTAINERS file parses correctly."
+    path_hint = "<git-top>"
 
     def run(self):
         MAINTAINERS_FILES = ["MAINTAINERS.yml", "MAINTAINERS.yaml"]
@@ -1560,6 +1557,7 @@ class ModulesMaintainers(ComplianceTest):
     """
     name = "ModulesMaintainers"
     doc = "Check that all modules have a MAINTAINERS entry."
+    path_hint = "<git-top>"
 
     def run(self):
         MAINTAINERS_FILES = ["MAINTAINERS.yml", "MAINTAINERS.yaml"]
@@ -1594,6 +1592,7 @@ class YAMLLint(ComplianceTest):
     """
     name = "YAMLLint"
     doc = "Check YAML files with YAMLLint."
+    path_hint = "<git-top>"
 
     def run(self):
         config_file = ZEPHYR_BASE / ".yamllint"
@@ -1624,6 +1623,7 @@ class SphinxLint(ComplianceTest):
 
     name = "SphinxLint"
     doc = "Check Sphinx/reStructuredText files with sphinx-lint."
+    path_hint = "<git-top>"
 
     # Checkers added/removed to sphinx-lint's default set
     DISABLE_CHECKERS = ["horizontal-tab", "missing-space-before-default-role"]
@@ -1665,6 +1665,7 @@ class KeepSorted(ComplianceTest):
     """
     name = "KeepSorted"
     doc = "Check for blocks of code or config that should be kept sorted."
+    path_hint = "<git-top>"
 
     MARKER = "zephyr-keep-sorted"
 
@@ -1760,6 +1761,7 @@ class Ruff(ComplianceTest):
     """
     name = "Ruff"
     doc = "Check python files with ruff."
+    path_hint = "<git-top>"
 
     def run(self):
         for file in get_files(filter="d"):
@@ -1807,6 +1809,7 @@ class TextEncoding(ComplianceTest):
     """
     name = "TextEncoding"
     doc = "Check the encoding of text files."
+    path_hint = "<git-top>"
 
     ALLOWED_CHARSETS = ["us-ascii", "utf-8"]
 


### PR DESCRIPTION
This reverts commits from PR #84054 as they are causing checkpatch to not run properly and causing code with compliance issues to be accepted just fine.
