### PR TITLE
scripts: check_compliance: un-ignore diff and patch for CheckPatch

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -261,7 +261,7 @@ class CheckPatch(ComplianceTest):
             cmd = [checkpatch]
 
         cmd.extend(['--mailback', '--no-tree', '-'])
-        diff = subprocess.Popen(('git', 'diff', '--no-ext-diff', '--', ':!*.diff', ':!*.patch', COMMIT_RANGE),
+        diff = subprocess.Popen(('git', 'diff', '--no-ext-diff', COMMIT_RANGE),
                                 stdout=subprocess.PIPE,
                                 cwd=GIT_TOP)
         try:


### PR DESCRIPTION
Un-ignore diff and patch files for CheckPatch.

This was originally added to avoid throwing false-positives when diff and patch files were actually in the repo, since it would incorrectly try to perform code-formatting checks on those files instead of on the content of the commit.

Testing Done:
```shell
gh pr checkout 88916
git rebase cfriedt/check-compliance-checkpatch-ignored
./scripts/ci/check_compliance.py -e ClangFormat -c HEAD~4..
...
Running KeepSorted       tests in /Users/cfriedt/zephyrproject/zephyr ...
Running Identity         tests in /Users/cfriedt/zephyrproject/zephyr ...
Running Kconfig          tests in /Users/cfriedt/zephyrproject/zephyr ...
Running SysbuildKconfig  tests in /Users/cfriedt/zephyrproject/zephyr ...
Running SphinxLint       tests in /Users/cfriedt/zephyrproject/zephyr ...
Running Pylint           tests in /Users/cfriedt/zephyrproject/zephyr ...
Running DevicetreeBindings tests in /Users/cfriedt/zephyrproject/zephyr ...
Running KconfigHWMv2     tests in /Users/cfriedt/zephyrproject/zephyr ...
Running KconfigBasic     tests in /Users/cfriedt/zephyrproject/zephyr ...
Running YAMLLint         tests in /Users/cfriedt/zephyrproject/zephyr ...
Running Gitlint          tests in /Users/cfriedt/zephyrproject/zephyr ...
Skipping ClangFormat
Running ModulesMaintainers tests in /Users/cfriedt/zephyrproject/zephyr ...
Running GitDiffCheck     tests in /Users/cfriedt/zephyrproject/zephyr ...
Running BoardYml         tests in /Users/cfriedt/zephyrproject/zephyr ...
Running MaintainersFormat tests in /Users/cfriedt/zephyrproject/zephyr ...
Running Nits             tests in /Users/cfriedt/zephyrproject/zephyr ...
Running Checkpatch       tests in /Users/cfriedt/zephyrproject/zephyr ...
Running TextEncoding     tests in /Users/cfriedt/zephyrproject/zephyr ...
Running ImageSize        tests in /Users/cfriedt/zephyrproject/zephyr ...
Running KconfigBasicNoModules tests in /Users/cfriedt/zephyrproject/zephyr ...
Running SysbuildKconfigBasicNoModules tests in /Users/cfriedt/zephyrproject/zephyr ...
Running Ruff             tests in /Users/cfriedt/zephyrproject/zephyr ...
Running BinaryFiles      tests in /Users/cfriedt/zephyrproject/zephyr ...
1 checks failed
ERROR   : Test Checkpatch failed: 
LINE_SPACING: Missing a blank line after declarations
File:drivers/serial/uart_native_pty.c
Line:63
ERROR   : Test Checkpatch failed: 
LONG_LINE: line length of 111 exceeds 100 columns
File:drivers/serial/uart_native_pty.c
Line:325
ERROR   : Test Checkpatch failed: 
LONG_LINE: line length of 104 exceeds 100 columns
File:drivers/serial/uart_native_pty.c
Line:333
ERROR   : Test Checkpatch failed: 
LONG_LINE: line length of 114 exceeds 100 columns
File:drivers/serial/uart_native_pty.c
Line:364
ERROR   : Test Checkpatch failed: 
TYPO_SPELLING: 'tranmission' may be misspelled - perhaps 'transmission'?
File:samples/drivers/uart/async_api/README.rst
Line:14
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:37
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:37
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:38
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:38
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:40
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:40
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:43
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:43
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:44
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:44
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:61
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:61
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:62
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:62
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:63
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:64
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:64
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:70
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:70
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:71
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:71
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:72
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:72
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:73
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:73
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:76
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:76
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:77
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:78
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:78
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:79
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:79
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:84
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:84
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:85
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:85
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:86
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:86
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:87
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:87
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:88
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:88
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:89
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:89
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:91
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:92
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:92
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:94
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:94
ERROR   : Test Checkpatch failed: 
SPACING: space required before the open parenthesis '('
File:samples/drivers/uart/async_api/src/main.c
Line:94
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:95
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:96
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:96
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:98
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:99
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:99
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:100
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:100
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:101
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:101
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:102
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:103
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:103
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:104
ERROR   : Test Checkpatch failed: 
LONG_LINE: line length of 124 exceeds 100 columns
File:samples/drivers/uart/async_api/src/main.c
Line:105
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:105
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:105
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:106
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:106
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:108
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:109
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:109
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:110
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:110
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:111
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:112
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:112
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:113
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:113
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:114
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:114
ERROR   : Test Checkpatch failed: 
ELSE_AFTER_BRACE: else should follow close brace '}'
File:samples/drivers/uart/async_api/src/main.c
Line:114
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:115
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:116
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:116
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:117
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:117
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:118
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:118
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:119
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:119
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:120
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:120
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:121
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:121
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:123
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:124
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:124
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:125
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:125
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:126
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:126
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:127
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:127
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:128
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:128
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:129
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:129
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:130
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:130
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:131
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:131
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:133
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:133
ERROR   : Test Checkpatch failed: 
CODE_INDENT: code indent should use tabs where possible
File:samples/drivers/uart/async_api/src/main.c
Line:134
ERROR   : Test Checkpatch failed: 
LEADING_SPACE: please, no spaces at the start of a line
File:samples/drivers/uart/async_api/src/main.c
Line:134

Complete results in compliance.xml
```