### PR TITLE
pmci: mctp: Fix No SOURCES CMake warning

### DIFF
--- a/subsys/pmci/CMakeLists.txt
+++ b/subsys/pmci/CMakeLists.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(mctp)
+add_subdirectory_ifdef(CONFIG_MCTP mctp)


### PR DESCRIPTION
The commit 1e0af58b519b ("pmci: Move MCTP into the PMCI subsys") changes 'mctp' directory adding to unconditionally, which will leading to:

CMake Warning at ./zephyrproject/zephyr/CMakeLists.txt:1022 (message):
  No SOURCES given to Zephyr library: subsys__pmci__mctp

  Excluding target from build.