### PR TITLE
drivers: ambiq: port more legacy drivers for apollo510

### DIFF
--- a/boards/ambiq/apollo510_evb/apollo510_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo510_evb/apollo510_evb-pinctrl.dtsi
@@ -24,6 +24,13 @@
 		};
 	};
 
+	adc0_default: adc0_default{
+		group1 {
+			pinmux = <ADCSE4_P15>, <ADCSE7_P12>;
+			drive-strength = "0.1";
+		};
+	};
+
 	i2c0_default: i2c0_default {
 		group1 {
 			pinmux = <M0SCL_P5>, <M0SDAWIR3_P6>;

--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -89,6 +89,12 @@
 	pinctrl-names = "default";
 };
 
+&adc0 {
+	pinctrl-0 = <&adc0_default>;
+	pinctrl-names = "default";
+	status = "disabled";
+};
+
 &counter0 {
 	status = "disabled";
 };

--- a/boards/ambiq/apollo510_evb/apollo510_evb.yaml
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
+  - adc
   - watchdog
   - counter
   - gpio

--- a/boards/ambiq/apollo510_evb/apollo510_evb.yaml
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.yaml
@@ -16,6 +16,7 @@ supported:
   - spi
   - i2c
   - rtc
+  - hwinfo
   - clock_control
   - mspi
 testing:

--- a/drivers/adc/adc_ambiq.c
+++ b/drivers/adc/adc_ambiq.c
@@ -52,7 +52,7 @@ static int adc_ambiq_set_resolution(am_hal_adc_slot_prec_e *prec, uint8_t adc_re
 	case 12:
 		*prec = AM_HAL_ADC_SLOT_12BIT;
 		break;
-#if !defined(CONFIG_SOC_SERIES_APOLLO4X)
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
 	case 14:
 		*prec = AM_HAL_ADC_SLOT_14BIT;
 		break;
@@ -80,7 +80,7 @@ static int adc_ambiq_slot_config(const struct device *dev, const struct adc_sequ
 	ADCSlotConfig.eChannel = channel;
 	ADCSlotConfig.bWindowCompare = false;
 	ADCSlotConfig.bEnabled = true;
-#if defined(CONFIG_SOC_SERIES_APOLLO4X)
+#if !defined(CONFIG_SOC_SERIES_APOLLO3X)
 	ADCSlotConfig.ui32TrkCyc = AM_HAL_ADC_MIN_TRKCYC;
 #endif
 	if (AM_HAL_STATUS_SUCCESS !=
@@ -101,8 +101,6 @@ static void adc_ambiq_isr(const struct device *dev)
 
 	/* Read the interrupt status. */
 	am_hal_adc_interrupt_status(data->adcHandle, &ui32IntMask, true);
-	/* Clear the ADC interrupt.*/
-	am_hal_adc_interrupt_clear(data->adcHandle, ui32IntMask);
 
 	/*
 	 * If we got a conversion completion interrupt (which should be our only
@@ -119,6 +117,8 @@ static void adc_ambiq_isr(const struct device *dev)
 		am_hal_adc_disable(data->adcHandle);
 		adc_context_on_sampling_done(&data->ctx, dev);
 	}
+	/* Clear the ADC interrupt.*/
+	am_hal_adc_interrupt_clear(data->adcHandle, ui32IntMask);
 }
 
 static int adc_ambiq_check_buffer_size(const struct adc_sequence *sequence, uint8_t active_channels)
@@ -280,9 +280,9 @@ static int adc_ambiq_init(const struct device *dev)
 
 	/* Initialize the ADC and get the handle*/
 	if (AM_HAL_STATUS_SUCCESS !=
-	    am_hal_adc_initialize((cfg->base - ADC_BASE) / (cfg->size * 4), &data->adcHandle)) {
+		am_hal_adc_initialize(0, &data->adcHandle)) {
 		ret = -ENODEV;
-		LOG_ERR("Faile to initialize ADC, code:%d", ret);
+		LOG_ERR("Failed to initialize ADC, code:%d", ret);
 		return ret;
 	}
 
@@ -292,7 +292,7 @@ static int adc_ambiq_init(const struct device *dev)
 	/* Set up the ADC configuration parameters. These settings are reasonable
 	 *  for accurate measurements at a low sample rate.
 	 */
-#if !defined(CONFIG_SOC_SERIES_APOLLO4X)
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
 	ADCConfig.eClock = AM_HAL_ADC_CLKSEL_HFRC;
 	ADCConfig.eReference = AM_HAL_ADC_REFSEL_INT_1P5;
 #else

--- a/drivers/flash/flash_ambiq.c
+++ b/drivers/flash/flash_ambiq.c
@@ -18,11 +18,11 @@ LOG_MODULE_REGISTER(flash_ambiq, CONFIG_FLASH_LOG_LEVEL);
 #define SOC_NV_FLASH_NODE DT_INST(0, soc_nv_flash)
 #define SOC_NV_FLASH_ADDR DT_REG_ADDR(SOC_NV_FLASH_NODE)
 #define SOC_NV_FLASH_SIZE DT_REG_SIZE(SOC_NV_FLASH_NODE)
-#if (CONFIG_SOC_SERIES_APOLLO4X)
-#define MIN_WRITE_SIZE 16
-#else
+#if (CONFIG_SOC_SERIES_APOLLO3X)
 #define MIN_WRITE_SIZE 4
-#endif /* CONFIG_SOC_SERIES_APOLLO4X */
+#else
+#define MIN_WRITE_SIZE 16
+#endif
 #define FLASH_WRITE_BLOCK_SIZE MAX(DT_PROP(SOC_NV_FLASH_NODE, write_block_size), MIN_WRITE_SIZE)
 #define FLASH_ERASE_BLOCK_SIZE DT_PROP(SOC_NV_FLASH_NODE, erase_block_size)
 
@@ -48,7 +48,7 @@ static struct k_sem flash_ambiq_sem;
 static const struct flash_parameters flash_ambiq_parameters = {
 	.write_block_size = FLASH_WRITE_BLOCK_SIZE,
 	.erase_value = FLASH_ERASE_BYTE,
-#if defined(CONFIG_SOC_SERIES_APOLLO4X)
+#if !defined(CONFIG_SOC_SERIES_APOLLO3X)
 	.caps = {
 		.no_explicit_erase = true,
 	},
@@ -113,17 +113,17 @@ static int flash_ambiq_write(const struct device *dev, off_t offset, const void 
 			aligned[j] = UNALIGNED_GET((uint32_t *)src);
 			src++;
 		}
-#if (CONFIG_SOC_SERIES_APOLLO4X)
-		ret = am_hal_mram_main_program(
-			AM_HAL_MRAM_PROGRAM_KEY, aligned,
-			(uint32_t *)(SOC_NV_FLASH_ADDR + offset + i * FLASH_WRITE_BLOCK_SIZE),
-			FLASH_WRITE_BLOCK_SIZE / sizeof(uint32_t));
-#elif (CONFIG_SOC_SERIES_APOLLO3X)
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
 		ret = am_hal_flash_program_main(
 			AM_HAL_FLASH_PROGRAM_KEY, aligned,
 			(uint32_t *)(SOC_NV_FLASH_ADDR + offset + i * FLASH_WRITE_BLOCK_SIZE),
 			FLASH_WRITE_BLOCK_SIZE / sizeof(uint32_t));
-#endif /* CONFIG_SOC_SERIES_APOLLO4X */
+#else
+		ret = am_hal_mram_main_program(
+			AM_HAL_MRAM_PROGRAM_KEY, aligned,
+			(uint32_t *)(SOC_NV_FLASH_ADDR + offset + i * FLASH_WRITE_BLOCK_SIZE),
+			FLASH_WRITE_BLOCK_SIZE / sizeof(uint32_t));
+#endif
 		if (ret) {
 			break;
 		}
@@ -150,9 +150,7 @@ static int flash_ambiq_erase(const struct device *dev, off_t offset, size_t len)
 		return 0;
 	}
 
-#if (CONFIG_SOC_SERIES_APOLLO4X)
-	/* The erase address and length alignment check will be done in HAL.*/
-#elif (CONFIG_SOC_SERIES_APOLLO3X)
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
 	if ((offset % FLASH_ERASE_BLOCK_SIZE) != 0) {
 		LOG_ERR("offset 0x%lx is not on a page boundary", (long)offset);
 		return -EINVAL;
@@ -162,15 +160,13 @@ static int flash_ambiq_erase(const struct device *dev, off_t offset, size_t len)
 		LOG_ERR("len %zu is not multiple of a page size", len);
 		return -EINVAL;
 	}
-#endif /* CONFIG_SOC_SERIES_APOLLO4X */
+#else
+	/* The erase address and length alignment check will be done in HAL.*/
+#endif
 
 	FLASH_SEM_TAKE();
 
-#if (CONFIG_SOC_SERIES_APOLLO4X)
-	ret = am_hal_mram_main_fill(AM_HAL_MRAM_PROGRAM_KEY, FLASH_ERASE_WORD,
-				    (uint32_t *)(SOC_NV_FLASH_ADDR + offset),
-				    (len / sizeof(uint32_t)));
-#elif (CONFIG_SOC_SERIES_APOLLO3X)
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
 	unsigned int key = 0;
 
 	key = irq_lock();
@@ -181,7 +177,11 @@ static int flash_ambiq_erase(const struct device *dev, off_t offset, size_t len)
 		AM_HAL_FLASH_ADDR2PAGE(((uint32_t)SOC_NV_FLASH_ADDR + offset)));
 
 	irq_unlock(key);
-#endif /* CONFIG_SOC_SERIES_APOLLO4X */
+#else
+	ret = am_hal_mram_main_fill(AM_HAL_MRAM_PROGRAM_KEY, FLASH_ERASE_WORD,
+				    (uint32_t *)(SOC_NV_FLASH_ADDR + offset),
+				    (len / sizeof(uint32_t)));
+#endif
 
 	FLASH_SEM_GIVE();
 

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -247,7 +247,7 @@ config HWINFO_RW61X
 config HWINFO_AMBIQ
 	bool "AMBIQ hwinfo"
 	default y
-	depends on SOC_SERIES_APOLLO4X
+	depends on SOC_SERIES_APOLLO4X || SOC_SERIES_APOLLO5X
 	select HWINFO_HAS_DRIVER
 	select AMBIQ_HAL
 	select AMBIQ_HAL_USE_HWINFO

--- a/drivers/hwinfo/hwinfo_ambiq.c
+++ b/drivers/hwinfo/hwinfo_ambiq.c
@@ -11,7 +11,6 @@
 
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
-
 	struct ambiq_hwinfo {
 		/* Ambiq Chip ID0 */
 		uint32_t chip_id_0;
@@ -27,7 +26,12 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	/* Contains the HAL hardware information about the device. */
 	am_hal_mcuctrl_device_t mcu_ctrl_device;
 
+#if (CONFIG_SOC_SERIES_APOLLO5X)
+	am_hal_info1_read(AM_HAL_INFO_INFOSPACE_CURRENT_INFO1, AM_REG_OTP_INFO1_TRIM_REV_O / 4, 1,
+			  &dev_hw_info.factory_trim_version);
+#else
 	am_hal_mram_info_read(1, AM_REG_INFO1_TRIM_REV_O / 4, 1, &dev_hw_info.factory_trim_version);
+#endif
 	am_hal_mcuctrl_info_get(AM_HAL_MCUCTRL_INFO_DEVICEID, &mcu_ctrl_device);
 
 	dev_hw_info.chip_id_0 = mcu_ctrl_device.ui32ChipID0;
@@ -61,9 +65,15 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	}
 
 	/* POWER CYCLE */
+#if (CONFIG_SOC_SERIES_APOLLO5X)
+	if (reset_status & AM_HAL_RESET_STATUS_POA) {
+		flags |= RESET_POR;
+	}
+#else
 	if (reset_status & AM_HAL_RESET_STATUS_POR) {
 		flags |= RESET_POR;
 	}
+#endif
 
 	/* BROWNOUT DETECTOR */
 	if (reset_status & AM_HAL_RESET_STATUS_BOD) {
@@ -109,6 +119,13 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 	if (reset_status & AM_HAL_RESET_STATUS_BOHPMEM) {
 		flags |= RESET_HARDWARE;
 	}
+
+#if (CONFIG_SOC_SERIES_APOLLO5X)
+	/* AIRCR */
+	if (reset_status & AM_HAL_RESET_STATUS_AIRCR) {
+		flags |= RESET_SOFTWARE;
+	}
+#endif
 
 	*cause = flags;
 	return 0;

--- a/dts/arm/ambiq/ambiq_apollo510.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo510.dtsi
@@ -549,6 +549,17 @@
 			status = "disabled";
 		};
 
+		adc0: adc@ADC_BASE_NAME {
+			compatible = "ambiq,adc";
+			reg = <ADC_REG_BASE ADC_REG_SIZE>;
+			interrupts = <19 0>;
+			interrupt-names = "ADC";
+			channel-count = <10>;
+			internal-vref-mv = <1190>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
 		pinctrl: pin-controller@GPIO_BASE_NAME {
 			compatible = "ambiq,apollo5-pinctrl";
 			reg = <GPIO_REG_BASE GPIO_REG_SIZE>;

--- a/samples/drivers/adc/adc_dt/boards/apollo510_evb.overlay
+++ b/samples/drivers/adc/adc_dt/boards/apollo510_evb.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Ambiq Micro Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+	zephyr,user {
+		io-channels = <&adc0 4>, <&adc0 7>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	interrupt-parent = <&nvic>;
+	interrupts = <19 0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/apollo510_evb.overlay
+++ b/tests/drivers/adc/adc_api/boards/apollo510_evb.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Ambiq Micro Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/ {
+	zephyr,user {
+		io-channels = <&adc0 4>, <&adc0 7>;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@7 {
+		reg = <7>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
This PR ports driver support to Apollo5 along with updating preprocessor conditions for different Apollo series in hwinfo, flash, and ADC drivers.