### PR TITLE
sensor: icm45686: Add I3C-bus support with IBI

### DIFF
--- a/drivers/sensor/tdk/icm45686/Kconfig
+++ b/drivers/sensor/tdk/icm45686/Kconfig
@@ -62,8 +62,10 @@ config ICM45686_THREAD_STACK_SIZE
 
 config ICM45686_STREAM
 	bool "Streaming mode"
-	depends on GPIO
-	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios)
+	depends on GPIO || \
+		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_INVENSENSE_ICM45686),int-gpios) || \
+		   $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
 	help
 	  Enable streaming of sensor data.
 

--- a/drivers/sensor/tdk/icm45686/Kconfig
+++ b/drivers/sensor/tdk/icm45686/Kconfig
@@ -10,6 +10,8 @@ menuconfig ICM45686
 	select SPI_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),spi)
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c)
 	select I2C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i2c)
+	select I3C if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
+	select I3C_RTIO if $(dt_compat_on_bus,$(DT_COMPAT_INVENSENSE_ICM45686),i3c)
 	help
 	  Enable driver for ICM45686 High-precision 6-axis motion
 	  tracking device.

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -449,7 +449,8 @@ static int icm45686_init(const struct device *dev)
 			.iodev = &icm45686_bus_##inst,						   \
 			.ctx = &icm45686_rtio_ctx_##inst,					   \
 			COND_CODE_1(DT_INST_ON_BUS(inst, i3c),					   \
-				(.type = ICM45686_BUS_I3C),					   \
+				(.type = ICM45686_BUS_I3C,					   \
+				 .i3c.id = I3C_DEVICE_ID_DT_INST(inst),),			   \
 			(COND_CODE_1(DT_INST_ON_BUS(inst, i2c),					   \
 				(.type = ICM45686_BUS_I2C), ())))				   \
 			COND_CODE_1(DT_INST_ON_BUS(inst, spi),					   \

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -133,6 +133,7 @@ struct icm45686_stream {
 enum icm45686_bus_type {
 	ICM45686_BUS_SPI,
 	ICM45686_BUS_I2C,
+	ICM45686_BUS_I3C,
 };
 
 struct icm45686_data {

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -14,6 +14,9 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/sensor/icm45686.h>
 #include <zephyr/rtio/rtio.h>
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(invensense_icm45686, i3c)
+#include <zephyr/drivers/i3c.h>
+#endif
 
 struct icm45686_encoded_payload {
 	union {
@@ -141,6 +144,13 @@ struct icm45686_data {
 		struct rtio_iodev *iodev;
 		struct rtio *ctx;
 		enum icm45686_bus_type type;
+/** Required to support In-band Interrupts */
+#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(invensense_icm45686, i3c)
+		struct {
+			struct i3c_device_desc *desc;
+			const struct i3c_device_id id;
+		} i3c;
+#endif
 	} rtio;
 	/** Single-shot encoded data instance to support fetch/get API */
 	struct icm45686_encoded_data edata;

--- a/drivers/sensor/tdk/icm45686/icm45686_bus.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_bus.h
@@ -38,6 +38,8 @@ static inline int icm45686_bus_read(const struct device *dev,
 	rtio_sqe_prep_read(read_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
 	if (data->rtio.type == ICM45686_BUS_I2C) {
 		read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	} else if (data->rtio.type == ICM45686_BUS_I3C) {
+		read_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
 	}
 
 	err = rtio_submit(ctx, 2);
@@ -78,6 +80,8 @@ static inline int icm45686_bus_write(const struct device *dev,
 	rtio_sqe_prep_write(write_buf_sqe, iodev, RTIO_PRIO_HIGH, buf, len, NULL);
 	if (data->rtio.type == ICM45686_BUS_I2C) {
 		write_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+	} else if (data->rtio.type == ICM45686_BUS_I3C) {
+		write_buf_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP;
 	}
 
 	err = rtio_submit(ctx, 2);

--- a/drivers/sensor/tdk/icm45686/icm45686_reg.h
+++ b/drivers/sensor/tdk/icm45686/icm45686_reg.h
@@ -49,6 +49,7 @@
 #define REG_FIFO_CONFIG3			0x21
 #define REG_FIFO_CONFIG4			0x22
 #define REG_DRIVE_CONFIG0			0x32
+#define REG_DRIVE_CONFIG1			0x33
 #define REG_WHO_AM_I				0x72
 #define REG_IREG_ADDR_15_8			0x7C
 #define REG_IREG_ADDR_7_0			0x7D
@@ -74,6 +75,8 @@
 #define REG_GYRO_CONFIG0_FS(val)			(((val) & BIT_MASK(4)) << 4)
 
 #define REG_DRIVE_CONFIG0_SPI_SLEW(val)			(((val) & BIT_MASK(2)) << 1)
+#define REG_DRIVE_CONFIG1_I3C_SLEW(val)			(((val) & BIT_MASK(3)) |		   \
+							 (((val) & BIT_MASK(3)) << 3))
 
 #define REG_MISC2_SOFT_RST(val)				((val << 1) & BIT(1))
 

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -206,6 +206,8 @@ static void icm45686_handle_event_actions(struct rtio *ctx,
 				   NULL);
 		if (data->rtio.type == ICM45686_BUS_I2C) {
 			data_rd_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+		} else if (data->rtio.type == ICM45686_BUS_I3C) {
+			data_rd_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
 		}
 		data_rd_sqe->flags |= RTIO_SQE_CHAINED;
 
@@ -237,6 +239,8 @@ static void icm45686_handle_event_actions(struct rtio *ctx,
 					 NULL);
 		if (data->rtio.type == ICM45686_BUS_I2C) {
 			write_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+		} else if (data->rtio.type == ICM45686_BUS_I3C) {
+			write_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP;
 		}
 		write_sqe->flags |= RTIO_SQE_CHAINED;
 
@@ -277,6 +281,8 @@ static void icm45686_handle_event_actions(struct rtio *ctx,
 				   NULL);
 		if (data->rtio.type == ICM45686_BUS_I2C) {
 			read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+		} else if (data->rtio.type == ICM45686_BUS_I3C) {
+			read_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
 		}
 		read_sqe->flags |= RTIO_SQE_CHAINED;
 	}
@@ -329,6 +335,8 @@ static void icm45686_event_handler(const struct device *dev)
 					 NULL);
 		if (data->rtio.type == ICM45686_BUS_I2C) {
 			write_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+		} else if (data->rtio.type == ICM45686_BUS_I3C) {
+			write_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP;
 		}
 		rtio_submit(data->rtio.ctx, 0);
 
@@ -389,6 +397,8 @@ static void icm45686_event_handler(const struct device *dev)
 			   NULL);
 	if (data->rtio.type == ICM45686_BUS_I2C) {
 		read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	} else if (data->rtio.type == ICM45686_BUS_I3C) {
+		read_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
 	}
 	read_sqe->flags |= RTIO_SQE_CHAINED;
 
@@ -413,6 +423,8 @@ static void icm45686_event_handler(const struct device *dev)
 			   NULL);
 	if (data->rtio.type == ICM45686_BUS_I2C) {
 		read_fifo_ct_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	} else if (data->rtio.type == ICM45686_BUS_I3C) {
+		read_fifo_ct_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
 	}
 	read_fifo_ct_sqe->flags |= RTIO_SQE_CHAINED;
 

--- a/dts/bindings/sensor/invensense,icm45686-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-i3c.yaml
@@ -1,0 +1,30 @@
+# # Copyright (c) 2025 Croxel Inc.
+# # SPDX-License-Identifier: Apache-2.0
+
+description: |
+    ICM45686 High-precision 6-axis motion tracking device
+    When setting the accel-pm, accel-range, accel-odr, gyro-pm, gyro-range,
+    gyro-odr properties in a .dts or .dtsi file you may include icm45686.h
+    and use the macros defined there.
+
+    Example:
+    #include <zephyr/dt-bindings/sensor/icm45686.h>
+
+    &i3c1 {
+      ...
+
+      icm42688: icm45686@680000046a00000011 {
+        ...
+
+        accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
+        accel-fs = <ICM45686_DT_ACCEL_FS_32>;
+        accel-odr = <ICM45686_DT_ACCEL_ODR_800>;
+        gyro-pwr-mode= <ICM45686_DT_GYRO_LN>;
+        gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
+        gyro-odr = <ICM45686_DT_GYRO_ODR_800>;
+      };
+    };
+
+compatible: "invensense,icm45686"
+
+include: ["i3c-device.yaml", "invensense,icm45686-common.yaml"]

--- a/tests/drivers/build_all/sensor/i3c.dtsi
+++ b/tests/drivers/build_all/sensor/i3c.dtsi
@@ -60,3 +60,10 @@ test_i3c_lsm6dsv32x: lsm6dsv32x@600000803E0000004 {
 	gyro-range = <LSM6DSV16X_DT_FS_2000DPS>;
 	gyro-odr = <LSM6DSV16X_DT_ODR_AT_60Hz>;
 };
+
+test_i3c_icm45686: icm45686@700000803E0000004 {
+	compatible = "invensense,icm45686";
+	reg = <0x7 0x00000803 0xE0000004>;
+	assigned-address = <0x7>;
+	int-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
### Description
This PR adds I3C bus support to ICM45686 driver, with the following features:
- Read/Decode.
- Streaming mode
    - with In-Band Interrupts.
    - with INT GPIO.

### Testing
- Run Shell sample on FRDM MCXN947 with Streaming mode enabled.
- Build command:
```
west build -b frdm_mcxn947/mcxn947/cpu0 samples/subsys/shell/shell_module -- -DCONFIG_SENSOR=y -DCONFIG_SENSOR_SHELL=y -DCONFIG_ICM45686_STREAM=y -DCONFIG_SENSOR_SHELL_STREAM=y
```
- DTS overlay (`boards/frdm_mcxn947_mcxn947_cpu0.overlay`):
``` dts
#include <zephyr/dt-bindings/sensor/icm45686.h>
#include <freq.h>

&i3c1 {
	status = "okay";

	i2c-scl-hz = <DT_FREQ_K(400)>;
	i3c-scl-hz = <DT_FREQ_K(400)>;
	i3c-od-scl-hz = <DT_FREQ_K(400)>;

	icm45686: icm45686@000000046a00000011 {
		compatible = "invensense,icm45686";
		reg = <0x00  0x046a 0x00000011>;

		// No int-gpios: use IBI for streaming mode

		accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;
		accel-fs = <ICM45686_DT_ACCEL_FS_2>;
		accel-odr = <ICM45686_DT_ACCEL_ODR_25>;
		accel-lpf = <ICM45686_DT_ACCEL_LPF_BW_1_32>;
		
		gyro-pwr-mode = <ICM45686_DT_GYRO_LN>;
		gyro-fs = <ICM45686_DT_GYRO_FS_4000>;
		gyro-odr = <ICM45686_DT_GYRO_ODR_25>;
		gyro-lpf = <ICM45686_DT_GYRO_LPF_BW_1_32>;

		fifo-watermark = <25>;
	};
};

```

- Console Output:
``` console
uart:~$ sensor get icm45686@000000046a00000011 
channel type=0(accel_x) index=0 shift=5 num_samples=1 value=7830306290ns (0.165198)
channel type=1(accel_y) index=0 shift=5 num_samples=1 value=7830306290ns (-0.456094)
channel type=2(accel_z) index=0 shift=5 num_samples=1 value=7830306290ns (9.818620)
channel type=3(accel_xyz) index=0 shift=5 num_samples=1 value=7830306290ns, (0.165198, -0.456094, 9.818620)
channel type=4(gyro_x) index=0 shift=12 num_samples=1 value=7830306290ns (0.000000)
channel type=5(gyro_y) index=0 shift=12 num_samples=1 value=7830306290ns (0.000000)
channel type=6(gyro_z) index=0 shift=12 num_samples=1 value=7830306290ns (0.000000)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=1 value=7830306290ns, (0.000000, 0.000000, 0.000000)
channel type=12(die_temp) index=0 shift=9 num_samples=1 value=7830306290ns (22.826085)
uart:~$ sensor get icm45686@000000046a00000011
uart:~$ sensor stream icm45686@000000046a00000011 on fifo_wm incl 
Enabling stream...
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=51354639843ns, (0.076949, -0.142023, 4.713081)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=51354639843ns, (0.000099, 0.000030, -0.000434)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=51354639843ns (23.932366)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=51833746156ns, (0.077284, -0.141113, 4.712458)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=51833746156ns, (0.000621, 0.000120, -0.000413)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=51833746156ns (23.956521)
Trigger (10 / fifo_wm) detected
channel type=3(accel_xyz) index=0 shift=9 num_samples=25 value=52312842336ns, (0.078194, -0.139102, 4.714900)
channel type=7(gyro_xyz) index=0 shift=12 num_samples=25 value=52312842336ns, (0.000217, 0.000125, -0.000360)
channel type=12(die_temp) index=0 shift=9 num_samples=25 value=52312842336ns (23.944443)
T
```