### PR TITLE
sensor: npm1300_charger: fixes & improved resolution

### DIFF
--- a/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
+++ b/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
@@ -153,8 +153,8 @@ static const struct linear_range vbus_current_ranges[] = {
 static void calc_temp(const struct npm1300_charger_config *const config, uint16_t code,
 		      struct sensor_value *valp)
 {
-	/* Ref: Datasheet Figure 42: Battery temperature (Kelvin) */
-	float log_result = log((1024.f / (float)code) - 1);
+	/* Ref: PS v1.2 Section 7.1.4: Battery temperature (Kelvin) */
+	float log_result = logf((1024.f / (float)code) - 1);
 	float inv_temp_k = (1.f / 298.15f) - (log_result / (float)config->thermistor_beta);
 
 	float temp = (1.f / inv_temp_k) - 273.15f;
@@ -165,7 +165,7 @@ static void calc_temp(const struct npm1300_charger_config *const config, uint16_
 static void calc_dietemp(const struct npm1300_charger_config *const config, uint16_t code,
 			 struct sensor_value *valp)
 {
-	/* Ref: Datasheet Figure 36: Die temperature (Celsius) */
+	/* Ref: PS v1.2 Section 7.1.4: Die temperature (Celsius) */
 	int32_t temp =
 		DIETEMP_OFFSET_MDEGC - (((int32_t)code * DIETEMP_FACTOR_MUL) / DIETEMP_FACTOR_DIV);
 

--- a/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
+++ b/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
@@ -196,14 +196,14 @@ static void calc_current(const struct npm1300_charger_config *const config,
 
 	switch (data->ibat_stat) {
 	case IBAT_STAT_DISCHARGE:
-		full_scale_ma = config->dischg_limit_microamp / 893;
+		full_scale_ma = -config->dischg_limit_microamp / 893;
 		break;
 	case IBAT_STAT_CHARGE_TRICKLE:
 	/* Fallthrough */
 	case IBAT_STAT_CHARGE_COOL:
 	/* Fallthrough */
 	case IBAT_STAT_CHARGE_NORMAL:
-		full_scale_ma = -config->current_microamp / 800;
+		full_scale_ma = config->current_microamp / 800;
 		break;
 	default:
 		full_scale_ma = 0;

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -161,11 +161,11 @@ enum sensor_channel {
 
 	/** Voltage, in volts **/
 	SENSOR_CHAN_GAUGE_VOLTAGE,
-	/** Average current, in amps **/
+	/** Average current, in amps (negative=discharging) **/
 	SENSOR_CHAN_GAUGE_AVG_CURRENT,
-	/** Standby current, in amps **/
+	/** Standby current, in amps (negative=discharging) **/
 	SENSOR_CHAN_GAUGE_STDBY_CURRENT,
-	/** Max load current, in amps **/
+	/** Max load current, in amps (negative=discharging) **/
 	SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT,
 	/** Gauge temperature  **/
 	SENSOR_CHAN_GAUGE_TEMP,


### PR DESCRIPTION
Use the standard sensor value conversion helpers for constructing `struct sensor_value` outputs.

Use `logf` instead of `log`.

Document the expected meaning of positive and negative currents for the fuel gauge channels.

Update the direction of the measured current to match that expected by the API and existing users.

Update the conversion functions for the charge/discharge current to be uA resolution.