### PR TITLE
MAINTAINERS.yml: promote maass-hamburg to mdio maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1699,10 +1699,11 @@ Release Notes:
     - drivers.memc
 
 "Drivers: MDIO":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - maass-hamburg
   collaborators:
     - decsny
-    - maass-hamburg
   files:
     - doc/hardware/peripherals/mdio.rst
     - drivers/mdio/


### PR DESCRIPTION
promote maass-hamburg to mdio maintainer.
MDIO and Ethernet kind of belong together, so it
make sense, that I am also the MDIO maintainer.