### PR TITLE
drivers: sensor: max31855: fixed sign bit positions

### DIFF
--- a/drivers/sensor/maxim/max31855/max31855.c
+++ b/drivers/sensor/maxim/max31855/max31855.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Christian Hirsch
+ * Copyright (c) 2025 Petr Vilím
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -72,7 +73,7 @@ static int max31855_channel_get(const struct device *dev, enum sensor_channel ch
 		temp = (temp >> THERMOCOUPLE_TEMPERATURE_POS) & 0x3fff;
 
 		/* if sign bit is set, make value negative */
-		if (temp & BIT(14)) {
+		if (temp & BIT(13)) {
 			temp |= THERMOCOUPLE_SIGN_BITS;
 		}
 
@@ -86,7 +87,7 @@ static int max31855_channel_get(const struct device *dev, enum sensor_channel ch
 		temp = (temp >> INTERNAL_TEMPERATURE_POS) & 0xfff;
 
 		/* if sign bit is set, make value negative */
-		if (temp & BIT(12)) {
+		if (temp & BIT(11)) {
 			temp |= INTERNAL_SIGN_BITS;
 		}
 


### PR DESCRIPTION
MAX31855 driver had a wrong position of sign bits causing invalid reading of negative temperature values. Fixed by shifting position of sign bit by one bit.