### PR TITLE
net: config: sntp: add option for failure try interval

### DIFF
--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -244,9 +244,18 @@ config NET_CONFIG_SNTP_INIT_RESYNC
 	  Perform an SNTP request over networking periodically to get and
 	  absolute wall clock time, and resync system time from it.
 
+if NET_CONFIG_SNTP_INIT_RESYNC
+
 config NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL
 	int "SNTP resync interval (sec)"
-	depends on NET_CONFIG_SNTP_INIT_RESYNC
 	default 3600
 
+config NET_CONFIG_SNTP_INIT_RESYNC_ON_FAILURE_INTERVAL
+	int "SNTP resync interval (sec) on failure"
+	default NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL
+	help
+	  If the SNTP request fails, then this is the interval to wait
+	  before trying again.
+
+endif # NET_CONFIG_SNTP_INIT_RESYNC
 endif # NET_CONFIG_CLOCK_SNTP_INIT

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -36,6 +36,10 @@ static int sntp_init_helper(struct sntp_time *tm)
 		return sntp_simple_addr((struct sockaddr *)&sntp_addr, sizeof(sntp_addr),
 					CONFIG_NET_CONFIG_SNTP_INIT_TIMEOUT, tm);
 	}
+	if (sizeof(CONFIG_NET_CONFIG_SNTP_INIT_SERVER) == 1) {
+		/* Empty address, skip using SNTP via Kconfig defaults */
+		return -EINVAL;
+	}
 	LOG_INF("SNTP address not set by DHCPv4, using Kconfig defaults");
 #endif /* NET_CONFIG_SNTP_INIT_SERVER_USE_DHCPV4_OPTION */
 	return sntp_simple(CONFIG_NET_CONFIG_SNTP_INIT_SERVER,

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -18,6 +18,11 @@ static void sntp_resync_handler(struct k_work *work);
 static K_WORK_DELAYABLE_DEFINE(sntp_resync_work_handle, sntp_resync_handler);
 #endif
 
+BUILD_ASSERT(
+	IS_ENABLED(CONFIG_NET_CONFIG_SNTP_INIT_SERVER_USE_DHCPV4_OPTION) ||
+	(sizeof(CONFIG_NET_CONFIG_SNTP_INIT_SERVER) != 1),
+	"SNTP server has to be configured, unless DHCPv4 is used to set it");
+
 static int sntp_init_helper(struct sntp_time *tm)
 {
 #ifdef CONFIG_NET_CONFIG_SNTP_INIT_SERVER_USE_DHCPV4_OPTION

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -54,8 +54,10 @@ int net_init_clock_via_sntp(void)
 
 end:
 #ifdef CONFIG_NET_CONFIG_SNTP_INIT_RESYNC
-	k_work_reschedule(&sntp_resync_work_handle,
-			  K_SECONDS(CONFIG_NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL));
+	k_work_reschedule(
+		&sntp_resync_work_handle,
+		(res < 0) ? K_SECONDS(CONFIG_NET_CONFIG_SNTP_INIT_RESYNC_ON_FAILURE_INTERVAL)
+			  : K_SECONDS(CONFIG_NET_CONFIG_SNTP_INIT_RESYNC_INTERVAL));
 #endif
 	return res;
 }


### PR DESCRIPTION
add option for a different resync interval, that is
applied when the sntp request fails.

also adds a build assert and optimisation at build time