### PR TITLE
boards: nxp: RW612: support override TX power limit file

### DIFF
--- a/boards/nxp/frdm_rw612/CMakeLists.txt
+++ b/boards/nxp/frdm_rw612/CMakeLists.txt
@@ -21,3 +21,12 @@ if (CONFIG_DT_HAS_NXP_ENET_MAC_ENABLED AND CONFIG_XTAL32K)
 		"mutually exclusive on FRDM_RW612 due to shared PCB nets "
 		"between the ethernet PHY and the external oscillator")
 endif()
+
+# Set TX power limit file to override the default one
+if (CONFIG_WIFI_NXP)
+  zephyr_include_directories(
+      tx_pwr_limits
+  )
+
+  zephyr_compile_definitions(WIFI_BT_TX_PWR_LIMITS_OVERRIDE="wlan_txpwrlimit_cfg_WW_rw610.h")
+endif()

--- a/boards/nxp/rd_rw612_bga/CMakeLists.txt
+++ b/boards/nxp/rd_rw612_bga/CMakeLists.txt
@@ -23,3 +23,12 @@ if (CONFIG_DT_HAS_NXP_ENET_MAC_ENABLED AND CONFIG_XTAL32K)
 		"mutually exclusive on RD_RW612_BGA due to shared PCB nets "
 		"between the ethernet PHY and the external oscillator")
 endif()
+
+# Set TX power limit file to override the default one
+if (CONFIG_WIFI_NXP)
+  zephyr_include_directories(
+      tx_pwr_limits
+  )
+
+  zephyr_compile_definitions(WIFI_BT_TX_PWR_LIMITS_OVERRIDE="wlan_txpwrlimit_cfg_WW_rw610.h")
+endif()

--- a/west.yml
+++ b/west.yml
@@ -208,7 +208,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 601e1e538abaf9f5985e28531b3b6a2a07e38d2a
+      revision: 5e5a498e79347c6b1be9cf6d7e553c5ff96cb379
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add here as an example that support setting customized TX power limit file to override the default one.
