### PR TITLE
ci: workflows: check for manifest dnm in the manifest workflow

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -53,3 +53,10 @@ jobs:
           verbosity-level: '1'
           labels: 'manifest'
           dnm-labels: 'DNM (manifest)'
+
+      - name: Check for label
+        if: ${{ contains(github.event.*.labels.*.name, 'DNM (manifest)') }}
+        run: |
+          echo "Pull request is labeled as 'DNM (manifest)'."
+          echo "This workflow fails so that the pull request cannot be merged."
+          exit 1

--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - name: Check for label
         if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
-                contains(github.event.*.labels.*.name, 'DNM (manifest)') ||
                 contains(github.event.*.labels.*.name, 'TSC') ||
                 contains(github.event.*.labels.*.name, 'Architecture Review') ||
                 contains(github.event.*.labels.*.name, 'dev-review') }}


### PR DESCRIPTION
The current CI setup sets the manifest DNM label in a workflow and checks it in a different workflow. The one performing the check is configured to rerun on label changes but it's been reported few times that the rerun logic does not seem to always run effectively and there's been cases where the manifest has been fixed but the label has not been removed by the automation, resulting in a stale PR.

Since the manifest has its own dedicated label, fix this race condition by checking for that label specifically in the manifest workflow rather than in a separate one, this means that the check is always performed after the script that sets the label.

It also means that on manifest changes the manifest step itself will fail rather than the PR metadata check one.