### PR TITLE
dts: stm32: Add st,stm32-qdec support to TIM1-TIM5 & TIM8 for STM32F2

### DIFF
--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -15,6 +15,7 @@
 #include <zephyr/dt-bindings/dma/stm32_dma.h>
 #include <zephyr/dt-bindings/adc/stm32f4_adc.h>
 #include <zephyr/dt-bindings/reset/stm32f2_4_7_reset.h>
+#include <zephyr/dt-bindings/sensor/qdec_stm32.h>
 #include <zephyr/dt-bindings/adc/adc.h>
 #include <freq.h>
 
@@ -421,6 +422,12 @@
 				status = "disabled";
 				#pwm-cells = <3>;
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
+			};
 		};
 
 		timers2: timers@40000000 {
@@ -437,6 +444,12 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
 			};
 		};
 
@@ -460,6 +473,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
+			};
 		};
 
 		timers4: timers@40000800 {
@@ -482,6 +501,12 @@
 				compatible = "st,stm32-counter";
 				status = "disabled";
 			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
+			};
 		};
 
 		timers5: timers@40000c00 {
@@ -503,6 +528,12 @@
 			counter {
 				compatible = "st,stm32-counter";
 				status = "disabled";
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
 			};
 		};
 
@@ -552,6 +583,12 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				#pwm-cells = <3>;
+			};
+
+			qdec {
+				compatible = "st,stm32-qdec";
+				status = "disabled";
+				st,input-filter-level = <NO_FILTER>;
 			};
 		};
 

--- a/samples/sensor/qdec/boards/nucleo_f207zg.overlay
+++ b/samples/sensor/qdec/boards/nucleo_f207zg.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Application overlay for creating quadrature decoder device instance
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec;
+	};
+};
+
+&timers3 {
+	status = "okay";
+
+	qdec: qdec {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pa6 &tim3_ch2_pa7>;
+		pinctrl-names = "default";
+		st,input-polarity-inverted;
+		st,input-filter-level = <FDIV32_N8>;
+		st,counts-per-revolution = <16>;
+	};
+};

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -27,16 +27,6 @@ tests:
         - "Quadrature decoder sensor test"
         - "Position = (.*) degrees"
 
-  sample.sensor.st_qdec_sensor:
-    platform_allow: nucleo_f401re
-    harness_config:
-      fixture: fixture_mech_encoder
-      type: multi_line
-      ordered: true
-      regex:
-        - "Quadrature decoder sensor test"
-        - "Position = (.*) degrees"
-
   sample.sensor.nrf_qdec_sensor:
     platform_allow:
       - nrf52840dk/nrf52840


### PR DESCRIPTION
QDEC FOR STM32F2: Added the qdec support for the STM32F2 microcontrollers

Currently only the stm32f4 has qdec peripheral in its timers. Other STM32 microcontrollers have qdec but only stm32f4 has support so I added support for the STM32F2 microcontrollers. Will start with other microcontrollers as well. Starts the processing of fixing #88902

Signed-off-by: Amaan Singh <amaansingh160@gmail.com>
