### PR TITLE
doc: semihosting: fix section level

### DIFF
--- a/doc/hardware/arch/semihost.rst
+++ b/doc/hardware/arch/semihost.rst
@@ -52,7 +52,7 @@ directory of the running process.
    semihost_close(fd);
 
 Additional Functionality
-########################
+************************
 
 Additional functionality is available by running semihosting instructions
 directly with :c:func:`semihost_exec` with one of the instructions defined


### PR DESCRIPTION
Wrong section level makes this section appear in the wrong table of
contents.

![image](https://github.com/user-attachments/assets/2aa70967-a209-4ce4-be86-ba83fbfedfb3)


Signed-off-by: Anas Nashif <anas.nashif@intel.com>
