### PR TITLE
sys: ring_buffer: fix possible ring_buf_put_claim() wrong size

### DIFF
--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -304,8 +304,9 @@ static inline uint32_t ring_buf_put_claim(struct ring_buf *buf,
 					  uint8_t **data,
 					  uint32_t size)
 {
+	uint32_t space = ring_buf_space_get(buf);
 	return ring_buf_area_claim(buf, &buf->put, data,
-				   MIN(size, ring_buf_space_get(buf)));
+				   MIN(size, space));
 }
 
 /**
@@ -385,8 +386,9 @@ static inline uint32_t ring_buf_get_claim(struct ring_buf *buf,
 					  uint8_t **data,
 					  uint32_t size)
 {
+	uint32_t buf_size = ring_buf_size_get(buf);
 	return ring_buf_area_claim(buf, &buf->get, data,
-				   MIN(size, ring_buf_size_get(buf)));
+				   MIN(size, buf_size));
 }
 
 /**


### PR DESCRIPTION
- The issue is caused by the MIN() macro, which expands to (a)<(b)?(a):(b), where ring_buf_space_get()/ring_buf_size_get()
  is used as 'b' and is evaluated twice. The issue occurs when the (a)<(b) condition evaluates such that (b) is selected,
  but the value of (b) changes between evaluations, resulting in a possibly larger value than (a).
- Fixes the potential incorrect behavior by storing the result of ring_buf_space_get()/ring_buf_size_get() in a variable before using it in the MIN macro.
