### PR TITLE
net: lib: sockets: Fix socketpair mempool size

### DIFF
--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -372,7 +372,7 @@ config HEAP_MEM_POOL_ADD_SIZE_SOCKETPAIR
 	int
 	default 9136 if WIFI_NM_HOSTAPD_AP
 	default 6852 if WIFI_NM_WPA_SUPPLICANT
-	default 256
+	default 296
 
 endif # NET_SOCKETPAIR_HEAP
 


### PR DESCRIPTION
The default size of `CONFIG_HEAP_MEM_POOL_ADD_SIZE_SOCKETPAIR` was not sufficient to allocatie 2 * `struct spair` as required by `spair_new()`. ~I also added a `BUILD_ASSERT` to prevent this from happening again.~

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/87047