### PR TITLE
logging: mtrace: don't activate with hook == NULL

### DIFF
--- a/subsys/logging/backends/log_backend_adsp_mtrace.c
+++ b/subsys/logging/backends/log_backend_adsp_mtrace.c
@@ -221,7 +221,7 @@ void adsp_mtrace_log_init(adsp_mtrace_log_hook_t hook)
 	mtrace_init();
 
 	mtrace_hook = hook;
-	mtrace_active = true;
+	mtrace_active = !!hook;
 }
 
 const struct log_backend *log_backend_adsp_mtrace_get(void)


### PR DESCRIPTION
adsp_mtrace_log_init() can be called with its argument equal NULL, mtrace_active shouldn't be set to true in that case.