### PR TITLE
soc: nxp: mcxn: configure CPU1 TrustZone access level

### DIFF
--- a/boards/nxp/frdm_mcxn947/board.c
+++ b/boards/nxp/frdm_mcxn947/board.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NXP
+ * Copyright 2024  NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/init.h>
@@ -83,19 +83,6 @@ __ramfunc static void enable_cache64(void)
 	__DSB();
 }
 #endif
-
-static void unsecure_gpio(GPIO_Type * base)
-{
-	/* Enables CPU1 to access GPIO registers
-	 * Pins and interrupts can be configured in non-secure access
-	 */
-	base->PCNS = 0xFFFFFFFFU;
-	base->ICNS = GPIO_ICNS_NSE1_MASK | GPIO_ICNS_NSE0_MASK;
-
-	/* Pins and interrupts can be configured in non-privilege access */
-	base->PCNP = 0xFFFFFFFFU;
-	base->ICNP = GPIO_ICNP_NPE1_MASK | GPIO_ICNP_NPE0_MASK;
-}
 
 void board_early_init_hook(void)
 {
@@ -196,27 +183,22 @@ void board_early_init_hook(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio0))
 	CLOCK_EnableClock(kCLOCK_Gpio0);
-	unsecure_gpio(GPIO0);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio1))
 	CLOCK_EnableClock(kCLOCK_Gpio1);
-	unsecure_gpio(GPIO1);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio2))
 	CLOCK_EnableClock(kCLOCK_Gpio2);
-	unsecure_gpio(GPIO2);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio3))
 	CLOCK_EnableClock(kCLOCK_Gpio3);
-	unsecure_gpio(GPIO3);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(gpio4))
 	CLOCK_EnableClock(kCLOCK_Gpio4);
-	unsecure_gpio(GPIO4);
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dac0))

--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -52,6 +52,15 @@ config MCUX_CORE_SUFFIX
 	default "_cm33_core1" if SOC_MCXN947_CPU1
 endif
 
+if SECOND_CORE_MCUX
+config SECOND_CORE_MCUX_ACCESS_LEVEL
+	int "default TrustZone access level for secondary core"
+	default 3
+	help
+	  Configures AHBSC MASTER_SEC_LEVEL register for the cpu1 before cpu1 is
+	  enabled.
+endif
+
 rsource "../../common/Kconfig.flexspi_xip"
 
 endif # SOC_SERIES_MCXN

--- a/soc/nxp/mcx/mcxn/soc.c
+++ b/soc/nxp/mcx/mcxn/soc.c
@@ -44,6 +44,13 @@ DT_FOREACH_STATUS_OKAY(nxp_lpspi, FLEXCOMM_CHECK)
 /* This function is also called at deep sleep resume. */
 static int second_core_boot(void)
 {
+	/* Configure CPU1 TrustZone access level before CPU1 is enabled */
+	AHBSC->MASTER_SEC_LEVEL |=
+		AHBSC_MASTER_SEC_LEVEL_CPU1(CONFIG_SECOND_CORE_MCUX_ACCESS_LEVEL);
+	AHBSC->MASTER_SEC_ANTI_POL_REG = (~AHBSC->MASTER_SEC_LEVEL &
+		~AHBSC_MASTER_SEC_ANTI_POL_REG_MASTER_SEC_LEVEL_ANTIPOL_LOCK_MASK) |
+		AHBSC_MASTER_SEC_ANTI_POL_REG_MASTER_SEC_LEVEL_ANTIPOL_LOCK(2);
+
 	/* Boot source for Core 1 from flash */
 	SYSCON->CPBOOT = ((uint32_t)(char *)DT_REG_ADDR(DT_CHOSEN(zephyr_code_cpu1_partition)) &
 			  SYSCON_CPBOOT_CPBOOT_MASK);


### PR DESCRIPTION
Configures AHBSC MASTER_SEC_LEVEL register for the cpu1 before cpu1 is enabled.  By default, this gives CPU1 secure and privileged access to the rest of the SOC, same as CPU0.

This also reverts feb966df36cbb8b6d847b9f0873bc79195e7fd22.  Configuring the GPIO access permissions is no longer required for CPU1 to access the GPIO.

Resolves #88965 .

Tested using the blinky sample running on CPU1 using the following commands:
```
west build -b frdm_mcxn947//cpu1 samples/basic/blinky -d blinky_cpu1 -p -- -DCONFIG_SECOND_CORE_MCUX=y
west flash -d blinky_cpu1
west build -b frdm_mcxn947//cpu0 samples/hello_world/  -d hello_cpu0_loader -p -- -DCONFIG_SECOND_CORE_MCUX=y
west flash -d hello_cpu0_loader
```
GPIO also accessible from CPU0, tested with sample blinky and button.
