### PR TITLE
scripts: ci: check_compliance.py: Fix check_disallowed_defconfigs: Windows

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -720,8 +720,14 @@ class KconfigCheck(ComplianceTest):
         disallowed_regex = "(" + "|".join(disallowed_symbols.keys()) + ")$"
 
         # Warning: Needs to work with both --perl-regexp and the 're' module
-        regex_boards = r"\bCONFIG_[A-Z0-9_]+\b(?!\s*##|[$@{(.*])"
-        regex_socs = r"\bconfig\s+[A-Z0-9_]+$"
+        # Windows
+        if os.name == 'nt':
+            # Remove word boundaries on Windows implementation
+            regex_boards = r"CONFIG_[A-Z0-9_]+(?!\s*##|[$@{(.*])"
+            regex_socs = r"config[ \t]+[A-Z0-9_]+"
+        else:
+            regex_boards = r"\bCONFIG_[A-Z0-9_]+\b(?!\s*##|[$@{(.*])"
+            regex_socs = r"\bconfig\s+[A-Z0-9_]+$"
 
         grep_stdout_boards = git("grep", "--line-number", "-I", "--null",
                                  "--perl-regexp", regex_boards, "--", ":boards",


### PR DESCRIPTION
scripts: ci: check_compliance.py: Fix check_disallowed_defconfigs: Windows

[#78615](https://github.com/zephyrproject-rtos/zephyr/pull/78615) added a check for disallowed Kconfigs which does not work on Windows machines. Windows machines seem to behave differently when faced with the \b word boundary marker. I have removed the \b word boundary marker from the grep commands when os.name=='nt'. The script performs the same as before for any other os.