### PR TITLE
Bluetooth: Classic: L2CAP: Handle multi L2CAP packets of a HCI ACL

### DIFF
--- a/subsys/bluetooth/host/classic/conn_br_internal.h
+++ b/subsys/bluetooth/host/classic/conn_br_internal.h
@@ -10,3 +10,5 @@
  */
 
 int bt_hci_connect_br_cancel(struct bt_conn *conn);
+
+void bt_br_acl_recv(struct bt_conn *conn, struct net_buf *buf, bool complete);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -471,7 +471,7 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags
 
 	net_buf_unref(buf);
 
-	if (conn->rx->len > acl_total_len) {
+	if ((conn->type != BT_CONN_TYPE_BR) && (conn->rx->len > acl_total_len)) {
 		LOG_ERR("ACL len mismatch (%u > %u)", conn->rx->len, acl_total_len);
 		bt_conn_reset_rx_state(conn);
 		return;
@@ -484,7 +484,11 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags
 	__ASSERT(buf->ref == 1, "buf->ref %d", buf->ref);
 
 	LOG_DBG("Successfully parsed %u byte L2CAP packet", buf->len);
-	bt_l2cap_recv(conn, buf, true);
+	if (IS_ENABLED(CONFIG_BT_CLASSIC) && (conn->type == BT_CONN_TYPE_BR)) {
+		bt_br_acl_recv(conn, buf, true);
+	} else {
+		bt_l2cap_recv(conn, buf, true);
+	}
 }
 
 void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)


### PR DESCRIPTION
In current implementation, if the HCI ACL data length exceeds on L2CAP packet, the HCI ACL data will be discarded.

Support the case if the transport is classic.

Add a function `bt_br_acl_recv()` to handle the multi L2CAP packets one by one.