### PR TITLE
Bluetooth: Classic: L2CAP: Fix the FCS incorrect issue

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -4356,9 +4356,10 @@ send_rsp:
 	}
 
 #if defined(CONFIG_BT_L2CAP_RET_FC)
-	if (BR_CHAN(chan)->tx.fcs == BT_L2CAP_BR_FCS_16BIT) {
-		/* If peer enables FCS, local also needs to enable it. */
+	if (BR_CHAN(chan)->tx.fcs != BR_CHAN(chan)->rx.fcs) {
+		/* If FCS flag is not consistent of both sides, FCS should be used as default. */
 		BR_CHAN(chan)->rx.fcs = BT_L2CAP_BR_FCS_16BIT;
+		BR_CHAN(chan)->tx.fcs = BT_L2CAP_BR_FCS_16BIT;
 	}
 
 	if (BR_CHAN(chan)->tx.extended_control) {


### PR DESCRIPTION
The FCS flag of TX direction is not set correctly if the FCS flag of RX direction is set. The issue could be found with following steps, Step 1, Local sends configuration request with ERET mode and FCS omitted.
Step 2, Peer replies the configuration response without any errors. Step 3, Peer sends configuration request with ERET mode and NO FCS. Step 4, Local replies the configuration response without any errors.

The FCS flag of TX is cleared incorrectly.

The FCS should be enabled if any one side enables the FCS.