### PR TITLE
drivers: sensors: add user_data to sensor_trigger

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -297,6 +297,10 @@ struct sensor_trigger {
 	enum sensor_trigger_type type;
 	/** Channel the trigger is set on. */
 	enum sensor_channel chan;
+	/** Pointer to user data. It can be used to associate the sequence
+	 * with any other data that is needed in the callback function
+	 */
+	void *user_data;
 };
 
 /**

--- a/tests/drivers/sensor/generic/src/dummy_sensor.c
+++ b/tests/drivers/sensor/generic/src/dummy_sensor.c
@@ -151,7 +151,7 @@ int dummy_sensor_trigger_set(const struct device *dev,
 		/* Use the same action to dummy above triggers */
 		if (handler != NULL) {
 			data->handler = handler;
-			data->handler(dev, NULL);
+			data->handler(dev, trig);
 		}
 		break;
 	default:

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -17,6 +17,8 @@
 K_SEM_DEFINE(sem, 0, 1);
 #define RETURN_SUCCESS  (0)
 
+#define USER_DATA ((void *)0x12345678)
+
 struct channel_sequence {
 	enum sensor_channel chan;
 	struct sensor_value data;
@@ -38,23 +40,23 @@ static struct channel_sequence chan_elements[] = {
 
 static struct trigger_sequence trigger_elements[] = {
 	/* trigger for SENSOR_TRIG_THRESHOLD */
-	{ {SENSOR_TRIG_THRESHOLD, SENSOR_CHAN_PROX},
+	{ {SENSOR_TRIG_THRESHOLD, SENSOR_CHAN_PROX, USER_DATA},
 	{ 127, 0 }, SENSOR_ATTR_UPPER_THRESH },
 
 	/* trigger for SENSOR_TRIG_TIMER */
-	{ {SENSOR_TRIG_TIMER, SENSOR_CHAN_PROX},
+	{ {SENSOR_TRIG_TIMER, SENSOR_CHAN_PROX, USER_DATA},
 	{ 130, 127 }, SENSOR_ATTR_UPPER_THRESH },
 
 	/* trigger for SENSOR_TRIG_DATA_READY */
-	{ {SENSOR_TRIG_DATA_READY, SENSOR_CHAN_PROX},
+	{ {SENSOR_TRIG_DATA_READY, SENSOR_CHAN_PROX, USER_DATA},
 	{ 150, 130 }, SENSOR_ATTR_UPPER_THRESH },
 
 	/* trigger for SENSOR_TRIG_DELTA */
-	{ {SENSOR_TRIG_DELTA, SENSOR_CHAN_PROX},
+	{ {SENSOR_TRIG_DELTA, SENSOR_CHAN_PROX, USER_DATA},
 	{ 180, 150 }, SENSOR_ATTR_UPPER_THRESH },
 
 	/* trigger for SENSOR_TRIG_NEAR_FAR */
-	{ {SENSOR_TRIG_NEAR_FAR, SENSOR_CHAN_PROX},
+	{ {SENSOR_TRIG_NEAR_FAR, SENSOR_CHAN_PROX, USER_DATA},
 	{ 155, 180 }, SENSOR_ATTR_UPPER_THRESH }
 };
 
@@ -144,7 +146,10 @@ static void trigger_handler(const struct device *dev,
 			    const struct sensor_trigger *trigger)
 {
 	ARG_UNUSED(dev);
-	ARG_UNUSED(trigger);
+
+	zassert_equal(USER_DATA, trigger->user_data,
+		"Invalid user data: %p, expected: %p",
+		USER_DATA, trigger->user_data);
 
 	k_sem_give(&sem);
 }


### PR DESCRIPTION
Introduce the field that can be used to associate a given trigger with any other data needed in the callback function.

This is very useful when wrapping sensors in C++ layers to be able to retreive the object containing the sensor.