### PR TITLE
tests: kernel/sleep: exclude npcx platforms from the test

### DIFF
--- a/tests/kernel/sleep/testcase.yaml
+++ b/tests/kernel/sleep/testcase.yaml
@@ -13,5 +13,9 @@ tests:
       - kernel
       - sleep
       - libc
+    platform_exclude:
+      - npcx4m8f_evb
+      - npcx7m6fb_evb
+      - npcx9m6f_evb
     extra_configs:
       - CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Pr https://github.com/zephyrproject-rtos/zephyr/pull/87878 fixed only the `kernel.common.timing`. The same fix should also be applied to `kernel.common.timing.minimallibc`.

fixes: #66185

