### PR TITLE
drivers: timer: remove fsl_power.h for MCXN series

### DIFF
--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/pm/pm.h>
 #include "fsl_ostimer.h"
-#ifndef CONFIG_SOC_MCXN236
+#ifndef CONFIG_SOC_SERIES_MCXN
 #include "fsl_power.h"
 #endif
 


### PR DESCRIPTION
Initial it was only removed for mcxn236 but mcnx947 would fail to compile then.
This PR fixes compilation for MCNX947 if the os_timer is enabled.