### PR TITLE
boards: nordic: nrf54h20dk iron board radiocore support

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_iron.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_iron.dts
@@ -42,6 +42,10 @@
 			reg = <0x6E000 DT_SIZE_K(200)>;
 		};
 
+		cpurad_slot0_partition: partition@54000 {
+			reg = <0x54000 DT_SIZE_K(256)>;
+		};
+
 		cpuppr_code_partition: partition@a4000 {
 			reg = <0xa4000 DT_SIZE_K(64)>;
 		};


### PR DESCRIPTION
Encode the radiocore's address into the application's DT as the application needs to instruct IRONside SE about where the radiocore should be booted from.