### PR TITLE
west.yml: hal_stm32 : cube package update to latest version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -243,7 +243,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: c17bcab857dbf2ec3100b2d0c3123957fcd42e78
+      revision: 237391328ba97f70240cd30b24cffeca6152f86f
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
- Main changes on H7RS cube package

   - Resynchronize zephyr hal_stm32 H7RS repository with the correct H7RS cube repository history 
   - Revert some fixes

depends on :  https://github.com/zephyrproject-rtos/zephyr/pull/88419 
