### PR TITLE
soc: adi: remove unused symbol sram_vector_table

### DIFF
--- a/soc/adi/max32/Kconfig.defconfig
+++ b/soc/adi/max32/Kconfig.defconfig
@@ -7,7 +7,4 @@ if SOC_FAMILY_MAX32
 
 rsource "Kconfig.defconfig.max*"
 
-config SRAM_VECTOR_TABLE
-	default y
-
 endif # SOC_FAMILY_MAX32


### PR DESCRIPTION
The symbol SRAM_VECTOR_TABLE is not used in the adi/max32 soc. Removed it in order to clean up the Kconfig file and avoid confusion with the upcoming new definition of SRAM_VECTOR_TABLE symbol. ([PR #87468](https://github.com/zephyrproject-rtos/zephyr/pull/87468))