### PR TITLE
soc: nordic: defer reset after programming all cores at nrf5340

### DIFF
--- a/soc/nordic/soc.yml
+++ b/soc/nordic/soc.yml
@@ -224,7 +224,6 @@ runners:
               - nrf52840
           - qualifiers:
               - nrf5340/cpunet
-          - qualifiers:
               - nrf5340/cpuapp
               - nrf5340/cpuapp/ns
           - qualifiers:


### PR DESCRIPTION
Do not perform reset in between programming app and radio core for nrf5340.