### PR TITLE
Fix the openamp_rsc_table sample by specifying the IPM capability for maximum data transfer size

### DIFF
--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -8,6 +8,14 @@ menuconfig IPM
 
 if IPM
 
+config IPM_MAX_DATA_SIZE
+	int "Max data size supported"
+	default 0 if IPM_STM32_IPCC || IPM_STM32_HSEM
+	default 1024
+	help
+	  Define the max size (in bytes) of data that can be transmitted or
+	  received by the IPM device.
+
 config IPM_MHU
 	bool "IPM MHU driver"
 	default y

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -31,6 +31,13 @@ LOG_MODULE_REGISTER(openamp_rsc_table);
 #error "Sample requires definition of shared memory for rpmsg"
 #endif
 
+#if CONFIG_IPM_MAX_DATA_SIZE > 0
+
+#define	IPM_SEND(dev, w, id, d, s) ipm_send(dev, w, id, d, s)
+#else
+#define IPM_SEND(dev, w, id, d, s) ipm_send(dev, w, id, NULL, 0)
+#endif
+
 /* Constants derived from device tree */
 #define SHM_NODE		DT_CHOSEN(zephyr_ipc_shm)
 #define SHM_START_ADDR	DT_REG_ADDR(SHM_NODE)
@@ -133,7 +140,7 @@ int mailbox_notify(void *priv, uint32_t id)
 	ARG_UNUSED(priv);
 
 	LOG_DBG("%s: msg received", __func__);
-	ipm_send(ipm_handle, 0, id, &id, 4);
+	IPM_SEND(ipm_handle, 0, id, &id, 4);
 
 	return 0;
 }


### PR DESCRIPTION
The samples/subsys/ipc/openamp_rsc_table sample requests to transfer data for mailboxes that support data transfer.
Some existing drivers return an error if size is non-null or print a warning message on each transfer.
Update these drivers to be compatible with the subsys/ipc/openamp_rsc_table sample, using LOG_WRN_ONCE to indicate only the first time that the driver does not support data transfers.

This fixes issue introduced in https://github.com/zephyrproject-rtos/zephyr/pull/85617/commits/e50a2ba5217d72a94169c2060bb5d1fb7e19bb1c