### PR TITLE
Add support for UDC for Apollo510 family

### DIFF
--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -199,6 +199,12 @@
 	};
 };
 
+zephyr_udc0: &usb {
+	vddusb33-gpios = <&gpio64_95 27 (GPIO_PULL_UP)>;
+	vddusb0p9-gpios = <&gpio64_95 26 (GPIO_PULL_UP)>;
+	status = "okay";
+};
+
 &gpio0_31 {
 	status = "okay";
 };

--- a/boards/ambiq/apollo510_evb/apollo510_evb.yaml
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.yaml
@@ -18,6 +18,7 @@ supported:
   - rtc
   - hwinfo
   - clock_control
+  - usbd
   - mspi
 testing:
   ignore_tags:

--- a/drivers/usb/udc/Kconfig.ambiq
+++ b/drivers/usb/udc/Kconfig.ambiq
@@ -56,4 +56,20 @@ config UDC_AMBIQ_PIO_MODE
 	  Select this option when cache coherency handling is to be avoided.
 endchoice
 
+config UDC_AMBIQ_DEB_ENABLE
+	hex "EP Double Buffer Enable"
+	default 0x0000
+	depends on SOC_SERIES_APOLLO5X
+	help
+	  Double Endpoint Buffer acceleration (DEB) is doubles an EP's FIFO size so
+	  that USB transfer could continue to happen while waiting for DMA/CPU to
+	  load/unload data from the EP FIFO. This hex value is a bitmap of endpoints
+	  for DEB to be enabled. BIT0-4 represents OUT_EP 1-5, while BIT16-20
+	  represents IN_EP 1-5. Take note that this feature is limited by total EP
+	  FIFO size. Proper calculation should be done before enabling DEB such that
+	  the total usage of FIFO for all endpoint doesn't exceed the FIFO available
+	  on SoC. The list of Soc with its FIFO size is listed below. The FIFO size
+	  here includes 128 bytes required by control endpoints.
+	  - Apollo510: (4096 Bytes FIFO)
+
 endif # UDC_AMBIQ

--- a/drivers/usb/udc/Kconfig.ambiq
+++ b/drivers/usb/udc/Kconfig.ambiq
@@ -8,6 +8,7 @@ config UDC_AMBIQ
 	select GPIO
 	select AMBIQ_HAL
 	select AMBIQ_HAL_USE_USB
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
 	help
 	  Enable USB Device Controller Driver.
 
@@ -25,12 +26,34 @@ config UDC_AMBIQ_THREAD_PRIORITY
 	help
 	  AMBIQ driver thread priority.
 
-
 config UDC_AMBIQ_MAX_QMESSAGES
 	int "UDC AMBIQ maximum number of ISR event messages"
 	range 4 64
 	default 8
 	help
 	  AMBIQ maximum number of ISR event messages.
+
+choice UDC_AMBIQ_DMA_MODE
+	prompt "DMA mode for non-control USB endpoints"
+	default UDC_AMBIQ_DMA0_MODE
+	depends on SOC_SERIES_APOLLO5X
+
+config UDC_AMBIQ_DMA0_MODE
+	bool "DMA0 transfer mode"
+	help
+	  Select this option when synchronous endpoint is used.
+
+config UDC_AMBIQ_DMA1_MODE
+	bool "DMA1 transfer mode"
+	help
+	  This option gives best throughput when endpoint buffer is greater than Max
+	  Packet Size. However this option cannot be chosen when synchronous
+	  endpoint is used.
+
+config UDC_AMBIQ_PIO_MODE
+	bool "PIO transfer mode"
+	help
+	  Select this option when cache coherency handling is to be avoided.
+endchoice
 
 endif # UDC_AMBIQ

--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -107,6 +107,9 @@ static int udc_ambiq_tx(const struct device *dev, uint8_t ep, struct net_buf *bu
 	if (buf == NULL) {
 		status = am_hal_usb_ep_xfer(priv->usb_handle, ep, NULL, 0);
 	} else {
+		if (!IS_ENABLED(CONFIG_UDC_AMBIQ_PIO_MODE) && (ep != USB_CONTROL_EP_IN)) {
+			sys_cache_data_flush_range(buf->data, buf->size);
+		}
 		status = am_hal_usb_ep_xfer(priv->usb_handle, ep, buf->data, buf->len);
 	}
 
@@ -123,7 +126,6 @@ static int udc_ambiq_rx(const struct device *dev, uint8_t ep, struct net_buf *bu
 {
 	struct udc_ambiq_data *priv = udc_get_private(dev);
 	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep);
-	struct udc_ep_config *cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
 	uint32_t status;
 	uint16_t rx_size = buf->size;
 
@@ -133,9 +135,20 @@ static int udc_ambiq_rx(const struct device *dev, uint8_t ep, struct net_buf *bu
 	}
 	udc_ep_set_busy(ep_cfg, true);
 
-	/* Make sure that OUT transaction size triggered doesn't exceed EP's MPS */
-	if ((ep != USB_CONTROL_EP_OUT) && (cfg->mps < rx_size)) {
-		rx_size = cfg->mps;
+	/*
+	 * Make sure that OUT transaction size triggered doesn't exceed EP's MPS,
+	 * as the USB IP has no way to detect end on transaction when last packet
+	 * is not a short packet. Except for UDC_AMBIQ_DMA1_MODE, where such
+	 * detection is available.
+	 */
+	if (!IS_ENABLED(CONFIG_UDC_AMBIQ_DMA1_MODE) && (ep != USB_CONTROL_EP_OUT) &&
+	    (ep_cfg->mps < rx_size)) {
+		rx_size = ep_cfg->mps;
+	}
+
+	/* Cache management if cache and DMA is enabled */
+	if (!IS_ENABLED(CONFIG_UDC_AMBIQ_PIO_MODE) && (ep != USB_CONTROL_EP_OUT)) {
+		sys_cache_data_invd_range(buf->data, buf->size);
 	}
 
 	status = am_hal_usb_ep_xfer(priv->usb_handle, ep, buf->data, rx_size);
@@ -212,7 +225,7 @@ static void udc_ambiq_ep0_setup_callback(const struct device *dev, uint8_t *usb_
 }
 
 static void udc_ambiq_ep_xfer_complete_callback(const struct device *dev, uint8_t ep_addr,
-						uint16_t xfer_len, am_hal_usb_xfer_code_e code,
+						uint32_t xfer_len, am_hal_usb_xfer_code_e code,
 						void *param)
 {
 	struct net_buf *buf;
@@ -473,11 +486,7 @@ static int udc_ambiq_disable(const struct device *dev)
 static void udc_ambiq_usb_isr(const struct device *dev)
 {
 	struct udc_ambiq_data *priv = udc_get_private(dev);
-	uint32_t int_status[3];
-
-	am_hal_usb_intr_status_get(priv->usb_handle, &int_status[0], &int_status[1],
-				   &int_status[2]);
-	am_hal_usb_interrupt_service(priv->usb_handle, int_status[0], int_status[1], int_status[2]);
+	am_hal_usb_handle_isr(priv->usb_handle);
 }
 
 static int usb_power_rails_set(const struct device *dev, bool on)
@@ -516,6 +525,45 @@ static int usb_power_rails_set(const struct device *dev, bool on)
 	return 0;
 }
 
+#if CONFIG_SOC_SERIES_APOLLO5X
+static int init_apollo5x(const struct udc_ambiq_data *priv)
+{
+	uint32_t am_ret = AM_HAL_STATUS_SUCCESS;
+	am_hal_clkmgr_board_info_t board;
+	am_hal_usb_phyclksrc_e phyclksrc;
+
+	/* Decide PHY clock source according to USB speed and board configuration*/
+	am_hal_clkmgr_board_info_get(&board);
+	if (priv->usb_speed == AM_HAL_USB_SPEED_FULL) {
+		phyclksrc = AM_HAL_USB_PHYCLKSRC_HFRC_24M;
+	} else if (board.sXtalHs.ui32XtalHsFreq == 48000000) {
+		phyclksrc = AM_HAL_USB_PHYCLKSRC_XTAL_HS_DIV2;
+	} else if (board.sXtalHs.ui32XtalHsFreq == 24000000) {
+		phyclksrc = AM_HAL_USB_PHYCLKSRC_XTAL_HS;
+	} else if (board.ui32ExtRefClkFreq == 48000000) {
+		phyclksrc = AM_HAL_USB_PHYCLKSRC_EXTREFCLK;
+	} else if (board.ui32ExtRefClkFreq == 24000000) {
+		phyclksrc = AM_HAL_USB_PHYCLKSRC_EXTREFCLK_DIV2;
+	} else {
+		phyclksrc = AM_HAL_USB_PHYCLKSRC_PLL;
+	}
+
+	if (phyclksrc == AM_HAL_USB_PHYCLKSRC_PLL) {
+		am_ret = am_hal_clkmgr_clock_config(AM_HAL_CLKMGR_CLK_ID_SYSPLL, 24000000, NULL);
+		if (am_ret != AM_HAL_STATUS_SUCCESS) {
+			LOG_WRN("Unable to configure SYSPLL for USB. Fallback to HFRC clock "
+				"source");
+			phyclksrc = AM_HAL_USB_PHYCLKSRC_HFRC_24M;
+		}
+	}
+
+	am_hal_usb_set_phy_clk_source(priv->usb_handle, phyclksrc);
+	am_hal_usb_phy_clock_enable(priv->usb_handle, true, priv->usb_speed);
+
+	return 0;
+}
+#endif
+
 static int udc_ambiq_init(const struct device *dev)
 {
 	struct udc_ambiq_data *priv = udc_get_private(dev);
@@ -542,10 +590,27 @@ static int udc_ambiq_init(const struct device *dev)
 	am_hal_usb_hardware_unreset();
 	/* Release USB PHY reset */
 	am_hal_usb_disable_phy_reset_override();
+
+#if CONFIG_SOC_SERIES_APOLLO5X
+	ret = init_apollo5x(priv);
+	if (ret) {
+		return ret;
+	}
+#endif
+
 	/* Set USB Speed */
 	am_hal_usb_set_dev_speed(priv->usb_handle, priv->usb_speed);
 	/* Enable USB interrupt */
 	am_hal_usb_intr_usb_enable(priv->usb_handle, USB_INTRUSB_Reset_Msk);
+	/* Configure DMA Modes */
+#if CONFIG_UDC_AMBIQ_DMA1_MODE
+	am_hal_usb_set_xfer_mode(priv->usb_handle, AM_HAL_USB_OUT_DMA_MODE_1);
+	am_hal_usb_set_xfer_mode(priv->usb_handle, AM_HAL_USB_IN_DMA_MODE_1);
+#elif CONFIG_UDC_AMBIQ_DMA0_MODE
+	am_hal_usb_set_xfer_mode(priv->usb_handle, AM_HAL_USB_OUT_DMA_MODE_0);
+	am_hal_usb_set_xfer_mode(priv->usb_handle, AM_HAL_USB_IN_DMA_MODE_0);
+#endif
+
 	/* Enable Control Endpoints */
 	if (udc_ep_enable_internal(dev, USB_CONTROL_EP_OUT, USB_EP_TYPE_CONTROL, EP0_MPS, 0)) {
 		LOG_ERR("Failed to enable control endpoint");
@@ -582,6 +647,10 @@ static int udc_ambiq_shutdown(const struct device *dev)
 	cfg->irq_disable_func(dev);
 	/* Assert USB PHY reset */
 	am_hal_usb_enable_phy_reset_override();
+#if CONFIG_SOC_SERIES_APOLLO5X
+	/* Release USB PHY Clock*/
+	am_hal_usb_phy_clock_enable(priv->usb_handle, false, priv->usb_speed);
+#endif
 	/* Disable the USB power rails */
 	ret = usb_power_rails_set(dev, false);
 	if (ret) {
@@ -911,7 +980,7 @@ static const struct udc_api udc_ambiq_api = {
 	}                                                                                          \
                                                                                                    \
 	static void udc_ambiq_ep_xfer_complete_callback_##n(                                       \
-		uint8_t ep_addr, uint16_t xfer_len, am_hal_usb_xfer_code_e code, void *param)      \
+		uint8_t ep_addr, uint32_t xfer_len, am_hal_usb_xfer_code_e code, void *param)      \
 	{                                                                                          \
 		udc_ambiq_ep_xfer_complete_callback(DEVICE_DT_INST_GET(n), ep_addr, xfer_len,      \
 						    code, param);                                  \
@@ -926,7 +995,8 @@ static const struct udc_api udc_ambiq_api = {
 		am_hal_usb_register_ep0_setup_received_callback(priv->usb_handle,                  \
 								udc_ambiq_ep0_setup_callback_##n); \
 		am_hal_usb_register_ep_xfer_complete_callback(                                     \
-			priv->usb_handle, udc_ambiq_ep_xfer_complete_callback_##n);                \
+			priv->usb_handle, (am_hal_usb_ep_xfer_complete_callback)                   \
+						  udc_ambiq_ep_xfer_complete_callback_##n);        \
 	}                                                                                          \
 	static void udc_ambiq_thread_##n(void *dev, void *arg1, void *arg2)                        \
 	{                                                                                          \

--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -564,6 +564,29 @@ static int init_apollo5x(const struct udc_ambiq_data *priv)
 }
 #endif
 
+#if CONFIG_UDC_AMBIQ_DEB_ENABLE
+static void init_double_buffers(const struct udc_ambiq_data *priv)
+{
+	uint32_t mask;
+
+	mask = CONFIG_UDC_AMBIQ_DEB_ENABLE & 0xFFFF;
+	while (mask) {
+		uint32_t ep = find_lsb_set(mask);
+
+		am_hal_usb_enable_ep_double_buffer(priv->usb_handle, ep, AM_HAL_USB_OUT_DIR, true);
+		mask &= ~(1U << (ep - 1));
+	}
+
+	mask = (CONFIG_UDC_AMBIQ_DEB_ENABLE >> 16) & 0xFFFF;
+	while (mask) {
+		uint32_t ep = find_lsb_set(mask);
+
+		am_hal_usb_enable_ep_double_buffer(priv->usb_handle, ep, AM_HAL_USB_IN_DIR, true);
+		mask &= ~(1U << (ep - 1));
+	}
+}
+#endif
+
 static int udc_ambiq_init(const struct device *dev)
 {
 	struct udc_ambiq_data *priv = udc_get_private(dev);
@@ -596,6 +619,10 @@ static int udc_ambiq_init(const struct device *dev)
 	if (ret) {
 		return ret;
 	}
+#endif
+
+#if CONFIG_UDC_AMBIQ_DEB_ENABLE
+	init_double_buffers(priv);
 #endif
 
 	/* Set USB Speed */

--- a/dts/arm/ambiq/ambiq_apollo510.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo510.dtsi
@@ -495,6 +495,15 @@
 			status = "disabled";
 		};
 
+		usb: usb@USB_BASE_NAME {
+			compatible = "ambiq,usb";
+			reg = <USB_REG_BASE USB_REG_SIZE>;
+			interrupts = <27 0>;
+			num-bidir-endpoints = <6>;
+			maximum-speed = "high-speed";
+			status = "disabled";
+		};
+
 		mspi0: mspi@MSPI0_BASE_NAME {
 			compatible = "ambiq,mspi-controller";
 			reg = <MSPI0_REG_BASE MSPI0_REG_SIZE>,

--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: f46941f3427bbc05d893a601660e6e3cffe9e29d
+      revision: 84ccbfc0b6041ba9f5688337c78bad99da5448ce
       path: modules/hal/ambiq
       groups:
         - hal


### PR DESCRIPTION
This PR adds support for UDC for Ambiq Apollo510 family. The boards tested are:
- apollo510_evb

Followings are the USB samples tested: 
- cdc_acm 
- console-next
- mass
- hid-keyboard (with `CONFIG_PM_DEVICE=n`)
- hid-mouse (with `CONFIG_PM_DEVICE=n`)
- webusb-next 
