### PR TITLE
Consolidate vendor info in board.yml files

### DIFF
--- a/boards/96boards/stm32_sensor_mez/board.yml
+++ b/boards/96boards/stm32_sensor_mez/board.yml
@@ -1,6 +1,6 @@
 board:
   name: 96b_stm32_sensor_mez
   full_name: STM32 Sensor Mezzanine
-  vendor: st
+  vendor: 96boards
   socs:
     - name: stm32f446xx

--- a/boards/acrn/acrn/board.yml
+++ b/boards/acrn/acrn/board.yml
@@ -2,15 +2,18 @@ boards:
 
   - name: acrn
     full_name: ACRN hypervisor
+    vendor: acrn
     socs:
       - name: atom
 
   - name: acrn_ehl_crb
     full_name: ACRN on EHL hypervisor
+    vendor: acrn
     socs:
       - name: atom
 
   - name: acrn_adl_crb
     full_name: ACRN Hypervisor on ADL
+    vendor: acrn
     socs:
       - name: atom

--- a/boards/ct/ctcc/board.yml
+++ b/boards/ct/ctcc/board.yml
@@ -1,6 +1,7 @@
 board:
   name: ctcc
   full_name: CTHINGS.CO Connectivity Card
+  vendor: ct
   socs:
     - name: nrf52840
     - name: nrf9161

--- a/boards/enjoydigital/litex_vexriscv/board.yml
+++ b/boards/enjoydigital/litex_vexriscv/board.yml
@@ -1,6 +1,6 @@
 board:
   name: litex_vexriscv
   full_name: LiteX VexRiscv
-  vendor: litex
+  vendor: enjoydigital
   socs:
   - name: litex_vexriscv

--- a/boards/franzininho/esp32s2_franzininho/board.yml
+++ b/boards/franzininho/esp32s2_franzininho/board.yml
@@ -1,6 +1,6 @@
 board:
   name: esp32s2_franzininho
   full_name: ESP32-S2 Franzininho
-  vendor: espressif
+  vendor: franzininho
   socs:
   - name: esp32s2

--- a/boards/intel/niosv_g/board.yml
+++ b/boards/intel/niosv_g/board.yml
@@ -1,5 +1,6 @@
 board:
   name: niosv_g
   full_name: INTEL FPGA niosv_g
+  vendor: intel
   socs:
     - name: niosv_g

--- a/boards/intel/niosv_m/board.yml
+++ b/boards/intel/niosv_m/board.yml
@@ -1,5 +1,6 @@
 board:
   name: niosv_m
   full_name: INTEL FPGA niosv_m
+  vendor: intel
   socs:
     - name: niosv_m

--- a/boards/intel/socfpga/agilex5_socdk/board.yml
+++ b/boards/intel/socfpga/agilex5_socdk/board.yml
@@ -1,5 +1,6 @@
 board:
   name: intel_socfpga_agilex5_socdk
   full_name: Agilex™ 5 SoC FPGA Development Kit
+  vendor: intel
   socs:
     - name: agilex5

--- a/boards/intel/socfpga/agilex_socdk/board.yml
+++ b/boards/intel/socfpga/agilex_socdk/board.yml
@@ -1,5 +1,6 @@
 board:
   name: intel_socfpga_agilex_socdk
   full_name: Agilex SoC Development Kit
+  vendor: intel
   socs:
     - name: agilex

--- a/boards/intel/socfpga_std/cyclonev_socdk/board.yml
+++ b/boards/intel/socfpga_std/cyclonev_socdk/board.yml
@@ -1,5 +1,6 @@
 board:
   name: cyclonev_socdk
   full_name: Cyclone® V SoC Development Kit
+  vendor: intel
   socs:
     - name: cyclonev

--- a/boards/others/serpente/board.yml
+++ b/boards/others/serpente/board.yml
@@ -1,6 +1,6 @@
 board:
   name: serpente
   full_name: Arturo182 Serpente
-  vendor: solderparty
+  vendor: others
   socs:
     - name: samd21e18a

--- a/boards/others/stm32f103_mini/board.yml
+++ b/boards/others/stm32f103_mini/board.yml
@@ -1,6 +1,6 @@
 board:
   name: stm32f103_mini
   full_name: STM32F103 Mini
-  vendor: st
+  vendor: others
   socs:
     - name: stm32f103xe

--- a/boards/qemu/x86/board.yml
+++ b/boards/qemu/x86/board.yml
@@ -2,6 +2,7 @@ boards:
 
   - name: qemu_x86
     full_name: QEMU Emulation for X86
+    vendor: intel
     socs:
       - name: atom
         variants:
@@ -13,11 +14,13 @@ boards:
 
   - name: qemu_x86_lakemont
     full_name: QEMU Emulation for X86 / Lakemont CPU
+    vendor: intel
     socs:
       - name: lakemont
 
   - name: qemu_x86_64
     full_name: QEMU Emulation for X86 64bit
+    vendor: intel
     socs:
       - name: atom
         variants:
@@ -25,5 +28,6 @@ boards:
 
   - name: qemu_x86_tiny
     full_name: QEMU Emulation for X86 Minimal Configuration
+    vendor: intel
     socs:
       - name: atom

--- a/boards/sc/scobc_module1/board.yml
+++ b/boards/sc/scobc_module1/board.yml
@@ -1,6 +1,6 @@
 board:
   name: scobc_module1
   full_name: OBC module 1
-  vendor: spacecubics
+  vendor: sc
   socs:
   - name: designstart_fpga_cortex_m3

--- a/boards/up-bridge-the-gap/up_squared/board.yml
+++ b/boards/up-bridge-the-gap/up_squared/board.yml
@@ -1,5 +1,6 @@
 board:
   name: up_squared
   full_name: UP Squared
+  vendor: up-bridge-the-gap
   socs:
     - name: apollo_lake

--- a/boards/up-bridge-the-gap/up_squared_pro_7000/board.yml
+++ b/boards/up-bridge-the-gap/up_squared_pro_7000/board.yml
@@ -1,5 +1,6 @@
 board:
   name: up_squared_pro_7000
   full_name: UP Squared Pro 7000
+  vendor: up-bridge-the-gap
   socs:
     - name: alder_lake

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -262,17 +262,7 @@ def get_catalog(generate_hw_features=False):
         logger.info("Skipping generation of supported hardware features.")
 
     for board in boards.values():
-        # We could use board.vendor but it is often incorrect. Instead, deduce vendor from
-        # containing folder. There are a few exceptions, like the "native" and "others" folders
-        # which we know are not actual vendors so treat them as such.
-        for folder in board.dir.parents:
-            if folder.name in ["native", "others"]:
-                vendor = "others"
-                break
-            elif vnd_lookup.vnd2vendor.get(folder.name):
-                vendor = folder.name
-                break
-
+        vendor = board.vendor or "others"
         socs = {soc.name for soc in board.socs}
         full_name = board.full_name or board.name
         doc_page = guess_doc_page(board)

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -780,7 +780,7 @@ ysoft	Y Soft Corporation a.s.
 zarlink	Zarlink Semiconductor
 zealz	Zealz
 zeitec	ZEITEC Semiconductor Co., LTD.
-zephyr	Zephyr-specific binding
+zephyr	The Zephyr Project
 zidoo	Shenzhen Zidoo Technology Co., Ltd.
 zii	Zodiac Inflight Innovations
 zinitix	Zinitix Co., Ltd

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -554,7 +554,7 @@ ZTEST(devicetree_api, test_bus)
 #define DT_DRV_COMPAT vnd_vendor
 
 #define VND_VENDOR "A stand-in for a real vendor which can be used in examples and tests"
-#define ZEP_VENDOR "Zephyr-specific binding"
+#define ZEP_VENDOR "The Zephyr Project"
 
 ZTEST(devicetree_api, test_vendor)
 {


### PR DESCRIPTION
Fixed vendor entries in board.yml files (added missing ones and fixed incorrect ones).

Consequently, removed the temporary logic in the gen_board_catalog script that was using board's folder names as a substitute for the lack of reliable info in board.yml files.