### PR TITLE
drivers: intc: irqstr: Fix uninitialized variable error

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_irqsteer.c
+++ b/drivers/interrupt_controller/intc_nxp_irqsteer.c
@@ -549,7 +549,7 @@ int z_soc_irq_is_enabled(unsigned int irq)
 	uint32_t parent_irq;
 	int i;
 	const struct irqsteer_config *cfg;
-	bool enabled;
+	bool enabled = false;
 
 	if (irq_get_level(irq) == 1) {
 		K_SPINLOCK(&irqstr_lock) {
@@ -559,7 +559,6 @@ int z_soc_irq_is_enabled(unsigned int irq)
 	}
 
 	parent_irq = irq_parent_level_2(irq);
-	enabled = false;
 
 	/* find dispatcher responsible for this interrupt */
 	for (i = 0; i < ARRAY_SIZE(dispatchers); i++) {


### PR DESCRIPTION
Move initialization of 'enabled' variable together with declaration. This fixes the following compiler error:
error: 'enabled' may be used uninitialized [-Werror=maybe-uninitialized]

This is not really an error but the compiler is tricked by the K_SPINLOCK() macro.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/88996