### PR TITLE
drivers: Wrap device driver APIs using DEVICE_API macro

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_mp13.c
+++ b/drivers/clock_control/clock_stm32_ll_mp13.c
@@ -80,7 +80,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 	return 0;
 }
 
-static const struct clock_control_driver_api stm32_clock_control_api = {
+static DEVICE_API(clock_control, stm32_clock_control_api) = {
 	.on = stm32_clock_control_on,
 	.off = stm32_clock_control_off,
 	.get_rate = stm32_clock_control_get_subsys_rate,

--- a/drivers/dma/dma_ti_cc23x0.c
+++ b/drivers/dma/dma_ti_cc23x0.c
@@ -368,7 +368,7 @@ static int dma_cc23x0_init(const struct device *dev)
 
 static struct dma_cc23x0_data cc23x0_data;
 
-static const struct dma_driver_api dma_cc23x0_api = {
+static DEVICE_API(dma, dma_cc23x0_api) = {
 	.config = dma_cc23x0_config,
 	.start = dma_cc23x0_start,
 	.stop = dma_cc23x0_stop,

--- a/drivers/mdio/mdio_xilinx_axienet.c
+++ b/drivers/mdio/mdio_xilinx_axienet.c
@@ -304,11 +304,12 @@ static int xilinx_axienet_mdio_probe(const struct device *dev)
 	return 0;
 }
 
-static const struct mdio_driver_api mdio_xilinx_axienet_api = {
+static DEVICE_API(mdio, mdio_xilinx_axienet_api) = {
 	.bus_disable = mdio_xilinx_axienet_bus_disable,
 	.bus_enable = mdio_xilinx_axienet_bus_enable,
 	.read = mdio_xilinx_axienet_read,
-	.write = mdio_xilinx_axienet_write};
+	.write = mdio_xilinx_axienet_write,
+};
 
 #define SETUP_IRQS(inst)                                                                           \
 	IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), xilinx_axienet_mdio_isr,      \

--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -329,7 +329,7 @@ static int mipi_dbi_dcnano_lcdif_reset(const struct device *dev, k_timeout_t del
 	return 0;
 }
 
-static struct mipi_dbi_driver_api mcux_dcnano_lcdif_dbi_api = {
+static DEVICE_API(mipi_dbi, mcux_dcnano_lcdif_dbi_api) = {
 	.reset = mipi_dbi_dcnano_lcdif_reset,
 	.command_write = mipi_dbi_dcnano_lcdif_command_write,
 	.write_display = mipi_dbi_dcnano_lcdif_write_display,

--- a/drivers/reset/reset_numaker.c
+++ b/drivers/reset/reset_numaker.c
@@ -64,7 +64,7 @@ static int reset_numaker_line_toggle(const struct device *dev, uint32_t id)
 	return 0;
 }
 
-static const struct reset_driver_api reset_numaker_driver_api = {
+static DEVICE_API(reset, reset_numaker_driver_api) = {
 	.status = reset_numaker_status,
 	.line_assert = reset_numaker_line_assert,
 	.line_deassert = reset_numaker_line_deassert,

--- a/drivers/sdhc/sdhc_ambiq.c
+++ b/drivers/sdhc/sdhc_ambiq.c
@@ -757,7 +757,7 @@ static int ambiq_sdio_card_interrupt_disable(const struct device *dev, int sourc
 	return 0;
 }
 
-static const struct sdhc_driver_api ambiq_sdio_api = {
+static DEVICE_API(sdhc, ambiq_sdio_api) = {
 	.reset = ambiq_sdio_reset,
 	.request = ambiq_sdio_request,
 	.set_io = ambiq_sdio_set_io,

--- a/drivers/spi/spi_cc23x0.c
+++ b/drivers/spi/spi_cc23x0.c
@@ -285,7 +285,7 @@ static int spi_cc23x0_release(const struct device *dev,
 	return 0;
 }
 
-static const struct spi_driver_api spi_cc23x0_driver_api = {
+static DEVICE_API(spi, spi_cc23x0_driver_api) = {
 	.transceive = spi_cc23x0_transceive,
 	.release = spi_cc23x0_release,
 };


### PR DESCRIPTION
Put the device APIs in their respective linker sections with the DEVICE_API wrapper macro.