### PR TITLE
net: openthread: radio: fix otPlatRadioClearSrcMatch* return values

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -1172,7 +1172,7 @@ otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance,
 
 	if (radio_api->configure(radio_dev, IEEE802154_CONFIG_ACK_FPB,
 				 &config) != 0) {
-		return OT_ERROR_NO_BUFS;
+		return OT_ERROR_NO_ADDRESS;
 	}
 
 	return OT_ERROR_NONE;
@@ -1191,7 +1191,7 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance,
 
 	if (radio_api->configure(radio_dev, IEEE802154_CONFIG_ACK_FPB,
 				 &config) != 0) {
-		return OT_ERROR_NO_BUFS;
+		return OT_ERROR_NO_ADDRESS;
 	}
 
 	return OT_ERROR_NONE;


### PR DESCRIPTION
Fix the return values of `otPlatRadioClearSrcMatchShortEntry` and `otPlatRadioClearSrcMatchExtEntry` to match the [OpenThread API](https://github.com/openthread/openthread/blob/3e7528e4e9cc992166dba8db471d063443d60710/include/openthread/platform/radio.h#L1078-L1098).