### PR TITLE
Bluetooth: Classic: SSP: Fix bonding flag mismatch issue

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -652,6 +652,25 @@ void bt_hci_io_capa_resp(struct net_buf *buf)
 		return;
 	}
 
+	if (atomic_test_bit(conn->flags, BT_CONN_BR_PAIRING_INITIATOR) &&
+	    (evt->authentication > BT_HCI_NO_BONDING_MITM) &&
+	    !atomic_test_bit(conn->flags, BT_CONN_BR_BONDABLE)) {
+		/*
+		 * BLUETOOTH CORE SPECIFICATION Version 6.0 | Vol 3, Part C, section 9.4.2.
+		 * A device in the non-bondable mode does not allow a bond to be created with a
+		 * peer device.
+		 *
+		 * If the local is SSP initiator and non-bondable mode, and the bonding is required
+		 * by peer device, reports the pairing failure and disconnects the ACL connection
+		 * with error `BT_HCI_ERR_AUTH_FAIL`.
+		 */
+		LOG_WRN("Bonding flag mismatch (initiator:false != responder:true)");
+		ssp_pairing_complete(conn, bt_security_err_get(BT_HCI_ERR_AUTH_FAIL));
+		bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+		bt_conn_unref(conn);
+		return;
+	}
+
 	conn->br.remote_io_capa = evt->capability;
 	conn->br.remote_auth = evt->authentication;
 	atomic_set_bit(conn->flags, BT_CONN_BR_PAIRING);


### PR DESCRIPTION
A bonding issue is found with following conditions, 
a. Local is a SSP initiator and it is in non-bondable mode, 
b. Peer is in bondable mode,
c. The bonding flag in Authentication_Requirements of local IOCAP is `No Bonding`,
d. the bonding flag in Authentication_Requirements of peer IOCAP is `Bonding`.

The bonding information will be exchanged and stored. It is incorrect behavior.

Fix the issue by reporting a pairing failure and disconnecting the ACL connection with error BT_HCI_ERR_AUTH_FAIL.