### PR TITLE
drivers: uart: esp32: revert level to PRE_KERNEL_1

### DIFF
--- a/drivers/dma/dma_esp32_gdma.c
+++ b/drivers/dma/dma_esp32_gdma.c
@@ -703,6 +703,6 @@ static void *irq_handlers[] = {
 	};                                                                                         \
 												   \
 	DEVICE_DT_INST_DEFINE(idx, &dma_esp32_init, NULL, &dma_data_##idx, &dma_config_##idx,      \
-			      PRE_KERNEL_2, CONFIG_DMA_INIT_PRIORITY, &dma_esp32_api);
+			      PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY, &dma_esp32_api);
 
 DT_INST_FOREACH_STATUS_OKAY(DMA_ESP32_INIT)

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -1057,7 +1057,7 @@ static DEVICE_API(uart, uart_esp32_api) = {
 		ESP_UART_UHCI_INIT(idx)};                                                          \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(idx, uart_esp32_init, NULL, &uart_esp32_data_##idx,                  \
-			      &uart_esp32_cfg_port_##idx, PRE_KERNEL_2,                            \
+			      &uart_esp32_cfg_port_##idx, PRE_KERNEL_1,                            \
 			      CONFIG_SERIAL_INIT_PRIORITY, &uart_esp32_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ESP32_UART_INIT);


### PR DESCRIPTION
printf is failing in hello_world sample due to current uart driver init level. This reverts back to PRE_KERNEL_1.
As uart depends on GDMA, set it also to same level.

Fixes #88803