### PR TITLE
Bluetooth: CAP: Broadcast: Add check for memory allocation for create

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -542,7 +542,12 @@ struct bt_cap_initiator_broadcast_create_param {
  * @param[in]  param             Parameters to start the audio streams.
  * @param[out] broadcast_source  Pointer to the broadcast source created.
  *
- * @return 0 on success or negative error value on failure.
+ * @retval 0 Success
+ * @retval -EINVAL @p param is invalid or @p broadcast_source is NULL
+ * @retval -ENOMEM Could not allocate more broadcast sources, subgroups or ISO streams, or the
+ *         provided codec configuration data is too large when merging the BIS and subgroup
+ *         configuration data.
+ * @retval -ENOEXEC The broadcast source failed to be created for other reasons
  */
 int bt_cap_initiator_broadcast_audio_create(
 	const struct bt_cap_initiator_broadcast_create_param *param,


### PR DESCRIPTION
When creating a broadcast source with
bt_cap_initiator_broadcast_audio_create there was no check if all broadcast sources were already allocated, which could cause a NULL pointer dereference.

Add a check, a test and documentation about possibly error codes of the function.