### PR TITLE
scripts: runners: Introduce bflb_mcu_tool runner 

### DIFF
--- a/boards/aithinker/ai_wb2_12f/board.cmake
+++ b/boards/aithinker/ai_wb2_12f/board.cmake
@@ -18,3 +18,8 @@ board_runner_args(openocd --gdb-init "mem 0x22020000 0x2203C000 rw")
 board_runner_args(openocd --gdb-init "mem 0x42020000 0x4203C000 rw")
 board_runner_args(openocd --gdb-init "mem 0x23000000 0x23400000 ro")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
+board_runner_args(bflb_mcu_tool --chipname bl602)
+include(${ZEPHYR_BASE}/boards/common/bflb_mcu_tool.board.cmake)
+
+board_set_flasher(bflb_mcu_tool)

--- a/boards/bflb/bl60x/bl604e_iot_dvk/board.cmake
+++ b/boards/bflb/bl60x/bl604e_iot_dvk/board.cmake
@@ -18,3 +18,9 @@ board_runner_args(openocd --gdb-init "mem 0x22020000 0x2203C000 rw")
 board_runner_args(openocd --gdb-init "mem 0x42020000 0x4203C000 rw")
 board_runner_args(openocd --gdb-init "mem 0x23000000 0x23400000 ro")
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+
+board_runner_args(bflb_mcu_tool --chipname bl602)
+board_runner_args(bflb_mcu_tool --dev-id /dev/ttyACM0)
+include(${ZEPHYR_BASE}/boards/common/bflb_mcu_tool.board.cmake)
+
+board_set_flasher(bflb_mcu_tool)

--- a/boards/common/bflb_mcu_tool.board.cmake
+++ b/boards/common/bflb_mcu_tool.board.cmake
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_set_flasher_ifnset(bflb_mcu_tool)
+board_finalize_runner_args(bflb_mcu_tool)

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -26,6 +26,7 @@ def _import_runner_module(runner_name):
 
 _names = [
     # zephyr-keep-sorted-start
+    'bflb_mcu_tool',
     'blackmagicprobe',
     'bossac',
     'canopen_program',

--- a/scripts/west_commands/runners/bflb_mcu_tool.py
+++ b/scripts/west_commands/runners/bflb_mcu_tool.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2024-2025 MASSDRIVER EI (massdriver.space)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for the Official Bouffalo Lab open source command-line flash tool (bflb-mcu-tool)'''
+
+from runners.core import MissingProgram, RunnerCaps, ZephyrBinaryRunner
+
+DEFAULT_PORT = '/dev/ttyUSB0'
+DEFAULT_SPEED = '115200'
+DEFAULT_CHIP = 'bl602'
+DEFAULT_EXECUTABLE = "bflb-mcu-tool-uart"
+
+
+class BlFlashCommandBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for bflb-mcu-tool.'''
+
+    def __init__(
+        self, cfg, port=DEFAULT_PORT, baudrate=DEFAULT_SPEED, chipname=DEFAULT_CHIP, erase=False
+    ):
+        super().__init__(cfg)
+        self.port = port
+        self.baudrate = baudrate
+        self.chipname = chipname
+        self.erase = bool(erase)
+
+    @classmethod
+    def name(cls):
+        return 'bflb_mcu_tool'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'}, erase=True, dev_id=True)
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.set_defaults(dev_id=DEFAULT_PORT)
+        parser.add_argument(
+            '-b',
+            '--baudrate',
+            default=DEFAULT_SPEED,
+            help=f"serial port speed to use, default is {str(DEFAULT_SPEED)}",
+        )
+        parser.add_argument(
+            '-ch',
+            '--chipname',
+            default=DEFAULT_CHIP,
+            help=f"chip model, default is {str(DEFAULT_CHIP)}",
+            choices=['bl602', 'bl606p', 'bl616', 'bl702', 'bl702l', 'bl808'],
+        )
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return BlFlashCommandBinaryRunner(
+            cfg, port=args.dev_id, baudrate=args.baudrate, chipname=args.chipname, erase=args.erase
+        )
+
+    def do_run(self, command, **kwargs):
+        try:
+            self.require(DEFAULT_EXECUTABLE)
+        except MissingProgram as err:
+            self.logger.error(
+                "You may use `pip install bflb-mcu-tool-uart` to install bflb-mcu-tool-uart"
+            )
+            raise err
+        self.ensure_output('bin')
+        cmd_flash = [
+            DEFAULT_EXECUTABLE,
+            '--port',
+            self.port,
+            '--baudrate',
+            self.baudrate,
+            '--chipname',
+            self.chipname,
+            '--firmware',
+            self.cfg.bin_file,
+        ]
+        if self.erase is True:
+            cmd_flash.append("--erase")
+        self.check_call(cmd_flash)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -17,6 +17,7 @@ def test_runner_imports():
     expected = set((
         # zephyr-keep-sorted-start
         'arc-nsim',
+        'bflb_mcu_tool',
         'blackmagicprobe',
         'bossac',
         'canopen',


### PR DESCRIPTION
Introduces one of the official flash tools for bouffalolab platforms


Caveat: It does not like a python version above 3.11