### PR TITLE
pm: Fix case when forced state is not set

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -147,7 +147,7 @@ bool pm_system_suspend(int32_t kernel_ticks)
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, kernel_ticks);
 
-	if (!pm_policy_state_any_active()) {
+	if (!pm_policy_state_any_active() && (z_cpus_pm_forced_state[id] == NULL)) {
 		/* Return early if all states are unavailable. */
 		return false;
 	}


### PR DESCRIPTION
pm_suspend is returning early if there are no states available (due to locking or latency policy). However, if state is forced it should not return but rather enter forced power state.

See https://github.com/zephyrproject-rtos/zephyr/pull/88149#discussion_r2058371826.