### PR TITLE
Bluetooth: Classic: SSP: Correct pairing method

### DIFF
--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -248,9 +248,19 @@ static void ssp_pairing_complete(struct bt_conn *conn, uint8_t status)
 	}
 }
 
+#define BR_SSP_AUTH_MITM_DISABLED(auth) (((auth) & BT_MITM) == 0)
+
 static void ssp_auth(struct bt_conn *conn, uint32_t passkey)
 {
 	conn->br.pairing_method = ssp_pair_method(conn);
+
+	if (BR_SSP_AUTH_MITM_DISABLED(conn->br.local_auth) &&
+	    BR_SSP_AUTH_MITM_DISABLED(conn->br.remote_auth)) {
+		/*
+		 * If the MITM flag of both sides is false, the pairing method is `just works`.
+		 */
+		conn->br.pairing_method = JUST_WORKS;
+	}
 
 	/*
 	 * If local required security is HIGH then MITM is mandatory.
@@ -737,6 +747,8 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 		/* If bondable is false, clear bonding flag. */
 		auth = BT_HCI_SET_NO_BONDING(auth);
 	}
+
+	conn->br.local_auth = auth;
 
 	resp_buf = bt_hci_cmd_create(BT_HCI_OP_IO_CAPABILITY_REPLY, sizeof(*cp));
 	if (!resp_buf) {

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -150,6 +150,7 @@ struct bt_conn_br {
 	bt_addr_t		dst;
 	uint8_t			remote_io_capa;
 	uint8_t			remote_auth;
+	uint8_t			local_auth;
 	uint8_t			pairing_method;
 	/* remote LMP features pages per 8 bytes each */
 	uint8_t			features[LMP_MAX_PAGES][8];


### PR DESCRIPTION
In current implementation, if the MITM flag of both sides is disabled, the pairing method is incorrect.

Such as, the IOCAP of both sides is `display_yesorno`, the pairing method is `PASSKEY_CONFIRM`. But actually, it should be `JUST_WORKS` in this case.

Fix the issue by setting the pairing method to `JUST_WORKS` if the MITM flag of both sides is false.