### PR TITLE
mgmt: hawkbit: add event for confirmed current image during init

### DIFF
--- a/include/zephyr/mgmt/hawkbit/event.h
+++ b/include/zephyr/mgmt/hawkbit/event.h
@@ -57,6 +57,11 @@ enum hawkbit_event_type {
 	HAWKBIT_EVENT_END_RUN,
 	/** Event triggered before hawkBit does a reboot */
 	HAWKBIT_EVENT_BEFORE_REBOOT,
+	/**
+	 * Event triggered during initialisation when the current image is confirmed and the old
+	 * image is erased
+	 */
+	HAWKBIT_EVENT_CONFIRMED_CURRENT_IMAGE,
 };
 
 struct hawkbit_event_callback;

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -864,6 +864,8 @@ int hawkbit_init(void)
 			LOG_ERR("Failed to erase second slot: %d", ret);
 			return ret;
 		}
+
+		hawkbit_event_raise(HAWKBIT_EVENT_CONFIRMED_CURRENT_IMAGE);
 	}
 	hawkbit_initialized = true;
 


### PR DESCRIPTION
add event for confirmed current image during initialization.

For example in ram load mode, it could make sense, to copy the current image to the inactive slot for redundancy 