### PR TITLE
tests: console: use printf instead

### DIFF
--- a/tests/drivers/console/hello_world/src/main.c
+++ b/tests/drivers/console/hello_world/src/main.c
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/printk.h>
+#include <stdio.h>
 
 int main(void)
 {
-	printk("Hello World from Console\n");
+	printf("Hello World from Console\n");
 	return 0;
 }


### PR DESCRIPTION
This change aligns the test case with the hello_world sample.