### PR TITLE
soc: xlnx: zynqmp: Add sys_arch_reboot implementation

### DIFF
--- a/soc/xlnx/zynqmp/soc.c
+++ b/soc/xlnx/zynqmp/soc.c
@@ -10,6 +10,14 @@
 #include <zephyr/cache.h>
 
 #include <cmsis_core.h>
+#include "soc.h"
+
+void sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+
+	sys_write32(CRL_APB_RESET_CTRL_SRST_MASK, CRL_APB_RESET_CTRL);
+}
 
 void soc_reset_hook(void)
 {

--- a/soc/xlnx/zynqmp/soc.h
+++ b/soc/xlnx/zynqmp/soc.h
@@ -11,4 +11,7 @@
 /* Define CMSIS configurations */
 #define __CR_REV		1U
 
+#define CRL_APB_RESET_CTRL           0xFF5E0218
+#define CRL_APB_RESET_CTRL_SRST_MASK BIT(4)
+
 #endif /* _BOARD__H_ */


### PR DESCRIPTION
This platform was previously using a default sys_arch_reboot implementation which did nothing. Add an implementation which uses the CRL_APB_RESET_CTRL register to initiate a soft reset (SRST) of the device.