### PR TITLE
dts: arm: npcx: add device node for ram lock

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -515,6 +515,13 @@
 			#size-cells = <0>;
 			instance-id = <0x20>;
 		};
+
+		ramlock0: ramlock@4000c02e {
+			compatible = "syscon";
+			reg = <0x4000c02e 0x153>;
+			reg-io-width = <1>;
+			status = "disabled";
+		};
 	};
 
 	soc-if {

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -409,6 +409,13 @@
 			#reset-cells = <1>;
 			status = "disabled";
 		};
+
+		ramlock0: ramlock@4000c02e {
+			compatible = "syscon";
+			reg = <0x4000c02e 0x52>;
+			reg-io-width = <1>;
+			status = "disabled";
+		};
 	};
 
 	soc-id {


### PR DESCRIPTION
This commit adds a RAM lock node for both NPCX9 and NPCX4. Then, the user can use this node to configure the RAM lock settings.