### PR TITLE
tests: posix: move tv_to_ts to posix_clock.h

### DIFF
--- a/lib/posix/options/posix_clock.h
+++ b/lib/posix/options/posix_clock.h
@@ -15,6 +15,7 @@
 
 #include <zephyr/sys_clock.h>
 #include <zephyr/sys/__assert.h>
+#include <zephyr/posix/sys/time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,6 +37,12 @@ static inline int64_t ts_to_ns(const struct timespec *ts)
 static inline int64_t ts_to_ms(const struct timespec *ts)
 {
 	return ts->tv_sec * MSEC_PER_SEC + ts->tv_nsec / NSEC_PER_MSEC;
+}
+
+static inline void tv_to_ts(const struct timeval *tv, struct timespec *ts)
+{
+	ts->tv_sec = tv->tv_sec;
+	ts->tv_nsec = tv->tv_usec * NSEC_PER_USEC;
 }
 
 static inline bool tp_ge(const struct timespec *a, const struct timespec *b)

--- a/tests/posix/common/CMakeLists.txt
+++ b/tests/posix/common/CMakeLists.txt
@@ -10,3 +10,4 @@ zephyr_include_directories(${ZEPHYR_BASE}/lib/posix)
 target_sources(app PRIVATE ${app_sources})
 
 target_compile_options(app PRIVATE -U_POSIX_C_SOURCE -D_POSIX_C_SOURCE=200809L)
+target_include_directories(app PRIVATE ${ZEPHYR_BASE}/lib/posix/options)

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -4,33 +4,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include "posix_clock.h"
+
+#include <limits.h>
 #include <sys/time.h>
-#include <time.h>
 #include <unistd.h>
 
 #include <zephyr/ztest.h>
 #include <zephyr/logging/log.h>
-
-static inline int64_t ts_to_ns(const struct timespec *ts)
-{
-	return ts->tv_sec * NSEC_PER_SEC + ts->tv_nsec;
-}
-
-static inline void tv_to_ts(const struct timeval *tv, struct timespec *ts)
-{
-	ts->tv_sec = tv->tv_sec;
-	ts->tv_nsec = tv->tv_usec * NSEC_PER_USEC;
-}
-
-#define _tp_op(_a, _b, _op) (ts_to_ns(_a) _op ts_to_ns(_b))
-
-#define _decl_op(_type, _name, _op)                                                                \
-	static inline _type _name(const struct timespec *_a, const struct timespec *_b)            \
-	{                                                                                          \
-		return _tp_op(_a, _b, _op);                                                        \
-	}
-
-_decl_op(bool, tp_ge, >=); /* a >= b */
 
 ZTEST(clock, test_gettimeofday)
 {


### PR DESCRIPTION
Move the private static inline function tv_to_ts() to posix_clock.h.

This de-duplicates some definitions.