### PR TITLE
drivers: udc: renesas: enable high-speed USB support

### DIFF
--- a/drivers/usb/udc/Kconfig.renesas_ra
+++ b/drivers/usb/udc/Kconfig.renesas_ra
@@ -6,6 +6,7 @@ config UDC_RENESAS_RA
 	default y
 	depends on DT_HAS_RENESAS_RA_UDC_ENABLED
 	select USE_RA_FSP_USB_DEVICE
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
 	select PINCTRL
 	help
 	  Enable Renesas RA family UDC driver.

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -748,9 +748,11 @@ static const struct udc_api udc_renesas_ra_api = {
 	(DT_NODE_HAS_COMPAT(id, renesas_ra_usbhs) ? UDC_BUS_SPEED_HS : UDC_BUS_SPEED_FS)
 
 #define USB_RENESAS_RA_SPEED_IDX(id)                                                               \
-	(DT_NODE_HAS_COMPAT(id, renesas_ra_usbhs)                                                  \
-		 ? DT_ENUM_IDX_OR(id, maximum_speed, UDC_BUS_SPEED_HS)                             \
-		 : DT_ENUM_IDX_OR(id, maximum_speed, UDC_BUS_SPEED_FS))
+	COND_CODE_1(CONFIG_UDC_DRIVER_HIGH_SPEED_SUPPORT_ENABLED,                                  \
+		    (DT_NODE_HAS_COMPAT(id, renesas_ra_usbhs)                                      \
+			? DT_ENUM_IDX_OR(id, maximum_speed, UDC_BUS_SPEED_HS)                      \
+			: DT_ENUM_IDX_OR(id, maximum_speed, UDC_BUS_SPEED_FS)),                    \
+		    (UDC_BUS_SPEED_FS))
 
 #define USB_RENESAS_RA_IRQ_CONNECT(idx, n)                                                         \
 	IRQ_CONNECT(DT_IRQ_BY_IDX(DT_INST_PARENT(n), idx, irq),                                    \


### PR DESCRIPTION
Due to https://github.com/zephyrproject-rtos/zephyr/pull/76255 was merged few weeks ago, this PR to fix Renesas RA USB device issue when using with the high-speed port:
- Select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT for Renesas RA UDC