### PR TITLE
tests: counter: fix test_valid_function_without_alarm for count-down timer

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -731,16 +731,16 @@ static void test_valid_function_without_alarm(const struct device *dev)
 	ticks_tol = ticks_expected / 10;
 	ticks_tol = ticks_tol < 2 ? 2 : ticks_tol;
 
-	if (!counter_is_counting_up(dev)) {
-		ticks_expected = counter_get_top_value(dev) - ticks_expected;
-	}
-
 	err = counter_start(dev);
 	zassert_equal(0, err, "%s: counter failed to start", dev->name);
 
 	/* counter might not start from 0, use current value as offset */
 	counter_get_value(dev, &tick_current);
-	ticks_expected += tick_current;
+	if (counter_is_counting_up(dev)) {
+		ticks_expected += tick_current;
+	} else {
+		ticks_expected = tick_current - ticks_expected;
+	}
 
 	k_busy_wait(wait_for_us);
 


### PR DESCRIPTION
The `ticks_expected` was not calculated correctly for count-down timer, let's fix this.

Tested on https://docs.zephyrproject.org/latest/boards/nxp/s32z2xxdc2/doc/index.html board
```
SUITE PASS - 100.00% [counter_basic]: pass = 9, fail = 0, skip = 1, total = 10 duration = 14.864 seconds
 - PASS - [counter_basic.test_all_channels] duration = 1.151 seconds
 - PASS - [counter_basic.test_cancelled_alarm_does_not_expire] duration = 4.519 seconds
 - PASS - [counter_basic.test_late_alarm] duration = 1.031 seconds
 - PASS - [counter_basic.test_late_alarm_error] duration = 1.031 seconds
 - PASS - [counter_basic.test_multiple_alarms] duration = 1.031 seconds
 - PASS - [counter_basic.test_set_top_value_with_alarm] duration = 1.684 seconds
 - PASS - [counter_basic.test_short_relative_alarm] duration = 1.035 seconds
 - PASS - [counter_basic.test_single_shot_alarm_notop] duration = 1.311 seconds
 - SKIP - [counter_basic.test_single_shot_alarm_top] duration = 1.031 seconds
 - PASS - [counter_basic.test_valid_function_without_alarm] duration = 1.040 seconds

SUITE PASS - 100.00% [counter_no_callback]: pass = 1, fail = 0, skip = 0, total = 1 duration = 1.061 seconds
 - PASS - [counter_no_callback.test_set_top_value_without_alarm] duration = 1.061 seconds
```


Fix: https://github.com/zephyrproject-rtos/zephyr/issues/89065