### PR TITLE
net: tcp: Remove the 'goto next_state' in tcp_in()

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2921,7 +2921,6 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 		}
 	}
 
-next_state:
 	len = pkt ? tcp_data_len(pkt) : 0;
 
 	switch (conn->state) {
@@ -3584,8 +3583,6 @@ out:
 
 			k_sem_give(&conn->connect_sem);
 		}
-
-		goto next_state;
 	}
 
 	if (conn->context) {


### PR DESCRIPTION
Each incoming TCP packet has been completely handled in current state. No need to do further process by 'goto next_state'. And, that might even cause exceptions due to the NULL 'th'.