### PR TITLE
Bluetooth: RFCOMM: Add RPN command sending support

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -155,6 +155,72 @@ struct bt_rfcomm_server {
 	struct bt_rfcomm_server	*_next;
 };
 
+/** @brief RFCOMM RPN baud rate values */
+enum {
+	BT_RFCOMM_RPN_BAUD_RATE_2400 = 0x0,
+	BT_RFCOMM_RPN_BAUD_RATE_4800 = 0x1,
+	BT_RFCOMM_RPN_BAUD_RATE_7200 = 0x2,
+	BT_RFCOMM_RPN_BAUD_RATE_9600 = 0x3,
+	BT_RFCOMM_RPN_BAUD_RATE_19200 = 0x4,
+	BT_RFCOMM_RPN_BAUD_RATE_38400 = 0x5,
+	BT_RFCOMM_RPN_BAUD_RATE_57600 = 0x6,
+	BT_RFCOMM_RPN_BAUD_RATE_115200 = 0x7,
+	BT_RFCOMM_RPN_BAUD_RATE_230400 = 0x8
+};
+
+/** @brief RFCOMM RPN data bit values */
+enum {
+	BT_RFCOMM_RPN_DATA_BITS_5 = 0x0,
+	BT_RFCOMM_RPN_DATA_BITS_6 = 0x1,
+	BT_RFCOMM_RPN_DATA_BITS_7 = 0x2,
+	BT_RFCOMM_RPN_DATA_BITS_8 = 0x3
+};
+
+/** @brief RFCOMM RPN stop bit values */
+enum {
+	BT_RFCOMM_RPN_STOP_BITS_1 = 0,
+	BT_RFCOMM_RPN_STOP_BITS_1_5 = 1
+};
+
+/** @brief RFCOMM RPN parity bit values */
+enum {
+	BT_RFCOMM_RPN_PARITY_NONE = 0x0,
+	BT_RFCOMM_RPN_PARITY_ODD = 0x1,
+	BT_RFCOMM_RPN_PARITY_EVEN = 0x3,
+	BT_RFCOMM_RPN_PARITY_MARK = 0x5,
+	BT_RFCOMM_RPN_PARITY_SPACE = 0x7
+};
+
+/** @brief Combine data bits, stop bits and parity into a single line settings byte
+ *
+ *  @param data Data bits value (0-3)
+ *  @param stop Stop bits value (0-1)
+ *  @param parity Parity value (0-7)
+ *
+ *  @return Combined line settings byte
+ */
+#define BT_RFCOMM_SET_LINE_SETTINGS(data, stop, parity) ((data & 0x3) | \
+							 ((stop & 0x1) << 2) | \
+							 ((parity & 0x7) << 3))
+
+#define BT_RFCOMM_RPN_FLOW_NONE         0x00
+#define BT_RFCOMM_RPN_XON_CHAR          0x11
+#define BT_RFCOMM_RPN_XOFF_CHAR         0x13
+
+/* Set 1 to all the param mask except reserved */
+#define BT_RFCOMM_RPN_PARAM_MASK_ALL    0x3f7f
+
+/** @brief RFCOMM Remote Port Negotiation (RPN) structure */
+struct bt_rfcomm_rpn {
+	uint8_t  dlci;
+	uint8_t  baud_rate;
+	uint8_t  line_settings;
+	uint8_t  flow_control;
+	uint8_t  xon_char;
+	uint8_t  xoff_char;
+	uint16_t param_mask;
+} __packed;
+
 /** @brief Register RFCOMM server
  *
  *  Register RFCOMM server for a channel, each new connection is authorized
@@ -213,6 +279,16 @@ int bt_rfcomm_dlc_disconnect(struct bt_rfcomm_dlc *dlc);
  *  @return New buffer.
  */
 struct net_buf *bt_rfcomm_create_pdu(struct net_buf_pool *pool);
+
+/**
+ * @brief Send Remote Port Negotiation command
+ *
+ * @param dlc Pointer to the RFCOMM DLC
+ * @param rpn Pointer to the RPN parameters to send
+ *
+ * @return 0 on success, negative error code on failure
+ */
+int bt_rfcomm_send_rpn_cmd(struct bt_rfcomm_dlc *dlc, struct bt_rfcomm_rpn *rpn);
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -730,6 +730,38 @@ static int rfcomm_send_rpn(struct bt_rfcomm_session *session, uint8_t cr,
 	return rfcomm_send(session, buf);
 }
 
+int bt_rfcomm_send_rpn_cmd(struct bt_rfcomm_dlc *dlc, struct bt_rfcomm_rpn *rpn)
+{
+	struct bt_rfcomm_session *session;
+
+	if (!dlc || !rpn) {
+		return -EINVAL;
+	}
+
+	/* Validate baud rate */
+	if (rpn->baud_rate > BT_RFCOMM_RPN_BAUD_RATE_230400) {
+		LOG_ERR("Invalid baud rate: %u", rpn->baud_rate);
+		return -EINVAL;
+	}
+
+	session = dlc->session;
+	if (!session) {
+		return -ENOTCONN;
+	}
+
+	if (dlc->state != BT_RFCOMM_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	LOG_DBG("dlc %p", dlc);
+
+	/* Set DLCI in the RPN command */
+	rpn->dlci = BT_RFCOMM_SET_ADDR(dlc->dlci, 1);
+
+	/* Send the RPN command */
+	return rfcomm_send_rpn(session, BT_RFCOMM_MSG_CMD_CR, rpn);
+}
+
 static int rfcomm_send_test(struct bt_rfcomm_session *session, uint8_t cr,
 			    uint8_t *pattern, uint8_t len)
 {

--- a/subsys/bluetooth/host/classic/rfcomm_internal.h
+++ b/subsys/bluetooth/host/classic/rfcomm_internal.h
@@ -90,37 +90,12 @@ struct bt_rfcomm_rls {
 } __packed;
 
 #define BT_RFCOMM_RPN   0x24
-struct bt_rfcomm_rpn {
-	uint8_t  dlci;
-	uint8_t  baud_rate;
-	uint8_t  line_settings;
-	uint8_t  flow_control;
-	uint8_t  xon_char;
-	uint8_t  xoff_char;
-	uint16_t param_mask;
-} __packed;
 
 #define BT_RFCOMM_TEST  0x08
 #define BT_RFCOMM_NSC   0x04
 
 #define BT_RFCOMM_FCON  0x28
 #define BT_RFCOMM_FCOFF 0x18
-
-/* Default RPN Settings */
-#define BT_RFCOMM_RPN_BAUD_RATE_9600    0x03
-#define BT_RFCOMM_RPN_DATA_BITS_8       0x03
-#define BT_RFCOMM_RPN_STOP_BITS_1       0x00
-#define BT_RFCOMM_RPN_PARITY_NONE       0x00
-#define BT_RFCOMM_RPN_FLOW_NONE         0x00
-#define BT_RFCOMM_RPN_XON_CHAR          0x11
-#define BT_RFCOMM_RPN_XOFF_CHAR         0x13
-
-/* Set 1 to all the param mask except reserved */
-#define BT_RFCOMM_RPN_PARAM_MASK_ALL    0x3f7f
-
-#define BT_RFCOMM_SET_LINE_SETTINGS(data, stop, parity) ((data & 0x3) | \
-							 ((stop & 0x1) << 2) | \
-							 ((parity & 0x7) << 3))
 
 /* DV = 1 IC = 0 RTR = 1 RTC = 1 FC = 0 EXT = 0 */
 #define BT_RFCOMM_DEFAULT_V24_SIG 0x8d

--- a/subsys/bluetooth/host/classic/shell/rfcomm.c
+++ b/subsys/bluetooth/host/classic/shell/rfcomm.c
@@ -232,6 +232,42 @@ static int cmd_disconnect(const struct shell *sh, size_t argc, char *argv[])
 	return err;
 }
 
+static int cmd_send_rpn(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+	struct bt_rfcomm_rpn rpn;
+
+	if (!rfcomm_dlc.session) {
+		shell_error(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	/* Initialize RPN with default values */
+	memset(&rpn, 0, sizeof(rpn));
+
+	/* Set default values for RPN parameters */
+	rpn.baud_rate = BT_RFCOMM_RPN_BAUD_RATE_9600;
+	rpn.line_settings = BT_RFCOMM_SET_LINE_SETTINGS(
+		BT_RFCOMM_RPN_DATA_BITS_8,
+		BT_RFCOMM_RPN_STOP_BITS_1,
+		BT_RFCOMM_RPN_PARITY_NONE);
+	rpn.flow_control = BT_RFCOMM_RPN_FLOW_NONE;
+	rpn.xon_char = BT_RFCOMM_RPN_XON_CHAR;
+	rpn.xoff_char = BT_RFCOMM_RPN_XOFF_CHAR;
+	rpn.param_mask = BT_RFCOMM_RPN_PARAM_MASK_ALL;
+
+	shell_print(sh, "Sending RFCOMM RPN command with default settings");
+
+	err = bt_rfcomm_send_rpn_cmd(&rfcomm_dlc, &rpn);
+	if (err < 0) {
+		shell_error(sh, "Unable to send RPN command: %d", err);
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "RFCOMM RPN command sent successfully");
+	return 0;
+}
+
 #define HELP_NONE "[none]"
 #define HELP_ADDR_LE "<address: XX:XX:XX:XX:XX:XX> <type: (public|random)>"
 
@@ -240,6 +276,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(rfcomm_cmds,
 	SHELL_CMD_ARG(connect, NULL, "<channel>", cmd_connect, 2, 0),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
 	SHELL_CMD_ARG(send, NULL, "<number of packets>", cmd_send, 2, 0),
+	SHELL_CMD_ARG(rpn, NULL, "Send RPN command with default settings", cmd_send_rpn, 1, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Add support for Remote Port Negotiation (RPN) commands in the RFCOMM. This allows applications to configure the serial port parameters over RFCOMM connections, such as baud rate, data bits, stop bits, parity and flow control.

Changes include:
- Add enumerations for RPN parameters (baud rate, data bits, stop bits, parity)
- Add a public API function bt_rfcomm_send_rpn_cmd() to send RPN commands
- Add shell command to test RPN with default parameters

This functionality is required by certain Bluetooth profiles that use RFCOMM and need to configure serial port parameters.