### PR TITLE
posix: fix typo in pthread_cond_init

### DIFF
--- a/lib/posix/options/cond.c
+++ b/lib/posix/options/cond.c
@@ -186,7 +186,7 @@ int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut, const struc
 int pthread_cond_init(pthread_cond_t *cvar, const pthread_condattr_t *att)
 {
 	struct posix_cond *cv;
-	struct posix_condattr *attr = (struct posix_condattr *)attr;
+	struct posix_condattr *attr = (struct posix_condattr *)att;
 
 	*cvar = PTHREAD_COND_INITIALIZER;
 	cv = to_posix_cond(cvar);

--- a/tests/posix/common/src/cond.c
+++ b/tests/posix/common/src/cond.c
@@ -69,4 +69,20 @@ ZTEST(cond, test_pthread_condattr)
 	zassert_ok(pthread_condattr_destroy(&att));
 }
 
+/**
+ * @brief Test pthread_cond_init() with a pre-existing initialized attribute.
+ */
+ZTEST(cond, test_cond_init_existing_initialized_condattr)
+{
+	pthread_cond_t cond;
+	pthread_condattr_t att = {0};
+
+	zassert_ok(pthread_condattr_init(&att));
+	zassert_ok(pthread_cond_init(&cond, &att), "pthread_cond_init failed with valid attr");
+
+	/* Clean up */
+	zassert_ok(pthread_cond_destroy(&cond));
+	zassert_ok(pthread_condattr_destroy(&att));
+}
+
 ZTEST_SUITE(cond, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Caught by clang in CI.
Also added a test for better coverage in the future.