### PR TITLE
boards: st: stm32 add the SD disk name to boards with sdmmc node

### DIFF
--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -97,6 +97,7 @@
 		&sdmmc1_d3_pc11 &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };
 
 &adc1 {

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -320,6 +320,7 @@ zephyr_udc0: &usbotg_fs {
 	pwr-gpios = <&gpioh 10 GPIO_ACTIVE_LOW>;
 	bus-width = <4>;
 	clk-div = <4>;
+	disk-name = "SD";
 };
 
 &flash0 {

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -294,6 +294,7 @@ zephyr_udc0: &usbotg_fs {
 	cd-gpios = <&gpiog 1 GPIO_ACTIVE_LOW>;
 	bus-width = <4>;
 	clk-div = <4>;
+	disk-name = "SD";
 };
 
 &flash0 {

--- a/boards/st/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/st/stm32f469i_disco/stm32f469i_disco.dts
@@ -137,4 +137,5 @@ zephyr_udc0: &usbotg_fs {
 		     &sdio_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpiog 2 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -173,6 +173,7 @@ zephyr_udc0: &usbotg_fs {
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };
 
 &mac {

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -160,6 +160,7 @@ zephyr_udc0: &usbotg_fs {
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };
 
 &mac {

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -181,6 +181,7 @@ arduino_serial: &usart6 {};
 		     &sdmmc2_ck_pd6 &sdmmc2_cmd_pd7>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };
 
 &quadspi {

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -301,6 +301,7 @@
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioh 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -163,6 +163,7 @@
 		     &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpiof 5 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };
 
 &octospi1 {

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -255,6 +255,7 @@ zephyr_udc0: &usbotg_hs {
 			&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 };
 
 &quadspi {

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -231,6 +231,7 @@
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/st/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/st/stm32l496g_disco/stm32l496g_disco.dts
@@ -158,6 +158,7 @@
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -220,6 +220,7 @@
 		&sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
+	disk-name = "SD";
 };
 
 &adc1 {

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -314,7 +314,7 @@ zephyr_udc0: &usb {
 
 &sdmmc1 {
 	status = "okay";
-
+	disk-name = "SD";
 	pinctrl-0 = <&sdmmc1_d0_pc8
 		     &sdmmc1_d1_pc9
 		     &sdmmc1_d2_pc10

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -202,6 +202,7 @@
 	bus-width = <4>;
 	cd-gpios = <&gpion 12 GPIO_ACTIVE_HIGH>;
 	pwr-gpios = <&gpioq 7 GPIO_ACTIVE_HIGH>;
+	disk-name = "SD";
 };
 
 &spi5 {

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -198,6 +198,7 @@ uart0: &usart3 {
 		&sdmmc1_d6_pc6 &sdmmc1_d7_pc7
 		&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb.dts
+++ b/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb.dts
@@ -103,6 +103,7 @@
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	cd-gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -146,6 +146,7 @@
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpiod 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
@@ -123,6 +123,7 @@
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpiod 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/weact/stm32f405_core/weact_stm32f405_core.dts
+++ b/boards/weact/stm32f405_core/weact_stm32f405_core.dts
@@ -112,6 +112,7 @@
 		     &sdio_ck_pc12 &sdio_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioa 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	disk-name = "SD";
 };
 
 &rtc {

--- a/boards/weact/stm32h5_core/weact_stm32h5_core.dts
+++ b/boards/weact/stm32h5_core/weact_stm32h5_core.dts
@@ -54,6 +54,7 @@
 	cd-gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioa 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -345,6 +345,7 @@ zephyr_udc0: &usbotg_fs {
 		     &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpiog 7 GPIO_ACTIVE_LOW>;
+	disk-name = "SD";
 	status = "okay";
 
 	disk {

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -7,6 +7,7 @@ include: [mmc.yaml, pinctrl-device.yaml, reset-device.yaml]
 properties:
   disk-name:
     type: string
+    required: true
     description: |
       Disk name.
 

--- a/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
@@ -13,6 +13,8 @@
 		     &sdmmc1_cmd_pd2>;
 
 	pinctrl-names = "default";
+
+	disk-name = "SD";
 };
 
 / {

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f4_sdmmc48_pll.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f4_sdmmc48_pll.overlay
@@ -31,4 +31,5 @@
 			&sdio_d2_pc10 &sdio_d3_pc11>;
 	pinctrl-names = "default";
 	status = "okay";
+	disk-name = "SD";
 };


### PR DESCRIPTION
Add a disk name to the SDMMC node, as done for all other SD card compatibles in tree.

Like the PR https://github.com/zephyrproject-rtos/zephyr/pull/88691/ did for the stm32h747 disco
 
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/89081