### PR TITLE
Bluetooth: CSIP: Set member: Fix issue with re-registration

### DIFF
--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019 Bose Corporation
- * Copyright (c) 2020-2024 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,7 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
 
+#include "bs_tracing.h"
 #include "bstests.h"
 #include "common.h"
 #ifdef CONFIG_BT_CSIP_SET_MEMBER
@@ -288,6 +289,46 @@ static void test_new_set_size_and_rank(void)
 	PASS("CSIP Set member passed: Client successfully disconnected\n");
 }
 
+static void test_register(void)
+{
+	for (size_t iteration = 1; iteration <= 5; iteration++) {
+		struct bt_csip_set_member_svc_inst
+			*svc_insts[CONFIG_BT_CSIP_SET_MEMBER_MAX_INSTANCE_COUNT];
+		int err;
+
+		printk("Running iteration %zu\n", iteration);
+
+		ARRAY_FOR_EACH(svc_insts, i) {
+			err = bt_csip_set_member_register(&param, &svc_insts[i]);
+			if (err != 0) {
+				FAIL("[%zu]: Could not register CSIS (err %d)\n", i, err);
+				return;
+			}
+		}
+
+		err = bt_csip_set_member_register(&param, &svc_inst);
+		if (err == 0) {
+			FAIL("Registered more CSIS than expected\n");
+			return;
+		}
+
+		ARRAY_FOR_EACH(svc_insts, i) {
+			err = bt_csip_set_member_unregister(svc_insts[i]);
+			if (err != 0) {
+				FAIL("[%zu]: Could not unregister CSIS (err %d)\n", i, err);
+				return;
+			}
+			svc_insts[i] = NULL;
+		}
+	}
+
+	PASS("CSIP Set member register passed\n");
+	/* We can terminate the test immediately here as there is no peer devices we keep
+	 * communicating with.
+	 */
+	bs_trace_silent_exit(0);
+}
+
 static void test_args(int argc, char *argv[])
 {
 	for (size_t argn = 0; argn < argc; argn++) {
@@ -350,6 +391,13 @@ static const struct bst_test_instance test_connect[] = {
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
 		.test_main_f = test_new_set_size_and_rank,
+		.test_args_f = test_args,
+	},
+	{
+		.test_id = "csip_set_member_register",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_register,
 		.test_args_f = test_args,
 	},
 	BSTEST_END_MARKER,

--- a/tests/bsim/bluetooth/audio/test_scripts/csip_register.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/csip_register.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
+
+VERBOSITY_LEVEL=2
+EXECUTE_TIMEOUT=30
+
+cd ${BSIM_OUT_PATH}/bin
+
+SIMULATION_ID="csip_register"
+
+Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
+  -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=csip_set_member_register \
+  -RealEncryption=1 -rs=20 -D=1 -argstest rank 1 size 2
+
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
+  -D=1 -sim_length=1e6 $@
+
+wait_for_background_jobs


### PR DESCRIPTION
The bt_csip_set_member_register kept a counter that was not decreased when bt_csip_set_member_unregister was called. This meant that we could register and unregister CSIS, but we could not re-register once it had been unregistered.

This commit fixes this by removing the counter and instead rely on the service instance state, which also requires restoring the original service definition, as well as adding a test that would have failed with the previous version.