### PR TITLE
bluetooth: host: Fix param_len for LE CS Test command

### DIFF
--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -618,6 +618,10 @@ int bt_le_cs_start_test(const struct bt_le_cs_test_param *params)
 
 	cp->override_parameters_length = override_parameters_length;
 
+	struct bt_hci_cmd_hdr *hdr = (struct bt_hci_cmd_hdr *)buf->data;
+
+	hdr->param_len += override_parameters_length;
+
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CS_TEST, buf, NULL);
 }
 #endif /* CONFIG_BT_CHANNEL_SOUNDING_TEST */


### PR DESCRIPTION
The parameter length for this command was missing the additional length from the arrayed parameters.