### PR TITLE
boards: st: stm32h7s78_dk: include correct SoC pinctrl dtsi

### DIFF
--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 #include <st/h7rs/stm32h7s7X8.dtsi>
-#include <st/h7/stm32h7s7l8hx-pinctrl.dtsi>
+#include <st/h7/stm32h7s7l8hxh-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 


### PR DESCRIPTION
The STM32H7S78-DK board is equipped with an STM32H7S7L8H6H. According to
the datasheet DS14359 (*), section 8, the trailing `H` in this SoC model
name indicates that it supports hexadeca SPI, in addition to quad and octa
modes that are supported on all variants in this family.

This fixes the issue where some pinctrl nodes are missing, when enabling
support for memories using 16 bit wide SPI transfer interfaces, like the
PSRAM chip on this board.

(*) https://www.st.com/resource/en/datasheet/stm32h7s7l8.pdf
