### PR TITLE
include: arch: ffs: include toolchain.h

### DIFF
--- a/include/zephyr/arch/common/ffs.h
+++ b/include/zephyr/arch/common/ffs.h
@@ -11,7 +11,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/types.h>
-#include <zephyr/toolchain/common.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Modify the include of toolchain/common.h to toolchain.h The reason why we should/cannot include toolchain/common.h is that it has an #error if included directly, and it requires including it via toolchain.h instead.