### PR TITLE
drivers: gnss: gnss_emul missing month_day data

### DIFF
--- a/drivers/gnss/gnss_emul.c
+++ b/drivers/gnss/gnss_emul.c
@@ -380,6 +380,7 @@ static void gnss_emul_set_utc(const struct device *dev)
 	data->data.utc.millisecond = millisecond;
 	data->data.utc.minute = datetime.tm_min;
 	data->data.utc.month = datetime.tm_mon + 1;
+	data->data.utc.month_day = datetime.tm_mday;
 	data->data.utc.century_year = datetime.tm_year % 100;
 }
 

--- a/tests/drivers/gnss/gnss_nmea0183/src/main.c
+++ b/tests/drivers/gnss/gnss_nmea0183/src/main.c
@@ -327,7 +327,7 @@ ZTEST(gnss_nmea0183, test_parse_gga_fix)
 		      "Incorrectly parsed fix status");
 
 	zassert_equal(data.info.satellites_cnt, 6,
-		      "Incorrectly parsed number of satelites");
+		      "Incorrectly parsed number of satellites");
 
 	zassert_equal(data.info.hdop, 1410, "Incorrectly parsed HDOP");
 	zassert_equal(data.nav_data.altitude, 15234, "Incorrectly parsed altitude");


### PR DESCRIPTION
Just a minor fix to the gnss_emul.c to fix a the missing month_day data. Also minor spelling fixes in the test code.

Signed-off-by: Fabian Kainka <f.kainka@gmx.de>