### PR TITLE
samples: modbus: tcp_server: improve server latency

### DIFF
--- a/samples/subsys/modbus/tcp_server/src/main.c
+++ b/samples/subsys/modbus/tcp_server/src/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020 PHYTEC Messtechnik GmbH
  * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Petr Vilím
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -283,6 +284,10 @@ int main(void)
 		LOG_ERR("error: socket: %d", errno);
 		return 0;
 	}
+
+	uint8_t enable = 1;
+
+	setsockopt(serv, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
 
 	bind_addr.sin_family = AF_INET;
 	bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/samples/subsys/modbus/tcp_server/src/main.c
+++ b/samples/subsys/modbus/tcp_server/src/main.c
@@ -265,6 +265,7 @@ static int modbus_tcp_connection(int client)
 int main(void)
 {
 	int serv;
+	int enable;
 	struct sockaddr_in bind_addr;
 	static int counter;
 
@@ -285,7 +286,7 @@ int main(void)
 		return 0;
 	}
 
-	uint8_t enable = 1;
+	enable = 1;
 
 	setsockopt(serv, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
 


### PR DESCRIPTION
Add TCP_NODELAY to disable Nagle's algorithm - significantly reduces server latency

When reading or writing modbus registers in continuous mode without closing connection (or port) between each read or write, the server latency increases from few milliseconds to above 50ms. This behavior was observed independently of different hardware configurations, e. g. ESP32-S3-DevKitC-1 (connected by Wi-Fi), XMC4700-Relax-kit or a custom board with Wiznet W5500 + STM32G0B1RE (both connected by ethernet).

After logging packets with Wireshark, cause was found in long delay between client query and server response. Disabling Nagle's algorithm in TCP stack completely solved this issue.