### PR TITLE
drivers: hwinfo: ensure z_vrfy_hwinfo_get_device_eui64() uses int

### DIFF
--- a/drivers/hwinfo/hwinfo_handlers.c
+++ b/drivers/hwinfo/hwinfo_handlers.c
@@ -15,7 +15,7 @@ ssize_t z_vrfy_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 }
 #include <zephyr/syscalls/hwinfo_get_device_id_mrsh.c>
 
-ssize_t z_vrfy_hwinfo_get_device_eui64(uint8_t *buffer)
+int z_vrfy_hwinfo_get_device_eui64(uint8_t *buffer)
 {
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(buffer, 8));
 


### PR DESCRIPTION
The prototype declared for `hwinfo_get_device_eui64()` in `drivers/hwinfo.h` is below.

```cpp
__syscall int hwinfo_get_device_eui64(uint8_t *buffer);
```

But the corresponding z_vrfy function for this syscall in `drivers/hwinfo/hwinfo_handlers.c` returns `ssize_t` rather than `int` which is inconsistent.

Use `int` instead of `ssize_t` in the implementation.