### PR TITLE
drivers: serial: allow STM32U5 series lpuart to function in low power

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -34,6 +34,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "uart_stm32.h"
 
+#include <stm32_ll_bus.h>
 #include <stm32_ll_usart.h>
 #include <stm32_ll_lpuart.h>
 #if defined(CONFIG_PM) && defined(IS_UART_WAKEUP_FROMSTOP_INSTANCE)
@@ -2199,6 +2200,12 @@ static int uart_stm32_registers_configure(const struct device *dev)
 			LL_EXTI_EnableIT_0_31(BIT(config->wakeup_line));
 		}
 	}
+#if defined(CONFIG_SOC_SERIES_STM32U5X) && DT_HAS_COMPAT_STATUS_OKAY(st_stm32_lpuart)
+	if (config->wakeup_source) {
+		/* Allow LPUART to operate in STOP modes. */
+		LL_SRDAMR_GRP1_EnableAutonomousClock(LL_SRDAMR_GRP1_PERIPH_LPUART1AMEN);
+	}
+#endif
 #endif /* CONFIG_PM */
 
 	LL_USART_Enable(usart);


### PR DESCRIPTION
An additional register needs to be set to allow STM32U5XX series processors to use LPUART in low power modes, such as STOP2 (supported through the PM subsys).

Tested with samples/drivers/uart/echo_bot on nucleo_u5a5zj_q with build command;
`west build -b nucleo_u5a5zj_q samples/drivers/uart/echo_bot --pristine -- -DCONFIG_PM=y;`
and app.overlay added;
```
/*
 * Copyright (c) 2019-2024 Vestas Wind Systems A/S
 *
 * SPDX-License-Identifier: Apache-2.0
 */

/ {
	chosen {
		zephyr,shell_uart = &lpuart1;
	};
};

&lpuart1 {
    pinctrl-0 = <&lpuart1_tx_pg7 &lpuart1_rx_pg8>;
    pinctrl-names = "default";
    current-speed = <9600>;
    clocks = <&rcc STM32_CLOCK_BUS_APB3 0x40>,
             <&rcc STM32_SRC_LSE LPUART1_SEL(3)>;
    wakeup-source;
    fifo-enable;
    status = "okay";
};
```

Device can be seen to perform as expected.
![image](https://github.com/user-attachments/assets/c99b76c2-5191-4115-8e8b-b98305d9235d)

