### PR TITLE
Bluetooth: hci_uart_async: Add testcase for desync

### DIFF
--- a/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
+++ b/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
@@ -2,32 +2,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/kernel.h>
-#include <zephyr/sys/__assert.h>
-#include <zephyr/sys/time_units.h>
-#include <zephyr/toolchain/common.h>
 #include <errno.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
-
-#include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
-#include <zephyr/sys/byteorder.h>
-#include <zephyr/logging/log.h>
-#include <zephyr/sys/util.h>
-
-#include <zephyr/device.h>
-#include <zephyr/init.h>
-#include <zephyr/drivers/uart.h>
-
-#include <zephyr/usb/usb_device.h>
-
-#include <zephyr/net_buf.h>
+#include <zephyr/autoconf.h>
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/l2cap.h>
-#include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/hci_raw.h>
+#include <zephyr/bluetooth/hci_types.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel/thread_stack.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/toolchain/common.h>
+#include <zephyr/usb/usb_device.h>
 
 LOG_MODULE_REGISTER(hci_uart_async, LOG_LEVEL_DBG);
 

--- a/tests/bluetooth/hci_uart_async/app.overlay
+++ b/tests/bluetooth/hci_uart_async/app.overlay
@@ -1,9 +1,9 @@
 / {
 	chosen {
-		zephyr,bt-c2h-uart = &test_uart;
+		zephyr,bt-c2h-uart = &virtual_uart;
 	};
 
-	test_uart: test_uart {
+	virtual_uart: virtual_uart {
 		compatible = "vnd,serial";
 		status = "okay";
 		buffer-size = <100>;

--- a/tests/bluetooth/hci_uart_async/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/hci_uart_async/dts/bindings/zephyr,bt-hci-test.yaml
@@ -1,6 +1,6 @@
-description: Bluetooth HCI for test purposes
+description: Bluetooth HCI mock controller
 
-compatible: "zephyr,bt-hci-test"
+compatible: "zephyr,bt-hci-mock-controller"
 
 include: bt-hci.yaml
 

--- a/tests/bluetooth/hci_uart_async/test.overlay
+++ b/tests/bluetooth/hci_uart_async/test.overlay
@@ -1,10 +1,10 @@
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_test;
+		zephyr,bt-hci = &bt_hci_mock_controller;
 	};
 
-	bt_hci_test: bt_hci_test {
-		compatible = "zephyr,bt-hci-test";
+	bt_hci_mock_controller: bt_hci_mock_controller {
+		compatible = "zephyr,bt-hci-mock-controller";
 		status = "okay";
 	};
 };


### PR DESCRIPTION
This adds a testcase that verifies that the hci_uart_async sample handles garbage appearing on the UART correctly, generating a HCI Hardware Error event.

This includes updating the test mock with the capability of reading what the DUT sends on UART to verify the HCI Hardware Error event is sent correctly.

The readability of the mocks has been improved, with better variable names and more comments.

IWYU has been applied to hci_uart_async sample and the test.