### PR TITLE
Disable timer after DMA error.

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -819,6 +819,9 @@ static void dma_callback(const struct device *dev, void *user_data,
 			LL_ADC_REG_StopConversion(adc);
 #endif
 			dma_stop(data->dma.dma_dev, data->dma.channel);
+			if (data->ctx.options.interval_us != 0U) {
+				adc_context_disable_timer(&data->ctx);
+			}
 			adc_context_complete(&data->ctx, status);
 		}
 	}


### PR DESCRIPTION
In the STM32 generic ADC driver code with DMA configured the code path without DMA errors disables the timer while the path with errors does not disabled the timer. The timer should be disabled in both instances. The default implementation of adc_context_disable_timer will have no effect if the timer is not running, however other implementations may not behave this way.