### PR TITLE
subsys: llext: support ARC MPU

### DIFF
--- a/boards/qemu/arc/qemu_arc_qemu_arc_em.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_em.yaml
@@ -12,4 +12,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+ram: 4096
 vendor: snps

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs.yaml
@@ -13,4 +13,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+ram: 4096
 vendor: snps

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs5x.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs5x.yaml
@@ -12,4 +12,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+ram: 4096
 vendor: snps

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs6x.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs6x.yaml
@@ -12,4 +12,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+ram: 4096
 vendor: snps

--- a/boards/qemu/arc/qemu_arc_qemu_arc_hs_xip.yaml
+++ b/boards/qemu/arc/qemu_arc_qemu_arc_hs_xip.yaml
@@ -12,4 +12,5 @@ testing:
   ignore_tags:
     - net
     - bluetooth
+ram: 4096
 vendor: snps

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -20,8 +20,10 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 
 #ifdef CONFIG_MMU_PAGE_SIZE
 #define LLEXT_PAGE_SIZE CONFIG_MMU_PAGE_SIZE
+#elif CONFIG_ARC_MPU_VER == 2
+#define LLEXT_PAGE_SIZE 2048
 #else
-/* Arm's MPU wants a 32 byte minimum mpu region */
+/* Arm and non-v2 ARC MPUs want a 32 byte minimum MPU region */
 #define LLEXT_PAGE_SIZE 32
 #endif
 
@@ -77,7 +79,7 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 	 * program-accessible data (not to string tables, for example).
 	 */
 	if (region->sh_flags & SHF_ALLOC) {
-		if (IS_ENABLED(CONFIG_ARM_MPU)) {
+		if (IS_ENABLED(CONFIG_ARM_MPU) || IS_ENABLED(CONFIG_ARC_MPU)) {
 			/* On ARM with an MPU, regions must be sized and
 			 * aligned to the same power of two (larger than 32).
 			 */

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -44,7 +44,9 @@ tests:
     extra_configs:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
   llext.readonly_mpu:
-    arch_allow: arm # Xtensa needs writable storage, currently not supported on RISC-V
+    arch_allow:
+      - arm # Xtensa needs writable storage, currently not supported on RISC-V
+      - arc
     filter: CONFIG_ARCH_HAS_USERSPACE
     extra_configs:
       - CONFIG_USERSPACE=y


### PR DESCRIPTION
Make it so LLEXT allocates a memory region equal or greater to the minimum size supported by the MPU, to ensure no region overlap.

Note: Per discussion in Discord's llext channel, I found out tests aren't currently running on ARC due to the min_ram filter in common. I've filed a feature request [here](https://github.com/zephyrproject-rtos/zephyr/issues/89117) to be able to set different min_ram per architecture. In the meantime, what do you think of the ugly workaround of creating a copy of the each test for ARC with a different min_ram? Example below.

```
...
llext.readonly:
    arch_allow:               # Xtensa needs writable storage
      - arm
      - riscv
    filter: not CONFIG_MPU and not CONFIG_MMU
    extra_conf_files: ['no_mem_protection.conf']
    extra_configs:
      - CONFIG_LLEXT_STORAGE_WRITABLE=n
  llext.readonly.arc:
    arch_allow:
      - arc
    filter: not CONFIG_MPU and not CONFIG_MMU
    extra_conf_files: ['no_mem_protection.conf']
    extra_configs:
      - CONFIG_LLEXT_STORAGE_WRITABLE=n
    min_ram: 128
...
```