### PR TITLE
samples: net: secure_mqtt_sensor_actuator: replace error code with enum val

### DIFF
--- a/samples/net/secure_mqtt_sensor_actuator/src/mqtt_client.c
+++ b/samples/net/secure_mqtt_sensor_actuator/src/mqtt_client.c
@@ -214,7 +214,7 @@ static void mqtt_event_handler(struct mqtt_client *const client, const struct mq
 		break;
 
 	case MQTT_EVT_SUBACK:
-		if (evt->result == 0x80) {
+		if (evt->result == MQTT_SUBACK_FAILURE) {
 			LOG_ERR("MQTT SUBACK error [%d]", evt->result);
 			break;
 		}


### PR DESCRIPTION
The error code `0x80` is replaced with its corresponding `mqtt_suback_return_code` enum value (see [enum definition](https://github.com/zephyrproject-rtos/zephyr/blob/f412cc643d91660b7acffacdbb6e18b100fccf7c/include/zephyr/net/mqtt.h#L180) for verification. This seems to make the code more readable, as users of this example do not have to look up, what `0x80` encodes.