### PR TITLE
drivers: counter: introduce counter capture api

### DIFF
--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -10,6 +10,22 @@ menuconfig COUNTER
 
 if COUNTER
 
+config COUNTER_CAPTURE
+	bool "Counter capture"
+	select EXPERIMENTAL
+	depends on COUNTER_SUPPORTS_CAPTURE
+	help
+	  Enable support for counter capture. This is a feature that allows
+	  hardware timestamping of external events as well as a software
+	  interrupt on the event. This feature is not supported by all
+	  counter drivers.
+
+config COUNTER_SUPPORTS_CAPTURE
+	bool
+	help
+	  Select this option if the counter driver supports the counter capture
+	  API. This is to be set the driver.
+
 config COUNTER_INIT_PRIORITY
 	int "Counter init priority"
 	default 60

--- a/drivers/counter/Kconfig.stm32_timer
+++ b/drivers/counter/Kconfig.stm32_timer
@@ -6,5 +6,7 @@ config COUNTER_TIMER_STM32
 	default y
 	depends on DT_HAS_ST_STM32_COUNTER_ENABLED
 	select RESET
+	select PINCTRL if COUNTER_CAPTURE
+	select COUNTER_SUPPORTS_CAPTURE
 	help
 	  Enable the counter driver for STM32 family of processors.

--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2026 Meta Platforms
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -277,3 +278,21 @@ static inline int z_vrfy_counter_set_guard_period_64(const struct device *dev, u
 }
 #include <zephyr/syscalls/counter_set_guard_period_64_mrsh.c>
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
+
+#ifdef CONFIG_COUNTER_CAPTURE
+static inline int z_vrfy_counter_enable_capture(const struct device *dev,
+						uint8_t chan_id)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_enable_capture((const struct device *)dev, chan_id);
+}
+#include <zephyr/syscalls/counter_enable_capture_mrsh.c>
+
+static inline int z_vrfy_counter_disable_capture(const struct device *dev,
+						 uint8_t chan_id)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_COUNTER));
+	return z_impl_counter_disable_capture((const struct device *)dev, chan_id);
+}
+#include <zephyr/syscalls/counter_disable_capture_mrsh.c>
+#endif /* CONFIG_COUNTER_CAPTURE */

--- a/drivers/counter/counter_stm32_timer.c
+++ b/drivers/counter/counter_stm32_timer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Kent Hall.
+ * Copyright (c) 2026 Meta Platforms
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +12,8 @@
 #include <zephyr/drivers/reset.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/atomic.h>
+#include <zephyr/drivers/counter/stm32.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #include <stm32_ll_tim.h>
 #include <stm32_ll_rcc.h>
@@ -53,6 +56,30 @@ static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
 };
 #endif
+
+#ifdef CONFIG_COUNTER_CAPTURE
+/** Channel to LL mapping. */
+static const uint32_t ch2ll[TIMER_MAX_CH] = {
+	LL_TIM_CHANNEL_CH1, LL_TIM_CHANNEL_CH2,
+	LL_TIM_CHANNEL_CH3, LL_TIM_CHANNEL_CH4,
+};
+
+static uint32_t (*const get_timer_capture[TIMER_MAX_CH])(const TIM_TypeDef *) = {
+	LL_TIM_IC_GetCaptureCH1, LL_TIM_IC_GetCaptureCH2,
+	LL_TIM_IC_GetCaptureCH3, LL_TIM_IC_GetCaptureCH4,
+};
+
+static uint32_t (*const get_over_capture[TIMER_MAX_CH])(const TIM_TypeDef *) = {
+	LL_TIM_IsActiveFlag_CC1OVR, LL_TIM_IsActiveFlag_CC2OVR,
+	LL_TIM_IsActiveFlag_CC3OVR, LL_TIM_IsActiveFlag_CC4OVR,
+};
+
+static void (*const clear_over_capture[TIMER_MAX_CH])(TIM_TypeDef *) = {
+	LL_TIM_ClearFlag_CC1OVR, LL_TIM_ClearFlag_CC2OVR,
+	LL_TIM_ClearFlag_CC3OVR, LL_TIM_ClearFlag_CC4OVR,
+};
+#endif /* CONFIG_COUNTER_CAPTURE */
+
 /** Channel to interrupt enable function mapping. */
 static void(*const enable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_EnableIT_CC1, LL_TIM_EnableIT_CC2,
@@ -95,7 +122,11 @@ struct counter_stm32_data {
 };
 
 struct counter_stm32_ch_data {
-	counter_alarm_callback_t callback;
+	counter_alarm_callback_t alarm_cb;
+#ifdef CONFIG_COUNTER_CAPTURE
+	counter_capture_cb_t capture_cb;
+	bool single_shot_capture;
+#endif /* CONFIG_COUNTER_CAPTURE */
 	void *user_data;
 };
 
@@ -110,6 +141,9 @@ struct counter_stm32_config {
 	uint32_t irqn;
 	/* Reset controller device configuration */
 	const struct reset_dt_spec reset;
+#ifdef CONFIG_COUNTER_CAPTURE
+	const struct pinctrl_dev_config *pcfg;
+#endif /* CONFIG_COUNTER_CAPTURE */
 
 	LOG_INSTANCE_PTR_DECLARE(log);
 };
@@ -263,7 +297,7 @@ static int counter_stm32_set_cc(const struct device *dev, uint8_t id,
 		if (irq_on_late) {
 			counter_stm32_counter_stm32_set_cc_int_pending(dev, id);
 		} else {
-			config->ch_data[id].callback = NULL;
+			config->ch_data[id].alarm_cb = NULL;
 		}
 	} else {
 		enable_it[id](timer);
@@ -282,11 +316,20 @@ static int counter_stm32_set_alarm(const struct device *dev, uint8_t chan,
 		return -EINVAL;
 	}
 
-	if (chdata->callback) {
+	if (chdata->alarm_cb) {
 		return -EBUSY;
 	}
 
-	chdata->callback = alarm_cfg->callback;
+#ifdef CONFIG_COUNTER_CAPTURE
+	/* Can't use channel if is used for a capture */
+	if (LL_TIM_CC_IsEnabledChannel(config->timer, ch2ll[chan])) {
+		LOG_ERR("%s: cannot use channel %d for alarm while capture is enabled",
+			dev->name, chan);
+		return -EBUSY;
+	}
+#endif /* CONFIG_COUNTER_CAPTURE */
+
+	chdata->alarm_cb = alarm_cfg->callback;
 	chdata->user_data = alarm_cfg->user_data;
 
 	return counter_stm32_set_cc(dev, chan, alarm_cfg);
@@ -297,7 +340,7 @@ static int counter_stm32_cancel_alarm(const struct device *dev, uint8_t chan)
 	const struct counter_stm32_config *config = dev->config;
 
 	disable_it[chan](config->timer);
-	config->ch_data[chan].callback = NULL;
+	config->ch_data[chan].alarm_cb = NULL;
 
 	return 0;
 }
@@ -314,7 +357,7 @@ static int counter_stm32_set_top_value(const struct device *dev,
 		/* Overflow can be changed only when all alarms are
 		 * disabled.
 		 */
-		if (config->ch_data[i].callback) {
+		if (config->ch_data[i].alarm_cb) {
 			return -EBUSY;
 		}
 	}
@@ -411,6 +454,16 @@ static int counter_stm32_init_timer(const struct device *dev)
 	/* config/enable IRQ */
 	cfg->irq_config_func(dev);
 
+#ifdef CONFIG_COUNTER_CAPTURE
+	if (cfg->pcfg) {
+		r = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (r < 0) {
+			LOG_ERR("%s: Counter Capture pinctrl setup failed (%d)", dev->name, r);
+			return r;
+		}
+	}
+#endif /* CONFIG_COUNTER_CAPTURE */
+
 	/* initialize timer */
 	LL_TIM_SetPrescaler(timer, cfg->prescaler);
 	LL_TIM_SetAutoReload(timer, counter_get_max_top_value(dev));
@@ -474,6 +527,167 @@ static int counter_stm32_set_value(const struct device *dev, uint32_t ticks)
 	return 0;
 }
 
+
+#ifdef CONFIG_COUNTER_CAPTURE
+static int counter_stm32_enable_capture(const struct device *dev, uint8_t chan)
+{
+	const struct counter_stm32_config *config = dev->config;
+	TIM_TypeDef *timer = config->timer;
+	struct counter_stm32_ch_data *chdata = &config->ch_data[chan];
+
+	/* Prevent configuring capture on a channel already used for alarms */
+	if (chdata->alarm_cb != NULL) {
+		LOG_ERR("%s: Channel %d already configured for alarm, cannot set capture",
+			dev->name, chan);
+		return -EBUSY;
+	}
+
+	/* Make sure a capture callback is set */
+	if (chdata->capture_cb == NULL) {
+		LOG_ERR("%s: Capture callback not set for channel %d, please configure",
+			dev->name, chan);
+		return -EINVAL;
+	}
+
+	/* enable interrupt */
+	enable_it[chan](timer);
+
+	LL_TIM_CC_EnableChannel(timer, ch2ll[chan]);
+
+	return 0;
+}
+
+static int counter_stm32_disable_capture(const struct device *dev, uint8_t chan)
+{
+	const struct counter_stm32_config *config = dev->config;
+	struct counter_stm32_ch_data *chdata = &config->ch_data[chan];
+	TIM_TypeDef *timer = config->timer;
+
+	LL_TIM_CC_DisableChannel(timer, ch2ll[chan]);
+
+	/* disable interrupt */
+	disable_it[chan](timer);
+	chdata->capture_cb = NULL;
+
+	return 0;
+}
+
+static int counter_stm32_capture_configure(const struct device *dev, uint8_t chan,
+					      counter_capture_flags_t flags,
+					      counter_capture_cb_t cb, void *user_data)
+{
+	const struct counter_stm32_config *config = dev->config;
+	struct counter_stm32_ch_data *chdata = &config->ch_data[chan];
+	TIM_TypeDef *timer = config->timer;
+	uint32_t config_flags = LL_TIM_ACTIVEINPUT_DIRECTTI;
+
+	/* Prevent configuring capture on a channel already used for alarms */
+	if (chdata->alarm_cb != NULL) {
+		LOG_ERR("%s: Channel %d already configured for alarm, cannot set capture",
+			dev->name, chan);
+		return -EBUSY;
+	}
+
+	/* Config is only writable when it is off */
+	if (LL_TIM_CC_IsEnabledChannel(timer, ch2ll[chan])) {
+		LOG_ERR("%s: Capture channel %d is enabled, cannot reconfigure", dev->name, chan);
+		return -EBUSY;
+	}
+
+	/* Configure polarity */
+	if ((flags & COUNTER_CAPTURE_BOTH_EDGES) == COUNTER_CAPTURE_BOTH_EDGES) {
+		config_flags |= LL_TIM_IC_POLARITY_BOTHEDGE;
+	} else if (flags & COUNTER_CAPTURE_FALLING_EDGE) {
+		config_flags |= LL_TIM_IC_POLARITY_FALLING;
+	} else if (flags & COUNTER_CAPTURE_RISING_EDGE) {
+		config_flags |= LL_TIM_IC_POLARITY_RISING;
+	} else {
+		return -EINVAL;
+	}
+
+	/* Configure prescaler */
+	switch (flags & COUNTER_CAPTURE_STM32_PRESCALER_DIV_MSK) {
+	case COUNTER_CAPTURE_STM32_PRESCALER_DIV1:
+		config_flags |= LL_TIM_ICPSC_DIV1;
+		break;
+	case COUNTER_CAPTURE_STM32_PRESCALER_DIV2:
+		config_flags |= LL_TIM_ICPSC_DIV2;
+		break;
+	case COUNTER_CAPTURE_STM32_PRESCALER_DIV4:
+		config_flags |= LL_TIM_ICPSC_DIV4;
+		break;
+	case COUNTER_CAPTURE_STM32_PRESCALER_DIV8:
+		config_flags |= LL_TIM_ICPSC_DIV8;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	/* Configure filter */
+	switch (flags & COUNTER_CAPTURE_STM32_FILTER_MSK) {
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV1_N1:
+		config_flags |= LL_TIM_IC_FILTER_FDIV1;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_TIM_KER_CK_N2:
+		config_flags |= LL_TIM_IC_FILTER_FDIV1_N2;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_TIM_KER_CK_N4:
+		config_flags |= LL_TIM_IC_FILTER_FDIV1_N4;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_TIM_KER_CK_N8:
+		config_flags |= LL_TIM_IC_FILTER_FDIV1_N8;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV2_N6:
+		config_flags |= LL_TIM_IC_FILTER_FDIV2_N6;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV2_N8:
+		config_flags |= LL_TIM_IC_FILTER_FDIV2_N8;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV4_N6:
+		config_flags |= LL_TIM_IC_FILTER_FDIV4_N6;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV4_N8:
+		config_flags |= LL_TIM_IC_FILTER_FDIV4_N8;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV8_N6:
+		config_flags |= LL_TIM_IC_FILTER_FDIV8_N6;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV8_N8:
+		config_flags |= LL_TIM_IC_FILTER_FDIV8_N8;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV16_N5:
+		config_flags |= LL_TIM_IC_FILTER_FDIV16_N5;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV16_N6:
+		config_flags |= LL_TIM_IC_FILTER_FDIV16_N6;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV16_N8:
+		config_flags |= LL_TIM_IC_FILTER_FDIV16_N8;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV32_N5:
+		config_flags |= LL_TIM_IC_FILTER_FDIV32_N5;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV32_N6:
+		config_flags |= LL_TIM_IC_FILTER_FDIV32_N6;
+		break;
+	case COUNTER_CAPTURE_STM32_FILTER_DTS_DIV32_N8:
+		config_flags |= LL_TIM_IC_FILTER_FDIV32_N8;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	chdata->capture_cb = cb;
+	chdata->user_data = user_data;
+	chdata->single_shot_capture = (flags & COUNTER_CAPTURE_SINGLE_SHOT) ? true : false;
+
+	/* Apply configuration */
+	LL_TIM_IC_Config(timer, ch2ll[chan], config_flags);
+
+	return 0;
+}
+#endif
+
 static void counter_stm32_top_irq_handle(const struct device *dev)
 {
 	struct counter_stm32_data *data = dev->data;
@@ -484,27 +698,80 @@ static void counter_stm32_top_irq_handle(const struct device *dev)
 	cb(dev, data->top_user_data);
 }
 
-static void counter_stm32_alarm_irq_handle(const struct device *dev, uint32_t id)
+static void counter_stm32_irq_handle(const struct device *dev, uint32_t id)
 {
 	const struct counter_stm32_config *config = dev->config;
 	struct counter_stm32_data *data = dev->data;
 	TIM_TypeDef *timer = config->timer;
 
 	struct counter_stm32_ch_data *chdata;
-	counter_alarm_callback_t cb;
 
 	atomic_and(&data->cc_int_pending, ~BIT(id));
-	disable_it[id](timer);
 
 	chdata = &config->ch_data[id];
-	cb = chdata->callback;
-	chdata->callback = NULL;
 
-	if (cb) {
-		uint32_t cc_val = get_timer_compare[id](timer);
+#ifdef CONFIG_COUNTER_CAPTURE
+	/* With Counter Capture, we need to check which mode it was configured for */
+	if (LL_TIM_IC_GetActiveInput(timer, ch2ll[id]) == LL_TIM_ACTIVEINPUT_DIRECTTI) {
+		counter_capture_cb_t cb = chdata->capture_cb;
 
-		cb(dev, id, cc_val, chdata->user_data);
+		/*
+		 * CCxOF is also set if at least two consecutive captures
+		 * occurred whereas the flag was not cleared
+		 */
+		if (get_over_capture[id](timer)) {
+			LOG_ERR("%s: overcapture on channel %d", dev->name, id);
+			clear_over_capture[id](timer);
+		}
+
+		if (cb) {
+			uint32_t cc_val = get_timer_capture[id](timer);
+			uint32_t pol = LL_TIM_IC_GetPolarity(timer, ch2ll[id]);
+			uint32_t filter = LL_TIM_IC_GetFilter(timer, ch2ll[id]);
+			uint32_t prescaler = LL_TIM_IC_GetPrescaler(timer, ch2ll[id]);
+			counter_capture_flags_t flags = 0;
+
+			/* translate stm32 flags to zephyr flags */
+			if (pol == LL_TIM_IC_POLARITY_RISING) {
+				flags = COUNTER_CAPTURE_RISING_EDGE;
+			} else if (pol == LL_TIM_IC_POLARITY_FALLING) {
+				flags = COUNTER_CAPTURE_FALLING_EDGE;
+			} else if (pol == LL_TIM_IC_POLARITY_BOTHEDGE) {
+				flags = COUNTER_CAPTURE_BOTH_EDGES;
+			}
+
+			/* Set Vendor flags */
+			flags |= FIELD_PREP(COUNTER_CAPTURE_STM32_FILTER_MSK, filter);
+			flags |= FIELD_PREP(COUNTER_CAPTURE_STM32_PRESCALER_DIV_MSK, prescaler);
+
+			/* For single shot capture, disable the channel after capture event */
+			if (chdata->single_shot_capture) {
+				flags |= COUNTER_CAPTURE_SINGLE_SHOT;
+				counter_stm32_disable_capture(dev, id);
+			} else {
+				flags |= COUNTER_CAPTURE_CONTINUOUS;
+			}
+
+			cb(dev, id, flags, cc_val, chdata->user_data);
+		}
+	} else {
+#endif
+		counter_alarm_callback_t cb;
+
+		/* alarm is one-shot, disable the interrupt after it fires */
+		disable_it[id](timer);
+
+		cb = chdata->alarm_cb;
+		chdata->alarm_cb = NULL;
+
+		if (cb) {
+			uint32_t cc_val = get_timer_compare[id](timer);
+
+			cb(dev, id, cc_val, chdata->user_data);
+		}
+#ifdef CONFIG_COUNTER_CAPTURE
 	}
+#endif
 }
 
 static DEVICE_API(counter, counter_stm32_driver_api) = {
@@ -521,6 +788,11 @@ static DEVICE_API(counter, counter_stm32_driver_api) = {
 	.set_guard_period = counter_stm32_set_guard_period,
 	.get_freq = counter_stm32_get_freq,
 	.set_value = counter_stm32_set_value,
+#ifdef CONFIG_COUNTER_CAPTURE
+	.enable_capture = counter_stm32_enable_capture,
+	.disable_capture = counter_stm32_disable_capture,
+	.capture_configure = counter_stm32_capture_configure,
+#endif
 };
 
 #define TIM_IRQ_HANDLE_CC(timx, cc)						\
@@ -531,7 +803,7 @@ static DEVICE_API(counter, counter_stm32_driver_api) = {
 			if (hw_irq) {						\
 				LL_TIM_ClearFlag_CC##cc(timer);			\
 			}							\
-			counter_stm32_alarm_irq_handle(dev, cc - 1U);		\
+			counter_stm32_irq_handle(dev, cc - 1U);			\
 		}								\
 	} while (0)
 
@@ -602,6 +874,10 @@ static void counter_stm32_irq_handler_global(const struct device *dev)
 	BUILD_ASSERT(NUM_CH(TIM(idx)) <= TIMER_MAX_CH,				  \
 		     "TIMER too many channels");				  \
 										  \
+	IF_ENABLED(CONFIG_COUNTER_CAPTURE,					  \
+		(IF_ENABLED(DT_INST_PINCTRL_HAS_NAME(idx, default),		  \
+		(PINCTRL_DT_INST_DEFINE(idx);))))				  \
+										  \
 	static struct counter_stm32_data counter##idx##_data;			  \
 	static struct counter_stm32_ch_data counter##idx##_ch_data[TIMER_MAX_CH]; \
 										  \
@@ -639,6 +915,10 @@ static void counter_stm32_irq_handler_global(const struct device *dev)
 				    (DT_IRQ_BY_NAME(TIMER(idx), cc, irq)),	  \
 				    (DT_IRQ_BY_NAME(TIMER(idx), global, irq))),	  \
 		.reset = RESET_DT_SPEC_GET(TIMER(idx)),				  \
+		IF_ENABLED(CONFIG_COUNTER_CAPTURE,				  \
+			(.pcfg = COND_CODE_1(					  \
+				DT_NODE_HAS_PROP(DT_DRV_INST(idx), pinctrl_0),	  \
+				(PINCTRL_DT_INST_DEV_CONFIG_GET(idx)), (NULL)),)) \
 	};									  \
 										  \
 	DEVICE_DT_INST_DEFINE(idx,						  \

--- a/dts/bindings/counter/st,stm32-counter.yaml
+++ b/dts/bindings/counter/st,stm32-counter.yaml
@@ -5,4 +5,4 @@ description: STM32 counters
 
 compatible: "st,stm32-counter"
 
-include: base.yaml
+include: [base.yaml, pinctrl-device.yaml]

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2016 Intel Corporation
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Meta Platforms
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +22,11 @@
  * @version 1.0.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup counter_interface_ext Device-specific Counter API extensions
+ *
+ * @{
+ * @}
  */
 
 #include <errno.h>
@@ -112,6 +118,64 @@ extern "C" {
 #define COUNTER_GUARD_PERIOD_LATE_TO_SET BIT(0)
 
 /**@} */
+
+/**
+ * @anchor COUNTER_CAPTURE_FLAGS
+ * @name Counter capture flags
+ *
+ * @brief Used by @ref counter_capture_configure.
+ * @{
+ */
+
+/**
+ * @brief Capture rising edge of an external input signal
+ */
+#define COUNTER_CAPTURE_RISING_EDGE BIT(0)
+
+/**
+ * @brief Capture falling edge of an external input signal
+ */
+#define COUNTER_CAPTURE_FALLING_EDGE BIT(1)
+
+/**
+ * @brief Capture both falling and rising edge of an external input signal
+ */
+#define COUNTER_CAPTURE_BOTH_EDGES (COUNTER_CAPTURE_FALLING_EDGE | COUNTER_CAPTURE_RISING_EDGE)
+
+/**
+ * @brief Capture an event continuously until stopped.
+ */
+#define COUNTER_CAPTURE_CONTINUOUS 0
+
+/**
+ * @brief Capture a single event
+ */
+#define COUNTER_CAPTURE_SINGLE_SHOT BIT(2)
+
+/**
+ * @brief Provides a type to hold Counter Capture configuration flags.
+ *
+ * The lower 8 bits are used for standard flags.
+ * The upper 24 bits are reserved for SoC specific flags.
+ *
+ * @see @ref COUNTER_CAPTURE_FLAGS.
+ */
+
+typedef uint32_t counter_capture_flags_t;
+
+/**@} */
+
+/** @brief Counter capture callback
+ *
+ * @param dev       Pointer to the device structure for the driver instance
+ * @param chan_id   Channel ID
+ * @param flags     Configuration flags (@ref COUNTER_CAPTURE_FLAGS)
+ * @param ticks     Counter value that triggered the capture
+ * @param user_data User data
+ */
+typedef void (*counter_capture_cb_t)(const struct device *dev, uint8_t chan_id,
+				     counter_capture_flags_t flags, uint32_t ticks,
+				     void *user_data);
 
 /** @brief Alarm callback
  *
@@ -292,6 +356,18 @@ struct counter_top_cfg_64 {
 	uint32_t flags;
 };
 
+/** @brief Counter capture callback for 64 bits ticks
+ *
+ * @param dev       Pointer to the device structure for the driver instance
+ * @param chan_id   Channel ID
+ * @param flags     Configuration flags (@ref COUNTER_CAPTURE_FLAGS)
+ * @param ticks     Counter value that triggered the capture in 64 bits
+ * @param user_data User data
+ */
+typedef void (*counter_capture_cb_64_t)(const struct device *dev, uint8_t chan_id,
+					counter_capture_flags_t flags, uint64_t ticks,
+					void *user_data);
+
 /**
  * @def_driverbackendgroup{Counter,counter_interface}
  * @{
@@ -346,6 +422,18 @@ typedef uint64_t (*counter_api_get_top_value_64)(const struct device *dev);
 /** @brief Callback API to set the counter top value (64 bits). */
 typedef int (*counter_api_set_top_value_64)(const struct device *dev,
 					    const struct counter_top_cfg_64 *cfg);
+/** @brief Callback API to configure counter capture on a channel. */
+typedef int (*counter_api_capture_configure)(const struct device *dev, uint8_t chan_id,
+					     counter_capture_flags_t flags,
+					     counter_capture_cb_t cb, void *user_data);
+/** @brief Callback API to configure counter capture on a channel with 64-bit ticks. */
+typedef int (*counter_api_capture_configure_64)(const struct device *dev, uint8_t chan_id,
+						counter_capture_flags_t flags,
+						counter_capture_cb_64_t cb, void *user_data);
+/** @brief Callback API to enable counter capture on a channel. */
+typedef int (*counter_api_enable_capture)(const struct device *dev, uint8_t chan_id);
+/** @brief Callback API to disable counter capture on a channel. */
+typedef int (*counter_api_disable_capture)(const struct device *dev, uint8_t chan_id);
 
 /**
  * @driver_ops{Counter}
@@ -439,6 +527,26 @@ __subsystem struct counter_driver_api {
 	 */
 	counter_api_set_top_value_64 set_top_value_64;
 #endif /* CONFIG_COUNTER_64BITS_TICKS */
+#ifdef CONFIG_COUNTER_CAPTURE
+	/**
+	 * @driver_ops_mandatory @copybrief counter_capture_configure
+	 */
+	counter_api_capture_configure capture_configure;
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	/**
+	 * @driver_ops_mandatory @copybrief counter_capture_configure_64
+	 */
+	counter_api_capture_configure_64 capture_configure_64;
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
+	/**
+	 * @driver_ops_mandatory @copybrief counter_enable_capture
+	 */
+	counter_api_enable_capture enable_capture;
+	/**
+	 * @driver_ops_mandatory @copybrief counter_disable_capture
+	 */
+	counter_api_disable_capture disable_capture;
+#endif /* CONFIG_COUNTER_CAPTURE */
 };
 /**
  * @}
@@ -1288,6 +1396,162 @@ static inline int z_impl_counter_set_value_64(const struct device *dev, uint64_t
 	return -ENOTSUP;
 #endif
 }
+
+#if defined(CONFIG_COUNTER_CAPTURE) || defined(__DOXYGEN__)
+/**
+ * @brief Counter capture APIs.
+ * @defgroup counter_capture Counter capture APIs
+ * @ingroup counter_interface
+ * @{
+ *
+ * [Experimental] Users should note that the APIs can change
+ * as a part of ongoing development.
+ */
+
+/**
+ * @brief Configure a capture channel and register its callback
+ *
+ * Configures the edge polarity and capture mode (single-shot vs
+ * continuous) for a capture channel, and registers the callback that
+ * delivers captured tick values.
+ *
+ * @note The mapping from a capture channel to its input source (e.g. a
+ *       physical pad or an internal signal) is vendor-specific and
+ *       is not part of this API. On most SoCs the channel-to-pin
+ *       association is fixed by the hardware and exposed through
+ *       devicetree (typically via pinctrl or a dedicated property on the
+ *       counter node). Refer to the binding for your counter device for
+ *       how to select the input. Future revisions of this API may add a
+ *       runtime source-selection call (e.g. counter_capture_set_source or
+ *       add a source argument to this function) if SoCs with a configurable
+ *       input fabric require it.
+ *
+ * @param dev  Pointer to the device structure for the driver instance
+ * @param chan_id Channel ID
+ * @param flags Configuration flags (@ref COUNTER_CAPTURE_FLAGS)
+ * @param cb Callback function reference
+ * @param user_data Argument passed to the callback function
+ *
+ * @retval 0 If successful.
+ * @retval Negative error code on failure
+ */
+static inline int counter_capture_configure(const struct device *dev, uint8_t chan_id,
+					    counter_capture_flags_t flags,
+					    counter_capture_cb_t cb, void *user_data)
+{
+	const struct counter_driver_api *api = DEVICE_API_GET(counter, dev);
+
+	if (api->capture_configure == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (chan_id >= counter_get_num_of_channels(dev)) {
+		return -ENOTSUP;
+	}
+
+	return api->capture_configure(dev, chan_id, flags, cb, user_data);
+}
+
+#if defined(CONFIG_COUNTER_64BITS_TICKS) || defined(__DOXYGEN__)
+/**
+ * @brief Configure a capture channel and register its callback for 64 bits ticks
+ *
+ * Configures the edge polarity and capture mode (single-shot vs
+ * continuous) for a capture channel, and registers the 64b callback that
+ * delivers captured tick values.
+ *
+ * @note The mapping from a capture channel to its input source (e.g. a
+ *       physical pad or an internal signal) is vendor-specific and
+ *       is not part of this API. On most SoCs the channel-to-pin
+ *       association is fixed by the hardware and exposed through
+ *       devicetree (typically via pinctrl or a dedicated property on the
+ *       counter node). Refer to the binding for your counter device for
+ *       how to select the input. Future revisions of this API may add a
+ *       runtime source-selection call (e.g. counter_capture_set_source or
+ *       add a source argument to this function) if SoCs with a configurable
+ *       input fabric require it.
+ *
+ * @param dev  Pointer to the device structure for the driver instance
+ * @param chan_id Channel ID
+ * @param flags Configuration flags (@ref COUNTER_CAPTURE_FLAGS)
+ * @param cb Callback function reference
+ * @param user_data Argument passed to the callback function
+ *
+ * @retval 0 If successful.
+ * @retval Negative error code on failure
+ */
+static inline int counter_capture_configure_64(const struct device *dev, uint8_t chan_id,
+					       counter_capture_flags_t flags,
+					       counter_capture_cb_64_t cb, void *user_data)
+{
+	const struct counter_driver_api *api = DEVICE_API_GET(counter, dev);
+
+	if (api->capture_configure_64 == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (chan_id >= counter_get_num_of_channels(dev)) {
+		return -ENOTSUP;
+	}
+
+	return api->capture_configure_64(dev, chan_id, flags, cb, user_data);
+}
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
+
+/**
+ * @brief Enable capture on a channel.
+ *
+ * @param dev  Pointer to the device structure for the driver instance.
+ * @param chan_id Channel ID.
+ *
+ * @retval 0 If successful.
+ * @retval Negative error code on failure
+ */
+__syscall int counter_enable_capture(const struct device *dev, uint8_t chan_id);
+
+static inline int z_impl_counter_enable_capture(const struct device *dev, uint8_t chan_id)
+{
+	const struct counter_driver_api *api = DEVICE_API_GET(counter, dev);
+
+	if (api->enable_capture == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (chan_id >= counter_get_num_of_channels(dev)) {
+		return -ENOTSUP;
+	}
+
+	return api->enable_capture(dev, chan_id);
+}
+
+/**
+ * @brief Disable capture on a channel.
+ *
+ * @param dev  Pointer to the device structure for the driver instance.
+ * @param chan_id Channel ID.
+ *
+ * @retval 0 If successful.
+ * @retval Negative error code on failure
+ */
+__syscall int counter_disable_capture(const struct device *dev, uint8_t chan_id);
+
+static inline int z_impl_counter_disable_capture(const struct device *dev, uint8_t chan_id)
+{
+	const struct counter_driver_api *api = DEVICE_API_GET(counter, dev);
+
+	if (api->disable_capture == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (chan_id >= counter_get_num_of_channels(dev)) {
+		return -ENOTSUP;
+	}
+
+	return api->disable_capture(dev, chan_id);
+}
+
+/** @} */
+#endif /* CONFIG_COUNTER_CAPTURE */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/counter/stm32.h
+++ b/include/zephyr/drivers/counter/stm32.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Meta Platforms
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Header file for STM32 counter capture driver
+ * @ingroup counter_stm32_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_COUNTER_STM32_H_
+#define ZEPHYR_INCLUDE_DRIVERS_COUNTER_STM32_H_
+
+/**
+ * @defgroup counter_stm32_interface STM32 counter capture
+ * @ingroup counter_interface_ext
+ * @brief STM32 counter capture driver
+ * @{
+ */
+
+/**
+ * @name Custom counter flags for STM32
+ *
+ * These flags can be used with the counter API in the upper 24 bits of counter_capture_flags_t
+ * They allow the usage of the filter and prescaler settings of the STM32 timers.
+ * @{
+ */
+/** @cond INTERNAL_HIDDEN */
+#define COUNTER_CAPTURE_STM32_PRESCALER_DIV_POS 8
+#define COUNTER_CAPTURE_STM32_PRESCALER_DIV_MSK (0x3 << COUNTER_CAPTURE_STM32_PRESCALER_DIV_POS)
+#define COUNTER_CAPTURE_STM32_FILTER_POS        10
+#define COUNTER_CAPTURE_STM32_FILTER_MSK        (0xF << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @endcond */
+
+/**
+ * @name Prescaler Divider
+ * @brief Ratio of the prescaler for input capture.
+ * @{
+ */
+
+/** @brief Capture on every edge */
+#define COUNTER_CAPTURE_STM32_PRESCALER_DIV1 (0 << COUNTER_CAPTURE_STM32_PRESCALER_DIV_POS)
+/** @brief Capture on every 2nd edge */
+#define COUNTER_CAPTURE_STM32_PRESCALER_DIV2 (1 << COUNTER_CAPTURE_STM32_PRESCALER_DIV_POS)
+/** @brief Capture on every 4th edge */
+#define COUNTER_CAPTURE_STM32_PRESCALER_DIV4 (2 << COUNTER_CAPTURE_STM32_PRESCALER_DIV_POS)
+/** @brief Capture on every 8th edge */
+#define COUNTER_CAPTURE_STM32_PRESCALER_DIV8 (3 << COUNTER_CAPTURE_STM32_PRESCALER_DIV_POS)
+
+/** @} */
+
+/**
+ * @name Input Capture Sampling Frequency and Digital Filter
+ * @brief Configuration for sampling frequency and digital filter length.
+ * @{
+ */
+
+/** @brief Sampling: fDTS, N=1 (no filter) */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV1_N1   (0 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fTIM_KER_CK, N=2 */
+#define COUNTER_CAPTURE_STM32_FILTER_TIM_KER_CK_N2 (1 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fTIM_KER_CK, N=4 */
+#define COUNTER_CAPTURE_STM32_FILTER_TIM_KER_CK_N4 (2 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fTIM_KER_CK, N=8 */
+#define COUNTER_CAPTURE_STM32_FILTER_TIM_KER_CK_N8 (3 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/2, N=6 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV2_N6   (4 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/2, N=8 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV2_N8   (5 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/4, N=6 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV4_N6   (6 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/4, N=8 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV4_N8   (7 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/8, N=6 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV8_N6   (8 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/8, N=8 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV8_N8   (9 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/16, N=5 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV16_N5  (10 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/16, N=6 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV16_N6  (11 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/16, N=8 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV16_N8  (12 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/32, N=5 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV32_N5  (13 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/32, N=6 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV32_N6  (14 << COUNTER_CAPTURE_STM32_FILTER_POS)
+/** @brief Sampling: fDTS/32, N=8 */
+#define COUNTER_CAPTURE_STM32_FILTER_DTS_DIV32_N8  (15 << COUNTER_CAPTURE_STM32_FILTER_POS)
+
+/** @} */
+
+/** @} */
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_COUNTER_STM32_H_ */


### PR DESCRIPTION
This introduces apis for input capture on the STM32. This is something
agnostic enough that is seen on other vendors such as Atmel's SAM line
and others.

A use case for this would be time stamping a rising and/or falling edge
where precision and lack of jitter is important. The only way to currently
do this in zephyr is to set up a GPIO interrupt and then read the counter
or kernel time... but this can have limitations of software such as the
processor may have a lot going on and can be subject to interrupt latencies.
Having a hardware 'latch' done of the rising and/or falling edge with
respect to a timer can eliminate these imprecisions.

How this is to be used, is that an application is to call
`capture_callback_set` with the configuration of the channel number, flags
(such as falling, rising, or both edges), and then a callback function. Then
the `capture_enable` function is to be called to enable this. The callback
has the timestamp of the edge in ticks and the edge that it captured (rising
or falling).

----

~~This also introduces an api for set the counter time.~~

~~Also, this set frequency to be 64 bits rather than 32 bits, as counters, 
such as those that use fractional adders, tick at resolutions
greater than 4294967295Hz. This changes the freq in the common info
to a uint64_t. This retains the existing `counter_get_freq` function which
will still return a 32bit value. This also adds a `counter_get_freq_64`
function to get a 64bit value for the frequency.~~

~~Add inline helper functions for converting ticks to nanoseconds.~~

~~Also implement an inline helper for converting microseconds or
nanoseconds with a 64bit tick value.~~

split in to https://github.com/zephyrproject-rtos/zephyr/pull/94189