### PR TITLE
dts: weact_stm32h5_core: Define clk_hsi48 to fix USB support

### DIFF
--- a/boards/weact/stm32h5_core/weact_stm32h5_core.dts
+++ b/boards/weact/stm32h5_core/weact_stm32h5_core.dts
@@ -69,6 +69,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_hse {
 	status = "okay";
 	clock-frequency = <DT_FREQ_M(8)>;


### PR DESCRIPTION
The USB CDC driver relies on the HSI48 internal oscillator as the default clock source for USB functionality. In the weact_stm32h5_core device tree, the clk_hsi48 node was missing, resulting in USB initialization failure.

Define the clk_hsi48 clock to ensure correct USB operation.