### PR TITLE
drivers: pinctrl: enable the AFIO clock on the CH32V003/20x/30x

### DIFF
--- a/drivers/pinctrl/pinctrl_wch_20x_30x_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_20x_30x_afio.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT wch_20x_30x_afio
+
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/ch32v20x_30x-pinctrl.h>
 
@@ -87,3 +90,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 
 	return 0;
 }
+
+static int pinctrl_clock_init(void)
+{
+	const struct device *clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+	uint8_t clock_id = DT_INST_CLOCKS_CELL(0, id);
+
+	return clock_control_on(clock_dev, (clock_control_subsys_t *)(uintptr_t)clock_id);
+}
+
+SYS_INIT(pinctrl_clock_init, PRE_KERNEL_1, 0);

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -77,6 +77,7 @@
 			reg = <0x40010000 0x10>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&rcc CH32V00X_CLOCK_AFIO>;
 			status = "okay";
 
 			gpioa: gpio@40010800 {

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -76,6 +76,7 @@
 			reg = <0x40010000 16>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
 
 			gpioa: gpio@40010800 {
 				compatible = "wch,gpio";


### PR DESCRIPTION
The Alternate Function IO (AFIO) block must have the clock enabled before use. Some remappings seem to work without, but some like EXTI do not. Fix.

This is the same as https://github.com/zephyrproject-rtos/zephyr/pull/83353 and parts of https://github.com/zephyrproject-rtos/zephyr/pull/87397 but moves the definition to Devicetree.

This is needed by the GPIO EXTI support in https://github.com/zephyrproject-rtos/zephyr/pull/89139