### PR TITLE
modules: mbedtls: fix conditional compilation for `MBEDTLS_PKCS1_V21`

### DIFF
--- a/modules/mbedtls/configs/config-mbedtls.h
+++ b/modules/mbedtls/configs/config-mbedtls.h
@@ -384,7 +384,7 @@
 #define MBEDTLS_PKCS1_V15
 #endif
 
-#if defined(CONFIG_MBEDTLS_PKCS1_V15)
+#if defined(CONFIG_MBEDTLS_PKCS1_V21)
 #define MBEDTLS_PKCS1_V21
 #endif
 


### PR DESCRIPTION
Fix the conditional compilation to use `CONFIG_MBEDTLS_PKCS1_V21` instead of `CONFIG_MBEDTLS_PKCS1_V15` when enabling `MBEDTLS_PKCS1_V21`.