### PR TITLE
samples: drivers: uart: async_api: exclude some NXP platforms with LPUART

### DIFF
--- a/samples/drivers/uart/async_api/sample.yaml
+++ b/samples/drivers/uart/async_api/sample.yaml
@@ -9,5 +9,17 @@ tests:
       - uart
     filter: CONFIG_SERIAL and
             CONFIG_UART_ASYNC_API and
-            dt_chosen_enabled("zephyr,shell-uart")
+            dt_chosen_enabled("zephyr,shell-uart") and
+            not CONFIG_UART_MCUX_LPUART
+    harness: keyboard
+  sample.drivers.uart.async_api.lpuart:
+    tags:
+      - serial
+      - uart
+    filter: CONFIG_SERIAL and
+            CONFIG_UART_ASYNC_API and
+            dt_chosen_enabled("zephyr,shell-uart") and
+            CONFIG_UART_MCUX_LPUART and
+            not CONFIG_CPU_HAS_DCACHE
+    depends_on: dma
     harness: keyboard


### PR DESCRIPTION
NXP platforms with the LPUART require DMA for the async feature. Exclude platforms without DMA.  Also exclude platforms with DCACHE since this sample does not place the UART buffers in non-cacheable memory.

Resolves #89142 

Twister no longer has build failures on NXP platforms with LPUART using this command:
```
west twister --vendor nxp -s sample.drivers.uart.async_api
```