### PR TITLE
net: zperf: custom data upload support

### DIFF
--- a/doc/connectivity/networking/api/zperf.rst
+++ b/doc/connectivity/networking/api/zperf.rst
@@ -236,3 +236,13 @@ The ``-w`` option can be used like this to delay the startup of the jobs.
    Protocol:               TCP
    Session id:             0
    Total 2 sessions done
+
+Custom Data Upload
+******************
+
+zperf supports more advanced data upload profiling by setting a custom data
+source through :c:member:`zperf_upload_params.data_loader`. This enables the
+generation of custom packet contents instead of sending a constant packet
+consisting solely of the ``z`` character. An example use case would be
+determining the maximum throughput of uploading data from an external flash
+memory chip.

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -177,6 +177,11 @@ New APIs and options
 
     * Moved OpenThread-related Kconfig options from ``subsys/net/l2/openthread/Kconfig`` to ``modules/openthread/Kconfig``.
 
+  * zperf
+
+    * :kconfig:option:`CONFIG_ZPERF_SESSION_PER_THREAD`
+    * :c:member:`zperf_upload_params.data_loader`
+
 * Sensor
 
   * :c:func:`sensor_value_to_deci`

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -36,6 +36,7 @@ enum zperf_status {
 } __packed;
 
 struct zperf_upload_params {
+	uint64_t unix_offset_us;
 	struct sockaddr peer_addr;
 	uint32_t duration_ms;
 	uint32_t rate_kbps;

--- a/include/zephyr/net/zperf.h
+++ b/include/zephyr/net/zperf.h
@@ -35,8 +35,24 @@ enum zperf_status {
 	ZPERF_SESSION_ERROR
 } __packed;
 
+/**
+ * @brief Zperf callback function to load custom data for upload
+ *
+ * @param user_ctx User context for data load
+ * @param offset Current offset of custom data
+ * @param data Pointer to load data into
+ * @param len Length of data to load in bytes
+ *
+ * @retval 0 On successful data load
+ * @retval -errno Data load failed, terminate data upload
+ */
+typedef int (*zperf_data_load_custom)(void *user_ctx, uint64_t offset,
+				      uint8_t *data, uint32_t len);
+
 struct zperf_upload_params {
 	uint64_t unix_offset_us;
+	zperf_data_load_custom data_loader;
+	void *data_loader_ctx;
 	struct sockaddr peer_addr;
 	uint32_t duration_ms;
 	uint32_t rate_kbps;

--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -53,9 +53,10 @@ source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_ZPERF_MAX_PACKET_SIZE
 	int "Maximum packet size"
-	default 1024
+	default 1064
 	help
-	  Upper size limit for packets sent by zperf.
+	  Upper size limit for packets sent by zperf. Default allows for a 1kB
+	  payload with the 40 byte iperf UDP client header.
 
 config NET_ZPERF_SERVER
 	bool "zperf server support"

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -957,6 +957,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 	int ret;
 	int seconds;
 
+	param.unix_offset_us = k_uptime_get() * USEC_PER_MSEC;
 	param.options.priority = -1;
 	is_udp = proto == IPPROTO_UDP;
 
@@ -1210,6 +1211,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 	size_t opt_cnt = 0;
 	int seconds;
 
+	param.unix_offset_us = k_uptime_get() * USEC_PER_MSEC;
 	is_udp = proto == IPPROTO_UDP;
 
 	/* Parse options */

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -150,6 +150,8 @@ static int udp_upload(int sock, int port,
 		      const struct zperf_upload_params *param,
 		      struct zperf_results *results)
 {
+	size_t header_size =
+		sizeof(struct zperf_udp_datagram) + sizeof(struct zperf_client_hdr_v1);
 	uint32_t duration_in_ms = param->duration_ms;
 	uint32_t packet_size = param->packet_size;
 	uint32_t rate_in_kbps = param->rate_kbps;
@@ -164,13 +166,11 @@ static int udp_upload(int sock, int port,
 	int ret;
 
 	if (packet_size > PACKET_SIZE_MAX) {
-		NET_WARN("Packet size too large! max size: %u",
-			 PACKET_SIZE_MAX);
+		NET_WARN("Packet size too large! max size: %u", PACKET_SIZE_MAX);
 		packet_size = PACKET_SIZE_MAX;
 	} else if (packet_size < sizeof(struct zperf_udp_datagram)) {
-		NET_WARN("Packet size set to the min size: %zu",
-			 sizeof(struct zperf_udp_datagram));
-		packet_size = sizeof(struct zperf_udp_datagram);
+		NET_WARN("Packet size set to the min size: %zu", header_size);
+		packet_size = header_size;
 	}
 
 	/* Start the loop */


### PR DESCRIPTION
Add support for uploading custom data, instead of a static packet of 'z'. This can be used for more accurate profiling of uplink throughput for a given application. For example, reading data from flash, or application level encryption.

The timestamp in the UDP header is expected to be a Unix timestamp, not an application uptime. Add the option to specify the Unix time at function entry so that the reported timestamps are accurate. (See wireshark decoding of the payload below)
![image](https://github.com/user-attachments/assets/f5e74cae-fe69-47cd-924e-9b57221affb5)
