### PR TITLE
Fix getting incorrect TWT capabilities and Link mode of stations.

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -288,7 +288,18 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 		if (con_sta_info->is_11n_enabled) {
 			ap_sta_info.link_mode = WIFI_4;
 		} else {
-			ap_sta_info.link_mode = WIFI_3;
+			if (con_sta_info->bandmode == BAND_B) {
+				ap_sta_info.link_mode = WIFI_1;
+			} else {
+				uint32_t ap_channel = 0;
+
+				(void)wlan_get_uap_channel(&ap_channel);
+				if (ap_channel > 14) {
+					ap_sta_info.link_mode = WIFI_2;
+				} else {
+					ap_sta_info.link_mode = WIFI_3;
+				}
+			}
 		}
 #ifdef CONFIG_NXP_WIFI_11AC
 		if (con_sta_info->is_11ac_enabled) {

--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -302,7 +302,10 @@ int nxp_wifi_wlan_event_callback(enum wlan_event_reason reason, void *data)
 #endif
 
 #ifdef CONFIG_NXP_WIFI_11AX_TWT
-		ap_sta_info.twt_capable = true;
+		IEEEtypes_HECap_t sta_he_cap = con_sta_info->he_cap;
+		uint8_t sta_twt_cap = sta_he_cap.he_mac_cap[0];
+
+		ap_sta_info.twt_capable = sta_twt_cap & HE_MAC_CAP_TWT_REQ_SUPPORT ? true : false;
 #endif
 
 		memcpy(ap_sta_info.mac, con_sta_info->mac_addr, WIFI_MAC_ADDR_LEN);

--- a/drivers/wifi/nxp/nxp_wifi_drv.h
+++ b/drivers/wifi/nxp/nxp_wifi_drv.h
@@ -23,6 +23,7 @@
 #include "wlan_bt_fw.h"
 #include "wlan.h"
 #include "wm_net.h"
+#include "mlan_api.h"
 #if defined(CONFIG_NXP_WIFI_SHELL)
 #include "wifi_shell.h"
 #endif


### PR DESCRIPTION
[Description]:
Start a soft AP which supports 11AX and 11AX TWT.
External station connects to this AP.
Enter 'wifi ap stations' command to get station capabilities.
Log shows:
```
$ AP stations:
$ ============
$ Station 1:
$ ==========
$ MAC: C0:95:DA:00:EA:CC
$ Link mode: WIFI 5 (802.11ac/VHT)
$ TWT: Supported
```
This command is used to get external station capabilities. TWT is a 802.11 AX feature. Obviously, for stations with link mode 802.11 AC, TWT is not supported.

[Debug]:
When external station connects AP, will call hostapd_send_wifi_mgmt_ap_sta_event() to fill sta_info before notifying L2 Wi-Fi layer.
Call hapd_is_twt_capable() to get station TWT capability. But now, the TWT capability is AP's capability rather than stations. 

[Fix]:
1. Get the stations' TWT capability rather than AP self.
2. Rename hapd_is_twt_capable() to hapd_get_sta_he_twt_capable() to better match the function.
3. Update NXP Wi-Fi shim driver to support display Link mode and TWT capability of external stations.


