### PR TITLE
drivers: ambiq: add counter/rtc support for apollo510

### DIFF
--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -84,6 +84,10 @@
 	pinctrl-names = "default";
 };
 
+&counter0 {
+	status = "disabled";
+};
+
 &rtc0 {
 	status = "disabled";
 	clock = "XTAL";

--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -84,6 +84,11 @@
 	pinctrl-names = "default";
 };
 
+&rtc0 {
+	status = "disabled";
+	clock = "XTAL";
+};
+
 &uart0 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_default>;

--- a/boards/ambiq/apollo510_evb/apollo510_evb.yaml
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.yaml
@@ -10,6 +10,7 @@ toolchain:
 supported:
   - uart
   - watchdog
+  - counter
   - gpio
   - rtc
   - clock_control

--- a/boards/ambiq/apollo510_evb/apollo510_evb.yaml
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.yaml
@@ -11,6 +11,7 @@ supported:
   - uart
   - watchdog
   - gpio
+  - rtc
   - clock_control
 testing:
   ignore_tags:

--- a/dts/arm/ambiq/ambiq_apollo510.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo510.dtsi
@@ -125,6 +125,132 @@
 			status = "okay";
 		};
 
+		counter0: counter@40008200 {
+			compatible = "ambiq,counter";
+			reg = <0x40008200 0x20>;
+			interrupts = <67 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter1: counter@40008220 {
+			compatible = "ambiq,counter";
+			reg = <0x40008220 0x20>;
+			interrupts = <68 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter2: counter@40008240 {
+			compatible = "ambiq,counter";
+			reg = <0x40008240 0x20>;
+			interrupts = <69 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter3: counter@40008260 {
+			compatible = "ambiq,counter";
+			reg = <0x40008260 0x20>;
+			interrupts = <70 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter4: counter@40008280 {
+			compatible = "ambiq,counter";
+			reg = <0x40008280 0x20>;
+			interrupts = <71 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter5: counter@400082a0 {
+			compatible = "ambiq,counter";
+			reg = <0x400082a0 0x20>;
+			interrupts = <72 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter6: counter@400082c0 {
+			compatible = "ambiq,counter";
+			reg = <0x400082c0 0x20>;
+			interrupts = <73 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter7: counter@400082e0 {
+			compatible = "ambiq,counter";
+			reg = <0x400082e0 0x20>;
+			interrupts = <74 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter8: counter@40008300 {
+			compatible = "ambiq,counter";
+			reg = <0x40008300 0x20>;
+			interrupts = <75 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter9: counter@40008320 {
+			compatible = "ambiq,counter";
+			reg = <0x40008320 0x20>;
+			interrupts = <76 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter10: counter@40008340 {
+			compatible = "ambiq,counter";
+			reg = <0x40008340 0x20>;
+			interrupts = <77 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter11: counter@40008360 {
+			compatible = "ambiq,counter";
+			reg = <0x40008360 0x20>;
+			interrupts = <78 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter12: counter@40008380 {
+			compatible = "ambiq,counter";
+			reg = <0x40008380 0x20>;
+			interrupts = <79 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
+		counter13: counter@400083a0 {
+			compatible = "ambiq,counter";
+			reg = <0x400083a0 0x20>;
+			interrupts = <80 0>;
+			clock-frequency = <DT_FREQ_M(6)>;
+			clk-source = <1>;
+			status = "disabled";
+		};
+
 		rtc0: rtc@RTC_BASE_NAME {
 			compatible = "ambiq,rtc";
 			reg = <RTC_REG_BASE RTC_REG_SIZE>;

--- a/dts/arm/ambiq/ambiq_apollo510.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo510.dtsi
@@ -125,6 +125,14 @@
 			status = "okay";
 		};
 
+		rtc0: rtc@RTC_BASE_NAME {
+			compatible = "ambiq,rtc";
+			reg = <RTC_REG_BASE RTC_REG_SIZE>;
+			interrupts = <2 0>;
+			alarms-count = <1>;
+			status = "disabled";
+		};
+
 		wdt0: watchdog@WDT_BASE_NAME {
 			compatible = "ambiq,watchdog";
 			reg = <WDT_REG_BASE WDT_REG_SIZE>;

--- a/samples/drivers/counter/alarm/boards/apollo510_evb.overlay
+++ b/samples/drivers/counter/alarm/boards/apollo510_evb.overlay
@@ -1,0 +1,3 @@
+&counter0 {
+	status = "okay";
+};

--- a/samples/drivers/rtc/boards/apollo510_evb.overlay
+++ b/samples/drivers/rtc/boards/apollo510_evb.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/apollo510_evb.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/apollo510_evb.overlay
@@ -1,0 +1,3 @@
+&counter0 {
+	status = "okay";
+};

--- a/tests/drivers/rtc/rtc_api/boards/apollo510_evb.conf
+++ b/tests/drivers/rtc/rtc_api/boards/apollo510_evb.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_TEST_RTC_ALARM_TIME_MASK=79

--- a/tests/drivers/rtc/rtc_api/boards/apollo510_evb.overlay
+++ b/tests/drivers/rtc/rtc_api/boards/apollo510_evb.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Ambiq Micro Inc. <www.ambiq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		rtc = &rtc0;
+	};
+};
+
+&rtc0 {
+	status = "okay";
+};


### PR DESCRIPTION
This pull request updates the board configuration for the Apollo510 EVB by adding timer components.