### PR TITLE
dts: lilygo/ttgo_tbeam: add axp2101 charger node

### DIFF
--- a/boards/lilygo/ttgo_tbeam/ttgo_tbeam_esp32_procpu.dts
+++ b/boards/lilygo/ttgo_tbeam/ttgo_tbeam_esp32_procpu.dts
@@ -118,6 +118,13 @@
 				regulator-boot-on;
 			};
 		};
+
+		charger: charger {
+			compatible = "x-powers,axp2101-charger";
+			charge-term-current-microamp = <25000>;
+			constant-charge-current-max-microamp = <1000000>;
+			constant-charge-voltage-max-microvolt = <4200000>;
+		};
 	};
 };
 


### PR DESCRIPTION
The board provides an axp2101 chip with a builtin charger. We add the corresponding charger node with values taken from the official XPowers library example. This makes the board compatible with the drivers/charger example.

[1] https://github.com/lewisxhe/XPowersLib/blob/a7d06b98c1136c8fee7854b1d29a9f012b2aba83/examples/AXP2101_Charge_Example/AXP2101_Charge_Example.ino

Note: I would like to get an Ack / a confirmation from Lilygo regarding the safety of the chosen values.