### PR TITLE
Fix uuid.h usage in C++ code due 'namespace' reserved keyword

### DIFF
--- a/include/zephyr/sys/uuid.h
+++ b/include/zephyr/sys/uuid.h
@@ -67,7 +67,7 @@ int uuid_generate_v4(struct uuid *out);
  * @details This function computes a deterministic UUID starting from a namespace UUID and binary
  * data.
  *
- * @param namespace A pointer to an UUID to be used as namespace.
+ * @param ns A pointer to an UUID to be used as namespace.
  * @param data A pointer to the data that will be hashed to produce the UUID.
  * @param data_size The size of the data buffer.
  * @param out The UUID where the result will be written.
@@ -77,7 +77,7 @@ int uuid_generate_v4(struct uuid *out);
  * @retval -ENOMEM Memory allocation failed
  * @retval -ENOTSUP mbedTLS returned an unrecognized error
  */
-int uuid_generate_v5(const struct uuid *namespace, const void *data, size_t data_size,
+int uuid_generate_v5(const struct uuid *ns, const void *data, size_t data_size,
 		     struct uuid *out);
 
 /**

--- a/lib/uuid/uuid.c
+++ b/lib/uuid/uuid.c
@@ -79,7 +79,7 @@ int uuid_generate_v4(struct uuid *out)
 #endif
 
 #if defined(CONFIG_UUID_V5)
-int uuid_generate_v5(const struct uuid *namespace, const void *data, size_t data_size,
+int uuid_generate_v5(const struct uuid *ns, const void *data, size_t data_size,
 		     struct uuid *out)
 {
 	if (out == NULL) {
@@ -114,7 +114,7 @@ int uuid_generate_v5(const struct uuid *namespace, const void *data, size_t data
 		ret = -EINVAL;
 		goto exit;
 	}
-	mbedtls_err = mbedtls_md_update(&ctx, namespace->val, UUID_SIZE);
+	mbedtls_err = mbedtls_md_update(&ctx, ns->val, UUID_SIZE);
 	if (mbedtls_err != 0) {
 		/* Might return MBEDTLS_ERR_MD_BAD_INPUT_DATA */
 		ret = -EINVAL;


### PR DESCRIPTION
In uuid.h the function uuid_generate_v5 had a 'namespace' parameter which is a reserved C++ keyword. Renamed to 'ns'.