### PR TITLE
driver: hwinfo: nxp_rcm correct implementation of get_supported_reset…

### DIFF
--- a/drivers/hwinfo/hwinfo_mcux_rcm.c
+++ b/drivers/hwinfo/hwinfo_mcux_rcm.c
@@ -120,12 +120,9 @@ int z_impl_hwinfo_clear_reset_cause(void)
 #if (defined(FSL_FEATURE_RCM_HAS_PARAM) && FSL_FEATURE_RCM_HAS_PARAM)
 int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 {
-	uint32_t sources;
+	*supported = hwinfo_mcux_rcm_xlate_reset_sources(UINT32_MAX);
 
-	sources = RCM_GetResetSourceImplementedStatus(RCM);
-	*supported = hwinfo_mcux_rcm_xlate_reset_sources(sources);
-
-	LOG_DBG("sources = 0x%08x, supported = 0x%08x", sources, *supported);
+	LOG_DBG("supported = 0x%08x", *supported);
 
 	return 0;
 }


### PR DESCRIPTION
…_cause()

The function should return all possible combinations for reset cause. Removed the surrounding #ifdef as the _xlate_() function is platform specific to handle all cases for the dedicated platform.

This PR should fix #89163
Somehow related to PR #89161 as the code and idea was taken from this driver.

Regards, Adib