### PR TITLE
driver: watchdog: Add provision to add early warning interrupt

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -65,6 +65,15 @@ config WDT_COUNTER_CH_COUNT
 
 endif # WDT_COUNTER
 
+config WDT_EARLY_WARNING_INTERRUPT_SUPPORT
+	bool "Watchdog early warning interrupt support"
+	help
+	  Add support for the watchdog early warning interrupt. If the watchdog peripheral
+	  supports early warning interrupts, a callback can be set by the user to handle the
+	  cases when the watchdog window is opened. Certain devices have to be provisioned
+	  for when the minimum window time is reached, in order to notify the user that the
+	  window is opened.
+
 source "drivers/watchdog/Kconfig.stm32"
 
 source "drivers/watchdog/Kconfig.cmsdk_apb"

--- a/drivers/watchdog/wdt_sam0.c
+++ b/drivers/watchdog/wdt_sam0.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(wdt_sam0);
 #endif
 
 struct wdt_sam0_dev_data {
-	wdt_callback_t cb;
+	wdt_callback_t ew_cb;
 	bool timeout_valid;
 };
 
@@ -90,8 +90,8 @@ static void wdt_sam0_isr(const struct device *dev)
 
 	WDT_REGS->INTFLAG.reg = WDT_INTFLAG_EW;
 
-	if (data->cb != NULL) {
-		data->cb(dev, 0);
+	if (data->ew_cb != NULL) {
+		data->ew_cb(dev, 0);
 	}
 }
 
@@ -205,8 +205,8 @@ static int wdt_sam0_install_timeout(const struct device *dev,
 	wdt_sam0_wait_synchronization();
 
 	/* Only enable IRQ if a callback was provided */
-	data->cb = cfg->callback;
-	if (data->cb) {
+	data->ew_cb = cfg->callback;
+	if (data->ew_cb) {
 		WDT_REGS->INTENSET.reg = WDT_INTENSET_EW;
 	} else {
 		WDT_REGS->INTENCLR.reg = WDT_INTENCLR_EW;
@@ -219,7 +219,7 @@ static int wdt_sam0_install_timeout(const struct device *dev,
 
 timeout_invalid:
 	data->timeout_valid = false;
-	data->cb = NULL;
+	data->ew_cb = NULL;
 
 	return -EINVAL;
 }

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -92,6 +92,11 @@ struct wdt_timeout_cfg {
 	struct wdt_window window;
 	/** Timeout callback (can be `NULL`). */
 	wdt_callback_t callback;
+#if defined(CONFIG_WDT_EARLY_WARNING_INTERRUPT_SUPPORT) || defined(__DOXYGEN__)
+	/** Early warning callback (can be `NULL`). */
+	wdt_callback_t ew_callback;
+#endif /**WDT_EARLY_WARNING_INTERRUPT_SUPPORT*/
+
 #if defined(CONFIG_WDT_MULTISTAGE) || defined(__DOXYGEN__)
 	/**
 	 * Pointer to the next timeout configuration.

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -19,7 +19,7 @@
  * To use this sample the devicetree's /aliases must have a 'watchdog0' property.
  */
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
-#define WDT_MAX_WINDOW  100U
+#define WDT_MAX_WINDOW 100U
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_wdt)
 /* Nordic supports a callback, but it has 61.2 us to complete before
  * the reset occurs, which is too short for this sample to do anything
@@ -29,16 +29,16 @@
 #elif DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_watchdog)
 #define WDT_ALLOW_CALLBACK 0
 #elif DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_wwdgt)
-#define WDT_MAX_WINDOW 24U
-#define WDT_MIN_WINDOW 18U
+#define WDT_MAX_WINDOW    24U
+#define WDT_MIN_WINDOW    18U
 #define WDG_FEED_INTERVAL 12U
 #elif DT_HAS_COMPAT_STATUS_OKAY(intel_tco_wdt)
 #define WDT_ALLOW_CALLBACK 0
-#define WDT_MAX_WINDOW 3000U
+#define WDT_MAX_WINDOW     3000U
 #elif DT_HAS_COMPAT_STATUS_OKAY(nxp_fs26_wdog)
-#define WDT_MAX_WINDOW  1024U
-#define WDT_MIN_WINDOW	320U
-#define WDT_OPT 0
+#define WDT_MAX_WINDOW    1024U
+#define WDT_MIN_WINDOW    320U
+#define WDT_OPT           0
 #define WDG_FEED_INTERVAL (WDT_MIN_WINDOW + ((WDT_MAX_WINDOW - WDT_MIN_WINDOW) / 4))
 #elif DT_HAS_COMPAT_STATUS_OKAY(renesas_ra_wdt)
 #define WDT_ALLOW_CALLBACK 0
@@ -52,11 +52,11 @@
 #endif
 
 #ifndef WDT_MAX_WINDOW
-#define WDT_MAX_WINDOW  1000U
+#define WDT_MAX_WINDOW 1000U
 #endif
 
 #ifndef WDT_MIN_WINDOW
-#define WDT_MIN_WINDOW  0U
+#define WDT_MIN_WINDOW 0U
 #endif
 
 #ifndef WDG_FEED_INTERVAL
@@ -95,8 +95,7 @@ static void wdt_ew_callback(const struct device *wdt_dev, int channel_id)
 	}
 
 	wdt_feed(wdt_dev, channel_id);
-
-	printk("Fed watchdog after watchdog window opened... \n");
+	printk("Fed watchdog after watchdog window opened...\n");
 	handled_event = true;
 }
 #endif /* WDT_EARLY_WARNING_INTERRUPT_SUPPORT*/
@@ -142,6 +141,9 @@ int main(void)
 		/* IWDG driver for STM32 doesn't support callback */
 		printk("Callback support rejected, continuing anyway\n");
 		wdt_config.callback = NULL;
+#if WDT_EARLY_WARNING_INTERRUPT_SUPPORT
+		wdt_config.ew_callback = NULL;
+#endif /* WDT_EARLY_WARNING_INTERRUPT_SUPPORT*/
 		wdt_channel_id = wdt_install_timeout(wdt, &wdt_config);
 	}
 	if (wdt_channel_id < 0) {


### PR DESCRIPTION
- Added new structure element to keep early warning interrupt callback for watchdog window open.
- This is added so that user can initialise a callback in the interrupt ISR do some handling when the early warning window is enabled, if the hardware supports it.
- If a certain hw does not support it, they can keep it as NULL.
- A new kconfig property added to conditionally compile if the feature is available for a particular device.