### PR TITLE
tests: spi_loopback: Assign buffer for TX buffer array structure

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -340,7 +340,7 @@ ZTEST(spi_loopback, test_spi_null_rx_buf_set)
 {
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];
 	const struct spi_buf_set tx = spi_loopback_setup_xfer(tx_bufs_pool, 1,
-							      NULL, BUF_SIZE);
+							      buffer_tx, BUF_SIZE);
 
 	spi_loopback_transceive(spec, &tx, NULL);
 }


### PR DESCRIPTION
In the `test_spi_null_rx_buf_set` case, the TX buffer array structure is not assigned to any `buffer_tx` pointer. In some SPI drivers, this case may result in an error because the transfer is not conducted and an error is returned.

As a solution: I assigned the `buffer_tx` pointer to the TX buffer array structure.