### PR TITLE
boards: rak: add support for stm32 cube programmer

### DIFF
--- a/boards/rakwireless/rak3172/board.cmake
+++ b/boards/rakwireless/rak3172/board.cmake
@@ -4,6 +4,8 @@
 board_runner_args(pyocd "--target=stm32wle5ccux")
 board_runner_args(pyocd "--flash-opt=-O cmsis_dap.limit_packets=1")
 board_runner_args(jlink "--device=STM32WLE5CC" "--speed=4000" "--reset-after-load")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
Added support for stm32 cube programmer to RAK3172 module.

Tested with:
- `samples/hello_world`
- `samples/basic/blinky`

Flashed samples via stm32cubeprogrammer
- `west flash -r stm32cubeprogrammer`