### PR TITLE
add JLink runner for A-Core on imx91 imx8mm/n/p platforms

### DIFF
--- a/boards/nxp/imx8mm_evk/board.cmake
+++ b/boards/nxp/imx8mm_evk/board.cmake
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 
 if(CONFIG_BOARD_IMX8MM_EVK_MIMX8MM6_M4)
   board_set_debugger_ifnset(jlink)
   board_set_flasher_ifnset(jlink)
 
   board_runner_args(jlink "--device=MIMX8MD6_M4")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()
+
+if(CONFIG_SOC_MIMX8MM6_A53)
+  board_runner_args(jlink "--device=MIMX8MM6_A53_0" "--no-reset" "--flash-sram")
+
   include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 endif()

--- a/boards/nxp/imx8mm_evk/doc/index.rst
+++ b/boards/nxp/imx8mm_evk/doc/index.rst
@@ -68,6 +68,50 @@ Programming and Debugging (A53)
 
 .. zephyr:board-supported-runners::
 
+There are multiple methods to program and debug Zephyr on the A53 core:
+
+Option 1. Boot Zephyr by Using JLink Runner
+===========================================
+
+The default runner for the board is JLink, connect the EVK board's JTAG connector to
+the host computer using a J-Link debugger, power up the board and stop the board at
+U-Boot command line.
+
+Then use "west flash" or "west debug" command to load the zephyr.bin
+image from the host computer and start the Zephyr application on A53 core0.
+
+Flash and Run
+-------------
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: imx8mm_evk/mimx8mm6/a53
+   :goals: flash
+
+Then the following log could be found on UART4 console:
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build v4.1.0-3063-g38519ca2c028 ***
+    Hello World! imx8mm_evk/mimx8mm6/a53
+
+Debug
+-----
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: imx8mm_evk/mimx8mm6/a53
+   :goals: debug
+
+Option 2. Boot Zephyr by Using U-Boot Command
+=============================================
+
 U-Boot "cpu" command is used to load and kick Zephyr to Cortex-A secondary Core, Currently
 it is supported in : `Real-Time Edge U-Boot`_ (use the branch "uboot_vxxxx.xx-y.y.y,
 xxxx.xx is uboot version and y.y.y is Real-Time Edge Software version, for example
@@ -79,22 +123,45 @@ v2.9.0), and pre-build images and user guide can be found at `Real-Time Edge Sof
 .. _Real-Time Edge Software:
    https://www.nxp.com/rtedge
 
-Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
-plug the SD card into the board. Power it up and stop the u-boot execution at
-prompt.
+Step 1: Download Zephyr Image into DDR Memory
+---------------------------------------------
 
-Use U-Boot to load and kick zephyr.bin to Cortex-A53 Core0:
-
-.. code-block:: console
-
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; go 0x93c00000
-
-Or kick zephyr.bin to the other Cortex-A53 Core, for example Core2:
+Firstly need to download Zephyr binary image into DDR memory, it can use tftp:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; cpu 2 release 0x93c00000
+    tftp 0x93c00000 zephyr.bin
 
+Or copy the Zephyr image ``zephyr.bin`` SD card and plug the card into the board, for example
+if copy to the FAT partition of the SD card, use the following U-Boot command to load the image
+into DDR memory (assuming the SD card is dev 1, fat partition ID is 1, they could be changed
+based on actual setup):
+
+.. code-block:: console
+
+    fatload mmc 1:1 0x93c00000 zephyr.bin;
+
+Step 2: Boot Zephyr
+-------------------
+
+Then use the following command to boot Zephyr on the core0:
+
+.. code-block:: console
+
+    dcache off; icache flush; go 0x93c00000;
+
+Or use "cpu" command to boot from secondary Core, for example Core1:
+
+.. code-block:: console
+
+    dcache flush; icache flush; cpu 1 release 0x93c00000
+
+Option 3. Boot Zephyr by Using Remoteproc under Linux
+=====================================================
+
+When running Linux on the A55 core, it can use the remoteproc framework to load and boot Zephyr,
+refer to Real-Time Edge user guide for more details. Pre-build images and user guide can be found
+at `Real-Time Edge Software`_.
 
 Use this configuration to run basic Zephyr applications and kernel tests,
 for example, with the :zephyr:code-sample:`synchronization` sample:
@@ -103,28 +170,19 @@ for example, with the :zephyr:code-sample:`synchronization` sample:
    :zephyr-app: samples/synchronization
    :host-os: unix
    :board: imx8mm_evk/mimx8mm6/a53
-   :goals: run
+   :goals: build
 
 This will build an image with the synchronization sample app, boot it and
-display the following ram console output:
+display the following console output:
 
 .. code-block:: console
 
-    *** Booting Zephyr OS build zephyr-v3.1.0-3575-g44dd713bd883  ***
-    thread_a: Hello World from cpu 0 on mimx8mm_evk_a53!
-    thread_b: Hello World from cpu 0 on mimx8mm_evk_a53!
-    thread_a: Hello World from cpu 0 on mimx8mm_evk_a53!
-    thread_b: Hello World from cpu 0 on mimx8mm_evk_a53!
-    thread_a: Hello World from cpu 0 on mimx8mm_evk_a53!
-
-Use Jailhouse hypervisor, after root cell linux is up:
-
-.. code-block:: console
-
-    #jailhouse enable imx8mm.cell
-    #jailhouse cell create imx8mm-zephyr.cell
-    #jailhouse cell load 1 zephyr.bin -a 0x93c00000
-    #jailhouse cell start 1
+    *** Booting Zephyr OS build v4.1.0-3063-g38519ca2c028 ***
+    thread_a: Hello World from cpu 0 on mimx8mm_evk!
+    thread_b: Hello World from cpu 0 on mimx8mm_evk!
+    thread_a: Hello World from cpu 0 on mimx8mm_evk!
+    thread_b: Hello World from cpu 0 on mimx8mm_evk!
+    thread_a: Hello World from cpu 0 on mimx8mm_evk!
 
 Programming and Debugging (M4)
 ******************************

--- a/boards/nxp/imx8mn_evk/board.cmake
+++ b/boards/nxp/imx8mn_evk/board.cmake
@@ -1,1 +1,10 @@
+#
+# Copyright 2025 NXP
+#
 # SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_SOC_MIMX8MN6_A53)
+  board_runner_args(jlink "--device=MIMX8MN6_A53_0" "--no-reset" "--flash-sram")
+
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()

--- a/boards/nxp/imx8mn_evk/doc/index.rst
+++ b/boards/nxp/imx8mn_evk/doc/index.rst
@@ -62,28 +62,88 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
+There are multiple methods to program and debug Zephyr on the A53 core:
+
+Option 1. Boot Zephyr by Using JLink Runner
+===========================================
+
+The default runner for the board is JLink, connect the EVK board's JTAG connector to
+the host computer using a J-Link debugger, power up the board and stop the board at
+U-Boot command line.
+
+Then use "west flash" or "west debug" command to load the zephyr.bin
+image from the host computer and start the Zephyr application on A53 core0.
+
+Flash and Run
+-------------
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: imx8mn_evk/mimx8mn6/a53
+   :goals: flash
+
+Then the following log could be found on UART4 console:
+
+.. code-block:: console
+
+    *** Booting Zephyr OS build v4.1.0-3063-g38519ca2c028 ***
+    Hello World! imx8mn_evk/mimx8mn6/a53
+
+Debug
+-----
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: imx8mn_evk/mimx8mn6/a53
+   :goals: debug
+
+Option 2. Boot Zephyr by Using U-Boot Command
+=============================================
+
 U-Boot "cpu" command is used to load and kick Zephyr to Cortex-A secondary Core, Currently
 it has been supported in latest U-Boot version by `patch serials`_.
 
 .. _patch serials:
    https://patchwork.ozlabs.org/project/uboot/list/?series=417536&archive=both&state=*
 
-Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and
-plug the SD card into the board. Power it up and stop the u-boot execution at
-prompt.
+Step 1: Download Zephyr Image into DDR Memory
+---------------------------------------------
 
-Use U-Boot to load and kick zephyr.bin to Cortex-A53 Core0:
-
-.. code-block:: console
-
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; go 0x93c00000
-
-Or kick zephyr.bin to the other Cortex-A53 Core, for example Core2:
+Firstly need to download Zephyr binary image into DDR memory, it can use tftp:
 
 .. code-block:: console
 
-    fatload mmc 1:1 0x93c00000 zephyr.bin; dcache flush; icache flush; cpu 2 release 0x93c00000
+    tftp 0x93c00000 zephyr.bin
 
+Or copy the Zephyr image ``zephyr.bin`` SD card and plug the card into the board, for example
+if copy to the FAT partition of the SD card, use the following U-Boot command to load the image
+into DDR memory (assuming the SD card is dev 1, fat partition ID is 1, they could be changed
+based on actual setup):
+
+.. code-block:: console
+
+    fatload mmc 1:1 0x93c00000 zephyr.bin;
+
+Step 2: Boot Zephyr
+-------------------
+
+Then use the following command to boot Zephyr on the core0:
+
+.. code-block:: console
+
+    dcache off; icache flush; go 0x93c00000;
+
+Or use "cpu" command to boot from secondary Core, for example Core1:
+
+.. code-block:: console
+
+    dcache flush; icache flush; cpu 1 release 0x93c00000
 
 Use this configuration to run basic Zephyr applications and kernel tests,
 for example, with the :zephyr:code-sample:`synchronization` sample:
@@ -92,28 +152,19 @@ for example, with the :zephyr:code-sample:`synchronization` sample:
    :zephyr-app: samples/synchronization
    :host-os: unix
    :board: imx8mn_evk/mimx8mn6/a53
-   :goals: run
+   :goals: build
 
 This will build an image with the synchronization sample app, boot it and
 display the following ram console output:
 
 .. code-block:: console
 
-    *** Booting Zephyr OS build zephyr-v3.1.0-3575-g44dd713bd883  ***
-    thread_a: Hello World from cpu 0 on mimx8mn_evk_a53!
-    thread_b: Hello World from cpu 0 on mimx8mn_evk_a53!
-    thread_a: Hello World from cpu 0 on mimx8mn_evk_a53!
-    thread_b: Hello World from cpu 0 on mimx8mn_evk_a53!
-    thread_a: Hello World from cpu 0 on mimx8mn_evk_a53!
-
-Use Jailhouse hypervisor, after root cell linux is up:
-
-.. code-block:: console
-
-    #jailhouse enable imx8mn.cell
-    #jailhouse cell create imx8mn-zephyr.cell
-    #jailhouse cell load 1 zephyr.bin -a 0x93c00000
-    #jailhouse cell start 1
+    *** Booting Zephyr OS build v4.1.0-3063-g38519ca2c028 ***
+    thread_a: Hello World from cpu 0 on mimx8mn_evk!
+    thread_b: Hello World from cpu 0 on mimx8mn_evk!
+    thread_a: Hello World from cpu 0 on mimx8mn_evk!
+    thread_b: Hello World from cpu 0 on mimx8mn_evk!
+    thread_a: Hello World from cpu 0 on mimx8mn_evk!
 
 .. include:: ../../common/board-footer.rst
    :start-after: nxp-board-footer

--- a/boards/nxp/imx8mp_evk/board.cmake
+++ b/boards/nxp/imx8mp_evk/board.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -16,5 +16,11 @@ if(CONFIG_SOC_MIMX8ML8_M7)
   board_set_flasher_ifnset(jlink)
 
   board_runner_args(jlink "--device=MIMX8ML8_M7")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()
+
+if(CONFIG_SOC_MIMX8ML8_A53)
+  board_runner_args(jlink "--device=MIMX8ML8_A53_0" "--no-reset" "--flash-sram")
+
   include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 endif()

--- a/boards/nxp/imx91_evk/board.cmake
+++ b/boards/nxp/imx91_evk/board.cmake
@@ -1,0 +1,8 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=MIMX9131" "--no-reset" "--flash-sram")
+
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/nxp/imx91_evk/doc/index.rst
+++ b/boards/nxp/imx91_evk/doc/index.rst
@@ -72,6 +72,53 @@ CPU's UART1 for A55 core.
 Programming and Debugging
 *******************************
 
+.. zephyr:board-supported-runners::
+
+There are multiple methods to program and debug Zephyr
+
+Option 1. Boot Zephyr by Using JLink Runner
+===========================================
+
+The default runner for the board is JLink, connect the EVK board's JTAG connector to
+the host computer using a J-Link debugger, power up the board and stop the board at
+U-Boot command line.
+
+Then use "west flash" or "west debug" command to load the zephyr.bin
+image from the host computer and start the Zephyr application on A55 core0.
+
+Flash and Run
+-------------
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: imx91_evk/mimx9131
+   :goals: flash
+
+Then the following log could be found on UART1 console:
+
+.. code-block:: console
+
+
+    *** Booting Zephyr OS build v4.1.0-3063-g2c7ef313ac38 ***
+    Hello World! imx91_evk/mimx9131
+
+Debug
+-----
+
+Here is an example for the :zephyr:code-sample:`hello_world` application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: imx91_evk/mimx9131
+   :goals: debug
+
+Option 2. Boot Zephyr by Using U-Boot Command
+=============================================
+
 U-Boot "go" command is used to load and kick Zephyr to Cortex-A55 Core.
 
 Copy the compiled ``zephyr.bin`` to the first FAT partition of the SD card and


### PR DESCRIPTION
1. Added JLink runner for A-Core on imx91 imx8mm/n/p platforms
2. Updated board document for different booting and flash methods.