### PR TITLE
Bluetooth: Kconfig: Remove outdated references to bt_recv_prio()

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -87,8 +87,7 @@ config BT_RECV_WORKQ_SYS
 	bool "Process low priority HCI packets in the system work queue"
 	help
 	  When this option is selected, the host will process incoming low priority HCI packets
-	  in the system work queue. The HCI driver shall not call bt_recv_prio().
-	  High priority HCI packets will processed in the context of the caller of bt_recv().
+	  in the system work queue.
 	  The application needs to ensure the system workqueue stack size (SYSTEM_WORKQUEUE_STACK_SIZE)
 	  is large enough, refer to BT_RX_STACK_SIZE for the recommended minimum.
 	  Warning: Enabling this option will cause the latency of incoming Bluetooth events to be
@@ -102,8 +101,7 @@ config BT_RECV_WORKQ_BT
 	bool "Process low priority HCI packets in the bluetooth-specific work queue"
 	help
 	  When this option is selected, the host will process incoming low priority HCI packets
-	  in the bluetooth-specific work queue. The HCI driver shall not call bt_recv_prio().
-	  High priority HCI packets will processed in the context of the caller of bt_recv().
+	  in the Bluetooth-specific work queue.
 	  The application needs to ensure the bluetooth-specific work queue size is large enough,
 	  refer to BT_RX_STACK_SIZE for the recommended minimum.
 endchoice


### PR DESCRIPTION
The bt_recv() and bt_recv_prio() APIs don't exist anymore, so remove any references to them from the Kconfig help texts.