### PR TITLE
drivers: flash-nxp-s32-qspi: ignore flash operations with zero size

### DIFF
--- a/drivers/flash/flash_nxp_s32_qspi.c
+++ b/drivers/flash/flash_nxp_s32_qspi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -93,7 +93,11 @@ int nxp_s32_qspi_write(const struct device *dev, off_t offset, const void *src, 
 	size_t len;
 	int ret = 0;
 
-	if (!src || !size) {
+	if (!size) {
+		return 0;
+	}
+
+	if (!src) {
 		return -EINVAL;
 	}
 
@@ -187,7 +191,11 @@ int nxp_s32_qspi_erase(const struct device *dev, off_t offset, size_t size)
 	size_t erase_size;
 	int ret = 0;
 
-	if (!area_is_subregion(dev, offset, size) || !size) {
+	if (!size) {
+		return 0;
+	}
+
+	if (!area_is_subregion(dev, offset, size)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The current shim driver for flash-nxp-s32-qspi returns invalid error when handling write, erase operations with zero size.
This issue causes the failure of the tests/subsys/settings/fcb/.
Updated to ignore the flash operations with zero size instead of.
Fix #89181