### PR TITLE
boards: nordic: Replace SYS_INIT with board hooks

### DIFF
--- a/boards/nordic/nrf52840dongle/Kconfig
+++ b/boards/nordic/nrf52840dongle/Kconfig
@@ -3,7 +3,8 @@
 # Copyright (c) 2018-2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_NRF52840DONGLE
+config BOARD_NRF52840DONGLE
+	select BOARD_EARLY_INIT_HOOK
 
 config BOARD_HAS_NRF5_BOOTLOADER
 	bool "Board has nRF5 bootloader"
@@ -11,5 +12,3 @@ config BOARD_HAS_NRF5_BOOTLOADER
 	help
 	  If selected, applications are linked so that they can be loaded by Nordic
 	  nRF5 bootloader.
-
-endif # BOARD_NRF52840DONGLE

--- a/boards/nordic/nrf52840dongle/board.c
+++ b/boards/nordic/nrf52840dongle/board.c
@@ -7,10 +7,9 @@
 #include <zephyr/init.h>
 #include <hal/nrf_power.h>
 
-static int board_nrf52840dongle_nrf52840_init(void)
+void board_early_init_hook(void)
 {
-
-	/* if the nrf52840dongle_nrf52840 board is powered from USB
+	/* If the nrf52840dongle/nrf52840 board target is powered from USB
 	 * (high voltage mode), GPIO output voltage is set to 1.8 volts by
 	 * default and that is not enough to turn the green and blue LEDs on.
 	 * Increase GPIO voltage to 3.0 volts.
@@ -37,9 +36,4 @@ static int board_nrf52840dongle_nrf52840_init(void)
 		/* a reset is required for changes to take effect */
 		NVIC_SystemReset();
 	}
-
-	return 0;
 }
-
-SYS_INIT(board_nrf52840dongle_nrf52840_init, PRE_KERNEL_1,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/boards/nordic/nrf5340_audio_dk/Kconfig
+++ b/boards/nordic/nrf5340_audio_dk/Kconfig
@@ -1,0 +1,7 @@
+# nRF5340 Audio DK board configuration
+
+# Copyright (c) 2019 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NRF5340_AUDIO_DK
+	select BOARD_LATE_INIT_HOOK if BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP || BOARD_NRF5340_AUDIO_DK_NRF5340_CPUAPP_NS

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_config.c
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_config.c
@@ -11,7 +11,7 @@
 
 LOG_MODULE_REGISTER(nrf5340_audio_dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
-static int core_config(void)
+void board_late_init_hook(void)
 {
 	nrf_gpiote_latency_t latency;
 
@@ -21,8 +21,4 @@ static int core_config(void)
 		LOG_DBG("Setting gpiote latency to low power");
 		nrf_gpiote_latency_set(NRF_GPIOTE, NRF_GPIOTE_LATENCY_LOWPOWER);
 	}
-
-	return 0;
 }
-
-SYS_INIT(core_config, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/boards/nordic/nrf9160dk/Kconfig
+++ b/boards/nordic/nrf9160dk/Kconfig
@@ -8,6 +8,9 @@ config BOARD_NRF9160DK
 	# (board.c), so it is forced here to be enabled always, not only
 	# enabled by default (in defconfig).
 	select GPIO if BOARD_NRF9160DK_NRF52840
+	select BOARD_EARLY_INIT_HOOK if BOARD_NRF9160DK_NRF52840 && \
+					$(dt_nodelabel_exists,external_flash_pins_routing)
+	select BOARD_LATE_INIT_HOOK if BOARD_NRF9160DK_NRF52840
 
 if BOARD_NRF9160DK_NRF52840
 

--- a/boards/nordic/nrf9160dk/board.c
+++ b/boards/nordic/nrf9160dk/board.c
@@ -160,7 +160,7 @@ static int reset_pin_configure(void)
 }
 #endif /* USE_RESET_GPIO */
 
-static int init(void)
+void board_late_init_hook(void)
 {
 	int rc;
 
@@ -170,7 +170,7 @@ static int init(void)
 
 		if (!device_is_ready(cfg->gpio)) {
 			LOG_ERR("%s is not ready", cfg->gpio->name);
-			return -ENODEV;
+			return;
 		}
 
 		flags |= (cfg->on ? GPIO_OUTPUT_ACTIVE
@@ -188,7 +188,7 @@ static int init(void)
 		}
 #endif
 		if (rc) {
-			return rc;
+			return;
 		}
 	}
 
@@ -201,21 +201,17 @@ static int init(void)
 	rc = reset_pin_configure();
 	if (rc) {
 		LOG_ERR("Unable to configure reset pin, err %d", rc);
-		return -EIO;
+		return;
 	}
 #endif
 
 	LOG_INF("Board configured.");
-
-	return 0;
 }
 
-SYS_INIT(init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
-
 #define EXT_MEM_CTRL DT_NODELABEL(external_flash_pins_routing)
-#if DT_NODE_EXISTS(EXT_MEM_CTRL)
 
-static int early_init(void)
+#if DT_NODE_EXISTS(EXT_MEM_CTRL)
+void board_early_init_hook(void)
 {
 	/* As soon as possible after the system starts up, enable the analog
 	 * switch that routes signals to the external flash. Otherwise, the
@@ -234,9 +230,5 @@ static int early_init(void)
 		nrf_gpio_pin_set(psel);
 	}
 	nrf_gpio_cfg_output(psel);
-
-	return 0;
 }
-
-SYS_INIT(early_init, PRE_KERNEL_1, 0);
 #endif


### PR DESCRIPTION
Updates to use board hooks since SYS_INIT should not be used in boards