### PR TITLE
dts: bindings: npm1300-charger: make vbus-limit-microamp required

### DIFF
--- a/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
+++ b/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
@@ -147,8 +147,7 @@ static const struct linear_range charger_current_range = LINEAR_RANGE_INIT(32000
 static const uint16_t discharge_limits[] = {84U, 415U};
 
 /* Linear range for vbusin current limit */
-static const struct linear_range vbus_current_ranges[] = {
-	LINEAR_RANGE_INIT(100000, 0, 1U, 1U), LINEAR_RANGE_INIT(500000, 100000, 5U, 15U)};
+static const struct linear_range vbus_current_range = LINEAR_RANGE_INIT(100000, 100000, 1U, 15U);
 
 static void calc_temp(const struct npm1300_charger_config *const config, uint16_t code,
 		      struct sensor_value *valp)
@@ -478,9 +477,7 @@ static int npm1300_charger_attr_set(const struct device *dev, enum sensor_channe
 		int32_t current = (val->val1 * 1000000) + val->val2;
 		uint16_t idx;
 
-		ret = linear_range_group_get_win_index(vbus_current_ranges,
-						       ARRAY_SIZE(vbus_current_ranges), current,
-						       current, &idx);
+		ret = linear_range_get_win_index(&vbus_current_range, current, current, &idx);
 
 		if (ret == -EINVAL) {
 			return ret;
@@ -573,9 +570,8 @@ int npm1300_charger_init(const struct device *dev)
 	}
 
 	/* Configure vbus current limit */
-	ret = linear_range_group_get_win_index(vbus_current_ranges, ARRAY_SIZE(vbus_current_ranges),
-					       config->vbus_limit_microamp,
-					       config->vbus_limit_microamp, &idx);
+	ret = linear_range_get_win_index(&vbus_current_range, config->vbus_limit_microamp,
+					 config->vbus_limit_microamp, &idx);
 	if (ret == -EINVAL) {
 		return ret;
 	}

--- a/dts/bindings/sensor/nordic,npm1300-charger.yaml
+++ b/dts/bindings/sensor/nordic,npm1300-charger.yaml
@@ -45,10 +45,10 @@ properties:
 
   vbus-limit-microamp:
     type: int
+    required: true
     description: |
       Vbus current limit in uA.
-      Available values are 100 mA, or between 500 mA and 1500 mA in 100 mA steps.
-      If omitted, the default value of 100 mA will be used.
+      Available range is 100 mA to 1500 mA in 100 mA steps.
 
   thermistor-ohms:
     type: int


### PR DESCRIPTION
Make the vbus-limit-microamp property of npm1300-charger required and change its range to reflect the one actually supported by the device.