### PR TITLE
tests: remove unused variables

### DIFF
--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -14,12 +14,6 @@ enum units { UNIT_ticks, UNIT_cyc, UNIT_ms, UNIT_us, UNIT_ns };
 
 enum round { ROUND_floor, ROUND_ceil, ROUND_near };
 
-static const char *const round_s[] = {
-	[ROUND_floor] = "floor",
-	[ROUND_ceil] = "ceil",
-	[ROUND_near] = "near",
-};
-
 struct test_rec {
 	enum units src;
 	enum units dst;
@@ -287,8 +281,8 @@ static void test_conversion(struct test_rec *t, uint64_t val)
 	zassert_true(diff <= maxdiff && diff >= mindiff,
 		     "Convert %llu (%llx) from %u Hz to %u Hz %u-bit %s\n"
 		     "result %llu (%llx) diff %lld (%llx) should be in [%lld:%lld]",
-		     val, val, from_hz, to_hz, t->precision, round_s[t->round],
-		     result, result, diff, diff, mindiff, maxdiff);
+		     val, val, from_hz, to_hz, t->precision, t->round, result, result, diff, diff,
+		     mindiff, maxdiff);
 }
 
 ZTEST(timer_api, test_time_conversions)

--- a/tests/subsys/logging/log_syst/src/mock_backend.c
+++ b/tests/subsys/logging/log_syst/src/mock_backend.c
@@ -66,7 +66,6 @@ void validate_msg(const char *type, const char *optional_flags,
 	const char *raw_data_str = "SYS-T RAW DATA: ";
 	const char *output_str = test_output_buf;
 	const char *syst_format_headers[4] = {type, optional_flags, module_id, sub_type};
-	const char *syst_headers_name[4] = {"type", "optional_flags", "module_id", "sub_type"};
 
 	/* Validate "SYS-T RAW DATA: " prefix in the output_str */
 	zassert_mem_equal(raw_data_str, output_str, strlen(raw_data_str),
@@ -77,8 +76,7 @@ void validate_msg(const char *type, const char *optional_flags,
 	/* Validate the headers in the SYS-T data format */
 	for (int i = 0; i < ARRAY_SIZE(syst_format_headers); i++) {
 		zassert_mem_equal(output_str, syst_format_headers[i],
-				  strlen(syst_format_headers[i]),
-				  "Incorrect Comparison of %s", syst_headers_name[i]);
+				  strlen(syst_format_headers[i]), "Incorrect header comparison");
 
 		output_str = output_str+2;
 	}


### PR DESCRIPTION
Commit " [78b1ad9](https://github.com/zephyrproject-rtos/zephyr/commit/78b1ad9a73750462bfff779df2356660aa400c3b) Re-enable -Wunused-variable for clang. " restores checking for unused variables, which revealed an unused variables in the code.
The unused variable has been removed.