### PR TITLE
modules/hal_st: Align to stmemsc HAL i/f v2.9.1

### DIFF
--- a/drivers/sensor/st/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/st/lps22hh/lps22hh_trigger.c
@@ -31,7 +31,7 @@ static int lps22hh_enable_int(const struct device *dev, int enable)
 	/* set interrupt */
 	lps22hh_pin_int_route_get(ctx, &int_route);
 	int_route.drdy_pres = enable;
-	return lps22hh_pin_int_route_set(ctx, &int_route);
+	return lps22hh_pin_int_route_set(ctx, int_route);
 }
 
 /**

--- a/west.yml
+++ b/west.yml
@@ -238,7 +238,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 05fd4533730a9aea845261c5d24ed9832a6f0b6e
+      revision: 9f81b4427e955885398805b7bca0da3a8cd9109c
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Align all sensor drivers that are using stmemsc (STdC) HAL i/f to new APIs of stmemsc v2.9.1.

Requires https://github.com/zephyrproject-rtos/hal_st/pull/25
