### PR TITLE
arch: arm: enable pxn support at arch level

### DIFF
--- a/arch/arm/core/mpu/Kconfig
+++ b/arch/arm/core/mpu/Kconfig
@@ -71,6 +71,7 @@ config CUSTOM_SECTION_MIN_ALIGN_SIZE
 
 config ARM_MPU_PXN
 	bool
+	default y
 	depends on ARMV8_1_M_MAINLINE
 	help
 	  Enable support for Armv8.1-m MPU's Privileged Execute Never (PXN) attr.

--- a/soc/arm/mps3/Kconfig
+++ b/soc/arm/mps3/Kconfig
@@ -15,7 +15,6 @@ config SOC_MPS3_CORSTONE300
 	select ARMV8_1_M_MVEI
 	select ARMV8_1_M_MVEF
 	select ARMV8_1_M_PMU
-	select ARM_MPU_PXN if ARM_MPU
 
 config SOC_MPS3_CORSTONE310
 	select CPU_CORTEX_M85
@@ -26,7 +25,6 @@ config SOC_MPS3_CORSTONE310
 	select ARMV8_1_M_MVEI
 	select ARMV8_1_M_MVEF
 	select ARMV8_1_M_PMU
-	select ARM_MPU_PXN if ARM_MPU
 
 config ARMV8_1_M_PMU_EVENTCNT
 	int


### PR DESCRIPTION
Move PXN support selection to arch so that it is enabled for all Armv8.1-m socs.