### PR TITLE
drivers: dp: add STM32 support

### DIFF
--- a/drivers/dp/swdp_ll_pin.h
+++ b/drivers/dp/swdp_ll_pin.h
@@ -8,18 +8,6 @@
 #include <zephyr/drivers/gpio.h>
 #include <soc.h>
 
-#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
-#define CPU_CLOCK		64000000U
-#else
-#define CPU_CLOCK		CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
-#endif
-
-#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
-#define FAST_BITBANG_HW_SUPPORT 1
-#else
-#define FAST_BITBANG_HW_SUPPORT 0
-#endif
-
 static ALWAYS_INLINE void pin_delay_asm(uint32_t delay)
 {
 #if defined(CONFIG_CPU_CORTEX_M)
@@ -36,50 +24,43 @@ static ALWAYS_INLINE void pin_delay_asm(uint32_t delay)
 #endif
 }
 
+#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
+
+#include "swdp_ll_pin_nrf.h"
+
+#else
+
+#define CPU_CLOCK CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
+#define FAST_BITBANG_HW_SUPPORT 0
+
 static ALWAYS_INLINE void swdp_ll_pin_input(void *const base, uint8_t pin)
 {
-#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
-	NRF_GPIO_Type * reg = base;
-
-	reg->PIN_CNF[pin] = 0b0000;
-#endif
 }
 
 static ALWAYS_INLINE void swdp_ll_pin_output(void *const base, uint8_t pin)
 {
-#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
-	NRF_GPIO_Type * reg = base;
-
-	reg->PIN_CNF[pin] = 0b0001;
-#endif
 }
 
 
 static ALWAYS_INLINE void swdp_ll_pin_set(void *const base, uint8_t pin)
 {
-#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
-	NRF_GPIO_Type * reg = base;
-
-	reg->OUTSET = BIT(pin);
-#endif
 }
 
 static ALWAYS_INLINE void swdp_ll_pin_clr(void *const base, uint8_t pin)
 {
-#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
-	NRF_GPIO_Type * reg = base;
-
-	reg->OUTCLR = BIT(pin);
-#endif
 }
 
 static ALWAYS_INLINE uint32_t swdp_ll_pin_get(void *const base, uint8_t pin)
 {
-#if defined(CONFIG_SOC_SERIES_NRF52X) || defined(CONFIG_SOC_SERIES_NRF53X)
-	NRF_GPIO_Type * reg = base;
-
-	return ((reg->IN >> pin) & 1);
-#else
 	return 0UL;
-#endif
 }
+
+#endif
+
+#ifndef CPU_CLOCK
+#error "CPU_CLOCK not defined by any soc specific driver"
+#endif
+
+#ifndef FAST_BITBANG_HW_SUPPORT
+#error "FAST_BITBANG_HW_SUPPORT not defined by any soc specific driver"
+#endif

--- a/drivers/dp/swdp_ll_pin.h
+++ b/drivers/dp/swdp_ll_pin.h
@@ -28,6 +28,10 @@ static ALWAYS_INLINE void pin_delay_asm(uint32_t delay)
 
 #include "swdp_ll_pin_nrf.h"
 
+#elif defined(CONFIG_SOC_FAMILY_STM32)
+
+#include "swdp_ll_pin_stm32.h"
+
 #else
 
 #define CPU_CLOCK CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/drivers/dp/swdp_ll_pin_nrf.h
+++ b/drivers/dp/swdp_ll_pin_nrf.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define CPU_CLOCK 64000000U
+#define FAST_BITBANG_HW_SUPPORT 1
+
+static ALWAYS_INLINE void swdp_ll_pin_input(void *const base, uint8_t pin)
+{
+	NRF_GPIO_Type *reg = base;
+
+	reg->PIN_CNF[pin] = 0b0000;
+}
+
+static ALWAYS_INLINE void swdp_ll_pin_output(void *const base, uint8_t pin)
+{
+	NRF_GPIO_Type *reg = base;
+
+	reg->PIN_CNF[pin] = 0b0001;
+}
+
+static ALWAYS_INLINE void swdp_ll_pin_set(void *const base, uint8_t pin)
+{
+	NRF_GPIO_Type *reg = base;
+
+	reg->OUTSET = BIT(pin);
+}
+
+static ALWAYS_INLINE void swdp_ll_pin_clr(void *const base, uint8_t pin)
+{
+	NRF_GPIO_Type *reg = base;
+
+	reg->OUTCLR = BIT(pin);
+}
+
+static ALWAYS_INLINE uint32_t swdp_ll_pin_get(void *const base, uint8_t pin)
+{
+	NRF_GPIO_Type *reg = base;
+
+	return ((reg->IN >> pin) & 1);
+}

--- a/drivers/dp/swdp_ll_pin_stm32.h
+++ b/drivers/dp/swdp_ll_pin_stm32.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stm32_ll_gpio.h>
+#include "stm32_hsem.h"
+
+#define CPU_CLOCK CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC
+#define FAST_BITBANG_HW_SUPPORT 1
+
+static ALWAYS_INLINE void swdp_ll_pin_input(void *const base, uint8_t pin)
+{
+	GPIO_TypeDef *gpio = base;
+
+	z_stm32_hsem_lock(CFG_HW_GPIO_SEMID, HSEM_LOCK_DEFAULT_RETRY);
+
+	LL_GPIO_SetPinMode(gpio, BIT(pin), LL_GPIO_MODE_INPUT);
+
+	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);
+}
+
+static ALWAYS_INLINE void swdp_ll_pin_output(void *const base, uint8_t pin)
+{
+	GPIO_TypeDef *gpio = base;
+
+	z_stm32_hsem_lock(CFG_HW_GPIO_SEMID, HSEM_LOCK_DEFAULT_RETRY);
+
+	LL_GPIO_SetPinMode(gpio, BIT(pin), LL_GPIO_MODE_OUTPUT);
+
+	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);
+}
+
+static ALWAYS_INLINE void swdp_ll_pin_set(void *const base, uint8_t pin)
+{
+	GPIO_TypeDef *gpio = base;
+	uint32_t val;
+
+	z_stm32_hsem_lock(CFG_HW_GPIO_SEMID, HSEM_LOCK_DEFAULT_RETRY);
+
+	val = LL_GPIO_ReadOutputPort(gpio);
+	val |= BIT(pin);
+	LL_GPIO_WriteOutputPort(gpio, val);
+
+	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);
+}
+
+static ALWAYS_INLINE void swdp_ll_pin_clr(void *const base, uint8_t pin)
+{
+	GPIO_TypeDef *gpio = base;
+	uint32_t val;
+
+	z_stm32_hsem_lock(CFG_HW_GPIO_SEMID, HSEM_LOCK_DEFAULT_RETRY);
+
+	val = LL_GPIO_ReadOutputPort(gpio);
+	val &= ~BIT(pin);
+	LL_GPIO_WriteOutputPort(gpio, val);
+
+	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);
+}
+
+static ALWAYS_INLINE uint32_t swdp_ll_pin_get(void *const base, uint8_t pin)
+{
+	GPIO_TypeDef *gpio = base;
+
+	return (LL_GPIO_ReadInputPort(gpio) >> pin) & 1;
+}


### PR DESCRIPTION
Add support for direct control of STM32 gpios to the DP driver.

---

Tested on an  F3 and on an H7, should work on all of them.