### PR TITLE
ethernet: phy: add dt prop for default speed

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -97,6 +97,9 @@ Devicetree
   superfamily. Therefore, any dts files for boards that use Series 2 SoCs will need to change their
   include from ``#include <silabs/some_soc.dtsi>`` to ``#include <silabs/xg2[1-9]/some_soc.dtsi>``.
 
+* The :c:macro:`DT_ENUM_HAS_VALUE` and :c:macro:`DT_INST_ENUM_HAS_VALUE` macros are now
+  checking all values, when used on an array, not just the first one.
+
 DAI
 ===
 

--- a/dts/bindings/ethernet/phy/ethernet-phy.yaml
+++ b/dts/bindings/ethernet/phy/ethernet-phy.yaml
@@ -26,3 +26,15 @@ properties:
       - "100BASE-T Full-Duplex"
       - "1000BASE-T Half-Duplex"
       - "1000BASE-T Full-Duplex"
+  default-speeds:
+    type: string-array
+    description: The selected speeds are used to configure the PHY during initialization
+    enum:
+      - "10BASE Half-Duplex"
+      - "10BASE Full-Duplex"
+      - "100BASE Half-Duplex"
+      - "100BASE Full-Duplex"
+      - "1000BASE Half-Duplex"
+      - "1000BASE Full-Duplex"
+    default: ["10BASE Half-Duplex", "10BASE Full-Duplex", "100BASE Half-Duplex",
+              "100BASE Full-Duplex", "1000BASE Half-Duplex", "1000BASE Full-Duplex"]

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -1045,14 +1045,14 @@
 	IS_ENABLED(DT_CAT8(node_id, _P_, prop, _IDX_, idx, _ENUM_VAL_, value, _EXISTS))
 
 /**
- * @brief Equivalent to DT_ENUM_HAS_VALUE_BY_IDX(node_id, prop, 0, value).
+ * @brief Does a node enumeration property have a given value?
  * @param node_id node identifier
  * @param prop lowercase-and-underscores property name
  * @param value lowercase-and-underscores enumeration value
  * @return 1 if the node property has the value @a value, 0 otherwise.
  */
 #define DT_ENUM_HAS_VALUE(node_id, prop, value) \
-	DT_ENUM_HAS_VALUE_BY_IDX(node_id, prop, 0, value)
+	IS_ENABLED(DT_CAT6(node_id, _P_, prop, _ENUM_VAL_, value, _EXISTS))
 
 /**
  * @brief Get a string property's value as a token.

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -686,6 +686,8 @@ def enum_macros(prop: edtlib.Property, macro: str):
         ret[f"{macro}_IDX_{i}_EXISTS"] = 1
         # DT_N_<node-id>_P_<prop-id>_IDX_<i>_ENUM_VAL_<val>_EXISTS 1
         ret[f"{macro}_IDX_{i}_ENUM_VAL_{subval}_EXISTS"] = 1
+        # DT_N_<node-id>_P_<prop-id>_ENUM_VAL_<val>_EXISTS 1
+        ret[f"{macro}_ENUM_VAL_{subval}_EXISTS"] = 1
 
     return ret
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2193,6 +2193,12 @@ ZTEST(devicetree_api, test_enums)
 	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 2, bar));
 	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_string_array), val, 2, zoo));
 
+	/* DT_ENUM_HAS_VALUE on string-array enum */
+	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_string_array), val, foo));
+	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_string_array), val, zoo));
+	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_string_array), val, foo));
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_string_array), val, baz));
+
 	/* DT_ENUM_IDX_BY_IDX and DT_ENUM_HAS_VALUE_BY_IDX on int-array enum */
 	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 0), 3);
 	zassert_equal(DT_ENUM_IDX_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 1), 4);
@@ -2210,6 +2216,16 @@ ZTEST(devicetree_api, test_enums)
 	zassert_true(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 3, 0));
 	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 3, 2));
 	zassert_false(DT_ENUM_HAS_VALUE_BY_IDX(DT_NODELABEL(test_enum_int_array), val, 3, 1));
+
+	/* DT_ENUM_HAS_VALUE on int-array enum */
+	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 0));
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 1));
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 2));
+	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 3));
+	zassert_true(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 4));
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 5));
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 6));
+	zassert_false(DT_ENUM_HAS_VALUE(DT_NODELABEL(test_enum_int_array), val, 7));
 }
 #undef TO_MY_ENUM
 #undef TO_MY_ENUM_2


### PR DESCRIPTION
add dt prop for default speeds, that the phy is
configured on init by default.

Contains:  https://github.com/zephyrproject-rtos/zephyr/pull/88411 (all commits before drivers: ethernet: phy: add dt prop for default speeds)
