### PR TITLE
doc: shields: nrf7002xx: fix section headers hierarchy

### DIFF
--- a/boards/shields/nrf7002eb/doc/index.rst
+++ b/boards/shields/nrf7002eb/doc/index.rst
@@ -44,7 +44,7 @@ Usage
 The shield can be used in any application by setting ``--shield nrf7002eb`` when invoking ``west build``.
 
 Shield Variants
-###############
+***************
 
 The nRF7002 EB has a variant which includes the COEX pins. These pins are not be routed to the
 edge-connector on some boards, like earlier revisions of the Thingy53 than v1.0.0.
@@ -53,7 +53,7 @@ edge-connector on some boards, like earlier revisions of the Thingy53 than v1.0.
 - ``nrf7002eb_coex``: Variant which includes the COEX pins.
 
 SR Co-existence
-###############
+***************
 
 The nRF7002 EB supports SR co-existence provided the host board supports it. The SR co-existence
 pins are connected to the host board's GPIO pins.

--- a/boards/shields/nrf7002ek/doc/index.rst
+++ b/boards/shields/nrf7002ek/doc/index.rst
@@ -44,7 +44,7 @@ Usage
 The shield can be used in any application by setting ``--shield nrf7002ek`` when invoking ``west build``.
 
 SR Co-existence
-###############
+***************
 
 The nRF7002 EK supports SR co-existence provided the host board supports it. The SR co-existence
 pins are connected to the host board's GPIO pins. The interface is selected by setting
@@ -56,7 +56,7 @@ Two Kconfig options are available to enable SR co-existence:
 - :kconfig:option:`CONFIG_NRF70_SR_COEX_RF_SWITCH`: Control SR side RF switch.
 
 Shield Variants
-###############
+***************
 
 The nRF7002 EK is available in four variants:
 


### PR DESCRIPTION
Fixed the headings hierarchy as there were multiple `###` headings when only one should be used as the document's title.

<img width="282" alt="image" src="https://github.com/user-attachments/assets/e52670fd-56cc-482a-9dac-77ab0d5680d3" />
