### PR TITLE
Bluetooth: ISO: fix hci_le_set_cig_params validation

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -2192,7 +2192,7 @@ int bt_iso_cig_create(const struct bt_iso_cig_param *param, struct bt_iso_cig **
 
 	cig_rsp = (void *)rsp->data;
 
-	if (rsp->len < sizeof(cig_rsp) || cig_rsp->num_handles != param->num_cis) {
+	if (rsp->len < sizeof(*cig_rsp) || cig_rsp->num_handles != param->num_cis) {
 		LOG_WRN("Unexpected response to hci_le_set_cig_params");
 		err = -EIO;
 		net_buf_unref(rsp);


### PR DESCRIPTION
Sizeof of a pointer doesn't make sense here, and e.g. on native_sim/native/64 this would fail.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
