### PR TITLE
drivers: allow disabling gpio interrupt in ifx-cat1 gpio driver

### DIFF
--- a/drivers/gpio/gpio_ifx_cat1.c
+++ b/drivers/gpio/gpio_ifx_cat1.c
@@ -203,7 +203,7 @@ static int gpio_cat1_pin_interrupt_configure(const struct device *dev, gpio_pin_
 		break;
 
 	default:
-		return -ENOTSUP;
+		break;
 	}
 
 	Cy_GPIO_SetInterruptEdge(base, pin, trig_pdl);


### PR DESCRIPTION
	- allow GPIO_INT_MODE_DISABLED in interrupt_configure function