### PR TITLE
pm: Cleanup PM stats

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -209,15 +209,22 @@ bool pm_system_suspend(int32_t kernel_ticks)
 	 * sent the notification in pm_system_resume().
 	 */
 	k_sched_lock();
-	pm_stats_start();
+
+	if (IS_ENABLED(CONFIG_PM_STATS)) {
+		pm_stats_start();
+	}
 	/* Enter power state */
 	pm_state_notify(true);
 	atomic_set_bit(z_post_ops_required, id);
 	pm_state_set(z_cpus_pm_state[id]->state, z_cpus_pm_state[id]->substate_id);
-	pm_stats_stop();
 
 	/* Wake up sequence starts here */
-	pm_stats_update(z_cpus_pm_state[id]->state);
+
+	if (IS_ENABLED(CONFIG_PM_STATS)) {
+		pm_stats_stop();
+		pm_stats_update(z_cpus_pm_state[id]->state);
+	}
+
 	pm_system_resume();
 	k_sched_unlock();
 	SYS_PORT_TRACING_FUNC_EXIT(pm, system_suspend, ticks,

--- a/subsys/pm/pm_stats.h
+++ b/subsys/pm/pm_stats.h
@@ -10,14 +10,8 @@
 
 #include <zephyr/pm/state.h>
 
-#ifdef CONFIG_PM_STATS
 void pm_stats_start(void);
 void pm_stats_stop(void);
 void pm_stats_update(enum pm_state state);
-#else
-static inline void pm_stats_start(void) {}
-static inline void pm_stats_stop(void) {}
-static inline void pm_stats_update(enum pm_state state) {}
-#endif /* CONFIG_PM_STATS */
 
 #endif /* ZEPHYR_SUBSYS_PM_PM_STATS_H_ */


### PR DESCRIPTION
Convert PM stats code to use IS_ENABLED in place of #ifdefs.

Note, this also fixes a corner case that triggers a NULL reference when building the PM tests with `CONFIG_PM_STATS=n` and coverage enabled. 

See https://github.com/zephyrproject-rtos/zephyr/issues/89228