### PR TITLE
Support gPTP sync with PI control and fix i.MXRT1060 support

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -296,7 +296,11 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 
 #ifdef CONFIG_PTP_CLOCK_NXP_ENET
 	case IMX_CCM_ENET_PLL:
+#if defined(CONFIG_SOC_SERIES_IMXRT10XX)
+		*rate = CLOCK_GetPllFreq(kCLOCK_PllEnet25M);
+#else
 		*rate = CLOCK_GetPllFreq(kCLOCK_PllEnet);
+#endif
 		break;
 #endif
 

--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -179,8 +179,7 @@ void nxp_enet_ptp_clock_callback(const struct device *dev,
 
 		ENET_Ptp1588SetChannelMode(data->base, kENET_PtpTimerChannel3,
 				kENET_PtpChannelPulseHighonCompare, true);
-		ENET_Ptp1588Configure(data->base, data->enet_handle,
-				      &ptp_config);
+		ENET_Ptp1588StartTimer(data->base, ptp_config.ptp1588ClockSrc_Hz);
 	}
 }
 

--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -29,7 +29,6 @@ struct ptp_clock_nxp_enet_config {
 
 struct ptp_clock_nxp_enet_data {
 	ENET_Type *base;
-	double clock_ratio;
 	enet_handle_t *enet_handle;
 	struct k_mutex ptp_mutex;
 };
@@ -110,16 +109,11 @@ static int ptp_clock_nxp_enet_rate_adjust(const struct device *dev,
 		return 0;
 	}
 
-	ratio *= data->clock_ratio;
-
 	/* Limit possible ratio. */
 	if ((ratio > 1.0 + 1.0/(2 * hw_inc)) ||
 			(ratio < 1.0 - 1.0/(2 * hw_inc))) {
 		return -EINVAL;
 	}
-
-	/* Save new ratio. */
-	data->clock_ratio = ratio;
 
 	if (ratio < 1.0) {
 		corr = hw_inc - 1;
@@ -177,7 +171,6 @@ void nxp_enet_ptp_clock_callback(const struct device *dev,
 		/* only for ERRATA_2579 */
 		ptp_config.channel = kENET_PtpTimerChannel3;
 		ptp_config.ptp1588ClockSrc_Hz = enet_ref_pll_rate;
-		data->clock_ratio = 1.0;
 
 		/* Share the mutex with mac driver */
 		ptp_data->ptp_mutex = &data->ptp_mutex;

--- a/include/zephyr/drivers/ethernet/eth_nxp_enet.h
+++ b/include/zephyr/drivers/ethernet/eth_nxp_enet.h
@@ -40,6 +40,12 @@ enum nxp_enet_driver {
 	NXP_ENET_PTP_CLOCK,
 };
 
+struct nxp_enet_ptp_data {
+	struct k_sem ptp_ts_sem;
+	struct k_mutex *ptp_mutex; /* created in PTP driver */
+	void *enet; /* enet_handle poiniter used by PTP driver */
+};
+
 extern void nxp_enet_mdio_callback(const struct device *mdio_dev,
 		enum nxp_enet_callback_reason event,
 		void *data);

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -211,4 +211,10 @@ config NET_GPTP_STATISTICS
 	  Enable this if you need to collect gPTP statistics. The statistics
 	  can be seen in net-shell if needed.
 
+config NET_GPTP_MONITOR_SYNC_STATUS
+	bool "Monitor real-time synchronization status"
+	help
+	  Monitor real-time synchronization status, like synchronization offset,
+	  frequency offset and so on. This will print continuous messages.
+
 endif # NET_GPTP

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -35,6 +35,7 @@ K_FIFO_DEFINE(gptp_rx_queue);
 static k_tid_t tid;
 static struct k_thread gptp_thread_data;
 struct gptp_domain gptp_domain;
+struct gptp_clock_data gptp_clock;
 
 int gptp_get_port_number(struct net_if *iface)
 {
@@ -911,6 +912,18 @@ int gptp_get_port_data(struct gptp_domain *domain,
 	return 0;
 }
 
+double gptp_servo_pi(int64_t nanosecond_diff)
+{
+	double kp = 0.7;
+	double ki = 0.3;
+	double ppb;
+
+	gptp_clock.pi_drift += ki * nanosecond_diff;
+	ppb = kp * nanosecond_diff + gptp_clock.pi_drift;
+
+	return ppb;
+}
+
 static void init_ports(void)
 {
 	net_if_foreach(gptp_add_port, &gptp_domain.default_ds.nb_ports);
@@ -928,6 +941,9 @@ static void init_ports(void)
 void net_gptp_init(void)
 {
 	gptp_domain.default_ds.nb_ports = 0U;
+
+	gptp_clock.domain = &gptp_domain;
+	gptp_clock.pi_drift = 0.0;
 
 	init_ports();
 }

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -786,14 +786,12 @@ static void gptp_update_local_port_clock(void)
 		nanosecond_diff = -(int64_t)NSEC_PER_SEC + nanosecond_diff;
 	}
 
-	ptp_clock_rate_adjust(clk, port_ds->neighbor_rate_ratio);
-
 	/* If time difference is too high, set the clock value.
 	 * Otherwise, adjust it.
 	 */
 	if (second_diff || (second_diff == 0 &&
-			    (nanosecond_diff < -5000 ||
-			     nanosecond_diff > 5000))) {
+			    (nanosecond_diff < -50000000 ||
+			     nanosecond_diff > 50000000))) {
 		bool underflow = false;
 
 		key = irq_lock();
@@ -822,28 +820,22 @@ static void gptp_update_local_port_clock(void)
 			tm.second++;
 			tm.nanosecond -= NSEC_PER_SEC;
 		}
-
-		/* This prints too much data normally but can be enabled to see
-		 * what time we are setting to the local clock.
-		 */
-		if (0) {
-			NET_INFO("Set local clock %lu.%lu",
-				 (unsigned long int)tm.second,
-				 (unsigned long int)tm.nanosecond);
+		if (IS_ENABLED(CONFIG_NET_GPTP_MONITOR_SYNC_STATUS)) {
+			NET_INFO("Set local clock %"PRIu64".%09u", tm.second, tm.nanosecond);
 		}
-
 		ptp_clock_set(clk, &tm);
 
 	skip_clock_set:
 		irq_unlock(key);
 	} else {
-		if (nanosecond_diff < -200) {
-			nanosecond_diff = -200;
-		} else if (nanosecond_diff > 200) {
-			nanosecond_diff = 200;
-		}
+		double ppb = gptp_servo_pi(nanosecond_diff);
 
-		ptp_clock_adjust(clk, nanosecond_diff);
+		ptp_clock_rate_adjust(clk, 1.0 + (ppb / 1000000000.0));
+
+		if (IS_ENABLED(CONFIG_NET_GPTP_MONITOR_SYNC_STATUS)) {
+			NET_INFO("sync offset %9"PRId64" ns, freq offset %f ppb",
+				 nanosecond_diff, ppb);
+		}
 	}
 }
 #endif /* CONFIG_NET_GPTP_USE_DEFAULT_CLOCK_UPDATE */

--- a/subsys/net/l2/ethernet/gptp/gptp_private.h
+++ b/subsys/net/l2/ethernet/gptp/gptp_private.h
@@ -31,6 +31,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief gPTP clock data.
+ */
+struct gptp_clock_data {
+	/** gptp_domain pointer */
+	struct gptp_domain *domain;
+	/** pi control drift value */
+	double pi_drift;
+};
+
+extern struct gptp_clock_data gptp_clock;
+
+/**
  * @brief Is a slave acting as a slave.
  *
  * Utility to check if a port is configured as a slave.
@@ -116,6 +128,15 @@ static inline uint64_t gptp_timestamp_to_nsec(struct net_ptp_time *ts)
 
 	return (ts->second * NSEC_PER_SEC) + ts->nanosecond;
 }
+
+/**
+ * @brief gPTP PI servo.
+ *
+ * @param nanosecond_diff nanosecond offset.
+ *
+ * @return ppb value to adjust.
+ */
+double gptp_servo_pi(int64_t nanosecond_diff);
 
 /**
  * @brief Change the port state


### PR DESCRIPTION
I'm just starting to look at zephyr gPTP with a i.MXRT1060 EVK board on hand.
It looks like there are many problems in both drivers and gPTP stack.
So, I basically fixed key issues in ENET MAC/PTP drivers for RT1060. Also added a simple PI control algorithm to support continuous frequency adjustment in gPTP stack.

Finally the sync offset convergence on RT1060 was as below log. It's stable at about 100ns sync offset. (RT1060 PTP clock nominal frequency is 25M, 40ns period)

```
[00:00:02.822,000] <inf> phy_mc_ksz8081: PHY 0 is up
[00:00:02.822,000] <inf> phy_mc_ksz8081: PHY (0) Link speed 100 Mb, full duplex

[00:00:02.823,000] <inf> eth_nxp_enet_mac: Link is up
*** Booting Zephyr OS build v4.1.0-3062-g764340614802 ***
[00:00:02.826,000] <inf> net_config: Initializing network
[00:00:02.826,000] <inf> net_config: IPv4 address: 192.0.2.1
[00:00:02.928,000] <inf> net_config: IPv6 address: 2001:db8::1
[00:00:03.830,000] <wrn> net_gptp: Reset Pdelay requests
[00:00:05.268,000] <dbg> net_gptp_sample: gptp_phase_dis_cb: GM FA:FA:62:FF:FE:FE:A2:11 last phase 0.0
[00:00:06.893,000] <inf> net_gptp: sync offset   -117781 ns, freq offset -117781.000000 ppb
[00:00:07.894,000] <inf> net_gptp: sync offset    -73643 ns, freq offset -108977.300000 ppb
[00:00:08.894,000] <inf> net_gptp: sync offset    -37936 ns, freq offset -95363.200000 ppb
[00:00:09.894,000] <inf> net_gptp: sync offset    -15866 ns, freq offset -84674.000000 ppb
[00:00:10.895,000] <inf> net_gptp: sync offset     -4318 ns, freq offset -77885.800000 ppb
[00:00:11.895,000] <inf> net_gptp: sync offset       564 ns, freq offset -74299.200000 ppb
[00:00:12.895,000] <inf> net_gptp: sync offset      1731 ns, freq offset -72963.000000 ppb
[00:00:13.895,000] <inf> net_gptp: sync offset      1687 ns, freq offset -72487.700000 ppb
[00:00:14.896,000] <inf> net_gptp: sync offset      1098 ns, freq offset -72570.600000 ppb
[00:00:15.896,000] <inf> net_gptp: sync offset       540 ns, freq offset -72799.200000 ppb
[00:00:16.896,000] <inf> net_gptp: sync offset       181 ns, freq offset -72996.200000 ppb
[00:00:17.896,000] <inf> net_gptp: sync offset       127 ns, freq offset -72995.900000 ppb
[00:00:18.896,000] <inf> net_gptp: sync offset       -50 ns, freq offset -73134.800000 ppb
[00:00:19.897,000] <inf> net_gptp: sync offset        59 ns, freq offset -73040.800000 ppb
[00:00:20.897,000] <inf> net_gptp: sync offset       -39 ns, freq offset -73121.100000 ppb
[00:00:21.897,000] <inf> net_gptp: sync offset        41 ns, freq offset -73052.800000 ppb
[00:00:22.897,000] <inf> net_gptp: sync offset       -89 ns, freq offset -73170.500000 ppb
[00:00:23.897,000] <inf> net_gptp: sync offset        62 ns, freq offset -73046.200000 ppb
[00:00:24.897,000] <inf> net_gptp: sync offset       -64 ns, freq offset -73153.600000 ppb
[00:00:25.898,000] <inf> net_gptp: sync offset       -27 ns, freq offset -73135.800000 ppb
[00:00:26.898,000] <inf> net_gptp: sync offset        50 ns, freq offset -73066.900000 ppb
[00:00:27.898,000] <inf> net_gptp: sync offset        -3 ns, freq offset -73104.900000 ppb
[00:00:28.899,000] <inf> net_gptp: sync offset        66 ns, freq offset -73036.800000 ppb
[00:00:29.899,000] <inf> net_gptp: sync offset       -63 ns, freq offset -73146.000000 ppb
[00:00:30.899,000] <inf> net_gptp: sync offset       -28 ns, freq offset -73129.900000 ppb
[00:00:31.900,000] <inf> net_gptp: sync offset       132 ns, freq offset -72978.300000 ppb
[00:00:32.900,000] <inf> net_gptp: sync offset        -7 ns, freq offset -73077.700000 ppb
[00:00:33.900,000] <inf> net_gptp: sync offset      -139 ns, freq offset -73211.800000 ppb
[00:00:34.901,000] <inf> net_gptp: sync offset       -58 ns, freq offset -73172.500000 ppb
[00:00:35.901,000] <inf> net_gptp: sync offset         1 ns, freq offset -73130.900000 ppb
[00:00:36.901,000] <inf> net_gptp: sync offset        82 ns, freq offset -73049.600000 ppb
[00:00:37.901,000] <inf> net_gptp: sync offset        -4 ns, freq offset -73111.000000 ppb
[00:00:38.902,000] <inf> net_gptp: sync offset       109 ns, freq offset -72999.200000 ppb

```

Thanks.