### PR TITLE
lora: two minor updates

### DIFF
--- a/boards/shields/semtech_sx1262mb2das/semtech_sx1262mb2das.overlay
+++ b/boards/shields/semtech_sx1262mb2das/semtech_sx1262mb2das.overlay
@@ -17,7 +17,7 @@
 	lora_semtech_sx1262mb2das: sx1262@0 {
 		compatible = "semtech,sx1262";
 		reg = <0>;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 		label = "SX1262";
 		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_LOW>;
 		busy-gpios = <&arduino_header 9 GPIO_ACTIVE_HIGH>;

--- a/samples/drivers/lora/receive/README.rst
+++ b/samples/drivers/lora/receive/README.rst
@@ -39,45 +39,45 @@ Sample Output
    [00:00:00.235,000] <inf> lora_receive: Synchronous reception
    [00:00:00.956,000] <inf> lora_receive: LoRa RX RSSI: -60dBm, SNR: 7dB
    [00:00:00.956,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 30             |hellowor ld 0
    [00:00:02.249,000] <inf> lora_receive: LoRa RX RSSI: -57dBm, SNR: 9dB
    [00:00:02.249,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 31             |hellowor ld 1
    [00:00:03.541,000] <inf> lora_receive: LoRa RX RSSI: -57dBm, SNR: 9dB
    [00:00:03.541,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 32             |hellowor ld 2
    [00:00:04.834,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:04.834,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 33             |hellowor ld 3
    [00:00:04.834,000] <inf> lora_receive: Asynchronous reception
    [00:00:06.127,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:06.127,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 34             |hellowor ld 4
    [00:00:07.419,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:07.419,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 35             |hellowor ld 5
    [00:00:08.712,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:08.712,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 36             |hellowor ld 6
    [00:00:10.004,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:10.004,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 37             |hellowor ld 7
    [00:00:11.297,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:11.297,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 38             |hellowor ld 8
    [00:00:12.590,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:12.590,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 39             |hellowor ld 9
    [00:00:13.884,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:13.884,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 30             |hellowor ld 0
    [00:00:15.177,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:15.177,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 31             |hellowor ld 1
    [00:00:16.470,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:16.470,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 32             |hellowor ld 2
    [00:00:17.762,000] <inf> lora_receive: LoRa RX RSSI: -55dBm, SNR: 9dB
    [00:00:17.762,000] <inf> lora_receive: LoRa RX payload
-                                          68 65 6c 6c 6f 77 6f 72  6c 64                   |hellowor ld
+                                          68 65 6c 6c 6f 77 6f 72  6c 64 20 33             |hellowor ld 3
    [00:00:17.762,000] <inf> lora_receive: Stopping packet receptions

--- a/samples/drivers/lora/send/README.rst
+++ b/samples/drivers/lora/send/README.rst
@@ -32,6 +32,6 @@ Sample Output
 
 .. code-block:: console
 
-    [00:00:00.531,000] <inf> lora_send: Data sent!
-    [00:00:01.828,000] <inf> lora_send: Data sent!
-    [00:00:03.125,000] <inf> lora_send: Data sent!
+    [00:00:00.531,000] <inf> lora_send: Data sent 0!
+    [00:00:01.828,000] <inf> lora_send: Data sent 1!
+    [00:00:03.125,000] <inf> lora_send: Data sent 2!

--- a/samples/drivers/lora/send/sample.yaml
+++ b/samples/drivers/lora/send/sample.yaml
@@ -10,6 +10,6 @@ tests:
     harness_config:
       type: one_line
       regex:
-        - "<inf> lora_send: Data sent!"
+        - "<inf> lora_send: Data sent 0!"
     integration_platforms:
       - b_l072z_lrwan1

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -14,13 +14,13 @@
 BUILD_ASSERT(DT_NODE_HAS_STATUS_OKAY(DEFAULT_RADIO_NODE),
 	     "No default LoRa radio specified in DT");
 
-#define MAX_DATA_LEN 10
+#define MAX_DATA_LEN 12
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lora_send);
 
-char data[MAX_DATA_LEN] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
+char data[MAX_DATA_LEN] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd', ' ', '0'};
 
 int main(void)
 {
@@ -56,10 +56,17 @@ int main(void)
 			return 0;
 		}
 
-		LOG_INF("Data sent!");
+		LOG_INF("Data sent %c!", data[MAX_DATA_LEN - 1]);
 
 		/* Send data at 1s interval */
 		k_sleep(K_MSEC(1000));
+
+		/* Increment final character to differentiate packets */
+		if (data[MAX_DATA_LEN - 1] == '9') {
+			data[MAX_DATA_LEN - 1] = '0';
+		} else {
+			data[MAX_DATA_LEN - 1] += 1;
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
Add a counter to the `send` sample so that receivers can validate they aren't just receiving the previous payload multiple times.

Reduce the bus frequency for one of the LoRa shields to resolve errors seen while testing.