### PR TITLE
bluetooth: host: Fix premature semaphore giving

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -601,8 +601,6 @@ static void hci_num_completed_packets(struct net_buf *buf)
 		while (count--) {
 			sys_snode_t *node;
 
-			k_sem_give(bt_conn_get_pkts(conn));
-
 			/* move the next TX context from the `pending` list to
 			 * the `complete` list.
 			 */
@@ -613,6 +611,8 @@ static void hci_num_completed_packets(struct net_buf *buf)
 				__ASSERT_NO_MSG(0);
 				break;
 			}
+
+			k_sem_give(bt_conn_get_pkts(conn));
 
 			sys_slist_append(&conn->tx_complete, node);
 


### PR DESCRIPTION
There was a semaphore in hci_core which was given to early when receiving the BT_HCI_EVT_NUM_COMPLETED_PACKETS message from the controller.