### PR TITLE
Fix regulator voltage test case run failure on nxp boards

### DIFF
--- a/drivers/regulator/regulator_pca9420.c
+++ b/drivers/regulator/regulator_pca9420.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 NXP
+ * Copyright (c) 2021, 2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -157,7 +157,7 @@ static const struct linear_range buck2_ranges[] = {
 };
 
 static const struct linear_range ldo1_ranges[] = {
-	LINEAR_RANGE_INIT(1700000, 25000U, 0x0U, 0x9U),
+	LINEAR_RANGE_INIT(1700000, 25000U, 0x0U, 0x8U),
 	LINEAR_RANGE_INIT(1900000, 0U, 0x9U, 0xFU),
 };
 

--- a/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S3x_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, 2024 NXP
+ * Copyright 2022, 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -477,6 +477,9 @@
 		#nxp,reference-cells = <1>;
 		nxp,buffer-startup-delay-us = <400>;
 		nxp,bandgap-startup-time-us = <20>;
+		nxp,current-compensation-en;
+		nxp,internal-voltage-regulator-en;
+		nxp,chop-oscillator-en;
 	};
 };
 

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -713,6 +713,9 @@
 		#nxp,reference-cells = <1>;
 		nxp,buffer-startup-delay-us = <400>;
 		nxp,bandgap-startup-time-us = <20>;
+		nxp,current-compensation-en;
+		nxp,internal-voltage-regulator-en;
+		nxp,chop-oscillator-en;
 		regulator-min-microvolt = <1000000>;
 		regulator-max-microvolt = <2100000>;
 	};

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -826,6 +826,9 @@
 		reg = <0x111000 0x14>;
 		status = "disabled";
 		#nxp,reference-cells = <1>;
+		nxp,current-compensation-en;
+		nxp,internal-voltage-regulator-en;
+		nxp,chop-oscillator-en;
 		nxp,buffer-startup-delay-us = <400>;
 		nxp,bandgap-startup-time-us = <20>;
 		regulator-min-microvolt = <1000000>;

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -367,6 +367,8 @@
 		regulator-min-microvolt = <1000000>;
 		regulator-max-microvolt = <2100000>;
 		nxp,current-compensation-en;
+		nxp,internal-voltage-regulator-en;
+		nxp,chop-oscillator-en;
 		status = "disabled";
 	};
 

--- a/dts/bindings/regulator/nxp,vref.yaml
+++ b/dts/bindings/regulator/nxp,vref.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 NXP
+# Copyright 2023-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP VREF SOC peripheral
@@ -40,6 +40,19 @@ properties:
       Enable second-order curvature compensation.
       This must be enabled to achieve the performance stated in the datasheet.
       However, the reset value of the peripheral has it disabled.
+
+  nxp,internal-voltage-regulator-en:
+    type: boolean
+    description: |
+      Enables the internal regulator to produce a constant internal voltage
+      supply to reduce the sensitivity to external supply noise and variation.
+
+  nxp,chop-oscillator-en:
+    type: boolean
+    description: |
+      Enables the chop oscillator. When set, the internal chopping operation
+      is enabled and the internal analog offset is minimized. When using the
+      internal voltage regulator, you must also enable the chop oscillator.
 
   "#nxp,reference-cells":
     type: int

--- a/include/zephyr/dt-bindings/regulator/nxp_vref.h
+++ b/include/zephyr/dt-bindings/regulator/nxp_vref.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,7 +20,6 @@
 #define NXP_VREF_MODE_STANDBY 0
 #define NXP_VREF_MODE_LOW_POWER 1
 #define NXP_VREF_MODE_HIGH_POWER 2
-#define NXP_VREF_MODE_INTERNAL_REGULATOR 3
 
 /** @} */
 

--- a/tests/drivers/regulator/voltage/boards/frdm_mcxn236.overlay
+++ b/tests/drivers/regulator/voltage/boards/frdm_mcxn236.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,13 +7,11 @@
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
-/* To do this test, connect LPADC0 channel 2A(J8 pin 12) to VREF_OUT (J2 pin 19) */
-
 / {
 	resources: resources {
 		compatible = "test-regulator-voltage";
 		regulators = <&vref>;
-		tolerance-microvolt = <10000>;
+		tolerance-microvolt = <20000>;
 		set-read-delay-ms = <1>;
 		adc-avg-count = <10>;
 		io-channels = <&lpadc0 0>;
@@ -23,7 +21,7 @@
 };
 
 &vref {
-	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {
@@ -31,7 +29,8 @@
 	#size-cells = <0>;
 
 	/* In this case, the LPADC reference source cannot be set to VREFO,
-	 * switch the reference source to VDD_ANA.
+	 * switch the reference source to VDD_ANA. The user needs to measure the
+	 * voltage of VDD_ANA pin to set the value of 'zephyr,vref-mv'.
 	 */
 	voltage-ref= <2>;
 
@@ -39,9 +38,13 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
-		zephyr,vref-mv = <3300>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		/* VDD_ANA is not accurate to 3300mV, after measurement,
+		 * the actual voltage is 3285mV.
+		 */
+		zephyr,vref-mv = <3285>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 7)>;
 		zephyr,resolution = <12>;
-		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+		/* ADC0 channel 7 A-side is internally connected to VREFO. */
+		zephyr,input-positive = <MCUX_LPADC_CH7A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/regulator/voltage/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,13 +7,11 @@
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
-/* To do this test, connect LPADC0 channel 2A(J8 pin 28) to VREF_OUT (TP1) */
-
 / {
 	resources: resources {
 		compatible = "test-regulator-voltage";
 		regulators = <&vref>;
-		tolerance-microvolt = <10000>;
+		tolerance-microvolt = <30000>;
 		set-read-delay-ms = <1>;
 		adc-avg-count = <10>;
 		io-channels = <&lpadc0 0>;
@@ -23,7 +21,7 @@
 };
 
 &vref {
-	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {
@@ -31,7 +29,8 @@
 	#size-cells = <0>;
 
 	/* In this case, the LPADC reference source cannot be set to VREFO,
-	 * switch the reference source to VDD_ANA.
+	 * switch the reference source to VDD_ANA. The user needs to measure the
+	 * voltage of VDD_ANA pin to set the value of 'zephyr,vref-mv'.
 	 */
 	voltage-ref= <2>;
 
@@ -39,9 +38,13 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
-		zephyr,vref-mv = <3300>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		/* VDD_ANA is not accurate to 3300mV, after measurement,
+		 * the actual voltage is 3285mV.
+		 */
+		zephyr,vref-mv = <3285>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 7)>;
 		zephyr,resolution = <12>;
-		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+		/* ADC0 channel 7 A-side is internally connected to VREFO. */
+		zephyr,input-positive = <MCUX_LPADC_CH7A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
+++ b/tests/drivers/regulator/voltage/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,13 +7,11 @@
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
-/* To do this test, connect LPADC0 channel 2A(J8 pin 28) to VREF_OUT (TP1) */
-
 / {
 	resources: resources {
 		compatible = "test-regulator-voltage";
 		regulators = <&vref>;
-		tolerance-microvolt = <10000>;
+		tolerance-microvolt = <30000>;
 		set-read-delay-ms = <1>;
 		adc-avg-count = <10>;
 		io-channels = <&lpadc0 0>;
@@ -23,7 +21,7 @@
 };
 
 &vref {
-	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {
@@ -31,7 +29,8 @@
 	#size-cells = <0>;
 
 	/* In this case, the LPADC reference source cannot be set to VREFO,
-	 * switch the reference source to VDD_ANA.
+	 * switch the reference source to VDD_ANA. The user needs to measure the
+	 * voltage of VDD_ANA pin to set the value of 'zephyr,vref-mv'.
 	 */
 	voltage-ref= <2>;
 
@@ -39,9 +38,13 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
-		zephyr,vref-mv = <3300>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		/* VDD_ANA is not accurate to 3300mV, after measurement,
+		 * the actual voltage is 3285mV.
+		 */
+		zephyr,vref-mv = <3285>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 7)>;
 		zephyr,resolution = <12>;
-		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+		/* ADC0 channel 7 A-side is internally connected to VREFO. */
+		zephyr,input-positive = <MCUX_LPADC_CH7A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/boards/frdm_mcxw71.overlay
+++ b/tests/drivers/regulator/voltage/boards/frdm_mcxw71.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,13 +7,11 @@
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
-/* To do this test, connect LPADC0 channel 6A(J4 pin 5) to VREF_OUT (J2 pin 3) */
-
 / {
 	resources: resources {
 		compatible = "test-regulator-voltage";
 		regulators = <&vref>;
-		tolerance-microvolt = <40000>;
+		tolerance-microvolt = <20000>;
 		set-read-delay-ms = <1>;
 		adc-avg-count = <10>;
 		io-channels = <&adc0 0>;
@@ -23,7 +21,7 @@
 };
 
 &vref {
-	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &adc0 {
@@ -31,7 +29,8 @@
 	#size-cells = <0>;
 
 	/* In this case, the LPADC reference source cannot be set to VREFO,
-	 * switch the reference source to VDD_ANA.
+	 * switch the reference source to VDD_ANA. The user needs to measure the
+	 * voltage of VDD_ANA pin to set the value of 'zephyr,vref-mv'.
 	 */
 	voltage-ref= <0>;
 
@@ -39,10 +38,13 @@
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
-		zephyr,vref-mv = <3300>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		/* VDD_ANA is not accurate to 3300mV, after measurement,
+		 * the actual voltage is 3285mV.
+		 */
+		zephyr,vref-mv = <3285>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 7)>;
 		zephyr,resolution = <12>;
-		/* the signal name is ADC0_A6 but it is still channel 2 */
-		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+		/* ADC0 channel 23 A-side is internally connected to VREFO. */
+		zephyr,input-positive = <MCUX_LPADC_CH23A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/boards/lpcxpresso55s36.overlay
+++ b/tests/drivers/regulator/voltage/boards/lpcxpresso55s36.overlay
@@ -1,39 +1,49 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
-/* To do this test, connect AN (J7-1) to VREF_OUT (J12-16) */
-
 / {
 	resources: resources {
 		compatible = "test-regulator-voltage";
 		regulators = <&vref0>;
-		tolerance-microvolt = <1000000>;
+		tolerance-microvolt = <20000>;
 		set-read-delay-ms = <10>;
 		adc-avg-count = <10>;
 		io-channels = <&adc0 0>;
+		min-microvolt = <1000000>;
+		max-microvolt = <2100000>;
 	};
 };
 
 &vref0 {
-	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &adc0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	/* In this case, the LPADC reference source cannot be set to VREFO,
+	 * switch the reference source to VDDA. The user needs to measure the
+	 * voltage of VDDA pin to set the value of 'zephyr,vref-mv'.
+	 */
+	voltage-ref= <2>;
+
 	channel@0 {
 		reg = <0>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
-		zephyr,vref-mv = <1800>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		/* VDDA is not accurate to 3300mV, after measurement,
+		 * the actual voltage is 3285mV.
+		 */
+		zephyr,vref-mv = <3285>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 7)>;
 		zephyr,resolution = <12>;
-		zephyr,input-positive = <MCUX_LPADC_CH0A>;
+		/* ADC0 channel 5 A-side is internally connected to VREFO. */
+		zephyr,input-positive = <MCUX_LPADC_CH5A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
+++ b/tests/drivers/regulator/voltage/boards/mcx_n9xx_evk_mcxn947_cpu0.overlay
@@ -7,13 +7,11 @@
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
-/* To do this test, connect LPADC0 channel 2A(J20 pin 28) to VREF_OUT (JP28-1) */
-
 / {
 	resources: resources {
 		compatible = "test-regulator-voltage";
 		regulators = <&vref>;
-		tolerance-microvolt = <10000>;
+		tolerance-microvolt = <20000>;
 		set-read-delay-ms = <1>;
 		adc-avg-count = <10>;
 		io-channels = <&lpadc0 0>;
@@ -23,7 +21,7 @@
 };
 
 &vref {
-	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {
@@ -31,7 +29,8 @@
 	#size-cells = <0>;
 
 	/* In this case, the LPADC reference source cannot be set to VREFO,
-	 * switch the reference source to VDD_ANA.
+	 * switch the reference source to VDD_ANA. The user needs to measure the
+	 * voltage of VDD_ANA pin to set the value of 'zephyr,vref-mv'.
 	 */
 	voltage-ref= <2>;
 
@@ -40,8 +39,9 @@
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,vref-mv = <3300>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 7)>;
 		zephyr,resolution = <12>;
-		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+		/* ADC0 channel 7 A-side is internally connected to VREFO. */
+		zephyr,input-positive = <MCUX_LPADC_CH7A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
+++ b/tests/drivers/regulator/voltage/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
@@ -7,13 +7,11 @@
 #include <zephyr/dt-bindings/adc/mcux-lpadc.h>
 #include <zephyr/dt-bindings/regulator/nxp_vref.h>
 
-/* To do this test, connect LPADC0 channel 2A(J20 pin 28) to VREF_OUT (JP28-1) */
-
 / {
 	resources: resources {
 		compatible = "test-regulator-voltage";
 		regulators = <&vref>;
-		tolerance-microvolt = <10000>;
+		tolerance-microvolt = <20000>;
 		set-read-delay-ms = <1>;
 		adc-avg-count = <10>;
 		io-channels = <&lpadc0 0>;
@@ -23,7 +21,7 @@
 };
 
 &vref {
-	regulator-initial-mode = <NXP_VREF_MODE_INTERNAL_REGULATOR>;
+	regulator-initial-mode = <NXP_VREF_MODE_HIGH_POWER>;
 };
 
 &lpadc0 {
@@ -31,7 +29,8 @@
 	#size-cells = <0>;
 
 	/* In this case, the LPADC reference source cannot be set to VREFO,
-	 * switch the reference source to VDD_ANA.
+	 * switch the reference source to VDD_ANA. The user needs to measure the
+	 * voltage of VDD_ANA pin to set the value of 'zephyr,vref-mv'.
 	 */
 	voltage-ref= <2>;
 
@@ -40,8 +39,9 @@
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_EXTERNAL0";
 		zephyr,vref-mv = <3300>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 7)>;
 		zephyr,resolution = <12>;
-		zephyr,input-positive = <MCUX_LPADC_CH2A>;
+		/* ADC0 channel 7 A-side is internally connected to VREFO. */
+		zephyr,input-positive = <MCUX_LPADC_CH7A>;
 	};
 };

--- a/tests/drivers/regulator/voltage/testcase.yaml
+++ b/tests/drivers/regulator/voltage/testcase.yaml
@@ -21,6 +21,8 @@ tests:
       - lpcxpresso55s36
       - frdm_mcxn947/mcxn947/cpu0
       - mcx_n9xx_evk/mcxn947/cpu0
+      - frdm_mcxn236
+      - frdm_mcxw71
     harness_config:
       fixture: gpio_loopback
   drivers.regulator.voltage.rpi_pico_vreg:


### PR DESCRIPTION
Main changes:
1. Add new boolean type `nxp,high-performance-en` property for `nxp,vref`. The user can use this property to improve the stability and accuracy of the VREF output voltage.
2. Remove the code that sets the UTRIM register to 0 in nxp VREF driver, because UTRIM is automatically loaded with a factory-trimmed value. Zeroing will affect the accuracy.
3. VREF does not have `NXP_VREF_MODE_INTERNAL_REGULATOR` mode, the internal voltage regulator and chop oscillator are used to suppress power supply noise and reduce voltage offset, so remove the NXP_VREF_MODE_INTERNAL_REGULATOR mode. there are only three modes in VREF, the first is the standby mode (`CSR[BUF21EN] = 0, CSR[HI_PWR_LV] = X`), the second is low power mode (`CSR[BUF21EN] = 1, CSR[HI_PWR_LV] = 0`), and the third is high power mode (`CSR[BUF21EN] = 1, CSR[HI_PWR_LV] = 1`). 

fixed https://github.com/zephyrproject-rtos/zephyr/issues/88826