### PR TITLE
drivers: hwinfo: litex: add warning and infos

### DIFF
--- a/drivers/hwinfo/CMakeLists.txt
+++ b/drivers/hwinfo/CMakeLists.txt
@@ -37,3 +37,9 @@ zephyr_library_sources_ifdef(CONFIG_HWINFO_SILABS_S2   hwinfo_silabs_series2.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_SMARTBOND   hwinfo_smartbond.c)
 zephyr_library_sources_ifdef(CONFIG_HWINFO_STM32       hwinfo_stm32.c)
 # zephyr-keep-sorted-stop
+
+if (CONFIG_HWINFO_LITEX)
+  message(WARNING "
+    Warning: CONFIG_HWINFO_LITEX does not return a unique device id. It is shared
+    across all devices with the same bitstream.")
+endif()

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -191,7 +191,9 @@ config HWINFO_LITEX
 	depends on DT_HAS_LITEX_DNA0_ENABLED
 	select HWINFO_HAS_DRIVER
 	help
-	  Enable LiteX hwinfo driver
+	  Enable LiteX hwinfo driver. It does not return a unique device id. It is shared
+	  across all devices with the same bitstream. See litex/soc/cores/identifier.py in the
+	  LiteX repository for more information.
 
 config HWINFO_PSOC6
 	bool "Cypress PSOC 6 unique device ID"


### PR DESCRIPTION
adds warning and info about the LiteX hwinfo
driver, that the returned device id is not unique.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>