### PR TITLE
STM32H7S78-DK: add support for XSPI PSRAM

### DIFF
--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -183,6 +183,7 @@ Default Zephyr Peripheral Mapping:
 - LD4 (blue) : PM3
 - ADC1 channel 6 input : PF12
 - USB OTG FS DM/DP : PM12/PM11
+- XSPI1 NCS/DQS0/DQS1/CLK/IO: PO0/PO2/PO3/PO4/PP0..15
 
 System Clock
 ------------

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -21,6 +21,13 @@
 		zephyr,sram = &sram0;
 	};
 
+	psram: memory@90000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x90000000 DT_SIZE_M(32)>;
+		zephyr,memory-region = "PSRAM";
+		zephyr,memory-attr = <DT_MEM_ARM_MPU_RAM>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		green_led: led_1 {
@@ -171,6 +178,33 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
+};
+
+&xspi1 {
+	pinctrl-0 = <&xspim_p1_ncs1_po0 &xspim_p1_dqs0_po2
+		     &xspim_p1_dqs1_po3 &xspim_p1_clk_po4
+		     &xspim_p1_io0_pp0 &xspim_p1_io1_pp1 &xspim_p1_io2_pp2
+		     &xspim_p1_io3_pp3 &xspim_p1_io4_pp4 &xspim_p1_io5_pp5
+		     &xspim_p1_io6_pp6 &xspim_p1_io7_pp7 &xspim_p1_io8_pp8
+		     &xspim_p1_io9_pp9 &xspim_p1_io10_pp10 &xspim_p1_io11_pp11
+		     &xspim_p1_io12_pp12 &xspim_p1_io13_pp13 &xspim_p1_io14_pp14
+		     &xspim_p1_io15_pp15>;
+
+	pinctrl-names = "default";
+	status = "okay";
+
+	memc: aps256xxn-obr@0 {
+		compatible = "st,stm32-xspi-psram";
+		reg = <0>;
+		size = <DT_SIZE_M(256)>; /* 256 Mbits */
+		max-frequency = <DT_FREQ_M(200)>;
+		fixed-latency;
+		io-x16-mode;
+		read-latency = <4>;
+		write-latency = <1>;
+		burst-length = <0>;
+		status = "okay";
+	};
 };
 
 &die_temp {

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.yaml
@@ -15,4 +15,5 @@ supported:
   - adc
   - usb_device
   - usbd
+  - memc
 vendor: st

--- a/drivers/memc/memc_stm32_xspi_psram.c
+++ b/drivers/memc/memc_stm32_xspi_psram.c
@@ -206,7 +206,6 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 	const struct memc_stm32_xspi_psram_config *dev_cfg = dev->config;
 	struct memc_stm32_xspi_psram_data *dev_data = dev->data;
 	XSPI_HandleTypeDef hxspi = dev_data->hxspi;
-	XSPI_TypeDef *xspi = hxspi.Instance;
 	uint32_t ahb_clock_freq;
 	XSPIM_CfgTypeDef cfg = {0};
 	XSPI_RegularCmdTypeDef cmd = {0};
@@ -332,14 +331,21 @@ static int memc_stm32_xspi_psram_init(const struct device *dev)
 	}
 
 	mem_mapped_cfg.TimeOutActivation = HAL_XSPI_TIMEOUT_COUNTER_DISABLE;
+
+#if defined(XSPI_CR_NOPREF)
 	mem_mapped_cfg.NoPrefetchData = HAL_XSPI_AUTOMATIC_PREFETCH_ENABLE;
+#endif
+#if defined(XSPI_CR_NOPREF_AXI)
 	mem_mapped_cfg.NoPrefetchAXI = HAL_XSPI_AXI_PREFETCH_DISABLE;
+#endif
 
 	if (HAL_XSPI_MemoryMapped(&hxspi, &mem_mapped_cfg) != HAL_OK) {
 		return -EIO;
 	}
 
-	MODIFY_REG(xspi->CR, XSPI_CR_NOPREF, HAL_XSPI_AUTOMATIC_PREFETCH_DISABLE);
+#if defined(XSPI_CR_NOPREF)
+	MODIFY_REG(hxspi.Instance->CR, XSPI_CR_NOPREF, HAL_XSPI_AUTOMATIC_PREFETCH_DISABLE);
+#endif
 
 	return 0;
 }

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -492,6 +492,28 @@
 			status = "disabled";
 		};
 
+		xspi1: spi@52005000 {
+			compatible = "st,stm32-xspi";
+			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
+			interrupts = <105 0>;
+			clock-names = "xspix";
+			clocks = <&rcc STM32_CLOCK(AHB5, 5U)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		xspi2: spi@5200a000 {
+			compatible = "st,stm32-xspi";
+			reg = <0x5200a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
+			interrupts = <106 0>;
+			clock-names = "xspix";
+			clocks = <&rcc STM32_CLOCK(AHB5, 12U)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
 		iwdg: iwdg1: watchdog@58004800 {
 			compatible = "st,stm32-watchdog";
 			reg = <0x58004800 0x400>;


### PR DESCRIPTION
Add support for the PSRAM chip on board of the STM32H7S78-DK development kit.

Also include the 2 following needed changes:

- Add XSPI bus definitions on the stm32h7rs
- Fix STM32 XSPI PSRAM driver for SoCs where prefetch options are not available
