### PR TITLE
net: core: Rework l3 handling

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -103,6 +103,10 @@ Deprecated APIs and options
   deprecated, because support for anonymous authentication had been removed from the
   hawkBit server in version 0.8.0.
 
+* :kconfig:option:`NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE` Kconfig option has been
+   deprecated. All frames are now forwarded by default, and the option is no longer
+   needed.
+
 New APIs and options
 ====================
 
@@ -160,6 +164,10 @@ New APIs and options
   * :c:func:`display_clear`
 
 * Networking:
+
+  * Core
+
+    * All packets are passed through l3 handlers.
 
   * IPv4
 

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -168,6 +168,8 @@ New APIs and options
   * Core
 
     * All packets are passed through l3 handlers.
+    * Add new ``loopback`` flag for packets which are directly passed back
+      with :c:func:`net_pkt_is_loopback` and :c:func:`net_pkt_set_loopback`.
 
   * IPv4
 

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -119,7 +119,7 @@ struct net_pkt {
 	/** Allow placing the packet into sys_slist_t */
 	sys_snode_t next;
 #endif
-#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_ETHERNET_BRIDGE)
+#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_L2_VIRTUAL)
 	struct net_if *orig_iface; /* Original network interface */
 #endif
 

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -244,6 +244,8 @@ struct net_pkt {
 	uint8_t tx_timestamping : 1; /** Timestamp transmitted packet */
 	uint8_t rx_timestamping : 1; /** Timestamp received packet */
 #endif
+	uint8_t loopback: 1; /** Set to 1 if this packet is a loopback packet */
+
 	/* bitfield byte alignment boundary */
 
 #if defined(CONFIG_NET_IP)
@@ -405,7 +407,7 @@ static inline void net_pkt_set_iface(struct net_pkt *pkt, struct net_if *iface)
 
 static inline struct net_if *net_pkt_orig_iface(struct net_pkt *pkt)
 {
-#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_ETHERNET_BRIDGE)
+#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_L2_VIRTUAL)
 	return pkt->orig_iface;
 #else
 	return pkt->iface;
@@ -415,7 +417,7 @@ static inline struct net_if *net_pkt_orig_iface(struct net_pkt *pkt)
 static inline void net_pkt_set_orig_iface(struct net_pkt *pkt,
 					  struct net_if *iface)
 {
-#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_ETHERNET_BRIDGE)
+#if defined(CONFIG_NET_ROUTING) || defined(CONFIG_NET_L2_VIRTUAL)
 	pkt->orig_iface = iface;
 #else
 	ARG_UNUSED(pkt);
@@ -573,6 +575,16 @@ static inline void net_pkt_set_chksum_done(struct net_pkt *pkt,
 					   bool is_chksum_done)
 {
 	pkt->chksum_done = is_chksum_done;
+}
+
+static inline void net_pkt_set_loopback(struct net_pkt *pkt, bool loopback)
+{
+	pkt->loopback = loopback;
+}
+
+static inline bool net_pkt_is_loopback(struct net_pkt *pkt)
+{
+	return pkt->loopback;
 }
 
 static inline uint8_t net_pkt_ip_hdr_len(struct net_pkt *pkt)

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -146,22 +146,7 @@ l3_process:
 
 	uint8_t family = net_pkt_family(pkt);
 
-	if (IS_ENABLED(CONFIG_NET_IP) && (family == AF_INET || family == AF_INET6 ||
-					  family == AF_UNSPEC || family == AF_PACKET)) {
-		/* IP version and header length. */
-		uint8_t vtc_vhl = NET_IPV6_HDR(pkt)->vtc & 0xf0;
-
-		if (IS_ENABLED(CONFIG_NET_IPV6) && vtc_vhl == 0x60) {
-			return net_ipv6_input(pkt, net_pkt_is_loopback(pkt));
-		} else if (IS_ENABLED(CONFIG_NET_IPV4) && vtc_vhl == 0x40) {
-			return net_ipv4_input(pkt, net_pkt_is_loopback(pkt));
-		}
-
-		NET_DBG("Unknown IP family packet (0x%x)", NET_IPV6_HDR(pkt)->vtc & 0xf0);
-		net_stats_update_ip_errors_protoerr(net_pkt_iface(pkt));
-		net_stats_update_ip_errors_vhlerr(net_pkt_iface(pkt));
-		return NET_DROP;
-	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && family == AF_CAN) {
+	if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && family == AF_CAN) {
 		return net_canbus_socket_input(pkt);
 	}
 

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -64,8 +64,7 @@ LOG_MODULE_REGISTER(net_core, CONFIG_NET_CORE_LOG_LEVEL);
 #include "net_stats.h"
 
 #if defined(CONFIG_NET_NATIVE)
-static inline enum net_verdict process_data(struct net_pkt *pkt,
-					    bool is_loopback)
+static inline enum net_verdict process_data(struct net_pkt *pkt)
 {
 	int ret;
 
@@ -87,7 +86,7 @@ static inline enum net_verdict process_data(struct net_pkt *pkt,
 	/* If the packet is routed back to us via loopback or is an IPv4/IPv6 reassembled
 	 * packet then it can be processed by the l3 directly.
 	 */
-	if (is_loopback || net_pkt_is_ip_reassembled(pkt)) {
+	if (net_pkt_is_loopback(pkt) || net_pkt_is_ip_reassembled(pkt)) {
 		goto l3_process;
 	}
 
@@ -153,9 +152,9 @@ l3_process:
 		uint8_t vtc_vhl = NET_IPV6_HDR(pkt)->vtc & 0xf0;
 
 		if (IS_ENABLED(CONFIG_NET_IPV6) && vtc_vhl == 0x60) {
-			return net_ipv6_input(pkt, is_loopback);
+			return net_ipv6_input(pkt, net_pkt_is_loopback(pkt));
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) && vtc_vhl == 0x40) {
-			return net_ipv4_input(pkt, is_loopback);
+			return net_ipv4_input(pkt, net_pkt_is_loopback(pkt));
 		}
 
 		NET_DBG("Unknown IP family packet (0x%x)", NET_IPV6_HDR(pkt)->vtc & 0xf0);
@@ -172,10 +171,10 @@ l3_process:
 	return NET_DROP;
 }
 
-static void processing_data(struct net_pkt *pkt, bool is_loopback)
+static void processing_data(struct net_pkt *pkt)
 {
 again:
-	switch (process_data(pkt, is_loopback)) {
+	switch (process_data(pkt)) {
 	case NET_CONTINUE:
 		if (IS_ENABLED(CONFIG_NET_L2_VIRTUAL)) {
 			/* If we have a tunneling packet, feed it back
@@ -450,7 +449,8 @@ int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout)
 		 * to RX processing.
 		 */
 		NET_DBG("Loopback pkt %p back to us", pkt);
-		processing_data(pkt, true);
+		net_pkt_set_loopback(pkt, true);
+		processing_data(pkt);
 		ret = 0;
 		goto err;
 	}
@@ -510,7 +510,6 @@ err:
 
 static void net_rx(struct net_if *iface, struct net_pkt *pkt)
 {
-	bool is_loopback = false;
 	size_t pkt_len;
 
 	pkt_len = net_pkt_get_len(pkt);
@@ -522,12 +521,12 @@ static void net_rx(struct net_if *iface, struct net_pkt *pkt)
 	if (IS_ENABLED(CONFIG_NET_LOOPBACK)) {
 #ifdef CONFIG_NET_L2_DUMMY
 		if (net_if_l2(iface) == &NET_L2_GET_NAME(DUMMY)) {
-			is_loopback = true;
+			net_pkt_set_loopback(pkt, true);
 		}
 #endif
 	}
 
-	processing_data(pkt, is_loopback);
+	processing_data(pkt);
 
 	net_print_statistics();
 	net_pkt_print();

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2047,6 +2047,7 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_l2_bridged(clone_pkt, net_pkt_is_l2_bridged(pkt));
 	net_pkt_set_l2_processed(clone_pkt, net_pkt_is_l2_processed(pkt));
 	net_pkt_set_ll_proto_type(clone_pkt, net_pkt_ll_proto_type(pkt));
+	net_pkt_set_loopback(clone_pkt, net_pkt_is_loopback(pkt));
 
 #if defined(CONFIG_NET_OFFLOAD) || defined(CONFIG_NET_L2_IPIP)
 	net_pkt_set_remote_address(clone_pkt, net_pkt_remote_address(pkt),

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -166,11 +166,15 @@ config NET_ETHERNET_BRIDGE_SHELL
 	  Enables shell utility to manage bridge configuration interactively.
 
 config NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE
-	bool "Forward unrecognized EtherType frames further into net stack"
+	bool "Forward unrecognized EtherType frames further into net stack [DEPRECATED]"
 	default y if NET_SOCKETS_PACKET
+	select DEPRECATED
 	help
 	  When enabled, the Ethernet L2 will forward even those frames for which
 	  it does not recognize the EtherType in the header. By default, such
 	  frames are dropped at the L2 processing.
+
+	  All frames will be passed through the stack by default. Through this,
+	  the Kconfig is deprecated and will be removed in Zephyr v4.3.
 
 endif # NET_L2_ETHERNET

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -368,27 +368,6 @@ drop:
 	return NET_DROP;
 }
 
-#if defined(CONFIG_NET_IPV6)
-static enum net_verdict ethernet_ip_recv(struct net_if *iface,
-					 uint16_t ptype,
-					 struct net_pkt *pkt)
-{
-	ARG_UNUSED(iface);
-
-	if (ptype == NET_ETH_PTYPE_IPV6) {
-		net_pkt_set_family(pkt, AF_INET6);
-	} else {
-		return NET_DROP;
-	}
-
-	return NET_CONTINUE;
-}
-#endif /* CONFIG_NET_IPV6 */
-
-#if defined(CONFIG_NET_IPV6)
-ETH_NET_L3_REGISTER(IPv6, NET_ETH_PTYPE_IPV6, ethernet_ip_recv);
-#endif /* CONFIG_NET_IPV6 */
-
 #if defined(CONFIG_NET_IPV4)
 static inline bool ethernet_ipv4_dst_is_broadcast_or_mcast(struct net_pkt *pkt)
 {

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -683,3 +683,16 @@ void ieee802154_init(struct net_if *iface)
 		ctx->tx_power = tx_power;
 	}
 }
+
+static enum net_verdict ieee802154_l3_recv(struct net_if *iface, uint16_t ptype,
+					   struct net_pkt *pkt)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(ptype);
+	ARG_UNUSED(pkt);
+
+	return NET_CONTINUE;
+}
+
+NET_L3_REGISTER(&NET_L2_GET_NAME(IEEE802154), IEEE802154, NET_ETH_PTYPE_IEEE802154,
+		ieee802154_l3_recv);

--- a/tests/net/ipv4_fragment/src/main.c
+++ b/tests/net/ipv4_fragment/src/main.c
@@ -627,6 +627,7 @@ ZTEST(net_ipv4_fragment, test_udp)
 	/* Setup packet for insertion */
 	net_pkt_set_iface(pkt, iface1);
 	net_pkt_set_family(pkt, AF_INET);
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
 
 	/* Update IPv4 headers */
@@ -696,6 +697,7 @@ ZTEST(net_ipv4_fragment, test_tcp)
 
 	net_pkt_set_iface(pkt, iface1);
 	net_pkt_set_family(pkt, AF_INET);
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
 
 	packet_len = net_pkt_get_len(pkt);
@@ -750,6 +752,7 @@ ZTEST(net_ipv4_fragment, test_fragment_timeout)
 	zassert_not_null(pkt, "Packet creation failure");
 
 	net_pkt_set_family(pkt, AF_INET);
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
 
 	/* Create packet from base data */
@@ -840,6 +843,7 @@ ZTEST(net_ipv4_fragment, test_do_not_fragment)
 	/* Setup packet for insertion */
 	net_pkt_set_iface(pkt, iface1);
 	net_pkt_set_family(pkt, AF_INET);
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IP);
 	net_pkt_set_ip_hdr_len(pkt, sizeof(struct net_ipv4_hdr));
 
 	/* Update IPv4 headers */

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -2314,6 +2314,7 @@ ZTEST(net_ipv6_fragment, test_recv_ipv6_fragment)
 	zassert_not_null(pkt1, "packet");
 
 	net_pkt_set_family(pkt1, AF_INET6);
+	net_pkt_set_ll_proto_type(pkt1, NET_ETH_PTYPE_IPV6);
 	net_pkt_set_ip_hdr_len(pkt1, sizeof(struct net_ipv6_hdr));
 	net_pkt_cursor_init(pkt1);
 
@@ -2354,6 +2355,7 @@ ZTEST(net_ipv6_fragment, test_recv_ipv6_fragment)
 	zassert_not_null(pkt2, "packet");
 
 	net_pkt_set_family(pkt2, AF_INET6);
+	net_pkt_set_ll_proto_type(pkt2, NET_ETH_PTYPE_IPV6);
 	net_pkt_set_ip_hdr_len(pkt2, sizeof(struct net_ipv6_hdr));
 	net_pkt_cursor_init(pkt2);
 

--- a/tests/net/lib/mdns_responder/src/main.c
+++ b/tests/net/lib/mdns_responder/src/main.c
@@ -296,9 +296,9 @@ static void send_msg(const uint8_t *data, size_t len)
 	struct net_pkt *pkt;
 	int res;
 
-	pkt = net_pkt_alloc_with_buffer(iface1, NET_IPV6UDPH_LEN + len, AF_UNSPEC,
-					0, K_FOREVER);
+	pkt = net_pkt_alloc_with_buffer(iface1, NET_IPV6UDPH_LEN + len, AF_INET6, 0, K_FOREVER);
 	zassert_not_null(pkt, "PKT is null");
+	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_IPV6);
 
 	res = net_pkt_write(pkt, ipv6_hdr_start, sizeof(ipv6_hdr_start));
 	zassert_equal(res, 0, "pkt write for header start failed");


### PR DESCRIPTION
This PR rework the l3 handling from the ethernet l2 driver into the net_core. For that it does:

- Loopback flag in net_pkt
- Dedicated l3 handler for ipv4
- Dedicated l3 handler for ipv6
- L3 handler for IEEE802.15.4
- Allow L3 handlers to not specify an l2 to handle DUMMY and VIRTUAL l2.

The idea is to allow virutal intefaces to go throug the l3 handlers. So for example (a potential macsec l2 inteface), the flow could look like: l2 ethernet -> l2 macsec ->l2 vlan -> l3 handler.