### PR TITLE
samples: hello_world_user: unify board identifier output between `hello_world` samples

### DIFF
--- a/samples/userspace/hello_world_user/src/main.c
+++ b/samples/userspace/hello_world_user/src/main.c
@@ -19,7 +19,7 @@ static void user_function(void *p1, void *p2, void *p3)
 {
 	printf("Hello World from %s (%s)\n",
 	       k_is_user_context() ? "UserSpace!" : "privileged mode.",
-	       CONFIG_BOARD);
+	       CONFIG_BOARD_TARGET);
 	__ASSERT(k_is_user_context(), "User mode execution was expected");
 }
 


### PR DESCRIPTION
This patch unifies the board target identifier output in the `hello_world_user` sample to match that in the [`hello_world/src/main.c`](https://github.com/zephyrproject-rtos/zephyr/blob/38ad2a5894a645ece7c832653935902a64184495/samples/hello_world/src/main.c) file.