### PR TITLE
boards: nxp: imx-flexspi-nor: add missing sizes for is25wp064

### DIFF
--- a/boards/madmachine/mm_feather/mm_feather.dts
+++ b/boards/madmachine/mm_feather/mm_feather.dts
@@ -60,11 +60,13 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <67108864>;
+		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
 	};
 };
 

--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -60,11 +60,13 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <67108864>;
+		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
 	};
 };
 

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -162,11 +162,13 @@ nxp_parallel_i2c: &lpi2c1 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <67108864>;
+		size = <DT_SIZE_M(64 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";
 		jedec-id = [9d 70 17];
+		erase-block-size = <4096>;
+		write-block-size = <1>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Adds erase-block-size and write-block-size for is25wp064 nxp,imx-flexspi-nor.