### PR TITLE
Stm32 external dcache support for drivers

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -19,6 +19,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
 #include <soc.h>
+#include <stm32_cache.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/policy.h>
@@ -1380,34 +1381,6 @@ static void uart_stm32_isr(const struct device *dev)
 
 #ifdef CONFIG_UART_ASYNC_API
 
-#ifdef CONFIG_DCACHE
-static bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
-{
-	bool buf_within_nocache = false;
-
-#ifdef CONFIG_NOCACHE_MEMORY
-	buf_within_nocache = (buf >= ((uintptr_t)_nocache_ram_start)) &&
-		((buf + len_bytes - 1) <= ((uintptr_t)_nocache_ram_end));
-	if (buf_within_nocache) {
-		return true;
-	}
-#endif /* CONFIG_NOCACHE_MEMORY */
-
-#ifdef CONFIG_MEM_ATTR
-	buf_within_nocache = mem_attr_check_buf(
-		(void *)buf, len_bytes, DT_MEM_ARM_MPU_RAM_NOCACHE) == 0;
-	if (buf_within_nocache) {
-		return true;
-	}
-#endif /* CONFIG_MEM_ATTR */
-
-	buf_within_nocache = (buf >= ((uintptr_t)__rodata_region_start)) &&
-		((buf + len_bytes - 1) <= ((uintptr_t)__rodata_region_end));
-
-	return buf_within_nocache;
-}
-#endif /* CONFIG_DCACHE */
-
 static int uart_stm32_async_callback_set(const struct device *dev,
 					 uart_callback_t callback,
 					 void *user_data)
@@ -1633,12 +1606,10 @@ static int uart_stm32_async_tx(const struct device *dev,
 		return -EBUSY;
 	}
 
-#ifdef CONFIG_DCACHE
-	if (!buf_in_nocache((uintptr_t)tx_data, buf_size)) {
+	if (!stm32_buf_in_nocache((uintptr_t)tx_data, buf_size)) {
 		LOG_ERR("Tx buffer should be placed in a nocache memory region");
 		return -EFAULT;
 	}
-#endif /* CONFIG_DCACHE */
 
 #ifdef CONFIG_PM
 	data->tx_poll_stream_on = false;
@@ -1745,12 +1716,10 @@ static int uart_stm32_async_rx_enable(const struct device *dev,
 		return -EBUSY;
 	}
 
-#ifdef CONFIG_DCACHE
-	if (!buf_in_nocache((uintptr_t)rx_buf, buf_size)) {
+	if (!stm32_buf_in_nocache((uintptr_t)rx_buf, buf_size)) {
 		LOG_ERR("Rx buffer should be placed in a nocache memory region");
 		return -EFAULT;
 	}
-#endif /* CONFIG_DCACHE */
 
 	data->dma_rx.offset = 0;
 	data->dma_rx.buffer = rx_buf;
@@ -1876,12 +1845,10 @@ static int uart_stm32_async_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 	} else if (!data->dma_rx.enabled) {
 		err = -EACCES;
 	} else {
-#ifdef CONFIG_DCACHE
-		if (!buf_in_nocache((uintptr_t)buf, len)) {
+		if (!stm32_buf_in_nocache((uintptr_t)buf, len)) {
 			LOG_ERR("Rx buffer should be placed in a nocache memory region");
 			return -EFAULT;
 		}
-#endif /* CONFIG_DCACHE */
 		data->rx_next_buffer = buf;
 		data->rx_next_buffer_len = len;
 	}

--- a/soc/st/stm32/common/CMakeLists.txt
+++ b/soc/st/stm32/common/CMakeLists.txt
@@ -33,3 +33,5 @@ SoC Power Management (CONFIG_PM) enabled but the DBGMCU is still enabled \
 (CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP). The SoC will use more power than expected \
 in STOP modes due to internal oscillators that remain active.")
 endif()
+
+zephyr_sources_ifdef(CONFIG_DCACHE stm32_cache.c)

--- a/soc/st/stm32/common/stm32_cache.c
+++ b/soc/st/stm32/common/stm32_cache.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Henrik Lindblom <henrik.lindblom@vaisala.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "stm32_cache.h"
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/mem_mgmt/mem_attr.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/sys/math_extras.h>
+
+bool stm32_buf_in_nocache(uintptr_t buf, size_t len_bytes)
+{
+	uintptr_t buf_end;
+
+	/* Note: (len_bytes - 1) is safe because a length of 0 would overflow to 4 billion. */
+	if (u32_add_overflow(buf, len_bytes - 1, (uint32_t *)&buf_end)) {
+		return false;
+	}
+
+#ifdef CONFIG_EXTERNAL_CACHE
+	/* STM32 DCACHE is enabled but it does not cover internal SRAM. If the buffer is in SRAM it
+	 * is not cached by DCACHE.
+	 *
+	 * NOTE: This incorrectly returns true if Zephyr image RAM resides in external memory.
+	 */
+	if (((uintptr_t)_image_ram_start) <= buf && buf_end < ((uintptr_t)_image_ram_end)) {
+		return true;
+	}
+#endif /* CONFIG_EXTERNAL_CACHE */
+
+#ifdef CONFIG_NOCACHE_MEMORY
+	/* Check if buffer is in NOCACHE region defined by the linker. */
+	if ((uintptr_t)_nocache_ram_start <= buf && buf_end <= (uintptr_t)_nocache_ram_end) {
+		return true;
+	}
+#endif /* CONFIG_NOCACHE_MEMORY */
+
+#ifdef CONFIG_MEM_ATTR
+	/* Check if buffer is in a region marked NOCACHE in DT. */
+	if (mem_attr_check_buf((void *)buf, len_bytes, DT_MEM_ARM_MPU_RAM_NOCACHE) == 0) {
+		return true;
+	}
+#endif /* CONFIG_MEM_ATTR */
+
+	/* Check if buffer is in read-only region, which cannot be stale due to DCACHE because it is
+	 * not writeable.
+	 */
+	if ((uintptr_t)__rodata_region_start <= buf && buf_end <= (uintptr_t)__rodata_region_end) {
+		return true;
+	}
+
+	/* Not in any region known to be NOCACHE */
+	return false;
+}

--- a/soc/st/stm32/common/stm32_cache.h
+++ b/soc/st/stm32/common/stm32_cache.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Henrik Lindblom <henrik.lindblom@vaisala.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef STM32_CACHE_H_
+#define STM32_CACHE_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <zephyr/toolchain.h>
+
+#if defined(CONFIG_DCACHE)
+/**
+ * @brief Check if the given buffer resides in nocache memory
+ *
+ * Always returns true if CONFIG_DCACHE is not set.
+ *
+ * @param buf Buffer
+ * @param len_bytes Buffer size in bytes
+ * @return true if buf resides completely in nocache memory
+ */
+bool stm32_buf_in_nocache(uintptr_t buf, size_t len_bytes);
+
+#else /* !CONFIG_DCACHE */
+
+static inline bool stm32_buf_in_nocache(uintptr_t buf, size_t len_bytes)
+{
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len_bytes);
+
+	/* Whole memory is nocache if DCACHE is disabled */
+	return true;
+}
+
+#endif /* CONFIG_DCACHE */
+
+#endif /* STM32_CACHE_H_ */


### PR DESCRIPTION
For drivers that check for `CONFIG_DCACHE` the recent changes from #88585 enable the DCACHE peripheral for a bunch of STM32 Cortex-M33 chips. Some drivers, when configured to use DMA check if DCACHE option is enabled and proceed to check whether the buffer resides in cached memory. The STM32 DCACHE peripheral only supports external memories so the buffer validation lacks a simple check for external cache controllers. Also, the same buffer validation function has essentially been copy pasted in many drivers so this PR moves that to a shared location under soc/.

Fixes #89218