### PR TITLE
net: websocket: Make use of any leftover data after HTTP processing 

### DIFF
--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -260,6 +260,13 @@ struct http_request {
 	/** Length of the user supplied receive buffer */
 	size_t recv_buf_len;
 
+	/** Length of the unprocessed data left inside the user supplied receive
+	 *  buffer. In typical HTTP processing this should be 0, however in case
+	 *  of switching protocols, there may be some data left belonging to the
+	 *  new protocol.
+	 */
+	size_t data_len;
+
 	/** The URL for this request, for example: /index.html */
 	const char *url;
 

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -480,7 +480,7 @@ static void http_report_progress(struct http_request *req)
 static int http_wait_data(int sock, struct http_request *req, const k_timepoint_t req_end_timepoint)
 {
 	int total_received = 0;
-	size_t offset = 0;
+	size_t offset = 0, processed = 0;
 	int received, ret;
 	struct zsock_pollfd fds[1];
 	int nfds = 1;
@@ -525,25 +525,43 @@ static int http_wait_data(int sock, struct http_request *req, const k_timepoint_
 			} else if (received < 0) {
 				ret = -errno;
 				goto error;
-			} else {
-				req->internal.response.data_len += received;
-
-				(void)http_parser_execute(
-					&req->internal.parser, &req->internal.parser_settings,
-					req->internal.response.recv_buf + offset, received);
 			}
 
 			total_received += received;
 			offset += received;
 
+			processed = http_parser_execute(
+				&req->internal.parser, &req->internal.parser_settings,
+				req->internal.response.recv_buf, offset);
+
+			if (processed > offset) {
+				LOG_ERR("HTTP parser error, too much data consumed");
+				ret = -EBADMSG;
+				goto error;
+			}
+
+			if (req->internal.parser.http_errno != HPE_OK) {
+				LOG_ERR("HTTP parsing error, %d",
+					req->internal.parser.http_errno);
+				ret = -EBADMSG;
+				goto error;
+			}
+
+			req->internal.response.data_len += processed;
+			offset -= processed;
+
 			if (offset >= req->internal.response.recv_buf_len) {
-				offset = 0;
+				/* This means the parser did not consume any data
+				 * and we can't fit any more in the buffer.
+				 */
+				LOG_ERR("HTTP RX buffer full, cannot proceed");
+				ret = -ENOMEM;
+				goto error;
 			}
 
 			if (req->internal.response.message_complete) {
 				http_report_complete(req);
-				break;
-			} else if (offset == 0) {
+			} else {
 				http_report_progress(req);
 
 				/* Re-use the result buffer and start to fill it again */
@@ -551,9 +569,23 @@ static int http_wait_data(int sock, struct http_request *req, const k_timepoint_
 				req->internal.response.body_frag_start = NULL;
 				req->internal.response.body_frag_len = 0;
 			}
+
+			if (offset > 0) {
+				/* In case there are any unprocessed data left,
+				 * move them to the front of the buffer.
+				 */
+				memmove(req->internal.response.recv_buf,
+					req->internal.response.recv_buf + processed,
+					offset);
+			}
 		}
 
-	} while (true);
+	} while (!req->internal.response.message_complete);
+
+	/* If there's still some data left in the buffer after HTTP processing,
+	 * reflect this in data_len variable.
+	 */
+	req->data_len = offset;
 
 	return total_received;
 

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -384,10 +384,11 @@ int websocket_connect(int sock, struct websocket_request *wreq,
 
 	NET_DBG("[%p] WS connection to peer established (fd %d)", ctx, fd);
 
-	/* We will re-use the temp buffer in receive function if needed but
-	 * in order that to work the amount of data in buffer must be set to 0
+	/* We will re-use the temp buffer in receive function. If there were
+	 * any leftover data from HTTP headers processing, we need to reflect
+	 * this in the count variable.
 	 */
-	ctx->recv_buf.count = 0;
+	ctx->recv_buf.count = req.data_len;
 
 	/* Init parser FSM */
 	ctx->parser_state = WEBSOCKET_PARSER_STATE_OPCODE;


### PR DESCRIPTION
In case websocket data was piggybacked in the same packet as HTTP Switching Protocols reply, the websocket client would ignore that data, because the HTTP client library would read them already out from the socket. This PR attempts to fix this.

Fixes #89193

~~Marking as DNM for now until the issue is confirmed as resolved by the reporter~~