### PR TITLE
updatehub: report error before rollback on unconfirmed image

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -284,6 +284,10 @@ New APIs and options
     * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY`
     * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY_SIZE`
 
+* UpdateHub
+
+  * :c:func:`updatehub_report_error`
+
 * Other
 
   * :kconfig:option:`CONFIG_LV_Z_COLOR_MONO_HW_INVERSION`

--- a/include/zephyr/mgmt/updatehub.h
+++ b/include/zephyr/mgmt/updatehub.h
@@ -90,6 +90,15 @@ __syscall int updatehub_confirm(void);
  */
 __syscall int updatehub_reboot(void);
 
+/**
+ * @brief Report an update failure to the UpdateHub server.
+ *
+ * @details This sends an ERROR state (UPDATEHUB_STATE_ERROR) for the last package.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+__syscall int updatehub_report_error(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -1001,7 +1001,9 @@ static void autohandler(struct k_work *work)
 	case UPDATEHUB_UNCONFIRMED_IMAGE:
 		LOG_ERR("Image is unconfirmed. Rebooting to revert back to previous"
 			"confirmed image.");
-
+		if (report(UPDATEHUB_STATE_ERROR) < 0) {
+			LOG_ERR("Failed to report rollback error to server");
+		}
 		LOG_PANIC();
 		updatehub_reboot();
 		break;
@@ -1043,4 +1045,9 @@ void z_impl_updatehub_autohandler(void)
 
 	k_work_init_delayable(&updatehub_work_handle, autohandler);
 	k_work_reschedule(&updatehub_work_handle, K_NO_WAIT);
+}
+
+int z_impl_updatehub_report_error(void)
+{
+	return report(UPDATEHUB_STATE_ERROR);
 }

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -1001,9 +1001,7 @@ static void autohandler(struct k_work *work)
 	case UPDATEHUB_UNCONFIRMED_IMAGE:
 		LOG_ERR("Image is unconfirmed. Rebooting to revert back to previous"
 			"confirmed image.");
-		if (report(UPDATEHUB_STATE_ERROR) < 0) {
-			LOG_ERR("Failed to report rollback error to server");
-		}
+		updatehub_report_error();
 		LOG_PANIC();
 		updatehub_reboot();
 		break;
@@ -1049,5 +1047,10 @@ void z_impl_updatehub_autohandler(void)
 
 int z_impl_updatehub_report_error(void)
 {
-	return report(UPDATEHUB_STATE_ERROR);
+	int ret = report(UPDATEHUB_STATE_ERROR);
+
+	if (ret < 0) {
+		LOG_ERR("Failed to report rollback error to server");
+	}
+	return ret;
 }


### PR DESCRIPTION
# Summary
Fixes an issue where unconfirmed images are rolled back without notifying the UpdateHub server.

# Motivation
When using updatehub_autohandler() with CONFIG_BOOT_UPGRADE_ONLY=n, unconfirmed images are correctly rolled back. However, the UpdateHub agent does not send an "error" report to the server, causing it to re-offer the same broken update.

There is the same problem when using manual mode, there are no ways to report the failure to the Updatehub server.

# Fix
Sends an error report before rebooting on rollback in updatehub_autohandler().
Expose a updatehub_report_error() function, that allows manual mode to report an error to the server.

