### PR TITLE
NXP: Fix UART glitches when entering suspend or standby power modes

### DIFF
--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -134,11 +134,22 @@ static void mcux_flexcomm_poll_out(const struct device *dev,
 {
 	const struct mcux_flexcomm_config *config = dev->config;
 
-	/* Wait until space is available in TX FIFO */
-	while (!(USART_GetStatusFlags(config->base) & kUSART_TxFifoEmptyFlag)) {
+	/* Wait until space is available in TX FIFO, as per API description:
+	 * This routine checks if the transmitter is full.
+	 * When the transmitter is not full, it writes a character to the data register.
+	 * It waits and blocks the calling thread otherwise.
+	 */
+	while (!(USART_GetStatusFlags(config->base) & kUSART_TxFifoNotFullFlag)) {
 	}
 
 	USART_WriteByte(config->base, c);
+
+	/* Wait for the transfer to complete, as per API description:
+	 * This function is a blocking call. It blocks the calling thread until the character
+	 * is sent.
+	 */
+	while (!(USART_GetStatusFlags(config->base) & kUSART_TxFifoEmptyFlag)) {
+	}
 }
 
 static int mcux_flexcomm_err_check(const struct device *dev)

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -61,15 +61,13 @@ if PM
 # For PM mode 3 we change this config to get better accuracy
 # when using the iKHz RTC clock as system clock.
 config SYS_CLOCK_TICKS_PER_SEC
-	default 1000
-	depends on $(dt_nodelabel_enabled,standby)
+	default 1000 if "$(dt_nodelabel_enabled,standby)"
 
 # Enable PM_DEVICE by default if STANDBY mode is enabled
 # as we use the TURN_OFF and TURN_ON actions to recover
 # from Standby mode (PM Mode 3)
 config PM_DEVICE
-	default y
-	depends on "$(dt_nodelabel_enabled,standby)"
+	default y if "$(dt_nodelabel_enabled,standby)"
 
 # Enable PM_POLICY_DEVICE_CONSTRAINTS by default when doing PM_DEVICE.
 # This will allow support of device power states.
@@ -79,8 +77,7 @@ config PM_POLICY_DEVICE_CONSTRAINTS
 # Enable the counter if STANDBY mode is enabled
 # RTC counter is the wakeup source from STANDBY mode
 config COUNTER
-	default y
-	depends on "$(dt_nodelabel_enabled,standby)"
+	default y if "$(dt_nodelabel_enabled,standby)"
 
 config MCUX_OS_TIMER_PM_POWERED_OFF
 	default y


### PR DESCRIPTION
Character glitches are observed when entering suspend and standby low power modes.
To fix it, we need to make sure the transfer is done before returning from the `poll_out` API.
This is aligned with the driver API description:
```
This routine checks if the transmitter is full. When the transmitter is not full, it writes a character to the data register. It waits and blocks the calling thread otherwise. This function is a blocking call. It blocks the calling thread until the character is sent.
```

Also fix wrong use of `depends on` for RW defconfig, use `default y if` instead.

