### PR TITLE
drivers/sensor: lis2dux12: add high performance mode

### DIFF
--- a/dts/bindings/sensor/st,lis2dux12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dux12-common.yaml
@@ -5,7 +5,7 @@ description: |
     When setting the odr, power-mode, and range properties in a .dts or .dtsi file you may include
     st_lis2dux12.h and use the macros defined there.
     Example:
-    #include <zephyr/dt-bindings/sensor/st_lis2dux12.h>
+    #include <zephyr/dt-bindings/sensor/lis2dux12.h>
     lis2dux12: lis2dux12@0 {
       ...
       power-mode = <LIS2DUX12_OPER_MODE_LOW_POWER>;
@@ -68,8 +68,8 @@ properties:
 
       - 0 # LIS2DUX12_OPER_MODE_POWER_DOWN
       - 1 # LIS2DUX12_OPER_MODE_LOW_POWER
-      - 2 # LIS2DUX12_OPER_MODE_HIGH_RESOLUTION
-      - 3 # LIS2DUX12_OPER_MODE_HIGH_FREQUENCY
+      - 2 # LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE
+      - 3 # LIS2DUX12_OPER_MODE_SINGLE_SHOT
 
     enum: [0, 1, 2, 3]
 

--- a/include/zephyr/dt-bindings/sensor/lis2dux12.h
+++ b/include/zephyr/dt-bindings/sensor/lis2dux12.h
@@ -9,10 +9,10 @@
 #include <zephyr/dt-bindings/dt-util.h>
 
 /* Operating Mode */
-#define LIS2DUX12_OPER_MODE_POWER_DOWN      0
-#define LIS2DUX12_OPER_MODE_LOW_POWER       1
-#define LIS2DUX12_OPER_MODE_HIGH_RESOLUTION 2
-#define LIS2DUX12_OPER_MODE_HIGH_FREQUENCY  3
+#define LIS2DUX12_OPER_MODE_POWER_DOWN        0
+#define LIS2DUX12_OPER_MODE_LOW_POWER         1
+#define LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE  2
+#define LIS2DUX12_OPER_MODE_SINGLE_SHOT       3
 
 /* Data rate */
 #define LIS2DUX12_DT_ODR_OFF      0

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1010,7 +1010,7 @@ test_i2c_lis2dux12: lis2dux12@8a {
 	int2-gpios = <&test_gpio 0 0>;
 	range = <LIS2DUX12_DT_FS_16G>;
 	odr = <LIS2DUX12_DT_ODR_100Hz>;
-	power-mode = <LIS2DUX12_OPER_MODE_HIGH_FREQUENCY>;
+	power-mode = <LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE>;
 	status = "okay";
 };
 
@@ -1227,7 +1227,7 @@ test_i2c_lis2duxs12: lis2duxs12@a7 {
 	int2-gpios = <&test_gpio 0 0>;
 	range = <LIS2DUX12_DT_FS_16G>;
 	odr = <LIS2DUX12_DT_ODR_100Hz>;
-	power-mode = <LIS2DUX12_OPER_MODE_HIGH_FREQUENCY>;
+	power-mode = <LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Add driver capability to properly set high performance mode while setting data rate (thru lis2duxxx_mode_set() API) based on how power-mode is set into DTS: if it is set to LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE then configure HP mode, LP/ULP mode otherwise.

Fix: #87886

The fix consists in using the ```cfg->pm``` value read from DTS to form a proper odr value to set also the power mode. In fact, the stmemsc API used is 
```
int32_t lis2dux12_mode_set(const stmdev_ctx_t *ctx, const lis2dux12_md_t *val);
```

If the power mode is ```LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE``` then we need to transform the odr found, let's say ```LIS2DUX12_DT_ODR_800Hz``` i.e.  0x0b into 0x1b.
