### PR TITLE
samples: env_posix: Avoid test-shell race on SMP targets

### DIFF
--- a/samples/posix/env/src/main.c
+++ b/samples/posix/env/src/main.c
@@ -45,6 +45,7 @@ static void *entry(void *arg)
 	setenv("BUILD_VERSION", VERSION_BUILD, 1);
 	setenv("ALERT", "", 1);
 
+	sleep(1);
 	env();
 
 	while (true) {


### PR DESCRIPTION
This test is problematic on SMP (nsim/nsim_hs5x/smp) targets due to a race between early output and shell initialization
after changes in PR #74700.

Adding a 1-second delay before printing avoids the issue and allows the test to pass reliably.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/89445