### PR TITLE
logging: backend: net: improve and fix

### DIFF
--- a/subsys/logging/backends/log_backend_net.c
+++ b/subsys/logging/backends/log_backend_net.c
@@ -314,7 +314,8 @@ static void init_net(struct log_backend const *const backend)
 {
 	ARG_UNUSED(backend);
 
-	if (strlen(CONFIG_LOG_BACKEND_NET_SERVER) != 0) {
+	if (sizeof(CONFIG_LOG_BACKEND_NET_SERVER) != 1) {
+		/* Non empty address, set server via Kconfig defaults */
 		const char *server = CONFIG_LOG_BACKEND_NET_SERVER;
 		bool ret;
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -553,17 +553,8 @@ int net_config_init_app(const struct device *dev, const char *app_info)
 	/* This is activated late as it requires the network stack to be up
 	 * and running before syslog messages can be sent to network.
 	 */
-	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET) &&
-	    IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART)) {
-		const struct log_backend *backend = log_backend_net_get();
-
-		if (!log_backend_is_active(backend)) {
-			if (backend->api->init != NULL) {
-				backend->api->init(backend);
-			}
-
-			log_backend_activate(backend, NULL);
-		}
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART)) {
+		log_backend_net_start();
 	}
 
 	return ret;


### PR DESCRIPTION
Remove redundant initialization of the network log backend to prevent overwriting server settings and optimize Kconfig value checks using sizeof for better compiler performance.