### PR TITLE
stm32n6: tests: drivers:   update testcase yaml file 

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_target_api/testcase.yaml
@@ -17,6 +17,7 @@ tests:
       - stm32f072b_disco
       - stm32f3_disco
       - stm32h573i_dk
+      - stm32n6570_dk/stm32n657xx/sb
       - stm32u083c_dk
       - nucleo_c071rb
       - nucleo_g071rb

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -80,6 +80,7 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
       - stm32h573i_dk
+      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - nucleo_g474re
   drivers.spi.stm32_spi_dma_dt_nocache_mem.loopback:
@@ -137,6 +138,7 @@ tests:
       - nucleo_wl55jc
       - stm32f3_disco
       - stm32h573i_dk
+      - stm32n6570_dk/stm32n657xx/sb
     integration_platforms:
       - stm32h573i_dk
   drivers.spi.gd32_spi_interrupt.loopback:


### PR DESCRIPTION
Add `stm32n6570_dk` in testcase file for CI test drivers purpose.

Related tests: 
- tests: drivers: i2c: i2c_target_api
- tests: drivers: spi: spi_loopback

