### PR TITLE
stm32u083c_dk: tests: drivers: add support for stm32u083c_dk on usart and spi drivers test

### DIFF
--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -38,15 +38,15 @@
 	};
 };
 
-&usart1 {
-	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+&usart2 {
+	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";
 };
 
-&usart2 {
-	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
+&usart3 {
+	pinctrl-0 = <&usart3_tx_pc4 &usart3_rx_pc5>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";
@@ -102,6 +102,13 @@
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&spi3 {
+	pinctrl-0 = <&spi3_nss_pa15 &spi3_sck_pc10
+		     &spi3_miso_pc11 &spi3_mosi_pc12>;
+	pinctrl-names = "default";
+	status = "okay";
 };
 
 &timers1 {

--- a/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32u083c_dk.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi3 {
+	dmas = <&dmamux1 2 41 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
+		&dmamux1 1 40 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -82,6 +82,7 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m7
       - stm32h573i_dk
       - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
     integration_platforms:
       - nucleo_g474re
   drivers.spi.stm32_spi_dma_dt_nocache_mem.loopback:
@@ -141,6 +142,7 @@ tests:
       - stm32f3_disco
       - stm32h573i_dk
       - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
     integration_platforms:
       - stm32h573i_dk
   drivers.spi.gd32_spi_interrupt.loopback:

--- a/tests/drivers/uart/uart_async_api/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32u083c_dk.overlay
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+dut: &usart3 {
+	dmas = <&dmamux1 5 74 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 73 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};


### PR DESCRIPTION
Extend tests coverage

Add the stm32u083c_dk board for test bench purposes on SPI and USART drivers.