### PR TITLE
NXP drivers: counter_mcux_ctimer: Adds PM low-power recovery support

### DIFF
--- a/tests/drivers/counter/counter_basic_api/Kconfig
+++ b/tests/drivers/counter/counter_basic_api/Kconfig
@@ -1,0 +1,10 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_DRIVER_COUNTER_MCUX_LPC_RTC_HIGHRES
+	bool "tests the nxp_lpc_rtc_highres compatible driver"
+	default y if COUNTER_MCUX_LPC_RTC_HIGHRES
+	help
+	  tests the nxp_lpc_rtc_highres compatible driver
+
+source "Kconfig.zephyr"

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_rw612.conf
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_rw612.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier Apache-2.0
+#
+CONFIG_PM=y

--- a/tests/drivers/counter/counter_basic_api/enable_standby.overlay
+++ b/tests/drivers/counter/counter_basic_api/enable_standby.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2025 NXP
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&standby {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -84,7 +84,7 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_MCUX_LPC_RTC_1HZ
 	DEVS_FOR_DT_COMPAT(nxp_lpc_rtc)
 #endif
-#ifdef CONFIG_COUNTER_MCUX_LPC_RTC_HIGHRES
+#ifdef CONFIG_TEST_DRIVER_COUNTER_MCUX_LPC_RTC_HIGHRES
 	DEVS_FOR_DT_COMPAT(nxp_lpc_rtc_highres)
 #endif
 #ifdef CONFIG_COUNTER_GECKO_RTCC

--- a/tests/drivers/counter/counter_basic_api/testcase.yaml
+++ b/tests/drivers/counter/counter_basic_api/testcase.yaml
@@ -40,3 +40,14 @@ tests:
     timeout: 400
     extra_args:
       DTC_OVERLAY_FILE="boards/mimxrt685_evk_rtc_1khz.overlay"
+  drivers.counter.basic_api.standby.lpc_rtc_highres:
+    tags:
+      - drivers
+      - counter
+    depends_on: counter
+    platform_allow: frdm_rw612
+    timeout: 400
+    extra_configs:
+      - CONFIG_TEST_DRIVER_COUNTER_MCUX_LPC_RTC_HIGHRES=n
+    extra_args:
+      DTC_OVERLAY_FILE="enable_standby.overlay"


### PR DESCRIPTION
Enables Sleep mode (PM3) in RW61x for Ctimer.