### PR TITLE
net: vlan: Make vlan independent of l2 ethernet

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -751,6 +751,13 @@ struct net_eth_vlan_hdr {
 	uint16_t type;
 } __packed;
 
+/* Vlan header */
+struct net_vlan_hdr {
+	uint16_t tpid; /* tag protocol id */
+	uint16_t tci; /* tag control info */
+	uint16_t type; /* Next protocol type */
+};
+
 /** @endcond */
 
 /**

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -722,9 +722,6 @@ struct ethernet_context {
 	/** Is network carrier up */
 	bool is_net_carrier_up : 1;
 
-	/** Is this context already initialized */
-	bool is_init : 1;
-
 	/** Types of Ethernet network interfaces */
 	enum ethernet_if_types eth_if_type;
 };

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -752,8 +752,11 @@ struct net_if {
 	 */
 	uint8_t pe_prefer_public : 1;
 
+	/** Is this interface already initialized */
+	bool is_init : 1;
+
 	/** Unused bit flags (ignore) */
-	uint8_t _unused : 6;
+	uint8_t _unused : 5;
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -278,10 +278,6 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 		if (IS_ENABLED(CONFIG_NET_CAPTURE) && pending) {
 			net_pkt_set_captured(pkt, net_pkt_is_captured(pending));
 		}
-
-		if (IS_ENABLED(CONFIG_NET_VLAN) && pending) {
-			net_pkt_set_vlan_tag(pkt, net_pkt_vlan_tag(pending));
-		}
 	}
 
 	net_pkt_set_ll_proto_type(pkt, NET_ETH_PTYPE_ARP);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -987,5 +987,5 @@ void ethernet_init(struct net_if *iface)
 
 	net_arp_init();
 
-	ctx->is_init = true;
+	iface->is_init = true;
 }


### PR DESCRIPTION
This PR changes the VLAN logic in such a away, that it can be layered with other future virtual interfaces (like q-in-q or macsec).

Biggest changes:
 * Move VLAN receive logic to net_core
 * Split VLAN send logic from ethernet logic and layer them.
 * Allow attaching vlan interfaces to virtual and ethernet l2 interfaces