### PR TITLE
Nxp enabled lptmr for imx95 cm7

### DIFF
--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.dts
@@ -79,3 +79,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&lptmr2 {
+	status = "okay";
+};

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -19,4 +19,5 @@ supported:
   - pwm
   - spi
   - netif:eth
+  - counter
 vendor: nxp

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -464,6 +464,18 @@
 			status = "disabled";
 		};
 
+		lptmr2: timer@424d0000 {
+			compatible = "nxp,lptmr";
+			reg = <0x424d0000 DT_SIZE_K(4)>;
+			interrupts = <63 0>;
+			clocks = <&scmi_clk IMX95_CLK_LPTMR2>;
+			clock-frequency = <32000>;
+			clk-source = <2>;
+			prescaler = <1>;
+			resolution = <32>;
+			status = "disabled";
+		};
+
 		mu5: mailbox@44610000 {
 			compatible = "nxp,mbox-imx-mu";
 			reg = <0x44610000 DT_SIZE_K(4)>;


### PR DESCRIPTION
enables LPTMR2 interface for nxp, imx95_evk_mimx9596_m7
Tested with sample counter_basic_api