### PR TITLE
Modify btwt_setup usage

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1772,14 +1772,23 @@ static int nxp_wifi_set_btwt(const struct device *dev, struct wifi_twt_params *p
 {
 	wlan_btwt_config_t btwt_config;
 
-	btwt_config.action = 1;
-	btwt_config.sub_id = params->btwt.sub_id;
-	btwt_config.nominal_wake = params->btwt.nominal_wake;
-	btwt_config.max_sta_support = params->btwt.max_sta_support;
-	btwt_config.twt_mantissa = params->btwt.twt_mantissa;
-	btwt_config.twt_offset = params->btwt.twt_offset;
-	btwt_config.twt_exponent = params->btwt.twt_exponent;
-	btwt_config.sp_gap = params->btwt.sp_gap;
+	memset(&btwt_config, 0, sizeof(wlan_btwt_config_t));
+
+	btwt_config.bcast_bet_sta_wait = params->btwt.btwt_sta_wait;
+	btwt_config.bcast_offset = params->btwt.btwt_offset;
+	btwt_config.bcast_twtli = params->btwt.btwt_li;
+	btwt_config.count = params->btwt.btwt_count;
+
+	for (int i = 0; i < btwt_config.count; i++) {
+		btwt_config.btwt_sets[i].btwt_id
+			= params->btwt.btwt_set_cfg[i].btwt_id;
+		btwt_config.btwt_sets[i].bcast_mantissa
+			= params->btwt.btwt_set_cfg[i].btwt_mantissa;
+		btwt_config.btwt_sets[i].bcast_exponent
+			= params->btwt.btwt_set_cfg[i].btwt_exponent;
+		btwt_config.btwt_sets[i].nominal_wake
+			= params->btwt.btwt_set_cfg[i].btwt_nominal_wake;
+	}
 
 	return wlan_set_btwt_cfg(&btwt_config);
 }

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -702,6 +702,20 @@ struct wifi_ps_params {
 	enum wifi_ps_exit_strategy exit_strategy;
 };
 
+#define WIFI_BTWT_AGREEMENT_MAX 5
+
+/** @brief Wi-Fi broadcast TWT parameters */
+struct wifi_btwt_params {
+	/** Broadcast TWT ID */
+	uint8_t btwt_id;
+	/** Broadcast TWT mantissa */
+	uint16_t btwt_mantissa;
+	/** Broadcast TWT exponent */
+	uint8_t btwt_exponent;
+	/** Broadcast TWT range */
+	uint8_t btwt_nominal_wake;
+};
+
 /** @brief Wi-Fi TWT parameters */
 struct wifi_twt_params {
 	/** TWT operation, see enum wifi_twt_operation */
@@ -748,20 +762,16 @@ struct wifi_twt_params {
 		} setup;
 		/** Setup specific parameters */
 		struct {
-			/** Broadcast TWT AP config */
-			uint16_t sub_id;
-			/** Range 64-255 */
-			uint8_t nominal_wake;
-			/** Max STA support */
-			uint8_t max_sta_support;
-			/** TWT mantissa */
-			uint16_t twt_mantissa;
-			/** TWT offset */
-			uint16_t twt_offset;
-			/** TWT exponent */
-			uint8_t twt_exponent;
-			/** SP gap */
-			uint8_t sp_gap;
+			/** Broadcast TWT station wait time */
+			uint8_t btwt_sta_wait;
+			/** Broadcast TWT offset */
+			uint16_t btwt_offset;
+			/** In multiple of 4 beacon interval */
+			uint8_t btwt_li;
+			/** Broadcast TWT agreement count */
+			uint8_t btwt_count;
+			/** Broadcast TWT agreement sets */
+			struct wifi_btwt_params btwt_set_cfg[WIFI_BTWT_AGREEMENT_MAX];
 		} btwt;
 		/** Teardown specific parameters */
 		struct {

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -3900,8 +3900,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
 		"<id0> <mantissa0> <exponent0> <nominal_wake0>: 64-255\n"
 		"<id1> <mantissa1> <exponent1> <nominal_wake1>: 64-255\n"
 		"<idx> <mantissax> <exponentx> <nominal_wakex>: 64-255\n"
-		" The total number of '0, 1, ..., x' is session_num\n",
-		"[-i, --iface=<interface index>] : Interface index.\n"
+		" The total number of '0, 1, ..., x' is session_num\n"
+		"[-i, --iface=<interface index>] : Interface index.\n",
 		cmd_wifi_btwt_setup,
 		13, 2),
 	SHELL_CMD_ARG(teardown, NULL, " Teardown a TWT flow:\n"


### PR DESCRIPTION
subsys: net: l2: wifi: Modify btwt_setup usage.
    
    Usage:
    wifi twt btwt_setup <sta_wait> <offset>
    <twtli> <session_num>
    <id0> <mantissa0> <exponent0> <nominal_wake0>
    <id1> <mantissa1> <exponent1> <nominal_wake1>
    <idx> <mantissax> <exponentx> <nominal_wakex>
    The total number of '0, 1, ..., x' is session_num
    
    For example:
    wifi twt btwt_setup 0 0 0 2 0 112 10 128 1 32 10 64

drivers: nxp: wifi: Modify shim driver to support btwt changes.
    
    Align struct wlan_btwt_config_t in shim driver
    with nxp wifi driver.
