### PR TITLE
dts: arm: nuvoton: add adc node of numaker m55m1x

### DIFF
--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/reset/numaker_m55m1x_reset.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 / {
 	chosen {
@@ -393,6 +394,19 @@
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
+		};
+
+		eadc0: eadc@40241000 {
+			compatible = "nuvoton,numaker-adc";
+			reg = <0x40241000 0x280>;
+			interrupts = <126 0>;
+			resets = <&rst NUMAKER_SYS_EADC0RST>;
+			clocks = <&pcc NUMAKER_EADC0_MODULE
+				  NUMAKER_CLK_EADCSEL_EADC0SEL_PCLK0
+				  NUMAKER_CLK_EADCDIV_EADC0DIV(10)>;
+			channels = <28>;
+			status = "disabled";
+			#io-channel-cells = <1>;
 		};
 	};
 };

--- a/tests/drivers/adc/adc_api/boards/numaker_m55m1.overlay
+++ b/tests/drivers/adc/adc_api/boards/numaker_m55m1.overlay
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	zephyr,user {
+		io-channels = <&eadc0 6>, <&eadc0 8>;
+	};
+};
+
+&pinctrl {
+	/* EVB's UNO Pin A0 & A2 for ADC channel 6 & 8 */
+	eadc0_default: eadc0_default {
+		group0 {
+			pinmux = <PB6MFP_EADC0_CH6>, <PB8MFP_EADC0_CH8>;
+		};
+	};
+};
+
+&eadc0 {
+	status = "okay";
+	pinctrl-0 = <&eadc0_default>;
+	pinctrl-names = "default";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <10>;
+	};
+
+	channel@8 {
+		reg = <8>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <10>;
+	};
+};


### PR DESCRIPTION
This PR is to add ADC node for Nuvoton NuMaker M55M1X series.
It also includes support for Nuvoton numaker board (numaker_m55m1) in adc_api test.

Test result of adc_api on numaker_m55m1 board as:
```
===================================================================
TESTSUITE adc_basic succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [adc_basic]: pass = 6, fail = 0, skip = 0, total = 6 duration = 0.520 seconds
 - PASS - [adc_basic.test_adc_asynchronous_call] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_invalid_request] duration = 0.011 seconds
 - PASS - [adc_basic.test_adc_repeated_samplings] duration = 0.083 seconds
 - PASS - [adc_basic.test_adc_sample_one_channel] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_sample_two_channels] duration = 0.006 seconds
 - PASS - [adc_basic.test_adc_sample_with_interval] duration = 0.408 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```