### PR TITLE
doc: fuel_gauge: upate api documentation

### DIFF
--- a/doc/hardware/peripherals/fuel_gauge.rst
+++ b/doc/hardware/peripherals/fuel_gauge.rst
@@ -3,11 +3,7 @@
 Fuel Gauge
 ##########
 
-The fuel gauge subsystem exposes an API to uniformly access battery fuel gauge devices. Currently,
-only reading data is supported.
-
-Note: This API is currently experimental and this doc will be significantly changed as new features
-are added to the API.
+The fuel gauge subsystem exposes an API to uniformly access battery fuel gauge devices.
 
 Basic Operation
 ***************
@@ -21,7 +17,8 @@ Fuel gauges typically support multiple properties, such as temperature readings 
 or present-time current/voltage.
 
 Properties are fetched by the client one at a time using :c:func:`fuel_gauge_get_prop`, or fetched
-in a batch using :c:func:`fuel_gauge_get_props`.
+in a batch using :c:func:`fuel_gauge_get_props`. Buffer properties, e.g. device name, are fetched by
+using :c:func:`fuel_gauge_get_buffer_prop`.
 
 Properties are set by the client one at a time using :c:func:`fuel_gauge_set_prop`, or set in a
 batch using :c:func:`fuel_gauge_set_props`.


### PR DESCRIPTION
As discussed in #89000 I updated the fuel gauge API documentation.

It removes outdated description and adds missing API call `fuel_gauge_get_buffer_props`.