### PR TITLE
samples: fs_sample: avoid CI fail for mm_feather

### DIFF
--- a/samples/subsys/fs/fs_sample/sample.yaml
+++ b/samples/subsys/fs/fs_sample/sample.yaml
@@ -7,6 +7,8 @@ common:
 tests:
   sample.filesystem.fat_fs:
     depends_on: sdhc
+    platform_exclude:
+      - mm_feather
     harness: console
     harness_config:
       fixture: fixture_sdhc


### PR DESCRIPTION
- Avoid CI fail for the mm_feather board https://github.com/zephyrproject-rtos/zephyr/issues/89305.
- Exclude the mm_feather board from sample.filesystem.fat_fs test case.