### PR TITLE
MMC + FatFS fixes 

### DIFF
--- a/boards/madmachine/mm_feather/mm_feather.dts
+++ b/boards/madmachine/mm_feather/mm_feather.dts
@@ -171,6 +171,12 @@
 	pinctrl-2 = <&pinmux_usdhc1_med>;
 	pinctrl-3 = <&pinmux_usdhc1_fast>;
 	pinctrl-names = "default", "slow", "med", "fast";
+
+	mmc {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
+	};
 };
 
 &edma0 {

--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -113,6 +113,7 @@
 	DT_FOREACH_STATUS_OKAY(zephyr_flash_disk, _FF_DISK_NAME) \
 	DT_FOREACH_STATUS_OKAY(zephyr_ram_disk, _FF_DISK_NAME) \
 	DT_FOREACH_STATUS_OKAY(zephyr_sdmmc_disk, _FF_DISK_NAME) \
+	DT_FOREACH_STATUS_OKAY(zephyr_mmc_disk, _FF_DISK_NAME) \
 	DT_FOREACH_STATUS_OKAY(st_stm32_sdmmc, _FF_DISK_NAME)
 
 #undef FF_VOLUMES


### PR DESCRIPTION
* Add missing mmc node to the mm_feather board (fixes #89305 and fixes CI for PR #89257)
* fatfs: add support for mmc disks when generating FF_VOLUME_STRS 

makes `west twister --all -s sample.filesystem.fat_fs --no-detailed-test-id` pass (vs. 2 failures before this PR)