### PR TITLE
drivers: fuel_gauge: Fix incorrect variable in bq27xx chem_id switch

### DIFF
--- a/drivers/sensor/ti/bq274xx/bq274xx.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx.c
@@ -363,7 +363,7 @@ static int bq274xx_ensure_chemistry(const struct device *dev)
 
 		uint16_t cmd;
 
-		switch (val) {
+		switch (chem_id) {
 		case BQ27427_CHEM_ID_A:
 			cmd = BQ27427_CTRL_CHEM_A;
 			break;


### PR DESCRIPTION
In the bq27xx driver, a `switch(val)` statement is incorrectly used in place of `switch(chem_id)` in the logic that handles different chip variants. This leads to incorrect behavior for chips like the BQ27427, where the `chem_id` determines how certain readings (e.g. SoC at full charge) are processed. In my case for full charged 4.2V battery SoC was ~90%, because of default configuration is for batteries with 4.35V full charge voltage.

This patch replaces the wrong variable and ensures correct behavior for devices relying on the `chem_id` value. The issue was observed on a custom board using a BQ27427 gauge, but the bug exists in the generic logic and should be fixed regardless of board.

**Tested on:** Custom board with BQ27427  
**Impact:** Fixes incorrect behavior due to wrong switch condition  
**Risk:** Low — should affects only code paths for specific chem_id variants

**Warning:** I can't verify if driver works properly on Zephyr supported board "innblue22" with another variant of chip (BQ27421)