### PR TITLE
drivers: clock_control: STM32U5XX wake up clocks

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -887,6 +887,19 @@ int stm32_clock_control_init(const struct device *dev)
 		return -ENOTSUP;
 	}
 
+#ifdef CONFIG_PM
+	/* Disable unused clocks that are enabled (e.g. by bootloader or as wakeup source).
+	 * These will not be enabled, unless the MCU uses them for PM wakeup purposes.
+	 */
+	if (!IS_ENABLED(STM32_MSIS_ENABLED) && (READ_BIT(RCC->CR, RCC_CR_MSISON) != 0U)) {
+		LL_RCC_MSIS_Disable();
+	}
+
+	if (!IS_ENABLED(STM32_HSI_ENABLED) && (READ_BIT(RCC->CR, RCC_CR_HSION) != 0U)) {
+		LL_RCC_HSI_Disable();
+	}
+#endif
+
 	/* Set FLASH latency */
 	/* If freq not increased, set flash latency after all clock setting */
 	if (old_hclk_freq >= CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) {


### PR DESCRIPTION
Disable wake-up source clocks for STM32U5XX if not enabled by DTS.
