### PR TITLE
Twister plugin filter

### DIFF
--- a/doc/develop/test/index.rst
+++ b/doc/develop/test/index.rst
@@ -10,6 +10,8 @@ Testing
    twister
    twister_statuses
    twister/twister_blackbox
+   plugin_filters/plugin_filters_documentation
+   plugin_filters/plugin_filters_creation
    pytest
    coverage
    BabbleSim<bsim>

--- a/doc/develop/test/plugin_filters/plugin_filters_creation.rst
+++ b/doc/develop/test/plugin_filters/plugin_filters_creation.rst
@@ -1,0 +1,123 @@
+.. _pluginFilterCreation:
+
+Filter Creation
+###############
+
+Filter Interface
+****************
+
+The filter interface class offers a clear representation of what a filter should look like.
+It implements four abstract methods, out of which one (either exclude or include) should always
+be implemented. The interface should always be the superclass of each Filter instance, even if it
+contains a minimal amount of actual logic.  In fact, a filter can still function without throwing
+exceptions even if it doesn't extend the Filter Interface, or at least it could, as long as it
+implements every method of said class. This is exactly the reason why it would be better if
+all Filters extended the interface: all the methods of the Interface are called on each Filter, so
+having a blank implementation in the superclass allows the user to ignore the nonessential ones.
+
+.. literalinclude:: ../../../../scripts/pylib/twister/plugin_filters/filter_interface.py
+    :language: python
+    :linenos:
+    :caption: Filter Interface
+
+Filter Class
+************
+
+Each Filter should be contained in its own .py file. As soon as this has been created,
+it is essential to define a class named **Filter** that inherits from **FilterInterface**.
+Each filter file must contain exactly one class with this specific name.
+The requirement exists because the system's dynamic import mechanism looks precisely
+for this label when seeking a desired Filter implementation.
+
+This design choice, although strict and very limiting, simplifies the commands.
+Having to specify the name of each Filter class would've made the
+:ref:`plugin filter <pluginFilterCommandsPG>` and
+:ref:`plugin filter JSON String <pluginFilterCommandsPGJS>` calls longer,
+while only :ref:`plugin filter JSON Path <pluginFilterCommandsPGJP>`
+would have been unaffected.
+
+It would have also been possible to implement a method that searched for a class
+extending **FilterInterface**, but such an approach could have caused conflicts
+in files where multiple classes inherited the interface.
+
+.. note::
+
+    If desired, the actual filter's name can still be changed by using a wrapper.
+    This strategy would involve an empty class with the Filter name inheriting the
+    actual implementation, therefore allowing the original instance to have any desired name.
+
+    Example:
+
+    .. code-block:: python
+
+        from plugin_filters.filter_interface import FilterInterface
+
+        class MyFilterWithACustomName(FilterInterface):
+            # Actual filter implementation
+            ...
+
+        class Filter(MyFilterWithACustomName):
+            pass
+
+Setup Method
+************
+
+After creating the Filter class, the next step should be the definition of ``setup(...)``.
+This method will be fed the filter parameters entered in the twister call and is therefore
+a crucial part of a filter's implementation. The method's parameters can be extended both with
+positional and keyword arguments without any restrictions, although it is suggested to keep the
+refecences to both ``*args`` and ``**kwargs``. Having these two elements will prevent exceptions
+from being thrown on simple argument mistakes. More severe errors (for example forgetting a
+positional argument) will still throw exceptions, although those will be caught quickly and
+handled accordingly.
+
+The method should mainly be used to assign values to the filter object (as seen in the
+:ref:`implementation example <pluginFilterExampleRegex>`), or also to execute some code
+before the filtering process commences.
+
+Setup is also the only method from the Filter Interface (currently) where the super class
+implements some actual logic. Calling ``super().setup(*args, **kwargs)`` is *highly suggested*,
+since it will initialize ``exclude_reason`` and ``include_reason``, two important variables
+used in the logging process. Although their absence will not break the execution, these two
+variables help users understand why a specific Test Suite was skipped. Therefore, it is
+preferable not to leave them undefined.
+
+Exclude / Include Methods
+*************************
+
+The ``exclude(...)`` and ``include(...)`` are simple but important parts of the interface.
+These two methods shall decide whether a filter has to be executed or not.
+
+The implementation depends entirely on the filter's goal, with the only constant
+being its parameters: all methods overriding ``exclude(...)`` or ``include(...)`` will be given
+exactly two: a reference to self and the TestSuite, whose exclusion / inclusion must be decided.
+
+``exclude(...)`` and ``include(...)`` must always return a boolean. Their result will tell
+the filter handler whether a filter must be excluded / included (return True) or left as it is
+(return False).
+
+.. note::
+
+    Exclude will always be called before include is. This means that include, which was built to
+    override decisions made by filters with lower priority, can override decisons taken by its
+    own exclude method as well.
+
+Teardown Method
+***************
+
+Teardown is a simple hook that allows some code to be executed once the filtering process has
+finished running. Possible usages for this method go from a simple logging statement to closing
+file handlers, network connections, etc. It receives only one parameter, a reference to self.
+
+.. _pluginFilterExampleRegex:
+
+Implementation Example
+######################
+
+The regex filter is a very simple implementation of a filter. Examining it can help understanding
+the inner workings of a custom filter.
+
+.. literalinclude:: ../../../../scripts/pylib/twister/plugin_filters/filters/filter_id_regex.py
+    :language: python
+    :linenos:
+    :caption: Example class implementation

--- a/doc/develop/test/plugin_filters/plugin_filters_documentation.rst
+++ b/doc/develop/test/plugin_filters/plugin_filters_documentation.rst
@@ -1,0 +1,215 @@
+.. _pluginFilterDocu:
+
+Plugin Filter to Twister
+########################
+
+Twister works only with static information found in files such as testcase.yaml and samples.yaml.
+The Plugin Filter system gives to the developers the necessary tools for creating custom filters,
+potentially reducing the CI load for tests and static code analysis.
+
+Usage
+*****
+
+This section will explain how to use the plugin with filters that have already been implemented.
+To understand how to create a filter from scratch, consult the corresponding documentation under
+the :ref:`Filter Creation <pluginFilterCreation>` page.
+
+TL;DR - Twister call
+====================
+
+JSON Structure
+--------------
+
+    Two out of the three plugin filter commands use a specific .json format.
+    The basic rules for an error-free execution are the following:
+
+    *   The outermost layer of the .json must be a list of dictionaries.
+    *   Each dictionary must contain one to three values:
+
+        *   *filter_file_path* - A string, representing the path to the filter.
+        *   *args* - A list of strings, representing the positional arguments of the filter.
+        *   *kwargs* - A dictionary with string key-value pairs, representing the keyword arguments
+            of the filter.
+
+    Example:
+
+    .. code-block:: json
+
+        [
+            {
+                "filter_file_path": "filter_id_regex",
+                "args": [
+                    ".*semaphores"
+                ]
+            }
+        ]
+
+Plugin filter variants
+----------------------
+
+    Three plugin-filter variations can be called:
+
+.. _pluginFilterCommandsPGJP:
+
+    *   **--plugin-filter-json-path**, accepts a path pointing to a json containing filter data.
+
+        Notation:
+
+        .. code-block:: bash
+
+            scripts/twister <twister-arguments> --plugin-filter-json-path <path-to-json-file>
+
+        Examples:
+
+        .. code-block:: bash
+
+            scripts/twister -T samples/philosophers --plugin-filter-json-path 'scripts/pylib/twister/plugin_filters/filters/filter_id_regex_example_conf.json'
+            scripts/twister -T samples/philosophers --plugin-filter-json-path '~/filter_id_regex_example_conf.json'
+
+.. _pluginFilterCommandsPG:
+
+    *   **--plugin-filter**, accepts a string containing filter data.
+        This string must be made out of "blocks" separated by semicolons,
+        where each block corresponds to a filter and its parameters.
+        A block must always start with the path to the filter,
+        followed by the filter's args and kwargs (if required).
+
+        Notation:
+
+        .. code-block:: bash
+
+            scripts/twister <twister-arguments> --plugin-filter <[subpath/]plugin-filter-name-1> <arg-1> <arg-N> <kwarg-key-1>=<kwarg-value-1> <kwarg-key-n>=<kwarg-value-n>; <[subpath/]plugin-filter-name-n> <arg-1> <arg-N> <kwarg-key-1>=<kwarg-value-1> <kwarg-key-n>=<kwarg-value-n>
+
+        Examples:
+
+        .. code-block:: bash
+
+            scripts/twister -T samples/philosophers --plugin-filter filter_id_regex '.*semaphores'
+            scripts/twister -T samples/philosophers --plugin-filter filter_id_regex regex_pattern='.*semaphores' "exclude_reason='Suite is not testing Semaphores'" "include_reason='Suite is testing Semaphores'"
+            scripts/twister -T samples/philosophers --plugin-filter filter_id_regex '.*semaphores'; filter_id_regex '.*stacks'
+
+        .. note::
+
+            Spaces in arguments will lead to unexpected behaviour if not handled correctly.
+            Due to inner limitations, for example, the input for a command with one positional
+            argument (`... 'my arg' ...`) and a command with two positional arguments
+            (`... 'my' 'arg' ...`) will end up containing the exact same values.
+
+            To ensure the code works correctly, these parameters must be written as kwargs and
+            encased in double quotes, as seen in the following snippets.
+
+            .. code-block:: bash
+
+                # No spaces - no problem
+                scripts/twister -T samples/philosophers --plugin-filter filter_id_regex '.*same_prio'
+                scripts/twister -T samples/philosophers --plugin-filter filter_id_regex '.*same_prio' exclude_reason='same_prio_filter'
+
+                # Spaces - wrapping required
+                scripts/twister -T samples/philosophers --plugin-filter filter_id_regex "regex_pattern='.*same priority'"
+                scripts/twister -T samples/philosophers --plugin-filter filter_id_regex "regex_pattern='.*same priority'" "exclude_reason='Suite is not testing Same Priority'"
+
+
+.. _pluginFilterCommandsPGJS:
+
+    *   **--plugin-filter-json-string**, accepts a json-formatted string containing filter data.
+
+        Notation:
+
+        .. code-block:: bash
+
+            scripts/twister <twister-arguments> --plugin-filter-json-string <json-string>
+
+        Examples:
+
+        .. code-block:: bash
+
+            scripts/twister -T samples/philosophers --plugin-filter-json-string '[{"filter_file_path": "filter_id_regex", "args": [".*semaphores"]}]'
+            scripts/twister -T samples/philosophers --plugin-filter-json-string '[{"filter_file_path": "filter_id_regex", "kwargs": {"regex_pattern": ".*semaphores", "exclude_reason": "Suite is not testing Semaphores", "include_reason": "Suite is testing Semaphores"}}]'
+            scripts/twister -T samples/philosophers --plugin-filter-json-string '[{"filter_file_path": "filter_id_regex.py", "args": [".*semaphores"]}]'
+            scripts/twister -T samples/philosophers --plugin-filter-json-string '[{"filter_file_path": "filter_id_regex.py", "kwargs": {"regex_pattern": ".*semaphores", "exclude_reason": "Suite is not testing Semaphores", "include_reason": "Suite is testing Semaphores"}}]'
+
+    .. note::
+
+        Any positional argument can be passed as a keyword argument,
+        as long as the parameter name matches. The reverse is not allowed.
+
+    .. note::
+
+        Kwargs ``exclude_reason`` and ``include_reason``, although not mandatory, are highly suggested.
+
+Pathing
+=======
+
+    Two formats are supported: system (path/to/the/filter) and python (path.to.the.filter) paths.
+
+    .. note::
+
+        python paths can **only** be used for subdirectories of *``scripts/pylib/twister/``*
+
+    To avoid long paths, the script searches filters only inside the
+    ``zephyr/scripts/pylib/twister/plugin_filters/filters`` directory.
+
+    If additional filters are located elsewhere, an environmental variable called
+    **TWISTER_PLUGIN_FILTER_ROOTS** can be defined, effectively expanding the search range of the
+    function.
+
+    To set this variable, insert all the desired paths (separated by semicolons) in a string
+    and run the following snippet in the console:
+
+    .. code-block:: bash
+
+        export TWISTER_PLUGIN_FILTER_ROOTS="<path-1>;<path-n>"
+
+    Once the roots have been exported, twister calls in the same terminal instance will
+    automatically scan the specified directories and select the correct filter implementations.
+
+    .. note::
+
+        Paths in **TWISTER_PLUGIN_FILTER_ROOTS** can use both the system and the python format.
+
+    .. note::
+
+        The usage of semicolons as separators is not hard-coded. If desired, the environmental variable
+        **TWISTER_PLUGIN_FILTER_ROOTS_SEPARATOR** will allow the selection of an alternative symbol.
+
+    Filter paths - examples:
+
+    *   The file ``filter_id_regex.py`` is located under
+        *``zephyr/scripts/pylib/twister/plugin_filters/filters``*.
+        Since ``plugin_filters.filters`` is considered the default filter directory,
+        the filter path can be limited to ``filter_id_regex``.
+    *   A hypotetical ``hello_world_filter.py`` filter located under
+        *``zephyr/scripts/pylib/twister/plugin_filters/filters/subdirectory``*
+        wouldn't need additions to the **ROOTS** list either,
+        but its path should mention the subdirectory, meaning the filter
+        path would become ``subdirectory.hello_world_filter``.
+    *   When filters are stored outside of the region reachable by python paths,
+        system ones are needed. Filtering with the file ``foo_bar_filter.py``,
+        located under *``/home/user/desktop/my_filters/subdir/foo_bar_filter.py``*,
+        would require the addition of *``~/desktop/my_filters/``*
+        to the **ROOTS** and the usage of ``subdir/foo_bar_filter.py`` in the filter path.
+
+Arguments
+=========
+
+    Once the path is clear, args and kwargs must be specified. The easiest way to understand
+    which ones are needed is to read the setup method of the filter. A well-written filter should
+    describe its parameters with suitable names and avoid dynamically retrieving them from the
+    ``*args`` list or ``**kwargs`` dictionary.
+
+    Example:
+
+    *   The setup method of ``filter_id_regex.py`` has the following implementation:
+
+        .. code-block:: python
+
+            def setup(self, regex_pattern: str, *args, **kwargs):
+                super().setup(*args, **kwargs)
+
+                self.regex_pattern = regex_pattern
+
+        This shows that ``filter_id_regex.py`` requires one positional argument, a string.
+        Inspecting the super class would reveal two more arguments, exclude_reason and
+        include_reason. These are not mandatory, but highly suggested. The code above could
+        therefore be improved by referencing them directly, instead of forwarding the kwargs
+        dictionary.

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1774,3 +1774,9 @@ To run a single testsuite instead of a whole group of test you can run:
 .. code-block:: bash
 
    $ twister -p qemu_riscv32 -s tests/kernel/interrupt/arch.shared_interrupt
+
+Twister plugin filter
+*********************
+
+For information regarding how to use plugin filters, consult :ref:`Plugin Filter Documentation <pluginFilterDocu>`.
+For information regarding writing a custom plugin filter, visit the :ref:`Plugin Filter Creation <pluginFilterCreation>` page.

--- a/scripts/pylib/twister/plugin_filters/args/args_descriptor.py
+++ b/scripts/pylib/twister/plugin_filters/args/args_descriptor.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Baumer Group. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from argparse import _ArgumentGroup
+
+_GENERAL_FILTER_DESCRIPTION = (
+    "Allows the selection of one (or multiple) filter(s) "
+    "to reduce the amount of tests to perform on twister launch. "
+)
+
+_COMMAND_DELIMITERS_WARNING = (
+    "(< and > are present only for delimiting the command, "
+    "do not include them in the actual call). "
+)
+
+_GENERAL_JSON_FILTER_DESCRIPTION = (
+    "The names of these filters, along with their arguments, will be parsed from a json "
+)
+
+_JSON_STRING_FILTER_DESCRIPTION = _GENERAL_JSON_FILTER_DESCRIPTION + "string. "
+_JSON_PATH_FILTER_DESCRIPTION = (
+    _GENERAL_JSON_FILTER_DESCRIPTION
+    + "file. "
+    + "The path to said file can be either absolute or relative. "
+    + f"The root for relative paths is the current working directory '{os.getcwd()}'. "
+)
+
+_BASIC_FILTER_FORMAT = (
+    "The argument should have one of the two following formats: "
+    + "< --plugin-filter 'filter_file_path_1 arg1 arg2 kwarg1=1234 kwarg2=5678; "
+    + "filter_file_path_2 arg3' >, or alternatively "
+    + "< --plugin-filter filter_file_path_1 arg1 arg2 kwarg1=1234 kwarg2=5678\\; "
+    + "filter_file_path_2 arg3 > "
+    + _COMMAND_DELIMITERS_WARNING
+    + "In both cases spaces serve as a separator for the parameters, "
+    + "while semicolons are used to mark the end of a filter and its data, "
+    + "allowing the user to append a new one. "
+)
+
+_JSON_FILTER_FORMAT = (
+    "The JSON should comply with the following structural guidelines: "
+    "The outermost layer must be a list, "
+    "which is used to contain one or more dictionaries with the filter data. "
+    "Each dictionary must contain a 'filter_file_path' key-value pair. "
+    "This variable specifies the relative path to the file where the filter is located "
+    "(the absolute path is generated separately by iterating through "
+    "the TWISTER_PLUGIN_FILTER_ROOTS environmental variable). "
+    "The dictionary allows to specify an 'args' and a 'kwargs' property to feed to the filter. "
+    "If used, the args key must be linked to a list, while kwargs must be linked to a dictionary. "
+)
+
+_JSON_STRING_FILTER_EXAMPLE = (
+    "Examples: "
+    "without arguments: "
+    "< --plugin-filter-json-string '[{\"filter_file_path\": \"skip_matching_id\"}]' >, "
+    "with the usage of kwargs: "
+    "< --plugin-filter-json-string "
+    "'[{"
+    "\"filter_file_path\": \"skip_matching_id\", "
+    "\"kwargs\": {\"id_filter\": \"sample.kernel.philosopher.semaphores\"}"
+    "}]' "
+    ">, "
+    "and with both args and kwargs: "
+    "< --plugin-filter-json-string "
+    "'[{"
+    "\"filter_file_path\": \"skip_matching_id\", "
+    "\"args\": [123, 456], "
+    "\"kwargs\": {\"id_filter\": \"sample.kernel.philosopher.semaphores\"}"
+    "}]' "
+    ">. " + _COMMAND_DELIMITERS_WARNING
+)
+
+_JSON_PATH_FILTER_EXAMPLE = (
+    "Examples: "
+    "< --plugin-filter-json-path filter_details.json > "
+    "(only for .json files located inside the current working directory tree), or also "
+    "< --plugin-filter-json-path '/home/user/filter_configs/filter_details.json' > "
+    + _COMMAND_DELIMITERS_WARNING
+)
+
+_GENERAL_ROOT_NOTES = (
+    "NOTE: "
+    "In order to find the correct filter file, "
+    "the script must be provided with a list of root directories. "
+    "This list can be defined by creating a new environmental variable, "
+    "named 'TWISTER_PLUGIN_FILTER_ROOTS'. "
+    "This variable will be used to iterate through the specified roots "
+    "until the required filter_file_path is found. "
+    "An example for said variable could be: ['/home/user/external_filters']. "
+    "Although valid, this array will still undergo a slight modification: "
+    "The automatic addition of the 'plugin_filters' root at the end of the list. "
+    "This is done because this directory contains "
+    "both the filter framework and the regex filter example. "
+    "Roots can either be normal ('/home/user/external_filters') "
+    "or pythonic paths ('myfilters.filters'). "
+    "Although both can be used, "
+    "the format of filter_file_path must always correspond to the one of its root. "
+    "For example, if the root is 'plugin_filters', "
+    "valid filter_file_paths would be 'file_name1' or 'sub_dir.file_name2'. "
+    "On the other hand, a root such as '/home/user/external_filters'"
+    " requires 'file_name1.py' or 'dir/file_name2.py'. "
+)
+
+
+def add_arguments(case_select: _ArgumentGroup):
+    plugin_filter_mex_group = case_select.add_mutually_exclusive_group()
+
+    plugin_filter_mex_group.add_argument(
+        "--plugin-filter",
+        nargs="+",
+        help=(_GENERAL_FILTER_DESCRIPTION + _BASIC_FILTER_FORMAT + _GENERAL_ROOT_NOTES),
+    )
+
+    plugin_filter_mex_group.add_argument(
+        "--plugin-filter-json-string",
+        help=(
+            _GENERAL_FILTER_DESCRIPTION
+            + _JSON_STRING_FILTER_DESCRIPTION
+            + _JSON_FILTER_FORMAT
+            + _JSON_STRING_FILTER_EXAMPLE
+            + _GENERAL_ROOT_NOTES
+        ),
+    )
+
+    plugin_filter_mex_group.add_argument(
+        "--plugin-filter-json-path",
+        help=(
+            _GENERAL_FILTER_DESCRIPTION
+            + _JSON_PATH_FILTER_DESCRIPTION
+            + _JSON_FILTER_FORMAT
+            + _JSON_PATH_FILTER_EXAMPLE
+            + _GENERAL_ROOT_NOTES
+        ),
+    )

--- a/scripts/pylib/twister/plugin_filters/args/args_parser.py
+++ b/scripts/pylib/twister/plugin_filters/args/args_parser.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Baumer Group. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import os
+import sys
+
+_FILTER_SEPARATOR = ';'
+
+_FILTER_DICT_PATH = 'filter_file_path'
+_FILTER_DICT_ARGS = 'args'
+_FILTER_DICT_KWARGS = 'kwargs'
+
+logger = logging.getLogger('twister')
+logger.setLevel(logging.DEBUG)
+
+
+class _FilterDictionary:
+    path: str
+    args: list
+    kwargs: dict
+
+    def __init__(self, path, args: list | None = None, kwargs: dict | None = None):
+        self.path = path
+
+        self.args = args if isinstance(args, list) else []
+        self.kwargs = kwargs if isinstance(kwargs, dict) else {}
+
+    def to_dictionary(self) -> dict:
+        return {
+            _FILTER_DICT_PATH: self.path,
+            _FILTER_DICT_ARGS: self.args,
+            _FILTER_DICT_KWARGS: self.kwargs,
+        }
+
+
+def _handle_filter_token(token, block_starts: bool, filter_list: list[_FilterDictionary]) -> bool:
+    next_block_starts = token.endswith(_FILTER_SEPARATOR)
+    clean_token = token.removesuffix(_FILTER_SEPARATOR)
+
+    if block_starts:
+        filter_list.append(_FilterDictionary(clean_token))
+
+    elif len(filter_list) > 0 and (current_filter := filter_list[-1]) is not None:
+        if '=' in clean_token and not (clean_token.startswith('"') or clean_token.startswith("'")):
+            key, value = clean_token.split('=', 1)
+
+            if key in current_filter.kwargs:
+                logger.warning(
+                    "Kwarg key %s already registered for filter %s. "
+                    "Value will be updated from %s to %s.",
+                    key,
+                    current_filter.path,
+                    current_filter.kwargs[key],
+                    value,
+                )
+
+            current_filter.kwargs[key] = value
+        else:
+            current_filter.args.append(clean_token)
+
+    return next_block_starts
+
+
+def _smart_split(
+    args_wrapper: str, splitter_char: str = ' ', block_chars: list[str] | None = None
+) -> list[str]:
+    tokens = []
+    block_chars = block_chars if block_chars is not None else ['"', "'"]
+
+    blocks = []
+    temp_str: str = ""
+
+    for char in args_wrapper:
+        if char == splitter_char and len(blocks) == 0:
+            tokens.append(temp_str)
+            temp_str = ""
+
+            continue
+
+        temp_str += char
+
+        if char in block_chars:
+            if (blocks_len := len(blocks)) == 0 or blocks[blocks_len - 1] != char:
+                blocks.append(char)
+            else:
+                blocks.pop()
+
+    if temp_str:
+        tokens.append(temp_str)
+
+    return tokens
+
+
+def _handle_simple_filter(filter_args):
+    filter_list = []
+    next_block_starts = True
+
+    for args_wrapper in filter_args:
+        for token in _smart_split(args_wrapper):
+            next_block_starts = _handle_filter_token(token, next_block_starts, filter_list)
+
+    return [filter_obj.to_dictionary() for filter_obj in filter_list]
+
+
+def _handle_json_string_filter(filter_args):
+    return json.loads(filter_args)
+
+
+def _handle_json_path_filter(filter_args):
+    if not os.path.exists(json_path := os.path.expanduser(filter_args)):
+        logger.error(
+            "Provided path %s doesn't exist in the system "
+            "or in the current working directory %s. "
+            "Halting twister process...",
+            json_path,
+            os.getcwd(),
+        )
+        sys.exit(1)
+
+    if not os.path.isfile(json_path):
+        logger.error(
+            "Provided path %s doesn't lead to a file. Halting twister process...", json_path
+        )
+        sys.exit(1)
+
+    try:
+        with open(json_path, encoding='UTF-8') as json_file:
+            return json.load(json_file)
+    except OSError as e:
+        logger.error(
+            "JSON parser crashed with error %s while trying to parse %s. "
+            "Halting twister process...",
+            e,
+            json_path,
+        )
+        sys.exit(1)
+
+
+def _handle_json_filter(filter_args, handle_method):
+    if callable(handle_method):
+        try:
+            return handle_method(filter_args)
+        except (TypeError, ValueError) as e:
+            logger.error(
+                "JSON parser crashed with error %s while trying to parse %s. "
+                "Halting twister process...",
+                e,
+                filter_args,
+            )
+            sys.exit(1)
+    else:
+        logger.error(
+            "Handle JSON Filter method was fed an uncallable handle method. "
+            "Halting twister process..."
+        )
+        sys.exit(1)
+
+
+def parse_arguments(options):
+    if filter_args := options.plugin_filter:
+        options.plugin_filter = _handle_simple_filter(filter_args)
+    elif filter_args := options.plugin_filter_json_string:
+        options.plugin_filter = _handle_json_filter(filter_args, _handle_json_string_filter)
+    elif filter_args := options.plugin_filter_json_path:
+        options.plugin_filter = _handle_json_filter(filter_args, _handle_json_path_filter)

--- a/scripts/pylib/twister/plugin_filters/filter_interface.py
+++ b/scripts/pylib/twister/plugin_filters/filter_interface.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Baumer Group. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+class FilterInterface:
+    """
+    Interface for Plugin Filters.
+    Helps users to greatly reduce the filtering scope with self-written code.
+    """
+
+    exclude_reason: str
+    include_reason: str
+
+    def setup(self, *_args, **kwargs):
+        """
+        Initialises the Filter object. The arguments and keyword arguments given in the command
+        will be passed to the Filters by this method.
+        """
+        self.exclude_reason = kwargs.get('exclude_reason', '')
+        self.include_reason = kwargs.get('include_reason', '')
+
+    def exclude(self, _suite) -> bool:
+        """
+        Examines a given Test Suite and decides if it must be excluded from the test plan.
+
+        Returns:
+            bool: True, if the suite should be skipped
+        """
+        return False
+
+    def include(self, _suite) -> bool:
+        """
+        Examines a given Test Suite and decides if it must be included in the test plan.
+
+        Returns:
+            bool: True, if the suite should not be skipped
+        """
+        return False
+
+    def teardown(self):
+        """
+        Simple hook to execute some code after the filter has been used
+        """

--- a/scripts/pylib/twister/plugin_filters/filters/filter_id_regex.py
+++ b/scripts/pylib/twister/plugin_filters/filters/filter_id_regex.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Baumer Group. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+from plugin_filters.filter_interface import FilterInterface
+from twisterlib.testplan import TestSuite
+
+
+class Filter(FilterInterface):
+    """
+    The Filter ID Regex excludes Suites based on their ID.
+    """
+
+    regex_pattern: str = "*"
+
+    # pylint: disable=arguments-differ
+    def setup(self, regex_pattern: str, *args, **kwargs):
+        super().setup(*args, **kwargs)
+
+        self.regex_pattern = regex_pattern
+
+    def exclude(self, suite: TestSuite):
+        # Example: the regex_pattern "sample\\.bluetooth\\..*" would skip all but those test cases
+        # from testcase.yaml or sample.yaml resp. the testsuites already collected in the testplan
+        # that start with sample.bluetooth.
+        return not bool(re.search(self.regex_pattern, suite.id))
+
+    def include(self, suite: TestSuite):
+        # Example: the regex_pattern "sample\\.bluetooth\\..*" would include only those test cases
+        # from testcase.yaml or sample.yaml resp. the testsuites already collected in the testplan
+        # that start with sample.bluetooth.
+        return bool(re.search(self.regex_pattern, suite.id))

--- a/scripts/pylib/twister/plugin_filters/filters/filter_id_regex_example_conf.json
+++ b/scripts/pylib/twister/plugin_filters/filters/filter_id_regex_example_conf.json
@@ -1,0 +1,17 @@
+[
+    {
+        "filter_file_path":"filter_id_regex",
+        "kwargs": {
+            "regex_pattern": ".*static",
+            "exclude_reason": "this filter selects only tests from the static group",
+            "include_reason": "this suite contains the keyword 'static'"
+        }
+    },
+    {
+        "filter_file_path":"filter_id_regox",
+        "kwargs": {
+            "regex_pattern": ".*stacks",
+            "exclude_reason": "this filter doesn't exist and should just trigger a warning"
+        }
+    }
+]

--- a/scripts/pylib/twister/plugin_filters/logic/filter_handler.py
+++ b/scripts/pylib/twister/plugin_filters/logic/filter_handler.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Baumer Group. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import importlib.util
+import inspect
+import logging
+import os
+from importlib.util import spec_from_file_location
+
+from plugin_filters.filter_interface import FilterInterface
+from twisterlib.statuses import TwisterStatus
+
+_DEFAULT_ROOT_NORMAL = './scripts/pylib/twister/plugin_filters/filters'
+_DEFAULT_ROOT_PYTHONIC = 'plugin_filters.filters'
+_DEFAULT_ROOTS_SEPARATOR = ';'
+
+_SEPARATOR_ENV_VARIABLE_NAME = 'TWISTER_PLUGIN_FILTER_ROOTS_SEPARATOR'
+_ROOTS_ENV_VARIABLE_NAME = "TWISTER_PLUGIN_FILTER_ROOTS"
+
+logger = logging.getLogger('twister')
+logger.setLevel(logging.DEBUG)
+
+
+def _get_root_list():
+    root_list = []
+    roots_var = os.getenv(_ROOTS_ENV_VARIABLE_NAME)
+    roots_separator = os.getenv(_SEPARATOR_ENV_VARIABLE_NAME, _DEFAULT_ROOTS_SEPARATOR)
+
+    logger.info(roots_var)
+
+    if roots_var:
+        root_list = roots_var.split(roots_separator)
+
+    if _DEFAULT_ROOT_PYTHONIC not in root_list:
+        root_list.append(_DEFAULT_ROOT_PYTHONIC)
+
+    if _DEFAULT_ROOT_NORMAL not in root_list:
+        root_list.append(_DEFAULT_ROOT_NORMAL)
+
+    return root_list
+
+
+def _get_file_name(base_name: str, pythonic_path: bool):
+    return (
+        (base_name[:-3] if base_name.endswith('.py') else base_name)
+        if pythonic_path
+        else (base_name if base_name.endswith('.py') else base_name + '.py')
+    )
+
+
+def _get_class(file_name: str, file_path: str, class_name='Filter'):
+    class_reference = None
+
+    try:
+        if (
+            os.path.exists(
+                class_path := os.path.expanduser(
+                    os.path.join(file_path, _get_file_name(file_name, False))
+                )
+            )
+            and (module_specification := spec_from_file_location(class_name, class_path))
+            and (module := importlib.util.module_from_spec(module_specification))
+        ):
+            module_specification.loader.exec_module(module)
+            class_reference = getattr(module, class_name, None)
+
+        if class_reference is None:
+            import_string = f"{file_path}.{_get_file_name(file_name, True)}"
+
+            try:
+                if importlib.util.find_spec(import_string):
+                    class_reference = getattr(
+                        importlib.import_module(import_string), class_name, None
+                    )
+            except ImportError:
+                pass
+
+        if class_reference and inspect.isclass(class_reference):
+            return class_reference()
+    except FileNotFoundError as fnf_error:
+        logger.error(
+            "Exception while attempting to import file %s: %s", str(file_name), str(fnf_error)
+        )
+
+    return None
+
+
+def _get_filter_instances(file_path, filter_roots: list[str]) -> list[tuple[FilterInterface, str]]:
+    filter_instances = []
+
+    for root in filter_roots:
+        filter_obj = _get_class(file_path, root)
+
+        if isinstance(filter_obj, FilterInterface):
+            filter_instances.append((filter_obj, root))
+
+    return filter_instances
+
+
+def _get_filter(plugin_filter, filter_list, filter_roots):
+    if isinstance(plugin_filter, dict) and (
+        file_path := plugin_filter.get('filter_file_path', None)
+    ):
+        args = plugin_filter.get('args', [])
+        kwargs = plugin_filter.get('kwargs', {})
+
+        logger.info("Initialising filter: %s", str(file_path))
+
+        root_found = False
+        filters = _get_filter_instances(file_path, filter_roots)
+
+        for filter_instance, filter_root in filters:
+            if not root_found:
+                try:
+                    filter_instance.setup(*args, **kwargs)
+
+                    filter_list.append(filter_instance)
+
+                    logger.info("Found filter instance in root %s", str(filter_root))
+                    root_found = True
+                except TypeError as error:
+                    logger.warning(
+                        "Filter %s located in root %s "
+                        "crashed with Type Error %s. "
+                        "If the name of the given filter and its arguments "
+                        "correspond to the intended ones, the issue might be caused by "
+                        "the root configuration (%s). "
+                        "The script will keep searching for the filter in lower roots. "
+                        "In order to avoid this warning, please check if any of the roots "
+                        "contains a filter with the same path as %s. If so, "
+                        "consider renaming your filter or giving its root a higher priority "
+                        "(the highest priority is given to the first element of the list "
+                        "linked to the plugin filter roots env variable, "
+                        "while the last one has the lowest. "
+                        "To increase the priority of your root, "
+                        "move it towards the start of the list.). ",
+                        str(filter_instance),
+                        str(filter_root),
+                        str(error),
+                        str(filter_roots),
+                        str(file_path),
+                    )
+            else:
+                logger.info("Ignoring filter instance in root %s, ", str(filter_root))
+        if not root_found:
+            logger.warning(
+                "Filter %s could not be found in any of the examined roots (%s)",
+                str(file_path),
+                str(filter_roots),
+            )
+
+
+def get_filters(filter_dictionaries: list[dict], filter_roots: list[str] | None = None):
+    plugin_filters: list[FilterInterface] = []
+    filter_roots = filter_roots if filter_roots is not None else _get_root_list()
+
+    if filter_dictionaries is None or not isinstance(filter_dictionaries, list):
+        return plugin_filters
+
+    for plugin_filter in filter_dictionaries:
+        _get_filter(plugin_filter, plugin_filters, filter_roots)
+
+    # Reverse the filter list, since the first filter in the command should have the
+    # most decisional power (should be executed last).
+    plugin_filters.reverse()
+
+    return plugin_filters
+
+
+def _is_valid_suite(suite):
+    return suite.status not in [TwisterStatus.FILTER, TwisterStatus.SKIP] and not suite.skip
+
+
+def _get_filter_description(filter_obj: FilterInterface) -> str:
+    try:
+        source_file = os.path.basename(inspect.getfile(filter_obj.__class__))
+
+        return f"{os.path.splitext(source_file)[0]}.{filter_obj.__class__.__name__}"
+    except TypeError:
+        return ""
+
+
+def _run_filter(suite, filter_obj: FilterInterface):
+    if filter_obj.exclude(suite):
+        suite.skip = True
+
+        logger.debug(
+            "Test Suite %s excluded from test plan by filter %s%s",
+            str(suite.id),
+            _get_filter_description(filter_obj),
+            f": {reason}" if bool(reason := filter_obj.exclude_reason) else "",
+        )
+
+    if filter_obj.include(suite):
+        suite.skip = False
+
+        logger.debug(
+            "Test Suite %s included into test plan by filter %s%s",
+            str(suite.id),
+            _get_filter_description(filter_obj),
+            f": {reason}" if bool(reason := filter_obj.include_reason) else "",
+        )
+
+
+def handle_suite(suite, plugin_filters: list[FilterInterface]):
+    if _is_valid_suite(suite):
+        logger.debug("Examining Test Suite %s", str(suite.id))
+
+        for filter_obj in plugin_filters:
+            _run_filter(suite, filter_obj)

--- a/scripts/pylib/twister/plugin_filters/plugin_filters_api.py
+++ b/scripts/pylib/twister/plugin_filters/plugin_filters_api.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 Baumer Group. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from argparse import _ArgumentGroup
+
+from plugin_filters.args import args_descriptor, args_parser
+from plugin_filters.filter_interface import FilterInterface
+from plugin_filters.logic import filter_handler
+
+
+def plugin_filter_add_arguments(case_select: _ArgumentGroup):
+    return args_descriptor.add_arguments(case_select)
+
+
+def plugin_filter_parse_arguments(options):
+    return args_parser.parse_arguments(options)
+
+
+def plugin_filter_get_filters(
+    filter_dictionaries: list[dict], filter_roots: list[str] | None = None
+):
+    return filter_handler.get_filters(filter_dictionaries, filter_roots)
+
+
+def plugin_filter_handle_suite(suite, plugin_filters: list[FilterInterface]):
+    return filter_handler.handle_suite(suite, plugin_filters)
+
+
+def plugin_filter_teardown_filters(plugin_filters: list[FilterInterface]):
+    for plugin_filter in plugin_filters:
+        plugin_filter.teardown()

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -21,6 +21,10 @@ from importlib import metadata
 from pathlib import Path
 
 import zephyr_module
+from plugin_filters.plugin_filters_api import (
+    plugin_filter_add_arguments,
+    plugin_filter_parse_arguments,
+)
 from twisterlib.constants import SUPPORTED_SIMS
 from twisterlib.coverage import supported_coverage_formats
 from twisterlib.error import TwisterRuntimeError
@@ -150,6 +154,8 @@ Artificially long but functional example:
         action="store_true",
         help="Run only those tests that failed the previous twister run "
              "invocation.")
+
+    plugin_filter_add_arguments(case_select)
 
     test_plan_report_xor.add_argument("--list-tests", action="store_true",
                              help="""List of all sub-test functions recursively found in
@@ -1027,6 +1033,8 @@ def parse_arguments(
     elif on_init and options.allow_installed_plugin and PYTEST_PLUGIN_INSTALLED:
         logger.warning("You work with installed version of "
                        "pytest-twister-harness plugin.")
+
+    plugin_filter_parse_arguments(options)
 
     return options
 


### PR DESCRIPTION
## Introduction

The changes in this PR implement an interface that will allow custom-written filters to include and exclude test suites from the default twister test plan. This PR is a continuation of [Pull Request 65959](https://github.com/zephyrproject-rtos/zephyr/pull/65959).

### Problem description

Twister works with static information found in testcase.yaml and samples.yaml files. Dynamic information, such as an analysis of which files have changed compared to the main branch, for example, is not supported for filtering. The CI load for tests and static code analysis can be reduced by taking such dynamic information into account.

### Proposed change

Create a plugin interface to allow for project defined as well as user defined plugin filters.

## Detailed RFC

See Proposed change (Detailed)

### Proposed change (Detailed)

- Creation of a 'TWISTER_PLUGIN_FILTER_ROOTS' environmental variable, which shall contain a list of paths, pointing to the directories where filter files are saved. Thanks to this, filter paths in the `--plugin-filter` calls can always be considered relative, greatly shortening the length of the argument's parameters.
The list supports two types of paths: default ones, for example `/home/user/desktop/my_filters/`, and python paths, such as `plugin_filters.filters`. Python paths are only allowed for subdirectories of `zephyr/twister`, while default paths can use any folder for the filter search. 
**Note**: when running a plugin-filter, the filter_file_path must always correspond to the format of its root. 
For example, filter  `/home/user/desktop/my_filters/subdir/my_custom_filter.py` would imply `subdir/my_custom_filter.py` as file_filter_path and `/home/user/desktop/my_filters` as filter root.
On the other hand, the python path for filter `.../zephyr/twister/plugin_filters/filters/subdir/my_other_custom_filter.py` would be `subdir.my_other_custom_filter` for the filter and `plugin_filters.filters` for its root.

- Addition of three arguments to the Twister argparser

  - --plugin-filter, accepts a string containing filter data. This string must contain "blocks" separated by semicolons. Each block must start with the path to the filter, followed by the filter's args and kwargs (if required). 
  Examples:
  `--plugin-filter filter_id_regex '.*static'`
  `--plugin-filter filter_id_regex regex_pattern='.*static'`
  `--plugin-filter filter_id_regex '.*static'; filter_id_regex '.*twister'`

  - --plugin-filter-json-string, accepts a json-formatted string containing filter data. This string must contain a list with one or more dictionaries, each with at least a filter_file_path property (the path to the filter) and, if required, the filter's args and / or kwargs.
  Examples:
  `--plugin-filter-json-string '[{"filter_file_path": "filter_id_regex", "args": [".*static"]}]'`
  `--plugin-filter-json-string '[{"filter_file_path": "filter_id_regex", "kwargs": {"regex_pattern": ".*static"}}]'`

  - --plugin-filter-json-path, accepts a path pointing to a json file containing filter data. The data in said file must follow the same guidelines as the string in --plugin-filter-json-string.
  Examples:
  `--plugin-filter-json-path 'scripts/pylib/twister/plugin_filters/filters/filter_id_regex_example_conf.json'`
  `--plugin-filter-json-path '/home/user/filter_id_regex_example_conf.json'`

- Implementation of python files to handle the data received by the three arguments and translate it in a common format

- Implementation of logic permitting the selected filters to set the TestSuite.skip flag to True or False, depending on the exclude and include methods of each filter. 
**Note**: initially, all filters are included. The code will iterate through the filter list and run each filter's exclude (executed first) and include (called only after exclude) methods. If multiple filters are selected, the code is based on **FILO** (first in last out). This means that each filter in the list will be able to override decisions made by the ones contained later in the the list, while its inclusions / exclusions can be overridden by the ones defined earlier. An example execution would follow this logic:

  - Command: `--plugin-filter my_filter1; my_filter2; my_filter3`
  - Initial suites: ['one', 'two', 'three', 'four', 'five', 'six', 'seven']
  - my_filter3 excludes one, four and five. Suites becomes ['two', 'three', 'six', 'seven']
  - my_filter2 excludes two and six, includes four. Suites becomes ['three', 'four', 'seven']
  - my_filter1 excludes three, includes five and six. Suites becomes ['four', 'five', 'six', 'seven']

  Note: if a filter excludes and includes a suite at the same time, said suite will be **included**

  Note: if the skip flag of a filter was set to `True` outside of the Plugin environment, the filters will ignore it to prevent its reactivation.

### Dependencies

Python Dependencies:
- os
- sys
- json
- shlex
- inspect
- argparse
- importlib
- re (for regex filter)

Twister Dependencies:
- Environment.py
- TestPlan.py

### Concerns and Unresolved Questions

No concerns or unresolved questions

## Alternatives

Leave twister as is
