### PR TITLE
[Backport v3.7-branch] logging: fixes and enhancements to initialization and shell cmds

### DIFF
--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -83,6 +83,7 @@ struct log_backend_control_block {
 	void *ctx;
 	uint8_t id;
 	bool active;
+	bool initialized;
 
 	/* Initialization level. */
 	uint8_t level;
@@ -140,6 +141,7 @@ static inline void log_backend_init(const struct log_backend *const backend)
 	if (backend->api->init) {
 		backend->api->init(backend);
 	}
+	backend->cb->initialized = true;
 }
 
 /**

--- a/subsys/logging/log_cmds.c
+++ b/subsys/logging/log_cmds.c
@@ -342,7 +342,19 @@ static int log_go(const struct shell *sh,
 		  char **argv)
 {
 	if (backend || !IS_ENABLED(CONFIG_LOG_FRONTEND)) {
-		log_backend_activate(backend, backend->cb->ctx);
+		if (!backend->cb->initialized) {
+			log_backend_init(backend);
+			while (log_backend_is_ready(backend) != 0) {
+				if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+					k_msleep(10);
+				}
+			}
+			if (log_backend_is_ready(backend) == 0) {
+				log_backend_enable(backend, backend->cb->ctx, CONFIG_LOG_MAX_LEVEL);
+			}
+		} else {
+			log_backend_activate(backend, backend->cb->ctx);
+		}
 		return 0;
 	}
 

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -286,6 +286,14 @@ void log_core_init(void)
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
 		z_log_runtime_filters_init();
 	}
+
+	STRUCT_SECTION_FOREACH(log_backend, backend) {
+		uint32_t id;
+		/* As first slot in filtering mask is reserved, backend ID has offset.*/
+		id = LOG_FILTER_FIRST_BACKEND_SLOT_IDX;
+		id += backend - log_backend_get(0);
+		log_backend_id_set(backend, id);
+	}
 }
 
 static uint32_t activate_foreach_backend(uint32_t mask)

--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -553,12 +553,6 @@ void log_backend_enable(struct log_backend const *const backend,
 			void *ctx,
 			uint32_t level)
 {
-	/* As first slot in filtering mask is reserved, backend ID has offset.*/
-	uint32_t id = LOG_FILTER_FIRST_BACKEND_SLOT_IDX;
-
-	id += backend - log_backend_get(0);
-
-	log_backend_id_set(backend, id);
 	backend->cb->level = level;
 	backend_filter_set(backend, level);
 	log_backend_activate(backend, ctx);


### PR DESCRIPTION
Backport from #84955 + #87097

The fix in #84955 introduce a bug which is fixed later by #87097, this PR is a combination of both, so that it fixes things without introducing bugs

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/84952
___

## Test

```
west build -b qemu_riscv64 -p auto -t run zephyr/samples/hello_world -- -DCONFIG_LOG=y -DCONFIG_SHELL=y -DCONFIG_LOG_CMDS=y -DCONFIG_LOG_BACKEND_UART=y -DCONFIG_LOG_BACKEND_UART_AUTOSTART=n
```

**Before the patch**
<details>

<summary>Full console log</summary>

```
Hello World! qemu_riscv64/qemu_virt_riscv64


*** Booting Zephyr OS build v3.7.1-113-gcab2f9d27f3e ***
uart:~$ log list_backends
log_backend_uart
        - Status: disabled
        - ID: 0

shell_uart_backend
        - Status: enabled
        - ID: 2

uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | inf     | inf
getopt                                   | inf     | inf
log                                      | inf     | inf
log_mgmt                                 | inf     | inf
log_uart                                 | inf     | inf
mpu                                      | inf     | inf
os                                       | inf     | inf
shell.shell_uart                         | inf     | inf
shell_uart                               | inf     | inf
uart_ns16550                             | inf     | inf
uart:~$ log backend log_backend_uart status
Logs are halted!
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | inf     | inf
getopt                                   | inf     | inf
log                                      | inf     | inf
log_mgmt                                 | inf     | inf
log_uart                                 | inf     | inf
mpu                                      | inf     | inf
os                                       | inf     | inf
shell.shell_uart                         | inf     | inf
shell_uart                               | inf     | inf
uart_ns16550                             | inf     | inf
uart:~$ log backend shell_uart_backend enable wrn
uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | wrn     | inf
getopt                                   | wrn     | inf
log                                      | wrn     | inf
log_mgmt                                 | wrn     | inf
log_uart                                 | wrn     | inf
mpu                                      | wrn     | inf
os                                       | wrn     | inf
shell.shell_uart                         | wrn     | inf
shell_uart                               | wrn     | inf
uart_ns16550                             | wrn     | inf
uart:~$ log backend log_backend_uart status
Logs are halted!
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | wrn     | inf
getopt                                   | wrn     | inf
log                                      | wrn     | inf
log_mgmt                                 | wrn     | inf
log_uart                                 | wrn     | inf
mpu                                      | wrn     | inf
os                                       | wrn     | inf
shell.shell_uart                         | wrn     | inf
shell_uart                               | wrn     | inf
uart_ns16550                             | wrn     | inf
uart:~$ 
```
</details>

**After the patch:**
```
Hello World! qemu_riscv64/qemu_virt_riscv64


*** Booting Zephyr OS build v3.7.1-115-gd9d6b62c29d5 ***
uart:~$ log list_backends
log_backend_uart
        - Status: disabled
        - ID: 1

shell_uart_backend
        - Status: enabled
        - ID: 2

uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | inf     | inf
getopt                                   | inf     | inf
log                                      | inf     | inf
log_mgmt                                 | inf     | inf
log_uart                                 | inf     | inf
mpu                                      | inf     | inf
os                                       | inf     | inf
shell.shell_uart                         | inf     | inf
shell_uart                               | inf     | inf
uart_ns16550                             | inf     | inf
uart:~$ log backend log_backend_uart status
Logs are halted!
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | none    | inf
getopt                                   | none    | inf
log                                      | none    | inf
log_mgmt                                 | none    | inf
log_uart                                 | none    | inf
mpu                                      | none    | inf
os                                       | none    | inf
shell.shell_uart                         | none    | inf
shell_uart                               | none    | inf
uart_ns16550                             | none    | inf
uart:~$ log backend shell_uart_backend enable wrn
uart:~$ log backend shell_uart_backend status
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | wrn     | inf
getopt                                   | wrn     | inf
log                                      | wrn     | inf
log_mgmt                                 | wrn     | inf
log_uart                                 | wrn     | inf
mpu                                      | wrn     | inf
os                                       | wrn     | inf
shell.shell_uart                         | wrn     | inf
shell_uart                               | wrn     | inf
uart_ns16550                             | wrn     | inf
uart:~$ log backend log_backend_uart status
Logs are halted!
module_name                              | current | built-in 
----------------------------------------------------------
cbprintf_package                         | none    | inf
getopt                                   | none    | inf
log                                      | none    | inf
log_mgmt                                 | none    | inf
log_uart                                 | none    | inf
mpu                                      | none    | inf
os                                       | none    | inf
shell.shell_uart                         | none    | inf
shell_uart                               | none    | inf
uart_ns16550                             | none    | inf
uart:~$ 
```