### PR TITLE
net: conn_mgr: sntp: logging: backend: net: extend usage

### DIFF
--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -26,7 +26,7 @@ extern "C" {
  * @brief Connection Manager Connectivity API
  * @defgroup conn_mgr_connectivity Connection Manager Connectivity API
  * @since 3.4
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup networking
  * @{
  */

--- a/include/zephyr/net/conn_mgr_connectivity_impl.h
+++ b/include/zephyr/net/conn_mgr_connectivity_impl.h
@@ -27,7 +27,7 @@ extern "C" {
  * @brief Connection Manager Connectivity Implementation API
  * @defgroup conn_mgr_connectivity_impl Connection Manager Connectivity Implementation API
  * @since 3.4
- * @version 0.1.0
+ * @version 0.8.0
  * @ingroup conn_mgr_connectivity
  * @{
  */

--- a/subsys/logging/backends/Kconfig.net
+++ b/subsys/logging/backends/Kconfig.net
@@ -119,6 +119,17 @@ config LOG_BACKEND_NET_AUTOSTART
 	  started by the application later on. Otherwise the logging
 	  thread might block.
 
+config LOG_BACKEND_NET_USE_CONNECTION_MANAGER
+	bool "Use connection manager for start and stop networking backend"
+	depends on NET_CONNECTION_MANAGER
+	depends on LOG_BACKEND_NET_AUTOSTART
+	default y
+	help
+	  When enabled the connection manager will be used to start and stop
+	  the networking backend. This is useful when the application
+	  needs to wait for the network connection to be established before
+	  starting the logging backend.
+
 config LOG_BACKEND_NET_USE_DHCPV4_OPTION
 	bool "Use DHCPv4 Log Server Option to configure syslog server"
 	depends on NET_DHCPV4

--- a/subsys/logging/backends/log_backend_net.c
+++ b/subsys/logging/backends/log_backend_net.c
@@ -338,9 +338,18 @@ static void panic(struct log_backend const *const backend)
 	panic_mode = true;
 }
 
+/* After initialization of the logger, this function avoids
+ * the logger subsys to enable it.
+ */
+static int backend_ready(const struct log_backend *const backend)
+{
+	return log_backend_is_active(backend) ? 0 : -EAGAIN;
+}
+
 const struct log_backend_api log_backend_net_api = {
 	.panic = panic,
 	.init = init_net,
+	.is_ready = backend_ready,
 	.process = process,
 	.format_set = format_set,
 };

--- a/subsys/net/conn_mgr/Kconfig
+++ b/subsys/net/conn_mgr/Kconfig
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_CONNECTION_MANAGER
-	bool "Network connection manager [EXPERIMENTAL]"
+	bool "Network connection manager"
 	depends on NET_IPV6 || NET_IPV4
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
-	select EXPERIMENTAL
 	help
 	  When enabled, this will start the connection manager that will
 	  listen to network interface and IP events in order to verify

--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -257,5 +257,14 @@ config NET_CONFIG_SNTP_INIT_RESYNC_ON_FAILURE_INTERVAL
 	  If the SNTP request fails, then this is the interval to wait
 	  before trying again.
 
+config NET_CONFIG_SNTP_INIT_USE_CONNECTION_MANAGER
+	bool "Use connection manager to start and stop SNTP client"
+	default y
+	depends on NET_CONNECTION_MANAGER
+	help
+	  If this option is set, then the connection manager is used to
+	  start and stop the SNTP server. This way an SNTP request is
+	  also sent everytime when the network connection is established.
+
 endif # NET_CONFIG_SNTP_INIT_RESYNC
 endif # NET_CONFIG_CLOCK_SNTP_INIT

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -546,7 +546,8 @@ int net_config_init_app(const struct device *dev, const char *app_info)
 		NET_ERR("Network initialization failed (%d)", ret);
 	}
 
-	if (IS_ENABLED(CONFIG_NET_CONFIG_CLOCK_SNTP_INIT)) {
+	if (IS_ENABLED(CONFIG_NET_CONFIG_CLOCK_SNTP_INIT) &&
+	    !IS_ENABLED(CONFIG_NET_CONFIG_SNTP_INIT_USE_CONNECTION_MANAGER)) {
 		net_init_clock_via_sntp();
 	}
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -553,7 +553,8 @@ int net_config_init_app(const struct device *dev, const char *app_info)
 	/* This is activated late as it requires the network stack to be up
 	 * and running before syslog messages can be sent to network.
 	 */
-	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART)) {
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART) &&
+	    !IS_ENABLED(CONFIG_LOG_BACKEND_NET_USE_CONNECTION_MANAGER)) {
 		log_backend_net_start();
 	}
 

--- a/subsys/net/lib/config/init_clock_sntp.c
+++ b/subsys/net/lib/config/init_clock_sntp.c
@@ -10,6 +10,7 @@ LOG_MODULE_DECLARE(net_config, CONFIG_NET_CONFIG_LOG_LEVEL);
 
 #include <errno.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/sntp.h>
 #include <zephyr/posix/time.h>
 
@@ -86,3 +87,24 @@ static void sntp_resync_handler(struct k_work *work)
 	LOG_DBG("Time resynced using SNTP");
 }
 #endif /* CONFIG_NET_CONFIG_SNTP_INIT_RESYNC */
+
+#ifdef CONFIG_NET_CONFIG_SNTP_INIT_USE_CONNECTION_MANAGER
+static void l4_event_handler(uint32_t mgmt_event, struct net_if *iface, void *info,
+			     size_t info_length, void *user_data)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(info);
+	ARG_UNUSED(info_length);
+	ARG_UNUSED(user_data);
+
+	if (mgmt_event == NET_EVENT_L4_CONNECTED) {
+		k_work_reschedule(&sntp_resync_work_handle, K_NO_WAIT);
+	} else if (mgmt_event == NET_EVENT_L4_DISCONNECTED) {
+		k_work_cancel_delayable(&sntp_resync_work_handle);
+	}
+}
+
+NET_MGMT_REGISTER_EVENT_HANDLER(sntp_init_event_handler,
+				NET_EVENT_L4_CONNECTED | NET_EVENT_L4_DISCONNECTED,
+				&l4_event_handler, NULL);
+#endif /* CONFIG_LOG_BACKEND_NET_USE_CONNECTION_MANAGER */

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1201,7 +1201,8 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 			log_backend_net_set_ip((struct sockaddr *)&log_server);
 
 			if (IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART) &&
-			    !IS_ENABLED(CONFIG_NET_CONFIG_SETTINGS)) {
+			    !IS_ENABLED(CONFIG_NET_CONFIG_SETTINGS) &&
+			    !IS_ENABLED(CONFIG_LOG_BACKEND_NET_USE_CONNECTION_MANAGER)) {
 				log_backend_net_start();
 			}
 

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1200,9 +1200,10 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 			log_server.sin_family = AF_INET;
 			log_backend_net_set_ip((struct sockaddr *)&log_server);
 
-#ifdef CONFIG_LOG_BACKEND_NET_AUTOSTART
-			log_backend_net_start();
-#endif
+			if (IS_ENABLED(CONFIG_LOG_BACKEND_NET_AUTOSTART) &&
+			    !IS_ENABLED(CONFIG_NET_CONFIG_SETTINGS)) {
+				log_backend_net_start();
+			}
 
 			NET_DBG("options_log_server: %s", net_sprint_ipv4_addr(&log_server));
 


### PR DESCRIPTION
log backend net:
- When used when used with CONFIG_NET_IPV4_ACD and CONFIG_LOG_BACKEND_NET_USE_DHCPV4_OPTION a lot of warnings about dropped packages are generated, this fixes it. When used with the connection manager it is completely fixed, without it just at startup.
- can now use the connection manager to enable and disable the backend

net config init sntp:
- add option to use the connection manager

connection manager:
- set to unstable as it is used by multiple parts in zephyr and numerous samples

Fixes: #89643
