### PR TITLE
drivers: firmware: nrf_ironside: Minor fixes

### DIFF
--- a/drivers/firmware/CMakeLists.txt
+++ b/drivers/firmware/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # zephyr-keep-sorted-start
-add_subdirectory(nrf_ironside)
 add_subdirectory_ifdef(CONFIG_ARM_SCMI scmi)
+add_subdirectory_ifdef(CONFIG_NRF_IRONSIDE nrf_ironside)
 # zephyr-keep-sorted-stop

--- a/drivers/firmware/nrf_ironside/Kconfig
+++ b/drivers/firmware/nrf_ironside/Kconfig
@@ -1,10 +1,16 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+config NRF_IRONSIDE
+	bool
+	depends on SOC_NRF54H20_IRON
+	help
+	  This is selected by drivers interacting with Nordic IRONside firmware.
+
 config NRF_IRONSIDE_CALL
 	bool
 	depends on DT_HAS_NORDIC_IRONSIDE_CALL_ENABLED
-	depends on SOC_NRF54H20_IRON
+	select NRF_IRONSIDE
 	select EVENTS
 	select MBOX
 	help

--- a/drivers/firmware/nrf_ironside/call.c
+++ b/drivers/firmware/nrf_ironside/call.c
@@ -29,8 +29,8 @@ BUILD_ASSERT((sizeof(struct ironside_call_buf) % CONFIG_DCACHE_LINE_SIZE) == 0);
 static const struct mbox_dt_spec mbox_rx = MBOX_DT_SPEC_INST_GET(0, rx);
 static const struct mbox_dt_spec mbox_tx = MBOX_DT_SPEC_INST_GET(0, tx);
 
-K_EVENT_DEFINE(alloc_evts);
-K_EVENT_DEFINE(rsp_evts);
+static K_EVENT_DEFINE(alloc_evts);
+static K_EVENT_DEFINE(rsp_evts);
 
 static void ironside_call_rsp(const struct device *dev, mbox_channel_id_t channel_id,
 			      void *user_data, struct mbox_msg *data)


### PR DESCRIPTION
* Guard behind `CONFIG_NRF_IRONSIDE`
* Make events static