### PR TITLE
drivers: wifi: nxp: Select EVENTS

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -10,6 +10,7 @@ menuconfig WIFI_NXP
 	select SDHC if !SOC_SERIES_RW6XX
 	select SDIO_STACK if !SOC_SERIES_RW6XX
 	select WIFI_NM
+	select EVENTS
 	depends on DT_HAS_NXP_WIFI_ENABLED
 	help
 	  Enable NXP SoC Wi-Fi support.


### PR DESCRIPTION
The driver uses k_event objects and needs to select the EVENTS kconfig option.

Fixes #89320