### PR TITLE
tests: spi_loopback: fix null_rx_buf test

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -340,7 +340,7 @@ ZTEST(spi_loopback, test_spi_null_rx_buf_set)
 {
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];
 	const struct spi_buf_set tx = spi_loopback_setup_xfer(tx_bufs_pool, 1,
-							      NULL, BUF_SIZE);
+							      buffer_tx, BUF_SIZE);
 
 	spi_loopback_transceive(spec, &tx, NULL);
 }


### PR DESCRIPTION
This commit fixes the SPI loopback test for devices using the mcux_ecspi driver.
The driver expects either the rx or tx buffer not to be null. If this is not the case, a error code is returned resulting in a failed loopback test.
This check finds place in `hal-nxp/mcux/mcux-sdk/drivers/ecspi/fsl_exspi:732`.

Exactly this is done in the `test_spi_null_rx_buf_set` function.
It should test the behavior if having a rx buffer that is NULL, but also uses a tx buffer that is from the driver point of view NULL.

The fix is to add a tx buffer to the spi loopback test function `test_spi_null_rx_buf_set`.


To be honest, I am not quite sure if changing the test is the correct way to fix that behavior or if patching it in the MCUX driver would be the better solution.