### PR TITLE
boards: Remove nxp board-vendor from non-NXP boards

### DIFF
--- a/boards/element14/warp7/warp7_mcimx7d_m4.yaml
+++ b/boards/element14/warp7/warp7_mcimx7d_m4.yaml
@@ -20,4 +20,3 @@ testing:
 supported:
   - gpio
   - i2c
-vendor: nxp

--- a/boards/madmachine/mm_feather/mm_feather.yaml
+++ b/boards/madmachine/mm_feather/mm_feather.yaml
@@ -22,4 +22,3 @@ supported:
   - uart
   - pwm
   - spi
-vendor: nxp

--- a/boards/madmachine/mm_swiftio/mm_swiftio.yaml
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.yaml
@@ -16,4 +16,3 @@ flash: 8192
 supported:
   - counter
   - sdhc
-vendor: nxp

--- a/boards/phytec/phyboard_polis/phyboard_polis_mimx8mm6_m4.yaml
+++ b/boards/phytec/phyboard_polis/phyboard_polis_mimx8mm6_m4.yaml
@@ -22,4 +22,3 @@ supported:
   - spi
   - gpio
   - can
-vendor: nxp

--- a/boards/phytec/phyboard_pollux/phyboard_pollux_mimx8ml8_m7.yaml
+++ b/boards/phytec/phyboard_pollux/phyboard_pollux_mimx8ml8_m7.yaml
@@ -20,4 +20,3 @@ testing:
 supported:
   - uart
   - gpio
-vendor: nxp

--- a/boards/pjrc/teensy4/teensy40.yaml
+++ b/boards/pjrc/teensy4/teensy40.yaml
@@ -21,4 +21,3 @@ testing:
   ignore_tags:
     - net
     - posix
-vendor: nxp

--- a/boards/pjrc/teensy4/teensy41.yaml
+++ b/boards/pjrc/teensy4/teensy41.yaml
@@ -23,4 +23,3 @@ testing:
   ignore_tags:
     - net
     - posix
-vendor: nxp

--- a/boards/segger/ip_k66f/ip_k66f.yaml
+++ b/boards/segger/ip_k66f/ip_k66f.yaml
@@ -14,4 +14,3 @@ supported:
   - netif:eth
 ram: 256
 flash: 2048
-vendor: nxp

--- a/boards/technexion/pico_pi/pico_pi_mcimx7d_m4.yaml
+++ b/boards/technexion/pico_pi/pico_pi_mcimx7d_m4.yaml
@@ -17,4 +17,3 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: nxp

--- a/boards/toradex/colibri_imx7d/colibri_imx7d_mcimx7d_m4.yaml
+++ b/boards/toradex/colibri_imx7d/colibri_imx7d_mcimx7d_m4.yaml
@@ -19,4 +19,3 @@ testing:
     - bluetooth
 supported:
   - pwm
-vendor: nxp

--- a/boards/udoo/udoo_neo_full/udoo_neo_full_mcimx6x_m4.yaml
+++ b/boards/udoo/udoo_neo_full/udoo_neo_full_mcimx6x_m4.yaml
@@ -17,4 +17,3 @@ supported:
   - counter
   - gpio
   - uart
-vendor: nxp


### PR DESCRIPTION
- Delete nxp board-vendor references from non-NXP board .yaml files.
- board.yml files already contain the correct board-vendor names.