### PR TITLE
display: stm32_ltdc: rework blanking_on/off

### DIFF
--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -63,7 +63,14 @@ static inline int display_setup(const struct device *const display_dev, const ui
 		return ret;
 	}
 
-	return display_blanking_off(display_dev);
+	/* Turn off blanking if driver supports it */
+	ret = display_blanking_off(display_dev);
+	if (ret == -ENOSYS) {
+		LOG_DBG("Display blanking off not available");
+		ret = 0;
+	}
+
+	return ret;
 }
 
 static inline void video_display_frame(const struct device *const display_dev,

--- a/samples/subsys/display/cfb_custom_font/src/main.c
+++ b/samples/subsys/display/cfb_custom_font/src/main.c
@@ -27,7 +27,10 @@ int main(void)
 		}
 	}
 
-	if (display_blanking_off(display) != 0) {
+	err = display_blanking_off(display);
+	if (err == -ENOSYS) {
+		printk("Display blanking off not available");
+	} else if (err) {
 		printk("Failed to turn off display blanking\n");
 		return 0;
 	}


### PR DESCRIPTION
The display_blanking_on description states that if available, backlight should also be disabled / enabled on driver blanking on / off. Moreover, upon driver initialization, the display blanking (hence backlight state as well) should be same as if display_blanking_on had been called.

For those reasons, keep the backlight off upon initialization of the driver. Moreover, the LTDC driver does not always have a display_controller attached to it, hence do not return an error when there is no display_controller.

------

I've successfully tested this on STM32MP13xx using the samples/driver/display and on STM32N6 using the samples/driver/video/capture however it would be great if other platforms could be tested as well.