### PR TITLE
boards: beagle: beagleconnect_freedom: Enable watchdog timer

### DIFF
--- a/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
+++ b/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
@@ -23,6 +23,7 @@
 		mcuboot-button0 = &button0;
 		sensor0 = &light;
 		sensor1 = &humidity;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {
@@ -284,4 +285,8 @@
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};
+};
+
+&wdt0 {
+	status = "okay";
 };


### PR DESCRIPTION
Enable watchdog timer in the base tree. This is required for MicroPython.