### PR TITLE
storage/stream_flash: Fix description of erased_up_to

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -65,8 +65,11 @@ struct stream_flash_ctx {
 	stream_flash_callback_t callback; /* Callback invoked after write op */
 #endif
 #ifdef CONFIG_STREAM_FLASH_ERASE
-	size_t erased_up_to;		/* Offset of last erased byte, relative to
-					 * offset in this context.
+	size_t erased_up_to;		/* First offset in continuous range,
+					 * relative to the stream_flash_ctx.offset,
+					 * that has not yet been erased while
+					 * preparing Stream Flash designated area
+					 * for write.
 					 */
 #endif
 	size_t write_block_size;	/* Offset/size device write alignment */


### PR DESCRIPTION
The description incorrectly stated that it points to last erased offset, while it actually points to first offset that has not yet been erased.