### PR TITLE
net: mdns increase buf size

### DIFF
--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -206,6 +206,12 @@ config MDNS_RESPONDER
 
 if MDNS_RESPONDER
 
+config MDNS_RESOLVER_BUF_SIZE
+	int "Size of the net_buf pool buffers"
+	default 512
+	help
+	  For larger DNS SD TXT records and long service instance names, bigger buffers are necessary
+
 config MDNS_RESPONDER_TTL
 	int "Time-to-Live of returned DNS name"
 	default 600

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -115,8 +115,9 @@ static int setup_dst_addr(int sock, sa_family_t family,
 #define DNS_RESOLVER_BUF_CTR	(DNS_RESOLVER_MIN_BUF + \
 				 CONFIG_MDNS_RESOLVER_ADDITIONAL_BUF_CTR)
 
+#define MDNS_RESOLVER_BUF_SIZE CONFIG_MDNS_RESOLVER_BUF_SIZE
 NET_BUF_POOL_DEFINE(mdns_msg_pool, DNS_RESOLVER_BUF_CTR,
-		    DNS_RESOLVER_MAX_BUF_SIZE, 0, NULL);
+		    MDNS_RESOLVER_BUF_SIZE, 0, NULL);
 
 static void create_ipv6_addr(struct sockaddr_in6 *addr)
 {
@@ -595,7 +596,7 @@ static int dns_read(int sock,
 	int queries;
 	int ret;
 
-	data_len = MIN(len, DNS_RESOLVER_MAX_BUF_SIZE);
+	data_len = MIN(len, MDNS_RESOLVER_BUF_SIZE);
 
 	/* Store the DNS query name into a temporary net_buf, which will be
 	 * eventually used to send a response


### PR DESCRIPTION
for longer DNS-SD text records and instance names we need a bigger buffer