### PR TITLE
soc: nxp: imxrt: fix incorrect flexram partition function call

### DIFF
--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -367,7 +367,7 @@ void soc_reset_hook(void)
 
 #if defined(FLEXRAM_RUNTIME_BANKS_USED)
 	/* Configure flexram if not running from RAM */
-	memc_flexram_dt_partition();
+	flexram_dt_partition();
 #endif
 }
 #endif

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -782,7 +782,7 @@ void __used _soc_reset_hook(void)
 
 #if defined(FLEXRAM_RUNTIME_BANKS_USED)
 	/* Configure flexram if not running from RAM */
-	memc_flexram_dt_partition();
+	flexram_dt_partition();
 #endif
 }
 #endif


### PR DESCRIPTION
Replace incorrect call to memc_flexram_dt_partition() with flexram_dt_partition() to resolve build error on
IMXRT10xx and IMXRT11xx. 

Error was introduced in commit [db63e563a950](https://github.com/zephyrproject-rtos/zephyr/commit/db63e563a950dbea4ebd8213009a701d2f0247f5)