### PR TITLE
Fix operation bounds check for Flash Map API

### DIFF
--- a/subsys/storage/flash_map/flash_map_priv.h
+++ b/subsys/storage/flash_map/flash_map_priv.h
@@ -33,7 +33,7 @@ static inline struct flash_area const *get_flash_area_from_id(int idx)
 static inline bool is_in_flash_area_bounds(const struct flash_area *fa,
 					   off_t off, size_t len)
 {
-	return (off >= 0) && ((off + len) <= fa->fa_size);
+	return (off >= 0) && (off < fa->fa_size) && (len <= (fa->fa_size - off));
 }
 
 #endif /* ZEPHYR_SUBSYS_STORAGE_FLASH_MAP_PRIV_H_ */


### PR DESCRIPTION
All functions area using is_in_flash_area_bounds for checking parameters; the function was not immune to integer overflow.
The PR fixes the function and adds test scenario for overflows.

Fixes #89349