### PR TITLE
samples: sensor: lps22hh: fix title

### DIFF
--- a/samples/sensor/lps22hh/README.rst
+++ b/samples/sensor/lps22hh/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: lps22hh
-   :name: LPSS22HH Temperature and Pressure Sensor
+   :name: LPS22HH Temperature and Pressure Sensor
    :relevant-api: sensor_interface
 
    Get pressure and temperature data from an LPS22HH sensor (polling & trigger mode).

--- a/samples/sensor/lps22hh_i3c/README.rst
+++ b/samples/sensor/lps22hh_i3c/README.rst
@@ -1,5 +1,5 @@
 .. zephyr:code-sample:: lps22hh_i3c
-   :name: LPSS22HH Temperature and Pressure Sensor (I3C)
+   :name: LPS22HH Temperature and Pressure Sensor (I3C)
    :relevant-api: sensor_interface
 
    Get pressure and temperature data from an LPS22HH sensor over I3C (polling &


### PR DESCRIPTION
The name of the sensor in the title had one S too many, it should be LPS22HH instead of LPSS22HH.

Same for the I3C version of the sample.