### PR TITLE
GPIO driver support for RW61x PM3

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -5,6 +5,7 @@
  */
 
 #define DT_DRV_COMPAT nxp_lpc_gpio_port
+
 /** @file
  * @brief GPIO driver for LPC54XXX family
  *
@@ -37,31 +38,32 @@
 #define INT_SOURCE_NONE 3
 
 struct gpio_mcux_lpc_config {
- /* gpio_driver_config needs to be first */
- struct gpio_driver_config common;
- GPIO_Type *gpio_base;
- uint8_t int_source;
+	/* gpio_driver_config needs to be first */
+	struct gpio_driver_config common;
+	GPIO_Type *gpio_base;
+	uint8_t int_source;
 #ifdef IOPCTL
- IOPCTL_Type *pinmux_base;
+	IOPCTL_Type *pinmux_base;
 #endif
 #ifdef IOCON
- IOCON_Type *pinmux_base;
+	IOCON_Type *pinmux_base;
 #endif
 #ifdef MCI_IO_MUX
- MCI_IO_MUX_Type * pinmux_base;
+	MCI_IO_MUX_Type * pinmux_base;
 #endif
- uint32_t port_no;
+	uint32_t port_no;
 };
 
 struct gpio_mcux_lpc_data {
- /* gpio_driver_data needs to be first */
- struct gpio_driver_data common;
- /* port ISR callback routine address */
- sys_slist_t callbacks;
+	/* gpio_driver_data needs to be first */
+	struct gpio_driver_data common;
+	/* port ISR callback routine address */
+	sys_slist_t callbacks;
 };
+
 #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
-      defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
-      defined(CONFIG_PM_DEVICE))
+	defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+	defined(CONFIG_PM_DEVICE))
 static struct gpio_mux_registers_context_t{
 	/*GPIO Configuration Registers*/
 	uint32_t DIR[2];
@@ -70,182 +72,182 @@ static struct gpio_mux_registers_context_t{
 	uint32_t INTENB[2];
 	uint32_t INTPOL[2];
 	uint32_t INTEDG[2];
-	/*PinCtrl Configuration Registers*/                         
-	uint32_t GPIO_GRP0;                         
-	uint32_t GPIO_GRP1;                         
+	/*PinCtrl Configuration Registers*/
+	uint32_t GPIO_GRP0;
+	uint32_t GPIO_GRP1;
 }gpio_mux_registers_context;
 #endif /*RW612/RW610 MCU*/
 
 static int gpio_mcux_lpc_configure(const struct device *dev, gpio_pin_t pin,
-				gpio_flags_t flags)
+				   gpio_flags_t flags)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- GPIO_Type *gpio_base = config->gpio_base;
- uint32_t port = config->port_no;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	GPIO_Type *gpio_base = config->gpio_base;
+	uint32_t port = config->port_no;
 
- if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
-	 return -ENOTSUP;
- }
+	if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
+		return -ENOTSUP;
+	}
 
 #ifdef IOPCTL /* RT600 and RT500 series */
- IOPCTL_Type *pinmux_base = config->pinmux_base;
- volatile uint32_t *pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
+	IOPCTL_Type *pinmux_base = config->pinmux_base;
+	volatile uint32_t *pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
 
- /*
-  * Enable input buffer for both input and output pins, it costs
-  * nothing and allows values to be read back.
-  */
- *pinconfig |= IOPCTL_PIO_INBUF_EN;
+	/*
+	 * Enable input buffer for both input and output pins, it costs
+	 * nothing and allows values to be read back.
+	 */
+	*pinconfig |= IOPCTL_PIO_INBUF_EN;
 
- if ((flags & GPIO_SINGLE_ENDED) != 0) {
-	 *pinconfig |= IOPCTL_PIO_PSEDRAIN_EN;
- } else {
-	 *pinconfig &= ~IOPCTL_PIO_PSEDRAIN_EN;
- }
- /* Select GPIO mux for this pin (func 0 is always GPIO) */
- *pinconfig &= ~(IOPCTL_PIO_FSEL_MASK);
+	if ((flags & GPIO_SINGLE_ENDED) != 0) {
+		*pinconfig |= IOPCTL_PIO_PSEDRAIN_EN;
+	} else {
+		*pinconfig &= ~IOPCTL_PIO_PSEDRAIN_EN;
+	}
+	/* Select GPIO mux for this pin (func 0 is always GPIO) */
+	*pinconfig &= ~(IOPCTL_PIO_FSEL_MASK);
 #endif
 #ifdef IOCON /* LPC SOCs */
- volatile uint32_t *pinconfig;
- IOCON_Type *pinmux_base;
+	volatile uint32_t *pinconfig;
+	IOCON_Type *pinmux_base;
 
- pinmux_base = config->pinmux_base;
- pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
+	pinmux_base = config->pinmux_base;
+	pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
 
- if ((flags & GPIO_SINGLE_ENDED) != 0) {
-	 /* Set ODE bit. */
-	 *pinconfig |= IOCON_PIO_OD_MASK;
- }
+	if ((flags & GPIO_SINGLE_ENDED) != 0) {
+		/* Set ODE bit. */
+		*pinconfig |= IOCON_PIO_OD_MASK;
+	}
 
- if ((flags & GPIO_INPUT) != 0) {
-	 /* Set DIGIMODE bit */
-	 *pinconfig |= IOCON_PIO_DIGIMODE_MASK;
- }
- /* Select GPIO mux for this pin (func 0 is always GPIO) */
- *pinconfig &= ~(IOCON_PIO_FUNC_MASK);
+	if ((flags & GPIO_INPUT) != 0) {
+		/* Set DIGIMODE bit */
+		*pinconfig |= IOCON_PIO_DIGIMODE_MASK;
+	}
+	/* Select GPIO mux for this pin (func 0 is always GPIO) */
+	*pinconfig &= ~(IOCON_PIO_FUNC_MASK);
 #endif
 #ifdef MCI_IO_MUX /* RW61x SOCs */
-	 /* Construct a pin control state, and apply it directly. */
-	 pinctrl_soc_pin_t pin_cfg;
+		/* Construct a pin control state, and apply it directly. */
+		pinctrl_soc_pin_t pin_cfg;
 
-	 if (config->port_no == 1) {
-		 pin_cfg = IOMUX_GPIO_IDX(pin + 32) | IOMUX_TYPE(IOMUX_GPIO);
-	 } else {
-		 pin_cfg = IOMUX_GPIO_IDX(pin) | IOMUX_TYPE(IOMUX_GPIO);
-	 }
-	 /* Add pull up flags, if required */
-	 if ((flags & GPIO_PULL_UP) != 0) {
-		 pin_cfg |= IOMUX_PAD_PULL(0x1);
-	 } else if ((flags & GPIO_PULL_DOWN) != 0) {
-		 pin_cfg |= IOMUX_PAD_PULL(0x2);
-	 }
-	 pinctrl_configure_pins(&pin_cfg, 1, 0);
+		if (config->port_no == 1) {
+			pin_cfg = IOMUX_GPIO_IDX(pin + 32) | IOMUX_TYPE(IOMUX_GPIO);
+		} else {
+			pin_cfg = IOMUX_GPIO_IDX(pin) | IOMUX_TYPE(IOMUX_GPIO);
+		}
+		/* Add pull up flags, if required */
+		if ((flags & GPIO_PULL_UP) != 0) {
+			pin_cfg |= IOMUX_PAD_PULL(0x1);
+		} else if ((flags & GPIO_PULL_DOWN) != 0) {
+			pin_cfg |= IOMUX_PAD_PULL(0x2);
+		}
+		pinctrl_configure_pins(&pin_cfg, 1, 0);
 #endif
 
- if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
+	if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
 #ifdef IOPCTL /* RT600 and RT500 series */
-	 *pinconfig |= IOPCTL_PIO_PUPD_EN;
-	 if ((flags & GPIO_PULL_UP) != 0) {
-		 *pinconfig |= IOPCTL_PIO_PULLUP_EN;
-	 } else if ((flags & GPIO_PULL_DOWN) != 0) {
-		 *pinconfig &= ~(IOPCTL_PIO_PULLUP_EN);
-	 }
+		*pinconfig |= IOPCTL_PIO_PUPD_EN;
+		if ((flags & GPIO_PULL_UP) != 0) {
+			*pinconfig |= IOPCTL_PIO_PULLUP_EN;
+		} else if ((flags & GPIO_PULL_DOWN) != 0) {
+			*pinconfig &= ~(IOPCTL_PIO_PULLUP_EN);
+		}
 #endif
 #ifdef IOCON /* LPC SOCs */
 
-	 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
-	 if ((flags & GPIO_PULL_UP) != 0) {
-		 *pinconfig |= IOCON_PIO_MODE_PULLUP;
-	 } else if ((flags & GPIO_PULL_DOWN) != 0) {
-		 *pinconfig |= IOCON_PIO_MODE_PULLDOWN;
-	 }
+		*pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
+		if ((flags & GPIO_PULL_UP) != 0) {
+			*pinconfig |= IOCON_PIO_MODE_PULLUP;
+		} else if ((flags & GPIO_PULL_DOWN) != 0) {
+			*pinconfig |= IOCON_PIO_MODE_PULLDOWN;
+		}
 #endif
- } else {
+	} else {
 #ifdef IOPCTL /* RT600 and RT500 series */
-	 *pinconfig &= ~IOPCTL_PIO_PUPD_EN;
+		*pinconfig &= ~IOPCTL_PIO_PUPD_EN;
 #endif
 #ifdef IOCON /* LPC SOCs */
-	 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
+		*pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
 #endif
 #ifdef MCI_IO_MUX
 
 #endif
- }
+	}
 
- /* supports access by pin now,you can add access by port when needed */
- if (flags & GPIO_OUTPUT_INIT_HIGH) {
-	 gpio_base->SET[port] = BIT(pin);
- }
+	/* supports access by pin now,you can add access by port when needed */
+	if (flags & GPIO_OUTPUT_INIT_HIGH) {
+		gpio_base->SET[port] = BIT(pin);
+	}
 
- if (flags & GPIO_OUTPUT_INIT_LOW) {
-	 gpio_base->CLR[port] = BIT(pin);
- }
+	if (flags & GPIO_OUTPUT_INIT_LOW) {
+		gpio_base->CLR[port] = BIT(pin);
+	}
 
- /* input-0,output-1 */
- WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
+	/* input-0,output-1 */
+	WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
 
- return 0;
+	return 0;
 }
 
 static int gpio_mcux_lpc_port_get_raw(const struct device *dev,
-				   uint32_t *value)
+				      uint32_t *value)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- GPIO_Type *gpio_base = config->gpio_base;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	GPIO_Type *gpio_base = config->gpio_base;
 
- *value = gpio_base->PIN[config->port_no];
+	*value = gpio_base->PIN[config->port_no];
 
- return 0;
+	return 0;
 }
 
 static int gpio_mcux_lpc_port_set_masked_raw(const struct device *dev,
-					  uint32_t mask,
-					  uint32_t value)
+					     uint32_t mask,
+					     uint32_t value)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- GPIO_Type *gpio_base = config->gpio_base;
- uint32_t port = config->port_no;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	GPIO_Type *gpio_base = config->gpio_base;
+	uint32_t port = config->port_no;
 
- /* Writing 0 allows R+W, 1 disables the pin */
- gpio_base->MASK[port] = ~mask;
- gpio_base->MPIN[port] = value;
- /* Enable back the pins, user won't assume pins remain masked*/
- gpio_base->MASK[port] = 0U;
+	/* Writing 0 allows R+W, 1 disables the pin */
+	gpio_base->MASK[port] = ~mask;
+	gpio_base->MPIN[port] = value;
+	/* Enable back the pins, user won't assume pins remain masked*/
+	gpio_base->MASK[port] = 0U;
 
- return 0;
+	return 0;
 }
 
 static int gpio_mcux_lpc_port_set_bits_raw(const struct device *dev,
-					uint32_t mask)
+					   uint32_t mask)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- GPIO_Type *gpio_base = config->gpio_base;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	GPIO_Type *gpio_base = config->gpio_base;
 
- gpio_base->SET[config->port_no] = mask;
+	gpio_base->SET[config->port_no] = mask;
 
- return 0;
+	return 0;
 }
 
 static int gpio_mcux_lpc_port_clear_bits_raw(const struct device *dev,
-					  uint32_t mask)
+					     uint32_t mask)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- GPIO_Type *gpio_base = config->gpio_base;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	GPIO_Type *gpio_base = config->gpio_base;
 
- gpio_base->CLR[config->port_no] = mask;
+	gpio_base->CLR[config->port_no] = mask;
 
- return 0;
+	return 0;
 }
 
 static int gpio_mcux_lpc_port_toggle_bits(const struct device *dev,
-				   uint32_t mask)
+					  uint32_t mask)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- GPIO_Type *gpio_base = config->gpio_base;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	GPIO_Type *gpio_base = config->gpio_base;
 
- gpio_base->NOT[config->port_no] = mask;
+	gpio_base->NOT[config->port_no] = mask;
 
- return 0;
+	return 0;
 }
 
 
@@ -253,66 +255,66 @@ static int gpio_mcux_lpc_port_toggle_bits(const struct device *dev,
 /* Called by PINT when pin interrupt fires */
 static void gpio_mcux_lpc_pint_cb(uint8_t pin, void *user)
 {
- const struct device *dev = user;
- const struct gpio_mcux_lpc_config *config = dev->config;
- struct gpio_mcux_lpc_data *data = dev->data;
- uint32_t gpio_pin;
+	const struct device *dev = user;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	struct gpio_mcux_lpc_data *data = dev->data;
+	uint32_t gpio_pin;
 
- /* Subtract port number times 32 from pin number to get GPIO API
-  * pin number.
-  */
- gpio_pin = pin - (config->port_no * 32);
+	/* Subtract port number times 32 from pin number to get GPIO API
+	 * pin number.
+	 */
+	gpio_pin = pin - (config->port_no * 32);
 
- gpio_fire_callbacks(&data->callbacks, dev, BIT(gpio_pin));
+	gpio_fire_callbacks(&data->callbacks, dev, BIT(gpio_pin));
 }
 
 
 /* Installs interrupt handler using PINT interrupt controller. */
 static int gpio_mcux_lpc_pint_interrupt_cfg(const struct device *dev,
-					 gpio_pin_t pin,
-					 enum gpio_int_mode mode,
-					 enum gpio_int_trig trig)
+					    gpio_pin_t pin,
+					    enum gpio_int_mode mode,
+					    enum gpio_int_trig trig)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- enum nxp_pint_trigger interrupt_mode = NXP_PINT_NONE;
- uint32_t port = config->port_no;
- int ret;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	enum nxp_pint_trigger interrupt_mode = NXP_PINT_NONE;
+	uint32_t port = config->port_no;
+	int ret;
 
- switch (mode) {
- case GPIO_INT_MODE_DISABLED:
-	 nxp_pint_pin_disable((port * 32) + pin);
-	 return 0;
- case GPIO_INT_MODE_LEVEL:
-	 if (trig == GPIO_INT_TRIG_HIGH) {
-		 interrupt_mode = NXP_PINT_HIGH;
-	 } else if (trig == GPIO_INT_TRIG_LOW) {
-		 interrupt_mode = NXP_PINT_LOW;
-	 } else {
-		 return -ENOTSUP;
-	 }
-	 break;
- case GPIO_INT_MODE_EDGE:
-	 if (trig == GPIO_INT_TRIG_HIGH) {
-		 interrupt_mode = NXP_PINT_RISING;
-	 } else if (trig == GPIO_INT_TRIG_LOW) {
-		 interrupt_mode = NXP_PINT_FALLING;
-	 } else {
-		 interrupt_mode = NXP_PINT_BOTH;
-	 }
-	 break;
- default:
-	 return -ENOTSUP;
- }
+	switch (mode) {
+	case GPIO_INT_MODE_DISABLED:
+		nxp_pint_pin_disable((port * 32) + pin);
+		return 0;
+	case GPIO_INT_MODE_LEVEL:
+		if (trig == GPIO_INT_TRIG_HIGH) {
+			interrupt_mode = NXP_PINT_HIGH;
+		} else if (trig == GPIO_INT_TRIG_LOW) {
+			interrupt_mode = NXP_PINT_LOW;
+		} else {
+			return -ENOTSUP;
+		}
+		break;
+	case GPIO_INT_MODE_EDGE:
+		if (trig == GPIO_INT_TRIG_HIGH) {
+			interrupt_mode = NXP_PINT_RISING;
+		} else if (trig == GPIO_INT_TRIG_LOW) {
+			interrupt_mode = NXP_PINT_FALLING;
+		} else {
+			interrupt_mode = NXP_PINT_BOTH;
+		}
+		break;
+	default:
+		return -ENOTSUP;
+	}
 
- /* PINT treats GPIO pins as continuous. Each port has 32 pins */
- ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode, (trig & GPIO_INT_WAKEUP));
- if (ret < 0) {
-	 return ret;
- }
- /* Install callback */
- return nxp_pint_pin_set_callback((port * 32) + pin,
-				   gpio_mcux_lpc_pint_cb,
-				   (struct device *)dev);
+	/* PINT treats GPIO pins as continuous. Each port has 32 pins */
+	ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode, (trig & GPIO_INT_WAKEUP));
+	if (ret < 0) {
+		return ret;
+	}
+	/* Install callback */
+	return nxp_pint_pin_set_callback((port * 32) + pin,
+					  gpio_mcux_lpc_pint_cb,
+					  (struct device *)dev);
 }
 #endif /* CONFIG_NXP_PINT */
 
@@ -320,121 +322,122 @@ static int gpio_mcux_lpc_pint_interrupt_cfg(const struct device *dev,
 #if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
 
 static int gpio_mcux_lpc_module_interrupt_cfg(const struct device *dev,
-					   gpio_pin_t pin,
-					   enum gpio_int_mode mode,
-					   enum gpio_int_trig trig)
+					      gpio_pin_t pin,
+					      enum gpio_int_mode mode,
+					      enum gpio_int_trig trig)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- gpio_interrupt_index_t int_idx;
- gpio_interrupt_config_t pin_config;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	gpio_interrupt_index_t int_idx;
+	gpio_interrupt_config_t pin_config;
 
- if (config->int_source == INT_SOURCE_NONE) {
-	 return -ENOTSUP;
- }
+	if (config->int_source == INT_SOURCE_NONE) {
+		return -ENOTSUP;
+	}
 
- /* Route interrupt to source A or B based on interrupt source */
- int_idx = (config->int_source == INT_SOURCE_INTA) ?
-		 kGPIO_InterruptA : kGPIO_InterruptB;
+	/* Route interrupt to source A or B based on interrupt source */
+	int_idx = (config->int_source == INT_SOURCE_INTA) ?
+			kGPIO_InterruptA : kGPIO_InterruptB;
 
- /* Disable interrupt if requested */
- if (mode ==  GPIO_INT_MODE_DISABLED) {
-	 GPIO_PinDisableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
-	 return 0;
- }
+	/* Disable interrupt if requested */
+	if (mode ==  GPIO_INT_MODE_DISABLED) {
+		GPIO_PinDisableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
+		return 0;
+	}
 
- /* Set pin interrupt level */
- if (mode == GPIO_INT_MODE_LEVEL) {
-	 pin_config.mode = kGPIO_PinIntEnableLevel;
- } else if (mode == GPIO_INT_MODE_EDGE) {
-	 pin_config.mode = kGPIO_PinIntEnableEdge;
- } else {
-	 return -ENOTSUP;
- }
+	/* Set pin interrupt level */
+	if (mode == GPIO_INT_MODE_LEVEL) {
+		pin_config.mode = kGPIO_PinIntEnableLevel;
+	} else if (mode == GPIO_INT_MODE_EDGE) {
+		pin_config.mode = kGPIO_PinIntEnableEdge;
+	} else {
+		return -ENOTSUP;
+	}
 
- /* Set pin interrupt trigger */
- if (trig == GPIO_INT_TRIG_HIGH) {
-	 pin_config.polarity = kGPIO_PinIntEnableHighOrRise;
- } else if (trig == GPIO_INT_TRIG_LOW) {
-	 pin_config.polarity = kGPIO_PinIntEnableLowOrFall;
- } else {
-	 return -ENOTSUP;
- }
+	/* Set pin interrupt trigger */
+	if (trig == GPIO_INT_TRIG_HIGH) {
+		pin_config.polarity = kGPIO_PinIntEnableHighOrRise;
+	} else if (trig == GPIO_INT_TRIG_LOW) {
+		pin_config.polarity = kGPIO_PinIntEnableLowOrFall;
+	} else {
+		return -ENOTSUP;
+	}
 
- /* Enable interrupt with new configuration */
- GPIO_SetPinInterruptConfig(config->gpio_base, config->port_no, pin, &pin_config);
- GPIO_PinEnableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
- return 0;
+	/* Enable interrupt with new configuration */
+	GPIO_SetPinInterruptConfig(config->gpio_base, config->port_no, pin, &pin_config);
+	GPIO_PinEnableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
+	return 0;
 }
 
 /* GPIO module interrupt handler */
 void gpio_mcux_lpc_module_isr(const struct device *dev)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- struct gpio_mcux_lpc_data *data = dev->data;
- uint32_t status;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	struct gpio_mcux_lpc_data *data = dev->data;
+	uint32_t status;
 
- status = GPIO_PortGetInterruptStatus(config->gpio_base,
-				 config->port_no,
-				 config->int_source == INT_SOURCE_INTA ?
-				 kGPIO_InterruptA : kGPIO_InterruptB);
- GPIO_PortClearInterruptFlags(config->gpio_base,
-				 config->port_no,
-				 config->int_source == INT_SOURCE_INTA ?
-				 kGPIO_InterruptA : kGPIO_InterruptB,
-				 status);
- gpio_fire_callbacks(&data->callbacks, dev, status);
+	status = GPIO_PortGetInterruptStatus(config->gpio_base,
+					config->port_no,
+					config->int_source == INT_SOURCE_INTA ?
+					kGPIO_InterruptA : kGPIO_InterruptB);
+	GPIO_PortClearInterruptFlags(config->gpio_base,
+					config->port_no,
+					config->int_source == INT_SOURCE_INTA ?
+					kGPIO_InterruptA : kGPIO_InterruptB,
+					status);
+	gpio_fire_callbacks(&data->callbacks, dev, status);
 }
 
 #endif /* FSL_FEATURE_GPIO_HAS_INTERRUPT */
 
 
 static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
-					  gpio_pin_t pin,
-					  enum gpio_int_mode mode,
-					  enum gpio_int_trig trig)
+						 gpio_pin_t pin,
+						 enum gpio_int_mode mode,
+						 enum gpio_int_trig trig)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
- GPIO_Type *gpio_base = config->gpio_base;
- uint32_t port = config->port_no;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+	GPIO_Type *gpio_base = config->gpio_base;
+	uint32_t port = config->port_no;
 
- /* Ensure pin used as interrupt is set as input*/
- if ((mode & GPIO_INT_ENABLE) &&
-	 ((gpio_base->DIR[port] & BIT(pin)) != 0)) {
-	 return -ENOTSUP;
- }
+	/* Ensure pin used as interrupt is set as input*/
+	if ((mode & GPIO_INT_ENABLE) &&
+		((gpio_base->DIR[port] & BIT(pin)) != 0)) {
+		return -ENOTSUP;
+	}
 #if defined(CONFIG_NXP_PINT)
- if (config->int_source == INT_SOURCE_PINT) {
-	 return gpio_mcux_lpc_pint_interrupt_cfg(dev, pin, mode, trig);
- }
+	if (config->int_source == INT_SOURCE_PINT) {
+		return gpio_mcux_lpc_pint_interrupt_cfg(dev, pin, mode, trig);
+	}
 #endif /* CONFIG_NXP_PINT */
 #if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
- return gpio_mcux_lpc_module_interrupt_cfg(dev, pin, mode, trig);
+	return gpio_mcux_lpc_module_interrupt_cfg(dev, pin, mode, trig);
 #else
- return -ENOTSUP;
+	return -ENOTSUP;
 #endif
 }
 
 void gpio_mcux_lpc_trigger_cb(const struct device *dev, uint32_t pins)
 {
- struct gpio_mcux_lpc_data *data = dev->data;
+	struct gpio_mcux_lpc_data *data = dev->data;
 
- gpio_fire_callbacks(&data->callbacks, dev, pins);
+	gpio_fire_callbacks(&data->callbacks, dev, pins);
 }
 
 static int gpio_mcux_lpc_manage_cb(const struct device *port,
-				struct gpio_callback *callback, bool set)
+				   struct gpio_callback *callback, bool set)
 {
- struct gpio_mcux_lpc_data *data = port->data;
+	struct gpio_mcux_lpc_data *data = port->data;
 
- return gpio_manage_callback(&data->callbacks, callback, set);
+	return gpio_manage_callback(&data->callbacks, callback, set);
 }
 
 #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
-defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
-defined(CONFIG_PM_DEVICE))
+	defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+	defined(CONFIG_PM_DEVICE))
 static void gpio_mcux_lpc_context_save(const struct device *dev)
 {
-const struct gpio_mcux_lpc_config *config = dev->config;
+	const struct gpio_mcux_lpc_config *config = dev->config;
+
 	gpio_mux_registers_context.DIR[0] = config->gpio_base->DIR[0];
 	gpio_mux_registers_context.DIR[1] = config->gpio_base->DIR[1];
 	gpio_mux_registers_context.PIN[0] = config->gpio_base->PIN[0];
@@ -449,8 +452,8 @@ const struct gpio_mcux_lpc_config *config = dev->config;
 	gpio_mux_registers_context.INTEDG[1] = config->gpio_base->INTEDG[1];
 
 	/*IO muxes registers should be handled in the pinctrl driver
-this is a PRELIMINARY solution to continue with the PM3 
-support for RW612 platform*/
+	this is a PRELIMINARY solution to continue with the PM3 
+	support for RW612 platform*/
 	gpio_mux_registers_context.GPIO_GRP0 = config->pinmux_base->GPIO_GRP0;
 	gpio_mux_registers_context.GPIO_GRP1 = config->pinmux_base->GPIO_GRP1;
 }
@@ -472,60 +475,61 @@ static void gpio_mcux_lpc_context_restore(const struct device *dev)
 	config->gpio_base->INTEDG[0] = gpio_mux_registers_context.INTEDG[0]; 
 	config->gpio_base->INTEDG[1] = gpio_mux_registers_context.INTEDG[1]; 
 
-/*IO muxes registers should be handled in the pinctrl driver
-this is a PRELIMINARY solution to continue with the PM3 
-support for RW612 platform*/
+	/*IO muxes registers should be handled in the pinctrl driver
+	this is a PRELIMINARY solution to continue with the PM3 
+	support for RW612 platform*/
 	config->pinmux_base->GPIO_GRP0 = gpio_mux_registers_context.GPIO_GRP0;
 	config->pinmux_base->GPIO_GRP1 = gpio_mux_registers_context.GPIO_GRP1;
 }
 #endif /*RW610/RW612 MCU*/
+
 static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
 {
- const struct gpio_mcux_lpc_config *config = dev->config;
+	const struct gpio_mcux_lpc_config *config = dev->config;
 
- switch (action) {
- case PM_DEVICE_ACTION_RESUME:
-	 break;
- case PM_DEVICE_ACTION_SUSPEND:
-	 break;
- case PM_DEVICE_ACTION_TURN_OFF:
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
 #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
-defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
-defined(CONFIG_PM_DEVICE))
-        gpio_mcux_lpc_context_save(dev);
-#endif /*RW610/RW612 MCU*/ 
-	 break;
- case PM_DEVICE_ACTION_TURN_ON:
-	 GPIO_PortInit(config->gpio_base, config->port_no);
-#if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
-defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
-defined(CONFIG_PM_DEVICE))
-	 gpio_mcux_lpc_context_restore(dev);
+	defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+	defined(CONFIG_PM_DEVICE))
+		gpio_mcux_lpc_context_save(dev);
 #endif /*RW610/RW612 MCU*/
-	 break;
- default:
-	 return -ENOTSUP;
- }
- return 0;
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
+		GPIO_PortInit(config->gpio_base, config->port_no);
+#if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+	defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+	defined(CONFIG_PM_DEVICE))
+		gpio_mcux_lpc_context_restore(dev);
+#endif /*RW610/RW612 MCU*/
+		break;
+	default:
+		return -ENOTSUP;
+	}
+	return 0;
 }
 
 static int gpio_mcux_lpc_init(const struct device *dev)
 {
- /* Rest of the init is done from the PM_DEVICE_TURN_ON action
-  * which is invoked by pm_device_driver_init().
-  */
- return pm_device_driver_init(dev, gpio_mcux_lpc_pm_action);
+	/* Rest of the init is done from the PM_DEVICE_TURN_ON action
+	 * which is invoked by pm_device_driver_init().
+	 */
+	return pm_device_driver_init(dev, gpio_mcux_lpc_pm_action);
 }
 
 static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
- .pin_configure = gpio_mcux_lpc_configure,
- .port_get_raw = gpio_mcux_lpc_port_get_raw,
- .port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
- .port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,
- .port_clear_bits_raw = gpio_mcux_lpc_port_clear_bits_raw,
- .port_toggle_bits = gpio_mcux_lpc_port_toggle_bits,
- .pin_interrupt_configure = gpio_mcux_lpc_pin_interrupt_configure,
- .manage_callback = gpio_mcux_lpc_manage_cb,
+	.pin_configure = gpio_mcux_lpc_configure,
+	.port_get_raw = gpio_mcux_lpc_port_get_raw,
+	.port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
+	.port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,
+	.port_clear_bits_raw = gpio_mcux_lpc_port_clear_bits_raw,
+	.port_toggle_bits = gpio_mcux_lpc_port_toggle_bits,
+	.pin_interrupt_configure = gpio_mcux_lpc_pin_interrupt_configure,
+	.manage_callback = gpio_mcux_lpc_manage_cb,
 };
 
 
@@ -541,48 +545,48 @@ static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
 #endif
 
 #define GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)						\
- do {										\
-	 IRQ_CONNECT(DT_INST_IRQ(inst, irq),					\
-		 DT_INST_IRQ(inst, priority),					\
-		 gpio_mcux_lpc_module_isr, DEVICE_DT_INST_GET(inst), 0);		\
-	 irq_enable(DT_INST_IRQ(inst, irq));					\
- } while (false)
+	do {										\
+		IRQ_CONNECT(DT_INST_IRQ(inst, irq),					\
+			DT_INST_IRQ(inst, priority),					\
+			gpio_mcux_lpc_module_isr, DEVICE_DT_INST_GET(inst), 0);		\
+		irq_enable(DT_INST_IRQ(inst, irq));					\
+	} while (false)
 
 #define GPIO_MCUX_LPC_MODULE_IRQ(inst)							\
- IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, 0),					\
-	 (GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)))
+	IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, 0),					\
+		(GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)))
 
 
 #define GPIO_MCUX_LPC(n)								\
- static int lpc_gpio_init_##n(const struct device *dev);				\
-										 \
- static const struct gpio_mcux_lpc_config gpio_mcux_lpc_config_##n = {		\
-	 .common = {								\
-		 .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),		\
-	 },									\
-	 .gpio_base = (GPIO_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
-	 .pinmux_base = PINMUX_BASE,						\
-	 .int_source = DT_INST_ENUM_IDX(n, int_source),				\
-	 .port_no = DT_INST_REG_ADDR(n)						\
- };										\
-										 \
- static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\
-										 \
- PM_DEVICE_DT_INST_DEFINE(n, gpio_mcux_lpc_pm_action);				\
-										 \
- DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n,					\
-		 PM_DEVICE_DT_INST_GET(n),						\
-		 &gpio_mcux_lpc_data_##n,						\
-		 &gpio_mcux_lpc_config_##n, PRE_KERNEL_1,				\
-		 CONFIG_GPIO_INIT_PRIORITY,						\
-		 &gpio_mcux_lpc_driver_api);						\
-										 \
- static int lpc_gpio_init_##n(const struct device *dev)				\
- {										\
-	 gpio_mcux_lpc_init(dev);						\
-	 GPIO_MCUX_LPC_MODULE_IRQ(n);						\
-										 \
-	 return 0;								\
- }
+	static int lpc_gpio_init_##n(const struct device *dev);				\
+											\
+	static const struct gpio_mcux_lpc_config gpio_mcux_lpc_config_##n = {		\
+		.common = {								\
+			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),		\
+		},									\
+		.gpio_base = (GPIO_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
+		.pinmux_base = PINMUX_BASE,						\
+		.int_source = DT_INST_ENUM_IDX(n, int_source),				\
+		.port_no = DT_INST_REG_ADDR(n)						\
+	};										\
+											\
+	static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\
+											\
+	PM_DEVICE_DT_INST_DEFINE(n, gpio_mcux_lpc_pm_action);				\
+											\
+	DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n,					\
+		    PM_DEVICE_DT_INST_GET(n),						\
+		    &gpio_mcux_lpc_data_##n,						\
+		    &gpio_mcux_lpc_config_##n, PRE_KERNEL_1,				\
+		    CONFIG_GPIO_INIT_PRIORITY,						\
+		    &gpio_mcux_lpc_driver_api);						\
+											\
+	static int lpc_gpio_init_##n(const struct device *dev)				\
+	{										\
+		gpio_mcux_lpc_init(dev);						\
+		GPIO_MCUX_LPC_MODULE_IRQ(n);						\
+											\
+		return 0;								\
+	}
 
 DT_INST_FOREACH_STATUS_OKAY(GPIO_MCUX_LPC)

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -4,590 +4,585 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- #define DT_DRV_COMPAT nxp_lpc_gpio_port
+#define DT_DRV_COMPAT nxp_lpc_gpio_port
+/** @file
+ * @brief GPIO driver for LPC54XXX family
+ *
+ * Note:
+ * - fsl_pint internally tries to manage interrupts, but this is not used (e.g.
+ *   s_pintCallback), Zephyr's interrupt management system is used in place.
+ */
 
- /** @file
-  * @brief GPIO driver for LPC54XXX family
-  *
-  * Note:
-  * - fsl_pint internally tries to manage interrupts, but this is not used (e.g.
-  *   s_pintCallback), Zephyr's interrupt management system is used in place.
-  */
- 
- #include <errno.h>
- #include <zephyr/device.h>
- #include <zephyr/drivers/gpio.h>
- #include <zephyr/pm/device.h>
- #include <zephyr/irq.h>
- #include <soc.h>
- #include <fsl_common.h>
- #include <zephyr/drivers/gpio/gpio_utils.h>
- #ifdef CONFIG_NXP_PINT
- #include <zephyr/drivers/interrupt_controller/nxp_pint.h>
- #endif
- #include <fsl_gpio.h>
- #include <fsl_device_registers.h>
- #ifdef MCI_IO_MUX
- #include <zephyr/drivers/pinctrl.h>
- #endif
- 
- /* Interrupt sources, matching int-source enum in DTS binding definition */
- #define INT_SOURCE_PINT 0
- #define INT_SOURCE_INTA 1
- #define INT_SOURCE_INTB 2
- #define INT_SOURCE_NONE 3
- 
- struct gpio_mcux_lpc_config {
-	 /* gpio_driver_config needs to be first */
-	 struct gpio_driver_config common;
-	 GPIO_Type *gpio_base;
-	 uint8_t int_source;
- #ifdef IOPCTL
-	 IOPCTL_Type *pinmux_base;
- #endif
- #ifdef IOCON
-	 IOCON_Type *pinmux_base;
- #endif
- #ifdef MCI_IO_MUX
-	 MCI_IO_MUX_Type * pinmux_base;
- #endif
-	 uint32_t port_no;
- };
- 
- struct gpio_mcux_lpc_data {
-	 /* gpio_driver_data needs to be first */
-	 struct gpio_driver_data common;
-	 /* port ISR callback routine address */
-	 sys_slist_t callbacks;
- };
+#include <errno.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/irq.h>
+#include <soc.h>
+#include <fsl_common.h>
+#include <zephyr/drivers/gpio/gpio_utils.h>
+#ifdef CONFIG_NXP_PINT
+#include <zephyr/drivers/interrupt_controller/nxp_pint.h>
+#endif
+#include <fsl_gpio.h>
+#include <fsl_device_registers.h>
+#ifdef MCI_IO_MUX
+#include <zephyr/drivers/pinctrl.h>
+#endif
 
- #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
-       defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
-       defined(CONFIG_PM_DEVICE))
- static struct gpio_mux_registers_context_t{
- 	/*GPIO Configuration Registers*/
- 	uint32_t DIR[2];
- 	uint32_t PIN[2];
- 	uint32_t INTENA[2];
- 	uint32_t INTENB[2];
- 	uint32_t INTPOL[2];
- 	uint32_t INTEDG[2];
+/* Interrupt sources, matching int-source enum in DTS binding definition */
+#define INT_SOURCE_PINT 0
+#define INT_SOURCE_INTA 1
+#define INT_SOURCE_INTB 2
+#define INT_SOURCE_NONE 3
 
- 	/*PinCtrl Configuration Registers*/                         
- 	uint32_t GPIO_GRP0;                         
- 	uint32_t GPIO_GRP1;                         
- }gpio_mux_registers_context;
- #endif /*RW612/RW610 MCU*/
- 
- static int gpio_mcux_lpc_configure(const struct device *dev, gpio_pin_t pin,
-					gpio_flags_t flags)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 GPIO_Type *gpio_base = config->gpio_base;
-	 uint32_t port = config->port_no;
- 
-	 if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
-		 return -ENOTSUP;
-	 }
- 
- #ifdef IOPCTL /* RT600 and RT500 series */
-	 IOPCTL_Type *pinmux_base = config->pinmux_base;
-	 volatile uint32_t *pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
- 
-	 /*
-	  * Enable input buffer for both input and output pins, it costs
-	  * nothing and allows values to be read back.
-	  */
-	 *pinconfig |= IOPCTL_PIO_INBUF_EN;
- 
-	 if ((flags & GPIO_SINGLE_ENDED) != 0) {
-		 *pinconfig |= IOPCTL_PIO_PSEDRAIN_EN;
-	 } else {
-		 *pinconfig &= ~IOPCTL_PIO_PSEDRAIN_EN;
-	 }
-	 /* Select GPIO mux for this pin (func 0 is always GPIO) */
-	 *pinconfig &= ~(IOPCTL_PIO_FSEL_MASK);
- #endif
- #ifdef IOCON /* LPC SOCs */
-	 volatile uint32_t *pinconfig;
-	 IOCON_Type *pinmux_base;
- 
-	 pinmux_base = config->pinmux_base;
-	 pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
- 
-	 if ((flags & GPIO_SINGLE_ENDED) != 0) {
-		 /* Set ODE bit. */
-		 *pinconfig |= IOCON_PIO_OD_MASK;
-	 }
- 
-	 if ((flags & GPIO_INPUT) != 0) {
-		 /* Set DIGIMODE bit */
-		 *pinconfig |= IOCON_PIO_DIGIMODE_MASK;
-	 }
-	 /* Select GPIO mux for this pin (func 0 is always GPIO) */
-	 *pinconfig &= ~(IOCON_PIO_FUNC_MASK);
- #endif
- #ifdef MCI_IO_MUX /* RW61x SOCs */
-		 /* Construct a pin control state, and apply it directly. */
-		 pinctrl_soc_pin_t pin_cfg;
- 
-		 if (config->port_no == 1) {
-			 pin_cfg = IOMUX_GPIO_IDX(pin + 32) | IOMUX_TYPE(IOMUX_GPIO);
-		 } else {
-			 pin_cfg = IOMUX_GPIO_IDX(pin) | IOMUX_TYPE(IOMUX_GPIO);
-		 }
-		 /* Add pull up flags, if required */
-		 if ((flags & GPIO_PULL_UP) != 0) {
-			 pin_cfg |= IOMUX_PAD_PULL(0x1);
-		 } else if ((flags & GPIO_PULL_DOWN) != 0) {
-			 pin_cfg |= IOMUX_PAD_PULL(0x2);
-		 }
-		 pinctrl_configure_pins(&pin_cfg, 1, 0);
- #endif
- 
-	 if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
- #ifdef IOPCTL /* RT600 and RT500 series */
-		 *pinconfig |= IOPCTL_PIO_PUPD_EN;
-		 if ((flags & GPIO_PULL_UP) != 0) {
-			 *pinconfig |= IOPCTL_PIO_PULLUP_EN;
-		 } else if ((flags & GPIO_PULL_DOWN) != 0) {
-			 *pinconfig &= ~(IOPCTL_PIO_PULLUP_EN);
-		 }
- #endif
- #ifdef IOCON /* LPC SOCs */
- 
-		 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
-		 if ((flags & GPIO_PULL_UP) != 0) {
-			 *pinconfig |= IOCON_PIO_MODE_PULLUP;
-		 } else if ((flags & GPIO_PULL_DOWN) != 0) {
-			 *pinconfig |= IOCON_PIO_MODE_PULLDOWN;
-		 }
- #endif
-	 } else {
- #ifdef IOPCTL /* RT600 and RT500 series */
-		 *pinconfig &= ~IOPCTL_PIO_PUPD_EN;
- #endif
- #ifdef IOCON /* LPC SOCs */
-		 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
- #endif
- #ifdef MCI_IO_MUX
- 
- #endif
-	 }
- 
-	 /* supports access by pin now,you can add access by port when needed */
-	 if (flags & GPIO_OUTPUT_INIT_HIGH) {
-		 gpio_base->SET[port] = BIT(pin);
-	 }
- 
-	 if (flags & GPIO_OUTPUT_INIT_LOW) {
-		 gpio_base->CLR[port] = BIT(pin);
-	 }
- 
-	 /* input-0,output-1 */
-	 WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
- 
-	 return 0;
- }
- 
- static int gpio_mcux_lpc_port_get_raw(const struct device *dev,
-					   uint32_t *value)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 GPIO_Type *gpio_base = config->gpio_base;
- 
-	 *value = gpio_base->PIN[config->port_no];
- 
-	 return 0;
- }
- 
- static int gpio_mcux_lpc_port_set_masked_raw(const struct device *dev,
-						  uint32_t mask,
-						  uint32_t value)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 GPIO_Type *gpio_base = config->gpio_base;
-	 uint32_t port = config->port_no;
- 
-	 /* Writing 0 allows R+W, 1 disables the pin */
-	 gpio_base->MASK[port] = ~mask;
-	 gpio_base->MPIN[port] = value;
-	 /* Enable back the pins, user won't assume pins remain masked*/
-	 gpio_base->MASK[port] = 0U;
- 
-	 return 0;
- }
- 
- static int gpio_mcux_lpc_port_set_bits_raw(const struct device *dev,
-						uint32_t mask)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 GPIO_Type *gpio_base = config->gpio_base;
- 
-	 gpio_base->SET[config->port_no] = mask;
- 
-	 return 0;
- }
- 
- static int gpio_mcux_lpc_port_clear_bits_raw(const struct device *dev,
-						  uint32_t mask)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 GPIO_Type *gpio_base = config->gpio_base;
- 
-	 gpio_base->CLR[config->port_no] = mask;
- 
-	 return 0;
- }
- 
- static int gpio_mcux_lpc_port_toggle_bits(const struct device *dev,
-					   uint32_t mask)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 GPIO_Type *gpio_base = config->gpio_base;
- 
-	 gpio_base->NOT[config->port_no] = mask;
- 
-	 return 0;
- }
- 
- 
- #ifdef CONFIG_NXP_PINT
- /* Called by PINT when pin interrupt fires */
- static void gpio_mcux_lpc_pint_cb(uint8_t pin, void *user)
- {
-	 const struct device *dev = user;
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 struct gpio_mcux_lpc_data *data = dev->data;
-	 uint32_t gpio_pin;
- 
-	 /* Subtract port number times 32 from pin number to get GPIO API
-	  * pin number.
-	  */
-	 gpio_pin = pin - (config->port_no * 32);
- 
-	 gpio_fire_callbacks(&data->callbacks, dev, BIT(gpio_pin));
- }
- 
- 
- /* Installs interrupt handler using PINT interrupt controller. */
- static int gpio_mcux_lpc_pint_interrupt_cfg(const struct device *dev,
-						 gpio_pin_t pin,
-						 enum gpio_int_mode mode,
-						 enum gpio_int_trig trig)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 enum nxp_pint_trigger interrupt_mode = NXP_PINT_NONE;
-	 uint32_t port = config->port_no;
-	 int ret;
- 
-	 switch (mode) {
-	 case GPIO_INT_MODE_DISABLED:
-		 nxp_pint_pin_disable((port * 32) + pin);
-		 return 0;
-	 case GPIO_INT_MODE_LEVEL:
-		 if (trig == GPIO_INT_TRIG_HIGH) {
-			 interrupt_mode = NXP_PINT_HIGH;
-		 } else if (trig == GPIO_INT_TRIG_LOW) {
-			 interrupt_mode = NXP_PINT_LOW;
-		 } else {
-			 return -ENOTSUP;
-		 }
-		 break;
-	 case GPIO_INT_MODE_EDGE:
-		 if (trig == GPIO_INT_TRIG_HIGH) {
-			 interrupt_mode = NXP_PINT_RISING;
-		 } else if (trig == GPIO_INT_TRIG_LOW) {
-			 interrupt_mode = NXP_PINT_FALLING;
-		 } else {
-			 interrupt_mode = NXP_PINT_BOTH;
-		 }
-		 break;
-	 default:
-		 return -ENOTSUP;
-	 }
- 
-	 /* PINT treats GPIO pins as continuous. Each port has 32 pins */
-	 ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode, (trig & GPIO_INT_WAKEUP));
-	 if (ret < 0) {
-		 return ret;
-	 }
-	 /* Install callback */
-	 return nxp_pint_pin_set_callback((port * 32) + pin,
-					   gpio_mcux_lpc_pint_cb,
-					   (struct device *)dev);
- }
- #endif /* CONFIG_NXP_PINT */
- 
- 
- #if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
- 
- static int gpio_mcux_lpc_module_interrupt_cfg(const struct device *dev,
-						   gpio_pin_t pin,
-						   enum gpio_int_mode mode,
-						   enum gpio_int_trig trig)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 gpio_interrupt_index_t int_idx;
-	 gpio_interrupt_config_t pin_config;
- 
-	 if (config->int_source == INT_SOURCE_NONE) {
-		 return -ENOTSUP;
-	 }
- 
-	 /* Route interrupt to source A or B based on interrupt source */
-	 int_idx = (config->int_source == INT_SOURCE_INTA) ?
-			 kGPIO_InterruptA : kGPIO_InterruptB;
- 
-	 /* Disable interrupt if requested */
-	 if (mode ==  GPIO_INT_MODE_DISABLED) {
-		 GPIO_PinDisableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
-		 return 0;
-	 }
- 
-	 /* Set pin interrupt level */
-	 if (mode == GPIO_INT_MODE_LEVEL) {
-		 pin_config.mode = kGPIO_PinIntEnableLevel;
-	 } else if (mode == GPIO_INT_MODE_EDGE) {
-		 pin_config.mode = kGPIO_PinIntEnableEdge;
-	 } else {
-		 return -ENOTSUP;
-	 }
- 
-	 /* Set pin interrupt trigger */
-	 if (trig == GPIO_INT_TRIG_HIGH) {
-		 pin_config.polarity = kGPIO_PinIntEnableHighOrRise;
-	 } else if (trig == GPIO_INT_TRIG_LOW) {
-		 pin_config.polarity = kGPIO_PinIntEnableLowOrFall;
-	 } else {
-		 return -ENOTSUP;
-	 }
- 
-	 /* Enable interrupt with new configuration */
-	 GPIO_SetPinInterruptConfig(config->gpio_base, config->port_no, pin, &pin_config);
-	 GPIO_PinEnableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
-	 return 0;
- }
- 
- /* GPIO module interrupt handler */
- void gpio_mcux_lpc_module_isr(const struct device *dev)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 struct gpio_mcux_lpc_data *data = dev->data;
-	 uint32_t status;
- 
-	 status = GPIO_PortGetInterruptStatus(config->gpio_base,
-					 config->port_no,
-					 config->int_source == INT_SOURCE_INTA ?
-					 kGPIO_InterruptA : kGPIO_InterruptB);
-	 GPIO_PortClearInterruptFlags(config->gpio_base,
-					 config->port_no,
-					 config->int_source == INT_SOURCE_INTA ?
-					 kGPIO_InterruptA : kGPIO_InterruptB,
-					 status);
-	 gpio_fire_callbacks(&data->callbacks, dev, status);
- }
- 
- #endif /* FSL_FEATURE_GPIO_HAS_INTERRUPT */
- 
- 
- static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
-						  gpio_pin_t pin,
-						  enum gpio_int_mode mode,
-						  enum gpio_int_trig trig)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
-	 GPIO_Type *gpio_base = config->gpio_base;
-	 uint32_t port = config->port_no;
- 
-	 /* Ensure pin used as interrupt is set as input*/
-	 if ((mode & GPIO_INT_ENABLE) &&
-		 ((gpio_base->DIR[port] & BIT(pin)) != 0)) {
-		 return -ENOTSUP;
-	 }
- #if defined(CONFIG_NXP_PINT)
-	 if (config->int_source == INT_SOURCE_PINT) {
-		 return gpio_mcux_lpc_pint_interrupt_cfg(dev, pin, mode, trig);
-	 }
- #endif /* CONFIG_NXP_PINT */
- #if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
-	 return gpio_mcux_lpc_module_interrupt_cfg(dev, pin, mode, trig);
- #else
+struct gpio_mcux_lpc_config {
+ /* gpio_driver_config needs to be first */
+ struct gpio_driver_config common;
+ GPIO_Type *gpio_base;
+ uint8_t int_source;
+#ifdef IOPCTL
+ IOPCTL_Type *pinmux_base;
+#endif
+#ifdef IOCON
+ IOCON_Type *pinmux_base;
+#endif
+#ifdef MCI_IO_MUX
+ MCI_IO_MUX_Type * pinmux_base;
+#endif
+ uint32_t port_no;
+};
+
+struct gpio_mcux_lpc_data {
+ /* gpio_driver_data needs to be first */
+ struct gpio_driver_data common;
+ /* port ISR callback routine address */
+ sys_slist_t callbacks;
+};
+#if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+      defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+      defined(CONFIG_PM_DEVICE))
+static struct gpio_mux_registers_context_t{
+	/*GPIO Configuration Registers*/
+	uint32_t DIR[2];
+	uint32_t PIN[2];
+	uint32_t INTENA[2];
+	uint32_t INTENB[2];
+	uint32_t INTPOL[2];
+	uint32_t INTEDG[2];
+	/*PinCtrl Configuration Registers*/                         
+	uint32_t GPIO_GRP0;                         
+	uint32_t GPIO_GRP1;                         
+}gpio_mux_registers_context;
+#endif /*RW612/RW610 MCU*/
+
+static int gpio_mcux_lpc_configure(const struct device *dev, gpio_pin_t pin,
+				gpio_flags_t flags)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ GPIO_Type *gpio_base = config->gpio_base;
+ uint32_t port = config->port_no;
+
+ if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
 	 return -ENOTSUP;
- #endif
  }
- 
- void gpio_mcux_lpc_trigger_cb(const struct device *dev, uint32_t pins)
- {
-	 struct gpio_mcux_lpc_data *data = dev->data;
- 
-	 gpio_fire_callbacks(&data->callbacks, dev, pins);
+
+#ifdef IOPCTL /* RT600 and RT500 series */
+ IOPCTL_Type *pinmux_base = config->pinmux_base;
+ volatile uint32_t *pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
+
+ /*
+  * Enable input buffer for both input and output pins, it costs
+  * nothing and allows values to be read back.
+  */
+ *pinconfig |= IOPCTL_PIO_INBUF_EN;
+
+ if ((flags & GPIO_SINGLE_ENDED) != 0) {
+	 *pinconfig |= IOPCTL_PIO_PSEDRAIN_EN;
+ } else {
+	 *pinconfig &= ~IOPCTL_PIO_PSEDRAIN_EN;
  }
- 
- static int gpio_mcux_lpc_manage_cb(const struct device *port,
-					struct gpio_callback *callback, bool set)
- {
-	 struct gpio_mcux_lpc_data *data = port->data;
- 
-	 return gpio_manage_callback(&data->callbacks, callback, set);
+ /* Select GPIO mux for this pin (func 0 is always GPIO) */
+ *pinconfig &= ~(IOPCTL_PIO_FSEL_MASK);
+#endif
+#ifdef IOCON /* LPC SOCs */
+ volatile uint32_t *pinconfig;
+ IOCON_Type *pinmux_base;
+
+ pinmux_base = config->pinmux_base;
+ pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
+
+ if ((flags & GPIO_SINGLE_ENDED) != 0) {
+	 /* Set ODE bit. */
+	 *pinconfig |= IOCON_PIO_OD_MASK;
  }
- 
- #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
- defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
- defined(CONFIG_PM_DEVICE))
- static void gpio_mcux_lpc_context_save(const struct device *dev)
- {
+
+ if ((flags & GPIO_INPUT) != 0) {
+	 /* Set DIGIMODE bit */
+	 *pinconfig |= IOCON_PIO_DIGIMODE_MASK;
+ }
+ /* Select GPIO mux for this pin (func 0 is always GPIO) */
+ *pinconfig &= ~(IOCON_PIO_FUNC_MASK);
+#endif
+#ifdef MCI_IO_MUX /* RW61x SOCs */
+	 /* Construct a pin control state, and apply it directly. */
+	 pinctrl_soc_pin_t pin_cfg;
+
+	 if (config->port_no == 1) {
+		 pin_cfg = IOMUX_GPIO_IDX(pin + 32) | IOMUX_TYPE(IOMUX_GPIO);
+	 } else {
+		 pin_cfg = IOMUX_GPIO_IDX(pin) | IOMUX_TYPE(IOMUX_GPIO);
+	 }
+	 /* Add pull up flags, if required */
+	 if ((flags & GPIO_PULL_UP) != 0) {
+		 pin_cfg |= IOMUX_PAD_PULL(0x1);
+	 } else if ((flags & GPIO_PULL_DOWN) != 0) {
+		 pin_cfg |= IOMUX_PAD_PULL(0x2);
+	 }
+	 pinctrl_configure_pins(&pin_cfg, 1, 0);
+#endif
+
+ if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
+#ifdef IOPCTL /* RT600 and RT500 series */
+	 *pinconfig |= IOPCTL_PIO_PUPD_EN;
+	 if ((flags & GPIO_PULL_UP) != 0) {
+		 *pinconfig |= IOPCTL_PIO_PULLUP_EN;
+	 } else if ((flags & GPIO_PULL_DOWN) != 0) {
+		 *pinconfig &= ~(IOPCTL_PIO_PULLUP_EN);
+	 }
+#endif
+#ifdef IOCON /* LPC SOCs */
+
+	 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
+	 if ((flags & GPIO_PULL_UP) != 0) {
+		 *pinconfig |= IOCON_PIO_MODE_PULLUP;
+	 } else if ((flags & GPIO_PULL_DOWN) != 0) {
+		 *pinconfig |= IOCON_PIO_MODE_PULLDOWN;
+	 }
+#endif
+ } else {
+#ifdef IOPCTL /* RT600 and RT500 series */
+	 *pinconfig &= ~IOPCTL_PIO_PUPD_EN;
+#endif
+#ifdef IOCON /* LPC SOCs */
+	 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
+#endif
+#ifdef MCI_IO_MUX
+
+#endif
+ }
+
+ /* supports access by pin now,you can add access by port when needed */
+ if (flags & GPIO_OUTPUT_INIT_HIGH) {
+	 gpio_base->SET[port] = BIT(pin);
+ }
+
+ if (flags & GPIO_OUTPUT_INIT_LOW) {
+	 gpio_base->CLR[port] = BIT(pin);
+ }
+
+ /* input-0,output-1 */
+ WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
+
+ return 0;
+}
+
+static int gpio_mcux_lpc_port_get_raw(const struct device *dev,
+				   uint32_t *value)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ GPIO_Type *gpio_base = config->gpio_base;
+
+ *value = gpio_base->PIN[config->port_no];
+
+ return 0;
+}
+
+static int gpio_mcux_lpc_port_set_masked_raw(const struct device *dev,
+					  uint32_t mask,
+					  uint32_t value)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ GPIO_Type *gpio_base = config->gpio_base;
+ uint32_t port = config->port_no;
+
+ /* Writing 0 allows R+W, 1 disables the pin */
+ gpio_base->MASK[port] = ~mask;
+ gpio_base->MPIN[port] = value;
+ /* Enable back the pins, user won't assume pins remain masked*/
+ gpio_base->MASK[port] = 0U;
+
+ return 0;
+}
+
+static int gpio_mcux_lpc_port_set_bits_raw(const struct device *dev,
+					uint32_t mask)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ GPIO_Type *gpio_base = config->gpio_base;
+
+ gpio_base->SET[config->port_no] = mask;
+
+ return 0;
+}
+
+static int gpio_mcux_lpc_port_clear_bits_raw(const struct device *dev,
+					  uint32_t mask)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ GPIO_Type *gpio_base = config->gpio_base;
+
+ gpio_base->CLR[config->port_no] = mask;
+
+ return 0;
+}
+
+static int gpio_mcux_lpc_port_toggle_bits(const struct device *dev,
+				   uint32_t mask)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ GPIO_Type *gpio_base = config->gpio_base;
+
+ gpio_base->NOT[config->port_no] = mask;
+
+ return 0;
+}
+
+
+#ifdef CONFIG_NXP_PINT
+/* Called by PINT when pin interrupt fires */
+static void gpio_mcux_lpc_pint_cb(uint8_t pin, void *user)
+{
+ const struct device *dev = user;
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ struct gpio_mcux_lpc_data *data = dev->data;
+ uint32_t gpio_pin;
+
+ /* Subtract port number times 32 from pin number to get GPIO API
+  * pin number.
+  */
+ gpio_pin = pin - (config->port_no * 32);
+
+ gpio_fire_callbacks(&data->callbacks, dev, BIT(gpio_pin));
+}
+
+
+/* Installs interrupt handler using PINT interrupt controller. */
+static int gpio_mcux_lpc_pint_interrupt_cfg(const struct device *dev,
+					 gpio_pin_t pin,
+					 enum gpio_int_mode mode,
+					 enum gpio_int_trig trig)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ enum nxp_pint_trigger interrupt_mode = NXP_PINT_NONE;
+ uint32_t port = config->port_no;
+ int ret;
+
+ switch (mode) {
+ case GPIO_INT_MODE_DISABLED:
+	 nxp_pint_pin_disable((port * 32) + pin);
+	 return 0;
+ case GPIO_INT_MODE_LEVEL:
+	 if (trig == GPIO_INT_TRIG_HIGH) {
+		 interrupt_mode = NXP_PINT_HIGH;
+	 } else if (trig == GPIO_INT_TRIG_LOW) {
+		 interrupt_mode = NXP_PINT_LOW;
+	 } else {
+		 return -ENOTSUP;
+	 }
+	 break;
+ case GPIO_INT_MODE_EDGE:
+	 if (trig == GPIO_INT_TRIG_HIGH) {
+		 interrupt_mode = NXP_PINT_RISING;
+	 } else if (trig == GPIO_INT_TRIG_LOW) {
+		 interrupt_mode = NXP_PINT_FALLING;
+	 } else {
+		 interrupt_mode = NXP_PINT_BOTH;
+	 }
+	 break;
+ default:
+	 return -ENOTSUP;
+ }
+
+ /* PINT treats GPIO pins as continuous. Each port has 32 pins */
+ ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode, (trig & GPIO_INT_WAKEUP));
+ if (ret < 0) {
+	 return ret;
+ }
+ /* Install callback */
+ return nxp_pint_pin_set_callback((port * 32) + pin,
+				   gpio_mcux_lpc_pint_cb,
+				   (struct device *)dev);
+}
+#endif /* CONFIG_NXP_PINT */
+
+
+#if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
+
+static int gpio_mcux_lpc_module_interrupt_cfg(const struct device *dev,
+					   gpio_pin_t pin,
+					   enum gpio_int_mode mode,
+					   enum gpio_int_trig trig)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ gpio_interrupt_index_t int_idx;
+ gpio_interrupt_config_t pin_config;
+
+ if (config->int_source == INT_SOURCE_NONE) {
+	 return -ENOTSUP;
+ }
+
+ /* Route interrupt to source A or B based on interrupt source */
+ int_idx = (config->int_source == INT_SOURCE_INTA) ?
+		 kGPIO_InterruptA : kGPIO_InterruptB;
+
+ /* Disable interrupt if requested */
+ if (mode ==  GPIO_INT_MODE_DISABLED) {
+	 GPIO_PinDisableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
+	 return 0;
+ }
+
+ /* Set pin interrupt level */
+ if (mode == GPIO_INT_MODE_LEVEL) {
+	 pin_config.mode = kGPIO_PinIntEnableLevel;
+ } else if (mode == GPIO_INT_MODE_EDGE) {
+	 pin_config.mode = kGPIO_PinIntEnableEdge;
+ } else {
+	 return -ENOTSUP;
+ }
+
+ /* Set pin interrupt trigger */
+ if (trig == GPIO_INT_TRIG_HIGH) {
+	 pin_config.polarity = kGPIO_PinIntEnableHighOrRise;
+ } else if (trig == GPIO_INT_TRIG_LOW) {
+	 pin_config.polarity = kGPIO_PinIntEnableLowOrFall;
+ } else {
+	 return -ENOTSUP;
+ }
+
+ /* Enable interrupt with new configuration */
+ GPIO_SetPinInterruptConfig(config->gpio_base, config->port_no, pin, &pin_config);
+ GPIO_PinEnableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
+ return 0;
+}
+
+/* GPIO module interrupt handler */
+void gpio_mcux_lpc_module_isr(const struct device *dev)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ struct gpio_mcux_lpc_data *data = dev->data;
+ uint32_t status;
+
+ status = GPIO_PortGetInterruptStatus(config->gpio_base,
+				 config->port_no,
+				 config->int_source == INT_SOURCE_INTA ?
+				 kGPIO_InterruptA : kGPIO_InterruptB);
+ GPIO_PortClearInterruptFlags(config->gpio_base,
+				 config->port_no,
+				 config->int_source == INT_SOURCE_INTA ?
+				 kGPIO_InterruptA : kGPIO_InterruptB,
+				 status);
+ gpio_fire_callbacks(&data->callbacks, dev, status);
+}
+
+#endif /* FSL_FEATURE_GPIO_HAS_INTERRUPT */
+
+
+static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
+					  gpio_pin_t pin,
+					  enum gpio_int_mode mode,
+					  enum gpio_int_trig trig)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+ GPIO_Type *gpio_base = config->gpio_base;
+ uint32_t port = config->port_no;
+
+ /* Ensure pin used as interrupt is set as input*/
+ if ((mode & GPIO_INT_ENABLE) &&
+	 ((gpio_base->DIR[port] & BIT(pin)) != 0)) {
+	 return -ENOTSUP;
+ }
+#if defined(CONFIG_NXP_PINT)
+ if (config->int_source == INT_SOURCE_PINT) {
+	 return gpio_mcux_lpc_pint_interrupt_cfg(dev, pin, mode, trig);
+ }
+#endif /* CONFIG_NXP_PINT */
+#if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
+ return gpio_mcux_lpc_module_interrupt_cfg(dev, pin, mode, trig);
+#else
+ return -ENOTSUP;
+#endif
+}
+
+void gpio_mcux_lpc_trigger_cb(const struct device *dev, uint32_t pins)
+{
+ struct gpio_mcux_lpc_data *data = dev->data;
+
+ gpio_fire_callbacks(&data->callbacks, dev, pins);
+}
+
+static int gpio_mcux_lpc_manage_cb(const struct device *port,
+				struct gpio_callback *callback, bool set)
+{
+ struct gpio_mcux_lpc_data *data = port->data;
+
+ return gpio_manage_callback(&data->callbacks, callback, set);
+}
+
+#if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+defined(CONFIG_PM_DEVICE))
+static void gpio_mcux_lpc_context_save(const struct device *dev)
+{
+const struct gpio_mcux_lpc_config *config = dev->config;
+	gpio_mux_registers_context.DIR[0] = config->gpio_base->DIR[0];
+	gpio_mux_registers_context.DIR[1] = config->gpio_base->DIR[1];
+	gpio_mux_registers_context.PIN[0] = config->gpio_base->PIN[0];
+	gpio_mux_registers_context.PIN[1] = config->gpio_base->PIN[1];
+	gpio_mux_registers_context.INTENA[0] = config->gpio_base->INTENA[0];
+	gpio_mux_registers_context.INTENA[1] = config->gpio_base->INTENA[1];
+	gpio_mux_registers_context.INTENB[0] = config->gpio_base->INTENB[0];
+	gpio_mux_registers_context.INTENB[1] = config->gpio_base->INTENB[1];
+	gpio_mux_registers_context.INTPOL[0] = config->gpio_base->INTPOL[0];
+	gpio_mux_registers_context.INTPOL[1] = config->gpio_base->INTPOL[1];
+	gpio_mux_registers_context.INTEDG[0] = config->gpio_base->INTEDG[0];
+	gpio_mux_registers_context.INTEDG[1] = config->gpio_base->INTEDG[1];
+
+	/*IO muxes registers should be handled in the pinctrl driver
+this is a PRELIMINARY solution to continue with the PM3 
+support for RW612 platform*/
+	gpio_mux_registers_context.GPIO_GRP0 = config->pinmux_base->GPIO_GRP0;
+	gpio_mux_registers_context.GPIO_GRP1 = config->pinmux_base->GPIO_GRP1;
+}
+
+static void gpio_mcux_lpc_context_restore(const struct device *dev)
+{
 	const struct gpio_mcux_lpc_config *config = dev->config;
 
- 	gpio_mux_registers_context.DIR[0] = config->gpio_base->DIR[0];
- 	gpio_mux_registers_context.DIR[1] = config->gpio_base->DIR[1];
- 	gpio_mux_registers_context.PIN[0] = config->gpio_base->PIN[0];
- 	gpio_mux_registers_context.PIN[1] = config->gpio_base->PIN[1];
- 	gpio_mux_registers_context.INTENA[0] = config->gpio_base->INTENA[0];
- 	gpio_mux_registers_context.INTENA[1] = config->gpio_base->INTENA[1];
- 	gpio_mux_registers_context.INTENB[0] = config->gpio_base->INTENB[0];
- 	gpio_mux_registers_context.INTENB[1] = config->gpio_base->INTENB[1];
- 	gpio_mux_registers_context.INTPOL[0] = config->gpio_base->INTPOL[0];
- 	gpio_mux_registers_context.INTPOL[1] = config->gpio_base->INTPOL[1];
- 	gpio_mux_registers_context.INTEDG[0] = config->gpio_base->INTEDG[0];
- 	gpio_mux_registers_context.INTEDG[1] = config->gpio_base->INTEDG[1];
- 
- 	/*IO muxes registers should be handled in the pinctrl driver
-	this is a PRELIMINARY solution to continue with the PM3 
-	support for RW612 platform*/
- 	gpio_mux_registers_context.GPIO_GRP0 = config->pinmux_base->GPIO_GRP0;
- 	gpio_mux_registers_context.GPIO_GRP1 = config->pinmux_base->GPIO_GRP1;
- }
- 
- static void gpio_mcux_lpc_context_restore(const struct device *dev)
- {
- 	const struct gpio_mcux_lpc_config *config = dev->config;
- 
- 	config->gpio_base->DIR[0] = gpio_mux_registers_context.DIR[0];
- 	config->gpio_base->DIR[1] = gpio_mux_registers_context.DIR[1];
- 	config->gpio_base->PIN[0] = gpio_mux_registers_context.PIN[0];
- 	config->gpio_base->PIN[1] = gpio_mux_registers_context.PIN[1]; 
- 	config->gpio_base->INTENA[0] = gpio_mux_registers_context.INTENA[0]; 
- 	config->gpio_base->INTENA[1] = gpio_mux_registers_context.INTENA[1]; 
- 	config->gpio_base->INTENB[0] = gpio_mux_registers_context.INTENB[0]; 
- 	config->gpio_base->INTENB[1] = gpio_mux_registers_context.INTENB[1]; 
- 	config->gpio_base->INTPOL[0] = gpio_mux_registers_context.INTPOL[0]; 
- 	config->gpio_base->INTPOL[1] = gpio_mux_registers_context.INTPOL[1]; 
- 	config->gpio_base->INTEDG[0] = gpio_mux_registers_context.INTEDG[0]; 
- 	config->gpio_base->INTEDG[1] = gpio_mux_registers_context.INTEDG[1]; 
- 
-	/*IO muxes registers should be handled in the pinctrl driver
-	this is a PRELIMINARY solution to continue with the PM3 
-	support for RW612 platform*/
- 	config->pinmux_base->GPIO_GRP0 = gpio_mux_registers_context.GPIO_GRP0;
- 	config->pinmux_base->GPIO_GRP1 = gpio_mux_registers_context.GPIO_GRP1;
- }
- #endif /*RW610/RW612 MCU*/
+	config->gpio_base->DIR[0] = gpio_mux_registers_context.DIR[0];
+	config->gpio_base->DIR[1] = gpio_mux_registers_context.DIR[1];
+	config->gpio_base->PIN[0] = gpio_mux_registers_context.PIN[0];
+	config->gpio_base->PIN[1] = gpio_mux_registers_context.PIN[1]; 
+	config->gpio_base->INTENA[0] = gpio_mux_registers_context.INTENA[0]; 
+	config->gpio_base->INTENA[1] = gpio_mux_registers_context.INTENA[1]; 
+	config->gpio_base->INTENB[0] = gpio_mux_registers_context.INTENB[0]; 
+	config->gpio_base->INTENB[1] = gpio_mux_registers_context.INTENB[1]; 
+	config->gpio_base->INTPOL[0] = gpio_mux_registers_context.INTPOL[0]; 
+	config->gpio_base->INTPOL[1] = gpio_mux_registers_context.INTPOL[1]; 
+	config->gpio_base->INTEDG[0] = gpio_mux_registers_context.INTEDG[0]; 
+	config->gpio_base->INTEDG[1] = gpio_mux_registers_context.INTEDG[1]; 
 
- static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
- {
-	 const struct gpio_mcux_lpc_config *config = dev->config;
- 
-	 switch (action) {
-	 case PM_DEVICE_ACTION_RESUME:
-		 break;
-	 case PM_DEVICE_ACTION_SUSPEND:
-		 break;
-	 case PM_DEVICE_ACTION_TURN_OFF:
- #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
- defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
- defined(CONFIG_PM_DEVICE))
-         gpio_mcux_lpc_context_save(dev);
- #endif /*RW610/RW612 MCU*/ 
-		 break;
-	 case PM_DEVICE_ACTION_TURN_ON:
-		 GPIO_PortInit(config->gpio_base, config->port_no);
- #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
- defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
- defined(CONFIG_PM_DEVICE))
-		 gpio_mcux_lpc_context_restore(dev);
- #endif /*RW610/RW612 MCU*/
-		 break;
-	 default:
-		 return -ENOTSUP;
-	 }
-	 return 0;
+/*IO muxes registers should be handled in the pinctrl driver
+this is a PRELIMINARY solution to continue with the PM3 
+support for RW612 platform*/
+	config->pinmux_base->GPIO_GRP0 = gpio_mux_registers_context.GPIO_GRP0;
+	config->pinmux_base->GPIO_GRP1 = gpio_mux_registers_context.GPIO_GRP1;
+}
+#endif /*RW610/RW612 MCU*/
+static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
+{
+ const struct gpio_mcux_lpc_config *config = dev->config;
+
+ switch (action) {
+ case PM_DEVICE_ACTION_RESUME:
+	 break;
+ case PM_DEVICE_ACTION_SUSPEND:
+	 break;
+ case PM_DEVICE_ACTION_TURN_OFF:
+#if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+defined(CONFIG_PM_DEVICE))
+        gpio_mcux_lpc_context_save(dev);
+#endif /*RW610/RW612 MCU*/ 
+	 break;
+ case PM_DEVICE_ACTION_TURN_ON:
+	 GPIO_PortInit(config->gpio_base, config->port_no);
+#if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+defined(CONFIG_PM_DEVICE))
+	 gpio_mcux_lpc_context_restore(dev);
+#endif /*RW610/RW612 MCU*/
+	 break;
+ default:
+	 return -ENOTSUP;
  }
- 
- static int gpio_mcux_lpc_init(const struct device *dev)
- {
-	 /* Rest of the init is done from the PM_DEVICE_TURN_ON action
-	  * which is invoked by pm_device_driver_init().
-	  */
-	 return pm_device_driver_init(dev, gpio_mcux_lpc_pm_action);
+ return 0;
+}
+
+static int gpio_mcux_lpc_init(const struct device *dev)
+{
+ /* Rest of the init is done from the PM_DEVICE_TURN_ON action
+  * which is invoked by pm_device_driver_init().
+  */
+ return pm_device_driver_init(dev, gpio_mcux_lpc_pm_action);
+}
+
+static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
+ .pin_configure = gpio_mcux_lpc_configure,
+ .port_get_raw = gpio_mcux_lpc_port_get_raw,
+ .port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
+ .port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,
+ .port_clear_bits_raw = gpio_mcux_lpc_port_clear_bits_raw,
+ .port_toggle_bits = gpio_mcux_lpc_port_toggle_bits,
+ .pin_interrupt_configure = gpio_mcux_lpc_pin_interrupt_configure,
+ .manage_callback = gpio_mcux_lpc_manage_cb,
+};
+
+
+
+#ifdef IOPCTL
+#define PINMUX_BASE	IOPCTL
+#endif
+#ifdef IOCON
+#define PINMUX_BASE	IOCON
+#endif
+#ifdef MCI_IO_MUX
+#define PINMUX_BASE	MCI_IO_MUX
+#endif
+
+#define GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)						\
+ do {										\
+	 IRQ_CONNECT(DT_INST_IRQ(inst, irq),					\
+		 DT_INST_IRQ(inst, priority),					\
+		 gpio_mcux_lpc_module_isr, DEVICE_DT_INST_GET(inst), 0);		\
+	 irq_enable(DT_INST_IRQ(inst, irq));					\
+ } while (false)
+
+#define GPIO_MCUX_LPC_MODULE_IRQ(inst)							\
+ IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, 0),					\
+	 (GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)))
+
+
+#define GPIO_MCUX_LPC(n)								\
+ static int lpc_gpio_init_##n(const struct device *dev);				\
+										 \
+ static const struct gpio_mcux_lpc_config gpio_mcux_lpc_config_##n = {		\
+	 .common = {								\
+		 .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),		\
+	 },									\
+	 .gpio_base = (GPIO_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
+	 .pinmux_base = PINMUX_BASE,						\
+	 .int_source = DT_INST_ENUM_IDX(n, int_source),				\
+	 .port_no = DT_INST_REG_ADDR(n)						\
+ };										\
+										 \
+ static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\
+										 \
+ PM_DEVICE_DT_INST_DEFINE(n, gpio_mcux_lpc_pm_action);				\
+										 \
+ DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n,					\
+		 PM_DEVICE_DT_INST_GET(n),						\
+		 &gpio_mcux_lpc_data_##n,						\
+		 &gpio_mcux_lpc_config_##n, PRE_KERNEL_1,				\
+		 CONFIG_GPIO_INIT_PRIORITY,						\
+		 &gpio_mcux_lpc_driver_api);						\
+										 \
+ static int lpc_gpio_init_##n(const struct device *dev)				\
+ {										\
+	 gpio_mcux_lpc_init(dev);						\
+	 GPIO_MCUX_LPC_MODULE_IRQ(n);						\
+										 \
+	 return 0;								\
  }
- 
- static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
-	 .pin_configure = gpio_mcux_lpc_configure,
-	 .port_get_raw = gpio_mcux_lpc_port_get_raw,
-	 .port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
-	 .port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,
-	 .port_clear_bits_raw = gpio_mcux_lpc_port_clear_bits_raw,
-	 .port_toggle_bits = gpio_mcux_lpc_port_toggle_bits,
-	 .pin_interrupt_configure = gpio_mcux_lpc_pin_interrupt_configure,
-	 .manage_callback = gpio_mcux_lpc_manage_cb,
- };
- 
- 
- 
- #ifdef IOPCTL
- #define PINMUX_BASE	IOPCTL
- #endif
- #ifdef IOCON
- #define PINMUX_BASE	IOCON
- #endif
- #ifdef MCI_IO_MUX
- #define PINMUX_BASE	MCI_IO_MUX
- #endif
- 
- #define GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)						\
-	 do {										\
-		 IRQ_CONNECT(DT_INST_IRQ(inst, irq),					\
-			 DT_INST_IRQ(inst, priority),					\
-			 gpio_mcux_lpc_module_isr, DEVICE_DT_INST_GET(inst), 0);		\
-		 irq_enable(DT_INST_IRQ(inst, irq));					\
-	 } while (false)
- 
- #define GPIO_MCUX_LPC_MODULE_IRQ(inst)							\
-	 IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, 0),					\
-		 (GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)))
- 
- 
- #define GPIO_MCUX_LPC(n)								\
-	 static int lpc_gpio_init_##n(const struct device *dev);				\
-											 \
-	 static const struct gpio_mcux_lpc_config gpio_mcux_lpc_config_##n = {		\
-		 .common = {								\
-			 .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),		\
-		 },									\
-		 .gpio_base = (GPIO_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
-		 .pinmux_base = PINMUX_BASE,						\
-		 .int_source = DT_INST_ENUM_IDX(n, int_source),				\
-		 .port_no = DT_INST_REG_ADDR(n)						\
-	 };										\
-											 \
-	 static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\
-											 \
-	 PM_DEVICE_DT_INST_DEFINE(n, gpio_mcux_lpc_pm_action);				\
-											 \
-	 DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n,					\
-			 PM_DEVICE_DT_INST_GET(n),						\
-			 &gpio_mcux_lpc_data_##n,						\
-			 &gpio_mcux_lpc_config_##n, PRE_KERNEL_1,				\
-			 CONFIG_GPIO_INIT_PRIORITY,						\
-			 &gpio_mcux_lpc_driver_api);						\
-											 \
-	 static int lpc_gpio_init_##n(const struct device *dev)				\
-	 {										\
-		 gpio_mcux_lpc_init(dev);						\
-		 GPIO_MCUX_LPC_MODULE_IRQ(n);						\
-											 \
-		 return 0;								\
-	 }
- 
- DT_INST_FOREACH_STATUS_OKAY(GPIO_MCUX_LPC)
+
+DT_INST_FOREACH_STATUS_OKAY(GPIO_MCUX_LPC)

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -4,668 +4,590 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_lpc_gpio_port
+ #define DT_DRV_COMPAT nxp_lpc_gpio_port
 
-/** @file
- * @brief GPIO driver for LPC54XXX family
- *
- * Note:
- * - fsl_pint internally tries to manage interrupts, but this is not used (e.g.
- *   s_pintCallback), Zephyr's interrupt management system is used in place.
- */
+ /** @file
+  * @brief GPIO driver for LPC54XXX family
+  *
+  * Note:
+  * - fsl_pint internally tries to manage interrupts, but this is not used (e.g.
+  *   s_pintCallback), Zephyr's interrupt management system is used in place.
+  */
+ 
+ #include <errno.h>
+ #include <zephyr/device.h>
+ #include <zephyr/drivers/gpio.h>
+ #include <zephyr/pm/device.h>
+ #include <zephyr/irq.h>
+ #include <soc.h>
+ #include <fsl_common.h>
+ #include <zephyr/drivers/gpio/gpio_utils.h>
+ #ifdef CONFIG_NXP_PINT
+ #include <zephyr/drivers/interrupt_controller/nxp_pint.h>
+ #endif
+ #include <fsl_gpio.h>
+ #include <fsl_device_registers.h>
+ #ifdef MCI_IO_MUX
+ #include <zephyr/drivers/pinctrl.h>
+ #endif
+ 
+ /* Interrupt sources, matching int-source enum in DTS binding definition */
+ #define INT_SOURCE_PINT 0
+ #define INT_SOURCE_INTA 1
+ #define INT_SOURCE_INTB 2
+ #define INT_SOURCE_NONE 3
+ 
+ struct gpio_mcux_lpc_config {
+	 /* gpio_driver_config needs to be first */
+	 struct gpio_driver_config common;
+	 GPIO_Type *gpio_base;
+	 uint8_t int_source;
+ #ifdef IOPCTL
+	 IOPCTL_Type *pinmux_base;
+ #endif
+ #ifdef IOCON
+	 IOCON_Type *pinmux_base;
+ #endif
+ #ifdef MCI_IO_MUX
+	 MCI_IO_MUX_Type * pinmux_base;
+ #endif
+	 uint32_t port_no;
+ };
+ 
+ struct gpio_mcux_lpc_data {
+	 /* gpio_driver_data needs to be first */
+	 struct gpio_driver_data common;
+	 /* port ISR callback routine address */
+	 sys_slist_t callbacks;
+ };
 
-#include <errno.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/gpio.h>
-#include <zephyr/pm/device.h>
-#include <zephyr/irq.h>
-#include <soc.h>
-#include <fsl_common.h>
-#include <zephyr/drivers/gpio/gpio_utils.h>
-#ifdef CONFIG_NXP_PINT
-#include <zephyr/drivers/interrupt_controller/nxp_pint.h>
-#endif
-#include <fsl_gpio.h>
-#include <fsl_device_registers.h>
-#ifdef MCI_IO_MUX
-#include <zephyr/drivers/pinctrl.h>
-#endif
+ #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+       defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+       defined(CONFIG_PM_DEVICE))
+ static struct gpio_mux_registers_context_t{
+ 	/*GPIO Configuration Registers*/
+ 	uint32_t DIR[2];
+ 	uint32_t PIN[2];
+ 	uint32_t INTENA[2];
+ 	uint32_t INTENB[2];
+ 	uint32_t INTPOL[2];
+ 	uint32_t INTEDG[2];
 
-/* Interrupt sources, matching int-source enum in DTS binding definition */
-#define INT_SOURCE_PINT 0
-#define INT_SOURCE_INTA 1
-#define INT_SOURCE_INTB 2
-#define INT_SOURCE_NONE 3
-
-struct gpio_mcux_lpc_config {
-	/* gpio_driver_config needs to be first */
-	struct gpio_driver_config common;
-	GPIO_Type *gpio_base;
-	uint8_t int_source;
-#ifdef IOPCTL
-	IOPCTL_Type *pinmux_base;
-#endif
-#ifdef IOCON
-	IOCON_Type *pinmux_base;
-#endif
-#ifdef MCI_IO_MUX
-	MCI_IO_MUX_Type * pinmux_base;
-#endif
-	uint32_t port_no;
-};
-
-struct gpio_mcux_lpc_data {
-	/* gpio_driver_data needs to be first */
-	struct gpio_driver_data common;
-	/* port ISR callback routine address */
-	sys_slist_t callbacks;
-};
-
-#ifdef CONFIG_PM_DEVICE
-static struct gpio_mux_registers_context_t{
-	/*GPIO Configuration Registers*/
-	uint8_t B[2][32];
-	uint32_t W[2][32];
-	uint32_t DIR[2];
-	uint32_t MASK[2];
-	uint32_t PIN[2];
-	uint32_t MPIN[2];
-	uint32_t SET[2];
-	uint32_t CLR[2];
-	uint32_t NOT[2];
-	uint32_t DIRSET[2];
-	uint32_t DIRCLR[2];
-	uint32_t DIRNOT[2];
-	uint32_t INTENA[2];
-	uint32_t INTENB[2];
-	uint32_t INTPOL[2];
-	uint32_t INTEDG[2];
-	uint32_t INTSTATA[2];
-	uint32_t INTSTATB[2];
-
-	/*PinCtrl Configuration Registers*/
-	uint32_t S_GPIO;                            
-    uint32_t FC0;                               
-    uint32_t FC1;                               
-    uint32_t FC2;                               
-    uint32_t FC3;                               
-	uint32_t FC14;                              
-	uint32_t FSEL;                              
-	uint32_t C_TIMER_IN;                        
-	uint32_t C_TIMER_OUT;                       
-	uint32_t SC_TIMER;                          
-	uint32_t GPIO_GRP0;                         
-	uint32_t GPIO_GRP1;                         
-}gpio_mux_registers_context;
-#endif /*CONFIG_PM_DEVICE*/
-
-
-static int gpio_mcux_lpc_configure(const struct device *dev, gpio_pin_t pin,
-				   gpio_flags_t flags)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_Type *gpio_base = config->gpio_base;
-	uint32_t port = config->port_no;
-
-	if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
-		return -ENOTSUP;
-	}
-
-#ifdef IOPCTL /* RT600 and RT500 series */
-	IOPCTL_Type *pinmux_base = config->pinmux_base;
-	volatile uint32_t *pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
-
-	/*
-	 * Enable input buffer for both input and output pins, it costs
-	 * nothing and allows values to be read back.
-	 */
-	*pinconfig |= IOPCTL_PIO_INBUF_EN;
-
-	if ((flags & GPIO_SINGLE_ENDED) != 0) {
-		*pinconfig |= IOPCTL_PIO_PSEDRAIN_EN;
-	} else {
-		*pinconfig &= ~IOPCTL_PIO_PSEDRAIN_EN;
-	}
-	/* Select GPIO mux for this pin (func 0 is always GPIO) */
-	*pinconfig &= ~(IOPCTL_PIO_FSEL_MASK);
-#endif
-#ifdef IOCON /* LPC SOCs */
-	volatile uint32_t *pinconfig;
-	IOCON_Type *pinmux_base;
-
-	pinmux_base = config->pinmux_base;
-	pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
-
-	if ((flags & GPIO_SINGLE_ENDED) != 0) {
-		/* Set ODE bit. */
-		*pinconfig |= IOCON_PIO_OD_MASK;
-	}
-
-	if ((flags & GPIO_INPUT) != 0) {
-		/* Set DIGIMODE bit */
-		*pinconfig |= IOCON_PIO_DIGIMODE_MASK;
-	}
-	/* Select GPIO mux for this pin (func 0 is always GPIO) */
-	*pinconfig &= ~(IOCON_PIO_FUNC_MASK);
-#endif
-#ifdef MCI_IO_MUX /* RW61x SOCs */
-		/* Construct a pin control state, and apply it directly. */
-		pinctrl_soc_pin_t pin_cfg;
-
-		if (config->port_no == 1) {
-			pin_cfg = IOMUX_GPIO_IDX(pin + 32) | IOMUX_TYPE(IOMUX_GPIO);
-		} else {
-			pin_cfg = IOMUX_GPIO_IDX(pin) | IOMUX_TYPE(IOMUX_GPIO);
-		}
-		/* Add pull up flags, if required */
-		if ((flags & GPIO_PULL_UP) != 0) {
-			pin_cfg |= IOMUX_PAD_PULL(0x1);
-		} else if ((flags & GPIO_PULL_DOWN) != 0) {
-			pin_cfg |= IOMUX_PAD_PULL(0x2);
-		}
-		pinctrl_configure_pins(&pin_cfg, 1, 0);
-#endif
-
-	if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
-#ifdef IOPCTL /* RT600 and RT500 series */
-		*pinconfig |= IOPCTL_PIO_PUPD_EN;
-		if ((flags & GPIO_PULL_UP) != 0) {
-			*pinconfig |= IOPCTL_PIO_PULLUP_EN;
-		} else if ((flags & GPIO_PULL_DOWN) != 0) {
-			*pinconfig &= ~(IOPCTL_PIO_PULLUP_EN);
-		}
-#endif
-#ifdef IOCON /* LPC SOCs */
-
-		*pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
-		if ((flags & GPIO_PULL_UP) != 0) {
-			*pinconfig |= IOCON_PIO_MODE_PULLUP;
-		} else if ((flags & GPIO_PULL_DOWN) != 0) {
-			*pinconfig |= IOCON_PIO_MODE_PULLDOWN;
-		}
-#endif
-	} else {
-#ifdef IOPCTL /* RT600 and RT500 series */
-		*pinconfig &= ~IOPCTL_PIO_PUPD_EN;
-#endif
-#ifdef IOCON /* LPC SOCs */
-		*pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
-#endif
-#ifdef MCI_IO_MUX
-
-#endif
-	}
-
-	/* supports access by pin now,you can add access by port when needed */
-	if (flags & GPIO_OUTPUT_INIT_HIGH) {
-		gpio_base->SET[port] = BIT(pin);
-	}
-
-	if (flags & GPIO_OUTPUT_INIT_LOW) {
-		gpio_base->CLR[port] = BIT(pin);
-	}
-
-	/* input-0,output-1 */
-	WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
-
-	return 0;
-}
-
-static int gpio_mcux_lpc_port_get_raw(const struct device *dev,
-				      uint32_t *value)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	*value = gpio_base->PIN[config->port_no];
-
-	return 0;
-}
-
-static int gpio_mcux_lpc_port_set_masked_raw(const struct device *dev,
-					     uint32_t mask,
-					     uint32_t value)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_Type *gpio_base = config->gpio_base;
-	uint32_t port = config->port_no;
-
-	/* Writing 0 allows R+W, 1 disables the pin */
-	gpio_base->MASK[port] = ~mask;
-	gpio_base->MPIN[port] = value;
-	/* Enable back the pins, user won't assume pins remain masked*/
-	gpio_base->MASK[port] = 0U;
-
-	return 0;
-}
-
-static int gpio_mcux_lpc_port_set_bits_raw(const struct device *dev,
+ 	/*PinCtrl Configuration Registers*/                         
+ 	uint32_t GPIO_GRP0;                         
+ 	uint32_t GPIO_GRP1;                         
+ }gpio_mux_registers_context;
+ #endif /*RW612/RW610 MCU*/
+ 
+ static int gpio_mcux_lpc_configure(const struct device *dev, gpio_pin_t pin,
+					gpio_flags_t flags)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 GPIO_Type *gpio_base = config->gpio_base;
+	 uint32_t port = config->port_no;
+ 
+	 if (((flags & GPIO_INPUT) != 0) && ((flags & GPIO_OUTPUT) != 0)) {
+		 return -ENOTSUP;
+	 }
+ 
+ #ifdef IOPCTL /* RT600 and RT500 series */
+	 IOPCTL_Type *pinmux_base = config->pinmux_base;
+	 volatile uint32_t *pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
+ 
+	 /*
+	  * Enable input buffer for both input and output pins, it costs
+	  * nothing and allows values to be read back.
+	  */
+	 *pinconfig |= IOPCTL_PIO_INBUF_EN;
+ 
+	 if ((flags & GPIO_SINGLE_ENDED) != 0) {
+		 *pinconfig |= IOPCTL_PIO_PSEDRAIN_EN;
+	 } else {
+		 *pinconfig &= ~IOPCTL_PIO_PSEDRAIN_EN;
+	 }
+	 /* Select GPIO mux for this pin (func 0 is always GPIO) */
+	 *pinconfig &= ~(IOPCTL_PIO_FSEL_MASK);
+ #endif
+ #ifdef IOCON /* LPC SOCs */
+	 volatile uint32_t *pinconfig;
+	 IOCON_Type *pinmux_base;
+ 
+	 pinmux_base = config->pinmux_base;
+	 pinconfig = (volatile uint32_t *)&(pinmux_base->PIO[port][pin]);
+ 
+	 if ((flags & GPIO_SINGLE_ENDED) != 0) {
+		 /* Set ODE bit. */
+		 *pinconfig |= IOCON_PIO_OD_MASK;
+	 }
+ 
+	 if ((flags & GPIO_INPUT) != 0) {
+		 /* Set DIGIMODE bit */
+		 *pinconfig |= IOCON_PIO_DIGIMODE_MASK;
+	 }
+	 /* Select GPIO mux for this pin (func 0 is always GPIO) */
+	 *pinconfig &= ~(IOCON_PIO_FUNC_MASK);
+ #endif
+ #ifdef MCI_IO_MUX /* RW61x SOCs */
+		 /* Construct a pin control state, and apply it directly. */
+		 pinctrl_soc_pin_t pin_cfg;
+ 
+		 if (config->port_no == 1) {
+			 pin_cfg = IOMUX_GPIO_IDX(pin + 32) | IOMUX_TYPE(IOMUX_GPIO);
+		 } else {
+			 pin_cfg = IOMUX_GPIO_IDX(pin) | IOMUX_TYPE(IOMUX_GPIO);
+		 }
+		 /* Add pull up flags, if required */
+		 if ((flags & GPIO_PULL_UP) != 0) {
+			 pin_cfg |= IOMUX_PAD_PULL(0x1);
+		 } else if ((flags & GPIO_PULL_DOWN) != 0) {
+			 pin_cfg |= IOMUX_PAD_PULL(0x2);
+		 }
+		 pinctrl_configure_pins(&pin_cfg, 1, 0);
+ #endif
+ 
+	 if (flags & (GPIO_PULL_UP | GPIO_PULL_DOWN)) {
+ #ifdef IOPCTL /* RT600 and RT500 series */
+		 *pinconfig |= IOPCTL_PIO_PUPD_EN;
+		 if ((flags & GPIO_PULL_UP) != 0) {
+			 *pinconfig |= IOPCTL_PIO_PULLUP_EN;
+		 } else if ((flags & GPIO_PULL_DOWN) != 0) {
+			 *pinconfig &= ~(IOPCTL_PIO_PULLUP_EN);
+		 }
+ #endif
+ #ifdef IOCON /* LPC SOCs */
+ 
+		 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
+		 if ((flags & GPIO_PULL_UP) != 0) {
+			 *pinconfig |= IOCON_PIO_MODE_PULLUP;
+		 } else if ((flags & GPIO_PULL_DOWN) != 0) {
+			 *pinconfig |= IOCON_PIO_MODE_PULLDOWN;
+		 }
+ #endif
+	 } else {
+ #ifdef IOPCTL /* RT600 and RT500 series */
+		 *pinconfig &= ~IOPCTL_PIO_PUPD_EN;
+ #endif
+ #ifdef IOCON /* LPC SOCs */
+		 *pinconfig &= ~(IOCON_PIO_MODE_PULLUP|IOCON_PIO_MODE_PULLDOWN);
+ #endif
+ #ifdef MCI_IO_MUX
+ 
+ #endif
+	 }
+ 
+	 /* supports access by pin now,you can add access by port when needed */
+	 if (flags & GPIO_OUTPUT_INIT_HIGH) {
+		 gpio_base->SET[port] = BIT(pin);
+	 }
+ 
+	 if (flags & GPIO_OUTPUT_INIT_LOW) {
+		 gpio_base->CLR[port] = BIT(pin);
+	 }
+ 
+	 /* input-0,output-1 */
+	 WRITE_BIT(gpio_base->DIR[port], pin, flags & GPIO_OUTPUT);
+ 
+	 return 0;
+ }
+ 
+ static int gpio_mcux_lpc_port_get_raw(const struct device *dev,
+					   uint32_t *value)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 GPIO_Type *gpio_base = config->gpio_base;
+ 
+	 *value = gpio_base->PIN[config->port_no];
+ 
+	 return 0;
+ }
+ 
+ static int gpio_mcux_lpc_port_set_masked_raw(const struct device *dev,
+						  uint32_t mask,
+						  uint32_t value)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 GPIO_Type *gpio_base = config->gpio_base;
+	 uint32_t port = config->port_no;
+ 
+	 /* Writing 0 allows R+W, 1 disables the pin */
+	 gpio_base->MASK[port] = ~mask;
+	 gpio_base->MPIN[port] = value;
+	 /* Enable back the pins, user won't assume pins remain masked*/
+	 gpio_base->MASK[port] = 0U;
+ 
+	 return 0;
+ }
+ 
+ static int gpio_mcux_lpc_port_set_bits_raw(const struct device *dev,
+						uint32_t mask)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 GPIO_Type *gpio_base = config->gpio_base;
+ 
+	 gpio_base->SET[config->port_no] = mask;
+ 
+	 return 0;
+ }
+ 
+ static int gpio_mcux_lpc_port_clear_bits_raw(const struct device *dev,
+						  uint32_t mask)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 GPIO_Type *gpio_base = config->gpio_base;
+ 
+	 gpio_base->CLR[config->port_no] = mask;
+ 
+	 return 0;
+ }
+ 
+ static int gpio_mcux_lpc_port_toggle_bits(const struct device *dev,
 					   uint32_t mask)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	gpio_base->SET[config->port_no] = mask;
-
-	return 0;
-}
-
-static int gpio_mcux_lpc_port_clear_bits_raw(const struct device *dev,
-					     uint32_t mask)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	gpio_base->CLR[config->port_no] = mask;
-
-	return 0;
-}
-
-static int gpio_mcux_lpc_port_toggle_bits(const struct device *dev,
-					  uint32_t mask)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_Type *gpio_base = config->gpio_base;
-
-	gpio_base->NOT[config->port_no] = mask;
-
-	return 0;
-}
-
-
-#ifdef CONFIG_NXP_PINT
-/* Called by PINT when pin interrupt fires */
-static void gpio_mcux_lpc_pint_cb(uint8_t pin, void *user)
-{
-	const struct device *dev = user;
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	struct gpio_mcux_lpc_data *data = dev->data;
-	uint32_t gpio_pin;
-
-	/* Subtract port number times 32 from pin number to get GPIO API
-	 * pin number.
-	 */
-	gpio_pin = pin - (config->port_no * 32);
-
-	gpio_fire_callbacks(&data->callbacks, dev, BIT(gpio_pin));
-}
-
-
-/* Installs interrupt handler using PINT interrupt controller. */
-static int gpio_mcux_lpc_pint_interrupt_cfg(const struct device *dev,
-					    gpio_pin_t pin,
-					    enum gpio_int_mode mode,
-					    enum gpio_int_trig trig)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	enum nxp_pint_trigger interrupt_mode = NXP_PINT_NONE;
-	uint32_t port = config->port_no;
-	int ret;
-
-	switch (mode) {
-	case GPIO_INT_MODE_DISABLED:
-		nxp_pint_pin_disable((port * 32) + pin);
-		return 0;
-	case GPIO_INT_MODE_LEVEL:
-		if (trig == GPIO_INT_TRIG_HIGH) {
-			interrupt_mode = NXP_PINT_HIGH;
-		} else if (trig == GPIO_INT_TRIG_LOW) {
-			interrupt_mode = NXP_PINT_LOW;
-		} else {
-			return -ENOTSUP;
-		}
-		break;
-	case GPIO_INT_MODE_EDGE:
-		if (trig == GPIO_INT_TRIG_HIGH) {
-			interrupt_mode = NXP_PINT_RISING;
-		} else if (trig == GPIO_INT_TRIG_LOW) {
-			interrupt_mode = NXP_PINT_FALLING;
-		} else {
-			interrupt_mode = NXP_PINT_BOTH;
-		}
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
-	/* PINT treats GPIO pins as continuous. Each port has 32 pins */
-	ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode, (trig & GPIO_INT_WAKEUP));
-	if (ret < 0) {
-		return ret;
-	}
-	/* Install callback */
-	return nxp_pint_pin_set_callback((port * 32) + pin,
-					  gpio_mcux_lpc_pint_cb,
-					  (struct device *)dev);
-}
-#endif /* CONFIG_NXP_PINT */
-
-
-#if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
-
-static int gpio_mcux_lpc_module_interrupt_cfg(const struct device *dev,
-					      gpio_pin_t pin,
-					      enum gpio_int_mode mode,
-					      enum gpio_int_trig trig)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	gpio_interrupt_index_t int_idx;
-	gpio_interrupt_config_t pin_config;
-
-	if (config->int_source == INT_SOURCE_NONE) {
-		return -ENOTSUP;
-	}
-
-	/* Route interrupt to source A or B based on interrupt source */
-	int_idx = (config->int_source == INT_SOURCE_INTA) ?
-			kGPIO_InterruptA : kGPIO_InterruptB;
-
-	/* Disable interrupt if requested */
-	if (mode ==  GPIO_INT_MODE_DISABLED) {
-		GPIO_PinDisableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
-		return 0;
-	}
-
-	/* Set pin interrupt level */
-	if (mode == GPIO_INT_MODE_LEVEL) {
-		pin_config.mode = kGPIO_PinIntEnableLevel;
-	} else if (mode == GPIO_INT_MODE_EDGE) {
-		pin_config.mode = kGPIO_PinIntEnableEdge;
-	} else {
-		return -ENOTSUP;
-	}
-
-	/* Set pin interrupt trigger */
-	if (trig == GPIO_INT_TRIG_HIGH) {
-		pin_config.polarity = kGPIO_PinIntEnableHighOrRise;
-	} else if (trig == GPIO_INT_TRIG_LOW) {
-		pin_config.polarity = kGPIO_PinIntEnableLowOrFall;
-	} else {
-		return -ENOTSUP;
-	}
-
-	/* Enable interrupt with new configuration */
-	GPIO_SetPinInterruptConfig(config->gpio_base, config->port_no, pin, &pin_config);
-	GPIO_PinEnableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
-	return 0;
-}
-
-/* GPIO module interrupt handler */
-void gpio_mcux_lpc_module_isr(const struct device *dev)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	struct gpio_mcux_lpc_data *data = dev->data;
-	uint32_t status;
-
-	status = GPIO_PortGetInterruptStatus(config->gpio_base,
-					config->port_no,
-					config->int_source == INT_SOURCE_INTA ?
-					kGPIO_InterruptA : kGPIO_InterruptB);
-	GPIO_PortClearInterruptFlags(config->gpio_base,
-					config->port_no,
-					config->int_source == INT_SOURCE_INTA ?
-					kGPIO_InterruptA : kGPIO_InterruptB,
-					status);
-	gpio_fire_callbacks(&data->callbacks, dev, status);
-}
-
-#endif /* FSL_FEATURE_GPIO_HAS_INTERRUPT */
-
-
-static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 GPIO_Type *gpio_base = config->gpio_base;
+ 
+	 gpio_base->NOT[config->port_no] = mask;
+ 
+	 return 0;
+ }
+ 
+ 
+ #ifdef CONFIG_NXP_PINT
+ /* Called by PINT when pin interrupt fires */
+ static void gpio_mcux_lpc_pint_cb(uint8_t pin, void *user)
+ {
+	 const struct device *dev = user;
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 struct gpio_mcux_lpc_data *data = dev->data;
+	 uint32_t gpio_pin;
+ 
+	 /* Subtract port number times 32 from pin number to get GPIO API
+	  * pin number.
+	  */
+	 gpio_pin = pin - (config->port_no * 32);
+ 
+	 gpio_fire_callbacks(&data->callbacks, dev, BIT(gpio_pin));
+ }
+ 
+ 
+ /* Installs interrupt handler using PINT interrupt controller. */
+ static int gpio_mcux_lpc_pint_interrupt_cfg(const struct device *dev,
 						 gpio_pin_t pin,
 						 enum gpio_int_mode mode,
 						 enum gpio_int_trig trig)
-{
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 enum nxp_pint_trigger interrupt_mode = NXP_PINT_NONE;
+	 uint32_t port = config->port_no;
+	 int ret;
+ 
+	 switch (mode) {
+	 case GPIO_INT_MODE_DISABLED:
+		 nxp_pint_pin_disable((port * 32) + pin);
+		 return 0;
+	 case GPIO_INT_MODE_LEVEL:
+		 if (trig == GPIO_INT_TRIG_HIGH) {
+			 interrupt_mode = NXP_PINT_HIGH;
+		 } else if (trig == GPIO_INT_TRIG_LOW) {
+			 interrupt_mode = NXP_PINT_LOW;
+		 } else {
+			 return -ENOTSUP;
+		 }
+		 break;
+	 case GPIO_INT_MODE_EDGE:
+		 if (trig == GPIO_INT_TRIG_HIGH) {
+			 interrupt_mode = NXP_PINT_RISING;
+		 } else if (trig == GPIO_INT_TRIG_LOW) {
+			 interrupt_mode = NXP_PINT_FALLING;
+		 } else {
+			 interrupt_mode = NXP_PINT_BOTH;
+		 }
+		 break;
+	 default:
+		 return -ENOTSUP;
+	 }
+ 
+	 /* PINT treats GPIO pins as continuous. Each port has 32 pins */
+	 ret = nxp_pint_pin_enable((port * 32) + pin, interrupt_mode, (trig & GPIO_INT_WAKEUP));
+	 if (ret < 0) {
+		 return ret;
+	 }
+	 /* Install callback */
+	 return nxp_pint_pin_set_callback((port * 32) + pin,
+					   gpio_mcux_lpc_pint_cb,
+					   (struct device *)dev);
+ }
+ #endif /* CONFIG_NXP_PINT */
+ 
+ 
+ #if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
+ 
+ static int gpio_mcux_lpc_module_interrupt_cfg(const struct device *dev,
+						   gpio_pin_t pin,
+						   enum gpio_int_mode mode,
+						   enum gpio_int_trig trig)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 gpio_interrupt_index_t int_idx;
+	 gpio_interrupt_config_t pin_config;
+ 
+	 if (config->int_source == INT_SOURCE_NONE) {
+		 return -ENOTSUP;
+	 }
+ 
+	 /* Route interrupt to source A or B based on interrupt source */
+	 int_idx = (config->int_source == INT_SOURCE_INTA) ?
+			 kGPIO_InterruptA : kGPIO_InterruptB;
+ 
+	 /* Disable interrupt if requested */
+	 if (mode ==  GPIO_INT_MODE_DISABLED) {
+		 GPIO_PinDisableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
+		 return 0;
+	 }
+ 
+	 /* Set pin interrupt level */
+	 if (mode == GPIO_INT_MODE_LEVEL) {
+		 pin_config.mode = kGPIO_PinIntEnableLevel;
+	 } else if (mode == GPIO_INT_MODE_EDGE) {
+		 pin_config.mode = kGPIO_PinIntEnableEdge;
+	 } else {
+		 return -ENOTSUP;
+	 }
+ 
+	 /* Set pin interrupt trigger */
+	 if (trig == GPIO_INT_TRIG_HIGH) {
+		 pin_config.polarity = kGPIO_PinIntEnableHighOrRise;
+	 } else if (trig == GPIO_INT_TRIG_LOW) {
+		 pin_config.polarity = kGPIO_PinIntEnableLowOrFall;
+	 } else {
+		 return -ENOTSUP;
+	 }
+ 
+	 /* Enable interrupt with new configuration */
+	 GPIO_SetPinInterruptConfig(config->gpio_base, config->port_no, pin, &pin_config);
+	 GPIO_PinEnableInterrupt(config->gpio_base, config->port_no, pin, int_idx);
+	 return 0;
+ }
+ 
+ /* GPIO module interrupt handler */
+ void gpio_mcux_lpc_module_isr(const struct device *dev)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 struct gpio_mcux_lpc_data *data = dev->data;
+	 uint32_t status;
+ 
+	 status = GPIO_PortGetInterruptStatus(config->gpio_base,
+					 config->port_no,
+					 config->int_source == INT_SOURCE_INTA ?
+					 kGPIO_InterruptA : kGPIO_InterruptB);
+	 GPIO_PortClearInterruptFlags(config->gpio_base,
+					 config->port_no,
+					 config->int_source == INT_SOURCE_INTA ?
+					 kGPIO_InterruptA : kGPIO_InterruptB,
+					 status);
+	 gpio_fire_callbacks(&data->callbacks, dev, status);
+ }
+ 
+ #endif /* FSL_FEATURE_GPIO_HAS_INTERRUPT */
+ 
+ 
+ static int gpio_mcux_lpc_pin_interrupt_configure(const struct device *dev,
+						  gpio_pin_t pin,
+						  enum gpio_int_mode mode,
+						  enum gpio_int_trig trig)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+	 GPIO_Type *gpio_base = config->gpio_base;
+	 uint32_t port = config->port_no;
+ 
+	 /* Ensure pin used as interrupt is set as input*/
+	 if ((mode & GPIO_INT_ENABLE) &&
+		 ((gpio_base->DIR[port] & BIT(pin)) != 0)) {
+		 return -ENOTSUP;
+	 }
+ #if defined(CONFIG_NXP_PINT)
+	 if (config->int_source == INT_SOURCE_PINT) {
+		 return gpio_mcux_lpc_pint_interrupt_cfg(dev, pin, mode, trig);
+	 }
+ #endif /* CONFIG_NXP_PINT */
+ #if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
+	 return gpio_mcux_lpc_module_interrupt_cfg(dev, pin, mode, trig);
+ #else
+	 return -ENOTSUP;
+ #endif
+ }
+ 
+ void gpio_mcux_lpc_trigger_cb(const struct device *dev, uint32_t pins)
+ {
+	 struct gpio_mcux_lpc_data *data = dev->data;
+ 
+	 gpio_fire_callbacks(&data->callbacks, dev, pins);
+ }
+ 
+ static int gpio_mcux_lpc_manage_cb(const struct device *port,
+					struct gpio_callback *callback, bool set)
+ {
+	 struct gpio_mcux_lpc_data *data = port->data;
+ 
+	 return gpio_manage_callback(&data->callbacks, callback, set);
+ }
+ 
+ #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+ defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+ defined(CONFIG_PM_DEVICE))
+ static void gpio_mcux_lpc_context_save(const struct device *dev)
+ {
 	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_Type *gpio_base = config->gpio_base;
-	uint32_t port = config->port_no;
 
-	/* Ensure pin used as interrupt is set as input*/
-	if ((mode & GPIO_INT_ENABLE) &&
-		((gpio_base->DIR[port] & BIT(pin)) != 0)) {
-		return -ENOTSUP;
-	}
-#if defined(CONFIG_NXP_PINT)
-	if (config->int_source == INT_SOURCE_PINT) {
-		return gpio_mcux_lpc_pint_interrupt_cfg(dev, pin, mode, trig);
-	}
-#endif /* CONFIG_NXP_PINT */
-#if (defined(FSL_FEATURE_GPIO_HAS_INTERRUPT) && FSL_FEATURE_GPIO_HAS_INTERRUPT)
-	return gpio_mcux_lpc_module_interrupt_cfg(dev, pin, mode, trig);
-#else
-	return -ENOTSUP;
-#endif
-}
+ 	gpio_mux_registers_context.DIR[0] = config->gpio_base->DIR[0];
+ 	gpio_mux_registers_context.DIR[1] = config->gpio_base->DIR[1];
+ 	gpio_mux_registers_context.PIN[0] = config->gpio_base->PIN[0];
+ 	gpio_mux_registers_context.PIN[1] = config->gpio_base->PIN[1];
+ 	gpio_mux_registers_context.INTENA[0] = config->gpio_base->INTENA[0];
+ 	gpio_mux_registers_context.INTENA[1] = config->gpio_base->INTENA[1];
+ 	gpio_mux_registers_context.INTENB[0] = config->gpio_base->INTENB[0];
+ 	gpio_mux_registers_context.INTENB[1] = config->gpio_base->INTENB[1];
+ 	gpio_mux_registers_context.INTPOL[0] = config->gpio_base->INTPOL[0];
+ 	gpio_mux_registers_context.INTPOL[1] = config->gpio_base->INTPOL[1];
+ 	gpio_mux_registers_context.INTEDG[0] = config->gpio_base->INTEDG[0];
+ 	gpio_mux_registers_context.INTEDG[1] = config->gpio_base->INTEDG[1];
+ 
+ 	/*IO muxes registers should be handled in the pinctrl driver
+	this is a PRELIMINARY solution to continue with the PM3 
+	support for RW612 platform*/
+ 	gpio_mux_registers_context.GPIO_GRP0 = config->pinmux_base->GPIO_GRP0;
+ 	gpio_mux_registers_context.GPIO_GRP1 = config->pinmux_base->GPIO_GRP1;
+ }
+ 
+ static void gpio_mcux_lpc_context_restore(const struct device *dev)
+ {
+ 	const struct gpio_mcux_lpc_config *config = dev->config;
+ 
+ 	config->gpio_base->DIR[0] = gpio_mux_registers_context.DIR[0];
+ 	config->gpio_base->DIR[1] = gpio_mux_registers_context.DIR[1];
+ 	config->gpio_base->PIN[0] = gpio_mux_registers_context.PIN[0];
+ 	config->gpio_base->PIN[1] = gpio_mux_registers_context.PIN[1]; 
+ 	config->gpio_base->INTENA[0] = gpio_mux_registers_context.INTENA[0]; 
+ 	config->gpio_base->INTENA[1] = gpio_mux_registers_context.INTENA[1]; 
+ 	config->gpio_base->INTENB[0] = gpio_mux_registers_context.INTENB[0]; 
+ 	config->gpio_base->INTENB[1] = gpio_mux_registers_context.INTENB[1]; 
+ 	config->gpio_base->INTPOL[0] = gpio_mux_registers_context.INTPOL[0]; 
+ 	config->gpio_base->INTPOL[1] = gpio_mux_registers_context.INTPOL[1]; 
+ 	config->gpio_base->INTEDG[0] = gpio_mux_registers_context.INTEDG[0]; 
+ 	config->gpio_base->INTEDG[1] = gpio_mux_registers_context.INTEDG[1]; 
+ 
+	/*IO muxes registers should be handled in the pinctrl driver
+	this is a PRELIMINARY solution to continue with the PM3 
+	support for RW612 platform*/
+ 	config->pinmux_base->GPIO_GRP0 = gpio_mux_registers_context.GPIO_GRP0;
+ 	config->pinmux_base->GPIO_GRP1 = gpio_mux_registers_context.GPIO_GRP1;
+ }
+ #endif /*RW610/RW612 MCU*/
 
-void gpio_mcux_lpc_trigger_cb(const struct device *dev, uint32_t pins)
-{
-	struct gpio_mcux_lpc_data *data = dev->data;
-
-	gpio_fire_callbacks(&data->callbacks, dev, pins);
-}
-
-static int gpio_mcux_lpc_manage_cb(const struct device *port,
-				   struct gpio_callback *callback, bool set)
-{
-	struct gpio_mcux_lpc_data *data = port->data;
-
-	return gpio_manage_callback(&data->callbacks, callback, set);
-}
-
-static int gpio_mcux_lpc_init(const struct device *dev)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	GPIO_PortInit(config->gpio_base, config->port_no);
-	return 0;
-}
-
-#ifdef CONFIG_PM_DEVICE
-static void gpio_mcux_lpc_context_save(const struct device *dev)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	uint8_t *u8_src_ptr;
-	uint8_t *u8_dst_ptr;
-	uint16_t index;
-
-	/*GPIO Registers*/
-	u8_src_ptr = (uint8_t*)config->gpio_base->B;
-	u8_dst_ptr = (uint8_t*)&gpio_mux_registers_context.B[0][0];
-	for(index=0; index<sizeof(gpio_mux_registers_context.B); index++){
-		u8_dst_ptr[index] = u8_src_ptr[index];
-	}
-
-	u8_src_ptr = (uint8_t*)config->gpio_base->W;
-	u8_dst_ptr = (uint8_t*)&gpio_mux_registers_context.W[0][0];
-	for(index=0; index<(sizeof(gpio_mux_registers_context.W)/4); index++){
-		u8_dst_ptr[index] = u8_src_ptr[index];
-	}
-
-	gpio_mux_registers_context.DIR[0] = config->gpio_base->DIR[0];
-	gpio_mux_registers_context.DIR[1] = config->gpio_base->DIR[1];
-	gpio_mux_registers_context.MASK[0] = config->gpio_base->MASK[0];
-	gpio_mux_registers_context.MASK[1] = config->gpio_base->MASK[1];
-	gpio_mux_registers_context.PIN[0] = config->gpio_base->PIN[0];
-	gpio_mux_registers_context.PIN[1] = config->gpio_base->PIN[1];
-	gpio_mux_registers_context.MPIN[0] = config->gpio_base->MPIN[0];
-	gpio_mux_registers_context.MPIN[1] = config->gpio_base->MPIN[1];
-	gpio_mux_registers_context.SET[0] = config->gpio_base->SET[0];
-	gpio_mux_registers_context.SET[1] = config->gpio_base->SET[1];
-	gpio_mux_registers_context.CLR[0] = config->gpio_base->CLR[0];
-	gpio_mux_registers_context.CLR[1] = config->gpio_base->CLR[1];
-	gpio_mux_registers_context.NOT[0] = config->gpio_base->NOT[0];
-	gpio_mux_registers_context.NOT[1] = config->gpio_base->NOT[1];
-	gpio_mux_registers_context.DIRSET[0] = config->gpio_base->DIRSET[0];
-	gpio_mux_registers_context.DIRSET[1] = config->gpio_base->DIRSET[1];
-	gpio_mux_registers_context.DIRCLR[0] = config->gpio_base->DIRCLR[0];
-	gpio_mux_registers_context.DIRCLR[1] = config->gpio_base->DIRCLR[1];
-	gpio_mux_registers_context.DIRNOT[0] = config->gpio_base->DIRNOT[0];
-	gpio_mux_registers_context.DIRNOT[1] = config->gpio_base->DIRNOT[1];
-	gpio_mux_registers_context.INTENA[0] = config->gpio_base->INTENA[0];
-	gpio_mux_registers_context.INTENA[1] = config->gpio_base->INTENA[1];
-	gpio_mux_registers_context.INTENB[0] = config->gpio_base->INTENB[0];
-	gpio_mux_registers_context.INTENB[1] = config->gpio_base->INTENB[1];
-	gpio_mux_registers_context.INTPOL[0] = config->gpio_base->INTPOL[0];
-	gpio_mux_registers_context.INTPOL[1] = config->gpio_base->INTPOL[1];
-	gpio_mux_registers_context.INTEDG[0] = config->gpio_base->INTEDG[0];
-	gpio_mux_registers_context.INTEDG[1] = config->gpio_base->INTEDG[1];
-	gpio_mux_registers_context.INTSTATA[0] = config->gpio_base->INTSTATA[0];
-	gpio_mux_registers_context.INTSTATA[1] = config->gpio_base->INTSTATA[1];
-	gpio_mux_registers_context.INTSTATB[0] = config->gpio_base->INTSTATB[0];
-	gpio_mux_registers_context.INTSTATB[1] = config->gpio_base->INTSTATB[1];
-
-	/*IO MUX Registers*/
-	gpio_mux_registers_context.GPIO_GRP0 = config->pinmux_base->GPIO_GRP0;
-	gpio_mux_registers_context.GPIO_GRP1 = config->pinmux_base->GPIO_GRP1;
-}
-
-
-static void gpio_mcux_lpc_context_restore(const struct device *dev)
-{
-	const struct gpio_mcux_lpc_config *config = dev->config;
-	uint8_t *u8_src_ptr;
-	uint8_t *u8_dst_ptr;
-	uint16_t index;
-
-	/*GPIO Registers*/
-	u8_src_ptr = (uint8_t*)&gpio_mux_registers_context.B[0][0];
-	u8_dst_ptr = (uint8_t*)config->gpio_base->B;
-	for(index=0; index<sizeof(gpio_mux_registers_context.B); index++){
-		u8_dst_ptr[index] = u8_src_ptr[index];
-	}
-
-	u8_src_ptr = (uint8_t*)&gpio_mux_registers_context.W[0][0];
-	u8_dst_ptr = (uint8_t*)config->gpio_base->W;
-	for(index=0; index<(sizeof(gpio_mux_registers_context.W)/4); index++){
-		u8_dst_ptr[index] = u8_src_ptr[index];
-	}
-
-	config->gpio_base->DIR[0] = gpio_mux_registers_context.DIR[0];
-	config->gpio_base->DIR[1] = gpio_mux_registers_context.DIR[1];
-	config->gpio_base->MASK[0] = gpio_mux_registers_context.MASK[0];
-	config->gpio_base->MASK[1] = gpio_mux_registers_context.MASK[1];
-	config->gpio_base->PIN[0] = gpio_mux_registers_context.PIN[0];
-	config->gpio_base->PIN[1] = gpio_mux_registers_context.PIN[1];
-	config->gpio_base->MPIN[0] = gpio_mux_registers_context.MPIN[0];
-	config->gpio_base->MPIN[1] = gpio_mux_registers_context.MPIN[1];
-	config->gpio_base->SET[0] = gpio_mux_registers_context.SET[0];
-	config->gpio_base->SET[1] = gpio_mux_registers_context.SET[1];
-	config->gpio_base->CLR[0] = gpio_mux_registers_context.CLR[0];
-	config->gpio_base->CLR[1] = gpio_mux_registers_context.CLR[1];
-	config->gpio_base->NOT[0] = gpio_mux_registers_context.NOT[0];
-	config->gpio_base->NOT[1] = gpio_mux_registers_context.NOT[1];
-	config->gpio_base->DIRSET[0] = gpio_mux_registers_context.DIRSET[0]; 
-	config->gpio_base->DIRSET[1] = gpio_mux_registers_context.DIRSET[1]; 
-	config->gpio_base->DIRCLR[0] = gpio_mux_registers_context.DIRCLR[0]; 
-	config->gpio_base->DIRCLR[1] = gpio_mux_registers_context.DIRCLR[1]; 
-	config->gpio_base->DIRNOT[0] = gpio_mux_registers_context.DIRNOT[0]; 
-	config->gpio_base->DIRNOT[1] = gpio_mux_registers_context.DIRNOT[1]; 
-	config->gpio_base->INTENA[0] = gpio_mux_registers_context.INTENA[0]; 
-	config->gpio_base->INTENA[1] = gpio_mux_registers_context.INTENA[1]; 
-	config->gpio_base->INTENB[0] = gpio_mux_registers_context.INTENB[0]; 
-	config->gpio_base->INTENB[1] = gpio_mux_registers_context.INTENB[1]; 
-	config->gpio_base->INTPOL[0] = gpio_mux_registers_context.INTPOL[0]; 
-	config->gpio_base->INTPOL[1] = gpio_mux_registers_context.INTPOL[1]; 
-	config->gpio_base->INTEDG[0] = gpio_mux_registers_context.INTEDG[0]; 
-	config->gpio_base->INTEDG[1] = gpio_mux_registers_context.INTEDG[1]; 
-	config->gpio_base->INTSTATA[0] = gpio_mux_registers_context.INTSTATA[0]; 
-	config->gpio_base->INTSTATA[1] = gpio_mux_registers_context.INTSTATA[1]; 
-	config->gpio_base->INTSTATB[0] = gpio_mux_registers_context.INTSTATB[0]; 
-	config->gpio_base->INTSTATB[1] = gpio_mux_registers_context.INTSTATB[1]; 
-
-	/*IO MUX Registers*/
-	config->pinmux_base->GPIO_GRP0 = gpio_mux_registers_context.GPIO_GRP0;
-	config->pinmux_base->GPIO_GRP1 = gpio_mux_registers_context.GPIO_GRP1;
-}
-
-
-static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
-{
-	switch (action) {
-	case PM_DEVICE_ACTION_RESUME:
-		break;
-	case PM_DEVICE_ACTION_SUSPEND:
-		break;
-	case PM_DEVICE_ACTION_TURN_OFF:
-		gpio_mcux_lpc_context_save(dev);
-		break;
-	case PM_DEVICE_ACTION_TURN_ON:
-		gpio_mcux_lpc_init(dev);
-		gpio_mcux_lpc_context_restore(dev);
-		break;
-	default:
-		return -ENOTSUP;
-	}
-	return 0;
-}
-#endif /*CONFIG_PM_DEVICE*/
-
-static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
-	.pin_configure = gpio_mcux_lpc_configure,
-	.port_get_raw = gpio_mcux_lpc_port_get_raw,
-	.port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
-	.port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,
-	.port_clear_bits_raw = gpio_mcux_lpc_port_clear_bits_raw,
-	.port_toggle_bits = gpio_mcux_lpc_port_toggle_bits,
-	.pin_interrupt_configure = gpio_mcux_lpc_pin_interrupt_configure,
-	.manage_callback = gpio_mcux_lpc_manage_cb,
-};
-
-
-
-#ifdef IOPCTL
-#define PINMUX_BASE	IOPCTL
-#endif
-#ifdef IOCON
-#define PINMUX_BASE	IOCON
-#endif
-#ifdef MCI_IO_MUX
-#define PINMUX_BASE	MCI_IO_MUX
-#endif
-
-#define GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)						\
-	do {										\
-		IRQ_CONNECT(DT_INST_IRQ(inst, irq),					\
-			DT_INST_IRQ(inst, priority),					\
-			gpio_mcux_lpc_module_isr, DEVICE_DT_INST_GET(inst), 0);		\
-		irq_enable(DT_INST_IRQ(inst, irq));					\
-	} while (false)
-
-#define GPIO_MCUX_LPC_MODULE_IRQ(inst)							\
-	IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, 0),					\
-		(GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)))
-
-
-#define GPIO_MCUX_LPC(n)								\
-	static int lpc_gpio_init_##n(const struct device *dev);				\
-											\
-	static const struct gpio_mcux_lpc_config gpio_mcux_lpc_config_##n = {		\
-		.common = {								\
-			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),		\
-		},									\
-		.gpio_base = (GPIO_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
-		.pinmux_base = PINMUX_BASE,						\
-		.int_source = DT_INST_ENUM_IDX(n, int_source),				\
-		.port_no = DT_INST_REG_ADDR(n)						\
-	};										\
-											\
-	static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\
-											\
-	PM_DEVICE_DT_INST_DEFINE(n, gpio_mcux_lpc_pm_action);				\
-											\
-	DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n,					\
-		    PM_DEVICE_DT_INST_GET(n),						\
-		    &gpio_mcux_lpc_data_##n,						\
-		    &gpio_mcux_lpc_config_##n, PRE_KERNEL_1,				\
-		    CONFIG_GPIO_INIT_PRIORITY,						\
-		    &gpio_mcux_lpc_driver_api);						\
-											\
-	static int lpc_gpio_init_##n(const struct device *dev)				\
-	{										\
-		gpio_mcux_lpc_init(dev);						\
-		GPIO_MCUX_LPC_MODULE_IRQ(n);						\
-											\
-		return 0;								\
-	}
-
-DT_INST_FOREACH_STATUS_OKAY(GPIO_MCUX_LPC)
+ static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
+ {
+	 const struct gpio_mcux_lpc_config *config = dev->config;
+ 
+	 switch (action) {
+	 case PM_DEVICE_ACTION_RESUME:
+		 break;
+	 case PM_DEVICE_ACTION_SUSPEND:
+		 break;
+	 case PM_DEVICE_ACTION_TURN_OFF:
+ #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+ defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+ defined(CONFIG_PM_DEVICE))
+         gpio_mcux_lpc_context_save(dev);
+ #endif /*RW610/RW612 MCU*/ 
+		 break;
+	 case PM_DEVICE_ACTION_TURN_ON:
+		 GPIO_PortInit(config->gpio_base, config->port_no);
+ #if ((defined(CPU_RW610ETA2I) || defined(CPU_RW610HNA2I) || defined(CPU_RW610UKA2I) || \
+ defined(CPU_RW612ETA2I) || defined(CPU_RW612HNA2I) || defined(CPU_RW612UKA2I)) && \
+ defined(CONFIG_PM_DEVICE))
+		 gpio_mcux_lpc_context_restore(dev);
+ #endif /*RW610/RW612 MCU*/
+		 break;
+	 default:
+		 return -ENOTSUP;
+	 }
+	 return 0;
+ }
+ 
+ static int gpio_mcux_lpc_init(const struct device *dev)
+ {
+	 /* Rest of the init is done from the PM_DEVICE_TURN_ON action
+	  * which is invoked by pm_device_driver_init().
+	  */
+	 return pm_device_driver_init(dev, gpio_mcux_lpc_pm_action);
+ }
+ 
+ static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
+	 .pin_configure = gpio_mcux_lpc_configure,
+	 .port_get_raw = gpio_mcux_lpc_port_get_raw,
+	 .port_set_masked_raw = gpio_mcux_lpc_port_set_masked_raw,
+	 .port_set_bits_raw = gpio_mcux_lpc_port_set_bits_raw,
+	 .port_clear_bits_raw = gpio_mcux_lpc_port_clear_bits_raw,
+	 .port_toggle_bits = gpio_mcux_lpc_port_toggle_bits,
+	 .pin_interrupt_configure = gpio_mcux_lpc_pin_interrupt_configure,
+	 .manage_callback = gpio_mcux_lpc_manage_cb,
+ };
+ 
+ 
+ 
+ #ifdef IOPCTL
+ #define PINMUX_BASE	IOPCTL
+ #endif
+ #ifdef IOCON
+ #define PINMUX_BASE	IOCON
+ #endif
+ #ifdef MCI_IO_MUX
+ #define PINMUX_BASE	MCI_IO_MUX
+ #endif
+ 
+ #define GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)						\
+	 do {										\
+		 IRQ_CONNECT(DT_INST_IRQ(inst, irq),					\
+			 DT_INST_IRQ(inst, priority),					\
+			 gpio_mcux_lpc_module_isr, DEVICE_DT_INST_GET(inst), 0);		\
+		 irq_enable(DT_INST_IRQ(inst, irq));					\
+	 } while (false)
+ 
+ #define GPIO_MCUX_LPC_MODULE_IRQ(inst)							\
+	 IF_ENABLED(DT_INST_IRQ_HAS_IDX(inst, 0),					\
+		 (GPIO_MCUX_LPC_MODULE_IRQ_CONNECT(inst)))
+ 
+ 
+ #define GPIO_MCUX_LPC(n)								\
+	 static int lpc_gpio_init_##n(const struct device *dev);				\
+											 \
+	 static const struct gpio_mcux_lpc_config gpio_mcux_lpc_config_##n = {		\
+		 .common = {								\
+			 .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),		\
+		 },									\
+		 .gpio_base = (GPIO_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
+		 .pinmux_base = PINMUX_BASE,						\
+		 .int_source = DT_INST_ENUM_IDX(n, int_source),				\
+		 .port_no = DT_INST_REG_ADDR(n)						\
+	 };										\
+											 \
+	 static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\
+											 \
+	 PM_DEVICE_DT_INST_DEFINE(n, gpio_mcux_lpc_pm_action);				\
+											 \
+	 DEVICE_DT_INST_DEFINE(n, lpc_gpio_init_##n,					\
+			 PM_DEVICE_DT_INST_GET(n),						\
+			 &gpio_mcux_lpc_data_##n,						\
+			 &gpio_mcux_lpc_config_##n, PRE_KERNEL_1,				\
+			 CONFIG_GPIO_INIT_PRIORITY,						\
+			 &gpio_mcux_lpc_driver_api);						\
+											 \
+	 static int lpc_gpio_init_##n(const struct device *dev)				\
+	 {										\
+		 gpio_mcux_lpc_init(dev);						\
+		 GPIO_MCUX_LPC_MODULE_IRQ(n);						\
+											 \
+		 return 0;								\
+	 }
+ 
+ DT_INST_FOREACH_STATUS_OKAY(GPIO_MCUX_LPC)


### PR DESCRIPTION
**THIS IS A PRELIMINARY SOLUTION TO HELP CONTINUE THE DRIVER'S SUPPORT FOR POWER MANAGEMENT ON RW61x DEVICES**
On RW61x devices, when entering in PM3, all peripheral lose their state/context. After exiting from this power mode, that context needs to be restored. This PR saves the GPIOs registers before entering to PM3 and restores the registers after exiting PM3, this helps the application recover all GPIOs configurations when returning from this power mode. 