### PR TITLE
tests: mgmt: mcumgr: img_mgmt_slot_info: Fix overlay

### DIFF
--- a/tests/subsys/mgmt/mcumgr/img_mgmt_slot_info/boards/nrf5340dk_nrf5340_cpuapp_dual_slot.overlay
+++ b/tests/subsys/mgmt/mcumgr/img_mgmt_slot_info/boards/nrf5340dk_nrf5340_cpuapp_dual_slot.overlay
@@ -5,10 +5,10 @@
  */
 
 /delete-node/ &boot_partition;
-/delete-node/ &slot0_partition;
-/delete-node/ &slot1_partition;
 /delete-node/ &slot0_ns_partition;
 /delete-node/ &slot1_ns_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
 
 &flash0 {
 	partitions {


### PR DESCRIPTION
Fixes the order of the overlay which now throws an error