### PR TITLE
drivers: sensors: improve range check in `sensor_value_from_float/double`

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1345,18 +1345,15 @@ static inline float sensor_value_to_float(const struct sensor_value *val)
  */
 static inline int sensor_value_from_double(struct sensor_value *val, double inp)
 {
-	if (inp < INT32_MIN || inp > INT32_MAX) {
+	if (inp < (double)INT32_MIN || inp > (double)INT32_MAX) {
 		return -ERANGE;
 	}
 
-	double val2 = (inp - (int32_t)inp) * 1000000.0;
+	int32_t val1 = (int32_t)inp;
+	int32_t val2 = (int32_t)((inp - (double)val1) * 1000000.0);
 
-	if (val2 < INT32_MIN || val2 > INT32_MAX) {
-		return -ERANGE;
-	}
-
-	val->val1 = (int32_t)inp;
-	val->val2 = (int32_t)val2;
+	val->val1 = val1;
+	val->val2 = val2;
 
 	return 0;
 }
@@ -1370,14 +1367,15 @@ static inline int sensor_value_from_double(struct sensor_value *val, double inp)
  */
 static inline int sensor_value_from_float(struct sensor_value *val, float inp)
 {
-	float val2 = (inp - (int32_t)inp) * 1000000.0f;
-
-	if (val2 < INT32_MIN || val2 > (float)(INT32_MAX - 1)) {
+	if (inp < (float)INT32_MIN || inp >= (float)INT32_MAX) {
 		return -ERANGE;
 	}
 
-	val->val1 = (int32_t)inp;
-	val->val2 = (int32_t)val2;
+	int32_t val1 = (int32_t)inp;
+	int32_t val2 = (int32_t)((inp - (float)val1) * 1000000.0f);
+
+	val->val1 = val1;
+	val->val2 = val2;
 
 	return 0;
 }

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -325,6 +325,38 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 			"the data does not match");
 	zassert_equal(data.val2, SENSOR_PI%(data.val1 * 1000000LL),
 			"the data does not match");
+
+	/* Extensive tests for edge cases */
+	int ret;
+
+	sensor_value_from_double(&data, -2147483648.0);
+	zassert_equal(data.val1, -2147483648, "the data does not match");
+	zassert_equal(data.val2, 0, "the data does not match");
+
+	ret = sensor_value_from_double(&data, -2147483649.0);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
+	sensor_value_from_double(&data, 2147483647.0);
+	zassert_equal(data.val1, 2147483647, "the data does not match");
+	zassert_equal(data.val2, 0, "the data does not match");
+
+	ret = sensor_value_from_double(&data, 2147483648.0);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
+	sensor_value_from_float(&data, -2147483648.0f);
+	zassert_equal(data.val1, -2147483648, "the data does not match");
+	zassert_equal(data.val2, 0, "the data does not match");
+
+	ret = sensor_value_from_float(&data, -2147483904.0f);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
+	sensor_value_from_float(&data, 2147483520.0f);
+	zassert_equal(data.val1, 2147483520, "the data does not match");
+	zassert_equal(data.val2, 0, "the data does not match");
+
+	ret = sensor_value_from_float(&data, 2147483584.0f);
+	zassert_equal(ret, -ERANGE, "range error expected");
+
 #endif
 	/* reset test data to positive value */
 	data.val1 = 3;


### PR DESCRIPTION
Avoid undefined behavior caused by casting floating-point values outside the int32_t range. The updated implementation explicitly validates input bounds before performing conversions, ensuring consistent behavior across platforms.

Added test cases to cover edge conditions near float rounding limits and INT32 range boundaries.
