### PR TITLE
nRF 5340 spec compliance issues

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -57,6 +57,7 @@
 		};
 
 		peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x50000000 0x10000000>;

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -40,6 +40,7 @@
 		};
 
 		peripheral@40000000 {
+			reg = <0x40000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x40000000 0x10000000>;


### PR DESCRIPTION
dts: arm: nordic: nrf5340: cpuapp: peripheral: add missing reg
 
Add missing reg property to nrf5340_cpuapp.dts peripheral
node.