### PR TITLE
boards: st: nucleo_u083rc: improve pyocd flashing

### DIFF
--- a/boards/st/nucleo_u083rc/board.cmake
+++ b/boards/st/nucleo_u083rc/board.cmake
@@ -2,6 +2,8 @@
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 board_runner_args(pyocd "--target=stm32u083rctx")
+board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
+board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
 board_runner_args(jlink "--device=STM32U083RC" "--reset-after-load")
 


### PR DESCRIPTION
`pyocd` fails the second time the MCU is flashed.

Add `pyocd` flags identical to other nucleo boards to fix the issue.