### PR TITLE
mgmt: mcumgr: grp: os_mgmt: Support reboot without multithreading

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -25,7 +25,7 @@ if REBOOT
 config MCUMGR_GRP_OS_RESET_MS
 	int "Delay before executing reset command (ms)"
 	default 250
-	depends on REBOOT
+	depends on MULTITHREADING
 	help
 	  When a reset command is received, the system waits this many milliseconds
 	  before performing the reset.  This delay allows time for the MCUmgr
@@ -33,7 +33,6 @@ config MCUMGR_GRP_OS_RESET_MS
 
 config MCUMGR_GRP_OS_RESET_HOOK
 	bool "Reset hook"
-	depends on REBOOT
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS
 	help
 	  Allows applications to control and get notifications of when a reset

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -70,15 +70,15 @@ choice MCUMGR_GRP_OS_TASKSTAT_THREAD_NAME_CHOICE
 	  Select what will serve as thread name in "taskstat" response.
 	  By default taskstat responses use thread priority, when THREAD_NAME is disabled,
 
-	config MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_NAME_FOR_NAME
-		bool "Thread name"
-		depends on THREAD_NAME
+config MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_NAME_FOR_NAME
+	bool "Thread name"
+	depends on THREAD_NAME
 
-	config MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_IDX_FOR_NAME
-		bool "Thread index"
+config MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_IDX_FOR_NAME
+	bool "Thread index"
 
-	config MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_PRIO_FOR_NAME
-		bool "Thread priority"
+config MCUMGR_GRP_OS_TASKSTAT_USE_THREAD_PRIO_FOR_NAME
+	bool "Thread priority"
 
 endchoice
 

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -57,7 +57,7 @@
 
 LOG_MODULE_REGISTER(mcumgr_os_grp, CONFIG_MCUMGR_GRP_OS_LOG_LEVEL);
 
-#ifdef CONFIG_REBOOT
+#if defined(CONFIG_REBOOT) && defined(CONFIG_MULTITHREADING)
 static void os_mgmt_reset_work_handler(struct k_work *work);
 
 K_WORK_DELAYABLE_DEFINE(os_mgmt_reset_work, os_mgmt_reset_work_handler);
@@ -354,12 +354,14 @@ static int os_mgmt_taskstat_read(struct smp_streamer *ctxt)
 /**
  * Command handler: os reset
  */
+#ifdef CONFIG_MULTITHREADING
 static void os_mgmt_reset_work_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
 
 	sys_reboot(SYS_REBOOT_WARM);
 }
+#endif
 
 static int os_mgmt_reset(struct smp_streamer *ctxt)
 {
@@ -398,8 +400,12 @@ static int os_mgmt_reset(struct smp_streamer *ctxt)
 	}
 #endif
 
+#ifdef CONFIG_MULTITHREADING
 	/* Reboot the system from the system workqueue thread. */
 	k_work_schedule(&os_mgmt_reset_work, K_MSEC(CONFIG_MCUMGR_GRP_OS_RESET_MS));
+#else
+	sys_reboot(SYS_REBOOT_WARM);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
    Adds support for the OS mgmt reboot command when multithreading
    is disabled


    Fixes some elements that were indented twice
