### PR TITLE
cmake: emu: armfvp: fix run command for ns variant

### DIFF
--- a/cmake/emu/armfvp.cmake
+++ b/cmake/emu/armfvp.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Arm Limited (or its affiliates). All rights reserved.
+# Copyright (c) 2021-2022, 2025 Arm Limited (or its affiliates). All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 find_program(
@@ -53,7 +53,7 @@ elseif(CONFIG_ARMV8_A_NS)
     --data cluster0.cpu0="${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}"@0x88000000
     )
 else()
-  string(FIND "${ARMFVP_FLAGS}" " -a " ARMFVP_APPARG_POS)
+  string(FIND "${ARMFVP_FLAGS}" "-a;" ARMFVP_APPARG_POS)
   if(${ARMFVP_APPARG_POS} EQUAL -1)
     set(ARMFVP_FLAGS ${ARMFVP_FLAGS}
       -a ${APPLICATION_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME}


### PR DESCRIPTION
Support to run non secure variants with ARMFVP was enabled with [a7122cf5](https://gitlab.geo.arm.com/software/iot-m-sw/zephyrproject-rtos/zephyr/-/commit/a7122cf51f39c72d9210c8a6f5fa54825244ee78) and [fa45bebc](https://gitlab.geo.arm.com/software/iot-m-sw/zephyrproject-rtos/zephyr/-/commit/fa45bebccfb1fa4ce25627518b0000cd80057555) however, the pattern search doesn't work as expected.
This commit fixes that.