### PR TITLE
mgmt: hawkbit: change hawkbit interface to support directly supplying server ip address

### DIFF
--- a/include/zephyr/mgmt/hawkbit/config.h
+++ b/include/zephyr/mgmt/hawkbit/config.h
@@ -29,8 +29,13 @@
  * settings.
  */
 struct hawkbit_runtime_config {
-	/** Server address */
+	/**
+	 * Server address (domain name or IP address if
+	 * CONFIG_HAWKBIT_USE_DOMAIN_NAME is enabled)
+	 */
 	char *server_addr;
+	/** Server domain name */
+	char *server_domain;
 	/** Server port */
 	uint16_t server_port;
 	/** Security token */
@@ -57,6 +62,27 @@ int hawkbit_set_config(struct hawkbit_runtime_config *config);
 struct hawkbit_runtime_config hawkbit_get_config(void);
 
 /**
+ * @brief Set the hawkBit server hostname.
+ *
+ * @param domain_str Server hostname to set.
+ * @retval 0 on success.
+ * @retval -EINVAL if string length mismatch for server_domain
+ * @retval -EAGAIN if probe is currently running.
+ */
+static inline int hawkbit_set_server_domain(char *domain_str)
+{
+	struct hawkbit_runtime_config set_config = {
+		.server_addr = NULL,
+		.server_domain = domain_str,
+		.server_port = 0,
+		.auth_token = NULL,
+		.tls_tag = 0,
+	};
+
+	return hawkbit_set_config(&set_config);
+}
+
+/**
  * @brief Set the hawkBit server address.
  *
  * @param addr_str Server address to set.
@@ -68,6 +94,7 @@ static inline int hawkbit_set_server_addr(char *addr_str)
 {
 	struct hawkbit_runtime_config set_config = {
 		.server_addr = addr_str,
+		.server_domain = NULL,
 		.server_port = 0,
 		.auth_token = NULL,
 		.tls_tag = 0,
@@ -87,6 +114,7 @@ static inline int hawkbit_set_server_port(uint16_t port)
 {
 	struct hawkbit_runtime_config set_config = {
 		.server_addr = NULL,
+		.server_domain = NULL,
 		.server_port = port,
 		.auth_token = NULL,
 		.tls_tag = 0,
@@ -106,6 +134,7 @@ static inline int hawkbit_set_ddi_security_token(char *token)
 {
 	struct hawkbit_runtime_config set_config = {
 		.server_addr = NULL,
+		.server_domain = NULL,
 		.server_port = 0,
 		.auth_token = token,
 		.tls_tag = 0,
@@ -125,6 +154,7 @@ static inline int hawkbit_set_tls_tag(sec_tag_t tag)
 {
 	struct hawkbit_runtime_config set_config = {
 		.server_addr = NULL,
+		.server_domain = NULL,
 		.server_port = 0,
 		.auth_token = NULL,
 		.tls_tag = tag,
@@ -141,6 +171,16 @@ static inline int hawkbit_set_tls_tag(sec_tag_t tag)
 static inline char *hawkbit_get_server_addr(void)
 {
 	return hawkbit_get_config().server_addr;
+}
+
+/**
+ * @brief Get the hawkBit server hostname.
+ *
+ * @return Server hostname.
+ */
+static inline char *hawkbit_get_server_domain(void)
+{
+	return hawkbit_get_config().server_domain;
 }
 
 /**

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -70,6 +70,22 @@ config HAWKBIT_SET_SETTINGS_RUNTIME
 	help
 	  Enable to set hawkbit settings at runtime.
 
+config HAWKBIT_USE_DOMAIN_NAME
+	bool "Use server_domain for domain name instead of server_addr"
+	depends on HAWKBIT_SET_SETTINGS_RUNTIME
+	help
+	  Enable to use the server_domain field for TLS and HTTP. If enabled,
+	  server_addr can accept an already resolved IP address, and the domain name
+	  can be provided via server_domain.
+
+config HAWKBIT_DOMAIN_NAME_MAX_LEN
+	int "The buffer size for storing the domain name string"
+	default DNS_RESOLVER_MAX_QUERY_LEN if DNS_RESOLVER
+	default 255
+	depends on HAWKBIT_USE_DOMAIN_NAME
+	help
+	  The size for the internal buffer used to hold the domain name string.
+
 choice HAWKBIT_DDI_SECURITY
 	prompt "hawkBit DDI API authentication modes"
 	default HAWKBIT_DDI_NO_SECURITY


### PR DESCRIPTION
The hawkbit subsystem assumes that `getaddrinfo` will supply a valid, usable IP address. This isn't the case when using a network layer that depends on NAT64 for IPv4 traffic, like OpenThread. A DNS address obtained while behind a NAT64 requires conversion to IPv6 and adding the NAT64 prefix. As of now, `getaddrinfo` is not aware of NAT64 and does not handle this. In this case it can be better for the application itself to handle DNS resolution and provide properly prefixed IP addresses to the hawkbit subsystem.

This pull request adds an additional interface field (`server_hostname`) for the server hostname and changes `server_addr` to optionally point to an IP address. This is a potentially less confusing naming scheme, as hawkbit _does not_ currently work if an address is provided to `server_addr` instead of a hostname.

This commit also increases the default DNS name length slightly to accommodate larger hostnames longer than 20 bytes, i.e. (hawkbit.yourcompany.com). I also added some error handling in case a hostname is too long, so the hawkbit interface returns an error instead of quietly using a truncated and incorrect hostname.

This commit also changes how the `controllerId` is generated based on device id, and disentangles the two. The `controllerId` is what hawkbit uses to uniquely identify a device, and is not necessarily the same as the device id, and should be fully customizable by the user if needed. Previously, all custom device ids were being prepended with `CONFIG_BOARD`. When a user selects `CONFIG_HAWKBIT_CUSTOM_DEVICE_ID`,  they should be able to specify the full `controllerId` used with hawkbit.