### PR TITLE
doc: boards: shields: nxp_m2_wifi_bt: add blobs command

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/doc/index.rst
+++ b/boards/shields/nxp_m2_wifi_bt/doc/index.rst
@@ -38,6 +38,16 @@ This shield works with below host platform,
 
 - :zephyr:board:`mimxrt1060_evk` Rev-C.
 
+Fetch Binary Blobs
+******************
+
+To support Bluetooth or Wi-Fi, nxp_m2_wifi_bt requires fetching binary blobs,
+using the following command:
+
+.. code-block:: console
+
+   west blobs fetch hal_nxp
+
 Programming
 ***********
 


### PR DESCRIPTION
Add command to fetch the firmware blobs from hal_nxp.