### PR TITLE
spi: nrfx_spim: fix incorrect clock behaviour with PM

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -161,7 +161,7 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 		nrfy_spim_disable(reg);
 	}
 
-	if (!IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+	if (!pm_device_runtime_is_enabled(dev)) {
 		release_clock(dev);
 	}
 
@@ -550,7 +550,7 @@ static int transceive(const struct device *dev,
 
 	error = configure(dev, spi_cfg);
 
-	if (error == 0 && !IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+	if (error == 0 && !pm_device_runtime_is_enabled(dev)) {
 		error = request_clock(dev);
 	}
 
@@ -686,7 +686,7 @@ static int spim_resume(const struct device *dev)
 	nrf_gpd_retain_pins_set(dev_config->pcfg, false);
 #endif
 
-	return IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) ? request_clock(dev) : 0;
+	return pm_device_runtime_is_enabled(dev) ? request_clock(dev) : 0;
 }
 
 static void spim_suspend(const struct device *dev)
@@ -699,7 +699,7 @@ static void spim_suspend(const struct device *dev)
 		dev_data->initialized = false;
 	}
 
-	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+	if (pm_device_runtime_is_enabled(dev)) {
 		release_clock(dev);
 	}
 


### PR DESCRIPTION
Fixes incorrect usage of `IF_ENABLED(CONFIG_PM_DEVICE_RUNTIME)` for clock control. 