### PR TITLE
Bluetooth: Controller: Be more explicit with thread names

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -1025,14 +1025,14 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv)
 			K_KERNEL_STACK_SIZEOF(prio_recv_thread_stack),
 			prio_recv_thread, (void *)dev, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, K_NO_WAIT);
-	k_thread_name_set(&prio_recv_thread_data, "BT RX pri");
+	k_thread_name_set(&prio_recv_thread_data, "BT CTLR RX pri");
 #endif /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 
 	k_thread_create(&recv_thread_data, recv_thread_stack,
 			K_KERNEL_STACK_SIZEOF(recv_thread_stack),
 			recv_thread, (void *)dev, NULL, NULL,
 			K_PRIO_COOP(CONFIG_BT_RX_PRIO), 0, K_NO_WAIT);
-	k_thread_name_set(&recv_thread_data, "BT RX");
+	k_thread_name_set(&recv_thread_data, "BT CTLR RX");
 
 	LOG_DBG("Success.");
 


### PR DESCRIPTION
The "BT RX pri" and "BT RX" are too easily confused with host-side threads, e.g. the host RX thread is called "BT RX WQ". Add "CTLR" to the Controller side thread names to make it clear that they're managed by the controller.