### PR TITLE
NXP drivers: pwm mcux sctimer: adds PM low power support

### DIFF
--- a/drivers/pwm/Kconfig.mcux_sctimer
+++ b/drivers/pwm/Kconfig.mcux_sctimer
@@ -1,4 +1,4 @@
-# Copyright 2021 NXP
+# Copyright 2021, 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 config PWM_MCUX_SCTIMER
@@ -9,3 +9,12 @@ config PWM_MCUX_SCTIMER
 	select PINCTRL
 	help
 	  Enable sctimer based pwm driver.
+
+config PWM_MCUX_SCT_KEEP_STATE
+	bool "Retain output level after PWM is disabled"
+	default y
+	help
+	  When enabled, the PWM driver will hold the inactive output level and
+	  retain the power management lock even after the PWM signal is
+	  stopped (pulse = 0). This prevents the pin from floating or losing state
+	  in low power modes where the peripheral or pad may be disabled.

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -430,6 +430,7 @@
 		status = "disabled";
 		prescaler = <8>;
 		#pwm-cells = <3>;
+		zephyr,disabling-power-states = <&suspend &standby>;
 		power-domains = <&power_mode3_domain>;
 	};
 

--- a/tests/drivers/pwm/pwm_api/boards/frdm_rw612.conf
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_rw612.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier Apache-2.0
+#
+CONFIG_PM=y
+CONFIG_PWM_MCUX_SCT_KEEP_STATE=n

--- a/tests/drivers/pwm/pwm_api/boards/frdm_rw612.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/frdm_rw612.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Enable standby low power mode */
+&standby {
+	status = "okay";
+};


### PR DESCRIPTION
Enables Sleep mode (PM3) in RW61x.

Tested tests/drivers/pwm/pwm_api on FRDM-RW612. Verified that RW612 goes into standby mode once all channels are inactive (pulse = 0).