### PR TITLE
cmake: Handle MPU_ALIGN in CONFIG_CMAKE_LINKER_GENERATOR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1460,11 +1460,37 @@ macro(setup_linker_pass)
     "PASS_DEFINES;DEPENDENCIES;SOURCES;LIBRARIES_PRE_SCRIPT;LIBRARIES_POST_SCRIPT"
     ${ARGN}
   )
+
+  # To make the same expression syntax work for all linkers we need some
+  # extra machinery. We could have had a way of just translating the syntax,
+  # but it shows that not all linkers can express everything we need, and also
+  # that the may not allow e.g. alignment of a section depend on the
+  # section itself.
+  # So, lets use ld syntax for expressions, but evaluate them on the side,
+  # in a script (gen_linker_evaluation.py). So in linker pass we collect
+  # expressions that need external evaluation in a json file, and before the
+  # next pass evaluate the expressions and add the results as
+  # zephyr_linker_include_generated() input.
+  #
+  # The concept of "the previously built pass" is somewhat elusive:
+  # linker_pass_define          ${ZEPHYR_CURRENT_LINKER_PASS} ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+  # LINKER_APP_SMEM_UNALIGNED   0                             zephyr_pre0
+  # LINKER_ZEPHYR_PREBUILT      1                             zephyr_pre1
+  # LINKER_ZEPHYR_FINAL         1                             zephyr_pre1
+  # To avoid fixing this, keep track of the previous linker_pass_define and
+  # use that to pickup the previous pass name (if any).
+  get_property(sls_EVALUATE_INPUT GLOBAL PROPERTY LINKER_EVALUATE_PREVIOUS_FILE)
+  if(sls_EVALUATE_INPUT AND CONFIG_CMAKE_LINKER_GENERATOR)
+    # Add the output from expression evaluations from the previous pass
+    zephyr_linker_include_generated(CMAKE ${sls_EVALUATE_INPUT} PASS ${arg_sls_PASS_DEFINES})
+  endif()
+
   # Setup generation of the linker script
   configure_linker_script(
     ${arg_sls_CMD_FILE}
     "${arg_sls_PASS_DEFINES}"
     ${arg_sls_DEPENDENCIES}
+    ${sls_EVALUATE_INPUT}
     zephyr_generated_headers
   )
   add_custom_target(
@@ -1488,7 +1514,27 @@ macro(setup_linker_pass)
     LIBRARIES_POST_SCRIPT ${arg_sls_LIBRARIES_POST_SCRIPT}
     DEPENDENCIES          ${CODE_RELOCATION_DEP}
   )
-  set_property(TARGET   ${arg_sls_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/${arg_sls_CMD_FILE})
+  set_property(TARGET   ${arg_sls_EXECUTABLE} APPEND PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/${arg_sls_CMD_FILE} ${sls_EVALUATE_INPUT})
+
+  if(CONFIG_CMAKE_LINKER_GENERATOR)
+    # After linking the executable we can generate the linker evaluate file for
+    # the next pass.
+    set (sls_EVALUATE_FILE ${PROJECT_BINARY_DIR}/include/generated/z_linker_evaluated_${arg_sls_PASS_DEFINES}.cmake)
+    set_property(GLOBAL PROPERTY LINKER_EVALUATE_PREVIOUS_FILE ${sls_EVALUATE_FILE})
+    add_custom_command(
+      COMMENT "Generate ${sls_EVALUATE_FILE}"
+      OUTPUT ${sls_EVALUATE_FILE}
+      DEPENDS ${arg_sls_EXECUTABLE}
+      COMMAND
+      ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/build/gen_z_evaluated.py
+      --elf $<TARGET_FILE:${arg_sls_EXECUTABLE}>
+      --input ${PROJECT_BINARY_DIR}/z_linker_evaluate_${arg_sls_PASS_DEFINES}.json
+      --output ${sls_EVALUATE_FILE}
+      $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+  endif()
 endmacro()
 
 if(CONFIG_USERSPACE OR CONFIG_DEVICE_DEPS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1442,38 +1442,71 @@ if(CONFIG_USERSPACE)
   endforeach()
 endif()
 
-if(CONFIG_USERSPACE OR CONFIG_DEVICE_DEPS)
+# setup linking targets for a new linker pass.
+# This sets up generation of linker scripts, adds a new executable and
+# defines how it is linked.
+# EXECUTABLE - the executable name
+# CMD_FILE - file name of the linker-script
+# PASS_DEFINES - list of -Defines for the pass
+# DEPENDENCIES - list of extra dependencies
+# SCRIPT_TARGET - name of the linker script custom target
+# LIBRARIES_PRE_SCRIPT
+# LIBRARIES_POST_SCRIPT - passed on to target_ld_link_elf
+#
+macro(setup_linker_pass)
+  cmake_parse_arguments(
+    arg_sls ""
+    "EXECUTABLE;CMD_FILE;SCRIPT_TARGET"
+    "PASS_DEFINES;DEPENDENCIES;SOURCES;LIBRARIES_PRE_SCRIPT;LIBRARIES_POST_SCRIPT"
+    ${ARGN}
+  )
+  # Setup generation of the linker script
   configure_linker_script(
-    ${ZEPHYR_CURRENT_LINKER_CMD}
-    "${LINKER_PASS_${ZEPHYR_CURRENT_LINKER_PASS}_DEFINE}"
-    ${CODE_RELOCATION_DEP}
-    ${APP_SMEM_UNALIGNED_DEP}
-    ${APP_SMEM_UNALIGNED_LD}
-    ${APP_SMEM_PINNED_UNALIGNED_LD}
+    ${arg_sls_CMD_FILE}
+    "${arg_sls_PASS_DEFINES}"
+    ${arg_sls_DEPENDENCIES}
     zephyr_generated_headers
-    )
-
+  )
   add_custom_target(
-    linker_zephyr_pre${ZEPHYR_CURRENT_LINKER_PASS}_script
+    ${arg_sls_SCRIPT_TARGET}
     DEPENDS
-    ${ZEPHYR_CURRENT_LINKER_CMD}
-    )
-
+    ${arg_sls_CMD_FILE}
+  )
   set_property(TARGET
-    linker_zephyr_pre${ZEPHYR_CURRENT_LINKER_PASS}_script
+    ${arg_sls_SCRIPT_TARGET}
     PROPERTY INCLUDE_DIRECTORIES
     ${ZEPHYR_INCLUDE_DIRS}
-    )
-
-  add_executable(${ZEPHYR_LINK_STAGE_EXECUTABLE} misc/empty_file.c)
+  )
+  # Setup linking of the executable
+  # FIXME: Is there any way to get rid of empty_file.c?
+  add_executable(${arg_sls_EXECUTABLE} misc/empty_file.c ${arg_sls_SOURCES})
   toolchain_ld_link_elf(
-    TARGET_ELF            ${ZEPHYR_LINK_STAGE_EXECUTABLE}
-    OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${ZEPHYR_LINK_STAGE_EXECUTABLE}.map
-    LIBRARIES_PRE_SCRIPT  ""
-    LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/${ZEPHYR_CURRENT_LINKER_CMD}
-    LIBRARIES_POST_SCRIPT ""
+    TARGET_ELF            ${arg_sls_EXECUTABLE}
+    OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${arg_sls_EXECUTABLE}.map
+    LIBRARIES_PRE_SCRIPT  ${arg_sls_LIBRARIES_PRE_SCRIPT}
+    LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/${arg_sls_CMD_FILE}
+    LIBRARIES_POST_SCRIPT ${arg_sls_LIBRARIES_POST_SCRIPT}
     DEPENDENCIES          ${CODE_RELOCATION_DEP}
   )
+  set_property(TARGET   ${arg_sls_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/${arg_sls_CMD_FILE})
+endmacro()
+
+if(CONFIG_USERSPACE OR CONFIG_DEVICE_DEPS)
+
+  setup_linker_pass(
+    EXECUTABLE ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+    CMD_FILE ${ZEPHYR_CURRENT_LINKER_CMD}
+    PASS_DEFINES ${LINKER_PASS_${ZEPHYR_CURRENT_LINKER_PASS}_DEFINE}
+    SCRIPT_TARGET linker_zephyr_pre${ZEPHYR_CURRENT_LINKER_PASS}_script
+    DEPENDENCIES ${CODE_RELOCATION_DEP}
+      ${APP_SMEM_UNALIGNED_DEP}
+      ${APP_SMEM_UNALIGNED_LD}
+      ${APP_SMEM_PINNED_UNALIGNED_LD}
+      zephyr_generated_headers
+    LIBRARIES_PRE_SCRIPT  ""
+    LIBRARIES_POST_SCRIPT ""
+  )
+
   target_link_libraries_ifdef(CONFIG_NATIVE_LIBRARY ${ZEPHYR_LINK_STAGE_EXECUTABLE}
                               $<TARGET_PROPERTY:linker,no_position_independent>)
   target_byproducts(TARGET ${ZEPHYR_LINK_STAGE_EXECUTABLE}
@@ -1656,41 +1689,25 @@ if(CONFIG_USERSPACE)
   )
 endif()
 
-configure_linker_script(
-  ${ZEPHYR_CURRENT_LINKER_CMD}
-  "${LINKER_PASS_${ZEPHYR_CURRENT_LINKER_PASS}_DEFINE}"
-  ${APP_SMEM_ALIGNED_DEP}
-  ${KOBJECT_LINKER_DEP}
-  ${CODE_RELOCATION_DEP}
-  zephyr_generated_headers
-  )
-
-add_custom_target(
-  linker_zephyr_prebuilt_script_target
-  DEPENDS
-  ${ZEPHYR_CURRENT_LINKER_CMD}
-  )
-
-set_property(TARGET
-  linker_zephyr_prebuilt_script_target
-  PROPERTY INCLUDE_DIRECTORIES
-  ${ZEPHYR_INCLUDE_DIRS}
-  )
-
 # Read global variables into local variables
 get_property(GASF GLOBAL PROPERTY GENERATED_APP_SOURCE_FILES)
 get_property(GKOF GLOBAL PROPERTY GENERATED_KERNEL_OBJECT_FILES)
 get_property(GKSF GLOBAL PROPERTY GENERATED_KERNEL_SOURCE_FILES)
 
-# FIXME: Is there any way to get rid of empty_file.c?
-add_executable(       ${ZEPHYR_LINK_STAGE_EXECUTABLE} misc/empty_file.c ${GASF})
-toolchain_ld_link_elf(
-  TARGET_ELF            ${ZEPHYR_LINK_STAGE_EXECUTABLE}
-  OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${ZEPHYR_LINK_STAGE_EXECUTABLE}.map
+setup_linker_pass(
+  EXECUTABLE ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+  CMD_FILE ${ZEPHYR_CURRENT_LINKER_CMD}
+  PASS_DEFINES ${LINKER_PASS_${ZEPHYR_CURRENT_LINKER_PASS}_DEFINE}
+  SCRIPT_TARGET linker_zephyr_prebuilt_script_target
+  DEPENDENCIES ${APP_SMEM_ALIGNED_DEP}
+    ${KOBJECT_LINKER_DEP}
+    ${CODE_RELOCATION_DEP}
+    zephyr_generated_headers
+  SOURCES ${GASF}
   LIBRARIES_PRE_SCRIPT  ""
-  LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/${ZEPHYR_CURRENT_LINKER_CMD}
-  DEPENDENCIES          ${CODE_RELOCATION_DEP}
+  LIBRARIES_POST_SCRIPT ""
 )
+
 target_link_libraries_ifdef(CONFIG_NATIVE_LIBRARY ${ZEPHYR_LINK_STAGE_EXECUTABLE}
                             $<TARGET_PROPERTY:linker,partial_linking>)
 target_byproducts(TARGET ${ZEPHYR_LINK_STAGE_EXECUTABLE}
@@ -1716,35 +1733,19 @@ else()
   # The final linker pass uses the same source linker script of the
   # previous passes, but this time with a different output
   # file and preprocessed with the define LINKER_ZEPHYR_FINAL.
-  configure_linker_script(
-    linker.cmd
-    "LINKER_ZEPHYR_FINAL"
-    ${CODE_RELOCATION_DEP}
-    ${ZEPHYR_LINK_STAGE_EXECUTABLE}
-    zephyr_generated_headers
-    )
-
-  add_custom_target(
-    linker_zephyr_final_script_target
-    DEPENDS
-    linker.cmd
-    )
-  set_property(TARGET
-    linker_zephyr_final_script_target
-    PROPERTY INCLUDE_DIRECTORIES
-    ${ZEPHYR_INCLUDE_DIRS}
-  )
-
-  add_executable(       ${ZEPHYR_FINAL_EXECUTABLE} misc/empty_file.c ${GASF} ${GKSF})
-  toolchain_ld_link_elf(
-    TARGET_ELF            ${ZEPHYR_FINAL_EXECUTABLE}
-    OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${ZEPHYR_FINAL_EXECUTABLE}.map
+  setup_linker_pass(
+    EXECUTABLE ${ZEPHYR_FINAL_EXECUTABLE}
+    CMD_FILE linker.cmd
+    PASS_DEFINES "LINKER_ZEPHYR_FINAL"
+    SCRIPT_TARGET linker_zephyr_final_script_target
+    DEPENDENCIES ${CODE_RELOCATION_DEP}
+      ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+      zephyr_generated_headers
+    SOURCES ${GASF} ${GKSF}
     LIBRARIES_PRE_SCRIPT  ${GKOF}
-    LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/linker.cmd
     LIBRARIES_POST_SCRIPT ""
-    DEPENDENCIES          ${CODE_RELOCATION_DEP}
   )
-  set_property(TARGET   ${ZEPHYR_FINAL_EXECUTABLE} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/linker.cmd)
+
   add_dependencies(     ${ZEPHYR_FINAL_EXECUTABLE} linker_zephyr_final_script_target)
 
   # Use the pass2 elf as the final elf

--- a/cmake/linker/iar/target.cmake
+++ b/cmake/linker/iar/target.cmake
@@ -43,6 +43,16 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   endif()
   zephyr_linker_generate_linker_settings_file(${cmake_linker_script_settings})
 
+  #The concept of "the previously built pass" is somewhat elusive:
+  # linker_pass_define          ${ZEPHYR_CURRENT_LINKER_PASS} ${ZEPHYR_LINK_STAGE_EXECUTABLE}
+  # LINKER_APP_SMEM_UNALIGNED   0                             zephyr_pre0
+  # LINKER_ZEPHYR_PREBUILT      1                             zephyr_pre1
+  # LINKER_ZEPHYR_FINAL         1                             zephyr_pre1
+  # To avoid fixing this in CMakelists, We'll just keep track of the previous
+  # linker_pass_define we got and use that to pickup the previous pass name (if any).
+
+  message("Yopehjdi: ${linker_script_gen} pass: ${linker_pass_define} current pass: ${ZEPHYR_CURRENT_LINKER_PASS} previous pass: ${PREV_PASS} stage_executable: ${ZEPHYR_LINK_STAGE_EXECUTABLE} iar_evaluate: ${IAR_EVALUATE_FILE}")
+
   add_custom_command(
     OUTPUT ${linker_script_gen}
            ${STEERING_FILE}

--- a/cmake/linker/linker_script_variable_utils.cmake
+++ b/cmake/linker/linker_script_variable_utils.cmake
@@ -1,0 +1,358 @@
+# Copyright (c) 2025 IAR Systems AB
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file contains utilities for handling @variables@ for the linker script
+# generator
+# There are some tests that cna be run like so:
+# cmake -D TEST_AT_VARIABLE_UTILS=1 -P linker_script_variable_utils.cmake -B .
+
+# @ variables are used for the cmake linker generator to refer to values not
+# known at configure time. this is provides the glue needed to bring
+# information together from the different scripts and passes, allowing e.g.
+# the size of kobject from gen_kobject.py to be used when defining sections
+#
+# The syntax is:
+# pattern <= @(<variable-name>[:undef=<pattern>][:<def-name>=<pattern>]*)@
+# variable-name <= pattern
+# def-name <= cmake-variable-name
+#
+# each of the <def-name>=<pattern> are used to set variables during the
+# evaluation of this expression.
+# As a special case unedf=<pattern> is used if <variable-name> is not defined
+#
+# As a shortcut the parenthesis in @()@ can be omitted if there are no nested
+# patterns. (e.g) @foo:undef=1@
+#
+# The value of a variable @FOO@ is stored in ordinary (scoped)
+# cmake-variable AT_VAR_FOO, or if it is not defined FOO.
+#
+# Example variable definitions:               Expands to:
+# V1 = "value"                                "value"
+# V2 = "a ref to @V1@"                        "a ref to value"
+# V2a = "shortcut @V1@ or @(V1)@"             "shortcut value or value"
+# V3 = "A maybe ref @MAYBE:undef=foo@"        "A maybe ref foo"
+# V4 = "A recursive @(@OTHER:undef=V1@)@"     "A recursive value"
+# DOUBLE ="@arg@@arg@"
+# V5 = "Two @(@DOUBLE@:arg=bar)@"             "Two barbar"
+# REF = "@(@ref@@index@)@"
+# V6 = "@V2@ is @REF:ref=V:index=2@"          "a ref to value is a ref to value"
+#
+
+# Expand variable expressions in input non-expressions are copied over
+# Expressions according to above: @(name[:undef=<str>][:name1=<value>])@
+# where:
+#    name - the name of a variable ([a-zA-Z_-]+) or a @-variable
+#           expression expanding to a name
+#    undef=<str> - uses <str> if no definition of name is found
+#    name1=<value> - define @name1@=<value> during expansion of name.
+# Where the undef=VALUE gets picked if we dont find name
+# and foo=bar defines a (local) variable in the current expansion
+function(expand_variables input output_var)
+  set(result "")
+
+  while(NOT input STREQUAL "")
+    string(FIND "${input}" "@" pos)
+    # Move everything from start of input to pos into result:
+    string(SUBSTRING "${input}" 0 ${pos} before_at)
+    string(APPEND result "${before_at}")
+    if(pos EQUAL -1)
+      # no more at found, done
+      break()
+    else()
+      # We now have a @ at pos, check if it is @( or @
+      string(SUBSTRING "${input}" ${pos} 2 opening)
+      if(opening STREQUAL "@(")
+        math(EXPR var_start "${pos} + 2")
+        string(SUBSTRING "${input}" ${var_start} -1 var_expr_input)
+        parse_paren_at_expression("${var_expr_input}" var_expr input_remainder)
+      else()
+        # The case @foo@
+        math(EXPR var_start "${pos} + 1")
+        string(SUBSTRING "${input}" ${var_start} -1 var_expr_input)
+        parse_single_at_expression("${var_expr_input}" var_expr input_remainder)
+      endif()
+      # message("Found @ at ${pos} expr = \"${var_expr}\" remainder: \"${input_remainder}\"")
+      #Now var_expr is the content inside the expression separators
+      expand_parsed_expression("${var_expr}" var_result)
+      # Let someone on the outside preview the expression expansion. This is
+      # used to capture expressions for the between-linker-passes-evaluation
+      preview_var_replacement(value "${var_expr}" "${var_result}")
+
+      string(APPEND result ${var_result})
+      set(input "${input_remainder}")
+    endif()
+  endwhile()
+  set(${output_var} "${result}" PARENT_SCOPE)
+endfunction()
+
+# ----------------------------------------------------------------------------
+# Utility functions
+#
+# like string(FIND input substring result) but with a starting position
+function(find_next_occurrence input substring result start)
+  string(SUBSTRING "${input}" ${start} -1 part)
+  string(FIND "${part}" "${substring}" pos)
+  if(NOT pos EQUAL -1)
+    math(EXPR pos "${pos} + ${start}")
+  endif()
+  set(${result} ${pos} PARENT_SCOPE)
+endfunction()
+
+# find the first )@ @ or @( after starting_pos
+# result_pos   - is the index AFTER that marker
+# result_marker- is the marker
+function(find_next_opening_or_close input starting_pos result_pos result_marker)
+  find_next_occurrence("${input}" "@" at ${starting_pos})
+  if(at EQUAL -1) #nothing found
+    set(${result_marker} "" PARENT_SCOPE)
+    set(${result_pos} -1 PARENT_SCOPE)
+  else()
+    # is it a )@ (after starting_pos)?
+    if(at GREATER starting_pos)
+      math(EXPR paren_at "${at} - 1")
+      string(SUBSTRING "${input}" ${paren_at} 2 maybe_closing)
+      if(maybe_closing STREQUAL ")@")
+        #found ")@" at paren_at
+        math(EXPR pos "${at} + 1")
+        set(${result_marker} ")@" PARENT_SCOPE)
+        set(${result_pos} ${pos} PARENT_SCOPE)
+        return()
+      endif()
+    endif()
+    string(SUBSTRING "${input}" ${at} 2 at_str)
+    if(at_str STREQUAL "@(")
+      math(EXPR pos "${at} + 2")
+    else()
+      math(EXPR pos "${at} + 1")
+      set(at_str "@")
+    endif()
+    set(${result_marker} ${at_str} PARENT_SCOPE)
+    set(${result_pos} ${pos} PARENT_SCOPE)
+  endif()
+endfunction()
+
+# input starts with a var expression that started with a @
+# on return var_expr is the expression split into parts
+#           remainder is the rest of input (excluding the closing @)
+function(parse_single_at_expression input var_expr remainder)
+  string(FIND "${input}" "@" end_at)
+  if(end_at EQUAL -1)
+    message(FATAL_ERROR "Syntax error in @ expression \"${input}\"")
+  else()
+    string(SUBSTRING "${input}" 0 ${end_at} var_str)
+    math(EXPR remainder_start "${end_at} + 1")
+    string(SUBSTRING "${input}" ${remainder_start} -1 input_remainder)
+
+    #split the expression into a parts list.
+    string(REPLACE ":" ";" var_str "${var_str}")
+  endif()
+  set(${var_expr} "${var_str}" PARENT_SCOPE)
+  set(${remainder} "${input_remainder}" PARENT_SCOPE)
+endfunction()
+
+# input starts with a var expression that started with a @(
+# on return var_expr is the expression split into parts
+#           remainder is the rest of input (excluding the closing @)
+function(parse_paren_at_expression input var_expr remainder )
+  # Find the matching )@ looking out for enclosed @expr@ and @()@.
+  set(pos 0)
+  string(LENGTH "${input}" length)
+  set(nesting_depth 0)
+
+  # To split the expression into parts, we need to replace , with ; (cmake
+  # list separator), but only if we are not inside a nested @-expression.
+  # We build this list as a string, appending bits to it after maybe
+  # list-splitting
+  set(parts)
+  set(nesting_start)
+
+  while(pos LESS_EQUAL length)
+    find_next_opening_or_close("${input}" ${pos} next_pos marker)
+    if(marker STREQUAL "") # nothing found
+      break()
+    endif()
+
+    if(nesting_depth EQUAL 0)
+      # We are outside of any nested expressions, so the bit up to the marker
+      # should be considered for splitting into expression parts.
+      string(LENGTH "${marker}" marker_length )
+      math(EXPR marker_start_pos "${next_pos} - ${marker_length}")
+      math(EXPR part_len "${marker_start_pos} - ${pos}")
+      string(SUBSTRING "${input}" ${pos} ${part_len} part_str)
+      string(REPLACE ":" ";" part_str "${part_str}")
+      string(APPEND parts "${part_str}")
+      if(marker STREQUAL ")@") # final closing
+      else()
+        # This is a nesting start
+        set(nesting_start ${marker_start_pos})
+      endif()
+    endif()
+
+    if(marker STREQUAL "@")
+      #Found the start of @foo@ so grab everything to the next @
+      find_next_occurrence("${input}" "@" at_end_pos ${next_pos} )
+      if(at_end_pos EQUAL -1)
+        break()
+      else()
+        #swallow the enclosed @foo@ by continuing after at_end_pos
+        math(EXPR next_pos "${at_end_pos} + 1")
+      endif()
+    elseif(marker STREQUAL "@(")
+      math(EXPR nesting_depth "${nesting_depth} + 1")
+    elseif(marker STREQUAL ")@")
+      #this will set nesting_depth to -1 when we find our end marker.
+      math(EXPR nesting_depth "${nesting_depth} - 1")
+    else()
+      message(FATAL_ERROR "unhandled marker ${marker} in \"${input}\"")
+    endif()
+
+    if(nesting_depth LESS_EQUAL 0 AND DEFINED nesting_start)
+      # we reached a non-nesting state so add the nested bits to the parts
+      math(EXPR nested_length "${next_pos} - ${nesting_start}")
+      string(SUBSTRING "${input}" ${nesting_start} ${nested_length} nested)
+      # Yes, string append since this is nested and should not be split into
+      # separate parts
+      string(APPEND parts "${nested}")
+      set(nesting_start)
+    endif()
+
+    if(nesting_depth EQUAL -1)
+      # found the matching end marker!
+      math(EXPR expr_end "${next_pos} - 2")
+      string(SUBSTRING "${input}" ${next_pos} -1 remainder_str)
+      set(${var_expr} "${parts}" PARENT_SCOPE)
+      set(${remainder} "${remainder_str}" PARENT_SCOPE)
+      return() # This is the everything is good return.
+    endif()
+
+    set(pos ${next_pos})
+  endwhile()
+  message(FATAL_ERROR "Syntax error in @ expression ${input}")
+endfunction()
+
+# Expands a list of expression parts into result
+# expression_parts - a list of expression parts (name,undef,defs)
+# result           - is set to the expanded value
+function(expand_parsed_expression expression_parts result)
+  set(original_parts "${expression_parts}")
+  # Take the variable name from the list
+  list(POP_FRONT expression_parts name)
+
+  # Find and handle var=<value> parts, and undef
+  set(undef_value)
+  foreach( p IN LISTS expression_parts)
+    # message("   Looking at part ${p}")
+    if(p MATCHES "([^=]+)=(.*)")
+      # Define a local variable, in this function scope.
+      set(AT_VAR_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}")
+      if(CMAKE_MATCH_1 STREQUAL "undef")
+        set(undef_value "${CMAKE_MATCH_2}")
+      endif()
+    endif()
+  endforeach()
+
+  # expand the variable-name (handle "pointers" @(@(FOO)@)@ ):
+  expand_variables("${name}" expanded_name)
+
+  # Look up the value as AT_VAR_name first, or else as name
+  set(actual_name)
+  foreach(n IN ITEMS "AT_VAR_${expanded_name}" "${expanded_name}")
+    if(DEFINED ${n})
+      set(actual_name ${n})
+    endif()
+  endforeach()
+
+  # Load the actual value
+  if(actual_name)
+    set(value ${${actual_name}})
+  elseif(DEFINED undef_value)
+    # Expand the undef value:
+    expand_variables(${undef_value} value)
+  endif()
+  # Handle variable expressions inside expressions
+  # Expand the value until the result does not change:
+  while(1)
+    expand_variables("${value}" new_value)
+    if(new_value STREQUAL value)
+      if(CMAKE_VERBOSE_MAKEFILE)
+        message("Expanded variable ${original_parts} with value ${value}")
+      endif()
+      set(${result} "${value}" PARENT_SCOPE)
+      return()
+    endif()
+    set(value "${new_value}")
+  endwhile()
+endfunction()
+
+#-----------------------------------------------------------------------------
+# Some tests.
+
+if(TEST_AT_VARIABLE_UTILS)
+
+  function(preview_var_replacement result expression expanded)
+    message("  PREVIEW: ${expression} => ${expanded}")
+    set(${result} "${expanded}" PARENT_SCOPE)
+  endfunction()
+
+  function(check_equal description actual expected)
+    if(NOT actual STREQUAL expected)
+      set(MAYBE_FATAL "FATAL_ERROR")
+    else()
+      set(MAYBE_FATAL )
+    endif()
+    message(${MAYBE_FATAL} " ${description}: \"${actual}\" expected \"${expected}\"")
+  endfunction()
+
+  function(test_parse_paren_at_expression expand exp_expr exp_remainder)
+    message("==========================================")
+    message("input = ${expand}")
+    parse_paren_at_expression("${expand}" var_expr remainder)
+    check_equal("expression" "${var_expr}" "${exp_expr}")
+    check_equal("remainder" "${remainder}" "${exp_remainder}")
+  endfunction()
+
+  test_parse_paren_at_expression("foo)@" "foo" "")
+  test_parse_paren_at_expression("foo)@apa" "foo" "apa")
+  test_parse_paren_at_expression("foo)@@apa@" "foo" "@apa@")
+  test_parse_paren_at_expression("@foo@)@" "@foo@" "")
+  test_parse_paren_at_expression("@(foo)@)@" "@(foo)@" "")
+  test_parse_paren_at_expression("a@(b)@@(apa@(foo)@papa)@)@" "a@(b)@@(apa@(foo)@papa)@" "")
+
+  test_parse_paren_at_expression("@foo:undef=u@)@" "@foo:undef=u@" "")
+  test_parse_paren_at_expression("@(inner:undef=j)@:undef=u)@" "@(inner:undef=j)@;undef=u" "")
+  test_parse_paren_at_expression("@(inner:undef=j)@:undef=u)@,apa" "@(inner:undef=j)@;undef=u" ",apa")
+
+  function(test_vars expand expected)
+    message("==========================================")
+    message("args = ${expand}")
+    expand_variables("${expand}" result)
+    check_equal("expanssion" "${result}" "${expected}")
+  endfunction()
+
+  set(AT_VAR_VAR1 "hello")
+  set(AT_VAR_VAR2 "world")
+  set(AT_VAR_REFER_TO_VAR2 "Something plus @VAR2@ is nice")
+  set(AT_VAR_WITH_PARAM "Some value @arg:undef=no_arg_given@")
+  set(AT_VAR_ARG1_OR_ARG2 "@(ARG1:undef=@ARG2@)@")
+
+  set(AT_VAR_MPU_ALIGN "MAX(0 , 2 << LOG2CEIL(@region_size@) )")
+  set(AT_VAR_SMEM_PARTITION_ALIGN "@MPU_ALIGN@")
+  set(AT_VAR_EVAL_MPU_ALIGN "@(Z_EVALUATE;undef=0;expr=MAX(32 , 2 << LOG2CEIL(@region_size@) ))@")
+
+  test_vars("@VAR1@" "hello")
+  test_vars("@VAR1@ @VAR2@" "hello world")
+  test_vars("@VAR1@ @REFER_TO_VAR2@ @VAR2@" "hello Something plus world is nice world")
+  test_vars("@SOME_FUNKY:undef=undefined@" "undefined")
+  test_vars("@(SOME_FUNKY:undef=@VAR1@)@" "hello")
+  test_vars("@WITH_PARAM@" "Some value no_arg_given")
+  test_vars("@WITH_PARAM:arg=something_given@" "Some value something_given")
+  test_vars("@(MY_OWN_DEF:MY_OWN_DEF=self)@" "self")
+  test_vars("@(ARG1_OR_ARG2:ARG2=self)@" "self")
+  test_vars("recursive @(@OTHER:undef=VAR1@)@" "recursive hello")
+
+  test_vars("@(SMEM_PARTITION_ALIGN:undef=42:region_size=end-start)@" "MAX(0 , 2 << LOG2CEIL(end-start) )")
+
+  test_vars("@(EVAL_MPU_ALIGN:undef=4077:region_size=the_size)@" "0")
+  test_vars("@(EVAL_MPU_ALIGN:undef=4077:region_size=the_size:Z_EVALUATE=@(expr)@)@" "MAX(32 , 2 << LOG2CEIL(the_size) )")
+endif()

--- a/cmake/linker_script/common/kobject-data.cmake
+++ b/cmake/linker_script/common/kobject-data.cmake
@@ -51,7 +51,7 @@ if(CONFIG_USERSPACE)
     ".kobject_data.data*"
     ".kobject_data.sdata*"
     PASS LINKER_ZEPHYR_PREBUILT LINKER_ZEPHYR_FINAL
-    ALIGN @KOBJECT_DATA_ALIGN,undef:4@
+    ALIGN @KOBJECT_DATA_ALIGN:undef=4@
     MIN_SIZE @KOBJECT_DATA_SZ@
     MAX_SIZE @KOBJECT_DATA_SZ@
     SYMBOLS _kobject_data_area_start _kobject_data_area_end

--- a/cmake/linker_script/common/kobject-priv-stacks.cmake
+++ b/cmake/linker_script/common/kobject-priv-stacks.cmake
@@ -7,7 +7,7 @@ if(CONFIG_USERSPACE)
     # Padding is needed to preserve kobject addresses
     # if we have reserved more space than needed.
     zephyr_linker_section(NAME .priv_stacks_noinit GROUP NOINIT_REGION NOINPUT NOINIT
-                MIN_SIZE @KOBJECT_PRIV_STACKS_SZ,undef:0@ MAX_SIZE @KOBJECT_PRIV_STACKS_SZ,undef:0@)
+                MIN_SIZE @KOBJECT_PRIV_STACKS_SZ:undef=0@ MAX_SIZE @KOBJECT_PRIV_STACKS_SZ:undef=0@)
 
     zephyr_linker_section_configure(
       SECTION .priv_stacks_noinit
@@ -23,7 +23,7 @@ if(CONFIG_USERSPACE)
     # during the final stages of linking (LINKER_ZEPHYR_FINAL).
     zephyr_linker_section_configure(
       SECTION .priv_stacks_noinit
-      ALIGN @KOBJECT_PRIV_STACKS_ALIGN,undef:0@
+      ALIGN @KOBJECT_PRIV_STACKS_ALIGN:undef=0@
       INPUT ".priv_stacks.noinit"
       KEEP
       PASS LINKER_ZEPHYR_PREBUILT LINKER_ZEPHYR_FINAL

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5521,7 +5521,7 @@ function(zephyr_linker_include_generated)
   list(APPEND files ${INCLUDE_CMAKE} ${INCLUDE_KCONFIG} ${INCLUDE_HEADER})
   list(LENGTH files files_count)
   if(NOT ${files_count} EQUAL 1)
-    message(FATAL_ERROR "zephyr_linker_include_generated(${ARGV0} ...) must have one of CMAKE, KCONFIG or HEADER")
+    message(FATAL_ERROR "zephyr_linker_include_generated(${ARGN} ...) must have one of CMAKE, KCONFIG or HEADER")
   endif()
 
   zephyr_linker_check_pass_param("${INCLUDE_PASS}")

--- a/scripts/build/gen_app_partitions.py
+++ b/scripts/build/gen_app_partitions.py
@@ -253,6 +253,7 @@ def zephyr_linker_section(name, group, align = None, noinput = True, align_with_
     props = {"""NAME""": name, """GROUP""": group}
     if align :
         props['ALIGN'] = align
+        align_with_input = False
     #The bool flags are always there:
     props['NOIPUT'] = noinput
     props['ALIGN_WITH_INPUT'] = align_with_input
@@ -279,8 +280,9 @@ def zephyr_linker_symbol(symbol, expr) :
 
 class CmakeTemplate:
     section_name = "@_APP_SMEM{SECTION}_SECTION_NAME@"
+    smem_partition_align = "@SMEM_PARTITION_ALIGN:region_size=z_data_smem_{partition}_bss_end - z_data_smem_{partition}_part_start@"
     data_template = (
-        zephyr_linker_section_configure(section=section_name, align="@SMEM_PARTITION_ALIGN_BYTES@")+
+        zephyr_linker_section_configure(section=section_name, align=smem_partition_align)+
         zephyr_linker_section_configure(section=section_name, input="data_smem_{partition}_data*", symbols="z_data_smem_{partition}_part_start", keep=True)
     )
 
@@ -294,20 +296,20 @@ class CmakeTemplate:
 
     footer_template = (
         zephyr_linker_section_configure(section=section_name, symbols="z_data_smem_{partition}_bss_end", keep=True) +
-        zephyr_linker_section_configure(section=section_name, align="@SMEM_PARTITION_ALIGN_BYTES@") +
+        zephyr_linker_section_configure(section=section_name, align=smem_partition_align) +
         zephyr_linker_section_configure(section=section_name, symbols="z_data_smem_{partition}_part_end", keep=True)
     )
 
     linker_start_seq = (
         zephyr_linker_section(name=section_name, group="APP_SMEM_GROUP", noinput=True, align_with_input=True) +
-        zephyr_linker_section_configure(section=section_name, align="@APP_SHARED_ALIGN_BYTES@", symbols="_app_smem{section}_start"))
+        zephyr_linker_section_configure(section=section_name, align="@APP_SHARED_ALIGN@", symbols="_app_smem{section}_start"))
 
     linker_end_seq = (
-        zephyr_linker_section_configure(section=section_name, align="@APP_SHARED_ALIGN_BYTES@") +
+        zephyr_linker_section_configure(section=section_name, align="@APP_SHARED_ALIGN@") +
         zephyr_linker_section_configure(section=section_name, symbols="_app_smem{section}_end") )
 
     empty_app_smem = (
-        zephyr_linker_section(name=section_name, group="APP_SMEM_GROUP", align="@APP_SHARED_ALIGN_BYTES@", noinput=True, align_with_input=True) +
+        zephyr_linker_section(name=section_name, group="APP_SMEM_GROUP", align="@APP_SHARED_ALIGN@", noinput=True, align_with_input=True) +
         zephyr_linker_section_configure(section = section_name, symbols="_app_smem{section}_start") +
         zephyr_linker_section_configure(section = section_name, symbols="_app_smem{section}_end") )
 

--- a/scripts/build/gen_z_evaluated.py
+++ b/scripts/build/gen_z_evaluated.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Script to bridge the gap between ld-syntax expressions and IAR Ilink capabilities
+
+This works by leveraging the multiple linker passes; for PASS i
+the zephyr_linker_XXXX() tags things with @IAR_EVALUATE@ that needs special
+treatment (e.g. MPU_ALIGN(region_size)). This is picked up by
+config_file_script.cmake during @-variable expansion, and puts it into a file
+(iar_evaluate_PASS.json).
+
+This script reads iar_evaluate_PASSi.json and the corresponding
+zephyr_PASSi.elf file to evaluate the required expressions. The results
+are put into a .cmake file that defines the required @IAR_EVALUATED_@ variables.
+This file is then zephyr_linker_include_generated() into PASSi+1.
+
+The grand plan is thus: open the elf file to gather all symbol values.
+Iterate over all of the elements in the json, evaluate the expressions and if
+it succeeds put the resulting @IAR_EVALUATED@ thig into the cmake.
+"""
+
+import argparse
+import json
+import math
+import re
+
+import elftools.common.exceptions
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+
+
+def cmake_list_append(list, props):
+    tokens = [rf"{key}\;{value}" for key, value in props.items()]
+    stuff = r"\;".join(tokens)
+    return """list(APPEND """ + list + """ \"{""" + stuff + """}\")\n"""
+
+
+def zephyr_linker_include_var(var, value):
+    props = {"""VAR""": var, """VALUE""": value}
+    return cmake_list_append("VARIABLES", props)
+
+
+def parse_elf_file(file):
+    symbols = {}
+    with open(file, 'rb') as f:
+        try:
+            elffile = ELFFile(f)
+        except elftools.common.exceptions.ELFError as e:
+            exit(f"Error: {args.elf}: {e}")
+
+        symbol_tbls = [s for s in elffile.iter_sections() if isinstance(s, SymbolTableSection)]
+
+        for section in symbol_tbls:
+            for symbol in section.iter_symbols():
+                if symbol['st_shndx'] == "SHN_UNDEF":
+                    continue
+                if symbol['st_info']['bind'] != 'STB_GLOBAL':
+                    continue
+
+                symbols[symbol.name] = symbol['st_value']
+        return symbols
+
+
+def parse_input_file(name):
+    expressions = {}
+    with open(name, 'rb') as f:
+        all_exprs = json.load(f)
+
+        for expr in all_exprs:
+            if expr['name'] not in expressions:
+                expressions[expr['name']] = expr['expression']
+    return expressions
+
+
+# define some ld-expression functions:
+# There are a bunch of them that require info about sections and segments
+# let's ignore them for now...
+def MAX(a, b):
+    return max(a, b)
+
+
+def MIN(a, b):
+    return min(a, b)
+
+
+def LOG2CEIL(x):
+    if x <= 0:
+        raise ValueError("LOG2CEIL is not defined for non-positive values")
+    return math.ceil(math.log2(x))
+
+
+def evaluate_expressions(expressions, symbols):
+    variables = {}
+    for name, expr in expressions.items():
+        # Replace symbol names with their values
+        for symbol, value in symbols.items():
+            expr = re.sub(r'\b' + symbol + r'\b', str(value), expr)
+        value = eval(expr)
+        variables[name] = value
+    return variables
+
+
+def generate_cmake_output(variables, output):
+    with open(output, 'w') as f:
+        for name, value in variables.items():
+            f.write(zephyr_linker_include_var(name, value))
+
+
+def parse_args():
+    global args
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+    parser.add_argument("-e", "--elf", required=True, default=None, help="ELF file")
+    parser.add_argument("-i", "--input", required=True, help="input json expressions file")
+    parser.add_argument("-o", "--output", required=True, help="Output cmake file file")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Verbose Output")
+
+    args = parser.parse_args()
+
+
+def main():
+    parse_args()
+
+    symbols = parse_elf_file(args.elf)
+    if args.verbose:
+        print(f"Symbols: {symbols}")
+    expressions = parse_input_file(args.input)
+    variables = evaluate_expressions(expressions, symbols)
+    generate_cmake_output(variables, args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Until now it has not been possible to handle MPU_ALIGN(region_size) entierly inside the CMAKE_LINKER_GENERATOR machinery, since it has been relying on the c-preprocessor definition. This does not scale for e.g. the iar-linker, which would require a different include-file duplicating the MPU_ALIGN definition. It also makes the logic hard to follow, since the info is spread out between the cmake-files, #include files, all brought guarded with #ifdefs. Doing it all in cmake allows us to collect all this at the same place.

This patch tries to fix that by extending the already existing @variables@ to handle arguments using the syntax @MPU_ALIGN,region_size=42@ which sets @region_size@ to 42 while expanding @MPU_ALIGN@. The syntax is choosen to not interfere with cmake...



