### PR TITLE
drivers: can: support nuvoton m55m1x series

### DIFF
--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
@@ -25,6 +25,14 @@
 		};
 	};
 
+	/* CAN TX/RX --> PJ10/PJ11 (J8) */
+	canfd0_default: canfd0_default {
+		group0 {
+			pinmux = <PJ10MFP_CANFD0_TXD>,
+				 <PJ11MFP_CANFD0_RXD>;
+		};
+	};
+
 	/* EMAC multi-function pins for MDIO, TX, REFCLK, RX pins */
 	emac_default: emac_default {
 		group0 {

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
@@ -27,6 +27,7 @@
 		zephyr,itcm = &itcm;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,canbus = &canfd0;
 	};
 
 	leds {
@@ -83,6 +84,12 @@
 &uart0 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&canfd0 {
+	pinctrl-0 = <&canfd0_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1.yaml
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1.yaml
@@ -12,4 +12,5 @@ ram: 1536
 flash: 2048
 supported:
   - gpio
+  - can
 vendor: nuvoton

--- a/drivers/can/Kconfig.numaker
+++ b/drivers/can/Kconfig.numaker
@@ -9,6 +9,6 @@ config CAN_NUMAKER
 	select CAN_MCAN
 	select PINCTRL
 	depends on DT_HAS_NUVOTON_NUMAKER_CANFD_ENABLED
-	depends on SOC_SERIES_M46X || SOC_SERIES_M2L31X
+	depends on SOC_SERIES_M46X || SOC_SERIES_M2L31X || SOC_SERIES_M55M1X
 	help
 	  Enables Nuvoton NuMaker CAN FD driver, using Bosch M_CAN

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -18,12 +18,6 @@
 
 LOG_MODULE_REGISTER(can_numaker, CONFIG_CAN_LOG_LEVEL);
 
-/* CANFD Clock Source Selection */
-#define NUMAKER_CANFD_CLKSEL_HXT      0
-#define NUMAKER_CANFD_CLKSEL_PLL_DIV2 1
-#define NUMAKER_CANFD_CLKSEL_HCLK     2
-#define NUMAKER_CANFD_CLKSEL_HIRC     3
-
 /* Implementation notes
  * 1. Use Bosch M_CAN driver (m_can) as backend
  * 2. Need to modify can_numaker_get_core_clock() for new SOC support
@@ -55,18 +49,33 @@ static int can_numaker_get_core_clock(const struct device *dev, uint32_t *rate)
 	clkdiv_divider = CLK_GetModuleClockDivider(config->clk_modidx) + 1;
 
 	switch (clksrc_rate_idx) {
-	case NUMAKER_CANFD_CLKSEL_HXT:
+#if defined(CONFIG_SOC_SERIES_M46X)
+	case (CLK_CLKSEL0_CANFD0SEL_HXT >> CLK_CLKSEL0_CANFD0SEL_Pos):
 		*rate = __HXT / clkdiv_divider;
 		break;
-	case NUMAKER_CANFD_CLKSEL_PLL_DIV2:
+	case (CLK_CLKSEL0_CANFD0SEL_PLL_DIV2 >> CLK_CLKSEL0_CANFD0SEL_Pos):
 		*rate = (CLK_GetPLLClockFreq() / 2) / clkdiv_divider;
 		break;
-	case NUMAKER_CANFD_CLKSEL_HCLK:
+	case (CLK_CLKSEL0_CANFD0SEL_HCLK >> CLK_CLKSEL0_CANFD0SEL_Pos):
 		*rate = CLK_GetHCLKFreq() / clkdiv_divider;
 		break;
-	case NUMAKER_CANFD_CLKSEL_HIRC:
+	case (CLK_CLKSEL0_CANFD0SEL_HIRC >> CLK_CLKSEL0_CANFD0SEL_Pos):
 		*rate = __HIRC / clkdiv_divider;
 		break;
+#elif defined(CONFIG_SOC_SERIES_M2L31X)
+	case (CLK_CLKSEL0_CANFD0SEL_HXT >> CLK_CLKSEL0_CANFD0SEL_Pos):
+		*rate = __HXT / clkdiv_divider;
+		break;
+	case (CLK_CLKSEL0_CANFD0SEL_HIRC48M >> CLK_CLKSEL0_CANFD0SEL_Pos):
+		*rate = __HIRC48 / clkdiv_divider;
+		break;
+	case (CLK_CLKSEL0_CANFD0SEL_HCLK >> CLK_CLKSEL0_CANFD0SEL_Pos):
+		*rate = CLK_GetHCLKFreq() / clkdiv_divider;
+		break;
+	case (CLK_CLKSEL0_CANFD0SEL_HIRC >> CLK_CLKSEL0_CANFD0SEL_Pos):
+		*rate = __HIRC / clkdiv_divider;
+		break;
+#endif
 	default:
 		LOG_ERR("Invalid clock source rate index");
 		return -EIO;

--- a/drivers/can/can_numaker.c
+++ b/drivers/can/can_numaker.c
@@ -75,6 +75,22 @@ static int can_numaker_get_core_clock(const struct device *dev, uint32_t *rate)
 	case (CLK_CLKSEL0_CANFD0SEL_HIRC >> CLK_CLKSEL0_CANFD0SEL_Pos):
 		*rate = __HIRC / clkdiv_divider;
 		break;
+#elif defined(CONFIG_SOC_SERIES_M55M1X)
+	case (CLK_CANFDSEL_CANFD0SEL_HXT >> CLK_CANFDSEL_CANFD0SEL_Pos):
+		*rate = __HXT / clkdiv_divider;
+		break;
+	case (CLK_CANFDSEL_CANFD0SEL_APLL0_DIV2 >> CLK_CANFDSEL_CANFD0SEL_Pos):
+		*rate = (CLK_GetAPLL0ClockFreq() / 2) / clkdiv_divider;
+		break;
+	case (CLK_CANFDSEL_CANFD0SEL_HCLK0 >> CLK_CANFDSEL_CANFD0SEL_Pos):
+		*rate = CLK_GetHCLK0Freq() / clkdiv_divider;
+		break;
+	case (CLK_CANFDSEL_CANFD0SEL_HIRC >> CLK_CANFDSEL_CANFD0SEL_Pos):
+		*rate = __HIRC / clkdiv_divider;
+		break;
+	case (CLK_CANFDSEL_CANFD0SEL_HIRC48M_DIV4 >> CLK_CANFDSEL_CANFD0SEL_Pos):
+		*rate = (__HIRC48M / 4) / clkdiv_divider;
+		break;
 #endif
 	default:
 		LOG_ERR("Invalid clock source rate index");

--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -337,6 +337,34 @@
 			status = "disabled";
 		};
 
+		canfd0: canfd@40222000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40222000 0x200>, <0x40222200 0x1800>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <117 0>, <118 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_SYS_CANFD0RST>;
+			clocks = <&pcc NUMAKER_CANFD0_MODULE
+				  NUMAKER_CLK_CANFDSEL_CANFD0SEL_HCLK0
+				  NUMAKER_CLK_CANFDDIV_CANFD0DIV(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
+
+		canfd1: canfd@40224000 {
+			compatible = "nuvoton,numaker-canfd";
+			reg = <0x40224000 0x200>, <0x40224200 0x1800>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <119 0>, <120 0>;
+			interrupt-names = "int0", "int1";
+			resets = <&rst NUMAKER_SYS_CANFD1RST>;
+			clocks = <&pcc NUMAKER_CANFD1_MODULE
+				  NUMAKER_CLK_CANFDSEL_CANFD1SEL_HCLK0
+				  NUMAKER_CLK_CANFDDIV_CANFD1DIV(1)>;
+			bosch,mram-cfg = <0x0 12 10 3 3 3 3 3>;
+			status = "disabled";
+		};
+
 		emac: ethernet@40208000 {
 			compatible = "nuvoton,numaker-ethernet";
 			reg = <0x40208000 0x2000>;


### PR DESCRIPTION
This updates nuvoton numaker can-fd driver, including:
1. Add support for m55m1x can-fd
2. Fix m2l31x can-fd core clock and support test code