### PR TITLE
Bluetooth: Controller: Fix handling of odd SDU intervals in CIS central

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -231,7 +231,7 @@ uint8_t ll_cig_parameters_commit(uint8_t cig_id, uint16_t *handles)
 		 * handle the throughput. For unframed these must be divisible, if they're not,
 		 * framed mode must be forced.
 		 */
-		iso_interval_us = cig->c_sdu_interval;
+		iso_interval_us = (cig->c_sdu_interval / ISO_INT_UNIT_US) * ISO_INT_UNIT_US;
 
 		if (iso_interval_us < ISO_INTERVAL_TO_US(BT_HCI_ISO_INTERVAL_MIN)) {
 			/* ISO_Interval is below minimum (5 ms) */


### PR DESCRIPTION
Make sure iso_interval_us is in a multiple of 1.25 ms instead of directly assigning it the value of SDU interval

Fixes EBQ failures in LL/CIS/CEN/BV-36-C and LL/CIS/CEN/BV-37-C