### PR TITLE
userspace: Weak defintions for generated k-object lookup functions

### DIFF
--- a/cmake/linker_script/common/kobject-text.cmake
+++ b/cmake/linker_script/common/kobject-text.cmake
@@ -24,25 +24,4 @@ if(CONFIG_USERSPACE)
     EXPR
     "(@_kobject_text_area_end@ - @_kobject_text_area_start@)"
     )
-
-  if(CONFIG_DYNAMIC_OBJECTS)
-    zephyr_linker_section_configure(
-      SECTION
-      _kobject_text_area
-      SYMBOLS
-      z_object_gperf_find
-      z_object_gperf_wordlist_foreach
-      PASS NOT LINKER_ZEPHYR_FINAL
-      )
-  else()
-    zephyr_linker_section_configure(
-      SECTION
-      _kobject_text_area
-      SYMBOLS
-      k_object_find
-      k_object_wordlist_foreach
-      PASS NOT LINKER_ZEPHYR_FINAL
-      )
-  endif()
-
 endif()

--- a/include/zephyr/linker/kobject-text.ld
+++ b/include/zephyr/linker/kobject-text.ld
@@ -14,15 +14,6 @@
 	*(".kobject_data.text*")
 	PLACE_SYMBOL_HERE(_kobject_text_area_end);
 	_kobject_text_area_used = _kobject_text_area_end - _kobject_text_area_start;
-#ifndef LINKER_ZEPHYR_FINAL
-#ifdef CONFIG_DYNAMIC_OBJECTS
-	PROVIDE(z_object_gperf_find = .);
-	PROVIDE(z_object_gperf_wordlist_foreach = .);
-#else
-	PROVIDE(k_object_find = .);
-	PROVIDE(k_object_wordlist_foreach = .);
-#endif
-#endif
 
 	/* In a valid build the MAX function will always evaluate to the
 	second argument below, but to give the user a good error message

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -521,6 +521,33 @@ void k_object_wordlist_foreach(_wordlist_cb_func_t func, void *context)
 }
 #endif /* CONFIG_DYNAMIC_OBJECTS */
 
+/* In the earlier linker-passes before we have the real generated
+ * implementation of the lookup functions, we need some weak dummies.
+ * Being __weak, they will be replaced by the generated implementations in
+ * the later linker passes.
+ */
+#ifdef CONFIG_DYNAMIC_OBJECTS
+Z_GENERIC_SECTION(.kobject_data.text.dummies)
+__weak struct k_object *z_object_gperf_find(const void *obj)
+{
+	return NULL;
+}
+Z_GENERIC_SECTION(.kobject_data.text.dummies)
+__weak void z_object_gperf_wordlist_foreach(_wordlist_cb_func_t func, void *context)
+{
+}
+#else
+Z_GENERIC_SECTION(.kobject_data.text.dummies)
+__weak struct k_object *k_object_find(const void *obj)
+{
+	return NULL;
+}
+Z_GENERIC_SECTION(.kobject_data.text.dummies)
+__weak void k_object_wordlist_foreach(_wordlist_cb_func_t func, void *context)
+{
+}
+#endif
+
 static unsigned int thread_index_get(struct k_thread *thread)
 {
 	struct k_object *ko;


### PR DESCRIPTION
Instead of obscure linker-file hacks providing dummy definitions before we have the proper generated k-object lookup functions, provide weak definitions  that will be taken out by the real generated implementations when they are available.

