### PR TITLE
drivers: i2c: esp32: add dependency to MULTITHREADING

### DIFF
--- a/drivers/i2c/Kconfig.esp32
+++ b/drivers/i2c/Kconfig.esp32
@@ -8,6 +8,7 @@ config I2C_ESP32
 	bool "ESP32 I2C driver"
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_I2C_ENABLED
+	depends on MULTITHREADING
 	select GPIO_ESP32
 	help
 	  Enables the ESP32 I2C driver


### PR DESCRIPTION
The i2c driver implementation for esp32 internally uses z_impl_k_sem_give and alike, which are only available on MULTITHREADING.

Not selecting this leads to link time errors. To reflect this dependency, we also add it to the drivers kconfig.