### PR TITLE
video: renamimg of all 4 8 bit bayer format to be consistent with others, add a S prefix

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -394,6 +394,16 @@ xSPI
   Note that the property gives the actual size of the memory device in bits.
   Previous mapping address information is now described in xspi node at SoC dtsi level.
 
+Video
+=====
+
+* 8 bit RAW Bayer formats BGGR8 / GBRG8 / GRBG8 / RGGB8 have been renamed by adding
+  a S prefix in front:
+
+  ``VIDEO_PIX_FMT_BGGR8`` becomes ``VIDEO_PIX_FMT_SBGGR8``
+  ``VIDEO_PIX_FMT_GBRG8`` becomes ``VIDEO_PIX_FMT_SGBRG8``
+  ``VIDEO_PIX_FMT_GRBG8`` becomes ``VIDEO_PIX_FMT_SGRBG8``
+  ``VIDEO_PIX_FMT_RGGB8`` becomes ``VIDEO_PIX_FMT_SRGGB8``
 
 Other subsystems
 ****************

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -883,7 +883,7 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
  * | Gggggggg | Rrrrrrrr | Gggggggg | Rrrrrrrr | ...
  * @endcode
  */
-#define VIDEO_PIX_FMT_BGGR8 VIDEO_FOURCC('B', 'A', '8', '1')
+#define VIDEO_PIX_FMT_SBGGR8 VIDEO_FOURCC('B', 'A', '8', '1')
 
 /**
  * @code{.unparsed}
@@ -892,7 +892,7 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
  * | Rrrrrrrr | Gggggggg | Rrrrrrrr | Gggggggg | ...
  * @endcode
  */
-#define VIDEO_PIX_FMT_GBRG8 VIDEO_FOURCC('G', 'B', 'R', 'G')
+#define VIDEO_PIX_FMT_SGBRG8 VIDEO_FOURCC('G', 'B', 'R', 'G')
 
 /**
  * @code{.unparsed}
@@ -901,7 +901,7 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
  * | Bbbbbbbb | Gggggggg | Bbbbbbbb | Gggggggg | ...
  * @endcode
  */
-#define VIDEO_PIX_FMT_GRBG8 VIDEO_FOURCC('G', 'R', 'B', 'G')
+#define VIDEO_PIX_FMT_SGRBG8 VIDEO_FOURCC('G', 'R', 'B', 'G')
 
 /**
  * @code{.unparsed}
@@ -910,7 +910,7 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
  * | Gggggggg | Bbbbbbbb | Gggggggg | Bbbbbbbb | ...
  * @endcode
  */
-#define VIDEO_PIX_FMT_RGGB8 VIDEO_FOURCC('R', 'G', 'G', 'B')
+#define VIDEO_PIX_FMT_SRGGB8 VIDEO_FOURCC('R', 'G', 'G', 'B')
 
 /**
  * @code{.unparsed}
@@ -1371,10 +1371,10 @@ void video_closest_frmival(const struct device *dev, enum video_endpoint_id ep,
 static inline unsigned int video_bits_per_pixel(uint32_t pixfmt)
 {
 	switch (pixfmt) {
-	case VIDEO_PIX_FMT_BGGR8:
-	case VIDEO_PIX_FMT_GBRG8:
-	case VIDEO_PIX_FMT_GRBG8:
-	case VIDEO_PIX_FMT_RGGB8:
+	case VIDEO_PIX_FMT_SBGGR8:
+	case VIDEO_PIX_FMT_SGBRG8:
+	case VIDEO_PIX_FMT_SGRBG8:
+	case VIDEO_PIX_FMT_SRGGB8:
 	case VIDEO_PIX_FMT_GREY:
 		return 8;
 	case VIDEO_PIX_FMT_SBGGR10P:


### PR DESCRIPTION
Renaming of BGGR8 (etc) into SBGGR8 to be similar to other formats and similar to what is done in other software environments.