### PR TITLE
Bluetooth: Host: Remove conditional stack size for BT_SETTINGS

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -112,7 +112,6 @@ config BT_RX_STACK_SIZE
 	default 3092 if BT_MESH_GATT_CLIENT
 	default 2600 if BT_MESH
 	default 2048 if BT_AUDIO
-	default 2200 if BT_SETTINGS
 	default 1200
 	help
 	  Size of the receiving thread stack. This is the context from


### PR DESCRIPTION
With BT_SETTINGS enabled, there doesn't seem to (anymore?) be any substantial overhead in stack consumption:

 0x200020b8 BT RX WQ
        options: 0x0, priority: -8 timeout: -9223372036854775808
        state: pending, entry: 0x5ba69
        stack size 2240, unused 1072, usage 1168 / 2240 (52 %)

Let's just remove the conditional default and fall back to the non-conditional one which is 1200.