### PR TITLE
dts: arm: st: u0: fix msi clock

### DIFF
--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -64,7 +64,7 @@
 		clk_msi: clk-msi {
 			#clock-cells = <0>;
 			compatible = "st,stm32-msi-clock";
-			msi-range = <4>; /* 4MHz (reset value) */
+			msi-range = <6>; /* 4MHz (reset value) */
 			status = "disabled";
 		};
 

--- a/dts/bindings/clock/st,stm32-msi-clock.yaml
+++ b/dts/bindings/clock/st,stm32-msi-clock.yaml
@@ -19,7 +19,7 @@ properties:
       - 1 # range 1 around 200 kHz
       - 2 # range 2 around 400 kHz
       - 3 # range 3 around 800 kHz
-      - 4 # range 4 around 1M Hz
+      - 4 # range 4 around 1 MHz
       - 5 # range 5 around 2 MHz
       - 6 # range 6 around 4 MHz (reset value)
       - 7 # range 7 around 8 MHz


### PR DESCRIPTION
`msi-range` value 4 sets MSI clock frequency to 1 MHz and not 4 MHz as
intended.

Change value to 6 to increase clock to 4 MHz which matches comment.