### PR TITLE
drivers: intc_nxp_pint: Decouple from fsl_power.h

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -12,7 +12,8 @@
 #include <zephyr/drivers/interrupt_controller/nxp_pint.h>
 
 #include <fsl_inputmux.h>
-#include <fsl_power.h>
+
+#include "intc_nxp_pint/power.h"
 
 #define DT_DRV_COMPAT nxp_pint
 
@@ -94,14 +95,8 @@ int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger, bool wake)
 	 * driver handles the IRQ
 	 */
 	PINT_PinInterruptConfig(pint_base, slot, trigger, NULL);
-#if !(defined(FSL_FEATURE_POWERLIB_EXTEND) && (FSL_FEATURE_POWERLIB_EXTEND != 0))
-	if (wake) {
-		EnableDeepSleepIRQ(pint_irq_cfg[slot].irq);
-	} else {
-		DisableDeepSleepIRQ(pint_irq_cfg[slot].irq);
-		irq_enable(pint_irq_cfg[slot].irq);
-	}
-#endif
+	nxp_pint_pin_deep_sleep_irq(pint_irq_cfg[slot].irq, wake);
+
 	return 0;
 }
 

--- a/drivers/interrupt_controller/intc_nxp_pint/power.h
+++ b/drivers/interrupt_controller/intc_nxp_pint/power.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file abstracts operations exposed by fsl_power.h from NXP HAL,
+ * for cases when that driver can't be compiled (DSP targets).
+ */
+
+#ifndef __ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_NXP_PINT_POWER_H__
+#define __ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_NXP_PINT_POWER_H__
+
+#include <stdbool.h>
+#include <zephyr/irq.h>
+#include <fsl_pint.h>
+
+#if defined(FSL_FEATURE_SOC_PMC_COUNT) && FSL_FEATURE_SOC_PMC_COUNT > 0
+#include <fsl_power.h>
+#endif
+
+static inline void nxp_pint_pin_deep_sleep_irq(uint8_t irq, bool wake)
+{
+#if (defined(FSL_FEATURE_SOC_PMC_COUNT) && FSL_FEATURE_SOC_PMC_COUNT > 0) &&                       \
+	!(defined(FSL_FEATURE_POWERLIB_EXTEND) && (FSL_FEATURE_POWERLIB_EXTEND != 0))
+	if (wake) {
+		EnableDeepSleepIRQ(irq);
+	} else {
+		DisableDeepSleepIRQ(irq);
+		irq_enable(irq);
+	}
+#else
+	ARG_UNUSED(irq);
+	ARG_UNUSED(wake);
+#endif
+}
+
+#endif


### PR DESCRIPTION
Add drivers/interrupt_controller/intc_nxp_pint/power.h abstracting `EnableDeepSleepIRQ` and `DisableDeepSleepIRQ` invocations from `intc_nxp_pint.c`. Modify `intc_nxp_pint.c` to use that file.

`fsl_power.c` and `fsl_power.h` can't be built on the `mimxrt685_evk/mimxrt685s/hifi4` target, so it's excluded from it in `hal_nxp`. 

That board is yet to be merged - this PR is a prerequisite.