### PR TITLE
boards: mimxrt685_evk/mimxrt685s/cm33: Enable MU

### DIFF
--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -35,6 +35,7 @@
 		sdhc0 = &usdhc0;
 		dmic-dev = &dmic0;
 		mcuboot-button0 = &user_button_1;
+		mbox = &mbox;
 	};
 
 	chosen {
@@ -408,6 +409,10 @@ zephyr_udc0: &usbhs {
 
 /* Disable this node if not using USB and need another MPU region */
 &sram1 {
+	status = "okay";
+};
+
+&mbox {
 	status = "okay";
 };
 

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -589,6 +589,18 @@
 			status = "disabled";
 		};
 	};
+
+	mbox: mbox@110000 {
+		#mbox-cells = <1>;
+
+		compatible = "nxp,mbox-imx-mu";
+		reg = <0x110000 0x1000>;
+
+		interrupts = <34 0>;
+		rx-channels = <4>;
+
+		status = "disabled";
+	};
 };
 
 &flexspi {


### PR DESCRIPTION
Enable the MU peripheral for the CM33 domain of the `mimxrt685_evk`.

Intended to be used in AMP scenarios of the `mimxrt685_evk` (IPC between CM33 and HiFi 4 DSP domains), marking this as a prerequisite for complete support of the i.MX RT685's HiFi 4 DSP domain.