### PR TITLE
boards: nxp: Fix nxp board-vendor duplication

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.yaml
+++ b/boards/nxp/frdm_k22f/frdm_k22f.yaml
@@ -20,4 +20,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_k64f/frdm_k64f.yaml
+++ b/boards/nxp/frdm_k64f/frdm_k64f.yaml
@@ -27,4 +27,3 @@ supported:
   - usb_device
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_k82f/frdm_k82f.yaml
+++ b/boards/nxp/frdm_k82f/frdm_k82f.yaml
@@ -22,4 +22,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.yaml
@@ -18,4 +18,3 @@ supported:
   - spi
   - uart
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.yaml
@@ -24,4 +24,3 @@ supported:
   - spi
   - dma
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_kl25z/frdm_kl25z.yaml
+++ b/boards/nxp/frdm_kl25z/frdm_kl25z.yaml
@@ -18,4 +18,3 @@ supported:
   - flash
   - i2c
   - usb_device
-vendor: nxp

--- a/boards/nxp/frdm_kw41z/frdm_kw41z.yaml
+++ b/boards/nxp/frdm_kw41z/frdm_kw41z.yaml
@@ -19,4 +19,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.yaml
@@ -20,4 +20,3 @@ supported:
   - gpio
   - pwm
   - uart
-vendor: nxp

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.yaml
@@ -28,4 +28,3 @@ supported:
   - usb_device
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_mcxa166/frdm_mcxa166.yaml
+++ b/boards/nxp/frdm_mcxa166/frdm_mcxa166.yaml
@@ -20,4 +20,3 @@ supported:
   - watchdog
   - counter
   - dma
-vendor: nxp

--- a/boards/nxp/frdm_mcxa276/frdm_mcxa276.yaml
+++ b/boards/nxp/frdm_mcxa276/frdm_mcxa276.yaml
@@ -20,4 +20,3 @@ supported:
   - watchdog
   - counter
   - dma
-vendor: nxp

--- a/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
+++ b/boards/nxp/frdm_mcxc242/frdm_mcxc242.yaml
@@ -27,4 +27,3 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: nxp

--- a/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
+++ b/boards/nxp/frdm_mcxc444/frdm_mcxc444.yaml
@@ -27,4 +27,3 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: nxp

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
@@ -27,4 +27,3 @@ supported:
   - spi
   - watchdog
   - usb_device
-vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0.yaml
@@ -31,4 +31,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.yaml
@@ -30,4 +30,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu1.yaml
@@ -16,4 +16,3 @@ toolchain:
 supported:
   - dma
   - gpio
-vendor: nxp

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.yaml
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.yaml
@@ -13,4 +13,3 @@ supported:
   - i2c
   - pwm
   - watchdog
-vendor: nxp

--- a/boards/nxp/hexiwear/hexiwear_mkw40z4.yaml
+++ b/boards/nxp/hexiwear/hexiwear_mkw40z4.yaml
@@ -10,4 +10,3 @@ toolchain:
 testing:
   ignore_tags:
     - net
-vendor: nxp

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53.yaml
@@ -20,4 +20,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.yaml
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_a53_smp.yaml
@@ -19,4 +19,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_m4.yaml
+++ b/boards/nxp/imx8mm_evk/imx8mm_evk_mimx8mm6_m4.yaml
@@ -18,4 +18,3 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53.yaml
@@ -20,4 +20,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.yaml
+++ b/boards/nxp/imx8mn_evk/imx8mn_evk_mimx8mn6_a53_smp.yaml
@@ -19,4 +19,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53.yaml
@@ -20,4 +20,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_a53_smp.yaml
@@ -19,4 +19,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_adsp.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_adsp.yaml
@@ -13,4 +13,3 @@ testing:
     - net
     - bluetooth
     - mcumgr
-vendor: nxp

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7.yaml
@@ -20,4 +20,3 @@ testing:
 supported:
   - spi
   - uart
-vendor: nxp

--- a/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7_ddr.yaml
+++ b/boards/nxp/imx8mp_evk/imx8mp_evk_mimx8ml8_m7_ddr.yaml
@@ -20,4 +20,3 @@ testing:
 supported:
   - spi
   - uart
-vendor: nxp

--- a/boards/nxp/imx8mq_evk/imx8mq_evk_mimx8mq6_m4.yaml
+++ b/boards/nxp/imx8mq_evk/imx8mq_evk_mimx8mq6_m4.yaml
@@ -17,4 +17,3 @@ testing:
   ignore_tags:
     - net
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx8qm_mek/imx8qm_mek_mimx8qm6_adsp.yaml
+++ b/boards/nxp/imx8qm_mek/imx8qm_mek_mimx8qm6_adsp.yaml
@@ -8,4 +8,3 @@ testing:
   only_tags:
     - kernel
     - sof
-vendor: nxp

--- a/boards/nxp/imx8qxp_mek/imx8qxp_mek_mimx8qx6_adsp.yaml
+++ b/boards/nxp/imx8qxp_mek/imx8qxp_mek_mimx8qx6_adsp.yaml
@@ -8,4 +8,3 @@ testing:
   only_tags:
     - kernel
     - sof
-vendor: nxp

--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
@@ -14,4 +14,3 @@ toolchain:
 ram: 1024
 supported:
   - uart
-vendor: nxp

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_a55.yaml
@@ -22,4 +22,3 @@ supported:
 testing:
   ignore_tags:
     - bluetooth
-vendor: nxp

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.yaml
@@ -13,4 +13,3 @@ flash: 128
 supported:
   - gpio
   - uart
-vendor: nxp

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33_ddr.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33_ddr.yaml
@@ -13,4 +13,3 @@ flash: 0
 supported:
   - gpio
   - uart
-vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
@@ -16,4 +16,3 @@ supported:
   - counter
   - i2c
   - uart
-vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55_smp.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55_smp.yaml
@@ -17,4 +17,3 @@ supported:
   - i2c
   - smp
   - uart
-vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7.yaml
@@ -19,4 +19,3 @@ supported:
   - pwm
   - spi
   - netif:eth
-vendor: nxp

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_m7_ddr.yaml
@@ -14,4 +14,3 @@ toolchain:
   - gnuarmemb
 supported:
   - uart
-vendor: nxp

--- a/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.yaml
+++ b/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.yaml
@@ -13,4 +13,3 @@ supported:
   - i2c
   - serial
   - eeprom
-vendor: nxp

--- a/boards/nxp/lpcxpresso51u68/lpcxpresso51u68.yaml
+++ b/boards/nxp/lpcxpresso51u68/lpcxpresso51u68.yaml
@@ -18,4 +18,3 @@ supported:
   - gpio
   - i2c
   - spi
-vendor: nxp

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m0.yaml
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m0.yaml
@@ -16,4 +16,3 @@ testing:
 toolchain:
   - zephyr
   - gnuarmemb
-vendor: nxp

--- a/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.yaml
+++ b/boards/nxp/lpcxpresso54114/lpcxpresso54114_lpc54114_m4.yaml
@@ -20,4 +20,3 @@ supported:
   - gpio
   - i2c
   - spi
-vendor: nxp

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06.yaml
@@ -16,4 +16,3 @@ supported:
   - can
   - flash
   - gpio
-vendor: nxp

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16.yaml
@@ -25,4 +25,3 @@ supported:
   - spi
   - usb_device
   - usbd
-vendor: nxp

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.yaml
@@ -24,4 +24,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -22,4 +22,3 @@ supported:
   - pwm
   - usb_device
   - usbd
-vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.yaml
@@ -28,4 +28,3 @@ supported:
   - sdhc
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0_ns.yaml
@@ -21,4 +21,3 @@ supported:
   - gpio
   - spi
   - watchdog
-vendor: nxp

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu1.yaml
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu1.yaml
@@ -15,4 +15,3 @@ toolchain:
   - gnuarmemb
 supported:
   - gpio
-vendor: nxp

--- a/boards/nxp/ls1046ardb/ls1046ardb_ls1046a.yaml
+++ b/boards/nxp/ls1046ardb/ls1046ardb_ls1046a.yaml
@@ -6,4 +6,3 @@ toolchain:
   - zephyr
   - cross-compile
 ram: 1024
-vendor: nxp

--- a/boards/nxp/ls1046ardb/ls1046ardb_ls1046a_smp.yaml
+++ b/boards/nxp/ls1046ardb/ls1046ardb_ls1046a_smp.yaml
@@ -6,4 +6,3 @@ toolchain:
   - zephyr
   - cross-compile
 ram: 1024
-vendor: nxp

--- a/boards/nxp/ls1046ardb/ls1046ardb_ls1046a_smp_4cores.yaml
+++ b/boards/nxp/ls1046ardb/ls1046ardb_ls1046a_smp_4cores.yaml
@@ -6,4 +6,3 @@ toolchain:
   - zephyr
   - cross-compile
 ram: 1024
-vendor: nxp

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0.yaml
@@ -31,4 +31,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.yaml
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.yaml
@@ -29,4 +29,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu1.yaml
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu1.yaml
@@ -16,4 +16,3 @@ toolchain:
 supported:
   - dma
   - gpio
-vendor: nxp

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.yaml
@@ -27,4 +27,3 @@ supported:
   - i2c
   - spi
   - usb_device
-vendor: nxp

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.yaml
@@ -24,4 +24,3 @@ supported:
   - i2c
   - spi
   - usb_device
-vendor: nxp

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.yaml
@@ -26,4 +26,3 @@ supported:
   - sdhc
   - spi
   - usb_device
-vendor: nxp

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -28,4 +28,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.yaml
@@ -22,4 +22,3 @@ supported:
   - i2c
   - pwm
   - spi
-vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.yaml
@@ -29,4 +29,3 @@ supported:
   - usb_device
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.yaml
@@ -29,4 +29,3 @@ supported:
   - usb_device
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.yaml
@@ -31,4 +31,3 @@ supported:
   - usb_device
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.yaml
@@ -33,4 +33,3 @@ supported:
   - usb_device
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.yaml
@@ -30,4 +30,3 @@ supported:
   - spi
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
@@ -30,4 +30,3 @@ supported:
   - spi
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.yaml
@@ -28,4 +28,3 @@ supported:
   - uart
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.yaml
@@ -32,4 +32,3 @@ supported:
   - usb_device
   - video
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.yaml
@@ -20,4 +20,3 @@ supported:
   - i2c
   - pwm
   - uart
-vendor: nxp

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.yaml
@@ -26,4 +26,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4.yaml
@@ -19,4 +19,3 @@ supported:
   - gpio
   - i2c
   - pwm
-vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.yaml
@@ -20,4 +20,3 @@ supported:
   - i2c
   - pwm
   - spi
-vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.yaml
@@ -31,4 +31,3 @@ supported:
   - usbd
   - video
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.yaml
@@ -29,4 +29,3 @@ supported:
   - usbd
   - video
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.yaml
@@ -30,4 +30,3 @@ supported:
   - watchdog
   - usbd
   - sdhc
-vendor: nxp

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm7.yaml
@@ -27,4 +27,3 @@ supported:
   - sdhc
   - spi
   - uart
-vendor: nxp

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.yaml
@@ -29,4 +29,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_f1.yaml
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_f1.yaml
@@ -7,4 +7,3 @@ toolchain:
 testing:
   only_tags:
     - kernel
-vendor: nxp

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.yaml
@@ -32,4 +32,3 @@ supported:
   - usb_device
   - usbd
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.yaml
@@ -22,4 +22,3 @@ supported:
   - adc
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.yaml
@@ -18,4 +18,3 @@ supported:
   - gpio
   - uart
   - adc
-vendor: nxp

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi1.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi1.yaml
@@ -15,4 +15,3 @@ toolchain:
 testing:
   only_tags:
     - kernel
-vendor: nxp

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.yaml
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.yaml
@@ -15,4 +15,3 @@ toolchain:
 testing:
   only_tags:
     - kernel
-vendor: nxp

--- a/boards/nxp/mr_canhubk3/mr_canhubk3.yaml
+++ b/boards/nxp/mr_canhubk3/mr_canhubk3.yaml
@@ -23,4 +23,3 @@ supported:
   - spi
   - uart
   - watchdog
-vendor: nxp

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.yaml
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.yaml
@@ -18,4 +18,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0.yaml
@@ -20,4 +20,3 @@ supported:
   - i2c
   - dma
   - pwm
-vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu0_D.yaml
@@ -20,4 +20,3 @@ supported:
   - i2c
   - dma
   - pwm
-vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1.yaml
@@ -20,4 +20,3 @@ supported:
   - i2c
   - dma
   - pwm
-vendor: nxp

--- a/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
+++ b/boards/nxp/s32z2xxdc2/s32z2xxdc2_s32z270_rtu1_D.yaml
@@ -20,4 +20,3 @@ supported:
   - i2c
   - dma
   - pwm
-vendor: nxp

--- a/boards/nxp/twr_ke18f/twr_ke18f.yaml
+++ b/boards/nxp/twr_ke18f/twr_ke18f.yaml
@@ -18,4 +18,3 @@ supported:
   - pwm
   - spi
   - watchdog
-vendor: nxp

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.yaml
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.yaml
@@ -10,4 +10,3 @@ flash: 1024
 supported:
   - flash
   - i2c
-vendor: nxp

--- a/boards/nxp/ucans32k1sic/ucans32k1sic.yaml
+++ b/boards/nxp/ucans32k1sic/ucans32k1sic.yaml
@@ -3,7 +3,6 @@
 
 identifier: ucans32k1sic
 name: NXP UCANS32K1SIC
-vendor: nxp
 type: mcu
 arch: arm
 ram: 124

--- a/boards/nxp/usb_kw24d512/usb_kw24d512.yaml
+++ b/boards/nxp/usb_kw24d512/usb_kw24d512.yaml
@@ -11,4 +11,3 @@ supported:
   - flash
   - usb_device
   - watchdog
-vendor: nxp

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.yaml
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.yaml
@@ -27,4 +27,3 @@ supported:
   - spi
   - usb_device
   - watchdog
-vendor: nxp


### PR DESCRIPTION
As main board.yml files already have the correct board-vendor information,
there's no need to duplicate it in other .yaml files.