### PR TITLE
cmake: modules: shields: optional pre_dt_shield.cmake file

### DIFF
--- a/cmake/modules/shields.cmake
+++ b/cmake/modules/shields.cmake
@@ -93,6 +93,8 @@ if(DEFINED SHIELD)
       ${SHIELD_DIR_${s}}
       )
 
+    include(${SHIELD_DIR_${s}}/pre_dt_shield.cmake OPTIONAL)
+
     # Search for shield/shield.conf file
     if(EXISTS ${SHIELD_DIR_${s}}/${s}.conf)
       list(APPEND

--- a/doc/build/dts/intro-input-output.rst
+++ b/doc/build/dts/intro-input-output.rst
@@ -112,6 +112,9 @@ this:
 
    list(APPEND EXTRA_DTC_FLAGS "-Wno-simple_bus_reg")
 
+Shield directories can contain a file named :file:`pre_dt_shield.cmake` which
+has the same functionality as the aforementioned :file:`pre_dt_board.cmake`.
+
 .. _dt-outputs:
 
 Output files

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -19,7 +19,8 @@ under :zephyr_file:`boards/shields`:
    boards/shields/<shield>
    ├── <shield>.overlay
    ├── Kconfig.shield
-   └── Kconfig.defconfig
+   ├── Kconfig.defconfig
+   └── pre_dt_shield.cmake
 
 These files provides shield configuration as follows:
 
@@ -36,6 +37,9 @@ These files provides shield configuration as follows:
   is made to be consistent with the :ref:`default_board_configuration`. Hence,
   shield configuration should be done by keeping in mind that features
   activation is application responsibility.
+
+* **pre_dt_shield.cmake**: This optional file can be used to pass additional
+  arguments to the devicetree compiler ``dtc``.
 
 Besides, in order to avoid name conflicts with devices that may be defined at
 board level, it is advised, specifically for shields devicetree descriptions,


### PR DESCRIPTION
I have a shield that uses a I2C mux which has multiple devices with the same I2C-address connected to it. This generates devicetree warnings while building because of the duplicated addresses. Boards have the pre_dt_board.cmake file which can be used to get around this issue (and more of course), however shields lack the capability to run any cmake code before the devicetree phase. The proposed change simply includes a file called pre_dt_shield.cmake, if it exists, for each active shield.