### PR TITLE
RFC: Bluetooth: Fix building applications with Privacy without ACL or SMP

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -2529,6 +2529,7 @@ void radio_ccm_disable(void)
 	nrf_ccm_task_trigger(NRF_CCM, NRF_CCM_TASK_STOP);
 	nrf_ccm_disable(NRF_CCM);
 }
+#endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 static uint8_t MALIGN(4) _aar_scratch[3];
@@ -2659,7 +2660,6 @@ uint8_t radio_ar_resolve(const uint8_t *addr)
 
 }
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-#endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
 
 #if defined(CONFIG_BT_CTLR_DF_SUPPORT) && !defined(CONFIG_ZTEST)
 /* @brief Function configures CTE inline register to start sampling of CTE

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -63,8 +63,11 @@
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) || defined(CONFIG_BT_CTLR_BROADCAST_ISO_ENC)
 #include <hal/nrf_ccm.h>
-#include <hal/nrf_aar.h>
 #endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+#include <hal/nrf_aar.h>
+#endif /* CONFIG_BT_CTLR_PRIVACY */
 
 /* Define to reset PPI registration.
  * This has to come before the ppi/dppi includes below.

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -175,18 +175,6 @@ static inline void hal_trigger_crypt_ppi_disable(void)
 	nrf_ccm_subscribe_clear(NRF_CCM, NRF_CCM_TASK_START);
 }
 
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-/*******************************************************************************
- * Trigger automatic address resolution on Bit counter match:
- * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
- */
-static inline void hal_trigger_aar_ppi_config(void)
-{
-	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_BCMATCH, HAL_TRIGGER_AAR_PPI);
-	nrf_aar_subscribe_set(NRF_AAR, NRF_AAR_TASK_START, HAL_TRIGGER_AAR_PPI);
-}
-#endif /* CONFIG_BT_CTLR_PRIVACY */
-
 /* When hardware does not support Coded PHY we still allow the Controller
  * implementation to accept Coded PHY flags, but the Controller will use 1M
  * PHY on air. This is implementation specific feature.
@@ -228,6 +216,18 @@ static inline void hal_trigger_crypt_by_bcmatch_ppi_config(void)
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 #endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+/*******************************************************************************
+ * Trigger automatic address resolution on Bit counter match:
+ * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
+ */
+static inline void hal_trigger_aar_ppi_config(void)
+{
+	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_BCMATCH, HAL_TRIGGER_AAR_PPI);
+	nrf_aar_subscribe_set(NRF_AAR, NRF_AAR_TASK_START, HAL_TRIGGER_AAR_PPI);
+}
+#endif /* CONFIG_BT_CTLR_PRIVACY */
 
 /******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -260,19 +260,6 @@ static inline void hal_trigger_crypt_by_bcmatch_ppi_config(void)
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 
 /*******************************************************************************
- * Trigger automatic address resolution on Bit counter match:
- * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
- *
- * PPI channel 23 is pre-programmed with the following fixed settings:
- *   EEP: RADIO->EVENTS_BCMATCH
- *   TEP: AAR->TASKS_START
- */
-static inline void hal_trigger_aar_ppi_config(void)
-{
-	/* No need to configure anything for the pre-programmed channel. */
-}
-
-/*******************************************************************************
  * Trigger Radio Rate override upon Rateboost event.
  */
 #if defined(CONFIG_BT_CTLR_PHY_CODED) && defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
@@ -285,6 +272,19 @@ static inline void hal_trigger_rateoverride_ppi_config(void)
 		(uint32_t)&(NRF_CCM->TASKS_RATEOVERRIDE));
 }
 #endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
+
+/*******************************************************************************
+ * Trigger automatic address resolution on Bit counter match:
+ * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
+ *
+ * PPI channel 23 is pre-programmed with the following fixed settings:
+ *   EEP: RADIO->EVENTS_BCMATCH
+ *   TEP: AAR->TASKS_START
+ */
+static inline void hal_trigger_aar_ppi_config(void)
+{
+	/* No need to configure anything for the pre-programmed channel. */
+}
 
 /******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -295,6 +295,101 @@ config BT_FILTER_ACCEPT_LIST
 	  advertising reports.
 	  Connections can be established automatically for accepted peers.
 
+config BT_PRIVACY
+	bool "Device privacy"
+	select BT_RPA
+	help
+	  Enable privacy for the local device. This makes the device use Resolvable
+	  Private Addresses (RPAs) by default.
+
+	  Note:
+	  Establishing connections as a directed advertiser, or to a directed
+	  advertiser is only possible if the controller also supports privacy.
+
+config BT_PRIVACY_RANDOMIZE_IR
+	bool "Randomize identity root for fallback identities"
+	depends on BT_PRIVACY
+	select BT_SETTINGS
+	help
+	  Enabling this option will cause the Host to ignore controller-provided
+	  identity roots (IR). The Host will instead use bt_rand to generate
+	  identity resolving keys (IRK) and store them in the settings subsystem.
+
+	  Setting this config may come with a performance penalty to boot time,
+	  as the hardware RNG may need time to generate entropy and will block
+	  Bluetooth initialization.
+
+	  This option increases privacy, as explained in the following text.
+
+	  The IR determines the IRK of the identity. The IRK is used to both
+	  generate and resolve (recognize) the private addresses of an identity.
+	  The IRK is a shared secret, distributed to peers bonded to that
+	  identity.
+
+	  An attacker that has stolen or once bonded and retained the IRK can
+	  forever resolve addresses from that IRK, even if that bond has been
+	  deleted locally.
+
+	  Deleting an identity should ideally delete the IRK as well and thereby
+	  restore anonymity from previously bonded peers. But unless this config
+	  is set, this does not always happen.
+
+	  In particular, a factory reset function that wipes the data in the
+	  settings subsystem may not affect the controller-provided IRs. If
+	  those IRs are reused, this device can be tracked across factory resets.
+
+	  For optimal privacy, a new IRK (i.e., identity) should be used per
+	  bond. However, this naturally limits advertisements from that identity
+	  to be recognizable by only that one bonded device.
+
+	  A description of the exact effect of this setting follows.
+
+	  If the application has not setup an identity before calling
+	  settings_load()/settings_load_subtree("bt") after bt_enable(), the
+	  Host will automatically try to load saved identities from the settings
+	  subsystem, and if there are none, set up the default identity
+	  (BT_ID_DEFAULT).
+
+	  If the controller has a public address (HCI_Read_BD_ADDR), that becomes
+	  the address of the default identity. The Host will by default try to
+	  obtain the IR for that identity from the controller (by Zephyr HCI
+	  Read_Key_Hierarchy_Roots). Setting this config randomizes the IR
+	  instead.
+
+	  If the controller does not have a public address, the Host will try
+	  to source the default identity from the static address information
+	  from controller (Zephyr HCI Read_Static_Addresses). This results in an
+	  identity for each entry in Read_Static_Addresses. Setting this config
+	  randomizes the IRs during this process.
+
+config BT_RPA_TIMEOUT
+	int "Resolvable Private Address timeout"
+	depends on BT_PRIVACY
+	default 900
+	range 1 $(UINT16_MAX)
+	help
+	  This option defines how often resolvable private address is rotated.
+	  Value is provided in seconds and defaults to 900 seconds (15 minutes).
+
+config BT_RPA_TIMEOUT_DYNAMIC
+	bool "Support setting the Resolvable Private Address timeout at runtime"
+	depends on BT_PRIVACY
+	help
+	  This option allows the user to override the default value of
+	  the Resolvable Private Address timeout using dedicated APIs.
+
+config BT_RPA_SHARING
+	bool "Share the Resolvable Private Address between advertising sets"
+	depends on BT_PRIVACY && BT_EXT_ADV
+	help
+	  This option configures the advertising sets linked with the same
+	  Bluetooth identity to use the same Resolvable Private Address in
+	  a given rotation period. After the RPA timeout, the new RPA is
+	  generated and shared between the advertising sets in the subsequent
+	  rotation period. When this option is disabled, the generated RPAs
+	  of the advertising sets differ from each other in a given rotation
+	  period.
+
 config BT_LIM_ADV_TIMEOUT
 	int "Timeout for limited advertising in 1s units"
 	default 30
@@ -437,100 +532,6 @@ config BT_PASSKEY_KEYPRESS
 	help
 	  Enable support for receiving and sending Keypress Notifications during
 	  Passkey Entry during pairing.
-
-config BT_PRIVACY
-	bool "Device privacy"
-	help
-	  Enable privacy for the local device. This makes the device use Resolvable
-	  Private Addresses (RPAs) by default.
-
-	  Note:
-	  Establishing connections as a directed advertiser, or to a directed
-	  advertiser is only possible if the controller also supports privacy.
-
-config BT_PRIVACY_RANDOMIZE_IR
-	bool "Randomize identity root for fallback identities"
-	depends on BT_PRIVACY
-	select BT_SETTINGS
-	help
-	  Enabling this option will cause the Host to ignore controller-provided
-	  identity roots (IR). The Host will instead use bt_rand to generate
-	  identity resolving keys (IRK) and store them in the settings subsystem.
-
-	  Setting this config may come with a performance penalty to boot time,
-	  as the hardware RNG may need time to generate entropy and will block
-	  Bluetooth initialization.
-
-	  This option increases privacy, as explained in the following text.
-
-	  The IR determines the IRK of the identity. The IRK is used to both
-	  generate and resolve (recognize) the private addresses of an identity.
-	  The IRK is a shared secret, distributed to peers bonded to that
-	  identity.
-
-	  An attacker that has stolen or once bonded and retained the IRK can
-	  forever resolve addresses from that IRK, even if that bond has been
-	  deleted locally.
-
-	  Deleting an identity should ideally delete the IRK as well and thereby
-	  restore anonymity from previously bonded peers. But unless this config
-	  is set, this does not always happen.
-
-	  In particular, a factory reset function that wipes the data in the
-	  settings subsystem may not affect the controller-provided IRs. If
-	  those IRs are reused, this device can be tracked across factory resets.
-
-	  For optimal privacy, a new IRK (i.e., identity) should be used per
-	  bond. However, this naturally limits advertisements from that identity
-	  to be recognizable by only that one bonded device.
-
-	  A description of the exact effect of this setting follows.
-
-	  If the application has not setup an identity before calling
-	  settings_load()/settings_load_subtree("bt") after bt_enable(), the
-	  Host will automatically try to load saved identities from the settings
-	  subsystem, and if there are none, set up the default identity
-	  (BT_ID_DEFAULT).
-
-	  If the controller has a public address (HCI_Read_BD_ADDR), that becomes
-	  the address of the default identity. The Host will by default try to
-	  obtain the IR for that identity from the controller (by Zephyr HCI
-	  Read_Key_Hierarchy_Roots). Setting this config randomizes the IR
-	  instead.
-
-	  If the controller does not have a public address, the Host will try
-	  to source the default identity from the static address information
-	  from controller (Zephyr HCI Read_Static_Addresses). This results in an
-	  identity for each entry in Read_Static_Addresses. Setting this config
-	  randomizes the IRs during this process.
-
-config BT_RPA_TIMEOUT
-	int "Resolvable Private Address timeout"
-	depends on BT_PRIVACY
-	default 900
-	range 1 $(UINT16_MAX)
-	help
-	  This option defines how often resolvable private address is rotated.
-	  Value is provided in seconds and defaults to 900 seconds (15 minutes).
-
-config BT_RPA_TIMEOUT_DYNAMIC
-	bool "Support setting the Resolvable Private Address timeout at runtime"
-	depends on BT_PRIVACY
-	help
-	  This option allows the user to override the default value of
-	  the Resolvable Private Address timeout using dedicated APIs.
-
-config BT_RPA_SHARING
-	bool "Share the Resolvable Private Address between advertising sets"
-	depends on BT_PRIVACY && BT_EXT_ADV
-	help
-	  This option configures the advertising sets linked with the same
-	  Bluetooth identity to use the same Resolvable Private Address in
-	  a given rotation period. After the RPA timeout, the new RPA is
-	  generated and shared between the advertising sets in the subsequent
-	  rotation period. When this option is disabled, the generated RPAs
-	  of the advertising sets differ from each other in a given rotation
-	  period.
 
 config BT_SIGNING
 	bool "Data signing support"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3810,7 +3810,7 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 
 	create_param_setup(create_param);
 
-#if defined(CONFIG_BT_SMP)
+#if defined(CONFIG_BT_PRIVACY)
 	if (bt_dev.le.rl_entries > bt_dev.le.rl_size) {
 		/* Use host-based identity resolving. */
 		bt_conn_set_state(conn, BT_CONN_SCAN_BEFORE_INITIATING);
@@ -3827,7 +3827,7 @@ int bt_conn_le_create(const bt_addr_le_t *peer, const struct bt_conn_le_create_p
 		*ret_conn = conn;
 		return 0;
 	}
-#endif
+#endif /* defined(CONFIG_BT_PRIVACY) */
 
 	bt_conn_set_state(conn, BT_CONN_INITIATING);
 

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -296,23 +296,26 @@ struct bt_dev_le {
 	uint16_t		acl_mtu;
 	struct k_sem		acl_pkts;
 #endif /* CONFIG_BT_CONN */
+
 #if defined(CONFIG_BT_ISO)
 	uint16_t		iso_mtu;
 	uint8_t			iso_limit;
 	struct k_sem		iso_pkts;
 #endif /* CONFIG_BT_ISO */
+
 #if defined(CONFIG_BT_BROADCASTER)
 	uint16_t max_adv_data_len;
 #endif /* CONFIG_BT_BROADCASTER */
 
-#if defined(CONFIG_BT_SMP)
+#if defined(CONFIG_BT_PRIVACY)
 	/* Size of the controller resolving list */
 	uint8_t                    rl_size;
 	/* Number of entries in the resolving list. rl_entries > rl_size
 	 * means that host-side resolving is used.
 	 */
 	uint8_t                    rl_entries;
-#endif /* CONFIG_BT_SMP */
+#endif /* CONFIG_BT_PRIVACY */
+
 	/* List of `struct bt_conn` that have either pending data to send, or
 	 * something to process (e.g. a disconnection event).
 	 *

--- a/subsys/bluetooth/host/id.h
+++ b/subsys/bluetooth/host/id.h
@@ -38,6 +38,9 @@ int bt_id_init(void);
 
 uint8_t bt_id_read_public_addr(bt_addr_le_t *addr);
 
+/** Generate IRK from Identity Root (IR) */
+int bt_id_irk_get(uint8_t *ir, uint8_t *irk);
+
 int bt_id_set_create_conn_own_addr(bool use_filter, uint8_t *own_addr_type);
 
 int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type);

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5203,36 +5203,6 @@ int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf)
 }
 #endif /* CONFIG_BT_SIGNING */
 
-static int smp_d1(const uint8_t *key, uint16_t d, uint16_t r, uint8_t res[16])
-{
-	int err;
-
-	LOG_DBG("key %s d %u r %u", bt_hex(key, 16), d, r);
-
-	sys_put_le16(d, &res[0]);
-	sys_put_le16(r, &res[2]);
-	memset(&res[4], 0, 16 - 4);
-
-	err = bt_encrypt_le(key, res, res);
-	if (err) {
-		return err;
-	}
-
-	LOG_DBG("res %s", bt_hex(res, 16));
-	return 0;
-}
-
-int bt_smp_irk_get(uint8_t *ir, uint8_t *irk)
-{
-	uint8_t invalid_ir[16] = { 0 };
-
-	if (!memcmp(ir, invalid_ir, 16)) {
-		return -EINVAL;
-	}
-
-	return smp_d1(ir, 1, 0, irk);
-}
-
 #if defined(CONFIG_BT_SMP_SELFTEST)
 /* Test vectors are taken from RFC 4493
  * https://tools.ietf.org/html/rfc4493

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -187,9 +187,6 @@ int bt_smp_sign_verify(struct bt_conn *conn, struct net_buf *buf);
  */
 int bt_smp_sign(struct bt_conn *conn, struct net_buf *buf);
 
-/** Generate IRK from Identity Root (IR) */
-int bt_smp_irk_get(uint8_t *ir, uint8_t *irk);
-
 /** Converts a SMP error to string.
  *
  * The error codes are described in the Bluetooth Core specification,

--- a/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
+++ b/tests/bsim/bluetooth/compile.nrf54l15bsim_nrf54l15_cpuapp.sh
@@ -13,6 +13,9 @@ export BOARD="${BOARD:-nrf54l15bsim/nrf54l15/cpuapp}"
 
 source ${ZEPHYR_BASE}/tests/bsim/compile.source
 
+app=tests/bsim/bluetooth/ll/advx compile
+app=tests/bsim/bluetooth/ll/advx conf_overlay=overlay-ticker_expire_info.conf compile
+app=tests/bsim/bluetooth/ll/advx conf_overlay=overlay-scan_aux_use_chains.conf compile
 app=tests/bsim/bluetooth/ll/throughput compile
 app=tests/bsim/bluetooth/ll/multiple_id compile
 app=tests/bsim/bluetooth/ll/bis conf_overlay=overlay-sequential.conf compile

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx.sh
@@ -13,10 +13,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_advx_prj_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=advx
+  -v=${verbosity_level} -s=${simulation_id} -RealEncryption=1 -d=0 -testid=advx
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_advx_prj_conf\
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=scanx
+  -v=${verbosity_level} -s=${simulation_id} -RealEncryption=1 -d=1 -testid=scanx
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_scan_aux_use_chains.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_scan_aux_use_chains.sh
@@ -13,10 +13,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_advx_prj_conf_overlay-scan_aux_use_chains_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=advx
+  -v=${verbosity_level} -s=${simulation_id} -RealEncryption=1 -d=0 -testid=advx
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_advx_prj_conf_overlay-scan_aux_use_chains_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=scanx
+  -v=${verbosity_level} -s=${simulation_id} -RealEncryption=1 -d=1 -testid=scanx
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_ticker_expire_info.sh
+++ b/tests/bsim/bluetooth/ll/advx/tests_scripts/basic_advx_ticker_expire_info.sh
@@ -13,10 +13,10 @@ EXECUTE_TIMEOUT=120
 cd ${BSIM_OUT_PATH}/bin
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_advx_prj_conf_overlay-ticker_expire_info_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=advx
+  -v=${verbosity_level} -s=${simulation_id} -RealEncryption=1 -d=0 -testid=advx
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_ll_advx_prj_conf_overlay-ticker_expire_info_conf \
-  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=scanx
+  -v=${verbosity_level} -s=${simulation_id} -RealEncryption=1 -d=1 -testid=scanx
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
   -D=2 -sim_length=60e6 $@

--- a/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
+++ b/tests/bsim/bluetooth/tests.nrf54l15bsim_nrf54l15_cpuapp.txt
@@ -1,5 +1,6 @@
 # Search paths(s) for tests which will be run in the nrf54l15 app core
 # This file is used in CI to select which tests are run
+tests/bsim/bluetooth/ll/advx/
 tests/bsim/bluetooth/ll/throughput/
 tests/bsim/bluetooth/ll/multiple_id/
 tests/bsim/bluetooth/ll/bis/tests_scripts/broadcast_iso_interleaved.sh


### PR DESCRIPTION
Update Host implementation so that Host can use the Controller Privacy feature to generate Advertising Resolvable Private
Address without enabling ACL Connection and Security Manager Protocol support in application builds.

Fix building Controller with Privacy feature without enabling LE Encryption support. This should allow being either Observer or Broadcaster role with Privacy features.

From https://github.com/zephyrproject-rtos/zephyr/pull/89408#discussion_r2129087202
As a developer of an LE Audio Auracast transmitter would like to use unique Identity Root and unique Identity Address in every nRF SoC to advertise using resolvable private address. My Auracast receivers (plural) are programmed with my transmitter's unique Identity Address and Identity Resolution Key as peer Id address and peer IRK, respectively, such that using filter accept list will enable the receiver's Controller implement to perform periodic advertising sync without the Host needing to receive redundant advertising reports of other devices in the vicinity. 

