### PR TITLE
drivers: gpio: sn74hc595: fix terminology for GPIO expander

### DIFF
--- a/drivers/gpio/Kconfig.sn74hc595
+++ b/drivers/gpio/Kconfig.sn74hc595
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config GPIO_SN74HC595
-	bool "SN74HC595 shift register as GPIO extender"
+	bool "SN74HC595 shift register as GPIO expander"
 	default y
 	depends on DT_HAS_TI_SN74HC595_ENABLED
 	depends on SPI
 	help
-	  Use SN74HC595 as GPIO extender
+	  Use SN74HC595 as GPIO expander
 
 if GPIO_SN74HC595
 


### PR DESCRIPTION
The Kconfig help text for the SN74HC595 driver refers to the device as a "GPIO extender", which is inconsistent with the devicetree binding file (ti,sn74hc595.yaml) that describes it as a "GPIO expander".