### PR TITLE
dtlib: add file/line information to generated DTS files

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -290,11 +290,21 @@ set_property(DIRECTORY APPEND PROPERTY
 # Run GEN_EDT_SCRIPT.
 #
 
+if(WEST_TOPDIR)
+  set(GEN_EDT_WORKSPACE_DIR ${WEST_TOPDIR})
+else()
+  # If West is not available, define the parent directory of ZEPHYR_BASE as
+  # the workspace. This will create comments that reference the files in the
+  # Zephyr tree with a 'zephyr/' prefix.
+  set(GEN_EDT_WORKSPACE_DIR ${ZEPHYR_BASE}/..)
+endif()
+
 string(REPLACE ";" " " EXTRA_DTC_FLAGS_RAW "${EXTRA_DTC_FLAGS}")
 set(CMD_GEN_EDT ${PYTHON_EXECUTABLE} ${GEN_EDT_SCRIPT}
 --dts ${DTS_POST_CPP}
 --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
 --bindings-dirs ${DTS_ROOT_BINDINGS}
+--workspace-dir ${GEN_EDT_WORKSPACE_DIR}
 --dts-out ${ZEPHYR_DTS}.new # for debugging and dtc
 --edt-pickle-out ${EDT_PICKLE}.new
 ${EXTRA_GEN_EDT_ARGS}

--- a/scripts/dts/gen_edt.py
+++ b/scripts/dts/gen_edt.py
@@ -43,6 +43,7 @@ def main():
 
     try:
         edt = edtlib.EDT(args.dts, args.bindings_dirs,
+                         workspace_dir=args.workspace_dir,
                          # Suppress this warning if it's suppressed in dtc
                          warn_reg_unit_address_mismatch=
                              "-Wno-simple_bus_reg" not in args.dtc_flags,
@@ -71,6 +72,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--bindings-dirs", nargs='+', required=True,
                         help="directory with bindings in YAML format, "
                         "we allow multiple")
+    parser.add_argument("--workspace-dir", default=os.getcwd(),
+                        help="directory to be used as reference for generated "
+                        "relative paths (e.g. WEST_TOPDIR)")
     parser.add_argument("--dts-out", required=True,
                         help="path to write merged DTS source code to (e.g. "
                              "as a debugging aid)")

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -1415,7 +1415,7 @@ class DT:
             prop._add_marker(_MarkerType.LABEL, tok.val)
             self._next_token()
 
-    def _node_phandle(self, node):
+    def _node_phandle(self, node, src_prop):
         # Returns the phandle for Node 'node', creating a new phandle if the
         # node has no phandle, and fixing up the value for existing
         # self-referential phandles (which get set to b'\0\0\0\0' initially).
@@ -1435,6 +1435,8 @@ class DT:
                 phandle_i += 1
             self.phandle2node[phandle_i] = node
 
+            phandle_prop.filename = src_prop.filename
+            phandle_prop.lineno = src_prop.lineno
             phandle_prop.value = phandle_i.to_bytes(4, "big")
             node.props["phandle"] = phandle_prop
 
@@ -1878,7 +1880,7 @@ class DT:
                         if marker_type is _MarkerType.PATH:
                             res += ref_node.path.encode("utf-8") + b'\0'
                         else:  # marker_type is PHANDLE
-                            res += self._node_phandle(ref_node)
+                            res += self._node_phandle(ref_node, prop)
                             # Skip over the dummy phandle placeholder
                             pos += 4
 

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -207,7 +207,7 @@ class Node:
             # a relative path cannot be established (on Windows with files
             # in different drives, for example).
             try:
-                return os.path.relpath(filename, start=os.getcwd())
+                return os.path.relpath(filename, start=self.dt._base_dir)
             except ValueError:
                 return filename
 
@@ -787,7 +787,7 @@ class DT:
     #
 
     def __init__(self, filename: Optional[str], include_path: Iterable[str] = (),
-                 force: bool = False):
+                 force: bool = False, base_dir: Optional[str] = None):
         """
         Parses a DTS file to create a DT instance. Raises OSError if 'filename'
         can't be opened, and DTError for any parse errors.
@@ -804,6 +804,11 @@ class DT:
         force:
           Try not to raise DTError even if the input tree has errors.
           For experimental use; results not guaranteed.
+
+        base_dir:
+          Path to the directory that is to be used as the reference for
+          the generated relative paths in comments. When not provided, the
+          current working directory is used.
         """
         # Remember to update __deepcopy__() if you change this.
 
@@ -817,6 +822,7 @@ class DT:
         self.filename = filename
 
         self._force = force
+        self._base_dir = base_dir or os.getcwd()
 
         if filename is not None:
             self._parse_file(filename, include_path)
@@ -974,7 +980,7 @@ class DT:
         """
 
         # We need a new DT, obviously. Make a new, empty one.
-        ret = DT(None, (), self._force)
+        ret = DT(None, (), self._force, self._base_dir)
 
         # Now allocate new Node objects for every node in self, to use
         # in the new DT. Set their parents to None for now and leave

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -207,7 +207,8 @@ class Node:
         s += f"{self.name} {{\n"
 
         for prop in self.props.values():
-            s += "\t" + str(prop) + "\n"
+            prop_str = textwrap.indent(str(prop), "\t")
+            s += prop_str + "\n"
 
         for child in self.nodes.values():
             s += textwrap.indent(child.__str__(), "\t") + "\n"
@@ -588,6 +589,7 @@ class Property:
             return s + ";"
 
         s += " ="
+        newline = "\n" + " " * len(s)
 
         for i, (pos, marker_type, ref) in enumerate(self._markers):
             if i < len(self._markers) - 1:
@@ -602,11 +604,11 @@ class Property:
                 # end - 1 to strip off the null terminator
                 s += f' "{_decode_and_escape(self.value[pos:end - 1])}"'
                 if end != len(self.value):
-                    s += ","
+                    s += f",{newline}"
             elif marker_type is _MarkerType.PATH:
                 s += " &" + ref
                 if end != len(self.value):
-                    s += ","
+                    s += f",{newline}"
             else:
                 # <> or []
 
@@ -638,7 +640,7 @@ class Property:
 
                     s += _N_BYTES_TO_END_STR[elm_size]
                     if pos != len(self.value):
-                        s += ","
+                        s += f",{newline}"
 
         return s + ";"
 

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -945,15 +945,15 @@ class DT:
         Returns a DTS representation of the devicetree. Called automatically if
         the DT instance is print()ed.
         """
-        s = "/dts-v1/;\n\n"
+        s = "/dts-v1/;\n"
 
         if self.memreserves:
+            s += "\n"
             for labels, address, offset in self.memreserves:
                 # List the labels in a consistent order to help with testing
                 for label in labels:
                     s += f"{label}: "
                 s += f"/memreserve/ {address:#018x} {offset:#018x};\n"
-            s += "\n"
 
         return s + str(self.root)
 

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1993,6 +1993,7 @@ class EDT:
     def __init__(self,
                  dts: Optional[str],
                  bindings_dirs: list[str],
+                 workspace_dir: Optional[str] = None,
                  warn_reg_unit_address_mismatch: bool = True,
                  default_prop_types: bool = True,
                  support_fixed_partitions_on_any_bus: bool = True,
@@ -2008,6 +2009,10 @@ class EDT:
         bindings_dirs:
           List of paths to directories containing bindings, in YAML format.
           These directories are recursively searched for .yaml files.
+
+        workspace_dir:
+          Path to the root of the Zephyr workspace. This is used as a base
+          directory for relative paths in the generated devicetree comments.
 
         warn_reg_unit_address_mismatch (default: True):
           If True, a warning is logged if a node has a 'reg' property where
@@ -2077,7 +2082,7 @@ class EDT:
 
         if dts is not None:
             try:
-                self._dt = DT(dts)
+                self._dt = DT(dts, base_dir=workspace_dir)
             except DTError as e:
                 raise EDTError(e) from e
             self._finish_init()

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -2538,7 +2538,7 @@ def test_filename_and_lineno():
             f.write('''/* a new node */
 / {
 	node1: test-node1 {
-		prop1A = "value1A";
+		prop1A = "short value 1A";
 	};
 };
 ''')
@@ -2551,17 +2551,17 @@ def test_filename_and_lineno():
 
 / {
 	node2: test-node2 {
-		prop2A = "value2A";
-		prop2B = "value2B";
+		prop2A = "value 2A";
+		prop2B = "multi", "line", "value", "2B";
 	};
 };
 
 &node1 {
-	prop1B = "value1B";
+	prop1B = "longer value 1B";
 };
 ''')
 
-        dt = dtlib.DT(main_file, include_path=[tmpdir])
+        dt = dtlib.DT(main_file, include_path=[tmpdir], base_dir=tmpdir)
 
         test_node2 = dt.get_node('/test-node2')
         prop2A = test_node2.props['prop2A']
@@ -2584,3 +2584,27 @@ def test_filename_and_lineno():
         assert prop1A.lineno == 4
         assert os.path.samefile(prop1B.filename, main_file)
         assert prop1B.lineno == 13
+
+        # Test contents and alignment of the generated file comments
+        assert str(dt) == '''
+/dts-v1/;
+
+/* node '/' defined in included.dtsi:2 */
+/ {
+
+	/* node '/test-node1' defined in included.dtsi:3 */
+	node1: test-node1 {
+		prop1A = "short value 1A";  /* in included.dtsi:4 */
+		prop1B = "longer value 1B"; /* in test_with_include.dts:13 */
+	};
+
+	/* node '/test-node2' defined in test_with_include.dts:6 */
+	node2: test-node2 {
+		prop2A = "value 2A"; /* in test_with_include.dts:7 */
+		prop2B = "multi",
+		         "line",
+		         "value",
+		         "2B";       /* in test_with_include.dts:8 */
+	};
+};
+'''[1:-1]

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -26,6 +26,17 @@ from devicetree import dtlib
 #   - to run a particular test function or functions, use
 #     '-k test_function_pattern_goes_here'
 
+def uncomment(dts):
+    '''Trim added comments from a DT string.'''
+
+    # remove node comments, including leading empty line
+    dts = re.sub(r'\n\n[ \t]*/\*.*?\*/\n', '\n', dts, flags=re.DOTALL)
+
+    # remove property comments
+    dts = re.sub(r'[ \t]*/\*.*?\*/\n', '\n', dts)
+
+    return dts
+
 def parse(dts, include_path=(), **kwargs):
     '''Parse a DTS string 'dts', using the given include path.
 
@@ -48,7 +59,7 @@ def verify_parse(dts, expected, include_path=()):
 
     dt = parse(dts[1:], include_path)
 
-    actual = str(dt)
+    actual = uncomment(str(dt))
     expected = expected[1:-1]
     assert actual == expected, f'unexpected round-trip on {dts}'
 
@@ -1029,7 +1040,7 @@ def test_include_curdir(tmp_path):
 };
 """)
         dt = dtlib.DT("test.dts")
-        assert str(dt) == """
+        assert uncomment(str(dt)) == """
 /dts-v1/;
 
 / {
@@ -1086,7 +1097,7 @@ y /include/ "via-include-path-1"
 	y = < 0x2 >;
 };
 """[1:-1]
-    assert str(dt) == expected_dt
+    assert uncomment(str(dt)) == expected_dt
 
 def test_include_misc(tmp_path):
     '''Miscellaneous /include/ tests.'''

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -30,7 +30,9 @@ def uncomment(dts):
     '''Trim added comments from a DT string.'''
 
     # remove node comments, including leading empty line
+    # but keep the one before the root node
     dts = re.sub(r'\n\n[ \t]*/\*.*?\*/\n', '\n', dts, flags=re.DOTALL)
+    dts = re.sub(r'\n/ {\n', r'\n\n/ {\n', dts)
 
     # remove property comments
     dts = re.sub(r'[ \t]*/\*.*?\*/\n', '\n', dts)

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -530,7 +530,9 @@ def test_property_offset_labels():
 /dts-v1/;
 
 / {
-	a = l01: l02: < l03: &node l04: l05: 0x2 l06: l07: l08: >, [ l09: 03 l10: l11: 04 l12: l13: l14: ], "A";
+	a = l01: l02: < l03: &node l04: l05: 0x2 l06: l07: l08: >,
+	    [ l09: 03 l10: l11: 04 l12: l13: l14: ],
+	    "A";
 	b = < 0x0 l23: l24: >;
 	node: node {
 		phandle = < 0x1 >;
@@ -610,8 +612,11 @@ def test_node_path_references():
 
 / {
 	a = &label;
-	b = [ 01 ], &label;
-	c = [ 01 ], &label, < 0x2 >;
+	b = [ 01 ],
+	    &label;
+	c = [ 01 ],
+	    &label,
+	    < 0x2 >;
 	d = &{/abc};
 	label: abc {
 		e = &label;
@@ -867,7 +872,12 @@ def test_mixed_assign():
 /dts-v1/;
 
 / {
-	x = [ FF FF ], &abc, < 0xff &abc 0xff &abc >, &abc, [ FF FF ], "abc";
+	x = [ FF FF ],
+	    &abc,
+	    < 0xff &abc 0xff &abc >,
+	    &abc,
+	    [ FF FF ],
+	    "abc";
 	abc: abc {
 		phandle = < 0x1 >;
 	};
@@ -1180,7 +1190,8 @@ def test_omit_if_no_ref():
 /dts-v1/;
 
 / {
-	x = < &{/referenced} >, &referenced2;
+	x = < &{/referenced} >,
+	    &referenced2;
 	referenced {
 		phandle = < 0x1 >;
 	};
@@ -1775,7 +1786,7 @@ def test_prop_type_casting():
         "strings",
         "expected property 'strings' on / in .* to be assigned with " +
         re.escape("'strings = \"string\";', ")+
-        re.escape("not 'strings = \"foo\", \"bar\", \"baz\";'"))
+        "not 'strings = \"foo\",\\s*\"bar\",\\s*\"baz\";'")
     verify_to_string_error_matches(
         "invalid_string",
         re.escape(r"value of property 'invalid_string' (b'\xff\x00') on / ") +
@@ -2076,7 +2087,9 @@ def test_duplicate_labels():
 
 / {
 	label: foo {
-		x = &{/foo}, &label, < &label >;
+		x = &{/foo},
+		    &label,
+		    < &label >;
 		phandle = < 0x1 >;
 	};
 };
@@ -2175,7 +2188,8 @@ def test_names():
 /dts-v1/;
 
 / {
-	aA0,._+*#?- = &_, &{/aA0,._+@-};
+	aA0,._+*#?- = &_,
+	              &{/aA0,._+@-};
 	+ = [ 00 ];
 	* = [ 02 ];
 	- = [ 01 ];
@@ -2232,7 +2246,9 @@ def test_dense_input():
 / {
 	l1: l2: foo {
 		l3: l4: bar {
-			l5: x = l6: [ l7: 01 l8: 02 l9: ], [ 03 ], "a";
+			l5: x = l6: [ l7: 01 l8: 02 l9: ],
+			        [ 03 ],
+			        "a";
 		};
 	};
 };

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: d4f9036a88e53080bf2b186afa5289f9c77a0f73
+      revision: 615b2b76f18427f7fa6ec2bf765aeed1994dc64e
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
The goal of this PR is to augment the auto-generated `zephyr.dts` file with comments detailing the source files that are responsible for each property or node definition. 

I have continued the work made by @kartben in #80698 and added a few extra features:

- generated array properties with one item per line, to avoid unreadable comment blocks after extra long lines;
- added file:line information for the `phandle` property that refers to (one of) the actual references to the node;
- filtered the comments in the test suite so that only actual code is compared;
- used the West workspace dir (or the parent of ZEPHYR_BASE if West is not available) as the reference for the relative paths in comments.

<details><summary>Click here for the DTS generated for reel_board by compiling samples/net/wifi/shell</summary>

```c
/dts-v1/;

/* node '/' defined in zephyr/dts/common/skeleton.dtsi:9 */
/ {
        #address-cells = < 0x1 >;         /* in zephyr/dts/common/skeleton.dtsi:10 */
        #size-cells = < 0x1 >;            /* in zephyr/dts/common/skeleton.dtsi:11 */
        model = "reel board";             /* in zephyr/boards/phytec/reel_board/reel_board.dts:14 */
        compatible = "phytec,reel_board"; /* in zephyr/boards/phytec/reel_board/reel_board.dts:15 */

        /* node '/chosen' defined in zephyr/dts/common/skeleton.dtsi:12 */
        chosen {
                zephyr,bt-hci = &bt_hci_controller;          /* in zephyr/dts/arm/nordic/nrf52840.dtsi:10 */
                zephyr,entropy = &rng;                       /* in zephyr/dts/arm/nordic/nrf52840.dtsi:11 */
                zephyr,flash-controller = &flash_controller; /* in zephyr/dts/arm/nordic/nrf52840.dtsi:12 */
                zephyr,sram = &sram0;                        /* in zephyr/boards/phytec/reel_board/reel_board.dts:23 */
                zephyr,flash = &flash0;                      /* in zephyr/boards/phytec/reel_board/reel_board.dts:24 */
                zephyr,code-partition = &slot0_partition;    /* in zephyr/boards/phytec/reel_board/reel_board.dts:25 */
                zephyr,ieee802154 = &ieee802154;             /* in zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:14 */
                zephyr,console = &uart0;                     /* in zephyr/boards/phytec/reel_board/reel_board.dts:18 */
                zephyr,shell-uart = &uart0;                  /* in zephyr/boards/phytec/reel_board/reel_board.dts:19 */
                zephyr,uart-mcumgr = &uart0;                 /* in zephyr/boards/phytec/reel_board/reel_board.dts:20 */
                zephyr,bt-mon-uart = &uart0;                 /* in zephyr/boards/phytec/reel_board/reel_board.dts:21 */
                zephyr,bt-c2h-uart = &uart0;                 /* in zephyr/boards/phytec/reel_board/reel_board.dts:22 */
                zephyr,display = &ssd16xx;                   /* in zephyr/boards/phytec/reel_board/reel_board.dts:26 */
        };

        [...]

        /* node '/soc' defined in zephyr/dts/arm/armv7-m.dtsi:6 */
        soc {
                #address-cells = < 0x1 >;             /* in zephyr/dts/arm/armv7-m.dtsi:7 */
                #size-cells = < 0x1 >;                /* in zephyr/dts/arm/armv7-m.dtsi:8 */
                compatible = "nordic,nrf52840-qiaa",
                             "nordic,nrf52840",
                             "nordic,nrf52",
                             "simple-bus";            /* in zephyr/dts/arm/nordic/nrf52840_qiaa.dtsi:29 */
                interrupt-parent = < &nvic >;         /* in zephyr/dts/arm/armv7-m.dtsi:10 */
                ranges;                               /* in zephyr/dts/arm/armv7-m.dtsi:11 */

                /* node '/soc/interrupt-controller@e000e100' defined in zephyr/dts/arm/armv7-m.dtsi:13 */
                nvic: interrupt-controller@e000e100 {
                        #address-cells = < 0x1 >;            /* in zephyr/dts/arm/armv7-m.dtsi:14 */
                        compatible = "arm,v7m-nvic";         /* in zephyr/dts/arm/armv7-m.dtsi:15 */
                        reg = < 0xe000e100 0xc00 >;          /* in zephyr/dts/arm/armv7-m.dtsi:16 */
                        interrupt-controller;                /* in zephyr/dts/arm/armv7-m.dtsi:17 */
                        #interrupt-cells = < 0x2 >;          /* in zephyr/dts/arm/armv7-m.dtsi:18 */
                        arm,num-irq-priority-bits = < 0x3 >; /* in zephyr/dts/arm/nordic/nrf52840.dtsi:572 */
                        phandle = < 0x1 >;                   /* in zephyr/dts/arm/armv7-m.dtsi:10 */
                };

                [...]
        
                /* node '/soc/spi@4002f000' defined in zephyr/dts/arm/nordic/nrf52840.dtsi:525 */
                spi3: arduino_spi: spi@4002f000 {
                        compatible = "nordic,nrf-spim";    /* in zephyr/dts/arm/nordic/nrf52840.dtsi:526 */
                        #address-cells = < 0x1 >;          /* in zephyr/dts/arm/nordic/nrf52840.dtsi:527 */
                        #size-cells = < 0x0 >;             /* in zephyr/dts/arm/nordic/nrf52840.dtsi:528 */
                        reg = < 0x4002f000 0x1000 >;       /* in zephyr/dts/arm/nordic/nrf52840.dtsi:529 */
                        interrupts = < 0x2f 0x1 >;         /* in zephyr/dts/arm/nordic/nrf52840.dtsi:530 */
                        max-frequency = < 0x1e84800 >;     /* in zephyr/dts/arm/nordic/nrf52840.dtsi:531 */
                        easydma-maxcnt-bits = < 0x10 >;    /* in zephyr/dts/arm/nordic/nrf52840.dtsi:532 */
                        rx-delay-supported;                /* in zephyr/dts/arm/nordic/nrf52840.dtsi:533 */
                        rx-delay = < 0x2 >;                /* in zephyr/dts/arm/nordic/nrf52840.dtsi:534 */
                        status = "ok";                     /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:27 */
                        cs-gpios = < &gpio1 0x3 0x1 >;     /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:28 */
                        pinctrl-0 = < &spi3_default_alt >; /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:29 */
                        pinctrl-1 = < &spi3_sleep_alt >;   /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:30 */
                        pinctrl-names = "default",
                                        "sleep";           /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:31 */

                        /* node '/soc/spi@4002f000/winc1500@0' defined in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:33 */
                        winc1500@0 {
                                status = "ok";                     /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:34 */
                                compatible = "atmel,winc1500";     /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:35 */
                                reg = < 0x0 >;                     /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:36 */
                                spi-max-frequency = < 0x3d0900 >;  /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:37 */
                                irq-gpios = < &gpio1 0x7 0x1 >;    /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:38 */
                                reset-gpios = < &gpio1 0x8 0x1 >;  /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:39 */
                                enable-gpios = < &gpio1 0xc 0x0 >; /* in zephyr/samples/net/wifi/shell/boards/reel_board.overlay:40 */
                        };
                };
                
                [...]
        };

        /* node '/connector' defined in zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:55 */
        arduino_header: connector {
                compatible = "arduino-header-r3";          /* in zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:56 */
                #gpio-cells = < 0x2 >;                     /* in zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:57 */
                gpio-map-mask = < 0xffffffff 0xffffffc0 >; /* in zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:58 */
                gpio-map-pass-thru = < 0x0 0x3f >;         /* in zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:59 */
                gpio-map = < 0x0 0x0 &gpio0 0x3 0x0 >,
                           < 0x1 0x0 &gpio0 0x4 0x0 >,
                           < 0x2 0x0 &gpio0 0x1c 0x0 >,
                           < 0x3 0x0 &gpio0 0x1d 0x0 >,
                           < 0x4 0x0 &gpio0 0x1e 0x0 >,
                           < 0x5 0x0 &gpio0 0x1f 0x0 >,
                           < 0x6 0x0 &gpio1 0x1 0x0 >,
                           < 0x7 0x0 &gpio1 0x2 0x0 >,
                           < 0x8 0x0 &gpio1 0x3 0x0 >,
                           < 0x9 0x0 &gpio1 0x4 0x0 >,
                           < 0xa 0x0 &gpio1 0x5 0x0 >,
                           < 0xb 0x0 &gpio1 0x6 0x0 >,
                           < 0xc 0x0 &gpio1 0x7 0x0 >,
                           < 0xd 0x0 &gpio1 0x8 0x0 >,
                           < 0xe 0x0 &gpio1 0xa 0x0 >,
                           < 0xf 0x0 &gpio1 0xb 0x0 >,
                           < 0x10 0x0 &gpio1 0xc 0x0 >,
                           < 0x11 0x0 &gpio1 0xd 0x0 >,
                           < 0x12 0x0 &gpio1 0xe 0x0 >,
                           < 0x13 0x0 &gpio1 0xf 0x0 >,
                           < 0x14 0x0 &gpio0 0x1a 0x0 >,
                           < 0x15 0x0 &gpio0 0x1b 0x0 >;   /* in zephyr/boards/phytec/reel_board/dts/reel_board.dtsi:60 */
        };
                
        [...]
};
```
</details> 

### Review notes

All commits named `dtlib:` only affect `dtlib.py` and its test suite.

The `gen_edt:` commit touches several other files as it propagates the workspace path, calculated in `cmake/modules/dts.cmake`, to `gen_edt.py`, then `edtlib.py`, and finally `dtlib.py`. 
