### PR TITLE
boards: nxp: frdm_mcxa153: enable DMA

### DIFF
--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -68,6 +68,10 @@
 	};
 };
 
+&edma0 {
+	status = "okay";
+};
+
 &flash {
 	partitions {
 		compatible = "fixed-partitions";


### PR DESCRIPTION
Enable DMA by default for this board.

Twister did not find any issues on this board.