### PR TITLE
soc: esp32: include ksched.h in esp32-mp.c

### DIFF
--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -22,6 +22,7 @@
 #ifdef CONFIG_SMP
 
 #include <ipi.h>
+#include <ksched.h>
 
 #ifndef CONFIG_SOC_ESP32_PROCPU
 static struct k_spinlock loglock;


### PR DESCRIPTION
esp32-mp.c calls z_sched_ipi() so it needs to include ksched.h, as it is no longer included via kernel.h after removal of kernel/internal/smp.h.