### PR TITLE
[DNM] rust: add comment support to DTS parser

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -290,11 +290,21 @@ set_property(DIRECTORY APPEND PROPERTY
 # Run GEN_EDT_SCRIPT.
 #
 
+if(WEST_TOPDIR)
+  set(GEN_EDT_WORKSPACE_DIR ${WEST_TOPDIR})
+else()
+  # If West is not available, define the parent directory of ZEPHYR_BASE as
+  # the workspace. This will create comments that reference the files in the
+  # Zephyr tree with a 'zephyr/' prefix.
+  set(GEN_EDT_WORKSPACE_DIR ${ZEPHYR_BASE}/..)
+endif()
+
 string(REPLACE ";" " " EXTRA_DTC_FLAGS_RAW "${EXTRA_DTC_FLAGS}")
 set(CMD_GEN_EDT ${PYTHON_EXECUTABLE} ${GEN_EDT_SCRIPT}
 --dts ${DTS_POST_CPP}
 --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
 --bindings-dirs ${DTS_ROOT_BINDINGS}
+--workspace-dir ${GEN_EDT_WORKSPACE_DIR}
 --dts-out ${ZEPHYR_DTS}.new # for debugging and dtc
 --edt-pickle-out ${EDT_PICKLE}.new
 ${EXTRA_GEN_EDT_ARGS}

--- a/scripts/dts/gen_edt.py
+++ b/scripts/dts/gen_edt.py
@@ -43,6 +43,7 @@ def main():
 
     try:
         edt = edtlib.EDT(args.dts, args.bindings_dirs,
+                         workspace_dir=args.workspace_dir,
                          # Suppress this warning if it's suppressed in dtc
                          warn_reg_unit_address_mismatch=
                              "-Wno-simple_bus_reg" not in args.dtc_flags,
@@ -71,6 +72,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--bindings-dirs", nargs='+', required=True,
                         help="directory with bindings in YAML format, "
                         "we allow multiple")
+    parser.add_argument("--workspace-dir", default=os.getcwd(),
+                        help="directory to be used as reference for generated "
+                        "relative paths (e.g. WEST_TOPDIR)")
     parser.add_argument("--dts-out", required=True,
                         help="path to write merged DTS source code to (e.g. "
                              "as a debugging aid)")

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -1415,7 +1415,7 @@ class DT:
             prop._add_marker(_MarkerType.LABEL, tok.val)
             self._next_token()
 
-    def _node_phandle(self, node):
+    def _node_phandle(self, node, src_prop):
         # Returns the phandle for Node 'node', creating a new phandle if the
         # node has no phandle, and fixing up the value for existing
         # self-referential phandles (which get set to b'\0\0\0\0' initially).
@@ -1435,6 +1435,8 @@ class DT:
                 phandle_i += 1
             self.phandle2node[phandle_i] = node
 
+            phandle_prop.filename = src_prop.filename
+            phandle_prop.lineno = src_prop.lineno
             phandle_prop.value = phandle_i.to_bytes(4, "big")
             node.props["phandle"] = phandle_prop
 
@@ -1878,7 +1880,7 @@ class DT:
                         if marker_type is _MarkerType.PATH:
                             res += ref_node.path.encode("utf-8") + b'\0'
                         else:  # marker_type is PHANDLE
-                            res += self._node_phandle(ref_node)
+                            res += self._node_phandle(ref_node, prop)
                             # Skip over the dummy phandle placeholder
                             pos += 4
 

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -945,15 +945,15 @@ class DT:
         Returns a DTS representation of the devicetree. Called automatically if
         the DT instance is print()ed.
         """
-        s = "/dts-v1/;\n\n"
+        s = "/dts-v1/;\n"
 
         if self.memreserves:
+            s += "\n"
             for labels, address, offset in self.memreserves:
                 # List the labels in a consistent order to help with testing
                 for label in labels:
                     s += f"{label}: "
                 s += f"/memreserve/ {address:#018x} {offset:#018x};\n"
-            s += "\n"
 
         return s + str(self.root)
 

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -202,13 +202,37 @@ class Node:
         Returns a DTS representation of the node. Called automatically if the
         node is print()ed.
         """
-        s = "".join(label + ": " for label in self.labels)
+        def safe_relpath(filename):
+            # Returns a relative path to the file, or the absolute path if
+            # a relative path cannot be estabilished (on Windows with files
+            # in different drives, for example).
+            try:
+                return os.path.relpath(filename, start=os.getcwd())
+            except ValueError:
+                return filename
+
+        rel_filename = safe_relpath(self.filename)
+        s = f"\n/* node '{self.path}' defined in {rel_filename}:{self.lineno} */\n"
+        s += "".join(label + ": " for label in self.labels)
 
         s += f"{self.name} {{\n"
 
+        lines = []
+        comments = {}
         for prop in self.props.values():
             prop_str = textwrap.indent(str(prop), "\t")
-            s += prop_str + "\n"
+            lines.extend(prop_str.splitlines(True))
+
+            rel_filename = safe_relpath(prop.filename)
+            comment = f"/* in {rel_filename}:{prop.lineno} */"
+            comments[len(lines)-1] = comment
+
+        if lines:
+            max_len = max([ len(line.rstrip()) for line in lines ])
+            for i, line in enumerate(lines):
+                if i in comments:
+                    line += " " * (max_len - len(line) + 1) + comments[i] + "\n"
+                s += line
 
         for child in self.nodes.values():
             s += textwrap.indent(child.__str__(), "\t") + "\n"

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -207,7 +207,8 @@ class Node:
         s += f"{self.name} {{\n"
 
         for prop in self.props.values():
-            s += "\t" + str(prop) + "\n"
+            prop_str = textwrap.indent(str(prop), "\t")
+            s += prop_str + "\n"
 
         for child in self.nodes.values():
             s += textwrap.indent(child.__str__(), "\t") + "\n"
@@ -588,6 +589,7 @@ class Property:
             return s + ";"
 
         s += " ="
+        newline = "\n" + " " * len(s)
 
         for i, (pos, marker_type, ref) in enumerate(self._markers):
             if i < len(self._markers) - 1:
@@ -602,11 +604,11 @@ class Property:
                 # end - 1 to strip off the null terminator
                 s += f' "{_decode_and_escape(self.value[pos:end - 1])}"'
                 if end != len(self.value):
-                    s += ","
+                    s += "," + newline
             elif marker_type is _MarkerType.PATH:
                 s += " &" + ref
                 if end != len(self.value):
-                    s += ","
+                    s += "," + newline
             else:
                 # <> or []
 
@@ -638,7 +640,7 @@ class Property:
 
                     s += _N_BYTES_TO_END_STR[elm_size]
                     if pos != len(self.value):
-                        s += ","
+                        s += "," + newline
 
         return s + ";"
 

--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -207,7 +207,7 @@ class Node:
             # a relative path cannot be estabilished (on Windows with files
             # in different drives, for example).
             try:
-                return os.path.relpath(filename, start=os.getcwd())
+                return os.path.relpath(filename, start=self.dt._base_dir)
             except ValueError:
                 return filename
 
@@ -787,7 +787,7 @@ class DT:
     #
 
     def __init__(self, filename: Optional[str], include_path: Iterable[str] = (),
-                 force: bool = False):
+                 force: bool = False, base_dir: Optional[str] = None):
         """
         Parses a DTS file to create a DT instance. Raises OSError if 'filename'
         can't be opened, and DTError for any parse errors.
@@ -804,6 +804,11 @@ class DT:
         force:
           Try not to raise DTError even if the input tree has errors.
           For experimental use; results not guaranteed.
+
+        base_dir:
+          Path to the directory that is to be used as the reference for
+          the generated relative paths in comments. When not provided, the
+          current working directory is used.
         """
         # Remember to update __deepcopy__() if you change this.
 
@@ -817,6 +822,7 @@ class DT:
         self.filename = filename
 
         self._force = force
+        self._base_dir = base_dir or os.getcwd()
 
         if filename is not None:
             self._parse_file(filename, include_path)
@@ -974,7 +980,7 @@ class DT:
         """
 
         # We need a new DT, obviously. Make a new, empty one.
-        ret = DT(None, (), self._force)
+        ret = DT(None, (), self._force, self._base_dir)
 
         # Now allocate new Node objects for every node in self, to use
         # in the new DT. Set their parents to None for now and leave

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -1982,6 +1982,7 @@ class EDT:
     def __init__(self,
                  dts: Optional[str],
                  bindings_dirs: list[str],
+                 workspace_dir: Optional[str] = None,
                  warn_reg_unit_address_mismatch: bool = True,
                  default_prop_types: bool = True,
                  support_fixed_partitions_on_any_bus: bool = True,
@@ -1997,6 +1998,10 @@ class EDT:
         bindings_dirs:
           List of paths to directories containing bindings, in YAML format.
           These directories are recursively searched for .yaml files.
+
+        workspace_dir:
+          Path to the root of the Zephyr workspace. This is used as a base
+          directory for relative paths in the generated devicetree comments.
 
         warn_reg_unit_address_mismatch (default: True):
           If True, a warning is logged if a node has a 'reg' property where
@@ -2066,7 +2071,7 @@ class EDT:
 
         if dts is not None:
             try:
-                self._dt = DT(dts)
+                self._dt = DT(dts, base_dir=workspace_dir)
             except DTError as e:
                 raise EDTError(e) from e
             self._finish_init()

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -26,6 +26,17 @@ from devicetree import dtlib
 #   - to run a particular test function or functions, use
 #     '-k test_function_pattern_goes_here'
 
+def uncomment(dts):
+    '''Trim added comments from a DT string.'''
+
+    # remove node comments, including leading empty line
+    dts = re.sub(r'\n\n[ \t]*/\*.*?\*/\n', '\n', dts, flags=re.DOTALL)
+
+    # remove property comments
+    dts = re.sub(r'[ \t]*/\*.*?\*/\n', '\n', dts)
+
+    return dts
+
 def parse(dts, include_path=(), **kwargs):
     '''Parse a DTS string 'dts', using the given include path.
 
@@ -48,7 +59,7 @@ def verify_parse(dts, expected, include_path=()):
 
     dt = parse(dts[1:], include_path)
 
-    actual = str(dt)
+    actual = uncomment(str(dt))
     expected = expected[1:-1]
     assert actual == expected, f'unexpected round-trip on {dts}'
 
@@ -1029,7 +1040,7 @@ def test_include_curdir(tmp_path):
 };
 """)
         dt = dtlib.DT("test.dts")
-        assert str(dt) == """
+        assert uncomment(str(dt)) == """
 /dts-v1/;
 
 / {
@@ -1086,7 +1097,7 @@ y /include/ "via-include-path-1"
 	y = < 0x2 >;
 };
 """[1:-1]
-    assert str(dt) == expected_dt
+    assert uncomment(str(dt)) == expected_dt
 
 def test_include_misc(tmp_path):
     '''Miscellaneous /include/ tests.'''

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -30,7 +30,9 @@ def uncomment(dts):
     '''Trim added comments from a DT string.'''
 
     # remove node comments, including leading empty line
+    # but keep the one before the root node
     dts = re.sub(r'\n\n[ \t]*/\*.*?\*/\n', '\n', dts, flags=re.DOTALL)
+    dts = re.sub(r'\n/ {\n', r'\n\n/ {\n', dts)
 
     # remove property comments
     dts = re.sub(r'[ \t]*/\*.*?\*/\n', '\n', dts)

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -530,7 +530,9 @@ def test_property_offset_labels():
 /dts-v1/;
 
 / {
-	a = l01: l02: < l03: &node l04: l05: 0x2 l06: l07: l08: >, [ l09: 03 l10: l11: 04 l12: l13: l14: ], "A";
+	a = l01: l02: < l03: &node l04: l05: 0x2 l06: l07: l08: >,
+	    [ l09: 03 l10: l11: 04 l12: l13: l14: ],
+	    "A";
 	b = < 0x0 l23: l24: >;
 	node: node {
 		phandle = < 0x1 >;
@@ -610,8 +612,11 @@ def test_node_path_references():
 
 / {
 	a = &label;
-	b = [ 01 ], &label;
-	c = [ 01 ], &label, < 0x2 >;
+	b = [ 01 ],
+	    &label;
+	c = [ 01 ],
+	    &label,
+	    < 0x2 >;
 	d = &{/abc};
 	label: abc {
 		e = &label;
@@ -867,7 +872,12 @@ def test_mixed_assign():
 /dts-v1/;
 
 / {
-	x = [ FF FF ], &abc, < 0xff &abc 0xff &abc >, &abc, [ FF FF ], "abc";
+	x = [ FF FF ],
+	    &abc,
+	    < 0xff &abc 0xff &abc >,
+	    &abc,
+	    [ FF FF ],
+	    "abc";
 	abc: abc {
 		phandle = < 0x1 >;
 	};
@@ -1180,7 +1190,8 @@ def test_omit_if_no_ref():
 /dts-v1/;
 
 / {
-	x = < &{/referenced} >, &referenced2;
+	x = < &{/referenced} >,
+	    &referenced2;
 	referenced {
 		phandle = < 0x1 >;
 	};
@@ -1775,7 +1786,7 @@ def test_prop_type_casting():
         "strings",
         "expected property 'strings' on / in .* to be assigned with " +
         re.escape("'strings = \"string\";', ")+
-        re.escape("not 'strings = \"foo\", \"bar\", \"baz\";'"))
+        "not 'strings = \"foo\",\\s*\"bar\",\\s*\"baz\";'")
     verify_to_string_error_matches(
         "invalid_string",
         re.escape(r"value of property 'invalid_string' (b'\xff\x00') on / ") +
@@ -2076,7 +2087,9 @@ def test_duplicate_labels():
 
 / {
 	label: foo {
-		x = &{/foo}, &label, < &label >;
+		x = &{/foo},
+		    &label,
+		    < &label >;
 		phandle = < 0x1 >;
 	};
 };
@@ -2175,7 +2188,8 @@ def test_names():
 /dts-v1/;
 
 / {
-	aA0,._+*#?- = &_, &{/aA0,._+@-};
+	aA0,._+*#?- = &_,
+	              &{/aA0,._+@-};
 	+ = [ 00 ];
 	* = [ 02 ];
 	- = [ 01 ];
@@ -2232,7 +2246,9 @@ def test_dense_input():
 / {
 	l1: l2: foo {
 		l3: l4: bar {
-			l5: x = l6: [ l7: 01 l8: 02 l9: ], [ 03 ], "a";
+			l5: x = l6: [ l7: 01 l8: 02 l9: ],
+			        [ 03 ],
+			        "a";
 		};
 	};
 };

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: d4f9036a88e53080bf2b186afa5289f9c77a0f73
+      revision: pull/96/head
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
This PR tests the change in zephyrproject-rtos/zephyr-lang-rust#96 that filters comments in DTS files with the new DTS comments implemented in #89410 (the first 5 commits).