### PR TITLE
twister: improve the alignment of columns in verbose output

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1553,6 +1553,15 @@ class ProjectBuilder(FilterBuilder):
             f'{TwisterStatus.get_color(instance.status)}{str.upper(instance.status)}{Fore.RESET}'
         )
 
+        def name_columns(instance, plat_width, ts_width):
+            # try to compensate for a platform name longer than plat_width
+            # by reclaiming extra spaces after the testsuite name, if any
+            plat_name = instance.platform.name
+            ts_name = instance.testsuite.name
+            plat_extra = max(0, len(plat_name) - plat_width)
+            ts_width = max(0, ts_width - plat_extra)
+            return f"{plat_name:<{plat_width}} {ts_name:<{ts_width}}"
+
         if instance.status in [TwisterStatus.ERROR, TwisterStatus.FAIL]:
             if instance.status == TwisterStatus.ERROR:
                 results.error_increment()
@@ -1562,7 +1571,7 @@ class ProjectBuilder(FilterBuilder):
                 status += " " + instance.reason
             else:
                 logger.error(
-                    f"{instance.platform.name:<25} {instance.testsuite.name:<50}"
+                    f"{name_columns(instance, 25, 50)}"
                     f" {status}: {instance.reason}"
                 )
             if not self.options.verbose:
@@ -1603,7 +1612,7 @@ class ProjectBuilder(FilterBuilder):
                     more_info += f" <{instance.toolchain}>"
             logger.info(
                 f"{results.done - results.filtered_static:>{total_tests_width}}/{total_to_do}"
-                f" {instance.platform.name:<25} {instance.testsuite.name:<50}"
+                f" {name_columns(instance, 25, 50)}"
                 f" {status} ({more_info})"
             )
 


### PR DESCRIPTION
This purely cosmetic change improves the alignment of columns in the verbose Twister output by reclaiming extra space in the testsuite name column when the platform name oveflows its allocated width.

Current sample log:
```
INFO    -   2/105 qemu_riscv64/qemu_virt_riscv64/smp tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.183s <zephyr>)
INFO    -   3/105 qemu_riscv64/qemu_virt_riscv64 tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.059s <zephyr>)
INFO    -   4/105 mps2/an385                tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.084s <zephyr>)
INFO    -   5/105 mps2/an521/cpu0           tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.190s <zephyr>)
INFO    -   6/105 native_sim/native         tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (native 0.052s <host>)
INFO    -   7/105 qemu_cortex_a53/qemu_cortex_a53 tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.221s <zephyr>)
INFO    -   8/105 qemu_cortex_m0/nrf51822   tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.072s <zephyr>)
INFO    -   9/105 mps3/corstone300/an547    tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.177s <zephyr>)
INFO    -  10/105 qemu_cortex_a9/xc7z007s   tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.543s <zephyr>)
INFO    -  11/105 qemu_cortex_a53/qemu_cortex_a53/smp tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.089s <zephyr>)
INFO    -  12/105 qemu_cortex_r5/zynqmp_rpu tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 8.109s <zephyr>)
```

With this PR:
```
INFO    -   2/105 qemu_riscv64/qemu_virt_riscv64/smp tests/kernel/fifo/fifo_usage/kernel.fifo.usage PASSED (qemu 1.183s <zephyr>)
INFO    -   3/105 qemu_riscv64/qemu_virt_riscv64 tests/kernel/fifo/fifo_usage/kernel.fifo.usage PASSED (qemu 1.059s <zephyr>)
INFO    -   4/105 mps2/an385                tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.084s <zephyr>)
INFO    -   5/105 mps2/an521/cpu0           tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.190s <zephyr>)
INFO    -   6/105 native_sim/native         tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (native 0.052s <host>)
INFO    -   7/105 qemu_cortex_a53/qemu_cortex_a53 tests/kernel/fifo/fifo_usage/kernel.fifo.usage PASSED (qemu 1.221s <zephyr>)
INFO    -   8/105 qemu_cortex_m0/nrf51822   tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.072s <zephyr>)
INFO    -   9/105 mps3/corstone300/an547    tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.177s <zephyr>)
INFO    -  10/105 qemu_cortex_a9/xc7z007s   tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 1.543s <zephyr>)
INFO    -  11/105 qemu_cortex_a53/qemu_cortex_a53/smp tests/kernel/fifo/fifo_usage/kernel.fifo.usage PASSED (qemu 1.089s <zephyr>)
INFO    -  12/105 qemu_cortex_r5/zynqmp_rpu tests/kernel/fifo/fifo_usage/kernel.fifo.usage     PASSED (qemu 8.109s <zephyr>)
```

