### PR TITLE
drivers: gpio: xlnx_ps: Do not clear GPIO states on initialization

### DIFF
--- a/drivers/gpio/gpio_xlnx_ps_bank.c
+++ b/drivers/gpio/gpio_xlnx_ps_bank.c
@@ -441,9 +441,6 @@ static int gpio_xlnx_ps_bank_init(const struct device *dev)
 
 	sys_write32(~0x0, GPIO_XLNX_PS_BANK_INT_DIS_REG);  /* Disable all interrupts */
 	sys_write32(~0x0, GPIO_XLNX_PS_BANK_INT_STAT_REG); /* Clear all interrupts */
-	sys_write32(0x0, GPIO_XLNX_PS_BANK_OEN_REG);       /* All outputs disabled */
-	sys_write32(0x0, GPIO_XLNX_PS_BANK_DIRM_REG);      /* All pins input */
-	sys_write32(0x0, GPIO_XLNX_PS_BANK_DATA_REG);      /* Zero data register */
 
 	return 0;
 }


### PR DESCRIPTION
This driver was setting all GPIO lines to input and the data register to zero on initialization. This does not appear to be common practice among other GPIO drivers, and in fact caused a serious problem on the ZynqMP platform, where between 1 and 4 of the top-most GPIO lines are frequently used by platform firmware and Vivado as reset lines for the programmable logic. Since these resets are active low, and their input/output state is ignored due to how they are connected to the EMIO GPIO outputs from the PS, this caused the PL reset to be asserted when the GPIO driver initialized, preventing any logic using that reset from functioning properly.

There may also be other cases where GPIO line states have already been set by the boot loader or firmware and clearing them may result in improper behavior or glitches on the lines during initialization.

Update the driver to disable GPIO interrupts but leave the pin modes/states unchanged until/unless they are explicitly reconfigured.