### PR TITLE
kernel: Timeslice enhancements

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -144,6 +144,29 @@ struct _ready_q {
 
 typedef struct _ready_q _ready_q_t;
 
+/* kernel timeout record */
+struct _timeout;
+typedef void (*_timeout_func_t)(struct _timeout *t);
+
+struct _timeout {
+	sys_dnode_t node;
+	_timeout_func_t fn;
+#ifdef CONFIG_TIMEOUT_64BIT
+	/* Can't use k_ticks_t for header dependency reasons */
+	int64_t dticks;
+#else
+	int32_t dticks;
+#endif
+};
+
+struct _timeslice {
+	/* timeout for the timeslice */
+	struct _timeout timeout;
+
+	/* true if timeslice expired */
+	bool expired;
+};
+
 struct _cpu {
 	/* nested interrupt count */
 	uint32_t nested;
@@ -194,6 +217,10 @@ struct _cpu {
 
 #ifdef CONFIG_OBJ_CORE_SYSTEM
 	struct k_obj_core  obj_core;
+#endif
+
+#ifdef CONFIG_TIMESLICING
+	struct _timeslice timeslice;
 #endif
 
 	/* Per CPU architecture specifics */
@@ -291,21 +318,6 @@ typedef struct {
 #define Z_WAIT_Q_INIT(wait_q) { SYS_DLIST_STATIC_INIT(&(wait_q)->waitq) }
 
 #endif /* CONFIG_WAITQ_SCALABLE */
-
-/* kernel timeout record */
-struct _timeout;
-typedef void (*_timeout_func_t)(struct _timeout *t);
-
-struct _timeout {
-	sys_dnode_t node;
-	_timeout_func_t fn;
-#ifdef CONFIG_TIMEOUT_64BIT
-	/* Can't use k_ticks_t for header dependency reasons */
-	int64_t dticks;
-#else
-	int32_t dticks;
-#endif
-};
 
 typedef void (*k_thread_timeslice_fn_t)(struct k_thread *thread, void *data);
 

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -72,7 +72,6 @@ void z_requeue_current(struct k_thread *curr);
 struct k_thread *z_swap_next_thread(void);
 void z_thread_abort(struct k_thread *thread);
 void move_thread_to_end_of_prio_q(struct k_thread *thread);
-bool thread_is_sliceable(struct k_thread *thread);
 
 static inline void z_reschedule_unlocked(void)
 {

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -64,7 +64,7 @@ bool z_thread_prio_set(struct k_thread *thread, int prio);
 void *z_get_next_switch_handle(void *interrupted);
 
 void z_time_slice(void);
-void z_reset_time_slice(struct k_thread *curr);
+void z_reset_time_slice(unsigned int cpu, struct k_thread *curr);
 void z_sched_ipi(void);
 void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);

--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -101,8 +101,6 @@ void z_sched_ipi(void)
 #endif /* CONFIG_TRACE_SCHED_IPI */
 
 #ifdef CONFIG_TIMESLICING
-	if (thread_is_sliceable(_current)) {
-		z_time_slice();
-	}
+	z_time_slice();
 #endif /* CONFIG_TIMESLICING */
 }

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -293,7 +293,7 @@ static ALWAYS_INLINE void update_cache(int preempt_ok)
 	if (should_preempt(thread, preempt_ok)) {
 #ifdef CONFIG_TIMESLICING
 		if (thread != _current) {
-			z_reset_time_slice(thread);
+			z_reset_time_slice(0, thread);
 		}
 #endif /* CONFIG_TIMESLICING */
 		update_metairq_preempt(thread);
@@ -880,7 +880,7 @@ void *z_get_next_switch_handle(void *interrupted)
 			set_current(new_thread);
 
 #ifdef CONFIG_TIMESLICING
-			z_reset_time_slice(new_thread);
+			z_reset_time_slice(cpu_id, new_thread);
 #endif /* CONFIG_TIMESLICING */
 
 #ifdef CONFIG_SPIN_VALIDATE

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -54,7 +54,7 @@ static struct _timeout *next(struct _timeout *t)
 	return (n == NULL) ? NULL : CONTAINER_OF(n, struct _timeout, node);
 }
 
-static void remove_timeout(struct _timeout *t)
+static ALWAYS_INLINE void remove_timeout(struct _timeout *t)
 {
 	if (next(t) != NULL) {
 		next(t)->dticks += t->dticks;

--- a/kernel/timeslicing.c
+++ b/kernel/timeslicing.c
@@ -36,7 +36,7 @@ static inline int slice_time(struct k_thread *thread)
 	return ret;
 }
 
-bool thread_is_sliceable(struct k_thread *thread)
+static bool thread_is_sliceable(struct k_thread *thread)
 {
 	bool ret = thread_is_preemptible(thread)
 		&& slice_time(thread) != 0
@@ -99,7 +99,7 @@ void k_thread_time_slice_set(struct k_thread *thread, int32_t thread_slice_ticks
 }
 #endif
 
-/* Called out of each timer interrupt */
+/* Called out of each timer and IPI interrupt */
 void z_time_slice(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&_sched_spinlock);

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -52,13 +52,13 @@ static void setup_threads(void)
 	k_thread_priority_set(k_current_get(), init_prio);
 }
 
-static void spawn_threads(int sleep_sec)
+static void spawn_threads(int sleep_msec)
 {
 	for (int i = 0; i < THREADS_NUM; i++) {
 		tdata[i].tid = k_thread_create(&tthread[i], tstacks[i],
 					       STACK_SIZE, thread_entry,
 					       INT_TO_POINTER(i),
-					       INT_TO_POINTER(sleep_sec),
+					       INT_TO_POINTER(sleep_msec),
 					       NULL, tdata[i].priority, 0,
 					       K_NO_WAIT);
 	}


### PR DESCRIPTION
Fixes a couple of minor issues with respect to time slicing and allows for a configurable time slice reset.

1. Calls to k_thread_time_slice_reset() used to always reset the time slice on the current CPU regardless of whether the target thread was running on the current CPU or if it was even running. We now target the correct CPU, and it only takes immediate effect if the thread that CPU's current thread.
2. Refactored thread_is_sliceable() to ensure that thread-level slice-ability does not override conditions such as the thread being prevented from executing.
3. Adds CONFIG_TIMESLICE_AUTO_RESET. If disabled, then we do not always reset the timeslice. That is, if the outgoing thread switches out before the time slice expires, then the incoming thread may continue to use the same time slice (with some restrictions) without resetting the timer. 

Update:
Dropped the auto-reset  portion as it would have introduced too much unpredictability.