### PR TITLE
samples: gnss: vmu_rt1170: correct alias assignment to gnss node

### DIFF
--- a/samples/drivers/gnss/boards/vmu_rt1170_mimxrt1176_cm7.overlay
+++ b/samples/drivers/gnss/boards/vmu_rt1170_mimxrt1176_cm7.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		gnss = &lpuart3;
+		gnss = &gnss;
 	};
 };
 
@@ -14,7 +14,7 @@
 	status = "okay";
 	current-speed = <115200>;
 
-	u_blox_m8: u-blox,m8 {
+	gnss: gnss {
 		status = "okay";
 		compatible = "u-blox,m8";
 		uart-baudrate = <115200>;


### PR DESCRIPTION
Otherwise, the callback subscriptions the application subscribes to will not ever trigger.

Additionally, rename this overlay so it's compatible with hwmv2 target: `vmu_rt1170/mimxrt1176/cm7`.