### PR TITLE
tests: twister_blackbox: fix vendor filter test

### DIFF
--- a/scripts/tests/twister_blackbox/test_filter.py
+++ b/scripts/tests/twister_blackbox/test_filter.py
@@ -55,7 +55,7 @@ class TestFilter:
             'intel',
             [
                 r'(it8xxx2_evb/it81302bx).*?(FILTERED: Not a selected vendor platform)',
-                r'(qemu_x86/atom).*?(FILTERED: Not a selected vendor platform)',
+                r'(hsdk/arc_hsdk).*?(FILTERED: Not a selected vendor platform)',
                 r'(DEBUG\s+- adding intel_adl_crb)'
             ]
         ),


### PR DESCRIPTION
Commit 6dc27a4 from PR #89024 unknowingly broke Twister blackbox tests by correctly placing Atom targets under the `intel` vendor. Since this was not previously the case, the Twister blackbox vendor filter test for `intel` was actually expecting `qemu_x86/atom` to be filtered out as _"Not a selected vendor platform"..._ :sweat_smile:

Hotfix since CI is currently broken for #89422 (fails with [this error](https://github.com/zephyrproject-rtos/zephyr/actions/runs/14800471828/job/41557795850?pr=89422#step:6:260)).