### PR TITLE
dts: arm: st: l4: add support for STM32L431XB SoC

### DIFF
--- a/dts/arm/st/l4/stm32l431Xb.dtsi
+++ b/dts/arm/st/l4/stm32l431Xb.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Mirai SHINJO
+ * Copyright (c) 2025 Alexander Apostolu
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/l4/stm32l431.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(64)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(128)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This patch adds support for the STM32L431XB SoC, which is the 128kB flash / 64kB SRAM variant of the STM32L4X1 SoC familiy.