### PR TITLE
boards: stm32h573i-dk: add display support

### DIFF
--- a/boards/st/stm32h573i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h573i_dk/Kconfig.defconfig
@@ -21,4 +21,16 @@ config SDMMC_STM32_CLOCK_CHECK
 
 endif # DISK_DRIVER_SDMMC
 
+if DISPLAY
+
+choice ST7789V_PIXEL_FORMAT
+	default ST7789V_BGR565
+endchoice
+
+# Required to enable LCD backlight
+config REGULATOR
+	default y
+
+endif # DISPLAY
+
 endif # BOARD_STM32H573I_DK

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -180,6 +180,16 @@ Serial Port
 STM32H573I-DK Discovery board has 3 U(S)ARTs. The Zephyr console output is
 assigned to USART1. Default settings are 115200 8N1.
 
+TFT LCD screen
+--------------
+
+The TFT LCD screen is supported for the STM32H573I-DK Discovery board.
+It can be tested using :zephyr:code-sample:`display` sample:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/display
+   :board: stm32h573i_dk
+   :goals: build
 
 Programming and Debugging
 *************************

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -11,6 +11,8 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr.h>
 #include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
+#include <zephyr/dt-bindings/mipi_dbi/mipi_dbi.h>
 / {
 	model = "STMicroelectronics STM32H573I DISCOVERY KIT board";
 	compatible = "st,stm32h573i-dk";
@@ -22,6 +24,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,canbus = &fdcan1;
+		zephyr,display = &st7789v;
 	};
 
 	leds {
@@ -53,6 +56,13 @@
 		};
 	};
 
+	lcd_bl_ctrl {
+		compatible = "regulator-fixed";
+		regulator-name = "LCD Backlight Driver";
+		enable-gpios = <&gpioi 3 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
+
 	aliases {
 		led0 = &blue_led_0;
 		sw0 = &user_button;
@@ -69,6 +79,77 @@
 		zephyr,memory-region = "EXTMEM";
 		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+};
+
+&fmc {
+	pinctrl-0 = <&fmc_a0_pf0 &fmc_ne1_pc7 &fmc_nwe_pd5 &fmc_noe_pd4
+		     &fmc_d0_pd14 &fmc_d1_pd15 &fmc_d2_pd0 &fmc_d3_pd1
+		     &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9 &fmc_d7_pe10
+		     &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13 &fmc_d11_pe14
+		     &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9 &fmc_d15_pd10>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sram {
+		compatible = "st,stm32-fmc-nor-psram";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		bank@0 {
+			reg = <0x0>;
+			st,control = <STM32_FMC_DATA_ADDRESS_MUX_DISABLE
+				STM32_FMC_MEMORY_TYPE_SRAM
+				STM32_FMC_NORSRAM_MEM_BUS_WIDTH_16
+				STM32_FMC_BURST_ACCESS_MODE_DISABLE
+				STM32_FMC_WAIT_SIGNAL_POLARITY_LOW
+				STM32_FMC_WAIT_TIMING_BEFORE_WS
+				STM32_FMC_WRITE_OPERATION_ENABLE
+				STM32_FMC_WAIT_SIGNAL_DISABLE
+				STM32_FMC_EXTENDED_MODE_DISABLE
+				STM32_FMC_ASYNCHRONOUS_WAIT_DISABLE
+				STM32_FMC_WRITE_BURST_DISABLE
+				STM32_FMC_CONTINUOUS_CLOCK_SYNC_ONLY
+				STM32_FMC_WRITE_FIFO_DISABLE
+				STM32_FMC_PAGE_SIZE_NONE>;
+			st,timing = <1 1 32 0 2 2 STM32_FMC_ACCESS_MODE_A>;
+
+			fmc-mipi-dbi {
+				compatible = "st,stm32-fmc-mipi-dbi";
+				reset-gpios = <&gpioh 13 GPIO_ACTIVE_LOW>;
+				power-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
+				register-select-pin = <0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				st7789v: lcd-panel@0 {
+					compatible = "sitronix,st7789v";
+					reg = <0>;
+					mipi-mode = "MIPI_DBI_MODE_8080_BUS_16_BIT";
+					/* A write cycle should be 68ns */
+					mipi-max-frequency = <14705882>;
+					width = <240>;
+					height = <240>;
+					x-offset = <0>;
+					y-offset = <0>;
+					vcom = <0x1F>;
+					gctrl = <0x35>;
+					vdvs = <0x20>;
+					mdac = <0x00>;
+					gamma = <0x01>;
+					colmod = <0x05>;
+					lcm = <0x2c>;
+					porch-param = [0c 0c 00 33 33];
+					cmd2en-param = [5a 69 02 00];
+					pwctrl1-param = [a4 a1];
+					pvgam-param = [D0 08 11 08 0C 15 39 33 50 36 13 14 29 2D];
+					nvgam-param = [D0 08 10 08 06 06 39 44 51 0B 16 14 2F 31];
+					ram-param = [00 F0];
+					rgb-param = [40 02 14];
+				};
+			};
+		};
 	};
 };
 


### PR DESCRIPTION
## Summary

- Add display support for the st7789v LCD controller.
- Automatically enable the LCD backlight at boot to use the display sample as is, because the LCD backlight is normally off.

## Tests

### Environment

Tested on an stm32h573i-dk board (mb1677-h573i-c02) with the `display` sample.

### Commands

```sh
$ west build -p always -b stm32h573i_dk zephyr/samples/drivers/display
$ west flash --runner pyocd
```

### Results

- Backlight OK
- Colors OK
- Display OK

![IMG20250504233911](https://github.com/user-attachments/assets/27c94461-78f5-422c-9c03-08cfe64c2848)

## References

- Schematics of the stm32h573i-dk board used for the pinout: https://www.st.com/resource/en/schematic_pack/mb1677-h573i-c02-schematic.pdf
- PR of the first support of the st7789v through the FMC of the STM32: https://github.com/zephyrproject-rtos/zephyr/pull/75172

Signed-off-by: Samuel Quiniou <samuel.quiniou@rtone.fr>