### PR TITLE
scripts: ci: check_compliance: fix identity check for multiple DCO signoffs

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1460,7 +1460,8 @@ class Identity(ComplianceTest):
 
             match_signoff = re.search(r"signed-off-by:\s(.*)", body,
                                       re.IGNORECASE)
-            detailed_match = re.search(r"signed-off-by:\s(.*) <(.*)>", body,
+            detailed_match = re.search(rf"signed-off-by:\s({re.escape(auth_name)}) <({re.escape(auth_email)})>",
+                                       body,
                                        re.IGNORECASE)
 
             failures = []


### PR DESCRIPTION
The current implementation of the identity check fails if multiple DCO signoff lines are present and the first instance of the signoff line does not belong to the author of the commit. This patch proposes a solution that allows patches with multiple DCO signoff lines to pass the identity check, regardless of the order of the signoff lines.