### PR TITLE
Initial Support for ElemRV-N

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -126,6 +126,19 @@ ACPI:
   tests:
     - acpi
 
+Aesc Platform:
+  status: maintained
+  maintainers:
+    - dnltz
+  files:
+    - soc/aesc/
+    - dts/riscv/aesc/
+    - boards/aesc/
+  files-regex:
+    - ^drivers/.*aesc(\.c)?$
+  labels:
+    - "area: Aesc Silicon Platform"
+
 Antmicro platforms:
   status: maintained
   maintainers:

--- a/boards/aesc/elemrv/Kconfig.elemrv
+++ b/boards/aesc/elemrv/Kconfig.elemrv
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_ELEMRV
+	select SOC_ELEMRV_N

--- a/boards/aesc/elemrv/board.yml
+++ b/boards/aesc/elemrv/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: elemrv
+  full_name: ElemRV-N
+  vendor: aesc
+  socs:
+  - name: elemrv_n

--- a/boards/aesc/elemrv/doc/index.rst
+++ b/boards/aesc/elemrv/doc/index.rst
@@ -1,0 +1,72 @@
+.. zephyr:board:: elemrv
+
+Overview
+********
+
+ElemRV-N is an end-to-end open-source RISC-V microcontroller designed using SpinalHDL.
+
+Version 0.2 of ElemRV-N was successfully fabricated using `IHP's Open PDK`_, a 130nm open semiconductor process, with support from `FMD-QNC`_.
+
+For more details, refer to the official `GitHub Project`_.
+
+.. note::
+   The currently supported silicon version is ElemRV-N 0.2.
+
+Supported Features
+******************
+
+.. zephyr:board-supported-hw::
+
+System Clock
+============
+
+The system clock for the RISC-V core is set to 20 MHz. This value is specified in the ``cpu0`` devicetree node using the ``clock-frequency`` property.
+
+CPU
+===
+
+ElemRV-N integrates a VexRiscv RISC-V core featuring a 5-stage pipeline and the following ISA extensions:
+
+* M (Integer Multiply/Divide)
+* C (Compressed Instructions)
+
+It also includes the following general-purpose ``Z`` extensions:
+
+* Zicntr – Base Counter and Timer extensions
+* Zicsr – Control and Status Register operations
+* Zifencei – Instruction-fetch fence
+
+The complete ISA string for this CPU is: ``RV32IMC_Zicntr_Zicsr_Zifencei``
+
+Hart-Level Interrupt Controller (HLIC)
+======================================
+
+Each CPU core is equipped with a Hart-Level Interrupt Controller, configurable through Control and Status Registers (CSRs).
+
+Machine Timer
+=============
+
+A RISC-V compliant machine timer is enabled by default.
+
+Serial
+======
+
+The UART (Universal Asynchronous Receiver-Transmitter) interface is a configurable serial communication peripheral used for transmitting and receiving data.
+
+By default, ``uart0`` operates at a baud rate of ``115200``, which can be adjusted via the elemrv device tree.
+
+To evaluate the UART interface, build and run the following sample:
+
+.. zephyr-app-commands::
+   :board: elemrv/elemrv_n
+   :zephyr-app: samples/hello_world
+   :goals: build
+
+.. _GitHub Project:
+   https://github.com/aesc-silicon/elemrv
+
+.. _IHP's Open PDK:
+   https://github.com/IHP-GmbH/IHP-Open-PDK
+
+.. _FMD-QNC:
+   https://www.elektronikforschung.de/projekte/fmd-qnc

--- a/boards/aesc/elemrv/elemrv_elemrv_n.dts
+++ b/boards/aesc/elemrv/elemrv_elemrv_n.dts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <aesc/elemrv-n.dtsi>
+
+/ {
+	model = "ElemRV-N";
+	compatible = "aesc,elemrv-n";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,sram = &hyperbus;
+		zephyr,flash = &flash;
+	};
+
+	soc {
+		ocram: memory@80000000 {
+			device_type = "memory";
+			compatible = "mmio-sram";
+			reg = <0x80000000 DT_SIZE_K(1)>;
+		};
+
+		hyperbus: memory@90000000 {
+			device_type = "memory";
+			compatible = "mmio-sram";
+			reg = <0x90000000 DT_SIZE_K(32)>;
+		};
+
+		flash: flash@a0010000 {
+			compatible = "soc-nv-flash";
+			reg = <0xa0010000 DT_SIZE_K(32)>;
+		};
+	};
+};
+
+&uart0 {
+	clock-frequency = <DT_FREQ_M(20)>;
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(20)>;
+};

--- a/boards/aesc/elemrv/elemrv_elemrv_n.yaml
+++ b/boards/aesc/elemrv/elemrv_elemrv_n.yaml
@@ -1,0 +1,9 @@
+identifier: elemrv/elemrv_n
+name: ElemRV-N
+type: mcu
+arch: riscv
+toolchain:
+  - cross-compile
+  - zephyr
+ram: 32
+flash: 32

--- a/boards/aesc/elemrv/elemrv_elemrv_n_defconfig
+++ b/boards/aesc/elemrv/elemrv_elemrv_n_defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+# Serial Driver
+CONFIG_SERIAL=y
+
+# Enable Console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/aesc/index.rst
+++ b/boards/aesc/index.rst
@@ -1,0 +1,10 @@
+.. _boards-aesc:
+
+Aesc Silicon
+############
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -247,6 +247,10 @@ New Boards
 
    * :zephyr:board:`versalnet_rpu` (``versalnet_rpu``)
 
+* Aesc Silicon
+
+   * :zephyr:board:`elemrv` (``elemrv``)
+
 * aithinker
 
    * :zephyr:board:`ai_wb2_12f` (``ai_wb2_12f``)

--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -17,6 +17,7 @@ zephyr_library_sources_ifdef(CONFIG_USB_CDC_ACM ${ZEPHYR_BASE}/misc/empty_file.c
 zephyr_library_sources_ifdef(CONFIG_LEUART_GECKO leuart_gecko.c)
 zephyr_library_sources_ifdef(CONFIG_LPUART_ESP32 lpuart_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_SERIAL_ESP32_USB serial_esp32_usb.c)
+zephyr_library_sources_ifdef(CONFIG_UART_AESC uart_aesc.c)
 zephyr_library_sources_ifdef(CONFIG_UART_ALTERA uart_altera.c)
 zephyr_library_sources_ifdef(CONFIG_UART_ALTERA_JTAG uart_altera_jtag.c)
 zephyr_library_sources_ifdef(CONFIG_UART_APBUART uart_apbuart.c)

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -157,6 +157,7 @@ config UART_SHELL
 comment "Serial Drivers"
 
 # zephyr-keep-sorted-start
+rsource "Kconfig.aesc"
 rsource "Kconfig.altera"
 rsource "Kconfig.altera_jtag"
 rsource "Kconfig.apbuart"

--- a/drivers/serial/Kconfig.aesc
+++ b/drivers/serial/Kconfig.aesc
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+config UART_AESC
+	bool "Aesc Silicon UART driver"
+	default y
+	depends on DT_HAS_AESC_UART_ENABLED
+	select SERIAL_HAS_DRIVER
+	help
+	  Enable the Aesc Silicon UART driver.

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT aesc_uart
+
+#include <errno.h>
+#include <ip_identification.h>
+#include <soc.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(aesc_uart, CONFIG_UART_LOG_LEVEL);
+
+struct uart_aesc_data {
+	DEVICE_MMIO_NAMED_RAM(regs);
+};
+
+struct uart_aesc_config {
+	DEVICE_MMIO_NAMED_ROM(regs);
+	uint64_t sys_clk_freq;
+	uint32_t current_speed;
+};
+
+struct uart_aesc_regs {
+	uint32_t data_width;
+	uint32_t sampling_sizes;
+	uint32_t fifo_depths;
+	uint32_t permissions;
+	uint32_t read_write;
+	uint32_t fifo_status;
+	uint32_t clock_div;
+	uint32_t frame_cfg;
+	uint32_t ip;
+	uint32_t ie;
+};
+
+#define DEV_CFG(dev) ((struct uart_aesc_config *)(dev)->config)
+#define DEV_DATA(dev) ((struct uart_aesc_data *)(dev)->data)
+#define DEV_UART(dev)							     \
+	((struct uart_aesc_regs *)DEVICE_MMIO_NAMED_GET(dev, regs))
+
+#define AESC_UART_IRQ_TX_EN			BIT(0)
+#define AESC_UART_IRQ_RX_EN			BIT(1)
+#define AESC_UART_FIFO_TX_COUNT_MASK		GENMASK(23, 16)
+#define AESC_UART_READ_FIFO_VALID_BIT		BIT(16)
+
+static void uart_aesc_poll_out(const struct device *dev, unsigned char c)
+{
+	struct uart_aesc_regs *uart = DEV_UART(dev);
+
+	while ((uart->fifo_status & AESC_UART_FIFO_TX_COUNT_MASK) == 0) {
+		/* Wait until transmit fifo is empty */
+	}
+	uart->read_write = c;
+}
+
+static int uart_aesc_poll_in(const struct device *dev, unsigned char *c)
+{
+	const struct uart_aesc_regs *uart = DEV_UART(dev);
+	int val;
+
+	val = uart->read_write;
+	if (val & AESC_UART_READ_FIFO_VALID_BIT) {
+		*c = val & 0xFF;
+		return 0;
+	}
+
+	return -1;
+}
+
+static int uart_aesc_init(const struct device *dev)
+{
+	const struct uart_aesc_config *cfg = DEV_CFG(dev);
+	volatile uintptr_t *base_addr = (volatile uintptr_t *)DEV_UART(dev);
+	volatile struct uart_aesc_regs *uart;
+
+	DEVICE_MMIO_NAMED_MAP(dev, regs, K_MEM_CACHE_NONE);
+	LOG_DBG("IP core version: %i.%i.%i.",
+		ip_id_get_major_version(base_addr),
+		ip_id_get_minor_version(base_addr),
+		ip_id_get_patchlevel(base_addr)
+	);
+	DEVICE_MMIO_NAMED_GET(dev, regs) = ip_id_relocate_driver(base_addr);
+	LOG_DBG("Relocate driver to address 0x%lx.", DEVICE_MMIO_NAMED_GET(dev, regs));
+	uart = DEV_UART(dev);
+
+	uart->clock_div = cfg->sys_clk_freq / cfg->current_speed / 8;
+	uart->frame_cfg = 7;
+
+	return 0;
+}
+
+static const struct uart_driver_api uart_aesc_driver_api = {
+	.poll_in          = uart_aesc_poll_in,
+	.poll_out         = uart_aesc_poll_out,
+	.err_check        = NULL,
+};
+
+#define AESC_UART_INIT(no)						     \
+	static struct uart_aesc_data uart_aesc_dev_data_##no;		     \
+	static struct uart_aesc_config uart_aesc_dev_cfg_##no = {	     \
+		DEVICE_MMIO_NAMED_ROM_INIT(regs,			     \
+					   DT_INST(no, aesc_uart)),	     \
+		.sys_clk_freq =						     \
+			DT_PROP(DT_INST(no, aesc_uart), clock_frequency),    \
+		.current_speed =					     \
+			DT_PROP(DT_INST(no, aesc_uart), current_speed),	     \
+	};								     \
+	DEVICE_DT_INST_DEFINE(no,					     \
+			      uart_aesc_init,				     \
+			      NULL,					     \
+			      &uart_aesc_dev_data_##no,			     \
+			      &uart_aesc_dev_cfg_##no,			     \
+			      PRE_KERNEL_1,				     \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	     \
+			      (void *)&uart_aesc_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(AESC_UART_INIT)

--- a/dts/bindings/serial/aesc,uart.yaml
+++ b/dts/bindings/serial/aesc,uart.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 Aesc Silicon
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+title: Aesc Silicon UART (Universal Synchronous/Asynchronous Receiver/Transmitter)
+
+description: |
+  The UART (Universal Asynchronous Receiver-Transmitter) IP Core is a configurable serial
+  communication interface designed to handle data transmission and reception. The core includes
+  an internal clock divider and supports flexible frame configurations, allowing for variable data
+  length, parity, and stop bit settings.
+
+compatible: "aesc,uart"
+
+include: uart-controller.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -33,6 +33,7 @@ adh	AD Holdings Plc.
 adi	Analog Devices, Inc.
 advantech	Advantech Corporation
 aeroflexgaisler	Aeroflex Gaisler AB
+aesc	Aesc Silicon
 aesop	AESOP Embedded Forum
 al	Annapurna Labs
 alcatel	Alcatel

--- a/dts/riscv/aesc/elemrv-n.dtsi
+++ b/dts/riscv/aesc/elemrv-n.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <aesc/nitrogen.dtsi>
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "aesc,elemrv-n-soc", "simple-bus";
+		ranges;
+
+		uart0: uart0@f0006000 {
+			compatible = "aesc,uart";
+			reg = <0xf0006000 0x1000>;
+			status = "disabled";
+		};
+	};
+};

--- a/dts/riscv/aesc/nitrogen.dtsi
+++ b/dts/riscv/aesc/nitrogen.dtsi
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <freq.h>
+#include <mem.h>
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			compatible = "litex,vexriscv-standard";
+			device_type = "cpu";
+			reg = <0>;
+			riscv,isa = "rv32imc";
+			status = "okay";
+
+			hlic: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+	};
+
+	soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "aesc,nitrogen-soc", "simple-bus";
+		ranges;
+
+		mtimer: machine-timer@f0020000 {
+			compatible = "riscv,machine-timer";
+			reg = <0xf0020000 0x8 0xf0020008 0x8>;
+			interrupts-extended = <&hlic 7>;
+			status = "okay";
+		};
+	};
+};

--- a/soc/aesc/CMakeLists.txt
+++ b/soc/aesc/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(.)
+
+add_subdirectory(${SOC_SERIES})

--- a/soc/aesc/Kconfig
+++ b/soc/aesc/Kconfig
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "*/Kconfig"

--- a/soc/aesc/Kconfig.defconfig
+++ b/soc/aesc/Kconfig.defconfig
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "*/Kconfig.defconfig"

--- a/soc/aesc/Kconfig.soc
+++ b/soc/aesc/Kconfig.soc
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+rsource "*/Kconfig.soc"

--- a/soc/aesc/ip_identification.h
+++ b/soc/aesc/ip_identification.h
@@ -1,0 +1,104 @@
+/** @file
+ *  @brief IP Identification API.
+ *
+ *  Copyright (c) 2025 Aesc Silicon
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <zephyr/sys/util.h>
+
+#ifndef INCLUDE_DRIVERS_AESC_IP_IDENTIFICATION_H_
+#define INCLUDE_DRIVERS_AESC_IP_IDENTIFICATION_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Each Aesc Silicon IP core is equipped with a so-called IP identification
+ * table at the beginning of each register map. This table helps to identify
+ * the underlying hardware.
+ *
+ * IP identification table for API v0:
+ *
+ * +---------+---------+---------+---------+
+ * | 31 - 24 | 23 - 16 | 15 -  8 |  7 -  0 |
+ * +=========+=========+=========+=========+
+ * |     API |  Length |                ID |    0x00 (header)
+ * +---------+---------+-------------------+
+ * |   Major |   Minor |             Patch |    0x04 (version)
+ * +---------+---------+-------------------+
+ *
+ * header.api_version: Version of this IP identification table.
+ * header.length: Total length of the IP identification table.
+ *                Important to relocate the register map.
+ * header.id: ID of this IP core.
+ * version: Defines the version of this IP core with major.minor.patchlevel.
+ */
+
+struct aesc_ip_id_table {
+	uint32_t header;
+	uint32_t version;
+};
+
+#define CONV_ADDR(addr) ((struct aesc_ip_id_table *)addr)
+
+#define HEADER_API_MASK			GENMASK(31, 24)
+#define HEADER_LENGTH_MASK		GENMASK(23, 16)
+#define HEADER_ID_MASK			GENMASK(15, 0)
+#define VERSION_MAJOR_MASK		GENMASK(31, 24)
+#define VERSION_MINOR_MASK		GENMASK(23, 16)
+#define VERSION_PATCH_MASK		GENMASK(15, 0)
+
+static inline unsigned int ip_id_get_major_version(volatile uintptr_t *addr)
+{
+	const volatile struct aesc_ip_id_table *table = CONV_ADDR(addr);
+
+	return FIELD_GET(VERSION_MAJOR_MASK, table->version);
+}
+
+static inline unsigned int ip_id_get_minor_version(volatile uintptr_t *addr)
+{
+	const volatile struct aesc_ip_id_table *table = CONV_ADDR(addr);
+
+	return FIELD_GET(VERSION_MINOR_MASK, table->version);
+}
+
+static inline unsigned int ip_id_get_patchlevel(volatile uintptr_t *addr)
+{
+	const volatile struct aesc_ip_id_table *table = CONV_ADDR(addr);
+
+	return FIELD_GET(VERSION_PATCH_MASK, table->version);
+}
+
+static inline unsigned int ip_id_get_api_version(volatile uintptr_t *addr)
+{
+	const volatile struct aesc_ip_id_table *table = CONV_ADDR(addr);
+
+	return FIELD_GET(HEADER_API_MASK, table->header);
+}
+
+static inline unsigned int ip_id_get_header_length(volatile uintptr_t *addr)
+{
+	const volatile struct aesc_ip_id_table *table = CONV_ADDR(addr);
+
+	return FIELD_GET(HEADER_LENGTH_MASK, table->header);
+}
+
+static inline unsigned int ip_id_get_id(volatile uintptr_t *addr)
+{
+	const volatile struct aesc_ip_id_table *table = CONV_ADDR(addr);
+
+	return FIELD_GET(HEADER_ID_MASK, table->header);
+}
+
+static inline uintptr_t ip_id_relocate_driver(volatile uintptr_t *addr)
+{
+	return (uintptr_t)addr + ip_id_get_header_length(addr);
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* INCLUDE_DRIVERS_AESC_IP_IDENTIFICATION_H_ */

--- a/soc/aesc/nitrogen/CMakeLists.txt
+++ b/soc/aesc/nitrogen/CMakeLists.txt
@@ -1,0 +1,5 @@
+zephyr_include_directories(.)
+
+set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld
+    CACHE INTERNAL "SoC Linker script ${SOC_NAME}"
+)

--- a/soc/aesc/nitrogen/Kconfig
+++ b/soc/aesc/nitrogen/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NITROGEN
+	select RISCV
+	select RISCV_PRIVILEGED
+	select INCLUDE_RESET_VECTOR
+	select ATOMIC_OPERATIONS_C
+	select RISCV_ISA_RV32I
+	select RISCV_ISA_EXT_M
+	select RISCV_ISA_EXT_C
+	select RISCV_ISA_EXT_ZICSR
+	select RISCV_ISA_EXT_ZIFENCEI
+
+config SOC_PART_NUMBER
+	default "elemrv_n" if SOC_ELEMRV_N

--- a/soc/aesc/nitrogen/Kconfig.defconfig
+++ b/soc/aesc/nitrogen/Kconfig.defconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_NITROGEN
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+config NUM_IRQS
+	default 12
+
+config XIP
+	default n
+
+endif # SOC_SERIES_NITROGEN

--- a/soc/aesc/nitrogen/Kconfig.soc
+++ b/soc/aesc/nitrogen/Kconfig.soc
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Aesc Silicon
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_NITROGEN
+	bool
+
+config SOC_ELEMRV_N
+	bool
+	select SOC_SERIES_NITROGEN
+
+config SOC_SERIES
+	default "nitrogen" if SOC_SERIES_NITROGEN
+
+config SOC
+	default "elemrv_n" if SOC_ELEMRV_N

--- a/soc/aesc/nitrogen/linker.ld
+++ b/soc/aesc/nitrogen/linker.ld
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/arch/riscv/common/linker.ld>

--- a/soc/aesc/nitrogen/soc.h
+++ b/soc/aesc/nitrogen/soc.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 Aesc Silicon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __RISCV32_AESC_VEXRISCV_NITROGEN_SOC_H_
+#define __RISCV32_AESC_VEXRISCV_NITROGEN_SOC_H_
+
+#endif /* __RISCV32_AESC_VEXRISCV_NITROGEN_SOC_H_ */

--- a/soc/aesc/soc.yml
+++ b/soc/aesc/soc.yml
@@ -1,0 +1,4 @@
+series:
+- name: nitrogen
+  socs:
+  - name: elemrv_n


### PR DESCRIPTION


This pull-request adds initial support for ElemRV-N [0], an end-to-end open-source RISC-V microcontroller designed using SpinalHDL successfully tapped-out with IHP's Open PDK [1].

Support for interfaces already exists on my fork and will be added after this PR got merged.

0: https://github.com/aesc-silicon/elemrv
1: https://github.com/IHP-GmbH/IHP-Open-PDK
