### PR TITLE
drivers: NXP ENET: fix for issue: calling Timestamp IRQ handler from ISR.

### DIFF
--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -626,6 +626,10 @@ static void eth_nxp_enet_isr(const struct device *dev)
 		nxp_enet_driver_cb(config->mdio, NXP_ENET_MDIO, NXP_ENET_INTERRUPT, NULL);
 	}
 
+	if ((eir & kENET_TsAvailInterrupt) || (eir & kENET_TsTimerInterrupt)) {
+		ENET_TimeStampIRQHandler(ENET_IRQ_HANDLER_ARGS(data->base, &data->enet_handle));
+	}
+
 	irq_unlock(irq_lock_key);
 }
 


### PR DESCRIPTION
Fixes #89444

When compiled with gPTP support, the NXP ENET driver does not call the timestamp IRQ handler (ENET_TimeStampIRQHandler()) handling timer interrupt events (counting seconds of ENET PTP clock) and timestamp available events (tx packet timestamp available). Consequently, the event flags are never reset. The system will not respond anymore (does not execute other threads anymore). Moreover, the seconds of the ENET PTP clock are not updated correctly since timer events are not handled. (The timestamp available events are less critical since they are also written to the packet data structure after transmission.) Obviously, this leads to a broken gPTP implementation for NXP ENET since seconds are not tracked correctly.

The problem is easy to fix: call the existing ENET_TimeStampIRQHandler() from eth_nxp_enet_isr() when timer interrupt events or timestamp available events are set.
