### PR TITLE
drivers: sensor: tmp1075: add support for fractional threshold values

### DIFF
--- a/drivers/sensor/ti/tmp1075/tmp1075.h
+++ b/drivers/sensor/ti/tmp1075/tmp1075.h
@@ -14,6 +14,10 @@
 
 /* Extended resolution is not supported on TMP1075 */
 #define TMP1075_DATA_NORMAL_SHIFT 4
+#define TMP1075_DATA_FRAC_SHIFT   4
+#define TMP1075_DATA_FRAC_MASK    0x00F0
+#define TMP1075_DATA_INTE_SHIFT   8
+#define TMP1075_DATA_INTE_MASK    0xFF00
 #define uCELSIUS_IN_CELSIUS       1000000
 
 #define TMP1075_REG_TEMPERATURE 0x00


### PR DESCRIPTION
Previously, the TMP1075 driver only used the integer part (val1) of the sensor_value when setting TLOW and THIGH thresholds. This limited the precision of temperature threshold configuration and could be insufficient in applications requiring fine-grained control.

This patch adds proper handling for the fractional part (val2) by encoding it into bits [7:4] of the 12-bit temperature register according to the TMP1075 datasheet. The decoding logic in get_threshold_attribute() is also updated to recover the fractional value accurately.