### PR TITLE
driver: ptp clock NXP ENET: invalid assertion

### DIFF
--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -152,7 +152,7 @@ void nxp_enet_ptp_clock_callback(const struct device *dev,
 	struct ptp_clock_nxp_enet_data *data = dev->data;
 	struct nxp_enet_ptp_data *ptp_data;
 
-	__ASSERT(cb_data == NULL, "ptp data is NULL");
+	__ASSERT(cb_data != NULL, "ptp data is NULL");
 
 	ptp_data = (struct nxp_enet_ptp_data *)cb_data;
 


### PR DESCRIPTION
Fixes #89449

The following assertion in the NXP PTP driver, function nxp_enet_ptp_clock_callback(), file zephyr/drivers/ptp_clock/ptp_clock_nxp_enet.c, is wrong:

```
__ASSERT(cb_data == NULL, "ptp data is NULL");
```

The intention is to ensure that cb_data is *not* NULL, therefore, the check should be for cb_data != NULL:

```
__ASSERT(cb_data != NULL, "ptp data is NULL");
```
