### PR TITLE
boards: beagle: enable shell support for BeagleBone AI64 and BeagleY-AI

### DIFF
--- a/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
+++ b/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
@@ -19,6 +19,7 @@
 	chosen {
 		zephyr,sram = &atcm;
 		zephyr,console = &uart2;
+		zephyr,shell-uart = &uart2;
 	};
 
 	cpus {

--- a/boards/beagle/beagley_ai/beagley_ai_j722s_main_r5f0_0.dts
+++ b/boards/beagle/beagley_ai/beagley_ai_j722s_main_r5f0_0.dts
@@ -18,6 +18,7 @@
 	chosen {
 		zephyr,sram = &atcm;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	cpus {

--- a/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
+++ b/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
@@ -18,6 +18,7 @@
 	chosen {
 		zephyr,sram = &atcm;
 		zephyr,console = &uart1;
+		zephyr,shell-uart = &uart1;
 	};
 
 	cpus {


### PR DESCRIPTION
Introduce shell access to BeagleBone AI64 and BeagleY-AI.