### PR TITLE
drivers: ethernet: xlnx_gem: add set_config function

### DIFF
--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -48,6 +48,9 @@ static enum ethernet_hw_caps
 static int  eth_xlnx_gem_get_config(const struct device *dev,
 				    enum ethernet_config_type type,
 				    struct ethernet_config *config);
+static int eth_xlnx_gem_set_config(const struct device *dev,
+				   enum ethernet_config_type type,
+				   const struct ethernet_config *config);
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 static struct net_stats_eth *eth_xlnx_gem_stats(const struct device *dev);
 #endif
@@ -73,6 +76,7 @@ static const struct ethernet_api eth_xlnx_gem_apis = {
 	.start		  = eth_xlnx_gem_start_device,
 	.stop		  = eth_xlnx_gem_stop_device,
 	.get_config	  = eth_xlnx_gem_get_config,
+	.set_config	  = eth_xlnx_gem_set_config,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	.get_stats	  = eth_xlnx_gem_stats,
 #endif
@@ -649,9 +653,7 @@ static enum ethernet_hw_caps eth_xlnx_gem_get_capabilities(
 		caps |= ETHERNET_DUPLEX_SET;
 	}
 
-	if (dev_conf->copy_all_frames) {
-		caps |= ETHERNET_PROMISC_MODE;
-	}
+	caps |= ETHERNET_PROMISC_MODE;
 
 	return caps;
 }
@@ -706,6 +708,55 @@ static int eth_xlnx_gem_get_config(const struct device *dev,
 	default:
 		return -ENOTSUP;
 	};
+}
+
+/**
+ * @brief GEM hardware configuration data set function
+ * Modifies hardware configuration details of the specified device
+ * instance. Multiple hardware configuration items can be addressed
+ * depending on the type parameter. Currently supports setting the
+ * controller's MAC address and enabling/disabling promiscuous mode
+ * if this is enabled at the system level.
+ *
+ * @param dev Pointer to the device data
+ * @param type The hardware configuration item to be modified
+ * @param config Pointer to the struct containing the configuration
+ *               data to be applied.
+ * @return 0 if the specified configuration item was successfully
+ *         modified, -ENOTSUP if the specified configuration item
+ *         is not supported by this function.
+ */
+static int eth_xlnx_gem_set_config(const struct device *dev,
+				   enum ethernet_config_type type,
+				   const struct ethernet_config *config)
+{
+	struct eth_xlnx_gem_dev_data *dev_data = dev->data;
+
+	switch (type) {
+#ifdef CONFIG_NET_PROMISCUOUS_MODE
+	case ETHERNET_CONFIG_TYPE_PROMISC_MODE:
+		const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
+		uint32_t reg_val = sys_read32(dev_conf->base_addr + ETH_XLNX_GEM_NWCFG_OFFSET);
+
+		if (config->promisc_mode) {
+			reg_val |= ETH_XLNX_GEM_NWCFG_COPYALLEN_BIT;
+		} else {
+			reg_val &= ~ETH_XLNX_GEM_NWCFG_COPYALLEN_BIT;
+		}
+		sys_write32(reg_val, dev_conf->base_addr + ETH_XLNX_GEM_NWCFG_OFFSET);
+		break;
+#endif
+	case ETHERNET_CONFIG_TYPE_MAC_ADDRESS:
+		memcpy(dev_data->mac_addr, config->mac_address.addr, sizeof(dev_data->mac_addr));
+		eth_xlnx_gem_set_mac_address(dev);
+		net_if_set_link_addr(dev_data->iface, dev_data->mac_addr,
+				     sizeof(dev_data->mac_addr), NET_LINK_ETHERNET);
+		break;
+	default:
+		return -ENOTSUP;
+	};
+
+	return 0;
 }
 
 #ifdef CONFIG_NET_STATISTICS_ETHERNET
@@ -983,10 +1034,6 @@ static void eth_xlnx_gem_set_initial_nwcfg(const struct device *dev)
 	if (dev_conf->disable_bcast) {
 		/* [05]     Do not receive broadcast frames */
 		reg_val |= ETH_XLNX_GEM_NWCFG_BCASTDIS_BIT;
-	}
-	if (dev_conf->copy_all_frames) {
-		/* [04]     Copy all frames */
-		reg_val |= ETH_XLNX_GEM_NWCFG_COPYALLEN_BIT;
 	}
 	if (dev_conf->discard_non_vlan) {
 		/* [02]     Receive only VLAN frames */

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -464,7 +464,6 @@ static const struct eth_xlnx_gem_dev_cfg eth_xlnx_gem##port##_dev_cfg = {\
 	.enable_ucast_hash		= DT_INST_PROP(port, unicast_hash),\
 	.enable_mcast_hash		= DT_INST_PROP(port, multicast_hash),\
 	.disable_bcast			= DT_INST_PROP(port, reject_broadcast),\
-	.copy_all_frames		= DT_INST_PROP(port, promiscuous_mode),\
 	.discard_non_vlan		= DT_INST_PROP(port, discard_non_vlan),\
 	.enable_fdx			= DT_INST_PROP(port, full_duplex),\
 	.disc_rx_ahb_unavail		= DT_INST_PROP(port, discard_rx_frame_ahb_unavail),\
@@ -722,7 +721,6 @@ struct eth_xlnx_gem_dev_cfg {
 	bool				enable_ucast_hash : 1;
 	bool				enable_mcast_hash : 1;
 	bool				disable_bcast : 1;
-	bool				copy_all_frames : 1;
 	bool				discard_non_vlan : 1;
 	bool				enable_fdx : 1;
 	bool				disc_rx_ahb_unavail : 1;

--- a/dts/bindings/ethernet/xlnx,gem.yaml
+++ b/dts/bindings/ethernet/xlnx,gem.yaml
@@ -313,12 +313,6 @@ properties:
       Optional feature flag - Reject broadcast frames. When set, frames
       addressed to the all-ones broadcast address will be rejected.
 
-  promiscuous-mode:
-    type: boolean
-    description: |
-      Optional feature flag - Enable promiscuous mode. When set, all valid
-      frames will be accepted.
-
   discard-non-vlan:
     type: boolean
     description: Optional feature flag - Discard non-VLAN frames. When set,


### PR DESCRIPTION
Add an implementation for the Ethernet API's set_config hook to the Xilinx GEM device driver.

Supported features:
- change MAC address at run-time
- enable/disable promiscuous mode (only if this feature is enabled at system level)

Checked for the correct contents of the NWCFG (enable/disable promiscuous mode) and MAC address top/bottom registers post calling set_config using a hardware debugger on an XC7Z020.