### PR TITLE
Bluetooth: BAP: Add control point cbs to BASS

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -791,6 +791,52 @@ struct bt_bap_scan_delegator_cb {
 	 * @param is_scanning true if scanning started, false if scanning stopped.
 	 */
 	void (*scanning_state)(struct bt_conn *conn, bool is_scanning);
+	/**
+	 * @brief Add Source operation callback
+	 *
+	 * These callbacks notify the application when a request comes
+	 * in to add a source. The application can return 0 to
+	 * accept or any other value to reject the request.
+	 *
+	 * @param conn       Pointer to the connection that initiated the request,
+	 *                   or NULL if locally triggered.
+	 * @param recv_state Pointer to the requested receive state to be added.
+	 *
+	 * @return 0 in case of accept, or other value to reject.
+	 */
+	int (*add_source)(struct bt_conn *conn,
+			  const struct bt_bap_scan_delegator_recv_state *recv_state);
+
+	/**
+	 * @brief Modify Source operation callback
+	 *
+	 * These callbacks notify the application when a request comes
+	 * in to modify a source. The application can return 0 to
+	 * accept or any other value to reject the request.
+	 *
+	 * @param conn       Pointer to the connection that initiated the request,
+	 *                   or NULL if locally triggered.
+	 * @param recv_state Pointer to the requested receive state to be modified.
+	 *
+	 * @return 0 in case of accept, or other value to reject.
+	 */
+	int (*modify_source)(struct bt_conn *conn,
+			     const struct bt_bap_scan_delegator_recv_state *recv_state);
+
+	/**
+	 * @brief Remove Source operation callback
+	 *
+	 * These callbacks notify the application when a request comes
+	 * in to remove a source. The application can return 0 to
+	 * accept or any other value to reject the request.
+	 *
+	 * @param conn   Pointer to the connection that initiated the request,
+	 *               or NULL if locally triggered.
+	 * @param src_id The Source ID that is requested to be removed.
+	 *
+	 * @return 0 in case of accept, or other value to reject.
+	 */
+	int (*remove_source)(struct bt_conn *conn, uint8_t src_id);
 };
 
 /** Structure holding information of audio stream endpoint */

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -51,6 +51,8 @@ CREATE_FLAG(flag_recv_state_updated_with_bis_sync);
 CREATE_FLAG(flag_recv_state_removed);
 CREATE_FLAG(flag_broadcast_code_requested);
 CREATE_FLAG(flag_incorrect_broadcast_code);
+CREATE_FLAG(flag_remove_source_cb_called);
+CREATE_FLAG(flag_remove_source_rejected);
 
 /* Broadcaster variables */
 static bt_addr_le_t g_broadcaster_addr;
@@ -256,8 +258,16 @@ static void bap_broadcast_assistant_broadcast_code_cb(struct bt_conn *conn, int 
 
 static void bap_broadcast_assistant_rem_src_cb(struct bt_conn *conn, int err)
 {
+	SET_FLAG(flag_remove_source_cb_called);
+
 	if (err != 0) {
-		FAIL("BASS remove source failed (%d)\n", err);
+		if (err == BT_ATT_ERR_WRITE_REQ_REJECTED) {
+			SET_FLAG(flag_remove_source_rejected);
+			printk("Remove source rejected (expected): err=%d\n", err);
+			return;
+		}
+
+		FAIL("BASS remove source failed (err %d)\n", err);
 		return;
 	}
 
@@ -690,9 +700,20 @@ static void test_bass_remove_source(void)
 	printk("Removing source\n");
 	UNSET_FLAG(flag_cb_called);
 	UNSET_FLAG(flag_write_complete);
+	UNSET_FLAG(flag_remove_source_cb_called);
+	UNSET_FLAG(flag_remove_source_rejected);
+
 	err = bt_bap_broadcast_assistant_rem_src(default_conn, recv_state.src_id);
 	if (err != 0) {
 		FAIL("Could not remove source (err %d)\n", err);
+		return;
+	}
+
+	/* Wait for the remove callback to be invoked */
+	WAIT_FOR_FLAG(flag_remove_source_cb_called);
+
+	if (TEST_FLAG(flag_remove_source_rejected)) {
+		printk("Remove source was rejected as expected\n");
 		return;
 	}
 
@@ -802,6 +823,12 @@ static void test_main_server_sync_client_rem(void)
 
 	printk("Waiting for receive state with BIS sync\n");
 	WAIT_FOR_FLAG(flag_recv_state_updated_with_bis_sync);
+
+	printk("Attempting to remove source for the first time\n");
+	test_bass_remove_source();
+
+	WAIT_FOR_FLAG(flag_remove_source_rejected);
+	printk("First remove source attempt was rejected as expected\n");
 
 	test_bass_remove_source();
 

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -40,7 +40,13 @@ CREATE_FLAG(flag_broadcast_code_received);
 CREATE_FLAG(flag_recv_state_updated);
 CREATE_FLAG(flag_bis_sync_requested);
 CREATE_FLAG(flag_bis_sync_term_requested);
+CREATE_FLAG(flag_broadcast_source_added);
+CREATE_FLAG(flag_broadcast_source_modified);
+CREATE_FLAG(flag_broadcast_source_removed);
+CREATE_FLAG(flag_remove_source_rejected);
+
 static volatile uint32_t g_broadcast_id;
+static bool reject_control_op;
 
 struct sync_state {
 	uint8_t src_id;
@@ -240,6 +246,13 @@ static void recv_state_updated_cb(struct bt_conn *conn,
 	SET_FLAG(flag_recv_state_updated);
 }
 
+static void reset_cp_flags(void)
+{
+	UNSET_FLAG(flag_broadcast_source_added);
+	UNSET_FLAG(flag_broadcast_source_modified);
+	UNSET_FLAG(flag_broadcast_source_removed);
+}
+
 static int pa_sync_req_cb(struct bt_conn *conn,
 			  const struct bt_bap_scan_delegator_recv_state *recv_state,
 			  bool past_avail, uint16_t pa_interval)
@@ -247,6 +260,7 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 	struct sync_state *state;
 	int err;
 
+	reset_cp_flags();
 	printk("PA Sync request: past_avail %u, pa_interval 0x%04x\n: %p",
 	       past_avail, pa_interval, recv_state);
 
@@ -351,12 +365,44 @@ static int bis_sync_req_cb(struct bt_conn *conn,
 	return 0;
 }
 
+static int add_source_cb(struct bt_conn *conn,
+	const struct bt_bap_scan_delegator_recv_state *recv_state)
+{
+	printk("Add Source callback: src_id=%u\n", recv_state->src_id);
+	SET_FLAG(flag_broadcast_source_added);
+	return 0;
+}
+
+static int modify_source_cb(struct bt_conn *conn,
+	   const struct bt_bap_scan_delegator_recv_state *recv_state)
+{
+	printk("Modify Source callback: src_id=%u\n", recv_state->src_id);
+	SET_FLAG(flag_broadcast_source_modified);
+	return 0;
+}
+
+static int remove_source_cb(struct bt_conn *conn, uint8_t src_id)
+{
+	printk("Remove Source callback: src_id=%u\n", src_id);
+
+	if (reject_control_op) {
+		SET_FLAG(flag_remove_source_rejected);
+		return BT_ATT_ERR_WRITE_REQ_REJECTED;
+	}
+
+	SET_FLAG(flag_broadcast_source_removed);
+	return 0;
+}
+
 static struct bt_bap_scan_delegator_cb scan_delegator_cb = {
 	.recv_state_updated = recv_state_updated_cb,
 	.pa_sync_req = pa_sync_req_cb,
 	.pa_sync_term_req = pa_sync_term_req_cb,
 	.broadcast_code = broadcast_code_cb,
 	.bis_sync_req = bis_sync_req_cb,
+	.add_source = add_source_cb,
+	.modify_source = modify_source_cb,
+	.remove_source = remove_source_cb
 };
 
 static void pa_synced_cb(struct bt_le_per_adv_sync *sync,
@@ -728,6 +774,7 @@ static void test_main_client_sync(void)
 		return;
 	}
 
+	WAIT_FOR_FLAG(flag_broadcast_source_added);
 	/* Wait for broadcast assistant to request us to sync to PA */
 	printk("Waiting for flag_pa_synced\n");
 	WAIT_FOR_FLAG(flag_pa_synced);
@@ -735,6 +782,7 @@ static void test_main_client_sync(void)
 	/* Mod all sources by modifying the metadata */
 	mod_all_sources();
 
+	WAIT_FOR_FLAG(flag_broadcast_source_modified);
 	/* Wait for broadcast assistant to tell us to BIS sync */
 	printk("Waiting for flag_bis_sync_requested\n");
 	WAIT_FOR_FLAG(flag_bis_sync_requested);
@@ -750,6 +798,7 @@ static void test_main_client_sync(void)
 	printk("Waiting for flag_pa_terminated\n");
 	WAIT_FOR_FLAG(flag_pa_terminated);
 
+	WAIT_FOR_FLAG(flag_broadcast_source_removed);
 	PASS("BAP Scan Delegator Client Sync passed\n");
 }
 
@@ -788,6 +837,13 @@ static void test_main_server_sync_client_rem(void)
 	/* Set the BIS sync state */
 	sync_all_broadcasts();
 
+	/* Enable rejection for the first remove source request */
+	reject_control_op = true;
+
+	WAIT_FOR_FLAG(flag_remove_source_rejected);
+
+	/* Disable rejection for subsequent remove source requests */
+	reject_control_op = false;
 	/* For for client to remove source and thus terminate the PA */
 	printk("Waiting for flag_pa_terminated\n");
 	WAIT_FOR_FLAG(flag_pa_terminated);


### PR DESCRIPTION
For the control point operations, add/modify/
remove source, callbacks are added so that Application can decide whether to accept/reject the control point operations.

Fixes: #82921 