### PR TITLE
Bluetooth: Host: remove useless select in BT_HOST_CRYPTO_PRNG

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -182,9 +182,6 @@ config BT_HOST_CRYPTO
 config BT_HOST_CRYPTO_PRNG
 	bool "Use PSA crypto API library for random number generation"
 	default y
-	select PSA_WANT_ALG_SHA_256
-	select PSA_WANT_KEY_TYPE_HMAC
-	select PSA_WANT_ALG_HMAC
 	depends on BT_HOST_CRYPTO
 	help
 	  When selected, will use PSA Crypto API library for random number generation.


### PR DESCRIPTION
PSA Crypto API always allow psa_generate_random() to be called (i.e. there is no PSA_WANT_xxx symbol that can be used to disable it). How random numbers are generated internally is a library internal detail, but the end user (Bluetooth) does not need to worry about this.

Hash SHA-256 and HMAC were leftover from the transition from TinyCrypt to PSA Crypto API, but these are not required in the latter case. Keeping them enabled ends up in enabling more stuff than it's strictly necessary in PSA Crypto API.