### PR TITLE
doc: guidelines: fix twister test sensors command

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -588,7 +588,7 @@ for example:
 
 .. code-block:: bash
 
-   west twister -p native_sim -s tests/drivers/build_all/sensor/sensors.generic_test
+   west twister -p native_sim -s tests/drivers/build_all/sensor/drivers.sensor.generic_test
 
 .. _static_analysis:
 


### PR DESCRIPTION
This commit updates the test suite name according to the changes made in #87714 