### PR TITLE
drivers: sensor: maxim,ds3231: fix config dependency

### DIFF
--- a/drivers/sensor/maxim/ds3231/Kconfig
+++ b/drivers/sensor/maxim/ds3231/Kconfig
@@ -14,9 +14,13 @@ config SENSOR_DS3231
 	help
 	  Enable driver for DS3231 I2C-based temperature sensor.
 
+if SENSOR_DS3231
+
 config SENSOR_DS3231_INIT_PRIORITY
 	int "DS3231 sensor driver init priority"
 	default 86
 	help
 	Init priority for the DS3231 sensor driver. It must be
 	greater than MFD_INIT_PRIORITY.
+
+endif # SENSOR_DS3231


### PR DESCRIPTION
Make the config which is specific for DS3231 depend on the driver for it being enabled.