### PR TITLE
net: fix configuration of `NET_LINK_ADDR_MAX_LENGTH`

### DIFF
--- a/include/zephyr/net/net_linkaddr.h
+++ b/include/zephyr/net/net_linkaddr.h
@@ -30,14 +30,10 @@ extern "C" {
  */
 
 /** Maximum length of the link address */
-#ifdef CONFIG_NET_L2_IEEE802154
-#define NET_LINK_ADDR_MAX_LENGTH 8
-#else
-#ifdef CONFIG_NET_L2_PPP
+#if defined(CONFIG_NET_L2_PHY_IEEE802154) || defined(CONFIG_NET_L2_PPP)
 #define NET_LINK_ADDR_MAX_LENGTH 8
 #else
 #define NET_LINK_ADDR_MAX_LENGTH 6
-#endif
 #endif
 
 /**


### PR DESCRIPTION
Replace `CONFIG_NET_L2_IEEE802154` with `CONFIG_NET_L2_PHY_IEEE802154` as `NET_LINK_ADDR_MAX_LENGTH` should be set to `8` for all IEEE 802.15.4 based L2, e.g. OpenThread.