### PR TITLE
dts: ite: it51xxx: Change the base address of voltage selection

### DIFF
--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -92,7 +92,7 @@
 			reg = <0x00f01601 1   /* GPDR (set) */
 			       0x00f01661 1   /* GPDMR (get) */
 			       0x00f01671 1   /* GPOTR */
-			       0x00f016d4 1   /* P18SCR */
+			       0x00f05001 1   /* GPxyCR1 */
 			       0x00f01610 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -114,7 +114,7 @@
 				   &wuc_wu82    /* GPA5 */
 				   &wuc_wu83    /* GPA6 */
 				   &wuc_wu100>; /* GPA7 */
-			has-volt-sel = <1 1 1 1 0 0 1 1>;
+			has-volt-sel = <1 1 1 1 1 1 1 1>;
 			#gpio-cells = <2>;
 		};
 
@@ -123,7 +123,7 @@
 			reg = <0x00f01602 1   /* GPDR (set) */
 			       0x00f01662 1   /* GPDMR (get) */
 			       0x00f01672 1   /* GPOTR */
-			       0x00f016d5 1   /* P18SCR */
+			       0x00f05011 1   /* GPxyCR1 */
 			       0x00f01618 7   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <7>;
@@ -143,7 +143,7 @@
 				   &wuc_no_func /* NO_FUNC */
 				   &wuc_wu104   /* GPB5 */
 				   &wuc_wu105>; /* GPB6 */
-			has-volt-sel = <0 0 1 0 0 0 0 0>;
+			has-volt-sel = <0 0 1 0 0 1 1 0>;
 			#gpio-cells = <2>;
 		};
 
@@ -152,7 +152,7 @@
 			reg = <0x00f01603 1   /* GPDR (set) */
 			       0x00f01663 1   /* GPDMR (get) */
 			       0x00f01673 1   /* GPOTR */
-			       0x00f016d6 1   /* P18SCR */
+			       0x00f05021 1   /* GPxyCR1 */
 			       0x00f01620 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -174,7 +174,7 @@
 				   &wuc_wu109  /* GPC5 */
 				   &wuc_wu23   /* GPC6 */
 				   &wuc_wu86>; /* GPC7 */
-			has-volt-sel = <1 0 0 1 1 1 1 0>;
+			has-volt-sel = <1 1 1 1 1 1 1 1>;
 			#gpio-cells = <2>;
 		};
 
@@ -183,7 +183,7 @@
 			reg = <0x00f01604 1   /* GPDR (set) */
 			       0x00f01664 1   /* GPDMR (get) */
 			       0x00f01674 1   /* GPOTR */
-			       0x00f016d7 1   /* P18SCR */
+			       0x00f05031 1   /* GPxyCR1 */
 			       0x00f01628 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -205,7 +205,7 @@
 				   &wuc_wu112  /* GPD5 */
 				   &wuc_wu113  /* GPD6 */
 				   &wuc_wu87>; /* GPD7 */
-			has-volt-sel = <0 0 0 0 0 1 1 1>;
+			has-volt-sel = <1 1 1 1 1 1 1 1>;
 			#gpio-cells = <2>;
 		};
 
@@ -214,7 +214,7 @@
 			reg = <0x00f01605 1   /* GPDR (set) */
 			       0x00f01665 1   /* GPDMR (get) */
 			       0x00f01675 1   /* GPOTR */
-			       0x00f016d8 1   /* P18SCR */
+			       0x00f05041 1   /* GPxyCR1 */
 			       0x00f01630 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -236,7 +236,7 @@
 				   &wuc_wu40   /* GPE5 */
 				   &wuc_wu45   /* GPE6 */
 				   &wuc_wu46>; /* GPE7 */
-			has-volt-sel = <0 1 1 1 0 1 0 0>;
+			has-volt-sel = <1 1 1 1 0 1 1 1>;
 			#gpio-cells = <2>;
 		};
 
@@ -245,7 +245,7 @@
 			reg = <0x00f01606 1   /* GPDR (set) */
 			       0x00f01666 1   /* GPDMR (get) */
 			       0x00f01676 1   /* GPOTR */
-			       0x00f016d9 1   /* P18SCR */
+			       0x00f05051 1   /* GPxyCR1 */
 			       0x00f01638 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -267,7 +267,7 @@
 				   &wuc_wu65   /* GPF5 */
 				   &wuc_wu66   /* GPF6 */
 				   &wuc_wu67>; /* GPF7 */
-			has-volt-sel = <1 1 0 0 0 0 0 0>;
+			has-volt-sel = <1 1 1 1 1 1 1 1>;
 			#gpio-cells = <2>;
 		};
 
@@ -276,7 +276,7 @@
 			reg = <0x00f01607 1   /* GPDR (set) */
 			       0x00f01667 1   /* GPDMR (get) */
 			       0x00f01677 1   /* GPOTR */
-			       0x00f016da 1   /* P18SCR */
+			       0x00f05061 1   /* GPxyCR1 */
 			       0x00f01640 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -298,7 +298,7 @@
 				   &wuc_no_func   /* NO_FUNC */
 				   &wuc_wu118     /* GPG6 */
 				   &wuc_no_func>; /* NO_FUNC */
-			has-volt-sel = <1 0 1 0 0 0 0 0>;
+			has-volt-sel = <1 1 1 0 0 0 1 0>;
 			#gpio-cells = <2>;
 		};
 
@@ -307,7 +307,7 @@
 			reg = <0x00f01608 1   /* GPDR (set) */
 			       0x00f01668 1   /* GPDMR (get) */
 			       0x00f01678 1   /* GPOTR */
-			       0x00f016db 1   /* P18SCR */
+			       0x00f05071 1   /* GPxyCR1 */
 			       0x00f01648 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -329,7 +329,7 @@
 				   &wuc_wu89    /* GPH5 */
 				   &wuc_wu90    /* GPH6 */
 				   &wuc_wu127>; /* GPH7 */
-			has-volt-sel = <0 0 0 1 1 1 1 1>;
+			has-volt-sel = <1 1 1 1 1 0 0 1>;
 			#gpio-cells = <2>;
 		};
 
@@ -338,7 +338,7 @@
 			reg = <0x00f01609 1   /* GPDR (set) */
 			       0x00f01669 1   /* GPDMR (get) */
 			       0x00f01679 1   /* GPOTR */
-			       0x00f016dc 1   /* P18SCR */
+			       0x00f05081 1   /* GPxyCR1 */
 			       0x00f01650 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -369,7 +369,7 @@
 			reg = <0x00f0160a 1   /* GPDR (set) */
 			       0x00f0166a 1   /* GPDMR (get) */
 			       0x00f0167a 1   /* GPOTR */
-			       0x00f016dd 1   /* P18SCR */
+			       0x00f05091 1   /* GPxyCR1 */
 			       0x00f01658 8   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <8>;
@@ -400,7 +400,7 @@
 			reg = <0x00f0160b 1   /* GPDR (set) */
 			       0x00f0166b 1   /* GPDMR (get) */
 			       0x00f0167b 1   /* GPOTR */
-			       NO_FUNC 1      /* P18SCR */
+			       NO_FUNC 1      /* GPxyCR1 */
 			       0x00f01690 8   /* GPCR */
 			       0x00f01d2d 1>; /* KSOLFSELR */
 			ngpios = <8>;
@@ -430,7 +430,7 @@
 			reg = <0x00f0160c 1   /* GPDR (set) */
 			       0x00f0166c 1   /* GPDMR (get) */
 			       0x00f0167c 1   /* GPOTR */
-			       NO_FUNC 1      /* P18SCR */
+			       NO_FUNC 1      /* GPxyCR1 */
 			       0x00f01698 8   /* GPCR */
 			       0x00f01d2e 1>; /* KSOHFSELR */
 			ngpios = <8>;
@@ -460,7 +460,7 @@
 			reg = <0x00f0160d 1   /* GPDR (set) */
 			       0x00f0166d 1   /* GPDMR (get) */
 			       NO_FUNC 1      /* GPOTR */
-			       NO_FUNC 1      /* P18SCR */
+			       NO_FUNC 1      /* GPxyCR1 */
 			       0x00f016a0 7   /* GPCR */
 			       NO_FUNC 1>;
 			ngpios = <7>;
@@ -488,7 +488,7 @@
 			reg = <0x00f0160e 1   /* GPDR (set) */
 			       0x00f0166e 1   /* GPDMR (get) */
 			       0x00f0167e 1   /* GPOTR */
-			       NO_FUNC 1      /* P18SCR */
+			       NO_FUNC 1      /* GPxyCR1 */
 			       0x00f016a8 8   /* GPCR */
 			       0x00f01d2c 1>; /* KSIFSELR */
 			ngpios = <8>;
@@ -532,10 +532,10 @@
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
 			func4-en-mask = <0        0        0        0
 					 0        0        0        0       >;
-			volt-sel =      <0xf016d4 0xf016d4 0xf016d4 0xf016d4
-					 NO_FUNC  NO_FUNC  0xf016d4 0xf016d4>;
-			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-					 0        0        BIT(6)   BIT(7)  >;
+			volt-sel =      <0xf05001 0xf05003 0xf05005 0xf05007
+					 0xf05009 0xf0500b 0xf0500d 0xf0500f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   BIT(3)
+					 BIT(3)   BIT(3)   BIT(3)   BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -552,10 +552,10 @@
 					 NO_FUNC  0xf016ed NO_FUNC  NO_FUNC >;
 			func4-en-mask = <0        0        BIT(2)   0
 					 0        BIT(3)   0        0       >;
-			volt-sel =      <NO_FUNC  NO_FUNC  0xf016d5 NO_FUNC
-					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
-			volt-sel-mask = <0        0        BIT(2)   0
-					 0        0        0        0       >;
+			volt-sel =      <NO_FUNC  NO_FUNC  0xf05015 NO_FUNC
+					 NO_FUNC  0xf0501b 0xf0501d NO_FUNC >;
+			volt-sel-mask = <0        0        BIT(3)   0
+					 0        BIT(3)   BIT(3)   0       >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -572,10 +572,10 @@
 					 NO_FUNC  NO_FUNC  0xf016f4 0xf016f5>;
 			func4-en-mask = <0        0        0        0
 					 0        0        BIT(0)   BIT(0)  >;
-			volt-sel =      <0xf016d6 NO_FUNC  NO_FUNC  0xf016d6
-					 0xf016d6 0xf016d6 0xf016d6 NO_FUNC >;
-			volt-sel-mask = <BIT(0)   0        0        BIT(3)
-					 BIT(4)   BIT(5)   BIT(6)   0       >;
+			volt-sel =      <0xf05021 0xf05023 0xf05025 0xf05027
+					 0xf05029 0xf0502b 0xf0502d 0xf0502f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   BIT(3)
+					 BIT(3)   BIT(3)   BIT(3)   BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -592,10 +592,10 @@
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
 			func4-en-mask = <0        0        0        0
 					 0        0        0        0       >;
-			volt-sel =      <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
-					 NO_FUNC  0xf016d7 0xf016d7 0xf016d7>;
-			volt-sel-mask = <0        0        0        0
-					 0        BIT(5)   BIT(6)   BIT(7)  >;
+			volt-sel =      <0xf05031 0xf05033 0xf05035 0xf05037
+					 0xf05039 0xf0503b 0xf0503d 0xf0503f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   BIT(3)
+					 BIT(3)   BIT(3)   BIT(3)   BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -612,10 +612,10 @@
 					 NO_FUNC  NO_FUNC  0xf016f5 NO_FUNC >;
 			func4-en-mask = <BIT(4)   0        0        0
 					 0        0        BIT(1)   0       >;
-			volt-sel =      <NO_FUNC  0xf016d8 0xf016d8 0xf016d8
-					 NO_FUNC  0xf016d8 NO_FUNC  NO_FUNC >;
-			volt-sel-mask = <0        BIT(1)   BIT(2)   BIT(3)
-					 0        BIT(5)   0        0       >;
+			volt-sel =      <0xf05041 0xf05043 0xf05045 0xf05047
+					 NO_FUNC  0xf0504b 0xf0504d 0xf0504f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   BIT(3)
+					 0        BIT(3)   BIT(3)   BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -632,10 +632,10 @@
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
 			func4-en-mask = <0        0        0        0
 					 0        0        0        0      >;
-			volt-sel =      <0xf016d9 0xf016d9 NO_FUNC  NO_FUNC
-					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
-			volt-sel-mask = <BIT(0)   BIT(1)   0        0
-					 0        0        0        0      >;
+			volt-sel =      <0xf05051 0xf05053 0xf05055 0xf05057
+					 0xf05059 0xf0505b 0xf0505d 0xf0505f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   BIT(3)
+					 BIT(3)   BIT(3)   BIT(3)   BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -652,10 +652,10 @@
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
 			func4-en-mask = <0        BIT(6)   0        0
 					 0        0        0        0      >;
-			volt-sel =      <0xf016da NO_FUNC  0xf016da NO_FUNC
-					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC>;
-			volt-sel-mask = <BIT(0)   0        BIT(2)   0
-					 0        0        0        0      >;
+			volt-sel =      <0xf05061 0xf05063 0xf05065 NO_FUNC
+					 NO_FUNC  NO_FUNC  0xf0506d NO_FUNC>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   0
+					 0        0        BIT(3)   0      >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -672,10 +672,10 @@
 					 NO_FUNC  NO_FUNC  NO_FUNC  0xf016f5>;
 			func4-en-mask = <BIT(2)   BIT(5)   BIT(5)   0
 					 0        0        0        BIT(7)  >;
-			volt-sel =      <NO_FUNC  NO_FUNC  NO_FUNC  0xf016db
-					 0xf016db 0xf016db 0xf016db 0xf016db>;
-			volt-sel-mask = <0        0        0        BIT(3)
-					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			volt-sel =      <0xf05071 0xf05073 0xf05075 0xf05077
+					 0xf05079 NO_FUNC  NO_FUNC  0xf0507f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   BIT(3)
+					 BIT(3)   0        0        BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -692,10 +692,10 @@
 					 NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC >;
 			func4-en-mask = <0        0        0        0
 					 0        0        0        0       >;
-			volt-sel =      <0xf016dc 0xf016dc 0xf016dc 0xf016dc
-					 0xf016dc 0xf016dc 0xf016dc 0xf016dc>;
-			volt-sel-mask = <BIT(0)   BIT(1)   BIT(2)   BIT(3)
-					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			volt-sel =      <0xf05081 0xf05083 0xf05085 0xf05087
+					 0xf05089 0xf0508b 0xf0508d 0xf0508f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   BIT(3)   BIT(3)
+					 BIT(3)   BIT(3)   BIT(3)   BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};
@@ -712,10 +712,10 @@
 					 NO_FUNC  NO_FUNC  0xf016ed 0xf016f0>;
 			func4-en-mask = <0        0        0        0
 					 0        0        BIT(3)   BIT(4)  >;
-			volt-sel =      <0xf016dd NO_FUNC  0xf016dd 0xf016dd
-					 0xf016dd 0xf016dd 0xf016dd 0xf016dd>;
-			volt-sel-mask = <BIT(0)   0        BIT(2)   BIT(3)
-					 BIT(4)   BIT(5)   BIT(6)   BIT(7)  >;
+			volt-sel =      <0xf05091 0xf05093 NO_FUNC  0xf05097
+					 0xf05099 0xf0509b 0xf0509d 0xf0509f>;
+			volt-sel-mask = <BIT(3)   BIT(3)   0        BIT(3)
+					 BIT(3)   BIT(3)   BIT(3)   BIT(3)  >;
 			#pinmux-cells = <2>;
 			gpio-group;
 		};


### PR DESCRIPTION
Change the base address of GPIO and pinctrl voltage selection. The new base address enables more pins to support voltage selection.