### PR TITLE
drivers: pinctrl: npcx: add pinctrl driver support for npck3

### DIFF
--- a/drivers/pinctrl/Kconfig.npcx
+++ b/drivers/pinctrl/Kconfig.npcx
@@ -3,7 +3,6 @@
 # Copyright (c) 2022 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-
 config PINCTRL_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) pin controller driver"
 	default y
@@ -11,3 +10,9 @@ config PINCTRL_NPCX
 	help
 	  This option enables the pin controller driver for NPCX family of
 	  processors.
+
+config PINCTRL_NPCX_EX
+	bool "Extended NPCX driver support"
+	default y if DT_HAS_NUVOTON_NPCX_PINCTRL_NPCKN_ENABLED
+	help
+	  This option enables the extended driver for NPCKN variant of processors.

--- a/drivers/pinctrl/pinctrl_npcx.c
+++ b/drivers/pinctrl/pinctrl_npcx.c
@@ -139,11 +139,24 @@ static void npcx_psl_input_detection_configure(const pinctrl_soc_pin_t *pin)
 	}
 
 	/* Configure detection mode of PSL input pads */
+#if defined(CONFIG_PINCTRL_NPCX_EX)
+	if (pin->flags.psl_in_mode == NPCX_PSL_IN_MODE_EDGE) {
+		inst_glue->PSL_CTS3 |= BIT(psl_in->port);
+	} else {
+		inst_glue->PSL_CTS3 &= ~BIT(psl_in->port);
+	}
+
+	/* Clear event bits */
+	inst_glue->PSL_CTS |= BIT(psl_in->port);
+	inst_glue->PSL_IN_POS |= BIT(psl_in->port);
+	inst_glue->PSL_IN_NEG |= BIT(psl_in->port);
+#else
 	if (pin->flags.psl_in_mode == NPCX_PSL_IN_MODE_EDGE) {
 		inst_glue->PSL_CTS |= NPCX_PSL_CTS_MODE_BIT(psl_in->port);
 	} else {
 		inst_glue->PSL_CTS &= ~NPCX_PSL_CTS_MODE_BIT(psl_in->port);
 	}
+#endif /* CONFIG_PINCTRL_NPCX_EX */
 }
 
 static void npcx_device_control_configure(const pinctrl_soc_pin_t *pin)

--- a/dts/arm/nuvoton/npck/npck.dtsi
+++ b/dts/arm/nuvoton/npck/npck.dtsi
@@ -56,7 +56,7 @@
 	 *  Then, the user can override the pin control options at the board level.
 	 */
 	pinctrl: pinctrl {
-		compatible = "nuvoton,npcx-pinctrl";
+		compatible = "nuvoton,npcx-pinctrl", "nuvoton,npcx-pinctrl-npckn";
 		status = "okay";
 	};
 

--- a/dts/bindings/pinctrl/nuvoton,npcx-pinctrl-npckn.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pinctrl-npckn.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Nuvoton npcx pinctrl for npckn variant
+
+compatible: "nuvoton,npcx-pinctrl-npckn"
+
+include: nuvoton,npcx-pinctrl.yaml


### PR DESCRIPTION
1. Added pinctrl driver support for npck3.
2. Introduced a compatible-based mechanism to enhance flexibility and maintainability.