### PR TITLE
Bluetooth: Controller: Fix missing connection handle invalidate

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central_iso.c
@@ -155,6 +155,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	/* Get reference to ACL context */
 	conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+	LL_ASSERT(conn_lll != NULL);
 
 	/* Pick the event_count calculated in the ULL prepare */
 	cis_lll->event_count = cis_lll->event_count_prepare;
@@ -433,6 +434,8 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 		/* Get reference to ACL context */
 		const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 
+		LL_ASSERT(conn_lll != NULL);
+
 		if (conn_lll->enc_rx) {
 			radio_ccm_disable();
 		}
@@ -479,6 +482,8 @@ static void isr_tx(void *param)
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+
+	LL_ASSERT(conn_lll != NULL);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	/* PHY */
@@ -584,6 +589,7 @@ static void isr_tx(void *param)
 
 		/* Get reference to ACL context */
 		evt_conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+		LL_ASSERT(evt_conn_lll != NULL);
 
 		/* Calculate the radio channel to use for next subevent */
 		data_chan_id = lll_chan_id(cis_lll->access_addr);
@@ -630,6 +636,7 @@ static void isr_tx(void *param)
 
 		/* Get reference to ACL context */
 		next_conn_lll = ull_conn_lll_get(next_cis_lll->acl_handle);
+		LL_ASSERT(next_conn_lll != NULL);
 
 		/* Calculate the radio channel to use for ISO event */
 		data_chan_id = lll_chan_id(next_cis_lll->access_addr);
@@ -770,6 +777,8 @@ static void isr_rx(void *param)
 			/* Get reference to ACL context */
 			const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 
+			LL_ASSERT(conn_lll != NULL);
+
 			/* If required, wait for CCM to finish
 			 */
 			if (pdu_rx->len && conn_lll->enc_rx) {
@@ -857,6 +866,7 @@ isr_rx_next_subevent:
 
 		/* Get reference to ACL context */
 		next_conn_lll = ull_conn_lll_get(next_cis_lll->acl_handle);
+		LL_ASSERT(next_conn_lll != NULL);
 
 		/* Calculate CIS channel if not already calculated */
 		if (se_curr < cis_lll->nse) {
@@ -1032,6 +1042,8 @@ static void isr_prepare_subevent(void *param)
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+
+	LL_ASSERT(conn_lll != NULL);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	/* PHY */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -169,6 +169,7 @@ static int prepare_cb(struct lll_prepare_param *p)
 
 	/* Get reference to ACL context */
 	conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+	LL_ASSERT(conn_lll != NULL);
 
 	/* Pick the event_count calculated in the ULL prepare */
 	cis_lll->event_count = cis_lll->event_count_prepare;
@@ -449,6 +450,8 @@ static void abort_cb(struct lll_prepare_param *prepare_param, void *param)
 		/* Get reference to ACL context */
 		const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
 
+		LL_ASSERT(conn_lll != NULL);
+
 		if (conn_lll->enc_rx) {
 			radio_ccm_disable();
 		}
@@ -563,6 +566,7 @@ static void isr_rx(void *param)
 
 	/* Get reference to ACL context */
 	conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+	LL_ASSERT(conn_lll != NULL);
 
 	if (crc_ok) {
 		struct node_rx_pdu *node_rx;
@@ -876,6 +880,8 @@ static void isr_tx(void *param)
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+
+	LL_ASSERT(conn_lll != NULL);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	/* PHY */
@@ -1040,6 +1046,7 @@ static void isr_prepare_subevent(void *param)
 
 	/* Get reference to ACL context */
 	conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+	LL_ASSERT(conn_lll != NULL);
 
 	/* Calculate the radio channel to use for next subevent
 	 */
@@ -1065,6 +1072,7 @@ static void isr_prepare_subevent_next_cis(void *param)
 
 	/* Get reference to ACL context */
 	conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+	LL_ASSERT(conn_lll != NULL);
 
 	/* Event counter value,  0-15 bit of cisEventCounter */
 	event_counter = cis_lll->event_count;
@@ -1101,6 +1109,8 @@ static void isr_prepare_subevent_common(void *param)
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	/* Get reference to ACL context */
 	const struct lll_conn *conn_lll = ull_conn_lll_get(cis_lll->acl_handle);
+
+	LL_ASSERT(conn_lll != NULL);
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
 	/* PHY */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -1686,6 +1686,7 @@ void ll_rx_mem_release(void **node_rx)
 				memq_link_t *link;
 
 				conn = ll_conn_get(rx_free->hdr.handle);
+				LL_ASSERT(conn != NULL);
 
 				LL_ASSERT(!conn->lll.link_tx_free);
 				link = memq_deinit(&conn->lll.memq_tx.head,
@@ -2868,6 +2869,8 @@ static inline void rx_demux_rx(memq_link_t *link, struct node_rx_hdr *rx)
 		(void)memq_dequeue(memq_ull_rx.tail, &memq_ull_rx.head, NULL);
 
 		conn = ll_conn_get(rx->handle);
+		LL_ASSERT(conn != NULL);
+
 		if (ull_cp_cc_awaiting_established(conn)) {
 			ull_cp_cc_established(conn, BT_HCI_ERR_SUCCESS);
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central_iso.c
@@ -859,6 +859,7 @@ uint8_t ull_central_iso_setup(uint16_t cis_handle,
 
 	/* ACL connection of the new CIS */
 	conn = ll_conn_get(cis->lll.acl_handle);
+	LL_ASSERT(conn != NULL);
 
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 	uint16_t event_counter;
@@ -982,6 +983,7 @@ int ull_central_iso_cis_offset_get(uint16_t cis_handle,
 	LL_ASSERT(cis);
 
 	conn = ll_conn_get(cis->lll.acl_handle);
+	LL_ASSERT(conn != NULL);
 
 	/* `ull_conn_llcp()` (caller of this function) is called before `ull_ref_inc()` hence we do
 	 * not need to use `ull_conn_event_counter()`.
@@ -1060,10 +1062,12 @@ static void mfy_cig_offset_get(void *param)
 			(EVENT_TICKER_RES_MARGIN_US << 2U);
 	offset_min_us += cig->sync_delay - cis->sync_delay;
 
+	conn = ll_conn_get(cis->lll.acl_handle);
+	LL_ASSERT(conn != NULL);
+
 	/* Ensure the offset is not greater than the ACL interval, considering
 	 * the minimum CIS offset requirement.
 	 */
-	conn = ll_conn_get(cis->lll.acl_handle);
 	conn_interval_us = (uint32_t)conn->lll.interval * CONN_INT_UNIT_US;
 	offset_limit_us = conn_interval_us + PDU_CIS_OFFSET_MIN_US;
 	while (offset_min_us >= offset_limit_us) {
@@ -1170,10 +1174,12 @@ static void mfy_cis_offset_get(void *param)
 	hal_ticker_remove_jitter(&ticks_to_expire, &remainder);
 	cig_remainder_us = remainder;
 
+	conn = ll_conn_get(cis->lll.acl_handle);
+	LL_ASSERT(conn != NULL);
+
 	/* Add a tick for negative remainder and return positive remainder
 	 * value.
 	 */
-	conn = ll_conn_get(cis->lll.acl_handle);
 	remainder = conn->llcp.prep.remainder;
 	hal_ticker_add_jitter(&ticks_to_expire, &remainder);
 	acl_remainder_us = remainder;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -781,6 +781,7 @@ int ull_conn_reset(void)
 	(void)ull_central_reset();
 #endif /* CONFIG_BT_CENTRAL */
 
+	/* Stop any active ticker related to connection roles */
 	for (handle = 0U; handle < CONFIG_BT_MAX_CONN; handle++) {
 		disable(handle);
 	}
@@ -1667,6 +1668,14 @@ static int init_reset(void)
 	mem_init(conn_pool, sizeof(struct ll_conn),
 		 sizeof(conn_pool) / sizeof(struct ll_conn), &conn_free);
 
+	/* Invalidate connection handles, refer to ll_connected_get() */
+	for (uint16_t handle = 0U; handle < CONFIG_BT_MAX_CONN; handle++) {
+		struct ll_conn *conn;
+
+		conn = ll_conn_get(handle);
+		conn->lll.handle = LLL_HANDLE_INVALID;
+	}
+
 	/* Initialize tx pool. */
 	mem_init(mem_conn_tx.pool, CONN_TX_BUF_SIZE, CONN_DATA_BUFFERS,
 		 &mem_conn_tx.free);
@@ -1836,7 +1845,6 @@ static inline void disable(uint16_t handle)
 					conn, &conn->lll);
 	LL_ASSERT_INFO2(err == 0 || err == -EALREADY, handle, err);
 
-	conn->lll.handle = LLL_HANDLE_INVALID;
 	conn->lll.link_tx_free = NULL;
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1570,8 +1570,8 @@ void ull_conn_tx_ack(uint16_t handle, memq_link_t *link, struct node_tx *tx)
 			/* Tx Node not re-used, ensure link->next is non-NULL */
 			LL_ASSERT(link->next);
 
+			/* Pass conn as-is to ull_cp_release_tx(), NULL check is done there */
 			conn = ll_connected_get(handle);
-			LL_ASSERT(conn != NULL);
 
 			ull_cp_release_tx(conn, tx);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -485,6 +485,8 @@ void ull_conn_iso_done(struct node_rx_event_done *done)
 				if (!cis->event_expire) {
 					struct ll_conn *conn = ll_conn_get(cis->lll.acl_handle);
 
+					LL_ASSERT(conn != NULL);
+
 					cis->event_expire = RADIO_CONN_EVENTS(
 							conn->supervision_timeout * 10U * 1000U,
 							cig->iso_interval * CONN_INT_UNIT_US);
@@ -526,8 +528,11 @@ void ull_conn_iso_done(struct node_rx_event_done *done)
 	if (cis && (ticks_drift_plus || ticks_drift_minus)) {
 		uint8_t ticker_id = TICKER_ID_CONN_ISO_BASE +
 				    ll_conn_iso_group_handle_get(cig);
-		struct ll_conn *conn = ll_connected_get(cis->lll.acl_handle);
 		uint32_t ticker_status;
+		struct ll_conn *conn;
+
+		conn = ll_connected_get(cis->lll.acl_handle);
+		LL_ASSERT(conn != NULL);
 
 		ticker_status = ticker_update(TICKER_INSTANCE_ID_CTLR,
 					      TICKER_USER_ID_ULL_HIGH,
@@ -1252,6 +1257,8 @@ static void cis_disabled_cb(void *param)
 			ll_iso_stream_released_cb_t cis_released_cb;
 
 			conn = ll_conn_get(cis->lll.acl_handle);
+			LL_ASSERT(conn != NULL);
+
 			cis_released_cb = cis->released_cb;
 			cis->released_cb = NULL;
 
@@ -1314,6 +1321,7 @@ static void cis_disabled_cb(void *param)
 				ll_rx_put_sched(node_terminate->hdr.link, node_terminate);
 			} else {
 				conn = ll_conn_get(cis->lll.acl_handle);
+				LL_ASSERT(conn != NULL);
 
 				/* CIS was not established - complete the procedure with error */
 				if (ull_cp_cc_awaiting_established(conn)) {

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -2023,7 +2023,10 @@ void ull_iso_resume_ticker_start(struct lll_event *resume_event,
 				struct ll_conn *conn;
 
 				cis = ll_conn_iso_stream_get(stream_handle);
+
 				conn = ll_conn_get(cis->lll.acl_handle);
+				LL_ASSERT(conn != NULL);
+
 				phy = conn->lll.phy_rx;
 #endif /* CONFIG_BT_CTLR_CONN_ISO */
 #if defined(CONFIG_BT_CTLR_SYNC_ISO)

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -65,6 +65,7 @@ static struct ll_conn *ll_cis_get_acl_awaiting_reply(uint16_t handle, uint8_t *e
 	}
 
 	for (int h = 0; h < CONFIG_BT_MAX_CONN; h++) {
+		/* Handle h in valid range, hence conn will be non-NULL */
 		struct ll_conn *conn = ll_conn_get(h);
 		uint16_t cis_handle = ull_cp_cc_ongoing_handle(conn);
 
@@ -317,6 +318,7 @@ uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 	}
 
 	conn = ll_conn_get(cis->lll.acl_handle);
+	LL_ASSERT(conn != NULL);
 
 	cis_offset = sys_get_le24(ind->cis_offset);
 


### PR DESCRIPTION
Fix missing connection handle invalidate on Controller power up.

The connection context are zero-initialized on startup and calls to `ll_connected_get()` would incorrectly return a valid connection context pointer for connection handle 0.