### PR TITLE
scripts: sort boards alphabetically

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -118,7 +118,7 @@ def kconfig_load(app: Sphinx) -> tuple[kconfiglib.Kconfig, dict[str, str]]:
         root_args = argparse.Namespace(**{'board_roots': [Path(ZEPHYR_BASE)],
                                           'soc_roots': [Path(ZEPHYR_BASE)], 'board': None,
                                           'board_dir': []})
-        v2_boards = list_boards.find_v2_boards(root_args).values()
+        v2_boards = list_boards.find_v2_boards(root_args)
 
         with open(Path(td) / "boards" / "Kconfig.boards", "w") as f:
             for board in v2_boards:

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -522,7 +522,7 @@ class KconfigCheck(ComplianceTest):
         root_args = argparse.Namespace(**{'board_roots': board_roots,
                                           'soc_roots': soc_roots, 'board': None,
                                           'board_dir': []})
-        v2_boards = list_boards.find_v2_boards(root_args).values()
+        v2_boards = list_boards.find_v2_boards(root_args)
 
         with open(kconfig_defconfig_file, 'w') as fp:
             for board in v2_boards:

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -248,7 +248,7 @@ class Filters:
         # Look for boards in monitored repositories
         lb_args = argparse.Namespace(**{'arch_roots': roots, 'board_roots': roots, 'board': None, 'soc_roots':roots,
                                         'board_dir': None})
-        known_boards = list_boards.find_v2_boards(lb_args).values()
+        known_boards = list_boards.find_v2_boards(lb_args)
 
         for changed in changed_boards:
             for board in known_boards:

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -347,7 +347,7 @@ def find_v2_boards(args):
         board_extensions.extend(e)
 
     extend_v2_boards(boards, board_extensions)
-    return boards
+    return sorted(boards.values(), key=lambda board: board.name)
 
 
 def parse_args():
@@ -415,7 +415,7 @@ def board_v2_qualifiers_csv(board):
 def dump_v2_boards(args):
     boards = find_v2_boards(args)
 
-    for b in boards.values():
+    for b in boards:
         qualifiers_list = board_v2_qualifiers(b)
         if args.cmakeformat is not None:
             notfound = lambda x: x or 'NOTFOUND'

--- a/scripts/pylib/twister/twisterlib/platform.py
+++ b/scripts/pylib/twister/twisterlib/platform.py
@@ -209,7 +209,7 @@ def generate_platforms(board_roots, soc_roots, arch_roots):
     lb_args = Namespace(board_roots=board_roots, soc_roots=soc_roots, arch_roots=arch_roots,
                         board=None, board_dir=None)
 
-    for board in list_boards.find_v2_boards(lb_args).values():
+    for board in list_boards.find_v2_boards(lb_args):
         for board_dir in board.directories:
             if board_dir in dir2data:
                 # don't load the same board data twice

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -106,7 +106,7 @@ class Boards(WestCommand):
                                         revisions=revisions_list,
                                         dir=board.dir, hwm=board.hwm, qualifiers=''))
 
-        for board in list_boards.find_v2_boards(args).values():
+        for board in list_boards.find_v2_boards(args):
             if name_re is not None and not name_re.search(board.name):
                 continue
 


### PR DESCRIPTION
Sort the output alphabetically when executing 'west boards'. Doing so makes it simpler to locate boards while scrolling through the list of all accessible boards. This method is compatible with the '-n' argument too, which also will result in a filtered and sorted list.