### PR TITLE
mcumgr: img_mgmt_client: Add missing include

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
@@ -8,6 +8,7 @@
 #define H_IMG_MGMT_CLIENT_
 
 #include <inttypes.h>
+#include <zephyr/mgmt/mcumgr/mgmt/mgmt_defines.h>
 #include <zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp/smp_client.h>
 


### PR DESCRIPTION
This header uses enum mcumgr_err_t but does not include the header where it is defined. Fixed in this commit.