### PR TITLE
Sy1xx/sy1xx pinctrl slew rate

### DIFF
--- a/boards/sensry/ganymed_bob/ganymed_bob_sy120-pinctrl.dtsi
+++ b/boards/sensry/ganymed_bob/ganymed_bob_sy120-pinctrl.dtsi
@@ -114,26 +114,32 @@
 
 	/omit-if-no-ref/ rgmii_tx_ctl: rgmii_tx_ctl {
 		pinmux = <SY1XX_RGMII0_PAD_CFG0 SY1XX_PAD(2)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_tx_clk: rgmii_tx_clk {
 		pinmux = <SY1XX_RGMII0_PAD_CFG0 SY1XX_PAD(3)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd0: rgmii_txd0 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(0)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd1: rgmii_txd1 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(1)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd2: rgmii_txd2 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(2)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd3: rgmii_txd3 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(3)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_rxd0: rgmii_rxd0 {

--- a/boards/sensry/ganymed_sk/ganymed_sk_sy120-pinctrl.dtsi
+++ b/boards/sensry/ganymed_sk/ganymed_sk_sy120-pinctrl.dtsi
@@ -114,26 +114,32 @@
 
 	/omit-if-no-ref/ rgmii_tx_ctl: rgmii_tx_ctl {
 		pinmux = <SY1XX_RGMII0_PAD_CFG0 SY1XX_PAD(2)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_tx_clk: rgmii_tx_clk {
 		pinmux = <SY1XX_RGMII0_PAD_CFG0 SY1XX_PAD(3)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd0: rgmii_txd0 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(0)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd1: rgmii_txd1 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(1)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd2: rgmii_txd2 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(2)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_txd3: rgmii_txd3 {
 		pinmux = <SY1XX_RGMII0_PAD_CFG1 SY1XX_PAD(3)>;
+		slew-rate = <3>;
 	};
 
 	/omit-if-no-ref/ rgmii_rxd0: rgmii_rxd0 {

--- a/dts/bindings/pinctrl/sensry,sy1xx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/sensry,sy1xx-pinctrl.yaml
@@ -72,3 +72,19 @@ child-binding:
       description: |
         Pin mux selection. See the SOC level pinctrl header
         for a defined list of these options.
+
+    slew-rate:
+      type: int
+      enum:
+        - 0 # 2pF
+        - 1 # 4pF
+        - 2 # 8pF
+        - 3 # 16pF
+      default: 0
+      description: |
+        Selects the output drive strength. Choices represent approximate capacitive load.
+        The default corresponds to the reset value of the register field.
+        - 0.. 2pF, Weakest drive
+        - 1.. 4pF, Low drive
+        - 2.. 8pF, Medium drive
+        - 3.. 16pF, Strongest drive

--- a/soc/sensry/ganymed/sy1xx/common/pinctrl_soc.h
+++ b/soc/sensry/ganymed/sy1xx/common/pinctrl_soc.h
@@ -45,6 +45,7 @@ typedef struct {
 		(SY1XX_PULL_UP_ENABLE * DT_PROP(node, bias_pull_up)) << SY1XX_PAD_PULL_UP_OFFS |   \
 		(SY1XX_PULL_DOWN_ENABLE * DT_PROP(node, bias_pull_down))                           \
 			<< SY1XX_PAD_PULL_DOWN_OFFS |                                              \
+		(DT_PROP(node, slew_rate) << SY1XX_PAD_DRIVE_OFFS) |                               \
 		(SY1XX_TRISTATE_ENABLE * DT_PROP(node, bias_high_impedance))                       \
 			<< SY1XX_PAD_TRISTATE_OFFS |                                               \
 		(SY1XX_OUTPUT_ENABLE & (1 - DT_PROP(node, input_enable))) << SY1XX_PAD_DIR_OFFS    \


### PR DESCRIPTION
all pins support setting the slew rate to one of 4 pre-defined values. 