### PR TITLE
boards: 96boards: carbon: Increase main stack size when CONFIG_MBEDTLS_INIT is set

### DIFF
--- a/boards/96boards/carbon/Kconfig.defconfig
+++ b/boards/96boards/carbon/Kconfig.defconfig
@@ -9,6 +9,9 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
+configdefault MAIN_STACK_SIZE
+	default 1600 if MBEDTLS_INIT
+
 endif # BOARD_96B_CARBON_STM32F401XE
 
 if BOARD_96B_CARBON_NRF51822


### PR DESCRIPTION
Increase main stack size when `CONFIG_MBEDTLS_INIT` is enabled to avoid stack overflow.
`samples/bluetooth/beacon` was considered for this change. It has also been tested with `samples/bluetooth/peripheral_hr`.

Fixes #99098 