### PR TITLE
dts: update power-states node for ACE 3.0

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -48,24 +48,24 @@
 			reg = <4>;
 			cpu-power-states = <&d0i3 &d3>;
 		};
-	};
 
-	power-states {
-		d0i3: idle {
-			compatible = "zephyr,power-state";
-			power-state-name = "runtime-idle";
-			min-residency-us = <200>;
-			exit-latency-us = <100>;
-		};
-		/* PM_STATE_SOFT_OFF can be entered only by calling pm_state_force.
-		 * The procedure is triggered by IPC from the HOST (SET_DX).
-		 */
-		d3: off {
-			compatible = "zephyr,power-state";
-			power-state-name = "soft-off";
-			min-residency-us = <0>;
-			exit-latency-us = <0>;
-			status = "disabled";
+		power-states {
+			d0i3: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+				min-residency-us = <200>;
+				exit-latency-us = <100>;
+			};
+			/* PM_STATE_SOFT_OFF can be entered only by calling pm_state_force.
+			 * The procedure is triggered by IPC from the HOST (SET_DX).
+			 */
+			d3: off {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				min-residency-us = <0>;
+				exit-latency-us = <0>;
+				status = "disabled";
+			};
 		};
 	};
 

--- a/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30_ptl.dtsi
@@ -48,24 +48,24 @@
 			reg = <4>;
 			cpu-power-states = <&d0i3 &d3>;
 		};
-	};
 
-	power-states {
-		d0i3: idle {
-			compatible = "zephyr,power-state";
-			power-state-name = "runtime-idle";
-			min-residency-us = <200>;
-			exit-latency-us = <100>;
-		};
-		/* PM_STATE_SOFT_OFF can be entered only by calling pm_state_force.
-		 * The procedure is triggered by IPC from the HOST (SET_DX).
-		 */
-		d3: off {
-			compatible = "zephyr,power-state";
-			power-state-name = "soft-off";
-			min-residency-us = <0>;
-			exit-latency-us = <0>;
-			status = "disabled";
+		power-states {
+			d0i3: idle {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+				min-residency-us = <200>;
+				exit-latency-us = <100>;
+			};
+			/* PM_STATE_SOFT_OFF can be entered only by calling pm_state_force.
+			 * The procedure is triggered by IPC from the HOST (SET_DX).
+			 */
+			d3: off {
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
+				min-residency-us = <0>;
+				exit-latency-us = <0>;
+				status = "disabled";
+			};
 		};
 	};
 


### PR DESCRIPTION
This patch modifies the DTS files for Intel ADSP ACE 3.0 platforms, ensuring the power-states node is a child of the cpus node. This change aligns with Linux conventions and mirrors the adjustments made in commit e4c43e4cc98 for other platforms.