### PR TITLE
scripts: west_commands: runners: do not print newline in telnet decode

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -966,4 +966,4 @@ class ZephyrBinaryRunner(abc.ABC):
                 elif key.fileobj == sock:
                     resp = sock.recv(2048)
                     if resp:
-                        print(resp.decode())
+                        print(resp.decode(), end='')


### PR DESCRIPTION
Remove the newline printed after decoding a block of telnet data from the server in the "pure python" implementation used when netcat is not available. This newline print is incorrect as it is not in the RTT output being produced from the device, and can impact programs like twister which expect specific strings in the output and cannot handle these strings being split across two lines