### PR TITLE
mgmt: hawkbit: do not prepend custom controllerId

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -604,6 +604,13 @@ Video
 Other subsystems
 ****************
 
+hawkBit
+=======
+
+* When :kconfig:option:`CONFIG_HAWKBIT_CUSTOM_DEVICE_ID` is enabled, device_id will no longer
+  be prepended with :kconfig:option:`CONFIG_BOARD`. It is the user's responsibility to write a
+  callback that prepends the board name if needed.
+
 Modules
 *******
 

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -772,7 +772,8 @@ int hawkbit_set_custom_data_cb(hawkbit_config_device_data_cb_handler_t cb)
 	return -ENOTSUP;
 }
 
-int hawkbit_default_config_data_cb(const char *device_id, uint8_t *buffer, const size_t buffer_size)
+int hawkbit_default_config_data_cb(const char *device_id, uint8_t *buffer,
+				const size_t buffer_size)
 {
 	struct hawkbit_cfg cfg = {
 		.mode = "merge",
@@ -1283,8 +1284,7 @@ static void s_probe(void *o)
 
 	LOG_INF("Polling target data from hawkBit");
 
-	snprintk(url_buffer, sizeof(url_buffer), "%s/%s-%s", HAWKBIT_JSON_URL, CONFIG_BOARD,
-		 s->device_id);
+	snprintk(url_buffer, sizeof(url_buffer), "%s/%s", HAWKBIT_JSON_URL, s->device_id);
 
 	if (!send_request(&s->hb_context, HAWKBIT_PROBE, url_buffer, NULL)) {
 		LOG_ERR("Send request failed (%s)", "HAWKBIT_PROBE");
@@ -1474,9 +1474,8 @@ static void s_report(void *o)
 	uint8_t status_buffer[CONFIG_HAWKBIT_STATUS_BUFFER_SIZE] = {0};
 	char url_buffer[URL_BUFFER_SIZE] = {0};
 
-	snprintk(url_buffer, sizeof(url_buffer), "%s/%s-%s/%s/%d/%s", HAWKBIT_JSON_URL,
-		 CONFIG_BOARD, s->device_id, "deploymentBase", s->hb_context.json_action_id,
-		 "feedback");
+	snprintk(url_buffer, sizeof(url_buffer), "%s/%s/%s/%d/%s", HAWKBIT_JSON_URL,
+		 s->device_id, "deploymentBase", s->hb_context.json_action_id, "feedback");
 
 	LOG_INF("Reporting deployment feedback %s (%s) for action %d",
 		feedback.status.result.finished, feedback.status.execution,

--- a/subsys/mgmt/hawkbit/hawkbit_device.c
+++ b/subsys/mgmt/hawkbit/hawkbit_device.c
@@ -21,15 +21,20 @@ static bool hawkbit_get_device_identity_default(char *id, int id_max_len)
 {
 #ifdef CONFIG_HAWKBIT_HWINFO_DEVICE_ID
 	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
-	ssize_t length;
+	ssize_t id_length, length;
 
-	length = hwinfo_get_device_id(hwinfo_id, DEVICE_ID_BIN_MAX_SIZE);
+	memset(id, 0, id_max_len);
+	length = snprintk(id, id_max_len, "%s-", CONFIG_BOARD);
 	if (length <= 0) {
 		return false;
 	}
 
-	memset(id, 0, id_max_len);
-	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len);
+	id_length = hwinfo_get_device_id(hwinfo_id, DEVICE_ID_BIN_MAX_SIZE);
+	if (id_length <= 0) {
+		return false;
+	}
+
+	length = bin2hex(hwinfo_id, (size_t)id_length, &id[length], id_max_len - length);
 
 	return length > 0;
 #else /* CONFIG_HAWKBIT_HWINFO_DEVICE_ID */

--- a/subsys/mgmt/hawkbit/hawkbit_device.h
+++ b/subsys/mgmt/hawkbit/hawkbit_device.h
@@ -15,7 +15,7 @@
 #define DEVICE_ID_HEX_MAX_SIZE	(CONFIG_HAWKBIT_DEVICE_ID_MAX_LENGTH + 1)
 #else
 #define DEVICE_ID_BIN_MAX_SIZE	16
-#define DEVICE_ID_HEX_MAX_SIZE	((DEVICE_ID_BIN_MAX_SIZE * 2) + 1)
+#define DEVICE_ID_HEX_MAX_SIZE	(sizeof(CONFIG_BOARD) + (DEVICE_ID_BIN_MAX_SIZE * 2) + 1)
 #endif
 
 bool hawkbit_get_device_identity(char *id, int id_max_len);


### PR DESCRIPTION
This PR changes how the controllerId is generated based on device id, and disentangles the two. The controllerId is what hawkbit uses to uniquely identify a device, and is not necessarily the same as the device id, and should be fully customizeable by the user if needed. Previously, all custom device ids were being prepended with `CONFIG_BOARD`. When a user selects `CONFIG_HAWKBIT_CUSTOM_DEVICE_ID`, they should be able to specify the full controllerId used with hawkbit, without a forced prepend.

The default handler (`hawkbit_get_device_identity_default`) for returning the controllerId is modified to also include the prefix, so the default behavior without `CONFIG_HAWKBIT_CUSTOM_DEVICE_ID` enabled is preserved.