### PR TITLE
drivers: i2c: i2c_stm32_v2: stability improvements

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -110,6 +110,7 @@ struct i2c_stm32_data {
 		unsigned int is_arlo;
 		unsigned int is_nack;
 		unsigned int is_err;
+		bool continue_in_next;
 		struct i2c_msg *msg;
 		unsigned int len;
 		uint8_t *buf;

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -631,10 +631,14 @@ int i2c_stm32_error(const struct device *dev)
 		goto end;
 	}
 
+	/* Don't end a transaction on bus error in master mode
+	 * as errata sheet says that spurious false detections
+	 * of BERR can happen which shall be ignored.
+	 * If a real Bus Error occurs, transaction will time out.
+	 */
 	if (LL_I2C_IsActiveFlag_BERR(i2c)) {
 		LL_I2C_ClearFlag_BERR(i2c);
 		data->current.is_err = 1U;
-		goto end;
 	}
 
 #if defined(CONFIG_SMBUS_STM32_SMBALERT)


### PR DESCRIPTION
Due to various reported stability issues with the STM32 I2C V2 driver in interrupt mode, the controller part is rewritten in an attempt to closely follow documentation found in reference manual and errata sheets.

See https://github.com/zephyrproject-rtos/zephyr/issues/70077

A side effect should also be increased performance

This PR replaces the old draft at https://github.com/zephyrproject-rtos/zephyr/pull/82940