### PR TITLE
soc: add stm32l100xb

### DIFF
--- a/dts/arm/st/l1/stm32l100.dtsi
+++ b/dts/arm/st/l1/stm32l100.dtsi
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Conny Marco Menebröcker
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/l1/stm32l1.dtsi>
+
+/ {
+	soc {
+		compatible = "st,stm32l100", "st,stm32l1", "simple-bus";
+	};
+};

--- a/dts/arm/st/l1/stm32l100Xb.dtsi
+++ b/dts/arm/st/l1/stm32l100Xb.dtsi
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Conny Marco Menebröcker
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/l1/stm32l100.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(10)>;
+	};
+
+	soc {
+		flash-controller@40023c00 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(128)>;
+			};
+		};
+
+		eeprom: eeprom@8080000{
+			reg = <0x08080000 DT_SIZE_K(2)>;
+		};
+
+		rtc@40002800 {
+			bbram: backup_regs {
+				compatible = "st,stm32-bbram";
+				st,backup-regs = <5>;
+				status = "disabled";
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -155,6 +155,7 @@ family:
     - name: stm32l081xx
   - name: stm32l1x
     socs:
+    - name: stm32l100xb
     - name: stm32l151xb
     - name: stm32l151xba
     - name: stm32l151xc

--- a/soc/st/stm32/stm32l1x/Kconfig.defconfig.stm32l100xb
+++ b/soc/st/stm32/stm32l1x/Kconfig.defconfig.stm32l100xb
@@ -1,0 +1,11 @@
+# STMicroelectronics STM32L100XB MCU
+
+# Copyright (c) 2025 Conny Marco Menebröcker
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32L100XB
+
+config NUM_IRQS
+	default 46
+
+endif # SOC_STM32L100XB

--- a/soc/st/stm32/stm32l1x/Kconfig.soc
+++ b/soc/st/stm32/stm32l1x/Kconfig.soc
@@ -10,6 +10,10 @@ config SOC_SERIES_STM32L1X
 config SOC_SERIES
 	default "stm32l1x" if SOC_SERIES_STM32L1X
 
+config SOC_STM32L100XB
+	bool
+	select SOC_SERIES_STM32L1X
+
 config SOC_STM32L151XB
 	bool
 	select SOC_SERIES_STM32L1X
@@ -31,6 +35,7 @@ config SOC_STM32L152XE
 	select SOC_SERIES_STM32L1X
 
 config SOC
+	default "stm32l100xb" if SOC_STM32L100XB
 	default "stm32l151xb" if SOC_STM32L151XB
 	default "stm32l151xba" if SOC_STM32L151XBA
 	default "stm32l151xc" if SOC_STM32L151XC


### PR DESCRIPTION
This patch adds support for the stm32l100 SoC. Tested on private board.