### PR TITLE
Bluetooth: Audio: Rename ctx type prohibited to none

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -297,6 +297,9 @@ Bluetooth Audio
 * ``bt_csip_set_member_get_sirk`` has been removed. Use :c:func:`bt_csip_set_member_get_info` to get
   the SIRK (and other information). (:github:`86996`)
 
+* ``BT_AUDIO_CONTEXT_TYPE_PROHIBITED`` has been renamed to
+  :c:enumerator:`BT_AUDIO_CONTEXT_TYPE_NONE`. (:github:`89506`)
+
 Bluetooth HCI
 =============
 

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -301,8 +301,8 @@ enum bt_audio_codec_cfg_frame_dur {
  * These values are defined by the Generic Audio Assigned Numbers, bluetooth.com
  */
 enum bt_audio_context {
-	/** Prohibited */
-	BT_AUDIO_CONTEXT_TYPE_PROHIBITED = 0,
+	/** No context type */
+	BT_AUDIO_CONTEXT_TYPE_NONE = 0,
 	/**
 	 * Identifies audio where the use case context does not match any other defined value,
 	 * or where the context is unknown or cannot be determined.
@@ -2099,8 +2099,8 @@ int bt_audio_codec_cap_meta_set_vendor(struct bt_audio_codec_cap *codec_cap,
 static inline char *bt_audio_context_bit_to_str(enum bt_audio_context context)
 {
 	switch (context) {
-	case BT_AUDIO_CONTEXT_TYPE_PROHIBITED:
-		return "Prohibited";
+	case BT_AUDIO_CONTEXT_TYPE_NONE:
+		return "None";
 	case BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED:
 		return "Unspecified";
 	case BT_AUDIO_CONTEXT_TYPE_CONVERSATIONAL:

--- a/include/zephyr/bluetooth/audio/pacs.h
+++ b/include/zephyr/bluetooth/audio/pacs.h
@@ -213,7 +213,7 @@ int bt_pacs_conn_set_available_contexts_for_conn(struct bt_conn *conn, enum bt_a
  * @param dir      Direction of the endpoints to get contexts for.
  *
  * @return Bitmask of available contexts.
- * @retval BT_AUDIO_CONTEXT_TYPE_PROHIBITED if @p conn or @p dir are invalid
+ * @retval BT_AUDIO_CONTEXT_TYPE_NONE if @p conn or @p dir are invalid
  */
 enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *conn,
 							      enum bt_audio_dir dir);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2147,7 +2147,7 @@ static bool ascs_parse_metadata(struct bt_data *data, void *user_data)
 		}
 
 		context = sys_get_le16(data_value);
-		if (context == BT_AUDIO_CONTEXT_TYPE_PROHIBITED) {
+		if (context == BT_AUDIO_CONTEXT_TYPE_NONE) {
 			*result->rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_METADATA_INVALID,
 						       data_type);
 			result->err = -EINVAL;

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -64,8 +64,8 @@ static uint32_t pacs_snk_location;
 #endif /* CONFIG_BT_PAC_SNK_LOC */
 #endif /* CONFIG_BT_PAC_SNK */
 
-static uint16_t src_available_contexts = BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
-static uint16_t snk_available_contexts = BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
+static uint16_t src_available_contexts = BT_AUDIO_CONTEXT_TYPE_NONE;
+static uint16_t snk_available_contexts = BT_AUDIO_CONTEXT_TYPE_NONE;
 
 enum {
 	FLAG_ACTIVE,
@@ -308,7 +308,7 @@ static uint16_t supported_context_get(enum bt_audio_dir dir)
 		break;
 	}
 
-	return BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
+	return BT_AUDIO_CONTEXT_TYPE_NONE;
 }
 
 static ssize_t supported_context_read(struct bt_conn *conn,
@@ -1561,7 +1561,7 @@ enum bt_audio_context bt_pacs_get_available_contexts(enum bt_audio_dir dir)
 		break;
 	}
 
-	return BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
+	return BT_AUDIO_CONTEXT_TYPE_NONE;
 }
 
 enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *conn,
@@ -1569,7 +1569,7 @@ enum bt_audio_context bt_pacs_get_available_contexts_for_conn(struct bt_conn *co
 {
 	CHECKIF(conn == NULL) {
 		LOG_ERR("NULL conn");
-		return BT_AUDIO_CONTEXT_TYPE_PROHIBITED;
+		return BT_AUDIO_CONTEXT_TYPE_NONE;
 	}
 
 	return pacs_get_available_contexts_for_conn(conn, dir);

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3724,7 +3724,7 @@ static int cmd_context(const struct shell *sh, size_t argc, char *argv[])
 	ctx = ctx_val;
 
 	if (!strcmp(argv[3], "supported")) {
-		if (ctx_val == BT_AUDIO_CONTEXT_TYPE_PROHIBITED) {
+		if (ctx_val == BT_AUDIO_CONTEXT_TYPE_NONE) {
 			shell_error(sh, "Invalid context: %lu", ctx_val);
 
 			return -ENOEXEC;


### PR DESCRIPTION
The context type PROHIBITED has been removed from
the Bluetooth assigned numbers document. It is, however, still used in some profiles to indicate either "No context type supported" or "None available", and thus a rename to "NONE" makes sense.