### PR TITLE
Simpler link optimization flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,18 +215,29 @@ get_property(OPTIMIZE_FOR_SPEED_FLAG TARGET compiler PROPERTY optimization_speed
 get_property(OPTIMIZE_FOR_SIZE_FLAG  TARGET compiler PROPERTY optimization_size)
 get_property(OPTIMIZE_FOR_SIZE_AGGRESSIVE_FLAG TARGET compiler PROPERTY optimization_size_aggressive)
 
+get_property(OPTIMIZE_LINK_FOR_NO_OPTIMIZATIONS_FLAG TARGET linker PROPERTY no_optimization)
+get_property(OPTIMIZE_LINK_FOR_DEBUG_FLAG TARGET linker PROPERTY optimization_debug)
+get_property(OPTIMIZE_LINK_FOR_SPEED_FLAG TARGET linker PROPERTY optimization_speed)
+get_property(OPTIMIZE_LINK_FOR_SIZE_FLAG  TARGET linker PROPERTY optimization_size)
+get_property(OPTIMIZE_LINK_FOR_SIZE_AGGRESSIVE_FLAG TARGET linker PROPERTY optimization_size_aggressive)
+
 # From kconfig choice, pick the actual OPTIMIZATION_FLAG to use.
 # Kconfig choice ensures only one of these CONFIG_*_OPTIMIZATIONS is set.
 if(CONFIG_NO_OPTIMIZATIONS)
   set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_NO_OPTIMIZATIONS_FLAG})
+  set(OPTIMIZATION_LINK_FLAG ${OPTIMIZE_LINK_FOR_NO_OPTIMIZATIONS_FLAG})
 elseif(CONFIG_DEBUG_OPTIMIZATIONS)
   set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_DEBUG_FLAG})
+  set(OPTIMIZATION_LINK_FLAG ${OPTIMIZE_LINK_FOR_DEBUG_FLAG})
 elseif(CONFIG_SPEED_OPTIMIZATIONS)
   set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_SPEED_FLAG})
+  set(OPTIMIZATION_LINK_FLAG ${OPTIMIZE_LINK_FOR_SPEED_FLAG})
 elseif(CONFIG_SIZE_OPTIMIZATIONS)
   set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_SIZE_FLAG}) # Default in kconfig
+  set(OPTIMIZATION_LINK_FLAG ${OPTIMIZE_LINK_FOR_SIZE_FLAG})
 elseif(CONFIG_SIZE_OPTIMIZATIONS_AGGRESSIVE)
   set(OPTIMIZATION_FLAG ${OPTIMIZE_FOR_SIZE_AGGRESSIVE_FLAG})
+  set(OPTIMIZATION_LINK_FLAG ${OPTIMIZE_LINK_FOR_SIZE_AGGRESSIVE_FLAG})
 else()
   message(FATAL_ERROR
     "Unreachable code. Expected optimization level to have been chosen. See Kconfig.zephyr")
@@ -242,6 +253,7 @@ endif()
 # Apply the final optimization flag(s)
 zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:${OPTIMIZATION_FLAG}>)
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${OPTIMIZATION_FLAG}>)
+add_link_options(${OPTIMIZATION_LINK_FLAG})
 
 if(CONFIG_LTO)
   zephyr_compile_options($<TARGET_PROPERTY:compiler,optimization_lto>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2333,6 +2333,9 @@ add_subdirectory_ifdef(
   cmake/makefile_exports
   )
 
+# Ask the compiler to set the lib_include_dir and rt_library properties
+compiler_set_linker_properties()
+
 toolchain_linker_finalize()
 
 # export build information

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -100,21 +100,6 @@ if(NOT "${ARCH}" STREQUAL "posix")
     endif()
   endif()
 
-  # This libgcc code is partially duplicated in compiler/*/target.cmake
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${clang_target_flag} ${TOOLCHAIN_C_FLAGS}
-            --print-libgcc-file-name
-    OUTPUT_VARIABLE RTLIB_FILE_NAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-  get_filename_component(RTLIB_DIR ${RTLIB_FILE_NAME} DIRECTORY)
-  get_filename_component(RTLIB_NAME_WITH_PREFIX ${RTLIB_FILE_NAME} NAME_WLE)
-  string(REPLACE lib "" RTLIB_NAME ${RTLIB_NAME_WITH_PREFIX})
-
-  set_property(TARGET linker PROPERTY lib_include_dir "-L${RTLIB_DIR}")
-  set_property(TARGET linker PROPERTY rt_library "-l${RTLIB_NAME}")
-
   list(APPEND CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 

--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -98,21 +98,6 @@ if(SYSROOT_DIR)
   set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${NEWLIB_DIR}")
 endif()
 
-# This libgcc code is partially duplicated in compiler/*/target.cmake
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
-  OUTPUT_VARIABLE LIBGCC_FILE_NAME
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-assert_exists(LIBGCC_FILE_NAME)
-
-get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
-
-assert_exists(LIBGCC_DIR)
-
-set_linker_property(PROPERTY lib_include_dir "-L\"${LIBGCC_DIR}\"")
-
 # For CMake to be able to test if a compiler flag is supported by the
 # toolchain we need to give CMake the necessary flags to compile and
 # link a dummy C file.

--- a/cmake/compiler/icx/target.cmake
+++ b/cmake/compiler/icx/target.cmake
@@ -45,21 +45,6 @@ else()
   list(APPEND TOOLCHAIN_C_FLAGS "-m32")
 endif()
 
-
-# This libgcc code is partially duplicated in compiler/*/target.cmake
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
-  OUTPUT_VARIABLE LIBGCC_FILE_NAME
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
-
-list(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
-if(LIBGCC_DIR)
-  list(APPEND TOOLCHAIN_LIBS gcc)
-endif()
-
 set(CMAKE_REQUIRED_FLAGS -nostartfiles -nostdlib ${isystem_include_flags})
 string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 

--- a/cmake/compiler/target_template.cmake
+++ b/cmake/compiler/target_template.cmake
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025, Nordic Semiconductor ASA
+
+# Template file for optional Zephyr compiler functions.
+#
+# This file will define optional compiler functions for toolchains that are not
+# defining these functions themselves.
+
+if(NOT COMMAND compiler_file_path)
+
+  # Search for filename in default compiler library path using the
+  # --print-file-name option which is common to gcc and clang.  If the
+  # file is not found, filepath_out will be set to an empty string.
+  #
+  # This only works if none of the compiler flags used to compute
+  # the library path involve generator expressions as we cannot
+  # evaluate those in this function.
+  #
+  # Compilers needing a different implementation should provide this
+  # function in their target.cmake file
+
+  function(compiler_file_path filename filepath_out)
+
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} ${OPTIMIZATION_FLAG}
+      --print-file-name ${filename}
+      OUTPUT_VARIABLE filepath
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(${filepath} STREQUAL ${filename})
+      set(filepath "")
+    endif()
+    set(${filepath_out} "${filepath}" PARENT_SCOPE)
+  endfunction()
+
+endif()
+
+if(NOT COMMAND compiler_set_linker_properties)
+
+  # Set the lib_include_dir and rt_library linker properties
+  # by searching for the runtime library in the compiler default
+  # library search path. If no runtime library is found, these
+  # properties will remain unset
+  #
+  # Compilers needing a different implementation should provide this
+  # function in their target.cmake file
+  #
+  # This is skipped on the posix architecture as that uses the host
+  # compiler configuration directly
+
+  function(compiler_set_linker_properties)
+    if(NOT "${ARCH}" STREQUAL "posix")
+      # Compute complete path to the runtime library using the
+      # --print-libgcc-file-name compiler flag
+      execute_process(
+        COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} ${OPTIMIZATION_FLAG}
+        --print-libgcc-file-name
+        OUTPUT_VARIABLE library_path
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+      # Compute the library directory name
+
+      get_filename_component(library_dir ${library_path} DIRECTORY)
+      set_linker_property(PROPERTY lib_include_dir "-L${library_dir}")
+
+      # Compute the linker option for this library
+
+      get_filename_component(library_basename ${library_path} NAME_WLE)
+
+      # Remove the leading 'lib' prefix to leave a value suitable for use with
+      # the linker -l flag
+      string(REPLACE lib "" library_name ${library_basename})
+
+      set_linker_property(PROPERTY rt_library "-l${library_name}")
+    endif()
+  endfunction()
+
+endif()

--- a/cmake/compiler/xcc/target.cmake
+++ b/cmake/compiler/xcc/target.cmake
@@ -40,17 +40,6 @@ foreach(file_name include/stddef.h include-fixed/limits.h)
   list(APPEND NOSTDINC ${_OUTPUT})
 endforeach()
 
-# This libgcc code is partially duplicated in compiler/*/target.cmake
-execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
-  OUTPUT_VARIABLE LIBGCC_FILE_NAME
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-get_filename_component(LIBGCC_DIR ${LIBGCC_FILE_NAME} DIRECTORY)
-
-list(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
-
 # For CMake to be able to test if a compiler flag is supported by the
 # toolchain we need to give CMake the necessary flags to compile and
 # link a dummy C file.

--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -49,6 +49,13 @@ check_set_linker_property(TARGET linker PROPERTY sort_alignment
                           ${LINKERFLAGPREFIX},--sort-section=alignment
 )
 
+# Copy all of the compiler optimization properties to the equivalent linker properties
+foreach(prop no_optimization optimization_debug optimization_speed
+    optimization_size optimization_size_aggressive optimization_fast)
+  get_property(optimization_flag TARGET compiler PROPERTY ${prop})
+  set_property(TARGET linker PROPERTY ${prop} ${optimization_flag})
+endforeach()
+
 # Some linker flags might not be purely ld specific, but a combination of
 # linker and compiler, such as:
 # --coverage for clang

--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -159,10 +159,12 @@ macro(toolchain_linker_finalize)
 
   set(cpp_link "${common_link}")
   if(NOT "${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "host")
-    if(CONFIG_CPP_EXCEPTIONS AND LIBGCC_DIR)
+    compiler_file_path(crtbegin.o CRTBEGIN_PATH)
+    compiler_file_path(crtend.o CRTEND_PATH)
+    if(CONFIG_CPP_EXCEPTIONS AND CRTBEGIN_PATH AND CRTEND_PATH)
       # When building with C++ Exceptions, it is important that crtbegin and crtend
       # are linked at specific locations.
-      set(cpp_link "<LINK_FLAGS> ${LIBGCC_DIR}/crtbegin.o ${link_libraries} ${LIBGCC_DIR}/crtend.o")
+      set(cpp_link "<LINK_FLAGS> ${CRTBEGIN_PATH} ${link_libraries} ${CRTEND_PATH}")
     endif()
   endif()
   set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> ${cpp_link}")

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -53,3 +53,18 @@ set_property(TARGET linker PROPERTY relax)
 # Linker flag for defining specs. Defined only by gcc, when gcc is used as
 # front-end for ld.
 set_compiler_property(PROPERTY specs)
+
+#####################################################
+# This section covers flags related to optimization #
+#####################################################
+set_property(TARGET linker PROPERTY no_optimization)
+
+set_property(TARGET linker PROPERTY optimization_debug)
+
+set_property(TARGET linker PROPERTY optimization_speed)
+
+set_property(TARGET linker PROPERTY optimization_size)
+
+set_property(TARGET linker PROPERTY optimization_size_aggressive)
+
+set_property(TARGET linker PROPERTY optimization_fast)

--- a/cmake/linker/lld/linker_flags.cmake
+++ b/cmake/linker/lld/linker_flags.cmake
@@ -17,6 +17,13 @@ set_property(TARGET linker PROPERTY lto_arguments)
 
 check_set_linker_property(TARGET linker PROPERTY sort_alignment ${LINKERFLAGPREFIX},--sort-section=alignment)
 
+# Copy all of the compiler optimization properties to the equivalent linker properties
+foreach(prop no_optimization optimization_debug optimization_speed
+    optimization_size optimization_size_aggressive optimization_fast)
+  get_property(optimization_flag TARGET compiler PROPERTY ${prop})
+  set_property(TARGET linker PROPERTY ${prop} ${optimization_flag})
+endforeach()
+
 if(CONFIG_RISCV_GP)
   check_set_linker_property(TARGET linker PROPERTY relax ${LINKERFLAGPREFIX},--relax-gp)
 endif()

--- a/cmake/linker/xt-ld/linker_flags.cmake
+++ b/cmake/linker/xt-ld/linker_flags.cmake
@@ -34,3 +34,10 @@ check_set_linker_property(TARGET linker PROPERTY sort_alignment
                           ${LINKERFLAGPREFIX},--sort-common=descending
                           ${LINKERFLAGPREFIX},--sort-section=alignment
 )
+
+# Copy all of the compiler optimization properties to the equivalent linker properties
+foreach(prop no_optimization optimization_debug optimization_speed
+    optimization_size optimization_size_aggressive optimization_fast)
+  get_property(optimization_flag TARGET compiler PROPERTY ${prop})
+  set_property(TARGET linker PROPERTY ${prop} ${optimization_flag})
+endforeach()

--- a/cmake/linker/xt-ld/target.cmake
+++ b/cmake/linker/xt-ld/target.cmake
@@ -11,14 +11,16 @@ find_program(CMAKE_LINKER xt-ld ${LD_SEARCH_PATH})
 
 set_ifndef(LINKERFLAGPREFIX -Wl)
 
-if(CONFIG_CPP_EXCEPTIONS)
+compiler_file_path(crtbegin.o CRTBEGIN_PATH)
+compiler_file_path(crtend.o CRTEND_PATH)
+if(CONFIG_CPP_EXCEPTIONS AND CRTBEGIN_PATH AND CRTEND_PATH)
   # When building with C++ Exceptions, it is important that crtbegin and crtend
   # are linked at specific locations.
   # The location is so important that we cannot let this be controlled by normal
   # link libraries, instead we must control the link command specifically as
   # part of toolchain.
   set(CMAKE_CXX_LINK_EXECUTABLE
-      "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> ${LIBGCC_DIR}/crtbegin.o <OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${LIBGCC_DIR}/crtend.o")
+      "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> ${CRTBEGIN_PATH} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${CRTEND_PATH}")
 endif()
 
 # Run $LINKER_SCRIPT file through the C preprocessor, producing ${linker_script_gen}

--- a/cmake/modules/FindTargetTools.cmake
+++ b/cmake/modules/FindTargetTools.cmake
@@ -106,6 +106,7 @@ include(${ZEPHYR_BASE}/cmake/bintools/bintools_template.cmake)
 include(${TOOLCHAIN_ROOT}/cmake/bintools/${BINTOOLS}/target.cmake OPTIONAL)
 
 include(${TOOLCHAIN_ROOT}/cmake/linker/target_template.cmake)
+include(${TOOLCHAIN_ROOT}/cmake/compiler/target_template.cmake)
 
 set(TargetTools_FOUND TRUE)
 set(TARGETTOOLS_FOUND TRUE)


### PR DESCRIPTION
This series has the same goal as #87657 but does it in a more straightforward fashion by creating linker properties for each optimization level and passing those to the linker rather than creating a function to map compiler flags to linker flags.

In addition, the mechanism to extract the non-generator expression compiler flags has been removed; none of those are currently relevant for the multilib selection; all we need is the existing toolchain_c_flags and optimization flag.