### PR TITLE
dts: silabs: Add informatation for PA availability

### DIFF
--- a/dts/arm/silabs/efr32mg21a020f1024im32.dtsi
+++ b/dts/arm/silabs/efr32mg21a020f1024im32.dtsi
@@ -13,7 +13,8 @@
 	};
 
 	soc {
-		compatible = "silabs,efr32mg21a020f1024im32", "silabs,efr32mg21", "silabs,efr32", "simple-bus";
+		compatible = "silabs,efr32mg21a020f1024im32", "silabs,efr32mg21", "silabs,efr32", "simple-bus",
+						"silabs-hp-pa", "silabs-mp-pa", "silabs-lp-pa";
 
 		flash-controller@50030000 {
 			flash0: flash@0 {

--- a/dts/arm/silabs/efr32mg24b020f1536im40.dtsi
+++ b/dts/arm/silabs/efr32mg24b020f1536im40.dtsi
@@ -15,7 +15,7 @@
 	soc {
 		compatible = "silabs,efr32mg24b020f1536im40",
 					"silabs,efr32mg24", "silabs,efr32",
-					"simple-bus";
+					"simple-bus", "silabs-hp-pa";
 	};
 };
 

--- a/dts/arm/silabs/efr32mg24b210f1536im48.dtsi
+++ b/dts/arm/silabs/efr32mg24b210f1536im48.dtsi
@@ -16,7 +16,7 @@
 		compatible = "silabs,efr32mg24b210f1536im48",
 					 "silabs,efr32mg24",
 					 "silabs,efr32",
-					 "simple-bus";
+					 "simple-bus",  "silabs-mp-pa", "silabs-lp-pa";
 	};
 };
 

--- a/dts/arm/silabs/efr32mg24b220f1536im48.dtsi
+++ b/dts/arm/silabs/efr32mg24b220f1536im48.dtsi
@@ -15,7 +15,7 @@
 	soc {
 		compatible = "silabs,efr32mg24b220f1536im48",
 					 "silabs,efr32mg24", "silabs,efr32",
-					 "simple-bus";
+					 "simple-bus", "silabs-hp-pa";
 	};
 };
 

--- a/dts/arm/silabs/efr32mg24b310f1536im48.dtsi
+++ b/dts/arm/silabs/efr32mg24b310f1536im48.dtsi
@@ -15,7 +15,7 @@
 	soc {
 		compatible = "silabs,efr32mg24b310f1536im48",
 					 "silabs,efr32mg24", "silabs,efr32",
-					 "simple-bus";
+					 "simple-bus","silabs-mp-pa", "silabs-lp-pa";
 	};
 };
 

--- a/dts/arm/silabs/efr32zg23b020f512im48.dtsi
+++ b/dts/arm/silabs/efr32zg23b020f512im48.dtsi
@@ -15,7 +15,7 @@
 	soc {
 		compatible = "silabs,efr32zg23b020f512im48",
 					"silabs,efr32zg23", "silabs,efr32",
-					"simple-bus";
+					"simple-bus", "silabs-hp-pa";
 	};
 };
 

--- a/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b140f1024im40.dtsi
@@ -10,7 +10,7 @@
 / {
 	soc {
 		compatible = "silabs,efr32bg29b140f1024im40", "silabs,efr32bg29", "silabs,xg29",
-			     "silabs,efr32", "simple-bus";
+			     "silabs,efr32", "simple-bus", "silabs-hp-pa", "silabs-lp-pa";
 	};
 };
 

--- a/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32bg29b230f1024cm40.dtsi
@@ -11,7 +11,7 @@
 / {
 	soc {
 		compatible = "silabs,efr32bg29b230f1024cm40", "silabs,efr32bg29", "silabs,xg29",
-			     "silabs,efr32", "simple-bus";
+			     "silabs,efr32", "simple-bus", "silabs-hp-pa", "silabs-lp-pa";
 	};
 };
 

--- a/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b140f1024im40.dtsi
@@ -10,7 +10,7 @@
 / {
 	soc {
 		compatible = "silabs,efr32mg29b140f1024im40", "silabs,efr32mg29", "silabs,xg29",
-			     "silabs,efr32", "simple-bus";
+			     "silabs,efr32", "simple-bus", "silabs-hp-pa", "silabs-lp-pa";
 	};
 };
 

--- a/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
+++ b/dts/arm/silabs/xg29/efr32mg29b230f1024cm40.dtsi
@@ -11,7 +11,7 @@
 / {
 	soc {
 		compatible = "silabs,efr32mg29b230f1024cm40", "silabs,efr32mg29", "silabs,xg29",
-			     "silabs,efr32", "simple-bus";
+			     "silabs,efr32", "simple-bus", "silabs-hp-pa", "silabs-lp-pa";
 	};
 };
 


### PR DESCRIPTION
Different SOC variants may have several power amplifiers and  this information was not available in devicetree. It was available in header files but that information is not usable when construction overlay files.