### PR TITLE
doc: release-notes-4-2: Add coredump new Kconfig options

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -231,6 +231,8 @@ New APIs and options
   * Core Dump
 
     * :kconfig:option:`CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP`, enabled by default for ARM Cortex M when :kconfig:option:`CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN` is selected.
+    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY`
+    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY_SIZE`
 
 * Other
 


### PR DESCRIPTION
A new coredump backend was added, and can be enabled and configured directly via Kconfig.