### PR TITLE
boards: nxp: mimxrt1040_evk: Convert to Bluetooth M.2 shield

### DIFF
--- a/boards/nxp/mimxrt1040_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1040_evk/doc/index.rst
@@ -293,7 +293,7 @@ steps:
 Bluetooth Module
 ----------------
 
-For Murate 2EL M.2 Mdoule, the following hardware rework needs to be applied,
+For the :ref:`nxp_m2_wifi_bt` shield, the following hardware rework needs to be applied,
 Solder 0 ohm resistors for R96, and R93.
 Remove resistors from R497, R498, R456 and R457.
 

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -32,7 +32,6 @@
 		zephyr,flash-controller = &w25q64jvssiq;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,uart-mcumgr = &lpuart1;
-		zephyr,bt-hci = &bt_hci_uart;
 	};
 
 	sdram0: memory@80000000 {
@@ -233,28 +232,6 @@ lpi2c3: &lpi2c3 {
 	status = "okay";
 };
 
-m2_hci_uart: &lpuart3 {
-	pinctrl-0 = <&pinmux_lpuart3_flowcontrol>;
-	pinctrl-1 = <&pinmux_lpuart3_sleep>;
-	pinctrl-names = "default", "sleep";
+m2_hci_bt_uart: &lpuart3 {};
 
-	bt_hci_uart: bt_hci_uart {
-		compatible = "zephyr,bt-hci-uart";
-
-		m2_bt_module {
-			compatible = "nxp,bt-hci-uart";
-			sdio-reset-gpios = <&gpio3 4 GPIO_ACTIVE_HIGH>;
-			w-disable-gpios = <&gpio3 2 GPIO_ACTIVE_HIGH>;
-			hci-operation-speed = <115200>;
-			hw-flow-control;
-			fw-download-primary-speed = <115200>;
-			fw-download-secondary-speed = <3000000>;
-			fw-download-secondary-flowcontrol;
-		};
-	};
-};
-
-&m2_hci_uart {
-	status = "okay";
-	current-speed = <115200>;
-};
+m2_wifi_sdio: &usdhc1 {};

--- a/boards/shields/nxp_m2_wifi_bt/boards/mimxrt1040_evk_mimxrt1042.overlay
+++ b/boards/shields/nxp_m2_wifi_bt/boards/mimxrt1040_evk_mimxrt1042.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&m2_hci_bt_uart {
+	/delete-property/ pinctrl-0;
+	/delete-property/ pinctrl-1;
+	/delete-property/ pinctrl-2;
+	/delete-property/ pinctrl-names;
+	pinctrl-0 = <&pinmux_lpuart3_flowcontrol>;
+	pinctrl-1 = <&pinmux_lpuart3_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	bt_hci_uart: bt_hci_uart {
+		m2_bt_module: m2_bt_module {
+			sdio-reset-gpios = <&gpio3 4 GPIO_ACTIVE_HIGH>;
+			w-disable-gpios = <&gpio3 2 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&m2_wifi_sdio {
+	/* TODO: Unsupported; Fix pinctrl */
+};

--- a/samples/bluetooth/handsfree/boards/mimxrt1040_evk_mimxrt1042.conf
+++ b/samples/bluetooth/handsfree/boards/mimxrt1040_evk_mimxrt1042.conf
@@ -1,2 +1,0 @@
-#select NXP NW612 firmware for IW612 Chipset
-CONFIG_BT_NXP_NW612=y

--- a/samples/bluetooth/handsfree_ag/boards/mimxrt1040_evk_mimxrt1042.conf
+++ b/samples/bluetooth/handsfree_ag/boards/mimxrt1040_evk_mimxrt1042.conf
@@ -1,2 +1,0 @@
-#select NXP NW612 Chipset
-CONFIG_BT_NXP_NW612=y


### PR DESCRIPTION
Use the shield nxp_m2_wifi_bt instead of defining on board nodes.

NXP devs, please verify on actual hardware.