### PR TITLE
soc: intel_adsp: Manage power gating based on core activity

### DIFF
--- a/soc/intel/intel_adsp/ace/multiprocessing.c
+++ b/soc/intel/intel_adsp/ace/multiprocessing.c
@@ -11,6 +11,7 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/xtensa/arch.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
 #include <zephyr/pm/device_runtime.h>
 #include <ksched.h>
 
@@ -147,6 +148,11 @@ void soc_start_core(int cpu_num)
 		} else {
 			*rom_jump_vector = (uint32_t) dsp_restore_vector;
 		}
+
+		/* The primary core cannot enter power gating if any of the secondary cores are
+		 * active.
+		 */
+		pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 #else
 		*rom_jump_vector = (uint32_t) z_soc_mp_asm_entry;
 #endif

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -5,6 +5,7 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/device.h>
 #include <zephyr/debug/sparse.h>
@@ -342,6 +343,10 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 			/* do power down - this function won't return */
 			power_down(true, IS_ENABLED(CONFIG_ADSP_POWER_DOWN_HPSRAM), true);
 		} else {
+			/* When all secondary cores are turned off, power gating for the primary
+			 * core will be re-enabled.
+			 */
+			pm_policy_state_lock_put(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 			power_gate_entry(cpu);
 		}
 		break;

--- a/soc/intel/intel_adsp/ace/power.c
+++ b/soc/intel/intel_adsp/ace/power.c
@@ -82,17 +82,17 @@ void power_down(bool disable_lpsram, bool disable_hpsram, bool response_to_ipc);
  */
 extern void platform_context_restore(void);
 
-/*
+/**
  * @brief pointer to a persistent storage space, to be set by platform code
  */
 uint8_t *global_imr_ram_storage;
 
-/*8
- * @biref a d3 restore boot entry point
+/**
+ * @brief a d3 restore boot entry point
  */
 extern void boot_entry_d3_restore(void);
 
-/*
+/**
  * @brief re-enables IDC interrupt for all cores after exiting D3 state
  *
  * Called once from core 0
@@ -101,8 +101,8 @@ extern void soc_mp_on_d3_exit(void);
 
 #else
 
-/*
- * @biref FW entry point called by ROM during normal boot flow
+/**
+ * @brief FW entry point called by ROM during normal boot flow
  */
 extern void rom_entry(void);
 

--- a/soc/intel/intel_adsp/cavs/power.c
+++ b/soc/intel/intel_adsp/cavs/power.c
@@ -47,8 +47,8 @@ LOG_MODULE_REGISTER(soc);
 
 #define ALL_USED_INT_LEVELS_MASK (L2_INTERRUPT_MASK | L3_INTERRUPT_MASK)
 
-/*
- * @biref FW entry point called by ROM during normal boot flow
+/**
+ * @brief FW entry point called by ROM during normal boot flow
  */
 extern void rom_entry(void);
 void mp_resume_entry(void);


### PR DESCRIPTION
This patch enhances the power management capabilities of the Intel ADSP by ensuring that power gating states are appropriately managed based on core activity. It prevents the primary core from entering power gating if secondary cores are active and re-enables power gating when all secondary cores are off, using `pm_policy_state_lock_get` and `pm_policy_state_lock_put` functions. 

The Sound Open Firmware (SOF) project currently uses a custom power management policy to achieve these effects. With this patch, the default power management policy can be utilized, allowing the option to disable the custom policy while maintaining system reliability and performance across different core states.