### PR TITLE
drivers: display_st7567: Fix unintialized variable warning

### DIFF
--- a/drivers/display/display_st7567.c
+++ b/drivers/display/display_st7567.c
@@ -338,7 +338,7 @@ static int st7567_reset(const struct device *dev)
 static int st7567_clear(const struct device *dev)
 {
 	const struct st7567_config *config = dev->config;
-	int ret;
+	int ret = 0;
 	uint8_t buf = 0;
 
 	uint8_t cmd_buf[] = {


### PR DESCRIPTION
Theoretically (if either `height` or `width` in `config` is set to 0), the `ret` variable might be returned from `st7567_clear()` without being initialized.
Add initialization of this variable to avoid compiler warnings.