### PR TITLE
mgmt: hawkbit: don't require DNS_RESOLVER

### DIFF
--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -11,7 +11,6 @@ menuconfig HAWKBIT
 	depends on IMG_MANAGER
 	depends on NETWORKING
 	depends on HTTP_CLIENT
-	depends on DNS_RESOLVER
 	depends on JSON_LIBRARY
 	depends on BOOTLOADER_MCUBOOT
 	depends on SMF
@@ -57,7 +56,8 @@ config HAWKBIT_TENANT
 config HAWKBIT_SERVER
 	string "User address for the hawkbit server"
 	help
-	  Configure the hawkbit server address.
+	  Configure the hawkbit server address. If the address is not an IP address,
+	  CONFIG_DNS_RESOLVER must be enabled to resolve the hostname.
 
 config HAWKBIT_PORT
 	int "Port number for the hawkbit server"


### PR DESCRIPTION
When the supplied server address is already an
ip address, CONFIG_DNS_RESOLVER is not required,
as zsock_getaddrinfo() can resolve literal addresses without it.