### PR TITLE
MAINTAINERS: Add avolmat-st as collaborator in Drivers: Video

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2162,6 +2162,7 @@ Release Notes:
     - loicpoulain
     - josuah
     - ngphibang
+    - avolmat-st
   files:
     - drivers/video/
     - include/zephyr/drivers/video.h


### PR DESCRIPTION
Adding Alain Volmat (avolmat-st) as collaborator in Drivers: Video

Alain's contributions:
https://github.com/zephyrproject-rtos/zephyr/issues?q=%20author%3Aavolmat-st%20