### PR TITLE
boards: opta: enable qspi

### DIFF
--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
@@ -122,3 +122,34 @@ zephyr_udc0: &usbotg_fs {
 		reg = <0x00>;
 	};
 };
+
+&quadspi {
+	pinctrl-0 = < &quadspi_bk1_io0_pd11
+		      &quadspi_bk1_io1_pd12
+		      &quadspi_bk1_io2_pe2
+		      &quadspi_bk1_io3_pd13
+		      &quadspi_bk1_ncs_pg6
+		      &quadspi_clk_pb2 >;
+	pinctrl-names = "default";
+	status = "okay";
+
+	at25sf128a: qspi-nor-flash@90000000 {
+		compatible = "st,stm32-qspi-nor";
+		reg = < 0x90000000 DT_SIZE_M(16) >; /* 128 MBits */
+		qspi-max-frequency = <DT_FREQ_M(70)>;
+		status = "okay";
+		spi-bus-width = <2>;
+		st,read-id-dummy-cycles = <16>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = < 1 >;
+			#size-cells = < 1 >;
+
+			storage_partition: partition@0 {
+				label = "storage";
+				reg=< 0x0 DT_SIZE_K(15872) >;
+			};
+		};
+	};
+};

--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.yaml
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.yaml
@@ -10,6 +10,7 @@ flash: 768
 supported:
   - gpio
   - netif:eth
+  - qspi
 testing:
   ignore_tags:
     - mpu


### PR DESCRIPTION
For a personal project I wanted to store a 16 byte key but I was unable to work with the flash reliably using the Arduino mbed code.
I am far from an expert here so assume nothing :)

Features enabled by this commit:
* QSPI

With this change the following test passes:
```
west build -p always -b arduino_opta/stm32h747xx/m7 samples/drivers/spi_flash
cd  build
west flash
```

Note: using the API below I seem to get the JEDEC ID in the wrong order (01 1F 89) (expect 1F 89 01)
```
const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(at25sf128a));
unsigned char buf[3] = {0};
int ret = flash_read_jedec_id(dev, buf);
printk("read flash jedec id (%02X %02X %02X) (expect 1F 89 01) with status %d\n", buf[0], buf[1], buf[2], ret);
```

Partially based on this: https://github.com/zephyrproject-rtos/zephyr/commit/68d0aaedb1527d7e69e16eece88b03f69cbb662e