### PR TITLE
drivers: display: Sitronix ST7567 avoid uninitialized build warning

### DIFF
--- a/drivers/display/display_st7567.c
+++ b/drivers/display/display_st7567.c
@@ -338,7 +338,7 @@ static int st7567_reset(const struct device *dev)
 static int st7567_clear(const struct device *dev)
 {
 	const struct st7567_config *config = dev->config;
-	int ret;
+	int ret = 0;
 	uint8_t buf = 0;
 
 	uint8_t cmd_buf[] = {


### PR DESCRIPTION
gcc 14 believes this function may return an unitialized value causing undefined behaviour in the caller:
```
drivers/display/display_st7567.c:415:12: error: ‘ret’ may be used uninitialized [-Werror=maybe-uninitialized]
  415 |         if (ret < 0) {
      |            ^
```
Let's fix it by initializing ret which has a trivial cost.

Fixes this test failing to build in main:
twister -p native_sim/native/64 -p native_sim -T tests/drivers/build_all/display