### PR TITLE
soc: espressif: esp32: include ksched.h to avoid warning

### DIFF
--- a/soc/espressif/esp32/esp32-mp.c
+++ b/soc/espressif/esp32/esp32-mp.c
@@ -22,6 +22,7 @@
 #ifdef CONFIG_SMP
 
 #include <ipi.h>
+#include <ksched.h>
 
 #ifndef CONFIG_SOC_ESP32_PROCPU
 static struct k_spinlock loglock;


### PR DESCRIPTION
Include ksched.h to avoid implicit declaration warning for function `z_sched_ipi`

Fixes #89546