### PR TITLE
yaml: save intermediate files in the build directory

### DIFF
--- a/cmake/modules/yaml.cmake
+++ b/cmake/modules/yaml.cmake
@@ -526,7 +526,7 @@ function(yaml_save)
 
     cmake_path(SET yaml_path "${yaml_file}")
     cmake_path(GET yaml_path STEM yaml_file_no_ext)
-    set(expanded_file ${yaml_file_no_ext}_${genex_save_count}.yaml)
+    set(expanded_file ${CMAKE_CURRENT_BINARY_DIR}/${yaml_file_no_ext}_${genex_save_count}.yaml)
     set_property(TARGET ${save_target} PROPERTY expanded_file ${expanded_file})
 
     # comment this to keep the temporary files


### PR DESCRIPTION
Make sure to provide full paths when saving the intermediate files in `yaml_save`, to prevent them from being saved in the current (source) directory. Fixes #89545.