### PR TITLE
drivers: serial: max32: indicate need for FULL_LIBC support

### DIFF
--- a/drivers/serial/Kconfig.max32
+++ b/drivers/serial/Kconfig.max32
@@ -12,6 +12,8 @@ config UART_MAX32
 	select PINCTRL
 	select SERIAL_SUPPORT_ASYNC if DT_HAS_ADI_MAX32_DMA_ENABLED
 	select DMA if UART_ASYNC_API
+	# UART HAL uses pow() function, so we need full LIBC
+	select REQUIRES_FULL_LIBC
 	help
 	  This option enables the UART driver for MAX32 family of
 	  processors.


### PR DESCRIPTION
Indicate the need for FULL_LIBC support within the max32 driver Kconfig, since this driver's HAL uses the pow() function.

Fixes #89550