### PR TITLE
pinctrl: Add missing newline in .dtsi

### DIFF
--- a/boards/wch/ch32v003evt/ch32v003evt-pinctrl.dtsi
+++ b/boards/wch/ch32v003evt/ch32v003evt-pinctrl.dtsi
@@ -13,6 +13,7 @@
 			drive-push-pull;
 			slew-rate = "max-speed-10mhz";
 		};
+
 		group2 {
 			pinmux = <USART1_RX_PD6_0>;
 			bias-pull-up;

--- a/boards/wch/linkw/linkw-pinctrl.dtsi
+++ b/boards/wch/linkw/linkw-pinctrl.dtsi
@@ -13,6 +13,7 @@
 			drive-push-pull;
 			slew-rate = "max-speed-10mhz";
 		};
+
 		group2 {
 			pinmux = <USART2_RX_PA3_0>;
 			bias-pull-up;


### PR DESCRIPTION
Add a missing newline between two groups in the pin control .dtsi file for the ch32v003evt and the linkw board to comply with style rules.

This little style issue is being copy and pasted into every new wch board, and each time @nordicjm has to go and ask to add the newline, so this commit fix the original style issue.

https://github.com/zephyrproject-rtos/zephyr/pull/87125#discussion_r1995754814
https://github.com/zephyrproject-rtos/zephyr/pull/89361#discussion_r2075143757
https://github.com/zephyrproject-rtos/zephyr/pull/87072#discussion_r1994993553
https://github.com/zephyrproject-rtos/zephyr/pull/89451#discussion_r2075168001