### PR TITLE
drivers: fpga: ice40: Fix log level

### DIFF
--- a/drivers/fpga/fpga_ice40_bitbang.c
+++ b/drivers/fpga/fpga_ice40_bitbang.c
@@ -38,7 +38,7 @@
  * direct register access to the set and clear registers.
  */
 
-LOG_MODULE_DECLARE(fpga_ice40);
+LOG_MODULE_DECLARE(fpga_ice40, CONFIG_FPGA_LOG_LEVEL);
 
 struct fpga_ice40_config_bitbang {
 	struct gpio_dt_spec clk;

--- a/drivers/fpga/fpga_ice40_common.c
+++ b/drivers/fpga/fpga_ice40_common.c
@@ -10,7 +10,7 @@
 
 #include "fpga_ice40_common.h"
 
-LOG_MODULE_REGISTER(fpga_ice40);
+LOG_MODULE_REGISTER(fpga_ice40, CONFIG_FPGA_LOG_LEVEL);
 
 void fpga_ice40_crc_to_str(uint32_t crc, char *s)
 {

--- a/drivers/fpga/fpga_ice40_spi.c
+++ b/drivers/fpga/fpga_ice40_spi.c
@@ -15,7 +15,7 @@
 
 #include "fpga_ice40_common.h"
 
-LOG_MODULE_DECLARE(fpga_ice40);
+LOG_MODULE_DECLARE(fpga_ice40, CONFIG_FPGA_LOG_LEVEL);
 
 static int fpga_ice40_load(const struct device *dev, uint32_t *image_ptr, uint32_t img_size)
 {


### PR DESCRIPTION
All FPGA driver implementations should respect `CONFIG_FPGA_LOG_LEVEL`.