### PR TITLE
drivers: spi: nxp_lpspi: Fix race condition in ISR

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -89,11 +89,6 @@ static inline void lpspi_handle_rx_irq(const struct device *dev)
 	}
 
 	LOG_DBG("RX done %d words to spi buf", total_words_written);
-
-	if (spi_context_rx_len_left(ctx) == 0) {
-		base->IER &= ~LPSPI_IER_RDIE_MASK;
-		base->CR |= LPSPI_CR_RRF_MASK; /* flush rx fifo */
-	}
 }
 
 /* constructs the next word from the buffer */
@@ -202,18 +197,22 @@ static inline void lpspi_handle_tx_irq(const struct device *dev)
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
 	struct spi_context *ctx = &data->ctx;
 
+	base->SR = LPSPI_SR_TDF_MASK;
+
+	/* If we receive a TX interrupt but no more data is available,
+	 * we can be sure that all data has been written to the bus.
+	 * Disable the interrupt to signal that we are done.
+	 */
+	if (!spi_context_tx_on(ctx)) {
+		base->IER &= ~LPSPI_IER_TDIE_MASK;
+		return;
+	}
+
 	while (spi_context_tx_on(ctx) && lpspi_data->fill_len > 0) {
 		size_t this_buf_words_sent = MIN(lpspi_data->fill_len, ctx->tx_len);
 
 		spi_context_update_tx(ctx, lpspi_data->word_size_bytes, this_buf_words_sent);
 		lpspi_data->fill_len -= this_buf_words_sent;
-	}
-
-	base->SR = LPSPI_SR_TDF_MASK;
-
-	if (!spi_context_tx_on(ctx)) {
-		base->IER &= ~LPSPI_IER_TDIE_MASK;
-		return;
 	}
 
 	lpspi_next_tx_fill(data->dev);
@@ -253,6 +252,11 @@ static void lpspi_isr(const struct device *dev)
 		lpspi_handle_tx_irq(dev);
 	}
 
+	if (spi_context_rx_len_left(ctx) == 0) {
+		base->IER &= ~LPSPI_IER_RDIE_MASK;
+		base->CR |= LPSPI_CR_RRF_MASK; /* flush rx fifo */
+	}
+
 	if (spi_context_tx_on(ctx)) {
 		return;
 	}
@@ -275,7 +279,10 @@ static void lpspi_isr(const struct device *dev)
 		 * need to end xfer in order to get last bit clocked out on bus.
 		 */
 		base->TCR |= LPSPI_TCR_CONT_MASK;
-	} else if (spi_context_rx_len_left(ctx) == 0) {
+	}
+
+	/* Both receive and transmit parts disable their interrupt once finished. */
+	if (base->IER == 0) {
 		lpspi_end_xfer(dev);
 	}
 }


### PR DESCRIPTION
Fixes #89557.

The main architectural change is that the RX/TX halves of a transmission now signal that they are finished by disabling their interrupts.

This in turn will then be picked up further down in the ISR as the signal that the entire transmission is over.

The order of operations inside the `handle_tx_irq` had to be changed, so that the interrupt only gets disabled once both of those are fulfilled:
- no more TX data available
- physical transmission finished

Before, the IRQ got disabled while the physical transmission was not finished yet; for that to be a given we must be out of data **and** an active TX interrupt must exist. In the current code, it got disabled once we had no more data, but the TX interrupt wasn't set.

The second fix is that RX will be cleared and RX interrupts will be disabled every time we get an interrupt and we have no more data to send. Previously, this was only done if an RX interrupt was pending, which made it possible that the RX interrupts were still enabled at the end of the transmission.