### PR TITLE
drivers: gpio: update GPIO register addresses for TI Davinci Driver

### DIFF
--- a/drivers/gpio/gpio_davinci.c
+++ b/drivers/gpio/gpio_davinci.c
@@ -33,7 +33,8 @@ LOG_MODULE_REGISTER(gpio_davinci, CONFIG_GPIO_LOG_LEVEL);
 #define GPIO_DAVINCI_DIR_RESET_VAL	(0xFFFFFFFF)
 
 struct gpio_davinci_regs {
-	uint32_t dir;
+	uint32_t UNUSED[4];		/* 0x00-0x0C */
+	uint32_t dir;			/* 0x10 */
 	uint32_t out_data;
 	uint32_t set_data;
 	uint32_t clr_data;

--- a/dts/arm/ti/am62x_m4.dtsi
+++ b/dts/arm/ti/am62x_m4.dtsi
@@ -78,7 +78,7 @@
 
 	gpio0: gpio@4201010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x4201010 0x100>;
+		reg = <0x4201000 0x100>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <24>;

--- a/dts/arm/ti/am64x_m4.dtsi
+++ b/dts/arm/ti/am64x_m4.dtsi
@@ -99,7 +99,7 @@
 
 	gpio0: gpio@4201010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x4201010 0x100>;
+		reg = <0x4201000 0x100>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <24>;

--- a/dts/arm/ti/j722s_main.dtsi
+++ b/dts/arm/ti/j722s_main.dtsi
@@ -21,7 +21,7 @@
 
 	gpio0: gpio@600010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x00600010 0x100>;
+		reg = <0x00600000 0x100>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <92>;
@@ -30,7 +30,7 @@
 
 	gpio1: gpio@601010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x00601010 0x100>;
+		reg = <0x00601000 0x100>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <52>;

--- a/dts/arm/ti/j722s_mcu.dtsi
+++ b/dts/arm/ti/j722s_mcu.dtsi
@@ -15,7 +15,7 @@
 
 	mcu_gpio0: gpio@4201010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x4201010 0x100>;
+		reg = <0x4201000 0x100>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <24>;


### PR DESCRIPTION
This PR resolves a discrepancy between the Linux kernel and Zephyr’s version of the Davinci GPIO driver.

Previously, the Zephyr driver expected the DIR register to be at offset 0x00, whereas according to the TRM — and as implemented in the Linux kernel — it actually resides at offset 0x10. To work around this, Zephyr DTS files for TI platforms (e.g., AM6xx,J7xx) defined the GPIO base address with an added 0x10 offset.

This setup was confusing for developers unfamiliar with the Zephyr-specific deviation, especially when trying to align with TRM documentation or reuse DTS files from the Linux kernel.