### PR TITLE
drivers: serial: serial_test: Improve IRQ-driven support

### DIFF
--- a/drivers/serial/serial_test.c
+++ b/drivers/serial/serial_test.c
@@ -155,6 +155,11 @@ static void irq_callback_set(const struct device *dev, uart_irq_callback_user_da
 	LOG_DBG("callback set");
 }
 
+static int irq_update(const struct device *dev)
+{
+	return 1;
+}
+
 static int fifo_fill(const struct device *dev, const uint8_t *tx_data, int size)
 {
 	struct serial_vnd_data *data = dev->data;
@@ -433,6 +438,7 @@ static DEVICE_API(uart, serial_vnd_api) = {
 #endif /* CONFIG_UART_USE_RUNTIME_CONFIGURE */
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	.irq_callback_set = irq_callback_set,
+	.irq_update = irq_update,
 	.irq_rx_enable = irq_rx_enable,
 	.irq_rx_disable = irq_rx_disable,
 	.irq_rx_ready = irq_rx_ready,


### PR DESCRIPTION
Fix some deficiencies in the IRQ-driven implementation of the serial_test driver, so it can be more generally used as a mock serial port in testing code which uses IRQ-driven serial operation:

- Support non-NULL IRQ callback user data
- Support irq_update call