### PR TITLE
Reduce number of writable symbols stored in ROM

### DIFF
--- a/arch/arc/core/vector_table.c
+++ b/arch/arc/core/vector_table.c
@@ -47,7 +47,7 @@ struct vector_table {
 	uintptr_t unused_2;
 };
 
-struct vector_table _VectorTable Z_GENERIC_SECTION(.exc_vector_table) = {
+const struct vector_table _VectorTable Z_GENERIC_SECTION(.exc_vector_table) = {
 	(uintptr_t)__reset,
 	(uintptr_t)__memory_error,
 	(uintptr_t)__instruction_error,

--- a/arch/arm/core/cortex_a_r/irq_manage.c
+++ b/arch/arm/core/cortex_a_r/irq_manage.c
@@ -132,7 +132,7 @@ static inline void z_arm_irq_dynamic_direct_isr_dispatch(void)
 	uint32_t irq = __get_IPSR() - 16;
 
 	if (irq < IRQ_TABLE_SIZE) {
-		struct _isr_table_entry *isr_entry = &_sw_isr_table[irq];
+		const struct _isr_table_entry *isr_entry = &_sw_isr_table[irq];
 
 		isr_entry->isr(isr_entry->arg);
 	}

--- a/arch/arm/core/cortex_m/irq_manage.c
+++ b/arch/arm/core/cortex_m/irq_manage.c
@@ -256,7 +256,7 @@ static inline void z_arm_irq_dynamic_direct_isr_dispatch(void)
 	uint32_t irq = __get_IPSR() - 16;
 
 	if (irq < IRQ_TABLE_SIZE) {
-		struct _isr_table_entry *isr_entry = &_sw_isr_table[irq];
+		const struct _isr_table_entry *isr_entry = &_sw_isr_table[irq];
 
 		isr_entry->isr(isr_entry->arg);
 	}

--- a/arch/arm/core/cortex_m/isr_wrapper.c
+++ b/arch/arm/core/cortex_m/isr_wrapper.c
@@ -76,7 +76,7 @@ void _isr_wrapper(void)
 	 */
 	irq_number -= 16;
 
-	struct _isr_table_entry *entry = &_sw_isr_table[irq_number];
+	const struct _isr_table_entry *entry = &_sw_isr_table[irq_number];
 	(entry->isr)(entry->arg);
 
 #if defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)

--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -78,7 +78,7 @@ void __irq_vector_table __attribute__((naked)) _irq_vector_table(void) {
 #else
 
 /* The IRQ vector table is an array of vector addresses */
-uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
+const uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
 	[0 ...(IRQ_TABLE_SIZE - 1)] = (uintptr_t)&IRQ_VECTOR_TABLE_DEFAULT_ISR,
 };
 #endif /* CONFIG_IRQ_VECTOR_TABLE_JUMP_BY_CODE */
@@ -88,6 +88,9 @@ uintptr_t __irq_vector_table _irq_vector_table[IRQ_TABLE_SIZE] = {
  * type and bypass the _sw_isr_table, then do not generate one.
  */
 #ifdef CONFIG_GEN_SW_ISR_TABLE
+#ifndef CONFIG_DYNAMIC_INTERRUPTS
+const
+#endif
 struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
 	[0 ...(IRQ_TABLE_SIZE - 1)] = {(const void *)0x42,
 				       &z_irq_spurious},
@@ -95,6 +98,9 @@ struct _isr_table_entry __sw_isr_table _sw_isr_table[IRQ_TABLE_SIZE] = {
 #endif
 
 #ifdef CONFIG_SHARED_INTERRUPTS
+#ifndef CONFIG_DYNAMIC_INTERRUPTS
+const
+#endif
 struct z_shared_isr_table_entry __shared_sw_isr_table z_shared_sw_isr_table[IRQ_TABLE_SIZE] = {
 };
 #endif

--- a/arch/common/isr_tables_shell.c
+++ b/arch/common/isr_tables_shell.c
@@ -8,7 +8,8 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/sw_isr_table.h>
 
-static void dump_isr_table_entry(const struct shell *sh, int idx, struct _isr_table_entry *entry)
+static void dump_isr_table_entry(const struct shell *sh, int idx,
+				 const struct _isr_table_entry *entry)
 {
 
 	if ((entry->isr == z_irq_spurious) || (entry->isr == NULL)) {

--- a/arch/mips/core/irq_manage.c
+++ b/arch/mips/core/irq_manage.c
@@ -70,7 +70,7 @@ void z_mips_enter_irq(uint32_t ipending)
 
 	while (ipending) {
 		int index;
-		struct _isr_table_entry *ite;
+		const struct _isr_table_entry *ite;
 
 		if (IS_ENABLED(CONFIG_TRACING_ISR)) {
 			sys_trace_isr_enter();

--- a/cmake/linker_script/common/thread-local-storage.cmake
+++ b/cmake/linker_script/common/thread-local-storage.cmake
@@ -13,7 +13,7 @@ if(CONFIG_THREAD_LOCAL_STORAGE)
   zephyr_linker_section_configure(SECTION .tbss INPUT ".tbss.*")
   zephyr_linker_section_configure(SECTION .tbss INPUT ".gnu.linkonce.tb.*")
   zephyr_linker_section_configure(SECTION .tbss INPUT ".tcommon")
-  # GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+  # GROUP_ROM_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
   #
   # These needs to be outside of the tdata/tbss

--- a/drivers/interrupt_controller/intc_dw_ace.c
+++ b/drivers/interrupt_controller/intc_dw_ace.c
@@ -150,7 +150,7 @@ static void dwint_isr(const void *arg)
 	while (fs) {
 		uint32_t bit = find_lsb_set(fs) - 1;
 		uint32_t offset = CONFIG_2ND_LVL_ISR_TBL_OFFSET + bit;
-		struct _isr_table_entry *ent = &_sw_isr_table[offset];
+		const struct _isr_table_entry *ent = &_sw_isr_table[offset];
 
 		fs &= ~BIT(bit);
 		ent->isr(ent->arg);

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -93,7 +93,7 @@ struct plic_config {
 	uint32_t nr_irqs;
 	uint32_t irq;
 	riscv_plic_irq_config_func_t irq_config_func;
-	struct _isr_table_entry *isr_table;
+	const struct _isr_table_entry *isr_table;
 	const uint32_t *const hart_context;
 };
 
@@ -490,7 +490,7 @@ static void plic_irq_handler(const struct device *dev)
 {
 	const struct plic_config *config = dev->config;
 	mem_addr_t claim_complete_addr = get_claim_complete_addr(dev);
-	struct _isr_table_entry *ite;
+	const struct _isr_table_entry *ite;
 	uint32_t cpu_id = arch_curr_cpu()->id;
 	/* Get the IRQ number generating the interrupt */
 	const uint32_t local_irq = sys_read32(claim_complete_addr);

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -43,7 +43,7 @@ struct rv32m1_intmux_config {
 	INTMUX_Type *regs;
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
-	struct _isr_table_entry *isr_base;
+	const struct _isr_table_entry *isr_base;
 };
 
 #define DEV_REGS(dev) (((const struct rv32m1_intmux_config *)(dev->config))->regs)
@@ -112,8 +112,8 @@ static void rv32m1_intmux_isr(const void *arg)
 	INTMUX_Type *regs = DEV_REGS(dev);
 	uint32_t channel = POINTER_TO_UINT(arg);
 	uint32_t line = (regs->CHANNEL[channel].CHn_VEC >> 2);
-	struct _isr_table_entry *isr_base = config->isr_base;
-	struct _isr_table_entry *entry;
+	const struct _isr_table_entry *isr_base = config->isr_base;
+	const struct _isr_table_entry *entry;
 
 	/*
 	 * Make sure the vector is valid, there is a note of page 1243~1244

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -120,7 +120,7 @@ static void swerv_pic_irq_handler(const void *arg)
 {
 	uint32_t tmp;
 	uint32_t irq;
-	struct _isr_table_entry *ite;
+	const struct _isr_table_entry *ite;
 
 	/* trigger the capture of the interrupt source ID */
 	__asm__ swerv_pic_writecsr(meicpct, 0);
@@ -136,7 +136,7 @@ static void swerv_pic_irq_handler(const void *arg)
 	irq += RISCV_MAX_GENERIC_IRQ;
 
 	/* Call the corresponding IRQ handler in _sw_isr_table */
-	ite = (struct _isr_table_entry *)&_sw_isr_table[irq];
+	ite = (const struct _isr_table_entry *)&_sw_isr_table[irq];
 	if (ite->isr) {
 		ite->isr(ite->arg);
 	}

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -58,7 +58,7 @@ static inline void vexriscv_litex_irq_setie(uint32_t ie)
 
 static void vexriscv_litex_irq_handler(const void *device)
 {
-	struct _isr_table_entry *ite;
+	const struct _isr_table_entry *ite;
 	uint32_t pending, mask, irqs;
 
 	pending = vexriscv_litex_irq_pending();

--- a/include/zephyr/linker/thread-local-storage.ld
+++ b/include/zephyr/linker/thread-local-storage.ld
@@ -8,10 +8,10 @@
 		*(.tdata .tdata.* .gnu.linkonce.td.*);
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
-	SECTION_DATA_PROLOGUE(tbss,,)
+	SECTION_DATA_PROLOGUE(tbss,(NOLOAD),)
 	{
 		*(.tbss .tbss.* .gnu.linkonce.tb.* .tcommon);
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
 	/*
 	 * These needs to be outside of the tdata/tbss

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -44,7 +44,11 @@ struct _isr_table_entry {
 /* The software ISR table itself, an array of these structures indexed by the
  * irq line
  */
-extern struct _isr_table_entry _sw_isr_table[];
+extern
+#ifndef CONFIG_DYNAMIC_INTERRUPTS
+const
+#endif
+struct _isr_table_entry _sw_isr_table[];
 
 struct _irq_parent_entry {
 	const struct device *dev;
@@ -173,7 +177,11 @@ struct z_shared_isr_table_entry {
 
 void z_shared_isr(const void *data);
 
-extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
+extern
+#ifndef CONFIG_DYNAMIC_INTERRUPTS
+const
+#endif
+struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 #endif /* CONFIG_SHARED_INTERRUPTS */
 
 /** This interrupt gets put directly in the vector table */

--- a/scripts/build/gen_isr_tables_parser_carrays.py
+++ b/scripts/build/gen_isr_tables_parser_carrays.py
@@ -198,7 +198,7 @@ typedef void (* ISR)(const void *);
         fp.write("}\n")
 
     def __write_address_irq_vector_table(self, fp):
-        fp.write("uintptr_t __irq_vector_table _irq_vector_table[%d] = {\n" % self.__nv)
+        fp.write("const uintptr_t __irq_vector_table _irq_vector_table[%d] = {\n" % self.__nv)
         for i in range(self.__nv):
             func = self.__vt[i]
 
@@ -213,6 +213,8 @@ typedef void (* ISR)(const void *);
         fp.write("};\n")
 
     def __write_shared_table(self, fp):
+        if not self.__config.check_sym("CONFIG_DYNAMIC_INTERRUPTS"):
+            fp.write("const ")
         fp.write("struct z_shared_isr_table_entry __shared_sw_isr_table"
                 " z_shared_sw_isr_table[%d] = {\n" % self.__nv)
 
@@ -256,6 +258,8 @@ typedef void (* ISR)(const void *);
         if not self.__swt:
             return
 
+        if not self.__config.check_sym("CONFIG_DYNAMIC_INTERRUPTS"):
+            fp.write("const ")
         fp.write("struct _isr_table_entry __sw_isr_table _sw_isr_table[%d] = {\n"
                 % self.__nv)
 

--- a/soc/cdns/xtensa_sample_controller/include/_soc_inthandlers.h
+++ b/soc/cdns/xtensa_sample_controller/include/_soc_inthandlers.h
@@ -90,19 +90,19 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 	if (mask & 0x7f) {
 		if (mask & 0x7) {
 			if (mask & (1 << 0)) {
-				struct _isr_table_entry *e = &_sw_isr_table[0];
+				const struct _isr_table_entry *e = &_sw_isr_table[0];
 
 				e->isr(e->arg);
 				return 1 << 0;
 			}
 			if (mask & (1 << 1)) {
-				struct _isr_table_entry *e = &_sw_isr_table[1];
+				const struct _isr_table_entry *e = &_sw_isr_table[1];
 
 				e->isr(e->arg);
 				return 1 << 1;
 			}
 			if (mask & (1 << 2)) {
-				struct _isr_table_entry *e = &_sw_isr_table[2];
+				const struct _isr_table_entry *e = &_sw_isr_table[2];
 
 				e->isr(e->arg);
 				return 1 << 2;
@@ -110,26 +110,26 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 		} else {
 			if (mask & 0x18) {
 				if (mask & (1 << 3)) {
-					struct _isr_table_entry *e = &_sw_isr_table[3];
+					const struct _isr_table_entry *e = &_sw_isr_table[3];
 
 					e->isr(e->arg);
 					return 1 << 3;
 				}
 				if (mask & (1 << 4)) {
-					struct _isr_table_entry *e = &_sw_isr_table[4];
+					const struct _isr_table_entry *e = &_sw_isr_table[4];
 
 					e->isr(e->arg);
 					return 1 << 4;
 				}
 			} else {
 				if (mask & (1 << 5)) {
-					struct _isr_table_entry *e = &_sw_isr_table[5];
+					const struct _isr_table_entry *e = &_sw_isr_table[5];
 
 					e->isr(e->arg);
 					return 1 << 5;
 				}
 				if (mask & (1 << 6)) {
-					struct _isr_table_entry *e = &_sw_isr_table[6];
+					const struct _isr_table_entry *e = &_sw_isr_table[6];
 
 					e->isr(e->arg);
 					return 1 << 6;
@@ -139,19 +139,19 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 	} else {
 		if (mask & 0x18080) {
 			if (mask & (1 << 7)) {
-				struct _isr_table_entry *e = &_sw_isr_table[7];
+				const struct _isr_table_entry *e = &_sw_isr_table[7];
 
 				e->isr(e->arg);
 				return 1 << 7;
 			}
 			if (mask & (1 << 15)) {
-				struct _isr_table_entry *e = &_sw_isr_table[15];
+				const struct _isr_table_entry *e = &_sw_isr_table[15];
 
 				e->isr(e->arg);
 				return 1 << 15;
 			}
 			if (mask & (1 << 16)) {
-				struct _isr_table_entry *e = &_sw_isr_table[16];
+				const struct _isr_table_entry *e = &_sw_isr_table[16];
 
 				e->isr(e->arg);
 				return 1 << 16;
@@ -159,26 +159,26 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 		} else {
 			if (mask & 0x60000) {
 				if (mask & (1 << 17)) {
-					struct _isr_table_entry *e = &_sw_isr_table[17];
+					const struct _isr_table_entry *e = &_sw_isr_table[17];
 
 					e->isr(e->arg);
 					return 1 << 17;
 				}
 				if (mask & (1 << 18)) {
-					struct _isr_table_entry *e = &_sw_isr_table[18];
+					const struct _isr_table_entry *e = &_sw_isr_table[18];
 
 					e->isr(e->arg);
 					return 1 << 18;
 				}
 			} else {
 				if (mask & (1 << 19)) {
-					struct _isr_table_entry *e = &_sw_isr_table[19];
+					const struct _isr_table_entry *e = &_sw_isr_table[19];
 
 					e->isr(e->arg);
 					return 1 << 19;
 				}
 				if (mask & (1 << 20)) {
-					struct _isr_table_entry *e = &_sw_isr_table[20];
+					const struct _isr_table_entry *e = &_sw_isr_table[20];
 
 					e->isr(e->arg);
 					return 1 << 20;
@@ -192,7 +192,7 @@ static inline int _xtensa_handle_one_int1(unsigned int mask)
 static inline int _xtensa_handle_one_int2(unsigned int mask)
 {
 	if (mask & (1 << 8)) {
-		struct _isr_table_entry *e = &_sw_isr_table[8];
+		const struct _isr_table_entry *e = &_sw_isr_table[8];
 
 		e->isr(e->arg);
 		return 1 << 8;
@@ -204,26 +204,26 @@ static inline int _xtensa_handle_one_int3(unsigned int mask)
 {
 	if (mask & 0x600) {
 		if (mask & (1 << 9)) {
-			struct _isr_table_entry *e = &_sw_isr_table[9];
+			const struct _isr_table_entry *e = &_sw_isr_table[9];
 
 			e->isr(e->arg);
 			return 1 << 9;
 		}
 		if (mask & (1 << 10)) {
-			struct _isr_table_entry *e = &_sw_isr_table[10];
+			const struct _isr_table_entry *e = &_sw_isr_table[10];
 
 			e->isr(e->arg);
 			return 1 << 10;
 		}
 	} else {
 		if (mask & (1 << 11)) {
-			struct _isr_table_entry *e = &_sw_isr_table[11];
+			const struct _isr_table_entry *e = &_sw_isr_table[11];
 
 			e->isr(e->arg);
 			return 1 << 11;
 		}
 		if (mask & (1 << 21)) {
-			struct _isr_table_entry *e = &_sw_isr_table[21];
+			const struct _isr_table_entry *e = &_sw_isr_table[21];
 
 			e->isr(e->arg);
 			return 1 << 21;
@@ -235,7 +235,7 @@ static inline int _xtensa_handle_one_int3(unsigned int mask)
 static inline int _xtensa_handle_one_int4(unsigned int mask)
 {
 	if (mask & (1 << 12)) {
-		struct _isr_table_entry *e = &_sw_isr_table[12];
+		const struct _isr_table_entry *e = &_sw_isr_table[12];
 
 		e->isr(e->arg);
 		return 1 << 12;
@@ -246,7 +246,7 @@ static inline int _xtensa_handle_one_int4(unsigned int mask)
 static inline int _xtensa_handle_one_int5(unsigned int mask)
 {
 	if (mask & (1 << 13)) {
-		struct _isr_table_entry *e = &_sw_isr_table[13];
+		const struct _isr_table_entry *e = &_sw_isr_table[13];
 
 		e->isr(e->arg);
 		return 1 << 13;
@@ -262,7 +262,7 @@ static inline int _xtensa_handle_one_int6(unsigned int mask)
 static inline int _xtensa_handle_one_int7(unsigned int mask)
 {
 	if (mask & (1 << 14)) {
-		struct _isr_table_entry *e = &_sw_isr_table[14];
+		const struct _isr_table_entry *e = &_sw_isr_table[14];
 
 		e->isr(e->arg);
 		return 1 << 14;

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -170,7 +170,7 @@ void rtc_nrf_isr(void);
 
 #define IRQ_VECTOR_TABLE_SIZE (MAX(POWER_CLOCK_IRQ_NUM, MAX(TIMER_IRQ_NUM, _ISR_OFFSET + 2)) + 1)
 
-vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
+const vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
 #if (POWER_CLOCK_IRQ_NUM != -1)
 	[POWER_CLOCK_IRQ_NUM] = nrfx_power_clock_irq_handler,
 #endif
@@ -186,7 +186,7 @@ vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
  * the custom vector table to handle the timer "tick" interrupts.
  */
 extern void rtc_isr(void);
-vth __irq_vector_table _irq_vector_table[] = {isr0, isr1, isr2, 0, rtc_isr};
+const vth __irq_vector_table _irq_vector_table[] = {isr0, isr1, isr2, 0, rtc_isr};
 
 /* clang-format off */
 #elif (defined(CONFIG_SOC_SERIES_IMXRT6XX) || defined(CONFIG_SOC_SERIES_IMXRT5XX) ||               \
@@ -199,7 +199,7 @@ vth __irq_vector_table _irq_vector_table[] = {isr0, isr1, isr2, 0, rtc_isr};
  * the timer "tick" interrupts.
  */
 extern void mcux_lpc_ostick_isr(void);
-vth __irq_vector_table _irq_vector_table[] = {
+const vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, mcux_lpc_ostick_isr};
 #elif (defined(CONFIG_SOC_SERIES_IMXRT10XX) || defined(CONFIG_SOC_SERIES_IMXRT11XX)) &&            \
@@ -213,7 +213,7 @@ extern void mcux_imx_gpt_isr(void);
 #if defined(CONFIG_SOC_MIMXRT1011)
 /* clang-format off */
 /* RT1011 GPT timer interrupt is at offset 30 */
-vth __irq_vector_table _irq_vector_table[] = {
+const vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, mcux_imx_gpt_isr
 };
@@ -221,7 +221,7 @@ vth __irq_vector_table _irq_vector_table[] = {
 #elif defined(CONFIG_SOC_SERIES_IMXRT10XX)
 /* clang-format off */
 /* RT10xx GPT timer interrupt is at offset 100 */
-vth __irq_vector_table _irq_vector_table[] = {
+const vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -231,7 +231,7 @@ vth __irq_vector_table _irq_vector_table[] = {
 /* clang-format on */
 #elif defined(CONFIG_SOC_SERIES_IMXRT11XX)
 /* RT11xx GPT timer interrupt is at offset 119 */
-vth __irq_vector_table _irq_vector_table[] = {
+const vth __irq_vector_table _irq_vector_table[] = {
 	isr0, isr1, isr2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0,    0,    0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -242,7 +242,7 @@ vth __irq_vector_table _irq_vector_table[] = {
 #error "GPT timer enabled, but no known SOC selected. ISR table needs rework"
 #endif
 #else
-vth __irq_vector_table _irq_vector_table[] = {isr0, isr1, isr2};
+const vth __irq_vector_table _irq_vector_table[] = {isr0, isr1, isr2};
 #endif /* CONFIG_SOC_FAMILY_NORDIC_NRF */
 
 /**

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -12,7 +12,7 @@
 #include <zephyr/interrupt_util.h>
 #include <zephyr/sys/barrier.h>
 
-extern uintptr_t _irq_vector_table[];
+extern const uintptr_t _irq_vector_table[];
 
 #if defined(ARCH_IRQ_DIRECT_CONNECT) && defined(CONFIG_GEN_IRQ_VECTOR_TABLE)
 #define HAS_DIRECT_IRQS
@@ -243,7 +243,7 @@ static int check_vector(void *isr, int offset)
 #ifdef CONFIG_GEN_SW_ISR_TABLE
 static int check_sw_isr(void *isr, uintptr_t arg, int offset)
 {
-	struct _isr_table_entry *e = &_sw_isr_table[TABLE_INDEX(offset)];
+	const struct _isr_table_entry *e = &_sw_isr_table[TABLE_INDEX(offset)];
 
 	TC_PRINT("Checking _sw_isr_table entry %d for irq %d\n",
 		 TABLE_INDEX(offset), IRQ_LINE(offset));

--- a/tests/kernel/interrupt/src/dynamic_isr.c
+++ b/tests/kernel/interrupt/src/dynamic_isr.c
@@ -20,7 +20,11 @@ static void dyn_isr(const void *arg)
 }
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE)
-extern struct _isr_table_entry _sw_isr_table[];
+extern
+#ifndef CONFIG_DYNAMIC_INTERRUPTS
+const
+#endif
+struct _isr_table_entry _sw_isr_table[];
 
 #if defined(CONFIG_RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET)
 #define IRQ_OFFSET CONFIG_RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET

--- a/tests/kernel/interrupt/src/interrupt_offload.c
+++ b/tests/kernel/interrupt/src/interrupt_offload.c
@@ -102,6 +102,8 @@ void isr_handler(const void *param)
 #define TEST_IRQ_DYN_LINE 0
 #endif
 
+#else
+#define TEST_IRQ_DYN_LINE 0
 #endif
 
 static void init_dyn_interrupt(void)
@@ -111,11 +113,13 @@ static void init_dyn_interrupt(void)
 		ztest_test_skip();
 	}
 
+#if defined(CONFIG_DYNAMIC_INTERRUPTS)
 	/* We just initialize dynamic interrupt once, then reuse them */
 	if (!vector_num) {
 		vector_num = irq_connect_dynamic(TEST_IRQ_DYN_LINE, 1,
 					isr_handler, (void *)&irq_param, 0);
 	}
+#endif
 
 	TC_PRINT("vector(%d)\n", vector_num);
 	zassert_true(vector_num > 0, "no vector can be used");

--- a/tests/kernel/interrupt/src/test_shared_irq.h
+++ b/tests/kernel/interrupt/src/test_shared_irq.h
@@ -40,8 +40,8 @@ static inline bool client_exists_at_index(void (*routine)(const void *arg),
 					  void *arg, int irq, size_t idx)
 {
 	size_t i;
-	struct z_shared_isr_table_entry *shared_entry;
-	struct _isr_table_entry *client;
+	const struct z_shared_isr_table_entry *shared_entry;
+	const struct _isr_table_entry *client;
 
 	shared_entry = &z_shared_sw_isr_table[irq];
 


### PR DESCRIPTION
This series fixes three places where symbols stored in ROM were not marked const:

 1. .tbss symbols. These aren't actually stored in ROM, but if we tell the linker to pretend to place them in ROM, that segment gets marked writable.
 2. _sw_isr_table when DYNAMIC_INTERRUPTS is not enabled
 3. _irq_vector_table when it is an array of uintptr_t.

These three patches are sufficient to get samples/hello_world linking on cortex m3 without marking anything RWX.