### PR TITLE
drivers: icm42688: fix FIFO HIRES packet gyro scale

### DIFF
--- a/drivers/sensor/tdk/icm42688/icm42688_decoder.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_decoder.c
@@ -250,7 +250,7 @@ static int icm42688_read_imu_from_packet(const uint8_t *pkt, bool is_accel, int 
 
 	const uint32_t scale[2][2] = {
 		/* low-res,	hi-res */
-		{35744,		8936}, /* gyro */
+		{35744,		2235}, /* gyro */
 		{40168,		2511}, /* accel */
 	};
 


### PR DESCRIPTION
The original scale value used to convert raw gyro value to q31 format is incorrect. Updated to the correct value.

The new value is calculated as follows:
`(pi / 180) / ((131 << 1) / 2^(31 - 6))`
where 131 is the sensitivity value provided by the datasheet (in LSB/dps), the left shift by 1 is due to the fact that the LSB is always 0 for 20-bit packet and 6 is the shift value used by the driver.

See: ICM42688 datasheet (DS-000347 revision 1.8) section 6.1