### PR TITLE
drivers: clock: npcx: correct the setting for module power-down

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -13,6 +13,12 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(clock_control_npcx, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
+#if defined(CONFIG_NPCX_SOC_VARIANT_NPCXN)
+#define NPCX_PWDWN_CTL_START_OFFSET NPCX_PWDWN_CTL1
+#elif defined(CONFIG_NPCX_SOC_VARIANT_NPCKN)
+#define NPCX_PWDWN_CTL_START_OFFSET NPCX_PWDWN_CTL0
+#endif
+
 /* Driver config */
 struct npcx_pcc_config {
 	/* cdcg device base address */
@@ -243,7 +249,7 @@ static int npcx_clock_control_init(const struct device *dev)
 	 * power consumption.
 	 */
 	for (int i = 0; i < ARRAY_SIZE(pddwn_ctl_val); i++) {
-		NPCX_PWDWN_CTL(pmc_base, i) = pddwn_ctl_val[i];
+		NPCX_PWDWN_CTL(pmc_base, i + NPCX_PWDWN_CTL_START_OFFSET) = pddwn_ctl_val[i];
 	}
 
 	/* Turn off the clock of the eSPI module only if eSPI isn't required */


### PR DESCRIPTION
The PWDWN_CTLx has been adjusted to support NPCK chips. 
This commit updates the power-down control at initialization for NPCXN and NPCKN chips.