### PR TITLE
dts/bindings/pwm/it8xxx2: remove redundant property

### DIFF
--- a/boards/ite/it82xx2_evb/it82xx2_evb.dts
+++ b/boards/ite/it82xx2_evb/it82xx2_evb.dts
@@ -134,15 +134,14 @@
 	pinctrl-names = "default";
 };
 
-/* pwm for test */
+/*
+ * pwm for test:
+ * If we need pwm output in ITE chip power saving mode,
+ * then we should set frequency <=324Hz.
+ */
 &pwm0 {
 	status = "okay";
 	prescaler-cx = <PWM_PRESCALER_C6>;
-	/*
-	 * If we need pwm output in ITE chip power saving mode,
-	 * then we should set frequency <=324Hz.
-	 */
-	pwm-output-frequency = <324>;
 	pinctrl-0 = <&pwm0_gpa0_default>;
 	pinctrl-names = "default";
 };
@@ -151,7 +150,6 @@
 &pwm7 {
 	status = "okay";
 	prescaler-cx = <PWM_PRESCALER_C4>;
-	pwm-output-frequency = <30000>;
 	pinctrl-0 = <&pwm7_gpa7_default>;
 	pinctrl-names = "default";
 };

--- a/boards/ite/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/ite/it8xxx2_evb/it8xxx2_evb.dts
@@ -121,15 +121,14 @@
 		     &uart2_tx_gph2_default>;
 	pinctrl-names = "default";
 };
-/* pwm for test */
+/*
+ * pwm for test:
+ * If we need pwm output in ITE chip power saving mode,
+ * then we should set frequency <=324Hz.
+ */
 &pwm0 {
 	status = "okay";
 	prescaler-cx = <PWM_PRESCALER_C6>;
-	/*
-	 * If we need pwm output in ITE chip power saving mode,
-	 * then we should set frequency <=324Hz.
-	 */
-	pwm-output-frequency = <324>;
 	pinctrl-0 = <&pwm0_gpa0_default>;
 	pinctrl-names = "default";
 };
@@ -137,7 +136,6 @@
 &pwm7 {
 	status = "okay";
 	prescaler-cx = <PWM_PRESCALER_C4>;
-	pwm-output-frequency = <30000>;
 	pinctrl-0 = <&pwm7_gpa7_default>;
 	pinctrl-names = "default";
 };

--- a/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
@@ -42,10 +42,6 @@ properties:
       - 3
     description: 1 = PWM_PRESCALER_C4, 2 = PWM_PRESCALER_C6, 3 = PWM_PRESCALER_C7
 
-  pwm-output-frequency:
-    type: int
-    description: PWM output frequency for operation
-
   pinctrl-0:
     required: true
 


### PR DESCRIPTION
it8xxx2 pwm driver does not handle "pwm-output-frequency" property, so setting the property in borad.dts is useless.

About PWM output frequency, it can be set by pwm-cells "period", "pwm-output-frequency" is really redundant.