### PR TITLE
Maintainers update

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1837,6 +1837,8 @@ Release Notes:
   status: odd fixes
   collaborators:
     - aasinclair
+    - nordic-auko
+    - seov-nordic
   files:
     - drivers/mfd/
     - include/zephyr/drivers/mfd/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1864,7 +1864,8 @@ Release Notes:
 "Drivers: Regulators":
   status: maintained
   maintainers:
-    - gmarull
+    - nordic-auko
+    - seov-nordic
   collaborators:
     - danieldegrasse
     - aasinclair


### PR DESCRIPTION
Add @nordic-auko and @seov-nordic as maintainers for Regulators driver, and as collaborators for MFD driver. Remove @gmarull as maintainer for Regulators driver.
This reflects update of responsibilities from the Nordic development side 