### PR TITLE
MAINTAINERS.yml: rename NXP Drivers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3786,7 +3786,7 @@ Intel Platforms (Agilex):
   labels:
     - "platform: Intel SoC FPGA Agilex"
 
-NXP Drivers:
+NXP Platform Drivers:
   status: maintained
   maintainers:
     - dleach02
@@ -3827,7 +3827,7 @@ NXP Drivers:
     - "platform: NXP Drivers"
   description: NXP Drivers
 
-NXP Wireless:
+NXP Platform Wireless:
   status: maintained
   maintainers:
     - dleach02
@@ -3841,7 +3841,7 @@ NXP Wireless:
   labels:
     - "platform: NXP Drivers"
 
-NXP MCUX USB:
+NXP Platform MCUX USB:
   status: maintained
   maintainers:
     - mmahadevan108


### PR DESCRIPTION
The set_assignees.py script detects platforms
by checking if the Area title contains the string
"Platform",  this was missing for some NXP
Platforms, so this adds it. This way the platform
maintainers are assigned preferably.

This way I as the ethernet maintainer don't get assigned for changes that mainly change the nxp ethernet drivers.