### PR TITLE
nRF GPIO: Fix get_config not returning initial output setting

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -254,6 +254,9 @@ static int gpio_nrfx_pin_get_config(const struct device *port, gpio_pin_t pin,
 
 	if (dir == NRF_GPIO_PIN_DIR_OUTPUT) {
 		*flags |= GPIO_OUTPUT;
+		*flags |= nrf_gpio_pin_out_read(abs_pin)
+			? GPIO_OUTPUT_INIT_HIGH
+			: GPIO_OUTPUT_INIT_LOW;
 	}
 
 	nrf_gpio_pin_input_t input = nrf_gpio_pin_input_get(abs_pin);


### PR DESCRIPTION
The nRF GPIO hardware does not store the initial output value set resulting from gpio_pin_configure() and thus, when gpio_get_config() is used, the initial value is not returned.

This commit reads the output value, and converts this to the corresponding INIT flag in the config

fixes: #88293