### PR TITLE
sca: add coverity as a SCA variant

### DIFF
--- a/cmake/sca/coverity/sca.cmake
+++ b/cmake/sca/coverity/sca.cmake
@@ -1,0 +1,21 @@
+
+find_program(COVERITY_BUILD NAMES cov-build REQUIRED)
+find_program(COVERITY_CONFIGURE NAMES cov-configure REQUIRED)
+message(STATUS "Found SCA: Coverity (${COVERITY_BUILD})")
+
+
+zephyr_get(COVERITY_OUTPUT_DIR)
+
+if(NOT COVERITY_OUTPUT_DIR)
+  set(output_dir ${CMAKE_BINARY_DIR}/sca/coverity)
+else()
+  set(output_dir ${COVERITY_OUTPUT_DIR})
+endif()
+
+file(MAKE_DIRECTORY ${output_dir})
+
+set(output_arg --dir=${output_dir})
+
+
+set(CMAKE_C_COMPILER_LAUNCHER ${COVERITY_BUILD} ${output_arg} CACHE INTERNAL "")
+set(CMAKE_CXX_COMPILER_LAUNCHER ${COVERITY_BUILD} ${output_arg} CACHE INTERNAL "")

--- a/doc/develop/sca/coverity.rst
+++ b/doc/develop/sca/coverity.rst
@@ -1,0 +1,33 @@
+.. _coverity:
+
+Coverity
+#########
+
+Coverity Scan is a service by which Black Duck provides the results of analysis
+on open source coding projects to open source code developers that have
+registered their products with Coverity Scan.
+
+This integration was only tested with scan.coverity.com and the tool
+distribution available through this service.
+
+Generating Build Data Files
+***************************
+
+To use this integration, coverity tool distribution must be found in your :envvar:`PATH` environment and
+:ref:`west build <west-building>` should be called with a ``-DZEPHYR_SCA_VARIANT=coverity``
+parameter, e.g.
+
+.. code-block:: shell
+
+    west build -b qemu_cortex_m3 samples/hello_world -- -DZEPHYR_SCA_VARIANT=coverity
+
+
+Results of the scan will be generated as :file:`build/sca/coverity`.
+
+You can also set :envvar:`COVERITY_OUTPUT_DIR` as the destination for multiple
+and incremental scan results.
+
+Result Analysis
+****************
+
+Follow the instructions on http://scan.coverity.com for uploading results.

--- a/doc/develop/sca/index.rst
+++ b/doc/develop/sca/index.rst
@@ -67,3 +67,4 @@ The following is a list of SCA tools natively supported by Zephyr build system.
    cpptest
    eclair
    polyspace
+   coverity


### PR DESCRIPTION
Add coverity integration as a SCA variant. This is targetting the
service provided by blackduck to open-source projects available on
scan.coverity.com.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
