### PR TITLE
soc: nordic: nrf54h: Remove external square wave

### DIFF
--- a/soc/nordic/nrf54h/bicr/bicr-schema.json
+++ b/soc/nordic/nrf54h/bicr/bicr-schema.json
@@ -350,12 +350,10 @@
           "type": "string",
           "title": "Mode",
           "enumNames": [
-            "Crystal",
-            "External square signal"
+            "Crystal"
           ],
           "enum": [
-            "CRYSTAL",
-            "EXT_SQUARE"
+            "CRYSTAL"
           ],
           "default": "CRYSTAL"
         },


### PR DESCRIPTION
This option is no longer present in the Datasheet, remove it from the BICR JSON file.