### PR TITLE
modules: openthread: fix unused function error

### DIFF
--- a/modules/openthread/platform/logging.c
+++ b/modules/openthread/platform/logging.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "platform-zephyr.h"
 
+#if defined(CONFIG_LOG)
 /* Convert OT log level to zephyr log level. */
 static inline int log_translate(otLogLevel aLogLevel)
 {
@@ -38,6 +39,7 @@ static inline int log_translate(otLogLevel aLogLevel)
 
 	return -1;
 }
+#endif
 
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {


### PR DESCRIPTION
Compile `log_translate` function only if `CONFIG_LOG` is defined.