### PR TITLE
nRF GPIO and SPI PM_DEVICE_RUNTIME

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -11,6 +11,8 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/dt-bindings/gpio/nordic-nrf-gpio.h>
 #include <zephyr/irq.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include <zephyr/drivers/gpio/gpio_utils.h>
 
@@ -62,53 +64,37 @@ static nrf_gpio_pin_pull_t get_pull(gpio_flags_t flags)
 	return NRF_GPIO_PIN_NOPULL;
 }
 
-static int gpio_nrfx_gpd_retain_set(const struct device *port, uint32_t mask, gpio_flags_t flags)
+static void gpio_nrfx_gpd_retain_set(const struct device *port, uint32_t mask, gpio_flags_t flags)
 {
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
 
-	if (cfg->pad_pd == NRF_GPD_FAST_ACTIVE1) {
-		int ret;
-
-		if (flags & GPIO_OUTPUT) {
-			nrf_gpio_port_retain_enable(cfg->port, mask);
-		}
-
-		ret = nrf_gpd_release(NRF_GPD_FAST_ACTIVE1);
-		if (ret < 0) {
-			return ret;
-		}
+	if (cfg->pad_pd != NRF_GPD_FAST_ACTIVE1 || !(flags & GPIO_OUTPUT)) {
+		return;
 	}
+
+	nrf_gpio_port_retain_enable(cfg->port, mask);
 #else
 	ARG_UNUSED(port);
 	ARG_UNUSED(mask);
 	ARG_UNUSED(flags);
 #endif
-
-	return 0;
 }
 
-static int gpio_nrfx_gpd_retain_clear(const struct device *port, uint32_t mask)
+static void gpio_nrfx_gpd_retain_clear(const struct device *port, uint32_t mask)
 {
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
 
-	if (cfg->pad_pd == NRF_GPD_FAST_ACTIVE1) {
-		int ret;
-
-		ret = nrf_gpd_request(NRF_GPD_FAST_ACTIVE1);
-		if (ret < 0) {
-			return ret;
-		}
-
-		nrf_gpio_port_retain_disable(cfg->port, mask);
+	if (cfg->pad_pd != NRF_GPD_FAST_ACTIVE1) {
+		return;
 	}
+
+	nrf_gpio_port_retain_disable(cfg->port, mask);
 #else
 	ARG_UNUSED(port);
 	ARG_UNUSED(mask);
 #endif
-
-	return 0;
 }
 
 static int gpio_nrfx_pin_configure(const struct device *port, gpio_pin_t pin,
@@ -152,10 +138,12 @@ static int gpio_nrfx_pin_configure(const struct device *port, gpio_pin_t pin,
 		return -EINVAL;
 	}
 
-	ret = gpio_nrfx_gpd_retain_clear(port, BIT(pin));
+	ret = pm_device_runtime_get(port);
 	if (ret < 0) {
 		return ret;
 	}
+
+	gpio_nrfx_gpd_retain_clear(port, BIT(pin));
 
 	if (flags & GPIO_OUTPUT_INIT_HIGH) {
 		nrf_gpio_port_out_set(cfg->port, BIT(pin));
@@ -237,8 +225,8 @@ static int gpio_nrfx_pin_configure(const struct device *port, gpio_pin_t pin,
 	}
 
 end:
-	(void)gpio_nrfx_gpd_retain_set(port, BIT(pin), flags);
-	return ret;
+	gpio_nrfx_gpd_retain_set(port, BIT(pin), flags);
+	return pm_device_runtime_put(port);
 }
 
 #ifdef CONFIG_GPIO_GET_CONFIG
@@ -328,15 +316,16 @@ static int gpio_nrfx_port_set_masked_raw(const struct device *port,
 	const uint32_t set_mask = value & mask;
 	const uint32_t clear_mask = (~set_mask) & mask;
 
-	ret = gpio_nrfx_gpd_retain_clear(port, mask);
+	ret = pm_device_runtime_get(port);
 	if (ret < 0) {
 		return ret;
 	}
 
+	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_set(reg, set_mask);
 	nrf_gpio_port_out_clear(reg, clear_mask);
-
-	return gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	return pm_device_runtime_put(port);
 }
 
 static int gpio_nrfx_port_set_bits_raw(const struct device *port,
@@ -345,14 +334,15 @@ static int gpio_nrfx_port_set_bits_raw(const struct device *port,
 	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
 	int ret;
 
-	ret = gpio_nrfx_gpd_retain_clear(port, mask);
+	ret = pm_device_runtime_get(port);
 	if (ret < 0) {
 		return ret;
 	}
 
+	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_set(reg, mask);
-
-	return gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	return pm_device_runtime_put(port);
 }
 
 static int gpio_nrfx_port_clear_bits_raw(const struct device *port,
@@ -361,14 +351,15 @@ static int gpio_nrfx_port_clear_bits_raw(const struct device *port,
 	NRF_GPIO_Type *reg = get_port_cfg(port)->port;
 	int ret;
 
-	ret = gpio_nrfx_gpd_retain_clear(port, mask);
+	ret = pm_device_runtime_get(port);
 	if (ret < 0) {
 		return ret;
 	}
 
+	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_clear(reg, mask);
-
-	return gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	return pm_device_runtime_put(port);
 }
 
 static int gpio_nrfx_port_toggle_bits(const struct device *port,
@@ -380,15 +371,16 @@ static int gpio_nrfx_port_toggle_bits(const struct device *port,
 	const uint32_t clear_mask = (~value) & mask;
 	int ret;
 
-	ret = gpio_nrfx_gpd_retain_clear(port, mask);
+	ret = pm_device_runtime_get(port);
 	if (ret < 0) {
 		return ret;
 	}
 
+	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_set(reg, set_mask);
 	nrf_gpio_port_out_clear(reg, clear_mask);
-
-	return gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	return pm_device_runtime_put(port);
 }
 
 #ifdef CONFIG_GPIO_NRFX_INTERRUPT
@@ -547,17 +539,68 @@ static void nrfx_gpio_handler(nrfx_gpiote_pin_t abs_pin,
 	IRQ_CONNECT(DT_IRQN(node_id), DT_IRQ(node_id, priority), nrfx_isr, \
 		    NRFX_CONCAT(nrfx_gpiote_, DT_PROP(node_id, instance), _irq_handler), 0);
 
+static int gpio_nrfx_pm_suspend(const struct device *port)
+{
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
+
+	if (cfg->pad_pd != NRF_GPD_FAST_ACTIVE1) {
+		return 0;
+	}
+
+	return nrf_gpd_release(NRF_GPD_FAST_ACTIVE1);
+#else
+	ARG_UNUSED(port);
+	return 0;
+#endif
+}
+
+static int gpio_nrfx_pm_resume(const struct device *port)
+{
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
+
+	if (cfg->pad_pd != NRF_GPD_FAST_ACTIVE1) {
+		return 0;
+	}
+
+	return nrf_gpd_request(NRF_GPD_FAST_ACTIVE1);
+#else
+	ARG_UNUSED(port);
+	return 0;
+#endif
+}
+
+static int gpio_nrfx_pm_hook(const struct device *port, enum pm_device_action action)
+{
+	int ret;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_SUSPEND:
+		ret = gpio_nrfx_pm_suspend(port);
+		break;
+	case PM_DEVICE_ACTION_RESUME:
+		ret = gpio_nrfx_pm_resume(port);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+
 static int gpio_nrfx_init(const struct device *port)
 {
 	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
 	nrfx_err_t err;
 
 	if (!has_gpiote(cfg)) {
-		return 0;
+		goto pm_init;
 	}
 
 	if (nrfx_gpiote_init_check(&cfg->gpiote)) {
-		return 0;
+		goto pm_init;
 	}
 
 	err = nrfx_gpiote_init(&cfg->gpiote, 0 /*not used*/);
@@ -570,7 +613,8 @@ static int gpio_nrfx_init(const struct device *port)
 	DT_FOREACH_STATUS_OKAY(nordic_nrf_gpiote, GPIOTE_IRQ_HANDLER_CONNECT);
 #endif /* CONFIG_GPIO_NRFX_INTERRUPT */
 
-	return 0;
+pm_init:
+	return pm_device_driver_init(port, gpio_nrfx_pm_hook);
 }
 
 static DEVICE_API(gpio, gpio_nrfx_drv_api_funcs) = {
@@ -635,8 +679,10 @@ static DEVICE_API(gpio, gpio_nrfx_drv_api_funcs) = {
 									\
 	static struct gpio_nrfx_data gpio_nrfx_p##id##_data;		\
 									\
+	PM_DEVICE_DT_INST_DEFINE(id, gpio_nrfx_pm_hook);		\
+									\
 	DEVICE_DT_INST_DEFINE(id, gpio_nrfx_init,			\
-			 NULL,						\
+			 PM_DEVICE_DT_INST_GET(id),			\
 			 &gpio_nrfx_p##id##_data,			\
 			 &gpio_nrfx_p##id##_cfg,			\
 			 PRE_KERNEL_1,					\

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -153,7 +153,12 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 	void *reg = dev_config->spim.p_reg;
 
 	if (deactivate_cs) {
+		/*
+		 * We may suspend SPI only if we don't have to keep CS asserted, as we
+		 * need to keep the CS GPIO port resumed until spi_release() in this case.
+		 */
 		spi_context_cs_control(&dev_data->ctx, false);
+		pm_device_runtime_put_async(dev, K_NO_WAIT);
 	}
 
 	if (NRF_SPIM_IS_320MHZ_SPIM(reg) && !(dev_data->ctx.config->operation & SPI_HOLD_ON_CS)) {
@@ -163,8 +168,6 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 	if (!IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
 		release_clock(dev);
 	}
-
-	pm_device_runtime_put_async(dev, K_NO_WAIT);
 }
 
 static inline uint32_t get_nrf_spim_frequency(uint32_t frequency)
@@ -402,7 +405,7 @@ static void finish_transaction(const struct device *dev, int error)
 	spi_context_complete(ctx, dev, error);
 	dev_data->busy = false;
 
-	finalize_spi_transaction(dev, true);
+	finalize_spi_transaction(dev, (dev_data->ctx.config->operation & SPI_HOLD_ON_CS) > 0);
 }
 
 static void transfer_next_chunk(const struct device *dev)

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -39,10 +39,16 @@
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
+	cs-gpios = <&gpio7 0 0>;
 };
 
 &gpio0 {
 	status = "okay";
+};
+
+&gpio7 {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
 };
 
 &gpiote130 {


### PR DESCRIPTION
### Problem description:
On the nRFH20, some GPIOs are on a power domain. This power domain has to be resumed to use the GPIOs, and resuming them has to be done through IPC, thus, not from ISRs. The current solution just to use the GPIOs is to internally resume the domain from the driver, set/clear the pin, then suspend it again. This is slow and has to be done from thread context.

So, if we use SPI, and the CS is a GPIO on one of these special ports, we can't control the CS GPIO from the SPI ISR.

### The solution:
Implement PM_DEVICE_RUNTIME in GPIO driver, so port can be resumed once, from thread, then used from ISR with no IPC calls needed, then suspend port. Additonally, extend SPI driver to resume the port when it is resumed, and suspend once suspended, like a bus. Lastly, extend SPI test suite to support PM_DEVICE_RUNTIME.

Now, if PM_DEVICE_RUNTIME is not used, GPIO power domain is resumed on init, and kept on. if PM_DEVICE_RUNTIME is enabled, user can get the SPI, which gets the GPIO, which gets the GPIO power domain, before the transaction.

This touches the spi_context and spi_loopback test hence why the PR is not isolated to nordic :)