### PR TITLE
nordic GPD: select PINCTRL

### DIFF
--- a/soc/nordic/nrf54h/gpd/Kconfig
+++ b/soc/nordic/nrf54h/gpd/Kconfig
@@ -6,6 +6,7 @@ config SOC_NRF54H20_GPD
 	imply NRFS
 	imply NRFS_GDPWR_SERVICE_ENABLED
 	select ONOFF
+	select PINCTRL
 	default y if !MCUBOOT && (SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD)
 	help
 	  This option enables the Global Power Domain service.


### PR DESCRIPTION
Include pinctrl.h in gpd.c and IMPLY the PINCTRL option if the SOC_NRF54H20_GPD option is enabled, as it is used within the gpd.c though not necessarily called.