### PR TITLE
soc: silabs: workaround for NULL address assignment

### DIFF
--- a/soc/silabs/silabs_siwx91x/siwg917/soc.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/soc.c
@@ -16,6 +16,17 @@ void soc_early_init_hook(void)
 	SystemInit();
 }
 
+/* Reserve the address 0x0 at the start of the RAM. LINKER_KEEP is used to prevent the compiler from
+ * optimizing this function away. __ramfunc is used to place this function in RAM. It also has the
+ * advantage of being moved with the ramfunc section if CONFIG_SRAM_VECTOR_TABLE is set.
+ * TODO: In case of multiple __ramfunc functions, we need to ensure that null_pointer_function
+ * is the first to be placed in RAM. This can be achieved by modifying the ramfunc linker script.
+ */
+__ramfunc void null_pointer_function(void)
+{
+}
+LINKER_KEEP(null_pointer_function);
+
 /* SiWx917's bootloader requires IRQn 32 to hold payload's entry point address. */
 extern void z_arm_reset(void);
 Z_ISR_DECLARE_DIRECT(32, 0, z_arm_reset);


### PR DESCRIPTION
Since the RAM start address for the siwg_917 SoC is set to 0x0, nothing prevents placing a RAM function or data at address 0x0. This can create a NULL pointer error (or a failed assertion in tests) when the function is called or the data is accessed. This commit adds a workaround to prevent the RAM start address from being used by reserving the address 0x0 with a dummy function.

LINKER_KEEP is used to prevent the compiler from optimizing this function away.

__ramfunc is used to place this function in RAM. It also has the advantage of being moved with the ramfunc section if CONFIG_SRAM_VECTOR_TABLE is set.

Limitation: In the case of multiple __ramfunc functions, we need to ensure that null_pointer_function is the first to be placed in RAM. This can be achieved by modifying the ramfunc linker script. It is not done in this commit.

This problem has been found by working on RTC driver and especially running rtc_api tests. In the test_y2k test, one variable is defined static and then placed in data section with the ram start address (since it is considered as the first .data). It raises an assertion in the next check.

```
ZTEST(rtc_api, test_y2k)
{
	enum test_time {
		Y99,
		Y2K,
	};

	static struct rtc_time rtm[2] = {
		{.tm_isdst = -1, .tm_nsec = 0},
		{.tm_isdst = -1, .tm_nsec = 0},
	};
	struct tm *const tm[2] = {
		(struct tm *const)&rtm[0],
		(struct tm *const)&rtm[1],
	};
	const time_t t[] = {
		[Y99] = RTC_TEST_START_TIME,
		[Y2K] = RTC_TEST_STOP_TIME,
	};

	/* Party like it's 1999 */
	zassert_not_null(gmtime_r(&t[Y99], tm[Y99])); <==== FAILED ASSERT HERE
```