### PR TITLE
west.yml: Update hal_stm32 for new signals in -pcintrl.dtsi

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 02d82ee3aa0daa29ab6f107f9969508b89bc6bf7
+      revision: 5cbc642b1a79d4f373b1587f8c3027f31bf0d30c
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Mostly ETH pins on MP13 and HSPI pins on STM32U5.
