### PR TITLE
drivers: wifi: siwx91x: Add features to opermode (boot config)

### DIFF
--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -45,6 +45,14 @@ config NET_MGMT_EVENT_STACK_SIZE
 config NET_MGMT_EVENT_QUEUE_SIZE
 	default 10
 
+config WIFI_SILABS_SIWX91X_LIMIT_PACKET_BUF_PER_STA
+	bool "Limits the number of packets buffered per STA in AP mode"
+	default y
+	help
+	  In AP mode, if the bit is set, only two packets per Station (STA)
+	  would be buffered when the STA is in Power Save (PS) mode.
+	  This helps manage buffer usage and ensures efficient packet handling.
+
 config WIFI_SILABS_SIWX91X_ENABLE_ROAMING
 	bool "WiFi roaming support"
 	help

--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -55,6 +55,7 @@ config WIFI_SILABS_SIWX91X_LIMIT_PACKET_BUF_PER_STA
 
 config WIFI_SILABS_SIWX91X_ENABLE_ROAMING
 	bool "WiFi roaming support"
+	default y
 	help
 	  Enable this option to configure roaming parameters.
 	  Roaming will be enabled automatically when the
@@ -72,7 +73,7 @@ config WIFI_SILABS_SIWX91X_ROAMING_USE_DEAUTH
 config WIFI_SILABS_SIWX91X_ROAMING_TRIGGER_LEVEL
 	int "Default value of roam trigger level (in dBm)"
 	default -70
-	range -10 -100
+	range -100 -10
 	depends on WIFI_SILABS_SIWX91X_ENABLE_ROAMING
 	help
 	  Sets the default roam trigger level. Higher values trigger

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -35,8 +35,14 @@ int siwg91x_get_nwp_config(int wifi_oper_mode, sl_wifi_device_configuration_t *g
 		.boot_config = {
 			.feature_bit_map = SL_SI91X_FEAT_SECURITY_OPEN | SL_SI91X_FEAT_WPS_DISABLE,
 			.tcp_ip_feature_bit_map = SL_SI91X_TCP_IP_FEAT_EXTENSION_VALID,
-			.custom_feature_bit_map = SL_SI91X_CUSTOM_FEAT_EXTENSION_VALID,
-			.ext_custom_feature_bit_map = SL_SI91X_EXT_FEAT_XTAL_CLK,
+			.custom_feature_bit_map = SL_SI91X_CUSTOM_FEAT_EXTENSION_VALID |
+						  SL_SI91X_CUSTOM_FEAT_RTC_FROM_HOST,
+			.ext_custom_feature_bit_map =
+				SL_SI91X_EXT_FEAT_XTAL_CLK | SL_SI91X_EXT_FEAT_1P8V_SUPPORT |
+				SL_SI91X_EXT_FEAT_DISABLE_XTAL_CORRECTION |
+				SL_SI91X_EXT_FEAT_NWP_QSPI_80MHZ_CLK_ENABLE |
+				SL_SI91X_EXT_FEAT_FRONT_END_SWITCH_PINS_ULP_GPIO_4_5_0 |
+				SL_SI91X_EXT_FEAT_FRONT_END_INTERNAL_SWITCH,
 		}
 	};
 	sl_si91x_boot_configuration_t *boot_config = &default_config.boot_config;
@@ -78,9 +84,7 @@ int siwg91x_get_nwp_config(int wifi_oper_mode, sl_wifi_device_configuration_t *g
 #ifdef CONFIG_WIFI_SILABS_SIWX91X
 		boot_config->ext_tcp_ip_feature_bit_map = SL_SI91X_CONFIG_FEAT_EXTENSION_VALID;
 		boot_config->config_feature_bit_map = SL_SI91X_ENABLE_ENHANCED_MAX_PSP;
-		boot_config->ext_custom_feature_bit_map |=
-			SL_SI91X_EXT_FEAT_IEEE_80211W |
-			SL_SI91X_EXT_FEAT_FRONT_END_SWITCH_PINS_ULP_GPIO_4_5_0;
+		boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_IEEE_80211W;
 #endif
 
 #ifdef CONFIG_BT_SILABS_SIWX91X
@@ -111,7 +115,8 @@ int siwg91x_get_nwp_config(int wifi_oper_mode, sl_wifi_device_configuration_t *g
 		}
 
 		if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_LIMIT_PACKET_BUF_PER_STA)) {
-			boot_config->custom_feature_bit_map |= SL_SI91X_CUSTOM_FEAT_LIMIT_PACKETS_PER_STA;
+			boot_config->custom_feature_bit_map |=
+				SL_SI91X_CUSTOM_FEAT_LIMIT_PACKETS_PER_STA;
 		}
 
 	} else {
@@ -119,6 +124,10 @@ int siwg91x_get_nwp_config(int wifi_oper_mode, sl_wifi_device_configuration_t *g
 	}
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X
+	if (!IS_ENABLED(CONFIG_PM)) {
+		boot_config->custom_feature_bit_map |= SL_SI91X_CUSTOM_FEAT_SOC_CLK_CONFIG_160MHZ;
+	}
+
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_OFFLOAD)) {
 		boot_config->tcp_ip_feature_bit_map |= SL_SI91X_TCP_IP_FEAT_ICMP;
 		boot_config->ext_tcp_ip_feature_bit_map |= SL_SI91X_EXT_TCP_IP_WINDOW_SCALING;

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -109,6 +109,11 @@ int siwg91x_get_nwp_config(int wifi_oper_mode, sl_wifi_device_configuration_t *g
 		if (IS_ENABLED(CONFIG_BT_SILABS_SIWX91X)) {
 			LOG_WRN("Bluetooth is not supported in AP mode");
 		}
+
+		if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_LIMIT_PACKET_BUF_PER_STA)) {
+			boot_config->custom_feature_bit_map |= SL_SI91X_CUSTOM_FEAT_LIMIT_PACKETS_PER_STA;
+		}
+
 	} else {
 		return -EINVAL;
 	}


### PR DESCRIPTION
- Added certain features to boot_config
- Added WIFI_SILABS_SIWX91X_LIMIT_PACKET_BUF_PER_STA to Kconfig
- Enabled roaming by default