### PR TITLE
MAINTAINERS.yml: Add etienne-lms as STM32 collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4185,6 +4185,7 @@ STM32 Platforms:
     - marwaiehm-st
     - mathieuchopstm
     - djiatsaf-st
+    - etienne-lms
   files:
     - boards/st/
     - drivers/*/*stm32*.c


### PR DESCRIPTION
We need @etienne-lms reviews to count.

Current reviews:
https://github.com/zephyrproject-rtos/zephyr/issues?q=state%3Aclosed%20%20reviewed-by%3Aetienne-lms