### PR TITLE
[v4.0-branch] doc: ci: update the workflow to build on Python 3.12

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -22,6 +22,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
     - name: Install Python dependencies
       run: |
         sudo pip3 install -U setuptools wheel pip

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -70,6 +70,11 @@ jobs:
       cancel-in-progress: true
 
     steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
     - name: install-pkgs
       run: |
         sudo apt-get update
@@ -201,6 +206,11 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
 
     - name: install-pkgs
       run: |


### PR DESCRIPTION
The HTML doc build workflow recently started failing to install python packages, breaking all backports. Seems to work when using Python 3.12, this is already done in main in bacb99da6d4.

Fixes #89618