### PR TITLE
kernel: events: introduce safe variants of k_event_wait()

### DIFF
--- a/doc/kernel/services/synchronization/events.rst
+++ b/doc/kernel/services/synchronization/events.rst
@@ -108,8 +108,8 @@ the event object.
         ...
     }
 
-Waiting for Events
-==================
+Waiting for Events (without removal)
+====================================
 
 Threads wait for events by calling :c:func:`k_event_wait`.
 
@@ -143,6 +143,58 @@ before continuing.
         uint32_t  events;
 
         events = k_event_wait_all(&my_event, 0x121, false, K_MSEC(50));
+        if (events == 0) {
+            printk("At least one input device is not available!");
+        } else {
+            /* Access the desired input devices */
+            ...
+        }
+        ...
+    }
+
+Waiting for Events (with removal)
+=================================
+
+Threads wait for events (with atomic removal upon receipt) by calling
+:c:func:`k_event_wait_safe`.
+
+The following code builds on the example above, and waits up to 50 milliseconds
+for any of the specified events to be posted.  A warning is issued if none
+of the events are posted in time.
+
+If events are received on time, then they will not be present in the event
+object until the next time that the events are set or posted.
+
+.. code-block:: c
+
+    void consumer_thread(void)
+    {
+        uint32_t  events;
+
+        events = k_event_wait_safe(&my_event, 0xFFF, K_MSEC(50));
+        if (events == 0) {
+            printk("No input devices are available!");
+        } else {
+            /* Access the desired input device(s) */
+            ...
+        }
+        ...
+    }
+
+Alternatively, the consumer thread may desire to wait for all the events
+(with atomic removal upon receipt) before continuing using
+:c:func:`k_event_wait_all_safe`.
+
+If all events are received on time, then they will not be present in the event
+object until the next time that the events are set or posted.
+
+.. code-block:: c
+
+    void consumer_thread(void)
+    {
+        uint32_t  events;
+
+        events = k_event_wait_all_safe(&my_event, 0x121, K_MSEC(50));
         if (events == 0) {
             printk("At least one input device is not available!");
         } else {

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2508,6 +2508,45 @@ __syscall uint32_t k_event_wait_all(struct k_event *event, uint32_t events,
 				    bool reset, k_timeout_t timeout);
 
 /**
+ * @brief Wait for any of the specified events (safe version)
+ *
+ * This call is nearly identical to @ref k_event_wait with the main difference
+ * being that the safe version atomically clears received events from the
+ * event object. This mitigates the need for calling @ref k_event_clear, or
+ * passing a "reset" argument, since doing so may result in lost event
+ * information.
+ *
+ * @param event Address of the event object
+ * @param events Set of desired events on which to wait
+ * @param timeout Waiting period for the desired set of events or one of the
+ *                special values K_NO_WAIT and K_FOREVER.
+ *
+ * @retval set of matching events upon success
+ * @retval 0 if no matching event was received within the specified time
+ */
+__syscall uint32_t k_event_wait_safe(struct k_event *event, uint32_t events, k_timeout_t timeout);
+
+/**
+ * @brief Wait for all of the specified events (safe version)
+ *
+ * This call is nearly identical to @ref k_event_wait_all with the main
+ * difference being that the safe version atomically clears received events
+ * from the event object. This mitigates the need for calling
+ * @ref k_event_clear, or passing a "reset" argument, since doing so may
+ * result in lost event information.
+ *
+ * @param event Address of the event object
+ * @param events Set of desired events on which to wait
+ * @param timeout Waiting period for the desired set of events or one of the
+ *                special values K_NO_WAIT and K_FOREVER.
+ *
+ * @retval set of matching events upon success
+ * @retval 0 if all matching events were not received within the specified time
+ */
+__syscall uint32_t k_event_wait_all_safe(struct k_event *event, uint32_t events,
+					 k_timeout_t timeout);
+
+/**
  * @brief Test the events currently tracked in the event object
  *
  * @funcprops \isr_ok

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -359,6 +359,36 @@ uint32_t z_vrfy_k_event_wait_all(struct k_event *event, uint32_t events,
 #include <zephyr/syscalls/k_event_wait_all_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
+uint32_t z_impl_k_event_wait_safe(struct k_event *event, uint32_t events, k_timeout_t timeout)
+{
+	return k_event_wait_internal(event, events, K_EVENT_WAIT_REMOVE, timeout);
+}
+
+#ifdef CONFIG_USERSPACE
+uint32_t z_vrfy_k_event_wait_safe(struct k_event *event, uint32_t events,
+				  k_timeout_t timeout)
+{
+	K_OOPS(K_SYSCALL_OBJ(event, K_OBJ_EVENT));
+	return z_impl_k_event_wait_safe(event, events, timeout);
+}
+#include <zephyr/syscalls/k_event_wait_safe_mrsh.c>
+#endif /* CONFIG_USERSPACE */
+
+uint32_t z_impl_k_event_wait_all_safe(struct k_event *event, uint32_t events, k_timeout_t timeout)
+{
+	return k_event_wait_internal(event, events, K_EVENT_WAIT_ALL | K_EVENT_WAIT_REMOVE,
+				     timeout);
+}
+
+#ifdef CONFIG_USERSPACE
+uint32_t z_vrfy_k_event_wait_all_safe(struct k_event *event, uint32_t events, k_timeout_t timeout)
+{
+	K_OOPS(K_SYSCALL_OBJ(event, K_OBJ_EVENT));
+	return z_impl_k_event_wait_all_safe(event, events, timeout);
+}
+#include <zephyr/syscalls/k_event_wait_all_safe_mrsh.c>
+#endif /* CONFIG_USERSPACE */
+
 #ifdef CONFIG_OBJ_CORE_EVENT
 static int init_event_obj_core_list(void)
 {

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -36,9 +36,10 @@
 
 #define K_EVENT_WAIT_ANY      0x00   /* Wait for any events */
 #define K_EVENT_WAIT_ALL      0x01   /* Wait for all events */
-#define K_EVENT_WAIT_MASK     0x01
-
 #define K_EVENT_WAIT_RESET    0x02   /* Reset events prior to waiting */
+#define K_EVENT_WAIT_REMOVE   0x04   /* Remove matched events from the event object */
+
+#define K_EVENT_WAIT_MASK K_EVENT_WAIT_ALL
 
 struct event_walk_data {
 	struct k_thread  *head;
@@ -77,7 +78,7 @@ void z_vrfy_k_event_init(struct k_event *event)
 #endif /* CONFIG_USERSPACE */
 
 /**
- * @brief determine if desired set of events been satisfied
+ * @brief determine the set of events that have been been satisfied
  *
  * This routine determines if the current set of events satisfies the desired
  * set of events. If @a wait_condition is K_EVENT_WAIT_ALL, then at least
@@ -85,30 +86,39 @@ void z_vrfy_k_event_init(struct k_event *event)
  * wait_condition is not K_EVENT_WAIT_ALL, it is assumed to be K_EVENT_WAIT_ANY.
  * In the K_EVENT_WAIT_ANY case, the request is satisfied when any of the
  * current set of events are present in the desired set of events.
+ *
+ * @return 0 if the wait condition is not satisfied, otherwise the set of
+ * events that satisfy the wait condition.
  */
-static bool are_wait_conditions_met(uint32_t desired, uint32_t current,
-				    unsigned int wait_condition)
+static uint32_t are_wait_conditions_met(uint32_t desired, uint32_t current,
+					unsigned int wait_condition)
 {
-	uint32_t  match = current & desired;
+	uint32_t match = current & desired;
 
-	if (wait_condition == K_EVENT_WAIT_ALL) {
-		return match == desired;
+	if ((wait_condition == K_EVENT_WAIT_ALL) && (match != desired)) {
+		return 0;
 	}
 
 	/* wait_condition assumed to be K_EVENT_WAIT_ANY */
 
-	return match != 0;
+	return match;
 }
 
 static int event_walk_op(struct k_thread *thread, void *data)
 {
+	uint32_t match;
 	unsigned int      wait_condition;
 	struct event_walk_data *event_data = data;
 
 	wait_condition = thread->event_options & K_EVENT_WAIT_MASK;
 
-	if (are_wait_conditions_met(thread->events, event_data->events,
-				    wait_condition)) {
+	match = are_wait_conditions_met(thread->events, event_data->events, wait_condition);
+	if (match != 0) {
+
+		/*
+		 * Overwrite the threads mask of events with the exact match.
+		 */
+		thread->events = match;
 
 		/*
 		 * Events create a list of threads to wake up. We do
@@ -166,7 +176,6 @@ static uint32_t k_event_post_internal(struct k_event *event, uint32_t events,
 		struct k_thread *next;
 		do {
 			arch_thread_return_value_set(thread, 0);
-			thread->events = events;
 			next = thread->next_event_link;
 			z_sched_wake_thread(thread, false);
 			thread = next;
@@ -268,16 +277,17 @@ static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 
 	/* Test if the wait conditions have already been met. */
 
-	if (are_wait_conditions_met(events, event->events, wait_condition)) {
-		rv = event->events;
-
-		k_spin_unlock(&event->lock, key);
-		goto out;
+	rv = are_wait_conditions_met(events, event->events, wait_condition);
+	if ((rv != 0) && ((options & K_EVENT_WAIT_REMOVE) != 0)) {
+		/* Remove events that have been received */
+		event->events &= ~rv;
 	}
 
-	/* Match conditions have not been met. */
-
-	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
+	if (K_TIMEOUT_EQ(timeout, K_NO_WAIT) || (rv != 0)) {
+		/*
+		 * Match conditions have either already been met, or the caller specified
+		 * K_NO_WAIT, and match conditions have not been met.
+		 */
 		k_spin_unlock(&event->lock, key);
 		goto out;
 	}
@@ -294,15 +304,17 @@ static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 					   options, timeout);
 
 	if (z_pend_curr(&event->lock, key, &event->wait_q, timeout) == 0) {
-		/* Retrieve the set of events that woke the thread */
 		rv = thread->events;
+		if (options & K_EVENT_WAIT_REMOVE) {
+			/* Remove events that have been received */
+			event->events &= ~rv;
+		}
 	}
 
 out:
-	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_event, wait, event,
-				       events, rv & events);
+	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_event, wait, event, events, rv);
 
-	return rv & events;
+	return rv;
 }
 
 /**

--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -434,6 +434,45 @@ ZTEST(events_api, test_event_receive)
 
 	test_wake_multiple_threads();
 }
+
+ZTEST(events_api, test_k_event_wait_safe)
+{
+	uint32_t events;
+
+	k_event_set(&test_event, 0x73);
+
+	events = k_event_wait_safe(&test_event, 0x11, K_NO_WAIT);
+	zexpect_equal(events, 0x11, "expected 0x11, got %x", events);
+
+	events = k_event_wait_safe(&test_event, 0x11, K_NO_WAIT);
+	zexpect_equal(events, 0x0, "phantom events %x not removed from event object", events);
+
+	events = k_event_wait_safe(&test_event, 0x62, K_NO_WAIT);
+	zexpect_equal(events, 0x62, "expected 0x62, got %x", events);
+
+	events = k_event_wait_safe(&test_event, -1, K_NO_WAIT);
+	zexpect_equal(events, 0x0, "phantom events %x not removed from event object", events);
+}
+
+ZTEST(events_api, test_k_event_wait_all_safe)
+{
+	uint32_t events;
+
+	k_event_set(&test_event, 0x73);
+
+	events = k_event_wait_all_safe(&test_event, 0x81, K_NO_WAIT);
+	zexpect_equal(events, 0x0, "expected 0x0, got %x", events);
+
+	events = k_event_wait_all_safe(&test_event, 0x11, K_NO_WAIT);
+	zexpect_equal(events, 0x11, "expected 0x11, got %x", events);
+
+	events = k_event_wait_all_safe(&test_event, 0x63, K_NO_WAIT);
+	zexpect_equal(events, 0x0, "expected 0x0, got %x", events);
+
+	events = k_event_wait_all_safe(&test_event, 0x62, K_NO_WAIT);
+	zexpect_equal(events, 0x62, "expected 0x62, got %x", events);
+}
+
 /**
  * @}
  */


### PR DESCRIPTION
This change introduces two companion syscalls that allow us to wait for events in a safe way; `k_event_wait_safe()` and `k_event_wait_all_safe()`. These syscalls will remove any (`k_event_wait_safe()`) or all (`k_event_wait_all_safe()`) of the specified events from the event object upon success. 

With that, callers will not receive phantom events. Each time an event is ready, callers can be certain that it was an actual event.

Similarly, there is no explicit need to reset or clear events manually, since the received events are automatically cleared by `k_event_wait_safe()` and `k_event_wait_all_safe()`.

> [!NOTE]  
> Losing event information is equally probably for level-triggered and edge-triggered events. Hence the choice of the `_safe` suffix.

Fixes #89625

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/89624/docs/kernel/services/synchronization/events.html)

Testing Done:
```shell
west build -p auto -b qemu_riscv64 -t run tests/kernel/events/event_api
...
*** Booting Zephyr OS build v4.1.0-3746-g43bdaf9ef17b ***
Running TESTSUITE events_api
===================================================================
START - test_event_deliver
 PASS - test_event_deliver in 0.001 seconds
===================================================================
START - test_event_receive
 PASS - test_event_receive in 0.447 seconds
===================================================================
START - test_k_event_init
 PASS - test_k_event_init in 0.001 seconds
===================================================================
START - test_k_event_wait_all_safe
 PASS - test_k_event_wait_all_safe in 0.001 seconds
===================================================================
START - test_k_event_wait_safe
 PASS - test_k_event_wait_safe in 0.001 seconds
===================================================================
TESTSUITE events_api succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [events_api]: pass = 5, fail = 0, skip = 0, total = 5 duration = 0.451 seconds
 - PASS - [events_api.test_event_deliver] duration = 0.001 seconds
 - PASS - [events_api.test_event_receive] duration = 0.447 seconds
 - PASS - [events_api.test_k_event_init] duration = 0.001 seconds
 - PASS - [events_api.test_k_event_wait_all_safe] duration = 0.001 seconds
 - PASS - [events_api.test_k_event_wait_safe] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```