### PR TITLE
soc: nxp: rw: Policy constraints when PM2 enabled

### DIFF
--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -67,7 +67,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 # as we use the TURN_OFF and TURN_ON actions to recover
 # from Standby mode (PM Mode 3)
 config PM_DEVICE
-	default y if "$(dt_nodelabel_enabled,standby)"
+	default y if "$(dt_nodelabel_enabled,standby)" || "$(dt_nodelabel_enabled,suspend)"
 
 # Enable PM_POLICY_DEVICE_CONSTRAINTS by default when doing PM_DEVICE.
 # This will allow support of device power states.


### PR DESCRIPTION
When PM2 is enabled, it will disable many of the devices, so need to enable PM policy constraints for this mode also so that device drivers can work.