### PR TITLE
video: dcmi: add endpoint usage in dcmi & update dma property in dtsi

### DIFF
--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -240,10 +240,6 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-names = "default";
 	status = "okay";
 
-	dmas = <&dma1 0 38 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
-		STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
-		STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
-
 	port {
 		dcmi_ep_in: endpoint {
 			remote-endpoint-label = "gc2145_ep_out";

--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -225,7 +225,7 @@ zephyr_udc0: &usbotg_hs {
 
 		port {
 			gc2145_ep_out: endpoint {
-				remote-endpoint = <&dcmi_ep_in>;
+				remote-endpoint-label = "dcmi_ep_in";
 			};
 		};
 
@@ -240,19 +240,17 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-names = "default";
 	status = "okay";
 
-	sensor = <&gc2145>;
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <0>;
-	capture-rate = <1>;
 	dmas = <&dma1 0 38 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 		STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
 		STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 
 	port {
 		dcmi_ep_in: endpoint {
-			remote-endpoint = <&gc2145_ep_out>;
+			remote-endpoint-label = "gc2145_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <0>;
 		};
 	};
 };

--- a/boards/shields/st_b_cams_omv_mb1683/boards/stm32h7b3i_dk.overlay
+++ b/boards/shields/st_b_cams_omv_mb1683/boards/stm32h7b3i_dk.overlay
@@ -17,10 +17,6 @@
 		&dcmi_d0_pc6 &dcmi_d1_pc7 &dcmi_d2_pg10 &dcmi_d3_pc9
 		&dcmi_d4_pc11 &dcmi_d5_pd3 &dcmi_d6_pb8 &dcmi_d7_pb9>;
 	pinctrl-names = "default";
-
-	dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
-		STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
-		STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 };
 
 &dma1 {

--- a/boards/shields/st_b_cams_omv_mb1683/st_b_cams_omv_mb1683.overlay
+++ b/boards/shields/st_b_cams_omv_mb1683/st_b_cams_omv_mb1683.overlay
@@ -33,17 +33,14 @@
 
 &st_cam_dvp {
 	status = "okay";
-	sensor = <&ov5640>;
-
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <1>;
-	capture-rate = <1>;
 
 	port {
 		dcmi_ep_in: endpoint {
 			remote-endpoint-label = "ov5640_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <1>;
 		};
 	};
 };

--- a/boards/shields/weact_ov2640_cam_module/boards/mini_stm32h743.overlay
+++ b/boards/shields/weact_ov2640_cam_module/boards/mini_stm32h743.overlay
@@ -44,12 +44,6 @@
 	};
 };
 
-&zephyr_camera_dvp {
-	dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
-		STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
-		STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
-};
-
 &dma1 {
 	status = "okay";
 };

--- a/boards/shields/weact_ov2640_cam_module/weact_ov2640_cam_module.overlay
+++ b/boards/shields/weact_ov2640_cam_module/weact_ov2640_cam_module.overlay
@@ -21,7 +21,7 @@
 
 		port {
 			ov2640_ep_out: endpoint {
-				remote-endpoint = <&zephyr_camera_dvp_in>;
+				remote-endpoint-label = "zephyr_camera_dvp_in";
 			};
 		};
 	};
@@ -29,16 +29,14 @@
 
 &zephyr_camera_dvp {
 	status = "okay";
-	sensor = <&ov2640>;
-	bus-width = <8>;
-	hsync-active = <0>;
-	vsync-active = <0>;
-	pixelclk-active = <1>;
-	capture-rate = <1>;
 
 	port {
 		zephyr_camera_dvp_in: endpoint {
-			remote-endpoint = <&ov2640_ep_out>;
+			remote-endpoint-label = "ov2640_ep_out";
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <1>;
 		};
 	};
 };

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -501,6 +501,13 @@ Video
   ``VIDEO_PIX_FMT_GRBG8`` becomes ``VIDEO_PIX_FMT_SGRBG8``
   ``VIDEO_PIX_FMT_RGGB8`` becomes ``VIDEO_PIX_FMT_SRGGB8``
 
+* On STM32 devices, the DCMI driver (:dtcompatible:`st,stm32-dcmi`) now relies on endpoint based
+  video-interfaces.yaml bindings for sensor interface properties (such as bus width and
+  synchronization signals).
+  Also the ``capture-rate`` property has been replaced by the usage of the frame interval API
+  :c:func:`video_set_frmival`.
+  See (:github:`89627`).
+
 Other subsystems
 ****************
 

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -417,16 +417,22 @@ static struct video_stm32_dcmi_data video_stm32_dcmi_data_0 = {
 		.Instance = (DCMI_TypeDef *) DT_INST_REG_ADDR(0),
 		.Init = {
 				.SynchroMode = DCMI_SYNCHRO_HARDWARE,
-				.PCKPolarity = (DT_INST_PROP(0, pixelclk_active) ?
-						DCMI_PCKPOLARITY_RISING : DCMI_PCKPOLARITY_FALLING),
-				.HSPolarity = (DT_INST_PROP(0, hsync_active) ?
-						DCMI_HSPOLARITY_HIGH : DCMI_HSPOLARITY_LOW),
-				.VSPolarity = (DT_INST_PROP(0, vsync_active) ?
-						DCMI_VSPOLARITY_HIGH : DCMI_VSPOLARITY_LOW),
+				.PCKPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+							  pclk_sample, 0) ?
+							  DCMI_PCKPOLARITY_RISING :
+							  DCMI_PCKPOLARITY_FALLING,
+				.HSPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+							 hsync_active, 0) ?
+							 DCMI_HSPOLARITY_HIGH : DCMI_HSPOLARITY_LOW,
+				.VSPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+							 vsync_active, 0) ?
+							 DCMI_VSPOLARITY_HIGH : DCMI_VSPOLARITY_LOW,
 				.CaptureRate = STM32_DCMI_GET_CAPTURE_RATE(
-							DT_INST_PROP(0, capture_rate)),
+							DT_PROP_OR(DT_DRV_INST(inst), capture_rate,
+								   1)),
 				.ExtendedDataMode = STM32_DCMI_GET_BUS_WIDTH(
-							DT_INST_PROP(0, bus_width)),
+							DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+								   bus_width, 8)),
 				.JPEGMode = DCMI_JPEG_DISABLE,
 				.ByteSelectMode = DCMI_BSM_ALL,
 				.ByteSelectStart = DCMI_OEBS_ODD,
@@ -436,7 +442,7 @@ static struct video_stm32_dcmi_data video_stm32_dcmi_data_0 = {
 	},
 };
 
-#define SOURCE_DEV(n) DEVICE_DT_GET(DT_INST_PHANDLE(n, sensor))
+#define SOURCE_DEV(n) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(n, 0, 0)))
 
 static const struct video_stm32_dcmi_config video_stm32_dcmi_config_0 = {
 	.pclken = {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -1086,6 +1086,9 @@
 			interrupts = <78 0>;
 			interrupt-names = "dcmi";
 			clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+			dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
+				STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
+				STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -11,23 +11,21 @@ description: |
 
     &dcmi {
       status = "okay";
-      sensor = <&ov2640>;
       pinctrl-0 = <&dcmi_hsync_pa4 &dcmi_pixclk_pa6 &dcmi_vsync_pb7
                   &dcmi_d0_pc6 &dcmi_d1_pc7 &dcmi_d2_pe0 &dcmi_d3_pe1
                   &dcmi_d4_pe4 &dcmi_d5_pd3 &dcmi_d6_pe5 &dcmi_d7_pe6>;
       pinctrl-names = "default";
-      bus-width = <8>;
-      hsync-active = <0>;
-      vsync-active = <0>;
-      pixelclk-active = <1>;
-      capture-rate = <1>;
       dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
               STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
               STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 
       port {
         dcmi_ep_in: endpoint {
-          remote-endpoint = <&ov2640_ep_out>;
+          remote-endpoint-label = "ov2640_ep_out";
+          bus-width = <8>;
+          hsync-active = <0>;
+          vsync-active = <0>;
+          pclk-sample = <1>;
         };
       };
     };
@@ -39,64 +37,6 @@ include: [base.yaml, pinctrl-device.yaml]
 properties:
   interrupts:
     required: true
-
-  sensor:
-    required: true
-    type: phandle
-    description: phandle of connected sensor device
-
-  bus-width:
-    type: int
-    required: true
-    enum:
-      - 8
-      - 10
-      - 12
-      - 14
-    default: 8
-    description: |
-      Number of data lines actively used, valid for the parallel busses.
-
-  hsync-active:
-    type: int
-    required: true
-    enum:
-      - 0
-      - 1
-    description: |
-      Polarity of horizontal synchronization (DCMI_HSYNC_Polarity).
-      0 Horizontal synchronization active Low.
-      1 Horizontal synchronization active High.
-
-      For example, if DCMI_HSYNC_Polarity is programmed active high:
-      When HSYNC is low, the data is valid.
-      When HSYNC is high, the data is not valid (horizontal blanking).
-
-  vsync-active:
-    type: int
-    required: true
-    enum:
-      - 0
-      - 1
-    description: |
-      Polarity of vertical synchronization (DCMI_VSYNC_Polarity).
-      0 Vertical synchronization active Low.
-      1 Vertical synchronization active High.
-
-      For example, if DCMI_VSYNC_Polarity is programmed active high:
-      When VSYNC is low, the data is valid.
-      When VSYNC is high, the data is not valid (vertical blanking).
-
-  pixelclk-active:
-    type: int
-    required: true
-    enum:
-      - 0
-      - 1
-    description: |
-      Polarity of pixel clock (DCMI_PIXCK_Polarity).
-      0 Pixel clock active on Falling edge.
-      1 Pixel clock active on Rising edge.
 
   capture-rate:
     type: int
@@ -122,3 +62,7 @@ properties:
       dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
               STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
               STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
+
+child-binding:
+  child-binding:
+    include: video-interfaces.yaml

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -35,20 +35,6 @@ properties:
   interrupts:
     required: true
 
-  capture-rate:
-    type: int
-    enum:
-      - 1
-      - 2
-      - 4
-    default: 1
-    description: |
-      The DCMI can capture all frames or alternate frames. If it is not specified,
-      the default is all frames.
-      1 Capture all frames.
-      2 Capture alternate frames.
-      4 Capture one frame every 4 frames.
-
   dmas:
     required: true
     description: |

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -15,9 +15,6 @@ description: |
                   &dcmi_d0_pc6 &dcmi_d1_pc7 &dcmi_d2_pe0 &dcmi_d3_pe1
                   &dcmi_d4_pe4 &dcmi_d5_pd3 &dcmi_d6_pe5 &dcmi_d7_pe6>;
       pinctrl-names = "default";
-      dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
-              STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
-              STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 
       port {
         dcmi_ep_in: endpoint {

--- a/tests/drivers/build_all/video/testcase.yaml
+++ b/tests/drivers/build_all/video/testcase.yaml
@@ -22,3 +22,9 @@ tests:
   drivers.video.mcux_smartdma.build:
     platform_allow:
       - frdm_mcxn947/mcxn947/cpu0
+  drivers.video.stm32_dcmi.build:
+    platform_allow:
+      - stm32h7b3i_dk/stm32h7b3xx
+      - arduino_nicla_vision/stm32h747xx/m7
+    extra_args:
+      - platform:stm32h7b3i_dk/stm32h7b3xx:SHIELD=st_b_cams_omv_mb1683


### PR DESCRIPTION
This PR update the DCMI driver / bindings and all users of this driver in order to rely on the video-interfaces bindings rather that having its own properties.
In a second step, considering that the DMA settings are closely linked to the IP itself and the way it is connected internally, I propose to move the dma property from within the board dts into the dtsi so that each board / shield overlay do not have to copy again the same property. As a matter of fact the dcmi driver is also setting most of the DMA settings from within the driver itself.