### PR TITLE
drivers: interrupt_controller: intc_clic: Add support for irq preemption

### DIFF
--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -55,6 +55,7 @@ config CLIC_PARAMETER_INTCTLBITS
 config CLIC_PARAMETER_MNLBITS
 	int "The number of bits in CLICINTCTLBITS to encode the interrupt level"
 	range 0 CLIC_PARAMETER_INTCTLBITS
+	default CLIC_PARAMETER_INTCTLBITS if CLIC_SUPPORT_INTERRUPT_PREEMPTION
 	default 0
 	help
 	  This option specifies the number of bits in CLICINTCTLBITS assigned to
@@ -72,5 +73,16 @@ config LEGACY_CLIC
 	help
 	  Enables legacy clic, where smclicshv extension is not supported and
 	  hardware vectoring is set via mode bits of mtvec.
+
+config CLIC_SUPPORT_INTERRUPT_PREEMPTION
+	bool "Support for nested interrupts in CLIC"
+	default y if NUCLEI_ECLIC
+	depends on CLIC
+	help
+	  Enables support for nested interrupts in the Core Local Interrupt Controller,
+	  allowing higher priority interrupts to preempt the execution of lower priority
+	  interrupt handlers. Note that preemption is on CLIC only supported for level-based
+	  interrupts. If CLIC_SUPPORT_INTERRUPT_PREEMPTION is enabled, zephyr irq priority are treated as CLIC
+	  irq levels.
 
 endif # CLIC

--- a/drivers/interrupt_controller/intc_clic.S
+++ b/drivers/interrupt_controller/intc_clic.S
@@ -71,7 +71,9 @@ irq_loop:
 #ifdef CONFIG_TRACING_ISR
 	call sys_trace_isr_enter
 #endif
-
+#ifdef CONFIG_CLIC_SUPPORT_INTERRUPT_PREEMPTION
+        csrrsi t0, mstatus, MSTATUS_MIE
+#endif
 	/* Call corresponding registered function in _sw_isr_table. a0 is offset in pointer with
 	 * the mtvt, sw irq table is 2-pointer wide -> shift by one. */
 	csrr t0, CSR_MTVT

--- a/drivers/interrupt_controller/intc_clic.c
+++ b/drivers/interrupt_controller/intc_clic.c
@@ -23,6 +23,13 @@
 #error "Unknown CLIC controller compatible for this configuration"
 #endif
 
+/* Make sure that all priorities are treated as levels for irq preemption support */
+#ifdef CONFIG_CLIC_SUPPORT_INTERRUPT_PREEMPTION
+BUILD_ASSERT(CONFIG_CLIC_PARAMETER_INTCTLBITS == CONFIG_CLIC_PARAMETER_MNLBITS,
+	     "CONFIG_CLIC_PARAMETER_INTCTLBITS must be equal to CONFIG_CLIC_PARAMETER_MNLBITS for "
+	     "irq preemption support");
+#endif
+
 struct clic_data {
 	uint8_t nlbits;
 	uint8_t intctlbits;

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -11,8 +11,8 @@
 /*
  * Run the nested interrupt test for the supported platforms only.
  */
-#if defined(CONFIG_CPU_CORTEX_M) || defined(CONFIG_ARC) || \
-	defined(CONFIG_GIC) || defined(CONFIG_NRFX_CLIC)
+#if defined(CONFIG_CPU_CORTEX_M) || defined(CONFIG_ARC) || defined(CONFIG_GIC) ||                  \
+	defined(CONFIG_NRFX_CLIC) || defined(CONFIG_SOC_GD32VF103)
 #define TEST_NESTED_ISR
 #endif
 
@@ -20,6 +20,12 @@
 
 #define ISR0_TOKEN	0xDEADBEEF
 #define ISR1_TOKEN	0xCAFEBABE
+
+#if defined(CONFIG_RISCV_HAS_CLIC)
+#define IRQ_FLAGS 1 /* rising edge */
+#else
+#define IRQ_FLAGS 0
+#endif
 
 /*
  * This test uses two IRQ lines selected within the range of available IRQs on
@@ -65,6 +71,12 @@
 #elif defined(CONFIG_SOC_NRF54H20_CPUPPR)
 #define IRQ0_LINE	14
 #define IRQ1_LINE	15
+
+#define IRQ0_PRIO	1
+#define IRQ1_PRIO	2
+#elif defined(CONFIG_SOC_GD32VF103)
+#define IRQ0_LINE	17
+#define IRQ1_LINE	18
 
 #define IRQ0_PRIO	1
 #define IRQ1_PRIO	2
@@ -150,8 +162,8 @@ ZTEST(interrupt_feature, test_nested_isr)
 #endif
 
 	/* Connect and enable test IRQs */
-	arch_irq_connect_dynamic(irq_line_0, IRQ0_PRIO, isr0, NULL, 0);
-	arch_irq_connect_dynamic(irq_line_1, IRQ1_PRIO, isr1, NULL, 0);
+	arch_irq_connect_dynamic(irq_line_0, IRQ0_PRIO, isr0, NULL, IRQ_FLAGS);
+	arch_irq_connect_dynamic(irq_line_1, IRQ1_PRIO, isr1, NULL, IRQ_FLAGS);
 
 	irq_enable(irq_line_0);
 	irq_enable(irq_line_1);


### PR DESCRIPTION
Introduce support for nested interrupts (preemption) in the Core Local Interrupt Controller (CLIC) for RISC-V.

CLIC irq priorities do not support preemption, that is why the zephyr priorities are treated as CLIC level when `CLIC_SUPPORT_INTERRUPT_PREEMPTION` is enabled.

Tested on `longan_nano` -> only enabled for `NUCLEI_ECLIC`, but should work on newer CLIC versions as well.