### PR TITLE
drivers: flash_stm32_qspi: fix qspi_read_jedec_id()

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -317,11 +317,12 @@ static int qspi_read_jedec_id(const struct device *dev, uint8_t *id)
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
 	uint8_t data[JESD216_READ_ID_LEN];
+	uint32_t dummy_cycles = DT_INST_PROP(0, st_read_id_dummy_cycles);
 
 	QSPI_CommandTypeDef cmd = {
 		.Instruction = JESD216_CMD_READ_ID,
 		.AddressSize = QSPI_ADDRESS_NONE,
-		.DummyCycles = 8,
+		.DummyCycles = dummy_cycles,
 		.InstructionMode = QSPI_INSTRUCTION_1_LINE,
 		.AddressMode = QSPI_ADDRESS_1_LINE,
 		.DataMode = QSPI_DATA_1_LINE,
@@ -333,7 +334,7 @@ static int qspi_read_jedec_id(const struct device *dev, uint8_t *id)
 	hal_ret = HAL_QSPI_Command_IT(&dev_data->hqspi, &cmd);
 
 	if (hal_ret != HAL_OK) {
-		LOG_ERR("%d: Failed to send OSPI instruction", hal_ret);
+		LOG_ERR("%d: Failed to send QSPI instruction", hal_ret);
 		return -EIO;
 	}
 

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -71,3 +71,8 @@ properties:
       protection register that initializes to write-protected.  Use this
       property to indicate that the BPR must be unlocked before write
       operations can proceed.
+
+  st,read-id-dummy-cycles:
+    type: int
+    default: 8
+    description: The number of dummy-cycles required when reading jedec id


### PR DESCRIPTION
The Arduino Opta has an at25sf128a with JEDEC ID 1F 89 01.
[This PR](https://github.com/zephyrproject-rtos/zephyr/pull/89539) adds support for this, but the id read is 01 1F 89. 
Changing DummyCycles to 16 causes the correct value to be read.
Unfortunately I do not have other devices to test this against.

From my understanding, no dummy bytes should be required:
![image](https://github.com/user-attachments/assets/c68e2d2b-e5c0-46e5-9eec-007ad1602d2d)

Adding @pillo79 