### PR TITLE
tests: net: coap_server: Adjust test filters

### DIFF
--- a/tests/net/lib/coap_server/common/testcase.yaml
+++ b/tests/net/lib/coap_server/common/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  min_ram: 16
+  min_ram: 40
+  min_flash: 180
+  depends_on: netif
   tags:
     - net
     - coap


### PR DESCRIPTION
Add netif dependency for the test suite, as in other networking tests and adjust minimal RAM and FLASH values.

Fixes #89644