### PR TITLE
boards: st: b_u585i_iot02a:  stm32 u585_iot board ns variant RAM region increased Fixes #84294

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.dts
@@ -14,9 +14,14 @@
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
-		zephyr,sram = &sram0;
+		zephyr,sram = &nsram;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
+	};
+
+	/* Zephyr RAM is set to SRAM3 region */
+	nsram: memory@20040000 {
+		reg = <0x20040000 DT_SIZE_K(512)>;
 	};
 
 	aliases {


### PR DESCRIPTION
The previous zephyr,sram definition used SRAM1 Region where only 127 kB are available in the TF-M Build. With this change the Zephyr RAM is moved to SRAM3 Region where 512 kB can be used.