### PR TITLE
boards: beagle: beagleplay_cc1352p7: Enable watchdog timer

### DIFF
--- a/boards/beagle/beagleplay/beagleplay_cc1352p7.dts
+++ b/boards/beagle/beagleplay/beagleplay_cc1352p7.dts
@@ -16,6 +16,7 @@
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {
@@ -91,5 +92,9 @@
 };
 
 &ieee802154g {
+	status = "okay";
+};
+
+&wdt0 {
 	status = "okay";
 };


### PR DESCRIPTION
Enable watchdog timer in the base tree. This is required for MicroPython.