### PR TITLE
Bluetooth: Host: Remove unnecessary ifdef from cs.c

### DIFF
--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -29,7 +29,6 @@
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_cs);
 
-#if defined(CONFIG_BT_CHANNEL_SOUNDING)
 #if defined(CONFIG_BT_CHANNEL_SOUNDING_TEST)
 static struct bt_le_cs_test_cb cs_test_callbacks;
 #endif
@@ -1479,5 +1478,3 @@ int bt_le_cs_get_antenna_path(uint8_t n_ap,
 		return -EINVAL;
 	}
 }
-
-#endif /* CONFIG_BT_CHANNEL_SOUNDING */


### PR DESCRIPTION
The building of cs.c based on the respective Kconfig option is already taken care of CMakeLists.txt, so it's redundant to try to protect the code through ifdefs in the c-file as well.