### PR TITLE
boards: sipeed: longan_nano: Add J-Link runner support

### DIFF
--- a/boards/sipeed/longan_nano/board.cmake
+++ b/boards/sipeed/longan_nano/board.cmake
@@ -7,6 +7,8 @@ board_runner_args(openocd "--cmd-pre-load=gd32vf103-pre-load")
 board_runner_args(openocd "--cmd-load=gd32vf103-load")
 board_runner_args(openocd "--cmd-post-verify=gd32vf103-post-verify")
 board_runner_args(dfu-util "--pid=28e9:0189" "--alt=0" "--dfuse")
+board_runner_args(jlink "--device=GD32VF103CBT6" "--speed=4000" "--iface=jtag" "--tool-opt=-jtagconf -1,-1 -autoconnect 1" "--reset-after-load")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Adds the J-Link runner support for the longan_nano board.