### PR TITLE
net: ptp: fix infinite loop in pkt frag

### DIFF
--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -275,6 +275,7 @@ struct ptp_msg *ptp_msg_from_pkt(struct net_pkt *pkt)
 		/* remove packet temporarily. */
 		buf = pkt->buffer;
 		pkt->buffer = buf->frags;
+		buf->frags = NULL;
 
 		hdr = net_udp_get_hdr(pkt, NULL);
 


### PR DESCRIPTION
There was wrong implementation in pkt frag removing and inserting. This was causing infinite loop in either net_buf_frag_last or net_pkt_get_len. This happened only when the pkt frag removing and inserting was executed too fast after sending pkt before ethernet_send calling net_pkt_get_len.