### PR TITLE
soc: nordic: nrf54l: remove workaround for nRF54L anomaly 31

### DIFF
--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -151,13 +151,6 @@ static inline void power_and_clock_configuration(void)
 	}
 
 #if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
-#if NRF54L_ERRATA_31_ENABLE_WORKAROUND
-	/* Workaround for Errata 31 */
-	if (nrf54l_errata_31()) {
-		*((volatile uint32_t *)0x50120624ul) = 20 | 1<<5;
-		*((volatile uint32_t *)0x5012063Cul) &= ~(1<<19);
-	}
-#endif
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
 


### PR DESCRIPTION
MDK 8.69.1 included in nrfx 3.10 already applies the workaround, so there is no need to do it again.

MDK code for reference: https://github.com/zephyrproject-rtos/hal_nordic/blob/6541dc3a175ef8cd0970f7d8f1d954928e6bde8c/nrfx/mdk/system_nrf54l.c#L133-L138