### PR TITLE
native_simulator: Get latest from upstream

### DIFF
--- a/scripts/native_simulator/common/src/include/nsi_tracing.h
+++ b/scripts/native_simulator/common/src/include/nsi_tracing.h
@@ -8,6 +8,7 @@
 #define NSI_COMMON_SRC_INCL_NSI_TRACING_H
 
 #include <stdarg.h>
+#include "nsi_utils.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,10 +22,10 @@ extern "C" {
  * All print()/vprint() APIs take the same arguments as printf()/vprintf().
  */
 
-void nsi_print_error_and_exit(const char *format, ...);
+NSI_FUNC_NORETURN void nsi_print_error_and_exit(const char *format, ...);
 void nsi_print_warning(const char *format, ...);
 void nsi_print_trace(const char *format, ...);
-void nsi_vprint_error_and_exit(const char *format, va_list vargs);
+NSI_FUNC_NORETURN void nsi_vprint_error_and_exit(const char *format, va_list vargs);
 void nsi_vprint_warning(const char *format, va_list vargs);
 void nsi_vprint_trace(const char *format, va_list vargs);
 

--- a/scripts/native_simulator/common/src/include/nsi_utils.h
+++ b/scripts/native_simulator/common/src/include/nsi_utils.h
@@ -31,6 +31,7 @@
 
 #define NSI_FUNC_NORETURN __attribute__((__noreturn__))
 #define NSI_WEAK __attribute__((__weak__))
+#define NSI_INLINE static __attribute__((__always_inline__)) inline
 
 #if defined(__clang__)
   /* The address sanitizer in llvm adds padding (redzones) after data

--- a/scripts/native_simulator/common/src/main.c
+++ b/scripts/native_simulator/common/src/main.c
@@ -121,8 +121,7 @@ int main(int argc, char *argv[])
 		nsi_hws_one_event();
 	}
 
-	/* This line should be unreachable */
-	return 1; /* LCOV_EXCL_LINE */
+	NSI_CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 
 #endif /* NSI_NO_MAIN */

--- a/scripts/native_simulator/common/src/nce.c
+++ b/scripts/native_simulator/common/src/nce.c
@@ -16,19 +16,19 @@
  * a time. Check the docs for more info.
  */
 
-#include <pthread.h>
 #include <stdbool.h>
-#include <unistd.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <errno.h>
+#include "nsi_utils.h"
 #include "nce_if.h"
 #include "nsi_safe_call.h"
 
 struct nce_status_t {
-	/* Conditional variable to know if the CPU is running or halted/idling */
-	pthread_cond_t  cond_cpu;
-	/* Mutex for the conditional variable cond_cpu */
-	pthread_mutex_t mtx_cpu;
-	/* Variable which tells if the CPU is halted (1) or not (0) */
+	sem_t sem_sw; /* Semaphore to hold the CPU/SW thread(s) */
+	sem_t sem_hw; /* Semaphore to hold the HW thread */
 	bool cpu_halted;
 	bool terminate; /* Are we terminating the program == cleaning up */
 	void (*start_routine)(void);
@@ -48,6 +48,16 @@ struct nce_status_t {
 
 extern void nsi_exit(int exit_code);
 
+NSI_INLINE int nce_sem_rewait(sem_t *semaphore)
+{
+	int ret;
+
+	while ((ret = sem_wait(semaphore)) == EINTR) {
+		/* Restart wait if we were interrupted */
+	}
+	return ret;
+}
+
 /*
  * Initialize an instance of the native simulator CPU emulator
  * and return a pointer to it.
@@ -65,8 +75,8 @@ void *nce_init(void)
 	this->cpu_halted = true;
 	this->terminate = false;
 
-	NSI_SAFE_CALL(pthread_cond_init(&this->cond_cpu, NULL));
-	NSI_SAFE_CALL(pthread_mutex_init(&this->mtx_cpu, NULL));
+	NSI_SAFE_CALL(sem_init(&this->sem_sw, 0, 0));
+	NSI_SAFE_CALL(sem_init(&this->sem_hw, 0, 0));
 
 	return (void *)this;
 }
@@ -104,13 +114,9 @@ void nce_terminate(void *this_arg)
 	} else if (this->terminate == false) {
 
 		this->terminate = true;
-
-		NSI_SAFE_CALL(pthread_mutex_lock(&this->mtx_cpu));
-
 		this->cpu_halted = true;
 
-		NSI_SAFE_CALL(pthread_cond_broadcast(&this->cond_cpu));
-		NSI_SAFE_CALL(pthread_mutex_unlock(&this->mtx_cpu));
+		NSI_SAFE_CALL(sem_post(&this->sem_hw));
 
 		while (1) {
 			sleep(1);
@@ -123,46 +129,6 @@ void nce_terminate(void *this_arg)
 	/* LCOV_EXCL_STOP */
 }
 
-/**
- * Helper function which changes the status of the CPU (halted or running)
- * and waits until somebody else changes it to the opposite
- *
- * Both HW and SW threads will use this function to transfer control to the
- * other side.
- *
- * This is how the idle thread halts the CPU and gets halted until the HW models
- * raise a new interrupt; and how the HW models awake the CPU, and wait for it
- * to complete and go to idle.
- */
-static void change_cpu_state_and_wait(struct nce_status_t *this, bool halted)
-{
-	NSI_SAFE_CALL(pthread_mutex_lock(&this->mtx_cpu));
-
-	NCE_DEBUG("Going to halted = %d\n", halted);
-
-	this->cpu_halted = halted;
-
-	/* We let the other side know the CPU has changed state */
-	NSI_SAFE_CALL(pthread_cond_broadcast(&this->cond_cpu));
-
-	/* We wait until the CPU state has been changed. Either:
-	 * we just awoke it, and therefore wait until the CPU has run until
-	 * completion before continuing (before letting the HW models do
-	 * anything else)
-	 *  or
-	 * we are just hanging it, and therefore wait until the HW models awake
-	 * it again
-	 */
-	while (this->cpu_halted == halted) {
-		/* Here we unlock the mutex while waiting */
-		pthread_cond_wait(&this->cond_cpu, &this->mtx_cpu);
-	}
-
-	NCE_DEBUG("Awaken after halted = %d\n", halted);
-
-	NSI_SAFE_CALL(pthread_mutex_unlock(&this->mtx_cpu));
-}
-
 /*
  * Helper function that wraps the SW start_routine
  */
@@ -170,9 +136,8 @@ static void *sw_wrapper(void *this_arg)
 {
 	struct nce_status_t *this = (struct nce_status_t *)this_arg;
 
-	/* Ensure nce_boot_cpu has reached the cond loop */
-	NSI_SAFE_CALL(pthread_mutex_lock(&this->mtx_cpu));
-	NSI_SAFE_CALL(pthread_mutex_unlock(&this->mtx_cpu));
+	/* Ensure nce_boot_cpu is blocked in nce_wake_cpu() */
+	NSI_SAFE_CALL(nce_sem_rewait(&this->sem_sw));
 
 #if (NCE_DEBUG_PRINTS)
 		pthread_t sw_thread = pthread_self();
@@ -198,9 +163,6 @@ void nce_boot_cpu(void *this_arg, void (*start_routine)(void))
 {
 	struct nce_status_t *this = (struct nce_status_t *)this_arg;
 
-	NSI_SAFE_CALL(pthread_mutex_lock(&this->mtx_cpu));
-
-	this->cpu_halted = false;
 	this->start_routine = start_routine;
 
 	/* Create a thread for the embedded SW init: */
@@ -208,15 +170,7 @@ void nce_boot_cpu(void *this_arg, void (*start_routine)(void))
 
 	NSI_SAFE_CALL(pthread_create(&sw_thread, NULL, sw_wrapper, this_arg));
 
-	/* And we wait until the embedded OS has send the CPU to sleep for the first time */
-	while (this->cpu_halted == false) {
-		pthread_cond_wait(&this->cond_cpu, &this->mtx_cpu);
-	}
-	NSI_SAFE_CALL(pthread_mutex_unlock(&this->mtx_cpu));
-
-	if (this->terminate) {
-		nsi_exit(0);
-	}
+	nce_wake_cpu(this_arg);
 }
 
 /*
@@ -236,7 +190,12 @@ void nce_halt_cpu(void *this_arg)
 		nsi_print_error_and_exit("Programming error on: %s ",
 					"This CPU was already halted\n");
 	}
-	change_cpu_state_and_wait(this, true);
+	this->cpu_halted = true;
+
+	NSI_SAFE_CALL(sem_post(&this->sem_hw));
+	NSI_SAFE_CALL(nce_sem_rewait(&this->sem_sw));
+
+	NCE_DEBUG("CPU awaken, HW thread held\n");
 }
 
 /*
@@ -255,7 +214,13 @@ void nce_wake_cpu(void *this_arg)
 		nsi_print_error_and_exit("Programming error on: %s ",
 					"This CPU was already awake\n");
 	}
-	change_cpu_state_and_wait(this, false);
+
+	this->cpu_halted = false;
+
+	NSI_SAFE_CALL(sem_post(&this->sem_sw));
+	NSI_SAFE_CALL(nce_sem_rewait(&this->sem_hw));
+
+	NCE_DEBUG("CPU went to sleep, HW continues\n");
 
 	/*
 	 * If while the SW was running it was decided to terminate the execution

--- a/scripts/native_simulator/common/src/nsi_errno.c
+++ b/scripts/native_simulator/common/src/nsi_errno.c
@@ -18,6 +18,7 @@ struct nsi_errno_mid_map {
 #define ERR(_name) {_name, NSI_ERRNO_MID_##_name}
 
 static const struct nsi_errno_mid_map map[] = {
+	{0, 0},
 	ERR(EPERM),
 	ERR(ENOENT),
 	ERR(ESRCH),
@@ -101,10 +102,6 @@ static const struct nsi_errno_mid_map map[] = {
 
 int nsi_errno_to_mid(int err)
 {
-	if (err == 0) {
-		return err;
-	}
-
 	for (int i = 0; i < NSI_ARRAY_SIZE(map); i++) {
 		if (map[i].err == err) {
 			return map[i].mid_err;
@@ -116,10 +113,6 @@ int nsi_errno_to_mid(int err)
 
 int nsi_errno_from_mid(int err)
 {
-	if (err == 0) {
-		return err;
-	}
-
 	for (int i = 0; i < NSI_ARRAY_SIZE(map); i++) {
 		if (map[i].mid_err == err) {
 			return map[i].err;

--- a/scripts/native_simulator/common/src/nsi_hw_scheduler.c
+++ b/scripts/native_simulator/common/src/nsi_hw_scheduler.c
@@ -163,4 +163,5 @@ void nsi_hws_init(void)
  */
 void nsi_hws_cleanup(void)
 {
+	/* Nothing to be done so far */
 }

--- a/scripts/native_simulator/native/src/native_rtc.c
+++ b/scripts/native_simulator/native/src/native_rtc.c
@@ -27,11 +27,11 @@ uint64_t native_rtc_gettime_us(int clock_type)
 
 		hwtimer_get_pseudohost_rtc_time(&nsec, &sec);
 		return sec * 1000000UL + nsec / 1000U;
+	} else {
+		nsi_print_error_and_exit("Unknown clock source %i\n",
+					clock_type);
+		return 0;
 	}
-
-	nsi_print_error_and_exit("Unknown clock source %i\n",
-				   clock_type);
-	return 0;
 }
 
 /**

--- a/scripts/native_simulator/native/src/nsi_cmdline.c
+++ b/scripts/native_simulator/native/src/nsi_cmdline.c
@@ -114,8 +114,6 @@ static void print_invalid_opt_error(char *argv)
  */
 void nsi_handle_cmd_line(int argc, char *argv[])
 {
-	int i;
-
 	nsi_add_testargs_option();
 
 	s_argv = argv;
@@ -130,9 +128,9 @@ void nsi_handle_cmd_line(int argc, char *argv[])
 		}
 	}
 
-	for (i = 1; i < argc; i++) {
+	for (int i = 1; i < argc; i++) {
 
-		if ((nsi_cmd_is_option(argv[i], "testargs", 0))) {
+		if (nsi_cmd_is_option(argv[i], "testargs", 0)) {
 			test_argc = argc - i - 1;
 			test_argv = &argv[i+1];
 			break;

--- a/scripts/native_simulator/native/src/nsi_cmdline_common.c
+++ b/scripts/native_simulator/native/src/nsi_cmdline_common.c
@@ -123,44 +123,44 @@ void nsi_cmd_read_option_value(const char *str, void *dest, const char type,
 			   const char *option)
 {
 	int error = 0;
-	char *endptr = NULL;
+	const char *endptr = NULL;
 
 	switch (type) {
 	case 'b':
 		if (strcasecmp(str, "false") == 0) {
 			*(bool *)dest = false;
-			endptr = (char *)str + 5;
+			endptr = (const char *)str + 5;
 		} else if (strcmp(str, "0") == 0) {
 			*(bool *)dest = false;
-			endptr = (char *)str + 1;
+			endptr = (const char *)str + 1;
 		} else if (strcasecmp(str, "true") == 0) {
 			*(bool *)dest = true;
-			endptr = (char *)str + 4;
+			endptr = (const char *)str + 4;
 		} else if (strcmp(str, "1") == 0) {
 			*(bool *)dest = true;
-			endptr = (char *)str + 1;
+			endptr = (const char *)str + 1;
 		} else {
 			error = 1;
 		}
 		break;
 	case 's':
-		*(char **)dest = (char *)str;
-		endptr = (char *)str + strlen(str);
+		*(const char **)dest = (const char *)str;
+		endptr = (const char *)str + strlen(str);
 		break;
 	case 'u':
-		*(uint32_t *)dest = strtoul(str, &endptr, 0);
+		*(uint32_t *)dest = strtoul(str, (char **)&endptr, 0);
 		break;
 	case 'U':
-		*(uint64_t *)dest = strtoull(str, &endptr, 0);
+		*(uint64_t *)dest = strtoull(str, (char **)&endptr, 0);
 		break;
 	case 'i':
-		*(int32_t *)dest = strtol(str, &endptr, 0);
+		*(int32_t *)dest = strtol(str, (char **)&endptr, 0);
 		break;
 	case 'I':
-		*(int64_t *)dest = strtoll(str, &endptr, 0);
+		*(int64_t *)dest = strtoll(str, (char **)&endptr, 0);
 		break;
 	case 'd':
-		*(double *)dest = strtod(str, &endptr);
+		*(double *)dest = strtod(str, (char **)&endptr);
 		break;
 	default:
 		nsi_print_error_and_exit(CMD_TYPE_ERROR, type);

--- a/scripts/native_simulator/native/src/timer_model.c
+++ b/scripts/native_simulator/native/src/timer_model.c
@@ -455,7 +455,7 @@ static void cmd_rt_ratio_found(char *argv, int offset)
 {
 	NSI_ARG_UNUSED(argv);
 	NSI_ARG_UNUSED(offset);
-	if ((args.rt_ratio <= 0)) {
+	if (args.rt_ratio <= 0) {
 		nsi_print_error_and_exit("The ratio needs to be > 0. "
 					  "Please use --help for more info\n");
 	}


### PR DESCRIPTION
Align with native_simulator's upstream main
19293fafc9959b03ece651e5e2afb768cfa891cf

Which includes:
19293fa misc trivial changes to please static analyzers
2a41263 nsi_tracing: Annotate functions as noreturn
f0307c1 nct: Simplify and improve switching performance
9f0c825 nce: Optimize/improve performance
63ce7e2 nsi_utils: Add macro to define static inline functions
6035bd8 nsi_errno: Minor optimization with no functional impact
