### PR TITLE
flash: stm32h7x: fix implicit declaration for LL_GetFlashSize

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -836,6 +836,7 @@ static const struct flash_parameters *flash_stm32h7_get_parameters(const struct 
 	return &flash_stm32h7_parameters;
 }
 
+#ifndef CONFIG_SOC_SERIES_STM32H7RSX
 /* Gives the total logical device size in bytes and return 0. */
 static int flash_stm32h7_get_size(const struct device *dev, uint64_t *size)
 {
@@ -845,6 +846,7 @@ static int flash_stm32h7_get_size(const struct device *dev, uint64_t *size)
 
 	return 0;
 }
+#endif /* !CONFIG_SOC_SERIES_STM32H7RSX */
 
 void flash_stm32_page_layout(const struct device *dev, const struct flash_pages_layout **layout,
 			     size_t *layout_size)
@@ -903,7 +905,9 @@ static DEVICE_API(flash, flash_stm32h7_api) = {
 	.write = flash_stm32h7_write,
 	.read = flash_stm32h7_read,
 	.get_parameters = flash_stm32h7_get_parameters,
+#ifndef CONFIG_SOC_SERIES_STM32H7RSX
 	.get_size = flash_stm32h7_get_size,
+#endif
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 	.page_layout = flash_stm32_page_layout,
 #endif


### PR DESCRIPTION
Since https://github.com/zephyrproject-rtos/zephyr/pull/83114 was merged,
I get twister errors unrelated to my pull requests for the STM32H7S78-DK
(for example https://github.com/zephyrproject-rtos/zephyr/actions/runs/14900504138/job/41851537049#step:12:1369)

This is because the function LL_GetFlashSize() was removed from hal_stm32
on the STM32H7RS series in
https://github.com/zephyrproject-rtos/hal_stm32/commit/e5eba65b7674d2883817203856b1d5eb8d08132d (see changes in [stm32cube/stm32h7rsxx/drivers/include/stm32h7rsxx_ll_utils.h](https://github.com/zephyrproject-rtos/hal_stm32/commit/e5eba65b7674d2883817203856b1d5eb8d08132d#diff-2bace14ba67ae23104d696c92d7f0300fd5c39dc7bc3f26f978ee3d4efd4460e))

I am unsure if the removal from hal_stm32 is intentional. If yes, then this
commit should be merged into Zephyr to fix compilation for that target.
Otherwise, hal_stm32 must be patched, Zephyr's west manifest updated, and
this commit can be discarded.

Signed-off-by: Titouan Christophe <titouan.christophe@mind.be>
