### PR TITLE
Add IPC memory and mailbox chosen properties for Beagle

### DIFF
--- a/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
+++ b/boards/beagle/beaglebone_ai64/beaglebone_ai64_j721e_main_r5f0_0.dts
@@ -20,6 +20,8 @@
 		zephyr,sram = &atcm;
 		zephyr,console = &uart2;
 		zephyr,shell-uart = &uart2;
+		zephyr,ipc = &ipc0;
+		zephyr,ipc_shm = &ddr0;
 	};
 
 	cpus {
@@ -43,6 +45,12 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0xa2200000 DT_SIZE_M(14)>;
 		zephyr,memory-region = "DRAM";
+	};
+
+	ipc0: ipc {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox1 0>, <&mbox1 1>;
+		mbox-names = "tx", "rx";
 	};
 };
 

--- a/boards/beagle/beagley_ai/beagley_ai_j722s_main_r5f0_0.dts
+++ b/boards/beagle/beagley_ai/beagley_ai_j722s_main_r5f0_0.dts
@@ -19,6 +19,8 @@
 		zephyr,sram = &atcm;
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
+		zephyr,ipc = &ipc0;
+		zephyr,ipc_shm = &ddr0;
 	};
 
 	cpus {
@@ -42,6 +44,12 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0xa2200000 DT_SIZE_M(14)>;
 		zephyr,memory-region = "DRAM";
+	};
+
+	ipc0: ipc {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox3 0>, <&mbox3 1>;
+		mbox-names = "tx", "rx";
 	};
 };
 

--- a/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
+++ b/boards/beagle/beagley_ai/beagley_ai_j722s_mcu_r5f0_0.dts
@@ -19,6 +19,8 @@
 		zephyr,sram = &atcm;
 		zephyr,console = &uart1;
 		zephyr,shell-uart = &uart1;
+		zephyr,ipc = &ipc0;
+		zephyr,ipc_shm = &ddr0;
 	};
 
 	cpus {
@@ -42,6 +44,12 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0xa1200000 DT_SIZE_M(14)>;
 		zephyr,memory-region = "DRAM";
+	};
+
+	ipc0: ipc {
+		compatible = "zephyr,mbox-ipm";
+		mboxes = <&mbox1 0>, <&mbox1 1>;
+		mbox-names = "tx", "rx";
 	};
 };
 


### PR DESCRIPTION
These selections are used by applications using the OpenAMP IPC frameworks. Add these here to allow those applications and the examples[0] to work out-of-box without needing additional overlays.

[0] https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/ipc