### PR TITLE
Revert "ci: workflows: check for manifest dnm in the manifest workflow"

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -53,10 +53,3 @@ jobs:
           verbosity-level: '1'
           labels: 'manifest'
           dnm-labels: 'DNM (manifest)'
-
-      - name: Check for label
-        if: ${{ contains(github.event.*.labels.*.name, 'DNM (manifest)') }}
-        run: |
-          echo "Pull request is labeled as 'DNM (manifest)'."
-          echo "This workflow fails so that the pull request cannot be merged."
-          exit 1

--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Check for label
         if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
+                contains(github.event.*.labels.*.name, 'DNM (manifest)') ||
                 contains(github.event.*.labels.*.name, 'TSC') ||
                 contains(github.event.*.labels.*.name, 'Architecture Review') ||
                 contains(github.event.*.labels.*.name, 'dev-review') }}


### PR DESCRIPTION
This reverts commit 370e0882cbadf4f603f5d41834e34e9282546b64, the condition is evaluated at workout creation time so this does not work at all, plus some conditions don't have a label removal logic so pairing this with the manifest run does not work anyway.