### PR TITLE
soc: esp32c6: Fix sleep routine

### DIFF
--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -405,6 +405,7 @@ SECTIONS
     *libzephyr.a:esp_memory_utils.*(.literal .literal.* .text .text.*)
     *libzephyr.a:pmu_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:pmu_param.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:pmu_sleep.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_clk.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_clk_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:rtc_time.*(.literal .literal.* .text .text.*)

--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: e3532f053177077647104ae2ef215f0214dc5713
+      revision: 1f1d6937f8bdd884f907ef455ea1508822a7d75e
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
PMU related functions need to be located in IRAM when sleep process is triggered, as cache is disabled past a certain point in the execution of the sleep process.