### PR TITLE
tests/llext: Compute linker script option rather than using -Wl,-T

### DIFF
--- a/tests/subsys/llext/CMakeLists.txt
+++ b/tests/subsys/llext/CMakeLists.txt
@@ -69,6 +69,11 @@ if(NOT CONFIG_LLEXT_TYPE_ELF_OBJECT)
   )
 endif()
 
+get_property(TOPT GLOBAL PROPERTY TOPT)
+get_property(COMPILER_TOPT TARGET compiler PROPERTY linker_script)
+set_ifndef(  TOPT "${COMPILER_TOPT}")
+set_ifndef(  TOPT -Wl,-T) # Use this if the compiler driver doesn't set a value
+
 if (CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND NOT CONFIG_ARM AND NOT CONFIG_RISCV)
   # Manually fix the pre_located extension's text address at a multiple of 4
   get_target_property(pre_located_target pre_located_ext lib_target)
@@ -78,7 +83,7 @@ if (CONFIG_LLEXT_TYPE_ELF_RELOCATABLE AND NOT CONFIG_ARM AND NOT CONFIG_RISCV)
     POST_BUILD
     COMMAND ${CMAKE_C_COMPILER}
     ${LLEXT_APPEND_FLAGS}
-    -Wl,-r -Wl,-Ttext=0xbada110c -nostdlib -nodefaultlibs -nostartfiles
+    -Wl,-r ${TOPT}text=0xbada110c -nostdlib -nodefaultlibs -nostartfiles
     $<TARGET_OBJECTS:${pre_located_target}> -o ${pre_located_file}
   )
 endif()


### PR DESCRIPTION
Use the same logic as the top-level Zephyr CMakeLists.txt does to find the linker script option by using the first one of these which is set:

 1. Global TOPT property
 2. Compiler's linker_script property
 3. -Wl,-T

This avoids toolchains which insert a default linker script when none is provided on the command line using the -T option.