### PR TITLE
drivers: spi: spi_pico_pio: Fix data size issue

### DIFF
--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -671,8 +671,8 @@ static int spi_pico_pio_transceive_impl(const struct device *dev, const struct s
 
 	do {
 		spi_pico_pio_txrx(dev);
-		spi_context_update_tx(spi_ctx, 1, data->tx_count);
-		spi_context_update_rx(spi_ctx, 1, data->rx_count);
+		spi_context_update_tx(spi_ctx, data->dfs, data->tx_count);
+		spi_context_update_rx(spi_ctx, data->dfs, data->rx_count);
 	} while (spi_pico_pio_transfer_ongoing(data));
 
 	spi_context_cs_control(spi_ctx, false);


### PR DESCRIPTION
### Bug Description ###
When a higher level driver calls the SPI driver for the Pico platform, found in `spi_rpi_pico_pio.c`, and passes **multiple** transmit and receive buffers to the function `spi_transceive()`, an **incorrect number** of transferred bits is observed.

#### Test Setup ####
A device driver was given multiple buffers, each sized to be used for 16 bit transfers. The specifications for the SPI layer for that device was set so that a 16 bit frame size is used.

Buffers:
```
	uint8_t tx1_bytes[2];
	uint8_t tx2_bytes[2];
	...
        const struct spi_buf tx_buf[3] = {
                {
                        .buf = tx1_bytes,
                        .len = sizeof(tx1_bytes)
                },
                {
                        .buf = tx2_bytes,
                        .len = sizeof(tx2_bytes)
	        },
                {
                        .buf = NULL,
	                .len = 1
                }
        };
	...
```

Config spec:
```
	static const struct adctest_config test_##t##_config_##n = { \
		.bus = SPI_DT_SPEC_GET(INST_DT_ADCTEST(n, t), \
					 SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | \
					 SPI_MODE_CPOL | SPI_MODE_CPHA | \
					 SPI_WORD_SET(16), 0), \
		.channels = ch, \
	}; \
```

#### Debug Log From SPI Driver ####
The test program was compiled with debug logs enabled.
```
[00:00:08.071,000] <dbg> spi_pico_pio: spi_context_buffers_setup: tx_bufs 0x200046e8 - rx_bufs 0x200046e0 - 2
[00:00:08.071,000] <dbg> spi_pico_pio: spi_context_buffers_setup: current_tx 0x20004708 (2), current_rx 0x200046f0 (2), tx buf/len 0 x2000472c/1, rx buf/len 0x20004728/1
[00:00:08.072,000] <dbg> spi_pico_pio: spi_context_update_tx: tx buf/len 0x20004724/2
[00:00:08.072,000] <dbg> spi_pico_pio: spi_context_update_rx: rx buf/len 0x20004720/2
[00:00:08.073,000] <dbg> spi_pico_pio: spi_context_update_tx: tx buf/len 0/0
[00:00:08.073,000] <dbg> spi_pico_pio: spi_context_update_rx: rx buf/len 0/0
```
The log shows that the **second** buffer was described to have the length `2`, instead of the correct value `1`.

#### SPI Hardware Signals ####
The SPI clock signal used by the test program was checked.
![DS1Z_SPIclk_Original_RPI_PIO](https://github.com/user-attachments/assets/732fb1c4-0fd9-4438-9f2f-a7af588e9785)
The second transfer shows a **doubling** of the expected 16 clock cycles.

### Proposed Fix ###
This commit replace the "hard-coded" value of `1` with the correct value found `data->dfs`.

### Behavior After Change ###
The same test application was used after the proposed fix.

#### Debug Log From SPI Driver ####
New log
```
[00:00:07.059,000] <dbg> spi_pico_pio: spi_context_buffers_setup: tx_bufs 0x200046e8 - rx_bufs 0x200046e0 - 2
[00:00:07.059,000] <dbg> spi_pico_pio: spi_context_buffers_setup: current_tx 0x20004708 (2), current_rx 0x200046f0 (2), tx buf/len 0 x2000472c/1, rx buf/len 0x20004728/1
[00:00:07.060,000] <dbg> spi_pico_pio: spi_context_update_tx: tx buf/len 0x20004724/1
[00:00:07.060,000] <dbg> spi_pico_pio: spi_context_update_rx: rx buf/len 0x20004720/1
[00:00:07.060,000] <dbg> spi_pico_pio: spi_context_update_tx: tx buf/len 0/0
[00:00:07.061,000] <dbg> spi_pico_pio: spi_context_update_rx: rx buf/len 0/0
```
The log shows that the **second** buffer was described to have the correct length value `1`.

#### SPI Hardware Signals ####
The SPI clock signal used by the test program was checked.
![DS1Z_SPIclk_Fixed_RPI_PIO](https://github.com/user-attachments/assets/c5ba6f49-4017-429d-976c-31bede56d630)
The second transfer now shows 16 clock cycles.