### PR TITLE
drivers: dma: Add PM handler for NXP LPC DMA driver

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -19,6 +19,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/util_macro.h>
 #include <zephyr/drivers/dma/dma_mcux_lpc.h>
+#include <zephyr/pm/device.h>
 
 #define DT_DRV_COMPAT nxp_lpc_dma
 
@@ -845,6 +846,26 @@ static int dma_mcux_lpc_get_attribute(const struct device *dev, uint32_t type, u
 	return 0;
 }
 
+static int dma_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
+		DMA_Init(DEV_BASE(dev));
+		INPUTMUX_Init(INPUTMUX);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
 static int dma_mcux_lpc_init(const struct device *dev)
 {
 	const struct dma_mcux_lpc_config *config = dev->config;
@@ -869,12 +890,12 @@ static int dma_mcux_lpc_init(const struct device *dev)
 
 	data->num_channels_used = 0;
 
-	DMA_Init(DEV_BASE(dev));
-	INPUTMUX_Init(INPUTMUX);
-
 	config->irq_config_func(dev);
 
-	return 0;
+	/* Complete the remaining hardware specific init in the TURN_ON action
+	 * of the power management handler.
+	 */
+	return pm_device_driver_init(dev, dma_mcux_lpc_pm_action);
 }
 
 static DEVICE_API(dma, dma_mcux_lpc_api) = {
@@ -937,9 +958,11 @@ static const struct dma_mcux_lpc_config dma_##n##_config = {		\
 		.otrig_array = dma_##n##_otrig_arr,			\
 	};								\
 									\
+	PM_DEVICE_DT_INST_DEFINE(n, dma_mcux_lpc_pm_action);		\
+									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			    dma_mcux_lpc_init,				\
-			    NULL,					\
+			    PM_DEVICE_DT_INST_GET(n),			\
 			    &dma_data_##n, &dma_##n##_config,		\
 			    PRE_KERNEL_1, CONFIG_DMA_INIT_PRIORITY,	\
 			    &dma_mcux_lpc_api);				\

--- a/samples/subsys/display/lvgl/boards/frdm_rw612.conf
+++ b/samples/subsys/display/lvgl/boards/frdm_rw612.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_PM=y

--- a/samples/subsys/display/lvgl/boards/frdm_rw612.overlay
+++ b/samples/subsys/display/lvgl/boards/frdm_rw612.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&standby {
+	status = "okay";
+};


### PR DESCRIPTION
Add the PM handler. Reinitialize the DMA block in the TURN_ON action, this is needed for some SoC's after the system
exits certain power modes.

Tested with the LVGL sample that enables DMA. 

This is PR should merge after https://github.com/zephyrproject-rtos/zephyr/pull/89905 https://github.com/zephyrproject-rtos/zephyr/pull/90019 as these PR's have code additions that is needed for the input subsystem to work when PM Mode 3 is enabled on the RW612 SoC.