### PR TITLE
x86: x86_64: ARCH_HAS_STACKWALK possible with optimization

### DIFF
--- a/arch/x86/core/Kconfig.intel64
+++ b/arch/x86/core/Kconfig.intel64
@@ -35,7 +35,6 @@ config ARCH_HAS_STACKWALK
 	select DEBUG_INFO
 	select THREAD_STACK_INFO
 	depends on !OMIT_FRAME_POINTER
-	depends on NO_OPTIMIZATIONS
 	help
 	  Internal config to indicate that the arch_stack_walk() API is implemented
 	  and it can be enabled.

--- a/tests/arch/common/stack_unwind/testcase.yaml
+++ b/tests/arch/common/stack_unwind/testcase.yaml
@@ -33,8 +33,8 @@ tests:
   arch.common.stack_unwind.x86:
     arch_allow: x86
     extra_configs:
-      - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_OMIT_FRAME_POINTER=n
+      - CONFIG_OVERRIDE_FRAME_POINTER_DEFAULT=y
     integration_platforms:
       - qemu_x86
       - qemu_x86_64


### PR DESCRIPTION
Stack walking on x86_64 can run with compiler optimization and does not need `CONFIG_NO_OPTIMIZATIONS` as long as frame pointers are not omitted. So remove the "depends on" for x86_64 from `CONFIG_ARCH_HAS_STACKWALK`.

The `stack_unwind` test is updated to reflect this change.
