### PR TITLE
drivers: stepper: adi_tmc: tmc5xxxx: fixed standstill detection

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx.c
@@ -341,7 +341,7 @@ static int tmc50xx_stepper_is_moving(const struct device *dev, bool *is_moving)
 		return -EIO;
 	}
 
-	*is_moving = (FIELD_GET(TMC5XXX_DRV_STATUS_STST_BIT, reg_value) == 1U);
+	*is_moving = (FIELD_GET(TMC5XXX_DRV_STATUS_STST_BIT, reg_value) != 1U);
 	LOG_DBG("Stepper motor controller %s is moving: %d", dev->name, *is_moving);
 	return 0;
 }

--- a/drivers/stepper/adi_tmc/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx.c
@@ -394,7 +394,7 @@ static int tmc51xx_stepper_is_moving(const struct device *dev, bool *is_moving)
 		return -EIO;
 	}
 
-	*is_moving = (FIELD_GET(TMC5XXX_DRV_STATUS_STST_BIT, reg_value) == 1U);
+	*is_moving = (FIELD_GET(TMC5XXX_DRV_STATUS_STST_BIT, reg_value) != 1U);
 	LOG_DBG("Stepper motor controller %s is moving: %d", dev->name, *is_moving);
 	return 0;
 }


### PR DESCRIPTION
The standstill detection logic now stands corrected. 
Moving would be indicated when the standstill bit is not zero.

For eg: TMC51xx:
![image](https://github.com/user-attachments/assets/fd9312ec-85a7-4154-8405-1b8b25b7548a)

TMC50xx:
![image](https://github.com/user-attachments/assets/4efe9390-2b91-40de-9833-60ecc65c424b)
