### PR TITLE
Update sensor.h with new sensor channel and sensor attribute enums

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -201,6 +201,14 @@ enum sensor_channel {
 	SENSOR_CHAN_GRAVITY_VECTOR,
 	/** Gyroscope bias (X/Y/Z components in radians/s) */
 	SENSOR_CHAN_GBIAS_XYZ,
+	/** Light flicker frequency in Hz. */
+	SENSOR_CHAN_FLICKER,
+	/** Photopic light intensity in lux. */
+	SENSOR_CHAN_PHOTOPIC,
+	/** Gain for sensitivity adjustment. */
+	SENSOR_CHAN_GAIN,
+	/** Ultraviolet A (UVA) radiation in μW/cm². */
+	SENSOR_CHAN_UVA,
 
 	/** All channels. */
 	SENSOR_CHAN_ALL,
@@ -360,6 +368,15 @@ enum sensor_attribute {
 	 * Number of all common sensor attributes.
 	 */
 	SENSOR_ATTR_COMMON_COUNT,
+
+	/**
+	 * One-shot measurement for single readings.
+	 */
+	SENSOR_ATTR_ONE_SHOT,
+	/**
+	 * Auto-disable sensor after conditions are met.
+	 */
+	SENSOR_ATTR_AUTO_DISABLE,
 
 	/**
 	 * This and higher values are sensor specific.


### PR DESCRIPTION
### Description

Add new sensor channels to support flicker, photopic, gain, and uva data. Add new sensor attributes to support one-shot reading mode, and auto-disable functionality. This change will help provide more support for Flicker sensors and ALS sensors using the Zephyr Sensor API.