### PR TITLE
drivers: iom: define ambiq spi/i2c dma mode as a binding property

### DIFF
--- a/drivers/i2c/Kconfig.ambiq
+++ b/drivers/i2c/Kconfig.ambiq
@@ -16,16 +16,10 @@ menuconfig I2C_AMBIQ
 
 if I2C_AMBIQ
 
-config I2C_AMBIQ_DMA
-	bool "AMBIQ APOLLO I2C DMA Support"
-	help
-	  Enable DMA for Ambiq I2C.
-
 config I2C_AMBIQ_HANDLE_CACHE
 	bool "Turn on cache handling in i2c driver"
 	default y
 	depends on CACHE_MANAGEMENT && DCACHE
-	depends on I2C_AMBIQ_DMA
 	help
 	  Disable this if cache has been handled in upper layers.
 

--- a/drivers/spi/Kconfig.ambiq
+++ b/drivers/spi/Kconfig.ambiq
@@ -18,17 +18,10 @@ menuconfig SPI_AMBIQ_SPIC
 
 if SPI_AMBIQ_SPIC
 
-config SPI_AMBIQ_DMA
-	bool "AMBIQ APOLLO SPI DMA Support"
-	depends on SPI_AMBIQ_SPIC
-	help
-	  Enable DMA for Ambiq SPI.
-
 config SPI_AMBIQ_HANDLE_CACHE
 	bool "Turn on cache handling in spi driver"
 	default y
 	depends on CACHE_MANAGEMENT && DCACHE
-	depends on SPI_AMBIQ_DMA
 	help
 	  Disable this if cache has been handled in upper layers.
 

--- a/dts/bindings/mfd/ambiq,iom.yaml
+++ b/dts/bindings/mfd/ambiq,iom.yaml
@@ -14,6 +14,10 @@ properties:
   interrupts:
     required: true
 
+  dma-mode:
+    description: Enables DMA over SPI/I2C.
+    type: boolean
+
   cmdq-buffer-location:
     type: string
     description: |


### PR DESCRIPTION
Changed to define ambiq spi/i2c dma mode as a binding property instead of kconfig macros, making it more flexible for different spi/i2c instances.