### PR TITLE
arch:arm:cortex_m: Fix sysmpu header not found issue

### DIFF
--- a/arch/arm/core/cortex_m/scb.c
+++ b/arch/arm/core/cortex_m/scb.c
@@ -23,7 +23,7 @@
 #include <zephyr/cache.h>
 #include <zephyr/arch/cache.h>
 
-#if defined(CONFIG_CPU_HAS_NXP_SYSMPU)
+#if defined(CONFIG_ARM_MPU) && defined(CONFIG_CPU_HAS_NXP_SYSMPU)
 #include <fsl_sysmpu.h>
 #endif
 


### PR DESCRIPTION
The NXP SYSMPU driver function is only used when both `CONFIG_ARM_MPU` and `CONFIG_CPU_HAS_NXP_SYSMPU` are defined, but the driver header fsl_sysmpu.h is included if `CONFIG_CPU_HAS_NXP_SYSMPU` is defined.

When `CONFIG_CPU_HAS_NXP_SYSMPU` is defined but `CONFIG_ARM_MPU` not defined, sysmpu driver is not added in the build process, but still searching its header, this results in build fail.

Update to use the same macro condition, only use sysmpu driver when both macro defined.