### PR TITLE
soc: st: add stm32u535 support

### DIFF
--- a/dts/arm/st/u5/stm32u535.dtsi
+++ b/dts/arm/st/u5/stm32u535.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Harris Tomy
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/u5/stm32u5.dtsi>
+
+/ {
+	soc {
+		/* USB-C PD is not available on this part. */
+		/delete-node/ ucpd@4000dc00;
+
+		/* Advanced Encryption Standard HW accelerator is not available on this part. */
+		/delete-node/ aes@420c0000;
+
+		compatible = "st,stm32u535", "st,stm32u5", "simple-bus";
+
+		usb: usb@40016000 {
+			compatible = "st,stm32-usb";
+			reg = <0x40016000 0x400>;
+			interrupts = <73 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <2048>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
+				<&rcc STM32_SRC_HSI48 ICKLK_SEL(0)>;
+			phys = <&usb_fs_phy>;
+			status = "disabled";
+		};
+	};
+
+	usb_fs_phy: usb_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+	};
+};

--- a/dts/arm/st/u5/stm32u535Xi.dtsi
+++ b/dts/arm/st/u5/stm32u535Xi.dtsi
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Harris Tomy
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/u5/stm32u535.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		/* SRAM1 + SRAM2 */
+		reg = <0x20000000 DT_SIZE_K(256)>;
+	};
+
+	sram1: memory@28000000 {
+		/* SRAM4, low-power background autonomous mode */
+		reg = <0x28000000 DT_SIZE_K(16)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(512)>;
+			};
+		};
+	};
+};

--- a/soc/st/stm32/soc.yml
+++ b/soc/st/stm32/soc.yml
@@ -206,6 +206,7 @@ family:
     - name: stm32u5a5xx
     - name: stm32u5a9xx
     - name: stm32u5g9xx
+    - name: stm32u535xx
     - name: stm32u545xx
     - name: stm32u575xx
     - name: stm32u585xx

--- a/soc/st/stm32/stm32u5x/Kconfig.defconfig.stm32u535xx
+++ b/soc/st/stm32/stm32u5x/Kconfig.defconfig.stm32u535xx
@@ -1,0 +1,11 @@
+# ST Microelectronics STM32U535XX MCU
+
+# Copyright (c) 2025 Harris Tomy
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32U535XX
+
+config NUM_IRQS
+	default 126
+
+endif # SOC_STM32U535XX

--- a/soc/st/stm32/stm32u5x/Kconfig.soc
+++ b/soc/st/stm32/stm32u5x/Kconfig.soc
@@ -4,6 +4,7 @@
 # Copyright (c) 2023 PSICONTROL nv
 # Copyright (c) 2023 STMicroelectronics
 # Copyright (c) 2025 Charles Dias
+# Copyright (c) 2025 Harris Tomy
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_STM32U5X
@@ -12,6 +13,10 @@ config SOC_SERIES_STM32U5X
 
 config SOC_SERIES
 	default "stm32u5x" if SOC_SERIES_STM32U5X
+
+config SOC_STM32U535XX
+	bool
+	select SOC_SERIES_STM32U5X
 
 config SOC_STM32U545XX
 	bool
@@ -49,6 +54,7 @@ config SOC
 	default "stm32u5a5xx" if SOC_STM32U5A5XX
 	default "stm32u5a9xx" if SOC_STM32U5A9XX
 	default "stm32u5g9xx" if SOC_STM32U5G9XX
+	default "stm32u535xx" if SOC_STM32U535XX
 	default "stm32u545xx" if SOC_STM32U545XX
 	default "stm32u575xx" if SOC_STM32U575XX
 	default "stm32u585xx" if SOC_STM32U585XX


### PR DESCRIPTION
We are using a custom board that uses the STM32U535 SoC, similar to #78910. 

This PR adds the necessary modifications to the soc files and addition of the dts files required. 

The only difference between this SoC and the 545 is the lack of the HW Encryption module, hence the deletion of the peripheral in the devicetree file.