### PR TITLE
NXP drivers: watchdog mcux wwdt: adds PM low power support

### DIFF
--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -202,6 +202,7 @@
 		reg = <0xe000 0x1000>;
 		interrupts = <0 0>;
 		status = "disabled";
+		power-domains = <&power_mode3_domain>;
 		clk-divider = <1>;
 	};
 

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/frdm_rw612.conf
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/frdm_rw612.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier Apache-2.0
+#
+CONFIG_WDT_MCUX_WWDT_WARNING_INTERRUPT_CFG=512
+CONFIG_PM=y

--- a/tests/drivers/watchdog/wdt_basic_reset_none/boards/frdm_rw612.overlay
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/boards/frdm_rw612.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Enable standby low power mode */
+&standby {
+	status = "okay";
+};


### PR DESCRIPTION
Enables Sleep mode (PM3) in RW61x.

Tested tests/drivers/watchdog/wdt_basic_reset_none on FRDM-RW612. Verified that the wdt continues running after PM3 wake-up.