### PR TITLE
Bluetooth: Host: Rename acl_data to bt_conn_rx for clarity

### DIFF
--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -84,7 +84,7 @@ static void evt_pool_destroy(struct net_buf *buf)
 }
 
 NET_BUF_POOL_DEFINE(acl_in_pool, (BT_BUF_ACL_RX_COUNT_EXTRA + BT_BUF_HCI_ACL_RX_COUNT),
-		    BT_BUF_ACL_SIZE(CONFIG_BT_BUF_ACL_RX_SIZE), sizeof(struct acl_data),
+		    BT_BUF_ACL_SIZE(CONFIG_BT_BUF_ACL_RX_SIZE), sizeof(struct bt_conn_rx),
 		    acl_in_pool_destroy);
 
 NET_BUF_POOL_FIXED_DEFINE(evt_pool, CONFIG_BT_BUF_EVT_RX_COUNT, BT_BUF_EVT_RX_SIZE, 0,
@@ -101,8 +101,8 @@ static void hci_rx_pool_destroy(struct net_buf *buf)
 	buf_rx_freed_notify(BT_BUF_EVT | BT_BUF_ACL_IN);
 }
 
-NET_BUF_POOL_FIXED_DEFINE(hci_rx_pool, BT_BUF_RX_COUNT, BT_BUF_RX_SIZE, sizeof(struct acl_data),
-			  hci_rx_pool_destroy);
+NET_BUF_POOL_FIXED_DEFINE(hci_rx_pool, BT_BUF_RX_COUNT, BT_BUF_RX_SIZE,
+			  sizeof(struct bt_conn_rx), hci_rx_pool_destroy);
 #endif /* CONFIG_BT_HCI_ACL_FLOW_CONTROL */
 
 struct net_buf *bt_buf_get_rx(enum bt_buf_type type, k_timeout_t timeout)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -209,11 +209,11 @@ struct bt_conn_tx {
 	void *user_data;
 };
 
-struct acl_data {
+struct bt_conn_rx {
 	/* Index into the bt_conn storage array */
 	uint8_t  index;
 
-	/** ACL connection handle */
+	/** Connection handle */
 	uint16_t handle;
 };
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -160,7 +160,7 @@ struct cmd_data {
 static struct cmd_data cmd_data[BT_BUF_CMD_TX_COUNT];
 
 #define cmd(buf) (&cmd_data[net_buf_id(buf)])
-#define acl(buf) ((struct acl_data *)net_buf_user_data(buf))
+#define acl(buf) ((struct bt_conn_rx *)net_buf_user_data(buf))
 
 static bool drv_quirk_no_reset(void)
 {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -63,7 +63,7 @@ static void iso_rx_buf_destroy(struct net_buf *buf)
 }
 
 NET_BUF_POOL_FIXED_DEFINE(iso_rx_pool, CONFIG_BT_ISO_RX_BUF_COUNT,
-			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_RX_MTU), sizeof(struct iso_data),
+			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_RX_MTU), sizeof(struct bt_conn_rx),
 			  iso_rx_buf_destroy);
 
 static struct bt_iso_recv_info iso_info_data[CONFIG_BT_ISO_RX_BUF_COUNT];

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -20,14 +20,6 @@
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys_clock.h>
 
-struct iso_data {
-	/* Index into the bt_conn storage array */
-	uint8_t  index;
-
-	/** ISO connection handle */
-	uint16_t handle;
-};
-
 enum bt_iso_cig_state {
 	BT_ISO_CIG_STATE_IDLE,
 	BT_ISO_CIG_STATE_CONFIGURED,
@@ -76,7 +68,7 @@ struct bt_iso_big {
 	ATOMIC_DEFINE(flags, BT_BIG_NUM_FLAGS);
 };
 
-#define iso(buf) ((struct iso_data *)net_buf_user_data(buf))
+#define iso(buf) ((struct bt_conn_rx *)net_buf_user_data(buf))
 
 /* Process ISO buffer */
 void hci_iso(struct net_buf *buf);


### PR DESCRIPTION
We already have bt_conn_tx for outgoing buffer user data, so name the struct for incoming (rx) buffers similarly.