### PR TITLE
stm32 ospi bindings fixes dtc warnings

### DIFF
--- a/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
+++ b/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.dts
@@ -269,9 +269,10 @@ zephyr_udc0: &usbotg_fs {
 
 	status = "okay";
 
-	mx25r6435f: ospi-nor-flash@90000000 {
+	mx25r6435f: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Megabits */
+		reg = <0>;
+		size = <DT_SIZE_M(64)>; /* 64 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(26)>; /* for Voltage Range 2 */
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;

--- a/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.dts
+++ b/boards/fanke/fk7b0m1_vbt6/fk7b0m1_vbt6.dts
@@ -85,7 +85,8 @@
 	/* Winbond external flash */
 	w25q64jvssiq_qspi: qspi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0 DT_SIZE_M(8)>; /* 64 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(64)>; /* 64 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(133)>;
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -246,9 +246,10 @@ zephyr_udc0: &usbotg_fs {
 
 	status = "okay";
 
-	mx25r6435f: ospi-nor-flash@90000000 {
+	mx25r6435f: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x90000000 DT_SIZE_M(8)>; /* 64 Megabits */
+		reg = <0>;
+		size = <DT_SIZE_M(64)>; /* 64 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(26)>; /* for Voltage Range 2 */
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -137,9 +137,10 @@ stm32_lp_tick_source: &lptim1 {
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@70000000 {
+	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 512 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -180,9 +180,10 @@
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@90000000 {
+	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 512 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -287,9 +287,10 @@
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@90000000 {
+	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 512 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -290,10 +290,11 @@ zephyr_udc0: &usbotg_fs {
 			&octospim_p2_dqs_pg15>;
 	pinctrl-names = "default";
 
-	mx25lm51245: ospi-nor-flash@90000000 {
+	mx25lm51245: ospi-nor-flash@0 {
 		status = "okay";
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 512 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(25)>;
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -227,9 +227,10 @@ stm32_lp_tick_source: &lptim1 {
 
 	status = "okay";
 
-	mx25lm51245: ospi-nor-flash@90000000 {
+	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(512)>; /* 512 Megabits */
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;

--- a/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
+++ b/boards/weact/mini_stm32h7b0/mini_stm32h7b0.dts
@@ -142,9 +142,10 @@ zephyr_udc0: &usbotg_hs {
 		&octospim_p1_io2_pe2 &octospim_p1_io3_pd13>;
 	status = "okay";
 
-	w25q64_qspi: ospi-nor-flash@90000000 {
+	w25q64_qspi: ospi-nor-flash@0{
 		compatible = "st,stm32-ospi-nor";
-		reg = <0x90000000 DT_SIZE_M(64)>; /* 64 Mbits */
+		reg = <0>;
+		size = <DT_SIZE_M(64)>; /* 64 Mbits */
 		ospi-max-frequency = <40000000>;
 		status = "okay";
 		spi-bus-width = <4>;

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -610,8 +610,9 @@ SPI
 * The binding file for :dtcompatible:`andestech,atcspi200` has been renamed to have a name
   matching the compatible string.
 
-xSPI
-====
+
+oSPI/xSPI
+=========
 
 * On STM32 devices, external memories device tree descriptions for size and address are now split
   in two separate properties to comply with specification recommendations.
@@ -620,7 +621,7 @@ xSPI
   is changed to ``reg = <0>;`` ``size = <DT_SIZE_M(512)>; / 512 Mbits */``.
 
   Note that the property gives the actual size of the memory device in bits.
-  Previous mapping address information is now described in xspi node at SoC dtsi level.
+  Previous mapping address information is now described in xspi or ospi nodes at SoC dtsi level.
 
 Video
 =====

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -39,8 +39,8 @@ LOG_MODULE_REGISTER(flash_stm32_ospi, CONFIG_FLASH_LOG_LEVEL);
 #define DT_OSPI_PROP_OR(prop, default_value) \
 	DT_PROP_OR(STM32_OSPI_NODE, prop, default_value)
 
-/* Get the base address of the flash from the DTS node */
-#define STM32_OSPI_BASE_ADDRESS DT_INST_REG_ADDR(0)
+/* Get the base address of the flash from the DTS st,stm32-ospi node */
+#define STM32_OSPI_BASE_ADDRESS DT_REG_ADDR_BY_IDX(STM32_OSPI_NODE, 1)
 
 #define STM32_OSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
 
@@ -2658,7 +2658,7 @@ static const struct flash_stm32_ospi_config flash_stm32_ospi_cfg = {
 		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospi_mgr, bits)},
 #endif
 	.irq_config = flash_stm32_ospi_irq_config_func,
-	.flash_size = DT_INST_REG_SIZE(0),
+	.flash_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
 	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),
 	.data_mode = DT_INST_PROP(0, spi_bus_width), /* SPI or OPI */
 	.data_rate = DT_INST_PROP(0, data_rate), /* DTR or STR */

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -95,25 +95,25 @@
 
 		octospi1: spi@52005000 {
 			compatible = "st,stm32-ospi";
-			reg = <0x52005000 0x1000>;
+			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <92 0>;
 			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 
 		octospi2: spi@5200a000 {
 			compatible = "st,stm32-ospi";
-			reg = <0x5200a000 0x1000>;
+			reg = <0x5200a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <150 0>;
 			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB3, 19U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -58,25 +58,25 @@
 
 		octospi1: spi@52005000 {
 			compatible = "st,stm32-ospi";
-			reg = <0x52005000 0x1000>;
+			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <92 0>;
 			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 
 		octospi2: spi@5200a000 {
 			compatible = "st,stm32-ospi";
-			reg = <0x5200a000 0x1000>;
+			reg = <0x5200a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <150 0>;
 			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB3, 19U)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -379,7 +379,7 @@
 
 		octospi1: spi@a0001000 {
 			compatible = "st,stm32-ospi";
-			reg = <0xa0001000 0x400>;
+			reg = <0xa0001000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <71 0>;
 			clock-names = "ospix", "ospi-ker", "ospi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>,
@@ -387,13 +387,13 @@
 				<&rcc STM32_CLOCK(AHB2, 20U)>;
 
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 
 		octospi2: spi@a0001400 {
 			compatible = "st,stm32-ospi";
-			reg = <0xa0001400 0x400>;
+			reg = <0xa0001400 0x400>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <76 0>;
 			clock-names = "ospix", "ospi-ker", "ospi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB3, 9U)>,
@@ -401,7 +401,7 @@
 				<&rcc STM32_CLOCK(AHB2, 20U)>;
 
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -434,13 +434,13 @@
 
 		octospi1: spi@44021000 {
 			compatible = "st,stm32-ospi";
-			reg = <0x44021000 0x400>;
+			reg = <0x44021000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <76 0>;
 			clock-names = "ospix", "ospi-ker";
 			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>,
 					<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -695,14 +695,27 @@
 
 		octospi1: spi@420d1400 {
 			compatible = "st,stm32-ospi";
-			reg = <0x420d1400 0x400>;
+			reg = <0x420d1400 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <76 0>;
 			clock-names = "ospix", "ospi-ker", "ospi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB2_2, 4)>,
 				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
 				<&rcc STM32_CLOCK(AHB2, 21)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+		};
+
+		octospi2: spi@420d2400 {
+			compatible = "st,stm32-ospi";
+			reg = <0x420d2400 0x400>, <0x70000000 DT_SIZE_M(256)>;
+			interrupts = <120 0>;
+			clock-names = "ospix", "ospi-ker", "ospi-mgr";
+			clocks = <&rcc STM32_CLOCK(AHB2_2, 8U)>,
+				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
+				<&rcc STM32_CLOCK(AHB2, 21U)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5_extra.dtsi
+++ b/dts/arm/st/u5/stm32u5_extra.dtsi
@@ -57,14 +57,14 @@
 
 		octospi2: spi@420d2400 {
 			compatible = "st,stm32-ospi";
-			reg = <0x420d2400 0x400>;
+			reg = <0x420d2400 0x400>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <120 0>;
 			clock-names = "ospix", "ospi-ker", "ospi-mgr";
 			clocks = <&rcc STM32_CLOCK(AHB2_2, 8)>,
 				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
 				<&rcc STM32_CLOCK(AHB2, 21)>;
 			#address-cells = <1>;
-			#size-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -6,9 +6,10 @@ description: |
 
     Representation of a serial flash on a octospi bus:
 
-        mx25lm51245: ospi-nor-flash@70000000 {
+        mx25lm51245: ospi-nor-flash@0 {
                 compatible = "st,stm32-ospi-nor";
-                reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
+                reg = <0>;
+                size = <DT_SIZE_M(512)>; /* 512 Mbits */
                 data-mode = <OSPI_OPI_MODE>; /* access on 8 data lines */
                 data-rate = <OSPI_DTR_TRANSFER>; /* access in DTR */
                 ospi-max-frequency = <DT_FREQ_M(50)>;
@@ -22,6 +23,9 @@ include: ["flash-controller.yaml", "jedec,jesd216.yaml"]
 on-bus: ospi
 
 properties:
+  size:
+    required: true
+    description: Flash Memory size in bits
   reg:
     required: true
     description: Flash Memory base address and size in bytes

--- a/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-xspi-nor.yaml
@@ -6,9 +6,10 @@ description: |
 
     Representation of a serial flash on a xspi bus:
 
-        mx25lm51245: xspi-nor-flash@70000000 {
+        mx25lm51245: xspi-nor-flash@0 {
                 compatible = "st,stm32-xspi-nor";
-                reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits */
+                reg = <0>;
+                size = <DT_SIZE_M(512)>; /* 512 Mbits */
                 data-mode = <XSPI_OCTO_MODE>; /* access on 8 data lines */
                 data-rate = <XSPI_DTR_TRANSFER>; /* access in DTR */
                 ospi-max-frequency = <DT_FREQ_M(50)>;

--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -30,8 +30,8 @@
 /* On stm32 OSPI, external flash is mapped in XIP region at address given by the reg property. */
 
 #define EXTFLASH_NODE	DT_INST(0, st_stm32_ospi_nor)
-#define EXTFLASH_ADDR	DT_REG_ADDR(DT_INST(0, st_stm32_ospi_nor))
-#define EXTFLASH_SIZE	DT_REG_SIZE(DT_INST(0, st_stm32_ospi_nor))
+#define EXTFLASH_ADDR	DT_REG_ADDR_BY_IDX(DT_PARENT(EXTFLASH_NODE), 1)
+#define EXTFLASH_SIZE	(DT_PROP(EXTFLASH_NODE, size) / 8)
 
 #elif defined(CONFIG_STM32_MEMMAP) && DT_NODE_EXISTS(DT_INST(0, st_stm32_qspi_nor))
 /* On stm32 QSPI, external flash is mapped in XIP region at address given by the reg property. */


### PR DESCRIPTION
This PR is for fixing the https://github.com/zephyrproject-rtos/zephyr/issues/88404 for the OSPI compatible

It changes the way the "st,stm32-ospi-nor" compatible declares the external flash base address and size.

The "st,stm32-ospi" node, gives the external memory base address and maximum allocated space (in bytes):

		ospi1: spi@47001400 {
			compatible = "st,stm32-ospi";
			reg = <0x47001400 0x400>, <0x90000000 0x10000000>;
The "st,stm32-ospi-nor" node, gives the external NOR device size in Bits through the size property

	mx25lm51245: ospi-nor-flash@0 {
		compatible = "st,stm32-ospi-nor";
		reg = <0>;
		size = <0x20000000>; /* 512 Mbits */