### PR TITLE
clang warnings: comparison of int of different signs

### DIFF
--- a/arch/arm/include/cortex_m/exception.h
+++ b/arch/arm/include/cortex_m/exception.h
@@ -47,7 +47,7 @@ extern volatile irq_offload_routine_t offload_routine;
 /* Prefix. Indicates that this is an EXC_RETURN value.
  * This field reads as 0b11111111.
  */
-#define EXC_RETURN_INDICATOR_PREFIX            (0xFF << 24)
+#define EXC_RETURN_INDICATOR_PREFIX            (0xFFU << 24)
 /* bit[0]: Exception Secure. The security domain the exception was taken to. */
 #define EXC_RETURN_EXCEPTION_SECURE_Pos        0
 #define EXC_RETURN_EXCEPTION_SECURE_Msk        BIT(EXC_RETURN_EXCEPTION_SECURE_Pos)

--- a/kernel/include/priority_q.h
+++ b/kernel/include/priority_q.h
@@ -280,7 +280,7 @@ static ALWAYS_INLINE unsigned int z_priq_mq_best_queue_index(struct _priq_mq *pq
 
 static ALWAYS_INLINE void z_priq_mq_init(struct _priq_mq *q)
 {
-	for (int i = 0; i < ARRAY_SIZE(q->queues); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(q->queues); i++) {
 		sys_dlist_init(&q->queues[i]);
 	}
 

--- a/lib/utils/bitarray.c
+++ b/lib/utils/bitarray.c
@@ -620,7 +620,7 @@ found:
 	/* The bit we are looking for must be in the current bundle idx.
 	 * Find out the exact index of the bit.
 	 */
-	for (int j = 0; j <= bundle_bitness(bitarray) - 1; j++) {
+	for (size_t j = 0; j <= bundle_bitness(bitarray) - 1; j++) {
 		if (bitarray->bundles[idx] & mask & BIT(j)) {
 			if (--n <= 0) {
 				*found_at = idx * bundle_bitness(bitarray) + j;


### PR DESCRIPTION
This PR fixes three `-Wsign-compare` warnings raised by Clang when building with `-Wall` and `-Wextra` in three of zephyr's internal components:
- kernel priority_q
- utils bitarray
- arch arm exception