### PR TITLE
dts: bindings: soc clock

### DIFF
--- a/soc/st/stm32/stm32f4x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32f4x/Kconfig.defconfig
@@ -27,4 +27,7 @@ config IDLE_STACK_SIZE
 
 endif # PM
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+       default $(dt_node_int_prop_int,/soc/rcc@40023800,clock-frequency)
+
 endif # SOC_SERIES_STM32F4X


### PR DESCRIPTION
soc clock cycles per sec is getting from DTS

based on nordicjm suggestion:
CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC should be in Kconfig.defconfig of soc, which should get it from a dts property, see https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/gd/gd32/gd32f3x0/Kconfig.defconfig.gd32f350#L6 for an example