### PR TITLE
modules: mbedtls: fix PSA Kconfig file generation on Windows

### DIFF
--- a/modules/mbedtls/create_psa_files.py
+++ b/modules/mbedtls/create_psa_files.py
@@ -1,6 +1,7 @@
 #!/bin/python3
 
 # Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) Atmosic 2025
 # SPDX-License-Identifier: Apache-2.0
 
 import re
@@ -16,6 +17,9 @@ INPUT_FILE = os.path.normpath(os.path.join(SCRIPT_PATH, INPUT_REL_PATH))
 
 KCONFIG_PATH=os.path.join(SCRIPT_PATH, "Kconfig.psa.auto")
 HEADER_PATH=os.path.join(SCRIPT_PATH, "configs", "config-psa.h")
+
+if sys.platform == "win32":
+    INPUT_REL_PATH = INPUT_REL_PATH.replace("\\", "/")
 
 KCONFIG_HEADER="""\
 # Copyright (c) 2024 Nordic Semiconductor ASA


### PR DESCRIPTION
**Root cause**
The INPUT_REAL_PATH parameter varies depending on the operating system. In a Windows environment, the direction of the path slashes differs from that in config.psa and config-psa.h, causing content mismatches and resulting in build failure.

**Solution**
When running in a Windows environment, convert the slash direction to match that used in config.psa and config-psa.h to eliminate the issue.