### PR TITLE
tests: drivers: virtualization: qemu_kvm_arm64.overlay: fix SPDX license

### DIFF
--- a/tests/drivers/virtualization/ivshmem/plain/boards/qemu_kvm_arm64.overlay
+++ b/tests/drivers/virtualization/ivshmem/plain/boards/qemu_kvm_arm64.overlay
@@ -2,6 +2,6 @@
  * Copyright (c) 2021 Intel Corporation
  * Copyright (c) 2022 Huawei France Technologies SASU
  *
- * SPDX-License-Identifier: Apache-2.0 and UNLICENSED
+ * SPDX-License-Identifier: Apache-2.0
  */
 #include "pcie_ivshmem.dtsi"


### PR DESCRIPTION
"UNLICENSED" is not a valid SPDX License Identifier. Remove it from the list and just keep "Apache-2.0".

Fixes: #89413