### PR TITLE
Revert "boards: nordic: nrf54h20: disable sec ipc"

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -143,9 +143,14 @@
 };
 
 &cpusec_cpuapp_ipc {
+	status = "okay";
 	mbox-names = "tx", "rx";
 	tx-region = <&cpuapp_cpusec_ipc_shm>;
 	rx-region = <&cpusec_cpuapp_ipc_shm>;
+};
+
+&cpusec_bellboard {
+	status = "okay";
 };
 
 ipc0: &cpuapp_cpurad_ipc {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -60,9 +60,14 @@
 };
 
 &cpusec_cpurad_ipc {
+	status = "okay";
 	mbox-names = "tx", "rx";
 	tx-region = <&cpurad_cpusec_ipc_shm>;
 	rx-region = <&cpusec_cpurad_ipc_shm>;
+};
+
+&cpusec_bellboard {
+	status = "okay";
 };
 
 ipc0: &cpuapp_cpurad_ipc {


### PR DESCRIPTION
This reverts commit 5386a64cb53ef4b4456b4e13ca2e4ec739b5e6e7.

Issue is no longer relevant. Simplify use of board by restoring enabling secure ipc by default.