### PR TITLE
boards: unify connectorized i2c ports to use `zephyr_i2c`

### DIFF
--- a/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3_procpu.dts
+++ b/boards/adafruit/feather_esp32s3/adafruit_feather_esp32s3_procpu.dts
@@ -115,7 +115,7 @@
 	filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
 };
 
-&i2c0 {
+zephyr_i2c: &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	pinctrl-0 = <&i2c0_default>;

--- a/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft_procpu.dts
+++ b/boards/adafruit/feather_esp32s3_tft/adafruit_feather_esp32s3_tft_procpu.dts
@@ -162,7 +162,7 @@
 	filter-smooth-level = <ESP32_TOUCH_FILTER_SMOOTH_MODE_IIR_2>;
 };
 
-&i2c0 {
+zephyr_i2c: &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	pinctrl-0 = <&i2c0_default>;

--- a/boards/arduino/mkrzero/arduino_mkrzero.dts
+++ b/boards/arduino/mkrzero/arduino_mkrzero.dts
@@ -40,7 +40,7 @@
 	clock-frequency = <48000000>;
 };
 
-&sercom0 {
+zephyr_i2c: &sercom0 {
 	status = "okay";
 	compatible = "atmel,sam0-i2c";
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/arduino/nicla_sense_me/arduino_nicla_sense_me.dts
+++ b/boards/arduino/nicla_sense_me/arduino_nicla_sense_me.dts
@@ -88,7 +88,7 @@
 };
 
 /* I2C1 in datasheet */
-&i2c1 {
+zephyr_i2c: &i2c1 {
 	compatible = "nordic,nrf-twim";
 	/* Cannot be used together with spi1. */
 	status = "okay";

--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -95,7 +95,7 @@
 	};
 };
 
-&i2c1 {
+zephyr_i2c: &i2c1 {
 	status = "disabled";
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -83,7 +83,7 @@
 };
 
 /* I2C1 in datasheet */
-&i2c1 {
+zephyr_i2c: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -113,6 +113,6 @@
 	status = "okay";
 };
 
-qwiic_i2c: &iic0 {};
+zephyr_i2c: &iic0 {};
 arduino_i2c: &iic1 {};
 arduino_spi: &spi0 {};

--- a/boards/m5stack/m5stack_atom_lite/grove_connectors.dtsi
+++ b/boards/m5stack/m5stack_atom_lite/grove_connectors.dtsi
@@ -15,4 +15,4 @@
 	};
 };
 
-grove_i2c1: &i2c1 {};
+zephyr_i2c: &i2c1 {};

--- a/boards/m5stack/m5stack_atoms3/grove_connectors.dtsi
+++ b/boards/m5stack/m5stack_atoms3/grove_connectors.dtsi
@@ -14,4 +14,4 @@
 	};
 };
 
-grove_i2c1: &i2c1 {};
+zephyr_i2c: &i2c1 {};

--- a/boards/m5stack/m5stack_atoms3_lite/grove_connectors.dtsi
+++ b/boards/m5stack/m5stack_atoms3_lite/grove_connectors.dtsi
@@ -15,4 +15,4 @@
 	};
 };
 
-grove_i2c1: &i2c1 {};
+zephyr_i2c: &i2c1 {};

--- a/boards/m5stack/m5stack_core2/grove_connectors.dtsi
+++ b/boards/m5stack/m5stack_core2/grove_connectors.dtsi
@@ -15,5 +15,5 @@
 	};
 };
 
-grove_i2c: &i2c1 {};
+zephyr_i2c: &i2c1 {};
 grove_uart: &uart1 {};

--- a/boards/m5stack/m5stack_cores3/grove_connectors.dtsi
+++ b/boards/m5stack/m5stack_cores3/grove_connectors.dtsi
@@ -14,5 +14,5 @@
 	};
 };
 
-grove_i2c: &i2c1 {};
+zephyr_i2c: &i2c1 {};
 grove_uart: &uart2 {};

--- a/boards/pimoroni/pico_plus2/pico_plus2.dtsi
+++ b/boards/pimoroni/pico_plus2/pico_plus2.dtsi
@@ -175,4 +175,4 @@ pico_spi: &spi0 {};
 pico_i2c0: &i2c0 {};
 pico_i2c1: &i2c1 {};
 pico_serial: &uart0 {};
-stemma_qt_i2c: &i2c0 {};
+zephyr_i2c: &i2c0 {};

--- a/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/seeed/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -168,7 +168,7 @@ stm32_lp_tick_source: &lptim1 {
 
 /* connectors: */
 grove_serial: &usart1 {};
-grove_i2c: &i2c2 {};
+zephyr_i2c: &i2c2 {};
 
 &flash0 {
 	partitions {

--- a/boards/seeed/wio_terminal/grove_connectors.dtsi
+++ b/boards/seeed/wio_terminal/grove_connectors.dtsi
@@ -22,4 +22,4 @@
 	};
 };
 
-grove_i2c1: &sercom3 {};
+zephyr_i2c: &sercom3 {};

--- a/boards/shields/adafruit_aw9523/adafruit_aw9523.overlay
+++ b/boards/shields/adafruit_aw9523/adafruit_aw9523.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&stemma_qt_i2c {
+&zephyr_i2c {
 	status = "okay";
 
 	adafruit_aw9523: aw9523b@58 {

--- a/boards/shields/arduino_modulino_buttons/arduino_modulino_buttons.overlay
+++ b/boards/shields/arduino_modulino_buttons/arduino_modulino_buttons.overlay
@@ -7,7 +7,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/led/led.h>
 
-&qwiic_i2c {
+&zephyr_i2c {
 	modulino-buttons@3e {
 		compatible = "i2c-device";
 		reg = <0x3e>;

--- a/boards/shields/arduino_modulino_smartleds/arduino_modulino_smartleds.overlay
+++ b/boards/shields/arduino_modulino_smartleds/arduino_modulino_smartleds.overlay
@@ -12,7 +12,7 @@
 	};
 };
 
-&qwiic_i2c {
+&zephyr_i2c {
 	modulino_smartleds: modulino-smartleds@36 {
 		compatible = "arduino,modulino-smartleds";
 		reg = <0x36>;

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040-pinctrl.dtsi
@@ -16,6 +16,17 @@
 		};
 	};
 
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_P16>;
+			input-enable;
+		};
+		group2 {
+			pinmux = <I2C0_SCL_P17>;
+			input-enable;
+		};
+	};
+
 	i2c1_default: i2c1_default {
 		group1 {
 			pinmux = <I2C1_SDA_P2>;

--- a/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
+++ b/boards/sparkfun/pro_micro_rp2040/sparkfun_pro_micro_rp2040.dts
@@ -65,6 +65,13 @@
 	pinctrl-names = "default";
 };
 
+zephyr_i2c: &i2c0 {
+	status = "okay";
+	pinctrl-0 = <&i2c0_default>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
 &i2c1 {
 	status = "okay";
 	pinctrl-0 = <&i2c1_default>;

--- a/boards/sparkfun/red_v_things_plus/sparkfun_red_v_things_plus.dts
+++ b/boards/sparkfun/red_v_things_plus/sparkfun_red_v_things_plus.dts
@@ -63,7 +63,7 @@
 	pinctrl-names = "default";
 };
 
-&i2c0 {
+zephyr_i2c: &i2c0 {
 	status = "okay";
 	clock-frequency = <100000>;
 	pinctrl-0 = <&i2c0_0_default &i2c0_1_default>;

--- a/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_common.dtsi
+++ b/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_common.dtsi
@@ -124,7 +124,7 @@
 	pinctrl-names = "default", "sleep";
 };
 
-&i2c1 {
+zephyr_i2c: &i2c1 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -83,7 +83,7 @@
 	status = "okay";
 };
 
-&i2c0 {
+zephyr_i2c: &i2c0 {
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 	status = "okay";


### PR DESCRIPTION
Unify all pluggable i2c nodelabel in zephyr boards and shield to ue the `zephyr_i2c` label, this is to make shields and boards with pluggable i2c interfaces interoperatable with the zephyr shield system. Some of these are actually the same thing (qwiic/stemma) and even for ones with different connectors (grove) there's adapter to go between each other, so it really makes no sense to use the commercial name, they are all i2c devices and can be used with i2c "shields".

There's few "standards" in the wild for connectorized i2c ports, qwiic, stemma-qt, the other stemma one, grove, eslov, probably more.

And none of them has an interrupt pin, imagine that, polling or burst, what a concept.

Anyway, there's adapters to adapt between them, we have a shield infrastructure that can use well-known labels to put sensors on busses at build time, use `zephyr_i2c` for this purpose. Could use any label but we already have `zephyr_udc`, `zephyr_mipi_dsi`, `zephyr_lcdif` let's go with it.

This differs from `arduino_i2c` and `feather_i2c` as those are parth of the arduino or feather pinout, but shields exists to adapt those to qwiic (or equivalent too) and we can represent those with a shield to map the label just fine.