### PR TITLE
net: l2: openthread: Fix error logs on adding already present address

### DIFF
--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -216,8 +216,18 @@ void add_ipv6_addr_to_ot(struct openthread_context *context,
 	}
 
 	openthread_mutex_lock();
-	error = otIp6AddUnicastAddress(openthread_get_default_instance(), &addr);
+	if (!otIp6HasUnicastAddress(openthread_get_default_instance(),
+				    &addr.mAddress)) {
+		error = otIp6AddUnicastAddress(openthread_get_default_instance(),
+					       &addr);
+	} else {
+		error = OT_ERROR_ALREADY;
+	}
 	openthread_mutex_unlock();
+
+	if (error == OT_ERROR_ALREADY) {
+		return;
+	}
 
 	if (error != OT_ERROR_NONE) {
 		NET_ERR("Failed to add IPv6 unicast address %s [%d]",
@@ -238,6 +248,10 @@ void add_ipv6_maddr_to_ot(struct openthread_context *context,
 	openthread_mutex_lock();
 	error = otIp6SubscribeMulticastAddress(openthread_get_default_instance(), &addr);
 	openthread_mutex_unlock();
+
+	if (error == OT_ERROR_ALREADY) {
+		return;
+	}
 
 	if (error != OT_ERROR_NONE) {
 		NET_ERR("Failed to add IPv6 multicast address %s [%d]",


### PR DESCRIPTION
Error checking of otIp6AddUnicastAddress() and
otIp6SubscribeMulticastAddress() was added recently, however it wasn't taken into account that those APIs return an error on attempt to register an IPv6 address that is already present on the OT interface. Therefore, add more specific error checks, to return silently in case address was already present.

As those two APIs are not very consistent, and otIp6AddUnicastAddress() returns OT_ERROR_INVALID_ARGS in such cases, add an extra check if the address is already present before attempting to register the address.