### PR TITLE
Enable lvgl example for g1120b0mipi rt700

### DIFF
--- a/boards/shields/g1120b0mipi/g1120b0mipi.overlay
+++ b/boards/shields/g1120b0mipi/g1120b0mipi.overlay
@@ -20,6 +20,7 @@
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&ft3267_g1120b0mipi>;
+		display = <&rm67162_g1120b0mipi>;
 		invert-y;
 	};
 };

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -116,6 +116,8 @@ struct mipi_dsi_msg {
 	size_t rx_len;
 	/** Reception buffer. */
 	void *rx_buf;
+	/** User data. */
+	void *user_data;
 };
 
 /** MIPI-DSI host driver API. */

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -27,6 +27,8 @@ struct lvgl_disp_data disp_data[DT_ZEPHYR_DISPLAYS_COUNT] = {{
 	.blanking_on = false,
 }};
 
+#define DISPLAY_BUFFER_ALIGN(alignbytes) __aligned(alignbytes)
+
 #if DT_HAS_COMPAT_STATUS_OKAY(zephyr_displays)
 #define DISPLAY_NODE(n) DT_ZEPHYR_DISPLAY(n)
 #elif DT_HAS_CHOSEN(zephyr_display)
@@ -77,21 +79,21 @@ static uint8_t *mono_vtile_buf_p[DT_ZEPHYR_DISPLAYS_COUNT] = {NULL};
 /* prevent unaligned memory accesses. */
 
 /* clang-format off */
-#define LV_BUFFERS_DEFINE(n)                                                                       \
-	static uint8_t buf0_##n[BUFFER_SIZE(n)]							   \
-	IF_ENABLED(CONFIG_LV_Z_VDB_CUSTOM_SECTION, (Z_GENERIC_SECTION(.lvgl_buf)))                 \
-						       __aligned(CONFIG_LV_Z_VDB_ALIGN);           \
-                                                                                                   \
-	IF_ENABLED(CONFIG_LV_Z_DOUBLE_VDB, (							   \
-	static uint8_t buf1_##n[BUFFER_SIZE(n)]							   \
-	IF_ENABLED(CONFIG_LV_Z_VDB_CUSTOM_SECTION, (Z_GENERIC_SECTION(.lvgl_buf)))		   \
-			__aligned(CONFIG_LV_Z_VDB_ALIGN);					   \
-	))                                            \
-                                                                                                   \
-	IF_ENABLED(ALLOC_MONOCHROME_CONV_BUFFER, (						   \
-	static uint8_t mono_vtile_buf_##n[BUFFER_SIZE(n)]					   \
-	IF_ENABLED(CONFIG_LV_Z_VDB_CUSTOM_SECTION, (Z_GENERIC_SECTION(.lvgl_buf)))		   \
-			__aligned(CONFIG_LV_Z_VDB_ALIGN);					   \
+#define LV_BUFFERS_DEFINE(n)									\
+	static DISPLAY_BUFFER_ALIGN(LV_DRAW_BUF_ALIGN) uint8_t buf0_##n[BUFFER_SIZE(n)]		\
+	IF_ENABLED(CONFIG_LV_Z_VDB_CUSTOM_SECTION, (Z_GENERIC_SECTION(.lvgl_buf)))		\
+						       __aligned(CONFIG_LV_Z_VDB_ALIGN);	\
+												\
+	IF_ENABLED(CONFIG_LV_Z_DOUBLE_VDB, (							\
+	static DISPLAY_BUFFER_ALIGN(LV_DRAW_BUF_ALIGN) uint8_t buf1_##n[BUFFER_SIZE(n)]		\
+	IF_ENABLED(CONFIG_LV_Z_VDB_CUSTOM_SECTION, (Z_GENERIC_SECTION(.lvgl_buf)))		\
+			__aligned(CONFIG_LV_Z_VDB_ALIGN);					\
+	))											\
+												\
+	IF_ENABLED(ALLOC_MONOCHROME_CONV_BUFFER, (						\
+	static uint8_t mono_vtile_buf_##n[BUFFER_SIZE(n)]					\
+	IF_ENABLED(CONFIG_LV_Z_VDB_CUSTOM_SECTION, (Z_GENERIC_SECTION(.lvgl_buf)))		\
+			__aligned(CONFIG_LV_Z_VDB_ALIGN);					\
 	))
 
 FOR_EACH(LV_BUFFERS_DEFINE, (), LV_DISPLAYS_IDX_LIST);

--- a/modules/lvgl/lvgl_display_16bit.c
+++ b/modules/lvgl/lvgl_display_16bit.c
@@ -20,7 +20,7 @@ void lvgl_flush_cb_16bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.y = area->y1;
 	flush.desc.buf_size = w * 2U * h;
 	flush.desc.width = w;
-	flush.desc.pitch = w;
+	flush.desc.pitch = ROUND_UP(w * 2U, LV_DRAW_BUF_STRIDE_ALIGN) / 2U;
 	flush.desc.height = h;
 	flush.buf = (void *)px_map;
 

--- a/modules/lvgl/lvgl_display_24bit.c
+++ b/modules/lvgl/lvgl_display_24bit.c
@@ -20,7 +20,7 @@ void lvgl_flush_cb_24bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.y = area->y1;
 	flush.desc.buf_size = w * 3U * h;
 	flush.desc.width = w;
-	flush.desc.pitch = w;
+	flush.desc.pitch = ROUND_UP(w * 3U, LV_DRAW_BUF_STRIDE_ALIGN) / 3U;
 	flush.desc.height = h;
 	flush.buf = (void *)px_map;
 

--- a/modules/lvgl/lvgl_display_32bit.c
+++ b/modules/lvgl/lvgl_display_32bit.c
@@ -20,7 +20,7 @@ void lvgl_flush_cb_32bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.y = area->y1;
 	flush.desc.buf_size = w * 4U * h;
 	flush.desc.width = w;
-	flush.desc.pitch = w;
+	flush.desc.pitch = ROUND_UP(w * 4U, LV_DRAW_BUF_STRIDE_ALIGN) / 4U;
 	flush.desc.height = h;
 	flush.buf = (void *)px_map;
 	lvgl_flush_display(&flush);

--- a/modules/lvgl/lvgl_display_8bit.c
+++ b/modules/lvgl/lvgl_display_8bit.c
@@ -19,7 +19,7 @@ void lvgl_flush_cb_8bit(lv_display_t *display, const lv_area_t *area, uint8_t *p
 	flush.y = area->y1;
 	flush.desc.buf_size = w * h;
 	flush.desc.width = w;
-	flush.desc.pitch = w;
+	flush.desc.pitch = ROUND_UP(w, LV_DRAW_BUF_STRIDE_ALIGN);
 	flush.desc.height = h;
 	flush.buf = (void *)px_map;
 

--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -10,6 +10,7 @@ common:
     - platform:mimxrt1060_evk:SHIELD=rk043fn66hs_ctg
     - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
     - platform:mimxrt595_evk/mimxrt595s/cm33:SHIELD=rk055hdmipi4ma0
+    - platform:mimxrt700_evk/mimxrt798s/cm33_cpu0:SHIELD=g1120b0mipi
   tags:
     - samples
     - display


### PR DESCRIPTION
1.Fix bug in drivers: mipi_dsi: dsi_mcux_2l when using NXP DCNano DBI driver, previously the pitch>width situation is not supported properly.
2.Enable lvgl example for g1120b0mipi on mimxrt798s