### PR TITLE
cmake: fix syscall dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,6 @@ set(OFFSETS_H_TARGET           offsets_h)
 set(SYSCALL_LIST_H_TARGET      syscall_list_h_target)
 set(DRIVER_VALIDATION_H_TARGET driver_validation_h_target)
 set(KOBJ_TYPES_H_TARGET        kobj_types_h_target)
-set(PARSE_SYSCALLS_TARGET      parse_syscalls_target)
 set(DEVICE_API_LD_TARGET       device_api_ld_target)
 
 define_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT BRIEF_DOCS " " FULL_DOCS " ")
@@ -834,7 +833,7 @@ add_custom_command(
   --file-list        ${syscalls_file_list_output}
   $<$<BOOL:${CONFIG_EMIT_ALL_SYSCALLS}>:--emit-all-syscalls>
   DEPENDS ${syscalls_subdirs_trigger} ${PARSE_SYSCALLS_HEADER_DEPENDS}
-          ${syscalls_file_list_output} ${syscalls_interface}
+          ${syscalls_file_list_output} syscalls_interface
   )
 
 # Make sure Picolibc is built before the rest of the system; there's no explicit
@@ -851,12 +850,6 @@ set_property(TARGET ${SYSCALL_LIST_H_TARGET}
              ADDITIONAL_CLEAN_FILES
              ${CMAKE_CURRENT_BINARY_DIR}/include/generated/zephyr/syscalls
 )
-
-add_custom_target(${PARSE_SYSCALLS_TARGET}
-  DEPENDS
-  ${syscalls_json}
-  ${struct_tags_json}
-  )
 
 # 64-bit systems do not require special handling of 64-bit system call
 # parameters or return values, indicate this to the system call boilerplate
@@ -900,7 +893,7 @@ add_custom_command(
   COMMAND
   ${LEGACY_SYSCALL_LIST_H_ARGS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS ${PARSE_SYSCALLS_TARGET}
+  DEPENDS ${syscalls_json}
   )
 
 include(${ZEPHYR_BASE}/cmake/kobj.cmake)
@@ -911,9 +904,13 @@ gen_kobject_list(
   OUTPUTS ${DRV_VALIDATION}
   SCRIPT_ARGS --validation-output ${DRV_VALIDATION}
   INCLUDES ${struct_tags_json}
+  DEPENDS ${struct_tags_json}
   )
 
-gen_kobject_list_headers(INCLUDES ${struct_tags_json})
+gen_kobject_list_headers(
+  INCLUDES ${struct_tags_json}
+  DEPENDS ${struct_tags_json}
+  )
 
 # Generate sections for kernel device subsystems
 set(
@@ -1270,6 +1267,7 @@ if(CONFIG_USERSPACE)
     OUTPUT ${KOBJECT_PREBUILT_HASH_LIST}
     KERNEL_TARGET ${ZEPHYR_LINK_STAGE_EXECUTABLE}
     INCLUDES ${struct_tags_json}
+    DEPENDS ${struct_tags_json}
     )
 
   add_custom_command(
@@ -1466,6 +1464,7 @@ if(CONFIG_USERSPACE)
     OUTPUT ${KOBJECT_HASH_LIST}
     KERNEL_TARGET ${ZEPHYR_LINK_STAGE_EXECUTABLE}
     INCLUDES ${struct_tags_json}
+    DEPENDS ${struct_tags_json}
     )
 
   # Use gperf to generate C code (KOBJECT_HASH_OUTPUT_SRC_PRE) which implements a
@@ -2298,7 +2297,7 @@ if(CONFIG_LLEXT_EDK)
       ${SYSCALL_SPLIT_TIMEOUT_ARG}
     COMMAND ${CMAKE_COMMAND}
         -P ${ZEPHYR_BASE}/cmake/llext-edk.cmake
-    DEPENDS ${logical_target_for_zephyr_elf} build_info_yaml_saved
+    DEPENDS ${logical_target_for_zephyr_elf} ${syscalls_json} build_info_yaml_saved
     COMMAND_EXPAND_LISTS
   )
   add_custom_target(llext-edk DEPENDS ${llext_edk_file})

--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -27,7 +27,6 @@ function(gen_kobject_list)
     DEPENDS
       ${arg_DEPENDS}
       ${GEN_KOBJECT_LIST}
-      ${PARSE_SYSCALLS_TARGET}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
   add_custom_target(${arg_TARGET} DEPENDS ${arg_OUTPUTS})
@@ -39,7 +38,7 @@ function(gen_kobject_list_gperf)
   cmake_parse_arguments(PARSE_ARGV 0 arg
     ""
     "TARGET;OUTPUT;KERNEL_TARGET"
-    "INCLUDES"
+    "INCLUDES;DEPENDS"
   )
   gen_kobject_list(
     TARGET ${arg_TARGET}
@@ -48,7 +47,9 @@ function(gen_kobject_list_gperf)
       --kernel $<TARGET_FILE:${arg_KERNEL_TARGET}>
       --gperf-output ${arg_OUTPUT}
     INCLUDES ${arg_INCLUDES}
-    DEPENDS ${arg_KERNEL_TARGET}
+    DEPENDS
+      ${arg_DEPENDS}
+      ${arg_KERNEL_TARGET}
     )
 endfunction()
 
@@ -58,7 +59,7 @@ function(gen_kobject_list_headers)
   cmake_parse_arguments(PARSE_ARGV 0 arg
     ""
     "GEN_DIR_OUT_VAR"
-    "INCLUDES"
+    "INCLUDES;DEPENDS"
   )
   if (PROJECT_BINARY_DIR)
     set(gen_dir ${PROJECT_BINARY_DIR}/include/generated/zephyr)
@@ -80,6 +81,9 @@ function(gen_kobject_list_headers)
       --kobj-otype-output ${KOBJ_OTYPE}
       --kobj-size-output ${KOBJ_SIZE}
     INCLUDES ${arg_INCLUDES}
+    DEPENDS
+      ${arg_DEPENDS}
+      ${arg_KERNEL_TARGET}
   )
 
   if(arg_GEN_DIR_OUT_VAR)


### PR DESCRIPTION
Replace _parse_syscalls_target_ custom target with explicit dependency management for syscall depending file generation.

Fixes #89729