### PR TITLE
Add "BT_BUF_EVT_RX_SIZE" in default-kconfig as 255 to avoid bt-samples buffer-alloc issue due to larger packet size

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -68,6 +68,9 @@ config BT_LONG_WQ_STACK_SIZE
 config MAIN_STACK_SIZE
 	default 2560
 
+config BT_BUF_EVT_RX_SIZE
+	default $(UINT8_MAX)
+
 if SHELL
 
 config SHELL_STACK_SIZE


### PR DESCRIPTION
- As default bt_buf_rx_size is small and cause buffer-full scenario too quickly when scan ongoing,BT samples which needs continous larger event buffer does not work correctly.

- Adding support of "BT_BUF_EVT_RX_SIZE" as part of shield default kconfig to avoid such issues for BT samples which run on shield with IW416/IW612 chipsets over H4 transport.

Below is the one possible issue example,
![image](https://github.com/user-attachments/assets/52be3e90-bf0b-4f11-89cc-2c515461ea32)
