### PR TITLE
dts: bindings: ti,ads1119

### DIFF
--- a/dts/bindings/adc/ti,ads1119.yaml
+++ b/dts/bindings/adc/ti,ads1119.yaml
@@ -7,6 +7,9 @@ compatible: "ti,ads1119"
 
 include: [adc-controller.yaml, i2c-device.yaml]
 
+io-channel-cells:
+  - input
+
 properties:
   "#io-channel-cells":
     const: 1


### PR DESCRIPTION
Added io-channel-cells to the binding as is standard for the ads1x1x binding. Additionally, this prevents an issue where you cannot compile due to the length of this property being longer than expected.