### PR TITLE
drivers: led: led_gpio: Add support of blink

### DIFF
--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -27,3 +27,5 @@ zephyr_library_sources_ifdef(CONFIG_TLC59108 tlc59108.c)
 zephyr_library_sources_ifdef(CONFIG_LED_SHELL   led_shell.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   led_handlers.c)
+
+zephyr_library_sources_ifdef(CONFIG_LED_BLINK_FALLBACK blink_fallback.c)

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -26,6 +26,23 @@ config LED_SHELL
 	help
 	  Enable LED shell for testing.
 
+config LED_BLINK_FALLBACK
+	bool "LED Blink fallback"
+	help
+	  Provides a software implementation of LED blink API.
+	  This could be used when the LED controller doesn't support blinking.
+
+if LED_BLINK_FALLBACK
+
+config LED_BLINK_FALLBACK_COUNT
+	int "Maximum of LED using blink fallback"
+	default 3
+	help
+	  This set the maximum number of LED that could blink
+	  in the same time using blink fallback.
+
+endif # LED_BLINK_FALLBACK
+
 # zephyr-keep-sorted-start
 source "drivers/led/Kconfig.axp192"
 source "drivers/led/Kconfig.dac"

--- a/drivers/led/Kconfig.gpio
+++ b/drivers/led/Kconfig.gpio
@@ -8,3 +8,12 @@ config LED_GPIO
 	select GPIO
 	help
 	  Enable driver for GPIO LEDs.
+
+if LED_GPIO
+
+config LED_GPIO_BLINK
+	bool "GPIO LED Blink API"
+	help
+	  Enable support of the blink API.
+
+endif

--- a/drivers/led/blink_fallback.c
+++ b/drivers/led/blink_fallback.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/led.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+
+#define LED_ON  ((void *)1)
+#define LED_OFF ((void *)0)
+
+struct led_blink_fallback_data {
+	const struct device *dev;
+	uint32_t led;
+	struct k_timer blink_timer;
+	uint32_t delay_on;
+	uint32_t delay_off;
+};
+
+static struct led_blink_fallback_data blink_fallback_data[CONFIG_LED_BLINK_FALLBACK_COUNT];
+
+static void led_blink_fallback_timer_cb(struct k_timer *timer_id)
+{
+	struct led_blink_fallback_data *data =
+		CONTAINER_OF(timer_id, struct led_blink_fallback_data, blink_timer);
+	const struct led_driver_api *api = (const struct led_driver_api *)data->dev->api;
+
+	if (k_timer_user_data_get(timer_id) == LED_ON) {
+		api->off(data->dev, data->led);
+		k_timer_user_data_set(&data->blink_timer, LED_OFF);
+		k_timer_start(timer_id, K_MSEC(data->delay_off), K_NO_WAIT);
+	} else {
+		api->on(data->dev, data->led);
+		k_timer_user_data_set(&data->blink_timer, LED_ON);
+		k_timer_start(timer_id, K_MSEC(data->delay_on), K_NO_WAIT);
+	}
+}
+
+static struct led_blink_fallback_data *led_fallback_get_data(const struct device *dev, uint32_t led)
+{
+	for (int i = 0; i < CONFIG_LED_BLINK_FALLBACK_COUNT; i++) {
+		struct led_blink_fallback_data *data = &blink_fallback_data[i];
+
+		if (data->dev == dev && data->led == led) {
+			return data;
+		}
+
+		if (data->dev == NULL) {
+			return data;
+		}
+	}
+
+	return NULL;
+}
+
+int led_blink_fallback(const struct device *dev, uint32_t led, uint32_t delay_on,
+		       uint32_t delay_off)
+{
+	struct led_blink_fallback_data *data = led_fallback_get_data(dev, led);
+
+	if (!data) {
+		return -ENODEV;
+	}
+
+	if (delay_on == 0 && delay_off == 0) {
+		if (!data->dev) {
+			return -ENODEV;
+		}
+		k_timer_stop(&data->blink_timer);
+		data->dev = NULL;
+		return 0;
+	}
+
+	if (data->dev) {
+		data->delay_on = delay_on;
+		data->delay_off = delay_off;
+		return 0;
+	}
+
+	data->dev = dev;
+	data->led = led;
+	data->delay_on = delay_on;
+	data->delay_off = delay_off;
+
+	k_timer_init(&data->blink_timer, led_blink_fallback_timer_cb, NULL);
+	k_timer_user_data_set(&data->blink_timer, LED_ON);
+	k_timer_start(&data->blink_timer, K_MSEC(delay_on), K_NO_WAIT);
+
+	return 0;
+}

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -24,6 +24,65 @@ struct led_gpio_config {
 	const struct gpio_dt_spec *led;
 };
 
+#ifdef CONFIG_LED_GPIO_BLINK
+#define MAX_GPIO_LEDS 32
+struct led_gpio_data {
+	const struct led_gpio_config *config;
+	struct k_timer *blink_timer;
+	uint32_t *delay_on;
+	uint32_t *delay_off;
+	uint32_t blink_state;
+};
+
+static void led_gpio_timer_cb(struct k_timer *timer_id)
+{
+	struct led_gpio_data *data = k_timer_user_data_get(timer_id);
+	const struct led_gpio_config *config = data->config;
+	int led = timer_id - data->blink_timer;
+	const struct gpio_dt_spec *led_gpio = &config->led[led];
+
+	data->blink_state ^= 1 << led;
+	gpio_pin_set_dt(led_gpio, data->blink_state & (1 << led));
+	if (data->blink_state & (1 << led)) {
+		k_timer_start(&data->blink_timer[led], K_MSEC(data->delay_on[led]), K_NO_WAIT);
+	} else {
+		k_timer_start(&data->blink_timer[led], K_MSEC(data->delay_off[led]), K_NO_WAIT);
+	}
+}
+
+static int led_gpio_blink(const struct device *dev, uint32_t led,
+			  uint32_t delay_on, uint32_t delay_off)
+{
+	struct led_gpio_data *data = dev->data;
+
+	data->blink_state = 1 << led;
+	data->delay_on[led] = delay_on;
+	data->delay_off[led] = delay_off;
+
+	k_timer_start(&data->blink_timer[led], K_MSEC(delay_on), K_NO_WAIT);
+
+	return 0;
+}
+
+static void led_gpio_stop_blink(const struct device *dev, uint32_t led)
+{
+	struct led_gpio_data *data = dev->data;
+
+	k_timer_stop(&data->blink_timer[led]);
+}
+
+static void led_gpio_blink_init(const struct device *dev, uint32_t led)
+{
+	struct led_gpio_data *data = dev->data;
+
+	k_timer_init(&data->blink_timer[led], led_gpio_timer_cb, NULL);
+	k_timer_user_data_set(&data->blink_timer[led], (void *)data);
+}
+#else
+static void led_gpio_stop_blink(const struct device *dev, uint32_t led) {}
+static void led_gpio_blink_init(const struct device *dev, uint32_t led) {}
+#endif /* CONFIG_LED_GPIO_BLINK */
+
 static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
 {
 
@@ -41,11 +100,13 @@ static int led_gpio_set_brightness(const struct device *dev, uint32_t led, uint8
 
 static int led_gpio_on(const struct device *dev, uint32_t led)
 {
+	led_gpio_stop_blink(dev, led);
 	return led_gpio_set_brightness(dev, led, 100);
 }
 
 static int led_gpio_off(const struct device *dev, uint32_t led)
 {
+	led_gpio_stop_blink(dev, led);
 	return led_gpio_set_brightness(dev, led, 0);
 }
 
@@ -62,6 +123,7 @@ static int led_gpio_init(const struct device *dev)
 	for (size_t i = 0; (i < config->num_leds) && !err; i++) {
 		const struct gpio_dt_spec *led = &config->led[i];
 
+		led_gpio_blink_init(dev, i);
 		if (device_is_ready(led->port)) {
 			err = gpio_pin_configure_dt(led, GPIO_OUTPUT_INACTIVE);
 
@@ -81,22 +143,53 @@ static DEVICE_API(led, led_gpio_api) = {
 	.on		= led_gpio_on,
 	.off		= led_gpio_off,
 	.set_brightness	= led_gpio_set_brightness,
+#ifdef CONFIG_LED_GPIO_BLINK
+	.blink		= led_gpio_blink,
+#endif
 };
 
-#define LED_GPIO_DEVICE(i)					\
+#define LED_GPIO_BLINK_DATA(i, count)				\
+static struct k_timer blink_timers_##i[count];                  \
+static uint32_t delay_on_##i[count];	                        \
+static uint32_t delay_off_##i[count];	                        \
+static struct led_gpio_data led_gpio_data_##i = {		\
+	.config		= &led_gpio_config_##i,			\
+	.blink_timer	= blink_timers_##i,			\
+	.delay_on	= delay_on_##i,				\
+	.delay_off	= delay_off_##i,			\
+};								\
+BUILD_ASSERT(ARRAY_SIZE(gpio_dt_spec_##i) <= MAX_GPIO_LEDS);
+
+#define LED_GPIO_CONFIG(i)					\
 								\
 static const struct gpio_dt_spec gpio_dt_spec_##i[] = {		\
 	DT_INST_FOREACH_CHILD_SEP_VARGS(i, GPIO_DT_SPEC_GET, (,), gpios) \
 };								\
 								\
 static const struct led_gpio_config led_gpio_config_##i = {	\
-	.num_leds	= ARRAY_SIZE(gpio_dt_spec_##i),	\
+	.num_leds	= ARRAY_SIZE(gpio_dt_spec_##i),		\
 	.led		= gpio_dt_spec_##i,			\
 };								\
+
+
+#ifdef CONFIG_LED_GPIO_BLINK
+#define LED_GPIO_DEVICE(i)					\
+LED_GPIO_CONFIG(i);						\
+LED_GPIO_BLINK_DATA(i, ARRAY_SIZE(gpio_dt_spec_##i));		\
+								\
+DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,			\
+		      &led_gpio_data_##i, &led_gpio_config_##i,	\
+		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
+		      &led_gpio_api);
+#else /* CONFIG_LED_GPIO_BLINK */
+#define LED_GPIO_DEVICE(i)					\
+LED_GPIO_CONFIG(i);						\
 								\
 DEVICE_DT_INST_DEFINE(i, &led_gpio_init, NULL,			\
 		      NULL, &led_gpio_config_##i,		\
 		      POST_KERNEL, CONFIG_LED_INIT_PRIORITY,	\
 		      &led_gpio_api);
+#endif /* CONFIG_LED_GPIO_BLINK */
+
 
 DT_INST_FOREACH_STATUS_OKAY(LED_GPIO_DEVICE)

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -123,6 +123,17 @@ __subsystem struct led_driver_api {
 	led_api_write_channels write_channels;
 };
 
+#ifdef CONFIG_LED_BLINK_FALLBACK
+int led_blink_fallback(const struct device *dev, uint32_t led, uint32_t delay_on,
+		       uint32_t delay_off);
+#else
+static inline int led_blink_fallback(const struct device *dev, uint32_t led, uint32_t delay_on,
+				     uint32_t delay_off)
+{
+	return -ENOSYS;
+}
+#endif
+
 /**
  * @brief Blink an LED
  *
@@ -145,7 +156,7 @@ static inline int z_impl_led_blink(const struct device *dev, uint32_t led,
 		(const struct led_driver_api *)dev->api;
 
 	if (api->blink == NULL) {
-		return -ENOSYS;
+		return led_blink_fallback(dev, led, delay_on, delay_off);
 	}
 	return api->blink(dev, led, delay_on, delay_off);
 }
@@ -308,6 +319,7 @@ static inline int z_impl_led_on(const struct device *dev, uint32_t led)
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
+	led_blink_fallback(dev, led, 0, 0);
 	return api->on(dev, led);
 }
 
@@ -327,6 +339,7 @@ static inline int z_impl_led_off(const struct device *dev, uint32_t led)
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
+	led_blink_fallback(dev, led, 0, 0);
 	return api->off(dev, led);
 }
 


### PR DESCRIPTION
The led_api_blink is quite convenient to use.
This adds its support to the led_gpio driver.