### PR TITLE
boards: openocd: Use manufacturer specific openocd configuration for ST boards

### DIFF
--- a/boards/common/openocd-stm32.board.cmake
+++ b/boards/common/openocd-stm32.board.cmake
@@ -18,3 +18,5 @@ elseif(CONFIG_SOC_SERIES_STM32F2X OR
        CONFIG_SOC_SERIES_STM32F7X)
   board_runner_args(openocd "--cmd-erase=stm32f2x mass_erase 0")
 endif()
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/common/openocd.board.cmake
+++ b/boards/common/openocd.board.cmake
@@ -20,6 +20,3 @@ board_finalize_runner_args(openocd
   --cmd-load "${OPENOCD_CMD_LOAD_DEFAULT}"
   --cmd-verify "${OPENOCD_CMD_VERIFY_DEFAULT}"
   )
-
-# Manufacturer common options
-include(${CMAKE_CURRENT_LIST_DIR}/openocd-stm32.board.cmake)

--- a/boards/others/stm32f103_mini/board.cmake
+++ b/boards/others/stm32f103_mini/board.cmake
@@ -2,5 +2,5 @@
 
 board_runner_args(jlink "--device=STM32F103RC" "--speed=4000")
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/b_l072z_lrwan1/board.cmake
+++ b/boards/st/b_l072z_lrwan1/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L072CZ" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/b_l4s5i_iot01a/board.cmake
+++ b/boards/st/b_l4s5i_iot01a/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L4S5VI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/b_u585i_iot02a/board.cmake
+++ b/boards/st/b_u585i_iot02a/board.cmake
@@ -30,5 +30,5 @@ board_runner_args(jlink "--device=STM32U585AI" "--reset-after-load")
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 # FIXME: openocd runner requires use of STMicro openocd fork.
 # Check board documentation for more details.
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/disco_l475_iot1/board.cmake
+++ b/boards/st/disco_l475_iot1/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L475VG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_c071rb/board.cmake
+++ b/boards/st/nucleo_c071rb/board.cmake
@@ -5,4 +5,4 @@ board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/nucleo_f030r8/board.cmake
+++ b/boards/st/nucleo_f030r8/board.cmake
@@ -7,6 +7,6 @@ board_runner_args(probe-rs "--chip=STM32F030R8Tx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)

--- a/boards/st/nucleo_f031k6/board.cmake
+++ b/boards/st/nucleo_f031k6/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F031K6" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f042k6/board.cmake
+++ b/boards/st/nucleo_f042k6/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F042K6" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f070rb/board.cmake
+++ b/boards/st/nucleo_f070rb/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F070RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f072rb/board.cmake
+++ b/boards/st/nucleo_f072rb/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F072RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f091rc/board.cmake
+++ b/boards/st/nucleo_f091rc/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F091RC" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f103rb/board.cmake
+++ b/boards/st/nucleo_f103rb/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F103RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f207zg/board.cmake
+++ b/boards/st/nucleo_f207zg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F207ZG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f302r8/board.cmake
+++ b/boards/st/nucleo_f302r8/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F302R8" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f303k8/board.cmake
+++ b/boards/st/nucleo_f303k8/board.cmake
@@ -10,5 +10,5 @@ board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f303re/board.cmake
+++ b/boards/st/nucleo_f303re/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F303RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f334r8/board.cmake
+++ b/boards/st/nucleo_f334r8/board.cmake
@@ -10,5 +10,5 @@ board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f401re/board.cmake
+++ b/boards/st/nucleo_f401re/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F401RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f410rb/board.cmake
+++ b/boards/st/nucleo_f410rb/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F410RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f411re/board.cmake
+++ b/boards/st/nucleo_f411re/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F411RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f412zg/board.cmake
+++ b/boards/st/nucleo_f412zg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F412ZG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f413zh/board.cmake
+++ b/boards/st/nucleo_f413zh/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F413ZH" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f429zi/board.cmake
+++ b/boards/st/nucleo_f429zi/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F429ZI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f439zi/board.cmake
+++ b/boards/st/nucleo_f439zi/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F439ZI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f446re/board.cmake
+++ b/boards/st/nucleo_f446re/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F446RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f446ze/board.cmake
+++ b/boards/st/nucleo_f446ze/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F446ZE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f722ze/board.cmake
+++ b/boards/st/nucleo_f722ze/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F722ZE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f746zg/board.cmake
+++ b/boards/st/nucleo_f746zg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F746ZG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f756zg/board.cmake
+++ b/boards/st/nucleo_f756zg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F756ZG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_f767zi/board.cmake
+++ b/boards/st/nucleo_f767zi/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F767ZI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g031k8/board.cmake
+++ b/boards/st/nucleo_g031k8/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32G031K8" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g070rb/board.cmake
+++ b/boards/st/nucleo_g070rb/board.cmake
@@ -9,6 +9,6 @@ board_runner_args(jlink "--device=STM32G070RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g071rb/board.cmake
+++ b/boards/st/nucleo_g071rb/board.cmake
@@ -9,6 +9,6 @@ board_runner_args(jlink "--device=STM32G071RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g0b1re/board.cmake
+++ b/boards/st/nucleo_g0b1re/board.cmake
@@ -10,6 +10,6 @@ board_runner_args(jlink "--device=STM32G0B1RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g431kb/board.cmake
+++ b/boards/st/nucleo_g431kb/board.cmake
@@ -8,5 +8,5 @@ board_runner_args(jlink "--device=STM32G431KB" "--speed=4000")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g431rb/board.cmake
+++ b/boards/st/nucleo_g431rb/board.cmake
@@ -8,5 +8,5 @@ board_runner_args(jlink "--device=STM32G431RB" "--speed=4000")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_g474re/board.cmake
+++ b/boards/st/nucleo_g474re/board.cmake
@@ -7,6 +7,6 @@ board_runner_args(jlink "--device=STM32G474RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_h503rb/board.cmake
+++ b/boards/st/nucleo_h503rb/board.cmake
@@ -12,5 +12,5 @@ board_runner_args(pyocd "--target=stm32h503rbtx")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 # FIXME: official openocd runner not yet available.

--- a/boards/st/nucleo_h533re/board.cmake
+++ b/boards/st/nucleo_h533re/board.cmake
@@ -15,5 +15,5 @@ board_runner_args(openocd "--no-halt")
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 # FIXME: official openocd runner not yet available.

--- a/boards/st/nucleo_h563zi/board.cmake
+++ b/boards/st/nucleo_h563zi/board.cmake
@@ -15,5 +15,5 @@ board_runner_args(openocd "--no-halt")
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
-#include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+#include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 # FIXME: official openocd runner not yet available.

--- a/boards/st/nucleo_h723zg/board.cmake
+++ b/boards/st/nucleo_h723zg/board.cmake
@@ -7,5 +7,5 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_h743zi/board.cmake
+++ b/boards/st/nucleo_h743zi/board.cmake
@@ -9,6 +9,6 @@ board_runner_args(pyocd "--target=stm32h743zitx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/nucleo_h745zi_q/board.cmake
+++ b/boards/st/nucleo_h745zi_q/board.cmake
@@ -12,5 +12,5 @@ endif()
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_h753zi/board.cmake
+++ b/boards/st/nucleo_h753zi/board.cmake
@@ -7,5 +7,5 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_h755zi_q/board.cmake
+++ b/boards/st/nucleo_h755zi_q/board.cmake
@@ -11,5 +11,5 @@ endif()
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_h7a3zi_q/board.cmake
+++ b/boards/st/nucleo_h7a3zi_q/board.cmake
@@ -7,5 +7,5 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_h7s3l8/board.cmake
+++ b/boards/st/nucleo_h7s3l8/board.cmake
@@ -7,4 +7,4 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/nucleo_l011k4/board.cmake
+++ b/boards/st/nucleo_l011k4/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L011K4" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l031k6/board.cmake
+++ b/boards/st/nucleo_l031k6/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L031K6" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l053r8/board.cmake
+++ b/boards/st/nucleo_l053r8/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L053R8" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l073rz/board.cmake
+++ b/boards/st/nucleo_l073rz/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L073RZ" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l152re/board.cmake
+++ b/boards/st/nucleo_l152re/board.cmake
@@ -5,4 +5,4 @@ board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/nucleo_l412rb_p/board.cmake
+++ b/boards/st/nucleo_l412rb_p/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L412RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l432kc/board.cmake
+++ b/boards/st/nucleo_l432kc/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L432KC" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l433rc_p/board.cmake
+++ b/boards/st/nucleo_l433rc_p/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L433RC" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l452re/board.cmake
+++ b/boards/st/nucleo_l452re/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L452RE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l476rg/board.cmake
+++ b/boards/st/nucleo_l476rg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L476RG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l496zg/board.cmake
+++ b/boards/st/nucleo_l496zg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L496ZG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l4a6zg/board.cmake
+++ b/boards/st/nucleo_l4a6zg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L4A6ZG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l4r5zi/board.cmake
+++ b/boards/st/nucleo_l4r5zi/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L4R5ZI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_l552ze_q/board.cmake
+++ b/boards/st/nucleo_l552ze_q/board.cmake
@@ -24,4 +24,4 @@ board_runner_args(pyocd "--target=stm32l552zetxq")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/nucleo_u575zi_q/board.cmake
+++ b/boards/st/nucleo_u575zi_q/board.cmake
@@ -11,6 +11,6 @@ board_runner_args(jlink "--device=STM32U575ZI" "--reset-after-load")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_u5a5zj_q/board.cmake
+++ b/boards/st/nucleo_u5a5zj_q/board.cmake
@@ -11,6 +11,6 @@ board_runner_args(jlink "--device=STM32U5A5ZJ" "--reset-after-load")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/nucleo_wb05kz/board.cmake
+++ b/boards/st/nucleo_wb05kz/board.cmake
@@ -5,5 +5,5 @@ board_runner_args(pyocd "--target=stm32wb05kzvx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/nucleo_wb07cc/board.cmake
+++ b/boards/st/nucleo_wb07cc/board.cmake
@@ -5,5 +5,5 @@ board_runner_args(pyocd "--target=stm32wb07ccvx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/nucleo_wb55rg/board.cmake
+++ b/boards/st/nucleo_wb55rg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(pyocd "--target=stm32wb55rgvx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/nucleo_wba55cg/board.cmake
+++ b/boards/st/nucleo_wba55cg/board.cmake
@@ -3,4 +3,4 @@ board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/nucleo_wba65ri/board.cmake
+++ b/boards/st/nucleo_wba65ri/board.cmake
@@ -3,4 +3,4 @@
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/nucleo_wl55jc/board.cmake
+++ b/boards/st/nucleo_wl55jc/board.cmake
@@ -5,4 +5,4 @@ board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/st25dv_mb1283_disco/board.cmake
+++ b/boards/st/st25dv_mb1283_disco/board.cmake
@@ -2,5 +2,5 @@
 
 board_runner_args(jlink "--device=STM32F405RG" "--speed=4000")
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/steval_fcu001v1/board.cmake
+++ b/boards/st/steval_fcu001v1/board.cmake
@@ -2,7 +2,7 @@
 
 board_runner_args(jlink "--device=STM32F401CC" "--speed=4000")
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 
 

--- a/boards/st/steval_stwinbx1/board.cmake
+++ b/boards/st/steval_stwinbx1/board.cmake
@@ -16,4 +16,4 @@ board_runner_args(openocd "--no-halt")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/stm3210c_eval/board.cmake
+++ b/boards/st/stm3210c_eval/board.cmake
@@ -2,5 +2,5 @@
 
 board_runner_args(jlink "--device=STM32F107VC" "--speed=4000")
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32373c_eval/board.cmake
+++ b/boards/st/stm32373c_eval/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F373VC" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f072_eval/board.cmake
+++ b/boards/st/stm32f072_eval/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F072VB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f072b_disco/board.cmake
+++ b/boards/st/stm32f072b_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F072RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f0_disco/board.cmake
+++ b/boards/st/stm32f0_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F051R8" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f3_disco/board.cmake
+++ b/boards/st/stm32f3_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F303VC" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f411e_disco/board.cmake
+++ b/boards/st/stm32f411e_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F411VE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f412g_disco/board.cmake
+++ b/boards/st/stm32f412g_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F412ZG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f413h_disco/board.cmake
+++ b/boards/st/stm32f413h_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F413ZH" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f429i_disc1/board.cmake
+++ b/boards/st/stm32f429i_disc1/board.cmake
@@ -9,6 +9,6 @@ board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/stm32f469i_disco/board.cmake
+++ b/boards/st/stm32f469i_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F469NI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f4_disco/board.cmake
+++ b/boards/st/stm32f4_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F407VG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f723e_disco/board.cmake
+++ b/boards/st/stm32f723e_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F723IE" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f746g_disco/board.cmake
+++ b/boards/st/stm32f746g_disco/board.cmake
@@ -8,5 +8,5 @@ board_runner_args(jlink "--device=STM32F746NG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f7508_dk/board.cmake
+++ b/boards/st/stm32f7508_dk/board.cmake
@@ -7,5 +7,5 @@ board_runner_args(jlink "--device=STM32F750N8" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32f769i_disco/board.cmake
+++ b/boards/st/stm32f769i_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F769NI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32g0316_disco/board.cmake
+++ b/boards/st/stm32g0316_disco/board.cmake
@@ -7,6 +7,6 @@ board_runner_args(jlink "--device=STM32G031J6" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -20,5 +20,5 @@ board_runner_args(openocd "--no-halt")
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 # FIXME: official openocd runner not yet available.

--- a/boards/st/stm32h735g_disco/board.cmake
+++ b/boards/st/stm32h735g_disco/board.cmake
@@ -8,5 +8,5 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h745i_disco/board.cmake
+++ b/boards/st/stm32h745i_disco/board.cmake
@@ -19,5 +19,5 @@ endif()
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h747i_disco/board.cmake
+++ b/boards/st/stm32h747i_disco/board.cmake
@@ -21,5 +21,5 @@ endif()
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h750b_dk/board.cmake
+++ b/boards/st/stm32h750b_dk/board.cmake
@@ -13,5 +13,5 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h757i_eval/board.cmake
+++ b/boards/st/stm32h757i_eval/board.cmake
@@ -17,5 +17,5 @@ endif()
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h7b3i_dk/board.cmake
+++ b/boards/st/stm32h7b3i_dk/board.cmake
@@ -14,5 +14,5 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32h7s78_dk/board.cmake
+++ b/boards/st/stm32h7s78_dk/board.cmake
@@ -7,4 +7,4 @@ board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 # FIXME: openocd runner not yet available.
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/stm32l1_disco/board.cmake
+++ b/boards/st/stm32l1_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L151RB" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32l476g_disco/board.cmake
+++ b/boards/st/stm32l476g_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L476VG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32l496g_disco/board.cmake
+++ b/boards/st/stm32l496g_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L496AG" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32l4r9i_disco/board.cmake
+++ b/boards/st/stm32l4r9i_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32L4R9AI" "--speed=4000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32l562e_dk/board.cmake
+++ b/boards/st/stm32l562e_dk/board.cmake
@@ -20,5 +20,5 @@ board_runner_args(jlink "--device=STM32L562QE" "--speed=4000")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32mp135f_dk/board.cmake
+++ b/boards/st/stm32mp135f_dk/board.cmake
@@ -1,6 +1,6 @@
 # Copyright (c) 2025 STMicroelectronics
 # SPDX-License-Identifier: Apache-2.0
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd.cfg")

--- a/boards/st/stm32mp157c_dk2/board.cmake
+++ b/boards/st/stm32mp157c_dk2/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd.cfg")

--- a/boards/st/stm32u5a9j_dk/board.cmake
+++ b/boards/st/stm32u5a9j_dk/board.cmake
@@ -10,4 +10,4 @@ board_runner_args(openocd "--no-halt")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/stm32u5g9j_dk1/board.cmake
+++ b/boards/st/stm32u5g9j_dk1/board.cmake
@@ -10,4 +10,4 @@ board_runner_args(openocd "--no-halt")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/stm32u5g9j_dk2/board.cmake
+++ b/boards/st/stm32u5g9j_dk2/board.cmake
@@ -10,4 +10,4 @@ board_runner_args(openocd "--no-halt")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/stm32vl_disco/board.cmake
+++ b/boards/st/stm32vl_disco/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(jlink "--device=STM32F100RB" "--speed=8000")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/st/stm32wb5mm_dk/board.cmake
+++ b/boards/st/stm32wb5mm_dk/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(pyocd "--target=stm32wb55vgyx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/st/stm32wb5mmg/board.cmake
+++ b/boards/st/stm32wb5mmg/board.cmake
@@ -6,5 +6,5 @@ board_runner_args(pyocd "--target=stm32wb55vgyx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -79,6 +79,10 @@ Boards
 * Espressif boards ``esp32_devkitc_wroom`` and ``esp32_devkitc_wrover`` shared almost identical features.
   The differences are covered by the Kconfig options so both boards were merged into ``esp32_devkitc``.
 
+* STM32 boards should now add OpenOCD programming support by including ``openocd-stm32.board.cmake``
+  instead of ``openocd.board.cmake``. The ``openocd-stm32.board.cmake`` file extends the default
+  OpenOCD runner with manufacturer-specific configuration like STM32 mass erase commands.
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
The OpenOCD STM32-specific configuration was included into the common configuration, which was then used in board files. Follow nRF5 convention instead: use manufacturer-specific config in boards.

Also due to the fact that the include of STM32-specific config was placed *after* board_finalize_runner_args() it didn't really work anyways.