### PR TITLE
drivers: flash: stm32: fix FLASH_ constants renamed in hal_stm32

### DIFF
--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -55,8 +55,6 @@ struct flash_stm32_priv {
 #define FLASH_CR_SNB FLASH_CR_SSN
 #define FLASH_CR_SNB_Pos FLASH_CR_SSN_Pos
 #define KEYR1 KEYR
-#define FLASH_OPT_KEY1 FLASH_OPTKEY1
-#define FLASH_OPT_KEY2 FLASH_OPTKEY2
 #endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
 /* Differentiate between arm trust-zone non-secure/secure, and others. */


### PR DESCRIPTION
In hal_stm32 commit "update stm32h7rs to cube version V1.2.0"
https://github.com/zephyrproject-rtos/hal_stm32/commit/e5eba65b7674d2883817203856b1d5eb8d08132d
the constants FLASH_OPTKEY1/2 for the STM32H7RS have been renamed to
FLASH_OPT_KEY1/2. For backward compatibility, 2 defines have been added
to Legacy/stm32_hal_legacy.h, so that FLASH_OPTKEYx is an alias for
FLASH_OPT_KEYx.

However, in Zephyr's STM32 flash driver, the alias is defined the other
way around since 5dc537389a4844cd36c5a29035e32b2c30d2e9fc, which leads to
Twister build failures, for example
https://github.com/zephyrproject-rtos/zephyr/actions/runs/14927867714/job/41936931524#step:12:1335

To fix the build issue, we can simply remove that alias in Zephyr, since
it is no longer needed.

Signed-off-by: Titouan Christophe <titouan.christophe@mind.be>
