### PR TITLE
scripts: runners: nrfutil: Check return code after Popen

### DIFF
--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -96,6 +96,8 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
                         raise subprocess.CalledProcessError(
                             jout['data']['error']['code'], cmd
                         )
+        if p.returncode != 0:
+            raise subprocess.CalledProcessError(p.returncode, cmd)
 
         return jout_all
 

--- a/scripts/west_commands/tests/test_nrf.py
+++ b/scripts/west_commands/tests/test_nrf.py
@@ -414,6 +414,7 @@ def check_expected(tool, test_case, check_fn, get_snr, tmpdir, runner_config):
 def test_init(check_call, popen, get_snr, require, tool, test_case,
               runner_config, tmpdir):
     popen.return_value.__enter__.return_value.stdout = io.BytesIO(b'')
+    popen.return_value.__enter__.return_value.returncode = 0
 
     require.side_effect = functools.partial(require_patch, tool)
     runner_config = fix_up_runner_config(test_case, runner_config, tmpdir)
@@ -447,6 +448,7 @@ def test_init(check_call, popen, get_snr, require, tool, test_case,
 def test_create(check_call, popen, get_snr, require, tool, test_case,
                 runner_config, tmpdir):
     popen.return_value.__enter__.return_value.stdout = io.BytesIO(b'')
+    popen.return_value.__enter__.return_value.returncode = 0
 
     require.side_effect = functools.partial(require_patch, tool)
     runner_config = fix_up_runner_config(test_case, runner_config, tmpdir)


### PR DESCRIPTION
The code invoking nrfutil was not checking the return code of the subprocess, which meant that if the underlying tool was exiting with a failure error code it remained undetected.