### PR TITLE
drivers: rtc: api: adjust callback APIs to not be syscalls

### DIFF
--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -368,11 +368,8 @@ static inline int z_impl_rtc_alarm_is_pending(const struct device *dev, uint16_t
  * @return -ENOTSUP if API is not supported by hardware
  * @return -errno code if failure
  */
-__syscall int rtc_alarm_set_callback(const struct device *dev, uint16_t id,
-				     rtc_alarm_callback callback, void *user_data);
-
-static inline int z_impl_rtc_alarm_set_callback(const struct device *dev, uint16_t id,
-						rtc_alarm_callback callback, void *user_data)
+static inline int rtc_alarm_set_callback(const struct device *dev, uint16_t id,
+					 rtc_alarm_callback callback, void *user_data)
 {
 	if (DEVICE_API_GET(rtc, dev)->alarm_set_callback == NULL) {
 		return -ENOSYS;
@@ -411,11 +408,8 @@ static inline int z_impl_rtc_alarm_set_callback(const struct device *dev, uint16
  * @return -ENOTSUP if API is not supported by hardware
  * @return -errno code if failure
  */
-__syscall int rtc_update_set_callback(const struct device *dev, rtc_update_callback callback,
-				      void *user_data);
-
-static inline int z_impl_rtc_update_set_callback(const struct device *dev,
-						 rtc_update_callback callback, void *user_data)
+static inline int rtc_update_set_callback(const struct device *dev,
+					  rtc_update_callback callback, void *user_data)
 {
 	if (DEVICE_API_GET(rtc, dev)->update_set_callback == NULL) {
 		return -ENOSYS;


### PR DESCRIPTION
The rtc device driver APIs rtc_update_set_callback and rtc_alarm_set_callback are not allowed from usermode threads, thus they should not be marked as syscalls. The APIs where never implemented as sycalls, there is no z_vrfy wrapper for them, so only change needed is to not mark them as syscalls with the special __syscall "attribute" and z_impl wrapper.