### PR TITLE
tests: posix: xsi_realtime: bump min_ram to 96k

### DIFF
--- a/tests/posix/xsi_realtime/testcase.yaml
+++ b/tests/posix/xsi_realtime/testcase.yaml
@@ -9,6 +9,10 @@ common:
     - simulation
   min_flash: 64
   min_ram: 96
+  integration_platforms:
+    - qemu_x86
+    - qemu_cortex_a53
+    - qemu_riscv64
   platform_exclude:
     # linker_zephyr_pre0.cmd:140: syntax error (??)
     - qemu_xtensa/dc233c

--- a/tests/posix/xsi_realtime/testcase.yaml
+++ b/tests/posix/xsi_realtime/testcase.yaml
@@ -8,8 +8,7 @@ common:
     - arch
     - simulation
   min_flash: 64
-  min_ram: 32
-  timeout: 240
+  min_ram: 96
   platform_exclude:
     # linker_zephyr_pre0.cmd:140: syntax error (??)
     - qemu_xtensa/dc233c


### PR DESCRIPTION
The xsi_realtime testsuite now includes tests for `fsync()` and `fdatasync()` which require a ram-based fat filesystem.

Technically speaking, it would probably not be 100% necessary to use a ramdisk to test these functions, but then the test would be limited to running on platforms with some file-system based storage.

The timeout was removed, since it did not seem like any of the functions under test would block for an abnormal amount of time, and it was likely just copy-pasta from 6b3750f73c24cfd35432f7ab1fa2348593e5132e.

Additionally, add integration platforms for the xsi_realtime testsuite.

Fixes #89485