### PR TITLE
drivers: flash: xspi: Put delay block config under specific bit

### DIFF
--- a/drivers/flash/flash_stm32_xspi.c
+++ b/drivers/flash/flash_stm32_xspi.c
@@ -2187,7 +2187,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 
 #endif /* XSPIM */
 
-#if defined(DLYB_XSPI1) || defined(DLYB_XSPI2) || defined(DLYB_OCTOSPI1) || defined(DLYB_OCTOSPI2)
+#if defined(XSPI_DCR1_DLYBYP)
 	/* XSPI delay block init Function */
 	HAL_XSPI_DLYB_CfgTypeDef xspi_delay_block_cfg = {0};
 
@@ -2201,7 +2201,7 @@ static int flash_stm32_xspi_init(const struct device *dev)
 	}
 
 	LOG_DBG("Delay Block Init");
-#endif /* DLYB_ */
+#endif /* XSPI_DCR1_DLYBYP */
 
 #if STM32_XSPI_USE_DMA
 	/* Configure and enable the DMA channels after XSPI config */


### PR DESCRIPTION
On some series, use of Delay Block could be possible on OSPI device but not on HSPI one (which uses this drivers).
As a quick fix check the presence of XSPI Delay Block by-pass configuration bit instead of the Delay Block presence.

Note: This fix works because we don't have cases today where this driver is used for OSPI and HSPI instances with mixed DLYB compatibility. This may have to be reviewed one day and may require a more complex fix with instantiable configuration, but this day may never come as well.