### PR TITLE
drivers: dp: fix build on M0 MCUs

### DIFF
--- a/drivers/dp/swdp_ll_pin.h
+++ b/drivers/dp/swdp_ll_pin.h
@@ -23,7 +23,8 @@
 static ALWAYS_INLINE void pin_delay_asm(uint32_t delay)
 {
 #if defined(CONFIG_CPU_CORTEX_M)
-	__asm volatile ("movs r3, %[p]\n"
+	__asm volatile (".syntax unified\n"
+			"movs r3, %[p]\n"
 			".start_%=:\n"
 			"subs r3, #1\n"
 			"bne .start_%=\n"

--- a/samples/subsys/dap/sample.yaml
+++ b/samples/subsys/dap/sample.yaml
@@ -9,4 +9,5 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - frdm_k64f
+      - nucleo_c071rb
     tags: dap


### PR DESCRIPTION
Current code does not build on Cortex-M0, seems like it does not like subs:

Error: instruction not supported in Thumb16 mode -- `subs r3,#1'

Replace the instruction with a sub and cmp, add an M0+ board so this is tested in CI.