### PR TITLE
LVGL: input: fix input devices binding to displays

### DIFF
--- a/modules/lvgl/input/lvgl_common_input.c
+++ b/modules/lvgl/input/lvgl_common_input.c
@@ -52,7 +52,8 @@ static lv_display_t *lvgl_input_get_display(const struct device *dev)
 	lv_display_t *lv_disp = NULL;
 
 	if (disp_dev == NULL) {
-		return NULL;
+		LOG_DBG("No display phandle is passed in DT, defaulting to LV Default Display");
+		return lv_display_get_default();
 	}
 
 	for (int i = 0; i < DT_ZEPHYR_DISPLAYS_COUNT; i++) {


### PR DESCRIPTION
When no `display` property is present in LVGL input device node in DT, we should default to binding the device to LVGL Default Display to preserve the old behavior and not break LVGL Input on setups with only one display.

Fixes a regression introduced by #86815 