### PR TITLE
boards: devicetree: replace 'zephyr,touch' chosen property with the 'touch' DT alias

### DIFF
--- a/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
+++ b/boards/ezurio/bl5340_dvk/bl5340_dvk_nrf5340_cpuapp_common.dtsi
@@ -16,7 +16,6 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,display = &ili9340;
 		zephyr,bt-hci = &bt_hci_ipc0;
-		zephyr,touch = &ft5336;
 	};
 
 	/* Main LEDs and buttons are on an I2C TCA9538 GPIO port expander */
@@ -106,6 +105,7 @@
 		watchdog0 = &wdt0;
 		accel0 = &lis3dh;
 		bbram0 = &extrtc0;
+		touch = &ft5336;
 	};
 
 	mipi_dbi {

--- a/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
+++ b/boards/lilygo/twatch_s3/twatch_s3_procpu.dts
@@ -20,6 +20,7 @@
 		watchdog0 = &wdt0;
 		rtc = &pfc8563_rtc;
 		pwm-led0 = &backlight_pwm;
+		touch = &ft5336;
 	};
 
 	chosen {
@@ -30,7 +31,6 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &esp32_bt_hci;
 		zephyr,display = &st7789v;
-		zephyr,touch = &ft5336;
 		zephyr,ipc_shm = &shm0;
 		zephyr,ipc = &ipm0;
 	};

--- a/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
+++ b/boards/m5stack/m5stack_core2/m5stack_core2_procpu.dts
@@ -25,6 +25,7 @@
 		rtc = &pfc8563_rtc;
 		led0 = &led_pwr;
 		sdhc0 = &sd0;
+		touch = &ft5336_touch;
 	};
 
 	chosen {
@@ -36,7 +37,6 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,rtc = &pfc8563_rtc;
 		zephyr,bt-hci = &esp32_bt_hci;
-		zephyr,touch = &ft5336_touch;
 	};
 
 	leds {

--- a/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
+++ b/boards/m5stack/m5stack_cores3/m5stack_cores3_procpu_common.dtsi
@@ -19,7 +19,6 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,rtc = &bm8563_rtc;
 		zephyr,bt-hci = &esp32_bt_hci;
-		zephyr,touch = &ft6336_touch;
 	};
 
 	aliases {
@@ -32,6 +31,7 @@
 		rtc = &bm8563_rtc;
 		sdhc0 = &sd0;
 		led0 = &axp2101_led;
+		touch = &ft6336_touch;
 	};
 
 	lvgl_pointer {

--- a/boards/native/native_sim/native_sim.dts
+++ b/boards/native/native_sim/native_sim.dts
@@ -25,7 +25,6 @@
 		zephyr,canbus = &can_loopback0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_userchan;
-		zephyr,touch = &input_sdl_touch;
 	};
 
 	aliases {
@@ -34,6 +33,7 @@
 		spi-0 = &spi0;
 		led0 = &led0;
 		rtc = &rtc;
+		touch = &input_sdl_touch;
 	};
 
 	leds {

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -21,6 +21,7 @@
 		watchdog0 = &wdog0;
 		sdhc0 = &usdhc1;
 		mcuboot-button0 = &user_button;
+		touch = &ft5336;
 	};
 
 	chosen {
@@ -34,7 +35,6 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
-		zephyr,touch = &ft5336;
 	};
 
 	sdram0: memory@80000000 {

--- a/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
+++ b/boards/nxp/rd_rw612_bga/dts/goworld_16880_lcm.overlay
@@ -3,7 +3,6 @@
 / {
 	chosen {
 		zephyr,display = &st7796s_lcdic;
-		zephyr,touch = &ft7401;
 	};
 
 	lvgl_pointer {
@@ -11,6 +10,10 @@
 		input = <&ft7401>;
 		swap-xy;
 		invert-y;
+	};
+
+	aliases {
+		touch = &ft7401;
 	};
 };
 

--- a/boards/pine64/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/pine64/pinetime_devkit0/pinetime_devkit0.dts
@@ -27,7 +27,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &st7789v;
-		zephyr,touch = &cst816s;
 	};
 
 	aliases {
@@ -37,6 +36,7 @@
 		led3 = &statusled;	/* status led, may be not populated */
 		sw0 = &key_in;  /* key in */
 		watchdog0 = &wdt0;
+		touch = &cst816s;
 	};
 
 	leds {

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_lcdc.overlay
@@ -10,13 +10,16 @@
 / {
 	chosen {
 		zephyr,display = &lcdc;
-		zephyr,touch = &display_touch;
 	};
 
 	lvgl_pointer {
 		input = <&display_touch>;
 		status = "okay";
 		swap-xy;
+	};
+
+	aliases {
+		touch = &display_touch;
 	};
 };
 

--- a/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
+++ b/boards/renesas/da1469x_dk_pro/dts/da1469x_dk_pro_mipi_dbi.overlay
@@ -10,7 +10,6 @@
 / {
 	chosen {
 		zephyr,display = &ili9340;
-		zephyr,touch = &display_touch;
 	};
 
 	lvgl_pointer {
@@ -19,6 +18,10 @@
 		swap-xy;
 		invert-x;
 		invert-y;
+	};
+
+	aliases {
+		touch = &display_touch;
 	};
 };
 

--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -9,7 +9,6 @@
 / {
 	chosen {
 		zephyr,display = &adafruit_2_8_tft_touch_v2_ili9340;
-		zephyr,touch = &ft5336_adafruit_2_8_tft_touch_v2;
 	};
 
 	lvgl_pointer {
@@ -43,6 +42,10 @@
 			pgamctrl = [0f 31 2b 0c 0e 08 4e f1 37 07 10 03 0e 09 00];
 			ngamctrl = [00 0e 14 03 11 07 31 c1 48 08 0f 0c 31 36 0f];
 		};
+	};
+
+	aliases {
+		touch = &ft5336_adafruit_2_8_tft_touch_v2;
 	};
 };
 

--- a/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
+++ b/boards/shields/arduino_giga_display_shield/boards/arduino_giga_r1_m7.overlay
@@ -14,11 +14,11 @@
 
 	aliases {
 		accel0 = &gt911;
+		touch = &gt911;
 	};
 
 	chosen {
 		zephyr,display = &zephyr_lcd_controller;
-		zephyr,touch = &gt911;
 	};
 };
 

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -9,7 +9,6 @@
 / {
 	chosen {
 		zephyr,display = &ili9340_buydisplay_2_8_tft_touch_arduino;
-		zephyr,touch = &ft5336_buydisplay_2_8_tft_touch_arduino;
 	};
 
 	lvgl_pointer {
@@ -44,6 +43,10 @@
 			pgamctrl = [0f 31 2b 0c 0e 08 4e f1 37 07 10 03 0e 09 00];
 			ngamctrl = [00 0e 14 03 11 07 31 c1 48 08 0f 0c 31 36 0f];
 		};
+	};
+
+	aliases {
+		touch = &ft5336_buydisplay_2_8_tft_touch_arduino;
 	};
 };
 

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -9,7 +9,6 @@
 / {
 	chosen {
 		zephyr,display = &ili9488_buydisplay_3_5_tft_touch_arduino;
-		zephyr,touch = &ft5336_buydisplay_3_5_tft_touch_arduino;
 	};
 
 	lvgl_pointer {
@@ -43,6 +42,10 @@
 			pgamctrl = [00 03 09 08 16 0a 3f 78 4c 09 0a 08 16 1a 0f];
 			ngamctrl = [00 16 19 03 0f 05 32 45 46 04 0e 0d 35 37 0f];
 		};
+	};
+
+	aliases {
+		touch = &ft5336_buydisplay_3_5_tft_touch_arduino;
 	};
 };
 

--- a/boards/shields/g1120b0mipi/g1120b0mipi.overlay
+++ b/boards/shields/g1120b0mipi/g1120b0mipi.overlay
@@ -7,7 +7,6 @@
 /{
 	chosen {
 		zephyr,display = &rm67162_g1120b0mipi;
-		zephyr,touch = &ft3267_g1120b0mipi;
 	};
 
 	en_mipi_display_g1120b0mipi: enable-mipi-display {
@@ -22,6 +21,10 @@
 		input = <&ft3267_g1120b0mipi>;
 		display = <&rm67162_g1120b0mipi>;
 		invert-y;
+	};
+
+	aliases {
+		touch = &ft3267_g1120b0mipi;
 	};
 };
 

--- a/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_8080.overlay
@@ -9,7 +9,6 @@
 /{
 	chosen {
 		zephyr,display = &st7796s;
-		zephyr,touch = &gt911_lcd_par_s035;
 	};
 
 	lvgl_pointer {
@@ -17,6 +16,10 @@
 		input = <&gt911_lcd_par_s035>;
 		swap-xy;
 		invert-y;
+	};
+
+	aliases {
+		touch = &gt911_lcd_par_s035;
 	};
 };
 

--- a/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
+++ b/boards/shields/lcd_par_s035/lcd_par_s035_spi.overlay
@@ -10,7 +10,6 @@
 /{
 	chosen {
 		zephyr,display = &st7796s;
-		zephyr,touch = &gt911_lcd_par_s035;
 	};
 
 	lvgl_pointer {
@@ -18,6 +17,10 @@
 		input = <&gt911_lcd_par_s035>;
 		swap-xy;
 		invert-y;
+	};
+
+	aliases {
+		touch = &gt911_lcd_par_s035;
 	};
 };
 

--- a/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
+++ b/boards/shields/rk043fn02h_ct/rk043fn02h_ct.overlay
@@ -9,12 +9,15 @@
 /{
 	chosen {
 		zephyr,display = &zephyr_lcdif;
-		zephyr,touch = &ft5336_rk043fn02h_ct;
 	};
 
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&ft5336_rk043fn02h_ct>;
+	};
+
+	aliases {
+		touch = &ft5336_rk043fn02h_ct;
 	};
 };
 

--- a/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
+++ b/boards/shields/rk043fn66hs_ctg/rk043fn66hs_ctg.overlay
@@ -9,12 +9,15 @@
 /{
 	chosen {
 		zephyr,display = &zephyr_lcdif;
-		zephyr,touch = &gt911_rk043fn66hs_ctg;
 	};
 
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&gt911_rk043fn66hs_ctg>;
+	};
+
+	aliases {
+		touch = &gt911_rk043fn66hs_ctg;
 	};
 };
 

--- a/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
+++ b/boards/shields/rk055hdmipi4m/rk055hdmipi4m.overlay
@@ -9,7 +9,6 @@
 /{
 	chosen {
 		zephyr,display = &lcdif;
-		zephyr,touch = &gt911_rk055hdmipi4m;
 	};
 
 	en_mipi_display: enable-mipi-display {
@@ -22,6 +21,10 @@
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&gt911_rk055hdmipi4m>;
+	};
+
+	aliases {
+		touch = &gt911_rk055hdmipi4m;
 	};
 };
 

--- a/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
+++ b/boards/shields/rk055hdmipi4ma0/rk055hdmipi4ma0.overlay
@@ -9,7 +9,6 @@
 /{
 	chosen {
 		zephyr,display = &lcdif;
-		zephyr,touch = &gt911_rk055hdmipi4ma0;
 	};
 
 	en_mipi_display_rk055hdmipi4ma0: enable-mipi-display-rk055hdmipi4ma0 {
@@ -22,6 +21,10 @@
 	lvgl_pointer {
 		compatible = "zephyr,lvgl-pointer-input";
 		input = <&gt911_rk055hdmipi4ma0>;
+	};
+
+	aliases {
+		touch = &gt911_rk055hdmipi4ma0;
 	};
 };
 

--- a/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
+++ b/boards/shields/seeed_xiao_round_display/seeed_xiao_round_display.overlay
@@ -10,7 +10,6 @@
 / {
 	chosen {
 		zephyr,display = &gc9a01_xiao_round_display;
-		zephyr,touch = &chsc6x_xiao_round_display;
 	};
 
 	vbatt {
@@ -27,6 +26,7 @@
 
 	aliases {
 		rtc = &pcf8563_xiao_round_display;
+		touch = &chsc6x_xiao_round_display;
 	};
 
 	xiao_round_display_mipi_dbi {

--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -22,7 +22,6 @@
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;
 		zephyr,display = &ltdc;
-		zephyr,touch = &stmpe811;
 	};
 
 	sdram2: sdram@d0000000 {
@@ -59,6 +58,7 @@
 	aliases {
 		led0 = &green_led_3;
 		sw0 = &user_button;
+		touch = &stmpe811;
 	};
 
 	lvgl_pointer {

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -24,7 +24,6 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,flash-controller = &n25q128a1;
 		zephyr,display = &ltdc;
-		zephyr,touch = &ft5336;
 	};
 
 	leds {
@@ -71,6 +70,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		touch = &ft5336;
 	};
 };
 

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -24,7 +24,6 @@
 		zephyr,dtcm = &dtcm;
 		zephyr,flash-controller = &n25q128a1;
 		zephyr,display = &ltdc;
-		zephyr,touch = &ft5336;
 	};
 
 	leds {
@@ -62,6 +61,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		touch = &ft5336;
 	};
 };
 

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -22,7 +22,6 @@
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
 		zephyr,flash-controller = &mx25l51245g;
-		zephyr,touch = &ft6202;
 	};
 
 	sdram1: sdram@c0000000 {
@@ -77,6 +76,7 @@
 		led1 = &green_led_2;
 		led2 = &green_led_3;
 		sw0 = &user_button;
+		touch = &ft6202;
 	};
 
 	quadspi_memory_avail: memory-avail@90000000 {

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -22,7 +22,6 @@
 		zephyr,flash = &flash0;
 		zephyr,display = &ltdc;
 		zephyr,canbus = &fdcan1;
-		zephyr,touch = &ft5336;
 	};
 
 	leds {
@@ -104,6 +103,7 @@
 		led0 = &blue_led;
 		led1 = &red_led;
 		sw0 = &user_button;
+		touch = &ft5336;
 	};
 };
 

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -20,7 +20,6 @@
 		zephyr,sram = &axisram2;
 		zephyr,canbus = &fdcan1;
 		zephyr,display = &ltdc;
-		zephyr,touch = &gt911;
 		spi-flash0 = &mx66uw1g45g;
 		zephyr,flash-controller = &mx66uw1g45g;
 		zephyr,flash = &mx66uw1g45g;
@@ -29,6 +28,7 @@
 
 	aliases {
 		led0 = &green_led_1;
+		touch = &gt911;
 	};
 
 	lvgl_pointer {

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -21,7 +21,6 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ltdc;
-		zephyr,touch = &gt911;
 	};
 
 	leds {
@@ -57,6 +56,7 @@
 		die-temp0 = &die_temp;
 		volt-sensor0 = &vref1;
 		volt-sensor1 = &vbat4;
+		touch = &gt911;
 	};
 
 	ext_memory: memory@a0000000 {

--- a/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
+++ b/boards/waveshare/esp32s3_touch_lcd_1_28/esp32s3_touch_lcd_1_28_esp32s3_procpu.dts
@@ -22,6 +22,7 @@
 		sw0 = &button0;
 		uart-0 = &uart0;
 		watchdog0 = &wdt0;
+		touch = &cst816s;
 	};
 
 	chosen {
@@ -32,7 +33,6 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &gc9a01;
 		zephyr,bt-hci = &esp32_bt_hci;
-		zephyr,touch = &cst816s;
 	};
 
 	/* Buttons */

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -462,8 +462,6 @@ device.
    * - zephyr,led-strip
      - A LED-strip node which is used to determine the timings of the
        WS2812 GPIO driver
-   * - zephyr,touch
-     - touchscreen controller device node.
    * - mcuboot,ram-load-dev
      - When a Zephyr application is built to be loaded to RAM by MCUboot, with
        :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP_RAM_LOAD`,

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -102,6 +102,8 @@ Devicetree
   to more specific locations. Therefore, any dts files which ``#include <common/some_file.dtsi>``
   a file from in the zephyr tree will need to be changed to just ``#include <some_file.dtsi>``.
 
+* ``/chosen node`` ``zephyr,touch`` property has been replaced by the ``touch`` alias.
+
 * Silicon Labs SoC-level dts files for Series 2 have been reorganized in subdirectories per device
   superfamily. Therefore, any dts files for boards that use Series 2 SoCs will need to change their
   include from ``#include <silabs/some_soc.dtsi>`` to ``#include <silabs/xg2[1-9]/some_soc.dtsi>``.

--- a/samples/subsys/input/draw_touch_events/README.rst
+++ b/samples/subsys/input/draw_touch_events/README.rst
@@ -11,9 +11,9 @@ if the touch screen works for a board, examine its parameters such as inverted/s
 
 Building and Running
 ********************
-While this is a generic sample and it should work with any boards with both display controllers
-and touch controllers supported by Zephyr (provided the corresponding ``/chosen node`` properties
-are set i.e. ``zephyr,touch`` and ``zephyr,display``).
+This is a generic sample and it should work with any board with both a display controller
+and a touch controller supported by Zephyr (provided ``/chosen node`` ``zephyr,display`` property
+and ``touch`` alias are set in devicetree).
 Below is an example on how to build the sample for :zephyr:board:`stm32f746g_disco`:
 
 .. zephyr-app-commands::

--- a/samples/subsys/input/draw_touch_events/src/main.c
+++ b/samples/subsys/input/draw_touch_events/src/main.c
@@ -13,12 +13,12 @@
 
 LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 
-#if !DT_NODE_EXISTS(DT_CHOSEN(zephyr_touch))
-#error "Unsupported board: zephyr,touch is not assigned"
+#if !DT_NODE_EXISTS(DT_ALIAS(touch))
+#error "Unsupported board: 'touch' alias is not assigned in devicetree"
 #endif
 
 #if !DT_NODE_EXISTS(DT_CHOSEN(zephyr_display))
-#error "Unsupported board: zephyr,display is not assigned"
+#error "Unsupported board: 'zephyr,display' chosen property is not assigned in devicetree"
 #endif
 
 #define WIDTH     (DT_PROP(DT_CHOSEN(zephyr_display), width))
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 #define REFRESH_RATE 100
 
 static const struct device *const display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
-static const struct device *const touch_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_touch));
+static const struct device *const touch_dev = DEVICE_DT_GET(DT_ALIAS(touch));
 static struct display_buffer_descriptor buf_desc = {
 	.buf_size = BUFFER_SIZE, .pitch = CROSS_DIM, .width = CROSS_DIM, .height = CROSS_DIM};
 


### PR DESCRIPTION
`zephyr,touch` chosen property is currently used only by the `samples/subsys/input/draw_touch_events` and not used by any in-tree driver, subsystem, or module.
Hence, it is not justified to keep this chosen property as it only creates confusion and leads users to wrongly assume that setting it produces some effect in Zephyr internals.