### PR TITLE
boards: efm32gg_sltb009a: uart: Fix USART0 loc 1

### DIFF
--- a/boards/silabs/dev_kits/sltb009a/sltb009a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb009a/sltb009a-pinctrl.dtsi
@@ -10,10 +10,10 @@
 	/* configuration for usart0 device, default state - operating as UART */
 	usart0_default: usart0_default {
 		group1 {
-			psels = <GECKO_PSEL(UART_TX, E, 0)>,
-				<GECKO_PSEL(UART_RX, E, 1)>,
-				<GECKO_LOC(UART_TX, 7)>,
-				<GECKO_LOC(UART_RX, 6)>;
+			psels = <GECKO_PSEL(UART_TX, E, 7)>,
+				<GECKO_PSEL(UART_RX, E, 6)>,
+				<GECKO_LOC(UART_TX, 1)>,
+				<GECKO_LOC(UART_RX, 1)>;
 		};
 	};
 


### PR DESCRIPTION
Probably just a typo...

Silabs Thunderboard EFM32GG12 (OPN: SLTB009A) connects USART0 location 1 to the VCOM pins of the on-board debugger.

US0_TX loc 1 is pin PE7
US0_RX loc 1 is pin PE6

For those wanting to trace this back to vendor documentation, see:

- [EFM32 Giant Gecko Series 1 Family Data Sheet](https://www.silabs.com/documents/public/data-sheets/efm32gg12-datasheet.pdf) v1.0, page 197 for USART0 location pin mappings
- [UG371: Thunderboard EFM32GG12 User's Guide](https://www.silabs.com/documents/public/user-guides/ug371-sltb009a-user-guide.pdf) v1.1, page 8 for VCOM to USART0 mapping.