### PR TITLE
soc: wch: drop the stack size overrides for the CH32V208

### DIFF
--- a/soc/wch/ch32v/qingke_v4c/Kconfig.defconfig
+++ b/soc/wch/ch32v/qingke_v4c/Kconfig.defconfig
@@ -6,15 +6,6 @@ if SOC_SERIES_QINGKE_V4C
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
 
-config MAIN_STACK_SIZE
-	default 512
-
-config IDLE_STACK_SIZE
-	default 256
-
-config ISR_STACK_SIZE
-	default 256
-
 config CLOCK_CONTROL
 	default y
 


### PR DESCRIPTION
These were added for the CH32V003 as it has 2 KiB of RAM which is too little for the Zephyr defaults.

Remove. This fixes some of the samples that do things such as printk in an ISR.