### PR TITLE
drivers: gpio: Fix PCA6416 configuration

### DIFF
--- a/drivers/gpio/gpio_pca6416.c
+++ b/drivers/gpio/gpio_pca6416.c
@@ -472,7 +472,7 @@ static DEVICE_API(gpio, api_table) = {
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),	\
 		},								\
 		.interrupt_enabled = DT_INST_NODE_HAS_PROP(n, interrupt_gpios),	\
-		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, interrupt_gpios, {}),	\
+		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, interrupt_gpios, {0}),	\
 	};									\
 										\
 	static struct pca6416_drv_data pca6416_drvdata_##n = {			\

--- a/drivers/gpio/gpio_pca6416.c
+++ b/drivers/gpio/gpio_pca6416.c
@@ -472,7 +472,7 @@ static DEVICE_API(gpio, api_table) = {
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),	\
 		},								\
 		.interrupt_enabled = DT_INST_NODE_HAS_PROP(n, interrupt_gpios),	\
-		.gpio_int = GPIO_DT_SPEC_INST_GET(n, interrupt_gpios),	\
+		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, interrupt_gpios, {}),	\
 	};									\
 										\
 	static struct pca6416_drv_data pca6416_drvdata_##n = {			\


### PR DESCRIPTION
In PCA 6416 (or the compatible TCA) GPIO expander, when the interrupt pin is not connected, the DTS property _interrupt_gpios_ should not be declared. However, macro GPIO_DT_SPEC_INST_GET requires it, even if DT_INST_NODE_HAS_PROP correctly sets interrupt enable to false.