### PR TITLE
dts: boards: esp32c3_supermini: Fix active led level

### DIFF
--- a/boards/others/esp32c3_supermini/esp32c3_supermini.dts
+++ b/boards/others/esp32c3_supermini/esp32c3_supermini.dts
@@ -42,7 +42,7 @@
 	leds {
 		compatible = "gpio-leds";
 		blue_led_0: led_0 {
-			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 			label = "Blue LED 0";
 		};
 	};


### PR DESCRIPTION
Fix led active level to low according to schematic
<img width="1377" alt="esp32supermini" src="https://github.com/user-attachments/assets/4edafcfd-1875-4835-abcb-f4078c05db9c" />
