### PR TITLE
cmake: gcc: target_arm: enable asm-syntax-unified

### DIFF
--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -3,6 +3,7 @@
 set(ARM_C_FLAGS)
 
 list(APPEND ARM_C_FLAGS   -mcpu=${GCC_M_CPU})
+list(APPEND ARM_C_FLAGS   -masm-syntax-unified)
 
 if(CONFIG_COMPILER_ISA_THUMB2)
   list(APPEND ARM_C_FLAGS   -mthumb)


### PR DESCRIPTION
Enable Unified Assembler Language on ARM GCC, seems like few code snippets requires it to be portable to all ARM variants.