### PR TITLE
debug: `ASSERT_VERBOSE` depends on `PRINTK`

### DIFF
--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -228,6 +228,7 @@ config FORCE_NO_ASSERT
 config ASSERT_VERBOSE
 	bool "Verbose assertions"
 	default y
+	depends on PRINTK
 	help
 	  This option enables printing an assert message with information about
 	  the assertion that occurred. This includes printing the location,


### PR DESCRIPTION
When both `PRINTK` and `ASSERT` are disabled, the firmware image will still contain a symbol for `assert_print` function which increases the memory footprint by 14 bytes. In this case the function doesn't do anything and so these 14 bytes are not useful.

This change also reduces the memory footprint elsewhere such as in the bluetooth subsystem which implements `BT_ASSERT_VERBOSE`. Now it will be nop. On nRF52832 this is on the order of 300 - 400 bytes when configured for peripheral only (just as an example).