### PR TITLE
counter: cmsdk_apb_timer: Use clock freq from DT clocks

### DIFF
--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -16,6 +16,20 @@
 
 #include "timer_cmsdk_apb.h"
 
+#define TIMER_NODE DT_INST(0, arm_cmsdk_timer)
+#define CLOCK_NODE DT_PHANDLE(TIMER_NODE, clocks)
+
+#define HAS_TIMER_CLOCK DT_NODE_HAS_PROP(TIMER_NODE, clocks)
+#define HAS_CLOCK_FREQUENCY DT_NODE_HAS_PROP(CLOCK_NODE, clock_frequency)
+
+#if HAS_TIMER_CLOCK && HAS_CLOCK_FREQUENCY
+#define TIMER_CMSDK_FREQ(inst) \
+	DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency)
+#else
+#define TIMER_CMSDK_FREQ(inst) \
+	24000000U  /* fallback default */
+#endif /* HAS_TIMER_CLOCK && HAS_CLOCK_FREQUENCY */
+
 typedef void (*timer_config_func_t)(const struct device *dev);
 
 struct tmr_cmsdk_apb_cfg {
@@ -172,7 +186,7 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 	static const struct tmr_cmsdk_apb_cfg tmr_cmsdk_apb_cfg_##inst = { \
 		.info = {						\
 			.max_top_value = UINT32_MAX,			\
-			.freq = 24000000U,				\
+			.freq = TIMER_CMSDK_FREQ(inst),			\
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		\
 			.channels = 0U,					\
 		},							\


### PR DESCRIPTION
Previously, the CMSDK APB timer driver hardcoded the counter clock frequency to 24 MHz, which limits reuse across SoCs and boards with different timer clock
sources.
This patch replaces the hardcoded frequency with a value derived from the device tree's `clocks` phandle, using the `clock-frequency` property of the referenced clock controller node. If the property is missing, it falls back to a default 24 MHz and issues a build-time warning.