### PR TITLE
drivers: icm42688: move misleading debug message

### DIFF
--- a/drivers/sensor/tdk/icm42688/icm42688_rtio_stream.c
+++ b/drivers/sensor/tdk/icm42688/icm42688_rtio_stream.c
@@ -171,7 +171,6 @@ icm42688_get_read_config_trigger(const struct sensor_read_config *cfg,
 			return &cfg->triggers[i];
 		}
 	}
-	LOG_DBG("Unsupported trigger (%d)", trig);
 	return NULL;
 }
 
@@ -207,6 +206,7 @@ static void icm42688_int_status_cb(struct rtio *r, const struct rtio_sqe *sqr, v
 				  FIELD_GET(BIT_INT_STATUS_FIFO_FULL, drv_data->int_status) != 0;
 
 	if (!has_fifo_ths_trig && !has_fifo_full_trig) {
+		LOG_DBG("No FIFO trigger is configured");
 		gpio_pin_interrupt_configure_dt(&drv_cfg->gpio_int1, GPIO_INT_EDGE_TO_ACTIVE);
 		return;
 	}


### PR DESCRIPTION
When SENSOR_TRIG_FIFO_WATERMARK or SENSOR_TRIG_FIFO_FULL is not configured, an unsupported trigger debug message will be printed. Moved such that a no trigger configured debug message will be printed only if both triggers are not configured.