### PR TITLE
driver: wifi: esp32: fix send event for AP_STA mode

### DIFF
--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -95,7 +95,7 @@ static int esp32_wifi_send(const struct device *dev, struct net_pkt *pkt)
 	const int pkt_len = net_pkt_get_len(pkt);
 	esp_interface_t ifx = data->state == ESP32_AP_CONNECTED ? ESP_IF_WIFI_AP : ESP_IF_WIFI_STA;
 
-	if (esp32_data.state != ESP32_STA_CONNECTED && esp32_data.state != ESP32_AP_CONNECTED) {
+	if (data->state != ESP32_STA_CONNECTED && data->state != ESP32_AP_CONNECTED) {
 		return -EIO;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/89780