### PR TITLE
sysbuild: pass CMAKE_TOOLCHAIN_FILE via shared_cmake_variables_list

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -309,6 +309,7 @@ function(ExternalZephyrProject_Add)
     shared_cmake_variables_list
     CMAKE_BUILD_TYPE
     CMAKE_VERBOSE_MAKEFILE
+    CMAKE_TOOLCHAIN_FILE
   )
 
   set(sysbuild_cache_file ${CMAKE_BINARY_DIR}/${ZBUILD_APPLICATION}_sysbuild_cache.txt)


### PR DESCRIPTION
while I was trying to use `LLVM` and `clang` as a toolchain to build nRF-related projects I came up with a cmake toolchain that was specifying correct paths to common headers, libraries. The file is passed to `west` via `--toolchain` option. It works for non-sysbuild configurations and doesn't for sysbuild.
This commit allows for sysbuild-based builds to use the specified cmake toolchain file on all stages by adding `CMAKE_TOOLCHAIN_FILE` variable to the `shared_cmake_variables_list`

