### PR TITLE
drivers: gpio: pca series: dereference pointer in assignment

### DIFF
--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -1068,7 +1068,7 @@ static int gpio_pca_series_port_read_standard(
 	if (ret) {
 		LOG_ERR("port read error %d", ret);
 	} else {
-		value = sys_le32_to_cpu(input_data);
+		*value = (gpio_port_value_t)sys_le32_to_cpu(input_data);
 	}
 	k_sem_give(&data->lock);
 #endif /* CONFIG_GPIO_PCA_SERIES_INTERRUPT */


### PR DESCRIPTION
Properly dereference the value pointer in assignment.

```
In function 'gpio_pca_series_port_read_standard':
warning: assignment to 'gpio_port_value_t *' {aka 'unsigned int *'} \
  from 'uint32_t' {aka 'unsigned int'} makes pointer from integer   \
  without a cast [-Wint-conversion]
 1071 |                 value = sys_le32_to_cpu(input_data);
      |                       ^
```

Fixes #89787