### PR TITLE
net: fix constness in http_request

### DIFF
--- a/include/zephyr/net/http/client.h
+++ b/include/zephyr/net/http/client.h
@@ -279,7 +279,7 @@ struct http_request {
 	 * some header fields may remain constant through the application's
 	 * life cycle. This is a NULL terminated list of header fields.
 	 */
-	const char **header_fields;
+	const char * const *header_fields;
 
 	/** The value of the Content-Type header field, may be NULL */
 	const char *content_type_value;


### PR DESCRIPTION
Since we are taking a double pointer to an array owned by the user, we should also make all but the top-level of indirection const, since we are not planning on modifying it.

In my case the headers come from here (c++):
```c++
     constexpr static const char *chuncked_headers[] = {                                                                                                      
             "Transfer-Encoding: chunked\r\n",
             NULL
         };
``` 
which is const all the way down