### PR TITLE
drivers: gpio: davinci: Allow empty pinctrl

### DIFF
--- a/drivers/gpio/gpio_davinci.c
+++ b/drivers/gpio/gpio_davinci.c
@@ -163,7 +163,7 @@ static int gpio_davinci_init(const struct device *dev)
 	config->bank_config(dev);
 
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENOENT) {
 		LOG_ERR("failed to apply pinctrl");
 		return ret;
 	}


### PR DESCRIPTION
Ignore error if default pinctrl missing. Some devices allow specifying pinctrl in them, which is better to do , specially for static (on-board) devices to keep overlays simpler.