### PR TITLE
sample: arch: mpu: mpu_test: skip run automate for SoC S32Z

### DIFF
--- a/samples/arch/mpu/mpu_test/sample.yaml
+++ b/samples/arch/mpu/mpu_test/sample.yaml
@@ -3,7 +3,7 @@ sample:
 tests:
   sample.mpu.mpu_test:
     arch_allow: arm
-    filter: CONFIG_CPU_HAS_MPU and not CONFIG_ARM64
+    filter: CONFIG_CPU_HAS_MPU and not CONFIG_ARM64 and not CONFIG_SOC_SERIES_S32ZE
     tags:
       - mpu
     harness: shell


### PR DESCRIPTION
Due to input automated testing, the memory addresses (0x1, 0x2) are not available in any managed memory region, causing the automated test to fail. This test should be run manually.