### PR TITLE
Bluetooth: Host: K_NO_WAIT in bt_att_req_alloc() in sysworkq

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2015-2016 Intel Corporation
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -3932,12 +3933,25 @@ static void att_chan_mtu_updated(struct bt_att_chan *updated_chan)
 struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout)
 {
 	struct bt_att_req *req = NULL;
+	k_tid_t current_thread = k_current_get();
 
-	if (k_current_get() == att_handle_rsp_thread) {
-		/* No req will be fulfilled while blocking on the bt_recv thread.
-		 * Blocking would cause deadlock.
+	if (current_thread == att_handle_rsp_thread ||
+	    current_thread == k_work_queue_thread_get(&k_sys_work_q)) {
+		/* bt_att_req are released by the att_handle_rsp_thread.
+		 * A blocking allocation the same thread would cause a
+		 * deadlock.
+		 *
+		 * Likewise, the system work queue is used for
+		 * tx_processor(), which is needed to send currently
+		 * pending requests. Blocking here in a situation where
+		 * all the request holding a bt_att_req have yet to go
+		 * through the tx_processor() would cause a deadlock.
+		 *
+		 * Note the att_handle_rsp_thread might be the system
+		 * work queue thread or the dedicated BT RX WQ thread,
+		 * depending on kconfig.
 		 */
-		LOG_DBG("Timeout discarded. No blocking on bt_recv thread.");
+		LOG_DBG("Timeout discarded. No blocking on BT RX WQ or SYS WQ threads.");
 		timeout = K_NO_WAIT;
 	}
 


### PR DESCRIPTION
This commit prevents ATT request APIs from blocking waiting on the req_slab pool on the system work queue. The API will instead return -ENOMEM.

This aligns with commit 05b16b971bfad509206337a6ae22e8d7f5159ffd, which establishes that the GATT request APIs are non-blocking on the system work queue. That commit makes GATT request APIs fail with -ENOMEM when they fail to allocate a buffer for the ATT PDU on the system work queue.

There is no reason to make this distinction between the two resources, and this makes the API more consistent.