### PR TITLE
scripts: ci: check_compliance: Add check for github references

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1485,6 +1485,31 @@ class Identity(ComplianceTest):
                 self.failure('\n'.join(failures))
 
 
+class GithubReferences(ComplianceTest):
+    """
+    Checks if there are github references in commit descriptions
+    """
+    name = "GithubReferences"
+    doc = "See https://docs.zephyrproject.org/latest/contribute/guidelines.html#commit-guidelines for more details"
+
+    def run(self):
+        for shaidx in get_shas(COMMIT_RANGE):
+            body = git(
+                'show', '-s', '--format=%b', shaidx
+            )
+
+            match_references = re.search(r"(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s(GH\-|#[0-9])", body,
+                                         re.IGNORECASE)
+
+            failures = []
+
+            if match_references:
+                failures.append(f'{shaidx}: Contains github references (place in github pull request message instead)')
+
+            if failures:
+                self.failure('\n'.join(failures))
+
+
 class BinaryFiles(ComplianceTest):
     """
     Check that the diff contains no binary files.


### PR DESCRIPTION
Adds a check for github references in commit messages then fails if they are found as per contribution guidelines

Github reference tag list from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
Github URL list from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls