### PR TITLE
tests: Bluetooth: Audio: Remove dependency on host mocks

### DIFF
--- a/tests/bluetooth/audio/mocks/CMakeLists.txt
+++ b/tests/bluetooth/audio/mocks/CMakeLists.txt
@@ -9,6 +9,7 @@
 #
 
 add_library(mocks STATIC
+  src/assert.c
   src/bap_stream.c
   src/conn.c
   src/crypto.c
@@ -39,8 +40,7 @@ target_sources(testbinary PRIVATE
   ${ZEPHYR_BASE}/include/zephyr/kernel.h
 )
 
-add_subdirectory(${ZEPHYR_BASE}/tests/bluetooth/host host_mocks)
-
-target_link_libraries(mocks PRIVATE test_interface host_mocks)
+target_link_libraries(mocks PRIVATE test_interface)
+target_compile_options(test_interface INTERFACE -include ztest.h)
 target_link_options(mocks PUBLIC
   "SHELL:-T ${ZEPHYR_BASE}/tests/bluetooth/audio/mocks/mock-sections.ld")

--- a/tests/bluetooth/audio/mocks/include/assert.h
+++ b/tests/bluetooth/audio/mocks/include/assert.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/fff.h>
+#include <zephyr/kernel.h>
+
+/* List of fakes used by this unit tester */
+#define ASSERT_FFF_FAKES_LIST(FAKE)           \
+		FAKE(mock_check_if_assert_expected)   \
+
+DECLARE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
+
+#define expect_assert()     (mock_check_if_assert_expected_fake.return_val = 1)

--- a/tests/bluetooth/audio/mocks/src/assert.c
+++ b/tests/bluetooth/audio/mocks/src/assert.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include "assert.h"
+
+DEFINE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
+
+void assert_print(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vprintk(fmt, ap);
+	va_end(ap);
+}
+
+void assert_post_action(const char *file, unsigned int line)
+{
+	/* ztest_test_pass()/ztest_test_fail() are used to stop the execution
+	 * If this is an unexpected assert (i.e. not following expect_assert())
+	 * calling mock_check_if_assert_expected() will return 'false' as
+	 * a default return value
+	 */
+	if (mock_check_if_assert_expected() == true) {
+		printk("Assertion expected as part of a test case.\n");
+		/* Mark the test as passed and stop execution:
+		 * Needed in the passing scenario to prevent undefined behavior after hitting the
+		 * assert. In real builds (non-UT), the system will be halted by the assert.
+		 */
+		ztest_test_pass();
+	} else {
+		/* Mark the test as failed and stop execution */
+		ztest_test_fail();
+	}
+}


### PR DESCRIPTION
Removes the dependency on the host mocks for LE Audio tests. This is done by copying the missing mocks for assert into the audio mocks, and then always including ztest.h.

The inclusion of ztest.h is due to the fact that
arch/cpu.h does not have an appropriate header file for ztest, and some header files depend on ARCH_STACK_PTR_ALIGN which is usually defined by those headers in cpu.h. However ztest.h does define this value as well, and thus needs to be included always.