### PR TITLE
drivers: pwm: support for numaker m55m1x

### DIFF
--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -436,6 +436,30 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
+
+		epwm0: epwm@40242000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x40242000 0x37c>;
+			interrupts = <31 0>, <32 0>, <33 0>;
+			interrupt-names = "pair0", "pair1", "pair2";
+			resets = <&rst NUMAKER_SYS_EPWM0RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_EPWM0_MODULE NUMAKER_CLK_EPWMSEL_EPWM0SEL_PCLK0 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		epwm1: epwm@40282000 {
+			compatible = "nuvoton,numaker-pwm";
+			reg = <0x40282000 0x37c>;
+			interrupts = <35 0>, <36 0>, <37 0>;
+			interrupt-names = "pair0", "pair1", "pair2";
+			resets = <&rst NUMAKER_SYS_EPWM1RST>;
+			prescaler = <19>;
+			clocks = <&pcc NUMAKER_EPWM1_MODULE NUMAKER_CLK_EPWMSEL_EPWM1SEL_PCLK2 0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/pwm/pwm_loopback/boards/numaker_m55m1.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/numaker_m55m1.overlay
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+&pinctrl {
+	epwm1_default: epwm1_default {
+		group0 {
+			/* EVB's D5, D4 --> PC12, PC11 */
+			pinmux = <PC12MFP_EPWM1_CH0>,
+				 <PC11MFP_EPWM1_CH1>;
+		};
+	};
+};
+
+/ {
+	pwm_loopback_0 {
+		compatible = "test-pwm-loopback";
+		pwms = <&epwm1 0 0 PWM_POLARITY_NORMAL>,
+		       <&epwm1 1 0 PWM_POLARITY_NORMAL>;
+	};
+};
+
+&epwm1 {
+	status = "okay";
+	prescaler = <19>;
+	pinctrl-0 = <&epwm1_default>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
This PR is to add support for Nuvoton NuMaker M55M1X series.

Verified OK by pwm_loopback:
```
===================================================================
TESTSUITE pwm_loopback succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [pwm_loopback]: pass = 7, fail = 0, skip = 1, total = 8 duration = 3.328 seconds
 - PASS - [pwm_loopback.test_capture_busy] duration = 0.008 seconds
 - PASS - [pwm_loopback.test_capture_timeout] duration = 1.002 seconds
 - PASS - [pwm_loopback.test_continuous_capture] duration = 1.176 seconds
 - PASS - [pwm_loopback.test_period_capture] duration = 0.314 seconds
 - PASS - [pwm_loopback.test_period_capture_inverted] duration = 0.389 seconds
 - SKIP - [pwm_loopback.test_pulse_and_period_capture] duration = 0.014 seconds
 - PASS - [pwm_loopback.test_pulse_capture] duration = 0.236 seconds
 - PASS - [pwm_loopback.test_pulse_capture_inverted] duration = 0.189 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```