### PR TITLE
west.yml: update hal_espressif

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -167,7 +167,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: e794f935ff732f4e03f2e007d1e342f881ef0d4a
+      revision: 19deab41774962eda2fbe6ced5ee30365e658df9
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
- Fix ESP32-C2 rom puts call, which crashes when using printf without arguments.

- Fix espressif monitor error when CTRL+C is pressed to exit terminal.