### PR TITLE
subsys: modbus: modbus_serial: divide by zero check

### DIFF
--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -582,6 +582,11 @@ int modbus_serial_init(struct modbus_context *ctx,
 		}
 	}
 
+	if (param.serial.baud == 0) {
+		LOG_ERR("Baudrate is 0");
+		return -EINVAL;
+	}
+
 	if (param.serial.baud <= 38400) {
 		cfg->rtu_timeout = (numof_bits * if_delay_max) /
 				   param.serial.baud;


### PR DESCRIPTION
Check if the baudrate is not 0 before dividing by it to get the rtu_timeout. When the baudrate happens to be 0, the rtu_timeout is set to the maximum.
Although this has no practical use, it could be used in a simulated modbus network.