### PR TITLE
mgmt: hawkbit: add shell autohandler timeout Kconfig

### DIFF
--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -47,6 +47,17 @@ config HAWKBIT_SHELL
 	help
 	  Activate shell module that provides hawkBit commands.
 
+config HAWKBIT_SHELL_AUTOHANDLER_TIMEOUT
+	int "hawkBit shell autohandler timeout"
+	default 200
+	depends on HAWKBIT_SHELL
+	help
+	  Set the timeout in milliseconds for the hawkBit shell autohandler. During
+	  the timeout, the hawkBit shell autohandler blocks the shell and waits for
+	  the hawkBit autohandler to finish. During this time, log messages for the
+	  shell logger are not printed, so this timeout should be set to a value that
+	  is not too long, to not drop the logs.
+
 config HAWKBIT_TENANT
 	string "Tenant name for the hawkbit server"
 	default "default"

--- a/subsys/mgmt/hawkbit/shell.c
+++ b/subsys/mgmt/hawkbit/shell.c
@@ -27,7 +27,8 @@ static void cmd_run(const struct shell *sh, size_t argc, char **argv)
 
 	hawkbit_autohandler(false);
 
-	switch (hawkbit_autohandler_wait(UINT32_MAX, K_FOREVER)) {
+	switch (hawkbit_autohandler_wait(UINT32_MAX,
+					 K_MSEC(CONFIG_HAWKBIT_SHELL_AUTOHANDLER_TIMEOUT))) {
 	case HAWKBIT_UNCONFIRMED_IMAGE:
 		shell_error(sh, "Image is unconfirmed."
 				"Rebooting to revert back to previous confirmed image");
@@ -55,6 +56,10 @@ static void cmd_run(const struct shell *sh, size_t argc, char **argv)
 
 	case HAWKBIT_NOT_INITIALIZED:
 		shell_error(sh, "hawkBit not initialized");
+		break;
+
+	case HAWKBIT_NO_RESPONSE:
+		shell_info(sh, "hawkBit is still running, see log for more information");
 		break;
 
 	default:


### PR DESCRIPTION
Add shell autohandler timeout configuration option. If the shell is used as a logging backend, logs won't be printed before the timeout ends and logs could be dropped.