### PR TITLE
soc: silabs: siwx91x: Initialize NWP sufficiently early

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -19,4 +19,12 @@ config SOC_SILABS_SLEEPTIMER
 	help
 	  The Sleeptimer HAL module is used for SIWX91X.
 
+config SIWX91X_NWP_INIT_PRIORITY
+	int "SiWx91x Network Processor init priority"
+	default 39
+	help
+	  Initialization priority of the SiWx91x Network Processor. NWP init must
+	  have a higher priority than services that depend on it, such as Bluetooth,
+	  Wi-Fi and crypto.
+
 endif # SOC_FAMILY_SILABS_SIWX91X

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -193,7 +193,11 @@ static int siwg917_nwp_init(void)
 
 	return 0;
 }
-SYS_INIT(siwg917_nwp_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+#if defined(CONFIG_MBEDTLS_INIT)
+BUILD_ASSERT(CONFIG_SIWX91X_NWP_INIT_PRIORITY < CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+	     "mbed TLS must be initialized after the NWP.");
+#endif
+SYS_INIT(siwg917_nwp_init, POST_KERNEL, CONFIG_SIWX91X_NWP_INIT_PRIORITY);
 
 /* IRQn 74 is used for communication with co-processor */
 Z_ISR_DECLARE(74, 0, IRQ074_Handler, 0);


### PR DESCRIPTION
The NWP provides Bluetooth, Wi-Fi and crypto services, and must be initialized before any users of these. Mbed TLS is initialized at priority level 40 (kernel default priority), ensure that the NWP is initialized before that.

Make the priority configurable to allow users to tweak the init sequence.