### PR TITLE
modules: hal_rpi_pico: set `-std=gnu11` in a more toolchain independent way.

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 if(CONFIG_HAS_RPI_PICO)
   zephyr_library()
-  zephyr_library_compile_options(-std=gnu11)
+  set_property(TARGET ${ZEPHYR_CURRENT_LIBRARY} PROPERTY C_STANDARD 11)
 
   set(rp2_common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2_common)
   set(rp2xxx_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/${CONFIG_SOC_SERIES})


### PR DESCRIPTION
The hardcoded flag in #84974 causes some issues with IAR.

This tries to set `-std=gnu11` in a more toolchain independent way.

Trying to fix this to start work on `hal_rpi_pico` using IAR toolchain.

I tried doing in the "proper cmake way", there are a couple of other ways, but I don't have experience enough in these parts to have an opinion:
* Add this to `zephyr_library_property`?
* Add generator expressions to compiler/linker in style with other flags
* `if(CMAKE_C_COMPILER_ID`

I'm not sure that mixing and matching C++ versions in the same linking unit is wise anyway?
And if #30105 goes through, maybe we can have the right version globally?