### PR TITLE
net: mqtt-sn: Correct the allowed Keep Alive value range

### DIFF
--- a/subsys/net/lib/mqtt_sn/Kconfig
+++ b/subsys/net/lib/mqtt_sn/Kconfig
@@ -58,7 +58,7 @@ config MQTT_SN_LIB_MAX_PUBLISH
 config MQTT_SN_KEEPALIVE
 	int "Maximum number of clients Keep alive time for MQTT-SN (in seconds)"
 	default 60
-	range 1 $(UINT8_MAX)
+	range 0 $(UINT16_MAX)
 	help
 	  Keep alive time for MQTT-SN (in seconds). Sending of Ping Requests to
 	  keep the connection alive are governed by this value.

--- a/subsys/net/lib/mqtt_sn/mqtt_sn.c
+++ b/subsys/net/lib/mqtt_sn/mqtt_sn.c
@@ -842,6 +842,11 @@ static int process_ping(struct mqtt_sn_client *client, int64_t *next_cycle)
 	struct mqtt_sn_gateway *gw = NULL;
 	int64_t next_ping;
 
+	if (CONFIG_MQTT_SN_KEEPALIVE == 0) {
+		/* Keep Alive disabled. */
+		return 0;
+	}
+
 	if (client->ping_retries == N_RETRY) {
 		/* Last ping was acked */
 		next_ping = client->last_ping + T_KEEPALIVE_MSEC;


### PR DESCRIPTION
Keep Alive timeout is represented by 2-byte unsigned integer, however the corresponding Kconfig option was limited to UINT8_MAX only. Also, similarly to regular MQTT, allow to disable the Keep Alive functionality by specifying the Keep Alive value to 0.

Fixes #89684