### PR TITLE
net: dns: dispatcher: fix OOB array access

### DIFF
--- a/subsys/net/lib/dns/dispatcher.c
+++ b/subsys/net/lib/dns/dispatcher.c
@@ -345,6 +345,10 @@ int dns_dispatcher_unregister(struct dns_socket_dispatcher *ctx)
 			goto out;
 		}
 
+		if (ctx->fds[i].fd < 0) {
+			continue;
+		}
+
 		dispatch_table[ctx->fds[i].fd].ctx = NULL;
 	}
 


### PR DESCRIPTION
Validate that the file descriptor is not a negative number before writing to the `dispatch_table` `ctx` field. Setting file descriptors to `-1` is the standard "not in use" value, and in fact the entire array of `fds` is set to this value in `dns_resolve_init_locked`. This resolves memory corruption of whichever variable is unfortunate to exist just before `dispatch_table` in memory.