### PR TITLE
debug: define thread_info offset for RX

### DIFF
--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -77,6 +77,8 @@ const size_t _kernel_thread_info_offsets[] = {
 #elif defined(CONFIG_NIOS2)
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = offsetof(struct k_thread,
 						callee_saved.sp),
+#elif defined(CONFIG_RX)
+	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,
 #elif defined(CONFIG_RISCV)
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = offsetof(struct k_thread,
 						callee_saved.sp),


### PR DESCRIPTION
Handling for RX architecture.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
