### PR TITLE
tests: drivers: rtc: rtc_api: boards: Enable ALARM and UPDATE testing

### DIFF
--- a/tests/drivers/rtc/rtc_api/boards/intel_adl_crb.conf
+++ b/tests/drivers/rtc/rtc_api/boards/intel_adl_crb.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_UPDATE=y

--- a/tests/drivers/rtc/rtc_api/boards/intel_btl_s_crb.conf
+++ b/tests/drivers/rtc/rtc_api/boards/intel_btl_s_crb.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_UPDATE=y

--- a/tests/drivers/rtc/rtc_api/boards/intel_rpl_p_crb.conf
+++ b/tests/drivers/rtc/rtc_api/boards/intel_rpl_p_crb.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_UPDATE=y

--- a/tests/drivers/rtc/rtc_api/boards/intel_rpl_s_crb.conf
+++ b/tests/drivers/rtc/rtc_api/boards/intel_rpl_s_crb.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_RTC_ALARM=y
+CONFIG_RTC_UPDATE=y


### PR DESCRIPTION
Enabled CONFIG_ALARM and CONFIG_UPDATE to enable these tests on intel platforms.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>