### PR TITLE
Bluetooth: ISO: Remove BT_ISO_TX_FRAG_COUNT

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -330,6 +330,9 @@ Bluetooth Host
 * The macro ``BT_GATT_CCC_INITIALIZER`` in :zephyr_file:`include/zephyr/bluetooth/gatt.h`
   has been renamed to :c:macro:`BT_GATT_CCC_MANAGED_USER_DATA_INIT`. (:github:`88652`)
 
+* The ``CONFIG_BT_ISO_TX_FRAG_COUNT`` Kconfig option was removed as it was completely unused.
+  Any uses of it can simply be removed. (:github:`89836`)
+
 Bluetooth Classic
 =================
 

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -307,18 +307,6 @@ config BT_ISO_TX_BUF_COUNT
 	help
 	  Number of buffers available for outgoing Isochronous channel SDUs.
 
-config BT_ISO_TX_FRAG_COUNT
-	int "Number of ISO TX fragment buffers"
-	default 2
-	range 0 $(UINT8_MAX)
-	help
-	  Number of buffers available for fragments of TX buffers. Warning:
-	  setting this to 0 means that the application must ensure that
-	  queued TX buffers never need to be fragmented, i.e. that the
-	  controller's buffer size is large enough. If this is not ensured,
-	  and there are no dedicated fragment buffers, a deadlock may occur.
-	  In most cases the default value of 2 is a safe bet.
-
 config BT_ISO_TX_MTU
 	int "Maximum supported MTU for Isochronous TX buffers"
 	range 1 4095


### PR DESCRIPTION
The Kconfig option has not been in use for anything for a long time, and can safely be removed.