### PR TITLE
soc: nordic: allow setting VPR_LAUNCHER support for out of tree SoCs

### DIFF
--- a/soc/nordic/Kconfig.sysbuild
+++ b/soc/nordic/Kconfig.sysbuild
@@ -1,4 +1,8 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+config HAS_NORDIC_VPR_LAUNCHER_IMAGE
+	bool
+
 rsource "common/vpr/Kconfig.sysbuild"
+orsource "*/Kconfig.sysbuild"

--- a/soc/nordic/common/vpr/Kconfig.sysbuild
+++ b/soc/nordic/common/vpr/Kconfig.sysbuild
@@ -4,7 +4,7 @@
 config VPR_LAUNCHER
 	bool "VPR launcher"
 	default y
-	depends on (SOC_NRF54H20_CPUPPR || SOC_NRF54H20_CPUFLPR || SOC_NRF54L09_ENGA_CPUFLPR || SOC_NRF54L15_CPUFLPR || SOC_NRF54L20_ENGA_CPUFLPR || SOC_NRF9280_CPUPPR)
+	depends on HAS_NORDIC_VPR_LAUNCHER_IMAGE
 	help
 	  Include VPR launcher in build.
 	  VPR launcher is a minimal sample built for an ARM core that starts given VPR core.

--- a/soc/nordic/nrf54h/Kconfig.sysbuild
+++ b/soc/nordic/nrf54h/Kconfig.sysbuild
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF54H20_CPUPPR || SOC_NRF54H20_CPUFLPR
+
+config HAS_NORDIC_VPR_LAUNCHER_IMAGE
+	default y
+
+endif

--- a/soc/nordic/nrf54l/Kconfig.sysbuild
+++ b/soc/nordic/nrf54l/Kconfig.sysbuild
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF54L09_ENGA_CPUFLPR || SOC_NRF54L15_CPUFLPR || SOC_NRF54L20_ENGA_CPUFLPR
+
+config HAS_NORDIC_VPR_LAUNCHER_IMAGE
+	default y
+
+endif

--- a/soc/nordic/nrf92/Kconfig.sysbuild
+++ b/soc/nordic/nrf92/Kconfig.sysbuild
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF9280_CPUPPR
+
+config HAS_NORDIC_VPR_LAUNCHER_IMAGE
+	default y
+
+endif


### PR DESCRIPTION
Make the compilation of vpr_launcher dependent on sysbuild Kconfig that can be set by SoC.