### PR TITLE
soc: silabs: add missing kconfig resource for siwx91x

### DIFF
--- a/soc/silabs/silabs_siwx91x/Kconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig
@@ -10,7 +10,13 @@ config SOC_FAMILY_SILABS_SIWX91X
 	select HAS_SILABS_WISECONNECT
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 
+if SOC_FAMILY_SILABS_SIWX91X
+
+rsource "*/Kconfig"
+
 config SOC_SILABS_SLEEPTIMER
 	bool
 	help
 	  The Sleeptimer HAL module is used for SIWX91X.
+
+endif # SOC_FAMILY_SILABS_SIWX91X


### PR DESCRIPTION
Fixes the missing Kconfig resource for the siwx91x SoC. This ensures that soc_early_init_hook function is correctly called for the siwg917 SoC during initialization.