### PR TITLE
posix: Use 'char' for posix_condattr bitfields

### DIFF
--- a/include/zephyr/arch/rx/linker.ld
+++ b/include/zephyr/arch/rx/linker.ld
@@ -53,6 +53,10 @@ SECTIONS
 
 #include <zephyr/linker/rel-sections.ld>
 
+#ifdef CONFIG_LLEXT
+#include <zephyr/linker/llext-sections.ld>
+#endif
+
 	GROUP_START(ROMABLE_REGION)
 	. = ROM_START;   /* for kernel logging */
 	PLACE_SYMBOL_HERE(__rodata_region_start);
@@ -65,15 +69,26 @@ SECTIONS
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,ROM_START,)
 	{
 		_image_text_start = .;
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rom-start.ld>
 		*(.text)
 		*(.text.*)
 		*(P)
+		. = ALIGN(4);
 		etext = .;
+#include <zephyr/linker/kobject-text.ld>
 	} GROUP_LINK_IN(ROMABLE_REGION)
 
 	_image_text_end = .;
 
 	#include <zephyr/linker/common-rom.ld>
+
+/* Located in generated directory. This file is populated by calling
+ * zephyr_linker_sources(ROM_SECTIONS ...). Useful for grouping iterable RO structs.
+ */
+#include <snippets-rom-sections.ld>
 
 	SECTION_PROLOGUE(.rvectors,,)
 	{
@@ -105,13 +120,26 @@ SECTIONS
 		*(.got)
 		*(.got.plt)
 	} GROUP_LINK_IN(ROMABLE_REGION)
+
+#include <zephyr/linker/thread-local-storage.ld>
+#include <zephyr/linker/cplusplus-rom.ld>
+
 	SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
 	{
 		*(.rodata)
 		*(.rodata.*)
+		*(.gnu.linkonce.r)
+		*(.gnu.linkonce.r.*)
 		*(C_1)
 		*(C_2)
 		*(C)
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-rodata.ld>
+#include <zephyr/linker/kobject-rom.ld>
+
 		_erodata = .;
 	} GROUP_LINK_IN(ROMABLE_REGION)
 	SECTION_PROLOGUE(eh_frame_hdr,,)
@@ -154,6 +182,22 @@ SECTIONS
 
 	_image_ram_start = .;
 
+#include <app_data_alignment.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-ram-sections.ld>
+
+#if defined(CONFIG_USERSPACE)
+#define APP_SHARED_ALIGN MPU_MIN_SIZE_ALIGN
+#define SMEM_PARTITION_ALIGN MPU_ALIGN
+
+#include <app_smem.ld>
+	_app_smem_size = _app_smem_end - _app_smem_start;
+	_app_smem_rom_start = LOADADDR(_APP_SMEM_SECTION_NAME);
+#endif /* CONFIG_USERSPACE */
+
 	#if CONFIG_SRAM_BASE_ADDRESS == 0
 		/* RX memory starts at address 0 which can be confused with NULL. To prevent this, block
 		 * the first memory page (16 Bytes).
@@ -163,6 +207,8 @@ SECTIONS
 			. = 0x10;
 		} GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 	#endif
+
+#include <zephyr/linker/common-noinit.ld>
 
 	SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
 	{
@@ -180,6 +226,13 @@ SECTIONS
 	/* the sections defined in common-ram.ld have to be initialized on
 	 * reset as well, to place them before _edata */
 #include <zephyr/linker/common-ram.ld>
+#include <zephyr/linker/kobject-data.ld>
+#include <zephyr/linker/cplusplus-ram.ld>
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#include <snippets-data-sections.ld>
 
 	_edata = .;
 
@@ -196,18 +249,18 @@ SECTIONS
 
 	_ebss = . ;
 
-#include <zephyr/linker/common-noinit.ld>
-
 	_image_ram_end = .;
 	_end = .;
 	PROVIDE(__end = _end);
 
-	GROUP_END(RAMABLE_REGION)
-
 /* Located in generated directory. This file is populated by the
-* zephyr_linker_sources() CMake function.
-*/
+ * zephyr_linker_sources() Cmake function.
+ */
 #include <snippets-sections.ld>
+
+#include <zephyr/linker/ram-end.ld>
+
+	GROUP_END(RAMABLE_REGION)
 
 #include <zephyr/linker/debug-sections.ld>
 

--- a/lib/posix/options/posix_internal.h
+++ b/lib/posix/options/posix_internal.h
@@ -68,10 +68,10 @@ struct posix_thread {
 
 struct posix_condattr {
 	/* leaves room for CLOCK_REALTIME (1, default) and CLOCK_MONOTONIC (4) */
-	unsigned int clock: 3;
-	bool initialized: 1;
+	unsigned char clock: 3;
+	char initialized: 1;
 #ifdef _POSIX_THREAD_PROCESS_SHARED
-	unsigned int pshared: 1;
+	unsigned char pshared: 1;
 #endif
 };
 

--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -213,6 +213,10 @@ def parse_log_const_symbols(database, log_const_area, log_const_symbols, string_
             # Not enough data to unpack
             continue
 
+        if sym.entry['st_size'] == 0:
+            # Empty entry
+            continue
+
         str_ptr, level = struct.unpack(formatter, datum)
 
         # Offset to rodata section for string

--- a/scripts/logging/dictionary/database_gen.py
+++ b/scripts/logging/dictionary/database_gen.py
@@ -166,7 +166,7 @@ def find_log_const_symbols(elf):
             continue
 
         for symbol in section.iter_symbols():
-            if symbol.name.startswith("log_const_"):
+            if symbol.name.startswith("log_const_") or symbol.name.startswith("_log_const_"):
                 ret_list.append(symbol)
 
     return ret_list

--- a/scripts/logging/dictionary/dictionary_parser/log_database.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_database.py
@@ -55,6 +55,9 @@ ARCHS = {
     "riscv" : {
         "kconfig": "CONFIG_RISCV",
     },
+    "rx" : {
+        "kconfig": "CONFIG_RX",
+    },
     "xtensa" : {
         "kconfig": "CONFIG_XTENSA",
     },

--- a/subsys/debug/thread_info.c
+++ b/subsys/debug/thread_info.c
@@ -95,6 +95,9 @@ const size_t _kernel_thread_info_offsets[] = {
 	 * unimplemented to avoid the #warning below.
 	 */
 	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,
+#elif defined(CONFIG_RX)
+	/* RX doesn't store *anything* inside thread objects yet */
+	[THREAD_INFO_OFFSET_T_STACK_PTR] = THREAD_INFO_UNIMPLEMENTED,
 #else
 	/* Use a special value so that OpenOCD knows that obtaining the stack
 	 * pointer is not possible on this particular architecture.

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/include/os_mgmt_processor.h
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/include/os_mgmt_processor.h
@@ -152,6 +152,16 @@ extern "C" {
 #endif
 #elif defined(CONFIG_RISCV)
 #define PROCESSOR_NAME "riscv"
+#elif defined(CONFIG_RX)
+#if defined(CONFIG_CPU_RXV1)
+#define PROCESSOR_NAME "rxv1"
+#elif defined(CONFIG_CPU_RXV2)
+#define PROCESSOR_NAME "rxv2"
+#elif defined(CONFIG_CPU_RXV3)
+#define PROCESSOR_NAME "rxv3"
+#else
+#define PROCESSOR_NAME "rx"
+#endif
 #elif defined(CONFIG_XTENSA)
 #define PROCESSOR_NAME "xtensa"
 #elif defined(CONFIG_SPARC)

--- a/tests/arch/rx/acc/src/main.c
+++ b/tests/arch/rx/acc/src/main.c
@@ -85,8 +85,6 @@ static void thread_2_entry(void *p1, void *p2, void *p3)
 ZTEST(rx_acc_tests, test_counting_value)
 {
 
-	uint32_t events;
-
 	k_event_init(&my_event);
 
 	k_tid_t tid_1 = k_thread_create(&thread_1, tstack_thread_1, STACK_SIZE, thread_1_entry,

--- a/tests/lib/c_lib/common/src/test_sqrt.c
+++ b/tests/lib/c_lib/common/src/test_sqrt.c
@@ -6,9 +6,24 @@
  */
 
 #include <math.h>
+#include <float.h>
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 
+#ifndef FLT_IS_IEC_60559
+#ifdef __FLT_IS_IEC_60559__
+#define FLT_IS_IEC_60559 __FLT_IS_IEC_60559__
+#else
+#define FLT_IS_IEC_60559 0
+#endif
+#endif
+#ifndef DBL_IS_IEC_60559
+#ifdef __DBL_IS_IEC_60559__
+#define DBL_IS_IEC_60559 __DBL_IS_IEC_60559__
+#else
+#define DBL_IS_IEC_60559 0
+#endif
+#endif
 
 #define local_abs(x) (((x) < 0) ? -(x) : (x))
 
@@ -97,11 +112,14 @@ int32_t ierror;
 int32_t *p_square = (int32_t *)&square;
 int32_t *p_root_squared = (int32_t *)&root_squared;
 
-
 	max_error = 0;
 
 	/* test the special cases of 0.0, NAN, -NAN, INFINITY, -INFINITY,  and -10.0 */
 	zassert_true(sqrtf(0.0f) == 0.0f, "sqrtf(0.0)");
+#ifndef FLT_IS_IEC_60559
+#error no iec indication
+#endif
+#if FLT_IS_IEC_60559 == 1
 	zassert_true(isnanf(sqrtf(NAN)), "sqrt(nan)");
 #ifdef issignallingf
 	zassert_true(issignallingf(sqrtf(NAN)), "ssignalingf(sqrtf(nan))");
@@ -111,6 +129,7 @@ int32_t *p_root_squared = (int32_t *)&root_squared;
 	zassert_true(isinff(sqrtf(INFINITY)), "isinff(sqrt(inf))");
 	zassert_true(isnanf(sqrtf(-INFINITY)), "isnanf(sqrt(-inf))");
 	zassert_true(isnanf(sqrtf(-10.0f)), "isnanf(sqrt(-10.0))");
+#endif
 
 	for (exponent = 1.0e-10f; exponent < 1.0e10f; exponent *= 10.0f) {
 		for (i = 0; i < NUM_TEST_FLOATS; i++) {
@@ -165,6 +184,7 @@ int64_t *p_root_squared = (int64_t *)&root_squared;
 
 	/* test the special cases of 0.0, NAN, -NAN, INFINITY, -INFINITY,  and -10.0 */
 	zassert_true(sqrt(0.0) == 0.0, "sqrt(0.0)");
+#if DBL_IS_IEC_60559 == 1
 	zassert_true(isnan(sqrt((double)NAN)), "sqrt(nan)");
 #ifdef issignalling
 	zassert_true(issignalling(sqrt((double)NAN)), "ssignaling(sqrt(nan))");
@@ -174,6 +194,7 @@ int64_t *p_root_squared = (int64_t *)&root_squared;
 	zassert_true(isinf(sqrt((double)INFINITY)), "isinf(sqrt(inf))");
 	zassert_true(isnan(sqrt((double)-INFINITY)), "isnan(sqrt(-inf))");
 	zassert_true(isnan(sqrt(-10.0)), "isnan(sqrt(-10.0))");
+#endif
 
 	for (exponent = 1.0e-10; exponent < 1.0e10; exponent *= 10.0) {
 		for (i = 0; i < NUM_TEST_DOUBLES; i++) {

--- a/tests/lib/json/src/main.c
+++ b/tests/lib/json/src/main.c
@@ -936,15 +936,23 @@ ZTEST(lib_json_test, test_json_double_infinity)
 
 ZTEST(lib_json_test, test_json_doubles_limits)
 {
-	char encoded[] = "{\"double_max\":1.797693134862315e+308,"
+#if __SIZEOF_DOUBLE__ == 4
+#define TEST_DOUBLE_MIN -1.1754e-38
+#define TEST_DOUBLE_MAX 1.1754e-38
+#else
+#define TEST_DOUBLE_MIN 1.797693134862315e+308
+#define TEST_DOUBLE_MAX 1.797693134862315e+308
+#endif
+#define str(x) #x
+	char encoded[] = "{\"double_max\":" str(TEST_DOUBLE_MAX) ","
 			 "\"double_cero\":0,"
-			 "\"double_min\":-1.797693134862315e+308"
+		         "\"double_min\":" str(TEST_DOUBLE_MIN) "-1.797693134862315e+308"
 			 "}";
 
 	struct test_double_limits limits = {
-		.double_max = 1.797693134862315e+308,
+		.double_max = TEST_DOUBLE_MAX,
 		.double_cero = 0,
-		.double_min = -1.797693134862315e+308,
+		.double_min = TEST_DOUBLE_MIN
 	};
 
 	char buffer[sizeof(encoded)];

--- a/tests/lib/sprintf/src/main.c
+++ b/tests/lib/sprintf/src/main.c
@@ -99,6 +99,21 @@ static int WriteFrmtd_vf(FILE *stream, char *format, ...)
  *
  */
 
+#ifndef FLT_IS_IEC_60559
+#ifdef __FLT_IS_IEC_60559__
+#define FLT_IS_IEC_60559 __FLT_IS_IEC_60559__
+#else
+#define FLT_IS_IEC_60559 0
+#endif
+#endif
+#ifndef DBL_IS_IEC_60559
+#ifdef __DBL_IS_IEC_60559__
+#define DBL_IS_IEC_60559 __DBL_IS_IEC_60559__
+#else
+#define DBL_IS_IEC_60559 0
+#endif
+#endif
+
 #ifdef CONFIG_STDOUT_CONSOLE
 ZTEST(sprintf, test_sprintf_double)
 {
@@ -118,6 +133,7 @@ ZTEST(sprintf, test_sprintf_double)
 		return;
 	}
 
+#if DBL_IS_IEC_60559 == 1 && __SIZEOF_DOUBLE__ == 8
 	var.exponent = 0x00000000;
 	var.fraction = 0x7ff00000; /* Bit pattern for +INF (double) */
 	sprintf(buffer, "%e", var.d);
@@ -229,6 +245,7 @@ ZTEST(sprintf, test_sprintf_double)
 	sprintf(buffer, "%G", var.d);
 	zassert_true((strcmp(buffer, "-NAN") == 0),
 		     "sprintf(-NAN) - incorrect output '%s'\n", buffer);
+#endif
 
 	var.d = 1.0;
 	sprintf(buffer, "%f", var.d);
@@ -268,6 +285,7 @@ ZTEST(sprintf, test_sprintf_double)
 	zassert_true((strcmp(buffer, "-1.000000") == 0),
 		     "sprintf(-1.0) - incorrect output '%s'\n", buffer);
 
+#if __SIZEOF_DOUBLE__ >= 8
 	var.d = 1234.56789;
 	sprintf(buffer, "%f", var.d);
 	zassert_true((strcmp(buffer, "1234.567890") == 0),
@@ -279,7 +297,6 @@ ZTEST(sprintf, test_sprintf_double)
 	 * on the library used and FPU implementation. However the length
 	 * and decimal position should remain identical.
 	 */
-	var.d = 0x1p800;
 	sprintf(buffer, "%.140f", var.d);
 	zassert_true((strlen(buffer) == 382),
 		     "sprintf(<large output>) - incorrect length %d\n",
@@ -309,6 +326,7 @@ ZTEST(sprintf, test_sprintf_double)
 	zassert_true((strcmp(buffer + 119, "0000387259") == 0),
 		      "sprintf(<large output>) - got \"%s\" "
 		      "while expecting \"0000387259\"\n", buffer + 119);
+#endif
 
 	/*******************/
 	var.d = 1234.0;
@@ -376,6 +394,7 @@ ZTEST(sprintf, test_sprintf_double)
 		     "sprintf(0.0001505) - incorrect "
 		     "output '%s'\n", buffer);
 
+#if __SIZEOF_DOUBLE__ >= 8
 	var.exponent = 0x00000001;
 	var.fraction = 0x00000000; /* smallest denormal value */
 	sprintf(buffer, "%g", var.d);
@@ -387,6 +406,7 @@ ZTEST(sprintf, test_sprintf_double)
 	zassert_true((strcmp(buffer, "4.94066e-324") == 0),
 		     "sprintf(4.94066e-324) - incorrect "
 		     "output '%s'\n", buffer);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Ensure that posix_condattr is smaller than pthread_condattr by keeping it under one byte.