### PR TITLE
soc: stm32: Defaults to "stm32f401xe" when SOC_STM32F401XD selected

### DIFF
--- a/soc/st/stm32/stm32f4x/Kconfig.soc
+++ b/soc/st/stm32/stm32f4x/Kconfig.soc
@@ -104,7 +104,7 @@ config SOC_STM32F479XX
 
 config SOC
 	default "stm32f401xc" if SOC_STM32F401XC
-	default "stm32f401xd" if SOC_STM32F401XD
+	default "stm32f401xe" if SOC_STM32F401XD
 	default "stm32f401xe" if SOC_STM32F401XE
 	default "stm32f405xx" if SOC_STM32F405XX
 	default "stm32f407xx" if SOC_STM32F407XE


### PR DESCRIPTION
The STM32F401XE and STM32F401XD family of devices are identical except for a difference in the flash storage size. Let's reuse the F401XE HAL symbol for the newly introduced F401XD variants.