### PR TITLE
riscv: use reg-names in machine timer driver and DTS

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -242,6 +242,28 @@ Timer
   :kconfig:option:`CONFIG_NATIVE_POSIX_TIMER` has been deprecated in favor of
   :kconfig:option:`CONFIG_NATIVE_SIM_TIMER`, (:github:`86612`).
 
+* :dtcompatible:`andestech,machine-timer`, :dtcompatible:`neorv32-machine-timer`,
+  :dtcompatible:`telink,machine-timer`, :dtcompatible:`lowrisc,machine-timer`,
+  :dtcompatible:`niosv-machine-timer`, and :dtcompatible:`scr,machine-timer` have
+  been unified under :dtcompatible:`riscv,machine-timer`.
+
+  The addresses of both ``MTIME`` and ``MTIMECMP`` registers must now be explicitly
+  specified using the ``reg`` and ``reg-names`` properties. The ``reg-names`` property
+  is now **required**, and must list names corresponding one-to-one with each entry
+  in ``reg``. (:github:`84175` and :github:`89847`)
+
+  Example:
+
+  .. code-block:: devicetree
+
+    mtimer: timer@d1000000 {
+        compatible = "riscv,machine-timer";
+        interrupts-extended = <&cpu0_intc 7>;
+        reg = <0xd1000000 0x8
+               0xd1000008 0x8>;
+        reg-names = "mtime", "mtimecmp";
+    };
+
 Modem
 =====
 

--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -16,8 +16,8 @@
 
 #define DT_DRV_COMPAT riscv_machine_timer
 
-#define MTIME_REG    DT_INST_REG_ADDR_BY_IDX(0, 0)
-#define MTIMECMP_REG DT_INST_REG_ADDR_BY_IDX(0, 1)
+#define MTIME_REG    DT_INST_REG_ADDR_BY_NAME(0, mtime)
+#define MTIMECMP_REG DT_INST_REG_ADDR_BY_NAME(0, mtimecmp)
 #define TIMER_IRQN   DT_INST_IRQN(0)
 
 #define CYC_PER_TICK (uint32_t)(sys_clock_hw_cycles_per_sec() / CONFIG_SYS_CLOCK_TICKS_PER_SEC)

--- a/dts/bindings/timer/riscv,machine-timer.yaml
+++ b/dts/bindings/timer/riscv,machine-timer.yaml
@@ -10,5 +10,7 @@ include: base.yaml
 properties:
   reg:
     required: true
+  reg-names:
+    required: true
   interrupts-extended:
     required: true

--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -217,6 +217,7 @@
 		mtimer: timer@e6000000 {
 			compatible = "riscv,machine-timer";
 			reg = <0xe6000000 0x8 0xe6000008 0x8>;
+			reg-names = "mtime", "mtimecmp";
 			interrupts-extended = <&cpu0_intc 7 &cpu1_intc 7
 					       &cpu2_intc 7 &cpu3_intc 7
 					       &cpu4_intc 7 &cpu5_intc 7

--- a/dts/riscv/gd/gd32vf103.dtsi
+++ b/dts/riscv/gd/gd32vf103.dtsi
@@ -43,6 +43,7 @@
 		systimer: timer@d1000000 {
 			compatible = "nuclei,systimer", "riscv,machine-timer";
 			reg = <0xd1000000 0x8 0xd1000008 0x8>;
+			reg-names = "mtime", "mtimecmp";
 			interrupts-extended = <&eclic 7 0>;
 			clk-divider = <NUCLEI_SYSTIMER_DIVIDER_4>;
 		};


### PR DESCRIPTION
Since #84175, addresses of the MTIME and MTIMECMP registers are defined in DTS and retrieved using the `DT_INST_REG_ADDR_BY_IDX` macro.

This PR refines that approach by switching to `DT_INST_REG_ADDR_BY_NAME`, using the `reg-names` property to explicitly identify the MTIME and MTIMECMP registers. This improves readability and avoids reliance on index ordering, especially in cases where one of the registers may be absent or implemented differently.

This PR includes:

1. An update to the `riscv,machine-timer` driver to use `reg-names` instead of register index.
2. DTS updates to add `reg-names = "mtime", "mtimecmp"` to all relevant machine timer nodes.

This enhancement enables better support for platforms with nonstandard timer register layouts and serves as a prerequisite for #69594.