### PR TITLE
rtio: API version 0.2.0, unstable

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -48,7 +48,7 @@ extern "C" {
  * @brief RTIO
  * @defgroup rtio RTIO
  * @since 3.2
- * @version 0.1.0
+ * @version 0.2.0
  * @ingroup os_services
  * @{
  */


### PR DESCRIPTION
We're well past the experimental stage, but there are still some things that may change. Bumping the API version to 0.2.0 signals this.