### PR TITLE
maintainer: add rx architecture

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3310,6 +3310,19 @@ RISCV arch:
   tests:
     - arch.riscv
 
+RX arch:
+  status: maintained
+  maintainers:
+    - duynguyenxa
+  files:
+    - arch/rx/
+    - dts/rx/
+    - include/zephyr/arch/rx/
+    - boards/qemu/rx/
+    - soc/renesas/rx/
+  labels:
+    - "area: RX Architecture"
+
 Retention:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add section with RX architecture and initial most obvious files. More to
be added by maintainers.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
