### PR TITLE
cmake: kconfig: auto-generate boolean board revision option

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -66,6 +66,14 @@ if(DEFINED BOARD_REVISION)
     message(DEPRECATION "Use of '${board_rev_file}.conf' is deprecated, please switch to '${board_rev_file}_defconfig'")
     set_ifndef(BOARD_REVISION_CONFIG ${BOARD_DIR}/${board_rev_file}.conf)
   endif()
+
+  # Generate boolean board revision kconfig option
+  zephyr_string(SANITIZE TOUPPER BOARD_REVISION_GEN_CONFIG_VAR "BOARD_REVISION_${BOARD_REVISION}")
+
+  file(APPEND ${KCONFIG_BOARD_DIR}/Kconfig
+       "config ${BOARD_REVISION_GEN_CONFIG_VAR}\n"
+       "\tdef_bool y\n"
+  )
 endif()
 
 set(DOTCONFIG                  ${PROJECT_BINARY_DIR}/.config)

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -971,7 +971,8 @@ Missing SoC names or CONFIG_SOC vs soc.yml out of sync:
                 sym_name = sym_name[len(self.CONFIG_):]  # Strip CONFIG_
                 if sym_name not in defined_syms and \
                    sym_name not in self.UNDEF_KCONFIG_ALLOWLIST and \
-                   not (sym_name.endswith("_MODULE") and sym_name[:-7] in defined_syms):
+                   not (sym_name.endswith("_MODULE") and sym_name[:-7] in defined_syms) \
+                   and not sym_name.startswith("BOARD_REVISION_"):
 
                     undef_to_locs[sym_name].append(f"{path}:{lineno}")
 


### PR DESCRIPTION
Automatically generate a boolean `CONFIG_BOARD_REVISION_FOO=y` Kconfig option based on e.g. `CONFIG_BOARD_REVISION="foo"`.

The allows us to use conditional expressions with the C preprocessor and also allows us to use e.g. `if (IS_ENABLED(CONFIG_BOARD_REVISION_FOO)) ...`.

Closes #89375