### PR TITLE
drivers: eeprom: tmp11x: remove redundant build assert

### DIFF
--- a/drivers/eeprom/eeprom_tmp11x.c
+++ b/drivers/eeprom/eeprom_tmp11x.c
@@ -16,11 +16,6 @@ struct eeprom_tmp11x_config {
 	const struct device *parent;
 };
 
-BUILD_ASSERT(CONFIG_EEPROM_INIT_PRIORITY >
-	     CONFIG_SENSOR_INIT_PRIORITY,
-	     "TMP11X eeprom driver must be initialized after TMP11X sensor "
-	     "driver");
-
 static size_t eeprom_tmp11x_size(const struct device *dev)
 {
 	return EEPROM_TMP11X_SIZE;


### PR DESCRIPTION
Initialization priority is already check by `check_init_priorities.py`