### PR TITLE
drivers: usb: udc: support numaker m55m1x series soc

### DIFF
--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1-pinctrl.dtsi
@@ -51,4 +51,14 @@
 				 slew-rate = "fast";
 		};
 	};
+
+	/* USBD multi-function pins for VBUS, D+, D-, and ID pins */
+	usbd_default: usbd_default {
+		group0 {
+			pinmux = <PA12MFP_USB_VBUS>,
+				 <PA13MFP_USB_D_MINUS>,
+				 <PA14MFP_USB_D_PLUS>,
+				 <PA15MFP_USB_OTG_ID>;
+		};
+	};
 };

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
@@ -17,6 +17,8 @@
 	aliases {
 		led0 = &green_led;
 		led1 = &yellow_led;
+		sw0 = &btn0;
+		sw1 = &btn1;
 	};
 
 	chosen {
@@ -41,6 +43,20 @@
 		yellow_led: led_1 {
 			gpios = <&gpiod 6 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		btn0: btn0 {
+			label = "BTN0";
+			gpios = <&gpioi 11 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+		btn1: btn1 {
+			label = "BTN1";
+			gpios = <&gpioh 1 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
 };

--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
@@ -49,6 +49,14 @@
 	status = "okay";
 };
 
+&gpioh {
+	status = "okay";
+};
+
+&gpioi {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";
@@ -96,6 +104,13 @@
 
 &emac {
 	pinctrl-0 = <&emac_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+/* On enabled, usbd is required to be clocked in 48MHz. */
+zephyr_udc0: &usbd {
+	pinctrl-0 = <&usbd_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -265,7 +265,7 @@ config HWINFO_AMBIQ
 config HWINFO_NUMAKER
 	bool "NuMaker hwinfo"
 	default y
-	depends on SOC_SERIES_M46X
+	depends on SOC_SERIES_M46X || SOC_SERIES_M55M1X
 	select HWINFO_HAS_DRIVER
 	select HAS_NUMAKER_FMC
 	help

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -299,9 +299,17 @@ static int numaker_usbd_hw_setup(const struct device *dev)
 
 	SYS_UnlockReg();
 
-	/* Configure USB PHY for USBD */
+	/* Configure USB role as USB Device and enable USB PHY */
+#if defined(CONFIG_SOC_SERIES_M46X)
 	SYS->USBPHY = (SYS->USBPHY & ~SYS_USBPHY_USBROLE_Msk) |
 		      (SYS_USBPHY_USBROLE_STD_USBD | SYS_USBPHY_USBEN_Msk | SYS_USBPHY_SBO_Msk);
+#elif defined(CONFIG_SOC_SERIES_M2L31X)
+	SYS->USBPHY = (SYS->USBPHY & ~SYS_USBPHY_USBROLE_Msk) |
+		      (SYS_USBPHY_USBROLE_STD_USBD | SYS_USBPHY_USBEN_Msk | SYS_USBPHY_SBO_Msk);
+#elif defined(CONFIG_SOC_SERIES_M55M1X)
+	SYS->USBPHY = (SYS->USBPHY & ~SYS_USBPHY_USBROLE_Msk) |
+		      ((0 << SYS_USBPHY_USBROLE_Pos) | SYS_USBPHY_OTGPHYEN_Msk);
+#endif
 
 	/* Invoke Clock controller to enable module clock */
 	memset(&scc_subsys, 0x00, sizeof(scc_subsys));

--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -45,6 +45,7 @@
 			reg = <0x40001000 0x100>;
 			#clock-cells = <0>;
 			lxt = "enable";
+			hirc48m = "enable";
 			clk-pclkdiv = <(NUMAKER_CLK_PCLKDIV_PCLK0DIV(2) |
 					NUMAKER_CLK_PCLKDIV_PCLK1DIV(2) |
 					NUMAKER_CLK_PCLKDIV_PCLK2DIV(2) |
@@ -459,6 +460,19 @@
 			clocks = <&pcc NUMAKER_EPWM1_MODULE NUMAKER_CLK_EPWMSEL_EPWM1SEL_PCLK2 0>;
 			#pwm-cells = <3>;
 			status = "disabled";
+		};
+
+		usbd: usbd@4025c000 {
+			compatible = "nuvoton,numaker-usbd";
+			reg = <0x4025c000 0x1000>;
+			interrupts = <58 0>;
+			resets = <&rst NUMAKER_SYS_USBD0RST>;
+			clocks = <&pcc NUMAKER_USBD0_MODULE NUMAKER_CLK_USBSEL_USBSEL_HIRC48M
+				  NUMAKER_CLK_USBDIV_USBDIV(1)>;
+			dma-buffer-size = <1536>;
+			status = "disabled";
+			num-bidir-endpoints = <25>;
+			disallow-iso-in-out-same-number;
 		};
 	};
 };

--- a/soc/nuvoton/numaker/m55m1x/soc.c
+++ b/soc/nuvoton/numaker/m55m1x/soc.c
@@ -141,13 +141,13 @@ void soc_reset_hook(void)
 	/* Wait for LIRC clock ready */
 	CLK_WaitClockReady(CLK_STATUS_LIRCSTB_Msk);
 
-#if DT_NODE_HAS_PROP(DT_NODELABEL(scc), hirc48)
-	/* Enable/disable 48 MHz high-speed internal RC oscillator (HIRC48) */
-	if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48) == NUMAKER_SCC_CLKSW_ENABLE) {
+#if DT_NODE_HAS_PROP(DT_NODELABEL(scc), hirc48m)
+	/* Enable/disable 48 MHz high-speed internal RC oscillator (HIRC48M) */
+	if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48m) == NUMAKER_SCC_CLKSW_ENABLE) {
 		CLK_EnableXtalRC(CLK_SRCCTL_HIRC48MEN_Msk);
-		/* Wait for HIRC48 clock ready */
+		/* Wait for HIRC48M clock ready */
 		CLK_WaitClockReady(CLK_STATUS_HIRC48MSTB_Msk);
-	} else if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48) == NUMAKER_SCC_CLKSW_DISABLE) {
+	} else if (DT_ENUM_IDX(DT_NODELABEL(scc), hirc48m) == NUMAKER_SCC_CLKSW_DISABLE) {
 		CLK_DisableXtalRC(CLK_SRCCTL_HIRC48MEN_Msk);
 	}
 #endif


### PR DESCRIPTION
This adds nuvoton numaker m55m1x series soc into usbd_next support. It involves relevant modifications, including:
1. Fix failure to enable `HICR48M`, which is to clock usbd and phy
2. Support `HWINFO` for USB device serial number
3. Add BTN0/BTN1 buttons on numaker_m55m1 board for hid-mouse sample test

Test samples:
- samples/subsys/usb/cdc_acm
- samples/subsys/usb/hid-mouse
- samples/subsys/usb/mass
