### PR TITLE
pm: Return false if pm_state_force fails to set state

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -130,6 +130,10 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 		 "Invalid power state %d!", info->state);
 
 	info = pm_state_get(cpu, info->state, info->substate_id);
+	if (info == NULL) {
+		/* Return false if the state could not be retrieved */
+		return false;
+	}
 
 	key = k_spin_lock(&pm_forced_state_lock);
 	z_cpus_pm_forced_state[cpu] = info;


### PR DESCRIPTION
Ensure `pm_state_force` returns `false` when it fails to retrieve or set the desired power state. This change improves error handling and ensures the function's behavior aligns with its intended purpose.