### PR TITLE
add GPIO support on i.MX 943 A-Core

### DIFF
--- a/boards/nxp/imx943_evk/doc/index.rst
+++ b/boards/nxp/imx943_evk/doc/index.rst
@@ -38,6 +38,7 @@ Hardware
 - ADC interface
 - SINC interface
 - Debug interface
+
   - One USB-to-UART/MPSSE device, FT4232H
   - One USB 3.2 Type-C connector (J15) for FT4232H provides quad serial ports
   - JTAG header J16

--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_a55.yaml
@@ -13,5 +13,6 @@ toolchain:
   - cross-compile
 ram: 1024
 supported:
+  - gpio
   - uart
 vendor: nxp

--- a/drivers/gpio/gpio_mcux_rgpio.c
+++ b/drivers/gpio/gpio_mcux_rgpio.c
@@ -56,6 +56,10 @@ static int mcux_rgpio_configure(const struct device *dev,
 	struct pinctrl_soc_pin pin_cfg;
 	int cfg_idx = pin, i;
 
+	if (flags == GPIO_DISCONNECTED) {
+		return -ENOTSUP;
+	}
+
 	/* Make sure pin is supported */
 	if ((config->common.port_pin_mask & BIT(pin)) == 0) {
 		return -ENOTSUP;

--- a/drivers/gpio/gpio_mcux_rgpio.c
+++ b/drivers/gpio/gpio_mcux_rgpio.c
@@ -273,10 +273,12 @@ static int mcux_rgpio_manage_callback(const struct device *dev,
 static void mcux_rgpio_port_isr(const struct device *dev)
 {
 	RGPIO_Type *base = (RGPIO_Type *)DEVICE_MMIO_NAMED_GET(dev, reg_base);
+	const struct mcux_rgpio_config *config = dev->config;
 	struct mcux_rgpio_data *data = dev->data;
 	uint32_t int_flags;
 
 	int_flags = base->ISFR[0]; /* Notice: only irq0 is used for now */
+	int_flags &= config->common.port_pin_mask; /* don't handle unusable pin */
 	base->ISFR[0] = int_flags;
 
 	gpio_fire_callbacks(&data->callbacks, dev, int_flags);

--- a/drivers/gpio/gpio_mcux_rgpio.c
+++ b/drivers/gpio/gpio_mcux_rgpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024, NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,6 +20,12 @@
 #define DEV_CFG(_dev) \
 	((const struct mcux_rgpio_config *)(_dev)->config)
 #define DEV_DATA(_dev) ((struct mcux_rgpio_data *)(_dev)->data)
+
+/*
+ * Default PAD config value for SCMI pinctrl:
+ * Pull down, Slight Fast Slew Rate, X4 driver strength.
+ */
+#define GPIO_PIN_DEFAUT_PAD_VAL 0x0000051e
 
 struct mcux_rgpio_config {
 	/* gpio_driver_config needs to be first */
@@ -68,10 +74,15 @@ static int mcux_rgpio_configure(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+#if defined(CONFIG_PINCTRL_IMX_SCMI)
+	/* For SCMI Pinctrl platform, set default PAD config value for SCMI pinctrl. */
+	uint32_t reg = GPIO_PIN_DEFAUT_PAD_VAL;
+#else
 	/* Set appropriate bits in pin configuration register */
 	volatile uint32_t *gpio_cfg_reg = (volatile uint32_t *)
 			((size_t)config->pin_muxes[cfg_idx].config_register);
 	uint32_t reg = *gpio_cfg_reg;
+#endif
 
 #if defined(CONFIG_SOC_SERIES_IMXRT118X)
 	/* PUE/PDRV types have the same ODE bit */

--- a/dts/arm64/nxp/nxp_mimx943_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx943_a55.dtsi
@@ -192,6 +192,85 @@
 		status = "disabled";
 	};
 
+	gpio2: gpio@43810000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43810000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 55 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	gpio3: gpio@43820000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43820000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 56 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 57 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <26>;
+		status = "disabled";
+	};
+
+	gpio4: gpio@43840000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43840000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 58 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 59 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	gpio5: gpio@43850000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43850000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 61 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	gpio6: gpio@43860000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43860000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 63 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	gpio7: gpio@43870000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43870000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 64 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 65 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <28>;
+		gpio-reserved-ranges = <10 6>;
+		status = "disabled";
+	};
+
 	mu1: mbox@44220000 {
 		compatible = "nxp,mbox-imx-mu";
 		reg = <0x44220000 DT_SIZE_K(64)>;
@@ -244,4 +323,252 @@
 		#mbox-cells = <1>;
 		status = "disabled";
 	};
+
+	gpio1: gpio@47400000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x47400000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 13 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <16>;
+		status = "disabled";
+	};
+};
+
+/*
+ * GPIO pinmux options. These options define the pinmux settings
+ * for GPIO ports on the package, so that the GPIO driver can
+ * select GPIO mux options during GPIO configuration.
+ */
+
+&gpio1{
+	pinmux = <&iomuxc_i2c1_scl_gpio_io_gpio1_io0>,
+		<&iomuxc_i2c1_sda_gpio_io_gpio1_io1>,
+		<&iomuxc_i2c2_scl_gpio_io_gpio1_io2>,
+		<&iomuxc_i2c2_sda_gpio_io_gpio1_io3>,
+		<&iomuxc_uart1_rxd_gpio_io_gpio1_io4>,
+		<&iomuxc_uart1_txd_gpio_io_gpio1_io5>,
+		<&iomuxc_uart2_rxd_gpio_io_gpio1_io6>,
+		<&iomuxc_uart2_txd_gpio_io_gpio1_io7>,
+		<&iomuxc_pdm_clk_gpio_io_gpio1_io8>,
+		<&iomuxc_pdm_bit_stream0_gpio_io_gpio1_io9>,
+		<&iomuxc_pdm_bit_stream1_gpio_io_gpio1_io10>,
+		<&iomuxc_sai1_txfs_gpio_io_gpio1_io11>,
+		<&iomuxc_sai1_txc_gpio_io_gpio1_io12>,
+		<&iomuxc_sai1_txd0_gpio_io_gpio1_io13>,
+		<&iomuxc_sai1_rxd0_gpio_io_gpio1_io14>,
+		<&iomuxc_wdog_any_gpio_io_gpio1_io15>;
+};
+
+&gpio2{
+	pinmux = <&iomuxc_gpio_io00_gpio_io_gpio2_io0>,
+		<&iomuxc_gpio_io01_gpio_io_gpio2_io1>,
+		<&iomuxc_gpio_io02_gpio_io_gpio2_io2>,
+		<&iomuxc_gpio_io03_gpio_io_gpio2_io3>,
+		<&iomuxc_gpio_io04_gpio_io_gpio2_io4>,
+		<&iomuxc_gpio_io05_gpio_io_gpio2_io5>,
+		<&iomuxc_gpio_io06_gpio_io_gpio2_io6>,
+		<&iomuxc_gpio_io07_gpio_io_gpio2_io7>,
+		<&iomuxc_gpio_io08_gpio_io_gpio2_io8>,
+		<&iomuxc_gpio_io09_gpio_io_gpio2_io9>,
+		<&iomuxc_gpio_io10_gpio_io_gpio2_io10>,
+		<&iomuxc_gpio_io11_gpio_io_gpio2_io11>,
+		<&iomuxc_gpio_io12_gpio_io_gpio2_io12>,
+		<&iomuxc_gpio_io13_gpio_io_gpio2_io13>,
+		<&iomuxc_gpio_io14_gpio_io_gpio2_io14>,
+		<&iomuxc_gpio_io15_gpio_io_gpio2_io15>,
+		<&iomuxc_gpio_io16_gpio_io_gpio2_io16>,
+		<&iomuxc_gpio_io17_gpio_io_gpio2_io17>,
+		<&iomuxc_gpio_io18_gpio_io_gpio2_io18>,
+		<&iomuxc_gpio_io19_gpio_io_gpio2_io19>,
+		<&iomuxc_gpio_io20_gpio_io_gpio2_io20>,
+		<&iomuxc_gpio_io21_gpio_io_gpio2_io21>,
+		<&iomuxc_gpio_io22_gpio_io_gpio2_io22>,
+		<&iomuxc_gpio_io23_gpio_io_gpio2_io23>,
+		<&iomuxc_gpio_io24_gpio_io_gpio2_io24>,
+		<&iomuxc_gpio_io25_gpio_io_gpio2_io25>,
+		<&iomuxc_gpio_io26_gpio_io_gpio2_io26>,
+		<&iomuxc_gpio_io27_gpio_io_gpio2_io27>,
+		<&iomuxc_gpio_io28_gpio_io_gpio2_io28>,
+		<&iomuxc_gpio_io29_gpio_io_gpio2_io29>,
+		<&iomuxc_gpio_io30_gpio_io_gpio2_io30>,
+		<&iomuxc_gpio_io31_gpio_io_gpio2_io31>;
+};
+
+&gpio3{
+	pinmux = <&iomuxc_gpio_io32_gpio_io_gpio3_io0>,
+		<&iomuxc_gpio_io33_gpio_io_gpio3_io1>,
+		<&iomuxc_gpio_io34_gpio_io_gpio3_io2>,
+		<&iomuxc_gpio_io35_gpio_io_gpio3_io3>,
+		<&iomuxc_gpio_io36_gpio_io_gpio3_io4>,
+		<&iomuxc_gpio_io37_gpio_io_gpio3_io5>,
+		<&iomuxc_gpio_io38_gpio_io_gpio3_io6>,
+		<&iomuxc_gpio_io39_gpio_io_gpio3_io7>,
+		<&iomuxc_gpio_io40_gpio_io_gpio3_io8>,
+		<&iomuxc_gpio_io41_gpio_io_gpio3_io9>,
+		<&iomuxc_gpio_io42_gpio_io_gpio3_io10>,
+		<&iomuxc_gpio_io43_gpio_io_gpio3_io11>,
+		<&iomuxc_gpio_io44_gpio_io_gpio3_io12>,
+		<&iomuxc_gpio_io45_gpio_io_gpio3_io13>,
+		<&iomuxc_gpio_io46_gpio_io_gpio3_io14>,
+		<&iomuxc_gpio_io47_gpio_io_gpio3_io15>,
+		<&iomuxc_gpio_io48_gpio_io_gpio3_io16>,
+		<&iomuxc_gpio_io49_gpio_io_gpio3_io17>,
+		<&iomuxc_gpio_io50_gpio_io_gpio3_io18>,
+		<&iomuxc_gpio_io51_gpio_io_gpio3_io19>,
+		<&iomuxc_gpio_io52_gpio_io_gpio3_io20>,
+		<&iomuxc_gpio_io53_gpio_io_gpio3_io21>,
+		<&iomuxc_gpio_io54_gpio_io_gpio3_io22>,
+		<&iomuxc_gpio_io55_gpio_io_gpio3_io23>,
+		<&iomuxc_gpio_io56_gpio_io_gpio3_io24>,
+		<&iomuxc_gpio_io57_gpio_io_gpio3_io25>;
+};
+
+&gpio4{
+	pinmux = <&iomuxc_ccm_clko1_gpio_io_gpio4_io0>,
+		<&iomuxc_ccm_clko2_gpio_io_gpio4_io1>,
+		<&iomuxc_ccm_clko3_gpio_io_gpio4_io2>,
+		<&iomuxc_ccm_clko4_gpio_io_gpio4_io3>,
+		<&iomuxc_dap_tdi_gpio_io_gpio4_io4>,
+		<&iomuxc_dap_tms_swdio_gpio_io_gpio4_io5>,
+		<&iomuxc_dap_tclk_swclk_gpio_io_gpio4_io6>,
+		<&iomuxc_dap_tdo_traceswo_gpio_io_gpio4_io7>,
+		<&iomuxc_sd1_clk_gpio_io_gpio4_io8>,
+		<&iomuxc_sd1_cmd_gpio_io_gpio4_io9>,
+		<&iomuxc_sd1_data0_gpio_io_gpio4_io10>,
+		<&iomuxc_sd1_data1_gpio_io_gpio4_io11>,
+		<&iomuxc_sd1_data2_gpio_io_gpio4_io12>,
+		<&iomuxc_sd1_data3_gpio_io_gpio4_io13>,
+		<&iomuxc_sd1_data4_gpio_io_gpio4_io14>,
+		<&iomuxc_sd1_data5_gpio_io_gpio4_io15>,
+		<&iomuxc_sd1_data6_gpio_io_gpio4_io16>,
+		<&iomuxc_sd1_data7_gpio_io_gpio4_io17>,
+		<&iomuxc_sd1_strobe_gpio_io_gpio4_io18>,
+		<&iomuxc_sd2_vselect_gpio_io_gpio4_io19>,
+		<&iomuxc_sd2_cd_b_gpio_io_gpio4_io20>,
+		<&iomuxc_sd2_clk_gpio_io_gpio4_io21>,
+		<&iomuxc_sd2_cmd_gpio_io_gpio4_io22>,
+		<&iomuxc_sd2_data0_gpio_io_gpio4_io23>,
+		<&iomuxc_sd2_data1_gpio_io_gpio4_io24>,
+		<&iomuxc_sd2_data2_gpio_io_gpio4_io25>,
+		<&iomuxc_sd2_data3_gpio_io_gpio4_io26>,
+		<&iomuxc_sd2_reset_b_gpio_io_gpio4_io27>,
+		<&iomuxc_sd2_gpio0_gpio_io_gpio4_io28>,
+		<&iomuxc_sd2_gpio1_gpio_io_gpio4_io29>,
+		<&iomuxc_sd2_gpio2_gpio_io_gpio4_io30>,
+		<&iomuxc_sd2_gpio3_gpio_io_gpio4_io31>;
+};
+
+&gpio5{
+	pinmux = <&iomuxc_eth0_txd0_gpio_io_gpio5_io0>,
+		<&iomuxc_eth0_txd1_gpio_io_gpio5_io1>,
+		<&iomuxc_eth0_tx_en_gpio_io_gpio5_io2>,
+		<&iomuxc_eth0_tx_clk_gpio_io_gpio5_io3>,
+		<&iomuxc_eth0_rxd0_gpio_io_gpio5_io4>,
+		<&iomuxc_eth0_rxd1_gpio_io_gpio5_io5>,
+		<&iomuxc_eth0_rx_dv_gpio_io_gpio5_io6>,
+		<&iomuxc_eth0_txd2_gpio_io_gpio5_io7>,
+		<&iomuxc_eth0_txd3_gpio_io_gpio5_io8>,
+		<&iomuxc_eth0_rxd2_gpio_io_gpio5_io9>,
+		<&iomuxc_eth0_rxd3_gpio_io_gpio5_io10>,
+		<&iomuxc_eth0_rx_clk_gpio_io_gpio5_io11>,
+		<&iomuxc_eth0_rx_er_gpio_io_gpio5_io12>,
+		<&iomuxc_eth0_tx_er_gpio_io_gpio5_io13>,
+		<&iomuxc_eth0_crs_gpio_io_gpio5_io14>,
+		<&iomuxc_eth0_col_gpio_io_gpio5_io15>,
+		<&iomuxc_eth1_txd0_gpio_io_gpio5_io16>,
+		<&iomuxc_eth1_txd1_gpio_io_gpio5_io17>,
+		<&iomuxc_eth1_tx_en_gpio_io_gpio5_io18>,
+		<&iomuxc_eth1_tx_clk_gpio_io_gpio5_io19>,
+		<&iomuxc_eth1_rxd0_gpio_io_gpio5_io20>,
+		<&iomuxc_eth1_rxd1_gpio_io_gpio5_io21>,
+		<&iomuxc_eth1_rx_dv_gpio_io_gpio5_io22>,
+		<&iomuxc_eth1_txd2_gpio_io_gpio5_io23>,
+		<&iomuxc_eth1_txd3_gpio_io_gpio5_io24>,
+		<&iomuxc_eth1_rxd2_gpio_io_gpio5_io25>,
+		<&iomuxc_eth1_rxd3_gpio_io_gpio5_io26>,
+		<&iomuxc_eth1_rx_clk_gpio_io_gpio5_io27>,
+		<&iomuxc_eth1_rx_er_gpio_io_gpio5_io28>,
+		<&iomuxc_eth1_tx_er_gpio_io_gpio5_io29>,
+		<&iomuxc_eth1_crs_gpio_io_gpio5_io30>,
+		<&iomuxc_eth1_col_gpio_io_gpio5_io31>;
+};
+
+&gpio6{
+	pinmux = <&iomuxc_eth2_mdc_gpio1_gpio_io_gpio6_io0>,
+		<&iomuxc_eth2_mdio_gpio2_gpio_io_gpio6_io1>,
+		<&iomuxc_eth2_txd3_gpio_io_gpio6_io2>,
+		<&iomuxc_eth2_txd2_gpio_io_gpio6_io3>,
+		<&iomuxc_eth2_txd1_gpio_io_gpio6_io4>,
+		<&iomuxc_eth2_txd0_gpio_io_gpio6_io5>,
+		<&iomuxc_eth2_tx_ctl_gpio_io_gpio6_io6>,
+		<&iomuxc_eth2_tx_clk_gpio_io_gpio6_io7>,
+		<&iomuxc_eth2_rx_ctl_gpio_io_gpio6_io8>,
+		<&iomuxc_eth2_rx_clk_gpio_io_gpio6_io9>,
+		<&iomuxc_eth2_rxd0_gpio_io_gpio6_io10>,
+		<&iomuxc_eth2_rxd1_gpio_io_gpio6_io11>,
+		<&iomuxc_eth2_rxd2_gpio_io_gpio6_io12>,
+		<&iomuxc_eth2_rxd3_gpio_io_gpio6_io13>,
+		<&iomuxc_eth3_mdc_gpio1_gpio_io_gpio6_io14>,
+		<&iomuxc_eth3_mdio_gpio2_gpio_io_gpio6_io15>,
+		<&iomuxc_eth3_txd3_gpio_io_gpio6_io16>,
+		<&iomuxc_eth3_txd2_gpio_io_gpio6_io17>,
+		<&iomuxc_eth3_txd1_gpio_io_gpio6_io18>,
+		<&iomuxc_eth3_txd0_gpio_io_gpio6_io19>,
+		<&iomuxc_eth3_tx_ctl_gpio_io_gpio6_io20>,
+		<&iomuxc_eth3_tx_clk_gpio_io_gpio6_io21>,
+		<&iomuxc_eth3_rx_ctl_gpio_io_gpio6_io22>,
+		<&iomuxc_eth3_rx_clk_gpio_io_gpio6_io23>,
+		<&iomuxc_eth3_rxd0_gpio_io_gpio6_io24>,
+		<&iomuxc_eth3_rxd1_gpio_io_gpio6_io25>,
+		<&iomuxc_eth3_rxd2_gpio_io_gpio6_io26>,
+		<&iomuxc_eth3_rxd3_gpio_io_gpio6_io27>,
+		<&iomuxc_eth4_mdc_gpio1_gpio_io_gpio6_io28>,
+		<&iomuxc_eth4_mdio_gpio2_gpio_io_gpio6_io29>,
+		<&iomuxc_eth4_tx_clk_gpio_io_gpio6_io30>,
+		<&iomuxc_eth4_tx_ctl_gpio_io_gpio6_io31>;
+};
+
+/*
+ * Use the NULL pinmux for the GPIO io port which is not available to
+ * make the driver to be easy.
+ */
+&scmi_iomuxc {
+	/omit-if-no-ref/ null_pinmux: NULL_PINMUX {
+		pinmux = <0x0 0 0x0 0 0x0>;
+	};
+};
+
+&gpio7{
+	pinmux = <&iomuxc_eth4_txd0_gpio_io_gpio7_io0>,
+		<&iomuxc_eth4_txd1_gpio_io_gpio7_io1>,
+		<&iomuxc_eth4_txd2_gpio_io_gpio7_io2>,
+		<&iomuxc_eth4_txd3_gpio_io_gpio7_io3>,
+		<&iomuxc_eth4_rxd0_gpio_io_gpio7_io4>,
+		<&iomuxc_eth4_rxd1_gpio_io_gpio7_io5>,
+		<&iomuxc_eth4_rxd2_gpio_io_gpio7_io6>,
+		<&iomuxc_eth4_rxd3_gpio_io_gpio7_io7>,
+		<&iomuxc_eth4_rx_ctl_gpio_io_gpio7_io8>,
+		<&iomuxc_eth4_rx_clk_gpio_io_gpio7_io9>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&iomuxc_xspi1_data0_gpio_io_gpio7_io16>,
+		<&iomuxc_xspi1_data1_gpio_io_gpio7_io17>,
+		<&iomuxc_xspi1_data2_gpio_io_gpio7_io18>,
+		<&iomuxc_xspi1_data3_gpio_io_gpio7_io19>,
+		<&iomuxc_xspi1_data4_gpio_io_gpio7_io20>,
+		<&iomuxc_xspi1_data5_gpio_io_gpio7_io21>,
+		<&iomuxc_xspi1_data6_gpio_io_gpio7_io22>,
+		<&iomuxc_xspi1_data7_gpio_io_gpio7_io23>,
+		<&iomuxc_xspi1_dqs_gpio_io_gpio7_io24>,
+		<&iomuxc_xspi1_sclk_gpio_io_gpio7_io25>,
+		<&iomuxc_xspi1_ss0_b_gpio_io_gpio7_io26>,
+		<&iomuxc_xspi1_ss1_b_gpio_io_gpio7_io27>;
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/imx943_evk_mimx94398_a55.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/imx943_evk_mimx94398_a55.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	resources {
+		compatible = "test-gpio-basic-api";
+		/*
+		 * Use connector J44 Pin10 M1_LED_TP1 which connects to GPIO2 Pin31 as output
+		 * GPIO, and connector J52 Pin16 M1_PWM_PFC2 which connect to GPIO2 Pin21 as
+		 * input GPIO, connect these two pins with a Dupont Line.
+		 */
+		out-gpios = <&gpio2 31 0>;
+		in-gpios = <&gpio2 21 0>;
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c
@@ -30,6 +30,11 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_twice_trigger)
 	cb_cnt = 0;
 
 	ret = gpio_pin_configure(dev_out, PIN_OUT, GPIO_DISCONNECTED);
+	if (ret == -ENOTSUP) {
+		TC_PRINT("NOTE: cannot configure pin as disconnected; trying as input\n");
+		ret = gpio_pin_configure(dev_out, PIN_OUT, GPIO_INPUT | GPIO_PULL_UP);
+	}
+	zassert_ok(ret, "config PIN_OUT failed");
 
 	/* 1. Configure PIN_IN callback */
 	ret = gpio_pin_configure(dev_in, PIN_IN, GPIO_INPUT);
@@ -81,6 +86,11 @@ ZTEST(after_flash_gpio_config_trigger, test_gpio_config_trigger)
 	cb_cnt = 0;
 
 	ret = gpio_pin_configure(dev_out, PIN_OUT, GPIO_DISCONNECTED);
+	if (ret == -ENOTSUP) {
+		TC_PRINT("NOTE: cannot configure pin as disconnected; trying as input\n");
+		ret = gpio_pin_configure(dev_out, PIN_OUT, GPIO_INPUT | GPIO_PULL_UP);
+	}
+	zassert_ok(ret, "config PIN_OUT failed");
 
 	/* 1. Configure PIN_IN callback */
 	ret = gpio_pin_configure(dev_in, PIN_IN, GPIO_INPUT);


### PR DESCRIPTION
This PR is to add GPIO support for i.MX 943 EVK A-Core and with some minimal board document fix.