### PR TITLE
bluetooth: mesh: fix advertiser pool memory leakage after device is suspended

### DIFF
--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -434,6 +434,13 @@ void bt_mesh_adv_friend_ready(void)
 	}
 }
 
+static void adv_sent(struct bt_mesh_ext_adv *ext_adv)
+{
+	atomic_set_bit(ext_adv->flags, ADV_FLAG_SENT);
+
+	bt_mesh_wq_submit(&ext_adv->work);
+}
+
 int bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
 {
 	int err;
@@ -458,9 +465,7 @@ int bt_mesh_adv_terminate(struct bt_mesh_adv *adv)
 		/* Do not call `cb:end`, since this user action */
 		adv->ctx.cb = NULL;
 
-		atomic_set_bit(ext_adv->flags, ADV_FLAG_SENT);
-
-		bt_mesh_wq_submit(&ext_adv->work);
+		adv_sent(ext_adv);
 
 		return 0;
 	}
@@ -502,8 +507,7 @@ static struct bt_mesh_ext_adv *adv_instance_find(struct bt_le_ext_adv *instance)
 	return NULL;
 }
 
-static void adv_sent(struct bt_le_ext_adv *instance,
-		     struct bt_le_ext_adv_sent_info *info)
+static void ext_adv_set_sent(struct bt_le_ext_adv *instance, struct bt_le_ext_adv_sent_info *info)
 {
 	struct bt_mesh_ext_adv *ext_adv = adv_instance_find(instance);
 
@@ -517,9 +521,7 @@ static void adv_sent(struct bt_le_ext_adv *instance,
 		return;
 	}
 
-	atomic_set_bit(ext_adv->flags, ADV_FLAG_SENT);
-
-	bt_mesh_wq_submit(&ext_adv->work);
+	adv_sent(ext_adv);
 }
 
 int bt_mesh_adv_enable(void)
@@ -527,7 +529,7 @@ int bt_mesh_adv_enable(void)
 	int err;
 
 	static const struct bt_le_ext_adv_cb adv_cb = {
-		.sent = adv_sent,
+		.sent = ext_adv_set_sent,
 	};
 
 	if (advs[0].instance) {
@@ -536,8 +538,7 @@ int bt_mesh_adv_enable(void)
 	}
 
 	for (int i = 0; i < ARRAY_SIZE(advs); i++) {
-		err = bt_le_ext_adv_create(&advs[i].adv_param, &adv_cb,
-					   &advs[i].instance);
+		err = bt_le_ext_adv_create(&advs[i].adv_param, &adv_cb, &advs[i].instance);
 		if (err) {
 			return err;
 		}
@@ -565,11 +566,6 @@ int bt_mesh_adv_disable(void)
 			return err;
 		}
 
-		/* `adv_sent` is called to finish transmission of an adv buffer that was pushed to
-		 * the host before the advertiser was stopped, but did not finish.
-		 */
-		adv_sent(advs[i].instance, NULL);
-
 		err = bt_le_ext_adv_delete(advs[i].instance);
 		if (err) {
 			LOG_ERR("Failed to delete adv %d", err);
@@ -579,6 +575,11 @@ int bt_mesh_adv_disable(void)
 		advs[i].instance = NULL;
 
 		atomic_clear_bit(advs[i].flags, ADV_FLAG_SUSPENDING);
+
+		/* `adv_sent` is called to finish transmission of an adv buffer that was pushed to
+		 * the host before the advertiser was stopped, but did not finish.
+		 */
+		adv_sent(&advs[i]);
 	}
 
 	return 0;

--- a/tests/bsim/bluetooth/mesh/tests_scripts/advertiser/disable.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/advertiser/disable.sh
@@ -17,15 +17,18 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # 1. Tx device creates `CONFIG_BT_MESH_ADV_BUF_COUNT` advertisements, setting the first byte of the
 # PDU to 0xAA and the second byte of the PDU to the advertisement order number
 # 2. Tx devices pushes all created advs to the pool by calling `bt_mesh_adv_send` function
-# 3. When the `bt_mesh_send_cb.start` callback is called for the first adv, the tx device submits
-#    a work item which suspends the advertiser by calling `bt_mesh_adv_disable`.
+# 3. After calling sending function Tx device immediately suspends the advertiser.
 # 4. Tx device checks that for the first adv the `bt_mesh_send_cb.end` callback is called with the
 #    error code `0`.
 # 5. Tx device checks that for the consecutive advs the `bt_mesh_send_cb.start` is called with error
 #    `-ENODEV`.
 # 6. Tx device checks that no more advs can be created using `bt_mesh_adv_create` function.
 # 7. Tx device resumes the advertiser and repeats steps 1 and 2.
-# 8. Tx device expects that all advs are sent.
+# 8. When the `bt_mesh_send_cb.start` callback is called for the first adv, the tx device submits
+#    a work item which suspends the advertiser by calling `bt_mesh_adv_disable`.
+# 9. Tx device repeats steps 4-6.
+# 10. Tx device resumes the advertiser and repeats steps 1 and 2.
+# 11. Tx device expects that all advs are sent.
 #
 # Rx device procedure:
 # 1. Rx devices listens all the time while tx device sends advs and ensure that no new advs were
@@ -35,7 +38,7 @@ RunTest mesh_adv_disable adv_tx_disable adv_rx_disable
 
 # Low latency overlay uses legacy advertiser
 overlay=overlay_low_lat_conf
-RunTest mesh_adv_disable adv_tx_disable adv_rx_disable
+RunTest mesh_adv_disable_low_lat adv_tx_disable adv_rx_disable
 
 overlay=overlay_workq_sys_conf
 RunTest mesh_adv_disable_workq adv_tx_disable adv_rx_disable

--- a/tests/bsim/bluetooth/mesh/tests_scripts/suspend/suspend_resume_unref.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/suspend/suspend_resume_unref.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test that initiates a broadcasting of the test model command and immediately suspends device.
+# After a short pause, the device is resumed and attempt of broadcasting is repeated.
+# This is repeated twice more time than allocated advertiser pool size to be sure in that
+# device unreferences allocated advertiser from the pool back if it is suspended.
+#
+# Test procedure:
+# 0. Provisioning and setup.
+# 1. Send test model command twice to check that all allocated advertisers are freed.
+# 2. Suspend Mesh.
+# 3. Resume Mesh.
+# 4. Repeat steps 1-3 twice more than allocated advertiser pool size.
+overlay="overlay_psa_conf"
+RunTest mesh_suspend_resume_unref suspend_dut_suspend_resume_unref
+
+overlay="overlay_low_lat_conf_overlay_psa_conf"
+RunTest mesh_suspend_resume_unref_low_lat suspend_dut_suspend_resume_unref


### PR DESCRIPTION
If the device is suspended, then the advertiser is stopped and deleted. The high level logic that is responsible for adv memory unreferencing is not called.
PR adds advertisement buffer unreferencing if advertiser in SUSPENDING state as well as bsim test that checks there is no memory leakage anymore.