### PR TITLE
sysbuild: Add support for image configuration dtc overlay files

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -388,6 +388,17 @@ function(ExternalZephyrProject_Add)
 
   if(DEFINED ZBUILD_APP_TYPE)
     list(APPEND image_default "${CMAKE_SOURCE_DIR}/image_configurations/${ZBUILD_APP_TYPE}_image_default.cmake")
+    set(image_default_dtc_overlay "${CMAKE_SOURCE_DIR}/image_configurations/${ZBUILD_APP_TYPE}_image_default.overlay")
+
+    if(EXISTS ${image_default_dtc_overlay})
+      if(NOT ${image_default_dtc_overlay} IN_LIST ${ZBUILD_APPLICATION}_EXTRA_DTC_OVERLAY_FILE)
+        list(APPEND ${ZBUILD_APPLICATION}_EXTRA_DTC_OVERLAY_FILE ${image_default_dtc_overlay})
+        set(${ZBUILD_APPLICATION}_EXTRA_DTC_OVERLAY_FILE
+            ${${ZBUILD_APPLICATION}_EXTRA_DTC_OVERLAY_FILE}
+            CACHE INTERNAL "Application extra DTC overlay file" FORCE
+        )
+      endif()
+    endif()
   endif()
 
   set_target_properties(${ZBUILD_APPLICATION} PROPERTIES IMAGE_CONF_SCRIPT "${image_default}")

--- a/share/sysbuild/image_configurations/FIRMWARE_LOADER_image_default.overlay
+++ b/share/sysbuild/image_configurations/FIRMWARE_LOADER_image_default.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		zephyr,code-partition = &slot1_partition;
+	};
+};


### PR DESCRIPTION
    Adds support for using image-specific configuration devicetree
    overlay files

and

    Adds a devicetree overlay file for the firmware loader image which
    sets the code partition to slot 1, which is where the firmware loader
    image resides