### PR TITLE
mgmt: mcumgr: grp: img_mgmt: Add support for firmware loader mode

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -64,6 +64,7 @@ config MCUMGR_GRP_IMG_VERBOSE_ERR
 
 config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY
 	bool "Allow to confirm secondary slot of non-active image"
+	depends on !MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER
 	default y
 	help
 	  Allows to confirm secondary (non-active) slot of non-active image.
@@ -74,6 +75,7 @@ config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY
 
 config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY
 	bool "Allow to confirm slots of non-active image"
+	depends on !MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER
 	select MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_SECONDARY
 	help
 	  Allows to confirm any slot of non-active image.
@@ -82,18 +84,18 @@ config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_IMAGE_ANY
 	  broken and may not boot in other slot; instead application should
 	  have means to test and confirm the image.
 
-if !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 config MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING
 	bool "Allow to erase pending slot"
+	depends on !MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 	default y
 	help
 	  Allows erasing secondary slot which is marked for test or confirmed; this allows
 	  erasing slots that have been set for next boot but the device has not
 	  reset yet, so has not yet been swapped.
-endif
 
 config MCUMGR_GRP_IMG_DIRECT_UPLOAD
 	bool "Allow direct image upload"
+	depends on !MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER
 	help
 	  Enables directly uploading image to selected image partition.
 	  This changes how "image" is understood by MCUmgr: normally MCUmgr allows uploading to
@@ -106,6 +108,7 @@ config MCUMGR_GRP_IMG_DIRECT_UPLOAD
 
 config MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT
 	bool "Reject Direct-XIP applications with mismatched address"
+	depends on MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP || MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
 	help
 	  When enabled, the MCUmgr will compare base address of application,
 	  encoded into .bin file header with use of imgtool, on upload and will

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -87,7 +87,11 @@ BUILD_ASSERT(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
 #define ACTIVE_IMAGE_IS 0
 #endif
 
+#if CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER
+#define SLOTS_PER_IMAGE 1
+#else
 #define SLOTS_PER_IMAGE 2
+#endif
 
 LOG_MODULE_REGISTER(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);
 
@@ -360,7 +364,7 @@ img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash)
 	int i;
 	struct image_version ver;
 
-	for (i = 0; i < 2 * CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER; i++) {
+	for (i = 0; i < SLOTS_PER_IMAGE * CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER; i++) {
 		if (img_mgmt_read_info(i, &ver, hash, NULL) != 0) {
 			continue;
 		}
@@ -381,7 +385,7 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
 	int i;
 	uint8_t hash[IMAGE_HASH_LEN];
 
-	for (i = 0; i < 2 * CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER; i++) {
+	for (i = 0; i < SLOTS_PER_IMAGE * CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER; i++) {
 		if (img_mgmt_read_info(i, ver, hash, NULL) != 0) {
 			continue;
 		}
@@ -1087,7 +1091,8 @@ static const struct mgmt_handler img_mgmt_handlers[] = {
 	[IMG_MGMT_ID_STATE] = {
 		.mh_read = img_mgmt_state_read,
 #if defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP) || \
-	defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD)
+	defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_RAM_LOAD) || \
+	defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
 		.mh_write = NULL
 #else
 		.mh_write = img_mgmt_state_write,

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -250,8 +250,7 @@ int img_mgmt_active_image(void)
 /*
  * Reads the version and build hash from the specified image slot.
  */
-int img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
-				   uint32_t *flags)
+int img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash, uint32_t *flags)
 {
 	struct image_header hdr;
 	struct image_tlv tlv;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -61,7 +61,8 @@ LOG_MODULE_DECLARE(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);
 /**
  * Collects information about the specified image slot.
  */
-#ifndef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+#if !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP) && \
+	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
 uint8_t
 img_mgmt_state_flags(int query_slot)
 {
@@ -143,7 +144,8 @@ img_mgmt_state_flags(int query_slot)
 #endif
 
 #if !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP) && \
-	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT)
+	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT) && \
+	!defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
 int img_mgmt_get_next_boot_slot(int image, enum img_mgmt_next_boot_type *type)
 {
 	const int active_slot = img_mgmt_active_slot(image);
@@ -300,7 +302,8 @@ out:
 	return return_slot;
 }
 #endif /* !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP) && \
-	* !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT)
+	* !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT) && \
+	* !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
 	*/
 
 
@@ -322,6 +325,9 @@ img_mgmt_state_any_pending(void)
 int
 img_mgmt_slot_in_use(int slot)
 {
+#if defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
+	return 0;
+#else
 	int image = img_mgmt_slot_to_image(slot);
 	int active_slot = img_mgmt_active_slot(image);
 
@@ -348,6 +354,7 @@ img_mgmt_slot_in_use(int slot)
 #endif
 
 	return (active_slot == slot);
+#endif /* !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER) */
 }
 
 /**

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -140,6 +140,7 @@ img_mgmt_flash_area_id(int slot)
 		fa_id = FIXED_PARTITION_ID(SLOT0_PARTITION);
 		break;
 
+#if !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER)
 	case 1:
 		fa_id = FIXED_PARTITION_ID(SLOT1_PARTITION);
 		break;
@@ -167,6 +168,7 @@ img_mgmt_flash_area_id(int slot)
 		fa_id = FIXED_PARTITION_ID(SLOT5_PARTITION);
 		break;
 #endif
+#endif /* !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER) */
 
 	default:
 		fa_id = -1;


### PR DESCRIPTION
Adds support for using img mgmt in firmware loader mode, to allow for loading an update image to a device