### PR TITLE
tests: drivers: spi: spi_loopback: Test fast instance at low frequency

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf_at_1mhz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf_at_1mhz.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Note: 1 MHz is too low for fast SPI instance on some nRF platforms.
+ * In such case, use slow instance instead.
+ * This overlay is for negative test.
+ */
+
+&dut_fast {
+	spi-max-frequency = <DT_FREQ_M(1)>;
+};

--- a/tests/drivers/spi/spi_loopback/boards/nrf_at_2mhz.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf_at_2mhz.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Note: 2 MHz is too low for fast SPI instance on some nRF platforms.
+ * In such case, use slow instance instead.
+ * This overlay is for negative test.
+ */
+
+&dut_fast {
+	spi-max-frequency = <DT_FREQ_M(2)>;
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -232,6 +232,18 @@ tests:
     filter: CONFIG_DT_HAS_NXP_FLEXIO_ENABLED and
             CONFIG_DT_HAS_NXP_FLEXIO_SPI_ENABLED
     platform_allow: mimxrt1040_evk
+  drivers.spi.nrf54h_fast_2mhz:
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+      - EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_2mhz.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    harness: console
+    harness_config:
+      fixture: spi_loopback
+      type: one_line
+      regex:
+        - "Failed to initialize nrfx driver"
   drivers.spi.nrf54h_fast_8mhz:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_allow:
@@ -248,6 +260,17 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_32mhz.overlay"
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.nrf54l_1mhz:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_1mhz.overlay"
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
+    harness: console
+    harness_config:
+      fixture: spi_loopback
+      type: one_line
+      regex:
+        - "Failed to initialize nrfx driver"
   drivers.spi.nrf54l_8mhz:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_8mhz.overlay"
     platform_allow:


### PR DESCRIPTION
Due to limited value of clock divider, fast SPI instance can work only at higher bitrates.

Add check for error message when fast instance is
configured to work at low/unsupported bitrate.