### PR TITLE
boards: stm32: Add spi1 to nucleo_h503rb

### DIFF
--- a/boards/st/nucleo_h503rb/nucleo_h503rb.dts
+++ b/boards/st/nucleo_h503rb/nucleo_h503rb.dts
@@ -100,6 +100,13 @@
 	status = "okay";
 };
 
+&spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
 &rng {
 	status = "okay";
 };


### PR DESCRIPTION
Added spi1 configuration to Nucleo H503RB.