### PR TITLE
boards: st: Fix Arduino UART pins for some Nucleo-H7 boards

### DIFF
--- a/boards/st/nucleo_h723zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h723zg/arduino_r3_connector.dtsi
@@ -36,4 +36,4 @@
 
 arduino_i2c: &i2c1 {};
 arduino_spi: &spi1 {};
-arduino_serial: &uart8 {};
+arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -119,6 +119,13 @@
 	d3ppre = <2>;  /* APB4: 137.5 MHz */
 };
 
+&lpuart1 {
+	pinctrl-0 = <&lpuart1_tx_pb6 &lpuart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_h743zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h743zi/arduino_r3_connector.dtsi
@@ -38,3 +38,4 @@
 
 arduino_i2c: &i2c1 {};
 arduino_spi: &spi1 {};
+arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -110,6 +110,13 @@
 	d3ppre = <2>;
 };
 
+&lpuart1 {
+	pinctrl-0 = <&lpuart1_tx_pb6 &lpuart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
@@ -37,4 +37,4 @@
 
 arduino_i2c: &i2c1 {};
 
-arduino_serial: &uart8 {};
+arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -74,6 +74,13 @@
 	clock-frequency = <DT_FREQ_M(480)>;
 };
 
+&lpuart1 {
+	pinctrl-0 = <&lpuart1_tx_pb6 &lpuart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_h753zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h753zi/arduino_r3_connector.dtsi
@@ -37,3 +37,4 @@
 
 arduino_i2c: &i2c1 {};
 arduino_spi: &spi1 {};
+arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -108,6 +108,13 @@
 	d3ppre = <2>;
 };
 
+&lpuart1 {
+	pinctrl-0 = <&lpuart1_tx_pb6 &lpuart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
@@ -37,4 +37,4 @@
 
 arduino_i2c: &i2c1 {};
 
-arduino_serial: &uart8 {};
+arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -92,6 +92,13 @@
 	clock-frequency = <DT_FREQ_M(480)>;
 };
 
+&lpuart1 {
+	pinctrl-0 = <&lpuart1_tx_pb6 &lpuart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";

--- a/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
@@ -34,3 +34,5 @@
 			   <21 0 &gpiob 8 0>;	/* D15 */
 	};
 };
+
+arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -91,6 +91,13 @@
 	d3ppre = <2>;
 };
 
+&lpuart1 {
+	pinctrl-0 = <&lpuart1_tx_pb6 &lpuart1_rx_pb7>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";


### PR DESCRIPTION
Assign correct UART pins to `arduino_serial` according to the boards' schematics for some Nucleo-H7 boards.

Add `arduino_serial` node label and assign appropriate UART pins for the other Nucleo-H7 boards.