### PR TITLE
dts: arm: silabs: change siwg917 board ram start address

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -27,19 +27,28 @@
 		};
 	};
 
-	sram0: memory@0 {
+	/* The first 1KB of SRAM is reserved for the NWP (Network Processor).
+	 * It also protects against null pointer exceptions.
+	 */
+	nwp_reserved: memory@0 {
+		compatible = "zephyr,memory-region","mmio-sram";
+		reg = <0x00000000 DT_SIZE_K(1)>;
+		zephyr,memory-region = "NWP_RESERVED_RAM";
+	};
+
+	sram0: memory@400 {
 		compatible = "mmio-sram";
-		/* siwx91x has 672kB of SRAM shared between the Cortex-M4
+		/* siwx91x has 671kB of SRAM shared between the Cortex-M4
 		 * (Zephyr) and the NWP (Network Processor). 3 memory
 		 * configurations are
 		 * possible:
-		 *  - 196kB
-		 *  - 256kB
-		 *  - 320kB
+		 *  - 195kB
+		 *  - 255kB
+		 *  - 319kB
 		 * Less memory is allocated to Zephyr, more memory is allocated
 		 * to NWP, better are the WiFi and BLE performances.
 		 */
-		reg = <0x00000000 DT_SIZE_K(256)>;
+		reg = <0x00000400 DT_SIZE_K(255)>;
 	};
 
 	sram_dma1: memory-dma@24061c00 {

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -22,9 +22,9 @@
 
 LOG_MODULE_REGISTER(siwx91x_nwp);
 
-BUILD_ASSERT(DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(196) ||
-	     DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(256) ||
-	     DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(320));
+BUILD_ASSERT(DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(195) ||
+	     DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(255) ||
+	     DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(319));
 
 int siwg91x_get_nwp_config(int wifi_oper_mode, sl_wifi_device_configuration_t *get_config)
 {
@@ -43,11 +43,12 @@ int siwg91x_get_nwp_config(int wifi_oper_mode, sl_wifi_device_configuration_t *g
 
 	__ASSERT(get_config, "get_config cannot be NULL");
 
-	if (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(196)) {
+	/* The size does not match exactly because 1 KB is reserved at the start of the RAM */
+	if (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(195)) {
 		boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_480K_M4SS_192K;
-	} else if (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(256)) {
+	} else if (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(255)) {
 		boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_416K_M4SS_256K;
-	} else if (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(320)) {
+	} else if (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) == KB(319)) {
 		boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_352K_M4SS_320K;
 	} else {
 		 k_panic();


### PR DESCRIPTION
The first 1 KB is reserved for the NWP (Network Coprocessor). 

This PR also resolves the null pointer error issue, as a .data or a _ramfunc might get the address 0x0 before this patch.