### PR TITLE
boards: adi: Add both HyperRAM banks to APARD32690

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -9,6 +9,7 @@
 #include <adi/max32/max32690.dtsi>
 #include <adi/max32/max32690-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
+#include <zephyr/dt-bindings/memory-controller/adi-max32-hpb.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -81,6 +82,22 @@
 			   <19 0 &gpio1 26 0>,	/* D13 */
 			   <20 0 &gpio2 17 0>,	/* D14 */
 			   <21 0 &gpio2 18 0>;	/* D15 */
+	};
+
+	sdram1: sdram1@60000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		status = "disabled";
+		device_type = "memory";
+		reg = <0x60000000 DT_SIZE_M(64)>;
+		zephyr,memory-region = "SDRAM1";
+	};
+
+	sdram2: sdram2@70000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		status = "disabled";
+		device_type = "memory";
+		reg = <0x70000000 DT_SIZE_M(64)>;
+		zephyr,memory-region = "SDRAM2";
 	};
 };
 
@@ -226,4 +243,53 @@ pmod_spi: &spi4 {
 &w1 {
 	pinctrl-0 = <&owm_io_p0_8 &owm_pe_p0_7>;
 	pinctrl-names = "default";
+};
+
+&hpb {
+	pinctrl-0 = <&hyp_cs0n_p1_11 &hyp_cs1n_p1_17 &hyp_rwds_p1_14
+				 &hyp_d0_p1_12 &hyp_d1_p1_15
+				 &hyp_d2_p1_19 &hyp_d3_p1_20 &hyp_d4_p1_13
+				 &hyp_d5_p1_16 &hyp_d6_p1_18 &hyp_d7_p1_21>;
+	pinctrl-names = "default";
+	enable-emcc;
+
+	mem@0 {
+		reg = <0>;
+		base-address = <0x60000000>;
+		device-type = <ADI_MAX32_HPB_DEV_TYPE_HYPER_RAM>;
+
+		latency-cycles = <ADI_MAX32_HPB_LAT_6>;
+		read-cs-high = <ADI_MAX32_HPB_CS_HIGH_10_5>;
+		write-cs-high = <ADI_MAX32_HPB_CS_HIGH_10_5>;
+		read-cs-setup = <ADI_MAX32_HPB_CS_SETUP_HOLD_16>;
+		write-cs-setup = <ADI_MAX32_HPB_CS_SETUP_HOLD_14>;
+		read-cs-hold = <ADI_MAX32_HPB_CS_SETUP_HOLD_5>;
+		write-cs-hold = <ADI_MAX32_HPB_CS_SETUP_HOLD_12>;
+
+		/* CR0 settings. Key setting is enabling 6-clock latency, since
+		 * HPB doesn't support 7-clock latency which is default
+		 */
+		config-regs =     <0x1000>;
+		config-reg-vals = <0x801F>;
+	};
+
+	mem@1 {
+		reg = <1>;
+		base-address = <0x70000000>;
+		device-type = <ADI_MAX32_HPB_DEV_TYPE_HYPER_RAM>;
+
+		latency-cycles = <ADI_MAX32_HPB_LAT_6>;
+		read-cs-high = <ADI_MAX32_HPB_CS_HIGH_10_5>;
+		write-cs-high = <ADI_MAX32_HPB_CS_HIGH_10_5>;
+		read-cs-setup = <ADI_MAX32_HPB_CS_SETUP_HOLD_16>;
+		write-cs-setup = <ADI_MAX32_HPB_CS_SETUP_HOLD_14>;
+		read-cs-hold = <ADI_MAX32_HPB_CS_SETUP_HOLD_5>;
+		write-cs-hold = <ADI_MAX32_HPB_CS_SETUP_HOLD_12>;
+
+		/* CR0 settings. Key setting is enabling 6-clock latency, since
+		 * HPB doesn't support 7-clock latency which is default
+		 */
+		config-regs =     <0x1000>;
+		config-reg-vals = <0x801F>;
+	};
 };

--- a/boards/adi/apard32690/apard32690_max32690_m4.yaml
+++ b/boards/adi/apard32690/apard32690_max32690_m4.yaml
@@ -17,5 +17,6 @@ supported:
   - trng
   - counter
   - w1
+  - memc
 ram: 1024
 flash: 3072


### PR DESCRIPTION
Add the correct HypeBus setup for both banks of HypeRAM found on the APARD32690 board.