### PR TITLE
cmake: Set RX build use 64bit doubles as default

### DIFF
--- a/cmake/compiler/gcc/target_rx.cmake
+++ b/cmake/compiler/gcc/target_rx.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 list(APPEND TOOLCHAIN_C_FLAGS)
-list(APPEND TOOLCHAIN_C_FLAGS  -mlittle-endian-data -ffunction-sections -fdata-sections)
+list(APPEND TOOLCHAIN_C_FLAGS  -mlittle-endian-data -ffunction-sections -fdata-sections -m64bit-doubles)
 
 list(APPEND TOOLCHAIN_LD_FLAGS)
 list(APPEND TOOLCHAIN_LD_FLAGS -mlittle-endian-data)


### PR DESCRIPTION
The RX floating-point hardware only works on 32-bit values so default gcc will build doubles as 32-bit, this make many test fail on RX build test.
This commit force the build for RX arch to use 64-bit doubles FPU will be supported later on this arch