### PR TITLE
NXP drivers: mcux gau adc: adds PM low power support

### DIFF
--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 NXP
+ * Copyright 2022-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -547,6 +547,7 @@
 			interrupts = <112 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			zephyr,disabling-power-states = <&suspend &standby>;
 			power-domains = <&power_mode3_domain>;
 		};
 
@@ -556,6 +557,7 @@
 			interrupts = <111 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			zephyr,disabling-power-states = <&suspend &standby>;
 			power-domains = <&power_mode3_domain>;
 		};
 

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -768,6 +768,7 @@ static inline int adc_channel_setup_dt(const struct adc_dt_spec *spec)
  *                  interval was too small. All requested samples are written
  *                  in the buffer, but at least some of them were taken with
  *                  an extra delay compared to what was scheduled.
+ * @retval <0       Any other negative value indicates an error condition.
  */
 __syscall int adc_read(const struct device *dev,
 		       const struct adc_sequence *sequence);

--- a/samples/drivers/adc/adc_dt/boards/frdm_rw612.conf
+++ b/samples/drivers/adc/adc_dt/boards/frdm_rw612.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier Apache-2.0
+#
+CONFIG_PM=y

--- a/samples/drivers/adc/adc_dt/boards/frdm_rw612.overlay
+++ b/samples/drivers/adc/adc_dt/boards/frdm_rw612.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022, 2025 NXP
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,4 +35,8 @@
 		zephyr,resolution = <16>;
 		zephyr,input-positive = <GAU_ADC_CH1>;
 	};
+};
+
+&standby {
+	status = "okay";
 };


### PR DESCRIPTION
Tested samples/drivers/adc/adc_dt on FRDM-RW612. Verified that the ADC state is restored after PM3 mode and the read data is consistent.