### PR TITLE
Update PM code for the NXP LPC GPIO driver

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
@@ -79,4 +79,24 @@
 			slew-rate = "normal";
 		};
 	};
+
+	pinmux_hsgpio0: pinmux_hsgpio0 {
+		group0 {
+			pinmux = <IO_MUX_GPIO11
+				IO_MUX_GPIO12
+				IO_MUX_GPIO18
+				IO_MUX_GPIO21
+				>;
+			slew-rate = "normal";
+		};
+	};
+
+	pinmux_hsgpio1: pinmux_hsgpio1 {
+		group0 {
+			pinmux = <IO_MUX_GPIO44
+				IO_MUX_GPIO55
+				>;
+			slew-rate = "normal";
+		};
+	};
 };

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -75,6 +75,14 @@
 
 &hsgpio0 {
 	status = "okay";
+	pinctrl-0 = <&pinmux_hsgpio0>;
+	pinctrl-names = "default";
+};
+
+&hsgpio1 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_hsgpio1>;
+	pinctrl-names = "default";
 };
 
 &flexspi {

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -18,6 +18,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/drivers/pinctrl.h>
 #include <zephyr/irq.h>
 #include <soc.h>
 #include <fsl_common.h>
@@ -52,6 +53,7 @@ struct gpio_mcux_lpc_config {
 	MCI_IO_MUX_Type * pinmux_base;
 #endif
 	uint32_t port_no;
+	const struct pinctrl_dev_config *pincfg;
 };
 
 struct gpio_mcux_lpc_data {
@@ -417,6 +419,7 @@ static int gpio_mcux_lpc_manage_cb(const struct device *port,
 static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	const struct gpio_mcux_lpc_config *config = dev->config;
+	int error;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
@@ -427,6 +430,10 @@ static int gpio_mcux_lpc_pm_action(const struct device *dev, enum pm_device_acti
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
 		GPIO_PortInit(config->gpio_base, config->port_no);
+		error = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+		if (error) {
+			return error;
+		}
 		break;
 	default:
 		return -ENOTSUP;
@@ -479,6 +486,7 @@ static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
 
 
 #define GPIO_MCUX_LPC(n)								\
+	PINCTRL_DT_INST_DEFINE(n);							\
 	static int lpc_gpio_init_##n(const struct device *dev);				\
 											\
 	static const struct gpio_mcux_lpc_config gpio_mcux_lpc_config_##n = {		\
@@ -488,7 +496,8 @@ static DEVICE_API(gpio, gpio_mcux_lpc_driver_api) = {
 		.gpio_base = (GPIO_Type *)DT_REG_ADDR(DT_INST_PARENT(n)),		\
 		.pinmux_base = PINMUX_BASE,						\
 		.int_source = DT_INST_ENUM_IDX(n, int_source),				\
-		.port_no = DT_INST_REG_ADDR(n)						\
+		.port_no = DT_INST_REG_ADDR(n),						\
+		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n)				\
 	};										\
 											\
 	static struct gpio_mcux_lpc_data gpio_mcux_lpc_data_##n;			\

--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -10,6 +10,7 @@
 #include <zephyr/irq.h>
 #include <errno.h>
 #include <zephyr/drivers/interrupt_controller/nxp_pint.h>
+#include <zephyr/pm/device.h>
 
 #include <fsl_inputmux.h>
 #include <fsl_power.h>
@@ -185,6 +186,24 @@ static void nxp_pint_isr(uint8_t *slot)
 	}
 }
 
+static int intc_nxp_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		break;
+	case PM_DEVICE_ACTION_TURN_OFF:
+		break;
+	case PM_DEVICE_ACTION_TURN_ON:
+		PINT_Init(pint_base);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
 
 /* Defines PINT IRQ handler for a given irq index */
 #define NXP_PINT_IRQ(idx, node_id)						\
@@ -205,10 +224,12 @@ static int intc_nxp_pint_init(const struct device *dev)
 	 * parameter.
 	 */
 	LISTIFY(8, NXP_PINT_IRQ, (;), DT_INST(0, DT_DRV_COMPAT));
-	PINT_Init(pint_base);
 	memset(pin_pint_id, NO_PINT_ID, ARRAY_SIZE(pin_pint_id));
-	return 0;
+
+	return pm_device_driver_init(dev, intc_nxp_pm_action);
 }
 
-DEVICE_DT_INST_DEFINE(0, intc_nxp_pint_init, NULL, NULL, NULL,
+PM_DEVICE_DT_INST_DEFINE(0, intc_nxp_pm_action);
+
+DEVICE_DT_INST_DEFINE(0, intc_nxp_pint_init, PM_DEVICE_DT_INST_GET(0), NULL, NULL,
 		      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -327,6 +327,7 @@
 			<35 2>, <36 2>, <37 2>, <38 2>;
 		num-lines = <8>;
 		num-inputs = <64>;
+		power-domains = <&power_mode3_domain>;
 	};
 
 	imu: nxp_wifi {

--- a/dts/bindings/gpio/nxp,lpc-gpio-port.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio-port.yaml
@@ -5,7 +5,7 @@ description: LPC GPIO port device.
 
 compatible: "nxp,lpc-gpio-port"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, base.yaml, pinctrl-device.yaml]
 
 properties:
   reg:


### PR DESCRIPTION
The pinctrl register bits need to be restored to GPIO mode after we exit from certain low power modes. We cannot rely
on the pin function to default to GPIO.
Also the PINT driver needs to be reinitialized in case we lose its state after we exit certain low power modes.