### PR TITLE
ci: doc: Accessibility improvements + add automated checks in CI

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -149,11 +149,103 @@ jobs:
         lcov --remove doc-coverage.info \*/deprecated > new.info
         genhtml --no-function-coverage --no-branch-coverage new.info -o coverage-report
 
+    - name: Set up Node.js
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        node-version: 24
+
+    - name: Run accessibility check (pa11y)
+      run: |
+        apt-get update -qq && apt-get install -y --no-install-recommends \
+          libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+          libxkbcommon0 libxdamage1 libgbm1 libpango-1.0-0 \
+          libcairo2 libasound2t64
+
+        npm install -g pa11y-ci@4 pa11y-ci-reporter-html@7
+        npx puppeteer browsers install chrome
+
+        python3 -m http.server 8000 --directory doc/_build/html &
+        SERVER_PID=$!
+        sleep 1
+
+        cat <<EOF > .pa11y-ci.json
+        {
+          "defaults": {
+            "timeout": 240000,
+            "runners": [
+              "axe",
+              "htmlcs"
+            ],
+            "concurrency": 2,
+            "chromeLaunchConfig": {
+              "args": [
+                "--disable-dev-shm-usage",
+                "--no-sandbox"
+              ]
+            }
+          },
+          "urls": [
+            {
+              "url": "http://localhost:8000/index.html?mode=light",
+              "screenCapture": "./pa11y-ci-report/index.png"
+            },
+            {
+              "url": "http://localhost:8000/index.html?mode=dark",
+              "screenCapture": "./pa11y-ci-report/index-dark.png"
+            },
+            {
+              "url": "http://localhost:8000/boards/index.html?mode=light#name=devkit",
+              "screenCapture": "./pa11y-ci-report/boards.png"
+            },
+            {
+              "url": "http://localhost:8000/boards/index.html?mode=dark#name=devkit",
+              "screenCapture": "./pa11y-ci-report/boards-dark.png"
+            },
+            {
+              "url": "http://localhost:8000/samples/index.html?mode=light",
+              "screenCapture": "./pa11y-ci-report/samples.png"
+            },
+            {
+              "url": "http://localhost:8000/samples/index.html?mode=dark",
+              "screenCapture": "./pa11y-ci-report/samples-dark.png"
+            },
+            {
+              "url": "http://localhost:8000/develop/getting_started/index.html?mode=light",
+              "screenCapture": "./pa11y-ci-report/getting-started.png"
+            },
+            {
+              "url": "http://localhost:8000/develop/getting_started/index.html?mode=dark",
+              "screenCapture": "./pa11y-ci-report/getting-started-dark.png"
+            },
+            {
+              "url": "http://localhost:8000/contribute/documentation/guidelines.html?mode=light",
+              "screenCapture": "./pa11y-ci-report/guidelines.png"
+            },
+            {
+              "url": "http://localhost:8000/contribute/documentation/guidelines.html?mode=dark",
+              "screenCapture": "./pa11y-ci-report/guidelines-dark.png"
+            }
+          ]
+        }
+        EOF
+
+        mkdir -p pa11y-ci-report
+        pa11y-ci -c .pa11y-ci.json -T 9999 --reporter=pa11y-ci-reporter-html
+
+        kill $SERVER_PID
+
     - name: Compress documentation build artifacts
       run: |
         tar --use-compress-program="xz -T0" -cf html-output.tar.xz --exclude html/_sources --exclude html/doxygen/xml --directory=doc/_build html
         tar --use-compress-program="xz -T0" -cf api-output.tar.xz --directory=doc/_build html/doxygen/html
         tar --use-compress-program="xz -T0" -cf api-coverage.tar.xz coverage-report
+        tar --use-compress-program="xz -T0" -cf accessibility-report.tar.xz pa11y-ci-report
+
+    - name: Upload accessibility report
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: accessibility-report
+        path: accessibility-report.tar.xz
 
     - name: Upload HTML output
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -176,11 +268,16 @@ jobs:
         DOC_URL="https://builds.zephyrproject.io/${REPO_NAME}/pr/${PR_NUM}/docs/"
         API_DOC_URL="https://builds.zephyrproject.io/${REPO_NAME}/pr/${PR_NUM}/docs/doxygen/html/"
         API_COVERAGE_URL="https://builds.zephyrproject.io/${REPO_NAME}/pr/${PR_NUM}/api-coverage/"
+        A11Y_REPORT_URL="https://builds.zephyrproject.io/${REPO_NAME}/pr/${PR_NUM}/accessibility-report/"
 
         echo "${PR_NUM}" > pr_num
-        echo "Documentation will be available shortly at: ${DOC_URL}" >> $GITHUB_STEP_SUMMARY
-        echo "API Documentation will be available shortly at: ${API_DOC_URL}" >> $GITHUB_STEP_SUMMARY
-        echo "API Coverage Report will be available shortly at: ${API_COVERAGE_URL}" >> $GITHUB_STEP_SUMMARY
+        echo "Build results will be available shortly at the following URLs:" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- Documentation: ${DOC_URL}" >> $GITHUB_STEP_SUMMARY
+        echo "- API Documentation: ${API_DOC_URL}" >> $GITHUB_STEP_SUMMARY
+        echo "- API Coverage Report: ${API_COVERAGE_URL}" >> $GITHUB_STEP_SUMMARY
+        echo "- Accessibility Report: ${A11Y_REPORT_URL}" >> $GITHUB_STEP_SUMMARY
+
 
     - name: Upload PR number
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -306,7 +306,8 @@ a.internal:visited code.literal {
 }
 
 .highlight .ch /* Comment.Hashbang */,
-.highlight .cp /* Comment.Preproc */ {
+.highlight .cp /* Comment.Preproc */,
+.highlight .gp /* Generic.Prompt */ {
     color: var(--highlight-keyword2-color);
 }
 

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -467,6 +467,17 @@ kbd, .kbd,
     border-color: var(--guiitems-border-color);
 }
 
+/* footnote labels and brackets tweaks */
+.rst-content .fn-bracket,
+.rst-content .footnote .label,
+.rst-content .citation .label {
+  color: var(--body-color)
+}
+.rst-content .backrefs {
+  color: var(--link-color);
+}
+
+
 /* heading tweaks to make document hierarchy easier to grasp */
 
 .rst-content section > h1 {

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -107,6 +107,30 @@ a.btn:hover {
     color: var(--link-color);
 }
 
+/* Ensure links in body text are visually distinct from other text as per WCAG 1.4.1 */
+.rst-content p a,
+.rst-content blockquote p a,
+.rst-content dl dd p a,
+.rst-content li a {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-thickness: from-font;
+  text-underline-offset: 0.2em;
+}
+.rst-content p a:hover,
+.rst-content blockquote p a:hover,
+.rst-content dl dd p a:hover,
+.rst-content li a:hover {
+  text-decoration: underline;
+}
+/* Preserve no-underline for buttons & navigation */
+a.btn,
+.wy-menu-vertical a,
+.wy-breadcrumbs a,
+.rst-versions a {
+  text-decoration: none !important;
+}
+
 /* Style external links differently to make them easier to distinguish from internal links. */
 .reference.external {
     background-position: center right;

--- a/doc/_static/css/dark.css
+++ b/doc/_static/css/dark.css
@@ -27,11 +27,11 @@
     --navbar-scrollbar-active-color: #7929d2;
     --navbar-scrollbar-background: #1c1e21;
 
-    --link-color: #8cf;
-    --link-color-hover: #9df;
-    --link-color-active: #6ad;
+    --link-color: #6ad;
+    --link-color-hover: #8cf;
+    --link-color-active: #5bc;
     --link-color-visited: #cb99f6;
-    --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjOGNmIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4K");
+    --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNmFkIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4=");
     --classref-badge-text-color: hsl(0, 0%, 70%);
 
     --hr-color: #555;
@@ -54,13 +54,13 @@
     --highlight-background-color: #202531;
     --highlight-background-emph-color: #2d3444;
     --highlight-default-color: rgba(255, 255, 255, 0.85);
-    --highlight-comment-color: rgba(204, 206, 211, 0.5);
-    --highlight-keyword-color: #ff7085;
+    --highlight-comment-color: rgba(204, 206, 211, 0.72);
+    --highlight-keyword-color: #ff8598;
     --highlight-keyword2-color: #42ffc2;
     --highlight-number-color: #a1ffe0;
     --highlight-decorator-color: #abc8ff;
-    --highlight-type-color: #8effda;
-    --highlight-type2-color: #c6ffed;
+    --highlight-type-color: #7df0cb;
+    --highlight-type2-color: #a5f3da;
     --highlight-function-color: #57b3ff;
     --highlight-operator-color: #abc8ff;
     --highlight-string-color: #ffeca1;

--- a/doc/_static/css/light.css
+++ b/doc/_static/css/light.css
@@ -26,11 +26,11 @@
     --navbar-scrollbar-active-color: #7929d2;
     --navbar-scrollbar-background: #131e2b;
 
-    --link-color: #2273a9;
-    --link-color-hover: #3091d1;
-    --link-color-active: #105078;
-    --link-color-visited: #9b59b6;
-    --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMjk4MGI5Ij48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4K");
+    --link-color: #1a5a8a;
+    --link-color-hover: #2563a8;
+    --link-color-active: #0d3d5c;
+    --link-color-visited: #6b3d8a;
+    --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMWE1YThhIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4=");
     --classref-badge-text-color: hsl(0, 0%, 45%);
 
     --hr-color: #e1e4e5;
@@ -53,15 +53,15 @@
     --highlight-background-emph-color: #dbe6c3;
     --highlight-default-color: #404040;
     --highlight-comment-color: #408090;
-    --highlight-keyword-color: #007020;
+    --highlight-keyword-color: #005a1a;
     --highlight-keyword2-color: #902000;
-    --highlight-number-color: #208050;
+    --highlight-number-color: #165a38;
     --highlight-decorator-color: #4070a0;
-    --highlight-type-color: #007020;
-    --highlight-type2-color: #0e84b5;
+    --highlight-type-color: #005a1a;
+    --highlight-type2-color: #0b668c;
     --highlight-function-color: #06287e;
     --highlight-operator-color: #666666;
-    --highlight-string-color: #4070a0;
+    --highlight-string-color: #2d5a88;
 
     --admonition-note-background-color: #e7f2fa;
     --admonition-note-color: #404040;

--- a/doc/_static/js/custom.js
+++ b/doc/_static/js/custom.js
@@ -119,4 +119,10 @@ const registerOnScrollEvent = (function(){
 
         registerOnScrollEvent(mediaQuery);
         mediaQuery.addListener(registerOnScrollEvent);
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const mode = urlParams.get('mode');
+        if (mode) {
+          document.querySelector('dark-mode-toggle').setAttribute('mode', mode);
+        }
       });

--- a/doc/_templates/searchbox.html
+++ b/doc/_templates/searchbox.html
@@ -10,18 +10,18 @@
     {%- if google_searchengine_id is defined %}
     <span id="search-se-settings-icon" class="fa fa-gear" role="button" tabindex="0"
           title="Search settings" aria-label="Search settings"
-          aria-haspopup="true" aria-controls="search-se-menu" aria-expanded="false"
+          aria-haspopup="menu" aria-controls="search-se-menu" aria-expanded="false"
           onclick="toggleSearchEngineSettingsMenu()">
     </span>
     <div id="search-se-menu" role="menu" aria-labelledby="search-se-settings-icon">
       <ul>
         <li id="search-se-menuitem-sphinx" role="menuitemradio" tabindex="-1"
             aria-label="Built-in search" onclick="switchSearchEngine('sphinx')">
-          Built-in search <span class="fa fa-check">
+          Built-in search <span class="fa fa-check"></span>
         </li>
         <li id="search-se-menuitem-google" role="menuitemradio" tabindex="-1"
             aria-label="Google search" onclick="switchSearchEngine('google')">
-          Google search <span class="fa fa-check">
+          Google search <span class="fa fa-check"></span>
         </li>
     </div>
     {%- endif %}

--- a/doc/_templates/searchbox.html
+++ b/doc/_templates/searchbox.html
@@ -23,6 +23,7 @@
             aria-label="Google search" onclick="switchSearchEngine('google')">
           Google search <span class="fa fa-check"></span>
         </li>
+      </ul>
     </div>
     {%- endif %}
     <input type="hidden" name="check_keywords" value="yes" />

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -752,6 +752,7 @@ charts, and other types of diagrams that can be expressed as a graph.
 To include a Graphviz diagram in a document, use the :rst:dir:`graphviz` directive. For example::
 
    .. graphviz::
+      :caption: An example graph using Graphviz
 
       digraph G {
          rankdir=LR;
@@ -763,6 +764,7 @@ To include a Graphviz diagram in a document, use the :rst:dir:`graphviz` directi
 Would render as:
 
    .. graphviz::
+      :caption: An example graph using Graphviz
 
       digraph G {
          rankdir=LR;


### PR DESCRIPTION
Use pa11y to run axe and htmlcs on a few key documentation pages to ensure they meet WCAG and other recommendations in terms of accessibility. The reports will be deployed in a similar way as doxygen coverage report and while there is currently no intention to ever "fail" a build that wouldn't meet accessibility standards, this could be theoretically be done in the future.

The PR also introduces various minor accessibility and contrast tweaks that help improve the initial score (and objectively improve the UX for everyone).

<img width="1110" height="629" alt="image" src="https://github.com/user-attachments/assets/d6d84ca8-be7e-431f-9023-932d4a9e6e45" />

<img width="952" height="731" alt="image" src="https://github.com/user-attachments/assets/739b52ee-2eb5-4030-8b54-7f4477382850" />
