### PR TITLE
Bluetooth: Host: Use macro for nanoseconds per second

### DIFF
--- a/subsys/bluetooth/host/shell/gatt.c
+++ b/subsys/bluetooth/host/shell/gatt.c
@@ -27,6 +27,7 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/time_units.h>
+#include <zephyr/sys_clock.h>
 #include <zephyr/sys/util.h>
 #include <sys/types.h>
 
@@ -61,14 +62,14 @@ static void update_write_stats(uint16_t len)
 	/* if last data rx-ed was greater than 1 second in the past,
 	 * reset the metrics.
 	 */
-	if (delta > 1000000000) {
+	if (delta > NSEC_PER_SEC) {
 		write_stats.len = 0U;
 		write_stats.rate = 0U;
 		cycle_stamp = k_cycle_get_32();
 	} else {
 		write_stats.len += len;
 		write_stats.rate = ((uint64_t)write_stats.len << 3) *
-			1000000000U / delta;
+			NSEC_PER_SEC / delta;
 	}
 }
 

--- a/subsys/bluetooth/host/shell/l2cap.c
+++ b/subsys/bluetooth/host/shell/l2cap.c
@@ -29,6 +29,7 @@
 #include <zephyr/shell/shell_string_conv.h>
 #include <zephyr/sys/atomic_types.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys_clock.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/util.h>
@@ -76,13 +77,13 @@ static int l2cap_recv_metrics(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	/* if last data rx-ed was greater than 1 second in the past,
 	 * reset the metrics.
 	 */
-	if (delta > 1000000000) {
+	if (delta > NSEC_PER_SEC) {
 		len = 0U;
 		l2cap_rate = 0U;
 		cycle_stamp = k_cycle_get_32();
 	} else {
 		len += buf->len;
-		l2cap_rate = ((uint64_t)len << 3) * 1000000000U / delta;
+		l2cap_rate = ((uint64_t)len << 3) * NSEC_PER_SEC / delta;
 	}
 
 	return 0;


### PR DESCRIPTION
Use the macro `NSEC_PER_SEC` defined in `sys_clock.h` for nanoseconds per second when updating write stats.

Fixes: #62641 

Issue #62641 was mostly implemented, but as a comment pointed out there were two files that still used the `1000000000U` constant instead of the macro `NSEC_PER_SEC`, which is defined as `((NSEC_PER_USEC) * (USEC_PER_MSEC) * (MSEC_PER_SEC))`.