### PR TITLE
lib: acpi: Enable poweroff feature

### DIFF
--- a/include/zephyr/acpi/acpi.h
+++ b/include/zephyr/acpi/acpi.h
@@ -299,4 +299,19 @@ ACPI_MADT_LOCAL_APIC *acpi_local_apic_get(int cpu_num);
  */
 int acpi_invoke_method(char *path, ACPI_OBJECT_LIST *arg_list, ACPI_OBJECT *ret_obj);
 
-#endif
+#if defined(CONFIG_ACPI_POWEROFF) || defined(__DOXYGEN__)
+/**
+ * @brief system level poweroff by setting it to soft off.
+ * Requires @kconfig{CONFIG_ACPI_POWEROFF} to be enabled.
+ *
+ * @return -EINVAL if the pm1_cnt address is not available.
+ */
+int acpi_poweroff(void);
+#else
+static inline int acpi_poweroff(void)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_ACPI_POWEROFF */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_ACPI_H_ */

--- a/lib/acpi/Kconfig
+++ b/lib/acpi/Kconfig
@@ -34,6 +34,11 @@ config ACPI_SHELL
 	help
 	  Enable commands for debugging ACPI using the built-in shell.
 
+config ACPI_POWEROFF
+	bool "Power off functionality by setting system to S5 power state"
+	help
+	  Enable support for system power off through ACPI.
+
 config ACPI_DEV_MAX
 	int "maximum child devices"
 	default 1000

--- a/lib/acpi/acpi_shell.c
+++ b/lib/acpi/acpi_shell.c
@@ -346,6 +346,16 @@ static int read_table(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+#if defined(CONFIG_ACPI_POWEROFF)
+
+static void cmd_acpi_poweroff(const struct shell *sh)
+{
+	if (acpi_poweroff()) {
+		shell_print(sh, "ACPI poweroff failed due to invalid PM1_CNT address");
+	}
+}
+#endif
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_acpi,
 	SHELL_CMD(crs, NULL,
@@ -366,6 +376,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		  get_acpi_dev_resource),
 	SHELL_CMD(rd_table, NULL, "read ACPI table (eg: acpi read_table APIC)",
 		  read_table),
+#if defined(CONFIG_ACPI_POWEROFF)
+	SHELL_CMD(poweroff, NULL, "poweroff the platform", cmd_acpi_poweroff),
+#endif
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );
 

--- a/soc/intel/alder_lake/CMakeLists.txt
+++ b/soc/intel/alder_lake/CMakeLists.txt
@@ -10,4 +10,6 @@ zephyr_cc_option(-march=goldmont)
 zephyr_library_sources(cpu.c)
 zephyr_library_sources(../common/soc_gpio.c)
 
+zephyr_library_sources_ifdef(CONFIG_POWEROFF ../common/power.c)
+
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/intel/alder_lake/Kconfig
+++ b/soc/intel/alder_lake/Kconfig
@@ -9,3 +9,4 @@ config SOC_ALDER_LAKE
 	select PCIE_MSI
 	select DYNAMIC_INTERRUPTS
 	select X86_MMU
+	select HAS_POWEROFF if ACPI_POWEROFF

--- a/soc/intel/atom/CMakeLists.txt
+++ b/soc/intel/atom/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 zephyr_include_directories(.)
 
+zephyr_library_sources_ifdef(CONFIG_POWEROFF ../common/power.c)
 set(SOC_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/linker.ld CACHE INTERNAL "")

--- a/soc/intel/atom/Kconfig
+++ b/soc/intel/atom/Kconfig
@@ -4,5 +4,6 @@
 config SOC_ATOM
 	select X86
 	select CPU_ATOM
+	select HAS_POWEROFF if ACPI_POWEROFF
 	imply X86_MMU
 	select ARCH_HAS_RESERVED_PAGE_FRAMES

--- a/soc/intel/common/power.c
+++ b/soc/intel/common/power.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/poweroff.h>
+#include <zephyr/acpi/acpi.h>
+
+void z_sys_poweroff(void)
+{
+#if defined(CONFIG_ACPI_POWEROFF)
+	acpi_poweroff();
+#endif
+	CODE_UNREACHABLE;
+}


### PR DESCRIPTION
Enable system power-off feature using ACPI by setting platform to S5 state.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>