### PR TITLE
stm32wba55cg: tests: drivers: spi: spi_loopback: update gpdma1 request sel

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_wba55cg.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi1 {
-	dmas = <&gpdma1 0 7 STM32_DMA_PERIPH_TX
-		&gpdma1 1 6 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma1 0 2 STM32_DMA_PERIPH_TX
+		&gpdma1 1 1 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";


### PR DESCRIPTION
According to the WBA55 reference manual RM0493, the GPDMA1 requests for spi1_rx_dma and spi1_tx_dma are 1 and 2.

Solve the failed test in the drivers.spi.stm32_spi_dma.loopback scenario.