### PR TITLE
stm32h573i_dk: tests: drivers: spi: spi_loopback:  Change the GPDMA used instance for the SPI test

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/stm32h573i_dk.overlay
@@ -9,8 +9,8 @@
 };
 
 &spi2 {
-	dmas = <&gpdma1 0 9 STM32_DMA_PERIPH_TX
-		&gpdma1 1 8 STM32_DMA_PERIPH_RX>;
+	dmas = <&gpdma2 0 9 STM32_DMA_PERIPH_TX
+		&gpdma2 1 8 STM32_DMA_PERIPH_RX>;
 	dma-names = "tx", "rx";
 
 	slow@0 {
@@ -23,10 +23,6 @@
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 	};
-};
-
-&gpdma1 {
-	status = "okay";
 };
 
 &gpdma2 {


### PR DESCRIPTION
The test succeeded with GPDMA2 instead of GPDMA1.