### PR TITLE
boards: frdm_mcxa166, frdm_mcxa276: add hwinfo support

### DIFF
--- a/drivers/hwinfo/hwinfo_mcux_mcx_cmc.c
+++ b/drivers/hwinfo/hwinfo_mcux_mcx_cmc.c
@@ -11,6 +11,22 @@
 
 LOG_MODULE_REGISTER(hwinfo_cmc, CONFIG_HWINFO_LOG_LEVEL);
 
+#ifndef CMC0
+#define CMC0 CMC
+#endif
+
+#ifdef CMC_SRS_VBAT_MASK
+#define CMC_RESET_MASK_POR (CMC_SRS_POR_MASK | CMC_SRS_VBAT_MASK)
+#else
+#define CMC_RESET_MASK_POR CMC_SRS_POR_MASK
+#endif
+
+#ifdef CMC_SRS_WWDT1_MASK
+#define CMC_RESET_MASK_WATCHDOG (CMC_SRS_WWDT0_MASK | CMC_SRS_WWDT1_MASK)
+#else
+#define CMC_RESET_MASK_WATCHDOG CMC_SRS_WWDT0_MASK
+#endif
+
 /**
  * @brief Translate from CMC reset source mask to Zephyr hwinfo sources mask.
  *
@@ -29,7 +45,7 @@ static uint32_t hwinfo_mcux_cmc_xlate_reset_sources(uint32_t sources)
 		mask |= RESET_LOW_POWER_WAKE;
 	}
 
-	if (sources & (CMC_SRS_POR_MASK | CMC_SRS_VBAT_MASK)) {
+	if (sources & CMC_RESET_MASK_POR) {
 		mask |= RESET_POR;
 	}
 
@@ -49,7 +65,7 @@ static uint32_t hwinfo_mcux_cmc_xlate_reset_sources(uint32_t sources)
 		mask |= RESET_CLOCK;
 	}
 
-	if (sources & (CMC_SRS_WWDT0_MASK | CMC_SRS_WWDT1_MASK)) {
+	if (sources & CMC_RESET_MASK_WATCHDOG) {
 		mask |= RESET_WATCHDOG;
 	}
 
@@ -65,9 +81,11 @@ static uint32_t hwinfo_mcux_cmc_xlate_reset_sources(uint32_t sources)
 		mask |= RESET_WATCHDOG;
 	}
 
+#ifdef CMC_SRS_SECVIO_MASK
 	if (sources & CMC_SRS_SECVIO_MASK) {
 		mask |= RESET_SECURITY;
 	}
+#endif
 
 	return mask;
 }

--- a/dts/arm/nxp/nxp_mcxa166.dtsi
+++ b/dts/arm/nxp/nxp_mcxa166.dtsi
@@ -270,6 +270,11 @@
 				erase-block-size = <8192>;
 				write-block-size = <128>;
 			};
+
+			uuid: uuid@1100800 {
+				compatible = "nxp,lpc-uid";
+				reg = <0x1100800 0x10>;
+			};
 		};
 
 		edma0: dma-controller@40080000 {

--- a/dts/arm/nxp/nxp_mcxa276.dtsi
+++ b/dts/arm/nxp/nxp_mcxa276.dtsi
@@ -270,6 +270,11 @@
 				erase-block-size = <8192>;
 				write-block-size = <128>;
 			};
+
+			uuid: uuid@1100800 {
+				compatible = "nxp,lpc-uid";
+				reg = <0x1100800 0x10>;
+			};
 		};
 
 		edma0: dma-controller@40080000 {

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -26,6 +26,7 @@ config SOC_MCXA166
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
+	select HAS_MCUX_MCX_CMC
 
 config SOC_MCXA276
 	select CPU_CORTEX_M33
@@ -33,3 +34,4 @@ config SOC_MCXA276
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
+	select HAS_MCUX_MCX_CMC


### PR DESCRIPTION
1. enable hwinfo support: device_id and reset_cause
2. verified tests/drivers/hwinfo, API hwinfo_get_device_id and get_reset_cause