### PR TITLE
rtc: fix gpio_pin_configure_dt error

### DIFF
--- a/drivers/rtc/rtc_pcf8563.c
+++ b/drivers/rtc/rtc_pcf8563.c
@@ -72,7 +72,7 @@ struct pcf8563_config {
 
 #ifdef PCF8563_INT1_GPIOS_IN_USE
 /* This work will run the user callback function */
-void callback_work_handler(struct k_work *work);
+static void callback_work_handler(struct k_work *work);
 K_WORK_DEFINE(callback_work, callback_work_handler);
 #endif
 
@@ -423,7 +423,7 @@ static int pcf8563_alarm_set_callback(const struct device *dev, uint16_t id,
 	data->dev = dev;
 
 	/* The PCF8563 int pin requires a pull up to work */
-	ret = gpio_pin_configure_dt(&config->int1, GPIO_INPUT | GPIO_PULL_UP);
+	ret = gpio_pin_configure_dt(&config->int1, GPIO_INPUT);
 	if (ret < 0) {
 		LOG_ERR("Error %d: failed to configure %s pin %d",
 		       ret, config->int1.port->name, config->int1.pin);


### PR DESCRIPTION
GPIO_PULLUP is not in other driver gpio int API, so keep the same