### PR TITLE
boards: nxp: mimxrt1064_evk: set LinkServer as the default runner

### DIFF
--- a/boards/nxp/mimxrt1064_evk/board.cmake
+++ b/boards/nxp/mimxrt1064_evk/board.cmake
@@ -8,6 +8,6 @@ board_runner_args(pyocd "--target=mimxrt1064")
 board_runner_args(jlink "--device=MIMXRT1064")
 board_runner_args(linkserver  "--device=MIMXRT1064xxxxA:EVK-MIMXRT1064")
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)

--- a/boards/nxp/mimxrt1064_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1064_evk/doc/index.rst
@@ -275,9 +275,10 @@ Configuring a Debug Probe
 =========================
 
 .. note::
-	When the device transitions into low power states, the debugger may be
-	unable to access the chip. Use caution when enabling ``CONFIG_PM``, and
-	if the debugger cannot flash the part, see :ref:`Troubleshooting RT1064`
+	* To boot from the QSPI flash, make sure SW7 is set to 0010 and SW5 is set to 0000.
+	* When the device transitions into low power states, the debugger may be
+	  unable to access the chip. Use caution when enabling ``CONFIG_PM``, and
+	  if the debugger cannot flash the part, see :ref:`Troubleshooting RT1064`
 
 For the RT1064, J47/J48 are the SWD isolation jumpers, J42 is the DFU
 mode jumper, and J21 is the 20 pin JTAG/SWD header.
@@ -396,7 +397,7 @@ connected to the EVK properly.
    https://www.nxp.com/webapp/Download?colCode=IMXRT1064QSG
 
 .. _MIMXRT1064-EVK User Guide:
-   https://www.nxp.com/docs/en/data-sheet/MIMXRT10601064EKBHUG.pdf
+   https://www.nxp.com/webapp/Download?colCode=MIMXRT10601064EKBHUG
 
 .. _MIMXRT1064-EVK Debug Firmware:
    https://www.nxp.com/docs/en/application-note/AN13206.pdf

--- a/boards/nxp/mimxrt1064_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1064_evk/doc/index.rst
@@ -263,7 +263,7 @@ This board supports 3 debug host tools. Please install your preferred host
 tool, then follow the instructions in `Configuring a Debug Probe`_ to
 configure the board appropriately.
 
-* :ref:`jlink-debug-host-tools` (Default, Supported by NXP)
+* :ref:`jlink-debug-host-tools` (Supported by NXP)
 * :ref:`linkserver-debug-host-tools` (Supported by NXP)
 * :ref:`pyocd-debug-host-tools` (Not supported by NXP)
 


### PR DESCRIPTION
- Sets LinkServer as the default runner for mimxrt1064-evk board, as the board is configured for CMSIS-DAP by default.
- Fixes link to the MIMXRT1064-EVK User Guide (was broken).
- Adds a note about SW7 and SW5 settings to boot from QSPI.

