### PR TITLE
tests: drivers: flash common testing in non SPI-NOR

### DIFF
--- a/tests/drivers/flash/common/boards/fk7b0m1_vbt6.overlay
+++ b/tests/drivers/flash/common/boards/fk7b0m1_vbt6.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set last blocks of the code flash as storage partition */
+		storage_partition: partition@1e0000 {
+			label = "storage";
+			reg = <0x1e000 DT_SIZE_K(8)>;
+		};
+	};
+};

--- a/tests/drivers/flash/common/boards/mini_stm32h7b0.overlay
+++ b/tests/drivers/flash/common/boards/mini_stm32h7b0.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 2 last blocks of the code flash as storage partition */
+		storage_partition: partition@1e000 {
+			label = "storage";
+			reg = <0x1e000 DT_SIZE_K(8)>;
+		};
+	};
+};


### PR DESCRIPTION
Set an overlay to build tests/drivers/flash/common/ drivers.flash.common.disable_spi_nor when the SPI NOR exists but test does not use it.

Fix error on https://github.com/zephyrproject-rtos/zephyr/issues/89826#issuecomment-2875623648
for the 2 platforms  **fk7b0m1_vbt6** and **mini_stm32h7b0** where the storage partition was in the spi-NOR

As the testcase is disabling the spi-nor (CONFIG_SPI_NOR=n),  the storage partition has to be moved to the internal flash to run the testcase
and test the SOC.