### PR TITLE
boards: frdm_mcxn236: Fix USB next support on this board

### DIFF
--- a/boards/nxp/frdm_mcxn236/board.c
+++ b/boards/nxp/frdm_mcxn236/board.c
@@ -13,9 +13,13 @@
 #include "usb.h"
 
 /* USB PHY configuration */
-#define BOARD_USB_PHY_D_CAL     0x04U
-#define BOARD_USB_PHY_TXCAL45DP 0x07U
-#define BOARD_USB_PHY_TXCAL45DM 0x07U
+#define BOARD_USB_PHY_D_CAL     (0x04U)
+#define BOARD_USB_PHY_TXCAL45DP (0x07U)
+#define BOARD_USB_PHY_TXCAL45DM (0x07U)
+
+usb_phy_config_struct_t usbPhyConfig = {
+	BOARD_USB_PHY_D_CAL, BOARD_USB_PHY_TXCAL45DP, BOARD_USB_PHY_TXCAL45DM,
+};
 #endif
 
 /* Board xtal frequency in Hz */
@@ -219,11 +223,7 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_HF_to_ADC0);
 #endif
 
-#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb1)) && CONFIG_USB_DC_NXP_EHCI
-	usb_phy_config_struct_t usbPhyConfig = {
-		BOARD_USB_PHY_D_CAL, BOARD_USB_PHY_TXCAL45DP, BOARD_USB_PHY_TXCAL45DM,
-	};
-
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb1)) && (CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
 	SPC0->ACTIVE_VDELAY = 0x0500;
 	/* Change the power DCDC to 1.8v (By default, DCDC is 1.8V), CORELDO to 1.1v (By default,
 	 * CORELDO is 1.0V)
@@ -259,7 +259,9 @@ void board_early_init_hook(void)
 	CLOCK_EnableClock(kCLOCK_UsbHsPhy);
 	CLOCK_EnableUsbhsPhyPllClock(kCLOCK_Usbphy480M, BOARD_XTAL0_CLK_HZ);
 	CLOCK_EnableUsbhsClock();
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb1)) && CONFIG_USB_DC_NXP_EHCI
 	USB_EhciPhyInit(kUSB_ControllerEhci0, BOARD_XTAL0_CLK_HZ, &usbPhyConfig);
+#endif
 #endif
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpcmp0))

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -130,6 +130,14 @@
 
 zephyr_udc0: &usb1 {
 	status = "okay";
+	phy-handle = <&usbphy1>;
+};
+
+&usbphy1 {
+	status = "okay";
+	tx-d-cal = <4>;
+	tx-cal-45-dp-ohms = <7>;
+	tx-cal-45-dm-ohms = <7>;
 };
 
 &lpcmp0 {

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.yaml
@@ -25,6 +25,6 @@ supported:
   - pwm
   - regulator
   - spi
+  - usbd
   - watchdog
-  - usb_device
 vendor: nxp

--- a/dts/arm/nxp/nxp_mcxn23x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxn23x_common.dtsi
@@ -754,6 +754,12 @@
 		status = "disabled";
 	};
 
+	usbphy1: usbphy@10a000 {
+		compatible = "nxp,usbphy";
+		reg = <0x10a000 0x1000>;
+		status = "disabled";
+	};
+
 	lpcmp0: lpcmp@51000 {
 		compatible = "nxp,lpcmp";
 		reg = <0x51000 0x1000>;


### PR DESCRIPTION
This board was missing key code changes needed to support Zephyr USB Next