### PR TITLE
posix: clock: fix maybe-uninitialized warning in z_clock_gettime

### DIFF
--- a/lib/posix/options/clock_common.c
+++ b/lib/posix/options/clock_common.c
@@ -59,12 +59,10 @@ int z_vrfy___posix_clock_get_base(clockid_t clock_id, struct timespec *ts)
 
 int z_clock_gettime(clockid_t clock_id, struct timespec *ts)
 {
-	struct timespec base;
+	struct timespec base = {.tv_sec = 0, .tv_nsec = 0};
 
 	switch (clock_id) {
 	case CLOCK_MONOTONIC:
-		base.tv_sec = 0;
-		base.tv_nsec = 0;
 		break;
 
 	case CLOCK_REALTIME:


### PR DESCRIPTION
Compiler gets confused and thinks base may be used uninitialized. This shouldn't be possible, but to make the warning go away, initialize it.

Fixes CI issue in main https://github.com/zephyrproject-rtos/zephyr/actions/runs/15014534061/job/42189411225