### PR TITLE
arm64: core: force data synchronization between context switch

### DIFF
--- a/arch/arm64/core/switch.S
+++ b/arch/arm64/core/switch.S
@@ -74,6 +74,13 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	ldp	x0, x1, [sp], #16
 #endif
 
+#ifdef CONFIG_SMP
+	/* Write barrier: ensure all preceding writes are executed
+	* before writing the switch handle
+	*/
+	dmb sy
+#endif
+
 	/* save old thread into switch handle which is required by
 	 * z_sched_switch_spin()
 	 */


### PR DESCRIPTION
This patch fixes memory corruption that can happen when running in multi-thread and multi-core environment with heavy scheduling stress.

In SMP configuration, we must ensure that all thread's context is stored before writing the switch_handle flag. Otherwise some of the thread context writes could be delayed after another CPU begins to schedule this thread which could lead to memory corruptions.