### PR TITLE
Bluetooth: RFCOMM: Fix CR bit in DISC frame

### DIFF
--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -376,7 +376,7 @@ static int rfcomm_send_disc(struct bt_rfcomm_session *session, uint8_t dlci)
 	buf = bt_l2cap_create_pdu(NULL, 0);
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
-	cr = BT_RFCOMM_RESP_CR(session->role);
+	cr = BT_RFCOMM_CMD_CR(session->role);
 	hdr->address = BT_RFCOMM_SET_ADDR(dlci, cr);
 	hdr->control = BT_RFCOMM_SET_CTRL(BT_RFCOMM_DISC, BT_RFCOMM_PF_NON_UIH);
 	hdr->length = BT_RFCOMM_SET_LEN_8(0);


### PR DESCRIPTION
The CR bit in DISC frames should be set as a command rather than a response.
This patch fixes the rfcomm_send_disc function to correctly use BT_RFCOMM_CMD_CR
instead of BT_RFCOMM_RESP_CR when setting the CR bit in the address field of
DISC frames.

This issue causes PTS fail