### PR TITLE
refine imx jlink runner

### DIFF
--- a/boards/nxp/imx93_evk/CMakeLists.txt
+++ b/boards/nxp/imx93_evk/CMakeLists.txt
@@ -5,12 +5,3 @@
 
 zephyr_library()
 zephyr_library_sources(board.c)
-
-if(CONFIG_SOC_MIMX9352_A55)
-  file(WRITE ${CMAKE_BINARY_DIR}/zephyr/runner.jlinkscript
-    "LE
-    loadfile "${CMAKE_BINARY_DIR}/zephyr/zephyr.bin" ${CONFIG_SRAM_BASE_ADDRESS}
-    WReg PC ${CONFIG_SRAM_BASE_ADDRESS}
-    g
-    q")
-endif()

--- a/boards/nxp/imx93_evk/board.cmake
+++ b/boards/nxp/imx93_evk/board.cmake
@@ -5,7 +5,7 @@
 
 if(CONFIG_SOC_MIMX9352_A55)
 
-board_runner_args(jlink "--device=MIMX9352_A55_0" "--no-reset" "--flash-script=${CMAKE_BINARY_DIR}/zephyr/runner.jlinkscript")
+board_runner_args(jlink "--device=MIMX9352_A55_0" "--no-reset" "--flash-sram")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 

--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -727,6 +727,12 @@ class ZephyrBinaryRunner(abc.ABC):
         else:
             return build_conf['CONFIG_FLASH_BASE_ADDRESS']
 
+    @staticmethod
+    def sram_address_from_build_conf(build_conf: BuildConfiguration):
+        '''return CONFIG_SRAM_BASE_ADDRESS.
+        '''
+        return build_conf['CONFIG_SRAM_BASE_ADDRESS']
+
     def run(self, command: str, **kwargs):
         '''Runs command ('flash', 'debug', 'debugserver', 'attach').
 

--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -54,7 +54,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                  commander=DEFAULT_JLINK_EXE,
                  dt_flash=True, erase=True, reset=False,
                  iface='swd', speed='auto', flash_script = None,
-                 loader=None,
+                 loader=None, flash_sram=False,
                  gdbserver='JLinkGDBServer',
                  gdb_host='',
                  gdb_port=DEFAULT_JLINK_GDB_PORT,
@@ -73,6 +73,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.commander = commander
         self.flash_script = flash_script
         self.dt_flash = dt_flash
+        self.flash_sram = flash_sram
         self.erase = erase
         self.reset = reset
         self.gdbserver = gdbserver
@@ -173,6 +174,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                             help='RTT client, default is JLinkRTTClient')
         parser.add_argument('--rtt-port', default=DEFAULT_JLINK_RTT_PORT,
                             help=f'jlink rtt port, defaults to {DEFAULT_JLINK_RTT_PORT}')
+        parser.add_argument('--flash-sram', default=False, action='store_true',
+                            help='if given, flashing the image to SRAM and '
+                            'modify PC register to be SRAM base address')
 
         parser.set_defaults(reset=False)
 
@@ -182,6 +186,7 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                                  dev_id=args.dev_id,
                                  commander=args.commander,
                                  dt_flash=args.dt_flash,
+                                 flash_sram=args.flash_sram,
                                  erase=args.erase,
                                  reset=args.reset,
                                  iface=args.iface, speed=args.speed,
@@ -386,7 +391,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
             if self.file_type == FileType.HEX:
                 flash_cmd = f'loadfile "{self.file}"'
             elif self.file_type == (FileType.BIN or FileType.MOT):
-                if self.dt_flash:
+                if self.flash_sram:
+                    flash_addr = self.sram_address_from_build_conf(self.build_conf)
+                elif self.dt_flash:
                     flash_addr = self.flash_address_from_build_conf(self.build_conf)
                 else:
                     flash_addr = 0
@@ -407,7 +414,9 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
                 flash_cmd = f'loadfile {self.mot_name}'
             # Preferring .bin over .elf
             elif self.bin_name is not None and os.path.isfile(self.bin_name):
-                if self.dt_flash:
+                if self.flash_sram:
+                    flash_addr = self.sram_address_from_build_conf(self.build_conf)
+                elif self.dt_flash:
                     flash_addr = self.flash_address_from_build_conf(self.build_conf)
                 else:
                     flash_addr = 0
@@ -428,6 +437,10 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
 
         if self.reset:
             lines.append('r') # Reset and halt the target
+
+        if self.flash_sram:
+            sram_addr = self.sram_address_from_build_conf(self.build_conf)
+            lines.append(f'WReg PC 0x{sram_addr:x}') # Change PC to start of SRAM
 
         lines.append('g') # Start the CPU
 


### PR DESCRIPTION
The ogirnal design is using a J-Link script, then the path of image is saved into the script file during building, it will has issue when generate twister artifacts and copy it to another path for testing as path is changed. so refine it to use new parameter of J-Link runner parameter "--flash-sram" to fix this issue.
