### PR TITLE
boards: pan1783: add RST pin on mikrobus connector

### DIFF
--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
@@ -76,7 +76,7 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map =	<0 0 &gpio0 4 0>,	/* AN */
-				/* Not a GPIO*/		/* RST */
+				<1 0 &gpio1 6 0>,	/* RST */
 				<2 0 &gpio1 12 0>,	/* CS */
 				<3 0 &gpio1 15 0>,	/* SCK */
 				<4 0 &gpio1 14 0>,	/* MISO */

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
@@ -69,7 +69,7 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map =        <0 0 &gpio0 4 0>,        /* AN  */
-		/* Not a GPIO*/                /* RST */
+		<1 0 &gpio1 6 0>,         /* RST */
 		<2 0 &gpio1 12 0>,        /* CS   */
 		<3 0 &gpio1 15 0>,        /* SCK  */
 		<4 0 &gpio1 14 0>,        /* MISO */


### PR DESCRIPTION
The RST pin of the Mikrobus connector is P1.06

see https://pideu.panasonic.de/development-hub/pan1783/evaluation_board/user_guide/#mikrobus-interface

<img width="810" alt="image" src="https://github.com/user-attachments/assets/b6ec2247-ff3a-4f26-9aa1-6a03d7de7fd6" />
