### PR TITLE
twister: Enable gathering footprint if test plan exists

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1895,7 +1895,6 @@ class TwisterRunner:
                 except queue.Empty:
                     break
                 else:
-                    inst.metrics.update(self.instances[inst.name].metrics)
                     inst.metrics["handler_time"] = inst.execution_time
                     self.instances[inst.name] = inst
 

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -2530,7 +2530,7 @@ def test_twisterrunner_run(
     pipeline_q = queue.LifoQueue()
     done_q = queue.LifoQueue()
     done_instance = mock.Mock(
-        metrics={'k2': 'v2'},
+        metrics={'k': 'v2'},
         execution_time=30
     )
     done_instance.name='dummy instance'
@@ -2570,8 +2570,7 @@ def test_twisterrunner_run(
     assert tr.jobserver.name == expected_jobserver
 
     assert tr.instances['dummy instance'].metrics == {
-        'k': 'v',
-        'k2': 'v2',
+        'k': 'v2',
         'handler_time': 30
     }
 


### PR DESCRIPTION
If test plan is used, memory usage metrics are overridden. Result of this operation is missing memory footprint.

This change removes redundand metrics update and fixes described inconvenience.