### PR TITLE
libc/minimal: Add stub 'sys/lock.h'

### DIFF
--- a/lib/libc/minimal/include/sys/lock.h
+++ b/lib/libc/minimal/include/sys/lock.h
@@ -1,0 +1,12 @@
+/* sys/lock.h */
+
+/*
+ * Copyright © 2025 Keith Packard
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This file is intentionally empty.
+ * It allows code including it to compile with the minimal libc.
+ */


### PR DESCRIPTION
This file is explicitly included by the espressif hal module. It's an internal file provided by picolibc and newlib. Provide a stub to let code designed for those to work with the minimal C library.