### PR TITLE
zbus: make CONFIG_HEAP_MEM_POOL_ADD_SIZE_ZBUS configurable

### DIFF
--- a/doc/services/zbus/index.rst
+++ b/doc/services/zbus/index.rst
@@ -401,7 +401,7 @@ rate by following design tips:
    ZBus uses :zephyr_file:`include/zephyr/net_buf.h` (network buffers) to exchange data with message
    subscribers. Thus, choose carefully the configurations
    :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_SIZE` and
-   :kconfig:option:`CONFIG_HEAP_MEM_POOL_SIZE`. They are crucial to a proper VDED execution
+   :kconfig:option:`CONFIG_HEAP_MEM_POOL_ADD_SIZE_ZBUS`. They are crucial to a proper VDED execution
    (delivery guarantee) considering message subscribers. If you want to keep an isolated pool for a
    specific set of channels, you can use
    :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_POOL_ISOLATION` with a dedicated pool. Look
@@ -943,6 +943,8 @@ Related configuration options:
   a pool for the message subscriber for a set of channels;
 * :kconfig:option:`CONFIG_ZBUS_MSG_SUBSCRIBER_NET_BUF_STATIC_DATA_SIZE` the biggest message of zbus
   channels to be transported into a message buffer;
+* :kconfig:option:`CONFIG_HEAP_MEM_POOL_ADD_SIZE_ZBUS` the reserved heap size for ZBus in a whole
+  including message buffer allocation;
 * :kconfig:option:`CONFIG_ZBUS_RUNTIME_OBSERVERS` enables the runtime observer registration;
 * :kconfig:option:`CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_DYNAMIC` allocate the runtime observers
   dynamically using the heap;

--- a/subsys/zbus/Kconfig
+++ b/subsys/zbus/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ZBUS
-	bool "Zbus support"
+	bool "ZBus support"
 	depends on MULTITHREADING
 	help
 	  Enables support for Zephyr message bus.
@@ -101,7 +101,7 @@ config ZBUS_PRIORITY_BOOST
 	  to determine a temporary publisher priority.
 
 config ZBUS_ASSERT_MOCK
-	bool "Zbus assert mock for test purposes."
+	bool "ZBus assert mock for test purposes."
 	help
 	  This configuration enables the developer to change the _ZBUS_ASSERT behavior. When this configuration is
 	  enabled, _ZBUS_ASSERT returns -EFAULT instead of assert. It makes it more straightforward to test invalid
@@ -109,11 +109,17 @@ config ZBUS_ASSERT_MOCK
 
 
 config HEAP_MEM_POOL_ADD_SIZE_ZBUS
-	int
+	int "ZBus requested heap pool size."
 	default 2048 if ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC && !ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_DYNAMIC
 	default 1024 if !ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC && ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_DYNAMIC
 	default 3072 if ZBUS_MSG_SUBSCRIBER_BUF_ALLOC_DYNAMIC && ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_DYNAMIC
-
+	default 0
+	help
+	  Configures the available heap memory pool for ZBus.
+	  The heap is used for various ZBus operations (especially required for dynamic buffer allocation for
+	  message subscribers and runtime observers).
+	  In case of dynamic net buffer allocation the heap must fit all data distributed via message subscribers.
+	  Can be set manual, if more heap is required, or default heap size is too big for the soc.
 
 module = ZBUS
 module-str = zbus


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/77631 introduces default non configurable values for zbus heap. This may result in insufficient heap size for application or soc,

This change :

- introduces the option to configure the heap size, without changing the usability.
- updates the documentation to refer to automatic heap calculation configuration when using zbus

Recreation of https://github.com/zephyrproject-rtos/zephyr/pull/89012 to avoid CI failures.