### PR TITLE
stm32wba55cg: tests: drivers: gpio: gpio_basic_api: update arduino pins header

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_wba55cg.overlay
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* loopback with arduino header D2 and D3 */
+/* loopback with arduino header D4 and D5 */
 
 / {
 	resources {
 		compatible = "test-gpio-basic-api";
 		status = "okay";
-		out-gpios = <&arduino_header 8 (GPIO_ACTIVE_HIGH | GPIO_PUSH_PULL | GPIO_PULL_UP)>;
-		in-gpios = <&arduino_header 9 (GPIO_ACTIVE_HIGH | GPIO_PUSH_PULL | GPIO_PULL_UP)>;
+		out-gpios = <&arduino_header 11 (GPIO_ACTIVE_HIGH | GPIO_PUSH_PULL | GPIO_PULL_UP)>;
+		in-gpios = <&arduino_header 10 (GPIO_ACTIVE_HIGH | GPIO_PUSH_PULL | GPIO_PULL_UP)>;
 	};
 };


### PR DESCRIPTION
Loopback with D4 <-> D5 to avoid a failed test with the error "physical pull-down does not read low."
It looks like pins D2-D3 couldn't be configured to pull-up for some reason.