### PR TITLE
kernel: userspace: Fix memory leak in dynamic_object_create

### DIFF
--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -364,7 +364,7 @@ static struct k_object *dynamic_object_create(enum k_objects otype, size_t align
 	} else {
 		dyn->data = z_thread_aligned_alloc(align, obj_size_get(otype) + size);
 		if (dyn->data == NULL) {
-			k_free(dyn->data);
+			k_free(dyn);
 			return NULL;
 		}
 		dyn->kobj.name = dyn->data;


### PR DESCRIPTION
If memory allocation for a dynamic object fails, an attempt is made to free a null pointer instead of the allocated element of the dynamic object list.