### PR TITLE
[DNM] ci: github: Explicit west version for action-zephyr-setup

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -112,6 +112,7 @@ jobs:
       with:
         app-path: zephyr
         toolchains: 'all'
+        west-version: 1.5.0
 
     - name: install-pip
       working-directory: zephyr
@@ -231,6 +232,7 @@ jobs:
       with:
         app-path: zephyr
         toolchains: 'arm-zephyr-eabi'
+        west-version: 1.5.0
 
     - name: install-pip-pkgs
       working-directory: zephyr

--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -63,6 +63,7 @@ jobs:
         with:
           app-path: zephyr
           toolchains: aarch64-zephyr-elf:arc-zephyr-elf:arc64-zephyr-elf:arm-zephyr-eabi:mips-zephyr-elf:riscv64-zephyr-elf:sparc-zephyr-elf:x86_64-zephyr-elf:xtensa-dc233c_zephyr-elf:xtensa-sample_controller32_zephyr-elf:rx-zephyr-elf
+          west-version: 1.5.0
 
       - name: Build firmware
         working-directory: zephyr

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -69,6 +69,7 @@ jobs:
         with:
           app-path: zephyr
           toolchains: all
+          west-version: 1.5.0
 
       - name: Environment Setup
         working-directory: zephyr

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -49,6 +49,7 @@ jobs:
       with:
         app-path: zephyr
         toolchains: all
+        west-version: 1.5.0
 
     - name: Run Pytest For Twister Black Box Tests
       if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
Runs CI workflows using the action-zephyr-setup with an explicit west version.