### PR TITLE
tests: kernel: timer: Align timer tests to nRF54

### DIFF
--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -28,7 +28,7 @@ struct timer_data {
  */
 #define INEXACT_MS_CONVERT ((CONFIG_SYS_CLOCK_TICKS_PER_SEC % MSEC_PER_SEC) != 0)
 
-#if CONFIG_NRF_RTC_TIMER
+#if CONFIG_NRF_RTC_TIMER || CONFIG_NRF_GRTC_TIMER
 /* On Nordic SOCs one or both of the tick and busy-wait clocks may
  * derive from sources that have slews that sum to +/- 13%.
  */

--- a/tests/kernel/timer/timer_behavior/testcase.yaml
+++ b/tests/kernel/timer/timer_behavior/testcase.yaml
@@ -13,6 +13,8 @@ tests:
         regex:
           - "RECORD:(?P<metrics>.*)"
         as_json: ['metrics']
+    platform_exclude:
+      - nrf54h20dk/nrf54h20/cpuppr
   kernel.timer.timer_behavior_external:
     tags:
       - kernel


### PR DESCRIPTION
The new Nordic platforms use GRTC instead of RTC
as the system timer.
Also the nrf54h20 CPUPPR target does not have enough memory to execute the `timer_behavior` test.