### PR TITLE
tests: Bluetooth: Audio: Add RX check for each stream

### DIFF
--- a/tests/bsim/bluetooth/audio/src/bap_common.h
+++ b/tests/bsim/bluetooth/audio/src/bap_common.h
@@ -117,5 +117,7 @@ static inline bool valid_metadata_type(uint8_t type, uint8_t len)
 		return false;
 	}
 }
-
+bool bap_stream_is_streaming(const struct bt_bap_stream *bap_stream);
+bool cap_stream_is_streaming(const struct bt_cap_stream *cap_stream);
+bool audio_test_stream_is_streaming(const struct audio_test_stream *test_stream);
 #endif /* ZEPHYR_TEST_BSIM_BT_AUDIO_TEST_COMMON_ */

--- a/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
+++ b/tests/bsim/bluetooth/audio/src/bap_stream_rx.c
@@ -17,6 +17,8 @@
 
 LOG_MODULE_REGISTER(bap_stream_rx, LOG_LEVEL_INF);
 
+#define LOG_INTERVAL 100
+
 static void log_stream_rx(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
 			  struct net_buf *buf)
 {
@@ -27,39 +29,59 @@ static void log_stream_rx(struct bt_bap_stream *stream, const struct bt_iso_recv
 		info->seq_num, info->ts);
 }
 
+static void log_stream_err(struct audio_test_stream *test_stream,
+			   const struct bt_iso_recv_info *info, struct net_buf *buf)
+{
+	if (!test_stream->last_rx_failed || (test_stream->rx_cnt % LOG_INTERVAL) == 0U) {
+		log_stream_rx(&test_stream->stream.bap_stream, info, buf);
+	}
+
+	test_stream->last_rx_failed = true;
+}
+
 void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_recv_info *info,
 			   struct net_buf *buf)
 {
 	struct audio_test_stream *test_stream = audio_test_stream_from_bap_stream(stream);
+	static bool last_failed;
 
 	test_stream->rx_cnt++;
 	if ((info->flags & BT_ISO_FLAGS_VALID) != 0) {
 		if (memcmp(buf->data, mock_iso_data, buf->len) == 0) {
 			test_stream->valid_rx_cnt++;
+			last_failed = false;
 
 			if (test_stream->valid_rx_cnt >= MIN_SEND_COUNT) {
-				/* We set the flag is just one stream has received the expected */
-				SET_FLAG(flag_audio_received);
+				SET_FLAG(test_stream->flag_audio_received);
 			}
 		} else {
-			log_stream_rx(stream, info, buf);
+			log_stream_err(test_stream, info, buf);
 			FAIL("Unexpected data received\n");
 		}
 	}
 
-	if ((test_stream->rx_cnt % 50U) == 0U) {
+	if ((test_stream->rx_cnt % LOG_INTERVAL) == 0U) {
 		log_stream_rx(stream, info, buf);
 	}
 
+	if (test_stream->rx_cnt >= LOG_INTERVAL && test_stream->valid_rx_cnt == 0U) {
+		log_stream_err(test_stream, info, buf);
+
+		FAIL("No valid RX received: %zu/%zu\n", test_stream->valid_rx_cnt,
+		     test_stream->rx_cnt);
+	}
+
 	if (info->ts == test_stream->last_info.ts) {
-		log_stream_rx(stream, info, buf);
+		log_stream_err(test_stream, info, buf);
+
 		if (test_stream->valid_rx_cnt > 1U) {
 			FAIL("Duplicated timestamp received: %u\n", test_stream->last_info.ts);
 		}
 	}
 
 	if (info->seq_num == test_stream->last_info.seq_num) {
-		log_stream_rx(stream, info, buf);
+		log_stream_err(test_stream, info, buf);
+
 		if (test_stream->valid_rx_cnt > 1U) {
 			FAIL("Duplicated PSN received: %u\n", test_stream->last_info.seq_num);
 		}
@@ -67,14 +89,17 @@ void bap_stream_rx_recv_cb(struct bt_bap_stream *stream, const struct bt_iso_rec
 
 	if (info->flags & BT_ISO_FLAGS_ERROR) {
 		/* Fail the test if we have not received what we expected */
-		log_stream_rx(stream, info, buf);
-		if (test_stream->valid_rx_cnt > 1U && !TEST_FLAG(flag_audio_received)) {
+		log_stream_err(test_stream, info, buf);
+
+		if (test_stream->valid_rx_cnt > 1U &&
+		    !TEST_FLAG(test_stream->flag_audio_received)) {
 			FAIL("ISO receive error\n");
 		}
 	}
 
 	if (info->flags & BT_ISO_FLAGS_LOST) {
-		log_stream_rx(stream, info, buf);
+		log_stream_err(test_stream, info, buf);
+
 		if (test_stream->valid_rx_cnt > 1U) {
 			FAIL("ISO receive lost\n");
 		}

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_client_test.c
@@ -850,8 +850,11 @@ static void transceive_streams(void)
 	}
 
 	if (source_stream != NULL) {
+		struct audio_test_stream *test_stream =
+			audio_test_stream_from_bap_stream(source_stream);
+
 		printk("Waiting for data\n");
-		WAIT_FOR_FLAG(flag_audio_received);
+		WAIT_FOR_FLAG(test_stream->flag_audio_received);
 	}
 }
 

--- a/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_unicast_server_test.c
@@ -336,8 +336,11 @@ static void transceive_test_streams(void)
 	}
 
 	if (sink_stream != NULL) {
+		struct audio_test_stream *test_stream =
+			audio_test_stream_from_bap_stream(sink_stream);
+
 		printk("Waiting for data\n");
-		WAIT_FOR_FLAG(flag_audio_received);
+		WAIT_FOR_FLAG(test_stream->flag_audio_received);
 	}
 }
 

--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -282,6 +282,7 @@ static void started_cb(struct bt_bap_stream *stream)
 	test_stream->valid_rx_cnt = 0U;
 	test_stream->seq_num = 0U;
 	test_stream->tx_cnt = 0U;
+	UNSET_FLAG(test_stream->flag_audio_received);
 
 	printk("Stream %p started\n", stream);
 	k_sem_give(&sem_broadcast_started);
@@ -333,6 +334,7 @@ static void unicast_stream_started(struct bt_bap_stream *stream)
 	test_stream->valid_rx_cnt = 0U;
 	test_stream->seq_num = 0U;
 	test_stream->tx_cnt = 0U;
+	UNSET_FLAG(test_stream->flag_audio_received);
 
 	printk("Started stream %p\n", stream);
 
@@ -796,7 +798,6 @@ static void init(void)
 		UNSET_FLAG(flag_base_received);
 		UNSET_FLAG(flag_pa_synced);
 		UNSET_FLAG(flag_pa_request);
-		UNSET_FLAG(flag_audio_received);
 		UNSET_FLAG(flag_base_metadata_updated);
 		UNSET_FLAG(flag_bis_sync_requested);
 
@@ -882,7 +883,11 @@ static void init(void)
 static void wait_for_data(void)
 {
 	printk("Waiting for data\n");
-	WAIT_FOR_FLAG(flag_audio_received);
+	ARRAY_FOR_EACH_PTR(broadcast_sink_streams, test_stream) {
+		if (audio_test_stream_is_streaming(test_stream)) {
+			WAIT_FOR_FLAG(test_stream->flag_audio_received);
+		}
+	}
 	printk("Data received\n");
 }
 

--- a/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_peripheral_test.c
@@ -769,10 +769,15 @@ static void create_and_sync_sink(void)
 
 static void wait_for_data(void)
 {
-	UNSET_FLAG(flag_audio_received);
-
 	LOG_DBG("Waiting for data");
-	WAIT_FOR_FLAG(flag_audio_received);
+
+	ARRAY_FOR_EACH_PTR(streams, test_stream) {
+		if (audio_test_stream_is_streaming(test_stream) &&
+		    bap_stream_rx_can_recv(&test_stream->stream.bap_stream)) {
+			WAIT_FOR_FLAG(test_stream->flag_audio_received);
+		}
+	}
+
 	LOG_DBG("Data received");
 }
 

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -42,7 +42,6 @@ struct bt_conn *default_conn;
 atomic_t flag_connected;
 atomic_t flag_disconnected;
 atomic_t flag_conn_updated;
-atomic_t flag_audio_received;
 volatile bt_security_t security_level;
 #if defined(CONFIG_BT_CSIP_SET_MEMBER)
 uint8_t csip_rsi[BT_CSIP_RSI_SIZE];

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -140,7 +140,6 @@ extern struct bt_conn *default_conn;
 extern atomic_t flag_connected;
 extern atomic_t flag_disconnected;
 extern atomic_t flag_conn_updated;
-extern atomic_t flag_audio_received;
 extern volatile bt_security_t security_level;
 extern uint8_t csip_rsi[BT_CSIP_RSI_SIZE];
 
@@ -170,6 +169,8 @@ struct audio_test_stream {
 	struct bt_iso_recv_info last_info;
 	size_t rx_cnt;
 	size_t valid_rx_cnt;
+	atomic_t flag_audio_received;
+	bool last_rx_failed;
 };
 
 static inline struct bt_cap_stream *cap_stream_from_bap_stream(struct bt_bap_stream *bap_stream)

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -187,6 +187,7 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 	test_stream->valid_rx_cnt = 0U;
 	test_stream->seq_num = 0U;
 	test_stream->tx_cnt = 0U;
+	UNSET_FLAG(test_stream->flag_audio_received);
 
 	printk("Started stream %p\n", stream);
 
@@ -935,6 +936,20 @@ static void unicast_group_delete(struct bt_cap_unicast_group *unicast_group)
 	}
 }
 
+static void wait_for_data(void)
+{
+	printk("Waiting for data\n");
+
+	ARRAY_FOR_EACH_PTR(unicast_streams, unicast_stream) {
+		if (bap_stream_rx_can_recv(&unicast_stream->stream.stream.bap_stream) &&
+		    audio_test_stream_is_streaming(&unicast_stream->stream)) {
+			WAIT_FOR_FLAG(unicast_stream->stream.flag_audio_received);
+		}
+	}
+
+	printk("Data received\n");
+}
+
 static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 {
 	struct bt_cap_unicast_group *unicast_group;
@@ -994,8 +1009,7 @@ static void test_gmap_ugg_unicast_ac(const struct gmap_unicast_ac_param *param)
 	}
 
 	if (expect_rx) {
-		printk("Waiting for data\n");
-		WAIT_FOR_FLAG(flag_audio_received);
+		wait_for_data();
 	}
 
 	cap_initiator_unicast_audio_stop(unicast_group);

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_multiple_group_multiple_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_multiple_group_multiple_bis.sh
@@ -13,6 +13,14 @@ cd ${BSIM_OUT_PATH}/bin
 
 SIMULATION_ID="bap_broadcast_audio_multiple_group_multiple_bis"
 
+# The test has been ignored for nrf54l15bsim until
+# https://github.com/zephyrproject-rtos/zephyr/issues/98941 has been fixed, as it currently won't
+# pass for nrf54l15bsim.
+if [ "${BOARD_TS}" == "nrf54l15bsim_nrf54l15_cpuapp" ]; then
+    echo "Skipping test for ${BOARD_TS}"
+    exit 0
+fi
+
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \
   -RealEncryption=1 -rs=23 -D=2 -argstest subgroup_cnt 2 streams_per_subgroup_cnt 2

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_multiple_group_multiple_bis.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_broadcast_audio_vs_multiple_group_multiple_bis.sh
@@ -13,6 +13,14 @@ cd ${BSIM_OUT_PATH}/bin
 
 SIMULATION_ID="bap_broadcast_audio_vs_multiple_group_multiple_bis"
 
+# The test has been ignored for nrf54l15bsim until
+# https://github.com/zephyrproject-rtos/zephyr/issues/98941 has been fixed, as it currently won't
+# pass for nrf54l15bsim.
+if [ "${BOARD_TS}" == "nrf54l15bsim_nrf54l15_cpuapp" ]; then
+    echo "Skipping test for ${BOARD_TS}"
+    exit 0
+fi
+
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 -testid=broadcast_source \
   -RealEncryption=1 -rs=23 -D=2 -argstest subgroup_cnt 2 streams_per_subgroup_cnt 2 vs_codec


### PR DESCRIPTION
Changed the generic global flag_audio_received flag to exist for each stream. This will help verify that each stream, if configured for RX, receives the expected data.