### PR TITLE
Fixed Regulator Initialization Bug

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -84,6 +84,7 @@ static DEVICE_API(regulator, regulator_fixed_api) = {
 static int regulator_fixed_init(const struct device *dev)
 {
 	const struct regulator_fixed_config *cfg = dev->config;
+	bool is_enabled = false;
 
 	regulator_common_data_init(dev);
 
@@ -98,9 +99,17 @@ static int regulator_fixed_init(const struct device *dev)
 		if (ret < 0) {
 			return ret;
 		}
+
+		ret = gpio_pin_get_dt(&cfg->enable);
+
+		if (ret < 0) {
+			return ret;
+		}
+
+		is_enabled = ret;
 	}
 
-	return regulator_common_init(dev, false);
+	return regulator_common_init(dev, is_enabled);
 }
 
 #define REGULATOR_FIXED_DEFINE(inst)                                              \

--- a/dts/bindings/regulator/regulator-fixed.yaml
+++ b/dts/bindings/regulator/regulator-fixed.yaml
@@ -10,6 +10,7 @@ include:
     property-allowlist:
       - regulator-name
       - regulator-boot-on
+      - regulator-boot-off
       - regulator-always-on
       - regulator-min-microvolt
       - regulator-max-microvolt


### PR DESCRIPTION
Hello,

I found another post describing the same issue #77542 and want to add some more detail to help sort out what the issue could be.

## The Environment
I am using a STM32 H743VIT on a custom PCB and Zephyr 3.7 to control some regulators via GPIO enable lines. All of my ACTIVE_HIGH GPIO enable pins are working as expected and all of my ACTIVE_LOW pins exhibit the same problem described in the aforementioned issue.

## The Erroneous Behavior
At start up all of the ACTIVE_LOW GPIO pins don't assert so all the regulators erroneously turn on.

Via the regulator cli commands I issue an is_enabled command and it reports the regulator is disabled which indicates to me that the regulator driver thinks it's off when it isn't.

## My Root Cause Analysis
As I understand it the GPIO structure contains a 16 bit variable of type gpio_dt_flags_h for the Device Tree flags. Also as far as I can tell, the macros to control the initialization behavior, namely GPIO_OUTPUT_ACTIVE and GPIO_OUTPUT_INACTIVE, are both out of bounds at 2^17 and 2^18, so adding those into the device tree manually would do nothing. 

When Zephyr boots up it calls do_device_init() on the regulator node, which internally calls gpio_pin_configure that takes in an argument for extra flags; The only thing passed in here is GPIO_OUTPUT which does not prescribe the initialization state of the pin. When this function executes the regulator turns on so **I think the bug is here and another flag needs to be added to ensure the GPIO is set to the correct state**.

## My Fix
I updated the parameter to be GPIO_OUTPUT_INACTIVE since regulator_common_init will handle asserting the pin if it's defined to do so in the device tree.

## The Expected Behavior
At start up all of the ACTIVE_LOW GPIO pins assert so all the regulators remain off.