### PR TITLE
doc: Add reference to time slice Kconfig options

### DIFF
--- a/doc/kernel/services/scheduling/index.rst
+++ b/doc/kernel/services/scheduling/index.rst
@@ -257,6 +257,14 @@ for a kernel object, such as a mutex.
 Use preemptive threads to give priority to time-sensitive processing
 over less time-sensitive processing.
 
+
+Configuration Options
+**********************
+
+* :kconfig:option:`CONFIG_TIMESLICING`
+* :kconfig:option:`CONFIG_TIMESLICE_SIZE`
+* :kconfig:option:`CONFIG_TIMESLICE_PRIORITY`
+
 .. _cpu_idle:
 
 CPU Idling


### PR DESCRIPTION
Updates the scheduling documentation to include references to the time slicing Kconfig options to make them easier to notice.