### PR TITLE
drivers: wifi: nxp: Fix TWT setup issue.

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1235,7 +1235,11 @@ static int nxp_wifi_status(const struct device *dev, struct wifi_iface_status *s
 			} else {
 				status->link_mode = WIFI_3;
 			}
-
+#ifdef CONFIG_NXP_WIFI_11AX_TWT
+			status->twt_capable = nxp_wlan_network.twt_capab;
+#else
+			status->twt_capable = false;
+#endif
 			status->band = nxp_wlan_network.channel > 14 ? WIFI_FREQ_BAND_5_GHZ
 								     : WIFI_FREQ_BAND_2_4_GHZ;
 			status->security = nxp_wifi_key_mgmt_to_zephyr(


### PR DESCRIPTION
When try to set twt, system will try to
get interface status firstly.
In shim driver, miss filling twt_capable field.
The twt_capable is set as false by default.
Failed to set twt because of incorrect
twt_capable.

Add enhance code to fill twt_capable field
in shim driver.