### PR TITLE
drivers: usb: Prevent from perpetual locked state

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -869,6 +869,10 @@ int usb_dc_ep_clear_stall(const uint8_t ep)
 		return -EINVAL;
 	}
 
+	if (!ep_state->ep_stalled) {
+		return 0;
+	}
+
 	status = HAL_PCD_EP_ClrStall(&usb_dc_stm32_state.pcd, ep);
 	if (status != HAL_OK) {
 		LOG_ERR("HAL_PCD_EP_ClrStall failed(0x%02x), %d", ep,


### PR DESCRIPTION
The USB CDC driver is unable to process any bulk IN transfers after receiving 'Clear Feature - Endpoint Halt' request from host due to perpetual locked state caused by previously scheduled transfer, that will never be finished, as the endpoint's state is set to NAK. Fix by cancelling the transfer and releasing the resources blocking from scheduling next transfer upon receiving 'Clear Feature - Endpoint Halt' request.

Fixes #89990