### PR TITLE
net: lib: zperf: fix compilation with UDP/TCP only

### DIFF
--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -426,6 +426,11 @@ static int cmd_udp_download_stop(const struct shell *sh, size_t argc,
 {
 	int ret;
 
+	if (!IS_ENABLED(CONFIG_NET_UDP)) {
+		shell_warn(sh, "UDP not supported");
+		return -ENOEXEC;
+	}
+
 	ret = zperf_udp_download_stop();
 	if (ret < 0) {
 		shell_fprintf(sh, SHELL_WARNING, "UDP server not running!\n");
@@ -1493,6 +1498,11 @@ static int cmd_tcp_download_stop(const struct shell *sh, size_t argc,
 				 char *argv[])
 {
 	int ret;
+
+	if (!IS_ENABLED(CONFIG_NET_TCP)) {
+		shell_warn(sh, "TCP not supported");
+		return -ENOEXEC;
+	}
 
 	ret = zperf_tcp_download_stop();
 	if (ret < 0) {


### PR DESCRIPTION
Fix regression introduced by #88747 that breaks linking with zperf server enabled but TCP or UDP disabled.