### PR TITLE
boards: nxp: make equal partition slots

### DIFF
--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -204,25 +204,26 @@ zephyr_udc0: &usbotg {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 2KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 3 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(180) + DT_SIZE_K(6))>;
+			reg = <0x00010000 DT_SIZE_K(182)>;
 		};
-		slot1_partition: partition@3E800 {
+		slot1_partition: partition@3D800 {
 			label = "image-1";
-			reg = <0x0003E800 DT_SIZE_K(180)>;
+			reg = <0x0003D800 DT_SIZE_K(182)>;
 		};
-		storage_partition: partition@6B800 {
+		storage_partition: partition@6B000 {
 			label = "storage";
-			reg = <0x0006B800 DT_SIZE_K(82)>;
+			reg = <0x0006B000 DT_SIZE_K(84)>;
 		};
 
 	};

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -233,21 +233,22 @@ zephyr_udc0: &usbotg {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 4KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(416) + DT_SIZE_K(8))>;
+			reg = <0x00010000 DT_SIZE_K(420)>;
 		};
-		slot1_partition: partition@7a000 {
+		slot1_partition: partition@79000 {
 			label = "image-1";
-			reg = <0x0007a000 DT_SIZE_K(416)>;
+			reg = <0x00079000 DT_SIZE_K(420)>;
 		};
 		storage_partition: partition@e2000 {
 			label = "storage";

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -158,20 +158,21 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 4KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(44)>;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@b000 {
 			label = "image-0";
-			reg = <0xb000 (DT_SIZE_K(96) + DT_SIZE_K(8))>;
+			reg = <0xb000 DT_SIZE_K(100)>;
 		};
-		slot1_partition: partition@25000 {
+		slot1_partition: partition@24000 {
 			label = "image-1";
-			reg = <0x25000 DT_SIZE_K(96)>;
+			reg = <0x24000 DT_SIZE_K(100)>;
 		};
 		storage_partition: partition@3d000 {
 			label = "storage";

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -141,20 +141,21 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 2KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(44)>;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@b000 {
 			label = "image-0";
-			reg = <0xb000 (DT_SIZE_K(98) + DT_SIZE_K(4))>;
+			reg = <0xb000 DT_SIZE_K(100)>;
 		};
-		slot1_partition: partition@24800 {
+		slot1_partition: partition@24000 {
 			label = "image-1";
-			reg = <0x24800 DT_SIZE_K(98)>;
+			reg = <0x24000 DT_SIZE_K(100)>;
 		};
 		storage_partition: partition@3d000 {
 			label = "storage";

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -158,25 +158,27 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 2KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 3 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(202) + DT_SIZE_K(6))>;
+			reg = <0x00010000 DT_SIZE_K(204)>;
 		};
-		slot1_partition: partition@44000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x00044000 DT_SIZE_K(202)>;
+			reg = <0x00043000 DT_SIZE_K(204)>;
 		};
-		storage_partition: partition@76800 {
+		storage_partition: partition@76000 {
 			label = "storage";
-			reg = <0x00076800 DT_SIZE_K(38)>;
+			reg = <0x00076000 DT_SIZE_K(40)>;
 		};
 	};
 };

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -135,17 +135,19 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 8KB.
 		 */
 		boot_partition: partition@0 {
 			reg = <0x0 DT_SIZE_K(64)>;
 		};
 		slot0_partition: partition@10000 {
-			reg = <0x10000 (DT_SIZE_K(416) + DT_SIZE_K(16))>;
+			reg = <0x10000 DT_SIZE_K(424)>;
 		};
-		slot1_partition: partition@7C000 {
-			reg = <0x7C000 DT_SIZE_K(416)>;
+		slot1_partition: partition@7A000 {
+			reg = <0x7A000 DT_SIZE_K(424)>;
 		};
 		storage_partition: partition@E4000 {
 			reg = <0xE4000 DT_SIZE_K(112)>;

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -101,24 +101,25 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(2 * 4))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@323000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00323000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@623000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00623000 (DT_SIZE_M(58) - DT_SIZE_K(136))>;
+				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/hexiwear/hexiwear_mk64f12.dts
+++ b/boards/nxp/hexiwear/hexiwear_mk64f12.dts
@@ -187,21 +187,23 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 4KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(416) + DT_SIZE_K(8))>;
+			reg = <0x00010000 DT_SIZE_K(420)>;
 		};
-		slot1_partition: partition@7a000 {
+		slot1_partition: partition@79000 {
 			label = "image-1";
-			reg = <0x0007a000 DT_SIZE_K(416)>;
+			reg = <0x00079000 DT_SIZE_K(420)>;
 		};
 		storage_partition: partition@e2000 {
 			label = "storage";

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -105,24 +105,26 @@ arduino_serial: &lpuart1 {};
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
+				reg = <0x00020000 DT_SIZE_M(7)>;
 			};
-			slot1_partition: partition@723000 {
+			slot1_partition: partition@720000 {
 				label = "image-1";
-				reg = <0x00723000 DT_SIZE_M(7)>;
+				reg = <0x00720000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E23000 {
+			storage_partition: partition@E20000 {
 				label = "storage";
-				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
+				reg = <0x00E20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -102,24 +102,26 @@ arduino_serial: &lpuart4 {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
+				reg = <0x00020000 DT_SIZE_M(7)>;
 			};
-			slot1_partition: partition@723000 {
+			slot1_partition: partition@720000 {
 				label = "image-1";
-				reg = <0x00723000 DT_SIZE_M(7)>;
+				reg = <0x00720000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E23000 {
+			storage_partition: partition@E20000 {
 				label = "storage";
-				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
+				reg = <0x00E20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -109,24 +109,26 @@ arduino_serial: &lpuart2 {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@322000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00322000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@622000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
+				reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -102,20 +102,22 @@ arduino_serial: &lpuart2 {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 4KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 (DT_SIZE_K(1920) + DT_SIZE_K(8))>;
+			reg = <0x00020000 DT_SIZE_K(1924)>;
 		};
-		slot1_partition: partition@202000 {
+		slot1_partition: partition@201000 {
 			label = "image-1";
-			reg = <0x00202000 DT_SIZE_K(1920)>;
+			reg = <0x00201000 DT_SIZE_K(1924)>;
 		};
 		storage_partition: partition@3E2000 {
 			label = "storage";

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -131,24 +131,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@322000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00322000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@622000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
+				reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
@@ -48,24 +48,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 256KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(512))>;
+				reg = <0x00040000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@3C0000 {
+			slot1_partition: partition@340000 {
 				label = "image-1";
-				reg = <0x003C0000 DT_SIZE_M(3)>;
+				reg = <0x00340000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@6C0000 {
+			storage_partition: partition@640000 {
 				label = "storage";
-				reg = <0x006C0000 (DT_SIZE_M(58) - DT_SIZE_K(768))>;
+				reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
@@ -33,24 +33,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@322000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00322000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@622000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
+				reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
@@ -46,24 +46,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 256KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(512))>;
+				reg = <0x00040000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@3C0000 {
+			slot1_partition: partition@340000 {
 				label = "image-1";
-				reg = <0x003C0000 DT_SIZE_M(3)>;
+				reg = <0x00340000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@6C0000 {
+			storage_partition: partition@640000 {
 				label = "storage";
-				reg = <0x006C0000 (DT_SIZE_M(58) - DT_SIZE_K(768))>;
+				reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
@@ -36,24 +36,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(8))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@322000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00322000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@622000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00622000 (DT_SIZE_M(2) - DT_SIZE_K(136))>;
+				reg = <0x00620000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -207,24 +207,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 256KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(256)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@40000 {
 				label = "image-0";
-				reg = <0x00040000 (DT_SIZE_M(3) + DT_SIZE_K(512))>;
+				reg = <0x00040000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@3C0000 {
+			slot1_partition: partition@340000 {
 				label = "image-1";
-				reg = <0x003C0000 DT_SIZE_M(3)>;
+				reg = <0x00340000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@6C0000 {
+			storage_partition: partition@640000 {
 				label = "storage";
-				reg = <0x006C0000 (DT_SIZE_M(58) - DT_SIZE_K(768))>;
+				reg = <0x00640000 (DT_SIZE_M(58) - DT_SIZE_K(256))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -188,20 +188,22 @@ nxp_parallel_i2c: &lpi2c1 {};
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 4KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 (DT_SIZE_K(1980) + DT_SIZE_K(8))>;
+			reg = <0x00020000 DT_SIZE_K(1984)>;
 		};
-		slot1_partition: partition@211000 {
+		slot1_partition: partition@210000 {
 			label = "image-1";
-			reg = <0x00211000 DT_SIZE_K(1980)>;
+			reg = <0x00210000 DT_SIZE_K(1984)>;
 		};
 		/* The storage partition is located in is25wp064 */
 	};

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -105,24 +105,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
+				reg = <0x00020000 DT_SIZE_M(7)>;
 			};
-			slot1_partition: partition@723000 {
+			slot1_partition: partition@720000 {
 				label = "image-1";
-				reg = <0x00723000 DT_SIZE_M(7)>;
+				reg = <0x00720000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E23000 {
+			storage_partition: partition@E20000 {
 				label = "storage";
-				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
+				reg = <0x00E20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -233,24 +233,25 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
+				reg = <0x00020000 DT_SIZE_M(7)>;
 			};
-			slot1_partition: partition@723000 {
+			slot1_partition: partition@720000 {
 				label = "image-1";
-				reg = <0x00723000 DT_SIZE_M(7)>;
+				reg = <0x00720000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E23000 {
+			storage_partition: partition@E20000 {
 				label = "storage";
-				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
+				reg = <0x00E20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -36,24 +36,25 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
+				reg = <0x00020000 DT_SIZE_M(7)>;
 			};
-			slot1_partition: partition@723000 {
+			slot1_partition: partition@720000 {
 				label = "image-1";
-				reg = <0x00723000 DT_SIZE_M(7)>;
+				reg = <0x00720000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E23000 {
+			storage_partition: partition@E20000 {
 				label = "storage";
-				reg = <0x00E23000 (DT_SIZE_M(50) - DT_SIZE_K(140))>;
+				reg = <0x00E20000 (DT_SIZE_M(50) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -39,24 +39,25 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
+				reg = <0x00020000 DT_SIZE_M(7)>;
 			};
-			slot1_partition: partition@723000 {
+			slot1_partition: partition@720000 {
 				label = "image-1";
-				reg = <0x00723000 DT_SIZE_M(7)>;
+				reg = <0x00720000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E23000 {
+			storage_partition: partition@E20000 {
 				label = "storage";
-				reg = <0x00E23000 (DT_SIZE_M(50) - DT_SIZE_K(140))>;
+				reg = <0x00E20000 (DT_SIZE_M(50) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk.dtsi
@@ -199,24 +199,25 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(7) + DT_SIZE_K(12))>;
+				reg = <0x00020000 DT_SIZE_M(7)>;
 			};
-			slot1_partition: partition@723000 {
+			slot1_partition: partition@720000 {
 				label = "image-1";
-				reg = <0x00723000 DT_SIZE_M(7)>;
+				reg = <0x00720000 DT_SIZE_M(7)>;
 			};
-			storage_partition: partition@E23000 {
+			storage_partition: partition@E20000 {
 				label = "storage";
-				reg = <0x00E23000 (DT_SIZE_M(2) - DT_SIZE_K(140))>;
+				reg = <0x00E20000 (DT_SIZE_M(2) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -406,24 +406,25 @@ zephyr_udc0: &usbhs {
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(3 * 4))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@323000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00323000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@623000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00623000 (DT_SIZE_M(58) - DT_SIZE_K(140))>;
+				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -268,24 +268,25 @@ i2s1: &flexcomm3 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(2 * 4))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@323000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00323000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@623000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00623000 (DT_SIZE_M(58) - DT_SIZE_K(136))>;
+				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -149,24 +149,25 @@ arduino_i2c: &flexcomm2 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 2 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(2 * 4))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@323000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x00323000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@623000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x00623000 (DT_SIZE_M(58) - DT_SIZE_K(136))>;
+				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 			};
 		};
 	};

--- a/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/nxp/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -236,25 +236,26 @@ zephyr_udc0: &usbotg {
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 4KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 3 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(928) + DT_SIZE_K(12))>;
+			reg = <0x00010000 DT_SIZE_K(932)>;
 		};
-		slot1_partition: partition@FB000 {
+		slot1_partition: partition@F9000 {
 			label = "image-1";
-			reg = <0x000FB000 DT_SIZE_K(928)>;
+			reg = <0x000F9000 DT_SIZE_K(932)>;
 		};
-		storage_partition: partition@1E3000 {
+		storage_partition: partition@1E2000 {
 			label = "storage";
-			reg = <0x001E3000 DT_SIZE_K(116)>;
+			reg = <0x001E2000 DT_SIZE_K(120)>;
 		};
 	};
 };

--- a/boards/nxp/twr_ke18f/twr_ke18f.dts
+++ b/boards/nxp/twr_ke18f/twr_ke18f.dts
@@ -338,21 +338,23 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 4KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(200) + DT_SIZE_K(8))>;
+			reg = <0x00010000 DT_SIZE_K(204)>;
 		};
-		slot1_partition: partition@44000 {
+		slot1_partition: partition@43000 {
 			label = "image-1";
-			reg = <0x00044000 DT_SIZE_K(200)>;
+			reg = <0x00043000 DT_SIZE_K(204)>;
 		};
 		storage_partition: partition@76000 {
 			label = "storage";

--- a/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/nxp/twr_kv58f220m/twr_kv58f220m.dts
@@ -115,21 +115,23 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		/*
+		 * Partition sizes must be aligned
+		 * to the flash memory sector size of 8KB.
+		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
-		/* The MCUBoot swap-move algorithm uses the last 2 sectors
-		 * of the primary slot0 for swap status and move.
-		 */
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 (DT_SIZE_K(416) + DT_SIZE_K(16))>;
+			reg = <0x00010000 DT_SIZE_K(424)>;
 		};
-		slot1_partition: partition@7C000 {
+		slot1_partition: partition@7A000 {
 			label = "image-1";
-			reg = <0x0007C000 DT_SIZE_K(416)>;
+			reg = <0x0007A000 DT_SIZE_K(424)>;
 		};
 		storage_partition: partition@E4000 {
 			label = "storage";

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -212,24 +212,26 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			/*
+			 * Partition sizes must be aligned
+			 * to the flash memory sector size of 4KB.
+			 */
 			boot_partition: partition@0 {
 				label = "mcuboot";
 				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			/* The MCUBoot swap-move algorithm uses the last 3 sectors
-			 * of the primary slot0 for swap status and move.
-			 */
 			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00020000 (DT_SIZE_M(3) + DT_SIZE_K(3 * 4))>;
+				reg = <0x00020000 DT_SIZE_M(3)>;
 			};
-			slot1_partition: partition@32E000 {
+			slot1_partition: partition@320000 {
 				label = "image-1";
-				reg = <0x0032E000 DT_SIZE_M(3)>;
+				reg = <0x00320000 DT_SIZE_M(3)>;
 			};
-			storage_partition: partition@62E000 {
+			storage_partition: partition@620000 {
 				label = "storage";
-				reg = <0x0062E000 (DT_SIZE_M(58) - DT_SIZE_K(140))>;
+				reg = <0x00620000 (DT_SIZE_M(58) - DT_SIZE_K(128))>;
 			};
 		};
 	};


### PR DESCRIPTION
- creates equal partition slots for NXP boards.
- allows support for all firmware update modes, primarily for the new preferred "Swap using offset".
- also should fix https://github.com/zephyrproject-rtos/zephyr/issues/88850