### PR TITLE
boards: st: nucleo_g474re: fix comment in Kconfig.defconfig

### DIFF
--- a/boards/st/nucleo_g474re/Kconfig.defconfig
+++ b/boards/st/nucleo_g474re/Kconfig.defconfig
@@ -9,4 +9,4 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
-endif # BOARD_NUCLEO_G431RB
+endif # BOARD_NUCLEO_G474RE


### PR DESCRIPTION
Comment is referring to wrong board.