### PR TITLE
Bluetooth: ISO: Add check to prevent premature BIG termination

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -1313,6 +1313,9 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 /**
  * @brief Terminates a BIG as a broadcaster or receiver
  *
+ * This function cannot be called while in @ref bt_iso_big_cb.started, @ref bt_iso_big_cb.stopped,
+ * @ref bt_iso_chan_ops.connected or @ref bt_iso_chan_ops.disconnected callbacks.
+ *
  * @param big    Pointer to the BIG structure.
  *
  * @return 0 in case of success or negative value in case of error.

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -51,6 +51,11 @@ enum {
 	BT_BIG_PENDING,
 	/* Creating a BIG as a receiver */
 	BT_BIG_SYNCING,
+	/* BIG is busy handling an HCI event.
+	 *
+	 * Use this to prevent API calls from modifying the BIG while the event is being processed.
+	 */
+	BT_BIG_BUSY,
 
 	BT_BIG_NUM_FLAGS,
 };


### PR DESCRIPTION
There was an issue where terminating the BIG while in the ISO connected callbacks could lead to continueing the loops would cause access to cleared memory.

The simple solution to this is to simply prevent
bt_iso_big_terminate from terminating the BIGs while we are processing the BIG HCI events.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/89985