### PR TITLE
sensors: Add AC metrics to sensor channels

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -202,6 +202,35 @@ enum sensor_channel {
 	/** Gyroscope bias (X/Y/Z components in radians/s) */
 	SENSOR_CHAN_GBIAS_XYZ,
 
+	/** AC active energy */
+	SENSOR_CHAN_AC_ACTIVE_ENERGY,
+	/** AC fundamental reactive energy */
+	SENSOR_CHAN_AC_FUNDAMENTAL_REACTIVE_ENERGY,
+	/** AC apparent energy */
+	SENSOR_CHAN_AC_APPARENT_ENERGY,
+	/** AC active power */
+	SENSOR_CHAN_AC_ACTIVE_POWER,
+	/** AC fundamental reactive power */
+	SENSOR_CHAN_AC_FUNDAMENTAL_REACTIVE_POWER,
+	/** AC apparent power */
+	SENSOR_CHAN_AC_APPARENT_POWER,
+	/** AC current RMS */
+	SENSOR_CHAN_AC_CURRENT_RMS,
+	/** AC half current RMS */
+	SENSOR_CHAN_AC_HALF_CURRENT_RMS,
+	/** AC voltage RMS */
+	SENSOR_CHAN_AC_VOLTAGE_RMS,
+	/** AC half voltage RMS */
+	SENSOR_CHAN_AC_HALF_VOLTAGE_RMS,
+	/** AC power factor */
+	SENSOR_CHAN_AC_POWER_FACTOR,
+	/** AC period */
+	SENSOR_CHAN_AC_PERIOD,
+	/** AC frequency */
+	SENSOR_CHAN_AC_FREQUENCY,
+	/** AC angle */
+	SENSOR_CHAN_AC_ANGLE,
+
 	/** All channels. */
 	SENSOR_CHAN_ALL,
 


### PR DESCRIPTION
There are no Alternating Current (AC) channels in the sensor channels list. Add the necessary channels to make energy metering devices available on the sensor API.

This is needed by the addition of the ADE9153A energy metering sensor #90003