### PR TITLE
device: Provide de-init device function only if requested

### DIFF
--- a/kernel/Kconfig.device
+++ b/kernel/Kconfig.device
@@ -33,6 +33,16 @@ config DEVICE_DT_METADATA
 	  each device. This allows you to use device_get_by_dt_nodelabel(),
 	  device_get_dt_metadata(), etc.
 
+config DEVICE_DEINIT_SUPPORT
+	bool "Support device de-initialization"
+	default y
+	help
+	  In very specific case, it might be necessary to de-initialize
+	  a device at runtime. This is possible by providing a function
+	  to do so. Note, that this will grow every struct device by a
+	  function pointer. All device drivers that use the relevant
+	  macros and provide such function should select this option.
+
 endmenu
 
 menu "Initialization Priorities"

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -145,6 +145,7 @@ bool z_impl_device_is_ready(const struct device *dev)
 
 int z_impl_device_deinit(const struct device *dev)
 {
+#ifdef CONFIG_DEVICE_DEINIT_SUPPORT
 	int ret;
 
 	if (!dev->state->initialized) {
@@ -163,6 +164,10 @@ int z_impl_device_deinit(const struct device *dev)
 	dev->state->initialized = false;
 
 	return 0;
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif /* CONFIG_DEVICE_DEINIT_SUPPORT */
 }
 
 #ifdef CONFIG_USERSPACE


### PR DESCRIPTION
Option is enabled by default in order to no alter current behavior