### PR TITLE
device: Add an option to generate the device name from the node-label

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -195,9 +195,17 @@ typedef int16_t device_handle_t;
  *
  * @return The value of the node's `label` property, if it has one.
  * Otherwise, the node's full name in `node-name@unit-address` form.
+ * If CONFIG_DEVICE_DT_NAME_FROM_NODE_LABEL is enabled, it will use the
+ * node-label in priority over the full name, if the `label` property is not
+ * present. Note that, in this case, the first node-label is always used.
  */
 #define DEVICE_DT_NAME(node_id)                                                \
-	DT_PROP_OR(node_id, label, DT_NODE_FULL_NAME(node_id))
+	DT_PROP_OR(node_id, label,                                             \
+		   COND_CODE_1(CONFIG_DEVICE_DT_NAME_FROM_NODE_LABEL,          \
+			       (COND_CODE_1(DT_HAS_NODELABEL_MAIN(node_id),   \
+					    (DT_NODELABEL_MAIN_STR(node_id)), \
+					    (DT_NODE_FULL_NAME(node_id)))),   \
+			       (DT_NODE_FULL_NAME(node_id))))
 
 /**
  * @brief Create a device object from a devicetree node identifier and set it up

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -196,6 +196,34 @@
 #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
 
 /**
+ * @brief Check if a node has a main node-label
+ *
+ * @param node_id node identifier
+ * @return 1 if such macro exists, 0 otherwise
+ */
+#define DT_HAS_NODELABEL_MAIN(node_id)				\
+	IS_ENABLED(DT_CAT(node_id, _NODELABEL_MAIN_EXISTS))
+
+/**
+ * @brief Get the main node label macro from a node identifier
+ *
+ * @param node_id node identifier
+ * @return the macro which, if it exists, will give the main node label
+ */
+#define DT_NODELABEL_MAIN(node_id) DT_CAT(node_id, _NODELABEL_MAIN)
+
+/**
+ * @brief Get the main node label as a string
+ *
+ * Note: Prior to calling this macro, one should ensure that DT_NODELABEL_MAIN
+ * actually exists.
+ *
+ * @param node_id node identifier
+ * @return node's main label as a string
+ */
+#define DT_NODELABEL_MAIN_STR(node_id) STRINGIFY(DT_NODELABEL_MAIN(node_id))
+
+/**
  * @brief Get a node identifier from /aliases
  *
  * This macro's argument is a property of the `/aliases` node. It

--- a/kernel/Kconfig.device
+++ b/kernel/Kconfig.device
@@ -33,6 +33,19 @@ config DEVICE_DT_METADATA
 	  each device. This allows you to use device_get_by_dt_nodelabel(),
 	  device_get_dt_metadata(), etc.
 
+config DEVICE_DT_NAME_FROM_NODE_LABEL
+	bool "Use DTS (first) node label as device name"
+	help
+	  In DTS you can provide a 'label' property to define a more human
+	  readable name. However, this is nowadays a deprecated property,
+	  letting the node full name as the default.
+	  But it is less human readable, and can be confusing in some
+	  cases (i2c@0f00bar0 can be less readable than i2c1 for instance).
+	  DTS provides an other way to get a unique identifier,
+	  more human readable: the node-label. Let's use it instead.
+	  Note that in case there are 2+ node-labels define for a node,
+	  the first one will be used.
+
 endmenu
 
 menu "Initialization Priorities"

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -92,6 +92,9 @@ def main():
 
             out_comment("Helpers for dealing with node labels:")
             out_dt_define(f"{node.z_path_id}_NODELABEL_NUM", len(node.labels))
+            if len(node.labels) >= 1:
+                out_dt_define(f"{node.z_path_id}_NODELABEL_MAIN", node.labels[0])
+                out_dt_define(f"{node.z_path_id}_NODELABEL_MAIN_EXISTS", 1)
             out_dt_define(f"{node.z_path_id}_FOREACH_NODELABEL(fn)",
                           " ".join(f"fn({nodelabel})" for nodelabel in node.labels))
             out_dt_define(f"{node.z_path_id}_FOREACH_NODELABEL_VARGS(fn, ...)",


### PR DESCRIPTION
Quick background why I am proposing this: 
node-id is clearly not as readable as the node-label, and this pushed us to maintain an overlay injecting 'label' property for each node. Which looks like
```
&uart0 {
        label = "uart0";
};
```
multiplied by as many devices as we have...

Kind of redundant info. 

I arbitrarily took the first node-label of a node to be the main nodelabel.

It is not an isolated experience, as seen in the commit 3d24b8b5 or 1b4cef32 for instance. But these mean that CONFIG_DEVICE_DT_METADATA is enabled, and that takes ROM etc...

This option is disabled by default, logic is not changed: label is the default if present.