### PR TITLE
Bsim update to v2.6 & boards bsim: Provide control of disconnection on exit

### DIFF
--- a/boards/native/nrf_bsim/common/bsim_control.h
+++ b/boards/native/nrf_bsim/common/bsim_control.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef BOARDS_NATIVE_BSIM_COMMON_BSIM_CONTROL_H
+#define BOARDS_NATIVE_BSIM_COMMON_BSIM_CONTROL_H
+
+#include <stdint.h>
+#include "bsim_args_runner.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void bsim_set_terminate_on_exit(bool terminate);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARDS_NATIVE_BSIM_COMMON_BSIM_CONTROL_H */

--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
       remote: babblesim
       repo-path: base
       path: tools/bsim/components
-      revision: 153101c61ce7106f6ba8b108b5c6488efdc1151a
+      revision: d562cd57317d33531ee3655d84660c57b8dc64c9
       groups:
         - babblesim
     - name: babblesim_ext_2G4_channel_NtNcable
@@ -100,7 +100,7 @@ manifest:
       remote: babblesim
       repo-path: ext_2G4_phy_v1
       path: tools/bsim/components/ext_2G4_phy_v1
-      revision: 62e797b2c518e5bb6123a198382ed2b64b8c068e
+      revision: dbfd6b068f3bde8e56dcea58b4e686a8efc01cbe
       groups:
         - babblesim
     - name: babblesim_ext_libCryptov1
@@ -112,7 +112,7 @@ manifest:
         - babblesim
     - name: bsim
       repo-path: babblesim-manifest
-      revision: a88d3353451387ca490a6a7f7c478a90c4ee05b7
+      revision: 193b8ba94cdc6ecbc3bb7fe80b87dee456e5eab0
       path: tools/bsim
       groups:
         - babblesim


### PR DESCRIPTION
    boards native bsim: Provide control of disconnection on exit
    
    Allow either programatically from the test/code or from the command
    line to chose if this executable exiting should terminate the
    whole simulation, or if it should only disconnect the device.
-------
    manifest: Update bsim to version v2.6
    
    Main changes since v2.5:
    * ext_2G4_phy_v1: Now supports DISCONNECTS during abort re-evaluations
    * ext_2G4_phy_v1: Also support bitrates multiple of 250Kbps and 333Kbps
    
    Note: Like before, bsim remains fully backwards compatible
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>