### PR TITLE
Handle GPIO direction reg offset in driver

### DIFF
--- a/drivers/gpio/gpio_davinci.c
+++ b/drivers/gpio/gpio_davinci.c
@@ -27,14 +27,11 @@ LOG_MODULE_REGISTER(gpio_davinci, CONFIG_GPIO_LOG_LEVEL);
 #define DEV_CFG(dev) \
 		((const struct gpio_davinci_config *)((dev)->config))
 #define DEV_DATA(dev) ((struct gpio_davinci_data *)(dev)->data)
-#define DEV_GPIO_CFG_BASE(dev) \
-	((struct gpio_davinci_regs *)DEVICE_MMIO_NAMED_GET(dev, port_base))
 
 #define GPIO_DAVINCI_DIR_RESET_VAL	(0xFFFFFFFF)
 
 struct gpio_davinci_regs {
-	uint32_t UNUSED[4];		/* 0x00-0x0C */
-	uint32_t dir;			/* 0x10 */
+	uint32_t dir;
 	uint32_t out_data;
 	uint32_t set_data;
 	uint32_t clr_data;
@@ -64,10 +61,22 @@ struct gpio_davinci_config {
 	const struct pinctrl_dev_config *pcfg;
 };
 
+const unsigned int offset_array[5] = {0x10, 0x38, 0x60, 0x88, 0xb0};
+#define MAX_REGS_BANK ARRAY_SIZE(offset_array)
+
+#define BANK0 0
+
+static struct gpio_davinci_regs *gpio_davinci_get_regs(const struct device *dev, uint8_t bank)
+{
+	__ASSERT(bank < MAX_REGS_BANK, "Invalid bank");
+	return (struct gpio_davinci_regs *)((uint8_t *)DEVICE_MMIO_NAMED_GET(dev, port_base) +
+					    offset_array[bank]);
+}
+
 static int gpio_davinci_configure(const struct device *dev, gpio_pin_t pin,
 					gpio_flags_t flags)
 {
-	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
+	volatile struct gpio_davinci_regs *regs = gpio_davinci_get_regs(dev, BANK0);
 
 	if ((flags & GPIO_SINGLE_ENDED) != 0) {
 		return -ENOTSUP;
@@ -94,7 +103,7 @@ static int gpio_davinci_configure(const struct device *dev, gpio_pin_t pin,
 static int gpio_davinci_port_get_raw(const struct device *dev,
 					gpio_port_value_t *value)
 {
-	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
+	volatile struct gpio_davinci_regs *regs = gpio_davinci_get_regs(dev, BANK0);
 
 	*value = regs->in_data;
 
@@ -104,7 +113,7 @@ static int gpio_davinci_port_get_raw(const struct device *dev,
 static int gpio_davinci_port_set_masked_raw(const struct device *dev,
 		gpio_port_pins_t mask, gpio_port_value_t value)
 {
-	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
+	volatile struct gpio_davinci_regs *regs = gpio_davinci_get_regs(dev, BANK0);
 
 	regs->out_data = (regs->out_data & (~mask)) | (mask & value);
 
@@ -114,7 +123,7 @@ static int gpio_davinci_port_set_masked_raw(const struct device *dev,
 static int gpio_davinci_port_set_bits_raw(const struct device *dev,
 						gpio_port_pins_t mask)
 {
-	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
+	volatile struct gpio_davinci_regs *regs = gpio_davinci_get_regs(dev, BANK0);
 
 	regs->set_data |= mask;
 
@@ -124,7 +133,7 @@ static int gpio_davinci_port_set_bits_raw(const struct device *dev,
 static int gpio_davinci_port_clear_bits_raw(const struct device *dev,
 						gpio_port_pins_t mask)
 {
-	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
+	volatile struct gpio_davinci_regs *regs = gpio_davinci_get_regs(dev, BANK0);
 
 	regs->clr_data |= mask;
 
@@ -134,7 +143,7 @@ static int gpio_davinci_port_clear_bits_raw(const struct device *dev,
 static int gpio_davinci_port_toggle_bits(const struct device *dev,
 						gpio_port_pins_t mask)
 {
-	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
+	volatile struct gpio_davinci_regs *regs = gpio_davinci_get_regs(dev, BANK0);
 
 	regs->out_data ^= mask;
 
@@ -167,11 +176,11 @@ static int gpio_davinci_init(const struct device *dev)
 	return 0;
 }
 
-#define GPIO_DAVINCI_INIT_FUNC(n)						  \
-	static void gpio_davinci_bank_##n##_config(const struct device *dev)	  \
-	{									  \
-		volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev); \
-		regs->dir = GPIO_DAVINCI_DIR_RESET_VAL;                           \
+#define GPIO_DAVINCI_INIT_FUNC(n)                                                                  \
+	static void gpio_davinci_bank_##n##_config(const struct device *dev)                       \
+	{                                                                                          \
+		volatile struct gpio_davinci_regs *regs = gpio_davinci_get_regs(dev, BANK0);       \
+		regs->dir = GPIO_DAVINCI_DIR_RESET_VAL;                                            \
 	}
 
 #define GPIO_DAVINCI_INIT(n)							  \

--- a/dts/arm/ti/am62x_m4.dtsi
+++ b/dts/arm/ti/am62x_m4.dtsi
@@ -76,7 +76,7 @@
 		status = "disabled";
 	};
 
-	gpio0: gpio@4201010 {
+	gpio0: gpio@4201000 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x4201000 0x100>;
 		gpio-controller;

--- a/dts/arm/ti/am64x_m4.dtsi
+++ b/dts/arm/ti/am64x_m4.dtsi
@@ -97,7 +97,7 @@
 		status = "disabled";
 	};
 
-	gpio0: gpio@4201010 {
+	gpio0: gpio@4201000 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x4201000 0x100>;
 		gpio-controller;

--- a/dts/arm/ti/j722s_main.dtsi
+++ b/dts/arm/ti/j722s_main.dtsi
@@ -19,7 +19,7 @@
 		status = "okay";
 	};
 
-	gpio0: gpio@600010 {
+	gpio0: gpio@600000 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x00600000 0x100>;
 		gpio-controller;
@@ -28,7 +28,7 @@
 		status = "disabled";
 	};
 
-	gpio1: gpio@601010 {
+	gpio1: gpio@601000 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x00601000 0x100>;
 		gpio-controller;

--- a/dts/arm/ti/j722s_mcu.dtsi
+++ b/dts/arm/ti/j722s_mcu.dtsi
@@ -13,7 +13,7 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	mcu_gpio0: gpio@4201010 {
+	mcu_gpio0: gpio@4201000 {
 		compatible = "ti,davinci-gpio";
 		reg = <0x4201000 0x100>;
 		gpio-controller;


### PR DESCRIPTION
Currently, the start address in devicetree for GPIO controllers using gpio-davinci points to the direction register. This is different from Linux dt which points to the start of GPIO controller, and handles getting the address for the direction register in the driver.

Essentially, this means that Zephyr address = Linux address + 0x10.

This can be confusing for anyone not familiar with this quirk. Additionally, the dt value in reg property seems to be invalid since the the size of the region is now ACTUAL SIZE - 0x10.

The Linux kernel driver handles calculating the direction register address for a GPIO bank, so Zephyr should do the same.

I am also introducing the offsets for the other banks in this PR but they cannot be used yet, since Zephyr GPIO subsystem is currently limited to only 32 pins per port (PocketBeagle 2 MAIN_GPIO0 has 92 pins).