### PR TITLE
init: Make entry init-function less and introduce service objects

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -12,6 +12,7 @@ zephyr_linker_section_obj_level(SECTION init LEVEL APPLICATION)
 zephyr_linker_section_obj_level(SECTION init LEVEL SMP)
 
 zephyr_iterable_section(NAME device NUMERIC KVMA RAM_REGION GROUP RODATA_REGION)
+zephyr_iterable_section(NAME service NUMERIC KVMA RAM_REGION GROUP RODATA_REGION)
 
 if(CONFIG_GEN_SW_ISR_TABLE AND NOT CONFIG_DYNAMIC_INTERRUPTS)
   # ld align has been changed to subalign to provide identical behavior scatter vs. ld.

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1263,7 +1263,6 @@ device_get_dt_nodelabels(const struct device *dev)
 	static const Z_DECL_ALIGN(struct init_entry) __used __noasan Z_INIT_ENTRY_SECTION(         \
 		level, prio, Z_DEVICE_INIT_SUB_PRIO(node_id))                                      \
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                                     \
-			.init_fn = NULL,                                                           \
 			.dev = (const struct device *)&DEVICE_NAME_GET(dev_id),                    \
 		}
 

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -22,6 +22,8 @@
 
 	ITERABLE_SECTION_ROM_NUMERIC(device, Z_LINK_ITERABLE_SUBALIGN)
 
+	ITERABLE_SECTION_ROM_NUMERIC(service, Z_LINK_ITERABLE_SUBALIGN)
+
 #if defined(CONFIG_GEN_SW_ISR_TABLE) && defined(CONFIG_SHARED_INTERRUPTS)
 	/* since z_shared_isr() is not referenced anywhere when
 	 * zephyr_pre0.elf is built, the linker will end up dropping it.

--- a/include/zephyr/service.h
+++ b/include/zephyr/service.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024 Tomasz Bursztyka.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_SERVICE_H_
+#define ZEPHYR_INCLUDE_SERVICE_H_
+
+#include <zephyr/sys/iterable_sections.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup service System service
+ * @ingroup os_services
+ *
+ * A system service is a one-shot initialized software component, instantiated
+ * via SYS_INIT() or  SYS_INIT_NAMED(). It does not provide any public API.
+ *
+ * @{
+ */
+
+/**
+ * @brief Structure to store service instance
+ *
+ * This will be defined through SYS_INIT/SYS_INIT_NAMED
+ */
+struct service {
+	/**
+	 * Initialization function
+	 */
+	int (*init)(void);
+};
+
+/** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Expands to the name of a global service object
+ *
+ * @param name Service name.
+ *
+ * @return The full name of the service object defined by the service
+ *         definition macro.
+ */
+#define Z_SERVICE_NAME_GET(name) _CONCAT(__service_, name)
+
+/**
+ * @brief Initializer for @ref service
+ *
+ * @param init_fn Initialization function (mandatory).
+ */
+#define Z_SERVICE_INIT(init_fn)                                       \
+	{                                                             \
+		.init = (init_fn)                                     \
+	}
+
+/**
+ * @brief Service section name (used for sorting purposes).
+ *
+ * @param level Initialization level.
+ * @param prio Initialization priority.
+ */
+#define Z_SERVICE_SECTION_NAME(level, prio)                           \
+	_CONCAT(INIT_LEVEL_ORD(level), _##prio)
+
+/**
+ * @brief Define a @ref service
+ *
+ * @param name Service name.
+ * @param init_fn Initialization function.
+ * @param level Initialization level.
+ * @param prio Initialization priority.
+ */
+#define Z_SERVICE_DEFINE(name, init_fn, level, prio)                  \
+	static const                                                  \
+	STRUCT_SECTION_ITERABLE_NAMED_ALTERNATE(                      \
+		service, service,				      \
+		Z_SERVICE_SECTION_NAME(level, prio),                  \
+		Z_SERVICE_NAME_GET(name)) = Z_SERVICE_INIT(init_fn)
+
+/** @endcond */
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_SERVICE_H_ */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -136,6 +136,9 @@ enum init_level {
 extern const struct init_entry __init_SMP_start[];
 #endif /* CONFIG_SMP */
 
+TYPE_SECTION_START_EXTERN(struct service, service);
+TYPE_SECTION_END_EXTERN(struct service, service);
+
 /*
  * storage space for the interrupt stack
  *
@@ -337,6 +340,12 @@ static int do_device_init(const struct device *dev)
 	return rc;
 }
 
+static inline bool is_entry_about_service(const void *obj)
+{
+	return (obj >= (void *)_service_list_start &&
+		obj < (void *)_service_list_end);
+}
+
 /**
  * @brief Execute all the init entry initialization functions at a given level
  *
@@ -365,17 +374,26 @@ static void z_sys_init_run_level(enum init_level level)
 	const struct init_entry *entry;
 
 	for (entry = levels[level]; entry < levels[level+1]; entry++) {
-		const struct device *dev = entry->dev;
 		int result = 0;
 
+		if (unlikely(entry->_init_object == NULL)) {
+			continue;
+		}
+
 		sys_trace_sys_init_enter(entry, level);
-		if (dev != NULL) {
+
+		if (is_entry_about_service(entry->_init_object)) {
+			const struct service *srv = entry->srv;
+
+			result = srv->init();
+		} else {
+			const struct device *dev = entry->dev;
+
 			if ((dev->flags & DEVICE_FLAG_INIT_DEFERRED) == 0U) {
 				result = do_device_init(dev);
 			}
-		} else {
-			result = entry->init_fn();
 		}
+
 		sys_trace_sys_init_exit(entry, level, result);
 	}
 }

--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -202,15 +202,14 @@ class ZephyrInitLevels:
                     raise ValueError(f"no symbol at addr {addr:08x}")
                 obj, size, shidx = self._objects[addr]
 
-                arg0_name = self._object_name(self._initlevel_pointer(addr, 0, shidx))
-                arg1_name = self._object_name(self._initlevel_pointer(addr, 1, shidx))
+                arg_name = self._object_name(self._initlevel_pointer(addr, 0, shidx))
 
-                self.initlevels[level].append(f"{obj}: {arg0_name}({arg1_name})")
+                self.initlevels[level].append(f"{obj}: {arg_name}")
 
-                ordinal = self._device_ord_from_name(arg1_name)
+                ordinal = self._device_ord_from_name(arg_name)
                 if ordinal:
                     prio = Priority(level, priority)
-                    self.devices[ordinal] = (prio, arg0_name)
+                    self.devices[ordinal] = prio
 
                 addr += size
                 priority += 1
@@ -256,8 +255,8 @@ class Validator():
                 self.log.info(f"Ignoring priority: {dev_node._binding.compatible}")
                 return
 
-        dev_prio, dev_init = self._obj.devices.get(dev_ord, (None, None))
-        dep_prio, dep_init = self._obj.devices.get(dep_ord, (None, None))
+        dev_prio = self._obj.devices.get(dev_ord, None)
+        dep_prio = self._obj.devices.get(dep_ord, None)
 
         if not dev_prio or not dep_prio:
             return
@@ -272,12 +271,12 @@ class Validator():
                                "the devicetree dependencies.")
             self.errors += 1
             self.log.error(
-                    f"{dev_node.path} <{dev_init}> is initialized before its dependency "
-                    f"{dep_node.path} <{dep_init}> ({dev_prio} < {dep_prio})")
+                    f"{dev_node.path} is initialized before its dependency "
+                    f"{dep_node.path} ({dev_prio} < {dep_prio})")
         else:
             self.log.info(
-                    f"{dev_node.path} <{dev_init}> {dev_prio} > "
-                    f"{dep_node.path} <{dep_init}> {dep_prio}")
+                    f"{dev_node.path} {dev_prio} > "
+                    f"{dep_node.path} {dep_prio}")
 
     def check_edt(self):
         """Scan through all known devices and validate the init priorities."""

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -28,7 +28,7 @@ static K_CONDVAR_DEFINE(wait_start);
 STRUCT_SECTION_START_EXTERN(net_socket_service_desc);
 STRUCT_SECTION_END_EXTERN(net_socket_service_desc);
 
-static struct service {
+static struct service_context {
 	struct zsock_pollfd events[CONFIG_ZVFS_POLL_MAX];
 	int count;
 } ctx;

--- a/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
+++ b/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
@@ -9,10 +9,10 @@ import sys
 
 REFERENCE_OUTPUT = [
         "ERROR: Device initialization priority validation failed, the sequence of initialization calls does not match the devicetree dependencies.",
-        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /gpio@ffff <NULL> (PRE_KERNEL_1+0 < PRE_KERNEL_1+1)",
-        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /i2c@11112222 <NULL> (PRE_KERNEL_1+0 < PRE_KERNEL_1+2)",
-        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /gpio@ffff <NULL> PRE_KERNEL_1+1",
-        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /i2c@11112222 <NULL> PRE_KERNEL_1+2",
+        "ERROR: /i2c@11112222/test-i2c-dev@10 is initialized before its dependency /gpio@ffff (PRE_KERNEL_1+0 < PRE_KERNEL_1+1)",
+        "ERROR: /i2c@11112222/test-i2c-dev@10 is initialized before its dependency /i2c@11112222 (PRE_KERNEL_1+0 < PRE_KERNEL_1+2)",
+        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1+3 > /gpio@ffff PRE_KERNEL_1+1",
+        "INFO: /i2c@11112222/test-i2c-dev@11 PRE_KERNEL_1+3 > /i2c@11112222 PRE_KERNEL_1+2",
 ]
 
 if len(sys.argv) != 2:


### PR DESCRIPTION
- optimizing ROM utilization 
- introducing de-facto a new "service" object to do so (but not exposed via any public API)

Up for a discussion. But I am still planning on removing the priority from the device driver model (and generate it automatically), following what I started here #79340, and service is going to be used also then. (I foresee that we could even have more complicated 'service' that can be stopped/restarted at run-time etc... all with device dependencies, thus being able to react on relevant PM events and so on.)