### PR TITLE
net: conn_mgr: Fix disconnect with CONN_MGR_IF_NO_AUTO_DOWN unset

### DIFF
--- a/include/zephyr/net/conn_mgr_connectivity.h
+++ b/include/zephyr/net/conn_mgr_connectivity.h
@@ -90,6 +90,12 @@ enum conn_mgr_if_flag {
 	CONN_MGR_IF_NO_AUTO_DOWN,
 
 /** @cond INTERNAL_HIDDEN */
+	/**
+	 * Internal flag indicating that the interface is in active (application initiated)
+	 * disconnect.
+	 */
+	CONN_MGR_IF_DISCONNECTING,
+
 	/* Total number of flags - must be at the end of the enum */
 	CONN_MGR_NUM_IF_FLAGS,
 /** @endcond */

--- a/include/zephyr/net/conn_mgr_connectivity_impl.h
+++ b/include/zephyr/net/conn_mgr_connectivity_impl.h
@@ -57,8 +57,6 @@ struct conn_mgr_conn_api {
 	 * stop any in-progress attempts to associate to a network, the bound iface pointed to by
 	 * if_conn->iface.
 	 *
-	 * Must be non-blocking.
-	 *
 	 * Called by @ref conn_mgr_if_disconnect.
 	 */
 	int (*disconnect)(struct conn_mgr_conn_binding *const binding);


### PR DESCRIPTION
Connection manager enforces non-blocking disconnect() behavior, yet in case CONN_MGR_IF_NO_AUTO_DOWN flag is not set, it'd put the interface down right after, disrupting the disconnect process.

As putting the interface down can be handled in the corresponding event handler as well, when the interface is actually disconnected, remove the conn_mgr_conn_if_auto_admin_down() call from conn_mgr_if_disconnect(). To make this work with persistence flag, introduce a new internal flag indicating that the interface is in active disconnect.

Finally, since it isn't really necessary that disconnect() API call is non-blocking, remove that requirement.

Fixes #89802