### PR TITLE
submanifests: optional: Fix Rust DTS parsing to allow for comments

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: d4f9036a88e53080bf2b186afa5289f9c77a0f73
+      revision: 615b2b76f18427f7fa6ec2bf765aeed1994dc64e
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
In order to merge a change to put source-location comments in the generated DTS, the rust DTS reader needs to be able to handle these comments.  This brings in a single change from the v4.1 release:

    commit 615b2b76f18427f7fa6ec2bf765aeed1994dc64e
    Author: Luca Burelli <l.burelli@arduino.cc>
    Date:   Fri May 2 18:44:46 2025 +0200

        dts.pest: Add support for comments in devicetree source files