### PR TITLE
drivers: bluetooth: hci: Use TRNG peripheral for BLE purpose on WB0x

### DIFF
--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -24,6 +24,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,bt-c2h-uart = &usart1;
+		zephyr,entropy = &rng;
 	};
 
 	leds: leds {
@@ -165,6 +166,10 @@
 		pinctrl-names = "default";
 		status = "okay";
 	};
+};
+
+&rng {
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -24,6 +24,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,bt-c2h-uart = &usart1;
+		zephyr,entropy = &rng;
 	};
 
 	leds: leds {
@@ -162,6 +163,10 @@
 		pinctrl-0 = <&tim1_ch3_pb2>;
 		pinctrl-names = "default";
 	};
+};
+
+&rng {
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -24,6 +24,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,bt-c2h-uart = &usart1;
+		zephyr,entropy = &rng;
 	};
 
 	leds: leds {
@@ -164,6 +165,10 @@
 		pinctrl-names = "default";
 		status = "okay";
 	};
+};
+
+&rng {
+	status = "okay";
 };
 
 &flash0 {

--- a/soc/st/stm32/stm32wb0x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32wb0x/Kconfig.defconfig
@@ -19,9 +19,6 @@ config BT_AUTO_DATA_LEN_UPDATE
 config BT_HCI_ACL_FLOW_CONTROL
 	default n
 
-config MAIN_STACK_SIZE
-	default 1600
-
 endif # BT
 
 endif # SOC_SERIES_STM32WB0X

--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 5cbc642b1a79d4f373b1587f8c3027f31bf0d30c
+      revision: 90f56420db7b2567675f623af09c474eae410814
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Call entropy APIs to use TRNG peripheral on STM32WB0x devices for BLE purposes.

Enable `rng` node on Nucleo-WB0x boards.

Supplementary [PR#267](https://github.com/zephyrproject-rtos/hal_stm32/pull/267)