### PR TITLE
drivers: clock control: stm32H7 has the same clock source for all PLL

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -53,15 +53,29 @@
 /* This check should only be performed for the M7 core code */
 #ifdef CONFIG_CPU_CORTEX_M7
 
-/* Choose PLL SRC */
-#if defined(STM32_PLL_SRC_HSI)
+/* Choose PLL SRC : same source for all the PLL */
+#if defined(STM32_PLL_SRC_HSI) || defined(STM32_PLL2_SRC_HSI) || defined(STM32_PLL3_SRC_HSI)
 #define PLLSRC_FREQ  ((STM32_HSI_FREQ)/(STM32_HSI_DIVISOR))
-#elif defined(STM32_PLL_SRC_CSI)
+#endif
+
+#if defined(STM32_PLL_SRC_CSI) || defined(STM32_PLL2_SRC_CSI) || defined(STM32_PLL3_SRC_CSI)
+#if !defined(PLLSRC_FREQ)
 #define PLLSRC_FREQ  STM32_CSI_FREQ
-#elif defined(STM32_PLL_SRC_HSE)
+#else
+#error "All PLLs must have the same clock source"
+#endif
+#endif
+
+#if defined(STM32_PLL_SRC_HSE) || defined(STM32_PLL2_SRC_HSE) || defined(STM32_PLL3_SRC_HSE)
+#if !defined(PLLSRC_FREQ)
 #define PLLSRC_FREQ  STM32_HSE_FREQ
 #else
-#define PLLSRC_FREQ 0
+#error "All PLLs must have the same clock source"
+#endif
+#endif
+
+#if !defined(PLLSRC_FREQ)
+#define PLLSRC_FREQ  0
 #endif
 
 /* Given source clock and dividers, computed the output frequency of PLLP */
@@ -782,13 +796,19 @@ static int set_up_plls(void)
 	/* Configure PLL source */
 
 	/* Can be HSE , HSI 64Mhz/HSIDIV, CSI 4MHz*/
-	if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
+	if (IS_ENABLED(STM32_PLL_SRC_HSE) ||
+		IS_ENABLED(STM32_PLL2_SRC_HSE) ||
+		IS_ENABLED(STM32_PLL3_SRC_HSE)) {
 		/* Main PLL configuration and activation */
 		LL_RCC_PLL_SetSource(LL_RCC_PLLSOURCE_HSE);
-	} else if (IS_ENABLED(STM32_PLL_SRC_CSI)) {
+	} else if (IS_ENABLED(STM32_PLL_SRC_CSI) ||
+		IS_ENABLED(STM32_PLL2_SRC_CSI) ||
+		IS_ENABLED(STM32_PLL3_SRC_CSI)) {
 		/* Main PLL configuration and activation */
 		LL_RCC_PLL_SetSource(LL_RCC_PLLSOURCE_CSI);
-	} else if (IS_ENABLED(STM32_PLL_SRC_HSI)) {
+	} else if (IS_ENABLED(STM32_PLL_SRC_HSI) ||
+		IS_ENABLED(STM32_PLL2_SRC_HSI) ||
+		IS_ENABLED(STM32_PLL3_SRC_HSI)) {
 		/* Main PLL configuration and activation */
 		LL_RCC_PLL_SetSource(LL_RCC_PLLSOURCE_HSI);
 	} else {


### PR DESCRIPTION
Select the PLL clock source for PLL2 or PLL3 as well as main PLL This choice is useful if main PLL is off (sysclock from fixed clock) but PLL2 or PLL3 are on for other peripherals

When configuring a stm32h7 board DTS with fixed clock source
The main PLL can be enabled but not selected as the clock source or can be disabled but another PLL2 enabled for any peripheral

For example on nucleo_h743zi:

```
&pll {
	status = "disabled";
};

&pll2 {
	div-m = <4>;
	mul-n = <120>;
	div-p = <2>;
	div-q = <3>; /* gives 80MHz to the FDCAN */
	div-r = <2>;
	clocks = <&clk_hse>;
	status = "okay";
};

&rcc {
	clocks = <&clk_hsi>;
	clock-frequency = <DT_FREQ_M(64)>;
	d1cpre = <1>;
	hpre = <2>;
	d1ppre = <2>;
	d2ppre1 = <2>;
	d2ppre2 = <2>;
	d3ppre = <2>;
};
```

Note that usart3 console on the default selected clock  source  (rcc_pclk1)  could require a lower baudrate than 115200 (freq/baudrate must be > = 16)