### PR TITLE
board: WeAct blackpill: add support for stm32CubeProgrammer

### DIFF
--- a/boards/weact/blackpill_f401cc/board.cmake
+++ b/boards/weact/blackpill_f401cc/board.cmake
@@ -3,8 +3,10 @@
 
 board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32F401CC" "--speed=4000")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/weact/blackpill_f401ce/board.cmake
+++ b/boards/weact/blackpill_f401ce/board.cmake
@@ -2,8 +2,10 @@
 
 board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32F401CE" "--speed=4000")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/weact/blackpill_f411ce/board.cmake
+++ b/boards/weact/blackpill_f411ce/board.cmake
@@ -2,8 +2,10 @@
 
 board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32F411CE" "--speed=4000")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
This add support for the blackpill boards that use the soc stm32f401cc,
stm32f401ce and stm32f411ce.

Tested with the sample

Command to flash `west flash -r stm32cubeprogrammer`

This PR addresses #90024 issue

Signed-off-by: leonardo-munoz-pragmafw <leonardo.munoz@pragmafw.com>