### PR TITLE
arch: xtensa: Update arch_user_string_nlen()

### DIFF
--- a/arch/xtensa/core/mpu.c
+++ b/arch/xtensa/core/mpu.c
@@ -1078,7 +1078,7 @@ out:
 	return ret;
 }
 
-bool xtensa_mem_kernel_has_access(void *addr, size_t size, int write)
+bool xtensa_mem_kernel_has_access(const void *addr, size_t size, int write)
 {
 	uintptr_t aligned_addr;
 	size_t aligned_size, addr_offset;

--- a/arch/xtensa/core/ptables.c
+++ b/arch/xtensa/core/ptables.c
@@ -1112,7 +1112,7 @@ static int mem_buffer_validate(const void *addr, size_t size, int write, int rin
 	return ret;
 }
 
-bool xtensa_mem_kernel_has_access(void *addr, size_t size, int write)
+bool xtensa_mem_kernel_has_access(const void *addr, size_t size, int write)
 {
 	return mem_buffer_validate(addr, size, write, XTENSA_MMU_KERNEL_RING) == 0;
 }

--- a/arch/xtensa/core/syscall_helper.c
+++ b/arch/xtensa/core/syscall_helper.c
@@ -115,7 +115,7 @@ size_t arch_user_string_nlen(const char *s, size_t maxsize, int *err_arg)
 	 * For MPU systems, this would simply results in access errors
 	 * and the exception handler will terminate the thread.
 	 */
-	if (!xtensa_mem_kernel_has_access(s, maxsize, 0)) {
+	if (arch_buffer_validate(s, maxsize, 0)) {
 		/*
 		 * API says we need to set err_arg to -1 if there are
 		 * any errors.

--- a/arch/xtensa/core/syscall_helper.c
+++ b/arch/xtensa/core/syscall_helper.c
@@ -115,7 +115,7 @@ size_t arch_user_string_nlen(const char *s, size_t maxsize, int *err_arg)
 	 * For MPU systems, this would simply results in access errors
 	 * and the exception handler will terminate the thread.
 	 */
-	if (!xtensa_mem_kernel_has_access((void *)s, maxsize, 0)) {
+	if (!xtensa_mem_kernel_has_access(s, maxsize, 0)) {
 		/*
 		 * API says we need to set err_arg to -1 if there are
 		 * any errors.

--- a/arch/xtensa/include/xtensa_internal.h
+++ b/arch/xtensa/include/xtensa_internal.h
@@ -72,7 +72,7 @@ void xtensa_userspace_enter(k_thread_entry_t user_entry,
  *
  * @return False if the permissions don't match.
  */
-bool xtensa_mem_kernel_has_access(void *addr, size_t size, int write);
+bool xtensa_mem_kernel_has_access(const void *addr, size_t size, int write);
 
 /**
  * @}


### PR DESCRIPTION
On some platforms, address 0 is actually valid in the kernel, but we do not want it to be valid in userspace--so it is insufficient to only use mem_kernel_has_access(). However, arch_buffer_validate() does not always recover well, so it too is insufficient on its own. Thus, we use both.