### PR TITLE
settings: replace [[maybe_unused]] by __maybe_unused

### DIFF
--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -116,8 +116,8 @@ static int settings_set_default_cb(const char *name, size_t len, settings_read_c
  * Returns the value's length in the provided `param` pointer
  */
 static int settings_get_val_len_default_cb(const char *name, size_t len,
-					   [[maybe_unused]] settings_read_cb read_cb,
-					   [[maybe_unused]] void *cb_arg, void *param)
+					   settings_read_cb read_cb __maybe_unused,
+					   void *cb_arg __maybe_unused, void *param)
 {
 	const char *next;
 	size_t name_len;

--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -278,7 +278,7 @@ static ssize_t settings_zms_load_one(struct settings_store *cs, const char *name
  * It updates as well the next cache index and the next linked list node ID.
  */
 static int settings_zms_get_next_ll(struct settings_zms *cf, uint32_t *ll_hash_id,
-				    [[maybe_unused]] uint32_t *ll_cache_index)
+				    uint32_t *ll_cache_index __maybe_unused)
 {
 	struct settings_hash_linked_list settings_element;
 	int ret = 0;


### PR DESCRIPTION
PR #87792 introduced the use of `[[maybe_unused]]` which for some reason only the clang CI workflow is flagging as a problem. `[[maybe_unused]]` is a C23 construct, so fallback to Zephyr's `__maybe_unused`.