### PR TITLE
nrf7002ek: dts: Add pull down to SPIM GPIO pins

### DIFF
--- a/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -16,31 +16,21 @@
 
 /*
  * Override the default pinctrl settings for SPI4 when used with the nRF7002 EK
- * to pull down the MISO line. This is needed to avoid floating inputs when
+ * to pull down the SPIM lines. This is needed to avoid floating inputs when
  * the SPI4 is not used. The default pinctrl settings are defined in the
  * nrf5340_cpuapp_common_pinctrl.dtsi file.
  */
 &pinctrl {
 	spi4_default: spi4_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
-		};
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 1, 14)>;
 			bias-pull-down;
 		};
 	};
 
 	spi4_sleep: spi4_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
-		};
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 1, 14)>;
 			bias-pull-down;
+			low-power-enable;
 		};
-		low-power-enable;
 	};
 };


### PR DESCRIPTION
Add pull downs to all SPIM GPIO pins on nRF5340DK to ensure the i/o pins on the nrf7002 device are not floating when SPI is inactive.