### PR TITLE
drivers: wifi: siwx91x: Add missing 11ax flags and twt_retry_interval

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -1313,6 +1313,7 @@ static int siwx91x_set_twt_setup(struct wifi_twt_params *params)
 	int twt_req_type = siwx91x_convert_z_sl_twt_req_type(params->setup_cmd);
 
 	sl_wifi_twt_request_t twt_req = {
+		.twt_retry_interval = 5,
 		.wake_duration_unit = 0,
 		.wake_int_mantissa = params->setup.twt_mantissa,
 		.un_announced_twt = !params->setup.announce,

--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -87,6 +87,10 @@ if(CONFIG_WIFI_SILABS_SIWX91X)
     ${WISECONNECT_DIR}/components/service/network_manager/src/sl_net_basic_profiles.c
     ${WISECONNECT_DIR}/components/service/network_manager/src/sl_net_credentials.c
   )
+  zephyr_compile_definitions(
+    SLI_SI91X_CONFIG_WIFI6_PARAMS
+    SLI_SI91X_ENABLE_TWT_FEATURE
+  )
   zephyr_compile_definitions_ifdef(CONFIG_NET_IPV6
     SLI_SI91X_ENABLE_IPV6
   )


### PR DESCRIPTION
Added flags needed for 11ax and TWT to be enabled
Added a default value for twt_retry_interval