### PR TITLE
soc: npcx: npcx9: disable CCDEV_SEL in early initialization.

### DIFF
--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -198,6 +198,13 @@ struct scfg_reg {
 #define NPCX_JEN_CTL1_JEN_ENABLE  0x9
 #define NPCX_JEN_CTL1_JEN_DISABLE 0x6
 
+#define NPCX_JEN_CTL2_OFFSET 0x121
+#define NPCX_JEN_CTL2(base)  (*(volatile uint8_t *)(base + (NPCX_JEN_CTL2_OFFSET)))
+
+#define NPCX_JEN_CTL2_CCDEV_SEL_EN     FIELD(0, 4)
+#define NPCX_JEN_CTL2_CCDEV_SEL_ENABLE  0x9
+#define NPCX_JEN_CTL2_CCDEV_SEL_DISABLE 0x6
+
 /* SCFG register fields */
 #define NPCX_DEVCNT_F_SPI_TRIS         6
 #define NPCX_DEVCNT_HIF_TYP_SEL_FIELD  FIELD(2, 2)

--- a/soc/nuvoton/npcx/npcx9/soc.c
+++ b/soc/nuvoton/npcx/npcx9/soc.c
@@ -20,6 +20,9 @@ void soc_early_init_hook(void)
 
 		SET_FIELD(NPCX_JEN_CTL1(scfg_base), NPCX_JEN_CTL1_JEN_HEN,
 			  NPCX_JEN_CTL1_JEN_DISABLE);
+
+		SET_FIELD(NPCX_JEN_CTL2(scfg_base), NPCX_JEN_CTL2_CCDEV_SEL_EN,
+			  NPCX_JEN_CTL2_CCDEV_SEL_DISABLE);
 	}
 	scfg_init();
 }


### PR DESCRIPTION
Enhances the early initialization hook to disable CCDEV_SEL selection using the new control definitions.