### PR TITLE
ci: pr_metadata_check: convert DNM logic to python

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -18,16 +18,23 @@ jobs:
     name: Prevent Merging
     runs-on: ubuntu-24.04
     steps:
-      - name: Check for label
-        if: ${{ contains(github.event.*.labels.*.name, 'DNM') ||
-                contains(github.event.*.labels.*.name, 'DNM (manifest)') ||
-                contains(github.event.*.labels.*.name, 'TSC') ||
-                contains(github.event.*.labels.*.name, 'Architecture Review') ||
-                contains(github.event.*.labels.*.name, 'dev-review') }}
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: 3.12
+          cache: pip
+          cache-dependency-path: scripts/requirements-actions.txt
+
+      - name: Install Python dependencies
         run: |
-          echo "Pull request is labeled as 'DNM', 'TSC', 'Architecture Review' or 'dev-review'."
-          echo "This workflow fails so that the pull request cannot be merged."
-          exit 1
+          pip install -r scripts/requirements-actions.txt --require-hashes
+
+      - name: Run the check script
+        run: |
+          ./scripts/ci/do_not_merge.py -p "${{ github.event.pull_request.number }}"
 
   empty_pr_description:
     if: ${{ github.event.pull_request.body == '' }}

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import sys
+
+import github
+
+DNM_LABELS = ["DNM", "DNM (manifest)", "TSC", "Architecture Review", "dev-review"]
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+
+    parser.add_argument("-p", "--pull-request", required=True, type=int, help="The PR number")
+
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+
+    token = os.environ.get('GITHUB_TOKEN', None)
+    gh = github.Github(token)
+    repo = gh.get_repo("zephyrproject-rtos/zephyr")
+    pr = repo.get_pull(args.pull_request)
+
+    for label in pr.get_labels():
+        if label.name in DNM_LABELS:
+            print(f"Pull request is labeled as \"{label.name}\".")
+            print("This workflow fails so that the pull request cannot be merged.")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Hi, GH backends are causing more mysery recently, trying to work around it, proposing to keep this simple for a start see if helps, followups:
- expand DNM to catch wildcards
- integrate the PR message check in the python code too
- add a strategic delay to wait for the metadata workflow to finish since this step is primarily racing with it

Yes I know this will use a shocking ONE github API call per PR, I'd say it's worth for not having to manually chase down PRs dropped from the merge list and close/reopen them or mess about with labels.

---

GitHub seems to have issue with workflow state caching that causes the DNM step to not work properly in few cases and not detecting changes in the DNM tag, forcing people to mess with tags or close/opening PRs, which in turns restarts all workflows.

Convert the script to Python so that the tag data is guaranteed to be fresh.