### PR TITLE
SPI: Nordic: nrfx_spim self get patch

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -403,6 +403,11 @@ static void finish_transaction(const struct device *dev, int error)
 	spi_context_complete(ctx, dev, error);
 	dev_data->busy = false;
 
+	if (dev_data->ctx.config->operation & SPI_LOCK_ON) {
+		/* Keep device resumed until call to spi_release() */
+		(void)pm_device_runtime_get(dev);
+	}
+
 	finalize_spi_transaction(dev, true);
 }
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -154,12 +154,7 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 	void *reg = dev_config->spim.p_reg;
 
 	if (deactivate_cs) {
-		/*
-		 * We may suspend SPI only if we don't have to keep CS asserted, as we
-		 * need to keep the CS GPIO port resumed until spi_release() in this case.
-		 */
 		spi_context_cs_control(&dev_data->ctx, false);
-		pm_device_runtime_put_async(dev, K_NO_WAIT);
 	}
 
 	if (NRF_SPIM_IS_320MHZ_SPIM(reg) && !(dev_data->ctx.config->operation & SPI_HOLD_ON_CS)) {
@@ -169,6 +164,8 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 	if (!IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
 		release_clock(dev);
 	}
+
+	pm_device_runtime_put_async(dev, K_NO_WAIT);
 }
 
 static inline uint32_t get_nrf_spim_frequency(uint32_t frequency)
@@ -406,7 +403,7 @@ static void finish_transaction(const struct device *dev, int error)
 	spi_context_complete(ctx, dev, error);
 	dev_data->busy = false;
 
-	finalize_spi_transaction(dev, (dev_data->ctx.config->operation & SPI_HOLD_ON_CS) > 0);
+	finalize_spi_transaction(dev, true);
 }
 
 static void transfer_next_chunk(const struct device *dev)


### PR DESCRIPTION
Revert initial patch which caused SPI CS line to get "stuck" asserted, and apply new patch which solves the same issue, but without a stuck CS line :) In short, nrfx drivers try to self resume/suspend internally when possible, for SPI, that is before and after a transaction is performed. However, this did not take into account spi_release() which caused an unbalanced suspend.