### PR TITLE
Bluetooth: Add missing depends on for stack size Kconfig

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -13,6 +13,7 @@ config BT_UART
 config BT_H4
 	bool "H:4 UART"
 	select BT_UART
+	select BT_DRV_RX_SUPPORT
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_UART_ENABLED
 	help
@@ -22,6 +23,7 @@ config BT_H4
 config BT_H5
 	bool "H:5 UART [EXPERIMENTAL]"
 	select BT_UART
+	select BT_DRV_RX_SUPPORT
 	select EXPERIMENTAL
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_3WIRE_UART_ENABLED
@@ -69,6 +71,7 @@ config BT_HCI_IPC_ENDPOINT_BOUND_TIMEOUT_MS
 config BT_SPI
 	bool
 	select SPI
+	select BT_DRV_RX_SUPPORT
 	help
 	  Supports Bluetooth ICs using SPI as the communication protocol.
 	  HCI packets are sent and received as single Byte transfers,
@@ -121,6 +124,7 @@ config BT_STM32_IPM
 	bool
 	default y
 	depends on DT_HAS_ST_STM32WB_RF_ENABLED
+	select BT_DRV_RX_SUPPORT
 	select USE_STM32_HAL_CORTEX
 	select HAS_STM32LIB
 	select BT_HCI_SETUP
@@ -266,6 +270,7 @@ config BT_AMBIQ_HCI
 	default y
 	depends on DT_HAS_AMBIQ_BT_HCI_SPI_ENABLED
 	select SPI
+	select BT_DRV_RX_SUPPORT
 	select GPIO if SOC_SERIES_APOLLO4X
 	select CLOCK_CONTROL if SOC_SERIES_APOLLO4X
 	select BT_HCI_SETUP
@@ -345,12 +350,20 @@ config BT_HCI_SETUP
 
 config BT_DRV_TX_STACK_SIZE
 	int
+	depends on BT_H5
 	default 256
 	help
 	  Stack size for the HCI driver's TX thread.
 
+config BT_DRV_RX_SUPPORT
+	bool
+
+config BT_DRV_RX_HIGH_PRIO_SUPPORT
+	bool
+
 config BT_DRV_RX_STACK_SIZE
 	int
+	depends on BT_DRV_RX_SUPPORT
 	default 640 if (BT_SPI || BT_AMBIQ_HCI)
 	default BT_RX_STACK_SIZE if (BT_H4 || BT_HCI_RAW_H4)
 	default BT_STM32_IPM_RX_STACK_SIZE if BT_STM32_IPM

--- a/drivers/bluetooth/hci/Kconfig.nxp
+++ b/drivers/bluetooth/hci/Kconfig.nxp
@@ -25,6 +25,7 @@ config HCI_NXP_SET_CAL_DATA_ANNEX100
 
 config HCI_NXP_RX_THREAD
 	bool "Process RX buffers in a dedicated thread"
+	select BT_DRV_RX_SUPPORT
 	help
 	  Some platforms receive the HCI RX buffers in ISR context.
 	  If enabled, the HCI RX message is queued by the ISR, and the message is processed

--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -372,7 +372,7 @@ static int bt_apollo_open(const struct device *dev, bt_hci_recv_t recv)
 	/* Start RX thread */
 	k_thread_create(&spi_rx_thread_data, spi_rx_stack, K_KERNEL_STACK_SIZEOF(spi_rx_stack),
 			(k_thread_entry_t)bt_spi_rx_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, K_NO_WAIT);
+			K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO), 0, K_NO_WAIT);
 
 	ret = bt_apollo_controller_init(spi_send_packet);
 	if (ret == 0) {

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -368,7 +368,7 @@ static void bt_rx_thread(void *p1, void *p2, void *p3)
 }
 
 K_THREAD_DEFINE(nxp_hci_rx_thread, CONFIG_BT_DRV_RX_STACK_SIZE, bt_rx_thread, NULL, NULL, NULL,
-		K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, 0);
+		K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO), 0, 0);
 
 static void hci_rx_cb(uint8_t packetType, uint8_t *data, uint16_t len)
 {

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -272,7 +272,7 @@ static int slz_bt_open(const struct device *dev, bt_hci_recv_t recv)
 
 	k_thread_create(&slz_rx_thread, slz_rx_stack, K_KERNEL_STACK_SIZEOF(slz_rx_stack),
 			slz_rx_thread_func, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, K_NO_WAIT);
+			K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO), 0, K_NO_WAIT);
 	k_thread_name_set(&slz_rx_thread, "EFR32 HCI RX");
 
 	rail_isr_installer();

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -663,7 +663,7 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 	k_thread_create(&spi_rx_thread_data, spi_rx_stack,
 			K_KERNEL_STACK_SIZEOF(spi_rx_stack),
 			bt_spi_rx_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
+			K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 
 	/* Device will let us know when it's ready */

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -559,7 +559,7 @@ static int bt_ipm_open(const struct device *dev, bt_hci_recv_t recv)
 	k_thread_create(&ipm_rx_thread_data, ipm_rx_stack,
 			K_KERNEL_STACK_SIZEOF(ipm_rx_stack),
 			bt_ipm_rx_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
+			K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 
 	hci->recv = recv;

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -398,7 +398,7 @@ static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)
 	k_thread_create(&spi_rx_thread_data, spi_rx_stack,
 			K_KERNEL_STACK_SIZEOF(spi_rx_stack),
 			bt_spi_rx_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
+			K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 	k_thread_name_set(&spi_rx_thread_data, "bt_spi_rx_thread");
 

--- a/drivers/bluetooth/hci/userchan.c
+++ b/drivers/bluetooth/hci/userchan.c
@@ -308,7 +308,7 @@ static int uc_open(const struct device *dev, bt_hci_recv_t recv)
 	k_thread_create(&rx_thread_data, rx_thread_stack,
 			K_KERNEL_STACK_SIZEOF(rx_thread_stack),
 			rx_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
+			K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 
 	LOG_DBG("returning");

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -50,6 +50,7 @@ config BT_HCI_RAW
 
 config BT_HCI_RAW_H4
 	bool "RAW HCI H:4 transport"
+	select BT_DRV_RX_SUPPORT
 	help
 	  This option enables HCI RAW access to work over an H:4
 	  transport, note that it still need to be selected at runtime.

--- a/subsys/bluetooth/common/dummy.c
+++ b/subsys/bluetooth/common/dummy.c
@@ -31,15 +31,15 @@ BUILD_ASSERT(alignof(bt_addr_t) == 1);
 BUILD_ASSERT(sizeof(bt_addr_le_t) == BT_ADDR_LE_SIZE);
 BUILD_ASSERT(alignof(bt_addr_le_t) == 1);
 
-#if defined(CONFIG_BT_HCI_HOST)
+#if defined(CONFIG_BT_HCI_HOST) && defined(CONFIG_BT_DRV_RX_HIGH_PRIO_SUPPORT)
 /* The Bluetooth subsystem requires that higher priority events shall be given
  * in a priority higher than the Bluetooth Host's Tx and the Controller's
  * receive thread priority.
  * This is required in order to dispatch Number of Completed Packets event
  * before any new data arrives on a connection to the Host threads.
  */
-BUILD_ASSERT(CONFIG_BT_DRIVER_RX_HIGH_PRIO < CONFIG_BT_HCI_TX_PRIO);
-#endif /* defined(CONFIG_BT_HCI_HOST) */
+BUILD_ASSERT(CONFIG_BT_RX_HIGH_PRIO < CONFIG_BT_HCI_TX_PRIO);
+#endif /* CONFIG_BT_HCI_HOST && CONFIG_BT_DRV_RX_HIGH_PRIO_SUPPORT */
 
 #if (defined(CONFIG_LOG_BACKEND_RTT) &&                     \
      (defined(CONFIG_SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL) || \

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -147,6 +147,7 @@ config BT_LL_SW_SPLIT
 	default y
 	depends on DT_HAS_ZEPHYR_BT_HCI_LL_SW_SPLIT_ENABLED
 	select HAS_BT_CTLR
+	select BT_DRV_RX_HIGH_PRIO_SUPPORT if !BT_HCI_RAW
 	help
 	  Use Zephyr software Bluetooth LE Link Layer ULL LLL split implementation.
 

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -126,7 +126,7 @@ config BT_CTLR_RX_POLL
 config BT_CTLR_RX_PRIO_STACK_SIZE
 	# Hidden
 	int
-	depends on !BT_HCI_RAW
+	depends on BT_DRV_RX_HIGH_PRIO_SUPPORT
 	default 448
 	help
 	  Controller's Co-Operative high priority Rx thread stack size.

--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -1024,7 +1024,7 @@ static int hci_driver_open(const struct device *dev, bt_hci_recv_t recv)
 	k_thread_create(&prio_recv_thread_data, prio_recv_thread_stack,
 			K_KERNEL_STACK_SIZEOF(prio_recv_thread_stack),
 			prio_recv_thread, (void *)dev, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO), 0, K_NO_WAIT);
+			K_PRIO_COOP(CONFIG_BT_RX_HIGH_PRIO), 0, K_NO_WAIT);
 	k_thread_name_set(&prio_recv_thread_data, "BT CTLR RX pri");
 #endif /* CONFIG_BT_CTLR_RX_PRIO_STACK_SIZE */
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -110,6 +110,7 @@ endchoice
 
 config BT_RX_STACK_SIZE
 	int "Size of the receiving thread stack"
+	depends on BT_DRV_RX_SUPPORT || BT_RECV_WORKQ_BT
 	default 768 if BT_HCI_RAW
 	default 3092 if BT_MESH_GATT_CLIENT
 	default 2600 if BT_MESH
@@ -126,11 +127,13 @@ config BT_RX_STACK_SIZE
 config BT_RX_PRIO
 	# Hidden option for Co-Operative Rx thread priority
 	int
+	depends on BT_DRV_RX_SUPPORT || BT_RECV_WORKQ_BT
 	default 8
 
-config BT_DRIVER_RX_HIGH_PRIO
-	# Hidden option for Co-Operative HCI driver RX thread priority
+config BT_RX_HIGH_PRIO
+	# Hidden option for Co-Operative HCI driver High Priority Rx thread priority
 	int
+	depends on BT_DRV_RX_HIGH_PRIO_SUPPORT
 	default 6
 
 config BT_CONN_TX_NOTIFY_WQ


### PR DESCRIPTION
Add missing depends on for stack size Kconfig values.