### PR TITLE
drivers: wifi: siwx91x: Fix/connect bugfixes

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -23,6 +23,7 @@
 #include "sl_wifi_constants.h"
 
 #define SIWX91X_DRIVER_VERSION KERNEL_VERSION_STRING
+#define SIWX91X_DEFAULT_PASSIVE_SCAN_DWELL_TIME 400
 
 LOG_MODULE_REGISTER(siwx91x_wifi);
 
@@ -736,6 +737,9 @@ siwx91x_configure_scan_dwell_time(sl_wifi_scan_type_t scan_type, uint16_t dwell_
 						 dwell_time_active);
 		break;
 	case SL_WIFI_SCAN_TYPE_PASSIVE:
+		if (!dwell_time_passive) {
+			dwell_time_passive = SIWX91X_DEFAULT_PASSIVE_SCAN_DWELL_TIME;
+		}
 		ret = sl_si91x_configure_timeout(SL_SI91X_CHANNEL_PASSIVE_SCAN_TIMEOUT,
 						 dwell_time_passive);
 		break;

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -182,20 +182,6 @@ static int siwx91x_status(const struct device *dev, struct wifi_iface_status *st
 	memcpy(status->bssid, wlan_info.bssid, WIFI_MAC_ADDR_LEN);
 	status->wpa3_ent_type = WIFI_WPA3_ENTERPRISE_NA;
 
-	ret = sl_si91x_get_join_configuration(interface, &join_config);
-	if (ret != SL_STATUS_OK) {
-		LOG_ERR("Failed to get join configuration: 0x%x", ret);
-		return -EINVAL;
-	}
-
-	if (join_config & SL_SI91X_JOIN_FEAT_MFP_CAPABLE_REQUIRED) {
-		status->mfp = WIFI_MFP_REQUIRED;
-	} else if (join_config & SL_SI91X_JOIN_FEAT_MFP_CAPABLE_ONLY) {
-		status->mfp = WIFI_MFP_OPTIONAL;
-	} else {
-		status->mfp = WIFI_MFP_DISABLE;
-	}
-
 	if (interface & SL_WIFI_2_4GHZ_INTERFACE) {
 		status->band = WIFI_FREQ_BAND_2_4_GHZ;
 	}
@@ -207,6 +193,27 @@ static int siwx91x_status(const struct device *dev, struct wifi_iface_status *st
 		status->iface_mode = WIFI_MODE_INFRA;
 		status->channel = wlan_info.channel_number;
 		status->twt_capable = true;
+
+		ret = sl_si91x_get_join_configuration(interface, &join_config);
+		if (ret != SL_STATUS_OK) {
+			LOG_ERR("Failed to get join configuration: 0x%x", ret);
+			return -EINVAL;
+		}
+
+		if (wlan_info.sec_type == SL_WIFI_WPA3) {
+			status->mfp = WIFI_MFP_REQUIRED;
+		} else if (wlan_info.sec_type == SL_WIFI_WPA3_TRANSITION) {
+			status->mfp = WIFI_MFP_OPTIONAL;
+		} else if (wlan_info.sec_type == SL_WIFI_WPA2) {
+			if (join_config & SL_SI91X_JOIN_FEAT_MFP_CAPABLE_REQUIRED) {
+				status->mfp = WIFI_MFP_REQUIRED;
+			} else {
+				status->mfp = WIFI_MFP_OPTIONAL;
+			}
+		} else {
+			status->mfp = WIFI_MFP_DISABLE;
+		}
+
 		ret = sl_wifi_get_signal_strength(SL_WIFI_CLIENT_INTERFACE, &rssi);
 		if (ret) {
 			LOG_ERR("Failed to get signal strength: 0x%x", ret);
@@ -231,10 +238,10 @@ static int siwx91x_status(const struct device *dev, struct wifi_iface_status *st
 			LOG_ERR("Failed to get the AP configuration: 0x%x", ret);
 			return -EINVAL;
 		}
-
 		status->twt_capable = false;
 		status->link_mode = WIFI_4;
 		status->iface_mode = WIFI_MODE_AP;
+		status->mfp = WIFI_MFP_DISABLE;
 		status->channel = sl_ap_cfg.channel.channel;
 		status->beacon_interval = sl_ap_cfg.beacon_interval;
 		status->dtim_period = sl_ap_cfg.dtim_beacon_count;

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -179,7 +179,7 @@ static int siwx91x_status(const struct device *dev, struct wifi_iface_status *st
 
 	strncpy(status->ssid, wlan_info.ssid, WIFI_SSID_MAX_LEN);
 	status->ssid_len = strlen(status->ssid);
-	memcpy(status->bssid, wlan_info.mac_address, WIFI_MAC_ADDR_LEN);
+	memcpy(status->bssid, wlan_info.bssid, WIFI_MAC_ADDR_LEN);
 	status->wpa3_ent_type = WIFI_WPA3_ENTERPRISE_NA;
 
 	ret = sl_si91x_get_join_configuration(interface, &join_config);


### PR DESCRIPTION
Resolved these three bugs in this PR:

1. Passive scan is failing if user doesn't provide any dwell time because SDK is not sending 400 ms to firmware according to spec.

2. BSSID values got changed after connection, Before connection its showing BSSID of AP and after connection its showing BSSID of STA connected.

3. Status is showing DISABLE after connection in WPA3 – SDK is not updating global variable of join feature bit map.