### PR TITLE
arch: arm: clear r7 to match aarch64 smp implementation

### DIFF
--- a/arch/arm/core/cortex_a_r/reset.S
+++ b/arch/arm/core/cortex_a_r/reset.S
@@ -227,12 +227,12 @@ EL1_Reset_Handler:
     /* signal our desire to vote */
     mov r5, #1
     strb r5, [r4, r2]
+    mov r7, #0
     ldr r3, [r0, #BOOT_PARAM_MPID_OFFSET]
     cmn r3, #1
     beq 1f
 
     /* some core already won, release */
-    mov r7, #0
     strb r7, [r4, r2]
     b _secondary_core
 


### PR DESCRIPTION
add mov r7,  #0 as aarch64 implementation uses wzr which returns 0 on read but r7 might have an undefined value after a reset.

[https://github.com/zephyrproject-rtos/zephyr/blob/main/arch/arm/core/cortex_a_r/reset.S](url) : 
```diff

    /* some core already won, release */
    mov r7, #0
    strb r7, [r4, r2]
    b _secondary_core

    /* suggest current core then release */
1:  str r1, [r0, #BOOT_PARAM_MPID_OFFSET]
+   mov r7, #0
    strb r7, [r4, r2]
    dmb
```
[https://github.com/zephyrproject-rtos/zephyr/blob/main/arch/arm64/core/reset.S](url) :
```assembly
	/* some core already won, release */
	strb	wzr, [x4, x2]
	b	secondary_core

	/* suggest current core then release */
1:	str	x1, [x0, #BOOT_PARAM_MPID_OFFSET]
	strb	wzr, [x4, x2]
	dmb	ish
```