### PR TITLE
Bluetooth: Host: L2CAP: Fix checking signaling packets size

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1049,8 +1049,9 @@ static void le_conn_param_rsp(struct bt_l2cap *l2cap, struct net_buf *buf)
 {
 	struct bt_l2cap_conn_param_rsp *rsp = (void *)buf->data;
 
-	if (buf->len < sizeof(*rsp)) {
-		LOG_ERR("Too small LE conn param rsp");
+	if (buf->len != sizeof(*rsp)) {
+		LOG_ERR("Invalid LE conn param rsp size (%u != %zu)",
+			buf->len, sizeof(*rsp));
 		return;
 	}
 
@@ -1066,8 +1067,9 @@ static void le_conn_param_update_req(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_conn_param_req *req = (void *)buf->data;
 	bool accepted;
 
-	if (buf->len < sizeof(*req)) {
-		LOG_ERR("Too small LE conn update param req");
+	if (buf->len != sizeof(*req)) {
+		LOG_ERR("Invalid LE conn update param req size (%u != %zu)",
+			buf->len, sizeof(*req));
 		return;
 	}
 
@@ -1458,8 +1460,9 @@ static void le_conn_req(struct bt_l2cap *l2cap, uint8_t ident,
 	uint16_t psm, scid, mtu, mps, credits;
 	uint16_t result;
 
-	if (buf->len < sizeof(*req)) {
-		LOG_ERR("Too small LE conn req packet size");
+	if (buf->len != sizeof(*req)) {
+		LOG_ERR("Invalid LE conn req packet size (%u != %zu)",
+			buf->len, sizeof(*req));
 		return;
 	}
 
@@ -1759,8 +1762,9 @@ static void le_ecred_reconf_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_le_chan *ch;
 	uint16_t result;
 
-	if (buf->len < sizeof(*rsp)) {
-		LOG_ERR("Too small ecred reconf rsp packet size");
+	if (buf->len != sizeof(*rsp)) {
+		LOG_ERR("Invalid ecred reconf rsp packet size (%u != %zu)",
+			buf->len, sizeof(*rsp));
 		return;
 	}
 
@@ -1820,8 +1824,9 @@ static void le_disconn_req(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_disconn_rsp *rsp;
 	uint16_t dcid;
 
-	if (buf->len < sizeof(*req)) {
-		LOG_ERR("Too small LE conn req packet size");
+	if (buf->len != sizeof(*req)) {
+		LOG_ERR("Invalid LE conn req packet size (%u != %zu)",
+			buf->len, sizeof(*req));
 		return;
 	}
 
@@ -2039,8 +2044,9 @@ static void le_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_le_conn_rsp *rsp = (void *)buf->data;
 	uint16_t dcid, mtu, mps, credits, result;
 
-	if (buf->len < sizeof(*rsp)) {
-		LOG_ERR("Too small LE conn rsp packet size");
+	if (buf->len != sizeof(*rsp)) {
+		LOG_ERR("Invalid LE conn rsp packet size (%u != %zu)",
+			buf->len, sizeof(*rsp));
 		return;
 	}
 
@@ -2111,8 +2117,9 @@ static void le_disconn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_disconn_rsp *rsp = (void *)buf->data;
 	uint16_t scid;
 
-	if (buf->len < sizeof(*rsp)) {
-		LOG_ERR("Too small LE disconn rsp packet size");
+	if (buf->len != sizeof(*rsp)) {
+		LOG_ERR("Invalid LE disconn rsp packet size (%u != %zu)",
+			buf->len, sizeof(*rsp));
 		return;
 	}
 
@@ -2137,8 +2144,9 @@ static void le_credits(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_le_chan *le_chan;
 	uint16_t credits, cid;
 
-	if (buf->len < sizeof(*ev)) {
-		LOG_ERR("Too small LE Credits packet size");
+	if (buf->len != sizeof(*ev)) {
+		LOG_ERR("Invalid LE Credits packet size (%u != %zu)",
+			buf->len, sizeof(*ev));
 		return;
 	}
 


### PR DESCRIPTION
Recent test specification added additional test for validating invalid packet sizes on L2CAP signaling channel. IUT is allowed to either disconnect link, ignore packet, reject packet or issue a warning to upper tester if other action is taken.

To keep things in line with previous check for too small size simply ignore fixed size packets of invalid length.

This was affecting L2CAP/COS/CED/BI-11-C qualification test.