### PR TITLE
sys: timeutil: add utility functions for struct timespec

### DIFF
--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -301,12 +301,12 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
  */
 int32_t timeutil_sync_skew_to_ppb(float skew);
 
-#ifdef __cplusplus
-}
-#endif
-
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_SYS_TIMEUTIL_H_ */

--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -21,8 +21,18 @@
 #ifndef ZEPHYR_INCLUDE_SYS_TIMEUTIL_H_
 #define ZEPHYR_INCLUDE_SYS_TIMEUTIL_H_
 
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <time.h>
 
+#include <zephyr/sys_clock.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/time_units.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus
@@ -300,6 +310,414 @@ int timeutil_sync_local_from_ref(const struct timeutil_sync_state *tsp,
  * if the skew cannot be represented in the return type.
  */
 int32_t timeutil_sync_skew_to_ppb(float skew);
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup timeutil_timespec_apis Timespec Utility APIs
+ * @ingroup timeutil_apis
+ * @{
+ */
+
+/**
+ * @brief Check if a timespec is valid.
+ *
+ * Check if a timespec is valid (i.e. normalized) by ensuring that the `tv_nsec` field is in the
+ * range `[0, NSEC_PER_SEC-1]`.
+ *
+ * @note @p ts must not be `NULL`.
+ *
+ * @param ts the timespec to check
+ *
+ * @return `true` if the timespec is valid, otherwise `false`.
+ */
+static inline bool timespec_is_valid(const struct timespec *ts)
+{
+	__ASSERT_NO_MSG(ts != NULL);
+
+	return (ts->tv_nsec >= 0) && (ts->tv_nsec < NSEC_PER_SEC);
+}
+
+/**
+ * @brief Normalize a timespec so that the `tv_nsec` field is in valid range.
+ *
+ * Normalize a timespec by adjusting the `tv_sec` and `tv_nsec` fields so that the `tv_nsec` field
+ * is in the range `[0, NSEC_PER_SEC-1]`. This is achieved by converting nanoseconds to seconds and
+ * accumulating seconds in either the positive direction when `tv_nsec` > `NSEC_PER_SEC`, or in the
+ * negative direction when `tv_nsec` < 0.
+ *
+ * In pseudocode, normalization can be done as follows:
+ * ```python
+ * if ts.tv_nsec >= NSEC_PER_SEC:
+ *     sec = ts.tv_nsec / NSEC_PER_SEC
+ *     ts.tv_sec += sec
+ *     ts.tv_nsec -= sec * NSEC_PER_SEC
+ * elif ts.tv_nsec < 0:
+ *      # div_round_up(abs(ts->tv_nsec), NSEC_PER_SEC)
+ *	    sec = (NSEC_PER_SEC - ts.tv_nsec - 1) / NSEC_PER_SEC
+ *	    ts.tv_sec -= sec;
+ *	    ts.tv_nsec += sec * NSEC_PER_SEC;
+ * ```
+ *
+ * @note There are two cases where the normalization can result in integer overflow. These can
+ * be extrapolated to not simply overflowing the `tv_sec` field by one second, but also by any
+ * realizable multiple of `NSEC_PER_SEC`.
+ *
+ * 1. When `tv_nsec` is negative and `tv_sec` is already most negative.
+ * 2. When `tv_nsec` is greater-or-equal to `NSEC_PER_SEC` and `tv_sec` is already most positive.
+ *
+ * If the operation would result in integer overflow, return value is `false`.
+ *
+ * @note @p ts must be non-`NULL`.
+ *
+ * @param ts the timespec to be normalized
+ *
+ * @return `true` if the operation completes successfully, otherwise `false`.
+ */
+static inline bool timespec_normalize(struct timespec *ts)
+{
+	__ASSERT_NO_MSG(ts != NULL);
+
+#if defined(CONFIG_SPEED_OPTIMIZATIONS) && HAS_BUILTIN(__builtin_add_overflow)
+
+	int sign = (ts->tv_nsec >= 0) - (ts->tv_nsec < 0);
+	int64_t sec = (ts->tv_nsec >= (long)NSEC_PER_SEC) * (ts->tv_nsec / (long)NSEC_PER_SEC) +
+		      ((ts->tv_nsec < 0) && (ts->tv_nsec != LONG_MIN)) *
+			      DIV_ROUND_UP((unsigned long)-ts->tv_nsec, (long)NSEC_PER_SEC) +
+		      (ts->tv_nsec == LONG_MIN) * ((LONG_MAX / NSEC_PER_SEC) + 1);
+	bool overflow = __builtin_add_overflow(ts->tv_sec, sign * sec, &ts->tv_sec);
+
+	ts->tv_nsec -= sign * (long)NSEC_PER_SEC * sec;
+
+	if (!overflow) {
+		__ASSERT_NO_MSG(timespec_is_valid(ts));
+	}
+
+	return !overflow;
+
+#else
+
+	long sec;
+
+	if (ts->tv_nsec >= (long)NSEC_PER_SEC) {
+		sec = ts->tv_nsec / (long)NSEC_PER_SEC;
+	} else if (ts->tv_nsec < 0) {
+		if ((sizeof(ts->tv_nsec) == sizeof(uint32_t)) && (ts->tv_nsec == LONG_MIN)) {
+			sec = DIV_ROUND_UP(LONG_MAX / NSEC_PER_USEC, USEC_PER_SEC);
+		} else {
+			sec = DIV_ROUND_UP((unsigned long)-ts->tv_nsec, NSEC_PER_SEC);
+		}
+	} else {
+		sec = 0;
+	}
+
+	if ((ts->tv_nsec < 0) && (ts->tv_sec < 0) && (ts->tv_sec - INT64_MIN < sec)) {
+		/*
+		 * When `tv_nsec` is negative and `tv_sec` is already most negative,
+		 * further subtraction would cause integer overflow.
+		 */
+		return false;
+	}
+
+	if ((ts->tv_nsec >= (long)NSEC_PER_SEC) && (ts->tv_sec > 0) &&
+	    (INT64_MAX - ts->tv_sec < sec)) {
+		/*
+		 * When `tv_nsec` is >= `NSEC_PER_SEC` and `tv_sec` is already most
+		 * positive, further addition would cause integer overflow.
+		 */
+		return false;
+	}
+
+	if (ts->tv_nsec >= (long)NSEC_PER_SEC) {
+		ts->tv_sec += sec;
+		ts->tv_nsec -= sec * (long)NSEC_PER_SEC;
+	} else if (ts->tv_nsec < 0) {
+		ts->tv_sec -= sec;
+		ts->tv_nsec += sec * (long)NSEC_PER_SEC;
+	} else {
+		/* no change: SonarQube was complaining */
+	}
+
+	__ASSERT_NO_MSG(timespec_is_valid(ts));
+
+	return true;
+
+#endif
+}
+
+/**
+ * @brief Add one timespec to another
+ *
+ * This function sums the two timespecs pointed to by @p a and @p b and stores the result in the
+ * timespce pointed to by @p a.
+ *
+ * If the operation would result in integer overflow, return value is `false`.
+ *
+ * @note @p a and @p b must be non-`NULL` and normalized.
+ *
+ * @param a the timespec which is added to
+ * @param b the timespec to be added
+ *
+ * @return `true` if the operation was successful, otherwise `false`.
+ */
+static inline bool timespec_add(struct timespec *a, const struct timespec *b)
+{
+	__ASSERT_NO_MSG((a != NULL) && timespec_is_valid(a));
+	__ASSERT_NO_MSG((b != NULL) && timespec_is_valid(b));
+
+#if defined(CONFIG_SPEED_OPTIMIZATIONS) && HAS_BUILTIN(__builtin_add_overflow)
+
+	return !__builtin_add_overflow(a->tv_sec, b->tv_sec, &a->tv_sec) &&
+	       !__builtin_add_overflow(a->tv_nsec, b->tv_nsec, &a->tv_nsec) &&
+	       timespec_normalize(a);
+
+#else
+
+	if ((a->tv_sec < 0) && (b->tv_sec < 0) && (INT64_MIN - a->tv_sec > b->tv_sec)) {
+		/* negative integer overflow would occur */
+		return false;
+	}
+
+	if ((a->tv_sec > 0) && (b->tv_sec > 0) && (INT64_MAX - a->tv_sec < b->tv_sec)) {
+		/* positive integer overflow would occur */
+		return false;
+	}
+
+	a->tv_sec += b->tv_sec;
+	a->tv_nsec += b->tv_nsec;
+
+	return timespec_normalize(a);
+
+#endif
+}
+
+/**
+ * @brief Negate a timespec object
+ *
+ * Negate the timespec object pointed to by @p ts and store the result in the same
+ * memory location.
+ *
+ * If the operation would result in integer overflow, return value is `false`.
+ *
+ * @param ts The timespec object to negate.
+ *
+ * @return `true` of the operation is successful, otherwise `false`.
+ */
+static inline bool timespec_negate(struct timespec *ts)
+{
+	__ASSERT_NO_MSG((ts != NULL) && timespec_is_valid(ts));
+
+#if defined(CONFIG_SPEED_OPTIMIZATIONS) && HAS_BUILTIN(__builtin_sub_overflow)
+
+	return !__builtin_sub_overflow(0LL, ts->tv_sec, &ts->tv_sec) &&
+	       !__builtin_sub_overflow(0L, ts->tv_nsec, &ts->tv_nsec) && timespec_normalize(ts);
+
+#else
+
+	if (ts->tv_sec == INT64_MIN) {
+		/* -INT64_MIN > INT64_MAX, so +ve integer overflow would occur */
+		return false;
+	}
+
+	ts->tv_sec = -ts->tv_sec;
+	ts->tv_nsec = -ts->tv_nsec;
+
+	return timespec_normalize(ts);
+
+#endif
+}
+
+/**
+ * @brief Subtract one timespec from another
+ *
+ * This function subtracts the timespec pointed to by @p b from the timespec pointed to by @p a and
+ * stores the result in the timespce pointed to by @p a.
+ *
+ * If the operation would result in integer overflow, return value is `false`.
+ *
+ * @note @p a and @p b must be non-`NULL`.
+ *
+ * @param a the timespec which is subtracted from
+ * @param b the timespec to be subtracted
+ *
+ * @return `true` if the operation is successful, otherwise `false`.
+ */
+static inline bool timespec_sub(struct timespec *a, const struct timespec *b)
+{
+	__ASSERT_NO_MSG(a != NULL);
+	__ASSERT_NO_MSG(b != NULL);
+
+	struct timespec neg = *b;
+
+	return timespec_negate(&neg) && timespec_add(a, &neg);
+}
+
+/**
+ * @brief Compare two timespec objects
+ *
+ * This function compares two timespec objects pointed to by @p a and @p b.
+ *
+ * @note @p a and @p b must be non-`NULL` and normalized.
+ *
+ * @param a the first timespec to compare
+ * @param b the second timespec to compare
+ *
+ * @return -1, 0, or +1 if @a a is less than, equal to, or greater than @a b, respectively.
+ */
+static inline int timespec_compare(const struct timespec *a, const struct timespec *b)
+{
+	__ASSERT_NO_MSG((a != NULL) && timespec_is_valid(a));
+	__ASSERT_NO_MSG((b != NULL) && timespec_is_valid(b));
+
+	return (((a->tv_sec == b->tv_sec) && (a->tv_nsec < b->tv_nsec)) * -1) +
+	       (((a->tv_sec == b->tv_sec) && (a->tv_nsec > b->tv_nsec)) * 1) +
+	       ((a->tv_sec < b->tv_sec) * -1) + ((a->tv_sec > b->tv_sec));
+}
+
+/**
+ * @brief Check if two timespec objects are equal
+ *
+ * This function checks if the two timespec objects pointed to by @p a and @p b are equal.
+ *
+ * @note @p a and @p b must be non-`NULL` are not required to be normalized.
+ *
+ * @param a the first timespec to compare
+ * @param b the second timespec to compare
+ *
+ * @return true if the two timespec objects are equal, otherwise false.
+ */
+static inline bool timespec_equal(const struct timespec *a, const struct timespec *b)
+{
+	__ASSERT_NO_MSG(a != NULL);
+	__ASSERT_NO_MSG(b != NULL);
+
+	return (a->tv_sec == b->tv_sec) && (a->tv_nsec == b->tv_nsec);
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @ingroup timeutil_repr_apis
+ * @{
+ */
+
+/**
+ * @brief Convert a kernel timeout to a timespec
+ *
+ * This function converts time durations expressed as Zephyr @ref k_timeout_t
+ * objects to `struct timespec` objects.
+ *
+ * @param timeout the kernel timeout to convert
+ * @param[out] ts the timespec to store the result
+ */
+static inline void timespec_from_timeout(k_timeout_t timeout, struct timespec *ts)
+{
+	__ASSERT_NO_MSG(ts != NULL);
+
+#if defined(CONFIG_SPEED_OPTIMIZATIONS)
+
+	uint64_t ns = k_ticks_to_ns_ceil64(timeout.ticks);
+
+	*ts = (struct timespec){
+		.tv_sec = (timeout.ticks == K_TICKS_FOREVER) * INT64_MAX +
+			  (timeout.ticks != K_TICKS_FOREVER) * (ns / NSEC_PER_SEC),
+		.tv_nsec = (timeout.ticks == K_TICKS_FOREVER) * (NSEC_PER_SEC - 1) +
+			   (timeout.ticks != K_TICKS_FOREVER) * (ns % NSEC_PER_SEC),
+	};
+
+#else
+
+	if (timeout.ticks == 0) {
+		/* This is equivalent to K_NO_WAIT, but without including <zephyr/kernel.h> */
+		ts->tv_sec = 0;
+		ts->tv_nsec = 0;
+	} else if (timeout.ticks == K_TICKS_FOREVER) {
+		/* This is roughly equivalent to K_FOREVER, but not including <zephyr/kernel.h> */
+		ts->tv_sec = (time_t)INT64_MAX;
+		ts->tv_nsec = NSEC_PER_SEC - 1;
+	} else {
+		uint64_t ns = k_ticks_to_ns_ceil64(timeout.ticks);
+
+		ts->tv_sec = ns / NSEC_PER_SEC;
+		ts->tv_nsec = ns - ts->tv_sec * NSEC_PER_SEC;
+	}
+
+#endif
+
+	__ASSERT_NO_MSG(timespec_is_valid(ts));
+}
+
+/**
+ * @brief Convert a timespec to a kernel timeout
+ *
+ * This function converts durations expressed as a `struct timespec` to Zephyr @ref k_timeout_t
+ * objects.
+ *
+ * Given that the range of a `struct timespec` is much larger than the range of @ref k_timeout_t,
+ * and also given that the functions are only intended to be used to convert time durations
+ * (which are always positive), the function will saturate to @ref K_NO_WAIT if the `tv_sec` field
+ * of @a ts is negative.
+ *
+ * Similarly, if the duration is too large to fit in @ref k_timeout_t, the function will
+ * saturate to @ref K_FOREVER.
+ *
+ * @param ts the timespec to convert
+ * @return the kernel timeout
+ */
+static inline k_timeout_t timespec_to_timeout(const struct timespec *ts)
+{
+	__ASSERT_NO_MSG((ts != NULL) && timespec_is_valid(ts));
+
+#if defined(CONFIG_SPEED_OPTIMIZATIONS)
+
+	return (k_timeout_t){
+		.ticks = ((ts->tv_sec == INT64_MAX) && (ts->tv_nsec == NSEC_PER_SEC - 1)) *
+				 K_TICKS_FOREVER +
+			 ((ts->tv_sec != INT64_MAX) && (ts->tv_sec >= 0)) *
+				 (IS_ENABLED(CONFIG_TIMEOUT_64BIT)
+					  ? (int64_t)(CLAMP(
+						    k_sec_to_ticks_floor64(ts->tv_sec) +
+							    k_ns_to_ticks_floor64(ts->tv_nsec),
+						    0, (uint64_t)INT64_MAX))
+					  : (uint32_t)(CLAMP(
+						    k_sec_to_ticks_floor64(ts->tv_sec) +
+							    k_ns_to_ticks_floor64(ts->tv_nsec),
+						    0, (uint64_t)UINT32_MAX)))};
+
+#else
+
+	if ((ts->tv_sec < 0) || (ts->tv_sec == 0 && ts->tv_nsec == 0)) {
+		/* This is equivalent to K_NO_WAIT, but without including <zephyr/kernel.h> */
+		return (k_timeout_t){
+			.ticks = 0,
+		};
+	} else if (ts->tv_sec == INT64_MAX && ts->tv_nsec == NSEC_PER_SEC - 1) {
+		/* This is equivalent to K_FOREVER, but not including <zephyr/kernel.h> */
+		return (k_timeout_t){
+			.ticks = K_TICKS_FOREVER,
+		};
+	} else {
+		if (IS_ENABLED(CONFIG_TIMEOUT_64BIT)) {
+			return (k_timeout_t){
+				.ticks = (int64_t)CLAMP(k_sec_to_ticks_floor64(ts->tv_sec) +
+								k_ns_to_ticks_floor64(ts->tv_nsec),
+							0, (uint64_t)INT64_MAX),
+			};
+		} else {
+			return (k_timeout_t){
+				.ticks = (uint32_t)CLAMP(k_sec_to_ticks_floor64(ts->tv_sec) +
+								 k_ns_to_ticks_floor64(ts->tv_nsec),
+							 0, (uint64_t)UINT32_MAX),
+			};
+		}
+	}
+
+#endif
+}
 
 /**
  * @}

--- a/lib/posix/options/posix_clock.h
+++ b/lib/posix/options/posix_clock.h
@@ -16,18 +16,13 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/posix/sys/time.h>
+#include <zephyr/sys/timeutil.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** @cond INTERNAL_HIDDEN */
-
-static inline bool timespec_is_valid(const struct timespec *ts)
-{
-	__ASSERT_NO_MSG(ts != NULL);
-	return (ts->tv_nsec >= 0) && (ts->tv_nsec < NSEC_PER_SEC);
-}
 
 static inline int64_t ts_to_ns(const struct timespec *ts)
 {
@@ -47,7 +42,7 @@ static inline void tv_to_ts(const struct timeval *tv, struct timespec *ts)
 
 static inline bool tp_ge(const struct timespec *a, const struct timespec *b)
 {
-	return ts_to_ns(a) >= ts_to_ns(b);
+	return timespec_compare(a, b) >= 0;
 }
 
 static inline int64_t tp_diff(const struct timespec *a, const struct timespec *b)

--- a/tests/lib/timespec_util/CMakeLists.txt
+++ b/tests/lib/timespec_util/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(timespec_util)
+
+FILE(GLOB app_sources src/main.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/lib/timespec_util/prj.conf
+++ b/tests/lib/timespec_util/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/tests/lib/timespec_util/src/main.c
+++ b/tests/lib/timespec_util/src/main.c
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <time.h>
+
+#include <zephyr/ztest.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/sys/timeutil.h>
+#include <zephyr/sys/util.h>
+
+BUILD_ASSERT(sizeof(time_t) == sizeof(int64_t), "time_t must be 64-bit");
+BUILD_ASSERT(sizeof(((struct timespec *)0)->tv_sec) == sizeof(int64_t), "tv_sec must be 64-bit");
+
+/* need NSEC_PER_SEC to be signed for the purposes of this testsuite */
+#undef NSEC_PER_SEC
+#define NSEC_PER_SEC 1000000000L
+
+#undef CORRECTABLE
+#define CORRECTABLE true
+
+#undef UNCORRECTABLE
+#define UNCORRECTABLE false
+
+/*
+ * test spec for simple timespec validation
+ *
+ * If a timespec is expected to be valid, then invalid_ts and valid_ts are equal.
+ *
+ * If a timespec is expected to be invalid, then invalid_ts and valid_ts are not equal.
+ */
+struct ts_test_spec {
+	struct timespec invalid_ts;
+	struct timespec valid_ts;
+	bool expect_valid;
+	bool correctable;
+};
+
+#define DECL_VALID_TS_TEST(sec, nsec)                                                              \
+	{                                                                                          \
+		.invalid_ts = {(sec), (nsec)},                                                     \
+		.valid_ts = {(sec), (nsec)},                                                       \
+		.expect_valid = true,                                                              \
+		.correctable = false,                                                              \
+	}
+
+/*
+ * Invalid timespecs can usually be converted to valid ones by adding or subtracting
+ * multiples of `NSEC_PER_SEC` from tv_nsec, and incrementing or decrementing tv_sec
+ * proportionately, unless doing so would result in signed integer overflow.
+ *
+ * There are two particular corner cases:
+ * 1. making tv_sec more negative would overflow the tv_sec field in the negative direction
+ * 1. making tv_sec more positive would overflow the tv_sec field in the positive direction
+ */
+#define DECL_INVALID_TS_TEST(invalid_sec, invalid_nsec, valid_sec, valid_nsec, is_correctable)     \
+	{                                                                                          \
+		.valid_ts = {(valid_sec), (valid_nsec)},                                           \
+		.invalid_ts = {(invalid_sec), (invalid_nsec)},                                     \
+		.expect_valid = false,                                                             \
+		.correctable = (is_correctable),                                                   \
+	}
+
+/*
+ * Easily verifiable tests for both valid and invalid timespecs.
+ */
+static const struct ts_test_spec ts_tests[] = {
+	/* Valid cases */
+	DECL_VALID_TS_TEST(0, 0),
+	DECL_VALID_TS_TEST(0, 1),
+	DECL_VALID_TS_TEST(1, 0),
+	DECL_VALID_TS_TEST(1, 1),
+	DECL_VALID_TS_TEST(1, NSEC_PER_SEC - 1),
+	DECL_VALID_TS_TEST(-1, 0),
+	DECL_VALID_TS_TEST(-1, 1),
+	DECL_VALID_TS_TEST(-1, 0),
+	DECL_VALID_TS_TEST(-1, 1),
+	DECL_VALID_TS_TEST(-1, NSEC_PER_SEC - 1),
+	DECL_VALID_TS_TEST(INT64_MIN, 0),
+	DECL_VALID_TS_TEST(INT64_MIN, NSEC_PER_SEC - 1),
+	DECL_VALID_TS_TEST(INT64_MAX, 0),
+	DECL_VALID_TS_TEST(INT64_MAX, NSEC_PER_SEC - 1),
+
+	/* Correctable, invalid cases */
+	DECL_INVALID_TS_TEST(0, -2 * NSEC_PER_SEC + 1, -2, 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, -2 * NSEC_PER_SEC - 1, -3, NSEC_PER_SEC - 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, -NSEC_PER_SEC - 1, -2, NSEC_PER_SEC - 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, -1, -1, NSEC_PER_SEC - 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, NSEC_PER_SEC, 1, 0, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, NSEC_PER_SEC + 1, 1, 0, CORRECTABLE),
+	DECL_INVALID_TS_TEST(1, -1, 0, NSEC_PER_SEC - 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(1, NSEC_PER_SEC, 2, 0, CORRECTABLE),
+	DECL_INVALID_TS_TEST(-1, -1, -2, NSEC_PER_SEC - 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, NSEC_PER_SEC, 1, 0, CORRECTABLE),
+	DECL_INVALID_TS_TEST(1, -1, 0, NSEC_PER_SEC - 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(1, NSEC_PER_SEC, 2, 0, CORRECTABLE),
+	DECL_INVALID_TS_TEST(INT64_MIN, NSEC_PER_SEC, INT64_MIN + 1, 0, CORRECTABLE),
+	DECL_INVALID_TS_TEST(INT64_MAX, -1, INT64_MAX - 1, NSEC_PER_SEC - 1, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, LONG_MIN, LONG_MAX / NSEC_PER_SEC, 145224192, CORRECTABLE),
+	DECL_INVALID_TS_TEST(0, LONG_MAX, LONG_MAX / NSEC_PER_SEC, LONG_MAX % NSEC_PER_SEC,
+			     CORRECTABLE),
+
+	/* Uncorrectable, invalid cases */
+	DECL_INVALID_TS_TEST(INT64_MIN + 2, -2 * NSEC_PER_SEC - 1, 0, 0, UNCORRECTABLE),
+	DECL_INVALID_TS_TEST(INT64_MIN + 1, -NSEC_PER_SEC - 1, 0, 0, UNCORRECTABLE),
+	DECL_INVALID_TS_TEST(INT64_MIN + 1, -NSEC_PER_SEC - 1, 0, 0, UNCORRECTABLE),
+	DECL_INVALID_TS_TEST(INT64_MIN, -1, 0, 0, UNCORRECTABLE),
+	DECL_INVALID_TS_TEST(INT64_MAX, NSEC_PER_SEC, 0, 0, UNCORRECTABLE),
+	DECL_INVALID_TS_TEST(INT64_MAX - 1, 2 * NSEC_PER_SEC, 0, 0, UNCORRECTABLE),
+};
+
+ZTEST(timeutil_api, test_timespec_is_valid)
+{
+	ARRAY_FOR_EACH(ts_tests, i) {
+		const struct ts_test_spec *const tspec = &ts_tests[i];
+		bool valid = timespec_is_valid(&tspec->invalid_ts);
+
+		zexpect_equal(valid, tspec->expect_valid,
+			      "%d: timespec_is_valid({%ld, %ld}) = %s, expected true", i,
+			      tspec->valid_ts.tv_sec, tspec->valid_ts.tv_nsec,
+			      tspec->expect_valid ? "false" : "true");
+	}
+}
+
+ZTEST(timeutil_api, test_timespec_normalize)
+{
+	ARRAY_FOR_EACH(ts_tests, i) {
+		bool different;
+		bool overflow;
+		const struct ts_test_spec *const tspec = &ts_tests[i];
+		struct timespec norm = tspec->invalid_ts;
+
+		overflow = !timespec_normalize(&norm);
+		zexpect_not_equal(tspec->expect_valid || tspec->correctable, overflow,
+				  "%d: timespec_normalize({%ld, %ld}) %s, unexpectedly", i,
+				  (long)tspec->invalid_ts.tv_sec, (long)tspec->invalid_ts.tv_nsec,
+				  tspec->correctable ? "failed" : "succeeded");
+
+		if (!tspec->expect_valid && tspec->correctable) {
+			different = !timespec_equal(&tspec->invalid_ts, &norm);
+			zexpect_true(different, "%d: {%ld, %ld} and {%ld, %ld} are unexpectedly %s",
+				     i, tspec->invalid_ts.tv_sec, tspec->invalid_ts.tv_nsec,
+				     norm.tv_sec, tspec->valid_ts.tv_sec,
+				     (tspec->expect_valid || tspec->correctable) ? "different"
+										 : "equal");
+		}
+	}
+}
+
+ZTEST(timeutil_api, test_timespec_add)
+{
+	bool overflow;
+	struct timespec actual;
+	const struct atspec {
+		struct timespec a;
+		struct timespec b;
+		struct timespec result;
+		bool expect;
+	} tspecs[] = {
+		/* non-overflow cases */
+		{.a = {0, 0}, .b = {0, 0}, .result = {0, 0}, .expect = false},
+		{.a = {1, 1}, .b = {1, 1}, .result = {2, 2}, .expect = false},
+		{.a = {-1, 1}, .b = {-1, 1}, .result = {-2, 2}, .expect = false},
+		{.a = {-1, NSEC_PER_SEC - 1}, .b = {0, 1}, .result = {0, 0}, .expect = false},
+		/* overflow cases */
+		{.a = {INT64_MAX, 0}, .b = {1, 0}, .result = {0}, .expect = true},
+		{.a = {INT64_MIN, 0}, .b = {-1, 0}, .result = {0}, .expect = true},
+		{.a = {INT64_MAX, NSEC_PER_SEC - 1}, .b = {1, 1}, .result = {0}, .expect = true},
+		{.a = {INT64_MIN, NSEC_PER_SEC - 1}, .b = {-1, 0}, .result = {0}, .expect = true},
+	};
+
+	ARRAY_FOR_EACH(tspecs, i) {
+		const struct atspec *const tspec = &tspecs[i];
+
+		actual = tspec->a;
+		overflow = !timespec_add(&actual, &tspec->b);
+
+		zexpect_equal(overflow, tspec->expect,
+			      "%d: timespec_add({%ld, %ld}, {%ld, %ld}) %s, unexpectedly", i,
+			      tspec->a.tv_sec, tspec->a.tv_nsec, tspec->b.tv_sec, tspec->b.tv_nsec,
+			      tspec->expect ? "succeeded" : "failed");
+
+		if (!tspec->expect) {
+			zexpect_equal(timespec_equal(&actual, &tspec->result), true,
+				      "%d: {%ld, %ld} and {%ld, %ld} are unexpectedly different", i,
+				      actual.tv_sec, actual.tv_nsec, tspec->result.tv_sec,
+				      tspec->result.tv_nsec);
+		}
+	}
+}
+
+ZTEST(timeutil_api, test_timespec_negate)
+{
+	struct ntspec {
+		struct timespec ts;
+		struct timespec result;
+		bool expect_failure;
+	} tspecs[] = {
+		/* non-overflow cases */
+		{.ts = {0, 0}, .result = {0, 0}, .expect_failure = false},
+		{.ts = {1, 1}, .result = {-2, NSEC_PER_SEC - 1}, .expect_failure = false},
+		{.ts = {-1, 1}, .result = {0, NSEC_PER_SEC - 1}, .expect_failure = false},
+		{.ts = {INT64_MAX, 0}, .result = {INT64_MIN + 1, 0}, .expect_failure = false},
+		/* overflow cases */
+		{.ts = {INT64_MIN, 0}, .result = {0}, .expect_failure = true},
+	};
+
+	ARRAY_FOR_EACH(tspecs, i) {
+		bool overflow;
+		const struct ntspec *const tspec = &tspecs[i];
+		struct timespec actual = tspec->ts;
+
+		overflow = !timespec_negate(&actual);
+		zexpect_equal(overflow, tspec->expect_failure,
+			      "%d: timespec_negate({%ld, %ld}) %s, unexpectedly", i,
+			      tspec->ts.tv_sec, tspec->ts.tv_nsec,
+			      tspec->expect_failure ? "did not overflow" : "overflowed");
+
+		if (!tspec->expect_failure) {
+			zexpect_true(timespec_equal(&actual, &tspec->result),
+				     "%d: {%ld, %ld} and {%ld, %ld} are unexpectedly different", i,
+				     actual.tv_sec, actual.tv_nsec, tspec->result.tv_sec,
+				     tspec->result.tv_nsec);
+		}
+	}
+}
+
+ZTEST(timeutil_api, test_timespec_sub)
+{
+	struct timespec a = {0};
+	struct timespec b = {0};
+
+	zexpect_true(timespec_sub(&a, &b));
+}
+
+ZTEST(timeutil_api, test_timespec_compare)
+{
+	struct timespec a;
+	struct timespec b;
+
+	a = (struct timespec){0};
+	b = (struct timespec){0};
+	zexpect_equal(timespec_compare(&a, &b), 0);
+
+	a = (struct timespec){-1};
+	b = (struct timespec){0};
+	zexpect_equal(timespec_compare(&a, &b), -1);
+
+	a = (struct timespec){1};
+	b = (struct timespec){0};
+	zexpect_equal(timespec_compare(&a, &b), 1);
+}
+
+ZTEST(timeutil_api, test_timespec_equal)
+{
+	struct timespec a;
+	struct timespec b;
+
+	a = (struct timespec){0};
+	b = (struct timespec){0};
+	zexpect_true(timespec_equal(&a, &b));
+
+	a = (struct timespec){-1};
+	b = (struct timespec){0};
+	zexpect_false(timespec_equal(&a, &b));
+}
+
+#define K_TICK_MAX  ((uint64_t)(CONFIG_TIMEOUT_64BIT ? (INT64_MAX) : (UINT32_MAX)))
+#define NS_PER_TICK (NSEC_PER_SEC / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+
+/* 0 := lower limit, 2 := upper limit */
+static const struct timespec k_timeout_limits[] = {
+	/* K_NO_WAIT + 1 tick */
+	{
+		.tv_sec = 0,
+		.tv_nsec = NS_PER_TICK,
+	},
+	/* K_FOREVER - 1 tick */
+	{
+		.tv_sec = CLAMP((NS_PER_TICK * K_TICK_MAX) / NSEC_PER_SEC, 0, INT64_MAX),
+		.tv_nsec = CLAMP((NS_PER_TICK * K_TICK_MAX) % NSEC_PER_SEC, 0, NSEC_PER_SEC - 1),
+	},
+};
+
+static const struct tospec {
+	k_timeout_t timeout;
+	struct timespec tspec;
+	int saturation;
+} tospecs[] = {
+	{K_NO_WAIT, {INT64_MIN, 0}, -1},
+	{K_NO_WAIT, {-1, 0}, -1},
+	{K_NO_WAIT, {-1, NSEC_PER_SEC - 1}, -1},
+	{K_NO_WAIT, {0, 0}, 0},
+	{K_NSEC(0), {0, 0}, 0},
+	{K_NSEC(2000000000), {2, 0}, 0},
+	{K_USEC(0), {0, 0}, 0},
+	{K_USEC(2000000), {2, 0}, 0},
+	{K_MSEC(100), {0, 100000000}, 0},
+	{K_MSEC(2000), {2, 0}, 0},
+	{K_SECONDS(0), {0, 0}, 0},
+	{K_SECONDS(1), {1, 0}, 0},
+	{K_SECONDS(100), {100, 0}, 0},
+	{K_FOREVER, {INT64_MAX, NSEC_PER_SEC - 1}, 0},
+};
+
+ZTEST(timeutil_api, test_timespec_from_timeout)
+{
+	ARRAY_FOR_EACH(tospecs, i) {
+		const struct tospec *const tspec = &tospecs[i];
+		struct timespec actual;
+
+		if (tspec->saturation != 0) {
+			/* saturation cases are only checked in test_timespec_to_timeout */
+			continue;
+		}
+
+		timespec_from_timeout(tspec->timeout, &actual);
+		zexpect_true(timespec_equal(&actual, &tspec->tspec),
+			     "%d: {%ld, %ld} and {%ld, %ld} are unexpectedly different", i,
+			     actual.tv_sec, actual.tv_nsec, tspec->tspec.tv_sec,
+			     tspec->tspec.tv_nsec);
+	}
+}
+
+ZTEST(timeutil_api, test_timespec_to_timeout)
+{
+	ARRAY_FOR_EACH(tospecs, i) {
+		const struct tospec *const tspec = &tospecs[i];
+		k_timeout_t actual;
+
+		if (tspec->saturation == 0) {
+			/* no saturation / exact match */
+			actual = timespec_to_timeout(&tspec->tspec);
+			zexpect_equal(actual.ticks, tspec->timeout.ticks,
+				      "%d: {%" PRId64 "} and {%" PRId64
+				      "} are unexpectedly different",
+				      i, (int64_t)actual.ticks, (int64_t)tspec->timeout.ticks);
+			continue;
+		}
+
+		if ((tspec->saturation < 0) ||
+		    (timespec_compare(&tspec->tspec, &k_timeout_limits[0]) < 0)) {
+			/* K_NO_WAIT saturation */
+			actual = timespec_to_timeout(&tspec->tspec);
+			zexpect_equal(actual.ticks, K_NO_WAIT.ticks,
+				      "%d: {%" PRId64 "} and {%" PRId64
+				      "} are unexpectedly different",
+				      i, (int64_t)actual.ticks, (int64_t)K_NO_WAIT.ticks);
+			continue;
+		}
+
+		if ((tspec->saturation > 0) ||
+		    (timespec_compare(&tspec->tspec, &k_timeout_limits[1]) > 0)) {
+			/* K_FOREVER saturation */
+			actual = timespec_to_timeout(&tspec->tspec);
+			zexpect_equal(actual.ticks, K_TICKS_FOREVER,
+				      "%d: {%" PRId64 "} and {%" PRId64
+				      "} are unexpectedly different",
+				      i, (int64_t)actual.ticks, (int64_t)K_TICKS_FOREVER);
+			continue;
+		}
+	}
+}
+
+static void *setup(void)
+{
+	printk("CONFIG_TIMEOUT_64BIT=%c\n", CONFIG_TIMEOUT_64BIT ? 'y' : 'n');
+	printk("K_TICK_MAX: %lld\n", (long long)K_TICK_MAX);
+	printk("minimum timeout: {%lld, %lld}\n", (long long)k_timeout_limits[0].tv_sec,
+	       (long long)k_timeout_limits[0].tv_nsec);
+	printk("maximum timeout: {%lld, %lld}\n", (long long)k_timeout_limits[1].tv_sec,
+	       (long long)k_timeout_limits[1].tv_nsec);
+
+	return NULL;
+}
+
+ZTEST_SUITE(timeutil_api, NULL, setup, NULL, NULL, NULL);

--- a/tests/lib/timespec_util/testcase.yaml
+++ b/tests/lib/timespec_util/testcase.yaml
@@ -1,0 +1,36 @@
+# FIXME: this should be under tests/unit/timeutil but will not work due to #90029
+common:
+  filter: not CONFIG_NATIVE_LIBC
+  tags:
+    - timeutils
+  # 1 tier0 platform per supported architecture
+  platform_key:
+    - arch
+    - simulation
+  integration_platforms:
+    - native_sim/native/64
+tests:
+  libraries.timespec_utils: {}
+  libraries.timespec_utils.speed:
+    extra_configs:
+      - CONFIG_SPEED_OPTIMIZATIONS=y
+  libraries.timespec_utils.armclang_std_libc:
+    toolchain_allow: armclang
+    extra_configs:
+      - CONFIG_ARMCLANG_STD_LIBC=y
+  libraries.timespec_utils.arcmwdtlib:
+    toolchain_allow: arcmwdt
+    extra_configs:
+      - CONFIG_ARCMWDT_LIBC=y
+  libraries.timespec_utils.minimal:
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+  libraries.timespec_utils.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+  libraries.timespec_utils.picolibc:
+    tags: picolibc
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_PICOLIBC=y


### PR DESCRIPTION
Add a number of utility functions for manipulating struct timespec.

* timespec_add()
* timespec_compare()
* timespec_equal()
* timespec_is_valid()
* timespec_negate()
* timespec_normalize()
* timespec_sub()
* timespec_from_timeout()
* timespec_to_timeout()

If the `__builtin_add_overflow()` function is available, then these functions use are mostly branchless, which should provide decent performance on systems with caches and branch prediction (gated by `CONFIG_SPEED_OPTIMIZATIONS`). Otherwise, manually written alternatives exist that are also perhaps more readable.

The two functions at the end convert time durations between representation as `struct timespec` and `k_timeout_t`.

Fixes #88115

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/90060/docs/kernel/timeutil.html)

Testing Done:
```shell
twister -i -T tests/lib/timespec_util
INFO    - Total complete:   45/  45  100%  built (not run):    0, filtered:  280, failed:    0, error:    0
INFO    - 7 test scenarios (322 configurations) selected, 280 configurations filtered (277 by static filter, 3 at runtime).
INFO    - 42 of 42 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 49.20 seconds.
INFO    - 378 of 378 executed test cases passed (100.00%) on 9 out of total 1058 platforms (0.85%).
INFO    - 42 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```