### PR TITLE
arch: ffs: Fix underflow when calling find_lsb_set with 0

### DIFF
--- a/include/zephyr/arch/common/ffs.h
+++ b/include/zephyr/arch/common/ffs.h
@@ -57,6 +57,9 @@ static ALWAYS_INLINE unsigned int find_lsb_set(uint32_t op)
 	return __builtin_ffs(op);
 
 #else
+	if (op == 0U) {
+		return 0;
+	}
 	/*
 	 * Toolchain does not have __builtin_ffs(). Leverage find_lsb_set()
 	 * by first clearing all but the lowest set bit.


### PR DESCRIPTION
If `op` is 0 then the operation `op - 1` would trigger an underflow. Since the underflowed result is `&` with 0 it wouldn't cause an incorrect result, but there is not really any reason to perform these bit operations and then call find_msb_set if `op` is 0.