### PR TITLE
scripts: runners: nios2 runner has been dropped

### DIFF
--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -44,7 +44,6 @@ _names = [
     'minichlink',
     'misc',
     'native',
-    'nios2',
     'nrfjprog',
     'nrfutil',
     'nsim',


### PR DESCRIPTION
Remove `nios2` from list of available runners as it's just been dropped with commit 5fe84d5b699e6c9589b2a9bbdd19cb915b869a68