### PR TITLE
CMSIS 6 update

### DIFF
--- a/arch/arm/include/cortex_m/dwt.h
+++ b/arch/arm/include/cortex_m/dwt.h
@@ -32,12 +32,18 @@ extern "C" {
 /* Define DWT LSR masks which are currently not defined by the CMSIS V5.1.2.
  * (LSR register is defined but not its bitfields).
  * Reuse ITM LSR mask as it is the same offset than DWT LSR one.
+ * TODO: update these to use only CMSIS_6 when all of zephyr and modules have
+ * update to CMSIS_6.
  */
 #if !defined DWT_LSR_Present_Msk
-#define DWT_LSR_Present_Msk ITM_LSR_Present_Msk
+#define DWT_LSR_Present_Msk \
+	IF_ENABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_Present_Msk)) \
+	IF_DISABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_PRESENT_Msk))
 #endif
 #if !defined DWT_LSR_Access_Msk
-#define DWT_LSR_Access_Msk ITM_LSR_Access_Msk
+#define DWT_LSR_Access_Msk \
+	IF_ENABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_Access_Msk)) \
+	IF_DISABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_ACCESS_Msk))
 #endif
 
 static inline void dwt_access(bool ena)

--- a/doc/hardware/arch/arm_cortex_m.rst
+++ b/doc/hardware/arch/arm_cortex_m.rst
@@ -632,8 +632,16 @@ script as well.
 CMSIS
 *****
 
-Cortex-M CMSIS headers are hosted in a standalone module repository:
-`zephyrproject-rtos/cmsis <https://github.com/zephyrproject-rtos/cmsis>`_.
+Cortex-M CMSIS headers are provided through standalone module repositories:
+
+- **CMSIS 5**: `zephyrproject-rtos/cmsis <https://github.com/zephyrproject-rtos/cmsis>`_
+- **CMSIS 6**: `zephyrproject-rtos/CMSIS_6 <https://github.com/zephyrproject-rtos/CMSIS_6>`_
+
+Zephyr has begun transitioning to **CMSIS 6** as the default source for Cortex-M core headers.
+However, at present, Zephyr includes headers from **both** the CMSIS 6 and legacy CMSIS 5 modules.
+
+The legacy CMSIS 5 headers remain available primarily for compatibility with vendor HALs, while all
+new architecture-level development should use **CMSIS 6** headers whenever possible.
 
 :kconfig:option:`CONFIG_CPU_CORTEX_M` selects :kconfig:option:`CONFIG_HAS_CMSIS_CORE` to signify that
 CMSIS headers are available for all supported Cortex-M variants.

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -524,6 +524,20 @@ ZBus
 Modules
 *******
 
+CMSIS
+=====
+
+* Cortex-M boards/socs now require the ``CMSIS_6`` module to build properly (instead of ``cmsis``
+  which was CMSIS 5.9.0).
+  If trying to build a Cortex-M board, do a ``west update`` to make sure that ``CMSIS_6`` module is
+  available before running ``west build`` or other commands.
+
+  Boards or SOCs or modules using the older ``cmsis`` module either with a local copy or via the
+  :kconfig:option:`CONFIG_ZEPHYR_CMSIS_MODULE_DIR` are requested to move to the ``CMSIS_6`` module
+  which can be accessed via the :kconfig:option:`CONFIG_ZEPHYR_CMSIS_6_MODULE_DIR` configuration.
+
+  Note: Zephyr will continue using the older ``cmsis`` module for Cortex-A and Cortex-R targets.
+
 Architectures
 *************
 

--- a/modules/cmsis_6/CMakeLists.txt
+++ b/modules/cmsis_6/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Copyright (c) 2023 Nordic Semiconductor ASA
 # Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 

--- a/modules/cmsis_6/cmsis_core.h
+++ b/modules/cmsis_6/cmsis_core.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2023 Nordic Semiconductor ASA
  * Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Update release notes to announce the switch to CMSIS_6 for Cortex-M arch.
This also includes follow up changes discussed as part of PR #89370.
