### PR TITLE
dts: arm: xilinx: zynq7000: add i2c0 and i2c1 controller nodes

### DIFF
--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -167,6 +167,30 @@
 				status = "okay";
 			};
 		};
+
+		i2c0: i2c@e0004000 {
+			compatible = "cdns,i2c";
+			reg = <0xe0004000 0x1000>;
+			status = "disabled";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-depth = <16>;
+		};
+
+		i2c1: i2c@e0005000 {
+			compatible = "cdns,i2c-r1p10";
+			reg = <0xe0005000 0x1000>;
+			status = "disabled";
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL
+					IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-depth = <16>;
+		};
 	};
 
 	slcr: slcr@f8000000 {


### PR DESCRIPTION
Add device tree nodes for the Cadence I2C controllers present in Zynq-7000 SoCs. These I2C controllers are implemented as hard IP blocks in the Processing System (PS) portion of the chip. They are located at 0xe0004000 (i2c0) and 0xe0005000 (i2c1), respectively.

Each node includes standard properties such as compatible strings, memory-mapped address ranges, interrupt configuration, and FIFO depth. Both nodes are marked as "disabled" by default and can be enabled in board-specific overlays depending on application needs.

Reference: UG585 Zynq-7000 SoC TRM
Link: https://docs.amd.com/r/en-US/ug585-zynq-7000-SoC-TRM