### PR TITLE
Wi-Fi buffers in SPIRAM

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -24,7 +24,7 @@ if WIFI_ESP32
 config HEAP_MEM_POOL_ADD_SIZE_ESP_WIFI
 	int
 	default 40960 if ESP_WIFI_HEAP_SYSTEM
-	default 0
+	default 19456 if ESP_WIFI_HEAP_SPIRAM
 	help
 	  Make sure there is a minimal heap available for Wi-Fi driver.
 
@@ -32,8 +32,11 @@ choice ESP_WIFI_HEAP
 	prompt "Wi-Fi adapter heap memory"
 	default ESP_WIFI_HEAP_SYSTEM
 
-	config ESP_WIFI_HEAP_SYSTEM
-		bool "Wi-Fi adapter use kernel mempool heap (k_malloc)"
+config ESP_WIFI_HEAP_SYSTEM
+	bool "Wi-Fi adapter use kernel mempool heap (k_malloc)"
+
+config ESP_WIFI_HEAP_SPIRAM
+	bool "Wi-Fi adapter use spiram mempool heap (smh_malloc)"
 
 endchoice # ESP_WIFI_HEAP
 
@@ -131,11 +134,13 @@ choice ESP32_WIFI_TX_BUFFER
 	  WiFi TX buffers. If PSRAM is disabled, "Dynamic" should be selected
 	  to improve the utilization of RAM.
 
-	config ESP32_WIFI_STATIC_TX_BUFFER
-		bool "Static"
-	config ESP32_WIFI_DYNAMIC_TX_BUFFER
-		bool "Dynamic"
-endchoice
+config ESP32_WIFI_STATIC_TX_BUFFER
+	bool "Static"
+
+config ESP32_WIFI_DYNAMIC_TX_BUFFER
+	bool "Dynamic"
+
+endchoice # ESP32_WIFI_TX_BUFFER
 
 config ESP32_WIFI_TX_BUFFER_TYPE
 	int
@@ -200,11 +205,13 @@ choice ESP32_WIFI_MGMT_RX_BUFFER
 	  If "Dynamic" is selected, each WiFi RX MGMT buffer is allocated as needed when a MGMT data frame is
 	  received. The MGMT buffer is freed after the MGMT data frame has been processed by the WiFi driver.
 
-	config ESP32_WIFI_STATIC_RX_MGMT_BUFFER
-		bool "Static"
-	config ESP32_WIFI_DYNAMIC_RX_MGMT_BUFFER
-		bool "Dynamic"
-endchoice
+config ESP32_WIFI_STATIC_RX_MGMT_BUFFER
+	bool "Static"
+
+config ESP32_WIFI_DYNAMIC_RX_MGMT_BUFFER
+	bool "Dynamic"
+
+endchoice # ESP32_WIFI_MGMT_RX_BUFFER
 
 config ESP32_WIFI_DYNAMIC_RX_MGMT_BUF
 	int

--- a/west.yml
+++ b/west.yml
@@ -164,7 +164,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: fa60a7aaa1f834c66413bbaa771794cf8aa82946
+      revision: e3532f053177077647104ae2ef215f0214dc5713
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR enables the SPIRAM buffers to be partially allocated in the external memory.

Build instructions:
```
west build -b esp32s3_devkitm/esp32s3/procpu samples/net/wifi/shell/ -p -DCONFIG_BOOTLOADER_MCUBOOT=y -DCONFIG_ESP_SPIRAM=y -DCONFIG_ESP_SPIRAM_SIZE=2097152 -DCONFIG_ESP_WIFI_HEAP_SPIRAM=y -DCONFIG_ESP32_WIFI_NET_ALLOC_SPIRAM=y -DCONFIG_SPIRAM_FETCH_INSTRUCTIONS=y -DCONFIG_SPIRAM_RODATA=y -DCONFIG_SPIRAM_SPEED_80M=y
```