### PR TITLE
Two collab sdk dev fixes

### DIFF
--- a/include/zephyr/toolchain/zephyr_stdint.h
+++ b/include/zephyr/toolchain/zephyr_stdint.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_
 #define ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_
 
+#ifndef ZEPHYR_USE_TOOLCHAIN_STDINT
+
 /*
  * Some gcc versions and/or configurations as found in the Zephyr SDK
  * (questionably) define __INT32_TYPE__ and derivatives as a long int
@@ -103,4 +105,5 @@
 #define __INT64_C(c) c ## LL
 #define __UINT64_C(c) c ## ULL
 
+#endif /* ZEPHYR_USE_TOOLCHAIN_STDINT */
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_ */

--- a/modules/cmsis-dsp/CMakeLists.txt
+++ b/modules/cmsis-dsp/CMakeLists.txt
@@ -19,6 +19,8 @@ if(CONFIG_CMSIS_DSP)
     ${cmsis_glue_path}/CMSIS/Core/Include
   )
 
+  zephyr_library_compile_definitions(ZEPHYR_USE_TOOLCHAIN_STDINT)
+
   # Global Feature Definitions
   zephyr_library_compile_definitions_ifdef(CONFIG_CMSIS_DSP_NEON                  ARM_MATH_NEON)
   zephyr_library_compile_definitions_ifdef(CONFIG_CMSIS_DSP_NEON_EXPERIMENTAL     ARM_MATH_NEON_EXPERIMENTAL)


### PR DESCRIPTION
 * Align iterable objects to 8 bytes when using 64 bit timeouts
 * Increase test stack size when using c++ exceptions