### PR TITLE
drivers: i2c: Add support for clock stretching in the i2c-gpio module.

### DIFF
--- a/drivers/i2c/Kconfig.gpio
+++ b/drivers/i2c/Kconfig.gpio
@@ -8,3 +8,19 @@ config I2C_GPIO
 	select I2C_BITBANG
 	help
 	  Enable software driven (bit banging) I2C support using GPIO pins
+
+if I2C_GPIO
+
+config I2C_GPIO_CLOCK_STRETCHING
+	bool "GPIO bit banging I2C clock stretching support"
+	default y
+	help
+	  Enable Slave clock stretching support
+
+config I2C_GPIO_CLOCK_STRETCHING_TIMEOUT_US
+	int "GPIO bit banging I2C clock stretching timeout (us)"
+	default 100000
+	help
+	  Timeout for clock stretching in microseconds.
+
+endif # I2C_GPIO

--- a/drivers/i2c/i2c_bitbang.h
+++ b/drivers/i2c/i2c_bitbang.h
@@ -12,6 +12,10 @@
 struct i2c_bitbang_io {
 	/* Set the state of the SCL line (zero/non-zero value) */
 	void (*set_scl)(void *io_context, int state);
+#ifdef CONFIG_I2C_GPIO_CLOCK_STRETCHING
+	/* Return the state of the SCL line (zero/non-zero value) */
+	int (*get_scl)(void *io_context);
+#endif
 	/* Set the state of the SDA line (zero/non-zero value) */
 	void (*set_sda)(void *io_context, int state);
 	/* Return the state of the SDA line (zero/non-zero value) */


### PR DESCRIPTION
Some I2C peripherals like TI charger or gauge chips need support for I2C clock stretching. This patch includes that and makes these modules usable with I2C emulation over GPIO.