### PR TITLE
MAINTAINERS: Add video maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2176,11 +2176,12 @@ Release Notes:
     - "area: Timer"
 
 "Drivers: Video":
-  status: odd fixes
-  collaborators:
-    - loicpoulain
+  status: maintained
+  maintainers:
     - josuah
     - ngphibang
+  collaborators:
+    - loicpoulain
     - avolmat-st
   files:
     - drivers/video/


### PR DESCRIPTION
The video section has evolved but lacks maintainers, which affects the process of merging video-related PRs. As initially discussed by @josuah and @avolmat-st, add myself "ngphibang" as maintainer for video drivers.

It would be better to have more maintainers to consolidate the review process.

@loicpoulain @josuah @avolmat-st 