### PR TITLE
xtensa: gdbstub: fix backtracing and stack unwinding

### DIFF
--- a/arch/xtensa/core/gdbstub.c
+++ b/arch/xtensa/core/gdbstub.c
@@ -178,11 +178,20 @@ static void read_sreg(struct gdb_ctx *ctx, struct xtensa_register *reg)
 		break;
 #endif
 #if XCHAL_HAVE_WINDOWED
+	/*
+	 * Returning 0 for WINDOWBASE and 1 for WINDOWSTART. This is
+	 * effectively telling GDB that only A0-A3 and AR0-AR3 contain
+	 * active data and other physical registers do not. GDB then
+	 * must rely on spilled values on stack. Otherwise, GDB will try
+	 * to look at all AR* registers for previous frame(s). Since we
+	 * do not save all AR* register values, there is nothing for
+	 * GDB to look at, and thus failing to unwind stack.
+	 */
 	case WINDOWBASE:
-		val = get_one_sreg(WINDOWBASE);
+		val = 0;
 		break;
 	case WINDOWSTART:
-		val = get_one_sreg(WINDOWSTART);
+		val = 1;
 		break;
 #endif
 #if XCHAL_NUM_INTLEVELS > 0
@@ -426,6 +435,16 @@ static void copy_to_ctx(struct gdb_ctx *ctx, const struct arch_esf *stack)
 {
 	struct xtensa_register *reg;
 	int idx, num_laddr_regs;
+	int32_t a0save;
+
+	/* Need to spill all registers so their values are on the stack instead of
+	 * the physical register file. This is required for GDB backtracing to
+	 * walk through stack.
+	 */
+	__asm__ volatile("mov %0, a0;"
+			 "call0 xtensa_spill_reg_windows;"
+			 "mov a0, %0"
+			 : "=r"(a0save));
 
 	const uint32_t *bsa = *(const int **)stack;
 
@@ -470,26 +489,13 @@ static void copy_to_ctx(struct gdb_ctx *ctx, const struct arch_esf *stack)
 	}
 
 #if XCHAL_HAVE_WINDOWED
-	uint8_t a0_idx, ar_idx, wb_start;
+	uint8_t a0_idx, ar_idx;
 
-	wb_start = (uint8_t)xtensa_gdb_ctx.regs[xtensa_gdb_ctx.wb_idx].val;
-
-	/*
-	 * Copied the logical registers A0-A15 to physical registers (AR*)
-	 * according to WINDOWBASE.
-	 */
+	/* Copied the logical registers A0-A15 to physical registers AR0-AR15. */
 	for (idx = 0; idx < num_laddr_regs; idx++) {
-		/* Index to register description array for A */
+		/* Index to register description array for A and AR */
 		a0_idx = xtensa_gdb_ctx.a0_idx + idx;
-
-		/* Find the start of window (== WINDOWBASE * 4) */
-		ar_idx = wb_start * 4;
-		/* Which logical register we are working on... */
-		ar_idx += idx;
-		/* Wrap around A64 (or A32) -> A0 */
-		ar_idx %= XCHAL_NUM_AREGS;
-		/* Index to register description array for AR */
-		ar_idx += xtensa_gdb_ctx.ar_idx;
+		ar_idx = xtensa_gdb_ctx.ar_idx + idx;
 
 		xtensa_gdb_ctx.regs[ar_idx].val = xtensa_gdb_ctx.regs[a0_idx].val;
 		xtensa_gdb_ctx.regs[ar_idx].seqno = xtensa_gdb_ctx.regs[a0_idx].seqno;
@@ -954,10 +960,6 @@ void arch_gdb_init(void)
 		case XTREG_GRP_ADDR:
 			/* AR0: 0x0100 */
 			xtensa_gdb_ctx.ar_idx = idx;
-			break;
-		case (XTREG_GRP_SPECIAL + WINDOWBASE):
-			/* WINDOWBASE (Special Register) */
-			xtensa_gdb_ctx.wb_idx = idx;
 			break;
 		default:
 			break;

--- a/arch/xtensa/core/gdbstub.c
+++ b/arch/xtensa/core/gdbstub.c
@@ -427,7 +427,7 @@ static void copy_to_ctx(struct gdb_ctx *ctx, const struct arch_esf *stack)
 	struct xtensa_register *reg;
 	int idx, num_laddr_regs;
 
-	uint32_t *bsa = *(const int **)stack;
+	const uint32_t *bsa = *(const int **)stack;
 
 	if (bsa - (const uint32_t *)stack > 12) {
 		num_laddr_regs = 16;

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -153,7 +153,7 @@ void xtensa_dump_stack(const void *stack)
 	bsa = frame->ptr_to_bsa;
 
 	/* Calculate number of high registers. */
-	num_high_regs = (uint8_t *)bsa - (uint8_t *)frame + sizeof(void *);
+	num_high_regs = (uint8_t *)bsa - ((uint8_t *)frame + sizeof(void *));
 	num_high_regs /= sizeof(uintptr_t);
 
 	/* And high registers are always comes in 4 in a block. */

--- a/include/zephyr/arch/arch_interface.h
+++ b/include/zephyr/arch/arch_interface.h
@@ -1069,6 +1069,15 @@ int arch_gdb_add_breakpoint(struct gdb_ctx *ctx, uint8_t type,
 int arch_gdb_remove_breakpoint(struct gdb_ctx *ctx, uint8_t type,
 			       uintptr_t addr, uint32_t kind);
 
+/**
+ * @brief Post processing after memory write.
+ *
+ * @param[in] addr  Starting address of the memory region
+ * @param[in] len   Size of the memory region
+ * @param[in] align Write alignment of memory region
+ */
+void arch_gdb_post_memory_write(uintptr_t addr, size_t len, uint8_t align);
+
 #endif
 /** @} */
 

--- a/include/zephyr/arch/xtensa/gdbstub.h
+++ b/include/zephyr/arch/xtensa/gdbstub.h
@@ -102,9 +102,6 @@ struct gdb_ctx {
 
 	/** Index in register descriptions of AR0 register */
 	uint8_t			ar_idx;
-
-	/** Index in register descriptions of WINDOWBASE register */
-	uint8_t			wb_idx;
 };
 
 /**

--- a/subsys/debug/gdbstub/gdbstub.c
+++ b/subsys/debug/gdbstub/gdbstub.c
@@ -171,6 +171,13 @@ int arch_gdb_remove_breakpoint(struct gdb_ctx *ctx, uint8_t type,
 	return -2;
 }
 
+__weak
+void arch_gdb_post_memory_write(uintptr_t addr, size_t len, uint8_t align)
+{
+	ARG_UNUSED(addr);
+	ARG_UNUSED(len);
+	ARG_UNUSED(align);
+}
 
 /**
  * Add preamble and termination to the given data.
@@ -547,6 +554,9 @@ static int gdb_mem_write(const uint8_t *buf, uintptr_t addr,
 	} else {
 		ret = gdb_mem_write_unaligned(buf, addr, len);
 	}
+
+
+	arch_gdb_post_memory_write(addr, len, align);
 
 out:
 	return ret;

--- a/tests/subsys/debug/gdbstub/boards/esp_wrover_kit_esp32_procpu.overlay
+++ b/tests/subsys/debug/gdbstub/boards/esp_wrover_kit_esp32_procpu.overlay
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+	chosen {
+		zephyr,gdbstub-uart = &uart0;
+	};
+};


### PR DESCRIPTION
This fixes GDB backtracing by forcibly spilling all registers, and returning 0s for WINDOWSTART and WINDOWBASE. This is effectively telling GDB that none of physical registers contains active data, and must rely on spilled values on stack. Otherwise, GDB will try to look at AR* registers for previous frame(s). Since we don't save all AR* register values, there is nothing for GDB to look at, and thus failing to unwind stack.

With this change, there is no need to populate a portion of the AR* registers, and no need for keep tracking where those registers related to windowed are.
