### PR TITLE
net: tcp: Fix TCP reset issue

### DIFF
--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -2202,7 +2202,7 @@ static void handle_server_rst_on_closed_port(sa_family_t af, struct tcphdr *th)
 		/* Port was closed so expect RST instead of SYN */
 		test_verify_flags(th, RST | ACK);
 		zassert_equal(ntohl(th->th_seq), 0, "Invalid SEQ value");
-		zassert_equal(ntohl(th->th_ack), seq, "Invalid ACK value");
+		zassert_equal(ntohl(th->th_ack), seq + 1, "Invalid ACK value");
 		t_state = T_CLOSING;
 		test_sem_give();
 		break;


### PR DESCRIPTION
According to RFC793 chapter3.5 with the 'Reset Processing' part, "In the SYN-SENT state (a RST received in response to an initial SYN), the RST is acceptable if the ACK field acknowledges the SYN." So, in the net_tcp_reply_rst() we should use 'ack++' if no ACK flag but have SYN flag.
And, all the RST packet should use net_tcp_reply_rst() instead of tcp_out().

Fixes #90086
