### PR TITLE
bt uart fixes

### DIFF
--- a/drivers/serial/Kconfig.bt
+++ b/drivers/serial/Kconfig.bt
@@ -8,6 +8,7 @@ config UART_BT
 	select UART_INTERRUPT_DRIVEN
 	select RING_BUFFER
 	select EXPERIMENTAL
+	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  Enable the UART over NUS Bluetooth driver, which can be used to pipe
 	  serial data over Bluetooth LE GATT using NUS (Nordic UART Service).

--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -311,6 +311,7 @@ static int uart_bt_workqueue_init(void)
 	k_work_queue_start(&nus_work_queue, nus_work_queue_stack,
 			   K_THREAD_STACK_SIZEOF(nus_work_queue_stack),
 			   CONFIG_UART_BT_WORKQUEUE_PRIORITY, NULL);
+	k_thread_name_set(&nus_work_queue.thread, "uart_bt");
 
 	return 0;
 }


### PR DESCRIPTION
Select SERIAL_SUPPORT_INTERRUPT for uart_bt, this is required to have the interrupt API available.

---

Set the bt_uart workqueue name so it does not show up as a mystery thread on the thread list.