### PR TITLE
driver: video: remove endpoint id in esp32 driver

### DIFF
--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -249,7 +249,7 @@ static int video_esp32_get_caps(const struct device *dev, struct video_caps *cap
 	caps->min_line_count = caps->max_line_count = LINE_COUNT_HEIGHT;
 
 	/* Forward the message to the source device */
-	return video_get_caps(config->source_dev, ep, caps);
+	return video_get_caps(config->source_dev, caps);
 }
 
 static int video_esp32_get_fmt(const struct device *dev, struct video_format *fmt)

--- a/tests/drivers/build_all/video/testcase.yaml
+++ b/tests/drivers/build_all/video/testcase.yaml
@@ -28,3 +28,6 @@ tests:
       - arduino_nicla_vision/stm32h747xx/m7
     extra_args:
       - platform:stm32h7b3i_dk/stm32h7b3xx:SHIELD=st_b_cams_omv_mb1683
+  drivers.video.esp32_dvp.build:
+    platform_allow:
+      - esp32s3_eye/esp32s3/procpu


### PR DESCRIPTION
1) Remove endpoint ID entry in esp32 video driver needed after API changes.
2) Add build_all/video tests for ESP32-S3 video driver.