### PR TITLE
MAINTAINERS: Add avolmat-st as maintainer in Drivers: Video

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2176,12 +2176,13 @@ Release Notes:
     - "area: Timer"
 
 "Drivers: Video":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - avolmat-st
   collaborators:
     - loicpoulain
     - josuah
     - ngphibang
-    - avolmat-st
   files:
     - drivers/video/
     - include/zephyr/drivers/video.h


### PR DESCRIPTION
Related:

- https://github.com/zephyrproject-rtos/zephyr/pull/90083 (@ngphibang)
- https://github.com/zephyrproject-rtos/zephyr/pull/90100
- https://github.com/zephyrproject-rtos/zephyr/pull/90102

Move @avolmat-st from collaborators to maintainers section in Drivers: Video. Mark video area as "maintained".