### PR TITLE
doc: migration-guide-4.2: video: add note on pitch

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -608,6 +608,11 @@ Video
   ``video_stream_start``
   ``video_stream_stop``
 
+* ``video_format.pitch`` has been updated to be set explicitly by the driver, a task formerly
+  required by the application. This update enables the application to correctly allocate a buffer
+  size on a per driver basis. Existing applications will not be broken by this change but can be
+  simplified as performed in the sample in the commit ``33dcbe37cfd3593e8c6e9cfd218dd31fdd533598``.
+
 Audio
 =====
 


### PR DESCRIPTION
Dependencies:

- https://github.com/zephyrproject-rtos/zephyr/pull/87366

Document the change of semantics of video_format.pitch field, modified in 33dcbe37cfd3593e8c6e9cfd218dd31fdd533598

A separate patch to allow it to be discussed separately and speed-up #87366 review.