### PR TITLE
usb: Add USB OTG HS support for STM32H7S3 (NUCLEO-H7S3L8)

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -136,6 +136,12 @@
 	status = "okay";
 };
 
+zephyr_udc0: &usbotg_hs {
+	status = "okay";
+	pinctrl-0 = <&usb_otg_hs_dm_pm5 &usb_otg_hs_dp_pm6>;
+	pinctrl-names = "default";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -37,7 +37,7 @@ config UDC_STM32_MAX_QMESSAGES
 
 config UDC_STM32_CLOCK_CHECK
 	bool "Runtime USB 48MHz clock check"
-	default y if !(SOC_SERIES_STM32F1X || SOC_SERIES_STM32F3X || SOC_SERIES_STM32U5X)
+	default y if !(SOC_SERIES_STM32F1X || SOC_SERIES_STM32F3X || SOC_SERIES_STM32U5X || SOC_SERIES_STM32H7RSX)
 	help
 	  Enable USB clock 48MHz configuration runtime check.
 	  In specific cases, this check might provide wrong verdict and should

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1088,6 +1088,13 @@ static int priv_clock_enable(void)
 
 	/* Enable VDDUSB */
 	LL_PWR_EnableVddUSB();
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) && defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	LL_PWR_EnableUSBReg();
+	LL_PWR_EnableUSBHSPHYReg();
+	LL_PWR_EnableUSBVoltageDetector();
+	__HAL_RCC_USB_OTG_HS_CLK_ENABLE();
+	/* Configuring the SYSCFG registers OTG_HS PHY : OTG_HS PHY enable*/
+	__HAL_RCC_USBPHYC_CLK_ENABLE();
 #elif defined(PWR_USBSCR_USB33SV) || defined(PWR_SVMCR_USV)
 	/*
 	 * VDDUSB independent USB supply (PWR clock is on)
@@ -1158,6 +1165,8 @@ static int priv_clock_enable(void)
 	 */
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB1OTGHSULPI);
+#elif defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USBOTGHS);
 #elif defined(CONFIG_SOC_SERIES_STM32U5X)
 	LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_USBPHY);
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -874,6 +874,19 @@
 			pinctrl-0 = <&pinctrl_dummy>;
 			pinctrl-names = "default";
 		};
+
+		usbotg_hs: usb@40040000 {
+			compatible = "st,stm32-otghs";
+			reg = <0x40040000 0x40000>;
+			interrupts = <91 0>;
+			interrupt-names = "otghs";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			maximum-speed = "high-speed";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x06000000>;
+			phys = <&otgfs_phy>;
+			status = "disabled";
+		};
 	};
 
 	otgfs_phy: otgfs_phy {

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -329,6 +329,10 @@
 				reg = <0x58023c00 0x400>;
 				clocks = <&rcc STM32_CLOCK(AHB4, 15U)>;
 			};
+
+			pinctrl_dummy: dummy_pins {
+				pinmux = <0>;
+			};
 		};
 
 		usart1: serial@42001000 {
@@ -851,6 +855,9 @@
 				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(2)>;
 			dmas = <&gpdma1 1 63 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;
+			dma-names = "tx";
+			pinctrl-0 = <&pinctrl_dummy>;
+			pinctrl-names = "default";
 			status = "disabled";
 		};
 
@@ -863,7 +870,9 @@
 				 <&rcc STM32_SRC_PLL3_P SAI1_SEL(2)>;
 			dmas = <&gpdma1 0 64 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;
-			status = "disabled";
+			dma-names = "rx";
+			pinctrl-0 = <&pinctrl_dummy>;
+			pinctrl-names = "default";
 		};
 	};
 


### PR DESCRIPTION
Fixed:
- [x] match methods to the latest commit in upstream
- [x] add node zephyr_udc0: &usbotg_hs in board dts

Reference: 
- https://github.com/zephyrproject-rtos/zephyr/compare/main...FRASTM:zephyr:stm32h7rs_otg_hs

Test:
- [x] test passed
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/cdc_acm/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/cdc_acm_bridge/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/hid-keyboard/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/hid-mouse/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/midi/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/testusb/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/webusb
- [x] test failed
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/dfu*/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/uac2_explicit_feedback/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/uac2_implicit_feedback/
  - [x] west build -p always -b nucleo_h7s3l8 samples/subsys/usb/mass/

TODO:
- [ ] integrate [mcuboot](https://github.com/zephyrproject-rtos/mcuboot/compare/main...FRASTM:mcuboot:xip_h7s3)