### PR TITLE
dts: nxp: imx95_a55: add GPIO device nodes

### DIFF
--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -266,6 +266,58 @@
 		status = "disabled";
 	};
 
+	gpio2: gpio@43810000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43810000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 50 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	gpio3: gpio@43820000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43820000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 51 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 52 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	gpio4: gpio@43840000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43840000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 53 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 54 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <30>;
+		status = "disabled";
+	};
+
+	gpio5: gpio@43850000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43850000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 56 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <18>;
+		status = "disabled";
+	};
+
 	mu1: mbox@44220000 {
 		compatible = "nxp,mbox-imx-mu";
 		reg = <0x44220000 DT_SIZE_K(64)>;
@@ -283,6 +335,7 @@
 		clocks = <&scmi_clk IMX95_CLK_LPUART1>;
 		status = "disabled";
 	};
+
 
 	lpuart2: serial@44390000 {
 		compatible = "nxp,imx-lpuart", "nxp,lpuart";
@@ -402,4 +455,166 @@
 		prescaler = <1>;
 		status = "disabled";
 	};
+
+	gpio1: gpio@47400000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x47400000 DT_SIZE_K(64)>;
+		interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+				<GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-names = "irq_0", "irq_1";
+		interrupt-parent = <&gic>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <16>;
+		status = "disabled";
+	};
+};
+
+/*
+ * GPIO pinmux options. These options define the pinmux settings
+ * for GPIO ports on the package, so that the GPIO driver can
+ * select GPIO mux options during GPIO configuration.
+ */
+
+&gpio1{
+	pinmux = <&iomuxc_i2c1_scl_gpio_io_bit_gpio1_io_bit0>,
+		<&iomuxc_i2c1_sda_gpio_io_bit_gpio1_io_bit1>,
+		<&iomuxc_i2c2_scl_gpio_io_bit_gpio1_io_bit2>,
+		<&iomuxc_i2c2_sda_gpio_io_bit_gpio1_io_bit3>,
+		<&iomuxc_uart1_rxd_gpio_io_bit_gpio1_io_bit4>,
+		<&iomuxc_uart1_txd_gpio_io_bit_gpio1_io_bit5>,
+		<&iomuxc_uart2_rxd_gpio_io_bit_gpio1_io_bit6>,
+		<&iomuxc_uart2_txd_gpio_io_bit_gpio1_io_bit7>,
+		<&iomuxc_pdm_clk_gpio_io_bit_gpio1_io_bit8>,
+		<&iomuxc_pdm_bit_stream0_gpio_io_bit_gpio1_io_bit9>,
+		<&iomuxc_pdm_bit_stream1_gpio_io_bit_gpio1_io_bit10>,
+		<&iomuxc_sai1_txfs_gpio_io_bit_gpio1_io_bit11>,
+		<&iomuxc_sai1_txc_gpio_io_bit_gpio1_io_bit12>,
+		<&iomuxc_sai1_txd0_gpio_io_bit_gpio1_io_bit13>,
+		<&iomuxc_sai1_rxd0_gpio_io_bit_gpio1_io_bit14>,
+		<&iomuxc_wdog_any_gpio_io_bit_gpio1_io_bit15>;
+};
+
+&gpio2{
+	pinmux = <&iomuxc_gpio_io00_gpio_io_bit_gpio2_io_bit0>,
+		<&iomuxc_gpio_io01_gpio_io_bit_gpio2_io_bit1>,
+		<&iomuxc_gpio_io02_gpio_io_bit_gpio2_io_bit2>,
+		<&iomuxc_gpio_io03_gpio_io_bit_gpio2_io_bit3>,
+		<&iomuxc_gpio_io04_gpio_io_bit_gpio2_io_bit4>,
+		<&iomuxc_gpio_io05_gpio_io_bit_gpio2_io_bit5>,
+		<&iomuxc_gpio_io06_gpio_io_bit_gpio2_io_bit6>,
+		<&iomuxc_gpio_io07_gpio_io_bit_gpio2_io_bit7>,
+		<&iomuxc_gpio_io08_gpio_io_bit_gpio2_io_bit8>,
+		<&iomuxc_gpio_io09_gpio_io_bit_gpio2_io_bit9>,
+		<&iomuxc_gpio_io10_gpio_io_bit_gpio2_io_bit10>,
+		<&iomuxc_gpio_io11_gpio_io_bit_gpio2_io_bit11>,
+		<&iomuxc_gpio_io12_gpio_io_bit_gpio2_io_bit12>,
+		<&iomuxc_gpio_io13_gpio_io_bit_gpio2_io_bit13>,
+		<&iomuxc_gpio_io14_gpio_io_bit_gpio2_io_bit14>,
+		<&iomuxc_gpio_io15_gpio_io_bit_gpio2_io_bit15>,
+		<&iomuxc_gpio_io16_gpio_io_bit_gpio2_io_bit16>,
+		<&iomuxc_gpio_io17_gpio_io_bit_gpio2_io_bit17>,
+		<&iomuxc_gpio_io18_gpio_io_bit_gpio2_io_bit18>,
+		<&iomuxc_gpio_io19_gpio_io_bit_gpio2_io_bit19>,
+		<&iomuxc_gpio_io20_gpio_io_bit_gpio2_io_bit20>,
+		<&iomuxc_gpio_io21_gpio_io_bit_gpio2_io_bit21>,
+		<&iomuxc_gpio_io22_gpio_io_bit_gpio2_io_bit22>,
+		<&iomuxc_gpio_io23_gpio_io_bit_gpio2_io_bit23>,
+		<&iomuxc_gpio_io24_gpio_io_bit_gpio2_io_bit24>,
+		<&iomuxc_gpio_io25_gpio_io_bit_gpio2_io_bit25>,
+		<&iomuxc_gpio_io26_gpio_io_bit_gpio2_io_bit26>,
+		<&iomuxc_gpio_io27_gpio_io_bit_gpio2_io_bit27>,
+		<&iomuxc_gpio_io28_gpio_io_bit_gpio2_io_bit28>,
+		<&iomuxc_gpio_io29_gpio_io_bit_gpio2_io_bit29>,
+		<&iomuxc_gpio_io30_gpio_io_bit_gpio2_io_bit30>,
+		<&iomuxc_gpio_io31_gpio_io_bit_gpio2_io_bit31>;
+};
+
+&gpio3{
+	pinmux = <&iomuxc_sd2_cd_b_gpio_io_bit_gpio3_io_bit0>,
+		<&iomuxc_sd2_clk_gpio_io_bit_gpio3_io_bit1>,
+		<&iomuxc_sd2_cmd_gpio_io_bit_gpio3_io_bit2>,
+		<&iomuxc_sd2_data0_gpio_io_bit_gpio3_io_bit3>,
+		<&iomuxc_sd2_data1_gpio_io_bit_gpio3_io_bit4>,
+		<&iomuxc_sd2_data2_gpio_io_bit_gpio3_io_bit5>,
+		<&iomuxc_sd2_data3_gpio_io_bit_gpio3_io_bit6>,
+		<&iomuxc_sd2_reset_b_gpio_io_bit_gpio3_io_bit7>,
+		<&iomuxc_sd1_clk_gpio_io_bit_gpio3_io_bit8>,
+		<&iomuxc_sd1_cmd_gpio_io_bit_gpio3_io_bit9>,
+		<&iomuxc_sd1_data0_gpio_io_bit_gpio3_io_bit10>,
+		<&iomuxc_sd1_data1_gpio_io_bit_gpio3_io_bit11>,
+		<&iomuxc_sd1_data2_gpio_io_bit_gpio3_io_bit12>,
+		<&iomuxc_sd1_data3_gpio_io_bit_gpio3_io_bit13>,
+		<&iomuxc_sd1_data4_gpio_io_bit_gpio3_io_bit14>,
+		<&iomuxc_sd1_data5_gpio_io_bit_gpio3_io_bit15>,
+		<&iomuxc_sd1_data6_gpio_io_bit_gpio3_io_bit16>,
+		<&iomuxc_sd1_data7_gpio_io_bit_gpio3_io_bit17>,
+		<&iomuxc_sd1_strobe_gpio_io_bit_gpio3_io_bit18>,
+		<&iomuxc_sd2_vselect_gpio_io_bit_gpio3_io_bit19>,
+		<&iomuxc_sd3_clk_gpio_io_bit_gpio3_io_bit20>,
+		<&iomuxc_sd3_cmd_gpio_io_bit_gpio3_io_bit21>,
+		<&iomuxc_sd3_data0_gpio_io_bit_gpio3_io_bit22>,
+		<&iomuxc_sd3_data1_gpio_io_bit_gpio3_io_bit23>,
+		<&iomuxc_sd3_data2_gpio_io_bit_gpio3_io_bit24>,
+		<&iomuxc_sd3_data3_gpio_io_bit_gpio3_io_bit25>,
+		<&iomuxc_ccm_clko1_gpio_io_bit_gpio3_io_bit26>,
+		<&iomuxc_ccm_clko2_gpio_io_bit_gpio3_io_bit27>,
+		<&iomuxc_dap_tdi_gpio_io_bit_gpio3_io_bit28>,
+		<&iomuxc_dap_tms_swdio_gpio_io_bit_gpio3_io_bit29>,
+		<&iomuxc_dap_tclk_swclk_gpio_io_bit_gpio3_io_bit30>,
+		<&iomuxc_dap_tdo_traceswo_gpio_io_bit_gpio3_io_bit31>;
+};
+
+&gpio4{
+	pinmux = <&iomuxc_enet1_mdc_gpio_io_bit_gpio4_io_bit0>,
+		<&iomuxc_enet1_mdio_gpio_io_bit_gpio4_io_bit1>,
+		<&iomuxc_enet1_td3_gpio_io_bit_gpio4_io_bit2>,
+		<&iomuxc_enet1_td2_gpio_io_bit_gpio4_io_bit3>,
+		<&iomuxc_enet1_td1_gpio_io_bit_gpio4_io_bit4>,
+		<&iomuxc_enet1_td0_gpio_io_bit_gpio4_io_bit5>,
+		<&iomuxc_enet1_tx_ctl_gpio_io_bit_gpio4_io_bit6>,
+		<&iomuxc_enet1_txc_gpio_io_bit_gpio4_io_bit7>,
+		<&iomuxc_enet1_rx_ctl_gpio_io_bit_gpio4_io_bit8>,
+		<&iomuxc_enet1_rxc_gpio_io_bit_gpio4_io_bit9>,
+		<&iomuxc_enet1_rd0_gpio_io_bit_gpio4_io_bit10>,
+		<&iomuxc_enet1_rd1_gpio_io_bit_gpio4_io_bit11>,
+		<&iomuxc_enet1_rd2_gpio_io_bit_gpio4_io_bit12>,
+		<&iomuxc_enet1_rd3_gpio_io_bit_gpio4_io_bit13>,
+		<&iomuxc_enet2_mdc_gpio_io_bit_gpio4_io_bit14>,
+		<&iomuxc_enet2_mdio_gpio_io_bit_gpio4_io_bit15>,
+		<&iomuxc_enet2_td3_gpio_io_bit_gpio4_io_bit16>,
+		<&iomuxc_enet2_td2_gpio_io_bit_gpio4_io_bit17>,
+		<&iomuxc_enet2_td1_gpio_io_bit_gpio4_io_bit18>,
+		<&iomuxc_enet2_td0_gpio_io_bit_gpio4_io_bit19>,
+		<&iomuxc_enet2_tx_ctl_gpio_io_bit_gpio4_io_bit20>,
+		<&iomuxc_enet2_txc_gpio_io_bit_gpio4_io_bit21>,
+		<&iomuxc_enet2_rx_ctl_gpio_io_bit_gpio4_io_bit22>,
+		<&iomuxc_enet2_rxc_gpio_io_bit_gpio4_io_bit23>,
+		<&iomuxc_enet2_rd0_gpio_io_bit_gpio4_io_bit24>,
+		<&iomuxc_enet2_rd1_gpio_io_bit_gpio4_io_bit25>,
+		<&iomuxc_enet2_rd2_gpio_io_bit_gpio4_io_bit26>,
+		<&iomuxc_enet2_rd3_gpio_io_bit_gpio4_io_bit27>,
+		<&iomuxc_ccm_clko3_gpio_io_bit_gpio4_io_bit28>,
+		<&iomuxc_ccm_clko4_gpio_io_bit_gpio4_io_bit29>;
+};
+
+&gpio5{
+	pinmux = <&iomuxc_xspi1_data0_gpio_io_bit_gpio5_io_bit0>,
+		<&iomuxc_xspi1_data1_gpio_io_bit_gpio5_io_bit1>,
+		<&iomuxc_xspi1_data2_gpio_io_bit_gpio5_io_bit2>,
+		<&iomuxc_xspi1_data3_gpio_io_bit_gpio5_io_bit3>,
+		<&iomuxc_xspi1_data4_gpio_io_bit_gpio5_io_bit4>,
+		<&iomuxc_xspi1_data5_gpio_io_bit_gpio5_io_bit5>,
+		<&iomuxc_xspi1_data6_gpio_io_bit_gpio5_io_bit6>,
+		<&iomuxc_xspi1_data7_gpio_io_bit_gpio5_io_bit7>,
+		<&iomuxc_xspi1_dqs_gpio_io_bit_gpio5_io_bit8>,
+		<&iomuxc_xspi1_sclk_gpio_io_bit_gpio5_io_bit9>,
+		<&iomuxc_xspi1_ss0_b_gpio_io_bit_gpio5_io_bit10>,
+		<&iomuxc_xspi1_ss1_b_gpio_io_bit_gpio5_io_bit11>,
+		<&iomuxc_gpio_io32_gpio_io_bit_gpio5_io_bit12>,
+		<&iomuxc_gpio_io33_gpio_io_bit_gpio5_io_bit13>,
+		<&iomuxc_gpio_io34_gpio_io_bit_gpio5_io_bit14>,
+		<&iomuxc_gpio_io35_gpio_io_bit_gpio5_io_bit15>,
+		<&iomuxc_gpio_io36_gpio_io_bit_gpio5_io_bit16>,
+		<&iomuxc_gpio_io37_gpio_io_bit_gpio5_io_bit17>;
 };


### PR DESCRIPTION
Added all GPIO device nodes in i.MX 95 Cortex-A Core SoC dts.