### PR TITLE
boards: nucleo_h753zi: add pyOCD support

### DIFF
--- a/boards/st/nucleo_h753zi/board.cmake
+++ b/boards/st/nucleo_h753zi/board.cmake
@@ -4,8 +4,10 @@
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32H753ZI" "--speed=4000")
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
+board_runner_args(pyocd "--target=stm32h753zitx")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
This patch adds pyOCD runner configuration for
the nucleo_h753zi board.