### PR TITLE
Fix NXP ENET timestamp interrupt

### DIFF
--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -627,6 +627,9 @@ static void eth_nxp_enet_isr(const struct device *dev)
 		nxp_enet_driver_cb(config->mdio, NXP_ENET_MDIO, NXP_ENET_INTERRUPT, NULL);
 	}
 
+#ifdef CONFIG_PTP_CLOCK_NXP_ENET
+	ENET_TimeStampIRQHandler(data->base, &data->enet_handle);
+#endif
 	irq_unlock(irq_lock_key);
 }
 

--- a/drivers/ptp_clock/ptp_clock_nxp_enet.c
+++ b/drivers/ptp_clock/ptp_clock_nxp_enet.c
@@ -180,6 +180,7 @@ void nxp_enet_ptp_clock_callback(const struct device *dev,
 		ENET_Ptp1588SetChannelMode(data->base, kENET_PtpTimerChannel3,
 				kENET_PtpChannelPulseHighonCompare, true);
 		ENET_Ptp1588StartTimer(data->base, ptp_config.ptp1588ClockSrc_Hz);
+		ENET_EnableInterrupts(data->base, ENET_TS_INTERRUPT);
 	}
 }
 


### PR DESCRIPTION
This is fix-up for NXP ENET timestamp interrupt.
Thanks.