### PR TITLE
drivers: syscon: fixes for the API

### DIFF
--- a/drivers/syscon/syscon.c
+++ b/drivers/syscon/syscon.c
@@ -29,26 +29,15 @@ struct syscon_generic_data {
 
 static int syscon_generic_get_base(const struct device *dev, uintptr_t *addr)
 {
-	if (!dev) {
-		return -ENODEV;
-	}
-
 	*addr = DEVICE_MMIO_GET(dev);
 	return 0;
 }
 
 static int syscon_generic_read_reg(const struct device *dev, uint16_t reg, uint32_t *val)
 {
-	const struct syscon_generic_config *config;
-	struct syscon_generic_data *data;
+	const struct syscon_generic_config *config = dev->config;
+	struct syscon_generic_data *data = dev->data;
 	uintptr_t base_address;
-
-	if (!dev) {
-		return -ENODEV;
-	}
-
-	data = dev->data;
-	config = dev->config;
 
 	if (!val) {
 		return -EINVAL;
@@ -79,16 +68,9 @@ static int syscon_generic_read_reg(const struct device *dev, uint16_t reg, uint3
 
 static int syscon_generic_write_reg(const struct device *dev, uint16_t reg, uint32_t val)
 {
-	const struct syscon_generic_config *config;
-	struct syscon_generic_data *data;
+	const struct syscon_generic_config *config = dev->config;
+	struct syscon_generic_data *data = dev->data;
 	uintptr_t base_address;
-
-	if (!dev) {
-		return -ENODEV;
-	}
-
-	data = dev->data;
-	config = dev->config;
 
 	if (syscon_sanitize_reg(&reg, data->size, config->reg_width)) {
 		return -EINVAL;

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -71,7 +71,8 @@ __subsystem struct syscon_driver_api {
  *
  * @param dev The device to get the register size for.
  * @param addr Where to write the base address.
- * @return 0 When addr was written to.
+ * @return 0 When @a addr was written to.
+ * @return -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_get_base(const struct device *dev, uintptr_t *addr);
 
@@ -79,8 +80,8 @@ static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *ad
 {
 	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
 
-	if (api == NULL) {
-		return -ENOTSUP;
+	if ((api == NULL) || (api->get_base == NULL)) {
+		return -ENOSYS;
 	}
 
 	return api->get_base(dev, addr);
@@ -96,7 +97,8 @@ static inline int z_impl_syscon_get_base(const struct device *dev, uintptr_t *ad
  * @param reg The register offset
  * @param val The returned value read from the syscon register
  *
- * @return 0 on success, negative on error
+ * @return 0 on success.
+ * @return -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_read_reg(const struct device *dev, uint16_t reg, uint32_t *val);
 
@@ -104,8 +106,8 @@ static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg,
 {
 	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
 
-	if (api == NULL) {
-		return -ENOTSUP;
+	if ((api == NULL) || (api->read == NULL)) {
+		return -ENOSYS;
 	}
 
 	return api->read(dev, reg, val);
@@ -121,7 +123,8 @@ static inline int z_impl_syscon_read_reg(const struct device *dev, uint16_t reg,
  * @param reg The register offset
  * @param val The value to be written in the register
  *
- * @return 0 on success, negative on error
+ * @return 0 on success.
+ * @return -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_write_reg(const struct device *dev, uint16_t reg, uint32_t val);
 
@@ -129,8 +132,8 @@ static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg
 {
 	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
 
-	if (api == NULL) {
-		return -ENOTSUP;
+	if ((api == NULL) || (api->write == NULL)) {
+		return -ENOSYS;
 	}
 
 	return api->write(dev, reg, val);
@@ -142,12 +145,17 @@ static inline int z_impl_syscon_write_reg(const struct device *dev, uint16_t reg
  * @param dev The device to get the register size for.
  * @param size Pointer to write the size to.
  * @return 0 for success.
+ * @return -ENOSYS If the API or function isn't implemented.
  */
 __syscall int syscon_get_size(const struct device *dev, size_t *size);
 
 static inline int z_impl_syscon_get_size(const struct device *dev, size_t *size)
 {
 	const struct syscon_driver_api *api = (const struct syscon_driver_api *)dev->api;
+
+	if ((api == NULL) || (api->get_size == NULL)) {
+		return -ENOSYS;
+	}
 
 	return api->get_size(dev, size);
 }

--- a/tests/drivers/syscon/src/main.c
+++ b/tests/drivers/syscon/src/main.c
@@ -18,7 +18,6 @@ ZTEST(syscon, test_size)
 	const size_t expected_size = DT_REG_SIZE(DT_NODELABEL(syscon));
 	size_t size;
 
-	zassert_not_null(dev);
 	zassert_ok(syscon_get_size(dev, &size));
 	zassert_equal(size, expected_size, "size(%zu) != expected_size(%zu)", size,
 		      expected_size);


### PR DESCRIPTION
1. The `dev` pointer passed to the implementation should never be `NULL`, remove the checks
2. We should return `ENOSYS` when a function isn't implemented