### PR TITLE
soc: espressif: convert rtc peripheral to clock subsystem

### DIFF
--- a/drivers/clock_control/Kconfig.esp32
+++ b/drivers/clock_control/Kconfig.esp32
@@ -6,6 +6,6 @@
 config CLOCK_CONTROL_ESP32
 	bool "ESP32 Clock driver"
 	default y
-	depends on DT_HAS_ESPRESSIF_ESP32_RTC_ENABLED
+	depends on DT_HAS_ESPRESSIF_ESP32_CLOCK_ENABLED
 	help
 	  Enable support for ESP32 clock driver.

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT espressif_esp32_rtc
+#define DT_DRV_COMPAT espressif_esp32_clock
 
 #define CPU_RESET_REASON RTC_SW_CPU_RESET
 
@@ -812,8 +812,8 @@ static const struct esp32_cpu_clock_config esp32_cpu_clock_config0 = {
 };
 
 static const struct esp32_rtc_clock_config esp32_rtc_clock_config0 = {
-	.rtc_fast_clock_src = DT_PROP(DT_INST(0, espressif_esp32_rtc), fast_clk_src),
-	.rtc_slow_clock_src = DT_PROP(DT_INST(0, espressif_esp32_rtc), slow_clk_src),
+	.rtc_fast_clock_src = DT_PROP(DT_INST(0, espressif_esp32_clock), fast_clk_src),
+	.rtc_slow_clock_src = DT_PROP(DT_INST(0, espressif_esp32_clock), slow_clk_src),
 };
 
 static const struct esp32_clock_config esp32_clock_config0 = {
@@ -821,7 +821,7 @@ static const struct esp32_clock_config esp32_clock_config0 = {
 	.rtc = esp32_rtc_clock_config0
 };
 
-DEVICE_DT_DEFINE(DT_NODELABEL(rtc),
+DEVICE_DT_DEFINE(DT_NODELABEL(clock),
 		 clock_control_esp32_init,
 		 NULL,
 		 NULL,

--- a/drivers/watchdog/xt_wdt_esp32.c
+++ b/drivers/watchdog/xt_wdt_esp32.c
@@ -168,9 +168,9 @@ DEVICE_DT_DEFINE(DT_NODELABEL(xt_wdt),
 	defined(CONFIG_SOC_SERIES_ESP32C3))
 #error "XT WDT is not supported"
 #else
-BUILD_ASSERT((DT_PROP(DT_INST(0, espressif_esp32_rtc), slow_clk_src) ==
+BUILD_ASSERT((DT_PROP(DT_INST(0, espressif_esp32_clock), slow_clk_src) ==
 	      ESP32_RTC_SLOW_CLK_SRC_XTAL32K) ||
-		     (DT_PROP(DT_INST(0, espressif_esp32_rtc), slow_clk_src) ==
+		     (DT_PROP(DT_INST(0, espressif_esp32_clock), slow_clk_src) ==
 		      ESP32_RTC_SLOW_CLK_32K_EXT_OSC),
 	     "XT WDT is only supported with XTAL32K or 32K_EXT_OSC as slow clock source");
 #endif

--- a/dts/bindings/clock/espressif,esp32-clock.yaml
+++ b/dts/bindings/clock/espressif,esp32-clock.yaml
@@ -1,16 +1,13 @@
 # Copyright (c) 2020, Mohamed ElShahawi
 # SPDX-License-Identifier: Apache-2.0
 
-description: ESP32 RTC (Power & Clock Controller Module) Module
+description: ESP32 Clock (Power & Clock Controller Module) Module
 
-compatible: "espressif,esp32-rtc"
+compatible: "espressif,esp32-clock"
 
-include: [clock-controller.yaml, base.yaml]
+include: [clock-controller.yaml]
 
 properties:
-  reg:
-    required: true
-
   fast-clk-src:
     type: int
     required: true

--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -50,6 +50,14 @@
 		status = "disabled";
 	};
 
+	clock: clock {
+		compatible = "espressif,esp32-clock";
+		fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
+		slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
+		#clock-cells = <1>;
+		status = "okay";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -85,19 +93,10 @@
 			status = "okay";
 		};
 
-		rtc: rtc@60008000 {
-			compatible = "espressif,esp32-rtc";
-			reg = <0x60008000 0x1000>;
-			fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
-			slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
-			#clock-cells = <1>;
-			status = "okay";
-		};
-
 		rtc_timer: rtc_timer@60008004 {
 			reg = <0x60008004 0xC>;
-			compatible = "espressif,esp32-rtc-timer";
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			compatible = "espressif,esp32-rtc_timer";
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
@@ -140,7 +139,7 @@
 			reg = <0x60013000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C0_MODULE>;
+			clocks = <&clock ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
 
@@ -150,7 +149,7 @@
 			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART0_MODULE>;
+			clocks = <&clock ESP32_UART0_MODULE>;
 		};
 
 		uart1: uart@60010000 {
@@ -159,7 +158,7 @@
 			status = "disabled";
 			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART1_MODULE>;
+			clocks = <&clock ESP32_UART1_MODULE>;
 			current-speed = <115200>;
 		};
 
@@ -168,14 +167,14 @@
 			pwm-controller;
 			#pwm-cells = <3>;
 			reg = <0x60019000 0x1000>;
-			clocks = <&rtc ESP32_LEDC_MODULE>;
+			clocks = <&clock ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
 
 		timer0: counter@6001f000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x6001F000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -194,7 +193,7 @@
 			reg = <0x60024000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SPI2_MODULE>;
+			clocks = <&clock ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
 			dma-host = <0>;
 			status = "disabled";
@@ -205,7 +204,7 @@
 			reg = <0x6001f048 0x20>;
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			status = "disabled";
 		};
 
@@ -219,7 +218,7 @@
 		adc0: adc@60040000 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x60040000 4>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			unit = <1>;
 			channel-count = <5>;
 			#io-channel-cells = <1>;

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -74,6 +74,14 @@
 		status = "disabled";
 	};
 
+	clock: clock {
+		compatible = "espressif,esp32-clock";
+		fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
+		slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
+		#clock-cells = <1>;
+		status = "okay";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -109,19 +117,10 @@
 			status = "okay";
 		};
 
-		rtc: rtc@60008000 {
-			compatible = "espressif,esp32-rtc";
-			reg = <0x60008000 0x1000>;
-			fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
-			slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
-			#clock-cells = <1>;
-			status = "okay";
-		};
-
 		xt_wdt: xt_wdt@60008004 {
 			compatible = "espressif,esp32-xt-wdt";
 			reg = <0x60008004 0x4>;
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
@@ -129,8 +128,8 @@
 
 		rtc_timer: rtc_timer@60008004 {
 			reg = <0x60008004 0xC>;
-			compatible = "espressif,esp32-rtc-timer";
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			compatible = "espressif,esp32-rtc_timer";
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
@@ -173,7 +172,7 @@
 			reg = <0x60013000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C0_MODULE>;
+			clocks = <&clock ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
 
@@ -184,7 +183,7 @@
 			reg = <0x6002d000 0x1000>;
 			interrupts = <I2S1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S1_MODULE>;
+			clocks = <&clock ESP32_I2S1_MODULE>;
 			dmas = <&dma 2>, <&dma 3>;
 			dma-names = "rx", "tx";
 			unit = <0>;
@@ -197,7 +196,7 @@
 			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART0_MODULE>;
+			clocks = <&clock ESP32_UART0_MODULE>;
 		};
 
 		uart1: uart@60010000 {
@@ -206,7 +205,7 @@
 			status = "disabled";
 			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART1_MODULE>;
+			clocks = <&clock ESP32_UART1_MODULE>;
 			current-speed = <115200>;
 		};
 
@@ -215,7 +214,7 @@
 			pwm-controller;
 			#pwm-cells = <3>;
 			reg = <0x60019000 0x1000>;
-			clocks = <&rtc ESP32_LEDC_MODULE>;
+			clocks = <&clock ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
 
@@ -225,13 +224,13 @@
 			status = "disabled";
 			interrupts = <USB_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_USB_MODULE>;
+			clocks = <&clock ESP32_USB_MODULE>;
 		};
 
 		timer0: counter@6001f000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x6001F000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -242,7 +241,7 @@
 		timer1: counter@60020000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x60020000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -261,7 +260,7 @@
 			reg = <0x6002b000 DT_SIZE_K(4)>;
 			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TWAI_MODULE>;
+			clocks = <&clock ESP32_TWAI_MODULE>;
 			status = "disabled";
 		};
 
@@ -270,7 +269,7 @@
 			reg = <0x60024000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SPI2_MODULE>;
+			clocks = <&clock ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
 			dma-host = <0>;
 			status = "disabled";
@@ -281,7 +280,7 @@
 			reg = <0x6001f048 0x20>;
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			status = "disabled";
 		};
 
@@ -290,7 +289,7 @@
 			reg = <0x60020048 0x20>;
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			status = "disabled";
 		};
 
@@ -304,7 +303,7 @@
 		adc0: adc@60040000 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x60040000 4>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			unit = <1>;
 			channel-count = <5>;
 			#io-channel-cells = <1>;
@@ -320,7 +319,7 @@
 				<DMA_CH1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
 				<DMA_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_GDMA_MODULE>;
+			clocks = <&clock ESP32_GDMA_MODULE>;
 			dma-channels = <6>;
 			dma-buf-addr-alignment = <4>;
 			status = "disabled";

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -68,6 +68,14 @@
 		status = "disabled";
 	};
 
+	clock: clock {
+		compatible = "espressif,esp32-clock";
+		fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
+		slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
+		#clock-cells = <1>;
+		status = "okay";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -112,7 +120,7 @@
 		timer0: counter@60008000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x60008000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -123,7 +131,7 @@
 		timer1: counter@60009000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x60009000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -131,19 +139,10 @@
 			status = "disabled";
 		};
 
-		rtc: rtc@600b0000 {
-			compatible = "espressif,esp32-rtc";
-			reg = <0x600B0000 DT_SIZE_K(1)>;
-			fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
-			slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
-			#clock-cells = <1>;
-			status = "okay";
-		};
-
 		rtc_timer: rtc_timer@600b0c00 {
-			compatible = "espressif,esp32-rtc-timer";
+			compatible = "espressif,esp32-rtc_timer";
 			reg = <0x600B0C00 DT_SIZE_K(1)>;
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <LP_RTC_TIMER_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
@@ -152,7 +151,7 @@
 		trng0: trng@600b2808 {
 			compatible = "espressif,esp32-trng";
 			reg = <0x600B2808 0x4>;
-			clocks = <&rtc ESP32_RNG_MODULE>;
+			clocks = <&clock ESP32_RNG_MODULE>;
 			status = "disabled";
 		};
 
@@ -161,7 +160,7 @@
 			reg = <0x6000B000 DT_SIZE_K(4)>;
 			interrupts = <TWAI0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TWAI0_MODULE>;
+			clocks = <&clock ESP32_TWAI0_MODULE>;
 			status = "disabled";
 		};
 
@@ -170,7 +169,7 @@
 			reg = <0x6000D000 DT_SIZE_K(4)>;
 			interrupts = <TWAI1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TWAI1_MODULE>;
+			clocks = <&clock ESP32_TWAI1_MODULE>;
 			status = "disabled";
 		};
 
@@ -179,7 +178,7 @@
 			reg = <0x60081000 DT_SIZE_K(4)>;
 			interrupts = <GSPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SPI2_MODULE>;
+			clocks = <&clock ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
 			dma-host = <0>;
 			status = "disabled";
@@ -190,7 +189,7 @@
 			reg = <0x60008048 0x20>;
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			status = "disabled";
 		};
 
@@ -199,7 +198,7 @@
 			reg = <0x60009048 0x20>;
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			status = "disabled";
 		};
 
@@ -228,7 +227,7 @@
 		adc0: adc@6000e000 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x6000E000 4>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			unit = <1>;
 			channel-count = <7>;
 			#io-channel-cells = <1>;
@@ -247,7 +246,7 @@
 				<DMA_IN_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>,
 				<DMA_OUT_CH2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_GDMA_MODULE>;
+			clocks = <&clock ESP32_GDMA_MODULE>;
 			dma-channels = <6>;
 			dma-buf-addr-alignment = <4>;
 			status = "disabled";
@@ -270,7 +269,7 @@
 			reg = <0x60004000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C0_MODULE>;
+			clocks = <&clock ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
 
@@ -280,7 +279,7 @@
 			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART0_MODULE>;
+			clocks = <&clock ESP32_UART0_MODULE>;
 		};
 
 		uart1: uart@60001000 {
@@ -289,7 +288,7 @@
 			status = "disabled";
 			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART1_MODULE>;
+			clocks = <&clock ESP32_UART1_MODULE>;
 			current-speed = <115200>;
 		};
 
@@ -306,7 +305,7 @@
 			status = "disabled";
 			interrupts = <USB_SERIAL_JTAG_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_USB_MODULE>;
+			clocks = <&clock ESP32_USB_MODULE>;
 		};
 
 		ledc0: ledc@60007000 {
@@ -314,7 +313,7 @@
 			pwm-controller;
 			#pwm-cells = <3>;
 			reg = <0x60007000 0x1000>;
-			clocks = <&rtc ESP32_LEDC_MODULE>;
+			clocks = <&clock ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
 
@@ -323,7 +322,7 @@
 			reg = <0x60014000 DT_SIZE_K(4)>;
 			interrupts = <MCPWM0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_MCPWM0_MODULE>;
+			clocks = <&clock ESP32_MCPWM0_MODULE>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -77,13 +77,13 @@
 		compatible = "espressif,esp32-eth";
 		interrupts = <ETH_MAC_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 		interrupt-parent = <&intc>;
-		clocks = <&rtc ESP32_EMAC_MODULE>;
+		clocks = <&clock ESP32_EMAC_MODULE>;
 		status = "disabled";
 	};
 
 	mdio: mdio {
 		compatible = "espressif,esp32-mdio";
-		clocks = <&rtc ESP32_EMAC_MODULE>;
+		clocks = <&clock ESP32_EMAC_MODULE>;
 		status = "disabled";
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -91,6 +91,14 @@
 
 	pinctrl: pin-controller {
 		compatible = "espressif,esp32-pinctrl";
+		status = "okay";
+	};
+
+	clock: clock {
+		compatible = "espressif,esp32-clock";
+		fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
+		slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
+		#clock-cells = <1>;
 		status = "okay";
 	};
 
@@ -180,20 +188,10 @@
 			status = "okay";
 		};
 
-		rtc: rtc@3ff48000 {
-			compatible = "espressif,esp32-rtc";
-			reg = <0x3ff48000 0x0D8>;
-			fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
-			slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
-			#clock-cells = <1>;
-			status = "okay";
-
-		};
-
 		rtc_timer: rtc_timer@3ff48004 {
 			reg = <0x3ff48004 0xC>;
 			compatible = "espressif,esp32-rtc-timer";
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
@@ -232,7 +230,7 @@
 			reg = <0x3ff40000 0x400>;
 			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART0_MODULE>;
+			clocks = <&clock ESP32_UART0_MODULE>;
 			status = "disabled";
 		};
 
@@ -241,7 +239,7 @@
 			reg = <0x3ff50000 0x400>;
 			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART1_MODULE>;
+			clocks = <&clock ESP32_UART1_MODULE>;
 			status = "disabled";
 		};
 
@@ -250,7 +248,7 @@
 			reg = <0x3ff6E000 0x400>;
 			interrupts = <UART2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART2_MODULE>;
+			clocks = <&clock ESP32_UART2_MODULE>;
 			status = "disabled";
 		};
 
@@ -259,7 +257,7 @@
 			reg = <0x3ff57000 0x1000>;
 			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PCNT_MODULE>;
+			clocks = <&clock ESP32_PCNT_MODULE>;
 			status = "disabled";
 		};
 
@@ -267,7 +265,7 @@
 			compatible = "espressif,esp32-ledc";
 			#pwm-cells = <3>;
 			reg = <0x3ff59000 0x800>;
-			clocks = <&rtc ESP32_LEDC_MODULE>;
+			clocks = <&clock ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
 
@@ -276,7 +274,7 @@
 			reg = <0x3ff5e000 0x1000>;
 			interrupts = <PWM0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PWM0_MODULE>;
+			clocks = <&clock ESP32_PWM0_MODULE>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
@@ -286,7 +284,7 @@
 			reg = <0x3ff6c000 0x1000>;
 			interrupts = <PWM1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PWM1_MODULE>;
+			clocks = <&clock ESP32_PWM1_MODULE>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
@@ -345,7 +343,7 @@
 			reg = <0x3ff53000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C0_MODULE>;
+			clocks = <&clock ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
 
@@ -356,7 +354,7 @@
 			reg = <0x3ff67000 0x1000>;
 			interrupts = <I2C_EXT1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C1_MODULE>;
+			clocks = <&clock ESP32_I2C1_MODULE>;
 			status = "disabled";
 		};
 
@@ -369,7 +367,7 @@
 				     <I2S0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-names = "rx", "tx";
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S0_MODULE>;
+			clocks = <&clock ESP32_I2S0_MODULE>;
 			unit = <0>;
 			status = "disabled";
 		};
@@ -383,7 +381,7 @@
 				     <I2S1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-names = "rx", "tx";
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S1_MODULE>;
+			clocks = <&clock ESP32_I2S1_MODULE>;
 			unit = <1>;
 			status = "disabled";
 		};
@@ -399,7 +397,7 @@
 			reg = <0x3ff5f048 0x20>;
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			status = "okay";
 		};
 
@@ -408,7 +406,7 @@
 			reg = <0x3ff60048 0x20>;
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			status = "disabled";
 		};
 
@@ -417,7 +415,7 @@
 			reg = <0x3ff64000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_HSPI_MODULE>;
+			clocks = <&clock ESP32_HSPI_MODULE>;
 			dma-clk = <ESP32_SPI_DMA_MODULE>;
 			dma-host = <0>;
 			status = "disabled";
@@ -428,7 +426,7 @@
 			reg = <0x3ff65000 DT_SIZE_K(4)>;
 			interrupts = <SPI3_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_VSPI_MODULE>;
+			clocks = <&clock ESP32_VSPI_MODULE>;
 			dma-clk = <ESP32_SPI_DMA_MODULE>;
 			dma-host = <1>;
 			status = "disabled";
@@ -439,14 +437,14 @@
 			reg = <0x3ff6b000 DT_SIZE_K(4)>;
 			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TWAI_MODULE>;
+			clocks = <&clock ESP32_TWAI_MODULE>;
 			status = "disabled";
 		};
 
 		timer0: counter@3ff5f000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3ff5f000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -457,7 +455,7 @@
 		timer1: counter@3ff5f024 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3ff5f024 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <1>;
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -468,7 +466,7 @@
 		timer2: counter@3ff60000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3ff60000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -479,7 +477,7 @@
 		timer3: counter@3ff60024 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3ff60024 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <1>;
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -492,7 +490,7 @@
 			reg = <0x3ff48800 0x100>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};
@@ -500,7 +498,7 @@
 		adc0: adc@3ff48800 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x3ff48800 10>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			unit = <1>;
 			channel-count = <8>;
 			#io-channel-cells = <1>;
@@ -510,7 +508,7 @@
 		adc1: adc@3ff48890 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x3ff48890 10>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			unit = <2>;
 			channel-count = <10>;
 			#io-channel-cells = <1>;
@@ -522,7 +520,7 @@
 			reg = <0x3ff68000 0x1000>;
 			interrupts = <SDIO_HOST_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SDMMC_MODULE>;
+			clocks = <&clock ESP32_SDMMC_MODULE>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -73,6 +73,13 @@
 		status = "okay";
 	};
 
+	clock: clock {
+		compatible = "espressif,esp32-clock";
+		fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_XTAL_D4>;
+		slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
+		#clock-cells = <1>;
+		status = "okay";
+	};
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -123,19 +130,10 @@
 			status = "okay";
 		};
 
-		rtc: rtc@3f408000 {
-			compatible = "espressif,esp32-rtc";
-			reg = <0x3f408000 0x0D8>;
-			fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_XTAL_D4>;
-			slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
-			#clock-cells = <1>;
-			status = "okay";
-		};
-
 		xt_wdt: xt_wdt@3f408004 {
 			compatible = "espressif,esp32-xt-wdt";
 			reg = <0x3f408004 0x4>;
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
@@ -143,8 +141,8 @@
 
 		rtc_timer: rtc_timer@3f408004 {
 			reg = <0x3f408004 0xC>;
-			compatible = "espressif,esp32-rtc-timer";
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			compatible = "espressif,esp32-rtc_timer";
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "okay";
@@ -171,7 +169,7 @@
 			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART0_MODULE>;
+			clocks = <&clock ESP32_UART0_MODULE>;
 		};
 
 		uart1: uart@3f410000 {
@@ -180,7 +178,7 @@
 			status = "disabled";
 			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART1_MODULE>;
+			clocks = <&clock ESP32_UART1_MODULE>;
 			current-speed = <115200>;
 		};
 
@@ -189,7 +187,7 @@
 			reg = <0x3f417000 0x1000>;
 			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PCNT_MODULE>;
+			clocks = <&clock ESP32_PCNT_MODULE>;
 			status = "disabled";
 		};
 
@@ -198,7 +196,7 @@
 			pwm-controller;
 			#pwm-cells = <3>;
 			reg = <0x3f419000 0x1000>;
-			clocks = <&rtc ESP32_LEDC_MODULE>;
+			clocks = <&clock ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
 
@@ -242,7 +240,7 @@
 			reg = <0x3f413000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C0_MODULE>;
+			clocks = <&clock ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
 
@@ -253,7 +251,7 @@
 			reg = <0x3f427000 0x1000>;
 			interrupts = <I2C_EXT1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C1_MODULE>;
+			clocks = <&clock ESP32_I2C1_MODULE>;
 			status = "disabled";
 		};
 
@@ -266,7 +264,7 @@
 				     <I2S0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-names = "rx", "tx";
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S0_MODULE>;
+			clocks = <&clock ESP32_I2S0_MODULE>;
 			unit = <0>;
 			status = "disabled";
 		};
@@ -274,7 +272,7 @@
 		timer0: counter@3f41f000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3f41f000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -285,7 +283,7 @@
 		timer1: counter@3f41f024 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3f41f024 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <1>;
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -296,7 +294,7 @@
 		timer2: counter@3f420000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3f420000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -307,7 +305,7 @@
 		timer3: counter@3f420024 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x3f420024 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <1>;
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -325,7 +323,7 @@
 			reg = <0x3f424000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_FSPI_MODULE>;
+			clocks = <&clock ESP32_FSPI_MODULE>;
 			dma-clk = <ESP32_SPI2_DMA_MODULE>;
 			dma-host = <0>;
 			status = "disabled";
@@ -336,7 +334,7 @@
 			reg = <0x3f425000 DT_SIZE_K(4)>;
 			interrupts = <SPI3_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_HSPI_MODULE>;
+			clocks = <&clock ESP32_HSPI_MODULE>;
 			dma-clk = <ESP32_SPI3_DMA_MODULE>;
 			dma-host = <1>;
 			status = "disabled";
@@ -347,7 +345,7 @@
 			reg = <0x3f41f048 0x20>;
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			status = "disabled";
 		};
 
@@ -356,7 +354,7 @@
 			reg = <0x3f42f048 0x20>;
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			status = "disabled";
 		};
 
@@ -365,7 +363,7 @@
 			reg = <0x3f408800 0x100>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PERIPH_SARADC_MODULE>;
+			clocks = <&clock ESP32_PERIPH_SARADC_MODULE>;
 			#io-channel-cells = <1>;
 		};
 
@@ -379,7 +377,7 @@
 		adc0: adc@3f440018 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x3f440018 100>;
-			clocks = <&rtc ESP32_PERIPH_SARADC_MODULE>;
+			clocks = <&clock ESP32_PERIPH_SARADC_MODULE>;
 			unit = <1>;
 			channel-count = <10>;
 			#io-channel-cells = <1>;
@@ -389,7 +387,7 @@
 		adc1: adc@3f440028 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x3f440028 100>;
-			clocks = <&rtc ESP32_PERIPH_SARADC_MODULE>;
+			clocks = <&clock ESP32_PERIPH_SARADC_MODULE>;
 			unit = <2>;
 			channel-count = <10>;
 			#io-channel-cells = <1>;
@@ -401,7 +399,7 @@
 			reg = <0x3f42b000 DT_SIZE_K(4)>;
 			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TWAI_MODULE>;
+			clocks = <&clock ESP32_TWAI_MODULE>;
 			status = "disabled";
 		};
 	};

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -80,6 +80,14 @@
 		status = "okay";
 	};
 
+	clock: clock {
+		compatible = "espressif,esp32-clock";
+		fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
+		slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
+		#clock-cells = <1>;
+		status = "okay";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -165,19 +173,10 @@
 			status = "okay";
 		};
 
-		rtc: rtc@60021000 {
-			compatible = "espressif,esp32-rtc";
-			reg = <0x60021000 0x2000>;
-			fast-clk-src = <ESP32_RTC_FAST_CLK_SRC_RC_FAST>;
-			slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_SLOW>;
-			#clock-cells = <1>;
-			status = "okay";
-		};
-
 		xt_wdt: xt_wdt@60021004 {
 			compatible = "espressif,esp32-xt-wdt";
 			reg = <0x60021004 0x4>;
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
@@ -185,8 +184,8 @@
 
 		rtc_timer: rtc_timer@60008004 {
 			reg = <0x60008004 0xC>;
-			compatible = "espressif,esp32-rtc-timer";
-			clocks = <&rtc ESP32_MODULE_MAX>;
+			compatible = "espressif,esp32-rtc_timer";
+			clocks = <&clock ESP32_MODULE_MAX>;
 			interrupts = <RTC_CORE_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
@@ -211,7 +210,7 @@
 			reg = <0x60000000 0x1000>;
 			interrupts = <UART0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART0_MODULE>;
+			clocks = <&clock ESP32_UART0_MODULE>;
 			status = "disabled";
 		};
 
@@ -220,7 +219,7 @@
 			reg = <0x60010000 0x1000>;
 			interrupts = <UART1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART1_MODULE>;
+			clocks = <&clock ESP32_UART1_MODULE>;
 			status = "disabled";
 		};
 
@@ -229,7 +228,7 @@
 			reg = <0x6002e000 0x1000>;
 			interrupts = <UART2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_UART2_MODULE>;
+			clocks = <&clock ESP32_UART2_MODULE>;
 			status = "disabled";
 		};
 
@@ -287,7 +286,7 @@
 			reg = <0x60013000 DT_SIZE_K(4)>;
 			interrupts = <I2C_EXT0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C0_MODULE>;
+			clocks = <&clock ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
 
@@ -298,7 +297,7 @@
 			reg = <0x60027000 DT_SIZE_K(4)>;
 			interrupts = <I2C_EXT1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2C1_MODULE>;
+			clocks = <&clock ESP32_I2C1_MODULE>;
 			status = "disabled";
 		};
 
@@ -309,7 +308,7 @@
 			reg = <0x6000f000 0x1000>;
 			interrupts = <I2S0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S0_MODULE>;
+			clocks = <&clock ESP32_I2S0_MODULE>;
 			dmas = <&dma 2>, <&dma 3>;
 			dma-names = "rx", "tx";
 			unit = <0>;
@@ -323,7 +322,7 @@
 			reg = <0x6002d000 0x1000>;
 			interrupts = <I2S1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S1_MODULE>;
+			clocks = <&clock ESP32_I2S1_MODULE>;
 			dmas = <&dma 4>, <&dma 5>;
 			dma-names = "rx", "tx";
 			unit = <1>;
@@ -335,7 +334,7 @@
 			reg = <0x60024000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SPI2_MODULE>;
+			clocks = <&clock ESP32_SPI2_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
 			dma-host = <0>;
 			status = "disabled";
@@ -346,7 +345,7 @@
 			reg = <0x60025000 DT_SIZE_K(4)>;
 			interrupts = <SPI3_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SPI3_MODULE>;
+			clocks = <&clock ESP32_SPI3_MODULE>;
 			dma-clk = <ESP32_GDMA_MODULE>;
 			dma-host = <1>;
 			status = "disabled";
@@ -362,7 +361,7 @@
 		adc0: adc@60040000 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x60040000 4>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			unit = <1>;
 			channel-count = <10>;
 			#io-channel-cells = <1>;
@@ -372,7 +371,7 @@
 		adc1: adc@60040004 {
 			compatible = "espressif,esp32-adc";
 			reg = <0x60040004 4>;
-			clocks = <&rtc ESP32_SARADC_MODULE>;
+			clocks = <&clock ESP32_SARADC_MODULE>;
 			unit = <2>;
 			channel-count = <10>;
 			#io-channel-cells = <1>;
@@ -384,14 +383,14 @@
 			reg = <0x6002b000 DT_SIZE_K(4)>;
 			interrupts = <TWAI_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TWAI_MODULE>;
+			clocks = <&clock ESP32_TWAI_MODULE>;
 			status = "disabled";
 		};
 
 		lcd_cam: lcd_cam@60041000 {
 			compatible = "espressif,esp32-lcd-cam";
 			reg = <0x60041000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_LCD_CAM_MODULE>;
+			clocks = <&clock ESP32_LCD_CAM_MODULE>;
 			interrupts = <LCD_CAM_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
@@ -403,13 +402,13 @@
 			status = "disabled";
 			interrupts = <USB_SERIAL_JTAG_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_USB_MODULE>;
+			clocks = <&clock ESP32_USB_MODULE>;
 		};
 
 		timer0: counter@6001f000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x6001f000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -420,7 +419,7 @@
 		timer1: counter@6001f024 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x6001f024 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			group = <0>;
 			index = <1>;
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -431,7 +430,7 @@
 		timer2: counter@60020000 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x60020000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -442,7 +441,7 @@
 		timer3: counter@60020024 {
 			compatible = "espressif,esp32-timer";
 			reg = <0x60020024 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			group = <1>;
 			index = <1>;
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
@@ -454,7 +453,7 @@
 			reg = <0x6001f048 0x20>;
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG0_MODULE>;
+			clocks = <&clock ESP32_TIMG0_MODULE>;
 			status = "disabled";
 		};
 
@@ -463,7 +462,7 @@
 			reg = <0x60020048 0x20>;
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_TIMG1_MODULE>;
+			clocks = <&clock ESP32_TIMG1_MODULE>;
 			status = "disabled";
 		};
 
@@ -477,7 +476,7 @@
 			compatible = "espressif,esp32-ledc";
 			#pwm-cells = <3>;
 			reg = <0x60019000 DT_SIZE_K(4)>;
-			clocks = <&rtc ESP32_LEDC_MODULE>;
+			clocks = <&clock ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
 
@@ -486,7 +485,7 @@
 			reg = <0x6001e000 DT_SIZE_K(4)>;
 			interrupts = <PWM0_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PWM0_MODULE>;
+			clocks = <&clock ESP32_PWM0_MODULE>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
@@ -496,7 +495,7 @@
 			reg = <0x6002c000 DT_SIZE_K(4)>;
 			interrupts = <PWM1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PWM1_MODULE>;
+			clocks = <&clock ESP32_PWM1_MODULE>;
 			#pwm-cells = <3>;
 			status = "disabled";
 		};
@@ -506,7 +505,7 @@
 			reg = <0x60017000 DT_SIZE_K(4)>;
 			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PCNT_MODULE>;
+			clocks = <&clock ESP32_PCNT_MODULE>;
 			status = "disabled";
 		};
 
@@ -526,7 +525,7 @@
 				<DMA_IN_CH4_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>,
 				<DMA_OUT_CH4_INTR_SOURCE IRQ_DEFAULT_PRIORITY ESP_INTR_FLAG_SHARED>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_GDMA_MODULE>;
+			clocks = <&clock ESP32_GDMA_MODULE>;
 			dma-channels = <10>;
 			dma-buf-addr-alignment = <4>;
 			status = "disabled";
@@ -537,7 +536,7 @@
 			reg = <0x60028000 0x1000>;
 			interrupts = <SDIO_HOST_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_SDMMC_MODULE>;
+			clocks = <&clock ESP32_SDMMC_MODULE>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/samples/boards/espressif/xt_wdt/app.overlay
+++ b/samples/boards/espressif/xt_wdt/app.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-&rtc {
+&clock {
 	slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_XTAL32K>;
 };
 

--- a/samples/boards/espressif/xt_wdt/src/main.c
+++ b/samples/boards/espressif/xt_wdt/src/main.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(xt_wdt_sample, CONFIG_WDT_LOG_LEVEL);
 
 K_SEM_DEFINE(wdt_sem, 0, 1);
 
-static const struct device *const clk_dev = DEVICE_DT_GET_ONE(espressif_esp32_rtc);
+static const struct device *const clk_dev = DEVICE_DT_GET_ONE(espressif_esp32_clock);
 const struct device *const wdt = DEVICE_DT_GET_ONE(espressif_esp32_xt_wdt);
 
 static void wdt_callback(const struct device *wdt_dev, int channel_id)

--- a/tests/boards/espressif/rtc_clk/src/rtc_clk_test.c
+++ b/tests/boards/espressif/rtc_clk/src/rtc_clk_test.c
@@ -20,7 +20,7 @@
 #define DT_CPU_COMPAT espressif_riscv
 #endif
 
-static const struct device *const clk_dev = DEVICE_DT_GET_ONE(espressif_esp32_rtc);
+static const struct device *const clk_dev = DEVICE_DT_GET_ONE(espressif_esp32_clock);
 
 static void *rtc_clk_setup(void)
 {

--- a/tests/drivers/clock_control/clock_control_api/src/esp32_device_subsys.h
+++ b/tests/drivers/clock_control/clock_control_api/src/esp32_device_subsys.h
@@ -26,7 +26,7 @@ static const struct device_subsys_data subsys_data[] = {
 
 static const struct device_data devices[] = {
 	{
-		.dev = DEVICE_DT_GET_ONE(espressif_esp32_rtc),
+		.dev = DEVICE_DT_GET_ONE(espressif_esp32_clock),
 		.subsys_data =  subsys_data,
 		.subsys_cnt = ARRAY_SIZE(subsys_data)
 	}

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -10,7 +10,7 @@ LOG_MODULE_REGISTER(test);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_clock)
 #include "nrf_device_subsys.h"
-#elif DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_rtc)
+#elif DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_clock)
 #include "esp32_device_subsys.h"
 #elif DT_HAS_COMPAT_STATUS_OKAY(silabs_series_clock)
 #include "silabs_device_subsys.h"

--- a/tests/drivers/counter/counter_basic_api/socs/esp32_procpu.overlay
+++ b/tests/drivers/counter/counter_basic_api/socs/esp32_procpu.overlay
@@ -2,6 +2,6 @@
 	status = "okay";
 };
 
-&rtc {
+&clock {
 	slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_FAST_D256>;
 };

--- a/tests/drivers/counter/counter_basic_api/socs/esp32c2.overlay
+++ b/tests/drivers/counter/counter_basic_api/socs/esp32c2.overlay
@@ -6,6 +6,6 @@
 	status = "okay";
 };
 
-&rtc {
+&clock {
 	slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_FAST_D256>;
 };

--- a/tests/drivers/counter/counter_basic_api/socs/esp32c3.overlay
+++ b/tests/drivers/counter/counter_basic_api/socs/esp32c3.overlay
@@ -2,6 +2,6 @@
 	status = "okay";
 };
 
-&rtc {
+&clock {
 	slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_FAST_D256>;
 };

--- a/tests/drivers/counter/counter_basic_api/socs/esp32c3_usb.overlay
+++ b/tests/drivers/counter/counter_basic_api/socs/esp32c3_usb.overlay
@@ -2,6 +2,6 @@
 	status = "okay";
 };
 
-&rtc {
+&clock {
 	slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_FAST_D256>;
 };

--- a/tests/drivers/counter/counter_basic_api/socs/esp32s2.overlay
+++ b/tests/drivers/counter/counter_basic_api/socs/esp32s2.overlay
@@ -2,6 +2,6 @@
 	status = "okay";
 };
 
-&rtc {
+&clock {
 	slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_FAST_D256>;
 };

--- a/tests/drivers/counter/counter_basic_api/socs/esp32s3_procpu.overlay
+++ b/tests/drivers/counter/counter_basic_api/socs/esp32s3_procpu.overlay
@@ -6,6 +6,6 @@
 	status = "okay";
 };
 
-&rtc {
+&clock {
 	slow-clk-src = <ESP32_RTC_SLOW_CLK_SRC_RC_FAST_D256>;
 };


### PR DESCRIPTION
Current ESP32 clock system is mixed with RTC labeling/registers,
but it doesn't implement a real-time clock (RTC) driver.

To avoid confusion and allow adding a proper RTC driver later,
this commit renames the existing RTC interface to CLOCK and make
it as a subsystem without any peripheral attached to it.

This better reflects its actual purpose as a general clock controller.