### PR TITLE
Bluetooth: Classic: Add role change event cb

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1975,6 +1975,17 @@ struct bt_conn_cb {
 
 #endif
 
+#if defined(CONFIG_BT_CLASSIC)
+	/** @brief The role of the connection has changed.
+	 *
+	 *  This callback notifies the application that the role switch procedure has completed.
+	 *
+	 *  @param conn Connection object.
+	 *  @param status HCI status of role change event.
+	 */
+	void (*role_changed)(struct bt_conn *conn, uint8_t status);
+#endif
+
 	/** @internal Internally used field for list handling */
 	sys_snode_t _node;
 };

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2688,6 +2688,29 @@ struct bt_conn *bt_conn_lookup_addr_br(const bt_addr_t *peer);
  */
 const bt_addr_t *bt_conn_get_dst_br(const struct bt_conn *conn);
 
+/** @brief Change the role of the conn.
+ *
+ *  @param conn Connection object.
+ *  @param role The role that want to switch as, the value is @ref BT_HCI_ROLE_CENTRAL and
+ *              @ref BT_HCI_ROLE_PERIPHERAL from hci_types.h.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ *  @return -ENOBUFS HCI command buffer is not available.
+ *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection
+ */
+int bt_conn_br_switch_role(const struct bt_conn *conn, uint8_t role);
+
+/** @brief Enable/disable role switch of the connection by setting the connection's link policy.
+ *
+ *  @param conn Connection object.
+ *  @param enable Value enable/disable role switch of controller.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ *  @return -ENOBUFS HCI command buffer is not available.
+ *  @return -EINVAL @p conn is not a valid @ref BT_CONN_TYPE_BR connection.
+ */
+int bt_conn_br_set_role_switch_enable(const struct bt_conn *conn, bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -363,6 +363,7 @@ struct bt_hci_cmd_hdr {
 
 /* OpCode Group Fields */
 #define BT_OGF_LINK_CTRL                        0x01
+#define BT_OGF_LINK_POLICY                      0x02
 #define BT_OGF_BASEBAND                         0x03
 #define BT_OGF_INFO                             0x04
 #define BT_OGF_STATUS                           0x05
@@ -556,6 +557,43 @@ struct bt_hci_cp_user_passkey_neg_reply {
 struct bt_hci_cp_io_capability_neg_reply {
 	bt_addr_t bdaddr;
 	uint8_t   reason;
+} __packed;
+
+#define BT_HCI_OP_SWITCH_ROLE                   BT_OP(BT_OGF_LINK_POLICY, 0x000b)
+struct bt_hci_cp_switch_role {
+	bt_addr_t bdaddr;
+	uint8_t   role;
+} __packed;
+
+#define BT_HCI_LINK_POLICY_SETTINGS_ENABLE_ROLE_SWITCH  BIT(0)
+#define BT_HCI_LINK_POLICY_SETTINGS_ENABLE_HOLD_MODE    BIT(1)
+#define BT_HCI_LINK_POLICY_SETTINGS_ENABLE_SNIFF_SWITCH BIT(2)
+
+#define BT_HCI_OP_READ_LINK_POLICY_SETTINGS     BT_OP(BT_OGF_LINK_POLICY, 0x000c)
+struct bt_hci_cp_read_link_policy_settings {
+	uint16_t handle;
+} __packed;
+struct bt_hci_rp_read_link_policy_settings {
+	uint8_t  status;
+	uint16_t handle;
+	uint16_t link_policy_settings;
+} __packed;
+
+#define BT_HCI_OP_WRITE_LINK_POLICY_SETTINGS    BT_OP(BT_OGF_LINK_POLICY, 0x000d)
+struct bt_hci_cp_write_link_policy_settings {
+	uint16_t handle;
+	uint16_t link_policy_settings;
+} __packed;
+
+#define BT_HCI_OP_READ_DEFAULT_LINK_POLICY_SETTINGS  BT_OP(BT_OGF_LINK_POLICY, 0x000e)
+struct bt_hci_rp_read_default_link_policy_settings {
+	uint8_t  status;
+	uint16_t default_link_policy_settings;
+} __packed;
+
+#define BT_HCI_OP_WRITE_DEFAULT_LINK_POLICY_SETTINGS BT_OP(BT_OGF_LINK_POLICY, 0x000f)
+struct bt_hci_cp_write_default_link_policy_settings {
+	uint16_t default_link_policy_settings;
 } __packed;
 
 #define BT_HCI_OP_SET_EVENT_MASK                BT_OP(BT_OGF_BASEBAND, 0x0001) /* 0x0c01 */

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -508,6 +508,12 @@ config BT_COD
 	  consult the following link:
 	  https://www.bluetooth.com/specifications/assigned-numbers
 
+config BT_DEFAULT_ROLE_SWITCH_ENABLE
+	bool "Default Bluetooth Role Switch Enable/Disable State"
+	help
+	  This option sets the controller's default link policy to
+	  enable/disable the role switch.
+
 endif # BT_CLASSIC
 
 endmenu

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -800,7 +800,10 @@ int bt_br_init(void)
 	struct bt_hci_cp_write_ssp_mode *ssp_cp;
 	struct bt_hci_cp_write_inquiry_mode *inq_cp;
 	struct bt_hci_write_local_name *name_cp;
+	struct bt_hci_rp_read_default_link_policy_settings *rp;
+	struct net_buf *rsp;
 	int err;
+	uint16_t default_link_policy_settings;
 
 	/* Read extended local features */
 	if (BT_FEAT_EXT_FEATURES(bt_dev.features)) {
@@ -901,6 +904,38 @@ int bt_br_init(void)
 		sc_cp->sc_support = 0x01;
 
 		err = bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_SC_HOST_SUPP, buf, NULL);
+		if (err) {
+			return err;
+		}
+	}
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_READ_DEFAULT_LINK_POLICY_SETTINGS, NULL, &rsp);
+	if (err) {
+		return err;
+	}
+
+	rp = (void *)rsp->data;
+	default_link_policy_settings = rp->default_link_policy_settings;
+
+	bool should_enable = IS_ENABLED(CONFIG_BT_DEFAULT_ROLE_SWITCH_ENABLE);
+	bool is_enabled = (default_link_policy_settings &
+			   BT_HCI_LINK_POLICY_SETTINGS_ENABLE_ROLE_SWITCH);
+
+	/* Enable/Disable the default role switch */
+	if (should_enable != is_enabled) {
+		struct bt_hci_cp_write_default_link_policy_settings *policy_cp;
+
+		default_link_policy_settings ^= BT_HCI_LINK_POLICY_SETTINGS_ENABLE_ROLE_SWITCH;
+
+		buf = bt_hci_cmd_alloc(K_FOREVER);
+		if (!buf) {
+			return -ENOBUFS;
+		}
+
+		policy_cp = net_buf_add(buf, sizeof(*policy_cp));
+		policy_cp->default_link_policy_settings = default_link_policy_settings;
+
+		err = bt_hci_cmd_send_sync(BT_HCI_OP_WRITE_DEFAULT_LINK_POLICY_SETTINGS, buf, NULL);
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -681,21 +681,21 @@ void bt_hci_role_change(struct net_buf *buf)
 
 	LOG_DBG("status 0x%02x role %u addr %s", evt->status, evt->role, bt_addr_str(&evt->bdaddr));
 
-	if (evt->status) {
-		return;
-	}
-
 	conn = bt_conn_lookup_addr_br(&evt->bdaddr);
 	if (!conn) {
 		LOG_ERR("Can't find conn for %s", bt_addr_str(&evt->bdaddr));
 		return;
 	}
 
-	if (evt->role) {
-		conn->role = BT_CONN_ROLE_PERIPHERAL;
-	} else {
-		conn->role = BT_CONN_ROLE_CENTRAL;
+	if (evt->status == 0) {
+		if (evt->role == BT_HCI_ROLE_PERIPHERAL) {
+			conn->role = BT_CONN_ROLE_PERIPHERAL;
+		} else {
+			conn->role = BT_CONN_ROLE_CENTRAL;
+		}
 	}
+
+	bt_conn_role_changed(conn, evt->status);
 
 	bt_conn_unref(conn);
 }

--- a/subsys/bluetooth/host/classic/shell/bredr.h
+++ b/subsys/bluetooth/host/classic/shell/bredr.h
@@ -1,0 +1,20 @@
+/** @file
+ *  @brief Bluetooth shell functions
+ *
+ *  This is not to be included by the application.
+ */
+
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __BREDR_H
+#define __BREDR_H
+#include <stddef.h>
+#include <stdint.h>
+
+void role_changed(struct bt_conn *conn, uint8_t status);
+
+#endif /* __BREDR_H */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1844,6 +1844,25 @@ void bt_conn_connected(struct bt_conn *conn)
 	notify_connected(conn);
 }
 
+#if defined(CONFIG_BT_CLASSIC)
+void bt_conn_role_changed(struct bt_conn *conn, uint8_t status)
+{
+	struct bt_conn_cb *callback;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
+		if (callback->role_changed) {
+			callback->role_changed(conn, status);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb) {
+		if (cb->role_changed) {
+			cb->role_changed(conn, status);
+		}
+	}
+}
+#endif
+
 static int conn_disconnect(struct bt_conn *conn, uint8_t reason)
 {
 	int err;

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -478,6 +478,8 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state);
 
 void bt_conn_connected(struct bt_conn *conn);
 
+void bt_conn_role_changed(struct bt_conn *conn, uint8_t status);
+
 int bt_conn_le_conn_update(struct bt_conn *conn,
 			   const struct bt_le_conn_param *param);
 

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -53,6 +53,9 @@
 #include "controller/ll_sw/shell/ll.h"
 #endif /* CONFIG_BT_LL_SW_SPLIT */
 #include "host/shell/bt.h"
+#if defined(CONFIG_BT_CLASSIC)
+#include "host/classic/shell/bredr.h"
+#endif
 
 static bool no_settings_load;
 
@@ -1191,6 +1194,9 @@ static struct bt_conn_cb conn_callbacks = {
 	.le_cs_read_remote_fae_table_complete = print_remote_cs_fae_table,
 	.le_cs_config_complete = le_cs_config_created,
 	.le_cs_config_removed = le_cs_config_removed,
+#endif
+#if defined(CONFIG_BT_CLASSIC)
+	.role_changed = role_changed,
 #endif
 };
 #endif /* CONFIG_BT_CONN */


### PR DESCRIPTION
add `role_changed` to `struct bt_conn_cb` to notify the HCI_Role_Change event to application.
add BT_HCI_OP_SWITCH_ROLE and struct bt_hci_cp_switch_role.
~add br switch-role shell cmd and test the role_changed callback.~