### PR TITLE
license: fix copyright owner

### DIFF
--- a/drivers/dac/Kconfig.dac161s997
+++ b/drivers/dac/Kconfig.dac161s997
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/drivers/dac/dac_dac161s997.c
+++ b/drivers/dac/dac_dac161s997.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/drivers/mfd/mfd_ad559x.h
+++ b/drivers/mfd/mfd_ad559x.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/drivers/mfd/mfd_ad559x_i2c.c
+++ b/drivers/mfd/mfd_ad559x_i2c.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/drivers/sensor/explorir_m/Kconfig
+++ b/drivers/sensor/explorir_m/Kconfig
@@ -1,6 +1,6 @@
 # ExplorIR-M CO2 sensor configuration options
 
-# Copyright (c) 2023, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 config EXPLORIR_M

--- a/drivers/sensor/explorir_m/explorir_m.c
+++ b/drivers/sensor/explorir_m/explorir_m.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/drivers/sensor/fcx_mldx5/Kconfig
+++ b/drivers/sensor/fcx_mldx5/Kconfig
@@ -1,6 +1,6 @@
 # FCX-MLDx5 O2 sensor configuration options
 
-# Copyright (c) 2024, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 config FCX_MLDX5

--- a/drivers/sensor/fcx_mldx5/fcx_mldx5.c
+++ b/drivers/sensor/fcx_mldx5/fcx_mldx5.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/drivers/sensor/tsic_xx6/CMakeLists.txt
+++ b/drivers/sensor/tsic_xx6/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()

--- a/drivers/sensor/tsic_xx6/Kconfig
+++ b/drivers/sensor/tsic_xx6/Kconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 config TSIC_XX6

--- a/drivers/sensor/tsic_xx6/tsic_xx6.c
+++ b/drivers/sensor/tsic_xx6/tsic_xx6.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/drivers/sensor/veaa_x_3/Kconfig
+++ b/drivers/sensor/veaa_x_3/Kconfig
@@ -1,6 +1,6 @@
 # VEAA-X-3 configuration options
 
-# Copyright (c) 2024, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 config VEAA_X_3

--- a/drivers/sensor/veaa_x_3/veaa_x_3.c
+++ b/drivers/sensor/veaa_x_3/veaa_x_3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/dts/bindings/dac/ti,dac161s997.yaml
+++ b/dts/bindings/dac/ti,dac161s997.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: TI DAC161S997 16-bit 1 channel SPI DAC for 4-20 mA loops

--- a/dts/bindings/mfd/adi,ad559x-i2c.yaml
+++ b/dts/bindings/mfd/adi,ad559x-i2c.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: Analog AD559X ADC/DAC/GPIO chip via I2C bus

--- a/dts/bindings/mfd/adi,ad559x-spi.yaml
+++ b/dts/bindings/mfd/adi,ad559x-spi.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: Analog AD559X ADC/DAC/GPIO chip via SPI bus

--- a/dts/bindings/sensor/ap,fcx-mldx5.yaml
+++ b/dts/bindings/sensor/ap,fcx-mldx5.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: Angst+Pfister O2 sensor

--- a/dts/bindings/sensor/festo,veaa-x-3.yaml
+++ b/dts/bindings/sensor/festo,veaa-x-3.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: |

--- a/dts/bindings/sensor/gss,explorir-m.yaml
+++ b/dts/bindings/sensor/gss,explorir-m.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: Gas Sensing Solutions CO2 sensor

--- a/dts/bindings/sensor/ist,tsic-xx6.yaml
+++ b/dts/bindings/sensor/ist,tsic-xx6.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, Vitrolife A/S
+# Copyright (c) 2025 Prevas A/S
 # SPDX-License-Identifier: Apache-2.0
 
 description: |

--- a/include/zephyr/drivers/dac/dac161s997.h
+++ b/include/zephyr/drivers/dac/dac161s997.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/zephyr/drivers/sensor/explorir_m.h
+++ b/include/zephyr/drivers/sensor/explorir_m.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/zephyr/drivers/sensor/fcx_mldx5.h
+++ b/include/zephyr/drivers/sensor/fcx_mldx5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/zephyr/drivers/sensor/veaa_x_3.h
+++ b/include/zephyr/drivers/sensor/veaa_x_3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/zephyr/dt-bindings/sensor/tmp11x.h
+++ b/include/zephyr/dt-bindings/sensor/tmp11x.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/drivers/adc/adc_dt/boards/nucleo_h563zi.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nucleo_h563zi.overlay
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  */
 
 / {

--- a/samples/sensor/co2_polling/src/main.c
+++ b/samples/sensor/co2_polling/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/sensor/veaa_x_3/Kconfig
+++ b/samples/sensor/veaa_x_3/Kconfig
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2024 Vitrolife A/S
+#  Copyright (c) 2025 Prevas A/S
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/samples/sensor/veaa_x_3/boards/nucleo_h563zi.overlay
+++ b/samples/sensor/veaa_x_3/boards/nucleo_h563zi.overlay
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (c) 2024, Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  */
 
 /* spi1 sck conflicts with dac1 channel 3 */

--- a/samples/sensor/veaa_x_3/src/main.c
+++ b/samples/sensor/veaa_x_3/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/drivers/build_all/sensor/pwm.dtsi
+++ b/tests/drivers/build_all/sensor/pwm.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Vitrolife A/S
+ * Copyright (c) 2025 Prevas A/S
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
Change license owner to Prevas due to initially wrong owner due to company
mix-up during co-development.