### PR TITLE
tests: littlefs: add mimxrt1064/1160-evk support

### DIFF
--- a/tests/subsys/fs/littlefs/boards/mimxrt1064_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1064_evk.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&is25wp064 {
+	partitions {
+		large_partition: partition@400000 {
+			label = "large";
+			reg = <0x00400000 DT_SIZE_M(3)>;
+		};
+		medium_partition: partition@700000 {
+			label = "medium";
+			reg = <0x00700000 DT_SIZE_K(960)>;
+		};
+		small_partition: partition@7F0000 {
+			label = "small";
+			reg = <0x007F0000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&is25wp128 {
+	partitions {
+		large_partition: partition@C00000 {
+			label = "large";
+			reg = <0x00C00000 DT_SIZE_M(3)>;
+		};
+		medium_partition: partition@F00000 {
+			label = "medium";
+			reg = <0x00F00000 DT_SIZE_K(960)>;
+		};
+		small_partition: partition@FF0000 {
+			label = "small";
+			reg = <0x00FF0000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -14,6 +14,8 @@ common:
     - mimxrt1040_evk
     - mimxrt1050_evk/mimxrt1052/hyperflash
     - mimxrt1060_evk/mimxrt1062/qspi
+    - mimxrt1064_evk
+    - mimxrt1160_evk/mimxrt1166/cm7
     - mimxrt1170_evk/mimxrt1176/cm7
     - mimxrt1180_evk/mimxrt1189/cm33
     - mimxrt595_evk/mimxrt595s/cm33


### PR DESCRIPTION
Adds support for mimxrt1064-evk and mimxrt1160-evk boards to the littlefs test.