### PR TITLE
mgmt: ec_host_cmd: npcx: remove the SHI enable in the init

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -1000,8 +1000,6 @@ static int shi_npcx_init_registers(const struct device *dev)
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), shi_npcx_isr, DEVICE_DT_INST_GET(0),
 		    0);
 
-	shi_npcx_enable(dev);
-
 	return ret;
 }
 


### PR DESCRIPTION
This commit removes the SHI enable in the initialization. It can be enabled by the application explicitly calling it when needed. The SHI backend relies on the application layer to provide a data buffer for EC Host Commands. If SHI is enabled before this buffer is initialized, there is a risk that the driver may access a NULL buffer, leading to a system panic.