### PR TITLE
scripts: blobs: add license-click-through property

### DIFF
--- a/scripts/west_commands/blobs.py
+++ b/scripts/west_commands/blobs.py
@@ -55,6 +55,8 @@ class Blobs(WestCommand):
             - type: type of blob
             - version: version string
             - license_path: path to the license file for the blob
+            - license-abspath: absolute path to the license file for the blob
+            - click-through: need license click-through or not
             - uri: URI to the remote location of the blob
             - description: blob text description
             - doc-url: URL to the documentation for this blob
@@ -151,6 +153,33 @@ class Blobs(WestCommand):
                 self.dbg('Blob {module}: {abspath} is up to date'.format(**blob))
                 continue
             self.inf('Fetching blob {module}: {abspath}'.format(**blob))
+
+            if blob['click-through']:
+                while True:
+                    user_input = input("For this blob, need to read and accept "
+                                       "license to continue. Read it?\n"
+                                       "Please type 'y' or 'n' and press enter to confirm: ")
+                    if user_input.upper() == "Y" or user_input.upper() == "N":
+                        break
+
+                if user_input.upper() != "Y":
+                    self.wrn('Skip fetching this blob.')
+                    continue
+
+                with open(blob['license-abspath']) as license_file:
+                    license_content = license_file.read()
+                    print(license_content)
+
+                while True:
+                    user_input = input("Accept license to continue?\n"
+                                       "Please type 'y' or 'n' and press enter to confirm: ")
+                    if user_input.upper() == "Y" or user_input.upper() == "N":
+                        break
+
+                if user_input.upper() != "Y":
+                    self.wrn('Skip fetching this blob.')
+                    continue
+
             self.fetch_blob(blob['url'], blob['abspath'])
             if not self.verify_blob(blob):
                 bad_checksum_count += 1

--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -143,6 +143,10 @@ mapping:
           license-path:
             required: true
             type: str
+          click-through:
+            required: false
+            type: bool
+            default: false
           url:
             required: true
             type: str
@@ -341,6 +345,7 @@ def process_blobs(module, meta):
     for blob in mblobs:
         blob['module'] = meta.get('name', None)
         blob['abspath'] = blobs_path / Path(blob['path'])
+        blob['license-abspath'] = Path(module) / Path(blob['license-path'])
         blob['status'] = get_blob_status(blob['abspath'], blob['sha256'])
         blobs.append(blob)
 


### PR DESCRIPTION
Added a license-click-through property. Some downloading may need to accept license to continue.

And an example using it is https://github.com/zephyrproject-rtos/hal_nxp/pull/515

Thanks.