### PR TITLE
drivers: i2s_nrfx: Add missing <hal/nrf_clock.h> inclusion

### DIFF
--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>
 #include <nrfx_i2s.h>
+#include <hal/nrf_clock.h>
 
 #include <zephyr/logging/log.h>
 #include <zephyr/irq.h>
@@ -971,7 +972,8 @@ static DEVICE_API(i2s, i2s_nrf_drv_api) = {
 		init_clock_manager(dev);				     \
 		return 0;						     \
 	}								     \
-	BUILD_ASSERT(I2S_CLK_SRC(idx) != ACLK || NRF_I2S_HAS_CLKCONFIG,	     \
+	BUILD_ASSERT(I2S_CLK_SRC(idx) != ACLK ||			     \
+		     (NRF_I2S_HAS_CLKCONFIG && NRF_CLOCK_HAS_HFCLKAUDIO),    \
 		"Clock source ACLK is not available.");			     \
 	BUILD_ASSERT(I2S_CLK_SRC(idx) != ACLK ||			     \
 		     DT_NODE_HAS_PROP(DT_NODELABEL(clock),		     \

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -8,9 +8,6 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 
 #include <zephyr/device.h>
-#ifdef NRF_CLOCK
-#include <hal/nrf_clock.h>
-#endif
 #include <zephyr/sys/onoff.h>
 #include <zephyr/drivers/clock_control.h>
 
@@ -19,6 +16,8 @@ extern "C" {
 #endif
 
 #if defined(CONFIG_CLOCK_CONTROL_NRF)
+
+#include <hal/nrf_clock.h>
 
 /** @brief Clocks handled by the CLOCK peripheral.
  *


### PR DESCRIPTION
This driver uses the NRF_CLOCK_HAS_HFCLKAUDIO symbol that is defined in <hal/nrf_clock.h>, so it should explicitly include that header, not count on this inclusion being done by some other header, like <zephyr/drivers/clock_control/nrf_clock_control.h>.
Extend also the build assertion that checks if the audio clock can be used so that now it ensures that the above symbol is defined (to prevent the driver from silently discarding the audio clock configured as the clock source).

Additionally, fix inclusion of <hal/nrf_clock.h> in <zephyr/drivers/clock_control/nrf_clock_control.h>, which was done under not always valid condition (and that actually revealed the above problem in the i2s_nrfx driver).