### PR TITLE
toolchain: gcc: fixes __ramfunc usage with Clang

### DIFF
--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -209,8 +209,17 @@ do {                                                                    \
 #define __ramfunc
 #elif defined(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT)
 #if defined(CONFIG_ARM)
+#if defined(__clang__)
+/* No long_call attribute for Clang.
+ * Rely on linker to place required veneers.
+ * https://github.com/llvm/llvm-project/issues/39969
+ */
+#define __ramfunc __attribute__((noinline)) __attribute__((section(".ramfunc")))
+#else
+/* GCC version */
 #define __ramfunc	__attribute__((noinline))			\
 			__attribute__((long_call, section(".ramfunc")))
+#endif
 #else
 #define __ramfunc	__attribute__((noinline))			\
 			__attribute__((section(".ramfunc")))


### PR DESCRIPTION
With Clang you can't set long_call attribute on function basis. Instead of converting all calls to long calls let the linker create veneers when necessary.

LLVM issue:
* https://github.com/llvm/llvm-project/issues/39969

Steps to take to see the original issue:
```
west build -b mimxrt595_evk/mimxrt595s/cm33 samples/hello_world/ -- -DCONFIG_XIP=y -DCONFIG_LLVM_USE_LLD=y -DCONFIG_COMPILER_RT_RTLIB=y
```
```
.../zephyr/boards/nxp/mimxrt595_evk/board.h:10:1: warning: unknown attribute 'long_call' ignored [-Wunknown-attributes]
   10 | __ramfunc int32_t power_manager_set_profile(uint32_t power_profile);
      | ^~~~~~~~~
.../zephyr/include/zephyr/toolchain/gcc.h:213:19: note: expanded from macro '__ramfunc'
  213 |                         __attribute__((long_call, section(".ramfunc")))
      |                                        ^~~~~~~~~
1 warning generated.
```
