### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -320,7 +320,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: d5b95fdd0260e8189e788d40d2863d1e2d4be159
+      revision: c6296f600a6851bd652f207ab4908d339e1ce705
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: e0adc318539934e575b2f777b482b5536dbeb429


### PR DESCRIPTION
Update the HW models module to:
c6296f600a6851bd652f207ab4908d339e1ce705

Including the following:
c6296f6 52/53 CCM: Remove warning on TASK_STOP
cb790ab hw_testcheat_if: Typo fix in comment
38956c4 RADIO: Add cheat interface to disable Tx or Rx