### PR TITLE
bluetooth: cyw43xxx: support PatchRAM files with multiple LaunchRAM commands

### DIFF
--- a/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
+++ b/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
@@ -189,15 +189,12 @@ static int bt_firmware_download(const uint8_t *firmware_image, uint32_t size)
 
 		switch (op_code) {
 		case BT_HCI_VND_OP_WRITE_RAM:
+		case BT_HCI_VND_OP_LAUNCH_RAM:
 			/* Update remaining length and data pointer:
 			 * content of data length + 2 bytes of opcode and 1 byte of data length.
 			 */
 			data += data_length + 3;
 			remaining_length -= data_length + 3;
-			break;
-
-		case BT_HCI_VND_OP_LAUNCH_RAM:
-			remaining_length = 0;
 			break;
 
 		default:


### PR DESCRIPTION
The CYW43xxx for Infineon Controllers stops after the first LauncRAM command. Newer Controllers like the CYW5557x update the firmware in multiple stages, which is supported by this commit.

This and #90154 are required to let Infineon's AIROC driver load the current PatchRAM file.