### PR TITLE
bluetooth: cyw43xxx: support autobaud feature

### DIFF
--- a/drivers/bluetooth/hci/Kconfig.infineon
+++ b/drivers/bluetooth/hci/Kconfig.infineon
@@ -196,6 +196,22 @@ config AIROC_CUSTOM_FIRMWARE_HCD_BLOB
 	  Path to BT firmware HCD file for custom or vendor CYW43xx modules.
 	  It can be absolute path, or relative from project folder.
 
+config AIROC_AUTOBAUD_MODE
+	bool "Autobaud mode"
+	help
+	  Use Autobaud feature of AIROC Controller for fast firmware download
+
+	  Newer AIROC Controllers such as CYW555xx only allow firmware
+	  upload in Download Mode after a Recovery Reset.
+	  In Download Mode the Baud Rate vendor command cannot be used
+	  initially. Instead, Autobaud mode allows to direct use a higher
+	  baud rate.
+
+	  Autobaud mode is not required on older AIROC controllers.
+
+	  https://infineon.github.io/btsdk-docs/BT-SDK/AIROC-HCI-Firmware-Download.pdf
+
+
 # Change size of command lengths. It for vendor commands related to
 # firmware downloading.
 config BT_BUF_CMD_TX_SIZE

--- a/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
+++ b/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
@@ -251,14 +251,27 @@ int bt_h4_vnd_setup(const struct device *dev)
 	/* BT settling time after power on */
 	(void)k_msleep(BT_POWER_ON_SETTLING_TIME_MS);
 
+	/* Newer controllers like CYW555xx require Download mode for firmware upload.
+	 * In Download mode, the baudrate cannot be changed without the Minidriver.
+	 * We use auto-baud mode to use a higher baud rate directly.
+	 */
+	if (IS_ENABLED(CONFIG_AIROC_AUTOBAUD_MODE) &&
+	    (fw_download_speed != default_uart_speed)) {
+		err = bt_hci_uart_set_baudrate(dev, fw_download_speed);
+		if (err) {
+			return err;
+		}
+	}
+
 	/* Send HCI_RESET */
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, NULL);
 	if (err) {
 		return err;
 	}
 
-	/* Re-configure baudrate for BT Controller */
-	if (fw_download_speed != default_uart_speed) {
+	/* Re-configure baudrate for BT Controller (if we haven't already) */
+	if (!IS_ENABLED(CONFIG_AIROC_AUTOBAUD_MODE) &&
+	    (fw_download_speed != default_uart_speed)) {
 		err = bt_update_controller_baudrate(dev, fw_download_speed);
 		if (err) {
 			return err;


### PR DESCRIPTION
Newer AIROC controllers like the CYW55573 don't support changing the baudrate in Download Mode. However, a higher baud rate can be used directly to sent HCI Reset.

This commit adds the KConfig flag CONFIG_AIROC_DOWNLOAD_MODE to enable the new behaviour.

This and #90153 are required to let Infineon's AIROC driver load the current PatchRAM file.