### PR TITLE
[Backport v4.0-branch] net: http: server: The detail length of wildcard detail was wrong

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -163,7 +163,8 @@ config HTTP_SERVER_WEBSOCKET
 
 config HTTP_SERVER_RESOURCE_WILDCARD
 	bool "Allow wildcard matching of resources"
-	select FNMATCH
+	# The POSIX_C_LIB_EXT will get fnmatch() support
+	select POSIX_C_LIB_EXT
 	help
 	  Allow user to specify wildcards when setting up resource strings.
 	  This means that instead of specifying multiple resources with exact

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -678,6 +678,17 @@ static int compare_strings(const char *s1, const char *s2)
 	return 1; /* Strings are not equal */
 }
 
+static int path_len_without_query(const char *path)
+{
+	int len = 0;
+
+	while ((path[len] != '\0') && (path[len] != '?')) {
+		len++;
+	}
+
+	return len;
+}
+
 static bool skip_this(struct http_resource_desc *resource, bool is_websocket)
 {
 	struct http_resource_detail *detail;
@@ -713,7 +724,7 @@ struct http_resource_detail *get_resource_detail(const char *path,
 				ret = fnmatch(resource->resource, path,
 					      (FNM_PATHNAME | FNM_LEADING_DIR));
 				if (ret == 0) {
-					*path_len = strlen(resource->resource);
+					*path_len = path_len_without_query(path);
 					return resource->detail;
 				}
 			}

--- a/tests/net/lib/http_server/common/src/main.c
+++ b/tests/net/lib/http_server/common/src/main.c
@@ -77,6 +77,8 @@ HTTP_RESOURCE_DEFINE(resource_6, service_D, "/fo*", RES(1));
 HTTP_RESOURCE_DEFINE(resource_7, service_D, "/f[ob]o3.html", RES(1));
 HTTP_RESOURCE_DEFINE(resource_8, service_D, "/fb?3.htm", RES(0));
 HTTP_RESOURCE_DEFINE(resource_9, service_D, "/f*4.html", RES(3));
+HTTP_RESOURCE_DEFINE(resource_11, service_D, "/foo/*", RES(3));
+HTTP_RESOURCE_DEFINE(resource_12, service_D, "/foo/b?r", RES(3));
 
 ZTEST(http_service, test_HTTP_SERVICE_DEFINE)
 {
@@ -345,6 +347,25 @@ ZTEST(http_service, test_HTTP_RESOURCE_WILDCARD)
 	zassert_not_null(res, "Cannot find resource");
 	zassert_true(len > 0, "Length not set");
 	zassert_equal(res, RES(5), "Resource mismatch");
+
+	res = CHECK_PATH("/foo/bar", &len);
+	zassert_not_null(res, "Resource not found");
+	zassert_true(len == (sizeof("/foo/bar") - 1), "Length not set correctly");
+	zassert_equal(res, RES(3), "Resource mismatch");
+
+	res = CHECK_PATH("/foo/bar?param=value", &len);
+	zassert_not_null(res, "Resource not found");
+	zassert_true(len == (sizeof("/foo/bar") - 1), "Length not set correctly");
+	zassert_equal(res, RES(3), "Resource mismatch");
+
+	res = CHECK_PATH("/bar?foo=value", &len);
+	zassert_is_null(res, "Resource found");
+	zassert_equal(len, 0, "Length set");
+
+	res = CHECK_PATH("/foo/bar?param=value", &len);
+	zassert_not_null(res, "Resource not found");
+	zassert_true(len == (sizeof("/foo/bar") - 1), "Length not set correctly");
+	zassert_equal(res, RES(3), "Resource mismatch");
 }
 
 extern void http_server_get_content_type_from_extension(char *url, char *content_type,


### PR DESCRIPTION
Backport commits from https://github.com/zephyrproject-rtos/zephyr/pull/86648.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/90103
