### PR TITLE
tests: drivers: spi: spi_loopback: Test fast spi on slow GPIO port

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p2.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_cpuapp_fast_p2.overlay
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi121_default: spi121_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_MISO, 2, 10)>;
+		};
+
+		group2 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 2)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 11)>;
+			nordic,drive-mode = <NRF_DRIVE_E0E1>;
+		};
+	};
+
+	spi121_sleep: spi121_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 2)>,
+				<NRF_PSEL(SPIM_MISO, 2, 10)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 11)>;
+			low-power-enable;
+		};
+	};
+};
+
+&dma_fast_region {
+	status = "okay";
+};
+
+&nfct {
+	status = "disabled";
+	nfct-pins-as-gpios;
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi121 {
+	status = "okay";
+	pinctrl-0 = <&spi121_default>;
+	pinctrl-1 = <&spi121_sleep>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	memory-regions = <&dma_fast_region>;
+	zephyr,pm-device-runtime-auto;
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
+	};
+
+	dut_fast: fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -262,6 +262,12 @@ tests:
       - EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_32mhz.overlay"
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.nrf54h_fast_8mhz_port2:
+    extra_args:
+      - DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast_p2.overlay"
+      - CONFIG_NRF_REGTOOL_VERBOSITY=2
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
   drivers.spi.nrf54l_1mhz:
     extra_args: EXTRA_DTC_OVERLAY_FILE="boards/nrf_at_1mhz.overlay"
     platform_allow:


### PR DESCRIPTION
Add test configuration where fast SPI instance operates at slow GPIO port 2.