### PR TITLE
drivers: gpio: Fix GPIO initial status

### DIFF
--- a/drivers/gpio/gpio_rts5912.c
+++ b/drivers/gpio/gpio_rts5912.c
@@ -180,7 +180,7 @@ static int gpio_rts5912_configuration(const struct device *port, gpio_pin_t pin,
 	if (flags & GPIO_OUTPUT) {
 		if (flags & GPIO_OUTPUT_INIT_HIGH) {
 			pin_output_high(port, pin);
-		} else {
+		} else if (flags & GPIO_OUTPUT_INIT_LOW) {
 			pin_output_low(port, pin);
 		}
 	}


### PR DESCRIPTION
The current procedure to initialize the GPIO is:
If the GPIO is configured as GPIO_OUTPUT and also has the
GPIO_OUTPUT_INIT_HIGH flag, set it to output high; otherwise, set it to
output low.

This may fail if the GPIO is simply configured as GPIO_OUTPUT without
specifying either INIT_HIGH or INIT_LOW, which means it is intended to
preserve the previous status. But in this case, we are currently setting it
to output low.

Fix this by explicitly initializing the GPIO to high or low according to the
configuration:
If the GPIO is configured as GPIO_OUTPUT and also with the
GPIO_OUTPUT_INIT_HIGH flag, set it to output high.  
If the GPIO is configured as GPIO_OUTPUT and also with the
GPIO_OUTPUT_INIT_LOW flag, set it to output low.
If the GPIO is configured as GPIO_OUTPUT only, do not set the output value.