### PR TITLE
modules/cmsis-dsp: Don't use Zephyr stdint.h

### DIFF
--- a/modules/cmsis-dsp/CMakeLists.txt
+++ b/modules/cmsis-dsp/CMakeLists.txt
@@ -19,6 +19,9 @@ if(CONFIG_CMSIS_DSP)
     ${cmsis_glue_path}/CMSIS/Core/Include
   )
 
+  # Define ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_ to avoid using Zephyr's stdint.h
+  zephyr_library_compile_definitions(ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_)
+
   # Global Feature Definitions
   zephyr_library_compile_definitions_ifdef(CONFIG_CMSIS_DSP_NEON                  ARM_MATH_NEON)
   zephyr_library_compile_definitions_ifdef(CONFIG_CMSIS_DSP_NEON_EXPERIMENTAL     ARM_MATH_NEON_EXPERIMENTAL)


### PR DESCRIPTION
Zephyr replaces the toolchain version of stdint.h to define uint32_t and int32_t as int rather than long. This breaks the ARM MVE intrinics which require uint32_t to be defined as unsigned long.

Provide 'ZEPHYR_USE_TOOLCHAIN_STDINT' which causes zephyr_stdint.h to be skipped, ensuring that the normal stdint.h types are used instead.