### PR TITLE
Move from `ETH_STM32_HAL_MII` Kconfig option to `phy-connection-type` devicetree binding

### DIFF
--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
@@ -107,6 +107,7 @@ zephyr_udc0: &usbotg_fs {
 		&eth_txd0_pg13
 	>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 	status = "okay";
 };
 

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -222,6 +222,7 @@
 		      &eth_txd1_pg12
 		      &eth_txd0_pg13 >;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 	status = "okay";
 };
 

--- a/boards/olimex/stm32_e407/olimex_stm32_e407.dts
+++ b/boards/olimex/stm32_e407/olimex_stm32_e407.dts
@@ -127,4 +127,5 @@ zephyr_udc0: &usbotg_hs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -189,6 +189,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -186,6 +186,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -207,6 +207,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &backup_sram {

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -151,6 +151,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -198,6 +198,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &flash0 {

--- a/boards/st/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.dts
@@ -49,6 +49,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb15>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -178,6 +178,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -203,6 +203,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q_stm32h745xx_m7.dts
@@ -115,6 +115,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -182,6 +182,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q_stm32h755xx_m7.dts
@@ -114,6 +114,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -178,6 +178,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &quadspi {

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -174,6 +174,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &quadspi {

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -161,6 +161,7 @@ arduino_serial: &usart6 {};
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &sdmmc2 {

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -166,6 +166,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -138,6 +138,7 @@
 		     &eth_txd0_pb12
 		     &eth_txd1_pb13>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 	status = "okay";
 };
 

--- a/boards/st/stm32h745i_disco/Kconfig.defconfig
+++ b/boards/st/stm32h745i_disco/Kconfig.defconfig
@@ -11,9 +11,6 @@ if NETWORKING
 config NET_L2_ETHERNET
 	default y
 
-config ETH_STM32_HAL_MII
-	default y
-
 # STM32H745I-DISCO have PHY connected to address 1
 config ETH_STM32_HAL_PHY_ADDRESS
 	default 1

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -144,6 +144,7 @@
 		     &eth_txd0_pg13
 		     &eth_rx_er_pi10>;
 	pinctrl-names = "default";
+	phy-connection-type = "mii";
 };
 
 &mdio {

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -144,6 +144,7 @@
 		     &eth_txd0_pg13
 		     &eth_txd1_pg12>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/boards/witte/linum/linum.dts
+++ b/boards/witte/linum/linum.dts
@@ -238,6 +238,7 @@ zephyr_udc0: &usbotg_fs {
 		     &eth_txd0_pg13
 		     &eth_txd1_pg14>;
 	pinctrl-names = "default";
+	phy-connection-type = "rmii";
 };
 
 &mdio {

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -32,6 +32,9 @@ Boards
 Device Drivers and Devicetree
 *****************************
 
+* Removed Kconfig option ``ETH_STM32_HAL_MII`` (:github:`86074`).
+  PHY interface type is now selected via the ``phy-connection-type`` property in the device tree.
+
 Bluetooth
 *********
 

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -70,11 +70,6 @@ config ETH_STM32_HAL_PHY_ADDRESS
 	help
 	  The phy address to use.
 
-config ETH_STM32_HAL_MII
-	bool "Use MII interface"
-	help
-	  Use the MII physical interface instead of RMII.
-
 config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
 	int "Carrier check timeout period (ms)"
 	default 500

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -88,6 +88,12 @@ static const struct device *eth_stm32_phy_dev = DEVICE_PHY_BY_NAME(0);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet) */
 
+#define MAC_NODE DT_NODELABEL(mac)
+
+#define STM32_ETH_PHY_MODE(node_id) \
+	(DT_ENUM_HAS_VALUE(node_id, phy_connection_type, mii) ? \
+		ETH_MEDIA_INTERFACE_MII : ETH_MEDIA_INTERFACE_RMII)
+
 #define ETH_DMA_TX_TIMEOUT_MS	20U  /* transmit timeout in milliseconds */
 
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
@@ -1311,6 +1317,10 @@ static const struct eth_stm32_hal_dev_cfg eth0_config = {
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 
+BUILD_ASSERT(DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, mii) ||
+	     DT_ENUM_HAS_VALUE(MAC_NODE, phy_connection_type, rmii),
+	     "Unsupported PHY connection type selected");
+
 static struct eth_stm32_hal_dev_data eth0_data = {
 	.heth = {
 		.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(0),
@@ -1330,8 +1340,7 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 			.ChecksumMode = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
 					ETH_CHECKSUM_BY_HARDWARE : ETH_CHECKSUM_BY_SOFTWARE,
 #endif /* !CONFIG_SOC_SERIES_STM32H7X */
-			.MediaInterface = IS_ENABLED(CONFIG_ETH_STM32_HAL_MII) ?
-					  ETH_MEDIA_INTERFACE_MII : ETH_MEDIA_INTERFACE_RMII,
+			.MediaInterface = STM32_ETH_PHY_MODE(MAC_NODE),
 		},
 	},
 };

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1243,7 +1243,7 @@ static int eth_stm32_hal_set_config(const struct device *dev,
 #if defined(CONFIG_ETH_STM32_MULTICAST_FILTER)
 	case ETHERNET_CONFIG_TYPE_FILTER:
 		eth_stm32_mcast_filter(dev, &config->filter);
-		break;
+		return 0;
 #endif /* CONFIG_ETH_STM32_MULTICAST_FILTER */
 	default:
 		break;

--- a/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
+++ b/dts/bindings/ethernet/st,stm32-ethernet-common.yaml
@@ -18,3 +18,5 @@ properties:
     required: true
   pinctrl-names:
     required: true
+  phy-connection-type:
+    required: true

--- a/modules/zcbor/CMakeLists.txt
+++ b/modules/zcbor/CMakeLists.txt
@@ -8,6 +8,7 @@ if(CONFIG_ZCBOR)
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_common.c
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_decode.c
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_encode.c
+    ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_print.c
   )
 
   zephyr_library_compile_definitions(_POSIX_C_SOURCE=200809L)

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -42,6 +42,48 @@ LOG_MODULE_REGISTER(net_sock_addr, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #endif
 
+#if defined(CONFIG_DNS_RESOLVER) || defined(CONFIG_NET_IP)
+
+static int getaddrinfo_null_host(int port, const struct zsock_addrinfo *hints,
+				struct zsock_addrinfo *res)
+{
+	if (!hints || !(hints->ai_flags & AI_PASSIVE)) {
+		return DNS_EAI_FAIL;
+	}
+
+	/* For AF_UNSPEC, should we default to IPv6 or IPv4? */
+	if (hints->ai_family == AF_INET || hints->ai_family == AF_UNSPEC) {
+		struct sockaddr_in *addr = net_sin(&res->_ai_addr);
+
+		addr->sin_addr.s_addr = INADDR_ANY;
+		addr->sin_port = htons(port);
+		addr->sin_family = AF_INET;
+		INIT_ADDRINFO(res, addr);
+		res->ai_family = AF_INET;
+	} else if (hints->ai_family == AF_INET6) {
+		struct sockaddr_in6 *addr6 = net_sin6(&res->_ai_addr);
+
+		addr6->sin6_addr = in6addr_any;
+		addr6->sin6_port = htons(port);
+		addr6->sin6_family = AF_INET6;
+		INIT_ADDRINFO(res, addr6);
+		res->ai_family = AF_INET6;
+	} else {
+		return DNS_EAI_FAIL;
+	}
+
+	if (hints->ai_socktype == SOCK_DGRAM) {
+		res->ai_socktype = SOCK_DGRAM;
+		res->ai_protocol = IPPROTO_UDP;
+	} else {
+		res->ai_socktype = SOCK_STREAM;
+		res->ai_protocol = IPPROTO_TCP;
+	}
+	return 0;
+}
+
+#endif
+
 #if defined(CONFIG_DNS_RESOLVER)
 
 struct getaddrinfo_state {
@@ -177,42 +219,6 @@ again:
 	}
 
 	return st;
-}
-
-static int getaddrinfo_null_host(int port, const struct zsock_addrinfo *hints,
-				struct zsock_addrinfo *res)
-{
-	if (!hints || !(hints->ai_flags & AI_PASSIVE)) {
-		return DNS_EAI_FAIL;
-	}
-
-	/* For AF_UNSPEC, should we default to IPv6 or IPv4? */
-	if (hints->ai_family == AF_INET || hints->ai_family == AF_UNSPEC) {
-		struct sockaddr_in *addr = net_sin(&res->_ai_addr);
-		addr->sin_addr.s_addr = INADDR_ANY;
-		addr->sin_port = htons(port);
-		addr->sin_family = AF_INET;
-		INIT_ADDRINFO(res, addr);
-		res->ai_family = AF_INET;
-	} else if (hints->ai_family == AF_INET6) {
-		struct sockaddr_in6 *addr6 = net_sin6(&res->_ai_addr);
-		addr6->sin6_addr = in6addr_any;
-		addr6->sin6_port = htons(port);
-		addr6->sin6_family = AF_INET6;
-		INIT_ADDRINFO(res, addr6);
-		res->ai_family = AF_INET6;
-	} else {
-		return DNS_EAI_FAIL;
-	}
-
-	if (hints->ai_socktype == SOCK_DGRAM) {
-		res->ai_socktype = SOCK_DGRAM;
-		res->ai_protocol = IPPROTO_UDP;
-	} else {
-		res->ai_socktype = SOCK_STREAM;
-		res->ai_protocol = IPPROTO_TCP;
-	}
-	return 0;
 }
 
 int z_impl_z_zsock_getaddrinfo_internal(const char *host, const char *service,
@@ -363,8 +369,19 @@ static int try_resolve_literal_addr(const char *host, const char *service,
 	int socktype = SOCK_STREAM;
 	int protocol = IPPROTO_TCP;
 
+	if (service) {
+		port = strtol(service, NULL, 10);
+		if (port < 1 || port > 65535) {
+			return DNS_EAI_NONAME;
+		}
+	}
+
 	if (!host) {
-		return DNS_EAI_NONAME;
+		if (hints->ai_flags & AI_PASSIVE) {
+			return getaddrinfo_null_host(port, hints, res);
+		} else {
+			return DNS_EAI_NONAME;
+		}
 	}
 
 	if (hints) {
@@ -387,12 +404,6 @@ static int try_resolve_literal_addr(const char *host, const char *service,
 		return DNS_EAI_NONAME;
 	}
 
-	if (service) {
-		port = strtol(service, NULL, 10);
-		if (port < 1 || port > 65535) {
-			return DNS_EAI_NONAME;
-		}
-	}
 
 	res->ai_family = resolved_family;
 	res->ai_socktype = socktype;

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -984,9 +984,9 @@ static void state_collect(const struct shell *sh)
 			(void)sh->iface->api->read(sh->iface, buf,
 							sizeof(buf), &count);
 			if (count) {
-				z_flag_cmd_ctx_set(sh, true);
+				bool prev_cmd_ctx = z_flag_cmd_ctx_set(sh, true);
 				bypass(sh, buf, count);
-				z_flag_cmd_ctx_set(sh, false);
+				z_flag_cmd_ctx_set(sh, prev_cmd_ctx);
 				/* Check if bypass mode ended. */
 				if (!(volatile shell_bypass_cb_t *)sh->ctx->bypass) {
 					state_set(sh, SHELL_STATE_ACTIVE);


### PR DESCRIPTION
Fix `warning: ETH_STM32_HAL_MII` when building MCUboot.

Cherry-pick commits from zephyrproject-rtos/zephyr#86074 into our `v4.1.0_dynon` branch. 
