### PR TITLE
Bluetooth: Host: Add advertising state to bt_le_ext_adv_info

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1714,6 +1714,27 @@ int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv);
  */
 uint8_t bt_le_ext_adv_get_index(struct bt_le_ext_adv *adv);
 
+/** Advertising states. */
+enum bt_le_ext_adv_state {
+	/** The advertising set has been created but not enabled. */
+	BT_LE_EXT_ADV_STATE_DISABLED,
+
+	/** The advertising set is enabled. */
+	BT_LE_EXT_ADV_STATE_ENABLED,
+};
+
+/** Periodic Advertising states. */
+enum bt_le_per_adv_state {
+	/** Not configured for periodic advertising. */
+	BT_LE_PER_ADV_STATE_NONE,
+
+	/** The advertising set has been configured for periodic advertising, but is not enabled. */
+	BT_LE_PER_ADV_STATE_DISABLED,
+
+	/** Periodic advertising is enabled. */
+	BT_LE_PER_ADV_STATE_ENABLED,
+};
+
 /** @brief Advertising set info structure. */
 struct bt_le_ext_adv_info {
 	/** Local identity handle. */
@@ -1724,15 +1745,22 @@ struct bt_le_ext_adv_info {
 
 	/** Current local advertising address used. */
 	const bt_addr_le_t         *addr;
+
+	/** Extended advertising state. */
+	enum bt_le_ext_adv_state ext_adv_state;
+
+	/** Periodic advertising state. */
+	enum bt_le_per_adv_state per_adv_state;
 };
 
 /**
  * @brief Get advertising set info
  *
  * @param adv Advertising set object
- * @param info Advertising set info object
+ * @param info Advertising set info object. The values in this object are only valid on success.
  *
- * @return Zero on success or (negative) error code on failure.
+ * @retval 0 Success.
+ * @retval -EINVAL @p adv is not valid advertising set or @p info is NULL.
  */
 int bt_le_ext_adv_get_info(const struct bt_le_ext_adv *adv,
 			   struct bt_le_ext_adv_info *info);

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -2571,13 +2571,18 @@ static int cmd_adv_info(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_le_ext_adv_get_info(adv, &info);
 	if (err) {
-		shell_error(sh, "OOB data failed");
+		shell_error(sh, "Failed to get advertising set info: %d", err);
 		return err;
 	}
 
 	shell_print(sh, "Advertiser[%d] %p", selected_adv, adv);
 	shell_print(sh, "Id: %d, TX power: %d dBm", info.id, info.tx_power);
+	shell_print(sh, "Adv state: %d", info.ext_adv_state);
 	print_le_addr("Address", info.addr);
+
+	if (IS_ENABLED(CONFIG_BT_PER_ADV)) {
+		shell_print(sh, "Per Adv state: %d", info.per_adv_state);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The bt_le_ext_adv_info struct has been extended to also contain the advertising and periodic advertising states.

Additionally, the function verifies the input to avoid NULL pointer access, and more importantly does not return 0 with `addr` set to a valid that is not
used for advertising.