### PR TITLE
sca: eclair: substitute deprecated service STD.emptrecd

### DIFF
--- a/cmake/sca/eclair/ECL/toolchain.ecl
+++ b/cmake/sca/eclair/ECL/toolchain.ecl
@@ -50,8 +50,8 @@ Variables\";
 -config=STD.emptinit,behavior={c18,GCC,specified}
 -doc_end
 -doc_begin="See Chapter \"6.19 Structures with No Members\" of "GCC_MANUAL"."
--config=STD.emptrecd,behavior={c99,GCC,specified}
--config=STD.emptrecd,behavior={c18,GCC,specified}
+-config=STD.anonstct,behavior={c99,GCC,specified}
+-config=STD.anonstct,behavior={c18,GCC,specified}
 -doc_end
 -doc="See Chapter \"6.18 Arrays of Length Zero\" of "GCC_MANUAL"."
 -config=STD.arayzero,behavior={c99,GCC,specified}


### PR DESCRIPTION
The ECLAIR service STD.emptrecd (which checks for empty structures) is now
deprecated.
Use STD.anonstct (which checks for structures with no named
members, an UB in C99)

Based on a change by Nicola Vetrini in the Xen project:

https://lists.xenproject.org/archives/html/xen-changelog/2024-12/msg00125.html

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
