### PR TITLE
drivers: nrfx: enable cross domain pins for nRF54L15

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -148,6 +148,27 @@ BUILD_ASSERT(IS_ENABLED(CONFIG_CLOCK_CONTROL));
  */
 #define UARTE_ANY_HIGH_SPEED (UARTE_FOR_EACH_INSTANCE(INSTANCE_IS_HIGH_SPEED, (||), (0)))
 
+#define UARTE_PINS_CROSS_DOMAIN(unused, prefix, idx, _)			\
+	COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(UARTE(prefix##idx)),	\
+		   (UARTE_PROP(idx, cross_domain_pins_supported)),	\
+		   (0))
+
+#if UARTE_FOR_EACH_INSTANCE(UARTE_PINS_CROSS_DOMAIN, (||), (0))
+#include <hal/nrf_gpio.h>
+/* Certain UARTE instances support usage of cross domain pins in form of dedicated pins on
+ * a port different from the default one.
+ */
+#define UARTE_CROSS_DOMAIN_PINS_SUPPORTED 1
+#endif
+
+#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED && defined(CONFIG_NRF_SYS_EVENT)
+#include <nrf_sys_event.h>
+/* To use cross domain pins, constant latency mode needs to be applied, which is
+ * handled via nrf_sys_event requests.
+ */
+#define UARTE_CROSS_DOMAIN_PINS_HANDLE 1
+#endif
+
 #ifdef UARTE_ANY_CACHE
 /* uart120 instance does not retain BAUDRATE register when ENABLE=0. When this instance
  * is used then baudrate must be set after enabling the peripheral and not before.
@@ -371,6 +392,10 @@ struct uarte_nrfx_config {
 #endif
 	uint8_t *poll_out_byte;
 	uint8_t *poll_in_byte;
+#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
+	bool cross_domain;
+	int8_t default_port;
+#endif
 };
 
 /* Using Macro instead of static inline function to handle NO_OPTIMIZATIONS case
@@ -443,6 +468,32 @@ static void uarte_disable_locked(const struct device *dev, uint32_t dis_mask)
 #endif
 	nrf_uarte_disable(get_uarte_instance(dev));
 }
+
+#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
+static bool uarte_has_cross_domain_connection(const struct uarte_nrfx_config *config)
+{
+	const struct pinctrl_dev_config *pcfg = config->pcfg;
+	const struct pinctrl_state *state;
+	int ret;
+
+	ret = pinctrl_lookup_state(pcfg, PINCTRL_STATE_DEFAULT, &state);
+	if (ret < 0) {
+		LOG_ERR("Unable to read pin state");
+		return false;
+	}
+
+	for (uint8_t i = 0U; i < state->pin_cnt; i++) {
+		uint32_t pin = NRF_GET_PIN(state->pins[i]);
+
+		if ((pin != NRF_PIN_DISCONNECTED) &&
+		    (nrf_gpio_pin_port_number_extract(&pin) != config->default_port)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif
 
 #if defined(UARTE_ANY_NONE_ASYNC) && !defined(CONFIG_UART_NRFX_UARTE_NO_IRQ)
 /**
@@ -726,6 +777,19 @@ static void uarte_periph_enable(const struct device *dev)
 	nrf_uarte_enable(uarte);
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	nrf_gpd_retain_pins_set(config->pcfg, false);
+#endif
+#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
+	if (config->cross_domain && uarte_has_cross_domain_connection(config)) {
+#if UARTE_CROSS_DOMAIN_PINS_HANDLE
+		int err;
+
+		err = nrf_sys_event_request_global_constlat();
+		(void)err;
+		__ASSERT_NO_MSG(err >= 0);
+#else
+		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
+#endif
+	}
 #endif
 #if UARTE_BAUDRATE_RETENTION_WORKAROUND
 	nrf_uarte_baudrate_set(uarte,
@@ -2411,6 +2475,19 @@ static void uarte_pm_suspend(const struct device *dev)
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	nrf_gpd_retain_pins_set(cfg->pcfg, true);
 #endif
+#if UARTE_CROSS_DOMAIN_PINS_SUPPORTED
+	if (cfg->cross_domain && uarte_has_cross_domain_connection(cfg)) {
+#if UARTE_CROSS_DOMAIN_PINS_HANDLE
+		int err;
+
+		err = nrf_sys_event_release_global_constlat();
+		(void)err;
+		__ASSERT_NO_MSG(err >= 0);
+#else
+		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
+#endif
+	}
+#endif
 
 	nrf_uarte_disable(uarte);
 
@@ -2693,6 +2770,11 @@ static int uarte_instance_init(const struct device *dev,
 				.accuracy = 0,				       \
 				.precision = NRF_CLOCK_CONTROL_PRECISION_DEFAULT,\
 				},))					       \
+		IF_ENABLED(UARTE_PINS_CROSS_DOMAIN(_, /*empty*/, idx, _),      \
+			(.cross_domain = true,				       \
+			 .default_port =				       \
+				DT_PROP_OR(DT_PHANDLE(UARTE(idx),	       \
+					default_gpio_port), port, -1),))       \
 	};								       \
 	UARTE_DIRECT_ISR_DECLARE(idx)					       \
 	static int uarte_##idx##_init(const struct device *dev)		       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -43,6 +43,16 @@ LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 #define SPI_BUFFER_IN_RAM 1
 #endif
 
+/*
+ * We use NODELABEL here because the nrfx API requires us to call
+ * functions which are named according to SoC peripheral instance
+ * being operated on. Since DT_INST() makes no guarantees about that,
+ * it won't work.
+ */
+#define SPIM(idx)			DT_NODELABEL(spi##idx)
+#define SPIM_PROP(idx, prop)		DT_PROP(SPIM(idx), prop)
+#define SPIM_HAS_PROP(idx, prop)	DT_NODE_HAS_PROP(SPIM(idx), prop)
+
 #if defined(CONFIG_CLOCK_CONTROL_NRF_HSFLL_GLOBAL)
 #define SPIM_REQUESTS_CLOCK(node) \
 	DT_NODE_HAS_COMPAT(DT_CLOCKS_CTLR(node), nordic_nrf_hsfll_global)
@@ -58,6 +68,28 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_PM_DEVICE_SYSTEM_MANAGED));
 #else
 #define SPIM_REQUESTS_CLOCK(node) 0
 #endif
+
+#define SPIM_PINS_CROSS_DOMAIN(unused, prefix, idx, _)			\
+	COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(SPIM(prefix##idx)),		\
+		   (SPIM_PROP(idx, cross_domain_pins_supported)),	\
+		   (0))
+
+#if NRFX_FOREACH_PRESENT(SPIM, SPIM_PINS_CROSS_DOMAIN, (||), (0))
+#include <hal/nrf_gpio.h>
+/* Certain SPIM instances support usage of cross domain pins in form of dedicated pins on
+ * a port different from the default one.
+ */
+#define SPIM_CROSS_DOMAIN_SUPPORTED 1
+#endif
+
+#if SPIM_CROSS_DOMAIN_SUPPORTED && defined(CONFIG_NRF_SYS_EVENT)
+#include <nrf_sys_event.h>
+/* To use cross domain pins, constant latency mode needs to be applied, which is
+ * handled via nrf_sys_event requests.
+ */
+#define SPIM_CROSS_DOMAIN_PINS_HANDLE 1
+#endif
+
 
 struct spi_nrfx_data {
 	struct spi_context ctx;
@@ -97,6 +129,10 @@ struct spi_nrfx_config {
 #ifdef USE_CLOCK_REQUESTS
 	const struct device *clk_dev;
 	struct nrf_clock_spec clk_spec;
+#endif
+#if SPIM_CROSS_DOMAIN_SUPPORTED
+	bool cross_domain;
+	int8_t default_port;
 #endif
 };
 
@@ -146,6 +182,32 @@ static inline void release_clock(const struct device *dev)
 	ARG_UNUSED(dev);
 #endif
 }
+
+#if SPIM_CROSS_DOMAIN_SUPPORTED
+static bool spim_has_cross_domain_connection(const struct spi_nrfx_config *config)
+{
+	const struct pinctrl_dev_config *pcfg = config->pcfg;
+	const struct pinctrl_state *state;
+	int ret;
+
+	ret = pinctrl_lookup_state(pcfg, PINCTRL_STATE_DEFAULT, &state);
+	if (ret < 0) {
+		LOG_ERR("Unable to read pin state");
+		return false;
+	}
+
+	for (uint8_t i = 0U; i < state->pin_cnt; i++) {
+		uint32_t pin = NRF_GET_PIN(state->pins[i]);
+
+		if ((pin != NRF_PIN_DISCONNECTED) &&
+		    (nrf_gpio_pin_port_number_extract(&pin) != config->default_port)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif
 
 static inline void finalize_spi_transaction(const struct device *dev, bool deactivate_cs)
 {
@@ -685,6 +747,19 @@ static int spim_resume(const struct device *dev)
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	nrf_gpd_retain_pins_set(dev_config->pcfg, false);
 #endif
+#if SPIM_CROSS_DOMAIN_SUPPORTED
+	if (dev_config->cross_domain && spim_has_cross_domain_connection(dev_config)) {
+#if SPIM_CROSS_DOMAIN_PINS_HANDLE
+		int err;
+
+		err = nrf_sys_event_request_global_constlat();
+		(void)err;
+		__ASSERT_NO_MSG(err >= 0);
+#else
+		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
+#endif
+	}
+#endif
 
 	return pm_device_runtime_is_enabled(dev) ? request_clock(dev) : 0;
 }
@@ -707,6 +782,19 @@ static void spim_suspend(const struct device *dev)
 
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	nrf_gpd_retain_pins_set(dev_config->pcfg, true);
+#endif
+#if SPIM_CROSS_DOMAIN_SUPPORTED
+	if (dev_config->cross_domain && spim_has_cross_domain_connection(dev_config)) {
+#if SPIM_CROSS_DOMAIN_PINS_HANDLE
+		int err;
+
+		err = nrf_sys_event_request_global_constlat();
+		(void)err;
+		__ASSERT_NO_MSG(err >= 0);
+#else
+		__ASSERT(false, "NRF_SYS_EVENT needs to be enabled to use cross domain pins.\n");
+#endif
+	}
 #endif
 
 	(void)pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_SLEEP);
@@ -787,15 +875,6 @@ static int spi_nrfx_deinit(const struct device *dev)
 	return 0;
 }
 
-/*
- * We use NODELABEL here because the nrfx API requires us to call
- * functions which are named according to SoC peripheral instance
- * being operated on. Since DT_INST() makes no guarantees about that,
- * it won't work.
- */
-#define SPIM(idx)			DT_NODELABEL(spi##idx)
-#define SPIM_PROP(idx, prop)		DT_PROP(SPIM(idx), prop)
-#define SPIM_HAS_PROP(idx, prop)	DT_NODE_HAS_PROP(SPIM(idx), prop)
 #define SPIM_MEM_REGION(idx)		DT_PHANDLE(SPIM(idx), memory_regions)
 
 #define SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)				\
@@ -887,6 +966,11 @@ static int spi_nrfx_deinit(const struct device *dev)
 			 .clk_spec = {					       \
 				.frequency = NRF_CLOCK_CONTROL_FREQUENCY_MAX,  \
 			 },))						       \
+		IF_ENABLED(SPIM_PINS_CROSS_DOMAIN(_, /*empty*/, idx, _),       \
+			(.cross_domain = true,				       \
+			 .default_port =				       \
+				DT_PROP_OR(DT_PHANDLE(SPIM(idx),	       \
+					default_gpio_port), port, -1),))       \
 	};								       \
 	BUILD_ASSERT(!SPIM_HAS_PROP(idx, wake_gpios) ||			       \
 		     !(DT_GPIO_FLAGS(SPIM(idx), wake_gpios) & GPIO_ACTIVE_LOW),\

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -14,3 +14,13 @@ properties:
     type: boolean
     description: |
       UARTE has RX frame timeout HW feature.
+
+  default-gpio-port:
+    type: phandle
+    description: |
+      UARTE default GPIO port.
+
+  cross-domain-pins-supported:
+    type: boolean
+    description: |
+      UARTE allows usage of cross domain pins with constant latency mode required.

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -61,3 +61,13 @@ properties:
         and SPI master again keeps the line in the low state
       Please note that the line must be configured and properly handled on
       both sides for the mechanism to work correctly.
+
+  default-gpio-port:
+    type: phandle
+    description: |
+      SPI default GPIO port.
+
+  cross-domain-pins-supported:
+    type: boolean
+    description: |
+      SPI allows usage of cross domain pins with constant latency mode required.

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -320,6 +320,8 @@
 				status = "disabled";
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				default-gpio-port = <&gpio1>;
+				cross-domain-pins-supported;
 			};
 
 			i2c21: i2c@c7000 {
@@ -359,6 +361,8 @@
 				status = "disabled";
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				default-gpio-port = <&gpio1>;
+				cross-domain-pins-supported;
 			};
 
 			i2c22: i2c@c8000 {

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -311,6 +311,8 @@
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
+				default-gpio-port = <&gpio1>;
+				cross-domain-pins-supported;
 			};
 
 			uart20: uart@c6000 {
@@ -352,6 +354,8 @@
 				rx-delay-supported;
 				rx-delay = <1>;
 				status = "disabled";
+				default-gpio-port = <&gpio1>;
+				cross-domain-pins-supported;
 			};
 
 			uart21: uart@c7000 {

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi21_default_alt: spi21_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+				<NRF_PSEL(SPIM_MISO, 2, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+		};
+	};
+
+	spi21_sleep_alt: spi21_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 2, 6)>,
+				<NRF_PSEL(SPIM_MISO, 2, 9)>,
+				<NRF_PSEL(SPIM_MOSI, 2, 8)>;
+			low-power-enable;
+		};
+	};
+
+	spi22_default_alt: spi22_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 11)>,
+				<NRF_PSEL(SPIS_MISO, 1, 13)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 12)>,
+				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+		};
+	};
+
+	spi22_sleep_alt: spi22_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 1, 11)>,
+				<NRF_PSEL(SPIS_MISO, 1, 13)>,
+				<NRF_PSEL(SPIS_MOSI, 1, 12)>,
+				<NRF_PSEL(SPIS_CSN, 1, 14)>;
+			low-power-enable;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi21 {
+	status = "okay";
+	pinctrl-0 = <&spi21_default_alt>;
+	pinctrl-1 = <&spi21_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+	zephyr,pm-device-runtime-auto;
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(1)>;
+	};
+};
+
+dut_spis: &spi22 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spi22_default_alt>;
+	pinctrl-1 = <&spi22_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	/delete-property/rx-delay-supported;
+	/delete-property/rx-delay;
+};

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -89,3 +89,18 @@ tests:
       - CONFIG_PM_DEVICE=y
       - CONFIG_PM_DEVICE_RUNTIME=y
     filter: CONFIG_SOC_FAMILY_NORDIC_NRF
+
+  drivers.spi.spi_cross_domain:
+    harness_config:
+      fixture: spi_p1_p2_loopback
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=0
+      - CONFIG_NRF_SYS_EVENT=y
+    extra_args: DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay"
+    platform_exclude:
+      - nrf52840dk/nrf52840
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr
+      - nrf54l20pdk/nrf54l20/cpuapp
+      - ophelia4ev/nrf54l15/cpuapp

--- a/tests/drivers/uart/uart_elementary/boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&pinctrl {
+	uart21_default: uart21_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 8)>,
+				<NRF_PSEL(UART_RX, 2, 7)>,
+				<NRF_PSEL(UART_RTS, 2, 10)>,
+				<NRF_PSEL(UART_CTS, 2, 9)>;
+		};
+	};
+
+	uart21_sleep: uart21_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 2, 8)>,
+				<NRF_PSEL(UART_RX, 2, 7)>,
+				<NRF_PSEL(UART_RTS, 2, 10)>,
+				<NRF_PSEL(UART_CTS, 2, 9)>;
+			low-power-enable;
+		};
+	};
+};
+
+dut: &uart21 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&uart21_default>;
+	pinctrl-1 = <&uart21_sleep>;
+	pinctrl-names = "default", "sleep";
+	hw-flow-control;
+};

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -113,3 +113,12 @@ tests:
     extra_configs:
       - CONFIG_DUAL_UART_TEST=y
       - CONFIG_SETUP_MISMATCH_TEST=y
+  drivers.uart.uart_elementary_cross_domain:
+    filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
+    harness_config:
+      fixture: uart_p1_p2_loopback
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_args: DTC_OVERLAY_FILE="boards/nrf54l15dk_nrf54l15_cpuapp_cross_domain.overlay"
+    extra_configs:
+      - CONFIG_NRF_SYS_EVENT=y


### PR DESCRIPTION
UARTE20, UARTE21, SPI(M/S)20 and SPIM(M/S)21 instances enable usage of pins on different port, but require request for constant latency mode. Added handling of such scenario in the driver. Added testcases to cover it.