### PR TITLE
drivers: modem: replace K_SPINLOCK macro where needed

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1111,6 +1111,7 @@ static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, siz
 	int ret;
 
 	k_spinlock_key_t key = k_spin_lock(&cmux->work_lock);
+
 	if (!cmux->attached) {
 		ret = -EPERM;
 		k_spin_unlock(&cmux->work_lock, key);
@@ -1127,6 +1128,7 @@ static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, siz
 	};
 
 	ret = modem_cmux_transmit_data_frame(cmux, &frame);
+	
 	k_spin_unlock(&cmux->work_lock, key);
 
 	return ret;

--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -1128,7 +1128,7 @@ static int modem_cmux_dlci_pipe_api_transmit(void *data, const uint8_t *buf, siz
 	};
 
 	ret = modem_cmux_transmit_data_frame(cmux, &frame);
-	
+
 	k_spin_unlock(&cmux->work_lock, key);
 
 	return ret;

--- a/subsys/modem/modem_pipelink.c
+++ b/subsys/modem/modem_pipelink.c
@@ -30,7 +30,9 @@ bool modem_pipelink_is_connected(struct modem_pipelink *link)
 	bool connected;
 
 	k_spinlock_key_t key = k_spin_lock(&link->spinlock);
+
 	connected = link->connected;
+	
 	k_spin_unlock(&link->spinlock, key);
 
 	return connected;

--- a/subsys/modem/modem_pipelink.c
+++ b/subsys/modem/modem_pipelink.c
@@ -32,7 +32,7 @@ bool modem_pipelink_is_connected(struct modem_pipelink *link)
 	k_spinlock_key_t key = k_spin_lock(&link->spinlock);
 
 	connected = link->connected;
-	
+
 	k_spin_unlock(&link->spinlock, key);
 
 	return connected;

--- a/subsys/modem/modem_pipelink.c
+++ b/subsys/modem/modem_pipelink.c
@@ -29,9 +29,9 @@ bool modem_pipelink_is_connected(struct modem_pipelink *link)
 {
 	bool connected;
 
-	K_SPINLOCK(&link->spinlock) {
-		connected = link->connected;
-	}
+	k_spinlock_key_t key = k_spin_lock(&link->spinlock);
+	connected = link->connected;
+	k_spin_unlock(&link->spinlock, key);
 
 	return connected;
 }

--- a/subsys/modem/modem_stats.c
+++ b/subsys/modem/modem_stats.c
@@ -35,7 +35,9 @@ static struct modem_stats_buffer *stats_buffer_list_first(void)
 	struct modem_stats_buffer *first;
 
 	k_spinlock_key_t key = k_spin_lock(&stats_buffer_lock);
+
 	first = stats_buffer_from_node(sys_slist_peek_head(&stats_buffer_list));
+
 	k_spin_unlock(&stats_buffer_lock, key);
 
 	return first;
@@ -46,7 +48,9 @@ static struct modem_stats_buffer *stats_buffer_list_next(struct modem_stats_buff
 	struct modem_stats_buffer *next;
 
 	k_spinlock_key_t key = k_spin_lock(&stats_buffer_lock);
+
 	next = stats_buffer_from_node(sys_slist_peek_next(&buffer->node));
+	
 	k_spin_unlock(&stats_buffer_lock, key);
 
 	return next;

--- a/subsys/modem/modem_stats.c
+++ b/subsys/modem/modem_stats.c
@@ -50,7 +50,7 @@ static struct modem_stats_buffer *stats_buffer_list_next(struct modem_stats_buff
 	k_spinlock_key_t key = k_spin_lock(&stats_buffer_lock);
 
 	next = stats_buffer_from_node(sys_slist_peek_next(&buffer->node));
-	
+
 	k_spin_unlock(&stats_buffer_lock, key);
 
 	return next;

--- a/subsys/modem/modem_stats.c
+++ b/subsys/modem/modem_stats.c
@@ -32,22 +32,22 @@ static void stats_buffer_list_append(struct modem_stats_buffer *buffer)
 
 static struct modem_stats_buffer *stats_buffer_list_first(void)
 {
-	struct modem_stats_buffer *first = NULL;
+	struct modem_stats_buffer *first;
 
-	K_SPINLOCK(&stats_buffer_lock) {
-		first = stats_buffer_from_node(sys_slist_peek_head(&stats_buffer_list));
-	}
+	k_spinlock_key_t key = k_spin_lock(&stats_buffer_lock);
+	first = stats_buffer_from_node(sys_slist_peek_head(&stats_buffer_list));
+	k_spin_unlock(&stats_buffer_lock, key);
 
 	return first;
 }
 
 static struct modem_stats_buffer *stats_buffer_list_next(struct modem_stats_buffer *buffer)
 {
-	struct modem_stats_buffer *next = NULL;
+	struct modem_stats_buffer *next;
 
-	K_SPINLOCK(&stats_buffer_lock) {
-		next = stats_buffer_from_node(sys_slist_peek_next(&buffer->node));
-	}
+	k_spinlock_key_t key = k_spin_lock(&stats_buffer_lock);
+	next = stats_buffer_from_node(sys_slist_peek_next(&buffer->node));
+	k_spin_unlock(&stats_buffer_lock, key);
 
 	return next;
 }


### PR DESCRIPTION
This PR is related to the following Zephyr PR:
https://github.com/zephyrproject-rtos/zephyr/pull/81431
Some compilers (e.g. arm-zephyr-eabi-gcc) don't understand
the K_SPINLOCK() macro and therefore do warn about
uninitialized variables in the modem related modules.
Fix: Replaced the K_SPINLOCK macro with explicit k_spin_lock/k_spin_unlock calls
only at relevant locations in the modem subsystem.

Signed-off-by: Fabian Kainka <f.kainka@gmx.de>