### PR TITLE
soc: power: Add ELS and PKC reinit when resuming from PM3

### DIFF
--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -14,6 +14,11 @@
 
 #include "fsl_power.h"
 
+#ifdef CONFIG_MCUX_ELS_PKC
+#include "mcux_els.h"
+#include "mcux_pkc.h"
+#endif
+
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/timer/system_timer.h>
 
@@ -192,7 +197,10 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			restore_mpu_state();
 #endif /* CONFIG_MPU */
 			clock_init();
-
+#ifdef CONFIG_MCUX_ELS_PKC
+			ELS_PowerDownWakeupInit(ELS);
+			PKC_PowerDownWakeupInit(PKC);
+#endif /* CONFIG_MCUX_ELS_PKC */
 			sys_clock_idle_exit();
 		}
 


### PR DESCRIPTION
After resuming from PM3, need to reinit ELS and PKC because some modules might use ELS and PKC for crypto.