### PR TITLE
drivers: dp: use atomic APIs for pin set/reset

### DIFF
--- a/drivers/dp/swdp_ll_pin.h
+++ b/drivers/dp/swdp_ll_pin.h
@@ -12,13 +12,12 @@ static ALWAYS_INLINE void pin_delay_asm(uint32_t delay)
 {
 #if defined(CONFIG_CPU_CORTEX_M)
 	__asm volatile (".syntax unified\n"
-			"movs r3, %[p]\n"
 			".start_%=:\n"
-			"subs r3, #1\n"
+			"subs %0, #1\n"
 			"bne .start_%=\n"
+			: "+l" (delay)
 			:
-			: [p] "r" (delay)
-			: "r3", "cc"
+			: "cc"
 			);
 #else
 #warning "Pin delay is not defined"

--- a/drivers/dp/swdp_ll_pin_stm32.h
+++ b/drivers/dp/swdp_ll_pin_stm32.h
@@ -35,29 +35,15 @@ static ALWAYS_INLINE void swdp_ll_pin_output(void *const base, uint8_t pin)
 static ALWAYS_INLINE void swdp_ll_pin_set(void *const base, uint8_t pin)
 {
 	GPIO_TypeDef *gpio = base;
-	uint32_t val;
 
-	z_stm32_hsem_lock(CFG_HW_GPIO_SEMID, HSEM_LOCK_DEFAULT_RETRY);
-
-	val = LL_GPIO_ReadOutputPort(gpio);
-	val |= BIT(pin);
-	LL_GPIO_WriteOutputPort(gpio, val);
-
-	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);
+	LL_GPIO_SetOutputPin(gpio, BIT(pin));
 }
 
 static ALWAYS_INLINE void swdp_ll_pin_clr(void *const base, uint8_t pin)
 {
 	GPIO_TypeDef *gpio = base;
-	uint32_t val;
 
-	z_stm32_hsem_lock(CFG_HW_GPIO_SEMID, HSEM_LOCK_DEFAULT_RETRY);
-
-	val = LL_GPIO_ReadOutputPort(gpio);
-	val &= ~BIT(pin);
-	LL_GPIO_WriteOutputPort(gpio, val);
-
-	z_stm32_hsem_unlock(CFG_HW_GPIO_SEMID);
+	LL_GPIO_ResetOutputPin(gpio, BIT(pin));
 }
 
 static ALWAYS_INLINE uint32_t swdp_ll_pin_get(void *const base, uint8_t pin)


### PR DESCRIPTION
Use LL_GPIO_SetOutputPin and LL_GPIO_ResetOutputPin for the STM32 optimized DP functions. This yelds a speedup of the bit-banged interface from about 585kHz to 640kHz on an STM32C0.