### PR TITLE
tests: arch: arm_irq_vector_table: Fix IRQ number used by nRF GRTC

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -163,7 +163,7 @@ void timer0_nrf_isr(void);
 	defined(CONFIG_SOC_SERIES_NRF92X)
 void nrfx_grtc_irq_handler(void);
 #define TIMER_IRQ_HANDLER nrfx_grtc_irq_handler
-#define TIMER_IRQ_NUM     GRTC_0_IRQn
+#define TIMER_IRQ_NUM     DT_IRQN(DT_NODELABEL(grtc))
 #else
 void rtc_nrf_isr(void);
 #define TIMER_IRQ_HANDLER rtc_nrf_isr


### PR DESCRIPTION
Instead of using hard-coded GRTC_0_IRQn value, obtain information from DT to get the IRQ number actually used by the nrf_grtc_timer driver.

Fixes #90127.