### PR TITLE
boards: atmel: samx7x add hsmci peripheral

### DIFF
--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -17,6 +17,7 @@
 		led0 = &green_led;
 		sw0 = &sw0_user_button;
 		watchdog0 = &wdt;
+		sdhc0 = &hsmci;
 	};
 
 	chosen {
@@ -236,5 +237,19 @@ zephyr_udc0: &usbhs {
 	qdec3: qdec {
 		pinctrl-0 = <&qdec3_default>;
 		pinctrl-names = "default";
+	};
+};
+
+&hsmci {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&hsmci_default>;
+	cd-gpios = <&pioc 16 GPIO_ACTIVE_LOW>;
+
+	mmc {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
 	};
 };

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained-pinctrl.dtsi
@@ -182,4 +182,15 @@
 				 <PD17B_USART2_SCK>;
 		};
 	};
+
+	hsmci_default: hsmci_default {
+		group1 {
+			pinmux = <PA28C_HSMCI_MCCDA>,
+				 <PA25D_HSMCI_MCCK>,
+				 <PA30C_HSMCI_MCDA0>,
+				 <PA31C_HSMCI_MCDA1>,
+				 <PA26C_HSMCI_MCDA2>,
+				 <PA27C_HSMCI_MCDA3>;
+		};
+	};
 };

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.yaml
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21.yaml
@@ -18,6 +18,7 @@ supported:
   - i2s
   - pwm
   - netif:eth
+  - sdhc
   - spi
   - usb_device
   - watchdog

--- a/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21b.yaml
+++ b/boards/atmel/sam/sam_e70_xplained/sam_e70_xplained_same70q21b.yaml
@@ -18,6 +18,7 @@ supported:
   - i2s
   - pwm
   - netif:eth
+  - sdhc
   - spi
   - usb_device
   - watchdog

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -21,6 +21,7 @@
 		sw0 = &sw0_user_button;
 		sw1 = &sw1_user_button;
 		watchdog0 = &wdt;
+		sdhc0 = &hsmci;
 	};
 
 	chosen {
@@ -339,6 +340,20 @@ zephyr_udc0: &usbhs {
 
 &rtc {
 	status = "okay";
+};
+
+&hsmci {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&hsmci_default>;
+	cd-gpios = <&piod 18 GPIO_ACTIVE_LOW>;
+
+	mmc {
+		compatible = "zephyr,sdmmc-disk";
+		disk-name = "SD";
+		status = "okay";
+	};
 };
 
 ext1_spi: &spi0 {

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-pinctrl.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-pinctrl.dtsi
@@ -153,4 +153,15 @@
 				 <PD19B_USART2_CTS>;
 		};
 	};
+
+	hsmci_default: hsmci_default {
+		group1 {
+			pinmux = <PA28C_HSMCI_MCCDA>,
+				 <PA25D_HSMCI_MCCK>,
+				 <PA30C_HSMCI_MCDA0>,
+				 <PA31C_HSMCI_MCDA1>,
+				 <PA26C_HSMCI_MCDA2>,
+				 <PA27C_HSMCI_MCDA3>;
+		};
+	};
 };

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21.yaml
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21.yaml
@@ -22,6 +22,7 @@ supported:
   - pwm
   - netif:eth
   - rtc
+  - sdhc
   - spi
   - usb_device
   - watchdog

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21b.yaml
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult_samv71q21b.yaml
@@ -22,6 +22,7 @@ supported:
   - pwm
   - netif:eth
   - rtc
+  - sdhc
   - spi
   - usb_device
   - watchdog

--- a/dts/arm/atmel/samx7x.dtsi
+++ b/dts/arm/atmel/samx7x.dtsi
@@ -46,6 +46,13 @@
 	};
 
 	soc {
+		hsmci: hsmci@40000000 {
+			compatible = "atmel,sam-hsmci";
+			reg = <0x40000000 0x4000>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 18>;
+			status = "disabled";
+		};
+
 		ssc: ssc@40004000 {
 			compatible = "atmel,sam-ssc";
 			reg = <0x40004000 0x4000>;


### PR DESCRIPTION
Adds samx7x hsmci peripheral according to datasheet sections 10-1 and 14.1: https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/DataSheets/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527.pdf

Updates sam_e70_xplained overlay to include pin mapping to the SD card connected to the hsmci and adds sdhc0 alias.

Relevant https://github.com/zephyrproject-rtos/zephyr/issues/18614