### PR TITLE
samples: bluetooth: fix adv_update error in bthome_sensor_template

### DIFF
--- a/samples/bluetooth/bthome_sensor_template/src/main.c
+++ b/samples/bluetooth/bthome_sensor_template/src/main.c
@@ -34,23 +34,6 @@ static struct bt_data ad[] = {
 	BT_DATA(BT_DATA_SVC_DATA16, service_data, ARRAY_SIZE(service_data))
 };
 
-static void bt_ready(int err)
-{
-	if (err) {
-		printk("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
-
-	printk("Bluetooth initialized\n");
-
-	/* Start advertising */
-	err = bt_le_adv_start(ADV_PARAM, ad, ARRAY_SIZE(ad), NULL, 0);
-	if (err) {
-		printk("Advertising failed to start (err %d)\n", err);
-		return;
-	}
-}
-
 int main(void)
 {
 	int err;
@@ -59,9 +42,18 @@ int main(void)
 	printk("Starting BTHome sensor template\n");
 
 	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(bt_ready);
+	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
+		return 0;
+	}
+
+	printk("Bluetooth initialized\n");
+
+	/* Start advertising */
+	err = bt_le_adv_start(ADV_PARAM, ad, ARRAY_SIZE(ad), NULL, 0);
+	if (err) {
+		printk("Advertising failed to start (err %d)\n", err);
 		return 0;
 	}
 


### PR DESCRIPTION
Issue:
"bt_le_adv_update_data()" func calls just after bt_enable() call without completion of bt_ready() which is called as part of worker thread within init_work() causes issue where bluetooth controller has not been initialized and provides cb to app before app requests advertise_update to the stack.

Solution:
Calling bt_ready() in the same thread of bt_enable() fixes this issue.