### PR TITLE
maintainers: NXP Wireless: add mcxw driver filter

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3829,10 +3829,12 @@ NXP Wireless:
   collaborators:
     - MaochenWang1
     - axelnxp
+    - George-Stefan
   files:
     - drivers/wifi/nxp/
     - drivers/bluetooth/hci/*nxp*
     - drivers/ieee802154/ieee802154_kw41z.c
+    - drivers/*/*mcxw*.c
   labels:
     - "platform: NXP Drivers"
 


### PR DESCRIPTION
- Add mcxw filter to catch changes to drivers/ieee802154/ieee802154_mcxw.c
- Add George-Stefan as a collaborator for NXP Wireless
