### PR TITLE
Tidy-ups to gen_relocate_app.py

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -234,7 +234,6 @@
 ]
 "./scripts/build/gen_relocate_app.py" = [
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
-    "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
     "UP037",    # https://docs.astral.sh/ruff/rules/quoted-annotation

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -235,7 +235,6 @@
 "./scripts/build/gen_relocate_app.py" = [
     "B028",     # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
-    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
@@ -1476,7 +1475,6 @@ exclude = [
     "./scripts/build/gen_kobject_list.py",
     "./scripts/build/gen_kobject_placeholders.py",
     "./scripts/build/gen_offset_header.py",
-    "./scripts/build/gen_relocate_app.py",
     "./scripts/build/gen_strerror_table.py",
     "./scripts/build/gen_strsignal_table.py",
     "./scripts/build/gen_symtab.py",

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -234,7 +234,6 @@
 ]
 "./scripts/build/gen_relocate_app.py" = [
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
-    "UP037",    # https://docs.astral.sh/ruff/rules/quoted-annotation
 ]
 "./scripts/build/gen_strerror_table.py" = [
     "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -234,7 +234,6 @@
 ]
 "./scripts/build/gen_relocate_app.py" = [
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
-    "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
     "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -233,7 +233,6 @@
     "UP031",    # https://docs.astral.sh/ruff/rules/printf-string-formatting
 ]
 "./scripts/build/gen_relocate_app.py" = [
-    "B028",     # https://docs.astral.sh/ruff/rules/no-explicit-stacklevel
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -234,8 +234,6 @@
 ]
 "./scripts/build/gen_relocate_app.py" = [
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
-    "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation
-    "UP035",    # https://docs.astral.sh/ruff/rules/deprecated-import
     "UP037",    # https://docs.astral.sh/ruff/rules/quoted-annotation
 ]
 "./scripts/build/gen_strerror_table.py" = [

--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -234,7 +234,6 @@
 ]
 "./scripts/build/gen_relocate_app.py" = [
     "E101",     # https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
     "SIM102",   # https://docs.astral.sh/ruff/rules/collapsible-if
     "SIM401",   # https://docs.astral.sh/ruff/rules/if-else-block-instead-of-dict-get
     "UP006",    # https://docs.astral.sh/ruff/rules/non-pep585-annotation

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -333,7 +333,7 @@ def print_linker_sections(list_sections: 'list[OutputSection]'):
 
 
 def add_phdr(memory_type, phdrs):
-    return f'{memory_type} {phdrs[memory_type] if memory_type in phdrs else ""}'
+    return f'{memory_type} {phdrs.get(memory_type, "")}'
 
 
 def string_create_helper(

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -643,7 +643,7 @@ def main():
     sram_data_linker_file = args.output_sram_data
     sram_bss_linker_file = args.output_sram_bss
     rel_dict, phdrs = create_dict_wrt_mem()
-    complete_list_of_sections: 'dict[MemoryRegion, dict[SectionKind, list[OutputSection]]]' = (
+    complete_list_of_sections: dict[MemoryRegion, dict[SectionKind, list[OutputSection]]] = (
         defaultdict(lambda: defaultdict(list))
     )
 
@@ -652,7 +652,7 @@ def main():
 
     # for each memory_type, create text/rodata/data/bss sections for all obj files
     for memory_type, files in rel_dict.items():
-        full_list_of_sections: 'dict[SectionKind, list[OutputSection]]' = defaultdict(list)
+        full_list_of_sections: dict[SectionKind, list[OutputSection]] = defaultdict(list)
 
         for filename, symbol_filter in files:
             obj_filename = get_obj_filename(all_obj_files, filename)

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -551,9 +551,8 @@ def get_obj_filename(all_obj_files, filename):
     obj_filename = filename.split("/")[-1] + ".obj"
 
     for obj_file in all_obj_files:
-        if obj_file.name == obj_filename:
-            if filename.split("/")[-2] in obj_file.parent.name:
-                return str(obj_file)
+        if obj_file.name == obj_filename and filename.split("/")[-2] in obj_file.parent.name:
+            return str(obj_file)
 
 
 # Extracts all possible components for the input string:

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -49,9 +49,7 @@ import warnings
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import NamedTuple
-from typing import NewType
-from typing import Tuple
+from typing import NamedTuple, NewType, Tuple
 
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -49,7 +49,7 @@ import warnings
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import NamedTuple, NewType, Tuple
+from typing import NamedTuple, NewType
 
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
@@ -297,7 +297,7 @@ def assign_to_correct_mem_region(
     return {MemoryRegion(memory_region): output_sections}
 
 
-def section_kinds_from_memory_region(memory_region: str) -> 'Tuple[set[SectionKind], str]':
+def section_kinds_from_memory_region(memory_region: str) -> 'tuple[set[SectionKind], str]':
     """
     Get the section kinds requested by the given memory region name.
 

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -266,7 +266,8 @@ def find_sections(filename: str, symbol_filter: str) -> 'dict[SectionKind, list[
                     warnings.warn(
                         "Common variable found. Move "
                         + symbol.name
-                        + " to bss by assigning it to 0/NULL"
+                        + " to bss by assigning it to 0/NULL",
+                        stacklevel=2,
                     )
 
     return out
@@ -608,10 +609,12 @@ def create_dict_wrt_mem():
         for file_glob in file_list:
             glob_results = glob.glob(file_glob)
             if not glob_results:
-                warnings.warn("File: " + file_glob + " Not found")
+                warnings.warn("File: " + file_glob + " Not found", stacklevel=2)
                 continue
             elif len(glob_results) > 1:
-                warnings.warn("Regex in file lists is deprecated, please use file(GLOB) instead")
+                warnings.warn(
+                    "Regex in file lists is deprecated, please use file(GLOB) instead", stacklevel=2
+                )
             file_name_list.extend(glob_results)
         if len(file_name_list) == 0:
             continue

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -41,10 +41,10 @@ Multiple regions can be appended together like SRAM2_DATA_BSS
 this will place data and bss inside SRAM2.
 """
 
-import sys
 import argparse
 import glob
 import re
+import sys
 import warnings
 from collections import defaultdict
 from enum import Enum

--- a/scripts/build/gen_relocate_app.py
+++ b/scripts/build/gen_relocate_app.py
@@ -405,21 +405,28 @@ def generate_linker_script(
             )
 
         gen_string += string_create_helper(
-            SectionKind.LITERAL, memory_type, full_list_of_sections, 1, is_copy, phdrs
+            SectionKind.LITERAL,
+            memory_type,
+            full_list_of_sections,
+            True,
+            is_copy,
+            phdrs,
         )
         gen_string += string_create_helper(
-            SectionKind.TEXT, memory_type, full_list_of_sections, 1, is_copy, phdrs
+            SectionKind.TEXT, memory_type, full_list_of_sections, True, is_copy, phdrs
         )
         gen_string += string_create_helper(
-            SectionKind.RODATA, memory_type, full_list_of_sections, 1, is_copy, phdrs
+            SectionKind.RODATA, memory_type, full_list_of_sections, True, is_copy, phdrs
         )
 
         if region_is_default_ram(memory_type) and is_copy:
             gen_string += MPU_RO_REGION_END.format(mem=memory_type.lower())
 
         data_sections = string_create_helper(
-            SectionKind.DATA, memory_type, full_list_of_sections, 1, 1, phdrs
-        ) + string_create_helper(SectionKind.BSS, memory_type, full_list_of_sections, 0, 1, phdrs)
+            SectionKind.DATA, memory_type, full_list_of_sections, True, True, phdrs
+        ) + string_create_helper(
+            SectionKind.BSS, memory_type, full_list_of_sections, False, True, phdrs
+        )
 
         if region_is_default_ram(memory_type):
             gen_string_sram_data += data_sections


### PR DESCRIPTION
  * Apply Ruff code formatting
  * Various code conciseness improvements
  * Use named fields in string template to improve clarity
  * Use `bool` when applicable instead of `int`
  * Fix all ruff linting warnings with the exception of E101.