### PR TITLE
kernel/init: Corrected a typo

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -256,7 +256,7 @@ z_early_memset(&_nocache_ram_start, 0,
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION
 /**
- * @brief Clear BSS within the bot region
+ * @brief Clear BSS within the boot region
  *
  * This routine clears the BSS within the boot region.
  * This is separate from z_bss_zero() as boot region may


### PR DESCRIPTION
"bot region" should read "boot region".