### PR TITLE
include: usb_ch9: ensure packing of `usb_setup_packet`

### DIFF
--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -41,12 +41,12 @@ struct usb_setup_packet {
 	union {
 		uint8_t bmRequestType;
 		struct usb_req_type_field RequestType;
-	};
+	} __packed;
 	uint8_t bRequest;
 	uint16_t wValue;
 	uint16_t wIndex;
 	uint16_t wLength;
-};
+} __packed;
 
 /** USB Setup packet RequestType Direction values (from Table 9-2) */
 #define USB_REQTYPE_DIR_TO_DEVICE	0


### PR DESCRIPTION
`struct usb_setup_packet` represents the setup data payload of a USB control message which is exactly 8-bytes in length.

On a legacy build of GCC 4.1.2 for an OpenRISC-like architecture it was found that the compiler added padding after the `bmRequestType` anonymous union, and subsequently the `bRequest` field causing the structure to be padded to 12-bytes in length with the fields incorrectly laid out.

This patch corrects the issue by applying the `__packed` attribute to the anonymous union. This corrects the issue.

The `__packed` attribute is also applied to the outer structure for the sake of consistency.