### PR TITLE
drivers: led: Provide a fallback implementation of blink API

### DIFF
--- a/drivers/led/CMakeLists.txt
+++ b/drivers/led/CMakeLists.txt
@@ -25,6 +25,8 @@ zephyr_library_sources_ifdef(CONFIG_PCA9633 pca9633.c)
 zephyr_library_sources_ifdef(CONFIG_TLC59108 tlc59108.c)
 # zephyr-keep-sorted-stop
 
+zephyr_library_sources(led_core.c)
+
 zephyr_library_sources_ifdef(CONFIG_LED_SHELL   led_shell.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   led_handlers.c)

--- a/drivers/led/Kconfig
+++ b/drivers/led/Kconfig
@@ -26,6 +26,12 @@ config LED_SHELL
 	help
 	  Enable LED shell for testing.
 
+config LED_BLINK_SOFTWARE
+	bool "LED Blink fallback"
+	help
+	  Provides a software implementation of LED blink API.
+	  This could be used when the LED controller doesn't support blinking.
+
 # zephyr-keep-sorted-start
 source "drivers/led/Kconfig.axp192"
 source "drivers/led/Kconfig.dac"

--- a/drivers/led/led_blink.h
+++ b/drivers/led/led_blink.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_LED_LED_BLINK_H_
+#define ZEPHYR_DRIVERS_LED_LED_BLINK_H_
+
+#define LED_BLINK_SOFTWARE_DATA_INIT(node_id) {}
+
+#define LED_BLINK_SOFTWARE_DATA(inst, name) \
+	COND_CODE_1(CONFIG_LED_BLINK_SOFTWARE, ( \
+	.name = (struct led_blink_software_data[]) {\
+		DT_INST_FOREACH_CHILD_SEP(inst, LED_BLINK_SOFTWARE_DATA_INIT, (,)) \
+	},), ())
+
+#ifdef CONFIG_LED_BLINK_SOFTWARE
+struct led_blink_software_data {
+	const struct device *dev;
+	uint32_t led;
+	struct k_work_delayable work;
+	uint32_t delay_on;
+	uint32_t delay_off;
+};
+
+int led_blink_software_start(const struct device *dev, uint32_t led, uint32_t delay_on,
+			     uint32_t delay_off);
+#else
+struct led_blink_software_data;
+static inline int led_blink_software_start(const struct device *dev, uint32_t led,
+					   uint32_t delay_on, uint32_t delay_off)
+{
+	return -ENOSYS;
+}
+#endif
+
+#endif /* ZEPHYR_DRIVERS_LED_LED_BLINK_H_ */

--- a/drivers/led/led_core.c
+++ b/drivers/led/led_core.c
@@ -5,8 +5,11 @@
  */
 
 #include <zephyr/drivers/led.h>
+#include <zephyr/kernel.h>
 
-int z_impl_led_on(const struct device *dev, uint32_t led)
+#include "led_blink.h"
+
+static int led_core_on(const struct device *dev, uint32_t led)
 {
 	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
 
@@ -21,7 +24,7 @@ int z_impl_led_on(const struct device *dev, uint32_t led)
 	return api->on(dev, led);
 }
 
-int z_impl_led_off(const struct device *dev, uint32_t led)
+static int led_core_off(const struct device *dev, uint32_t led)
 {
 	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
 
@@ -36,9 +39,109 @@ int z_impl_led_off(const struct device *dev, uint32_t led)
 	return api->off(dev, led);
 }
 
+#ifdef CONFIG_LED_BLINK_SOFTWARE
+static void led_blink_software_off(struct k_work *work);
+static struct led_blink_software_data *led_blink_software_get_data(const struct device *dev,
+								   uint32_t led)
+{
+	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
+
+	if (!api->get_blink_data) {
+		return NULL;
+	}
+
+	return api->get_blink_data(dev, led);
+}
+
+static void led_blink_software_on(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct led_blink_software_data *data =
+		CONTAINER_OF(dwork, struct led_blink_software_data, work);
+
+	led_core_on(data->dev, data->led);
+	k_work_init_delayable(&data->work, led_blink_software_off);
+	k_work_schedule(&data->work, K_MSEC(data->delay_on));
+}
+
+static void led_blink_software_off(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct led_blink_software_data *data =
+		CONTAINER_OF(dwork, struct led_blink_software_data, work);
+
+	led_core_off(data->dev, data->led);
+	k_work_init_delayable(&data->work, led_blink_software_on);
+	k_work_schedule(&data->work, K_MSEC(data->delay_off));
+}
+
+int led_blink_software_start(const struct device *dev, uint32_t led, uint32_t delay_on,
+			     uint32_t delay_off)
+{
+	struct led_blink_software_data *data;
+
+	data = led_blink_software_get_data(dev, led);
+	if (!data) {
+		return -EINVAL;
+	}
+
+	if (!delay_on && !delay_off) {
+		/* Default 1Hz blinking when delay_on and delay_off are 0 */
+		delay_on = 500;
+		delay_off = 500;
+	} else if (!delay_on) {
+		/* Always off */
+		led_core_off(dev, led);
+	} else if (!delay_off) {
+		/* Always on */
+		led_core_on(dev, led);
+	}
+
+	data->dev = dev;
+	data->led = led;
+	data->delay_on = delay_on;
+	data->delay_off = delay_off;
+
+	k_work_init_delayable(&data->work, led_blink_software_on);
+	return k_work_schedule(&data->work, K_NO_WAIT);
+}
+
+static void led_blink_software_stop(const struct device *dev, uint32_t led)
+{
+	struct led_blink_software_data *data;
+
+	data = led_blink_software_get_data(dev, led);
+	if (data) {
+		struct k_work_sync sync;
+
+		k_work_cancel_delayable_sync(&data->work, &sync);
+	}
+}
+#else
+static inline void led_blink_software_stop(const struct device *dev, uint32_t led)
+{
+}
+#endif /* CONFIG_LED_BLINK_SOFTWARE */
+
+int z_impl_led_on(const struct device *dev, uint32_t led)
+{
+	led_blink_software_stop(dev, led);
+	return led_core_on(dev, led);
+}
+
+int z_impl_led_off(const struct device *dev, uint32_t led)
+{
+	led_blink_software_stop(dev, led);
+	return led_core_off(dev, led);
+}
+
 int z_impl_led_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
 {
 	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
+
+	if (!value) {
+		led_blink_software_stop(dev, led);
+	}
 
 	if (api->set_brightness == NULL) {
 		if (api->on == NULL || api->off == NULL) {
@@ -66,7 +169,7 @@ int z_impl_led_blink(const struct device *dev, uint32_t led, uint32_t delay_on, 
 	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
 
 	if (api->blink == NULL) {
-		return -ENOSYS;
+		return led_blink_software_start(dev, led, delay_on, delay_off);
 	}
 	return api->blink(dev, led, delay_on, delay_off);
 }

--- a/drivers/led/led_core.c
+++ b/drivers/led/led_core.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/led.h>
+
+int z_impl_led_on(const struct device *dev, uint32_t led)
+{
+	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
+
+	if (api->set_brightness == NULL && api->on == NULL) {
+		return -ENOSYS;
+	}
+
+	if (api->on == NULL) {
+		return api->set_brightness(dev, led, LED_BRIGHTNESS_MAX);
+	}
+
+	return api->on(dev, led);
+}
+
+int z_impl_led_off(const struct device *dev, uint32_t led)
+{
+	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
+
+	if (api->set_brightness == NULL && api->off == NULL) {
+		return -ENOSYS;
+	}
+
+	if (api->off == NULL) {
+		return api->set_brightness(dev, led, 0);
+	}
+
+	return api->off(dev, led);
+}
+
+int z_impl_led_set_brightness(const struct device *dev, uint32_t led, uint8_t value)
+{
+	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
+
+	if (api->set_brightness == NULL) {
+		if (api->on == NULL || api->off == NULL) {
+			return -ENOSYS;
+		}
+	}
+
+	if (value > LED_BRIGHTNESS_MAX) {
+		return -EINVAL;
+	}
+
+	if (api->set_brightness == NULL) {
+		if (value) {
+			return api->on(dev, led);
+		} else {
+			return api->off(dev, led);
+		}
+	}
+
+	return api->set_brightness(dev, led, value);
+}
+
+int z_impl_led_blink(const struct device *dev, uint32_t led, uint32_t delay_on, uint32_t delay_off)
+{
+	const struct led_driver_api *api = (const struct led_driver_api *)dev->api;
+
+	if (api->blink == NULL) {
+		return -ENOSYS;
+	}
+	return api->blink(dev, led, delay_on, delay_off);
+}

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -61,6 +61,18 @@ typedef int (*led_api_blink)(const struct device *dev, uint32_t led,
 			     uint32_t delay_on, uint32_t delay_off);
 
 /**
+ * @typedef led_api_get_blink_data()
+ * @brief Callback API for getting data used by software blinking
+ *
+ * @param dev LED device
+ * @param led LED number
+ * @return Pointer to the software blinking data structure for the specified LED,
+ *         or NULL if not supported or in case of an error.
+ */
+typedef struct led_blink_software_data *(*led_api_get_blink_data)(const struct device *dev,
+								  uint32_t led);
+
+/**
  * @typedef led_api_get_info()
  * @brief Optional API callback to get LED information
  *
@@ -123,6 +135,7 @@ __subsystem struct led_driver_api {
 	led_api_set_brightness set_brightness;
 	/* Optional callbacks. */
 	led_api_blink blink;
+	led_api_get_blink_data get_blink_data;
 	led_api_get_info get_info;
 	led_api_set_color set_color;
 	led_api_write_channels write_channels;


### PR DESCRIPTION
The LED blink API is quite useful but this is not supported by all the LED controller.
This provides a software implementation of blink that use a delayable work to blink a LED.
This could be enabled using Kconfig, as well the maximum number of LED that could blink at the same time using blink fallback. This does not requires any changes to driver to be used.