### PR TITLE
Peress/i2c npcx controller

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -558,8 +558,7 @@ static int i2c_ctrl_recovery(const struct device *dev)
 	ret = i2c_ctrl_wait_stop_completed(dev, I2C_MAX_TIMEOUT);
 	inst->SMBCST |= BIT(NPCX_SMBCST_BB);
 	if (ret != 0) {
-		LOG_ERR("Abort i2c port%02x fail! Bus might be stalled.",
-								data->port);
+		LOG_ERR("Abort i2c %s::%02x fail! Bus might be stalled.", dev->name, data->port);
 	}
 
 	/*
@@ -571,8 +570,7 @@ static int i2c_ctrl_recovery(const struct device *dev)
 	inst->SMBCTL2 &= ~BIT(NPCX_SMBCTL2_ENABLE);
 	ret = i2c_ctrl_wait_idle_completed(dev, I2C_MAX_TIMEOUT);
 	if (ret != 0) {
-		LOG_ERR("Reset i2c port%02x fail! Bus might be stalled.",
-								data->port);
+		LOG_ERR("Reset i2c %s::%02x fail! Bus might be stalled.", dev->name, data->port);
 		return -EIO;
 	}
 
@@ -1014,7 +1012,7 @@ static void i2c_ctrl_isr(const struct device *dev)
 		/* Make sure slave doesn't hold bus by reading FIFO again */
 		tmp = i2c_ctrl_fifo_read(dev);
 
-		LOG_ERR("Bus error occurred on i2c port%02x!", data->port);
+		LOG_ERR("Bus error occurred on i2c %s::%02x!", dev->name, data->port);
 		data->oper_state = NPCX_I2C_ERROR_RECOVERY;
 
 		/* I/O error occurred */
@@ -1438,7 +1436,7 @@ int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 		    data->oper_state == NPCX_I2C_ERROR_RECOVERY) {
 			ret = npcx_i2c_ctrl_recover_bus(i2c_dev);
 			if (ret != 0) {
-				LOG_ERR("Recover Bus failed");
+				LOG_ERR("Recover Bus failed: %s::%d", i2c_dev->name, port);
 				goto out;
 			}
 
@@ -1479,8 +1477,8 @@ int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 		if (data->trans_err == 0) {
 			data->oper_state = NPCX_I2C_IDLE;
 		} else {
-			LOG_ERR("STOP fail! bus is held on i2c port%02x!",
-								data->port);
+			LOG_ERR("STOP fail! bus is held on i2c %s::%02x!\n", i2c_dev->name,
+				data->port);
 			data->oper_state = NPCX_I2C_ERROR_RECOVERY;
 		}
 	}

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -630,7 +630,6 @@ static void i2c_ctrl_handle_write_int_event(const struct device *dev)
 		size_t tx_remain = i2c_ctrl_calculate_msg_remains(dev);
 		size_t tx_avail = MIN(tx_remain, i2c_ctrl_fifo_tx_avail(dev));
 
-		LOG_DBG("tx remains %d, avail %d", tx_remain, tx_avail);
 		for (int i = 0U; i < tx_avail; i++) {
 			i2c_ctrl_fifo_write(dev, *(data->ptr_msg++));
 		}
@@ -700,8 +699,6 @@ static void i2c_ctrl_handle_read_int_event(const struct device *dev)
 		/* Calculate how many remaining bytes need to receive */
 		size_t rx_remain = i2c_ctrl_calculate_msg_remains(dev);
 		size_t rx_occupied = i2c_ctrl_fifo_rx_occupied(dev);
-
-		LOG_DBG("rx remains %d, occupied %d", rx_remain, rx_occupied);
 
 		/* Is it the last read transaction with STOP condition? */
 		if (rx_occupied >= rx_remain &&
@@ -998,7 +995,6 @@ static void i2c_ctrl_isr(const struct device *dev)
 	uint8_t status, tmp;
 
 	status = inst->SMBST & NPCX_VALID_SMBST_MASK;
-	LOG_DBG("status: %02x, %d", status, data->oper_state);
 
 #ifdef CONFIG_I2C_TARGET
 	if (atomic_get(&data->registered_target_mask) != (atomic_val_t) 0) {

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -1237,8 +1237,12 @@ int npcx_i2c_ctrl_target_register(const struct device *i2c_dev,
 	int addr_idx;
 
 	/* A transiaction is ongoing */
-	if (data->oper_state != NPCX_I2C_IDLE) {
+	if (data->oper_state != NPCX_I2C_IDLE && data->oper_state != NPCX_I2C_ERROR_RECOVERY) {
+		LOG_ERR("Reg TGT in err state: %d", data->oper_state);
 		return -EBUSY;
+	}
+	if (data->oper_state == NPCX_I2C_ERROR_RECOVERY) {
+		LOG_WRN("Reg TGT in Recovery");
 	}
 
 	/* Find valid smbaddr location */


### PR DESCRIPTION
Allow npcx9m7fb i2c controller to go into target mode when in error recovery as well as idle.