### PR TITLE
add GPIO support for  imx91_evk

### DIFF
--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131.dts
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_mimx91.dtsi>
 #include "imx91_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	model = "NXP i.MX91 A55";
@@ -24,6 +25,44 @@
 		reg = <0x80000000 DT_SIZE_M(1)>;
 	};
 
+	aliases {
+		led0 = &led_r;
+		led1 = &led_g;
+		sw0 = &btn_1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_r: led_r {
+			label = "LED_R";
+			gpios = <&gpio2 13 GPIO_ACTIVE_HIGH>;
+		};
+		led_g: led_g {
+			label = "LED_G";
+			gpios = <&gpio2 4 GPIO_ACTIVE_HIGH>;
+		};
+		led_b: led_b {
+			label = "LED_B";
+			gpios = <&gpio2 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		btn_1: btn_1{
+			label = "BTN1";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+
+		btn_2: btn_2{
+			label = "BTN2";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_1>;
+		};
+	};
+
 };
 
 &lpuart1 {
@@ -31,4 +70,8 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-names = "default";
+};
+
+&gpio2{
+	status = "okay";
 };

--- a/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
+++ b/boards/nxp/imx91_evk/imx91_evk_mimx9131.yaml
@@ -13,5 +13,6 @@ toolchain:
   - cross-compile
 ram: 1024
 supported:
+  - gpio
   - uart
 vendor: nxp

--- a/dts/arm64/nxp/nxp_mimx91.dtsi
+++ b/dts/arm64/nxp/nxp_mimx91.dtsi
@@ -9,6 +9,7 @@
 #include <arm64/armv8-a.dtsi>
 #include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	#address-cells = <1>;
@@ -73,6 +74,54 @@
 		#clock-cells = <3>;
 	};
 
+	gpio1: gpio@47400000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x47400000 DT_SIZE_K(64)>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <16>;
+		status = "disabled";
+	};
+
+	gpio2: gpio@43810000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43810000 DT_SIZE_K(64)>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 57 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 58 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <30>;
+		status = "disabled";
+	};
+
+	gpio3: gpio@43820000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43820000 DT_SIZE_K(64)>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 60 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	gpio4: gpio@43830000 {
+		compatible = "nxp,imx-rgpio";
+		reg = <0x43830000 DT_SIZE_K(64)>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SPI 189 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
+					<GIC_SPI 190 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <30>;
+		status = "disabled";
+	};
+
 	lpuart1: serial@44380000 {
 		compatible = "nxp,imx-lpuart", "nxp,lpuart";
 		reg = <0x44380000 DT_SIZE_K(64)>;
@@ -92,4 +141,124 @@
 		clocks = <&ccm IMX_CCM_LPUART2_CLK 0x6c 24>;
 		status = "disabled";
 	};
+};
+
+&gpio1{
+	pinmux = <&iomuxc1_i2c1_scl_gpio_io_gpio1_io0>,
+		<&iomuxc1_i2c1_sda_gpio_io_gpio1_io1>,
+		<&iomuxc1_i2c2_scl_gpio_io_gpio1_io2>,
+		<&iomuxc1_i2c2_sda_gpio_io_gpio1_io3>,
+		<&iomuxc1_uart1_rxd_gpio_io_gpio1_io4>,
+		<&iomuxc1_uart1_txd_gpio_io_gpio1_io5>,
+		<&iomuxc1_uart2_rxd_gpio_io_gpio1_io6>,
+		<&iomuxc1_uart2_txd_gpio_io_gpio1_io7>,
+		<&iomuxc1_pdm_clk_gpio_io_gpio1_io8>,
+		<&iomuxc1_pdm_bit_stream0_gpio_io_gpio1_io9>,
+		<&iomuxc1_pdm_bit_stream1_gpio_io_gpio1_io10>,
+		<&iomuxc1_sai1_txfs_gpio_io_gpio1_io11>,
+		<&iomuxc1_sai1_txc_gpio_io_gpio1_io12>,
+		<&iomuxc1_sai1_txd0_gpio_io_gpio1_io13>,
+		<&iomuxc1_sai1_rxd0_gpio_io_gpio1_io14>,
+		<&iomuxc1_wdog_any_gpio_io_gpio1_io15>;
+};
+
+&gpio2{
+	pinmux = <&iomuxc1_gpio_io00_gpio_io_gpio2_io0>,
+		<&iomuxc1_gpio_io01_gpio_io_gpio2_io1>,
+		<&iomuxc1_gpio_io02_gpio_io_gpio2_io2>,
+		<&iomuxc1_gpio_io03_gpio_io_gpio2_io3>,
+		<&iomuxc1_gpio_io04_gpio_io_gpio2_io4>,
+		<&iomuxc1_gpio_io05_gpio_io_gpio2_io5>,
+		<&iomuxc1_gpio_io06_gpio_io_gpio2_io6>,
+		<&iomuxc1_gpio_io07_gpio_io_gpio2_io7>,
+		<&iomuxc1_gpio_io08_gpio_io_gpio2_io8>,
+		<&iomuxc1_gpio_io09_gpio_io_gpio2_io9>,
+		<&iomuxc1_gpio_io10_gpio_io_gpio2_io10>,
+		<&iomuxc1_gpio_io11_gpio_io_gpio2_io11>,
+		<&iomuxc1_gpio_io12_gpio_io_gpio2_io12>,
+		<&iomuxc1_gpio_io13_gpio_io_gpio2_io13>,
+		<&iomuxc1_gpio_io14_gpio_io_gpio2_io14>,
+		<&iomuxc1_gpio_io15_gpio_io_gpio2_io15>,
+		<&iomuxc1_gpio_io16_gpio_io_gpio2_io16>,
+		<&iomuxc1_gpio_io17_gpio_io_gpio2_io17>,
+		<&iomuxc1_gpio_io18_gpio_io_gpio2_io18>,
+		<&iomuxc1_gpio_io19_gpio_io_gpio2_io19>,
+		<&iomuxc1_gpio_io20_gpio_io_gpio2_io20>,
+		<&iomuxc1_gpio_io21_gpio_io_gpio2_io21>,
+		<&iomuxc1_gpio_io22_gpio_io_gpio2_io22>,
+		<&iomuxc1_gpio_io23_gpio_io_gpio2_io23>,
+		<&iomuxc1_gpio_io24_gpio_io_gpio2_io24>,
+		<&iomuxc1_gpio_io25_gpio_io_gpio2_io25>,
+		<&iomuxc1_gpio_io26_gpio_io_gpio2_io26>,
+		<&iomuxc1_gpio_io27_gpio_io_gpio2_io27>,
+		<&iomuxc1_gpio_io28_gpio_io_gpio2_io28>,
+		<&iomuxc1_gpio_io29_gpio_io_gpio2_io29>;
+};
+
+&gpio3{
+	pinmux = <&iomuxc1_sd2_cd_b_gpio_io_gpio3_io0>,
+		<&iomuxc1_sd2_clk_gpio_io_gpio3_io1>,
+		<&iomuxc1_sd2_cmd_gpio_io_gpio3_io2>,
+		<&iomuxc1_sd2_data0_gpio_io_gpio3_io3>,
+		<&iomuxc1_sd2_data1_gpio_io_gpio3_io4>,
+		<&iomuxc1_sd2_data2_gpio_io_gpio3_io5>,
+		<&iomuxc1_sd2_data3_gpio_io_gpio3_io6>,
+		<&iomuxc1_sd2_reset_b_gpio_io_gpio3_io7>,
+		<&iomuxc1_sd1_clk_gpio_io_gpio3_io8>,
+		<&iomuxc1_sd1_cmd_gpio_io_gpio3_io9>,
+		<&iomuxc1_sd1_data0_gpio_io_gpio3_io10>,
+		<&iomuxc1_sd1_data1_gpio_io_gpio3_io11>,
+		<&iomuxc1_sd1_data2_gpio_io_gpio3_io12>,
+		<&iomuxc1_sd1_data3_gpio_io_gpio3_io13>,
+		<&iomuxc1_sd1_data4_gpio_io_gpio3_io14>,
+		<&iomuxc1_sd1_data5_gpio_io_gpio3_io15>,
+		<&iomuxc1_sd1_data6_gpio_io_gpio3_io16>,
+		<&iomuxc1_sd1_data7_gpio_io_gpio3_io17>,
+		<&iomuxc1_sd1_strobe_gpio_io_gpio3_io18>,
+		<&iomuxc1_sd2_vselect_gpio_io_gpio3_io19>,
+		<&iomuxc1_sd3_clk_gpio_io_gpio3_io20>,
+		<&iomuxc1_sd3_cmd_gpio_io_gpio3_io21>,
+		<&iomuxc1_sd3_data0_gpio_io_gpio3_io22>,
+		<&iomuxc1_sd3_data1_gpio_io_gpio3_io23>,
+		<&iomuxc1_sd3_data2_gpio_io_gpio3_io24>,
+		<&iomuxc1_sd3_data3_gpio_io_gpio3_io25>,
+		<&iomuxc1_ccm_clko1_gpio_io_gpio3_io26>,
+		<&iomuxc1_ccm_clko2_gpio_io_gpio3_io27>,
+		<&iomuxc1_dap_tdi_gpio_io_gpio3_io28>,
+		<&iomuxc1_dap_tms_swdio_gpio_io_gpio3_io29>,
+		<&iomuxc1_dap_tclk_swclk_gpio_io_gpio3_io30>,
+		<&iomuxc1_dap_tdo_traceswo_gpio_io_gpio3_io31>;
+};
+
+&gpio4{
+	pinmux = <&iomuxc1_enet1_mdc_gpio_io_gpio4_io0>,
+		<&iomuxc1_enet1_mdio_gpio_io_gpio4_io1>,
+		<&iomuxc1_enet1_td3_gpio_io_gpio4_io2>,
+		<&iomuxc1_enet1_td2_gpio_io_gpio4_io3>,
+		<&iomuxc1_enet1_td1_gpio_io_gpio4_io4>,
+		<&iomuxc1_enet1_td0_gpio_io_gpio4_io5>,
+		<&iomuxc1_enet1_tx_ctl_gpio_io_gpio4_io6>,
+		<&iomuxc1_enet1_txc_gpio_io_gpio4_io7>,
+		<&iomuxc1_enet1_rx_ctl_gpio_io_gpio4_io8>,
+		<&iomuxc1_enet1_rxc_gpio_io_gpio4_io9>,
+		<&iomuxc1_enet1_rd0_gpio_io_gpio4_io10>,
+		<&iomuxc1_enet1_rd1_gpio_io_gpio4_io11>,
+		<&iomuxc1_enet1_rd2_gpio_io_gpio4_io12>,
+		<&iomuxc1_enet1_rd3_gpio_io_gpio4_io13>,
+		<&iomuxc1_enet2_mdc_gpio_io_gpio4_io14>,
+		<&iomuxc1_enet2_mdio_gpio_io_gpio4_io15>,
+		<&iomuxc1_enet2_td3_gpio_io_gpio4_io16>,
+		<&iomuxc1_enet2_td2_gpio_io_gpio4_io17>,
+		<&iomuxc1_enet2_td1_gpio_io_gpio4_io18>,
+		<&iomuxc1_enet2_td0_gpio_io_gpio4_io19>,
+		<&iomuxc1_enet2_tx_ctl_gpio_io_gpio4_io20>,
+		<&iomuxc1_enet2_txc_gpio_io_gpio4_io21>,
+		<&iomuxc1_enet2_rx_ctl_gpio_io_gpio4_io22>,
+		<&iomuxc1_enet2_rxc_gpio_io_gpio4_io23>,
+		<&iomuxc1_enet2_rd0_gpio_io_gpio4_io24>,
+		<&iomuxc1_enet2_rd1_gpio_io_gpio4_io25>,
+		<&iomuxc1_enet2_rd2_gpio_io_gpio4_io26>,
+		<&iomuxc1_enet2_rd3_gpio_io_gpio4_io27>,
+		<&iomuxc1_ccm_clko3_gpio_io_gpio4_io28>,
+		<&iomuxc1_ccm_clko4_gpio_io_gpio4_io29>;
 };

--- a/tests/drivers/gpio/gpio_basic_api/boards/imx91_evk_mimx9131.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/imx91_evk_mimx9131.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	resources {
+		compatible = "test-gpio-basic-api";
+		/*
+		 * Use connector J1001 Pin 8 which connect to EXP_GPIO_IO14 as input
+		 * GPIO, and connector J1001 Pin 33 which connect to EXP_GPIO_IO13 as
+		 * output GPIO, connect these two pins with a Dupont Line.
+		 */
+		out-gpios = <&gpio2 13 0>;
+		in-gpios = <&gpio2 14 0>;
+	};
+};

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2fe4ab6cd0d5586d12cc396197d956493575a0dd
+      revision: e0b43431640a565b4500c58fc5e1aaebec2f463d
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add GPIO device tree nodes for imx91.
Add gpio in board yaml file, gpio are enabled by default.
Add btn and led nodes to ensure the button and blinky samples can work.
Add board overlay file for driver test case: gpio_basic_api.

For sequencing, need the following to merge first:

- [x] #89909