### PR TITLE
Enable multi channel support for ADS1x15

### DIFF
--- a/drivers/adc/adc_ads1x1x.c
+++ b/drivers/adc/adc_ads1x1x.c
@@ -516,15 +516,14 @@ static int ads1x1x_validate_sequence(const struct device *dev, const struct adc_
 
 	while (channels) {
 		channel = find_lsb_set(channels) - 1;
-		resolution = data->differential[channel] ? config->resolution : config->resolution - 1;
-
-		if (sequence->resolution != resolution) {
-			LOG_ERR("unsupported resolution %d", sequence->resolution);
+		if (channel >= config->channels) {
+			LOG_ERR("unsupported channel id '%d'", channel);
 			return -ENOTSUP;
 		}
 
-		if (channel >= config->channels) {
-			LOG_ERR("unsupported channel id '%d'", channel);
+		resolution = data->differential[channel] ? config->resolution : config->resolution - 1;
+		if (sequence->resolution != resolution) {
+			LOG_ERR("unsupported resolution %d", sequence->resolution);
 			return -ENOTSUP;
 		}
 


### PR DESCRIPTION
ADS1115 is used in my project, but it supports only 1 channel at current driver.
This branch just extends multi-channel support for ADS1015/ADS1115.
It is tested on ADS1115 for single channel and multi-channels, but other variants are not tested.
Modification is refer to adc_mcp320x.c
