### PR TITLE
drivers: flash_stm32h7: fix flash size detection

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -45,7 +45,11 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #define REAL_FLASH_SIZE_KB (KB(STM32H7_M4_FLASH_SIZE * 2))
 #endif
 #else
+#if defined(DUAL_BANK)
+#define REAL_FLASH_SIZE_KB (DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash)) * 2)
+#else
 #define REAL_FLASH_SIZE_KB DT_REG_SIZE(DT_INST(0, st_stm32_nv_flash))
+#endif
 #endif
 #define SECTOR_PER_BANK ((REAL_FLASH_SIZE_KB / FLASH_SECTOR_SIZE) / 2)
 #if defined(DUAL_BANK)


### PR DESCRIPTION
Commit 0e41b07309a893f1f5eafeede9bbeee237ccf8a4 ("drivers : flash: update way to get flash size") changed the way total Flash size is retrieved from the `LL_FLASH_GetSize()` HAL function to the current `DT_REG_SIZE()` macro.

However, they are not equivalent:

- With `LL_FLASH_GetSize()`, `REAL_FLASH_SIZE_KB` returned the *total* size of the Flash memory, reading it from a ROM register of the CPU. For example, it was 2048 (2MB) for a STM32H747xI.

- The current `DT_REG_SIZE()` reads the size from a flash *bank*, therefore it only returns half of the total Flash size on dual bank devices.

This mismatch causes issues with the `DISCONTINUOUS_BANKS` logic below, incorrectly matching partitions close to the end of the first bank as appearing to span both and triggering the "range overlaps discontinuity" check later.

Fix it by doubling the size when appropriate, in the same way it is already done for the M4 core.

Fixes #90252.