### PR TITLE
soc: nordic: Use proper devicetree entries for clock frequency

### DIFF
--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -243,6 +243,7 @@
 			reg = <0x41016000 0x1000>;
 			cc-num = <4>;
 			interrupts = <22 NRF_DEFAULT_IRQ_PRIORITY>;
+			clock-frequency = <32768>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/timer/nordic,nrf-grtc.yaml
+++ b/dts/bindings/timer/nordic,nrf-grtc.yaml
@@ -45,3 +45,10 @@ properties:
     description: Number of capture/compare channels
     type: int
     required: true
+
+  clock-frequency:
+    type: int
+    default: 1000000
+    description: |
+      Clock frequency information for tick increment operations, this default value comes from
+      the nRF54L15 datasheet.

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -532,6 +532,29 @@ def dt_nodelabel_bool_prop(kconf, _, label, prop):
 
     return _dt_node_bool_prop_generic(edt.label2node.get, label, prop)
 
+def dt_nodelabel_int_prop(kconf, _, label, prop):
+    """
+    This function takes a 'label' and looks for an EDT node with that label.
+    If it finds an EDT node, it will look to see if that node has a int
+    property by the name of 'prop'.  If the 'prop' exists it will return the
+    value of the property, otherwise it returns "0".
+    """
+    if doc_mode or edt is None:
+        return "0"
+
+    try:
+        node = edt.label2node.get(label)
+    except edtlib.EDTError:
+        return "0"
+
+    if not node or node.props[prop].type != "int":
+        return "0"
+
+    if not node.props[prop].val:
+        return "0"
+
+    return str(node.props[prop].val)
+
 def dt_chosen_bool_prop(kconf, _, chosen, prop):
     """
     This function takes a /chosen node property named 'chosen', and
@@ -1059,6 +1082,7 @@ functions = {
         "dt_nodelabel_reg_size_hex": (dt_nodelabel_reg, 1, 3),
         "dt_node_bool_prop": (dt_node_bool_prop, 2, 2),
         "dt_nodelabel_bool_prop": (dt_nodelabel_bool_prop, 2, 2),
+        "dt_nodelabel_int_prop": (dt_nodelabel_int_prop, 2, 2),
         "dt_chosen_bool_prop": (dt_chosen_bool_prop, 2, 2),
         "dt_node_has_prop": (dt_node_has_prop, 2, 2),
         "dt_nodelabel_has_prop": (dt_nodelabel_has_prop, 2, 2),

--- a/soc/nordic/Kconfig.defconfig
+++ b/soc/nordic/Kconfig.defconfig
@@ -13,10 +13,6 @@ rsource "*/Kconfig.defconfig"
 config CLOCK_CONTROL
 	default y if SYS_CLOCK_EXISTS && !NRF_PLATFORM_HALTIUM && !RISCV_CORE_NORDIC_VPR
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 1000000 if NRF_GRTC_TIMER
-	default 32768
-
 config SYS_CLOCK_TICKS_PER_SEC
 	default 128 if !TICKLESS_KERNEL
 	default 31250  if NRF_GRTC_TIMER

--- a/soc/nordic/nrf51/Kconfig.defconfig
+++ b/soc/nordic/nrf51/Kconfig.defconfig
@@ -13,4 +13,7 @@ config NUM_IRQS
 config NRF_RTC_TIMER
 	default y if SYS_CLOCK_EXISTS
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
+
 endif # SOC_SERIES_NRF51X

--- a/soc/nordic/nrf52/Kconfig.defconfig
+++ b/soc/nordic/nrf52/Kconfig.defconfig
@@ -11,4 +11,7 @@ rsource "Kconfig.defconfig.nrf52*"
 config NRF_RTC_TIMER
 	default y if SYS_CLOCK_EXISTS
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
+
 endif # SOC_SERIES_NRF52X

--- a/soc/nordic/nrf53/Kconfig.defconfig
+++ b/soc/nordic/nrf53/Kconfig.defconfig
@@ -11,4 +11,7 @@ rsource "Kconfig.defconfig.nrf53*"
 config NRF_RTC_TIMER
 	default y if SYS_CLOCK_EXISTS
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
+
 endif # SOC_SERIES_NRF53X

--- a/soc/nordic/nrf54h/Kconfig.defconfig
+++ b/soc/nordic/nrf54h/Kconfig.defconfig
@@ -27,10 +27,6 @@ config BUILD_OUTPUT_ADJUST_LMA
 config BUILD_OUTPUT_HEX
 	default y
 
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 1000000 if NRF_GRTC_TIMER
-	default 32768 if NRF_RTC_TIMER
-
 endif # RISCV
 
 config SPI_DW_HSSI
@@ -44,5 +40,8 @@ config PM_DEVICE_POWER_DOMAIN
 
 config PM_DEVICE_RUNTIME
 	default y if PM_DEVICE
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_nodelabel_int_prop,grtc,clock-frequency) if NRF_GRTC_TIMER
 
 endif # SOC_SERIES_NRF54HX

--- a/soc/nordic/nrf54l/Kconfig.defconfig
+++ b/soc/nordic/nrf54l/Kconfig.defconfig
@@ -46,4 +46,7 @@ config BUILD_OUTPUT_ADJUST_LMA
 
 endif # RISCV
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_nodelabel_int_prop,grtc,clock-frequency) if NRF_GRTC_TIMER
+
 endif # SOC_SERIES_NRF54LX

--- a/soc/nordic/nrf91/Kconfig.defconfig
+++ b/soc/nordic/nrf91/Kconfig.defconfig
@@ -11,4 +11,7 @@ rsource "Kconfig.defconfig.nrf91*"
 config NRF_RTC_TIMER
 	default y if SYS_CLOCK_EXISTS
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_nodelabel_int_prop,rtc1,clock-frequency)
+
 endif # SOC_SERIES_NRF91X

--- a/soc/nordic/nrf92/Kconfig.defconfig
+++ b/soc/nordic/nrf92/Kconfig.defconfig
@@ -38,4 +38,7 @@ config SPI_DW_HSSI
 config SPI_DW_ACCESS_WORD_ONLY
 	default y if SPI_DW
 
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_nodelabel_int_prop,grtc,clock-frequency) if NRF_GRTC_TIMER
+
 endif # SOC_SERIES_NRF92X


### PR DESCRIPTION
    dts: bindings: timer: Add default clock frequency for nordic grtc
    
    Adds a default for the nordic grtc



    soc: nordic: Use proper devicetree entries for clock frequency
    
    Sets the SYS_CLOCK_HW_CYCLES_PER_SEC Kconfig from devicetree
    entries. Also fixes invalid configuration on nrf54h20 whereby it
    attempts to take the clock frequency from a peripheral that does
    not exist
