### PR TITLE
MAINTAINERS: add myself as maintainer for PTP Clock

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1995,7 +1995,9 @@ Release Notes:
     - sample.drivers.espi.ps2
 
 "Drivers: PTP Clock":
-  status: odd fixes
+  status: maintained
+  maintainers:
+    - yangbolu1991
   files:
     - drivers/ptp_clock/
     - include/zephyr/drivers/ptp_clock.h


### PR DESCRIPTION
I'd like to request to work as maintainer for PTP Clock.

I was the maintainer for Linux `PTP VIRTUAL CLOCK SUPPORT` and `FREESCALE QORIQ PTP CLOCK DRIVER`.
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/MAINTAINERS?h=v6.15-rc7#n19614
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/MAINTAINERS?h=v6.15-rc7#n9485

```
PTP VIRTUAL CLOCK SUPPORT
M:	Yangbo Lu <yangbo.lu@nxp.com>
L:	netdev@vger.kernel.org
S:	Maintained
F:	drivers/ptp/ptp_vclock.c
F:	net/ethtool/phc_vclocks.c

FREESCALE QORIQ PTP CLOCK DRIVER
M:	Yangbo Lu <yangbo.lu@nxp.com>
L:	netdev@vger.kernel.org
S:	Maintained
F:	Documentation/devicetree/bindings/ptp/fsl,ptp.yaml
F:	drivers/net/ethernet/freescale/dpaa2/dpaa2-ptp*
F:	drivers/net/ethernet/freescale/dpaa2/dprtc*
F:	drivers/net/ethernet/freescale/enetc/enetc_ptp.c
F:	drivers/ptp/ptp_qoriq.c
F:	drivers/ptp/ptp_qoriq_debugfs.c
F:	include/linux/fsl/ptp_qoriq.h
```

Although I haven't been working on zephyr PTP for long, I have clear understanding for current zephyr PTP clock and PTP/gPTP stack. And started to contribute for it.

```
$ git log --oneline --grep='Yangbo Lu' | grep ptp
09ff615f67c drivers: ptp_clock_nxp_enet: re-enable ENET timestamp IRQ
2c10b2fb463 drivers: ptp_clock: add ptp_clock shell commands
1ee51232def net: ptp: fix infinite loop in pkt frag
07e1de381ab net: ptp: adjust only frequency for continuous synchronization
e9efff6e332 net: ptp: calculate link delay with right timestamps
f8b450d6a52 net: gptp: adjust only frequency for continuous synchronization
faa55bd44b2 drivers: ptp_clock_nxp_enet: avoid configuring IRQ handlers again
0e4a334f1c9 drivers: ptp_clock_nxp_enet: adjust rate based on nominal frequency
383d4f499e3 drivers: eth_nxp_enet: fix data share with ptp driver
```

Thanks.
