### PR TITLE
MAINTAINERS: nxp-mpu: add more collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3916,6 +3916,8 @@ NXP Platforms (MPU):
     - dleach02
     - dbaluta
     - iuliana-prodan
+    - yangbolu1991
+    - Zhiqiang-Hou
   files:
     - dts/arm64/nxp/
     - dts/arm/nxp/nxp_imx*


### PR DESCRIPTION
Add yangbolu1991 and Zhiqiang-Hou as the collaborators for NXP MPU, yangbolu1991 has contributed a lot of in scope of MPU M-core and Zhiqiang-Hou has contributed a lot of in scope of MPU A-Core, they could help to fast the review process.