### PR TITLE
drivers: spi: stm32H7 spi driver with shield controls the EOT flag

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -498,9 +498,14 @@ static void spi_stm32_complete(const struct device *dev, int status)
 	ll_func_disable_int_errors(spi);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+#ifdef CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI
+	/* Using this spi shield, Disable the EOT unconditionnaly */
+	LL_SPI_DisableIT_EOT(spi);
+#else
 	if (cfg->fifo_enabled) {
 		LL_SPI_DisableIT_EOT(spi);
 	}
+#endif /* CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI */
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 #endif /* CONFIG_SPI_STM32_INTERRUPT */
@@ -529,6 +534,11 @@ static void spi_stm32_complete(const struct device *dev, int status)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	uint32_t transfer_dir = LL_SPI_GetTransferDirection(spi);
 
+#ifdef CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI
+	/* Using this spi shield, clear the EOT unconditionnaly */
+	LL_SPI_ClearFlag_EOT(spi);
+	/* This is not a problem to clear it again if cfg->fifo_enabled */
+#endif /* CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI */
 	if (cfg->fifo_enabled) {
 		LL_SPI_ClearFlag_TXTF(spi);
 		LL_SPI_ClearFlag_OVR(spi);
@@ -882,9 +892,14 @@ static int spi_stm32_half_duplex_switch_to_receive(const struct spi_stm32_config
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
+#ifdef CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI
+		/* Using this spi shield, Enable the EOT unconditionnaly */
+		LL_SPI_EnableIT_EOT(spi);
+#else
 		if (cfg->fifo_enabled) {
 			LL_SPI_EnableIT_EOT(spi);
 		}
+#endif /* CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI */
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 		ll_func_enable_int_errors(spi);
@@ -990,9 +1005,15 @@ static int transceive(const struct device *dev,
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
-	if (cfg->fifo_enabled) {
+#ifdef CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI
+		/* Using this spi shield, Enable the EOT unconditionnaly */
 		LL_SPI_EnableIT_EOT(spi);
-	}
+#else
+		if (cfg->fifo_enabled) {
+			LL_SPI_EnableIT_EOT(spi);
+		}
+#endif /* CONFIG_SHIELD_X_NUCLEO_WB05KN1_SPI */
+
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */
 
 	ll_func_enable_int_errors(spi);


### PR DESCRIPTION
With STM32H7, the EOT flag has to be cleared and controlled unconditionnaly when the wb05kn1 nucleo shield is used with SPI bus

This change is given by the https://community.st.com/t5/stm32-mcus-wireless/x-nucleo-wb05kn1-zephyr-problem/td-p/784767

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/88603


test with `west build -p -b nucleo_h753zi samples/bluetooth/beacon --shield x_nucleo_wb05kn1_spi`