### PR TITLE
samples: adc_dt: add overlay for STM32F0-DISCO

### DIFF
--- a/boards/st/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/st/stm32f0_disco/stm32f0_disco.dts
@@ -50,6 +50,14 @@
 	};
 };
 
+&adc1 {
+	pinctrl-0 = <&adc_in0_pa0 &adc_in1_pa1>;
+	pinctrl-names = "default";
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
 &clk_lsi {
 	status = "okay";
 };

--- a/boards/st/stm32f0_disco/stm32f0_disco.yaml
+++ b/boards/st/stm32f0_disco/stm32f0_disco.yaml
@@ -8,4 +8,5 @@ toolchain:
 ram: 8
 supported:
   - watchdog
+  - adc
 vendor: st

--- a/samples/drivers/adc/adc_dt/boards/stm32f0_disco.overlay
+++ b/samples/drivers/adc/adc_dt/boards/stm32f0_disco.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Sudarsan N
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	zephyr,user {
+		io-channels = <&adc1 0>, <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
This PR enables ADC1 on the STM32F0-DISCO board by updating the board DTS and YAML to support ADC on PA0 (ADC_IN0). It also adds a board-specific overlay for the adc_dt sample to enable ADC channel usage on this board.

Tested and verified with the adc_dt sample.