### PR TITLE
west.yml: depend on hal_adi pr 25

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: f8f65473168a4e9f71f20c0c5387f6b80fe54cf3
+      revision: refs/pull/25/head
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Tmp patch to depend on:
https://github.com/zephyrproject-rtos/hal_adi/pull/25 
Updated adc to support Zephyr RTIO stream

Signed-off-by: Dimitrije Lilic dimitrije.lilic@orioninc.com