### PR TITLE
Specify and document current PM_DEVICE behavior, including PM_DEVICE=n and device_deinit()

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -68,6 +68,10 @@ New APIs and options
 
 .. zephyr-keep-sorted-start re(^\* \w)
 
+* Power management
+
+   * :c:func:`pm_device_driver_deinit`
+
 * Settings
 
    * :kconfig:option:`CONFIG_SETTINGS_TFM_ITS`

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -622,13 +622,22 @@ int pm_device_power_domain_remove(const struct device *dev,
 bool pm_device_is_powered(const struct device *dev);
 
 /**
- * @brief Setup a device driver into the lowest valid power mode
+ * @brief Move a device driver into its initial device power state.
  *
- * This helper function is intended to be called at the end of a driver
- * init function to automatically setup the device into the lowest power
- * mode. It assumes that the device has been configured as if it is in
- * @ref PM_DEVICE_STATE_OFF, or @ref PM_DEVICE_STATE_SUSPENDED if device can
- * never be powered off.
+ * @details This function uses the device driver's internal PM hook to
+ * move the device from the OFF state to the initial power state expected
+ * by the system.
+ *
+ * The initial power state expected by the system is:
+ *
+ * - ACTIVE if CONFIG_PM_DEVICE=n or (CONFIG_PM_DEVICE=y and
+ *   CONFIG_PM_DEVICE_RUNTIME=n) or (CONFIG_PM_DEVICE_RUNTIME=y and
+ *   !pm_device_runtime_is_enabled(dev)).
+ * - SUSPENDED if CONFIG_PM_DEVICE_RUNTIME=y and device's parent power domain is ACTIVE.
+ * - OFF if CONFIG_PM_DEVICE_RUNTIME=y and device's parent power domain is SUSPENDED.
+ *
+ * @note This function must be called at the end of a driver's init
+ * function.
  *
  * @param dev Device instance.
  * @param action_cb Device PM control callback function.

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -646,6 +646,25 @@ bool pm_device_is_powered(const struct device *dev);
  */
 int pm_device_driver_init(const struct device *dev, pm_device_action_cb_t action_cb);
 
+/**
+ * @brief Prepare PM device for device driver deinit
+ *
+ * @details Ensures device is either SUSPENDED or OFF. If CONFIG_PM_DEVICE=y,
+ * the function checks whether power management has moved the device to
+ * either the SUSPENDED or OFF states. If CONFIG_PM_DEVICE=n, the function
+ * uses the device driver's internal PM hook to move the device to the
+ * SUSPENDED state.
+ *
+ * @note This function must be called at the beginning of a driver's deinit
+ * function.
+ *
+ * @param dev Device instance.
+ * @param action_cb Device PM control callback function.
+ * @retval 0 if success.
+ * @retval -EBUSY Device is not SUSPENDED nor OFF
+ * @retval -errno code if failure.
+ */
+int pm_device_driver_deinit(const struct device *dev, pm_device_action_cb_t action_cb);
 #else
 static inline int pm_device_state_get(const struct device *dev,
 				      enum pm_device_state *state)
@@ -740,6 +759,11 @@ static inline int pm_device_driver_init(const struct device *dev, pm_device_acti
 	}
 
 	return 0;
+}
+
+static inline int pm_device_driver_deinit(const struct device *dev, pm_device_action_cb_t action_cb)
+{
+	return action_cb(dev, PM_DEVICE_ACTION_SUSPEND);
 }
 
 #endif /* CONFIG_PM_DEVICE */

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -401,3 +401,14 @@ int pm_device_driver_init(const struct device *dev,
 	/* Return the PM_DEVICE_ACTION_RESUME result */
 	return rc;
 }
+
+int pm_device_driver_deinit(const struct device *dev,
+			    pm_device_action_cb_t action_cb)
+{
+	struct pm_device_base *pm = dev->pm_base;
+
+	return pm->state == PM_DEVICE_STATE_SUSPENDED ||
+	       pm->state == PM_DEVICE_STATE_OFF ?
+	       0 :
+	       -EBUSY;
+}


### PR DESCRIPTION
This PR aims to document the status quo of device power management to provide a foundation for current driver development, and future refactoring discussions, since we need to agree on the current state before being able to discuss the future state :)

The PR also adds the missing counterpart to `pm_device_driver_init()`.