### PR TITLE
tests: drivers: gpio_hogs: Add nrf54 platforms.

### DIFF
--- a/tests/drivers/gpio/gpio_hogs/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	zephyr,user {
+		output-high-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio0 {
+	hog1 {
+		gpio-hog;
+		gpios = <3 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+
+	hog2 {
+		gpio-hog;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+
+	hog3 {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_LOW>;
+		input;
+	};
+};

--- a/tests/drivers/gpio/gpio_hogs/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/gpio/gpio_hogs/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	zephyr,user {
+		output-high-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		output-low-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+		input-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio0 {
+	hog1 {
+		gpio-hog;
+		gpios = <3 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+
+	hog2 {
+		gpio-hog;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+
+	hog3 {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_LOW>;
+		input;
+	};
+};

--- a/tests/drivers/gpio/gpio_hogs/testcase.yaml
+++ b/tests/drivers/gpio/gpio_hogs/testcase.yaml
@@ -9,6 +9,8 @@ tests:
       - native_sim/native/64
       - frdm_k64f
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - nucleo_g474re
       - nrf52_bsim
       - nrf5340bsim/nrf5340/cpuapp


### PR DESCRIPTION
Add overlays and entries in testcase.yaml to enable tests execution on nrf54 DKs.