### PR TITLE
drivers: video: ov7670: Set default format to RGB565 QVGA

### DIFF
--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -551,9 +551,9 @@ static int ov7670_init(const struct device *dev)
 	k_msleep(5);
 
 	/* Set default camera format (QVGA, YUYV) */
-	fmt.pixelformat = VIDEO_PIX_FMT_YUYV;
-	fmt.width = 640;
-	fmt.height = 480;
+	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
+	fmt.width = 320;
+	fmt.height = 240;
 	ret = ov7670_set_fmt(dev, &fmt);
 	if (ret < 0) {
 		return ret;


### PR DESCRIPTION
The default format for ov7670 is currently VGA YUYV and it counts on the smartdma to reset the format to RGB565 QVGA when get_format() is called.

Recently, set_format() is decoupled from get_format() so this assumption is nolonger correct.

Set the default format to RGB565 QVGA instead.