### PR TITLE
drivers: wifi: siwx91x: Alternative implementation of power-save support

### DIFF
--- a/drivers/wifi/siwx91x/Kconfig.siwx91x
+++ b/drivers/wifi/siwx91x/Kconfig.siwx91x
@@ -14,6 +14,24 @@ config WIFI_SILABS_SIWX91X
 
 if WIFI_SILABS_SIWX91X
 
+config WIFI_SILABS_SIWX91X_ENHANCED_MAX_PSP
+	bool "Enhanced Max PSP Support"
+	default y
+	help
+	  Enable this option to allow the device to configure
+	  Enhanced Maximum Power Save (PSP) support during
+	  device initialization.
+
+	  **Advantages:**
+	  - Reduces power consumption during low traffic periods.
+	  - Automatically transitions to Fast PSP for improved responsiveness
+	    when traffic is high.
+
+	  **Limitations:**
+	  - Initially uses PS-Poll frames for power management, even if the
+	    user configures NULL frame-based.
+	  - Switches to NULL frame-based only when traffic increases.
+
 choice
 	prompt "Network stack"
 	default WIFI_SILABS_SIWX91X_NET_STACK_NATIVE

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -21,6 +21,7 @@ struct siwx91x_dev {
 	enum wifi_iface_state scan_prev_state;
 	scan_result_cb_t scan_res_cb;
 	uint16_t scan_max_bss_cnt;
+	struct wifi_ps_params ps_params;
 	uint8_t max_num_sta;
 	bool reboot_needed;
 	bool hidden_ssid;

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -69,9 +69,11 @@ static void siwx91x_configure_sta_mode(sl_si91x_boot_configuration_t *boot_confi
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X
 	boot_config->ext_tcp_ip_feature_bit_map = SL_SI91X_CONFIG_FEAT_EXTENSION_VALID;
-	boot_config->config_feature_bit_map = SL_SI91X_ENABLE_ENHANCED_MAX_PSP;
 	boot_config->ext_custom_feature_bit_map |= SL_SI91X_EXT_FEAT_IEEE_80211W |
 			SL_SI91X_EXT_FEAT_FRONT_END_SWITCH_PINS_ULP_GPIO_4_5_0;
+	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_ENHANCED_MAX_PSP)) {
+		boot_config->config_feature_bit_map = SL_SI91X_ENABLE_ENHANCED_MAX_PSP;
+	}
 #endif
 
 #ifdef CONFIG_BT_SILABS_SIWX91X


### PR DESCRIPTION
This PR is an alternative to https://github.com/zephyrproject-rtos/zephyr/pull/86537. It based on the work made by @ArunmaniAlagarsamy2710. However, rather than juggling with various states, it stores the Power Save parameters in the main structure. Then, it is able to easily restore the Power Save parameters when required.