### PR TITLE
Add shields to board catalog, take 2

### DIFF
--- a/boards/index.rst
+++ b/boards/index.rst
@@ -3,26 +3,28 @@
 Supported Boards and Shields
 ############################
 
+This page lists all the boards and shields that are currently supported in Zephyr.
+
 If you are looking to add Zephyr support for a new board, please start with the
-:ref:`board_porting_guide`.
+:ref:`board_porting_guide`. When adding support documentation for a board, remember to use the
+template available under :zephyr_file:`doc/templates/board.tmpl`.
 
-When adding support documentation for a board, remember to use the template
-available under :zephyr_file:`doc/templates/board.tmpl`.
-
-Shields are hardware add-ons that can be stacked on top of a board to add extra
-functionality. They are listed separately from boards, towards :ref:`the end of
-this page <boards-shields>`.
+Shields are hardware add-ons that can be stacked on top of a board to add extra functionality.
+Refer to the :ref:`shield_porting_guide` for more information on how to port a shield.
 
 .. admonition:: Search Tips
    :class: dropdown
 
-   * Use the form below to filter the list of supported boards. If a field is left empty, it will
-     not be used in the filtering process.
+   * Use the form below to filter the list of supported boards and shields. If a field is left
+     empty, it will not be used in the filtering process.
 
-   * A board must meet **all** criteria selected across different fields. For example, if you select
-     both a vendor and an architecture, only boards that match both will be displayed. Within a
-     single field, selecting multiple options (such as two architectures) will show boards matching
-     **either** option.
+   * Filtering by name and vendor is available for both boards and shields. The rest of the fields
+     apply only to boards.
+
+   * A board/shield must meet **all** criteria selected across different fields. For example, if you
+     select both a vendor and an architecture, only boards that match both will be displayed. Within
+     a single field, selecting multiple options (such as two architectures) will show boards
+     matching **either** option.
 
    * The list of supported hardware features for each board is automatically generated using
      information from the Devicetree. It may not be reflecting the full list of supported features
@@ -40,14 +42,3 @@ this page <boards-shields>`.
    */index
 
 .. zephyr:board-catalog::
-
-.. _boards-shields:
-
-Shields
-#######
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   shields/**/*

--- a/boards/shields/abrobot_esp32c3_oled/shield.yml
+++ b/boards/shields/abrobot_esp32c3_oled/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: abrobot_sh1106_72x40
+  full_name: ABRobot ESP32C3 OLED Shield
+  vendor: others

--- a/boards/shields/adafruit_2_8_tft_touch_v2/shield.yml
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: adafruit_2_8_tft_touch_v2
+    full_name: Adafruit 2.8" TFT Touch Shield V2 (Uno)
+    vendor: adafruit
+
+  - name: adafruit_2_8_tft_touch_v2_nano
+    full_name: Adafruit 2.8" TFT Touch Shield V2 (Nano)
+    vendor: adafruit

--- a/boards/shields/adafruit_adalogger_featherwing/shield.yml
+++ b/boards/shields/adafruit_adalogger_featherwing/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: adafruit_adalogger_featherwing
+  full_name: Adafruit Adalogger FeatherWing
+  vendor: adafruit

--- a/boards/shields/adafruit_aw9523/shield.yml
+++ b/boards/shields/adafruit_aw9523/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: adafruit_aw9523
+  full_name: Adafruit AW9523 GPIO Expander and LED Driver
+  vendor: adafruit

--- a/boards/shields/adafruit_data_logger/shield.yml
+++ b/boards/shields/adafruit_data_logger/shield.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024, Nordic Semiconductor ASA
+
+shield:
+  name: adafruit_data_logger
+  full_name: Adafruit Data Logger Shield
+  vendor: adafruit

--- a/boards/shields/adafruit_neopixel_grid_bff/shield.yml
+++ b/boards/shields/adafruit_neopixel_grid_bff/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: adafruit_neopixel_grid_bff
+    full_name: Adafruit NeoPixel Grid BFF
+    vendor: adafruit
+
+  - name: adafruit_neopixel_grid_bff_display
+    full_name: Adafruit NeoPixel Grid BFF (with display matrix)
+    vendor: adafruit

--- a/boards/shields/adafruit_pca9685/shield.yml
+++ b/boards/shields/adafruit_pca9685/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: adafruit_pca9685
+  full_name: Adafruit PCA9685 PWM Shield
+  vendor: adafruit

--- a/boards/shields/adafruit_winc1500/shield.yml
+++ b/boards/shields/adafruit_winc1500/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: adafruit_winc1500
+  full_name: Adafruit WINC1500 WiFi Shield
+  vendor: adafruit

--- a/boards/shields/amg88xx/shield.yml
+++ b/boards/shields/amg88xx/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: amg88xx_grid_eye_eval_shield
+    full_name: Panasonic Grid-EYE Evaluation Shield
+    vendor: panasonic
+
+  - name: amg88xx_eval_kit
+    full_name: Panasonic Grid-EYE Evaluation Kit
+    vendor: panasonic

--- a/boards/shields/arceli_eth_w5500/shield.yml
+++ b/boards/shields/arceli_eth_w5500/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: arceli_eth_w5500
+  full_name: Arceli ETH W5500 Shield
+  vendor: wiznet

--- a/boards/shields/arduino_giga_display_shield/shield.yml
+++ b/boards/shields/arduino_giga_display_shield/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: arduino_giga_display_shield
+  full_name: Arduino GIGA Display Shield
+  vendor: arduino

--- a/boards/shields/arduino_modulino_buttons/shield.yml
+++ b/boards/shields/arduino_modulino_buttons/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: arduino_modulino_buttons
+  full_name: Arduino Modulino Buttons
+  vendor: arduino

--- a/boards/shields/arduino_modulino_smartleds/shield.yml
+++ b/boards/shields/arduino_modulino_smartleds/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: arduino_modulino_smartleds
+  full_name: Arduino Modulino SmartLEDs
+  vendor: arduino

--- a/boards/shields/arduino_uno_click/shield.yml
+++ b/boards/shields/arduino_uno_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: arduino_uno_click
+  full_name: Arduino UNO Click
+  vendor: arduino

--- a/boards/shields/atmel_rf2xx/shield.yml
+++ b/boards/shields/atmel_rf2xx/shield.yml
@@ -1,0 +1,19 @@
+shields:
+  - name: atmel_rf2xx
+    full_name: Atmel AT86RF2XX Transceiver
+    vendor: atmel
+  - name: atmel_rf2xx_arduino
+    full_name: Atmel AT86RF2XX Transceiver for Arduino
+    vendor: atmel
+  - name: atmel_rf2xx_legacy
+    full_name: Atmel AT86RF2XX Transceiver for Atmel Xplained (legacy)
+    vendor: atmel
+  - name: atmel_rf2xx_mikrobus
+    full_name: Atmel AT86RF2XX Transceiver for MikroBUS
+    vendor: atmel
+  - name: atmel_rf2xx_xplained
+    full_name: Atmel AT86RF2XX Transceiver for Atmel Xplained
+    vendor: atmel
+  - name: atmel_rf2xx_xpro
+    full_name: Atmel AT86RF2XX Transceiver for Atmel Xplained Pro
+    vendor: atmel

--- a/boards/shields/boostxl_ulpsense/shield.yml
+++ b/boards/shields/boostxl_ulpsense/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: boostxl_ulpsense
+  full_name: BOOSTXL-ULPSENSE
+  vendor: ti

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/shield.yml
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: buydisplay_2_8_tft_touch_arduino
+  full_name: BuyDisplay 2.8" TFT Touch Shield
+  vendor: gooddisplay

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/shield.yml
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: buydisplay_3_5_tft_touch_arduino
+  full_name: BuyDisplay 3.5" TFT Touch Shield
+  vendor: gooddisplay

--- a/boards/shields/dac80508_evm/shield.yml
+++ b/boards/shields/dac80508_evm/shield.yml
@@ -1,0 +1,4 @@
+shields:
+  - name: dac80508_evm
+    full_name: DAC80508 Evaluation Module
+    vendor: ti

--- a/boards/shields/dvp_20pin_ov7670/shield.yml
+++ b/boards/shields/dvp_20pin_ov7670/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: dvp_20pin_ov7670
+  full_name: DVP 20-pin OV7670 Camera Shield
+  vendor: ovti

--- a/boards/shields/dvp_fpc24_mt9m114/shield.yml
+++ b/boards/shields/dvp_fpc24_mt9m114/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: dvp_fpc24_mt9m114
+  full_name: DVP FPC-24 MT9M114 Camera Module
+  vendor: aptina

--- a/boards/shields/esp_8266/shield.yml
+++ b/boards/shields/esp_8266/shield.yml
@@ -1,0 +1,12 @@
+shields:
+  - name: esp_8266
+    full_name: ESP-8266 Module
+    vendor: espressif
+
+  - name: esp_8266_arduino
+    full_name: ESP-8266 Module (Arduino)
+    vendor: espressif
+
+  - name: esp_8266_mikrobus
+    full_name: ESP-8266 Module (MikroBus)
+    vendor: espressif

--- a/boards/shields/eval_ad4052_ardz/shield.yml
+++ b/boards/shields/eval_ad4052_ardz/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: eval_ad4052_ardz
+  full_name: AD4052 Evaluation Shield
+  vendor: adi

--- a/boards/shields/eval_adxl362_ardz/shield.yml
+++ b/boards/shields/eval_adxl362_ardz/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: eval_adxl362_ardz
+  full_name: ADXL362 Evaluation Shield
+  vendor: adi

--- a/boards/shields/eval_adxl367_ardz/shield.yml
+++ b/boards/shields/eval_adxl367_ardz/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: eval_adxl367_ardz
+  full_name: ADXL367 Evaluation Shield
+  vendor: adi

--- a/boards/shields/eval_adxl372_ardz/shield.yml
+++ b/boards/shields/eval_adxl372_ardz/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: eval_adxl372_ardz
+  full_name: ADXL372 Evaluation Shield
+  vendor: adi

--- a/boards/shields/frdm_cr20a/shield.yml
+++ b/boards/shields/frdm_cr20a/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: frdm_cr20a
+  full_name: FRDM-CR20A
+  vendor: nxp

--- a/boards/shields/frdm_kw41z/shield.yml
+++ b/boards/shields/frdm_kw41z/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: frdm_kw41z
+  full_name: FRDM-KW41Z
+  vendor: nxp

--- a/boards/shields/frdm_stbc_agm01/shield.yml
+++ b/boards/shields/frdm_stbc_agm01/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: frdm_stbc_agm01
+  full_name: FRDM-ST BC-AGM01
+  vendor: nxp

--- a/boards/shields/ftdi_vm800c/shield.yml
+++ b/boards/shields/ftdi_vm800c/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: ftdi_vm800c
+  full_name: FTDI VM800C Display Shield
+  vendor: ftdi

--- a/boards/shields/g1120b0mipi/shield.yml
+++ b/boards/shields/g1120b0mipi/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: g1120b0mipi
+  full_name: G1120B0 MIPI Display Shield
+  vendor: boe

--- a/boards/shields/index.rst
+++ b/boards/shields/index.rst
@@ -1,0 +1,8 @@
+Shields
+#######
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   **/*

--- a/boards/shields/inventek_eswifi/shield.yml
+++ b/boards/shields/inventek_eswifi/shield.yml
@@ -1,0 +1,12 @@
+shields:
+  - name: inventek_eswifi
+    full_name: Inventek es-WIFI Shield (generic)
+    vendor: inventek
+
+  - name: inventek_eswifi_arduino_spi
+    full_name: Inventek es-WIFI Shield (SPI)
+    vendor: inventek
+
+  - name: inventek_eswifi_arduino_uart
+    full_name: Inventek es-WIFI Mini Shield (UART)
+    vendor: inventek

--- a/boards/shields/lcd_par_s035/shield.yml
+++ b/boards/shields/lcd_par_s035/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: lcd_par_s035_8080
+    full_name: NXP LCD_PAR_S035 TFT LCD Module (Parallel)
+    vendor: nxp
+
+  - name: lcd_par_s035_spi
+    full_name: NXP LCD_PAR_S035 TFT LCD Module (SPI)
+    vendor: nxp

--- a/boards/shields/link_board_eth/shield.yml
+++ b/boards/shields/link_board_eth/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: link_board_eth
+  full_name: link board ETH
+  vendor: phytec

--- a/boards/shields/lmp90100_evb/shield.yml
+++ b/boards/shields/lmp90100_evb/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: lmp90100_evb
+  full_name: LMP90100 Sensor AFE Evaluation Board
+  vendor: ti

--- a/boards/shields/ls0xx_generic/shield.yml
+++ b/boards/shields/ls0xx_generic/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: ls013b7dh03
+  full_name: Sharp memory display generic shield
+  vendor: sharp

--- a/boards/shields/m5stack_cardputer/shield.yml
+++ b/boards/shields/m5stack_cardputer/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: m5stack_cardputer
+  full_name: M5Stack Cardputer
+  vendor: m5stack

--- a/boards/shields/m5stack_core2_ext/shield.yml
+++ b/boards/shields/m5stack_core2_ext/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: m5stack_core2_ext
+  full_name: M5Stack-Core2 base shield
+  vendor: m5stack

--- a/boards/shields/max3421e/shield.yml
+++ b/boards/shields/max3421e/shield.yml
@@ -1,0 +1,4 @@
+shields:
+  - name: sparkfun_max3421e
+    full_name: SparkFun USB Host Shield
+    vendor: sparkfun

--- a/boards/shields/max7219/shield.yml
+++ b/boards/shields/max7219/shield.yml
@@ -1,0 +1,4 @@
+shields:
+  - name: max7219_8x8
+    full_name: MAX7219 8x8 Display shield
+    vendor: others

--- a/boards/shields/mcp2515/shield.yml
+++ b/boards/shields/mcp2515/shield.yml
@@ -1,0 +1,12 @@
+shields:
+  - name: adafruit_can_picowbell
+    full_name: PiCowbell CAN Bus for Pico
+    vendor: adafruit
+
+  - name: dfrobot_can_bus_v2_0
+    full_name: CAN-BUS Shield V2
+    vendor: dfrobot
+
+  - name: keyestudio_can_bus_ks0411
+    full_name: Keyestudio CAN-BUS Shield
+    vendor: others

--- a/boards/shields/mikroe_accel13_click/shield.yml
+++ b/boards/shields/mikroe_accel13_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: mikroe_accel13_click
+  full_name: ACCEL 13 Click
+  vendor: mikroe

--- a/boards/shields/mikroe_adc_click/shield.yml
+++ b/boards/shields/mikroe_adc_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: mikroe_adc_click
+  full_name: ADC Click
+  vendor: mikroe

--- a/boards/shields/mikroe_ble_tiny_click/shield.yml
+++ b/boards/shields/mikroe_ble_tiny_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: mikroe_ble_tiny_click
+  full_name: BLE TINY Click
+  vendor: mikroe

--- a/boards/shields/mikroe_eth3_click/shield.yml
+++ b/boards/shields/mikroe_eth3_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: mikroe_eth3_click
+  full_name: ETH3 Click
+  vendor: mikroe

--- a/boards/shields/mikroe_eth_click/shield.yml
+++ b/boards/shields/mikroe_eth_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: mikroe_eth_click
+  full_name: ETH Click
+  vendor: mikroe

--- a/boards/shields/mikroe_lte_iot10_click/shield.yml
+++ b/boards/shields/mikroe_lte_iot10_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: mikroe_lte_iot10_click
+  full_name: LTE IoT 10 Click
+  vendor: mikroe

--- a/boards/shields/mikroe_mcp2518fd_click/shield.yml
+++ b/boards/shields/mikroe_mcp2518fd_click/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: mikroe_mcp2518fd_click
+  full_name: MikroElektronika MCP2518FD Click shield
+  vendor: mikroe

--- a/boards/shields/mikroe_weather_click/shield.yml
+++ b/boards/shields/mikroe_weather_click/shield.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2024, Nordic Semiconductor ASA
+
+shields:
+  - name: mikroe_weather_click_i2c
+    full_name: Weather Click (I2C)
+    vendor: mikroe
+
+  - name: mikroe_weather_click_spi
+    full_name: Weather Click (SPI)
+    vendor: mikroe

--- a/boards/shields/mikroe_wifi_bt_click/shield.yml
+++ b/boards/shields/mikroe_wifi_bt_click/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: mikroe_wifi_bt_click_arduino
+    full_name: WIFI BLE Click (Arduino)
+    vendor: mikroe
+
+  - name: mikroe_wifi_bt_click_mikrobus
+    full_name: WIFI BLE Click (MikroBus)
+    vendor: mikroe

--- a/boards/shields/npm1100_ek/shield.yml
+++ b/boards/shields/npm1100_ek/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: npm1100_ek
+  full_name: nPM1100 EK
+  vendor: nordic

--- a/boards/shields/npm1300_ek/shield.yml
+++ b/boards/shields/npm1300_ek/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: npm1300_ek
+  full_name: nPM1300 EK
+  vendor: nordic

--- a/boards/shields/npm2100_ek/shield.yml
+++ b/boards/shields/npm2100_ek/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: npm2100_ek
+  full_name: nPM2100 EK
+  vendor: nordic

--- a/boards/shields/npm6001_ek/shield.yml
+++ b/boards/shields/npm6001_ek/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: npm6001_ek
+  full_name: nPM6001 EK
+  vendor: nordic

--- a/boards/shields/nrf7002eb/shield.yml
+++ b/boards/shields/nrf7002eb/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: nrf7002eb
+    full_name: nRF7002 Evaluation Board Shield
+    vendor: nordic
+
+  - name: nrf7002eb_coex
+    full_name: nRF7002 Evaluation Board Shield (SR Co-Existence)
+    vendor: nordic

--- a/boards/shields/nrf7002ek/shield.yml
+++ b/boards/shields/nrf7002ek/shield.yml
@@ -1,0 +1,16 @@
+shields:
+  - name: nrf7002ek
+    full_name: nRF7002 Evaluation Kit Shield
+    vendor: nordic
+
+  - name: nrf7002ek_nrf7000
+    full_name: nRF7002 Evaluation Kit Shield (nRF7000)
+    vendor: nordic
+
+  - name: nrf7002ek_nrf7001
+    full_name: nRF7002 Evaluation Kit Shield (nRF7001)
+    vendor: nordic
+
+  - name: nrf7002ek_coex
+    full_name: nRF7002 Evaluation Kit Shield (SR Co-Existence)
+    vendor: nordic

--- a/boards/shields/nxp_btb44_ov5640/shield.yml
+++ b/boards/shields/nxp_btb44_ov5640/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: nxp_btb44_ov5640
+  full_name: NXP BTB44 OV5640 Camera Module
+  vendor: nxp

--- a/boards/shields/nxp_m2_wifi_bt/shield.yml
+++ b/boards/shields/nxp_m2_wifi_bt/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: nxp_m2_1xk_wifi_bt
+    full_name: NXP M2 WiFi/BT Shield (Murata 1XK)
+    vendor: nxp
+
+  - name: nxp_m2_2el_wifi_bt
+    full_name: NXP M2 WiFi/BT Shield (Murata 2EL)
+    vendor: nxp

--- a/boards/shields/p3t1755dp_ard_i2c/shield.yml
+++ b/boards/shields/p3t1755dp_ard_i2c/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: p3t1755dp_ard_i2c
+  full_name: P3T1755DP Arduino I2C Shield
+  vendor: nxp

--- a/boards/shields/p3t1755dp_ard_i3c/shield.yml
+++ b/boards/shields/p3t1755dp_ard_i3c/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: p3t1755dp_ard_i3c
+  full_name: P3T1755DP Arduino I3C Shield
+  vendor: nxp

--- a/boards/shields/pmod_acl/shield.yml
+++ b/boards/shields/pmod_acl/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: pmod_acl
+  full_name: Digilent Pmod ACL
+  vendor: digilent

--- a/boards/shields/pmod_sd/shield.yml
+++ b/boards/shields/pmod_sd/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: pmod_sd
+  full_name: Pmod SD Card Shield
+  vendor: digilent

--- a/boards/shields/renesas_us159_da14531evz/shield.yml
+++ b/boards/shields/renesas_us159_da14531evz/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: renesas_us159_da14531evz
+  full_name: US159-DA14531EVZ Pmod
+  vendor: renesas

--- a/boards/shields/reyax_lora/shield.yml
+++ b/boards/shields/reyax_lora/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: reyax_lora
+  full_name: Reyax LoRa RYLR896 and RYLR915 Modules
+  vendor: reyax

--- a/boards/shields/rk043fn02h_ct/shield.yml
+++ b/boards/shields/rk043fn02h_ct/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: rk043fn02h_ct
+  full_name: RK043FN02H-CT 4.3" LCD Panel
+  vendor: nxp

--- a/boards/shields/rk043fn66hs_ctg/shield.yml
+++ b/boards/shields/rk043fn66hs_ctg/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: rk043fn66hs_ctg
+  full_name: RK043FN66HS-CTG 4.3" LCD Panel
+  vendor: nxp

--- a/boards/shields/rk055hdmipi4m/shield.yml
+++ b/boards/shields/rk055hdmipi4m/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: rk055hdmipi4m
+  full_name: RK055HDMIPI4M 5.5" LCD Panel
+  vendor: nxp

--- a/boards/shields/rk055hdmipi4ma0/shield.yml
+++ b/boards/shields/rk055hdmipi4ma0/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: rk055hdmipi4ma0
+  full_name: RK055HDMIPI4MA0 5.5" LCD Panel
+  vendor: nxp

--- a/boards/shields/rpi_pico_uno_flexypin/shield.yml
+++ b/boards/shields/rpi_pico_uno_flexypin/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: rpi_pico_uno_flexypin
+  full_name: Raspberry Pi Pico to UNO FlexyPin Adapter
+  vendor: others

--- a/boards/shields/rtk7eka6m3b00001bu/shield.yml
+++ b/boards/shields/rtk7eka6m3b00001bu/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: rtk7eka6m3b00001bu
+  full_name: RTK7EKA6M3B00001BU Display
+  vendor: renesas

--- a/boards/shields/rtkmipilcdb00000be/shield.yml
+++ b/boards/shields/rtkmipilcdb00000be/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: rtkmipilcdb00000be
+  full_name: RTKMIPILCDB00000BE MIPI Display
+  vendor: renesas

--- a/boards/shields/seeed_w5500/shield.yml
+++ b/boards/shields/seeed_w5500/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: seeed_w5500
+  full_name: W5500 Ethernet Shield
+  vendor: seeed

--- a/boards/shields/seeed_xiao_expansion_board/shield.yml
+++ b/boards/shields/seeed_xiao_expansion_board/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: seeed_xiao_expansion_board
+  full_name: Expansion Board Base for XIAO
+  vendor: seeed

--- a/boards/shields/seeed_xiao_round_display/shield.yml
+++ b/boards/shields/seeed_xiao_round_display/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: seeed_xiao_round_display
+  full_name: Round Display for XIAO
+  vendor: seeed

--- a/boards/shields/semtech_sx1262mb2das/shield.yml
+++ b/boards/shields/semtech_sx1262mb2das/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: semtech_sx1262mb2das
+  full_name: Semtech SX1262MB2DAS LoRa Shield
+  vendor: semtech

--- a/boards/shields/semtech_sx1272mb2das/shield.yml
+++ b/boards/shields/semtech_sx1272mb2das/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: semtech_sx1272mb2das
+  full_name: SX1272MB2DAS LoRa Shield
+  vendor: semtech

--- a/boards/shields/semtech_sx1276mb1mas/shield.yml
+++ b/boards/shields/semtech_sx1276mb1mas/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: semtech_sx1276mb1mas
+  full_name: SX1276MB1MAS LoRa Shield
+  vendor: semtech

--- a/boards/shields/sparkfun_carrier_asset_tracker/shield.yml
+++ b/boards/shields/sparkfun_carrier_asset_tracker/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: sparkfun_carrier_asset_tracker
+  full_name: SparkFun MicroMod Asset Tracker Shield
+  vendor: sparkfun

--- a/boards/shields/sparkfun_sara_r4/shield.yml
+++ b/boards/shields/sparkfun_sara_r4/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: sparkfun_sara_r4
+  full_name: Sparkfun Sara R4
+  vendor: sparkfun

--- a/boards/shields/ssd1306/shield.yml
+++ b/boards/shields/ssd1306/shield.yml
@@ -1,0 +1,16 @@
+shields:
+  - name: ssd1306_128x32
+    full_name: SSD1306 128x32 pixels generic shield
+    vendor: others
+
+  - name: ssd1306_128x64
+    full_name: SSD1306 128x64 pixels generic shield
+    vendor: others
+
+  - name: ssd1306_128x64_spi
+    full_name: SSD1306 128x64 pixels generic shield (SPI)
+    vendor: others
+
+  - name: sh1106_128x64
+    full_name: SH1106 128x64 pixels generic shield
+    vendor: others

--- a/boards/shields/st7735r/shield.yml
+++ b/boards/shields/st7735r/shield.yml
@@ -1,0 +1,4 @@
+shields:
+  - name: st7735r_ada_160x128
+    full_name: Adafruit 160x128 1.8" SPI TFT display
+    vendor: adafruit

--- a/boards/shields/st7789v_generic/shield.yml
+++ b/boards/shields/st7789v_generic/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: st7789v_tl019fqv01
+    full_name: ST7789V TL019FQV01
+    vendor: others
+
+  - name: st7789v_waveshare_240x240
+    full_name: Waveshare 240x240 1.3inch IPS LCD
+    vendor: waveshare

--- a/boards/shields/st_b_cams_omv_mb1683/shield.yml
+++ b/boards/shields/st_b_cams_omv_mb1683/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: st_b_cams_omv_mb1683
+  full_name: ST B-CAMS-OMV MB1683 Camera Shield
+  vendor: st

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/shield.yml
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: st_b_lcd40_dsi1_mb1166
+    full_name: ST B-LCD40-DSI1
+    vendor: st
+
+  - name: st_b_lcd40_dsi1_mb1166_a09
+    full_name: ST B-LCD40-DSI1 (MB1166-A09)
+    vendor: st

--- a/boards/shields/tcan4550evm/shield.yml
+++ b/boards/shields/tcan4550evm/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: tcan4550evm
+  full_name: Texas Instruments TCAN4550EVM
+  vendor: ti

--- a/boards/shields/ti_bp_bassensorsmkii/shield.yml
+++ b/boards/shields/ti_bp_bassensorsmkii/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: ti_bp_bassensorsmkii
+  full_name: BP-BASSENSORSMKII
+  vendor: ti

--- a/boards/shields/v2c_daplink/shield.yml
+++ b/boards/shields/v2c_daplink/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: v2c_daplink
+    full_name: ARM V2C-DAPLink for DesignStart FPGA
+    vendor: arm
+
+  - name: v2c_daplink_cfg
+    full_name: ARM V2C-DAPLink for DesignStart FPGA (boot from QSPI)
+    vendor: arm

--- a/boards/shields/waveshare_epaper/shield.yml
+++ b/boards/shields/waveshare_epaper/shield.yml
@@ -1,0 +1,32 @@
+shields:
+  - name: waveshare_epaper_gdeh029a1
+    full_name: WAVESHARE e-Paper GDEH029A1
+    vendor: waveshare
+
+  - name: waveshare_epaper_gdeh0154a07
+    full_name: WAVESHARE e-Paper GDEH0154A07
+    vendor: waveshare
+
+  - name: waveshare_epaper_gdeh0213b1
+    full_name: WAVESHARE e-Paper GDEH0213B1
+    vendor: waveshare
+
+  - name: waveshare_epaper_gdeh0213b72
+    full_name: WAVESHARE e-Paper GDEH0213B72
+    vendor: waveshare
+
+  - name: waveshare_epaper_gdew042t2-p
+    full_name: WAVESHARE e-Paper GDEW042T2-P
+    vendor: waveshare
+
+  - name: waveshare_epaper_gdew042t2
+    full_name: WAVESHARE e-Paper GDEW042T2
+    vendor: waveshare
+
+  - name: waveshare_epaper_gdew075t7
+    full_name: WAVESHARE e-Paper GDEW075T7
+    vendor: waveshare
+
+  - name: waveshare_epaper_gdey0213b74
+    full_name: WAVESHARE e-Paper GDEY0213B74
+    vendor: waveshare

--- a/boards/shields/waveshare_pico_lcd_1_14/shield.yml
+++ b/boards/shields/waveshare_pico_lcd_1_14/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: waveshare_pico_lcd_1_14
+  full_name: Waveshare Pico LCD 1.14"
+  vendor: waveshare

--- a/boards/shields/waveshare_pico_oled_1_3/shield.yml
+++ b/boards/shields/waveshare_pico_oled_1_3/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: waveshare_pico_oled_1_3
+  full_name: Waveshare Pico OLED 1.3"
+  vendor: waveshare

--- a/boards/shields/waveshare_ups/shield.yml
+++ b/boards/shields/waveshare_ups/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: waveshare_pico_ups_b
+  full_name: Waveshare Pico UPS-B shield
+  vendor: waveshare

--- a/boards/shields/weact_ov2640_cam_module/shield.yml
+++ b/boards/shields/weact_ov2640_cam_module/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: weact_ov2640_cam_module
+  full_name: WeAct OV2640 Camera Module Shield
+  vendor: weact

--- a/boards/shields/wnc_m14a2a/shield.yml
+++ b/boards/shields/wnc_m14a2a/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: wnc_m14a2a
+  full_name: Wnc M14A2A
+  vendor: wnc

--- a/boards/shields/x_nucleo_53l0a1/shield.yml
+++ b/boards/shields/x_nucleo_53l0a1/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: x_nucleo_53l0a1
+  full_name: X-NUCLEO-53L0A1
+  vendor: st

--- a/boards/shields/x_nucleo_bnrg2a1/shield.yml
+++ b/boards/shields/x_nucleo_bnrg2a1/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: x_nucleo_bnrg2a1
+  full_name: X-NUCLEO-BNRG2A1
+  vendor: st

--- a/boards/shields/x_nucleo_eeprma2/shield.yml
+++ b/boards/shields/x_nucleo_eeprma2/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: x_nucleo_eeprma2
+  full_name: X-NUCLEO-EEPRMA2
+  vendor: st

--- a/boards/shields/x_nucleo_gfx01m2/shield.yml
+++ b/boards/shields/x_nucleo_gfx01m2/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: x_nucleo_gfx01m2
+  full_name: X-NUCLEO-GFX01M2 Display Shield
+  vendor: st

--- a/boards/shields/x_nucleo_idb05a1/shield.yml
+++ b/boards/shields/x_nucleo_idb05a1/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: x_nucleo_idb05a1
+  full_name: X-NUCLEO-IDB05A1
+  vendor: st

--- a/boards/shields/x_nucleo_iks01a1/shield.yml
+++ b/boards/shields/x_nucleo_iks01a1/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: x_nucleo_iks01a1
+  full_name: X-NUCLEO-IKS01A1
+  vendor: st

--- a/boards/shields/x_nucleo_iks01a2/shield.yml
+++ b/boards/shields/x_nucleo_iks01a2/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: x_nucleo_iks01a2
+    full_name: X-NUCLEO-IKS01A2 (Standard / Mode 1)
+    vendor: st
+
+  - name: x_nucleo_iks01a2_shub
+    full_name: X-NUCLEO-IKS01A2 (SensorHub / Mode 2)
+    vendor: st

--- a/boards/shields/x_nucleo_iks01a3/shield.yml
+++ b/boards/shields/x_nucleo_iks01a3/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: x_nucleo_iks01a3
+    full_name: X-NUCLEO-IKS01A3 (Standard / Mode 1)
+    vendor: st
+
+  - name: x_nucleo_iks01a3_shub
+    full_name: X-NUCLEO-IKS01A3 (SensorHub / Mode 2)
+    vendor: st

--- a/boards/shields/x_nucleo_iks02a1/shield.yml
+++ b/boards/shields/x_nucleo_iks02a1/shield.yml
@@ -1,0 +1,12 @@
+shields:
+  - name: x_nucleo_iks02a1
+    full_name: X-NUCLEO-IKS02A1 (Standard / Mode 1)
+    vendor: st
+
+  - name: x_nucleo_iks02a1_shub
+    full_name: X-NUCLEO-IKS02A1 (SensorHub / Mode 2)
+    vendor: st
+
+  - name: x_nucleo_iks02a1_mic
+    full_name: X-NUCLEO-IKS02A1 (Microphone)
+    vendor: st

--- a/boards/shields/x_nucleo_iks4a1/shield.yml
+++ b/boards/shields/x_nucleo_iks4a1/shield.yml
@@ -1,0 +1,12 @@
+shields:
+  - name: x_nucleo_iks4a1
+    full_name: X-NUCLEO-IKS4A1 (Mode 1)
+    vendor: st
+
+  - name: x_nucleo_iks4a1_shub1
+    full_name: X-NUCLEO-IKS4A1 (Mode 3)
+    vendor: st
+
+  - name: x_nucleo_iks4a1_shub2
+    full_name: X-NUCLEO-IKS4A1 (Mode 2)
+    vendor: st

--- a/boards/shields/x_nucleo_wb05kn1/shield.yml
+++ b/boards/shields/x_nucleo_wb05kn1/shield.yml
@@ -1,0 +1,8 @@
+shields:
+  - name: x_nucleo_wb05kn1_spi
+    full_name: X-NUCLEO-WB05KN1 (SPI)
+    vendor: st
+
+  - name: x_nucleo_wb05kn1_uart
+    full_name: X-NUCLEO-WB05KN1 (UART)
+    vendor: st

--- a/cmake/modules/shields.cmake
+++ b/cmake/modules/shields.cmake
@@ -31,6 +31,7 @@
 include_guard(GLOBAL)
 
 include(extensions)
+include(python)
 
 # Check that SHIELD has not changed.
 zephyr_check_cache(SHIELD WATCH)
@@ -46,31 +47,42 @@ endif()
 # After processing all shields, only invalid shields will be left in this list.
 set(SHIELD-NOTFOUND ${SHIELD_AS_LIST})
 
-foreach(root ${BOARD_ROOT})
-  set(shield_dir ${root}/boards/shields)
-  # Match the Kconfig.shield files in the shield directories to make sure we are
-  # finding shields, e.g. x_nucleo_iks01a1/Kconfig.shield
-  file(GLOB_RECURSE shields_refs_list ${shield_dir}/*/Kconfig.shield)
+# Prepare list shields command.
+# This command is used for locating the shield dir as well as printing all shields
+# in the system in the following cases:
+# - User specifies an invalid SHIELD
+# - User invokes '<build-command> shields' target
+list(TRANSFORM BOARD_ROOT PREPEND "--board-root=" OUTPUT_VARIABLE board_root_args)
 
-  # The above gives a list of Kconfig.shield files, like this:
-  #
-  # x_nucleo_iks01a1/Kconfig.shield;x_nucleo_iks01a2/Kconfig.shield
-  #
-  # we construct a list of shield names by extracting the directories
-  # from each file and looking for <shield>.overlay files in there.
-  # Each overlay corresponds to a shield. We obtain the shield name by
-  # removing the .overlay extension.
-  # We also create a SHIELD_DIR_${name} variable for each shield's directory.
-  foreach(shields_refs ${shields_refs_list})
-    get_filename_component(shield_path ${shields_refs} DIRECTORY)
-    file(GLOB shield_overlays RELATIVE ${shield_path} ${shield_path}/*.overlay)
-    foreach(overlay ${shield_overlays})
-      get_filename_component(shield ${overlay} NAME_WE)
-      list(APPEND SHIELD_LIST ${shield})
-      set(SHIELD_DIR_${shield} ${shield_path})
-    endforeach()
+set(list_shields_commands
+  COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/list_shields.py
+  ${board_root_args} --json
+)
+
+# Get list of shields in JSON format
+execute_process(${list_shields_commands}
+  OUTPUT_VARIABLE shields_json
+  ERROR_VARIABLE err_shields
+  RESULT_VARIABLE ret_val
+)
+
+if(ret_val)
+  message(FATAL_ERROR "Error finding shields\nError message: ${err_shields}")
+endif()
+
+string(JSON shields_length LENGTH ${shields_json})
+
+if(shields_length GREATER 0)
+  math(EXPR shields_length "${shields_length} - 1")
+
+  foreach(i RANGE ${shields_length})
+    string(JSON shield GET "${shields_json}" "${i}")
+    string(JSON shield_name GET ${shield} name)
+    string(JSON shield_dir GET ${shield} dir)
+    list(APPEND SHIELD_LIST ${shield_name})
+    set(SHIELD_DIR_${shield_name} ${shield_dir})
   endforeach()
-endforeach()
+endif()
 
 # Process shields in-order
 if(DEFINED SHIELD)

--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -757,6 +757,7 @@ class BoardCatalogDirective(SphinxDirective):
                 "board-catalog.html",
                 {
                     "boards": domain_data["boards"],
+                    "shields": domain_data["shields"],
                     "vendors": domain_data["vendors"],
                     "socs": domain_data["socs"],
                     "hw_features_present": self.env.app.config.zephyr_generate_hw_features,
@@ -1381,6 +1382,7 @@ def load_board_catalog_into_domain(app: Sphinx) -> None:
         hw_features_vendor_filter=app.config.zephyr_hw_features_vendor_filter,
     )
     app.env.domaindata["zephyr"]["boards"] = board_catalog["boards"]
+    app.env.domaindata["zephyr"]["shields"] = board_catalog["shields"]
     app.env.domaindata["zephyr"]["vendors"] = board_catalog["vendors"]
     app.env.domaindata["zephyr"]["socs"] = board_catalog["socs"]
     app.env.domaindata["zephyr"]["runners"] = board_catalog["runners"]

--- a/doc/_extensions/zephyr/domain/static/css/board-catalog.css
+++ b/doc/_extensions/zephyr/domain/static/css/board-catalog.css
@@ -146,6 +146,7 @@
   flex-direction: column;
   align-items: center;
   transition: transform 0.3s ease;
+  position: relative;
 }
 
 .board-card:hover,
@@ -153,6 +154,34 @@
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
   transform: translateY(-5px);
   text-decoration: none;
+}
+
+.board-card.shield::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  border-style: solid;
+  border-width: 0 48px 48px 0;
+  border-color: transparent var(--admonition-note-title-background-color) transparent transparent;
+  border-radius: 0 8px 0 0;
+}
+
+.board-card.shield::after {
+  rotate: 45deg;
+  content: "SHIELD";
+  position: absolute;
+  top: 7px;
+  right: 6px;
+  color: var(--admonition-note-title-color);
+  font-size: 11px;
+  font-weight: 600;
+  z-index: 1;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .board-card .picture {
@@ -245,6 +274,23 @@
   box-shadow: none;
   list-style-position: outside;
   max-width: none;
+}
+
+#catalog.compact .board-card.shield::before {
+  display: none; /* Remove the S prefix */
+}
+
+#catalog.compact .board-card.shield::after {
+  content: "Shield";
+  color: var(--admonition-note-color);
+  background-color: var(--admonition-note-background-color);
+  padding: 2px 10px 2px 10px;
+  border-radius: 30px;
+  font-size: 0.8em;
+}
+
+#catalog.compact .board-card.shield {
+  padding: 4px 0;
 }
 
 #catalog.compact .board-card .vendor,

--- a/doc/_extensions/zephyr/domain/static/js/board-catalog.js
+++ b/doc/_extensions/zephyr/domain/static/js/board-catalog.js
@@ -119,7 +119,7 @@ function setupHWCapabilitiesField() {
   const datalist = document.getElementById('tag-list');
 
   const tagCounts = Array.from(document.querySelectorAll('.board-card')).reduce((acc, board) => {
-    board.getAttribute('data-supported-features').split(' ').forEach(tag => {
+    (board.getAttribute('data-supported-features') || '').split(' ').forEach(tag => {
       acc[tag] = (acc[tag] || 0) + 1;
     });
     return acc;
@@ -254,12 +254,14 @@ function resetForm() {
 }
 
 function updateBoardCount() {
-  const boards = document.getElementsByClassName("board-card");
-  const visibleBoards = Array.from(boards).filter(
-    (board) => !board.classList.contains("hidden")
-  ).length;
-  const totalBoards = boards.length;
-  document.getElementById("nb-matches").textContent = `Showing ${visibleBoards} of ${totalBoards}`;
+  const boards = Array.from(document.getElementsByClassName("board-card"));
+  const visible = boards.filter(board => !board.classList.contains("hidden"));
+  const shields = boards.filter(board => board.classList.contains("shield"));
+  const visibleShields = visible.filter(board => board.classList.contains("shield"));
+
+  document.getElementById("nb-matches").textContent =
+    `Showing ${visible.length - visibleShields.length} of ${boards.length - shields.length} boards,`
+    + ` ${visibleShields.length} of ${shields.length} shields`;
 }
 
 function filterBoards() {
@@ -281,10 +283,10 @@ function filterBoards() {
 
   Array.from(boards).forEach(function (board) {
     const boardName = board.getAttribute("data-name").toLowerCase();
-    const boardArchs = board.getAttribute("data-arch").split(" ");
-    const boardVendor = board.getAttribute("data-vendor");
-    const boardSocs = board.getAttribute("data-socs").split(" ");
-    const boardSupportedFeatures = board.getAttribute("data-supported-features").split(" ");
+    const boardArchs = (board.getAttribute("data-arch") || "").split(" ").filter(Boolean);
+    const boardVendor = board.getAttribute("data-vendor") || "";
+    const boardSocs = (board.getAttribute("data-socs") || "").split(" ").filter(Boolean);
+    const boardSupportedFeatures = (board.getAttribute("data-supported-features") || "").split(" ").filter(Boolean);
 
     let matches = true;
 

--- a/doc/_extensions/zephyr/domain/templates/board-catalog.html
+++ b/doc/_extensions/zephyr/domain/templates/board-catalog.html
@@ -3,12 +3,12 @@
   SPDX-License-Identifier: Apache-2.0
 #}
 
-<form class="filter-form" aria-label="Filter boards by name, architecture, and vendor">
+<form class="filter-form" aria-label="Filter boards & shields by name, architecture, and vendor">
 
   <div class="form-group" style="flex-basis: 100%">
     <label for="name">Name</label>
     <input type="text" id="name"
-      placeholder='Name (or partial name) of the board, e.g. "reel board", "nucleo", &hellip;'
+      placeholder='Name (or partial name) of the board/shield, e.g. "reel board", "nucleo", &hellip;'
       oninput="filterBoards()" />
   </div>
 
@@ -35,9 +35,11 @@
     <div class="select-container">
       <select id="vendor">
         <option value="" disabled selected>Select a vendor</option>
-        {# Only show those vendors that have actual boards in the catalog.
+        {# Only show those vendors that have actual boards or shields in the catalog.
            Note: as sorting per vendor name is not feasible in Jinja, the option list is sorted in the JavaScript code later #}
-        {% for vendor in (boards | items | map(attribute='1.vendor') | unique ) -%}
+        {% set board_vendors = boards | items | map(attribute='1.vendor') | unique | list %}
+        {% set shield_vendors = shields | items | map(attribute='1.vendor') | unique | list %}
+        {% for vendor in (board_vendors + shield_vendors) | unique -%}
         <option value="{{ vendor }}">{{ vendors[vendor] }}</option>
         {% endfor %}
       </select>
@@ -97,6 +99,10 @@
 <div id="catalog">
   {% for board_name, board in boards | items | sort(attribute='1.full_name') -%}
   {% include "board-card.html" %}
+  {% endfor %}
+
+  {% for shield_name, shield in shields | items | sort(attribute='1.full_name') -%}
+  {% include "shield-card.html" %}
   {% endfor %}
 </div>
 

--- a/doc/_extensions/zephyr/domain/templates/shield-card.html
+++ b/doc/_extensions/zephyr/domain/templates/shield-card.html
@@ -1,0 +1,25 @@
+{#
+  Copyright (c) 2024-2025, The Linux Foundation.
+  SPDX-License-Identifier: Apache-2.0
+#}
+
+<a
+  class="board-card shield"
+  {% if shield.doc_page -%}
+  href="../{{ shield.doc_page | replace(".rst", ".html") }}"
+  {% else -%}
+  href="#"
+  {% endif -%}
+  aria-label="Open the documentation page for {{ shield.full_name }}"
+  data-name="{{ shield.full_name}}"
+  data-vendor="{{ shield.vendor }}"
+  tabindex="0">
+  <div class="vendor">{{ vendors[shield.vendor] }}</div>
+  {% if shield.image -%}
+  <img alt="A picture of the {{ shield.full_name }} shield"
+    src="../_images/{{ shield.image.split('/')[-1] }}" class="picture" />
+  {% else -%}
+  <div class="no-picture fa fa-microchip picture"></div>
+  {% endif -%}
+  <div class="board-name">{{ shield.full_name }}</div>
+</a>

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -8,6 +8,8 @@ to extend its features and services for easier and modularized prototyping.
 In Zephyr, the shield feature provides Zephyr-formatted shield
 descriptions for easier compatibility with applications.
 
+.. _shield_porting_guide:
+
 Shield porting and configuration
 ********************************
 

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -17,12 +17,28 @@ under :zephyr_file:`boards/shields`:
 .. code-block:: none
 
    boards/shields/<shield>
+   ├── shield.yml
    ├── <shield>.overlay
    ├── Kconfig.shield
    ├── Kconfig.defconfig
    └── pre_dt_shield.cmake
 
 These files provides shield configuration as follows:
+
+* **shield.yml**: This file provides metadata about the shield in YAML format.
+  It must contain the following fields:
+
+  * ``name``: Name of the shield used in Kconfig and build system (required)
+  * ``full_name``: Full commercial name of the shield (required)
+  * ``vendor``: Manufacturer/vendor of the shield (required)
+
+  Example:
+
+  .. code-block:: yaml
+
+     name: foo_shield
+     full_name: Foo Shield for Arduino
+     vendor: acme
 
 * **<shield>.overlay**: This file provides a shield description in devicetree
   format that is merged with the board's :ref:`devicetree <dt-guide>`

--- a/scripts/list_shields.py
+++ b/scripts/list_shields.py
@@ -38,6 +38,9 @@ def find_shields_in(root):
     shields = root / 'boards' / 'shields'
     ret = []
 
+    if not shields.exists():
+        return ret
+
     for maybe_shield in (shields).iterdir():
         if not maybe_shield.is_dir():
             continue

--- a/scripts/list_shields.py
+++ b/scripts/list_shields.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -57,6 +58,7 @@ def find_shields_in(root):
 def parse_args():
     parser = argparse.ArgumentParser(allow_abbrev=False)
     add_args(parser)
+    add_args_formatting(parser)
     return parser.parse_args()
 
 def add_args(parser):
@@ -66,9 +68,19 @@ def add_args(parser):
                         type=Path, action='append',
                         help='add a board root, may be given more than once')
 
+def add_args_formatting(parser):
+    parser.add_argument("--json", action='store_true',
+                        help='''output list of shields in JSON format''')
+
 def dump_shields(shields):
-    for shield in shields:
-        print(f'  {shield.name}')
+    if args.json:
+        print(
+            json.dumps([{'dir': shield.dir.as_posix(), 'name': shield.name} for shield in shields])
+        )
+    else:
+        for shield in shields:
+            print(f'  {shield.name}')
 
 if __name__ == '__main__':
-    dump_shields(find_shields(parse_args()))
+    args = parse_args()
+    dump_shields(find_shields(args))

--- a/scripts/list_shields.py
+++ b/scripts/list_shields.py
@@ -6,8 +6,23 @@
 
 import argparse
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+import pykwalify.core
+import yaml
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
+SHIELD_SCHEMA_PATH = str(Path(__file__).parent / 'schemas' / 'shield-schema.yml')
+with open(SHIELD_SCHEMA_PATH) as f:
+    shield_schema = yaml.load(f.read(), Loader=SafeLoader)
+
+SHIELD_YML = 'shield.yml'
 
 #
 # This is shared code between the build system's 'shields' target
@@ -22,9 +37,20 @@ from pathlib import Path
 class Shield:
     name: str
     dir: Path
+    full_name: str | None = None
+    vendor: str | None = None
 
 def shield_key(shield):
     return shield.name
+
+def process_shield_data(shield_data, shield_dir):
+    # Create shield from yaml data
+    return Shield(
+        name=shield_data['name'],
+        dir=shield_dir,
+        full_name=shield_data.get('full_name'),
+        vendor=shield_data.get('vendor')
+    )
 
 def find_shields(args):
     ret = []
@@ -45,6 +71,28 @@ def find_shields_in(root):
     for maybe_shield in (shields).iterdir():
         if not maybe_shield.is_dir():
             continue
+
+        # Check for shield.yml first
+        shield_yml = maybe_shield / SHIELD_YML
+        if shield_yml.is_file():
+            with shield_yml.open('r', encoding='utf-8') as f:
+                shield_data = yaml.load(f.read(), Loader=SafeLoader)
+
+            try:
+                pykwalify.core.Core(source_data=shield_data, schema_data=shield_schema).validate()
+            except pykwalify.errors.SchemaError as e:
+                sys.exit(f'ERROR: Malformed shield.yml in file: {shield_yml.as_posix()}\n{e}')
+
+            if 'shields' in shield_data:
+                # Multiple shields format
+                for shield_info in shield_data['shields']:
+                    ret.append(process_shield_data(shield_info, maybe_shield))
+            elif 'shield' in shield_data:
+                # Single shield format
+                ret.append(process_shield_data(shield_data['shield'], maybe_shield))
+            continue
+
+        # Fallback to legacy method if no shield.yml
         for maybe_kconfig in maybe_shield.iterdir():
             if maybe_kconfig.name == 'Kconfig.shield':
                 for maybe_overlay in maybe_shield.iterdir():

--- a/scripts/schemas/shield-schema.yml
+++ b/scripts/schemas/shield-schema.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright The Zephyr Project Contributors
+
+# A pykwalify schema for basic validation of the structure of a shield metadata YAML file.
+#
+# The shield.yml file can contain either a single shield definition or a list of shields.
+
+schema;shield-schema:
+  type: map
+  mapping:
+    name:
+      required: true
+      type: str
+      desc: Name of the shield (used in Kconfig and build system)
+    full_name:
+      required: true
+      type: str
+      desc: Full name of the shield (typically the commercial name)
+    vendor:
+      required: true
+      type: str
+      desc: Manufacturer/vendor of the shield
+
+type: map
+range:
+  min: 1
+  max: 1
+mapping:
+  shield:
+    include: shield-schema
+  shields:
+    type: seq
+    sequence:
+      - include: shield-schema

--- a/scripts/west_commands/shields.py
+++ b/scripts/west_commands/shields.py
@@ -49,6 +49,8 @@ class Shields(WestCommand):
             The following arguments are available:
 
             - name: shield name
+            - full_name: shield full name (typically, its commercial name)
+            - vendor: shield vendor
             - dir: directory that contains the shield definition
             '''))
 
@@ -82,4 +84,9 @@ class Shields(WestCommand):
         for shield in list_shields.find_shields(args):
             if name_re is not None and not name_re.search(shield.name):
                 continue
-            self.inf(args.format.format(name=shield.name, dir=shield.dir))
+            self.inf(args.format.format(
+                name=shield.name,
+                dir=shield.dir,
+                vendor=shield.vendor if hasattr(shield, 'vendor') else '',
+                full_name=shield.full_name if hasattr(shield, 'full_name') else shield.name
+            ))


### PR DESCRIPTION
Addressed performance issues from previous version (#90025) by having shields.cmake completely delegate shield detection/parsing to list_shields.py.

Basically the main change vs. #90025 is the second commit - the third commit, introducing shield.yml, is not touching shields.cmake anymore since only list_shields.py needs to be updated where before the logic was duplicated between shields.cmake and list_shields.py.

First commit is new as well and fixing a bug which probably no one caught before as it would have crashed only for people using e.g. `west shields` when having as part of their list BOARD_ROOT a folder _not_ containing a `boards/shields` folder.

https://builds.zephyrproject.io/zephyr/pr/90288/docs/boards/index.html#name=giga