### PR TITLE
net: zperf: Make UDP upload report retransmission count configurable

### DIFF
--- a/subsys/net/lib/zperf/Kconfig
+++ b/subsys/net/lib/zperf/Kconfig
@@ -71,4 +71,13 @@ config NET_ZPERF_MAX_SESSIONS
 	help
 	  Upper size limit for connections handled by zperf.
 
+config NET_ZPERF_UDP_REPORT_RETANSMISSION_COUNT
+	int "Maximum number of UDP upload report retransmissions"
+	depends on NET_UDP
+	range 1 16
+	default 4
+	help
+	  Maximum number of retries zperf will take to retrieve the UDP upload
+	  report from the server.
+
 endif

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -67,7 +67,7 @@ static inline int zperf_upload_fin(int sock,
 	struct zperf_client_hdr_v1 *hdr;
 	uint32_t secs = end_time_us / USEC_PER_SEC;
 	uint32_t usecs = end_time_us % USEC_PER_SEC;
-	int loop = 2;
+	int loop = CONFIG_NET_ZPERF_UDP_REPORT_RETANSMISSION_COUNT;
 	int ret = 0;
 	struct timeval rcvtimeo = {
 		.tv_sec = 2,

--- a/subsys/net/lib/zperf/zperf_udp_uploader.c
+++ b/subsys/net/lib/zperf/zperf_udp_uploader.c
@@ -118,7 +118,7 @@ static inline int zperf_upload_fin(int sock,
 			}
 
 			ret = zsock_recv(sock, stats, sizeof(stats), 0);
-			if (ret == -EAGAIN) {
+			if (ret < 0 && errno == EAGAIN) {
 				NET_WARN("Stats receive timeout");
 			} else if (ret < 0) {
 				NET_ERR("Failed to receive packet (%d)", errno);


### PR DESCRIPTION
As in the title + one small fix for the return value check.

Resolves #90253