### PR TITLE
mspm0: Add support for hwinfo

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -297,4 +297,11 @@ config HWINFO_RENESAS_RA
 	help
 	  Enable RENESAS RA hwinfo driver
 
+config HWINFO_MSPM0
+	bool "TI MSPM0 hwinfo"
+	default y
+	depends on SOC_FAMILY_TI_MSPM0
+	help
+	  Enable TI MSPM0 hwinfo driver
+
 endif

--- a/drivers/hwinfo/hwinfo_mspm0.c
+++ b/drivers/hwinfo/hwinfo_mspm0.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 Linumiz GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <ti/driverlib/driverlib.h>
+#include <string.h>
+
+static uint32_t reset_cause;
+ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
+{
+	struct mspm0_device_id {
+		uint16_t manufacturer;
+		uint16_t partnum;
+		uint8_t version;
+		uint32_t traceid;
+		uint16_t user_partnum;
+		uint8_t user_var;
+	};
+
+	struct mspm0_device_id info = {0};
+
+	info.manufacturer = DL_FactoryRegion_getManufacturerCode();
+	info.partnum = DL_FactoryRegion_getPartNumber();
+	info.version = DL_FactoryRegion_getVersion();
+	info.traceid = DL_FactoryRegion_getTraceID();
+	info.user_partnum = DL_FactoryRegion_getUserIDPart();
+	info.user_var = DL_FactoryRegion_getUserIDVariant();
+
+	if (length > sizeof(info)) {
+		length = sizeof(info);
+	}
+	memcpy(buffer, &info, length);
+
+	return length;
+}
+
+int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
+{
+	uint32_t reason;
+
+	if (reset_cause != 0) {
+		*cause = reset_cause;
+		return 0;
+	}
+
+	reason = DL_SYSCTL_getResetCause();
+	switch (reason) {
+	case DL_SYSCTL_RESET_CAUSE_POR_HW_FAILURE:
+		*cause = RESET_POR;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_POR_EXTERNAL_NRST:
+		__fallthrough;
+	case DL_SYSCTL_RESET_CAUSE_BOOTRST_EXTERNAL_NRST:
+		*cause = RESET_PIN;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_POR_SW_TRIGGERED:
+		__fallthrough;
+	case DL_SYSCTL_RESET_CAUSE_BOOTRST_SW_TRIGGERED:
+		__fallthrough;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_SW_TRIGGERED:
+		__fallthrough;
+	case DL_SYSCTL_RESET_CAUSE_CPURST_SW_TRIGGERED:
+		*cause = RESET_SOFTWARE;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_BOR_SUPPLY_FAILURE:
+		*cause = RESET_BROWNOUT;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_BOR_WAKE_FROM_SHUTDOWN:
+		*cause = RESET_LOW_POWER_WAKE;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_BOOTRST_NON_PMU_PARITY_FAULT:
+		*cause = RESET_PARITY;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_BOOTRST_CLOCK_FAULT:
+		*cause = RESET_CLOCK;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_BSL_EXIT:
+		__fallthrough;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_BSL_ENTRY:
+		*cause = RESET_BOOTLOADER;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_WWDT0_VIOLATION:
+		__fallthrough;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_WWDT1_VIOLATION:
+		*cause = RESET_WATCHDOG;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_FLASH_ECC_ERROR:
+		*cause = RESET_FLASH;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_CPU_LOCKUP_VIOLATION:
+		*cause = RESET_CPU_LOCKUP;
+		break;
+	case DL_SYSCTL_RESET_CAUSE_SYSRST_DEBUG_TRIGGERED:
+		__fallthrough;
+	case DL_SYSCTL_RESET_CAUSE_CPURST_DEBUG_TRIGGERED:
+		*cause = RESET_DEBUG;
+		break;
+	default:
+		break;
+	}
+
+	reset_cause = *cause;
+
+	return 0;
+}
+
+int z_impl_hwinfo_clear_reset_cause(void)
+{
+	reset_cause = 0;
+
+	return 0;
+}
+
+int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
+{
+	*supported = RESET_POR
+		   | RESET_PIN
+		   | RESET_SOFTWARE
+		   | RESET_BROWNOUT
+		   | RESET_LOW_POWER_WAKE
+		   | RESET_PARITY
+		   | RESET_CLOCK
+		   | RESET_BOOTLOADER
+		   | RESET_WATCHDOG
+		   | RESET_FLASH
+		   | RESET_CPU_LOCKUP
+		   | RESET_DEBUG;
+
+	return 0;
+}

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -69,6 +69,8 @@ extern "C" {
 #define RESET_TEMPERATURE			BIT(14)
 /** Bootloader reset (entry / exit) */
 #define RESET_BOOTLOADER			BIT(15)
+/** Flash ECC reset */
+#define RESET_FLASH				BIT(16)
 /**
  * @}
  */

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -67,6 +67,8 @@ extern "C" {
 #define RESET_USER				BIT(13)
 /** Temperature reset */
 #define RESET_TEMPERATURE			BIT(14)
+/** Bootloader reset (entry / exit) */
+#define RESET_BOOTLOADER			BIT(15)
 /**
  * @}
  */


### PR DESCRIPTION
Add support for hardware information driver for mspm0 series. This PR also includes addition of new flash ECC error and bootloader as reset cause.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>