### PR TITLE
west: blobs: fetch `--allow-regex` filter

### DIFF
--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -214,6 +214,12 @@ Additionally the tool allows you to specify the modules you want to list,
 fetch or clean blobs for by typing the module names as a command-line
 parameter.
 
+The argument ``--allow-regex`` can be passed ``west blobs fetch`` to restrict
+the specific blobs that are fetched, by passing a regular expression::
+
+  # For example, only download esp32 blobs, skip the other variants
+  west blobs fetch hal_espressif --allow-regex 'lib/esp32/.*'
+
 .. _west-twister:
 
 Twister wrapper: ``west twister``


### PR DESCRIPTION
When building in CI for specific SOCs, it's useful to only have `west blobs
fetch` pull a selected set of blob objects. This is especially helpful on
`hal_espressif`, which currently has 78 blob objects.

Add a `--allow-regex` arg to the `west blobs fetch` subcommand to filter
only specified blobs, for example:

```bash
# only download esp32 blobs, skip the other variants
❯ west blobs fetch hal_espressif --allow-regex 'lib/esp32/.*'
```

Also, replace all `str.format()` invocations with f-strings per review
feedback.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>