### PR TITLE
doc: kernel: services: correct usage example of k_poll_signal_reset

### DIFF
--- a/doc/kernel/services/polling.rst
+++ b/doc/kernel/services/polling.rst
@@ -296,7 +296,7 @@ been signaled.
                 // weird error
             }
 
-            k_poll_signal_reset(signal);
+            k_poll_signal_reset(&signal);
             events[0].state = K_POLL_STATE_NOT_READY;
         }
     }


### PR DESCRIPTION
Correct usage example of `k_poll_signal_reset`

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/90095