### PR TITLE
boards: renesas: update RX130 doc to use mainline zephyr sdk

### DIFF
--- a/boards/renesas/rsk_rx130/doc/index.rst
+++ b/boards/renesas/rsk_rx130/doc/index.rst
@@ -64,43 +64,21 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-Applications for the ``rsk_rx130@512kb`` board target configuration can be
-built, flashed, and debugged as below.
-
-Currently, the Zephyr SDK hasn't added support for RX builds yet, so the GCC for RX toolchain is required and build system need to be set to use "cross-compile".
-
-  - Download and install GCC for RX v8.3.0.202405 toolchain:
-
-    https://llvm-gcc-renesas.com/rx-download-toolchains/
-
-  - Set env variable:
-
-   .. code-block:: console
-
-      export ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
-      export CROSS_COMPILE=<Path to your toolchain>/bin/rx-elf-
-
-  - Build the Blinky Sample for RSK-RX130-512KB:
-
-   .. code-block:: console
-
-      cd ~/zephyrproject/zephyr
-      west build -p always -b rsk_rx130@512kb samples/basic/blinky
+Applications for the ``rsk_rx130@512kb`` board target can be built, flashed, and
+debugged in the usual way. See :ref:`build_an_application` and
+:ref:`application_run` for more details on building and running.
 
 Flashing
 ========
 
-Program can be flashed to RSKRX130-512KB via Jlink with RX adapter boards.
+Program can be flashed to RSKRX130-512KB using Jlink with RX adapter boards, by
+connecting the board's debug connector port to the host PC. Here's an example
+for building and flashing the :zephyr:code-sample:`hello_world` application.
 
-To flash the program to board
-
-  1. Connect from board's debug connector port to host PC using Jlink debugger.
-
-  2. Execute west command
-
-   .. code-block:: console
-
-      west flash
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: rsk_rx130@512kb
+   :goals: build flash
 
 Debugging
 =========


### PR DESCRIPTION
The Zephyr SDK 0.17.1 supports the RX architecture so the documentation of the RX130 board has been updated to reflect this.