### PR TITLE
fix potential speculative access that might trigger bus faults on Cortex-M7

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_regions.c
+++ b/arch/arm/core/mpu/arm_mpu_regions.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Linaro Limited.
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,8 +11,18 @@
 #include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
+
+#if defined(CONFIG_CPU_CORTEX_M7) && defined(CONFIG_CPU_HAS_ARM_MPU) && \
+	defined(CONFIG_CPU_HAS_DCACHE)
+	/* Erratum 1013783-B (SDEN-1068427): use first region to prevent speculative access
+	 * in entire memory space
+	 */
+	MPU_REGION_ENTRY("BACKGROUND",
+			 0,
+			 {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk}),
+#endif
+
 #ifdef CONFIG_XIP
-	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)
@@ -22,7 +33,6 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 #endif
 
-	/* Region 1 */
 	MPU_REGION_ENTRY("SRAM_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)

--- a/soc/nxp/s32/s32k3/mpu_regions.c
+++ b/soc/nxp/s32/s32k3/mpu_regions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 NXP
+ * Copyright 2023, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,13 @@ extern char _rom_attr[];
 #endif
 
 static struct arm_mpu_region mpu_regions[] = {
+
+	/* ERR011573: use first region to prevent speculative access in entire memory space */
+	{
+		.name = "BACKGROUND",
+		.base = 0,
+		.attr = {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk},
+	},
 
 	/* Keep before CODE region so it can be overlapped by SRAM CODE in non-XIP systems */
 	{


### PR DESCRIPTION
Due to erratum [1013783-B](https://documentation-service.arm.com/static/665dff778ad83c4754308908?token=), speculative accesses might be performed to normal memory unmapped in the MPU. This can be avoided by using MPU region 0 to cover all unmapped memory and make this region execute-never and inaccessible.

Note that this applies for all Cortex-M7 revisions implementing MPU and D-cache, so although the issue was reported for `mr_canhubk3` board that implements custom SoC MPU regions, I added the fix for any Cortex-M7 SoC having those features enabled.

Fixes #89852