### PR TITLE
drivers: Update DTC transfer info alignment for Renesas RA drivers

### DIFF
--- a/drivers/i2c/i2c_renesas_ra_sci_b.c
+++ b/drivers/i2c/i2c_renesas_ra_sci_b.c
@@ -55,14 +55,14 @@ struct sci_b_i2c_data {
 #ifdef CONFIG_I2C_RENESAS_RA_SCI_B_DTC
 	/* RX */
 	transfer_instance_t rx_transfer;
-	transfer_info_t rx_transfer_info;
+	transfer_info_t rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	transfer_cfg_t rx_transfer_cfg;
 	dtc_instance_ctrl_t rx_transfer_ctrl;
 	dtc_extended_cfg_t rx_transfer_cfg_extend;
 
 	/* TX */
 	transfer_instance_t tx_transfer;
-	transfer_info_t tx_transfer_info;
+	transfer_info_t tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	transfer_cfg_t tx_transfer_cfg;
 	dtc_instance_ctrl_t tx_transfer_ctrl;
 	dtc_extended_cfg_t tx_transfer_cfg_extend;

--- a/drivers/sdhc/sdhc_renesas_ra.c
+++ b/drivers/sdhc/sdhc_renesas_ra.c
@@ -65,7 +65,7 @@ struct sdhc_ra_priv {
 	/* Transfer DTC */
 	struct st_transfer_instance transfer;
 	struct st_dtc_instance_ctrl transfer_ctrl;
-	struct st_transfer_info transfer_info;
+	struct st_transfer_info transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg transfer_cfg;
 	struct st_dtc_extended_cfg transfer_cfg_extend;
 };

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -49,7 +49,7 @@ struct uart_ra_sci_b_data {
 	/* RX */
 	struct st_transfer_instance rx_transfer;
 	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info;
+	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
 	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 	struct k_work_delayable rx_timeout_work;
@@ -64,7 +64,7 @@ struct uart_ra_sci_b_data {
 	/* TX */
 	struct st_transfer_instance tx_transfer;
 	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info;
+	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
 	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
 	struct k_work_delayable tx_timeout_work;

--- a/drivers/serial/uart_renesas_ra_sci.c
+++ b/drivers/serial/uart_renesas_ra_sci.c
@@ -63,7 +63,7 @@ struct uart_ra_sci_data {
 
 	struct st_transfer_instance rx_transfer;
 	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info;
+	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
 	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 
@@ -72,7 +72,7 @@ struct uart_ra_sci_data {
 
 	struct st_transfer_instance tx_transfer;
 	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info;
+	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
 	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
 #endif

--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -45,14 +45,14 @@ struct ra_spi_data {
 	/* RX */
 	struct st_transfer_instance rx_transfer;
 	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info;
+	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
 	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 
 	/* TX */
 	struct st_transfer_instance tx_transfer;
 	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info;
+	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
 	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
 #endif

--- a/drivers/spi/spi_renesas_ra.c
+++ b/drivers/spi/spi_renesas_ra.c
@@ -41,14 +41,14 @@ struct ra_spi_data {
 	/* RX */
 	struct st_transfer_instance rx_transfer;
 	struct st_dtc_instance_ctrl rx_transfer_ctrl;
-	struct st_transfer_info rx_transfer_info;
+	struct st_transfer_info rx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg rx_transfer_cfg;
 	struct st_dtc_extended_cfg rx_transfer_cfg_extend;
 
 	/* TX */
 	struct st_transfer_instance tx_transfer;
 	struct st_dtc_instance_ctrl tx_transfer_ctrl;
-	struct st_transfer_info tx_transfer_info;
+	struct st_transfer_info tx_transfer_info DTC_TRANSFER_INFO_ALIGNMENT;
 	struct st_transfer_cfg tx_transfer_cfg;
 	struct st_dtc_extended_cfg tx_transfer_cfg_extend;
 #endif


### PR DESCRIPTION
Update DTC transfer info alignment for Renesas RA SCI_B_I2C, SCI_B_UART, SCI_UART, SPI_B, SPI, SDHC drivers