### PR TITLE
boards: st: fix boards DTS files coding style issues

### DIFF
--- a/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/st/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -22,18 +22,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		blue_led_2: led2 {
 			gpios = <&gpioa 15 GPIO_ACTIVE_HIGH>;
 			label = "LED_DOWN_BLUE";
 		};
+
 		orange_led_3: led3 {
 			gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 			label = "LED_LEFT_ORANGE";
 		};
+
 		green_led_4: led4 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "LED_RIGHT_GREEN";
 		};
+
 		red_led_5: led5 {
 			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
 			label = "LED_UP_RED";
@@ -42,26 +46,31 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		joystick_sel: button0 {
 			label = "JOYSTICK_SEL";
 			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joystick_left: button1 {
 			label = "JOYSTICK_LEFT";
 			gpios = <&gpioc 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joystick_down: button2 {
 			label = "JOYSTICK_DOWN";
 			gpios = <&gpioc 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joystick_right: button3 {
 			label = "JOYSTICK_RIGHT";
 			gpios = <&gpiob 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_RIGHT>;
 		};
+
 		joystick_up: button4 {
 			label = "JOYSTICK_UP";
 			gpios = <&gpiob 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -97,7 +106,7 @@
 
 stm32_lp_tick_source: &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
-	<&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
+		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";
 };
 

--- a/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -22,18 +22,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_0: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 1";
 		};
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 2";
 		};
+
 		blue_led: led_2 {
 			gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
 			label = "Blue LED";
 		};
+
 		red_led: led_3 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "Red LED";
@@ -42,6 +46,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "Push button switch";
 			gpios = <&gpiob 2 GPIO_ACTIVE_LOW>;

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -27,10 +27,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		green_led_2: led_2 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -39,6 +41,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -173,7 +176,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -13,10 +13,12 @@
 / {
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioh 7 GPIO_ACTIVE_LOW>;
 			label = "User LD7";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpioh 6 GPIO_ACTIVE_LOW>;
 			label = "User LD6";
@@ -25,6 +27,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -104,6 +107,7 @@ stm32_lp_tick_source: &lptim1 {
 &timers4 {
 	status = "okay";
 	st,prescaler = <1>;
+
 	pwm4: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim4_ch1_pb6>;
@@ -114,6 +118,7 @@ stm32_lp_tick_source: &lptim1 {
 &timers3 {
 	status = "okay";
 	st,prescaler = <255>;
+
 	pwm3: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim3_ch2_pe4>;

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -53,23 +53,26 @@
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
 		};
+
 		slot1_partition: partition@78000 {
 			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
 		};
+
 		scratch_partition: partition@e0000 {
 			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
 		};
+
 		storage_partition: partition@f0000 {
 			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
 		};
-
 	};
 };
 

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.dts
@@ -27,7 +27,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -44,26 +43,31 @@
 			reg = <0x00000000 DT_SIZE_K(224)>;
 			read-only;
 		};
+
 		/* Secure image primary slot */
 		slot0_partition: partition@38000 {
 			label = "image-0";
 			reg = <0x00038000 DT_SIZE_K(384)>;
 		};
+
 		/* Non-secure image primary slot */
 		slot0_ns_partition: partition@98000 {
 			label = "image-0-nonsecure";
 			reg = <0x00098000 DT_SIZE_K(512)>;
 		};
+
 		/* Secure image secondary slot */
 		slot1_partition: partition@118000 {
 			label = "image-1";
 			reg = <0x00118000 DT_SIZE_K(384)>;
 		};
+
 		/* Non-secure image secondary slot */
 		slot1_ns_partition: partition@178000 {
 			label = "image-1-nonsecure";
 			reg = <0x00178000 DT_SIZE_K(512)>;
 		};
+
 		/* Applicative Non Volatile Storage */
 		storage_partition: partition@1f8000 {
 			label = "storage";

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -27,10 +27,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		green_led_2: led_2 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -39,6 +41,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -58,6 +61,7 @@
 			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "green LD1";
 		};
+
 		green_pwm_2: green_led_2 {
 			pwms = <&pwm15 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "green LD2";
@@ -336,7 +340,7 @@ zephyr_udc0: &usbotg_fs {
 			slot1_partition: partition@0 {
 				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(864)>;
-				};
+			};
 
 			slot2_partition: partition@d8000 {
 				label = "image-3";

--- a/boards/st/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/st/nucleo_c031c6/nucleo_c031c6.dts
@@ -23,6 +23,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_4: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -39,6 +40,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "user button";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -23,6 +23,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
@@ -44,6 +45,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "user button";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/st/nucleo_f030r8/nucleo_f030r8.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/st/nucleo_f031k6/nucleo_f031k6.dts
@@ -21,6 +21,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_3: led_3 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -29,6 +30,7 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
+
 		green_pwm_led: green_pwm_led {
 			pwms = <&pwm2 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};

--- a/boards/st/nucleo_f042k6/nucleo_f042k6.dts
+++ b/boards/st/nucleo_f042k6/nucleo_f042k6.dts
@@ -21,6 +21,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_3: led_3 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -29,6 +30,7 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
+
 		green_pwm_led: green_pwm_led {
 			pwms = <&pwm3 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};

--- a/boards/st/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/st/nucleo_f070rb/nucleo_f070rb.dts
@@ -25,6 +25,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -33,6 +34,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f072rb/nucleo_f072rb.dts
+++ b/boards/st/nucleo_f072rb/nucleo_f072rb.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/st/nucleo_f091rc/nucleo_f091rc.dts
@@ -25,6 +25,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -33,6 +34,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -142,7 +144,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/st/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/st/nucleo_f103rb/nucleo_f103rb.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -23,14 +23,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -44,10 +47,12 @@
 			pwms = <&pwm3 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Green PWM LED";
 		};
+
 		blue_pwm_led: led_pwm_2 {
 			pwms = <&pwm4 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Blue PWM LED";
 		};
+
 		red_pwm_led: led_pwm_0 {
 			pwms = <&pwm12 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Red PWM LED";
@@ -56,6 +61,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_f302r8/nucleo_f302r8.dts
+++ b/boards/st/nucleo_f302r8/nucleo_f302r8.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/st/nucleo_f303k8/nucleo_f303k8.dts
@@ -22,6 +22,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_3: green_led_3 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 			label = "LD3";
@@ -29,6 +30,7 @@
 	};
 	pwmleds {
 		compatible = "pwm-leds";
+
 		green_pwm_led: green_pwm_led {
 			pwms = <&pwm2 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};

--- a/boards/st/nucleo_f303re/nucleo_f303re.dts
+++ b/boards/st/nucleo_f303re/nucleo_f303re.dts
@@ -25,6 +25,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -33,6 +34,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/st/nucleo_f334r8/nucleo_f334r8.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -127,7 +129,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/st/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/st/nucleo_f401re/nucleo_f401re.dts
@@ -26,6 +26,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -34,6 +35,7 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
+
 		green_pwm_led: green_pwm_led {
 			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -129,7 +131,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -150,10 +151,12 @@
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
+
 		slot1_partition: partition@40000 {
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
+
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;

--- a/boards/st/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/st/nucleo_f410rb/nucleo_f410rb.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -120,7 +122,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -140,6 +141,7 @@
 			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(32)>;
 		};
+
 		/*
 		 * The flash sectors 4 at 0x00010000 and ending at
 		 * 0x001ffff
@@ -148,6 +150,7 @@
 			label = "image-1";
 			reg = <0x00010000 DT_SIZE_K(32)>;
 		};
+
 		scratch_partition: partition@18000 {
 			label = "image-scratch";
 			reg = <0x00018000 DT_SIZE_K(32)>;

--- a/boards/st/nucleo_f411re/nucleo_f411re.dts
+++ b/boards/st/nucleo_f411re/nucleo_f411re.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_f412zg/nucleo_f412zg.dts
+++ b/boards/st/nucleo_f412zg/nucleo_f412zg.dts
@@ -23,14 +23,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -39,6 +42,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/st/nucleo_f413zh/nucleo_f413zh.dts
@@ -24,14 +24,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -40,6 +43,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -25,14 +25,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -41,6 +44,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -241,7 +245,6 @@ zephyr_udc0: &usbotg_fs {
 			label = "image-scratch";
 			reg = <0x000a0000 DT_SIZE_K(128)>;
 		};
-
 	};
 };
 

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -25,6 +25,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -33,6 +34,7 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
+
 		green_pwm_led: green_pwm_led {
 			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -40,6 +42,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -157,7 +160,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -183,10 +185,12 @@
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
+
 		slot1_partition: partition@40000 {
 			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
+
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -24,14 +24,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_2: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_3: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -40,6 +43,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -184,7 +188,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -27,14 +27,17 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -43,6 +46,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -217,7 +221,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -32,14 +32,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led: led_1 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led: led_2 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -48,6 +51,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -32,14 +32,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led: led_1 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led: led_2 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -48,6 +51,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -198,6 +202,5 @@ zephyr_udc0: &usbotg_fs {
 			label = "image-scratch";
 			reg = <0x000C0000 DT_SIZE_K(256)>;
 		};
-
 	};
 };

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -33,14 +33,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led: led_1 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led: led_2 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -49,6 +52,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_g031k8/nucleo_g031k8.dts
+++ b/boards/st/nucleo_g031k8/nucleo_g031k8.dts
@@ -22,6 +22,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_3: led_3 {
 			gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";

--- a/boards/st/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/st/nucleo_g070rb/nucleo_g070rb.dts
@@ -25,6 +25,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -33,6 +34,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -101,6 +103,7 @@
 &timers3 {
 	st,prescaler = <10000>;
 	status = "okay";
+
 	pwm3: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pa6>;

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -23,9 +23,9 @@
 		zephyr,flash = &flash0;
 	};
 
-
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -34,6 +34,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -107,6 +108,7 @@
 &timers3 {
 	st,prescaler = <10000>;
 	status = "okay";
+
 	pwm3: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pa6>;

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -27,6 +27,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -35,6 +36,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -115,6 +117,7 @@ zephyr_udc0: &usb {
 &timers3 {
 	st,prescaler = <10000>;
 	status = "okay";
+
 	pwm3: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pb4>;
@@ -125,6 +128,7 @@ zephyr_udc0: &usb {
 &timers15 {
 	st,prescaler = <10000>;
 	status = "okay";
+
 	pwm15: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim15_ch1_pb14>;
@@ -205,14 +209,17 @@ zephyr_udc0: &usb {
 			reg = <0x00000000 DT_SIZE_K(48)>;
 			read-only;
 		};
+
 		slot0_partition: partition@C000 {
 			label = "image-0";
 			reg = <0x0000C000 DT_SIZE_K(200)>;
 		};
+
 		slot1_partition: partition@3E000 {
 			label = "image-1";
 			reg = <0x0003E000 DT_SIZE_K(200)>;
 		};
+
 		/* final 64KiB reserved for app storage partition */
 		storage_partition: partition@70000 {
 			label = "storage";

--- a/boards/st/nucleo_g431kb/nucleo_g431kb.dts
+++ b/boards/st/nucleo_g431kb/nucleo_g431kb.dts
@@ -21,6 +21,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -102,7 +103,6 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/st/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/st/nucleo_g431rb/nucleo_g431rb.dts
@@ -25,6 +25,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -41,6 +42,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -163,7 +165,6 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -173,14 +174,17 @@ stm32_lp_tick_source: &lptim1 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(34)>;
 		};
+
 		slot0_partition: partition@8800 {
 			label = "image-0";
 			reg = <0x00008800 DT_SIZE_K(48)>;
 		};
+
 		slot1_partition: partition@14800 {
 			label = "image-1";
 			reg = <0x00014800 DT_SIZE_K(42)>;
 		};
+
 		/* Set 4Kb of storage at the end of the 128Kb of flash */
 		storage_partition: partition@1f000 {
 			label = "storage";

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -26,6 +26,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -42,6 +43,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -177,14 +179,17 @@ stm32_lp_tick_source: &lptim1 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(34)>;
 		};
+
 		slot0_partition: partition@8800 {
 			label = "image-0";
 			reg = <0x00008800 DT_SIZE_K(240)>;
 		};
+
 		slot1_partition: partition@44800 {
 			label = "image-1";
 			reg = <0x00044800 DT_SIZE_K(234)>;
 		};
+
 		/* Set 4Kb of storage at the end of the 512Kb of flash */
 		storage_partition: partition@7f000 {
 			label = "storage";

--- a/boards/st/nucleo_h503rb/nucleo_h503rb.dts
+++ b/boards/st/nucleo_h503rb/nucleo_h503rb.dts
@@ -28,6 +28,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -36,6 +37,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_42 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
@@ -41,6 +42,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -14,14 +14,17 @@
 / {
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led_1: led_2 {
 			gpios = <&gpiof 4 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpiog 4 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -30,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -180,14 +184,17 @@
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(960)>;
 		};
+
 		slot1_partition: partition@100000 {
 			label = "image-1";
 			reg = <0x00100000 DT_SIZE_K(960)>;
 		};
+
 		storage_partition: partition@1f0000 {
 			label = "storage";
 			reg = <0x001f0000 DT_SIZE_K(64)>;

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -29,14 +29,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led: led_1 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led: led_2 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -54,6 +57,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -26,10 +26,12 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led: led_1 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -46,6 +48,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -272,7 +275,6 @@ zephyr_udc0: &usbotg_fs {
 			label = "image-scratch";
 			reg = <0x000c0000 DT_SIZE_K(128)>;
 		};
-
 	};
 };
 

--- a/boards/st/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
+++ b/boards/st/nucleo_h745zi_q/nucleo_h745zi_q.dtsi
@@ -11,10 +11,12 @@
 / {
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led: led_2 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -23,6 +25,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 			label = "User SB1";

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -26,10 +26,12 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led: led_1 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -46,6 +48,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -260,6 +263,5 @@ zephyr_udc0: &usbotg_fs {
 			label = "image-scratch";
 			reg = <0x000c0000 DT_SIZE_K(128)>;
 		};
-
 	};
 };

--- a/boards/st/nucleo_h755zi_q/nucleo_h755zi_q.dtsi
+++ b/boards/st/nucleo_h755zi_q/nucleo_h755zi_q.dtsi
@@ -11,14 +11,17 @@
 / {
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_1 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led: led_2 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -27,6 +30,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 			label = "User SB1";

--- a/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/st/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -25,10 +25,12 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led: led_1 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -45,6 +47,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -24,14 +24,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_1 {
 			gpios = <&gpiod 10 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		yellow_led: led_2 {
 			gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led: led_3 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -40,6 +43,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -196,14 +200,17 @@
 				label = "image-0";
 				reg = <0x00000000 DT_SIZE_K(512)>;
 			};
+
 			slot1_partition: partition@80000 {
 				label = "image-1";
 				reg = <0x0080000 DT_SIZE_K(512)>;
 			};
+
 			scratch_partition: partition@100000 {
 				label = "image-scratch";
 				reg = <0x00100000 DT_SIZE_K(64)>;
 			};
+
 			storage_partition: partition@110000 {
 				label = "storage";
 				reg = <0x00110000 DT_SIZE_K(64)>;

--- a/boards/st/nucleo_l011k4/nucleo_l011k4.dts
+++ b/boards/st/nucleo_l011k4/nucleo_l011k4.dts
@@ -22,6 +22,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -30,6 +31,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 12 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_l031k6/nucleo_l031k6.dts
+++ b/boards/st/nucleo_l031k6/nucleo_l031k6.dts
@@ -22,6 +22,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";

--- a/boards/st/nucleo_l053r8/nucleo_l053r8.dts
+++ b/boards/st/nucleo_l053r8/nucleo_l053r8.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/st/nucleo_l073rz/nucleo_l073rz.dts
@@ -25,6 +25,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -33,6 +34,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/st/nucleo_l152re/nucleo_l152re.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_0: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -23,6 +23,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -31,6 +32,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/st/nucleo_l432kc/nucleo_l432kc.dts
@@ -22,6 +22,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";

--- a/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 			label = "User";

--- a/boards/st/nucleo_l452re/nucleo_l452re.dts
+++ b/boards/st/nucleo_l452re/nucleo_l452re.dts
@@ -17,6 +17,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";

--- a/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -24,6 +24,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -116,9 +117,8 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-		/*
-		 * Reserve the final 16 KiB for file system partition
-		 */
+
+		/* Reserve the final 16 KiB for file system partition */
 		storage_partition: partition@7c000 {
 			label = "storage";
 			reg = <0x0007c000 0x00004000>;

--- a/boards/st/nucleo_l452re/nucleo_l452re_stm32l452xx_p.dts
+++ b/boards/st/nucleo_l452re/nucleo_l452re_stm32l452xx_p.dts
@@ -16,6 +16,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_0 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -24,6 +24,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,6 +33,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;

--- a/boards/st/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/st/nucleo_l496zg/nucleo_l496zg.dts
@@ -23,14 +23,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_2: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_3: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -47,6 +50,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User Button";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.dts
+++ b/boards/st/nucleo_l4a6zg/nucleo_l4a6zg.dts
@@ -23,14 +23,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_2: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_3: led_3 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -47,6 +50,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User Button";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -23,6 +23,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_0: led_0 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
@@ -41,6 +42,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -12,14 +12,17 @@
 / {
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -28,6 +31,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.dts
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.dts
@@ -29,7 +29,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -47,21 +46,25 @@
 			reg = <0x00000000 DT_SIZE_K(80)>;
 			read-only;
 		};
+
 		/* Secure image primary slot */
 		slot0_partition: partition@14000 {
 			label = "image-0";
 			reg = <0x00014000 DT_SIZE_K(180)>;
 		};
+
 		/* Non-secure image primary slot */
 		slot0_ns_partition: partition@41000 {
 			label = "image-0-nonsecure";
 			reg = <0x00041000 DT_SIZE_K(36)>;
 		};
+
 		/* Secure image secondary slot */
 		slot1_partition: partition@4a000 {
 			label = "image-1";
 			reg = <0x0004a000 DT_SIZE_K(180)>;
 		};
+
 		/* Non-secure image secondary slot */
 		slot1_ns_partition: partition@77000 {
 			label = "image-1-nonsecure";

--- a/boards/st/nucleo_u031r8/nucleo_u031r8.dts
+++ b/boards/st/nucleo_u031r8/nucleo_u031r8.dts
@@ -26,6 +26,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -34,6 +35,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -26,6 +26,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_4 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -34,6 +35,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;

--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -13,14 +13,17 @@
 / {
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpiog 2 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -29,6 +32,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -147,7 +151,7 @@
 	status = "okay";
 
 	pwm3: pwm {
-	pinctrl-0 = <&tim3_ch2_pc7>;
+		pinctrl-0 = <&tim3_ch2_pc7>;
 		pinctrl-names = "default";
 		status = "okay";
 	};

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q-common.dtsi
@@ -12,14 +12,17 @@
 / {
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led_1: led_2 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_1: led_3 {
 			gpios = <&gpiog 2 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -28,6 +31,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -146,7 +150,7 @@
 	status = "okay";
 
 	pwm3: pwm {
-	pinctrl-0 = <&tim3_ch2_pc7>;
+		pinctrl-0 = <&tim3_ch2_pc7>;
 		pinctrl-names = "default";
 		status = "okay";
 	};

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -48,14 +48,17 @@
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(1952)>;
 		};
+
 		slot1_partition: partition@1f8000 {
 			label = "image-1";
 			reg = <0x001f8000 DT_SIZE_K(1960)>;
 		};
+
 		storage_partition: partition@3e2000 {
 			label = "storage";
 			reg = <0x003e2000 DT_SIZE_K(120)>;

--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -28,12 +28,15 @@
 
 	leds: leds {
 		compatible ="gpio-leds";
+
 		blue_led_1: led_0 {
 			gpios = <&gpiob 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
+
 		red_led_1: led_2 {
 			gpios = <&gpiob 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
@@ -42,6 +45,7 @@
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
 		status = "okay";
+
 		pwm_red_led_1: pwm_led_1 {
 			pwms = <&pwm2 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -49,16 +53,19 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button_1: button_0 {
 			label = "SW1";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		user_button_2: button_1 {
 			label = "SW2";
 			gpios = <&gpiob 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+
 		user_button_3: button_2 {
 			label = "SW3";
 			gpios = <&gpiob 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -165,6 +172,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
 		/* Set 8KB of storage at the end of 192KB flash */
 		storage_partition: partition@2e000 {
 			label = "storage";

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -28,12 +28,15 @@
 
 	leds: leds {
 		compatible ="gpio-leds";
+
 		blue_led_1: led_0 {
 			gpios = <&gpiob 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
+
 		red_led_1: led_2 {
 			gpios = <&gpiob 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
@@ -41,6 +44,7 @@
 
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
+
 		pwm_red_led_1: pwm_red_led_1 {
 			pwms = <&pwm1 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -48,16 +52,19 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button_1: button_0 {
 			label = "SW1";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		user_button_2: button_1 {
 			label = "SW2";
 			gpios = <&gpiob 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+
 		user_button_3: button_2 {
 			label = "SW3";
 			gpios = <&gpiob 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -162,6 +169,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
 		/* Set aside 16KB of storage at the end of 256KB flash */
 		storage_partition: partition@3c000 {
 			label = "storage";

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -28,12 +28,15 @@
 
 	leds: leds {
 		compatible ="gpio-leds";
+
 		blue_led_1: led_0 {
 			gpios = <&gpiob 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
+
 		green_led_1: led_1 {
 			gpios = <&gpiob 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
+
 		red_led_1: led_2 {
 			gpios = <&gpiob 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		};
@@ -42,6 +45,7 @@
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
 		status = "okay";
+
 		pwm_red_led_1: pwm_led_1 {
 			pwms = <&pwm2 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -49,16 +53,19 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button_1: button_0 {
 			label = "SW1";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		user_button_2: button_1 {
 			label = "SW2";
 			gpios = <&gpiob 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+
 		user_button_3: button_2 {
 			label = "SW3";
 			gpios = <&gpiob 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -164,6 +171,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
 		/* Set 32KB of storage at the end of 512KB flash */
 		storage_partition: partition@78000 {
 			label = "storage";

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -26,14 +26,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		blue_led_1: led_0 {
 			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
 			label = "User LED1";
 		};
+
 		green_led_2: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "User LED2";
 		};
+
 		red_led_3: led_2 {
 			gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 			label = "User LED3";
@@ -42,16 +45,19 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button_1: button_0 {
 			label = "SW1";
 			gpios = <&gpioc 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		user_button_2: button_1 {
 			label = "SW2";
 			gpios = <&gpiod 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+
 		user_button_3: button_2 {
 			label = "SW3";
 			gpios = <&gpiod 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -162,6 +168,7 @@
 
 &timers2 {
 	status = "okay";
+
 	pwm2: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa15>;
@@ -227,23 +234,26 @@ zephyr_udc0: &usb {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 		};
+
 		slot0_partition: partition@c000 {
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
 		};
+
 		slot1_partition: partition@70000 {
 			label = "image-1";
 			reg = <0x00070000 DT_SIZE_K(400)>;
 		};
+
 		scratch_partition: partition@d4000 {
 			label = "image-scratch";
 			reg = <0x000d4000 DT_SIZE_K(16)>;
 		};
+
 		storage_partition: partition@d8000 {
 			label = "storage";
 			reg = <0x000d8000 DT_SIZE_K(8)>;
 		};
-
 	};
 };
 

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -29,14 +29,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		blue_led_1: led_0 {
 			gpios = <&gpiob 4 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
 		};
+
 		green_led_2: led_1 {
 			gpios = <&gpioa 9 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 		};
+
 		red_led_3: led_2 {
 			gpios = <&gpiob 8 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
@@ -53,16 +56,19 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button_1: button_0 {
 			label = "User B1";
 			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		user_button_2: button_1 {
 			label = "User B2";
 			gpios = <&gpiob 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+
 		user_button_3: button_2 {
 			label = "User B3";
 			gpios = <&gpiob 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -206,14 +212,17 @@ stm32_lp_tick_source: &lptim1 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(456)>;
 		};
+
 		slot1_partition: partition@82000 {
 			label = "image-1";
 			reg = <0x00082000 DT_SIZE_K(448)>;
 		};
+
 		storage_partition: partition@f2000 {
 			label = "storage";
 			reg = <0x000f2000 DT_SIZE_K(56)>;

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -25,14 +25,17 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		blue_led_1: led_0 {
 			gpios = <&gpiob 15 GPIO_ACTIVE_HIGH>;
 			label = "User LED1";
 		};
+
 		green_led_2: led_1 {
 			gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 			label = "User LED2";
 		};
+
 		green_led_3: led_2 {
 			gpios = <&gpiob 11 GPIO_ACTIVE_HIGH>;
 			label = "User LED3";
@@ -41,16 +44,19 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button_1: button_0 {
 			label = "SW1";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		user_button_2: button_1 {
 			label = "SW2";
 			gpios = <&gpioa 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_1>;
 		};
+
 		user_button_3: button_2 {
 			label = "SW3";
 			gpios = <&gpioc 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -138,6 +144,7 @@ stm32_lp_tick_source: &lptim1 {
 
 &timers2 {
 	status = "okay";
+
 	pwm2: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim2_ch4_pb11>;
@@ -172,6 +179,7 @@ stm32_lp_tick_source: &lptim1 {
 
 &subghzspi {
 	status = "okay";
+
 	lora: radio@0 {
 		status = "okay";
 		tx-enable-gpios = <&gpioc 4 GPIO_ACTIVE_LOW>; /* FE_CTRL1 */
@@ -200,10 +208,12 @@ stm32_lp_tick_source: &lptim1 {
 			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
+
 		slot0_partition: partition@8000 {
 			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(104)>;
 		};
+
 		slot1_partition: partition@22000 {
 			label = "image-1";
 			reg = <0x00022000 DT_SIZE_K(104)>;

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -24,6 +24,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		blue_led: led {
 			gpios = <&gpiob 15 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
@@ -37,6 +38,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User PB1";
 			gpios = <&gpiog 1 GPIO_ACTIVE_LOW>;
@@ -138,7 +140,8 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	cs-gpios = <&gpioe 11 GPIO_ACTIVE_LOW>, <&gpioe 12 GPIO_ACTIVE_LOW>, <&gpioe 10 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpioe 11 GPIO_ACTIVE_LOW>, <&gpioe 12 GPIO_ACTIVE_LOW>,
+		<&gpioe 10 GPIO_ACTIVE_LOW>;
 
 	lis2dw12: lis2dw12@0 {
 		compatible = "st,lis2dw12";
@@ -168,6 +171,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpiod 0 GPIO_ACTIVE_LOW>;
+
 	spbtle_1s_sensortile_box: spbtle-1s@0 {
 		compatible = "st,hci-spi-v2";
 		reg = <0>;
@@ -208,7 +212,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -229,10 +232,12 @@ zephyr_udc0: &usbotg_fs {
 			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(432)>;
 		};
+
 		slot1_partition: partition@8c000 {
 			label = "image-1";
 			reg = <0x0008C000 DT_SIZE_K(432)>;
 		};
+
 		scratch_partition: partition@f8000 {
 			label = "image-scratch";
 			reg = <0x000F8000 DT_SIZE_K(24)>;

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -22,18 +22,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiof 6 GPIO_ACTIVE_HIGH>;
 			label = "User GREEN led";
 		};
+
 		red_led_1: led_2 {
 			gpios = <&gpioh 11 GPIO_ACTIVE_HIGH>;
 			label = "User RED led";
 		};
+
 		yellow_led_1: led_3 {
 			gpios = <&gpioh 12 GPIO_ACTIVE_HIGH>;
 			label = "User YELLOW led";
 		};
+
 		blue_led_1: led_4 {
 			gpios = <&gpiof 9 GPIO_ACTIVE_HIGH>;
 			label = "User YELLOW led";
@@ -42,11 +46,13 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		button1: button1 {
 			label = "User BT1";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button2: button2 {
 			label = "User BT2";
 			gpios = <&gpioe 0 GPIO_ACTIVE_HIGH>;
@@ -202,6 +208,7 @@ stm32_lp_tick_source: &lptim1 {
 &timers4 {
 	status = "okay";
 	st,prescaler = <1>;
+
 	pwm4: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim4_ch1_pb6>;
@@ -212,6 +219,7 @@ stm32_lp_tick_source: &lptim1 {
 &timers3 {
 	status = "okay";
 	st,prescaler = <255>;
+
 	pwm3: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim3_ch2_pe4>;
@@ -338,23 +346,26 @@ zephyr_udc0: &usbotg_fs {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
 		};
+
 		slot1_partition: partition@78000 {
 			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
 		};
+
 		scratch_partition: partition@e0000 {
 			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
 		};
+
 		storage_partition: partition@f0000 {
 			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
 		};
-
 	};
 };
 

--- a/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
+++ b/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
@@ -24,9 +24,11 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		orange_led: led_1 {
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 		};
+
 		yellow_led: led_2 {
 			gpios = <&gpioc 4 GPIO_ACTIVE_HIGH>;
 		};
@@ -34,26 +36,32 @@
 
 	buttons: gpio_keys {
 		compatible = "gpio-keys";
+
 		blue_button: button_1 {
 			gpios = <&gpioc 14 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		sel_button: button_2 {
 			gpios = <&gpioe 8 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		left_button: button_3 {
 			gpios = <&gpioe 9 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		right_button: button_4 {
 			gpios = <&gpioe 11 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_RIGHT>;
 		};
+
 		up_button: button_5 {
 			gpios = <&gpioe 10 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_UP>;
 		};
+
 		down_button: button_6 {
 			gpios = <&gpioe 12 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_DOWN>;
@@ -83,7 +91,7 @@
 			width = <240>;
 			height = <320>;
 			duplex = <0x800>;
-	    };
+		};
 	};
 };
 
@@ -134,7 +142,6 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
-
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;

--- a/boards/st/steval_fcu001v1/steval_fcu001v1.dts
+++ b/boards/st/steval_fcu001v1/steval_fcu001v1.dts
@@ -21,6 +21,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led_1: led_1 {
 			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -23,10 +23,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led: led_1 {
 			gpios = <&gpioh 12 GPIO_ACTIVE_HIGH>;
 			label = "LED_1";
 		};
+
 		orange_led: led_2 {
 			gpios = <&gpioh 10 GPIO_ACTIVE_HIGH>;
 			label = "LED_2";
@@ -44,6 +46,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioe 0 GPIO_ACTIVE_HIGH>;
@@ -154,19 +157,20 @@ stm32_lp_tick_source: &lptim1 {
 	cs-gpios = <&gpioh 6 GPIO_ACTIVE_LOW>,
 		   <&gpioh 15 GPIO_ACTIVE_LOW>,
 		   <&gpioi 7 GPIO_ACTIVE_LOW>;
+
 	iis2dlpc: iis2dlpc@0 {
 		compatible = "st,iis2dlpc";
 		spi-max-frequency = <DT_FREQ_M(10)>;
 		reg = <0>;
 		drdy-gpios = <&gpiof 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
-		drdy-int =  <1>;
+		drdy-int = <1>;
 	};
 
 	ism330dhcx: ism330dhcx@1 {
 		compatible = "st,ism330dhcx";
 		spi-max-frequency = <DT_FREQ_M(10)>;
 		reg = <1>;
-		drdy-gpios =  <&gpiob 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+		drdy-gpios = <&gpiob 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		int-pin = <1>;
 	};
 
@@ -175,7 +179,7 @@ stm32_lp_tick_source: &lptim1 {
 		spi-max-frequency = <DT_FREQ_M(10)>;
 		reg = <2>;
 		drdy-gpios = <&gpiof 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
-		int-pin =  <2>;
+		int-pin = <2>;
 	};
 };
 
@@ -184,6 +188,7 @@ stm32_lp_tick_source: &lptim1 {
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioe 1 GPIO_ACTIVE_LOW>;
+
 	hci_spi: bluenrg-2@0 {
 		compatible = "st,hci-spi-v2";
 		reg = <0>;
@@ -312,23 +317,26 @@ zephyr_udc0: &usbotg_fs {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
 		};
+
 		slot1_partition: partition@78000 {
 			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
 		};
+
 		scratch_partition: partition@e0000 {
 			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
 		};
+
 		storage_partition: partition@f0000 {
 			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
 		};
-
 	};
 };
 

--- a/boards/st/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/st/stm3210c_eval/stm3210c_eval.dts
@@ -22,6 +22,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -30,6 +31,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpiob 9 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/st/stm32373c_eval/stm32373c_eval.dts
@@ -22,6 +22,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpioc 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -30,6 +31,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "Key";
 			gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32c0116_dk/stm32c0116_dk.dts
+++ b/boards/st/stm32c0116_dk/stm32c0116_dk.dts
@@ -22,6 +22,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_3: led_3 {
 			gpios = <&gpiob 6 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
@@ -38,6 +39,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		reset_button: button {
 			label = "reset button";
 			gpios = <&gpiof 2 GPIO_ACTIVE_LOW>;
@@ -156,7 +158,6 @@
 		zephyr,resolution = <12>;
 		zephyr,vref-mv = <3300>;
 	};
-
 };
 
 &die_temp {

--- a/boards/st/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/st/stm32f072_eval/stm32f072_eval.dts
@@ -22,18 +22,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiod 8 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		orange_led_2: led_2 {
 			gpios = <&gpiod 9 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_3: led_3 {
 			gpios = <&gpiod 10 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led_4: led_4 {
 			gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -42,31 +46,37 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		tamper: tamper_button {
 			label = "tamper button";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		joy_sel: joystick_selection {
 			label = "joystick selection";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpiof 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpiof 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_UP>;
 		};
+
 		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpiof 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpioe 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;

--- a/boards/st/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/st/stm32f072b_disco/stm32f072b_disco.dts
@@ -23,18 +23,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_up_led_3: led_3 {
 			gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		yellow_left_4: led_4 {
 			gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
+
 		green_right_led_5: led_5 {
 			gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
+
 		blue_low_led_6: led_6 {
 			gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD6";
@@ -43,6 +47,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/st/stm32f0_disco/stm32f0_disco.dts
@@ -23,10 +23,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_3: led_3 {
 			gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led_4: led_4 {
 			gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -35,6 +37,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "Key";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
@@ -112,10 +115,12 @@
 			label = "image-0";
 			reg = <0x00004000 DT_SIZE_K(16)>;
 		};
+
 		slot1_partition: partition@8000 {
 			label = "image-1";
 			reg = <0x00008000 DT_SIZE_K(16)>;
 		};
+
 		scratch_partition: partition@c000 {
 			label = "image-scratch";
 			reg = <0x0000C000 DT_SIZE_K(16)>;

--- a/boards/st/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/st/stm32f0_disco/stm32f0_disco.dts
@@ -108,7 +108,7 @@
 
 		/*
 		 * The flash starting at offset 0x2000 and ending at
-		 * offset 0x3999 is reserved for use by the application.
+		 * offset 0x3fff is reserved for use by the application.
 		 */
 
 		slot0_partition: partition@4000 {

--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -23,34 +23,42 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led_3: led_3 {
 			gpios = <&gpioe 9 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led_4: led_4 {
 			gpios = <&gpioe 8 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
+
 		orange_led_5: led_5 {
 			gpios = <&gpioe 10 GPIO_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
+
 		green_led_6: led_6 {
 			gpios = <&gpioe 15 GPIO_ACTIVE_HIGH>;
 			label = "User LD6";
 		};
+
 		green_led_7: led_7 {
 			gpios = <&gpioe 11 GPIO_ACTIVE_HIGH>;
 			label = "User LD7";
 		};
+
 		orange_led_8: led_8 {
 			gpios = <&gpioe 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD8";
 		};
+
 		blue_led_9: led_9 {
 			gpios = <&gpioe 12 GPIO_ACTIVE_HIGH>;
 			label = "User LD9";
 		};
+
 		red_led_10: led_10 {
 			gpios = <&gpioe 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD10";
@@ -59,6 +67,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
@@ -188,7 +197,6 @@ zephyr_udc0: &usb {
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -209,6 +217,7 @@ zephyr_udc0: &usb {
 &timers1 {
 	st,prescaler = <10000>;
 	status = "okay";
+
 	pwm1: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pa8>;

--- a/boards/st/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco.dts
@@ -24,18 +24,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		orange_led_3: led_3 {
 			gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		green_led_4: led_4 {
 			gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
+
 		red_led_5: led_5 {
 			gpios = <&gpiod 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
+
 		blue_led_6: led_6 {
 			gpios = <&gpiod 15 GPIO_ACTIVE_HIGH>;
 			label = "User LD6";
@@ -44,15 +48,19 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
+
 		green_pwm_led: green_pwm_led {
 			pwms = <&pwm4 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		orange_pwm_led: orange_pwm_led {
 			pwms = <&pwm4 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		red_pwm_led: red_pwm_led {
 			pwms = <&pwm4 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		blue_pwm_led: blue_pwm_led {
 			pwms = <&pwm4 4 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -60,6 +68,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;

--- a/boards/st/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/st/stm32f412g_disco/stm32f412g_disco.dts
@@ -23,18 +23,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioe 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		orange_led_2: led_2 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_3: led_3 {
 			gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led_4: led_4 {
 			gpios = <&gpioe 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -43,26 +47,31 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		joy_sel: joystick_selection {
 			label = "joystick selection";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpiog 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpiog 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_UP>;
 		};
+
 		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpiof 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpiof 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;

--- a/boards/st/stm32f413h_disco/stm32f413h_disco.dts
+++ b/boards/st/stm32f413h_disco/stm32f413h_disco.dts
@@ -23,10 +23,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioc 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		red_led_2: led_2 {
 			gpios = <&gpioe 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";

--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -34,10 +34,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_3: led_3 {
 			gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		red_led_4: led_4 {
 			gpios = <&gpiog 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -46,6 +48,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
@@ -242,6 +245,7 @@
 	width = <240>;
 	height = <320>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
 	display-timings {
 		compatible = "zephyr,panel-timing";
 		de-active = <0>;
@@ -255,6 +259,7 @@
 		hfront-porch = <10>;
 		vfront-porch = <4>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;

--- a/boards/st/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/st/stm32f469i_disco/stm32f469i_disco.dts
@@ -24,18 +24,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpiog 6 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		orange_led_2: led_2 {
 			gpios = <&gpiod 4 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		red_led_3: led_3 {
 			gpios = <&gpiod 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led_4: led_4 {
 			gpios = <&gpiok 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -44,6 +48,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -24,18 +24,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		orange_led_3: led_3 {
 			gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		green_led_4: led_4 {
 			gpios = <&gpiod 12 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
+
 		red_led_5: led_5 {
 			gpios = <&gpiod 14 GPIO_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
+
 		blue_led_6: led_6 {
 			gpios = <&gpiod 15 GPIO_ACTIVE_HIGH>;
 			label = "User LD6";
@@ -44,6 +48,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "Key";
 			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;

--- a/boards/st/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/st/stm32f723e_disco/stm32f723e_disco.dts
@@ -24,14 +24,17 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		blue_led: led_1 {
 			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		red_led: led_2 {
 			gpios = <&gpioa 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD5";
 		};
+
 		green_led: led_3 {
 			gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD6";
@@ -40,6 +43,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -29,6 +29,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioi 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
@@ -37,6 +38,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioi 11 GPIO_ACTIVE_HIGH>;
@@ -222,7 +224,7 @@ zephyr_udc0: &usbotg_fs {
 			slot1_partition: partition@0 {
 				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(640)>;
-				};
+			};
 
 			storage_partition: partition@a0000 {
 				label = "storage";
@@ -258,6 +260,7 @@ zephyr_udc0: &usbotg_fs {
 		 * Note: SDRAM_CLK_MHZ = HCLK_MHZ / 2 (108 MHz)
 		 */
 		refresh-rate = <1667>;
+
 		bank@0 {
 			reg = <0>;
 			st,sdram-control = <STM32_FMC_SDRAM_NC_8
@@ -290,6 +293,7 @@ zephyr_udc0: &usbotg_fs {
 	width = <480>;
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
 	display-timings {
 		compatible = "zephyr,panel-timing";
 		de-active = <0>;
@@ -303,6 +307,7 @@ zephyr_udc0: &usbotg_fs {
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -29,6 +29,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_1 {
 			gpios = <&gpioi 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
@@ -37,6 +38,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioi 11 GPIO_ACTIVE_HIGH>;
@@ -209,7 +211,7 @@ zephyr_udc0: &usbotg_fs {
 			slot1_partition: partition@0 {
 				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(640)>;
-				};
+			};
 
 			storage_partition: partition@a0000 {
 				label = "storage";
@@ -245,6 +247,7 @@ zephyr_udc0: &usbotg_fs {
 		 * Note: SDRAM_CLK_MHZ = HCLK_MHZ / 2 (108 MHz)
 		 */
 		refresh-rate = <1667>;
+
 		bank@0 {
 			reg = <0>;
 			st,sdram-control = <STM32_FMC_SDRAM_NC_8
@@ -277,6 +280,7 @@ zephyr_udc0: &usbotg_fs {
 	width = <480>;
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
 	display-timings {
 		compatible = "zephyr,panel-timing";
 		de-active = <0>;
@@ -290,6 +294,7 @@ zephyr_udc0: &usbotg_fs {
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -40,14 +40,17 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led_1:led_1 {
 			gpios = <&gpioj 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		green_led_2:led_2 {
 			gpios = <&gpioj 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
+
 		green_led_3:led_3 {
 			gpios = <&gpioa 12 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -56,6 +59,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_HIGH>;
@@ -205,7 +209,7 @@ arduino_serial: &usart6 {};
 			slot1_partition: partition@0 {
 				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(16)>;
-				};
+			};
 
 			storage_partition: partition@1a0000 {
 				label = "storage";

--- a/boards/st/stm32g0316_disco/stm32g0316_disco.dts
+++ b/boards/st/stm32g0316_disco/stm32g0316_disco.dts
@@ -28,6 +28,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_2 {
 			gpios = <&gpioa 12 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
@@ -36,6 +37,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/st/stm32g071b_disco/stm32g071b_disco.dts
@@ -23,18 +23,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led_4: led4 {
 			gpios = <&gpiod 9 GPIO_ACTIVE_HIGH>;
 			label = "TO_REC";
 		};
+
 		red_led_5: led5 {
 			gpios = <&gpiod 8 GPIO_ACTIVE_HIGH>;
 			label = "TO_PLUG";
 		};
+
 		green_led_6: led6 {
 			gpios = <&gpiod 5 GPIO_ACTIVE_HIGH>;
 			label = "SINK_SPY";
 		};
+
 		green_led_7: led7 {
 			gpios = <&gpioc 12 GPIO_ACTIVE_HIGH>;
 			label = "SOURCE";
@@ -43,26 +47,31 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		joy_sel: button0 {
 			label = "JOY_SEL";
 			gpios = <&gpioc 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_left: button1 {
 			label = "JOY_LEFT";
 			gpios = <&gpioc 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joy_down: button2 {
 			label = "JOY_DOWN";
 			gpios = <&gpioc 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_right: button3 {
 			label = "JOY_RIGHT";
 			gpios = <&gpioc 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_RIGHT>;
 		};
+
 		joy_up: button4 {
 			label = "JOY_UP";
 			gpios = <&gpioc 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
@@ -72,6 +81,7 @@
 
 	cc_config {
 		compatible = "gpio-leds";
+
 		encc1 {
 			gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
 			label = "ENCC1";

--- a/boards/st/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/st/stm32g081b_eval/stm32g081b_eval.dts
@@ -22,18 +22,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led_1: led1 {
 			gpios = <&gpiod 5 GPIO_ACTIVE_HIGH>;
 			label = "LED1";
 		};
+
 		led_2: led2 {
 			gpios = <&gpiod 6 GPIO_ACTIVE_HIGH>;
 			label = "LED2";
 		};
+
 		led_3: led3 {
 			gpios = <&gpiod 8 GPIO_ACTIVE_HIGH>;
 			label = "LED3";
 		};
+
 		led_4: led4 {
 			gpios = <&gpiod 9 GPIO_ACTIVE_HIGH>;
 			label = "LED4";
@@ -42,26 +46,31 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		joy_sel: button0 {
 			label = "JOY_SEL";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_left: button1 {
 			label = "JOY_LEFT";
 			gpios = <&gpioc 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joy_down: button2 {
 			label = "JOY_DOWN";
 			gpios = <&gpioc 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_right: button3 {
 			label = "JOY_RIGHT";
 			gpios = <&gpioc 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_RIGHT>;
 		};
+
 		joy_up: button4 {
 			label = "JOY_UP";
 			gpios = <&gpioc 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
@@ -121,6 +130,7 @@
 
 &timers15 {
 	status = "okay";
+
 	pwm15: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim15_ch1_pc1>;

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -29,18 +29,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_0: led_1 {
 			gpios = <&gpioi 9 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
 		};
+
 		orange_led_0: led_2 {
 			gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 		};
+
 		red_led_0: led_3 {
 			gpios = <&gpiof 1 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
 		};
+
 		blue_led_0: led_4 {
 			gpios = <&gpiof 4 GPIO_ACTIVE_LOW>;
 			label = "User LD4";
@@ -49,6 +53,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -294,18 +299,22 @@
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
 		};
+
 		slot1_partition: partition@78000 {
 			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
 		};
+
 		scratch_partition: partition@e0000 {
 			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
 		};
+
 		/* Set 64KB of storage at the end of Bank1 */
 		storage_partition: partition@f0000 {
 			label = "storage";
@@ -386,14 +395,14 @@
 		status = "okay";
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   partition@0 {
-			       label = "nor";
-			       reg = <0x00000000 DT_SIZE_M(64)>;
-			   };
+			partition@0 {
+				label = "nor";
+				reg = <0x00000000 DT_SIZE_M(64)>;
+			};
 		};
 	};
 };

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -24,10 +24,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led: led_1 {
 			gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 		};
+
 		green_led: led_2 {
 			gpios = <&gpioc 3 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
@@ -36,6 +38,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -186,14 +189,14 @@
 		status = "okay";
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   partition@0 {
-			       label = "nor";
-			       reg = <0x00000000 DT_SIZE_M(4)>;
-			   };
+			partition@0 {
+				label = "nor";
+				reg = <0x00000000 DT_SIZE_M(4)>;
+			};
 		};
 	};
 };

--- a/boards/st/stm32h745i_disco/stm32h745i_disco.dtsi
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco.dtsi
@@ -12,14 +12,17 @@
 / {
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led: led_1 {
 			gpios = <&gpioj 2 GPIO_ACTIVE_HIGH>;
 			label = "User LD7";
 		};
+
 		red_led: led_2 {
 			gpios = <&gpioi 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD6";
 		};
+
 		green_led_2: led_3 {
 			gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
 			label = "User LD8";
@@ -28,6 +31,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 			label = "User SB1";

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -189,13 +189,13 @@
 		status = "okay";
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   storage_partition: partition@0 {
-			       reg = <0x0 DT_SIZE_M(64)>;
-			   };
+			storage_partition: partition@0 {
+				reg = <0x0 DT_SIZE_M(64)>;
+			};
 		};
 	};
 
@@ -264,6 +264,7 @@
 		num-auto-refresh = <8>;
 		mode-register = <0x220>;
 		refresh-rate = <0x603>;
+
 		bank@1 {
 			reg = <1>;
 			st,sdram-control = <STM32_FMC_SDRAM_NC_8

--- a/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco.dtsi
@@ -11,21 +11,25 @@
 / {
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_1:led_1 {
 			gpios = <&gpioi 12 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
 			status = "disabled";
 		};
+
 		orange_led_2:led_2 {
 			gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 			status = "disabled";
 		};
+
 		red_led_3:led_3 {
 			gpios = <&gpioi 14 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
 			status = "disabled";
 		};
+
 		blue_led_4:led_4 {
 			gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
 			label = "User LD4";
@@ -35,36 +39,42 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		wake_up: button {
 			label = "Wakeup";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 			status = "disabled";
 			zephyr,code = <INPUT_KEY_WAKEUP>;
 		};
+
 		joy_center: joystick_center {
 			label = "joystick center";
 			gpios = <&gpiok 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpiok 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpiok 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 			zephyr,code = <INPUT_KEY_UP>;
 		};
+
 		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpiok 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "disabled";
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpiok 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m4.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m4.dts
@@ -25,6 +25,7 @@
 		red_led_3:led_3 {
 			status = "okay";
 		};
+
 		blue_led_4:led_4 {
 			status = "okay";
 		};

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -43,6 +43,7 @@
 		green_led_1:led_1 {
 			status = "okay";
 		};
+
 		orange_led_2:led_2 {
 			status = "okay";
 		};
@@ -261,13 +262,13 @@ zephyr_udc0: &usbotg_hs {
 		status = "okay";
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   partition@0 {
-			       reg = <0x0 DT_SIZE_M(64)>;
-			   };
+			partition@0 {
+				reg = <0x0 DT_SIZE_M(64)>;
+			};
 		};
 	};
 

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -42,10 +42,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led: led_1 {
 			gpios = <&gpioi 13 GPIO_ACTIVE_LOW>;
 			label = "USER1 LD6";
 		};
+
 		green_led: led_2 {
 			gpios = <&gpioj 2 GPIO_ACTIVE_LOW>;
 			label = "USER2 LD7";
@@ -54,6 +56,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -84,6 +87,7 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
 		/* Flash has 128KB sector size */
 		boot_partition: partition@0 {
 			label = "mcuboot";
@@ -113,6 +117,7 @@
 	width = <480>;
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
 	display-timings {
 		compatible = "zephyr,panel-timing";
 		de-active = <1>;
@@ -126,6 +131,7 @@
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;
@@ -240,6 +246,7 @@
 		num-auto-refresh = <8>;
 		mode-register = <0x230>;
 		refresh-rate = <0x603>;
+
 		bank@1 {
 			reg = <1>;
 			st,sdram-control = <STM32_FMC_SDRAM_NC_8

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -27,10 +27,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led: led_0 {
 			gpios = <&gpiog 11 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
+
 		blue_led: led_1 {
 			gpios = <&gpiog 2 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -39,6 +41,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User PB";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -210,6 +213,7 @@
 		num-auto-refresh = <8>;
 		mode-register = <0x220>;
 		refresh-rate = <0x603>;
+
 		bank@1 {
 			reg = <1>;
 			st,sdram-control = <STM32_FMC_SDRAM_NC_9
@@ -252,6 +256,7 @@
 	width = <480>;
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
 	display-timings {
 		compatible = "zephyr,panel-timing";
 		de-active = <0>;
@@ -265,6 +270,7 @@
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;
@@ -290,14 +296,14 @@
 		status = "okay";
 
 		partitions {
-			   compatible = "fixed-partitions";
-			   #address-cells = <1>;
-			   #size-cells = <1>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-			   partition@0 {
-			       label = "nor";
-			       reg = <0x00000000 DT_SIZE_M(4)>;
-			   };
+			partition@0 {
+				label = "nor";
+				reg = <0x00000000 DT_SIZE_M(4)>;
+			};
 		};
 	};
 };

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -30,18 +30,22 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led: led_1 {
 			gpios = <&gpioo 1 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
 		};
+
 		orange_led: led_2 {
 			gpios = <&gpioo 5 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 		};
+
 		red_led: led_3 {
 			gpios = <&gpiom 2 GPIO_ACTIVE_LOW>;
 			label = "User LD3";
 		};
+
 		blue_led: led_4 {
 			gpios = <&gpiom 3 GPIO_ACTIVE_LOW>;
 			label = "User LD4";
@@ -50,6 +54,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
@@ -250,14 +255,17 @@
 				label = "image-0";
 				reg = <0x00000000 DT_SIZE_K(512)>;
 			};
+
 			slot1_partition: partition@80000 {
 				label = "image-1";
 				reg = <0x0080000 DT_SIZE_K(512)>;
 			};
+
 			scratch_partition: partition@100000 {
 				label = "image-scratch";
 				reg = <0x00100000 DT_SIZE_K(64)>;
 			};
+
 			storage_partition: partition@110000 {
 				label = "storage";
 				reg = <0x00110000 DT_SIZE_K(64)>;

--- a/boards/st/stm32l1_disco/stm32l152c_disco.dts
+++ b/boards/st/stm32l1_disco/stm32l152c_disco.dts
@@ -22,10 +22,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led: ld3 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led: ld4 {
 			gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -34,6 +36,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32l1_disco/stm32l1_disco.dts
+++ b/boards/st/stm32l1_disco/stm32l1_disco.dts
@@ -22,10 +22,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led: ld3 {
 			gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led: ld4 {
 			gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -34,6 +36,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32l476g_disco/stm32l476g_disco.dts
+++ b/boards/st/stm32l476g_disco/stm32l476g_disco.dts
@@ -26,10 +26,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_4: led_4 {
 			gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
 		};
+
 		green_led_5: led_5 {
 			gpios = <&gpioe 8 GPIO_ACTIVE_HIGH>;
 			label = "User LD5";
@@ -38,26 +40,31 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		joy_center: joystick_center {
 			label = "joystick center";
 			gpios = <&gpioa 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpioa 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpioa 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_UP>;
 		};
+
 		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpioa 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpioa 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;

--- a/boards/st/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/st/stm32l496g_disco/stm32l496g_disco.dts
@@ -24,6 +24,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_2: led_2 {
 			gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
@@ -32,26 +33,31 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		joy_sel: joystick_select {
 			label = "joystick select";
 			gpios = <&gpioc 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&gpioi 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&gpioi 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_UP>;
 		};
+
 		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&gpioi 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_LEFT>;
 		};
+
 		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&gpiof 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
@@ -69,7 +75,6 @@
 		volt-sensor0 = &vref;
 		volt-sensor1 = &vbat;
 	};
-
 };
 
 &clk_lsi {

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -22,10 +22,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		orange_led: led_1 {
 			gpios = <&mfx 0 GPIO_ACTIVE_LOW>;
 			label = "User LD1";
 		};
+
 		green_led: led_2 {
 			gpios = <&gpioh 4 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
@@ -34,26 +36,31 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		joy_sel: joystick_selection {
 			label = "joystick selection";
 			gpios = <&gpioc 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 		};
+
 		joy_up: joystick_up {
 			label = "joystick up";
 			gpios = <&mfx 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_UP>;
 		};
+
 		joy_down: joystick_down {
 			label = "joystick down";
 			gpios = <&mfx 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_DOWN>;
 		};
+
 		joy_right: joystick_right {
 			label = "joystick right";
 			gpios = <&mfx 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 			zephyr,code = <INPUT_KEY_RIGHT>;
 		};
+
 		joy_left: joystick_left {
 			label = "joystick left";
 			gpios = <&mfx 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;

--- a/boards/st/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk.dts
@@ -51,7 +51,7 @@
 
 		/* 2KB at the end of 512KB flash is set for storage */
 		storage_partition: partition@7f800 {
-			   reg = <0x0007f800 DT_SIZE_K(2)>;
-		   };
+			reg = <0x0007f800 DT_SIZE_K(2)>;
+		};
 	};
 };

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -14,10 +14,12 @@
 / {
 	leds {
 		compatible = "gpio-leds";
+
 		red_led_9: led_9 {
 			gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
 			label = "User LD9";
 		};
+
 		green_led_10: led_10 {
 			gpios = <&gpiog 12 GPIO_ACTIVE_LOW>;
 			label = "User LD10";
@@ -26,6 +28,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
@@ -90,6 +93,7 @@
 				register-select-pin = <0>;
 				#address-cells = <1>;
 				#size-cells = <0>;
+
 				st7789v: lcd-panel@0 {
 					compatible = "sitronix,st7789v";
 					reg = <0>;

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.dts
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_stm32l562xx_ns.dts
@@ -45,16 +45,19 @@
 			reg = <0x00000000 DT_SIZE_K(100)>;
 			read-only;
 		};
+
 		/* Secure image primary slot */
 		slot0_partition: partition@19000 {
 			reg = <0x00019000 DT_SIZE_K(240)>;
 		};
+
 		/* Non-secure image primary slot */
 		slot1_ns_partition: partition@55000 {
 			reg = <0x00055000 DT_SIZE_K(168)>;
 		};
+
 		/* 4KB at the end of 512KB flash is set for storage */
-		 storage_partition: partition@7f000 {
+		storage_partition: partition@7f000 {
 			reg = <0x0007f000 DT_SIZE_K(4)>;
 		};
 	};

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -147,6 +147,7 @@
 	width = <480>;
 	height = <272>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
 	display-timings {
 		compatible = "zephyr,panel-timing";
 		de-active = <0>;
@@ -160,6 +161,7 @@
 		hfront-porch = <32>;
 		vfront-porch = <2>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;

--- a/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.dts
+++ b/boards/st/stm32mp157c_dk2/stm32mp157c_dk2.dts
@@ -29,6 +29,7 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led_1: led_1 {
 			gpios = <&gpioh 7 GPIO_ACTIVE_HIGH>;
 			label = "LD7";
@@ -37,6 +38,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User 1";
 			gpios = <&gpioa 14 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -351,6 +351,7 @@ zephyr_udc0: &usbotg_hs1 {
 	width = <800>;
 	height = <480>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+
 	display-timings {
 		compatible = "zephyr,panel-timing";
 		de-active = <0>;
@@ -364,6 +365,7 @@ zephyr_udc0: &usbotg_hs1 {
 		hfront-porch = <8>;
 		vfront-porch = <8>;
 	};
+
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -27,6 +27,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
+
 		green_led_1: led_3 {
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
@@ -157,6 +158,7 @@
 		group = <6>;
 		channel-ios = <TSC_IO2>;
 		sampling-io = <TSC_IO1>;
+
 		ts1 {
 			compatible = "tsc-keys";
 			sampling-interval-ms = <10>;

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -23,10 +23,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led_0: led_3 {
 			gpios = <&gpioe 0 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		red_led_0: led_4 {
 			gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -35,6 +37,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button_0 {
 			label = "User";
 			gpios = <&gpioc 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
@@ -267,14 +270,17 @@ zephyr_udc0: &usbotg_hs {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+
 		slot0_partition: partition@10000 {
 			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(1952)>;
 		};
+
 		slot1_partition: partition@1f8000 {
 			label = "image-1";
 			reg = <0x001f8000 DT_SIZE_K(1960)>;
 		};
+
 		storage_partition: partition@3e2000 {
 			label = "storage";
 			reg = <0x003e2000 DT_SIZE_K(120)>;

--- a/boards/st/stm32vl_disco/stm32vl_disco.dts
+++ b/boards/st/stm32vl_disco/stm32vl_disco.dts
@@ -22,10 +22,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		green_led: ld3 {
 			gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 			label = "User LD3";
 		};
+
 		blue_led: ld4 {
 			gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>;
 			label = "User LD4";
@@ -34,6 +36,7 @@
 
 	gpio_keys {
 		compatible = "gpio-keys";
+
 		user_button: button {
 			label = "User";
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -37,11 +37,13 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpioc 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 1";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			gpios = <&gpioc 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button 2";
@@ -147,23 +149,26 @@ zephyr_udc0: &usb {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 		};
+
 		slot0_partition: partition@c000 {
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
 		};
+
 		slot1_partition: partition@70000 {
 			label = "image-1";
 			reg = <0x00070000 DT_SIZE_K(400)>;
 		};
+
 		scratch_partition: partition@d4000 {
 			label = "image-scratch";
 			reg = <0x000d4000 DT_SIZE_K(16)>;
 		};
+
 		storage_partition: partition@d8000 {
 			label = "storage";
 			reg = <0x000d8000 DT_SIZE_K(8)>;
 		};
-
 	};
 };
 

--- a/boards/st/stm32wb5mmg/stm32wb5mmg.dts
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg.dts
@@ -97,10 +97,10 @@ zephyr_udc0: &usb {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
 		};
+
 		slot0_partition: partition@c000 {
 			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
 		};
-
 	};
 };


### PR DESCRIPTION
Fix a few coding style issues in ST board DTS files to prevent they spread when a new board is introduced and used this DTS as example start point.

Issues addressed from Zephyr devicetree style guidelines [1]:
\- Indent with tabs.
\- Don’t insert empty lines before a dedenting };.
\- Insert a single empty line to separate nodes at the same hierarchy level.

By the way, fix also an inline comment (stm32f0_disco) ~~and a use of label reference (nucleo_f334r8)~~.

No functional change.

[1] https://docs.zephyrproject.org/latest/contribute/style/devicetree.html
