### PR TITLE
net: l2: wifi：fix the parameter count error when start SAP

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -3775,7 +3775,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Default no password for eap user.\n"
 		      "[-i, --iface=<interface index>] : Interface index.\n"
 		      "-h --help (prints help)",
-		      cmd_wifi_ap_enable, 2, 7),
+		      cmd_wifi_ap_enable, 2, 47),
 	SHELL_CMD_ARG(stations, NULL, "List stations connected to the AP\n"
 		      "[-i, --iface=<interface index>] : Interface index.\n",
 		      cmd_wifi_ap_stations, 1, 2),


### PR DESCRIPTION
During previous commit of adding interface arg, wrongly change the parameter count of 'wifi ap enable' to a small one. Change the value to 47 can fix this issue and match the need of adding interface arg.