### PR TITLE
net: tcp: Align TCP seqence validation with Spec

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -198,6 +198,7 @@ struct tcp_mss_option {
 
 enum tcp_state {
 	TCP_UNUSED = 0,
+	TCP_CLOSED,
 	TCP_LISTEN,
 	TCP_SYN_SENT,
 	TCP_SYN_RECEIVED,
@@ -207,8 +208,7 @@ enum tcp_state {
 	TCP_CLOSE_WAIT,
 	TCP_CLOSING,
 	TCP_LAST_ACK,
-	TCP_TIME_WAIT,
-	TCP_CLOSED
+	TCP_TIME_WAIT
 };
 
 enum tcp_data_mode {


### PR DESCRIPTION
According to RFC 793, the seqnum test includes 4 cases when STATE > TCP_SYN_SENT:

      Seg-len   Recv-win    Test
      -------        --------          ---------------------------------------
        0               0               SEG.SEQ = RCV.NXT
        0               >0             RCV.NXT =< SEG.SEQ < RCV.NXT+RCV.WND
       >0              0               not acceptable
       >0             >0              RCV.NXT =< SEG.SEQ < RCV.NXT+RCV.WND
                                      or RCV.NXT =< SEG.SEQ+SEG.LEN-1 <RCV.NXT+RCV.WND

Also, adjust the CLOSED place in 'enum tcp_state' to better align with the Spec. state sequence definition.
And, remove some code in FIN_WAIT1/2/CLOSING/TIMEWAIT state processing, because it won't happen after adding the sequence_validation.