### PR TITLE
drivers: gpio: davinci: fix gpio output

### DIFF
--- a/drivers/gpio/gpio_davinci.c
+++ b/drivers/gpio/gpio_davinci.c
@@ -116,7 +116,7 @@ static int gpio_davinci_port_set_bits_raw(const struct device *dev,
 {
 	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
 
-	regs->set_data |= mask;
+	regs->set_data = mask;
 
 	return 0;
 }
@@ -126,7 +126,7 @@ static int gpio_davinci_port_clear_bits_raw(const struct device *dev,
 {
 	volatile struct gpio_davinci_regs *regs = DEV_GPIO_CFG_BASE(dev);
 
-	regs->clr_data |= mask;
+	regs->clr_data = mask;
 
 	return 0;
 }


### PR DESCRIPTION
Currently to set/clear the pins, we do a logical OR of the value with the existing values in set/clear registers. However, reading these registers always returns the value in out_data register. This is undesirable as it can cause unnecessary complications. Consider the following scenario:

We need to set PIN 0:
set_data |= BIT(0)

We need to clear PIN 1:
clr_data |= BIT(1)

The latter would also clear the 0th bit due to the aforementioned behaviour.

This patch fixes this by writing the mask directly without ORing.