### PR TITLE
tests: drivers: spi: spi_loopback: skip tests if invalid config

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -196,13 +196,13 @@ static void spi_loopback_transceive(struct spi_dt_spec *const spec,
 	spi_loopback_gpio_cs_loopback_prepare();
 	ret = spi_transceive_dt(spec, tx, rx);
 	if (ret == -EINVAL || ret == -ENOTSUP) {
-		TC_PRINT("Spi config invalid for this controller - skip\n");
-		goto out;
+		TC_PRINT("Spi config invalid for this controller\n");
+		zassert_ok(pm_device_runtime_put(spec->bus));
+		ztest_test_skip();
 	}
 	zassert_ok(ret, "SPI transceive failed, code %d", ret);
 	/* There should be two CS triggers during the transaction, start and end */
 	zassert_false(spi_loopback_gpio_cs_loopback_check(2));
-out:
 	zassert_ok(pm_device_runtime_put(spec->bus));
 }
 


### PR DESCRIPTION
The `spi_loopback_transceive()` helper currently only prints a message if a configuration is invalid, continuing the test case as if it succeeded. This results in the test case using the helper trying to validate the result from a spi transaction that was skipped.

Fix this by explicitly skipping the test using the ztest framework's ztest_test_skip() function, which skips the entire test case.

Before this patch:

```
===================================================================
START - test_spi_word_size_9
E: Word sizes other than 8 bits are not supported
Spi config invalid for this controller - skip

    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/spi/spi_loopback/src/spi.c:628: spi_loopback_test_word_size: (memcmp(compare_data, rx_buffer, buffer_size) is true)
9-bit word buffer contents are different
 FAIL - test_spi_word_size_9 in 262.779 seconds
===================================================================
```
After this patch
```
START - test_spi_word_size_9
E: Word sizes other than 8 bits are not supported
Spi config invalid for this controller
 SKIP - test_spi_word_size_9 in 0.009 seconds
```

fixes: #90318