### PR TITLE
toolchain: do not redefine __fallthrough

### DIFF
--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -141,8 +141,10 @@ do {                                                                    \
 #define __ramfunc __attribute__((noinline, section(".ramfunc")))
 #endif /* !CONFIG_XIP */
 
+#ifndef __fallthrough
 /* TG-WG: ICCARM does not support __fallthrough */
 #define __fallthrough  [[fallthrough]]
+#endif
 
 #ifndef __packed
 #define __packed        __attribute__((__packed__))

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -13,8 +13,10 @@
 
 #define __no_optimization __attribute__((optnone))
 
+#ifndef __fallthrough
 #if __clang_major__ >= 10
 #define __fallthrough __attribute__((fallthrough))
+#endif
 #endif
 
 #define TOOLCHAIN_CLANG_VERSION \

--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -124,7 +124,9 @@
 
 
 #define __no_optimization __attribute__((optnone))
+#ifndef __fallthrough
 #define __fallthrough     __attribute__((fallthrough))
+#endif
 
 #define TOOLCHAIN_HAS_C_GENERIC                 1
 #define TOOLCHAIN_HAS_C_AUTO_TYPE               1


### PR DESCRIPTION
Do not redefine __fallthrough if already defined by the c library.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
