### PR TITLE
SDMA: Fix sound issues caused by SDMA driver

### DIFF
--- a/drivers/dma/dma_nxp_sdma.c
+++ b/drivers/dma/dma_nxp_sdma.c
@@ -376,11 +376,14 @@ static int dma_nxp_sdma_get_status(const struct device *dev, uint32_t channel,
 {
 	struct sdma_dev_data *dev_data = dev->data;
 	struct sdma_channel_data *chan_data;
+	unsigned int key;
 
 	chan_data = &dev_data->chan[channel];
 
+	key = irq_lock();
 	stat->free = chan_data->stat.free;
 	stat->pending_length = chan_data->stat.pending_length;
+	irq_unlock(key);
 
 	return 0;
 }
@@ -390,6 +393,7 @@ static int dma_nxp_sdma_reload(const struct device *dev, uint32_t channel, uint3
 {
 	struct sdma_dev_data *dev_data = dev->data;
 	struct sdma_channel_data *chan_data;
+	unsigned int key;
 
 	chan_data = &dev_data->chan[channel];
 
@@ -397,11 +401,13 @@ static int dma_nxp_sdma_reload(const struct device *dev, uint32_t channel, uint3
 		return 0;
 	}
 
+	key = irq_lock();
 	if (chan_data->direction == MEMORY_TO_PERIPHERAL) {
 		dma_nxp_sdma_produce(chan_data, size);
 	} else {
 		dma_nxp_sdma_consume(chan_data, size);
 	}
+	irq_unlock(key);
 
 	return 0;
 }

--- a/drivers/dma/dma_nxp_sdma.c
+++ b/drivers/dma/dma_nxp_sdma.c
@@ -237,6 +237,8 @@ static void dma_nxp_sdma_setup_bd(const struct device *dev, uint32_t channel,
 
 	chan_data = &dev_data->chan[channel];
 
+	chan_data->capacity = 0;
+
 	/* initialize bd pool */
 	chan_data->bd_pool = &dev_data->bd_pool[channel][0];
 	chan_data->bd_count = config->block_count;


### PR DESCRIPTION
This patch series:
* introduces sdma channel states in order to prevent invalid state transitions
* adds a fix for pause/resume sound issue because computation for total buffer length was wrong.
* adds a fix for a sound issue caused by a race when updating buffer status

