### PR TITLE
drivers: serial: stm32: simplify logic

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -411,13 +411,11 @@ static inline uint32_t uart_stm32_cfg2ll_databits(enum uart_config_data_bits db,
 #endif	/* LL_USART_DATAWIDTH_9B */
 	case UART_CFG_DATA_BITS_8:
 	default:
-		if (p == UART_CFG_PARITY_NONE) {
-			return LL_USART_DATAWIDTH_8B;
 #ifdef LL_USART_DATAWIDTH_9B
-		} else {
+		if (p != UART_CFG_PARITY_NONE) {
 			return LL_USART_DATAWIDTH_9B;
-#endif
 		}
+#endif
 		return LL_USART_DATAWIDTH_8B;
 	}
 }


### PR DESCRIPTION
Simplify the logic for the `uart_stm32_cfg2ll_databits` function regarding `LL_USART_DATAWIDTH_9B` being defined or not.