### PR TITLE
boards: nordic: nrf54l15dk: update lfxo capacitance

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
@@ -28,7 +28,7 @@
 
 &lfxo {
 	load-capacitors = "internal";
-	load-capacitance-femtofarad = <15500>;
+	load-capacitance-femtofarad = <17000>;
 };
 
 &hfxo {


### PR DESCRIPTION
Update the lfxo node load-capacitance-femtofarad to match the chosen external lfxo on the nRF54L15-DK design. Previous stray capacitance value was incorrect, which resulted in a too low load capacitance.