### PR TITLE
drivers: display: ls0xx: add display_clear support

### DIFF
--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -282,6 +282,7 @@ static DEVICE_API(display, ls0xx_driver_api) = {
 	.blanking_on = ls0xx_blanking_on,
 	.blanking_off = ls0xx_blanking_off,
 	.write = ls0xx_write,
+	.clear = ls0xx_clear,
 	.get_capabilities = ls0xx_get_capabilities,
 	.set_pixel_format = ls0xx_set_pixel_format,
 };


### PR DESCRIPTION
Add support for `display_clear` API to the Sharp display.