### PR TITLE
drivers: display: st7567: add display_clear support

### DIFF
--- a/drivers/display/display_st7567.c
+++ b/drivers/display/display_st7567.c
@@ -454,6 +454,7 @@ static DEVICE_API(display, st7567_driver_api) = {
 	.blanking_on = st7567_suspend,
 	.blanking_off = st7567_resume,
 	.write = st7567_write,
+	.clear = st7567_clear,
 	.set_contrast = st7567_set_contrast,
 	.get_capabilities = st7567_get_capabilities,
 	.set_pixel_format = st7567_set_pixel_format,


### PR DESCRIPTION
Add support for `display_clear` API to the st7567 display.