### PR TITLE
tests: arch: arm_interrupt: Fix stack overflows in .no_optimizations

### DIFF
--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -16,6 +16,7 @@ tests:
       - CONFIG_ZTEST_WARN_NO_OPTIMIZATIONS=n
       - CONFIG_IDLE_STACK_SIZE=512
       - CONFIG_MAIN_STACK_SIZE=2048
+      - CONFIG_ZTEST_STACK_SIZE=1280
   arch.arm.interrupt.extra_exception_info:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:


### PR DESCRIPTION
With e337b7b65de9071565ab3c36ef550bf723713c8f, the test started to fail with stack overflows in the no_optimizations scenario, so give the ztest thread a little more space.

See #90139.