### PR TITLE
tests: libc: thrd: minor corrections for conformance

### DIFF
--- a/tests/lib/c_lib/thrd/src/thrd.c
+++ b/tests/lib/c_lib/thrd/src/thrd.c
@@ -10,6 +10,7 @@
 #include <threads.h>
 
 #include <zephyr/sys_clock.h>
+#include <zephyr/sys/timeutil.h>
 #include <zephyr/ztest.h>
 
 static thrd_t     thr;
@@ -32,7 +33,7 @@ ZTEST(libc_thrd, test_thrd_sleep)
 	zassert_equal(thrd_success, thrd_sleep(&duration, &duration));
 
 	for (int i = 0; i < ARRAY_SIZE(delay_ms); ++i) {
-		duration = (struct timespec){.tv_nsec = delay_ms[i] * NSEC_PER_MSEC};
+		timespec_from_timeout(K_MSEC(delay_ms[i]), &duration);
 		remaining = (struct timespec){.tv_sec = 4242, .tv_nsec = 4242};
 
 		printk("sleeping %d ms\n", delay_ms[i]);

--- a/tests/lib/c_lib/thrd/src/thrd.c
+++ b/tests/lib/c_lib/thrd/src/thrd.c
@@ -23,7 +23,11 @@ ZTEST(libc_thrd, test_thrd_sleep)
 	struct timespec remaining;
 	const uint16_t delay_ms[] = {0, 100, 200, 400};
 
-	zassert_not_equal(0, thrd_sleep(NULL, NULL));
+	if (false) {
+		/* duration may not be NULL */
+		zassert_not_equal(thrd_success, thrd_sleep(NULL, NULL));
+	}
+
 	zassert_equal(thrd_success, thrd_sleep(&duration, NULL));
 	zassert_equal(thrd_success, thrd_sleep(&duration, &duration));
 

--- a/tests/lib/c_lib/thrd/src/thrd.c
+++ b/tests/lib/c_lib/thrd/src/thrd.c
@@ -24,8 +24,8 @@ ZTEST(libc_thrd, test_thrd_sleep)
 	const uint16_t delay_ms[] = {0, 100, 200, 400};
 
 	zassert_not_equal(0, thrd_sleep(NULL, NULL));
-	zassert_ok(thrd_sleep(&duration, NULL));
-	zassert_ok(thrd_sleep(&duration, &duration));
+	zassert_equal(thrd_success, thrd_sleep(&duration, NULL));
+	zassert_equal(thrd_success, thrd_sleep(&duration, &duration));
 
 	for (int i = 0; i < ARRAY_SIZE(delay_ms); ++i) {
 		duration = (struct timespec){.tv_nsec = delay_ms[i] * NSEC_PER_MSEC};
@@ -33,7 +33,7 @@ ZTEST(libc_thrd, test_thrd_sleep)
 
 		printk("sleeping %d ms\n", delay_ms[i]);
 		start = k_uptime_get();
-		zassert_ok(thrd_sleep(&duration, &remaining));
+		zassert_equal(thrd_success, thrd_sleep(&duration, &remaining));
 		end = k_uptime_get();
 		zassert_equal(remaining.tv_sec, 0);
 		zassert_equal(remaining.tv_nsec, 0);


### PR DESCRIPTION
* tests: libc: thrd: do not pass NULL for thrd_sleep() duration
* tests: libc: thrd: compare with thrd_success rather than ok or zero
* tests: libc: thrd: use timespec_from_timeout()