### PR TITLE
build: Allow custom sysroot in native_sim builds

### DIFF
--- a/boards/native/common/natsim_config.cmake
+++ b/boards/native/common/natsim_config.cmake
@@ -7,8 +7,15 @@ get_property(CCACHE GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
 target_link_options(native_simulator INTERFACE
   "-T ${ZEPHYR_BASE}/boards/native/common/natsim_linker_script.ld")
 
+if(SYSROOT_DIR)
+  message(NOTICE "Appending --sysroot=${SYSROOT_DIR} to native_simulator")
+  target_compile_options(native_simulator INTERFACE "--sysroot=${SYSROOT_DIR}")
+  target_link_options(native_simulator INTERFACE "--sysroot=${SYSROOT_DIR}")
+endif()
+
 set(nsi_config_content
   ${nsi_config_content}
+  "NSI_AR:=${CMAKE_AR}"
   "NSI_BUILD_OPTIONS:=$<JOIN:$<TARGET_PROPERTY:native_simulator,INTERFACE_COMPILE_OPTIONS>,\ >"
   "NSI_BUILD_PATH:=${zephyr_build_path}/NSI"
   "NSI_CC:=${CCACHE} ${CMAKE_C_COMPILER}"

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -18,6 +18,12 @@ endif()
 find_program(CMAKE_C_COMPILER   clang   ${find_program_clang_args})
 find_program(CMAKE_CXX_COMPILER clang++ ${find_program_clang_args})
 
+if(SYSROOT_DIR)
+  # The toolchain has specified a sysroot dir, pass it to the compiler
+  list(APPEND TOOLCHAIN_C_FLAGS "--sysroot=${SYSROOT_DIR}")
+  list(APPEND TOOLCHAIN_LD_FLAGS "--sysroot=${SYSROOT_DIR}")
+endif()
+
 if(NOT "${ARCH}" STREQUAL "posix")
   include(${ZEPHYR_BASE}/cmake/gcc-m-cpu.cmake)
   include(${ZEPHYR_BASE}/cmake/gcc-m-fpu.cmake)
@@ -72,7 +78,8 @@ if(NOT "${ARCH}" STREQUAL "posix")
   #
   # Other clang/LLVM distributions may come with other pre-built C libraries.
   # clang/LLVM supports using an alternative C library, either by direct linking,
-  # or by specifying '--sysroot <path>'.
+  # or by specifying '--sysroot <path>'. Sysroot can also be passed using the
+  # CMake variable SYSROOT_DIR which will append the '--sysroot <path>' flags.
   #
   # LLVM for Arm provides a 'newlib.cfg' file for newlib C selection.
   # Let us support this principle by looking for a dedicated 'newlib.cfg' or


### PR DESCRIPTION
When running naive sim builds, any custom cflags and toolchains we've set are lost. Specifically for us this included a custom directory for the sysroot and archive tool.

Add the sysroot (if available) to both NSI_BUILD_C_OPTIONS and a new NSI_EXTRA_LINK_OPTIONS. Additionally pass CMAKE_AR to NSI_AR.