### PR TITLE
net: tls_credentials_shell: Add credential buffer load argument

### DIFF
--- a/doc/connectivity/networking/api/tls_credentials_shell.rst
+++ b/doc/connectivity/networking/api/tls_credentials_shell.rst
@@ -15,7 +15,11 @@ Buffer Credential (``buf``)
 
 Buffer data incrementally into the credential buffer so that it can be added using the :ref:`tls_credentials_shell_add_cred` command.
 
-Alternatively, clear the credential buffer.
+Alternatively:
+
+   - Clear the credential buffer.
+
+   - Load credential directly to the credential buffer, ending with ``Ctrl + c``.
 
 Usage
 -----
@@ -27,6 +31,14 @@ To append ``<DATA>`` to the credential buffer, use:
    cred buf <DATA>
 
 Use this as many times as needed to load the full credential into the credential buffer, then use the :ref:`tls_credentials_shell_add_cred` command to store it.
+
+To load ``<DATA>`` directly to the credential buffer, use:
+
+.. code-block:: shell
+
+   cred buf load
+   <DATA>
+   Ctrl + c
 
 To clear the credential buffer, use:
 


### PR DESCRIPTION
Add argument to the TLS credential `cred buf` command that enables
a shell bypass to write the TLS credential directly to the credential
buffer.
This is useful for writing load credentials that cannot fit in a single
`cred buf` command and would otherwise have to be split into multiple
cred buf commands.
Sending multiple in succession like that from a script for example very
easily causes the shell RX buffer to get full, resulting in multiple
`RX ring buffer full.` warnings.
This is very difficult for a script to handle.

Using a bypass has much better performance and can easily avoid the
RX ring buffer full condition without increasing the RX ring buffer
to much.
It is also easier for a script to use.