### PR TITLE
sys: timeutil: check for 32-bit time_t to avoid warning

### DIFF
--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -516,7 +516,9 @@ static inline bool timespec_negate(struct timespec *ts)
 
 #else
 
-	if (ts->tv_sec == INT64_MIN) {
+	/* note: must check for 32-bit size here until #90029 is resolved */
+	if (((sizeof(ts->tv_sec) == sizeof(int32_t)) && (ts->tv_sec == INT32_MIN)) ||
+	    ((sizeof(ts->tv_sec) == sizeof(int64_t)) && (ts->tv_sec == INT64_MIN))) {
 		/* -INT64_MIN > INT64_MAX, so +ve integer overflow would occur */
 		return false;
 	}
@@ -695,7 +697,11 @@ static inline k_timeout_t timespec_to_timeout(const struct timespec *ts)
 		return (k_timeout_t){
 			.ticks = 0,
 		};
-	} else if (ts->tv_sec == INT64_MAX && ts->tv_nsec == NSEC_PER_SEC - 1) {
+		/* note: must check for 32-bit size here until #90029 is resolved */
+	} else if (((sizeof(ts->tv_sec) == sizeof(int32_t)) && (ts->tv_sec == INT32_MAX) &&
+		    (ts->tv_nsec == NSEC_PER_SEC - 1)) ||
+		   ((sizeof(ts->tv_sec) == sizeof(int64_t)) && (ts->tv_sec == INT64_MAX) &&
+		    (ts->tv_nsec == NSEC_PER_SEC - 1))) {
 		/* This is equivalent to K_FOREVER, but not including <zephyr/kernel.h> */
 		return (k_timeout_t){
 			.ticks = K_TICKS_FOREVER,


### PR DESCRIPTION
A warning was propogated to error when building for native_sim/native.

```
timeutil.h:519:17: error: result of comparison of constant \
  -9223372036854775808 with expression of type '__time_t' (aka 'long') \
  is always false [-Werror,-Wtautological-constant-out-of-range-compare]
```

This is due to the issue described in #90029.

Add workarounds to `timespec_to_timeout()` and `timespec_negate()` until 90029 is resolved.

Testing Done:
```shell
$ twister -i -p native_sim/native -T tests/lib/heap -T tests/kernel/common
INFO    - Using Ninja..
INFO    - Zephyr version: v4.1.0-4541-g52ab417e1007
INFO    - Using 'llvm' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:   10/  10  100%  built (not run):    0, filtered:    3, failed:    0, error:    0
INFO    - 10 test scenarios (11 configurations) selected, 3 configurations filtered (1 by static filter, 2 at runtime).
INFO    - 8 of 8 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 29.42 seconds.
INFO    - 433 of 433 executed test cases passed (100.00%) on 1 out of total 1064 platforms (0.09%).
INFO    - 21 selected test cases not executed: 21 skipped.
INFO    - 8 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```