### PR TITLE
dts: bindings: ambiq: add missing configs

### DIFF
--- a/drivers/gpio/Kconfig.ambiq
+++ b/drivers/gpio/Kconfig.ambiq
@@ -10,5 +10,6 @@ config GPIO_AMBIQ
 	default y
 	depends on DT_HAS_AMBIQ_GPIO_ENABLED
 	select AMBIQ_HAL
+	select AMBIQ_HAL_USE_GPIO
 	help
 	  Enable driver for Ambiq gpio.

--- a/dts/arm/ambiq/ambiq_apollo4p.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo4p.dtsi
@@ -109,7 +109,7 @@
 		};
 
 		uart0: uart@4001c000 {
-			compatible = "ambiq,pl011-uart";
+			compatible = "ambiq,pl011-uart", "arm,pl011";
 			reg = <0x4001c000 0x1000>;
 			interrupts = <15 0>;
 			interrupt-names = "UART0";
@@ -118,7 +118,7 @@
 		};
 
 		uart1: uart@4001d000 {
-			compatible = "ambiq,pl011-uart";
+			compatible = "ambiq,pl011-uart", "arm,pl011";
 			reg = <0x4001d000 0x1000>;
 			interrupts = <16 0>;
 			interrupt-names = "UART1";


### PR DESCRIPTION
This PR adds back pl011 for apollo4p and select AMBIQ_HAL_USE_GPIO to include ambiq GPIO HAL file.