### PR TITLE
net: tcp: Move the CLOSED state to the front

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -198,6 +198,7 @@ struct tcp_mss_option {
 
 enum tcp_state {
 	TCP_UNUSED = 0,
+	TCP_CLOSED,
 	TCP_LISTEN,
 	TCP_SYN_SENT,
 	TCP_SYN_RECEIVED,
@@ -207,8 +208,7 @@ enum tcp_state {
 	TCP_CLOSE_WAIT,
 	TCP_CLOSING,
 	TCP_LAST_ACK,
-	TCP_TIME_WAIT,
-	TCP_CLOSED
+	TCP_TIME_WAIT
 };
 
 enum tcp_data_mode {


### PR DESCRIPTION
In enum tcp_state {}, the CLOSED state was put at the last one. When we do Sequence & Ack validation, we will need to skip the CLOSED, LISTEN, SYNSENT states. It is easier for coding if we put the CLOSED to the front, e.g. if state > SYNSENT. And, in other OSes, the state sequence is normally defined like this.