### PR TITLE
net: wifi: fix the bug by non-wifi network call

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -356,7 +356,7 @@ static const struct wifi_mgmt_ops *const get_wifi_api(struct net_if *iface)
 	const struct device *dev = net_if_get_device(iface);
 	struct net_wifi_mgmt_offload *off_api;
 
-	if (dev == NULL) {
+	if (dev == NULL || !net_if_is_wifi(iface)) {
 		return NULL;
 	}
 


### PR DESCRIPTION

1. Description of the scenario where the problem occurs:

- When a non-wifi network card device is used in the code to call the wifi api in mgmt mode, the system will crash.

2. Root cause:

- In the get_wifi_api function, there is no check to see if the network card type is wifi, which will cause other types of network cards (such as Ethernet devices) to successfully assign the dev api element to the final return value of the function. This will cause a direct crash when other functions call the returned wifi api. The following are the differences between the apis of the two network card device driver layers:
      wifi(eg.drivers\wifi\esp32\src\esp_wifi_drv.c):
            static const struct wifi_mgmt_ops esp32_wifi_mgmt = {
	        .scan		   = esp32_wifi_scan,
	        .connect	   = esp32_wifi_connect,
	        .disconnect	   = esp32_wifi_disconnect,
	        .ap_enable	   = esp32_wifi_ap_enable,
	        .ap_disable	   = esp32_wifi_ap_disable,
	        .iface_status	   = esp32_wifi_status,
              #if defined(CONFIG_NET_STATISTICS_WIFI)
	              .get_stats	   = esp32_wifi_stats,
              #endif
              };

    ethernet(eg.drivers\ethernet\eth_lan865x.c)
            static const struct ethernet_api lan865x_api_func = {
	            .iface_api.init = lan865x_iface_init,
	            .get_capabilities = lan865x_port_get_capabilities,
	            .set_config = lan865x_set_config,
	            .send = lan865x_port_send,
            };

    Obviously, the APIs of the above two drivers are different, but after being called by the macro NET_DEVICE_DT_INST_DEFINE, they will be assigned to the api element of the device dev.

3.Device verification: 

- Based on the NXP frdm-rw612 development board, write a WiFi connection example program. Since the development board has both Ethernet and wireless network cards, two network card devices will be enumerated when the system starts. When the function net_if_get_default() is used to obtain the default network card, the obtained network card device is Ethernet, but if the function net_mgmt is used to initiate a WiFi connection at this time, it will directly cause the system to crash. After using the repair code, it will return the call error code instead of the system crash.

- application demo code for wifi connect:

        static void connect_to_wifi(void) {
            struct net_if *iface = net_if_get_default();
            struct wifi_connect_req_params cnx_params = {
                .ssid = WIFI_SSID,
                .ssid_length = strlen(WIFI_SSID),
                .psk = WIFI_PASSWORD,
                .psk_length = strlen(WIFI_PASSWORD),
                .channel = WIFI_CHANNEL_ANY,
                .security = WIFI_SECURITY_TYPE_PSK,
            };
            LOG_INF("%d", __LINE__);
            net_mgmt_init_event_callback(&wifi_cb, wifi_event_handler,
                                         NET_EVENT_WIFI_CONNECT_RESULT |
                                         NET_EVENT_WIFI_DISCONNECT_RESULT);
            LOG_INF("%d", __LINE__);
            net_mgmt_add_event_callback(&wifi_cb);
            LOG_INF("%d", __LINE__);
            int ret = net_mgmt(NET_REQUEST_WIFI_CONNECT, iface,
                               &cnx_params, sizeof(struct wifi_connect_req_params));
            LOG_INF("%d", __LINE__);
            if (ret) {
                LOG_ERR("Wi-Fi connect failed: %d", ret);
            } else {
                LOG_INF("Connecting to Wi-Fi...");
            }
        }


-log print output
    Original code run:
![image](https://github.com/user-attachments/assets/5b9bc190-057d-49ef-872c-5d9aef63e963)

    Fixed code run:
![image](https://github.com/user-attachments/assets/c086ef55-70b7-48f0-9ca1-38f392e33d00)
