### PR TITLE
drivers: wifi: siwx91x: Fix NWP assert and open credential bug

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -533,8 +533,6 @@ static int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_p
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
 	struct siwx91x_dev *sidev = dev->data;
-	/* Wiseconnect requires a valid PSK even if WIFI_SECURITY_TYPE_NONE is selected */
-	static const char dummy_psk[] = "dummy_value";
 	sl_wifi_ap_configuration_t saved_ap_cfg;
 	int ret;
 	int sec;
@@ -602,18 +600,14 @@ static int siwx91x_ap_enable(const struct device *dev, struct wifi_connect_req_p
 	}
 
 	siwx91x_ap_cfg.security = sec;
-	if (params->security == WIFI_SECURITY_TYPE_NONE) {
-		ret = sl_net_set_credential(siwx91x_ap_cfg.credential_id, SL_NET_WIFI_PSK,
-					    dummy_psk, strlen(dummy_psk));
-	} else {
+	if (params->security != WIFI_SECURITY_TYPE_NONE) {
 		ret = sl_net_set_credential(siwx91x_ap_cfg.credential_id, SL_NET_WIFI_PSK,
 					    params->psk, params->psk_length);
-	}
-
-	if (ret != SL_STATUS_OK) {
-		LOG_ERR("Failed to set credentials: 0x%x", ret);
-		wifi_mgmt_raise_ap_enable_result_event(sidev->iface, WIFI_STATUS_AP_FAIL);
-		return -EINVAL;
+		if (ret != SL_STATUS_OK) {
+			LOG_ERR("Failed to set credentials: 0x%x", ret);
+			wifi_mgmt_raise_ap_enable_result_event(sidev->iface, WIFI_STATUS_AP_FAIL);
+			return -EINVAL;
+		}
 	}
 
 	ret = siwx91x_nwp_reboot_if_required(dev, WIFI_SOFTAP_MODE);

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -176,8 +176,8 @@ int siwx91x_get_nwp_config(sl_wifi_device_configuration_t *get_config, uint8_t w
 	sl_si91x_boot_configuration_t *boot_config = &default_config.boot_config;
 
 	__ASSERT(get_config, "get_config cannot be NULL");
-	__ASSERT((hidden_ssid == true || max_num_sta != 0) && wifi_oper_mode != WIFI_SOFTAP_MODE,
-		 "hidden_ssid or max_num_sta requires SOFTAP mode");
+	__ASSERT((hidden_ssid == false && max_num_sta == 0) || wifi_oper_mode == WIFI_SOFTAP_MODE,
+		 "hidden_ssid or max_num_sta requires SOFT AP mode");
 
 	if (wifi_oper_mode == WIFI_SOFTAP_MODE && max_num_sta > AP_MAX_NUM_STA) {
 		LOG_ERR("Exceeded maximum supported stations (%d)", AP_MAX_NUM_STA);


### PR DESCRIPTION
- Fixed the assert related to AP mode / Hidden SSID in NWP bootup
- Removed the unnecessary set_credential API call in open security mode