### PR TITLE
actions: manifest: Handle binary blobs

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -42,7 +42,7 @@ jobs:
           west init -l . || true
 
       - name: Manifest
-        uses: zephyrproject-rtos/action-manifest@cb8f6fba6f20b5f8649bd573e80a7583a239894c # v1.7.0
+        uses: zephyrproject-rtos/action-manifest@1729cded3fc798cf0de4a789c596dcb9c40eb14c # v1.9.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           manifest-path: 'west.yml'
@@ -53,3 +53,5 @@ jobs:
           verbosity-level: '1'
           labels: 'manifest'
           dnm-labels: 'DNM (manifest)'
+          blobs-added-labels: 'Binary Blobs Added'
+          blobs-modified-labels: 'Binary Blobs Modified'


### PR DESCRIPTION
Update to a revision of the manifest action that includes: https://github.com/zephyrproject-rtos/action-manifest/pull/21

Also add the corresponding binary blobs labels parameters to the workflow.