### PR TITLE
drivers: watchdog: support numaker m55m1x

### DIFF
--- a/drivers/watchdog/wdt_wwdt_numaker.c
+++ b/drivers/watchdog/wdt_wwdt_numaker.c
@@ -42,7 +42,14 @@ struct wwdt_numaker_data {
 
 static int m_wwdt_numaker_clk_get_rate(const struct wwdt_numaker_config *cfg, uint32_t *rate)
 {
-
+#if defined(CONFIG_SOC_SERIES_M55M1X)
+	if (cfg->clk_src == CLK_WWDTSEL_WWDT0SEL_LIRC ||
+	    cfg->clk_src == CLK_WWDTSEL_WWDT1SEL_LIRC) {
+		*rate = __LIRC / (cfg->clk_div + 1);
+	} else {
+		*rate = __LXT / (cfg->clk_div + 1);
+	}
+#else
 	if (cfg->clk_src == CLK_CLKSEL1_WWDTSEL_LIRC) {
 		*rate = __LIRC / (cfg->clk_div + 1);
 	} else {
@@ -50,6 +57,7 @@ static int m_wwdt_numaker_clk_get_rate(const struct wwdt_numaker_config *cfg, ui
 		SystemCoreClockUpdate();
 		*rate = CLK_GetHCLKFreq() / 2048 / (cfg->clk_div + 1);
 	}
+#endif
 
 	return 0;
 }

--- a/dts/arm/nuvoton/m55m1x.dtsi
+++ b/dts/arm/nuvoton/m55m1x.dtsi
@@ -474,6 +474,14 @@
 			num-bidir-endpoints = <25>;
 			disallow-iso-in-out-same-number;
 		};
+
+		wwdt: watchdog@40240000 {
+			compatible = "nuvoton,numaker-wwdt";
+			reg = <0x40240000 0x10>;
+			interrupts = <9 0>;
+			clocks = <&pcc NUMAKER_WWDT0_MODULE NUMAKER_CLK_WWDTSEL_WWDT0SEL_LIRC 0>;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
This PR is to modify watchdog driver code to support m55m1x series.
Also update m55m1x.dtsi, to add wdt node.