### PR TITLE
boards: aithinker: update vendor name for Ai-Thinker WB2-12F board

### DIFF
--- a/boards/aithinker/ai_wb2_12f/board.yml
+++ b/boards/aithinker/ai_wb2_12f/board.yml
@@ -1,6 +1,6 @@
 board:
   name: ai_wb2_12f
   full_name: Ai-Thinker WB2-12F development board
-  vendor: bflb
+  vendor: aithinker
   socs:
     - name: bl602c00q2i

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -35,6 +35,7 @@ advantech	Advantech Corporation
 aeroflexgaisler	Aeroflex Gaisler AB
 aesc	Aesc Silicon
 aesop	AESOP Embedded Forum
+aithinker	Ai-Thinker Co., Ltd.
 al	Annapurna Labs
 alcatel	Alcatel
 alientek	Alientek


### PR DESCRIPTION
This board is from Ai-Thinker Co., Ltd., not BouffaloLabs, so update the vendor info accordingly.
    
