### PR TITLE
Lara r6 improvements

### DIFF
--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -63,4 +63,23 @@ config MODEM_CELLULAR_NEW_BAUDRATE_DELAY
 	default 100 if DT_HAS_U_BLOX_LARA_R6_ENABLED
 	default 300
 
-endif
+if DT_HAS_U_BLOX_LARA_R6_ENABLED
+
+choice MODEM_CELLULAR_RAT
+	prompt "Which Radio Access Technology to use"
+	default MODEM_CELLULAR_RAT_4G
+
+config MODEM_CELLULAR_RAT_4G
+	bool "Use only 4G"
+
+config MODEM_CELLULAR_RAT_4G_3G
+	bool "Use 4G & 3G"
+
+config MODEM_CELLULAR_RAT_4G_3G_2G
+	bool "Use 4G, 3G & 2G"
+
+endchoice
+
+endif #DT_HAS_U_BLOX_LARA_R6_ENABLED
+
+endif #MODEM_CELLULAR

--- a/drivers/modem/Kconfig.cellular
+++ b/drivers/modem/Kconfig.cellular
@@ -80,6 +80,9 @@ config MODEM_CELLULAR_RAT_4G_3G_2G
 
 endchoice
 
+config MODEM_CELLULAR_CLEAR_FORBIDDEN
+	bool "Clear forbidden networks from SIM-card on boot"
+
 endif #DT_HAS_U_BLOX_LARA_R6_ENABLED
 
 endif #MODEM_CELLULAR

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2200,6 +2200,11 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(u_blox_lara_r6_init_chat_script_cmds,
 #elif CONFIG_MODEM_CELLULAR_RAT_4G_3G_2G
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+URAT=3,2,0", ok_match),
 #endif
+#if CONFIG_MODEM_CELLULAR_CLEAR_FORBIDDEN
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CRSM=214,28539,0,0,12,"
+							 "\"FFFFFFFFFFFFFFFFFFFFFFFF\"",
+							 ok_match),
+#endif
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2193,6 +2193,13 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(u_blox_lara_r6_init_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CEREG?", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGREG?", ok_match),
+#if CONFIG_MODEM_CELLULAR_RAT_4G
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+URAT=3", ok_match),
+#elif CONFIG_MODEM_CELLULAR_RAT_4G_3G
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+URAT=3,2", ok_match),
+#elif CONFIG_MODEM_CELLULAR_RAT_4G_3G_2G
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+URAT=3,2,0", ok_match),
+#endif
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGSN", imei_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGMM", cgmm_match),

--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2178,6 +2178,13 @@ MODEM_CHAT_SCRIPT_DEFINE(u_blox_lara_r6_set_baudrate_chat_script,
  * which works well
  */
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(u_blox_lara_r6_init_chat_script_cmds,
+
+			      /* U-blox LARA-R6 LWM2M client is enabled by default. Not only causes
+			       * this the modem to connect to U-blox's server on its own, it also
+			       * for some reason causes the modem to reply "Destination
+			       * unreachable" to DNS answers from DNS requests that we send
+			       */
+			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+ULWM2M=1", allow_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=4", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CMEE=1", ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CREG=1", ok_match),


### PR DESCRIPTION
This PR adds the following features to U-blox LARA-R6 modem
* Disabling of the embedded LWM2M client in the modem. This client both connects to u-blox servers on its own initiative, and also cause issues with DNS replies to DNS requests made from Zephyr
* Adds a choice to select Radio Access Technology (4G, 3G, 2G)
* Adds an option to clear stored denied networks in the SIM-card. This command is taken from [Onomondo](https://onomondo.com/blog/how-to-clear-the-fplmn-list-on-a-sim/) which allows a user to select which networks the SIM-card is allowed to use. 