### PR TITLE
cmake: linker_script: fix __exidx_start

### DIFF
--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -125,7 +125,7 @@ endif()
 zephyr_linker_section(NAME .ARM.exidx GROUP ROM_REGION)
 # Here the original linker would check for __GCC_LINKER_CMD__, need to check toolchain linker ?
 #if(__GCC_LINKER_CMD__)
-  zephyr_linker_section_configure(SECTION .ARM.exidx INPUT ".gnu.linkonce.armexidx.*")
+  zephyr_linker_section_configure(SECTION .ARM.exidx INPUT ".gnu.linkonce.armexidx.*" SYMBOLS "__exidx_start" "__exidx_end")
 #endif()
 
 


### PR DESCRIPTION
This makes c++ sample
`sample.libraries.hash_map.newlib.cxx_unordered_map.djb2` start working on gcc w. `CMAKE_LINKER_GENERATOR=y`.

ld variant is here:
https://github.com/zephyrproject-rtos/zephyr/blob/b1f9351930f14775e90ebfb2d3d3998b6552ca1f/include/zephyr/arch/arm/cortex_m/scripts/linker.ld#L176