### PR TITLE
Bluetooth: Controller: nRF53x: Fix up ISO Rx Buffer size

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -2214,16 +2214,11 @@ static void *radio_ccm_ext_rx_pkt_set(struct ccm *cnf, uint8_t phy, uint8_t pdu_
 	!defined(CONFIG_SOC_COMPATIBLE_NRF54LX) && \
 	(!defined(CONFIG_BT_CTLR_DATA_LENGTH_MAX) || \
 	 (CONFIG_BT_CTLR_DATA_LENGTH_MAX < ((HAL_RADIO_PDU_LEN_MAX) - 4U)))
-
-#define NRF_CCM_WORKAROUND_XXXX_MAXPACKETSIZE_EXTRA 1U
-
 	const uint8_t max_len = (NRF_RADIO->PCNF1 & RADIO_PCNF1_MAXLEN_Msk) >>
 				RADIO_PCNF1_MAXLEN_Pos;
 
 	/* MAXPACKETSIZE value 0x001B (27) - 0x00FB (251) bytes */
-	NRF_CCM->MAXPACKETSIZE =
-		MAX(MIN((max_len - 4U + NRF_CCM_WORKAROUND_XXXX_MAXPACKETSIZE_EXTRA), 0x00FB),
-		    0x001B);
+	NRF_CCM->MAXPACKETSIZE = CLAMP((max_len - PDU_MIC_SIZE), 0x001B, 0x00FB);
 #endif
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
@@ -2402,7 +2397,7 @@ static void *radio_ccm_ext_tx_pkt_set(struct ccm *cnf, uint8_t pdu_type, void *p
 				RADIO_PCNF1_MAXLEN_Pos;
 
 	/* MAXPACKETSIZE value 0x001B (27) - 0x00FB (251) bytes */
-	NRF_CCM->MAXPACKETSIZE = max_len - 4U;
+	NRF_CCM->MAXPACKETSIZE = CLAMP((max_len - PDU_MIC_SIZE), 0x001B, 0x00FB);
 #endif
 
 #if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/pdu_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/pdu_vendor.h
@@ -10,6 +10,9 @@
 #define OCTET3_LEN 1U
 #endif /* !CONFIG_BT_CTLR_DATA_LENGTH_CLEAR */
 
+/* Minimum vendor specific Rx payload buffer allocation */
+#define LL_VND_OCTETS_RX_MIN 27
+
 /* Presence of vendor Data PDU struct octet3 */
 struct pdu_data_vnd_octet3 {
 	union {

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/pdu_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/pdu_vendor.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Minimum vendor specific Rx payload buffer allocation */
+#define LL_VND_OCTETS_RX_MIN 0
+
 /* No vendor Data PDU struct octet3 */
 struct pdu_data_vnd_octet3 {
 	union {

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -6,7 +6,6 @@
 
 #include <stddef.h>
 
-#include <soc.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci_types.h>
@@ -119,8 +118,15 @@ static void ticker_resume_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 			     void *param);
 
 #define NODE_RX_HEADER_SIZE (offsetof(struct node_rx_pdu, pdu))
+#define ISO_RX_HEADER_SIZE  (offsetof(struct pdu_bis, payload))
+
+/* Ensure both BIS and CIS PDU headers are of equal size */
+BUILD_ASSERT(ISO_RX_HEADER_SIZE == offsetof(struct pdu_cis, payload));
+
 /* ISO LL conformance tests require a PDU size of maximum 251 bytes + header */
-#define ISO_RX_BUFFER_SIZE (2 + 251)
+#define ISO_RX_BUFFER_SIZE (ISO_RX_HEADER_SIZE + \
+			    MAX(MAX(LL_BIS_OCTETS_RX_MAX, LL_CIS_OCTETS_RX_MAX), \
+				LL_VND_OCTETS_RX_MIN))
 
 /* Declare the ISO rx node RXFIFO. This is a composite pool-backed MFIFO for
  * rx_nodes. The declaration constructs the following data structures:


### PR DESCRIPTION
Fix up the bus fault by not violating the MAXPACKETSIZE value range of NRF_CCM h/w peripheral.

Fix up relates to commit 920117922bc8 ("Bluetooth: Controller: nRF53x: Fix NRF_CCM MAXPACKETSIZE value").

Fixes #89736.