### PR TITLE
nRF Clock control: Extend device specific API with `resolve` and `get_startup_time`

### DIFF
--- a/drivers/clock_control/clock_control_nrf2_global_hsfll.c
+++ b/drivers/clock_control/clock_control_nrf2_global_hsfll.c
@@ -62,43 +62,69 @@ static uint32_t global_hsfll_get_max_clock_frequency(const struct device *dev)
 	return dev_config->clock_frequencies[ARRAY_SIZE(dev_config->clock_frequencies) - 1];
 }
 
-static struct onoff_manager *global_hsfll_find_mgr(const struct device *dev,
-						   const struct nrf_clock_spec *spec)
+static int global_hsfll_resolve_spec_to_idx(const struct device *dev,
+					    const struct nrf_clock_spec *req_spec)
 {
-	struct global_hsfll_dev_data *dev_data = dev->data;
 	const struct global_hsfll_dev_config *dev_config = dev->config;
-	uint32_t frequency;
+	uint32_t req_frequency;
 
-	if (!spec) {
-		return &dev_data->clk_cfg.onoff[0].mgr;
-	}
-
-	if (spec->accuracy || spec->precision) {
+	if (req_spec->accuracy || req_spec->precision) {
 		LOG_ERR("invalid specification of accuracy or precision");
-		return NULL;
+		return -EINVAL;
 	}
 
-	frequency = spec->frequency == NRF_CLOCK_CONTROL_FREQUENCY_MAX
-		  ? global_hsfll_get_max_clock_frequency(dev)
-		  : spec->frequency;
+	req_frequency = req_spec->frequency == NRF_CLOCK_CONTROL_FREQUENCY_MAX
+		      ? global_hsfll_get_max_clock_frequency(dev)
+		      : req_spec->frequency;
 
 	for (uint8_t i = 0; i < ARRAY_SIZE(dev_config->clock_frequencies); i++) {
-		if (dev_config->clock_frequencies[i] < frequency) {
+		if (dev_config->clock_frequencies[i] < req_frequency) {
 			continue;
 		}
 
-		return &dev_data->clk_cfg.onoff[i].mgr;
+		return i;
 	}
 
 	LOG_ERR("invalid frequency");
-	return NULL;
+	return -EINVAL;
+}
+
+static void global_hsfll_get_spec_by_idx(const struct device *dev,
+					 uint8_t idx,
+					 struct nrf_clock_spec *spec)
+{
+	const struct global_hsfll_dev_config *dev_config = dev->config;
+
+	spec->frequency = dev_config->clock_frequencies[idx];
+	spec->accuracy = 0;
+	spec->precision = 0;
+}
+
+static struct onoff_manager *global_hsfll_get_mgr_by_idx(const struct device *dev, uint8_t idx)
+{
+	struct global_hsfll_dev_data *dev_data = dev->data;
+
+	return &dev_data->clk_cfg.onoff[idx].mgr;
+}
+
+static struct onoff_manager *global_hsfll_find_mgr_by_spec(const struct device *dev,
+							   const struct nrf_clock_spec *spec)
+{
+	int idx;
+
+	if (!spec) {
+		return global_hsfll_get_mgr_by_idx(dev, 0);
+	}
+
+	idx = global_hsfll_resolve_spec_to_idx(dev, spec);
+	return idx < 0 ? NULL : global_hsfll_get_mgr_by_idx(dev, idx);
 }
 
 static int api_request_global_hsfll(const struct device *dev,
 				    const struct nrf_clock_spec *spec,
 				    struct onoff_client *cli)
 {
-	struct onoff_manager *mgr = global_hsfll_find_mgr(dev, spec);
+	struct onoff_manager *mgr = global_hsfll_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return clock_config_request(mgr, cli);
@@ -110,7 +136,7 @@ static int api_request_global_hsfll(const struct device *dev,
 static int api_release_global_hsfll(const struct device *dev,
 				    const struct nrf_clock_spec *spec)
 {
-	struct onoff_manager *mgr = global_hsfll_find_mgr(dev, spec);
+	struct onoff_manager *mgr = global_hsfll_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return onoff_release(mgr);
@@ -123,13 +149,28 @@ static int api_cancel_or_release_global_hsfll(const struct device *dev,
 					      const struct nrf_clock_spec *spec,
 					      struct onoff_client *cli)
 {
-	struct onoff_manager *mgr = global_hsfll_find_mgr(dev, spec);
+	struct onoff_manager *mgr = global_hsfll_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return onoff_cancel_or_release(mgr, cli);
 	}
 
 	return -EINVAL;
+}
+
+static int api_resolve_global_hsfll(const struct device *dev,
+				    const struct nrf_clock_spec *req_spec,
+				    struct nrf_clock_spec *res_spec)
+{
+	int idx;
+
+	idx = global_hsfll_resolve_spec_to_idx(dev, req_spec);
+	if (idx < 0) {
+		return -EINVAL;
+	}
+
+	global_hsfll_get_spec_by_idx(dev, idx, res_spec);
+	return 0;
 }
 
 static DEVICE_API(nrf_clock_control, driver_api) = {
@@ -140,6 +181,7 @@ static DEVICE_API(nrf_clock_control, driver_api) = {
 	.request = api_request_global_hsfll,
 	.release = api_release_global_hsfll,
 	.cancel_or_release = api_cancel_or_release_global_hsfll,
+	.resolve = api_resolve_global_hsfll,
 };
 
 static enum gdfs_frequency_setting global_hsfll_freq_idx_to_nrfs_freq(const struct device *dev,

--- a/drivers/clock_control/clock_control_nrf2_hsfll.c
+++ b/drivers/clock_control/clock_control_nrf2_hsfll.c
@@ -100,35 +100,56 @@ static void hsfll_work_handler(struct k_work *work)
 	k_timer_start(&dev_data->timer, NRFS_DVFS_TIMEOUT, K_NO_WAIT);
 }
 
-static struct onoff_manager *hsfll_find_mgr(const struct device *dev,
-					    const struct nrf_clock_spec *spec)
+static int hsfll_resolve_spec_to_idx(const struct nrf_clock_spec *req_spec)
 {
-	struct hsfll_dev_data *dev_data = dev->data;
-	uint32_t frequency;
+	uint32_t req_frequency;
 
-	if (!spec) {
-		return &dev_data->clk_cfg.onoff[0].mgr;
-	}
-
-	if (spec->accuracy || spec->precision) {
+	if (req_spec->accuracy || req_spec->precision) {
 		LOG_ERR("invalid specification of accuracy or precision");
-		return NULL;
+		return -EINVAL;
 	}
 
-	frequency = spec->frequency == NRF_CLOCK_CONTROL_FREQUENCY_MAX
-		  ? HSFLL_FREQ_HIGH
-		  : spec->frequency;
+	req_frequency = req_spec->frequency == NRF_CLOCK_CONTROL_FREQUENCY_MAX
+		      ? HSFLL_FREQ_HIGH
+		      : req_spec->frequency;
 
 	for (int i = 0; i < ARRAY_SIZE(clock_options); ++i) {
-		if (frequency > clock_options[i].frequency) {
+		if (req_frequency > clock_options[i].frequency) {
 			continue;
 		}
 
-		return &dev_data->clk_cfg.onoff[i].mgr;
+		return i;
 	}
 
 	LOG_ERR("invalid frequency");
-	return NULL;
+	return -EINVAL;
+}
+
+static void hsfll_get_spec_by_idx(uint8_t idx, struct nrf_clock_spec *spec)
+{
+	spec->frequency = clock_options[idx].frequency;
+	spec->accuracy = 0;
+	spec->precision = 0;
+}
+
+static struct onoff_manager *hsfll_get_mgr_by_idx(const struct device *dev, uint8_t idx)
+{
+	struct hsfll_dev_data *dev_data = dev->data;
+
+	return &dev_data->clk_cfg.onoff[idx].mgr;
+}
+
+static struct onoff_manager *hsfll_find_mgr_by_spec(const struct device *dev,
+						    const struct nrf_clock_spec *spec)
+{
+	int idx;
+
+	if (!spec) {
+		return hsfll_get_mgr_by_idx(dev, 0);
+	}
+
+	idx = hsfll_resolve_spec_to_idx(spec);
+	return idx < 0 ? NULL : hsfll_get_mgr_by_idx(dev, idx);
 }
 #endif /* CONFIG_NRFS_DVFS_LOCAL_DOMAIN */
 
@@ -137,7 +158,7 @@ static int api_request_hsfll(const struct device *dev,
 			     struct onoff_client *cli)
 {
 #ifdef CONFIG_NRFS_DVFS_LOCAL_DOMAIN
-	struct onoff_manager *mgr = hsfll_find_mgr(dev, spec);
+	struct onoff_manager *mgr = hsfll_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return clock_config_request(mgr, cli);
@@ -153,7 +174,7 @@ static int api_release_hsfll(const struct device *dev,
 			     const struct nrf_clock_spec *spec)
 {
 #ifdef CONFIG_NRFS_DVFS_LOCAL_DOMAIN
-	struct onoff_manager *mgr = hsfll_find_mgr(dev, spec);
+	struct onoff_manager *mgr = hsfll_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return onoff_release(mgr);
@@ -170,13 +191,32 @@ static int api_cancel_or_release_hsfll(const struct device *dev,
 				       struct onoff_client *cli)
 {
 #ifdef CONFIG_NRFS_DVFS_LOCAL_DOMAIN
-	struct onoff_manager *mgr = hsfll_find_mgr(dev, spec);
+	struct onoff_manager *mgr = hsfll_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return onoff_cancel_or_release(mgr, cli);
 	}
 
 	return -EINVAL;
+#else
+	return -ENOTSUP;
+#endif
+}
+
+static int api_resolve_hsfll(const struct device *dev,
+			     const struct nrf_clock_spec *req_spec,
+			     struct nrf_clock_spec *res_spec)
+{
+#ifdef CONFIG_NRFS_DVFS_LOCAL_DOMAIN
+	int idx;
+
+	idx = hsfll_resolve_spec_to_idx(req_spec);
+	if (idx < 0) {
+		return -EINVAL;
+	}
+
+	hsfll_get_spec_by_idx(idx, res_spec);
+	return 0;
 #else
 	return -ENOTSUP;
 #endif
@@ -212,6 +252,7 @@ static DEVICE_API(nrf_clock_control, hsfll_drv_api) = {
 	.request = api_request_hsfll,
 	.release = api_release_hsfll,
 	.cancel_or_release = api_cancel_or_release_hsfll,
+	.resolve = api_resolve_hsfll,
 };
 
 #ifdef CONFIG_NRFS_DVFS_LOCAL_DOMAIN

--- a/drivers/clock_control/clock_control_nrf2_lfclk.c
+++ b/drivers/clock_control/clock_control_nrf2_lfclk.c
@@ -22,6 +22,8 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 #define LFCLK_LFLPRC_ACCURACY DT_INST_PROP(0, lflprc_accuracy_ppm)
 #define LFCLK_LFRC_ACCURACY DT_INST_PROP(0, lfrc_accuracy_ppm)
 #define LFCLK_HFXO_ACCURACY DT_PROP(LFCLK_HFXO_NODE, accuracy_ppm)
+#define LFCLK_LFLPRC_STARTUP_TIME_US DT_INST_PROP(0, lflprc_startup_time_us)
+#define LFCLK_LFRC_STARTUP_TIME_US DT_INST_PROP(0, lfrc_startup_time_us)
 
 #define LFCLK_MAX_OPTS 5
 #define LFCLK_DEF_OPTS 3
@@ -59,6 +61,8 @@ struct lfclk_dev_data {
 	struct k_timer timer;
 	uint16_t max_accuracy;
 	uint8_t clock_options_cnt;
+	uint32_t hfxo_startup_time_us;
+	uint32_t lfxo_startup_time_us;
 };
 
 struct lfclk_dev_config {
@@ -105,45 +109,108 @@ static void lfclk_work_handler(struct k_work *work)
 	}
 }
 
-static struct onoff_manager *lfclk_find_mgr(const struct device *dev,
-					    const struct nrf_clock_spec *spec)
+static int lfclk_resolve_spec_to_idx(const struct device *dev,
+				     const struct nrf_clock_spec *req_spec)
 {
 	struct lfclk_dev_data *dev_data = dev->data;
 	const struct lfclk_dev_config *dev_config = dev->config;
-	uint16_t accuracy;
+	uint16_t req_accuracy;
 
-	if (!spec) {
-		return &dev_data->clk_cfg.onoff[0].mgr;
-	}
-
-	if (spec->frequency > dev_config->fixed_frequency) {
+	if (req_spec->frequency > dev_config->fixed_frequency) {
 		LOG_ERR("invalid frequency");
-		return NULL;
+		return -EINVAL;
 	}
 
-	accuracy = spec->accuracy == NRF_CLOCK_CONTROL_ACCURACY_MAX
-		 ? dev_data->max_accuracy
-		 : spec->accuracy;
+	req_accuracy = req_spec->accuracy == NRF_CLOCK_CONTROL_ACCURACY_MAX
+		     ? dev_data->max_accuracy
+		     : req_spec->accuracy;
 
 	for (int i = 0; i < dev_data->clock_options_cnt; ++i) {
-		if ((accuracy &&
-		     accuracy < clock_options[i].accuracy) ||
-		    spec->precision > clock_options[i].precision) {
+		if ((req_accuracy &&
+		     req_accuracy < clock_options[i].accuracy) ||
+		     req_spec->precision > clock_options[i].precision) {
 			continue;
 		}
 
-		return &dev_data->clk_cfg.onoff[i].mgr;
+		return i;
 	}
 
 	LOG_ERR("invalid accuracy or precision");
-	return NULL;
+	return -EINVAL;
+}
+
+static void lfclk_get_spec_by_idx(const struct device *dev,
+				  uint8_t idx,
+				  struct nrf_clock_spec *spec)
+{
+	const struct lfclk_dev_config *dev_config = dev->config;
+
+	spec->frequency = dev_config->fixed_frequency;
+	spec->accuracy = clock_options[idx].accuracy;
+	spec->precision = clock_options[idx].precision;
+}
+
+static struct onoff_manager *lfclk_get_mgr_by_idx(const struct device *dev, uint8_t idx)
+{
+	struct lfclk_dev_data *dev_data = dev->data;
+
+	return &dev_data->clk_cfg.onoff[idx].mgr;
+}
+
+static int lfclk_get_startup_time_by_idx(const struct device *dev,
+					 uint8_t idx,
+					 uint32_t *startup_time_us)
+{
+	struct lfclk_dev_data *dev_data = dev->data;
+	nrfs_clock_src_t src = clock_options[idx].src;
+
+	switch (src) {
+	case NRFS_CLOCK_SRC_LFCLK_LFLPRC:
+		*startup_time_us = LFCLK_LFLPRC_STARTUP_TIME_US;
+		return 0;
+
+	case NRFS_CLOCK_SRC_LFCLK_LFRC:
+		*startup_time_us = LFCLK_LFRC_STARTUP_TIME_US;
+		return 0;
+
+	case NRFS_CLOCK_SRC_LFCLK_XO_PIXO:
+	case NRFS_CLOCK_SRC_LFCLK_XO_PIERCE:
+	case NRFS_CLOCK_SRC_LFCLK_XO_EXT_SINE:
+	case NRFS_CLOCK_SRC_LFCLK_XO_EXT_SQUARE:
+	case NRFS_CLOCK_SRC_LFCLK_XO_PIERCE_HP:
+	case NRFS_CLOCK_SRC_LFCLK_XO_EXT_SINE_HP:
+		*startup_time_us = dev_data->lfxo_startup_time_us;
+		return 0;
+
+	case NRFS_CLOCK_SRC_LFCLK_SYNTH:
+		*startup_time_us = dev_data->hfxo_startup_time_us;
+		return 0;
+
+	default:
+		break;
+	}
+
+	return -EINVAL;
+}
+
+static struct onoff_manager *lfclk_find_mgr_by_spec(const struct device *dev,
+						    const struct nrf_clock_spec *spec)
+{
+	int idx;
+
+	if (!spec) {
+		return lfclk_get_mgr_by_idx(dev, 0);
+	}
+
+	idx = lfclk_resolve_spec_to_idx(dev, spec);
+	return idx < 0 ? NULL : lfclk_get_mgr_by_idx(dev, idx);
 }
 
 static int api_request_lfclk(const struct device *dev,
 			     const struct nrf_clock_spec *spec,
 			     struct onoff_client *cli)
 {
-	struct onoff_manager *mgr = lfclk_find_mgr(dev, spec);
+	struct onoff_manager *mgr = lfclk_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return clock_config_request(mgr, cli);
@@ -155,7 +222,7 @@ static int api_request_lfclk(const struct device *dev,
 static int api_release_lfclk(const struct device *dev,
 			     const struct nrf_clock_spec *spec)
 {
-	struct onoff_manager *mgr = lfclk_find_mgr(dev, spec);
+	struct onoff_manager *mgr = lfclk_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return onoff_release(mgr);
@@ -168,13 +235,43 @@ static int api_cancel_or_release_lfclk(const struct device *dev,
 				       const struct nrf_clock_spec *spec,
 				       struct onoff_client *cli)
 {
-	struct onoff_manager *mgr = lfclk_find_mgr(dev, spec);
+	struct onoff_manager *mgr = lfclk_find_mgr_by_spec(dev, spec);
 
 	if (mgr) {
 		return onoff_cancel_or_release(mgr, cli);
 	}
 
 	return -EINVAL;
+}
+
+
+static int api_resolve(const struct device *dev,
+		       const struct nrf_clock_spec *req_spec,
+		       struct nrf_clock_spec *res_spec)
+{
+	int idx;
+
+	idx = lfclk_resolve_spec_to_idx(dev, req_spec);
+	if (idx < 0) {
+		return -EINVAL;
+	}
+
+	lfclk_get_spec_by_idx(dev, idx, res_spec);
+	return 0;
+}
+
+static int api_get_startup_time(const struct device *dev,
+				const struct nrf_clock_spec *spec,
+				uint32_t *startup_time_us)
+{
+	int idx;
+
+	idx = lfclk_resolve_spec_to_idx(dev, spec);
+	if (idx < 0) {
+		return -EINVAL;
+	}
+
+	return lfclk_get_startup_time_by_idx(dev, idx, startup_time_us);
 }
 
 static int api_get_rate_lfclk(const struct device *dev,
@@ -251,6 +348,19 @@ static int lfclk_init(const struct device *dev)
 			LOG_ERR("Unexpected LFOSC mode");
 			return -EINVAL;
 		}
+
+		dev_data->lfxo_startup_time_us = nrf_bicr_lfosc_startup_time_ms_get(BICR)
+					       * USEC_PER_MSEC;
+		if (dev_data->lfxo_startup_time_us == NRF_BICR_LFOSC_STARTUP_TIME_UNCONFIGURED) {
+			LOG_ERR("BICR LFXO startup time invalid");
+			return -ENODEV;
+		}
+	}
+
+	dev_data->hfxo_startup_time_us = nrf_bicr_hfxo_startup_time_us_get(BICR);
+	if (dev_data->hfxo_startup_time_us == NRF_BICR_HFXO_STARTUP_TIME_UNCONFIGURED) {
+		LOG_ERR("BICR HFXO startup time invalid");
+		return -ENODEV;
 	}
 
 	k_timer_init(&dev_data->timer, lfclk_update_timeout_handler, NULL);
@@ -269,6 +379,8 @@ static DEVICE_API(nrf_clock_control, lfclk_drv_api) = {
 	.request = api_request_lfclk,
 	.release = api_release_lfclk,
 	.cancel_or_release = api_cancel_or_release_lfclk,
+	.resolve = api_resolve,
+	.get_startup_time = api_get_startup_time,
 };
 
 static struct lfclk_dev_data lfclk_data;

--- a/dts/bindings/clock/nordic,nrf-fll16m.yaml
+++ b/dts/bindings/clock/nordic,nrf-fll16m.yaml
@@ -18,6 +18,7 @@ description: |
 
     fll16m {
             open-loop-accuracy-ppm = <20000>;
+            open-loop-startup-time-us = <400>;
             clocks = <&hfxo>, <&lfxo>;
             clock-names = "hfxo", "lfxo";
     };
@@ -33,4 +34,9 @@ properties:
   open-loop-accuracy-ppm:
     type: int
     description: Clock accuracy in parts per million
+    required: true
+
+  open-loop-startup-time-us:
+    type: int
+    description: Clock startup time if open-loop clock source is used.
     required: true

--- a/dts/bindings/clock/nordic,nrf-fll16m.yaml
+++ b/dts/bindings/clock/nordic,nrf-fll16m.yaml
@@ -32,4 +32,5 @@ properties:
 
   open-loop-accuracy-ppm:
     type: int
-    description: Clock accuracy in parts per million if open-loop clock source is used.
+    description: Clock accuracy in parts per million
+    required: true

--- a/dts/bindings/clock/nordic,nrf-lfclk.yaml
+++ b/dts/bindings/clock/nordic,nrf-lfclk.yaml
@@ -21,6 +21,8 @@ description: |
     lfclk {
             lfrc-accuracy-ppm = <500>;
             lflprc-accuracy-ppm = <1000>;
+            lfrc-startup-time-us = <400>;
+            lflprc-startup-time-us = <400>;
             clocks = <&hfxo>, <&lfxo>;
             clock-names = "hfxo", "lfxo";
     };
@@ -40,3 +42,11 @@ properties:
   lflprc-accuracy-ppm:
     type: int
     description: Clock accuracy in parts per million if LFLPRC clock source is used.
+
+  lfrc-startup-time-us:
+    type: int
+    description: Clock startup time in microseconds if LFRC clock source is used.
+
+  lflprc-startup-time-us:
+    type: int
+    description: Clock startup time in microseconds if LFLPRC clock source is used.

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -199,6 +199,8 @@
 			status = "okay";
 			lfrc-accuracy-ppm = <500>;
 			lflprc-accuracy-ppm = <1000>;
+			lfrc-startup-time-us = <200>; /* To be measured */
+			lflprc-startup-time-us = <200>; /* To be measured */
 			clocks = <&hfxo>, <&lfxo>;
 			clock-names = "hfxo", "lfxo";
 		};

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -177,6 +177,7 @@
 			#clock-cells = <0>;
 			clock-frequency = <DT_FREQ_M(16)>;
 			open-loop-accuracy-ppm = <20000>;
+			open-loop-startup-time-us = <200>; /* To be measured */
 			clocks = <&hfxo>, <&lfxo>;
 			clock-names = "hfxo", "lfxo";
 		};

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -197,6 +197,9 @@ __subsystem struct nrf_clock_control_driver_api {
 	int (*cancel_or_release)(const struct device *dev,
 				 const struct nrf_clock_spec *spec,
 				 struct onoff_client *cli);
+	int (*resolve)(const struct device *dev,
+		       const struct nrf_clock_spec *req_spec,
+		       struct nrf_clock_spec *res_spec);
 };
 
 /**
@@ -315,6 +318,30 @@ int nrf_clock_control_cancel_or_release(const struct device *dev,
 		(const struct nrf_clock_control_driver_api *)dev->api;
 
 	return api->cancel_or_release(dev, spec, cli);
+}
+
+/**
+ * @brief Resolve a requested clock spec to resulting spec.
+ *
+ * @param dev Device structure.
+ * @param req_spec The requested clock specification.
+ * @param res_spec Destination for the resulting clock specification.
+ *
+ * @retval Successful if successful.
+ * @retval -errno code if failure
+ */
+static inline int nrf_clock_control_resolve(const struct device *dev,
+					    const struct nrf_clock_spec *req_spec,
+					    struct nrf_clock_spec *res_spec)
+{
+	const struct nrf_clock_control_driver_api *api =
+		(const struct nrf_clock_control_driver_api *)dev->api;
+
+	if (api->resolve == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->resolve(dev, req_spec, res_spec);
 }
 
 /** @brief Request the HFXO from Zero Latency Interrupt context.

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -200,6 +200,9 @@ __subsystem struct nrf_clock_control_driver_api {
 	int (*resolve)(const struct device *dev,
 		       const struct nrf_clock_spec *req_spec,
 		       struct nrf_clock_spec *res_spec);
+	int (*get_startup_time)(const struct device *dev,
+				const struct nrf_clock_spec *spec,
+				uint32_t *startup_time_us);
 };
 
 /**
@@ -342,6 +345,29 @@ static inline int nrf_clock_control_resolve(const struct device *dev,
 	}
 
 	return api->resolve(dev, req_spec, res_spec);
+}
+
+/**
+ * @brief Get the startup timme of a clock.
+ *
+ * @param dev Device structure.
+ * @param startup_time_us Destination for startup time in microseconds.
+ *
+ * @retval Successful if successful.
+ * @retval -errno code if failure.
+ */
+static inline int nrf_clock_control_get_startup_time(const struct device *dev,
+						     const struct nrf_clock_spec *spec,
+						     uint32_t *startup_time_us)
+{
+	const struct nrf_clock_control_driver_api *api =
+		(const struct nrf_clock_control_driver_api *)dev->api;
+
+	if (api->get_startup_time == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_startup_time(dev, spec, startup_time_us);
 }
 
 /** @brief Request the HFXO from Zero Latency Interrupt context.


### PR DESCRIPTION
Extend nRF device driver specific API for getting the actual clock spec which will be applied based on a requested minimum spec, and the startup time for a specific clock spec. This is required to power optimize apps and subsystems like Bluetooth which need to know how far in advance a clock needs to be started, and what the actual accuracy/precision applied to a clock is (this could be way better than the requested minimum specs)

The nordic specific sample has been extended to demo usage of these APIs.