### PR TITLE
drivers: i2c: stm32: Fix size calculation of n_timings

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -550,7 +550,8 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##index = {					\
 		 .sda = GPIO_DT_SPEC_INST_GET_OR(index, sda_gpios, {0}),))			\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),					\
 		(.timings = (const struct i2c_config_timing *) i2c_timings_##index,		\
-		 .n_timings = ARRAY_SIZE(i2c_timings_##index),))				\
+		 .n_timings =									\
+			sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),))	\
 	I2C_DMA_INIT(index, tx)									\
 	I2C_DMA_INIT(index, rx)									\
 };												\


### PR DESCRIPTION
`timings` is an array of `struct i2c_config_timing` (3 x `uint32_t`). `i2c_timings_##index` is an array of `uint32_t` (hence the cast when it is assigned to `timings`). Therefore `ARRAY_SIZE(i2c_timings_##index)` is off by a factor 3 when used for `n_timings`.

Parentheses around the second `sizeof` are there to silence the gcc warning (-Wsizeof-array-div) that warns about not computing the size of `i2c_timings_##index`.