### PR TITLE
twister: Convert platform names before printing

### DIFF
--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -135,6 +135,16 @@ def twister(options: argparse.Namespace, default_options: argparse.Namespace):
         report.synopsis()
         return 0
 
+    # FIXME: This is a workaround for the fact that the hardware map can be usng
+    # the short name of the platform, while the testplan is using the full name.
+    #
+    # convert platform names coming from the hardware map to the full target
+    # name.
+    # this is needed to match the platform names in the testplan.
+    for d in hwm.duts:
+        if d.platform in tplan.platform_names:
+            d.platform = tplan.get_platform(d.platform).name
+
     if options.device_testing and not options.build_only:
         print("\nDevice testing on:")
         hwm.dump(filtered=tplan.selected_platforms)
@@ -149,15 +159,6 @@ def twister(options: argparse.Namespace, default_options: argparse.Namespace):
         tplan.create_build_dir_links()
 
     runner = TwisterRunner(tplan.instances, tplan.testsuites, env)
-    # FIXME: This is a workaround for the fact that the hardware map can be usng
-    # the short name of the platform, while the testplan is using the full name.
-    #
-    # convert platform names coming from the hardware map to the full target
-    # name.
-    # this is needed to match the platform names in the testplan.
-    for d in hwm.duts:
-        if d.platform in tplan.platform_names:
-            d.platform = tplan.get_platform(d.platform).name
     runner.duts = hwm.duts
     runner.run()
 


### PR DESCRIPTION
Just move a code with workaround to convert platform names to the full name with variants.
It fixes an issue, that not every platforms are printed before running tests.

Before fix:
(when using a platform that has a variant, but not given it with --platform or in hardware map):
`$ZEPHYR_BASE/scripts/twister -v -T samples/hello_world -p nrf9160dk/nrf9160 --device-testing --device-serial /dev/ttyACM0`

```
INFO    - Building initial testsuite list...
Device testing on:
| Platform   | ID   | Serial device   |
|------------|------|-----------------|
...
INFO    - 1/1 nrf9160dk@0.14.0/nrf9160  samples/hello_world/sample.basic.helloworld        PASSED (device 1.609s <zephyr>)
...
INFO    - 1 test configurations executed on platforms, 0 test configurations were only built.
Hardware distribution summary:
| Board                    | ID   |   Counter |   Failures |
|--------------------------|------|-----------|------------|
| nrf9160dk@0.14.0/nrf9160 |      |         1 |          0 |
```
after fix, you can find platform also in initial list:
```
INFO    - Building initial testsuite list...
Device testing on:
| Platform                 | ID   | Serial device   |
|--------------------------|------|-----------------|
| nrf9160dk@0.14.0/nrf9160 |      | /dev/ttyACM0    |
```



