### PR TITLE
dts: vendor: raspberrypi: Add partitions for Raspberry Pi

### DIFF
--- a/dts/vendor/raspberrypi/partitions_2M_default.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_default.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Beechwoods Software, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <raspberrypi/partitions_2M_storage.dtsi>

--- a/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_storage.dtsi
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Beechwoods Software, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * Usable flash. Starts at 0x100, after the bootloader. The partition
+		 * size is 1MB minus the 0x100 bytes taken by the bootloader.
+		 */
+		code_partition: partition@100 {
+			label = "code";
+			reg = <0x100 (DT_SIZE_M(1) - 0x100)>;
+			read-only;
+		};
+
+		storage_partition: partition@100000 {
+			label = "storage";
+			reg = <0x100000  DT_SIZE_M(1)>;
+		};
+	};
+};

--- a/dts/vendor/raspberrypi/partitions_2M_sysbuild.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_sysbuild.dtsi
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Beechwoods Software, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = < 0x1 >;
+		#size-cells = < 0x1 >;
+
+		second_stage_bootloader: partition@0 {
+			label = "second_stage_bootloader";
+			reg = < 0x0 0x100 >;
+			read-only;
+		};
+
+		boot_partition: partition@100 {
+			label = "mcuboot";
+			reg = < 0x100 0xfe00 >;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = < 0x10000 0xd0000 >;
+		};
+
+		slot1_partition: partition@E0000 {
+			label = "image-1";
+			reg = < 0xe0000 0xd0000 >;
+		};
+
+		storage_partition: partition@1B0000 {
+			label = "storage";
+			reg = < 0x1b0000 0x50000 >;
+		};
+	};
+};


### PR DESCRIPTION
Add partitions for Raspberry Pi boards with default to use Storage partitions and option to use Sysbuild partitions.