### PR TITLE
shields: add shield.yml for st_b_cams_imx_mb1854

### DIFF
--- a/boards/shields/st_b_cams_imx_mb1854/shield.yml
+++ b/boards/shields/st_b_cams_imx_mb1854/shield.yml
@@ -1,0 +1,4 @@
+shield:
+  name: st_b_cams_imx_mb1854
+  full_name: ST B-CAMS-IMX-MB1854
+  vendor: st


### PR DESCRIPTION
The PR for this shield was in-flight while shield.yml was being introduced. Add the missing file so that this shield is properly listed in the board catalog.

<img width="311" alt="image" src="https://github.com/user-attachments/assets/965fc1b6-a6a5-49b7-bbb1-c8039f8bb600" />