### PR TITLE
Add full_name property for archs and leverage in board catalog

### DIFF
--- a/arch/archs.yml
+++ b/arch/archs.yml
@@ -1,21 +1,31 @@
 archs:
   - name: arc
     path: arc
+    full_name: Synopsys DesignWare ARC
   - name: arm
     path: arm
+    full_name: ARM
   - name: arm64
     path: arm64
+    full_name: ARM 64
   - name: mips
     path: mips
+    full_name: MIPS
   - name: posix
     path: posix
+    full_name: POSIX
   - name: riscv
     path: riscv
+    full_name: RISC-V
   - name: sparc
     path: sparc
+    full_name: SPARC
   - name: xtensa
     path: xtensa
+    full_name: Xtensa
   - name: x86
     path: x86
+    full_name: x86
   - name: rx
     path: rx
+    full_name: Renesas RX

--- a/doc/_extensions/zephyr/domain/__init__.py
+++ b/doc/_extensions/zephyr/domain/__init__.py
@@ -760,6 +760,7 @@ class BoardCatalogDirective(SphinxDirective):
                     "shields": domain_data["shields"],
                     "vendors": domain_data["vendors"],
                     "socs": domain_data["socs"],
+                    "archs": domain_data["archs"],
                     "hw_features_present": self.env.app.config.zephyr_generate_hw_features,
                 },
             )
@@ -1385,6 +1386,7 @@ def load_board_catalog_into_domain(app: Sphinx) -> None:
     app.env.domaindata["zephyr"]["shields"] = board_catalog["shields"]
     app.env.domaindata["zephyr"]["vendors"] = board_catalog["vendors"]
     app.env.domaindata["zephyr"]["socs"] = board_catalog["socs"]
+    app.env.domaindata["zephyr"]["archs"] = board_catalog["archs"]
     app.env.domaindata["zephyr"]["runners"] = board_catalog["runners"]
 
 

--- a/doc/_extensions/zephyr/domain/templates/board-catalog.html
+++ b/doc/_extensions/zephyr/domain/templates/board-catalog.html
@@ -17,15 +17,9 @@
     <div class="select-container">
       <select id="arch">
         <option value="" disabled selected>Select an architecture</option>
-        <option value="arm">ARM</option>
-        <option value="arm64">ARM 64</option>
-        <option value="mips">MIPS</option>
-        <option value="posix">POSIX</option>
-        <option value="riscv">RISC-V</option>
-        <option value="sparc">SPARC</option>
-        <option value="arc">Synopsys DesignWare ARC</option>
-        <option value="x86">x86</option>
-        <option value="xtensa">Xtensa</option>
+        {% for arch_name, arch in archs | items | sort(attribute='1.full_name') -%}
+        <option value="{{ arch_name }}">{{ arch.full_name }}</option>
+        {% endfor %}
       </select>
     </div>
   </div>

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -22,11 +22,11 @@ ZEPHYR_BASE = Path(__file__).parents[2]
 ZEPHYR_BINDINGS = ZEPHYR_BASE / "dts/bindings"
 EDT_PICKLE_PATHS = [
     "zephyr/edt.pickle",
-    "hello_world/zephyr/edt.pickle"  # for board targets using sysbuild
+    "hello_world/zephyr/edt.pickle",  # for board targets using sysbuild
 ]
 RUNNERS_YAML_PATHS = [
     "zephyr/runners.yaml",
-    "hello_world/zephyr/runners.yaml"  # for board targets using sysbuild
+    "hello_world/zephyr/runners.yaml",  # for board targets using sysbuild
 ]
 
 logger = logging.getLogger(__name__)
@@ -73,8 +73,7 @@ class DeviceTreeUtils:
             The cached description for the node's compatible, creating it if needed.
         """
         return cls._compat_description_cache.setdefault(
-            node.matching_compat,
-            cls.get_first_sentence(node.description)
+            node.matching_compat, cls.get_first_sentence(node.description)
         )
 
 
@@ -176,9 +175,7 @@ def gather_board_build_info(twister_out_dir):
                 if runners_yaml_file:
                     with open(runners_yaml_file) as f:
                         runners_yaml = yaml.safe_load(f)
-                        board_runners.setdefault(board_name, {})[board_target] = (
-                            runners_yaml
-                        )
+                        board_runners.setdefault(board_name, {})[board_target] = runners_yaml
 
         except Exception as e:
             logger.error(f"Error processing build info file {build_info_file}: {e}")
@@ -196,12 +193,14 @@ def run_twister_cmake_only(outdir, vendor_filter):
     twister_cmd = [
         sys.executable,
         f"{ZEPHYR_BASE}/scripts/twister",
-        "-T", "samples/hello_world/",
+        "-T",
+        "samples/hello_world/",
         "-M",
         *[arg for path in EDT_PICKLE_PATHS for arg in ('--keep-artifacts', path)],
         *[arg for path in RUNNERS_YAML_PATHS for arg in ('--keep-artifacts', path)],
         "--cmake-only",
-        "--outdir", str(outdir),
+        "--outdir",
+        str(outdir),
     ]
 
     if vendor_filter:
@@ -214,7 +213,7 @@ def run_twister_cmake_only(outdir, vendor_filter):
         'PATH': os.environ.get('PATH', ''),
         'ZEPHYR_BASE': str(ZEPHYR_BASE),
         'HOME': os.environ.get('HOME', ''),
-        'PYTHONPATH': os.environ.get('PYTHONPATH', '')
+        'PYTHONPATH': os.environ.get('PYTHONPATH', ''),
     }
 
     try:
@@ -247,18 +246,22 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
             if root is not None:
                 module_settings[key].append(Path(module.project) / root)
 
-    Args = namedtuple("args", ["arch_roots", "board_roots", "soc_roots", "board_dir", "board"])
+    Args = namedtuple(
+        "args", ["arch_roots", "board_roots", "soc_roots", "board_dir", "board", "arch"]
+    )
     args_find_boards = Args(
         arch_roots=module_settings["arch_root"],
         board_roots=module_settings["board_root"],
         soc_roots=module_settings["soc_root"],
         board_dir=[],
         board=None,
+        arch=None,
     )
 
     boards = list_boards.find_v2_boards(args_find_boards)
     shields = list_shields.find_shields(args_find_boards)
     systems = list_hardware.find_v2_systems(args_find_boards)
+    archs = list_hardware.find_v2_archs(args_find_boards)
     board_catalog = {}
     shield_catalog = {}
     board_devicetrees = {}
@@ -296,7 +299,6 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
                         binding_type = "misc"
                         is_custom_binding = True
 
-
                     if node.matching_compat is None:
                         continue
 
@@ -316,9 +318,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
                         else:
                             locations.add("soc")
 
-                    existing_feature = features.get(binding_type, {}).get(
-                        node.matching_compat
-                    )
+                    existing_feature = features.get(binding_type, {}).get(node.matching_compat)
 
                     node_info = {
                         "filename": str(filename),
@@ -359,13 +359,13 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
 
         # Grab all the twister files for this board and use them to figure out all the archs it
         # supports.
-        archs = set()
+        board_archs = set()
         pattern = f"{board.name}*.yaml"
         for twister_file in board.dir.glob(pattern):
             try:
                 with open(twister_file) as f:
                     board_data = yaml.safe_load(f)
-                    archs.add(board_data.get("arch"))
+                    board_archs.add(board_data.get("arch"))
             except Exception as e:
                 logger.error(f"Error parsing twister file {twister_file}: {e}")
 
@@ -379,7 +379,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
             "full_name": full_name,
             "doc_page": doc_page_path,
             "vendor": vendor,
-            "archs": list(archs),
+            "archs": list(board_archs),
             "socs": list(socs),
             "revision_default": board.revision_default,
             "supported_features": supported_features,
@@ -403,6 +403,14 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
             "commands": runner.capabilities().commands,
         }
 
+    arch_catalog = {
+        arch['name']: {
+            "name": arch['name'],
+            "full_name": arch.get('full_name', arch['name']),
+        }
+        for arch in archs['archs']
+    }
+
     for shield in shields:
         doc_page = guess_doc_page(shield)
         if doc_page and doc_page.is_relative_to(ZEPHYR_BASE):
@@ -423,5 +431,6 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
         "shields": shield_catalog,
         "vendors": {**vnd_lookup.vnd2vendor, "others": "Other/Unknown"},
         "socs": socs_hierarchy,
+        "archs": arch_catalog,
         "runners": available_runners,
     }

--- a/scripts/schemas/arch-schema.yml
+++ b/scripts/schemas/arch-schema.yml
@@ -23,6 +23,10 @@ mapping:
             required: true
             type: str
             desc: Location of the arch implementation relative to the archs.yml file.
+          full_name:
+            required: false
+            type: str
+            desc: Full display name of the architecture
           comment:
             required: false
             type: str


### PR DESCRIPTION
Rather than hard coding the human readable name for the architectures that are available at a given point in time (and then get out of sync when e.g. NIOS II gets dropped, or Renesas RX gets added...), add a `full_name` to the archs in archs.yml and leverage that info in the catalog. 

https://builds.zephyrproject.io/zephyr/pr/90413/docs/boards/index.html#

List of architectures is now always in sync with archs.yml

<img width="391" alt="image" src="https://github.com/user-attachments/assets/6dff179a-03d2-4e19-8f54-a4c168eb2bc5" />


Fixes #90406
