### PR TITLE
doc: introduction: replace NIOS II mention by Renesas RX

### DIFF
--- a/doc/introduction/index.rst
+++ b/doc/introduction/index.rst
@@ -16,7 +16,7 @@ The Zephyr kernel supports multiple architectures, including:
  - ARMv7-R, ARMv8-R (Cortex-R, 32- and 64-bit)
  - Intel x86 (32- and 64-bit)
  - MIPS (MIPS32 Release 1 specification)
- - NIOS II Gen 2
+ - Renesas RX
  - RISC-V (32- and 64-bit)
  - SPARC V8
  - Tensilica Xtensa


### PR DESCRIPTION
Remove one last (?) mention of NIOS II in the docs ; use it as an opportunity to mention recently added support for Renesas RX.
