### PR TITLE
video: addition of __ASSERT to ensure proper arguments in api functions

### DIFF
--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -448,9 +448,6 @@ static int ov7670_get_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct ov7670_data *data = dev->data;
 
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
 	memcpy(fmt, &data->fmt, sizeof(data->fmt));
 	return 0;
 }

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -82,6 +82,8 @@ void video_buffer_release(struct video_buffer *vbuf)
 	struct mem_block *block = NULL;
 	int i;
 
+	__ASSERT_NO_MSG(vbuf != NULL);
+
 	/* vbuf to block */
 	for (i = 0; i < ARRAY_SIZE(video_block); i++) {
 		if (video_block[i].data == vbuf->buffer) {
@@ -99,6 +101,10 @@ void video_buffer_release(struct video_buffer *vbuf)
 int video_format_caps_index(const struct video_format_cap *fmts, const struct video_format *fmt,
 			    size_t *idx)
 {
+	__ASSERT_NO_MSG(fmts != NULL);
+	__ASSERT_NO_MSG(fmt != NULL);
+	__ASSERT_NO_MSG(idx != NULL);
+
 	for (int i = 0; fmts[i].pixelformat != 0; i++) {
 		if (fmts[i].pixelformat == fmt->pixelformat &&
 		    IN_RANGE(fmt->width, fmts[i].width_min, fmts[i].width_max) &&
@@ -114,6 +120,10 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
 				    const struct video_frmival *desired,
 				    struct video_frmival *match)
 {
+	__ASSERT_NO_MSG(stepwise != NULL);
+	__ASSERT_NO_MSG(desired != NULL);
+	__ASSERT_NO_MSG(match != NULL);
+
 	uint64_t min = stepwise->min.numerator;
 	uint64_t max = stepwise->max.numerator;
 	uint64_t step = stepwise->step.numerator;
@@ -136,6 +146,9 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
 
 void video_closest_frmival(const struct device *dev, struct video_frmival_enum *match)
 {
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(match != NULL);
+
 	struct video_frmival desired = match->discrete;
 	struct video_frmival_enum fie = {.format = match->format};
 	uint64_t best_diff_nsec = INT32_MAX;
@@ -207,6 +220,8 @@ int video_read_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32_
 	uint8_t *data_ptr;
 	int ret;
 
+	__ASSERT_NO_MSG(i2c != NULL);
+	__ASSERT_NO_MSG(reg_data != NULL);
 	__ASSERT(addr_size > 0, "The address must have a address size flag");
 	__ASSERT(data_size > 0, "The address must have a data size flag");
 
@@ -246,6 +261,9 @@ static int video_write_reg_retry(const struct i2c_dt_spec *i2c, uint8_t *buf_w, 
 {
 	int ret;
 
+	__ASSERT_NO_MSG(i2c != NULL);
+	__ASSERT_NO_MSG(buf_w != NULL);
+
 	for (int i = 0;; i++) {
 		ret = i2c_write_dt(i2c, buf_w, size);
 		if (ret == 0) {
@@ -272,6 +290,7 @@ int video_write_cci_reg(const struct i2c_dt_spec *i2c, uint32_t reg_addr, uint32
 	uint8_t *data_ptr;
 	int ret;
 
+	__ASSERT_NO_MSG(i2c != NULL);
 	__ASSERT(addr_size > 0, "The address must have a address size flag");
 	__ASSERT(data_size > 0, "The address must have a data size flag");
 
@@ -326,6 +345,8 @@ int video_write_cci_multiregs(const struct i2c_dt_spec *i2c, const struct video_
 {
 	int ret;
 
+	__ASSERT_NO_MSG(regs != NULL);
+
 	for (int i = 0; i < num_regs; i++) {
 		ret = video_write_cci_reg(i2c, regs[i].addr, regs[i].data);
 		if (ret < 0) {
@@ -341,6 +362,8 @@ int video_write_cci_multiregs8(const struct i2c_dt_spec *i2c, const struct video
 {
 	int ret;
 
+	__ASSERT_NO_MSG(regs != NULL);
+
 	for (int i = 0; i < num_regs; i++) {
 		ret = video_write_cci_reg(i2c, regs[i].addr | VIDEO_REG_ADDR8_DATA8, regs[i].data);
 		if (ret < 0) {
@@ -355,6 +378,8 @@ int video_write_cci_multiregs16(const struct i2c_dt_spec *i2c, const struct vide
 				size_t num_regs)
 {
 	int ret;
+
+	__ASSERT_NO_MSG(regs != NULL);
 
 	for (int i = 0; i < num_regs; i++) {
 		ret = video_write_cci_reg(i2c, regs[i].addr | VIDEO_REG_ADDR16_DATA8, regs[i].data);

--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -120,8 +120,12 @@ int video_init_ctrl(struct video_ctrl *ctrl, const struct device *dev, uint32_t 
 	uint32_t flags;
 	enum video_ctrl_type type;
 	struct video_ctrl *vc;
-	struct video_device *vdev = video_find_vdev(dev);
+	struct video_device *vdev;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(ctrl != NULL);
+
+	vdev = video_find_vdev(dev);
 	if (!vdev) {
 		return -EINVAL;
 	}
@@ -261,6 +265,9 @@ int video_get_ctrl(const struct device *dev, struct video_control *control)
 {
 	struct video_ctrl *ctrl = NULL;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(control != NULL);
+
 	int ret = video_find_ctrl(dev, control->id, &ctrl);
 
 	if (ret) {
@@ -299,11 +306,15 @@ int video_get_ctrl(const struct device *dev, struct video_control *control)
 int video_set_ctrl(const struct device *dev, struct video_control *control)
 {
 	struct video_ctrl *ctrl = NULL;
-	int ret = video_find_ctrl(dev, control->id, &ctrl);
+	int ret;
 	uint8_t i = 0;
 	int32_t val = 0;
 	int64_t val64 = 0;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(control != NULL);
+
+	ret = video_find_ctrl(dev, control->id, &ctrl);
 	if (ret) {
 		return ret;
 	}
@@ -516,6 +527,9 @@ int video_query_ctrl(const struct device *dev, struct video_ctrl_query *cq)
 	struct video_device *vdev;
 	struct video_ctrl *ctrl = NULL;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(cq != NULL);
+
 	if (cq->id & VIDEO_CTRL_FLAG_NEXT_CTRL) {
 		vdev = video_find_vdev(dev);
 		cq->id &= ~VIDEO_CTRL_FLAG_NEXT_CTRL;
@@ -552,7 +566,8 @@ void video_print_ctrl(const struct device *const dev, const struct video_ctrl_qu
 	const char *type = NULL;
 	char typebuf[8];
 
-	__ASSERT(dev && cq, "Invalid arguments");
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(cq != NULL);
 
 	/* Get type of the control */
 	switch (cq->type) {

--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -259,10 +259,6 @@ static int video_esp32_get_fmt(const struct device *dev, struct video_format *fm
 
 	LOG_DBG("Get format");
 
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
-
 	ret = video_get_format(cfg->source_dev, fmt);
 	if (ret) {
 		LOG_ERR("Failed to get format from source");
@@ -279,10 +275,6 @@ static int video_esp32_set_fmt(const struct device *dev, struct video_format *fm
 	const struct video_esp32_config *cfg = dev->config;
 	struct video_esp32_data *data = dev->data;
 	int ret;
-
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
 
 	ret = video_set_format(cfg->source_dev, fmt);
 	if (ret < 0) {

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -176,10 +176,6 @@ static int video_mcux_csi_get_fmt(const struct device *dev, struct video_format 
 {
 	const struct video_mcux_csi_config *config = dev->config;
 
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
-
 	if (config->source_dev && !video_get_format(config->source_dev, fmt)) {
 #if defined(CONFIG_VIDEO_MCUX_MIPI_CSI2RX)
 		video_pix_fmt_convert(fmt, true);

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -130,10 +130,6 @@ static int mipi_csi2rx_get_fmt(const struct device *dev, struct video_format *fm
 {
 	const struct mipi_csi2rx_config *config = dev->config;
 
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
-
 	if (video_get_format(config->sensor_dev, fmt)) {
 		return -EIO;
 	}

--- a/drivers/video/video_mcux_smartdma.c
+++ b/drivers/video/video_mcux_smartdma.c
@@ -220,10 +220,6 @@ static int nxp_video_sdma_set_format(const struct device *dev, struct video_form
 	const struct nxp_video_sdma_config *config = dev->config;
 	int ret;
 
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
-
 	if (!device_is_ready(config->sensor_dev)) {
 		LOG_ERR("Sensor device not ready");
 		return -ENODEV;
@@ -251,10 +247,6 @@ static int nxp_video_sdma_get_format(const struct device *dev, struct video_form
 {
 	const struct nxp_video_sdma_config *config = dev->config;
 	int ret;
-
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
 
 	if (!device_is_ready(config->sensor_dev)) {
 		LOG_ERR("Sensor device not ready");

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -210,10 +210,6 @@ static int video_stm32_dcmi_get_fmt(const struct device *dev, struct video_forma
 	const struct video_stm32_dcmi_config *config = dev->config;
 	int ret;
 
-	if (fmt == NULL) {
-		return -EINVAL;
-	}
-
 	/* Align DCMI format with the one provided by the sensor */
 	ret = video_get_format(config->sensor_dev, fmt);
 	if (ret < 0) {

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -390,10 +390,6 @@ static int video_sw_generator_set_frmival(const struct device *dev, struct video
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	if (frmival->denominator == 0 || frmival->numerator == 0) {
-		return -EINVAL;
-	}
-
 	data->frame_rate = CLAMP(DIV_ROUND_CLOSEST(frmival->denominator, frmival->numerator),
 				 MIN_FRAME_RATE, MAX_FRAME_RATE);
 	frmival->numerator = 1;

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -437,6 +437,10 @@ static inline int video_set_frmival(const struct device *dev, struct video_frmiv
 	__ASSERT_NO_MSG(dev != NULL);
 	__ASSERT_NO_MSG(frmival != NULL);
 
+	if (frmival->numerator == 0 || frmival->denominator == 0) {
+		return -EINVAL;
+	}
+
 	api = (const struct video_driver_api *)dev->api;
 	if (api->set_frmival == NULL) {
 		return -ENOSYS;
@@ -819,6 +823,7 @@ int video_format_caps_index(const struct video_format_cap *fmts, const struct vi
 static inline uint64_t video_frmival_nsec(const struct video_frmival *frmival)
 {
 	__ASSERT_NO_MSG(frmival != NULL);
+	__ASSERT_NO_MSG(frmival->denominator != 0);
 
 	return (uint64_t)NSEC_PER_SEC * frmival->numerator / frmival->denominator;
 }

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -376,8 +376,12 @@ __subsystem struct video_driver_api {
  */
 static inline int video_set_format(const struct device *dev, struct video_format *fmt)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(fmt != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->set_format == NULL) {
 		return -ENOSYS;
 	}
@@ -397,8 +401,12 @@ static inline int video_set_format(const struct device *dev, struct video_format
  */
 static inline int video_get_format(const struct device *dev, struct video_format *fmt)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(fmt != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->get_format == NULL) {
 		return -ENOSYS;
 	}
@@ -424,8 +432,12 @@ static inline int video_get_format(const struct device *dev, struct video_format
  */
 static inline int video_set_frmival(const struct device *dev, struct video_frmival *frmival)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(frmival != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->set_frmival == NULL) {
 		return -ENOSYS;
 	}
@@ -448,8 +460,12 @@ static inline int video_set_frmival(const struct device *dev, struct video_frmiv
  */
 static inline int video_get_frmival(const struct device *dev, struct video_frmival *frmival)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(frmival != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->get_frmival == NULL) {
 		return -ENOSYS;
 	}
@@ -476,8 +492,13 @@ static inline int video_get_frmival(const struct device *dev, struct video_frmiv
  */
 static inline int video_enum_frmival(const struct device *dev, struct video_frmival_enum *fie)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(fie != NULL);
+	__ASSERT_NO_MSG(fie->format != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->enum_frmival == NULL) {
 		return -ENOSYS;
 	}
@@ -502,6 +523,11 @@ static inline int video_enqueue(const struct device *dev, struct video_buffer *b
 {
 	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(buf != NULL);
+	__ASSERT_NO_MSG(buf->buffer != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->enqueue == NULL) {
 		return -ENOSYS;
 	}
@@ -526,8 +552,12 @@ static inline int video_enqueue(const struct device *dev, struct video_buffer *b
 static inline int video_dequeue(const struct device *dev, struct video_buffer **buf,
 				k_timeout_t timeout)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(buf != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->dequeue == NULL) {
 		return -ENOSYS;
 	}
@@ -550,8 +580,11 @@ static inline int video_dequeue(const struct device *dev, struct video_buffer **
  */
 static inline int video_flush(const struct device *dev, bool cancel)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->flush == NULL) {
 		return -ENOSYS;
 	}
@@ -576,8 +609,11 @@ static inline int video_flush(const struct device *dev, bool cancel)
  */
 static inline int video_stream_start(const struct device *dev, enum video_buf_type type)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->set_stream == NULL) {
 		return -ENOSYS;
 	}
@@ -599,9 +635,12 @@ static inline int video_stream_start(const struct device *dev, enum video_buf_ty
  */
 static inline int video_stream_stop(const struct device *dev, enum video_buf_type type)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 	int ret;
 
+	__ASSERT_NO_MSG(dev != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->set_stream == NULL) {
 		return -ENOSYS;
 	}
@@ -622,8 +661,12 @@ static inline int video_stream_stop(const struct device *dev, enum video_buf_typ
  */
 static inline int video_get_caps(const struct device *dev, struct video_caps *caps)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(caps != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->get_caps == NULL) {
 		return -ENOSYS;
 	}
@@ -712,8 +755,12 @@ void video_print_ctrl(const struct device *const dev, const struct video_ctrl_qu
  */
 static inline int video_set_signal(const struct device *dev, struct k_poll_signal *sig)
 {
-	const struct video_driver_api *api = (const struct video_driver_api *)dev->api;
+	const struct video_driver_api *api;
 
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG(sig != NULL);
+
+	api = (const struct video_driver_api *)dev->api;
 	if (api->set_signal == NULL) {
 		return -ENOSYS;
 	}
@@ -771,6 +818,8 @@ int video_format_caps_index(const struct video_format_cap *fmts, const struct vi
  */
 static inline uint64_t video_frmival_nsec(const struct video_frmival *frmival)
 {
+	__ASSERT_NO_MSG(frmival != NULL);
+
 	return (uint64_t)NSEC_PER_SEC * frmival->numerator / frmival->denominator;
 }
 


### PR DESCRIPTION
Over the video api function, some functions perform some pointer validation, via if statements or via __ASSERT while some other don't.
Some drivers also performs some pointers validity check (mostly on fmt pointers) while other don't.

In order to try to have something similar for all and avoid drivers having to think about wherher pointer checking is necessary or not, perform those checks within all API functions. Within api ops, drivers can now consider that all pointers are valid.