### PR TITLE
Configure the pins for RW612 for Sleep mode 

### DIFF
--- a/boards/nxp/frdm_rw612/init.c
+++ b/boards/nxp/frdm_rw612/init.c
@@ -6,6 +6,17 @@
 #include <zephyr/pm/pm.h>
 #include <fsl_power.h>
 #include <fsl_common.h>
+#include <fsl_io_mux.h>
+
+#define NON_AON_PINS_START	0
+#define NON_AON_PINS_BREAK	21
+#define NON_AON_PINS_RESTART	28
+#define NON_AON_PINS_END	63
+#define RF_CNTL_PINS_START	0
+#define RF_CNTL_PINS_END	3
+#define LED_BLUE_GPIO		0
+#define LED_RED_GPIO		1
+#define LED_GREEN_GPIO		12
 
 static void frdm_rw612_power_init_config(void)
 {
@@ -42,6 +53,26 @@ void board_early_init_hook(void)
 	};
 
 	pm_notifier_register(&frdm_rw612_pm_notifier);
+
+	int32_t i;
+
+	/* Set all non-AON pins output low level in sleep mode. */
+	for (i = NON_AON_PINS_START; i <= NON_AON_PINS_BREAK; i++) {
+		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
+	for (i = NON_AON_PINS_RESTART; i <= NON_AON_PINS_END; i++) {
+		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
+
+	/* Set the LED GPIO output pins to be High in PM3 as these pins are Active Low */
+	IO_MUX_SetPinOutLevelInSleep(LED_BLUE_GPIO, IO_MUX_SleepPinLevelHigh);
+	IO_MUX_SetPinOutLevelInSleep(LED_RED_GPIO, IO_MUX_SleepPinLevelHigh);
+	IO_MUX_SetPinOutLevelInSleep(LED_GREEN_GPIO, IO_MUX_SleepPinLevelHigh);
+
+	/* Set RF_CNTL 0-3 output low level in sleep mode. */
+	for (i = RF_CNTL_PINS_START; i <= RF_CNTL_PINS_END; i++) {
+		IO_MUX_SetRfPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
 #endif
 
 #ifdef CONFIG_I2S_TEST_SEPARATE_DEVICES

--- a/boards/nxp/rd_rw612_bga/init.c
+++ b/boards/nxp/rd_rw612_bga/init.c
@@ -6,6 +6,14 @@
 #include <zephyr/pm/pm.h>
 #include <fsl_power.h>
 #include <fsl_common.h>
+#include <fsl_io_mux.h>
+
+#define NON_AON_PINS_START      0
+#define NON_AON_PINS_BREAK      21
+#define NON_AON_PINS_RESTART    28
+#define NON_AON_PINS_END        63
+#define RF_CNTL_PINS_START      0
+#define RF_CNTL_PINS_END        3
 
 static void rdrw61x_power_init_config(void)
 {
@@ -42,6 +50,21 @@ void board_early_init_hook(void)
 	};
 
 	pm_notifier_register(&rdrw61x_pm_notifier);
+
+	int32_t i;
+
+	/* Set all non-AON pins output low level in sleep mode. */
+	for (i = NON_AON_PINS_START; i <= NON_AON_PINS_BREAK; i++) {
+		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
+	for (i = NON_AON_PINS_RESTART; i <= NON_AON_PINS_END; i++) {
+		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
+
+	/* Set RF_CNTL 0-3 output low level in sleep mode. */
+	for (i = RF_CNTL_PINS_START; i <= RF_CNTL_PINS_END; i++) {
+		IO_MUX_SetRfPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
 #endif
 
 #ifdef CONFIG_I2S_TEST_SEPARATE_DEVICES

--- a/drivers/pinctrl/pinctrl_mci_io_mux.c
+++ b/drivers/pinctrl/pinctrl_mci_io_mux.c
@@ -59,13 +59,6 @@ static void configure_pin_props(uint32_t pin_mux, uint8_t gpio_idx)
 	/* Set slew rate */
 	set = IOMUX_PAD_GET_SLEW(pin_mux) << ((gpio_idx & 0xF) << 1);
 	*slew_reg = (*slew_reg & ~mask) | set;
-
-	/* Set sleep force enable bit */
-	mask = (0x1 << (gpio_idx & 0x1F));
-	set = (IOMUX_PAD_GET_SLEEP_FORCE_EN(pin_mux) << (gpio_idx & 0x1F));
-	*sleep_force_en = (*sleep_force_en & ~mask) | set;
-	set = (IOMUX_PAD_GET_SLEEP_FORCE_VAL(pin_mux) << (gpio_idx & 0x1F));
-	*sleep_force_val = (*sleep_force_val & ~mask) | set;
 }
 
 static void select_gpio_mode(uint8_t gpio_idx)


### PR DESCRIPTION
Configure the pins for RW612 boards for PM Mode 3.
