### PR TITLE
drivers: flash: mcux: fix read for LPC55XXX

### DIFF
--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -238,8 +238,8 @@ static int flash_mcux_read(const struct device *dev, off_t offset,
 	 * on erased or otherwise unreadable pages. Emulate erased pages,
 	 * return other errors.
 	 */
-  #ifdef CONFIG_SOC_LPC55S36
-	/* On LPC55S36, use a HAL function to safely copy from Flash. */
+  #ifdef CONFIG_SOC_SERIES_LPC55XXX
+	/* On LPC55XXX, use a HAL function to safely copy from Flash. */
 	rc = FLASH_Read(&priv->config, addr, data, len);
 	switch (rc) {
 	case kStatus_FLASH_Success:
@@ -262,7 +262,7 @@ static int flash_mcux_read(const struct device *dev, off_t offset,
 		rc = -EIO;
 		break;
 	}
-  #else /* CONFIG_SOC_LPC55S36 */
+  #else /* CONFIG_SOC_SERIES_LPC55XXX */
 	/* On all other targets, check if the Flash area is readable.
 	 * If so, copy data from it directly.
 	 */
@@ -270,7 +270,7 @@ static int flash_mcux_read(const struct device *dev, off_t offset,
 	if (!rc) {
 		memcpy(data, (void *) addr, len);
 	}
-  #endif /* CONFIG_SOC_LPC55S36 */
+  #endif /* CONFIG_SOC_SERIES_LPC55XXX */
 
 	if (rc == -ENODATA) {
 		/* Erased area, return dummy data as an erased page. */


### PR DESCRIPTION
The soc_flash_mcux.c driver only invokes the HAL function for a flash read when CONFIG_SOC_LPC55S36 is defined. When using another chip in the series (LPC55S16 in my case) the FLASH_Read() call was not being used. This causes the flash driver to trigger a hard fault if the target flash area is uninitialized.

This change broadens the guard to instead use CONFIG_SOC_SERIES_LPC55XXX. This is one symbolic level up from (and is selected by) SOC_LPC55S36 as well as the other SOCs in that series which uses this driver.

The Kconfig for the symbol is here:
https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/nxp/lpc/lpc55xxx/Kconfig.soc#L4
