### PR TITLE
doc: posix: fix mutual dependency digraph

### DIFF
--- a/doc/services/portability/posix/implementation/index.rst
+++ b/doc/services/portability/posix/implementation/index.rst
@@ -67,7 +67,6 @@ Some general design considerations:
        libzfoo [fillcolor="#dae8fc"];
        libcommon [fillcolor="#f8cecc"];
 
-       libposix -> libzfoo;
        libposix -> libcommon;
        libzfoo -> libcommon;
    }


### PR DESCRIPTION
Fix the second directed graph where it shows how to break up a dependency cycle.

[Doc Preview](https://builds.zephyrproject.io/zephyr/pr/89624/docs/services/portability/posix/implementation/index.html#id1)