### PR TITLE
drivers: wifi: nxp: fix include guard typo, reduce compilation condition

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1207,12 +1207,10 @@ static int nxp_wifi_status(const struct device *dev, struct wifi_iface_status *s
 
 			if (if_handle->state.interface == WLAN_BSS_TYPE_STA) {
 				status->iface_mode = WIFI_MODE_INFRA;
-			}
-#ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
-			else if (if_handle->state.interface == WLAN_BSS_TYPE_UAP) {
+			} else if (IS_ENABLED(CONFIG_NXP_WIFI_SOFTAP_SUPPORT) &&
+				   (if_handle->state.interface == WLAN_BSS_TYPE_UAP)) {
 				status->iface_mode = WIFI_MODE_AP;
 			}
-#endif
 
 #ifdef CONFIG_NXP_WIFI_11AX
 			if (nxp_wlan_network.dot11ax) {
@@ -1267,12 +1265,11 @@ static int nxp_wifi_get_detail_stats(int bss_type, wlan_pkt_stats_t *stats)
 
 	if (bss_type == WLAN_BSS_TYPE_STA) {
 		ret = wlan_get_log(stats);
-	}
-#ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
-	else if (bss_type == WLAN_BSS_TYPE_UAP) {
+	} else if (IS_ENABLED(CONFIG_NXP_WIFI_SOFTAP_SUPPORT) &&
+		   (bss_type == WLAN_BSS_TYPE_UAP)) {
 		ret = wlan_uap_get_log(stats);
 	}
-#endif
+
 	return ret;
 }
 #endif
@@ -2008,13 +2005,12 @@ static int nxp_wifi_set_config(const struct device *dev, enum ethernet_config_ty
 				LOG_ERR("Failed to set Wi-Fi MAC Address");
 				return -ENOEXEC;
 			}
-#ifdef CONFIG_NXP_WIFI_SOFTAP_SUPPORT
-		} else if (if_handle->state.interface == WLAN_BSS_TYPE_UAP) {
+		} else if (IS_ENABLED(CONFIG_NXP_WIFI_SOFTAP_SUPPORT) &&
+			   (if_handle->state.interface == WLAN_BSS_TYPE_UAP)) {
 			if (wlan_set_uap_mac_addr(if_handle->mac_address)) {
 				LOG_ERR("Failed to set Wi-Fi MAC Address");
 				return -ENOEXEC;
 			}
-#endif
 		} else {
 			LOG_ERR("Invalid Interface index");
 			return -ENOEXEC;

--- a/drivers/wifi/nxp/nxp_wifi_drv.h
+++ b/drivers/wifi/nxp/nxp_wifi_drv.h
@@ -7,7 +7,7 @@
  * Wi-Fi L2 layer
  */
 
-#ifndef ZEPHYR_DRIVERS_WIFI_NNP_WIFI_DRV_H_
+#ifndef ZEPHYR_DRIVERS_WIFI_NXP_WIFI_DRV_H_
 #define ZEPHYR_DRIVERS_WIFI_NXP_WIFI_DRV_H_
 
 #include <zephyr/kernel.h>
@@ -83,4 +83,4 @@ void nxp_wifi_shell_register(struct nxp_wifi_dev *dev);
 #define nxp_wifi_shell_register(dev)
 #endif
 
-#endif
+#endif /* ZEPHYR_DRIVERS_WIFI_NXP_WIFI_DRV_H_ */


### PR DESCRIPTION
This PR contains ~3~ 2 commits which address the following:
- Fix include guard typo in `nxp_wifi_drv.h`
- ~~Simplify net_if_set_name calling logic~~
- Replaced conditional compilation of `CONFIG_NXP_WIFI_SOFTAP_SUPPORT` where applicable with `IS_ENABLED()`

Better to skip the second commit—it might cause more trouble than it’s worth.