### PR TITLE
drivers: disk: nvme: fix include guard typo

### DIFF
--- a/drivers/disk/nvme/nvme.h
+++ b/drivers/disk/nvme/nvme.h
@@ -6,7 +6,7 @@
  * with contributions from Alexander Motin and Wojciech Macek
  */
 
-#ifndef ZEPHYR_DRIVERS_DISK_NVME_NHME_H_
+#ifndef ZEPHYR_DRIVERS_DISK_NVME_NVME_H_
 #define ZEPHYR_DRIVERS_DISK_NVME_NVME_H_
 
 #include "nvme_helpers.h"
@@ -476,4 +476,4 @@ static inline void nvme_unlock(const struct device *dev)
 	k_mutex_unlock(&nvme_ctrlr->lock);
 }
 
-#endif /* ZEPHYR_DRIVERS_DISK_NVME_NHME_H_ */
+#endif /* ZEPHYR_DRIVERS_DISK_NVME_NVME_H_ */

--- a/drivers/disk/nvme/nvme_helpers.h
+++ b/drivers/disk/nvme/nvme_helpers.h
@@ -3,8 +3,8 @@
  * Copyright (c) 2022 Intel Corp.
  */
 
-#ifndef ZEPHYR_DRIVERS_DISK_NVME_NHME_HELPERS_H_
-#define ZEPHYR_DRIVERS_DISK_NVME_NHME_HELPERS_H_
+#ifndef ZEPHYR_DRIVERS_DISK_NVME_NVME_HELPERS_H_
+#define ZEPHYR_DRIVERS_DISK_NVME_NVME_HELPERS_H_
 
 #define NVME_GONE		0xfffffffful
 
@@ -516,4 +516,4 @@ enum shst_value {
 
 #define NVME_IS_BUFFER_DWORD_ALIGNED(_buf_addr) (!((uintptr_t)_buf_addr & 0x3))
 
-#endif /* ZEPHYR_DRIVERS_DISK_NVME_NHME_HELPERS_H_ */
+#endif /* ZEPHYR_DRIVERS_DISK_NVME_NVME_HELPERS_H_ */


### PR DESCRIPTION
Fix include guard name typo in `nvme.h` and `nvme_helpers.h`.