### PR TITLE
tests: Bluetooth: Audio: Add common start_broadcast_adv

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_initiator_broadcast_test.c
@@ -248,25 +248,6 @@ static void setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 	}
 }
 
-static void start_extended_adv(struct bt_le_ext_adv *adv)
-{
-	int err;
-
-	/* Start extended advertising */
-	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err) {
-		FAIL("Failed to start extended advertising: %d\n", err);
-		return;
-	}
-
-	/* Enable Periodic Advertising */
-	err = bt_le_per_adv_start(adv);
-	if (err) {
-		FAIL("Failed to enable periodic advertising: %d\n", err);
-		return;
-	}
-}
-
 static void stop_and_delete_extended_adv(struct bt_le_ext_adv *adv)
 {
 	int err;
@@ -662,7 +643,7 @@ static void test_main_cap_initiator_broadcast(void)
 
 	setup_extended_adv_data(broadcast_source, adv);
 
-	start_extended_adv(adv);
+	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
@@ -708,7 +689,7 @@ static void test_main_cap_initiator_broadcast_inval(void)
 
 	setup_extended_adv_data(broadcast_source, adv);
 
-	start_extended_adv(adv);
+	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
@@ -754,7 +735,7 @@ static void test_main_cap_initiator_broadcast_update(void)
 
 	setup_extended_adv_data(broadcast_source, adv);
 
-	start_extended_adv(adv);
+	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");
@@ -848,7 +829,7 @@ static int test_cap_initiator_ac(const struct cap_initiator_ac_param *param)
 
 	test_broadcast_audio_start(broadcast_source, adv);
 	setup_extended_adv_data(broadcast_source, adv);
-	start_extended_adv(adv);
+	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");

--- a/tests/bsim/bluetooth/audio/src/common.c
+++ b/tests/bsim/bluetooth/audio/src/common.c
@@ -247,6 +247,45 @@ void setup_broadcast_adv(struct bt_le_ext_adv **adv)
 	}
 }
 
+void start_broadcast_adv(struct bt_le_ext_adv *adv)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+	struct bt_le_ext_adv_info info;
+	int err;
+
+	err = bt_le_ext_adv_get_info(adv, &info);
+	if (err != 0) {
+		FAIL("Failed to get adv info: %d\n", err);
+		return;
+	}
+
+	if (info.per_adv_state == BT_LE_PER_ADV_STATE_NONE) {
+		FAIL("Cannot start periodic advertising for non-periodic advertising set");
+		return;
+	}
+
+	if (info.ext_adv_state == BT_LE_EXT_ADV_STATE_DISABLED) {
+		/* Start extended advertising */
+		err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
+		if (err != 0) {
+			FAIL("Failed to start extended advertising: %d\n", err);
+			return;
+		}
+	}
+
+	if (info.per_adv_state == BT_LE_PER_ADV_STATE_DISABLED) {
+		/* Enable Periodic Advertising */
+		err = bt_le_per_adv_start(adv);
+		if (err != 0) {
+			FAIL("Failed to enable periodic advertising: %d\n", err);
+			return;
+		}
+	}
+
+	bt_addr_le_to_str(info.addr, addr_str, sizeof(addr_str));
+	printk("Started advertising with addr %s\n", addr_str);
+}
+
 void test_tick(bs_time_t HW_device_time)
 {
 	if (bst_result != Passed) {

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -147,6 +147,7 @@ extern uint8_t csip_rsi[BT_CSIP_RSI_SIZE];
 void disconnected(struct bt_conn *conn, uint8_t reason);
 void setup_connectable_adv(struct bt_le_ext_adv **ext_adv);
 void setup_broadcast_adv(struct bt_le_ext_adv **adv);
+void start_broadcast_adv(struct bt_le_ext_adv *adv);
 void test_tick(bs_time_t HW_device_time);
 void test_init(void);
 uint16_t get_dev_cnt(void);

--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -1066,25 +1066,6 @@ static void setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 	}
 }
 
-static void start_extended_adv(struct bt_le_ext_adv *adv)
-{
-	int err;
-
-	/* Start extended advertising */
-	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err) {
-		FAIL("Failed to start extended advertising: %d\n", err);
-		return;
-	}
-
-	/* Enable Periodic Advertising */
-	err = bt_le_per_adv_start(adv);
-	if (err) {
-		FAIL("Failed to enable periodic advertising: %d\n", err);
-		return;
-	}
-}
-
 static void stop_and_delete_extended_adv(struct bt_le_ext_adv *adv)
 {
 	int err;
@@ -1222,7 +1203,7 @@ static int test_gmap_ugg_broadcast_ac(const struct gmap_broadcast_ac_param *para
 
 	broadcast_audio_start(broadcast_source, adv);
 	setup_extended_adv_data(broadcast_source, adv);
-	start_extended_adv(adv);
+	start_broadcast_adv(adv);
 
 	/* Wait for all to be started */
 	printk("Waiting for broadcast_streams to be started\n");

--- a/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
+++ b/tests/bsim/bluetooth/audio/src/pbp_public_broadcast_source_test.c
@@ -175,29 +175,6 @@ static int setup_extended_adv_data(struct bt_cap_broadcast_source *source,
 	return 0;
 }
 
-static int start_extended_adv(struct bt_le_ext_adv *adv)
-{
-	int err;
-
-	/* Start extended advertising */
-	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err) {
-		printk("Failed to start extended advertising: %d\n", err);
-
-		return err;
-	}
-
-	/* Enable Periodic Advertising */
-	err = bt_le_per_adv_start(adv);
-	if (err) {
-		printk("Failed to enable periodic advertising: %d\n", err);
-
-		return err;
-	}
-
-	return 0;
-}
-
 static int stop_extended_adv(struct bt_le_ext_adv *adv)
 {
 	int err;
@@ -289,11 +266,7 @@ static void test_main(void)
 			FAIL("Public Broadcast source failed\n");
 		}
 
-		err = start_extended_adv(adv);
-		if (err != 0) {
-			printk("Unable to start extended advertiser: %d\n", err);
-			FAIL("Public Broadcast source failed\n");
-		}
+		start_broadcast_adv(adv);
 
 		k_sem_take(&sem_started, SEM_TIMEOUT);
 


### PR DESCRIPTION
Add a common function, start_broadcast_adv, to start
broadcast advertisement in the LE Audio BSIM tests.