### PR TITLE
tests: Bluetooth: Audio: Add common TEST_SAMPLE_SIRK

### DIFF
--- a/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_acceptor_test.c
@@ -680,8 +680,7 @@ static void init(void)
 		.rank = 1,
 		.lockable = true,
 		/* Using the CSIP_SET_MEMBER test sample SIRK */
-		.sirk = { 0xcd, 0xcc, 0x72, 0xdd, 0x86, 0x8c, 0xcd, 0xce,
-			  0x22, 0xfd, 0xa1, 0x21, 0x09, 0x7d, 0x7d, 0x45 },
+		.sirk = TEST_SAMPLE_SIRK,
 	};
 	static const struct bt_audio_codec_cap codec_cap = BT_AUDIO_CODEC_CAP_LC3(
 		BT_AUDIO_CODEC_CAP_FREQ_ANY, BT_AUDIO_CODEC_CAP_DURATION_ANY,

--- a/tests/bsim/bluetooth/audio/src/common.h
+++ b/tests/bsim/bluetooth/audio/src/common.h
@@ -72,6 +72,13 @@ static const uint8_t mock_iso_data[] = {
 	0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff,
 };
 
+/* The sample SIRK as defined by the CSIS spec Appendix A.1.
+ * Sample data is Big Endian, so we reverse it for little-endian
+ */
+#define TEST_SAMPLE_SIRK                                                                           \
+	{REVERSE_ARGS(0x45, 0x7d, 0x7d, 0x09, 0x21, 0xa1, 0xfd, 0x22, 0xce, 0xcd, 0x8c, 0x86,      \
+		      0xdd, 0x72, 0xcc, 0xcd)}
+
 #define MIN_SEND_COUNT 100
 #define WAIT_SECONDS   100                           /* seconds */
 #define WAIT_TIME (WAIT_SECONDS * USEC_PER_SEC) /* microseconds*/

--- a/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
+++ b/tests/bsim/bluetooth/audio/src/csip_set_member_test.c
@@ -26,8 +26,7 @@ static uint8_t sirk_read_req_rsp = BT_CSIP_READ_SIRK_REQ_RSP_ACCEPT;
 struct bt_csip_set_member_register_param param = {
 	.lockable = true,
 	/* Using the CSIS test sample SIRK */
-	.sirk = {0xcd, 0xcc, 0x72, 0xdd, 0x86, 0x8c, 0xcd, 0xce, 0x22, 0xfd, 0xa1, 0x21, 0x09, 0x7d,
-		 0x7d, 0x45},
+	.sirk = TEST_SAMPLE_SIRK,
 };
 
 static void csip_lock_changed_cb(struct bt_conn *conn,

--- a/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugt_test.c
@@ -455,8 +455,7 @@ static void test_main(void)
 			.rank = csis_rank,
 			.lockable = true,
 			/* Using the CSIP_SET_MEMBER test sample SIRK */
-			.sirk = { 0xcd, 0xcc, 0x72, 0xdd, 0x86, 0x8c, 0xcd, 0xce,
-				  0x22, 0xfd, 0xa1, 0x21, 0x09, 0x7d, 0x7d, 0x45 },
+			.sirk = TEST_SAMPLE_SIRK,
 		};
 
 		err = bt_cap_acceptor_register(&csip_set_member_param, &csip_set_member);


### PR DESCRIPTION
Add a common definition of the TEST_SAMPLE_SIRK used by the BSIM tests.