### PR TITLE
drivers: wch: fix the ch32vfun.h path after the recent HAL update

### DIFF
--- a/boards/wch/ch32v003f4p6_dev_board/board.c
+++ b/boards/wch/ch32v003f4p6_dev_board/board.c
@@ -7,7 +7,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
-#include <ch32fun.h>
+#include <hal_ch32fun.h>
 
 #define AFIO_SWCFG_MASK    0x07000000
 #define AFIO_SWCFG_SWD_OFF 0x04000000

--- a/drivers/dma/dma_wch.c
+++ b/drivers/dma/dma_wch.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/clock_control.h>
 
-#include <ch32fun.h>
+#include <hal_ch32fun.h>
 
 #define DMA_WCH_MAX_CHAN      11
 #define DMA_WCH_MAX_CHAN_BASE 8

--- a/drivers/i2c/i2c_wch.c
+++ b/drivers/i2c/i2c_wch.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(i2c_wch);
 
 #include "i2c-priv.h"
 
-#include <ch32fun.h>
+#include <hal_ch32fun.h>
 
 typedef void (*irq_config_func_t)(const struct device *port);
 

--- a/drivers/pinctrl/pinctrl_wch_00x_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_00x_afio.c
@@ -10,7 +10,7 @@
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/dt-bindings/pinctrl/ch32v00x-pinctrl.h>
 
-#include <ch32fun.h>
+#include <hal_ch32fun.h>
 
 static GPIO_TypeDef *const wch_afio_pinctrl_regs[] = {
 	(GPIO_TypeDef *)DT_REG_ADDR(DT_NODELABEL(gpioa)),

--- a/drivers/pwm/pwm_wch_gptm.c
+++ b/drivers/pwm/pwm_wch_gptm.c
@@ -11,7 +11,7 @@
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
-#include <ch32fun.h>
+#include <hal_ch32fun.h>
 
 /* Each of the 4 channels uses 1 byte of CHCTLR{1,2} */
 #define CHCTLR_CHANNEL_MASK    0xFF

--- a/drivers/watchdog/wdt_iwdg_wch.c
+++ b/drivers/watchdog/wdt_iwdg_wch.c
@@ -11,7 +11,7 @@
 #include <zephyr/sys_clock.h>
 #include <errno.h>
 
-#include <ch32fun.h>
+#include <hal_ch32fun.h>
 
 static int iwdg_wch_setup(const struct device *dev, uint8_t options)
 {


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/87125 renamed the `ch32vfun.h` header but missed some of the drivers. Fix.

Fixes #90450 