### PR TITLE
drivers: pwm: fix an off-by-one error in the CH32V PWM driver

### DIFF
--- a/drivers/pwm/pwm_wch_gptm.c
+++ b/drivers/pwm/pwm_wch_gptm.c
@@ -80,7 +80,11 @@ static int pwm_wch_gptm_set_cycles(const struct device *dev, uint32_t channel,
 	}
 
 	if (period_cycles != 0) {
-		regs->ATRLR = period_cycles;
+		/*
+		 * Note that the period is ATRLR+1. The earlier checks handle the case where
+		 * pulse_cycles is zero or equal to period_cycles.
+		 */
+		regs->ATRLR = period_cycles - 1;
 	}
 
 	/* Set the polarity and enable */


### PR DESCRIPTION
The period is the reload register plus 1. Adjust. Note that the earlier code handles the cases where the pulse time is zero or equal to the period.

See the stm32 driver for similar code: https://github.com/zephyrproject-rtos/zephyr/blob/64ac57abcb90cebdc3e9ed8ea07784134a19a242/drivers/pwm/pwm_stm32.c#L378