### PR TITLE
samples: bluetooth: fix no ble advertising after disconnecting

### DIFF
--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -254,6 +254,14 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected, reason 0x%02x %s\n", reason, bt_hci_err_to_str(reason));
 }
 
+static void recycled(void) {
+	printk("connection recycled. Restart advertising a connection");
+	const int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	if (err) {
+		printk("Advertising failed to start (err %d)\n", err);
+	}
+}
+
 static void alert_stop(void)
 {
 	printk("Alert stopped\n");
@@ -272,6 +280,7 @@ static void alert_high_start(void)
 BT_CONN_CB_DEFINE(conn_callbacks) = {
 	.connected = connected,
 	.disconnected = disconnected,
+	.recycled = recycled,
 };
 
 BT_IAS_CB_DEFINE(ias_callbacks) = {

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -27,38 +27,35 @@
 #include <zephyr/bluetooth/services/ias.h>
 
 /* Custom Service Variables */
-#define BT_UUID_CUSTOM_SERVICE_VAL \
+#define BT_UUID_CUSTOM_SERVICE_VAL                                                                 \
 	BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef0)
 
-static const struct bt_uuid_128 vnd_uuid = BT_UUID_INIT_128(
-	BT_UUID_CUSTOM_SERVICE_VAL);
+static const struct bt_uuid_128 vnd_uuid = BT_UUID_INIT_128(BT_UUID_CUSTOM_SERVICE_VAL);
 
-static const struct bt_uuid_128 vnd_enc_uuid = BT_UUID_INIT_128(
-	BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef1));
+static const struct bt_uuid_128 vnd_enc_uuid =
+	BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef1));
 
-static const struct bt_uuid_128 vnd_auth_uuid = BT_UUID_INIT_128(
-	BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef2));
+static const struct bt_uuid_128 vnd_auth_uuid =
+	BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef2));
 
-#define VND_MAX_LEN 20
+#define VND_MAX_LEN                 20
 #define BT_HR_HEARTRATE_DEFAULT_MIN 90U
 #define BT_HR_HEARTRATE_DEFAULT_MAX 160U
 
-static uint8_t vnd_value[VND_MAX_LEN + 1] = { 'V', 'e', 'n', 'd', 'o', 'r'};
-static uint8_t vnd_auth_value[VND_MAX_LEN + 1] = { 'V', 'e', 'n', 'd', 'o', 'r'};
-static uint8_t vnd_wwr_value[VND_MAX_LEN + 1] = { 'V', 'e', 'n', 'd', 'o', 'r' };
+static uint8_t vnd_value[VND_MAX_LEN + 1] = {'V', 'e', 'n', 'd', 'o', 'r'};
+static uint8_t vnd_auth_value[VND_MAX_LEN + 1] = {'V', 'e', 'n', 'd', 'o', 'r'};
+static uint8_t vnd_wwr_value[VND_MAX_LEN + 1] = {'V', 'e', 'n', 'd', 'o', 'r'};
 
-static ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			void *buf, uint16_t len, uint16_t offset)
+static ssize_t read_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-				 strlen(value));
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, value, strlen(value));
 }
 
-static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			 const void *buf, uint16_t len, uint16_t offset,
-			 uint8_t flags)
+static ssize_t write_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
+			 uint16_t len, uint16_t offset, uint8_t flags)
 {
 	uint8_t *value = attr->user_data;
 
@@ -81,8 +78,7 @@ static void vnd_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 	simulate_vnd = (value == BT_GATT_CCC_INDICATE) ? 1 : 0;
 }
 
-static void indicate_cb(struct bt_conn *conn,
-			struct bt_gatt_indicate_params *params, uint8_t err)
+static void indicate_cb(struct bt_conn *conn, struct bt_gatt_indicate_params *params, uint8_t err)
 {
 	printk("Indication %s\n", err != 0U ? "fail" : "success");
 }
@@ -95,17 +91,14 @@ static void indicate_destroy(struct bt_gatt_indicate_params *params)
 
 #define VND_LONG_MAX_LEN 74
 static uint8_t vnd_long_value[VND_LONG_MAX_LEN + 1] = {
-		  'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '1',
-		  'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '2',
-		  'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '3',
-		  'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '4',
-		  'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '5',
-		  'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '6',
-		  '.', ' ' };
+	'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '1', 'V', 'e', 'n',
+	'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '2', 'V', 'e', 'n', 'd', 'o', 'r',
+	' ', 'd', 'a', 't', 'a', '3', 'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a',
+	't', 'a', '4', 'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '5',
+	'V', 'e', 'n', 'd', 'o', 'r', ' ', 'd', 'a', 't', 'a', '6', '.', ' '};
 
-static ssize_t write_long_vnd(struct bt_conn *conn,
-			      const struct bt_gatt_attr *attr, const void *buf,
-			      uint16_t len, uint16_t offset, uint8_t flags)
+static ssize_t write_long_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+			      const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	uint8_t *value = attr->user_data;
 
@@ -123,8 +116,8 @@ static ssize_t write_long_vnd(struct bt_conn *conn,
 	return len;
 }
 
-static const struct bt_uuid_128 vnd_long_uuid = BT_UUID_INIT_128(
-	BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef3));
+static const struct bt_uuid_128 vnd_long_uuid =
+	BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef3));
 
 static struct bt_gatt_cep vnd_long_cep = {
 	.properties = BT_GATT_CEP_RELIABLE_WRITE,
@@ -132,18 +125,16 @@ static struct bt_gatt_cep vnd_long_cep = {
 
 static int signed_value;
 
-static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			   void *buf, uint16_t len, uint16_t offset)
+static ssize_t read_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
+			   uint16_t len, uint16_t offset)
 {
 	const char *value = attr->user_data;
 
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
-				 sizeof(signed_value));
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, value, sizeof(signed_value));
 }
 
-static ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			    const void *buf, uint16_t len, uint16_t offset,
-			    uint8_t flags)
+static ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
+			    uint16_t len, uint16_t offset, uint8_t flags)
 {
 	uint8_t *value = attr->user_data;
 
@@ -156,16 +147,14 @@ static ssize_t write_signed(struct bt_conn *conn, const struct bt_gatt_attr *att
 	return len;
 }
 
-static const struct bt_uuid_128 vnd_signed_uuid = BT_UUID_INIT_128(
-	BT_UUID_128_ENCODE(0x13345678, 0x1234, 0x5678, 0x1334, 0x56789abcdef3));
+static const struct bt_uuid_128 vnd_signed_uuid =
+	BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x13345678, 0x1234, 0x5678, 0x1334, 0x56789abcdef3));
 
-static const struct bt_uuid_128 vnd_write_cmd_uuid = BT_UUID_INIT_128(
-	BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef4));
+static const struct bt_uuid_128 vnd_write_cmd_uuid =
+	BT_UUID_INIT_128(BT_UUID_128_ENCODE(0x12345678, 0x1234, 0x5678, 0x1234, 0x56789abcdef4));
 
-static ssize_t write_without_rsp_vnd(struct bt_conn *conn,
-				     const struct bt_gatt_attr *attr,
-				     const void *buf, uint16_t len, uint16_t offset,
-				     uint8_t flags)
+static ssize_t write_without_rsp_vnd(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+				     const void *buf, uint16_t len, uint16_t offset, uint8_t flags)
 {
 	uint8_t *value = attr->user_data;
 
@@ -187,43 +176,32 @@ static ssize_t write_without_rsp_vnd(struct bt_conn *conn,
 }
 
 /* Vendor Primary Service Declaration */
-BT_GATT_SERVICE_DEFINE(vnd_svc,
-	BT_GATT_PRIMARY_SERVICE(&vnd_uuid),
+BT_GATT_SERVICE_DEFINE(
+	vnd_svc, BT_GATT_PRIMARY_SERVICE(&vnd_uuid),
 	BT_GATT_CHARACTERISTIC(&vnd_enc_uuid.uuid,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE |
-			       BT_GATT_CHRC_INDICATE,
-			       BT_GATT_PERM_READ_ENCRYPT |
-			       BT_GATT_PERM_WRITE_ENCRYPT,
-			       read_vnd, write_vnd, vnd_value),
-	BT_GATT_CCC(vnd_ccc_cfg_changed,
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
-	BT_GATT_CHARACTERISTIC(&vnd_auth_uuid.uuid,
-			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE,
-			       BT_GATT_PERM_READ_AUTHEN |
-			       BT_GATT_PERM_WRITE_AUTHEN,
-			       read_vnd, write_vnd, vnd_auth_value),
-	BT_GATT_CHARACTERISTIC(&vnd_long_uuid.uuid, BT_GATT_CHRC_READ |
-			       BT_GATT_CHRC_WRITE | BT_GATT_CHRC_EXT_PROP,
-			       BT_GATT_PERM_READ | BT_GATT_PERM_WRITE |
-			       BT_GATT_PERM_PREPARE_WRITE,
+			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE | BT_GATT_CHRC_INDICATE,
+			       BT_GATT_PERM_READ_ENCRYPT | BT_GATT_PERM_WRITE_ENCRYPT, read_vnd,
+			       write_vnd, vnd_value),
+	BT_GATT_CCC(vnd_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
+	BT_GATT_CHARACTERISTIC(&vnd_auth_uuid.uuid, BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE,
+			       BT_GATT_PERM_READ_AUTHEN | BT_GATT_PERM_WRITE_AUTHEN, read_vnd,
+			       write_vnd, vnd_auth_value),
+	BT_GATT_CHARACTERISTIC(&vnd_long_uuid.uuid,
+			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE | BT_GATT_CHRC_EXT_PROP,
+			       BT_GATT_PERM_READ | BT_GATT_PERM_WRITE | BT_GATT_PERM_PREPARE_WRITE,
 			       read_vnd, write_long_vnd, &vnd_long_value),
 	BT_GATT_CEP(&vnd_long_cep),
-	BT_GATT_CHARACTERISTIC(&vnd_signed_uuid.uuid, BT_GATT_CHRC_READ |
-			       BT_GATT_CHRC_WRITE | BT_GATT_CHRC_AUTH,
-			       BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
-			       read_signed, write_signed, &signed_value),
-	BT_GATT_CHARACTERISTIC(&vnd_write_cmd_uuid.uuid,
-			       BT_GATT_CHRC_WRITE_WITHOUT_RESP,
-			       BT_GATT_PERM_WRITE, NULL,
-			       write_without_rsp_vnd, &vnd_wwr_value),
-);
+	BT_GATT_CHARACTERISTIC(&vnd_signed_uuid.uuid,
+			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE | BT_GATT_CHRC_AUTH,
+			       BT_GATT_PERM_READ | BT_GATT_PERM_WRITE, read_signed, write_signed,
+			       &signed_value),
+	BT_GATT_CHARACTERISTIC(&vnd_write_cmd_uuid.uuid, BT_GATT_CHRC_WRITE_WITHOUT_RESP,
+			       BT_GATT_PERM_WRITE, NULL, write_without_rsp_vnd, &vnd_wwr_value), );
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
-		      BT_UUID_16_ENCODE(BT_UUID_HRS_VAL),
-		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL),
-		      BT_UUID_16_ENCODE(BT_UUID_CTS_VAL)),
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_HRS_VAL),
+		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL), BT_UUID_16_ENCODE(BT_UUID_CTS_VAL)),
 	BT_DATA_BYTES(BT_DATA_UUID128_ALL, BT_UUID_CUSTOM_SERVICE_VAL),
 };
 
@@ -236,9 +214,7 @@ void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 	printk("Updated MTU: TX: %d RX: %d bytes\n", tx, rx);
 }
 
-static struct bt_gatt_cb gatt_callbacks = {
-	.att_mtu_updated = mtu_updated
-};
+static struct bt_gatt_cb gatt_callbacks = {.att_mtu_updated = mtu_updated};
 
 static void connected(struct bt_conn *conn, uint8_t err)
 {
@@ -254,9 +230,11 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected, reason 0x%02x %s\n", reason, bt_hci_err_to_str(reason));
 }
 
-static void recycled(void) {
+static void recycled(void)
+{
 	printk("connection recycled. Restart advertising a connection");
-	const int err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
+	const int err =
+		bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 	if (err) {
 		printk("Advertising failed to start (err %d)\n", err);
 	}
@@ -441,8 +419,7 @@ int main(void)
 	bt_gatt_cb_register(&gatt_callbacks);
 	bt_conn_auth_cb_register(&auth_cb_display);
 
-	vnd_ind_attr = bt_gatt_find_by_uuid(vnd_svc.attrs, vnd_svc.attr_count,
-					    &vnd_enc_uuid.uuid);
+	vnd_ind_attr = bt_gatt_find_by_uuid(vnd_svc.attrs, vnd_svc.attr_count, &vnd_enc_uuid.uuid);
 	bt_uuid_to_str(&vnd_enc_uuid.uuid, str, sizeof(str));
 	printk("Indicate VND attr %p (UUID %s)\n", vnd_ind_attr, str);
 

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -209,33 +209,33 @@ static const struct bt_data sd[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
 
-void mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
+void mtu_updated_cb(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
 	printk("Updated MTU: TX: %d RX: %d bytes\n", tx, rx);
 }
 
-static struct bt_gatt_cb gatt_callbacks = {.att_mtu_updated = mtu_updated};
+static struct bt_gatt_cb gatt_callbacks = {.att_mtu_updated = mtu_updated_cb, };
 
-static void connected(struct bt_conn *conn, uint8_t err)
+static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
-	if (err) {
+	if (0 != err) {
 		printk("Connection failed, err 0x%02x %s\n", err, bt_hci_err_to_str(err));
 	} else {
 		printk("Connected\n");
 	}
 }
 
-static void disconnected(struct bt_conn *conn, uint8_t reason)
+static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected, reason 0x%02x %s\n", reason, bt_hci_err_to_str(reason));
 }
 
-static void recycled(void)
+static void recycled_cb(void)
 {
 	printk("connection recycled. Restart advertising a connection");
 	const int err =
 		bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
-	if (err) {
+	if (0 != err) {
 		printk("Advertising failed to start (err %d)\n", err);
 	}
 }
@@ -256,9 +256,9 @@ static void alert_high_start(void)
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
-	.recycled = recycled,
+	.connected = connected_cb,
+	.disconnected = disconnected_cb,
+	.recycled = recycled_cb,
 };
 
 BT_IAS_CB_DEFINE(ias_callbacks) = {
@@ -278,7 +278,7 @@ static void bt_ready(void)
 	}
 
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
-	if (err) {
+	if (0 != err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return;
 	}
@@ -407,7 +407,7 @@ int main(void)
 	int err;
 
 	err = bt_enable(NULL);
-	if (err) {
+	if (0 != err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return 0;
 	}

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -33,7 +33,7 @@ static const struct bt_data ad[] = {
 static const struct bt_data sd[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
-
+#else
 static struct bt_le_adv_param adv_param = {
 	.id = BT_ID_DEFAULT,
 	.sid = 0U,

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -33,6 +33,18 @@ static const struct bt_data ad[] = {
 static const struct bt_data sd[] = {
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 };
+
+static struct bt_le_adv_param adv_param = {
+	.id = BT_ID_DEFAULT,
+	.sid = 0U,
+	.secondary_max_skip = 0U,
+	.options = (BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_CODED),
+	.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
+	.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
+	.peer = NULL,
+};
+
+static struct bt_le_ext_adv *adv;
 #endif /* !CONFIG_BT_EXT_ADV */
 
 /* Use atomic variable, 2 bits for connection and disconnection state */
@@ -205,10 +217,9 @@ static int start_adv(void)
 		printk("Advertising failed to start (err %d)\n", err);
 		return 0;
 	}
-
 #else  /* CONFIG_BT_EXT_ADV */
 	printk("Starting Extended Advertising (connectable and non-scannable)\n");
-	err = bt_le_ext_adv_start(ad, BT_LE_EXT_ADV_START_DEFAULT);
+	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
 	if (err) {
 		printk("Failed to start extended advertising set (err %d)\n", err);
 		return 0;
@@ -243,17 +254,6 @@ int main(void)
 	}
 
 #else  /* CONFIG_BT_EXT_ADV */
-	struct bt_le_adv_param adv_param = {
-		.id = BT_ID_DEFAULT,
-		.sid = 0U,
-		.secondary_max_skip = 0U,
-		.options = (BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_CODED),
-		.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
-		.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
-		.peer = NULL,
-	};
-	struct bt_le_ext_adv *adv;
-
 	printk("Creating a Coded PHY connectable non-scannable advertising set\n");
 	err = bt_le_ext_adv_create(&adv_param, NULL, &adv);
 	if (err) {

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -197,6 +197,7 @@ static void blink_stop(void)
 
 static int start_adv(void)
 {
+	int err;
 #if !defined(CONFIG_BT_EXT_ADV)
 	printk("Starting Legacy Advertising (connectable and scannable)\n");
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -22,10 +22,8 @@ static bool hrf_ntf_enabled;
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
-	BT_DATA_BYTES(BT_DATA_UUID16_ALL,
-		      BT_UUID_16_ENCODE(BT_UUID_HRS_VAL),
-		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL),
-		      BT_UUID_16_ENCODE(BT_UUID_DIS_VAL)),
+	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_HRS_VAL),
+		      BT_UUID_16_ENCODE(BT_UUID_BAS_VAL), BT_UUID_16_ENCODE(BT_UUID_DIS_VAL)),
 #if defined(CONFIG_BT_EXT_ADV)
 	BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME, sizeof(CONFIG_BT_DEVICE_NAME) - 1),
 #endif /* CONFIG_BT_EXT_ADV */
@@ -63,7 +61,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	(void)atomic_set_bit(state, STATE_DISCONNECTED);
 }
 
-static void recycled(void) {
+static void recycled(void)
+{
 	printk("connection recycled. Restart advertising a connection");
 	const int err = start_adv();
 	if (err) {
@@ -81,8 +80,7 @@ static void hrs_ntf_changed(bool enabled)
 {
 	hrf_ntf_enabled = enabled;
 
-	printk("HRS notification status changed: %s\n",
-	       enabled ? "enabled" : "disabled");
+	printk("HRS notification status changed: %s\n", enabled ? "enabled" : "disabled");
 }
 
 static struct bt_hrs_cb hrs_cb = {
@@ -136,12 +134,12 @@ static void hrs_notify(void)
 
 #if DT_NODE_HAS_STATUS_OKAY(LED0_NODE)
 #include <zephyr/drivers/gpio.h>
-#define HAS_LED     1
+#define HAS_LED 1
 static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
 #define BLINK_ONOFF K_MSEC(500)
 
 static struct k_work_delayable blink_work;
-static bool                  led_is_on;
+static bool led_is_on;
 
 static void blink_timeout(struct k_work *work)
 {
@@ -197,7 +195,8 @@ static void blink_stop(void)
 #endif /* LED0_NODE */
 #endif /* CONFIG_GPIO */
 
-static int start_adv(void) {
+static int start_adv(void)
+{
 #if !defined(CONFIG_BT_EXT_ADV)
 	printk("Starting Legacy Advertising (connectable and scannable)\n");
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
@@ -206,7 +205,7 @@ static int start_adv(void) {
 		return err;
 	}
 
-#else /* CONFIG_BT_EXT_ADV */
+#else  /* CONFIG_BT_EXT_ADV */
 	struct bt_le_adv_param adv_param = {
 		.id = BT_ID_DEFAULT,
 		.sid = 0U,
@@ -265,7 +264,7 @@ int main(void)
 
 	bt_hrs_cb_register(&hrs_cb);
 
-	err == start_adv();
+	err = start_adv();
 	if (0 == err) {
 		printk("Advertising successfully started\n");
 	} else {
@@ -307,7 +306,7 @@ int main(void)
 				return 0;
 			}
 
-#else /* CONFIG_BT_EXT_ADV */
+#else  /* CONFIG_BT_EXT_ADV */
 			printk("Starting Extended Advertising (connectable and non-scannable)\n");
 			err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
 			if (err) {

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -55,9 +55,9 @@ static ATOMIC_DEFINE(state, 2U);
 
 static int start_adv(void);
 
-static void connected(struct bt_conn *conn, uint8_t err)
+static void connected_cb(struct bt_conn *conn, uint8_t err)
 {
-	if (err) {
+	if (0 != err) {
 		printk("Connection failed, err 0x%02x %s\n", err, bt_hci_err_to_str(err));
 	} else {
 		printk("Connected\n");
@@ -66,26 +66,26 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	}
 }
 
-static void disconnected(struct bt_conn *conn, uint8_t reason)
+static void disconnected_cb(struct bt_conn *conn, uint8_t reason)
 {
 	printk("Disconnected, reason 0x%02x %s\n", reason, bt_hci_err_to_str(reason));
 
 	(void)atomic_set_bit(state, STATE_DISCONNECTED);
 }
 
-static void recycled(void)
+static void recycled_cb(void)
 {
 	printk("connection recycled. Restart advertising a connection");
 	const int err = start_adv();
-	if (err) {
+	if (0 != err) {
 		printk("Advertising failed to start (err %d)\n", err);
 	}
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {
-	.connected = connected,
-	.disconnected = disconnected,
-	.recycled = recycled,
+	.connected = connected_cb,
+	.disconnected = disconnected_cb,
+	.recycled = recycled_cb,
 };
 
 static void hrs_ntf_changed(bool enabled)
@@ -213,16 +213,16 @@ static int start_adv(void)
 #if !defined(CONFIG_BT_EXT_ADV)
 	printk("Starting Legacy Advertising (connectable and scannable)\n");
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
-	if (err) {
+	if (0 != err) {
 		printk("Advertising failed to start (err %d)\n", err);
-		return 0;
+		return err;
 	}
 #else  /* CONFIG_BT_EXT_ADV */
 	printk("Starting Extended Advertising (connectable and non-scannable)\n");
 	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err) {
+	if (0 != err) {
 		printk("Failed to start extended advertising set (err %d)\n", err);
-		return 0;
+		return err;
 	}
 #endif /* CONFIG_BT_EXT_ADV */
 
@@ -248,7 +248,7 @@ int main(void)
 #if !defined(CONFIG_BT_EXT_ADV)
 	printk("Starting Legacy Advertising (connectable and scannable)\n");
 	err = bt_le_adv_start(BT_LE_ADV_CONN_FAST_1, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
-	if (err) {
+	if (0 != err) {
 		printk("Advertising failed to start (err %d)\n", err);
 		return err;
 	}
@@ -256,13 +256,13 @@ int main(void)
 #else  /* CONFIG_BT_EXT_ADV */
 	printk("Creating a Coded PHY connectable non-scannable advertising set\n");
 	err = bt_le_ext_adv_create(&adv_param, NULL, &adv);
-	if (err) {
+	if (0 != err) {
 		printk("Failed to create Coded PHY extended advertising set (err %d)\n", err);
 
 		printk("Creating a non-Coded PHY connectable non-scannable advertising set\n");
 		adv_param.options &= ~BT_LE_ADV_OPT_CODED;
 		err = bt_le_ext_adv_create(&adv_param, NULL, &adv);
-		if (err) {
+		if (0 != err) {
 			printk("Failed to create extended advertising set (err %d)\n", err);
 			return err;
 		}
@@ -270,14 +270,14 @@ int main(void)
 
 	printk("Setting extended advertising data\n");
 	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), NULL, 0);
-	if (err) {
+	if (0 != err) {
 		printk("Failed to set extended advertising data (err %d)\n", err);
 		return err;
 	}
 
 	printk("Starting Extended Advertising (connectable non-scannable)\n");
 	err = bt_le_ext_adv_start(adv, BT_LE_EXT_ADV_START_DEFAULT);
-	if (err) {
+	if (0 != err) {
 		printk("Failed to start extended advertising set (err %d)\n", err);
 		return err;
 	}
@@ -287,7 +287,7 @@ int main(void)
 
 #if defined(HAS_LED)
 	err = blink_setup();
-	if (err) {
+	if (0 != err) {
 		return 0;
 	}
 


### PR DESCRIPTION
Related to #90111

At the ble GATT samples the advertising is not restarted after a disconnect happen. That fix adds that feature at the right place(at the recycle callback).