### PR TITLE
flash: espressif: erase flash region before writing when flash encryption is enabled

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -23,6 +23,7 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
@@ -33,6 +34,16 @@
 LOG_MODULE_REGISTER(flash_esp32, CONFIG_FLASH_LOG_LEVEL);
 
 #define FLASH_SEM_TIMEOUT (k_is_in_isr() ? K_NO_WAIT : K_FOREVER)
+
+#ifdef CONFIG_ESP32_EFUSE_VIRTUAL_KEEP_IN_FLASH
+#define ENCRYPTION_IS_VIRTUAL (!efuse_hal_flash_encryption_enabled())
+#else
+#define ENCRYPTION_IS_VIRTUAL 0
+#endif
+
+#ifndef ALIGN_OFFSET
+#define ALIGN_OFFSET(num, align) ((num) & ((align) - 1))
+#endif
 
 struct flash_esp32_dev_config {
 	spi_dev_t *controller;
@@ -75,6 +86,227 @@ static inline void flash_esp32_sem_give(const struct device *dev)
 #include <zephyr/sys/util.h>
 #include <stdint.h>
 #include <string.h>
+
+#ifndef CONFIG_MCUBOOT
+static int flash_esp32_read_check_enc(off_t address, void *buffer, size_t length)
+{
+	int ret = 0;
+
+	if (esp_flash_encryption_enabled()) {
+		LOG_DBG("Flash read ENCRYPTED - address 0x%lx size 0x%x", address, length);
+		ret = esp_flash_read_encrypted(NULL, address, buffer, length);
+	} else {
+		LOG_DBG("Flash read RAW - address 0x%lx size 0x%x", address, length);
+		ret = esp_flash_read(NULL, buffer, address, length);
+	}
+
+	if (ret != 0) {
+		LOG_ERR("Flash read error: %d", ret);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int flash_esp32_write_check_enc(off_t address, const void *buffer, size_t length)
+{
+	int ret = 0;
+
+	if (esp_flash_encryption_enabled() && !ENCRYPTION_IS_VIRTUAL) {
+		LOG_DBG("Flash write ENCRYPTED - address 0x%lx size 0x%x", address, length);
+		ret = esp_flash_write_encrypted(NULL, address, buffer, length);
+	} else {
+		LOG_DBG("Flash write RAW - address 0x%lx size 0x%x", address, length);
+		ret = esp_flash_write(NULL, buffer, address, length);
+	}
+
+	if (ret != 0) {
+		LOG_ERR("Flash write error: %d", ret);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_ESP_FLASH_ENCRYPTION
+#define FLASH_BUFFER_SIZE 32
+
+static bool aligned_flash_write(size_t dest_addr, const void *src, size_t size, bool erase);
+static bool aligned_flash_erase(size_t addr, size_t size);
+
+/* Auxiliar buffer to store the sector that will be partially written */
+static uint8_t write_aux_buf[FLASH_SECTOR_SIZE] = {0};
+
+/* Auxiliar buffer to store the sector that will be partially erased */
+static uint8_t erase_aux_buf[FLASH_SECTOR_SIZE] = {0};
+
+static bool aligned_flash_write(size_t dest_addr, const void *src, size_t size, bool erase)
+{
+	bool flash_encryption_enabled = esp_flash_encryption_enabled();
+
+	/* When flash encryption is enabled, write alignment is 32 bytes, however to avoid
+	 * inconsistences the region may be erased right before writing, thus the alignment
+	 * is set to the erase required alignment (FLASH_SECTOR_SIZE).
+	 * When flash encryption is not enabled, regular write alignment is 4 bytes.
+	 */
+	size_t alignment = flash_encryption_enabled ? (erase ? FLASH_SECTOR_SIZE : 32) : 4;
+
+	if (IS_ALIGNED(dest_addr, alignment) && IS_ALIGNED((uintptr_t)src, 4) &&
+	    IS_ALIGNED(size, alignment)) {
+		/* A single write operation is enough when all parameters are aligned */
+
+		if (flash_encryption_enabled && erase) {
+			if (esp_flash_erase_region(NULL, dest_addr, size) != ESP_OK) {
+				LOG_ERR("%s: Flash erase failed at 0x%08lx", __func__,
+					(uintptr_t)dest_addr);
+				return false;
+			}
+		}
+		return flash_esp32_write_check_enc(dest_addr, (void *)src, size) == ESP_OK;
+	}
+
+	LOG_DBG("%s: forcing unaligned write dest_addr: 0x%08lx src: 0x%08lx size: 0x%x erase: %c",
+		__func__, (uintptr_t)dest_addr, (uintptr_t)src, size, erase ? 't' : 'f');
+
+	size_t write_addr = dest_addr;
+	size_t bytes_remaining = size;
+	size_t src_offset = 0;
+
+	while (bytes_remaining > 0) {
+		size_t aligned_curr_addr = ROUND_DOWN(write_addr, alignment);
+		size_t curr_buf_off = write_addr - aligned_curr_addr;
+		size_t chunk_len = MIN(bytes_remaining, FLASH_SECTOR_SIZE - curr_buf_off);
+
+		/* Read data before modifying */
+		if (flash_esp32_read_check_enc(aligned_curr_addr, write_aux_buf,
+					       ROUND_UP(chunk_len, alignment)) != ESP_OK) {
+			LOG_ERR("%s: Flash read failed at 0x%08lx", __func__,
+				(uintptr_t)aligned_curr_addr);
+			return false;
+		}
+
+		/* Erase if needed */
+		if (flash_encryption_enabled && erase) {
+			if (esp_flash_erase_region(NULL, aligned_curr_addr,
+						   ROUND_UP(chunk_len, FLASH_SECTOR_SIZE)) !=
+			    ESP_OK) {
+				LOG_ERR("%s: Flash erase failed at 0x%08lx", __func__,
+					(uintptr_t)aligned_curr_addr);
+				return false;
+			}
+		}
+
+		/* Merge data into buffer */
+		memcpy(&write_aux_buf[curr_buf_off], &((const uint8_t *)src)[src_offset],
+		       chunk_len);
+
+		/* Write back aligned chunk */
+		if (flash_esp32_write_check_enc(aligned_curr_addr, write_aux_buf,
+						ROUND_UP(chunk_len, alignment)) != ESP_OK) {
+			LOG_ERR("%s: Flash write failed at 0x%08lx", __func__,
+				(uintptr_t)aligned_curr_addr);
+			return false;
+		}
+
+		write_addr += chunk_len;
+		src_offset += chunk_len;
+		bytes_remaining -= chunk_len;
+	}
+
+	return true;
+}
+
+static bool erase_partial_sector(size_t addr, size_t sector_size, size_t erase_start,
+								 size_t erase_end)
+{
+	/* Read full sector before erasing */
+	if (flash_esp32_read_check_enc(addr, erase_aux_buf, sector_size) != ESP_OK) {
+		LOG_ERR("%s: Flash read failed at 0x%08lx", __func__, (uintptr_t)addr);
+		return false;
+	}
+	/* Erase full sector */
+	if (esp_flash_erase_region(NULL, addr, sector_size) != ESP_OK) {
+		LOG_ERR("%s: Flash erase failed at 0x%08lx", __func__, (uintptr_t)addr);
+		return false;
+	}
+	/* Write back preserved head data up to erase_start */
+	if (erase_start > 0) {
+		if (!aligned_flash_write(addr, erase_aux_buf, erase_start, false)) {
+			LOG_ERR("%s: Flash write failed at 0x%08lx", __func__, (uintptr_t)addr);
+			return false;
+		}
+	}
+	/* Write back preserved tail data from erase_end up to sector end */
+	if (erase_end < sector_size) {
+		if (!aligned_flash_write(addr + erase_end, &erase_aux_buf[erase_end],
+								sector_size - erase_end, false)) {
+			LOG_ERR("%s: Flash write failed at 0x%08lx", __func__,
+					(uintptr_t)(addr + erase_end));
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool aligned_flash_erase(size_t addr, size_t size)
+{
+	if (IS_ALIGNED(addr, FLASH_SECTOR_SIZE) && IS_ALIGNED(size, FLASH_SECTOR_SIZE)) {
+		/* A single erase operation is enough when all parameters are aligned */
+		return esp_flash_erase_region(NULL, addr, size) == ESP_OK;
+	}
+
+	const size_t sector_size = FLASH_SECTOR_SIZE;
+	const size_t start_addr = ROUND_DOWN(addr, sector_size);
+	const size_t end_addr = ROUND_UP(addr + size, sector_size);
+	const size_t total_len = end_addr - start_addr;
+
+	LOG_DBG("%s: forcing unaligned erase on sector Offset: "
+		"0x%08lx Length: 0x%x total_len: 0x%x",
+		__func__, (uintptr_t)addr, (int)size, total_len);
+
+	size_t current_addr = start_addr;
+
+	while (current_addr < end_addr) {
+		bool preserve_head = (addr > current_addr);
+		bool preserve_tail = ((addr + size) < (current_addr + sector_size));
+
+		if (preserve_head || preserve_tail) {
+			size_t erase_start = preserve_head ? (addr - current_addr) : 0;
+			size_t erase_end =
+				MIN(current_addr + sector_size, addr + size) - current_addr;
+
+			LOG_DBG("%s: partial sector erase from: 0x%08lx to: 0x%08lx Length: 0x%x",
+				__func__, (uintptr_t)(current_addr + erase_start),
+				(uintptr_t)(current_addr + erase_end), erase_end - erase_start);
+
+			if (!erase_partial_sector(current_addr, sector_size, erase_start,
+						  erase_end)) {
+				return false;
+			}
+
+			current_addr += sector_size;
+		} else {
+			/* Full sector erase is safe, erase the next consecutive full sectors */
+			size_t contiguous_size =
+				ROUND_DOWN(addr + size, sector_size) - current_addr;
+
+			LOG_DBG("%s: sectors erased from: 0x%08lx length: 0x%x", __func__,
+				(uintptr_t)current_addr, contiguous_size);
+
+			if (esp_flash_erase_region(NULL, current_addr, contiguous_size) != ESP_OK) {
+				LOG_ERR("%s: Flash erase failed at 0x%08lx", __func__,
+					(uintptr_t)current_addr);
+				return false;
+			}
+
+			current_addr += contiguous_size;
+		}
+	}
+
+	return true;
+}
+#endif /* CONFIG_ESP_FLASH_ENCRYPTION */
+#endif /* !CONFIG_MCUBOOT */
 
 #ifdef CONFIG_MCUBOOT
 #define READ_BUFFER_SIZE 32
@@ -143,11 +375,7 @@ static int flash_esp32_read(const struct device *dev, off_t address, void *buffe
 #else
 	flash_esp32_sem_take(dev);
 
-	if (esp_flash_encryption_enabled()) {
-		ret = esp_flash_read_encrypted(NULL, address, buffer, length);
-	} else {
-		ret = esp_flash_read(NULL, buffer, address, length);
-	}
+	ret = flash_esp32_read_check_enc(address, buffer, length);
 
 	flash_esp32_sem_give(dev);
 #endif
@@ -179,11 +407,23 @@ static int flash_esp32_write(const struct device *dev,
 #else
 	flash_esp32_sem_take(dev);
 
+#ifdef CONFIG_ESP_FLASH_ENCRYPTION
+	bool erase = false;
+
 	if (esp_flash_encryption_enabled()) {
-		ret = esp_flash_write_encrypted(NULL, address, buffer, length);
-	} else {
-		ret = esp_flash_write(NULL, buffer, address, length);
+		/* Ensuring flash region has been erased before writing in order to
+		 * avoid inconsistences when hardware flash encryption is enabled.
+		 */
+		erase = true;
 	}
+
+	if (!aligned_flash_write(address, buffer, length, erase)) {
+		LOG_ERR("%s: Flash erase before write failed", __func__);
+		ret = -1;
+	}
+#else
+	ret = flash_esp32_write_check_enc(address, buffer, length);
+#endif
 
 	flash_esp32_sem_give(dev);
 #endif
@@ -204,7 +444,44 @@ static int flash_esp32_erase(const struct device *dev, off_t start, size_t len)
 	ret = esp_rom_flash_erase_range(start, len);
 #else
 	flash_esp32_sem_take(dev);
+
+#ifdef CONFIG_ESP_FLASH_ENCRYPTION
+	if (!aligned_flash_erase(start, len)) {
+		ret = -EIO;
+	}
+
+	if (esp_flash_encryption_enabled()) {
+		uint8_t erased_val_buf[FLASH_BUFFER_SIZE];
+		uint32_t bytes_remaining = len;
+		uint32_t offset = start;
+		uint32_t bytes_written = MIN(sizeof(erased_val_buf), len);
+
+		memset(erased_val_buf,
+			flash_get_parameters(dev)->erase_value, sizeof(erased_val_buf));
+
+		/* When hardware flash encryption is enabled, force expected erased
+		 * value (0xFF) into flash when erasing a region.
+		 *
+		 * This is handled on this implementation because MCUboot's state
+		 * machine relies on erased valued data (0xFF) readed from a
+		 * previously erased region that was not written yet, however when
+		 * hardware flash encryption is enabled, the flash read always
+		 * decrypts whats being read from flash, thus a region that was
+		 * erased would not be read as what MCUboot expected (0xFF).
+		 */
+		while (bytes_remaining != 0) {
+			if (!aligned_flash_write(offset, erased_val_buf, bytes_written, false)) {
+				LOG_ERR("%s: Flash erase failed", __func__);
+				return -1;
+			}
+			offset += bytes_written;
+			bytes_remaining -= bytes_written;
+		}
+	}
+#else
 	ret = esp_flash_erase_region(NULL, start, len);
+#endif
+
 	flash_esp32_sem_give(dev);
 #endif
 	if (ret != 0) {

--- a/soc/espressif/common/Kconfig.flash
+++ b/soc/espressif/common/Kconfig.flash
@@ -126,4 +126,16 @@ config SPI_FLASH_HPM_ENABLE
 	  This option is invisible, and will be selected automatically
 	  when ``ESPTOOLPY_FLASHFREQ_120M`` is selected.
 
+DT_CHOSEN_Z_FLASH := zephyr,flash
+DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
+DT_FLASH_WRITE_BLOCK_SIZE := $(dt_node_int_prop_int,$(DT_CHOSEN_FLASH_NODE),write-block-size)
+config ESP_FLASH_ENCRYPTION
+	bool "Hardware flash encryption compatibility"
+	depends on !ESP_SIMPLE_BOOT && !MCUBOOT && "$(DT_FLASH_WRITE_BLOCK_SIZE)" = 32
+	help
+	  Enable Espressif's hardware flash encryption compatibility with MCUboot
+	  Espressif Port.
+	  The flash encryption configuration must be enabled on the bootloader and
+	  the flash write block size must be set to 32 bytes on Zephyr's device tree.
+
 endif # SOC_FAMILY_ESPRESSIF_ESP32

--- a/soc/espressif/esp32/default.ld
+++ b/soc/espressif/esp32/default.ld
@@ -407,6 +407,8 @@ SECTIONS
     *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_ops.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_qio_mode.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_mmap.*(.literal .text .literal.* .text.*)
 
     /* [mapping:esp_system] */
     *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
@@ -497,7 +499,6 @@ SECTIONS
     *libzephyr.a:flash_partitions.*(.literal .text .literal.* .text.*)
     *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
     *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
 
     *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
@@ -640,6 +641,8 @@ SECTIONS
     *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:flash_qio_mode.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     /* [mapping:esp_mm] */
     *libzephyr.a:esp_cache.*(.rodata .rodata.*)
@@ -709,7 +712,6 @@ SECTIONS
 
     *libzephyr.a:periph_ctrl.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
-    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     . = ALIGN(4);

--- a/soc/espressif/esp32c2/default.ld
+++ b/soc/espressif/esp32c2/default.ld
@@ -270,6 +270,8 @@ SECTIONS
     *libzephyr.a:memspi_host_driver.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_mmap.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
 
     /* [mapping:esp_system] */
     *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
@@ -358,7 +360,6 @@ SECTIONS
     *libzephyr.a:flash_qio_mode.*(.literal .text .literal.* .text.*)
     *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
     *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
 
     *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
@@ -496,6 +497,8 @@ SECTIONS
     *libzephyr.a:flash_brownout_hook.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_qio_mode.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
 
     /* [mapping:esp_mm] */
     *libzephyr.a:esp_cache.*(.rodata .rodata.* .srodata .srodata.*)
@@ -546,14 +549,12 @@ SECTIONS
     *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:clk.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_clk.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops_esp32c2.*(.rodata .rodata.* .srodata .srodata.*)
 
     *libzephyr.a:esp_gpio_reserve.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .srodata .srodata.*)
 
     . = ALIGN(16);

--- a/soc/espressif/esp32c3/default.ld
+++ b/soc/espressif/esp32c3/default.ld
@@ -365,6 +365,8 @@ SECTIONS
     *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_ops.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:flash_mmap.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .literal.* .text .text.*)
 
     /* [mapping:esp_system] */
     *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
@@ -589,6 +591,8 @@ SECTIONS
     *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_qio_mode.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
 
     /* [mapping:esp_mm] */
     *libzephyr.a:esp_cache.*(.rodata .rodata.* .srodata .srodata.*)
@@ -639,13 +643,11 @@ SECTIONS
     *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:clk.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_clk.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .srodata .srodata.*)
 
     *libzephyr.a:esp_gpio_reserve.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .srodata .srodata.*)
 
     . = ALIGN(16);

--- a/soc/espressif/esp32c6/default.ld
+++ b/soc/espressif/esp32c6/default.ld
@@ -380,6 +380,8 @@ SECTIONS
     *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_ops.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_mmap.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
 
     /* [mapping:esp_system] */
     *libzephyr.a:reset_reason.*(.literal .literal.* .text .text.*)
@@ -474,7 +476,6 @@ SECTIONS
     *libzephyr.a:flash_qio_mode.*(.literal .text .literal.* .text.*)
     *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
     *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
 
     *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
@@ -608,6 +609,8 @@ SECTIONS
     *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:flash_qio_mode.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
 
     /* [mapping:esp_mm] */
     *libzephyr.a:esp_cache.*(.rodata .rodata.* .srodata .srodata.*)
@@ -671,13 +674,11 @@ SECTIONS
     *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:clk.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_clk.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .srodata .srodata.*)
 
     *libzephyr.a:esp_gpio_reserve.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .srodata .srodata.*)
 
     . = ALIGN(16);

--- a/soc/espressif/esp32h2/default.ld
+++ b/soc/espressif/esp32h2/default.ld
@@ -376,6 +376,8 @@ SECTIONS
     *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_ops.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_mmap.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
 
     /* [mapping:esp_system] */
     *libzephyr.a:reset_reason.*(.literal .literal.* .text .text.*)
@@ -447,7 +449,6 @@ SECTIONS
     *libzephyr.a:flash_qio_mode.*(.literal .text .literal.* .text.*)
     *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
     *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
 
     *libzephyr.a:esp_efuse_table.*(.literal .text .literal.* .text.*)
@@ -581,6 +582,8 @@ SECTIONS
     *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:flash_qio_mode.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
 
     /* [mapping:esp_mm] */
     *libzephyr.a:esp_cache.*(.rodata .rodata.* .srodata .srodata.*)
@@ -644,13 +647,11 @@ SECTIONS
     *libzephyr.a:cpu_region_protect.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:clk.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_clk.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .srodata .srodata.*)
 
     *libzephyr.a:esp_gpio_reserve.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .srodata .srodata.*)
-    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .srodata .srodata.*)
 
     . = ALIGN(16);

--- a/soc/espressif/esp32s2/default.ld
+++ b/soc/espressif/esp32s2/default.ld
@@ -411,6 +411,8 @@ SECTIONS
     *libzephyr.a:flash_brownout_hook.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_ops.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:flash_mmap.*(.literal .text .literal.* .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
 
     /* [mapping:esp_system] */
     *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
@@ -499,7 +501,6 @@ SECTIONS
     *libzephyr.a:flash_qio_mode.*(.literal .text .literal.* .text.*)
     *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
     *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
 
     *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
@@ -648,6 +649,8 @@ SECTIONS
     *libzephyr.a:spi_flash_wrap.*(.rodata .rodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:flash_qio_mode.*(.rodata .rodata.*)
+    *libzephyr.a:flash_mmap.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     /* [mapping:esp_mm] */
     *libzephyr.a:esp_cache.*(.rodata .rodata.*)
@@ -724,7 +727,6 @@ SECTIONS
 
     *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     . = ALIGN(4);

--- a/soc/espressif/esp32s3/default.ld
+++ b/soc/espressif/esp32s3/default.ld
@@ -433,6 +433,7 @@ SECTIONS
     *libzephyr.a:spi_flash_hpm_enable.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_oct_flash_init.*(.literal .literal.* .text .text.*)
     *libzephyr.a:flash_ops.*(.literal .literal.* .text .text.*)
+    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
 
     /* [mapping:esp_system] */
     *libzephyr.a:esp_err.*(.literal .literal.* .text .text.*)
@@ -518,7 +519,6 @@ SECTIONS
     *libzephyr.a:flash_qio_mode.*(.literal .text .literal.* .text.*)
     *libzephyr.a:spi_flash_hal.*(.literal .literal.* .text .text.*)
     *libzephyr.a:spi_flash_hal_common.*(.literal .literal.* .text .text.*)
-    *libzephyr.a:esp_flash_api.*(.literal .text .literal.* .text.*)
     *libzephyr.a:esp_flash_spi_init.*(.literal .text .literal.* .text.*)
 
     *libzephyr.a:secure_boot.*(.literal .text .literal.* .text.*)
@@ -676,6 +676,7 @@ SECTIONS
     *libzephyr.a:spi_flash_oct_flash_init.*(.rodata .rodata.*)
     *libzephyr.a:flash_qio_mode.*(.rodata .rodata.*)
     *libzephyr.a:flash_ops.*(.rodata .rodata.*)
+    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     /* [mapping:esp_mm] */
     *libzephyr.a:esp_cache.*(.rodata .rodata.*)
@@ -752,7 +753,6 @@ SECTIONS
 
     *libzephyr.a:spi_flash_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:spi_flash_hal_common.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
-    *libzephyr.a:esp_flash_api.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *libzephyr.a:esp_flash_spi_init.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     . = ALIGN(4);


### PR DESCRIPTION
Ensuring flash region has been erased before writing may avoid inconsistences when hardware flash encryption is enabled.
Add forced aligned flash erase.