### PR TITLE
Bluetooth: ASCS: Sonarcloud fixes

### DIFF
--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -274,9 +274,9 @@ static inline const char *bt_ascs_op_str(uint8_t op)
 		return "Update Metadata";
 	case BT_ASCS_RELEASE_OP:
 		return "Release";
+	default:
+		return "Unknown";
 	}
-
-	return "Unknown";
 }
 
 static inline const char *bt_ascs_rsp_str(uint8_t code)
@@ -312,9 +312,9 @@ static inline const char *bt_ascs_rsp_str(uint8_t code)
 		return "Insufficient Resources";
 	case BT_BAP_ASCS_RSP_CODE_UNSPECIFIED:
 		return "Unspecified Error";
+	default:
+		return "Unknown";
 	}
-
-	return "Unknown";
 }
 
 static inline const char *bt_ascs_reason_str(uint8_t reason)
@@ -342,9 +342,9 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 		return "Presentation Delay";
 	case BT_BAP_ASCS_REASON_CIS:
 		return "Invalid ASE CIS Mapping";
+	default:
+		return "Unknown";
 	}
-
-	return "Unknown";
 }
 
 int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);

--- a/subsys/bluetooth/audio/cap_acceptor.c
+++ b/subsys/bluetooth/audio/cap_acceptor.c
@@ -94,3 +94,29 @@ bool bt_cap_acceptor_ccid_exist(const struct bt_conn *conn, uint8_t ccid)
 
 	return false;
 }
+
+bool bt_cap_acceptor_ccids_exist(const struct bt_conn *conn, const uint8_t ccids[],
+				 uint8_t ccid_cnt)
+{
+	for (uint8_t i = 0; i < ccid_cnt; i++) {
+		const uint8_t ccid = ccids[i];
+
+		if (!bt_cap_acceptor_ccid_exist(conn, ccid)) {
+			LOG_DBG("CCID %u is unknown", ccid);
+
+			/* TBD:
+			 * Should we reject the Metadata?
+			 *
+			 * Should unknown CCIDs trigger a
+			 * discovery procedure for TBS or MCS?
+			 *
+			 * Or should we just accept as is, and
+			 * then let the application decide?
+			 */
+			return false;
+		}
+	}
+
+	/* This will also return true if the ccid_cnt is 0 which is intended */
+	return true;
+}

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -24,6 +24,8 @@
 #include <zephyr/types.h>
 
 bool bt_cap_acceptor_ccid_exist(const struct bt_conn *conn, uint8_t ccid);
+bool bt_cap_acceptor_ccids_exist(const struct bt_conn *conn, const uint8_t ccids[],
+				 uint8_t ccid_cnt);
 
 void bt_cap_initiator_codec_configured(struct bt_cap_stream *cap_stream);
 void bt_cap_initiator_qos_configured(struct bt_cap_stream *cap_stream);


### PR DESCRIPTION
Made a few complex functions simpler
Added missing default cases in switches
Fixes a bad cast that removed const
Moved loop iterators to inner loop