### PR TITLE
posix: c_lib_ext: complete the POSIX_C_LIB_EXT Option Group

### DIFF
--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -109,13 +109,13 @@ Enable this option group with :kconfig:option:`CONFIG_POSIX_C_LIB_EXT`.
     opterr, yes
     optind, yes
     optopt, yes
-    stpcpy(),
-    stpncpy(),
-    strcasecmp(),
-    strdup(),
+    stpcpy(), yes
+    stpncpy(), yes
+    strcasecmp(), yes
+    strdup(), yes
     strfmon(),
     strncasecmp(), yes
-    strndup(),
+    strndup(), yes
     strnlen(), yes
 
 .. _posix_option_group_clock_selection:

--- a/lib/posix/c_lib_ext/CMakeLists.txt
+++ b/lib/posix/c_lib_ext/CMakeLists.txt
@@ -12,6 +12,7 @@ zephyr_library_sources(
   getentropy.c
   getopt/getopt.c
   getopt/getopt_common.c
+  getopt/getsubopt.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_GETOPT_LONG getopt/getopt_long.c)

--- a/lib/posix/c_lib_ext/CMakeLists.txt
+++ b/lib/posix/c_lib_ext/CMakeLists.txt
@@ -13,6 +13,10 @@ zephyr_library_sources(
   getopt/getopt.c
   getopt/getopt_common.c
   getopt/getsubopt.c
+  stpcpy.c
+  strcasecmp.c
+  strdup.c
+  strnlen.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_GETOPT_LONG getopt/getopt_long.c)

--- a/lib/posix/c_lib_ext/Kconfig
+++ b/lib/posix/c_lib_ext/Kconfig
@@ -26,4 +26,8 @@ config GETOPT_LONG
 	  for other threads by extending function getopt_state_get in
 	  getopt_common.c file.
 
+module = GETOPT
+module-str = getopt
+source "subsys/logging/Kconfig.template.log_config"
+
 endif # POSIX_C_LIB_EXT

--- a/lib/posix/c_lib_ext/getopt/getopt.c
+++ b/lib/posix/c_lib_ext/getopt/getopt.c
@@ -39,7 +39,7 @@
 #include "getopt_common.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(getopt);
+LOG_MODULE_REGISTER(getopt, CONFIG_GETOPT_LOG_LEVEL);
 
 #define BADCH  ((int)'?')
 #define BADARG ((int)':')

--- a/lib/posix/c_lib_ext/getopt/getopt_long.c
+++ b/lib/posix/c_lib_ext/getopt/getopt_long.c
@@ -54,7 +54,7 @@
 #include "getopt_common.h"
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(getopt);
+LOG_MODULE_DECLARE(getopt, CONFIG_GETOPT_LOG_LEVEL);
 
 #define GNU_COMPATIBLE /* Be more compatible, configure's use us! */
 

--- a/lib/posix/c_lib_ext/getopt/getsubopt.c
+++ b/lib/posix/c_lib_ext/getopt/getsubopt.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(getopt, CONFIG_GETOPT_LOG_LEVEL);
+
+int getsubopt(char **optionp, char *const *keylist, char **valuep)
+{
+	size_t i, len;
+	char *begin, *end, *eq, *key, *val;
+
+	if (optionp == NULL || keylist == NULL) {
+		LOG_DBG("optionp or keylist is NULL");
+		return -1;
+	}
+
+	if (valuep != NULL) {
+		*valuep = NULL;
+	}
+
+	for (i = 0, begin = *optionp, end = begin, eq = NULL, len = strlen(*optionp); i <= len;
+	     ++i, ++end) {
+
+		char c = *end;
+
+		if ((c == '=') && (eq == NULL)) {
+			eq = end;
+		} else if (c == ',') {
+			*end = '\0';
+			*optionp = end + 1;
+			break;
+		} else if (c == '\0') {
+			*optionp = end;
+			break;
+		}
+	}
+
+	key = begin;
+	if (eq == NULL) {
+		len = end - begin;
+		if (valuep != NULL) {
+			*valuep = NULL;
+		}
+		LOG_DBG("key: %.*s", (int)len, key);
+	} else {
+		len = eq - begin;
+		val = eq + 1;
+		if (valuep != NULL) {
+			*valuep = val;
+		}
+		LOG_DBG("key: %.*s val: %.*s", (int)len, key, (int)(end - val), val);
+	}
+
+	if (len == 0) {
+		LOG_DBG("zero-length key");
+		return -1;
+	}
+
+	for (i = 0; true; ++i) {
+		if (keylist[i] == NULL) {
+			LOG_DBG("end of keylist of length %zu reached", i);
+			break;
+		}
+
+		if (strncmp(key, keylist[i], len) != 0) {
+			continue;
+		}
+
+		if (keylist[i][len] != '\0') {
+			LOG_DBG("key %.*s does not match keylist[%zu]: %s", (int)len, key, i,
+				keylist[i]);
+			continue;
+		}
+
+		return (int)i;
+	}
+
+	return -1;
+}

--- a/lib/posix/c_lib_ext/stpcpy.c
+++ b/lib/posix/c_lib_ext/stpcpy.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include <zephyr/toolchain.h>
+
+char *stpncpy(char *ZRESTRICT s1, const char *ZRESTRICT s2, size_t n)
+{
+	char *ret = NULL;
+
+	for (; n != 0; ++s1, ++s2, --n) {
+		*s1 = *s2;
+		if (*s2 == '\0') {
+			ret = s1;
+		}
+	}
+
+	for (; n != 0; --n) {
+		*s1++ = '\0';
+	}
+
+	if (ret == NULL) {
+		ret = s1;
+	}
+
+	return ret;
+}
+
+char *stpcpy(char *ZRESTRICT s1, const char *ZRESTRICT s2)
+{
+	return stpncpy(s1, s2, strlen(s2) + 1);
+}

--- a/lib/posix/c_lib_ext/strcasecmp.c
+++ b/lib/posix/c_lib_ext/strcasecmp.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ctype.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr/sys/util.h>
+
+__weak int strncasecmp(const char *s1, const char *s2, size_t n)
+{
+	int c1, c2;
+
+	for (; n != 0; --n) {
+		c1 = (unsigned char)*s1++;
+		c2 = (unsigned char)*s2++;
+		if (c1 == '\0') {
+			return c1 - c2;
+		}
+		if (c2 == '\0') {
+			return c1 - c2;
+		}
+
+		c1 = tolower(c1);
+		c2 = tolower(c2);
+
+		if (c1 != c2) {
+			return c1 - c2;
+		}
+	}
+
+	return 0;
+}
+
+int strcasecmp(const char *s1, const char *s2)
+{
+	return strncasecmp(s1, s2, min(strlen(s1), strlen(s2)));
+}

--- a/lib/posix/c_lib_ext/strdup.c
+++ b/lib/posix/c_lib_ext/strdup.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *strndup(const char *s, size_t n)
+{
+	char *ret = malloc(n);
+
+	if (ret != NULL) {
+		strncpy(ret, s, n);
+		ret[n - 1] = '\0';
+	}
+
+	return ret;
+}
+
+char *strdup(const char *s)
+{
+	return strndup(s, strlen(s) + 1);
+}

--- a/lib/posix/c_lib_ext/strnlen.c
+++ b/lib/posix/c_lib_ext/strnlen.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr/toolchain.h>
+
+__weak size_t strnlen(const char *s, size_t maxlen)
+{
+	size_t len;
+
+	for (len = 0; len < maxlen && s[len] != '\0'; ++len) {
+		/* nothing to do */
+	}
+
+	return len;
+}

--- a/tests/posix/c_lib_ext/src/getsubopt.c
+++ b/tests/posix/c_lib_ext/src/getsubopt.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include <stdlib.h>
+
+extern int getsubopt(char **optionp, char *const *keylistp, char **valuep);
+
+ZTEST(posix_c_lib_ext, test_getsubopt)
+{
+	char *value;
+	char *option;
+	char buf[32];
+
+	enum opte {
+		RO_OPTION,
+		RW_OPTION,
+		READ_SIZE_OPTION,
+		WRITE_SIZE_OPTION,
+		EMBEDDED_EQ_OPTION,
+	};
+
+	static const char *const key_list[] = {
+		[RO_OPTION] = "ro",
+		[RW_OPTION] = "rw",
+		[READ_SIZE_OPTION] = "rsize",
+		[WRITE_SIZE_OPTION] = "wsize",
+		[EMBEDDED_EQ_OPTION] = "equal",
+		NULL,
+	};
+
+	static const char *const empty_key_list[] = {
+		NULL,
+	};
+
+	/* degenerate cases */
+	zexpect_equal(-1, getsubopt(NULL, NULL, NULL));
+	zexpect_equal(-1, getsubopt(NULL, NULL, &value));
+	zexpect_equal(-1, getsubopt(NULL, (char **)key_list, NULL));
+	zexpect_equal(-1, getsubopt(NULL, (char **)key_list, &value));
+	zexpect_equal(-1, getsubopt(&option, NULL, NULL));
+	zexpect_equal(-1, getsubopt(&option, NULL, &value));
+
+	/* iterate over valuep being NULL and valid */
+	for (size_t j = 0; j < 2; ++j) {
+		char **valuep = (j == 0) ? NULL : &value;
+
+		/* empty options string */
+		memset(buf, 0, sizeof(buf));
+		option = buf;
+		value = (char *)0x4242;
+		zexpect_equal(-1, getsubopt(&option, (char **)key_list, valuep));
+		if (valuep != NULL) {
+			zexpect_equal(value, NULL);
+		}
+
+		/* empty key list */
+		strcpy(buf, "ro,rsize=512,equal=1=2,rw");
+		option = buf;
+		value = (char *)0x4242;
+		zexpect_equal(-1, getsubopt(&option, (char **)empty_key_list, valuep));
+		if (valuep != NULL) {
+			zexpect_equal(value, NULL);
+		}
+
+		strcpy(buf, "ro,rsize=512,equal=1=2,rw");
+		option = buf;
+		value = (char *)0x4242;
+		zexpect_equal(RO_OPTION, getsubopt(&option, (char **)key_list, valuep));
+		zexpect_equal(option, &buf[strlen("ro,")]);
+		if (valuep != NULL) {
+			zexpect_equal(value, NULL);
+		}
+
+		value = (char *)0x4242;
+		zexpect_equal(READ_SIZE_OPTION, getsubopt(&option, (char **)key_list, valuep));
+		zexpect_equal(option, &buf[strlen("ro,rsize=512,")]);
+		if (valuep != NULL) {
+			zexpect_str_equal(value, "512");
+		}
+
+		value = (char *)0x4242;
+		zexpect_equal(EMBEDDED_EQ_OPTION, getsubopt(&option, (char **)key_list, valuep));
+		zexpect_equal(option, &buf[strlen("ro,rsize=512,equal=1=2,")]);
+		if (valuep != NULL) {
+			zexpect_str_equal(value, "1=2");
+		}
+
+		value = (char *)0x4242;
+		zexpect_equal(RW_OPTION, getsubopt(&option, (char **)key_list, valuep));
+		zexpect_equal(option, &buf[strlen("ro,rsize=512,equal=1=2,rw")]);
+		if (valuep != NULL) {
+			zexpect_equal(value, NULL);
+		}
+
+		value = (char *)0x4242;
+		zexpect_equal(getsubopt(&option, (char **)key_list, valuep), -1);
+		if (valuep != NULL) {
+			zexpect_equal(value, NULL);
+		}
+
+		strcpy(buf, "oops");
+		option = buf;
+		value = (char *)0x4242;
+		zexpect_equal(getsubopt(&option, (char **)key_list, valuep), -1);
+		if (valuep != NULL) {
+			zexpect_equal(value, NULL);
+		}
+
+		/* some corner cases */
+		strcpy(buf, ",rsize=,");
+		option = buf;
+		value = (char *)0x4242;
+		zexpect_equal(-1, getsubopt(&option, (char **)key_list, valuep));
+		zexpect_equal(option, &buf[strlen(",")]);
+		if (valuep != NULL) {
+			zexpect_equal(value, NULL);
+		}
+
+		value = (char *)0x4242;
+		zexpect_equal(READ_SIZE_OPTION, getsubopt(&option, (char **)key_list, valuep));
+		zexpect_equal(option, &buf[strlen(",rsize=,")]);
+		if (valuep != NULL) {
+			zexpect_str_equal(value, "");
+		}
+	}
+}


### PR DESCRIPTION
Complete the POSIX_C_LIB_EXT Option Group with the addition of `getsubopt()`, `stpcpy()`, `stpncpy()`, `strcasecmp()`, `strdup()`, `strfmon()`, `strncasecmp()`, `strndup()`, `strnlen()`

* posix: getopt: use configurable log level
* posix: c_lib_ext: implement `getsubopt()`
* tests: posix: c_lib_ext: add tests for `getsubopt()`
* posix: c_lib_ext: add remaining string functions

> [!NOTE]
> Currently, the functions `strncasecmp()` and `strnlen()` are annotated `__weak` in POSIX to avoid multiple-definition errors, since they are already present in the minimal libc and common libc, in spite of not being specified by any ANSI or ISO C standard. Those are POSIX functions that are part of the `POSIX_C_LIBC_EXT` [Subprofiling Option Group](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html), so that should be fixed, if not here, then in a follow-up PR.

> [!NOTE]
> Currently, `strfmon()` needs to be implemented still, but since Zephyr currently has no plans to support locales (and it's unclear if there ever will be), and since `strfmon_l()` is part of the `POSIX_MULTI_CONCURRENT_LOCALES` Option Group, there are no plans to support `strfmon_l()`. The "C" locale is assumed.