### PR TITLE
samples: add the ch32v series to the Twister run

### DIFF
--- a/boards/wch/ch32v003evt/ch32v003evt.yaml
+++ b/boards/wch/ch32v003evt/ch32v003evt.yaml
@@ -11,3 +11,6 @@ supported:
   - dma
   - gpio
   - i2c
+  - pwm
+  - uart
+  - watchdog

--- a/boards/wch/ch32v003f4p6_dev_board/ch32v003f4p6_dev_board.yaml
+++ b/boards/wch/ch32v003f4p6_dev_board/ch32v003f4p6_dev_board.yaml
@@ -9,5 +9,7 @@ ram: 2
 flash: 16
 supported:
   - gpio
-  - uart
   - i2c
+  - pwm
+  - uart
+  - watchdog

--- a/boards/wch/ch32v006evt/ch32v006evt.dts
+++ b/boards/wch/ch32v006evt/ch32v006evt.dts
@@ -57,6 +57,7 @@
 		led0 = &blue_led1;
 		led1 = &blue_led2;
 		pwm-led0 = &blue_pwm2;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -87,4 +88,8 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart1_default>;
 	pinctrl-names = "default";
+};
+
+&iwdg {
+	status = "okay";
 };

--- a/boards/wch/ch32v006evt/ch32v006evt.yaml
+++ b/boards/wch/ch32v006evt/ch32v006evt.yaml
@@ -12,5 +12,6 @@ supported:
   - gpio
   - i2c
   - pwm
+  - uart
   - watchdog
 vendor: wch

--- a/boards/wch/ch32v303vct6_evt/ch32v303vct6_evt.yaml
+++ b/boards/wch/ch32v303vct6_evt/ch32v303vct6_evt.yaml
@@ -1,12 +1,12 @@
-identifier: bluepillplus_ch32v203
-name: WeActStudio BluePill Plus CH32V203
+identifier: ch32v303vct6_evt
+name: WCH CH32V303VCT6-EVT Evaluation Board
 type: mcu
 arch: riscv
 toolchain:
   - cross-compile
   - zephyr
-ram: 20
-flash: 224
+ram: 32
+flash: 480
 supported:
   - gpio
   - i2c

--- a/boards/wch/linkw/linkw.dts
+++ b/boards/wch/linkw/linkw.dts
@@ -51,6 +51,7 @@
 	aliases {
 		led0 = &blue_led;
 		sw0 = &mode;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -81,4 +82,8 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart2_default>;
 	pinctrl-names = "default";
+};
+
+&iwdg {
+	status = "okay";
 };

--- a/boards/wch/linkw/linkw.yaml
+++ b/boards/wch/linkw/linkw.yaml
@@ -10,3 +10,7 @@ flash: 128
 supported:
   - dma
   - gpio
+  - i2c
+  - pwm
+  - uart
+  - watchdog


### PR DESCRIPTION
The CH32V series now has GPIO, watchdog, I2C, and PWM drivers. Enable
Twister for these drivers by updating the board definitions to match.

On the larger chips, also enable the watchdog in Devicetree so it's
usable by the sample.

This should catch issues like https://github.com/zephyrproject-rtos/zephyr/pull/90438 in the future.