### PR TITLE
dts: arm: ti: Add MAIN domain UARTS

### DIFF
--- a/dts/arm/ti/am62x_m4.dtsi
+++ b/dts/arm/ti/am62x_m4.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/pinctrl/ti-k3-pinctrl.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <ti/k3-am62-main.dtsi>
 
 / {
 

--- a/dts/vendor/ti/k3-am62-main.dtsi
+++ b/dts/vendor/ti/k3-am62-main.dtsi
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * Device Tree Source for AM625 SoC Family Main Domain peripherals
+ *
+ * Copyright (C) 2020-2024 Texas Instruments Incorporated - https://www.ti.com/
+ * Copyright (c) 2025 Ayush Singh, BeagleBoard.org Foundation
+ */
+
+/ {
+	main_uart0: serial@2800000 {
+		compatible = "ns16550";
+		reg = <0x02800000 0x100>;
+		clock-frequency = <48000000>;
+		current-speed = <115200>;
+		reg-shift = <2>;
+		status = "disabled";
+	};
+
+	main_uart1: serial@2810000 {
+		compatible = "ns16550";
+		reg = <0x02810000 0x100>;
+		clock-frequency = <48000000>;
+		current-speed = <115200>;
+		reg-shift = <2>;
+		status = "disabled";
+	};
+
+	main_uart2: serial@2820000 {
+		compatible = "ns16550";
+		reg = <0x02820000 0x100>;
+		clock-frequency = <48000000>;
+		current-speed = <115200>;
+		reg-shift = <2>;
+		status = "disabled";
+	};
+
+	main_uart3: serial@2830000 {
+		compatible = "ns16550";
+		reg = <0x02830000 0x100>;
+		clock-frequency = <48000000>;
+		current-speed = <115200>;
+		reg-shift = <2>;
+		status = "disabled";
+	};
+
+	main_uart4: serial@2840000 {
+		compatible = "ns16550";
+		reg = <0x02840000 0x100>;
+		clock-frequency = <48000000>;
+		current-speed = <115200>;
+		reg-shift = <2>;
+		status = "disabled";
+	};
+
+	main_uart5: serial@2850000 {
+		compatible = "ns16550";
+		reg = <0x02850000 0x100>;
+		clock-frequency = <48000000>;
+		current-speed = <115200>;
+		reg-shift = <2>;
+		status = "disabled";
+	};
+
+	main_uart6: serial@2860000 {
+		compatible = "ns16550";
+		reg = <0x02860000 0x100>;
+		clock-frequency = <48000000>;
+		current-speed = <115200>;
+		reg-shift = <2>;
+		status = "disabled";
+	};
+};


### PR DESCRIPTION
M4F can use uarts from main domain of AM62. However, interrupts are not supported.

Tested on PocketBeagle 2 M4F

I am planning to add MAIN domain GPIOs and other peripherals as well, so it might be good if we could share the common stuff between a53s and m4f