### PR TITLE
samples: circular_dma: fix DMA config for nucleo_c031c6

### DIFF
--- a/samples/boards/st/uart/circular_dma/boards/nucleo_c031c6.overlay
+++ b/samples/boards/st/uart/circular_dma/boards/nucleo_c031c6.overlay
@@ -6,7 +6,7 @@
 
 &usart2 {
 	dmas = <&dmamux1 0 53 (STM32_DMA_PERIPH_TX)>,
-		<&dmamux1 3 52 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_8BITS | STM32_DMA_MODE_CYCLIC)>;
+		<&dmamux1 2 52 (STM32_DMA_PERIPH_RX | STM32_DMA_MEM_8BITS | STM32_DMA_MODE_CYCLIC)>;
 	dma-names = "tx", "rx";
 	fifo-enable;
 };


### PR DESCRIPTION
The circular DMA sample incorrectly configured channel 3 for the 
NUCLEO-C031C6 board, but this MCU has only 3 channels (0 - 2). 
Fixed by changing to channel 2.

Signed-off-by: Richard Skriwanek <richy@fnc.at>
