### PR TITLE
boards: st: nucleo_l433rc_p: add die_temp, vref, and vbat nodes

### DIFF
--- a/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -42,6 +42,9 @@
 	aliases {
 		led0 = &green_led;
 		sw0 = &user_button;
+		die-temp0 = &die_temp;
+		volt-sensor0 = &vref;
+		volt-sensor1 = &vbat;
 	};
 };
 
@@ -141,4 +144,22 @@
 			reg = <0x0003c000 DT_SIZE_K(16)>;
 		};
 	};
+};
+
+&adc1 {
+	st,adc-clock-source = "SYNC";
+	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&vref {
+	status = "okay";
+};
+
+&vbat {
+	status = "okay";
 };


### PR DESCRIPTION
Added die_temp, vref, and vbat nodes and their aliases to the nucleo_l433rc_p board.