### PR TITLE
drivers: stepper: add missing include guard

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2148,6 +2148,7 @@ Release Notes:
     - jbehrensnx
   files:
     - drivers/stepper/
+    - include/zephyr/drivers/stepper/
     - include/zephyr/drivers/stepper.h
     - dts/bindings/stepper/
     - doc/hardware/peripherals/stepper.rst

--- a/include/zephyr/drivers/stepper/stepper_drv84xx.h
+++ b/include/zephyr/drivers/stepper/stepper_drv84xx.h
@@ -11,6 +11,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef ZEPHYR_INCLUDE_DRIVERS_STEPPER_STEPPER_DRV84XX_H_
+#define ZEPHYR_INCLUDE_DRIVERS_STEPPER_STEPPER_DRV84XX_H_
+
 #include <stdint.h>
 #include <zephyr/drivers/stepper.h>
 
@@ -31,3 +34,5 @@ int drv84xx_microstep_recovery(const struct device *dev);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_STEPPER_STEPPER_DRV84XX_H_ */


### PR DESCRIPTION
Add missing include guard in drv84xx pubic header