### PR TITLE
cmake: allow shield overlays in APPLICATION_CONFIG_DIR

### DIFF
--- a/cmake/modules/configuration_files.cmake
+++ b/cmake/modules/configuration_files.cmake
@@ -65,11 +65,30 @@ zephyr_boilerplate_watch(CONF_FILE)
 
 zephyr_get(DTC_OVERLAY_FILE SYSBUILD LOCAL)
 
-# If DTC_OVERLAY_FILE is not set by the user, look for SoC and board-specific overlays
+# If DTC_OVERLAY_FILE is not set by the user, look for SoC and board/shield-specific overlays
 # in the 'boards' and `soc` configuration subdirectories.
 if(NOT DEFINED DTC_OVERLAY_FILE)
   zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR}/socs DTS DTC_OVERLAY_FILE QUALIFIERS SUFFIX ${FILE_SUFFIX})
   zephyr_file(CONF_FILES ${APPLICATION_CONFIG_DIR}/boards DTS DTC_OVERLAY_FILE SUFFIX ${FILE_SUFFIX})
+
+  if(DEFINED SHIELD_AS_LIST)
+    foreach(shield_name ${SHIELD_AS_LIST})
+      set(shield_overlay_path ${APPLICATION_CONFIG_DIR}/boards/shields/${shield_name}.overlay)
+
+      if(EXISTS ${shield_overlay_path})
+        list(APPEND DTC_OVERLAY_FILE ${shield_overlay_path})
+      endif()
+
+      # Also check for shield overlays with suffix support
+      if(DEFINED FILE_SUFFIX)
+        set(shield_overlay_suffix_path ${APPLICATION_CONFIG_DIR}/boards/shields/${shield_name}_${FILE_SUFFIX}.overlay)
+
+        if(EXISTS ${shield_overlay_suffix_path})
+          list(APPEND DTC_OVERLAY_FILE ${shield_overlay_suffix_path})
+        endif()
+      endif()
+    endforeach()
+  endif()
 endif()
 
 # If still not found, search for other overlays in the configuration directory.

--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -242,6 +242,10 @@ use as devicetree overlays:
 #. If the file :file:`boards/<BOARD>.overlay` exists, it will be used in addition to the above.
 #. If the current board has :ref:`multiple revisions <porting_board_revisions>`
    and :file:`boards/<BOARD>_<revision>.overlay` exists, it will be used in addition to the above.
+#. If one or more shields are specified using the :makevar:`SHIELD` variable, for each shield
+   the build system checks if :file:`boards/shields/<SHIELD>.overlay` exists. If a
+   :ref:`file suffix <application-file-suffixes>` is defined and
+   :file:`boards/shields/<SHIELD>_<FILE_SUFFIX>.overlay` also exists, it will be applied as well.
 #. If one or more files have been found in the previous steps, the build system
    stops looking and just uses those files.
 #. Otherwise, if :file:`<BOARD>.overlay` exists, it will be used, and the build

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -458,6 +458,33 @@ revision:
            ├── <board>.overlay
            └── <board>.defconfig
 
+Application-specific shield overlays
+************************************
+
+In addition to the shield overlays provided with the shield definition, applications
+can provide their own shield-specific devicetree overlays. These are automatically
+discovered when placed in the application's configuration directory under
+:file:`boards/shields/<SHIELD>.overlay`. If a :ref:`file suffix <application-file-suffixes>`
+is defined, overlays matching :file:`boards/shields/<SHIELD>_<FILE_SUFFIX>.overlay` will also
+be applied.
+
+For example, an application might need to adjust shield settings for a particular
+use case without modifying the shield definition itself:
+
+.. code-block:: none
+
+   <app>
+   ├── CMakeLists.txt
+   ├── prj.conf
+   ├── boards
+   │   └── shields
+   │       └── x_nucleo_iks01a1.overlay
+   └── src
+       └── main.c
+
+See :ref:`set-devicetree-overlays` for complete details on how devicetree overlays
+are discovered and applied.
+
 .. _gpio-nexus-node:
 
 GPIO nexus nodes


### PR DESCRIPTION
Add support for shield-specific overlays (including suffix support). They are searched in the 'boards/shields' directory of the application configuration directory.

Fixes zephyrproject-rtos/zephyr#86592

~Still need to add some docs~, and possibly some tests as well.

poke @jordanyates 