### PR TITLE
drivers: gpio_nrfx: Add missing break statements in gpio_pin_get_config

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -258,8 +258,10 @@ static int gpio_nrfx_pin_get_config(const struct device *port, gpio_pin_t pin,
 	switch (pull) {
 	case NRF_GPIO_PIN_PULLUP:
 		*flags |= GPIO_PULL_UP;
+		break;
 	case NRF_GPIO_PIN_PULLDOWN:
 		*flags |= GPIO_PULL_DOWN;
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
... so that the pull-up pin configuration can be correctly reported.

Fixes #90513.