### PR TITLE
drivers: adc_ad4130: Fix out-of-bounds accesses to channel_setup_cfg

### DIFF
--- a/drivers/adc/adc_ad4130.c
+++ b/drivers/adc/adc_ad4130.c
@@ -229,7 +229,7 @@ struct ad4130_config {
 struct adc_ad4130_data {
 	const struct device *dev;
 	struct adc_context ctx;
-	struct ad4130_channel_config channel_setup_cfg[AD4130_MAX_SETUPS];
+	struct ad4130_channel_config channel_setup_cfg[AD4130_MAX_CHANNELS];
 	uint8_t setup_cfg_slots;
 	struct k_sem acquire_signal;
 	uint16_t channels;
@@ -456,11 +456,6 @@ static int adc_ad4130_create_new_cfg(const struct device *dev, const struct adc_
 	enum ad4130_ref_sel ref_source;
 	enum ad4130_gain gain;
 
-	if (cfg->channel_id >= AD4130_MAX_CHANNELS) {
-		LOG_ERR("Invalid channel (%u)", cfg->channel_id);
-		return -EINVAL;
-	}
-
 	if (cfg->acquisition_time != ADC_ACQ_TIME_DEFAULT) {
 		LOG_ERR("invalid acquisition time %i", cfg->acquisition_time);
 		return -EINVAL;
@@ -563,6 +558,11 @@ static int adc_ad4130_channel_setup(const struct device *dev, const struct adc_c
 	int similar_channel_index;
 	int new_slot;
 	int ret;
+
+	if (cfg->channel_id >= AD4130_MAX_CHANNELS) {
+		LOG_ERR("Invalid channel (%u)", cfg->channel_id);
+		return -EINVAL;
+	}
 
 	data->channel_setup_cfg[cfg->channel_id].live_cfg = false;
 


### PR DESCRIPTION
Correct the size of the channel_setup_cfg array, as it should contain entries for all available channels (AD4130_MAX_CHANNELS), not for the available configuration slots (AD4130_MAX_SETUPS).
Move also checking of the channel index to the very beginning of adc_ad4130_channel_setup(), to avoid potential writes to .live_cfg beyond the channel_setup_cfg array.

Fixes #90507.
Fixes #90514.