### PR TITLE
net: ipv6: Make sure we do not access link address past array length

### DIFF
--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -1030,6 +1030,12 @@ int net_ipv6_addr_generate_iid(struct net_if *iface,
 
 			break;
 		case 8:
+			if (sizeof(lladdr->addr) < 8) {
+				NET_ERR("Invalid link layer address length %zu, expecting 8",
+					sizeof(lladdr->addr));
+				return -EINVAL;
+			}
+
 			memcpy(&tmp_addr.s6_addr[8], lladdr->addr, lladdr->len);
 			tmp_addr.s6_addr[8] ^= 0x02;
 			break;


### PR DESCRIPTION
It is possible to manually set link address length past 6 at runtime and trying to generate IPv6 IID address that way. This should fail as we could read two bytes past the address buffer. There is no issues in the copying as the target buffer has plenty of space.

Fixes #90544
Coverity-CID: 516232