### PR TITLE
net: ipv6: Do not access link address past array length

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -1536,6 +1536,10 @@ static inline bool net_ipv6_addr_based_on_ll(const struct in6_addr *addr,
 
 		break;
 	case 8:
+		if (sizeof(lladdr->addr) < 8) {
+			return false;
+		}
+
 		if (!memcmp(&addr->s6_addr[9], &lladdr->addr[1],
 			    lladdr->len - 1) &&
 		    (addr->s6_addr[8] ^ 0x02) == lladdr->addr[0]) {


### PR DESCRIPTION
It is possible to manually set link address length past 6 at runtime and trying to check IPv6 ll address that way. This should fail as we could read two bytes past the address buffer.

Fixes #90535
Coverity-CID: 516242