### PR TITLE
samples: drivers: nrf: flash: Execute nrf soc flash sample on nrf54l

### DIFF
--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -9,11 +9,13 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
     tags:
       - flash
       - drivers


### PR DESCRIPTION
Add nrf54l to nrf_soc_flash sample allowed targets.