### PR TITLE
[TI cc23x0 SoC] Add DMA mode to crypto driver

### DIFF
--- a/drivers/crypto/Kconfig.cc23x0
+++ b/drivers/crypto/Kconfig.cc23x0
@@ -13,3 +13,12 @@ config CRYPTO_CC23X0
 	  - ECB (Electronic Code Book) encryption only (decryption not supported by the hardware)
 	  - CTR (Counter)
 	  - CCM (CTR with CBC-MAC)
+
+config CRYPTO_CC23X0_DMA
+	bool "DMA support for TI CC23X0 AES accelerator devices"
+	depends on CRYPTO_CC23X0
+	select DMA
+	help
+	  DMA driven transactions for the AES peripheral.
+	  DMA driven mode offloads data transfer tasks from the CPU
+	  and requires fewer interrupts to handle the AES operations.

--- a/dts/arm/ti/cc23x0.dtsi
+++ b/dts/arm/ti/cc23x0.dtsi
@@ -84,6 +84,8 @@
 			compatible = "ti,cc23x0-aes";
 			reg = <0x400c0000 0x120>;
 			interrupts = <9 0>;
+			dmas = <&dma 4 3>, <&dma 5 4>;
+			dma-names = "cha", "chb";
 			status = "disabled";
 		};
 

--- a/dts/bindings/crypto/ti,cc23x0-aes.yaml
+++ b/dts/bindings/crypto/ti,cc23x0-aes.yaml
@@ -13,3 +13,30 @@ properties:
 
   interrupts:
     required: true
+
+  dmas:
+    description: |
+      Optional CHA & CHB DMA specifiers. Each specifier will have a phandle
+      reference to the DMA controller, the channel number, and the peripheral
+      trigger source.
+
+      Example for channels 4/5 with aestrga/aestrgb trigger sources:
+        dmas = <&dma 4 3>, <&dma 5 4>;
+
+      For ECB mode:
+        - CHA moves plaintext data into buffer registers when AES operation starts,
+        - CHB moves ciphertext to memory when AES completes.
+      For CTR (also used by CCM):
+        - CHA moves plaintext data into text XOR registers when AES operation starts,
+        - CHB moves ciphertext to memory after CHA has written the last text XOR register.
+      For CBC-MAC (also used by CCM):
+        - CHA moves plaintext data into buffer when AES operation starts,
+        - CHB is not used.
+
+  dma-names:
+    description: |
+      Required if the dmas property exists. These must be "cha" and "chb"
+      to match the dmas property.
+
+      Example:
+        dma-names = "cha", "chb";

--- a/samples/drivers/crypto/sample.yaml
+++ b/samples/drivers/crypto/sample.yaml
@@ -67,3 +67,18 @@ tests:
         - ".*: CBC mode DECRYPT - Match"
         - ".*: CTR mode ENCRYPT - Match"
         - ".*: CTR mode DECRYPT - Match"
+  sample.drivers.crypto.cc23x0_dma:
+    tags: crypto
+    filter: dt_compat_enabled("ti,cc23x0-aes") and dt_compat_enabled("ti,cc23x0-dma")
+    integration_platforms:
+      - lp_em_cc2340r5
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - ".*: Cipher Sample"
+        - ".*: ECB mode ENCRYPT - Match"
+        - ".*: CTR mode ENCRYPT - Match"
+        - ".*: CTR mode DECRYPT - Match"
+    extra_configs:
+      - CONFIG_CRYPTO_CC23X0_DMA=y


### PR DESCRIPTION
This series adds DMA mode support to crypto driver for the TI cc23x0 SoC.

Datasheet: https://www.ti.com/lit/ds/symlink/cc2340r5.pdf
