### PR TITLE
[TI cc23x0 SoC] Add DMA mode to ADC driver

### DIFF
--- a/drivers/adc/Kconfig.cc23x0
+++ b/drivers/adc/Kconfig.cc23x0
@@ -8,3 +8,13 @@ config ADC_CC23X0
 	select PINCTRL
 	help
 	  Enable the TI CC23X0 ADC driver.
+
+config ADC_CC23X0_DMA_DRIVEN
+	bool "DMA support for TI CC23X0 ADC devices"
+	depends on ADC_CC23X0
+	select DMA
+	help
+	  DMA driven mode offloads data transfer tasks from the CPU
+	  and requires fewer interrupts to handle the ADC sequence mode.
+	  When DMA mode is used, the ADC internal gain is not compensated
+	  for measurement adjustment.

--- a/dts/arm/ti/cc23x0.dtsi
+++ b/dts/arm/ti/cc23x0.dtsi
@@ -158,6 +158,8 @@
 			reg = <0x40050000 0xe30>;
 			interrupts = <15 0>;
 			#io-channel-cells = <1>;
+			dmas = <&dma 3 5>;
+			dma-names = "dma";
 			status = "disabled";
 		};
 	};

--- a/dts/bindings/adc/ti,cc23x0-adc.yaml
+++ b/dts/bindings/adc/ti,cc23x0-adc.yaml
@@ -23,5 +23,20 @@ properties:
   "#io-channel-cells":
     const: 1
 
+  dmas:
+    description: |
+      Optional DMA specifier. The specifier will have a phandle reference to the
+      DMA controller, the channel number, and the peripheral trigger source.
+
+      Example for channel 3 with adc0trg trigger source:
+        dmas = <&dma 3 5>;
+
+  dma-names:
+    description: |
+      Required if the dmas property exists. This should be "dma".
+
+      Example:
+        dma-names = "dma";
+
 io-channel-cells:
   - input


### PR DESCRIPTION
This series adds DMA mode support to ADC driver for the TI cc23x0 SoC.

Datasheet: https://www.ti.com/lit/ds/symlink/cc2340r5.pdf