### PR TITLE
[TI cc23x0 SoC] Add DMA mode to UART driver

### DIFF
--- a/drivers/serial/Kconfig.cc23x0
+++ b/drivers/serial/Kconfig.cc23x0
@@ -9,6 +9,15 @@ config UART_CC23X0
 	depends on DT_HAS_TI_CC23X0_UART_ENABLED
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
+	select SERIAL_SUPPORT_ASYNC
 	select PINCTRL
 	help
 	  Enable the TI SimpleLink CC23x0 UART driver.
+
+config UART_CC23X0_DMA_DRIVEN
+	bool "DMA support for TI CC23X0 UART devices"
+	depends on UART_CC23X0
+	depends on UART_ASYNC_API
+	select DMA
+	help
+	  DMA driven mode offloads data transfer tasks from the CPU.

--- a/dts/arm/ti/cc23x0.dtsi
+++ b/dts/arm/ti/cc23x0.dtsi
@@ -77,6 +77,8 @@
 			reg = <0x40034000 0x52>;
 			interrupts = <11 0>;
 			clocks = <&sysclk>;
+			dmas = <&dma 2 6>, <&dma 3 7>;
+			dma-names = "tx", "rx";
 			status = "disabled";
 		};
 

--- a/dts/bindings/serial/ti,cc23x0-uart.yaml
+++ b/dts/bindings/serial/ti,cc23x0-uart.yaml
@@ -31,3 +31,20 @@ properties:
     description: |
       Sets the number of data bits. Defaults to standard of 8 if not specified.
     default: 8
+
+  dmas:
+    description: |
+      Optional TX & RX DMA specifiers. Each specifier will have a phandle
+      reference to the DMA controller, the channel number, and the peripheral
+      trigger source.
+
+      Example for channels 2/3 with uart0txtrg/uart0rxtrg trigger sources:
+        dmas = <&dma 2 6>, <&dma 3 7>;
+
+  dma-names:
+    description: |
+      Required if the dmas property exists. This should be "tx" and "rx"
+      to match the dmas property.
+
+      Example:
+        dma-names = "tx", "rx";


### PR DESCRIPTION
This series adds DMA mode support to UART driver for the TI cc23x0 SoC.

Datasheet: https://www.ti.com/lit/ds/symlink/cc2340r5.pdf