### PR TITLE
tests: drivers: flash: common: Fix page size when no erase is required

### DIFF
--- a/drivers/flash/flash_util.c
+++ b/drivers/flash/flash_util.c
@@ -59,7 +59,7 @@ int z_impl_flash_fill(const struct device *dev, uint8_t val, off_t offset,
 
 		rc = api->write(dev, offset + stored, filler, chunk);
 		if (rc < 0) {
-			LOG_DBG("Fill to dev %p failed at offset 0x%zx\n",
+			LOG_ERR("Fill to dev %p failed at offset 0x%zx\n",
 				dev, (size_t)offset + stored);
 			break;
 		}

--- a/tests/drivers/flash/common/src/main.c
+++ b/tests/drivers/flash/common/src/main.c
@@ -79,7 +79,8 @@ static void flash_driver_before(void *arg)
 		TC_PRINT("No devices with erase requirement present\n");
 		erase_value = 0x55;
 		page_info.start_offset = TEST_AREA_OFFSET;
-		page_info.size = TEST_AREA_MAX - TEST_AREA_OFFSET;
+		/* test_flash_copy uses 2 pages, so split the test area */
+		page_info.size = (TEST_AREA_MAX - TEST_AREA_OFFSET) / 2;
 	}
 
 
@@ -102,6 +103,10 @@ static void flash_driver_before(void *arg)
 	/* Check if tested region fits in flash */
 	zassert_true((TEST_AREA_OFFSET + EXPECTED_SIZE) <= TEST_AREA_MAX,
 		     "Test area exceeds flash size");
+
+	/* Check if test region is suitable for test_flash_copy */
+	zassert_true((TEST_AREA_OFFSET + 2 * page_info.size) <= TEST_AREA_MAX,
+		     "test_flash_copy needs 2 flash pages");
 
 	/* Check if flash is cleared */
 	if (IS_ENABLED(CONFIG_FLASH_HAS_EXPLICIT_ERASE) && ebw_required) {


### PR DESCRIPTION
When no flash device requires erase, this test does not retrieve flash page size with flash_get_page_info_by_offs(), but instead it takes an arbitrary page size based on the test area length. Since the test_flash_copy routine needs to use two pages, the test area needs to be split into at least two parts. Correct the related code and add a check if test_flash_copy requirements are met.

Plus a minor improvement in flash_fill() that may help identify problems like the one above more quickly.

Fixes #89826,