### PR TITLE
shields: doc: allow to indicate supported hw features

### DIFF
--- a/boards/shields/abrobot_esp32c3_oled/shield.yml
+++ b/boards/shields/abrobot_esp32c3_oled/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: abrobot_sh1106_72x40
   full_name: ABRobot ESP32C3 OLED Shield
   vendor: others
+  supported_features:
+    - display

--- a/boards/shields/adafruit_2_8_tft_touch_v2/shield.yml
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/shield.yml
@@ -2,7 +2,15 @@ shields:
   - name: adafruit_2_8_tft_touch_v2
     full_name: Adafruit 2.8" TFT Touch Shield V2 (Uno)
     vendor: adafruit
+    supported_features:
+      - display
+      - input
+      - sdhc
 
   - name: adafruit_2_8_tft_touch_v2_nano
     full_name: Adafruit 2.8" TFT Touch Shield V2 (Nano)
     vendor: adafruit
+    supported_features:
+      - display
+      - input
+      - sdhc

--- a/boards/shields/adafruit_adalogger_featherwing/shield.yml
+++ b/boards/shields/adafruit_adalogger_featherwing/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: adafruit_adalogger_featherwing
   full_name: Adafruit Adalogger FeatherWing
   vendor: adafruit
+  supported_features:
+    - sdhc
+    - rtc

--- a/boards/shields/adafruit_aw9523/shield.yml
+++ b/boards/shields/adafruit_aw9523/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: adafruit_aw9523
   full_name: Adafruit AW9523 GPIO Expander and LED Driver
   vendor: adafruit
+  supported_features:
+    - mfd
+    - gpio

--- a/boards/shields/adafruit_data_logger/shield.yml
+++ b/boards/shields/adafruit_data_logger/shield.yml
@@ -6,3 +6,6 @@ shield:
   name: adafruit_data_logger
   full_name: Adafruit Data Logger Shield
   vendor: adafruit
+  supported_features:
+    - rtc
+    - sdhc

--- a/boards/shields/adafruit_neopixel_grid_bff/shield.yml
+++ b/boards/shields/adafruit_neopixel_grid_bff/shield.yml
@@ -2,7 +2,12 @@ shields:
   - name: adafruit_neopixel_grid_bff
     full_name: Adafruit NeoPixel Grid BFF
     vendor: adafruit
+    supported_features:
+      - led_strip
 
   - name: adafruit_neopixel_grid_bff_display
     full_name: Adafruit NeoPixel Grid BFF (with display matrix)
     vendor: adafruit
+    supported_features:
+      - led_strip
+      - display

--- a/boards/shields/adafruit_pca9685/shield.yml
+++ b/boards/shields/adafruit_pca9685/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: adafruit_pca9685
   full_name: Adafruit PCA9685 PWM Shield
   vendor: adafruit
+  supported_features:
+    - pwm

--- a/boards/shields/adafruit_winc1500/shield.yml
+++ b/boards/shields/adafruit_winc1500/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: adafruit_winc1500
   full_name: Adafruit WINC1500 WiFi Shield
   vendor: adafruit
+  supported_features:
+    - wifi

--- a/boards/shields/amg88xx/shield.yml
+++ b/boards/shields/amg88xx/shield.yml
@@ -2,7 +2,11 @@ shields:
   - name: amg88xx_grid_eye_eval_shield
     full_name: Panasonic Grid-EYE Evaluation Shield
     vendor: panasonic
+    supported_features:
+      - sensor
 
   - name: amg88xx_eval_kit
     full_name: Panasonic Grid-EYE Evaluation Kit
     vendor: panasonic
+    supported_features:
+      - sensor

--- a/boards/shields/arceli_eth_w5500/shield.yml
+++ b/boards/shields/arceli_eth_w5500/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: arceli_eth_w5500
   full_name: Arceli ETH W5500 Shield
   vendor: wiznet
+  supported_features:
+    - ethernet

--- a/boards/shields/arduino_giga_display_shield/shield.yml
+++ b/boards/shields/arduino_giga_display_shield/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: arduino_giga_display_shield
   full_name: Arduino GIGA Display Shield
   vendor: arduino
+  supported_features:
+    - display

--- a/boards/shields/arduino_modulino_buttons/shield.yml
+++ b/boards/shields/arduino_modulino_buttons/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: arduino_modulino_buttons
   full_name: Arduino Modulino Buttons
   vendor: arduino
+  supported_features:
+    - input
+    - led

--- a/boards/shields/arduino_modulino_smartleds/shield.yml
+++ b/boards/shields/arduino_modulino_smartleds/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: arduino_modulino_smartleds
   full_name: Arduino Modulino SmartLEDs
   vendor: arduino
+  supported_features:
+    - led_strip

--- a/boards/shields/arduino_uno_click/shield.yml
+++ b/boards/shields/arduino_uno_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: arduino_uno_click
   full_name: Arduino UNO Click
   vendor: arduino
+  supported_features:
+    - gpio

--- a/boards/shields/atmel_rf2xx/shield.yml
+++ b/boards/shields/atmel_rf2xx/shield.yml
@@ -2,18 +2,33 @@ shields:
   - name: atmel_rf2xx
     full_name: Atmel AT86RF2XX Transceiver
     vendor: atmel
+
   - name: atmel_rf2xx_arduino
     full_name: Atmel AT86RF2XX Transceiver for Arduino
     vendor: atmel
+    supported_features:
+      - ieee802154
+
   - name: atmel_rf2xx_legacy
     full_name: Atmel AT86RF2XX Transceiver for Atmel Xplained (legacy)
     vendor: atmel
+    supported_features:
+      - ieee802154
+
   - name: atmel_rf2xx_mikrobus
     full_name: Atmel AT86RF2XX Transceiver for MikroBUS
     vendor: atmel
+    supported_features:
+      - ieee802154
+
   - name: atmel_rf2xx_xplained
     full_name: Atmel AT86RF2XX Transceiver for Atmel Xplained
     vendor: atmel
+    supported_features:
+      - ieee802154
+
   - name: atmel_rf2xx_xpro
     full_name: Atmel AT86RF2XX Transceiver for Atmel Xplained Pro
     vendor: atmel
+    supported_features:
+      - ieee802154

--- a/boards/shields/boostxl_ulpsense/shield.yml
+++ b/boards/shields/boostxl_ulpsense/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: boostxl_ulpsense
   full_name: BOOSTXL-ULPSENSE
   vendor: ti
+  supported_features:
+    - sensor

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/shield.yml
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: buydisplay_2_8_tft_touch_arduino
   full_name: BuyDisplay 2.8" TFT Touch Shield
   vendor: gooddisplay
+  supported_features:
+    - input
+    - display

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/shield.yml
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: buydisplay_3_5_tft_touch_arduino
   full_name: BuyDisplay 3.5" TFT Touch Shield
   vendor: gooddisplay
+  supported_features:
+    - input
+    - display

--- a/boards/shields/dac80508_evm/shield.yml
+++ b/boards/shields/dac80508_evm/shield.yml
@@ -2,3 +2,5 @@ shields:
   - name: dac80508_evm
     full_name: DAC80508 Evaluation Module
     vendor: ti
+    supported_features:
+      - dac

--- a/boards/shields/dvp_20pin_ov7670/shield.yml
+++ b/boards/shields/dvp_20pin_ov7670/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: dvp_20pin_ov7670
   full_name: DVP 20-pin OV7670 Camera Shield
   vendor: ovti
+  supported_features:
+    - video

--- a/boards/shields/dvp_fpc24_mt9m114/shield.yml
+++ b/boards/shields/dvp_fpc24_mt9m114/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: dvp_fpc24_mt9m114
   full_name: DVP FPC-24 MT9M114 Camera Module
   vendor: aptina
+  supported_features:
+    - video

--- a/boards/shields/esp_8266/shield.yml
+++ b/boards/shields/esp_8266/shield.yml
@@ -2,11 +2,17 @@ shields:
   - name: esp_8266
     full_name: ESP-8266 Module
     vendor: espressif
+    supported_features:
+      - wifi
 
   - name: esp_8266_arduino
     full_name: ESP-8266 Module (Arduino)
     vendor: espressif
+    supported_features:
+      - wifi
 
   - name: esp_8266_mikrobus
     full_name: ESP-8266 Module (MikroBus)
     vendor: espressif
+    supported_features:
+      - wifi

--- a/boards/shields/eval_ad4052_ardz/shield.yml
+++ b/boards/shields/eval_ad4052_ardz/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: eval_ad4052_ardz
   full_name: AD4052 Evaluation Shield
   vendor: adi
+  supported_features:
+    - adc

--- a/boards/shields/eval_adxl362_ardz/shield.yml
+++ b/boards/shields/eval_adxl362_ardz/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: eval_adxl362_ardz
   full_name: ADXL362 Evaluation Shield
   vendor: adi
+  supported_features:
+    - sensor

--- a/boards/shields/eval_adxl367_ardz/shield.yml
+++ b/boards/shields/eval_adxl367_ardz/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: eval_adxl367_ardz
   full_name: ADXL367 Evaluation Shield
   vendor: adi
+  supported_features:
+    - sensor

--- a/boards/shields/eval_adxl372_ardz/shield.yml
+++ b/boards/shields/eval_adxl372_ardz/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: eval_adxl372_ardz
   full_name: ADXL372 Evaluation Shield
   vendor: adi
+  supported_features:
+    - sensor

--- a/boards/shields/frdm_cr20a/shield.yml
+++ b/boards/shields/frdm_cr20a/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: frdm_cr20a
   full_name: FRDM-CR20A
   vendor: nxp
+  supported_features:
+    - ieee802154

--- a/boards/shields/frdm_kw41z/shield.yml
+++ b/boards/shields/frdm_kw41z/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: frdm_kw41z
   full_name: FRDM-KW41Z
   vendor: nxp
+  supported_features:
+    - bluetooth

--- a/boards/shields/frdm_stbc_agm01/shield.yml
+++ b/boards/shields/frdm_stbc_agm01/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: frdm_stbc_agm01
   full_name: FRDM-ST BC-AGM01
   vendor: nxp
+  supported_features:
+    - sensor

--- a/boards/shields/ftdi_vm800c/shield.yml
+++ b/boards/shields/ftdi_vm800c/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: ftdi_vm800c
   full_name: FTDI VM800C Display Shield
   vendor: ftdi
+  supported_features:
+    - display

--- a/boards/shields/g1120b0mipi/shield.yml
+++ b/boards/shields/g1120b0mipi/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: g1120b0mipi
   full_name: G1120B0 MIPI Display Shield
   vendor: boe
+  supported_features:
+    - display

--- a/boards/shields/inventek_eswifi/shield.yml
+++ b/boards/shields/inventek_eswifi/shield.yml
@@ -6,7 +6,11 @@ shields:
   - name: inventek_eswifi_arduino_spi
     full_name: Inventek es-WIFI Shield (SPI)
     vendor: inventek
+    supported_features:
+      - wifi
 
   - name: inventek_eswifi_arduino_uart
     full_name: Inventek es-WIFI Mini Shield (UART)
     vendor: inventek
+    supported_features:
+      - wifi

--- a/boards/shields/lcd_par_s035/shield.yml
+++ b/boards/shields/lcd_par_s035/shield.yml
@@ -2,7 +2,13 @@ shields:
   - name: lcd_par_s035_8080
     full_name: NXP LCD_PAR_S035 TFT LCD Module (Parallel)
     vendor: nxp
+    supported_features:
+      - input
+      - display
 
   - name: lcd_par_s035_spi
     full_name: NXP LCD_PAR_S035 TFT LCD Module (SPI)
     vendor: nxp
+    supported_features:
+      - input
+      - display

--- a/boards/shields/link_board_eth/shield.yml
+++ b/boards/shields/link_board_eth/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: link_board_eth
   full_name: link board ETH
   vendor: phytec
+  supported_features:
+    - ethernet

--- a/boards/shields/lmp90100_evb/shield.yml
+++ b/boards/shields/lmp90100_evb/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: lmp90100_evb
   full_name: LMP90100 Sensor AFE Evaluation Board
   vendor: ti
+  supported_features:
+    - adc
+    - mtd

--- a/boards/shields/ls0xx_generic/shield.yml
+++ b/boards/shields/ls0xx_generic/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: ls013b7dh03
   full_name: Sharp memory display generic shield
   vendor: sharp
+  supported_features:
+    - display

--- a/boards/shields/m5stack_cardputer/shield.yml
+++ b/boards/shields/m5stack_cardputer/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: m5stack_cardputer
   full_name: M5Stack Cardputer
   vendor: m5stack
+  supported_features:
+    - display
+    - sdhc

--- a/boards/shields/m5stack_core2_ext/shield.yml
+++ b/boards/shields/m5stack_core2_ext/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: m5stack_core2_ext
   full_name: M5Stack-Core2 base shield
   vendor: m5stack
+  supported_features:
+    - sensor

--- a/boards/shields/max3421e/shield.yml
+++ b/boards/shields/max3421e/shield.yml
@@ -2,3 +2,5 @@ shields:
   - name: sparkfun_max3421e
     full_name: SparkFun USB Host Shield
     vendor: sparkfun
+    supported_features:
+      - usb

--- a/boards/shields/max7219/shield.yml
+++ b/boards/shields/max7219/shield.yml
@@ -2,3 +2,5 @@ shields:
   - name: max7219_8x8
     full_name: MAX7219 8x8 Display shield
     vendor: others
+    supported_features:
+      - display

--- a/boards/shields/mcp2515/shield.yml
+++ b/boards/shields/mcp2515/shield.yml
@@ -2,11 +2,17 @@ shields:
   - name: adafruit_can_picowbell
     full_name: PiCowbell CAN Bus for Pico
     vendor: adafruit
+    supported_features:
+      - can
 
   - name: dfrobot_can_bus_v2_0
     full_name: CAN-BUS Shield V2
     vendor: dfrobot
+    supported_features:
+      - can
 
   - name: keyestudio_can_bus_ks0411
     full_name: Keyestudio CAN-BUS Shield
     vendor: others
+    supported_features:
+      - can

--- a/boards/shields/mikroe_accel13_click/shield.yml
+++ b/boards/shields/mikroe_accel13_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: mikroe_accel13_click
   full_name: ACCEL 13 Click
   vendor: mikroe
+  supported_features:
+    - sensor

--- a/boards/shields/mikroe_adc_click/shield.yml
+++ b/boards/shields/mikroe_adc_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: mikroe_adc_click
   full_name: ADC Click
   vendor: mikroe
+  supported_features:
+    - adc

--- a/boards/shields/mikroe_ble_tiny_click/shield.yml
+++ b/boards/shields/mikroe_ble_tiny_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: mikroe_ble_tiny_click
   full_name: BLE TINY Click
   vendor: mikroe
+  supported_features:
+    - bluetooth

--- a/boards/shields/mikroe_eth3_click/shield.yml
+++ b/boards/shields/mikroe_eth3_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: mikroe_eth3_click
   full_name: ETH3 Click
   vendor: mikroe
+  supported_features:
+    - ethernet

--- a/boards/shields/mikroe_eth_click/shield.yml
+++ b/boards/shields/mikroe_eth_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: mikroe_eth_click
   full_name: ETH Click
   vendor: mikroe
+  supported_features:
+    - ethernet

--- a/boards/shields/mikroe_lte_iot10_click/shield.yml
+++ b/boards/shields/mikroe_lte_iot10_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: mikroe_lte_iot10_click
   full_name: LTE IoT 10 Click
   vendor: mikroe
+  supported_features:
+    - modem

--- a/boards/shields/mikroe_mcp2518fd_click/shield.yml
+++ b/boards/shields/mikroe_mcp2518fd_click/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: mikroe_mcp2518fd_click
   full_name: MikroElektronika MCP2518FD Click shield
   vendor: mikroe
+  supported_features:
+    - can

--- a/boards/shields/mikroe_weather_click/shield.yml
+++ b/boards/shields/mikroe_weather_click/shield.yml
@@ -6,7 +6,11 @@ shields:
   - name: mikroe_weather_click_i2c
     full_name: Weather Click (I2C)
     vendor: mikroe
+    supported_features:
+      - sensor
 
   - name: mikroe_weather_click_spi
     full_name: Weather Click (SPI)
     vendor: mikroe
+    supported_features:
+      - sensor

--- a/boards/shields/mikroe_wifi_bt_click/shield.yml
+++ b/boards/shields/mikroe_wifi_bt_click/shield.yml
@@ -2,7 +2,11 @@ shields:
   - name: mikroe_wifi_bt_click_arduino
     full_name: WIFI BLE Click (Arduino)
     vendor: mikroe
+    supported_features:
+      - wifi
 
   - name: mikroe_wifi_bt_click_mikrobus
     full_name: WIFI BLE Click (MikroBus)
     vendor: mikroe
+    supported_features:
+      - wifi

--- a/boards/shields/npm1100_ek/shield.yml
+++ b/boards/shields/npm1100_ek/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: npm1100_ek
   full_name: nPM1100 EK
   vendor: nordic
+  supported_features:
+    - regulator

--- a/boards/shields/npm1300_ek/shield.yml
+++ b/boards/shields/npm1300_ek/shield.yml
@@ -2,3 +2,10 @@ shield:
   name: npm1300_ek
   full_name: nPM1300 EK
   vendor: nordic
+  supported_features:
+    - mfd
+    - input
+    - gpio
+    - led
+    - regulator
+    - sensor

--- a/boards/shields/npm2100_ek/shield.yml
+++ b/boards/shields/npm2100_ek/shield.yml
@@ -2,3 +2,11 @@ shield:
   name: npm2100_ek
   full_name: nPM2100 EK
   vendor: nordic
+  supported_features:
+    - mfd
+    - input
+    - gpio
+    - led
+    - regulator
+    - sensor
+    - watchdog

--- a/boards/shields/npm6001_ek/shield.yml
+++ b/boards/shields/npm6001_ek/shield.yml
@@ -2,3 +2,8 @@ shield:
   name: npm6001_ek
   full_name: nPM6001 EK
   vendor: nordic
+  supported_features:
+    - mfd
+    - gpio
+    - watchdog
+    - regulator

--- a/boards/shields/nrf7002eb/shield.yml
+++ b/boards/shields/nrf7002eb/shield.yml
@@ -2,7 +2,11 @@ shields:
   - name: nrf7002eb
     full_name: nRF7002 Evaluation Board Shield
     vendor: nordic
+    supported_features:
+      - wifi
 
   - name: nrf7002eb_coex
     full_name: nRF7002 Evaluation Board Shield (SR Co-Existence)
     vendor: nordic
+    supported_features:
+      - wifi

--- a/boards/shields/nrf7002ek/shield.yml
+++ b/boards/shields/nrf7002ek/shield.yml
@@ -2,15 +2,23 @@ shields:
   - name: nrf7002ek
     full_name: nRF7002 Evaluation Kit Shield
     vendor: nordic
+    supported_features:
+      - wifi
 
   - name: nrf7002ek_nrf7000
     full_name: nRF7002 Evaluation Kit Shield (nRF7000)
     vendor: nordic
+    supported_features:
+      - wifi
 
   - name: nrf7002ek_nrf7001
     full_name: nRF7002 Evaluation Kit Shield (nRF7001)
     vendor: nordic
+    supported_features:
+      - wifi
 
   - name: nrf7002ek_coex
     full_name: nRF7002 Evaluation Kit Shield (SR Co-Existence)
     vendor: nordic
+    supported_features:
+      - wifi

--- a/boards/shields/nxp_btb44_ov5640/shield.yml
+++ b/boards/shields/nxp_btb44_ov5640/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: nxp_btb44_ov5640
   full_name: NXP BTB44 OV5640 Camera Module
   vendor: nxp
+  supported_features:
+    - video

--- a/boards/shields/nxp_m2_wifi_bt/shield.yml
+++ b/boards/shields/nxp_m2_wifi_bt/shield.yml
@@ -2,7 +2,13 @@ shields:
   - name: nxp_m2_1xk_wifi_bt
     full_name: NXP M2 WiFi/BT Shield (Murata 1XK)
     vendor: nxp
+    supported_features:
+      - bluetooth
+      - wifi
 
   - name: nxp_m2_2el_wifi_bt
     full_name: NXP M2 WiFi/BT Shield (Murata 2EL)
     vendor: nxp
+    supported_features:
+      - bluetooth
+      - wifi

--- a/boards/shields/p3t1755dp_ard_i2c/shield.yml
+++ b/boards/shields/p3t1755dp_ard_i2c/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: p3t1755dp_ard_i2c
   full_name: P3T1755DP Arduino I2C Shield
   vendor: nxp
+  supported_features:
+    - sensor

--- a/boards/shields/p3t1755dp_ard_i3c/shield.yml
+++ b/boards/shields/p3t1755dp_ard_i3c/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: p3t1755dp_ard_i3c
   full_name: P3T1755DP Arduino I3C Shield
   vendor: nxp
+  supported_features:
+    - sensor

--- a/boards/shields/pmod_acl/shield.yml
+++ b/boards/shields/pmod_acl/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: pmod_acl
   full_name: Digilent Pmod ACL
   vendor: digilent
+  supported_features:
+    - sensor

--- a/boards/shields/pmod_sd/shield.yml
+++ b/boards/shields/pmod_sd/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: pmod_sd
   full_name: Pmod SD Card Shield
   vendor: digilent
+  supported_features:
+    - sd

--- a/boards/shields/renesas_us159_da14531evz/shield.yml
+++ b/boards/shields/renesas_us159_da14531evz/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: renesas_us159_da14531evz
   full_name: US159-DA14531EVZ Pmod
   vendor: renesas
+  supported_features:
+    - bluetooth

--- a/boards/shields/reyax_lora/shield.yml
+++ b/boards/shields/reyax_lora/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: reyax_lora
   full_name: Reyax LoRa RYLR896 and RYLR915 Modules
   vendor: reyax
+  supported_features:
+    - lora

--- a/boards/shields/rk043fn02h_ct/shield.yml
+++ b/boards/shields/rk043fn02h_ct/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: rk043fn02h_ct
   full_name: RK043FN02H-CT 4.3" LCD Panel
   vendor: nxp
+  supported_features:
+    - input
+    - display

--- a/boards/shields/rk043fn66hs_ctg/shield.yml
+++ b/boards/shields/rk043fn66hs_ctg/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: rk043fn66hs_ctg
   full_name: RK043FN66HS-CTG 4.3" LCD Panel
   vendor: nxp
+  supported_features:
+    - input
+    - display

--- a/boards/shields/rk055hdmipi4m/shield.yml
+++ b/boards/shields/rk055hdmipi4m/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: rk055hdmipi4m
   full_name: RK055HDMIPI4M 5.5" LCD Panel
   vendor: nxp
+  supported_features:
+    - display
+    - input

--- a/boards/shields/rk055hdmipi4ma0/shield.yml
+++ b/boards/shields/rk055hdmipi4ma0/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: rk055hdmipi4ma0
   full_name: RK055HDMIPI4MA0 5.5" LCD Panel
   vendor: nxp
+  supported_features:
+    - display
+    - input

--- a/boards/shields/rpi_pico_uno_flexypin/shield.yml
+++ b/boards/shields/rpi_pico_uno_flexypin/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: rpi_pico_uno_flexypin
   full_name: Raspberry Pi Pico to UNO FlexyPin Adapter
   vendor: others
+  supported_features:
+    - gpio

--- a/boards/shields/rtk7eka6m3b00001bu/shield.yml
+++ b/boards/shields/rtk7eka6m3b00001bu/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: rtk7eka6m3b00001bu
   full_name: RTK7EKA6M3B00001BU Display
   vendor: renesas
+  supported_features:
+    - input
+    - display

--- a/boards/shields/rtkmipilcdb00000be/shield.yml
+++ b/boards/shields/rtkmipilcdb00000be/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: rtkmipilcdb00000be
   full_name: RTKMIPILCDB00000BE MIPI Display
   vendor: renesas
+  supported_features:
+    - input
+    - display

--- a/boards/shields/seeed_w5500/shield.yml
+++ b/boards/shields/seeed_w5500/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: seeed_w5500
   full_name: W5500 Ethernet Shield
   vendor: seeed
+  supported_features:
+    - ethernet

--- a/boards/shields/seeed_xiao_expansion_board/shield.yml
+++ b/boards/shields/seeed_xiao_expansion_board/shield.yml
@@ -2,3 +2,8 @@ shield:
   name: seeed_xiao_expansion_board
   full_name: Expansion Board Base for XIAO
   vendor: seeed
+  supported_features:
+    - input
+    - rtc
+    - display
+    - sdhc

--- a/boards/shields/seeed_xiao_round_display/shield.yml
+++ b/boards/shields/seeed_xiao_round_display/shield.yml
@@ -2,3 +2,8 @@ shield:
   name: seeed_xiao_round_display
   full_name: Round Display for XIAO
   vendor: seeed
+  supported_features:
+    - display
+    - input
+    - rtc
+    - sdhc

--- a/boards/shields/semtech_sx1262mb2das/shield.yml
+++ b/boards/shields/semtech_sx1262mb2das/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: semtech_sx1262mb2das
   full_name: Semtech SX1262MB2DAS LoRa Shield
   vendor: semtech
+  supported_features:
+    - lora

--- a/boards/shields/semtech_sx1272mb2das/shield.yml
+++ b/boards/shields/semtech_sx1272mb2das/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: semtech_sx1272mb2das
   full_name: SX1272MB2DAS LoRa Shield
   vendor: semtech
+  supported_features:
+    - lora

--- a/boards/shields/semtech_sx1276mb1mas/shield.yml
+++ b/boards/shields/semtech_sx1276mb1mas/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: semtech_sx1276mb1mas
   full_name: SX1276MB1MAS LoRa Shield
   vendor: semtech
+  supported_features:
+    - lora

--- a/boards/shields/sparkfun_carrier_asset_tracker/shield.yml
+++ b/boards/shields/sparkfun_carrier_asset_tracker/shield.yml
@@ -2,3 +2,7 @@ shield:
   name: sparkfun_carrier_asset_tracker
   full_name: SparkFun MicroMod Asset Tracker Shield
   vendor: sparkfun
+  supported_features:
+    - modem
+    - sdhc
+    - fuel-gauge

--- a/boards/shields/sparkfun_sara_r4/shield.yml
+++ b/boards/shields/sparkfun_sara_r4/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: sparkfun_sara_r4
   full_name: Sparkfun Sara R4
   vendor: sparkfun
+  supported_features:
+    - modem

--- a/boards/shields/ssd1306/shield.yml
+++ b/boards/shields/ssd1306/shield.yml
@@ -2,15 +2,23 @@ shields:
   - name: ssd1306_128x32
     full_name: SSD1306 128x32 pixels generic shield
     vendor: others
+    supported_features:
+      - display
 
   - name: ssd1306_128x64
     full_name: SSD1306 128x64 pixels generic shield
     vendor: others
+    supported_features:
+      - display
 
   - name: ssd1306_128x64_spi
     full_name: SSD1306 128x64 pixels generic shield (SPI)
     vendor: others
+    supported_features:
+      - display
 
   - name: sh1106_128x64
     full_name: SH1106 128x64 pixels generic shield
     vendor: others
+    supported_features:
+      - display

--- a/boards/shields/st7735r/shield.yml
+++ b/boards/shields/st7735r/shield.yml
@@ -2,3 +2,5 @@ shields:
   - name: st7735r_ada_160x128
     full_name: Adafruit 160x128 1.8" SPI TFT display
     vendor: adafruit
+    supported_features:
+      - display

--- a/boards/shields/st7789v_generic/shield.yml
+++ b/boards/shields/st7789v_generic/shield.yml
@@ -2,7 +2,11 @@ shields:
   - name: st7789v_tl019fqv01
     full_name: ST7789V TL019FQV01
     vendor: others
+    supported_features:
+      - display
 
   - name: st7789v_waveshare_240x240
     full_name: Waveshare 240x240 1.3inch IPS LCD
     vendor: waveshare
+    supported_features:
+      - display

--- a/boards/shields/st_b_cams_imx_mb1854/shield.yml
+++ b/boards/shields/st_b_cams_imx_mb1854/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: st_b_cams_imx_mb1854
   full_name: ST B-CAMS-IMX-MB1854
   vendor: st
+  supported_features:
+    - video

--- a/boards/shields/st_b_cams_omv_mb1683/shield.yml
+++ b/boards/shields/st_b_cams_omv_mb1683/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: st_b_cams_omv_mb1683
   full_name: ST B-CAMS-OMV MB1683 Camera Shield
   vendor: st
+  supported_features:
+    - video

--- a/boards/shields/st_b_lcd40_dsi1_mb1166/shield.yml
+++ b/boards/shields/st_b_lcd40_dsi1_mb1166/shield.yml
@@ -2,7 +2,13 @@ shields:
   - name: st_b_lcd40_dsi1_mb1166
     full_name: ST B-LCD40-DSI1
     vendor: st
+    supported_features:
+      - input
+      - display
 
   - name: st_b_lcd40_dsi1_mb1166_a09
     full_name: ST B-LCD40-DSI1 (MB1166-A09)
     vendor: st
+    supported_features:
+      - input
+      - display

--- a/boards/shields/tcan4550evm/shield.yml
+++ b/boards/shields/tcan4550evm/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: tcan4550evm
   full_name: Texas Instruments TCAN4550EVM
   vendor: ti
+  supported_features:
+    - can

--- a/boards/shields/ti_bp_bassensorsmkii/shield.yml
+++ b/boards/shields/ti_bp_bassensorsmkii/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: ti_bp_bassensorsmkii
   full_name: BP-BASSENSORSMKII
   vendor: ti
+  supported_features:
+    - sensor

--- a/boards/shields/v2c_daplink/shield.yml
+++ b/boards/shields/v2c_daplink/shield.yml
@@ -2,7 +2,13 @@ shields:
   - name: v2c_daplink
     full_name: ARM V2C-DAPLink for DesignStart FPGA
     vendor: arm
+    supported_features:
+      - mtd
+      - sdhc
 
   - name: v2c_daplink_cfg
     full_name: ARM V2C-DAPLink for DesignStart FPGA (boot from QSPI)
     vendor: arm
+    supported_features:
+      - mtd
+      - sdhc

--- a/boards/shields/waveshare_epaper/shield.yml
+++ b/boards/shields/waveshare_epaper/shield.yml
@@ -2,31 +2,47 @@ shields:
   - name: waveshare_epaper_gdeh029a1
     full_name: WAVESHARE e-Paper GDEH029A1
     vendor: waveshare
+    supported_features:
+      - display
 
   - name: waveshare_epaper_gdeh0154a07
     full_name: WAVESHARE e-Paper GDEH0154A07
     vendor: waveshare
+    supported_features:
+      - display
 
   - name: waveshare_epaper_gdeh0213b1
     full_name: WAVESHARE e-Paper GDEH0213B1
     vendor: waveshare
+    supported_features:
+      - display
 
   - name: waveshare_epaper_gdeh0213b72
     full_name: WAVESHARE e-Paper GDEH0213B72
     vendor: waveshare
+    supported_features:
+      - display
 
   - name: waveshare_epaper_gdew042t2-p
     full_name: WAVESHARE e-Paper GDEW042T2-P
     vendor: waveshare
+    supported_features:
+      - display
 
   - name: waveshare_epaper_gdew042t2
     full_name: WAVESHARE e-Paper GDEW042T2
     vendor: waveshare
+    supported_features:
+      - display
 
   - name: waveshare_epaper_gdew075t7
     full_name: WAVESHARE e-Paper GDEW075T7
     vendor: waveshare
+    supported_features:
+      - display
 
   - name: waveshare_epaper_gdey0213b74
     full_name: WAVESHARE e-Paper GDEY0213B74
     vendor: waveshare
+    supported_features:
+      - display

--- a/boards/shields/waveshare_pico_lcd_1_14/shield.yml
+++ b/boards/shields/waveshare_pico_lcd_1_14/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: waveshare_pico_lcd_1_14
   full_name: Waveshare Pico LCD 1.14"
   vendor: waveshare
+  supported_features:
+    - display
+    - input

--- a/boards/shields/waveshare_pico_oled_1_3/shield.yml
+++ b/boards/shields/waveshare_pico_oled_1_3/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: waveshare_pico_oled_1_3
   full_name: Waveshare Pico OLED 1.3"
   vendor: waveshare
+  supported_features:
+    - display
+    - input

--- a/boards/shields/waveshare_ups/shield.yml
+++ b/boards/shields/waveshare_ups/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: waveshare_pico_ups_b
   full_name: Waveshare Pico UPS-B shield
   vendor: waveshare
+  supported_features:
+    - sensor

--- a/boards/shields/weact_ov2640_cam_module/shield.yml
+++ b/boards/shields/weact_ov2640_cam_module/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: weact_ov2640_cam_module
   full_name: WeAct OV2640 Camera Module Shield
   vendor: weact
+  supported_features:
+    - video

--- a/boards/shields/x_nucleo_53l0a1/shield.yml
+++ b/boards/shields/x_nucleo_53l0a1/shield.yml
@@ -2,3 +2,6 @@ shield:
   name: x_nucleo_53l0a1
   full_name: X-NUCLEO-53L0A1
   vendor: st
+  supported_features:
+    - gpio
+    - sensor

--- a/boards/shields/x_nucleo_bnrg2a1/shield.yml
+++ b/boards/shields/x_nucleo_bnrg2a1/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: x_nucleo_bnrg2a1
   full_name: X-NUCLEO-BNRG2A1
   vendor: st
+  supported_features:
+    - bluetooth

--- a/boards/shields/x_nucleo_eeprma2/shield.yml
+++ b/boards/shields/x_nucleo_eeprma2/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: x_nucleo_eeprma2
   full_name: X-NUCLEO-EEPRMA2
   vendor: st
+  supported_features:
+    - mtd

--- a/boards/shields/x_nucleo_gfx01m2/shield.yml
+++ b/boards/shields/x_nucleo_gfx01m2/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: x_nucleo_gfx01m2
   full_name: X-NUCLEO-GFX01M2 Display Shield
   vendor: st
+  supported_features:
+    - display

--- a/boards/shields/x_nucleo_idb05a1/shield.yml
+++ b/boards/shields/x_nucleo_idb05a1/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: x_nucleo_idb05a1
   full_name: X-NUCLEO-IDB05A1
   vendor: st
+  supported_features:
+    - bluetooth

--- a/boards/shields/x_nucleo_iks01a1/shield.yml
+++ b/boards/shields/x_nucleo_iks01a1/shield.yml
@@ -2,3 +2,5 @@ shield:
   name: x_nucleo_iks01a1
   full_name: X-NUCLEO-IKS01A1
   vendor: st
+  supported_features:
+    - sensor

--- a/boards/shields/x_nucleo_iks01a2/shield.yml
+++ b/boards/shields/x_nucleo_iks01a2/shield.yml
@@ -2,7 +2,11 @@ shields:
   - name: x_nucleo_iks01a2
     full_name: X-NUCLEO-IKS01A2 (Standard / Mode 1)
     vendor: st
+    supported_features:
+      - sensor
 
   - name: x_nucleo_iks01a2_shub
     full_name: X-NUCLEO-IKS01A2 (SensorHub / Mode 2)
     vendor: st
+    supported_features:
+      - sensor

--- a/boards/shields/x_nucleo_iks01a3/shield.yml
+++ b/boards/shields/x_nucleo_iks01a3/shield.yml
@@ -2,7 +2,11 @@ shields:
   - name: x_nucleo_iks01a3
     full_name: X-NUCLEO-IKS01A3 (Standard / Mode 1)
     vendor: st
+    supported_features:
+      - sensor
 
   - name: x_nucleo_iks01a3_shub
     full_name: X-NUCLEO-IKS01A3 (SensorHub / Mode 2)
     vendor: st
+    supported_features:
+      - sensor

--- a/boards/shields/x_nucleo_iks02a1/shield.yml
+++ b/boards/shields/x_nucleo_iks02a1/shield.yml
@@ -2,11 +2,18 @@ shields:
   - name: x_nucleo_iks02a1
     full_name: X-NUCLEO-IKS02A1 (Standard / Mode 1)
     vendor: st
+    supported_features:
+      - sensor
 
   - name: x_nucleo_iks02a1_shub
     full_name: X-NUCLEO-IKS02A1 (SensorHub / Mode 2)
     vendor: st
+    supported_features:
+      - sensor
 
   - name: x_nucleo_iks02a1_mic
     full_name: X-NUCLEO-IKS02A1 (Microphone)
     vendor: st
+    supported_features:
+      - sensor
+      - audio

--- a/boards/shields/x_nucleo_iks4a1/shield.yml
+++ b/boards/shields/x_nucleo_iks4a1/shield.yml
@@ -2,11 +2,17 @@ shields:
   - name: x_nucleo_iks4a1
     full_name: X-NUCLEO-IKS4A1 (Mode 1)
     vendor: st
+    supported_features:
+      - sensor
 
   - name: x_nucleo_iks4a1_shub1
     full_name: X-NUCLEO-IKS4A1 (Mode 3)
     vendor: st
+    supported_features:
+      - sensor
 
   - name: x_nucleo_iks4a1_shub2
     full_name: X-NUCLEO-IKS4A1 (Mode 2)
     vendor: st
+    supported_features:
+      - sensor

--- a/boards/shields/x_nucleo_wb05kn1/shield.yml
+++ b/boards/shields/x_nucleo_wb05kn1/shield.yml
@@ -2,7 +2,11 @@ shields:
   - name: x_nucleo_wb05kn1_spi
     full_name: X-NUCLEO-WB05KN1 (SPI)
     vendor: st
+    supported_features:
+      - bluetooth
 
   - name: x_nucleo_wb05kn1_uart
     full_name: X-NUCLEO-WB05KN1 (UART)
     vendor: st
+    supported_features:
+      - bluetooth

--- a/doc/_extensions/zephyr/domain/templates/shield-card.html
+++ b/doc/_extensions/zephyr/domain/templates/shield-card.html
@@ -13,7 +13,15 @@
   aria-label="Open the documentation page for {{ shield.full_name }}"
   data-name="{{ shield.full_name}}"
   data-vendor="{{ shield.vendor }}"
-  tabindex="0">
+  data-supported-features="
+    {%- set feature_types = [] -%}
+    {%- for feature in shield.supported_features -%}
+      {%- if feature not in feature_types -%}
+        {%- set _ = feature_types.append(feature) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {{- feature_types|join(' ') -}}
+  " tabindex="0">
   <div class="vendor">{{ vendors[shield.vendor] }}</div>
   {% if shield.image -%}
   <img alt="A picture of the {{ shield.full_name }} shield"

--- a/doc/_scripts/gen_boards_catalog.py
+++ b/doc/_scripts/gen_boards_catalog.py
@@ -416,6 +416,7 @@ def get_catalog(generate_hw_features=False, hw_features_vendor_filter=None):
             "vendor": shield.vendor or "others",
             "doc_page": doc_page_path,
             "image": guess_image(shield),
+            "supported_features": shield.supported_features or [],
         }
 
     return {

--- a/doc/hardware/porting/shields.rst
+++ b/doc/hardware/porting/shields.rst
@@ -33,6 +33,11 @@ These files provides shield configuration as follows:
   * ``name``: Name of the shield used in Kconfig and build system (required)
   * ``full_name``: Full commercial name of the shield (required)
   * ``vendor``: Manufacturer/vendor of the shield (required)
+  * ``supported_features``: List of hardware features the shield supports (optional). In order to
+    help users identify the features a shield supports without having to dig into its overlay file,
+    the ``supported_features`` field can be used to list the types of features the shield supports.
+    The values should be the same as the ones defined in the
+    :zephyr_file:`dts/bindings/binding-types.txt` file.
 
   Example:
 
@@ -41,6 +46,9 @@ These files provides shield configuration as follows:
      name: foo_shield
      full_name: Foo Shield for Arduino
      vendor: acme
+     supported_features:
+       - display
+       - input
 
 * **<shield>.overlay**: This file provides a shield description in devicetree
   format that is merged with the board's :ref:`devicetree <dt-guide>`

--- a/scripts/list_shields.py
+++ b/scripts/list_shields.py
@@ -39,6 +39,7 @@ class Shield:
     dir: Path
     full_name: str | None = None
     vendor: str | None = None
+    supported_features: list[str] | None = None
 
 def shield_key(shield):
     return shield.name
@@ -49,7 +50,8 @@ def process_shield_data(shield_data, shield_dir):
         name=shield_data['name'],
         dir=shield_dir,
         full_name=shield_data.get('full_name'),
-        vendor=shield_data.get('vendor')
+        vendor=shield_data.get('vendor'),
+        supported_features=shield_data.get('supported_features', []),
     )
 
 def find_shields(args):

--- a/scripts/schemas/shield-schema.yml
+++ b/scripts/schemas/shield-schema.yml
@@ -21,6 +21,11 @@ schema;shield-schema:
       required: true
       type: str
       desc: Manufacturer/vendor of the shield
+    supported_features:
+      required: false
+      sequence:
+        - type: str
+          desc: A hardware feature the shield supports (see dts/bindings/binding-types.txt)
 
 type: map
 range:


### PR DESCRIPTION
Shield authors can now indicate an optional list of hardware features that the shield supports, in the form of the same kind of "binding type" already used for boards.

List of supported features for boards is dynamically computed based on the board DTS as the list may significantly evolve overtime and get out-of-sync. Shields are much more "static", plus, computing things automagically would likely be tricky, so using a hardcoded list should hopefully be acceptable :)