### PR TITLE
dts: rw6xx: (trivial) fix flexcomm14 node name

### DIFF
--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -293,7 +293,7 @@
 		status = "disabled";
 	};
 
-	flexcomm14: flexcom@126000 {
+	flexcomm14: flexcomm@126000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x126000 0x2000>;
 		interrupts = <20 0>;


### PR DESCRIPTION
Fix a trivial typo (`flexcom` -> `flexcomm`) in the DTS for the NXP RW6xx series.