### PR TITLE
drivers: adc_ad4130|adc_7124: Add ret initialization in *_perform_read()

### DIFF
--- a/drivers/adc/adc_ad4130.c
+++ b/drivers/adc/adc_ad4130.c
@@ -822,7 +822,7 @@ static int adc_ad4130_wait_for_conv_ready(const struct device *dev)
 
 static int adc_ad4130_perform_read(const struct device *dev)
 {
-	int ret;
+	int ret = 0;
 	struct adc_ad4130_data *data = dev->data;
 	uint16_t ch_idx = AD4130_INVALID_CHANNEL;
 	uint16_t prev_ch_idx = AD4130_INVALID_CHANNEL;

--- a/drivers/adc/adc_ad7124.c
+++ b/drivers/adc/adc_ad7124.c
@@ -1119,7 +1119,7 @@ static int adc_ad7124_get_read_chan_id(const struct device *dev, uint16_t *chan_
 
 static int adc_ad7124_perform_read(const struct device *dev)
 {
-	int ret;
+	int ret = 0;
 	struct adc_ad7124_data *data = dev->data;
 	uint16_t ch_idx = -1;
 	uint16_t prev_ch_idx = -1;


### PR DESCRIPTION
Add initialization of `ret` to avoid reports of uninitialized variable being returned. This variable normally gets initialized while the loop iterates over channels, but potentially it could be left uninitialized if the loop finished in its first iteration because of no channels to be processed.

Fixes #90511.
Fixes #90560.