### PR TITLE
drivers: clock_control_nrf: Prevent break from becoming dead code

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -685,6 +685,10 @@ static void clock_event_handler(nrfx_clock_evt_type_t event)
 	case NRFX_CLOCK_EVT_XO_TUNED:
 		clkstarted_handle(dev, CLOCK_CONTROL_NRF_TYPE_HFCLK);
 		break;
+	case NRFX_CLOCK_EVT_XO_TUNE_ERROR:
+	case NRFX_CLOCK_EVT_XO_TUNE_FAILED:
+		/* No processing needed. */
+		break;
 	case NRFX_CLOCK_EVT_HFCLK_STARTED:
 		/* HFCLK is stable after XOTUNED event.
 		 * HFCLK_STARTED means only that clock has been started.
@@ -736,15 +740,9 @@ static void clock_event_handler(nrfx_clock_evt_type_t event)
 #endif
 #if NRF_CLOCK_HAS_PLL
 	case NRFX_CLOCK_EVT_PLL_STARTED:
-#endif
-#if NRF_CLOCK_HAS_XO_TUNE
-	case NRFX_CLOCK_EVT_XO_TUNE_ERROR:
-	case NRFX_CLOCK_EVT_XO_TUNE_FAILED:
-#endif
-	{
-		/* unhandled event */
+		/* No processing needed. */
 		break;
-	}
+#endif
 	default:
 		__ASSERT_NO_MSG(0);
 		break;


### PR DESCRIPTION
When both NRF_CLOCK_HAS_XO_TUNE and NRF_CLOCK_HAS_PLL evaluate to 0, one break statement can end up not associated with any case and become dead code. Refactor a bit the related switch to avoid such situation.

Fixes #90556.