### PR TITLE
drivers: dma: sdma: Make access to DMA channel stats atomic

### DIFF
--- a/drivers/dma/dma_nxp_sdma.c
+++ b/drivers/dma/dma_nxp_sdma.c
@@ -374,11 +374,14 @@ static int dma_nxp_sdma_get_status(const struct device *dev, uint32_t channel,
 {
 	struct sdma_dev_data *dev_data = dev->data;
 	struct sdma_channel_data *chan_data;
+	unsigned int key;
 
 	chan_data = &dev_data->chan[channel];
 
+	key = irq_lock();
 	stat->free = chan_data->stat.free;
 	stat->pending_length = chan_data->stat.pending_length;
+	irq_unlock(key);
 
 	return 0;
 }
@@ -388,6 +391,7 @@ static int dma_nxp_sdma_reload(const struct device *dev, uint32_t channel, uint3
 {
 	struct sdma_dev_data *dev_data = dev->data;
 	struct sdma_channel_data *chan_data;
+	unsigned int key;
 
 	chan_data = &dev_data->chan[channel];
 
@@ -395,11 +399,13 @@ static int dma_nxp_sdma_reload(const struct device *dev, uint32_t channel, uint3
 		return 0;
 	}
 
+	key = irq_lock();
 	if (chan_data->direction == MEMORY_TO_PERIPHERAL) {
 		dma_nxp_sdma_produce(chan_data, size);
 	} else {
 		dma_nxp_sdma_consume(chan_data, size);
 	}
+	irq_unlock(key);
 
 	return 0;
 }


### PR DESCRIPTION
DMA channel stats like pending_length or free is not protected and can be modified in parallel by a consumer and a producer.

This can result in non-atomic updates which in turn will result in using stale data.

Fix this by making regions of code accessing dma stats atomic.


I'm running  a stress test on this over night, please DNM.