### PR TITLE
net: context: Verify if CONFIG_NET_SOCKETS_PACKET_DGRAM is enabled

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -482,6 +482,11 @@ static int net_context_check(sa_family_t family, enum net_sock_type type,
 			NET_DBG("AF_PACKET disabled");
 			return -EPFNOSUPPORT;
 		}
+		if (!IS_ENABLED(CONFIG_NET_SOCKETS_PACKET_DGRAM) &&
+		    type == SOCK_DGRAM) {
+			NET_DBG("DGRAM socket type disabled.");
+			return -EPROTOTYPE;
+		}
 		if (type != SOCK_RAW && type != SOCK_DGRAM) {
 			NET_DBG("AF_PACKET only supports RAW and DGRAM socket "
 				"types.");


### PR DESCRIPTION
Verify if CONFIG_NET_SOCKETS_PACKET_DGRAM is enabled when creating a datagram packet socket. Otherwise, it's possible to create non-functional AF_PACKET/SOCK_DGRAM socket w/o an error.