### PR TITLE
west: runners: nrfutil: Add key file when present to west flash command

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -469,6 +469,14 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
             core = "Application"
 
         self.op_program(self.hex_, erase_arg, ext_mem_erase_opt, defer=True, core=core)
+
+        if self.erase or self.recover:
+            # provision keys if keyfile.json exists in the build directory
+            keyfile = Path(self.cfg.build_dir).parent / 'keyfile.json'
+            if keyfile.exists():
+                self.logger.info(f'Provisioning key file: {keyfile}')
+                self.exec_op('x-provision-keys', keyfile=str(keyfile), defer=True)
+
         self.flush(force=False)
 
 

--- a/scripts/west_commands/runners/nrfutil.py
+++ b/scripts/west_commands/runners/nrfutil.py
@@ -147,6 +147,8 @@ class NrfUtilBinaryRunner(NrfBinaryRunner):
             cmd += ['--reset-kind', _op['kind']]
         elif op_type == 'erase':
             cmd.append(f'--{_op["kind"]}')
+        elif op_type == 'x-provision-keys':
+            cmd += ['--key-file', _op['keyfile']]
 
         cmd += ['--core', op['core']] if op.get('core') else []
         cmd += ['--x-family', f'{self.family}']


### PR DESCRIPTION
Added automatic KMU key provisioning, when keyfile.json
file exists in the build directory.
This enables automated key provisioning during the
flashing process to enable testing nRF54L aplications using Twister.
Only applicable on nrfutil runner.