### PR TITLE
boards: silabs: fix boards DTS files coding style issues

### DIFF
--- a/boards/gardena/sgrm/sgrm.dts
+++ b/boards/gardena/sgrm/sgrm.dts
@@ -15,9 +15,9 @@
 	chosen {
 		zephyr,console = &usart1;
 		zephyr,flash = &flash0;
+		zephyr,ppp-uart = &usart0;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
-		zephyr,ppp-uart = &usart0;
 	};
 };
 
@@ -41,9 +41,9 @@
 
 &usart0 {
 	current-speed = <500000>;
+	hw-flow-control;
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
-	hw-flow-control;
 	status = "okay";
 };
 
@@ -80,13 +80,13 @@
 		#size-cells = <1>;
 
 		slot0_partition: partition@0 {
-			label = "image-0";
 			reg = <0x00000000 DT_SIZE_K(192)>;
+			label = "image-0";
 		};
 
 		storage_partition: partition@30000 {
-			label = "storage";
 			reg = <0x00030000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -14,13 +14,13 @@
 	compatible = "seeed,xiao_mg24", "silabs,efr32mg24";
 
 	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -48,25 +48,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <95>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <44>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_M(78)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -98,19 +98,19 @@
 
 &eusart0 {
 	compatible = "silabs,eusart-uart";
+	current-speed = <115200>;
 	pinctrl-0 = <&eusart0_default>;
 	pinctrl-names = "default";
-	current-speed = <115200>;
 };
 
 &eusart1 {
 	compatible = "silabs,eusart-spi";
-	pinctrl-0 = <&eusart1_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
-	clock-frequency = <4000000>;
 	#address-cells = <1>;
 	#size-cells = <0>;
+	clock-frequency = <4000000>;
+	cs-gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
 };
 
 &i2c0 {
@@ -145,7 +145,6 @@
 
 &gpioc {
 	status = "okay";
-
 };
 
 &gpiod {
@@ -172,27 +171,27 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(48)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 720 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 0x000B8000>;
+			label = "image-0";
 		};
 
 		/* Reserve 720 kB for the application in slot 1 */
 		slot1_partition: partition@C4000 {
-			label = "image-1";
 			reg = <0x000C0000 0x000B8000>;
+			label = "image-1";
 		};
 
 		/* Set 16 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@17c000 {
-			label = "storage";
 			reg = <0x0017c000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk-pinctrl.dtsi
@@ -13,6 +13,7 @@
 				<SI32_MUX(USART0_RTS, 1, 14)>;
 			output-enable;
 		};
+
 		group2 {
 			pinmux = <SI32_MUX(USART0_RX, 1, 13)>,
 				<SI32_MUX(USART0_CTS, 1, 15)>;

--- a/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk.dts
+++ b/boards/silabs/dev_kits/sim3u1xx_dk/sim3u1xx_dk.dts
@@ -24,20 +24,21 @@
 		zephyr,console = &usart0;
 		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
 		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
 		led_red: led_2_10 {
-			label = "Red LED (DS3)";
 			gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>;
+			label = "Red LED (DS3)";
 		};
+
 		led_yellow: led_2_11 {
-			label = "Yellow LED (DS4)";
 			gpios = <&gpio2 11 GPIO_ACTIVE_HIGH>;
+			label = "Yellow LED (DS4)";
 		};
 	};
 
@@ -45,13 +46,14 @@
 		compatible = "gpio-keys";
 
 		user_button_sw2: button_0 {
-			label = "Push button switch (SW2)";
 			gpios = <&gpio2 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch (SW2)";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		user_button_sw3: button_1 {
-			label = "Push button switch (SW3)";
 			gpios = <&gpio2 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button switch (SW3)";
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
@@ -77,9 +79,9 @@
 
 &usart0 {
 	current-speed = <115200>;
+	hw-flow-control;
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
-	hw-flow-control;
 	status = "okay";
 };
 
@@ -100,20 +102,20 @@
 		#size-cells = <1>;
 
 		slot0_partition: partition@0 {
-			label = "image-0";
 			reg = <0x00000000 DT_SIZE_K(192)>;
+			label = "image-0";
 		};
 
 		storage_partition: partition@30000 {
-			label = "storage";
 			reg = <0x00030000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };
 
 &dma {
-	status = "okay";
 	dma-channels = <8>; /* Crypto DMA channels have ID 5, 6, and 7 */
+	status = "okay";
 };
 
 &crypto {

--- a/boards/silabs/dev_kits/sltb004a/sltb004a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb004a/sltb004a-pinctrl.dtsi
@@ -14,6 +14,7 @@
 			psels = <GECKO_PSEL(UART_RX, A, 1)>,
 				<GECKO_LOC(UART_RX, 0)>;
 		};
+
 		group2 {
 			/* configure PA.0 as UART_TX */
 			psels = <GECKO_PSEL(UART_TX, A, 0)>,

--- a/boards/silabs/dev_kits/sltb004a/sltb004a.dts
+++ b/boards/silabs/dev_kits/sltb004a/sltb004a.dts
@@ -26,18 +26,20 @@
 
 	chosen {
 		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiod 8 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiod 9 0>;
 			label = "LED 1";
@@ -46,12 +48,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpiod 14 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpiod 15 GPIO_ACTIVE_LOW>;
@@ -62,7 +66,7 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
-		status = "okay";
+
 		pwm_led0: pwm_led0 {
 			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -86,9 +90,9 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
+	location-clk = <GECKO_LOCATION(18) GECKO_PORT_F GECKO_PIN(7)>;
 	location-rx = <GECKO_LOCATION(30) GECKO_PORT_K GECKO_PIN(2)>;
 	location-tx = <GECKO_LOCATION(29) GECKO_PORT_K GECKO_PIN(0)>;
-	location-clk = <GECKO_LOCATION(18) GECKO_PORT_F GECKO_PIN(7)>;
 
 	cs-gpios = <&gpiok 1 GPIO_ACTIVE_LOW>;
 
@@ -97,8 +101,6 @@
 	mx25r80: mx25r8035f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		size = <0x800000>;
 		jedec-id = [c2 28 14];
 		sfdp-bfp = [
 			 e5 20 f1 ff  ff ff 7f 00  44 eb 08 6b  08 3b 04 bb
@@ -106,6 +108,8 @@
 			 10 d8 00 ff  23 72 f5 00  82 ed 04 b7  44 83 38 44
 			 30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
 		];
+		size = <0x800000>;
+		spi-max-frequency = <80000000>;
 	};
 };
 
@@ -158,14 +162,14 @@
 
 	/* This set selects for ENV_I2C supporting Si7021, Si11330, BMP280 */
 	/*
-	location-sda = <GECKO_LOCATION(17) GECKO_PORT_C GECKO_PIN(4)>;
 	location-scl = <GECKO_LOCATION(17) GECKO_PORT_C GECKO_PIN(5)>;
+	location-sda = <GECKO_LOCATION(17) GECKO_PORT_C GECKO_PIN(4)>;
 	*/
 
 	/* This set selects for HALL_I2C supporting Si7210 */
 	/*
-	location-sda = <GECKO_LOCATION(8) GECKO_PORT_B GECKO_PIN(8)>;
 	location-scl = <GECKO_LOCATION(8) GECKO_PORT_B GECKO_PIN(9)>;
+	location-sda = <GECKO_LOCATION(8) GECKO_PORT_B GECKO_PIN(8)>;
 	*/
 };
 
@@ -178,9 +182,9 @@
 	status = "okay";
 
 	pwm0: pwm {
-		status = "okay";
 		pin-location = <GECKO_LOCATION(17) GECKO_PORT_D GECKO_PIN(9)>;
 		prescaler = <1024>;
+		status = "okay";
 	};
 };
 
@@ -214,7 +218,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -222,13 +225,13 @@
 
 		/* Set 6Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fe800 {
-			label = "storage";
 			reg = <0x000fe800 0x00001800>;
+			label = "storage";
 		};
 
 	};
 };
 
 &trng0 {
-		status = "okay";
+	status = "okay";
 };

--- a/boards/silabs/dev_kits/sltb009a/sltb009a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb009a/sltb009a-pinctrl.dtsi
@@ -7,16 +7,6 @@
 #include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
-	/* configuration for usart0 device, default state - operating as UART */
-	usart0_default: usart0_default {
-		group1 {
-			psels = <GECKO_PSEL(UART_TX, E, 7)>,
-				<GECKO_PSEL(UART_RX, E, 6)>,
-				<GECKO_LOC(UART_TX, 1)>,
-				<GECKO_LOC(UART_RX, 1)>;
-		};
-	};
-
 	i2c0_default: i2c0_default {
 		group1 {
 			psels = <GECKO_PSEL(I2C_SDA, C, 0)>,
@@ -32,6 +22,16 @@
 				<GECKO_PSEL(I2C_SCL, C, 5)>,
 				<GECKO_LOC(I2C_SDA, 0)>,
 				<GECKO_LOC(I2C_SCL, 0)>;
+		};
+	};
+
+	/* configuration for usart0 device, default state - operating as UART */
+	usart0_default: usart0_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, E, 7)>,
+				<GECKO_PSEL(UART_RX, E, 6)>,
+				<GECKO_LOC(UART_TX, 1)>,
+				<GECKO_LOC(UART_RX, 1)>;
 		};
 	};
 };

--- a/boards/silabs/dev_kits/sltb009a/sltb009a.dts
+++ b/boards/silabs/dev_kits/sltb009a/sltb009a.dts
@@ -15,10 +15,10 @@
 
 	chosen {
 		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -32,10 +32,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpioe 12 GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpioa 13 GPIO_ACTIVE_HIGH>;
 			label = "LED 1";
@@ -44,11 +46,13 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpiod 5 GPIO_ACTIVE_HIGH>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			gpios = <&gpiod 8 GPIO_ACTIVE_HIGH>;
 			label = "User Push Button 1";
@@ -97,6 +101,7 @@
 
 &gpioa {
 	status = "okay";
+
 	board-controller-enable {
 		// VCOM Isolation. Set PA15 to HIGH to enable VCOM_{RX,TX}.
 		gpio-hog;
@@ -138,8 +143,8 @@
 
 		/* Set 12Kb of storage at the end of the 2048Kb of flash */
 		storage_partition: partition@1fd000 {
-			label = "storage";
 			reg = <0x001fd000 0x00003000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/dev_kits/sltb010a/sltb010a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a-pinctrl.dtsi
@@ -7,12 +7,29 @@
 #include <dt-bindings/pinctrl/silabs/xg22-pinctrl.h>
 
 &pinctrl {
+	itm_default: itm_default {
+		group0 {
+			pins = <GPIO_SWV_PA3>;
+			drive-push-pull;
+			output-high;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group0 {
+			pins = <I2C0_SDA_PD2>, <I2C0_SCL_PD3>;
+			bias-pull-up;
+			drive-open-drain;
+		};
+	};
+
 	usart0_default: usart0_default {
 		group0 {
 			pins = <USART0_TX_PC0>, <USART0_CLK_PC2>;
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <USART0_RX_PC1>;
 			input-enable;
@@ -25,26 +42,11 @@
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <USART1_RX_PA6>;
 			input-enable;
 			silabs,input-filter;
-		};
-	};
-
-	i2c0_default: i2c0_default {
-		group0 {
-			pins = <I2C0_SDA_PD2>, <I2C0_SCL_PD3>;
-			drive-open-drain;
-			bias-pull-up;
-		};
-	};
-
-	itm_default: itm_default {
-		group0 {
-			pins = <GPIO_SWV_PA3>;
-			drive-push-pull;
-			output-high;
 		};
 	};
 };

--- a/boards/silabs/dev_kits/sltb010a/sltb010a.dts
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a.dts
@@ -14,40 +14,41 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
-		sw0 = &button0;
 		spi0 = &usart0;
+		sw0 = &button0;
 		watchdog0 = &wdog0;
+
 		/* If enabled, MCUboot uses this for recovery mode entrance */
 		mcuboot-led0 = &led0;
 		mcuboot-button0 = &button0;
 	};
 
 	chosen {
-		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <120>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <37>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_K(76800)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -67,36 +68,36 @@
 };
 
 &dcdc {
-	status = "okay";
 	regulator-boot-on;
 	regulator-initial-mode = <SILABS_DCDC_MODE_BUCK>;
+	status = "okay";
 };
 
 &flash0 {
 	partitions {
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 0x0000c000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 224 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 0x00038000>;
+			label = "image-0";
 		};
 
 		/* Reserve 224 KiB for the application in slot 1 */
 		slot1_partition: partition@44000 {
-			label = "image-1";
 			reg = <0x00044000 0x00038000>;
+			label = "image-1";
 		};
 
 		/* Set 16 KiB of storage at the end of the 512 KiB of flash */
 		storage_partition: partition@7c000 {
-			label = "storage";
 			reg = <0x0007c000 0x00004000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
@@ -10,14 +10,15 @@
 	chosen {
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;
-		zephyr,shell-uart = &usart1;
-		zephyr,uart-pipe = &usart1;
-		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart1;
 	};
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
@@ -26,6 +27,7 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
@@ -41,23 +43,20 @@
 	/* GPIOs that power up different sensors */
 	sw_sensor_enable: gpio_switch_0 {
 		compatible = "regulator-fixed";
-		status = "okay";
-		regulator-name = "sw_sensor_enable";
-		startup-delay-us = <100000>;
 		/* Always on since sensor drivers won't enable it automatically */
 		regulator-always-on;
+		regulator-name = "sw_sensor_enable";
+		startup-delay-us = <100000>;
 	};
 
 	sw_mic_enable: gpio_switch_1 {
 		compatible = "regulator-fixed";
-		status = "okay";
 		regulator-name = "sw_mic_enable";
 		startup-delay-us = <100000>;
 	};
 
 	sw_imu_enable: gpio_switch_2 {
 		compatible = "regulator-fixed";
-		status = "okay";
 		regulator-name = "sw_imu_enable";
 		startup-delay-us = <100000>;
 	};
@@ -79,17 +78,15 @@
 };
 
 &usart0 {
-	status = "okay";
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	cs-gpios = <&gpioc 3 GPIO_ACTIVE_LOW>;
 
 	mx25r80: mx25r8035f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		size = <0x800000>;
 		jedec-id = [c2 28 14];
 		sfdp-bfp = [
 			 e5 20 f1 ff  ff ff 7f 00  44 eb 08 6b  08 3b 04 bb
@@ -97,14 +94,16 @@
 			 10 d8 00 ff  23 72 f5 00  82 ed 04 b7  44 83 38 44
 			 30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
 		];
+		size = <0x800000>;
+		spi-max-frequency = <80000000>;
 	};
 };
 
 &usart1 {
 	current-speed = <115200>;
-	status = "okay";
 	pinctrl-0 = <&usart1_default>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &wdog0 {
@@ -151,7 +150,6 @@
 
 	si7210@30 {
 		compatible = "silabs,si7210";
-		status = "okay";
 		reg = <0x30>;
 	};
 };

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b-pinctrl.dtsi
@@ -7,37 +7,17 @@
 #include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
-	usart0_default: usart0_default {
-		group0 {
-			pins = <USART0_TX_PA5>;
-			drive-push-pull;
-			output-high;
-		};
-		group1 {
-			pins = <USART0_RX_PA6>;
-			input-enable;
-			silabs,input-filter;
-		};
-	};
-
 	eusart1_default: eusart1_default {
 		group0 {
 			pins = <EUSART1_TX_PC3>, <EUSART1_SCLK_PC1>;
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <EUSART1_RX_PC2>;
 			input-enable;
 			silabs,input-filter;
-		};
-	};
-
-	i2c0_default: i2c0_default {
-		group0 {
-			pins = <I2C0_SCL_PC4>, <I2C0_SDA_PC5>;
-			drive-open-drain;
-			bias-pull-up;
 		};
 	};
 
@@ -46,6 +26,28 @@
 			pins = <GPIO_SWV_PA3>;
 			drive-push-pull;
 			output-high;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group0 {
+			pins = <I2C0_SCL_PC4>, <I2C0_SDA_PC5>;
+			bias-pull-up;
+			drive-open-drain;
+		};
+	};
+
+	usart0_default: usart0_default {
+		group0 {
+			pins = <USART0_TX_PA5>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART0_RX_PA6>;
+			input-enable;
+			silabs,input-filter;
 		};
 	};
 };

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b.dts
@@ -15,13 +15,13 @@
 	compatible = "silabs,xg24_brd2601b", "silabs,efr32mg24";
 
 	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	aliases {
@@ -35,12 +35,15 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		red_led: led_2 {
 			gpios = <&gpiod 2 GPIO_ACTIVE_LOW>;
 		};
+
 		green_led: led_0 {
 			gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
 		};
+
 		blue_led: led_1 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
 		};
@@ -48,10 +51,12 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpiob 2 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_1>;
@@ -65,9 +70,9 @@
 
 	sensor_enable: gpio_switch_0 {
 		compatible = "regulator-fixed";
+		regulator-boot-on;
 		regulator-name = "sensor_enable";
 		enable-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
-		regulator-boot-on;
 	};
 };
 
@@ -82,25 +87,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <140>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <63>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_M(78)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -132,23 +137,24 @@
 
 &eusart1 {
 	compatible = "silabs,eusart-spi";
-	pinctrl-0 = <&eusart1_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
-	clock-frequency = <4000000>;
 	#address-cells = <1>;
 	#size-cells = <0>;
+	clock-frequency = <4000000>;
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
 	status = "okay";
+
+	cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
 
 	mx25r32: mx25r3235f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		size = <0x2000000>;
-		jedec-id = [c2 28 16];
-		has-dpd;
 		dpd-wakeup-sequence = <30000 20 35000>;
+		has-dpd;
+		jedec-id = [c2 28 16];
 		mxicy,mx25r-power-mode = "low-power";
+		size = <0x2000000>;
+		spi-max-frequency = <80000000>;
 		zephyr,pm-device-runtime-auto;
 	};
 };
@@ -161,19 +167,16 @@
 	veml6035: veml6035@29 {
 		compatible = "vishay,veml7700";
 		reg = <0x29>;
-		status = "okay";
 	};
 
 	si7210: si7210@30 {
 		compatible = "silabs,si7210";
 		reg = <0x30>;
-		status = "okay";
 	};
 
 	si7021: si7021@40 {
 		compatible = "silabs,si7006";
 		reg = <0x40>;
-		status = "okay";
 	};
 };
 
@@ -206,10 +209,10 @@
 };
 
 &dcdc {
-	status = "okay";
 	regulator-boot-on;
 	regulator-initial-mode = <SILABS_DCDC_MODE_BUCK>;
 	silabs,pfmx-peak-current-milliamp = <120>;
+	status = "okay";
 };
 
 &flash0 {
@@ -220,33 +223,33 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x0000c000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 464 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 0x00074000>;
+			label = "image-0";
 		};
 
 		/* Reserve 464 kB for the application in slot 1 */
 		slot1_partition: partition@80000 {
-			label = "image-1";
 			reg = <0x00080000 0x00074000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@f4000 {
-			label = "image-scratch";
 			reg = <0x000f4000 0x00008000>;
+			label = "image-scratch";
 		};
 
 		/* Set 528Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fc000 {
-			label = "storage";
 			reg = <0x000fc000 0x00084000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
@@ -7,32 +7,33 @@
 #include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
-	usart0_default: usart0_default {
+	itm_default: itm_default {
 		group0 {
-			pins = <USART0_TX_PA5>;
+			pins = <GPIO_SWV_PA3>;
 			drive-push-pull;
 			output-high;
-		};
-		group1 {
-			pins = <USART0_RX_PA6>;
-			input-enable;
-			silabs,input-filter;
 		};
 	};
 
 	i2c0_default: i2c0_default {
 		group0 {
 			pins = <I2C0_SCL_PC4>, <I2C0_SDA_PC5>;
-			drive-open-drain;
 			bias-pull-up;
+			drive-open-drain;
 		};
 	};
 
-	itm_default: itm_default {
+	usart0_default: usart0_default {
 		group0 {
-			pins = <GPIO_SWV_PA3>;
+			pins = <USART0_TX_PA5>;
 			drive-push-pull;
 			output-high;
+		};
+
+		group1 {
+			pins = <USART0_RX_PA6>;
+			input-enable;
+			silabs,input-filter;
 		};
 	};
 };

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a.dts
@@ -15,13 +15,13 @@
 	compatible = "silabs,xg24_ek2703a", "silabs,efr32mg24";
 
 	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	aliases {
@@ -34,9 +34,11 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
 		};
+
 		led1: led_1 {
 			gpios = <&gpioa 7 GPIO_ACTIVE_LOW>;
 		};
@@ -44,10 +46,12 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpiob 2 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_1>;
@@ -71,25 +75,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <140>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <63>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_M(78)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -168,33 +172,33 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x0000c000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 464 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 0x00074000>;
+			label = "image-0";
 		};
 
 		/* Reserve 464 kB for the application in slot 1 */
 		slot1_partition: partition@80000 {
-			label = "image-1";
 			reg = <0x00080000 0x00074000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@f4000 {
-			label = "image-scratch";
 			reg = <0x000f4000 0x00008000>;
+			label = "image-scratch";
 		};
 
 		/* Set 528Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fc000 {
-			label = "storage";
 			reg = <0x000fc000 0x00084000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
@@ -10,14 +10,15 @@
 	chosen {
 		zephyr,bt-c2h-uart = &usart1;
 		zephyr,console = &usart1;
-		zephyr,shell-uart = &usart1;
-		zephyr,uart-pipe = &usart1;
-		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart1;
 	};
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiob 0 GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
@@ -26,6 +27,7 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
@@ -41,23 +43,20 @@
 	/* GPIOs that power up different sensors */
 	sw_sensor_enable: gpio_switch_0 {
 		compatible = "regulator-fixed";
-		status = "okay";
-		regulator-name = "sw_sensor_enable";
-		startup-delay-us = <100000>;
 		/* Always on since sensor drivers won't enable it automatically */
 		regulator-always-on;
+		regulator-name = "sw_sensor_enable";
+		startup-delay-us = <100000>;
 	};
 
 	sw_mic_enable: gpio_switch_1 {
 		compatible = "regulator-fixed";
-		status = "okay";
 		regulator-name = "sw_mic_enable";
 		startup-delay-us = <100000>;
 	};
 
 	sw_imu_enable: gpio_switch_2 {
 		compatible = "regulator-fixed";
-		status = "okay";
 		regulator-name = "sw_imu_enable";
 		startup-delay-us = <100000>;
 	};
@@ -88,8 +87,6 @@
 	mx25r80: mx25r8035f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		size = <0x800000>;
 		jedec-id = [c2 28 14];
 		sfdp-bfp = [
 			 e5 20 f1 ff  ff ff 7f 00  44 eb 08 6b  08 3b 04 bb
@@ -97,14 +94,16 @@
 			 10 d8 00 ff  23 72 f5 00  82 ed 04 b7  44 83 38 44
 			 30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
 		];
+		size = <0x800000>;
+		spi-max-frequency = <80000000>;
 	};
 };
 
 &usart1 {
 	current-speed = <115200>;
-	status = "okay";
 	pinctrl-0 = <&usart1_default>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &wdog0 {
@@ -151,7 +150,6 @@
 
 	si7210@30 {
 		compatible = "silabs,si7210";
-		status = "okay";
 		reg = <0x30>;
 	};
 };

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a-pinctrl.dtsi
@@ -7,12 +7,29 @@
 #include <dt-bindings/pinctrl/silabs/xg27-pinctrl.h>
 
 &pinctrl {
+	itm_default: itm_default {
+		group0 {
+			pins = <GPIO_SWV_PA3>;
+			drive-push-pull;
+			output-high;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group0 {
+			pins = <I2C0_SDA_PD2>, <I2C0_SCL_PD3>;
+			bias-pull-up;
+			drive-open-drain;
+		};
+	};
+
 	usart0_default: usart0_default {
 		group0 {
 			pins = <USART0_TX_PC0>, <USART0_CLK_PC2>;
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <USART0_RX_PC1>;
 			input-enable;
@@ -25,26 +42,11 @@
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <USART1_RX_PA6>;
 			input-enable;
 			silabs,input-filter;
-		};
-	};
-
-	i2c0_default: i2c0_default {
-		group0 {
-			pins = <I2C0_SDA_PD2>, <I2C0_SCL_PD3>;
-			drive-open-drain;
-			bias-pull-up;
-		};
-	};
-
-	itm_default: itm_default {
-		group0 {
-			pins = <GPIO_SWV_PA3>;
-			drive-push-pull;
-			output-high;
 		};
 	};
 };

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.dts
@@ -18,40 +18,41 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
-		sw0 = &button0;
 		spi0 = &usart0;
+		sw0 = &button0;
 		watchdog0 = &wdog0;
+
 		/* If enabled, MCUboot uses this for recovery mode entrance */
 		mcuboot-led0 = &led0;
 		mcuboot-button0 = &button0;
 	};
 
 	chosen {
-		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <140>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <63>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_K(76800)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -71,36 +72,36 @@
 };
 
 &dcdc {
-	status = "okay";
 	regulator-boot-on;
 	regulator-initial-mode = <SILABS_DCDC_MODE_BUCK>;
+	status = "okay";
 };
 
 &flash0 {
 	partitions {
 		/* Reserve 48 KiB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 0x0000c000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 328 KiB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 0x00052000>;
+			label = "image-0";
 		};
 
 		/* Reserve 328 KiB for the application in slot 1 */
 		slot1_partition: partition@5e000 {
-			label = "image-1";
 			reg = <0x0005e000 0x00052000>;
+			label = "image-1";
 		};
 
 		/* Set 64 KiB of storage at the end of the 768 KiB of flash */
 		storage_partition: partition@b0000 {
-			label = "storage";
 			reg = <0x000b0000 0x00010000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/radio_boards/common/efr32-series1-common.dtsi
+++ b/boards/silabs/radio_boards/common/efr32-series1-common.dtsi
@@ -9,12 +9,12 @@
 
 / {
 	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -28,10 +28,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiof 4 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiof 5 0>;
 			label = "LED 1";
@@ -40,12 +42,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpiof 6 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpiof 7 GPIO_ACTIVE_LOW>;
@@ -53,7 +57,6 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
-
 };
 
 &usart0 {
@@ -79,9 +82,9 @@
 	mx25r80: mx25r8035f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <33000000>;
-		size = <0x800000>;
 		jedec-id = [c2 28 14];
+		size = <0x800000>;
+		spi-max-frequency = <33000000>;
 	};
 };
 

--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -16,20 +16,20 @@
 	compatible = "silabs,x917_rb4338a", "silabs,siwg917";
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,bt-hci = &bt_hci0;
 		zephyr,code-partition = &code_partition;
 		zephyr,console = &ulpuart;
 		zephyr,shell-uart = &ulpuart;
+		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &ulpuart;
-		zephyr,bt-hci = &bt_hci0;
 	};
 
 	aliases {
+		dht0 = &si7021;
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
 		sw1 = &button1;
-		dht0 = &si7021;
 	};
 
 	leds {
@@ -60,33 +60,34 @@
 };
 
 &pinctrl0 {
-	ulpuart_default: ulpuart_default {
-		out {
-			pinmux = <ULPUART_TX_ULP11>;
-		};
-		in {
-			pinmux = <ULPUART_RX_ULP9>;
-		};
-	};
-
 	ulpi2c_default: ulpi2c_default {
 		group {
 			pinmux = <ULPI2C_SDA_ULP6>, <ULPI2C_SCL_ULP7>;
 		};
 	};
+
+	ulpuart_default: ulpuart_default {
+		out {
+			pinmux = <ULPUART_TX_ULP11>;
+		};
+
+		in {
+			pinmux = <ULPUART_RX_ULP9>;
+		};
+	};
 };
 
 &ulpuart {
-	status = "okay";
 	pinctrl-0 = <&ulpuart_default>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &ulpi2c {
-	status = "okay";
+	clock-frequency = <DT_FREQ_K(100)>;
 	pinctrl-0 = <&ulpi2c_default>;
 	pinctrl-names = "default";
-	clock-frequency = <DT_FREQ_K(100)>;
+	status = "okay";
 
 	si7021: si7021@40 {
 		compatible = "silabs,si7006";
@@ -101,13 +102,13 @@
 		#size-cells = <1>;
 
 		code_partition: partition@0 {
-			label = "code_partition";
 			reg = <0x0000000 DT_SIZE_K(2008)>;
+			label = "code_partition";
 		};
 
 		storage_partition: partition@1f6000 {
-			label = "storage";
 			reg = <0x001f6000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
@@ -17,18 +17,18 @@
 	compatible = "silabs,x917_rb4342a", "silabs,siwg917";
 
 	chosen {
-		zephyr,sram = &sram0;
+		zephyr,bt-hci = &bt_hci0;
 		zephyr,code-partition = &code_partition;
 		zephyr,console = &ulpuart;
 		zephyr,shell-uart = &ulpuart;
+		zephyr,sram = &sram0;
 		zephyr,uart-pipe = &ulpuart;
-		zephyr,bt-hci = &bt_hci0;
 	};
 
 	aliases {
+		dht0 = &si7021;
 		led0 = &led0;
 		sw0 = &button0;
-		dht0 = &si7021;
 	};
 
 	leds {
@@ -61,33 +61,34 @@
 		};
 	};
 
-	ulpuart_default: ulpuart_default {
-		out {
-			pinmux = <ULPUART_TX_ULP11>;
-		};
-		in {
-			pinmux = <ULPUART_RX_ULP9>;
-		};
-	};
-
 	ulpi2c_default: ulpi2c_default {
 		group {
 			pinmux = <ULPI2C_SDA_ULP6>, <ULPI2C_SCL_ULP7>;
 		};
 	};
+
+	ulpuart_default: ulpuart_default {
+		out {
+			pinmux = <ULPUART_TX_ULP11>;
+		};
+
+		in {
+			pinmux = <ULPUART_RX_ULP9>;
+		};
+	};
 };
 
 &ulpuart {
-	status = "okay";
 	pinctrl-0 = <&ulpuart_default>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &ulpi2c {
-	status = "okay";
+	clock-frequency = <DT_FREQ_K(100)>;
 	pinctrl-0 = <&ulpi2c_default>;
 	pinctrl-names = "default";
-	clock-frequency = <DT_FREQ_K(100)>;
+	status = "okay";
 
 	si7021: si7021@40 {
 		compatible = "silabs,si7006";
@@ -102,31 +103,31 @@
 		#size-cells = <1>;
 
 		code_partition: partition@0 {
-			label = "code_partition";
 			reg = <0x0000000 DT_SIZE_K(2008)>;
+			label = "code_partition";
 		};
 
 		storage_partition: partition@1f6000 {
-			label = "storage";
 			reg = <0x001f6000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };
 
 &psramctrl0 {
-	status = "okay";
 	clocks = <&clock0 SIWX91X_CLK_QSPI>;
 	pinctrl-0 = <&psram_default>;
 	pinctrl-names = "default";
 	device-id = [ 0d 5d 00 00 00 00 00 00 ];
-	normal-freq = <DT_FREQ_M(33)>;
 	fast-freq = <DT_FREQ_M(144)>;
+	normal-freq = <DT_FREQ_M(33)>;
+	status = "okay";
 
 	psram: psram@a000000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0xa000000 DT_SIZE_M(8)>;
-		zephyr,memory-region = "psram";
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
+		zephyr,memory-region = "psram";
 	};
 };
 

--- a/boards/silabs/radio_boards/slwrb4104a/slwrb4104a.dts
+++ b/boards/silabs/radio_boards/slwrb4104a/slwrb4104a.dts
@@ -25,33 +25,33 @@
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x00008000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
-			label = "image-0";
 			reg = <0x00008000 0x00037000>;
+			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
-			label = "image-1";
 			reg = <0x0003f000 0x00037000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
-			label = "image-scratch";
 			reg = <0x00076000 0x00008000>;
+			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
-			label = "storage";
 			reg = <0x0007e000 0x00002000>;
+			label = "storage";
 		};
 
 	};

--- a/boards/silabs/radio_boards/slwrb4161a/slwrb4161a.dts
+++ b/boards/silabs/radio_boards/slwrb4161a/slwrb4161a.dts
@@ -25,33 +25,33 @@
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x00008000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
-			label = "image-0";
 			reg = <0x00008000 0x00037000>;
+			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
-			label = "image-1";
 			reg = <0x0003f000 0x00037000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
-			label = "image-scratch";
 			reg = <0x00076000 0x00008000>;
+			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
-			label = "storage";
 			reg = <0x0007e000 0x00002000>;
+			label = "storage";
 		};
 
 	};
@@ -72,9 +72,9 @@
 	compatible = "silabs,usart-spi";
 	#address-cells = <1>;
 	#size-cells = <0>;
+	cs-gpios = <&gpioa 9 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&usart2_default>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpioa 9 GPIO_ACTIVE_LOW>;
 	status = "okay";
 };
 
@@ -86,6 +86,5 @@
 	si7021: si7021@40 {
 		compatible = "silabs,si7006";
 		reg = <0x40>;
-		status = "okay";
 	};
 };

--- a/boards/silabs/radio_boards/slwrb4170a/slwrb4170a.dts
+++ b/boards/silabs/radio_boards/slwrb4170a/slwrb4170a.dts
@@ -25,33 +25,33 @@
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x00008000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
-			label = "image-0";
 			reg = <0x00008000 0x00037000>;
+			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
-			label = "image-1";
 			reg = <0x0003f000 0x00037000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
-			label = "image-scratch";
 			reg = <0x00076000 0x00008000>;
+			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
-			label = "storage";
 			reg = <0x0007e000 0x00002000>;
+			label = "storage";
 		};
 
 	};

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a-pinctrl.dtsi
@@ -14,6 +14,7 @@
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <USART0_RX_PA6>;
 			input-enable;

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a.dts
@@ -14,12 +14,12 @@
 	compatible = "silabs,slwrb4180a", "silabs,efr32mg21";
 
 	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -33,10 +33,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiob 0 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiob 1 0>;
 			label = "LED 1";
@@ -45,12 +47,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpiod 2 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
@@ -58,7 +62,6 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
-
 };
 
 &cpu0 {
@@ -66,25 +69,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <129>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <79>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_K(76800)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -157,33 +160,33 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x0000c000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 464 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 0x00074000>;
+			label = "image-0";
 		};
 
 		/* Reserve 464 kB for the application in slot 1 */
 		slot1_partition: partition@80000 {
-			label = "image-1";
 			reg = <0x00080000 0x00074000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@f4000 {
-			label = "image-scratch";
 			reg = <0x000f4000 0x00008000>;
+			label = "image-scratch";
 		};
 
 		/* Set 16Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fc000 {
-			label = "storage";
 			reg = <0x000fc000 0x00004000>;
+			label = "storage";
 		};
 
 	};

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b-pinctrl.dtsi
@@ -13,6 +13,7 @@
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <USART0_RX_PA6>;
 			input-enable;

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b.dts
@@ -15,11 +15,11 @@
 	compatible = "silabs,slwrb4180b", "silabs,efr32mg21";
 
 	chosen {
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -67,25 +67,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <129>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <79>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_K(76800)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -161,23 +161,23 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000C000 DT_SIZE_K(472)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@82000 {
-			label = "image-1";
 			reg = <0x00082000 DT_SIZE_K(472)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@F8000 {
-			label = "storage";
 			reg = <0x000F8000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/radio_boards/slwrb4250b/slwrb4250b.dts
+++ b/boards/silabs/radio_boards/slwrb4250b/slwrb4250b.dts
@@ -13,16 +13,16 @@
 	model = "Silicon Labs BRD4250B (Flex Gecko 1 Radio Board)";
 	compatible = "silabs,slwrb4250b", "silabs,efr32fg1p";
 
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
 	pwmleds {
 		compatible = "pwm-leds";
-		status = "okay";
+
 		pwm_led0: pwm_led0 {
 			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
-	};
-
-	aliases {
-		pwm-led0 = &pwm_led0;
 	};
 };
 
@@ -34,9 +34,9 @@
 	status = "okay";
 
 	pwm0: pwm {
-		status = "okay";
 		pin-location = <GECKO_LOCATION(28) GECKO_PORT_F GECKO_PIN(4)>;
 		prescaler = <1024>;
+		status = "okay";
 	};
 };
 
@@ -48,35 +48,34 @@
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x00008000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 94 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
-			label = "image-0";
 			reg = <0x00008000 0x00017800>;
+			label = "image-0";
 		};
 
 		/* Reserve 94 kB for the application in slot 1 */
 		slot1_partition: partition@1f800 {
-			label = "image-1";
 			reg = <0x0001f800 0x00017800>;
+			label = "image-1";
 		};
 
 		/* Reserve 30 kB for the scratch partition */
 		scratch_partition: partition@37000 {
-			label = "image-scratch";
 			reg = <0x00037000 0x00007800>;
+			label = "image-scratch";
 		};
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
-			label = "storage";
 			reg = <0x0003e800 0x00001800>;
+			label = "storage";
 		};
-
 	};
 };
 

--- a/boards/silabs/radio_boards/slwrb4255a/slwrb4255a.dts
+++ b/boards/silabs/radio_boards/slwrb4255a/slwrb4255a.dts
@@ -27,35 +27,34 @@
 
 		/* Reserve 32 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x00008000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
-			label = "image-0";
 			reg = <0x00008000 0x00037000>;
+			label = "image-0";
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */
 		slot1_partition: partition@3f000 {
-			label = "image-1";
 			reg = <0x0003f000 0x00037000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@76000 {
-			label = "image-scratch";
 			reg = <0x00076000 0x00008000>;
+			label = "image-scratch";
 		};
 
 		/* Set 8Kb of storage at the end of the 512KB of flash */
 		storage_partition: partition@7e000 {
-			label = "storage";
 			reg = <0x0007e000 0x00002000>;
+			label = "storage";
 		};
-
 	};
 };
 

--- a/boards/silabs/radio_boards/slwrb4321a/slwrb4321a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4321a/slwrb4321a-pinctrl.dtsi
@@ -7,16 +7,6 @@
 #include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
-	/* configuration for usart0 device, default state - operating as UART */
-	usart0_default: usart0_default {
-		group1 {
-			psels = <GECKO_PSEL(UART_TX, A, 0)>,
-				<GECKO_PSEL(UART_RX, A, 1)>,
-				<GECKO_LOC(UART_TX, 0)>,
-				<GECKO_LOC(UART_RX, 0)>;
-		};
-	};
-
 	i2c0_default: i2c0_default {
 		group1 {
 			psels = <GECKO_PSEL(I2C_SDA, A, 0)>,
@@ -32,6 +22,16 @@
 				<GECKO_PSEL(I2C_SCL, B, 12)>,
 				<GECKO_LOC(I2C_SDA, 1)>,
 				<GECKO_LOC(I2C_SCL, 1)>;
+		};
+	};
+
+	/* configuration for usart0 device, default state - operating as UART */
+	usart0_default: usart0_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, A, 0)>,
+				<GECKO_PSEL(UART_RX, A, 1)>,
+				<GECKO_LOC(UART_TX, 0)>,
+				<GECKO_LOC(UART_RX, 0)>;
 		};
 	};
 };

--- a/boards/silabs/radio_boards/slwrb4321a/slwrb4321a.dts
+++ b/boards/silabs/radio_boards/slwrb4321a/slwrb4321a.dts
@@ -17,10 +17,10 @@
 
 	chosen {
 		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -34,10 +34,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpioa 4 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpioa 5 0>;
 			label = "LED 1";
@@ -46,12 +48,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpiod 6 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpiod 8 GPIO_ACTIVE_LOW>;
@@ -130,20 +134,19 @@
 
 	/* RMII interface pins */
 	location-rmii        = <GECKO_LOCATION(0)>;
-	location-rmii-refclk = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(3)>;
 	location-rmii-crs-dv = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(4)>;
-	location-rmii-txd0   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(15)>;
-	location-rmii-txd1   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(14)>;
-	location-rmii-tx-en  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
+	location-rmii-refclk = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(3)>;
+	location-rmii-rx-er  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
 	location-rmii-rxd0   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(2)>;
 	location-rmii-rxd1   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
-	location-rmii-rx-er  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
+	location-rmii-tx-en  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
+	location-rmii-txd0   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(15)>;
+	location-rmii-txd1   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(14)>;
 
 	status = "okay";
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -151,8 +154,8 @@
 
 		/* Set 12Kb of storage at the end of the 2048Kb of flash */
 		storage_partition: partition@1fd000 {
-			label = "storage";
 			reg = <0x001fd000 0x00003000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a-pinctrl.dtsi
@@ -7,12 +7,29 @@
 #include <dt-bindings/pinctrl/silabs/xg23-pinctrl.h>
 
 &pinctrl {
+	itm_default: itm_default {
+		group0 {
+			pins = <GPIO_SWV_PA3>;
+			drive-push-pull;
+			output-high;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group0 {
+			pins = <I2C0_SCL_PC5>, <I2C0_SDA_PC7>;
+			drive-open-drain;
+			bias-pull-up;
+		};
+	};
+
 	eusart0_default: eusart0_default {
 		group0 {
 			pins = <EUSART0_TX_PA8>;
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <EUSART0_RX_PA9>;
 			input-enable;
@@ -26,26 +43,11 @@
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <EUSART1_RX_PC2>;
 			input-enable;
 			silabs,input-filter;
-		};
-	};
-
-	i2c0_default: i2c0_default {
-		group0 {
-			pins = <I2C0_SCL_PC5>, <I2C0_SDA_PC7>;
-			drive-open-drain;
-			bias-pull-up;
-		};
-	};
-
-	itm_default: itm_default {
-		group0 {
-			pins = <GPIO_SWV_PA3>;
-			drive-push-pull;
-			output-high;
 		};
 	};
 };

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
@@ -15,30 +15,32 @@
 	compatible = "silabs,xg23_rb4210a", "silabs,efr32zg23";
 
 	chosen {
-		zephyr,console = &eusart0;
-		zephyr,shell-uart = &eusart0;
-		zephyr,uart-pipe = &eusart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &eusart0;
 		zephyr,display = &ls0xx_ls013b7dh03;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &eusart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &eusart0;
 	};
 
 	aliases {
+		dht0 = &si7021;
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
-		dht0 = &si7021;
 	};
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
 			label = "LED 1";
@@ -47,11 +49,13 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 1";
@@ -61,8 +65,8 @@
 
 	sensor_disp_enable: sensor_disp_enable {
 		compatible = "regulator-fixed";
-		regulator-name = "sensor_disp_enable";
 		enable-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
+		regulator-name = "sensor_disp_enable";
 		status = "okay";
 	};
 };
@@ -82,25 +86,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <106>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <38>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_M(78)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -132,34 +136,35 @@
 };
 
 &eusart1 {
-	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	pinctrl-0 = <&eusart1_default>;
 	pinctrl-names = "default";
+	status = "okay";
+
 	cs-gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>, <&gpioc 4 GPIO_ACTIVE_LOW>;
 
 	ls0xx_ls013b7dh03: ls0xx@0 {
 		compatible = "sharp,ls0xx";
-		spi-max-frequency = <DT_FREQ_K(1100)>;
 		reg = <0>;
-		width = <128>;
 		height = <128>;
+		spi-max-frequency = <DT_FREQ_K(1100)>;
+		width = <128>;
+		disp-en-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 		extcomin-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
 		extcomin-frequency = <60>;
-		disp-en-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 	};
 
 	mx25r80: mx25r8035f@1 {
 		compatible = "jedec,spi-nor";
 		reg = <1>;
-		spi-max-frequency = <DT_FREQ_M(33)>;
-		size = <DT_SIZE_M(8)>;
-		jedec-id = [c2 28 14];
-		has-dpd;
 		dpd-wakeup-sequence = <30000 20 35000>;
-		t-enter-dpd = <0>;
+		has-dpd;
+		jedec-id = [c2 28 14];
 		mxicy,mx25r-power-mode = "low-power";
+		size = <DT_SIZE_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(33)>;
+		t-enter-dpd = <0>;
 	};
 };
 
@@ -172,7 +177,6 @@
 		compatible = "silabs,si7006";
 		reg = <0x40>;
 		vin-supply = <&sensor_disp_enable>;
-		status = "okay";
 	};
 };
 
@@ -215,10 +219,10 @@
 };
 
 &dcdc {
-	status = "okay";
 	regulator-boot-on;
 	regulator-initial-mode = <SILABS_DCDC_MODE_BUCK>;
 	silabs,pfmx-peak-current-milliamp = <80>;
+	status = "okay";
 };
 
 &flash0 {
@@ -229,33 +233,33 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(48)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 208 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(208)>;
+			label = "image-0";
 		};
 
 		/* Reserve 208 kB for the application in slot 1 */
 		slot1_partition: partition@40000 {
-			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(208)>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@74000 {
-			label = "image-scratch";
 			reg = <0x00074000 DT_SIZE_K(32)>;
+			label = "image-scratch";
 		};
 
 		/* Set 16 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@7c000 {
-			label = "storage";
 			reg = <0x0007c000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c-pinctrl.dtsi
@@ -8,29 +8,25 @@
 #include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
-	usart0_default: usart0_default {
-		group0 {
-			pins = <USART0_TX_PA8>;
-			drive-push-pull;
-			output-high;
-		};
-		group1 {
-			pins = <USART0_RX_PA9>;
-			input-enable;
-			silabs,input-filter;
-		};
-	};
-
 	eusart1_default: eusart1_default {
 		group0 {
 			pins = <EUSART1_TX_PC1>, <EUSART1_SCLK_PC3>;
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <EUSART1_RX_PC2>;
 			input-enable;
 			silabs,input-filter;
+		};
+	};
+
+	itm_default: itm_default {
+		group0 {
+			pins = <GPIO_SWV_PA3>;
+			drive-push-pull;
+			output-high;
 		};
 	};
 
@@ -42,11 +38,17 @@
 		};
 	};
 
-	itm_default: itm_default {
+	usart0_default: usart0_default {
 		group0 {
-			pins = <GPIO_SWV_PA3>;
+			pins = <USART0_TX_PA8>;
 			drive-push-pull;
 			output-high;
+		};
+
+		group1 {
+			pins = <USART0_RX_PA9>;
+			input-enable;
+			silabs,input-filter;
 		};
 	};
 };

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
@@ -15,32 +15,34 @@
 	compatible = "silabs,xg24_rb4187c", "silabs,efr32mg24";
 
 	chosen {
-		zephyr,console = &usart0;
-		zephyr,shell-uart = &usart0;
-		zephyr,uart-pipe = &usart0;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &usart0;
 		zephyr,display = &ls0xx_ls013b7dh03;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart0;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
 	aliases {
+		dht0 = &si7021;
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
-		dht0 = &si7021;
 	};
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
 			label = "LED 1";
@@ -49,11 +51,13 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			gpios = <&gpiob 3 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 1";
@@ -63,9 +67,8 @@
 
 	sensor_enable: sensor_enable {
 		compatible = "regulator-fixed";
-		regulator-name = "sensor_enable";
 		enable-gpios = <&gpiod 3 GPIO_ACTIVE_HIGH>;
-		status = "okay";
+		regulator-name = "sensor_enable";
 	};
 };
 
@@ -84,25 +87,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <95>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <44>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_M(78)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -134,20 +137,21 @@
 
 &eusart1 {
 	compatible = "silabs,eusart-spi";
-	pinctrl-0 = <&eusart1_default>;
-	pinctrl-names = "default";
-	clock-frequency = <DT_FREQ_M(10)>;
-	cs-gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>, <&gpioc 4 GPIO_ACTIVE_LOW>;
 	#address-cells = <1>;
 	#size-cells = <0>;
+	clock-frequency = <DT_FREQ_M(10)>;
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
 	status = "okay";
+
+	cs-gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>, <&gpioc 4 GPIO_ACTIVE_LOW>;
 
 	ls0xx_ls013b7dh03: ls0xx@0 {
 		compatible = "sharp,ls0xx";
-		spi-max-frequency = <DT_FREQ_K(1100)>;
 		reg = <0>;
-		width = <128>;
 		height = <128>;
+		spi-max-frequency = <DT_FREQ_K(1100)>;
+		width = <128>;
 		extcomin-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
 		extcomin-frequency = <60>;
 		disp-en-gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
@@ -156,12 +160,12 @@
 	mx25r80: mx25r8035f@1 {
 		compatible = "jedec,spi-nor";
 		reg = <1>;
-		spi-max-frequency = <DT_FREQ_M(33)>;
-		size = <DT_SIZE_M(8)>;
-		jedec-id = [c2 28 14];
-		has-dpd;
 		dpd-wakeup-sequence = <30000 20 35000>;
+		has-dpd;
+		jedec-id = [c2 28 14];
 		mxicy,mx25r-power-mode = "low-power";
+		size = <DT_SIZE_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(33)>;
 		zephyr,pm-device-runtime-auto;
 	};
 };
@@ -175,7 +179,6 @@
 		compatible = "silabs,si7006";
 		reg = <0x40>;
 		vin-supply = <&sensor_enable>;
-		status = "okay";
 	};
 };
 
@@ -219,10 +222,10 @@
 };
 
 &dcdc {
-	status = "okay";
 	regulator-boot-on;
 	regulator-initial-mode = <SILABS_DCDC_MODE_BUCK>;
 	silabs,pfmx-peak-current-milliamp = <100>;
+	status = "okay";
 };
 
 &flash0 {
@@ -233,33 +236,33 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(48)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 720 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 0x000B4000>;
+			label = "image-0";
 		};
 
 		/* Reserve 720 kB for the application in slot 1 */
 		slot1_partition: partition@C0000 {
-			label = "image-1";
 			reg = <0x000C0000 0x000B4000>;
+			label = "image-1";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@174000 {
-			label = "image-scratch";
 			reg = <0x00174000 DT_SIZE_K(32)>;
+			label = "image-scratch";
 		};
 
 		/* Set 16 kB of storage at the end of the 1536 kB of flash */
 		storage_partition: partition@17c000 {
-			label = "storage";
 			reg = <0x0017c000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a-pinctrl.dtsi
@@ -7,37 +7,17 @@
 #include <dt-bindings/pinctrl/silabs/xg29-pinctrl.h>
 
 &pinctrl {
-	usart1_default: usart1_default {
-		group0 {
-			pins = <USART1_TX_PA5>;
-			drive-push-pull;
-			output-high;
-		};
-		group1 {
-			pins = <USART1_RX_PA6>;
-			input-enable;
-			silabs,input-filter;
-		};
-	};
-
 	eusart1_default: eusart1_default {
 		group0 {
 			pins = <EUSART1_TX_PC0>, <EUSART1_SCLK_PC2>;
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <EUSART1_RX_PC1>;
 			input-enable;
 			silabs,input-filter;
-		};
-	};
-
-	i2c0_default: i2c0_default {
-		group0 {
-			pins = <I2C0_SCL_PB2>, <I2C0_SDA_PB3>;
-			drive-open-drain;
-			bias-pull-up;
 		};
 	};
 
@@ -46,6 +26,28 @@
 			pins = <GPIO_SWV_PA3>;
 			drive-push-pull;
 			output-high;
+		};
+	};
+
+	i2c0_default: i2c0_default {
+		group0 {
+			pins = <I2C0_SCL_PB2>, <I2C0_SDA_PB3>;
+			bias-pull-up;
+			drive-open-drain;
+		};
+	};
+
+	usart1_default: usart1_default {
+		group0 {
+			pins = <USART1_TX_PA5>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART1_RX_PA6>;
+			input-enable;
+			silabs,input-filter;
 		};
 	};
 };

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a.dts
@@ -15,23 +15,23 @@
 	compatible = "silabs,xg29_rb4412a", "silabs,efr32mg29";
 
 	chosen {
-		zephyr,console = &usart1;
-		zephyr,shell-uart = &usart1;
-		zephyr,uart-pipe = &usart1;
-		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
 		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,console = &usart1;
 		zephyr,display = &ls013b7dh03;
+		zephyr,flash = &flash0;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,uart-pipe = &usart1;
 	};
 
 	aliases {
 		led0 = &led0;
 		led1 = &led1;
+		spi-flash0 = &mx25r80;
 		sw0 = &button0;
 		sw1 = &button1;
 		watchdog0 = &wdog0;
-		spi-flash0 = &mx25r80;
 	};
 
 	leds {
@@ -66,8 +66,8 @@
 
 	display_enable: sensor_enable: gpio_switch_0 {
 		compatible = "regulator-fixed";
-		regulator-name = "sensor_enable";
 		enable-gpios = <&gpioc 7 GPIO_ACTIVE_HIGH>;
+		regulator-name = "sensor_enable";
 	};
 };
 
@@ -82,25 +82,25 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <140>;
 	precision = <50>;
+	status = "okay";
 };
 
 &lfxo {
-	status = "okay";
 	ctune = <63>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_K(76800)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &em23grpaclk {
@@ -134,37 +134,37 @@
 	si7021: si7021@40 {
 		compatible = "silabs,si7006";
 		reg = <0x40>;
-		status = "okay";
 	};
 };
 
 &eusart1 {
-	pinctrl-0 = <&eusart1_default>;
-	pinctrl-names = "default";
-	clock-frequency = <DT_FREQ_M(8)>;
-	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
+	clock-frequency = <DT_FREQ_M(8)>;
+	pinctrl-0 = <&eusart1_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
 	cs-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>, <&gpioc 6 GPIO_ACTIVE_HIGH>;
 
 	mx25r80: mx25r8035f@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(33)>;
-		size = <0x800000>;
-		jedec-id = [c2 28 14];
-		has-dpd;
 		dpd-wakeup-sequence = <30000 20 35000>;
-		t-enter-dpd = <0>;
+		has-dpd;
+		jedec-id = [c2 28 14];
 		mxicy,mx25r-power-mode = "low-power";
+		size = <0x800000>;
+		spi-max-frequency = <DT_FREQ_M(33)>;
+		t-enter-dpd = <0>;
 	};
 
 	ls013b7dh03: ls0xx@1 {
 		compatible = "sharp,ls0xx";
-		spi-max-frequency = <DT_FREQ_M(2)>;
 		reg = <1>;
-		width = <128>;
 		height = <128>;
+		spi-max-frequency = <DT_FREQ_M(2)>;
+		width = <128>;
 		extcomin-gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
 		extcomin-frequency = <60>;
 	};
@@ -229,23 +229,23 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000C000 DT_SIZE_K(472)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@82000 {
-			label = "image-1";
 			reg = <0x00082000 DT_SIZE_K(472)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@F8000 {
-			label = "storage";
 			reg = <0x000F8000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/silabs/starter_kits/efm32wg_stk3800/efm32wg_stk3800.dts
+++ b/boards/silabs/starter_kits/efm32wg_stk3800/efm32wg_stk3800.dts
@@ -14,9 +14,9 @@
 
 	chosen {
 		zephyr,console = &uart0;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &uart0;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -29,10 +29,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpioe 2 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpioe 3 0>;
 			label = "LED 1";
@@ -41,12 +43,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpiob 9 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpiob 19 GPIO_ACTIVE_LOW>;
@@ -90,7 +94,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -98,9 +101,8 @@
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
-			label = "storage";
 			reg = <0x0003e800 0x00001800>;
+			label = "storage";
 		};
-
 	};
 };

--- a/boards/silabs/starter_kits/slstk3400a/slstk3400a.dts
+++ b/boards/silabs/starter_kits/slstk3400a/slstk3400a.dts
@@ -14,9 +14,9 @@
 
 	chosen {
 		zephyr,console = &usart1;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -29,10 +29,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiof 4 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiof 5 0>;
 			label = "LED 1";
@@ -41,12 +43,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpioc 10 GPIO_ACTIVE_LOW>;
@@ -54,7 +58,6 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
-
 };
 
 &cpu0 {
@@ -87,7 +90,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -95,9 +97,8 @@
 
 		/* Set 4Kb of storage at the end of the 64Kb of flash */
 		storage_partition: partition@f000 {
-			label = "storage";
 			reg = <0x0000f000 0x00001000>;
+			label = "storage";
 		};
-
 	};
 };

--- a/boards/silabs/starter_kits/slstk3401a/slstk3401a-common.dtsi
+++ b/boards/silabs/starter_kits/slstk3401a/slstk3401a-common.dtsi
@@ -12,9 +12,9 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -28,10 +28,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiof 4 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiof 5 0>;
 			label = "LED 1";
@@ -40,12 +42,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpiof 6 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpiof 7 GPIO_ACTIVE_LOW>;
@@ -120,7 +124,6 @@
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -128,9 +131,8 @@
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
-			label = "storage";
 			reg = <0x0003e800 0x00001800>;
+			label = "storage";
 		};
-
 	};
 };

--- a/boards/silabs/starter_kits/slstk3401a/slstk3401a-pinctrl.dtsi
+++ b/boards/silabs/starter_kits/slstk3401a/slstk3401a-pinctrl.dtsi
@@ -7,6 +7,15 @@
 #include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <GECKO_PSEL(I2C_SDA, C, 10)>,
+				<GECKO_PSEL(I2C_SCL, C, 11)>,
+				<GECKO_LOC(I2C_SDA, 15)>,
+				<GECKO_LOC(I2C_SCL, 15)>;
+		};
+	};
+
 	/* configuration for usart0 device, default state - operating as UART */
 	usart0_default: usart0_default {
 		group1 {
@@ -14,15 +23,6 @@
 				<GECKO_PSEL(UART_RX, A, 1)>,
 				<GECKO_LOC(UART_TX, 0)>,
 				<GECKO_LOC(UART_RX, 1)>;
-		};
-	};
-
-	i2c0_default: i2c0_default {
-		group1 {
-			psels = <GECKO_PSEL(I2C_SDA, C, 10)>,
-				<GECKO_PSEL(I2C_SCL, C, 11)>,
-				<GECKO_LOC(I2C_SDA, 15)>,
-				<GECKO_LOC(I2C_SCL, 15)>;
 		};
 	};
 };

--- a/boards/silabs/starter_kits/slstk3402a/slstk3402a-pinctrl.dtsi
+++ b/boards/silabs/starter_kits/slstk3402a/slstk3402a-pinctrl.dtsi
@@ -7,6 +7,15 @@
 #include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
+	i2c0_default: i2c0_default {
+		group1 {
+			psels = <GECKO_PSEL(I2C_SDA, C, 10)>,
+				<GECKO_PSEL(I2C_SCL, C, 11)>,
+				<GECKO_LOC(I2C_SDA, 15)>,
+				<GECKO_LOC(I2C_SCL, 15)>;
+		};
+	};
+
 	/* configuration for usart0 device, default state - operating as UART */
 	usart0_default: usart0_default {
 		group1 {
@@ -14,15 +23,6 @@
 				<GECKO_PSEL(UART_RX, A, 1)>,
 				<GECKO_LOC(UART_TX, 0)>,
 				<GECKO_LOC(UART_RX, 0)>;
-		};
-	};
-
-	i2c0_default: i2c0_default {
-		group1 {
-			psels = <GECKO_PSEL(I2C_SDA, C, 10)>,
-				<GECKO_PSEL(I2C_SCL, C, 11)>,
-				<GECKO_LOC(I2C_SDA, 15)>,
-				<GECKO_LOC(I2C_SCL, 15)>;
 		};
 	};
 };

--- a/boards/silabs/starter_kits/slstk3402a/slstk3402a_common.dtsi
+++ b/boards/silabs/starter_kits/slstk3402a/slstk3402a_common.dtsi
@@ -13,9 +13,9 @@
 
 	chosen {
 		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -31,10 +31,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpiof 4 0>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpiof 5 0>;
 			label = "LED 1";
@@ -42,6 +44,7 @@
 	};
 
 	buttons {
+
 		compatible = "gpio-keys";
 		button0: button_0 {
 			/* gpio flags need validation */
@@ -49,6 +52,7 @@
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpiof 7 GPIO_ACTIVE_LOW>;
@@ -59,7 +63,7 @@
 
 	pwmleds {
 		compatible = "pwm-leds";
-		status = "okay";
+
 		pwm_led0: pwm_led0 {
 			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -99,9 +103,9 @@
 	status = "okay";
 
 	pwm0: pwm {
-		status = "okay";
 		pin-location = <GECKO_LOCATION(28) GECKO_PORT_F GECKO_PIN(4)>;
 		prescaler = <1024>;
+		status = "okay";
 	};
 };
 
@@ -142,7 +146,6 @@
 
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -150,8 +153,8 @@
 
 		/* Set 6Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fe800 {
-			label = "storage";
 			reg = <0x000fe800 0x00001800>;
+			label = "storage";
 		};
 
 	};

--- a/boards/silabs/starter_kits/slstk3402a/slstk3402a_efm32jg12b500f1024gl125.dts
+++ b/boards/silabs/starter_kits/slstk3402a/slstk3402a_efm32jg12b500f1024gl125.dts
@@ -11,5 +11,4 @@
 / {
 	model = "Silicon Labs EFM32JG12 STK3402A board ";
 	compatible = "silabs,slstk3402a_jg", "silabs,efm32jg12b";
-
 };

--- a/boards/silabs/starter_kits/slstk3701a/slstk3701a-pinctrl.dtsi
+++ b/boards/silabs/starter_kits/slstk3701a/slstk3701a-pinctrl.dtsi
@@ -7,25 +7,6 @@
 #include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
-	/* configuration for usart0 device, default state - operating as UART */
-	usart0_default: usart0_default {
-		group1 {
-			psels = <GECKO_PSEL(UART_TX, A, 0)>,
-				<GECKO_PSEL(UART_RX, A, 1)>,
-				<GECKO_LOC(UART_TX, 0)>,
-				<GECKO_LOC(UART_RX, 0)>;
-		};
-	};
-
-	usart4_default: usart4_default {
-		group1 {
-			psels = <GECKO_PSEL(UART_TX, H, 4)>,
-				<GECKO_PSEL(UART_RX, H, 5)>,
-				<GECKO_LOC(UART_TX, 4)>,
-				<GECKO_LOC(UART_RX, 4)>;
-		};
-	};
-
 	i2c0_default: i2c0_default {
 		group1 {
 			psels = <GECKO_PSEL(I2C_SDA, C, 0)>,
@@ -50,6 +31,25 @@
 				<GECKO_PSEL(I2C_SCL, I, 5)>,
 				<GECKO_LOC(I2C_SDA, 7)>,
 				<GECKO_LOC(I2C_SCL, 7)>;
+		};
+	};
+
+	/* configuration for usart0 device, default state - operating as UART */
+	usart0_default: usart0_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, A, 0)>,
+				<GECKO_PSEL(UART_RX, A, 1)>,
+				<GECKO_LOC(UART_TX, 0)>,
+				<GECKO_LOC(UART_RX, 0)>;
+		};
+	};
+
+	usart4_default: usart4_default {
+		group1 {
+			psels = <GECKO_PSEL(UART_TX, H, 4)>,
+				<GECKO_PSEL(UART_RX, H, 5)>,
+				<GECKO_LOC(UART_TX, 4)>,
+				<GECKO_LOC(UART_RX, 4)>;
 		};
 	};
 };

--- a/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
+++ b/boards/silabs/starter_kits/slstk3701a/slstk3701a.dts
@@ -16,9 +16,9 @@
 
 	chosen {
 		zephyr,console = &usart4;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart4;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -32,10 +32,12 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led_0 {
 			gpios = <&gpioh 10 GPIO_ACTIVE_LOW>;
 			label = "LED 0";
 		};
+
 		led1: led_1 {
 			gpios = <&gpioh 13 GPIO_ACTIVE_LOW>;
 			label = "LED 1";
@@ -44,12 +46,14 @@
 
 	buttons {
 		compatible = "gpio-keys";
+
 		button0: button_0 {
 			/* gpio flags need validation */
 			gpios = <&gpioc 8 GPIO_ACTIVE_LOW>;
 			label = "User Push Button 0";
 			zephyr,code = <INPUT_KEY_0>;
 		};
+
 		button1: button_1 {
 			/* gpio flags need validation */
 			gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
@@ -161,20 +165,19 @@
 
 	/* RMII interface pins */
 	location-rmii        = <GECKO_LOCATION(1)>;
-	location-rmii-refclk = <GECKO_LOCATION(5) GECKO_PORT_D GECKO_PIN(10)>;
 	location-rmii-crs-dv = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(11)>;
-	location-rmii-txd0   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(7)>;
-	location-rmii-txd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(6)>;
-	location-rmii-tx-en  = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(8)>;
+	location-rmii-refclk = <GECKO_LOCATION(5) GECKO_PORT_D GECKO_PIN(10)>;
+	location-rmii-rx-er  = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(12)>;
 	location-rmii-rxd0   = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(9)>;
 	location-rmii-rxd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(9)>;
-	location-rmii-rx-er  = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(12)>;
+	location-rmii-tx-en  = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(8)>;
+	location-rmii-txd0   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(7)>;
+	location-rmii-txd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(6)>;
 
 	status = "okay";
 };
 
 &flash0 {
-
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -182,8 +185,8 @@
 
 		/* Set 12Kb of storage at the end of the 2048Kb of flash */
 		storage_partition: partition@1fd000 {
-			label = "storage";
 			reg = <0x001fd000 0x00003000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi
@@ -8,26 +8,13 @@
 #include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
-	/* configuration for uart0 device, default state */
-	usart0_default: usart0_default {
-		group0 {
-			pins = <USART0_TX_PA5>;
-			drive-push-pull;
-			output-high;
-		};
-		group1 {
-			pins = <USART0_RX_PA6>;
-			input-enable;
-			silabs,input-filter;
-		};
-	};
-
 	eusart1_default: eusart1_default {
 		group0 {
 			pins = <EUSART1_TX_PC6>, <EUSART1_SCLK_PC2>, <EUSART1_CS_PA7>;
 			drive-push-pull;
 			output-high;
 		};
+
 		group1 {
 			pins = <EUSART1_RX_PC3>;
 			input-enable;
@@ -42,4 +29,18 @@
 		};
 	};
 
+	/* configuration for uart0 device, default state */
+	usart0_default: usart0_default {
+		group0 {
+			pins = <USART0_TX_PA5>;
+			drive-push-pull;
+			output-high;
+		};
+
+		group1 {
+			pins = <USART0_RX_PA6>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
 };

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -16,12 +16,12 @@
 	 compatible = "sparkfun,sparkfun_thing_plus_mgm240p", "silabs,efr32mg24";
 
 	chosen {
+		zephyr,bt-hci = &bt_hci_silabs;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart0;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
-		zephyr,bt-hci = &bt_hci_silabs;
 	};
 
 	aliases {
@@ -32,17 +32,16 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		blue_led: led_1 {
 			gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 
 	wake_up_trigger: gpio-wake-up  {
 		compatible = "silabs,gecko-wake-up-trigger";
 		gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
 	};
-
 };
 
 &cpu0 {
@@ -50,19 +49,19 @@
 };
 
 &hfxo {
-	status = "okay";
 	ctune = <140>;
 	precision = <50>;
+	status = "okay";
 };
 
 &hfrcodpll {
 	clock-frequency = <DT_FREQ_M(78)>;
 	clocks = <&hfxo>;
-	dpll-n = <3839>;
-	dpll-m = <1919>;
+	dpll-autorecover;
 	dpll-edge = "fall";
 	dpll-lock = "phase";
-	dpll-autorecover;
+	dpll-m = <1919>;
+	dpll-n = <3839>;
 };
 
 &usart0 {
@@ -87,7 +86,6 @@
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 	status = "okay";
-
 };
 
 &gpio {
@@ -133,33 +131,33 @@
 
 		/* Reserve 48 kB for the bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 0x0000c000>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Reserve 464 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
-			label = "storage";
 			reg = <0x0000c000 0x00074000>;
+			label = "storage";
 		};
 
 		/* Reserve 464 kB for the application in slot 1 */
 		slot1_partition: partition@80000 {
-			label = "image-0";
 			reg = <0x00080000 0x00074000>;
+			label = "image-0";
 		};
 
 		/* Reserve 32 kB for the scratch partition */
 		scratch_partition: partition@f4000 {
-			label = "image-1";
 			reg = <0x000f4000 0x00008000>;
+			label = "image-1";
 		};
 
 		/* Set 528Kb of storage at the end of the 1024Kb of flash */
 		storage_partition: partition@fc000 {
-			label = "image-scratch";
 			reg = <0x000fc000 0x00084000>;
+			label = "image-scratch";
 		};
 	};
 };


### PR DESCRIPTION
Fix board DTS coding style issues to prevent them from spreading when a new board is introduced and uses an existing DTS as a referance.

Issues addressed from Zephyr devicetree style guidelines [1]:
- Don’t insert empty lines before a deindenting };.
- Insert a single empty line to separate nodes at the same hierarchy level.
- status is "okay" by default.
- compatible property comes first in node.
- reg property comes second in node.
- status property comes last in node.
- the rest of the properties within are nodes naturally sorted.
- child nodes are sorted by address or alphabetically if there is no address.

No functional change.

Link: https://docs.zephyrproject.org/latest/contribute/style/devicetree.html [1]

Took inspiration from https://github.com/zephyrproject-rtos/zephyr/pull/90312