### PR TITLE
drivers: clock_control: stm32: don't enable `RUNTIME_NMI` all the time

### DIFF
--- a/drivers/clock_control/Kconfig.stm32
+++ b/drivers/clock_control/Kconfig.stm32
@@ -13,7 +13,7 @@ menuconfig CLOCK_CONTROL_STM32_CUBE
 		SOC_SERIES_STM32H7RSX || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || \
 		SOC_SERIES_STM32N6X)
 	select RUNTIME_NMI if ($(dt_nodelabel_enabled,clk_hse) && \
-		$(dt_nodelabel_has_prop,clk_hse,css-enabled))
+		$(dt_nodelabel_bool_prop,clk_hse,css-enabled))
 	help
 	  Enable driver for Reset & Clock Control subsystem found
 	  in STM32 family of MCUs


### PR DESCRIPTION
The Clock Security System (CSS) feature signals failure of an external oscillator by triggering an NMI. As such, when this feature is enabled, `RUNTIME_NMI` must also be enabled such that the NMI handler can be modified to point to the appropriate function.

The STM32 clock control Kconfig checks whether the CSS has been enabled in Device Tree, and forcefully selects `RUNTIME_NMI` if enabled since the driver code will require it. However, the check has been implemented improperly: `dt_nodelabel_has_prop` was used instead of `dt_nodelabel_bool_prop`, an error similar to using `DT_NODE_HAS_PROP()` instead of `DT_PROP()` in C code.

Since the property always exists, as long as the HSE is enabled, the `RUNTIME_NMI` option is always select'ed, even if not actually required.

Use the correct Kconfig function to ensure RUNTIME_NMI is select'ed only when it is required, instead of whenever HSE is enabled regardless of CSS.