### PR TITLE
Bluetooth: CCP: Check conn type before access by index

### DIFF
--- a/subsys/bluetooth/audio/ccp_call_control_client.c
+++ b/subsys/bluetooth/audio/ccp_call_control_client.c
@@ -55,6 +55,8 @@ static struct bt_ccp_call_control_client clients[CONFIG_BT_MAX_CONN];
 
 static struct bt_ccp_call_control_client *get_client_by_conn(const struct bt_conn *conn)
 {
+	__ASSERT(bt_conn_is_type(conn, BT_CONN_TYPE_LE), "Invalid connection type for %p", conn);
+
 	return &clients[bt_conn_index(conn)];
 }
 
@@ -173,6 +175,11 @@ int bt_ccp_call_control_client_discover(struct bt_conn *conn,
 	CHECKIF(out_client == NULL) {
 		LOG_DBG("client is NULL");
 
+		return -EINVAL;
+	}
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		LOG_DBG("Invalid connection type for %p", conn);
 		return -EINVAL;
 	}
 

--- a/tests/bluetooth/audio/mocks/src/conn.c
+++ b/tests/bluetooth/audio/mocks/src/conn.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -75,4 +76,9 @@ void mock_bt_conn_disconnected(struct bt_conn *conn, uint8_t err)
 			cb->disconnected(conn, err);
 		}
 	}
+}
+
+bool bt_conn_is_type(const struct bt_conn *conn, enum bt_conn_type type)
+{
+	return true;
 }


### PR DESCRIPTION
Ensure that the connection type of the provided bt_conn is an LE connection.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/90563