### PR TITLE
ST DTS lint

### DIFF
--- a/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -180,8 +180,8 @@ zephyr_udc0: &usb {
 
 		/* Set aside 32KiB for data at the end of the 192KiB flash */
 		storage_partition: partition@28000 {
-			label = "storage";
 			reg = <0x00028000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/st/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -117,6 +117,7 @@ arduino_i2c: &i2c1 {};
 		     &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
 	status = "okay";
+
 	cs-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
 
 	lora: lora@0 {
@@ -148,8 +149,8 @@ arduino_i2c: &i2c1 {};
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &rtc {

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -102,15 +102,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
@@ -208,9 +208,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa15>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -240,10 +240,8 @@ zephyr_udc0: &usbotg_fs {
 		     &octospim_p1_io0_pe12 &octospim_p1_io1_pe13
 		     &octospim_p1_io2_pe14 &octospim_p1_io3_pe15>;
 	pinctrl-names = "default";
-
 	dmas = <&dma1 0 40 STM32_DMA_PERIPH_RX>; /* request 40 for OCTOSPI1 */
 	dma-names = "tx_rx";
-
 	status = "okay";
 
 	mx25r6435f: ospi-nor-flash@90000000 {
@@ -253,7 +251,6 @@ zephyr_udc0: &usbotg_fs {
 		spi-bus-width = <OSPI_QUAD_MODE>;
 		data-rate = <OSPI_STR_TRANSFER>;
 		writeoc="PP_1_4_4";
-
 		status = "okay";
 
 		partitions {

--- a/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/st/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -182,24 +182,24 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(976)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@104000 {
-			label = "image-1";
 			reg = <0x104000 DT_SIZE_K(976)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@1f8000 {
-			label = "storage";
 			reg = <0x1f8000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };
@@ -262,8 +262,8 @@ zephyr_udc0: &usbotg_fs {
 			#size-cells = <1>;
 
 			store_partition: partition@000 {
-				label = "store";
 				reg = <0x00000000 DT_SIZE_M(8)>;
+				label = "store";
 			};
 		};
 	};

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -50,28 +50,28 @@
 		 * Set the partitions with first MB to make use of the whole Bank1
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@78000 {
-			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@e0000 {
-			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
+			label = "image-scratch";
 		};
 
 		storage_partition: partition@f0000 {
-			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ns.dts
@@ -39,39 +39,39 @@
 		 */
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(224)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Secure image primary slot */
 		slot0_partition: partition@38000 {
-			label = "image-0";
 			reg = <0x00038000 DT_SIZE_K(384)>;
+			label = "image-0";
 		};
 
 		/* Non-secure image primary slot */
 		slot0_ns_partition: partition@98000 {
-			label = "image-0-nonsecure";
 			reg = <0x00098000 DT_SIZE_K(512)>;
+			label = "image-0-nonsecure";
 		};
 
 		/* Secure image secondary slot */
 		slot1_partition: partition@118000 {
-			label = "image-1";
 			reg = <0x00118000 DT_SIZE_K(384)>;
+			label = "image-1";
 		};
 
 		/* Non-secure image secondary slot */
 		slot1_ns_partition: partition@178000 {
-			label = "image-1-nonsecure";
 			reg = <0x00178000 DT_SIZE_K(512)>;
+			label = "image-1-nonsecure";
 		};
 
 		/* Applicative Non Volatile Storage */
 		storage_partition: partition@1f8000 {
-			label = "storage";
 			reg = <0x001f8000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -227,19 +227,19 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x10000 DT_SIZE_K(928)>;
+			label = "image-0";
 		};
 
 		storage_partition: partition@f8000 {
-			label = "storage";
 			reg = <0xf8000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };
@@ -338,13 +338,13 @@ zephyr_udc0: &usbotg_fs {
 			#size-cells = <1>;
 
 			slot1_partition: partition@0 {
-				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(864)>;
+				label = "image-1";
 			};
 
 			slot2_partition: partition@d8000 {
-				label = "image-3";
 				reg = <0x000d8000 DT_SIZE_M(7)>;
+				label = "image-3";
 			};
 		};
 	};

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -96,9 +96,9 @@
 };
 
 &clk_msi {
-	status = "okay";
 	msi-pll-mode;
 	msi-range = <11>; /* 48MHz USB bus clk */
+	status = "okay";
 };
 
 &pll {
@@ -136,15 +136,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
@@ -178,8 +178,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -192,10 +192,9 @@
 &spi3_miso_pc11 { slew-rate = "very-high-speed"; };
 
 &spi3 {
-	status = "okay";
-
 	pinctrl-0 = <&spi3_sck_pc10 &spi3_miso_pc11 &spi3_mosi_pc12>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	cs-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>,
 		   <&gpioe 0 GPIO_ACTIVE_LOW>;
@@ -249,9 +248,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa15>; /* CN1 pin 2 (ARD.D9-PWM) */
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -260,9 +259,9 @@
 	status = "okay";
 
 	pwm15: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim15_ch1_pb14>; /* LED2 */
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -307,9 +306,9 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &dma1 {
@@ -323,7 +322,6 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	dmas = <&dma1 5 5 0x0000>;
 	dma-names = "tx_rx";
-
 	status = "okay";
 
 	mx25r6435f: qspi-nor-flash@90000000 {

--- a/boards/st/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/st/nucleo_f091rc/nucleo_f091rc.dts
@@ -151,8 +151,8 @@
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
-			label = "storage";
 			reg = <0x0003e800 DT_SIZE_K(6)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/st/nucleo_f091rc/nucleo_f091rc.dts
@@ -103,8 +103,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
@@ -170,9 +170,9 @@
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &dma1 {

--- a/boards/st/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/st/nucleo_f103rb/nucleo_f103rb.dts
@@ -169,8 +169,8 @@
 
 		/* Set 2KB of storage at the end of 128KB flash */
 		storage_partition: partition@1f800 {
-			label = "storage";
 			reg = <0x0001f800 DT_SIZE_K(2)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/st/nucleo_f103rb/nucleo_f103rb.dts
@@ -97,8 +97,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_remap1_pb8 &i2c1_sda_remap1_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -120,9 +120,9 @@
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pwm_out_pa8>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -131,9 +131,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch2_pwm_in_pa1>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -122,15 +122,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &usart3 {
@@ -184,7 +184,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -195,12 +194,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -245,9 +245,9 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &backup_sram {
@@ -258,41 +258,41 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pe9>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &timers3 {
-	status = "okay";
 	st,prescaler = <10000>;
+	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch3_pb0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &timers4 {
-	status = "okay";
 	st,prescaler = <10000>;
+	status = "okay";
 
 	pwm4: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim4_ch2_pb7>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &timers12 {
-	status = "okay";
 	st,prescaler = <10000>;
+	status = "okay";
 
 	pwm12: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim12_ch1_pb14>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -215,8 +215,8 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(32)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -233,13 +233,13 @@ zephyr_udc0: &usbotg_fs {
 		 */
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x20000 DT_SIZE_K(448)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@90000 {
-			label = "image-1";
 			reg = <0x90000 DT_SIZE_K(448)>;
+			label = "image-1";
 		};
 	};
 };

--- a/boards/st/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/st/nucleo_f334r8/nucleo_f334r8.dts
@@ -96,8 +96,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -112,9 +112,9 @@
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pa8>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/st/nucleo_f334r8/nucleo_f334r8.dts
@@ -136,8 +136,8 @@
 
 		/* Set 6Kb of storage at the end of the 64Kb of flash */
 		storage_partition: partition@e800 {
-			label = "storage";
 			reg = <0x0000e800 DT_SIZE_K(6)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/st/nucleo_f401re/nucleo_f401re.dts
@@ -105,15 +105,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pc9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -168,9 +168,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa5>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/st/nucleo_f401re/nucleo_f401re.dts
@@ -137,8 +137,8 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -148,18 +148,18 @@
 		 */
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@40000 {
-			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@60000 {
-			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/st/nucleo_f410rb/nucleo_f410rb.dts
@@ -128,8 +128,8 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -138,8 +138,8 @@
 		 * 0x0000ffff
 		 */
 		slot0_partition: partition@8000 {
-			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(32)>;
+			label = "image-0";
 		};
 
 		/*
@@ -147,13 +147,13 @@
 		 * 0x001ffff
 		 */
 		slot1_partition: partition@10000 {
-			label = "image-1";
 			reg = <0x00010000 DT_SIZE_K(32)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@18000 {
-			label = "image-scratch";
 			reg = <0x00018000 DT_SIZE_K(32)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/st/nucleo_f410rb/nucleo_f410rb.dts
@@ -91,15 +91,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -116,9 +116,9 @@
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac_out1_pa5>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/st/nucleo_f413zh/nucleo_f413zh.dts
@@ -127,8 +127,8 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -138,18 +138,18 @@ zephyr_udc0: &usbotg_fs {
 		 */
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(256)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@60000 {
-			label = "image-1";
 			reg = <0x00060000 DT_SIZE_K(256)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@a0000 {
-			label = "image-scratch";
 			reg = <0x000a0000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f413zh/nucleo_f413zh.dts
+++ b/boards/st/nucleo_f413zh/nucleo_f413zh.dts
@@ -103,8 +103,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -158,9 +158,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -104,23 +104,23 @@
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -154,9 +154,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch3_pe13>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -179,7 +179,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -190,12 +189,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";

--- a/boards/st/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/st/nucleo_f429zi/nucleo_f429zi.dts
@@ -211,8 +211,8 @@ zephyr_udc0: &usbotg_fs {
 
 		/* 32KB for bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -230,20 +230,20 @@ zephyr_udc0: &usbotg_fs {
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(256)>;
+			label = "image-0";
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@60000 {
-			label = "image-1";
 			reg = <0x00060000 DT_SIZE_K(256)>;
+			label = "image-1";
 		};
 
 		/* swap slot: 128KB */
 		scratch_partition: partition@a0000 {
-			label = "image-scratch";
 			reg = <0x000a0000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.dts
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.dts
@@ -104,23 +104,23 @@
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -154,9 +154,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch3_pe13>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -179,7 +179,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -190,12 +189,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";

--- a/boards/st/nucleo_f439zi/nucleo_f439zi.dts
+++ b/boards/st/nucleo_f439zi/nucleo_f439zi.dts
@@ -211,8 +211,8 @@ zephyr_udc0: &usbotg_fs {
 
 		/* 32KB for bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -223,44 +223,44 @@ zephyr_udc0: &usbotg_fs {
 		 * Keep it commented in order it is not used by CI.
 		 *
 		 * storage_partition: partition@8000 {
-		 *	label = "storage";
 		 *	reg = <0x0008000 DT_SIZE_K(32)>;
+		 *	label = "storage";
 		 * };
 		 */
 
 		/* free sector: 64KB
 		 *
 		 * free0_partition: partition@10000 {
-		 *	label = "free-0";
 		 *	reg = <0x00010000 DT_SIZE_K(64)>;
+		 *	label = "free-0";
 		 * };
 		 */
 
 		/* application image slot: 896KB */
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(896)>;
+			label = "image-0";
 		};
 
 		/* free sectors: 4 * 16KB + 64KB
 		 *
 		 * free1_partition: partition@100000 {
-		 *	label = "free-1";
 		 *	reg = <0x00100000 DT_SIZE_K(128)>;
+		 *	label = "free-1";
 		 * };
 		 */
 
 		/* backup slot: 768KB */
 		slot1_partition: partition@120000 {
-			label = "image-1";
 			reg = <0x00120000 DT_SIZE_K(768)>;
+			label = "image-1";
 		};
 
 		/* free sector: 128KB
 		 *
 		 * free2_partition: partition@1e0000 {
-		 *	label = "free-2";
 		 *	reg = <0x0001e0000 DT_SIZE_K(128)>;
+		 *	label = "free-2";
 		 * };
 		 */
 	};

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -166,8 +166,8 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -177,23 +177,23 @@
 		 * by the application.
 		 */
 		storage_partition: partition@10000 {
-			label = "storage";
 			reg = <0x00010000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@40000 {
-			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@60000 {
-			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/st/nucleo_f446re/nucleo_f446re.dts
@@ -101,22 +101,22 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb3>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pa8 &i2c3_sda_pb4>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -130,9 +130,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa5>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -194,8 +194,8 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -205,21 +205,23 @@ zephyr_udc0: &usbotg_fs {
 		 * by the application.
 		 */
 		storage_partition: partition@10000 {
-			label = "storage";
 			reg = <0x00010000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
+			label = "image-0";
 		};
+
 		slot1_partition: partition@40000 {
-			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
+			label = "image-1";
 		};
+
 		scratch_partition: partition@60000 {
-			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/st/nucleo_f446ze/nucleo_f446ze.dts
@@ -127,15 +127,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 
@@ -165,9 +165,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pe9>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -96,12 +96,12 @@
 };
 
 &sdmmc1 {
-	status = "okay";
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9 &sdmmc1_d2_pc10
 		&sdmmc1_d3_pc11 &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &adc1 {
@@ -121,8 +121,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &can1 {
@@ -162,9 +162,9 @@
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch2_pe11 &tim1_ch3_pe13>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_f722ze/nucleo_f722ze.dts
+++ b/boards/st/nucleo_f722ze/nucleo_f722ze.dts
@@ -228,33 +228,33 @@ zephyr_udc0: &usbotg_fs {
 
 		/* sectors 0-3 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* sector 4 */
 		storage_partition: partition@10000 {
-			label = "storage";
 			reg = <0x00010000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 
 		/* sector 5 */
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
+			label = "image-0";
 		};
 
 		/* sector 6 */
 		slot1_partition: partition@40000 {
-			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
+			label = "image-1";
 		};
 
 		/* sector 7 */
 		scratch_partition: partition@60000 {
-			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -180,27 +180,27 @@ zephyr_udc0: &usbotg_fs {
 		 * there is no way to make the part smaller.
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(256)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {
-			label = "image-0";
 			reg = <0x00040000 DT_SIZE_K(256)>;
+			label = "image-0";
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@80000 {
-			label = "image-1";
 			reg = <0x00080000 DT_SIZE_K(256)>;
+			label = "image-1";
 		};
 
 		/* scratch slot: 256KB */
 		scratch_partition: partition@C0000 {
-			label = "image-scratch";
 			reg = <0x000C0000 DT_SIZE_K(256)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_f756zg/nucleo_f756zg.dts
+++ b/boards/st/nucleo_f756zg/nucleo_f756zg.dts
@@ -121,8 +121,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &timers1 {
@@ -130,9 +130,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch3_pe13>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -144,7 +144,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -155,12 +154,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";

--- a/boards/st/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/st/nucleo_f767zi/nucleo_f767zi.dts
@@ -130,8 +130,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &timers1 {
@@ -139,9 +139,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch3_pe13>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -181,9 +181,9 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &rng {
@@ -191,7 +191,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -202,12 +201,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -226,8 +226,8 @@ zephyr_udc0: &usbotg_fs {
 		 * the bootloader.
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x0 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -237,8 +237,8 @@ zephyr_udc0: &usbotg_fs {
 		 * This represents sectors 2-3 (32+32 kbytes)
 		 */
 		storage_partition: partition@10000 {
-			label = "storage";
 			reg = <0x00010000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 
 		/*
@@ -249,24 +249,24 @@ zephyr_udc0: &usbotg_fs {
 		 * Allocated 3 (256k x 3) sectors for image-0. Sectors 5-7.
 		 */
 		slot0_partition: partition@40000 {
-			label = "image-0";
 			reg = <0x00040000 DT_SIZE_K(768)>;
+			label = "image-0";
 		};
 
 		/*
 		 * Allocated 3 (256k x 3) sectors for image-1. Sectors 8-10.
 		 */
 		slot1_partition: partition@100000 {
-			label = "image-1";
 			reg = <0x00100000 DT_SIZE_K(768)>;
+			label = "image-1";
 		};
 
 		/*
 		 * Allocated 1 (256k) sector for image-scratch. Sector 11.
 		 */
 		scratch_partition: partition@1C0000 {
-			label = "image-scratch";
 			reg = <0x001C0000 DT_SIZE_K(256)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/st/nucleo_g070rb/nucleo_g070rb.dts
@@ -92,7 +92,6 @@
 &rtc {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000400>,
 		 <&rcc STM32_SRC_LSI RTC_SEL(2)>;
-
 	status = "okay";
 };
 
@@ -105,24 +104,24 @@
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pa6>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -144,8 +143,8 @@
 	pinctrl-names = "default";
 	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <4>;
-	status = "okay";
 	vref-mv = <3300>;
+	status = "okay";
 };
 
 &die_temp {

--- a/boards/st/nucleo_g070rb/nucleo_g070rb.dts
+++ b/boards/st/nucleo_g070rb/nucleo_g070rb.dts
@@ -160,8 +160,8 @@
 
 		/* Set 4KB of storage at the end of 128KB flash */
 		storage_partition: partition@1f000 {
-			label = "storage";
 			reg = <0x0001f000 DT_SIZE_K(4)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -173,8 +173,8 @@
 
 		/* Set 4KB of storage at the end of 128KB flash */
 		storage_partition: partition@1f000 {
-			label = "storage";
 			reg = <0x0001f000 DT_SIZE_K(4)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -110,24 +110,24 @@
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pa6>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -151,14 +151,14 @@
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
-	status = "okay";
 	vref-mv = <3300>;
+	status = "okay";
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &die_temp {

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -206,24 +206,24 @@ zephyr_udc0: &usb {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(48)>;
 			read-only;
+			reg = <0x00000000 DT_SIZE_K(48)>;
 		};
 
 		slot0_partition: partition@C000 {
-			label = "image-0";
 			reg = <0x0000C000 DT_SIZE_K(200)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@3E000 {
-			label = "image-1";
 			reg = <0x0003E000 DT_SIZE_K(200)>;
+			label = "image-1";
 		};
 
 		/* final 64KiB reserved for app storage partition */
 		storage_partition: partition@70000 {
-			label = "storage";
 			reg = <0x00070000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/st/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -63,8 +63,8 @@
 };
 
 &clk_hsi48 {
-	status = "okay";
 	crs-usb-sof;
+	status = "okay";
 };
 
 &pll {
@@ -119,9 +119,9 @@ zephyr_udc0: &usb {
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pb4>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -130,24 +130,24 @@ zephyr_udc0: &usb {
 	status = "okay";
 
 	pwm15: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim15_ch1_pb14>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa11 &i2c2_sda_pa12>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -177,9 +177,9 @@ zephyr_udc0: &usb {
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &fdcan1 {

--- a/boards/st/nucleo_g431kb/nucleo_g431kb.dts
+++ b/boards/st/nucleo_g431kb/nucleo_g431kb.dts
@@ -90,9 +90,9 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 
 	pwm4: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim4_ch3_pb8>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_g431kb/nucleo_g431kb.dts
+++ b/boards/st/nucleo_g431kb/nucleo_g431kb.dts
@@ -110,8 +110,8 @@ stm32_lp_tick_source: &lptim1 {
 
 		/* Set 4Kb of storage at the end of the 128Kb of flash */
 		storage_partition: partition@1f000 {
-			label = "storage";
 			reg = <0x0001f000 DT_SIZE_K(4)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/st/nucleo_g431rb/nucleo_g431rb.dts
@@ -146,9 +146,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa5>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -198,7 +198,7 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };

--- a/boards/st/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/st/nucleo_g431rb/nucleo_g431rb.dts
@@ -171,24 +171,24 @@ stm32_lp_tick_source: &lptim1 {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(34)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@8800 {
-			label = "image-0";
 			reg = <0x00008800 DT_SIZE_K(48)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@14800 {
-			label = "image-1";
 			reg = <0x00014800 DT_SIZE_K(42)>;
+			label = "image-1";
 		};
 
 		/* Set 4Kb of storage at the end of the 128Kb of flash */
 		storage_partition: partition@1f000 {
-			label = "storage";
 			reg = <0x0001f000 DT_SIZE_K(4)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -141,19 +141,20 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa5>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &timers3 {
 	st,prescaler = <10000>;
 	status = "okay";
+
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pb4>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -176,24 +176,24 @@ stm32_lp_tick_source: &lptim1 {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(34)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@8800 {
-			label = "image-0";
 			reg = <0x00008800 DT_SIZE_K(240)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@44800 {
-			label = "image-1";
 			reg = <0x00044800 DT_SIZE_K(234)>;
+			label = "image-1";
 		};
 
 		/* Set 4Kb of storage at the end of the 512Kb of flash */
 		storage_partition: partition@7f000 {
-			label = "storage";
 			reg = <0x0007f000 DT_SIZE_K(4)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -124,9 +124,9 @@
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch3_pb0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi-common.dtsi
@@ -181,23 +181,23 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(960)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@100000 {
-			label = "image-1";
 			reg = <0x00100000 DT_SIZE_K(960)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@1f0000 {
-			label = "storage";
 			reg = <0x001f0000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.dts
@@ -151,10 +151,10 @@
 };
 
 &spi1 {
-	status = "okay";
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
 };
 
 &i2c1 {

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -247,33 +247,33 @@ zephyr_udc0: &usbotg_fs {
 
 		/* 128KB for bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* storage: 128KB for settings */
 		storage_partition: partition@20000 {
-			label = "storage";
 			reg = <0x00020000 DT_SIZE_K(128)>;
+			label = "storage";
 		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {
-			label = "image-0";
 			reg = <0x00040000 DT_SIZE_K(256)>;
+			label = "image-0";
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@80000 {
-			label = "image-1";
 			reg = <0x00080000 DT_SIZE_K(256)>;
+			label = "image-1";
 		};
 
 		/* swap slot: 128KB */
 		scratch_partition: partition@c0000 {
-			label = "image-scratch";
 			reg = <0x000c0000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -151,9 +151,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm12: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim12_ch1_pb14>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -178,9 +178,9 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &rng {
@@ -204,7 +204,6 @@ zephyr_udc0: &usbotg_fs {
  *          must be in ON state.
  */
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -215,12 +214,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -229,10 +229,10 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &spi1 {
-	status = "okay";
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
 };
 
 &backup_sram {

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -140,8 +140,8 @@ zephyr_udc0: &usbotg_fs {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &timers12 {
@@ -149,9 +149,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm12: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim12_ch1_pb14>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -196,7 +196,6 @@ zephyr_udc0: &usbotg_fs {
  *          must be in ON state.
  */
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -207,12 +206,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -221,10 +221,10 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &spi1 {
-	status = "okay";
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/st/nucleo_h753zi/nucleo_h753zi.dts
@@ -235,33 +235,33 @@ zephyr_udc0: &usbotg_fs {
 
 		/* 128KB for bootloader */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* storage: 128KB for settings */
 		storage_partition: partition@20000 {
-			label = "storage";
 			reg = <0x00020000 DT_SIZE_K(128)>;
+			label = "storage";
 		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {
-			label = "image-0";
 			reg = <0x00040000 DT_SIZE_K(256)>;
+			label = "image-0";
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@80000 {
-			label = "image-1";
 			reg = <0x00080000 DT_SIZE_K(256)>;
+			label = "image-1";
 		};
 
 		/* swap slot: 128KB */
 		scratch_partition: partition@c0000 {
-			label = "image-scratch";
 			reg = <0x000c0000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -144,17 +144,17 @@
 };
 
 &spi1 {
-	status = "okay";
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pb5>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpiod 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -165,8 +165,8 @@
 
 		/* Set the partitions with first MB to make use of the whole Bank1 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 	};
 };
@@ -197,23 +197,23 @@
 			#size-cells = <1>;
 
 			slot0_partition: partition@0 {
-				label = "image-0";
 				reg = <0x00000000 DT_SIZE_K(512)>;
+				label = "image-0";
 			};
 
 			slot1_partition: partition@80000 {
-				label = "image-1";
 				reg = <0x0080000 DT_SIZE_K(512)>;
+				label = "image-1";
 			};
 
 			scratch_partition: partition@100000 {
-				label = "image-scratch";
 				reg = <0x00100000 DT_SIZE_K(64)>;
+				label = "image-scratch";
 			};
 
 			storage_partition: partition@110000 {
-				label = "storage";
 				reg = <0x00110000 DT_SIZE_K(64)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/st/nucleo_l152re/nucleo_l152re.dts
@@ -149,8 +149,8 @@
 
 		/* Set 8KB of storage at the end of 512KB flash */
 		storage_partition: partition@7e000 {
-			label = "storage";
 			reg = <0x0007e000 DT_SIZE_K(8)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/st/nucleo_l152re/nucleo_l152re.dts
@@ -136,9 +136,9 @@
 };
 
 &dac1 {
-	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &flash0 {
@@ -159,9 +159,9 @@
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pa6>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -138,8 +138,8 @@
 		 * Size = 16384 --> (HEX) 0x00004000
 		 */
 		storage_partition: partition@1c276 {
-			label = "storage";
 			reg = <0x0001c276 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/st/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -104,9 +104,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/st/nucleo_l432kc/nucleo_l432kc.dts
@@ -91,9 +91,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/st/nucleo_l432kc/nucleo_l432kc.dts
@@ -119,8 +119,8 @@
 		 * Reserve the final 16 KiB for file system partition
 		 */
 		storage_partition: partition@3c000 {
-			label = "storage";
 			reg = <0x0003c000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -114,9 +114,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/st/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -142,8 +142,8 @@
 		 * Reserve the final 16 KiB for file system partition
 		 */
 		storage_partition: partition@3c000 {
-			label = "storage";
 			reg = <0x0003c000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -120,8 +120,8 @@
 
 		/* Reserve the final 16 KiB for file system partition */
 		storage_partition: partition@7c000 {
-			label = "storage";
 			reg = <0x0007c000 0x00004000>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/st/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -94,9 +94,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -191,8 +191,8 @@ stm32_lp_tick_source: &lptim1 {
 
 		/* Set 32KB of storage at the end of 1024KB flash */
 		storage_partition: partition@f8000 {
-			label = "storage";
 			reg = <0x000f8000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -107,15 +107,15 @@ stm32_lp_tick_source: &lptim1 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -144,9 +144,9 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch3_pb10>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -155,9 +155,9 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pb4>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -180,9 +180,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/st/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -200,8 +200,8 @@ zephyr_udc0: &usbotg_fs {
 
 		/* Reserve last 16KiB for property storage */
 		storage_partition: partition@1FB000 {
-			label = "storage";
 			reg = <0x001FB000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.dts
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q_stm32l552xx_ns.dts
@@ -42,33 +42,33 @@
 		 */
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(80)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		/* Secure image primary slot */
 		slot0_partition: partition@14000 {
-			label = "image-0";
 			reg = <0x00014000 DT_SIZE_K(180)>;
+			label = "image-0";
 		};
 
 		/* Non-secure image primary slot */
 		slot0_ns_partition: partition@41000 {
-			label = "image-0-nonsecure";
 			reg = <0x00041000 DT_SIZE_K(36)>;
+			label = "image-0-nonsecure";
 		};
 
 		/* Secure image secondary slot */
 		slot1_partition: partition@4a000 {
-			label = "image-1";
 			reg = <0x0004a000 DT_SIZE_K(180)>;
+			label = "image-1";
 		};
 
 		/* Non-secure image secondary slot */
 		slot1_ns_partition: partition@77000 {
-			label = "image-1-nonsecure";
 			reg = <0x00077000 DT_SIZE_K(36)>;
+			label = "image-1-nonsecure";
 		};
 		/* Applicative Non Volatile Storage */
 		/* Not available in this config, use secure storage */

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -200,7 +200,6 @@ zephyr_udc0: &usbotg_hs1 {
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth1_rmii_ref_clk_pf7
 		     &eth1_rmii_crs_dv_pf10
 		     &eth1_rmii_rxd0_pf14
@@ -211,12 +210,13 @@ zephyr_udc0: &usbotg_hs1 {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth1_mdio_pf4 &eth1_mdc_pg11>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";

--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -251,8 +251,8 @@ zephyr_udc0: &usbotg_hs1 {
 			#size-cells = <1>;
 
 			storage_partition: partition@3ff0000 {
-				label = "storage";
 				reg = <0x3ff0000 DT_SIZE_K(64)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -155,8 +155,8 @@ stm32_lp_tick_source: &lptim1 {
 
 &spi1{
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
-	cs-gpios = <&gpiob 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpiob 6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	status = "okay";
 };
 

--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -45,23 +45,23 @@
 		 * with TZEN=0 (so w/o TFM).
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(1952)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@1f8000 {
-			label = "image-1";
 			reg = <0x001f8000 DT_SIZE_K(1960)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@3e2000 {
-			label = "storage";
 			reg = <0x003e2000 DT_SIZE_K(120)>;
+			label = "storage";
 		};
 
 	};

--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -175,8 +175,8 @@
 
 		/* Set 8KB of storage at the end of 192KB flash */
 		storage_partition: partition@2e000 {
-			label = "storage";
 			reg = <0x0002e000 DT_SIZE_K(8)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -148,16 +148,16 @@
 &spi3 {
 	pinctrl-0 = <&spi3_nss_pa9 &spi3_sck_pb3 &spi3_miso_pa8 &spi3_mosi_pa11>;
 	pinctrl-names = "default";
-	status = "okay";
 	/* Select 64MHz clock for SPI3 */
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 (1 << 14)>,
 		<&rcc STM32_SRC_SYSCLK SPI3_I2S3_SEL(3)>;
+	status = "okay";
 };
 
 
 &timers2 {
-	status = "okay";
 	st,prescaler = <10000>;
+	status = "okay";
 
 	pwm2: pwm {
 		/* PWM on red_led_1 */

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -147,20 +147,20 @@
 &spi2 {
 	pinctrl-0 = <&spi2_nss_pa4 &spi2_sck_pa5 &spi2_miso_pa7 &spi2_mosi_pa6>;
 	pinctrl-names = "default";
-	status = "okay";
 	/* Select 32MHz clock for SPI2 */
 	clocks = <&rcc STM32_CLOCK(APB1, 12)>,
 		<&rcc STM32_SRC_SYSCLK SPI2_I2S2_SEL(1)>;
+	status = "okay";
 };
 
 &timers1 {
-	status = "okay";
 	st,prescaler = <10000>;
+	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch3_pb2>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
+++ b/boards/st/nucleo_wb07cc/nucleo_wb07cc.dts
@@ -172,8 +172,8 @@
 
 		/* Set aside 16KB of storage at the end of 256KB flash */
 		storage_partition: partition@3c000 {
-			label = "storage";
 			reg = <0x0003c000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -148,15 +148,15 @@
 &spi3 {
 	pinctrl-0 = <&spi3_nss_pa9 &spi3_sck_pb3 &spi3_miso_pa8 &spi3_mosi_pa11>;
 	pinctrl-names = "default";
-	status = "okay";
 	/* Select 64MHz clock for SPI3 */
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 (1 << 14)>,
 		<&rcc STM32_SRC_SYSCLK SPI3_I2S3_SEL(3)>;
+	status = "okay";
 };
 
 &timers2 {
-	status = "okay";
 	st,prescaler = <10000>;
+	status = "okay";
 
 	pwm2: pwm {
 		/* PWM on red_led_1 */

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -174,8 +174,8 @@
 
 		/* Set 32KB of storage at the end of 512KB flash */
 		storage_partition: partition@78000 {
-			label = "storage";
 			reg = <0x00078000 DT_SIZE_K(32)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -127,15 +127,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pc0 &i2c3_sda_pc1>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &rtc {
@@ -160,9 +160,9 @@
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pa8>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -170,9 +170,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch1_pa15>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -204,9 +204,9 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 zephyr_udc0: &usb {
-	status = "okay";
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &rng {

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -231,28 +231,28 @@ zephyr_udc0: &usb {
 		 */
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@70000 {
-			label = "image-1";
 			reg = <0x00070000 DT_SIZE_K(400)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@d4000 {
-			label = "image-scratch";
 			reg = <0x000d4000 DT_SIZE_K(16)>;
+			label = "image-scratch";
 		};
 
 		storage_partition: partition@d8000 {
-			label = "storage";
 			reg = <0x000d8000 DT_SIZE_K(8)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -209,23 +209,23 @@ stm32_lp_tick_source: &lptim1 {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(456)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@82000 {
-			label = "image-1";
 			reg = <0x00082000 DT_SIZE_K(448)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@f2000 {
-			label = "storage";
 			reg = <0x000f2000 DT_SIZE_K(56)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
+++ b/boards/st/nucleo_wba55cg/nucleo_wba55cg.dts
@@ -122,10 +122,10 @@
 };
 
 &rtc {
-	status = "okay";
 	clocks = <&rcc STM32_CLOCK_BUS_APB7 0x00200000>,
 			<&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	prescaler = <32768>;
+	status = "okay";
 };
 
 &usart1 {
@@ -165,8 +165,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &adc4 {
@@ -186,9 +186,9 @@
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch2_pa9>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -161,8 +161,8 @@ stm32_lp_tick_source: &lptim1 {
 		#size-cells = <1>;
 
 		storage_partition: partition@1c0000 {
-			label = "storage";
 			reg = <0x001c0000 DT_SIZE_K(256)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -106,10 +106,10 @@
 };
 
 &rtc {
-	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB7, 21)>,
 			<&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	prescaler = <32768>;
+	status = "okay";
 };
 
 &usart1 {
@@ -132,8 +132,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb2 &i2c1_sda_pb1>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &adc4 {

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -204,19 +204,19 @@ stm32_lp_tick_source: &lptim1 {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(32)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		slot0_partition: partition@8000 {
-			label = "image-0";
 			reg = <0x00008000 DT_SIZE_K(104)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@22000 {
-			label = "image-1";
 			reg = <0x00022000 DT_SIZE_K(104)>;
+			label = "image-1";
 		};
 
 		/*
@@ -224,8 +224,8 @@ stm32_lp_tick_source: &lptim1 {
 		 * flash.
 		 */
 		storage_partition: partition@3c000 {
-			label = "storage";
 			reg = <0x0003c000 DT_SIZE_K(16)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -124,8 +124,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa12 &i2c2_sda_pa11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -146,9 +146,9 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch4_pb11>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -181,7 +181,6 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 
 	lora: radio@0 {
-		status = "okay";
 		tx-enable-gpios = <&gpioc 4 GPIO_ACTIVE_LOW>; /* FE_CTRL1 */
 		rx-enable-gpios = <&gpioc 5 GPIO_ACTIVE_LOW>; /* FE_CTRL2 */
 		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_1V7>;
@@ -194,6 +193,7 @@ stm32_lp_tick_source: &lptim1 {
 		power-amplifier-output = "rfo-hp";
 		rfo-lp-max-power = <15>;
 		rfo-hp-max-power = <22>;
+		status = "okay";
 	};
 };
 

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -218,8 +218,8 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -229,23 +229,23 @@ zephyr_udc0: &usbotg_fs {
 		 */
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(432)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@8c000 {
-			label = "image-1";
 			reg = <0x0008C000 DT_SIZE_K(432)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@f8000 {
-			label = "image-scratch";
 			reg = <0x000F8000 DT_SIZE_K(24)>;
+			label = "image-scratch";
 		};
 
 		storage_partition: partition@fc000 {
-			label = "storage";
 			reg = <0x000fc000 DT_SIZE_K(24)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -105,8 +105,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	hts221@5f {
 		compatible = "st,hts221";
@@ -124,8 +124,8 @@
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pg7 &i2c3_sda_pg8>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	stts751@38 {
 		compatible = "st,stts751";
@@ -170,6 +170,7 @@
 	pinctrl-0 = <&spi2_sck_pd1 &spi2_miso_pd3 &spi2_mosi_pc3>;
 	pinctrl-names = "default";
 	status = "okay";
+
 	cs-gpios = <&gpiod 0 GPIO_ACTIVE_LOW>;
 
 	spbtle_1s_sensortile_box: spbtle-1s@0 {

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -343,28 +343,28 @@ zephyr_udc0: &usbotg_fs {
 		 * Set the partitions with first MB to make use of the whole Bank1
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@78000 {
-			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@e0000 {
-			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
+			label = "image-scratch";
 		};
 
 		storage_partition: partition@f0000 {
-			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/sensortile_box_pro/sensortile_box_pro.dts
+++ b/boards/st/sensortile_box_pro/sensortile_box_pro.dts
@@ -91,9 +91,9 @@
 };
 
 &clk_msis {
-	status = "okay";
 	msi-range = <4>;
 	msi-pll-mode;
+	status = "okay";
 };
 
 &gpioi {
@@ -155,8 +155,9 @@ stm32_lp_tick_source: &lptim1 {
 &spi1 {
 	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;
 	status = "okay";
+
+	cs-gpios = <&gpioa 2 GPIO_ACTIVE_LOW>;
 
 	hci_spi: bluenrg-lp@0 {
 		compatible = "st,hci-spi-v2";
@@ -206,32 +207,32 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 &timers4 {
-	status = "okay";
 	st,prescaler = <1>;
+	status = "okay";
 
 	pwm4: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim4_ch1_pb6>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &timers3 {
-	status = "okay";
 	st,prescaler = <255>;
+	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch2_pe4>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	lps22df@5d {
 		compatible = "st,lps22df";
@@ -258,8 +259,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_ph5>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &aes {
@@ -317,7 +318,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &sdmmc1 {
-	status = "okay";
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2
@@ -329,6 +329,7 @@ zephyr_udc0: &usbotg_fs {
 	bus-width = <4>;
 	clk-div = <4>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
+++ b/boards/st/st25dv_mb1283_disco/st25dv_mb1283_disco.dts
@@ -138,8 +138,8 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	pinctrl-0 = <&spi2_mosi_pc3 &spi2_sck_pb13>;
-	cs-gpios = <&gpiob 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpiob 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	status = "okay";
 };
 

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -314,28 +314,28 @@ zephyr_udc0: &usbotg_fs {
 		 * Set the partitions with first MB to make use of the whole Bank1
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@78000 {
-			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@e0000 {
-			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
+			label = "image-scratch";
 		};
 
 		storage_partition: partition@f0000 {
-			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/steval_stwinbx1/steval_stwinbx1.dts
+++ b/boards/st/steval_stwinbx1/steval_stwinbx1.dts
@@ -82,9 +82,9 @@
 };
 
 &clk_msis {
-	status = "okay";
 	msi-range = <4>;
 	msi-pll-mode;
+	status = "okay";
 };
 
 &pll1 {
@@ -187,6 +187,7 @@ stm32_lp_tick_source: &lptim1 {
 	pinctrl-0 = <&spi3_sck_pg9 &spi3_miso_pb4 &spi3_mosi_pb5>;
 	pinctrl-names = "default";
 	status = "okay";
+
 	cs-gpios = <&gpioe 1 GPIO_ACTIVE_LOW>;
 
 	hci_spi: bluenrg-2@0 {
@@ -204,8 +205,8 @@ stm32_lp_tick_source: &lptim1 {
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_ph4 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	stts22h@3f {
 		compatible = "st,stts22h";
@@ -233,9 +234,9 @@ stm32_lp_tick_source: &lptim1 {
 	status = "okay";
 
 	pwm5: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim5_ch3_ph12>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -291,7 +292,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &sdmmc1 {
-	status = "okay";
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		&sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
@@ -300,6 +300,7 @@ zephyr_udc0: &usbotg_fs {
 	bus-width = <4>;
 	clk-div = <4>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/st/stm32f0_disco/stm32f0_disco.dts
@@ -109,8 +109,8 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(8)>;
+			label = "mcuboot";
 			read-only;
 		};
 
@@ -120,18 +120,18 @@
 		 */
 
 		slot0_partition: partition@4000 {
-			label = "image-0";
 			reg = <0x00004000 DT_SIZE_K(16)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@8000 {
-			label = "image-1";
 			reg = <0x00008000 DT_SIZE_K(16)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@c000 {
-			label = "image-scratch";
 			reg = <0x0000C000 DT_SIZE_K(16)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -204,8 +204,8 @@ zephyr_udc0: &usb {
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
-			label = "storage";
 			reg = <0x0003e800 DT_SIZE_K(6)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -137,8 +137,8 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	lsm303dlhc_magn: lsm303dlhc-magn@1e {
 		compatible = "st,lsm303dlhc-magn";
@@ -156,8 +156,8 @@
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pa9 &i2c2_sda_pa10>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &spi1 {
@@ -219,9 +219,9 @@ zephyr_udc0: &usb {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pa8>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -238,10 +238,10 @@ zephyr_udc0: &usb {
 };
 
 &dac1 {
-	status = "okay";
 	/* dac output pins(pa4,pa5,pa6) might conflict with spi1 pins */
 	pinctrl-0 = <&dac_out1_pa4>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &dma1 {

--- a/boards/st/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco.dts
@@ -127,34 +127,34 @@
 	status = "okay";
 
 	pwm4: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim4_ch1_pd12
 			     &tim4_ch2_pd13
 			     &tim4_ch3_pd14
 			     &tim4_ch4_pd15>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	lsm303agr_magn: lsm303agr-magn@1e {
 		compatible = "st,lis2mdl", "st,lsm303agr-magn";
-		status = "okay";
 		reg = <0x1e>;
 		irq-gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
+		status = "okay";
 	};
 
 	lsm303agr_accel: lsm303agr-accel@19 {
 		compatible = "st,lis2dh", "st,lsm303agr-accel";
-		status = "okay";
 		reg = <0x19>;
 		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
 			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
+		status = "okay";
 	};
 };
 

--- a/boards/st/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/st/stm32f411e_disco/stm32f411e_disco.dts
@@ -184,24 +184,24 @@ zephyr_udc0: &usbotg_fs {
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 			read-only;
 		};
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(128)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@40000 {
-			label = "image-1";
 			reg = <0x00040000 DT_SIZE_K(128)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@60000 {
-			label = "image-scratch";
 			reg = <0x00060000 DT_SIZE_K(128)>;
+			label = "image-scratch";
 		};
 	};
 };

--- a/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/st/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -187,8 +187,8 @@
 	pinctrl-0 = <&spi5_nss_pf6 &spi5_sck_pf7
 		     &spi5_miso_pf8 &spi5_mosi_pf9>;
 	pinctrl-names = "default";
-	status = "okay";
 	cs-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
+	status = "okay";
 };
 
 &fmc {
@@ -238,13 +238,15 @@
 		     &ltdc_b6_pb8 &ltdc_b7_pb9 &ltdc_de_pf10 &ltdc_clk_pg7
 		     &ltdc_hsync_pc6 &ltdc_vsync_pa4>;
 	pinctrl-names = "default";
-	ext-sdram = <&sdram2>;
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
 	display-controller = <&ili9341>;
-	status = "okay";
-
-	width = <240>;
+	ext-sdram = <&sdram2>;
 	height = <320>;
+	width = <240>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -259,10 +261,6 @@
 		hfront-porch = <10>;
 		vfront-porch = <4>;
 	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
 };
 
 zephyr_udc0: &usbotg_hs {

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -222,13 +222,13 @@ zephyr_udc0: &usbotg_fs {
 			#size-cells = <1>;
 
 			slot1_partition: partition@0 {
-				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(640)>;
+				label = "image-1";
 			};
 
 			storage_partition: partition@a0000 {
-				label = "storage";
 				reg = <0x000a0000 DT_SIZE_M(15)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -103,15 +103,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
@@ -152,9 +152,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pb4>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -169,17 +169,16 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &sdmmc1 {
-	status = "okay";
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -190,12 +189,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -250,7 +250,6 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	sdram {
-		status = "okay";
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
 		mode-register = <0x220>;
@@ -260,6 +259,7 @@ zephyr_udc0: &usbotg_fs {
 		 * Note: SDRAM_CLK_MHZ = HCLK_MHZ / 2 (108 MHz)
 		 */
 		refresh-rate = <1667>;
+		status = "okay";
 
 		bank@0 {
 			reg = <0>;
@@ -285,14 +285,16 @@ zephyr_udc0: &usbotg_fs {
 		     &ltdc_b4_pg12 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
 		     &ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi10 &ltdc_vsync_pi9>;
 	pinctrl-names = "default";
-	disp-on-gpios = <&gpioi 12 GPIO_ACTIVE_HIGH>;
 	bl-ctrl-gpios = <&gpiok 3 GPIO_ACTIVE_HIGH>;
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+	disp-on-gpios = <&gpioi 12 GPIO_ACTIVE_HIGH>;
 	ext-sdram = <&sdram1>;
-	status = "okay";
-
-	width = <480>;
 	height = <272>;
+	width = <480>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -307,8 +309,4 @@ zephyr_udc0: &usbotg_fs {
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
 };

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -94,15 +94,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_ph7 &i2c3_sda_ph8>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	ft5336: ft5336@38 {
 		compatible = "focaltech,ft5336";
@@ -143,9 +143,9 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch1_pb4>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -156,17 +156,16 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &sdmmc1 {
-	status = "okay";
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -177,12 +176,13 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -237,7 +237,6 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 
 	sdram {
-		status = "okay";
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
 		mode-register = <0x220>;
@@ -247,6 +246,7 @@ zephyr_udc0: &usbotg_fs {
 		 * Note: SDRAM_CLK_MHZ = HCLK_MHZ / 2 (108 MHz)
 		 */
 		refresh-rate = <1667>;
+		status = "okay";
 
 		bank@0 {
 			reg = <0>;
@@ -272,14 +272,16 @@ zephyr_udc0: &usbotg_fs {
 		     &ltdc_b4_pg12 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
 		     &ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi10 &ltdc_vsync_pi9>;
 	pinctrl-names = "default";
-	disp-on-gpios = <&gpioi 12 GPIO_ACTIVE_HIGH>;
 	bl-ctrl-gpios = <&gpiok 3 GPIO_ACTIVE_HIGH>;
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+	disp-on-gpios = <&gpioi 12 GPIO_ACTIVE_HIGH>;
 	ext-sdram = <&sdram1>;
-	status = "okay";
-
-	width = <480>;
 	height = <272>;
+	width = <480>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -294,8 +296,4 @@ zephyr_udc0: &usbotg_fs {
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
 };

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -209,13 +209,13 @@ zephyr_udc0: &usbotg_fs {
 			#size-cells = <1>;
 
 			slot1_partition: partition@0 {
-				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(640)>;
+				label = "image-1";
 			};
 
 			storage_partition: partition@a0000 {
-				label = "storage";
 				reg = <0x000a0000 DT_SIZE_M(15)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -207,13 +207,13 @@ arduino_serial: &usart6 {};
 			#size-cells = <1>;
 
 			slot1_partition: partition@0 {
-				label = "image-1";
 				reg = <0x00000000 DT_SIZE_K(16)>;
+				label = "image-1";
 			};
 
 			storage_partition: partition@1a0000 {
-				label = "storage";
 				reg = <0x001a0000 DT_SIZE_M(62)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -130,15 +130,15 @@ arduino_serial: &usart6 {};
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 };
 
 &i2c4 {
 	pinctrl-0 = <&i2c4_scl_pd12 &i2c4_sda_pb7>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	ft6202: ft6202@2a {
 		compatible = "focaltech,ft5336";
@@ -154,7 +154,6 @@ arduino_serial: &usart6 {};
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -165,12 +164,13 @@ arduino_serial: &usart6 {};
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -179,13 +179,13 @@ arduino_serial: &usart6 {};
 };
 
 &sdmmc2 {
-	status = "okay";
 	pinctrl-0 = <&sdmmc2_d0_pg9 &sdmmc2_d1_pg10
 		     &sdmmc2_d2_pb3 &sdmmc2_d3_pb4
 		     &sdmmc2_ck_pd6 &sdmmc2_cmd_pd7>;
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 15 GPIO_ACTIVE_LOW>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &quadspi {
@@ -220,7 +220,6 @@ arduino_serial: &usart6 {};
 };
 
 &fmc {
-	status = "okay";
 	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1 &fmc_nbl2_pi4 &fmc_nbl3_pi5
 		     &fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke0_ph2 &fmc_sdne0_ph3
 		     &fmc_sdnras_pf11 &fmc_sdncas_pg15
@@ -237,14 +236,14 @@ arduino_serial: &usart6 {};
 		     &fmc_d24_pi0 &fmc_d25_pi1 &fmc_d26_pi2 &fmc_d27_pi3
 		     &fmc_d28_pi6 &fmc_d29_pi7 &fmc_d30_pi9 &fmc_d31_pi10>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	sdram {
-		status = "okay";
-
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
 		mode-register = <0x230>;
 		refresh-rate = <603>;
+		status = "okay";
 
 		bank@0 {
 			reg = <0>;

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -296,29 +296,29 @@
 
 		/* Set the partitions with first MB to make use of the whole Bank1 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(416)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@78000 {
-			label = "image-1";
 			reg = <0x00078000 DT_SIZE_K(416)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@e0000 {
-			label = "image-scratch";
 			reg = <0x000e0000 DT_SIZE_K(64)>;
+			label = "image-scratch";
 		};
 
 		/* Set 64KB of storage at the end of Bank1 */
 		storage_partition: partition@f0000 {
-			label = "storage";
 			reg = <0x000f0000 DT_SIZE_K(64)>;
+			label = "storage";
 		};
 	};
 };
@@ -400,8 +400,8 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "nor";
 				reg = <0x00000000 DT_SIZE_M(64)>;
+				label = "nor";
 			};
 		};
 	};

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -238,9 +238,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch4_pa3>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -249,9 +249,9 @@
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch2_pb5>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -264,7 +264,6 @@
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_rxd0_pc4
 		     &eth_rxd1_pc5
 		     &eth_ref_clk_pa1
@@ -275,12 +274,13 @@
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -381,7 +381,6 @@
 		     &octospi1_clk_pf10 &octospi1_ncs_pg6
 		     &octospi1_dqs_pb2>;
 	pinctrl-names = "default";
-
 	status = "okay";
 
 	mx25lm51245: ospi-nor-flash@0 {

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -194,8 +194,8 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "nor";
 				reg = <0x00000000 DT_SIZE_M(4)>;
+				label = "nor";
 			};
 		};
 	};

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -147,9 +147,9 @@
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -177,7 +177,6 @@
 		     &octospim_p1_io6_pg9 &octospim_p1_io7_pd7
 		     &octospim_p1_dqs_pb2>;
 	pinctrl-names = "default";
-
 	status = "okay";
 
 	mx25lm51245: ospi-nor-flash@90000000 {
@@ -249,7 +248,7 @@
 };
 
 zephyr_udc0: &usbotg_hs {
-	status = "okay";
 	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
 	pinctrl-names = "default";
+	status = "okay";
 };

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -136,7 +136,6 @@
 	 * Cf Ethernet section in board documentation for more information on
 	 * the hw modification to be done to enable it.
 	 */
-	status = "okay";
 	pinctrl-0 = <&eth_ref_clk_pa1
 		     &eth_crs_dv_pa7
 		     &eth_rxd0_pc4
@@ -147,12 +146,13 @@
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -165,7 +165,6 @@
 };
 
 &fmc {
-	status = "okay";
 	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1 &fmc_nbl2_pi4 &fmc_nbl3_pi5
 		     &fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke1_ph7
 		     &fmc_sdne1_ph6 &fmc_sdnras_pf11 &fmc_sdncas_pg15
@@ -182,14 +181,14 @@
 		     &fmc_d27_pi3 &fmc_d28_pi6 &fmc_d29_pi7 &fmc_d30_pi9
 		     &fmc_d31_pi10>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	sdram {
-		status = "okay";
-
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
 		mode-register = <0x220>;
 		refresh-rate = <603>;
+		status = "okay";
 
 		bank@1 {
 			reg = <1>;
@@ -230,7 +229,6 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &sdmmc1 {
-	status = "okay";
 	clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00010000>,
 			<&rcc STM32_SRC_PLL2_R SDMMC_SEL(1)>;
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
@@ -241,6 +239,7 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &quadspi {

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -121,8 +121,8 @@
 
 		/* Set 2KB of storage at the end of first 1MB flash */
 		storage_partition: partition@ff800 {
-			label = "storage";
 			reg = <0x000ff800 DT_SIZE_K(2)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -90,8 +90,8 @@
 
 		/* Flash has 128KB sector size */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
+			label = "mcuboot";
 		};
 	};
 };
@@ -201,18 +201,18 @@
 			#size-cells = <1>;
 
 			slot0_partition: partition@0 {
-				label = "image-0";
 				reg = <0x00000000 DT_SIZE_K(2048)>;
+				label = "image-0";
 			};
 
 			slot1_partition: partition@200000 {
-				label = "image-1";
 				reg = <0x00200000 DT_SIZE_K(2048)>;
+				label = "image-1";
 			};
 
 			storage_partition: partition@400000 {
-				label = "storage";
 				reg = <0x00400000 DT_SIZE_K(128)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -105,18 +105,17 @@
 		&ltdc_b4_pk3 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
 		&ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi12 &ltdc_vsync_pi9>;
 	pinctrl-names = "default";
-
-	disp-on-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
-
-	ext-sdram = <&sdram2>;
-	status = "okay";
-
 	clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>,
 		<&rcc STM32_SRC_PLL3_R NO_SEL>;
-
-	width = <480>;
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+	disp-on-gpios = <&gpiod 7 GPIO_ACTIVE_HIGH>;
+	ext-sdram = <&sdram2>;
 	height = <272>;
+	width = <480>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -131,10 +130,6 @@
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
 };
 
 &pll {
@@ -241,11 +236,11 @@
 	status = "okay";
 
 	sdram {
-		status = "okay";
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
 		mode-register = <0x230>;
 		refresh-rate = <0x603>;
+		status = "okay";
 
 		bank@1 {
 			reg = <1>;

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -151,7 +151,6 @@
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth_ref_clk_pa1
 		     &eth_crs_dv_pa7
 		     &eth_rxd0_pc4
@@ -162,12 +161,13 @@
 	pinctrl-names = "default";
 	phy-connection-type = "rmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth_mdio_pa2 &eth_mdc_pc1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -180,7 +180,6 @@
 };
 
 &fmc {
-	status = "okay";
 	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1 &fmc_nbl2_pi4 &fmc_nbl3_pi5
 		     &fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke1_ph7
 		     &fmc_sdne1_ph6 &fmc_sdnras_pf11 &fmc_sdncas_pg15
@@ -197,14 +196,14 @@
 		     &fmc_d27_pi3 &fmc_d28_pi6 &fmc_d29_pi7 &fmc_d30_pi9
 		     &fmc_d31_pi10>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	sdram {
-		status = "okay";
-
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
 		mode-register = <0x220>;
 		refresh-rate = <603>;
+		status = "okay";
 
 		bank@1 {
 			reg = <1>;
@@ -245,7 +244,6 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &sdmmc1 {
-	status = "okay";
 	clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00010000>,
 			<&rcc STM32_SRC_PLL2_R SDMMC_SEL(1)>;
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
@@ -256,6 +254,7 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-names = "default";
 	cd-gpios = <&gpioi 8 GPIO_ACTIVE_LOW>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &quadspi {

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -129,23 +129,23 @@
 		#size-cells = <1>;
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(128)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@20000 {
-			label = "image-0";
 			reg = <0x00020000 DT_SIZE_K(896)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@100000 {
-			label = "image-1";
 			reg = <0x00100000 DT_SIZE_K(896)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@1e0000 {
-			label = "storage";
 			reg = <0x001e0000 DT_SIZE_K(128)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -208,11 +208,11 @@
 	status = "okay";
 
 	sdram {
-		status = "okay";
 		power-up-delay = <100>;
 		num-auto-refresh = <8>;
 		mode-register = <0x220>;
 		refresh-rate = <0x603>;
+		status = "okay";
 
 		bank@1 {
 			reg = <1>;
@@ -248,14 +248,16 @@
 		     &ltdc_b4_pk3 &ltdc_b5_pk4 &ltdc_b6_pk5 &ltdc_b7_pk6
 		     &ltdc_de_pk7 &ltdc_clk_pi14 &ltdc_hsync_pi12 &ltdc_vsync_pi13>;
 	pinctrl-names = "default";
-	disp-on-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	bl-ctrl-gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+	disp-on-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	ext-sdram = <&sdram2>;
-	status = "okay";
-
-	width = <480>;
 	height = <272>;
+	width = <480>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -270,10 +272,6 @@
 		hfront-porch = <8>;
 		vfront-porch = <4>;
 	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
 };
 
 &octospi1 {
@@ -284,7 +282,6 @@
 		     &octospim_p1_io6_pg9 &octospim_p1_io7_pd7
 		     &octospim_p1_dqs_pc5>;
 	pinctrl-names = "default";
-
 	status = "okay";
 
 	mx25lm51245: ospi-nor-flash@90000000 {

--- a/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/st/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -301,8 +301,8 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "nor";
 				reg = <0x00000000 DT_SIZE_M(4)>;
+				label = "nor";
 			};
 		};
 	};

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -220,8 +220,8 @@
 
 		/* Set the partitions with first MB to make use of the whole Bank1 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 	};
 };
@@ -252,23 +252,23 @@
 			#size-cells = <1>;
 
 			slot0_partition: partition@0 {
-				label = "image-0";
 				reg = <0x00000000 DT_SIZE_K(512)>;
+				label = "image-0";
 			};
 
 			slot1_partition: partition@80000 {
-				label = "image-1";
 				reg = <0x0080000 DT_SIZE_K(512)>;
+				label = "image-1";
 			};
 
 			scratch_partition: partition@100000 {
-				label = "image-scratch";
 				reg = <0x00100000 DT_SIZE_K(64)>;
+				label = "image-scratch";
 			};
 
 			storage_partition: partition@110000 {
-				label = "storage";
 				reg = <0x00110000 DT_SIZE_K(64)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -128,9 +128,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch4_pa3>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -139,9 +139,9 @@
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim3_ch2_pb5>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -194,7 +194,6 @@
 		     &xspim_p1_io9_pp9 &xspim_p1_io10_pp10 &xspim_p1_io11_pp11
 		     &xspim_p1_io12_pp12 &xspim_p1_io13_pp13 &xspim_p1_io14_pp14
 		     &xspim_p1_io15_pp15>;
-
 	pinctrl-names = "default";
 	status = "okay";
 
@@ -234,7 +233,6 @@
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11
 		     &xspim_p2_dqs0_pn0>;
 	pinctrl-names = "default";
-
 	status = "okay";
 
 	mx66uw1g45: xspi-nor-flash@0 {

--- a/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
+++ b/boards/st/stm32l4r9i_disco/stm32l4r9i_disco.dts
@@ -121,13 +121,12 @@
 };
 
 &clk_msi {
-	status = "okay";
 	msi-range = <6>;
 	msi-pll-mode;
+	status = "okay";
 };
 
 &pll {
-	status = "okay";
 	div-m = <1>;
 	mul-n = <60>;
 	/*
@@ -138,6 +137,7 @@
 	div-q = <2>;
 	div-r = <2>;
 	clocks = <&clk_msi>;
+	status = "okay";
 };
 
 &rcc {
@@ -149,24 +149,23 @@
 };
 
 &usart2 {
-	status = "okay";
 	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
 };
 
 &lpuart1 {
-	status = "okay";
 	pinctrl-0 = <&lpuart1_tx_pc1 &lpuart1_rx_pc0>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
 };
 
 &timers3 {
 	status = "okay";
 
 	pwm3: pwm {
-		status = "okay";
 		/*
 		 * N.B.: Datasheet indicates that ARD_D11 (wired to PB15) is connected to TIM3_CH2.
 		 * However, this is incorrect as PB15 cannot be muxed to TIM3 (see DS12023).
@@ -174,6 +173,7 @@
 		 */
 		pinctrl-0 = <&tim3_ch1_pb4>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -181,9 +181,9 @@
 	status = "okay";
 
 	pwm5: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim5_ch2_pa1 &tim5_ch4_pi0>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -191,9 +191,9 @@
 	status = "okay";
 
 	pwm8: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim8_ch1n_ph13>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -201,17 +201,17 @@
 	status = "okay";
 
 	pwm15: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim15_ch2_pf10 &tim15_ch2_pb15>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
 st_cam_i2c: &i2c1 {
-	status = "okay";
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 
 	mfx: gpio@42 {
 		compatible = "st,mfxstm32l152";
@@ -224,17 +224,17 @@ st_cam_i2c: &i2c1 {
 };
 
 &i2c3 {
-	status = "okay";
 	pinctrl-0 = <&i2c3_scl_pg7 &i2c3_sda_pg8>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &spi2 {
-	status = "okay";
 	pinctrl-0 = <&spi2_sck_pb13 &spi2_miso_pb14 &spi2_mosi_pb15>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpioi 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+	status = "okay";
 };
 
 &rtc {
@@ -244,28 +244,28 @@ st_cam_i2c: &i2c1 {
 };
 
 &sdmmc1 {
-	status = "okay";
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		&sdmmc1_d2_pc10 &sdmmc1_d3_pc11
 		&sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
 	disk-name = "SD";
+	status = "okay";
 };
 
 &adc1 {
-	status = "okay";
 	pinctrl-0 = <&adc1_in5_pa0 &adc1_in12_pa7 &adc1_in15_pb0
 			&adc1_in4_pc3 &adc1_in13_pc4>;
 	pinctrl-names = "default";
 	st,adc-clock-source = "SYNC";
 	st,adc-prescaler = <1>;
+	status = "okay";
 };
 
 zephyr_udc0: &usbotg_fs {
-	status = "okay";
 	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12
 			&usb_otg_fs_id_pa10>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &die_temp {
@@ -281,7 +281,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &octospi2 {
-	status = "okay";
 	pinctrl-0 = <&octospim_p2_clk_pi6 &octospim_p2_ncs_pg12
 			&octospim_p2_io0_pi11 &octospim_p2_io1_pi10
 			&octospim_p2_io2_pi9 &octospim_p2_io3_ph8
@@ -289,9 +288,9 @@ zephyr_udc0: &usbotg_fs {
 			&octospim_p2_io6_pg9 &octospim_p2_io7_pg10
 			&octospim_p2_dqs_pg15>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	mx25lm51245: ospi-nor-flash@90000000 {
-		status = "okay";
 		compatible = "st,stm32-ospi-nor";
 		reg = <0x90000000 DT_SIZE_M(64)>; /* 512 Mbits */
 		ospi-max-frequency = <DT_FREQ_M(25)>;

--- a/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/st/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -234,7 +234,6 @@ stm32_lp_tick_source: &lptim1 {
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
-		status = "okay";
 		sfdp-bfp = [
 			53 46 44 50 06 01 02 ff
 			00 06 01 10 30 00 00 ff

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -139,14 +139,15 @@
 			&ltdc_b4_ph14 &ltdc_b5_pe0 &ltdc_b6_pb6 &ltdc_b7_pf1
 			&ltdc_de_ph9 &ltdc_clk_pd9 &ltdc_hsync_pc6 &ltdc_vsync_pg4>;
 	pinctrl-names = "default";
-	disp-on-gpios = <&gpioi 7 GPIO_ACTIVE_HIGH>;
 	bl-ctrl-gpios = <&gpioe 12 GPIO_ACTIVE_HIGH>;
-
-	status = "okay";
-
-	width = <480>;
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+	disp-on-gpios = <&gpioi 7 GPIO_ACTIVE_HIGH>;
 	height = <272>;
+	width = <480>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -161,8 +162,4 @@
 		hfront-porch = <32>;
 		vfront-porch = <2>;
 	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
 };

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -67,12 +67,12 @@
 };
 
 &i2c2 {
-	status = "okay";
 	clocks = <&rcc STM32_CLOCK(APB1, 22)>,
 		 <&rcc STM32_SRC_CKPER I2C2_SEL(1)>;
 	pinctrl-0 = <&i2c2_scl_pd14 &i2c2_sda_pd4>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	gt911: gt911@5d {
 		compatible = "goodix,gt911";
@@ -237,7 +237,6 @@ csi_22pins_i2c: &i2c1 {
 };
 
 &sdmmc2 {
-	status = "okay";
 	clocks = <&rcc STM32_CLOCK(AHB5, 7)>,
 		 <&rcc STM32_SRC_IC4 SDMMC2_SEL(2)>;
 	pinctrl-0 = <&sdmmc2_d0_pc4 &sdmmc2_d1_pc5
@@ -248,6 +247,7 @@ csi_22pins_i2c: &i2c1 {
 	cd-gpios = <&gpion 12 GPIO_ACTIVE_HIGH>;
 	pwr-gpios = <&gpioq 7 GPIO_ACTIVE_HIGH>;
 	disk-name = "SD";
+	status = "okay";
 };
 
 &spi5 {
@@ -344,7 +344,6 @@ zephyr_udc0: &usbotg_hs1 {
 };
 
 &mac {
-	status = "okay";
 	pinctrl-0 = <&eth1_rgmii_gtx_clk_pf0
 		     &eth1_rgmii_clk125_pf2
 		     &eth1_rgmii_rx_clk_pf7
@@ -362,12 +361,13 @@ zephyr_udc0: &usbotg_hs1 {
 	pinctrl-names = "default";
 	phy-connection-type = "rgmii";
 	phy-handle = <&eth_phy>;
+	status = "okay";
 };
 
 &mdio {
-	status = "okay";
 	pinctrl-0 = <&eth1_mdio_pd12 &eth1_mdc_pd1>;
 	pinctrl-names = "default";
+	status = "okay";
 
 	eth_phy: ethernet-phy@0 {
 		compatible = "ethernet-phy";
@@ -386,16 +386,16 @@ zephyr_udc0: &usbotg_hs1 {
 			&ltdc_b4_ph3 &ltdc_b5_ph6 &ltdc_b6_pa8 &ltdc_b7_pa2
 			&ltdc_de_pg13 &ltdc_clk_pb13 &ltdc_hsync_pb14 &ltdc_vsync_pe11>;
 	pinctrl-names = "default";
-	disp-on-gpios = <&gpioq 3 GPIO_ACTIVE_HIGH>;
 	bl-ctrl-gpios = <&gpioq 6 GPIO_ACTIVE_HIGH>;
-
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
+	disp-on-gpios = <&gpioq 3 GPIO_ACTIVE_HIGH>;
 	ext-sdram = <&psram>;
-
-	status = "okay";
-
-	width = <800>;
 	height = <480>;
+	width = <800>;
 	pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -410,10 +410,6 @@ zephyr_udc0: &usbotg_hs1 {
 		hfront-porch = <8>;
 		vfront-porch = <8>;
 	};
-
-	def-back-color-red = <0xFF>;
-	def-back-color-green = <0xFF>;
-	def-back-color-blue = <0xFF>;
 };
 
 csi_22pins_interface: &dcmipp {

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -336,8 +336,8 @@ zephyr_udc0: &usbotg_hs1 {
 			#size-cells = <1>;
 
 			storage_partition: partition@7ff0000 {
-				label = "storage";
 				reg = <0x7ff0000 DT_SIZE_K(64)>;
+				label = "storage";
 			};
 		};
 	};

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -87,9 +87,9 @@
 };
 
 &clk_msis {
-	status = "okay";
 	msi-range = <4>; /* 4MHz (reset value) */
 	msi-pll-mode;
+	status = "okay";
 };
 
 &clk_lse {
@@ -139,22 +139,22 @@ uart0: &usart3 {
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pg14 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &i2c6 {
 	pinctrl-0 = <&i2c6_scl_pd1 &i2c6_sda_pd0>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &spi2 {
@@ -176,9 +176,9 @@ uart0: &usart3 {
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch2_pe11>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -187,9 +187,9 @@ uart0: &usart3 {
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch4_pa3>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -267,23 +267,23 @@ zephyr_udc0: &usbotg_hs {
 		 * Following flash partition is dedicated to the use of bootloader
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(1952)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@1f8000 {
-			label = "image-1";
 			reg = <0x001f8000 DT_SIZE_K(1960)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@3e2000 {
-			label = "storage";
 			reg = <0x003e2000 DT_SIZE_K(120)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -87,9 +87,9 @@
 };
 
 &clk_msis {
-	status = "okay";
 	msi-range = <4>; /* 4MHz (reset value) */
 	msi-pll-mode;
+	status = "okay";
 };
 
 &clk_lse {
@@ -139,22 +139,22 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pg14 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &i2c6 {
 	pinctrl-0 = <&i2c6_scl_pd1 &i2c6_sda_pd0>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &spi2 {
@@ -176,9 +176,9 @@
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch2_pe11>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -187,9 +187,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch4_pa3>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -267,23 +267,23 @@ zephyr_udc0: &usbotg_hs {
 		 * Following flash partition is dedicated to the use of bootloader
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(1952)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@1f8000 {
-			label = "image-1";
 			reg = <0x001f8000 DT_SIZE_K(1960)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@3e2000 {
-			label = "storage";
 			reg = <0x003e2000 DT_SIZE_K(120)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -289,23 +289,23 @@ zephyr_udc0: &usbotg_hs {
 		 * Following flash partition is dedicated to the use of bootloader
 		 */
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(64)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@10000 {
-			label = "image-0";
 			reg = <0x00010000 DT_SIZE_K(1952)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@1f8000 {
-			label = "image-1";
 			reg = <0x001f8000 DT_SIZE_K(1960)>;
+			label = "image-1";
 		};
 
 		storage_partition: partition@3e2000 {
-			label = "storage";
 			reg = <0x003e2000 DT_SIZE_K(120)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -67,17 +67,15 @@
 			&ltdc_b4_pd0 &ltdc_b5_pd1 &ltdc_b6_pe7 &ltdc_b7_pe8
 			&ltdc_de_pd6 &ltdc_clk_pd3 &ltdc_hsync_pe0 &ltdc_vsync_pd13>;
 	pinctrl-names = "default";
-	disp-on-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>;
 	bl-ctrl-gpios = <&gpioe 6 GPIO_ACTIVE_HIGH>;
-	status = "okay";
-
-	width = <800>;
-	height = <480>;
-	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
-
 	def-back-color-red = <0x00>;
 	def-back-color-green = <0x00>;
 	def-back-color-blue = <0x00>;
+	disp-on-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>;
+	height = <480>;
+	width = <800>;
+	pixel-format = <PANEL_PIXEL_FORMAT_RGB_888>;
+	status = "okay";
 
 	display-timings {
 		compatible = "zephyr,panel-timing";
@@ -104,9 +102,9 @@
 };
 
 &clk_msis {
-	status = "okay";
 	msi-range = <4>; /* 4MHz (reset value) */
 	msi-pll-mode;
+	status = "okay";
 };
 
 &clk_lse {
@@ -169,15 +167,15 @@
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pg14 &i2c1_sda_pg13>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &i2c2 {
 	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &spi1 {
@@ -192,9 +190,9 @@
 	status = "okay";
 
 	pwm1: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim1_ch2_pe11>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 
@@ -203,9 +201,9 @@
 	status = "okay";
 
 	pwm2: pwm {
-		status = "okay";
 		pinctrl-0 = <&tim2_ch4_pa3>;
 		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -146,28 +146,28 @@ zephyr_udc0: &usb {
 		 */
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
+			label = "image-0";
 		};
 
 		slot1_partition: partition@70000 {
-			label = "image-1";
 			reg = <0x00070000 DT_SIZE_K(400)>;
+			label = "image-1";
 		};
 
 		scratch_partition: partition@d4000 {
-			label = "image-scratch";
 			reg = <0x000d4000 DT_SIZE_K(16)>;
+			label = "image-scratch";
 		};
 
 		storage_partition: partition@d8000 {
-			label = "storage";
 			reg = <0x000d8000 DT_SIZE_K(8)>;
+			label = "storage";
 		};
 	};
 };

--- a/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
+++ b/boards/st/stm32wb5mm_dk/stm32wb5mm_dk.dts
@@ -123,9 +123,9 @@
 };
 
 zephyr_udc0: &usb {
-	status = "okay";
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &aes1 {
@@ -184,8 +184,8 @@ zephyr_udc0: &usb {
 &i2c3 {
 	pinctrl-0 = <&i2c3_scl_pb13 &i2c3_sda_pb11>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
 
 	vl53l0x@29 {
 		compatible = "st,vl53l0x";

--- a/boards/st/stm32wb5mmg/stm32wb5mmg.dts
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg.dts
@@ -75,9 +75,9 @@
 };
 
 zephyr_udc0: &usb {
-	status = "okay";
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 &flash0 {

--- a/boards/st/stm32wb5mmg/stm32wb5mmg.dts
+++ b/boards/st/stm32wb5mmg/stm32wb5mmg.dts
@@ -94,13 +94,13 @@ zephyr_udc0: &usb {
 		 */
 
 		boot_partition: partition@0 {
-			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(48)>;
+			label = "mcuboot";
 		};
 
 		slot0_partition: partition@c000 {
-			label = "image-0";
 			reg = <0x0000c000 DT_SIZE_K(400)>;
+			label = "image-0";
 		};
 	};
 };


### PR DESCRIPTION
Fixed two issues according to the device tree guidelines https://docs.kernel.org/devicetree/bindings/dts-coding-style.html:
1. The `reg` property should be second only to the `compatible` property within a node. This was not the case in many partition nodes definitions.
2. The `status` property should be the last property in a node.