### PR TITLE
doc: _extensions: board: show/hide boards and shield in catalog

### DIFF
--- a/doc/_extensions/zephyr/domain/static/css/board-catalog.css
+++ b/doc/_extensions/zephyr/domain/static/css/board-catalog.css
@@ -125,6 +125,58 @@
   background-color: transparent;
 }
 
+.visibility-toggles {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+}
+
+.toggle-group input {
+  display: none;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.toggle-switch {
+  width: 36px;
+  height: 18px;
+  background: #ccc;
+  border-radius: 18px;
+  position: relative;
+  transition: 0.3s;
+}
+
+.toggle-switch::before {
+  content: '';
+  width: 14px;
+  height: 14px;
+  background: white;
+  border-radius: 50%;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  transition: 0.3s;
+}
+
+.toggle-text {
+  font-size: 14px;
+  text-transform: none;
+}
+
+input:checked + .toggle-label .toggle-switch {
+  background: var(--admonition-note-title-background-color);
+}
+
+input:checked + .toggle-label .toggle-switch::before {
+  left: 20px;
+}
+
 #catalog {
   display: flex;
   flex-wrap: wrap;

--- a/doc/_extensions/zephyr/domain/templates/board-catalog.html
+++ b/doc/_extensions/zephyr/domain/templates/board-catalog.html
@@ -5,11 +5,31 @@
 
 <form class="filter-form" aria-label="Filter boards & shields by name, architecture, and vendor">
 
-  <div class="form-group" style="flex-basis: 100%">
+  <div class="form-group" style="flex-basis: 60%">
     <label for="name">Name</label>
     <input type="text" id="name"
       placeholder='Name (or partial name) of the board/shield, e.g. "reel board", "nucleo", &hellip;'
       oninput="filterBoards()" />
+  </div>
+
+  <div class="form-group">
+    <label>Showing</label>
+    <div class="visibility-toggles">
+      <div class="toggle-group">
+        <input type="checkbox" id="show-boards" checked>
+        <label for="show-boards" class="toggle-label">
+          <span class="toggle-switch"></span>
+          <span class="toggle-text">Boards</span>
+        </label>
+      </div>
+      <div class="toggle-group">
+        <input type="checkbox" id="show-shields" checked>
+        <label for="show-shields" class="toggle-label">
+          <span class="toggle-switch"></span>
+          <span class="toggle-text">Shields</span>
+        </label>
+      </div>
+    </div>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
Adds the ability to show/hide boards and shields in the board catalog.

<img width="860" alt="image" src="https://github.com/user-attachments/assets/5ff5a95b-c636-469a-8d98-d27ed5149dd6" />