### PR TITLE
doc: boards: Fix documentation for WCH boards.

### DIFF
--- a/boards/wch/ch32v003evt/doc/index.rst
+++ b/boards/wch/ch32v003evt/doc/index.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 
-The `WCH`_ CH32V003EVT hardware provides support for QingKe 32-bit RISC-V2A
+The `WCH`_ CH32V003EVT hardware provides support for QingKe V2A 32-bit RISC-V
 processor and the following devices:
 
 * CLOCK
@@ -16,7 +16,7 @@ the processor's information and the datasheet.
 Hardware
 ********
 
-The QingKe 32-bit RISC-V2A processor of the WCH CH32V003EVT is clocked by an
+The QingKe V2A 32-bit RISC-V processor of the WCH CH32V003EVT is clocked by an
 external crystal and runs at 48 MHz.
 
 Supported Features

--- a/boards/wch/ch32v003f4p6_dev_board/doc/index.rst
+++ b/boards/wch/ch32v003f4p6_dev_board/doc/index.rst
@@ -4,7 +4,7 @@ Overview
 ********
 
 The `WCH`_ CH32V003F4P6 Development Board hardware provides support for
-QingKe 32-bit RISC-V2A processor and the following devices:
+QingKe V2A 32-bit RISC-V processor and the following devices:
 
 * CLOCK
 * :abbr:`GPIO (General Purpose Input Output)`
@@ -17,7 +17,7 @@ and the datasheet.
 Hardware
 ********
 
-The QingKe 32-bit RISC-V2A processor of the WCH CH32V003F4P6_DEV_BOARD is clocked
+The QingKe V2A 32-bit RISC-V processor of the WCH CH32V003F4P6_DEV_BOARD is clocked
 by an internal RC oscillator and runs at 24 MHz.
 
 Supported Features

--- a/boards/wch/ch32v006evt/doc/index.rst
+++ b/boards/wch/ch32v006evt/doc/index.rst
@@ -13,7 +13,7 @@ information and the datasheet.
 Hardware
 ********
 
-The QingKe 32-bit RISC-V2C processor of the WCH CH32V006EVT is clocked by an
+The QingKe V2C 32-bit RISC-V processor of the WCH CH32V006EVT is clocked by an
 external crystal and runs at 48 MHz.
 
 Supported Features

--- a/boards/wch/ch32v303vct6_evt/doc/index.rst
+++ b/boards/wch/ch32v303vct6_evt/doc/index.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 
-The `WCH`_ CH3V303VCT6_EVT hardware provides support for QingKe V4F 32-bit RISC-V
+The `WCH`_ CH32V303VCT6-EVT hardware provides support for QingKe V4F 32-bit RISC-V
 processor.
 
 The `WCH webpage on CH32V303`_ contains
@@ -12,7 +12,7 @@ the processor's information and the datasheet.
 Hardware
 ********
 
-The QingKe V4F 32-bit RISC-V processor of the WCH CH32V303VCT6_EVT is clocked by an external
+The QingKe V4F 32-bit RISC-V processor of the WCH CH32V303VCT6-EVT is clocked by an external
 32 MHz crystal or the internal 8 MHz oscillator and runs up to 144 MHz.
 The CH32V303 SoC features 8 USART, 4 GPIO ports, 3 SPI, 2 I2C, 2 ADC, RTC,
 CAN, USB Host/Device, and 4 OPA.

--- a/boards/wch/ch32v303vct6_evt/doc/index.rst
+++ b/boards/wch/ch32v303vct6_evt/doc/index.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 
-The `WCH`_ CH3V303VCT6_EVT hardware provides support for QingKe 32-bit RISC-V4F
+The `WCH`_ CH3V303VCT6_EVT hardware provides support for QingKe V4F 32-bit RISC-V
 processor.
 
 The `WCH webpage on CH32V303`_ contains
@@ -12,7 +12,7 @@ the processor's information and the datasheet.
 Hardware
 ********
 
-The QingKe 32-bit RISC-V4F processor of the WCH CH32V303VCT6_EVT is clocked by an external
+The QingKe V4F 32-bit RISC-V processor of the WCH CH32V303VCT6_EVT is clocked by an external
 32 MHz crystal or the internal 8 MHz oscillator and runs up to 144 MHz.
 The CH32V303 SoC features 8 USART, 4 GPIO ports, 3 SPI, 2 I2C, 2 ADC, RTC,
 CAN, USB Host/Device, and 4 OPA.

--- a/boards/wch/linkw/doc/index.rst
+++ b/boards/wch/linkw/doc/index.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 
-The `WCH`_ LinkW hardware provides support for QingKe 32-bit RISC-V4C
+The `WCH`_ LinkW hardware provides support for QingKe V4C 32-bit RISC-V
 processor and the following devices:
 
 * CLOCK
@@ -17,7 +17,7 @@ The `WCH webpage on LinkW`_ contains the LinkW's schematic.
 Hardware
 ********
 
-The QingKe 32-bit RISC-V4C processor of the WCH LinkW is clocked by an external
+The QingKe V4C 32-bit RISC-V processor of the WCH LinkW is clocked by an external
 32 MHz crystal or the internal 8 MHz oscillator and runs up to 144 MHz.
 The CH32V208 SoC Features 4 USART, 4 GPIO ports, 2 SPI, 2 I2C, ADC, RTC,
 CAN, 2 USB Device, USB Host, OPA, ETH with PHY, several timers, and BLE 5.3.

--- a/boards/weact/bluepillplus_ch32v203/doc/index.rst
+++ b/boards/weact/bluepillplus_ch32v203/doc/index.rst
@@ -3,7 +3,7 @@
 Overview
 ********
 
-The `WeActStudio`_ BluePill Plus CH32V203 hardware provides support for QingKe 32-bit RISC-V4B
+The `WeActStudio`_ BluePill Plus CH32V203 hardware provides support for QingKe V4B 32-bit RISC-V
 processor and the following devices:
 
 * CLOCK


### PR DESCRIPTION
Fixes the name of the CH32V303VCT6-EVT board, and fix a typo present in almost all wch boards about the name of the SoC.