### PR TITLE
soc/ite/ec: it51xxx: Add a new SoC variant it51526bw

### DIFF
--- a/dts/riscv/ite/it51526bw-512.dtsi
+++ b/dts/riscv/ite/it51526bw-512.dtsi
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 ITE Corporation. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		flashctrl: flash-controller@f01000 {
+			compatible = "ite,it8xxx2-flash-controller";
+			reg = <0x00f01000 0x100>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				reg = <0 DT_SIZE_K(512)>;
+				erase-block-size = <4096>;
+				write-block-size = <4>;
+			};
+		};
+	};
+};

--- a/soc/ite/ec/it51xxx/Kconfig.soc
+++ b/soc/ite/ec/it51xxx/Kconfig.soc
@@ -15,8 +15,13 @@ config SOC_IT51526AW
 	bool
 	select SOC_IT51XXX
 
+config SOC_IT51526BW
+	bool
+	select SOC_IT51XXX
+
 config SOC_SERIES
 	default "it51xxx" if SOC_SERIES_IT51XXX
 
 config SOC
 	default "it51526aw" if SOC_IT51526AW
+	default "it51526bw" if SOC_IT51526BW

--- a/soc/ite/ec/soc.yml
+++ b/soc/ite/ec/soc.yml
@@ -20,3 +20,4 @@ family:
       - name: it51xxx
         socs:
           - name: it51526aw
+          - name: it51526bw


### PR DESCRIPTION
1. Add it51526bw SoC variant to it51xxx SoC series.
2. Create the .dtsi file with adjusted flash size for 512Kb (default = 1M).