### PR TITLE
net: tcp: Use correct seqnum for tcp_out and tcp_out_ext

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1618,7 +1618,7 @@ out:
 
 static void tcp_out(struct tcp *conn, uint8_t flags)
 {
-	(void)tcp_out_ext(conn, flags, NULL /* no data */, conn->seq);
+	(void)tcp_out_ext(conn, flags, NULL /* no data */, conn->seq + conn->unacked_len);
 }
 
 static int tcp_pkt_pull(struct net_pkt *pkt, size_t len)
@@ -2039,8 +2039,7 @@ static void tcp_send_keepalive_probe(struct k_work *work)
 	k_work_reschedule_for_queue(&tcp_work_q, &conn->keepalive_timer,
 				    K_SECONDS(conn->keep_intvl));
 
-
-	(void)tcp_out_ext(conn, ACK, NULL, conn->seq - 1);
+	(void)tcp_out_ext(conn, ACK, NULL, conn->seq + conn->unacked_len - 1);
 }
 #endif /* CONFIG_NET_TCP_KEEPALIVE */
 
@@ -2051,7 +2050,7 @@ static void tcp_send_zwp(struct k_work *work)
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
-	(void)tcp_out_ext(conn, ACK, NULL, conn->seq - 1);
+	(void)tcp_out_ext(conn, ACK, NULL, conn->seq + conn->unacked_len - 1);
 
 	tcp_derive_rto(conn);
 


### PR DESCRIPTION
Based on TCP Spec., the outgoing TCP packets shoud use SND.NXT as the seqnum. In Zephyr, the conn->seq works as the SND.UNA and the conn->seq + conn->unacked_len works as the SND.NXT. Currently, it uses SND.UNA in tcp_out() as the seqnum, which might get dropped as old packets and could not deliver the message to the peer. A few exceptions use SND.NXT - 1 as the seqnum are: keepalive, zero-window-probe, FIN/SYN retransmissions. 
And, for closing a connection, Zephyr won't send out FIN until all the data has been ACKed, so the conn->unacked_len is 0 and it is ok to use conn->seq as the SND.NXT.