### PR TITLE
dts: arm64: ti: ti_am62x_a53: Add MAIN_I2C*

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53-pinctrl.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53-pinctrl.dtsi
@@ -14,4 +14,14 @@
 	main_uart6_tx_default: main_uart6_tx_default {
 		pinmux = <K3_PINMUX(0x0020, PIN_OUTPUT, MUX_MODE_3)>;
 	};
+
+	main_i2c2_sda_default: main_i2c2_sda_default {
+		/* (K24) GPMC0_CSn3.I2C2_SDA */
+		pinmux = <K3_PINMUX(0x00b4, PIN_INPUT_PULLUP, MUX_MODE_1)>;
+	};
+
+	main_i2c2_scl_default: main_i2c2_scl_default {
+		/* (K22) GPMC0_CSn2.I2C2_SCL */
+		pinmux = <K3_PINMUX(0x00b0, PIN_INPUT_PULLUP, MUX_MODE_1)>;
+	};
 };

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.dts
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.dts
@@ -39,3 +39,9 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&main_i2c2 {
+	pinctrl-0 = <&main_i2c2_sda_default &main_i2c2_scl_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.yaml
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.yaml
@@ -9,3 +9,4 @@ ram: 524288
 vendor: beagle
 supported:
   - uart
+  - i2c

--- a/drivers/i2c/i2c_omap.c
+++ b/drivers/i2c/i2c_omap.c
@@ -99,7 +99,7 @@ typedef struct {
 typedef void (*init_func_t)(const struct device *dev);
 #define DEV_CFG(dev)      ((const struct i2c_omap_cfg *)(dev)->config)
 #define DEV_DATA(dev)     ((struct i2c_omap_data *)(dev)->data)
-#define DEV_I2C_BASE(dev) ((i2c_omap_regs_t *)DEVICE_MMIO_GET(dev))
+#define DEV_I2C_BASE(dev) ((volatile i2c_omap_regs_t *)DEVICE_MMIO_GET(dev))
 
 struct i2c_omap_cfg {
 	DEVICE_MMIO_ROM;
@@ -141,7 +141,7 @@ static void i2c_omap_init_ll(const struct device *dev)
 {
 
 	struct i2c_omap_data *data = DEV_DATA(dev);
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 
 	i2c_base_addr->CON = 0;
 	i2c_base_addr->PSC = data->speed_config.pscstate;
@@ -161,7 +161,7 @@ static void i2c_omap_init_ll(const struct device *dev)
 static int i2c_omap_reset(const struct device *dev)
 {
 	struct i2c_omap_data *data = DEV_DATA(dev);
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	uint64_t timeout;
 	uint16_t sysc;
 
@@ -268,7 +268,7 @@ static int i2c_omap_configure(const struct device *dev, uint32_t dev_config)
 static void i2c_omap_transmit_receive_data(const struct device *dev, uint8_t num_bytes)
 {
 	struct i2c_omap_data *data = DEV_DATA(dev);
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	uint8_t *buf_ptr = data->current_msg.buf;
 
 	while (num_bytes--) {
@@ -293,7 +293,7 @@ static void i2c_omap_transmit_receive_data(const struct device *dev, uint8_t num
 static void i2c_omap_resize_fifo(const struct device *dev, uint8_t size)
 {
 	struct i2c_omap_data *data = DEV_DATA(dev);
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 
 	if (data->receiver) {
 		i2c_base_addr->BUF &= I2C_OMAP_BUF_RXFIF_CLR;
@@ -316,7 +316,7 @@ static void i2c_omap_resize_fifo(const struct device *dev, uint8_t size)
 static int i2c_omap_get_sda(void *io_context)
 {
 	const struct device *dev = io_context;
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 
 	return (i2c_base_addr->SYSTEST & I2C_OMAP_SYSTEST_SDA_I_FUNC) ? 1 : 0;
 }
@@ -332,7 +332,7 @@ static int i2c_omap_get_sda(void *io_context)
 static void i2c_omap_set_sda(void *io_context, int state)
 {
 	const struct device *dev = io_context;
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 
 	if (state) {
 		i2c_base_addr->SYSTEST |= I2C_OMAP_SYSTEST_SDA_O;
@@ -352,7 +352,7 @@ static void i2c_omap_set_sda(void *io_context, int state)
 static void i2c_omap_set_scl(void *io_context, int state)
 {
 	const struct device *dev = io_context;
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 
 	if (state) {
 		i2c_base_addr->SYSTEST |= I2C_OMAP_SYSTEST_SCL_O;
@@ -374,7 +374,7 @@ static void i2c_omap_set_scl(void *io_context, int state)
 static int i2c_omap_recover_bus(const struct device *dev)
 {
 	const struct i2c_omap_cfg *cfg = DEV_CFG(dev);
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	struct i2c_omap_data *data = DEV_DATA(dev);
 
 	struct i2c_bitbang bitbang_omap;
@@ -418,7 +418,7 @@ restore:
  */
 static int i2c_omap_wait_for_bb(const struct device *dev)
 {
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	uint32_t timeout = k_uptime_get_32() + I2C_OMAP_TIMEOUT;
 
 	while (i2c_base_addr->STAT & I2C_OMAP_STAT_BB) {
@@ -450,7 +450,7 @@ static int i2c_omap_wait_for_bb(const struct device *dev)
 static int i2c_omap_transfer_message_ll(const struct device *dev)
 {
 	struct i2c_omap_data *data = DEV_DATA(dev);
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	uint16_t stat = i2c_base_addr->STAT, result = 0;
 
 	if (data->receiver) {
@@ -531,7 +531,7 @@ static int i2c_omap_transfer_message(const struct device *dev, struct i2c_msg *m
 				     uint16_t addr)
 {
 	struct i2c_omap_data *data = DEV_DATA(dev);
-	i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
+	volatile i2c_omap_regs_t *i2c_base_addr = DEV_I2C_BASE(dev);
 	unsigned long time_left = 1000;
 	uint16_t control_reg;
 	int result = 0;

--- a/drivers/i2c/i2c_omap.c
+++ b/drivers/i2c/i2c_omap.c
@@ -31,28 +31,28 @@ LOG_MODULE_REGISTER(omap_i2c, CONFIG_I2C_LOG_LEVEL);
 typedef struct {
 	uint8_t RESERVED_0[0x10]; /**< Reserved, offset: 0x0 */
 
-	__IO uint32_t SYSC;          /**< System Configuration, offset: 0x10 */
+	uint32_t SYSC;          /**< System Configuration, offset: 0x10 */
 	uint8_t RESERVED_1[0x18];    /**< Reserved, offset: 0x14 - 0x2C */
-	__IO uint32_t IRQENABLE_SET; /**< Interrupt Enable Set, offset: 0x2C */
+	uint32_t IRQENABLE_SET; /**< Interrupt Enable Set, offset: 0x2C */
 	uint8_t RESERVED_2[0x4];     /**< Reserved, offset: 0x30 - 0x34 */
-	__IO uint32_t WE;            /**< Wakeup Enable, offset: 0x34 */
+	uint32_t WE;            /**< Wakeup Enable, offset: 0x34 */
 	uint8_t RESERVED_3[0x4C];    /**< Reserved, offset: 0x38 - 0x84 */
-	__IO uint32_t IE;            /**< Interrupt Enable (Legacy), offset: 0x84 */
-	__IO uint32_t STAT;          /**< Status, offset: 0x88 */
+	uint32_t IE;            /**< Interrupt Enable (Legacy), offset: 0x84 */
+	uint32_t STAT;          /**< Status, offset: 0x88 */
 	uint8_t RESERVED_4[0x4];     /**< Reserved, offset: 0x8C - 0x90 */
-	__IO uint32_t SYSS;          /**< System Status, offset: 0x90 */
-	__IO uint32_t BUF;           /**< Buffer, offset: 0x94 */
-	__IO uint32_t CNT;           /**< Data Count, offset: 0x98 */
-	__IO uint32_t DATA;          /**< Data Access, offset: 0x9C */
+	uint32_t SYSS;          /**< System Status, offset: 0x90 */
+	uint32_t BUF;           /**< Buffer, offset: 0x94 */
+	uint32_t CNT;           /**< Data Count, offset: 0x98 */
+	uint32_t DATA;          /**< Data Access, offset: 0x9C */
 	uint8_t RESERVED_5[0x4];     /**< Reserved, offset: 0xA0 - 0xA4 */
-	__IO uint32_t CON;           /**< Configuration, offset: 0xA4 */
-	__IO uint32_t OA;            /**< Own Address, offset: 0xA8 */
-	__IO uint32_t SA;            /**< Target Address, offset: 0xAC */
-	__IO uint32_t PSC;           /**< Clock Prescaler, offset: 0xB0 */
-	__IO uint32_t SCLL;          /**< SCL Low Time, offset: 0xB4 */
-	__IO uint32_t SCLH;          /**< SCL High Time, offset: 0xB8 */
-	__IO uint32_t SYSTEST;       /**< System Test, offset: 0xBC */
-	__IO uint32_t BUFSTAT;       /**< Buffer Status, offset: 0xC0 */
+	uint32_t CON;           /**< Configuration, offset: 0xA4 */
+	uint32_t OA;            /**< Own Address, offset: 0xA8 */
+	uint32_t SA;            /**< Target Address, offset: 0xAC */
+	uint32_t PSC;           /**< Clock Prescaler, offset: 0xB0 */
+	uint32_t SCLL;          /**< SCL Low Time, offset: 0xB4 */
+	uint32_t SCLH;          /**< SCL High Time, offset: 0xB8 */
+	uint32_t SYSTEST;       /**< System Test, offset: 0xBC */
+	uint32_t BUFSTAT;       /**< Buffer Status, offset: 0xC0 */
 } i2c_omap_regs_t;
 
 /* I2C Configuration Register (I2C_OMAP_CON) */

--- a/dts/arm64/ti/ti_am62x_a53.dtsi
+++ b/dts/arm64/ti/ti_am62x_a53.dtsi
@@ -142,4 +142,48 @@
 		usr-id = <0>;
 		#mbox-cells = <1>;
 	};
+
+	main_i2c0: i2c@20000000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20000000 0x100>;
+		interrupts = <GIC_SPI 161 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_i2c1: i2c@20010000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20010000 0x100>;
+		interrupts = <GIC_SPI 162 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_i2c2: i2c@20020000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20020000 0x100>;
+		interrupts = <GIC_SPI 163 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_i2c3: i2c@20030000 {
+		compatible = "ti,omap-i2c";
+		reg = <0x20030000 0x100>;
+		interrupts = <GIC_SPI 164 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+		interrupt-parent = <&gic>;
+		clock-frequency = <100000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
Using the node naming scheme from linux kernel to use the domain prefix in nodes. It would be best if the naming scheme is followed for all new additions.

I will create PRs to migrate the already defined nodes to the prefix based naming scheme in the future.

Tested on Pocket Beagle 2