### PR TITLE
samples: sysbuild: with_mcuboot: Fix Kconfig setting

### DIFF
--- a/samples/sysbuild/with_mcuboot/sysbuild.conf
+++ b/samples/sysbuild/with_mcuboot/sysbuild.conf
@@ -1,4 +1,5 @@
 # Sysbuild configuration file.
 
-# Enable MCUboot per default for this sample.
+# Enable MCUboot using overwrite only mode for this sample.
 SB_CONFIG_BOOTLOADER_MCUBOOT=y
+SB_CONFIG_MCUBOOT_MODE_OVERWRITE_ONLY=y

--- a/samples/sysbuild/with_mcuboot/sysbuild/mcuboot.conf
+++ b/samples/sysbuild/with_mcuboot/sysbuild/mcuboot.conf
@@ -1,5 +1,5 @@
 # Example of sample specific Kconfig changes when building sample with MCUboot
-# when using sysbuild.
+# when using sysbuild. Note that the MCUboot operating mode is not set here as
+# sysbuild will automatically set it for both the application and MCUboot images itself
 CONFIG_MCUBOOT_LOG_LEVEL_WRN=y
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_MCUBOOT_DOWNGRADE_PREVENTION=y


### PR DESCRIPTION
Removes a superfluous Kconfig for setting the MCUboot operating mode as sysbuild does this automatically, adds a comment about why it is omitted, and then sets it in the correct place