### PR TITLE
west.yml: Update hal_nxp version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -205,7 +205,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 6a316c1bf7b381845ae8af64208906f6ec332eab
+      revision: pull/538/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp version, the new version hal_nxp would fix https://github.com/zephyrproject-rtos/zephyr/issues/88080.
The new version hal_nxp also added RT1170 dcd.c/.h back, the dcd is more stable than xmcd.