### PR TITLE
net: tcp: Fix user_data provided to accept callback

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -3027,7 +3027,7 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 			accept_cb(conn->context, &conn->context->remote,
 				  net_context_get_family(context) == AF_INET6 ?
 				  sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in),
-				  0, context);
+				  0, context->user_data);
 
 			next = TCP_ESTABLISHED;
 


### PR DESCRIPTION
TCP implementation provided the parent net_context pointer to the accept callback instead of the user_data pointer registered with net_tcp_accept(). This worked fine with the socket integration, as sockets explicitly registered parent context as user_data, however it shouldn't be hardcoded like this at the TCP level.

Fixes #90639