### PR TITLE
mgmt: hawkbit: reset action ID after successful update report

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -1483,6 +1483,11 @@ static void s_report(void *o)
 		return;
 	}
 
+	/* After reporting the successful update to the hawkBit server, we can reset the saved
+	 * action ID to 0, as we don't need it anymore.
+	 */
+	(void)hawkbit_device_acid_update(0);
+
 	smf_set_state(SMF_CTX(s), &hawkbit_states[S_HAWKBIT_PROBE]);
 }
 


### PR DESCRIPTION
reset action ID after successful update report.

When changing the server, it could be that the former action ID is the same as the new one, which results as the update being reported as successful, even thew it wasn't done. As we don't need that action ID anymore after reporting the successful update, we can reset it. 