### PR TITLE
Statistics handling rejig

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -323,7 +323,7 @@ manifest:
       revision: c6296f600a6851bd652f207ab4908d339e1ce705
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 5e185a2b33b4f5b9524999a5bfd96121d25ffdbc
+      revision: pull/53/head
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: f7f4d083c7909a39d86e217376c69b416ec4faf3


### PR DESCRIPTION
Fixes a corruption seen when active traffic is run with stats in the background (script)