### PR TITLE
tests/c_lib/common/src/test_sqrt: Fix when double is not 64 bits

### DIFF
--- a/tests/lib/c_lib/common/src/test_sqrt.c
+++ b/tests/lib/c_lib/common/src/test_sqrt.c
@@ -9,7 +9,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 
-
 #define local_abs(x) (((x) < 0) ? -(x) : (x))
 
 #ifndef NAN
@@ -30,11 +29,11 @@ static float test_floats[] = {
 #define	NUM_TEST_FLOATS	(sizeof(test_floats)/sizeof(float))
 
 static double test_doubles[] = {
-		1.0, 2.0, 3.0, 4.0,
-		5.0, 6.0, 7.0, 8.0, 9.0,	/* numbers across the decade */
-		3.14159265359, 2.718281828,	/* irrational numbers pi and e */
-		123.4,	0.025,	0.10,	1.875	/* numbers with infinite */
-						/* repeating binary representationa */
+	1.0, 2.0, 3.0, 4.0,
+	5.0, 6.0, 7.0, 8.0, 9.0,	/* numbers across the decade */
+	3.14159265359, 2.718281828,	/* irrational numbers pi and e */
+	123.4,	0.025,	0.10,	1.875	/* numbers with infinite */
+					/* repeating binary representationa */
 };
 #define	NUM_TEST_DOUBLES	(sizeof(test_floats)/sizeof(float))
 
@@ -88,13 +87,12 @@ static int isnanf(float x)
 
 ZTEST(libc_common, test_sqrtf)
 {
-int i;
-float	exponent, resf, square, root_squared, error;
-uint32_t max_error;
-int32_t ierror;
-int32_t *p_square = (int32_t *)&square;
-int32_t *p_root_squared = (int32_t *)&root_squared;
-
+	int i;
+	float exponent, resf, square, root_squared, error;
+	uint32_t max_error;
+	int32_t ierror;
+	int32_t *p_square = (int32_t *)&square;
+	int32_t *p_root_squared = (int32_t *)&root_squared;
 
 	max_error = 0;
 
@@ -150,13 +148,13 @@ ZTEST(libc_common, test_sqrt)
 	if (sizeof(double) != 8) {
 		ztest_test_skip();
 	}
-int i;
-double	resd, error, square, root_squared, exponent;
-uint64_t max_error;
-int64_t ierror;
-int64_t *p_square = (int64_t *)&square;
-int64_t *p_root_squared = (int64_t *)&root_squared;
 
+	int i;
+	double resd, error, square, root_squared, exponent;
+	uint64_t max_error;
+	int64_t ierror;
+	int64_t *p_square = (int64_t *)&square;
+	int64_t *p_root_squared = (int64_t *)&root_squared;
 
 	max_error = 0;
 

--- a/tests/lib/c_lib/common/src/test_sqrt.c
+++ b/tests/lib/c_lib/common/src/test_sqrt.c
@@ -29,8 +29,7 @@ static float test_floats[] = {
 	};
 #define	NUM_TEST_FLOATS	(sizeof(test_floats)/sizeof(float))
 
-#if __SIZEOF_DOUBLE__ == 8
-	static double test_doubles[] = {
+static double test_doubles[] = {
 		1.0, 2.0, 3.0, 4.0,
 		5.0, 6.0, 7.0, 8.0, 9.0,	/* numbers across the decade */
 		3.14159265359, 2.718281828,	/* irrational numbers pi and e */
@@ -60,7 +59,6 @@ static int isnan(double x)
 		((ieee754.u & 0x000fffffffffffff) != 0);
 }
 #endif
-#endif /* __SIZEOF_DOUBLE__ == 8 */
 
 #ifndef	isinff
 static int isinff(float x)


### PR DESCRIPTION
The combination of
32312692448eace36a653b55e985ff7ed3f6e276
74c9e7afab9db54b3ac43370f6e0eba203fa4f64
broke this test, when `__SIZEOF_DOUBLE__ != 8`.
In that case the test will fail to build,
as the variables the code uses are left ifdef'ed out.

Let's fix it.

and as a free bonus:
    
Fix several code compliance issues.
    
