### PR TITLE
samples: modules: lvgl: multi_display: fix typo in sample.yaml

### DIFF
--- a/samples/modules/lvgl/multi_display/sample.yaml
+++ b/samples/modules/lvgl/multi_display/sample.yaml
@@ -4,7 +4,7 @@ sample:
 common:
   modules:
     - lvgl
-  filter: dt_comp_enabled("zephyr,displays")
+  filter: dt_compat_enabled("zephyr,displays")
   tags:
     - samples
     - display


### PR DESCRIPTION
Fix typo in `sample.yaml` that prevents sample from being built in CI.