### PR TITLE
soc: imxrt: add mimxrt1052/1062 flashing configuration

### DIFF
--- a/soc/nxp/imxrt/soc.yml
+++ b/soc/nxp/imxrt/soc.yml
@@ -57,6 +57,10 @@ runners:
       - qualifiers:
         - mimxrt10([0-9]{2})
       - qualifiers:
+        - mimxrt1052/(qspi|hyperflash)
+      - qualifiers:
+        - mimxrt1062/(qspi|hyperflash)
+      - qualifiers:
         - mimxrt1166/cm7
         - mimxrt1166/cm4
       - qualifiers:
@@ -77,6 +81,10 @@ runners:
       groups:
       - qualifiers:
         - mimxrt10([0-9]{2})
+      - qualifiers:
+        - mimxrt1052/(qspi|hyperflash)
+      - qualifiers:
+        - mimxrt1062/(qspi|hyperflash)
       - qualifiers:
         - mimxrt1166/cm7
         - mimxrt1166/cm4


### PR DESCRIPTION
- Adds a flash runner configuration for mimxrt1052 and mimxrt1062, used for sysbuild multi-image projects, mainly for MCU-boot.
- Avoid unwanted multiple erases and resets.