### PR TITLE
boards: mimxrt1060_evk: set LinkServer as the default runner

### DIFF
--- a/boards/nxp/mimxrt1060_evk/board.cmake
+++ b/boards/nxp/mimxrt1060_evk/board.cmake
@@ -27,6 +27,6 @@ elseif ("${BOARD_QUALIFIERS}" MATCHES "hyperflash")
   board_runner_args(jlink "--loader=BankAddr=0x60000000&Loader=HyperFlash")
 endif()
 
+include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
-include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)

--- a/boards/nxp/mimxrt1060_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1060_evk/doc/index.rst
@@ -313,7 +313,7 @@ This board supports 3 debug host tools. Please install your preferred host
 tool, then follow the instructions in `Configuring a Debug Probe`_ to
 configure the board appropriately.
 
-* :ref:`jlink-debug-host-tools` (Default, Supported by NXP)
+* :ref:`jlink-debug-host-tools` (Supported by NXP)
 * :ref:`linkserver-debug-host-tools` (Supported by NXP)
 * :ref:`pyocd-debug-host-tools` (Not Supported by NXP)
 


### PR DESCRIPTION
Sets LinkServer as the default runner for the mimxrt1060-evk board, as the board is configured for CMSIS-DAP by default.