### PR TITLE
riscv: remove unused function warnings

### DIFF
--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -204,6 +204,7 @@ static bool set_pmp_entry(unsigned int *index_p, uint8_t perm,
 	return ok;
 }
 
+#ifdef CONFIG_PMP_STACK_GUARD
 static inline bool set_pmp_mprv_catchall(unsigned int *index_p,
 					 unsigned long *pmp_addr, unsigned long *pmp_cfg,
 					 unsigned int index_limit)
@@ -231,6 +232,7 @@ static inline bool set_pmp_mprv_catchall(unsigned int *index_p,
 
 	return ok;
 }
+#endif /* CONFIG_PMP_STACK_GUARD */
 
 /**
  * @brief Write a range of PMP entries to corresponding PMP registers
@@ -447,6 +449,7 @@ void z_riscv_pmp_init(void)
 /**
  * @Brief Initialize the per-thread PMP register copy with global values.
  */
+#if (defined(CONFIG_PMP_STACK_GUARD) && defined(CONFIG_MULTITHREADING)) || defined(CONFIG_USERSPACE)
 static inline unsigned int z_riscv_pmp_thread_init(unsigned long *pmp_addr,
 						   unsigned long *pmp_cfg,
 						   unsigned int index_limit)
@@ -466,6 +469,7 @@ static inline unsigned int z_riscv_pmp_thread_init(unsigned long *pmp_addr,
 
 	return global_pmp_end_index;
 }
+#endif
 
 #ifdef CONFIG_PMP_STACK_GUARD
 

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -196,13 +196,6 @@ static inline mem_addr_t get_threshold_priority_addr(const struct device *dev, u
 	return config->reg + (get_hart_context(dev, hartid) * CONTEXT_SIZE);
 }
 
-static ALWAYS_INLINE uint32_t local_irq_to_irq(const struct device *dev, uint32_t local_irq)
-{
-	const struct plic_config *config = dev->config;
-
-	return irq_to_level_2(local_irq) | config->irq;
-}
-
 #ifdef CONFIG_PLIC_SUPPORTS_SOFT_INTERRUPT
 static inline mem_addr_t get_pending_reg(const struct device *dev, uint32_t local_irq)
 {
@@ -718,6 +711,13 @@ static int cmd_stats_clear(const struct shell *sh, size_t argc, char *argv[])
 #endif /* CONFIG_PLIC_SHELL_IRQ_COUNT */
 
 #ifdef CONFIG_PLIC_SHELL_IRQ_AFFINITY
+static ALWAYS_INLINE uint32_t local_irq_to_irq(const struct device *dev, uint32_t local_irq)
+{
+	const struct plic_config *config = dev->config;
+
+	return irq_to_level_2(local_irq) | config->irq;
+}
+
 static int cmd_affinity_set(const struct shell *sh, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);


### PR DESCRIPTION
Modify files that generate unused functions warnings.