### PR TITLE
Bluetooth: Controller: Use OVERHEAD_XTAL_US from devicetree

### DIFF
--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -25,13 +25,22 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/offsets.h>
 
-/* We need to dummy out DT_NODE_HAS_STATUS when building the unittests.
+/* We need to dummy out DT_NODE_HAS_STATUS and DT_NODE_HAS_STATUS_OKAY when
+ * building the unittests.
  * Including devicetree.h would require generating dummy header files
  * to match what gen_defines creates, so it's easier to just dummy out
- * DT_NODE_HAS_STATUS. These are undefined at the end of the file.
+ * DT_NODE_HAS_STATUS and DT_NODE_HAS_STATUS_OKAY. These are undefined at the
+ * end of the file.
  */
 #ifdef ZTEST_UNITTEST
+#ifdef DT_NODE_HAS_STATUS
+#undef DT_NODE_HAS_STATUS
+#endif
 #define DT_NODE_HAS_STATUS(node, status) 0
+
+#ifdef DT_NODE_HAS_STATUS_OKAY
+#undef DT_NODE_HAS_STATUS_OKAY
+#endif
 #define DT_NODE_HAS_STATUS_OKAY(node) 0
 #else
 #include <zephyr/devicetree.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2018-2019 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#if DT_NODE_HAS_PROP(DT_NODELABEL(hfxo), startup_time_us)
+#define EVENT_OVERHEAD_XTAL_US        DT_PROP(DT_NODELABEL(hfxo), startup_time_us)
+#else
 #define EVENT_OVERHEAD_XTAL_US        1500
+#endif
 #define EVENT_OVERHEAD_PREEMPT_US     0    /* if <= min, then dynamic preempt */
 #define EVENT_OVERHEAD_PREEMPT_MIN_US 0
 #define EVENT_OVERHEAD_PREEMPT_MAX_US EVENT_OVERHEAD_XTAL_US

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -5,10 +5,13 @@
  */
 
 #include <stddef.h>
+
 #include <zephyr/kernel.h>
-#include <soc.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/bluetooth/hci_types.h>
 #include <zephyr/sys/byteorder.h>
+
+#include <soc.h>
 
 #include "hal/cpu.h"
 #include "hal/ecb.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/devicetree.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/sys/util.h>

--- a/tests/bluetooth/controller/mock_ctrl/src/ull.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/types.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/ztest.h>
 
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
 
 #include "hal/ccm.h"
 #include "hal/ticker.h"

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral_iso.c
@@ -7,6 +7,7 @@
 #include <zephyr/ztest.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/tests/bsim/bluetooth/mesh/src/test_brg.c
+++ b/tests/bsim/bluetooth/mesh/src/test_brg.c
@@ -18,7 +18,7 @@
 LOG_MODULE_REGISTER(test_brg, LOG_LEVEL_INF);
 
 #define WAIT_TIME          32  /*seconds*/
-#define WAIT_TIME_IVU_TEST 240 /* seconds */
+#define WAIT_TIME_IVU_TEST 250 /* seconds */
 #define BEACON_INTERVAL    10  /*seconds */
 
 #define PROV_ADDR         0x0001


### PR DESCRIPTION
Use the external crystal high frequency clock settling value
from devicetree.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>