### PR TITLE
drivers: stepper: allegro: Fix missing break statement

### DIFF
--- a/drivers/stepper/allegro/a4979.c
+++ b/drivers/stepper/allegro/a4979.c
@@ -121,6 +121,7 @@ static int a4979_stepper_set_micro_step_res(const struct device *dev,
 	case STEPPER_MICRO_STEP_4:
 		m0_value = 0;
 		m1_value = 1;
+		break;
 	case STEPPER_MICRO_STEP_16:
 		m0_value = 1;
 		m1_value = 1;


### PR DESCRIPTION
Fix missing break statement in a4979.c after line 123.

fixes: #90525
fixes: #90555