### PR TITLE
stm32h7: synchronize cores properly during boot

### DIFF
--- a/soc/st/stm32/common/stm32_hsem.h
+++ b/soc/st/stm32/common/stm32_hsem.h
@@ -28,9 +28,13 @@
 /* Index of the semaphore used to access the RCC */
 #define CFG_HW_RCC_SEMID                                        3U
 
-/* Index of the semaphore used to manage the entry Stop Mode procedure */
+/**
+ * Index of the semaphore used to manage the entry Stop Mode procedure.
+ * On STM32H7, this semaphore is instead used to gate the Cortex-M4 core
+ * until Cortex-M7 has finished initializing the system, and remains owned
+ * by CM7 afterwards.
+ */
 #define CFG_HW_ENTRY_STOP_MODE_SEMID                            4U
-#define CFG_HW_ENTRY_STOP_MODE_MASK_SEMID   (1U << CFG_HW_ENTRY_STOP_MODE_SEMID)
 
 /**
  *  Index of the semaphore used to manage the CLK48 clock configuration

--- a/soc/st/stm32/common/stm32_hsem.h
+++ b/soc/st/stm32/common/stm32_hsem.h
@@ -11,30 +11,26 @@
 #include <zephyr/kernel.h>
 
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
-/** HW semaphore Complement ID list defined in hw_conf.h from STM32WB
- * and used also for H7 dualcore targets
- */
 /**
- *  Index of the semaphore used by CPU2 to prevent the CPU1 to either write or
- *  erase data in flash. The CPU1 shall not either write or erase in flash when
- *  this semaphore is taken by the CPU2. When the CPU1 needs to either write or
- *  erase in flash, it shall first get the semaphore and release it just
- *  after writing a raw (64bits data) or erasing one sector.
- *  On v1.4.0 and older CPU2 wireless firmware, this semaphore is unused and
- *  CPU2 is using PES bit. By default, CPU2 is using the PES bit to protect its
- *  timing. The CPU1 may request the CPU2 to use the semaphore instead of the
- *  PES bit by sending the system command SHCI_C2_SetFlashActivityControl()
+ * Hardware semaphore assignment as defined in hw_conf.h from STM32WB.
+ * These assignments are also used on H7 dual-core targets.
  */
-#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID                    7U
 
-/**
- *  Index of the semaphore used by CPU1 to prevent the CPU2 to either write or
- *  erase data in flash. In order to protect its timing, the CPU1 may get this
- *  semaphore to prevent the  CPU2 to either write or erase in flash
- *  (as this will stall both CPUs)
- *  The PES bit shall not be used as this may stall the CPU2 in some cases.
- */
-#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID                    6U
+/* Index of the semaphore used to access the RNG */
+#define CFG_HW_RNG_SEMID                                        0U
+
+/* Index of the semaphore used to access the PKA */
+#define CFG_HW_PKA_SEMID                                        1U
+
+/* Index of the semaphore used to access the FLASH */
+#define CFG_HW_FLASH_SEMID                                      2U
+
+/* Index of the semaphore used to access the RCC */
+#define CFG_HW_RCC_SEMID                                        3U
+
+/* Index of the semaphore used to manage the entry Stop Mode procedure */
+#define CFG_HW_ENTRY_STOP_MODE_SEMID                            4U
+#define CFG_HW_ENTRY_STOP_MODE_MASK_SEMID   (1U << CFG_HW_ENTRY_STOP_MODE_SEMID)
 
 /**
  *  Index of the semaphore used to manage the CLK48 clock configuration
@@ -47,21 +43,27 @@
 #define CFG_HW_CLK48_CONFIG_SEMID                               5U
 #define CFG_HW_RCC_CRRCR_CCIPR_SEMID     CFG_HW_CLK48_CONFIG_SEMID
 
-/* Index of the semaphore used to manage the entry Stop Mode procedure */
-#define CFG_HW_ENTRY_STOP_MODE_SEMID                            4U
-#define CFG_HW_ENTRY_STOP_MODE_MASK_SEMID   (1U << CFG_HW_ENTRY_STOP_MODE_SEMID)
+/**
+ *  Index of the semaphore used by CPU1 to prevent the CPU2 to either write or
+ *  erase data in flash. In order to protect its timing, the CPU1 may get this
+ *  semaphore to prevent the  CPU2 to either write or erase in flash
+ *  (as this will stall both CPUs)
+ *  The PES bit shall not be used as this may stall the CPU2 in some cases.
+ */
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID                    6U
 
-/* Index of the semaphore used to access the RCC */
-#define CFG_HW_RCC_SEMID                                        3U
-
-/* Index of the semaphore used to access the FLASH */
-#define CFG_HW_FLASH_SEMID                                      2U
-
-/* Index of the semaphore used to access the PKA */
-#define CFG_HW_PKA_SEMID                                        1U
-
-/* Index of the semaphore used to access the RNG */
-#define CFG_HW_RNG_SEMID                                        0U
+/**
+ *  Index of the semaphore used by CPU2 to prevent the CPU1 to either write or
+ *  erase data in flash. The CPU1 shall not either write or erase in flash when
+ *  this semaphore is taken by the CPU2. When the CPU1 needs to either write or
+ *  erase in flash, it shall first get the semaphore and release it just
+ *  after writing a raw (64bits data) or erasing one sector.
+ *  On v1.4.0 and older CPU2 wireless firmware, this semaphore is unused and
+ *  CPU2 is using PES bit. By default, CPU2 is using the PES bit to protect its
+ *  timing. The CPU1 may request the CPU2 to use the semaphore instead of the
+ *  PES bit by sending the system command SHCI_C2_SetFlashActivityControl()
+ */
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID                    7U
 
 /** Index of the semaphore used to access GPIO */
 #define CFG_HW_GPIO_SEMID                                       8U
@@ -89,19 +91,18 @@
 
 #else
 /** Fake semaphore ID definition for compilation purpose only */
-#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID  0U
-#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID  0U
-#define CFG_HW_CLK48_CONFIG_SEMID             0U
-#define CFG_HW_RCC_CRRCR_CCIPR_SEMID          0U
-#define CFG_HW_ENTRY_STOP_MODE_SEMID          0U
-#define CFG_HW_RCC_SEMID                      0U
-#define CFG_HW_FLASH_SEMID                    0U
-#define CFG_HW_PKA_SEMID                      0U
-#define CFG_HW_RNG_SEMID                      0U
-#define CFG_HW_GPIO_SEMID                     0U
-#define CFG_HW_EXTI_SEMID                     0U
-#define CFG_HW_IPM_CPU1_SEMID                 0U
-#define CFG_HW_IPM_CPU2_SEMID                 0U
+#define CFG_HW_RNG_SEMID			0U
+#define CFG_HW_PKA_SEMID			0U
+#define CFG_HW_FLASH_SEMID			0U
+#define CFG_HW_RCC_SEMID			0U
+#define CFG_HW_ENTRY_STOP_MODE_SEMID		0U
+#define CFG_HW_CLK48_CONFIG_SEMID		0U
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU1_SEMID	0U
+#define CFG_HW_BLOCK_FLASH_REQ_BY_CPU2_SEMID	0U
+#define CFG_HW_GPIO_SEMID			0U
+#define CFG_HW_EXTI_SEMID			0U
+#define CFG_HW_IPM_CPU1_SEMID			0U
+#define CFG_HW_IPM_CPU2_SEMID			0U
 
 #endif /* CONFIG_SOC_SERIES_STM32WBX || CONFIG_STM32H7_DUAL_CORE */
 

--- a/soc/st/stm32/stm32h7x/soc_m7.c
+++ b/soc/st/stm32/stm32h7x/soc_m7.c
@@ -31,9 +31,13 @@ static int stm32h7_m4_wakeup(void)
 	LL_APB4_GRP1_EnableClock(LL_APB4_GRP1_PERIPH_SYSCFG);
 
 	if (READ_BIT(SYSCFG->UR1, SYSCFG_UR1_BCM4)) {
-		/* Cortex-M4 is waiting for end of system initialization made by
-		 * Cortex-M7. This initialization is now finished,
-		 * then Cortex-M7 takes HSEM so that CM4 can continue running.
+		/**
+		 * Cortex-M4 has been started by hardware.
+		 * Its `soc_early_init_hook()` will stall boot until
+		 * a specific HSEM becomes locked, which indicates
+		 * that Cortex-M7 has finished initializing the system.
+		 * As system initialization is now complete, lock the
+		 * HSEM to release CM4 and allow it to continue booting.
 		 */
 		LL_HSEM_1StepLock(HSEM, CFG_HW_ENTRY_STOP_MODE_SEMID);
 	} else if (IS_ENABLED(CONFIG_STM32H7_BOOT_M4_AT_INIT)) {


### PR DESCRIPTION
On dual-core STM32H7, the Cortex-M4 core is supposed to wait until the Cortex-M7 initializes the system before starting to execute. CM7 should signal this by locking a specific HSEM, which CM4 should poll until locked. However, the logic on the Cortex-M4 side was reading the `HSEM_RLR` register to obtain semaphore status, which *locks the semaphore on read* - in turn, this makes the CM4 start directly since it sees that the semaphore is locked (by itself).

Replace raw register read with call to proper LL API, which will read the `HSEM_R` register instead of `HSEM_RLR`, to make sure CM4 doesn't begin execution earlier than it should, and update the comments in `soc_m4.c` and `soc_m7.c` related to this boot process.

Fixes #86494 - confirmed working on STM32H747I-DISCO by flashing `samples/basic/blinky` on Cortex-M4 and `samples/hello_world` on Cortex-M7. With patch, the LED can be seen blinking only if `CONFIG_STM32H7_DUAL_CORE=y` (and `CONFIG_STM32H7_BOOT_M4_AT_INIT=y` if the `BCM4` option byte is disabled) - without patch, the LED can be seen blinking in all scenarios if the `BCM4` option byte is enabled.

First commit tidies `stm32_hsem.h` - mostly cosmetic changes, but I also removed the seemingly unused `CFG_HW_ENTRY_STOP_MODE_MASK_SEMID` define. This commit can be dropped if preferred.