### PR TITLE
tests/flash_map: Allow custom maps to opt out from some scenarios

### DIFF
--- a/tests/subsys/storage/flash_map/Kconfig
+++ b/tests/subsys/storage/flash_map/Kconfig
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+mainmenu "Flash Map test configuration"
+
+config TEST_FLASH_MAP_DISABLED_PARTITIONS
+	bool "Test support for disabled partitions"
+	default y if !FLASH_MAP_CUSTOM
+	help
+	  Test flash_area_open for returning -ENOENT for disabled partitions.
+	  Note that custom flash maps may not support disabled partitions
+	  and therefore not even generated id for them. In such case it would
+	  not be possible to provide disabled partition id to flash_area_open,
+	  making this test impossible to run.
+
+config TEST_FLASH_MAP_NODE_MACROS
+	bool "Test DTS macros for accessing partition info via DTS node"
+	default y if !FLASH_MAP_CUSTOM
+	help
+	  Custom flash map may be defined outside of DTS definition, therefore
+	  not have a DTS nodes for partitions.
+
+menu "Zephyr"
+source "Kconfig.zephyr"
+endmenu

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -25,6 +25,14 @@ struct flash_sector fs_sectors[2048];
 
 ZTEST(flash_map, test_flash_area_disabled_device)
 {
+	/* The test checks if Flash Map will report partition
+	 * non-existend if it is disabled, but it also assumes that
+	 * disabled parition will have an ID generated.
+	 * Custom partition maps may not be generating entries for
+	 * disabled partitions nor identifiers, which makes the
+	 * test fail with custom partition manager, for no real reason.
+	 */
+#if defined(CONFIG_TEST_FLASH_MAP_DISABLED_PARTITIONS)
 	const struct flash_area *fa;
 	int rc;
 
@@ -38,6 +46,9 @@ ZTEST(flash_map, test_flash_area_disabled_device)
 	 * because this macro will fail, at compile time, if node does not
 	 * exist or is disabled.
 	 */
+#else
+	ztest_test_skip();
+#endif
 }
 
 ZTEST(flash_map, test_flash_area_device_is_ready)
@@ -144,6 +155,11 @@ ZTEST(flash_map, test_flash_area_erased_val)
 
 ZTEST(flash_map, test_fixed_partition_node_macros)
 {
+	/* DTS node macros, for accessing fixed partitions, are only available
+	 * for DTS based partitions; custom flash map may define partition outside
+	 * of DTS definition, making the NODE macros fail to evaluate.
+	 */
+#if defined(CONFIG_TEST_FLASH_MAP_NODE_MACROS)
 	/* Test against changes in API */
 	zassert_equal(FIXED_PARTITION_NODE_OFFSET(SLOT1_PARTITION_NODE),
 		DT_REG_ADDR(SLOT1_PARTITION_NODE));
@@ -155,6 +171,9 @@ ZTEST(flash_map, test_fixed_partition_node_macros)
 	/* Taking by node and taking by label should give same device */
 	zassert_equal(FIXED_PARTITION_BY_NODE(DT_NODELABEL(SLOT1_PARTITION)),
 		      FIXED_PARTITION(SLOT1_PARTITION));
+#else
+	ztest_test_skip();
+#endif
 }
 
 ZTEST(flash_map, test_flash_area_erase_and_flatten)


### PR DESCRIPTION
The commit modifies the Flash Map test, providing Kconfigs that allow to opt out from testing disabled partitions and testing DTS node access.