### PR TITLE
doc: _extensions: kconfig: add :kconfig:option-regex: role

### DIFF
--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -1083,6 +1083,31 @@ Make sure to use the full name of the Kconfig option, including the ``CONFIG_`` 
 
       Check out :kconfig:option:`CONFIG_GPIO` for more information.
 
+.. rst:role:: kconfig:option-regex
+
+   This role is used to create links to regex searches for Kconfig options. It generates a link to
+   the Kconfig search page with the provided regex pattern automatically filled in as the search
+   query. It is useful for referencing multiple Kconfig options that share a common prefix, or
+   belong to a common category. For example::
+
+      Check out :kconfig:option-regex:`CONFIG_SECURE_STORAGE_ITS_(STORE|TRANSFORM)_.*_CUSTOM` for
+      the various customization possibilities.
+
+   Will render as:
+
+      Check out :kconfig:option-regex:`CONFIG_SECURE_STORAGE_ITS_(STORE|TRANSFORM)_.*_CUSTOM` for
+      the various customization possibilities.
+
+   It is encouraged to provide a custom link text to make the reference more readable. For example::
+
+      Check out the :kconfig:option-regex:`ITS Kconfig options <CONFIG_SECURE_STORAGE_ITS_.*>`
+      for more information.
+
+   Will render as:
+
+      Check out the :kconfig:option-regex:`ITS Kconfig options <CONFIG_SECURE_STORAGE_ITS_.*>`
+      for more information.
+
 Devicetree bindings
 ===================
 

--- a/doc/services/storage/secure_storage/index.rst
+++ b/doc/services/storage/secure_storage/index.rst
@@ -76,8 +76,8 @@ Configuration
 *************
 
 To configure the implementation of the PSA Secure Storage API provided by Zephyr, have a look at the
-``CONFIG_SECURE_STORAGE_.*`` Kconfig options. They are defined in the various Kconfig files found
-under ``subsys/secure_storage/``.
+available :kconfig:option-regex:`Kconfig options <CONFIG_SECURE_STORAGE_.*>`.
+They are defined in the various Kconfig files found under :zephyr_file:`subsys/secure_storage/`.
 
 Customization
 *************
@@ -100,8 +100,9 @@ ITS API
 Zephyr's implementation of the ITS API
 (:kconfig:option:`CONFIG_SECURE_STORAGE_ITS_IMPLEMENTATION_ZEPHYR`)
 makes use of the ITS transform and store modules, which can be configured and customized separately.
-Have a look at the ``CONFIG_SECURE_STORAGE_ITS_(STORE|TRANSFORM)_.*_CUSTOM``
-Kconfig options to see the different customization possibilities.
+Have a look at the :kconfig:option-regex:`ITS transform and store Kconfig options
+<CONFIG_SECURE_STORAGE_ITS_(STORE|TRANSFORM)_.*_CUSTOM>` to see the different customization
+possibilities.
 
 It's especially recommended to implement a custom encryption key provider
 (:kconfig:option:`CONFIG_SECURE_STORAGE_ITS_TRANSFORM_AEAD_KEY_PROVIDER_CUSTOM`)


### PR DESCRIPTION
Allow users to create links to Kconfig regex searches. The new role generates links to the Kconfig search page with the regex pattern as the search query.

Fixes zephyrproject-rtos/zephyr#90571

doc for the new role and demo of it in action: https://builds.zephyrproject.io/zephyr/pr/90681/docs/contribute/documentation/guidelines.html#role-kconfig-option-regex

<img width="854" alt="image" src="https://github.com/user-attachments/assets/b480eb27-82c0-43a2-acad-e3289bfad4ac" />