### PR TITLE
boards: arm: mps3: fix intermittent ci failures

### DIFF
--- a/boards/arm/mps3/mps3_corstone300_fvp.yaml
+++ b/boards/arm/mps3/mps3_corstone300_fvp.yaml
@@ -17,6 +17,7 @@ supported:
   - gpio
 testing:
   default: true
+  timeout_multiplier: 4
   ignore_tags:
     - bluetooth
     - net

--- a/boards/arm/mps3/mps3_corstone300_fvp_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone300_fvp_ns.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: mps3/corstone300/fvp/ns
@@ -12,5 +12,6 @@ toolchain:
   - zephyr
 testing:
   default: true
+  timeout_multiplier: 4
   only_tags:
     - trusted-firmware-m

--- a/boards/arm/mps3/mps3_corstone310_fvp.yaml
+++ b/boards/arm/mps3/mps3_corstone310_fvp.yaml
@@ -17,6 +17,7 @@ supported:
   - gpio
 testing:
   default: true
+  timeout_multiplier: 4
   ignore_tags:
     - drivers
     - bluetooth

--- a/boards/arm/mps3/mps3_corstone310_fvp_ns.yaml
+++ b/boards/arm/mps3/mps3_corstone310_fvp_ns.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 identifier: mps3/corstone310/fvp/ns
@@ -12,5 +12,6 @@ toolchain:
   - zephyr
 testing:
   default: true
+  timeout_multiplier: 4
   only_tags:
     - trusted-firmware-m


### PR DESCRIPTION
FVP's are functionally accurate but not cycle accurate which is
different from QEMU which prefers speed over accuracy.
This sometimes leads to intermittent test failures with FVP which
would otherwise pass with QEMU.
The intermittent failed tests are successful on retries however,
adding a timeout_multiplier would reduce the chance of failures so
we set the timeout_multiplier to a value which will avoid the issue.
Fixes #90654