### PR TITLE
subsys/fs/fuse: Fix adding missing stddef header

### DIFF
--- a/subsys/fs/fuse_fs_access_bottom.c
+++ b/subsys/fs/fuse_fs_access_bottom.c
@@ -10,6 +10,7 @@
 #undef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 700
 
+#include <stddef.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Instead of relaying on stddef.h being included by other headers let's include it explicitly, following a report of it being missing for Ubuntu 22.04 (glibc 2.35)

Fixes #90679