### PR TITLE
samples: enable build tests for the ch32v006evt

### DIFF
--- a/samples/basic/blinky/sample.yaml
+++ b/samples/basic/blinky/sample.yaml
@@ -7,6 +7,7 @@ tests:
       - gpio
     filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
     depends_on: gpio
+    min_ram: 8
     harness: led
     integration_platforms:
       - frdm_k64f

--- a/samples/basic/blinky_pwm/sample.yaml
+++ b/samples/basic/blinky_pwm/sample.yaml
@@ -9,6 +9,7 @@ tests:
       - drivers
       - pwm
     depends_on: pwm
+    min_ram: 8
     harness: console
     harness_config:
       type: multi_line

--- a/samples/drivers/led/pwm/sample.yaml
+++ b/samples/drivers/led/pwm/sample.yaml
@@ -6,6 +6,7 @@ tests:
     filter: dt_compat_enabled("pwm-leds")
     tags: LED
     depends_on: pwm
+    min_ram: 8
     platform_exclude: reel_board
     integration_platforms:
       - frdm_k22f

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -14,6 +14,7 @@ common:
       - "Waiting for reset..."
       - "Watchdog sample application"
   depends_on: watchdog
+  min_ram: 8
 tests:
   sample.drivers.watchdog:
     filter: not (CONFIG_SOC_FAMILY_STM32 or CONFIG_SOC_FAMILY_GD_GD32 or SOC_SERIES_GD32VF103)


### PR DESCRIPTION
The ch32v006evt has 8 KiB of RAM which is enough for many of the basic samples but, by default, Twister assumes that a sample needs 16 KiB of RAM.

Mark some of the samples as needing 8 KiB of RAM so the ch32v006evt gets better CI coverage.