### PR TITLE
dts: riscv: aesc: Add reg-names to machine timer node

### DIFF
--- a/dts/riscv/aesc/nitrogen.dtsi
+++ b/dts/riscv/aesc/nitrogen.dtsi
@@ -41,6 +41,7 @@
 		mtimer: machine-timer@f0020000 {
 			compatible = "riscv,machine-timer";
 			reg = <0xf0020000 0x8 0xf0020008 0x8>;
+			reg-names = "mtime", "mtimecmp";
 			interrupts-extended = <&hlic 7>;
 			status = "okay";
 		};


### PR DESCRIPTION
Commit 42fb9067e47312b46c9daf0ab34127a5a156a1ad makes it mandatory to now have reg-names property on the riscv,machine-timer node. This DTS file was somehow missed as part of the refactoring.