### PR TITLE
drivers: can: rcar: various code quality fixes

### DIFF
--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -830,7 +830,7 @@ static int can_rcar_recover(const struct device *dev, k_timeout_t timeout)
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
 	int64_t start_time;
-	int ret;
+	int ret = 0;
 
 	if (!data->common.started) {
 		return -ENETDOWN;

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -474,12 +474,11 @@ static void can_rcar_isr(const struct device *dev)
 static int can_rcar_leave_sleep_mode(const struct can_rcar_cfg *config)
 {
 	uint16_t ctlr, str;
-	int i;
 
 	ctlr = can_rcar_read16(config, RCAR_CAN_CTLR);
 	ctlr &= ~RCAR_CAN_CTLR_SLPM;
 	can_rcar_write16(config, RCAR_CAN_CTLR, ctlr);
-	for (i = 0; i < MAX_STR_READS; i++) {
+	for (int i = 0; i < MAX_STR_READS; i++) {
 		str = can_rcar_read16(config, RCAR_CAN_STR);
 		if (!(str & RCAR_CAN_STR_SLPST)) {
 			return 0;
@@ -491,7 +490,6 @@ static int can_rcar_leave_sleep_mode(const struct can_rcar_cfg *config)
 static int can_rcar_enter_reset_mode(const struct can_rcar_cfg *config, bool force)
 {
 	uint16_t ctlr;
-	int i;
 
 	ctlr = can_rcar_read16(config, RCAR_CAN_CTLR);
 	ctlr &= ~RCAR_CAN_CTLR_CANM_MASK;
@@ -500,7 +498,7 @@ static int can_rcar_enter_reset_mode(const struct can_rcar_cfg *config, bool for
 		ctlr |= RCAR_CAN_CTLR_CANM_HALT;
 	}
 	can_rcar_write16(config, RCAR_CAN_CTLR, ctlr);
-	for (i = 0; i < MAX_STR_READS; i++) {
+	for (int i = 0; i < MAX_STR_READS; i++) {
 		if (can_rcar_read16(config, RCAR_CAN_STR) & RCAR_CAN_STR_RSTST) {
 			return 0;
 		}
@@ -511,7 +509,6 @@ static int can_rcar_enter_reset_mode(const struct can_rcar_cfg *config, bool for
 static int can_rcar_enter_halt_mode(const struct can_rcar_cfg *config)
 {
 	uint16_t ctlr;
-	int i;
 
 	ctlr = can_rcar_read16(config, RCAR_CAN_CTLR);
 	ctlr &= ~RCAR_CAN_CTLR_CANM_MASK;
@@ -521,7 +518,7 @@ static int can_rcar_enter_halt_mode(const struct can_rcar_cfg *config)
 	/* Wait for controller to apply high bit timing settings */
 	k_usleep(1);
 
-	for (i = 0; i < MAX_STR_READS; i++) {
+	for (int i = 0; i < MAX_STR_READS; i++) {
 		if (can_rcar_read16(config, RCAR_CAN_STR) & RCAR_CAN_STR_HLTST) {
 			return 0;
 		}

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -1023,11 +1023,9 @@ static int can_rcar_init(const struct device *dev)
 	data->common.state_change_cb = NULL;
 	data->common.state_change_cb_user_data = NULL;
 
-	if (config->common.phy != NULL) {
-		if (!device_is_ready(config->common.phy)) {
-			LOG_ERR("CAN transceiver not ready");
-			return -ENODEV;
-		}
+	if (config->common.phy != NULL && !device_is_ready(config->common.phy)) {
+		LOG_ERR("CAN transceiver not ready");
+		return -ENODEV;
 	}
 
 	if (!device_is_ready(config->clock_dev)) {


### PR DESCRIPTION
- Always initialize the return value variable to avoid returning garbage.
- Declare the loop condition variable inside the loops to limit their scope.
- Merge two nested if-statements into one.