### PR TITLE
charger: axp2101: Corrects unsigned int comparison

### DIFF
--- a/drivers/charger/charger_axp2101.c
+++ b/drivers/charger/charger_axp2101.c
@@ -257,7 +257,7 @@ static int get_status(const struct device *dev, union charger_propval *val)
 	}
 
 	tmp = tmp & CHARGING_STATUS;
-	if ((tmp >= TRICKLE_CHARGE) && (tmp <= CONSTANT_VOLTAGE)) {
+	if (tmp <= CONSTANT_VOLTAGE) {
 		val->status = CHARGER_STATUS_CHARGING;
 	} else if (tmp == CHARGE_DONE) {
 		val->status = CHARGER_STATUS_FULL;


### PR DESCRIPTION
Removes an unnecessary comparison of an unsigned int against the value zero.