### PR TITLE
charger: axp2101: Guards against out-of-bounds read

### DIFF
--- a/drivers/charger/charger_axp2101.c
+++ b/drivers/charger/charger_axp2101.c
@@ -220,7 +220,7 @@ static int get_constant_charge_voltage_uv(const struct device *dev, union charge
 		return ret;
 	}
 
-	if (tmp > ARRAY_SIZE(constant_charge_voltage_lut)) {
+	if (tmp >= ARRAY_SIZE(constant_charge_voltage_lut)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Corrects the out-of-bounds check when reading
constant_charge_voltage_lut