### PR TITLE
tests: timer_api: logging/log_syst: fix unused var warnings when CONFIG_ZTEST_ASSERT_VERBOSE is 0

### DIFF
--- a/tests/kernel/timer/timer_api/src/timer_convert.c
+++ b/tests/kernel/timer/timer_api/src/timer_convert.c
@@ -14,7 +14,7 @@ enum units { UNIT_ticks, UNIT_cyc, UNIT_ms, UNIT_us, UNIT_ns };
 
 enum round { ROUND_floor, ROUND_ceil, ROUND_near };
 
-static const char *const round_s[] = {
+static const char *const round_s[] __maybe_unused = {
 	[ROUND_floor] = "floor",
 	[ROUND_ceil] = "ceil",
 	[ROUND_near] = "near",

--- a/tests/subsys/logging/log_syst/src/mock_backend.c
+++ b/tests/subsys/logging/log_syst/src/mock_backend.c
@@ -63,7 +63,8 @@ void validate_msg(const char *type, const char *optional_flags,
 	const char *raw_data_str = "SYS-T RAW DATA: ";
 	const char *output_str = test_output_buf;
 	const char *syst_format_headers[4] = {type, optional_flags, module_id, sub_type};
-	const char *syst_headers_name[4] = {"type", "optional_flags", "module_id", "sub_type"};
+	const char *syst_headers_name[4] __maybe_unused = {"type", "optional_flags", "module_id",
+							   "sub_type"};
 
 	/* Validate "SYS-T RAW DATA: " prefix in the output_str */
 	zassert_mem_equal(raw_data_str, output_str, strlen(raw_data_str),


### PR DESCRIPTION
When CONFIG_ZTEST_ASSERT_VERBOSE is 0, some `zassert_*()` functions do not use all of the inputs, resulting in compiler complaining about unused variables. So mark them `__used`.