### PR TITLE
drivers: flash: Clarify parameter validation order

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -395,6 +395,14 @@ static int flash_flexspi_hyperflash_read(const struct device *dev, off_t offset,
 {
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 
+	if (len == 0) {
+		return 0;
+	}
+
+	if (!buffer) {
+		return -EINVAL;
+	}
+
 	uint8_t *src = memc_flexspi_get_ahb_address(&data->controller,
 			data->port,
 			offset);

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -361,6 +361,15 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 		void *buffer, size_t len)
 {
 	struct flash_flexspi_nor_data *data = dev->data;
+
+	if (len == 0) {
+		return 0;
+	}
+
+	if (!buffer) {
+		return -EINVAL;
+	}
+
 	uint8_t *src = memc_flexspi_get_ahb_address(data->controller,
 						    data->port,
 						    offset);

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -325,6 +325,10 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 {
 	struct flash_flexspi_nor_data *data = dev->data;
 
+	if (len == 0) {
+		return 0;
+	}
+
 	if (!buffer) {
 		return -EINVAL;
 	}

--- a/drivers/flash/flash_nxp_s32_qspi.c
+++ b/drivers/flash/flash_nxp_s32_qspi.c
@@ -59,6 +59,10 @@ int nxp_s32_qspi_read(const struct device *dev, off_t offset, void *dest, size_t
 	Qspi_Ip_StatusType status;
 	int ret = 0;
 
+	if (size == 0) {
+		return 0;
+	}
+
 	if (!dest) {
 		return -EINVAL;
 	}

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -125,6 +125,18 @@ int flash_params_get_erase_cap(const struct flash_parameters *p)
  * @{
  */
 
+/**
+ * @brief Flash read implementation handler type
+ *
+ * @return 0 on success or len is zero, -EINVAL if page offset doesn't exist or data
+ *         destination is NULL
+ *
+ * @note Any necessary read protection management must be performed by
+ * the driver.
+ *
+ * For consistency across implementations, value check len parameter equal zero and
+ * return result 0 before validating the data destination parameter.
+ */
 typedef int (*flash_api_read)(const struct device *dev, off_t offset,
 			      void *data,
 			      size_t len);


### PR DESCRIPTION
Add some clarity on expected parameter validation order to have
consistency between implementations.

Update NXP flash drivers to align with parameter validation order

Fixes #87021

Signed-off-by: David Leach <david.leach@nxp.com>