### PR TITLE
samples: counter: alarm: fix CI build fail

### DIFF
--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -16,32 +16,12 @@ common:
   depends_on: counter
 tests:
   sample.drivers.counter.alarm:
-    platform_allow:
-      - nucleo_f746zg
-      - nrf51dk/nrf51822
-      - nrf52dk/nrf52832
-      - nrf52840dk/nrf52840
-      - nrf9160dk/nrf9160
-      - samd20_xpro
-      - bl5340_dvk/nrf5340/cpuapp
-      - gd32e103v_eval
-      - gd32e507z_eval
-      - gd32f403z_eval
-      - gd32f450i_eval
-      - gd32f450z_eval
-      - gd32e507v_start
-      - gd32f407v_start
-      - gd32f450v_start
-      - gd32f470i_eval
-      - stm32h735g_disco
-      - stm32h573i_dk
-      - rpi_pico
-      - mr_canhubk3
-      - s32z2xxdc2/s32z270/rtu0
-      - s32z2xxdc2/s32z270/rtu1
-      - s32z2xxdc2@D/s32z270/rtu0
-      - s32z2xxdc2@D/s32z270/rtu1
-      - lp_em_cc2340r5
+    platform_exclude:
+      - mps2/an385
+      - mimxrt1060_evk@A/mimxrt1062/qspi
+      - mimxrt1060_evk@B/mimxrt1062/qspi
+      - mimxrt1060_evk@C/mimxrt1062/hyperflash
+      - mimxrt1060_evk@C/mimxrt1062/qspi
     integration_platforms:
       - nucleo_f746zg
   sample.drivers.counter.alarm.stm32_rtc:


### PR DESCRIPTION
Exclude mimxrt1060_evk from build as this board
does not support this sample yet

Signed-off-by: The Nguyen <the.nguyen.yf@renesas.com>