### PR TITLE
dts: bindings: misc: add generic gpio controlled switch

### DIFF
--- a/dts/bindings/misc/zephyr,gpio-switch.yaml
+++ b/dts/bindings/misc/zephyr,gpio-switch.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Mario Paja
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Generic GPIO controlled switch
+
+compatible: "zephyr,gpio-switch"
+
+child-binding:
+  description: GPIO switch child node
+  properties:
+    gpios:
+      type: phandle-array
+      required: true
+
+    label:
+      type: string
+      description: Descriptive name of the switch


### PR DESCRIPTION
This PR adds a generic gpio controlled switch binding.

The issue for a generic gpio controlled switch binding arised at https://github.com/zephyrproject-rtos/zephyr/pull/90059