### PR TITLE
net: lib: coap: Return an error on removing a non-existing observer

### DIFF
--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -725,6 +725,12 @@ int coap_resource_parse_observe(struct coap_resource *resource, const struct coa
 		ret = coap_service_remove_observer(service, resource, addr, token, tkl);
 		if (ret < 0) {
 			LOG_WRN("Failed to remove observer (%d)", ret);
+			goto unlock;
+		}
+
+		if (ret == 0) {
+			/* Observer not found */
+			ret = -ENOENT;
 		}
 	}
 


### PR DESCRIPTION
If we're parsing a CoAP request with an observe option of '1', but there is no matching observer, return an error instead of returning a zero.

Fixes #90688