### PR TITLE
ci: Twister BBox test fix

### DIFF
--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
+
 name: Twister BlackBox TestSuite
 
 on:


### PR DESCRIPTION
WIP
Some of the smoke test runs seems to fail,
but they do not fail the whole workflow run.