### PR TITLE
drivers: sensor: icp101xx: remove logically dead code

### DIFF
--- a/drivers/sensor/tdk/icp101xx/icp101xx_drv.c
+++ b/drivers/sensor/tdk/icp101xx/icp101xx_drv.c
@@ -176,10 +176,6 @@ static int icp101xx_channel_get(const struct device *dev, enum sensor_channel ch
 	val->val1 = 0;
 	val->val2 = 0;
 
-	if (!((chan == SENSOR_CHAN_AMBIENT_TEMP) || (chan == SENSOR_CHAN_PRESS) ||
-	      (chan == SENSOR_CHAN_ALTITUDE))) {
-		return -ENOTSUP;
-	}
 	/* Zephyr expects kPa while ICP101xx returns Pa */
 	if (chan == SENSOR_CHAN_AMBIENT_TEMP) {
 #ifdef ICP101XX_DRV_USE_FLOATS


### PR DESCRIPTION
Removed a logically dead else by doing sensor channel check
in a way that's more aligned with how other drivers do it.

Fixes: CID 505949
Fixes: zephyrproject-rtos/zephyr#90558