### PR TITLE
drivers: Do not use deprecated OpenThread instance pointer.

### DIFF
--- a/drivers/hdlc_rcp_if/hdlc_rcp_if_uart.c
+++ b/drivers/hdlc_rcp_if/hdlc_rcp_if_uart.c
@@ -151,7 +151,7 @@ static void hdlc_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 	ctx->ot_context = net_if_l2_data(iface);
 
-	otPlatRadioGetIeeeEui64(ctx->ot_context->instance, eui64.m8);
+	otPlatRadioGetIeeeEui64(openthread_get_default_instance(), eui64.m8);
 	net_if_set_link_addr(iface, eui64.m8, OT_EXT_ADDRESS_SIZE,
 			     NET_LINK_IEEE802154);
 }


### PR DESCRIPTION
Implementation should use a dedicated function to get OpenThread instance instead of using the deprecated pointer from context.