### PR TITLE
led: fix up the ENOSYS condition to pass coverity

### DIFF
--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -207,9 +207,10 @@ static inline int z_impl_led_set_brightness(const struct device *dev,
 	const struct led_driver_api *api =
 		(const struct led_driver_api *)dev->api;
 
-	if (api->set_brightness == NULL &&
-	    api->on == NULL && api->off == NULL) {
-		return -ENOSYS;
+	if (api->set_brightness == NULL) {
+		if (api->on == NULL || api->off == NULL) {
+			return -ENOSYS;
+		}
 	}
 
 	if (value > LED_BRIGTHNESS_MAX) {


### PR DESCRIPTION
The current ENOSYS check code can proceed for a driver that hypothetically implements the on() but not the off() function of vice versa, which would result in a null pointer dereference.

This would be a weird use case but Coverity catches the situation, no harm in changing the ENOSYS check to fail if the on/off is half implemented, so let's change it to do that.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/90484