### PR TITLE
tests: boot: Update imgtool path in west_sign_wrapper

### DIFF
--- a/tests/boot/with_mcumgr/pytest/west_sign_wrapper.py
+++ b/tests/boot/with_mcumgr/pytest/west_sign_wrapper.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shlex
 
 from subprocess import check_output
@@ -11,6 +12,12 @@ from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
+
+
+def get_imgtool_path() -> Path:
+    """Get the path to the imgtool script."""
+    zephyr_base = os.getenv("ZEPHYR_BASE") or Path(__file__).parents[4]
+    return Path(zephyr_base).parent / "bootloader" / "mcuboot" / "scripts" / "imgtool.py"
 
 
 def west_sign_with_imgtool(
@@ -24,6 +31,7 @@ def west_sign_with_imgtool(
     command = [
         'west', 'sign',
         '-t', 'imgtool',
+        '--tool-path', str(get_imgtool_path()),
         '--no-hex',
         '--build-dir', str(build_dir)
     ]


### PR DESCRIPTION
Fixes `tests/boot/with_mcumgr` in case, when `imgtool` is not installed. Added `imgtool` path to `west sign` wrapper.

Log from internal CI before fix:
```
INFO: CMD: west sign -t imgtool --no-hex --build-dir twister-out/nrf52840dk_nrf52840/zephyr/tests/boot/with_mcumgr/boot.with_mcumgr.test_upgrade/with_mcumgr --sbin twister-out/nrf52840dk_nrf52840/zephyr/tests/boot/with_mcumgr/boot.with_mcumgr.test_upgrade/test_0_0_2_0.signed.bin -- --key bootloader/mcuboot/root-rsa-2048.pem --version 0.0.2+0
WARNING: west sign using imgtool is deprecated and will be removed in a future release
FATAL ERROR: imgtool not found; either install it (e.g. "pip3 install imgtool") or provide --tool-path
FAILED
```

to test it one can run:
`$ZEPHYR_BASE/scripts/twister -T tests/boot/with_mcumgr --device-testing --hardware-map hardware_map.yml --west-flash="--erase" --enable-slow  -vv -c -ll debug `

