### PR TITLE
Nordic nRF54HX and nRF92X soc trims

### DIFF
--- a/drivers/clock_control/clock_control_nrf_auxpll.c
+++ b/drivers/clock_control/clock_control_nrf_auxpll.c
@@ -26,7 +26,6 @@
 struct clock_control_nrf_auxpll_config {
 	NRF_AUXPLL_Type *auxpll;
 	uint32_t ref_clk_hz;
-	uint32_t ficr_ctune;
 	nrf_auxpll_config_t cfg;
 	uint16_t frequency;
 	nrf_auxpll_ctrl_outsel_t out_div;
@@ -113,7 +112,6 @@ static int clock_control_nrf_auxpll_init(const struct device *dev)
 	nrf_auxpll_ctrl_frequency_set(config->auxpll, config->frequency);
 
 	nrf_auxpll_lock(config->auxpll);
-	nrf_auxpll_trim_ctune_set(config->auxpll, sys_read8(config->ficr_ctune));
 	nrf_auxpll_config_set(config->auxpll, &config->cfg);
 	nrf_auxpll_ctrl_outsel_set(config->auxpll, config->out_div);
 	nrf_auxpll_unlock(config->auxpll);
@@ -127,8 +125,6 @@ static int clock_control_nrf_auxpll_init(const struct device *dev)
 	static const struct clock_control_nrf_auxpll_config config##n = {                          \
 		.auxpll = (NRF_AUXPLL_Type *)DT_INST_REG_ADDR(n),                                  \
 		.ref_clk_hz = DT_PROP(DT_INST_CLOCKS_CTLR(n), clock_frequency),                    \
-		.ficr_ctune = DT_REG_ADDR(DT_INST_PHANDLE(n, nordic_ficrs)) +                      \
-			      DT_INST_PHA(n, nordic_ficrs, offset),                                \
 		.cfg =                                                                             \
 			{                                                                          \
 				.outdrive = DT_INST_PROP(n, nordic_out_drive),                     \

--- a/dts/bindings/misc/nordic,nrf-memconf.yaml
+++ b/dts/bindings/misc/nordic,nrf-memconf.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nordic MEMCONF (Memory Configuration Registers)
+
+compatible: "nordic,nrf-memconf"
+
+include:
+  - base.yaml
+  - nordic-nrf-ficr-client.yaml
+
+properties:
+  reg:
+    required: true
+
+  nordic,ficrs:
+    required: true

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -284,8 +284,9 @@
 				nordic,ficrs =
 					<&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_VSUP>,
 					<&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_COARSE_0>,
-					<&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_FINE_0>;
-				nordic,ficr-names = "vsup", "coarse", "fine";
+					<&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_FINE_0>,
+					<&ficr NRF_FICR_TRIM_APPLICATION_HSFLL_TRIM_TCOEF>;
+				nordic,ficr-names = "vsup", "coarse", "fine", "tcoef";
 			};
 
 			cpuapp_ipct: ipct@13000 {

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -289,6 +289,16 @@
 				nordic,ficr-names = "vsup", "coarse", "fine", "tcoef";
 			};
 
+			cpuapp_memconf: memconf@12000 {
+				compatible = "nordic,nrf-memconf";
+				reg = <0x12000 0x1000>;
+				nordic,ficrs =
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_0_TRIM>,
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_1_TRIM>,
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_2_TRIM>,
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_3_TRIM>;
+			};
+
 			cpuapp_ipct: ipct@13000 {
 				compatible = "nordic,nrf-ipct-local";
 				reg = <0x13000 0x1000>;
@@ -341,6 +351,16 @@
 					<&ficr NRF_FICR_TRIM_RADIOCORE_HSFLL_TRIM_COARSE_1>,
 					<&ficr NRF_FICR_TRIM_RADIOCORE_HSFLL_TRIM_FINE_1>;
 				nordic,ficr-names = "vsup", "coarse", "fine";
+			};
+
+			cpurad_memconf: memconf@12000 {
+				compatible = "nordic,nrf-memconf";
+				reg = <0x12000 0x1000>;
+				nordic,ficrs =
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_0_TRIM>,
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_1_TRIM>,
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_2_TRIM>,
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_3_TRIM>;
 			};
 
 			cpurad_wdt010: watchdog@13000 {

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -176,6 +176,16 @@
 				nordic,ficr-names = "vsup", "coarse", "fine";
 			};
 
+			cpuapp_memconf: memconf@12000 {
+				compatible = "nordic,nrf-memconf";
+				reg = <0x12000 0x1000>;
+				nordic,ficrs =
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_0_TRIM>,
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_1_TRIM>,
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_2_TRIM>,
+					<&ficr NRF_FICR_TRIM_APPLICATION_MEMCONF_BLOCKTYPE_3_TRIM>;
+			};
+
 			cpuapp_ipct: ipct@13000 {
 				compatible = "nordic,nrf-ipct-local";
 				reg = <0x13000 0x1000>;
@@ -226,6 +236,16 @@
 					<&ficr NRF_FICR_TRIM_RADIOCORE_HSFLL_TRIM_COARSE_1>,
 					<&ficr NRF_FICR_TRIM_RADIOCORE_HSFLL_TRIM_FINE_1>;
 				nordic,ficr-names = "vsup", "coarse", "fine";
+			};
+
+			cpurad_memconf: memconf@12000 {
+				compatible = "nordic,nrf-memconf";
+				reg = <0x12000 0x1000>;
+				nordic,ficrs =
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_0_TRIM>,
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_1_TRIM>,
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_2_TRIM>,
+					<&ficr NRF_FICR_TRIM_RADIOCORE_MEMCONF_BLOCKTYPE_3_TRIM>;
 			};
 
 			cpurad_wdt010: watchdog@13000 {

--- a/soc/nordic/common/CMakeLists.txt
+++ b/soc/nordic/common/CMakeLists.txt
@@ -38,3 +38,7 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_NRF_SYS_EVENT nrf_sys_event.c)
 zephyr_library_sources_ifdef(CONFIG_MRAM_LATENCY mram_latency.c)
+
+if((CONFIG_SOC_SERIES_NRF54HX OR CONFIG_SOC_SERIES_NRF92X) AND CONFIG_ARM)
+  zephyr_library_sources(nrf54hx_nrf92x_trim.c)
+endif()

--- a/soc/nordic/common/nrf54hx_nrf92x_trim.c
+++ b/soc/nordic/common/nrf54hx_nrf92x_trim.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <hal/nrf_hsfll.h>
+#include <hal/nrf_auxpll.h>
+
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+#define FICR_ADDR_GET(node_id)									\
+	DT_REG_ADDR(DT_PHANDLE(node_id, nordic_ficrs)) +					\
+	DT_PHA(node_id, nordic_ficrs, offset)
+
+#define FICR_ADDR_GET_BY_NAME(node_id, name)							\
+	DT_REG_ADDR(DT_PHANDLE_BY_NAME(node_id, nordic_ficrs, name)) +				\
+	DT_PHA_BY_NAME(node_id, nordic_ficrs, name, offset)
+
+#if defined(CONFIG_SOC_NRF54H20_CPUAPP) || defined(CONFIG_SOC_NRF9280_CPUAPP)
+#define LOCAL_HSFLL_NODE DT_NODELABEL(cpuapp_hsfll)
+#elif defined(CONFIG_SOC_NRF54H20_CPURAD) || defined(CONFIG_SOC_NRF9280_CPURAD)
+#define LOCAL_HSFLL_NODE DT_NODELABEL(cpurad_hsfll)
+#else
+#error "unsupported"
+#endif
+
+static void trim_local_hsfll(void)
+{
+	NRF_HSFLL_Type *hsfll = (NRF_HSFLL_Type *)DT_REG_ADDR(LOCAL_HSFLL_NODE);
+	nrf_hsfll_trim_t trim = {
+		.vsup = sys_read32(FICR_ADDR_GET_BY_NAME(LOCAL_HSFLL_NODE, vsup)),
+		.coarse = sys_read32(FICR_ADDR_GET_BY_NAME(LOCAL_HSFLL_NODE, coarse)),
+		.fine = sys_read32(FICR_ADDR_GET_BY_NAME(LOCAL_HSFLL_NODE, fine))
+	};
+
+	LOG_DBG("Trim: HSFLL VSUP: 0x%.8x", trim.vsup);
+	LOG_DBG("Trim: HSFLL COARSE: 0x%.8x", trim.coarse);
+	LOG_DBG("Trim: HSFLL FINE: 0x%.8x", trim.fine);
+
+	nrf_hsfll_clkctrl_mult_set(hsfll,
+				   DT_PROP(LOCAL_HSFLL_NODE, clock_frequency) /
+				   DT_PROP(DT_CLOCKS_CTLR(LOCAL_HSFLL_NODE), clock_frequency));
+	nrf_hsfll_trim_set(hsfll, &trim);
+
+	nrf_hsfll_task_trigger(hsfll, NRF_HSFLL_TASK_FREQ_CHANGE);
+	/* HSFLL task frequency change needs to be triggered twice to take effect.*/
+	nrf_hsfll_task_trigger(hsfll, NRF_HSFLL_TASK_FREQ_CHANGE);
+
+	LOG_DBG("NRF_HSFLL->TRIM.VSUP = %d", hsfll->TRIM.VSUP);
+	LOG_DBG("NRF_HSFLL->TRIM.COARSE = %d", hsfll->TRIM.COARSE);
+	LOG_DBG("NRF_HSFLL->TRIM.FINE = %d", hsfll->TRIM.FINE);
+}
+
+#define TRIM_NRF_AUXPLL_DEFINE(node_id)								\
+	{											\
+		NRF_AUXPLL_Type *auxpll = (NRF_AUXPLL_Type *)DT_REG_ADDR(node_id);		\
+												\
+		LOG_DBG("Trim: AUXPLL CTUNE: 0x%02x", sys_read8(FICR_ADDR_GET(node_id)));	\
+		nrf_auxpll_lock(auxpll);							\
+		nrf_auxpll_trim_ctune_set(auxpll, sys_read8(FICR_ADDR_GET(node_id)));		\
+		nrf_auxpll_unlock(auxpll);							\
+		LOG_DBG("AUXPLL->AUXPL.CTUNE = %d", auxpll->TRIM.CTUNE);			\
+	}
+
+void nrf54hx_nrf92x_trim(void)
+{
+	trim_local_hsfll();
+
+	DT_FOREACH_STATUS_OKAY(nordic_nrf_auxpll, TRIM_NRF_AUXPLL_DEFINE)
+}

--- a/soc/nordic/common/nrf54hx_nrf92x_trim.h
+++ b/soc/nordic/common/nrf54hx_nrf92x_trim.h
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Apply factory trims to all owned and enabled peripherals */
+void nrf54hx_nrf92x_trim(void);

--- a/soc/nordic/nrf92/soc.c
+++ b/soc/nordic/nrf92/soc.c
@@ -10,22 +10,12 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
-#include <hal/nrf_hsfll.h>
+#include <nrf54hx_nrf92x_trim.h>
 #include <hal/nrf_lrcconf.h>
 #include <hal/nrf_spu.h>
 #include <soc/nrfx_coredep.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
-
-#if defined(NRF_APPLICATION)
-#define HSFLL_NODE DT_NODELABEL(cpuapp_hsfll)
-#elif defined(NRF_RADIOCORE)
-#define HSFLL_NODE DT_NODELABEL(cpurad_hsfll)
-#endif
-
-#define FICR_ADDR_GET(node_id, name)                                           \
-	DT_REG_ADDR(DT_PHANDLE_BY_NAME(node_id, nordic_ficrs, name)) +         \
-		DT_PHA_BY_NAME(node_id, nordic_ficrs, name, offset)
 
 #define SPU_INSTANCE_GET(p_addr)                                               \
 	((NRF_SPU_Type *)((p_addr) & (ADDRESS_REGION_Msk |                     \
@@ -53,37 +43,6 @@ static void power_domain_init(void)
 	nrf_lrcconf_retain_set(NRF_LRCCONF010, NRF_LRCCONF_POWER_DOMAIN_0, true);
 }
 
-static int trim_hsfll(void)
-{
-#if defined(HSFLL_NODE)
-
-	NRF_HSFLL_Type *hsfll = (NRF_HSFLL_Type *)DT_REG_ADDR(HSFLL_NODE);
-	nrf_hsfll_trim_t trim = {
-		.vsup = sys_read32(FICR_ADDR_GET(HSFLL_NODE, vsup)),
-		.coarse = sys_read32(FICR_ADDR_GET(HSFLL_NODE, coarse)),
-		.fine = sys_read32(FICR_ADDR_GET(HSFLL_NODE, fine))
-	};
-
-	LOG_DBG("Trim: HSFLL VSUP: 0x%.8x", trim.vsup);
-	LOG_DBG("Trim: HSFLL COARSE: 0x%.8x", trim.coarse);
-	LOG_DBG("Trim: HSFLL FINE: 0x%.8x", trim.fine);
-
-	nrf_hsfll_clkctrl_mult_set(hsfll,
-				   DT_PROP(HSFLL_NODE, clock_frequency) /
-					   DT_PROP(DT_CLOCKS_CTLR(HSFLL_NODE), clock_frequency));
-	nrf_hsfll_trim_set(hsfll, &trim);
-
-	nrf_hsfll_task_trigger(hsfll, NRF_HSFLL_TASK_FREQ_CHANGE);
-
-	LOG_DBG("NRF_HSFLL->TRIM.VSUP = %d", hsfll->TRIM.VSUP);
-	LOG_DBG("NRF_HSFLL->TRIM.COARSE = %d", hsfll->TRIM.COARSE);
-	LOG_DBG("NRF_HSFLL->TRIM.FINE = %d", hsfll->TRIM.FINE);
-
-#endif /* defined(HSFLL_NODE) */
-
-	return 0;
-}
-
 static int nordicsemi_nrf92_init(void)
 {
 	sys_cache_instr_enable();
@@ -91,7 +50,7 @@ static int nordicsemi_nrf92_init(void)
 
 	power_domain_init();
 
-	trim_hsfll();
+	nrf54hx_nrf92x_trim();
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ccm030))
 	/* DMASEC is set to non-secure by default, which prevents CCM from


### PR DESCRIPTION
Add missing factory calibration trim values to devicetree sources and move applying them to common, scalable file to be used by both nRF54HX and nRF92X SoCs.