### PR TITLE
kernel: work: add k_work_queue_run()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -3635,6 +3635,18 @@ void k_work_queue_start(struct k_work_q *queue,
 			k_thread_stack_t *stack, size_t stack_size,
 			int prio, const struct k_work_queue_config *cfg);
 
+/** @brief Run work queue using calling thread
+ *
+ * This will run the work queue forever unless stopped by @ref k_work_queue_stop.
+ *
+ * @param queue the queue to run
+ *
+ * @param cfg optional additional configuration parameters.  Pass @c
+ * NULL if not required, to use the defaults documented in
+ * k_work_queue_config.
+ */
+void k_work_queue_run(struct k_work_q *queue, const struct k_work_queue_config *cfg);
+
 /** @brief Access the thread that animates a work queue.
  *
  * This is necessary to grant a work queue thread access to things the work
@@ -4214,6 +4226,11 @@ struct k_work_q {
 	/* The thread that animates the work. */
 	struct k_thread thread;
 
+	/* The thread ID that animates the work. This may be an external thread
+	 * if k_work_queue_run() is used.
+	 */
+	k_tid_t thread_id;
+
 	/* All the following fields must be accessed only while the
 	 * work module spinlock is held.
 	 */
@@ -4264,7 +4281,7 @@ static inline k_ticks_t k_work_delayable_remaining_get(
 
 static inline k_tid_t k_work_queue_thread_get(struct k_work_q *queue)
 {
-	return &queue->thread;
+	return queue->thread_id;
 }
 
 /** @} */

--- a/tests/kernel/workq/work_queue/src/start_stop.c
+++ b/tests/kernel/workq/work_queue/src/start_stop.c
@@ -21,7 +21,7 @@ static void work_handler(struct k_work *work)
 	k_msleep(CONFIG_TEST_WORK_ITEM_WAIT_MS);
 }
 
-ZTEST(workqueue_api, test_k_work_queue_stop)
+ZTEST(workqueue_api, test_k_work_queue_start_stop)
 {
 	size_t i;
 	struct k_work work;
@@ -54,6 +54,69 @@ ZTEST(workqueue_api, test_k_work_queue_stop)
 	k_work_init(&work, work_handler);
 	zassert_equal(k_work_submit_to_queue(&work_q, &work), -ENODEV,
 		      "Succeeded to submit work item to non-initialized work queue");
+}
+
+#define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+
+static K_THREAD_STACK_DEFINE(run_stack, STACK_SIZE);
+
+static void run_q_main(void *workq_ptr, void *sem_ptr, void *p3)
+{
+	ARG_UNUSED(p3);
+
+	struct k_work_q *queue = (struct k_work_q *)workq_ptr;
+	struct k_sem *sem = (struct k_sem *)sem_ptr;
+
+	struct k_work_queue_config cfg = {
+		.name = "wq.run_q",
+		.no_yield = true,
+	};
+
+	k_work_queue_run(queue, &cfg);
+
+	k_sem_give(sem);
+}
+
+ZTEST(workqueue_api, test_k_work_queue_run_stop)
+{
+	int rc;
+	size_t i;
+	struct k_thread thread;
+	struct k_work work;
+	struct k_work_q work_q = {0};
+	struct k_work works[NUM_TEST_ITEMS];
+	struct k_sem ret_sem;
+
+	k_sem_init(&ret_sem, 0, 1);
+
+	(void)k_thread_create(&thread, run_stack, STACK_SIZE, run_q_main, &work_q, &ret_sem, NULL,
+			      K_PRIO_COOP(3), 0, K_FOREVER);
+
+	k_thread_start(&thread);
+
+	k_sleep(K_MSEC(CHECK_WAIT));
+
+	for (i = 0; i < NUM_TEST_ITEMS; i++) {
+		k_work_init(&works[i], work_handler);
+		zassert_equal(k_work_submit_to_queue(&work_q, &works[i]), 1,
+			      "Failed to submit work item");
+	}
+
+	/* Wait for the work item to complete */
+	k_sleep(K_MSEC(CHECK_WAIT));
+
+	zassert_equal(k_work_queue_stop(&work_q, K_FOREVER), -EBUSY,
+		      "Succeeded to stop work queue while it is running & not plugged");
+	zassert_true(k_work_queue_drain(&work_q, true) >= 0, "Failed to drain & plug work queue");
+	zassert_ok(k_work_queue_stop(&work_q, K_FOREVER), "Failed to stop work queue");
+
+	k_work_init(&work, work_handler);
+	zassert_equal(k_work_submit_to_queue(&work_q, &work), -ENODEV,
+		      "Succeeded to submit work item to non-initialized work queue");
+
+	/* Take the semaphore the other thread released once done running the queue */
+	rc = k_sem_take(&ret_sem, K_MSEC(1));
+	zassert_equal(rc, 0);
 }
 
 ZTEST_SUITE(workqueue_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
I wanted to put forward this additional kernel API for review/discussion. The initial work was completed by @bjarki-andreasen and then I've done some minor tweaks to the code & tests to ensure this path gets tested. (I've left @bjarki-andreasen as the `Signed-off-by` and added myself with `Co-authored-by`, but if that's the not process please let me know)

Add the ability to block and process a work queue by invoking `k_work_queue_run` from an existing thread. This can be particularly useful for using the `main` thread to process work items, in the same vein as the system work queue, but from a lower priority/preemptible thread.

### Technical Details

* This adds a small bit of extra storage to each work queue, to store the `k_tid_t` that is processing the queue, so we can use that ID for the couple areas in the work queue code that need to know if calls into the API are coming from the same thread currently processing a work item. Previously, the internal thread was used to make this comparison.
* In the interest of not breaking API, this does *not* remove the allocated `struct k_thread`. Doing so would likely need a restructuring of the work queue API for the existing APIs to pass in an externally allocated thread for all "entrypoints". I'm open to ideas here to avoid this, but I don't see any easy way.

TIA.