### PR TITLE
modules: optional: rust: Update to latest development

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
       groups:
         - optional
     - name: zephyr-lang-rust
-      revision: 615b2b76f18427f7fa6ec2bf765aeed1994dc64e
+      revision: 1cab77b436bccf2c84678e8825b586a093da0918
       path: modules/lang/rust
       remote: upstream
       groups:


### PR DESCRIPTION
Bring in the following changes to the Rust module, updating since rev 4.1.

    e53f6de1c06 fix(cmake): Evaluate generator expressions in sample cargo config e64cadb3c9e zephyr: thread: Add 'join_timeout' to RunningThread a683eb8a3b5 zephyr: Replace critical-section implementation 26cd3bc0c8a zephyr-sys: Export irq_lock/unlock
    901edef9bc8 zephyr: Specify minimum rust version
    0de6f6c390d zephyr-build: Simplify dt-yaml syntax
    edcef3ba39c zephyr: Remove stale doc references to futures 4096ad7c803 cmake: Fix dependency problem
    5557cb3fc35 zephyr: object: Fix bad doc link
    d921320cc7d zephyr: devicetree: Allow non-snake-case names in DT nodes 14618bd02f7 zephyr: sys: sync: Semaphore: Remove incorrect ALLOC check 47e270d5ac5 zephyr: sync: Conditionalize PinWeak on alloc f8b228fe71c samples: bench: Increase thread stack size on 64-bit platforms ec50a4317b9 zephyr: sync: Create PinWeak type
    2e5059a209d samples: async-philosophers: Remove overly specific imports a0061313850 samples: async-philosophers: Convert to general async 5c15fbb9d20 zephyr: Remove work-queue executor
    f107c93dce6 samples: rename work-philosophers to async-philosophers ed8d08bc890 samples: bench: Replace old async with new 087e584eae9 zephyr-macros: Incorporate fn name into thread name 72ed3818192 samples: philosophers: Migrate to new task declaration 44b2dd28073 zephyr: Add proc macro for thread declaration 8952b444b3a CI: Force python version 3.12
    e3518de6d07 cmake: add USES_TERMINAL to show cargo output b7dacdac984 zephyr: embassy: Use a semaphore for the executor a871c7f588c Add support for board native_sim/native/64 349164d630a samples: blinky: Remove incorrect integration platform b0866632d42 samples/tests: Ensure test/sample names are unique 7395ae4f486 zephyr-build: fix DTS parser for Windows a341bc50041 samples: philosophers: Migrate Mutex to const constructor 5000f459f26 samples: bench: Clean up formatting
    6020ab7db36 zephyr: Run rustfmt
    c1d74e1d5df samples: bench: Make Semaphores static 37754d29e0b samples: bench: Reduce benchmark iterations 11067823e53 samples: bench: Remove the 'basesem' prototype 3a4f08ba1ea zepyr: sys: sync: Mutex/Condvar
    64605eb89cf samples: bench: fix for API change
    8d7ca493801 zephyr: Convert `Queue` to new atomic initializer up 3a0016dace2 zephyr: sys: sync: Make Semaphore constructors `const` 5ceccc155c2 zephyr: object: Implement new ZephyrObject wrapper 2790674bb7f docgen: Enable async features for doc generation 1b475b7a9a8 tests: drivers: gpio-async: Test the async gpio operations 0347eac6882 zephyr: Add async 'wait_for_high' and 'wait_for_low' to gpio b60408c54ef zephyr: device: Add a possible static element with each device 28f7ec6b515 zephyr: device: gpio: Add a few more methods bcc9ee433bd zephyr: embassy: Add Default implementation a458d8e33eb zephyr: embassy: Eliminate unused printkln import dea64363115 samples: embassy: Detect proper end to the test 04d9e5714e6 samples: embassy: Increase task pool size eae89bc4d2b samples: embassy: Fix test name
    758a2c264c7 samples: embassy: Update formatting
    ac0eaac9d8b zephyr: Update rustfmt
    db93ee7978e samples: embassy: Update Embassy Demo for Zephyr executor a9958395985 zephyr: Implement `executor-zephyr` to use with Embassy 60d7c5396ac samples: embassy: Start of an embassy demo 1540e9ab785 zephyr: Add initial support for embassy 1503a982e00 docs: Update top-level index
    c58d1f20024 zephyr: Expand top-level crate docs
