### PR TITLE
west: spdx: allow to generate for different SPDX versions

### DIFF
--- a/.ruff-excludes.toml
+++ b/.ruff-excludes.toml
@@ -1117,10 +1117,6 @@
     "UP008",    # https://docs.astral.sh/ruff/rules/super-call-with-parameters
     "UP032",    # https://docs.astral.sh/ruff/rules/f-string
 ]
-"./scripts/west_commands/spdx.py" = [
-    "F541",     # https://docs.astral.sh/ruff/rules/f-string-missing-placeholders
-    "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
-]
 "./scripts/west_commands/tests/conftest.py" = [
     "I001",     # https://docs.astral.sh/ruff/rules/unsorted-imports
 ]

--- a/doc/develop/west/zephyr-cmds.rst
+++ b/doc/develop/west/zephyr-cmds.rst
@@ -75,7 +75,7 @@ See :zephyr_file:`share/zephyr-package/cmake` for details.
 Software bill of materials: ``west spdx``
 *****************************************
 
-This command generates SPDX 2.3 tag-value documents, creating relationships
+This command generates SPDX 2.2 or 2.3 tag-value documents, creating relationships
 from source files to the corresponding generated build files.
 ``SPDX-License-Identifier`` comments in source files are scanned and filled
 into the SPDX documents.
@@ -104,6 +104,12 @@ To use this command:
    .. code-block:: bash
 
       west spdx -d BUILD_DIR
+
+   By default, this generates SPDX 2.3 documents. To generate SPDX 2.2 documents instead:
+
+   .. code-block:: bash
+
+      west spdx -d BUILD_DIR --spdx-version 2.2
 
 .. note::
 
@@ -143,6 +149,10 @@ source files that are compiled to generate the built library files.
 
 - ``-s SPDX_DIR``: specifies an alternate directory where the SPDX documents
   should be written instead of :file:`BUILD_DIR/spdx/`.
+
+- ``--spdx-version {2.2,2.3}``: specifies which SPDX specification version to use.
+  Defaults to ``2.3``. SPDX 2.3 includes additional fields like ``PrimaryPackagePurpose``
+  that are not available in SPDX 2.2.
 
 - ``--analyze-includes``: in addition to recording the compiled source code
   files (e.g. ``.c``, ``.S``) in the bills-of-materials, also attempt to

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -6,11 +6,11 @@ import os
 import uuid
 
 from west.commands import WestCommand
-
 from zspdx.sbom import SBOMConfig, makeSPDX, setupCmakeQuery
+from zspdx.version import SPDX_VERSION_2_3, SUPPORTED_SPDX_VERSIONS, parse
 
 SPDX_DESCRIPTION = """\
-This command creates an SPDX 2.2 tag-value bill of materials
+This command creates an SPDX 2.2 or 2.3 tag-value bill of materials
 following the completion of a Zephyr build.
 
 Prior to the build, an empty file must be created at
@@ -41,6 +41,9 @@ class ZephyrSpdx(WestCommand):
                 help="namespace prefix")
         parser.add_argument('-s', '--spdx-dir',
                 help="SPDX output directory")
+        parser.add_argument('--spdx-version', choices=[str(v) for v in SUPPORTED_SPDX_VERSIONS],
+                default=str(SPDX_VERSION_2_3),
+                help="SPDX specification version to use (default: 2.3)")
         parser.add_argument('--analyze-includes', action="store_true",
                 help="also analyze included header files")
         parser.add_argument('--include-sdk', action="store_true",
@@ -55,6 +58,7 @@ class ZephyrSpdx(WestCommand):
         self.dbg("  --build-dir is", args.build_dir)
         self.dbg("  --namespace-prefix is", args.namespace_prefix)
         self.dbg("  --spdx-dir is", args.spdx_dir)
+        self.dbg("  --spdx-version is", args.spdx_version)
         self.dbg("  --analyze-includes is", args.analyze_includes)
         self.dbg("  --include-sdk is", args.include_sdk)
 
@@ -85,6 +89,11 @@ class ZephyrSpdx(WestCommand):
         # create the SPDX files
         cfg = SBOMConfig()
         cfg.buildDir = args.build_dir
+        try:
+            version_obj = parse(args.spdx_version)
+        except Exception:
+            self.die(f"Invalid SPDX version: {args.spdx_version}")
+        cfg.spdxVersion = version_obj
         if args.namespace_prefix:
             cfg.namespacePrefix = args.namespace_prefix
         else:

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -49,14 +49,14 @@ class ZephyrSpdx(WestCommand):
         return parser
 
     def do_run(self, args, unknown_args):
-        self.dbg(f"running zephyr SPDX generator")
+        self.dbg("running zephyr SPDX generator")
 
-        self.dbg(f"  --init is", args.init)
-        self.dbg(f"  --build-dir is", args.build_dir)
-        self.dbg(f"  --namespace-prefix is", args.namespace_prefix)
-        self.dbg(f"  --spdx-dir is", args.spdx_dir)
-        self.dbg(f"  --analyze-includes is", args.analyze_includes)
-        self.dbg(f"  --include-sdk is", args.include_sdk)
+        self.dbg("  --init is", args.init)
+        self.dbg("  --build-dir is", args.build_dir)
+        self.dbg("  --namespace-prefix is", args.namespace_prefix)
+        self.dbg("  --spdx-dir is", args.spdx_dir)
+        self.dbg("  --analyze-includes is", args.analyze_includes)
+        self.dbg("  --include-sdk is", args.include_sdk)
 
         if args.init:
             self.do_run_init(args)

--- a/scripts/west_commands/zspdx/sbom.py
+++ b/scripts/west_commands/zspdx/sbom.py
@@ -7,6 +7,7 @@ import os
 from west import log
 
 from zspdx.scanner import ScannerConfig, scanDocument
+from zspdx.version import SPDX_VERSION_2_3
 from zspdx.walker import Walker, WalkerConfig
 from zspdx.writer import writeSPDX
 
@@ -25,6 +26,9 @@ class SBOMConfig:
 
         # location of SPDX document output directory
         self.spdxDir = ""
+
+        # SPDX specification version to use
+        self.spdxVersion = SPDX_VERSION_2_3
 
         # should also analyze for included header files?
         self.analyzeIncludes = False
@@ -101,31 +105,33 @@ def makeSPDX(cfg):
 
     # write SDK document, if we made one
     if cfg.includeSDK:
-        retval = writeSPDX(os.path.join(cfg.spdxDir, "sdk.spdx"), w.docSDK)
+        retval = writeSPDX(os.path.join(cfg.spdxDir, "sdk.spdx"), w.docSDK, cfg.spdxVersion)
         if not retval:
             log.err("SPDX writer failed for SDK document; bailing")
             return False
 
     # write app document
-    retval = writeSPDX(os.path.join(cfg.spdxDir, "app.spdx"), w.docApp)
+    retval = writeSPDX(os.path.join(cfg.spdxDir, "app.spdx"), w.docApp, cfg.spdxVersion)
     if not retval:
         log.err("SPDX writer failed for app document; bailing")
         return False
 
     # write zephyr document
-    retval = writeSPDX(os.path.join(cfg.spdxDir, "zephyr.spdx"), w.docZephyr)
+    retval = writeSPDX(os.path.join(cfg.spdxDir, "zephyr.spdx"), w.docZephyr, cfg.spdxVersion)
     if not retval:
         log.err("SPDX writer failed for zephyr document; bailing")
         return False
 
     # write build document
-    retval = writeSPDX(os.path.join(cfg.spdxDir, "build.spdx"), w.docBuild)
+    retval = writeSPDX(os.path.join(cfg.spdxDir, "build.spdx"), w.docBuild, cfg.spdxVersion)
     if not retval:
         log.err("SPDX writer failed for build document; bailing")
         return False
 
     # write modules document
-    retval = writeSPDX(os.path.join(cfg.spdxDir, "modules-deps.spdx"), w.docModulesExtRefs)
+    retval = writeSPDX(
+        os.path.join(cfg.spdxDir, "modules-deps.spdx"), w.docModulesExtRefs, cfg.spdxVersion
+    )
     if not retval:
         log.err("SPDX writer failed for modules-deps document; bailing")
         return False

--- a/scripts/west_commands/zspdx/sbom.py
+++ b/scripts/west_commands/zspdx/sbom.py
@@ -113,19 +113,19 @@ def makeSPDX(cfg):
         return False
 
     # write zephyr document
-    writeSPDX(os.path.join(cfg.spdxDir, "zephyr.spdx"), w.docZephyr)
+    retval = writeSPDX(os.path.join(cfg.spdxDir, "zephyr.spdx"), w.docZephyr)
     if not retval:
         log.err("SPDX writer failed for zephyr document; bailing")
         return False
 
     # write build document
-    writeSPDX(os.path.join(cfg.spdxDir, "build.spdx"), w.docBuild)
+    retval = writeSPDX(os.path.join(cfg.spdxDir, "build.spdx"), w.docBuild)
     if not retval:
         log.err("SPDX writer failed for build document; bailing")
         return False
 
     # write modules document
-    writeSPDX(os.path.join(cfg.spdxDir, "modules-deps.spdx"), w.docModulesExtRefs)
+    retval = writeSPDX(os.path.join(cfg.spdxDir, "modules-deps.spdx"), w.docModulesExtRefs)
     if not retval:
         log.err("SPDX writer failed for modules-deps document; bailing")
         return False

--- a/scripts/west_commands/zspdx/version.py
+++ b/scripts/west_commands/zspdx/version.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 The Linux Foundation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from packaging.version import Version
+
+SPDX_VERSION_2_2 = Version("2.2")
+SPDX_VERSION_2_3 = Version("2.3")
+
+SUPPORTED_SPDX_VERSIONS = [
+    SPDX_VERSION_2_2,
+    SPDX_VERSION_2_3,
+]
+
+
+def parse(version_str):
+    v = Version(version_str)
+    if v not in SUPPORTED_SPDX_VERSIONS:
+        raise ValueError(f"Unsupported SPDX version: {version_str}")
+    return v


### PR DESCRIPTION
When support for SPDX 2.3 was added, it effectively dropped support for SPDX 2.2, which in retrospect was a bad idea since SPDX 2.2 is the version that is the current ISO/IEC standard.

This commit adds a `--spdx-version` option to the `west spdx` command so that users can generate SPDX 2.2 documents if they want.

Default is 2.3 given that's effectively what shipped for a few releases now, including latest LTS, but it could be argued it should be 2.2 as per my comment above re: it being the ISO standard.