### PR TITLE
boards: raspberrypi: rpi_pico: Use sysbuild.overlay

### DIFF
--- a/boards/raspberrypi/rpi_pico/Kconfig.sysbuild
+++ b/boards/raspberrypi/rpi_pico/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 Beechwoods Software Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+choice BOOTLOADER
+	default BOOTLOADER_MCUBOOT
+endchoice
+
+choice BOOT_SIGNATURE_TYPE
+	default BOOT_SIGNATURE_TYPE_NONE
+endchoice

--- a/boards/raspberrypi/rpi_pico/sysbuild.overlay
+++ b/boards/raspberrypi/rpi_pico/sysbuild.overlay
@@ -1,0 +1,7 @@
+/delete-node/ &code_partition;
+#include <raspberrypi/partitions_2M_sysbuild.dtsi>
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};


### PR DESCRIPTION
Use `boards/raspberrypi/rpi_pico/sysbuild.overlay` for rpi_pcio to build
SysBuild images.