### PR TITLE
samples: subsys: usb: mass: Include rpi_pico.overlay

### DIFF
--- a/samples/subsys/usb/mass/boards/rpi_pico_rp2040_w.overlay
+++ b/samples/subsys/usb/mass/boards/rpi_pico_rp2040_w.overlay
@@ -1,0 +1,1 @@
+#include "rpi_pico.overlay"


### PR DESCRIPTION
Include rpi_pico.overlay from the rpi_pico_rp2040_w.overlay in order to have `pico/rp2040/w` board to work out of the box.