### PR TITLE
modules: hal_wch: update the HAL to pull in CH32V00x support

### DIFF
--- a/drivers/pwm/pwm_wch_gptm.c
+++ b/drivers/pwm/pwm_wch_gptm.c
@@ -27,6 +27,20 @@
 /* Each of the 4 channels uses 1 nibble of CCER */
 #define CCER_MASK              (TIM_CC1P | TIM_CC1E)
 
+#ifdef TIM2_CTLR1_CEN
+/* ch32fun.h uses a different set of names for the CH32V00x series. Remap. */
+typedef GPTM_TypeDef TIM_TypeDef;
+#define TIM_CEN  TIM2_CTLR1_CEN
+#define TIM_OC1M TIM2_CHCTLR1_OC1M
+#define TIM_OC2M TIM2_CHCTLR1_OC2M
+#define TIM_OC3M TIM2_CHCTLR2_OC3M
+#define TIM_OC4M TIM2_CHCTLR2_OC4M
+#define TIM_CC1P TIM2_CCER_CC1P
+#define TIM_CC1E TIM2_CCER_CC1E
+#define TIM_CC1E TIM2_CCER_CC1E
+#define TIM_ARPE TIM2_CTLR1_ARPE
+#endif
+
 struct pwm_wch_gptm_config {
 	TIM_TypeDef *regs;
 	const struct device *clock_dev;

--- a/modules/hal_wch/hal_ch32fun.h
+++ b/modules/hal_wch/hal_ch32fun.h
@@ -13,7 +13,7 @@
 #endif
 
 #if defined(CONFIG_SOC_SERIES_CH32V00X)
-#define CH32V003 1
+#define CH32V00x 1
 #include <ch32fun.h>
 #endif
 

--- a/west.yml
+++ b/west.yml
@@ -260,7 +260,7 @@ manifest:
       groups:
         - hal
     - name: hal_wch
-      revision: 941f5182b5577d168e0cbcc0c9dd26294c1806a5
+      revision: 6dd313768b5f4cc69baeac4ce6e59f2038eb8ce5
       path: modules/hal/wch
       groups:
         - hal


### PR DESCRIPTION
Now that the HAL has been committed, pick it and fix the related build errors. This fixes the CH32V006 AFIO and ADC issues.

Tested by running `./scripts/twister -j3 -b --vendor wch` locally with in-flight PRs that expand the build test coverage.