### PR TITLE
Fix spi loopback thread test on fail case

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -289,7 +289,7 @@ ZTEST(spi_loopback, test_spi_complete_multiple_timed)
 							      buffer2_rx, BUF2_SIZE);
 	uint32_t freq = spec->config.frequency;
 	uint32_t start_time, end_time, cycles_spent;
-	uint64_t time_spent_us, expected_transfer_time_us;
+	uint64_t time_spent_us, expected_transfer_time_us, latency_measurement;
 
 	/* since this is a test program, there shouldn't be much to interfere with measurement */
 	start_time = k_cycle_get_32();
@@ -329,7 +329,12 @@ ZTEST(spi_loopback, test_spi_complete_multiple_timed)
 	zassert_true(time_spent_us >= minimum_transfer_time_us,
 			"Transfer faster than theoretically possible");
 
-	TC_PRINT("Latency measurement: %llu us\n", time_spent_us - expected_transfer_time_us);
+	/* handle overflow for print statement */
+	latency_measurement = time_spent_us - expected_transfer_time_us;
+	if (latency_measurement > time_spent_us) {
+		latency_measurement = 0;
+	}
+	TC_PRINT("Latency measurement: %llu us\n", latency_measurement);
 
 	/* Allow some overhead, but not too much */
 	zassert_true(time_spent_us <= expected_transfer_time_us * 8, "Very high latency");


### PR DESCRIPTION
In the case of thread test failing, it is not handled well and will mess up the execution of the rest of the test. This can be fixed as is done in the PR.

Also fixes a mistake on a value printed in the test log for the latency test, this problem did not actually affect the pass/fail of the test and neither does the fix to it.