### PR TITLE
soc: nxp_kinetis: Mark  __kinetis_flash_config  with __used attribute

### DIFF
--- a/soc/nxp/kinetis/flash_configuration.c
+++ b/soc/nxp/kinetis/flash_configuration.c
@@ -7,7 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/linker/sections.h>
 
-uint8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
+uint8_t __used __kinetis_flash_config_section __kinetis_flash_config[] = {
 	/* Backdoor Comparison Key (unused) */
 	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 


### PR DESCRIPTION
This is a fix for issue #90426 .
Marking __kinetis_flash_config  with __used attribute prevents unwanted deletion when compiling with LTO.