### PR TITLE
doc: release: update/consolidate LTS information

### DIFF
--- a/doc/project/release_process.rst
+++ b/doc/project/release_process.rst
@@ -226,7 +226,7 @@ Long Term Support (LTS)
 =======================
 
 Long-term support releases are designed to be supported and maintained
-for an extended period and is the recommended release for
+for an extended period and are the recommended release for
 products and the auditable branch used for certification.
 
 An LTS release is defined as:
@@ -235,8 +235,7 @@ An LTS release is defined as:
 - **Extended Stabilisation period**: Allow for more testing and bug fixing
 - **Stable APIs**
 - **Quality Driven Process**
-- **Long Term**: Maintained for an extended period of time (at least 2.5 years)
-  overlapping previous LTS release for at least half a year.
+- **Long Term**: Maintained for an extended period of time (at least 5 years).
 
 
 Product Focused
@@ -323,10 +322,22 @@ state of the software when it was released.
 Long Term Support and Maintenance
 ++++++++++++++++++++++++++++++++++
 
-A Zephyr LTS release is published every 2 years and is branched and maintained
-independently from the main tree for at least 2.5 years after it was
-released. Support and maintenance for an LTS release stops at least half a year
-after the following LTS release is published.
+LTS releases are published every 2.5 to 3 years and are branched and maintained independently from
+the main tree for approximately 5 years after they were released.
+
+Support is provided in three main phases:
+
+- **Phase 1 (first 2 years):** General bug fixes and security fixes, including platform and driver
+  fixes.
+- **Phase 2 (following 3+ years):** Security and OS stability fixes only.
+- **Phase 3:** Extended support may be available through third parties (details to be determined).
+
+Support for a given LTS release (LTS *N*) continues until the initial release of the LTS two
+versions ahead (LTS *N+2*). A final release of LTS *N* occurs shortly after the initial release of
+LTS *N+2*.
+
+The list of currently supported LTS releases and their EOL dates can be found
+:ref:`here <supported_releases>`.
 
 .. figure:: lts.svg
     :align: center

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -33,11 +33,8 @@ Long Term Support and Maintenance
 =================================
 
 A Zephyr :ref:`Long Term Support (LTS) <release_process_lts>` release is
-published every 2 years and is branched and maintained independently from the
-main tree for at least 2.5 years after it was released.
-
-Support and maintenance for an LTS release stops at least half a year
-after the following LTS release is published.
+published every 2.5 to 3 years and is branched and maintained independently from the
+main tree for approximately 5 years after it was released.
 
 Security Fixes
 ==============
@@ -51,6 +48,7 @@ following releases:
 
 For more information, see  :ref:`Security Vulnerability Reporting <reporting>`.
 
+.. _supported_releases:
 
 Supported Releases
 ******************


### PR DESCRIPTION
Update documentation with new LTS lifecycle information following TSC decision to extend LTS support to 5 years.
Also removed some duplicate information.