### PR TITLE
Workaround arch.shared_interrupt.lto.speed fail on apollo5

### DIFF
--- a/soc/ambiq/apollo5x/soc.c
+++ b/soc/ambiq/apollo5x/soc.c
@@ -48,9 +48,9 @@ void soc_early_init_hook(void)
 	/*
 	 * Set default temperature for spotmgr to room temperature
 	 */
-	am_hal_pwrctrl_temp_thresh_t dummy;
+	am_hal_pwrctrl_temp_thresh_t dummy[32];
 
-	am_hal_pwrctrl_temp_update(25.0f, &dummy);
+	am_hal_pwrctrl_temp_update(25.0f, dummy);
 
 	/* Enable Icache*/
 	sys_cache_instr_enable();


### PR DESCRIPTION
temporary workaround for the build fail by
west build -p always -b apollo510_evb tests/kernel/interrupt -T arch.shared_interrupt.lto.speed

Issue is described in https://github.com/zephyrproject-rtos/zephyr/issues/90777