### PR TITLE
drivers: pwm: nrfx: Add option to glitch free 100% duty cycle

### DIFF
--- a/drivers/pwm/Kconfig.nrfx
+++ b/drivers/pwm/Kconfig.nrfx
@@ -20,3 +20,13 @@ config PWM_NRFX
 	select PINCTRL
 	help
 	  Enable support for nrfx Hardware PWM driver for nRF52 MCU series.
+
+config PWM_NRFX_NO_GLITCH_DUTY_100
+	bool "No glitches when using 100% duty"
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_PWM),idleout-supported,True)
+	default y
+	help
+	  Due to how IDLEOUT feature in PWM works it is possible to see a glitch on a channel
+	  with 100% duty cycle when all other channels switches to 0% or 100%. Enabling this
+	  option ensures that there are no glitches but it also means that 100% duty cycle
+	  on any channels requires PWM peripheral to be active.

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -18,6 +18,11 @@ properties:
     type: boolean
     description: Set this to use center-aligned (up and down) counter mode.
 
+  idleout-supported:
+    type: boolean
+    description: |
+      Indicates if the PWM instance has the IDLEOUT register.
+
   "#pwm-cells":
     const: 3
 

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -656,6 +656,7 @@
 				clocks = <&hsfll120>;
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			spis120: spi@8e5000 {
@@ -1008,6 +1009,7 @@
 				clocks = <&fll16m>;
 				power-domains = <&gpd NRF_GPD_SLOW_ACTIVE>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			i2c130: i2c@9a5000 {
@@ -1141,6 +1143,7 @@
 				clocks = <&fll16m>;
 				power-domains = <&gpd NRF_GPD_SLOW_ACTIVE>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			i2c132: i2c@9b5000 {
@@ -1274,6 +1277,7 @@
 				clocks = <&fll16m>;
 				#pwm-cells = <3>;
 				power-domains = <&gpd NRF_GPD_SLOW_ACTIVE>;
+				idleout-supported;
 			};
 
 			i2c134: i2c@9c5000 {
@@ -1407,6 +1411,7 @@
 				clocks = <&fll16m>;
 				#pwm-cells = <3>;
 				power-domains = <&gpd NRF_GPD_SLOW_ACTIVE>;
+				idleout-supported;
 			};
 
 			i2c136: i2c@9d5000 {

--- a/dts/vendor/nordic/nrf54l20.dtsi
+++ b/dts/vendor/nordic/nrf54l20.dtsi
@@ -488,6 +488,7 @@
 				reg = <0xd2000 0x1000>;
 				interrupts = <210 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			pwm21: pwm@d3000 {
@@ -496,6 +497,7 @@
 				reg = <0xd3000 0x1000>;
 				interrupts = <211 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			pwm22: pwm@d4000 {
@@ -504,6 +506,7 @@
 				reg = <0xd4000 0x1000>;
 				interrupts = <212 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			adc: adc@d5000 {

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -477,6 +477,7 @@
 				reg = <0xd2000 0x1000>;
 				interrupts = <210 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			pwm21: pwm@d3000 {
@@ -485,6 +486,7 @@
 				reg = <0xd3000 0x1000>;
 				interrupts = <211 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			pwm22: pwm@d4000 {
@@ -493,6 +495,7 @@
 				reg = <0xd4000 0x1000>;
 				interrupts = <212 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			adc: adc@d5000 {

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -478,6 +478,7 @@
 				status = "disabled";
 				interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			spi120: spi@8e6000 {
@@ -766,6 +767,7 @@
 				status = "disabled";
 				interrupts = <420 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			i2c130: i2c@9a5000 {
@@ -880,6 +882,7 @@
 				status = "disabled";
 				interrupts = <436 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			i2c132: i2c@9b5000 {
@@ -994,6 +997,7 @@
 				status = "disabled";
 				interrupts = <452 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			i2c134: i2c@9c5000 {
@@ -1108,6 +1112,7 @@
 				status = "disabled";
 				interrupts = <468 NRF_DEFAULT_IRQ_PRIORITY>;
 				#pwm-cells = <3>;
+				idleout-supported;
 			};
 
 			i2c136: i2c@9d5000 {


### PR DESCRIPTION
IDLEOUT presence in PWM means that there are 3 sources from which PWM pin can be driven:
 - GPIO setting when PWM peripheral is disabled.
 - IDLEOUT setting when PWM is enabled.
 - PWM Sequence when it is in use.

IDLEOUT setting cannot be changed after enabling PWM so it is configured to the initial state of the pin. It means that if duty cycle is 100% and pin is normal, GPIO output is set to 1 but initial pin state was 0 (IDLEOUT setting) there will be a glitch between disabling a PWM sequence and disabling a PWM peripheral.

By default, PWM driver tries to disable PWM peripheral if all channels are 0% or 100% duty cycle to safe power. When IDLEOUT feature is present there will be a short glitch on channels with 100% duty cycle.

In order to avoid that `CONFIG_PWM_NRFX_NO_GLITCH_DUTY_100` option is added (enabled by default). When option is enabled 100% duty cycle is achieved by PWM sequence and not by driving a GPIO pin. It will consume more power in cases where all channels are 0% or 100% with at least one channel set to 100% duty cycle.