### PR TITLE
samples: counter: alarm: undef redefined TIMER for ambiq

### DIFF
--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -50,6 +50,9 @@ struct counter_alarm_cfg alarm_cfg;
 #elif defined(CONFIG_COUNTER_INFINEON_CAT1)
 #define TIMER DT_NODELABEL(counter0_0)
 #elif defined(CONFIG_COUNTER_AMBIQ)
+#ifdef TIMER
+#undef TIMER
+#endif
 #define TIMER DT_NODELABEL(counter0)
 #elif defined(CONFIG_COUNTER_SNPS_DW)
 #define TIMER DT_NODELABEL(timer0)


### PR DESCRIPTION
There's duplicated TIMER defined in ambiq hal, need to undef the old one in alarm sample.