### PR TITLE
net: tcp: Change SYN FIN to use send_data_timer

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -301,7 +301,6 @@ struct tcp { /* TCP connection */
 	int64_t last_nd_hint_time;
 #endif
 	size_t send_data_total;
-	size_t send_retries;
 	int unacked_len;
 	atomic_t ref_count;
 	enum tcp_state state;
@@ -330,7 +329,6 @@ struct tcp { /* TCP connection */
 	uint8_t dup_ack_cnt;
 #endif
 	uint8_t zwp_retries;
-	bool in_retransmission : 1;
 	bool in_connect : 1;
 	bool in_close : 1;
 #if defined(CONFIG_NET_TCP_KEEPALIVE)

--- a/subsys/net/lib/shell/conn.c
+++ b/subsys/net/lib/shell/conn.c
@@ -145,11 +145,11 @@ static void tcp_sent_list_cb(struct tcp *conn, void *user_data)
 			details->printed_details = true;
 		}
 
-		PR("%p   %ld    %u\t %u\t  %zd\t  %d\t  %d/%d/%d %s\n",
-		   conn, atomic_get(&conn->ref_count), conn->recv_win,
-		   conn->send_win, conn->send_data_total, conn->unacked_len,
-		   conn->in_retransmission, conn->in_connect, conn->in_close,
-		   sys_slist_is_empty(&conn->send_queue) ? "empty" : "data");
+		PR("%p   %ld    %u\t %u\t  %zd\t  %d\t  %d/%d/%d %s\n", conn,
+		   atomic_get(&conn->ref_count), conn->recv_win, conn->send_win,
+		   conn->send_data_total, conn->unacked_len,
+		   conn->data_mode == TCP_DATA_MODE_RESEND ? 1 : 0, conn->in_connect,
+		   conn->in_close, sys_slist_is_empty(&conn->send_queue) ? "empty" : "data");
 
 		details->count++;
 	}


### PR DESCRIPTION
The send_queue was used as SYN/FIN packet retransmission. Before the SYN/FIN being ACKed and dequeue-ed, the following packets in the send_queue cannot be sent out. That's why Zephyr had to send a FIN+ACK instead of a duplicated ACK-only in FINWAIT1, CLOSING. In fact, we can take SYN/FIN as kind of data and use the same send_data_timer for retransmission, like other OSes do. This way, the send_queue is simply used for local traffics.
Benefits (in theory):
1. The code is easier,
2. TxPkt performance is better after skipping enq/deq send_queue,
3. The struct tcp{} node is a few bytes smaller, saving memory.