### PR TITLE
modules: hal_infineon: Fix SPI support for AIROC driver

### DIFF
--- a/modules/hal_infineon/wifi-host-driver/CMakeLists.txt
+++ b/modules/hal_infineon/wifi-host-driver/CMakeLists.txt
@@ -25,6 +25,10 @@ if(CONFIG_AIROC_WLAN_MFG_FIRMWARE)
   zephyr_compile_definitions(WLAN_MFG_FIRMWARE)
 endif()
 
+if (CONFIG_AIROC_WIFI_BUS_SPI)
+  zephyr_compile_definitions(BLHS_SUPPORT)
+endif()
+
 zephyr_compile_definitions(CY_WIFI_COUNTRY=$<UPPER_CASE:${CONFIG_WHD_WIFI_COUNTRY}>)
 
 # Add WHD includes
@@ -59,7 +63,11 @@ zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/whd_wifi_p2p.c)
 # src/bus_protocols
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus.c)
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_common.c)
-zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_sdio_protocol.c)
+# zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_sdio_protocol.c)
+zephyr_library_sources_ifdef(CONFIG_AIROC_WIFI_BUS_SDIO
+  ${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_sdio_protocol.c)
+zephyr_library_sources_ifdef(CONFIG_AIROC_WIFI_BUS_SPI
+  ${hal_wifi_dir}/WHD/${whd_wifi_ver}/src/bus_protocols/whd_bus_spi_protocol.c)
 
 # resources/resource_imp
 zephyr_library_sources(${hal_wifi_dir}/WHD/${whd_wifi_ver}/resources/resource_imp/whd_resources.c)


### PR DESCRIPTION
Amends changes made in a recent update to the WHD driver to add conditional compilation of spi source file.

This support was originally added here: https://github.com/zephyrproject-rtos/zephyr/commit/37e39dee58ac4c837962546d8f60db82f23b4bb6#diff-13ce3c21bdef5739612dbf0b9d4eb3d007484a399d4e3eef0a19ee74da2414d4

Then in a recent change to update the WHD driver the ifdefs for `CONFIG_AIROC_WIFI_BUS_SPI` were removed: https://github.com/zephyrproject-rtos/zephyr/commit/c9ffcac8a7118ae2e6484bbf4cf10155b400772f#diff-13ce3c21bdef5739612dbf0b9d4eb3d007484a399d4e3eef0a19ee74da2414d4
(L60-62 of modules/hal_infineon/wifi-host-driver/CMakeLists.txt)