### PR TITLE
usb: device_next: save some flash and RAM

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -767,10 +767,12 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 		usbd_class_fs, usbd_class_node, class_name##_fs) = {		\
 		.c_data = &class_name,						\
 	};									\
+	IF_ENABLED(USBD_SUPPORTS_HIGH_SPEED, (					\
 	static STRUCT_SECTION_ITERABLE_ALTERNATE(				\
 		usbd_class_hs, usbd_class_node, class_name##_hs) = {		\
 		.c_data = &class_name,						\
-	}
+	}									\
+	))
 
 /** @brief Helper to declare request table of usbd_cctx_vendor_req
  *

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -269,10 +269,14 @@ struct usbd_status {
 /**
  * @brief Callback type definition for USB device message delivery
  *
- * The implementation uses the system workqueue, and a callback provided and
- * registered by the application. The application callback is called in the
- * context of the system workqueue. Notification messages are stored in a queue
- * and delivered to the callback in sequence.
+ * If the Kconfig option USBD_MSG_DEFERRED_MODE is enabled, then the callback
+ * is executed in the context of the system workqueue. Notification messages are
+ * stored in a queue and delivered to the callback in sequence.
+ *
+ * If the Kconfig option USBD_MSG_DEFERRED_MODE is disabled, the callback is
+ * executed in the context of the USB device stack thread. The user should make
+ * sure that the callback execution does not block or disrupt device stack
+ * handling.
  *
  * @param[in] ctx Pointer to USB device support context
  * @param[in] msg Pointer to USB device message

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -667,11 +667,15 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
  * The application defines a BOS capability descriptor node for descriptors
  * such as USB 2.0 Extension Descriptor.
  *
+ * @note It requires Kconfig options USBD_BOS_SUPPORT to be enabled.
+ *
  * @param name       Descriptor node identifier
  * @param len        Device Capability descriptor length
  * @param subset     Pointer to a Device Capability descriptor
  */
 #define USBD_DESC_BOS_DEFINE(name, len, subset)					\
+	BUILD_ASSERT(IS_ENABLED(CONFIG_USBD_BOS_SUPPORT),			\
+		     "USB device BOS support is disabled");			\
 	static struct usbd_desc_node name = {					\
 		.bos = {							\
 			.utype = USBD_DUT_BOS_NONE,				\
@@ -713,6 +717,8 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
  * @param vto_dev   Vendor callback for to-device direction request
  */
 #define USBD_DESC_BOS_VREQ_DEFINE(name, len, subset, vcode, vto_host, vto_dev)	\
+	BUILD_ASSERT(IS_ENABLED(CONFIG_USBD_BOS_SUPPORT),			\
+		     "USB device BOS support is disabled");			\
 	USBD_VREQUEST_DEFINE(vreq_nd_##name, vcode, vto_host, vto_dev);		\
 	static struct usbd_desc_node name = {					\
 		.bos = {							\

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -688,12 +688,16 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 /**
  * @brief Define a vendor request with recipient device
  *
+ * @note It requires Kconfig options USBD_VREQ_SUPPORT to be enabled.
+ *
  * @param name      Vendor request identifier
  * @param vcode     Vendor request code
  * @param vto_host  Vendor callback for to-host direction request
  * @param vto_dev   Vendor callback for to-device direction request
  */
 #define USBD_VREQUEST_DEFINE(name, vcode, vto_host, vto_dev)			\
+	BUILD_ASSERT(IS_ENABLED(CONFIG_USBD_VREQ_SUPPORT),			\
+		     "USB device vendor request support is disabled");		\
 	static struct usbd_vreq_node name = {					\
 		.code = vcode,							\
 		.to_host = vto_host,						\
@@ -708,6 +712,9 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
  *
  * USBD_DESC_BOS_VREQ_DEFINE(bos_vreq_webusb, sizeof(bos_cap_webusb), &bos_cap_webusb,
  *                           SAMPLE_WEBUSB_VENDOR_CODE, webusb_to_host_cb, NULL);
+ *
+ * @note It requires Kconfig options USBD_VREQ_SUPPORT and USBD_BOS_SUPPORT to
+ *       be enabled.
  *
  * @param name      Descriptor node identifier
  * @param len       Device Capability descriptor length

--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -497,6 +497,7 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 		.iSerialNumber = 0,					\
 		.bNumConfigurations = 0,				\
 	};								\
+	IF_ENABLED(USBD_SUPPORTS_HIGH_SPEED, (				\
 	static struct usb_device_descriptor				\
 	hs_desc_##device_name = {					\
 		.bLength = sizeof(struct usb_device_descriptor),	\
@@ -514,11 +515,14 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
 		.iSerialNumber = 0,					\
 		.bNumConfigurations = 0,				\
 	};								\
+	))								\
 	static STRUCT_SECTION_ITERABLE(usbd_context, device_name) = {	\
 		.name = STRINGIFY(device_name),				\
 		.dev = udc_dev,						\
 		.fs_desc = &fs_desc_##device_name,			\
+		IF_ENABLED(USBD_SUPPORTS_HIGH_SPEED, (			\
 		.hs_desc = &hs_desc_##device_name,			\
+		))							\
 	}
 
 /**

--- a/samples/subsys/usb/cdc_acm/sample.yaml
+++ b/samples/subsys/usb/cdc_acm/sample.yaml
@@ -30,6 +30,19 @@ tests:
       type: one_line
       regex:
         - "Wait for DTR"
+  sample.usb_device_next.cdc-acm-workqueue:
+    depends_on: usbd
+    tags: usb
+    extra_args:
+      - CONF_FILE="usbd_next_prj.conf"
+      - DCONFIG_USBD_CDC_ACM_WORKQUEUE=y
+    integration_platforms:
+      - frdm_k64f
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Wait for DTR"
   sample.usb.cdc-acm.buildonly:
     depends_on: usb_device
     tags: usb

--- a/samples/subsys/usb/common/Kconfig.sample_usbd
+++ b/samples/subsys/usb/common/Kconfig.sample_usbd
@@ -47,6 +47,7 @@ config SAMPLE_USBD_MAX_POWER
 
 config SAMPLE_USBD_20_EXTENSION_DESC
 	bool "Use default USB 2.0 Extension Descriptor"
+	depends on USBD_BOS_SUPPORT
 	help
 	  Set bcdUSB value to 0201 and use default USB 2.0 Extension Descriptor.
 

--- a/samples/subsys/usb/common/sample_usbd_init.c
+++ b/samples/subsys/usb/common/sample_usbd_init.c
@@ -60,6 +60,7 @@ USBD_CONFIGURATION_DEFINE(sample_hs_config,
 			  CONFIG_SAMPLE_USBD_MAX_POWER, &hs_cfg_desc);
 /* doc configuration instantiation end */
 
+#if CONFIG_SAMPLE_USBD_20_EXTENSION_DESC
 /*
  * This does not yet provide valuable information, but rather serves as an
  * example, and will be improved in the future.
@@ -72,6 +73,7 @@ static const struct usb_bos_capability_lpm bos_cap_lpm = {
 };
 
 USBD_DESC_BOS_DEFINE(sample_usbext, sizeof(bos_cap_lpm), &bos_cap_lpm);
+#endif
 
 static void sample_fix_code_triple(struct usbd_context *uds_ctx,
 				   const enum usbd_speed speed)
@@ -175,16 +177,16 @@ struct usbd_context *sample_usbd_setup_device(usbd_msg_cb_t msg_cb)
 		/* doc device init-and-msg end */
 	}
 
-	if (IS_ENABLED(CONFIG_SAMPLE_USBD_20_EXTENSION_DESC)) {
-		(void)usbd_device_set_bcd_usb(&sample_usbd, USBD_SPEED_FS, 0x0201);
-		(void)usbd_device_set_bcd_usb(&sample_usbd, USBD_SPEED_HS, 0x0201);
+#if CONFIG_SAMPLE_USBD_20_EXTENSION_DESC
+	(void)usbd_device_set_bcd_usb(&sample_usbd, USBD_SPEED_FS, 0x0201);
+	(void)usbd_device_set_bcd_usb(&sample_usbd, USBD_SPEED_HS, 0x0201);
 
-		err = usbd_add_descriptor(&sample_usbd, &sample_usbext);
-		if (err) {
-			LOG_ERR("Failed to add USB 2.0 Extension Descriptor");
-			return NULL;
-		}
+	err = usbd_add_descriptor(&sample_usbd, &sample_usbext);
+	if (err) {
+		LOG_ERR("Failed to add USB 2.0 Extension Descriptor");
+		return NULL;
 	}
+#endif
 
 	return &sample_usbd;
 }

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -43,6 +43,13 @@ config USBD_BOS_SUPPORT
 	  BOS support can be disabled if the application does not use a BOS
 	  descriptor.
 
+config USBD_VREQ_SUPPORT
+	bool "USB device vendor request support"
+	default y
+	help
+	  Allow the application to register a handler for the vendor request
+	  with the recipient device.
+
 config USBD_SHELL
 	bool "USB device shell"
 	depends on SHELL

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -36,6 +36,13 @@ config USBD_MAX_SPEED
 	default 0 if USBD_MAX_SPEED_FULL
 	default 1 if USBD_MAX_SPEED_HIGH
 
+config USBD_BOS_SUPPORT
+	bool "USB device BOS support"
+	default y
+	help
+	  BOS support can be disabled if the application does not use a BOS
+	  descriptor.
+
 config USBD_SHELL
 	bool "USB device shell"
 	depends on SHELL

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -81,8 +81,15 @@ config USBD_MSG_SLAB_COUNT
 	help
 	  Maximum number of USB device notification messages that can be queued.
 
+config USBD_MSG_DEFERRED_MODE
+	bool "Execute message callback from system workqueue"
+	default y
+	help
+	  Execute message callback from system workqueue. If disabled, message
+	  callback will be executed in the device stack context.
+
 config USBD_MSG_WORK_DELAY
-	int "USB device notification messages work delay"
+	int "USB device notification messages work delay" if USBD_MSG_DEFERRED_MODE
 	range 1 100
 	default 1
 	help

--- a/subsys/usb/device_next/class/Kconfig.cdc_acm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_acm
@@ -16,8 +16,15 @@ config USBD_CDC_ACM_CLASS
 
 if USBD_CDC_ACM_CLASS
 
+config USBD_CDC_ACM_WORKQUEUE
+	bool "Use dedicated workqueue in CDC ACM"
+	help
+	  Use the dedicated queue in CDC ACM implementation if the systemwork
+	  queue cannot be used due to performance issues or other conflicts.
+
 config USBD_CDC_ACM_STACK_SIZE
 	int "USB CDC ACM workqueue stack size"
+	depends on USBD_CDC_ACM_WORKQUEUE
 	default 1024
 	help
 	  USB CDC ACM workqueue stack size.

--- a/subsys/usb/device_next/class/Kconfig.cdc_acm
+++ b/subsys/usb/device_next/class/Kconfig.cdc_acm
@@ -29,6 +29,14 @@ config USBD_CDC_ACM_STACK_SIZE
 	help
 	  USB CDC ACM workqueue stack size.
 
+config USBD_CDC_ACM_BUF_POOL
+	bool "Use dedicated buffer pool"
+	default y if !USBD_MAX_SPEED_FULL
+	help
+	  Use a dedicated buffer pool whose size is based on the number of CDC
+	  ACM instances and the size of the bulk endpoints. When disabled, the
+	  implementation uses the UDC driver's pool.
+
 module = USBD_CDC_ACM
 module-str = usbd cdc_acm
 default-count = 1

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -631,6 +631,10 @@ static int sreq_get_desc_dev(struct usbd_context *const uds_ctx,
 		return 0;
 	}
 
+	if (head == NULL) {
+		return -EINVAL;
+	}
+
 	net_buf_add_mem(buf, head, MIN(len, head->bLength));
 
 	return 0;
@@ -748,6 +752,10 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 	default:
 		errno = -ENOTSUP;
 		return 0;
+	}
+
+	if (dev_dsc == NULL) {
+		return -EINVAL;
 	}
 
 	if (sys_le16_to_cpu(dev_dsc->bcdUSB) < 0x0201U) {

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -940,6 +940,11 @@ static int vendor_device_request(struct usbd_context *const uds_ctx,
 	struct usb_setup_packet *setup = usbd_get_setup_pkt(uds_ctx);
 	struct usbd_vreq_node *vreq_nd;
 
+	if (!IS_ENABLED(CONFIG_USBD_VREQ_SUPPORT)) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
 	vreq_nd = usbd_device_get_vreq(uds_ctx, setup->bRequest);
 	if (vreq_nd == NULL) {
 		errno = -ENOTSUP;

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -733,6 +733,11 @@ static int sreq_get_desc_bos(struct usbd_context *const uds_ctx,
 	struct usbd_desc_node *desc_nd;
 	size_t len;
 
+	if (!IS_ENABLED(CONFIG_USBD_BOS_SUPPORT)) {
+		errno = -ENOTSUP;
+		return 0;
+	}
+
 	switch (usbd_bus_speed(uds_ctx)) {
 	case USBD_SPEED_FS:
 		dev_dsc = uds_ctx->fs_desc;

--- a/subsys/usb/device_next/usbd_desc.c
+++ b/subsys/usb/device_next/usbd_desc.c
@@ -93,7 +93,8 @@ struct usbd_desc_node *usbd_get_descriptor(struct usbd_context *const uds_ctx,
 				}
 			}
 
-			if (desc_nd->bDescriptorType == USB_DESC_BOS) {
+			if (IS_ENABLED(CONFIG_USBD_BOS_SUPPORT) &&
+			    desc_nd->bDescriptorType == USB_DESC_BOS) {
 				return desc_nd;
 			}
 		}
@@ -142,7 +143,8 @@ int usbd_add_descriptor(struct usbd_context *const uds_ctx,
 		goto add_descriptor_error;
 	}
 
-	if (desc_nd->bDescriptorType == USB_DESC_BOS) {
+	if (IS_ENABLED(CONFIG_USBD_BOS_SUPPORT) &&
+	    desc_nd->bDescriptorType == USB_DESC_BOS) {
 		if (desc_nd->bos.utype == USBD_DUT_BOS_VREQ) {
 			ret =  usbd_device_register_vreq(uds_ctx, desc_nd->bos.vreq_nd);
 			if (ret) {

--- a/subsys/usb/device_next/usbd_desc.c
+++ b/subsys/usb/device_next/usbd_desc.c
@@ -126,8 +126,13 @@ int usbd_add_descriptor(struct usbd_context *const uds_ctx,
 	usbd_device_lock(uds_ctx);
 
 	hs_desc = uds_ctx->hs_desc;
+	if (USBD_SUPPORTS_HIGH_SPEED && hs_desc == NULL) {
+		ret = -EPERM;
+		goto add_descriptor_error;
+	}
+
 	fs_desc = uds_ctx->fs_desc;
-	if (!fs_desc || !hs_desc || usbd_is_initialized(uds_ctx)) {
+	if (!fs_desc || usbd_is_initialized(uds_ctx)) {
 		ret = -EPERM;
 		goto add_descriptor_error;
 	}
@@ -167,15 +172,24 @@ int usbd_add_descriptor(struct usbd_context *const uds_ctx,
 		case USBD_DUT_STRING_LANG:
 			break;
 		case USBD_DUT_STRING_MANUFACTURER:
-			hs_desc->iManufacturer = desc_nd->str.idx;
+			if (USBD_SUPPORTS_HIGH_SPEED) {
+				hs_desc->iManufacturer = desc_nd->str.idx;
+			}
+
 			fs_desc->iManufacturer = desc_nd->str.idx;
 			break;
 		case USBD_DUT_STRING_PRODUCT:
-			hs_desc->iProduct = desc_nd->str.idx;
+			if (USBD_SUPPORTS_HIGH_SPEED) {
+				hs_desc->iProduct = desc_nd->str.idx;
+			}
+
 			fs_desc->iProduct = desc_nd->str.idx;
 			break;
 		case USBD_DUT_STRING_SERIAL_NUMBER:
-			hs_desc->iSerialNumber = desc_nd->str.idx;
+			if (USBD_SUPPORTS_HIGH_SPEED) {
+				hs_desc->iSerialNumber = desc_nd->str.idx;
+			}
+
 			fs_desc->iSerialNumber = desc_nd->str.idx;
 			break;
 		default:

--- a/subsys/usb/device_next/usbd_desc.c
+++ b/subsys/usb/device_next/usbd_desc.c
@@ -145,7 +145,8 @@ int usbd_add_descriptor(struct usbd_context *const uds_ctx,
 
 	if (IS_ENABLED(CONFIG_USBD_BOS_SUPPORT) &&
 	    desc_nd->bDescriptorType == USB_DESC_BOS) {
-		if (desc_nd->bos.utype == USBD_DUT_BOS_VREQ) {
+		if (IS_ENABLED(CONFIG_USBD_VREQ_SUPPORT) &&
+		    desc_nd->bos.utype == USBD_DUT_BOS_VREQ) {
 			ret =  usbd_device_register_vreq(uds_ctx, desc_nd->bos.vreq_nd);
 			if (ret) {
 				goto add_descriptor_error;

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -364,6 +364,10 @@ int usbd_device_register_vreq(struct usbd_context *const uds_ctx,
 {
 	int ret = 0;
 
+	if (!IS_ENABLED(CONFIG_USBD_VREQ_SUPPORT)) {
+		return -ENOTSUP;
+	}
+
 	usbd_device_lock(uds_ctx);
 
 	if (usbd_is_initialized(uds_ctx)) {

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -89,8 +89,10 @@ int usbd_device_set_vid(struct usbd_context *const uds_ctx,
 	fs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_FS);
 	fs_desc->idVendor = sys_cpu_to_le16(vid);
 
-	hs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_HS);
-	hs_desc->idVendor = sys_cpu_to_le16(vid);
+	if (USBD_SUPPORTS_HIGH_SPEED) {
+		hs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_HS);
+		hs_desc->idVendor = sys_cpu_to_le16(vid);
+	}
 
 set_vid_exit:
 	usbd_device_unlock(uds_ctx);
@@ -113,8 +115,10 @@ int usbd_device_set_pid(struct usbd_context *const uds_ctx,
 	fs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_FS);
 	fs_desc->idProduct = sys_cpu_to_le16(pid);
 
-	hs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_HS);
-	hs_desc->idProduct = sys_cpu_to_le16(pid);
+	if (USBD_SUPPORTS_HIGH_SPEED) {
+		hs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_HS);
+		hs_desc->idProduct = sys_cpu_to_le16(pid);
+	}
 
 set_pid_exit:
 	usbd_device_unlock(uds_ctx);
@@ -137,8 +141,10 @@ int usbd_device_set_bcd_device(struct usbd_context *const uds_ctx,
 	fs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_FS);
 	fs_desc->bcdDevice = sys_cpu_to_le16(bcd);
 
-	hs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_HS);
-	hs_desc->bcdDevice = sys_cpu_to_le16(bcd);
+	if (USBD_SUPPORTS_HIGH_SPEED) {
+		hs_desc = get_device_descriptor(uds_ctx, USBD_SPEED_HS);
+		hs_desc->bcdDevice = sys_cpu_to_le16(bcd);
+	}
 
 set_bcd_device_exit:
 	usbd_device_unlock(uds_ctx);

--- a/subsys/usb/device_next/usbd_msg.c
+++ b/subsys/usb/device_next/usbd_msg.c
@@ -116,7 +116,11 @@ void usbd_msg_pub_simple(struct usbd_context *const ctx,
 	};
 
 	if (ctx->msg_cb != NULL) {
-		usbd_msg_pub(ctx, msg);
+		if (IS_ENABLED(CONFIG_USBD_MSG_DEFERRED_MODE)) {
+			usbd_msg_pub(ctx, msg);
+		} else {
+			ctx->msg_cb(ctx, &msg);
+		}
 	}
 }
 
@@ -129,6 +133,10 @@ void usbd_msg_pub_device(struct usbd_context *const ctx,
 	};
 
 	if (ctx->msg_cb != NULL) {
-		usbd_msg_pub(ctx, msg);
+		if (IS_ENABLED(CONFIG_USBD_MSG_DEFERRED_MODE)) {
+			usbd_msg_pub(ctx, msg);
+		} else {
+			ctx->msg_cb(ctx, &msg);
+		}
 	}
 }


### PR DESCRIPTION
Allow disabling of features that may not be needed. Exclude high-speed structures that the compiler cannot optimize if high-speed support is not enabled. Some of the if/endifs in CDC ACM are not worth it, as the resource savings are minimal.

The savings are about 1640B Flash and 1608B RAM (44892B/16240B vs 43252B/14632B) on frdm_k645f and 1944B Flash and 1752B RAM (54528B/15952B vs 52584B/14200B) on reel_board when built `samples/subsys/usb/cdc_acm` with options `-DCONFIG_USBD_MSG_DEFERRED_MODE=n -DCONFIG_USBD_VREQ_SUPPORT=n -DCONFIG_USBD_BOS_SUPPORT=n`.