### PR TITLE
drivers: spi: fix the update of spi_context tx & rx length

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -448,7 +448,7 @@ void spi_context_update_tx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		return;
 	}
 
-	ctx->tx_len -= len;
+	ctx->tx_len -= len * dfs;
 	if (!ctx->tx_len) {
 		/* Current buffer is done. Get the next one to be processed. */
 		++ctx->current_tx;
@@ -507,7 +507,7 @@ void spi_context_update_rx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		return;
 	}
 
-	ctx->rx_len -= len;
+	ctx->rx_len -= len * dfs;
 	if (!ctx->rx_len) {
 		/* Current buffer is done. Get the next one to be processed. */
 		++ctx->current_rx;


### PR DESCRIPTION
This PR is to fix spi_context.h .
The unit of spi_context's tx_len and rx_len is byte instead of frame.
The value of ctx->tx_len should be reduced by (len * dfs).