### PR TITLE
drivers: udc_dwc2: Inline vendor quirks if possible

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define DT_DRV_COMPAT snps_dwc2
+
 #include "udc_common.h"
 #include "udc_dwc2.h"
 
@@ -22,7 +24,6 @@
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(udc_dwc2, CONFIG_UDC_DRIVER_LOG_LEVEL);
-#include "udc_dwc2_vendor_quirks.h"
 
 enum dwc2_drv_event_type {
 	/* USB connection speed determined after bus reset */
@@ -3195,13 +3196,6 @@ static const struct udc_api udc_dwc2_api = {
 	.ep_enqueue = udc_dwc2_ep_enqueue,
 	.ep_dequeue = udc_dwc2_ep_dequeue,
 };
-
-#define DT_DRV_COMPAT snps_dwc2
-
-#define UDC_DWC2_VENDOR_QUIRK_GET(n)						\
-	COND_CODE_1(DT_NODE_VENDOR_HAS_IDX(DT_DRV_INST(n), 1),			\
-		    (&dwc2_vendor_quirks_##n),					\
-		    (NULL))
 
 #define UDC_DWC2_DT_INST_REG_ADDR(n)						\
 	COND_CODE_1(DT_NUM_REGS(DT_DRV_INST(n)), (DT_INST_REG_ADDR(n)),		\

--- a/drivers/usb/udc/udc_dwc2_vendor_quirks.h
+++ b/drivers/usb/udc/udc_dwc2_vendor_quirks.h
@@ -25,8 +25,6 @@ struct usb_dw_stm32_clk {
 	size_t pclken_len;
 };
 
-#define DT_DRV_COMPAT snps_dwc2
-
 static inline int stm32f4_fsotg_enable_clk(const struct usb_dw_stm32_clk *const clk)
 {
 	int ret;
@@ -94,7 +92,7 @@ static inline int stm32f4_fsotg_disable_phy(const struct device *dev)
 		return stm32f4_fsotg_enable_clk(&stm32f4_clk_##n);		\
 	}									\
 										\
-	struct dwc2_vendor_quirks dwc2_vendor_quirks_##n = {			\
+	const struct dwc2_vendor_quirks dwc2_vendor_quirks_##n = {		\
 		.pre_enable = stm32f4_fsotg_enable_clk_##n,			\
 		.post_enable = stm32f4_fsotg_enable_phy,			\
 		.disable = stm32f4_fsotg_disable_phy,				\
@@ -104,14 +102,11 @@ static inline int stm32f4_fsotg_disable_phy(const struct device *dev)
 
 DT_INST_FOREACH_STATUS_OKAY(QUIRK_STM32F4_FSOTG_DEFINE)
 
-#undef DT_DRV_COMPAT
-
 #endif /*DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_fsotg) */
 
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_usbhs)
 
-#define DT_DRV_COMPAT snps_dwc2
-
+#include <zephyr/logging/log.h>
 #include <nrfs_backend_ipc_service.h>
 #include <nrfs_usb.h>
 
@@ -129,6 +124,7 @@ static K_EVENT_DEFINE(usbhs_events);
 
 static void usbhs_vbus_handler(nrfs_usb_evt_t const *p_evt, void *const context)
 {
+	LOG_MODULE_DECLARE(udc_dwc2, CONFIG_UDC_DRIVER_LOG_LEVEL);
 	const struct device *dev = context;
 
 	switch (p_evt->type) {
@@ -156,6 +152,7 @@ static void usbhs_vbus_handler(nrfs_usb_evt_t const *p_evt, void *const context)
 
 static inline int usbhs_enable_nrfs_service(const struct device *dev)
 {
+	LOG_MODULE_DECLARE(udc_dwc2, CONFIG_UDC_DRIVER_LOG_LEVEL);
 	nrfs_err_t nrfs_err;
 	int err;
 
@@ -182,6 +179,7 @@ static inline int usbhs_enable_nrfs_service(const struct device *dev)
 
 static inline int usbhs_enable_core(const struct device *dev)
 {
+	LOG_MODULE_DECLARE(udc_dwc2, CONFIG_UDC_DRIVER_LOG_LEVEL);
 	NRF_USBHS_Type *wrapper = USBHS_DT_WRAPPER_REG_ADDR(0);
 	k_timeout_t timeout = K_FOREVER;
 
@@ -229,6 +227,7 @@ static inline int usbhs_disable_core(const struct device *dev)
 
 static inline int usbhs_disable_nrfs_service(const struct device *dev)
 {
+	LOG_MODULE_DECLARE(udc_dwc2, CONFIG_UDC_DRIVER_LOG_LEVEL);
 	nrfs_err_t nrfs_err;
 
 	nrfs_err = nrfs_usb_disable_request((void *)dev);
@@ -297,7 +296,7 @@ static inline int usbhs_pre_hibernation_exit(const struct device *dev)
 }
 
 #define QUIRK_NRF_USBHS_DEFINE(n)						\
-	struct dwc2_vendor_quirks dwc2_vendor_quirks_##n = {			\
+	const struct dwc2_vendor_quirks dwc2_vendor_quirks_##n = {		\
 		.init = usbhs_enable_nrfs_service,				\
 		.pre_enable = usbhs_enable_core,				\
 		.disable = usbhs_disable_core,					\
@@ -310,8 +309,6 @@ static inline int usbhs_pre_hibernation_exit(const struct device *dev)
 	};
 
 DT_INST_FOREACH_STATUS_OKAY(QUIRK_NRF_USBHS_DEFINE)
-
-#undef DT_DRV_COMPAT
 
 #endif /*DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_usbhs) */
 


### PR DESCRIPTION
Constify vendor quirks structure to not keep it in RAM. Use constified vendor quirks structure directly if there is only one snps,dwc2 instance to allow compiler inlining quirk implementation.