### PR TITLE
kernel: dynamic: Dynamic userspace stacks improvements

### DIFF
--- a/kernel/dynamic.c
+++ b/kernel/dynamic.c
@@ -31,15 +31,16 @@ static K_THREAD_STACK_ARRAY_DEFINE(dynamic_stack, CONFIG_DYNAMIC_THREAD_POOL_SIZ
 				   CONFIG_DYNAMIC_THREAD_STACK_SIZE);
 SYS_BITARRAY_DEFINE_STATIC(dynamic_ba, BA_SIZE);
 
-static k_thread_stack_t *z_thread_stack_alloc_pool(size_t size)
+static k_thread_stack_t *z_thread_stack_alloc_pool(size_t size, int flags)
 {
 	int rv;
 	size_t offset;
 	k_thread_stack_t *stack;
+	const size_t max_size = ((flags & K_USER) != 0) ? K_THREAD_STACK_SIZEOF(dynamic_stack[0]) :
+							  K_KERNEL_STACK_SIZEOF(dynamic_stack[0]);
 
-	if (size > CONFIG_DYNAMIC_THREAD_STACK_SIZE) {
-		LOG_DBG("stack size %zu is > pool stack size %d", size,
-			CONFIG_DYNAMIC_THREAD_STACK_SIZE);
+	if (size > max_size) {
+		LOG_DBG("stack size %zu is > pool stack size %zu", size, max_size);
 		return NULL;
 	}
 
@@ -79,11 +80,11 @@ k_thread_stack_t *z_impl_k_thread_stack_alloc(size_t size, int flags)
 	if (IS_ENABLED(CONFIG_DYNAMIC_THREAD_PREFER_ALLOC)) {
 		stack = z_thread_stack_alloc_dyn(size, flags);
 		if (stack == NULL && CONFIG_DYNAMIC_THREAD_POOL_SIZE > 0) {
-			stack = z_thread_stack_alloc_pool(size);
+			stack = z_thread_stack_alloc_pool(size, flags);
 		}
 	} else if (IS_ENABLED(CONFIG_DYNAMIC_THREAD_PREFER_POOL)) {
 		if (CONFIG_DYNAMIC_THREAD_POOL_SIZE > 0) {
-			stack = z_thread_stack_alloc_pool(size);
+			stack = z_thread_stack_alloc_pool(size, flags);
 		}
 
 		if ((stack == NULL) && IS_ENABLED(CONFIG_DYNAMIC_THREAD_ALLOC)) {


### PR DESCRIPTION
Optimize stack pool usage by add the `flags` parameter to the `z_thread_stack_alloc_pool` function and determine the maximum possible stack size based on the size of the reserved memory for stack and the thread type (flags).

The stack size that can be used by a thread depend on its type (kerner/user). For the same stack size, the macros `K_KERNEL_STACK_DECLARE` and `K_THREAD_STACK_DEFINE` may reserve different amount of memory. The actual memory required by the user thread stack may be larger than the user-specified size, as it can include additional reserved space.

Fix dynamic user stack allocation by use the `K_THREAD_STACK_LEN` macro to determine the size of the memory that need to by allocated for the user stack.

