### PR TITLE
Drivers: stm32: i2c rtio: Fix 'timings' array size

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_rtio.c
+++ b/drivers/i2c/i2c_ll_stm32_rtio.c
@@ -239,7 +239,8 @@ static const struct i2c_stm32_config i2c_stm32_cfg_##index = {					\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),						\
 	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2),					\
 		(.timings = (const struct i2c_config_timing *) i2c_timings_##index,		\
-		 .n_timings = ARRAY_SIZE(i2c_timings_##index),))				\
+		.n_timings =									\
+			sizeof(i2c_timings_##index) / (sizeof(struct i2c_config_timing)),))	\
 };												\
 												\
 I2C_RTIO_DEFINE(CONCAT(_i2c, index, _stm32_rtio),						\


### PR DESCRIPTION
Similar to #90402

> `timings` is an array of `struct i2c_config_timing` (3 x uint32_t). `i2c_timings_##index` is an array of uint32_t (hence the cast when it is assigned to `timings`). Therefore `ARRAY_SIZE(i2c_timings_##index)` is off by a factor of 3 when used for n_timings.