### PR TITLE
PR metadata check: few tweaks and wait for the Manifest workflow explicitly

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -35,13 +35,3 @@ jobs:
       - name: Run the check script
         run: |
           ./scripts/ci/do_not_merge.py -p "${{ github.event.pull_request.number }}"
-
-  empty_pr_description:
-    if: ${{ github.event.pull_request.body == '' }}
-    name: PR Description
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check for PR description
-        run: |
-          echo "Pull request description cannot be empty."
-          exit 1

--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Run the check script
         run: |
-          ./scripts/ci/do_not_merge.py -p "${{ github.event.pull_request.number }}"
+          python -u scripts/ci/do_not_merge.py -p "${{ github.event.pull_request.number }}"

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -34,13 +34,22 @@ def main(argv):
 
     print(f"pr: {pr.html_url}")
 
+    fail = False
+
     for label in pr.get_labels():
         print(f"label: {label.name}")
 
         if label.name in DNM_LABELS:
             print(f"Pull request is labeled as \"{label.name}\".")
-            print("This workflow fails so that the pull request cannot be merged.")
-            sys.exit(1)
+            fail = True
+
+    if not pr.body:
+        print("Pull request is description is empty.")
+        fail = True
+
+    if fail:
+        print("This workflow fails so that the pull request cannot be merged.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import datetime
 import os
 import sys
+import time
 
 import github
 
@@ -24,6 +26,30 @@ def parse_args(argv):
     return parser.parse_args(argv)
 
 
+WAIT_FOR_WORKFLOWS = set({"Manifest"})
+WAIT_FOR_DELAY_S = 60
+
+
+def workflow_delay(repo, pr):
+    print(f"PR is at {pr.head.sha}")
+
+    while True:
+        runs = repo.get_workflow_runs(head_sha=pr.head.sha)
+
+        completed = set()
+        for run in runs:
+            print(f"{run.name}: {run.status} {run.conclusion} {run.html_url}")
+            if run.status == "completed" and run.conclusion == "success":
+                completed.add(run.name)
+
+        if WAIT_FOR_WORKFLOWS.issubset(completed):
+            return
+
+        ts = datetime.datetime.now()
+        print(f"wait: {ts} completed={completed}")
+        time.sleep(WAIT_FOR_DELAY_S)
+
+
 def main(argv):
     args = parse_args(argv)
 
@@ -31,6 +57,8 @@ def main(argv):
     gh = github.Github(token)
     repo = gh.get_repo("zephyrproject-rtos/zephyr")
     pr = repo.get_pull(args.pull_request)
+
+    workflow_delay(repo, pr)
 
     print(f"pr: {pr.html_url}")
 

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -32,7 +32,11 @@ def main(argv):
     repo = gh.get_repo("zephyrproject-rtos/zephyr")
     pr = repo.get_pull(args.pull_request)
 
+    print(f"pr: {pr.html_url}")
+
     for label in pr.get_labels():
+        print(f"label: {label.name}")
+
         if label.name in DNM_LABELS:
             print(f"Pull request is labeled as \"{label.name}\".")
             print("This workflow fails so that the pull request cannot be merged.")


### PR DESCRIPTION
Couple improvements to the python script for pr metadata check, mainly add an explicit wait for the manifest run, hopefully it'll fix the current race condition for good.