### PR TITLE
MAINTAINERS: group dts into respective platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4312,7 +4312,7 @@ TI SimpleLink Platforms:
     - drivers/*/*cc25*
     - drivers/*/*cc26*
     - drivers/*/*cc32*
-    - dts/arm/ti/
+    - dts/arm/ti/cc*
     - dts/bindings/*/ti,*
     - soc/ti/simplelink/
     - dts/bindings/*/ti,*
@@ -4333,6 +4333,8 @@ TI K3 Platforms:
     - drivers/*/*davinci*
     - drivers/*/*omap*
     - drivers/*/*ti_k3*
+    - dts/arm/ti/am6*
+    - dts/arm/ti/j7*
     - dts/bindings/*/ti,k3*
     - soc/ti/k3/
   labels:


### PR DESCRIPTION
currently all the dts changes of Texas Instruments platform tags Simplelink due to the directory inclusion.

Split the dts inclusion for respective groups i.e K3, simplelink and mspm0 is already correctly grouped.

MSP432 is currently not under any tree of maintainence.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>