### PR TITLE
Revert "drivers: counter: introduce counter node in esp32 timers"

### DIFF
--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT espressif_esp32_counter
+#define DT_DRV_COMPAT espressif_esp32_timer
 
 #include <esp_clk_tree.h>
 #include <driver/timer_types_legacy.h>
@@ -360,12 +360,10 @@ static void counter_esp32_isr(void *arg)
 	timer_ll_clear_intr_status(data->hal_ctx.dev, TIMER_LL_EVENT_ALARM(data->hal_ctx.timer_id));
 }
 
-#define TIMER(idx)              DT_INST_PARENT(idx)
-
 #define ESP32_COUNTER_GET_CLK_DIV(idx)                                                             \
-	(((DT_PROP(TIMER(idx), prescaler) & UINT16_MAX) < 2)                                       \
+	(((DT_INST_PROP(idx, prescaler) & UINT16_MAX) < 2)                                         \
 		 ? 2                                                                               \
-		 : (DT_PROP(TIMER(idx), prescaler) & UINT16_MAX))
+		 : (DT_INST_PROP(idx, prescaler) & UINT16_MAX))
 
 #define ESP32_COUNTER_INIT(idx)                                                                    \
                                                                                                    \
@@ -384,13 +382,13 @@ static void counter_esp32_isr(void *arg)
 				.auto_reload = TIMER_AUTORELOAD_DIS,                               \
 				.divider = ESP32_COUNTER_GET_CLK_DIV(idx),                         \
 			},                                                                         \
-		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(TIMER(idx))),                            \
-		.clock_subsys = (clock_control_subsys_t)DT_CLOCKS_CELL(TIMER(idx), offset),        \
-		.group = DT_PROP(TIMER(idx), group),                                               \
-		.index = DT_PROP(TIMER(idx), index),                                               \
-		.irq_source = DT_IRQ_BY_IDX(TIMER(idx), 0, irq),                                   \
-		.irq_priority = DT_IRQ_BY_IDX(TIMER(idx), 0, priority),                            \
-		.irq_flags = DT_IRQ_BY_IDX(TIMER(idx), 0, flags)};                                 \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                              \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),          \
+		.group = DT_INST_PROP(idx, group),                                                 \
+		.index = DT_INST_PROP(idx, index),                                                 \
+		.irq_source = DT_INST_IRQ_BY_IDX(idx, 0, irq),                                     \
+		.irq_priority = DT_INST_IRQ_BY_IDX(idx, 0, priority),                              \
+		.irq_flags = DT_INST_IRQ_BY_IDX(idx, 0, flags)};                                   \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(idx, counter_esp32_init, NULL, &counter_data_##idx,                  \
 			      &counter_config_##idx, PRE_KERNEL_1, CONFIG_COUNTER_INIT_PRIORITY,   \

--- a/dts/bindings/counter/espressif,esp32-counter.yaml
+++ b/dts/bindings/counter/espressif,esp32-counter.yaml
@@ -1,8 +1,0 @@
-# Copyright (c) 2025 Joel Guittet
-# SPDX-License-Identifier: Apache-2.0
-
-description: ESP32 counters
-
-compatible: "espressif,esp32-counter"
-
-include: base.yaml

--- a/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
+++ b/dts/riscv/espressif/esp32c2/esp32c2_common.dtsi
@@ -181,11 +181,6 @@
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		trng0: trng@3ff700b0 {

--- a/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
+++ b/dts/riscv/espressif/esp32c3/esp32c3_common.dtsi
@@ -237,11 +237,6 @@
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer1: counter@60020000 {
@@ -253,11 +248,6 @@
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		trng0: trng@3ff700b0 {

--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -118,11 +118,6 @@
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer1: counter@60009000 {
@@ -134,11 +129,6 @@
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		rtc: rtc@600b0000 {

--- a/dts/xtensa/espressif/esp32/esp32_common.dtsi
+++ b/dts/xtensa/espressif/esp32/esp32_common.dtsi
@@ -452,11 +452,6 @@
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer1: counter@3ff5f024 {
@@ -468,11 +463,6 @@
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer2: counter@3ff60000 {
@@ -484,11 +474,6 @@
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer3: counter@3ff60024 {
@@ -500,11 +485,6 @@
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		dac: dac@3ff48800 {

--- a/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
+++ b/dts/xtensa/espressif/esp32s2/esp32s2_common.dtsi
@@ -280,11 +280,6 @@
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer1: counter@3f41f024 {
@@ -296,11 +291,6 @@
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer2: counter@3f420000 {
@@ -312,11 +302,6 @@
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer3: counter@3f420024 {
@@ -327,11 +312,6 @@
 			index = <1>;
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		trng0: trng@3f435110 {

--- a/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
+++ b/dts/xtensa/espressif/esp32s3/esp32s3_common.dtsi
@@ -415,11 +415,6 @@
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer1: counter@6001f024 {
@@ -431,11 +426,6 @@
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer2: counter@60020000 {
@@ -447,11 +437,6 @@
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		timer3: counter@60020024 {
@@ -462,11 +447,6 @@
 			index = <1>;
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-
-			counter {
-				compatible = "espressif,esp32-counter";
-				status = "disabled";
-			};
 		};
 
 		wdt0: watchdog@6001f048 {

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -103,7 +103,7 @@ static const struct device *const devices[] = {
 	DEVS_FOR_DT_COMPAT(xlnx_xps_timer_1_00_a)
 #endif
 #ifdef CONFIG_COUNTER_TMR_ESP32
-	DEVS_FOR_DT_COMPAT(espressif_esp32_counter)
+	DEVS_FOR_DT_COMPAT(espressif_esp32_timer)
 #endif
 #ifdef CONFIG_COUNTER_NXP_S32_SYS_TIMER
 	DEVS_FOR_DT_COMPAT(nxp_s32_sys_timer)


### PR DESCRIPTION
This reverts commit 9d4530fb79426d709f5d05f09b13e0a1a2c6bd9a.

Build and device tests are failing at
samples/drivers/counter/alarm
tests/drivers/counter/counter_basic_api

Better to revert this and rework to guarantee no regression.