### PR TITLE
video: sensors (ov5640/imx335) various improvements / fix

### DIFF
--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -464,7 +464,7 @@ static int imx335_init(const struct device *dev)
 		gpio_pin_set_dt(&cfg->reset_gpio, 0);
 	}
 
-	k_sleep(K_USEC(20)); /* T4 */
+	k_sleep(K_USEC(600)); /* T4 */
 
 	/* Initialize register values */
 	ret = video_write_cci_multiregs(&cfg->i2c, imx335_init_params,

--- a/drivers/video/imx335.c
+++ b/drivers/video/imx335.c
@@ -28,7 +28,9 @@ LOG_MODULE_REGISTER(video_imx335, CONFIG_VIDEO_LOG_LEVEL);
 
 struct imx335_config {
 	struct i2c_dt_spec i2c;
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	struct gpio_dt_spec reset_gpio;
+#endif
 	uint32_t input_clk;
 };
 
@@ -445,26 +447,27 @@ static int imx335_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (!gpio_is_ready_dt(&cfg->reset_gpio)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, cfg->reset_gpio.port->name);
-		return -ENODEV;
-	}
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
+	if (cfg->reset_gpio.port != NULL) {
+		if (!gpio_is_ready_dt(&cfg->reset_gpio)) {
+			LOG_ERR("%s: device %s is not ready", dev->name,
+				cfg->reset_gpio.port->name);
+			return -ENODEV;
+		}
 
-	/* Power up sequence */
-	if (cfg->reset_gpio.port) {
+		/* Power up sequence */
 		ret = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_ACTIVE);
 		if (ret) {
 			return ret;
 		}
-	}
 
-	k_sleep(K_NSEC(500)); /* Tlow */
+		k_sleep(K_NSEC(500)); /* Tlow */
 
-	if (cfg->reset_gpio.port) {
 		gpio_pin_set_dt(&cfg->reset_gpio, 0);
-	}
 
-	k_sleep(K_USEC(600)); /* T4 */
+		k_sleep(K_USEC(600)); /* T4 */
+	}
+#endif
 
 	/* Initialize register values */
 	ret = video_write_cci_multiregs(&cfg->i2c, imx335_init_params,
@@ -499,6 +502,12 @@ static int imx335_init(const struct device *dev)
 	return imx335_init_controls(dev);
 }
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
+#define IMX335_GET_RESET_GPIO(n)	.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),
+#else
+#define IMX335_GET_RESET_GPIO(n)
+#endif
+
 #define IMX335_INIT(n)										\
 	static struct imx335_data imx335_data_##n = {						\
 		.fmt = {									\
@@ -509,7 +518,7 @@ static int imx335_init(const struct device *dev)
 	};											\
 	static const struct imx335_config imx335_cfg_##n = {					\
 		.i2c = I2C_DT_SPEC_INST_GET(n),							\
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),			\
+		IMX335_GET_RESET_GPIO(n)							\
 		.input_clk = DT_INST_PROP_BY_PHANDLE(n, clocks, clock_frequency),		\
 	};											\
 												\

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -1329,12 +1329,12 @@ static int ov5640_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (!gpio_is_ready_dt(&cfg->reset_gpio)) {
+	if (cfg->reset_gpio.port != NULL && !gpio_is_ready_dt(&cfg->reset_gpio)) {
 		LOG_ERR("%s: device %s is not ready", dev->name, cfg->reset_gpio.port->name);
 		return -ENODEV;
 	}
 
-	if (!gpio_is_ready_dt(&cfg->powerdown_gpio)) {
+	if (cfg->powerdown_gpio.port != NULL && !gpio_is_ready_dt(&cfg->powerdown_gpio)) {
 		LOG_ERR("%s: device %s is not ready", dev->name, cfg->powerdown_gpio.port->name);
 		return -ENODEV;
 	}

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -117,8 +117,12 @@ enum ov5640_frame_rate {
 
 struct ov5640_config {
 	struct i2c_dt_spec i2c;
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	struct gpio_dt_spec reset_gpio;
+#endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(powerdown_gpios)
 	struct gpio_dt_spec powerdown_gpio;
+#endif
 	int bus_type;
 };
 
@@ -1329,42 +1333,54 @@ static int ov5640_init(const struct device *dev)
 		return -ENODEV;
 	}
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	if (cfg->reset_gpio.port != NULL && !gpio_is_ready_dt(&cfg->reset_gpio)) {
 		LOG_ERR("%s: device %s is not ready", dev->name, cfg->reset_gpio.port->name);
 		return -ENODEV;
 	}
+#endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(powerdown_gpios)
 	if (cfg->powerdown_gpio.port != NULL && !gpio_is_ready_dt(&cfg->powerdown_gpio)) {
 		LOG_ERR("%s: device %s is not ready", dev->name, cfg->powerdown_gpio.port->name);
 		return -ENODEV;
 	}
+#endif
 
 	/* Power up sequence */
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(powerdown_gpios)
 	if (cfg->powerdown_gpio.port != NULL) {
 		ret = gpio_pin_configure_dt(&cfg->powerdown_gpio, GPIO_OUTPUT_ACTIVE);
 		if (ret) {
 			return ret;
 		}
 	}
+#endif
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	if (cfg->reset_gpio.port != NULL) {
 		ret = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_ACTIVE);
 		if (ret) {
 			return ret;
 		}
 	}
+#endif
 
 	k_sleep(K_MSEC(5));
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(powerdown_gpios)
 	if (cfg->powerdown_gpio.port != NULL) {
 		gpio_pin_set_dt(&cfg->powerdown_gpio, 0);
 	}
+#endif
 
 	k_sleep(K_MSEC(1));
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 	if (cfg->reset_gpio.port != NULL) {
 		gpio_pin_set_dt(&cfg->reset_gpio, 0);
 	}
+#endif
 
 	k_sleep(K_MSEC(20));
 
@@ -1443,13 +1459,27 @@ static int ov5640_init(const struct device *dev)
 	return ov5640_init_controls(dev);
 }
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
+#define OV5640_GET_RESET_GPIO(n)								   \
+	.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),
+#else
+#define OV5640_GET_RESET_GPIO(n)
+#endif
+
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(powerdown_gpios)
+#define OV5640_GET_POWERDOWN_GPIO(n)								   \
+	.powerdown_gpio = GPIO_DT_SPEC_INST_GET_OR(n, powerdown_gpios, {0}),
+#else
+#define OV5640_GET_POWERDOWN_GPIO(n)
+#endif
+
 #define OV5640_INIT(n)                                                                             \
 	static struct ov5640_data ov5640_data_##n;                                                 \
                                                                                                    \
 	static const struct ov5640_config ov5640_cfg_##n = {                                       \
 		.i2c = I2C_DT_SPEC_INST_GET(n),                                                    \
-		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),                       \
-		.powerdown_gpio = GPIO_DT_SPEC_INST_GET_OR(n, powerdown_gpios, {0}),               \
+		OV5640_GET_RESET_GPIO(n)							   \
+		OV5640_GET_POWERDOWN_GPIO(n)							   \
 		.bus_type = DT_PROP_OR(DT_CHILD(DT_INST_CHILD(n, port), endpoint), bus_type,       \
 				       VIDEO_BUS_TYPE_CSI2_DPHY),                                  \
 	};                                                                                         \


### PR DESCRIPTION
On both OV5640 & IMX335 drivers, rely on DT_ANY_INST_HAS_PROP_STATUS_OKAY to reduce the footprint related to gpio reset/powerdown handling if those pins aren't being used.
Add a stability fix for the IMX335 in order to avoid getting i2c errors right after the IMX335 initialization.