### PR TITLE
soc: imxrt5xx: add fusion f1 dsp backtrace support

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -42,7 +42,7 @@ config XTENSA_USE_CORE_CRT1
 config XTENSA_ENABLE_BACKTRACE
 	bool "Backtrace on panic exception"
 	default y
-	depends on SOC_SERIES_ESP32 || SOC_FAMILY_INTEL_ADSP || SOC_XTENSA_DC233C
+	depends on SOC_SERIES_ESP32 || SOC_FAMILY_INTEL_ADSP || SOC_XTENSA_DC233C || SOC_MIMXRT595S_F1
 	help
 	  Enable this config option to print backtrace on panic exception
 

--- a/arch/xtensa/core/xtensa_backtrace.c
+++ b/arch/xtensa/core/xtensa_backtrace.c
@@ -11,7 +11,7 @@
 #include <esp_memory_utils.h>
 #elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 #include "debug_helpers.h"
-#elif defined(CONFIG_SOC_XTENSA_DC233C)
+#elif defined(CONFIG_SOC_XTENSA_DC233C) || defined(CONFIG_SOC_MIMXRT595S_F1)
 #include "backtrace_helpers.h"
 #endif
 
@@ -69,6 +69,8 @@ static inline bool xtensa_ptr_executable(const void *p)
 	return intel_adsp_ptr_executable(p);
 #elif defined(CONFIG_SOC_XTENSA_DC233C)
 	return xtensa_dc233c_ptr_executable(p);
+#elif defined(CONFIG_SOC_MIMXRT595S_F1)
+	return xtensa_mimxrt595s_f1_ptr_executable(p);
 #else
 #warning "xtensa_ptr_executable is not defined for this platform"
 #endif

--- a/soc/nxp/imxrt/imxrt5xx/f1/include/backtrace_helpers.h
+++ b/soc/nxp/imxrt/imxrt5xx/f1/include/backtrace_helpers.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef ZEPHYR_SOC_NXP_IMXRT_IMXRT5XX_F1_BACKTRACE_HELPERS_H_
+#define ZEPHYR_SOC_NXP_IMXRT_IMXRT5XX_F1_BACKTRACE_HELPERS_H_
+
+#include <zephyr/linker/linker-defs.h>
+
+#include <xtensa/config/core-isa.h>
+
+static inline bool xtensa_mimxrt595s_f1_ptr_executable(const void *p)
+{
+	return ((p >= (void *)__text_region_start) &&
+		(p <= (void *)__text_region_end));
+}
+
+#endif /* ZEPHYR_SOC_NXP_IMXRT_IMXRT5XX_F1_BACKTRACE_HELPERS_H_ */

--- a/soc/nxp/imxrt/imxrt5xx/f1/linker.ld
+++ b/soc/nxp/imxrt/imxrt5xx/f1/linker.ld
@@ -314,8 +314,10 @@ SECTIONS
     __text_region_start = ABSOLUTE(.);
     KEEP (*(.ResetVector.text))
     *(.ResetVector.literal)
-    *(.entry.text)
     *(.init.literal)
+    *(.entry.text)
+    /* to support backtrace */
+    KEEP (*(.iram1.literal .iram1))
     KEEP(*(.init))
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
     *(.fini.literal)


### PR DESCRIPTION
Add support for backtrace on faults for the Xtensa Fusion F1 DSP in the IMXRT595S.