### PR TITLE
logging: fix bug where links wouldn't be promptly activated

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -940,12 +940,21 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 	uint32_t links_active_mask = 0xFFFFFFFF;
 	uint8_t domain_offset = 0;
 	uint32_t activate_mask = z_log_init(false, false);
-	/* If some backends are not activated yet set periodical thread wake up
-	 * to poll backends for readiness. Period is set arbitrary.
-	 * If all backends are ready periodic wake up is not needed.
-	 */
-	k_timeout_t timeout = (activate_mask != 0) ? K_MSEC(50) : K_FOREVER;
+	k_timeout_t timeout;
 	bool processed_any = false;
+
+	if (IS_ENABLED(CONFIG_LOG_MULTIDOMAIN)) {
+		/* when multidomain is enabled, start in periodic polling
+		 * mode to check for link readiness
+		 */
+		timeout = K_MSEC(50);
+	} else {
+		/* If some backends are not activated yet set periodical thread wake up
+		 * to poll backends for readiness. Period is set arbitrary.
+		 * If all backends are ready periodic wake up is not needed.
+		 */
+		timeout = (activate_mask != 0) ? K_MSEC(50) : K_FOREVER;
+	}
 	thread_set(k_current_get());
 
 	/* Logging thread is periodically waken up until all backends that
@@ -955,10 +964,19 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 		if (activate_mask) {
 			activate_mask = activate_foreach_backend(activate_mask);
 			if (!activate_mask) {
-				/* Periodic wake up no longer needed since all
-				 * backends are ready.
-				 */
-				timeout = K_FOREVER;
+				if (IS_ENABLED(CONFIG_LOG_MULTIDOMAIN)) {
+					if (!links_active_mask) {
+						/* Periodic wake up no longer needed since all
+						 * backends and links are ready.
+						 */
+						timeout = K_FOREVER;
+					}
+				} else {
+					/* Periodic wake up no longer needed since all
+					 * backends are ready.
+					 */
+					timeout = K_FOREVER;
+				}
 			}
 		}
 
@@ -966,6 +984,12 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 		if (IS_ENABLED(CONFIG_LOG_MULTIDOMAIN) && links_active_mask) {
 			links_active_mask =
 				z_log_links_activate(links_active_mask, &domain_offset);
+			if (!links_active_mask && !activate_mask) {
+				/* Periodic wake up no longer needed since all
+				 * backends and links are ready.
+				 */
+				timeout = K_FOREVER;
+			}
 		}
 
 


### PR DESCRIPTION
The log process thread is what activates multidomain log links, but if all backends were already initialized, it would enter a mode where it would block until new local logs were ready to be processed, even if links were not yet completed in activation. Change the logic for computing the timeout used to block the processing thread so that it stays in periodic polling mode if there are still log links that haven't finished activating.