### PR TITLE
drivers: mbox_nxp_imx_mu: change send to return negative error

### DIFF
--- a/drivers/mbox/mbox_nxp_imx_mu.c
+++ b/drivers/mbox/mbox_nxp_imx_mu.c
@@ -61,7 +61,12 @@ static int nxp_imx_mu_send(const struct device *dev, uint32_t channel, const str
 
 	/* Signalling mode. */
 	if (msg == NULL) {
-		return MU_TriggerInterrupts(cfg->base, g_gen_int_trig_mask[channel]);
+		if (MU_TriggerInterrupts(cfg->base, g_gen_int_trig_mask[channel]) !=
+		    kStatus_Success) {
+			/* interrupt already pending, cannot trigger again */
+			return -EAGAIN;
+		}
+		return 0;
 	}
 
 	/* Data transfer mode. */


### PR DESCRIPTION
Change nxp_imx_mu_send() to return a negative errno value on error.

The fsl_mu function MU_TriggerInterrupts() returns either kStatus_Success or kStatus_Fail, which have the value 0 or 1, respectively. kStatus_Fail should not be returned to the upper levels, which expect negative values for errors, so add a check for the return value of
MU_TriggerInterrupts() and return an errno value on error.