### PR TITLE
drivers: dma_mcux_lpc: fix bug using INPUTMUX

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -553,10 +553,12 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 		DMA_EnableChannel(DEV_BASE(dev), config->linked_channel);
 
 		/* Link OTrig Muxes with passed-in channels */
+		INPUTMUX_Init(INPUTMUX);
 		INPUTMUX_AttachSignal(INPUTMUX, otrig_index,
 			dev_config->otrig_base_address + channel);
 		INPUTMUX_AttachSignal(INPUTMUX, config->linked_channel,
 				dev_config->itrig_base_address + otrig_index);
+		INPUTMUX_Deinit(INPUTMUX);
 
 		/* Otrig is now connected with linked channel */
 		dma_data->otrig_array[otrig_index].source_channel = channel;
@@ -857,7 +859,6 @@ static int dma_mcux_lpc_pm_action(const struct device *dev, enum pm_device_actio
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
 		DMA_Init(DEV_BASE(dev));
-		INPUTMUX_Init(INPUTMUX);
 		break;
 	default:
 		return -ENOTSUP;


### PR DESCRIPTION
The typical way of calling INPUTMUX_AttachSignal() is to bracket it around INPUTMUX_Init() and INPUTMUX_Deinit() calls because we can reduce power consumption by not keeping the interface powered when not changing INPUTMUX.

This driver was violating that convention, which caused it to not coexist well with other code that followed the usage convention because the INPUTMUX might be initialized or not depending on execution order with the other modules.