### PR TITLE
drivers: clock_control: mcux_syscon: Added get support for I2S_MCUX_FLEXCOMM

### DIFF
--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -154,7 +154,7 @@ static int mcux_lpc_syscon_clock_control_get_subsys_rate(const struct device *de
 	switch (clock_name) {
 
 #if defined(CONFIG_I2C_MCUX_FLEXCOMM) || defined(CONFIG_SPI_MCUX_FLEXCOMM) ||                      \
-	defined(CONFIG_UART_MCUX_FLEXCOMM)
+	defined(CONFIG_UART_MCUX_FLEXCOMM) || defined(CONFIG_I2S_MCUX_FLEXCOMM)
 	case MCUX_FLEXCOMM0_CLK:
 		*rate = CLOCK_GetFlexCommClkFreq(0);
 		break;


### PR DESCRIPTION
Previously, I2S_MCUX_FLEXCOMM was expected to use the external MCLK only but it's possible for I2S_MCUX_FLEXCOMM to be sourced from other clocks like the audio_pll_clk, in which case the driver needs to be able to get the current clock frequency in order to properly set dividers for requested sample rate.