### PR TITLE
kernel: fix handling of very large timeouts

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -1488,13 +1488,13 @@ const char *k_thread_state_str(k_tid_t thread_id, char *buf, size_t buf_size);
  * This macro generates a timeout delay that represents an expiration
  * at the absolute uptime value specified, in system ticks.  That is, the
  * timeout will expire immediately after the system uptime reaches the
- * specified tick count.
+ * specified tick count. Value is clamped to the range 0 to INT64_MAX-1.
  *
  * @param t Tick uptime value
  * @return Timeout delay value
  */
 #define K_TIMEOUT_ABS_TICKS(t) \
-	Z_TIMEOUT_TICKS(Z_TICK_ABS((k_ticks_t)MAX(t, 0)))
+	Z_TIMEOUT_TICKS(Z_TICK_ABS((k_ticks_t)CLAMP(t, 0, (INT64_MAX - 1))))
 
 /**
  * @brief Generates an absolute/uptime timeout value from seconds

--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -151,7 +151,14 @@ typedef struct {
 
 /* Test for relative timeout */
 #if CONFIG_TIMEOUT_64BIT
-#define Z_IS_TIMEOUT_RELATIVE(timeout)  (Z_TICK_ABS((timeout).ticks) < 0)
+/* Positive values are relative/delta timeouts and negative values are absolute
+ * timeouts, except -1 which is reserved for K_TIMEOUT_FOREVER. 0 is K_NO_WAIT,
+ * which is historically considered a relative timeout.
+ * K_TIMEOUT_FOREVER is not considered a relative timeout and neither is it
+ * considerd an absolute timeouts (so !Z_IS_TIMEOUT_RELATIVE() does not
+ * necessarily mean it is an absolute timeout if ticks == -1);
+ */
+#define Z_IS_TIMEOUT_RELATIVE(timeout)  (((timeout).ticks) >= 0)
 #else
 #define Z_IS_TIMEOUT_RELATIVE(timeout)  true
 #endif


### PR DESCRIPTION
When a very large timeout, like INT64_MAX passed by task_wdt_init(), is passed to z_add_timeout(), it
could become a very small negative number when
added to the timeout list. This would prevent any
new timeout from being added correctly.