### PR TITLE
dts:  Update mini_stm32h743.dts

### DIFF
--- a/boards/weact/mini_stm32h743/doc/index.rst
+++ b/boards/weact/mini_stm32h743/doc/index.rst
@@ -101,6 +101,35 @@ The STM32H743VI System Clock can be driven by an internal or external oscillator
 as well as by the main PLL clock. By default, the System clock is driven
 by the PLL clock at 240MHz. PLL clock is fed by a 25MHz high speed external clock.
 
+STM32H743VIT6 can support 480 MHz operation. To enable 480 MHz change the dts file 
+by commenting out 240 MHz &rcc node and subsequently uncommenting 480 MHz &rcc node.
+
+.. code-block:: console
+   /* Comment out 240 MHz
+   &rcc {
+   	clocks = <&pll>;
+   	clock-frequency = <DT_FREQ_M(240)>;
+   	d1cpre = <1>;
+   	hpre = <2>;
+   	d1ppre = <1>;
+   	d2ppre1 = <1>;
+   	d2ppre2 = <1>;
+   	d3ppre = <1>;
+   };
+   */
+   /* Uncomment for 480 MHZ ONLY. Comment &rcc node above (240 MHz) before uncommenting 480 MHz below */
+   
+   &rcc {
+   	clocks = <&pll>;
+   	clock-frequency = <DT_FREQ_M(480)>;
+   	d1cpre = <1>;
+   	hpre = <2>;
+   	d1ppre = <2>;
+   	d2ppre1 = <2>;
+   	d2ppre2 = <2>;
+   	d3ppre = <2>;
+   };
+
 Serial Port (USB CDC ACM)
 =========================
 

--- a/boards/weact/mini_stm32h743/doc/index.rst
+++ b/boards/weact/mini_stm32h743/doc/index.rst
@@ -104,31 +104,31 @@ by the PLL clock at 240MHz. PLL clock is fed by a 25MHz high speed external cloc
 STM32H743VIT6 can support 480 MHz operation. To enable 480 MHz change the dts file 
 by commenting out 240 MHz &rcc node and subsequently uncommenting 480 MHz &rcc node.
 
-.. code-block:: console
-   /* Comment out 240 MHz
-   &rcc {
-   	clocks = <&pll>;
-   	clock-frequency = <DT_FREQ_M(240)>;
-   	d1cpre = <1>;
-   	hpre = <2>;
-   	d1ppre = <1>;
-   	d2ppre1 = <1>;
-   	d2ppre2 = <1>;
-   	d3ppre = <1>;
-   };
-   */
-   /* Uncomment for 480 MHZ ONLY. Comment &rcc node above (240 MHz) before uncommenting 480 MHz below */
-   
-   &rcc {
-   	clocks = <&pll>;
-   	clock-frequency = <DT_FREQ_M(480)>;
-   	d1cpre = <1>;
-   	hpre = <2>;
-   	d1ppre = <2>;
-   	d2ppre1 = <2>;
-   	d2ppre2 = <2>;
-   	d3ppre = <2>;
-   };
+.. code-block::
+   :/* Comment out 240 MHz
+   :&rcc {
+   :	clocks = <&pll>;
+   :	clock-frequency = <DT_FREQ_M(240)>;
+   :	d1cpre = <1>;
+   :	hpre = <2>;
+   :	d1ppre = <1>;
+   :	d2ppre1 = <1>;
+   :	d2ppre2 = <1>;
+   :	d3ppre = <1>;
+   :};
+   :*/
+   :/* Uncomment for 480 MHZ ONLY. Comment &rcc node above (240 MHz) before uncommenting 480 MHz below */
+   :
+   :&rcc {
+   :	clocks = <&pll>;
+   :	clock-frequency = <DT_FREQ_M(480)>;
+   :	d1cpre = <1>;
+   :	hpre = <2>;
+   :	d1ppre = <2>;
+   :	d2ppre1 = <2>;
+   :	d2ppre2 = <2>;
+   :	d3ppre = <2>;
+   :};
 
 Serial Port (USB CDC ACM)
 =========================

--- a/boards/weact/mini_stm32h743/doc/index.rst
+++ b/boards/weact/mini_stm32h743/doc/index.rst
@@ -104,7 +104,8 @@ by the PLL clock at 240MHz. PLL clock is fed by a 25MHz high speed external cloc
 STM32H743VIT6 can support 480 MHz operation. To enable 480 MHz change the dts file 
 by commenting out 240 MHz &rcc node and subsequently uncommenting 480 MHz &rcc node.
 
-.. code-block::
+.. zephyr:dts-instruction::
+
    :/* Comment out 240 MHz
    :&rcc {
    :	clocks = <&pll>;

--- a/boards/weact/mini_stm32h743/doc/index.rst
+++ b/boards/weact/mini_stm32h743/doc/index.rst
@@ -104,7 +104,7 @@ by the PLL clock at 240MHz. PLL clock is fed by a 25MHz high speed external cloc
 STM32H743VIT6 can support 480 MHz operation. To enable 480 MHz change the dts file 
 by commenting out 240 MHz &rcc node and subsequently uncommenting 480 MHz &rcc node.
 
-.. dts-instruction::
+.. code-block:: console
 
    /* Comment out 240 MHz
    &rcc {

--- a/boards/weact/mini_stm32h743/doc/index.rst
+++ b/boards/weact/mini_stm32h743/doc/index.rst
@@ -104,32 +104,32 @@ by the PLL clock at 240MHz. PLL clock is fed by a 25MHz high speed external cloc
 STM32H743VIT6 can support 480 MHz operation. To enable 480 MHz change the dts file 
 by commenting out 240 MHz &rcc node and subsequently uncommenting 480 MHz &rcc node.
 
-.. zephyr:dts-instruction::
+.. dts-instruction::
 
-   :/* Comment out 240 MHz
-   :&rcc {
-   :	clocks = <&pll>;
-   :	clock-frequency = <DT_FREQ_M(240)>;
-   :	d1cpre = <1>;
-   :	hpre = <2>;
-   :	d1ppre = <1>;
-   :	d2ppre1 = <1>;
-   :	d2ppre2 = <1>;
-   :	d3ppre = <1>;
-   :};
-   :*/
-   :/* Uncomment for 480 MHZ ONLY. Comment &rcc node above (240 MHz) before uncommenting 480 MHz below */
-   :
-   :&rcc {
-   :	clocks = <&pll>;
-   :	clock-frequency = <DT_FREQ_M(480)>;
-   :	d1cpre = <1>;
-   :	hpre = <2>;
-   :	d1ppre = <2>;
-   :	d2ppre1 = <2>;
-   :	d2ppre2 = <2>;
-   :	d3ppre = <2>;
-   :};
+   /* Comment out 240 MHz
+   &rcc {
+   	clocks = <&pll>;
+   	clock-frequency = <DT_FREQ_M(240)>;
+   	d1cpre = <1>;
+   	hpre = <2>;
+   	d1ppre = <1>;
+   	d2ppre1 = <1>;
+   	d2ppre2 = <1>;
+   	d3ppre = <1>;
+   };
+   */
+   /* Uncomment for 480 MHZ ONLY. Comment &rcc node above (240 MHz) before uncommenting 480 MHz below */
+   
+   &rcc {
+   	clocks = <&pll>;
+   	clock-frequency = <DT_FREQ_M(480)>;
+   	d1cpre = <1>;
+   	hpre = <2>;
+   	d1ppre = <2>;
+   	d2ppre1 = <2>;
+   	d2ppre2 = <2>;
+   	d3ppre = <2>;
+   };
 
 Serial Port (USB CDC ACM)
 =========================

--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -140,6 +140,19 @@
 	d3ppre = <1>;
 };
 
+/* Uncomment for 480 MHZ ONLY. Comment &rcc node above (240 MHz) before uncommenting 480 MHz below
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(480)>;
+	d1cpre = <1>;
+	hpre = <2>;
+	d1ppre = <2>;
+	d2ppre1 = <2>;
+	d2ppre2 = <2>;
+	d3ppre = <2>;
+};
+*/
+
 &sdmmc1 {
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
 		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
@@ -243,6 +256,11 @@ zephyr_udc0: &usbotg_fs {
 
 zephyr_camera_i2c: &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	pinctrl-names = "default";
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
 };
 


### PR DESCRIPTION
Enable I2C2
Update dts to allow 480 MHz CPU
Update doc for instructions on how to enable 480 MHz