### PR TITLE
drivers: i3c: fix adv_info_get ret code

### DIFF
--- a/drivers/i3c/i3c_common.c
+++ b/drivers/i3c/i3c_common.c
@@ -772,7 +772,7 @@ int i3c_device_adv_info_get(struct i3c_device_desc *target)
 	struct i3c_ccc_mwl mwl = {0};
 	union i3c_ccc_getcaps caps = {0};
 	union i3c_ccc_getmxds mxds = {0};
-	int ret = -EIO;
+	int ret = 0;
 
 	/* GETMRL */
 	if (i3c_ccc_do_getmrl(target, &mrl) != 0) {


### PR DESCRIPTION
It's possible if a device is an i3c v1.0 spec, no hdr, no mxds, no controller caps, and does not have a mrl nor mwl. It should return 0 if it doesn't need to do anything.