### PR TITLE
doc: coding guidelines: clarify severity

### DIFF
--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -9,7 +9,12 @@ Main rules
 
 The coding guideline rules are based on MISRA-C 2012 and are a **subset** of MISRA-C.
 The subset is listed in the table below with a summary of the rules, its
-severity and the equivalent rules from other standards for reference.
+MISRA-C severity and the equivalent rules from other standards for reference.
+
+The severity and other references in the table below are for informational
+purposes only. The listed rules are all required for Zephyr and all new code
+should comply with the rules listed below.
+
 
 .. note::
 


### PR DESCRIPTION
Make a note about the severity column which is informational and
directly taken from MISRA. All rules in the table are required for
Zephyr.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
