### PR TITLE
drivers: flash: jesd216: improve mode support checks

### DIFF
--- a/drivers/flash/jesd216.c
+++ b/drivers/flash/jesd216.c
@@ -106,12 +106,28 @@ int jesd216_bfp_read_support(const struct jesd216_param_header *php,
 			rv = extract_instr(dw7 >> 16, res);
 		}
 		break;
-	/* Not clear how to detect these; they are identified only by
-	 * enable/disable sequences.
+	/* The only information for these in basic flash parameters is in DWORD20. This contains
+	 * maximum operation speed of these modes with and without data strobe. Unsupported
+	 * configurations have the value 0xF. So, to see if it is unsupported, we can see if both
+	 * the speed fields are set to 0xF.
 	 */
 	case JESD216_MODE_44D4D:
+		if ((php->len_dw >= 20) &&
+		    (((sys_le32_to_cpu(bfp->dw10[10]) >> 8) & 0xFF) != 0xFF)) {
+			rv = 0;
+		}
+		break;
 	case JESD216_MODE_888:
+		if ((php->len_dw >= 20) &&
+		    (((sys_le32_to_cpu(bfp->dw10[10]) >> 16) & 0xFF) != 0xFF)) {
+			rv = 0;
+		}
+		break;
 	case JESD216_MODE_8D8D8D:
+		if ((php->len_dw >= 20) &&
+		    (((sys_le32_to_cpu(bfp->dw10[10]) >> 24) & 0xFF) != 0xFF)) {
+			rv = 0;
+		}
 		break;
 	default:
 		rv = -EINVAL;


### PR DESCRIPTION
The only information for 4s-4d-4d, 8s-8s-8s and 8d-8d-8d in the basic flash parameter table is in DWORD20 with one byte for each of the aforementioned modes. This one byte is split into two fields that contain that mode's maximum operation speed with and without data strobe. Unsupported fields have the value of 0xF. For the mode to be supported, at least one of the two fields must not be 0xF, so we check the byte against 0xFF.