### PR TITLE
openthread: Fix OpenThread independence from Zephyr network.

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -277,6 +277,7 @@ endif()
 zephyr_library_named(openthread_utils)
 zephyr_library_sources(
   openthread.c
+  openthread_utils.c
 )
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
 zephyr_include_directories(include)

--- a/modules/openthread/include/openthread_utils.h
+++ b/modules/openthread/include/openthread_utils.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_MODULES_OPENTHREAD_OPENTHREAD_UTILS_H_
+#define ZEPHYR_MODULES_OPENTHREAD_OPENTHREAD_UTILS_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Convert a string representation of bytes into a buffer.
+ *
+ * This function parses a string containing hexadecimal byte values and fills
+ * the provided buffer with the corresponding bytes. The string may contain
+ * optional delimiters (such as spaces or colons) between byte values.
+ *
+ * @param buf      Pointer to the buffer where the parsed bytes will be stored.
+ * @param buf_len  Length of the buffer in bytes.
+ * @param src      Null-terminated string containing the hexadecimal byte values.
+ *
+ * @return 0 on success, or a negative value on error.
+ */
+int bytes_from_str(uint8_t *buf, int buf_len, const char *src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_MODULES_OPENTHREAD_OPENTHREAD_UTILS_H_ */

--- a/modules/openthread/openthread_utils.c
+++ b/modules/openthread/openthread_utils.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *   This file provides utility functions for the OpenThread module.
+ *
+ */
+
+#include <stddef.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <openthread_utils.h>
+
+int bytes_from_str(uint8_t *buf, int buf_len, const char *src)
+{
+	if (!buf || !src) {
+		return -EINVAL;
+	}
+
+	size_t i;
+	size_t src_len = strlen(src);
+	char *endptr;
+
+	for (i = 0U; i < src_len; i++) {
+		if (!isxdigit((unsigned char)src[i]) && src[i] != ':') {
+			return -EINVAL;
+		}
+	}
+
+	(void)memset(buf, 0, buf_len);
+
+	for (i = 0U; i < (size_t)buf_len; i++) {
+		buf[i] = (uint8_t)strtol(src, &endptr, 16);
+		src = ++endptr;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
If CONFIG_OPENTHREAD_SYS_INIT is enabled, OpenThread initialisation should also consider running OpenThread automatically if CONFIG_OPENTHREAD_MANUAL_START is disabled.

Removed also dependency on the `net_bytes_from_str` functions from the openthread.h file. Now, in the OpenThread module, there is an additional `openthread_utils.c/.h` file that can implement useful utilities for the OpenThread platform. Currently, it implements the `bytes_from_str` function to use it instead of `net_bytes_from_str`.