### PR TITLE
fix regression due to #90305

### DIFF
--- a/arch/arm/core/mpu/arm_mpu_regions.c
+++ b/arch/arm/core/mpu/arm_mpu_regions.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017 Linaro Limited.
- * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,18 +10,8 @@
 #include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
 
 static const struct arm_mpu_region mpu_regions[] = {
-
-#if defined(CONFIG_CPU_CORTEX_M7) && defined(CONFIG_CPU_HAS_ARM_MPU) && \
-	defined(CONFIG_CPU_HAS_DCACHE)
-	/* Erratum 1013783-B (SDEN-1068427): use first region to prevent speculative access
-	 * in entire memory space
-	 */
-	MPU_REGION_ENTRY("BACKGROUND",
-			 0,
-			 {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk}),
-#endif
-
 #ifdef CONFIG_XIP
+	/* Region 0 */
 	MPU_REGION_ENTRY("FLASH_0",
 			 CONFIG_FLASH_BASE_ADDRESS,
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)
@@ -33,6 +22,7 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 #endif
 
+	/* Region 1 */
 	MPU_REGION_ENTRY("SRAM_0",
 			 CONFIG_SRAM_BASE_ADDRESS,
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)

--- a/dts/arm/nxp/nxp_s32k344_m7.dtsi
+++ b/dts/arm/nxp/nxp_s32k344_m7.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 NXP
+ * Copyright 2023-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,7 @@
 #include <mem.h>
 #include <zephyr/dt-bindings/clock/nxp_s32k344_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {
 	cpus {
@@ -45,12 +46,14 @@
 			compatible = "zephyr,memory-region", "arm,itcm";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 			zephyr,memory-region = "ITCM";
+			zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_FLASH) )>;
 		};
 
 		dtcm: memory@20000000 {
 			compatible = "zephyr,memory-region", "arm,dtcm";
 			reg = <0x20000000 DT_SIZE_K(128)>;
 			zephyr,memory-region = "DTCM";
+			zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
 		};
 
 		sram0_1: sram0_1@20400000 {

--- a/soc/nxp/s32/s32k3/mpu_regions.c
+++ b/soc/nxp/s32/s32k3/mpu_regions.c
@@ -12,11 +12,16 @@
 extern char _rom_attr[];
 #endif
 
+#define REGION_PERIPHERAL_BASE_ADDRESS 0x40000000
+#define REGION_PERIPHERAL_SIZE         REGION_512M
+#define REGION_PPB_BASE_ADDRESS        0xE0000000
+#define REGION_PPB_SIZE                REGION_1M
+
 static struct arm_mpu_region mpu_regions[] = {
 
 	/* ERR011573: use first region to prevent speculative access in entire memory space */
 	{
-		.name = "BACKGROUND",
+		.name = "UNMAPPED",
 		.base = 0,
 		.attr = {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk},
 	},
@@ -42,6 +47,18 @@ static struct arm_mpu_region mpu_regions[] = {
 		.attr = {(uint32_t)_rom_attr},
 	},
 #endif
+
+	{
+		.name = "PERIPHERALS",
+		.base = REGION_PERIPHERAL_BASE_ADDRESS,
+		.attr = REGION_IO_ATTR(REGION_PERIPHERAL_SIZE),
+	},
+
+	{
+		.name = "PPB",
+		.base = REGION_PPB_BASE_ADDRESS,
+		.attr = REGION_PPB_ATTR(REGION_PPB_SIZE),
+	},
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
Address a regression introduced in #90305. While the intention was to avoid speculative access in the entire memory region, it overlooked the fact that many devices may rely on the architectural background region. Hence for now revert the change in `arm_mpu_regions.c` and address it only in the device where it was reported.
