### PR TITLE
boards: nordic: add runner config qualifiers for 54h20 'iron' variants

### DIFF
--- a/boards/nordic/nrf54h20dk/board.yml
+++ b/boards/nordic/nrf54h20dk/board.yml
@@ -18,3 +18,52 @@ board:
     default: "0.9.0"
     revisions:
     - name: "0.9.0"
+runners:
+  run_once:
+    '--recover':
+      - runners:
+          - nrfjprog
+          - nrfutil
+        run: first
+        groups:
+          - boards:
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuapp"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuapp/iron"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpurad"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpurad/iron"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuppr"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuppr/xip"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuflpr"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuflpr/xip"
+    '--erase':
+      - runners:
+          - nrfjprog
+          - jlink
+          - nrfutil
+        run: first
+        groups:
+          - boards:
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuapp"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuapp/iron"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpurad"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpurad/iron"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuppr"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuppr/xip"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuflpr"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuflpr/xip"
+    '--reset':
+      - runners:
+          - nrfjprog
+          - jlink
+          - nrfutil
+        run: last
+        groups:
+          - boards:
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuapp"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuapp/iron"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpurad"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpurad/iron"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuppr"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuppr/xip"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuflpr"
+              - "nrf54h20dk@0.9.0/nrf54h20/cpuflpr/xip"


### PR DESCRIPTION
Make it so the 54h20 'iron' variants have the same flashing behavior as the other 54h20 targets.