### PR TITLE
test: drivers: clock_control_api: Fix conf file application

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -38,4 +38,4 @@ tests:
       - ophelia4ev/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822
-    extra_args: CONF_FILE="nrf_lfclk_rc.conf"
+    extra_args: EXTRA_CONF_FILE="nrf_lfclk_rc.conf"


### PR DESCRIPTION
CONF_FILE parameter in testcase.yaml overwrites board specific configurations. Change it to EXTRA_CONF_FILE to apply both configurations.