### PR TITLE
boards: stm32n6570_dk: add  missing irq-gpios property for  gt911 node on i2c bus 

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -68,6 +68,7 @@
 		compatible = "goodix,gt911";
 		reg = <0x5d>;
 		reset-gpios = <&gpioe 4 GPIO_ACTIVE_LOW>;
+		irq-gpios = <&gpioq 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 	};
 };
 


### PR DESCRIPTION
The changes introduced by this commit https://github.com/zephyrproject-rtos/zephyr/pull/90279/commits/a91209eddbd0720029ce9470db0472163acebf14
add the `gt911` slave node to the I2C node without including the `irq-gpios` required by the `drivers/input/input_gt911.c` driver during initialization for `int_gpio` gt911_config struct member.


For example, run `west build -p -b stm32n6570_dk/stm32n657xx/sb samples/modules/lvgl/demos -T sample.modules.lvgl.demo_stress` to reproduce. 