### PR TITLE
llext:  add dynamic heap allocation support

### DIFF
--- a/doc/services/llext/config.rst
+++ b/doc/services/llext/config.rst
@@ -8,12 +8,28 @@ The following Kconfig options are available for the LLEXT subsystem:
 Heap size
 ----------
 
-The LLEXT subsystem needs a static heap to be allocated for extension related
-data. The following option controls this allocation.
+The LLEXT subsystem needs a heap to be allocated for extension related data.
+The following option controls this allocation, when allocating a static heap.
 
 :kconfig:option:`CONFIG_LLEXT_HEAP_SIZE`
 
         Size of the LLEXT heap in kilobytes.
+
+Alternatively the application can configure a dynamic heap using the following
+option.
+
+:kconfig:option:`CONFIG_LLEXT_HEAP_DYNAMIC`
+
+        Some applications require loading extensions into the memory which does
+        not exist during the boot time and cannot be allocated statically. Make
+        the application responsible for LLEXT heap allocation. Do not allocate
+        LLEXT heap statically.
+
+        Application must call :c:func:`llext_heap_init` in order to assign a
+        buffer to be used as the LLEXT heap, otherwise LLEXT modules will not
+        load. When the application does not need LLEXT functionality any more,
+        it should call :c:func:`llext_heap_uninit` which releases control of
+        the buffer back to the application.
 
 .. note::
 

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -428,6 +428,27 @@ void arch_elf_relocate_global(struct llext_loader *loader, struct llext *ext, co
 			      const elf_sym_t *sym, uint8_t *rel_addr, const void *link_addr);
 
 /**
+ * @brief Initialize LLEXT heap dynamically
+ *
+ * Use the provided memory block as the LLEXT heap at runtime.
+ *
+ * @param mem Pointer to memory.
+ * @param bytes Size of memory region, in bytes
+ *
+ * @returns 0 on success, or a negative error code.
+ * @retval -ENOSYS Option @kconfig{CONFIG_LLEXT_HEAP_DYNAMIC} is not enabled or supported
+ */
+int llext_heap_init(void *mem, size_t bytes);
+
+/**
+ * @brief Mark LLEXT heap as uninitialized.
+ *
+ * @returns 0 on success, or a negative error code.
+ * @retval -ENOSYS Option @kconfig{CONFIG_LLEXT_HEAP_DYNAMIC} is not enabled or supported
+ * @retval -EBUSY On heap not empty
+ */
+int llext_heap_uninit(void);
+/**
  * @}
  */
 

--- a/subsys/llext/Kconfig
+++ b/subsys/llext/Kconfig
@@ -44,8 +44,21 @@ config LLEXT_TYPE_ELF_SHAREDLIB
 
 endchoice
 
+config LLEXT_HEAP_DYNAMIC
+	bool "Do not allocate static LLEXT heap"
+	help
+	  Some applications require loading extensions into the memory which does not
+	  exist during the boot time and cannot be allocated statically. Make the application
+	  responsible for LLEXT heap allocation. Do not allocate LLEXT heap statically.
+
+	  Application must call llext_heap_init() in order to assign a buffer to be used
+	  as the LLEXT heap, otherwise LLEXT modules will not load. When the application
+	  does not need LLEXT functionality any more, it should call llext_heap_uninit(),
+	  which releases control of the buffer back to the application.
+
 config LLEXT_HEAP_SIZE
 	int "llext heap memory size in kilobytes"
+	depends on !LLEXT_HEAP_DYNAMIC
 	default 8
 	help
 	  Heap size in kilobytes available to llext for dynamic allocation

--- a/subsys/llext/llext_priv.h
+++ b/subsys/llext/llext_priv.h
@@ -22,10 +22,24 @@ int llext_copy_regions(struct llext_loader *ldr, struct llext *ext,
 void llext_free_regions(struct llext *ext);
 void llext_adjust_mmu_permissions(struct llext *ext);
 
+static inline bool llext_heap_is_inited(void)
+{
+#ifdef CONFIG_LLEXT_HEAP_DYNAMIC
+	extern bool llext_heap_inited;
+
+	return llext_heap_inited;
+#else
+	return true;
+#endif
+}
+
 static inline void *llext_alloc(size_t bytes)
 {
 	extern struct k_heap llext_heap;
 
+	if (!llext_heap_is_inited()) {
+		return NULL;
+	}
 	return k_heap_alloc(&llext_heap, bytes, K_NO_WAIT);
 }
 
@@ -33,6 +47,9 @@ static inline void *llext_aligned_alloc(size_t align, size_t bytes)
 {
 	extern struct k_heap llext_heap;
 
+	if (!llext_heap_is_inited()) {
+		return NULL;
+	}
 	return k_heap_aligned_alloc(&llext_heap, align, bytes, K_NO_WAIT);
 }
 
@@ -40,6 +57,9 @@ static inline void llext_free(void *ptr)
 {
 	extern struct k_heap llext_heap;
 
+	if (!llext_heap_is_inited()) {
+		return;
+	}
 	k_heap_free(&llext_heap, ptr);
 }
 

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -658,4 +658,29 @@ ZTEST(llext, test_ext_syscall_fail)
 	zassert_is_null(esf_fn, "est_fn should be NULL");
 }
 
-ZTEST_SUITE(llext, NULL, NULL, NULL, NULL, NULL);
+#ifdef CONFIG_LLEXT_HEAP_DYNAMIC
+#define TEST_LLEXT_HEAP_DYNAMIC_SIZE KB(64)
+static uint8_t llext_heap_data[TEST_LLEXT_HEAP_DYNAMIC_SIZE];
+#endif
+
+static void *ztest_suite_setup(void)
+{
+#ifdef CONFIG_LLEXT_HEAP_DYNAMIC
+	/* Test runtime allocation of the LLEXT loader heap */
+	zassert_ok(llext_heap_init(llext_heap_data, sizeof(llext_heap_data)));
+	LOG_INF("Allocated LLEXT dynamic heap of size %uKB\n",
+			(unsigned int)(sizeof(llext_heap_data)/KB(1)));
+#endif
+	return NULL;
+}
+
+static void ztest_suite_teardown(void *data)
+{
+	ARG_UNUSED(data);
+
+#ifdef CONFIG_LLEXT_HEAP_DYNAMIC
+	zassert_ok(llext_heap_uninit());
+#endif
+}
+
+ZTEST_SUITE(llext, NULL, ztest_suite_setup, NULL, NULL, ztest_suite_teardown);

--- a/tests/subsys/llext/testcase.yaml
+++ b/tests/subsys/llext/testcase.yaml
@@ -151,3 +151,11 @@ tests:
       - CONFIG_LLEXT_STORAGE_WRITABLE=n
       - CONFIG_LLEXT_EXPORT_DEV_IDS_BY_HASH=y
       - CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID=y
+
+  # Test dynamic heap allocation
+  llext.dynamic_heap:
+    arch_allow: arm
+    filter: not CONFIG_MPU and not CONFIG_MMU
+    extra_conf_files: ['no_mem_protection.conf']
+    extra_configs:
+      - CONFIG_LLEXT_HEAP_DYNAMIC=y


### PR DESCRIPTION
Some applications require loading extensions into the memory which does not exist during the boot time and cannot be allocated statically. Make the application responsible for LLEXT heap allocation. Do not allocate LLEXT heap statically.

This is created from and is a continuation of PR https://github.com/zephyrproject-rtos/zephyr/pull/90763.

TODO(@alexivanov-google): Comments to be addressed https://github.com/zephyrproject-rtos/zephyr/pull/90763#issuecomment-2921960740