### PR TITLE
[BACKPORT] modules: lvgl: Register print callback after lv_init

### DIFF
--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -209,11 +209,11 @@ static int lvgl_init(void)
 	lvgl_heap_init();
 #endif
 
+	lv_init();
+
 #if CONFIG_LV_Z_LOG_LEVEL != 0
 	lv_log_register_print_cb(lvgl_log);
 #endif
-
-	lv_init();
 
 #ifdef CONFIG_LV_Z_USE_FILESYSTEM
 	lvgl_fs_init();


### PR DESCRIPTION
Move initialization of the print callback handler after calling lv_init, as the latter zeroes the global callback structure.


(cherry picked from commit 5cffb8e5a6d6447174b62cc3a724b47161a2678f)

Fixes #90874