### PR TITLE
boards: renesas: ek_ra6m4: added arduino labels

### DIFF
--- a/boards/renesas/ek_ra6m4/ek_ra6m4.dts
+++ b/boards/renesas/ek_ra6m4/ek_ra6m4.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 #include "ek_ra6m4-pinctrl.dtsi"
 
@@ -62,6 +63,35 @@
 				<11 0 &ioport5 11 0>;	/* SDA  */
 							/* +5V */
 							/* GND */
+	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &ioport0 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &ioport0 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &ioport0 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &ioport0 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &ioport0 14 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &ioport0 15 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &ioport6 14 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &ioport6 13 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &ioport0 9 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &ioport1 11 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &ioport7 13 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &ioport7 12 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &ioport4 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &ioport3 4 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &ioport6 11 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &ioport3 3 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &ioport2 5 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &ioport2 3 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &ioport2 2 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &ioport2 4 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &ioport5 11 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &ioport5 12 0>;
 	};
 
 	buttons {
@@ -135,6 +165,10 @@
 	status = "okay";
 };
 
+&ioport3 {
+	status = "okay";
+};
+
 &ioport4 {
 	status = "okay";
 };
@@ -144,6 +178,10 @@
 };
 
 &ioport6 {
+	status = "okay";
+};
+
+&ioport7 {
 	status = "okay";
 };
 
@@ -244,6 +282,10 @@
 mikrobus_serial: &uart7 {};
 mikrobus_i2c: &iic1 {};
 mikrobus_spi: &spi0 {};
+
+arduino_serial: &uart7 {};
+arduino_i2c: &iic1 {};
+arduino_spi: &spi0 {};
 
 &wdt {
 	status = "okay";


### PR DESCRIPTION
Added arduino_header, arduino_serial, arduino_i2c and arduino_spi node labels to device tree board definition, allowing compatible shield boards to be used.