### PR TITLE
sw_isr_table: Add braces around subobject

### DIFF
--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -211,11 +211,10 @@ extern struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 #define Z_ISR_DECLARE_C(irq, flags, func, param, counter) \
 	_Z_ISR_DECLARE_C(irq, flags, func, param, counter)
 
-#define _Z_ISR_DECLARE_C(irq, flags, func, param, counter)                                \
-	_Z_ISR_TABLE_ENTRY(irq, func, param, _MK_ISR_ELEMENT_SECTION(counter));           \
-	static Z_DECL_ALIGN(struct _isr_list_sname) Z_GENERIC_SECTION(.intList)           \
-		__used _MK_ISR_NAME(func, counter) =                                      \
-		{irq, flags, _MK_ISR_ELEMENT_SECTION(counter)}
+#define _Z_ISR_DECLARE_C(irq, flags, func, param, counter)                                         \
+	_Z_ISR_TABLE_ENTRY(irq, func, param, _MK_ISR_ELEMENT_SECTION(counter));                    \
+	static Z_DECL_ALIGN(struct _isr_list_sname) Z_GENERIC_SECTION(.intList) __used             \
+	_MK_ISR_NAME(func, counter) = {irq, flags, {_MK_ISR_ELEMENT_SECTION(counter)}}
 
 /* Create an entry for _isr_table to be then placed by the linker.
  * An instance of struct _isr_list which gets put in the .intList


### PR DESCRIPTION
When building with clang, it warns:

```
subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c:1000:2:
error: suggest braces around initialization of subobject
[-Werror,-Wmissing-braces]

IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), shi_npcx_isr,
            DEVICE_DT_INST_GET(0), 0);
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/zephyr/irq.h:49:2: note: expanded from macro 'IRQ_CONNECT'
ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/zephyr/arch/arm/irq.h:124:2: note: expanded from macro
'ARCH_IRQ_CONNECT'
Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/zephyr/sw_isr_table.h:227:2: note: expanded from macro
'Z_ISR_DECLARE'
Z_ISR_DECLARE_C(irq, flags, func, param, __COUNTER__)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0
to see all)
include/zephyr/sw_isr_table.h:218:16: note: expanded from macro
'_Z_ISR_DECLARE_C'
{irq, flags, _MK_ISR_ELEMENT_SECTION(counter)}
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/zephyr/sw_isr_table.h:197:42: note: expanded from macro
'_MK_ISR_ELEMENT_SECTION'
#define _MK_ISR_ELEMENT_SECTION(counter) _MK_ISR_SECTION_NAME(irq,
                                         __FILE__, counter)
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
include/zephyr/sw_isr_table.h:195:2: note: expanded from macro
'_MK_ISR_SECTION_NAME'
"." Z_STRINGIFY(prefix) "." file "." Z_STRINGIFY(counter)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```