### PR TITLE
net: ip: 6lo: Fix undefined behavior reported by UBSAN

### DIFF
--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -128,8 +128,8 @@ static inline bool net_6lo_ll_prefix_padded_with_zeros(struct in6_addr *addr)
 
 static inline bool net_6lo_addr_16_bit_compressible(struct in6_addr *addr)
 {
-	return ((UNALIGNED_GET(&addr->s6_addr32[2]) == htonl(0xFF)) &&
-		 (UNALIGNED_GET(&addr->s6_addr16[6]) == htons(0xFE00)));
+	return ((UNALIGNED_GET(&addr->s6_addr32[2]) == htonl(0xFFu)) &&
+		 (UNALIGNED_GET(&addr->s6_addr16[6]) == htons(0xFE00u)));
 }
 
 static inline bool net_6lo_maddr_8_bit_compressible(struct in6_addr *addr)


### PR DESCRIPTION
htonl() and htons() take uint32_t/uint16_t as argument. Add the 'u' suffix to constants in `net_6lo_addr_16_bit_compressible` to ensure the correct unsigned type is used and to avoid undefined behavior if these functions are implemented as macros using bit shifts.

This fixes the following errors reported by UBSAN
```
zephyr/subsys/net/ip/6lo.c:131:49: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
zephyr/subsys/net/ip/6lo.c:131:49: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
zephyr/subsys/net/ip/6lo.c:131:49: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
zephyr/subsys/net/ip/6lo.c:131:49: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
```

This is a step towards fixing #90882.