### PR TITLE
dts: fix typo in vendor-prefixes for Digilent Inc.

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -177,7 +177,7 @@ dfrobot	DFRobot
 dh	DH electronics GmbH
 difrnce	Shenzhen Yagu Electronic Technology Co., Ltd.
 digi	Digi International Inc.
-digilent	Diglent, Inc.
+digilent	Digilent, Inc.
 diodes	Diodes Incorporated
 dioo	Dioo Microcircuit Co., Ltd
 dlc	DLC Display Co., Ltd.


### PR DESCRIPTION
The vendor-prefixes.txt file contained a typo where "Digilent Inc." was incorrectly spelled as "Diglent Inc."

Reference:
- https://www.digilent.com/
