### PR TITLE
video: stm32: dcmi: fix video interface properties read

### DIFF
--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -472,18 +472,18 @@ static struct video_stm32_dcmi_data video_stm32_dcmi_data_0 = {
 		.Instance = (DCMI_TypeDef *) DT_INST_REG_ADDR(0),
 		.Init = {
 				.SynchroMode = DCMI_SYNCHRO_HARDWARE,
-				.PCKPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+				.PCKPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(0, 0, 0),
 							  pclk_sample, 0) ?
 							  DCMI_PCKPOLARITY_RISING :
 							  DCMI_PCKPOLARITY_FALLING,
-				.HSPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+				.HSPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(0, 0, 0),
 							 hsync_active, 0) ?
 							 DCMI_HSPOLARITY_HIGH : DCMI_HSPOLARITY_LOW,
-				.VSPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+				.VSPolarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(0, 0, 0),
 							 vsync_active, 0) ?
 							 DCMI_VSPOLARITY_HIGH : DCMI_VSPOLARITY_LOW,
 				.ExtendedDataMode = STM32_DCMI_GET_BUS_WIDTH(
-							DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),
+							DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(0, 0, 0),
 								   bus_width, 8)),
 				.JPEGMode = DCMI_JPEG_DISABLE,
 				.ByteSelectMode = DCMI_BSM_ALL,


### PR DESCRIPTION
This commit fixes an error introduced by commit
c0dae0c9acf ("video: stm32: dcmi: perform config based on endpoint properties") in which incorrect instance was being access leading to usage of the default value for pixel clock / hsync / vsync polarities and bus width.