### PR TITLE
tests: modem_ubx: Fix clang failure by removing static keyword

### DIFF
--- a/tests/subsys/modem/modem_ubx/src/main.c
+++ b/tests/subsys/modem/modem_ubx/src/main.c
@@ -91,7 +91,7 @@ static void *test_setup(void)
 static inline void restore_ubx_script(void)
 {
 	static const struct ubx_frame frame_restored = UBX_FRAME_ACK_INITIALIZER(0x01, 0x02);
-	static const struct script_runner script_runner_restored = {
+	const struct script_runner script_runner_restored = {
 		.script = {
 			.request = {
 				.buf = &test_req,


### PR DESCRIPTION
Reported on latest clang-build run (250530): https://github.com/zephyrproject-rtos/zephyr/actions/runs/15352458821

