### PR TITLE
soc: npcx: Add __packed to flags struct in npcx_pinctrl

### DIFF
--- a/soc/nuvoton/npcx/common/pinctrl_soc.h
+++ b/soc/nuvoton/npcx/common/pinctrl_soc.h
@@ -125,7 +125,7 @@ struct npcx_pinctrl {
 		struct npcx_psl_input psl_in;
 		uint16_t cfg_word;
 	} cfg;
-	struct {
+	struct __packed {
 		/** Indicates the current pinctrl type. */
 		enum npcx_pinctrl_type type :2;
 		/** Properties used for pinmuxing. */


### PR DESCRIPTION
When building with clang and CONFIG_LTO, clang warns:

```
soc/nuvoton/npcx/common/pinctrl_soc.h:141:4: error: field flags within
'struct npcx_pinctrl' is less aligned than 'struct (unnamed struct at
soc/nuvoton/npcx/common/./pinctrl_soc.h:128:2)' and is usually due to
'struct npcx_pinctrl' being packed, which can lead to unaligned accesses
[-Werror,-Wunaligned-access]
         } flags;
           ^
```