### PR TITLE
cmake: compiler: Remove -fshort-enums

### DIFF
--- a/cmake/compiler/armclang/target.cmake
+++ b/cmake/compiler/armclang/target.cmake
@@ -16,10 +16,6 @@ include(${ZEPHYR_BASE}/cmake/gcc-m-fpu.cmake)
 # 'cortex-m33+nodsp' we need that to be 'cortex-m33' for CMAKE_SYSTEM_PROCESSOR
 string(REGEX REPLACE "\\+.*" "" CMAKE_SYSTEM_PROCESSOR ${GCC_M_CPU})
 
-list(APPEND TOOLCHAIN_C_FLAGS
-  -fshort-enums
-  )
-
 if(CONFIG_ARM64)
   list(APPEND TOOLCHAIN_C_FLAGS   -mcpu=${GCC_M_CPU})
 

--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -23,13 +23,6 @@ if(NOT "${ARCH}" STREQUAL "posix")
   include(${ZEPHYR_BASE}/cmake/gcc-m-fpu.cmake)
 
   if("${ARCH}" STREQUAL "arm")
-    list(APPEND TOOLCHAIN_C_FLAGS
-      -fshort-enums
-      )
-    list(APPEND TOOLCHAIN_LD_FLAGS
-      -fshort-enums
-      )
-
     include(${ZEPHYR_BASE}/cmake/compiler/clang/target_arm.cmake)
   elseif("${ARCH}" STREQUAL "arm64")
     include(${ZEPHYR_BASE}/cmake/compiler/clang/target_arm64.cmake)


### PR DESCRIPTION
"-fshort-enums" changes the ABI. It's not enabled for gcc, so it's not
clear why it's enabled for clang (only ARM) and armclang, other than it
looks like some users of these toolchains may be linking against code
that is compiled with "-fshort-enums".

As an example, when compiling with clang, CONFIG_LTO, and a toolchain
built without "-fshort-enums", the linker warns:

ld.lld: error: linking module flags 'min_enum_size': IDs have
conflicting values in
'/usr/armv7m-cros-eabi/usr/lib/libc++_static.a(string.cpp.o at 784090)'
and 'ld-temp.o'