### PR TITLE
arch: Add LLVM toolchain to ISR_TABLES_LOCAL_DECLARATION_SUPPORTED

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -448,7 +448,7 @@ config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
 	# List of currently supported architectures
 	depends on ARM || ARM64
 	# List of currently supported toolchains
-	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "gnuarmemb"
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "gnuarmemb" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "llvm"
 
 config ISR_TABLES_LOCAL_DECLARATION
 	bool "ISR tables created locally and placed by linker"


### PR DESCRIPTION
The LLVM toolchain can also compile this code.