### PR TITLE
arch/x86/core: Use CONFIG_QEMU_TARGET for QEMU specific code

### DIFF
--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -61,7 +61,7 @@ FUNC_NORETURN void z_prep_c(void *arg)
 #ifdef CONFIG_X86_VERY_EARLY_CONSOLE
 	z_x86_early_serial_init();
 
-#if defined(CONFIG_BOARD_QEMU_X86) || defined(CONFIG_BOARD_QEMU_X86_64)
+#if defined(CONFIG_QEMU_TARGET)
 	/*
 	 * Under QEMU and SeaBIOS, everything gets to be printed
 	 * immediately after "Booting from ROM.." as there is no newline.


### PR DESCRIPTION
Instead of both checking CONFIG_BOARD_QEMU_X86 and CONFIG_BOARD_QEMU_X86_64, simply check for CONFIG_QEMU_TARGET.

This also helps qemu_x86_tiny, qemu_x86_lakemont and any future/downstream QEMU targets to keep things simple.