### PR TITLE
Arch: Arm: SMP: Boot & Voting Refactor

### DIFF
--- a/arch/arm64/core/macro_priv.inc
+++ b/arch/arm64/core/macro_priv.inc
@@ -25,7 +25,7 @@
  * Get CPU logic id by looking up cpu_node_list
  * returns
  *   xreg0: MPID
- *   xreg1: logic id (0 ~ CONFIG_MP_MAX_NUM_CPUS - 1)
+ *   xreg1: logic id (0 ~ DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus)) - 1)
  * clobbers: xreg0, xreg1, xreg2, xreg3
  */
 .macro get_cpu_logic_id xreg0, xreg1, xreg2, xreg3
@@ -36,7 +36,7 @@
 	cmp	\xreg2, \xreg0
 	beq	2f
 	add	\xreg1, \xreg1, 1
-	cmp	\xreg1, #CONFIG_MP_MAX_NUM_CPUS
+	cmp	\xreg1, #DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus))
 	bne	1b
 	b	.
 2:

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -8,6 +8,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/offsets.h>
+#include <zephyr/devicetree.h>
 #include "boot.h"
 #include "macro_priv.inc"
 
@@ -163,7 +164,7 @@ resetwait:
 	/* wait */
 	bne	2b
 	add	x5, x5, #1
-	cmp	x5, #CONFIG_MP_MAX_NUM_CPUS
+	cmp	x5, #DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus))
 	bne	2b
 
 

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -37,7 +37,7 @@
 struct boot_params {
 	uint64_t mpid;
 	char *sp;
-	uint8_t voting[CONFIG_MP_MAX_NUM_CPUS];
+	uint8_t voting[DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus))];
 	arch_cpustart_t fn;
 	void *arg;
 	int cpu_num;
@@ -55,6 +55,8 @@ volatile struct boot_params __aligned(L1_CACHE_BYTES) arm64_cpu_boot_params = {
 const uint64_t cpu_node_list[] = {
 	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
 };
+
+BUILD_ASSERT(ARRAY_SIZE(cpu_node_list) == DT_CHILD_NUM_STATUS_OKAY(DT_PATH(cpus)));
 
 /* cpu_map saves the maping of core id and mpid */
 static uint64_t cpu_map[CONFIG_MP_MAX_NUM_CPUS] = {


### PR DESCRIPTION
To support boot-up from parts where usable cores are limited to subset of total cores in HW we expect the boot/primary core to configured to any of the usable clusterXcoreN. For example, in a system with 3 clusters, each having 6 cores, if on a particular device the Cluster0Core0 and Cluster0Core1 are non-functional due to issues like silicon yield defects or other hardware-related faults, booting from Cluster0Core2 may be necessary. To accommodate various cluster configurations, all the core's MPID must be explicitly listed in the cpu_node_list (all 18 cores for the system mentioned in example above). However, currently, the get_cpu_logic_id function assumes that CONFIG_MP_MAX_NUM_CPUS will always match to the length of cpu_node_list.
To correctly iterate over all MPIDs in cpu_node_list, this assumption needs to be revised. The logic should be updated to dynamically iterate through the all the entries in cpu_node_list.
 
Required change:

**Update get_cpu_logic_id Macro**:  Instead of comparing xreg1 (iterator) with CONFIG_MP_MAX_NUM_CPUS, compare it with the length of cpu_node_list updated in smp.c. This ensures the search covers the entire cpu_node_list to find cpu_logic_id.
As a result of the change described above, the voting mechanism also requires an update. Currently, voting relies on the logic_id obtained from get_cpu_logic_id, which is derived from the index of the MPID in the cpu_node_list. This approach assumes that logic_id values do not exceed CONFIG_MP_MAX_NUM_CPUS.
However, with the above change(1) allowing more flexible core configurations, logic_id values may now exceed this limit. This breaks the assumption that the voting array size is bounded by CONFIG_MP_MAX_NUM_CPUS. 
To resolve this limitation, the voting mechanism should be modified to use CPU_NUM instead of logic_id. This ensures that voting remains consistent, scalable, and accurate, regardless of the number of entries in cpu_node_list.
 
Required change:
 
**Update to boot_params Structure** :  To make CPU_NUM accessible during the early boot phase (e.g., in reset.s), it must be moved above the voting[CONFIG_MP_MAX_NUM_CPUS] array within the boot_params structure. Since the size of the voting array is variable and depends on CONFIG_MP_MAX_NUM_CPUS, placing CPU_NUM above it guarantees a fixed offset. This allows reliable access using the newly defined BOOT_PARAM_CPU_NUM_OFFSET in boot.h.