### PR TITLE
Revert "modules: hal_rpi_pico: set -std=gnu11 in a toolchain independ…

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 if(CONFIG_HAS_RPI_PICO)
   zephyr_library()
-  set_property(TARGET ${ZEPHYR_CURRENT_LIBRARY} PROPERTY C_STANDARD 11)
+  zephyr_library_compile_options(-std=gnu11)
 
   set(rp2_common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2_common)
   set(rp2xxx_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/${CONFIG_SOC_SERIES})


### PR DESCRIPTION
This reverts commit 05401b3f44753e857c32812775da7c9efdfa87c3.

Introducing c-std setting with CMake way in the commit, but the actual command line is below.

```
arm-zephyr-eabi-gcc -DKERNEL ... -std=gnu11 ...  -std=c99 ...
```

The setting `CONFIG_STD_C99` in Kconfig appends the `-std=c99`, and (At least in gcc,) options are processed last-come-first, so this setting was meaningless.

This will cause a build error,
https://github.com/zephyrproject-rtos/zephyr/actions/runs/15357763548/job/43220292776?pr=90893
so we will revert it.