### PR TITLE
kernel: mmu: Added a cast to avoid format warnings when logging

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -955,7 +955,7 @@ void k_mem_map_phys_bare(uint8_t **virt_ptr, uintptr_t phys, size_t size, uint32
 		 "wraparound for virtual address %p (size %zu)",
 		 dest_addr, size);
 
-	LOG_DBG("arch_mem_map(%p, 0x%lx, %zu, %x) offset %lu", dest_addr,
+	LOG_DBG("arch_mem_map(%p, 0x%lx, %zu, %x) offset %lu", (void *)dest_addr,
 		aligned_phys, aligned_size, flags, addr_offset);
 
 	arch_mem_map(dest_addr, aligned_phys, aligned_size, flags);


### PR DESCRIPTION
At runtime, `cbprintf` outputs a warning of the type check of the print format.
Added a cast to avoid this warning to the first argument of `device_map()` to `void*`.


I got the following logs.
```
[00:00:00.013,000] <wrn> cbprintf_package: (unsigned) char * used for %p argument. It's recommended to cast it to void * because it may cause misbehavior in certain configurations. String:"%s: arch_mem_map(%p, 0x%lx, %zu, %x) offset %lu" argument:1
[00:00:00.013,000] <dbg> os: k_mem_map_phys_bare: arch_mem_map(0x41ffd000, 0x38000000, 4096, 8) offset 0
```