### PR TITLE
sensor: ina230: fix single-shot and shutdown modes

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -61,6 +61,9 @@ Removed APIs and options
 * The TinyCrypt library was removed as the upstream version is no longer maintained.
   PSA Crypto API is now the recommended cryptographic library for Zephyr.
 
+* Removed deprecated property ``config`` and broken enum ``"Shutdown continuous"`` from
+  :dtcompatible:`ti,ina230`.
+
 Deprecated APIs and options
 ===========================
 

--- a/drivers/sensor/ti/ina23x/ina230.c
+++ b/drivers/sensor/ti/ina23x/ina230.c
@@ -29,41 +29,23 @@ static int ina230_channel_get(const struct device *dev, enum sensor_channel chan
 {
 	struct ina230_data *data = dev->data;
 	const struct ina230_config *const config = dev->config;
-	uint32_t bus_uv, power_uw;
-	int32_t current_ua;
+	int32_t val_micro;
 
 	switch (chan) {
 	case SENSOR_CHAN_VOLTAGE:
-		bus_uv = data->bus_voltage * config->uv_lsb;
-
-		/* convert to fractional volts (units for voltage channel) */
-		val->val1 = bus_uv / 1000000U;
-		val->val2 = bus_uv % 1000000U;
+		val_micro = data->bus_voltage * config->uv_lsb;
 		break;
-
 	case SENSOR_CHAN_CURRENT:
-		/* see datasheet "Programming" section for reference */
-		current_ua = data->current * config->current_lsb;
-
-		/* convert to fractional amperes */
-		val->val1 = current_ua / 1000000L;
-		val->val2 = current_ua % 1000000L;
+		val_micro = data->current * config->current_lsb;
 		break;
-
 	case SENSOR_CHAN_POWER:
-		power_uw = data->power * config->power_scale * config->current_lsb;
-
-		/* convert to fractional watts */
-		val->val1 = (int32_t)(power_uw / 1000000U);
-		val->val2 = (int32_t)(power_uw % 1000000U);
-
+		val_micro = data->power * config->power_scale * config->current_lsb;
 		break;
-
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return sensor_value_from_micro(val, val_micro);
 }
 
 static int ina230_sample_fetch(const struct device *dev, enum sensor_channel chan)

--- a/drivers/sensor/ti/ina23x/ina230.c
+++ b/drivers/sensor/ti/ina23x/ina230.c
@@ -235,7 +235,7 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 	static const struct ina230_config drv_config_##type##inst = {                              \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
 		.config = (DT_INST_PROP_OR(inst, high_precision, 0) << 12) |                       \
-			  DT_INST_PROP(inst, config) | (DT_INST_ENUM_IDX(inst, avg_count) << 9) |  \
+			  (DT_INST_ENUM_IDX(inst, avg_count) << 9) |                               \
 			  (DT_INST_ENUM_IDX(inst, vbus_conversion_time_us) << 6) |                 \
 			  (DT_INST_ENUM_IDX(inst, vshunt_conversion_time_us) << 3) |               \
 			  DT_INST_ENUM_IDX(inst, adc_mode),                                        \
@@ -247,7 +247,7 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 				    DT_INST_PROP(inst, rshunt_micro_ohms))) >>                     \
 				  (DT_INST_PROP_OR(inst, high_precision, 0) << 1)),                \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, alert_gpios), (INA230_CFG_IRQ(inst)),      \
-			    ())};   \
+			    ())};                                                                  \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, &ina230_init, NULL, &drv_data_##type##inst,             \
 				     &drv_config_##type##inst, POST_KERNEL,                        \
 				     CONFIG_SENSOR_INIT_PRIORITY, &ina230_driver_api);

--- a/drivers/sensor/ti/ina23x/ina230.c
+++ b/drivers/sensor/ti/ina23x/ina230.c
@@ -223,9 +223,9 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 
 #ifdef CONFIG_INA230_TRIGGER
 #define INA230_CFG_IRQ(inst)                                                                       \
-	.trig_enabled = true, .mask = DT_INST_PROP(inst, mask),                                    \
-	.alert_limit = DT_INST_PROP(inst, alert_limit),                                            \
-	.alert_gpio = GPIO_DT_SPEC_INST_GET(inst, alert_gpios)
+	.alert_gpio = GPIO_DT_SPEC_INST_GET(inst, alert_gpios),                                    \
+	.alert_limit = DT_INST_PROP(inst, alert_limit), .mask = DT_INST_PROP(inst, mask),          \
+	.trig_enabled = true,
 #else
 #define INA230_CFG_IRQ(inst)
 #endif /* CONFIG_INA230_TRIGGER */
@@ -234,18 +234,18 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 	static struct ina230_data drv_data_##type##inst;                                           \
 	static const struct ina230_config drv_config_##type##inst = {                              \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
+		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),                          \
+		.uv_lsb = type##_BUS_VOLTAGE_UV_LSB,                                               \
 		.config = (DT_INST_PROP_OR(inst, high_precision, 0) << 12) |                       \
 			  (DT_INST_ENUM_IDX(inst, avg_count) << 9) |                               \
 			  (DT_INST_ENUM_IDX(inst, vbus_conversion_time_us) << 6) |                 \
 			  (DT_INST_ENUM_IDX(inst, vshunt_conversion_time_us) << 3) |               \
 			  DT_INST_ENUM_IDX(inst, adc_mode),                                        \
-		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),                          \
-		.uv_lsb = type##_BUS_VOLTAGE_UV_LSB,                                               \
-		.power_scale = type##_POWER_SCALING,                                               \
 		.cal = (uint16_t)(((INA230_CAL_SCALING * 10000000ULL) /                            \
 				   ((uint64_t)DT_INST_PROP(inst, current_lsb_microamps) *          \
 				    DT_INST_PROP(inst, rshunt_micro_ohms))) >>                     \
 				  (DT_INST_PROP_OR(inst, high_precision, 0) << 1)),                \
+		.power_scale = type##_POWER_SCALING,                                               \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, alert_gpios), (INA230_CFG_IRQ(inst)),      \
 			    ())};                                                                  \
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, &ina230_init, NULL, &drv_data_##type##inst,             \

--- a/drivers/sensor/ti/ina23x/ina230.c
+++ b/drivers/sensor/ti/ina23x/ina230.c
@@ -295,7 +295,8 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 	static struct ina230_data drv_data_##type##inst;                                           \
 	static const struct ina230_config drv_config_##type##inst = {                              \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \
-		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps),                          \
+		.current_lsb = DT_INST_PROP(inst, current_lsb_microamps) *                         \
+			       COND_CODE_1(DT_INST_PROP(inst, direction_invert), (-1), (1)),       \
 		.uv_lsb = type##_BUS_VOLTAGE_UV_LSB,                                               \
 		.conv_duration_us = CONV_DURATION_US(inst),                                        \
 		.config = (DT_INST_PROP_OR(inst, high_precision, 0) << 12) |                       \

--- a/drivers/sensor/ti/ina23x/ina230.c
+++ b/drivers/sensor/ti/ina23x/ina230.c
@@ -54,6 +54,7 @@ static int ina230_channel_get(const struct device *dev, enum sensor_channel chan
 static int ina230_adc_run(const struct device *dev)
 {
 	const struct ina230_config *config = dev->config;
+	bool in_shutdown = config->adc_mode == 0;
 	uint16_t reg;
 	int ret, i;
 
@@ -62,8 +63,11 @@ static int ina230_adc_run(const struct device *dev)
 		return 0;
 	}
 
+	/* If idling in shutdown, update to single shot triggered */
+	reg = in_shutdown ? (config->config | 3) : config->config;
+
 	/* Write the configuration register to force a sample */
-	ret = ina23x_reg_write(&config->bus, INA230_REG_CONFIG, config->config);
+	ret = ina23x_reg_write(&config->bus, INA230_REG_CONFIG, reg);
 	if (ret < 0) {
 		LOG_ERR("Failed to trigger sample");
 		return ret;
@@ -82,6 +86,11 @@ static int ina230_adc_run(const struct device *dev)
 	}
 	if (i == INA_POLL_TIMEOUT_MS) {
 		ret = -EAGAIN;
+	}
+
+	if (in_shutdown) {
+		/* Return to shutdown mode */
+		(void)ina23x_reg_write(&config->bus, INA230_REG_CONFIG, config->config);
 	}
 
 	return ret;
@@ -282,6 +291,7 @@ static DEVICE_API(sensor, ina230_driver_api) = {
 	 DT_INST_PROP(inst, avg_count))
 
 #define INA230_DRIVER_INIT(inst, type)                                                             \
+	BUILD_ASSERT(DT_INST_ENUM_HAS_VALUE(inst, adc_mode, invalid) == false);                    \
 	static struct ina230_data drv_data_##type##inst;                                           \
 	static const struct ina230_config drv_config_##type##inst = {                              \
 		.bus = I2C_DT_SPEC_INST_GET(inst),                                                 \

--- a/drivers/sensor/ti/ina23x/ina230.h
+++ b/drivers/sensor/ti/ina23x/ina230.h
@@ -52,7 +52,7 @@ struct ina230_data {
 
 struct ina230_config {
 	struct i2c_dt_spec bus;
-	uint32_t current_lsb;
+	int32_t current_lsb;
 	uint32_t uv_lsb;
 	uint32_t conv_duration_us;
 	uint16_t config;

--- a/drivers/sensor/ti/ina23x/ina230.h
+++ b/drivers/sensor/ti/ina23x/ina230.h
@@ -34,6 +34,8 @@
 #define INA236_REG_MANUFACTURER_ID 0x3E
 #define INA236_REG_DEVICE_ID       0x3F
 
+#define INA230_REG_MASK_CNVR BIT(3)
+
 struct ina230_data {
 	const struct device *dev;
 	int16_t current;
@@ -52,9 +54,11 @@ struct ina230_config {
 	struct i2c_dt_spec bus;
 	uint32_t current_lsb;
 	uint32_t uv_lsb;
+	uint32_t conv_duration_us;
 	uint16_t config;
 	uint16_t cal;
 	uint8_t power_scale;
+	uint8_t adc_mode;
 #ifdef CONFIG_INA230_TRIGGER
 	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_limit;

--- a/drivers/sensor/ti/ina23x/ina230.h
+++ b/drivers/sensor/ti/ina23x/ina230.h
@@ -50,16 +50,16 @@ struct ina230_data {
 
 struct ina230_config {
 	struct i2c_dt_spec bus;
-	uint16_t config;
 	uint32_t current_lsb;
+	uint32_t uv_lsb;
+	uint16_t config;
 	uint16_t cal;
 	uint8_t power_scale;
-	uint32_t uv_lsb;
 #ifdef CONFIG_INA230_TRIGGER
-	bool trig_enabled;
-	uint16_t mask;
 	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_limit;
+	uint16_t mask;
+	bool trig_enabled;
 #endif /* CONFIG_INA230_TRIGGER */
 };
 

--- a/drivers/sensor/ti/ina23x/ina237.h
+++ b/drivers/sensor/ti/ina23x/ina237.h
@@ -54,7 +54,7 @@ struct ina237_config {
 	struct i2c_dt_spec bus;
 	uint16_t config;
 	uint16_t adc_config;
-	uint32_t current_lsb;
+	int32_t current_lsb;
 	uint16_t cal;
 	const struct gpio_dt_spec alert_gpio;
 	uint16_t alert_config;

--- a/dts/bindings/sensor/ti,ina230.yaml
+++ b/dts/bindings/sensor/ti,ina230.yaml
@@ -16,15 +16,6 @@ compatible: "ti,ina230"
 include: ti,ina23x-common.yaml
 
 properties:
-  config:
-    type: int
-    deprecated: true
-    default: 0x0000
-    description: |
-      Value of the configuration register
-      e.g shunt voltage and bus voltage ADC conversion
-      times, ADC and averaging, and ADC operating mode.
-
   alert-config:
     type: int
     description: Diag alert register, default matches the power-on reset value

--- a/dts/bindings/sensor/ti,ina230.yaml
+++ b/dts/bindings/sensor/ti,ina230.yaml
@@ -71,3 +71,7 @@ properties:
     default: 0
     # default alert limit is 0V
     description: Alert register, default matches the power-on reset value
+
+  direction-invert:
+    type: boolean
+    description: Invert the direction of reported current and power flow

--- a/dts/bindings/sensor/ti,ina230.yaml
+++ b/dts/bindings/sensor/ti,ina230.yaml
@@ -31,7 +31,7 @@ properties:
       - "Shunt Voltage single shot"
       - "Bus Voltage single shot"
       - "Bus and Shunt Voltage single shot"
-      - "Shutdown continuous"
+      - "invalid"
       - "Shunt voltage continuous"
       - "Bus voltage continuous"
       - "Bus and shunt voltage continuous"

--- a/tests/drivers/sensor/ina230/src/ina230_test.c
+++ b/tests/drivers/sensor/ina230/src/ina230_test.c
@@ -24,7 +24,6 @@ struct ina230_fixture {
 	const struct emul *mock;
 	const uint16_t current_lsb_uA;
 	const uint16_t rshunt_uOhms;
-	const uint16_t config;
 	const enum ina23x_ids dev_type;
 };
 
@@ -216,7 +215,6 @@ static void test_power(struct ina230_fixture *fixture)
 		.mock = EMUL_DT_GET(DT_DRV_INST(inst)),                                            \
 		.current_lsb_uA = DT_INST_PROP(inst, current_lsb_microamps),                       \
 		.rshunt_uOhms = DT_INST_PROP(inst, rshunt_micro_ohms),                             \
-		.config = DT_INST_PROP(inst, config),                                              \
 		.dev_type = INA23##v,                                                              \
 	}
 


### PR DESCRIPTION
When not running in one of the continuous modes, sampling needs to be explicitly triggered by a write to the configuration register. Extra steps need to be taken when idling in the shutdown mode, since writing the constant configuration value will just return to shutdown without sampling.

Includes other minor updates to the driver including common logging strings, using common conversion functions, more efficient struct packing and optional inversion of reported current and power flow.