### PR TITLE
llext: Do not print symbol resolution messages

### DIFF
--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -213,7 +213,7 @@ int llext_lookup_symbol(struct llext_loader *ldr, struct llext *ext, uintptr_t *
 			return -ENODATA;
 		}
 
-		LOG_INF("found symbol %s at %#lx", name, *link_addr);
+		LOG_DBG("found symbol %s at %#lx", name, *link_addr);
 	} else if (sym->st_shndx == SHN_ABS) {
 		/* Absolute symbol */
 		*link_addr = sym->st_value;
@@ -522,7 +522,7 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 					name, ELF_ST_TYPE(sym.st_info),
 					ELF_ST_BIND(sym.st_info), sym.st_shndx);
 
-				LOG_INF("writing relocation type %d at %#lx with symbol %s (%#lx)",
+				LOG_DBG("writing relocation type %d at %#lx with symbol %s (%#lx)",
 					(int)ELF_R_TYPE(rel.r_info), op_loc, name, link_addr);
 			}
 #endif /* CONFIG_LLEXT_LOG_LEVEL */


### PR DESCRIPTION
If the LLEXT extension is really large, these messages really add up. Making them debug messages.