### PR TITLE
boards: fk743m5: add sdram support and pyocd runner support

### DIFF
--- a/boards/fanke/fk743m5_xih6/board.cmake
+++ b/boards/fanke/fk743m5_xih6/board.cmake
@@ -3,7 +3,9 @@
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 board_runner_args(jlink "--device=STM32H743XI" "--speed=4000")
+board_runner_args(pyocd "--target=STM32H743XIHx")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/fanke/fk743m5_xih6/doc/index.rst
+++ b/boards/fanke/fk743m5_xih6/doc/index.rst
@@ -122,7 +122,19 @@ Then, press the RESET button, you should see the following message:
 Debugging
 =========
 
-This current Zephyr port does not support debugging.
+You can debug an application using the SWD interface with a J-Link or ST-Link. For more
+details, please refer to the `Flashing`_ section and run the ``west debug`` command
+instead of ``west flash``.
+
+Here is an example for the :zephyr:code-sample:`hello_world`
+application.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: fk743m5_xih6
+   :goals: debug
+   :flash-args: -r pyocd
+   :compact:
 
 References
 **********

--- a/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
+++ b/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
@@ -31,6 +31,21 @@
 	aliases {
 		led0 = &user_led;
 	};
+
+	ext_memory: memory@90000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x90000000 DT_SIZE_M(256)>;
+		zephyr,memory-region = "EXTMEM";
+		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
+
+	sdram1: sdram@c0000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0xc0000000 DT_SIZE_M(32)>;
+		zephyr,memory-region = "SDRAM1";
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
+	};
 };
 
 &clk_hsi48 {
@@ -97,6 +112,43 @@
 				label = "storage";
 				reg = <0x00000000 DT_SIZE_M(8)>;
 			};
+		};
+	};
+};
+
+&fmc {
+	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1
+	&fmc_sdclk_pg8 &fmc_sdnwe_pc0 &fmc_sdcke0_ph2
+	&fmc_sdne0_ph3 &fmc_sdnras_pf11 &fmc_sdncas_pg15
+	&fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
+	&fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
+	&fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
+	&fmc_a12_pg2  &fmc_d0_pd14 &fmc_d1_pd15
+	&fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
+	&fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
+	&fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
+	&fmc_d15_pd10>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sdram {
+		status = "okay";
+		power-up-delay = <100>;
+		num-auto-refresh = <8>;
+		mode-register = <0x230>;
+		refresh-rate = <0x603>;
+
+		bank@0 {
+			reg = <0>;
+			st,sdram-control = <STM32_FMC_SDRAM_NC_9
+			STM32_FMC_SDRAM_NR_13
+			STM32_FMC_SDRAM_MWID_16
+			STM32_FMC_SDRAM_NB_4
+			STM32_FMC_SDRAM_CAS_3
+			STM32_FMC_SDRAM_SDCLK_PERIOD_2
+			STM32_FMC_SDRAM_RBURST_ENABLE
+			STM32_FMC_SDRAM_RPIPE_1>;
+			st,sdram-timing = <2 7 4 7 3 2 2>;
 		};
 	};
 };

--- a/boards/fanke/fk743m5_xih6/fk743m5_xih6.yaml
+++ b/boards/fanke/fk743m5_xih6/fk743m5_xih6.yaml
@@ -13,4 +13,5 @@ supported:
   - spi
   - backup_sram
   - qspi
+  - memc
 vendor: fanke


### PR DESCRIPTION
boards: fk743m5: add sdram support and pyocd runner support

Running the tests/drivers/memc/ram/ result:

```
*** Booting Zephyr OS build 0aa982993652 ***
Running TESTSUITE test_ram
===================================================================
START - test_psram
 SKIP - test_psram in 0.001 seconds
===================================================================
START - test_ram0
 SKIP - test_ram0 in 0.001 seconds
===================================================================
START - test_sdram1
 PASS - test_sdram1 in 0.001 seconds
===================================================================
START - test_sdram2
 SKIP - test_sdram2 in 0.001 seconds
===================================================================
START - test_sram1
 PASS - test_sram1 in 0.001 seconds
===================================================================
START - test_sram2
 PASS - test_sram2 in 0.001 seconds
===================================================================
TESTSUITE test_ram succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [test_ram]: pass = 3, fail = 0, skip = 3, total = 6 duration = 0.006 seconds
 - SKIP - [test_ram.test_psram] duration = 0.001 seconds
 - SKIP - [test_ram.test_ram0] duration = 0.001 seconds
 - PASS - [test_ram.test_sdram1] duration = 0.001 seconds
 - SKIP - [test_ram.test_sdram2] duration = 0.001 seconds
 - PASS - [test_ram.test_sram1] duration = 0.001 seconds
 - PASS - [test_ram.test_sram2] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```