### PR TITLE
drivers: dma: esp32: guard driver's kconfig options

### DIFF
--- a/drivers/dma/Kconfig.esp32
+++ b/drivers/dma/Kconfig.esp32
@@ -8,8 +8,12 @@ config DMA_ESP32
 	help
 	  General Purpose DMA for ESP32 series.
 
+if DMA_ESP32
+
 config DMA_ESP32_MAX_DESCRIPTOR_NUM
 	int "Maximal number of available DMA descriptors"
 	default 16
 	help
 	  Reserves memory for a maximal number of descriptors
+
+endif # DMA_ESP32


### PR DESCRIPTION
Wrap the driver's options to prevent them from showing up in the global Kconfig menu.