### PR TITLE
soc: ambiq: adjust init process

### DIFF
--- a/soc/ambiq/apollo5x/Kconfig
+++ b/soc/ambiq/apollo5x/Kconfig
@@ -18,7 +18,7 @@ config SOC_SERIES_APOLLO5X
 	select AMBIQ_HAL
 	select HAS_PM
 	select SOC_EARLY_INIT_HOOK
-	select REQUIRES_FULL_LIBC
+	select FPU
 
 config SOC_AMBIQ_DCACHE_SIZE
 	int

--- a/soc/ambiq/apollo5x/soc.c
+++ b/soc/ambiq/apollo5x/soc.c
@@ -38,25 +38,6 @@ void soc_early_init_hook(void)
 
 	/* Internal timer15 for SPOT manager */
 	IRQ_CONNECT(82, 0, hal_internal_timer_isr, 0, 0);
-
-	/* Initialize for low power in the power control block */
-	am_hal_pwrctrl_low_power_init();
-
-	/* Enable SIMOBUCK for the apollo5 Family */
-	am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_SIMOBUCK_INIT, NULL);
-
-	/*
-	 * Set default temperature for spotmgr to room temperature
-	 */
-	am_hal_pwrctrl_temp_thresh_t dummy;
-
-	am_hal_pwrctrl_temp_update(25.0f, &dummy);
-
-	/* Enable Icache*/
-	sys_cache_instr_enable();
-
-	/* Enable Dcache */
-	sys_cache_data_enable();
 }
 
 #if CONFIG_CACHE_MANAGEMENT
@@ -84,3 +65,29 @@ bool buf_in_nocache(uintptr_t buf, size_t len_bytes)
 	return buf_within_nocache;
 }
 #endif
+
+int apollo5x_init(void)
+{
+	/* Initialize for low power in the power control block */
+	am_hal_pwrctrl_low_power_init();
+
+	/* Enable SIMOBUCK for the apollo5 Family */
+	am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_SIMOBUCK_INIT, NULL);
+
+	/*
+	 * Set default temperature for spotmgr to room temperature
+	 */
+	am_hal_pwrctrl_temp_thresh_t dummy;
+
+	am_hal_pwrctrl_temp_update(25.0f, &dummy);
+
+	/* Enable Icache*/
+	sys_cache_instr_enable();
+
+	/* Enable Dcache */
+	sys_cache_data_enable();
+
+	return 0;
+}
+
+SYS_INIT(apollo5x_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
split soc init into two parts as it is too large to be up front at early stages.