### PR TITLE
ci: move weekly build back to sunday night

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -12,8 +12,8 @@ on:
       - v*-branch
       - collab-*
   schedule:
-    # Run at 17:00 UTC on every Saturday
-    - cron: '0 17 * * 6'
+    # Run at 02:00 UTC on every Sunday
+    - cron: '0 2 * * 0'
 
 permissions:
   contents: read


### PR DESCRIPTION
Now that we have faster runners, we can move this back to the night and
be productive during the day :)

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
