### PR TITLE
cmake: add_llext_target: fix command expansion

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5960,6 +5960,7 @@ function(add_llext_target target_name)
             $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
     COMMAND ${slid_inject_cmd}
     DEPENDS ${llext_proc_target} ${llext_pkg_input}
+    COMMAND_EXPAND_LISTS
   )
 
   # Add user-visible target and dependency, and fill in properties


### PR DESCRIPTION
This updates the invocation of the `elfconvert` and `slid_inject` commands in the `add_llext_target` function, ensuring that the arguments are expanded correctly before passing them to the shell.

Fixes #90891.