### PR TITLE
samples: adc_dt: add dts overlay for STM32F4-DISCO

### DIFF
--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -164,6 +164,8 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &adc1 {
+	pinctrl-0 = <&adc1_in1_pa1 &adc1_in6_pa6>;
+	pinctrl-names = "default";
 	st,adc-prescaler = <2>;
 	status = "okay";
 };

--- a/boards/st/stm32f4_disco/stm32f4_disco.yaml
+++ b/boards/st/stm32f4_disco/stm32f4_disco.yaml
@@ -11,4 +11,5 @@ supported:
   - can
   - pwm
   - counter
+  - adc
 vendor: st

--- a/samples/drivers/adc/adc_dt/boards/stm32f4_disco.overlay
+++ b/samples/drivers/adc/adc_dt/boards/stm32f4_disco.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Ajith Anandhan
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	zephyr,user {
+		io-channels = <&adc1 1>, <&adc1 6>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/adc/adc_api/boards/stm32f4_disco.overlay
+++ b/tests/drivers/adc/adc_api/boards/stm32f4_disco.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Ajith Anandhan
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	zephyr,user {
+		io-channels = <&adc1 1>, <&adc1 6>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};


### PR DESCRIPTION
Add a board-specif overlay file for the adc_dt sample on the ST32F4-DISCO board to enable support for ADC channels.