### PR TITLE
dts: bindings: led: Add AIROC LED driver to the DTS bindings

### DIFF
--- a/dts/bindings/led/infineon,airoc-leds.yaml
+++ b/dts/bindings/led/infineon,airoc-leds.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2025 Beechwoods Software Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Infineon AIROC Wirless Controller
+  LED Port
+
+compatible: "infineon,airoc-leds"
+
+child-binding:
+  description: AIROC LED child node
+  properties:
+    gpios:
+      type: phandle-array
+      required: true


### PR DESCRIPTION
Add AIROC LED driver to the DTS bindings in the LED section.

Notes:
 - This PR depends on: https://github.com/zephyrproject-rtos/zephyr/pull/90914