### PR TITLE
stm32g0: mco: enable usage of MCO for STM32G0 

### DIFF
--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -94,6 +94,18 @@
 		};
 	};
 
+	mcos {
+		mco1: mco1 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+
+		mco2: mco2 {
+			compatible = "st,stm32-clock-mco";
+			status = "disabled";
+		};
+	};
+
 	soc {
 		flash: flash-controller@40022000 {
 			compatible = "st,stm32-flash-controller", "st,stm32g0-flash-controller";

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include <st/g0/stm32g071.dtsi>
+#include <zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h>
 
 / {
 

--- a/dts/arm/st/g0/stm32g0c1.dtsi
+++ b/dts/arm/st/g0/stm32g0c1.dtsi
@@ -6,6 +6,7 @@
 
 #include <st/g0/stm32g0b1.dtsi>
 #include <st/g0/stm32g0_crypt.dtsi>
+#include <zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h>
 
 / {
 	soc {

--- a/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Andreas Schuster <andreas.schuster@schuam.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_
+
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_256  8
+#define MCO_PRE_DIV_512  9
+#define MCO_PRE_DIV_1024 10
+
+/* MCO clock output */
+#define MCO_SEL_HSI48     2
+#define MCO_SEL_PLLPCLK   8
+#define MCO_SEL_PLLQCLK   9
+#define MCO_SEL_RTCCLK    10
+#define MCO_SEL_RTCWAKEUP 11
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -35,6 +35,9 @@
 #define STM32_SRC_PLL_Q		(STM32_SRC_PLL_P + 1)
 #define STM32_SRC_PLL_R		(STM32_SRC_PLL_Q + 1)
 
+/** @brief RCC_CFGR register offset */
+#define CFGR_REG 0x08
+
 /** @brief RCC_CCIPR register offset */
 #define CCIPR_REG		0x54
 #define CCIPR2_REG		0x58
@@ -43,6 +46,11 @@
 #define BDCR_REG		0x5C
 
 /** @brief Device domain clocks selection helpers */
+/** CFGR devices */
+#define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 15, 24, CFGR_REG)
+#define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 15, 28, CFGR_REG)
+#define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 15, 16, CFGR_REG)
+#define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 15, 20, CFGR_REG)
 /** CCIPR devices */
 #define USART1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 0, CCIPR_REG)
 #define USART2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 2, CCIPR_REG)
@@ -65,5 +73,23 @@
 #define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 12, CCIPR2_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 8, BDCR_REG)
+
+/* MCO prescaler : division factor */
+#define MCO_PRE_DIV_1   0
+#define MCO_PRE_DIV_2   1
+#define MCO_PRE_DIV_4   2
+#define MCO_PRE_DIV_8   3
+#define MCO_PRE_DIV_16  4
+#define MCO_PRE_DIV_32  5
+#define MCO_PRE_DIV_64  6
+#define MCO_PRE_DIV_128 7
+
+/* MCO clock output */
+#define MCO_SEL_SYSCLK  1
+#define MCO_SEL_HSI16   3
+#define MCO_SEL_HSE     4
+#define MCO_SEL_PLLRCLK 5
+#define MCO_SEL_LSI     6
+#define MCO_SEL_LSE     7
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_CLOCK_H_ */

--- a/samples/boards/st/mco/boards/nucleo_g0b1re.overlay
+++ b/samples/boards/st/mco/boards/nucleo_g0b1re.overlay
@@ -1,0 +1,15 @@
+&mco1 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_LSI MCO1_SEL(MCO_SEL_LSI)>;
+	prescaler = <MCO1_PRE(MCO_PRE_DIV_1)>;
+	pinctrl-0 = <&rcc_mco_pa8>;
+	pinctrl-names = "default";
+};
+
+&mco2 {
+	status = "okay";
+	clocks = <&rcc STM32_SRC_HSI MCO2_SEL(MCO_SEL_HSI16)>;
+	prescaler = <MCO2_PRE(MCO_PRE_DIV_16)>;
+	pinctrl-0 = <&rcc_mco_2_pa15>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
To be able to use the microcontroller clock output of the STM32G0 microcontrollers some macros and device tree entries were missing. This pull requests add them. Additionally a sample overlay for the NUCLEO-G0B1RE board was added to the mco sample.