### PR TITLE
drivers: dma: fix the WCH DMA transfer width

### DIFF
--- a/boards/wch/ch32v003evt/ch32v003evt.yaml
+++ b/boards/wch/ch32v003evt/ch32v003evt.yaml
@@ -8,5 +8,6 @@ toolchain:
 ram: 2
 flash: 16
 supported:
+  - dma
   - gpio
   - i2c

--- a/boards/wch/ch32v006evt/ch32v006evt.yaml
+++ b/boards/wch/ch32v006evt/ch32v006evt.yaml
@@ -8,6 +8,7 @@ toolchain:
 ram: 8
 flash: 62
 supported:
+  - dma
   - gpio
   - i2c
   - pwm

--- a/boards/wch/linkw/linkw.yaml
+++ b/boards/wch/linkw/linkw.yaml
@@ -8,4 +8,5 @@ toolchain:
 ram: 64
 flash: 128
 supported:
+  - dma
   - gpio


### PR DESCRIPTION
The driver treats the `source_data_size` and `dest_data_size` as a
width in bits and converts 8 bits to 1, 16 bits to 2, and 32 bits to 3.

This should be a width in bytes with 1 byte mapping to 0, 2 bytes to
1, and 4 bytes to 3.

Note that this preserves the current behaviour of silently accepting
invalid transfer bit widths.