### PR TITLE
dts: arm: ti: Fix length of pinctrl block in J722s

### DIFF
--- a/dts/arm/ti/j722s_main.dtsi
+++ b/dts/arm/ti/j722s_main.dtsi
@@ -15,7 +15,7 @@
 
 	pinctrl: pinctrl@f4000 {
 		compatible = "ti,k3-pinctrl";
-		reg = <0x000f4000 0x2ac>;
+		reg = <0x000f4000 0x2b0>;
 		status = "okay";
 	};
 


### PR DESCRIPTION
In J722s pin multiplexing datasheet, its confirmed that there are PADCONFIG registers ranging from 0 to 171.

therefore, in j722s_main.dtsi in zephyr, the pinctrl block must have reg = <0x000f4000 0x2b0>  to reflect the correct length : 
(171-0+1)*4 = 172*4 = 0x2b0.  

The value 0x2ac is incorrect as it might not take into account that PADCONFIG registers start with index 0 in documentation.