### PR TITLE
drivers: video: samples: improve the video-sw-generator doc

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -718,6 +718,9 @@ Video
   size on a per driver basis. Existing applications will not be broken by this change but can be
   simplified as performed in the sample in the commit ``33dcbe37cfd3593e8c6e9cfd218dd31fdd533598``.
 
+* Samples and projects using the :ref:`native simulator <native_sim>` now require specifying the
+  ``--snippet`` :ref:`video-sw-generator <snippet-video-sw-generator>` to build correctly.
+
 Audio
 =====
 

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -278,6 +278,7 @@ New APIs and options
   * :c:func:`video_api_ctrl_t`
   * :c:func:`video_query_ctrl`
   * :c:func:`video_print_ctrl`
+  * :ref:`video-sw-generator <snippet-video-sw-generator>`
 
 * PCIe
 

--- a/samples/drivers/video/capture/README.rst
+++ b/samples/drivers/video/capture/README.rst
@@ -83,14 +83,6 @@ using the :ref:`dvp_20pin_ov7670` and :ref:`lcd_par_s035` connected to the board
    :goals: build
    :compact:
 
-For :ref:`native_sim`, build this sample application with the following commands:
-
-.. zephyr-app-commands::
-   :zephyr-app: samples/drivers/video/capture
-   :board: native_sim
-   :goals: build
-   :compact:
-
 For testing purpose and without the need of any real video capture and/or display hardwares,
 a video software pattern generator is supported by the above build commands without
 specifying the shields, and using :ref:`snippet-video-sw-generator`:

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -22,6 +22,10 @@ LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 #endif
 
+#if !DT_HAS_CHOSEN(zephyr_camera)
+#error No camera chosen in devicetree. Missing "--shield" or "--snippet video-sw-generator" flag?
+#endif
+
 #if DT_HAS_CHOSEN(zephyr_display)
 static inline int display_setup(const struct device *const display_dev, const uint32_t pixfmt)
 {

--- a/samples/drivers/video/capture_to_lvgl/src/main.c
+++ b/samples/drivers/video/capture_to_lvgl/src/main.c
@@ -14,6 +14,14 @@
 
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
+#if !DT_HAS_CHOSEN(zephyr_camera)
+#error No camera chosen in devicetree. Missing "--shield" or "--snippet video-sw-generator" flag?
+#endif
+
+#if !DT_HAS_CHOSEN(zephyr_display)
+#error No display chosen in devicetree. Missing "--shield" flag?
+#endif
+
 int main(void)
 {
 	struct video_buffer *buffers[2];


### PR DESCRIPTION
After #88780 got merged, the `video-sw-generator` requires new command line flags to build.
This can be misleading and some confusion can be avoided as proposed through these commits:
- samples: drivers: video: add `DT_HAS_CHOSEN()` safeguards
- samples: drivers: video: capture: remove invalid build instruction 
- doc: release: mention new video-sw-generator snippet 

