### PR TITLE
pm: policy: fix mocks of CONFIG_PM_POLICY_DEVICE_CONSTRAINTS

### DIFF
--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -157,9 +157,7 @@ static int mcux_flexcomm_transfer(const struct device *dev,
 
 	k_sem_take(&data->lock, K_FOREVER);
 
-#ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
 	pm_policy_device_power_lock_get(dev);
-#endif
 
 	/* Iterate over all the messages */
 	for (int i = 0; i < num_msgs; i++) {
@@ -215,9 +213,7 @@ static int mcux_flexcomm_transfer(const struct device *dev,
 		msgs++;
 	}
 
-#ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
 	pm_policy_device_power_lock_put(dev);
-#endif
 
 	k_sem_give(&data->lock);
 

--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -430,9 +430,7 @@ static int mipi_dbi_lcdic_write_display(const struct device *dev,
 		goto release_sem;
 	}
 
-#ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
 	pm_policy_device_power_lock_get(dev);
-#endif
 
 	ret = mipi_dbi_lcdic_configure(dev, dbi_config);
 	if (ret) {
@@ -527,9 +525,7 @@ static int mipi_dbi_lcdic_write_display(const struct device *dev,
 	}
 
 release_power_lock:
-#ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
 	pm_policy_device_power_lock_put(dev);
-#endif
 
 release_sem:
 	k_sem_give(&dev_data->lock);
@@ -554,9 +550,7 @@ static int mipi_dbi_lcdic_write_cmd(const struct device *dev,
 		goto release_sem;
 	}
 
-#ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
 	pm_policy_device_power_lock_get(dev);
-#endif
 
 	ret = mipi_dbi_lcdic_configure(dev, dbi_config);
 	if (ret) {
@@ -632,9 +626,7 @@ static int mipi_dbi_lcdic_write_cmd(const struct device *dev,
 	}
 
 release_power_lock:
-#ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
 	pm_policy_device_power_lock_put(dev);
-#endif
 
 release_sem:
 	k_sem_give(&dev_data->lock);
@@ -821,9 +813,7 @@ static void mipi_dbi_lcdic_isr(const struct device *dev)
 			base->IMR |= LCDIC_ALL_INTERRUPTS;
 			/* All data has been sent. */
 			k_sem_give(&data->xfer_sem);
-#ifdef CONFIG_PM_POLICY_DEVICE_CONSTRAINTS
 			pm_policy_device_power_lock_put(dev);
-#endif
 		} else {
 			/* Command done. Queue next command */
 			data->cmd_bytes = MIN(data->xfer_bytes, LCDIC_MAX_XFER);

--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -205,32 +205,6 @@ void pm_policy_event_update(struct pm_policy_event *evt, int64_t uptime_ticks);
 void pm_policy_event_unregister(struct pm_policy_event *evt);
 
 /**
- * @brief Increase power state locks.
- *
- * Set power state locks in all power states that disable power in the given
- * device.
- *
- * @param dev Device reference.
- *
- * @see pm_policy_device_power_lock_put()
- * @see pm_policy_state_lock_get()
- */
-void pm_policy_device_power_lock_get(const struct device *dev);
-
-/**
- * @brief Decrease power state locks.
- *
- * Remove power state locks in all power states that disable power in the given
- * device.
- *
- * @param dev Device reference.
- *
- * @see pm_policy_device_power_lock_get()
- * @see pm_policy_state_lock_put()
- */
-void pm_policy_device_power_lock_put(const struct device *dev);
-
-/**
  * @brief Check if a state will disable a device
  *
  * This function allows client code to check if a state will disable a device.
@@ -295,6 +269,42 @@ static inline void pm_policy_event_unregister(struct pm_policy_event *evt)
 	ARG_UNUSED(evt);
 }
 
+static inline int64_t pm_policy_next_event_ticks(void)
+{
+	return -1;
+}
+
+#endif /* CONFIG_PM */
+
+#if defined(CONFIG_PM_POLICY_DEVICE_CONSTRAINTS) || defined(__DOXYGEN__)
+/**
+ * @brief Increase power state locks.
+ *
+ * Set power state locks in all power states that disable power in the given
+ * device.
+ *
+ * @param dev Device reference.
+ *
+ * @see pm_policy_device_power_lock_put()
+ * @see pm_policy_state_lock_get()
+ */
+void pm_policy_device_power_lock_get(const struct device *dev);
+
+/**
+ * @brief Decrease power state locks.
+ *
+ * Remove power state locks in all power states that disable power in the given
+ * device.
+ *
+ * @param dev Device reference.
+ *
+ * @see pm_policy_device_power_lock_get()
+ * @see pm_policy_state_lock_put()
+ */
+void pm_policy_device_power_lock_put(const struct device *dev);
+
+#else
+
 static inline void pm_policy_device_power_lock_get(const struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -304,13 +314,7 @@ static inline void pm_policy_device_power_lock_put(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 }
-
-static inline int64_t pm_policy_next_event_ticks(void)
-{
-	return -1;
-}
-
-#endif /* CONFIG_PM */
+#endif /* CONFIG_PM_POLICY_DEVICE_CONSTRAINTS */
 
 #if defined(CONFIG_PM) || defined(CONFIG_PM_POLICY_LATENCY_STANDALONE) || defined(__DOXYGEN__)
 /**


### PR DESCRIPTION
The APIs `pm_policy_device_power_lock_get` and `pm_policy_device_power_lock_put` are not mocked properly as they should be excluded based on `CONFIG_PM_POLICY_DEVICE_CONSTRAINTS`, not `CONFIG_PM`.