### PR TITLE
hal_rpi_pico: require GNU extensions for pico SDK

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -4,7 +4,6 @@ include(ExternalProject)
 
 if(CONFIG_HAS_RPI_PICO)
   zephyr_library()
-  set_property(TARGET ${ZEPHYR_CURRENT_LIBRARY} PROPERTY C_STANDARD 11)
 
   set(rp2_common_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/rp2_common)
   set(rp2xxx_dir ${ZEPHYR_HAL_RPI_PICO_MODULE_DIR}/src/${CONFIG_SOC_SERIES})

--- a/modules/hal_rpi_pico/Kconfig
+++ b/modules/hal_rpi_pico/Kconfig
@@ -3,6 +3,8 @@
 
 config HAS_RPI_PICO
 	bool
+	# pico-sdk makes use of typeof - and for that we need GNU extensions!
+	select GNU_C_EXTENSIONS
 
 config PICOSDK_USE_UART
 	bool


### PR DESCRIPTION
The pico SDK uses typeof() and the current approach, in CMakeLists.txt, wasn't enough. This commit adds a
dependency on GNU extensions to ensure the builds pass.

See #90936 for full details.