### PR TITLE
pm: device_runtime: fix unbalanced domain get/put

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -103,6 +103,12 @@ static int runtime_suspend(const struct device *dev, bool async,
 		}
 
 		pm->base.state = PM_DEVICE_STATE_SUSPENDED;
+
+		/* Now put the domain */
+		if (atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
+			(void)pm_device_runtime_put(PM_DOMAIN(dev->pm_base));
+			atomic_clear_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_CLAIMED);
+		}
 	}
 
 unlock:
@@ -139,6 +145,7 @@ static void runtime_suspend_work(struct k_work *work)
 	if ((ret == 0) &&
 	    atomic_test_bit(&pm->base.flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
 		(void)pm_device_runtime_put(PM_DOMAIN(&pm->base));
+		atomic_clear_bit(&pm->base.flags, PM_DEVICE_FLAG_PD_CLAIMED);
 	}
 
 	__ASSERT(ret == 0, "Could not suspend device (%d)", ret);
@@ -224,7 +231,7 @@ int pm_device_runtime_get(const struct device *dev)
 	 */
 	const struct device *domain = PM_DOMAIN(&pm->base);
 
-	if (domain != NULL) {
+	if (domain != NULL && !atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
 		ret = pm_device_runtime_get(domain);
 		if (ret != 0) {
 			goto unlock;
@@ -350,14 +357,6 @@ int pm_device_runtime_put(const struct device *dev)
 		k_spin_unlock(&pm_sync->lock, k);
 	} else {
 		ret = runtime_suspend(dev, false, K_NO_WAIT);
-
-		/*
-		 * Now put the domain
-		 */
-		if ((ret == 0) &&
-		    atomic_test_bit(&dev->pm_base->flags, PM_DEVICE_FLAG_PD_CLAIMED)) {
-			ret = pm_device_runtime_put(PM_DOMAIN(dev->pm_base));
-		}
 	}
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_put, dev, ret);
 

--- a/tests/subsys/pm/device_power_domains/src/main.c
+++ b/tests/subsys/pm/device_power_domains/src/main.c
@@ -114,6 +114,7 @@ ZTEST(device_power_domain, test_device_power_domain)
 	/* Directly request the supported device multiple times */
 	pm_device_runtime_get(dev);
 	pm_device_runtime_get(dev);
+	pm_device_runtime_get(dev);
 	/* Directly release the supported device the first time, check all still powered */
 	pm_device_runtime_put(dev);
 	zassert_true(pm_device_is_powered(dev), "");
@@ -121,8 +122,11 @@ ZTEST(device_power_domain, test_device_power_domain)
 	zassert_equal(PM_DEVICE_STATE_ACTIVE, state, "");
 	pm_device_state_get(reg_1, &state);
 	zassert_equal(PM_DEVICE_STATE_ACTIVE, state, "");
-	/* Directly release the supported device the second time, check all off */
-	pm_device_runtime_put(dev);
+	/* Release the supported device the twice using async */
+	zassert_ok(pm_device_runtime_put_async(dev, K_SECONDS(1)));
+	zassert_ok(pm_device_runtime_put_async(dev, K_SECONDS(1)));
+	k_sleep(K_SECONDS(2));
+	/* Check all off */
 	zassert_false(pm_device_is_powered(dev), "");
 	pm_device_state_get(dev, &state);
 	zassert_equal(PM_DEVICE_STATE_OFF, state, "");


### PR DESCRIPTION
pm_device_runtime has inconsistent behavior regarding getting and putting a device's domain. This commit aligns it to get the domain only once, once device is resumed, and put only once, once device is
suspended.