### PR TITLE
MAINTAINERS: Update filter for NXP Xtensa platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4002,6 +4002,10 @@ NXP Platforms (Xtensa):
   files:
     - soc/nxp/imx/*/adsp/
     - soc/nxp/imxrt/imxrt5xx/f1/
+    - soc/nxp/imxrt/imxrt7xx/hifi1/
+    - soc/nxp/imxrt/*/hifi4/
+    - soc/nxp/imxrt/imxrt[567]xx/CMakeLists.txt
+    - soc/nxp/imxrt/imxrt[567]xx/Kconfig*
   labels:
     - "platform: NXP Xtensa"
   description: NXP Xtensa platforms


### PR DESCRIPTION
Add new filters for Xtensa platforms:
	* imxrt7xx supports now a hifi1 core
	* imxrt6xx/imxrt7xx support now a hifi4 core

Kconfig* and CMakeList.txt files could be updated for Xtensa related code so add them to the filters too.