### PR TITLE
github: hello_world_multiplatform: set the toolchain list

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: zephyrproject-rtos/action-zephyr-setup@f7b70269a8eb01f70c8e710891e4c94972a2f6b4 # v1.0.6
         with:
           app-path: zephyr
-          toolchains: all
+          toolchains: aarch64-zephyr-elf:arc-zephyr-elf:arc64-zephyr-elf:arm-zephyr-eabi:mips-zephyr-elf:riscv64-zephyr-elf:sparc-zephyr-elf:x86_64-zephyr-elf:xtensa-dc233c_zephyr-elf:xtensa-sample_controller32_zephyr-elf
 
       - name: Build firmware
         working-directory: zephyr


### PR DESCRIPTION
The SDK is growing bigger and bigger, set the toolchain list so we only fetch the ones needed by the tests we run, save some disk space, apparently this workflow is getting close.