### PR TITLE
drivers: gpio: smartbond: fix PM_DEVICE_DEFINE usage

### DIFF
--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -430,9 +430,9 @@ static DEVICE_API(gpio, gpio_smartbond_drv_api_funcs) = {
 		return 0;								\
 	}										\
 											\
-	PM_DEVICE_DEFINE(id, gpio_smartbond_pm_action);					\
+	PM_DEVICE_DT_INST_DEFINE(id, gpio_smartbond_pm_action);				\
 	DEVICE_DT_INST_DEFINE(id, gpio_smartbond_init_##id,				\
-			      PM_DEVICE_GET(id),					\
+			      PM_DEVICE_DT_INST_GET(id),				\
 			      &gpio_smartbond_data_##id,				\
 			      &gpio_smartbond_config_##id,				\
 			      PRE_KERNEL_1,						\


### PR DESCRIPTION
The gpio_smartbond driver incorrectly uses the static PM_DEVICE_DEFINE() and PM_DEVICE_GET() macros when creating a driver instance from a devicetree instance number.

Update to use PM_DEVICE_DT_INST_DEFINE() and
PM_DEVICE_DT_INST_GET() macros.