### PR TITLE
drivers: wifi: siwx91x: Improve error handling and interface status

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -282,11 +282,13 @@ static int siwx91x_apply_power_save(struct siwx91x_dev *sidev)
 
 	interface = sl_wifi_get_default_interface();
 	if (FIELD_GET(SIWX91X_INTERFACE_MASK, interface) != SL_WIFI_CLIENT_INTERFACE) {
-		return 0;
+		LOG_ERR("Wi-Fi not in station mode");
+		return -EINVAL;
 	}
 
 	if (sidev->state == WIFI_STATE_INTERFACE_DISABLED) {
-		return 0;
+		LOG_ERR("Command given in invalid state");
+		return -EINVAL;
 	}
 
 	sl_wifi_get_performance_profile(&sl_ps_profile);

--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -481,7 +481,7 @@ static unsigned int siwx91x_on_join(sl_wifi_event_t event,
 static int siwx91x_status(const struct device *dev, struct wifi_iface_status *status)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
-	sl_si91x_rsp_wireless_info_t wlan_info = { };
+	sl_wifi_wireless_info_t wlan_info = { };
 	struct siwx91x_dev *sidev = dev->data;
 	uint8_t join_config;
 	int32_t rssi;
@@ -504,7 +504,6 @@ static int siwx91x_status(const struct device *dev, struct wifi_iface_status *st
 
 	strncpy(status->ssid, wlan_info.ssid, WIFI_SSID_MAX_LEN);
 	status->ssid_len = strlen(status->ssid);
-	memcpy(status->bssid, wlan_info.bssid, WIFI_MAC_ADDR_LEN);
 	status->wpa3_ent_type = WIFI_WPA3_ENTERPRISE_NA;
 
 	if (interface & SL_WIFI_2_4GHZ_INTERFACE) {
@@ -555,6 +554,7 @@ static int siwx91x_status(const struct device *dev, struct wifi_iface_status *st
 
 		status->beacon_interval = sys_get_le16(operational_statistics.beacon_interval);
 		status->dtim_period = operational_statistics.dtim_period;
+		memcpy(status->bssid, wlan_info.bssid, WIFI_MAC_ADDR_LEN);
 	} else if (FIELD_GET(SIWX91X_INTERFACE_MASK, interface) == SL_WIFI_AP_INTERFACE) {
 		sl_wifi_ap_configuration_t sl_ap_cfg = { };
 
@@ -571,6 +571,7 @@ static int siwx91x_status(const struct device *dev, struct wifi_iface_status *st
 		status->beacon_interval = sl_ap_cfg.beacon_interval;
 		status->dtim_period = sl_ap_cfg.dtim_beacon_count;
 		wlan_info.sec_type = (uint8_t)sl_ap_cfg.security;
+		memcpy(status->bssid, wlan_info.mac_address, WIFI_MAC_ADDR_LEN);
 	} else {
 		status->link_mode = WIFI_LINK_MODE_UNKNOWN;
 		status->iface_mode = WIFI_MODE_UNKNOWN;

--- a/soc/silabs/silabs_siwx91x/siwg917/nwp.c
+++ b/soc/silabs/silabs_siwx91x/siwg917/nwp.c
@@ -102,7 +102,10 @@ static void siwx91x_configure_ap_mode(sl_si91x_boot_configuration_t *boot_config
 {
 	boot_config->oper_mode = SL_SI91X_ACCESS_POINT_MODE;
 	boot_config->coex_mode = SL_SI91X_WLAN_ONLY_MODE;
-	boot_config->custom_feature_bit_map |= SL_SI91X_CUSTOM_FEAT_LIMIT_PACKETS_PER_STA;
+
+	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X_LIMIT_PACKET_BUF_PER_STA)) {
+		boot_config->custom_feature_bit_map |= SL_SI91X_CUSTOM_FEAT_LIMIT_PACKETS_PER_STA;
+	}
 
 	if (hidden_ssid) {
 		boot_config->custom_feature_bit_map |= SL_SI91X_CUSTOM_FEAT_AP_IN_HIDDEN_MODE;
@@ -200,6 +203,11 @@ int siwx91x_get_nwp_config(sl_wifi_device_configuration_t *get_config, uint8_t w
 	}
 
 	if (IS_ENABLED(CONFIG_WIFI_SILABS_SIWX91X)) {
+		if (!IS_ENABLED(CONFIG_PM)) {
+			boot_config->custom_feature_bit_map |=
+				SL_SI91X_CUSTOM_FEAT_SOC_CLK_CONFIG_160MHZ;
+		}
+
 		siwx91x_configure_network_stack(boot_config, wifi_oper_mode);
 	}
 


### PR DESCRIPTION
This PR addresses key issues in the siwx91x Wi-Fi driver:

- Corrected BSSID handling in interface status (aligned with HAL Silabs SDK 3.5.0).
- Restored missing SOC clock configuration and enabled default packet limit per STA.
- Fixed power save mode error handling (AP mode now returns -EINVAL).