### PR TITLE
net: ip: Relax alignment requirements of in(6)_addr/sockaddr_ll

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -202,7 +202,7 @@ struct sockaddr_ll {
 	uint8_t     sll_pkttype;  /**< Packet type                        */
 	uint8_t     sll_halen;    /**< Length of address                  */
 	uint8_t     sll_addr[8];  /**< Physical-layer address, big endian */
-};
+} __packed __aligned(2);
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -146,7 +146,7 @@ struct in6_addr {
 		uint16_t s6_addr16[8]; /**< In big endian */
 		uint32_t s6_addr32[4]; /**< In big endian */
 	};
-};
+} __packed;
 
 /** Binary size of the IPv6 address */
 #define NET_IPV6_ADDR_SIZE 16
@@ -159,7 +159,7 @@ struct in_addr {
 		uint32_t s4_addr32[1]; /**< In big endian */
 		uint32_t s_addr; /**< In big endian, for POSIX compatibility. */
 	};
-};
+} __packed;
 
 /** Binary size of the IPv4 address */
 #define NET_IPV4_ADDR_SIZE 4

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -682,10 +682,10 @@ union net_proto_header {
  */
 static inline bool net_ipv6_is_addr_loopback(struct in6_addr *addr)
 {
-	return UNALIGNED_GET(&addr->s6_addr32[0]) == 0 &&
-		UNALIGNED_GET(&addr->s6_addr32[1]) == 0 &&
-		UNALIGNED_GET(&addr->s6_addr32[2]) == 0 &&
-		ntohl(UNALIGNED_GET(&addr->s6_addr32[3])) == 1;
+	return addr->s6_addr32[0] == 0 &&
+		addr->s6_addr32[1] == 0 &&
+		addr->s6_addr32[2] == 0 &&
+		ntohl(addr->s6_addr32[3]) == 1;
 }
 
 /**
@@ -826,7 +826,7 @@ static inline bool net_ipv4_is_addr_loopback(struct in_addr *addr)
  */
 static inline bool net_ipv4_is_addr_unspecified(const struct in_addr *addr)
 {
-	return UNALIGNED_GET(&addr->s_addr) == 0;
+	return addr->s_addr == 0;
 }
 
 /**
@@ -838,7 +838,7 @@ static inline bool net_ipv4_is_addr_unspecified(const struct in_addr *addr)
  */
 static inline bool net_ipv4_is_addr_mcast(const struct in_addr *addr)
 {
-	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xF0000000) == 0xE0000000;
+	return (ntohl(addr->s_addr) & 0xF0000000) == 0xE0000000;
 }
 
 /**
@@ -850,7 +850,7 @@ static inline bool net_ipv4_is_addr_mcast(const struct in_addr *addr)
  */
 static inline bool net_ipv4_is_ll_addr(const struct in_addr *addr)
 {
-	return (ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xFFFF0000) == 0xA9FE0000;
+	return (ntohl(addr->s_addr) & 0xFFFF0000) == 0xA9FE0000;
 }
 
 /**
@@ -866,7 +866,7 @@ static inline bool net_ipv4_is_private_addr(const struct in_addr *addr)
 {
 	uint32_t masked_24, masked_16, masked_12, masked_10, masked_8;
 
-	masked_24 = ntohl(UNALIGNED_GET(&addr->s_addr)) & 0xFFFFFF00;
+	masked_24 = ntohl(addr->s_addr) & 0xFFFFFF00;
 	masked_16 = masked_24 & 0xFFFF0000;
 	masked_12 = masked_24 & 0xFFF00000;
 	masked_10 = masked_24 & 0xFFC00000;
@@ -890,7 +890,7 @@ static inline bool net_ipv4_is_private_addr(const struct in_addr *addr)
  *  @return Destination address.
  */
 #define net_ipaddr_copy(dest, src) \
-	UNALIGNED_PUT(UNALIGNED_GET(src), dest)
+	*(dest) = *(src)
 
 /**
  *  @brief Copy an IPv4 address raw buffer
@@ -927,7 +927,7 @@ static inline void net_ipv6_addr_copy_raw(uint8_t *dest,
 static inline bool net_ipv4_addr_cmp(const struct in_addr *addr1,
 				     const struct in_addr *addr2)
 {
-	return UNALIGNED_GET(&addr1->s_addr) == UNALIGNED_GET(&addr2->s_addr);
+	return addr1->s_addr == addr2->s_addr;
 }
 
 /**
@@ -983,7 +983,7 @@ static inline bool net_ipv6_addr_cmp_raw(const uint8_t *addr1,
  */
 static inline bool net_ipv6_is_ll_addr(const struct in6_addr *addr)
 {
-	return UNALIGNED_GET(&addr->s6_addr16[0]) == htons(0xFE80);
+	return addr->s6_addr16[0] == htons(0xFE80);
 }
 
 /**
@@ -995,7 +995,7 @@ static inline bool net_ipv6_is_ll_addr(const struct in6_addr *addr)
  */
 static inline bool net_ipv6_is_sl_addr(const struct in6_addr *addr)
 {
-	return UNALIGNED_GET(&addr->s6_addr16[0]) == htons(0xFEC0);
+	return addr->s6_addr16[0] == htons(0xFEC0);
 }
 
 
@@ -1036,7 +1036,7 @@ static inline bool net_ipv6_is_private_addr(const struct in6_addr *addr)
 {
 	uint32_t masked_32, masked_7;
 
-	masked_32 = ntohl(UNALIGNED_GET(&addr->s6_addr32[0]));
+	masked_32 = ntohl(addr->s6_addr32[0]);
 	masked_7 = masked_32 & 0xfc000000;
 
 	return masked_32 == 0x20010db8 || /* 2001:db8::/32 */
@@ -1148,10 +1148,10 @@ static inline bool net_ipv4_is_my_addr(const struct in_addr *addr)
  */
 static inline bool net_ipv6_is_addr_unspecified(const struct in6_addr *addr)
 {
-	return UNALIGNED_GET(&addr->s6_addr32[0]) == 0 &&
-		UNALIGNED_GET(&addr->s6_addr32[1]) == 0 &&
-		UNALIGNED_GET(&addr->s6_addr32[2]) == 0 &&
-		UNALIGNED_GET(&addr->s6_addr32[3]) == 0;
+	return addr->s6_addr32[0] == 0 &&
+		addr->s6_addr32[1] == 0 &&
+		addr->s6_addr32[2] == 0 &&
+		addr->s6_addr32[3] == 0;
 }
 
 /**
@@ -1164,10 +1164,10 @@ static inline bool net_ipv6_is_addr_unspecified(const struct in6_addr *addr)
  */
 static inline bool net_ipv6_is_addr_solicited_node(const struct in6_addr *addr)
 {
-	return UNALIGNED_GET(&addr->s6_addr32[0]) == htonl(0xff020000) &&
-		UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00000000 &&
-		UNALIGNED_GET(&addr->s6_addr32[2]) == htonl(0x00000001) &&
-		((UNALIGNED_GET(&addr->s6_addr32[3]) & htonl(0xff000000)) ==
+	return addr->s6_addr32[0] == htonl(0xff020000) &&
+		addr->s6_addr32[1] == 0x00000000 &&
+		addr->s6_addr32[2] == htonl(0x00000001) &&
+		((addr->s6_addr32[3] & htonl(0xff000000)) ==
 		 htonl(0xff000000));
 }
 
@@ -1298,12 +1298,12 @@ static inline bool net_ipv6_is_addr_mcast_org(const struct in6_addr *addr)
 static inline bool net_ipv6_is_addr_mcast_group(const struct in6_addr *addr,
 						const struct in6_addr *group)
 {
-	return UNALIGNED_GET(&addr->s6_addr16[1]) == group->s6_addr16[1] &&
-		UNALIGNED_GET(&addr->s6_addr16[2]) == group->s6_addr16[2] &&
-		UNALIGNED_GET(&addr->s6_addr16[3]) == group->s6_addr16[3] &&
-		UNALIGNED_GET(&addr->s6_addr32[1]) == group->s6_addr32[1] &&
-		UNALIGNED_GET(&addr->s6_addr32[2]) == group->s6_addr32[1] &&
-		UNALIGNED_GET(&addr->s6_addr32[3]) == group->s6_addr32[3];
+	return addr->s6_addr16[1] == group->s6_addr16[1] &&
+		addr->s6_addr16[2] == group->s6_addr16[2] &&
+		addr->s6_addr16[3] == group->s6_addr16[3] &&
+		addr->s6_addr32[1] == group->s6_addr32[1] &&
+		addr->s6_addr32[2] == group->s6_addr32[1] &&
+		addr->s6_addr32[3] == group->s6_addr32[3];
 }
 
 /**
@@ -1370,15 +1370,15 @@ void net_ipv6_addr_create_solicited_node(const struct in6_addr *src,
 {
 	dst->s6_addr[0]   = 0xFF;
 	dst->s6_addr[1]   = 0x02;
-	UNALIGNED_PUT(0, &dst->s6_addr16[1]);
-	UNALIGNED_PUT(0, &dst->s6_addr16[2]);
-	UNALIGNED_PUT(0, &dst->s6_addr16[3]);
-	UNALIGNED_PUT(0, &dst->s6_addr16[4]);
+	dst->s6_addr16[1] = 0;
+	dst->s6_addr16[2] = 0;
+	dst->s6_addr16[3] = 0;
+	dst->s6_addr16[4] = 0;
 	dst->s6_addr[10]  = 0U;
 	dst->s6_addr[11]  = 0x01;
 	dst->s6_addr[12]  = 0xFF;
 	dst->s6_addr[13]  = src->s6_addr[13];
-	UNALIGNED_PUT(UNALIGNED_GET(&src->s6_addr16[7]), &dst->s6_addr16[7]);
+	dst->s6_addr16[7] = src->s6_addr16[7];
 }
 
 /** @brief Construct an IPv6 address from eight 16-bit words.
@@ -1399,14 +1399,14 @@ static inline void net_ipv6_addr_create(struct in6_addr *addr,
 					uint16_t addr4, uint16_t addr5,
 					uint16_t addr6, uint16_t addr7)
 {
-	UNALIGNED_PUT(htons(addr0), &addr->s6_addr16[0]);
-	UNALIGNED_PUT(htons(addr1), &addr->s6_addr16[1]);
-	UNALIGNED_PUT(htons(addr2), &addr->s6_addr16[2]);
-	UNALIGNED_PUT(htons(addr3), &addr->s6_addr16[3]);
-	UNALIGNED_PUT(htons(addr4), &addr->s6_addr16[4]);
-	UNALIGNED_PUT(htons(addr5), &addr->s6_addr16[5]);
-	UNALIGNED_PUT(htons(addr6), &addr->s6_addr16[6]);
-	UNALIGNED_PUT(htons(addr7), &addr->s6_addr16[7]);
+	addr->s6_addr16[0] = htons(addr0);
+	addr->s6_addr16[1] = htons(addr1);
+	addr->s6_addr16[2] = htons(addr2);
+	addr->s6_addr16[3] = htons(addr3);
+	addr->s6_addr16[4] = htons(addr4);
+	addr->s6_addr16[5] = htons(addr5);
+	addr->s6_addr16[6] = htons(addr6);
+	addr->s6_addr16[7] = htons(addr7);
 }
 
 /**
@@ -1453,9 +1453,9 @@ static inline void net_ipv6_addr_create_v4_mapped(const struct in_addr *addr4,
  */
 static inline bool net_ipv6_addr_is_v4_mapped(const struct in6_addr *addr)
 {
-	if (UNALIGNED_GET(&addr->s6_addr32[0]) == 0 &&
-	    UNALIGNED_GET(&addr->s6_addr32[1]) == 0 &&
-	    UNALIGNED_GET(&addr->s6_addr16[5]) == 0xffff) {
+	if (addr->s6_addr32[0] == 0 &&
+	    addr->s6_addr32[1] == 0 &&
+	    addr->s6_addr16[5] == 0xffff) {
 		return true;
 	}
 

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -122,36 +122,36 @@ static int get_ihpc_inlined_size(uint16_t iphc)
 static inline bool net_6lo_ll_prefix_padded_with_zeros(struct in6_addr *addr)
 {
 	return (net_ipv6_is_ll_addr(addr) &&
-		(UNALIGNED_GET(&addr->s6_addr16[1]) == 0x00) &&
-		(UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00));
+		(addr->s6_addr16[1] == 0x00) &&
+		(addr->s6_addr32[1] == 0x00));
 }
 
 static inline bool net_6lo_addr_16_bit_compressible(struct in6_addr *addr)
 {
-	return ((UNALIGNED_GET(&addr->s6_addr32[2]) == htonl(0xFFu)) &&
-		 (UNALIGNED_GET(&addr->s6_addr16[6]) == htons(0xFE00u)));
+	return ((addr->s6_addr32[2] == htonl(0xFFu)) &&
+		 (addr->s6_addr16[6] == htons(0xFE00u)));
 }
 
 static inline bool net_6lo_maddr_8_bit_compressible(struct in6_addr *addr)
 {
 	return ((addr->s6_addr[1] == 0x02) &&
-		 (UNALIGNED_GET(&addr->s6_addr16[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr32[2]) == 0x00) &&
+		 (addr->s6_addr16[1] == 0x00) &&
+		 (addr->s6_addr32[1] == 0x00) &&
+		 (addr->s6_addr32[2] == 0x00) &&
 		 (addr->s6_addr[14] == 0x00));
 }
 
 static inline bool net_6lo_maddr_32_bit_compressible(struct in6_addr *addr)
 {
-	return ((UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr32[2]) == 0x00) &&
+	return ((addr->s6_addr32[1] == 0x00) &&
+		 (addr->s6_addr32[2] == 0x00) &&
 		 (addr->s6_addr[12] == 0x00));
 }
 
 static inline bool net_6lo_maddr_48_bit_compressible(struct in6_addr *addr)
 {
-	return ((UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr16[4]) == 0x00) &&
+	return ((addr->s6_addr32[1] == 0x00) &&
+		 (addr->s6_addr16[4] == 0x00) &&
 		 (addr->s6_addr[10] == 0x00));
 }
 

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -975,12 +975,10 @@ int net_ipv6_addr_generate_iid(struct net_if *iface,
 		int ret;
 
 		if (prefix == NULL) {
-			UNALIGNED_PUT(htonl(0xfe800000), &tmp_prefix.s6_addr32[0]);
+			tmp_prefix.s6_addr32[0] = htonl(0xfe800000);
 		} else {
-			UNALIGNED_PUT(UNALIGNED_GET(&prefix->s6_addr32[0]),
-				      &tmp_prefix.s6_addr32[0]);
-			UNALIGNED_PUT(UNALIGNED_GET(&prefix->s6_addr32[1]),
-				      &tmp_prefix.s6_addr32[1]);
+			tmp_prefix.s6_addr32[0] = prefix->s6_addr32[0];
+			tmp_prefix.s6_addr32[1] = prefix->s6_addr32[1];
 		}
 
 		ret = gen_stable_iid(if_index, &tmp_prefix, network_id, network_id_len,
@@ -992,11 +990,11 @@ int net_ipv6_addr_generate_iid(struct net_if *iface,
 	}
 
 	if (prefix == NULL) {
-		UNALIGNED_PUT(htonl(0xfe800000), &tmp_addr.s6_addr32[0]);
-		UNALIGNED_PUT(0, &tmp_addr.s6_addr32[1]);
+		tmp_addr.s6_addr32[0] = htonl(0xfe800000);
+		tmp_addr.s6_addr32[1] = 0;
 	} else {
-		UNALIGNED_PUT(UNALIGNED_GET(&prefix->s6_addr32[0]), &tmp_addr.s6_addr32[0]);
-		UNALIGNED_PUT(UNALIGNED_GET(&prefix->s6_addr32[1]), &tmp_addr.s6_addr32[1]);
+		tmp_addr.s6_addr32[0] = prefix->s6_addr32[0];
+		tmp_addr.s6_addr32[1] = prefix->s6_addr32[1];
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6_IID_EUI_64)) {
@@ -1006,7 +1004,7 @@ int net_ipv6_addr_generate_iid(struct net_if *iface,
 			 * Universal/Local bit. RFC 6282 ch 3.2.2
 			 */
 			if (lladdr->type == NET_LINK_IEEE802154) {
-				UNALIGNED_PUT(0, &tmp_addr.s6_addr32[2]);
+				tmp_addr.s6_addr32[2] = 0;
 				tmp_addr.s6_addr[11] = 0xff;
 				tmp_addr.s6_addr[12] = 0xfe;
 				tmp_addr.s6_addr[13] = 0U;

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1021,7 +1021,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 			ptr = &maddr->address.in_addr;
 
-		} else if (UNALIGNED_GET(&addr4->sin_addr.s_addr) == INADDR_ANY) {
+		} else if (addr4->sin_addr.s_addr == INADDR_ANY) {
 			if (iface == NULL) {
 				iface = net_if_ipv4_select_src_iface(
 					&net_sin(&context->remote)->sin_addr);

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3623,7 +3623,7 @@ bool net_if_ipv4_addr_mask_cmp(struct net_if *iface,
 			continue;
 		}
 
-		subnet = UNALIGNED_GET(&addr->s_addr) &
+		subnet = addr->s_addr &
 			 ipv4->unicast[i].netmask.s_addr;
 
 		if ((ipv4->unicast[i].ipv4.address.in_addr.s_addr &
@@ -3663,7 +3663,7 @@ static bool ipv4_is_broadcast_address(struct net_if *iface,
 		bcast.s_addr = ipv4->unicast[i].ipv4.address.in_addr.s_addr |
 			       ~ipv4->unicast[i].netmask.s_addr;
 
-		if (bcast.s_addr == UNALIGNED_GET(&addr->s_addr)) {
+		if (bcast.s_addr == addr->s_addr) {
 			ret = true;
 			goto out;
 		}
@@ -3991,7 +3991,7 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 				continue;
 			}
 
-			if (UNALIGNED_GET(&addr->s4_addr32[0]) ==
+			if (addr->s4_addr32[0] ==
 			    ipv4->unicast[i].ipv4.address.in_addr.s_addr) {
 
 				if (ret) {
@@ -4061,7 +4061,7 @@ struct in_addr net_if_ipv4_get_netmask_by_addr(struct net_if *iface,
 			continue;
 		}
 
-		subnet = UNALIGNED_GET(&addr->s_addr) &
+		subnet = addr->s_addr &
 			 ipv4->unicast[i].netmask.s_addr;
 
 		if ((ipv4->unicast[i].ipv4.address.in_addr.s_addr &
@@ -4102,7 +4102,7 @@ bool net_if_ipv4_set_netmask_by_addr(struct net_if *iface,
 			continue;
 		}
 
-		subnet = UNALIGNED_GET(&addr->s_addr) &
+		subnet = addr->s_addr &
 			 ipv4->unicast[i].netmask.s_addr;
 
 		if ((ipv4->unicast[i].ipv4.address.in_addr.s_addr &

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -176,7 +176,10 @@ char *z_impl_net_addr_ntop(sa_family_t family, const void *src,
 
 	if (family == AF_INET6) {
 		addr6 = (struct in6_addr *)src;
+		/* This is safe here, as w is only accessed with UNALIGNED_GET */
+		TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_ADDRESS_OF_PACKED_MEMBER)
 		w = (uint16_t *)addr6->s6_addr16;
+		TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_ADDRESS_OF_PACKED_MEMBER)
 		len = 8;
 
 		if (net_ipv6_addr_is_v4_mapped(addr6)) {

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -429,8 +429,7 @@ int z_impl_net_addr_pton(sa_family_t family, const char *src,
 
 			if (*src != ':') {
 				/* Normal IPv6 16-bit piece */
-				UNALIGNED_PUT(htons(strtol(src, NULL, 16)),
-					      &addr->s6_addr16[i]);
+				addr->s6_addr16[i] = htons(strtol(src, NULL, 16));
 				src = strchr(src, ':');
 				if (src) {
 					src++;
@@ -446,7 +445,7 @@ int z_impl_net_addr_pton(sa_family_t family, const char *src,
 			/* Two colons in a row */
 
 			for (; i < expected_groups; i++) {
-				UNALIGNED_PUT(0, &addr->s6_addr16[i]);
+				addr->s6_addr16[i] = 0;
 			}
 
 			tmp = strrchr(src, ':');

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -210,8 +210,8 @@ static void setup_iid_address(uint8_t *iid, struct in6_addr *addr)
 {
 	addr->s6_addr[0] = 0xfe;
 	addr->s6_addr[1] = 0x80;
-	UNALIGNED_PUT(0, &addr->s6_addr16[1]);
-	UNALIGNED_PUT(0, &addr->s6_addr32[1]);
+	addr->s6_addr16[1] = 0;
+	addr->s6_addr32[1] = 0;
 	memcpy(&addr->s6_addr[8], iid, PPP_INTERFACE_IDENTIFIER_LEN);
 
 	/* TODO: should we toggle local/global bit */

--- a/tests/net/lib/dns_sd/src/main.c
+++ b/tests/net/lib/dns_sd/src/main.c
@@ -694,7 +694,7 @@ ZTEST(dns_sd, test_setup_dst_addr)
 	zassert_equal(255, ttl, "TTL invalid (%d vs %d)", 255, ttl);
 	zassert_true(net_ipv4_addr_cmp(&addr_v4_expect,
 				       &net_sin(&dst)->sin_addr), "");
-	zassert_equal(8, dst_len, "");
+	zassert_equal(sizeof(struct sockaddr_in), dst_len, "");
 
 	(void)zsock_close(v4);
 
@@ -717,7 +717,7 @@ ZTEST(dns_sd, test_setup_dst_addr)
 	zassert_equal(255, ttl, "Hoplimit invalid (%d vs %d)", 255, ttl);
 	zassert_true(net_ipv6_addr_cmp(&addr_v6_expect,
 				       &net_sin6(&dst)->sin6_addr), "");
-	zassert_equal(24, dst_len, "");
+	zassert_equal(sizeof(struct sockaddr_in6), dst_len, "");
 
 	(void)zsock_close(v6);
 #endif


### PR DESCRIPTION
The in_addr and in6_addr structures currently have a 4-byte alignment
requirement. However, throughout the network subsystem, these structures
are accessed using UNALIGNED_GET/UNALIGNED_PUT macros to safely handle
unaligned memory accesses. This is often necessary as IP addresses do not
always occur aligned in network packets.

This commit reduces the alignment requirement of in_addr and in6_addr
to 1 byte by marking them as packed, reflecting their actual usage.

The struct sockaddr has a minimum alignment requirement of 2 bytes.
It is commonly cast to more specific socket address types
such as sockaddr_in, sockaddr_ll, etc. To ensure safe casting and avoid
potential unaligned memory accesses, these derived structures must not
have a stricter alignment requirement than sockaddr.

This commit reduces the minimum alignment of sockaddr_ll from 4 bytes to
2 bytes, aligning it with sockaddr and preventing possible issues on
architectures that do not tolerate unaligned accesses.

In addition, compiler warnings are generated for potentially problematic
code like taking a pointer with a larger alignment requirement from one
of the struct members.

This change also resolves issues reported by the Undefined Behavior
Sanitizer (UBSAN), which flagged these unaligned accesses as undefined
behavior.

Errors reported by UBSAN fixed by this PR:
```
zephyr/include/zephyr/net/net_ip.h:1151:9: runtime error: member access within misaligned address 0x080b105e for type 'const struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:1151:9: runtime error: member access within misaligned address 0x080c869a for type 'const struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:1151:9: runtime error: member access within misaligned address 0x080e4106 for type 'const struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:1151:9: runtime error: member access within misaligned address 0x080e5646 for type 'const struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080a6a9e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080a961e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080aaffe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080aaffe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab21e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab21e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab21e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab23e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab25e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab2fe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab31e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab3fe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab43e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab47e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab47e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab47e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab4fe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab51e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab5fe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab61e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab67e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab67e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab67e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab6fe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab71e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab73e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab73e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab73e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab81e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab81e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080ab81e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080aba1e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080aba1e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080aba1e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abb7e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abb7e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abb7e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abbfe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abbfe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abbfe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abc5e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abd9e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abd9e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abd9e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abefe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abefe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abefe for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abf7e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abf7e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:685:9: runtime error: member access within misaligned address 0x080abf7e for type 'struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:700:22: runtime error: member access within misaligned address 0x080c8aca for type 'const struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:700:22: runtime error: member access within misaligned address 0x080c8aea for type 'const struct in6_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:817:22: runtime error: member access within misaligned address 0x080be4ce for type 'struct in_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:817:22: runtime error: member access within misaligned address 0x080cb8de for type 'struct in_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:930:9: runtime error: member access within misaligned address 0x0809e3ce for type 'const struct in_addr', which requires 4 byte alignment
zephyr/include/zephyr/net/net_ip.h:930:9: runtime error: member access within misaligned address 0x0809e3ce for type 'const struct in_addr', which requires 4 byte alignment
zephyr/subsys/net/ip/utils.c:179:5: runtime error: member access within misaligned address 0xf42fa232 for type 'struct in6_addr', which requires 4 byte alignment
zephyr/subsys/net/ip/utils.c:179:5: runtime error: member access within misaligned address 0xf42fa232 for type 'struct in6_addr', which requires 4 byte alignment
zephyr/subsys/net/ip/utils.c:179:5: runtime error: member access within misaligned address 0xf49fb232 for type 'struct in6_addr', which requires 4 byte alignment
zephyr/subsys/net/ip/utils.c:802:8: runtime error: member access within misaligned address 0xf69ff1c6 for type 'struct sockaddr_in6', which requires 4 byte alignment
zephyr/subsys/net/ip/utils.c:802:8: runtime error: member access within misaligned address 0xf6aff1c6 for type 'struct sockaddr_in6', which requires 4 byte alignment
zephyr/subsys/net/ip/utils.c:893:8: runtime error: member access within misaligned address 0xf4afb25a for type 'struct sockaddr_in', which requires 4 byte alignment
zephyr/subsys/net/l2/virtual/ipip/ipip.c:277:34: runtime error: member access within misaligned address 0x080d1a26 for type 'struct sockaddr_in', which requires 4 byte alignment
zephyr/subsys/net/l2/virtual/ipip/ipip.c:277:34: runtime error: member access within misaligned address 0x080d1a26 for type 'struct sockaddr_in', which requires 4 byte alignment
zephyr/subsys/net/l2/virtual/ipip/ipip.c:282:35: runtime error: member access within misaligned address 0x080d1a26 for type 'struct sockaddr_in6', which requires 4 byte alignment
zephyr/subsys/net/l2/virtual/ipip/ipip.c:282:35: runtime error: member access within misaligned address 0x080d1a26 for type 'struct sockaddr_in6', which requires 4 byte alignment
zephyr/subsys/tracing/ctf/ctf_top.c:436:9: runtime error: member access within misaligned address 0xf4afb2e2 for type 'struct sockaddr_in', which requires 4 byte alignment
```

This is a step towards fixing #90882.