### PR TITLE
Fix support for tests/drivers/memc on SiWx91x

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
@@ -114,7 +114,7 @@
 	};
 };
 
-&psramctrl0 {
+&memc {
 	clocks = <&clock0 SIWX91X_CLK_QSPI>;
 	pinctrl-0 = <&psram_default>;
 	pinctrl-names = "default";

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.yaml
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.yaml
@@ -16,6 +16,7 @@ supported:
   - flash
   - gpio
   - i2c
+  - memc
   - pwm
   - uart
   - watchdog

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -97,7 +97,7 @@
 			};
 		};
 
-		psramctrl0: memory-controller@12040000 {
+		memc: memory-controller@12040000 {
 			compatible = "silabs,siwx91x-qspi-memory";
 			reg = <0x12040000 0x200>;
 			#address-cells = <1>;

--- a/tests/drivers/memc/ram/testcase.yaml
+++ b/tests/drivers/memc/ram/testcase.yaml
@@ -1,44 +1,10 @@
 tests:
-  drivers.memc.stm32_fmc_nor_psram:
-    tags:
-      - drivers
-      - memc
-    depends_on: memc
-    filter: dt_compat_enabled("st,stm32-fmc-nor-psram")
-  drivers.memc.stm32_sdram:
-    tags:
-      - drivers
-      - memc
-    depends_on: memc
-    filter: dt_compat_enabled("st,stm32-fmc-sdram")
-  drivers.memc.smc_sram:
-    tags:
-      - drivers
-      - memc
-    depends_on: memc
-    filter: dt_compat_enabled("atmel,sam-smc")
-    platform_allow: sam4s_xplained
-    integration_platforms:
-      - sam4s_xplained
-  drivers.memc.sifive_ddr:
+  drivers.memc:
     simulation_exclude:
       - renode
     tags:
       - drivers
       - memc
-    platform_allow: hifive_unmatched/fu740/s7
-  drivers.memc.renesas_ra_sdram:
-    tags:
-      - drivers
-      - memc
     depends_on: memc
-    filter: dt_compat_enabled("renesas,ra-sdram")
-    platform_allow:
-      - ek_ra8d1
-      - ra8d1_vision_board
-  drivers.memc.max32_hpb:
-    tags:
-      - drivers
-      - memc
-    filter: dt_compat_enabled("adi,max32-hpb")
-    platform_allow: max32690evkit/max32690/m4
+    integration_platforms:
+      - sam4s_xplained


### PR DESCRIPTION
The test tests/drivers/memc require a node named `memc`.

In addition, the list of filters declared in tests/drivers/memc seems unnecessary. The various boards should just declare their `memc` capability.