### PR TITLE
manifest: update hal_nxp

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: e0b43431640a565b4500c58fc5e1aaebec2f463d
+      revision: 0481c9885d9e14912b9ba67d0fbc8a5615e83510
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update hal_nxp to fix a debugging issue on MCXW72 when running BLE applications.