### PR TITLE
dts: xilinx: add cadence spi controllers to zynqmp.dtsi

### DIFF
--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -304,6 +304,31 @@
 					IRQ_DEFAULT_PRIORITY>;
 			reg = <0xfd070000 0x30000>;
 		};
-	};
 
+		spi0: spi@ff040000 {
+			compatible = "cdns,spi";
+			reg = <0xff040000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-width = <8>;
+			rx-fifo-depth = <128>;
+			tx-fifo-depth = <128>;
+		};
+
+		spi1: spi@ff050000 {
+			compatible = "cdns,spi";
+			reg = <0xff050000 0x1000>;
+			status = "disabled";
+			interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL
+				      IRQ_DEFAULT_PRIORITY>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			fifo-width = <8>;
+			rx-fifo-depth = <128>;
+			tx-fifo-depth = <128>;
+		};
+	};
 };


### PR DESCRIPTION
Adds spi controller nodes for Cadence SPI controllers in zynqmp.dtsi. A [driver for the Cadence SPI peripheral](https://github.com/zephyrproject-rtos/zephyr/pull/85973) on AMD devices was recently merged into Zephyr, this PR adds support for those peripherals on ZynqMP devices. The driver was confirmed to be functional on a ZUBoard 1CG (XCZU1CG) with the fix in [PR 88777](https://github.com/zephyrproject-rtos/zephyr/pull/88777).