### PR TITLE
dts: vendor: raspberrypi: Default to sysbuild

### DIFF
--- a/dts/vendor/raspberrypi/partitions_2M_default.dtsi
+++ b/dts/vendor/raspberrypi/partitions_2M_default.dtsi
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <raspberrypi/partitions_2M_storage.dtsi>
+#include <raspberrypi/partitions_2M_sysbuild.dtsi>


### PR DESCRIPTION
    Switch the default partitions for `raspberrypi` to use the `sysbuild`
    partitions in order to be consistent with the default partitions for
    other vendor defined partitions.
    
    Please refer to this PR for comments relating to this modification:
     - https://github.com/zephyrproject-rtos/mcuboot/pull/128