### PR TITLE
drivers: sensor: adi: adxl372: Remove logically dead code

### DIFF
--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -365,15 +365,7 @@ static void adxl372_process_status1_cb(struct rtio *r, const struct rtio_sqe *sq
 		return;
 	}
 
-	enum sensor_stream_data_opt data_opt;
-
-	if ((fifo_wmark_cfg != NULL) && (fifo_full_cfg == NULL)) {
-		data_opt = fifo_wmark_cfg->opt;
-	} else if ((fifo_wmark_cfg == NULL) && (fifo_full_cfg != NULL)) {
-		data_opt = fifo_full_cfg->opt;
-	} else {
-		data_opt = MIN(fifo_wmark_cfg->opt, fifo_full_cfg->opt);
-	}
+	enum sensor_stream_data_opt data_opt = MIN(fifo_wmark_cfg->opt, fifo_full_cfg->opt);
 
 	if (data_opt == SENSOR_STREAM_DATA_NOP || data_opt == SENSOR_STREAM_DATA_DROP) {
 		uint8_t *buf;


### PR DESCRIPTION
Remove logically dead if and else-if conditions as shown by the static analysis (#90531 ), replacing with the else statement.

When data_opt is assigned to the MIN of fifo_wmark_cfg and fifo_full_cfg, both those variables will be non-NULL as an earlier condition ensures the function returns if either one of the variables is NULL before assigning to data_opt.

Condition that ensures the function returns if either one of the variables is NULL,

```
	bool fifo_full_irq = false;

	if ((fifo_wmark_cfg != NULL) && (fifo_full_cfg != NULL) &&
	    FIELD_GET(ADXL372_INT1_MAP_FIFO_FULL_MSK, status1)) {
		fifo_full_irq = true;
	}

	if (!fifo_full_irq) {
		gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
		return;
	}
```

Fixes #90531
Fixes #90550 