### PR TITLE
doc: arch: Update file summary for kernel interfaces

### DIFF
--- a/include/zephyr/arch/arc/arch.h
+++ b/include/zephyr/arch/arc/arch.h
@@ -10,7 +10,7 @@
  *
  * This header contains the ARC specific kernel interface.  It is
  * included by the kernel interface architecture-abstraction header
- * include/arch/cpu.h)
+ * (include/zephyr/arch/cpu.h).
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_ARC_ARCH_H_

--- a/include/zephyr/arch/arm/arch.h
+++ b/include/zephyr/arch/arm/arch.h
@@ -10,7 +10,7 @@
  *
  * This header contains the ARM AArch32 specific kernel interface.  It is
  * included by the kernel interface architecture-abstraction header
- * (include/arm/cpu.h)
+ * (include/zephyr/arch/cpu.h).
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_ARCH_H_

--- a/include/zephyr/arch/arm64/arch.h
+++ b/include/zephyr/arch/arm64/arch.h
@@ -10,7 +10,7 @@
  *
  * This header contains the ARM64 specific kernel interface.  It is
  * included by the kernel interface architecture-abstraction header
- * (include/arm64/cpu.h)
+ * (include/zephyr/arch/cpu.h).
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM64_ARCH_H_

--- a/include/zephyr/arch/mips/arch.h
+++ b/include/zephyr/arch/mips/arch.h
@@ -6,6 +6,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief MIPS specific kernel interface header
+ *
+ * This header contains the MIPS specific kernel interface.  It is
+ * included by the kernel interface architecture-abstraction header
+ * (include/zephyr/arch/cpu.h).
+ */
+
 #ifndef ZEPHYR_INCLUDE_ARCH_MIPS_ARCH_H_
 #define ZEPHYR_INCLUDE_ARCH_MIPS_ARCH_H_
 

--- a/include/zephyr/arch/posix/arch.h
+++ b/include/zephyr/arch/posix/arch.h
@@ -8,11 +8,11 @@
 /**
  * @file
  * @brief POSIX arch specific kernel interface header
- * This header contains the POSIX arch specific kernel interface.
- * It is included by the generic kernel interface header (include/arch/cpu.h)
  *
+ * This header contains the POSIX arch specific kernel interface. It is
+ * included by the kernel interface architecture-abstraction header
+ * (include/zephyr/arch/cpu.h).
  */
-
 
 #ifndef ZEPHYR_INCLUDE_ARCH_POSIX_ARCH_H_
 #define ZEPHYR_INCLUDE_ARCH_POSIX_ARCH_H_

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -8,8 +8,10 @@
 /**
  * @file
  * @brief RISCV specific kernel interface header
+ *
  * This header contains the RISCV specific kernel interface.  It is
- * included by the generic kernel interface header (arch/cpu.h)
+ * included by the kernel interface architecture-abstraction header
+ * (include/zephyr/arch/cpu.h).
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_RISCV_ARCH_H_

--- a/include/zephyr/arch/rx/arch.h
+++ b/include/zephyr/arch/rx/arch.h
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Renesas RX specific kernel interface header
+ *
+ * This header contains the Renesas RX specific kernel interface.  It is
+ * included by the kernel interface architecture-abstraction header
+ * (include/zephyr/arch/cpu.h).
+ */
+
 #ifndef ZEPHYR_INCLUDE_ARCH_RX_ARCH_H_
 #define ZEPHYR_INCLUDE_ARCH_RX_ARCH_H_
 

--- a/include/zephyr/arch/sparc/arch.h
+++ b/include/zephyr/arch/sparc/arch.h
@@ -7,8 +7,10 @@
 /**
  * @file
  * @brief SPARC specific kernel interface header
+ *
  * This header contains the SPARC specific kernel interface.  It is
- * included by the generic kernel interface header (arch/cpu.h)
+ * included by the kernel interface architecture-abstraction header
+ * (include/zephyr/arch/cpu.h).
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_SPARC_ARCH_H_

--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -3,6 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief X86 specific kernel interface header
+ *
+ * This header contains the X86 specific kernel interfaces for both
+ * IA-32 and Intel-64.  It is included by the kernel interface
+ * architecture-abstraction header (include/zephyr/arch/cpu.h).
+ */
+
 #ifndef ZEPHYR_INCLUDE_ARCH_X86_ARCH_H_
 #define ZEPHYR_INCLUDE_ARCH_X86_ARCH_H_
 

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -7,8 +7,9 @@
 /**
  * @file
  * @brief IA-32 specific kernel interface header
- * This header contains the IA-32 specific kernel interface.  It is included
- * by the generic kernel interface header (include/arch/cpu.h)
+ *
+ * This header contains the IA-32 portion of the X86 specific kernel
+ * interface (see include/zephyr/arch/x86/cpu.h).
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_X86_IA32_ARCH_H_

--- a/include/zephyr/arch/x86/intel64/arch.h
+++ b/include/zephyr/arch/x86/intel64/arch.h
@@ -3,6 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Intel-64 specific kernel interface header
+ *
+ * This header contains the Intel-64 portion of the X86 specific kernel
+ * interface (see include/zephyr/arch/x86/cpu.h).
+ */
+
 #ifndef ZEPHYR_INCLUDE_ARCH_X86_INTEL64_ARCH_H_
 #define ZEPHYR_INCLUDE_ARCH_X86_INTEL64_ARCH_H_
 

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -6,8 +6,10 @@
 /**
  * @file
  * @brief Xtensa specific kernel interface header
- * This header contains the Xtensa specific kernel interface.  It is included
- * by the generic kernel interface header (include/zephyr/arch/cpu.h)
+ *
+ * This header contains the Xtensa specific kernel interface.  It is
+ * included by the kernel interface architecture-abstraction header
+ * (include/zephyr/arch/cpu.h).
  */
 
 #ifndef ZEPHYR_INCLUDE_ARCH_XTENSA_ARCH_H_


### PR DESCRIPTION
Updates the file summary on the various arch-specific kernel interfaces to accomplish two things:
  1. Fix the path in the comment
  2. Standardize on language/format.