### PR TITLE
soc: esp32c6: Fix clock references

### DIFF
--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -290,7 +290,7 @@
 			reg = <0x6000c000 0x1000>;
 			interrupts = <I2S1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S1_MODULE>;
+			clocks = <&clock ESP32_I2S1_MODULE>;
 			unit = <0>;
 			status = "disabled";
 		};
@@ -354,7 +354,7 @@
 			reg = <0x60012000 DT_SIZE_K(4)>;
 			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PCNT_MODULE>;
+			clocks = <&clock ESP32_PCNT_MODULE>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
since commit e0a915a17880806412871a81ca01a579f96c2c50, rtc is now clock

Fixes CI failures in main such as https://github.com/zephyrproject-rtos/zephyr/actions/runs/15399803763/job/43329468132