### PR TITLE
dts: esp32c6: fix: remove references to removed rtc node

### DIFF
--- a/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
+++ b/dts/riscv/espressif/esp32c6/esp32c6_common.dtsi
@@ -290,7 +290,7 @@
 			reg = <0x6000c000 0x1000>;
 			interrupts = <I2S1_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_I2S1_MODULE>;
+			clocks = <&clock ESP32_I2S1_MODULE>;
 			unit = <0>;
 			status = "disabled";
 		};
@@ -354,7 +354,7 @@
 			reg = <0x60012000 DT_SIZE_K(4)>;
 			interrupts = <PCNT_INTR_SOURCE IRQ_DEFAULT_PRIORITY 0>;
 			interrupt-parent = <&intc>;
-			clocks = <&rtc ESP32_PCNT_MODULE>;
+			clocks = <&clock ESP32_PCNT_MODULE>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
Remove remaining references (#90122). Fixes breakages seen in main-line CI.
References:
- (#90972): https://github.com/zephyrproject-rtos/zephyr/actions/runs/15401009174/job/43333619175?pr=90972
- (#90027): https://github.com/zephyrproject-rtos/zephyr/actions/runs/15401358451/job/43334772935?pr=90027
- (#90964): https://github.com/zephyrproject-rtos/zephyr/actions/runs/15400448349/job/43331776033?pr=90964