### PR TITLE
net: pkt: Fix net_pkt_pull issue

### DIFF
--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2236,21 +2236,12 @@ int net_pkt_pull(struct net_pkt *pkt, size_t length)
 		left -= rem;
 		if (left) {
 			memmove(c_op->pos, c_op->pos+rem, left);
-		} else {
-			struct net_buf *buf = pkt->buffer;
-
-			if (buf) {
-				pkt->buffer = buf->frags;
-				buf->frags = NULL;
-				net_buf_unref(buf);
-			}
-
-			net_pkt_cursor_init(pkt);
 		}
 
 		length -= rem;
 	}
 
+	net_pkt_trim_buffer(pkt);
 	net_pkt_cursor_init(pkt);
 
 	if (length) {


### PR DESCRIPTION
When the cursor has an offset in order to remove some data in the middle, and the pkt->buffer is a link of frags while the removed data is cross frags, the net_pkt_pull cannot work as expected. It can be easily detected in tests/net/net_pkt/src/main.c with ZTEST(net_pkt_pull) by adding an cursor offset via net_pkt_skip(). An typical user scenario is, that we want to keep the TCP/IP header and remove some TCP data.
Fix: #90979 