### PR TITLE
scripts: west_commands: patch: Support Python 3.10

### DIFF
--- a/scripts/west_commands/patch.py
+++ b/scripts/west_commands/patch.py
@@ -530,7 +530,11 @@ class Patch(WestCommand):
     @staticmethod
     def get_file_sha256sum(filename: Path) -> str:
         with open(filename, "rb") as fp:
-            digest = hashlib.file_digest(fp, "sha256")
+            # NOTE: If python 3.11 is the minimum, the following can be replaced with:
+            # digest = hashlib.file_digest(fp, "sha256")
+            digest = hashlib.new("sha256")
+            while chunk := fp.read(2**10):
+                digest.update(chunk)
 
         return digest.hexdigest()
 


### PR DESCRIPTION
The west patch command used hashlib.file_digest which was introduced in Python 3.11.
Replace with a loop to support Python 3.10 (the current minimum).