### PR TITLE
doc: hardware/porting/board_porting: fix minor typo

### DIFF
--- a/doc/hardware/porting/board_porting.rst
+++ b/doc/hardware/porting/board_porting.rst
@@ -164,7 +164,7 @@ The board qualifiers ``nrf5340/cpuapp/ns`` can be read as:
 - ``cpuapp``: The CPU cluster ``cpuapp``, which consists of a single Cortex-M33
   CPU core. The number of cores in a CPU cluster cannot be determined from the
   board qualifiers.
-- ``ns``: a variant, in this case ``ns`` is a common variant name is
+- ``ns``: a variant, in this case ``ns`` is a common variant name in
   Zephyr denoting a non-secure build for boards supporting :ref:`tfm`.
 
 Not all SoCs define CPU clusters or variants. For example a simple board


### PR DESCRIPTION
Correct a minor typo in the `hardware/porting/board_porting` documentation page.