### PR TITLE
STM32U3: provide support for ADC peripherals

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -94,6 +94,12 @@
 	status = "okay";
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_in1_pc0>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -7,6 +7,7 @@ toolchain:
 supported:
   - arduino_gpio
   - dac
+  - adc
   - gpio
   - usart
 ram: 256

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -26,6 +26,7 @@
 #include <stm32_ll_adc.h>
 #include <stm32_ll_system.h>
 #if defined(CONFIG_SOC_SERIES_STM32N6X) || \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
 #include <stm32_ll_pwr.h>
 #endif /* CONFIG_SOC_SERIES_STM32U5X */
@@ -202,6 +203,7 @@ static void adc_stm32_enable_dma_support(ADC_TypeDef *adc)
 	LL_ADC_REG_SetDMATransfer(adc, LL_ADC_REG_DMA_TRANSFER_UNLIMITED);
 #elif defined(CONFIG_SOC_SERIES_STM32H7X) || \
 	defined(CONFIG_SOC_SERIES_STM32N6X) || \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
 	/* H72x ADC3 and U5 ADC4 are different from the rest, but this call works also for them,
 	 * so no need to call their specific function
@@ -899,6 +901,7 @@ static int set_sequencer(const struct device *dev)
 		if (config->sequencer_type == FULLY_CONFIGURABLE) {
 #if defined(CONFIG_SOC_SERIES_STM32H7X) || \
 	defined(CONFIG_SOC_SERIES_STM32N6X) || \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
 			/*
 			 * Each channel in the sequence must be previously enabled in PCSEL.
@@ -1503,7 +1506,7 @@ static void adc_stm32_enable_analog_supply(void)
 {
 #if defined(CONFIG_SOC_SERIES_STM32N6X)
 	LL_PWR_EnableVddADC();
-#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+#elif defined(CONFIG_SOC_SERIES_STM32U5X) || defined(CONFIG_SOC_SERIES_STM32U3X)
 	LL_PWR_EnableVDDA();
 #endif /* CONFIG_SOC_SERIES_STM32U5X */
 }
@@ -1513,7 +1516,7 @@ static void adc_stm32_disable_analog_supply(void)
 {
 #if defined(CONFIG_SOC_SERIES_STM32N6X)
 	LL_PWR_DisableVddADC();
-#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+#elif defined(CONFIG_SOC_SERIES_STM32U5X) || defined(CONFIG_SOC_SERIES_STM32U3X)
 	LL_PWR_DisableVDDA();
 #endif /* CONFIG_SOC_SERIES_STM32U5X */
 }
@@ -1580,6 +1583,7 @@ static int adc_stm32_init(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32H7X) || \
 	defined(CONFIG_SOC_SERIES_STM32H7RSX) || \
 	defined(CONFIG_SOC_SERIES_STM32N6X) || \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
 	/*
 	 * L4, WB, G4, H5, H7 and U5 series STM32 needs to be awaken from deep sleep
@@ -1610,6 +1614,7 @@ static int adc_stm32_init(const struct device *dev)
 		}
 	}
 #elif defined(CONFIG_SOC_SERIES_STM32H7X) || \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBAX)
 	while (LL_ADC_IsActiveFlag_LDORDY(adc) == 0) {
@@ -1662,6 +1667,7 @@ static int adc_stm32_suspend_setup(const struct device *dev)
 	defined(CONFIG_SOC_SERIES_STM32H7X) || \
 	defined(CONFIG_SOC_SERIES_STM32H7RSX) || \
 	defined(CONFIG_SOC_SERIES_STM32N6X) || \
+	defined(CONFIG_SOC_SERIES_STM32U3X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
 	/*
 	 * L4, WB, G4, H5, H7 and U5 series STM32 needs to be put into

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -5,6 +5,8 @@
  */
 
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/stm32u5_adc.h>
 #include <zephyr/dt-bindings/clock/stm32u3_clock.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/reset/stm32u3_reset.h>
@@ -229,6 +231,38 @@
 			clocks = <&rcc STM32_CLOCK(APB3, 6)>;
 			resets = <&rctl STM32_RESET(APB3, 6)>;
 			interrupts = <66 0>;
+			status = "disabled";
+		};
+
+		adc1: adc@42028000 {
+			compatible = "st,stm32n6-adc", "st,stm32-adc";
+			reg = <0x42028000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
+			interrupts = <37 0>;
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 7 12 24 47 247 1500>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
+			status = "disabled";
+		};
+
+		adc2: adc@42028100 {
+			compatible = "st,stm32n6-adc", "st,stm32-adc";
+			reg = <0x42028100 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
+			interrupts = <113 0>;
+			#io-channel-cells = <1>;
+			resolutions = <STM32_ADC_RES(12, 0x00)
+				       STM32_ADC_RES(10, 0x01)
+				       STM32_ADC_RES(8, 0x02)
+				       STM32_ADC_RES(6, 0x03)>;
+			sampling-times = <2 3 7 12 24 47 247 1500>;
+			st,adc-sequencer = "FULLY_CONFIGURABLE";
+			st,adc-oversampler = "OVERSAMPLER_EXTENDED";
 			status = "disabled";
 		};
 

--- a/tests/drivers/adc/adc_api/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_u385rg_q.overlay
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 STMicroelectronics
+ */
+
+/ {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+};

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -51,6 +51,7 @@ tests:
       - nucleo_l152re
       - nucleo_l476rg
       - nucleo_u083rc
+      - nucleo_u385rg_q
       - nucleo_u575zi_q
       - nucleo_wb55rg
       - nucleo_wba55cg


### PR DESCRIPTION
This PR adds ADC peripherals on the stm32U3 boards.