### PR TITLE
Samples: Bluetooth: HR: Remove use of ISO config for IPC

### DIFF
--- a/samples/bluetooth/central_hr/overlay-bt_ll_sw_split.conf
+++ b/samples/bluetooth/central_hr/overlay-bt_ll_sw_split.conf
@@ -1,0 +1,11 @@
+# Configuration file to be used as an overlay to the hci_ipc sample for multi-core boards
+
+CONFIG_BT_EXT_ADV=y
+
+# Enable Coded PHY support
+CONFIG_BT_CTLR_PHY_CODED=y
+
+# Increase Advertising Data Length, as Complete Local Name too needs to be
+# placed in the AUX_ADV_IND PDU compared to when it is placed in ADV_SCAN_IND
+# PDU in the case of legacy advertising.
+CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=36

--- a/samples/bluetooth/central_hr/sample.yaml
+++ b/samples/bluetooth/central_hr/sample.yaml
@@ -17,31 +17,48 @@ tests:
     harness: bluetooth
     platform_allow:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     extra_args: EXTRA_CONF_FILE=overlay-extended.conf
     tags: bluetooth
+  sample.bluetooth.central_hr.multicore.bt_ll_sw_split.extended:
+    harness: bluetooth
+    platform_allow:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    extra_args:
+      - CONFIG_BT_EXT_ADV=y
+    tags: bluetooth
+    sysbuild: true
   sample.bluetooth.central_hr.bt_ll_sw_split.phy_coded:
     harness: bluetooth
     platform_allow:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     extra_args: EXTRA_CONF_FILE=overlay-phy_coded.conf
     tags: bluetooth
+  sample.bluetooth.central_hr.multicore.bt_ll_sw_split.phy_coded:
+    harness: bluetooth
+    platform_allow:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    extra_args:
+      - CONFIG_BT_EXT_ADV=y
+      - CONFIG_BT_AUTO_PHY_UPDATE=n
+    tags: bluetooth
+    sysbuild: true

--- a/samples/bluetooth/central_hr/sysbuild.cmake
+++ b/samples/bluetooth/central_hr/sysbuild.cmake
@@ -13,8 +13,8 @@ if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
 		BOARD       ${SB_CONFIG_NET_CORE_BOARD}
 	)
 
-	set(${NET_APP}_CONF_FILE
-	 ${NET_APP_SRC_DIR}/nrf5340_cpunet_iso-bt_ll_sw_split.conf
+	set(${NET_APP}_EXTRA_CONF_FILE
+	 ${ZEPHYR_BASE}/samples/bluetooth/central_hr/overlay-bt_ll_sw_split.conf
 	 CACHE INTERNAL ""
 	)
 

--- a/samples/bluetooth/peripheral_hr/overlay-bt_ll_sw_split.conf
+++ b/samples/bluetooth/peripheral_hr/overlay-bt_ll_sw_split.conf
@@ -1,0 +1,11 @@
+# Configuration file to be used as an overlay to the hci_ipc sample for multi-core boards
+
+CONFIG_BT_EXT_ADV=y
+
+# Enable Coded PHY support
+CONFIG_BT_CTLR_PHY_CODED=y
+
+# Increase Advertising Data Length, as Complete Local Name too needs to be
+# placed in the AUX_ADV_IND PDU compared to when it is placed in ADV_SCAN_IND
+# PDU in the case of legacy advertising.
+CONFIG_BT_CTLR_ADV_DATA_LEN_MAX=36

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -26,6 +26,7 @@ tests:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
     tags: bluetooth
+    sysbuild: true
   sample.bluetooth.peripheral_hr.minimal:
     harness: bluetooth
     platform_allow:
@@ -38,34 +39,51 @@ tests:
     harness: bluetooth
     platform_allow:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     extra_args: EXTRA_CONF_FILE=overlay-extended.conf
     tags: bluetooth
+  sample.bluetooth.peripheral_hr.multicore.bt_ll_sw_split.extended:
+    harness: bluetooth
+    platform_allow:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    extra_args: CONFIG_BT_EXT_ADV=y
+    tags: bluetooth
+    sysbuild: true
   sample.bluetooth.peripheral_hr.bt_ll_sw_split.phy_coded:
     harness: bluetooth
     platform_allow:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52_bsim
-      - nrf5340bsim/nrf5340/cpuapp
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
-      - nrf5340dk/nrf5340/cpuapp
     extra_args: EXTRA_CONF_FILE=overlay-phy_coded.conf
     tags: bluetooth
+    sysbuild: true
+  sample.bluetooth.peripheral_hr.multicore.bt_ll_sw_split.phy_coded:
+    harness: bluetooth
+    platform_allow:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340bsim/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpuapp
+    extra_args:
+      - CONFIG_BT_EXT_ADV=y
+      - CONFIG_BT_AUTO_PHY_UPDATE=n
+    tags: bluetooth
+    sysbuild: true
   sample.bluetooth.peripheral_hr_rv32m1_vega_openisa_rv32m1_ri5cy:
     platform_allow: rv32m1_vega/openisa_rv32m1/ri5cy
     tags: bluetooth

--- a/samples/bluetooth/peripheral_hr/sysbuild.cmake
+++ b/samples/bluetooth/peripheral_hr/sysbuild.cmake
@@ -13,8 +13,8 @@ if(SB_CONFIG_NET_CORE_IMAGE_HCI_IPC)
 		BOARD       ${SB_CONFIG_NET_CORE_BOARD}
 	)
 
-	set(${NET_APP}_CONF_FILE
-	 ${NET_APP_SRC_DIR}/nrf5340_cpunet_iso-bt_ll_sw_split.conf
+	set(${NET_APP}_EXTRA_CONF_FILE
+	 ${ZEPHYR_BASE}/samples/bluetooth/peripheral_hr/overlay-bt_ll_sw_split.conf
 	 CACHE INTERNAL ""
 	)
 


### PR DESCRIPTION
When compiling with sysbuild and IPC the samples would use the
nrf5340_cpunet_iso-bt_ll_sw_split.conf config file, which was
incompatible with the sample's host configuration.
    
Instead of using the ISO configuration file, define a hci_ipc
overlay in each sample with the necessary configurations
that support all host configurations.
    
This commit also updates the sample.yaml files to split
configurations for single- and multicore builds, as what
needs to be configured for each type is different.