### PR TITLE
drivers: sensor: ntc-thermistor-generic: add missing mutex retrieving data

### DIFF
--- a/drivers/sensor/ntc_thermistor/ntc_thermistor.c
+++ b/drivers/sensor/ntc_thermistor/ntc_thermistor.c
@@ -69,8 +69,10 @@ static int ntc_thermistor_channel_get(const struct device *dev, enum sensor_chan
 
 	switch (chan) {
 	case SENSOR_CHAN_AMBIENT_TEMP:
+		k_mutex_lock(&data->mutex, K_FOREVER);
 		ohm = ntc_get_ohm_of_thermistor(&cfg->ntc_cfg, data->sample_val,
 						data->sample_val_max);
+		k_mutex_unlock(&data->mutex);
 		temp = ntc_get_temp_mc(&cfg->ntc_cfg.type, ohm);
 		val->val1 = temp / 1000;
 		val->val2 = (temp % 1000) * 1000;


### PR DESCRIPTION
The ntc-thermistor-generic is not thread safe when calling sensor_channel_get() due to the mutex not being used in ntc_thermistor_channel_get() when the sampled data is accessed.
Add the thermistor_data mutex around the data access to fix.