### PR TITLE
Add ch32v303 packages (plus some gpio devicetree fix)

### DIFF
--- a/boards/wch/ch32v303vct6_evt/ch32v303vct6_evt.dts
+++ b/boards/wch/ch32v303vct6_evt/ch32v303vct6_evt.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 
-#include <wch/ch32v303/ch32v303.dtsi>
+#include <wch/ch32v303/ch32v303vct.dtsi>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include "ch32v303vct6_evt-pinctrl.dtsi"

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -76,7 +76,7 @@
 				reg = <0x40010800 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
 			};
 
@@ -85,7 +85,7 @@
 				reg = <0x40010C00 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
 			};
 
@@ -94,7 +94,7 @@
 				reg = <0x40011000 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
 			};
 
@@ -103,7 +103,7 @@
 				reg = <0x40011400 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
 			};
 		};

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -83,7 +83,7 @@
 				reg = <0x40010800 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
 			};
 
@@ -92,7 +92,7 @@
 				reg = <0x40010C00 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
 			};
 
@@ -101,7 +101,7 @@
 				reg = <0x40011000 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
 			};
 
@@ -110,7 +110,7 @@
 				reg = <0x40011400 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
 			};
 		};

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -78,7 +78,7 @@
 				reg = <0x40010800 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
 			};
 
@@ -87,7 +87,7 @@
 				reg = <0x40010C00 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
 			};
 
@@ -96,7 +96,7 @@
 				reg = <0x40011000 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
 			};
 
@@ -105,7 +105,7 @@
 				reg = <0x40011400 0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				ngpios = <8>;
+				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
 			};
 		};

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -108,6 +108,15 @@
 				ngpios = <16>;
 				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
 			};
+
+			gpioe: gpio@40011800 {
+				compatible = "wch,gpio";
+				reg = <0x40011800 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <16>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPE>;
+			};
 		};
 
 		usart1: uart@40013800 {

--- a/dts/riscv/wch/ch32v303/ch32v303cbt.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303cbt.dtsi
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Bootlin
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <wch/ch32v303/ch32v303.dtsi>
+
+&gpioc {
+	gpio-reserved-ranges = <0 13>;
+};
+
+&gpiod {
+	gpio-reserved-ranges = <2 14>;
+};
+
+&gpioe {
+	gpio-reserved-ranges = <0 16>;
+};

--- a/dts/riscv/wch/ch32v303/ch32v303rbt.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303rbt.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Bootlin
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <wch/ch32v303/ch32v303.dtsi>
+
+&gpiod {
+	gpio-reserved-ranges = <3 13>;
+};
+
+&gpioe {
+	gpio-reserved-ranges = <0 16>;
+};

--- a/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303rct.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Bootlin
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <wch/ch32v303/ch32v303.dtsi>
+
+&gpiod {
+	gpio-reserved-ranges = <3 13>;
+};
+
+&gpioe {
+	gpio-reserved-ranges = <0 16>;
+};

--- a/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303vct.dtsi
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Bootlin
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <wch/ch32v303/ch32v303.dtsi>
+
+&gpioc {
+	gpio-reserved-ranges = <0 3>, <14 2>;
+};


### PR DESCRIPTION
This series adds the different packages for the ch32v303.

It also fixes some errors in the devicetree related to the gpio nodes.