### PR TITLE
scripts: ci: add vermin (min python version check)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ MaintainersFormat.txt
 ModulesMaintainers.txt
 Nits.txt
 Pylint.txt
+PythonCompat.txt
 Ruff.txt
 SphinxLint.txt
 SysbuildKconfig.txt

--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -35,6 +35,7 @@ tabulate
 tomli>=1.1.0
 tox
 unidiff
+vermin
 west>=0.14.0
 xlsxwriter
 yamllint

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -1235,6 +1235,10 @@ urllib3==2.4.0 \
     #   elastic-transport
     #   pygithub
     #   requests
+vermin==1.6.0 \
+    --hash=sha256:6266ca02f55d1c2aa189a610017c132eb2d1934f09e72a955b1eb3820ee6d4ef \
+    --hash=sha256:f1fa9ee40f59983dc40e0477eb2b1fa8061a3df4c3b2bcf349add462a5610efb
+    # via -r requirements-actions.in
 virtualenv==20.31.2 \
     --hash=sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11 \
     --hash=sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -12,13 +12,13 @@ astroid==3.3.10 \
     --hash=sha256:104fb9cb9b27ea95e847a94c003be03a9e039334a8ebca5ee27dafaf5c5711eb \
     --hash=sha256:c332157953060c6deb9caa57303ae0d20b0fbdb2e59b4a4f2a6ba49d0a7961ce
     # via pylint
-awscli==1.40.24 \
-    --hash=sha256:6dbd7baebd5e01cd983dc8a816dfaa09155ce1825099ee09fd2044ea60024a3e \
-    --hash=sha256:a5d8dffa523f332839ec95501364df45d763c3000f9a61247324e6cfa46a3bf2
+awscli==1.40.27 \
+    --hash=sha256:92c84a3e9cbe3a7566bc738ad21201d9dad32dd7ab6a7a4906f7e1b29b9385ca \
+    --hash=sha256:d1e1047cccd675b48ab215b4012c91673de73ba498f503fd6eda3de1a24995d7
     # via -r requirements-actions.in
-botocore==1.38.25 \
-    --hash=sha256:5a960bd990a11cdb78865e908a58ed712d87d9b419f55ad21c99d7d21f0d6726 \
-    --hash=sha256:8c73e97d9662a6c92be33dab66cd1e2b59797154c7ec379ce3bb5d6779d9d78c
+botocore==1.38.28 \
+    --hash=sha256:515e1a535a27f17e1381aec1fb48eaa2c2308258c4db0bfd09e4f1cd1f239c44 \
+    --hash=sha256:63d5977a10a375c3fc11c8e15e1ae5a4daaf450af135d55c170cc537648edf25
     # via
     #   awscli
     #   s3transfer
@@ -840,7 +840,9 @@ pygithub==2.6.1 \
 pygments==2.19.1 \
     --hash=sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f \
     --hash=sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c
-    # via gcovr
+    # via
+    #   gcovr
+    #   pytest
 pyjwt==2.10.1 \
     --hash=sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953 \
     --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
@@ -875,9 +877,9 @@ pyserial==3.5 \
     --hash=sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb \
     --hash=sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0
     # via -r requirements-actions.in
-pytest==8.3.5 \
-    --hash=sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820 \
-    --hash=sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845
+pytest==8.4.0 \
+    --hash=sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6 \
+    --hash=sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e
     # via -r requirements-actions.in
 python-can==4.5.0 \
     --hash=sha256:1eec66833c1ac76a7e3d636ee0f8b4ba2752e892bab1c56ce74308b2216b5445 \
@@ -1063,9 +1065,9 @@ rsa==4.7.2 \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
     # via awscli
-ruamel-yaml==0.18.11 \
-    --hash=sha256:b586a3416676566ed45bf679a0909719f7ea7b58c03a9b6e03f905a1e2cd5076 \
-    --hash=sha256:eca06c9fce6ee3220845c4c54e58376586e041a6127e4d1958e12a3142084897
+ruamel-yaml==0.18.12 \
+    --hash=sha256:5a38fd5ce39d223bebb9e3a6779e86b9427a03fb0bf9f270060f8b149cffe5e2 \
+    --hash=sha256:790ba4c48b6a6e6b12b532a7308779eb12d2aaab3a80fdb8389216f28ea2b287
     # via pykwalify
 ruamel-yaml-clib==0.2.12 ; python_full_version < '3.14' and platform_python_implementation == 'CPython' \
     --hash=sha256:040ae85536960525ea62868b642bdb0c2cc6021c9f9d507810c0c604e66f5a7b \
@@ -1210,9 +1212,9 @@ tox==4.26.0 \
     --hash=sha256:75f17aaf09face9b97bd41645028d9f722301e912be8b4c65a3f938024560224 \
     --hash=sha256:a83b3b67b0159fa58e44e646505079e35a43317a62d2ae94725e0586266faeca
     # via -r requirements-actions.in
-typing-extensions==4.13.2 \
-    --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
-    --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
+typing-extensions==4.14.0 \
+    --hash=sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4 \
+    --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
     # via
     #   astroid
     #   elasticsearch

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -13,5 +13,6 @@ python-magic; sys_platform != "win32"
 ruff==0.11.11
 sphinx-lint
 unidiff
+vermin
 yamllint
 # zephyr-keep-sorted-stop


### PR DESCRIPTION
Add a compliance check that allows to flag when a given file requires Python version higher than 3.10 (minimum supported version in Zephyr at the time of writing) since not all Python scripts are tested against 3.10 in CI and we want to avoid introducing changes that could break users.

<img width="802" alt="image" src="https://github.com/user-attachments/assets/8e05fda5-65e1-4a6c-9627-6b48581b717f" />
