### PR TITLE
modules: cmsis: fix: CI with CMSIS

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -117,7 +117,7 @@ manifest:
       groups:
         - babblesim
     - name: cmsis
-      revision: d1b8b20b6278615b00e136374540eb1c00dcabe7
+      revision: 512cc7e895e8491696b61f7ba8066b4a182569b8
       path: modules/hal/cmsis
       groups:
         - hal


### PR DESCRIPTION
Update to the latest CMSIS because some modules still use CMSIS (v5.x) which when built with the latest toolchain returns below error in CI: `error: pac_armv81.h: No such file or directory`