### PR TITLE
twister: reports: try to show more build failures in generated summary

### DIFF
--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -845,4 +845,9 @@ class Reporting:
                 return line[line.index('error: ') :].strip()
             elif ": in function " in line:
                 last_warning = line[line.index('in function') :].strip()
+            elif "CMake Error at" in line:
+                for next_line in lines[i + 1 :]:
+                    if next_line.strip():
+                        return line + ' ' + next_line
+                return line
         return None


### PR DESCRIPTION
Some Build failures are actually cmake issues, so in that case, if
nothing is found as build failure, try to parse for cmake issues.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
