### PR TITLE
PM: Record metrics in power management tests

### DIFF
--- a/scripts/pylib/power-twister-harness/test_power.py
+++ b/scripts/pylib/power-twister-harness/test_power.py
@@ -77,6 +77,18 @@ def is_within_tolerance(measured_rms_value, expected_rms_value, tolerance_percen
     logger.debug(f"Expected RMS: {expected_rms_value:.2f} mA")
     logger.debug(f"Tolerance: {tolerance:.2f} mA")
     logger.debug(f"Measured  RMS: {measured_rms_value:.2f} mA")
-
+    logger.info(
+        'RECORD: ['
+        '{'
+        f'"expected_rms_ua": {expected_rms_value:.2f}'
+        '}'
+        ',{'
+        f'"tolerance_ua": {tolerance:.2f}'
+        '}'
+        ',{'
+        f'"measured_rms_ua": {measured_rms_value:.2f}'
+        '}'
+        ']'
+    )
     # Check if the measured value is within the range of expected ± tolerance
     return (expected_rms_value - tolerance) < measured_rms_value < (expected_rms_value + tolerance)

--- a/tests/subsys/pm/power_residency_time/testcase.yaml
+++ b/tests/subsys/pm/power_residency_time/testcase.yaml
@@ -15,6 +15,10 @@ common:
       num_of_transitions: 6
       expected_rms_values: [56.0, 4.0, 4.0, 1.2, 1.2, 0.26, 91]
       tolerance_percentage: 20
+    record:
+      regex:
+        - "RECORD:(?P<metrics>.*)"
+      as_json: ['metrics']
 
 tests:
   pm.power_residency_time:

--- a/tests/subsys/pm/power_states/testcase.yaml
+++ b/tests/subsys/pm/power_states/testcase.yaml
@@ -15,6 +15,10 @@ common:
       num_of_transitions: 4
       expected_rms_values: [56.0, 4.0, 1.2, 0.26, 140]
       tolerance_percentage: 20
+    record:
+      regex:
+        - "RECORD:(?P<metrics>.*)"
+      as_json: ['metrics']
 
 tests:
   pm.power_states:

--- a/tests/subsys/pm/power_wakeup_timer/testcase.yaml
+++ b/tests/subsys/pm/power_wakeup_timer/testcase.yaml
@@ -15,6 +15,10 @@ common:
       num_of_transitions: 1
       expected_rms_values: [0.26, 140]
       tolerance_percentage: 20
+    record:
+      regex:
+        - "RECORD:(?P<metrics>.*)"
+      as_json: ['metrics']
 
 tests:
   pm.power_wakeup_timer:


### PR DESCRIPTION
This change adds support for recording measured power data into the `twister.json` file during power management tests.

Justification:
The collected data can be used by third-party tools to visualize and analyze power consumption metrics, aiding in performance and efficiency evaluations.