### PR TITLE
modules: openthread: platform: logging: Take kconfig into account

### DIFF
--- a/modules/openthread/platform/logging.c
+++ b/modules/openthread/platform/logging.c
@@ -5,16 +5,10 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log_core.h>
 #include <stdarg.h>
-#include <stdio.h>
 
 #include <openthread/platform/logging.h>
-#include "openthread-core-zephyr-config.h"
-
-#define LOG_MODULE_NAME net_openthread
-#define LOG_LEVEL LOG_LEVEL_DBG
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include "platform-zephyr.h"
 
@@ -49,7 +43,7 @@ void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat
 	int level = log_translate(aLogLevel);
 	va_list param_list;
 
-	if (level < 0) {
+	if (level < 0 || level > CONFIG_OPENTHREAD_PLATFORM_LOG_LEVEL) {
 		return;
 	}
 


### PR DESCRIPTION
Currently all calls to `otPlatLog` with debug log level are printed. Cleanup logging.c