### PR TITLE
edtlib: fix _raw_unit_addr() function and _interrupt_parent() function

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2904,8 +2904,14 @@ def _interrupt_parent(start_node: dtlib_Node) -> dtlib_Node:
 
     while node:
         if "interrupt-parent" in node.props:
-            return node.props["interrupt-parent"].to_node()
+            iparent = node.props["interrupt-parent"].to_node()
+            assert "interrupt-controller" in iparent.props or "interrupt-map" in iparent.props
+            return iparent
         node = node.parent
+        if node is None:
+            _err(f"{start_node!r} no interrupt parent found")
+        if ("interrupt-controller" in node.props) or ("interrupt-map" in node.props):
+            return node
 
     _err(f"{start_node!r} has an 'interrupts' property, but neither the node "
          f"nor any of its parents has an 'interrupt-parent' property")

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -80,6 +80,22 @@
 				0 1  0 1  &{/interrupt-map-test/controller-1}  0 0    0 4
 				0 1  0 2  &{/interrupt-map-test/controller-2}  0 0 0  0 0 5>;
 		};
+		nexus-0 {
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
+			interrupt-map = <
+				0 0  &{/interrupt-map-test/controller-0}  0      0
+				0 1  &{/interrupt-map-test/controller-1}  0 0    0 1
+				1 2  &{/interrupt-map-test/controller-2}  0 0 0  0 0 2>;
+		};
+		nexus-1 {
+			#address-cells = <1>;
+			#interrupt-cells = <1>;
+			interrupt-map = <
+				4 0  &{/interrupt-map-test/controller-0}  0      3
+				4 1  &{/interrupt-map-test/controller-1}  0 0    0 4
+				4 2  &{/interrupt-map-test/controller-2}  0 0 0  0 0 5>;
+		};
 		node@0 {
 			reg = <0 0>;
 			interrupts = <0 0 0 1 0 2>;
@@ -91,6 +107,30 @@
 			    &{/interrupt-map-test/nexus} 0 0
 			    &{/interrupt-map-test/nexus} 0 1
 			    &{/interrupt-map-test/nexus} 0 2>;
+		};
+		node@2 {
+			reg = <0 2>;
+			interrupts = <0 0 0 1 1 2>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-0}>;
+		};
+		node@3 { /* Test the precedence of interrupts/interrupts-extended too */
+			reg = <0 3>;
+			interrupts = <1 2 0 0 0 1>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-0}>;
+			interrupts-extended = <
+			    &{/interrupt-map-test/nexus-0} 0 0
+			    &{/interrupt-map-test/nexus-0} 0 1
+			    &{/interrupt-map-test/nexus-0} 1 2>;
+		};
+		node@4 {
+			reg = <0 4>;
+			interrupts = <0 1 2>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-1}>;
+		};
+		node@100000004 {
+			reg = <1 4>;
+			interrupts = <0 1 2>;
+			interrupt-parent = <&{/interrupt-map-test/nexus-1}>;
 		};
 	};
 	interrupt-map-bitops-test {

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -97,6 +97,34 @@ def test_interrupts():
         edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
     ]
 
+    node = edt.get_node("/interrupt-map-test/node@2")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 0}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 1}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 2}, name=None, basename=None)
+    ]
+
+    node = edt.get_node("/interrupt-map-test/node@3")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 0}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 1}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 2}, name=None, basename=None)
+    ]
+
+    node = edt.get_node("/interrupt-map-test/node@4")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 3}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 4}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
+    ]
+
+    node = edt.get_node("/interrupt-map-test/node@100000004")
+    assert node.interrupts == [
+        edtlib.ControllerAndData(node=node, controller=controller_0, data={'one': 3}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_1, data={'one': 0, 'two': 4}, name=None, basename=None),
+        edtlib.ControllerAndData(node=node, controller=controller_2, data={'one': 0, 'two': 0, 'three': 5}, name=None, basename=None)
+    ]
+
     node = edt.get_node("/interrupt-map-bitops-test/node@70000000E")
     assert node.interrupts == [
         edtlib.ControllerAndData(node=node, controller=edt.get_node('/interrupt-map-bitops-test/controller'), data={'one': 3, 'two': 2}, name=None, basename=None)


### PR DESCRIPTION
This PR continues @avolkov-1221 work on PR  #77900 and tries to resolve the comments:

> The '_raw_unit_addr()' function was incorrectly written a long time ago. It tries to look up and use the '#address-cells' of the node containing the 'interrupts' property itself, instead of using the '#address-cells' of the interrupt controller's node (or its parent).
As a result, the mapping is successful only if the '#address-cells' value is the same in both the node and the interrupt controller, all other cases lead to random errors being generated by the 'gen_defines.py' script.
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/77890, https://github.com/zephyrproject-rtos/zephyr/issues/78020

Commit a9aadeddbb2e03306579153240fcfec62fcd317f implements the missing logic  in `_interrupt_parent()` function:
1. If an ancestor has an interrupt-controller or interrupt-map property,
   the walk must terminate.
2. If an interrupt-parent property is found, the linked node must be a
   valid interrupt controller or nexus.

as  mentioned in https://github.com/zephyrproject-rtos/zephyr/pull/77900/files#r1750393745.