### PR TITLE
NXP: bluetooth: Fix discarding multi-part extended advertising reports

### DIFF
--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -221,9 +221,19 @@ static bool is_hci_event_discardable(const uint8_t *evt_data)
 
 		switch (subevt_type) {
 		case BT_HCI_EVT_LE_ADVERTISING_REPORT:
-		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
 			ret = true;
 			break;
+#if defined(CONFIG_BT_EXT_ADV)
+		case BT_HCI_EVT_LE_EXT_ADVERTISING_REPORT:
+		{
+			const struct bt_hci_evt_le_ext_advertising_report *ext_adv =
+				(void *)&evt_data[3];
+
+			return (ext_adv->num_reports == 1) &&
+				   ((ext_adv->adv_info[0].evt_type &
+					 BT_HCI_LE_ADV_EVT_TYPE_LEGACY) != 0);
+		}
+#endif
 		default:
 			break;
 		}

--- a/soc/nxp/mcx/mcxw/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxw/Kconfig.defconfig
@@ -27,6 +27,12 @@ config BT_LONG_WQ_STACK_SIZE
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 2048
 
+config BT_BUF_EVT_RX_COUNT
+	default 16
+
+config BT_BUF_ACL_TX_COUNT
+	default 12
+
 if SHELL
 
 config SHELL_STACK_SIZE

--- a/soc/nxp/rw/Kconfig.defconfig
+++ b/soc/nxp/rw/Kconfig.defconfig
@@ -35,6 +35,12 @@ config BT_LONG_WQ_STACK_SIZE
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 2048
 
+config BT_BUF_EVT_RX_COUNT
+	default 12
+
+config BT_BUF_ACL_TX_COUNT
+	default 8
+
 if SHELL
 
 config SHELL_STACK_SIZE


### PR DESCRIPTION
* Adjust ACL bt_conn_tx contexts for both MCXW7x and RW61x to match respective controller's config
* Fix discarding multi-part extended advertising reports