### PR TITLE
scripts: west_commands: zspdx: SBOM generation meta-data update

### DIFF
--- a/scripts/west_commands/zspdx/datatypes.py
+++ b/scripts/west_commands/zspdx/datatypes.py
@@ -81,6 +81,9 @@ class PackageConfig:
     # package revision
     revision: str = ""
 
+    # package supplier or vendor
+    supplier: str = ""
+
     # package external references
     externalReferences: list = field(default_factory=list)
 

--- a/scripts/west_commands/zspdx/writer.py
+++ b/scripts/west_commands/zspdx/writer.py
@@ -119,7 +119,7 @@ PackageCopyrightText: {pkg.cfg.copyrightText}
         if re.fullmatch(CPE23TYPE_REGEX, ref):
             f.write(f"ExternalRef: SECURITY cpe23Type {ref}\n")
         elif re.fullmatch(PURL_REGEX, ref):
-            f.write(f"ExternalRef: PACKAGE_MANAGER purl {ref}\n")
+            f.write(f"ExternalRef: PACKAGE-MANAGER purl {ref}\n")
         else:
             log.wrn(f"Unknown external reference ({ref})")
 

--- a/scripts/west_commands/zspdx/writer.py
+++ b/scripts/west_commands/zspdx/writer.py
@@ -74,12 +74,22 @@ def generateDowloadUrl(url, revision):
 #   2) pkg: Package object being described
 #   3) spdx_version: SPDX specification version
 def writePackageSPDX(f, pkg, spdx_version=SPDX_VERSION_2_3):
+    #update package meta data based on provided CPE reference
+    for ref in pkg.cfg.externalReferences:
+        if re.fullmatch(CPE23TYPE_REGEX, ref):
+            metadata = ref.split(':',6)
+            #metadata should now be array like:
+            #[cpe,2.3,a,arm,mbed_tls,3.5.1,*:*:*:*:*:*:*]
+            pkg.cfg.supplier = metadata[3]
+            pkg.cfg.name = metadata[4]
+            pkg.cfg.version = metadata[5]
+
     spdx_normalized_name = _normalize_spdx_name(pkg.cfg.name)
     spdx_normalize_spdx_id = _normalize_spdx_name(pkg.cfg.spdxID)
 
     f.write(f"""##### Package: {spdx_normalized_name}
 
-PackageName: {spdx_normalized_name}
+PackageName: {pkg.cfg.name}
 SPDXID: {spdx_normalize_spdx_id}
 PackageLicenseConcluded: {pkg.concludedLicense}
 """)
@@ -101,6 +111,9 @@ PackageCopyrightText: {pkg.cfg.copyrightText}
         f.write(f"PackageVersion: {pkg.cfg.version}\n")
     elif len(pkg.cfg.revision) > 0:
         f.write(f"PackageVersion: {pkg.cfg.revision}\n")
+
+    if len(pkg.cfg.supplier) > 0:
+        f.write(f"PackageSupplier: Organization: {pkg.cfg.supplier}\n")
 
     for ref in pkg.cfg.externalReferences:
         if re.fullmatch(CPE23TYPE_REGEX, ref):


### PR DESCRIPTION
this pull request is a follow-up of discussion:
- https://github.com/zephyrproject-rtos/zephyr/discussions/90604#discussioncomment-13280647

this pull request will update the `PackageName`, `PackageVersionand` and `PackageSupplier` in the generated SBOM based on the information passed in the `external-references` in the module.yml. This way packages are better recognized by vulnerability scanning tools like `cve-bin-tool`.
In addition an extra option `external-references-comment` can now be passed into the module.yml that will add the SPDX `ExternalRefComment` field to the SBOM. These comments can be single line or multi line. 