### PR TITLE
dts: arm: st: h7: Correct dma-request value for H743 DMAMUX2

### DIFF
--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -26,7 +26,7 @@
 		};
 
 		dmamux2: dmamux@58025800 {
-			dma-requests= <107>;
+			dma-requests= <12>;
 		};
 
 		usbotg_fs: usb@40080000 {


### PR DESCRIPTION
As per the [reference manual for the STM32H742](https://www.st.com/resource/en/reference_manual/rm0433-stm32h742-stm32h743753-and-stm32h750-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) in Table 121, the number of peripheral request inputs for `DMAMUX2` should be defined as 12.

![image](https://github.com/user-attachments/assets/ca1bdd6f-a0ce-4655-a64b-e932c5c5a39e)
 