### PR TITLE
dts: arm: st: h7: Add support for STM32H742

### DIFF
--- a/dts/arm/st/h7/stm32h742.dtsi
+++ b/dts/arm/st/h7/stm32h742.dtsi
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 Brill Power
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <st/h7/stm32h7.dtsi>
+#include <zephyr/dt-bindings/display/panel.h>
+
+/ {
+	soc {
+		compatible = "st,stm32h742", "st,stm32h7", "simple-bus";
+
+		flash-controller@52002000 {
+			flash0: flash@8000000 {
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
+				write-block-size = <32>;
+				erase-block-size = <DT_SIZE_K(128)>;
+				/* maximum erase time for a 128K sector */
+				max-erase-time = <4000>;
+			};
+		};
+
+		dmamux1: dmamux@40020800 {
+			dma-requests= <107>;
+		};
+
+		dmamux2: dmamux@58025800 {
+			dma-requests= <12>;
+		};
+
+		usbotg_fs: usb@40080000 {
+			compatible = "st,stm32-otgfs";
+			reg = <0x40080000 0x40000>;
+			interrupts = <101 0>, <98 0>, <99 0>;
+			interrupt-names = "otgfs", "ep1_out", "ep1_in";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK(AHB1, 27)>,
+				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
+			phys = <&otghs_fs_phy>;
+			status = "disabled";
+		};
+
+		ltdc: display-controller@50001000 {
+			compatible = "st,stm32-ltdc";
+			reg = <0x50001000 0x200>;
+			interrupts = <88 0>, <89 0>;
+			interrupt-names = "ltdc", "ltdc_er";
+			clocks = <&rcc STM32_CLOCK(APB3, 3)>;
+			resets = <&rctl STM32_RESET(APB3, 3)>;
+			status = "disabled";
+		};
+
+		rtc@58004000 {
+			bbram: backup_regs {
+				compatible = "st,stm32-bbram";
+				st,backup-regs = <32>;
+				status = "disabled";
+			};
+		};
+	};
+
+	/* System data RAM accessible over AXI bus: AXI SRAM in D1 domain */
+	sram0: memory@24000000 {
+		compatible = "mmio-sram";
+		reg = <0x24000000 DT_SIZE_K(384)>;
+	};
+
+	/* System data RAM accessible over AHB bus: SRAM1 in D2 domain */
+	sram1: memory@30000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x30000000 DT_SIZE_K(32)>;
+		zephyr,memory-region = "SRAM1";
+	};
+
+	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
+	sram2: memory@30020000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x30020000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "SRAM2";
+	};
+
+	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */
+	sram4: memory@38000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x38000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "SRAM4";
+	};
+
+	dtcm: memory@20000000 {
+		compatible = "zephyr,memory-region", "arm,dtcm";
+		reg = <0x20000000 DT_SIZE_K(128)>;
+		zephyr,memory-region = "DTCM";
+	};
+
+	itcm: memory@0 {
+		compatible = "zephyr,memory-region", "arm,itcm";
+		reg = <0x00000000 DT_SIZE_K(64)>;
+		zephyr,memory-region = "ITCM";
+	};
+
+	otghs_fs_phy: otghs_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+	};
+
+	vref: vref {
+		io-channels = <&adc3 19>;
+	};
+
+	vbat: vbat {
+		io-channels = <&adc3 17>;
+	};
+};

--- a/dts/arm/st/h7/stm32h742Xg.dtsi
+++ b/dts/arm/st/h7/stm32h742Xg.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Brill Power
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/h7/stm32h742.dtsi>
+
+/ {
+	soc {
+		flash-controller@52002000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(1024)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/h7/stm32h742Xi.dtsi
+++ b/dts/arm/st/h7/stm32h742Xi.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Brill Power
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <st/h7/stm32h742.dtsi>
+
+/ {
+	soc {
+		flash-controller@52002000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(2048)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -1,85 +1,30 @@
 /*
  * Copyright (c) 2020 Teslabs Engineering S.L.
+ * Copyright (c) 2025 Brill Power
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <st/h7/stm32h7.dtsi>
-#include <zephyr/dt-bindings/display/panel.h>
+#include <st/h7/stm32h742.dtsi>
 
 / {
 	soc {
 		compatible = "st,stm32h743", "st,stm32h7", "simple-bus";
-
-		flash-controller@52002000 {
-			flash0: flash@8000000 {
-				compatible = "st,stm32-nv-flash", "soc-nv-flash";
-				write-block-size = <32>;
-				erase-block-size = <DT_SIZE_K(128)>;
-				/* maximum erase time for a 128K sector */
-				max-erase-time = <4000>;
-			};
-		};
-
-		dmamux1: dmamux@40020800 {
-			dma-requests= <107>;
-		};
-
-		dmamux2: dmamux@58025800 {
-			dma-requests= <12>;
-		};
-
-		usbotg_fs: usb@40080000 {
-			compatible = "st,stm32-otgfs";
-			reg = <0x40080000 0x40000>;
-			interrupts = <98 0>, <99 0>, <100 0>, <101 0>;
-			interrupt-names = "ep1_out", "ep1_in", "wkup", "otgfs";
-			num-bidir-endpoints = <9>;
-			ram-size = <4096>;
-			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB1, 27U)>,
-				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
-			phys = <&otghs_fs_phy>;
-			status = "disabled";
-		};
-
-		ltdc: display-controller@50001000 {
-			compatible = "st,stm32-ltdc";
-			reg = <0x50001000 0x200>;
-			interrupts = <88 0>, <89 0>;
-			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
-			resets = <&rctl STM32_RESET(APB3, 3U)>;
-			status = "disabled";
-		};
-
-		rtc@58004000 {
-			bbram: backup_regs {
-				compatible = "st,stm32-bbram";
-				st,backup-regs = <32>;
-				status = "disabled";
-			};
-		};
 	};
 
 	/* System data RAM accessible over AXI bus: AXI SRAM in D1 domain */
 	sram0: memory@24000000 {
 		reg = <0x24000000 DT_SIZE_K(512)>;
-		compatible = "mmio-sram";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM1 in D2 domain */
 	sram1: memory@30000000 {
 		reg = <0x30000000 DT_SIZE_K(128)>;
-		compatible = "zephyr,memory-region", "mmio-sram";
-		zephyr,memory-region = "SRAM1";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM2 in D2 domain */
 	sram2: memory@30020000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30020000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "SRAM2";
 	};
 
 	/* System data RAM accessible over AHB bus: SRAM3 in D2 domain */
@@ -87,37 +32,5 @@
 		compatible = "zephyr,memory-region", "mmio-sram";
 		reg = <0x30040000 DT_SIZE_K(32)>;
 		zephyr,memory-region = "SRAM3";
-	};
-
-	/* System data RAM accessible over AHB bus: SRAM4 in D3 domain  */
-	sram4: memory@38000000 {
-		reg = <0x38000000 DT_SIZE_K(64)>;
-		compatible = "zephyr,memory-region", "mmio-sram";
-		zephyr,memory-region = "SRAM4";
-	};
-
-	dtcm: memory@20000000 {
-		compatible = "zephyr,memory-region", "arm,dtcm";
-		reg = <0x20000000 DT_SIZE_K(128)>;
-		zephyr,memory-region = "DTCM";
-	};
-
-	itcm: memory@0 {
-		compatible = "zephyr,memory-region", "arm,itcm";
-		reg = <0x00000000 DT_SIZE_K(64)>;
-		zephyr,memory-region = "ITCM";
-	};
-
-	otghs_fs_phy: otghs_fs_phy {
-		compatible = "usb-nop-xceiv";
-		#phy-cells = <0>;
-	};
-
-	vref: vref {
-		io-channels = <&adc3 19>;
-	};
-
-	vbat: vbat {
-		io-channels = <&adc3 17>;
 	};
 };

--- a/soc/st/stm32/stm32h7x/Kconfig
+++ b/soc/st/stm32/stm32h7x/Kconfig
@@ -1,6 +1,7 @@
 # ST Microelectronics STM32H7 MCU series
 
 # Copyright (c) 2019 Linaro Limited
+# Copyright (c) 2025 Brill Power
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_STM32H7X
@@ -30,6 +31,9 @@ config SOC_STM32H730XXQ
 	select CPU_CORTEX_M7
 
 config SOC_STM32H735XX
+	select CPU_CORTEX_M7
+
+config SOC_STM32H742XX
 	select CPU_CORTEX_M7
 
 config SOC_STM32H743XX

--- a/soc/st/stm32/stm32h7x/Kconfig.defconfig.stm32h742xx
+++ b/soc/st/stm32/stm32h7x/Kconfig.defconfig.stm32h742xx
@@ -1,0 +1,11 @@
+# ST STM32H742X MCU configuration options
+
+# Copyright (c) 2025 Brill Power
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_STM32H742XX
+
+config NUM_IRQS
+	default 150
+
+endif # SOC_STM32H742XX

--- a/soc/st/stm32/stm32h7x/Kconfig.soc
+++ b/soc/st/stm32/stm32h7x/Kconfig.soc
@@ -3,6 +3,7 @@
 # Copyright (c) 2019 Linaro Limited
 # Copyright (c) 2020 Teslabs Engineering S.L.
 # Copyright (c) 2021 Electrolance Solutions
+# Copyright (c) 2025 Brill Power
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SERIES_STM32H7X
@@ -29,6 +30,10 @@ config SOC_STM32H730XXQ
 	select SOC_SERIES_STM32H7X
 
 config SOC_STM32H735XX
+	bool
+	select SOC_SERIES_STM32H7X
+
+config SOC_STM32H742XX
 	bool
 	select SOC_SERIES_STM32H7X
 
@@ -112,6 +117,7 @@ config SOC
 	default "stm32h730xx" if SOC_STM32H730XX
 	default "stm32h730xxq" if SOC_STM32H730XXQ
 	default "stm32h735xx" if SOC_STM32H735XX
+	default "stm32h742xx" if SOC_STM32H742XX
 	default "stm32h743xx" if SOC_STM32H743XX
 	default "stm32h745xx" if SOC_STM32H745XX_M7 || SOC_STM32H745XX_M4
 	default "stm32h747xx" if SOC_STM32H747XX_M7 || SOC_STM32H747XX_M4


### PR DESCRIPTION
Adds base Devicetree definitions for the STM32H742 series of microcontrollers