### PR TITLE
npcx_i2c_ctrl_transfer does not match original declaration

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -1414,7 +1414,7 @@ static void i2c_target_wk_isr(const struct device *dev, struct npcx_wui *wui)
 #endif /* CONFIG_I2C_TARGET */
 
 int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
-			      uint8_t num_msgs, uint16_t addr, int port)
+			      uint8_t num_msgs, uint16_t addr, uint8_t port)
 {
 	struct i2c_ctrl_data *const data = i2c_dev->data;
 	int ret = 0;


### PR DESCRIPTION
Fix npcx_i2c_ctrl_transfer arguments to match header to prevent warning: type of 'npcx_i2c_ctrl_transfer' does not match original declaration