### PR TITLE
drivers: intc: esp32: Disable IRQ before connect

### DIFF
--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -607,6 +607,7 @@ int esp_intr_alloc_intrstatus(int source,
 		/* Mark as unusable for other interrupt sources. This is ours now! */
 		vd->flags = VECDESC_FL_NONSHARED;
 		if (handler) {
+			irq_disable(intr);
 			irq_connect_dynamic(intr, 0, (intc_dyn_handler_t)handler, arg, 0);
 		}
 		if (flags & ESP_INTR_FLAG_EDGE) {


### PR DESCRIPTION
Disable IRQ before connecting new handler when interrupt is not shared.
This aligns intc behavior to version before PR #87369.