### PR TITLE
drivers: i2c_dw: fix request_bytes overflow when receiving > 256 bytes

### DIFF
--- a/drivers/i2c/i2c_dw.h
+++ b/drivers/i2c/i2c_dw.h
@@ -137,7 +137,7 @@ struct i2c_dw_dev_config {
 	uint16_t lcnt;
 
 	volatile uint8_t state; /* last direction of transfer */
-	uint8_t request_bytes;
+	uint32_t request_bytes;
 	uint8_t xfr_flags;
 	bool support_hs_mode;
 #ifdef CONFIG_I2C_DW_LPSS_DMA


### PR DESCRIPTION
The original definition of request_bytes as uint8_t caused incorrect behavior when attempting to receive more than 256 bytes, as the variable would overflow. This patch changes its type to uint32_t to allow correct tracking of large I2C transfers.