### PR TITLE
arch: riscv: core: Fix type

### DIFF
--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -17,8 +17,8 @@ GTEXT(__reset)
 
 /* imports */
 GTEXT(z_prep_c)
-GTEXT(riscv_cpu_wake_flag)
-GTEXT(riscv_cpu_sp)
+GDATA(riscv_cpu_wake_flag)
+GDATA(riscv_cpu_sp)
 GTEXT(arch_secondary_cpu_init)
 
 #if CONFIG_INCLUDE_RESET_VECTOR


### PR DESCRIPTION
`riscv_cpu_wake_flag` and `riscv_cpu_sp` are variables, not functions, so
they should use the `GDATA` macro instead of the `GTEXT` macro. Otherwise,
the linker will warn when LTO is enabled:

```
ld.bfd: warning: type of symbol `riscv_cpu_wake_flag' changed from 2 to
1 in /tmp/cc39w5oK.ltrans0.ltrans.o
ld.bfd: warning: type of symbol `riscv_cpu_sp' changed from 2 to 1 in
/tmp/cc39w5oK.ltrans0.ltrans.o
```