### PR TITLE
PocketBeagle 2 A53 enable GPIOs

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53-pinctrl.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53-pinctrl.dtsi
@@ -24,4 +24,17 @@
 		/* (K22) GPMC0_CSn2.I2C2_SCL */
 		pinmux = <K3_PINMUX(0x00b0, PIN_INPUT_PULLUP, MUX_MODE_1)>;
 	};
+
+	led_pins_default: led-default-pins {
+		pinmux = <
+			/* (F24) OSPI0_D3.GPIO0_6 */
+			K3_PINMUX(0x0018, PIN_OUTPUT, MUX_MODE_7)
+			/* (F25) OSPI0_D2.GPIO0_5 */
+			K3_PINMUX(0x0014, PIN_OUTPUT, MUX_MODE_7)
+			/* (G24) OSPI0_D1.GPIO0_4 */
+			K3_PINMUX(0x0010, PIN_OUTPUT, MUX_MODE_7)
+			/* (E25) OSPI0_D0.GPIO0_3 */
+			K3_PINMUX(0x000c, PIN_OUTPUT, MUX_MODE_7)
+		>;
+	};
 };

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.dts
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.dts
@@ -19,6 +19,10 @@
 		zephyr,sram = &ddr0;
 	};
 
+	aliases {
+		led0 = &led1;
+	};
+
 	cpus {
 		cpu@0 {
 			status = "okay";
@@ -32,6 +36,30 @@
 	ddr0: memory@80000000 {
 		reg = <0x80000000 DT_SIZE_M(512)>;
 	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led1: led_1 {
+			gpios = <&main_gpio0 6 GPIO_ACTIVE_HIGH>;
+			label = "LED 1";
+		};
+
+		led2: led_2 {
+			gpios = <&main_gpio0 5 GPIO_ACTIVE_HIGH>;
+			label = "LED 2";
+		};
+
+		led3: led_3 {
+			gpios = <&main_gpio0 4 GPIO_ACTIVE_HIGH>;
+			label = "LED 3";
+		};
+
+		led4: led_4 {
+			gpios = <&main_gpio0 3 GPIO_ACTIVE_HIGH>;
+			label = "LED 4";
+		};
+	};
 };
 
 &uart6 {
@@ -42,6 +70,12 @@
 
 &main_i2c2 {
 	pinctrl-0 = <&main_i2c2_sda_default &main_i2c2_scl_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&main_gpio0 {
+	pinctrl-0 = <&led_pins_default>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.yaml
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_a53.yaml
@@ -10,3 +10,4 @@ vendor: beagle
 supported:
   - uart
   - i2c
+  - gpio

--- a/dts/arm64/ti/ti_am62x_a53.dtsi
+++ b/dts/arm64/ti/ti_am62x_a53.dtsi
@@ -9,6 +9,7 @@
 #include <arm64/armv8-a.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/pinctrl/ti-k3-pinctrl.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	#address-cells = <1>;
@@ -184,6 +185,26 @@
 		clock-frequency = <100000>;
 		#address-cells = <1>;
 		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_gpio0: gpio@600000 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00600000 0x100>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		/* FIXME: Enable all 92 GPIOs */
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	main_gpio1: gpio@601000 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00601000 0x100>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		/* FIXME: Enable all 52 GPIOs */
+		ngpios = <32>;
 		status = "disabled";
 	};
 };


### PR DESCRIPTION
- Currently only 32 lines are enabled in both, since the GPIO subsystem does not support > 32 lines.
- Tested with the blinky example.