### PR TITLE
shell: introduce more structured help messages

### DIFF
--- a/drivers/audio/codec_shell.c
+++ b/drivers/audio/codec_shell.c
@@ -9,20 +9,20 @@
 #include <zephyr/audio/codec.h>
 
 #define CODEC_START_HELP                                                                           \
-	"Start output audio playback. Syntax:\n"                                                   \
-	"<device>"
+	SHELL_HELP("Start output audio playback",                                                  \
+		   "<device>")
 
 #define CODEC_STOP_HELP                                                                            \
-	"Stop output audio playback. Syntax:\n"                                                    \
-	"<device>"
+	SHELL_HELP("Stop output audio playback",                                                   \
+		   "<device>")
 
 #define CODEC_SET_PROP_HELP                                                                        \
-	"Set a codec property. Syntax:\n"                                                          \
-	"<device> <property> <channel> <value>"
+	SHELL_HELP("Set a codec property",                                                         \
+		   "<device> <property> <channel> <value>")
 
 #define CODEC_APPLY_PROP_HELP                                                                      \
-	"Apply any cached properties. Syntax:\n"                                                   \
-	"<device>"
+	SHELL_HELP("Apply any cached properties",                                                  \
+		   "<device>")
 
 static const char *const codec_property_name[] = {
 	[AUDIO_PROPERTY_OUTPUT_VOLUME] = "volume",

--- a/drivers/w1/w1_shell.c
+++ b/drivers/w1/w1_shell.c
@@ -370,43 +370,41 @@ static int cmd_w1_search(const struct shell *sh, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_w1,
 	SHELL_CMD_ARG(reset, NULL,
-		      "Reset 1-Wire bus.\n"
-		      "Usage: <device>",
+		      SHELL_HELP("Reset 1-Wire bus",
+				 "<device>"),
 		      cmd_w1_reset_bus, 2, 0),
 	SHELL_CMD_ARG(read_bit, NULL,
-		      "Read 1-Wire bit.\n"
-		      "Usage: <device>",
+		      SHELL_HELP("Read 1-Wire bit",
+				 "<device>"),
 		      cmd_w1_read_bit, 2, 0),
 	SHELL_CMD_ARG(read_byte, NULL,
-		      "Read 1-Wire byte.\n"
-		      "Usage: <device>",
+		      SHELL_HELP("Read 1-Wire byte",
+				 "<device>"),
 		      cmd_w1_read_byte, 2, 0),
 	SHELL_CMD_ARG(read_block, NULL,
-		      "Read 1-Wire block.\n"
-		      "Usage: <device> <num_bytes>",
+		      SHELL_HELP("Read 1-Wire block",
+				 "<device> <num_bytes>"),
 		      cmd_w1_read_block, 3, 0),
 	SHELL_CMD_ARG(write_bit, NULL,
-		      "Write 1-Wire bit.\n"
-		      "Usage: <device> <bit>",
+		      SHELL_HELP("Write 1-Wire bit",
+				 "<device> <bit>"),
 		      cmd_w1_write_bit, 3, 0),
 	SHELL_CMD_ARG(write_byte, NULL,
-		      "Write 1-Wire byte.\n"
-		      "Usage: <device> [-r] <byte>\n"
-		      OPTION_HELP_RESET,
+		      SHELL_HELP("Write 1-Wire byte",
+				 "<device> [-r] <byte>"),
 		      cmd_w1_write_byte, 3, 1),
 	SHELL_CMD_ARG(write_block, NULL,
-		      "Write 1-Wire block.\n"
-		      "Usage: <device> [-r] <byte1> [<byte2>, ...]\n"
-		      OPTION_HELP_RESET,
+		      SHELL_HELP("Write 1-Wire block",
+				 "<device> [-r] <byte1> [<byte2>, ...]"),
 		      cmd_w1_write_block, 3, BUF_SIZE),
 	SHELL_CMD_ARG(config, NULL,
-		      "Configure 1-Wire host.\n"
-		      "Usage: <device> <type> <value>\n"
-		      "<type> is either a name or an id.",
+		      SHELL_HELP("Configure 1-Wire host",
+				 "<device> <type> <value>\n"
+				 "<type> is either a name or an id."),
 		      cmd_w1_configure, 4, 0),
 	SHELL_CMD_ARG(search, NULL,
-		      "1-Wire devices.\n"
-		      "Usage: <device>",
+		      SHELL_HELP("Search 1-Wire devices on bus",
+				 "<device>"),
 		      cmd_w1_search, 2, 0),
 	SHELL_SUBCMD_SET_END /* Array terminated. */
 );

--- a/drivers/watchdog/wdt_shell.c
+++ b/drivers/watchdog/wdt_shell.c
@@ -9,20 +9,16 @@
 #include <zephyr/drivers/watchdog.h>
 
 #define WDT_SETUP_HELP                                                                             \
-	"Set up watchdog instance. Syntax:\n"                                                      \
-	"<device>"
+	SHELL_HELP("Set up watchdog instance", "<device>")
 
 #define WDT_DISABLE_HELP                                                                           \
-	"Disable watchdog instance. Syntax:\n"                                                     \
-	"<device>"
+	SHELL_HELP("Disable watchdog instance", "<device>")
 
 #define WDT_TIMEOUT_HELP                                                                           \
-	"Install a new timeout. Syntax:\n"                                                         \
-	"<device> <none|cpu|soc> <min_ms> <max_ms>"
+	SHELL_HELP("Install a new timeout", "<device> <none|cpu|soc> <min_ms> <max_ms>")
 
 #define WDT_FEED_HELP                                                                              \
-	"Feed specified watchdog timeout. Syntax:\n"                                               \
-	"<device> <channel_id>"
+	SHELL_HELP("Feed specified watchdog timeout", "<device> <channel_id>")
 
 static const char *const wdt_reset_name[] = {
 	[WDT_FLAG_RESET_NONE] = "none",

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -235,6 +235,82 @@ struct shell_static_entry {
 };
 
 /**
+ * @brief Shell structured help descriptor.
+ *
+ * @details This structure provides an organized way to specify command help
+ * as opposed to a free-form string. This helps make help messages more
+ * consistent and easier to read.
+ */
+struct shell_cmd_help {
+	/* @cond INTERNAL_HIDDEN */
+	uint32_t magic;
+	/* @endcond */
+	const char *description; /*!< Command description */
+	const char *usage;       /*!< Command usage string */
+};
+
+/**
+ * @cond INTERNAL_HIDDEN
+ */
+
+/**
+ * @brief Magic number used to identify the beginning of a structured help
+ * message when cast to a char pointer.
+ */
+#define SHELL_STRUCTURED_HELP_MAGIC 0x86D20BC4
+
+/**
+ * @endcond
+ */
+
+/**
+ * @brief Check if help string is structured help.
+ *
+ * @param help Pointer to help string or structured help.
+ * @return true if help is structured, false otherwise.
+ */
+static inline bool shell_help_is_structured(const char *help)
+{
+	const struct shell_cmd_help *structured = (const struct shell_cmd_help *)help;
+
+	return structured != NULL && structured->magic == SHELL_STRUCTURED_HELP_MAGIC;
+}
+
+#if defined(CONFIG_SHELL_HELP) || defined(__DOXYGEN__)
+/**
+ * @brief Helper macro to create structured help inline.
+ *
+ * This macro allows you to pass structured help directly to existing shell macros.
+ *
+ * Example:
+ *
+ * @code{.c}
+ * #define MY_CMD_HELP SHELL_HELP("Do stuff", "<device> <arg1> [<arg2>]")
+ * SHELL_CMD_REGISTER(my_cmd, NULL, MY_CMD_HELP, &my_cmd_handler, 1, 1);
+ * @endcode
+ *
+ * @param[in] _description	Command description.
+ *				This can be a multi-line string. First line should be one sentence
+ *				describing the command. Additional lines might be used to provide
+ *				additional details.
+ *
+ * @param[in] _usage		Command usage string.
+ *				This can be a multi-line string. First line should always be
+ *				indicating the command syntax (_without_ the command name).
+ *				Additional lines may be used to provide additional details, e.g.
+ *				explain the meaning of each argument, allowed values, etc.
+ */
+#define SHELL_HELP(_description, _usage)                                                           \
+	((const char *)&(const struct shell_cmd_help){                                             \
+		.magic = SHELL_STRUCTURED_HELP_MAGIC,                                              \
+		.description = (_description),                                                     \
+		.usage = (_usage),                                                                 \
+	})
+#else
+#define SHELL_HELP(_description, _usage) NULL
+#endif /* CONFIG_SHELL_HELP */
+
+/**
  * @brief Macro for defining and adding a root command (level 0) with required
  * number of arguments.
  *
@@ -244,7 +320,7 @@ struct shell_static_entry {
  *
  * @param[in] syntax	Command syntax (for example: history).
  * @param[in] subcmd	Pointer to a subcommands array.
- * @param[in] help	Pointer to a command help string.
+ * @param[in] help	Pointer to a command help string (use @ref SHELL_HELP for structured help)
  * @param[in] handler	Pointer to a function handler.
  * @param[in] mandatory	Number of mandatory arguments including command name.
  * @param[in] optional	Number of optional arguments.
@@ -275,7 +351,7 @@ struct shell_static_entry {
  *			exists and equals 1.
  * @param[in] syntax	Command syntax (for example: history).
  * @param[in] subcmd	Pointer to a subcommands array.
- * @param[in] help	Pointer to a command help string.
+ * @param[in] help	Pointer to a command help string (use @ref SHELL_HELP for structured help).
  * @param[in] handler	Pointer to a function handler.
  * @param[in] mandatory	Number of mandatory arguments including command name.
  * @param[in] optional	Number of optional arguments.
@@ -303,7 +379,7 @@ struct shell_static_entry {
  *
  * @param[in] syntax	Command syntax (for example: history).
  * @param[in] subcmd	Pointer to a subcommands array.
- * @param[in] help	Pointer to a command help string.
+ * @param[in] help	Pointer to a command help string. Use @ref SHELL_HELP for structured help.
  * @param[in] handler	Pointer to a function handler.
  */
 #define SHELL_CMD_REGISTER(syntax, subcmd, help, handler) \
@@ -319,7 +395,7 @@ struct shell_static_entry {
  *			exists and equals 1.
  * @param[in] syntax	Command syntax (for example: history).
  * @param[in] subcmd	Pointer to a subcommands array.
- * @param[in] help	Pointer to a command help string.
+ * @param[in] help	Pointer to a command help string. Use @ref SHELL_HELP for structured help.
  * @param[in] handler	Pointer to a function handler.
  */
 #define SHELL_COND_CMD_REGISTER(flag, syntax, subcmd, help, handler) \
@@ -455,7 +531,7 @@ struct shell_static_entry {
  *
  * @param[in] syntax	 Command syntax (for example: history).
  * @param[in] subcmd	 Pointer to a subcommands array.
- * @param[in] help	 Pointer to a command help string.
+ * @param[in] help	 Pointer to a command help string. Use @ref SHELL_HELP for structured help.
  * @param[in] handler	 Pointer to a function handler.
  * @param[in] mand	 Number of mandatory arguments including command name.
  * @param[in] opt	 Number of optional arguments.
@@ -477,7 +553,7 @@ struct shell_static_entry {
  *			 exists and equals 1.
  * @param[in] syntax	 Command syntax (for example: history).
  * @param[in] subcmd	 Pointer to a subcommands array.
- * @param[in] help	 Pointer to a command help string.
+ * @param[in] help	 Pointer to a command help string. Use @ref SHELL_HELP for structured help.
  * @param[in] handler	 Pointer to a function handler.
  * @param[in] mand	 Number of mandatory arguments including command name.
  * @param[in] opt	 Number of optional arguments.

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -38,6 +38,7 @@ static void formatted_text_print(const struct shell *sh, const char *str,
 
 	while (true) {
 		size_t idx = 0;
+		bool newline_found = false;
 
 		length = z_shell_strlen(str) - offset;
 
@@ -51,8 +52,14 @@ static void formatted_text_print(const struct shell *sh, const char *str,
 					z_cursor_next_line_move(sh);
 					z_shell_op_cursor_horiz_move(sh,
 							terminal_offset);
+					newline_found = true;
 					break;
 				}
+			}
+
+			/* If we found a newline, continue processing the remaining text */
+			if (newline_found) {
+				continue;
 			}
 
 			/* String will fit in one line. */

--- a/subsys/shell/shell_help.c
+++ b/subsys/shell/shell_help.c
@@ -113,6 +113,22 @@ static void formatted_text_print(const struct shell *sh, const char *str,
 	z_cursor_next_line_move(sh);
 }
 
+static void formatted_structured_help_print(const struct shell *sh, const char *item_name,
+					    const char *item_help, size_t terminal_offset)
+{
+	const struct shell_cmd_help *structured = (const struct shell_cmd_help *)item_help;
+
+	if (structured->description) {
+		formatted_text_print(sh, structured->description, terminal_offset, false);
+	}
+
+	if (structured->usage) {
+		z_shell_op_cursor_horiz_move(sh, terminal_offset);
+		z_shell_fprintf(sh, SHELL_NORMAL, "Usage: %s ", item_name);
+		formatted_text_print(sh, structured->usage, terminal_offset + 7, false);
+	}
+}
+
 static void help_item_print(const struct shell *sh, const char *item_name,
 			    uint16_t item_name_width, const char *item_help)
 {
@@ -150,7 +166,11 @@ static void help_item_print(const struct shell *sh, const char *item_name,
 		z_shell_fprintf(sh, SHELL_NORMAL, "%s: ", tabulator);
 	}
 	/* print option help */
-	formatted_text_print(sh, item_help, offset, false);
+	if (shell_help_is_structured(item_help)) {
+		formatted_structured_help_print(sh, item_name, item_help, offset);
+	} else {
+		formatted_text_print(sh, item_help, offset, false);
+	}
 }
 
 /* Function prints all subcommands of the parent command together with their
@@ -197,7 +217,11 @@ void z_shell_help_cmd_print(const struct shell *sh,
 
 	z_shell_fprintf(sh, SHELL_NORMAL, "%s%s", cmd->syntax, cmd_sep);
 
-	formatted_text_print(sh, cmd->help, field_width, false);
+	if (shell_help_is_structured(cmd->help)) {
+		formatted_structured_help_print(sh, cmd->syntax, cmd->help, field_width);
+	} else {
+		formatted_text_print(sh, cmd->help, field_width, false);
+	}
 }
 
 bool z_shell_help_request(const char *str)


### PR DESCRIPTION
In order to enable **better and more consistent help messages for shell commands**, this PR introduces a new `SHELL_HELP()` macro (and a few early adopters across various shell modules) that allows to document a command's description and usage in a more structured way, i.e. by clearly separating the command description from its syntax/usage instructions.

This will allow to get rid of all the inconsistent (and duplicated!) variations of "Syntax: ...", "Syntax:\n ...", "Usage: ...", in the commands, and formatting of the description+syntax is taken care of by the shell when it detects the help message is using the "structured" format. On the topic of avoiding string duplication, this also means that people don't need to include the command name when documenting the syntax as it's also done automatically when rendering the help text.

Before (also note the left margin bug in the help of `load` command that the first commit is fixing, and which I tested with various terminal width to make sure it was working correctly):

```shell
uart:~$ devmem --help
devmem - Read/write physical memory
         Usage:
         Read memory at address with optional width:
         devmem <address> [<width>]
         Write memory at address with mandatory width and value:
         devmem <address> <width> <value>
Subcommands:
  dump  : Usage:
          devmem dump -a <address> -s <size> [-w <width>]

  load  : Usage:
          devmem load [options] [address]
Options:
-e	little-endian parse
```

After:

```shell
uart:~$ devmem --help
devmem - Read/write physical memory
         Usage: devmem <address> [<width>]
                Reads memory at address with optional width.
                devmem <address> <width> <value>
                Writes memory at address with mandatory width and value.
Subcommands:
  dump  : Dump memory contents
          Usage: dump -a <address> -s <size> [-w <width>]
  load  : Load contents to memory
          Usage: load [options] <address>
                 Options:
                 -e	little-endian parse
```


Formatting of the help messages is intentionally mostly identical to what we had before, but we could possibly get more creative now that we have different independent "parts" that can be laid out independently.

> [!NOTE]
> One of the goals with this—if not the main goal—will be to be able to generate & capture accurate and well-structured documentation of all (ideally!) shell modules that we could embed in our online documentation. Possibly also have a searchable full list of commands and their help just like we have for example the Kconfig database.