### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -325,7 +325,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: c6296f600a6851bd652f207ab4908d339e1ce705
+      revision: 9eb489fdcde23d4f69ded78bca872bfc31b5ee79
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 0cd7f28d34a5279cd839940c199658a294165722


### PR DESCRIPTION
Update the HW models module to:
9eb489fdcde23d4f69ded78bca872bfc31b5ee79

Including the following:
9eb489f CLOCK (54): Add test interfaces to control duration and to fail tuning
787d8c8 CLOCK (52,53): Add test interface control start duration
8bd3a5f NHW_54_AAR_CCM_ECB: Do not inform about the ECB being already stopped
ca72ca7 RADIO: Add CodedPhy to old comment mentioning what is supported