### PR TITLE
boards: ezurio: bl654_usb: Add board.cmake file

### DIFF
--- a/boards/ezurio/bl654_usb/board.cmake
+++ b/boards/ezurio/bl654_usb/board.cmake
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Add board.cmake file for build system compatibility.