### PR TITLE
wifi: esp32s3: Fix IRQ allocation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: f57f1b1e6e2178a2afe4ec37ffb5fb1eb021e354
+      revision: 82c93ea7f5e90f7e028dc59bfa351d774eb66f37
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
HAL code depends on ESP_WIFI_TASK_CORE_ID symbol to properly build the reserved IRQs table.
If define is not present, IRQ 0 (wifi) is not reserved, causing interrupt allocation conflicts.

edit: Kconfig symbol moved to HAL.