### PR TITLE
boards: nxp: mcxn947: enable the default MCU-Boot swap mode

### DIFF
--- a/boards/nxp/frdm_mcxn947/Kconfig.defconfig
+++ b/boards/nxp/frdm_mcxn947/Kconfig.defconfig
@@ -14,11 +14,4 @@ config MAIN_STACK_SIZE
 
 endif
 
-if BOOTLOADER_MCUBOOT
-choice MCUBOOT_BOOTLOADER_MODE
-	# Board only supports MCUBoot via "upgrade only" method:
-	default MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
-endchoice
-endif #BOOTLOADER_MCUBOOT
-
 endif

--- a/boards/nxp/frdm_mcxn947/Kconfig.sysbuild
+++ b/boards/nxp/frdm_mcxn947/Kconfig.sysbuild
@@ -1,6 +1,0 @@
-# Copyright 2024 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-choice MCUBOOT_MODE
-	default MCUBOOT_MODE_OVERWRITE_ONLY
-endchoice

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -153,9 +153,6 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
-		/* For the MCUBoot "upgrade only" method,
-		 * the slot sizes must be equal.
-		 */
 		slot0_partition: partition@14000 {
 			label = "image-0";
 			reg = <0x00014000 DT_SIZE_K(984)>;

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.dts
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947_mcxn947_cpu0_qspi.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,flash = &w25q64jvssiq;
+		zephyr,flash-controller = &w25q64jvssiq;
 	};
 
 };

--- a/boards/nxp/mcx_n9xx_evk/Kconfig.defconfig
+++ b/boards/nxp/mcx_n9xx_evk/Kconfig.defconfig
@@ -14,11 +14,4 @@ config MAIN_STACK_SIZE
 
 endif
 
-if BOOTLOADER_MCUBOOT
-choice MCUBOOT_BOOTLOADER_MODE
-	# Board only supports MCUBoot via "upgrade only" method:
-	default MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
-endchoice
-endif #BOOTLOADER_MCUBOOT
-
 endif

--- a/boards/nxp/mcx_n9xx_evk/Kconfig.sysbuild
+++ b/boards/nxp/mcx_n9xx_evk/Kconfig.sysbuild
@@ -1,6 +1,0 @@
-# Copyright 2024 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-choice MCUBOOT_MODE
-	default MCUBOOT_MODE_OVERWRITE_ONLY
-endchoice

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk.dtsi
@@ -135,9 +135,6 @@ nxp_8080_touch_panel_i2c: &flexcomm2_lpi2c2 {
 			label = "mcuboot";
 			reg = <0x00000000 DT_SIZE_K(80)>;
 		};
-		/* For the MCUBoot "upgrade only" method,
-		 * the slot sizes must be equal.
-		 */
 		slot0_partition: partition@14000 {
 			label = "image-0";
 			reg = <0x00014000 DT_SIZE_K(984)>;

--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.dts
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu0_qspi.dts
@@ -19,6 +19,7 @@
 
 	chosen {
 		zephyr,flash = &w25q64jwtbjq;
+		zephyr,flash-controller = &w25q64jwtbjq;
 	};
 
 };


### PR DESCRIPTION
- Enables MCU-Boot default Swap mode for the FRDM-MCXN947 and MCX-N9XX-EVK, after the flash driver was upgraded to support the 16-byte programming.
- Fixes flash-controller for frdm_mcxn947_mcxn947_cpu0_qspi.