### PR TITLE
drivers: sensor: st: lps22hh: add device power management support

### DIFF
--- a/drivers/sensor/st/lps22hh/lps22hh.c
+++ b/drivers/sensor/st/lps22hh/lps22hh.c
@@ -23,24 +23,22 @@ LOG_MODULE_REGISTER(LPS22HH, CONFIG_SENSOR_LOG_LEVEL);
 
 static inline int lps22hh_set_odr_raw(const struct device *dev, uint8_t odr)
 {
-	const struct lps22hh_config * const cfg = dev->config;
+	const struct lps22hh_config *const cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 
 	return lps22hh_data_rate_set(ctx, odr);
 }
 
-static int lps22hh_sample_fetch(const struct device *dev,
-				enum sensor_channel chan)
+static int lps22hh_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct lps22hh_data *data = dev->data;
-	const struct lps22hh_config * const cfg = dev->config;
+	const struct lps22hh_config *const cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
 	uint32_t raw_press;
 	int16_t raw_temp;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL
-			|| chan == SENSOR_CHAN_PRESS
-			|| chan == SENSOR_CHAN_AMBIENT_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_PRESS ||
+			chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	switch (chan) {
 	case SENSOR_CHAN_PRESS:
@@ -81,8 +79,7 @@ static int lps22hh_sample_fetch(const struct device *dev,
 	return 0;
 }
 
-static inline void lps22hh_press_convert(struct sensor_value *val,
-					 int32_t raw_val)
+static inline void lps22hh_press_convert(struct sensor_value *val, int32_t raw_val)
 {
 	int32_t press_tmp = raw_val >> 8; /* raw value is left aligned (24 msb) */
 
@@ -97,16 +94,14 @@ static inline void lps22hh_press_convert(struct sensor_value *val,
 	val->val2 = (press_tmp % 40960) * 3125 / 128;
 }
 
-static inline void lps22hh_temp_convert(struct sensor_value *val,
-					int16_t raw_val)
+static inline void lps22hh_temp_convert(struct sensor_value *val, int16_t raw_val)
 {
 	/* Temperature sensitivity is 100 LSB/deg C */
 	val->val1 = raw_val / 100;
 	val->val2 = ((int32_t)raw_val % 100) * 10000;
 }
 
-static int lps22hh_channel_get(const struct device *dev,
-			       enum sensor_channel chan,
+static int lps22hh_channel_get(const struct device *dev, enum sensor_channel chan,
 			       struct sensor_value *val)
 {
 	struct lps22hh_data *data = dev->data;
@@ -147,10 +142,8 @@ static int lps22hh_odr_set(const struct device *dev, uint16_t freq)
 	return 0;
 }
 
-static int lps22hh_attr_set(const struct device *dev,
-			    enum sensor_channel chan,
-			    enum sensor_attribute attr,
-			    const struct sensor_value *val)
+static int lps22hh_attr_set(const struct device *dev, enum sensor_channel chan,
+			    enum sensor_attribute attr, const struct sensor_value *val)
 {
 	if (chan != SENSOR_CHAN_ALL) {
 		LOG_WRN("attr_set() not supported on this channel.");
@@ -234,9 +227,9 @@ static int lps22hh_init_chip(const struct device *dev)
 	return 0;
 }
 
-static int lps22hh_pm_action(const struct device* dev, enum pm_device_action action)
+static int lps22hh_pm_action(const struct device *dev, enum pm_device_action action)
 {
-	const struct lps22hh_config* cfg = dev->config;
+	const struct lps22hh_config *cfg = dev->config;
 	int ret = 0;
 
 	switch (action) {
@@ -311,44 +304,40 @@ static int lps22hh_init(const struct device *dev)
  */
 
 #ifdef CONFIG_LPS22HH_TRIGGER
-#define LPS22HH_CFG_IRQ(inst) \
-	.gpio_int = GPIO_DT_SPEC_INST_GET(inst, drdy_gpios),
+#define LPS22HH_CFG_IRQ(inst) .gpio_int = GPIO_DT_SPEC_INST_GET(inst, drdy_gpios),
 #else
 #define LPS22HH_CFG_IRQ(inst)
 #endif /* CONFIG_LPS22HH_TRIGGER */
 
-#define LPS22HH_CONFIG_COMMON(inst)					\
-	.odr = DT_INST_PROP(inst, odr),					\
+#define LPS22HH_CONFIG_COMMON(inst)                                     \
+	.odr = DT_INST_PROP(inst, odr),                                 \
 	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, drdy_gpios),		\
 			(LPS22HH_CFG_IRQ(inst)), ())
 
-#define LPS22HH_SPI_OPERATION (SPI_WORD_SET(8) |			\
-				SPI_OP_MODE_MASTER |			\
-				SPI_MODE_CPOL |				\
-				SPI_MODE_CPHA)				\
+#define LPS22HH_SPI_OPERATION (SPI_WORD_SET(8) | SPI_OP_MODE_MASTER | SPI_MODE_CPOL | SPI_MODE_CPHA)
 
-#define LPS22HH_CONFIG_SPI(inst)					\
-	{								\
-		STMEMSC_CTX_SPI(&lps22hh_config_##inst.stmemsc_cfg),	\
-		.stmemsc_cfg = {					\
+#define LPS22HH_CONFIG_SPI(inst)                                        \
+	{                                                               \
+		STMEMSC_CTX_SPI(&lps22hh_config_##inst.stmemsc_cfg),    \
+		.stmemsc_cfg =  {                                       \
 			.spi = SPI_DT_SPEC_INST_GET(inst,		\
-					   LPS22HH_SPI_OPERATION,	\
-					   0),				\
-		},							\
-		LPS22HH_CONFIG_COMMON(inst)				\
+				LPS22HH_SPI_OPERATION,			\
+				0),					\
+		},                                                      \
+		LPS22HH_CONFIG_COMMON(inst)                             \
 	}
 
 /*
  * Instantiation macros used when a device is on an I2C bus.
  */
 
-#define LPS22HH_CONFIG_I2C(inst)					\
-	{								\
-		STMEMSC_CTX_I2C(&lps22hh_config_##inst.stmemsc_cfg),	\
-		.stmemsc_cfg = {					\
-			.i2c = I2C_DT_SPEC_INST_GET(inst),		\
-		},							\
-		LPS22HH_CONFIG_COMMON(inst)				\
+#define LPS22HH_CONFIG_I2C(inst)                                          \
+	{                                                                 \
+		STMEMSC_CTX_I2C(&lps22hh_config_##inst.stmemsc_cfg),      \
+		.stmemsc_cfg =  {                                         \
+			.i2c = I2C_DT_SPEC_INST_GET(inst),                \
+		},                                                        \
+		LPS22HH_CONFIG_COMMON(inst)                               \
 	}
 
 /*
@@ -368,8 +357,8 @@ static int lps22hh_init(const struct device *dev)
 
 #define LPS22HH_CONFIG_I3C_OR_I2C(inst)					\
 	COND_CODE_0(DT_INST_PROP_BY_IDX(inst, reg, 1),			\
-		    (LPS22HH_CONFIG_I2C(inst)),				\
-		    (LPS22HH_CONFIG_I3C(inst)))
+		(LPS22HH_CONFIG_I2C(inst)),				\
+		(LPS22HH_CONFIG_I3C(inst)))
 
 /*
  * Main instantiation macro. Use of COND_CODE_1() selects the right
@@ -380,13 +369,13 @@ static int lps22hh_init(const struct device *dev)
 	static struct lps22hh_data lps22hh_data_##inst;				\
 	static const struct lps22hh_config lps22hh_config_##inst =		\
 	COND_CODE_1(DT_INST_ON_BUS(inst, spi),					\
-		    (LPS22HH_CONFIG_SPI(inst)),					\
-		    (COND_CODE_1(DT_INST_ON_BUS(inst, i3c),			\
-				 (LPS22HH_CONFIG_I3C_OR_I2C(inst)),		\
-				 (LPS22HH_CONFIG_I2C(inst)))));			\
-	PM_DEVICE_DT_INST_DEFINE(inst, lps22hh_pm_action); 			\
-	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hh_init, PM_DEVICE_DT_INST_GET(inst), &lps22hh_data_##inst,	\
-			      &lps22hh_config_##inst, POST_KERNEL,		\
-			      CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_driver_api);
+			(LPS22HH_CONFIG_SPI(inst)),				\
+			(COND_CODE_1(DT_INST_ON_BUS(inst, i3c),			\
+				(LPS22HH_CONFIG_I3C_OR_I2C(inst)),		\
+				(LPS22HH_CONFIG_I2C(inst)))));			\
+	PM_DEVICE_DT_INST_DEFINE(inst, lps22hh_pm_action);                                         \
+	SENSOR_DEVICE_DT_INST_DEFINE(inst, lps22hh_init, PM_DEVICE_DT_INST_GET(inst),              \
+				     &lps22hh_data_##inst, &lps22hh_config_##inst, POST_KERNEL,    \
+				     CONFIG_SENSOR_INIT_PRIORITY, &lps22hh_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(LPS22HH_DEFINE)


### PR DESCRIPTION
Adds device power management (both runtime and system-wide) support to the LPS22HH driver.
The sensor now registers with the Zephyr PM core, enters power-down by writing ODR = 0 (as specified in the datasheet) and restores the configured ODR on resume. Tested on a custom nRF54-based board that carries an LPS22HH.