### PR TITLE
boards: m5stack: m5stack_fire is not a default test platform

### DIFF
--- a/boards/m5stack/m5stack_fire/m5stack_fire_procpu.yaml
+++ b/boards/m5stack/m5stack_fire/m5stack_fire_procpu.yaml
@@ -14,5 +14,3 @@ supported:
   - nvs
   - pwm
 vendor: m5stack
-testing:
-  default: true


### PR DESCRIPTION
remove testing default=true from this board as it is not a default test platform

causes hello world workflow to fail in CI (on push but on PRs as well) https://github.com/zephyrproject-rtos/zephyr/actions/runs/15445801881