### PR TITLE
arch: arm: cortex-m: Reduce ZLI latency by not disabling them in wrapper

### DIFF
--- a/arch/arm/core/cortex_m/isr_wrapper.c
+++ b/arch/arm/core/cortex_m/isr_wrapper.c
@@ -38,21 +38,21 @@ void _isr_wrapper(void)
 
 #ifdef CONFIG_PM
 	/*
-	 * All interrupts are disabled when handling idle wakeup.  For tickless
-	 * idle, this ensures that the calculation and programming of the
-	 * device for the next timer deadline is not interrupted.  For
+	 * All non-ZLI interrupts are disabled when handling idle wakeup.  For
+	 * tickless idle, this ensures that the calculation and programming of
+	 * the device for the next timer deadline is not interrupted.  For
 	 * non-tickless idle, this ensures that the clearing of the kernel idle
-	 * state is not interrupted.  In each case, pm_system_resume
-	 * is called with interrupts disabled.
+	 * state is not interrupted.  In each case, pm_system_resume is called
+	 * with non-ZLI interrupts disabled.
 	 */
 
 	/*
-	 * Disable interrupts to prevent nesting while exiting idle state. This
-	 * is only necessary for the Cortex-M because it is the only ARM
-	 * architecture variant that automatically enables interrupts when
+	 * Disable non-ZLI interrupts to prevent nesting while exiting idle
+	 * state. This is only necessary for the Cortex-M because it is the only
+	 * ARM architecture variant that automatically enables interrupts when
 	 * entering an ISR.
 	 */
-	__disable_irq();
+	unsigned int key = arch_irq_lock();
 
 	/* is this a wakeup from idle ? */
 	/* requested idle duration, in ticks */
@@ -62,7 +62,7 @@ void _isr_wrapper(void)
 		pm_system_resume();
 	}
 	/* re-enable interrupts */
-	__enable_irq();
+	arch_irq_unlock(key);
 #endif /* CONFIG_PM */
 
 #if defined(CONFIG_ARM_CUSTOM_INTERRUPT_CONTROLLER)


### PR DESCRIPTION
The difference between `__irq_disable()` and `irq_lock()` is that the former essentially translates to `cpsid i`, whereas `irq_lock()` translates to setting `BASEPRI` (on cores with `BASEPRI`). This means that using `irq_lock()` does not disable zero-latency interrupts (ZLIs), which reduces the potential execution latency of ZLIs.

In both `isr_wrapper()` and `_arch_isr_direct_pm()` (which is just really an implementation of `ISR_DIRECT_PM()`), we were using `__irq_disable()` to disable all interrupts, including ZLIs. But the code executed with interrupts disabled handles waking up from idle, and so must only be protected against regular interrupts being executed, not ZLIs, which should have no effect on the correct execution of the code.