### PR TITLE
Revert "drivers: spi: fix the update of spi_context tx & rx length"

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -661,17 +661,17 @@ static inline size_t spi_context_total_rx_len(struct spi_context *ctx)
 /* Similar to spi_context_total_tx_len, except does not count words that have been finished
  * in the current buffer, ie only including what is remaining in the current buffer in the sum.
  */
-static inline size_t spi_context_tx_len_left(struct spi_context *ctx)
+static inline size_t spi_context_tx_len_left(struct spi_context *ctx, uint8_t dfs)
 {
-	return ctx->tx_len + spi_context_count_tx_buf_lens(ctx, 1);
+	return (ctx->tx_len * dfs) + spi_context_count_tx_buf_lens(ctx, 1);
 }
 
 /* Similar to spi_context_total_rx_len, except does not count words that have been finished
  * in the current buffer, ie only including what is remaining in the current buffer in the sum.
  */
-static inline size_t spi_context_rx_len_left(struct spi_context *ctx)
+static inline size_t spi_context_rx_len_left(struct spi_context *ctx, uint8_t dfs)
 {
-	return ctx->rx_len + spi_context_count_rx_buf_lens(ctx, 1);
+	return (ctx->rx_len * dfs) + spi_context_count_rx_buf_lens(ctx, 1);
 }
 
 #ifdef __cplusplus

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -496,7 +496,7 @@ void spi_context_update_tx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		return;
 	}
 
-	ctx->tx_len -= len * dfs;
+	ctx->tx_len -= len;
 	if (!ctx->tx_len) {
 		/* Current buffer is done. Get the next one to be processed. */
 		++ctx->current_tx;
@@ -555,7 +555,7 @@ void spi_context_update_rx(struct spi_context *ctx, uint8_t dfs, uint32_t len)
 		return;
 	}
 
-	ctx->rx_len -= len * dfs;
+	ctx->rx_len -= len;
 	if (!ctx->rx_len) {
 		/* Current buffer is done. Get the next one to be processed. */
 		++ctx->current_rx;

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi.c
@@ -241,6 +241,7 @@ static void lpspi_isr(const struct device *dev)
 	const struct lpspi_config *config = dev->config;
 	struct lpspi_data *data = dev->data;
 	struct lpspi_driver_data *lpspi_data = (struct lpspi_driver_data *)data->driver_data;
+	uint8_t word_size_bytes = lpspi_data->word_size_bytes;
 	struct spi_context *ctx = &data->ctx;
 	uint32_t status_flags = base->SR;
 
@@ -252,7 +253,7 @@ static void lpspi_isr(const struct device *dev)
 		lpspi_handle_tx_irq(dev);
 	}
 
-	if (spi_context_rx_len_left(ctx) == 0) {
+	if (spi_context_rx_len_left(ctx, word_size_bytes) == 0) {
 		base->IER &= ~LPSPI_IER_RDIE_MASK;
 		base->CR |= LPSPI_CR_RRF_MASK; /* flush rx fifo */
 	}
@@ -274,7 +275,8 @@ static void lpspi_isr(const struct device *dev)
 		lpspi_data->fill_len = fill_len;
 	}
 
-	if (spi_context_rx_len_left(ctx) == 1 && (LPSPI_VERID_MAJOR(base->VERID) < 2)) {
+	if ((DIV_ROUND_UP(spi_context_rx_len_left(ctx, word_size_bytes), word_size_bytes) == 1) &&
+	    (LPSPI_VERID_MAJOR(base->VERID) < 2)) {
 		/* Due to stalling behavior on older LPSPI,
 		 * need to end xfer in order to get last bit clocked out on bus.
 		 */


### PR DESCRIPTION
This reverts commit 4a486ce51ba7ebdd58dc22b6b1f4b679b177334f.

This change was totally wrong.

One can see clearly at https://github.com/zephyrproject-rtos/zephyr/blob/c57646450849a98a6f16891799e805c141c71e5d/drivers/spi/spi_context.h#L424-L426 that the units of this value is *frames*, NOT bytes. And everywhere it is used it is used as a frame value, and changing some assumption like this would require actually changing all the other places the assumption would now be wrong in both the spi_context.h file and all the SPI drivers in tree, which the PR that did this change did not do.

Fixes #91075