### PR TITLE
modules: hal_nxp: migrate dma_nxp_edma driver to SDK-NG

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -64,6 +64,7 @@ set_variable_ifdef(CONFIG_DMA_MCUX_EDMA_V3      CONFIG_MCUX_COMPONENT_driver.dma
 set_variable_ifdef(CONFIG_DMA_MCUX_EDMA         CONFIG_MCUX_COMPONENT_driver.edma)
 set_variable_ifdef(CONFIG_DMA_MCUX_EDMA_V3      CONFIG_MCUX_COMPONENT_driver.dma3)
 set_variable_ifdef(CONFIG_DMA_MCUX_EDMA_V4      CONFIG_MCUX_COMPONENT_driver.edma4)
+set_variable_ifdef(CONFIG_DMA_NXP_EDMA          CONFIG_MCUX_COMPONENT_driver.edma_rev2)
 set_variable_ifdef(CONFIG_ENTROPY_MCUX_RNGA     CONFIG_MCUX_COMPONENT_driver.rnga)
 set_variable_ifdef(CONFIG_ENTROPY_MCUX_TRNG     CONFIG_MCUX_COMPONENT_driver.trng)
 set_variable_ifdef(CONFIG_ENTROPY_MCUX_CAAM     CONFIG_MCUX_COMPONENT_driver.caam)

--- a/modules/hal_nxp/mcux/mcux-sdk/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/mcux-sdk/CMakeLists.txt
@@ -76,8 +76,6 @@ if (DEFINED CONFIG_SOC_RESET_HOOK)
   endif()
 endif()
 
-include_driver_ifdef(CONFIG_DMA_NXP_EDMA               edma_rev2       driver_edma_rev2)
-
 if(CONFIG_CPU_CORTEX_A)
   include_driver_ifdef(CONFIG_HAS_MCUX_CACHE		cache/armv8-a	driver_cache_armv8a)
 endif()

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: f37e22e5246d862161f024485ca369f70c20ffc0
+      revision: 008b9ccda27eea95370762808da10d5834ca1529
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Migrate the dma_nxp_edma driver to SDK-NG. This means:
	1) Adding the CMAKE logic required for compiling the module

	2) Updating the HAL_NXP manifest to pull in the patches which
	handle the migration on the HAL side

	3) Removing CMAKE logic from old mcux-sdk so that they are no
	longer included in the build