### PR TITLE
boards: ambiq: apollo510_evb: add pinctrl sleep mode

### DIFF
--- a/boards/ambiq/apollo510_evb/apollo510_evb-pinctrl.dtsi
+++ b/boards/ambiq/apollo510_evb/apollo510_evb-pinctrl.dtsi
@@ -18,6 +18,12 @@
 		};
 	};
 
+	uart0_sleep: uart0_sleep {
+		group1 {
+			pinmux = <GPIO_P30>, <GPIO_P55>;
+		};
+	};
+
 	swo_default: swo_default {
 		group0 {
 			pinmux = <SWO_P28>;
@@ -40,12 +46,24 @@
 		};
 	};
 
+	i2c0_sleep: i2c0_sleep {
+		group1 {
+			pinmux = <GPIO_P5>, <GPIO_P6>;
+		};
+	};
+
 	i2c1_default: i2c1_default {
 		group1 {
 			pinmux = <M1SCL_P8>, <M1SDAWIR3_P9>;
 			drive-open-drain;
 			drive-strength = "0.5";
 			bias-pull-up;
+		};
+	};
+
+	i2c1_sleep: i2c1_sleep {
+		group1 {
+			pinmux = <GPIO_P8>, <GPIO_P9>;
 		};
 	};
 
@@ -58,12 +76,39 @@
 		};
 	};
 
+	i2c2_sleep: i2c2_sleep {
+		group1 {
+			pinmux = <GPIO_P25>, <GPIO_P26>;
+		};
+	};
+
 	i2c3_default: i2c3_default {
 		group1 {
 			pinmux = <M3SCL_P31>, <M3SDAWIR3_P32>;
 			drive-open-drain;
 			drive-strength = "0.5";
 			bias-pull-up;
+		};
+	};
+
+	i2c3_sleep: i2c3_sleep {
+		group1 {
+			pinmux = <GPIO_P31>, <GPIO_P32>;
+		};
+	};
+
+	i2c4_default: i2c4_default {
+		group1 {
+			pinmux = <M4SCL_P34>, <M4SDAWIR3_P35>;
+			drive-open-drain;
+			drive-strength = "0.5";
+			bias-pull-up;
+		};
+	};
+
+	i2c4_sleep: i2c4_sleep {
+		group1 {
+			pinmux = <GPIO_P34>, <GPIO_P35>;
 		};
 	};
 
@@ -76,12 +121,24 @@
 		};
 	};
 
+	i2c5_sleep: i2c5_sleep {
+		group1 {
+			pinmux = <GPIO_P47>, <GPIO_P48>;
+		};
+	};
+
 	i2c6_default: i2c6_default {
 		group1 {
 			pinmux = <M6SCL_P61>, <M6SDAWIR3_P62>;
 			drive-open-drain;
 			drive-strength = "0.5";
 			bias-pull-up;
+		};
+	};
+
+	i2c6_sleep: i2c6_sleep {
+		group1 {
+			pinmux = <GPIO_P61>, <GPIO_P62>;
 		};
 	};
 
@@ -94,9 +151,21 @@
 		};
 	};
 
+	i2c7_sleep: i2c7_sleep {
+		group1 {
+			pinmux = <GPIO_P22>, <GPIO_P23>;
+		};
+	};
+
 	spid0_default: spid0_default {
 		group1 {
 			pinmux = <SLSCK_P11>, <SLMISO_P83>, <SLMOSI_P52>, <SLnCE_P13>;
+		};
+	};
+
+	spid0_sleep: spid0_sleep {
+		group1 {
+			pinmux = <GPIO_P11>, <GPIO_P83>, <GPIO_P52>, <GPIO_P13>;
 		};
 	};
 
@@ -106,9 +175,21 @@
 		};
 	};
 
+	spi0_sleep: spi0_sleep {
+		group1 {
+			pinmux = <GPIO_P5>, <GPIO_P7>, <GPIO_P6>;
+		};
+	};
+
 	spi1_default: spi1_default {
 		group1 {
 			pinmux = <M1SCK_P8>, <M1MISO_P10>, <M1MOSI_P9>;
+		};
+	};
+
+	spi1_sleep: spi1_sleep {
+		group1 {
+			pinmux = <GPIO_P8>, <GPIO_P10>, <GPIO_P9>;
 		};
 	};
 
@@ -118,9 +199,21 @@
 		};
 	};
 
+	spi2_sleep: spi2_sleep {
+		group1 {
+			pinmux = <GPIO_P25>, <GPIO_P27>, <GPIO_P26>;
+		};
+	};
+
 	spi3_default: spi3_default {
 		group1 {
 			pinmux = <M3SCK_P31>, <M3MISO_P33>, <M3MOSI_P32>;
+		};
+	};
+
+	spi3_sleep: spi3_sleep {
+		group1 {
+			pinmux = <GPIO_P31>, <GPIO_P33>, <GPIO_P32>;
 		};
 	};
 
@@ -130,9 +223,21 @@
 		};
 	};
 
+	spi4_sleep: spi4_sleep {
+		group1 {
+			pinmux = <GPIO_P34>, <GPIO_P36>, <GPIO_P35>;
+		};
+	};
+
 	spi5_default: spi5_default {
 		group1 {
 			pinmux = <M5SCK_P47>, <M5MISO_P49>, <M5MOSI_P48>;
+		};
+	};
+
+	spi5_sleep: spi5_sleep {
+		group1 {
+			pinmux = <GPIO_P47>, <GPIO_P49>, <GPIO_P48>;
 		};
 	};
 
@@ -142,9 +247,21 @@
 		};
 	};
 
+	spi6_sleep: spi6_sleep {
+		group1 {
+			pinmux = <GPIO_P61>, <GPIO_P63>, <GPIO_P62>;
+		};
+	};
+
 	spi7_default: spi7_default {
 		group1 {
 			pinmux = <M7SCK_P22>, <M7MISO_P24>, <M7MOSI_P23>;
+		};
+	};
+
+	spi7_sleep: spi7_sleep {
+		group1 {
+			pinmux = <GPIO_P22>, <GPIO_P24>, <GPIO_P23>;
 		};
 	};
 

--- a/boards/ambiq/apollo510_evb/apollo510_evb.dts
+++ b/boards/ambiq/apollo510_evb/apollo510_evb.dts
@@ -107,7 +107,8 @@
 &uart0 {
 	current-speed = <115200>;
 	pinctrl-0 = <&uart0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
 	status = "okay";
 };
 

--- a/drivers/spi/spi_ambiq_spic.c
+++ b/drivers/spi/spi_ambiq_spic.c
@@ -465,25 +465,44 @@ end:
 #ifdef CONFIG_PM_DEVICE
 static int spi_ambiq_pm_action(const struct device *dev, enum pm_device_action action)
 {
+	const struct spi_ambiq_config *cfg = dev->config;
 	struct spi_ambiq_data *data = dev->data;
-	uint32_t ret;
+	int err;
 	am_hal_sysctrl_power_state_e status;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		/* Set pins to active state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);
+		if (err < 0) {
+			return err;
+		}
 		status = AM_HAL_SYSCTRL_WAKE;
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
+		/* Move pins to sleep state */
+		err = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_SLEEP);
+		if ((err < 0) && (err != -ENOENT)) {
+			/*
+			 * If returning -ENOENT, no pins where defined for sleep mode :
+			 * Do not output on console (might sleep already) when going to
+			 * sleep,
+			 * "SPI pinctrl sleep state not available"
+			 * and don't block PM suspend.
+			 * Else return the error.
+			 */
+			return err;
+		}
 		status = AM_HAL_SYSCTRL_DEEPSLEEP;
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	ret = am_hal_iom_power_ctrl(data->iom_handler, status, true);
+	err = am_hal_iom_power_ctrl(data->iom_handler, status, true);
 
-	if (ret != AM_HAL_STATUS_SUCCESS) {
-		LOG_ERR("am_hal_iom_power_ctrl failed: %d", ret);
+	if (err != AM_HAL_STATUS_SUCCESS) {
+		LOG_ERR("am_hal_iom_power_ctrl failed: %d", err);
 		return -EPERM;
 	} else {
 		return 0;

--- a/soc/ambiq/apollo5x/soc.c
+++ b/soc/ambiq/apollo5x/soc.c
@@ -48,9 +48,9 @@ void soc_early_init_hook(void)
 	/*
 	 * Set default temperature for spotmgr to room temperature
 	 */
-	am_hal_pwrctrl_temp_thresh_t dummy;
+	am_hal_pwrctrl_temp_thresh_t dummy[32];
 
-	am_hal_pwrctrl_temp_update(25.0f, &dummy);
+	am_hal_pwrctrl_temp_update(25.0f, dummy);
 
 	/* Enable Icache*/
 	sys_cache_instr_enable();


### PR DESCRIPTION
This PR adds support for a new sleep mode via pinctrl for the Ambiq Apollo510 EVB board and updates several drivers and DTS files accordingly 