### PR TITLE
boards: imx93_evk: refine board document

### DIFF
--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -9,8 +9,9 @@ small and low cost package. The MCIMX93-EVK board is an entry-level development
 board, which helps developers to get familiar with the processor before
 investing a large amount of resources in more specific designs.
 
-i.MX93 MPU is composed of one cluster of 2x Cortex-A55 cores and a single
-Cortex®-M33 core. Zephyr OS is ported to run on one of the Cortex®-A55 core.
+i.MX93 MPU is composed of one cluster of 2x Cortex®-A55 cores and a single
+Cortex®-M33 core. Zephyr OS is ported on Cortex®-A55 core and Cortex®-M33
+core.
 
 - Board features:
 


### PR DESCRIPTION
Refine the board document to address Zephyr could run both Cortex-A Core and Cortex-M33 Core.