### PR TITLE
boards: arduino: uno_r4: enable all ioports needed by the arduino header

### DIFF
--- a/boards/arduino/uno_r4/arduino_uno_r4.dts
+++ b/boards/arduino/uno_r4/arduino_uno_r4.dts
@@ -38,7 +38,16 @@
 	};
 };
 
+
+&ioport0 {
+	status = "okay";
+};
+
 &ioport1 {
+	status = "okay";
+};
+
+&ioport3 {
 	status = "okay";
 };
 

--- a/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
+++ b/boards/arduino/uno_r4/arduino_uno_r4_wifi.overlay
@@ -94,6 +94,10 @@
 	};
 };
 
+&ioport4 {
+	status = "okay";
+};
+
 &spi0 {
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";


### PR DESCRIPTION
The arduino Uno R4 has only ioport1 enabled in the dts. The arduino header however uses ioport0,1,3 [minima variant] and ioport 0,1,3,4 [wifi variant]. This causes a build failure for some of the pins.

This change makes sure than an application can use any arduino pins.

Fixes: #90827 