### PR TITLE
drivers: spi: ra: Add check for unsupported SPI word sizes

### DIFF
--- a/drivers/spi/spi_b_renesas_ra8.c
+++ b/drivers/spi/spi_b_renesas_ra8.c
@@ -86,6 +86,7 @@ static int ra_spi_b_configure(const struct device *dev, const struct spi_config 
 {
 	struct ra_spi_data *data = dev->data;
 	fsp_err_t fsp_err;
+	uint8_t word_size = SPI_WORD_SIZE_GET(config->operation);
 
 	if (spi_context_configured(&data->ctx, config)) {
 		/* Nothing to do */
@@ -97,6 +98,11 @@ static int ra_spi_b_configure(const struct device *dev, const struct spi_config 
 	}
 
 	if ((config->operation & SPI_FRAME_FORMAT_TI) == SPI_FRAME_FORMAT_TI) {
+		return -ENOTSUP;
+	}
+
+	if (word_size < 4 || word_size > 32) {
+		LOG_ERR("Unsupported SPI word size: %u", word_size);
 		return -ENOTSUP;
 	}
 

--- a/drivers/spi/spi_renesas_ra.c
+++ b/drivers/spi/spi_renesas_ra.c
@@ -82,6 +82,7 @@ static int ra_spi_configure(const struct device *dev, const struct spi_config *c
 {
 	struct ra_spi_data *data = dev->data;
 	fsp_err_t fsp_err;
+	uint8_t word_size = SPI_WORD_SIZE_GET(config->operation);
 
 	if (spi_context_configured(&data->ctx, config)) {
 		/* Nothing to do */
@@ -93,6 +94,12 @@ static int ra_spi_configure(const struct device *dev, const struct spi_config *c
 	}
 
 	if ((config->operation & SPI_FRAME_FORMAT_TI) == SPI_FRAME_FORMAT_TI) {
+		return -ENOTSUP;
+	}
+
+	if (!((word_size >= 8 && word_size <= 16) || word_size == 20 || word_size == 24 ||
+	      word_size == 32)) {
+		LOG_ERR("Unsupported SPI word size: %u", word_size);
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
SPI driver for Renesas RA series include
- spi_renesas_ra: allows transfer bit length selectable as 8 -> 16, 20, 24, or 32 bits
- spi_b_renesas_ra8: allows transfer bit length selectable as 4 -> 32 bits

Add condition to filter out unsupported cases