### PR TITLE
bluetooth: keys: addr is null and assert in bt_keys_find_addr

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -79,7 +79,7 @@ static bool key_is_in_use(uint8_t id)
 {
 	struct key_data kdata = { false, id };
 
-	bt_conn_foreach(BT_CONN_TYPE_ALL, find_key_in_use, &kdata);
+	bt_conn_foreach(BT_CONN_TYPE_LE, find_key_in_use, &kdata);
 
 	return kdata.in_use;
 }


### PR DESCRIPTION
When there are br connections connected, find_key_in_use call bt_conn_get_dst to get br connection's dst and bt_conn_get_dst return NULL, then bt_keys_find_addr aseert because addr is NULL.