### PR TITLE
tests: drivers: sensor: spi: include `gpio.h` header

### DIFF
--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -6,6 +6,8 @@
  * Application overlay for spi devices
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
 /****************************************
  * PLEASE KEEP REG ADDRESSES SEQUENTIAL *
  ***************************************/


### PR DESCRIPTION
This patch adds a missing include directive to `spi.dtsi` in the `build_all` configuration. The include is required because commit 2ac316465fac introduced the use of `GPIO_ACTIVE_HIGH` and `GPIO_ACTIVE_LOW` macros.