### PR TITLE
usb: nxp mcux: usb device remote wakeup

### DIFF
--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -154,6 +154,7 @@ config USB_MCUX
 	default y
 	depends on DT_HAS_NXP_EHCI_ENABLED || DT_HAS_NXP_LPCIP3511_ENABLED
 	select PINCTRL
+	imply USB_DEVICE_REMOTE_WAKEUP
 	help
 	  NXP MCUX USB Device Controller Driver for MXRT and LPC SoC's.
 

--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -583,6 +583,18 @@ int usb_dc_ep_write(const uint8_t ep, const uint8_t *const data,
 	return 0;
 }
 
+int usb_dc_wakeup_request(void)
+{
+	usb_status_t status = dev_state.dev_struct.controllerInterface->deviceControl(
+		dev_state.dev_struct.controllerHandle, kUSB_DeviceControlResume, NULL);
+
+	if (status != kStatus_USB_Success) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
 static void update_control_stage(usb_device_callback_message_struct_t *cb_msg,
 				 uint32_t data_len, uint32_t max_data_len)
 {

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_device_config.h
@@ -40,6 +40,14 @@
 /* Whether device is self power. 1U supported, 0U not supported */
 #define USB_DEVICE_CONFIG_SELF_POWER (1U)
 
+/*! @brief Whether the low power mode is enabled or not. */
+#define USB_DEVICE_CONFIG_LOW_POWER_MODE (1U)
+
+#ifdef CONFIG_USB_DEVICE_REMOTE_WAKEUP
+/*! @brief Whether device remote wakeup supported. 1U supported, 0U not supported */
+#define USB_DEVICE_CONFIG_REMOTE_WAKEUP (1U)
+#endif
+
 #define NUM_INSTS DT_NUM_INST_STATUS_OKAY(nxp_ehci) + DT_NUM_INST_STATUS_OKAY(nxp_lpcip3511)
 BUILD_ASSERT(NUM_INSTS <= 1, "Only one USB device supported");
 #if DT_HAS_COMPAT_STATUS_OKAY(nxp_lpcip3511)


### PR DESCRIPTION
USB device remote wakeup implementation for NXP MCUX

PR as a result of the discussion here: https://github.com/zephyrproject-rtos/zephyr/issues/91063

@DerekSnell @MarkWangChinese 