### PR TITLE
west build: display closest matches when an invalid board is given

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -218,10 +218,9 @@ elseif(BOARD_DIR)
 	  "Please run a pristine build."
   )
 else()
-  message("No board named '${BOARD}' found.\n\n"
-          "Please choose one of the following boards:\n"
-  )
-  execute_process(${list_boards_commands})
+  message("No board named '${BOARD}' found. Did you mean:\n")
+  execute_process(${list_boards_commands} --fuzzy-match ${BOARD})
+  message("\nRun 'west boards' for the full list.")
   unset(CACHED_BOARD CACHE)
   message(FATAL_ERROR "Invalid BOARD; see above.")
 endif()


### PR DESCRIPTION
Currently, when an invalid board name is given to `west build`, it prints the full set of available boards, which is a wall of text that gives no immediate help to the user. 

This PR modifies this behavior so that when an invalid board is specified, the 3 board names that most closely match the input are printed. The user is also instructed to get the full set of boards via `west boards`:

```
$ west build -p -b ardduino_giga_r1/stm32h747xx/m7 samples/hello_world
-- west build: making build dir pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: samples/hello_world
-- CMake version: 3.22.1
-- Found Python3: venv/bin/python3.12 (found suitable version "3.12.0", minimum required is "3.10") found components: Interpreter 
-- Cache files will be written to: ~/.cache/zephyr
-- Zephyr version: 4.1.99 (zephyr)
-- Found west (found suitable version "1.4.0", minimum required is "0.14.0")
No board named 'ardduino_giga_r1' found. Did you mean:

arduino_giga_r1
arduino_uno_r4
arduino_zero

Run 'west boards' for the full list.
CMake Error at zephyr/cmake/modules/boards.cmake:225 (message):
  Invalid BOARD; see above.
```