### PR TITLE
soc: silabs: silabs_siwx91x: Increasing the mutex count

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_socket.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_socket.c
@@ -303,6 +303,7 @@ static int siwx91x_sock_accept(struct net_context *context,
 	SL_SI91X_FD_SET(ret, &sidev->fds_watch);
 	sl_si91x_select(SLI_NUMBER_OF_SOCKETS, &sidev->fds_watch, NULL, NULL, NULL,
 			siwx91x_sock_on_recv);
+	net_context_set_state(newcontext, NET_CONTEXT_CONNECTED);
 	if (cb) {
 		cb(newcontext, &addr_le, sizeof(addr_le), 0, user_data);
 	}

--- a/soc/silabs/silabs_siwx91x/Kconfig.defconfig
+++ b/soc/silabs/silabs_siwx91x/Kconfig.defconfig
@@ -45,6 +45,12 @@ config CMSIS_V2_THREAD_DYNAMIC_STACK_SIZE
 config CMSIS_V2_THREAD_MAX_STACK_SIZE
 	default 2048
 
+configdefault CMSIS_V2_MUTEX_MAX_COUNT
+	default 10
+
+configdefault CMSIS_V2_EVT_FLAGS_MAX_COUNT
+	default 10
+
 endif # WISECONNECT_NETWORK_STACK
 
 rsource "*/Kconfig.defconfig"


### PR DESCRIPTION
Increasing the mutex counts and event flag in order to avoid mutex failures in netoffload mode