### PR TITLE
drivers: spi: mcux_flexio: Fix flexio SPI loop delay issue

### DIFF
--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024, STRIM, ALC
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -101,11 +101,6 @@ static int spi_mcux_flexio_isr(void *user_data)
 	const struct device *dev = (const struct device *)user_data;
 	const struct spi_mcux_flexio_config *config = dev->config;
 	struct spi_mcux_flexio_data *data = dev->data;
-
-	/* Wait until data transfer complete. */
-	WAIT_FOR((3U == (FLEXIO_SPI_GetStatusFlags(config->flexio_spi)
-		& (uint32_t)(kFLEXIO_SPI_TxBufferEmptyFlag | kFLEXIO_SPI_RxBufferFullFlag))),
-		100, NULL);
 
 	FLEXIO_SPI_MasterTransferHandleIRQ(config->flexio_spi, &data->handle);
 

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: ad531e7b9980b171f90c651340bb1bb6cc2c6d51
+      revision: f37e22e5246d862161f024485ca369f70c20ffc0
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The function FLEXIO_SPI_MasterTransferNonBlocking has a bug when works in CS continuous mode. In this mode, both RX and TX interrupts are enabled, they share the same IRQ line.

In the ISR, the RX event and TX event are not handled well, so a short delay in ISR is needed.

The function FLEXIO_SPI_MasterTransferNonBlocking issue is fixed, the delay in ISR can be removed.