### PR TITLE
ci: do not pull optional modules

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -192,7 +192,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
           west init -l . || true
-          west config manifest.group-filter -- +ci,+optional
+          west config manifest.group-filter -- +ci
           west config --global update.narrow true
           west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || west update --path-cache /repo-cache/zephyrproject 2>&1 1> west.update.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /repo-cache/zephyrproject)
           west forall -c 'git reset --hard HEAD'

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Kernel initialization module
+ * @brief Kernel initialization module ++
  *
  * This module contains routines that are used to initialize the kernel.
  */


### PR DESCRIPTION
Lets see what breaks if optional modules/project are not pulled.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
