### PR TITLE
drivers: clock_control: siwx91x: Fix clock init

### DIFF
--- a/drivers/clock_control/clock_control_silabs_siwx91x.c
+++ b/drivers/clock_control/clock_control_silabs_siwx91x.c
@@ -226,6 +226,8 @@ static int siwx91x_clock_init(const struct device *dev)
 {
 	SystemCoreClockUpdate();
 
+	sl_si91x_clock_manager_init();
+
 	/* Use SoC PLL at configured frequency as core clock */
 	sl_si91x_clock_manager_m4_set_core_clk(M4_SOCPLLCLK, CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
 


### PR DESCRIPTION
New versions of the Wiseconnect HAL require a clock manager init function to be called as part of clock configuration.

Without this, the default reference clock isn't configured correctly for use with peripherals.