### PR TITLE
drivers: serial: ns16550: clock subsys correction

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -1940,7 +1940,7 @@ static DEVICE_API(uart, uart_ns16550_driver_api) = {
 				.sys_clk_freq = 0,                                   \
 				.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),  \
 				.clock_subsys = (clock_control_subsys_t) DT_INST_PHA(\
-								0, clocks, clkid),   \
+								n, clocks, clkid),   \
 			)                                                            \
 		)                                                                    \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(n, pcp),                            \


### PR DESCRIPTION
Fix clock subsys property selection when having multiple uart device that uses ns16550 driver.