### PR TITLE
twsiter: binary handler: pass verbose setting to west call

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -583,7 +583,10 @@ class DeviceHandler(Handler):
         if self.options.flash_command:
             return self._create_flash_command(hardware)
 
-        command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
+        command = ["west"]
+        if self.options.verbose > 2:
+            command.append(f"-{'v' * (self.options.verbose - 2)}")
+        command += ["flash", "--skip-rebuild", "-d", self.build_dir]
         command_extra_args = []
 
         # There are three ways this option is used.

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1187,7 +1187,7 @@ def test_devicehandler_create_command(
 ):
     handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
     handler.options = mock.Mock(west_flash=self_west_flash,
-                                flash_command=self_flash_command)
+                                flash_command=self_flash_command, verbose=0)
     handler.generator_cmd = 'generator_cmd'
 
     expected = [handler.build_dir if val == '$build_dir' else \
@@ -1453,7 +1453,8 @@ def test_devicehandler_handle(
     handler.options = mock.Mock(
         timeout_multiplier=1,
         west_flash=None,
-        west_runner=None
+        west_runner=None,
+        verbose=0
     )
     handler._start_serial_pty = mock.Mock(side_effect=mock_start_serial_pty)
     handler._create_command = mock.Mock(return_value=['dummy', 'command'])
@@ -2027,7 +2028,8 @@ def test_qemuhandler_handle(
     handler.options = mock.Mock(
         timeout_multiplier=1,
         west_flash=handler_options_west_flash,
-        west_runner=None
+        west_runner=None,
+        verbose=0,
     )
     handler.run_custom_script = mock.Mock(return_value=None)
     handler.make_device_available = mock.Mock(return_value=None)


### PR DESCRIPTION
1. pass verbose setting to west call.
2. refactor the runner setting code.