### PR TITLE
boards: shields: nrf7002: docs: Fix blobs command

### DIFF
--- a/boards/shields/nrf7002eb/doc/index.rst
+++ b/boards/shields/nrf7002eb/doc/index.rst
@@ -36,7 +36,7 @@ below to retrieve those files.
 .. code-block:: console
 
    west update
-   west blobs fetch hal_nordic
+   west blobs fetch nrf_wifi
 
 Usage
 *****

--- a/boards/shields/nrf7002ek/doc/index.rst
+++ b/boards/shields/nrf7002ek/doc/index.rst
@@ -36,7 +36,7 @@ below to retrieve those files.
 .. code-block:: console
 
    west update
-   west blobs fetch hal_nordic
+   west blobs fetch nrf_wifi
 
 Usage
 *****


### PR DESCRIPTION
The blobs for the nRF7002 are located in the nrf_wifi module instead of hal_nordic.