### PR TITLE
include: sys_clock: Fix compilation when SYS_CLOCK_EXISTS is disabled

### DIFF
--- a/include/zephyr/sys_clock.h
+++ b/include/zephyr/sys_clock.h
@@ -162,10 +162,11 @@ typedef struct {
 /** @endcond */
 
 #ifndef CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
-#if defined(CONFIG_SYS_CLOCK_EXISTS) && \
-	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 0)
+#if defined(CONFIG_SYS_CLOCK_EXISTS)
+#if CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 0
 #error "SYS_CLOCK_HW_CYCLES_PER_SEC must be non-zero!"
-#endif
+#endif /* CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 0 */
+#endif /* CONFIG_SYS_CLOCK_EXISTS */
 #endif /* CONFIG_TIMER_READS_ITS_FREQUENCY_AT_RUNTIME */
 
 /* kernel clocks */


### PR DESCRIPTION
If `CONFIG_SYS_CLOCK_EXISTS=n`, then
`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` will likely not be defined at all. Fix the compilation by moving the check for it being `== 0` to a separate preprocessor #if statement.