### PR TITLE
cmake: Fix warning if a Zephyr library is created in app-mode

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -585,7 +585,7 @@ endfunction()
 # constructor but must be called explicitly on CMake libraries that do
 # not use a zephyr library constructor.
 function(zephyr_append_cmake_library library)
-  if(TARGET zephyr_prebuilt)
+  if(TARGET zephyr_pre0)
     message(WARNING
       "zephyr_library() or zephyr_library_named() called in Zephyr CMake "
       "application mode. `${library}` will not be treated as a Zephyr library."


### PR DESCRIPTION
`zephyr_append_cmake_library` attempts to warn the user if a user calls it to create a Zephyr library while the build is in application mode. At that stage of the build, the list of Zephyr libraries has already been processed so the function is effectively a no-op. This warning originated from #35887.

This heuristic used to determine if the build was in kernel mode or application mode checked for the presence of the `zephyr_prebuilt` target. This check was broken by a previous commit (#39959) that renamed this target.

This commit fixes the heuristic by checking for the `zephyr_pre0` target instead of the `zephyr_prebuilt` target.

This was tested by calling `zephyr_append_cmake_library` from some application build files, building the application, and seeing the warning only for the call I added. No warnings were printed for any Zephyr internal libraries.