### PR TITLE
usb: device_next: Disassociate USB contexts from classes

### DIFF
--- a/subsys/usb/device_next/usbd_class.c
+++ b/subsys/usb/device_next/usbd_class.c
@@ -282,6 +282,7 @@ int usbd_class_remove_all(struct usbd_context *const uds_ctx,
 		c_nd = CONTAINER_OF(node, struct usbd_class_node, node);
 		atomic_clear_bit(&c_nd->state, USBD_CCTX_REGISTERED);
 		usbd_class_shutdown(c_nd->c_data);
+		c_nd->c_data->uds_ctx = NULL;
 		LOG_DBG("Remove class node %p from configuration %u", c_nd, cfg);
 	}
 


### PR DESCRIPTION
The usbd_class_remove_all removes all registered classes from a configuration. However, it previously left the uds_ctx back-pointer to the usdb_context set, meaning that if the class is re-registered with the usbd_register_class function, this fails with the error message "Class registered to other context at different speed" due to uds_ctx being set to another context.

This patch corrects the issue by clearing udc_ctx after usbd_class_shutdown has been called.