### PR TITLE
Make kernel timeout record (`struct _timeout`) a public API

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -348,7 +348,7 @@ struct rtio_sqe {
 		/** OP_DELAY */
 		struct {
 			k_timeout_t timeout; /**< Delay timeout. */
-			struct _timeout to; /**< Timeout struct. Used internally. */
+			struct k_timeout_record record; /**< Timeout record. Used internally. */
 		} delay;
 
 		/** OP_I2C_CONFIGURE */

--- a/subsys/rtio/rtio_sched.c
+++ b/subsys/rtio/rtio_sched.c
@@ -7,19 +7,11 @@
 #include <zephyr/kernel.h>
 #include <zephyr/rtio/rtio.h>
 
-/** Required to access Timeout Queue APIs, which are used instead of the
- * Timer APIs because of concerns on size on rtio_sqe (k_timer is more
- * than double the size of _timeout). Users will have to instantiate a
- * pool of SQE objects, thus its size directly impacts memory footprint
- * of RTIO applications.
- */
-#include <../kernel/include/timeout_q.h>
-
 #include "rtio_sched.h"
 
-static void rtio_sched_alarm_expired(struct _timeout *t)
+static void rtio_sched_alarm_expired(struct k_timeout_record *record)
 {
-	struct rtio_sqe *sqe = CONTAINER_OF(t, struct rtio_sqe, delay.to);
+	struct rtio_sqe *sqe = CONTAINER_OF(record, struct rtio_sqe, delay.record);
 	struct rtio_iodev_sqe *iodev_sqe = CONTAINER_OF(sqe, struct rtio_iodev_sqe, sqe);
 
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
@@ -29,6 +21,6 @@ void rtio_sched_alarm(struct rtio_iodev_sqe *iodev_sqe, k_timeout_t timeout)
 {
 	struct rtio_sqe *sqe = &iodev_sqe->sqe;
 
-	z_init_timeout(&sqe->delay.to);
-	z_add_timeout(&sqe->delay.to, rtio_sched_alarm_expired, timeout);
+	k_timeout_record_init(&sqe->delay.record);
+	k_timeout_record_add(&sqe->delay.record, rtio_sched_alarm_expired, timeout);
 }

--- a/tests/kernel/common/CMakeLists.txt
+++ b/tests/kernel/common/CMakeLists.txt
@@ -33,3 +33,9 @@ target_sources_ifdef(
 	app PRIVATE
 	src/irq_offload.c
 )
+
+target_sources_ifdef(
+	CONFIG_SYS_CLOCK_EXISTS
+	app PRIVATE
+	src/timeout_record.c
+)

--- a/tests/kernel/common/src/timeout_record.c
+++ b/tests/kernel/common/src/timeout_record.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+static K_SEM_DEFINE(test_sem, 0, 1);
+static struct k_timeout_record *test_record;
+
+extern void *common_setup(void);
+
+static void test_before(void *f)
+{
+	k_sem_reset(&test_sem);
+	test_record = NULL;
+}
+
+ZTEST_SUITE(timeout_record, NULL, common_setup, test_before, NULL, NULL);
+
+static void test_timeout_handler(struct k_timeout_record *record)
+{
+	test_record = record;
+	k_sem_give(&test_sem);
+}
+
+ZTEST(timeout_record, test_timeout_add_elapse_abort)
+{
+	struct k_timeout_record record;
+
+	k_timeout_record_init(&record);
+	(void)k_timeout_record_add(&record, test_timeout_handler, K_NO_WAIT);
+	zassert_ok(k_sem_take(&test_sem, K_MSEC(100)));
+	zassert_equal(&record, test_record);
+	zassert_false(k_timeout_record_abort(&record));
+}
+
+ZTEST(timeout_record, test_timeout_add_abort)
+{
+	struct k_timeout_record record;
+
+	k_timeout_record_init(&record);
+	(void)k_timeout_record_add(&record, test_timeout_handler, K_MSEC(1000));
+	zassert_equal(k_sem_take(&test_sem, K_MSEC(500)), -EAGAIN);
+	zassert_true(k_timeout_record_abort(&record));
+	zassert_equal(k_sem_take(&test_sem, K_MSEC(1000)), -EAGAIN);
+}


### PR DESCRIPTION
This PR promotes the internal kernel timeout record `struct _timeout` to a public struct and API, exposing it with a friendly name `struct k_timeout_record` and documenting it thoroughly. The kernel timeout record is really efficient and useful for subsystems which need a "timer" but can benefit from the lower overhead compared to the `k_timer`. The name `timeout_record` was inspired by @nashif :)

This PR is backwards compatible, it keeps the internal struct untouched, it just adds a wrapper around it, with a tiny test in `kernel/common` just to make sure the wrapper functions as expected.