### PR TITLE
samples: fs: typo in project name

### DIFF
--- a/samples/subsys/fs/fs_sample/CMakeLists.txt
+++ b/samples/subsys/fs/fs_sample/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(mass)
+project(fs_sample)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
Looked like copy-paste typo from the `samples/subsys/usb/mass` sample.

Signed-off-by: Noah Pendleton <noah.pendleton@gmail.com>
