### PR TITLE
arch: Add config for downstream toolchains to support local ISR tables

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -440,6 +440,12 @@ config ARCH_STACKWALK_MAX_FRAMES
 
 menu "Interrupt Configuration"
 
+config TOOLCHAIN_SUPPORTS_ISR_TABLES_LOCAL_DECLARATION
+	bool
+	help
+	  Hidden option to signal that toolchain supports local declaration of
+	  interrupt tables.
+
 config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
 	bool
 	default y
@@ -448,7 +454,7 @@ config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
 	# List of currently supported architectures
 	depends on ARM || ARM64
 	# List of currently supported toolchains
-	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "gnuarmemb" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "llvm"
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "gnuarmemb" || "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "llvm" || TOOLCHAIN_SUPPORTS_ISR_TABLES_LOCAL_DECLARATION
 
 config ISR_TABLES_LOCAL_DECLARATION
 	bool "ISR tables created locally and placed by linker"


### PR DESCRIPTION
Add config for local toolchains to indicate support for local declaration of ISR tables.