### PR TITLE
usb: device_next: hid: Fix endpoint address getters

### DIFF
--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -83,18 +83,28 @@ struct hid_device_data {
 
 static inline uint8_t hid_get_in_ep(struct usbd_class_data *const c_data)
 {
+	struct usbd_context *uds_ctx = usbd_class_get_ctx(c_data);
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct hid_device_config *dcfg = dev->config;
 	struct usbd_hid_descriptor *desc = dcfg->desc;
+
+	if (USBD_SUPPORTS_HIGH_SPEED && usbd_bus_speed(uds_ctx) == USBD_SPEED_HS) {
+		return desc->hs_in_ep.bEndpointAddress;
+	}
 
 	return desc->in_ep.bEndpointAddress;
 }
 
 static inline uint8_t hid_get_out_ep(struct usbd_class_data *const c_data)
 {
+	struct usbd_context *uds_ctx = usbd_class_get_ctx(c_data);
 	const struct device *dev = usbd_class_get_private(c_data);
 	const struct hid_device_config *dcfg = dev->config;
 	struct usbd_hid_descriptor *desc = dcfg->desc;
+
+	if (USBD_SUPPORTS_HIGH_SPEED && usbd_bus_speed(uds_ctx) == USBD_SPEED_HS) {
+		return desc->hs_out_ep.bEndpointAddress;
+	}
 
 	return desc->out_ep.bEndpointAddress;
 }


### PR DESCRIPTION
This PR resolves a bug where we'd provide the Full-Speed Endpoint Address instead of the High-Speed Endpoint Address.
 