### PR TITLE
tf-m: build: Treat warnings as errors

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -26,6 +26,11 @@ if (CONFIG_BUILD_WITH_TFM)
     endif()
   endif()
 
+  # Treat any warning as error
+  if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
+    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_WARNINGS_ARE_ERRORS:BOOL=ON)
+  endif()
+
   if (CONFIG_TFM_SFN)
     list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_SPM_BACKEND="SFN")
   else() # CONFIG_TFM_IPC

--- a/west.yml
+++ b/west.yml
@@ -360,7 +360,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: d38260c937f957e4617691daebc7b565e82a84c4
+      revision: 021e2bbd50c215e41710a72e05abce3224f074a7
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Starting in TF-M 2.2.0 there is a build option to treat warnings as errors. Lets use it.

Fixes #90864