### PR TITLE
drivers: nxp: wifi: Enable 11AX density config by default for IW610

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -785,6 +785,12 @@ config NXP_WIFI_RECOVERY
 	help
 	  This option is used to enable wifi recovery support.
 
+config NXP_WIFI_MMSF
+	bool "11AX density config"
+	default y if NXP_RW610 || NXP_IW610
+	help
+	  This option is used to specify/get 11ax density config in the Wi-Fi driver.
+
 if NXP_RW610
 
 config NXP_WIFI_FW_VDLLV2
@@ -848,12 +854,6 @@ config NXP_WIFI_COEX_DUTY_CYCLE
 	default y
 	help
 	  This option sets duty cycle in the Wi-Fi driver.
-
-config NXP_WIFI_MMSF
-	bool "11AX density config"
-	default y
-	help
-	  This option is used to specify/get 11ax density config in the Wi-Fi driver.
 
 config NXP_WIFI_IMD3_CFG
 	bool "Set imd validation parameters"


### PR DESCRIPTION
Enable NXP_WIFI_MMSF by default for IW610