### PR TITLE
Bluetooth: Classic: SDP: Fix buf leak issue

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1517,6 +1517,7 @@ static int sdp_client_ss_search(struct bt_sdp_client *session,
 		break;
 	default:
 		LOG_ERR("Unknown UUID type %u", param->uuid->type);
+		net_buf_unref(buf);
 		return -EINVAL;
 	}
 
@@ -1620,6 +1621,7 @@ static int sdp_client_ssa_search(struct bt_sdp_client *session,
 		break;
 	default:
 		LOG_ERR("Unknown UUID type %u", param->uuid->type);
+		net_buf_unref(buf);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
In the function `sdp_client_ss_search()` and `sdp_client_ssa_search()`, the allocated buf is not released if the required UUID is invalid.

Un-reference the allocated net buffer if the UUID is invalid.