### PR TITLE
Bluetooth: Classic: HFP_HF: Fix out of bounds potential issue

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_hf.c
+++ b/subsys/bluetooth/host/classic/hfp_hf.c
@@ -4171,6 +4171,8 @@ static int bt_hfp_hf_sco_accept(const struct bt_sco_accept_info *info,
 	LOG_DBG("conn %p", info->acl);
 
 	index = (size_t)bt_conn_index(info->acl);
+	__ASSERT(index < ARRAY_SIZE(bt_hfp_hf_pool), "Index is out of bounds");
+
 	hf = &bt_hfp_hf_pool[index];
 	if (hf->acl != info->acl) {
 		LOG_ERR("ACL %p of HF is unaligned with SCO's %p", hf->acl, info->acl);


### PR DESCRIPTION
There is a potential issue that the index of ACL may out of the bounds of the array `bt_hfp_hf_pool` if the array size is not aligned with the array size of `acl_conns`.

To avoid the potential issue, check if the ACL conn index is less than the array size of `bt_hfp_hf_pool` before accessing the array `bt_hfp_hf_pool` with ACL conn index.

Fixes #91172