### PR TITLE
tests: llext-edk: fix test timeout on some workloads

### DIFF
--- a/tests/misc/llext-edk/testcase.yaml
+++ b/tests/misc/llext-edk/testcase.yaml
@@ -7,3 +7,4 @@ tests:
     platform_allow:
       - qemu_cortex_r5
     toolchain_exclude: llvm
+    timeout: 120 # See #85662


### PR DESCRIPTION
`tests/misc/llext-edk/misc.edk.pytest` is timing out on some workloads. Double the timeout to 120 seconds to accommodate longer execution times.

Fixes #85662.