### PR TITLE
drivers: flash: mcux: mark is_area_readable as unused to fix build 

### DIFF
--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -95,7 +95,7 @@ static uint32_t get_cmd_status(uint32_t cmd, uint32_t addr, size_t len)
 /* This function prevents erroneous reading. Some ECC enabled devices will
  * crash when reading an erased area.
  */
-static status_t is_area_readable(uint32_t addr, size_t len)
+static status_t __attribute__((unused))  is_area_readable(uint32_t addr, size_t len)
 {
 	uint32_t key;
 	status_t status;


### PR DESCRIPTION
Added __attribute__((unused)) to suppress the unused-function warning for is_area_readable.

This fixes build failures on LPC55XXX platforms due to is_area_readable being defined but not used.


Fixes: #91164