### PR TITLE
kernel: Guard SYS_CLOCK_HW_CYCLES_PER_SEC to avoid spurious empty macro

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -828,6 +828,7 @@ config SYS_CLOCK_TICKS_PER_SEC
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	int "System clock's h/w timer frequency"
 	default 0 if TIMER_READS_ITS_FREQUENCY_AT_RUNTIME
+	depends on SYS_CLOCK_EXISTS
 	help
 	  This option specifies the frequency of the hardware timer used for the
 	  system clock (in Hz). This option is set by the SOC's or board's Kconfig file


### PR DESCRIPTION
If SYS_CLOCK_EXISTS is not enabled, then the SYS_CLOCK_HW_CYCLES_PER_SEC           
still gets created, but with no value. This causes the code generation             
in misc/generated/CMakeLists.txt to create an empty assembly macro:                
                                                                                   
`.equ  CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,`                                        
                                                                                   
which then causes a build error.                                                   
                                                                                   
Disable SYS_CLOCK_HW_CYCLES_PER_SEC entirely when SYS_CLOCK_EXISTS is              
disabled to fix this.                                                              
                                                                                   
This is a follow-up to 03f46db8591e191eaf8744ab36f8401aac102def. 