### PR TITLE
2 minor fixes around CONFIG_NATIVE_APPLICATION

### DIFF
--- a/include/zephyr/toolchain/mwdt.h
+++ b/include/zephyr/toolchain/mwdt.h
@@ -118,7 +118,7 @@
   #error "ARC MWDT doesn't support building with CONFIG_NEWLIB_LIBC as it doesn't have newlib"
 #endif /* CONFIG_NEWLIB_LIBC */
 
-#ifdef CONFIG_NATIVE_APPLICATION
+#ifdef CONFIG_NATIVE_BUILD
   #error "ARC MWDT doesn't support building Zephyr as an native application"
 #endif /* CONFIG_NATIVE_APPLICATION */
 

--- a/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.unit_testing
+++ b/subsys/testsuite/boards/unit_testing/unit_testing/Kconfig.unit_testing
@@ -5,6 +5,6 @@
 config BOARD_UNIT_TESTING
 	bool "Unit testing board"
 	select HAS_COVERAGE_SUPPORT
-	select NATIVE_APPLICATION
+	select NATIVE_BUILD
 	help
 	  Board for unit testing


### PR DESCRIPTION
    unit_testing: Fix NATIVE_APPLICATION kconfig dependency
    
    NATIVE_APPLICATION is deprecated, let's not use it, let's use instead
    NATIVE_BUILD.
    unit_testing is not really meant to be covered by NATIVE_APPLICATION,
    or NATIVE_BUILD for that matter, as these options are meant for POSIX
    arch based targets.
    Still, some kconfig options will default to something which will
    also be incompatible with unit_testing (primarily CONFIG_PICOLIBC=y)
    if we don't set at least NATIVE_BUILD, which would cause some unit
    tests to fail. So let's select NATIVE_BUILD to avoid needing to add
    extra dependencies on the libCs options.

-----

   include mwdt: Change ifdef from NATIVE_APPLICATION to NATIVE_BUILD
    
    NATIVE_APPLICATION is now deprecated so nobody will set it,
    but NATIVE_BUILD should cover the same case this build error
    is trying to warn about. Let's use it instead.
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>


Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/91127