### PR TITLE
drivers: i2c: stm32: fix build error after timeout patch

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -1292,6 +1292,8 @@ int i2c_stm32_transaction(const struct device *dev,
 
 #ifndef CONFIG_I2C_STM32_INTERRUPT
 	struct i2c_stm32_data *data = dev->data;
+	const struct i2c_stm32_config *cfg = dev->config;
+	I2C_TypeDef *i2c = cfg->i2c;
 
 	if (ret == -ETIMEDOUT) {
 		if (LL_I2C_IsEnabledReloadMode(i2c)) {


### PR DESCRIPTION
Follow-up to PR #88631: fix missing variable declarations introduced in the STM32 I2C LL driver after adding timeouts to blocking loops.

The missing declarations caused a build failure when interrupts were disabled (CONFIG_I2C_STM32_INTERRUPT=n).

Fixes a regression introduced in #88631.

Backport concerned (#90659, #90660, #90661)

@etienne-lms 