### PR TITLE
boards: nxp: mimxrt1170_evk: Add arduino GPIO/SPI/UART header nodes

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -49,9 +49,38 @@
 			pwms = <&flexpwm1_pwm2 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
+
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio9 9 0>,	/* A0 */
+			   <1 0 &gpio9 10 0>,	/* A1 */
+			   <2 0 &gpio9 11 0>,	/* A2 */
+			   <3 0 &gpio9 12 0>,	/* A3 */
+			   <4 0 &gpio9 8 0>,	/* A4 */
+			   <5 0 &gpio9 7 0>,	/* A5 */
+			   <6 0 &gpio11 12 0>,	/* D0 */
+			   <7 0 &gpio11 11 0>,	/* D1 */
+			   <8 0 &gpio11 13 0>,	/* D2 */
+			   <9 0 &gpio9 3 0>,	/* D3 */
+			   <10 0 &gpio9 5 0>,	/* D4 */
+			   <11 0 &gpio9 4 0>,	/* D5 */
+			   <12 0 &gpio8 31 0>,	/* D6 */
+			   <13 0 &gpio9 13 0>,	/* D7 */
+			   <14 0 &gpio9 6 0>,	/* D8 */
+			   <15 0 &gpio9 0 0>,	/* D9 */
+			   <16 0 &gpio9 28 0>,	/* D10 */
+			   <17 0 &gpio9 29 0>,	/* D11 */
+			   <18 0 &gpio9 30 0>,	/* D12 */
+			   <19 0 &gpio9 27 0>,	/* D13 */
+			   <20 0 &gpio12 4 0>,	/* D14 */
+			   <21 0 &gpio12 5 0>;	/* D15 */
+	};
 };
 
-&lpi2c5 {
+arduino_i2c: &lpi2c5 {
 	status = "okay";
 	pinctrl-0 = <&pinmux_lpi2c5>;
 	pinctrl-names = "default";
@@ -78,7 +107,8 @@
 	current-speed = <115200>;
 };
 
-&lpuart2 {
+arduino_serial: &lpuart2 {
+	/* No HW flow control possible for Arduino Header due to missing LPUART2 RTS on D3 */
 	pinctrl-0 = <&pinmux_lpuart2>;
 	pinctrl-1 = <&pinmux_lpuart2_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -180,7 +210,7 @@
 	pinctrl-names = "default";
 };
 
-&lpspi1 {
+arduino_spi: &lpspi1 {
 	pinctrl-0 = <&pinmux_lpspi1>;
 	pinctrl-names = "default";
 };


### PR DESCRIPTION
The MIMXRT1170-EVK/EVKB has an Arduino compatible header, add device tree nodes for the corresponding pins.