### PR TITLE
drivers: flash: stm32: add "generic read/write" ex op to QSPI driver

### DIFF
--- a/drivers/flash/Kconfig.stm32_qspi
+++ b/drivers/flash/Kconfig.stm32_qspi
@@ -6,7 +6,7 @@
 
 DT_STM32_QUADSPI_HAS_DMA := $(dt_compat_any_has_prop,$(DT_COMPAT_ST_STM32_QSPI),dmas)
 
-config FLASH_STM32_QSPI
+menuconfig FLASH_STM32_QSPI
 	bool "STM32 Quad SPI Flash driver"
 	default y
 	depends on DT_HAS_ST_STM32_QSPI_NOR_ENABLED
@@ -21,3 +21,22 @@ config FLASH_STM32_QSPI
 	select USE_STM32_HAL_DMA if $(DT_STM32_QUADSPI_HAS_DMA)
 	help
 	  Enable QSPI-NOR support on the STM32 family of processors.
+
+if FLASH_STM32_QSPI
+
+config FLASH_STM32_QSPI_GENERIC_READ
+	bool "Generic read command extended operation"
+	select FLASH_HAS_EX_OP
+	help
+	  Enables flash extended operation that can be used to transmit
+	  a custom command and read the result to a user-provided buffer.
+
+config FLASH_STM32_QSPI_GENERIC_WRITE
+	bool "Generic write command extended operation"
+	select FLASH_HAS_EX_OP
+	help
+	  Enables flash extended operation that can be used to transmit
+	  a custom command and write data taken from a user-provided
+	  buffer.
+
+endif # FLASH_STM32_QSPI

--- a/include/zephyr/drivers/flash/stm32_flash_api_extensions.h
+++ b/include/zephyr/drivers/flash/stm32_flash_api_extensions.h
@@ -64,6 +64,25 @@ enum stm32_ex_ops {
 	FLASH_STM32_EX_OP_OPTB_WRITE,
 };
 
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+enum stm32_qspi_ex_ops {
+	/*
+	 * QSPI generic read command.
+	 *
+	 * Transmit the custom command and read the result to the user-provided
+	 * buffer.
+	 */
+	FLASH_STM32_QSPI_EX_OP_GENERIC_READ,
+	/*
+	 * QSPI generic write command.
+	 *
+	 * Transmit the custom command and then write data taken from the
+	 * user-provided buffer.
+	 */
+	FLASH_STM32_QSPI_EX_OP_GENERIC_WRITE,
+};
+#endif /* CONFIG_FLASH_EX_OP_ENABLED */
+
 #if defined(CONFIG_FLASH_STM32_WRITE_PROTECT)
 struct flash_stm32_ex_op_sector_wp_in {
 	uint64_t enable_mask;


### PR DESCRIPTION
Some external flash modules have extra commands to support, for example, reading/writing an OTP zone. Given that the commands are highly specific and difficult to generalize, we add two ex ops that can be used to transmit a custom command (in the form of a full QSPI_CommandTypeDef) and then read or write a user-provided buffer.

As a reference here is the link to the discussion where one of the reviewers asked for using ex ops instead of custom code in a board.c file.

Link: https://github.com/zephyrproject-rtos/zephyr/pull/90264