### PR TITLE
dts: stm32wba: add the die_temp node on both wba5 and wba6

### DIFF
--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -75,6 +75,7 @@
 		sw2 = &user_button_3;
 		mcuboot-led0 = &blue_led_1;
 		mcuboot-button0 = &user_button_1;
+		die-temp0 = &die_temp;
 	};
 };
 
@@ -141,6 +142,10 @@
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
 	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+&die_temp {
 	status = "okay";
 };
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -484,8 +484,6 @@
 
 	die_temp: dietemp {
 		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x0BF90710>;
-		ts-cal2-addr = <0x0BF90742>;
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;

--- a/dts/arm/st/wba/stm32wba52.dtsi
+++ b/dts/arm/st/wba/stm32wba52.dtsi
@@ -9,4 +9,9 @@
 	soc {
 		compatible = "st,stm32wba52", "st,stm32wba", "simple-bus";
 	};
+
+	die_temp: dietemp {
+		ts-cal1-addr = <0x0BF90710>;
+		ts-cal2-addr = <0x0BF90742>;
+	};
 };

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -77,4 +77,9 @@
 			};
 		};
 	};
+
+	die_temp: dietemp {
+		ts-cal1-addr = <0x0BFA0710>;
+		ts-cal2-addr = <0x0BFA0742>;
+	};
 };


### PR DESCRIPTION
The die_temp node needs to be activated on the nucleo_stm32wba6. 
In order to do so, it's also required to split the temperature calibration addresses between stm32wba6 and stm32wba6 as they are not the same.