### PR TITLE
soc: imx943: a55: disable D-Cache when booting from el2

### DIFF
--- a/boards/nxp/imx943_evk/doc/index.rst
+++ b/boards/nxp/imx943_evk/doc/index.rst
@@ -82,13 +82,9 @@ Setup
 
 The default runner for the board is JLink, connect the EVK board's JTAG connector to
 the host computer using a J-Link debugger, power up the board and stop the board at
-U-Boot command line, execute the following U-boot command to disable D-Cache:
+U-Boot command line.
 
-.. code-block:: console
-
-    dcache off
-
-then use "west flash" or "west debug" command to load the zephyr.bin
+Then use "west flash" or "west debug" command to load the zephyr.bin
 image from the host computer and start the Zephyr application on A55 core0.
 
 Flash and Run
@@ -167,7 +163,7 @@ Use the following command to boot Zephyr on the core0:
 
 .. code-block:: console
 
-    dcache off; icache flush; go 0xd0000000;
+    dcache flush; icache flush; go 0xd0000000;
 
 Then the following log could be found on UART1 console:
 

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.a55
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.a55
@@ -16,6 +16,13 @@ config FLASH_BASE_ADDRESS
 config GIC_SAFE_CONFIG
 	default y
 
+# Disable data cache until MMU is enabled when booting from EL2
+config ARM64_DCACHE_ALL_OPS
+	default y
+
+config ARM64_BOOT_DISABLE_DCACHE
+	default y
+
 config MCUX_CORE_SUFFIX
 	default "_ca55" if SOC_MIMX94398_A55
 


### PR DESCRIPTION
Enabled CONFIG_ARM64_BOOT_DISABLE_DCACHE to disable D-Cache when booting from EL2.

This PR is to extend the previous implement to new platform: https://github.com/zephyrproject-rtos/zephyr/pull/88415