### PR TITLE
Spi loopback adjustments

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -291,10 +291,18 @@ ZTEST(spi_loopback, test_spi_complete_multiple_timed)
 	uint32_t start_time, end_time, cycles_spent;
 	uint64_t time_spent_us, expected_transfer_time_us, latency_measurement;
 
+	/*
+	 * spi_loopback_transceive() does an inline pm_device_runtime_get(), but since we are
+	 * timing the transfer, we need to get the SPI controller before we start the measurement.
+	 */
+	zassert_ok(pm_device_runtime_get(spec->bus));
+
 	/* since this is a test program, there shouldn't be much to interfere with measurement */
 	start_time = k_cycle_get_32();
 	spi_loopback_transceive(spec, &tx, &rx);
 	end_time = k_cycle_get_32();
+
+	zassert_ok(pm_device_runtime_put(spec->bus));
 
 	if (end_time >= start_time) {
 		cycles_spent = end_time - start_time;

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -691,7 +691,8 @@ ZTEST(spi_loopback, test_spi_word_size_32)
 				    sizeof(buffer_tx_32), &spec_copies[4], 32);
 }
 
-static K_THREAD_STACK_DEFINE(thread_stack[3], 512);
+static K_THREAD_STACK_DEFINE(thread_stack[3], CONFIG_ZTEST_STACK_SIZE +
+					      CONFIG_TEST_EXTRA_STACK_SIZE);
 static struct k_thread thread[3];
 
 static K_SEM_DEFINE(thread_sem, 0, 3);


### PR DESCRIPTION
Adjust the spi_loopback test to use a more optimal method of determining stack sizes used internally, and produce a more accurate transfer time measurement when pm device runtime is enabled.