### PR TITLE
boards: mcx_n9xx_evk: Fix name in mcx_n9xx_evk_mcxn947_cpu1.yaml

### DIFF
--- a/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu1.yaml
+++ b/boards/nxp/mcx_n9xx_evk/mcx_n9xx_evk_mcxn947_cpu1.yaml
@@ -5,7 +5,7 @@
 #
 
 identifier: mcx_n9xx_evk/mcxn947/cpu1
-name: NXP FRDM MCXN947 (CPU1)
+name: NXP MCX-N9XX-EVK (CPU1)
 type: mcu
 arch: arm
 ram: 64


### PR DESCRIPTION
It looks like the file was originally copy-pasted from frdm_mcxn947_mcxn947_cpu1.yaml but the name was not properly updated.
This commit corrects the name to match the actual board.