### PR TITLE
drivers: spi_ll_stm32: Add LOG to indicate that DMA cannot be enabled

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -1121,6 +1121,7 @@ static int transceive_dma(const struct device *dev,
 #ifdef CONFIG_DCACHE
 	if ((tx_bufs != NULL && !spi_buf_set_in_nocache(tx_bufs)) ||
 		(rx_bufs != NULL && !spi_buf_set_in_nocache(rx_bufs))) {
+		LOG_ERR("SPI DMA transfers not supported on cached memory");
 		return -EFAULT;
 	}
 #endif /* CONFIG_DCACHE */


### PR DESCRIPTION
Add LOG to indicate the reason why DMA cannot be enabled

When using the stm32h7 and W5500 network card driver, configuring CONFIG_SPI_STM32_DMA will silently fail.