### PR TITLE
net: http: Fix __z_http_service_define fields incorrectly ordered C++20

### DIFF
--- a/include/zephyr/net/http/service.h
+++ b/include/zephyr/net/http/service.h
@@ -99,8 +99,8 @@ struct http_service_desc {
 		.fd = &_name##_fd,                                                                 \
 		.detail = (void *)(_detail),                                                       \
 		.concurrent = (_concurrent),                                                       \
-		.data = &_name##_data,                                                             \
 		.backlog = (_backlog),                                                             \
+		.data = &_name##_data,                                                             \
 		.res_begin = (_res_begin),                                                         \
 		.res_end = (_res_end),                                                             \
 		.res_fallback = (_res_fallback),                                                   \


### PR DESCRIPTION
Instance of the http_service_desc struct created by the __z_http_service_define macro uses designated initializer with fields not following original http_service_desc struct order which lead to compile time exception when `#include <zephyr/net/http/service.h>` is included and project is compiled for C++20.

```shell
.../zephyr/include/zephyr/net/http/service.h:113:9: error: designator order for field 'http_service_desc::backlog' does not match declaration order in 'const http_service_desc'
  113 |         }
      |         ^
.../zephyr/include/zephyr/net/http/service.h:195:9: note: in expansion of macro '__z_http_service_define'
  195 |         __z_http_service_define(_name, _host, _port, _concurrent, _backlog, _detail,               \
      |         ^~~~~~~~~~~~~~~~~~~~~~~
```

As C++20 doesn't allow out-of-order designated initialization.

This PR fixes the order.