### PR TITLE
drivers: sensor: fix condition in SQE acquisition check

### DIFF
--- a/drivers/sensor/pixart/paa3905/paa3905.c
+++ b/drivers/sensor/pixart/paa3905/paa3905.c
@@ -82,7 +82,7 @@ static void paa3905_submit_one_shot(const struct device *dev, struct rtio_iodev_
 	struct rtio_sqe *read_sqe = rtio_sqe_acquire(data->rtio.ctx);
 	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(data->rtio.ctx);
 
-	if (!write_sqe || !read_sqe | !complete_sqe) {
+	if (!write_sqe || !read_sqe || !complete_sqe) {
 		LOG_ERR("Failed to acquire RTIO SQEs");
 		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
 		return;

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -179,7 +179,7 @@ static inline void icm45686_submit_one_shot(const struct device *dev,
 	struct rtio_sqe *read_sqe = rtio_sqe_acquire(data->rtio.ctx);
 	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(data->rtio.ctx);
 
-	if (!write_sqe || !read_sqe | !complete_sqe) {
+	if (!write_sqe || !read_sqe || !complete_sqe) {
 		LOG_ERR("Failed to acquire RTIO SQEs");
 		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
 		return;


### PR DESCRIPTION
Corrected the logical operator (||, not |) in the condition that checks for successful acquisition of RTIO SQEs.