### PR TITLE
drivers: sensor: mmc56x3: couple trivial fixes

### DIFF
--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -196,11 +196,16 @@ static int mmc56x3_chip_init(const struct device *dev)
 	const struct mmc56x3_config *config = &data->config;
 
 	ret = mmc56x3_chip_set_continuous_mode(dev, config->magn_odr);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ret = mmc56x3_chip_set_decimation_filter(dev, config->bw0, config->bw1);
+	if (ret < 0) {
+		return ret;
+	}
 
 	ret = mmc56x3_chip_set_auto_self_reset(dev, config->auto_sr);
-
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/sensor/memsic/mmc56x3/mmc56x3_decoder.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3_decoder.c
@@ -55,6 +55,7 @@ static int mmc56x3_decoder_get_size_info(struct sensor_chan_spec chan_spec, size
 	case SENSOR_CHAN_MAGN_Z:
 		*base_size = sizeof(struct sensor_q31_sample_data);
 		*frame_size = sizeof(struct sensor_q31_sample_data);
+		return 0;
 	case SENSOR_CHAN_MAGN_XYZ:
 		*base_size = sizeof(struct sensor_three_axis_data);
 		*frame_size = sizeof(struct sensor_three_axis_sample_data);


### PR DESCRIPTION
- Added a missing return in the mmc56x3_decoder_get_size_info
causing incorrect size calculation for single channel data

- Improved error handling in init code