### PR TITLE
usb: device_next: allow to use label as interface string descriptor

### DIFF
--- a/dts/bindings/usb/zephyr,hid-device.yaml
+++ b/dts/bindings/usb/zephyr,hid-device.yaml
@@ -8,11 +8,10 @@ compatible: "zephyr,hid-device"
 include: base.yaml
 
 properties:
-  interface-name:
-    type: string
+  label:
     description: |
-      HID device name. When this property is present, a USB device will use it
-      as the string descriptor of the interface.
+      The string defined by the label property is also used for the USB device
+      interface string descriptor.
 
   protocol-code:
     type: string

--- a/samples/subsys/usb/hid-keyboard/app.overlay
+++ b/samples/subsys/usb/hid-keyboard/app.overlay
@@ -7,7 +7,7 @@
 / {
 	hid_dev_0: hid_dev_0 {
 		compatible = "zephyr,hid-device";
-		interface-name = "HID0";
+		label = "HID0";
 		protocol-code = "keyboard";
 		in-report-size = <64>;
 		in-polling-period-us = <1000>;

--- a/samples/subsys/usb/hid-keyboard/large_in_report.overlay
+++ b/samples/subsys/usb/hid-keyboard/large_in_report.overlay
@@ -7,7 +7,7 @@
 / {
 	hid_dev_0: hid_dev_0 {
 		compatible = "zephyr,hid-device";
-		interface-name = "HID0";
+		label = "HID0";
 		in-report-size = <256>;
 		in-polling-period-us = <1000>;
 	};

--- a/samples/subsys/usb/hid-mouse/usbd_next.overlay
+++ b/samples/subsys/usb/hid-mouse/usbd_next.overlay
@@ -7,7 +7,7 @@
 / {
 	hid_dev_0: hid_dev_0 {
 		compatible = "zephyr,hid-device";
-		interface-name = "HID0";
+		label = "HID0";
 		protocol-code = "none";
 		in-polling-period-us = <1000>;
 		in-report-size = <64>;


### PR DESCRIPTION
The intention was to use the "interface-name" string property in the interface string descriptor, but using the label property is acceptable again. Therefore, allow the use of the DT label property string in the interface string descriptor.

Follow exactly the same approach as in the CDC ACM implementation introduced in the commit b0791400f61f
("usb: device_next: cdc_acm: allow setting the interface description").