### PR TITLE
dts: st: stm32l4r5: re-add SDMMC `idma` property

### DIFF
--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -342,6 +342,7 @@
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <49 0>;
+			idma;
 			status = "disabled";
 		};
 
@@ -352,6 +353,7 @@
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 23U)>;
 			interrupts = <47 0>;
+			idma;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The `idma` property added in 94847be1 was removed in the re-organisation in 306dea6f. Re-add the property at a more generic location.