### PR TITLE
drivers: disk: sdmmc_stm32: power up on request

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -279,10 +279,10 @@ static int stm32_sdmmc_dma_deinit(struct stm32_sdmmc_priv *priv)
 
 /* Forward declarations */
 static int stm32_sdmmc_pwr_on(struct stm32_sdmmc_priv *priv);
-static int stm32_sdmmc_pwr_off(struct stm32_sdmmc_priv *priv);
+static void stm32_sdmmc_pwr_off(struct stm32_sdmmc_priv *priv);
 static int stm32_sdmmc_card_detect_init(struct stm32_sdmmc_priv *priv);
 static bool stm32_sdmmc_card_present(struct stm32_sdmmc_priv *priv);
-static int stm32_sdmmc_card_detect_uninit(struct stm32_sdmmc_priv *priv);
+static void stm32_sdmmc_card_detect_uninit(struct stm32_sdmmc_priv *priv);
 
 static int stm32_sdmmc_access_init(struct disk_info *disk)
 {
@@ -676,16 +676,16 @@ remove_callback:
 	return err;
 }
 
-static int stm32_sdmmc_card_detect_uninit(struct stm32_sdmmc_priv *priv)
+static void stm32_sdmmc_card_detect_uninit(struct stm32_sdmmc_priv *priv)
 {
 	if (!priv->cd.port) {
-		return 0;
+		return;
 	}
 
 	gpio_pin_interrupt_configure_dt(&priv->cd, GPIO_INT_MODE_DISABLED);
 	gpio_pin_configure_dt(&priv->cd, GPIO_DISCONNECTED);
 	gpio_remove_callback(priv->cd.port, &priv->cd_cb);
-	return 0;
+	return;
 }
 #endif /* !CONFIG_SDMMC_STM32_EMMC */
 
@@ -711,12 +711,12 @@ static int stm32_sdmmc_pwr_on(struct stm32_sdmmc_priv *priv)
 	return 0;
 }
 
-static int stm32_sdmmc_pwr_off(struct stm32_sdmmc_priv *priv)
+static void stm32_sdmmc_pwr_off(struct stm32_sdmmc_priv *priv)
 {
 	int err;
 
 	if (!priv->pe.port) {
-		return 0;
+		return;
 	}
 
 	/* PINCTRL sleep mode when powered down */
@@ -725,7 +725,7 @@ static int stm32_sdmmc_pwr_off(struct stm32_sdmmc_priv *priv)
 		LOG_WRN("Failed to apply pin sleep states");
 	}
 	gpio_pin_configure_dt(&priv->pe, GPIO_OUTPUT_INACTIVE);
-	return 0;
+	return;
 }
 
 static int disk_stm32_sdmmc_init(const struct device *dev)

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -177,8 +177,7 @@ static int stm32_sdmmc_clock_disable(struct stm32_sdmmc_priv *priv)
 
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	return clock_control_off(clock,
-				 (clock_control_subsys_t)&priv->pclken);
+	return clock_control_off(clock, (clock_control_subsys_t)&priv->pclken[0]);
 }
 #endif
 

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -713,10 +713,17 @@ static int stm32_sdmmc_pwr_on(struct stm32_sdmmc_priv *priv)
 
 static int stm32_sdmmc_pwr_off(struct stm32_sdmmc_priv *priv)
 {
+	int err;
+
 	if (!priv->pe.port) {
 		return 0;
 	}
 
+	/* PINCTRL sleep mode when powered down */
+	err = pinctrl_apply_state(priv->pcfg, PINCTRL_STATE_SLEEP);
+	if ((err != 0) && (err != -ENOENT)) {
+		LOG_WRN("Failed to apply pin sleep states");
+	}
 	gpio_pin_configure_dt(&priv->pe, GPIO_OUTPUT_INACTIVE);
 	return 0;
 }


### PR DESCRIPTION
Move power configuration from the device init function into the
`DISK_IOCTL_CTRL_INIT` and `DISK_IOCTL_CTRL_DEINIT` handlers. If
`pwr-gpios` is defined, this ensures that the card is not powered up
until requested, and enables powering down the card when not in use.

This behaviour matches the implementation for `sdhc_spi`.

The updated implementation has been tested on a custom STM32L451RE board with the following devicetree definition:
```
&sdmmc1 {
	status = "okay";
	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9 &sdmmc1_d2_pc10
		&sdmmc1_d3_pc11 &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
	pinctrl-1 = <&analog_pc8 &analog_pc9 &analog_pc10
		&analog_pc11 &analog_pc12 &analog_pd2>;
	pinctrl-names = "default", "sleep";
	pwr-gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
	disk-name = "SD";
	bus-width = <4>;
	clk-div = <4>;

	/**
	 * The following channel configuration is correct, but does not compile for L4
	 * dmas = <&dma2 4 1 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
	 *        <&dma2 5 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
	 * dma-names = "tx", "rx";
	 */
};
```
The implementation remains working and low power after power cycling the card multiple times without an application reboot:
![image](https://github.com/user-attachments/assets/b575bf6f-b478-42d1-8a6f-3b8bf8b06bd9)
