### PR TITLE
STM32U3: add SPI support

### DIFF
--- a/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
@@ -36,4 +36,5 @@
 };
 
 arduino_i2c: &i2c1 {};
+arduino_spi: &spi3 {};
 arduino_serial: &lpuart1 {};

--- a/boards/st/nucleo_u385rg_q/doc/index.rst
+++ b/boards/st/nucleo_u385rg_q/doc/index.rst
@@ -190,6 +190,7 @@ Default Zephyr Peripheral Mapping:
 - LD4 : PA5
 - LPUART_1_TX : PA2
 - LPUART_1_RX : PA3
+- SPI3 NSS/SCK/MISO/MOSI : PA15/PB3/PB4/PB5 (Arduino SPI)
 - UART_1_TX : PA9
 - UART_1_RX : PA10
 - UART_3_TX : PC10

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -127,3 +127,10 @@
 &rng {
 	status = "okay";
 };
+
+&spi3 {
+	pinctrl-0 = <&spi3_nss_pa15 &spi3_sck_pb3
+		     &spi3_miso_pb4 &spi3_mosi_pb5>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -8,10 +8,12 @@ supported:
   - arduino_gpio
   - dac
   - adc
+  - arduino_spi
   - dma
   - arduino_i2c
   - gpio
   - i2c
+  - spi
   - usart
 ram: 256
 flash: 1024

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -333,6 +333,36 @@
 			dma-offset = <0>;
 			status = "disabled";
 		};
+
+		spi1: spi@40013000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40013000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
+			interrupts = <59 0>;
+			status = "disabled";
+		};
+
+		spi2: spi@40003800 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003800 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
+			interrupts = <60 0>;
+			status = "disabled";
+		};
+
+		spi3: spi@40002000 {
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40002000 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 8)>;
+			interrupts = <99 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u385rg_q.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi3 {
+	dmas = <&gpdma1 0 11 STM32_DMA_PERIPH_TX
+		&gpdma1 1 10 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};
+
+&gpdma1 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -69,6 +69,7 @@ tests:
       - nucleo_h753zi
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
+      - nucleo_u385rg_q
       - stm32h573i_dk
       - stm32n6570_dk/stm32n657xx/sb
       - stm32u083c_dk
@@ -102,6 +103,7 @@ tests:
       - nucleo_h745zi_q/stm32h745xx/m4
       - nucleo_h745zi_q/stm32h745xx/m7
       - nucleo_l152re
+      - nucleo_u385rg_q
       - nucleo_wba55cg
       - nucleo_wb55rg
       - nucleo_wl55jc


### PR DESCRIPTION
Add SPI support for STM32U3. Enable SPI on Nucleo U385RG_Q, and add SPI test overlays.