### PR TITLE
drivers: voltage_divider: handle ADC PM

### DIFF
--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(voltage, CONFIG_SENSOR_LOG_LEVEL);
@@ -125,6 +126,8 @@ static int pm_action(const struct device *dev, enum pm_device_action action)
 		}
 		data->earliest_sample = K_TIMEOUT_ABS_TICKS(
 			k_uptime_ticks() + k_us_to_ticks_ceil32(config->sample_delay_us));
+		/* Power up ADC */
+		pm_device_runtime_get(config->voltage.port.dev);
 		break;
 #ifdef CONFIG_PM_DEVICE
 	case PM_DEVICE_ACTION_SUSPEND:
@@ -132,6 +135,8 @@ static int pm_action(const struct device *dev, enum pm_device_action action)
 		if (ret != 0) {
 			LOG_ERR("failed to set GPIO for PM suspend");
 		}
+		/* Power down ADC */
+		pm_device_runtime_put(config->voltage.port.dev);
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;


### PR DESCRIPTION
Some ADC's draw significant power while enabled, so make sure the driver can handle ADC's that have device runtime PM enabled.