### PR TITLE
STM32U3: add WWDG and IWDG support

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -43,6 +43,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -132,5 +133,13 @@
 	pinctrl-0 = <&spi3_nss_pa15 &spi3_sck_pb3
 		     &spi3_miso_pb4 &spi3_mosi_pb5>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&iwdg {
+	status = "okay";
+};
+
+&wwdg {
 	status = "okay";
 };

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -16,5 +16,6 @@ supported:
   - spi
   - uart
   - usart
+  - watchdog
 ram: 256
 flash: 1024

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -363,6 +363,20 @@
 			interrupts = <99 0>;
 			status = "disabled";
 		};
+
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
+
+		wwdg: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002c00 0x400>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
+			interrupts = <0 0>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -47,6 +47,7 @@ tests:
       - nucleo_g474re
       - nucleo_l073rz
       - nucleo_l152re
+      - nucleo_u385rg_q
       - nucleo_wb55rg
       - nucleo_wl55jc
       - stm32f3_disco
@@ -89,6 +90,7 @@ tests:
       - nucleo_h743zi
       - nucleo_l073rz
       - nucleo_l152re
+      - nucleo_u385rg_q
       - nucleo_wb55rg
       - nucleo_wl55jc
       - stm32f3_disco

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -51,6 +51,7 @@ tests:
       - nucleo_wb55rg
       - nucleo_wl55jc
       - b_u585i_iot02a
+      - nucleo_u385rg_q
       - nucleo_u575zi_q
       - nucleo_c031c6
       - stm32h573i_dk
@@ -91,6 +92,7 @@ tests:
       - nucleo_h753zi
       - nucleo_h7s3l8
       - stm32h7s78_dk
+      - nucleo_u385rg_q
       - nucleo_wba55cg
     integration_platforms:
       - nucleo_f091rc


### PR DESCRIPTION
Add WWDG & IWDG support for STM32U3. Enable WWDG & IWDG on Nucleo U385RG_Q.