### PR TITLE
modules: hal: infineon: Add Kconfig option for pullups in Wifi Host Driver

### DIFF
--- a/drivers/wifi/infineon/Kconfig.airoc
+++ b/drivers/wifi/infineon/Kconfig.airoc
@@ -59,6 +59,12 @@ config WHD_WIFI_COUNTRY
 	  Sets the country, this will operate in for wifi initialization
 	  parameters. See the wifi-host-driver's whd_country_code_t for legal options.
 
+config WHD_DISABLE_SDIO_PULLUP_DURING_SPI_SLEEP
+	bool "Disable SDIO pullups during SPI sleep"
+	help
+	  Clears SDIO pullups when the SPI bus is configured for sleep.
+	  By default, this option is set to n, so SDIO pullups will be enabled.
+
 config AIROC_WIFI_CUSTOM
 	bool "Custom CYW43xx device/module"
 	help

--- a/modules/hal_infineon/wifi-host-driver/CMakeLists.txt
+++ b/modules/hal_infineon/wifi-host-driver/CMakeLists.txt
@@ -27,6 +27,10 @@ endif()
 
 zephyr_compile_definitions(CY_WIFI_COUNTRY=$<UPPER_CASE:${CONFIG_WHD_WIFI_COUNTRY}>)
 
+if(CONFIG_WHD_DISABLE_SDIO_PULLUP_DURING_SPI_SLEEP)
+  zephyr_compile_definitions(WHD_DISABLE_SDIO_PULLUP_DURING_SPI_SLEEP)
+endif()
+
 # Add WHD includes
 zephyr_include_directories(${hal_wifi_dir})
 zephyr_include_directories(${hal_wifi_dir}/WHD/${whd_wifi_ver}/inc)

--- a/west.yml
+++ b/west.yml
@@ -185,7 +185,7 @@ manifest:
       groups:
         - hal
     - name: hal_infineon
-      revision: 1030915af885cffc8cedc49a62291dd279a9e81e
+      revision: f78b8f8202db0115dc41aedda6f77dee8985254f
       path: modules/hal/infineon
       groups:
         - hal


### PR DESCRIPTION
This option allows board configurations to specify how to set the SDIO pull ups when the SPI bus goes to sleep, using the Infineon WHD. This is a board specific value.

This PR is dependent on a PR for `hal_infineon`: https://github.com/zephyrproject-rtos/hal_infineon/pull/28

It provides a fix to the issue highlighted in #90793 and #91226 

The default configuration is to leave things as they are for other boards relying on the current behaviour.

Happy to make further changes as necessary.

Thanks, Tim 👍 