### PR TITLE
drivers: intc_wch_pfic: correct/optimize interrupt disable logic

### DIFF
--- a/drivers/interrupt_controller/intc_wch_pfic.c
+++ b/drivers/interrupt_controller/intc_wch_pfic.c
@@ -12,23 +12,24 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
 
-#define SEVONPEND (1 << 4)
-#define WFITOWFE  (1 << 3)
+#define SEVONPEND BIT(4)
+#define WFITOWFE  BIT(3)
 
 void arch_irq_enable(unsigned int irq)
 {
-	PFIC->IENR[irq / 32] = 1 << (irq % 32);
+	PFIC->IENR[irq / 32] = BIT(irq % 32);
 }
 
 void arch_irq_disable(unsigned int irq)
 {
-	PFIC->IRER[irq / 32] = 1 << (irq % 32);
+	PFIC->IRER[irq / 32] = BIT(irq % 32);
 }
 
 int arch_irq_is_enabled(unsigned int irq)
 {
-	return ((PFIC->ISR[irq >> 5] & (1 << (irq & 0x1F))) != 0);
+	return ((PFIC->ISR[irq >> 5] & BIT(irq & 0x1F)) != 0);
 }
 
 static int pfic_init(void)

--- a/drivers/interrupt_controller/intc_wch_pfic.c
+++ b/drivers/interrupt_controller/intc_wch_pfic.c
@@ -23,7 +23,7 @@ void arch_irq_enable(unsigned int irq)
 
 void arch_irq_disable(unsigned int irq)
 {
-	PFIC->IRER[irq / 32] |= 1 << (irq % 32);
+	PFIC->IRER[irq / 32] = 1 << (irq % 32);
 }
 
 int arch_irq_is_enabled(unsigned int irq)


### PR DESCRIPTION
The IRER registers are write-only and clear the enable bit for the provided interrupt. Use a direct write instead of a read/modify/write sequence to avoid generating a bogus read access and improve performance

![image](https://github.com/user-attachments/assets/c4d88606-432e-4a5a-afdd-8ca147df3be4)
