### PR TITLE
drivers: misc: fix condition in gpio_ra_interrupt_unset function

### DIFF
--- a/drivers/misc/renesas_ra_external_interrupt/renesas_ra_external_interrupt.c
+++ b/drivers/misc/renesas_ra_external_interrupt/renesas_ra_external_interrupt.c
@@ -107,7 +107,7 @@ void gpio_ra_interrupt_unset(const struct device *dev, uint8_t port_num, uint8_t
 	const struct gpio_ra_irq_config *config = dev->config;
 	struct gpio_ra_irq_data *data = dev->data;
 
-	if ((port_num != data->callback.port_num) && (pin != data->callback.pin)) {
+	if ((port_num != data->callback.port_num) || (pin != data->callback.pin)) {
 		return;
 	}
 


### PR DESCRIPTION
Updated the condition in the gpio_ra_interrupt_unset function to use a logical OR instead of AND, since it should return if either port_num or pin is not the same as the current callback.