### PR TITLE
soc: sensry: fix irq enable/disable

### DIFF
--- a/soc/sensry/ganymed/sy1xx/common/soc.c
+++ b/soc/sensry/ganymed/sy1xx/common/soc.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(soc);
 #define SY1XX_ARCHI_ITC_ACK_SET_OFFSET    0x1c
 #define SY1XX_ARCHI_ITC_ACK_CLR_OFFSET    0x20
 #define SY1XX_ARCHI_ITC_FIFO_OFFSET       0x24
+#define SY1XX_ARCHI_ITC_IRQ_MASK          0x1f
 
 void sys_arch_reboot(int type)
 {
@@ -51,17 +52,13 @@ void riscv_clic_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags)
 
 void soc_enable_irq(uint32_t idx)
 {
-	uint32_t current = sys_read32(SY1XX_ARCHI_FC_ITC_ADDR + SY1XX_ARCHI_ITC_MASK_SET_OFFSET);
-
-	sys_write32(current | (1 << (idx & 0x1f)),
+	sys_write32(BIT(idx & SY1XX_ARCHI_ITC_IRQ_MASK),
 		    SY1XX_ARCHI_FC_ITC_ADDR + SY1XX_ARCHI_ITC_MASK_SET_OFFSET);
 }
 
 void soc_disable_irq(uint32_t idx)
 {
-	uint32_t current = sys_read32(SY1XX_ARCHI_FC_ITC_ADDR + SY1XX_ARCHI_ITC_MASK_CLR_OFFSET);
-
-	sys_write32(current & (~(1 << (idx & 0x1f))),
+	sys_write32(BIT(idx & SY1XX_ARCHI_ITC_IRQ_MASK),
 		    SY1XX_ARCHI_FC_ITC_ADDR + SY1XX_ARCHI_ITC_MASK_CLR_OFFSET);
 }
 

--- a/soc/sensry/ganymed/sy1xx/common/soc.c
+++ b/soc/sensry/ganymed/sy1xx/common/soc.c
@@ -31,8 +31,8 @@ void sys_arch_reboot(int type)
 	ARG_UNUSED(type);
 }
 
-#define SY1XX_ARCHI_REF_CLOCK (32768)
-#define SY1XX_ARCHI_PER_CLOCK (125000000)
+#define SY1XX_ARCHI_REF_CLOCK 32768
+#define SY1XX_ARCHI_PER_CLOCK 125000000
 
 uint32_t sy1xx_soc_get_rts_clock_frequency(void)
 {


### PR DESCRIPTION
SET/CLR registers are write-only so trying to read/modify/write is inefficient & illegal

@tswaehn just curious if this fix is correct - it was a suggestion I got while experimenting with LLMs on the codebase, but since it doesn't seem the ganymed documentation is public, it's hard to tell if it's correct :)