### PR TITLE
drivers: clock_control: esp32c6: fix modem clock source selection

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -98,7 +98,7 @@ static void esp32_clock_perip_init(void)
 						  ? MODEM_CLOCK_LPCLK_SRC_RC32K
 					  : (rtc_slow_clk_src == SOC_RTC_SLOW_CLK_SRC_OSC_SLOW)
 						  ? MODEM_CLOCK_LPCLK_SRC_EXT32K
-						  : SOC_RTC_SLOW_CLK_SRC_RC_SLOW);
+						  : MODEM_CLOCK_LPCLK_SRC_RC_SLOW);
 
 	modem_clock_select_lp_clock_source(PERIPH_WIFI_MODULE, modem_lpclk_src, 0);
 


### PR DESCRIPTION
Properly default to MODEM_CLOCK_LPCLK_SRC_RC_SLOW in modem LP clock source selection