### PR TITLE
drivers: dac: esp32: avoid out-of-range channel ID

### DIFF
--- a/drivers/dac/dac_esp32.c
+++ b/drivers/dac/dac_esp32.c
@@ -39,7 +39,7 @@ static int dac_esp32_channel_setup(const struct device *dev,
 {
 	ARG_UNUSED(dev);
 
-	if (channel_cfg->channel_id > SOC_DAC_CHAN_NUM) {
+	if (channel_cfg->channel_id >= SOC_DAC_CHAN_NUM) {
 		LOG_ERR("Channel %d is not valid", channel_cfg->channel_id);
 		return -EINVAL;
 	}


### PR DESCRIPTION
fix channel ID check in dac_esp32_channel_setup as it was allowing to set up a channel with ID greater than the number of channels.