### PR TITLE
drivers: led: fix LED_BRIGTHNESS_MAX typo

### DIFF
--- a/drivers/led/ht16k33.c
+++ b/drivers/led/ht16k33.c
@@ -130,7 +130,7 @@ static int ht16k33_led_set_brightness(const struct device *dev, uint32_t led,
 	uint8_t dim;
 	uint8_t cmd;
 
-	dim = (value * (HT16K33_DIMMING_LEVELS - 1)) / LED_BRIGTHNESS_MAX;
+	dim = (value * (HT16K33_DIMMING_LEVELS - 1)) / LED_BRIGHTNESS_MAX;
 	cmd = HT16K33_CMD_DIMMING_SET | dim;
 
 	if (i2c_write_dt(&config->i2c, &cmd, sizeof(cmd))) {

--- a/drivers/led/is31fl3194.c
+++ b/drivers/led/is31fl3194.c
@@ -146,7 +146,7 @@ static int is31fl3194_set_brightness(const struct device *dev, uint32_t led, uin
 	}
 
 	/* Rescale 0..100 to 0..255 */
-	value = value * 255 / LED_BRIGTHNESS_MAX;
+	value = value * 255 / LED_BRIGHTNESS_MAX;
 
 	ret = i2c_reg_write_byte_dt(&config->bus, led_channels[led], value);
 	if (ret == 0) {

--- a/drivers/led/is31fl3216a.c
+++ b/drivers/led/is31fl3216a.c
@@ -62,7 +62,7 @@ static int is31fl3216a_update_pwm(const struct i2c_dt_spec *i2c)
 
 static uint8_t is31fl3216a_brightness_to_pwm(uint8_t brightness)
 {
-	return (0xFFU * brightness) / LED_BRIGTHNESS_MAX;
+	return (0xFFU * brightness) / LED_BRIGHTNESS_MAX;
 }
 
 static int is31fl3216a_led_write_channels(const struct device *dev,
@@ -87,7 +87,7 @@ static int is31fl3216a_led_write_channels(const struct device *dev,
 	i2c_buffer[0] = IS31FL3216A_REG_PWM_LAST - start_channel -
 			(num_channels - 1);
 	for (i = 0; i < num_channels; i++) {
-		if (buf[num_channels - i - 1] > LED_BRIGTHNESS_MAX) {
+		if (buf[num_channels - i - 1] > LED_BRIGHTNESS_MAX) {
 			return -EINVAL;
 		}
 		i2c_buffer[i + 1] = is31fl3216a_brightness_to_pwm(

--- a/drivers/led/is31fl3733.c
+++ b/drivers/led/is31fl3733.c
@@ -96,7 +96,7 @@ static int is31fl3733_led_set_brightness(const struct device *dev, uint32_t led,
 {
 	const struct is31fl3733_config *config = dev->config;
 	int ret;
-	uint8_t led_brightness = (uint8_t)(((uint32_t)value * 255) / LED_BRIGTHNESS_MAX);
+	uint8_t led_brightness = (uint8_t)(((uint32_t)value * 255) / LED_BRIGHTNESS_MAX);
 
 	if (led >= IS31FL3733_MAX_LED) {
 		return -EINVAL;

--- a/drivers/led/led_dac.c
+++ b/drivers/led/led_dac.c
@@ -43,7 +43,7 @@ static int led_dac_set_brightness(const struct device *dev, uint32_t led, uint8_
 	value = pct > 0 ? config->leds[led].dac_min_brightness +
 				  (uint64_t)(config->leds[led].dac_max_brightness -
 					     config->leds[led].dac_min_brightness) *
-					  pct / LED_BRIGTHNESS_MAX
+					  pct / LED_BRIGHTNESS_MAX
 			: 0;
 
 	return led_dac_set_raw(dev, led, value);

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -65,7 +65,7 @@ static int led_pwm_set_brightness(const struct device *dev,
 	dt_led = &config->led[led];
 
 	return pwm_set_pulse_dt(&config->led[led],
-			(uint32_t) ((uint64_t) dt_led->period * value / LED_BRIGTHNESS_MAX));
+			(uint32_t) ((uint64_t) dt_led->period * value / LED_BRIGHTNESS_MAX));
 }
 
 static int led_pwm_init(const struct device *dev)

--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -164,7 +164,7 @@ static int cmd_set_brightness(const struct shell *sh,
 			     argv[arg_idx_value]);
 		return -EINVAL;
 	}
-	if (value > LED_BRIGTHNESS_MAX) {
+	if (value > LED_BRIGHTNESS_MAX) {
 		shell_error(sh, "Invalid LED brightness value %lu (max 100)",
 			    value);
 		return -EINVAL;

--- a/drivers/led/lp3943.c
+++ b/drivers/led/lp3943.c
@@ -178,7 +178,7 @@ static int lp3943_led_set_brightness(const struct device *dev, uint32_t led,
 		reg = LP3943_PWM1;
 	}
 
-	val = (value * 255U) / LED_BRIGTHNESS_MAX;
+	val = (value * 255U) / LED_BRIGHTNESS_MAX;
 	if (i2c_reg_write_byte_dt(&config->bus, reg, val)) {
 		LOG_ERR("LED write failed");
 		return -EIO;

--- a/drivers/led/lp50xx.c
+++ b/drivers/led/lp50xx.c
@@ -125,7 +125,7 @@ static int lp50xx_set_brightness(const struct device *dev,
 	}
 
 	buf[0] = LP50XX_LED0_BRIGHTNESS(config->num_modules) + led_info->index;
-	buf[1] = (value * 0xff) / LED_BRIGTHNESS_MAX;
+	buf[1] = (value * 0xff) / LED_BRIGHTNESS_MAX;
 
 	return i2c_write_dt(&config->bus, buf, sizeof(buf));
 }

--- a/drivers/led/lp5562.c
+++ b/drivers/led/lp5562.c
@@ -601,7 +601,7 @@ static int lp5562_program_set_brightness(const struct device *dev,
 {
 	uint8_t val;
 
-	val = (brightness * 0xFF) / LED_BRIGTHNESS_MAX;
+	val = (brightness * 0xFF) / LED_BRIGHTNESS_MAX;
 
 	return lp5562_program_command(dev, engine, command_index,
 			LP5562_PROG_COMMAND_SET_PWM, val);
@@ -781,7 +781,7 @@ static int lp5562_led_blink(const struct device *dev, uint32_t led,
 	}
 
 	ret = lp5562_program_set_brightness(dev, engine, command_index,
-			LED_BRIGTHNESS_MAX);
+			LED_BRIGHTNESS_MAX);
 	if (ret) {
 		return ret;
 	}
@@ -792,7 +792,7 @@ static int lp5562_led_blink(const struct device *dev, uint32_t led,
 	}
 
 	ret = lp5562_program_set_brightness(dev, engine, ++command_index,
-			LED_BRIGTHNESS_MAX);
+			LED_BRIGHTNESS_MAX);
 	if (ret) {
 		return ret;
 	}
@@ -845,7 +845,7 @@ static int lp5562_led_set_brightness(const struct device *dev, uint32_t led,
 		}
 	}
 
-	val = (value * 0xFF) / LED_BRIGTHNESS_MAX;
+	val = (value * 0xFF) / LED_BRIGHTNESS_MAX;
 
 	ret = lp5562_get_pwm_reg(led, &reg);
 	if (ret) {
@@ -862,7 +862,7 @@ static int lp5562_led_set_brightness(const struct device *dev, uint32_t led,
 
 static inline int lp5562_led_on(const struct device *dev, uint32_t led)
 {
-	return lp5562_led_set_brightness(dev, led, LED_BRIGTHNESS_MAX);
+	return lp5562_led_set_brightness(dev, led, LED_BRIGHTNESS_MAX);
 }
 
 static inline int lp5562_led_off(const struct device *dev, uint32_t led)
@@ -882,7 +882,7 @@ static inline int lp5562_led_off(const struct device *dev, uint32_t led)
 		}
 	}
 
-	return lp5562_led_set_brightness(dev, led, LED_BRIGTHNESS_MAX);
+	return lp5562_led_set_brightness(dev, led, LED_BRIGHTNESS_MAX);
 }
 
 static int lp5562_led_update_current(const struct device *dev)

--- a/drivers/led/lp5569.c
+++ b/drivers/led/lp5569.c
@@ -54,7 +54,7 @@ static int lp5569_led_set_brightness(const struct device *dev, uint32_t led, uin
 	}
 
 	/* Map 0-100 % to 0-255 pwm register value */
-	val = brightness * 255 / LED_BRIGTHNESS_MAX;
+	val = brightness * 255 / LED_BRIGHTNESS_MAX;
 
 	ret = i2c_reg_write_byte_dt(&config->bus, LP5569_LED0_PWM + led, val);
 	if (ret < 0) {

--- a/drivers/led/ncp5623.c
+++ b/drivers/led/ncp5623.c
@@ -105,7 +105,7 @@ static int ncp5623_set_brightness(const struct device *dev, uint32_t led, uint8_
 	}
 
 	/* Rescale 0..100 to 0..31 */
-	value = value * NCP5623_MAX_BRIGHTNESS / LED_BRIGTHNESS_MAX;
+	value = value * NCP5623_MAX_BRIGHTNESS / LED_BRIGHTNESS_MAX;
 
 	ret = i2c_reg_write_byte_dt(&config->bus, led_channels[led] | value, 0x70);
 

--- a/drivers/led/pca9633.c
+++ b/drivers/led/pca9633.c
@@ -119,7 +119,7 @@ static int pca9633_led_set_brightness(const struct device *dev, uint32_t led,
 	uint8_t val;
 
 	/* Set the LED brightness value */
-	val = (value * 255U) / LED_BRIGTHNESS_MAX;
+	val = (value * 255U) / LED_BRIGHTNESS_MAX;
 	if (i2c_reg_write_byte_dt(&config->i2c,
 			       PCA9633_PWM_BASE + led,
 			       val)) {

--- a/drivers/led/tlc59108.c
+++ b/drivers/led/tlc59108.c
@@ -139,7 +139,7 @@ static int tlc59108_led_set_brightness(const struct device *dev, uint32_t led,
 	}
 
 	/* Set the LED brightness value */
-	val = (value * 255U) / LED_BRIGTHNESS_MAX;
+	val = (value * 255U) / LED_BRIGHTNESS_MAX;
 	if (i2c_reg_write_byte_dt(&config->i2c, TLC59108_PWM_BASE + led, val)) {
 		LOG_ERR("LED 0x%x reg write failed", TLC59108_PWM_BASE + led);
 		return -EIO;

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -33,7 +33,7 @@ extern "C" {
 /**
  * @brief Maximum brightness level, range is 0 to 100.
  */
-#define LED_BRIGTHNESS_MAX 100u
+#define LED_BRIGHTNESS_MAX 100u
 
 /**
  * @brief LED information structure
@@ -213,7 +213,7 @@ static inline int z_impl_led_set_brightness(const struct device *dev,
 		}
 	}
 
-	if (value > LED_BRIGTHNESS_MAX) {
+	if (value > LED_BRIGHTNESS_MAX) {
 		return -EINVAL;
 	}
 
@@ -337,7 +337,7 @@ static inline int z_impl_led_on(const struct device *dev, uint32_t led)
 	}
 
 	if (api->on == NULL) {
-		return api->set_brightness(dev, led, LED_BRIGTHNESS_MAX);
+		return api->set_brightness(dev, led, LED_BRIGHTNESS_MAX);
 	}
 
 	return api->on(dev, led);


### PR DESCRIPTION
Renames LED_BRIGTHNESS_MAX to LED_BRIGHTNESS_MAX in led.h and all in-tree users of the macro.
