### PR TITLE
devicetree: Use `IS_EQ()` for `DT_SAME_NODE()`

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -690,7 +690,7 @@
  *         refer to the same node, and evaluates to 0 otherwise
  */
 #define DT_SAME_NODE(node_id1, node_id2) \
-	(DT_DEP_ORD(node_id1) == (DT_DEP_ORD(node_id2)))
+	IS_EQ(DT_DEP_ORD(node_id1), DT_DEP_ORD(node_id2))
 
 /**
  * @brief Get a devicetree node's node labels as an array of strings


### PR DESCRIPTION
`DT_SAME_NODE()` judges equality by `==` and cannot be used as a condition for `COND_CODE_1()`.
Using `UTIL_IS_EQ()` to make it possible for compile-time calculation.
