### PR TITLE
drivers:dac:dac_ad56xx.c - Added support for selected DAC channel for Channel A and Channel B together and All channel for AD5686

### DIFF
--- a/drivers/dac/dac_ad56xx.c
+++ b/drivers/dac/dac_ad56xx.c
@@ -295,6 +295,8 @@ static const uint8_t ad5686_channels[] = {
 	2,
 	4,
 	8,
+	3,
+	15,
 };
 #define DAC_AD5686_RESOLUTION    16
 #define DAC_AD5686_CHANNELS      ad5686_channels


### PR DESCRIPTION
Ref :- AD5686/AD5684 datasheet Page 19 , Table 9
![Screenshot 2025-06-07 175835](https://github.com/user-attachments/assets/5e8de7c2-5f69-4d34-bdb0-65b045de9b6c)

