### PR TITLE
lib: posix: dedicated symbol for POSIX system headers

### DIFF
--- a/lib/posix/options/CMakeLists.txt
+++ b/lib/posix/options/CMakeLists.txt
@@ -6,7 +6,7 @@ zephyr_syscall_header_ifdef(CONFIG_POSIX_CLOCK_SELECTION posix_clock.h)
 zephyr_syscall_header_ifdef(CONFIG_POSIX_TIMERS posix_clock.h)
 zephyr_syscall_header_ifdef(CONFIG_XSI_SINGLE_PROCESS posix_clock.h)
 
-if(CONFIG_POSIX_API)
+if(CONFIG_POSIX_SYSTEM_HEADERS)
   zephyr_include_directories(${ZEPHYR_BASE}/include/zephyr/posix)
 endif()
 

--- a/lib/posix/options/Kconfig.profile
+++ b/lib/posix/options/Kconfig.profile
@@ -2,10 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+config POSIX_SYSTEM_HEADERS
+	bool
+	depends on !NATIVE_APPLICATION
+	select NATIVE_LIBC_INCOMPATIBLE
+	help
+	  Make POSIX headers available to the system without the "zephyr/posix" prefix.
+
 config POSIX_API
 	bool "POSIX APIs"
 	depends on !NATIVE_APPLICATION
 	select NATIVE_LIBC_INCOMPATIBLE
+	select POSIX_SYSTEM_HEADERS
 	select POSIX_BASE_DEFINITIONS # clock_gettime(), pthread_create(), sem_get(), etc
 	select POSIX_AEP_REALTIME_MINIMAL # CLOCK_MONOTONIC, pthread_attr_setstack(), etc
 	select POSIX_NETWORKING if NETWORKING # inet_ntoa(), socket(), etc
@@ -99,6 +107,7 @@ endchoice # POSIX_AEP_CHOICE
 # Base Definitions (System Interfaces)
 config POSIX_BASE_DEFINITIONS
 	bool
+	select POSIX_SYSTEM_HEADERS
 	select POSIX_ASYNCHRONOUS_IO
 	select POSIX_BARRIERS
 	select POSIX_CLOCK_SELECTION


### PR DESCRIPTION
Add a dedicated symbol for including the POSIX system headers path directly into the include path, enabling (for example) `#include <time.h>` instead of `#include <zephyr/posix/time.h>`.

Cherry pick of the most useful commit from #88541 that enables individual subsystems to transition away from `CONFIG_POSIX_API` without otherwise impacting existing users.