### PR TITLE
posix: aio: include zephyr/toolchain.h for ZRESTRICT

### DIFF
--- a/include/zephyr/posix/aio.h
+++ b/include/zephyr/posix/aio.h
@@ -11,6 +11,8 @@
 #include <sys/types.h>
 #include <time.h>
 
+#include <zephyr/toolchain.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Previously, `ZRESTRICT` was used in `aio.h` without also including `zephyr/toolchain.h`.

Tests may have compiled because the toolchain header was included by some other means.

We should explicitly include it to ensure that `ZRESTRICT` is defined.