### PR TITLE
Fix video_query_ctrl skipped CIDs issue

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -400,6 +400,7 @@ int64_t video_get_csi_link_freq(const struct device *dev, uint8_t bpp, uint8_t l
 		.id = VIDEO_CID_LINK_FREQ,
 	};
 	struct video_ctrl_query ctrl_query = {
+		.dev = dev,
 		.id = VIDEO_CID_LINK_FREQ,
 	};
 	int ret;
@@ -410,7 +411,7 @@ int64_t video_get_csi_link_freq(const struct device *dev, uint8_t bpp, uint8_t l
 		goto fallback;
 	}
 
-	ret = video_query_ctrl(dev, &ctrl_query);
+	ret = video_query_ctrl(&ctrl_query);
 	if (ret < 0) {
 		return ret;
 	}

--- a/include/zephyr/drivers/video-controls.h
+++ b/include/zephyr/drivers/video-controls.h
@@ -455,7 +455,9 @@ struct video_ctrl_range {
  * Used to query information about a control.
  */
 struct video_ctrl_query {
-	/** control id */
+	/** device being queried, application needs to set this field */
+	const struct device *dev;
+	/** control id, application needs to set this field */
 	uint32_t id;
 	/** control type */
 	uint32_t type;

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -708,14 +708,13 @@ struct video_ctrl_query;
  * difficult. Hence, the best way to enumerate all kinds of device's supported controls is to
  * iterate with VIDEO_CTRL_FLAG_NEXT_CTRL.
  *
- * @param dev Pointer to the device structure.
  * @param cq Pointer to the control query struct.
  *
  * @retval 0 If successful.
  * @retval -EINVAL If the control id is invalid.
  * @retval -ENOTSUP If the control id is not supported.
  */
-int video_query_ctrl(const struct device *dev, struct video_ctrl_query *cq);
+int video_query_ctrl(struct video_ctrl_query *cq);
 
 /**
  * @brief Print all the information of a control.
@@ -724,10 +723,9 @@ int video_query_ctrl(const struct device *dev, struct video_ctrl_query *cq);
  * menu (if any) and current value, i.e. by invoking the video_get_ctrl(), in a
  * human readble format.
  *
- * @param dev Pointer to the device structure.
  * @param cq Pointer to the control query struct.
  */
-void video_print_ctrl(const struct device *const dev, const struct video_ctrl_query *const cq);
+void video_print_ctrl(const struct video_ctrl_query *const cq);
 
 /**
  * @brief Register/Unregister k_poll signal for a video endpoint.

--- a/samples/drivers/video/capture/src/main.c
+++ b/samples/drivers/video/capture/src/main.c
@@ -181,11 +181,15 @@ int main(void)
 
 	/* Get supported controls */
 	LOG_INF("- Supported controls:");
+	const struct device *last_dev = NULL;
+	struct video_ctrl_query cq = {.dev = video_dev, .id = VIDEO_CTRL_FLAG_NEXT_CTRL};
 
-	struct video_ctrl_query cq = {.id = VIDEO_CTRL_FLAG_NEXT_CTRL};
-
-	while (!video_query_ctrl(video_dev, &cq)) {
-		video_print_ctrl(video_dev, &cq);
+	while (!video_query_ctrl(&cq)) {
+		if (cq.dev != last_dev) {
+			last_dev = cq.dev;
+			LOG_INF("\t\tdevice: %s", cq.dev->name);
+		}
+		video_print_ctrl(&cq);
 		cq.id |= VIDEO_CTRL_FLAG_NEXT_CTRL;
 	}
 


### PR DESCRIPTION
This PR fixes the skipped CIDs issue as discussed in https://github.com/zephyrproject-rtos/zephyr/pull/91228 when enumerating controls with VIDEO_CTRL_FLAG_NEXT_CTRL, if child devices have controls with IDs lower or equal to the ones in the parent devices, those controls will be accidentally skipped.

Fix this by resetting the query's ID and tracking of device in the control query when moving to the next device in the pipeline.

video_query_ctrl() and video_print_ctrl() now do not need the device parameters as it is embedded in the control query.