### PR TITLE
STM32U3: add IWDG support

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -93,3 +93,7 @@
 &clk_lsi {
 	status = "okay";
 };
+
+&wwdg {
+	status = "okay";
+};

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -43,6 +43,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 
@@ -91,6 +92,10 @@
 };
 
 &clk_lsi {
+	status = "okay";
+};
+
+&iwdg {
 	status = "okay";
 };
 

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -8,5 +8,6 @@ supported:
   - arduino_gpio
   - gpio
   - usart
+  - watchdog
 ram: 256
 flash: 1024

--- a/drivers/flash/flash_stm32l5x.c
+++ b/drivers/flash/flash_stm32l5x.c
@@ -21,7 +21,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 
 #include "flash_stm32.h"
 
-#if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32U5X)
+#if defined(CONFIG_SOC_SERIES_STM32H5X) || defined(CONFIG_SOC_SERIES_STM32U5X) \
+	    || defined(CONFIG_SOC_SERIES_STM32U3X)
 /*
  * It is used to handle the 2 banks discontinuity case,
  * so define it to flash size to avoid the unexpected check.

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -231,6 +231,14 @@
 			interrupts = <66 0>;
 			status = "disabled";
 		};
+
+		wwdg: watchdog@40002c00 {
+			compatible = "st,stm32-window-watchdog";
+			reg = <0x40002c00 0x1000>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
+			interrupts = <0 7>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -239,6 +239,12 @@
 			interrupts = <0 7>;
 			status = "disabled";
 		};
+
+		iwdg: watchdog@40003000 {
+			compatible = "st,stm32-watchdog";
+			reg = <0x40003000 0x400>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/include/zephyr/dt-bindings/clock/stm32u3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u3_clock.h
@@ -79,10 +79,6 @@
 #define DAC1SH_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 19, CCIPR2_REG)
 #define OCTOSPI_SEL(val)	STM32_DT_CLOCK_SELECT((val), 1, 20, CCIPR2_REG)
 /** CCIPR3 devices */
-#define LPUART1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 3, 0, CCIPR3_REG)
-#define I2C3_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 6, CCIPR3_REG)
-#define LPTIM34_SEL(val)	STM32_DT_CLOCK_SELECT((val), 3, 8, CCIPR3_REG)
-#define LPTIM1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 10, CCIPR3_REG)
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 8, BDCR_REG)
 

--- a/samples/drivers/watchdog/sample.yaml
+++ b/samples/drivers/watchdog/sample.yaml
@@ -89,6 +89,7 @@ tests:
       - nucleo_h743zi
       - nucleo_l073rz
       - nucleo_l152re
+      - nucleo_u385rg_q
       - nucleo_wb55rg
       - nucleo_wl55jc
       - stm32f3_disco

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -91,6 +91,7 @@ tests:
       - nucleo_h753zi
       - nucleo_h7s3l8
       - stm32h7s78_dk
+      - nucleo_u385rg_q
       - nucleo_wba55cg
     integration_platforms:
       - nucleo_f091rc


### PR DESCRIPTION
Add watchdog support for STM32U3
Enable watchdog for Nucleo U385RG Q
Add Nucleo U385 Q to the wdt_basic_api test