### PR TITLE
STM32U3: add RNG (Random Nb Generator) support

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -99,3 +99,7 @@
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
 };
+
+&rng {
+	status = "okay";
+};

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -12,6 +12,7 @@
 
 / {
 	chosen {
+		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash;
 	};
 
@@ -237,6 +238,14 @@
 			reg = <0x42028400 0x400>;
 			clocks = <&rcc STM32_CLOCK(AHB2, 11)>;
 			#io-channel-cells = <1>;
+			status = "disabled";
+		};
+
+		rng: rng@420c0800 {
+			compatible = "st,stm32-rng";
+			reg = <0x420c0800 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
+			interrupts = <94 0>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
This PR adds the support of the RNG which is a true random number generator that provides full entropy outputs to the
application as 32-bit samples
This peripheral is enabled on the nucleo board u385rg_q