### PR TITLE
tests: posix: xsi_single_process: remove unnecessary min_ram filter

### DIFF
--- a/tests/posix/xsi_single_process/testcase.yaml
+++ b/tests/posix/xsi_single_process/testcase.yaml
@@ -28,7 +28,6 @@ tests:
       - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256
   portability.xsi.single_process.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
-    min_ram: 24
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE=256


### PR DESCRIPTION
The xsi single process test suite requires something like 256 bytes of heap space. There is no legitimate reason to require 24kB of ram.

This gets rid of a twister error seen in multiple PRs that should presumably be failing in a nightly run.

```shell
Error found: portability.xsi.single_process.newlib on qemu_cortex_m0/nrf51822 (Not enough RAM but is one of the integration platforms)
```

Testing done:
```shell
twister -i -p qemu_cortex_m0 -T tests/posix/xsi_single_process/
Renaming output directory to /home/cfriedt/zephyrproject/zephyr/twister-out.5
INFO    - Using Ninja..
INFO    - Zephyr version: v4.1.0-5419-gbc87aba947ea
INFO    - Using 'zephyr' toolchain.
INFO    - Building initial testsuite list...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/testplan.json
INFO    - JOBS: 32
INFO    - Adding tasks to the queue...
INFO    - Added initial list of jobs to queue
INFO    - Total complete:    4/   4  100%  built (not run):    0, filtered:    2, failed:    0, error:    0
INFO    - 6 test scenarios (6 configurations) selected, 2 configurations filtered (2 by static filter, 0 at runtime).
INFO    - 4 of 4 executed test configurations passed (100.00%), 0 built (not run), 0 failed, 0 errored, with no warnings in 15.15 seconds.
INFO    - 12 of 12 executed test cases passed (100.00%) on 1 out of total 1080 platforms (0.09%).
INFO    - 4 test configurations executed on platforms, 0 test configurations were only built.
INFO    - Saving reports...
INFO    - Writing JSON report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.json
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister.xml...
INFO    - Writing xunit report /home/cfriedt/zephyrproject/zephyr/twister-out/twister_report.xml...
INFO    - Run completed
```