### PR TITLE
Bluetooth: Controller: Fix incorrect elapsed events value

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync_iso.h
@@ -30,8 +30,10 @@ struct lll_sync_iso {
 
 	uint16_t iso_interval;
 
+	uint16_t lazy_prepare;
 	uint16_t latency_prepare;
 	uint16_t latency_event;
+
 	union {
 		struct lll_sync_iso_data_chan data_chan;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1129,7 +1129,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 #endif /* CONFIG_BT_PERIPHERAL */
 	}
 
-	elapsed_event = latency_event + lll->lazy_prepare + 1U;
+	elapsed_event = lll->lazy_prepare + 1U;
 
 	/* Reset supervision countdown */
 	if (done->extra.crc_valid && !done->extra.is_aborted) {

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -1342,7 +1342,7 @@ void ull_sync_done(struct node_rx_event_done *done)
 			sync->sync_expire = 0U;
 		}
 
-		elapsed_event = skip_event + lll->lazy_prepare + 1U;
+		elapsed_event = lll->lazy_prepare + 1U;
 
 		/* Reset supervision countdown */
 		if (done->extra.crc_valid) {

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -185,6 +185,7 @@ uint8_t ll_big_sync_create(uint8_t big_handle, uint16_t sync_handle,
 
 	/* Initialize sync LLL context */
 	lll = &sync_iso->lll;
+	lll->lazy_prepare = 0U;
 	lll->latency_prepare = 0U;
 	lll->latency_event = 0U;
 	lll->window_widening_prepare_us = 0U;
@@ -762,11 +763,6 @@ void ull_sync_iso_done(struct node_rx_event_done *done)
 
 	/* Events elapsed used in timeout checks below */
 	latency_event = lll->latency_event;
-	if (lll->latency_prepare) {
-		elapsed_event = latency_event + lll->latency_prepare;
-	} else {
-		elapsed_event = latency_event + 1U;
-	}
 
 	/* Check for establishmet failure */
 	if (done->extra.estab_failed) {
@@ -799,6 +795,8 @@ void ull_sync_iso_done(struct node_rx_event_done *done)
 			sync_iso->timeout_expire = sync_iso->timeout_reload;
 		}
 	}
+
+	elapsed_event = lll->lazy_prepare + 1U;
 
 	/* check timeout */
 	force = 0U;


### PR DESCRIPTION
Fix incorrect elapsed events value when LLL event prepare_cb was invoked but was aborted before anchor point sync. This caused premature supervision timeouts under applications configured with CONFIG_BT_CTLR_EVENT_OVERHEAD_RESERVE_MAX=n and CONFIG_BT_CTLR_PERIPHERAL_RESERVE_MAX=n.

Fixes commit 247037bd3e2a ("Bluetooth: Controller: Fix incorrect elapsed events value").