### PR TITLE
net: mqtt: Allow to bind client to a specific interface

### DIFF
--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -809,6 +809,11 @@ struct mqtt_transport {
 	 */
 	enum mqtt_transport_type type;
 
+	/** Name of the interface that the MQTT client instance should be bound to.
+	 *  Leave as NULL if not specified.
+	 */
+	const char *if_name;
+
 	/** Use either unsecured TCP or secured TLS transport */
 	union {
 		/** TCP socket transport for MQTT */

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
@@ -29,6 +29,26 @@ int mqtt_client_tcp_connect(struct mqtt_client *client)
 		return -errno;
 	}
 
+	NET_DBG("Created socket %d", client->transport.tcp.sock);
+
+	if (client->transport.if_name != NULL) {
+		struct ifreq ifname = { 0 };
+
+		strncpy(ifname.ifr_name, client->transport.if_name,
+			sizeof(ifname.ifr_name) - 1);
+
+		ret = zsock_setsockopt(client->transport.tcp.sock, SOL_SOCKET,
+				       SO_BINDTODEVICE, &ifname,
+				       sizeof(struct ifreq));
+		if (ret < 0) {
+			NET_ERR("Failed to bind ot interface %s error (%d)",
+				ifname.ifr_name, -errno);
+			goto error;
+		}
+
+		NET_DBG("Bound to interface %s", ifname.ifr_name);
+	}
+
 #if defined(CONFIG_SOCKS)
 	if (client->transport.proxy.addrlen != 0) {
 		ret = setsockopt(client->transport.tcp.sock,
@@ -40,8 +60,6 @@ int mqtt_client_tcp_connect(struct mqtt_client *client)
 		}
 	}
 #endif
-
-	NET_DBG("Created socket %d", client->transport.tcp.sock);
 
 	size_t peer_addr_size = sizeof(struct sockaddr_in6);
 

--- a/tests/net/lib/mqtt/v3_1_1/mqtt_client/src/main.c
+++ b/tests/net/lib/mqtt/v3_1_1/mqtt_client/src/main.c
@@ -710,6 +710,23 @@ ZTEST(mqtt_client, test_mqtt_connect)
 	zassert_false(test_ctx.connected, "MQTT client should be disconnected");
 }
 
+ZTEST(mqtt_client, test_mqtt_connect_with_binding)
+{
+	char name_buf[IFNAMSIZ] = { 0 };
+	int ret = net_if_get_name(net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY)),
+				  name_buf, sizeof(name_buf));
+
+
+	zassert_true(ret > 0, "Failed to get loopback interface name");
+
+	client_ctx.transport.if_name = name_buf;
+
+	test_connect();
+	zassert_true(test_ctx.connected, "MQTT client should be connected");
+	test_disconnect();
+	zassert_false(test_ctx.connected, "MQTT client should be disconnected");
+}
+
 ZTEST(mqtt_client, test_mqtt_ping)
 {
 	test_connect();


### PR DESCRIPTION
Add a new "if_name" pointer to the transport configuration structure, allowing the application to bind MQTT client to a specific network interface.