### PR TITLE
Fix immediate TCP connect failure with loopback and ACD enabled

### DIFF
--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -138,13 +138,18 @@ void net_ipv4_autoconf_start(struct net_if *iface)
 void net_ipv4_autoconf_reset(struct net_if *iface)
 {
 	struct net_if_config *cfg;
+	struct net_if_addr *ifaddr;
+	struct net_if *ret;
 
 	cfg = net_if_get_config(iface);
 	if (!cfg) {
 		return;
 	}
 
-	net_if_ipv4_addr_rm(iface, &cfg->ipv4auto.requested_ip);
+	ifaddr = net_if_ipv4_addr_lookup(&cfg->ipv4auto.requested_ip, &ret);
+	if (ifaddr != NULL && ret == iface) {
+		net_if_ipv4_addr_rm(iface, &cfg->ipv4auto.requested_ip);
+	}
 
 	NET_DBG("Autoconf reset for %p", iface);
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4402,6 +4402,11 @@ void net_if_ipv4_acd_failed(struct net_if *iface, struct net_if_addr *ifaddr)
 
 void net_if_ipv4_start_acd(struct net_if *iface, struct net_if_addr *ifaddr)
 {
+	if ((l2_flags_get(iface) & NET_L2_POINT_TO_POINT) ||
+	    net_ipv4_is_addr_loopback(&ifaddr->address.in_addr)) {
+		return;
+	}
+
 	ifaddr->addr_state = NET_ADDR_TENTATIVE;
 
 	if (net_if_is_up(iface)) {
@@ -4499,6 +4504,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 	struct net_if_addr *ifaddr = NULL;
 	struct net_if_addr_ipv4 *cur;
 	struct net_if_ipv4 *ipv4;
+	bool do_acd = false;
 	int idx;
 
 	net_if_lock(iface);
@@ -4571,7 +4577,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 		    !(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
 		    !net_ipv4_is_addr_loopback(addr)) {
 			/* ACD is started after the lock is released. */
-			;
+			do_acd = true;
 		} else {
 			ifaddr->addr_state = NET_ADDR_PREFERRED;
 		}
@@ -4584,7 +4590,9 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 
 		net_if_unlock(iface);
 
-		net_if_ipv4_start_acd(iface, ifaddr);
+		if (do_acd) {
+			net_if_ipv4_start_acd(iface, ifaddr);
+		}
 
 		return ifaddr;
 	}


### PR DESCRIPTION
The localhost address used in the connection was marked as `tentative` if ACD was enabled. This meant that we never tried to use it properly, which then led to situation that 127.0.0.1 address was used with non-loopback network interface, which caused connection failure when connecting to a localhost address.

Fixes #91118 