### PR TITLE
soc: raspberrrypi: rp2350: Add missing FPU support

### DIFF
--- a/soc/raspberrypi/rpi_pico/rp2350/Kconfig
+++ b/soc/raspberrypi/rpi_pico/rp2350/Kconfig
@@ -17,6 +17,7 @@ config SOC_RP2350A_M33
 	select CPU_CORTEX_M33
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_ARM_SAU
+	select CPU_HAS_FPU
 
 config SOC_RP2350B_M33
 	select ARM
@@ -26,6 +27,7 @@ config SOC_RP2350B_M33
 	select CPU_CORTEX_M33
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_ARM_SAU
+	select CPU_HAS_FPU
 
 config RP2_REQUIRES_IMAGE_DEFINITION_BLOCK
 	bool


### PR DESCRIPTION
Add CPU_HAS_FPU to make available the FPU feature.