### PR TITLE
Add riscv timebase-frequency property

### DIFF
--- a/dts/riscv/bflb/bl60x.dtsi
+++ b/dts/riscv/bflb/bl60x.dtsi
@@ -16,6 +16,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
+		timebase-frequency = <DT_FREQ_M(1)>;
 
 		cpu0: cpu@0 {
 			device_type = "cpu";

--- a/scripts/dts/gen_edt.py
+++ b/scripts/dts/gen_edt.py
@@ -48,7 +48,7 @@ def main():
                          warn_reg_unit_address_mismatch=
                              "-Wno-simple_bus_reg" not in args.dtc_flags,
                          default_prop_types=True,
-                         infer_binding_for_paths=["/zephyr,user"],
+                         infer_binding_for_paths=["/zephyr,user", "/cpus"],
                          werror=args.edtlib_Werror,
                          vendor_prefixes=vendor_prefixes)
     except edtlib.EDTError as e:

--- a/soc/bflb/Kconfig.defconfig
+++ b/soc/bflb/Kconfig.defconfig
@@ -5,7 +5,7 @@
 if SOC_FAMILY_BFLB
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+	default $(dt_node_int_prop_int,/cpus,timebase-frequency)
 
 rsource "*/Kconfig.defconfig"
 


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/37685

Some reviewers are getting extremely ornery about using kconfig to set timebase for CPUs where the time counter frequency isnt available somewhere in the device tree due to not being the CPU frequency and not being exposed, so here is a fix for this.

~~Ideally this property should be in the cpus group instead of per CPU but I havent managed to make the parser get the value from there instead.~~ Solved.