### PR TITLE
net: sockets_offload: Allow to enable/disable DNS offload at runtime

### DIFF
--- a/include/zephyr/net/socket_offload.h
+++ b/include/zephyr/net/socket_offload.h
@@ -41,6 +41,39 @@ struct socket_dns_offload {
  */
 void socket_offload_dns_register(const struct socket_dns_offload *ops);
 
+/**
+ * @brief Deregister an offloaded socket DNS API interface.
+ *
+ * @param ops A pointer to the offloaded socket DNS API interface.
+ *
+ * @retval 0 On success
+ * @retval -EINVAL Offloaded DNS API was not regsitered.
+ */
+int socket_offload_dns_deregister(const struct socket_dns_offload *ops);
+
+/**
+ * @brief Enable/disable DNS offloading at runtime.
+ *
+ * @param enable Whether to enable or disable the DNS offloading.
+ */
+void socket_offload_dns_enable(bool enable);
+
+/**
+ * @brief Check if DNS offloading is enabled.
+ *
+ * @retval true DNS offloaded API is registered and enabled.
+ * @retval false DNS offloading is disabled.
+ */
+#if defined(CONFIG_NET_SOCKETS_OFFLOAD)
+bool socket_offload_dns_is_enabled(void);
+#else
+static inline bool socket_offload_dns_is_enabled(void)
+{
+	return false;
+}
+#endif /* defined(CONFIG_NET_SOCKETS_OFFLOAD) */
+
+
 /** @cond INTERNAL_HIDDEN */
 
 int socket_offload_getaddrinfo(const char *node, const char *service,

--- a/subsys/net/lib/sockets/getaddrinfo.c
+++ b/subsys/net/lib/sockets/getaddrinfo.c
@@ -433,7 +433,7 @@ int zsock_getaddrinfo(const char *host, const char *service,
 		      const struct zsock_addrinfo *hints,
 		      struct zsock_addrinfo **res)
 {
-	if (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD)) {
+	if (socket_offload_dns_is_enabled()) {
 		return socket_offload_getaddrinfo(host, service, hints, res);
 	}
 
@@ -471,7 +471,7 @@ int zsock_getaddrinfo(const char *host, const char *service,
 
 void zsock_freeaddrinfo(struct zsock_addrinfo *ai)
 {
-	if (IS_ENABLED(CONFIG_NET_SOCKETS_OFFLOAD)) {
+	if (socket_offload_dns_is_enabled()) {
 		socket_offload_freeaddrinfo(ai);
 		return;
 	}

--- a/subsys/net/lib/sockets/socket_offload.c
+++ b/subsys/net/lib/sockets/socket_offload.c
@@ -12,7 +12,8 @@ LOG_MODULE_REGISTER(net_socket_offload, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 #include "sockets_internal.h"
 
-const struct socket_dns_offload *dns_offload;
+static const struct socket_dns_offload *dns_offload;
+static bool dns_offload_enabled;
 
 void socket_offload_dns_register(const struct socket_dns_offload *ops)
 {
@@ -20,6 +21,33 @@ void socket_offload_dns_register(const struct socket_dns_offload *ops)
 	__ASSERT_NO_MSG(dns_offload == NULL);
 
 	dns_offload = ops;
+
+	socket_offload_dns_enable(true);
+}
+
+int socket_offload_dns_deregister(const struct socket_dns_offload *ops)
+{
+	__ASSERT_NO_MSG(ops != NULL);
+
+	if (dns_offload != ops) {
+		return -EINVAL;
+	}
+
+	dns_offload = NULL;
+
+	socket_offload_dns_enable(false);
+
+	return 0;
+}
+
+void socket_offload_dns_enable(bool enable)
+{
+	dns_offload_enabled = enable;
+}
+
+bool socket_offload_dns_is_enabled(void)
+{
+	return (dns_offload != NULL) && dns_offload_enabled;
 }
 
 int socket_offload_getaddrinfo(const char *node, const char *service,


### PR DESCRIPTION
A proposal for an API which allows to enable/disable DNS offloading from the application at runtime.