### PR TITLE
samples: boards: st: blink with low power mode management in DEBUG

### DIFF
--- a/samples/boards/st/power_mgmt/blinky/README.rst
+++ b/samples/boards/st/power_mgmt/blinky/README.rst
@@ -40,6 +40,15 @@ After flashing, the LED starts to blink with a fixed period (SLEEP_TIME_MS).
 When LPTIM input clock has a prescaler, longer perdiod (up to 64 seconds)
 of low power can be tested.
 
+.. warning::
+   Debugging this sample may require enabling :kconfig:option:`CONFIG_DEBUG` ``=y``.
+   That will enable the :kconfig:option:`CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP`
+   and prevent the system to go to low power mode.
+   When enabled, entry in low-power modes will not disable power in the power domains
+   that should be powered off, ensuring that the debug logic remains always
+   available. However, low-power modes will no longer reduce the system's
+   power consumption in this configuration, which is the opposite of what
+   this sample is attempting to demonstrate.
 
 PM configurations
 *****************

--- a/samples/boards/st/power_mgmt/blinky/prj.conf
+++ b/samples/boards/st/power_mgmt/blinky/prj.conf
@@ -4,3 +4,7 @@ CONFIG_PM_DEVICE_RUNTIME=y
 CONFIG_PM_DEVICE_SYSTEM_MANAGED=y
 CONFIG_ASSERT=y
 CONFIG_GPIO=y
+
+# un-comment to allow debugging while in low-power mode
+# (inhibits reduced power consumption from being observed)
+#CONFIG_DEBUG=y


### PR DESCRIPTION
Add a precision about the CONFIG_DEBUG :
When CONFIG_DEBUG is set, the system will not enter the low power mode The DEBUG is possible but with higher power consumption of the target.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/91112