### PR TITLE
drivers: pinctrl: eos_s3: fix logical OR in pinctrl_eos_s3_configure_pin

### DIFF
--- a/drivers/pinctrl/pinctrl_eos_s3.c
+++ b/drivers/pinctrl/pinctrl_eos_s3.c
@@ -103,7 +103,7 @@ static int pinctrl_eos_s3_configure_pin(const pinctrl_soc_pin_t *pin)
 	WRITE_BIT(reg_value, PAD_PULL_DOWN_BIT, 0);
 	if (pin->high_impedance) {
 		WRITE_BIT(reg_value, PAD_PULL_UP_BIT, 0);
-	} else if (pin->pull_up | pin->pull_down) {
+	} else if (pin->pull_up || pin->pull_down) {
 		WRITE_BIT(reg_value, PAD_PULL_UP_BIT, pin->pull_up);
 		WRITE_BIT(reg_value, PAD_PULL_DOWN_BIT, pin->pull_down);
 	}


### PR DESCRIPTION
Fix incorrect use of bitwise OR operator when checking pull-up and pull-down resistor configuration.