### PR TITLE
west.yml: MCUboot synchronization from v3.7-branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -327,7 +327,7 @@ manifest:
       groups:
         - crypto
     - name: trusted-firmware-m
-      revision: 78854fffd4f57d91547dc3e15370d786ead01477
+      revision: cc9b6cc238a47c588ecca824fec6fd210331c015
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee

--- a/west.yml
+++ b/west.yml
@@ -287,7 +287,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 58538ddfe21843edb39d7e7502812e61696e55c4
+      revision: 7a29b5a6a10f9179cac3935645c2a1356dafb2b6
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  18d9df1f76f22bf538bdd7d2cd9e4198c91568c0

Brings following Zephyr relevant fixes:

  - 18d9df1f bootutil: Fix crash when bootutil_sha_init() is called in loop
  - c2f2f90d boot: bootutil: Only update the security counter for confirmed images
  - 5a7ee345 boot: bootutil: Fix max image size computation for swap-move/swap-offset
  - 116925f7 boot/zephyr/main: fix placement of pointer to arm vector
  - b4cff578 boot: bootutil: swap_scratch: Fix issue with bricking device
  - 480464d2 boot: bootutil: Refactor erase functionality to fix watchdog feeding
  - cc38cc27 boot: Use boot erase function instead of flash erase function
  - 33453828 boot: bootutil: Move erase function location
  - bb148939 boot: zephyr: flash_map: Fix missing include
  - 51620768 boot: boot_serial: Fix issue with CBOR and setting image state
  - a277cf03 zephyr: Fix trailer size computation for swap-scratch
  - ac0ac75e zephyr: Fix TLV area was included in trailer size when rounding up
  - 25922090 boot: bootutil: swap_move: Fix maximum application size
  - bf494562 boot: bootutil: loader: Add include for flash function

Fixes #91360