### PR TITLE
drivers: pinctrl: wch: remove useless operations

### DIFF
--- a/drivers/pinctrl/pinctrl_wch_00x_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_00x_afio.c
@@ -46,14 +46,11 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		regs->CFGLR = (regs->CFGLR & ~(0x0F << (pin * 4))) | (cfg << (pin * 4));
 
 		if (pins->output_high) {
-			regs->OUTDR |= BIT(pin);
-			regs->BSHR |= BIT(pin);
+			regs->BSHR = BIT(pin);
 		} else if (pins->output_low) {
-			regs->OUTDR |= BIT(pin);
 			/* Reset the pin. */
-			regs->BSHR |= BIT(pin + 16);
+			regs->BCR = BIT(pin);
 		} else {
-			regs->OUTDR &= ~(1 << pin);
 			if (pins->bias_pull_up) {
 				regs->BSHR = BIT(pin);
 			}

--- a/drivers/pinctrl/pinctrl_wch_20x_30x_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_20x_30x_afio.c
@@ -55,14 +55,11 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 				      (cfg << ((pin - 8) * 4));
 		}
 		if (pins->output_high) {
-			regs->OUTDR |= BIT(pin);
-			regs->BSHR |= BIT(pin);
+			regs->BSHR = BIT(pin);
 		} else if (pins->output_low) {
-			regs->OUTDR |= BIT(pin);
 			/* Reset the pin. */
-			regs->BSHR |= BIT(pin + 16);
+			regs->BCR = BIT(pin);
 		} else {
-			regs->OUTDR &= ~BIT(pin);
 			if (pins->bias_pull_up) {
 				regs->BSHR = BIT(pin);
 			}

--- a/drivers/pinctrl/pinctrl_wch_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_afio.c
@@ -45,14 +45,11 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 		regs->CFGLR = (regs->CFGLR & ~(0x0F << (pin * 4))) | (cfg << (pin * 4));
 
 		if (pins->output_high) {
-			regs->OUTDR |= BIT(pin);
-			regs->BSHR |= BIT(pin);
+			regs->BSHR = BIT(pin);
 		} else if (pins->output_low) {
-			regs->OUTDR |= BIT(pin);
 			/* Reset the pin. */
-			regs->BSHR |= BIT(pin + 16);
+			regs->BCR = BIT(pin);
 		} else {
-			regs->OUTDR &= ~(1 << pin);
 			if (pins->bias_pull_up) {
 				regs->BSHR = BIT(pin);
 			}


### PR DESCRIPTION
Remove redundant register updates in pinctrl_configure_pins, and replace the improper (and inefficient) use of bitwise OR assignment (|=) with direct assignments when writing to the write-only BSHR registers.

Hopefully I didn't miss something and there was no particular reason for all the redundant writes to OUTDR :)
This change saves 68 bytes of flash in pin control driver.