### PR TITLE
soc: mediatek: fix typo in macro name

### DIFF
--- a/soc/mediatek/mt8xxx/mbox.c
+++ b/soc/mediatek/mt8xxx/mbox.c
@@ -40,7 +40,7 @@
  */
 
 struct mtk_mbox {
-#ifdef SOC_SERIES_MT8195
+#ifdef CONFIG_SOC_SERIES_MT8195
 	uint32_t in_cmd;
 	uint32_t in_cmd_clr;
 	uint32_t in_msg[5];


### PR DESCRIPTION
s/SOC_SERIES_MT8195/CONFIG_SOC_SERIES_MT8195/

fwiw it's not quite clear whether only the `#else` should be kept instead - I'll let @andyross comment