### PR TITLE
drivers: watchdog: Add enableWait setting for wdt_mcux_imx_wdog

### DIFF
--- a/drivers/watchdog/wdt_mcux_imx_wdog.c
+++ b/drivers/watchdog/wdt_mcux_imx_wdog.c
@@ -41,14 +41,27 @@ static int mcux_wdog_setup(const struct device *dev, uint8_t options)
 		return -EINVAL;
 	}
 
+	/*
+	 * WDT_OPT_PAUSE_IN_SLEEP is a bit tricky because depending on
+	 * the frequency the platform is running at and the wdog timeout
+	 * value relative to the sleep time, the system may wakeup enough
+	 * to keep system time accurate enough on timer rollovers. During
+	 * this time, the wdog will start ticking again so you can
+	 * possibly still have the wdog expire.
+	 *
+	 */
+	data->wdog_config.workMode.enableWait =
+		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
+
 	data->wdog_config.workMode.enableStop =
 		(options & WDT_OPT_PAUSE_IN_SLEEP) == 0U;
 
 	data->wdog_config.workMode.enableDebug =
 		(options & WDT_OPT_PAUSE_HALTED_BY_DBG) == 0U;
 
+	LOG_DBG("Setup the watchdog: options: %d", options);
+
 	WDOG_Init(base, &data->wdog_config);
-	LOG_DBG("Setup the watchdog");
 
 	return 0;
 }


### PR DESCRIPTION
When WDT_OPT_PAUSE_IN_SLEEP option is passed in set enableWait flag in addition to the enableStop .

Fixes #86437