### PR TITLE
drivers: video: add more luma-only 0-padded formats

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1242,6 +1242,46 @@ int64_t video_get_csi_link_freq(const struct device *dev, uint8_t bpp, uint8_t l
 #define VIDEO_PIX_FMT_Y14P VIDEO_FOURCC('Y', '1', '4', 'P')
 
 /**
+ * Little endian, with the 6 most significant bits set to Zero.
+ * @code{.unparsed}
+ *   0                   1                   2                   3
+ * | yyyyyyyy 000000Yy | yyyyyyyy 000000Yy | yyyyyyyy 000000Yy | yyyyyyyy 000000Yy | ...
+ * | yyyyyyyy 000000Yy | yyyyyyyy 000000Yy | yyyyyyyy 000000Yy | yyyyyyyy 000000Yy | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_Y10 VIDEO_FOURCC('Y', '1', '0', ' ')
+
+/**
+ * Little endian, with the 4 most significant bits set to Zero.
+ * @code{.unparsed}
+ *   0                   1                   2                   3
+ * | yyyyyyyy 0000Yyyy | yyyyyyyy 0000Yyyy | yyyyyyyy 0000Yyyy | yyyyyyyy 0000Yyyy | ...
+ * | yyyyyyyy 0000Yyyy | yyyyyyyy 0000Yyyy | yyyyyyyy 0000Yyyy | yyyyyyyy 0000Yyyy | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_Y12 VIDEO_FOURCC('Y', '1', '2', ' ')
+
+/**
+ * Little endian, with the 2 most significant bits set to Zero.
+ * @code{.unparsed}
+ *   0                   1                   2                   3
+ * | yyyyyyyy 00Yyyyyy | yyyyyyyy 00Yyyyyy | yyyyyyyy 00Yyyyyy | yyyyyyyy 00Yyyyyy | ...
+ * | yyyyyyyy 00Yyyyyy | yyyyyyyy 00Yyyyyy | yyyyyyyy 00Yyyyyy | yyyyyyyy 00Yyyyyy | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_Y14 VIDEO_FOURCC('Y', '1', '4', ' ')
+
+/**
+ * Little endian.
+ * @code{.unparsed}
+ *   0                   1                   2                   3
+ * | yyyyyyyy Yyyyyyyy | yyyyyyyy Yyyyyyyy | yyyyyyyy Yyyyyyyy | yyyyyyyy Yyyyyyyy | ...
+ * | yyyyyyyy Yyyyyyyy | yyyyyyyy Yyyyyyyy | yyyyyyyy Yyyyyyyy | yyyyyyyy Yyyyyyyy | ...
+ * @endcode
+ */
+#define VIDEO_PIX_FMT_Y16 VIDEO_FOURCC('Y', '1', '6', ' ')
+
+/**
  * @}
  */
 
@@ -1456,6 +1496,10 @@ static inline unsigned int video_bits_per_pixel(uint32_t pixfmt)
 	case VIDEO_PIX_FMT_SGBRG16:
 	case VIDEO_PIX_FMT_SGRBG16:
 	case VIDEO_PIX_FMT_SRGGB16:
+	case VIDEO_PIX_FMT_Y10:
+	case VIDEO_PIX_FMT_Y12:
+	case VIDEO_PIX_FMT_Y14:
+	case VIDEO_PIX_FMT_Y16:
 		return 16;
 	case VIDEO_PIX_FMT_BGR24:
 	case VIDEO_PIX_FMT_RGB24:


### PR DESCRIPTION
Add several more luma-only formats also known as grayscale, of variable bit depth, 0-padded to fit 16-bits per pixel: Y10, Y12, Y14, Y16.

These are featured output formats for UVC, which do not require a particular "quirk".
These are equivalent to the bayer formats `SBGGR10, SGBRG10, SGRBG10, SRGGB10, SBGGR12, SGBRG12, SGRBG12, SRGGB12, SBGGR14, SGBRG14, SGRBG14, SRGGB14, SBGGR16, SGBRG16, SGRBG16, SRGGB16` the non-packed versions.