### PR TITLE
drivers: interrupt-controller: vim: fix off-by-one comparisons

### DIFF
--- a/drivers/interrupt_controller/intc_vim.c
+++ b/drivers/interrupt_controller/intc_vim.c
@@ -71,7 +71,7 @@ void z_vim_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
 {
 	uint32_t irq_group_num, irq_bit_num, regval;
 
-	if (irq > CONFIG_NUM_IRQS || prio > VIM_PRI_INT_MAX ||
+	if (irq >= CONFIG_NUM_IRQS || prio > VIM_PRI_INT_MAX ||
 	    (flags != IRQ_TYPE_EDGE && flags != IRQ_TYPE_LEVEL)) {
 		LOG_ERR("%s: Invalid argument irq = %u prio = %u flags = %u\n",
 			__func__, irq, prio, flags);
@@ -98,7 +98,7 @@ void z_vim_irq_enable(unsigned int irq)
 {
 	uint32_t irq_group_num, irq_bit_num;
 
-	if (irq > CONFIG_NUM_IRQS) {
+	if (irq >= CONFIG_NUM_IRQS) {
 		LOG_ERR("%s: Invalid irq number = %u\n", __func__, irq);
 		return;
 	}
@@ -113,7 +113,7 @@ void z_vim_irq_disable(unsigned int irq)
 {
 	uint32_t irq_group_num, irq_bit_num;
 
-	if (irq > CONFIG_NUM_IRQS) {
+	if (irq >= CONFIG_NUM_IRQS) {
 		LOG_ERR("%s: Invalid irq number = %u\n", __func__, irq);
 		return;
 	}
@@ -128,7 +128,7 @@ int z_vim_irq_is_enabled(unsigned int irq)
 {
 	uint32_t irq_group_num, irq_bit_num, regval;
 
-	if (irq > CONFIG_NUM_IRQS) {
+	if (irq >= CONFIG_NUM_IRQS) {
 		LOG_ERR("%s: Invalid irq number = %u\n", __func__, irq);
 		return -EINVAL;
 	}
@@ -145,7 +145,7 @@ void z_vim_arm_enter_irq(int irq)
 {
 	uint32_t irq_group_num, irq_bit_num;
 
-	if (irq > CONFIG_NUM_IRQS) {
+	if (irq >= CONFIG_NUM_IRQS) {
 		LOG_ERR("%s: Invalid irq number = %u\n", __func__, irq);
 		return;
 	}


### PR DESCRIPTION
IRQ numbers range from 0 to CONFIG_NUM_IRQS - 1