### PR TITLE
boards: frdm_mcxa166, frdm_mcxa346, frdm_mcxa366: add lpdac support

### DIFF
--- a/boards/nxp/frdm_mcxaxx6/board.c
+++ b/boards/nxp/frdm_mcxaxx6/board.c
@@ -158,6 +158,13 @@ void board_early_init_hook(void)
 	CLOCK_SetClockDiv(kCLOCK_DivWWDT0, 1u);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dac0))
+	SPC_EnableActiveModeAnalogModules(SPC0, kSPC_controlDac0);
+	CLOCK_SetClockDiv(kCLOCK_DivDAC0, 1u);
+	CLOCK_AttachClk(kFRO_LF_DIV_to_DAC0);
+	CLOCK_EnableClock(kCLOCK_GateDAC0);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ctimer0))
 	CLOCK_SetClockDiv(kCLOCK_DivCTIMER0, 1u);
 	CLOCK_AttachClk(kFRO_LF_DIV_to_CTIMER0);

--- a/boards/nxp/frdm_mcxaxx6/board_common.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/board_common.dtsi
@@ -236,6 +236,12 @@
 	status = "okay";
 };
 
+&dac0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_dac0>;
+	pinctrl-names = "default";
+};
+
 &lptmr0 {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266-pinctrl.dtsi
@@ -44,6 +44,14 @@
 		};
 	};
 
+	pinmux_dac0: pinmux_dac0 {
+		group0 {
+			pinmux = <DAC0_OUT_P2_2>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
+
 	pinmux_lpadc0: pinmux_lpadc0 {
 		group0 {
 			pinmux = <ADC0_A7_P2_7>;

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa266.yaml
@@ -23,6 +23,7 @@ supported:
   - watchdog
   - counter
   - dma
+  - dac
   - i3c
   - entropy
   - can

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa346-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa346-pinctrl.dtsi
@@ -26,6 +26,14 @@
 		};
 	};
 
+	pinmux_dac0: pinmux_dac0 {
+		group0 {
+			pinmux = <DAC0_OUT_P2_2>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
+
 	pinmux_lpadc0: pinmux_lpadc0 {
 		group0 {
 			pinmux = <ADC0_A7_P2_7>;

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa346.yaml
@@ -23,6 +23,7 @@ supported:
   - watchdog
   - counter
   - dma
+  - dac
   - opamp
   - can
   - arduino_gpio

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366-pinctrl.dtsi
@@ -44,6 +44,14 @@
 		};
 	};
 
+	pinmux_dac0: pinmux_dac0 {
+		group0 {
+			pinmux = <DAC0_OUT_P2_2>;
+			drive-strength = "low";
+			slew-rate = "fast";
+		};
+	};
+
 	pinmux_lpadc0: pinmux_lpadc0 {
 		group0 {
 			pinmux = <ADC0_A7_P2_7>;

--- a/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
+++ b/boards/nxp/frdm_mcxaxx6/frdm_mcxa366.yaml
@@ -23,6 +23,7 @@ supported:
   - watchdog
   - counter
   - dma
+  - dac
   - i3c
   - opamp
   - entropy

--- a/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
+++ b/dts/arm/nxp/mcx/nxp_mcxaxx6_common.dtsi
@@ -290,6 +290,15 @@
 			prescale = <0>;
 		};
 
+		dac0: dac@400b4000 {
+			compatible = "nxp,lpdac";
+			reg = <0x400b4000 0x1000>;
+			interrupts = <67 0>;
+			status = "disabled";
+			voltage-reference = <0>;
+			#io-channel-cells = <1>;
+		};
+
 		fmu: flash-controller@40095000 {
 			compatible = "nxp,msf1";
 			reg = <0x40095000 0x1000>;

--- a/samples/drivers/dac/README.rst
+++ b/samples/drivers/dac/README.rst
@@ -241,6 +241,54 @@ follows:
 
 Connect J10 pin 1-2., the DAC output is available on TP9.
 
+Building and Running for NXP FRDM-MCXA266
+============================================
+The sample can be built and executed for the :zephyr:board:`frdm_mcxa266` as
+follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: frdm_mcxa266
+   :goals: build flash
+   :gen-args: -DCONFIG_DAC_SAMPLE_RUN=y
+   :compact:
+
+DAC output is available on connector J1 pin 4.
+Because the DAC output pin conflicts with LPUART2 TX, the overlay switches the
+console to LPUART3. The J5 Pin 3 and 4 are LPUART3 Rx and Tx pins.
+
+Building and Running for NXP FRDM-MCXA346
+============================================
+The sample can be built and executed for the :zephyr:board:`frdm_mcxa346` as
+follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: frdm_mcxa346
+   :goals: build flash
+   :gen-args: -DCONFIG_DAC_SAMPLE_RUN=y
+   :compact:
+
+DAC output is available on connector J1 pin 4.
+Because the DAC output pin conflicts with LPUART2 TX, the overlay switches the
+console to LPUART3. The J5 Pin 3 and 4 are LPUART3 Rx and Tx pins.
+
+Building and Running for NXP FRDM-MCXA366
+============================================
+The sample can be built and executed for the :zephyr:board:`frdm_mcxa366` as
+follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/dac
+   :board: frdm_mcxa366
+   :goals: build flash
+   :gen-args: -DCONFIG_DAC_SAMPLE_RUN=y
+   :compact:
+
+DAC output is available on connector J1 pin 4.
+Because the DAC output pin conflicts with LPUART2 TX, the overlay switches the
+console to LPUART3. The J5 Pin 3 and 4 are LPUART3 Rx and Tx pins.
+
 Sample output
 =============
 

--- a/samples/drivers/dac/boards/frdm_mcxa266.overlay
+++ b/samples/drivers/dac/boards/frdm_mcxa266.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &lpuart3;
+		zephyr,shell-uart = &lpuart3;
+	};
+
+	/*
+	 * DAC0 output signal port is J1-4(P2_2).
+	 */
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};
+
+&lpuart2 {
+	status = "disabled";
+};
+
+&lpuart3 {
+	status = "okay";
+};

--- a/samples/drivers/dac/boards/frdm_mcxa346.overlay
+++ b/samples/drivers/dac/boards/frdm_mcxa346.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &lpuart3;
+		zephyr,shell-uart = &lpuart3;
+	};
+
+	/*
+	 * DAC0 output signal port is J1-4(P2_2).
+	 */
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};
+
+&lpuart2 {
+	status = "disabled";
+};
+
+&lpuart3 {
+	status = "okay";
+};

--- a/samples/drivers/dac/boards/frdm_mcxa366.overlay
+++ b/samples/drivers/dac/boards/frdm_mcxa366.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &lpuart3;
+		zephyr,shell-uart = &lpuart3;
+	};
+
+	/*
+	 * DAC0 output signal port is J1-4(P2_2).
+	 */
+	zephyr,user {
+		dac = <&dac0>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};
+
+&lpuart2 {
+	status = "disabled";
+};
+
+&lpuart3 {
+	status = "okay";
+};

--- a/tests/drivers/dac/dac_api/boards/frdm_mcxa266.overlay
+++ b/tests/drivers/dac/dac_api/boards/frdm_mcxa266.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &lpuart3;
+		zephyr,shell-uart = &lpuart3;
+	};
+};
+
+&lpuart2 {
+	status = "disabled";
+};
+
+&lpuart3 {
+	status = "okay";
+};

--- a/tests/drivers/dac/dac_api/boards/frdm_mcxa346.overlay
+++ b/tests/drivers/dac/dac_api/boards/frdm_mcxa346.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &lpuart3;
+		zephyr,shell-uart = &lpuart3;
+	};
+};
+
+&lpuart2 {
+	status = "disabled";
+};
+
+&lpuart3 {
+	status = "okay";
+};

--- a/tests/drivers/dac/dac_api/boards/frdm_mcxa366.overlay
+++ b/tests/drivers/dac/dac_api/boards/frdm_mcxa366.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &lpuart3;
+		zephyr,shell-uart = &lpuart3;
+	};
+};
+
+&lpuart2 {
+	status = "disabled";
+};
+
+&lpuart3 {
+	status = "okay";
+};

--- a/tests/drivers/dac/dac_api/testcase.yaml
+++ b/tests/drivers/dac/dac_api/testcase.yaml
@@ -62,6 +62,16 @@ tests:
       - bl5340_dvk/nrf5340/cpuapp
       - lp_mspm0g3507
       - lp_mspm0g3519
+  drivers.dac.api.dac0_channel0_mcxaxx6:
+    extra_args:
+      - EXTRA_DTC_OVERLAY_FILE="dac0-channel0.overlay"
+    platform_allow:
+      - frdm_mcxa266
+      - frdm_mcxa346
+      - frdm_mcxa366
+    harness: ztest
+    harness_config:
+      fixture: dac_fixture
   drivers.dac.api.dac1_channel1:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="dac1-channel1.overlay"


### PR DESCRIPTION
1. enable nxp,lpdac
2. verified samples/drivers/dac
3. dac_out pin conflict with lpuart2 tx use lpuart3 in the samples/drivers/dac