### PR TITLE
boards: frdm_mcxa153,frdm_mcxa156: add hwinfo support

### DIFF
--- a/drivers/hwinfo/hwinfo_mcux_mcx_cmc.c
+++ b/drivers/hwinfo/hwinfo_mcux_mcx_cmc.c
@@ -27,6 +27,12 @@ LOG_MODULE_REGISTER(hwinfo_cmc, CONFIG_HWINFO_LOG_LEVEL);
 #define CMC_RESET_MASK_WATCHDOG CMC_SRS_WWDT0_MASK
 #endif
 
+#ifdef CMC_SRS_CDOG1_MASK
+#define CMC_RESET_MASK_CDOG (CMC_SRS_CDOG0_MASK | CMC_SRS_CDOG1_MASK)
+#else
+#define CMC_RESET_MASK_CDOG CMC_SRS_CDOG0_MASK
+#endif
+
 /**
  * @brief Translate from CMC reset source mask to Zephyr hwinfo sources mask.
  *
@@ -77,7 +83,7 @@ static uint32_t hwinfo_mcux_cmc_xlate_reset_sources(uint32_t sources)
 		mask |= RESET_CPU_LOCKUP;
 	}
 
-	if (sources & (CMC_SRS_CDOG0_MASK | CMC_SRS_CDOG1_MASK)) {
+	if (sources & CMC_RESET_MASK_CDOG) {
 		mask |= RESET_WATCHDOG;
 	}
 

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -132,6 +132,11 @@
 				erase-block-size = <8192>;
 				write-block-size = <128>;
 			};
+
+			uuid: uuid@1100800 {
+				compatible = "nxp,lpc-uid";
+				reg = <0x1100800 0x10>;
+			};
 		};
 
 		gpio0: gpio@40102000 {

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -163,6 +163,11 @@
 				erase-block-size = <8192>;
 				write-block-size = <128>;
 			};
+
+			uuid: uuid@1100800 {
+				compatible = "nxp,lpc-uid";
+				reg = <0x1100800 0x10>;
+			};
 		};
 
 		ctimer0: ctimer@40004000 {

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -13,12 +13,14 @@ config SOC_SERIES_MCXA
 config SOC_MCXA153
 	select CPU_CORTEX_M33
 	select HAS_MCUX_CACHE
+	select HAS_MCUX_MCX_CMC
 
 config SOC_MCXA156
 	select CPU_CORTEX_M33
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
+	select HAS_MCUX_MCX_CMC
 
 config SOC_MCXA166
 	select CPU_CORTEX_M33


### PR DESCRIPTION
1. enable hwinfo support
   - device_id_get
   - get_reset_cause
   - get_supported_reset_cause
   - clear_reset_cause
2. verified tests/drivers/hwinfo