### PR TITLE
drivers: i2c: stm32: fix some macro name

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -197,9 +197,9 @@ static void i2c_stm32_irq_config_func_##index(const struct device *dev)				\
 }
 
 #else /* CONFIG_I2C_STM32_INTERRUPT */
-#define STM32_I2C_IRQ_HANDLER_DECL(index)
-#define STM32_I2C_IRQ_HANDLER_FUNCTION(index)
-#define STM32_I2C_IRQ_HANDLER(index)
+#define I2C_STM32_IRQ_HANDLER_DECL(index)
+#define I2C_STM32_IRQ_HANDLER_FUNCTION(index)
+#define I2C_STM32_IRQ_HANDLER(index)
 #endif /* CONFIG_I2C_STM32_INTERRUPT */
 
 #endif	/* ZEPHYR_DRIVERS_I2C_I2C_LL_STM32_H_ */

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -842,7 +842,7 @@ static inline int msg_done(const struct device *dev,
 			return -EIO;
 		}
 		if ((k_uptime_get() - start_time) >
-		    STM32_I2C_TRANSFER_TIMEOUT_MSEC) {
+		    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 			return -ETIMEDOUT;
 		}
 	}
@@ -851,7 +851,7 @@ static inline int msg_done(const struct device *dev,
 		LL_I2C_GenerateStopCondition(i2c);
 		while (!LL_I2C_IsActiveFlag_STOP(i2c)) {
 			if ((k_uptime_get() - start_time) >
-			    STM32_I2C_TRANSFER_TIMEOUT_MSEC) {
+			    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -886,7 +886,7 @@ static int i2c_stm32_msg_write(const struct device *dev, struct i2c_msg *msg,
 			}
 
 			if ((k_uptime_get() - start_time) >
-			    STM32_I2C_TRANSFER_TIMEOUT_MSEC) {
+			    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 				return -ETIMEDOUT;
 			}
 		}
@@ -917,7 +917,7 @@ static int i2c_stm32_msg_read(const struct device *dev, struct i2c_msg *msg,
 				return -EIO;
 			}
 			if ((k_uptime_get() - start_time) >
-			    STM32_I2C_TRANSFER_TIMEOUT_MSEC) {
+			    I2C_STM32_TRANSFER_TIMEOUT_MSEC) {
 				return -ETIMEDOUT;
 			}
 		}


### PR DESCRIPTION
Some macros haven't been properly renamed in previous commits. Fixes the wrong names that caused compilation errors.