### PR TITLE
sys: timeutil: Fix warning in timespec_is_valid

### DIFF
--- a/include/zephyr/sys/timeutil.h
+++ b/include/zephyr/sys/timeutil.h
@@ -338,7 +338,7 @@ static inline bool timespec_is_valid(const struct timespec *ts)
 {
 	__ASSERT_NO_MSG(ts != NULL);
 
-	return (ts->tv_nsec >= 0) && (ts->tv_nsec < NSEC_PER_SEC);
+	return (ts->tv_nsec >= 0) && (ts->tv_nsec < (long)NSEC_PER_SEC);
 }
 
 /**


### PR DESCRIPTION
Cast `NSEC_PER_SEC` to long to avoid the warning:

```
zephyr/include/zephyr/sys/timeutil.h:341:51: warning: comparison of integer expressions of different signedness: ‘long int’ and ‘unsigned int’ [-Wsign-compare]
  341 |         return (ts->tv_nsec >= 0) && (ts->tv_nsec < NSEC_PER_SEC);

```