### PR TITLE
boards: st: stm32h573i_dk: Add Arduino serial node

### DIFF
--- a/boards/st/stm32h573i_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h573i_dk/arduino_r3_connector.dtsi
@@ -37,3 +37,4 @@
 
 arduino_spi: &spi2 {};
 arduino_i2c: &i2c1 {};
+arduino_serial: &usart3 {};

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -233,6 +233,13 @@
 	status = "okay";
 };
 
+&usart3 {
+	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
 &timers2 {
 	st,prescaler = <10000>;
 	status = "okay";

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.yaml
@@ -8,6 +8,9 @@ ram: 640
 flash: 2048
 supported:
   - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - gpio
   - uart
   - watchdog


### PR DESCRIPTION
Specify the Arduino serial node for a Discovery kit with STM32H573II MCU.