### PR TITLE
doc: fix file path in sample "perf"

### DIFF
--- a/samples/subsys/profiling/perf/README.rst
+++ b/samples/subsys/profiling/perf/README.rst
@@ -62,7 +62,7 @@ Usage example
 
   .. code-block:: shell
 
-     python scripts/perf/stackcollapse.py perf_buf build/zephyr/zephyr.elf | <flamegraph_dir_path>/flamegraph.pl > graph.svg
+     python scripts/profiling/stackcollapse.py perf_buf build/zephyr/zephyr.elf | <flamegraph_dir_path>/flamegraph.pl > graph.svg
 
 Graph example
 =============


### PR DESCRIPTION
On the documentation of the sample "perf" the path for the script "stackcollapse" is incorrect.
Fix the path