### PR TITLE
usb: device_next: fix the null pointer dereference on FS devices

### DIFF
--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -683,12 +683,6 @@ static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
 	struct usb_device_qualifier_descriptor q_desc = {
 		.bLength = sizeof(struct usb_device_qualifier_descriptor),
 		.bDescriptorType = USB_DESC_DEVICE_QUALIFIER,
-		.bcdUSB = d_desc->bcdUSB,
-		.bDeviceClass = d_desc->bDeviceClass,
-		.bDeviceSubClass = d_desc->bDeviceSubClass,
-		.bDeviceProtocol = d_desc->bDeviceProtocol,
-		.bMaxPacketSize0 = d_desc->bMaxPacketSize0,
-		.bNumConfigurations = d_desc->bNumConfigurations,
 		.bReserved = 0U,
 	};
 	size_t len;
@@ -702,6 +696,17 @@ static int sreq_get_dev_qualifier(struct usbd_context *const uds_ctx,
 		errno = -ENOTSUP;
 		return 0;
 	}
+
+	if (d_desc == NULL) {
+		return -EINVAL;
+	}
+
+	q_desc.bcdUSB = d_desc->bcdUSB;
+	q_desc.bDeviceClass = d_desc->bDeviceClass;
+	q_desc.bDeviceSubClass = d_desc->bDeviceSubClass;
+	q_desc.bDeviceProtocol = d_desc->bDeviceProtocol;
+	q_desc.bMaxPacketSize0 = d_desc->bMaxPacketSize0;
+	q_desc.bNumConfigurations = d_desc->bNumConfigurations;
 
 	LOG_DBG("Get Device Qualifier");
 	len = MIN(setup->wLength, net_buf_tailroom(buf));

--- a/subsys/usb/device_next/usbd_device.c
+++ b/subsys/usb/device_next/usbd_device.c
@@ -66,6 +66,11 @@ int usbd_device_set_bcd_usb(struct usbd_context *const uds_ctx,
 	}
 
 	desc = get_device_descriptor(uds_ctx, speed);
+	if (desc == NULL) {
+		ret = -EINVAL;
+		goto set_bcd_exit;
+	}
+
 	desc->bcdUSB = sys_cpu_to_le16(bcd);
 
 set_bcd_exit:
@@ -167,6 +172,11 @@ int usbd_device_set_code_triple(struct usbd_context *const uds_ctx,
 	}
 
 	desc = get_device_descriptor(uds_ctx, speed);
+	if (desc == NULL) {
+		ret = -EINVAL;
+		goto set_code_triple_exit;
+	}
+
 	desc->bDeviceClass = base_class;
 	desc->bDeviceSubClass = subclass;
 	desc->bDeviceProtocol = protocol;


### PR DESCRIPTION
With the commit fe3c001eeb8c ("usb: device_next: disable high-speed USB device descriptor if not used") there is no high-speed device descriptor by default.