### PR TITLE
modules: hostap: Fix DPP security mode show issue

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -415,6 +415,8 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 		return WIFI_SECURITY_TYPE_FT_SAE;
 	case WPA_KEY_MGMT_FT_IEEE8021X:
 		return WIFI_SECURITY_TYPE_FT_EAP;
+	case WPA_KEY_MGMT_DPP:
+		return WIFI_SECURITY_TYPE_DPP;
 	case WPA_KEY_MGMT_FT_IEEE8021X_SHA384:
 		return WIFI_SECURITY_TYPE_FT_EAP_SHA384;
 	case WPA_KEY_MGMT_SAE_EXT_KEY:


### PR DESCRIPTION
[Description]
After DUT connects to AP through DPP,
enter 'wifi status' to check connection status.
Security shows UNKNOWN.

[Analysis]
1. DUT supplicant will add a dpp network after receiving GAS response. Assign ssid->key_mgmt as WPA_KEY_MGMT_DPP.
2. Call wpas_key_mgmt_to_zephyr() to convert hostapd/supplicant security type to zephry security type. In this function, convert WPA_KEY_MGMT_DPP to WIFI_SECURITY_TYPE_UNKNOWN.

[Fix]
1. Add code to convert WPA_KEY_MGMT_DPP to WIFI_SECURITY_TYPE_DPP.