### PR TITLE
drivers: spi: spi_pl022: disable the SSP before reconfiguring

### DIFF
--- a/drivers/spi/spi_pl022.c
+++ b/drivers/spi/spi_pl022.c
@@ -406,6 +406,8 @@ static int spi_pl022_configure(const struct device *dev,
 	cr1 |= SSP_CR1_MASK_SSE; /* Always enable SPI */
 	cr1 |= (op & SPI_MODE_LOOP) ? SSP_CR1_MASK_LBM : 0;
 
+	/* Disable the SSP before it is reconfigured */
+	SSP_WRITE_REG(SSP_CR1(cfg->reg), 0);
 	SSP_WRITE_REG(SSP_CPSR(cfg->reg), prescale);
 	SSP_WRITE_REG(SSP_CR0(cfg->reg), cr0);
 	SSP_WRITE_REG(SSP_CR1(cfg->reg), cr1);


### PR DESCRIPTION
When re-configuring the SSP, some changes do not immediately take effect. In particular changes to the clock polarity are not applied. Disabling and re-enabling the SSP forces the new configuration to take effect immediately.

I have an RP2040 device connected to 2 SPI devices, one of the devices requires the clock to idle high, so `SPI_MODE_CPOL` is set. A normal transaction looks like this:

![Screenshot From 2025-06-09 16-10-33](https://github.com/user-attachments/assets/1a893494-c564-469c-8110-60228ed4be88)

However, the first transaction after a SPI reconfigure (due to communicating with the second device) looks like this:

![Screenshot From 2025-06-09 16-11-01](https://github.com/user-attachments/assets/1c1dc70d-3447-46d6-b62a-e31003f9ebb7)

The clock has not switched to idle high (although it is left high after the transaction completes).

By disabling the SSP while it is reconfigured, we force the changed configuration to be applied and the clock correctly switches to idle high:

![Screenshot From 2025-06-10 11-34-13](https://github.com/user-attachments/assets/d614bf6d-2569-48cd-becf-f5e73659dad6)
