### PR TITLE
drivers: ethernet: phy: add support to disable autoneg

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -198,6 +198,9 @@ Ethernet
   together with :c:func:`net_eth_get_phy` should be used instead to configure the link
   (:github:`90652`).
 
+* :c:func:`phy_configure_link` got a ``flags`` parameter. Set it to ``0`` to preserve the old
+  behavior (:github:`91354`).
+
 Enhanced Serial Peripheral Interface (eSPI)
 ===========================================
 

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -471,7 +471,7 @@ static int nxp_enet_phy_configure(const struct device *phy, uint8_t phy_mode)
 	}
 
 	/* Configure the PHY */
-	ret = phy_configure_link(phy, speeds);
+	ret = phy_configure_link(phy, speeds, 0);
 
 	if (ret == -ENOTSUP) {
 		phy_get_link_state(phy, &state);

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -529,8 +529,8 @@ static int xilinx_axienet_probe(const struct device *dev)
 				      XILINX_AXIENET_RECEIVER_CONFIGURATION_FLOW_CONTROL_EN_MASK);
 
 	/* at time of writing, hardware does not support half duplex */
-	err = phy_configure_link(config->phy, LINK_FULL_10BASE | LINK_FULL_100BASE |
-						      LINK_FULL_1000BASE);
+	err = phy_configure_link(config->phy,
+				 LINK_FULL_10BASE | LINK_FULL_100BASE | LINK_FULL_1000BASE, 0);
 	if (err) {
 		LOG_WRN("Could not configure PHY: %d", -err);
 	}

--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -348,18 +348,6 @@ static int phy_adin2111_get_link_state(const struct device *dev,
 	return 0;
 }
 
-static int phy_adin2111_cfg_link(const struct device *dev,
-				 enum phy_link_speed adv_speeds)
-{
-	ARG_UNUSED(dev);
-
-	if (!!(adv_speeds & LINK_FULL_10BASE)) {
-		return 0;
-	}
-
-	return -ENOTSUP;
-}
-
 static int phy_adin2111_reset(const struct device *dev)
 {
 	int ret;
@@ -624,7 +612,6 @@ static int phy_adin2111_link_cb_set(const struct device *dev, phy_callback_t cb,
 
 static DEVICE_API(ethphy, phy_adin2111_api) = {
 	.get_link = phy_adin2111_get_link_state,
-	.cfg_link = phy_adin2111_cfg_link,
 	.link_cb_set = phy_adin2111_link_cb_set,
 	.read = phy_adin2111_reg_read,
 	.write = phy_adin2111_reg_write,

--- a/drivers/ethernet/phy/phy_dm8806.c
+++ b/drivers/ethernet/phy/phy_dm8806.c
@@ -522,12 +522,15 @@ static int phy_dm8806_get_link_state(const struct device *dev, struct phy_link_s
 	return ret;
 }
 
-static int phy_dm8806_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds)
+static int phy_dm8806_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds,
+			       enum phy_cfg_link_flag flags)
 {
 	uint8_t ret;
 	uint16_t data;
 	uint16_t req_speed;
 	const struct phy_dm8806_config *cfg = dev->config;
+
+	ARG_UNUSED(flags);
 
 	req_speed = adv_speeds;
 	switch (req_speed) {
@@ -546,6 +549,10 @@ static int phy_dm8806_cfg_link(const struct device *dev, enum phy_link_speed adv
 	case LINK_FULL_100BASE:
 		req_speed = DM8806_MODE_100_BASET_FULL_DUPLEX;
 		break;
+
+	default:
+		LOG_ERR("Invalid speed %d for PHY (%d)", adv_speeds, cfg->phy_addr);
+		return -EINVAL;
 	}
 
 	/* Power down */

--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -23,6 +23,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
+#include "phy_mii.h"
+
 #define PHY_MC_KSZ8081_OMSO_REG			0x16
 #define PHY_MC_KSZ8081_OMSO_FACTORY_MODE_MASK	BIT(15)
 #define PHY_MC_KSZ8081_OMSO_NAND_TREE_MASK	BIT(5)
@@ -339,7 +341,6 @@ static int phy_mc_ksz8081_cfg_link(const struct device *dev,
 	struct mc_ksz8081_data *data = dev->data;
 	struct phy_link_state state = {};
 	int ret;
-	uint32_t anar;
 
 	/* Lock mutex */
 	ret = k_mutex_lock(&data->mutex, K_FOREVER);
@@ -357,39 +358,9 @@ static int phy_mc_ksz8081_cfg_link(const struct device *dev,
 		goto done;
 	}
 
-	/* Read ANAR register to write back */
-	ret = phy_mc_ksz8081_read(dev, MII_ANAR, &anar);
-	if (ret) {
-		LOG_ERR("Error reading phy (%d) advertising register", config->addr);
-		goto done;
-	}
-
-	/* Setup advertising register */
-	if (speeds & LINK_FULL_100BASE) {
-		anar |= MII_ADVERTISE_100_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_100_FULL;
-	}
-	if (speeds & LINK_HALF_100BASE) {
-		anar |= MII_ADVERTISE_100_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_100_HALF;
-	}
-	if (speeds & LINK_FULL_10BASE) {
-		anar |= MII_ADVERTISE_10_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_10_FULL;
-	}
-	if (speeds & LINK_HALF_10BASE) {
-		anar |= MII_ADVERTISE_10_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_10_HALF;
-	}
-
-	/* Write capabilities to advertising register */
-	ret = phy_mc_ksz8081_write(dev, MII_ANAR, anar);
-	if (ret) {
-		LOG_ERR("Error writing phy (%d) advertising register", config->addr);
+	ret = phy_mii_set_anar_reg(dev, speeds);
+	if ((ret < 0) && (ret != -EALREADY)) {
+		LOG_ERR("Error setting ANAR register for phy (%d)", config->addr);
 		goto done;
 	}
 

--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -334,13 +334,18 @@ done:
 	return ret;
 }
 
-static int phy_mc_ksz8081_cfg_link(const struct device *dev,
-					enum phy_link_speed speeds)
+static int phy_mc_ksz8081_cfg_link(const struct device *dev, enum phy_link_speed speeds,
+				   enum phy_cfg_link_flag flags)
 {
 	const struct mc_ksz8081_config *config = dev->config;
 	struct mc_ksz8081_data *data = dev->data;
 	struct phy_link_state state = {};
 	int ret;
+
+	if (flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) {
+		LOG_ERR("Disabling auto-negotiation is not supported by this driver");
+		return -ENOTSUP;
+	}
 
 	/* Lock mutex */
 	ret = k_mutex_lock(&data->mutex, K_FOREVER);

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -420,17 +420,6 @@ static int lan86xx_config_collision_detection(const struct device *dev, bool plc
 	return phy_mc_t1s_c45_write(dev, MDIO_MMD_VENDOR_SPECIFIC2, LAN86XX_REG_COL_DET_CTRL0, new);
 }
 
-static int phy_mc_t1s_cfg_link(const struct device *dev, enum phy_link_speed speeds)
-{
-	ARG_UNUSED(dev);
-
-	if (speeds & LINK_HALF_10BASE) {
-		return 0;
-	}
-
-	return -ENOTSUP;
-}
-
 static int phy_mc_t1s_id(const struct device *dev, uint32_t *phy_id)
 {
 	uint32_t value;
@@ -533,7 +522,6 @@ static int phy_mc_t1s_init(const struct device *dev)
 
 static DEVICE_API(ethphy, mc_t1s_phy_api) = {
 	.get_link = phy_mc_t1s_get_link,
-	.cfg_link = phy_mc_t1s_cfg_link,
 	.link_cb_set = phy_mc_t1s_link_cb_set,
 	.set_plca_cfg = phy_mc_t1s_set_plca_cfg,
 	.get_plca_cfg = genphy_get_plca_cfg,

--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -400,16 +400,6 @@ static int phy_mc_vsc8541_get_link(const struct device *dev, struct phy_link_sta
 }
 
 /**
- * @brief Reconfigure the link speed; currently unused
- *
- */
-static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed speeds)
-{
-	/* the initial version does not support reconfiguration */
-	return -ENOTSUP;
-}
-
-/**
  * @brief Set callback which is used to announce link status changes
  *
  * @param dev device structure to phy device
@@ -542,7 +532,6 @@ static int phy_mc_vsc8541_write(const struct device *dev, uint16_t reg_addr, uin
 
 static DEVICE_API(ethphy, mc_vsc8541_phy_api) = {
 	.get_link = phy_mc_vsc8541_get_link,
-	.cfg_link = phy_mc_vsc8541_cfg_link,
 	.link_cb_set = phy_mc_vsc8541_link_cb_set,
 	.read = phy_mc_vsc8541_read,
 	.write = phy_mc_vsc8541_write,

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -101,13 +101,12 @@ static bool is_gigabit_supported(const struct device *dev)
 		return -EIO;
 	}
 
-	if (bmsr_reg & MII_BMSR_EXTEND_STATUS) {
+	if ((bmsr_reg & MII_BMSR_EXTEND_STATUS) != 0U) {
 		if (phy_mii_reg_read(dev, MII_ESTAT, &estat_reg) < 0) {
 			return -EIO;
 		}
 
-		if (estat_reg & (MII_ESTAT_1000BASE_T_HALF
-				 | MII_ESTAT_1000BASE_T_FULL)) {
+		if ((estat_reg & (MII_ESTAT_1000BASE_T_HALF | MII_ESTAT_1000BASE_T_FULL)) != 0U) {
 			return true;
 		}
 	}
@@ -139,7 +138,7 @@ static int reset(const struct device *dev)
 		if (phy_mii_reg_read(dev, MII_BMCR, &value) < 0) {
 			return -EIO;
 		}
-	} while (value & MII_BMCR_RESET);
+	} while ((value & MII_BMCR_RESET) != 0U);
 
 	return 0;
 }
@@ -176,7 +175,7 @@ static int update_link_state(const struct device *dev)
 		return -EIO;
 	}
 
-	link_up = bmsr_reg & MII_BMSR_LINK_STATUS;
+	link_up = (bmsr_reg & MII_BMSR_LINK_STATUS) != 0U;
 
 	/* If there is no change in link state don't proceed. */
 	if ((link_up == data->state.is_up) && !data->restart_autoneg) {
@@ -264,7 +263,7 @@ static int check_autonegotiation_completion(const struct device *dev)
 		return -EIO;
 	}
 
-	if (!(bmsr_reg & MII_BMSR_AUTONEG_COMPLETE)) {
+	if ((bmsr_reg & MII_BMSR_AUTONEG_COMPLETE) == 0U) {
 		if (sys_timepoint_expired(data->autoneg_timeout)) {
 			LOG_DBG("PHY (%d) auto-negotiate timedout", cfg->phy_addr);
 			return -ETIMEDOUT;
@@ -296,16 +295,16 @@ static int check_autonegotiation_completion(const struct device *dev)
 	}
 
 	if (data->gigabit_supported &&
-			((c1kt_reg & s1kt_reg) & MII_ADVERTISE_1000_FULL)) {
+			((c1kt_reg & s1kt_reg & MII_ADVERTISE_1000_FULL) != 0U)) {
 		data->state.speed = LINK_FULL_1000BASE;
 	} else if (data->gigabit_supported &&
-			((c1kt_reg & s1kt_reg) & MII_ADVERTISE_1000_HALF)) {
+			((c1kt_reg & s1kt_reg & MII_ADVERTISE_1000_HALF) != 0U)) {
 		data->state.speed = LINK_HALF_1000BASE;
-	} else if ((anar_reg & anlpar_reg) & MII_ADVERTISE_100_FULL) {
+	} else if ((anar_reg & anlpar_reg & MII_ADVERTISE_100_FULL) != 0U) {
 		data->state.speed = LINK_FULL_100BASE;
-	} else if ((anar_reg & anlpar_reg) & MII_ADVERTISE_100_HALF) {
+	} else if ((anar_reg & anlpar_reg & MII_ADVERTISE_100_HALF) != 0U) {
 		data->state.speed = LINK_HALF_100BASE;
-	} else if ((anar_reg & anlpar_reg) & MII_ADVERTISE_10_FULL) {
+	} else if ((anar_reg & anlpar_reg & MII_ADVERTISE_10_FULL) != 0U) {
 		data->state.speed = LINK_FULL_10BASE;
 	} else {
 		data->state.speed = LINK_HALF_10BASE;

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -347,8 +347,8 @@ static int phy_mii_write(const struct device *dev, uint16_t reg_addr,
 	return phy_mii_reg_write(dev, reg_addr, (uint16_t)data);
 }
 
-static int phy_mii_cfg_link(const struct device *dev,
-			    enum phy_link_speed adv_speeds)
+static int phy_mii_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds,
+			    enum phy_cfg_link_flag flags)
 {
 	struct phy_mii_dev_data *const data = dev->data;
 	const struct phy_mii_dev_config *const cfg = dev->config;
@@ -521,7 +521,7 @@ static int phy_mii_initialize_dynamic_link(const struct device *dev)
 	k_work_init_delayable(&data->monitor_work, monitor_work_handler);
 
 	/* Advertise default speeds */
-	phy_mii_cfg_link(dev, cfg->default_speeds);
+	phy_mii_cfg_link(dev, cfg->default_speeds, 0);
 
 	monitor_work_handler(&data->monitor_work.work);
 

--- a/drivers/ethernet/phy/phy_mii.h
+++ b/drivers/ethernet/phy/phy_mii.h
@@ -60,4 +60,72 @@ static inline int phy_mii_set_c1kt_reg(const struct device *dev, enum phy_link_s
 
 	return 0;
 }
+
+static inline int phy_mii_set_bmcr_reg_autoneg_disabled(const struct device *dev,
+							enum phy_link_speed adv_speeds)
+{
+	uint32_t bmcr_reg = 0U;
+	uint32_t bmcr_reg_old;
+
+	if (phy_read(dev, MII_BMCR, &bmcr_reg) < 0) {
+		return -EIO;
+	}
+	bmcr_reg_old = bmcr_reg;
+
+	/* Disable auto-negotiation */
+	bmcr_reg &= ~(MII_BMCR_AUTONEG_ENABLE | MII_BMCR_SPEED_LSB | MII_BMCR_SPEED_MSB);
+
+	if (PHY_LINK_IS_SPEED_1000M(adv_speeds)) {
+		bmcr_reg |= MII_BMCR_SPEED_1000;
+	} else if (PHY_LINK_IS_SPEED_100M(adv_speeds)) {
+		bmcr_reg |= MII_BMCR_SPEED_100;
+	} else if (PHY_LINK_IS_SPEED_10M(adv_speeds)) {
+		bmcr_reg |= MII_BMCR_SPEED_10;
+	} else {
+		LOG_ERR("Invalid speed %d", adv_speeds);
+		return -EINVAL;
+	}
+
+	WRITE_BIT(bmcr_reg, MII_BMCR_DUPLEX_MODE_BIT, PHY_LINK_IS_FULL_DUPLEX(adv_speeds));
+
+	if (bmcr_reg == bmcr_reg_old) {
+		return -EALREADY;
+	}
+
+	if (phy_write(dev, MII_BMCR, bmcr_reg) < 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static inline enum phy_link_speed phy_mii_get_link_speed_bmcr_reg(const struct device *dev,
+								  uint16_t bmcr_reg)
+{
+	enum phy_link_speed speed;
+
+	switch (bmcr_reg & (MII_BMCR_DUPLEX_MODE | MII_BMCR_SPEED_MASK)) {
+	case MII_BMCR_DUPLEX_MODE | MII_BMCR_SPEED_1000:
+		speed = LINK_FULL_1000BASE;
+		break;
+	case MII_BMCR_DUPLEX_MODE | MII_BMCR_SPEED_100:
+		speed = LINK_FULL_100BASE;
+		break;
+	case MII_BMCR_DUPLEX_MODE | MII_BMCR_SPEED_10:
+		speed = LINK_FULL_10BASE;
+		break;
+	case MII_BMCR_SPEED_1000:
+		speed = LINK_HALF_1000BASE;
+		break;
+	case MII_BMCR_SPEED_100:
+		speed = LINK_HALF_100BASE;
+		break;
+	case MII_BMCR_SPEED_10:
+	default:
+		speed = LINK_HALF_10BASE;
+		break;
+	}
+
+	return speed;
+}
 #endif /* ZEPHYR_PHY_MII_H_ */

--- a/drivers/ethernet/phy/phy_mii.h
+++ b/drivers/ethernet/phy/phy_mii.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_PHY_MII_H_
+#define ZEPHYR_PHY_MII_H_
+
+#include <zephyr/device.h>
+#include <zephyr/net/phy.h>
+#include <zephyr/net/mii.h>
+
+static inline int phy_mii_set_anar_reg(const struct device *dev, enum phy_link_speed adv_speeds)
+{
+	uint32_t anar_reg = 0U;
+	uint32_t anar_reg_old;
+
+	if (phy_read(dev, MII_ANAR, &anar_reg) < 0) {
+		return -EIO;
+	}
+	anar_reg_old = anar_reg;
+
+	WRITE_BIT(anar_reg, MII_ADVERTISE_10_FULL_BIT, (adv_speeds & LINK_FULL_10BASE) != 0U);
+	WRITE_BIT(anar_reg, MII_ADVERTISE_10_HALF_BIT, (adv_speeds & LINK_HALF_10BASE) != 0U);
+	WRITE_BIT(anar_reg, MII_ADVERTISE_100_FULL_BIT, (adv_speeds & LINK_FULL_100BASE) != 0U);
+	WRITE_BIT(anar_reg, MII_ADVERTISE_100_HALF_BIT, (adv_speeds & LINK_HALF_100BASE) != 0U);
+
+	if (anar_reg == anar_reg_old) {
+		return -EALREADY;
+	}
+
+	if (phy_write(dev, MII_ANAR, anar_reg) < 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static inline int phy_mii_set_c1kt_reg(const struct device *dev, enum phy_link_speed adv_speeds)
+{
+	uint32_t c1kt_reg = 0U;
+	uint32_t c1kt_reg_old;
+
+	if (phy_read(dev, MII_1KTCR, &c1kt_reg) < 0) {
+		return -EIO;
+	}
+	c1kt_reg_old = c1kt_reg;
+
+	WRITE_BIT(c1kt_reg, MII_ADVERTISE_1000_FULL_BIT, (adv_speeds & LINK_FULL_1000BASE) != 0U);
+	WRITE_BIT(c1kt_reg, MII_ADVERTISE_1000_HALF_BIT, (adv_speeds & LINK_HALF_1000BASE) != 0U);
+
+	if (c1kt_reg == c1kt_reg_old) {
+		return -EALREADY;
+	}
+
+	if (phy_write(dev, MII_1KTCR, c1kt_reg) < 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+#endif /* ZEPHYR_PHY_MII_H_ */

--- a/drivers/ethernet/phy/phy_qualcomm_ar8031.c
+++ b/drivers/ethernet/phy/phy_qualcomm_ar8031.c
@@ -22,6 +22,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(phy_qc_ar8031, CONFIG_PHY_LOG_LEVEL);
 
+#include "phy_mii.h"
+
 #define AR8031_PHY_ID1           0x004DU
 #define PHY_READID_TIMEOUT_COUNT 1000U
 
@@ -255,67 +257,23 @@ static void monitor_work_handler(struct k_work *work)
 
 static int qc_ar8031_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds)
 {
-	uint32_t anar_reg;
 	uint32_t bmcr_reg;
-	uint32_t c1kt_reg;
-
-	if (qc_ar8031_read(dev, MII_ANAR, &anar_reg) < 0) {
-		return -EIO;
-	}
 
 	if (qc_ar8031_read(dev, MII_BMCR, &bmcr_reg) < 0) {
 		return -EIO;
 	}
 
-	if (qc_ar8031_read(dev, MII_1KTCR, &c1kt_reg) < 0) {
+	ret = phy_mii_set_anar_reg(dev, speeds);
+	if ((ret < 0) && (ret != -EALREADY)) {
 		return -EIO;
 	}
 
-	if (adv_speeds & LINK_FULL_10BASE) {
-		anar_reg |= MII_ADVERTISE_10_FULL;
-	} else {
-		anar_reg &= ~MII_ADVERTISE_10_FULL;
-	}
-
-	if (adv_speeds & LINK_HALF_10BASE) {
-		anar_reg |= MII_ADVERTISE_10_HALF;
-	} else {
-		anar_reg &= ~MII_ADVERTISE_10_HALF;
-	}
-
-	if (adv_speeds & LINK_FULL_100BASE) {
-		anar_reg |= MII_ADVERTISE_100_FULL;
-	} else {
-		anar_reg &= ~MII_ADVERTISE_100_FULL;
-	}
-
-	if (adv_speeds & LINK_HALF_100BASE) {
-		anar_reg |= MII_ADVERTISE_100_HALF;
-	} else {
-		anar_reg &= ~MII_ADVERTISE_100_HALF;
-	}
-
-	if (adv_speeds & LINK_FULL_1000BASE) {
-		c1kt_reg |= MII_ADVERTISE_1000_FULL;
-	} else {
-		c1kt_reg &= ~MII_ADVERTISE_1000_FULL;
-	}
-
-	if (adv_speeds & LINK_HALF_1000BASE) {
-		c1kt_reg |= MII_ADVERTISE_1000_HALF;
-	} else {
-		c1kt_reg &= ~MII_ADVERTISE_1000_HALF;
-	}
-
-	if (qc_ar8031_write(dev, MII_1KTCR, c1kt_reg) < 0) {
+	ret = phy_mii_set_c1kt_reg(dev, speeds);
+	if ((ret < 0) && (ret != -EALREADY)) {
 		return -EIO;
 	}
 
 	bmcr_reg |= MII_BMCR_AUTONEG_ENABLE | MII_BMCR_AUTONEG_RESTART;
-
-	if (qc_ar8031_write(dev, MII_ANAR, anar_reg) < 0) {
-		return -EIO;
-	}
 
 	if (qc_ar8031_write(dev, MII_BMCR, bmcr_reg) < 0) {
 		return -EIO;

--- a/drivers/ethernet/phy/phy_realtek_rtl8211f.c
+++ b/drivers/ethernet/phy/phy_realtek_rtl8211f.c
@@ -280,12 +280,17 @@ result:
 	return ret;
 }
 
-static int phy_rt_rtl8211f_cfg_link(const struct device *dev,
-					enum phy_link_speed speeds)
+static int phy_rt_rtl8211f_cfg_link(const struct device *dev, enum phy_link_speed speeds,
+				    enum phy_cfg_link_flag flags)
 {
 	const struct rt_rtl8211f_config *config = dev->config;
 	struct rt_rtl8211f_data *data = dev->data;
 	int ret;
+
+	if (flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) {
+		LOG_ERR("Disabling auto-negotiation is not supported by this driver");
+		return -ENOTSUP;
+	}
 
 	/* Lock mutex */
 	ret = k_mutex_lock(&data->mutex, K_FOREVER);

--- a/drivers/ethernet/phy/phy_realtek_rtl8211f.c
+++ b/drivers/ethernet/phy/phy_realtek_rtl8211f.c
@@ -25,6 +25,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
+#include "phy_mii.h"
+
 #define REALTEK_OUI_MSB (0x1CU)
 
 #define PHY_RT_RTL8211F_PHYSR_REG (0x1A)
@@ -283,8 +285,6 @@ static int phy_rt_rtl8211f_cfg_link(const struct device *dev,
 {
 	const struct rt_rtl8211f_config *config = dev->config;
 	struct rt_rtl8211f_data *data = dev->data;
-	uint32_t anar;
-	uint32_t gbcr;
 	int ret;
 
 	/* Lock mutex */
@@ -303,60 +303,15 @@ static int phy_rt_rtl8211f_cfg_link(const struct device *dev,
 	k_work_cancel_delayable(&data->phy_monitor_work);
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 
-	/* Read ANAR register to write back */
-	ret = phy_rt_rtl8211f_read(dev, MII_ANAR, &anar);
-	if (ret) {
-		LOG_ERR("Error reading phy (%d) advertising register", config->addr);
+	ret = phy_mii_set_anar_reg(dev, speeds);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Error setting ANAR register for phy (%d)", config->addr);
 		goto done;
 	}
 
-	/* Read GBCR register to write back */
-	ret = phy_rt_rtl8211f_read(dev, MII_1KTCR, &gbcr);
-	if (ret) {
-		LOG_ERR("Error reading phy (%d) 1000Base-T control register", config->addr);
-		goto done;
-	}
-
-	/* Setup advertising register */
-	if (speeds & LINK_FULL_100BASE) {
-		anar |= MII_ADVERTISE_100_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_100_FULL;
-	}
-	if (speeds & LINK_HALF_100BASE) {
-		anar |= MII_ADVERTISE_100_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_100_HALF;
-	}
-	if (speeds & LINK_FULL_10BASE) {
-		anar |= MII_ADVERTISE_10_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_10_FULL;
-	}
-	if (speeds & LINK_HALF_10BASE) {
-		anar |= MII_ADVERTISE_10_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_10_HALF;
-	}
-
-	/* Setup 1000Base-T control register */
-	if (speeds & LINK_FULL_1000BASE) {
-		gbcr |= MII_ADVERTISE_1000_FULL;
-	} else {
-		gbcr &= ~MII_ADVERTISE_1000_FULL;
-	}
-
-	/* Write capabilities to advertising register */
-	ret = phy_rt_rtl8211f_write(dev, MII_ANAR, anar);
-	if (ret) {
-		LOG_ERR("Error writing phy (%d) advertising register", config->addr);
-		goto done;
-	}
-
-	/* Write capabilities to 1000Base-T control register */
-	ret = phy_rt_rtl8211f_write(dev, MII_1KTCR, gbcr);
-	if (ret) {
-		LOG_ERR("Error writing phy (%d) 1000Base-T control register", config->addr);
+	ret = phy_mii_set_c1kt_reg(dev, speeds);
+	if (ret < 0 && ret != -EALREADY) {
+		LOG_ERR("Error setting C1KT register for phy (%d)", config->addr);
 		goto done;
 	}
 

--- a/drivers/ethernet/phy/phy_ti_dp83825.c
+++ b/drivers/ethernet/phy/phy_ti_dp83825.c
@@ -360,11 +360,17 @@ done:
 	return ret;
 }
 
-static int phy_ti_dp83825_cfg_link(const struct device *dev, enum phy_link_speed speeds)
+static int phy_ti_dp83825_cfg_link(const struct device *dev, enum phy_link_speed speeds,
+				   enum phy_cfg_link_flag flags)
 {
 	const struct ti_dp83825_config *config = dev->config;
 	struct ti_dp83825_data *data = dev->data;
 	int ret;
+
+	if (flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) {
+		LOG_ERR("Disabling auto-negotiation is not supported by this driver");
+		return -ENOTSUP;
+	}
 
 	/* Lock mutex */
 	ret = k_mutex_lock(&data->mutex, K_FOREVER);

--- a/drivers/ethernet/phy/phy_ti_dp83825.c
+++ b/drivers/ethernet/phy/phy_ti_dp83825.c
@@ -22,6 +22,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
+#include "phy_mii.h"
+
 #define PHY_TI_DP83825_PHYSCR_REG     0x11
 #define PHY_TI_DP83825_PHYSCR_REG_IE  BIT(1)
 #define PHY_TI_DP83825_PHYSCR_REG_IOE BIT(0)
@@ -363,7 +365,6 @@ static int phy_ti_dp83825_cfg_link(const struct device *dev, enum phy_link_speed
 	const struct ti_dp83825_config *config = dev->config;
 	struct ti_dp83825_data *data = dev->data;
 	int ret;
-	uint32_t anar;
 
 	/* Lock mutex */
 	ret = k_mutex_lock(&data->mutex, K_FOREVER);
@@ -393,42 +394,9 @@ static int phy_ti_dp83825_cfg_link(const struct device *dev, enum phy_link_speed
 		goto done;
 	}
 
-	/* Read ANAR register to write back */
-	ret = phy_ti_dp83825_read(dev, MII_ANAR, &anar);
-	if (ret) {
-		LOG_ERR("Error reading phy (%d) advertising register", config->addr);
-		goto done;
-	}
-
-	/* Setup advertising register */
-	if (speeds & LINK_FULL_100BASE) {
-		anar |= MII_ADVERTISE_100_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_100_FULL;
-	}
-
-	if (speeds & LINK_HALF_100BASE) {
-		anar |= MII_ADVERTISE_100_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_100_HALF;
-	}
-
-	if (speeds & LINK_FULL_10BASE) {
-		anar |= MII_ADVERTISE_10_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_10_FULL;
-	}
-
-	if (speeds & LINK_HALF_10BASE) {
-		anar |= MII_ADVERTISE_10_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_10_HALF;
-	}
-
-	/* Write capabilities to advertising register */
-	ret = phy_ti_dp83825_write(dev, MII_ANAR, anar);
-	if (ret) {
-		LOG_ERR("Error writing phy (%d) advertising register", config->addr);
+	ret = phy_mii_set_anar_reg(dev, speeds);
+	if ((ret < 0) && (ret != -EALREADY)) {
+		LOG_ERR("Error setting ANAR register for phy (%d)", config->addr);
 		goto done;
 	}
 

--- a/drivers/ethernet/phy/phy_ti_dp83867.c
+++ b/drivers/ethernet/phy/phy_ti_dp83867.c
@@ -20,6 +20,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 
+#include "phy_mii.h"
+
 #define PHY_TI_DP83867_PHYSTS                 0x11
 #define PHY_TI_DP83867_PHYSTS_LINKSTATUS_MASK BIT(10)
 #define PHY_TI_DP83867_PHYSTS_LINKDUPLEX_MASK BIT(13)
@@ -283,7 +285,7 @@ static int phy_ti_dp83867_cfg_link(const struct device *dev, enum phy_link_speed
 	const struct ti_dp83867_config *config = dev->config;
 	struct ti_dp83867_data *data = dev->data;
 	int ret;
-	uint32_t anar, cfg1, val;
+	uint32_t val;
 
 	/* Lock mutex */
 	ret = k_mutex_lock(&data->mutex, K_FOREVER);
@@ -330,60 +332,15 @@ static int phy_ti_dp83867_cfg_link(const struct device *dev, enum phy_link_speed
 	k_work_cancel_delayable(&data->phy_monitor_work);
 #endif /* DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios) */
 
-	/* Read ANAR register to write back */
-	ret = phy_ti_dp83867_read(dev, MII_ANAR, &anar);
-	if (ret) {
-		LOG_ERR("Error reading phy (%d) advertising register", config->addr);
+	ret = phy_mii_set_anar_reg(dev, speeds);
+	if ((ret < 0) && (ret != -EALREADY)) {
+		LOG_ERR("Error setting ANAR register for phy (%d)", config->addr);
 		goto done;
 	}
 
-	/* Read CFG1 register to write back */
-	ret = phy_ti_dp83867_read(dev, MII_1KTCR, &cfg1);
-	if (ret) {
-		LOG_ERR("Error reading phy (%d) 1000Base-T control register", config->addr);
-		goto done;
-	}
-
-	/* Setup advertising register */
-	if (speeds & LINK_FULL_100BASE) {
-		anar |= MII_ADVERTISE_100_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_100_FULL;
-	}
-	if (speeds & LINK_HALF_100BASE) {
-		anar |= MII_ADVERTISE_100_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_100_HALF;
-	}
-	if (speeds & LINK_FULL_10BASE) {
-		anar |= MII_ADVERTISE_10_FULL;
-	} else {
-		anar &= ~MII_ADVERTISE_10_FULL;
-	}
-	if (speeds & LINK_HALF_10BASE) {
-		anar |= MII_ADVERTISE_10_HALF;
-	} else {
-		anar &= ~MII_ADVERTISE_10_HALF;
-	}
-
-	/* Setup 1000Base-T control register */
-	if (speeds & LINK_FULL_1000BASE) {
-		cfg1 |= MII_ADVERTISE_1000_FULL;
-	} else {
-		cfg1 &= ~MII_ADVERTISE_1000_FULL;
-	}
-
-	/* Write capabilities to advertising register */
-	ret = phy_ti_dp83867_write(dev, MII_ANAR, anar);
-	if (ret) {
-		LOG_ERR("Error writing phy (%d) advertising register", config->addr);
-		goto done;
-	}
-
-	/* Write capabilities to 1000Base-T control register */
-	ret = phy_ti_dp83867_write(dev, MII_1KTCR, cfg1);
-	if (ret) {
-		LOG_ERR("Error writing phy (%d) 1000Base-T control register", config->addr);
+	ret = phy_mii_set_c1kt_reg(dev, speeds);
+	if ((ret < 0) && (ret != -EALREADY)) {
+		LOG_ERR("Error setting C1KT register for phy (%d)", config->addr);
 		goto done;
 	}
 

--- a/drivers/ethernet/phy/phy_ti_dp83867.c
+++ b/drivers/ethernet/phy/phy_ti_dp83867.c
@@ -280,12 +280,18 @@ done:
 	return ret;
 }
 
-static int phy_ti_dp83867_cfg_link(const struct device *dev, enum phy_link_speed speeds)
+static int phy_ti_dp83867_cfg_link(const struct device *dev, enum phy_link_speed speeds,
+				   enum phy_cfg_link_flag flags)
 {
 	const struct ti_dp83867_config *config = dev->config;
 	struct ti_dp83867_data *data = dev->data;
 	int ret;
 	uint32_t val;
+
+	if (flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) {
+		LOG_ERR("Disabling auto-negotiation is not supported by this driver");
+		return -ENOTSUP;
+	}
 
 	/* Lock mutex */
 	ret = k_mutex_lock(&data->mutex, K_FOREVER);

--- a/drivers/ethernet/phy/phy_tja1103.c
+++ b/drivers/ethernet/phy/phy_tja1103.c
@@ -338,17 +338,6 @@ static void phy_tja1103_cfg_irq_poll(const struct device *dev)
 	}
 }
 
-static int phy_tja1103_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds)
-{
-	ARG_UNUSED(dev);
-
-	if (adv_speeds & LINK_FULL_100BASE) {
-		return 0;
-	}
-
-	return -ENOTSUP;
-}
-
 static int phy_tja1103_init(const struct device *dev)
 {
 	const struct phy_tja1103_config *const cfg = dev->config;
@@ -437,7 +426,6 @@ static int phy_tja1103_link_cb_set(const struct device *dev, phy_callback_t cb, 
 
 static DEVICE_API(ethphy, phy_tja1103_api) = {
 	.get_link = phy_tja1103_get_link_state,
-	.cfg_link = phy_tja1103_cfg_link,
 	.link_cb_set = phy_tja1103_link_cb_set,
 	.read = phy_tja1103_reg_read,
 	.write = phy_tja1103_reg_write,

--- a/drivers/ethernet/phy/phy_tja11xx.c
+++ b/drivers/ethernet/phy/phy_tja11xx.c
@@ -171,17 +171,6 @@ static void phy_tja11xx_cfg_irq_poll(const struct device *dev)
 	monitor_work_handler(&data->monitor_work.work);
 }
 
-static int phy_tja11xx_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds)
-{
-	ARG_UNUSED(dev);
-
-	if (adv_speeds & LINK_FULL_100BASE) {
-		return 0;
-	}
-
-	return -ENOTSUP;
-}
-
 static int phy_tja11xx_init(const struct device *dev)
 {
 	struct phy_tja11xx_data *const data = dev->data;
@@ -233,7 +222,6 @@ static int phy_tja11xx_link_cb_set(const struct device *dev, phy_callback_t cb, 
 
 static const struct ethphy_driver_api phy_tja11xx_api = {
 	.get_link = phy_tja11xx_get_link_state,
-	.cfg_link = phy_tja11xx_cfg_link,
 	.link_cb_set = phy_tja11xx_link_cb_set,
 	.read = phy_tja11xx_reg_read,
 	.write = phy_tja11xx_reg_write,

--- a/include/zephyr/net/mii.h
+++ b/include/zephyr/net/mii.h
@@ -54,32 +54,41 @@
 #define MII_ESTAT      0xf
 
 /* Basic Mode Control Register (BMCR) bit definitions */
+#define MII_BMCR_RESET_BIT           15
+#define MII_BMCR_LOOPBACK_BIT        14
+#define MII_BMCR_SPEED_LSB_BIT       13
+#define MII_BMCR_AUTONEG_ENABLE_BIT  12
+#define MII_BMCR_POWER_DOWN_BIT      11
+#define MII_BMCR_ISOLATE_BIT         10
+#define MII_BMCR_AUTONEG_RESTART_BIT 9
+#define MII_BMCR_DUPLEX_MODE_BIT     8
+#define MII_BMCR_SPEED_MSB_BIT       6
 /** PHY reset */
-#define MII_BMCR_RESET             BIT(15)
+#define MII_BMCR_RESET               BIT(MII_BMCR_RESET_BIT)
 /** enable loopback mode */
-#define MII_BMCR_LOOPBACK          BIT(14)
+#define MII_BMCR_LOOPBACK            BIT(MII_BMCR_LOOPBACK_BIT)
 /** 10=1000Mbps 01=100Mbps; 00=10Mbps */
-#define MII_BMCR_SPEED_LSB         BIT(13)
+#define MII_BMCR_SPEED_LSB           BIT(MII_BMCR_SPEED_LSB_BIT)
 /** Auto-Negotiation enable */
-#define MII_BMCR_AUTONEG_ENABLE    BIT(12)
+#define MII_BMCR_AUTONEG_ENABLE      BIT(MII_BMCR_AUTONEG_ENABLE_BIT)
 /** power down mode */
-#define MII_BMCR_POWER_DOWN        BIT(11)
+#define MII_BMCR_POWER_DOWN          BIT(MII_BMCR_POWER_DOWN_BIT)
 /** isolate electrically PHY from MII */
-#define MII_BMCR_ISOLATE           BIT(10)
+#define MII_BMCR_ISOLATE             BIT(MII_BMCR_ISOLATE_BIT)
 /** restart auto-negotiation */
-#define MII_BMCR_AUTONEG_RESTART   BIT(9)
+#define MII_BMCR_AUTONEG_RESTART     BIT(MII_BMCR_AUTONEG_RESTART_BIT)
 /** full duplex mode */
-#define MII_BMCR_DUPLEX_MODE       BIT(8)
+#define MII_BMCR_DUPLEX_MODE         BIT(MII_BMCR_DUPLEX_MODE_BIT)
 /** 10=1000Mbps 01=100Mbps; 00=10Mbps */
-#define MII_BMCR_SPEED_MSB         BIT(6)
+#define MII_BMCR_SPEED_MSB           BIT(MII_BMCR_SPEED_MSB_BIT)
 /** Link Speed Field */
-#define   MII_BMCR_SPEED_MASK      (BIT(6) | BIT(13))
+#define MII_BMCR_SPEED_MASK          (MII_BMCR_SPEED_MSB | MII_BMCR_SPEED_LSB)
 /** select speed 10 Mb/s */
-#define   MII_BMCR_SPEED_10        0
+#define MII_BMCR_SPEED_10            0
 /** select speed 100 Mb/s */
-#define   MII_BMCR_SPEED_100       BIT(13)
+#define MII_BMCR_SPEED_100           BIT(MII_BMCR_SPEED_LSB_BIT)
 /** select speed 1000 Mb/s */
-#define   MII_BMCR_SPEED_1000      BIT(6)
+#define MII_BMCR_SPEED_1000          BIT(MII_BMCR_SPEED_MSB_BIT)
 
 /* Basic Mode Status Register (BMSR) bit definitions */
 /** 100BASE-T4 capable */
@@ -115,36 +124,48 @@
 
 /* Auto-negotiation Advertisement Register (ANAR) bit definitions */
 /* Auto-negotiation Link Partner Ability Register (ANLPAR) bit definitions */
+#define MII_ADVERTISE_NEXT_PAGE_BIT    15
+#define MII_ADVERTISE_LPACK_BIT        14
+#define MII_ADVERTISE_REMOTE_FAULT_BIT 13
+#define MII_ADVERTISE_ASYM_PAUSE_BIT   11
+#define MII_ADVERTISE_PAUSE_BIT        10
+#define MII_ADVERTISE_100BASE_T4_BIT   9
+#define MII_ADVERTISE_100_FULL_BIT     8
+#define MII_ADVERTISE_100_HALF_BIT     7
+#define MII_ADVERTISE_10_FULL_BIT      6
+#define MII_ADVERTISE_10_HALF_BIT      5
 /** next page */
-#define MII_ADVERTISE_NEXT_PAGE    BIT(15)
+#define MII_ADVERTISE_NEXT_PAGE        BIT(MII_ADVERTISE_NEXT_PAGE_BIT)
 /** link partner acknowledge response */
-#define MII_ADVERTISE_LPACK        BIT(14)
+#define MII_ADVERTISE_LPACK            BIT(MII_ADVERTISE_LPACK_BIT)
 /** remote fault */
-#define MII_ADVERTISE_REMOTE_FAULT BIT(13)
+#define MII_ADVERTISE_REMOTE_FAULT     BIT(MII_ADVERTISE_REMOTE_FAULT_BIT)
 /** try for asymmetric pause */
-#define MII_ADVERTISE_ASYM_PAUSE   BIT(11)
+#define MII_ADVERTISE_ASYM_PAUSE       BIT(MII_ADVERTISE_ASYM_PAUSE_BIT)
 /** try for pause */
-#define MII_ADVERTISE_PAUSE        BIT(10)
+#define MII_ADVERTISE_PAUSE            BIT(MII_ADVERTISE_PAUSE_BIT)
 /** try for 100BASE-T4 support */
-#define MII_ADVERTISE_100BASE_T4   BIT(9)
+#define MII_ADVERTISE_100BASE_T4       BIT(MII_ADVERTISE_100BASE_T4_BIT)
 /** try for 100BASE-X full duplex support */
-#define MII_ADVERTISE_100_FULL     BIT(8)
+#define MII_ADVERTISE_100_FULL         BIT(MII_ADVERTISE_100_FULL_BIT)
 /** try for 100BASE-X support */
-#define MII_ADVERTISE_100_HALF     BIT(7)
+#define MII_ADVERTISE_100_HALF         BIT(MII_ADVERTISE_100_HALF_BIT)
 /** try for 10 Mb/s full duplex support */
-#define MII_ADVERTISE_10_FULL      BIT(6)
+#define MII_ADVERTISE_10_FULL          BIT(MII_ADVERTISE_10_FULL_BIT)
 /** try for 10 Mb/s half duplex support */
-#define MII_ADVERTISE_10_HALF      BIT(5)
+#define MII_ADVERTISE_10_HALF          BIT(MII_ADVERTISE_10_HALF_BIT)
 /** Selector Field Mask */
-#define MII_ADVERTISE_SEL_MASK     (0x1F << 0)
+#define MII_ADVERTISE_SEL_MASK         (0x1F << 0)
 /** Selector Field */
 #define MII_ADVERTISE_SEL_IEEE_802_3   0x01
 
 /* 1000BASE-T Control Register bit definitions */
+#define MII_ADVERTISE_1000_FULL_BIT 9
+#define MII_ADVERTISE_1000_HALF_BIT 8
 /** try for 1000BASE-T full duplex support */
-#define MII_ADVERTISE_1000_FULL    BIT(9)
+#define MII_ADVERTISE_1000_FULL     BIT(MII_ADVERTISE_1000_FULL_BIT)
 /** try for 1000BASE-T half duplex support */
-#define MII_ADVERTISE_1000_HALF    BIT(8)
+#define MII_ADVERTISE_1000_HALF     BIT(MII_ADVERTISE_1000_HALF_BIT)
 
 /** Advertise all speeds */
 #define MII_ADVERTISE_ALL (MII_ADVERTISE_10_HALF | MII_ADVERTISE_10_FULL |\

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -228,6 +228,7 @@ __subsystem struct ethphy_driver_api {
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  * @retval -ENOTSUP If not supported.
+ * @retval -EALREADY If already configured with the same speeds and flags.
  */
 static inline int phy_configure_link(const struct device *dev, enum phy_link_speed speeds,
 				     enum phy_cfg_link_flag flags)

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -24,6 +24,7 @@
  */
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <zephyr/sys/util_macro.h>
 #include <errno.h>
 
 #ifdef __cplusplus
@@ -94,6 +95,12 @@ struct phy_link_state {
 	enum phy_link_speed speed;
 	/** When true the link is active and connected */
 	bool is_up;
+};
+
+/** @brief Ethernet configure link flags. */
+enum phy_cfg_link_flag {
+	/** Auto-negotiation disable */
+	PHY_FLAG_AUTO_NEGOTIATION_DISABLED = BIT(0),
 };
 
 /** @brief PLCA (Physical Layer Collision Avoidance) Reconciliation Sublayer configurations */
@@ -176,7 +183,8 @@ __subsystem struct ethphy_driver_api {
 	int (*get_link)(const struct device *dev, struct phy_link_state *state);
 
 	/** Configure link */
-	int (*cfg_link)(const struct device *dev, enum phy_link_speed adv_speeds);
+	int (*cfg_link)(const struct device *dev, enum phy_link_speed adv_speeds,
+			enum phy_cfg_link_flag flags);
 
 	/** Set callback to be invoked when link state changes. Driver has to invoke
 	 * callback once after setting it, even if link state has not changed.
@@ -215,12 +223,14 @@ __subsystem struct ethphy_driver_api {
  *
  * @param[in]  dev     PHY device structure
  * @param      speeds  OR'd link speeds to be advertised by the PHY
+ * @param      flags   OR'd flags to control the link configuration or 0.
  *
  * @retval 0 If successful.
  * @retval -EIO If communication with PHY failed.
  * @retval -ENOTSUP If not supported.
  */
-static inline int phy_configure_link(const struct device *dev, enum phy_link_speed speeds)
+static inline int phy_configure_link(const struct device *dev, enum phy_link_speed speeds,
+				     enum phy_cfg_link_flag flags)
 {
 	const struct ethphy_driver_api *api = (const struct ethphy_driver_api *)dev->api;
 
@@ -228,7 +238,12 @@ static inline int phy_configure_link(const struct device *dev, enum phy_link_spe
 		return -ENOSYS;
 	}
 
-	return api->cfg_link(dev, speeds);
+	/* Check if only one speed is set, when auto-negotiation is disabled */
+	if ((flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) && !IS_POWER_OF_TWO(speeds)) {
+		return -EINVAL;
+	}
+
+	return api->cfg_link(dev, speeds, flags);
 }
 
 /**

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -824,6 +824,7 @@ static int cmd_net_link_speed(const struct shell *sh, size_t argc, char *argv[])
 	uint16_t user_input_spd;
 	struct net_if *iface;
 	uint16_t speed = 0U;
+	uint16_t flags = 0U;
 	int ret;
 
 	if (argc < 3) {
@@ -854,6 +855,10 @@ static int cmd_net_link_speed(const struct shell *sh, size_t argc, char *argv[])
 		user_input_spd = shell_strtoul(argv[k], 10, &ret);
 		switch (user_input_spd) {
 		case 0:
+			if (strcmp(argv[k], "no-autoneg") == 0) {
+				flags |= PHY_FLAG_AUTO_NEGOTIATION_DISABLED;
+				continue;
+			}
 			break;
 		case 10:
 			speed |= half_duplex ? LINK_HALF_10BASE : LINK_FULL_10BASE;
@@ -885,7 +890,7 @@ static int cmd_net_link_speed(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (speed != 0U) {
-		return phy_configure_link(phy_dev, speed, 0);
+		return phy_configure_link(phy_dev, speed, flags);
 	}
 	PR_WARNING("No speed specified\n");
 	return -ENOEXEC;

--- a/subsys/net/lib/shell/iface.c
+++ b/subsys/net/lib/shell/iface.c
@@ -885,7 +885,7 @@ static int cmd_net_link_speed(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (speed != 0U) {
-		return phy_configure_link(phy_dev, speed);
+		return phy_configure_link(phy_dev, speed, 0);
 	}
 	PR_WARNING("No speed specified\n");
 	return -ENOEXEC;


### PR DESCRIPTION
Adds support for disabling Auto-negotiation.

Done by adding a flags parameter to `phy_configure_link()`.

- also improved the phy_mii in general
- put commonly used parts used in the ethernet phys into a common header, so it can be shared.