### PR TITLE
stm32: i2c: i2c_api :  add  test config when interrupt mode is disabled 

### DIFF
--- a/tests/drivers/i2c/i2c_api/boards/stm32_arduino.overlay
+++ b/tests/drivers/i2c/i2c_api/boards/stm32_arduino.overlay
@@ -1,0 +1,5 @@
+/ {
+	aliases {
+		i2c-0 = &arduino_i2c;
+	};
+};

--- a/tests/drivers/i2c/i2c_api/testcase.yaml
+++ b/tests/drivers/i2c/i2c_api/testcase.yaml
@@ -18,3 +18,12 @@ tests:
     extra_args:
       - DTC_OVERLAY_FILE="./boards/${BOARD}_sci_b_i2c.overlay"
       - CONF_FILE="./prj.conf ./boards/${BOARD}_sci_b_i2c.conf"
+  drivers.i2c.stm32.interrupt_disabled:
+    depends_on:
+      - i2c
+      - arduino_i2c
+    filter: dt_nodelabel_enabled("arduino_i2c") and CONFIG_SOC_FAMILY_STM32
+    build_only: true
+    extra_args: "DTC_OVERLAY_FILE=boards/stm32_arduino.overlay"
+    extra_configs:
+      - CONFIG_I2C_STM32_INTERRUPT=n


### PR DESCRIPTION
Following observation made in this PR https://github.com/zephyrproject-rtos/zephyr/pull/91184 

This PR introduces a test scenario in the `i2c_api` test driver for `build-only`, to check for CI failures when the interrupt mode is disabled (`CONFIG_I2C_STM32_INTERRUPT=n`).

depends on https://github.com/zephyrproject-rtos/zephyr/pull/91345