### PR TITLE
ci: bsim tests: Trigger on any change on tests/bluetooth

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -10,7 +10,7 @@ on:
       - "tests/bsim/**"
       - "boards/nordic/nrf5*/*dt*"
       - "dts/*/nordic/**"
-      - "tests/bluetooth/common/testlib/**"
+      - "tests/bluetooth/**"
       - "samples/bluetooth/**"
       - "boards/native/**"
       - "soc/native/**"
@@ -123,7 +123,7 @@ jobs:
           files: |
             samples/bluetooth/
             subsys/bluetooth/
-            tests/bluetooth/common/testlib/
+            tests/bluetooth/
             tests/bsim/bluetooth/
 
       - name: Check if Networking files changed


### PR DESCRIPTION
As time passes we are adding more babblesim tests which depend on code/ tests from tests/bluetooth just like we have many based on samples from samples/bluetooth.
Let's also trigger the Babblesim CI job when anything changes in tests/bluetooth, instead of trying to pinpoint the specific folders we use, as otherwise every now and then we have coverage holes and issues are introduced in main.
