### PR TITLE
board: st: stm32u5g9j-dk2: Add toucscreen and hspi flash to u5g9 dk2

### DIFF
--- a/boards/st/stm32u5g9j_dk2/board.cmake
+++ b/boards/st/stm32u5g9j_dk2/board.cmake
@@ -3,6 +3,9 @@
 
 # keep first
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+if(CONFIG_STM32_MEMMAP)
+board_runner_args(stm32cubeprogrammer "--extload=MX66LM1G45G_STM32U5G9J-DK2.stldr")
+endif()
 
 board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")

--- a/boards/st/stm32u5g9j_dk2/doc/index.rst
+++ b/boards/st/stm32u5g9j_dk2/doc/index.rst
@@ -53,7 +53,7 @@ Default Zephyr Peripheral Mapping:
 - LD3 : PD4
 - User Button: PC13
 - I2C1 SCL/SDA : PG14/PG13
-- I2C2 SCL/SDA : PB10/PB11
+- I2C2 SCL/SDA : PF1/PF0
 - SPI1 SCK/MISO/MOSI/CS : PA5/PA6/PB5/PA3
 - ADC1 : channel5 PA0, channel12 PA7
 - ADC4 : channel4 PC3

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -21,6 +21,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ltdc;
+		zephyr,touch = &gt911;
 	};
 
 	leds {
@@ -175,10 +176,17 @@
 };
 
 &i2c2 {
-	pinctrl-0 = <&i2c2_scl_pb10 &i2c2_sda_pb11>;
 	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_STANDARD>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	gt911: gt911@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+		irq-gpios = <&gpioe 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpiod 2 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &spi1 {

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -58,6 +58,14 @@
 		volt-sensor0 = &vref1;
 		volt-sensor1 = &vbat4;
 	};
+
+	ext_memory: memory@a0000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0xa0000000 DT_SIZE_M(128)>;
+		zephyr,memory-region = "EXTMEM";
+		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
+	};
 };
 
 &ltdc {
@@ -319,9 +327,45 @@ zephyr_udc0: &usbotg_hs {
 	};
 };
 
+&xspi1 {
+	clocks = <&rcc STM32_CLOCK(AHB2_2, 12U)>,
+			 <&rcc STM32_SRC_PLL2_Q HSPI_SEL(2)>;
+
+	pinctrl-0 = <&hspi1_dqs0_pi2 &hspi1_ncs_ph9
+		&hspi1_io0_ph10 &hspi1_io1_ph11
+		&hspi1_io2_ph12 &hspi1_io3_ph13
+		&hspi1_io4_ph14 &hspi1_io5_ph15
+		&hspi1_io6_pi0 &hspi1_io7_pi1
+		&hspi1_clk_pi3>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	mx66lm1g45: xspi-nor-flash@0 {
+		compatible = "st,stm32-xspi-nor";
+		reg = <0>;
+		size = <DT_SIZE_M(1024)>; /* 1 Gbits */
+		ospi-max-frequency = <DT_FREQ_M(133)>;
+		spi-bus-width = <XSPI_OCTO_MODE>;
+		data-rate = <XSPI_DTR_TRANSFER>;
+		four-byte-opcodes;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			extflash_partition: partition@0 {
+				label = "ext_storage";
+				reg = <0 DT_SIZE_M(128)>;
+			};
+		};
+	};
+};
+
 &rtc {
 	clocks =  <&rcc STM32_CLOCK_BUS_APB3 0x00200000>,
-			<&rcc STM32_SRC_LSE RTC_SEL(1)>;
+			  <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };
 

--- a/dts/arm/st/u5/stm32u599.dtsi
+++ b/dts/arm/st/u5/stm32u599.dtsi
@@ -1,11 +1,16 @@
 /*
  * Copyright (c) 2023 PSICONTROL nv
  * Copyright (c) 2025 Harris Tomy
+ * Copyright (c) 2025 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <st/u5/stm32u595.dtsi>
+#include <zephyr/dt-bindings/memory-attr/memory-attr.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/dt-bindings/flash_controller/xspi.h>
+#include <mem.h>
 
 / {
 	soc {
@@ -18,6 +23,19 @@
 			interrupt-names = "ltdc", "ltdc_er";
 			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
 			resets = <&rctl STM32_RESET(APB2, 26)>;
+			status = "disabled";
+		};
+
+		xspi1: spi@420d3400 {
+			compatible = "st,stm32-xspi";
+			reg = <0x420d3400 0x400>,
+				<0xa0000000 DT_SIZE_M(256)>;
+			interrupts = <131 0>;
+			clock-names = "xspix", "xspi-ker";
+			clocks = <&rcc STM32_CLOCK(AHB2_2, 12)>,
+					 <&rcc STM32_SRC_SYSCLK HSPI_SEL(0)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
Adds HSPI external flash and GT911 touch screen driver support to the STM32U5G9J-DK2 board.