### PR TITLE
ci: BSIM: Add changes to the BT Tester to BSIM

### DIFF
--- a/.github/workflows/bsim-tests.yaml
+++ b/.github/workflows/bsim-tests.yaml
@@ -28,6 +28,7 @@ on:
       - "drivers/serial/*nrfx*"
       - "tests/drivers/uart/**"
       - '!**.rst'
+      - "tests/bluetooth/tester**"
 
 permissions:
   contents: read


### PR DESCRIPTION
The BT Tester is now actively being tested in BSIM to catch any runtime issues, but changes to the BT Tester application was not triggering the BSIM CI job.

Add `zephyr/tests/bluetooth/tester` to the paths.