### PR TITLE
net: stats: Make byte counters 64-bit 

### DIFF
--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -49,9 +49,9 @@ typedef uint32_t net_stats_t;
  */
 struct net_stats_bytes {
 	/** Number of bytes sent */
-	net_stats_t sent;
+	uint64_t sent;
 	/** Number of bytes received */
-	net_stats_t received;
+	uint64_t received;
 };
 
 /**
@@ -319,6 +319,8 @@ struct net_stats_rx_time {
 struct net_stats_tc {
 	/** TX statistics for each traffic class */
 	struct {
+		/** Number of bytes sent for this traffic class */
+		uint64_t bytes;
 		/** Helper for calculating average TX time statistics */
 		struct net_stats_tx_time tx_time;
 #if defined(CONFIG_NET_PKT_TXTIME_STATS_DETAIL)
@@ -330,14 +332,14 @@ struct net_stats_tc {
 		net_stats_t pkts;
 		/** Number of packets dropped for this traffic class */
 		net_stats_t dropped;
-		/** Number of bytes sent for this traffic class */
-		net_stats_t bytes;
 		/** Priority of this traffic class */
 		uint8_t priority;
 	} sent[NET_TC_TX_STATS_COUNT];
 
 	/** RX statistics for each traffic class */
 	struct {
+		/** Number of bytes received for this traffic class */
+		uint64_t bytes;
 		/** Helper for calculating average RX time statistics */
 		struct net_stats_rx_time rx_time;
 #if defined(CONFIG_NET_PKT_RXTIME_STATS_DETAIL)
@@ -349,8 +351,6 @@ struct net_stats_tc {
 		net_stats_t pkts;
 		/** Number of packets dropped for this traffic class */
 		net_stats_t dropped;
-		/** Number of bytes received for this traffic class */
-		net_stats_t bytes;
 		/** Priority of this traffic class */
 		uint8_t priority;
 	} recv[NET_TC_RX_STATS_COUNT];
@@ -404,14 +404,14 @@ struct net_stats_pkt_filter {
  * @brief All network statistics in one struct.
  */
 struct net_stats {
-	/** Count of malformed packets or packets we do not have handler for */
-	net_stats_t processing_error;
-
 	/**
 	 * This calculates amount of data transferred through all the
 	 * network interfaces.
 	 */
 	struct net_stats_bytes bytes;
+
+	/** Count of malformed packets or packets we do not have handler for */
+	net_stats_t processing_error;
 
 	/** IP layer errors */
 	struct net_stats_ip_errors ip_errors;

--- a/samples/net/stats/src/main.c
+++ b/samples/net/stats/src/main.c
@@ -99,7 +99,7 @@ static void print_stats(struct net_if *iface, struct net_stats *data)
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP)
-	printk("TCP bytes recv %u\tsent\t%u\n",
+	printk("TCP bytes recv %llu\tsent\t%llu\n",
 	       GET_STAT(iface, tcp.bytes.received),
 	       GET_STAT(iface, tcp.bytes.sent));
 	printk("TCP seg recv   %u\tsent\t%u\tdrop\t%u\n",
@@ -119,8 +119,8 @@ static void print_stats(struct net_if *iface, struct net_stats *data)
 	       GET_STAT(iface, tcp.connrst));
 #endif
 
-	printk("Bytes received %u\n", GET_STAT(iface, bytes.received));
-	printk("Bytes sent     %u\n", GET_STAT(iface, bytes.sent));
+	printk("Bytes received %llu\n", GET_STAT(iface, bytes.received));
+	printk("Bytes sent     %llu\n", GET_STAT(iface, bytes.sent));
 	printk("Processing err %u\n", GET_STAT(iface, processing_error));
 }
 
@@ -141,8 +141,8 @@ static void print_eth_stats(struct net_if *iface, struct net_stats_eth *data)
 	printk("Statistics for Ethernet interface %p [%d]\n", iface,
 	       net_if_get_by_iface(iface));
 
-	printk("Bytes received   : %u\n", data->bytes.received);
-	printk("Bytes sent       : %u\n", data->bytes.sent);
+	printk("Bytes received   : %llu\n", data->bytes.received);
+	printk("Bytes sent       : %llu\n", data->bytes.sent);
 	printk("Packets received : %u\n", data->pkts.rx);
 	printk("Packets sent     : %u\n", data->pkts.tx);
 	printk("Bcast received   : %u\n", data->broadcast.rx);

--- a/samples/net/stats/src/main.c
+++ b/samples/net/stats/src/main.c
@@ -32,25 +32,25 @@ static void print_stats(struct net_if *iface, struct net_stats *data)
 	}
 
 #if defined(CONFIG_NET_IPV6)
-	printk("IPv6 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d\n",
+	printk("IPv6 recv      %u\tsent\t%u\tdrop\t%u\tforwarded\t%u\n",
 	       GET_STAT(iface, ipv6.recv),
 	       GET_STAT(iface, ipv6.sent),
 	       GET_STAT(iface, ipv6.drop),
 	       GET_STAT(iface, ipv6.forwarded));
 #if defined(CONFIG_NET_IPV6_ND)
-	printk("IPv6 ND recv   %d\tsent\t%d\tdrop\t%d\n",
+	printk("IPv6 ND recv   %u\tsent\t%u\tdrop\t%u\n",
 	       GET_STAT(iface, ipv6_nd.recv),
 	       GET_STAT(iface, ipv6_nd.sent),
 	       GET_STAT(iface, ipv6_nd.drop));
 #endif /* CONFIG_NET_IPV6_ND */
 #if defined(CONFIG_NET_IPV6_PMTU)
-	printk("IPv6 PMTU recv %d\tsent\t%d\tdrop\t%d\n",
+	printk("IPv6 PMTU recv %u\tsent\t%u\tdrop\t%u\n",
 	       GET_STAT(iface, ipv6_pmtu.recv),
 	       GET_STAT(iface, ipv6_pmtu.sent),
 	       GET_STAT(iface, ipv6_pmtu.drop));
 #endif /* CONFIG_NET_IPV6_PMTU */
 #if defined(CONFIG_NET_STATISTICS_MLD)
-	printk("IPv6 MLD recv  %d\tsent\t%d\tdrop\t%d\n",
+	printk("IPv6 MLD recv  %u\tsent\t%u\tdrop\t%u\n",
 	       GET_STAT(iface, ipv6_mld.recv),
 	       GET_STAT(iface, ipv6_mld.sent),
 	       GET_STAT(iface, ipv6_mld.drop));
@@ -58,70 +58,70 @@ static void print_stats(struct net_if *iface, struct net_stats *data)
 #endif /* CONFIG_NET_IPV6 */
 
 #if defined(CONFIG_NET_IPV4)
-	printk("IPv4 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d\n",
+	printk("IPv4 recv      %u\tsent\t%u\tdrop\t%u\tforwarded\t%u\n",
 	       GET_STAT(iface, ipv4.recv),
 	       GET_STAT(iface, ipv4.sent),
 	       GET_STAT(iface, ipv4.drop),
 	       GET_STAT(iface, ipv4.forwarded));
 #endif /* CONFIG_NET_IPV4 */
 
-	printk("IP vhlerr      %d\thblener\t%d\tlblener\t%d\n",
+	printk("IP vhlerr      %u\thblener\t%u\tlblener\t%u\n",
 	       GET_STAT(iface, ip_errors.vhlerr),
 	       GET_STAT(iface, ip_errors.hblenerr),
 	       GET_STAT(iface, ip_errors.lblenerr));
-	printk("IP fragerr     %d\tchkerr\t%d\tprotoer\t%d\n",
+	printk("IP fragerr     %u\tchkerr\t%u\tprotoer\t%u\n",
 	       GET_STAT(iface, ip_errors.fragerr),
 	       GET_STAT(iface, ip_errors.chkerr),
 	       GET_STAT(iface, ip_errors.protoerr));
 
 #if defined(CONFIG_NET_IPV4_PMTU)
-	printk("IPv4 PMTU recv %d\tsent\t%d\tdrop\t%d\n",
+	printk("IPv4 PMTU recv %u\tsent\t%u\tdrop\t%u\n",
 	       GET_STAT(iface, ipv4_pmtu.recv),
 	       GET_STAT(iface, ipv4_pmtu.sent),
 	       GET_STAT(iface, ipv4_pmtu.drop));
 #endif /* CONFIG_NET_IPV4_PMTU */
 
-	printk("ICMP recv      %d\tsent\t%d\tdrop\t%d\n",
+	printk("ICMP recv      %u\tsent\t%u\tdrop\t%u\n",
 	       GET_STAT(iface, icmp.recv),
 	       GET_STAT(iface, icmp.sent),
 	       GET_STAT(iface, icmp.drop));
-	printk("ICMP typeer    %d\tchkerr\t%d\n",
+	printk("ICMP typeer    %u\tchkerr\t%u\n",
 	       GET_STAT(iface, icmp.typeerr),
 	       GET_STAT(iface, icmp.chkerr));
 
 #if defined(CONFIG_NET_UDP)
-	printk("UDP recv       %d\tsent\t%d\tdrop\t%d\n",
+	printk("UDP recv       %u\tsent\t%u\tdrop\t%u\n",
 	       GET_STAT(iface, udp.recv),
 	       GET_STAT(iface, udp.sent),
 	       GET_STAT(iface, udp.drop));
-	printk("UDP chkerr     %d\n",
+	printk("UDP chkerr     %u\n",
 	       GET_STAT(iface, udp.chkerr));
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP)
-	printk("TCP bytes recv %u\tsent\t%d\n",
+	printk("TCP bytes recv %u\tsent\t%u\n",
 	       GET_STAT(iface, tcp.bytes.received),
 	       GET_STAT(iface, tcp.bytes.sent));
-	printk("TCP seg recv   %d\tsent\t%d\tdrop\t%d\n",
+	printk("TCP seg recv   %u\tsent\t%u\tdrop\t%u\n",
 	       GET_STAT(iface, tcp.recv),
 	       GET_STAT(iface, tcp.sent),
 	       GET_STAT(iface, tcp.drop));
-	printk("TCP seg resent %d\tchkerr\t%d\tackerr\t%d\n",
+	printk("TCP seg resent %u\tchkerr\t%u\tackerr\t%u\n",
 	       GET_STAT(iface, tcp.resent),
 	       GET_STAT(iface, tcp.chkerr),
 	       GET_STAT(iface, tcp.ackerr));
-	printk("TCP seg rsterr %d\trst\t%d\tre-xmit\t%d\n",
+	printk("TCP seg rsterr %u\trst\t%u\tre-xmit\t%u\n",
 	       GET_STAT(iface, tcp.rsterr),
 	       GET_STAT(iface, tcp.rst),
 	       GET_STAT(iface, tcp.rexmit));
-	printk("TCP conn drop  %d\tconnrst\t%d\n",
+	printk("TCP conn drop  %u\tconnrst\t%u\n",
 	       GET_STAT(iface, tcp.conndrop),
 	       GET_STAT(iface, tcp.connrst));
 #endif
 
 	printk("Bytes received %u\n", GET_STAT(iface, bytes.received));
 	printk("Bytes sent     %u\n", GET_STAT(iface, bytes.sent));
-	printk("Processing err %d\n", GET_STAT(iface, processing_error));
+	printk("Processing err %u\n", GET_STAT(iface, processing_error));
 }
 
 #if defined(CONFIG_NET_STATISTICS_PER_INTERFACE)

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -152,7 +152,7 @@ static inline void stats(struct net_if *iface)
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP)
-		NET_INFO("TCP bytes recv %u\tsent\t%u",
+		NET_INFO("TCP bytes recv %llu\tsent\t%llu",
 			 GET_STAT(iface, tcp.bytes.received),
 			 GET_STAT(iface, tcp.bytes.sent));
 		NET_INFO("TCP seg recv   %u\tsent\t%u\tdrop\t%u",
@@ -172,8 +172,8 @@ static inline void stats(struct net_if *iface)
 			 GET_STAT(iface, tcp.connrst));
 #endif
 
-		NET_INFO("Bytes received %u", GET_STAT(iface, bytes.received));
-		NET_INFO("Bytes sent     %u", GET_STAT(iface, bytes.sent));
+		NET_INFO("Bytes received %llu", GET_STAT(iface, bytes.received));
+		NET_INFO("Bytes sent     %llu", GET_STAT(iface, bytes.sent));
 		NET_INFO("Processing err %u",
 			 GET_STAT(iface, processing_error));
 
@@ -183,7 +183,7 @@ static inline void stats(struct net_if *iface)
 		NET_INFO("TC  Priority\tSent pkts\tbytes");
 
 		for (i = 0; i < NET_TC_TX_COUNT; i++) {
-			NET_INFO("[%d] %s (%u)\t%u\t\t%u", i,
+			NET_INFO("[%d] %s (%u)\t%u\t\t%llu", i,
 				 priority2str(GET_STAT(iface,
 						       tc.sent[i].priority)),
 				 GET_STAT(iface, tc.sent[i].priority),
@@ -197,7 +197,7 @@ static inline void stats(struct net_if *iface)
 		NET_INFO("TC  Priority\tRecv pkts\tbytes");
 
 		for (i = 0; i < NET_TC_RX_COUNT; i++) {
-			NET_INFO("[%d] %s (%u)\t%u\t\t%u", i,
+			NET_INFO("[%d] %s (%u)\t%u\t\t%llu", i,
 				 priority2str(GET_STAT(iface,
 						       tc.recv[i].priority)),
 				 GET_STAT(iface, tc.recv[i].priority),

--- a/subsys/net/ip/net_stats.c
+++ b/subsys/net/ip/net_stats.c
@@ -85,25 +85,25 @@ static inline void stats(struct net_if *iface)
 		}
 
 #if defined(CONFIG_NET_STATISTICS_IPV6)
-		NET_INFO("IPv6 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d",
+		NET_INFO("IPv6 recv      %u\tsent\t%u\tdrop\t%u\tforwarded\t%u",
 			 GET_STAT(iface, ipv6.recv),
 			 GET_STAT(iface, ipv6.sent),
 			 GET_STAT(iface, ipv6.drop),
 			 GET_STAT(iface, ipv6.forwarded));
 #if defined(CONFIG_NET_STATISTICS_IPV6_ND)
-		NET_INFO("IPv6 ND recv   %d\tsent\t%d\tdrop\t%d",
+		NET_INFO("IPv6 ND recv   %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, ipv6_nd.recv),
 			 GET_STAT(iface, ipv6_nd.sent),
 			 GET_STAT(iface, ipv6_nd.drop));
 #endif /* CONFIG_NET_STATISTICS_IPV6_ND */
 #if defined(CONFIG_NET_STATISTICS_IPV6_PMTU)
-		NET_INFO("IPv6 PMTU recv %d\tsent\t%d\tdrop\t%d",
+		NET_INFO("IPv6 PMTU recv %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, ipv6_pmtu.recv),
 			 GET_STAT(iface, ipv6_pmtu.sent),
 			 GET_STAT(iface, ipv6_pmtu.drop));
 #endif /* CONFIG_NET_STATISTICS_IPV6_PMTU */
 #if defined(CONFIG_NET_STATISTICS_MLD)
-		NET_INFO("IPv6 MLD recv  %d\tsent\t%d\tdrop\t%d",
+		NET_INFO("IPv6 MLD recv  %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, ipv6_mld.recv),
 			 GET_STAT(iface, ipv6_mld.sent),
 			 GET_STAT(iface, ipv6_mld.drop));
@@ -111,70 +111,70 @@ static inline void stats(struct net_if *iface)
 #endif /* CONFIG_NET_STATISTICS_IPV6 */
 
 #if defined(CONFIG_NET_STATISTICS_IPV4)
-		NET_INFO("IPv4 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d",
+		NET_INFO("IPv4 recv      %u\tsent\t%u\tdrop\t%u\tforwarded\t%u",
 			 GET_STAT(iface, ipv4.recv),
 			 GET_STAT(iface, ipv4.sent),
 			 GET_STAT(iface, ipv4.drop),
 			 GET_STAT(iface, ipv4.forwarded));
 #endif /* CONFIG_NET_STATISTICS_IPV4 */
 
-		NET_INFO("IP vhlerr      %d\thblener\t%d\tlblener\t%d",
+		NET_INFO("IP vhlerr      %u\thblener\t%u\tlblener\t%u",
 			 GET_STAT(iface, ip_errors.vhlerr),
 			 GET_STAT(iface, ip_errors.hblenerr),
 			 GET_STAT(iface, ip_errors.lblenerr));
-		NET_INFO("IP fragerr     %d\tchkerr\t%d\tprotoer\t%d",
+		NET_INFO("IP fragerr     %u\tchkerr\t%u\tprotoer\t%u",
 			 GET_STAT(iface, ip_errors.fragerr),
 			 GET_STAT(iface, ip_errors.chkerr),
 			 GET_STAT(iface, ip_errors.protoerr));
 
 #if defined(CONFIG_NET_STATISTICS_IPV4_PMTU)
-		NET_INFO("IPv4 PMTU recv %d\tsent\t%d\tdrop\t%d",
+		NET_INFO("IPv4 PMTU recv %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, ipv4_pmtu.recv),
 			 GET_STAT(iface, ipv4_pmtu.sent),
 			 GET_STAT(iface, ipv4_pmtu.drop));
 #endif /* CONFIG_NET_STATISTICS_IPV4_PMTU */
 
-		NET_INFO("ICMP recv      %d\tsent\t%d\tdrop\t%d",
+		NET_INFO("ICMP recv      %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, icmp.recv),
 			 GET_STAT(iface, icmp.sent),
 			 GET_STAT(iface, icmp.drop));
-		NET_INFO("ICMP typeer    %d\tchkerr\t%d",
+		NET_INFO("ICMP typeer    %u\tchkerr\t%u",
 			 GET_STAT(iface, icmp.typeerr),
 			 GET_STAT(iface, icmp.chkerr));
 
 #if defined(CONFIG_NET_STATISTICS_UDP)
-		NET_INFO("UDP recv       %d\tsent\t%d\tdrop\t%d",
+		NET_INFO("UDP recv       %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, udp.recv),
 			 GET_STAT(iface, udp.sent),
 			 GET_STAT(iface, udp.drop));
-		NET_INFO("UDP chkerr     %d",
+		NET_INFO("UDP chkerr     %u",
 			 GET_STAT(iface, udp.chkerr));
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP)
-		NET_INFO("TCP bytes recv %u\tsent\t%d",
+		NET_INFO("TCP bytes recv %u\tsent\t%u",
 			 GET_STAT(iface, tcp.bytes.received),
 			 GET_STAT(iface, tcp.bytes.sent));
-		NET_INFO("TCP seg recv   %d\tsent\t%d\tdrop\t%d",
+		NET_INFO("TCP seg recv   %u\tsent\t%u\tdrop\t%u",
 			 GET_STAT(iface, tcp.recv),
 			 GET_STAT(iface, tcp.sent),
 			 GET_STAT(iface, tcp.drop));
-		NET_INFO("TCP seg resent %d\tchkerr\t%d\tackerr\t%d",
+		NET_INFO("TCP seg resent %u\tchkerr\t%u\tackerr\t%u",
 			 GET_STAT(iface, tcp.resent),
 			 GET_STAT(iface, tcp.chkerr),
 			 GET_STAT(iface, tcp.ackerr));
-		NET_INFO("TCP seg rsterr %d\trst\t%d\tre-xmit\t%d",
+		NET_INFO("TCP seg rsterr %u\trst\t%u\tre-xmit\t%u",
 			 GET_STAT(iface, tcp.rsterr),
 			 GET_STAT(iface, tcp.rst),
 			 GET_STAT(iface, tcp.rexmit));
-		NET_INFO("TCP conn drop  %d\tconnrst\t%d",
+		NET_INFO("TCP conn drop  %u\tconnrst\t%u",
 			 GET_STAT(iface, tcp.conndrop),
 			 GET_STAT(iface, tcp.connrst));
 #endif
 
 		NET_INFO("Bytes received %u", GET_STAT(iface, bytes.received));
 		NET_INFO("Bytes sent     %u", GET_STAT(iface, bytes.sent));
-		NET_INFO("Processing err %d",
+		NET_INFO("Processing err %u",
 			 GET_STAT(iface, processing_error));
 
 #if NET_TC_COUNT > 1
@@ -183,7 +183,7 @@ static inline void stats(struct net_if *iface)
 		NET_INFO("TC  Priority\tSent pkts\tbytes");
 
 		for (i = 0; i < NET_TC_TX_COUNT; i++) {
-			NET_INFO("[%d] %s (%d)\t%d\t\t%d", i,
+			NET_INFO("[%d] %s (%u)\t%u\t\t%u", i,
 				 priority2str(GET_STAT(iface,
 						       tc.sent[i].priority)),
 				 GET_STAT(iface, tc.sent[i].priority),
@@ -197,7 +197,7 @@ static inline void stats(struct net_if *iface)
 		NET_INFO("TC  Priority\tRecv pkts\tbytes");
 
 		for (i = 0; i < NET_TC_RX_COUNT; i++) {
-			NET_INFO("[%d] %s (%d)\t%d\t\t%d", i,
+			NET_INFO("[%d] %s (%u)\t%u\t\t%u", i,
 				 priority2str(GET_STAT(iface,
 						       tc.recv[i].priority)),
 				 GET_STAT(iface, tc.recv[i].priority),
@@ -213,7 +213,7 @@ static inline void stats(struct net_if *iface)
 		NET_INFO("Power management statistics:");
 		NET_INFO("Last suspend time: %u ms",
 			 GET_STAT(iface, pm.last_suspend_time));
-		NET_INFO("Got suspended %d times",
+		NET_INFO("Got suspended %u times",
 			 GET_STAT(iface, pm.suspend_count));
 		NET_INFO("Average suspend time: %u ms",
 			 (uint32_t)(GET_STAT(iface, pm.overall_suspend_time) /

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1562,8 +1562,8 @@ static void print_wifi_stats(struct net_if *iface, struct net_stats_wifi *data,
 	PR("Statistics for Wi-Fi interface %p [%d]\n", iface,
 	   net_if_get_by_iface(iface));
 
-	PR("Bytes received   : %u\n", data->bytes.received);
-	PR("Bytes sent       : %u\n", data->bytes.sent);
+	PR("Bytes received   : %llu\n", data->bytes.received);
+	PR("Bytes sent       : %llu\n", data->bytes.sent);
 	PR("Packets received : %u\n", data->pkts.rx);
 	PR("Packets sent     : %u\n", data->pkts.tx);
 	PR("Receive errors   : %u\n", data->errors.rx);

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -50,8 +50,8 @@ static void print_eth_stats(struct net_if *iface, struct net_stats_eth *data,
 	PR("Statistics for Ethernet interface %p [%d]\n", iface,
 	       net_if_get_by_iface(iface));
 
-	PR("Bytes received   : %u\n", data->bytes.received);
-	PR("Bytes sent       : %u\n", data->bytes.sent);
+	PR("Bytes received   : %llu\n", data->bytes.received);
+	PR("Bytes sent       : %llu\n", data->bytes.sent);
 	PR("Packets received : %u\n", data->pkts.rx);
 	PR("Packets sent     : %u\n", data->pkts.tx);
 	PR("Bcast received   : %u\n", data->broadcast.rx);
@@ -315,13 +315,13 @@ static void print_tc_tx_stats(const struct shell *sh, struct net_if *iface)
 		net_stats_t count = GET_STAT(iface,
 					     tc.sent[i].tx_time.count);
 		if (count == 0) {
-			PR("[%d] %s (%u)\t%u\t\t%u\t-\n", i,
+			PR("[%d] %s (%u)\t%u\t\t%llu\t-\n", i,
 			   priority2str(GET_STAT(iface, tc.sent[i].priority)),
 			   GET_STAT(iface, tc.sent[i].priority),
 			   GET_STAT(iface, tc.sent[i].pkts),
 			   GET_STAT(iface, tc.sent[i].bytes));
 		} else {
-			PR("[%d] %s (%u)\t%u\t\t%u\t%u us%s\n", i,
+			PR("[%d] %s (%u)\t%u\t\t%llu\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.sent[i].priority)),
 			   GET_STAT(iface, tc.sent[i].priority),
 			   GET_STAT(iface, tc.sent[i].pkts),
@@ -336,7 +336,7 @@ static void print_tc_tx_stats(const struct shell *sh, struct net_if *iface)
 	PR("TC  Priority\tSent pkts\tbytes\n");
 
 	for (i = 0; i < NET_TC_TX_COUNT; i++) {
-		PR("[%d] %s (%u)\t%u\t\t%u\n", i,
+		PR("[%d] %s (%u)\t%u\t\t%llu\n", i,
 		   priority2str(GET_STAT(iface, tc.sent[i].priority)),
 		   GET_STAT(iface, tc.sent[i].priority),
 		   GET_STAT(iface, tc.sent[i].pkts),
@@ -374,14 +374,14 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 		net_stats_t count = GET_STAT(iface,
 					     tc.recv[i].rx_time.count);
 		if (count == 0) {
-			PR("[%d] %s (%u)\t%u\t%u\t\t%u\t-\n", i,
+			PR("[%d] %s (%u)\t%u\t%u\t\t%llu\t-\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
 			   GET_STAT(iface, tc.recv[i].dropped),
 			   GET_STAT(iface, tc.recv[i].bytes));
 		} else {
-			PR("[%d] %s (%u)\t%u\t%u\t\t%u\t%u us%s\n", i,
+			PR("[%d] %s (%u)\t%u\t%u\t\t%llu\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
@@ -397,7 +397,7 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 	PR("TC  Priority\tRecv pkts\tDrop pkts\tbytes\n");
 
 	for (i = 0; i < NET_TC_RX_COUNT; i++) {
-		PR("[%d] %s (%u)\t%u\t%u\t\t%u\n", i,
+		PR("[%d] %s (%u)\t%u\t%u\t\t%llu\n", i,
 		   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 		   GET_STAT(iface, tc.recv[i].priority),
 		   GET_STAT(iface, tc.recv[i].pkts),
@@ -533,7 +533,7 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP) && defined(CONFIG_NET_NATIVE_TCP)
-	PR("TCP bytes recv %u\tsent\t%u\tresent\t%u\n",
+	PR("TCP bytes recv %llu\tsent\t%llu\tresent\t%u\n",
 	   GET_STAT(iface, tcp.bytes.received),
 	   GET_STAT(iface, tcp.bytes.sent),
 	   GET_STAT(iface, tcp.resent));
@@ -575,8 +575,8 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	   GET_STAT(iface, pkt_filter.tx.drop));
 #endif /* CONFIG_NET_STATISTICS_DNS */
 
-	PR("Bytes received %u\n", GET_STAT(iface, bytes.received));
-	PR("Bytes sent     %u\n", GET_STAT(iface, bytes.sent));
+	PR("Bytes received %llu\n", GET_STAT(iface, bytes.received));
+	PR("Bytes sent     %llu\n", GET_STAT(iface, bytes.sent));
 	PR("Processing err %u\n", GET_STAT(iface, processing_error));
 
 	print_tc_tx_stats(sh, iface);

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -315,13 +315,13 @@ static void print_tc_tx_stats(const struct shell *sh, struct net_if *iface)
 		net_stats_t count = GET_STAT(iface,
 					     tc.sent[i].tx_time.count);
 		if (count == 0) {
-			PR("[%d] %s (%d)\t%d\t\t%d\t-\n", i,
+			PR("[%d] %s (%u)\t%u\t\t%u\t-\n", i,
 			   priority2str(GET_STAT(iface, tc.sent[i].priority)),
 			   GET_STAT(iface, tc.sent[i].priority),
 			   GET_STAT(iface, tc.sent[i].pkts),
 			   GET_STAT(iface, tc.sent[i].bytes));
 		} else {
-			PR("[%d] %s (%d)\t%d\t\t%d\t%u us%s\n", i,
+			PR("[%d] %s (%u)\t%u\t\t%u\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.sent[i].priority)),
 			   GET_STAT(iface, tc.sent[i].priority),
 			   GET_STAT(iface, tc.sent[i].pkts),
@@ -336,7 +336,7 @@ static void print_tc_tx_stats(const struct shell *sh, struct net_if *iface)
 	PR("TC  Priority\tSent pkts\tbytes\n");
 
 	for (i = 0; i < NET_TC_TX_COUNT; i++) {
-		PR("[%d] %s (%d)\t%d\t\t%d\n", i,
+		PR("[%d] %s (%u)\t%u\t\t%u\n", i,
 		   priority2str(GET_STAT(iface, tc.sent[i].priority)),
 		   GET_STAT(iface, tc.sent[i].priority),
 		   GET_STAT(iface, tc.sent[i].pkts),
@@ -374,14 +374,14 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 		net_stats_t count = GET_STAT(iface,
 					     tc.recv[i].rx_time.count);
 		if (count == 0) {
-			PR("[%d] %s (%d)\t%d\t%d\t\t%d\t-\n", i,
+			PR("[%d] %s (%u)\t%u\t%u\t\t%u\t-\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
 			   GET_STAT(iface, tc.recv[i].dropped),
 			   GET_STAT(iface, tc.recv[i].bytes));
 		} else {
-			PR("[%d] %s (%d)\t%d\t%d\t\t%d\t%u us%s\n", i,
+			PR("[%d] %s (%u)\t%u\t%u\t\t%u\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
@@ -397,7 +397,7 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 	PR("TC  Priority\tRecv pkts\tDrop pkts\tbytes\n");
 
 	for (i = 0; i < NET_TC_RX_COUNT; i++) {
-		PR("[%d] %s (%d)\t%d\t%d\t\t%d\n", i,
+		PR("[%d] %s (%u)\t%u\t%u\t\t%u\n", i,
 		   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 		   GET_STAT(iface, tc.recv[i].priority),
 		   GET_STAT(iface, tc.recv[i].pkts),
@@ -459,25 +459,25 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 	}
 
 #if defined(CONFIG_NET_STATISTICS_IPV6) && defined(CONFIG_NET_NATIVE_IPV6)
-	PR("IPv6 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d\n",
+	PR("IPv6 recv      %u\tsent\t%u\tdrop\t%u\tforwarded\t%u\n",
 	   GET_STAT(iface, ipv6.recv),
 	   GET_STAT(iface, ipv6.sent),
 	   GET_STAT(iface, ipv6.drop),
 	   GET_STAT(iface, ipv6.forwarded));
 #if defined(CONFIG_NET_STATISTICS_IPV6_ND)
-	PR("IPv6 ND recv   %d\tsent\t%d\tdrop\t%d\n",
+	PR("IPv6 ND recv   %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, ipv6_nd.recv),
 	   GET_STAT(iface, ipv6_nd.sent),
 	   GET_STAT(iface, ipv6_nd.drop));
 #endif /* CONFIG_NET_STATISTICS_IPV6_ND */
 #if defined(CONFIG_NET_STATISTICS_IPV6_PMTU)
-	PR("IPv6 PMTU recv %d\tsent\t%d\tdrop\t%d\n",
+	PR("IPv6 PMTU recv %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, ipv6_pmtu.recv),
 	   GET_STAT(iface, ipv6_pmtu.sent),
 	   GET_STAT(iface, ipv6_pmtu.drop));
 #endif /* CONFIG_NET_STATISTICS_IPV6_PMTU */
 #if defined(CONFIG_NET_STATISTICS_MLD)
-	PR("IPv6 MLD recv  %d\tsent\t%d\tdrop\t%d\n",
+	PR("IPv6 MLD recv  %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, ipv6_mld.recv),
 	   GET_STAT(iface, ipv6_mld.sent),
 	   GET_STAT(iface, ipv6_mld.drop));
@@ -485,86 +485,86 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 #endif /* CONFIG_NET_STATISTICS_IPV6 */
 
 #if defined(CONFIG_NET_STATISTICS_IPV4) && defined(CONFIG_NET_NATIVE_IPV4)
-	PR("IPv4 recv      %d\tsent\t%d\tdrop\t%d\tforwarded\t%d\n",
+	PR("IPv4 recv      %u\tsent\t%u\tdrop\t%u\tforwarded\t%u\n",
 	   GET_STAT(iface, ipv4.recv),
 	   GET_STAT(iface, ipv4.sent),
 	   GET_STAT(iface, ipv4.drop),
 	   GET_STAT(iface, ipv4.forwarded));
 #endif /* CONFIG_NET_STATISTICS_IPV4 */
 
-	PR("IP vhlerr      %d\thblener\t%d\tlblener\t%d\n",
+	PR("IP vhlerr      %u\thblener\t%u\tlblener\t%u\n",
 	   GET_STAT(iface, ip_errors.vhlerr),
 	   GET_STAT(iface, ip_errors.hblenerr),
 	   GET_STAT(iface, ip_errors.lblenerr));
-	PR("IP fragerr     %d\tchkerr\t%d\tprotoer\t%d\n",
+	PR("IP fragerr     %u\tchkerr\t%u\tprotoer\t%u\n",
 	   GET_STAT(iface, ip_errors.fragerr),
 	   GET_STAT(iface, ip_errors.chkerr),
 	   GET_STAT(iface, ip_errors.protoerr));
 
 #if defined(CONFIG_NET_STATISTICS_IPV4_PMTU)
-	PR("IPv4 PMTU recv %d\tsent\t%d\tdrop\t%d\n",
+	PR("IPv4 PMTU recv %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, ipv4_pmtu.recv),
 	   GET_STAT(iface, ipv4_pmtu.sent),
 	   GET_STAT(iface, ipv4_pmtu.drop));
 #endif /* CONFIG_NET_STATISTICS_IPV4_PMTU */
 
 #if defined(CONFIG_NET_STATISTICS_ICMP) && defined(CONFIG_NET_NATIVE_IPV4)
-	PR("ICMP recv      %d\tsent\t%d\tdrop\t%d\n",
+	PR("ICMP recv      %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, icmp.recv),
 	   GET_STAT(iface, icmp.sent),
 	   GET_STAT(iface, icmp.drop));
-	PR("ICMP typeer    %d\tchkerr\t%d\n",
+	PR("ICMP typeer    %u\tchkerr\t%u\n",
 	   GET_STAT(iface, icmp.typeerr),
 	   GET_STAT(iface, icmp.chkerr));
 #endif
 #if defined(CONFIG_NET_STATISTICS_IGMP)
-	PR("IGMP recv      %d\tsent\t%d\tdrop\t%d\n",
+	PR("IGMP recv      %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, ipv4_igmp.recv),
 	   GET_STAT(iface, ipv4_igmp.sent),
 	   GET_STAT(iface, ipv4_igmp.drop));
 #endif /* CONFIG_NET_STATISTICS_IGMP */
 #if defined(CONFIG_NET_STATISTICS_UDP) && defined(CONFIG_NET_NATIVE_UDP)
-	PR("UDP recv       %d\tsent\t%d\tdrop\t%d\n",
+	PR("UDP recv       %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, udp.recv),
 	   GET_STAT(iface, udp.sent),
 	   GET_STAT(iface, udp.drop));
-	PR("UDP chkerr     %d\n",
+	PR("UDP chkerr     %u\n",
 	   GET_STAT(iface, udp.chkerr));
 #endif
 
 #if defined(CONFIG_NET_STATISTICS_TCP) && defined(CONFIG_NET_NATIVE_TCP)
-	PR("TCP bytes recv %u\tsent\t%d\tresent\t%d\n",
+	PR("TCP bytes recv %u\tsent\t%u\tresent\t%u\n",
 	   GET_STAT(iface, tcp.bytes.received),
 	   GET_STAT(iface, tcp.bytes.sent),
 	   GET_STAT(iface, tcp.resent));
-	PR("TCP seg recv   %d\tsent\t%d\tdrop\t%d\n",
+	PR("TCP seg recv   %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, tcp.recv),
 	   GET_STAT(iface, tcp.sent),
 	   GET_STAT(iface, tcp.seg_drop));
-	PR("TCP seg resent %d\tchkerr\t%d\tackerr\t%d\n",
+	PR("TCP seg resent %u\tchkerr\t%u\tackerr\t%u\n",
 	   GET_STAT(iface, tcp.rexmit),
 	   GET_STAT(iface, tcp.chkerr),
 	   GET_STAT(iface, tcp.ackerr));
-	PR("TCP seg rsterr %d\trst\t%d\n",
+	PR("TCP seg rsterr %u\trst\t%u\n",
 	   GET_STAT(iface, tcp.rsterr),
 	   GET_STAT(iface, tcp.rst));
-	PR("TCP conn drop  %d\tconnrst\t%d\n",
+	PR("TCP conn drop  %u\tconnrst\t%u\n",
 	   GET_STAT(iface, tcp.conndrop),
 	   GET_STAT(iface, tcp.connrst));
-	PR("TCP pkt drop   %d\n", GET_STAT(iface, tcp.drop));
+	PR("TCP pkt drop   %u\n", GET_STAT(iface, tcp.drop));
 #endif
 #if defined(CONFIG_NET_STATISTICS_DNS)
-	PR("DNS recv       %d\tsent\t%d\tdrop\t%d\n",
+	PR("DNS recv       %u\tsent\t%u\tdrop\t%u\n",
 	   GET_STAT(iface, dns.recv),
 	   GET_STAT(iface, dns.sent),
 	   GET_STAT(iface, dns.drop));
 #endif /* CONFIG_NET_STATISTICS_DNS */
 #if defined(CONFIG_NET_STATISTICS_PKT_FILTER)
-	PR("Filter drop rx %d"
-	   IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV4_HOOK, ("\tIPv4\t%d"))
-	   IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV6_HOOK, ("\tIPv6\t%d"))
-	   IF_ENABLED(CONFIG_NET_PKT_FILTER_LOCAL_IN_HOOK, ("\tlocal\t%d"))
-	   "\ttx\t%d\n",
+	PR("Filter drop rx %u"
+	   IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV4_HOOK, ("\tIPv4\t%u"))
+	   IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV6_HOOK, ("\tIPv6\t%u"))
+	   IF_ENABLED(CONFIG_NET_PKT_FILTER_LOCAL_IN_HOOK, ("\tlocal\t%u"))
+	   "\ttx\t%u\n",
 	   GET_STAT(iface, pkt_filter.rx.drop),
 	   IF_ENABLED(CONFIG_NET_PKT_FILTER_IPV4_HOOK,
 		      (GET_STAT(iface, pkt_filter.rx.ipv4_drop),))
@@ -577,7 +577,7 @@ static void net_shell_print_statistics(struct net_if *iface, void *user_data)
 
 	PR("Bytes received %u\n", GET_STAT(iface, bytes.received));
 	PR("Bytes sent     %u\n", GET_STAT(iface, bytes.sent));
-	PR("Processing err %d\n", GET_STAT(iface, processing_error));
+	PR("Processing err %u\n", GET_STAT(iface, processing_error));
 
 	print_tc_tx_stats(sh, iface);
 	print_tc_rx_stats(sh, iface);


### PR DESCRIPTION
* Fix format specifiers used for printing stats
* Make byte counters 64-bits to prevent overflows