### PR TITLE
tests: littlefs: add mimxrt1020/4-evk support

### DIFF
--- a/tests/subsys/fs/littlefs/boards/mimxrt1020_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1020_evk.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&is25lp064 {
+	partitions {
+		large_partition: partition@400000 {
+			label = "large";
+			reg = <0x00400000 DT_SIZE_M(3)>;
+		};
+		medium_partition: partition@700000 {
+			label = "medium";
+			reg = <0x00700000 DT_SIZE_K(960)>;
+		};
+		small_partition: partition@7F0000 {
+			label = "small";
+			reg = <0x007F0000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/boards/mimxrt1024_evk.overlay
+++ b/tests/subsys/fs/littlefs/boards/mimxrt1024_evk.overlay
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&w25q32jvwj0 {
+	partitions {
+		small_partition: partition@3F0000 {
+			label = "small";
+			reg = <0x003F0000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/tests/subsys/fs/littlefs/testcase.yaml
+++ b/tests/subsys/fs/littlefs/testcase.yaml
@@ -11,6 +11,7 @@ common:
     - frdm_rw612
     - mimxrt1010_evk
     - mimxrt1015_evk
+    - mimxrt1020_evk
     - mimxrt1040_evk
     - mimxrt1050_evk/mimxrt1052/hyperflash
     - mimxrt1060_evk/mimxrt1062/qspi
@@ -42,6 +43,7 @@ tests:
       - lpcxpresso55s28
       - lpcxpresso55s36
       - lpcxpresso55s69/lpc55s69/cpu0
+      - mimxrt1024_evk
   filesystem.littlefs.custom:
     timeout: 180
     extra_configs:


### PR DESCRIPTION
Adds support for mimxrt1020-evk and mimxrt1024-evk boards to the littlefs test.