### PR TITLE
List DNS service records in net-shell

### DIFF
--- a/subsys/net/lib/dns/dns_sd.c
+++ b/subsys/net/lib/dns/dns_sd.c
@@ -297,6 +297,11 @@ bool rec_is_valid(const struct dns_sd_rec *inst)
 	;
 }
 
+bool dns_sd_rec_is_valid(const struct dns_sd_rec *rec)
+{
+	return rec_is_valid(rec);
+}
+
 int add_a_record(const struct dns_sd_rec *inst, uint32_t ttl,
 		 uint16_t host_offset, uint32_t addr, uint8_t *buf,
 		 uint16_t buf_offset, uint16_t buf_size)

--- a/subsys/net/lib/dns/dns_sd.h
+++ b/subsys/net/lib/dns/dns_sd.h
@@ -158,6 +158,13 @@ int dns_sd_handle_service_type_enum(const struct dns_sd_rec *service,
 	const struct in_addr *addr4, const struct in6_addr *addr6,
 	uint8_t *buf, uint16_t buf_size);
 
+/**
+ * @brief Check if DNS-SD record is a valid one.
+ *
+ * @param rec the record to check
+ */
+bool dns_sd_rec_is_valid(const struct dns_sd_rec *rec);
+
 #ifdef __cplusplus
 };
 #endif


### PR DESCRIPTION
Add a `net dns list` command to net-shell that will print out currently defined DNS service records.