### PR TITLE
dts: nxp: rt1024: fix jedec-id for on-chip flash

### DIFF
--- a/dts/arm/nxp/nxp_rt1024.dtsi
+++ b/dts/arm/nxp/nxp_rt1024.dtsi
@@ -42,13 +42,13 @@
 	status = "okay";
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(4)>;
 	/* 32 megabit internal flash present on chip */
-	w25q32jvwj0: w25q32jvwj0@0 {
+	w25q32jvwj0: w25q32jvwj@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <DT_SIZE_M(32)>;
+		size = <DT_SIZE_M(4 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
-		jedec-id = [9d 70 17];
+		jedec-id = [ef 40 16];
 		erase-block-size = <DT_SIZE_K(4)>;
 		write-block-size = <1>;
 	};


### PR DESCRIPTION
Fixes the JEDEC-ID value of the W25Q32JVWJ on-chip flash of RT1024. 
It was incorrectly set to the value for the different IS25WP064 chip.