### PR TITLE
Bluetooth: shell: Fix unchecked return value

### DIFF
--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -822,13 +822,20 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 	if (default_conn == conn) {
 		struct bt_conn_info info;
+		int err;
 		enum bt_conn_type conn_type = BT_CONN_TYPE_LE;
 
 		if (IS_ENABLED(CONFIG_BT_CLASSIC)) {
 			conn_type |= BT_CONN_TYPE_BR;
 		}
 
-		bt_conn_get_info(conn, &info);
+		err = bt_conn_get_info(conn, &info);
+		if (err != 0) {
+			bt_shell_error("Failed to get connection info (err %d)", err);
+			__ASSERT_NO_MSG(false);
+			return;
+		}
+
 		bt_conn_unref(default_conn);
 		default_conn = NULL;
 


### PR DESCRIPTION
Fixes Coverity issue due to unchecked return value of `bt_conn_get_info` in `disconnected()`.

The API bt_conn_get_info cannot return a failure, and to fix the Coverity issue we assert that now. For defensive programming, we also print an error and exit gracefully.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/90903