### PR TITLE
boards: google_quincy: Enable NPCX firmware header

### DIFF
--- a/boards/google/quincy/google_quincy_defconfig
+++ b/boards/google/quincy/google_quincy_defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Google Inc
 # SPDX-License-Identifier: Apache-2.0
 
+# Enable NPCX firmware header
+CONFIG_NPCX_HEADER=y
+
 # General Kernel Options
 CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=15000000
 


### PR DESCRIPTION
This commit enables the CONFIG_NPCX_HEADER option for the Google Quincy board. This is necessary to properly support the NPCX firmware header requirements on this platform, ensuring correct boot and firmware updates.