### PR TITLE
drivers: i2c: i2c_dw: drop cmsis_code include

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -8,7 +8,9 @@
  */
 
 #include <zephyr/arch/cpu.h>
+#ifdef CONFIG_CPU_CORTEX_M
 #include <cmsis_core.h>
+#endif
 #include <soc.h>
 
 #include <stddef.h>


### PR DESCRIPTION
Drop the cmsis_core.h include from the i2c_dw driver, not sure why this was added, does not feel like this should depend on it and it's causing a build failure in various intel platforms on the weekly CI.

Tested with

west build -p -b up_squared/apollo_lake tests/drivers/build_all/led (and others)