### PR TITLE
os: add __weak to to assert_print to allow customization

### DIFF
--- a/lib/os/assert.c
+++ b/lib/os/assert.c
@@ -44,7 +44,17 @@ __weak void assert_post_action(const char *file, unsigned int line)
 }
 EXPORT_SYMBOL(assert_post_action);
 
-void assert_print(const char *fmt, ...)
+/**
+ * @brief Assert Print Handler
+ *
+ * This routine implements printing the assertion message.
+ *
+ * System designers may wish to substitute this implementation to store the
+ * assertion, or otherwise change the behavior of the assertion print
+ *
+ * @param N/A
+ */
+__weak void assert_print(const char *fmt, ...)
 {
 	va_list ap;
 


### PR DESCRIPTION
System designers may want to change the behavior of assert_print, such as storing the message off into retained RAM and instantly rebooting. Adding __weak allows customization