### PR TITLE
drivers: nxp_enet: Implement unique-mac property with HWINFO api

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -163,7 +163,7 @@
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
 	phy-handle = <&phy>;
-	zephyr,random-mac-address;
+	nxp,unique-mac;
 	phy-connection-type = "rmii";
 };
 

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -183,7 +183,7 @@ zephyr_lcdif: &lcdif {
 	pinctrl-0 = <&pinmux_enet>;
 	pinctrl-names = "default";
 	phy-handle = <&phy>;
-	zephyr,random-mac-address;
+	nxp,unique-mac;
 	phy-connection-type = "rmii";
 };
 

--- a/drivers/ethernet/Kconfig.nxp_enet
+++ b/drivers/ethernet/Kconfig.nxp_enet
@@ -4,6 +4,8 @@
 # Copyright 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
+DT_NXP_UNIQUE_MAC_PROP := nxp,unique-mac
+
 config ETH_NXP_ENET
 	bool "NXP ENET Ethernet driver"
 	default y
@@ -14,6 +16,7 @@ config ETH_NXP_ENET
 	select NET_POWER_MANAGEMENT if (PM_DEVICE && SOC_FAMILY_KINETIS)
 	select ETH_DSA_SUPPORT_DEPRECATED
 	select PINCTRL
+	select HWINFO if $(dt_compat_any_has_prop,$(DT_COMPAT_NXP_ENET_MAC),$(DT_NXP_UNIQUE_MAC_PROP),True)
 	help
 	  Enable NXP ENET Ethernet driver.
 

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -34,6 +34,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/hwinfo.h>
 
 #ifdef CONFIG_PTP_CLOCK
 #include <zephyr/drivers/ptp_clock.h>
@@ -640,12 +641,28 @@ static const struct device *eth_nxp_enet_get_phy(const struct device *dev)
 	return config->phy_dev;
 }
 
+/* we enable HWINFO from kconfig if the relevant DT prop is in the tree */
+#ifdef CONFIG_HWINFO
 /* Note this is not universally unique, it just is probably unique on a network */
 static inline void nxp_enet_unique_mac(uint8_t *mac_addr)
 {
-	uint32_t id = ETH_NXP_ENET_UNIQUE_ID;
+	uint8_t id_buf[3];
+	uint32_t id = 0;
+	int ret;
+
+	ret = hwinfo_get_device_id(id_buf, sizeof(id_buf));
+	if (ret == sizeof(id_buf)) {
+		id |= FIELD_PREP(0xFF0000, id_buf[2]);
+		id |= FIELD_PREP(0x00FF00, id_buf[1]);
+		id |= FIELD_PREP(0x0000FF, id_buf[0]);
+	} else {
+		/* Either implemented wrong, implemented insufficiently, or not at all */
+		/* This is fallback for platforms that don't have HWINFO properly */
+		id = ETH_NXP_ENET_UNIQUE_ID;
+	}
 
 	if (id == 0xFFFFFF) {
+		/* Allowed but should raise highest level error notice to user */
 		LOG_ERR("No unique MAC can be provided in this platform");
 	}
 
@@ -657,6 +674,9 @@ static inline void nxp_enet_unique_mac(uint8_t *mac_addr)
 	mac_addr[4] = FIELD_GET(0x00FF00, id);
 	mac_addr[5] = FIELD_GET(0x0000FF, id);
 }
+#else
+#define nxp_enet_unique_mac(...)
+#endif
 
 #ifdef CONFIG_SOC_FAMILY_NXP_IMXRT
 #include <fsl_ocotp.h>


### PR DESCRIPTION
Since the idea of the `nxp,unique-mac` property for this driver is that it will use some silicon ID for the lower 3 bytes of the mac address, and this is exactly what the hwinfo api can do, use this generic api to implement the driver. If the hwinfo is unimplemented, I kept the existing hardcoded values as a fallback.

Also, switched a couple in tree boards to be defined by default to use this property for testing coverage. One has HWINFO implemented (RW612) and one does not (RT1050).