### PR TITLE
drivers: video: common: avoid dead code in functions with retry

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -204,8 +204,9 @@ static int video_read_reg_retry(const struct i2c_dt_spec *i2c, uint8_t *buf_w, s
 			LOG_HEXDUMP_ERR(buf_w, size_w, "failed to write-read to I2C register");
 			return ret;
 		}
-
-		k_sleep(K_MSEC(1));
+		if (CONFIG_VIDEO_I2C_RETRY_NUM > 0) {
+			k_sleep(K_MSEC(1));
+		}
 	}
 
 	return 0;
@@ -274,8 +275,9 @@ static int video_write_reg_retry(const struct i2c_dt_spec *i2c, uint8_t *buf_w, 
 			LOG_HEXDUMP_ERR(buf_w, size, "failed to write to I2C register");
 			return ret;
 		}
-
-		k_sleep(K_MSEC(1));
+		if (CONFIG_VIDEO_I2C_RETRY_NUM > 0) {
+			k_sleep(K_MSEC(1));
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Here is a fix for:

- https://github.com/zephyrproject-rtos/zephyr/issues/90477
- https://github.com/zephyrproject-rtos/zephyr/issues/90478

Avoid `k_sleep()` never being called when `video_write_reg_retry()` and `video_read_reg_retry()` have a number of retry set to zero (default). The default number of retries being controlled by
`CONFIG_VIDEO_I2C_RETRY_NUM`.