### PR TITLE
Enable LPSPI CS testing

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -15,4 +15,12 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
+	transfer-delay = <100>;
+	sck-pcs-delay = <200>;
+	pcs-sck-delay = <200>;
+};
+
+&flexcomm1 {
+	interrupts = <36 1>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1050_evk_mimxrt1052_hyperflash.overlay
@@ -15,4 +15,8 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+
+	transfer-delay = <100>;
+	sck-pcs-delay = <200>;
+	pcs-sck-delay = <200>;
 };

--- a/tests/drivers/spi/spi_loopback/overlay-cs-loopback-gpio.overlay
+++ b/tests/drivers/spi/spi_loopback/overlay-cs-loopback-gpio.overlay
@@ -1,0 +1,11 @@
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
+/ {
+	zephyr,user {
+		/* Connect your SPI CS pin to the D8 pin to run the test */
+		cs-loopback-gpios = <&arduino_header>,
+				    <ARDUINO_HEADER_R3_D8>,
+				    <(GPIO_ACTIVE_LOW | GPIO_PUSH_PULL | GPIO_PULL_UP)>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -333,3 +333,10 @@ tests:
     extra_configs:
       - CONFIG_SPI_CC23X0_DMA_DRIVEN=y
       - CONFIG_SPI_ASYNC=n
+  drivers.spi.cs_loopback.disable_lpspi_dma:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="overlay-cs-loopback-gpio.overlay"
+    extra_configs:
+      - CONFIG_SPI_NXP_LPSPI_DMA=n
+    platform_allow:
+      - frdm_mcxn947/mcxn947/cpu0
+      - mimxrt1050_evk/mimxrt1052/hyperflash


### PR DESCRIPTION
Add overlay for arduino r3 for the CS testing enablement of the test.

Since I do not know the hardware range situations of all the vendors, for now I just put this as a platform_allow for two different version LPSPI platforms. RT1050 has LPSPI v1 and MCXN has LPSPI v2. 

Will depend on #90182 due to config changes name

Fixes #92200