### PR TITLE
arch: Use #include for isr_tables_swi.ld

### DIFF
--- a/arch/arm/core/swi_tables.ld
+++ b/arch/arm/core/swi_tables.ld
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-INCLUDE isr_tables_swi.ld
+#include "isr_tables_swi.ld"
 #endif

--- a/arch/arm64/core/swi_tables.ld
+++ b/arch/arm64/core/swi_tables.ld
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-INCLUDE isr_tables_swi.ld
+#include "isr_tables_swi.ld"
 #endif

--- a/arch/riscv/core/swi_tables.ld
+++ b/arch/riscv/core/swi_tables.ld
@@ -5,5 +5,5 @@
  */
 
 #if LINKER_ZEPHYR_FINAL && defined(CONFIG_ISR_TABLES_LOCAL_DECLARATION)
-INCLUDE isr_tables_swi.ld
+#include "isr_tables_swi.ld"
 #endif


### PR DESCRIPTION
We're already using the C preprocessor to decide whether to include
isr_tables_swi.ld. Use #include instead of INCLUDE for consistency and
to avoid potential issues where include paths passed to the the linker
and compiler are not in sync.