### PR TITLE
samples: sysbuild: with_mcuboot: Add rpi_pico/w support

### DIFF
--- a/samples/sysbuild/with_mcuboot/boards/rpi_pico.overlay
+++ b/samples/sysbuild/with_mcuboot/boards/rpi_pico.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Beechwoods Software Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &code_partition;
+
+#include <raspberrypi/partitions_2M_sysbuild.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};

--- a/samples/sysbuild/with_mcuboot/boards/rpi_pico_rp2040_w.overlay
+++ b/samples/sysbuild/with_mcuboot/boards/rpi_pico_rp2040_w.overlay
@@ -1,0 +1,1 @@
+#include "rpi_pico.overlay"

--- a/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/app.overlay
+++ b/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/app.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/boards/rpi_pico.overlay
+++ b/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/boards/rpi_pico.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Beechwoods Software Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &code_partition;
+
+#include <raspberrypi/partitions_2M_sysbuild.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/boards/rpi_pico_rp2040_w.overlay
+++ b/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/boards/rpi_pico_rp2040_w.overlay
@@ -1,0 +1,1 @@
+#include "rpi_pico.overlay"

--- a/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/prj.conf
+++ b/samples/sysbuild/with_mcuboot/sysbuild/mcuboot/prj.conf
@@ -1,0 +1,19 @@
+CONFIG_PM=n
+
+CONFIG_MAIN_STACK_SIZE=10240
+
+CONFIG_BOOT_ENCRYPT_IMAGE=n
+
+CONFIG_BOOT_UPGRADE_ONLY=n
+
+CONFIG_FLASH=y
+
+CONFIG_LOG=y
+### Ensure Zephyr logging changes don't use more resources
+CONFIG_LOG_DEFAULT_LEVEL=0
+### Use info log level by default
+CONFIG_MCUBOOT_LOG_LEVEL_INF=y
+### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
+CONFIG_CBPRINTF_NANO=y
+### Use the minimal C library to reduce flash usage
+CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Add rpi_pico and rpi_pico/rp2040/w support with the overlay for the app and the SysBuild config for the mcuboot build.