### PR TITLE
nvs: also support sector_size of 64KB

### DIFF
--- a/include/zephyr/fs/nvs.h
+++ b/include/zephyr/fs/nvs.h
@@ -48,7 +48,7 @@ struct nvs_fs {
 	/** Data write address */
 	uint32_t data_wra;
 	/** File system is split into sectors, each sector must be multiple of erase-block-size */
-	uint16_t sector_size;
+	uint32_t sector_size;
 	/** Number of sectors in the file system */
 	uint16_t sector_count;
 	/** Flag indicating if the file system is initialized */

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -1025,6 +1025,13 @@ int nvs_mount(struct nvs_fs *fs)
 		return -EINVAL;
 	}
 
+	/* check that sector size is not greater than max */
+	if (fs->sector_size > NVS_MAX_SECTOR_SIZE) {
+		LOG_ERR("Sector size %u too large, maximum is %zu",
+			fs->sector_size, NVS_MAX_SECTOR_SIZE);
+		return -EINVAL;
+	}
+
 	/* check that sector size is a multiple of pagesize */
 	rc = flash_get_page_info_by_offs(fs->flash_device, fs->offset, &info);
 	if (rc) {

--- a/subsys/fs/nvs/nvs_priv.h
+++ b/subsys/fs/nvs/nvs_priv.h
@@ -21,6 +21,8 @@ extern "C" {
 #define ADDR_SECT_SHIFT 16
 #define ADDR_OFFS_MASK 0x0000FFFF
 
+#define NVS_MAX_SECTOR_SIZE KB(64)
+
 /*
  * Status return values
  */

--- a/tests/subsys/fs/nvs/boards/native_sim_64kb_erase_block.overlay
+++ b/tests/subsys/fs/nvs/boards/native_sim_64kb_erase_block.overlay
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	erase-block-size = <0x10000>;
+
+	/*
+	 * Delete old partitions that were not aligned on 64kb addresses and
+	 * create new ones that are aligned.
+	 */
+	/delete-node/ partitions;
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00070000>;
+		};
+		slot1_partition: partition@80000 {
+			label = "image-1";
+			reg = <0x00080000 0x00070000>;
+		};
+		scratch_partition: partition@f0000 {
+			label = "image-scratch";
+			reg = <0x000f0000 0x00020000>;
+		};
+		storage_partition: partition@110000 {
+			label = "storage";
+			reg = <0x00110000 0x00050000>;
+		};
+	};
+};

--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -28,3 +28,6 @@ tests:
       - CONFIG_NVS_LOOKUP_CACHE=y
       - CONFIG_NVS_LOOKUP_CACHE_SIZE=64
     platform_allow: native_sim
+  filesystem.nvs.64kb_erase_block:
+    extra_args: DTC_OVERLAY_FILE=boards/native_sim_64kb_erase_block.overlay
+    platform_allow: native_sim


### PR DESCRIPTION
Allows NVS to work with flash device configured to use only 64KB block erase.