### PR TITLE
drivers: usb_dc_mcux: disable irq in detach

### DIFF
--- a/drivers/usb/device/usb_dc_mcux.c
+++ b/drivers/usb/device/usb_dc_mcux.c
@@ -226,6 +226,7 @@ int usb_dc_detach(void)
 		return -EIO;
 	}
 
+	irq_disable(DT_INST_IRQN(0));
 	status = dev_state.dev_struct.controllerInterface->deviceDeinit(
 						   dev_state.dev_struct.controllerHandle);
 	if (kStatus_USB_Success != status) {


### PR DESCRIPTION
Otherwise the next attach could have the ISR invoked before init has completely initialized all the required data structures to handle the ISR properly.