### PR TITLE
soc: espressif: riscv: disable local isr location

### DIFF
--- a/soc/espressif/common/Kconfig.defconfig
+++ b/soc/espressif/common/Kconfig.defconfig
@@ -12,6 +12,9 @@ config GEN_SW_ISR_TABLE
 config GEN_IRQ_VECTOR_TABLE
 	default n
 
+config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
+	default n
+
 config DYNAMIC_INTERRUPTS
 	default y if !SOC_ESP32C6_LPCORE
 


### PR DESCRIPTION
Disable support to local ISR declaration on Espressif SoCs. Code relocation is not yet supported, causing build fail.

Espressif build for risc-v SoCs is now failing due to #91018. Use this workaround to fix the issue and keep ISR location feature as not-supported for now.