### PR TITLE
driver: gpio: esp32: move config to iram

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -93,7 +93,7 @@ static inline bool gpio_pin_is_output_capable(uint32_t pin)
 	return ((BIT(pin) & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) != 0);
 }
 
-static int gpio_esp32_config(const struct device *dev,
+static int IRAM_ATTR gpio_esp32_config(const struct device *dev,
 			     gpio_pin_t pin,
 			     gpio_flags_t flags)
 {


### PR DESCRIPTION
Make gpio configuration in IRAM area to speed up
access.