### PR TITLE
net: lwm2m: ipso: accelerometer: remove buffers for optional resources

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -502,6 +502,14 @@ Networking
   the previously used ``NET_REQUEST_ETHERNET_GET_QAV_PARAM`` and
   ``NET_REQUEST_ETHERNET_GET_QAV_PARAM`` options.
 
+LwM2M
+=====
+
+* Accelerometer object: optional resources Y value, Z value, min range value,
+  max range value can now be used optionally as per the accelerometer object's
+  specification. Users of these resources will now need to provide a read
+  buffer.
+
 OpenThread
 ==========
 

--- a/subsys/net/lib/lwm2m/ipso_accelerometer.c
+++ b/subsys/net/lib/lwm2m/ipso_accelerometer.c
@@ -43,10 +43,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 /* resource state */
 struct ipso_accel_data {
 	double x_value;
-	double y_value;
-	double z_value;
-	double min_range;
-	double max_range;
 };
 
 static struct ipso_accel_data accel_data[MAX_INSTANCE_COUNT];
@@ -108,20 +104,12 @@ static struct lwm2m_engine_obj_inst *accel_create(uint16_t obj_inst_id)
 	INIT_OBJ_RES_DATA(X_VALUE_RID, res[avail], i, res_inst[avail], j,
 			  &accel_data[avail].x_value,
 			  sizeof(accel_data[avail].x_value));
-	INIT_OBJ_RES_DATA(Y_VALUE_RID, res[avail], i, res_inst[avail], j,
-			  &accel_data[avail].y_value,
-			  sizeof(accel_data[avail].y_value));
-	INIT_OBJ_RES_DATA(Z_VALUE_RID, res[avail], i, res_inst[avail], j,
-			  &accel_data[avail].z_value,
-			  sizeof(accel_data[avail].z_value));
+	INIT_OBJ_RES_OPTDATA(Y_VALUE_RID, res[avail], i, res_inst[avail], j);
+	INIT_OBJ_RES_OPTDATA(Z_VALUE_RID, res[avail], i, res_inst[avail], j);
 	INIT_OBJ_RES_OPTDATA(SENSOR_UNITS_RID, res[avail], i,
 			     res_inst[avail], j);
-	INIT_OBJ_RES_DATA(MIN_RANGE_VALUE_RID, res[avail], i, res_inst[avail],
-			  j, &accel_data[avail].min_range,
-			  sizeof(accel_data[avail].min_range));
-	INIT_OBJ_RES_DATA(MAX_RANGE_VALUE_RID, res[avail], i, res_inst[avail],
-			  j, &accel_data[avail].max_range,
-			  sizeof(accel_data[avail].max_range));
+	INIT_OBJ_RES_OPTDATA(MIN_RANGE_VALUE_RID, res[avail], i, res_inst[avail], j);
+	INIT_OBJ_RES_OPTDATA(MAX_RANGE_VALUE_RID, res[avail], i, res_inst[avail], j);
 #if defined(CONFIG_LWM2M_IPSO_ACCELEROMETER_VERSION_1_1)
 	INIT_OBJ_RES_OPTDATA(APPLICATION_TYPE_RID, res[avail], i,
 			     res_inst[avail], j);


### PR DESCRIPTION
Allows application code to control allocation of buffers of optional resources.

Y value, Z value, min range value, max range value resources are optional.