### PR TITLE
zephyr/linker: Move .tbss section back to ROMABLE_REGION

### DIFF
--- a/include/zephyr/linker/thread-local-storage.ld
+++ b/include/zephyr/linker/thread-local-storage.ld
@@ -11,7 +11,7 @@
 	SECTION_DATA_PROLOGUE(tbss,(NOLOAD),)
 	{
 		*(.tbss .tbss.* .gnu.linkonce.tb.* .tcommon);
-	} GROUP_ROM_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	/*
 	 * These needs to be outside of the tdata/tbss


### PR DESCRIPTION
Placing this in RAMABLE_REGION messes up the TLS offsets computed by the linker, presumably because it's not adjacent to the .tdata section.

In any case, it doesn't really matter as all we want the linker to do is compute offsets from the TLS base value for all .tdata and .tbss values.

This reverts part of #89577 which was breaking all TLS references.