### PR TITLE
drivers: video: fix null deref in video_get_csi_link_freq()

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -417,6 +417,10 @@ int64_t video_get_csi_link_freq(const struct device *dev, uint8_t bpp, uint8_t l
 		return -ERANGE;
 	}
 
+	if (ctrl_query.int_menu == NULL) {
+		return -EINVAL;
+	}
+
 	return (int64_t)ctrl_query.int_menu[ctrl.val];
 
 fallback:


### PR DESCRIPTION
Add null and bounds checks before accessing int_menu[ctrl.val].

CID: 525179
Fixes: #91244