### PR TITLE
maintainers.yml: Add path for LVGL samples

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5359,6 +5359,7 @@ West:
     - modules/lvgl/
     - tests/lib/gui/lvgl/
     - include/zephyr/dt-bindings/lvgl/
+    - samples/modules/lvgl/
   labels:
     - "area: LVGL"
 


### PR DESCRIPTION
Adds the path for the LVGL samples to the appropriate maintainer section.