### PR TITLE
drivers: video: fix uninitialized struct in ov9655_init()

### DIFF
--- a/drivers/video/mt9m114.c
+++ b/drivers/video/mt9m114.c
@@ -527,7 +527,11 @@ static int mt9m114_init_controls(const struct device *dev)
 static int mt9m114_init(const struct device *dev)
 {
 	const struct mt9m114_config *cfg = dev->config;
-	struct video_format fmt;
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_RGB565,
+		.width = 480,
+		.height = 272,
+	};
 	uint16_t val;
 	int ret;
 
@@ -559,11 +563,6 @@ static int mt9m114_init(const struct device *dev)
 		LOG_ERR("Unable to initialize mt9m114 config");
 		return ret;
 	}
-
-	/* Set default format to 480x272 RGB565 */
-	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
-	fmt.width = 480;
-	fmt.height = 272;
 
 	ret = mt9m114_set_fmt(dev, &fmt);
 	if (ret) {

--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -1324,7 +1324,7 @@ static int ov5640_init_controls(const struct device *dev)
 static int ov5640_init(const struct device *dev)
 {
 	const struct ov5640_config *cfg = dev->config;
-	struct video_format fmt;
+	struct video_format fmt = {0};
 	uint16_t chip_id;
 	int ret;
 

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -473,7 +473,11 @@ static int ov7670_init(const struct device *dev)
 	const struct ov7670_config *config = dev->config;
 	int ret, i;
 	uint8_t pid;
-	struct video_format fmt;
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_RGB565,
+		.width = 320,
+		.height = 240,
+	};
 	const struct ov7670_reg *reg;
 
 	if (!i2c_is_ready_dt(&config->bus)) {
@@ -547,10 +551,6 @@ static int ov7670_init(const struct device *dev)
 	/* Delay after reset */
 	k_msleep(5);
 
-	/* Set default camera format (QVGA, YUYV) */
-	fmt.pixelformat = VIDEO_PIX_FMT_RGB565;
-	fmt.width = 320;
-	fmt.height = 240;
 	ret = ov7670_set_fmt(dev, &fmt);
 	if (ret < 0) {
 		return ret;

--- a/drivers/video/ov9655.c
+++ b/drivers/video/ov9655.c
@@ -326,7 +326,12 @@ static int ov9655_get_fmt(const struct device *dev, struct video_format *fmt)
 static int ov9655_init(const struct device *dev)
 {
 	const struct ov9655_config *config = dev->config;
-	struct video_format fmt;
+	/* Set default camera format (QQVGA, YUYV) */
+	struct video_format fmt = {
+		.pixelformat = VIDEO_PIX_FMT_YUYV,
+		.width = 160,
+		.height = 120,
+	};
 	uint32_t pid;
 	int ret;
 
@@ -379,11 +384,6 @@ static int ov9655_init(const struct device *dev)
 		LOG_ERR("Incorrect product ID: 0x%04X", pid);
 		return -ENODEV;
 	}
-
-	/* Set default camera format (QQVGA, YUYV) */
-	fmt.pixelformat = VIDEO_PIX_FMT_YUYV;
-	fmt.width = 160;
-	fmt.height = 120;
 
 	return ov9655_set_fmt(dev, &fmt);
 }

--- a/drivers/video/video_emul_imager.c
+++ b/drivers/video/video_emul_imager.c
@@ -344,7 +344,11 @@ static int emul_imager_init_controls(const struct device *dev)
 
 int emul_imager_init(const struct device *dev)
 {
-	struct video_format fmt;
+	struct video_format fmt = {
+		.pixelformat = fmts[0].pixelformat,
+		.width = fmts[0].width_min,
+		.height = fmts[0].height_min,
+	};
 	uint8_t sensor_id;
 	int ret;
 
@@ -364,10 +368,6 @@ int emul_imager_init(const struct device *dev)
 		LOG_ERR("Could not set initial registers");
 		return ret;
 	}
-
-	fmt.pixelformat = fmts[0].pixelformat;
-	fmt.width = fmts[0].width_min;
-	fmt.height = fmts[0].height_min;
 
 	ret = emul_imager_set_fmt(dev, &fmt);
 	if (ret < 0) {


### PR DESCRIPTION
Zero-initialize fmt to fix Coverity CID 525180.

CID: 525180