### PR TITLE
drivers: i2s: stm32 sai add mclk-divider property

### DIFF
--- a/dts/bindings/i2s/st,stm32-sai.yaml
+++ b/dts/bindings/i2s/st,stm32-sai.yaml
@@ -25,17 +25,29 @@ properties:
   pinctrl-names:
     required: true
 
-  mclk-div-enable:
-    type: boolean
-    description: |
-      SAI NODIV property.
-      When property is not present, oversampling is enabled @ 256.
-
   mclk-enable:
     type: boolean
     description: |
       Master Clock Output function.
       An mck pin must be listed within pinctrl-0 when enabling this property.
+
+  mclk-divider:
+    type: string
+    default: "no-div"
+    description: |
+      Master Clock Divider Configuration.
+
+      When no-div property is present:
+      - MCKDIV = SAI_CK_x / (FS * (FRL + 1))
+      Otherwise:
+      - MCKDIV = SAI_CK_x / (FS * (OSR + 1) * 256)
+
+      When div-256 is present OSR is set to 0.
+      When div-512 is present OSR is set to 1.
+    enum:
+      - "no-div"
+      - "div-256"
+      - "div-512"
 
   synchronous:
     type: boolean

--- a/samples/drivers/i2s/output/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_u575zi_q.overlay
@@ -28,6 +28,6 @@
 	pinctrl-names = "default";
 	status = "okay";
 	mclk-enable;
-	mclk-div-enable;
+	mclk-divider = "div-256";
 	dma-names = "tx";
 };


### PR DESCRIPTION
This property enables the user to configure the Master Clock Divider
The property sets nodiv or osr value

 - If NODIV = 1 :
         MCKDIV[5:0] = SAI_CK_x / (FS * (FRL + 1))
 - Otherwise
         MCKDIV[5:0] = SAI_CK_x / (FS * (OSR + 1) * 256)