### PR TITLE
driver: timer: enable 64 bit cycle counter for MCUX_OS_TIMER

### DIFF
--- a/drivers/timer/Kconfig.mcux_os
+++ b/drivers/timer/Kconfig.mcux_os
@@ -8,6 +8,7 @@ config MCUX_OS_TIMER
 	default y
 	depends on DT_HAS_NXP_OS_TIMER_ENABLED
 	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	help
 	  This module implements a kernel device driver for the NXP OS
 	  event timer and provides the standard "system clock driver" interfaces.


### PR DESCRIPTION
Selects TIMER_HAS_64BIT_CYCLE_COUNTER as an dependency for MCUX_OS_TIMER This already is supported in the timer implementation in drivers/timer/mcux_os_timer.c