### PR TITLE
manifest lvgl: Update to fork with hotfix for Zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -302,7 +302,7 @@ manifest:
       revision: fb00b383072518c918e2258b0916c996f2d4eebe
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: cb85b35217e76a048276b63bca19e8ce7baeee08
+      revision: b03edc8e6282a963cd312cd0b409eb5ce263ea75
       path: modules/lib/gui/lvgl
     - name: mbedtls
       revision: 5f889934359deccf421554c7045a8381ef75298f


### PR DESCRIPTION
Update to fork from lvgl's master branch with the following fix:
* fix: ifdef function to avoid unused function build warning

Which fixes this issue being triggered in Zephyr's CI.