### PR TITLE
NXP imx95 add basic pm support

### DIFF
--- a/drivers/firmware/scmi/clk.c
+++ b/drivers/firmware/scmi/clk.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/firmware/scmi/clk.h>
 #include <string.h>
+#include <zephyr/kernel.h>
 
 /* TODO: if extended attributes are supported this should be moved
  * to the header file so that users will have access to it.
@@ -38,6 +39,7 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 	struct scmi_message msg, reply;
 	int ret;
 	struct scmi_clock_rate_set_reply reply_buffer;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto || !rate) {
@@ -57,7 +59,9 @@ int scmi_clock_rate_get(struct scmi_protocol *proto,
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}
@@ -75,6 +79,7 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 {
 	struct scmi_message msg, reply;
 	int status, ret;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto || !cfg) {
@@ -98,7 +103,9 @@ int scmi_clock_rate_set(struct scmi_protocol *proto, struct scmi_clock_rate_conf
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}
@@ -115,6 +122,7 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	struct scmi_message msg, reply;
 	int ret;
 	struct scmi_clock_parent_get_reply reply_buffer;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto || !parent_id) {
@@ -134,7 +142,9 @@ int scmi_clock_parent_get(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}
@@ -153,6 +163,7 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	struct scmi_clock_parent_config cfg = {.clk_id = clk_id, .parent_id = parent_id};
 	struct scmi_message msg, reply;
 	int status, ret;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto) {
@@ -172,7 +183,9 @@ int scmi_clock_parent_set(struct scmi_protocol *proto, uint32_t clk_id, uint32_t
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}
@@ -189,6 +202,7 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 {
 	struct scmi_message msg, reply;
 	int status, ret;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto || !cfg) {
@@ -223,7 +237,9 @@ int scmi_clock_config_set(struct scmi_protocol *proto,
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}
@@ -240,6 +256,7 @@ int scmi_clock_protocol_attributes(struct scmi_protocol *proto, uint32_t *attrib
 	struct scmi_message msg, reply;
 	struct scmi_clock_attributes_reply reply_buffer;
 	int ret;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto || !attributes) {
@@ -260,7 +277,9 @@ int scmi_clock_protocol_attributes(struct scmi_protocol *proto, uint32_t *attrib
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -51,3 +51,42 @@ int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg)
 
 	return 0;
 }
+
+int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_CPU_DOMAIN);
+	struct scmi_message msg, reply;
+	int status, ret;
+	bool use_polling;
+
+	/* sanity checks */
+	if (!proto || !cfg) {
+		return -EINVAL;
+	}
+
+	if (proto->id != SCMI_PROTOCOL_CPU_DOMAIN) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET, SCMI_COMMAND,
+					proto->id, 0x0);
+	msg.len = sizeof(*cfg);
+	msg.content = cfg;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	use_polling = true;
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (status != SCMI_SUCCESS) {
+		return scmi_status_to_errno(status);
+	}
+
+	return 0;
+}

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/drivers/firmware/scmi/pinctrl.h>
+#include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_pinctrl), NULL);
 
@@ -14,6 +15,7 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 	struct scmi_message msg, reply;
 	uint32_t config_num;
 	int32_t status, ret;
+	bool use_polling;
 
 	proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_PINCTRL);
 
@@ -50,7 +52,9 @@ int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/firmware/scmi/power.h>
 #include <string.h>
+#include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_power), NULL);
 
@@ -20,6 +21,7 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 	struct scmi_power_state_get_reply reply_buffer;
 	struct scmi_message msg, reply;
 	int ret;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto || !power_state) {
@@ -39,7 +41,9 @@ int scmi_power_state_get(uint32_t domain_id, uint32_t *power_state)
 	reply.len = sizeof(reply_buffer);
 	reply.content = &reply_buffer;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}
@@ -58,6 +62,7 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_POWER_DOMAIN);
 	struct scmi_message msg, reply;
 	int status, ret;
+	bool use_polling;
 
 	/* sanity checks */
 	if (!proto || !cfg) {
@@ -82,7 +87,9 @@ int scmi_power_state_set(struct scmi_power_state_config *cfg)
 	reply.len = sizeof(status);
 	reply.content = &status;
 
-	ret = scmi_send_message(proto, &msg, &reply);
+	use_polling = k_is_pre_kernel();
+
+	ret = scmi_send_message(proto, &msg, &reply, use_polling);
 	if (ret < 0) {
 		return ret;
 	}

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -15,9 +15,10 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-m7";
+			cpu-power-states = <&wait &stop &suspend>;
 			reg = <0>;
 
 			#address-cells = <1>;
@@ -26,6 +27,30 @@
 			mpu: mpu@e000ed90 {
 				compatible = "arm,armv7m-mpu";
 				reg = <0xe000ed90 0x40>;
+			};
+
+		};
+
+		power-states {
+			wait: power-state-wait {
+				compatible = "zephyr,power-state";
+				power-state-name = "runtime-idle";
+				min-residency-us = <100>;
+				exit-latency-us = <50>;
+			};
+
+			stop: power-state-stop {
+				compatible = "zephyr,power-state";
+				power-state-name = "suspend-to-idle";
+				min-residency-us = <1000>;
+				exit-latency-us = <200>;
+			};
+
+			suspend: power-state-suspend {
+				compatible = "zephyr,power-state";
+				power-state-name = "standby";
+				min-residency-us = <5000>;
+				exit-latency-us = <1000>;
 			};
 		};
 	};

--- a/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/cpu.h
@@ -21,6 +21,8 @@
 
 #define SCMI_PROTOCOL_CPU_DOMAIN 130
 
+#define SCMI_CPU_MAX_PDCONFIGS_T 7U
+
 /**
  * @struct scmi_cpu_sleep_mode_config
  *
@@ -31,6 +33,23 @@ struct scmi_cpu_sleep_mode_config {
 	uint32_t cpu_id;
 	uint32_t flags;
 	uint32_t sleep_mode;
+};
+
+struct scmi_pd_lpm_settings {
+	uint32_t domain_id;
+	uint32_t lpm_setting;
+	uint32_t ret_mask;
+};
+
+/**
+ * @struct scmi_cpu_pd_lpm_config
+ *
+ * @brief Describes cpu power domain low power mode setting
+ */
+struct scmi_cpu_pd_lpm_config {
+	uint32_t cpu_id;
+	uint32_t num_cfg;
+	struct scmi_pd_lpm_settings cfgs[SCMI_CPU_MAX_PDCONFIGS_T];
 };
 
 /**
@@ -64,4 +83,14 @@ enum scmi_cpu_domain_message {
  */
 int scmi_cpu_sleep_mode_set(struct scmi_cpu_sleep_mode_config *cfg);
 
+/**
+ * @brief Send the SCMI_CPU_DOMAIN_MSG_CPU_PD_LPM_CONFIG_SET command and get its reply
+ *
+ * @param cfg pointer to structure containing configuration
+ * to be set
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_cpu_pd_lpm_set(struct scmi_cpu_pd_lpm_config *cfg);
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_CPU_H_ */

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -115,8 +115,15 @@ int scmi_status_to_errno(int scmi_status);
  *
  * @retval 0 if successful
  * @retval negative errno if failure
+ * @param use_polling Specifies the communication mechanism used by the scmi
+ * platform to interact with agents.
+ * - true: Polling mode — the platform actively checks the message status
+ *   to determine if it has been processed
+ * - false: Interrupt mode — the platform relies on SCMI interrupts to
+ *   detect when a message has been handled.
  */
 int scmi_send_message(struct scmi_protocol *proto,
-		      struct scmi_message *msg, struct scmi_message *reply);
+		      struct scmi_message *msg, struct scmi_message *reply,
+		      bool use_polling);
 
 #endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_PROTOCOL_H_ */

--- a/soc/nxp/imx/imx9/imx95/Kconfig
+++ b/soc/nxp/imx/imx9/imx95/Kconfig
@@ -13,6 +13,7 @@ config SOC_MIMX9596_M7
 	select SOC_EARLY_INIT_HOOK
 	select HAS_MCUX
 	select HAS_MCUX_CACHE
+	select HAS_PM
 
 config SOC_MIMX9596_A55
 	select ARM64

--- a/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
+++ b/soc/nxp/imx/imx9/imx95/Kconfig.defconfig.mimx95.m7
@@ -50,5 +50,11 @@ config CACHE_MANAGEMENT
 
 config ETH_NXP_IMX_MSGINTR
 	default 2
+if PM
+# PM code that runs from the idle loop has a large
+# footprint. Hence increase the size when PM is enabled.
+config IDLE_STACK_SIZE
+	default 640
+endif
 
 endif # SOC_MIMX9596_M7

--- a/soc/nxp/imx/imx9/imx95/scmi_cpu_soc.h
+++ b/soc/nxp/imx/imx9/imx95/scmi_cpu_soc.h
@@ -23,4 +23,85 @@
 #define CPU_SLEEP_MODE_STOP     2U
 #define CPU_SLEEP_MODE_SUSPEND  3U
 
+/*!
+ * @name SCMI CPU LPM settings
+ */
+#define SCMI_CPU_LPM_SETTING_ON_NEVER          0U
+#define SCMI_CPU_LPM_SETTING_ON_RUN            1U
+#define SCMI_CPU_LPM_SETTING_ON_RUN_WAIT       2U
+#define SCMI_CPU_LPM_SETTING_ON_RUN_WAIT_STOP  3U
+#define SCMI_CPU_LPM_SETTING_ON_ALWAYS         4U
+
+#define CPU_PER_LPI_IDX_GPIO1           0U
+#define CPU_PER_LPI_IDX_GPIO2           1U
+#define CPU_PER_LPI_IDX_GPIO3           2U
+#define CPU_PER_LPI_IDX_GPIO4           3U
+#define CPU_PER_LPI_IDX_GPIO5           4U
+#define CPU_PER_LPI_IDX_CAN1            5U
+#define CPU_PER_LPI_IDX_CAN2            6U
+#define CPU_PER_LPI_IDX_CAN3            7U
+#define CPU_PER_LPI_IDX_CAN4            8U
+#define CPU_PER_LPI_IDX_CAN5            9U
+#define CPU_PER_LPI_IDX_LPUART1         10U
+#define CPU_PER_LPI_IDX_LPUART2         11U
+#define CPU_PER_LPI_IDX_LPUART3         12U
+#define CPU_PER_LPI_IDX_LPUART4         13U
+#define CPU_PER_LPI_IDX_LPUART5         14U
+#define CPU_PER_LPI_IDX_LPUART6         15U
+#define CPU_PER_LPI_IDX_LPUART7         16U
+#define CPU_PER_LPI_IDX_LPUART8         17U
+#define CPU_PER_LPI_IDX_WDOG3           18U
+#define CPU_PER_LPI_IDX_WDOG4           19U
+#define CPU_PER_LPI_IDX_WDOG5           20U
+
+
+/* MIX definitions */
+#define PWR_NUM_MIX_SLICE               23U
+
+#define PWR_MIX_SLICE_IDX_ANA           0U
+#define PWR_MIX_SLICE_IDX_AON           1U
+#define PWR_MIX_SLICE_IDX_BBSM          2U
+#define PWR_MIX_SLICE_IDX_CAMERA        3U
+#define PWR_MIX_SLICE_IDX_CCMSRCGPC     4U
+#define PWR_MIX_SLICE_IDX_A55C0         5U
+#define PWR_MIX_SLICE_IDX_A55C1         6U
+#define PWR_MIX_SLICE_IDX_A55C2         7U
+#define PWR_MIX_SLICE_IDX_A55C3         8U
+#define PWR_MIX_SLICE_IDX_A55C4         9U
+#define PWR_MIX_SLICE_IDX_A55C5         10U
+#define PWR_MIX_SLICE_IDX_A55P          11U
+#define PWR_MIX_SLICE_IDX_DDR           12U
+#define PWR_MIX_SLICE_IDX_DISPLAY       13U
+#define PWR_MIX_SLICE_IDX_GPU           14U
+#define PWR_MIX_SLICE_IDX_HSIO_TOP      15U
+#define PWR_MIX_SLICE_IDX_HSIO_WAON     16U
+#define PWR_MIX_SLICE_IDX_M7            17U
+#define PWR_MIX_SLICE_IDX_NETC          18U
+#define PWR_MIX_SLICE_IDX_NOC           19U
+#define PWR_MIX_SLICE_IDX_NPU           20U
+#define PWR_MIX_SLICE_IDX_VPU           21U
+#define PWR_MIX_SLICE_IDX_WAKEUP        22U
+
+#define PWR_MEM_SLICE_IDX_AON           0U
+#define PWR_MEM_SLICE_IDX_CAMERA        1U
+#define PWR_MEM_SLICE_IDX_A55C0         2U
+#define PWR_MEM_SLICE_IDX_A55C1         3U
+#define PWR_MEM_SLICE_IDX_A55C2         4U
+#define PWR_MEM_SLICE_IDX_A55C3         5U
+#define PWR_MEM_SLICE_IDX_A55C4         6U
+#define PWR_MEM_SLICE_IDX_A55C5         7U
+#define PWR_MEM_SLICE_IDX_A55P          8U
+#define PWR_MEM_SLICE_IDX_A55L3         9U
+#define PWR_MEM_SLICE_IDX_DDR           10U
+#define PWR_MEM_SLICE_IDX_DISPLAY       11U
+#define PWR_MEM_SLICE_IDX_GPU           12U
+#define PWR_MEM_SLICE_IDX_HSIO          13U
+#define PWR_MEM_SLICE_IDX_M7            14U
+#define PWR_MEM_SLICE_IDX_NETC          15U
+#define PWR_MEM_SLICE_IDX_NOC1          16U
+#define PWR_MEM_SLICE_IDX_NOC2          17U
+#define PWR_MEM_SLICE_IDX_NPU           18U
+#define PWR_MEM_SLICE_IDX_VPU           19U
+#define PWR_MEM_SLICE_IDX_WAKEUP        20U
+
 #endif /* ZEPHYR_NXP_IMX95_SCMI_CPU_SOC_H_ */

--- a/tests/subsys/pm/power_mgmt_soc/testcase.yaml
+++ b/tests/subsys/pm/power_mgmt_soc/testcase.yaml
@@ -19,6 +19,7 @@ tests:
       - max32655fthr/max32655/m4
       - max32657evkit/max32657
       - max32657evkit/max32657/ns
+      - imx95_evk/mimx9596/m7
     tags: pm
     integration_platforms:
       - mec15xxevb_assy6853


### PR DESCRIPTION
added basic pm support for imx95 evk m7 board, verified it in power_mgmt_soc test case, based on this case, M7 can enter/exit wait/suspend mode as we expected.