### PR TITLE
i2c: npcx: Verify msg is not null

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -753,7 +753,7 @@ static void i2c_ctrl_handle_read_int_event(const struct device *dev)
 	}
 
 	/* Is the STOP condition issued? */
-	if ((data->msg->flags & I2C_MSG_STOP) != 0) {
+	if (data->msg != NULL && (data->msg->flags & I2C_MSG_STOP) != 0) {
 		/* Clear rx FIFO threshold and status bits */
 		i2c_ctrl_fifo_clear_status(dev);
 


### PR DESCRIPTION
When using target mode, we've found that some times the msg field can be null through some of the code paths of the interrupt event handler.

For reference (sorry, only partners can view this issue) https://partnerissuetracker.corp.google.com/issues/423483932 contains the crash logs and the test run with this fix.