### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 990b1fcb367e27056b282f183e819964fdbfe907
+      revision: 11982df962e2314f4e0c73b7ebc17172026c9266
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  11982df962e2314f4e0c73b7ebc17172026c9266

Brings following Zephyr relevant fixes:

  - 11982df9 boot: Switch to picolibc
  - ef7d68bf boot: zephyr: boards: delete mcxn947 configuration.
  - 47dc5086 boot: zephyr: update NXP MPU define to new name
  - 35536633 boot: bootutil: bootutil_misc: Fix max image size for single images
  - e8b22363 bootutil: Fix crash when bootutil_sha_init() is called in loop
  - 0eaf6668 boot: bootutil: Only update the security counter for confirmed images
  - 792d411d bootutil: encryption: Fix typo in PSA code
  - 2e605191 boot: bootutil: swap-offset: Fix image size check during validation
  - 61d280b9 boot: bootutil: Fix max image size computation for swap-move/swap-offset
  - 17b56a0a imgtool: fix verify tlv offset before main scan
  - 264f6ee9 boot/zephyr/main: fix placement of pointer to arm vector
  - c412cdfb bootutil: Improve HKDF code
  - 454cae8b bootutil: Remove BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE
  - 2367a607 bootutil: Improve defines in PSA encryption source
  - 3f458fea Bootutil: always initialise the size returned by boot_util_image_size()
  - 671513cb zephyr: nRF54l15_cpuapp configuration with LTO enabled

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.