### PR TITLE
MAINTAINERS.yml: add net/mii.h header to ethernet area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1460,6 +1460,7 @@ Release Notes:
     - tests/drivers/ethernet/
     - include/zephyr/drivers/ethernet/
     - include/zephyr/net/phy.h
+    - include/zephyr/net/mii.h
     - include/zephyr/net/ethernet.h
   labels:
     - "area: Ethernet"


### PR DESCRIPTION
add include/zephyr/net/mii.h header to ethernet area.

It is only used by ethernet phys.