### PR TITLE
soc: st: stm32n6: invoke signing tool in silent mode

### DIFF
--- a/soc/st/stm32/stm32n6x/CMakeLists.txt
+++ b/soc/st/stm32/stm32n6x/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
   set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     COMMAND ${SIGNING_TOOL}
     -in ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin
-    -nk -t fsbl -hv 2.3
+    -nk -t fsbl -hv 2.3 --silent
     -o ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.signed.bin
     -dump ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.signed.bin
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}


### PR DESCRIPTION
The STM32 signing tool (`STM32_SigningTool_CLI`) is invoked as a post-build command to generate a signed Zephyr binary, which is required to run from flash on N6 series. If the file specified as output already exists, the tool will by default prompt to confirm it should be overwritten. However, when invoked from the build system rather than a terminal, this prompt will break the build (freeze during the `Linking C executable 'zephyr.elf'` step). This can be seen by building the same application twice in a row, as the second build will not be different enough to make the build artifacts be deleted and thus the (old) signed image will be seen by the tool. (`ninja` will be seen with a quickly increasing memory consumption - presumably because the tool will keep on logging the `Do you want to overwrite zephyr.signed.bin? (y/n)` message and `ninja` buffers them?)

Invoke the tool in silent mode such that user is never prompted. This fixes build failures while still working as intended (if present, the existing signed image will get overwritten properly).