### PR TITLE
lib: min_heap: Remove swap() and use byte-wise element swap

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -82,6 +82,7 @@ ForEachMacros:
   - 'HTTP_SERVICE_FOREACH_RESOURCE'
   - 'I3C_BUS_FOR_EACH_I3CDEV'
   - 'I3C_BUS_FOR_EACH_I2CDEV'
+  - 'MIN_HEAP_FOREACH'
 IfMacros:
   - 'CHECKIF'
 # Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/48520

--- a/include/zephyr/sys/min_heap.h
+++ b/include/zephyr/sys/min_heap.h
@@ -220,23 +220,18 @@ static inline void *min_heap_get_element(const struct min_heap *heap,
  *
  * @param heap Pointer to the heap.
  * @param node_var The loop variable used to reference each node.
- * @param body Code block to execute for each node.
  *
  * Example:
  * ```
  * void *node;
- * MIN_HEAP_FOREACH(&heap, node, {
+ * MIN_HEAP_FOREACH(&heap, node) {
  *	printk("Value: %d\n", node->value);
- * });
+ * }
  * ```
  */
-#define MIN_HEAP_FOREACH(heap, node_var, body) \
-	do { for (size_t _i = 0; _i < (heap)->size && \
-		(((node_var) = min_heap_get_element((heap), _i)) || true); \
-		++_i) { \
-			body; \
-		} \
-	} while (0)
+#define MIN_HEAP_FOREACH(heap, node_var)                                                           \
+	for (size_t _i = 0;                                                                        \
+	     _i < (heap)->size && (((node_var) = min_heap_get_element((heap), _i)) || true); ++_i)
 
 /**
  * @}

--- a/include/zephyr/sys/min_heap.h
+++ b/include/zephyr/sys/min_heap.h
@@ -212,6 +212,8 @@ void *min_heap_find(struct min_heap *heap, min_heap_eq_t eq,
 static inline void *min_heap_get_element(const struct min_heap *heap,
 					  size_t index)
 {
+	__ASSERT_NO_MSG(heap != NULL);
+
 	return (void *)((uintptr_t)heap->storage + index * heap->elem_size);
 }
 

--- a/include/zephyr/sys/min_heap.h
+++ b/include/zephyr/sys/min_heap.h
@@ -66,17 +66,21 @@ struct min_heap {
 };
 
 /**
- * @brief Define and initialize a heap instance at runtime.
+ * @brief Define a min-heap instance.
  *
- * @param name Name of the heap variable.
- * @param storage Pointer to the preallocated storage.
+ * @param name Base name for the heap instance.
  * @param cap Capacity (number of elements).
- * @param size Size of each element.
- * @param cmp_func Comparator function for the heap.
+ * @param elem_sz Size in bytes of each element.
+ * @param align Required alignment of each element.
+ * @param cmp_func Comparator function used by the heap
  */
-#define MIN_HEAP_DEFINE(name, storage, cap, size, cmp_func) \
-	struct min_heap name; \
-	min_heap_init(&name, storage, cap, size, cmp_func)
+#define MIN_HEAP_DEFINE(name, cap, elem_sz, align, cmp_func)                                       \
+	static uint8_t name##_storage[(cap) * (elem_sz)] __aligned(align);                         \
+	struct min_heap name = {.storage = name##_storage,                                         \
+				.capacity = (cap),                                                 \
+				.elem_size = (elem_sz),                                            \
+				.size = 0,                                                         \
+				.cmp = (cmp_func)}
 
 /**
  * @brief Define a statically allocated and aligned min-heap instance.

--- a/samples/data_structures/min-heap/src/main.c
+++ b/samples/data_structures/min-heap/src/main.c
@@ -57,11 +57,11 @@ int main(void)
 	}
 
 	printk("Heap elements by order of priority:\n");
-	MIN_HEAP_FOREACH(&my_heap, elem, {
+	MIN_HEAP_FOREACH(&my_heap, elem) {
 		struct data *d = elem;
 
 		printk("key=%d value=%d\n", d->key, d->value);
-	});
+	}
 
 	printk("Top of heap: ");
 	top = min_heap_peek(&my_heap);
@@ -77,11 +77,11 @@ int main(void)
 	}
 
 	printk("Heap after removal:\n");
-	MIN_HEAP_FOREACH(&my_heap, elem, {
+	MIN_HEAP_FOREACH(&my_heap, elem) {
 		struct data *d = elem;
 
 		printk("key=%d value=%d\n", d->key, d->value);
-	});
+	}
 
 	return 0;
 }

--- a/tests/lib/min_heap/src/test_min_heap.c
+++ b/tests/lib/min_heap/src/test_min_heap.c
@@ -131,10 +131,9 @@ ZTEST(min_heap_api, test_insert)
 ZTEST(min_heap_api, test_peek_and_pop)
 {
 	int ret;
-	uint8_t storage[HEAP_CAPACITY * sizeof(struct data)];
 
-	MIN_HEAP_DEFINE(runtime_heap, storage, HEAP_CAPACITY,
-			sizeof(struct data), compare_ls);
+	MIN_HEAP_DEFINE_STATIC(runtime_heap, HEAP_CAPACITY, sizeof(struct data),
+			       __alignof__(struct data), compare_ls);
 
 	for (int i = 0; i < ARRAY_SIZE(elements); i++) {
 


### PR DESCRIPTION
Zephyr does not allow variable-length arrays (VLAs). 
Replace the swap() function which used VLA with a byte-wise swap.