### PR TITLE
driver: serial: uart_shell: Add read command

### DIFF
--- a/drivers/serial/uart_shell.c
+++ b/drivers/serial/uart_shell.c
@@ -36,13 +36,56 @@ static int cmd_uart_write(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+
+static int cmd_uart_read(const struct shell *sh, size_t argc, char **argv)
+{
+	char *s_dev_name = argv[1];
+	const struct device *dev = shell_device_get_binding(s_dev_name);
+	int ret = 0;
+	char chr;
+	k_timepoint_t end;
+	uint64_t seconds;
+
+	if (!dev || !device_is_uart(dev)) {
+		shell_error(sh, "UART: Device driver %s not found.", s_dev_name);
+		return -ENODEV;
+	}
+
+	seconds = shell_strtoul(argv[2], 10, &ret);
+	if (ret != 0) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+	if (seconds < 1) {
+		return -EINVAL;
+	}
+	shell_info(sh, "UART: Read for %lli seconds from %s.", seconds, s_dev_name);
+
+	end = sys_timepoint_calc(K_SECONDS(seconds));
+	while (!sys_timepoint_expired(end)) {
+		ret = uart_poll_in(dev, &chr);
+		if (ret == 0) {
+			shell_fprintf_normal(sh, "%c", chr);
+		}
+		if (ret != 0 && ret != -1) {
+			shell_error(sh, "Failed to read from UART (%d)", ret);
+			break;
+		}
+	}
+
+	shell_fprintf_normal(sh, "\n");
+
+	return ret;
+}
+
+
 static int cmd_uart_baudrate(const struct shell *sh, size_t argc, char **argv)
 {
 	char *s_dev_name = argv[1];
 	const struct device *dev;
 	struct uart_config cfg;
 	uint32_t baudrate;
-	int ret;
+	int ret = 0;
 
 	dev = shell_device_get_binding(s_dev_name);
 	if (!dev || !device_is_uart(dev)) {
@@ -50,7 +93,11 @@ static int cmd_uart_baudrate(const struct shell *sh, size_t argc, char **argv)
 		return -ENODEV;
 	}
 
-	baudrate = strtol(argv[2], NULL, 10);
+	baudrate = shell_strtoul(argv[2], 10, &ret);
+	if (ret != 0) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
 	ret = uart_config_get(dev, &cfg);
 	if (ret < 0) {
 		shell_error(sh, "UART: Failed to get current configuration: %d", ret);
@@ -126,6 +173,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_uart_cmds,
 		      "Write data to the UART device\n"
 		      "Usage: write <device> <data>",
 		      cmd_uart_write, 3, 0),
+	SHELL_CMD_ARG(read, &dsub_device_name,
+		      "read data from the UART device\n"
+		      "Usage: read <device> <duration in secs>",
+		      cmd_uart_read, 3, 0),
 	SHELL_CMD_ARG(baudrate, &dsub_device_name,
 		      "Configure UART device baudrate\n"
 		      "Usage: baudrate <device> <baudrate>",


### PR DESCRIPTION
This command waits for a given time (in seconds) and will continuously poll from the UART device and print on the Shell console. This command can be used to also test the RX line.