### PR TITLE
twister: terminate_process: increase timeout before killing process

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
@@ -81,7 +81,7 @@ class BinaryAdapterBase(DeviceAdapter, abc.ABC):
             return
         return_code: int | None = self._process.poll()
         if return_code is None:
-            terminate_process(self._process)
+            terminate_process(self._process, self.base_timeout)
             return_code = self._process.wait(self.base_timeout)
         self._process = None
         logger.debug('Running subprocess finished with return code %s', return_code)


### PR DESCRIPTION
When running tests with coverage enabled, the test process starts to write the coverage data when it receives the SIGTERM signal. On slow machines, this can take longer than 0.5s. Increase the timeout and only attempt to kill the process if it is still running after the timeout.