### PR TITLE
samples: i2s_codec: Fix i2s API misuse

### DIFF
--- a/samples/drivers/i2s/i2s_codec/src/main.c
+++ b/samples/drivers/i2s/i2s_codec/src/main.c
@@ -171,16 +171,21 @@ int main(void)
 
 			for (i = 0; i < 2; i++) {
 #if CONFIG_USE_DMIC
+				/* If using DMIC, use a buffer (memory slab) from dmic_read */
 				ret = dmic_read(dmic_dev, 0, &mem_block, &block_size, TIMEOUT);
 				if (ret < 0) {
 					printk("read failed: %d", ret);
 					break;
 				}
+
+				ret = i2s_write(i2s_dev_codec, mem_block, block_size);
 #else
 				/* If not using DMIC, play a sine wave 440Hz */
 				mem_block = (void *)&__16kHz16bit_stereo_sine_pcm;
+				block_size = __16kHz16bit_stereo_sine_pcm_len;
+
+				ret = i2s_buf_write(i2s_dev_codec, mem_block, block_size);
 #endif
-				ret = i2s_write(i2s_dev_codec, mem_block, block_size);
 				if (ret < 0) {
 					printk("Failed to write data: %d\n", ret);
 					break;


### PR DESCRIPTION
Replace `i2s_write` invocation with `i2s_buf_write` invocation for test sine wave playback.

When `CONFIG_USE_DMIC=n`, this sample attempts to play back a test sine wave encoded in `sine.h`.  As the `i2s_write` treats the given buffer as a memory slab, it overwrites parts of it, resulting in data corruption and improper playback. `i2s_buf_write` accepts a buffer existing outside the playback queue (heap).

Manually tested on `mimxrt595_evk/mimxrt595s/cm33` where it was first observed. 