### PR TITLE
boards: nxp: mimxrt1180_evk: Add support for CM7 flash execution

### DIFF
--- a/boards/nxp/mimxrt1180_evk/Kconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig
@@ -3,3 +3,20 @@
 
 config BOARD_MIMXRT1180_EVK
 	select BOARD_EARLY_INIT_HOOK
+
+# CM7 execution mode
+config CM7_BOOT_FROM_FLASH
+	bool "Run CM7 core from Flash (XIP)"
+	depends on SECOND_CORE_MCUX && (SOC_MIMXRT1189_CM7 || SOC_MIMXRT1189_CM33)
+	default n
+	help
+	  If enabled, the CM7 core will run directly from flash (XIP).
+	  If disabled, the CM7 core will run from ITCM memory.
+
+# Define the FlexSPI offset for CM7
+config CM7_FLEXSPI_OFFSET
+	hex "CM7 FlexSPI offset"
+	depends on SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM33
+	default 0x28000000
+	help
+	  This is the FlexSPI offset for CM7.

--- a/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
+++ b/boards/nxp/mimxrt1180_evk/Kconfig.defconfig
@@ -14,17 +14,29 @@ config NXP_IMX_EXTERNAL_HYPERRAM
 
 if SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM7
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+
+config FLASH_LOAD_OFFSET
+	depends on CM7_BOOT_FROM_FLASH
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+config FLASH_LOAD_SIZE
+	depends on CM7_BOOT_FROM_FLASH
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
 config BUILD_OUTPUT_INFO_HEADER
 	default y
 
 DT_CHOSEN_IMAGE_M7 = nxp,m7-partition
 
-# Adjust the offset of the output image if building for RT18xx SOC
-config BUILD_OUTPUT_ADJUST_LMA
-	default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M7)) + \
-	$(dt_node_reg_addr_hex,/soc/spi@425e0000,1)) - \
-	$(dt_node_reg_addr_hex,/soc/itcm@0)"
-
-endif
-
+# Only adjust LMA if running from ITCM
+if !CM7_BOOT_FROM_FLASH
+	# Adjust the offset of the output image if building for RT18xx SOC ITCM
+	config BUILD_OUTPUT_ADJUST_LMA
+		default "($(dt_chosen_reg_addr_hex,$(DT_CHOSEN_IMAGE_M7)) + \
+		$(dt_node_reg_addr_hex,/soc/spi@425e0000,1)) - \
+		$(dt_node_reg_addr_hex,/soc/itcm@0)"
+endif # !CM7_BOOT_FROM_FLASH
+endif # SECOND_CORE_MCUX && BOARD_MIMXRT1180_EVK_MIMXRT1189_CM7
 endif # BOARD_MIMXRT1180_EVK

--- a/boards/nxp/mimxrt1180_evk/cm7_flash_boot.overlay
+++ b/boards/nxp/mimxrt1180_evk/cm7_flash_boot.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,flash = &w25q128jw;
+		zephyr,code-partition = &slot1_partition;
+	};
+};

--- a/boards/nxp/mimxrt1180_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1180_evk/doc/index.rst
@@ -164,6 +164,85 @@ DSA master port. DSA master port support is TODO work.
        |          |          |          |          |
    NETC External Interfaces (4 switch ports, 1 end-point port)
 
+Dual Core Operation
+*******************
+
+The MIMXRT1180 EVK supports dual core operation with both the Cortex-M33 and Cortex-M7 cores.
+By default, the CM33 core is the boot core and is responsible for initializing the system and
+starting the CM7 core.
+
+CM7 Execution Modes
+===================
+
+The CM7 core can execute code in two different modes:
+
+1. **ITCM Mode (Default)**: The CM7 code is copied from flash to ITCM (Instruction Tightly Coupled Memory)
+   and executed from there. This provides faster execution but is limited by the ITCM size.
+
+2. **Flash Mode**: The CM7 code is executed directly from flash memory (XIP - eXecute In Place).
+   This allows for larger code size but may be slower than ITCM execution.
+   When booting CM7 from Flash the TRDC execution permissions has to be set by CM33 core.
+
+Configuring CM7 Execution Mode
+==============================
+
+To configure the CM7 execution mode, you can use the following Kconfig option:
+
+.. code-block:: none
+
+   CONFIG_CM7_BOOT_FROM_FLASH=n  # For ITCM execution (default)
+   CONFIG_CM7_BOOT_FROM_FLASH=y  # For flash execution
+
+When building with west, you can specify this option on the command line:
+
+.. code-block:: bash
+
+   # For ITCM execution (default)
+   west build -b mimxrt1180_evk/mimxrt1189/cm33 samples/drivers/mbox --sysbuild
+
+   # For flash execution
+   west build -b mimxrt1180_evk/mimxrt1189/cm33 <sample_path> --sysbuild -- \
+     -D<remote_app_name>_EXTRA_DTC_OVERLAY_FILE=${ZEPHYR_BASE}/boards/nxp/mimxrt1180_evk/cm7_flash_boot.overlay \
+     -DCONFIG_CM7_BOOT_FROM_FLASH=y -D<remote_app_name>_CONFIG_CM7_BOOT_FROM_FLASH=y
+
+  west build -b mimxrt1180_evk/mimxrt1189/cm33 samples/drivers/mbox --sysbuild -- \
+     -Dremote_EXTRA_DTC_OVERLAY_FILE=${ZEPHYR_BASE}/boards/nxp/mimxrt1180_evk/cm7_flash_boot.overlay \
+     -DCONFIG_CM7_BOOT_FROM_FLASH=y -Dremote_CONFIG_CM7_BOOT_FROM_FLASH=y
+
+Flash Boot Overlay
+==================
+
+When executing the CM7 core from flash, you need to apply a device tree overlay to configure
+the flash memory properly. The overlay file is located at:
+
+.. code-block:: none
+
+   boards/nxp/mimxrt1180_evk/cm7_flash_boot.overlay
+
+This overlay configures the CM7 core to use the flash memory for code execution instead of ITCM.
+
+Memory Usage
+============
+
+* **ITCM Mode**: The CM7 code is copied from flash to ITCM.
+* **Flash Mode**: The CM7 code is executed directly from flash, which allows for larger code size.
+
+Performance Considerations
+==========================
+
+* **ITCM Mode**: Provides faster execution due to the low-latency ITCM memory.
+* **Flash Mode**: May be slower due to flash memory access times, but allows for larger code size.
+
+Dual Core samples Debugging
+===========================
+
+When debugging dual core samples, need to ensure the SW5 on "0100" mode.
+The CM33 core is responsible for copying and starting the CM7.
+To debug the CM7 it is useful to put infinite while loop either in reset vector or
+into main function and attach via debugger to CM7 core.
+
+CM7 core can be started again only after reset, so after flashing ensure to reset board.
+
 Programming and Debugging
 *************************
 
@@ -210,16 +289,6 @@ Please ensure to use a version of Linkserver above V1.5.30 and jumper JP5 is uni
 When debugging cm33 core, need to ensure the SW5 on "0100" mode.
 When debugging cm7 core, need to ensure the SW5 on "0001" mode.
 (Only support run cm7 image when debugging due to default boot core on board is cm33 core)
-
-Dual Core samples Debugging
-***************************
-
-When debugging dual core samples, need to ensure the SW5 on "0100" mode.
-The CM33 core is responsible for copying and starting the CM7.
-To debug the CM7 it is useful to put infinite while loop either in reset vector or
-into main function and attach via debugger to CM7 core.
-
-CM7 core can be started again only after reset, so after flashing ensure to reset board.
 
 Configuring a Console
 =====================

--- a/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.dts
+++ b/boards/nxp/mimxrt1180_evk/mimxrt1180_evk_mimxrt1189_cm33.dts
@@ -20,6 +20,7 @@
 		zephyr,flash-controller = &w25q128jw;
 		zephyr,flash = &w25q128jw;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,code-m7-partition = &slot1_partition;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,uart-mcumgr = &lpuart1;

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -26,7 +26,8 @@
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
-#if  defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)
+#if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)
+#if !defined(CONFIG_CM7_BOOT_FROM_FLASH)
 #include <zephyr_image_info.h>
 /* Memcpy macro to copy segments from secondary core image stored in flash
  * to RAM section that secondary core boots from.
@@ -36,6 +37,7 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 	memcpy((uint32_t *)(((SEGMENT_LMA_ADDRESS_ ## n) - ADJUSTED_LMA) + 0x303C0000),	\
 		(uint32_t *)(SEGMENT_LMA_ADDRESS_ ## n),			\
 		(SEGMENT_SIZE_ ## n))
+#endif /* !defined(CONFIG_CM7_BOOT_FROM_FLASH) */
 #endif
 
 /*
@@ -69,6 +71,18 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #define CM33_SET_TRDC 1U
 #endif
 
+#if (defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33))
+/* Handle CM7 core initialization based on execution mode */
+#if !defined(CONFIG_CM7_BOOT_FROM_FLASH)
+#define CM7_BOOT_ADDRESS (0)
+#else
+/* Get CM7 partition address from device tree */
+#define CM7_PARTITION_NODE DT_CHOSEN(zephyr_code_m7_partition)
+#define CM7_FLASH_ADDR     DT_REG_ADDR(CM7_PARTITION_NODE)
+#define CM7_BOOT_ADDRESS   (CM7_FLASH_ADDR + CONFIG_CM7_FLEXSPI_OFFSET)
+#endif /* defined(CONFIG_CM7_BOOT_FROM_FLASH) */
+#endif /* (defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)) */
+
 #ifdef CONFIG_INIT_ARM_PLL
 static const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN = {
 #if defined(CONFIG_SOC_MIMXRT1189_CM33) || defined(CONFIG_SOC_MIMXRT1189_CM7)
@@ -77,7 +91,7 @@ static const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN = {
 	/* PLL Loop divider, Fout = Fin * ( loopDivider / ( 2 * postDivider ) ) */
 	.loopDivider = 132,
 #else
-	#error "Unknown SOC, no pll configuration defined"
+#error "Unknown SOC, no pll configuration defined"
 #endif
 };
 #endif
@@ -763,6 +777,7 @@ void soc_early_init_hook(void)
 #endif /* defined(CONFIG_WDT_MCUX_RTWDOG) */
 
 #if (defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33))
+#if !defined(CONFIG_CM7_BOOT_FROM_FLASH)
 	/**
 	 * Copy CM7 core from flash to memory. Note that depending on where the
 	 * user decided to store CM7 code, this is likely going to read from the
@@ -774,6 +789,7 @@ void soc_early_init_hook(void)
 	 */
 	LISTIFY(SEGMENT_NUM, MEMCPY_SEGMENT, (;));
 #endif /* (defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)) */
+#endif /* !defined(CONFIG_CM7_BOOT_FROM_FLASH) */
 
 	/* Enable data cache */
 	sys_cache_data_enable();
@@ -788,7 +804,7 @@ void soc_reset_hook(void)
 	SystemInit();
 
 #if defined(CONFIG_SECOND_CORE_MCUX) && defined(CONFIG_CPU_CORTEX_M33)
-	Prepare_CM7(0);
+	Prepare_CM7(CM7_BOOT_ADDRESS);
 #endif
 }
 #endif


### PR DESCRIPTION
Add support for executing the CM7 core directly from flash memory (XIP - eXecute In Place) instead of copying to ITCM. This provides the following benefits:

- Allows for larger code size than the 512KB ITCM limit
- Simplifies memory management for large applications
- Reduces boot time by eliminating the need to copy code to ITCM

The implementation includes:

1. A new Kconfig option CM7_BOOT_FROM_FLASH (default: n) to control the execution mode
2. A device tree overlay (cm7_flash_boot.overlay) that configures the flash memory for CM7 execution
3. Updates to soc.c to calculate the correct CM7 boot address based on the flash partition
5. Documentation updates with instructions for both execution modes