### PR TITLE
scripts: ci: check_compliance: Ignore additional mcuboot Kconfigs

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1026,6 +1026,8 @@ flagged.
         "BOOT_ENCRYPT_IMAGE", # Used in sysbuild
         "BOOT_FIRMWARE_LOADER", # Used in sysbuild for MCUboot configuration
         "BOOT_FIRMWARE_LOADER_BOOT_MODE", # Used in sysbuild for MCUboot configuration
+        "BOOT_IMAGE_EXECUTABLE_RAM_SIZE", # MCUboot setting
+        "BOOT_IMAGE_EXECUTABLE_RAM_START", # MCUboot setting
         "BOOT_MAX_IMG_SECTORS_AUTO", # Used in sysbuild
         "BOOT_RAM_LOAD", # Used in sysbuild for MCUboot configuration
         "BOOT_SERIAL_BOOT_MODE",     # Used in (sysbuild-based) test/


### PR DESCRIPTION
Adds BOOT_IMAGE_EXECUTABLE_RAM_START and BOOT_IMAGE_EXECUTABLE_RAM_SIZE to the list of mcuboot symbols ignored by the compliance checking script.