### PR TITLE
boards: stm32: stm32n6570_dk: fix DTS errors for Ethernet

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -344,6 +344,15 @@ zephyr_udc0: &usbotg_hs1 {
 	};
 };
 
+/**
+ * Board-specific configuration, required to ensure that
+ * the Tx CLK and DAT signals arrive in sync at the PHY.
+ * Without this, the Tx will be unreliable
+ */
+&eth1_rgmii_gtx_clk_pf0 {
+	slew-rate = "medium-speed";
+};
+
 &mac {
 	status = "okay";
 	pinctrl-0 = <&eth1_rgmii_gtx_clk_pf0
@@ -358,8 +367,7 @@ zephyr_udc0: &usbotg_hs1 {
 		     &eth1_rgmii_rxd0_pf14
 		     &eth1_rgmii_rxd1_pf15
 		     &eth1_rgmii_txd2_pg3
-		     &eth1_rgmii_txd3_pg4
-		     &eth1_phy_intn_pd3>;
+		     &eth1_rgmii_txd3_pg4>;
 	pinctrl-names = "default";
 	phy-connection-type = "rgmii";
 	phy-handle = <&eth_phy>;
@@ -370,9 +378,20 @@ zephyr_udc0: &usbotg_hs1 {
 	pinctrl-0 = <&eth1_mdio_pd12 &eth1_mdc_pd1>;
 	pinctrl-names = "default";
 
-	eth_phy: ethernet-phy@0 {
-		compatible = "ethernet-phy";
-		reg = <0x0>;
+	eth_phy: ethernet-phy@1 {
+		compatible = "realtek,rtl8211f";
+		reg = <0x1>;
+		/**
+		 * PD3 can be used as alternate function ETH1_PHY_INTN,
+		 * which allows the Ethernet MAC to sense interrupts from
+		 * the PHY in order to signal them to the CPU via its own
+		 * interrupt lines. However, the Zephyr RTL8211F driver
+		 * is unaware of this mechanism. Skip configuring PD3 as
+		 * alternate function (in pinctrl of &mac) and provide the
+		 * pin to the RTL8211F driver for interrupt sensing using
+		 * the regular GPIO interrupt APIs.
+		 */
+		int-gpios = <&gpiod 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 };
 


### PR DESCRIPTION
The DTS for this board contained a few mistakes:
* The PHY address was incorrect
	* This did not impair functionality because the RTL8211F treats address 0 as "broadcast" and accepts commands sent to it by default
* An incorrect PHY driver was used
	* On-board PHY (`RTL8211F`) has an existing Zephyr driver - use that instead of the generic `phy_mii`
	* Rework Ethernet MAC pinctrl configuration to allow driver to receive PHY interrupts
* The RGMII GTX CLK pinctrl must be configured at `medium-speed`
	* **Fixes #90977 - unreliable Tx issue**
	* (c.f. commit description and board DTS for details)
