### PR TITLE
pm: adopt SHELL_HELP

### DIFF
--- a/subsys/pm/pm_shell.c
+++ b/subsys/pm/pm_shell.c
@@ -158,20 +158,20 @@ static int pm_cmd_runtime_put_async(const struct shell *sh, size_t argc, char *a
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pm_cmds,
 	SHELL_CMD_ARG(suspend, &dsub_device_name,
-		      "Call the PM suspend action on a device",
+		      SHELL_HELP("Call the PM suspend action on a device", "<device>"),
 		      pm_cmd_suspend, 2, 0),
 	SHELL_CMD_ARG(resume, &dsub_device_name,
-		      "Call the PM resume action on a device",
+		      SHELL_HELP("Call the PM resume action on a device", "<device>"),
 		      pm_cmd_resume, 2, 0),
 #if defined(CONFIG_PM_DEVICE_RUNTIME)
 	SHELL_CMD_ARG(runtime-get, &dsub_device_name,
-		      "Call the PM runtime get on a device",
+		      SHELL_HELP("Call the PM runtime get on a device", "<device>"),
 		      pm_cmd_runtime_get, 2, 0),
 	SHELL_CMD_ARG(runtime-put, &dsub_device_name,
-		      "Call the PM runtime put on a device",
+		      SHELL_HELP("Call the PM runtime put on a device", "<device>"),
 		      pm_cmd_runtime_put, 2, 0),
 	SHELL_CMD_ARG(runtime-put-async, &dsub_device_name,
-		      "Call the PM runtime put async on a device",
+		      SHELL_HELP("Call the PM runtime put async on a device", "<device>"),
 		      pm_cmd_runtime_put_async, 2, 0),
 #endif /* CONFIG_PM_DEVICE_RUNTIME */
 	SHELL_SUBCMD_SET_END);


### PR DESCRIPTION
Adopt SHELL_HELP macro for pm_shell

```console
uart:~$ pm --help
pm - PM commands
Subcommands:
  suspend            : Call the PM suspend action on a device
                       Usage: suspend <device>
  resume             : Call the PM resume action on a device
                       Usage: resume <device>
  runtime-get        : Call the PM runtime get on a device
                       Usage: runtime-get <device>
  runtime-put        : Call the PM runtime put on a device
                       Usage: runtime-put <device>
  runtime-put-async  : Call the PM runtime put async on a device
                       Usage: runtime-put-async <device>
```