### PR TITLE
drivers: sensor: ti: tmp11x: add optional attribute storage

### DIFF
--- a/drivers/sensor/ti/tmp11x/tmp11x.c
+++ b/drivers/sensor/ti/tmp11x/tmp11x.c
@@ -350,7 +350,6 @@ static int tmp11x_attr_set(const struct device *dev,
 	const struct tmp11x_dev_config *cfg = dev->config;
 	struct tmp11x_data *drv_data = dev->data;
 	int16_t value;
-	uint16_t avg;
 	int res = 0;
 	bool store;
 	int store_res = 0;
@@ -394,19 +393,19 @@ static int tmp11x_attr_set(const struct device *dev,
 		/* sensor supports averaging 1, 8, 32 and 64 samples */
 		switch (val->val1) {
 		case 1:
-			avg = TMP11X_AVG_1_SAMPLE;
+			value = TMP11X_AVG_1_SAMPLE;
 			break;
 
 		case 8:
-			avg = TMP11X_AVG_8_SAMPLES;
+			value = TMP11X_AVG_8_SAMPLES;
 			break;
 
 		case 32:
-			avg = TMP11X_AVG_32_SAMPLES;
+			value = TMP11X_AVG_32_SAMPLES;
 			break;
 
 		case 64:
-			avg = TMP11X_AVG_64_SAMPLES;
+			value = TMP11X_AVG_64_SAMPLES;
 			break;
 
 		default:
@@ -415,7 +414,7 @@ static int tmp11x_attr_set(const struct device *dev,
 		}
 
 		if (res == 0) {
-			res = tmp11x_write_config(dev, TMP11X_CFGR_AVG, avg);
+			res = tmp11x_write_config(dev, TMP11X_CFGR_AVG, value);
 		}
 
 		break;

--- a/drivers/sensor/ti/tmp11x/tmp11x.c
+++ b/drivers/sensor/ti/tmp11x/tmp11x.c
@@ -20,10 +20,10 @@
 
 #include "tmp11x.h"
 
-#define  EEPROM_SIZE_REG sizeof(uint16_t)
-#define  EEPROM_TMP117_RESERVED (2 * sizeof(uint16_t))
-#define  EEPROM_MIN_BUSY_MS 7
-#define  RESET_MIN_BUSY_MS 2
+#define EEPROM_SIZE_REG        sizeof(uint16_t)
+#define EEPROM_TMP117_RESERVED (2 * sizeof(uint16_t))
+#define EEPROM_MIN_BUSY_MS     7
+#define RESET_MIN_BUSY_MS      2
 
 LOG_MODULE_REGISTER(TMP11X, CONFIG_SENSOR_LOG_LEVEL);
 
@@ -31,8 +31,7 @@ int tmp11x_reg_read(const struct device *dev, uint8_t reg, uint16_t *val)
 {
 	const struct tmp11x_dev_config *cfg = dev->config;
 
-	if (i2c_burst_read_dt(&cfg->bus, reg, (uint8_t *)val, 2)
-	    < 0) {
+	if (i2c_burst_read_dt(&cfg->bus, reg, (uint8_t *)val, 2) < 0) {
 		return -EIO;
 	}
 
@@ -96,13 +95,11 @@ static inline int16_t tmp11x_sensor_value_to_reg_format(const struct sensor_valu
 	}
 }
 
-static bool check_eeprom_bounds(const struct device *dev, off_t offset,
-			       size_t len)
+static bool check_eeprom_bounds(const struct device *dev, off_t offset, size_t len)
 {
 	struct tmp11x_data *drv_data = dev->data;
 
-	if ((offset + len) > EEPROM_TMP11X_SIZE ||
-	    offset % EEPROM_SIZE_REG != 0 ||
+	if ((offset + len) > EEPROM_TMP11X_SIZE || offset % EEPROM_SIZE_REG != 0 ||
 	    len % EEPROM_SIZE_REG != 0) {
 		return false;
 	}
@@ -130,8 +127,7 @@ int tmp11x_eeprom_await(const struct device *dev)
 	return res;
 }
 
-int tmp11x_eeprom_write(const struct device *dev, off_t offset,
-			const void *data, size_t len)
+int tmp11x_eeprom_write(const struct device *dev, off_t offset, const void *data, size_t len)
 {
 	uint8_t reg;
 	const uint16_t *src = data;
@@ -167,8 +163,7 @@ int tmp11x_eeprom_write(const struct device *dev, off_t offset,
 	return res;
 }
 
-int tmp11x_eeprom_read(const struct device *dev, off_t offset, void *data,
-		       size_t len)
+int tmp11x_eeprom_read(const struct device *dev, off_t offset, void *data, size_t len)
 {
 	uint8_t reg;
 	uint16_t *dst = data;
@@ -189,7 +184,6 @@ int tmp11x_eeprom_read(const struct device *dev, off_t offset, void *data,
 	return res;
 }
 
-
 /**
  * @brief Check the Device ID
  *
@@ -202,30 +196,26 @@ int tmp11x_eeprom_read(const struct device *dev, off_t offset, void *data,
 static inline int tmp11x_device_id_check(const struct device *dev, uint16_t *id)
 {
 	if (tmp11x_reg_read(dev, TMP11X_REG_DEVICE_ID, id) != 0) {
-		LOG_ERR("%s: Failed to get Device ID register!",
-			dev->name);
+		LOG_ERR("%s: Failed to get Device ID register!", dev->name);
 		return -EIO;
 	}
 
 	if ((*id != TMP116_DEVICE_ID) && (*id != TMP117_DEVICE_ID) && (*id != TMP119_DEVICE_ID)) {
-		LOG_ERR("%s: Failed to match the device IDs!",
-			dev->name);
+		LOG_ERR("%s: Failed to match the device IDs!", dev->name);
 		return -EINVAL;
 	}
 
 	return 0;
 }
 
-static int tmp11x_sample_fetch(const struct device *dev,
-			       enum sensor_channel chan)
+static int tmp11x_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	struct tmp11x_data *drv_data = dev->data;
 	uint16_t value;
 	uint16_t cfg_reg = 0;
 	int rc;
 
-	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL ||
-			chan == SENSOR_CHAN_AMBIENT_TEMP);
+	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
 	/* clear sensor values */
 	drv_data->sample = 0U;
@@ -233,8 +223,7 @@ static int tmp11x_sample_fetch(const struct device *dev,
 	/* Make sure that a data is available */
 	rc = tmp11x_reg_read(dev, TMP11X_REG_CFGR, &cfg_reg);
 	if (rc < 0) {
-		LOG_ERR("%s, Failed to read from CFGR register",
-			dev->name);
+		LOG_ERR("%s, Failed to read from CFGR register", dev->name);
 		return rc;
 	}
 
@@ -246,8 +235,7 @@ static int tmp11x_sample_fetch(const struct device *dev,
 	/* Get the most recent temperature measurement */
 	rc = tmp11x_reg_read(dev, TMP11X_REG_TEMP, &value);
 	if (rc < 0) {
-		LOG_ERR("%s: Failed to read from TEMP register!",
-			dev->name);
+		LOG_ERR("%s: Failed to read from TEMP register!", dev->name);
 		return rc;
 	}
 
@@ -270,8 +258,7 @@ static void tmp11x_temperature_to_sensor_value(int16_t temperature, struct senso
 	val->val2 = tmp % 1000000;
 }
 
-static int tmp11x_channel_get(const struct device *dev,
-			      enum sensor_channel chan,
+static int tmp11x_channel_get(const struct device *dev, enum sensor_channel chan,
 			      struct sensor_value *val)
 {
 	struct tmp11x_data *drv_data = dev->data;
@@ -314,7 +301,7 @@ static int16_t tmp11x_conv_value(const struct sensor_value *val)
 
 static bool tmp11x_is_attr_store_supported(enum sensor_attribute attr)
 {
-	switch ((int) attr) {
+	switch ((int)attr) {
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
 	case SENSOR_ATTR_LOWER_THRESH:
 	case SENSOR_ATTR_UPPER_THRESH:
@@ -342,10 +329,8 @@ static int tmp11x_attr_store_reload(const struct device *dev)
 	return await_res != 0 ? await_res : reset_res;
 }
 
-static int tmp11x_attr_set(const struct device *dev,
-			   enum sensor_channel chan,
-			   enum sensor_attribute attr,
-			   const struct sensor_value *val)
+static int tmp11x_attr_set(const struct device *dev, enum sensor_channel chan,
+			   enum sensor_attribute attr, const struct sensor_value *val)
 {
 	const struct tmp11x_dev_config *cfg = dev->config;
 	struct tmp11x_data *drv_data = dev->data;
@@ -435,7 +420,7 @@ static int tmp11x_attr_set(const struct device *dev,
 	case SENSOR_ATTR_TMP11X_ALERT_PIN_POLARITY:
 		if (val->val1 == TMP11X_ALERT_PIN_ACTIVE_HIGH) {
 			res = tmp11x_write_config(dev, TMP11X_CFGR_ALERT_PIN_POL,
-						   TMP11X_CFGR_ALERT_PIN_POL);
+						  TMP11X_CFGR_ALERT_PIN_POL);
 		} else {
 			res = tmp11x_write_config(dev, TMP11X_CFGR_ALERT_PIN_POL, 0);
 		}
@@ -444,7 +429,7 @@ static int tmp11x_attr_set(const struct device *dev,
 	case SENSOR_ATTR_TMP11X_ALERT_MODE:
 		if (val->val1 == TMP11X_ALERT_THERM_MODE) {
 			res = tmp11x_write_config(dev, TMP11X_CFGR_ALERT_MODE,
-						   TMP11X_CFGR_ALERT_MODE);
+						  TMP11X_CFGR_ALERT_MODE);
 		} else {
 			res = tmp11x_write_config(dev, TMP11X_CFGR_ALERT_MODE, 0);
 		}
@@ -467,7 +452,7 @@ static int tmp11x_attr_set(const struct device *dev,
 			res = tmp11x_write_config(dev, TMP11X_CFGR_ALERT_DR_SEL, 0);
 		} else {
 			res = tmp11x_write_config(dev, TMP11X_CFGR_ALERT_DR_SEL,
-						   TMP11X_CFGR_ALERT_DR_SEL);
+						  TMP11X_CFGR_ALERT_DR_SEL);
 		}
 		break;
 #endif /* CONFIG_TMP11X_TRIGGER */
@@ -643,9 +628,15 @@ static int tmp11x_pm_control(const struct device *dev, enum pm_device_action act
 }
 #endif /* CONFIG_PM_DEVICE */
 
-#define DEFINE_TMP11X(_num)                                                            \
-	static struct tmp11x_data tmp11x_data_##_num;                                        \
-	static const struct tmp11x_dev_config tmp11x_config_##_num = {                       \
+#ifdef CONFIG_TMP11X_TRIGGER
+#define DEFINE_TMP11X_TRIGGER(_num) .alert_gpio = GPIO_DT_SPEC_INST_GET_OR(_num, alert_gpios, {}),
+#else
+#define DEFINE_TMP11X_TRIGGER(_num)
+#endif
+
+#define DEFINE_TMP11X(_num)                                                                        \
+	static struct tmp11x_data tmp11x_data_##_num;                                              \
+	static const struct tmp11x_dev_config tmp11x_config_##_num = {                             \
 		.bus = I2C_DT_SPEC_INST_GET(_num),                                                 \
 		.odr = DT_INST_PROP(_num, odr),                                                    \
 		.oversampling = DT_INST_PROP(_num, oversampling),                                  \
@@ -653,10 +644,11 @@ static int tmp11x_pm_control(const struct device *dev, enum pm_device_action act
 		.alert_mode = DT_INST_PROP(_num, alert_mode),                                      \
 		.alert_dr_sel = DT_INST_PROP(_num, alert_dr_sel),                                  \
 		.store_attr_values = DT_INST_PROP(_num, store_attr_values),                        \
-		IF_ENABLED(CONFIG_TMP11X_TRIGGER, \
-			(.alert_gpio = GPIO_DT_SPEC_INST_GET_OR(_num, alert_gpios, {}),)) }; \
-	PM_DEVICE_DT_INST_DEFINE(_num, tmp11x_pm_control); \
-	SENSOR_DEVICE_DT_INST_DEFINE(_num, tmp11x_init, PM_DEVICE_DT_INST_GET(_num), \
+		DEFINE_TMP11X_TRIGGER(_num)};                                                      \
+                                                                                                   \
+	PM_DEVICE_DT_INST_DEFINE(_num, tmp11x_pm_control);                                         \
+                                                                                                   \
+	SENSOR_DEVICE_DT_INST_DEFINE(_num, tmp11x_init, PM_DEVICE_DT_INST_GET(_num),               \
 				     &tmp11x_data_##_num, &tmp11x_config_##_num, POST_KERNEL,      \
 				     CONFIG_SENSOR_INIT_PRIORITY, &tmp11x_driver_api);
 

--- a/drivers/sensor/ti/tmp11x/tmp11x.h
+++ b/drivers/sensor/ti/tmp11x/tmp11x.h
@@ -11,29 +11,29 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
 
-#define TMP11X_REG_TEMP		0x0
-#define TMP11X_REG_CFGR		0x1
-#define TMP11X_REG_HIGH_LIM		0x2
-#define TMP11X_REG_LOW_LIM		0x3
-#define TMP11X_REG_EEPROM_UL		0x4
-#define TMP11X_REG_EEPROM1		0x5
-#define TMP11X_REG_EEPROM2		0x6
-#define TMP11X_REG_EEPROM3		0x7
-#define TMP117_REG_TEMP_OFFSET		0x7
-#define TMP11X_REG_EEPROM4		0x8
-#define TMP11X_REG_DEVICE_ID		0xF
+#define TMP11X_REG_TEMP        0x0
+#define TMP11X_REG_CFGR        0x1
+#define TMP11X_REG_HIGH_LIM    0x2
+#define TMP11X_REG_LOW_LIM     0x3
+#define TMP11X_REG_EEPROM_UL   0x4
+#define TMP11X_REG_EEPROM1     0x5
+#define TMP11X_REG_EEPROM2     0x6
+#define TMP11X_REG_EEPROM3     0x7
+#define TMP117_REG_TEMP_OFFSET 0x7
+#define TMP11X_REG_EEPROM4     0x8
+#define TMP11X_REG_DEVICE_ID   0xF
 
-#define TMP11X_RESOLUTION		78125       /* in tens of uCelsius*/
-#define TMP11X_RESOLUTION_DIV		10000000
+#define TMP11X_RESOLUTION     78125 /* in tens of uCelsius*/
+#define TMP11X_RESOLUTION_DIV 10000000
 
-#define TMP116_DEVICE_ID		0x1116
-#define TMP117_DEVICE_ID		0x0117
-#define TMP119_DEVICE_ID		0x2117
+#define TMP116_DEVICE_ID 0x1116
+#define TMP117_DEVICE_ID 0x0117
+#define TMP119_DEVICE_ID 0x2117
 
-#define TMP11X_CFGR_RESET		BIT(1)
-#define TMP11X_CFGR_AVG			(BIT(5) | BIT(6))
-#define TMP11X_CFGR_CONV		(BIT(7) | BIT(8) | BIT(9))
-#define TMP11X_CFGR_MODE		(BIT(10) | BIT(11))
+#define TMP11X_CFGR_RESET       BIT(1)
+#define TMP11X_CFGR_AVG         (BIT(5) | BIT(6))
+#define TMP11X_CFGR_CONV        (BIT(7) | BIT(8) | BIT(9))
+#define TMP11X_CFGR_MODE        (BIT(10) | BIT(11))
 #define TMP11X_CFGR_DATA_READY  BIT(13)
 #define TMP11X_EEPROM_UL_UNLOCK BIT(15)
 #define TMP11X_EEPROM_UL_BUSY   BIT(14)
@@ -43,13 +43,13 @@
 #define TMP11X_CFGR_ALERT_PIN_POL BIT(3) /* Alert pin polarity */
 #define TMP11X_CFGR_ALERT_MODE    BIT(4) /* Alert pin mode (1=therm, 0=alert) */
 
-#define TMP11X_AVG_1_SAMPLE		0
-#define TMP11X_AVG_8_SAMPLES	BIT(5)
-#define TMP11X_AVG_32_SAMPLES	BIT(6)
-#define TMP11X_AVG_64_SAMPLES	(BIT(5) | BIT(6))
-#define TMP11X_MODE_CONTINUOUS	0
-#define TMP11X_MODE_SHUTDOWN	BIT(10)
-#define TMP11X_MODE_ONE_SHOT	(BIT(10) | BIT(11))
+#define TMP11X_AVG_1_SAMPLE    0
+#define TMP11X_AVG_8_SAMPLES   BIT(5)
+#define TMP11X_AVG_32_SAMPLES  BIT(6)
+#define TMP11X_AVG_64_SAMPLES  (BIT(5) | BIT(6))
+#define TMP11X_MODE_CONTINUOUS 0
+#define TMP11X_MODE_SHUTDOWN   BIT(10)
+#define TMP11X_MODE_ONE_SHOT   (BIT(10) | BIT(11))
 
 struct tmp11x_data {
 	uint16_t sample;

--- a/drivers/sensor/ti/tmp11x/tmp11x.h
+++ b/drivers/sensor/ti/tmp11x/tmp11x.h
@@ -30,6 +30,7 @@
 #define TMP117_DEVICE_ID		0x0117
 #define TMP119_DEVICE_ID		0x2117
 
+#define TMP11X_CFGR_RESET		BIT(1)
 #define TMP11X_CFGR_AVG			(BIT(5) | BIT(6))
 #define TMP11X_CFGR_CONV		(BIT(7) | BIT(8) | BIT(9))
 #define TMP11X_CFGR_MODE		(BIT(10) | BIT(11))
@@ -76,6 +77,7 @@ struct tmp11x_dev_config {
 	bool alert_pin_polarity;
 	bool alert_mode;
 	bool alert_dr_sel;
+	bool store_attr_values;
 #ifdef CONFIG_TMP11X_TRIGGER
 	struct gpio_dt_spec alert_gpio;
 #endif

--- a/dts/bindings/sensor/ti,tmp11x.yaml
+++ b/dts/bindings/sensor/ti,tmp11x.yaml
@@ -60,3 +60,15 @@ properties:
       GPIO pin used for alert/interrupt functionality.
       Supported on TMP116, TMP117, and TMP119 devices.
       Alert pin functionality depends on Therm/alert modus.
+  store-attr-values:
+    type: boolean
+    description: |
+      Enable storage of sensor attribute values in EEPROM. On reset, the device
+      goes through a POR sequence that loads the values programmed in the
+      EEPROM into the respective register map locations.
+
+      The following values are supported by the sensor:
+      High limit register, low limit register, conversion cycle time, averaging
+      mode, conversion mode (continuous or shutdown mode), alert function mode
+      (alert or therm mode), alert polarity, and temperature offset (not
+      specified in datasheet).


### PR DESCRIPTION
Enable optional storage of sensor attribute values in EEPROM. On reset, the
device goes through a POR sequence that loads the values programmed in the
EEPROM into the respective register map locations.

The driver stores sample frequency, offset, oversampling and conversion
mode if the value is continuous or shutdown.

The functionality has been tested with sensor shell and power cycling
sensor:

Test (undocumented) temperature offset is stored:
```shell
uart:~$ sensor attr_set ti_tmp11x@48 ambient_temp offset 0
ti_tmp11x@48 channel=ambient_temp, attr=offset set to value=0
uart:~$ sensor get ti_tmp11x@48 ambient_temp
channel type=13(ambient_temp) index=0 shift=5 num_samples=1 value=27850764120ns (25.523436)
uart:~$ sensor attr_set ti_tmp11x@48 ambient_temp offset 50
ti_tmp11x@48 channel=ambient_temp, attr=offset set to value=50
uart:~$ sensor get ti_tmp11x@48 ambient_temp
channel type=13(ambient_temp) index=0 shift=7 num_samples=1 value=41787898070ns (75.617186)
uart:~$
[15:12:20.088] Disconnected
[15:12:21.089] Warning: Could not open tty device (No such file or directory)
[15:12:21.089] Waiting for tty device..
[15:12:36.106] Connected
uart:~$ sensor get ti_tmp11x@48 ambient_temp
channel type=13(ambient_temp) index=0 shift=7 num_samples=1 value=9192627504ns (75.554686)
uart:~$ sensor attr_get ti_tmp11x@48 ambient_temp offset
ti_tmp11x@48(channel=ambient_temp, attr=offset) value=50.000000
```

Test one-shot mode is not stored:
```shell
uart:~$ sensor attr_set ti_tmp11x@48 ambient_temp 18 1
ti_tmp11x@48 channel=ambient_temp, attr=accel_x set to value=1
uart:~$ sensor get ti_tmp11x@48 ambient_temp
channel type=13(ambient_temp) index=0 shift=7 num_samples=1 value=16991828850ns (75.562499)
uart:~$ sensor get ti_tmp11x@48 ambient_temp
Read failed
[00:00:21.332,000] <wrn> sensor_compat: Failed to fetch samples
uart:~$
[15:16:24.529] Disconnected
[15:16:25.530] Warning: Could not open tty device (No such file or directory)
[15:16:25.530] Waiting for tty device..
[15:16:33.540] Connected
uart:~$ sensor get ti_tmp11x@48 ambient_temp
channel type=13(ambient_temp) index=0 shift=7 num_samples=1 value=5901428070ns (75.406249)
uart:~$ sensor get ti_tmp11x@48 ambient_temp
channel type=13(ambient_temp) index=0 shift=7 num_samples=1 value=8688108162ns (75.351561)
```