### PR TITLE
cmake: compiler: gcc: riscv: remove spurious Zmmul

### DIFF
--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -81,7 +81,9 @@ if(CONFIG_RISCV_ISA_EXT_ZBS)
     string(CONCAT riscv_march ${riscv_march} "_zbs")
 endif()
 
-if(CONFIG_RISCV_ISA_EXT_ZMMUL AND
+# Check whether we already imply Zmmul by selecting the M extension; if not - enable it
+if(NOT CONFIG_RISCV_ISA_EXT_M AND
+   CONFIG_RISCV_ISA_EXT_ZMMUL AND
    "${GCC_COMPILER_VERSION}" VERSION_GREATER_EQUAL 13.0.0)
     string(CONCAT riscv_march ${riscv_march} "_zmmul")
 endif()


### PR DESCRIPTION
Zmmul is a subset of M extension.
No need to enable Zmmul redundantly if M is already present.

Reference:
https://github.com/riscv/riscv-isa-manual/blob/449cd0c79ae91cc6f547726b8a6270f975be676e/src/m.tex#L173
https://github.com/riscv/riscv-isa-manual/issues/869