### PR TITLE
Bluetooth: Host: Fix SMP Pairing failed code on invalid Public Key

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -4478,7 +4478,7 @@ static uint8_t smp_public_key(struct bt_smp *smp, struct net_buf *buf)
 		}
 	} else if (!bt_pub_key_is_valid(smp->pkey)) {
 		LOG_WRN("Received invalid public key");
-		return BT_SMP_ERR_INVALID_PARAMS;
+		return BT_SMP_ERR_DHKEY_CHECK_FAILED;
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CENTRAL) &&


### PR DESCRIPTION
Core Specification 6.1 clarified exptected erro code in case peer sending invalid Public Key. In case pairing is aborted during or immediately after Public Key Exchange phase has completed (which is the case here) expected reason code is set to "DHKey Check Failed".

This was affecting SM/CEN/KDU/BI-04-C and SM/PER/KDU/BI-04-C qualification test cases.