### PR TITLE
drivers: counter: adopt SHELL_HELP

### DIFF
--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -218,15 +218,18 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_timer,
 	SHELL_CMD_ARG(periodic, &dsub_device_name,
-		      "timer periodic <timer_instance_node_id> <time_in_us>", cmd_timer_periodic, 3,
-		      0),
+		      SHELL_HELP("Start a periodic timer with specified interval",
+				 "<timer_instance_node_id> <time_in_us>"),
+		      cmd_timer_periodic, 3, 0),
 	SHELL_CMD_ARG(oneshot, &dsub_device_name,
-		      "timer oneshot <timer_instance_node_id> <channel_id> <time_in_us>",
+		      SHELL_HELP("Set a one-shot alarm on specified channel",
+				 "<timer_instance_node_id> <channel_id> <time_in_us>"),
 		      cmd_timer_oneshot, 4, 0),
-	SHELL_CMD_ARG(freerun, &dsub_device_name, "timer freerun <timer_instance_node_id>",
+	SHELL_CMD_ARG(freerun, &dsub_device_name,
+		      SHELL_HELP("Start a timer in free-running mode", "<timer_instance_node_id>"),
 		      cmd_timer_free_running, 2, 0),
-	SHELL_CMD_ARG(stop, &dsub_device_name, "timer stop <timer_instance_node_id>",
-		      cmd_timer_stop, 2, 0),
+	SHELL_CMD_ARG(stop, &dsub_device_name,
+		      SHELL_HELP("Stop a timer", "<timer_instance_node_id>"), cmd_timer_stop, 2, 0),
 	SHELL_SUBCMD_SET_END /* array terminated. */
 );
 

--- a/drivers/counter/counter_timer_shell.c
+++ b/drivers/counter/counter_timer_shell.c
@@ -16,9 +16,9 @@
 #define ARGV_ONESHOT_TIME  3
 
 /* number of periodic interrupts */
-#define PERIODIC_CYCLES    10
-#define MAX_DELAY          UINT32_MAX
-#define MAX_CHANNEL        255U
+#define PERIODIC_CYCLES 10
+#define MAX_DELAY       UINT32_MAX
+#define MAX_CHANNEL     255U
 
 static struct k_sem timer_sem;
 
@@ -29,8 +29,8 @@ static void timer_top_handler(const struct device *counter_dev, void *user_data)
 	k_sem_give(&timer_sem);
 }
 
-static void timer_alarm_handler(const struct device *counter_dev, uint8_t chan_id,
-				uint32_t ticks, void *user_data)
+static void timer_alarm_handler(const struct device *counter_dev, uint8_t chan_id, uint32_t ticks,
+				void *user_data)
 {
 	ARG_UNUSED(counter_dev);
 
@@ -69,7 +69,7 @@ static int cmd_timer_free_running(const struct shell *shctx, size_t argc, char *
 
 	shell_info(shctx, "%s: Timer is freerunning", argv[ARGV_DEV]);
 
-	return  0;
+	return 0;
 }
 
 static int cmd_timer_stop(const struct shell *shctx, size_t argc, char **argv)
@@ -215,20 +215,19 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_timer,
-			SHELL_CMD_ARG(periodic, &dsub_device_name,
-			"timer periodic <timer_instance_node_id> <time_in_us>",
-			cmd_timer_periodic, 3, 0),
-			SHELL_CMD_ARG(oneshot, &dsub_device_name,
-			"timer oneshot <timer_instance_node_id> <channel_id> <time_in_us>",
-			cmd_timer_oneshot, 4, 0),
-			SHELL_CMD_ARG(freerun, &dsub_device_name,
-			"timer freerun <timer_instance_node_id>",
-			cmd_timer_free_running, 2, 0),
-			SHELL_CMD_ARG(stop, &dsub_device_name,
-			"timer stop <timer_instance_node_id>",
-			cmd_timer_stop, 2, 0),
-			SHELL_SUBCMD_SET_END /* array terminated. */
-			);
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_timer,
+	SHELL_CMD_ARG(periodic, &dsub_device_name,
+		      "timer periodic <timer_instance_node_id> <time_in_us>", cmd_timer_periodic, 3,
+		      0),
+	SHELL_CMD_ARG(oneshot, &dsub_device_name,
+		      "timer oneshot <timer_instance_node_id> <channel_id> <time_in_us>",
+		      cmd_timer_oneshot, 4, 0),
+	SHELL_CMD_ARG(freerun, &dsub_device_name, "timer freerun <timer_instance_node_id>",
+		      cmd_timer_free_running, 2, 0),
+	SHELL_CMD_ARG(stop, &dsub_device_name, "timer stop <timer_instance_node_id>",
+		      cmd_timer_stop, 2, 0),
+	SHELL_SUBCMD_SET_END /* array terminated. */
+);
 
 SHELL_CMD_REGISTER(timer, &sub_timer, "Timer commands", NULL);


### PR DESCRIPTION
Adopt SHELL_HELP macro for counter_timer_shell

```console
uart:~$ timer --help
timer - Timer commands
Subcommands:
  periodic  : Start a periodic timer with specified interval
              Usage: periodic <timer_instance_node_id> <time_in_us>
  oneshot   : Set a one-shot alarm on specified channel
              Usage: oneshot <timer_instance_node_id> <channel_id> <time_in_us>
  freerun   : Start a timer in free-running mode
              Usage: freerun <timer_instance_node_id>
  stop      : Stop a timer
              Usage: stop <timer_instance_node_id>
```

before was looking like this:

```console
uart:~$ timer --help
timer - Timer commands
Subcommands:
  periodic  : timer periodic <timer_instance_node_id> <time_in_us>
  oneshot   : timer oneshot <timer_instance_node_id> <channel_id> <time_in_us>
  freerun   : timer freerun <timer_instance_node_id>
  stop      : timer stop <timer_instance_node_id>
```