### PR TITLE
drivers: comparator: adopt SHELL_HELP

### DIFF
--- a/drivers/comparator/comparator_shell.c
+++ b/drivers/comparator/comparator_shell.c
@@ -255,21 +255,19 @@ static void dsub_device_lookup_0(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_0, dsub_device_lookup_0);
 
-#define GET_OUTPUT_HELP \
-	("comp get_output <device>")
+#define GET_OUTPUT_HELP SHELL_HELP("Read comparator output", "<device>")
 
-#define SET_TRIGGER_HELP \
-	("comp set_trigger <device> <NONE | RISING_EDGE | FALLING_EDGE | BOTH_EDGES>")
+#define SET_TRIGGER_HELP                                                                           \
+	SHELL_HELP("Set comparator trigger",                                                       \
+		   "<device> <NONE | RISING_EDGE | FALLING_EDGE | BOTH_EDGES>")
 
-#define AWAIT_TRIGGER_HELP								\
-	("comp await_trigger <device> [timeout] (default "				\
-	 STRINGIFY(AWAIT_TRIGGER_DEFAULT_TIMEOUT)					\
-	 "s, max "									\
-	 STRINGIFY(AWAIT_TRIGGER_MAX_TIMEOUT)						\
-	 "s)")
+#define AWAIT_TRIGGER_HELP                                                                         \
+	SHELL_HELP("Await comparator trigger",                                                     \
+		   "<device> [timeout]\n"                                                          \
+		   "timeout: default=" STRINGIFY(AWAIT_TRIGGER_DEFAULT_TIMEOUT) "s, "              \
+		   "max=" STRINGIFY(AWAIT_TRIGGER_MAX_TIMEOUT) "s")
 
-#define TRIGGER_PENDING_HELP \
-	("comp trigger_is_pending <device>")
+#define TRIGGER_PENDING_HELP SHELL_HELP("Check comparator trigger status", "<device>")
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_comp,


### PR DESCRIPTION
Adopt SHELL_HELP macro for comparator_shell

```console
uart:~$ comp --help
comp - Comparator device commands
Subcommands:
  get_output          : Read comparator output
                        Usage: get_output <device>
  set_trigger         : Set comparator trigger
                        Usage: set_trigger <device> <NONE | RISING_EDGE | FALLING_EDGE | BOTH_EDGES>
  await_trigger       : Await comparator trigger
                        Usage: await_trigger <device> [timeout]
                               timeout: default=10s, max=60s
  trigger_is_pending  : Check comparator trigger status
                        Usage: trigger_is_pending <device>
```


before was:
```console
uart:~$ comp --help
comp - Comparator device commands
Subcommands:
  get_output          : comp get_output <device>
  set_trigger         : comp set_trigger <device> <NONE | RISING_EDGE | FALLING_EDGE | BOTH_EDGES>
  await_trigger       : comp await_trigger <device> [timeout] (default 10s, max 60s)
  trigger_is_pending  : comp trigger_is_pending <device>
```