### PR TITLE
drivers: serial: silabs: Don't fail to init if clock is on

### DIFF
--- a/drivers/serial/uart_silabs_eusart.c
+++ b/drivers/serial/uart_silabs_eusart.c
@@ -1017,7 +1017,7 @@ static int eusart_init(const struct device *dev)
 	/* The peripheral and gpio clock are already enabled from soc and gpio driver */
 	/* Enable EUSART clock */
 	err = clock_control_on(config->clock_dev, (clock_control_subsys_t)&config->clock_cfg);
-	if (err < 0) {
+	if (err < 0 && err != -EALREADY) {
 		return err;
 	}
 

--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -1019,7 +1019,7 @@ static int uart_silabs_init(const struct device *dev)
 	/* The peripheral and gpio clock are already enabled from soc and gpio driver */
 	/* Enable USART clock */
 	err = clock_control_on(config->clock_dev, (clock_control_subsys_t)&config->clock_cfg);
-	if (err < 0) {
+	if (err < 0 && err != -EALREADY) {
 		return err;
 	}
 


### PR DESCRIPTION
It is not an error if the clock source for the UART is already enabled. This may happen if a bootloader has used the UART and not de-initialized it before booting the application.