### PR TITLE
drivers: spi: silabs: Don't fail to init if clock is on

### DIFF
--- a/drivers/spi/spi_silabs_usart.c
+++ b/drivers/spi/spi_silabs_usart.c
@@ -342,7 +342,7 @@ static int spi_silabs_usart_init(const struct device *dev)
 	/* Enable USART clock */
 #ifdef CONFIG_CLOCK_CONTROL
 	err = clock_control_on(config->clock_dev, (clock_control_subsys_t)&config->clock_cfg);
-	if (err < 0) {
+	if (err < 0 && err != -EALREADY) {
 		return err;
 	}
 #else


### PR DESCRIPTION
It is not an error if the clock source is already enabled. This may happen if a bootloader has used the peripheral and not de-initialized it before booting the application.