### PR TITLE
drivers: pwm: adopt SHELL_HELP

### DIFF
--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -144,12 +144,21 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(pwm_cmds,
-	SHELL_CMD_ARG(cycles, &dsub_device_name, "<device> <channel> <period in cycles> "
-		      "<pulse width in cycles> [flags]", cmd_cycles, 5, 1),
-	SHELL_CMD_ARG(usec, &dsub_device_name, "<device> <channel> <period in usec> "
-		      "<pulse width in usec> [flags]", cmd_usec, 5, 1),
-	SHELL_CMD_ARG(nsec, &dsub_device_name, "<device> <channel> <period in nsec> "
-		      "<pulse width in nsec> [flags]", cmd_nsec, 5, 1),
+	SHELL_CMD_ARG(
+		cycles, &dsub_device_name,
+		SHELL_HELP("Set PWM period and pulse width in cycles.",
+			   "<device> <channel> <period> <pulse width> [flags]"),
+		cmd_cycles, 5, 1),
+	SHELL_CMD_ARG(
+		usec, &dsub_device_name,
+		SHELL_HELP("Set PWM period and pulse width in microseconds.",
+			   "<device> <channel> <period> <pulse width> [flags]"),
+		cmd_usec, 5, 1),
+	SHELL_CMD_ARG(
+		nsec, &dsub_device_name,
+		SHELL_HELP("Set PWM period and pulse width in nanoseconds.",
+			   "<device> <channel> <period> <pulse width> [flags]"),
+		cmd_nsec, 5, 1),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Adopt SHELL_HELP macro for pwm_shell

I am kind of tempted to add a help for what the flags value can be?
Also think that each help should just say `... <period> <pulse> ...`?


```console
uart:~$ pwm --help
pwm - PWM shell commands
Subcommands:
  cycles  : Set PWM period and pulse width in cycles.
            Usage: cycles <device> <channel> <period> <pulse width> [flags]
  usec    : Set PWM period and pulse width in microseconds.
            Usage: usec <device> <channel> <period> <pulse width> [flags]
  nsec    : Set PWM period and pulse width in nanoseconds.
            Usage: nsec <device> <channel> <period> <pulse width> [flags]
```


Before was:

```console
uart:~$ pwm --help
pwm - PWM shell commands
Subcommands:
  cycles  : <device> <channel> <period in cycles> <pulse width in cycles> [flags]
  usec    : <device> <channel> <period in usec> <pulse width in usec> [flags]
  nsec    : <device> <channel> <period in nsec> <pulse width in nsec> [flags]
```