### PR TITLE
drivers: adc: silabs: Don't fail to init if clock is on

### DIFF
--- a/drivers/adc/iadc_gecko.c
+++ b/drivers/adc/iadc_gecko.c
@@ -370,7 +370,7 @@ static int adc_gecko_pm_action(const struct device *dev, enum pm_device_action a
 	if (action == PM_DEVICE_ACTION_RESUME) {
 		err = clock_control_on(config->clock_dev,
 				       (clock_control_subsys_t)&config->clock_cfg);
-		if (err < 0) {
+		if (err < 0 && err != -EALREADY) {
 			return err;
 		}
 


### PR DESCRIPTION
It is not an error if the clock source is already enabled. This may happen if a bootloader has used the peripheral and not de-initialized it before booting the application.