### PR TITLE
sensor: dht: Fix multi-instance type handling

### DIFF
--- a/drivers/sensor/aosong/dht/dht.c
+++ b/drivers/sensor/aosong/dht/dht.c
@@ -182,12 +182,13 @@ static int dht_channel_get(const struct device *dev,
 			   struct sensor_value *val)
 {
 	struct dht_data *drv_data = dev->data;
+	const struct dht_config *cfg = dev->config;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_AMBIENT_TEMP
 			|| chan == SENSOR_CHAN_HUMIDITY);
 
 	/* see data calculation example from datasheet */
-	if (IS_ENABLED(DT_INST_PROP(0, dht22))) {
+	if (cfg->is_dht22) {
 		/*
 		 * use both integral and decimal data bytes; resulted
 		 * 16bit data has a resolution of 0.1 units
@@ -258,6 +259,7 @@ static int dht_init(const struct device *dev)
 											\
 	static const struct dht_config dht_config_##inst = {				\
 		.dio_gpio = GPIO_DT_SPEC_INST_GET(inst, dio_gpios),			\
+		.is_dht22 = DT_INST_PROP(inst, dht22),					\
 	};										\
 											\
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, &dht_init, NULL,				\

--- a/drivers/sensor/aosong/dht/dht.h
+++ b/drivers/sensor/aosong/dht/dht.h
@@ -19,6 +19,7 @@ struct dht_data {
 
 struct dht_config {
 	struct gpio_dt_spec dio_gpio;
+	bool is_dht22; /* true for DHT22, false for DHT11 */
 };
 
 #endif


### PR DESCRIPTION
The DHT driver incorrectly assumes all sensor instances are the same type as the first instance (dht@0). The data parsing logic uses a hardcoded check of the devicetree property for instance 0, which causes incorrect readings when different sensor models (e.g., DHT11 and DHT22) are used together.

This change stores the model type in each per-instance config struct during initialization. The data parsing logic is updated to use this per-instance flag, ensuring each sensor is handled correctly according to its specific model.

Fixes: #91468

Signed-off-by: John Shelton <moosery@gmail.com>