### PR TITLE
drivers: gpio: cmsdk_ahb: support gpio_pin_get_config_dt

### DIFF
--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Linaro Limited.
+ * Copyright (c) 2025 Atmosic
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -134,6 +135,23 @@ int cmsdk_ahb_gpio_config(const struct device *dev, uint32_t mask, gpio_flags_t 
 	return 0;
 }
 
+#ifdef CONFIG_GPIO_GET_CONFIG
+static int gpio_cmsdk_ahb_get_config(const struct device *dev, gpio_pin_t pin, gpio_flags_t *flags)
+{
+	const struct gpio_cmsdk_ahb_cfg *const cfg = dev->config;
+
+	uint32_t mask = BIT(pin);
+
+	*flags = GPIO_DISCONNECTED;
+
+	if (cfg->port->outenableset & mask) {
+		*flags |= (cfg->port->dataout & mask) ? GPIO_OUTPUT_HIGH : GPIO_OUTPUT_LOW;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_GPIO_GET_CONFIG */
+
 /**
  * @brief Configure pin or port
  *
@@ -217,6 +235,9 @@ static int gpio_cmsdk_ahb_manage_callback(const struct device *dev,
 
 static DEVICE_API(gpio, gpio_cmsdk_ahb_drv_api_funcs) = {
 	.pin_configure = gpio_cmsdk_ahb_config,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = gpio_cmsdk_ahb_get_config,
+#endif
 	.port_get_raw = gpio_cmsdk_ahb_port_get_raw,
 	.port_set_masked_raw = gpio_cmsdk_ahb_port_set_masked_raw,
 	.port_set_bits_raw = gpio_cmsdk_ahb_port_set_bits_raw,


### PR DESCRIPTION
The `gpio_cmsdk_ahb.c` didn't support the get configuration API. This change is to add the feature to it.