### PR TITLE
drivers: dma: max32: check if bit other than status is set

### DIFF
--- a/drivers/dma/dma_max32.c
+++ b/drivers/dma/dma_max32.c
@@ -258,6 +258,11 @@ static void max32_dma_isr(const struct device *dev)
 			continue;
 		}
 
+		/* check if only enabled bit is set (interrupt is not there) and skip it */
+		if (flags == ADI_MAX32_DMA_STATUS_ST) {
+			continue;
+		}
+
 		/* Check for error interrupts */
 		if (flags & (ADI_MAX32_DMA_STATUS_BUS_ERR | ADI_MAX32_DMA_STATUS_TO_IF)) {
 			status = -EIO;


### PR DESCRIPTION
### Description

On any DMA interrupt, we iterate over all the channels, and if more than one channel is active at a time, This causes callback trigger on all active channel even with no interrupt. Because we check for flags <= 0, and for active channel bit 0 (enable bit) is set.
thus causing flags = 1, and iteration is not skipped.
This commit handle this behavior by skipping channel if only enable bit is set. thus triggering callback only on channels with a interrupt bit set.