### PR TITLE
disk: sdmmc: support L4 series with shared DMA channel

### DIFF
--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -70,10 +70,15 @@ properties:
 
       For example dmas for TX/RX on SDMMC
          dmas = <&dma2 4 6 0x30000 0x00>, <&dma2 4 3 0x30000 0x00>;
+      Alternatively, for a shared TX/RX DMA channels on a STM32L4
+         dmas = <&dma2 5 7 STM32_DMA_PRIORITY_HIGH>;
 
   dma-names:
     description: |
-      DMA channel name. If DMA should be used, expected value is "tx", "rx".
+      DMA channel name. If DMA should be used, expected value is either "tx", "rx"
+      or a single "txrx" for the shared channel configuration
 
       For example
          dma-names = "tx", "rx";
+      or
+         dma-names = "txrx";

--- a/tests/drivers/disk/disk_access/boards/stm32l496g_disco_stm32l496xx.conf
+++ b/tests/drivers/disk/disk_access/boards/stm32l496g_disco_stm32l496xx.conf
@@ -1,0 +1,1 @@
+CONFIG_DMA=y

--- a/tests/drivers/disk/disk_access/boards/stm32l496g_disco_stm32l496xx.overlay
+++ b/tests/drivers/disk/disk_access/boards/stm32l496g_disco_stm32l496xx.overlay
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&sdmmc1 {
+	/* Channel 5 request 7 on DMA2 */
+	dmas = <&dma2 5 7 STM32_DMA_PRIORITY_HIGH>;
+	dma-names = "txrx";
+};


### PR DESCRIPTION
Update the driver to support DMA operations on L4 series devices, with
a shared DMA channel. Split channels do not work on these chips, since
there is no dedicated TX and RX channels on the DMA, so configuring two
channels with SDMMC as the peripheral results in a non-functional
configuration.

Fixes #91216.