### PR TITLE
boards: frdm_mcxa166, frdm_mcxa276: add ostimer support

### DIFF
--- a/boards/nxp/frdm_mcxa166/board.c
+++ b/boards/nxp/frdm_mcxa166/board.c
@@ -234,6 +234,10 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_LF_DIV_to_LPSPI1);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ostimer0))
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lptmr0))
 
 /*

--- a/boards/nxp/frdm_mcxa276/board.c
+++ b/boards/nxp/frdm_mcxa276/board.c
@@ -239,6 +239,10 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO_LF_DIV_to_LPSPI1);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ostimer0))
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lptmr0))
 
 /*

--- a/drivers/timer/mcux_os_timer.c
+++ b/drivers/timer/mcux_os_timer.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/counter.h>
 #include <zephyr/pm/pm.h>
 #include "fsl_ostimer.h"
-#ifndef CONFIG_SOC_SERIES_MCXN
+#if !defined(CONFIG_SOC_SERIES_MCXN) && !defined(CONFIG_SOC_SERIES_MCXA)
 #include "fsl_power.h"
 #endif
 

--- a/dts/arm/nxp/nxp_mcxa166.dtsi
+++ b/dts/arm/nxp/nxp_mcxa166.dtsi
@@ -397,6 +397,13 @@
 			status = "disabled";
 		};
 
+		ostimer0: timers@400ad000 {
+			compatible = "nxp,os-timer";
+			reg = <0x400ad000 0x1000>;
+			interrupts = <57 0>;
+			status = "disabled";
+		};
+
 		wwdt0: watchdog@4000c000 {
 			compatible = "nxp,lpc-wwdt";
 			reg = <0x4000c000 0x1000>;

--- a/dts/arm/nxp/nxp_mcxa276.dtsi
+++ b/dts/arm/nxp/nxp_mcxa276.dtsi
@@ -410,6 +410,13 @@
 			status = "disabled";
 		};
 
+		ostimer0: timers@400ad000 {
+			compatible = "nxp,os-timer";
+			reg = <0x400ad000 0x1000>;
+			interrupts = <57 0>;
+			status = "disabled";
+		};
+
 		wwdt0: watchdog@4000c000 {
 			compatible = "nxp,lpc-wwdt";
 			reg = <0x4000c000 0x1000>;


### PR DESCRIPTION
1. add the ostimer
2. by default, the systick is used.
3. The ostimer could be tested with below configure in xxx.overlay: 
&systick {
    status = "disabled";
};

&ostimer0 {
    status = "okay";
};
And below configure in xxx.conf:
CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=1000000