### PR TITLE
driver: flash: mspi_nor: Allow Single IO mode for flash on nRF54H20-DK

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -293,6 +293,7 @@ ipc0: &cpuapp_cpurad_ipc {
 		mspi-cpp-mode = "MSPI_CPP_MODE_0";
 		mspi-endian = "MSPI_BIG_ENDIAN";
 		mspi-ce-polarity = "MSPI_CE_ACTIVE_LOW";
+		quad-enable-requirements = "S1B6";
 	};
 };
 

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -84,6 +84,7 @@ const struct flash_mspi_nor_cmds commands_single = {
 		.cmd = SPI_NOR_CMD_WREN,
 		.cmd_length = 1,
 	},
+#ifdef CONFIG_MSPI_SINGLE_IO_DUMMY_CYCLES_SUPPORTED
 	.read = {
 		.dir = MSPI_RX,
 		.cmd = SPI_NOR_CMD_READ_FAST,
@@ -91,6 +92,14 @@ const struct flash_mspi_nor_cmds commands_single = {
 		.addr_length = 3,
 		.rx_dummy = 8,
 	},
+#else
+	.read = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_READ,
+		.cmd_length = 1,
+		.addr_length = 3,
+	},
+#endif
 	.status = {
 		.dir = MSPI_RX,
 		.cmd = SPI_NOR_CMD_RDSR,
@@ -118,6 +127,7 @@ const struct flash_mspi_nor_cmds commands_single = {
 		.cmd = SPI_NOR_CMD_CE,
 		.cmd_length = 1,
 	},
+#ifdef CONFIG_MSPI_SINGLE_IO_DUMMY_CYCLES_SUPPORTED
 	.sfdp = {
 		.dir = MSPI_RX,
 		.cmd = JESD216_CMD_READ_SFDP,
@@ -125,6 +135,14 @@ const struct flash_mspi_nor_cmds commands_single = {
 		.addr_length = 3,
 		.rx_dummy = 8,
 	},
+#else
+	.sfdp = {
+		.dir = MSPI_RX,
+		.cmd = JESD216_CMD_READ_SFDP,
+		.cmd_length = 2,
+		.addr_length = 3,
+	},
+#endif
 };
 
 const struct flash_mspi_nor_cmds commands_quad_1_4_4 = {

--- a/drivers/mspi/Kconfig
+++ b/drivers/mspi/Kconfig
@@ -55,6 +55,11 @@ config MSPI_TIMING
 	  Enables mspi_timing_config calls in device drivers for those
 	  controllers that need this to proper function at high frequencies.
 
+config MSPI_SINGLE_IO_DUMMY_CYCLES_SUPPORTED
+	bool "Single IO mode supports dummy TX/RX cycles"
+	help
+	  Some drivers do not support dummy TX/RX cycles in single IO mode.
+
 module = MSPI
 module-str = mspi
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/mspi/Kconfig.ambiq
+++ b/drivers/mspi/Kconfig.ambiq
@@ -19,6 +19,7 @@ config MSPI_AMBIQ_AP3
 	imply MSPI_XIP
 	imply MSPI_SCRAMBLE
 	imply MSPI_TIMING
+	imply MSPI_SINGLE_IO_DUMMY_CYCLES_SUPPORTED
 	help
 	  Enable driver for Ambiq MSPI.
 


### PR DESCRIPTION
The flash MX25UW6345G on a nRF54H20-DK supports Single IO along with Quad IO mode. However, using Single IO does not work right away after changing the device tree setting to `mspi-io-mode = "MSPI_IO_MODE_SINGLE";` because of the following issues:


## Quad-Enable Requirement for Using Single IO

If the driver does not see this setting `quad-enable-requirements = "S1B6";` for Single IO mode, it fails out.
https://github.com/zephyrproject-rtos/zephyr/blob/ab3d2dc830fbbbe2abbfb3aff83614956aa74a98/drivers/flash/flash_mspi_nor.c#L571-L572
https://github.com/zephyrproject-rtos/zephyr/blob/ab3d2dc830fbbbe2abbfb3aff83614956aa74a98/drivers/flash/flash_mspi_nor.c#L548-L551

Luckily, Status Byte 1 Bit 6 for this flash part is not used for anything, and with local testing it is functional with this change.
![image](https://github.com/user-attachments/assets/60cc0600-3f2a-4012-9d5c-b81db251209a)

A proper fix for the driver has been requested to Nordic in Customer Support. I am suggesting this fix should be added till then to enable experimentation with MSPI Single IO on this eval-kit with an easy config override.

---

## Dummy TX/RX Cycles not supported in Single IO

https://github.com/zephyrproject-rtos/zephyr/blob/d4648a676717a609366decdb9b25fbe1d7767b1d/drivers/mspi/mspi_dw.c#L982-L985

Because of this limitation in MSPI DW driver, the flash MSPI driver should choose different READ command which does not require dummy cycles, like:
![image](https://github.com/user-attachments/assets/03d9fdc3-3b91-4545-a04e-c4427132a766)

Proper fix in the underlying MSPI DW again has been requested from Nordic Customer Support.

---
---

# Test

Sample application with filesystem and shell work just fine even with `mspi-io-mode = "MSPI_IO_MODE_SINGLE";` and lower max frequency (10MHz) now:
```
[00:00:00.352,086] <inf> littlefs: littlefs partition at /main
[00:00:00.352,103] <inf> littlefs: LittleFS version 2.9, disk version 2.1
[00:00:00.352,139] <inf> littlefs: FS at mx25uw6345g@0:0x0 is 128 0x10000-byte blocks with 512 cycle
[00:00:00.352,144] <inf> littlefs: partition sizes: rd 16 ; pr 16 ; ca 64 ; la 32
[00:00:00.352,780] <inf> littlefs: Automount /main succeeded
*** Booting nRF Connect SDK v3.0.0-3bfc46578e42 ***
*** Using Zephyr OS v4.0.99-c511707eb13d ***
Hello world from nrf54h20dk@0.9.0/nrf54h20/cpuapp

> fs erase_write_test /main/file 865240 2
Loop #1 done in 22099ms.
Loop #2 done in 22039ms.
Total: 44138ms, Per loop: ~22069ms, Speed: ~38.3KiBps

> fs read_test /main/file 2
File size: 845.0KiB
Loop #1 done in 1058ms.
Loop #2 done in 1058ms.
Total: 2116ms, Per loop: ~1058ms, Speed: ~798.6KiBps
```

