### PR TITLE
drivers/sensor/: lis2dux12: support FIFO modes

### DIFF
--- a/drivers/sensor/st/lis2dux12/lis2dux12.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12.c
@@ -277,6 +277,7 @@ static DEVICE_API(sensor, lis2dux12_driver_api) = {
 	.odr = DT_INST_PROP(inst, odr),							\
 	IF_ENABLED(CONFIG_LIS2DUX12_STREAM,						\
 		   (.fifo_wtm = DT_INST_PROP(inst, fifo_watermark),			\
+		    .fifo_mode_sel = DT_INST_PROP(inst, fifo_mode_sel),			\
 		    .accel_batch  = DT_INST_PROP(inst, accel_fifo_batch_rate),		\
 		    .ts_batch  = DT_INST_PROP(inst, timestamp_fifo_batch_rate),))	\
 	IF_ENABLED(UTIL_OR(DT_INST_NODE_HAS_PROP(inst, int1_gpios),			\

--- a/drivers/sensor/st/lis2dux12/lis2dux12.h
+++ b/drivers/sensor/st/lis2dux12/lis2dux12.h
@@ -106,7 +106,8 @@ struct lis2dux12_config {
 	uint8_t fifo_wtm;
 	uint8_t accel_batch : 3;
 	uint8_t ts_batch : 2;
-	uint8_t reserved : 3;
+	uint8_t fifo_mode_sel : 2;
+	uint8_t reserved : 1;
 #endif
 #ifdef CONFIG_LIS2DUX12_TRIGGER
 	const struct gpio_dt_spec int1_gpio;

--- a/drivers/sensor/st/lis2dux12/lis2dux12_decoder.h
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_decoder.h
@@ -29,11 +29,12 @@ struct lis2dux12_decoder_header {
 struct lis2dux12_fifo_data {
 	struct lis2dux12_decoder_header header;
 	uint32_t accel_odr: 4;
+	uint32_t fifo_mode_sel: 2;
 	uint32_t fifo_count: 7;
 	uint32_t reserved_1: 5;
 	uint32_t accel_batch_odr: 3;
 	uint32_t ts_batch_odr: 2;
-	uint32_t reserved: 11;
+	uint32_t reserved: 9;
 } __attribute__((__packed__));
 
 struct lis2dux12_rtio_data {

--- a/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
@@ -123,6 +123,7 @@ static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, v
 {
 	const struct device *dev = arg;
 	struct lis2dux12_data *lis2dux12 = dev->data;
+	const struct lis2dux12_config *cfg = dev->config;
 	struct rtio *rtio = lis2dux12->rtio_ctx;
 	struct gpio_dt_spec *irq_gpio = lis2dux12->drdy_gpio;
 	struct rtio_iodev *iodev = lis2dux12->iodev;
@@ -228,6 +229,7 @@ static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, v
 		rx_data->header.timestamp = lis2dux12->timestamp;
 		rx_data->header.int_status = lis2dux12->fifo_status[0];
 		rx_data->fifo_count = 0;
+		rx_data->fifo_mode_sel = 0;
 
 		/* complete request with ok */
 		rtio_iodev_sqe_ok(lis2dux12->streaming_sqe, 0);
@@ -281,6 +283,7 @@ static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, v
 			.int_status = lis2dux12->fifo_status[0],
 		},
 		.fifo_count = fifo_count,
+		.fifo_mode_sel = cfg->fifo_mode_sel,
 		.accel_batch_odr = lis2dux12->accel_batch_odr,
 		.accel_odr = lis2dux12->odr,
 	};

--- a/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
+++ b/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
@@ -155,7 +155,7 @@ static void st_lis2duxs12_stream_config_fifo(const struct device *dev,
 
 	/* disable FIFO as first thing */
 	fifo_mode.store = LIS2DUXS12_FIFO_1X;
-	fifo_mode.xl_only = 1;
+	fifo_mode.xl_only = 0;
 	fifo_mode.watermark = 0;
 	fifo_mode.operation = LIS2DUXS12_BYPASS_MODE;
 	fifo_mode.batch.dec_ts = LIS2DUXS12_DEC_TS_OFF;
@@ -168,10 +168,32 @@ static void st_lis2duxs12_stream_config_fifo(const struct device *dev,
 		pin_int.fifo_th = (trig_cfg.int_fifo_th) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 		pin_int.fifo_full = (trig_cfg.int_fifo_full) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
 
+		switch (config->fifo_mode_sel) {
+		case 0:
+			fifo_mode.store = LIS2DUXS12_FIFO_1X;
+			fifo_mode.xl_only = 0;
+			break;
+		case 1:
+			fifo_mode.store = LIS2DUXS12_FIFO_1X;
+			fifo_mode.xl_only = 1;
+			break;
+		case 2:
+			fifo_mode.store = LIS2DUXS12_FIFO_2X;
+			fifo_mode.xl_only = 1;
+			break;
+		}
+
 		fifo_mode.operation = LIS2DUXS12_STREAM_MODE;
 		fifo_mode.batch.dec_ts = config->ts_batch;
 		fifo_mode.batch.bdr_xl = config->accel_batch;
 		fifo_mode.watermark = config->fifo_wtm;
+
+		/* In case each FIFO word contains 2x accelerometer samples,
+		 * then watermark can be divided by two to match user expectation.
+		 */
+		if (config->fifo_mode_sel == 2) {
+			fifo_mode.watermark /= 2;
+		}
 	}
 
 	/*

--- a/dts/bindings/sensor/st,lis2dux12-common.yaml
+++ b/dts/bindings/sensor/st,lis2dux12-common.yaml
@@ -94,6 +94,19 @@ properties:
 
     enum: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 
+  fifo-mode-sel:
+    type: int
+    default: 0x0
+    description: |
+      Specify the sample content to be batched in FIFO.
+      Default is power-up configuration.
+
+      - 0x0 # 1x Accelerometer @12bit and 1x temperature @12bit samples
+      - 0x1 # 1x Accelerometer @16bit sample
+      - 0x2 # 2x Accelerometer @8bit samples (previous and current)
+
+    enum: [0x00, 0x01, 0x02]
+
   fifo-watermark:
     type: int
     default: 32


### PR DESCRIPTION
Support three different FIFO contents which are selectable through a new DT property, fifo-mode-sel, which may be set to one of the following values:

    - 0x0 # 1x Accelerometer @12bit and 1x temperature @12bit samples
    - 0x1 # 1x Accelerometer @16bit sample
    - 0x2 # 2x Accelerometer @8bit samples (previous and current)