### PR TITLE
drivers: wifi: esp_at: fix some crash issues

### DIFF
--- a/drivers/wifi/esp_at/esp_socket.c
+++ b/drivers/wifi/esp_at/esp_socket.c
@@ -76,6 +76,11 @@ void esp_socket_unref(struct esp_socket *sock)
 		}
 	} while (!atomic_cas(&sock->refcount, ref, ref - 1));
 
+	/* notifies free only on 1-to-0 transition */
+	if (ref > 1) {
+		return;
+	}
+
 	k_sem_give(&sock->sem_free);
 }
 


### PR DESCRIPTION
This fixes some crash issues on `esp_at` modem when running `net/sockets/big_http_download` sample with tls enabled, including:
1. Premature socket release when `esp_rx` thread can still hold reference to this socket
2. Deadlock in socket close path
