### PR TITLE
Bind DHCP received DNS server to correct network interface

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -490,18 +490,23 @@ static void esp_dns_work(struct k_work *work)
 	struct dns_resolve_context *dnsctx;
 	struct sockaddr_in *addrs = data->dns_addresses;
 	const struct sockaddr *dns_servers[ESP_MAX_DNS + 1] = {};
+	int interfaces[ESP_MAX_DNS];
 	size_t i;
-	int err;
+	int err, ifindex;
+
+	ifindex = net_if_get_by_ifindex(data->net_iface);
 
 	for (i = 0; i < ESP_MAX_DNS; i++) {
 		if (!addrs[i].sin_addr.s_addr) {
 			break;
 		}
 		dns_servers[i] = (struct sockaddr *) &addrs[i];
+		interfaces[i] = ifindex;
 	}
 
 	dnsctx = dns_resolve_get_default();
-	err = dns_resolve_reconfigure(dnsctx, NULL, dns_servers);
+	err = dns_resolve_reconfigure_with_interfaces(dnsctx, NULL, dns_servers,
+						      interfaces);
 	if (err) {
 		LOG_ERR("Could not set DNS servers: %d", err);
 	}

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -551,6 +551,16 @@ int dns_resolve_reconfigure_with_interfaces(struct dns_resolve_context *ctx,
 					    int interfaces[]);
 
 /**
+ * @brief Remove servers from the DNS resolving context.
+ *
+ * @param ctx DNS context
+ * @param if_index Network interface from which the DNS servers are removed.
+ *
+ * @return 0 if ok, <0 if error.
+ */
+int dns_resolve_remove(struct dns_resolve_context *ctx, int if_index);
+
+/**
  * @brief Cancel a pending DNS query.
  *
  * @details This releases DNS resources used by a pending query.

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -320,6 +320,7 @@ typedef void (*dns_resolve_cb_t)(enum dns_resolve_status status,
 /** @cond INTERNAL_HIDDEN */
 
 enum dns_resolve_context_state {
+	DNS_RESOLVE_CONTEXT_UNINITIALIZED = 0,
 	DNS_RESOLVE_CONTEXT_ACTIVE,
 	DNS_RESOLVE_CONTEXT_DEACTIVATING,
 	DNS_RESOLVE_CONTEXT_INACTIVE,

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -525,6 +525,32 @@ int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
 			    const struct sockaddr *servers_sa[]);
 
 /**
+ * @brief Reconfigure DNS resolving context with new server list and
+ *        allowing servers to be specified to a specific network interface.
+ *
+ * @param ctx DNS context
+ * @param servers_str DNS server addresses using textual strings. The
+ *        array is NULL terminated. The port number can be given in the string.
+ *        Syntax for the server addresses with or without port numbers:
+ *           IPv4        : 10.0.9.1
+ *           IPv4 + port : 10.0.9.1:5353
+ *           IPv6        : 2001:db8::22:42
+ *           IPv6 + port : [2001:db8::22:42]:5353
+ * @param servers_sa DNS server addresses as struct sockaddr. The array
+ *        is NULL terminated. Port numbers are optional in struct sockaddr, the
+ *        default will be used if set to 0.
+ * @param interfaces Network interfaces to which the DNS servers are bound.
+ *        This is an array of network interface indices. The array must be
+ *        the same length as the servers_str and servers_sa arrays.
+ *
+ * @return 0 if ok, <0 if error.
+ */
+int dns_resolve_reconfigure_with_interfaces(struct dns_resolve_context *ctx,
+					    const char *servers_str[],
+					    const struct sockaddr *servers_sa[],
+					    int interfaces[]);
+
+/**
  * @brief Cancel a pending DNS query.
  *
  * @details This releases DNS resources used by a pending query.

--- a/subsys/net/ip/Kconfig.stack
+++ b/subsys/net/ip/Kconfig.stack
@@ -17,6 +17,7 @@ config NET_TX_STACK_SIZE
 
 config NET_RX_STACK_SIZE
 	int "RX thread stack size"
+	default 1792 if DNS_RESOLVER
 	default 1500
 	help
 	  Set the RX thread stack size in bytes. The RX thread is waiting

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2469,6 +2469,9 @@ static inline bool handle_ra_rdnss(struct net_pkt *pkt, uint8_t len)
 	const struct sockaddr *dns_servers[] = {
 		(struct sockaddr *)&dns, NULL
 	};
+	int interfaces[] = {
+		net_if_get_by_iface(net_pkt_iface(pkt))
+	};
 	size_t rdnss_size;
 	int ret;
 
@@ -2505,7 +2508,8 @@ static inline bool handle_ra_rdnss(struct net_pkt *pkt, uint8_t len)
 
 	/* TODO: Handle lifetime. */
 	ctx = dns_resolve_get_default();
-	ret = dns_resolve_reconfigure(ctx, NULL, dns_servers);
+	ret = dns_resolve_reconfigure_with_interfaces(ctx, NULL, dns_servers,
+						      interfaces);
 	if (ret < 0) {
 		NET_DBG("Failed to set RDNSS resolve address: %d", ret);
 	}

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -327,6 +327,8 @@ static void ipcp_set_dns_servers(struct ppp_fsm *fsm)
 		(struct sockaddr *) &dns2,
 		NULL
 	};
+	int ifindex = net_if_get_by_iface(ctx->iface);
+	int interfaces[2] = { ifindex, ifindex };
 	int ret;
 
 	if (!dns1.sin_addr.s_addr) {
@@ -338,7 +340,8 @@ static void ipcp_set_dns_servers(struct ppp_fsm *fsm)
 	}
 
 	dnsctx = dns_resolve_get_default();
-	ret = dns_resolve_reconfigure(dnsctx, NULL, dns_servers);
+	ret = dns_resolve_reconfigure_with_interfaces(dnsctx, NULL, dns_servers,
+						      interfaces);
 	if (ret < 0) {
 		NET_ERR("Could not set DNS servers");
 		return;

--- a/subsys/net/lib/dhcpv4/Kconfig
+++ b/subsys/net/lib/dhcpv4/Kconfig
@@ -96,6 +96,23 @@ config NET_DHCPV4_OPTION_PRINT_IGNORED
 	  received and ignored. If this is not set, then we print these as unknown
 	  options.
 
+config NET_DHCPV4_DNS_SERVER_VIA_INTERFACE
+	bool "Make DNS servers specific to the network interface"
+	depends on NET_DHCPV4_OPTION_DNS_ADDRESS
+	default y
+	help
+	  If this is set, then if the system has multiple network interfaces
+	  and each has DHCP enabled, then assign DNS servers received from that
+	  network interface, to that specific interface.
+	  If this option is not set, then any interface can be used for all
+	  the configured DNS server addresses when doing DNS queries.
+	  Example: We receive DNS server 192.0.2.53 DHCPv4 option from Wi-Fi
+	  interface and DNS server 198.51.100.53 from Ethernet interface.
+	  When this option is set, the DNS resolver will use DNS server
+	  192.0.2.53 when sending DNS query to the Wi-Fi interface and DNS
+	  server 198.51.100.53 when sending DNS query to the Ethernet
+	  interface.
+
 endif # NET_DHCPV4
 
 config NET_DHCPV4_SERVER

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1668,6 +1668,16 @@ static void dhcpv4_iface_event_handler(struct net_mgmt_event_callback *cb,
 			if (!net_if_ipv4_addr_rm(iface, &iface->config.dhcpv4.requested_ip)) {
 				NET_DBG("Failed to remove addr from iface");
 			}
+
+			/* Remove DNS servers as interface is gone. We only need to
+			 * do this for this interface. If using global setting, the
+			 * DNS servers are removed automatically when the interface
+			 * comes back up.
+			 */
+			if (IS_ENABLED(CONFIG_NET_DHCPV4_DNS_SERVER_VIA_INTERFACE)) {
+				dns_resolve_remove(dns_resolve_get_default(),
+						   net_if_get_by_iface(iface));
+			}
 		}
 	} else if (mgmt_event == NET_EVENT_IF_UP) {
 		NET_DBG("Interface %p coming up", iface);

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1171,7 +1171,25 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 			for (uint8_t i = 0; i < dns_servers_cnt; i++) {
 				dnses[i].sin_family = AF_INET;
 			}
-			status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
+
+			if (IS_ENABLED(CONFIG_NET_DHCPV4_DNS_SERVER_VIA_INTERFACE)) {
+				/* If we are using the interface to resolve DNS servers,
+				 * we need to save the interface index.
+				 */
+				int ifindex = net_if_get_by_iface(iface);
+				int interfaces[MAX_DNS_SERVERS];
+
+				for (uint8_t i = 0; i < dns_servers_cnt; i++) {
+					interfaces[i] = ifindex;
+				}
+
+				status = dns_resolve_reconfigure_with_interfaces(ctx, NULL,
+										 dns_servers,
+										 interfaces);
+			} else {
+				status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
+			}
+
 			if (status < 0) {
 				NET_DBG("options_dns, failed to set "
 					"resolve address: %d", status);

--- a/subsys/net/lib/dhcpv6/Kconfig
+++ b/subsys/net/lib/dhcpv6/Kconfig
@@ -31,6 +31,23 @@ config NET_DHCPV6_OPTION_DNS_ADDRESS
 	  option from the server, and if available, use obtained information
 	  to configure DNS resolver.
 
+config NET_DHCPV6_DNS_SERVER_VIA_INTERFACE
+	bool "Make DNS servers specific to the network interface"
+	depends on NET_DHCPV6_OPTION_DNS_ADDRESS
+	default y
+	help
+	  If this is set, then if the system has multiple network interfaces
+	  and each has DHCP enabled, then assign DNS servers received from that
+	  network interface, to that specific interface.
+	  If this option is not set, then any interface can be used for all
+	  the configured DNS server addresses when doing DNS queries.
+	  Example: We receive DNS server 2001:db8::1:53 DHCPv6 option from Wi-Fi
+	  interface and DNS server 2001:db8::2:53 from Ethernet interface.
+	  When this option is set, the DNS resolver will use DNS server
+	  2001:db8::1:53 when sending DNS query to the Wi-Fi interface and DNS
+	  server 2001:db8::2:53 when sending DNS query to the Ethernet
+	  interface.
+
 if NET_DHCPV6
 module = NET_DHCPV6
 module-dep = NET_LOG

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -2217,6 +2217,16 @@ static void dhcpv6_iface_event_handler(struct net_mgmt_event_callback *cb,
 	if (mgmt_event == NET_EVENT_IF_DOWN) {
 		NET_DBG("Interface %p going down", iface);
 		dhcpv6_set_timeout(iface, UINT64_MAX);
+
+		/* Remove DNS servers as interface is gone. We only need to
+		 * do this for this interface. If using global setting, the
+		 * DNS servers are removed automatically when the interface
+		 * comes back up.
+		 */
+		if (IS_ENABLED(CONFIG_NET_DHCPV6_DNS_SERVER_VIA_INTERFACE)) {
+			dns_resolve_remove(dns_resolve_get_default(),
+					   net_if_get_by_iface(iface));
+		}
 	} else if (mgmt_event == NET_EVENT_IF_UP) {
 		NET_DBG("Interface %p coming up", iface);
 		dhcpv6_enter_state(iface, NET_DHCPV6_INIT);

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -1412,7 +1412,25 @@ static int dhcpv6_handle_dns_server_option(struct net_pkt *pkt)
 	}
 
 	ctx = dns_resolve_get_default();
-	status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
+
+	if (IS_ENABLED(CONFIG_NET_DHCPV6_DNS_SERVER_VIA_INTERFACE)) {
+		/* If we are using the interface to resolve DNS servers,
+		 * we need to save the interface index.
+		 */
+		int ifindex = net_if_get_by_iface(net_pkt_iface(pkt));
+		int interfaces[MAX_DNS_SERVERS];
+
+		for (uint8_t i = 0; i < server_count; i++) {
+			interfaces[i] = ifindex;
+		}
+
+		status = dns_resolve_reconfigure_with_interfaces(ctx, NULL,
+								 dns_servers,
+								 interfaces);
+	} else {
+		status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
+	}
+
 	if (status < 0) {
 		NET_DBG("Failed to reconfigure DNS resolver from DHCPv6 "
 			"option: %d", status);

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -121,6 +121,19 @@ config DNS_SERVER5
 
 endif # DNS_SERVER_IP_ADDRESSES
 
+config DNS_RECONFIGURE_CLEANUP
+	bool "Cleanup old DNS server entries when reconfiguring"
+	help
+	  If calling dns_resolve_reconfigure() when new DNS servers
+	  are being set, for example if receiving new ones from DHCP server,
+	  remove the old entries before setting up the new ones.
+	  If you have only one network interface, then this can be enabled.
+	  If you have multiple network interfaces, then this should be disabled
+	  because the later configuration update would remove the entries
+	  set by the other network interface configuration.
+	  The previous default in Zephyr 4.1 or earlier was to have this enabled.
+	  The current default in Zephyr 4.2 is to disable this option.
+
 config DNS_NUM_CONCUR_QUERIES
 	int "Number of simultaneous DNS queries per one DNS context"
 	default 1

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1877,9 +1877,10 @@ static bool dns_servers_exists(struct dns_resolve_context *ctx,
 	return true;
 }
 
-int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
-			    const char *servers[],
-			    const struct sockaddr *servers_sa[])
+int dns_resolve_reconfigure_with_interfaces(struct dns_resolve_context *ctx,
+					    const char *servers[],
+					    const struct sockaddr *servers_sa[],
+					    int interfaces[])
 {
 	int err;
 
@@ -1909,12 +1910,23 @@ int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
 		}
 	}
 
-	err = dns_resolve_init_locked(ctx, servers, servers_sa, &resolve_svc, 0, NULL);
+	err = dns_resolve_init_locked(ctx, servers, servers_sa,
+				      &resolve_svc, 0, interfaces);
 
 unlock:
 	k_mutex_unlock(&ctx->lock);
 
 	return err;
+}
+
+int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
+			    const char *servers[],
+			    const struct sockaddr *servers_sa[])
+{
+	return dns_resolve_reconfigure_with_interfaces(ctx,
+						       servers,
+						       servers_sa,
+						       NULL);
 }
 
 struct dns_resolve_context *dns_resolve_get_default(void)

--- a/subsys/net/lib/shell/conn.c
+++ b/subsys/net/lib/shell/conn.c
@@ -89,6 +89,8 @@ static void conn_handler_cb(struct net_conn *conn, void *user_data)
 
 	} else if (conn->local_addr.sa_family == AF_UNSPEC) {
 		snprintk(addr_local, sizeof(addr_local), "AF_UNSPEC");
+	} else if (conn->local_addr.sa_family == AF_PACKET) {
+		snprintk(addr_local, sizeof(addr_local), "AF_PACKET");
 	} else {
 		snprintk(addr_local, sizeof(addr_local), "AF_UNK(%d)",
 			 conn->local_addr.sa_family);

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -470,15 +470,17 @@ ZTEST(dns_addremove, test_dns_reconfigure_callback)
 	zassert_equal(ret, 0, "Cannot reconfigure DNS server");
 
 	/* Wait for DNS removed callback after reconfiguring DNS */
-	if (k_sem_take(&dns_removed, WAIT_TIME)) {
-		zassert_true(false,
-			     "Timeout while waiting for DNS removed callback");
-	}
+	if (IS_ENABLED(CONFIG_DNS_RECONFIGURE_CLEANUP)) {
+		if (k_sem_take(&dns_removed, WAIT_TIME)) {
+			zassert_true(false,
+				     "Timeout while waiting for DNS removed callback");
+		}
 
-	/* Wait for DNS added callback after reconfiguring DNS */
-	if (k_sem_take(&dns_added, WAIT_TIME)) {
-		zassert_true(false,
-			     "Timeout while waiting for DNS added callback");
+		/* Wait for DNS added callback after reconfiguring DNS */
+		if (k_sem_take(&dns_added, WAIT_TIME)) {
+			zassert_true(false,
+				     "Timeout while waiting for DNS added callback");
+		}
 	}
 
 	ret = dns_resolve_close(&resv_ipv4);

--- a/tests/net/lib/dns_addremove/testcase.yaml
+++ b/tests/net/lib/dns_addremove/testcase.yaml
@@ -14,3 +14,6 @@ tests:
   net.dns.no_ipv4:
     extra_configs:
       - CONFIG_NET_IPV4=n
+  net.dns.addremove.reconfigure_cleanup:
+    extra_configs:
+      - CONFIG_DNS_RECONFIGURE_CLEANUP=y

--- a/tests/net/lib/dns_dispatcher/src/main.c
+++ b/tests/net/lib/dns_dispatcher/src/main.c
@@ -175,11 +175,14 @@ static void *test_init(void)
 ZTEST(dns_dispatcher, test_dns_dispatcher)
 {
 	struct dns_resolve_context *ctx;
-	int sock1, sock2 = -1;
+	int ret, sock1, sock2 = -1;
 
 	ctx = dns_resolve_get_default();
 
-	dns_resolve_init_default(ctx);
+	dns_resolve_close(ctx);
+
+	ret = dns_resolve_init_default(ctx);
+	zassert_equal(ret, 0, "Cannot initialize DNS resolver (%d)", ret);
 
 	sock1 = ctx->servers[0].sock;
 

--- a/tests/net/lib/dns_dispatcher/testcase.yaml
+++ b/tests/net/lib/dns_dispatcher/testcase.yaml
@@ -8,3 +8,9 @@ common:
 tests:
   net.dns.dispatch:
     min_ram: 21
+  net.dns.dispatch.ctx_cleanup:
+    extra_configs:
+      - CONFIG_DNS_RECONFIGURE_CLEANUP=y
+  net.dns.dispatch.ctx_no_cleanup:
+    extra_configs:
+      - CONFIG_DNS_RECONFIGURE_CLEANUP=n


### PR DESCRIPTION
When we receive DNS servers via DHCPv4/6 options, bind the servers to certain network interface. This can be controlled by a Kconfig option if that is not desired. Add also support for removing the DNS servers from a network interface when that interface goes down.

Fixes #88915