### PR TITLE
drivers/espi: ite: Add it51xxx compatibility with it8xxx2 support

### DIFF
--- a/drivers/espi/Kconfig.it8xxx2
+++ b/drivers/espi/Kconfig.it8xxx2
@@ -5,7 +5,7 @@ config ESPI_IT8XXX2
 	bool "ITE IT8XXX2 embedded controller ESPI driver"
 	default y
 	depends on DT_HAS_ITE_IT8XXX2_ESPI_ENABLED
-	depends on SOC_IT8XXX2
+	depends on SOC_IT8XXX2 || SOC_IT51XXX
 	help
 	  Enable ITE IT8XXX2 ESPI driver.
 

--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -1189,6 +1189,31 @@
 			kso17-gpios = <&gpioc 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
 		};
 
+		espi0: espi@f03100 {
+			compatible = "ite,it8xxx2-espi";
+			reg = <0x00f03100 0xd8    /* eSPI slave */
+			       0x00f03200 0x9a    /* eSPI VW */
+			       0x00f03300 0xd0    /* eSPI Queue 0 */
+			       0x00f03400 0xc0    /* eSPI Queue 1 */
+			       0x00f01200 6       /* EC2I bridge */
+			       0x00f01300 11      /* Host KBC */
+			       0x00f01500 0x100   /* Host PMC */
+			       0x00f01000 0xd1>;  /* SMFI */
+			interrupts = <IT51XXX_IRQ_ESPI IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_ESPI_VW IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_KBC_IBF IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_KBC_OBE IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_PMC1_IBF IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_PCH_P80 IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_PMC2_IBF IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_WKINTD IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-parent = <&intc>;
+			wucctrl = <&wuc_wu42>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			status = "disabled";
+		};
+
 		twd0: watchdog@f04780 {
 			compatible = "ite,it51xxx-watchdog";
 			reg = <0x00f04780 0x20>;

--- a/soc/ite/ec/it51xxx/chip_chipregs.h
+++ b/soc/ite/ec/it51xxx/chip_chipregs.h
@@ -267,8 +267,16 @@ struct gctrl_it51xxx_regs {
 	volatile uint8_t reserved_1d_1f[3];
 	/* 0x20: Reset Control 5 */
 	volatile uint8_t GCTRL_RSTC5;
-	/* 0x21-0x37: reserved_21_37 */
-	volatile uint8_t reserved_21_37[23];
+	/* 0x21-0x2f: reserved_21_2f */
+	volatile uint8_t reserved_21_2f[15];
+	/* 0x30: Port 80h/81h Status Register */
+	volatile uint8_t GCTRL_P80H81HSR;
+	/* 0x31: Port 80h Data Register */
+	volatile uint8_t GCTRL_P80HDR;
+	/* 0x32: Port 81h Data Register */
+	volatile uint8_t GCTRL_P81HDR;
+	/* 0x33-0x37: reserved_33_37 */
+	volatile uint8_t reserved_33_37[5];
 	/* 0x38: Special Control 9 */
 	volatile uint8_t GCTRL_SPCTRL9;
 	/* 0x39-0x46: reserved_39_46 */

--- a/soc/ite/ec/it51xxx/linker.ld
+++ b/soc/ite/ec/it51xxx/linker.ld
@@ -377,6 +377,19 @@ SECTIONS
 
     __data_region_end = .;
 
+	SECTION_DATA_PROLOGUE(.h2ram_pool,(NOLOAD),)
+	{
+		/*
+		 * Append h2ram_pool section at the end of used memory, so gap
+		 * due to alignment is still available for newly added variables
+		 */
+		. = ALIGN(0x1000);
+		_h2ram_pool_start = .;
+		KEEP(*(.h2ram_pool))
+		_h2ram_pool_end = .;
+	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+	_h2ram_pool_size = ABSOLUTE(_h2ram_pool_end - _h2ram_pool_start);
+
 	__kernel_ram_end = .;
 	__kernel_ram_size = __kernel_ram_end - __kernel_ram_start;
 

--- a/soc/ite/ec/it51xxx/soc.c
+++ b/soc/ite/ec/it51xxx/soc.c
@@ -7,6 +7,8 @@
 #include <soc_common.h>
 #include <zephyr/kernel.h>
 
+#include "soc_espi.h"
+
 static mm_reg_t ecpm_base = DT_REG_ADDR(DT_NODELABEL(ecpm));
 /* it51xxx ECPM registers definition */
 /* 0x03: PLL Control */
@@ -57,12 +59,25 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 	csr_clear(mie, MIP_MEIP);
 	sys_trace_idle();
 
+#ifdef CONFIG_ESPI
+	/*
+	 * H2RAM feature requires RAM clock to be active. Since the below doze
+	 * mode will disable CPU and RAM clocks, enable eSPI transaction
+	 * interrupt to restore clocks. With this interrupt, EC will not defer
+	 * eSPI bus while transaction is accepted.
+	 */
+	espi_ite_ec_enable_trans_irq(ESPI_ITE_SOC_DEV, true);
+#endif
 	/* Chip doze after wfi instruction */
 	chip_pll_ctrl(mode);
 
 	/* Wait for interrupt */
 	__asm__ volatile("wfi");
 
+#ifdef CONFIG_ESPI
+	/* CPU has been woken up, the interrupt is no longer needed */
+	espi_ite_ec_enable_trans_irq(ESPI_ITE_SOC_DEV, false);
+#endif
 	/*
 	 * Enable M-mode external interrupt
 	 * An interrupt can not be fired yet until we enable global interrupt


### PR DESCRIPTION

The driver originally supported only it8xxx2 series. This updates introduces compatibility allow it to also support it51xxx series with minimal changes.