### PR TITLE
boards: we: correct CTS pin number of Ophelia-IV board

### DIFF
--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15-pinctrl.dtsi
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15-pinctrl.dtsi
@@ -12,7 +12,7 @@
 
 		group2 {
 			psels = <NRF_PSEL(UART_RX, 1, 15)>,
-				<NRF_PSEL(UART_CTS, 1, 2)>;
+				<NRF_PSEL(UART_CTS, 1, 7)>;
 			bias-pull-up;
 		};
 	};
@@ -22,7 +22,7 @@
 			psels = <NRF_PSEL(UART_TX, 1, 4)>,
 				<NRF_PSEL(UART_RX, 1, 15)>,
 				<NRF_PSEL(UART_RTS, 1, 6)>,
-				<NRF_PSEL(UART_CTS, 1, 2)>;
+				<NRF_PSEL(UART_CTS, 1, 7)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
boards: we: correct CTS pin number of Ophelia-IV board