### PR TITLE
Bluetooth: CAP: Add missing check for abort in the started cb

### DIFF
--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1827,6 +1827,14 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 			active_proc->proc_done_cnt, active_proc->proc_cnt);
 	}
 
+	if (bt_cap_common_proc_is_aborted()) {
+		if (bt_cap_common_proc_all_handled()) {
+			cap_initiator_unicast_audio_proc_complete();
+		}
+
+		return;
+	}
+
 	if (!bt_cap_common_proc_is_done()) {
 		struct bt_cap_initiator_proc_param *proc_param;
 		struct bt_cap_stream *next_cap_stream;


### PR DESCRIPTION
bt_cap_initiator_started did not have a check for aborted like all the other callbacks, which could cause the procedure to continue even if it was aborted.