### PR TITLE
drivers: gpio: smartbond: Fix PDC GPIO port selection

### DIFF
--- a/drivers/gpio/gpio_smartbond.c
+++ b/drivers/gpio/gpio_smartbond.c
@@ -77,10 +77,11 @@ struct gpio_smartbond_config {
 	volatile uint32_t *mode_regs;
 	volatile struct gpio_smartbond_latch_regs *latch_regs;
 	volatile struct gpio_smartbond_wkup_regs *wkup_regs;
-	/* Value of TRIG_SELECT for PDC_CTRLx_REG entry */
-	uint8_t wkup_trig_select;
 #if CONFIG_PM_DEVICE
 	uint8_t ngpios;
+#endif
+#if CONFIG_PM
+	uint8_t port;
 #endif
 };
 
@@ -226,7 +227,7 @@ static int gpio_smartbond_pin_interrupt_configure(const struct device *dev,
 	struct gpio_smartbond_data *data = dev->data;
 	uint32_t pin_mask = BIT(pin);
 #if CONFIG_PM
-	int trig_select_id = (config->wkup_trig_select << 5) | pin;
+	int trig_select_id = (config->port << 5) | pin;
 	int pdc_ix;
 #endif
 
@@ -410,7 +411,7 @@ static DEVICE_API(gpio, gpio_smartbond_drv_api_funcs) = {
 						DT_INST_REG_ADDR_BY_NAME(id, latch),	\
 		.wkup_regs = (volatile struct gpio_smartbond_wkup_regs *)		\
 						DT_INST_REG_ADDR_BY_NAME(id, wkup),	\
-		.wkup_trig_select = id,							\
+		IF_ENABLED(CONFIG_PM, (.port = DT_INST_PROP(id, port),))		\
 		GPIO_PM_DEVICE_CFG(.ngpios, DT_INST_PROP(id, ngpios))			\
 	};										\
 											\

--- a/dts/arm/renesas/smartbond/da1469x.dtsi
+++ b/dts/arm/renesas/smartbond/da1469x.dtsi
@@ -201,6 +201,7 @@
 				compatible = "renesas,smartbond-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
+				port = <0>;
 				ngpios = <32>;
 				reg = <0x50020a00 20
 					   0x50020a18 128
@@ -214,6 +215,7 @@
 				compatible = "renesas,smartbond-gpio";
 				gpio-controller;
 				#gpio-cells = <2>;
+				port = <1>;
 				ngpios = <23>;
 				reg = <0x50020a04 20
 					   0x50020a98 92

--- a/dts/bindings/gpio/renesas,smartbond-gpio.yaml
+++ b/dts/bindings/gpio/renesas,smartbond-gpio.yaml
@@ -11,6 +11,10 @@ properties:
   reg:
     required: true
 
+  port:
+    type: int
+    required: true
+
   "#gpio-cells":
     const: 2
 


### PR DESCRIPTION
The GPIO block instance is based on the instance number during the device driver initialization. This is not correct as instance numbers in no way reflect any numbering scheme. Therefore, a DTS property is introduced so that the block instance numbering is indicated explicitly.