### PR TITLE
tests: unit: util: increase coverage of utf-8 utils

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -652,8 +652,9 @@ static inline int64_t sign_extend_64(uint64_t value, uint8_t index)
  * truncated (by setting the NULL terminator) earlier by other means, that
  * the string ends with a properly formatted UTF-8 character (1-4 bytes).
  *
- * @htmlonly
  * Example:
+ *
+ * @code{.c}
  *      char test_str[] = "€€€";
  *      char trunc_utf8[8];
  *
@@ -663,7 +664,7 @@ static inline int64_t sign_extend_64(uint64_t value, uint8_t index)
  *      printf("Bad      : %s\n", trunc_utf8); // €€�
  *      utf8_trunc(trunc_utf8);
  *      printf("Truncated: %s\n", trunc_utf8); // €€
- * @endhtmlonly
+ * @endcode
  *
  * @param utf8_str NULL-terminated string
  *

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -821,30 +821,40 @@ ZTEST(util, test_SIZEOF_FIELD)
 
 ZTEST(util, test_utf8_trunc_truncated)
 {
-	char test_str[] = "€€€";
-	char expected_result[] = "€€";
+	struct {
+		char input[20];
+		char expected[20];
+	} tests[] = {
+		{"ééé", "éé"},                    /* 2-byte UTF-8 characters */
+		{"€€€", "€€"},                    /* 3-byte UTF-8 characters */
+		{"𠜎𠜎𠜎", "𠜎𠜎"},                 /* 4-byte UTF-8 characters */
+		{"Hello 世界!🌍", "Hello 世界!"},   /* mixed UTF-8 characters */
+	};
 
-	/* Remove last byte from truncated_test_str and verify that it first is incorrectly
-	 * truncated, followed by a proper truncation and verification
-	 */
-	test_str[strlen(test_str) - 1] = '\0';
-	zassert(strcmp(test_str, "€€€") != 0, "Failed to do invalid truncation");
-	zassert(strcmp(test_str, expected_result) != 0, "Failed to do invalid truncation");
-
-	utf8_trunc(test_str);
-
-	zassert_str_equal(test_str, expected_result, "Failed to truncate");
+	for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {
+		tests[i].input[strlen(tests[i].input) - 1] = '\0';
+		utf8_trunc(tests[i].input);
+		zassert_str_equal(tests[i].input, tests[i].expected, "Failed to truncate");
+	}
 }
 
 ZTEST(util, test_utf8_trunc_not_truncated)
 {
-	/* Attempt to truncate a valid UTF8 string and verify no changed */
-	char test_str[] = "€€€";
-	char expected_result[] = "€€€";
+	struct {
+		char input[20];
+		char expected[20];
+	} tests[] = {
+		{"abc", "abc"},                    /* 1-byte ASCII characters */
+		{"ééé", "ééé"},                    /* 2-byte UTF-8 characters */
+		{"€€€", "€€€"},                    /* 3-byte UTF-8 characters */
+		{"𠜎𠜎𠜎", "𠜎𠜎𠜎"},                /* 4-byte UTF-8 characters */
+		{"Hello 世界!🌍", "Hello 世界!🌍"},  /* mixed UTF-8 characters */
+	};
 
-	utf8_trunc(test_str);
-
-	zassert_str_equal(test_str, expected_result, "Failed to truncate");
+	for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {
+		utf8_trunc(tests[i].input);
+		zassert_str_equal(tests[i].input, tests[i].expected, "No-op truncation failed");
+	}
 }
 
 ZTEST(util, test_utf8_trunc_zero_length)


### PR DESCRIPTION
Test all possible UTF-8 sequence lengths for utf8_trunc()

![image](https://github.com/user-attachments/assets/d7165958-bc28-4b63-9ea9-bb30ba87c889)