### PR TITLE
dts: arm: adi: Enable timers for MAX32657

### DIFF
--- a/boards/adi/max32657evkit/max32657evkit_max32657.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.yaml
@@ -12,5 +12,6 @@ supported:
   - trng
   - watchdog
   - dma
+  - counter
 ram: 256
 flash: 960

--- a/boards/adi/max32657evkit/max32657evkit_max32657.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.yaml
@@ -13,5 +13,6 @@ supported:
   - watchdog
   - dma
   - counter
+  - pwm
 ram: 256
 flash: 960

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
@@ -12,5 +12,6 @@ supported:
   - watchdog
   - dma
   - counter
+  - pwm
 ram: 192
 flash: 576

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
@@ -11,5 +11,6 @@ supported:
   - gpio
   - watchdog
   - dma
+  - counter
 ram: 192
 flash: 576

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -154,6 +154,120 @@
 		clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
 		status = "disabled";
 	};
+
+	timer0: timer@10000 {
+		compatible = "adi,max32-timer";
+		reg = <0x10000 0x1000>;
+		interrupts = <4 0>;
+		status = "disabled";
+		clocks = <&gcr ADI_MAX32_CLOCK_BUS0 15>;
+		clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
+		prescaler = <1>;
+		pwm {
+			compatible = "adi,max32-pwm";
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+		counter {
+			compatible = "adi,max32-counter";
+			status = "disabled";
+		};
+	};
+
+	timer1: timer@11000 {
+		compatible = "adi,max32-timer";
+		reg = <0x11000 0x1000>;
+		interrupts = <5 0>;
+		status = "disabled";
+		clocks = <&gcr ADI_MAX32_CLOCK_BUS0 16>;
+		clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
+		prescaler = <1>;
+		pwm {
+			compatible = "adi,max32-pwm";
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+		counter {
+			compatible = "adi,max32-counter";
+			status = "disabled";
+		};
+	};
+
+	timer2: timer@12000 {
+		compatible = "adi,max32-timer";
+		reg = <0x12000 0x1000>;
+		interrupts = <6 0>;
+		status = "disabled";
+		clocks = <&gcr ADI_MAX32_CLOCK_BUS0 17>;
+		clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
+		prescaler = <1>;
+		pwm {
+			compatible = "adi,max32-pwm";
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+		counter {
+			compatible = "adi,max32-counter";
+			status = "disabled";
+		};
+	};
+
+	timer3: timer@13000 {
+		compatible = "adi,max32-timer";
+		reg = <0x13000 0x1000>;
+		interrupts = <7 0>;
+		status = "disabled";
+		clocks = <&gcr ADI_MAX32_CLOCK_BUS0 18>;
+		clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
+		prescaler = <1>;
+		pwm {
+			compatible = "adi,max32-pwm";
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+		counter {
+			compatible = "adi,max32-counter";
+			status = "disabled";
+		};
+	};
+
+	timer4: timer@14000 {
+		compatible = "adi,max32-timer";
+		reg = <0x14000 0x1000>;
+		interrupts = <8 0>;
+		status = "disabled";
+		clocks = <&gcr ADI_MAX32_CLOCK_BUS0 19>;
+		clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
+		prescaler = <1>;
+		pwm {
+			compatible = "adi,max32-pwm";
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+		counter {
+			compatible = "adi,max32-counter";
+			status = "disabled";
+		};
+	};
+
+	timer5: timer@15000 {
+		compatible = "adi,max32-timer";
+		reg = <0x15000 0x1000>;
+		interrupts = <9 0>;
+		status = "disabled";
+		clocks = <&gcr ADI_MAX32_CLOCK_BUS0 20>;
+		clock-source = <ADI_MAX32_PRPH_CLK_SRC_PCLK>;
+		prescaler = <1>;
+		pwm {
+			compatible = "adi,max32-pwm";
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+		counter {
+			compatible = "adi,max32-counter";
+			status = "disabled";
+		};
+	};
 };
 
 &nvic {

--- a/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657.overlay
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer0 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer1 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer2 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer3 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer4 {
+	status = "okay";
+	counter {
+		status = "okay";
+	};
+};
+
+&timer5 {
+	status = "okay";
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657_ns.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/max32657evkit_max32657_ns.overlay
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timer0 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer1 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer2 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer3 {
+	status = "okay";
+	prescaler = <2>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timer4 {
+	status = "okay";
+	counter {
+		status = "okay";
+	};
+};
+
+&timer5 {
+	status = "okay";
+	counter {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Add timer nodes to MAX32657 and enable tests for MAX32657EVKIT secure and non-secure variants.