### PR TITLE
github: hello_world_multiplatform: switch to python 3.12

### DIFF
--- a/.github/workflows/hello_world_multiplatform.yaml
+++ b/.github/workflows/hello_world_multiplatform.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Setup Zephyr project
         uses: zephyrproject-rtos/action-zephyr-setup@b2453c72966ee67b1433be22b250348d48283286 # v1.0.7


### PR DESCRIPTION
Switch the workflow to setup python 3.12, not sure why this was left out.