### PR TITLE
manifest: update hal_nxp with fix for RW61x wifi compilation

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: e8f6f6d8280fa589aa6ce36e6e7d4187597eaf54
+      revision: ad531e7b9980b171f90c651340bb1bb6cc2c6d51
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Update the NXP HAL revision to include a fix for the RW61x wifi compilation.

This fixes an error seen on CI on main, for more info see here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/15616301305/job/43989880809


- [x] needs to wait on #85555