### PR TITLE
drivers: i2c: sam: add support for sama7g5 TWI, EEPROM

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -49,12 +49,51 @@
 	};
 };
 
+&flx8 {
+	mchp,flexcom-mode = <SAM_FLEXCOM_MODE_TWI>;
+	status = "okay";
+
+	i2c8: i2c8@600 {
+		pinctrl-0 = <&pinctrl_i2c8_default>;
+		pinctrl-names = "default";
+		status = "okay";
+
+		eeprom0: eeprom0@52 {
+			compatible = "atmel,24mac02e4", "atmel,at24";
+			reg = <0x52>;
+			address-width = <8>;
+			pagesize = <16>;
+			size = <256>;
+			timeout = <5>;
+			status = "okay";
+		};
+
+		eeprom1: eeprom1@53 {
+			compatible = "atmel,24mac02e4", "atmel,at24";
+			reg = <0x53>;
+			address-width = <8>;
+			pagesize = <16>;
+			size = <256>;
+			timeout = <5>;
+			status = "okay";
+		};
+	};
+};
+
 &pinctrl {
 	pinctrl_flx3_default: flx3_default {
 		group1 {
 			pinmux = <PIN_PD16__FLEXCOM3_IO0>,
 				 <PIN_PD17__FLEXCOM3_IO1>;
 			bias-pull-up;
+		};
+	};
+
+	pinctrl_i2c8_default: i2c8_default {
+		group1 {
+			pinmux = <PIN_PC14__FLEXCOM8_IO0>,
+				 <PIN_PC13__FLEXCOM8_IO1>;
+			bias-disable;
 		};
 	};
 };

--- a/dts/arm/microchip/sam/sama7g5.dtsi
+++ b/dts/arm/microchip/sam/sama7g5.dtsi
@@ -45,6 +45,60 @@
 			#clock-cells = <1>;
 		};
 
+		flx0: flexcom@e1818000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe1818000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe1818000 0x800>;
+			status = "disabled";
+
+			usart0: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 38>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx1: flexcom@e181c000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe181c000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe181c000 0x800>;
+			status = "disabled";
+
+			usart1: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx2: flexcom@e1820000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe1820000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe1820000 0x800>;
+			status = "disabled";
+
+			usart2: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 40>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
 		flx3: flexcom@e1824000 {
 			compatible = "microchip,sam-flexcom";
 			reg = <0xe1824000 0x200>;
@@ -59,6 +113,150 @@
 				clocks = <&pmc PMC_TYPE_PERIPHERAL 41>;
 				interrupt-parent = <&gic>;
 				interrupts = <GIC_SPI 41 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx4: flexcom@e2018000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe2018000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe2018000 0x800>;
+			status = "disabled";
+
+			usart4: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 42>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx5: flexcom@e201c000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe201c000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe201c000 0x800>;
+			status = "disabled";
+
+			usart5: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 43>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 43 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx6: flexcom@e2020000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe2020000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe2020000 0x800>;
+			status = "disabled";
+
+			usart6: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx7: flexcom@e2024000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe2024000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe2024000 0x800>;
+			status = "disabled";
+
+			usart7: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 45>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 45 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx8: flexcom@e2818000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe2818000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe2818000 0x800>;
+			status = "disabled";
+
+			usart8: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 46>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx9: flexcom@e281c000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe281c000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe281c000 0x800>;
+			status = "disabled";
+
+			usart9: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 47>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 47 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx10: flexcom@e2820000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe2820000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe2820000 0x800>;
+			status = "disabled";
+
+			usart10: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 48>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
+
+		flx11: flexcom@e2824000 {
+			compatible = "microchip,sam-flexcom";
+			reg = <0xe2824000 0x200>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0x0 0xe2824000 0x800>;
+			status = "disabled";
+
+			usart11: serial@200 {
+				compatible = "atmel,sam-usart";
+				reg = <0x200 0x200>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 49>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 				status = "disabled";
 			};
 		};

--- a/dts/arm/microchip/sam/sama7g5.dtsi
+++ b/dts/arm/microchip/sam/sama7g5.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv7-a.dtsi>
 #include <mem.h>
 #include <zephyr/dt-bindings/clock/microchip_sam_pmc.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
@@ -53,6 +54,18 @@
 			ranges = <0x0 0xe1818000 0x800>;
 			status = "disabled";
 
+			i2c0: i2c0@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 38 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 38>;
+				status = "disabled";
+			};
+
 			usart0: serial@200 {
 				compatible = "atmel,sam-usart";
 				reg = <0x200 0x200>;
@@ -70,6 +83,18 @@
 			#size-cells = <1>;
 			ranges = <0x0 0xe181c000 0x800>;
 			status = "disabled";
+
+			i2c1: i2c1@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 39>;
+				status = "disabled";
+			};
 
 			usart1: serial@200 {
 				compatible = "atmel,sam-usart";
@@ -89,6 +114,18 @@
 			ranges = <0x0 0xe1820000 0x800>;
 			status = "disabled";
 
+			i2c2: i2c2@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 40 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 40>;
+				status = "disabled";
+			};
+
 			usart2: serial@200 {
 				compatible = "atmel,sam-usart";
 				reg = <0x200 0x200>;
@@ -106,6 +143,18 @@
 			#size-cells = <1>;
 			ranges = <0x0 0xe1824000 0x800>;
 			status = "disabled";
+
+			i2c3: i2c3@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 41 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 41>;
+				status = "disabled";
+			};
 
 			usart3: serial@200 {
 				compatible = "atmel,sam-usart";
@@ -125,6 +174,18 @@
 			ranges = <0x0 0xe2018000 0x800>;
 			status = "disabled";
 
+			i2c4: i2c4@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 42>;
+				status = "disabled";
+			};
+
 			usart4: serial@200 {
 				compatible = "atmel,sam-usart";
 				reg = <0x200 0x200>;
@@ -142,6 +203,18 @@
 			#size-cells = <1>;
 			ranges = <0x0 0xe201c000 0x800>;
 			status = "disabled";
+
+			i2c5: i2c5@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 43 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 43>;
+				status = "disabled";
+			};
 
 			usart5: serial@200 {
 				compatible = "atmel,sam-usart";
@@ -161,6 +234,18 @@
 			ranges = <0x0 0xe2020000 0x800>;
 			status = "disabled";
 
+			i2c6: i2c6@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 44 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 44>;
+				status = "disabled";
+			};
+
 			usart6: serial@200 {
 				compatible = "atmel,sam-usart";
 				reg = <0x200 0x200>;
@@ -178,6 +263,18 @@
 			#size-cells = <1>;
 			ranges = <0x0 0xe2024000 0x800>;
 			status = "disabled";
+
+			i2c7: i2c7@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 45 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 45>;
+				status = "disabled";
+			};
 
 			usart7: serial@200 {
 				compatible = "atmel,sam-usart";
@@ -197,6 +294,18 @@
 			ranges = <0x0 0xe2818000 0x800>;
 			status = "disabled";
 
+			i2c8: i2c8@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 46 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 46>;
+				status = "disabled";
+			};
+
 			usart8: serial@200 {
 				compatible = "atmel,sam-usart";
 				reg = <0x200 0x200>;
@@ -214,6 +323,18 @@
 			#size-cells = <1>;
 			ranges = <0x0 0xe281c000 0x800>;
 			status = "disabled";
+
+			i2c9: i2c9@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 47 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 47>;
+				status = "disabled";
+			};
 
 			usart9: serial@200 {
 				compatible = "atmel,sam-usart";
@@ -233,6 +354,18 @@
 			ranges = <0x0 0xe2820000 0x800>;
 			status = "disabled";
 
+			i2c10: i2c10@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 48>;
+				status = "disabled";
+			};
+
 			usart10: serial@200 {
 				compatible = "atmel,sam-usart";
 				reg = <0x200 0x200>;
@@ -250,6 +383,18 @@
 			#size-cells = <1>;
 			ranges = <0x0 0xe2824000 0x800>;
 			status = "disabled";
+
+			i2c11: i2c11@600 {
+				compatible = "atmel,sam-i2c-twi";
+				reg = <0x600 0x200>;
+				clock-frequency = <I2C_BITRATE_STANDARD>;
+				interrupt-parent = <&gic>;
+				interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				clocks = <&pmc PMC_TYPE_PERIPHERAL 49>;
+				status = "disabled";
+			};
 
 			usart11: serial@200 {
 				compatible = "atmel,sam-usart";

--- a/soc/microchip/sam/Kconfig.defconfig
+++ b/soc/microchip/sam/Kconfig.defconfig
@@ -10,4 +10,8 @@ rsource "*/Kconfig.defconfig"
 config CLOCK_CONTROL
 	default y
 
+config MFD
+	default y
+	depends on DT_HAS_MICROCHIP_SAM_FLEXCOM_ENABLED
+
 endif # SOC_FAMILY_MICROCHIP_SAM

--- a/soc/microchip/sam/sama7g5/soc.c
+++ b/soc/microchip/sam/sama7g5/soc.c
@@ -9,12 +9,17 @@
 #include <zephyr/arch/arm/mmu/arm_mmu.h>
 #include <zephyr/kernel.h>
 
+#define MMU_REGION_FLEXCOM_DEFN(idx, n)								\
+		COND_CODE_1(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flx##n)),			\
+			(MMU_REGION_FLAT_ENTRY("flexcom"#n, FLEXCOM##n##_BASE_ADDRESS, 0x4000,	\
+					       MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),),	\
+			())
+
 static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("vectors", CONFIG_KERNEL_VM_BASE, 0x1000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
 
-	MMU_REGION_FLAT_ENTRY("flexcom3", FLEXCOM3_BASE_ADDRESS, 0x4000,
-			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+	FOR_EACH_IDX(MMU_REGION_FLEXCOM_DEFN, (), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
 
 	MMU_REGION_FLAT_ENTRY("gic", GIC_DISTRIBUTOR_BASE, 0x1100,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),

--- a/tests/drivers/eeprom/api/boards/sama7g54_ek.overlay
+++ b/tests/drivers/eeprom/api/boards/sama7g54_ek.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2025 Microchip Technology Inc. and its subsidiaries
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		eeprom-0 = &eeprom0;
+	};
+};

--- a/tests/drivers/eeprom/api/testcase.yaml
+++ b/tests/drivers/eeprom/api/testcase.yaml
@@ -12,6 +12,7 @@ tests:
       - qemu_x86
       - nucleo_l152re
       - nucleo_l073rz
+      - sama7g54_ek
     integration_platforms:
       - qemu_x86
   drivers.eeprom.api.w_at2x_emul:
@@ -33,3 +34,4 @@ tests:
       - qemu_x86
       - nucleo_l152re
       - nucleo_l073rz
+      - sama7g54_ek

--- a/west.yml
+++ b/west.yml
@@ -195,7 +195,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 4b74f4081342423badcf758278bbc0582ca8735d
+      revision: 32a79d481c056b2204a5701d5a5799f9e5130dd7
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
Following are the changes included by the commits of the PR:
- add all USART (one of the FLEXCOM submodules) nodes to sama7g5.dtsi
- add all TWI (I2C, one of the FLEXCOM submodules) nodes to sama7g5.dtsi
- update MMU configurations for FLEXCOM
- update `i2c_sam_twi.c` for supporting sama7g5 TWI
- fix a bug in `i2c_sam_twi.c` which found with command `i2c scan`
- add eeprom nodes for sama7g54-ek on board EEPROM
- add sama7g54_ek to `tests/drivers/eeprom/api`
