### PR TITLE
disk: sdmmc_stm32: support clock bypass

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -801,7 +801,9 @@ static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 		.Instance = (MMC_TypeDef *)DT_INST_REG_ADDR(0),
 		.Init.ClockEdge = SDMMC_CLOCK_EDGE_RISING,
 #ifdef SDMMC_CLOCK_BYPASS_DISABLE
-		.Init.ClockBypass = SDMMC_CLOCK_BYPASS_DISABLE,
+		.Init.ClockBypass = DT_INST_PROP(0, clk_bypass)
+						? SDMMC_CLOCK_BYPASS_ENABLE
+						: SDMMC_CLOCK_BYPASS_DISABLE,
 #endif
 		.Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_DISABLE,
 		.Init.BusWide = SDMMC_BUS_WIDTH,

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -799,10 +799,14 @@ static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 	.irq_config = stm32_sdmmc_irq_config_func,
 	.hsd = {
 		.Instance = (MMC_TypeDef *)DT_INST_REG_ADDR(0),
-		.Init.BusWide = SDMMC_BUS_WIDTH,
-#if DT_INST_NODE_HAS_PROP(0, clk_div)
-		.Init.ClockDiv = DT_INST_PROP(0, clk_div),
+		.Init.ClockEdge = SDMMC_CLOCK_EDGE_RISING,
+#ifdef SDMMC_CLOCK_BYPASS_DISABLE
+		.Init.ClockBypass = SDMMC_CLOCK_BYPASS_DISABLE,
 #endif
+		.Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_DISABLE,
+		.Init.BusWide = SDMMC_BUS_WIDTH,
+		.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE,
+		.Init.ClockDiv = DT_INST_PROP_OR(0, clk_div, 0),
 	},
 #if DT_INST_NODE_HAS_PROP(0, cd_gpios)
 	.cd = GPIO_DT_SPEC_INST_GET(0, cd_gpios),

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -38,8 +38,8 @@ properties:
     type: int
     default: 1
     description: |
-        bus width for SDMMC access, defaults to the minimum necessary
-        number of bus lines
+      bus width for SDMMC access, defaults to the minimum necessary
+      number of bus lines
     enum:
       - 1
       - 4
@@ -49,8 +49,17 @@ properties:
     type: int
     default: 0
     description: |
-        Clock division factor for SDMMC. Typically the clock operates at 25MHz so
-        a division factor of 2 would be 25MHz / 2 = 12.5MHz.
+      Clock division factor for SDMMC. The relationship between this value
+      and the output bus frequency is FREQ_BUS = SDMMMC_CLK / [CLKDIV + 2].
+      Therefore an input clock of 25MHz and a division factor of 0 would
+      result in a bus frequency of 25MHz / [0 + 2] = 12.5MHz.
+
+  clk-bypass:
+    type: boolean
+    description: |
+      Bypass the clock divider configured in `clk-div`, which results in the
+      output bus frequency matching the input SDMMC_CLK. Not supported on
+      all part numbers.
 
   idma:
     type: boolean


### PR DESCRIPTION
Add support for the SDMMC clock bypass feature for those SoCs that have
it. This provides a SDMMC bus speed double that of `clk-div = <0>`.

Updated the `clk-div` documentation at the same time to be clearer on
how the bus clock speed is determined.
