### PR TITLE
Bluetooth: Remove useless `sys_cpu_to_le16` for `uint8_t` type

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -334,7 +334,7 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 	}
 
 	cp = net_buf_add(buf, sizeof(*cp));
-	cp->num_handles = sys_cpu_to_le16(1);
+	cp->num_handles = 1;
 
 	hc = net_buf_add(buf, sizeof(*hc));
 	hc->handle = sys_cpu_to_le16(handle);


### PR DESCRIPTION
The target variable is a `uint8_t`. It is not reasonable to pass a value with `uint16_t` in little-endian format.

Remove `sys_cpu_to_le16`, and pass the value directly.