### PR TITLE
drivers: wifi: nxp: add Kconfig of NXP_WIFI_AUTO_INIT

### DIFF
--- a/drivers/wifi/nxp/CMakeLists.txt
+++ b/drivers/wifi/nxp/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 if (CONFIG_WIFI_NXP)
 
-zephyr_library_sources(nxp_wifi_drv.c)
+zephyr_library_sources_ifdef(CONFIG_NXP_WIFI_AUTO_INIT nxp_wifi_drv.c)
 
 zephyr_library_sources_ifdef(CONFIG_NXP_WIFI_SHELL nxp_wifi_shell.c)
 zephyr_library_link_libraries_ifdef(CONFIG_WIFI_NM_WPA_SUPPLICANT hostap)

--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -31,6 +31,12 @@ config NXP_WIFI_CUSTOM
 	help
 	  Customize NXP Wi-Fi chip support.
 
+config NXP_WIFI_AUTO_INIT
+	bool "Auto initialize NXP Wi-Fi"
+	default y
+	help
+	  Automatically initialize NXP Wi-Fi driver and FW.
+
 choice NXP_WIFI_PART
 	prompt "Select NXP Wi-Fi part"
 	depends on !NXP_WIFI_CUSTOM


### PR DESCRIPTION
Add Kconfig to control the automatical initialization of NXP Wi-Fi driver and FW after device power on, and user can decide when to initialize driver and download FW.