### PR TITLE
samples: Bluetooth: hci_ipc: __ASSERT if failing to deliver complete message

### DIFF
--- a/samples/bluetooth/hci_ipc/src/main.c
+++ b/samples/bluetooth/hci_ipc/src/main.c
@@ -252,7 +252,7 @@ static void hci_ipc_send(struct net_buf *buf, bool is_fatal_err)
 			 * call to k_yield is against it.
 			 */
 			if (is_fatal_err) {
-				LOG_ERR("IPC service send error: %d", ret);
+				LOG_ERR("ipc_service_send error: %d", ret);
 			} else {
 				/* In the POSIX ARCH, code takes zero simulated time to execute,
 				 * so busy wait loops become infinite loops, unless we
@@ -267,7 +267,8 @@ static void hci_ipc_send(struct net_buf *buf, bool is_fatal_err)
 		}
 	} while (ret < 0);
 
-	LOG_INF("Sent message of %d bytes.", ret);
+	LOG_INF("ipc_service_send sent %d/%u bytes", ret, buf->len);
+	__ASSERT_NO_MSG(ret == buf->len);
 
 	net_buf_unref(buf);
 }


### PR DESCRIPTION
The hci_ipc sample does not support fragmentation of IPC-messages.

Give an ASSERT if only parts of an IPC-message is delivered.
This would happen for instance when the underlying transport mechanism cannot
hold the complete message.

Background:
The open-amp backend uses RPMSG_BUFFER_SIZE=512

Most applications and controllers use HCI-packets which are at most 255 bytes.
In some cases a controller may deliver HCI-packets beyond 255 bytes.
This may for instance be the case if the controller delivers large ISO SDUs as a
single HCI-packet.