### PR TITLE
scripts: kconfig: Add hex variants of arithmetic functions

### DIFF
--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -81,18 +81,29 @@ Integer functions
 
 The functions listed below can be used to do arithmetic operations
 on integer variables, such as addition, subtraction and more.
+Functions with and without the ``_hex`` suffix in their names
+return hexadecimal and decimal values respectively.
 
 .. code-block:: none
 
    $(add,<value>[,value]...)
+   $(add_hex,<value>[,value]...)
    $(dec,<value>[,value]...)
+   $(dec_hex,<value>[,value]...)
    $(div,<value>[,value]...)
+   $(div_hex,<value>[,value]...)
    $(inc,<value>[,value]...)
+   $(inc_hex,<value>[,value]...)
    $(max,<value>[,value]...)
+   $(max_hex,<value>[,value]...)
    $(min,<value>[,value]...)
+   $(min_hex,<value>[,value]...)
    $(mod,<value>[,value]...)
+   $(mod_hex,<value>[,value]...)
    $(mul,<value>[,value]...)
+   $(mul_hex,<value>[,value]...)
    $(sub,<value>[,value]...)
+   $(sub_hex,<value>[,value]...)
 
 
 String functions

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -983,8 +983,8 @@ def arith(kconf, name, *args):
     the operation on the first two arguments and operates the same operation as
     the result and the following argument.
     For interoperability with inc and dec,
-    if there is only one argument, it will be split with a comma and processed
-    as a sequence of numbers.
+    each argument can be a single number or a comma-separated list of numbers,
+    but all numbers are processed as if they were individual arguments.
 
     Examples in Kconfig:
 
@@ -1008,22 +1008,36 @@ def arith(kconf, name, *args):
     $(div, $(dec, 1, 1))   # Error (0 div 0)
     """
 
-    intarray = map(int, args if len(args) > 1 else args[0].split(","))
+    intarray = (int(val, base=0) for arg in args for val in arg.split(","))
 
     if name == "add":
         return str(int(functools.reduce(operator.add, intarray)))
+    elif name == "add_hex":
+        return hex(int(functools.reduce(operator.add, intarray)))
     elif name == "sub":
         return str(int(functools.reduce(operator.sub, intarray)))
+    elif name == "sub_hex":
+        return hex(int(functools.reduce(operator.sub, intarray)))
     elif name == "mul":
         return str(int(functools.reduce(operator.mul, intarray)))
+    elif name == "mul_hex":
+        return hex(int(functools.reduce(operator.mul, intarray)))
     elif name == "div":
         return str(int(functools.reduce(operator.truediv, intarray)))
+    elif name == "div_hex":
+        return hex(int(functools.reduce(operator.truediv, intarray)))
     elif name == "mod":
         return str(int(functools.reduce(operator.mod, intarray)))
+    elif name == "mod_hex":
+        return hex(int(functools.reduce(operator.mod, intarray)))
     elif name == "max":
         return str(int(functools.reduce(max, intarray)))
+    elif name == "max_hex":
+        return hex(int(functools.reduce(max, intarray)))
     elif name == "min":
         return str(int(functools.reduce(min, intarray)))
+    elif name == "min_hex":
+        return hex(int(functools.reduce(min, intarray)))
     else:
         assert False
 
@@ -1034,12 +1048,16 @@ def inc_dec(kconf, name, *args):
     Returns a string that concatenates numbers with a comma as a separator.
     """
 
-    intarray = map(int, args if len(args) > 1 else args[0].split(","))
+    intarray = (int(val, base=0) for arg in args for val in arg.split(","))
 
     if name == "inc":
         return ",".join(map(lambda a: str(a + 1), intarray))
+    if name == "inc_hex":
+        return ",".join(map(lambda a: hex(a + 1), intarray))
     elif name == "dec":
         return ",".join(map(lambda a: str(a - 1), intarray))
+    elif name == "dec_hex":
+        return ",".join(map(lambda a: hex(a - 1), intarray))
     else:
         assert False
 
@@ -1106,12 +1124,21 @@ functions = {
         "shields_list_contains": (shields_list_contains, 1, 1),
         "substring": (substring, 2, 3),
         "add": (arith, 1, 255),
+        "add_hex": (arith, 1, 255),
         "sub": (arith, 1, 255),
+        "sub_hex": (arith, 1, 255),
         "mul": (arith, 1, 255),
+        "mul_hex": (arith, 1, 255),
         "div": (arith, 1, 255),
+        "div_hex": (arith, 1, 255),
         "mod": (arith, 1, 255),
+        "mod_hex": (arith, 1, 255),
         "max": (arith, 1, 255),
+        "max_hex": (arith, 1, 255),
         "min": (arith, 1, 255),
+        "min_hex": (arith, 1, 255),
         "inc": (inc_dec, 1, 255),
+        "inc_hex": (inc_dec, 1, 255),
         "dec": (inc_dec, 1, 255),
+        "dec_hex": (inc_dec, 1, 255),
 }

--- a/tests/kconfig/functions/Kconfig
+++ b/tests/kconfig/functions/Kconfig
@@ -6,60 +6,60 @@ config KCONFIG_ARITHMETIC_ADD_10
 	default $(add, 10)
 
 config KCONFIG_ARITHMETIC_ADD_10_3
-	int
-	default $(add, 10, 3)
+	hex
+	default $(add_hex, 10, 3)
 
 config KCONFIG_ARITHMETIC_ADD_10_3_2
 	int
-	default $(add, 10, 3, 2)
+	default $(add, 0xa, 3, 0b10)
 
 config KCONFIG_ARITHMETIC_SUB_10
 	int
 	default $(sub, 10)
 
 config KCONFIG_ARITHMETIC_SUB_10_3
-	int
-	default $(sub, 10, 3)
+	hex
+	default $(sub_hex, 10, 3)
 
 config KCONFIG_ARITHMETIC_SUB_10_3_2
 	int
-	default $(sub, 10, 3, 2)
+	default $(sub, 0xa, 3, 0b10)
 
 config KCONFIG_ARITHMETIC_MUL_10
 	int
 	default $(mul, 10)
 
 config KCONFIG_ARITHMETIC_MUL_10_3
-	int
-	default $(mul, 10, 3)
+	hex
+	default $(mul_hex, 10, 3)
 
 config KCONFIG_ARITHMETIC_MUL_10_3_2
 	int
-	default $(mul, 10, 3, 2)
+	default $(mul, 0xa, 3, 0b10)
 
 config KCONFIG_ARITHMETIC_DIV_10
 	int
 	default $(div, 10)
 
 config KCONFIG_ARITHMETIC_DIV_10_3
-	int
-	default $(div, 10, 3)
+	hex
+	default $(div_hex, 10, 3)
 
 config KCONFIG_ARITHMETIC_DIV_10_3_2
 	int
-	default $(div, 10, 3, 2)
+	default $(div, 0xa, 3, 0b10)
 
 config KCONFIG_ARITHMETIC_MOD_10
 	int
 	default $(mod, 10)
 
 config KCONFIG_ARITHMETIC_MOD_10_3
-	int
-	default $(mod, 10, 3)
+	hex
+	default $(mod_hex, 10, 3)
 
 config KCONFIG_ARITHMETIC_MOD_10_3_2
 	int
-	default $(mod, 10, 3, 2)
+	default $(mod, 0xa, 3, 0b10)
 
 config KCONFIG_ARITHMETIC_INC_1
 	int
@@ -67,11 +67,11 @@ config KCONFIG_ARITHMETIC_INC_1
 
 config KCONFIG_ARITHMETIC_INC_1_1
 	string
-	default "$(inc, 1, 1)"
+	default "$(inc_hex, 1, 1)"
 
 config KCONFIG_ARITHMETIC_INC_INC_1_1
 	string
-	default "$(inc, $(inc, 1, 1))"
+	default "$(inc, $(inc_hex, 0x1, 0b1))"
 
 config KCONFIG_ARITHMETIC_DEC_1
 	int
@@ -79,38 +79,38 @@ config KCONFIG_ARITHMETIC_DEC_1
 
 config KCONFIG_ARITHMETIC_DEC_1_1
 	string
-	default "$(dec, 1, 1)"
+	default "$(dec_hex, 1, 1)"
 
 config KCONFIG_ARITHMETIC_DEC_DEC_1_1
 	string
-	default "$(dec, $(dec, 1, 1))"
+	default "$(dec, $(dec_hex, 0x1, 0b1))"
 
 config KCONFIG_ARITHMETIC_ADD_INC_1_1
 	int
-	default $(add, $(inc, 1, 1))
+	default $(add, $(inc_hex, 1, 1))
 
 config KCONFIG_MIN_10
 	int
 	default $(min, 10)
 
 config KCONFIG_MIN_10_3
-	int
-	default $(min, 10, 3)
+	hex
+	default $(min_hex, 10, 3)
 
 config KCONFIG_MIN_10_3_2
 	int
-	default $(min, 10, 3, 2)
+	default $(min, 0xa, 3, 0b10)
 
 config KCONFIG_MAX_10
 	int
 	default $(max, 10)
 
 config KCONFIG_MAX_10_3
-	int
-	default $(max, 10, 3)
+	hex
+	default $(max_hex, 10, 3)
 
 config KCONFIG_MAX_10_3_2
 	int
-	default $(max, 10, 3, 2)
+	default $(max, 0xa, 3, 0b10)
 
 source "Kconfig.zephyr"

--- a/tests/kconfig/functions/src/main.c
+++ b/tests/kconfig/functions/src/main.c
@@ -27,10 +27,10 @@ ZTEST(test_kconfig_functions, test_arithmetic)
 	zassert_equal(CONFIG_KCONFIG_ARITHMETIC_MOD_10_3, 10 % 3);
 	zassert_equal(CONFIG_KCONFIG_ARITHMETIC_MOD_10_3_2, 10 % 3 % 2);
 	zassert_equal(CONFIG_KCONFIG_ARITHMETIC_INC_1, 1 + 1);
-	zassert_str_equal(CONFIG_KCONFIG_ARITHMETIC_INC_1_1, "2,2");
+	zassert_str_equal(CONFIG_KCONFIG_ARITHMETIC_INC_1_1, "0x2,0x2");
 	zassert_str_equal(CONFIG_KCONFIG_ARITHMETIC_INC_INC_1_1, "3,3");
 	zassert_equal(CONFIG_KCONFIG_ARITHMETIC_DEC_1, 1 - 1);
-	zassert_str_equal(CONFIG_KCONFIG_ARITHMETIC_DEC_1_1, "0,0");
+	zassert_str_equal(CONFIG_KCONFIG_ARITHMETIC_DEC_1_1, "0x0,0x0");
 	zassert_str_equal(CONFIG_KCONFIG_ARITHMETIC_DEC_DEC_1_1, "-1,-1");
 	zassert_equal(CONFIG_KCONFIG_ARITHMETIC_ADD_INC_1_1, (1 + 1) + (1 + 1));
 }


### PR DESCRIPTION
Functions like `add` and `sub` can only return base 10 integers, which means they can't really be used to define Kconfig symbols of type `hex`.

For the same reason, there already exist pairs of devicetree functions named e.g., `dt_node_reg_addr_(int|hex)` after different return types.

Introduce `add_hex`, `sub_hex`, and friends.

To avoid confusion, it should be possible for those new functions to accept arguments in base 16 as well. It's actually easier to let all arithmetic functions take their inputs in "any" base, by leveraging Python's built-in: `int(..., base=0)`.