### PR TITLE
llext: make unresolved symbol errors fatal

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -401,35 +401,6 @@ int llext_get_section_header(struct llext_loader *loader, struct llext *ext,
 			     const char *search_name, elf_shdr_t *shdr);
 
 /**
- * @brief Architecture specific function for local binding relocations
- *
- * @param[in] loader Extension loader data and context
- * @param[in] ext Extension to call function in
- * @param[in] rel Relocation data provided by elf
- * @param[in] sym Corresponding symbol table entry
- * @param[in] rel_addr Address where relocation should be performed
- * @param[in] ldr_parm Loader parameters
- * @returns 0 on success or a negative error code
- */
-int arch_elf_relocate_local(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
-			    const elf_sym_t *sym, uint8_t *rel_addr,
-			    const struct llext_load_param *ldr_parm);
-
-/**
- * @brief Architecture specific function for global binding relocations
- *
- * @param[in] loader Extension loader data and context
- * @param[in] ext Extension to call function in
- * @param[in] rel Relocation data provided by elf
- * @param[in] sym Corresponding symbol table entry
- * @param[in] rel_addr Address where relocation should be performed
- * @param[in] link_addr target address for table-based relocations
- * @returns 0 on success or a negative error code
- */
-int arch_elf_relocate_global(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
-			     const elf_sym_t *sym, uint8_t *rel_addr, const void *link_addr);
-
-/**
  * @brief Initialize LLEXT heap dynamically
  *
  * Use the provided memory block as the LLEXT heap at runtime.

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -409,10 +409,11 @@ int llext_get_section_header(struct llext_loader *loader, struct llext *ext,
  * @param[in] sym Corresponding symbol table entry
  * @param[in] rel_addr Address where relocation should be performed
  * @param[in] ldr_parm Loader parameters
+ * @returns 0 on success or a negative error code
  */
-void arch_elf_relocate_local(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
-			     const elf_sym_t *sym, uint8_t *rel_addr,
-			     const struct llext_load_param *ldr_parm);
+int arch_elf_relocate_local(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
+			    const elf_sym_t *sym, uint8_t *rel_addr,
+			    const struct llext_load_param *ldr_parm);
 
 /**
  * @brief Architecture specific function for global binding relocations
@@ -423,9 +424,10 @@ void arch_elf_relocate_local(struct llext_loader *loader, struct llext *ext, con
  * @param[in] sym Corresponding symbol table entry
  * @param[in] rel_addr Address where relocation should be performed
  * @param[in] link_addr target address for table-based relocations
+ * @returns 0 on success or a negative error code
  */
-void arch_elf_relocate_global(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
-			      const elf_sym_t *sym, uint8_t *rel_addr, const void *link_addr);
+int arch_elf_relocate_global(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
+			     const elf_sym_t *sym, uint8_t *rel_addr, const void *link_addr);
 
 /**
  * @brief Initialize LLEXT heap dynamically

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -76,6 +76,35 @@ int llext_read_symbol(struct llext_loader *ldr, struct llext *ext, const elf_rel
 
 /** @endcond */
 
+/**
+ * @brief Architecture specific function for local binding relocations
+ *
+ * @param[in] loader Extension loader data and context
+ * @param[in] ext Extension to call function in
+ * @param[in] rel Relocation data provided by elf
+ * @param[in] sym Corresponding symbol table entry
+ * @param[in] rel_addr Address where relocation should be performed
+ * @param[in] ldr_parm Loader parameters
+ * @returns 0 on success or a negative error code
+ */
+int arch_elf_relocate_local(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
+			    const elf_sym_t *sym, uint8_t *rel_addr,
+			    const struct llext_load_param *ldr_parm);
+
+/**
+ * @brief Architecture specific function for global binding relocations
+ *
+ * @param[in] loader Extension loader data and context
+ * @param[in] ext Extension to call function in
+ * @param[in] rel Relocation data provided by elf
+ * @param[in] sym Corresponding symbol table entry
+ * @param[in] rel_addr Address where relocation should be performed
+ * @param[in] link_addr target address for table-based relocations
+ * @returns 0 on success or a negative error code
+ */
+int arch_elf_relocate_global(struct llext_loader *loader, struct llext *ext, const elf_rela_t *rel,
+			     const elf_sym_t *sym, uint8_t *rel_addr, const void *link_addr);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
With experience it becomes clear, that failing to resolve symbols during the linking process is likely fatal for the module loading and a simple warning isn't enough. Fail loading instead.