### PR TITLE
boards: raspberrypi: rpi_pico2: Add jlink runner for rpi_pico2 board

### DIFF
--- a/boards/raspberrypi/rpi_pico2/board.cmake
+++ b/boards/raspberrypi/rpi_pico2/board.cmake
@@ -12,7 +12,9 @@ board_runner_args(openocd --cmd-pre-init "source [find target/rp2350.cfg]")
 # https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html#debugging-with-swd
 board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 5000")
 
+board_runner_args(jlink "--device=RP2350_M33_0")
 board_runner_args(uf2 "--board-id=RP2350")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)

--- a/boards/raspberrypi/rpi_pico2/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico2/doc/index.rst
@@ -42,7 +42,7 @@ Programming and Debugging
 
 .. zephyr:board-supported-runners::
 
-The overall explanation regarding flashing and debugging is the same as or :zephyr:board:`rpi_pico`.
+The overall explanation regarding flashing and debugging is the same as for :zephyr:board:`rpi_pico`.
 See :ref:`rpi_pico_programming_and_debugging` in :zephyr:board:`rpi_pico` documentation. N.b. OpenOCD support requires using Raspberry Pi's forked version of OpenOCD.
 
 Below is an example of building and flashing the :zephyr:code-sample:`blinky` application.


### PR DESCRIPTION
jlink runner works fine for the Pico2, just like Pico1 (rpi_pico). Copied relevant lines from rpi_pico/board.cmake.
Fixed typo in documentation.