### PR TITLE
cmake: kconfig: regenerate .config when Kconfig sources are updated

### DIFF
--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -313,6 +313,18 @@ foreach(f ${merge_config_files})
   set(merge_config_files_checksum "${merge_config_files_checksum}${checksum}")
 endforeach()
 
+# Add to the checksum all the Kconfig files which were used last time
+set(merge_kconfig_checksum "")
+if(EXISTS ${PARSED_KCONFIG_SOURCES_TXT})
+  file(STRINGS ${PARSED_KCONFIG_SOURCES_TXT} parsed_kconfig_sources_list ENCODING UTF-8)
+  foreach(f ${parsed_kconfig_sources_list})
+    if(EXISTS ${f})
+      file(MD5 ${f} checksum)
+      set(merge_kconfig_checksum "${merge_kconfig_checksum}${checksum}")
+    endif()
+  endforeach()
+endif()
+
 # Create a new .config if it does not exists, or if the checksum of
 # the dependencies has changed
 set(merge_config_files_checksum_file ${PROJECT_BINARY_DIR}/.cmake.dotconfig.checksum)
@@ -326,7 +338,7 @@ if(EXISTS ${DOTCONFIG} AND EXISTS ${merge_config_files_checksum_file})
     merge_config_files_checksum_prev
     )
   if(
-      ${merge_config_files_checksum} STREQUAL
+      ${merge_config_files_checksum}${merge_kconfig_checksum} STREQUAL
       ${merge_config_files_checksum_prev}
       )
     # Checksum is the same as before
@@ -373,16 +385,16 @@ if(NOT "${ret}" STREQUAL "0")
   message(FATAL_ERROR "command failed with return code: ${ret}")
 endif()
 
-if(CREATE_NEW_DOTCONFIG)
-  # Write the new configuration fragment checksum. Only do this if kconfig.py
-  # succeeds, to avoid marking zephyr/.config as up-to-date when it hasn't been
-  # regenerated.
-  file(WRITE ${merge_config_files_checksum_file}
-             ${merge_config_files_checksum})
-endif()
-
 # Read out the list of 'Kconfig' sources that were used by the engine.
 file(STRINGS ${PARSED_KCONFIG_SOURCES_TXT} parsed_kconfig_sources_list ENCODING UTF-8)
+
+# Recalculate the Kconfig files' checksum, since the list of files may have
+# changed.
+set(merge_kconfig_checksum "")
+foreach(f ${parsed_kconfig_sources_list})
+  file(MD5 ${f} checksum)
+  set(merge_kconfig_checksum "${merge_kconfig_checksum}${checksum}")
+endforeach()
 
 # Force CMAKE configure when the Kconfig sources or configuration files changes.
 foreach(kconfig_input
@@ -392,6 +404,14 @@ foreach(kconfig_input
     )
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${kconfig_input})
 endforeach()
+
+if(CREATE_NEW_DOTCONFIG)
+  # Write the new configuration fragment checksum. Only do this if kconfig.py
+  # succeeds, to avoid marking zephyr/.config as up-to-date when it hasn't been
+  # regenerated.
+  file(WRITE ${merge_config_files_checksum_file}
+             ${merge_config_files_checksum}${merge_kconfig_checksum})
+endif()
 
 add_custom_target(config-twister DEPENDS ${DOTCONFIG})
 

--- a/cmake/modules/kconfig.cmake
+++ b/cmake/modules/kconfig.cmake
@@ -382,13 +382,13 @@ if(CREATE_NEW_DOTCONFIG)
 endif()
 
 # Read out the list of 'Kconfig' sources that were used by the engine.
-file(STRINGS ${PARSED_KCONFIG_SOURCES_TXT} PARSED_KCONFIG_SOURCES_LIST ENCODING UTF-8)
+file(STRINGS ${PARSED_KCONFIG_SOURCES_TXT} parsed_kconfig_sources_list ENCODING UTF-8)
 
 # Force CMAKE configure when the Kconfig sources or configuration files changes.
 foreach(kconfig_input
     ${merge_config_files}
     ${DOTCONFIG}
-    ${PARSED_KCONFIG_SOURCES_LIST}
+    ${parsed_kconfig_sources_list}
     )
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${kconfig_input})
 endforeach()


### PR DESCRIPTION
The existing logic caused a regeneration when any of the .conf files changed, but modifying the Kconfig files can also cause the .config file to become out of date e.g. by adding a new config option or by changing the default value of a config option (when that default is not overridden by a .conf).

Without this change, an incremental build wouldn't pick up the new value and would require the user to notice that and manually do a clean build.