### PR TITLE
Enable acmp on rt700

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -527,6 +527,11 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kSENSE_BASE_to_I3C23);
 	CLOCK_SetClkDiv(kCLOCK_DivI3c23Clk, 4U);
 #endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(acmp), okay)
+	CLOCK_EnableClock(kCLOCK_Acmp0);
+	RESET_ClearPeripheralReset(kACMP0_RST_SHIFT_RSTn);
+#endif
 }
 
 static void GlikeyWriteEnable(GLIKEY_Type *base, uint8_t idx)

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk-pinctrl.dtsi
@@ -167,4 +167,12 @@
 			drive-strength = "normal";
 		};
 	};
+
+	pinmux_acmp: pinmux_acmp {
+		group0 {
+			pinmux = <ACMP0_IN1_PIO10_8>;
+			drive-strength = "normal";
+			slew-rate = "normal";
+		};
+	};
 };

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu0.dts
@@ -263,4 +263,10 @@ zephyr_udc0: &usb0 {
 	status = "okay";
 };
 
+&acmp {
+	status = "okay";
+	pinctrl-0 = <&pinmux_acmp>;
+	pinctrl-names = "default";
+};
+
 p3t1755dp_ard_i2c_interface: &flexcomm8_lpi2c8 {};

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_cm33_cpu1.dts
@@ -97,3 +97,9 @@
 		status = "okay";
 	};
 };
+
+&acmp {
+	status = "okay";
+	pinctrl-0 = <&pinmux_acmp>;
+	pinctrl-names = "default";
+};

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu0.dtsi
@@ -1175,6 +1175,13 @@
 		ulps-control;
 		status = "disabled";
 	};
+
+	acmp: acmp@20b000 {
+		compatible = "nxp,kinetis-acmp";
+		reg = <0x20b000 0x1000>;
+		interrupts = <17 0>;
+		status = "disabled";
+	};
 };
 
 &systick {

--- a/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
+++ b/dts/arm/nxp/nxp_rt7xx_cm33_cpu1.dtsi
@@ -451,6 +451,13 @@
 		interrupts = <30 0>;
 		status = "disabled";
 	};
+
+	acmp: acmp@20b000 {
+		compatible = "nxp,kinetis-acmp";
+		reg = <0x20b000 0x1000>;
+		interrupts = <18 0>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/include/zephyr/drivers/sensor/mcux_acmp.h
+++ b/include/zephyr/drivers/sensor/mcux_acmp.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 Vestas Wind Systems A/S
- * Copyright 2022, 2024 NXP
+ * Copyright 2022, 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -37,7 +37,8 @@ extern "C" {
 #define MCUX_ACMP_HAS_OFFSET 0
 #endif
 
-#if defined(FSL_FEATURE_ACMP_HAS_C3_REG) && (FSL_FEATURE_ACMP_HAS_C3_REG != 0U)
+#if defined(FSL_FEATURE_ACMP_HAS_C3_REG) && (FSL_FEATURE_ACMP_HAS_C3_REG != 0U) && \
+	(FSL_FEATURE_ACMP_HAS_NO_3V_DOMAIN == 0U)
 #define MCUX_ACMP_HAS_DISCRETE_MODE 1
 #else
 #define MCUX_ACMP_HAS_DISCRETE_MODE 0
@@ -47,6 +48,18 @@ extern "C" {
 #define MCUX_ACMP_HAS_HYSTCTR 1
 #else
 #define MCUX_ACMP_HAS_HYSTCTR 0
+#endif
+
+#if defined(FSL_FEATURE_ACMP_HAS_NO_WINDOW_MODE) && (FSL_FEATURE_ACMP_HAS_NO_WINDOW_MODE == 1U)
+#define MCUX_ACMP_HAS_WINDOW_MODE 0
+#else
+#define MCUX_ACMP_HAS_WINDOW_MODE 1
+#endif
+
+#if defined(FSL_FEATURE_ACMP_HAS_NO_C0_SE_BIT) && (FSL_FEATURE_ACMP_HAS_NO_C0_SE_BIT == 1U)
+#define MCUX_ACMP_HAS_SAMPLE_CLOCK_SELECTION 0
+#else
+#define MCUX_ACMP_HAS_SAMPLE_CLOCK_SELECTION 1
 #endif
 
 enum sensor_channel_mcux_acmp {

--- a/samples/sensor/mcux_acmp/README.rst
+++ b/samples/sensor/mcux_acmp/README.rst
@@ -9,17 +9,11 @@ Overview
 
 This sample show how to use the NXP MCUX Analog Comparator (ACMP) driver. The
 sample supports the :zephyr:board:`twr_ke18f`, :zephyr:board:`mimxrt1170_evk`, :zephyr:board:`frdm_ke17z`
-, :zephyr:board:`frdm_ke17z512` and :zephyr:board:`mimxrt1180_evk`.
+, :zephyr:board:`frdm_ke17z512`, :zephyr:board:`mimxrt1180_evk` and :zephyr:board:`mimxrt700_evk`.
 
 The input voltage for the negative input of the analog comparator is
-provided by the ACMP Digital-to-Analog Converter (DAC). The input voltage for
-the positive input can be adjusted by turning the on-board potentiometer for
-:zephyr:board:`twr_ke18f` board, for :zephyr:board:`mimxrt1170_evk` the voltage signal is
-captured on J25-13, the :zephyr:board:`frdm_ke17z` and :zephyr:board:`frdm_ke17z512` boards are
-captured in J2-3, the :zephyr:board:`mimxrt1180_evk` board are captured in J45-13, need
-change the external voltage signal to check the output.
-
-The output value of the analog comparator is reported on the console.
+provided by the ACMP Digital-to-Analog Converter (DAC). The output value
+of the analog comparator is reported on the console.
 
 Building and Running
 ********************
@@ -82,5 +76,24 @@ ACMP input voltage by changing the voltage input to J45-13.
 .. zephyr-app-commands::
    :zephyr-app: samples/sensor/mcux_acmp
    :board: mimxrt1180_evk/mimxrt1189/cm7
+   :goals: flash
+   :compact:
+
+Building and Running for MIMXRT700-EVK
+=======================================
+Build the application for the MIMXRT700-EVK board, and adjust the
+ACMP input voltage by changing the voltage input to J7-9.
+
+Note:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/mcux_acmp
+   :board: mimxrt700_evk/mimxrt798s/cm33_cpu0
+   :goals: flash
+   :compact:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/sensor/mcux_acmp
+   :board: mimxrt700_evk/mimxrt798s/cm33_cpu1
    :goals: flash
    :compact:

--- a/samples/sensor/mcux_acmp/sample.yaml
+++ b/samples/sensor/mcux_acmp/sample.yaml
@@ -10,6 +10,8 @@ common:
     - mimxrt1170_evk/mimxrt1176/cm4
     - mimxrt1180_evk/mimxrt1189/cm33
     - mimxrt1180_evk/mimxrt1189/cm7
+    - mimxrt700_evk/mimxrt798s/cm33_cpu0
+    - mimxrt700_evk/mimxrt798s/cm33_cpu1
   integration_platforms:
     - twr_ke18f
   tags:

--- a/samples/sensor/mcux_acmp/src/main.c
+++ b/samples/sensor/mcux_acmp/src/main.c
@@ -27,6 +27,11 @@
 #define ACMP_POSITIVE 4
 #define ACMP_NEGATIVE 4
 #define ACMP_DAC_VREF 0
+#elif (defined(CONFIG_BOARD_MIMXRT700_EVK))
+#define ACMP_NODE  DT_NODELABEL(acmp)
+#define ACMP_POSITIVE 1
+#define ACMP_NEGATIVE 7
+#define ACMP_DAC_VREF 1
 #else
 #error Unsupported board
 #endif
@@ -97,7 +102,16 @@ static void acmp_trigger_handler(const struct device *dev,
 
 int main(void)
 {
-	struct sensor_trigger trigger;
+	struct sensor_trigger trigger[ARRAY_SIZE(triggers)] = {
+		[0] = {
+				.chan = SENSOR_CHAN_MCUX_ACMP_OUTPUT,
+				.type = triggers[0],
+			},
+		[1] = {
+			.chan = SENSOR_CHAN_MCUX_ACMP_OUTPUT,
+			.type = triggers[1],
+		}};
+
 	const struct device *const acmp = DEVICE_DT_GET(ACMP_NODE);
 	struct sensor_value val;
 	int err;
@@ -124,10 +138,8 @@ int main(void)
 	k_sleep(K_MSEC(1));
 
 	/* Set ACMP triggers */
-	trigger.chan = SENSOR_CHAN_MCUX_ACMP_OUTPUT;
 	for (i = 0; i < ARRAY_SIZE(triggers); i++) {
-		trigger.type = triggers[i];
-		err = sensor_trigger_set(acmp, &trigger, acmp_trigger_handler);
+		err = sensor_trigger_set(acmp, &trigger[i], acmp_trigger_handler);
 		if (err) {
 			printf("failed to set trigger %d (err %d)", i, err);
 			return 0;


### PR DESCRIPTION
1.Enabled ACMP on MIMXRT700 EVK
2.Fixed MCUX_ACMP driver bug, improved driver compatibility
3.Fixed MCUX_ACMP example bug.