### PR TITLE
tests: boards: nrf: i2c: Fix nrf52 and nrf53 pin assignment

### DIFF
--- a/tests/boards/nrf/i2c/i2c_slave/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/boards/nrf/i2c/i2c_slave/boards/nrf52840dk_nrf52840.overlay
@@ -7,33 +7,31 @@
 &pinctrl {
 	i2c0_default_alt: i2c0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
-				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 1)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
 		};
 	};
 
 	i2c0_sleep_alt: i2c0_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
-				<NRF_PSEL(TWIM_SCL, 0, 3)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 1)>,
+				<NRF_PSEL(TWIM_SCL, 1, 3)>;
 			low-power-enable;
 		};
 	};
 
 	i2c1_default_alt: i2c1_default_alt {
 		group1 {
-/* Temporary workaround as it is currently not possible
- * to configure pins for TWIS with pinctrl. */
-			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
-				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c1_sleep_alt: i2c1_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 0, 30)>,
-				<NRF_PSEL(TWIM_SCL, 0, 31)>;
+			psels = <NRF_PSEL(TWIM_SDA, 1, 2)>,
+				<NRF_PSEL(TWIM_SCL, 1, 4)>;
 			low-power-enable;
 		};
 	};

--- a/tests/boards/nrf/i2c/i2c_slave/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/boards/nrf/i2c/i2c_slave/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -8,32 +8,30 @@
 	i2c1_default_alt: i2c1_default_alt {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
-				<NRF_PSEL(TWIM_SCL, 0, 5)>;
+				<NRF_PSEL(TWIM_SCL, 0, 6)>;
 		};
 	};
 
 	i2c1_sleep_alt: i2c1_sleep_alt {
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 0, 4)>,
-				<NRF_PSEL(TWIM_SCL, 0, 5)>;
+				<NRF_PSEL(TWIM_SCL, 0, 6)>;
 			low-power-enable;
 		};
 	};
 
 	i2c2_default_alt: i2c2_default_alt {
 		group1 {
-/* Temporary workaround as it is currently not possible
- * to configure pins for TWIS with pinctrl. */
-			psels = <NRF_PSEL(TWIM_SDA, 0, 26)>,
-				<NRF_PSEL(TWIM_SCL, 0, 25)>;
+			psels = <NRF_PSEL(TWIM_SDA, 0, 5)>,
+				<NRF_PSEL(TWIM_SCL, 0, 7)>;
 			bias-pull-up;
 		};
 	};
 
 	i2c2_sleep_alt: i2c2_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(TWIM_SDA, 0, 26)>,
-				<NRF_PSEL(TWIM_SCL, 0, 25)>;
+			psels = <NRF_PSEL(TWIM_SDA, 0, 5)>,
+				<NRF_PSEL(TWIM_SCL, 0, 7)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
Fix the i2c loopbacks pins assignments for nrf52 and nrf53 to allow automated testing.