### PR TITLE
tests/drivers/memc/ram/ on adi_eval_adin1110ebz without sram region

### DIFF
--- a/tests/drivers/memc/ram/boards/adi_eval_adin1110ebz.overlay
+++ b/tests/drivers/memc/ram/boards/adi_eval_adin1110ebz.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram1 {
+	status = "disabled";
+};
+
+&sram2 {
+	status = "disabled";
+};


### PR DESCRIPTION
Add an overlay to execute the  tests/drivers/memc/ram/ on  adi_eval_adin1110ebz
without sram1 or sram2 
That will avoid warning about orphan section for
`DT_N_S_memory_10000000_P_zephyr_memory_region_STRING_TOKEN and DT_N_S_memory_20040000_P_zephyr_memory_region_STRING_TOKEN

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/89893