### PR TITLE
zms: fix init if a faulty bit is detected in the next free location

### DIFF
--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1146,6 +1146,8 @@ static int zms_init(struct zms_fs *fs)
 	uint32_t i;
 	uint32_t closed_sectors = 0;
 	bool zms_magic_exist = false;
+	bool ebw_required =
+		flash_params_get_erase_cap(fs->flash_parameters) & FLASH_ERASE_C_EXPLICIT;
 
 	k_mutex_lock(&fs->zms_lock, K_FOREVER);
 
@@ -1279,9 +1281,30 @@ static int zms_init(struct zms_fs *fs)
 		if (rc) {
 			goto end;
 		}
-		if (!zms_ate_valid(fs, &last_ate)) {
-			/* found empty location */
-			break;
+
+		/* Verify that the next location is empty.
+		 * For devices that do not need erase this should be a non valid ATE.
+		 * For devices that needs erase this should be filled with erase_value.
+		 */
+		if (ebw_required) {
+			size_t byte;
+
+			for (byte = 0; byte < sizeof(last_ate); byte++) {
+				if (((uint8_t *)&last_ate)[byte] !=
+				    (uint8_t)fs->flash_parameters->erase_value) {
+					break; /* break from the comparison loop */
+				}
+			}
+
+			if (byte == sizeof(last_ate)) {
+				/* found ff empty location */
+				break;
+			}
+		} else {
+			if (!zms_ate_valid(fs, &last_ate)) {
+				/* found empty location */
+				break;
+			}
 		}
 
 		/* ate on the last position within the sector is


### PR DESCRIPTION
For devices that need an erase before a write, ZMS do not verify that the next available location in the open sector is filled with the erase_value.
Fix this by adding a check at init.