### PR TITLE
boards: nordic: nrf54l*_cpuapp/nrf54l15_cpuapp_ns/nrf9160: use common dts partitioning

### DIFF
--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.dts
@@ -26,49 +26,5 @@
 	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
 };
 
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1022)>;
-};
-
-/* These partition sizes assume no FLPR area in RRAM */
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(224)>;
-		};
-
-		slot0_ns_partition: partition@48000 {
-			label = "image-0-nonsecure";
-			reg = <0x48000 DT_SIZE_K(224)>;
-		};
-
-		slot1_partition: partition@80000 {
-			label = "image-1";
-			reg = <0x80000 DT_SIZE_K(224)>;
-		};
-
-		slot1_ns_partition: partition@b8000 {
-			label = "image-1-nonsecure";
-			reg = <0xb8000 DT_SIZE_K(224)>;
-		};
-
-		/* 32K from 0xf0000 to 0xf7fff reserved for TF-M partitions */
-
-		storage_partition: partition@f8000 {
-			label = "storage";
-			reg = <0xf8000 DT_SIZE_K(28)>;
-		};
-
-		/* 2K from 0xff000 to 0xff7ff unused */
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l10_partition.dtsi>

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.yaml
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp.yaml
@@ -11,7 +11,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 192
-flash: 230
+flash: 1012
 supported:
   - adc
   - counter

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp_ns.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l10_cpuapp_ns.dts
@@ -59,6 +59,9 @@
 };
 
 &cpuapp_rram {
+	/* TODO: revert this hack when TF-M update is available that fixes partition sizes */
+	reg = <0x0 DT_SIZE_K(1022)>;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp.dts
@@ -20,41 +20,5 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(324)>;
-		};
-
-		slot0_ns_partition: partition@61000 {
-			label = "image-0-nonsecure";
-			reg = <0x61000 DT_SIZE_K(324)>;
-		};
-
-		slot1_partition: partition@b2000 {
-			label = "image-1";
-			reg = <0xb2000 DT_SIZE_K(324)>;
-		};
-
-		slot1_ns_partition: partition@103000 {
-			label = "image-1-nonsecure";
-			reg = <0x103000 DT_SIZE_K(324)>;
-		};
-
-		/* 32k from 0x154000 to 0x15bfff reserved for TF-M partitions */
-		storage_partition: partition@15c000 {
-			label = "storage";
-			reg = <0x15c000 DT_SIZE_K(36)>;
-		};
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_partition.dtsi>

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp.yaml
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp.yaml
@@ -11,7 +11,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 188
-flash: 324
+flash: 1428
 supported:
   - adc
   - counter

--- a/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp_ns.dts
+++ b/boards/ezurio/bl54l15_dvk/bl54l15_dvk_nrf54l15_cpuapp_ns.dts
@@ -58,51 +58,6 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* nRF54L15 has 1524 kB of non volatile memory (RRAM) but the
-		 * last 96kB are reserved for the FLPR MCU.
-		 *
-		 * This static layout needs to be the same with the upstream TF-M layout in the
-		 * header flash_layout.h of the relevant platform. Any updates in the layout
-		 * needs to happen both in the flash_layout.h and in this file at the same time.
-		 */
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0000000 DT_SIZE_K(512)>;
-		};
-
-		tfm_ps_partition: partition@80000 {
-			label = "tfm-ps";
-			reg = <0x00080000 DT_SIZE_K(16)>;
-		};
-
-		tfm_its_partition: partition@84000 {
-			label = "tfm-its";
-			reg = <0x00084000 DT_SIZE_K(16)>;
-		};
-
-		tfm_otp_partition: partition@88000 {
-			label = "tfm-otp";
-			reg = <0x00088000 DT_SIZE_K(8)>;
-		};
-
-		slot0_ns_partition: partition@8A000 {
-			label = "image-0-nonsecure";
-			reg = <0x0008A000 DT_SIZE_K(844)>;
-		};
-
-		storage_partition: partition@15D000 {
-			label = "storage";
-			reg = <0x00015D000 DT_SIZE_K(32)>;
-		};
-	};
-};
-
 &uart30 {
 	/* Disable so that TF-M can use this UART */
 	status = "disabled";
@@ -112,3 +67,6 @@
 	pinctrl-1 = <&uart30_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_ns_partition.dtsi>

--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp.dts
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp.dts
@@ -20,41 +20,5 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(324)>;
-		};
-
-		slot0_ns_partition: partition@61000 {
-			label = "image-0-nonsecure";
-			reg = <0x61000 DT_SIZE_K(324)>;
-		};
-
-		slot1_partition: partition@b2000 {
-			label = "image-1";
-			reg = <0xb2000 DT_SIZE_K(324)>;
-		};
-
-		slot1_ns_partition: partition@103000 {
-			label = "image-1-nonsecure";
-			reg = <0x103000 DT_SIZE_K(324)>;
-		};
-
-		/* 32k from 0x154000 to 0x15bfff reserved for TF-M partitions */
-		storage_partition: partition@15c000 {
-			label = "storage";
-			reg = <0x15c000 DT_SIZE_K(36)>;
-		};
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_partition.dtsi>

--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp.yaml
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp.yaml
@@ -11,7 +11,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 188
-flash: 324
+flash: 1428
 supported:
   - adc
   - counter

--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns.dts
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns.dts
@@ -58,51 +58,6 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* nRF54L15 has 1524 kB of non volatile memory (RRAM) but the
-		 * last 96kB are reserved for the FLPR MCU.
-		 *
-		 * This static layout needs to be the same with the upstream TF-M layout in the
-		 * header flash_layout.h of the relevant platform. Any updates in the layout
-		 * needs to happen both in the flash_layout.h and in this file at the same time.
-		 */
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0000000 DT_SIZE_K(512)>;
-		};
-
-		tfm_ps_partition: partition@80000 {
-			label = "tfm-ps";
-			reg = <0x00080000 DT_SIZE_K(16)>;
-		};
-
-		tfm_its_partition: partition@84000 {
-			label = "tfm-its";
-			reg = <0x00084000 DT_SIZE_K(16)>;
-		};
-
-		tfm_otp_partition: partition@88000 {
-			label = "tfm-otp";
-			reg = <0x00088000 DT_SIZE_K(8)>;
-		};
-
-		slot0_ns_partition: partition@8A000 {
-			label = "image-0-nonsecure";
-			reg = <0x0008A000 DT_SIZE_K(844)>;
-		};
-
-		storage_partition: partition@15D000 {
-			label = "storage";
-			reg = <0x00015D000 DT_SIZE_K(32)>;
-		};
-	};
-};
-
 &uart30 {
 	/* Disable so that TF-M can use this UART */
 	status = "disabled";
@@ -112,3 +67,6 @@
 	pinctrl-1 = <&uart30_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_ns_partition.dtsi>

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.dts
@@ -25,45 +25,5 @@
 	ranges = <0x0 0x20000000 DT_SIZE_K(96)>;
 };
 
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(500)>;
-};
-
-/* These partition sizes assume no FLPR area in RRAM */
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(100)>;
-		};
-
-		slot0_ns_partition: partition@29000 {
-			label = "image-0-nonsecure";
-			reg = <0x29000 DT_SIZE_K(100)>;
-		};
-
-		slot1_partition: partition@42000 {
-			label = "image-1";
-			reg = <0x42000 DT_SIZE_K(100)>;
-		};
-
-		slot1_ns_partition: partition@5b000 {
-			label = "image-1-nonsecure";
-			reg = <0x5b000 DT_SIZE_K(100)>;
-		};
-
-		storage_partition: partition@74000 {
-			label = "storage";
-			reg = <0x74000 DT_SIZE_K(36)>;
-		};
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l05_partition.dtsi>

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l05_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 96
-flash: 100
+flash: 500
 supported:
   - adc
   - counter

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.dts
@@ -25,49 +25,5 @@
 	ranges = <0x0 0x20000000 DT_SIZE_K(192)>;
 };
 
-&cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(1022)>;
-};
-
-/* These partition sizes assume no FLPR area in RRAM */
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(224)>;
-		};
-
-		slot0_ns_partition: partition@48000 {
-			label = "image-0-nonsecure";
-			reg = <0x48000 DT_SIZE_K(224)>;
-		};
-
-		slot1_partition: partition@80000 {
-			label = "image-1";
-			reg = <0x80000 DT_SIZE_K(224)>;
-		};
-
-		slot1_ns_partition: partition@b8000 {
-			label = "image-1-nonsecure";
-			reg = <0xb8000 DT_SIZE_K(224)>;
-		};
-
-		/* 32K from 0xf0000 to 0xf7fff reserved for TF-M partitions */
-
-		storage_partition: partition@f8000 {
-			label = "storage";
-			reg = <0xf8000 DT_SIZE_K(28)>;
-		};
-
-		/* 2K from 0xff000 to 0xff7ff unused */
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l10_partition.dtsi>

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 192
-flash: 230
+flash: 1012
 supported:
   - adc
   - counter

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_ns.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l10_cpuapp_ns.dts
@@ -58,6 +58,9 @@
 };
 
 &cpuapp_rram {
+	/* TODO: revert this hack when TF-M update is available that fixes partition sizes */
+	reg = <0x0 DT_SIZE_K(1022)>;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.dts
@@ -19,42 +19,5 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(324)>;
-		};
-
-		slot0_ns_partition: partition@61000 {
-			label = "image-0-nonsecure";
-			reg = <0x61000 DT_SIZE_K(324)>;
-		};
-
-		slot1_partition: partition@b2000 {
-			label = "image-1";
-			reg = <0xb2000 DT_SIZE_K(324)>;
-		};
-
-		slot1_ns_partition: partition@103000 {
-			label = "image-1-nonsecure";
-			reg = <0x103000 DT_SIZE_K(324)>;
-		};
-
-		/* 32k from 0x154000 to 0x15bfff reserved for TF-M partitions */
-
-		storage_partition: partition@15c000 {
-			label = "storage";
-			reg = <0x15c000 DT_SIZE_K(36)>;
-		};
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_partition.dtsi>

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 188
-flash: 324
+flash: 1428
 supported:
   - adc
   - counter

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_ns.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_ns.dts
@@ -57,51 +57,6 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* nRF54L15 has 1524 kB of non volatile memory (RRAM) but the
-		 * last 96kB are reserved for the FLPR MCU.
-		 *
-		 * This static layout needs to be the same with the upstream TF-M layout in the
-		 * header flash_layout.h of the relevant platform. Any updates in the layout
-		 * needs to happen both in the flash_layout.h and in this file at the same time.
-		 */
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0000000 DT_SIZE_K(512)>;
-		};
-
-		tfm_ps_partition: partition@80000 {
-			label = "tfm-ps";
-			reg = <0x00080000 DT_SIZE_K(16)>;
-		};
-
-		tfm_its_partition: partition@84000 {
-			label = "tfm-its";
-			reg = <0x00084000 DT_SIZE_K(16)>;
-		};
-
-		tfm_otp_partition: partition@88000 {
-			label = "tfm-otp";
-			reg = <0x00088000 DT_SIZE_K(8)>;
-		};
-
-		slot0_ns_partition: partition@8A000 {
-			label = "image-0-nonsecure";
-			reg = <0x0008A000 DT_SIZE_K(844)>;
-		};
-
-		storage_partition: partition@15D000 {
-			label = "storage";
-			reg = <0x00015D000 DT_SIZE_K(32)>;
-		};
-	};
-};
-
 &uart30 {
 	/* Disable so that TF-M can use this UART */
 	status = "disabled";
@@ -111,3 +66,6 @@
 	pinctrl-1 = <&uart30_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_ns_partition.dtsi>

--- a/boards/panasonic/panb511evb/panb511evb_nrf54l15_cpuapp.dts
+++ b/boards/panasonic/panb511evb/panb511evb_nrf54l15_cpuapp.dts
@@ -19,41 +19,5 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(324)>;
-		};
-
-		slot0_ns_partition: partition@61000 {
-			label = "image-0-nonsecure";
-			reg = <0x61000 DT_SIZE_K(324)>;
-		};
-
-		slot1_partition: partition@b2000 {
-			label = "image-1";
-			reg = <0xb2000 DT_SIZE_K(324)>;
-		};
-
-		slot1_ns_partition: partition@103000 {
-			label = "image-1-nonsecure";
-			reg = <0x103000 DT_SIZE_K(324)>;
-		};
-
-		/* 32k from 0x154000 to 0x15bfff reserved for TF-M partitions */
-		storage_partition: partition@15c000 {
-			label = "storage";
-			reg = <0x15c000 DT_SIZE_K(36)>;
-		};
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_partition.dtsi>

--- a/boards/panasonic/panb511evb/panb511evb_nrf54l15_cpuapp.yaml
+++ b/boards/panasonic/panb511evb/panb511evb_nrf54l15_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 188
-flash: 324
+flash: 1428
 supported:
   - adc
   - counter

--- a/boards/panasonic/panb511evb/panb511evb_nrf54l15_cpuapp_ns.dts
+++ b/boards/panasonic/panb511evb/panb511evb_nrf54l15_cpuapp_ns.dts
@@ -57,51 +57,6 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* nRF54L15 has 1524 kB of non volatile memory (RRAM) but the
-		 * last 96kB are reserved for the FLPR MCU.
-		 *
-		 * This static layout needs to be the same with the upstream TF-M layout in the
-		 * header flash_layout.h of the relevant platform. Any updates in the layout
-		 * needs to happen both in the flash_layout.h and in this file at the same time.
-		 */
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0000000 DT_SIZE_K(512)>;
-		};
-
-		tfm_ps_partition: partition@80000 {
-			label = "tfm-ps";
-			reg = <0x00080000 DT_SIZE_K(16)>;
-		};
-
-		tfm_its_partition: partition@84000 {
-			label = "tfm-its";
-			reg = <0x00084000 DT_SIZE_K(16)>;
-		};
-
-		tfm_otp_partition: partition@88000 {
-			label = "tfm-otp";
-			reg = <0x00088000 DT_SIZE_K(8)>;
-		};
-
-		slot0_ns_partition: partition@8A000 {
-			label = "image-0-nonsecure";
-			reg = <0x0008A000 DT_SIZE_K(844)>;
-		};
-
-		storage_partition: partition@15D000 {
-			label = "storage";
-			reg = <0x00015D000 DT_SIZE_K(32)>;
-		};
-	};
-};
-
 &uart20 {
 	/* Disable so that TF-M can use this UART */
 	status = "disabled";
@@ -111,3 +66,6 @@
 	pinctrl-1 = <&uart20_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_ns_partition.dtsi>

--- a/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp.dts
+++ b/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp.dts
@@ -21,41 +21,5 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(324)>;
-		};
-
-		slot0_ns_partition: partition@61000 {
-			label = "image-0-nonsecure";
-			reg = <0x61000 DT_SIZE_K(324)>;
-		};
-
-		slot1_partition: partition@b2000 {
-			label = "image-1";
-			reg = <0xb2000 DT_SIZE_K(324)>;
-		};
-
-		slot1_ns_partition: partition@103000 {
-			label = "image-1-nonsecure";
-			reg = <0x103000 DT_SIZE_K(324)>;
-		};
-
-		/* 32k from 0x154000 to 0x15bfff reserved for TF-M partitions */
-		storage_partition: partition@15c000 {
-			label = "storage";
-			reg = <0x15c000 DT_SIZE_K(36)>;
-		};
-	};
-};
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_partition.dtsi>

--- a/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp.yaml
+++ b/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp.yaml
@@ -12,7 +12,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 188
-flash: 324
+flash: 1428
 supported:
   - adc
   - counter

--- a/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp_ns.dts
+++ b/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp_ns.dts
@@ -58,51 +58,6 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		/* nRF54L15 has 1524 kB of non volatile memory (RRAM) but the
-		 * last 96kB are reserved for the FLPR MCU.
-		 *
-		 * This static layout needs to be the same with the upstream TF-M layout in the
-		 * header flash_layout.h of the relevant platform. Any updates in the layout
-		 * needs to happen both in the flash_layout.h and in this file at the same time.
-		 */
-		slot0_partition: partition@0 {
-			label = "image-0";
-			reg = <0x0000000 DT_SIZE_K(512)>;
-		};
-
-		tfm_ps_partition: partition@80000 {
-			label = "tfm-ps";
-			reg = <0x00080000 DT_SIZE_K(16)>;
-		};
-
-		tfm_its_partition: partition@84000 {
-			label = "tfm-its";
-			reg = <0x00084000 DT_SIZE_K(16)>;
-		};
-
-		tfm_otp_partition: partition@88000 {
-			label = "tfm-otp";
-			reg = <0x00088000 DT_SIZE_K(8)>;
-		};
-
-		slot0_ns_partition: partition@8A000 {
-			label = "image-0-nonsecure";
-			reg = <0x0008A000 DT_SIZE_K(844)>;
-		};
-
-		storage_partition: partition@15D000 {
-			label = "storage";
-			reg = <0x00015D000 DT_SIZE_K(32)>;
-		};
-	};
-};
-
 &uart30 {
 	/* Disable so that TF-M can use this UART */
 	status = "disabled";
@@ -111,3 +66,6 @@
 	pinctrl-1 = <&uart30_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_ns_partition.dtsi>

--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.dts
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.dts
@@ -26,46 +26,6 @@
 	};
 };
 
-&cpuapp_rram {
-	partitions {
-		compatible = "fixed-partitions";
-
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x0 DT_SIZE_K(64)>;
-		};
-
-		slot0_partition: partition@10000 {
-			label = "image-0";
-			reg = <0x10000 DT_SIZE_K(324)>;
-		};
-
-		slot0_ns_partition: partition@61000 {
-			label = "image-0-nonsecure";
-			reg = <0x61000 DT_SIZE_K(324)>;
-		};
-
-		slot1_partition: partition@b2000 {
-			label = "image-1";
-			reg = <0xb2000 DT_SIZE_K(324)>;
-		};
-
-		slot1_ns_partition: partition@103000 {
-			label = "image-1-nonsecure";
-			reg = <0x103000 DT_SIZE_K(324)>;
-		};
-
-		/* 32k from 0x154000 to 0x15bfff reserved for TF-M partitions */
-		storage_partition: partition@15c000 {
-			label = "storage";
-			reg = <0x15c000 DT_SIZE_K(36)>;
-		};
-	};
-};
-
 &cpuapp_sram {
 	status = "okay";
 };
@@ -172,3 +132,6 @@
 &adc {
 	status = "okay";
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf54l15_partition.dtsi>

--- a/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.yaml
+++ b/boards/we/ophelia4ev/ophelia4ev_nrf54l15_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 188
-flash: 324
+flash: 1428
 supported:
   - adc
   - counter

--- a/dts/vendor/nordic/nrf54l05_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l05_partition.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(500)>;
+};
+
+/* These partition sizes assume no FLPR area in RRAM */
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(200)>;
+		};
+
+		slot1_partition: partition@42000 {
+			label = "image-1";
+			reg = <0x42000 DT_SIZE_K(200)>;
+		};
+
+		storage_partition: partition@74000 {
+			label = "storage";
+			reg = <0x74000 DT_SIZE_K(36)>;
+		};
+	};
+};

--- a/dts/vendor/nordic/nrf54l10.dtsi
+++ b/dts/vendor/nordic/nrf54l10.dtsi
@@ -25,14 +25,14 @@
 };
 
 &cpuapp_rram {
-	reg = <0x0 DT_SIZE_K(960)>;
+	reg = <0x0 DT_SIZE_K(950)>;
 };
 
-/* 960 + 62 = 1022KB */
+/* 950 + 62 = 1012KB */
 &rram_controller {
-	cpuflpr_rram: rram@f0000 {
+	cpuflpr_rram: rram@ed800 {
 		compatible = "soc-nv-flash";
-		reg = <0xf0000 DT_SIZE_K(62)>;
+		reg = <0xed800 DT_SIZE_K(62)>;
 		erase-block-size = <4096>;
 		write-block-size = <16>;
 	};

--- a/dts/vendor/nordic/nrf54l10_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l10_partition.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1012)>;
+};
+
+/* These partition sizes assume no FLPR area in RRAM */
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(456)>;
+		};
+
+		slot1_partition: partition@82000 {
+			label = "image-1";
+			reg = <0x82000 DT_SIZE_K(456)>;
+		};
+
+		storage_partition: partition@f4000 {
+			label = "storage";
+			reg = <0xf4000 DT_SIZE_K(36)>;
+		};
+	};
+};

--- a/dts/vendor/nordic/nrf54l15_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_ns_partition.dtsi
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpuapp_rram {
+	/*
+	 * Default NVM layout on NRF54L15 Application MCU without BL2:
+	 * This layout matches (by necessity) that in the TF-M repository:
+	 *
+	 * 0x0000_0000 Secure image primary (512 KB)
+	 * 0x0008_0000 Protected Storage Area (16 KB)
+	 * 0x0008_4000 Internal Trusted Storage Area (16 KB)
+	 * 0x0008_8000 OTP / NV counters area (8 KB)
+	 * 0x0008_A000 Non-secure image primary (844 KB)
+	 * 0x0015_D000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+	 *             otherwise unused (32 KB)
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* nRF54L15 has 1524 kB of non volatile memory (RRAM) but the
+		 * last 96kB are reserved for the FLPR MCU.
+		 *
+		 * This static layout needs to be the same with the upstream TF-M layout in the
+		 * header flash_layout.h of the relevant platform. Any updates in the layout
+		 * needs to happen both in the flash_layout.h and in this file at the same time.
+		 */
+		slot0_partition: partition@0 {
+			label = "image-0";
+			reg = <0x0000000 DT_SIZE_K(512)>;
+		};
+
+		tfm_ps_partition: partition@80000 {
+			label = "tfm-ps";
+			reg = <0x00080000 DT_SIZE_K(16)>;
+		};
+
+		tfm_its_partition: partition@84000 {
+			label = "tfm-its";
+			reg = <0x00084000 DT_SIZE_K(16)>;
+		};
+
+		tfm_otp_partition: partition@88000 {
+			label = "tfm-otp";
+			reg = <0x00088000 DT_SIZE_K(8)>;
+		};
+
+		slot0_ns_partition: partition@8A000 {
+			label = "image-0-nonsecure";
+			reg = <0x0008A000 DT_SIZE_K(844)>;
+		};
+
+		storage_partition: partition@15D000 {
+			label = "storage";
+			reg = <0x00015D000 DT_SIZE_K(32)>;
+		};
+	};
+};

--- a/dts/vendor/nordic/nrf54l15_partition.dtsi
+++ b/dts/vendor/nordic/nrf54l15_partition.dtsi
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&cpuapp_rram {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x0 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 DT_SIZE_K(664)>;
+		};
+
+		slot1_partition: partition@b6000 {
+			label = "image-1";
+			reg = <0xb6000 DT_SIZE_K(664)>;
+		};
+
+		storage_partition: partition@15c000 {
+			label = "storage";
+			reg = <0x15c000 DT_SIZE_K(36)>;
+		};
+	};
+};

--- a/dts/vendor/nordic/nrf91xx_partition.dtsi
+++ b/dts/vendor/nordic/nrf91xx_partition.dtsi
@@ -35,23 +35,41 @@
 		};
 
 		slot0_partition: partition@10000 {
+			compatible = "fixed-subpartitions";
 			label = "image-0";
-			reg = <0x00010000 0x40000>;
-		};
+			reg = <0x00010000 0x70000>;
+			ranges = <0x0 0x10000 0x70000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		slot0_ns_partition: partition@50000 {
-			label = "image-0-nonsecure";
-			reg = <0x00050000 0x30000>;
+			slot0_s_partition: partition@0 {
+				label = "image-0-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot0_ns_partition: partition@40000 {
+				label = "image-0-nonsecure";
+				reg = <0x00040000 0x30000>;
+			};
 		};
 
 		slot1_partition: partition@80000 {
+			compatible = "fixed-subpartitions";
 			label = "image-1";
-			reg = <0x00080000 0x40000>;
-		};
+			reg = <0x00080000 0x70000>;
+			ranges = <0x0 0x80000 0x70000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		slot1_ns_partition: partition@c0000 {
-			label = "image-1-nonsecure";
-			reg = <0x000c0000 0x30000>;
+			slot1_s_partition: partition@0 {
+				label = "image-1-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot1_ns_partition: partition@40000 {
+				label = "image-1-nonsecure";
+				reg = <0x00040000 0x30000>;
+			};
 		};
 
 		tfm_ps_partition: partition@f0000 {

--- a/samples/subsys/fs/fs_sample/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -11,8 +11,6 @@
  */
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot0_ns_partition;
-/delete-node/ &slot1_ns_partition;
 /delete-node/ &storage_partition;
 
 &cpuapp_rram {

--- a/samples/subsys/fs/fs_sample/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -11,8 +11,6 @@
  */
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot0_ns_partition;
-/delete-node/ &slot1_ns_partition;
 /delete-node/ &storage_partition;
 
 &cpuapp_rram {

--- a/samples/subsys/fs/fs_sample/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -10,8 +10,6 @@
  */
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot0_ns_partition;
-/delete-node/ &slot1_ns_partition;
 /delete-node/ &storage_partition;
 
 &cpuapp_rram {
@@ -23,6 +21,7 @@
 		slot0_partition: parition@10000 {
 			reg = <0x00010000 DT_SIZE_K(300)>;
 		};
+
 		slot1_partition: partition@5b000 {
 			reg = <0x0005b000 DT_SIZE_K(300)>;
 		};

--- a/samples/subsys/fs/fs_sample/boards/ophelia4ev_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/fs/fs_sample/boards/ophelia4ev_nrf54l15_cpuapp.overlay
@@ -10,8 +10,6 @@
  */
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &slot0_ns_partition;
-/delete-node/ &slot1_ns_partition;
 /delete-node/ &storage_partition;
 
 &cpuapp_rram {


### PR DESCRIPTION
Adapts to common dts files for partition information