### PR TITLE
drvers: stepper: Modular Step-Dir Implementations

### DIFF
--- a/drivers/stepper/step_dir/CMakeLists.txt
+++ b/drivers/stepper/step_dir/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 zephyr_library()
 
+zephyr_library_sources(step_dir_stepper.c)
 zephyr_library_sources(step_dir_stepper_common.c)
 zephyr_library_sources(step_dir_stepper_work_timing.c)
 zephyr_library_sources_ifdef(CONFIG_STEP_DIR_STEPPER_COUNTER_TIMING step_dir_stepper_counter_timing.c)

--- a/drivers/stepper/step_dir/step_dir_stepper.c
+++ b/drivers/stepper/step_dir/step_dir_stepper.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Navimatix GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "step_dir_stepper.h"
+
+/* Allows wrapper functions to access the step_dir_stepper_api struct for function pointers. */
+struct step_dir_stepper_wrapper_config {
+	union step_dir_stepper_config config;
+	const struct step_dir_stepper_api *api;
+};
+
+int step_dir_stepper_move_by(const struct device *dev, const int32_t micro_steps)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->move_by(dev, micro_steps);
+}
+
+int step_dir_stepper_set_microstep_interval(const struct device *dev,
+					    const uint64_t microstep_interval_ns)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->set_microstep_interval(dev, microstep_interval_ns);
+}
+
+int step_dir_stepper_set_reference_position(const struct device *dev, const int32_t value)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->set_reference_position(dev, value);
+}
+
+int step_dir_stepper_get_actual_position(const struct device *dev, int32_t *value)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->get_actual_position(dev, value);
+}
+
+int step_dir_stepper_move_to(const struct device *dev, const int32_t value)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->move_to(dev, value);
+}
+
+int step_dir_stepper_is_moving(const struct device *dev, bool *is_moving)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->is_moving(dev, is_moving);
+}
+
+int step_dir_stepper_run(const struct device *dev, const enum stepper_direction direction)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->run(dev, direction);
+}
+
+int step_dir_stepper_stop(const struct device *dev)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->stop(dev);
+}
+
+int step_dir_stepper_set_event_callback(const struct device *dev, stepper_event_callback_t callback,
+					void *user_data)
+{
+	const struct step_dir_stepper_wrapper_config *config = dev->config;
+
+	return config->api->set_event_callback(dev, callback, user_data);
+}

--- a/drivers/stepper/step_dir/step_dir_stepper.h
+++ b/drivers/stepper/step_dir/step_dir_stepper.h
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2025 Navimatix GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_H_
+#define ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_H_
+
+/**
+ * @brief Stepper Driver APIs
+ * @defgroup step_dir_stepper Stepper Driver APIs
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/stepper.h>
+#include <zephyr/drivers/counter.h>
+
+#include "step_dir_stepper_common.h"
+
+/**
+ * @brief Function to initialize a step direction stepper device at init time.
+ *
+ * This function must be called at the end of the device init function.
+ *
+ * @param dev Step direction stepper device instance.
+ *
+ * @retval 0 If initialized successfully.
+ * @retval -errno Negative errno in case of failure.
+ */
+typedef int (*step_dir_stepper_init_t)(const struct device *dev);
+
+/**
+ * @brief Move the stepper motor by a given number of micro_steps.
+ *
+ * @param dev Pointer to the device structure.
+ * @param micro_steps Number of micro_steps to move. Can be positive or negative.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_move_by_t)(const struct device *dev, const int32_t micro_steps);
+
+/**
+ * @brief Move the stepper motor to the target position.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value The target position to set.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_move_to_t)(const struct device *dev, const int32_t value);
+
+/**
+ * @brief Set the step interval of the stepper motor.
+ *
+ * @param dev Pointer to the device structure.
+ * @param microstep_interval_ns The step interval in nanoseconds.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_set_microstep_interval_t)(const struct device *dev,
+							 const uint64_t microstep_interval_ns);
+
+/**
+ * @brief Set the reference position of the stepper motor.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value The reference position value to set.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_set_reference_position_t)(const struct device *dev,
+							 const int32_t value);
+
+/**
+ * @brief Get the actual (reference) position of the stepper motor.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value Pointer to a variable where the position value will be stored.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_get_actual_position_t)(const struct device *dev, int32_t *value);
+
+/**
+ * @brief Check if the stepper motor is still moving.
+ *
+ * @param dev Pointer to the device structure.
+ * @param is_moving Pointer to a boolean where the movement status will be stored.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_is_moving_t)(const struct device *dev, bool *is_moving);
+
+/**
+ * @brief Run the stepper with a given direction and step interval.
+ *
+ * @param dev Pointer to the device structure.
+ * @param direction The direction of movement (positive or negative).
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_run_t)(const struct device *dev,
+				      const enum stepper_direction direction);
+
+/**
+ * @brief Stop the stepper motor.
+ *
+ * @param dev Pointer to the device structure.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_stop_t)(const struct device *dev);
+
+/**
+ * @brief Set a callback function for stepper motor events.
+ *
+ * This function sets a user-defined callback that will be invoked when a stepper motor event
+ * occurs.
+ *
+ * @param dev Pointer to the device structure.
+ * @param callback The callback function to set.
+ * @param user_data Pointer to user-defined data that will be passed to the callback.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*step_dir_stepper_set_event_callback_t)(const struct device *dev,
+						     stepper_event_callback_t callback,
+						     void *user_data);
+
+/**
+ * @brief Handle a timing signal and update the stepper position.
+ * @param dev Pointer to the device structure.
+ */
+typedef void (*step_dir_stepper_handle_timing_signal_t)(const struct device *dev);
+
+/**
+ * @brief Trigger callback function for stepper motor events.
+ * @param dev Pointer to the device structure.
+ * @param event The stepper_event to rigger the callback for.
+ */
+typedef void (*step_dir_stepper_trigger_callback_t)(const struct device *dev,
+						    enum stepper_event event);
+
+/**
+ * @brief Step-Dir API.
+ */
+struct step_dir_stepper_api {
+	step_dir_stepper_init_t init;
+	step_dir_stepper_move_by_t move_by;
+	step_dir_stepper_move_to_t move_to;
+	step_dir_stepper_set_microstep_interval_t set_microstep_interval;
+	step_dir_stepper_set_reference_position_t set_reference_position;
+	step_dir_stepper_get_actual_position_t get_actual_position;
+	step_dir_stepper_is_moving_t is_moving;
+	step_dir_stepper_run_t run;
+	step_dir_stepper_stop_t stop;
+	step_dir_stepper_set_event_callback_t set_event_callback;
+	step_dir_stepper_handle_timing_signal_t handle_timing_signal;
+	step_dir_stepper_trigger_callback_t trigger_callback;
+};
+
+/**
+ * @brief Union containing the config struct of the step_dir implementations
+ */
+union step_dir_stepper_config {
+	struct step_dir_stepper_common_config common;
+};
+
+/**
+ * @brief Union containing the data struct of the step_dir implementations
+ */
+union step_dir_stepper_data {
+	struct step_dir_stepper_common_data common;
+};
+
+/**
+ * @brief Validate the offset of the data structures.
+ *
+ * @param config Name of the config structure.
+ * @param data Name of the data structure.
+ */
+#define STEP_DIR_STEPPER_STRUCT_CHECK(config, data)                                                \
+	BUILD_ASSERT(offsetof(config, step_dir_config) == 0,                                       \
+		     "struct step_dir_stepper_config must be placed first");                       \
+	BUILD_ASSERT(offsetof(data, step_dir_data) == 0,                                           \
+		     "struct step_dir_stepper_data must be placed first");
+
+extern const struct step_dir_stepper_api step_dir_stepper_common_api;
+
+#define STEP_DIR_STEPPER_SETUP(node_id)                                                            \
+	COND_CODE_1(DT_ENUM_HAS_VALUE(node_id, step_dir, common),				   \
+			(STEP_DIR_STEPPER_DT_COMMON_SETUP(node_id)), ())
+
+#define STEP_DIR_STEPPER_SELECT(node_id)                                                           \
+	COND_CODE_1(DT_ENUM_HAS_VALUE(node_id, step_dir, common), (&step_dir_stepper_common_api),  \
+	())
+
+#define STEP_DIR_STEPPER_CONFIG(node_id)                                                           \
+	COND_CODE_1(DT_ENUM_HAS_VALUE(node_id, step_dir, common),				   \
+			(.step_dir_config.common =                                                 \
+				STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(node_id)), ())
+
+#define STEP_DIR_STEPPER_DATA(node_id)                                                             \
+	COND_CODE_1(DT_ENUM_HAS_VALUE(node_id, step_dir, common),				   \
+			(.step_dir_data.common = STEP_DIR_STEPPER_DT_COMMON_DATA_INIT(node_id)), ())
+
+#define STEP_DIR_STEPPER_INST_SETUP(inst)  STEP_DIR_STEPPER_SETUP(DT_DRV_INST(inst))
+#define STEP_DIR_STEPPER_SELECT_INST(inst) STEP_DIR_STEPPER_SELECT(DT_DRV_INST(inst))
+#define STEP_DIR_STEPPER_CONFIG_INST(inst) STEP_DIR_STEPPER_CONFIG(DT_DRV_INST(inst))
+#define STEP_DIR_STEPPER_DATA_INST(inst)   STEP_DIR_STEPPER_DATA(DT_DRV_INST(inst))
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_move_by` to the stepper api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param micro_steps Number of micro_steps to move. Can be positive or negative.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_move_by(const struct device *dev, const int32_t micro_steps);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_set_microstep_interval` to the stepper
+ * api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param microstep_interval_ns The step interval in nanoseconds.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_set_microstep_interval(const struct device *dev,
+					    const uint64_t microstep_interval_ns);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_set_reference_position` to the stepper
+ * api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value The reference position value to set.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_set_reference_position(const struct device *dev, const int32_t value);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_get_actual_position` to the stepper api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value Pointer to a variable where the position value will be stored.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_get_actual_position(const struct device *dev, int32_t *value);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_move_to` to the stepper api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param value The target position to set.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_move_to(const struct device *dev, const int32_t value);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_is_moving` to the stepper api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param is_moving Pointer to a boolean where the movement status will be stored.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_is_moving(const struct device *dev, bool *is_moving);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_run` to the stepper api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param direction The direction of movement (positive or negative).
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_run(const struct device *dev, const enum stepper_direction direction);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_stop` to the stepper api.
+ *
+ * @param dev Pointer to the device structure.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_stop(const struct device *dev);
+
+/**
+ * @brief Wrapper function for assigning `step_dir_stepper_set_event_callback` to the stepper api.
+ *
+ * @param dev Pointer to the device structure.
+ * @param callback The callback function to set.
+ * @param user_data Pointer to user-defined data that will be passed to the callback.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_set_event_callback(const struct device *dev, stepper_event_callback_t callback,
+					void *user_data);
+
+#endif /* ZEPHYR_DRIVER_STEPPER_STEP_DIR_STEPPER_H_ */

--- a/drivers/stepper/step_dir/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.h
@@ -51,15 +51,8 @@ struct step_dir_stepper_common_config {
 		.invert_direction = DT_PROP(node_id, invert_direction),                            \
 		.timing_source = COND_CODE_1(DT_NODE_HAS_PROP(node_id, counter),                   \
 						(&step_counter_timing_source_api),                 \
-						(&step_work_timing_source_api)),                   \
-	}
-
-/**
- * @brief Initialize common step direction stepper config from devicetree instance.
- * @param inst Instance.
- */
-#define STEP_DIR_STEPPER_DT_INST_COMMON_CONFIG_INIT(inst)                                          \
-	STEP_DIR_STEPPER_DT_COMMON_CONFIG_INIT(DT_DRV_INST(inst))
+						(&step_work_timing_source_api)),    \
+		}
 
 /**
  * @brief Common step direction stepper data.
@@ -76,6 +69,7 @@ struct step_dir_stepper_common_data {
 	int32_t step_count;
 	stepper_event_callback_t callback;
 	void *event_cb_user_data;
+	step_dir_step_handler handler;
 
 	struct k_work_delayable stepper_dwork;
 
@@ -103,134 +97,14 @@ struct step_dir_stepper_common_data {
 	}
 
 /**
- * @brief Initialize common step direction stepper data from devicetree instance.
- * @param inst Instance.
- */
-#define STEP_DIR_STEPPER_DT_INST_COMMON_DATA_INIT(inst)                                            \
-	STEP_DIR_STEPPER_DT_COMMON_DATA_INIT(DT_DRV_INST(inst))
-
-/**
- * @brief Validate the offset of the common data structures.
+ * @brief Setup macro for step_dir_stepper_common
  *
- * @param config Name of the config structure.
- * @param data Name of the data structure.
- */
-#define STEP_DIR_STEPPER_STRUCT_CHECK(config, data)                                                \
-	BUILD_ASSERT(offsetof(config, common) == 0,                                                \
-		     "struct step_dir_stepper_common_config must be placed first");                \
-	BUILD_ASSERT(offsetof(data, common) == 0,                                                  \
-		     "struct step_dir_stepper_common_data must be placed first");
-
-/**
- * @brief Common function to initialize a step direction stepper device at init time.
+ * While the macro is empty for this step dir implementation, other step dir implementations can use
+ * it for things like pinctrl.
  *
- * This function must be called at the end of the device init function.
- *
- * @param dev Step direction stepper device instance.
- *
- * @retval 0 If initialized successfully.
- * @retval -errno Negative errno in case of failure.
+ * @param node_id The devicetree node identifier.
  */
-int step_dir_stepper_common_init(const struct device *dev);
-
-/**
- * @brief Move the stepper motor by a given number of micro_steps.
- *
- * @param dev Pointer to the device structure.
- * @param micro_steps Number of micro_steps to move. Can be positive or negative.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_move_by(const struct device *dev, const int32_t micro_steps);
-
-/**
- * @brief Set the step interval of the stepper motor.
- *
- * @param dev Pointer to the device structure.
- * @param microstep_interval_ns The step interval in nanoseconds.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_set_microstep_interval(const struct device *dev,
-					      const uint64_t microstep_interval_ns);
-
-/**
- * @brief Set the reference position of the stepper motor.
- *
- * @param dev Pointer to the device structure.
- * @param value The reference position value to set.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_set_reference_position(const struct device *dev, const int32_t value);
-
-/**
- * @brief Get the actual (reference) position of the stepper motor.
- *
- * @param dev Pointer to the device structure.
- * @param value Pointer to a variable where the position value will be stored.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_get_actual_position(const struct device *dev, int32_t *value);
-
-/**
- * @brief Set the absolute target position of the stepper motor.
- *
- * @param dev Pointer to the device structure.
- * @param value The target position to set.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_move_to(const struct device *dev, const int32_t value);
-
-/**
- * @brief Check if the stepper motor is still moving.
- *
- * @param dev Pointer to the device structure.
- * @param is_moving Pointer to a boolean where the movement status will be stored.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_is_moving(const struct device *dev, bool *is_moving);
-
-/**
- * @brief Run the stepper with a given direction and step interval.
- *
- * @param dev Pointer to the device structure.
- * @param direction The direction of movement (positive or negative).
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_run(const struct device *dev, const enum stepper_direction direction);
-
-/**
- * @brief Stop the stepper motor.
- *
- * @param dev Pointer to the device structure.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_stop(const struct device *dev);
-
-/**
- * @brief Set a callback function for stepper motor events.
- *
- * This function sets a user-defined callback that will be invoked when a stepper motor event
- * occurs.
- *
- * @param dev Pointer to the device structure.
- * @param callback The callback function to set.
- * @param user_data Pointer to user-defined data that will be passed to the callback.
- * @return 0 on success, or a negative error code on failure.
- */
-int step_dir_stepper_common_set_event_callback(const struct device *dev,
-					       stepper_event_callback_t callback, void *user_data);
-
-/**
- * @brief Handle a timing signal and update the stepper position.
- * @param dev Pointer to the device structure.
- */
-void stepper_handle_timing_signal(const struct device *dev);
-
-/**
- * @brief Trigger callback function for stepper motor events.
- * @param dev Pointer to the device structure.
- * @param event The stepper_event to rigger the callback for.
- */
-void stepper_trigger_callback(const struct device *dev, enum stepper_event event);
+#define STEP_DIR_STEPPER_DT_COMMON_SETUP(node_id)
 
 /** @} */
 

--- a/drivers/stepper/step_dir/step_dir_stepper_counter_timing.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_counter_timing.c
@@ -14,7 +14,7 @@ static void step_counter_top_interrupt(const struct device *dev, void *user_data
 	ARG_UNUSED(dev);
 	struct step_dir_stepper_common_data *data = user_data;
 
-	stepper_handle_timing_signal(data->dev);
+	data->handler(data->dev);
 }
 
 int step_counter_timing_source_update(const struct device *dev,
@@ -93,6 +93,15 @@ bool step_counter_timing_source_is_running(const struct device *dev)
 	return data->counter_running;
 }
 
+int step_counter_timing_register_handler(const struct device *dev, step_dir_step_handler handler)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	data->handler = handler;
+
+	return 0;
+}
+
 int step_counter_timing_source_init(const struct device *dev)
 {
 	const struct step_dir_stepper_common_config *config = dev->config;
@@ -118,4 +127,5 @@ const struct stepper_timing_source_api step_counter_timing_source_api = {
 	.needs_reschedule = step_counter_timing_source_needs_reschedule,
 	.stop = step_counter_timing_source_stop,
 	.is_running = step_counter_timing_source_is_running,
+	.register_step_handler = step_counter_timing_register_handler,
 };

--- a/drivers/stepper/step_dir/step_dir_stepper_timing_source.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_timing_source.h
@@ -9,6 +9,11 @@
 #include <zephyr/device.h>
 
 /**
+ * @brief Step-Dir function to call when time for one step has passed
+ */
+typedef void (*step_dir_step_handler)(const struct device *dev);
+
+/**
  * @brief Initialize the stepper timing source.
  *
  * @param dev Pointer to the device structure.
@@ -60,6 +65,16 @@ typedef int (*stepper_timing_source_stop)(const struct device *dev);
 typedef bool (*stepper_timing_source_is_running)(const struct device *dev);
 
 /**
+ * @brief Registers step-dir function to call when time for one step has passed.
+ *
+ * @param dev Pointer to the device structure.
+ * @param handler Step dir function to call.
+ * @return 0 on success, or a negative error code on failure.
+ */
+typedef int (*stepper_timing_source_register_step_handler)(const struct device *dev,
+							   step_dir_step_handler handler);
+
+/**
  * @brief Stepper timing source API.
  */
 struct stepper_timing_source_api {
@@ -69,6 +84,7 @@ struct stepper_timing_source_api {
 	stepper_timing_sources_requires_reschedule needs_reschedule;
 	stepper_timing_source_stop stop;
 	stepper_timing_source_is_running is_running;
+	stepper_timing_source_register_step_handler register_step_handler;
 };
 
 extern const struct stepper_timing_source_api step_work_timing_source_api;

--- a/drivers/stepper/step_dir/step_dir_stepper_work_timing.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_work_timing.c
@@ -23,7 +23,7 @@ static void stepper_work_step_handler(struct k_work *work)
 	struct step_dir_stepper_common_data *data =
 		CONTAINER_OF(dwork, struct step_dir_stepper_common_data, stepper_dwork);
 
-	stepper_handle_timing_signal(data->dev);
+	data->handler(data->dev);
 }
 
 int step_work_timing_source_init(const struct device *dev)
@@ -69,6 +69,15 @@ bool step_work_timing_source_is_running(const struct device *dev)
 	return k_work_delayable_is_pending(&data->stepper_dwork);
 }
 
+int step_work_timing_register_handler(const struct device *dev, step_dir_step_handler handler)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+
+	data->handler = handler;
+
+	return 0;
+}
+
 const struct stepper_timing_source_api step_work_timing_source_api = {
 	.init = step_work_timing_source_init,
 	.update = step_work_timing_source_update,
@@ -76,4 +85,5 @@ const struct stepper_timing_source_api step_work_timing_source_api = {
 	.needs_reschedule = step_work_timing_source_needs_reschedule,
 	.stop = step_work_timing_source_stop,
 	.is_running = step_work_timing_source_is_running,
+	.register_step_handler = step_work_timing_register_handler,
 };

--- a/dts/bindings/stepper/adi/adi,tmc2209.yaml
+++ b/dts/bindings/stepper/adi/adi,tmc2209.yaml
@@ -13,6 +13,7 @@ description: |
       step-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
       dir-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
       dual-edge-step;
+      step-dir = "common";
   }
 
 compatible: "adi,tmc2209"

--- a/dts/bindings/stepper/allegro/allegro,a4979.yml
+++ b/dts/bindings/stepper/allegro/allegro,a4979.yml
@@ -19,6 +19,7 @@ description: |
       m0-gpios = <&gpiod 13 0>;
       m1-gpios = <&gpiod 12 0>;
       counter = <&counter5>;
+      step-dir = "common";
   };
 
 compatible: "allegro,a4979"

--- a/dts/bindings/stepper/stepper-controller.yaml
+++ b/dts/bindings/stepper/stepper-controller.yaml
@@ -44,3 +44,9 @@ properties:
   counter:
     type: phandle
     description: Counter used for generating step-accurate pulse signals.
+
+  step-dir:
+    type: string
+    description: Identifier of the step-dir implementation used by step-dir drivers.
+    enum:
+      - "common"

--- a/dts/bindings/stepper/ti/ti,drv84xx.yaml
+++ b/dts/bindings/stepper/ti/ti,drv84xx.yaml
@@ -24,6 +24,7 @@ description: |
     m0-gpios = <&mikroe_stepper_gpios 0 0>;
     m1-gpios = <&mikroe_stepper_gpios 1 0>;
     counter = <&counter2>;
+    step-dir = "common";
   };
 
 

--- a/tests/drivers/build_all/stepper/gpio.dtsi
+++ b/tests/drivers/build_all/stepper/gpio.dtsi
@@ -17,6 +17,7 @@ adi_tmc2209: adi_tmc2209 {
 	step-gpios = <&test_gpio 0 0>;
 	dir-gpios = <&test_gpio 0 0>;
 	counter = <&counter0>;
+	step-dir = "common";
 };
 
 allegro_a4979: allegro_a4979 {
@@ -30,6 +31,7 @@ allegro_a4979: allegro_a4979 {
 	m0-gpios = <&test_gpio 0 0>;
 	m1-gpios = <&test_gpio 0 0>;
 	counter = <&counter0>;
+	step-dir = "common";
 };
 
 ti_drv84xx: ti_drv84xx {
@@ -43,6 +45,7 @@ ti_drv84xx: ti_drv84xx {
 	m0-gpios = <&test_gpio 0 0>;
 	m1-gpios = <&test_gpio 0 0>;
 	counter = <&counter0>;
+	step-dir = "common";
 };
 
 zephyr_gpio_stepper: zephyr_gpio_stepper {

--- a/tests/drivers/stepper/drv84xx/api/boards/native_sim.overlay
+++ b/tests/drivers/stepper/drv84xx/api/boards/native_sim.overlay
@@ -23,6 +23,7 @@
 		m0-gpios = <&gpio3 0 0>;
 		m1-gpios = <&gpio3 1 0>;
 		counter = <&counter0>;
+		step-dir = "common";
 
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/tests/drivers/stepper/drv84xx/emul/boards/native_sim.overlay
+++ b/tests/drivers/stepper/drv84xx/emul/boards/native_sim.overlay
@@ -18,6 +18,7 @@
 		m0-gpios = <&gpio3 0 0>;
 		m1-gpios = <&gpio3 1 0>;
 		counter = <&counter0>;
+		step-dir = "common";
 
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_adi_tmc2209.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_adi_tmc2209.overlay
@@ -21,5 +21,6 @@
 		en-gpios = <&gpio2 1 0>;
 		msx-gpios = <&gpio3 0 0>, <&gpio4 1 0>;
 		counter = <&counter0>;
+		step-dir = "common";
 	};
 };

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_adi_tmc2209_work_q.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_adi_tmc2209_work_q.overlay
@@ -20,5 +20,6 @@
 		step-gpios = <&gpio1 1 0>;
 		en-gpios = <&gpio2 1 0>;
 		msx-gpios = <&gpio3 0 0>, <&gpio4 1 0>;
+		step-dir = "common";
 	};
 };

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979.overlay
@@ -23,5 +23,6 @@
 		m0-gpios = <&gpio3 0 0>;
 		m1-gpios = <&gpio3 1 0>;
 		counter = <&counter0>;
+		step-dir = "common";
 	};
 };

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979_work_q.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_allegro_a4979_work_q.overlay
@@ -22,5 +22,6 @@
 		en-gpios = <&gpio2 1 0>;
 		m0-gpios = <&gpio3 0 0>;
 		m1-gpios = <&gpio3 1 0>;
+		step-dir = "common";
 	};
 };

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx.overlay
@@ -23,5 +23,6 @@
 		m0-gpios = <&gpio3 0 0>;
 		m1-gpios = <&gpio3 1 0>;
 		counter = <&counter0>;
+		step-dir = "common";
 	};
 };

--- a/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx_work_q.overlay
+++ b/tests/drivers/stepper/stepper_api/boards/native_sim_ti_drv84xx_work_q.overlay
@@ -22,5 +22,6 @@
 		en-gpios = <&gpio2 1 0>;
 		m0-gpios = <&gpio3 0 0>;
 		m1-gpios = <&gpio3 1 0>;
+		step-dir = "common";
 	};
 };


### PR DESCRIPTION
This PR changes the step-dir implementation, so that it can be replaced by changing the devicetree. This is so that other step-dir implementations, such as #87800 can be used without changing driver code.
This is done by using the same architecture used for allowing the exchange of timing sources.
Both the `stepper_api` and `drv84xx/api` test suites were successfully run.

This PR is NOT intended to stand in competition with #90748 , it is instead intended as a smaller scope interim solution until a larger rework that separates motion-controllers is ready.

The `STEP_DIR_STEPPER_SETUP` macro is not used by the common step-dir implementation, but others, like #87800 need it to, for example, setup pincontrol, so I decided to already include it.

EDIT: This would resolve RFC #87801.