### PR TITLE
dts: stm32: add Arduino Portenta H7 hardware PWM sample via timer

### DIFF
--- a/samples/basic/blinky_pwm/boards/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/samples/basic/blinky_pwm/boards/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timers3 {
+	status = "okay";
+	st,prescaler = <1000>;
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pc6 &tim3_ch2_pc7>;
+		pinctrl-names = "default";
+	};
+};
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led0;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm3 2 PWM_HZ(1000) PWM_POLARITY_NORMAL>;
+        	label = "PWM LED Arduino PIN D4";
+		};
+	};
+};

--- a/samples/basic/servo_motor/boards/arduino_portenta_h7_stm32h747xx_m7.overlay
+++ b/samples/basic/servo_motor/boards/arduino_portenta_h7_stm32h747xx_m7.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Arduino SA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&timers3 {
+	status = "okay";
+	st,prescaler = <100>;
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch1_pc6 &tim3_ch2_pc7>;
+		pinctrl-names = "default";
+	};
+};
+
+/ {
+    /* The sample expects a node labelled "servo" */
+    servo: servo {
+        compatible = "pwm-servo";
+		pwms = <&pwm3 2 PWM_HZ(333) PWM_POLARITY_NORMAL>;
+		label = "PWM Arduino PIN D4";
+        min-pulse = <PWM_USEC(500)>;
+        max-pulse = <PWM_USEC(2500)>;
+    };
+};


### PR DESCRIPTION
This adds sample support for PWM on Arduino Portenta H7 for blinky_pwm and servo_motor

It would've helped me a lot today.

Thank you!
R