### PR TITLE
Bluetooth: BAP: BA: Refactor discover to not do read

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -114,6 +114,14 @@ Bluetooth Host
   this method will be downgraded to unauthenticated when loaded from persistent storage, resulting
   in a lower security level.
 
+Bluetooth Audio
+===============
+
+* :c:func:`bt_bap_broadcast_assistant_discover` will now no longer perform reads of the remote BASS
+  receive states at the end of the procedure. Users will have to manually call
+  :c:func:`bt_bap_broadcast_assistant_read_recv_state` to read the existing receive states, if any,
+  prior to performing any operations. (:github:`91587``)
+
 Networking
 **********
 

--- a/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_broadcast_assistant_test.c
@@ -179,6 +179,7 @@ static void bap_broadcast_assistant_recv_state_cb(
 
 #if defined(CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER)
 	if (state->pa_sync_state == BT_BAP_PA_STATE_INFO_REQ) {
+		printk("Sending PAST %p to %p\n", g_pa_sync, conn);
 		err = bt_le_per_adv_sync_transfer(g_pa_sync, conn,
 						  BT_UUID_BASS_VAL);
 		if (err != 0) {

--- a/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
+++ b/tests/bsim/bluetooth/audio/src/bap_scan_delegator_test.c
@@ -152,11 +152,11 @@ static int pa_sync_past(struct bt_conn *conn,
 	param.skip = PA_SYNC_SKIP;
 	param.timeout = interval_to_sync_timeout(pa_interval);
 
+	printk("Subscribing to PAST from %p\n", conn);
 	err = bt_le_per_adv_sync_transfer_subscribe(conn, &param);
 	if (err != 0) {
 		printk("Could not do PAST subscribe: %d\n", err);
 	} else {
-		printk("Syncing with PAST: %d\n", err);
 		state->pa_syncing = true;
 		k_work_init_delayable(&state->pa_timer, pa_timer_handler);
 		(void)k_work_reschedule(&state->pa_timer,
@@ -237,14 +237,14 @@ static void recv_state_updated_cb(struct bt_conn *conn,
 
 	state = sync_state_get_by_src_id(recv_state->src_id);
 	if (state == NULL) {
-		FAIL("Could not get state");
+		FAIL("Could not get state\n");
 		return;
 	}
 
 	if (state->recv_state != NULL) {
 		if (state->recv_state != recv_state) {
-			FAIL("Sync state receive state mismatch: %p - %p",
-			     state->recv_state, recv_state);
+			FAIL("Sync state receive state mismatch: %p - %p\n", state->recv_state,
+			     recv_state);
 			return;
 		}
 	} else {
@@ -269,12 +269,12 @@ static int pa_sync_req_cb(struct bt_conn *conn,
 	int err;
 
 	reset_cp_flags();
-	printk("PA Sync request: past_avail %u, pa_interval 0x%04x\n: %p",
-	       past_avail, pa_interval, recv_state);
+	printk("PA Sync request: past_avail %u, pa_interval 0x%04x: %p\n", past_avail, pa_interval,
+	       recv_state);
 
 	state = sync_state_get_or_new(recv_state);
 	if (state == NULL) {
-		FAIL("Could not get state");
+		FAIL("Could not get state\n");
 		return -1;
 	}
 
@@ -517,7 +517,7 @@ static bool broadcast_source_found(struct bt_data *data, void *user_data)
 
 	state = sync_state_get_or_new(NULL);
 	if (state == NULL) {
-		FAIL("Failed to get sync state");
+		FAIL("Failed to get sync state\n");
 		return true;
 	}
 
@@ -932,7 +932,7 @@ static void test_main_server_sync_server_rem(void)
 
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, NULL);
 	if (err != 0) {
-		FAIL("Could not start scan (%d)", err);
+		FAIL("Could not start scan (%d)\n", err);
 		return;
 	}
 

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -25,7 +25,7 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \
-  -RealEncryption=1 -rs=69 -D=3 -start_offset=2e3
+  -RealEncryption=1 -rs=69 -D=3 -start_offset=4e3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -25,7 +25,7 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \
-  -RealEncryption=1 -rs=69 -D=3 -start_offset=4e3
+  -RealEncryption=1 -rs=79 -D=3 -start_offset=4e3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \

--- a/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/bap_bass_client_sync.sh
@@ -25,7 +25,7 @@ Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster \
-  -RealEncryption=1 -rs=79 -D=3 -start_offset=4e3
+  -RealEncryption=1 -rs=79 -D=3 -start_offset=6e3
 
 # Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 \


### PR DESCRIPTION
Refactor the bt_bap_broadcast_assistant_discover function to not read receives at the end of discovery.
This makes the function more true to what it is supposed to do, and significantly reduces the complexity of the procedure and the read callback.

Users will be required to, if wanted, to read the
receive state themselves with the existing
bt_bap_broadcast_assistant_read_recv_state.