### PR TITLE
tests: test_mcuboot: update the NXP board platform_allow list

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -18,15 +18,17 @@ tests:
       - frdm_k82f
       - frdm_ke17z
       - frdm_ke17z512
-      - rddrone_fmuk66
-      - twr_ke18f
+      - frdm_mcxa156
+      - frdm_mcxn236
       - frdm_mcxn947/mcxn947/cpu0
-      - mcx_n9xx_evk/mcxn947/cpu0
+      - frdm_mcxw71
+      - frdm_rw612
       - lpcxpresso55s06
       - lpcxpresso55s16
       - lpcxpresso55s28
       - lpcxpresso55s36
       - lpcxpresso55s69/lpc55s69/cpu0
+      - mcx_n9xx_evk/mcxn947/cpu0
       - mimxrt1010_evk
       - mimxrt1015_evk
       - mimxrt1020_evk
@@ -38,13 +40,15 @@ tests:
       - mimxrt1064_evk
       - mimxrt1160_evk/mimxrt1166/cm7
       - mimxrt1170_evk/mimxrt1176/cm7
-      - vmu_rt1170/mimxrt1176/cm7
+      - mimxrt1180_evk/mimxrt1189/cm33
       - mimxrt595_evk/mimxrt595s/cm33
       - mimxrt685_evk/mimxrt685s/cm33
+      - rddrone_fmuk66
+      - twr_ke18f
+      - vmu_rt1170/mimxrt1176/cm7
       - nrf52840dk/nrf52840
       - rd_rw612_bga
       - nucleo_wba55cg
-      - frdm_mcxw71
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840


### PR DESCRIPTION
- Adds new tested NXP boards to the test_mcuboot platform_allow list.
- Sorts NXP boards alphabetically.