### PR TITLE
drivers: video: Add index field to video buffer

### DIFF
--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -149,6 +149,8 @@ struct video_buffer {
 	void *driver_data;
 	/** pointer to the start of the buffer. */
 	uint8_t *buffer;
+	/** index of the buffer, optionally set by the application */
+	uint8_t index;
 	/** size of the buffer in bytes. */
 	uint32_t size;
 	/** number of bytes occupied by the valid data in the buffer. */


### PR DESCRIPTION
Introduce an index field to the video buffer structure to help track individual buffers throughout the workflow.

This is particularly useful in scenarios where buffers are managed in a pool, such as in GStreamer. The index allows efficient identification of the currently dequeued buffer without needing to iterate through the entire pool and compare buffer addresses.

To illustrate:

gstreamer keeps a `GstBuffer buffers[2];` pool that corresponds to 2 `struct video_buffer`. With index field, we can enqueue buffers[video_buffer.index] to the driver and when dequeuing, we know exactly which GstBuffer in the pool is dequeued.