### PR TITLE
samples: net: socketpair: ensure integration platform is on allow list

### DIFF
--- a/samples/net/sockets/socketpair/sample.yaml
+++ b/samples/net/sockets/socketpair/sample.yaml
@@ -8,10 +8,10 @@ common:
     - posix
   harness: net
   arch_exclude: posix
-  integration_platforms:
-    - qemu_x86
 tests:
   sample.net.sockets.socketpair:
+    integration_platforms:
+      - qemu_x86
     platform_exclude: s32k148_evb/s32k148
   sample.net.sockets.socketpair.s32k148_evb:
     extra_args: SHIELD=nxp_adtja1101


### PR DESCRIPTION
Ensure that qemu_x86 (the integration platform) is on the allow list for `sample.net.sockets.socketpair.s32k148_evb`.

```
INFO: Error found: sample.net.sockets.socketpair.s32k148_evb on
qemu_x86/atom (Not in testsuite platform allow list but is one of the
integration platforms)
```

https://github.com/zephyrproject-rtos/zephyr/actions/runs/15646760002/job/44085509728?pr=91121

The issue was introduced in 49091ff10b8601db64eae42298f8b8dfe431f6b1.