### PR TITLE
scripts: ci: check_compliance: allow CONFIG_BOARD_UNIT_TESTING

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1026,6 +1026,7 @@ flagged.
         "BOARD_MPS2_AN521_CPUTEST", # Used for board and SoC extension feature tests
         "BOARD_NATIVE_SIM_NATIVE_64_TWO", # Used for board and SoC extension feature tests
         "BOARD_NATIVE_SIM_NATIVE_ONE", # Used for board and SoC extension feature tests
+        "BOARD_UNIT_TESTING",  # Used for tests/unit
         "BOOT_DIRECT_XIP", # Used in sysbuild for MCUboot configuration
         "BOOT_DIRECT_XIP_REVERT", # Used in sysbuild for MCUboot configuration
         "BOOT_ENCRYPTION_KEY_FILE", # Used in sysbuild


### PR DESCRIPTION
Previously, code like the snippet below would not pass compliance checks. With this change, we add `CONFIG_BOARD_UNIT_TESTING` to the Kconfig allow list, so that it is not incorrectly reported as a compliance failure.

```cpp
#if defined(CONFIG_BOARD_UNIT_TESTING)
/* unit-testing only */
#endif
```