### PR TITLE
tests: drivers: can: Add st,stm-bxcan tests

### DIFF
--- a/tests/drivers/can/api/Kconfig
+++ b/tests/drivers/can/api/Kconfig
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "CAN Api test"
+
+source "Kconfig.zephyr"
+
+config CAN_TEST_MODE_LOOPBACK
+    bool "Use Loopback mode for test"
+    default y
+    help
+      Set the CAN controller into loopback mode to run the test
+
+config CAN_TEST_MODE_LISTENONLY
+   bool "Use Listenonly mode for test"
+   default n
+   help
+     Set the CAN controller into listenonly mode to run the test

--- a/tests/drivers/can/api/src/canfd.c
+++ b/tests/drivers/can/api/src/canfd.c
@@ -559,7 +559,7 @@ static bool canfd_predicate(const void *state)
 
 void *canfd_setup(void)
 {
-	can_common_test_setup(CAN_MODE_LOOPBACK | CAN_MODE_FD);
+	can_common_test_setup(TEST_CAN_INIT_MODE | CAN_MODE_FD);
 
 	return NULL;
 }

--- a/tests/drivers/can/api/src/classic.c
+++ b/tests/drivers/can/api/src/classic.c
@@ -1418,7 +1418,7 @@ ZTEST_USER(can_classic, test_set_mode_while_started)
 
 void *can_classic_setup(void)
 {
-	can_common_test_setup(CAN_MODE_LOOPBACK);
+	can_common_test_setup(TEST_CAN_INIT_MODE);
 
 	return NULL;
 }

--- a/tests/drivers/can/api/src/common.h
+++ b/tests/drivers/can/api/src/common.h
@@ -165,6 +165,21 @@ void assert_frame_equal(const struct can_frame *frame1,
 			uint32_t id_mask);
 
 /**
+ * Initial can mode.
+ */
+#if CONFIG_CAN_TEST_MODE_LOOPBACK
+#define TEST_CAN_INIT_MODE_LOOPBACK CAN_MODE_LOOPBACK
+#else
+#define TEST_CAN_INIT_MODE_LOOPBACK 0
+#endif // CONFIG_CAN_TEST_MODE_LOOPBACK
+#if CONFIG_CAN_TEST_MODE_LISTENONLY
+#define TEST_CAN_INIT_MODE_LISTENONLY CAN_MODE_LISTENONLY
+#else
+#define TEST_CAN_INIT_MODE_LISTENONLY 0
+#endif // CONFIG_CAN_TEST_MODE_LISTENONLY
+#define TEST_CAN_INIT_MODE (TEST_CAN_INIT_MODE_LOOPBACK | TEST_CAN_INIT_MODE_LISTENONLY)
+
+/**
  * @brief Common setup function for the CAN controller device under test.
  *
  * @param initial_mode Initial CAN controller operational mode.

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -21,3 +21,9 @@ tests:
     extra_configs:
       - CONFIG_CAN_NXP_S32_RX_FIFO=n
     filter: dt_compat_enabled("nxp,s32-canxl")
+  drivers.can.api.bxcan:
+    extra_configs:
+      - CONFIG_TEST_USERSPACE=y
+      - CONFIG_CAN_FD_MODE=n
+      - CONFIG_CAN_TEST_MODE_LISTENONLY=y
+    filter: dt_compat_enabled("st,stm32-bxcan")


### PR DESCRIPTION
Add can api tests for all devices that have a `st,stm-bxcan` can controller