### PR TITLE
drivers: hwinfo: esp32: fix reset cause handling for ESP_RST_PANIC

### DIFF
--- a/drivers/hwinfo/hwinfo_esp32.c
+++ b/drivers/hwinfo/hwinfo_esp32.c
@@ -85,6 +85,7 @@ int z_impl_hwinfo_get_reset_cause(uint32_t *cause)
 		break;
 	case ESP_RST_PANIC:
 		*cause = RESET_CPU_LOCKUP;
+		break;
 	case ESP_RST_BROWNOUT:
 		*cause = RESET_BROWNOUT;
 		break;


### PR DESCRIPTION
Added a missing break statement for the ESP_RST_PANIC case.