### PR TITLE
drivers: w1: shell: fix write_bit function as well as off-by-one error

### DIFF
--- a/drivers/w1/w1_shell.c
+++ b/drivers/w1/w1_shell.c
@@ -317,7 +317,7 @@ static int cmd_w1_configure(const struct shell *sh, size_t argc, char **argv)
 		}
 	}
 
-	if (type > W1_SETINGS_TYPE_COUNT) {
+	if (type >= W1_SETINGS_TYPE_COUNT) {
 		shell_error(sh, "invalid type %u", type);
 		return -EINVAL;
 	}

--- a/drivers/w1/w1_shell.c
+++ b/drivers/w1/w1_shell.c
@@ -176,7 +176,7 @@ static int cmd_w1_write_bit(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	(void)w1_lock_bus(dev);
-	ret = w1_write_byte(dev, (bool)input);
+	ret = w1_write_bit(dev, (bool)input);
 	if (ret < 0) {
 		shell_error(sh, "Failed to write bit [%d]", ret);
 	}


### PR DESCRIPTION
Two small trivial fixes, see commits