### PR TITLE
drivers: i3c: cdns: fix bitwise operation in CONF_STATUS0_DEV_ROLE macro

### DIFF
--- a/drivers/i3c/i3c_cdns.c
+++ b/drivers/i3c/i3c_cdns.c
@@ -34,7 +34,7 @@
 #define CONF_STATUS0_SUPPORTS_DDR         BIT(5)
 #define CONF_STATUS0_SEC_MASTER           BIT(4)
 /* And it was replaced with a Dev Role mask */
-#define CONF_STATUS0_DEV_ROLE(x)          ((x) & GENMASK(5, 4) >> 4)
+#define CONF_STATUS0_DEV_ROLE(x)          (((x) & GENMASK(5, 4)) >> 4)
 #define CONF_STATUS0_DEV_ROLE_MAIN_MASTER 0
 #define CONF_STATUS0_DEV_ROLE_SEC_MASTER  1
 #define CONF_STATUS0_DEV_ROLE_SLAVE       2


### PR DESCRIPTION
Updated the CONF_STATUS0_DEV_ROLE macro to ensure proper bitwise operation by adding parentheses around the bitmask operation.

@XenuIsWatching Also, it looks like `CONF_STATUS0_IBIR_DEPTH` maybe have a typo as well? Shouldn't it be `#define CONF_STATUS0_IBIR_DEPTH(x)        (4 << (((x) & GENMASK(7, 6)) >> 6))`
Looks like it's copy pasted from Linux but I dunno.