### PR TITLE
drivers: sensor: tdk: fix double tap trigger handler

### DIFF
--- a/drivers/sensor/tdk/icm42605/icm42605.c
+++ b/drivers/sensor/tdk/icm42605/icm42605.c
@@ -150,7 +150,7 @@ int icm42605_tap_fetch(const struct device *dev)
 					if (drv_data->double_tap_handler) {
 						LOG_DBG("Double Tap detected");
 						drv_data->double_tap_handler(dev
-						     , drv_data->tap_trigger);
+						     , drv_data->double_tap_trigger);
 					}
 				} else {
 					LOG_ERR("Trigger type is mismatched");


### PR DESCRIPTION
Ensure that the appropriate trigger is passed when a double tap is detected.