### PR TITLE
drivers: haptics: Trivial fixes

### DIFF
--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -16,7 +16,6 @@
 #include <zephyr/drivers/haptics/drv2605.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/drivers/haptics.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/util.h>

--- a/drivers/haptics/haptics_handlers.c
+++ b/drivers/haptics/haptics_handlers.c
@@ -20,7 +20,7 @@ static inline int z_vrfy_haptics_stop_output(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_HAPTICS(dev, stop_output));
 
-	z_impl_haptics_stop_output(dev);
+	return z_impl_haptics_stop_output(dev);
 }
 
 #include <syscalls/haptics_stop_output_mrsh.c>


### PR DESCRIPTION
- Actually propagate the return value of haptics_stop_output in syscall handler
- Fix duplicate include