### PR TITLE
drivers: sensor: icm42605: fix turn_off_sensor logic

### DIFF
--- a/drivers/sensor/tdk/icm42605/icm42605_setup.c
+++ b/drivers/sensor/tdk/icm42605/icm42605_setup.c
@@ -431,8 +431,8 @@ int icm42605_turn_off_sensor(const struct device *dev)
 
 	result = inv_spi_read(&cfg->spi, REG_PWR_MGMT0, &v, 1);
 
-	v ^= BIT_ACCEL_MODE_LNM;
-	v ^= BIT_GYRO_MODE_LNM;
+	v &= ~BIT_ACCEL_MODE_LNM;
+	v &= ~BIT_GYRO_MODE_LNM;
 
 	result = inv_spi_single_write(&cfg->spi, REG_PWR_MGMT0, &v);
 	if (result) {


### PR DESCRIPTION
While it would likely not directly cause issues with the current implementation, the logic of turning off the sensor should be to actually reset the flags, not to toggle them.