### PR TITLE
drivers: sensor: tdk: remove duplicate entries in ICM42X70_CONFIG_COMMON

### DIFF
--- a/drivers/sensor/tdk/icm42x70/icm42x70.c
+++ b/drivers/sensor/tdk/icm42x70/icm42x70.c
@@ -974,8 +974,6 @@ static DEVICE_API(sensor, icm42x70_driver_api) = {
 				    .accel_filt_bw = DT_INST_ENUM_IDX(inst, accel_filt_bw_hz),     \
 				    .accel_pwr_mode = DT_INST_ENUM_IDX(inst, power_mode),          \
 				    .apex = DT_INST_ENUM_IDX(inst, apex),                          \
-				    .accel_pwr_mode = DT_INST_ENUM_IDX(inst, power_mode),          \
-				    .apex = DT_INST_ENUM_IDX(inst, apex),                          \
 		 IF_ENABLED(CONFIG_USE_EMD_ICM42670,                                       \
 				(.gyro_fs = DT_INST_ENUM_IDX(inst, gyro_fs),))                     \
 		 IF_ENABLED(CONFIG_USE_EMD_ICM42670,                                       \


### PR DESCRIPTION
Eliminate redundant entries for `accel_pwr_mode` and `apex`.