### PR TITLE
drivers: serial: ra8_sci_b: fix overrun error flag clearing

### DIFF
--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -386,7 +386,7 @@ static int uart_ra_sci_b_fifo_read(const struct device *dev, uint8_t *rx_data, c
 	}
 
 	/* Clear overrun error flag */
-	cfg->regs->CFCLR_b.ORERC = 0U;
+	cfg->regs->CFCLR_b.ORERC = 1U;
 
 	return num_rx;
 }


### PR DESCRIPTION
Overrun error flag clearing happens by writing 1 to the ORERC register, not 0.

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/220bab7b-876b-4f84-9afc-93374a04b355" />
