### PR TITLE
input: input_hid: add missing const qualifier

### DIFF
--- a/subsys/input/input_hid.c
+++ b/subsys/input/input_hid.c
@@ -9,7 +9,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/usb/class/hid.h>
 
-static uint8_t input_to_hid_map[] = {
+static const uint8_t input_to_hid_map[] = {
 	[INPUT_KEY_A] = HID_KEY_A,
 	[INPUT_KEY_B] = HID_KEY_B,
 	[INPUT_KEY_C] = HID_KEY_C,

--- a/subsys/input/input_utils.c
+++ b/subsys/input/input_utils.c
@@ -247,7 +247,7 @@ static int input_cmd_kbd_matrix_state_dump(const struct shell *sh,
 	}
 
 	memset(kbd_matrix_state, 0, sizeof(kbd_matrix_state));
-	memset(kbd_matrix_key_mask, 0, sizeof(kbd_matrix_state));
+	memset(kbd_matrix_key_mask, 0, sizeof(kbd_matrix_key_mask));
 	kbd_matrix_state_dev = dev;
 
 	shell_info(sh, "Keyboard state logging enabled for %s", dev->name);


### PR DESCRIPTION
HID lookup table can live in Flash and save some RAM (quite a bit actually, as it's quite large!).