### PR TITLE
include: zephyr: xen: fix missing header declarations

### DIFF
--- a/include/zephyr/xen/dom0/domctl.h
+++ b/include/zephyr/xen/dom0/domctl.h
@@ -19,6 +19,7 @@ int xen_domctl_resumedomain(int domid);
 int xen_domctl_getvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
 int xen_domctl_setvcpucontext(int domid, int vcpu, vcpu_guest_context_t *ctxt);
 int xen_domctl_getdomaininfo(int domid, xen_domctl_getdomaininfo_t *dom_info);
+int xen_domctl_get_paging_mempool_size(int domid, uint64_t *size_mb);
 int xen_domctl_set_paging_mempool_size(int domid, uint64_t size_mb);
 int xen_domctl_max_mem(int domid, uint64_t max_memkb);
 int xen_domctl_set_address_size(int domid, int addr_size);

--- a/include/zephyr/xen/events.h
+++ b/include/zephyr/xen/events.h
@@ -78,6 +78,8 @@ int bind_event_channel(evtchn_port_t port, evtchn_cb_t cb, void *data);
  */
 int unbind_event_channel(evtchn_port_t port);
 int get_missed_events(evtchn_port_t port);
+int mask_event_channel(evtchn_port_t port);
+int unmask_event_channel(evtchn_port_t port);
 
 int xen_events_init(void);
 


### PR DESCRIPTION
Adds declarations for functions that have implementations but no header declarations.