### PR TITLE
net: lib: coap: fix bug and increase test coverage

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -136,7 +136,7 @@ static inline bool insert_be16(struct coap_packet *cpkt, uint16_t data, size_t o
 
 	memmove(&cpkt->data[offset + 2], &cpkt->data[offset], cpkt->offset - offset);
 
-	encode_be16(cpkt, cpkt->offset, data);
+	encode_be16(cpkt, offset, data);
 
 	return true;
 }

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -1652,6 +1652,36 @@ ZTEST(coap, test_coap_packet_options_with_large_values)
 	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 9, expected_0, 18, 60);
 }
 
+ZTEST(coap, test_coap_packet_options_with_large_delta)
+{
+	int r;
+	struct coap_packet cpkt;
+	uint8_t *data = data_buf[0];
+	static const char token[] = "token";
+	static const uint8_t payload[] = {0xde, 0xad, 0xbe, 0xef};
+
+	memset(data_buf[0], 0, ARRAY_SIZE(data_buf[0]));
+
+	r = coap_packet_init(&cpkt, data, COAP_BUF_SIZE, COAP_VERSION_1, COAP_TYPE_CON,
+			     strlen(token), token, COAP_METHOD_POST, 0x1234);
+	zassert_equal(r, 0, "Could not initialize packet");
+
+	r = coap_append_option_int(&cpkt, 65100, 0x5678);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_packet_append_payload_marker(&cpkt);
+	zassert_equal(r, 0, "Could not append payload marker");
+
+	r = coap_packet_append_payload(&cpkt, payload, ARRAY_SIZE(payload));
+	zassert_equal(r, 0, "Could not append payload");
+
+	static const uint8_t expected_0[] = {0x45, 0x02, 0x12, 0x34, 0x74, 0x6f, 0x6b,
+					     0x65, 0x6e, 0xe2, 0xfd, 0x3f, 0x56, 0x78,
+					     0xff, 0xde, 0xad, 0xbe, 0xef};
+
+	ASSERT_OPTIONS_AND_PAYLOAD(cpkt, 5, expected_0, 19, 65100);
+}
+
 static void assert_coap_packet_set_path_query_options(const char *path,
 						      const char * const *expected,
 						      size_t expected_len, uint16_t code)


### PR DESCRIPTION
Add a couple tests to increase coverage and fix a bug (likely copy-paste issue) in insert_be16 which, while hard to reproduce in real-world condition, could occur when dealing with options with large numbers/deltas being added out-of-order.