### PR TITLE
modules: hal_nordic: nrf_802154: Increase default number of RX buffers

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -183,7 +183,7 @@ config NRF_802154_CCA_CORR_LIMIT
 
 config NRF_802154_RX_BUFFERS
 	int "nRF 802.15.4 receive buffers"
-	default 16
+	default 20
 	help
 	  Number of buffers in nRF 802.15.4 driver serialization host's receive queue.
 	  If this value is modified, its remote counterpart must be set to the exact same value.


### PR DESCRIPTION
This commit increases the default number of RX buffers to ensure headroom for full IPv6 MTU.