### PR TITLE
kernel: add `k_heap_array_get`

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -132,6 +132,7 @@ New APIs and options
  * :c:func:`timespec_normalize`
  * :c:func:`timespec_from_timeout`
  * :c:func:`timespec_to_timeout`
+ * :c:func:`k_heap_array_get`
 
 * I2C
 

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5854,6 +5854,17 @@ void k_heap_free(struct k_heap *h, void *mem) __attribute_nonnull(1);
 #define K_HEAP_DEFINE_NOCACHE(name, bytes)			\
 	Z_HEAP_DEFINE_IN_SECT(name, bytes, __nocache)
 
+/** @brief Get the array of statically defined heaps
+ *
+ * Returns the pointer to the start of the static heap array.
+ * Static heaps are those declared through one of the `K_HEAP_DEFINE`
+ * macros.
+ *
+ * @param heap Pointer to location where heap array address is written
+ * @return Number of static heaps
+ */
+int k_heap_array_get(struct k_heap **heap);
+
 /**
  * @}
  */

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -12,6 +12,17 @@
 #include <ksched.h>
 #include <wait_q.h>
 
+int k_heap_array_get(struct k_heap **heap)
+{
+	int num;
+
+	/* Pointer to the start of the heap array */
+	STRUCT_SECTION_GET(k_heap, 0, heap);
+	/* Number of statically defined heaps */
+	STRUCT_SECTION_COUNT(k_heap, &num);
+	return num;
+}
+
 void k_heap_init(struct k_heap *heap, void *mem, size_t bytes)
 {
 	z_waitq_init(&heap->wait_q);

--- a/samples/basic/sys_heap/README.rst
+++ b/samples/basic/sys_heap/README.rst
@@ -33,9 +33,14 @@ Sample Output
 
 .. code-block:: console
 
-    System heap sample
+   System heap sample
 
-    allocated 0, free 196, max allocated 0, heap size 256
-    allocated 156, free 36, max allocated 156, heap size 256
-    allocated 100, free 92, max allocated 156, heap size 256
-    allocated 0, free 196, max allocated 156, heap size 256
+   allocated 0, free 196, max allocated 0, heap size 256
+   allocated 156, free 36, max allocated 156, heap size 256
+   allocated 100, free 92, max allocated 156, heap size 256
+   allocated 0, free 196, max allocated 156, heap size 256
+   1 static heap(s) allocated:
+         0 - address 0x80552a8 allocated 12, free 180, max allocated 12, heap size 256
+   2 heap(s) allocated (including static):
+         0 - address 0x80552a8 allocated 12, free 180, max allocated 12, heap size 256
+         1 - address 0x805530c allocated 0, free 196, max allocated 156, heap size 256

--- a/samples/basic/sys_heap/src/main.c
+++ b/samples/basic/sys_heap/src/main.c
@@ -15,6 +15,7 @@ static char heap_mem[HEAP_SIZE];
 static struct sys_heap heap;
 
 static void print_sys_memory_stats(struct sys_heap *);
+static void print_static_heaps(void);
 static void print_all_heaps(void);
 
 int main(void)
@@ -35,7 +36,17 @@ int main(void)
 	sys_heap_free(&heap, p);
 	print_sys_memory_stats(&heap);
 
+	/* Allocate from our custom k_heap to make the output
+	 * more interesting and prevent compiler optimisations from
+	 * discarding it.
+	 */
+	p = k_heap_alloc(&my_kernel_heap, 10, K_FOREVER);
+
+	print_static_heaps();
 	print_all_heaps();
+
+	/* Cleanup memory */
+	k_heap_free(&my_kernel_heap, p);
 	return 0;
 }
 
@@ -50,16 +61,30 @@ static void print_sys_memory_stats(struct sys_heap *hp)
 		stats.max_allocated_bytes, HEAP_SIZE);
 }
 
+static void print_static_heaps(void)
+{
+	struct k_heap *ha;
+	int n;
+
+	n = k_heap_array_get(&ha);
+	printk("%d static heap(s) allocated:\n", n);
+
+	for (int i = 0; i < n; i++) {
+		printk("\t%d - address %p ", i, &ha[i]);
+		print_sys_memory_stats(&ha[i].heap);
+	}
+}
+
 static void print_all_heaps(void)
 {
 	struct sys_heap **ha;
-	size_t i, n;
+	int n;
 
 	n = sys_heap_array_get(&ha);
-	printk("There are %zu heaps allocated:\n", n);
+	printk("%d heap(s) allocated (including static):\n", n);
 
-	for (i = 0; i < n; i++) {
-		printk("\t%zu - address %p ", i, ha[i]);
+	for (int i = 0; i < n; i++) {
+		printk("\t%d - address %p ", i, ha[i]);
 		print_sys_memory_stats(ha[i]);
 	}
 }

--- a/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
+++ b/tests/kernel/mem_heap/k_heap_api/src/test_kheap_api.c
@@ -291,3 +291,31 @@ ZTEST(k_heap_api, test_k_heap_calloc)
 
 	k_heap_free(&k_heap_test, p);
 }
+
+/**
+ * @brief Test to demonstrate k_heap_array_get()
+ *
+ * @ingroup kernel_kheap_api_tests
+ *
+ * @details The test ensures that valid values are returned
+ *
+ * @see k_heap_array_get()
+ */
+ZTEST(k_heap_api, test_k_heap_array_get)
+{
+	struct k_heap *ha = NULL;
+	bool test_heap_found = false;
+	int n;
+
+	n = k_heap_array_get(&ha);
+	zassert_not_equal(0, n, "No heaps returned");
+	zassert_not_null(ha, "Heap array pointer not populated");
+
+	/* Ensure that k_heap_test exists in the array */
+	for (int i = 0; i < n; i++) {
+		if (&k_heap_test == &ha[i]) {
+			test_heap_found = true;
+		}
+	}
+	zassert_true(test_heap_found);
+}


### PR DESCRIPTION
Add `k_heap_array_get` as an alternative to `sys_heap_array_get`, which only returns statically defined heaps (those defined with
`K_HEAP_DEFINE` or `K_HEAP_DEFINE_NOCACHE`), but doesn't depend on the application guessing a value for `CONFIG_SYS_HEAP_ARRAY_SIZE`.