### PR TITLE
drivers: adc_nrfx_saadc: Remove dead and misleading code

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -130,12 +130,8 @@ static struct driver_data m_data = {
 };
 
 /* Helper function to convert number of samples to the byte representation. */
-static uint32_t samples_to_bytes(const struct adc_sequence *sequence, uint16_t number_of_samples)
+static uint32_t samples_to_bytes(uint16_t number_of_samples)
 {
-	if (NRF_SAADC_8BIT_SAMPLE_WIDTH == 8 && sequence->resolution == 8) {
-		return number_of_samples;
-	}
-
 	return number_of_samples * 2;
 }
 
@@ -399,11 +395,11 @@ static void adc_context_update_buffer_pointer(struct adc_context *ctx,
 	if (!repeat) {
 #if defined(ADC_BUFFER_IN_RAM)
 		m_data.user_buffer = (uint8_t *)m_data.user_buffer +
-			samples_to_bytes(&ctx->sequence, nrfy_saadc_amount_get(NRF_SAADC));
+			samples_to_bytes(nrfy_saadc_amount_get(NRF_SAADC));
 #else
 		nrf_saadc_value_t *buffer =
 			(uint8_t *)nrf_saadc_buffer_pointer_get(NRF_SAADC) +
-			samples_to_bytes(&ctx->sequence, nrfy_saadc_amount_get(NRF_SAADC));
+			samples_to_bytes(nrfy_saadc_amount_get(NRF_SAADC));
 		nrfy_saadc_buffer_pointer_set(NRF_SAADC, buffer);
 #endif
 	}
@@ -490,7 +486,7 @@ static int check_buffer_size(const struct adc_sequence *sequence,
 {
 	size_t needed_buffer_size;
 
-	needed_buffer_size = samples_to_bytes(sequence, active_channels);
+	needed_buffer_size = samples_to_bytes(active_channels);
 
 	if (sequence->options) {
 		needed_buffer_size *= (1 + sequence->options->extra_samplings);
@@ -535,7 +531,6 @@ static int start_read(const struct device *dev,
 {
 	int error;
 	uint32_t selected_channels = sequence->channels;
-	uint8_t resolution = sequence->resolution;
 	uint8_t active_channels;
 	uint8_t channel_id;
 	nrf_saadc_burst_t burst;
@@ -563,22 +558,6 @@ static int start_read(const struct device *dev,
 			if (m_data.positive_inputs[channel_id] == 0U) {
 				LOG_ERR("Channel %u not configured",
 					    channel_id);
-				return -EINVAL;
-			}
-			/* Signal an error if the channel is configured as
-			 * single ended with a resolution which is identical
-			 * to the sample bit size. The SAADC's "single ended"
-			 * mode is really differential mode with the
-			 * negative input tied to ground. We can therefore
-			 * observe negative values if the positive input falls
-			 * below ground. If the sample bitsize is larger than
-			 * the resolution, we can detect negative values and
-			 * correct them to 0 after the sequencen has ended.
-			 */
-			if ((m_data.single_ended_channels & BIT(channel_id)) &&
-			    (NRF_SAADC_8BIT_SAMPLE_WIDTH == 8 && resolution == 8)) {
-				LOG_ERR("Channel %u invalid single ended resolution",
-					channel_id);
 				return -EINVAL;
 			}
 			/* When oversampling is used, the burst mode needs to
@@ -702,7 +681,7 @@ static void saadc_irq_handler(const struct device *dev)
 
 #if defined(ADC_BUFFER_IN_RAM)
 		memcpy(m_data.user_buffer, m_data.samples_buffer,
-			samples_to_bytes(&m_data.ctx.sequence, m_data.active_channels));
+			samples_to_bytes(m_data.active_channels));
 #endif
 
 		adc_context_on_sampling_done(&m_data.ctx, dev);


### PR DESCRIPTION
For a long time (since version 3.3.0) nrfx contained an incorrectly defined symbol NRF_SAADC_8BIT_SAMPLE_WIDTH that was set to 8 for nRF54L and nRF54H Series SoCs, which was probably only true for very early engineering revisions of those. Based on this, the adc_nrfx_saadc driver was incorrectly writing consecutive 8-bit samples in supplied buffers, cutting off the highest 8 bits of the results. And for sequences with multiple channels, it was even causing that the results written as 16-bit words by hardware were partially overwritten in next iteration.

In nrfx 3.12.0 (see commit f46798fa55881e6e24bb121d867c7753d4c6b775) this was finally corrected - the symbol is now deprecated and it is always set to 16. This commit is a follow-up to the above and removes parts of adc_nrfx_saadc that now became dead code to prevent further confusion regarding 8-bit sampling.