### PR TITLE
samples: drivers: adc_sequence: Remove misleading parts of nRF overlays

### DIFF
--- a/samples/drivers/adc/adc_sequence/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf52840dk_nrf52840.overlay
@@ -28,6 +28,5 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_VDD>;
-		zephyr,oversampling = <8>;
 	};
 };

--- a/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -10,12 +10,6 @@
 	};
 };
 
-/ {
-	zephyr,user {
-		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
-	};
-};
-
 &adc {
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -26,7 +20,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN1>; /* P1.01 */
-		zephyr,resolution = <10>;
 	};
 
 	channel@1 {
@@ -35,8 +28,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.02 */
-		zephyr,resolution = <12>;
-		zephyr,oversampling = <8>;
 	};
 
 	channel@2 {
@@ -46,8 +37,6 @@
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN9>; /* P9.01 */
 		zephyr,vref-mv = <3686>; /* 3.6V * 1024 */
-		zephyr,resolution = <12>;
-		zephyr,oversampling = <8>;
 	};
 
 	channel@7 {
@@ -57,6 +46,5 @@
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN3>; /* P1.03 */
 		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P1.07 */
-		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/adc_sequence/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -5,12 +5,6 @@
  */
 
 / {
-	zephyr,user {
-		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 7>;
-	};
-};
-
-/ {
 	aliases {
 		adc0 = &adc;
 	};
@@ -26,7 +20,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN4>; /* P1.11 */
-		zephyr,resolution = <10>;
 	};
 
 	channel@1 {
@@ -35,8 +28,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN2>; /* P1.06 */
-		zephyr,resolution = <12>;
-		zephyr,oversampling = <8>;
 	};
 
 	channel@2 {
@@ -45,8 +36,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_DVDD>; /* 0.9 V internal */
-		zephyr,resolution = <12>;
-		zephyr,oversampling = <8>;
 	};
 
 	channel@7 {
@@ -56,6 +45,5 @@
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P1.13 */
 		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P1.14 */
-		zephyr,resolution = <12>;
 	};
 };


### PR DESCRIPTION
Remove parts of overlays for nRF targets that were just copied from the adc_dt sample but are not used by the adc_sequence sample and only generate confusion here.