### PR TITLE
STM32U3: add UART DMA test

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -14,6 +14,7 @@ supported:
   - gpio
   - i2c
   - spi
+  - uart
   - usart
 ram: 256
 flash: 1024

--- a/tests/drivers/uart/uart_async_api/boards/nucleo_u385rg_q.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_u385rg_q.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &lpuart1 {
+	dmas = <&gpdma1 0 35 STM32_DMA_PERIPH_TX
+		&gpdma1 1 34 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&gpdma1 {
+	status = "okay";
+};


### PR DESCRIPTION
Add an overlay for tests/drivers/uart/uart_async_api/ for these two boards to test UART with DMA.