### PR TITLE
[DNM] adsp: add configuration to adsp virtual regions

### DIFF
--- a/drivers/mm/Kconfig
+++ b/drivers/mm/Kconfig
@@ -44,6 +44,48 @@ config MM_DRV_INTEL_ADSP_TLB
 	  Driver for the translation lookup buffer on
 	  Intel Audio DSP hardware.
 
+config MM_DRV_INTEL_ADSP_TLB_USE_PER_CORE_VIRTUAL_MEMORY_REGIONS
+	bool "Support for per core virtual memory regions"
+	depends on MM_DRV_INTEL_ADSP_MTL_TLB
+	default y
+	help
+	  This config enables per-core virtual memory regions
+
+config MM_DRV_INTEL_ADSP_TLB_PER_CORE_VIRTUAL_MEMORY_REGIONS_SIZE
+	hex "Size in bytes of virtual memory regions per core"
+	depends on MM_DRV_INTEL_ADSP_TLB_USE_PER_CORE_VIRTUAL_MEMORY_REGIONS
+	default 0x100000
+	help
+	  This config defines size of per-core virtual memory regions
+
+config MM_DRV_INTEL_ADSP_TLB_USE_VIRTUAL_MEMORY_SHARED_REGION
+	bool "Support for virtual memory region shared between all cores"
+	depends on MM_DRV_INTEL_ADSP_MTL_TLB
+	default y
+	help
+	  This config enables shared between all cores virtual memory region
+
+config MM_DRV_INTEL_ADSP_TLB_VIRTUAL_MEMORY_SHARED_REGION_SIZE
+	hex "Size in bytes of virtual memory region shared between all cores"
+	depends on MM_DRV_INTEL_ADSP_TLB_USE_VIRTUAL_MEMORY_SHARED_REGION
+	default 0x100000
+	help
+	  This config defines size of virtual memory region shared between all cores
+
+config MM_DRV_INTEL_ADSP_TLB_USE_VIRTUAL_MEMORY_OPPORTUNISTIC_REGION
+	bool "Support for opportunistic virtual memory region"
+	depends on MM_DRV_INTEL_ADSP_MTL_TLB
+	default y
+	help
+	  This config enables opportunistic virtual memory region
+
+config MM_DRV_INTEL_ADSP_TLB_VIRTUAL_MEMORY_OPPORTUNISTIC_REGION_SIZE
+	hex "Size in bytes of opportunistic virtual memory region"
+	depends on MM_DRV_INTEL_ADSP_TLB_USE_VIRTUAL_MEMORY_OPPORTUNISTIC_REGION
+	default 0x100000
+	help
+	  This config defines size of opportunistic virtual memory region
+
 config EXTERNAL_ADDRESS_TRANSLATION
 	bool "Support for external address translation modules"
 	depends on !MMU

--- a/soc/intel/intel_adsp/ace/include/adsp_memory_regions.h
+++ b/soc/intel/intel_adsp/ace/include/adsp_memory_regions.h
@@ -6,22 +6,38 @@
 #ifndef ZEPHYR_SOC_INTEL_ADSP_MEMORY_REGIONS_H_
 #define ZEPHYR_SOC_INTEL_ADSP_MEMORY_REGIONS_H_
 
-/* Define amount of regions other than core heaps that virtual memory will be split to
- * currently includes shared heap and oma region and one regions set to 0 as for table
- * iterator end value.
- */
-#define VIRTUAL_REGION_COUNT 3
-
-#define CORE_HEAP_SIZE 0x100000
-#define SHARED_HEAP_SIZE 0x100000
-#define OPPORTUNISTIC_REGION_SIZE 0x100000
-
 /* size of TLB table */
 #define TLB_SIZE DT_REG_SIZE_BY_IDX(DT_INST(0, intel_adsp_mtl_tlb), 0)
 
 /* Attribiutes for memory regions */
+#if CONFIG_MM_DRV_INTEL_ADSP_TLB_USE_PER_CORE_VIRTUAL_MEMORY_REGIONS
+#define VIRTUAL_REGION_COUNT_PER_CORE CONFIG_MP_MAX_NUM_CPUS
 #define MEM_REG_ATTR_CORE_HEAP 1U
+#else
+#define VIRTUAL_REGION_COUNT_PER_CORE 0
+#endif
+
+#if CONFIG_MM_DRV_INTEL_ADSP_TLB_USE_VIRTUAL_MEMORY_SHARED_REGION
+#define VIRTUAL_REGION_COUNT_SHARED 1
 #define MEM_REG_ATTR_SHARED_HEAP 2U
+#else
+#define VIRTUAL_REGION_COUNT_SHARED 0
+#endif
+
+#if CONFIG_MM_DRV_INTEL_ADSP_TLB_USE_VIRTUAL_MEMORY_OPPORTUNISTIC_REGION
+#define VIRTUAL_REGION_COUNT_OPPORTUNISTIC 1
 #define MEM_REG_ATTR_OPPORTUNISTIC_MEMORY 4U
+#else
+#define VIRTUAL_REGION_COUNT_OPPORTUNISTIC 0
+#endif
+
+/* Define amount of regions other than core heaps that virtual memory will be split to
+ * currently includes shared heap and oma region and one regions set to 0 as for table
+ * iterator end value.
+ */
+#define VIRTUAL_REGION_COUNT (VIRTUAL_REGION_COUNT_PER_CORE +		\
+			      VIRTUAL_REGION_COUNT_SHARED +		\
+			      VIRTUAL_REGION_COUNT_OPPORTUNISTIC + 1)
+
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_MEMORY_REGIONS_H_ */


### PR DESCRIPTION
virtual region feature in intel ADSP has no config options There's always a region per-core, a shared and
an opportunistic region.
All regions have a hard-coded sizes. There's also a defect: shared region gets its size from CORE_HEAP_SIZE macro

This commit adds kconfig options that allow enabling of each regions separately, as well as adjusting their sizes

