### PR TITLE
net: sockets_offload: Fix build error with NO_OPTIMIZATIONS

### DIFF
--- a/include/zephyr/net/socket_offload.h
+++ b/include/zephyr/net/socket_offload.h
@@ -67,10 +67,7 @@ void socket_offload_dns_enable(bool enable);
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 bool socket_offload_dns_is_enabled(void);
 #else
-static inline bool socket_offload_dns_is_enabled(void)
-{
-	return false;
-}
+#define socket_offload_dns_is_enabled() false
 #endif /* defined(CONFIG_NET_SOCKETS_OFFLOAD) */
 
 


### PR DESCRIPTION
When CONFIG_NO_OPTIMIZATIONS=y (and CONFIG_NET_SOCKETS_OFFLOAD = n) the compiler will not inline socket_offload_dns_is_enabled(), which means calls to socket_offload* remain, and the linker will fail with

in function `zsock_getaddrinfo': undefined reference to `socket_offload_getaddrinfo'
in function `zsock_freeaddrinfo': undefined reference to `socket_offload_freeaddrinfo'

Instead of relaying on that function being inlined and the if'ed code being removed, let's just use the preprocessor.

b18bc7cc3e484e8988142a5986d4fc712a326859

The issue can be seen in main, for ex. here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/15658608215/job/44113025391#step:13:2979 