### PR TITLE
net: dns: remove redundant check in mdns_unpack_query_header

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -462,10 +462,6 @@ int mdns_unpack_query_header(struct dns_msg_t *msg, uint16_t *src_id)
 		return -EINVAL;
 	}
 
-	if (dns_header_opcode(dns_header) != 0) {
-		return -EINVAL;
-	}
-
 	if (dns_header_rcode(dns_header) != 0) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
Drop this redundant check that was likely meant to be checking that Z field is zero but in the case of reception the RFC says it MUST be ignored anyway.