### PR TITLE
modules: mcuboot: Imply confirmed image generation in directxip mode

### DIFF
--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -231,6 +231,7 @@ config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT
 	select MCUBOOT_BOOTUTIL_LIB_FOR_DIRECT_XIP
 	select MCUBOOT_BOOTLOADER_MODE_HAS_NO_DOWNGRADE
 	select MCUBOOT_BOOTLOADER_NO_DOWNGRADE
+	imply MCUBOOT_GENERATE_CONFIRMED_IMAGE
 	help
 	  MCUboot expects slot0_partition and slot1_partition to exist in DT.
 	  In this mode MCUboot will boot the application with the higher version


### PR DESCRIPTION
Implies the Kconfig symbol for generated a padded, confirmed image when MCUboot has been configured in directxip mode with revert, as the main image must be confirmed in order for it to be booted