### PR TITLE
drivers: sdhc: fix sdhc caps field offset

### DIFF
--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -161,7 +161,7 @@ enum sd_voltage {
  * driver, using the @ref sdhc_get_host_props api.
  */
 struct sdhc_host_caps {
-	unsigned int timeout_clk_freq: 5;		/**< Timeout clock frequency */
+	unsigned int timeout_clk_freq: 6;		/**< Timeout clock frequency */
 	unsigned int _rsvd_6: 1;			/**< Reserved */
 	unsigned int timeout_clk_unit: 1;		/**< Timeout clock unit */
 	unsigned int sd_base_clk: 8;			/**< SD base clock frequency */


### PR DESCRIPTION
The first field in the capabilities register, "Timeout Clock Frequency" takes up the first 6 bits (5:0), not 5.

Reference: 2.2.26, SD Specifications, Part A2, SD Host Controller
           Simplified Specification, Version 4.20
           URL: https://www.sdcard.org/downloads/pls/pdf/?p=PartA2_SD%20Host_Controller_Simplified_Specification_Ver4.20.jpg

Side note: I am writing an SDHCI driver and found that most drivers write their own struct/macros for the SDHC registers, is it possible to have a common definition for these registers to avoid duplicated code?