### PR TITLE
boards: nxp: fix the is25wp064 flash size in DTS.

### DIFF
--- a/boards/madmachine/mm_feather/mm_feather.dts
+++ b/boards/madmachine/mm_feather/mm_feather.dts
@@ -60,7 +60,7 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <DT_SIZE_M(64 * 8)>;
+		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";

--- a/boards/madmachine/mm_swiftio/mm_swiftio.dts
+++ b/boards/madmachine/mm_swiftio/mm_swiftio.dts
@@ -60,7 +60,7 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <DT_SIZE_M(64 * 8)>;
+		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_qspi.dts
@@ -22,7 +22,7 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <67108864>;
+		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi.dts
@@ -24,7 +24,7 @@
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <67108864>;
+		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -162,7 +162,7 @@ nxp_parallel_i2c: &lpi2c1 {};
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <DT_SIZE_M(64 * 8)>;
+		size = <DT_SIZE_M(8 * 8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";


### PR DESCRIPTION
- fixes is25wp064 flash size in DTS. It must be 8 MBytes (64MBits).
- uses DT_SIZE_M() macro instead of an absolute value.