### PR TITLE
bluetooth: host: Fix uninitialized own_addr_type for legacy scan+adv

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -2005,8 +2005,8 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			if (!IS_ENABLED(CONFIG_BT_PRIVACY) &&
 			    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
 			    dev_scanning) {
-				scan_disabled = true;
-				bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
+				err = bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
+				scan_disabled = err == 0;
 			}
 
 			/* If we are scanning with the identity address, it does

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1997,13 +1997,13 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			 * problem.
 			 */
 #if defined(CONFIG_BT_OBSERVER)
-			bool scan_enabled = false;
+			bool scan_disabled = false;
 
 			/* If active scan with NRPA is ongoing refresh NRPA */
 			if (!IS_ENABLED(CONFIG_BT_PRIVACY) &&
 			    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
 			    atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
-				scan_enabled = true;
+				scan_disabled = true;
 				bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 			}
 #endif /* defined(CONFIG_BT_OBSERVER) */
@@ -2011,7 +2011,7 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 #if defined(CONFIG_BT_OBSERVER)
-			if (scan_enabled) {
+			if (scan_disabled) {
 				bt_le_scan_set_enable(BT_HCI_LE_SCAN_ENABLE);
 			}
 #endif /* defined(CONFIG_BT_OBSERVER) */

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1789,7 +1789,7 @@ int bt_id_set_create_conn_own_addr(bool use_filter, uint8_t *own_addr_type)
 #endif /* defined(CONFIG_BT_CENTRAL) */
 
 #if defined(CONFIG_BT_OBSERVER)
-static bool is_adv_using_rand_addr(void)
+static bool is_legacy_adv_enabled(void)
 {
 	struct bt_le_ext_adv *adv;
 
@@ -1805,7 +1805,27 @@ static bool is_adv_using_rand_addr(void)
 
 	adv = bt_le_adv_lookup_legacy();
 
-	return adv && atomic_test_bit(adv->flags, BT_ADV_ENABLED);
+	return adv != NULL && atomic_test_bit(adv->flags, BT_ADV_ENABLED);
+}
+
+static bool is_legacy_adv_using_id_addr(void)
+{
+	struct bt_le_ext_adv *adv;
+
+	if (!IS_ENABLED(CONFIG_BT_BROADCASTER) ||
+	    (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+	     BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features))) {
+		/* When advertising is not enabled or is using extended
+		 * advertising HCI commands then only the scanner uses the set
+		 * random address command.
+		 */
+		return false;
+	}
+
+	adv = bt_le_adv_lookup_legacy();
+
+	return adv != NULL && atomic_test_bit(adv->flags, BT_ADV_ENABLED)
+			   && atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY);
 }
 
 int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
@@ -1838,20 +1858,30 @@ int bt_id_set_scan_own_addr(bool active_scan, uint8_t *own_addr_type)
 		 * (through Kconfig).
 		 * Use same RPA as legacy advertiser if advertising.
 		 */
-		if (!IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
-		    !is_adv_using_rand_addr()) {
-			err = bt_id_set_private_addr(BT_ID_DEFAULT);
-			if (err) {
-				if (active_scan || !is_adv_using_rand_addr()) {
+		if (!IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY)) {
+			/* When using legacy advertising commands, the scanner and advertiser
+			 * share the same address, so we cannot change it.
+			 * When using extended advertising commands, however, the advertising
+			 * sets have their own addresses, so we can always change the scanner
+			 * address here.
+			 */
+			if (is_legacy_adv_using_id_addr()) {
+				if (bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
+					*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
+				} else {
+					*own_addr_type = BT_HCI_OWN_ADDR_PUBLIC;
+				}
+			} else if (is_legacy_adv_enabled()) {
+				*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
+			} else {
+				err = bt_id_set_private_addr(BT_ID_DEFAULT);
+				if (err) {
 					return err;
 				}
 
-				LOG_WRN("Ignoring failure to set address for passive scan (%d)",
-					err);
+				*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 			}
-
-			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
-		} else if (IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY)) {
+		} else {
 			if (bt_dev.id_addr[BT_ID_DEFAULT].type == BT_ADDR_LE_RANDOM) {
 				/* If scanning with Identity Address we must set the
 				 * random identity address for both active and passive

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -1998,22 +1998,38 @@ int bt_id_set_adv_own_addr(struct bt_le_ext_adv *adv, uint32_t options,
 			 */
 #if defined(CONFIG_BT_OBSERVER)
 			bool scan_disabled = false;
+			bool dev_scanning = atomic_test_bit(bt_dev.flags,
+							    BT_DEV_SCANNING);
 
 			/* If active scan with NRPA is ongoing refresh NRPA */
 			if (!IS_ENABLED(CONFIG_BT_PRIVACY) &&
 			    !IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) &&
-			    atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING)) {
+			    dev_scanning) {
 				scan_disabled = true;
 				bt_le_scan_set_enable(BT_HCI_LE_SCAN_DISABLE);
 			}
-#endif /* defined(CONFIG_BT_OBSERVER) */
-			err = bt_id_set_adv_private_addr(adv);
-			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
-#if defined(CONFIG_BT_OBSERVER)
+			/* If we are scanning with the identity address, it does
+			 * not make sense to set an NRPA.
+			 */
+			if (!IS_ENABLED(CONFIG_BT_SCAN_WITH_IDENTITY) ||
+			    !dev_scanning) {
+				err = bt_id_set_adv_private_addr(adv);
+				*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
+			} else {
+				if (id_addr->type == BT_ADDR_LE_RANDOM) {
+					*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
+				} else if (id_addr->type == BT_ADDR_LE_PUBLIC) {
+					*own_addr_type = BT_HCI_OWN_ADDR_PUBLIC;
+				}
+			}
+
 			if (scan_disabled) {
 				bt_le_scan_set_enable(BT_HCI_LE_SCAN_ENABLE);
 			}
+#else
+			err = bt_id_set_adv_private_addr(adv);
+			*own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 #endif /* defined(CONFIG_BT_OBSERVER) */
 		} else {
 			err = bt_id_set_adv_private_addr(adv);

--- a/tests/bluetooth/host/id/bt_id_set_adv_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_adv_own_addr/testcase.yaml
@@ -14,3 +14,7 @@ tests:
     extra_configs:
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
+  bluetooth.host.bt_id_set_adv_own_addr.scan_with_identity:
+    type: unit
+    extra_configs:
+      - CONFIG_BT_SCAN_WITH_IDENTITY=y

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/main.c
@@ -7,6 +7,8 @@
 #include "mocks/crypto.h"
 #include "mocks/hci_core.h"
 #include "mocks/rpa.h"
+#include "mocks/adv.h"
+#include "mocks/adv_expects.h"
 #include "testing_common_defs.h"
 
 #include <zephyr/bluetooth/hci.h>
@@ -72,6 +74,81 @@ ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy)
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);
 	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
+		     "Address type reference was incorrectly set");
+}
+
+/*
+ *  Test setting scan own address while 'CONFIG_BT_PRIVACY' isn't enabled.
+ *  Advertising is ongoing and uses a random device address.
+ *
+ *  Constraints:
+ *   - bt_id_set_private_addr() succeeds and returns 0
+ *   - 'CONFIG_BT_SCAN_WITH_IDENTITY' isn't enabled
+ *   - 'CONFIG_BT_PRIVACY' isn't enabled
+ *
+ *  Expected behaviour:
+ *   - bt_id_set_scan_own_addr() returns 0
+ *   - Address type reference is updated
+ */
+ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy_adv_ongoing_random_identity)
+{
+	int err;
+	struct bt_le_ext_adv *adv = &bt_dev.adv;
+	uint8_t own_addr_type = BT_ADDR_LE_ANONYMOUS;
+
+	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
+	Z_TEST_SKIP_IFDEF(CONFIG_BT_SCAN_WITH_IDENTITY);
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
+
+	bt_rand_fake.custom_fake = bt_rand_custom_fake;
+	bt_le_adv_lookup_legacy_fake.return_val = adv;
+
+	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_STATIC_RANDOM_LE_ADDR_1);
+
+	atomic_set_bit(adv->flags, BT_ADV_ENABLED);
+
+	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+
+	zassert_ok(err, "Unexpected error code '%d' was returned", err);
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_RANDOM,
+		     "Address type reference was incorrectly set");
+}
+
+/*
+ *  Test setting scan own address while 'CONFIG_BT_PRIVACY' isn't enabled.
+ *  Advertising is ongoing and uses a public device address.
+ *
+ *  Constraints:
+ *   - bt_id_set_private_addr() succeeds and returns 0
+ *   - 'CONFIG_BT_SCAN_WITH_IDENTITY' isn't enabled
+ *   - 'CONFIG_BT_PRIVACY' isn't enabled
+ *
+ *  Expected behaviour:
+ *   - bt_id_set_scan_own_addr() returns 0
+ *   - Address type reference is updated
+ */
+ZTEST(bt_id_set_scan_own_addr, test_set_nrpa_scan_address_no_privacy_adv_ongoing_public_identity)
+{
+	int err;
+	struct bt_le_ext_adv *adv = &bt_dev.adv;
+	uint8_t own_addr_type = BT_ADDR_LE_ANONYMOUS;
+
+	Z_TEST_SKIP_IFDEF(CONFIG_BT_PRIVACY);
+	Z_TEST_SKIP_IFDEF(CONFIG_BT_SCAN_WITH_IDENTITY);
+	Z_TEST_SKIP_IFNDEF(CONFIG_BT_BROADCASTER);
+
+	bt_rand_fake.custom_fake = bt_rand_custom_fake;
+	bt_le_adv_lookup_legacy_fake.return_val = adv;
+
+	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_LE_ADDR);
+
+	atomic_set_bit(adv->flags, BT_ADV_ENABLED);
+	atomic_set_bit(adv->flags, BT_ADV_USE_IDENTITY);
+
+	err = bt_id_set_scan_own_addr(false, &own_addr_type);
+
+	zassert_ok(err, "Unexpected error code '%d' was returned", err);
+	zassert_true(own_addr_type == BT_HCI_OWN_ADDR_PUBLIC,
 		     "Address type reference was incorrectly set");
 }
 

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/testcase.yaml
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/testcase.yaml
@@ -20,3 +20,7 @@ tests:
       - CONFIG_BT_SCAN_WITH_IDENTITY=y
       - CONFIG_BT_SMP=y
       - CONFIG_BT_PRIVACY=y
+  bluetooth.host.bt_id_set_scan_own_addr.scan_while_advertising:
+    type: unit
+    extra_configs:
+      - CONFIG_BT_BROADCASTER=y


### PR DESCRIPTION
In 25c993e5b74562137c2951db01c8a8d200e98d3d a new case was introduced where own_addr_type is not set by bt_id_set_scan_own_addr properly.

This led to issues for users where increasing their zephyr version led to failures to start scanning after advertising in the case where CONFIG_BT_SCAN_WITH_IDENTITY=n and legacy advertising commands are used.