### PR TITLE
drivers: spi: fix bad GENMASK in NXP LPSPI driver

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -23,7 +23,7 @@
 #define LPSPI_CHIP_SELECT_COUNT   4
 #define LPSPI_MIN_FRAME_SIZE_BITS 8
 
-#define LPSPI_INTERRUPT_BITS GENMASK(8, 13)
+#define LPSPI_INTERRUPT_BITS GENMASK(13, 8)
 
 /* Required by DEVICE_MMIO_NAMED_* macros */
 #define DEV_CFG(_dev)  ((const struct lpspi_config *)(_dev)->config)


### PR DESCRIPTION
Fixed swapped GENMASK arguments causing bad mask to be generated.