### PR TITLE
tests: Bluetooth: Tester: Handle BIGInfo after sync request

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
+++ b/tests/bluetooth/tester/src/audio/btp_bap_broadcast.h
@@ -47,6 +47,8 @@ struct btp_bap_broadcast_remote_source {
 	/* BIS Index bitfield read from sync request */
 	uint32_t requested_bis_sync;
 	bool assistant_request;
+	bool biginfo_received;
+	bool broadcast_code_received;
 	uint8_t sink_broadcast_code[BT_ISO_BROADCAST_CODE_SIZE];
 	const struct bt_bap_scan_delegator_recv_state *sink_recv_state;
 };


### PR DESCRIPTION
In the BAP Broadcast Sink implementation the sync request, the BIGInfo and the broadcast code can come in any other. Currently the btp_bap_broadcast_sink_bis_sync would reject the request if it came before the BIGInfo, but will now instead store the request and then apply it once the BIGInfo has been received, as there is not BIGInfo BTP event that the caller can use.