### PR TITLE
drivers: sdhc: split caps into standard and extra

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -520,6 +520,14 @@ Radio
 
 * Device trees and overlays using the old compatible strings must be updated to use the new names.
 
+SD Host Controller
+==================
+
+* Moved extra fields ``bus_4_bit_support``, ``hs200_support`` and ``hs400_support`` from
+  :c:struct:`sdhc_host_caps` to :c:struct:`sdhc_host_props` as per the
+  `SD Host Controller Specification <https://www.sdcard.org/downloads/pls/pdf/?p=PartA2_SD%20Host_Controller_Simplified_Specification_Ver4.20.jpg>`_.
+  (:github:`91701`)
+
 Shell
 =====
 

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -273,9 +273,9 @@ static void imx_usdhc_init_host_props(const struct device *dev)
 	props->host_caps.sdr104_support = (bool)(caps.flags & kUSDHC_SupportSDR104Flag);
 	props->host_caps.sdr50_support = (bool)(caps.flags & kUSDHC_SupportSDR50Flag);
 	props->host_caps.bus_8_bit_support = (bool)(caps.flags & kUSDHC_Support8BitFlag);
-	props->host_caps.bus_4_bit_support = (bool)(caps.flags & kUSDHC_Support4BitFlag);
-	props->host_caps.hs200_support = (bool)(cfg->mmc_hs200_1_8v);
-	props->host_caps.hs400_support = (bool)(cfg->mmc_hs400_1_8v);
+	props->bus_4_bit_support = (bool)(caps.flags & kUSDHC_Support4BitFlag);
+	props->hs200_support = (bool)(cfg->mmc_hs200_1_8v);
+	props->hs400_support = (bool)(cfg->mmc_hs400_1_8v);
 }
 
 /*

--- a/drivers/sdhc/intel_emmc_host.c
+++ b/drivers/sdhc/intel_emmc_host.c
@@ -1168,9 +1168,9 @@ static int emmc_get_host_props(const struct device *dev, struct sdhc_host_props 
 	props->host_caps.sdr104_support = (bool)(cap & BIT(33u));
 	props->host_caps.sdr50_support = (bool)(cap & BIT(32u));
 	props->host_caps.bus_8_bit_support = true;
-	props->host_caps.bus_4_bit_support = true;
-	props->host_caps.hs200_support = (bool)config->hs200_mode;
-	props->host_caps.hs400_support = (bool)config->hs400_mode;
+	props->bus_4_bit_support = true;
+	props->hs200_support = (bool)config->hs200_mode;
+	props->hs400_support = (bool)config->hs400_mode;
 
 	emmc->props = *props;
 

--- a/drivers/sdhc/mcux_sdif.c
+++ b/drivers/sdhc/mcux_sdif.c
@@ -118,7 +118,7 @@ static int mcux_sdif_get_host_props(const struct device *dev,
 	props->host_caps.high_spd_support = true;
 	props->host_caps.suspend_res_support = true;
 	props->host_caps.vol_330_support = true;
-	props->host_caps.bus_4_bit_support = true;
+	props->bus_4_bit_support = true;
 	props->host_caps.bus_8_bit_support = true;
 	props->max_current_330 = 1024;
 	return 0;

--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -1206,7 +1206,7 @@ static int rcar_mmc_set_bus_width(const struct device *dev, struct sdhc_io *ios)
 		reg_width = RCAR_MMC_OPTION_WIDTH_1;
 		break;
 	case SDHC_BUS_WIDTH4BIT:
-		if (data->props.host_caps.bus_4_bit_support) {
+		if (data->props.bus_4_bit_support) {
 			reg_width = RCAR_MMC_OPTION_WIDTH_4;
 		} else {
 			LOG_ERR("SDHC I/O: 4-bits bus width isn't supported");
@@ -1331,7 +1331,7 @@ static int rcar_mmc_set_timings(const struct device *dev, struct sdhc_io *ios)
 		}
 		break;
 	case SDHC_TIMING_HS400:
-		if (!data->props.host_caps.hs400_support) {
+		if (!data->props.hs400_support) {
 			LOG_ERR("SDHC I/O: HS400 timing isn't supported");
 			return -ENOTSUP;
 		}
@@ -1347,7 +1347,7 @@ static int rcar_mmc_set_timings(const struct device *dev, struct sdhc_io *ios)
 		data->ddr_mode = 1;
 		break;
 	case SDHC_TIMING_HS200:
-		if (!data->props.host_caps.hs200_support) {
+		if (!data->props.hs200_support) {
 			LOG_ERR("SDHC I/O: HS200 timing isn't supported");
 			return -ENOTSUP;
 		}
@@ -1947,7 +1947,7 @@ static void rcar_mmc_init_host_props(const struct device *dev)
 	case SDHC_BUS_WIDTH8BIT:
 		host_caps->bus_8_bit_support = 1;
 	case SDHC_BUS_WIDTH4BIT:
-		host_caps->bus_4_bit_support = 1;
+		props->bus_4_bit_support = 1;
 	default:
 		break;
 	}
@@ -1958,9 +1958,9 @@ static void rcar_mmc_init_host_props(const struct device *dev)
 	host_caps->sdr50_support = cfg->uhs_support;
 	/* neither Linux nor U-boot support DDR50 mode, that's why we don't support it too */
 	host_caps->ddr50_support = 0;
-	host_caps->hs200_support = cfg->mmc_hs200_1_8v;
+	props->hs200_support = cfg->mmc_hs200_1_8v;
 	/* TODO: add support */
-	host_caps->hs400_support = 0;
+	props->hs400_support = 0;
 #endif
 
 	host_caps->vol_330_support =

--- a/drivers/sdhc/sam_sdmmc.c
+++ b/drivers/sdhc/sam_sdmmc.c
@@ -995,7 +995,7 @@ static int sam_sdmmc_get_host_props(const struct device *dev, struct sdhc_host_p
 		props->host_caps.bus_8_bit_support = true;
 	}
 	if (config->bus_width != 1) {
-		props->host_caps.bus_4_bit_support = true;
+		props->bus_4_bit_support = true;
 	}
 	props->host_caps.adma_2_support      = (bool)(cap0 & SDMMC_CA0R_ADMA2SUP_Msk);
 	props->host_caps.high_spd_support    = (bool)(cap0 & SDMMC_CA0R_HSSUP_Msk);
@@ -1031,10 +1031,10 @@ static int sam_sdmmc_get_host_props(const struct device *dev, struct sdhc_host_p
 	props->host_caps.vdd2_180_support = false;
 	if (!config->no_18v) {
 		if (config->mmc_hs400_18v || config->mmc_hs200_18v) {
-			props->host_caps.hs200_support = true;
+			props->hs200_support = true;
 		}
 		if (config->mmc_hs400_18v) {
-			props->host_caps.hs400_support = true;
+			props->hs400_support = true;
 		}
 	}
 

--- a/drivers/sdhc/sdhc_ambiq.c
+++ b/drivers/sdhc/sdhc_ambiq.c
@@ -169,13 +169,13 @@ static int ambiq_sdio_get_host_props(const struct device *dev, struct sdhc_host_
 #if defined(CONFIG_SOC_SERIES_APOLLO5X)
 	props->host_caps.vol_330_support = true;
 #endif
-	props->host_caps.bus_4_bit_support = true;
+	props->bus_4_bit_support = true;
 	props->host_caps.bus_8_bit_support = true;
 	props->host_caps.high_spd_support = true;
 	props->host_caps.sdr50_support = true;
 	props->host_caps.sdr104_support = true;
 	props->host_caps.ddr50_support = true;
-	props->host_caps.hs200_support = true;
+	props->hs200_support = true;
 	props->max_current_330 = 1020;
 	props->max_current_300 = 1020;
 	props->max_current_180 = 1020;

--- a/drivers/sdhc/sdhc_esp32.c
+++ b/drivers/sdhc/sdhc_esp32.c
@@ -1423,11 +1423,10 @@ static DEVICE_API(sdhc, sdhc_api) = {
 					.ddr50_support = false,                                    \
 					.sdr104_support = false,                                   \
 					.sdr50_support = false,                                    \
-					.bus_8_bit_support = false,                                \
-					.bus_4_bit_support =                                       \
-						(DT_INST_PROP(n, bus_width) == 4) ? true : false,  \
-					.hs200_support = false,                                    \
-					.hs400_support = false}}};                                 \
+					.bus_8_bit_support = false},                               \
+			  .bus_4_bit_support = DT_INST_PROP(n, bus_width) == 4,                    \
+			  .hs200_support = false,                                                  \
+			  .hs400_support = false}};                                                \
                                                                                                    \
 	static struct sdhc_esp32_data sdhc_esp32_##n##_data = {                                    \
 		.bus_width = SDMMC_SLOT_WIDTH_DEFAULT,                                             \

--- a/drivers/sdhc/sdhc_infineon.c
+++ b/drivers/sdhc/sdhc_infineon.c
@@ -1127,11 +1127,10 @@ static DEVICE_API(sdhc, sdhc_infineon_api) = {
 					.ddr50_support = false,                                    \
 					.sdr104_support = false,                                   \
 					.sdr50_support = true,                                     \
-					.bus_8_bit_support = false,                                \
-					.bus_4_bit_support =                                       \
-						(DT_INST_PROP(n, bus_width) == 4) ? true : false,  \
-					.hs200_support = false,                                    \
-					.hs400_support = false}},                                  \
+					.bus_8_bit_support = false},                               \
+			  .bus_4_bit_support = (DT_INST_PROP(n, bus_width) == 4),		   \
+			  .hs200_support = false,						   \
+			  .hs400_support = false},                                                 \
 		IFX_SDHC_PERI_CLOCK_INIT(n)};                                                      \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, &sdhc_infineon_init##n, NULL, &sdhc_infineon_##n##_data,          \

--- a/drivers/sdhc/sdhc_max32.c
+++ b/drivers/sdhc/sdhc_max32.c
@@ -94,7 +94,7 @@ static void sdhc_max32_init_props(const struct device *dev)
 	sdhc_data->props.host_caps.sd_base_clk = 0x00;
 	sdhc_data->props.host_caps.max_blk_len = 0b10;
 	sdhc_data->props.host_caps.bus_8_bit_support = false;
-	sdhc_data->props.host_caps.bus_4_bit_support = false;
+	sdhc_data->props.bus_4_bit_support = false;
 	sdhc_data->props.host_caps.adma_2_support = true;
 	sdhc_data->props.host_caps.high_spd_support = true;
 	sdhc_data->props.host_caps.sdma_support = true;
@@ -119,8 +119,8 @@ static void sdhc_max32_init_props(const struct device *dev)
 	sdhc_data->props.host_caps.clk_multiplier = 0;
 	sdhc_data->props.host_caps.adma3_support = false;
 	sdhc_data->props.host_caps.vdd2_180_support = false;
-	sdhc_data->props.host_caps.hs200_support = false;
-	sdhc_data->props.host_caps.hs400_support = false;
+	sdhc_data->props.hs200_support = false;
+	sdhc_data->props.hs400_support = false;
 	sdhc_data->props.power_delay = sdhc_config->power_delay_ms;
 }
 

--- a/drivers/sdhc/sdhc_renesas_ra.c
+++ b/drivers/sdhc/sdhc_renesas_ra.c
@@ -721,12 +721,10 @@ static DEVICE_API(sdhc, sdhc_api) = {
 					.ddr50_support = false,                                    \
 					.sdr104_support = false,                                   \
 					.sdr50_support = false,                                    \
-					.bus_8_bit_support = false,                                \
-					.bus_4_bit_support = (DT_INST_PROP(index, bus_width) == 4) \
-								     ? true                        \
-								     : false,                      \
-					.hs200_support = false,                                    \
-					.hs400_support = false}},                                  \
+					.bus_8_bit_support = false},                               \
+			  .bus_4_bit_support = (DT_INST_PROP(index, bus_width) == 4),              \
+			  .hs200_support = false,                                                  \
+			  .hs400_support = false},                                                 \
 		RA_SDHI_EN(index),                                                                 \
 		RA_SDMMC_DTC_STRUCT_INIT(index)};                                                  \
                                                                                                    \

--- a/drivers/sdhc/sdhc_stm32.c
+++ b/drivers/sdhc/sdhc_stm32.c
@@ -551,7 +551,7 @@ static void sdhc_stm32_init_props(const struct device *dev)
 	props->host_caps.vol_330_support = true;
 	props->host_caps.vol_180_support = sdhc_config->support_1_8_v;
 	props->host_caps.bus_8_bit_support = (sdhc_config->bus_width == SDHC_BUS_WIDTH8BIT);
-	props->host_caps.bus_4_bit_support = (sdhc_config->bus_width == SDHC_BUS_WIDTH4BIT);
+	props->bus_4_bit_support = (sdhc_config->bus_width == SDHC_BUS_WIDTH4BIT);
 }
 
 static int sdhc_stm32_get_host_props(const struct device *dev, struct sdhc_host_props *props)

--- a/drivers/sdhc/xlnx_sdhc.c
+++ b/drivers/sdhc/xlnx_sdhc.c
@@ -587,14 +587,14 @@ static int xlnx_sdhc_host_props(const struct device *dev, struct sdhc_host_props
 			XLNX_SDHC_SLOT_TYPE_GET);
 	props->host_caps.bus_8_bit_support = XLNX_SDHC_GET_HOST_PROP_BIT(cap,
 			XLNX_SDHC_8BIT_SUPPORT);
-	props->host_caps.bus_4_bit_support = XLNX_SDHC_GET_HOST_PROP_BIT(cap,
+	props->bus_4_bit_support = XLNX_SDHC_GET_HOST_PROP_BIT(cap,
 			XLNX_SDHC_4BIT_SUPPORT);
 
 	if ((cap & CHECK_BITS(XLNX_SDHC_SDR400_SUPPORT)) != 0U) {
-		props->host_caps.hs400_support = (uint8_t)config->hs400_mode;
+		props->hs400_support = config->hs400_mode;
 		dev_data->has_phy = true;
 	}
-	props->host_caps.hs200_support = (uint8_t)config->hs200_mode;
+	props->hs200_support = config->hs200_mode;
 
 	dev_data->props = *props;
 

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -163,16 +163,16 @@ enum sd_voltage {
  * @brief SD host controller capabilities
  *
  * SD host controller capability flags. These flags should be set by the SDHC
- * driver, using the @ref sdhc_get_host_props api.
+ * driver, using the @ref sdhc_get_host_props api. These are packed to fit the capabilities register
+ * in the standard specification by the SD Association.
  */
 struct sdhc_host_caps {
-	unsigned int timeout_clk_freq: 5;		/**< Timeout clock frequency */
+	unsigned int timeout_clk_freq: 6;		/**< Timeout clock frequency */
 	unsigned int _rsvd_6: 1;			/**< Reserved */
 	unsigned int timeout_clk_unit: 1;		/**< Timeout clock unit */
 	unsigned int sd_base_clk: 8;			/**< SD base clock frequency */
 	unsigned int max_blk_len: 2;			/**< Max block length */
 	unsigned int bus_8_bit_support: 1;		/**< 8-bit Support for embedded device */
-	unsigned int bus_4_bit_support: 1;		/**< 4 bit bus support */
 	unsigned int adma_2_support: 1;			/**< ADMA2 support */
 	unsigned int _rsvd_20: 1;			/**< Reserved */
 	unsigned int high_spd_support: 1;		/**< High speed support */
@@ -194,6 +194,7 @@ struct sdhc_host_caps {
 	unsigned int drv_type_d_support: 1;		/**< Driver type D support */
 	unsigned int _rsvd_39: 1;			/**< Reserved */
 	unsigned int retune_timer_count: 4;		/**< Timer count for re-tuning */
+	unsigned int _rsvd_44: 1;			/**< Reserved */
 	unsigned int sdr50_needs_tuning: 1;		/**< Use tuning for SDR50 */
 	unsigned int retuning_mode: 2;			/**< Re-tuning mode */
 	unsigned int clk_multiplier: 8;			/**< Clock multiplier */
@@ -201,8 +202,6 @@ struct sdhc_host_caps {
 	unsigned int adma3_support: 1;			/**< ADMA3 support */
 	unsigned int vdd2_180_support: 1;		/**< 1.8V VDD2 support */
 	unsigned int _rsvd_61: 3;			/**< Reserved */
-	unsigned int hs200_support: 1;			/**< HS200 support */
-	unsigned int hs400_support: 1;			/**< HS400 support */
 };
 
 /**
@@ -235,6 +234,9 @@ struct sdhc_host_props {
 	uint32_t max_current_330; /*!< Max current (in mA) at 3.3V */
 	uint32_t max_current_300; /*!< Max current (in mA) at 3.0V */
 	uint32_t max_current_180; /*!< Max current (in mA) at 1.8V */
+	bool bus_4_bit_support; /**< 4 bit bus support */
+	bool hs200_support; /**< HS200 support */
+	bool hs400_support; /**< HS400 support */
 	bool is_spi; /*!< Is the host using SPI mode */
 };
 

--- a/subsys/sd/mmc.c
+++ b/subsys/sd/mmc.c
@@ -375,7 +375,7 @@ static int mmc_set_bus_width(struct sd_card *card)
 	if (card->host_props.host_caps.bus_8_bit_support && card->bus_width == 8) {
 		cmd.arg = MMC_SWITCH_8_BIT_BUS_ARG;
 		card->bus_io.bus_width = SDHC_BUS_WIDTH8BIT;
-	} else if (card->host_props.host_caps.bus_4_bit_support && card->bus_width >= 4) {
+	} else if (card->host_props.bus_4_bit_support && card->bus_width >= 4) {
 		cmd.arg = MMC_SWITCH_4_BIT_BUS_ARG;
 		card->bus_io.bus_width = SDHC_BUS_WIDTH4BIT;
 	} else {
@@ -454,7 +454,7 @@ static int mmc_set_timing(struct sd_card *card, struct mmc_ext_csd *ext)
 
 	/* Timing depends on EXT_CSD register information */
 	if ((ext->device_type.MMC_HS200_SDR_1200MV || ext->device_type.MMC_HS200_SDR_1800MV) &&
-	    (card->host_props.host_caps.hs200_support) &&
+	    (card->host_props.hs200_support) &&
 	    (card->bus_io.signal_voltage == SD_VOL_1_8_V) &&
 	    (card->bus_io.bus_width >= SDHC_BUS_WIDTH4BIT)) {
 		ret = mmc_set_hs_timing(card);
@@ -513,7 +513,7 @@ static int mmc_set_timing(struct sd_card *card, struct mmc_ext_csd *ext)
 
 	/* Switch to HS400 if applicable */
 	if ((ext->device_type.MMC_HS400_DDR_1200MV || ext->device_type.MMC_HS400_DDR_1800MV) &&
-	    (card->host_props.host_caps.hs400_support) &&
+	    (card->host_props.hs400_support) &&
 	    (card->bus_io.bus_width == SDHC_BUS_WIDTH8BIT)) {
 		/* Switch back to regular HS timing */
 		ret = mmc_set_hs_timing(card);

--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -591,7 +591,7 @@ static int sdmmc_init_hs(struct sd_card *card)
 		LOG_ERR("Failed to switch card to HS mode");
 		return ret;
 	}
-	if (card->host_props.host_caps.bus_4_bit_support && (card->flags & SD_4BITS_WIDTH)) {
+	if (card->host_props.bus_4_bit_support && (card->flags & SD_4BITS_WIDTH)) {
 		/* Raise bus width to 4 bits */
 		ret = sdmmc_set_bus_width(card, SDHC_BUS_WIDTH4BIT);
 		if (ret) {


### PR DESCRIPTION
Make sure the capabilities bitfield fits the standard SD Association
specification and move the extra capabilities to props.

Affected Drivers:
- infineon_sdio
- imx_usdhc
- intel_emmc_host
- rcar_mmc
- sam_sdmmc
- sdhc_ambiq
- sdhc_esp32
- sdhc_max32
- sdhc_renesas_ra
- sdhc_stm32
- xlnx_sdhc

Affected Subsys
- sd

Reference: 2.2.26, SD Specifications, Part A2, SD Host Controller
           Simplified Specification, Version 4.20
           URL: https://www.sdcard.org/downloads/pls/pdf/?p=PartA2_SD%20Host_Controller_Simplified_Specification_Ver4.20.jpg
