### PR TITLE
drivers: sensor: tsl2540: fix channel validation logic in attr_set

### DIFF
--- a/drivers/sensor/ams/tsl2540/tsl2540.c
+++ b/drivers/sensor/ams/tsl2540/tsl2540.c
@@ -156,7 +156,7 @@ static int tsl2540_attr_set(const struct device *dev, enum sensor_channel chan,
 	uint8_t temp;
 	double it;
 
-	if ((chan != SENSOR_CHAN_IR) & (chan != SENSOR_CHAN_LIGHT)) {
+	if ((chan != SENSOR_CHAN_IR) && (chan != SENSOR_CHAN_LIGHT)) {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Use && instead of & in channel validation logic to ensure channel is either CHAN_IR or CHAN_LIGHT.