### PR TITLE
drivers: memc: smartbond: add missing break statement in pm_action

### DIFF
--- a/drivers/memc/memc_smartbond_nor_psram.c
+++ b/drivers/memc/memc_smartbond_nor_psram.c
@@ -220,6 +220,7 @@ static int memc_smartbond_pm_action(const struct device *dev, enum pm_device_act
 		 */
 		memc_set_status(true, DT_INST_PROP_OR(0, clock_div, 0));
 		memc_automode_configure();
+		break;
 	default:
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
Add a missing break statement in the pm_action function to ensure that PM_DEVICE_ACTION_RESUME is not treated as an error.