### PR TITLE
drivers: clock_control: ambiq: add missing break statement

### DIFF
--- a/drivers/clock_control/clock_control_ambiq.c
+++ b/drivers/clock_control/clock_control_ambiq.c
@@ -45,6 +45,7 @@ static int ambiq_clock_on(const struct device *dev, clock_control_subsys_t sub_s
 		break;
 	case CLOCK_CONTROL_AMBIQ_TYPE_LFXTAL:
 		ret = am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32K_ENABLE, 0);
+		break;
 	default:
 		ret = -ENOTSUP;
 		break;


### PR DESCRIPTION
add missing break statement so that CLOCK_CONTROL_AMBIQ_TYPE_LFXTAL case is handled correctly.