### PR TITLE
drivers: intc: nxp_pint: fix off-by-one error in pin_enable

### DIFF
--- a/drivers/interrupt_controller/intc_nxp_pint.c
+++ b/drivers/interrupt_controller/intc_nxp_pint.c
@@ -69,7 +69,7 @@ int nxp_pint_pin_enable(uint8_t pin, enum nxp_pint_trigger trigger, bool wake)
 {
 	uint8_t slot = 0U;
 
-	if (pin > ARRAY_SIZE(pin_pint_id)) {
+	if (pin >= ARRAY_SIZE(pin_pint_id)) {
 		/* Invalid pin ID */
 		return -EINVAL;
 	}


### PR DESCRIPTION
Prevent out-of-bounds access in nxp_pint_pin_enable by fixing the comparison to use >= instead of >.