### PR TITLE
boards: lpcxpresso55s28: Use usbphy1 for udc0

### DIFF
--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -126,6 +126,7 @@
 
 zephyr_udc0: &usbhs {
 	status = "okay";
+	phy-handle = <&usbphy1>;
 };
 
 zephyr_uhc0: &usbhfs {


### PR DESCRIPTION
The PHY is necessary for a high speed USB connection. Same code as on the closely related lpcxpresso55s69.