### PR TITLE
manifest: Update hal_adi to pull DMA and low-power fixes for MAX32660

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - fs
     - name: hal_adi
-      revision: f8f65473168a4e9f71f20c0c5387f6b80fe54cf3
+      revision: 16829b77264678f31a2d077a870af7bdca2d39bd
       path: modules/hal/adi
       groups:
         - hal


### PR DESCRIPTION
Some DMA and LP wrappers were missing for MAX32660 which caused build errors on CI runs. Update hal_adi to get the necessary fixes.

HAL PR: https://github.com/zephyrproject-rtos/hal_adi/pull/28

Failing tests:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/15087287187/job/42411469045#step:13:2905
https://github.com/zephyrproject-rtos/zephyr/actions/runs/15514057490/job/43678591677#step:13:4186