### PR TITLE
STM32U3: add CAN support 

### DIFF
--- a/boards/st/nucleo_u385rg_q/doc/index.rst
+++ b/boards/st/nucleo_u385rg_q/doc/index.rst
@@ -187,6 +187,8 @@ Default Zephyr Peripheral Mapping:
 
 - DAC1_OUT1 : PA4
 - I2C1 SCL/SDA : PB6/PB7 (Arduino I2C)
+- FDCAN1_TX : PA12
+- FDCAN1_RX : PA11
 - LD4 : PA5
 - LPUART_1_TX : PA2
 - LPUART_1_RX : PA3
@@ -209,6 +211,13 @@ Serial Port
 
 Nucleo U385RG board has 4 U(S)ARTs, 1 LPUART. The Zephyr console output is assigned to
 USART1. Default settings are 115200 8N1.
+
+CAN
+---
+The STM32U385RG_Q does not have an onboard CAN transceiver. In
+order to use the CAN bus on the this board, an external CAN bus
+transceiver must be connected to ``PA11`` (``FDCAN1_RX``) and ``PA12``
+(``FDCAN1_TX``).
 
 
 Programming and Debugging

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -15,11 +15,12 @@
 	compatible = "st,stm32u385rg-nucleo-q";
 
 	chosen {
+		zephyr,canbus = &fdcan1;
+		zephyr,code-partition = &slot0_partition;
 		zephyr,console = &usart1;
+		zephyr,flash = &flash0;
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
-		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -143,6 +144,12 @@
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";
+};
+
+&fdcan1 {
+	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
 };
 
 &i2c1 {

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -5,12 +5,13 @@ arch: arm
 toolchain:
   - zephyr
 supported:
-  - arduino_gpio
-  - dac
   - adc
-  - arduino_spi
-  - dma
+  - arduino_gpio
   - arduino_i2c
+  - arduino_spi
+  - can
+  - dac
+  - dma
   - gpio
   - i2c
   - spi

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -279,6 +279,17 @@
 			status = "disabled";
 		};
 
+		fdcan1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+			reg-names = "m_can", "message_ram";
+			interrupts = <39 0>, <40 0>;
+			interrupt-names = "int0", "int1";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
+
 		i2c1: i2c@40005400 {
 			compatible = "st,stm32-i2c-v2";
 			reg = <0x40005400 0x400>;


### PR DESCRIPTION
Add CAN support for  Nucleo U385RG_Q.