### PR TITLE
drivers: ethernet: native_tap: make eth_native_tap_options const

### DIFF
--- a/drivers/ethernet/eth_native_tap.c
+++ b/drivers/ethernet/eth_native_tap.c
@@ -638,7 +638,7 @@ LISTIFY(CONFIG_ETH_NATIVE_TAP_INTERFACE_COUNT, DEFINE_PTP_DEVICE, (;), _);
 
 static void add_native_tap_options(void)
 {
-	static struct args_struct_t eth_native_tap_options[] = {
+	static const struct args_struct_t eth_native_tap_options[] = {
 		{
 			.is_mandatory = false,
 			.option = "eth-if",


### PR DESCRIPTION
Make the eth_native_tap_options table const to reflect how it's effectively used and passed to native_add_command_line_opts()