### PR TITLE
Fix buffer config in ESP32 Wi-Fi driver

### DIFF
--- a/drivers/wifi/esp32/Kconfig.esp32
+++ b/drivers/wifi/esp32/Kconfig.esp32
@@ -166,7 +166,7 @@ config ESP32_WIFI_STATIC_TX_BUFFER_NUM
 
 config ESP32_WIFI_CACHE_TX_BUFFER_NUM
 	int "Max number of WiFi cache TX buffers"
-	depends on ESP_SPIRAM
+	depends on ESP_SPIRAM && ESP_WIFI_HEAP_SPIRAM
 	range 16 128
 	default 32
 	help


### PR DESCRIPTION
This PR fixes the condition if `CONFIG_WIFI=y` and `CONFIG_ESP_SPIRAM=y` when an additional buffer set is allocated on the heap, even though the internal SRAM heap is used.