### PR TITLE
sys: atomic: declare static inline

### DIFF
--- a/include/zephyr/sys/atomic.h
+++ b/include/zephyr/sys/atomic.h
@@ -251,7 +251,7 @@ static inline void atomic_set_bit_to(atomic_t *target, int bit, bool val)
  * @param new_value New value to store.
  * @return true if @a new_value is written, false otherwise.
  */
-bool atomic_cas(atomic_t *target, atomic_val_t old_value, atomic_val_t new_value);
+static inline bool atomic_cas(atomic_t *target, atomic_val_t old_value, atomic_val_t new_value);
 
 /**
  * @brief Atomic compare-and-set with pointer values
@@ -268,7 +268,7 @@ bool atomic_cas(atomic_t *target, atomic_val_t old_value, atomic_val_t new_value
  * @param new_value New value to store.
  * @return true if @a new_value is written, false otherwise.
  */
-bool atomic_ptr_cas(atomic_ptr_t *target, atomic_ptr_val_t old_value,
+static inline bool atomic_ptr_cas(atomic_ptr_t *target, atomic_ptr_val_t old_value,
 		    atomic_ptr_val_t new_value);
 
 /**
@@ -283,7 +283,7 @@ bool atomic_ptr_cas(atomic_ptr_t *target, atomic_ptr_val_t old_value,
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
 
 /**
  * @brief Atomic subtraction.
@@ -297,7 +297,7 @@ atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
 
 /**
  * @brief Atomic increment.
@@ -310,7 +310,7 @@ atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_inc(atomic_t *target);
+static inline atomic_val_t atomic_inc(atomic_t *target);
 
 /**
  * @brief Atomic decrement.
@@ -323,7 +323,7 @@ atomic_val_t atomic_inc(atomic_t *target);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_dec(atomic_t *target);
+static inline atomic_val_t atomic_dec(atomic_t *target);
 
 /**
  * @brief Atomic get.
@@ -336,7 +336,7 @@ atomic_val_t atomic_dec(atomic_t *target);
  *
  * @return Value of @a target.
  */
-atomic_val_t atomic_get(const atomic_t *target);
+static inline atomic_val_t atomic_get(const atomic_t *target);
 
 /**
  * @brief Atomic get a pointer value
@@ -349,7 +349,7 @@ atomic_val_t atomic_get(const atomic_t *target);
  *
  * @return Value of @a target.
  */
-atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
+static inline atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
 
 /**
  * @brief Atomic get-and-set.
@@ -364,7 +364,7 @@ atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
 
 /**
  * @brief Atomic get-and-set for pointer values
@@ -379,7 +379,7 @@ atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target, atomic_ptr_val_t value);
+static inline atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target, atomic_ptr_val_t value);
 
 /**
  * @brief Atomic clear.
@@ -393,7 +393,7 @@ atomic_ptr_val_t atomic_ptr_set(atomic_ptr_t *target, atomic_ptr_val_t value);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_clear(atomic_t *target);
+static inline atomic_val_t atomic_clear(atomic_t *target);
 
 /**
  * @brief Atomic clear of a pointer value
@@ -407,7 +407,7 @@ atomic_val_t atomic_clear(atomic_t *target);
  *
  * @return Previous value of @a target.
  */
-atomic_ptr_val_t atomic_ptr_clear(atomic_ptr_t *target);
+static inline atomic_ptr_val_t atomic_ptr_clear(atomic_ptr_t *target);
 
 /**
  * @brief Atomic bitwise inclusive OR.
@@ -422,7 +422,7 @@ atomic_ptr_val_t atomic_ptr_clear(atomic_ptr_t *target);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
 
 /**
  * @brief Atomic bitwise exclusive OR (XOR).
@@ -437,7 +437,7 @@ atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
 
 /**
  * @brief Atomic bitwise AND.
@@ -452,7 +452,7 @@ atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
 
 /**
  * @brief Atomic bitwise NAND.
@@ -467,7 +467,7 @@ atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
  *
  * @return Previous value of @a target.
  */
-atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
 
 /**
  * @}

--- a/include/zephyr/sys/atomic_arch.h
+++ b/include/zephyr/sys/atomic_arch.h
@@ -15,39 +15,39 @@
 
 /* Arch specific atomic primitives */
 
-bool atomic_cas(atomic_t *target, atomic_val_t old_value,
+static inline bool atomic_cas(atomic_t *target, atomic_val_t old_value,
 			 atomic_val_t new_value);
 
-bool atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
-			      void *new_value);
+static inline bool atomic_ptr_cas(atomic_ptr_t *target, void *old_value,
+				  void *new_value);
 
-atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_add(atomic_t *target, atomic_val_t value);
 
-atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value);
 
-atomic_val_t atomic_inc(atomic_t *target);
+static inline atomic_val_t atomic_inc(atomic_t *target);
 
-atomic_val_t atomic_dec(atomic_t *target);
+static inline atomic_val_t atomic_dec(atomic_t *target);
 
-atomic_val_t atomic_get(const atomic_t *target);
+static inline atomic_val_t atomic_get(const atomic_t *target);
 
-void *atomic_ptr_get(const atomic_ptr_t *target);
+static inline void *atomic_ptr_get(const atomic_ptr_t *target);
 
-atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
 
-void *atomic_ptr_set(atomic_ptr_t *target, void *value);
+static inline void *atomic_ptr_set(atomic_ptr_t *target, void *value);
 
-atomic_val_t atomic_clear(atomic_t *target);
+static inline atomic_val_t atomic_clear(atomic_t *target);
 
-void *atomic_ptr_clear(atomic_ptr_t *target);
+static inline void *atomic_ptr_clear(atomic_ptr_t *target);
 
-atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_or(atomic_t *target, atomic_val_t value);
 
-atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value);
 
-atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_and(atomic_t *target, atomic_val_t value);
 
-atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
+static inline atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value);
 
 
 #endif /* ZEPHYR_INCLUDE_SYS_ATOMIC_ARCH_H_ */

--- a/include/zephyr/sys/atomic_c.h
+++ b/include/zephyr/sys/atomic_c.h
@@ -39,9 +39,9 @@ static inline atomic_val_t atomic_dec(atomic_t *target)
 
 }
 
-atomic_val_t atomic_get(const atomic_t *target);
+static inline atomic_val_t atomic_get(const atomic_t *target);
 
-atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
+static inline atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target);
 
 __syscall atomic_val_t atomic_set(atomic_t *target, atomic_val_t value);
 

--- a/kernel/atomic_c.c
+++ b/kernel/atomic_c.c
@@ -217,12 +217,12 @@ ATOMIC_SYSCALL_HANDLER_TARGET_VALUE(atomic_sub);
  *
  * @return The value read from <target>
  */
-atomic_val_t atomic_get(const atomic_t *target)
+static inline atomic_val_t atomic_get(const atomic_t *target)
 {
 	return *target;
 }
 
-atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target)
+static inline atomic_ptr_val_t atomic_ptr_get(const atomic_ptr_t *target)
 {
 	return *target;
 }


### PR DESCRIPTION
We head declarations diverging in different header files, make them all
static inline.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
