### PR TITLE
drivers: ethernet: vsc8541: various fixes

### DIFF
--- a/boards/sensry/ganymed_bob/ganymed_bob_sy120_gbm.dts
+++ b/boards/sensry/ganymed_bob/ganymed_bob_sy120_gbm.dts
@@ -30,7 +30,7 @@
 		reg = <0x0>;
 		status = "okay";
 
-		reset-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 
 		microchip,interface-type = "rgmii";
 	};

--- a/boards/sensry/ganymed_bob/ganymed_bob_sy120_gen1.dts
+++ b/boards/sensry/ganymed_bob/ganymed_bob_sy120_gen1.dts
@@ -30,7 +30,7 @@
 		reg = <0x0>;
 		status = "okay";
 
-		reset-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 
 		microchip,interface-type = "rgmii";
 	};

--- a/boards/sensry/ganymed_sk/ganymed_sk_sy120_gbm.dts
+++ b/boards/sensry/ganymed_sk/ganymed_sk_sy120_gbm.dts
@@ -41,7 +41,7 @@
 		reg = <0x0b>;
 		status = "okay";
 
-		reset-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 
 		microchip,interface-type = "rgmii";
 	};

--- a/boards/sensry/ganymed_sk/ganymed_sk_sy120_gen1.dts
+++ b/boards/sensry/ganymed_sk/ganymed_sk_sy120_gen1.dts
@@ -41,7 +41,7 @@
 		reg = <0x0b>;
 		status = "okay";
 
-		reset-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 
 		microchip,interface-type = "rgmii";
 	};

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -43,6 +43,13 @@ Bluetooth
 
 .. zephyr-keep-sorted-stop
 
+Ethernet
+========
+
+* The :dtcompatible:`microchip,vsc8541` PHY driver now expects the reset-gpios entry to specify
+  the GPIO_ACTIVE_LOW flag when the reset is being used as active low. Previously the active-low
+  nature was hard-coded into the driver. (:github:`91726`).
+
 Networking
 **********
 

--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -277,12 +277,15 @@ static int phy_mc_vsc8541_get_speed(const struct device *dev, struct phy_link_st
 static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds,
 				   enum phy_cfg_link_flag flags)
 {
+	int ret;
+
 	if ((flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) != 0U) {
-		LOG_ERR("Disabling auto-negotiation is not supported by this driver");
-		return -ENOTSUP;
+		ret = phy_mii_set_bmcr_reg_autoneg_disabled(dev, adv_speeds);
+	} else {
+		ret = phy_mii_cfg_link_autoneg(dev, adv_speeds, true);
 	}
 
-	return phy_mii_cfg_link_autoneg(dev, adv_speeds, true);
+	return ret;
 }
 
 /**

--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -230,14 +230,14 @@ static int phy_mc_vsc8541_get_speed(const struct device *dev, struct phy_link_st
 		return ret;
 	}
 
-	is_duplex = (aux_status & PHY_REG_PAGE0_EXT_DEV_AUX_DUPLEX) != 0;
+	is_duplex = (aux_status & PHY_REG_PAGE0_EXT_DEV_AUX_DUPLEX) != 0U;
 
 	ret = phy_mc_vsc8541_read(dev, PHY_REG_PAGE0_STAT1000_EXT2, &link1000_status);
 	if (ret < 0) {
 		return ret;
 	}
 
-	if ((link1000_status & BIT(12))) {
+	if ((link1000_status & BIT(12)) != 0U) {
 		state->speed = is_duplex ? LINK_FULL_1000BASE : LINK_HALF_1000BASE;
 		return 0; /* no need to check lower speeds */
 	}
@@ -247,7 +247,7 @@ static int phy_mc_vsc8541_get_speed(const struct device *dev, struct phy_link_st
 		return ret;
 	}
 
-	if (link100_status & BIT(12)) {
+	if ((link100_status & BIT(12)) != 0U) {
 		state->speed = is_duplex ? LINK_FULL_100BASE : LINK_HALF_100BASE;
 		return 0; /* no need to check lower speeds */
 	}
@@ -257,7 +257,7 @@ static int phy_mc_vsc8541_get_speed(const struct device *dev, struct phy_link_st
 		return ret;
 	}
 
-	if (link10_status & BIT(6)) {
+	if ((link10_status & BIT(6)) != 0U) {
 		state->speed = is_duplex ? LINK_FULL_10BASE : LINK_HALF_10BASE;
 	} else {
 		state->speed = 0; /* no link */
@@ -269,7 +269,7 @@ static int phy_mc_vsc8541_get_speed(const struct device *dev, struct phy_link_st
 static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed adv_speeds,
 				   enum phy_cfg_link_flag flags)
 {
-	if (flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) {
+	if ((flags & PHY_FLAG_AUTO_NEGOTIATION_DISABLED) != 0U) {
 		LOG_ERR("Disabling auto-negotiation is not supported by this driver");
 		return -ENOTSUP;
 	}
@@ -284,7 +284,6 @@ static int phy_mc_vsc8541_cfg_link(const struct device *dev, enum phy_link_speed
 static int phy_mc_vsc8541_init(const struct device *dev)
 {
 	struct mc_vsc8541_data *data = dev->data;
-	struct mc_vsc8541_config *cfg = dev->config;
 	int ret;
 
 	data->active_page = -1;
@@ -335,7 +334,7 @@ static int phy_mc_vsc8541_get_link(const struct device *dev, struct phy_link_sta
 
 	hasLink = (reg_sr & MII_BMSR_LINK_STATUS) != 0;
 
-	if (reg_cr & MII_BMCR_AUTONEG_ENABLE) {
+	if ((reg_cr & MII_BMCR_AUTONEG_ENABLE) != 0U) {
 		/* auto negotiation active; update status */
 		auto_negotiation_finished = (reg_sr & MII_BMSR_AUTONEG_COMPLETE) != 0;
 	}
@@ -489,6 +488,7 @@ write_end:
 
 static DEVICE_API(ethphy, mc_vsc8541_phy_api) = {
 	.get_link = phy_mc_vsc8541_get_link,
+	.cfg_link = phy_mc_vsc8541_cfg_link,
 	.link_cb_set = phy_mc_vsc8541_link_cb_set,
 	.read = phy_mc_vsc8541_read,
 	.write = phy_mc_vsc8541_write,

--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -427,6 +427,7 @@ static int phy_mc_vsc8541_read(const struct device *dev, uint16_t reg_addr, uint
 	reg_addr &= 0x00ff;
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
+	mdio_bus_enable(cfg->mdio_dev);
 
 	/* select page, given by register upper byte */
 	if (dev_data->active_page != page) {
@@ -441,6 +442,7 @@ static int phy_mc_vsc8541_read(const struct device *dev, uint16_t reg_addr, uint
 	ret = mdio_read(cfg->mdio_dev, cfg->addr, reg_addr, (uint16_t *)data);
 
 read_end:
+	mdio_bus_disable(cfg->mdio_dev);
 	k_mutex_unlock(&dev_data->mutex);
 
 	return ret;
@@ -467,6 +469,7 @@ static int phy_mc_vsc8541_write(const struct device *dev, uint16_t reg_addr, uin
 	reg_addr &= 0x00ff;
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
+	mdio_bus_enable(cfg->mdio_dev);
 
 	/* select page, given by register upper byte */
 	if (dev_data->active_page != page) {
@@ -481,6 +484,7 @@ static int phy_mc_vsc8541_write(const struct device *dev, uint16_t reg_addr, uin
 	ret = mdio_write(cfg->mdio_dev, cfg->addr, reg_addr, (uint16_t)data);
 
 write_end:
+	mdio_bus_disable(cfg->mdio_dev);
 	k_mutex_unlock(&dev_data->mutex);
 
 	return ret;

--- a/drivers/ethernet/phy/phy_microchip_vsc8541.c
+++ b/drivers/ethernet/phy/phy_microchip_vsc8541.c
@@ -143,14 +143,14 @@ static int phy_mc_vsc8541_reset(const struct device *dev)
 	}
 
 	/* configure the reset pin */
-	ret = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_ACTIVE);
+	ret = gpio_pin_configure_dt(&cfg->reset_gpio, GPIO_OUTPUT_INACTIVE);
 	if (ret < 0) {
 		return ret;
 	}
 
 	for (uint32_t i = 0; i < 2; i++) {
 		/* Start reset */
-		ret = gpio_pin_set_dt(&cfg->reset_gpio, 0);
+		ret = gpio_pin_set_dt(&cfg->reset_gpio, 1);
 		if (ret < 0) {
 			LOG_WRN("failed to set reset gpio");
 			return -EINVAL;
@@ -160,7 +160,7 @@ static int phy_mc_vsc8541_reset(const struct device *dev)
 		k_sleep(K_MSEC(200));
 
 		/* Reset over */
-		gpio_pin_set_dt(&cfg->reset_gpio, 1);
+		gpio_pin_set_dt(&cfg->reset_gpio, 0);
 
 		/* After de-asserting reset, must wait before using the config interface */
 		k_sleep(K_MSEC(200));


### PR DESCRIPTION
- Added missing MDIO enable/disable calls around accessing PHY registers, to make sure the MDIO bus is active first
- Cleaned up internal functions to use uint16_t for PHY register values
- Fixed inverted reset GPIO line
- Added SW reset timeout
- Implemented cfg_link function required by some MAC drivers