### PR TITLE
xtensa: Implement lazy HiFi context switching

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1179,3 +1179,9 @@ config ARCH_HAS_CUSTOM_CURRENT_IMPL
 	help
 	  Select when architecture implements arch_current_thread() &
 	  arch_current_thread_set().
+
+config ARCH_IPI_LAZY_COPROCESSORS_SAVE
+	bool
+	help
+	  Select when the architecture has multi-CPU lazy context switching
+	  of coprocessor registers.

--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -276,6 +276,15 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 }
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	return arch_float_disable(thread);
+#else
+	return -ENOTSUP;
+#endif
+}
+
 #if !defined(CONFIG_MULTITHREADING)
 
 K_KERNEL_STACK_ARRAY_DECLARE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS, CONFIG_ISR_STACK_SIZE);

--- a/arch/arm/core/cortex_a_r/thread.c
+++ b/arch/arm/core/cortex_a_r/thread.c
@@ -413,3 +413,12 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 	return -ENOTSUP;
 }
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
+
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	return arch_float_disable(thread);
+#else
+	return -ENOTSUP;
+#endif
+}

--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -460,6 +460,15 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 }
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	return arch_float_disable(thread);
+#else
+	return -ENOTSUP;
+#endif
+}
+
 /* Internal function for Cortex-M initialization,
  * applicable to either case of running Zephyr
  * with or without multi-threading support.

--- a/arch/arm64/core/thread.c
+++ b/arch/arm64/core/thread.c
@@ -199,3 +199,12 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
 	CODE_UNREACHABLE;
 }
 #endif
+
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+#if defined(CONFIG_FPU_SHARING)
+	return arch_float_disable(thread);
+#else
+	return -ENOTSUP;
+#endif
+}

--- a/arch/mips/core/thread.c
+++ b/arch/mips/core/thread.c
@@ -39,3 +39,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 	thread->callee_saved.sp = (unsigned long)stack_init;
 }
+
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+	return -ENOTSUP;
+}

--- a/arch/posix/core/thread.c
+++ b/arch/posix/core/thread.c
@@ -115,6 +115,12 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 }
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+	/* Posix does not support coprocessors */
+	return -ENOTSUP;
+}
+
 #if defined(CONFIG_ARCH_HAS_THREAD_ABORT)
 void z_impl_k_thread_abort(k_tid_t thread)
 {

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -255,3 +255,12 @@ FUNC_NORETURN void z_riscv_switch_to_main_no_multithreading(k_thread_entry_t mai
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 #endif /* !CONFIG_MULTITHREADING */
+
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+#ifdef CONFIG_FPU_SHARING
+	return arch_float_disable(thread);
+#else
+	return -ENOTSUP;
+#endif
+}

--- a/arch/rx/core/thread.c
+++ b/arch/rx/core/thread.c
@@ -51,3 +51,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack, char *sta
 
 	thread->switch_handle = (void *)iframe;
 }
+
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+	return -ENOTSUP;
+}

--- a/arch/sparc/core/thread.c
+++ b/arch/sparc/core/thread.c
@@ -77,3 +77,8 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 	return -ENOTSUP;
 }
 #endif /* CONFIG_FPU_SHARING */
+
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+	return -ENOTSUP;
+}

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -72,6 +72,15 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 }
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
+	return arch_float_disable(thread);
+#else
+	return -ENOTSUP;
+#endif
+}
+
 void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 		     char *stack_ptr, k_thread_entry_t entry,
 		     void *p1, void *p2, void *p3)

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -83,3 +83,11 @@ int arch_float_enable(struct k_thread *thread, unsigned int options)
 
 	return 0;
 }
+
+int arch_coprocessors_disable(struct k_thread *thread)
+{
+	/* x86-64 always has FP/SSE enabled so cannot be disabled */
+	ARG_UNUSED(thread);
+
+	return -ENOTSUP;
+}

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -153,6 +153,34 @@ config XTENSA_HIFI_SHARING
 	  across context switches to allow multiple threads to perform
 	  concurrent HiFi operations.
 
+if XTENSA_HIFI_SHARING
+
+choice XTENSA_HIFI_SHARING_MODEL
+	prompt "Xtensa HiFi Sharing Model"
+	depends on XTENSA_HIFI_SHARING
+	default XTENSA_EAGER_HIFI_SHARING
+
+config XTENSA_EAGER_HIFI_SHARING
+	bool "Eager HiFi Sharing"
+	help
+	  This option enables eager sharing of HiFi registers across context
+	  switches. This means that the HiFi registers are unconditionally
+	  saved and restored on every context switch, allowing multiple threads
+	  to use HiFi instructions concurrently.
+
+config XTENSA_LAZY_HIFI_SHARING
+	bool "Lazy HiFi Sharing"
+	depends on SCHED_IPI_SUPPORTED || (MP_MAX_NUM_CPUS = 1)
+	select ARCH_IPI_LAZY_COPROCESSORS_SAVE
+	help
+	  This option enables lazy sharing of HiFi registers across context
+	  switches. This means that the HiFi registers are saved and restored
+	  only when a thread actually uses HiFi instructions, allowing for
+	  more efficient use of resources when HiFi instructions are not used.
+endchoice
+
+endif    # XTENSA_HIFI_SHARING
+
 endif    # XTENSA_CPU_HAS_HIFI
 
 endmenu  # Xtensa HiFi Options

--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -29,7 +29,7 @@ zephyr_library_sources_ifdef(CONFIG_XTENSA_MPU mpu.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S syscall_helper.c)
 zephyr_library_sources_ifdef(CONFIG_LLEXT elf.c)
 zephyr_library_sources_ifdef(CONFIG_SMP smp.c)
-zephyr_library_sources_ifdef(CONFIG_XTENSA_EAGER_HIFI_SHARING xtensa_hifi.S)
+zephyr_library_sources_ifdef(CONFIG_XTENSA_HIFI_SHARING xtensa_hifi.S)
 
 zephyr_library_sources_ifdef(
   CONFIG_KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK

--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -29,7 +29,7 @@ zephyr_library_sources_ifdef(CONFIG_XTENSA_MPU mpu.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S syscall_helper.c)
 zephyr_library_sources_ifdef(CONFIG_LLEXT elf.c)
 zephyr_library_sources_ifdef(CONFIG_SMP smp.c)
-zephyr_library_sources_ifdef(CONFIG_XTENSA_HIFI_SHARING xtensa_hifi.S)
+zephyr_library_sources_ifdef(CONFIG_XTENSA_EAGER_HIFI_SHARING xtensa_hifi.S)
 
 zephyr_library_sources_ifdef(
   CONFIG_KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK

--- a/arch/xtensa/core/offsets/offsets.c
+++ b/arch/xtensa/core/offsets/offsets.c
@@ -61,7 +61,7 @@ GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu14);
 GEN_OFFSET_SYM(_xtensa_irq_bsa_t, fpu15);
 #endif
 
-#if defined(CONFIG_XTENSA_HIFI_SHARING)
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 GEN_OFFSET_SYM(_xtensa_irq_bsa_t, hifi);
 #endif
 

--- a/arch/xtensa/core/startup/reset_vector.S
+++ b/arch/xtensa/core/startup/reset_vector.S
@@ -566,7 +566,17 @@ unpackdone:
 	 * all CPENABLE bits must be set, even though they may not always
 	 * correspond to a coprocessor.
 	 */
+#ifdef CONFIG_XTENSA_LAZY_HIFI_SHARING
+	/*
+	 * Disable HiFi coprocessor by default. Should a thread try using
+         * the HiFi coprocessor, it will trigger an exception to both enable
+	 * it AND save/restore the HiFi state.
+	 */
+
+	movi	a2, 0xFF & ~(1 << XCHAL_CP_ID_AUDIOENGINELX)
+#else
 	movi	a2, 0xFF	 /* enable *all* bits, to allow dynamic TIE */
+#endif
 	wsr	a2, CPENABLE
 # endif
 

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -120,6 +120,10 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 {
 	thread->switch_handle = init_stack(thread, (int *)stack_ptr, entry,
 					   p1, p2, p3);
+#ifdef CONFIG_XTENSA_LAZY_HIFI_SHARING
+	memset(thread->arch.hifi_regs, 0, sizeof(thread->arch.hifi_regs));
+#endif /* CONFIG_XTENSA_LAZY_HIFI_SHARING */
+
 #ifdef CONFIG_KERNEL_COHERENCE
 	__ASSERT((((size_t)stack) % XCHAL_DCACHE_LINESIZE) == 0, "");
 	__ASSERT((((size_t)stack_ptr) % XCHAL_DCACHE_LINESIZE) == 0, "");

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -31,6 +31,16 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 extern char xtensa_arch_except_epc[];
 extern char xtensa_arch_kernel_oops_epc[];
 
+extern void xtensa_lazy_hifi_save(uint8_t *regs);
+extern void xtensa_lazy_hifi_load(uint8_t *regs);
+
+#if defined(CONFIG_XTENSA_LAZY_HIFI_SHARING) && (CONFIG_MP_MAX_NUM_CPUS > 1)
+#define LAZY_COPROCESSOR_LOCK
+
+static struct k_spinlock coprocessor_lock;
+#endif
+
+
 bool xtensa_is_outside_stack_bounds(uintptr_t addr, size_t sz, uint32_t ps)
 {
 	uintptr_t start, end;
@@ -279,6 +289,88 @@ static inline void *return_to(void *interrupted)
 #endif /* CONFIG_MULTITHREADING */
 }
 
+#if defined(LAZY_COPROCESSOR_LOCK)
+/**
+ * Spin until thread is no longer the HiFi owner on specified CPU.
+ * Note: Interrupts are locked on entry. Unlock before spinning to allow
+ * an IPI to be caught and processed; restore them afterwards.
+ */
+static void spin_while_hifi_owner(struct _cpu *cpu, struct k_thread *thread)
+{
+	unsigned int key;
+	unsigned int original;
+	unsigned int unlocked;
+
+	__asm__ volatile("rsr.ps %0" : "=r"(original));
+	unlocked = original & ~PS_INTLEVEL_MASK;
+	__asm__ volatile("wsr.ps %0; rsync" :: "r"(unlocked) : "memory");
+
+	/* Spin until thread is no longer the HiFi owner on the other CPU */
+
+	while ((struct k_thread *)
+	       atomic_ptr_get(&cpu->arch.hifi_owner) == thread) {
+		key = arch_irq_lock();
+		arch_spin_relax();
+		arch_irq_unlock(key);
+	}
+
+	__asm__ volatile("wsr.ps %0; rsync" :: "r"(original) : "memory");
+}
+
+/**
+ * Determine if the thread is the owner of a HiFi on another CPU. This is
+ * called with the coprocessor lock held
+ */
+static struct _cpu *thread_hifi_owner_elsewhere(struct k_thread *thread)
+{
+	struct _cpu *this_cpu = arch_curr_cpu();
+	struct k_thread *owner;
+
+	for (unsigned int i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++) {
+		owner = (struct k_thread *)
+			atomic_ptr_get(&_kernel.cpus[i].arch.hifi_owner);
+		if ((this_cpu != &_kernel.cpus[i]) && (owner == thread)) {
+			return &_kernel.cpus[i];
+		}
+	}
+	return NULL;
+}
+#endif
+
+/**
+ * This routine only needed for SMP systems with HiFi sharing. It handles the
+ * IPI sent to save the HiFi registers so the owner can load them onto another
+ * CPU.
+ */
+void arch_ipi_lazy_coprocessors_save(void)
+{
+#if defined(LAZY_COPROCESSOR_LOCK)
+	k_spinlock_key_t key = k_spin_lock(&coprocessor_lock);
+	struct _cpu *cpu = arch_curr_cpu();
+	struct k_thread *save_hifi = (struct k_thread *)
+				     atomic_ptr_get(&cpu->arch.save_hifi);
+	struct k_thread *hifi_owner = (struct k_thread *)
+				      atomic_ptr_get(&cpu->arch.hifi_owner);
+
+	if ((save_hifi == hifi_owner) && (save_hifi != NULL)) {
+		unsigned int cp;
+
+		__asm__ volatile("rsr.cpenable %0" : "=r"(cp));
+		cp |= BIT(XCHAL_CP_ID_AUDIOENGINELX);
+		__asm__ volatile("wsr.cpenable %0" :: "r"(cp));
+
+		xtensa_lazy_hifi_save(save_hifi->arch.hifi_regs);
+
+		cp &= ~BIT(XCHAL_CP_ID_AUDIOENGINELX);
+		__asm__ volatile("wsr.cpenable %0" :: "r"(cp));
+
+		atomic_ptr_set(&cpu->arch.hifi_owner, NULL);
+	}
+	atomic_ptr_set(&cpu->arch.save_hifi, NULL);
+	k_spin_unlock(&coprocessor_lock, key);
+#endif
+}
+
 /* The wrapper code lives here instead of in the python script that
  * generates _xtensa_handle_one_int*().  Seems cleaner, still kind of
  * ugly.
@@ -388,6 +480,59 @@ void *xtensa_excint1_c(void *esf)
 		bsa->pc += 3;
 		break;
 #endif /* !CONFIG_USERSPACE */
+#ifdef CONFIG_XTENSA_LAZY_HIFI_SHARING
+	case EXCCAUSE_CP_DISABLED(XCHAL_CP_ID_AUDIOENGINELX):
+		/* Identify the interrupted thread and the old HiFi owner */
+		struct k_thread *thread = _current;
+		struct k_thread *owner;
+		unsigned int cp;
+
+#if defined(LAZY_COPROCESSOR_LOCK)
+		/*
+		 * If the interrupted thread is a HiFi owner on another CPU,
+		 * then send an IPI to that CPU to have it save its HiFi state
+		 * and then return. This CPU will continue to raise the current
+		 * exception (and send IPIs) until the other CPU has both saved
+		 * the HiFi registers and cleared its HiFi owner.
+		 */
+
+		k_spinlock_key_t key  = k_spin_lock(&coprocessor_lock);
+		struct _cpu *cpu = thread_hifi_owner_elsewhere(thread);
+
+		if (cpu != NULL) {
+			cpu->arch.save_hifi = thread;
+			arch_sched_directed_ipi(BIT(cpu->id));
+			k_spin_unlock(&coprocessor_lock, key);
+			spin_while_hifi_owner(cpu, thread);
+			key = k_spin_lock(&coprocessor_lock);
+		}
+#endif
+		owner = (struct k_thread *)
+			atomic_ptr_get(&arch_curr_cpu()->arch.hifi_owner);
+
+		/* Enable the HiFi coprocessor */
+		__asm__ volatile("rsr.cpenable %0" : "=r"(cp));
+		cp |= BIT(XCHAL_CP_ID_AUDIOENGINELX);
+		__asm__ volatile("wsr.cpenable %0" :: "r"(cp));
+
+		if (owner == thread) {
+#if defined(LAZY_COPROCESSOR_LOCK)
+			k_spin_unlock(&coprocessor_lock, key);
+#endif
+			break;
+		}
+
+		if (owner != NULL) {
+			xtensa_lazy_hifi_save(owner->arch.hifi_regs);
+		}
+
+		atomic_ptr_set(&arch_curr_cpu()->arch.hifi_owner, thread);
+#if defined(LAZY_COPROCESSOR_LOCK)
+		k_spin_unlock(&coprocessor_lock, key);
+#endif
+		xtensa_lazy_hifi_load(thread->arch.hifi_regs);
+		break;
+#endif /* CONFIG_XTENSA_LAZY_HIFI_SHARING */
 	default:
 		reason = K_ERR_CPU_EXCEPTION;
 
@@ -453,6 +598,9 @@ skip_checks:
 #ifndef CONFIG_USERSPACE
 	case EXCCAUSE_SYSCALL:
 #endif /* !CONFIG_USERSPACE */
+#ifdef CONFIG_XTENSA_LAZY_HIFI_SHARING
+	case EXCCAUSE_CP_DISABLED(XCHAL_CP_ID_AUDIOENGINELX):
+#endif /* CONFIG_XTENSA_LAZY_HIFI_SHARING */
 		is_fatal_error = false;
 		break;
 	default:

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -307,6 +307,12 @@ xtensa_switch:
 
 #if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 	call0 _xtensa_hifi_save
+#elif defined(CONFIG_XTENSA_LAZY_HIFI_SHARING)
+	/* Disable HiFi sharing */
+	rsr a6, CPENABLE
+	movi a7, ~(1 << XCHAL_CP_ID_AUDIOENGINELX)
+	and a6, a6, a7
+	wsr a6, CPENABLE
 #endif
 
 	/* Now the high registers */

--- a/arch/xtensa/core/xtensa_asm2_util.S
+++ b/arch/xtensa/core/xtensa_asm2_util.S
@@ -185,7 +185,7 @@ _restore_ps_after:
 	FPU_REG_RESTORE
 #endif
 
-#if defined(CONFIG_XTENSA_HIFI_SHARING)
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 .extern _xtensa_hifi_load
 	call0 _xtensa_hifi_load
 #endif
@@ -305,7 +305,7 @@ xtensa_switch:
 	movi a0, _switch_restore_pc
 	s32i a0, a1, ___xtensa_irq_bsa_t_pc_OFFSET
 
-#if defined(CONFIG_XTENSA_HIFI_SHARING)
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 	call0 _xtensa_hifi_save
 #endif
 

--- a/arch/xtensa/core/xtensa_hifi.S
+++ b/arch/xtensa/core/xtensa_hifi.S
@@ -9,6 +9,7 @@
 #include <xtensa/config/tie.h>
 #include <xtensa/config/tie-asm.h>
 
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 /*
  * Load the HiFi registers from the hifi buffer in the BSA. Round the address
  * of this buffer up to XCHAL_CP1_SA_ALIGN bytes to guarantee the necessary
@@ -51,3 +52,32 @@ _xtensa_hifi_save:
         xchal_cp1_store a2 a3 a3 a3 a3  /* Only A2 and A3 are used by macro */
 
 	ret
+#elif defined(CONFIG_XTENSA_LAZY_HIFI_SHARING)
+/*
+ * Load the HiFi registers from the HiFi buffer in the k_thread structure.
+ */
+.global xtensa_lazy_hifi_load
+.align 4
+xtensa_lazy_hifi_load:
+	entry a1, 32
+	/* Spill registers onto stack */
+	call8 xthal_window_spill
+
+	/* A2 should be address of hifi storage; A3 is scratch */
+	xchal_cp1_load a2 a3 a3 a3 a3
+	retw
+
+/*
+ * Save the HiFi registers to the HiFi buffer in the k_thread structure.
+ */
+.global xtensa_lazy_hifi_save
+.align 4
+xtensa_lazy_hifi_save:
+	entry a1, 32
+	/* Spill registers onto stack */
+	call8 xthal_window_spill
+
+	/* A2 should be address of hifi storage; A3 is scratch */
+	xchal_cp1_store a2 a3 a3 a3 a3  /* Only A2 and A3 are used by macro */
+	retw
+#endif

--- a/arch/xtensa/include/xtensa_asm2_context.h
+++ b/arch/xtensa/include/xtensa_asm2_context.h
@@ -91,7 +91,7 @@
 # define _BSA_PADDING_FPU		(0)
 #endif
 
-#if defined(CONFIG_XTENSA_HIFI_SHARING)
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 # define _BSA_PADDING_HIFI		(XCHAL_CP1_SA_SIZE + XCHAL_CP1_SA_ALIGN)
 #else
 # define _BSA_PADDING_HIFI		(0)
@@ -173,7 +173,7 @@ struct xtensa_irq_base_save_area {
 	uintptr_t fpu15;
 #endif
 
-#if defined(CONFIG_XTENSA_HIFI_SHARING)
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 
 	/*
 	 * Carve space for the registers used by the HiFi audio engine

--- a/arch/xtensa/include/xtensa_asm2_s.h
+++ b/arch/xtensa/include/xtensa_asm2_s.h
@@ -17,7 +17,7 @@
  * only by the assembler.
  */
 
-#if defined(CONFIG_XTENSA_HIFI_SHARING)
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 .extern _xtensa_hifi_save
 #endif
 
@@ -437,7 +437,7 @@ _xstack_returned_\@:
 	FPU_REG_SAVE
 #endif
 
-#if defined(CONFIG_XTENSA_HIFI_SHARING)
+#if defined(CONFIG_XTENSA_EAGER_HIFI_SHARING)
 	call0 _xtensa_hifi_save    /* Save HiFi registers */
 #endif
 

--- a/include/zephyr/arch/structs.h
+++ b/include/zephyr/arch/structs.h
@@ -31,6 +31,8 @@
 #include <zephyr/arch/arm/structs.h>
 #elif defined(CONFIG_X86) && !defined(CONFIG_X86_64)
 #include <zephyr/arch/x86/ia32/structs.h>
+#elif defined(CONFIG_XTENSA)
+#include <zephyr/arch/xtensa/structs.h>
 #else
 
 /* Default definitions when no architecture specific definitions exist. */

--- a/include/zephyr/arch/xtensa/structs.h
+++ b/include/zephyr/arch/xtensa/structs.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_XTENSA_STRUCTS_H_
+#define ZEPHYR_INCLUDE_XTENSA_STRUCTS_H_
+
+/* Per CPU architecture specifics */
+struct _cpu_arch {
+#if defined(CONFIG_XTENSA_LAZY_HIFI_SHARING)
+	atomic_ptr_val_t hifi_owner; /* Owner of HiFi */
+#if CONFIG_MP_MAX_NUM_CPUS > 1
+	atomic_ptr_val_t save_hifi;  /* Save HiFi on IPI if match hifi_owner */
+#endif
+#elif defined(__cplusplus)
+	/* Ensure this struct does not have a size of 0 which is not allowed in C++. */
+	uint8_t dummy;
+#endif
+};
+
+#endif /* ZEPHYR_INCLUDE_XTENSA_STRUCTS_H_ */

--- a/include/zephyr/arch/xtensa/thread.h
+++ b/include/zephyr/arch/xtensa/thread.h
@@ -14,6 +14,10 @@
 #include <zephyr/arch/xtensa/mpu.h>
 #endif
 
+#ifdef CONFIG_XTENSA_LAZY_HIFI_SHARING
+#include <xtensa/config/tie.h>
+#endif
+
 /* Xtensa doesn't use these structs, but Zephyr core requires they be
  * defined so they can be included in struct _thread_base.  Dummy
  * field exists for sizeof compatibility with C++.
@@ -47,6 +51,11 @@ struct _thread_arch {
 	 * context switching or returning from non-nested interrupts.
 	 */
 	uint32_t return_ps;
+#endif
+
+#ifdef CONFIG_XTENSA_LAZY_HIFI_SHARING
+	/* A non-BSA region is required for lazy save/restore */
+	uint8_t hifi_regs[XCHAL_CP1_SA_SIZE] __aligned(XCHAL_CP1_SA_ALIGN);
 #endif
 };
 

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -212,6 +212,14 @@ int arch_float_disable(struct k_thread *thread);
 int arch_float_enable(struct k_thread *thread, unsigned int options);
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 
+/**
+ * @brief Disable coprocessor context preservation
+ *
+ * This function serves as a catchall for disabling the preservation of
+ * coprocessor context information when aborting a thread.
+ */
+int arch_coprocessors_disable(struct k_thread *thread);
+
 #if defined(CONFIG_USERSPACE) && defined(CONFIG_ARCH_HAS_THREAD_PRIV_STACK_SPACE_GET)
 /**
  * @brief Obtain privileged stack usage information for the specified thread

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -175,6 +175,15 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 				k_thread_entry_t _main);
 #endif /* CONFIG_ARCH_HAS_CUSTOM_SWAP_TO_MAIN */
 
+/**
+ * @brief Save coprocessor states on an IPI
+ *
+ * The function, invoked by the IPI handler, is used by cross-CPU lazy context
+ * switches. It saves the relevant coprocessor context(s) before signalling the
+ * waiting CPU that it has finished.
+ */
+void arch_ipi_lazy_coprocessors_save(void);
+
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 /**
  * @brief Disable floating point context preservation

--- a/kernel/ipi.c
+++ b/kernel/ipi.c
@@ -105,4 +105,8 @@ void z_sched_ipi(void)
 		z_time_slice();
 	}
 #endif /* CONFIG_TIMESLICING */
+
+#ifdef CONFIG_ARCH_IPI_LAZY_COPROCESSORS_SAVE
+	arch_ipi_lazy_coprocessors_save();
+#endif
 }

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1271,9 +1271,7 @@ static ALWAYS_INLINE void halt_thread(struct k_thread *thread, uint8_t new_state
 			return;
 		}
 
-#if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
-		arch_float_disable(thread);
-#endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
+		arch_coprocessors_disable(thread);
 
 		SYS_PORT_TRACING_FUNC(k_thread, sched_abort, thread);
 

--- a/tests/arch/xtensa/save_restore_hifi/src/main.c
+++ b/tests/arch/xtensa/save_restore_hifi/src/main.c
@@ -67,11 +67,13 @@ ZTEST(hifi, test_register_sanity)
 		k_thread_create(&thread[i], thread_stack[i], STACK_SIZE,
 				thread_entry, (void *)(uintptr_t)i, NULL, NULL,
 				priority - 1, 0, K_FOREVER);
-
-
 	}
 
 	k_thread_start(&thread[0]);
+
+	for (i = 0; i < NUM_THREADS; i++) {
+		k_thread_join(&thread[i], K_FOREVER);
+	}
 }
 
 ZTEST_SUITE(hifi, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/xtensa/save_restore_hifi/testcase.yaml
+++ b/tests/arch/xtensa/save_restore_hifi/testcase.yaml
@@ -1,7 +1,17 @@
 tests:
-  arch.xtensa.save_restore_hifi.mtl:
+  arch.xtensa.save_restore_hifi.eager.mtl:
     platform_allow:
       - intel_adsp/ace15_mtpm
     tags:
       - kernel
     ignore_faults: true
+    extra_configs:
+      - CONFIG_XTENSA_EAGER_HIFI_SHARING=y
+  arch.xtensa.save_restore_hifi.lazy.ptl:
+    platform_allow:
+      - intel_adsp/ace30/ptl
+    tags:
+      - kernel
+    ignore_faults: true
+    extra_configs:
+      - CONFIG_XTENSA_LAZY_HIFI_SHARING=y


### PR DESCRIPTION
This set of commits adds lazy context switching support for Xtensa's HiFi registers.

Rather than unconditionally saving and restoring the HiFi registers upon every thread context switch, the HiFi registers are  only saved/restored as needed. To this end, the HiFi coprocessor is disabled both on startup and every thread context switch. Thus, any attempts to use that coprocessor will result in an exception. This exception will in turn ...
  1. Enable the coprocessor
  2. Save the HiFi registers to the old thread (if applicable)
  3. Update the HiFi owner
  4. Restore the new HiFi owner's HiFi registers.

Update: This feature has removed a previous limitation where HiFi using threads needed to be bound to a single CPU. HiFi using threads are no longer bound to always execute on the same CPU.