### PR TITLE
Bluetooth: Classic: L2CAP: Set default value for monitor timeout

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -4028,6 +4028,14 @@ static uint16_t l2cap_br_conf_opt_ret_fc(struct bt_l2cap_chan *chan, struct net_
 			opt_ret_fc->tx_windows_size = CONFIG_BT_L2CAP_MAX_WINDOW_SIZE;
 		}
 
+		if (monitor_timeout == 0) {
+			monitor_timeout = CONFIG_BT_L2CAP_BR_MONITOR_TIMEOUT;
+		}
+
+		if (retransmission_timeout == 0) {
+			retransmission_timeout = CONFIG_BT_L2CAP_BR_RET_TIMEOUT;
+		}
+
 		opt_ret_fc->retransmission_timeout = sys_cpu_to_le16(retransmission_timeout);
 		opt_ret_fc->monitor_timeout = sys_cpu_to_le16(monitor_timeout);
 


### PR DESCRIPTION
When peer monitor_timeout is zero, set it to the default value defined by CONFIG_BT_L2CAP_BR_MONITOR_TIMEOUT. This ensures that the monitor timeout is always a valid value to avoid l2cap_br_monitor_timeout hang.