### PR TITLE
boards: nuvoton: numaker_m55m1: Enable gpioe in device tree

### DIFF
--- a/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
+++ b/boards/nuvoton/numaker_m55m1/numaker_m55m1.dts
@@ -65,6 +65,10 @@
 	status = "okay";
 };
 
+&gpioe {
+	status = "okay";
+};
+
 &gpioh {
 	status = "okay";
 };


### PR DESCRIPTION
This PR is to enable gpio-e module for numaker_m55m1 board.