### PR TITLE
samples: counter: alarm: removed imx95 a55/m7 to fix build issue

### DIFF
--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -22,6 +22,9 @@ tests:
       - mimxrt1060_evk@B/mimxrt1062/qspi
       - mimxrt1060_evk@C/mimxrt1062/hyperflash
       - mimxrt1060_evk@C/mimxrt1062/qspi
+      - imx95_evk/mimx9596/a55
+      - imx95_evk/mimx9596/a55/smp
+      - imx95_evk/mimx9596/m7
     integration_platforms:
       - nucleo_f746zg
   sample.drivers.counter.alarm.stm32_rtc:


### PR DESCRIPTION
Exclude imx95 m7 and a55 from build as this board does not support this sample yet