### PR TITLE
boards: nucleo_f411r: fix ram size to 128KB

### DIFF
--- a/boards/st/nucleo_f411re/nucleo_f411re.yaml
+++ b/boards/st/nucleo_f411re/nucleo_f411re.yaml
@@ -14,6 +14,6 @@ supported:
   - gpio
   - spi
   - i2c
-ram: 96
+ram: 128
 flash: 512
 vendor: st


### PR DESCRIPTION
Nucleo F411RE(STM32F411RET6) is provides 128 Kbytes of SRAM.

[ [Official Overview](https://www.st.com/en/microcontrollers-microprocessors/stm32f411re.html)  |  [Zephyr Docs](https://docs.zephyrproject.org/latest/boards/st/nucleo_f411re/doc/index.html) ]