### PR TITLE
boards: nxp: mimxrt1170_evk: Add note for Arduino R3 gpio input interrupts

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -51,6 +51,11 @@
 	};
 
 	arduino_header: connector {
+		/* NOTE:
+		 * The CM7 has no interrupt numbers for gpio9/gpio11/gpio12, so it isn't possible
+		 * to use input interrupts with A0-A5 or D0-D15.
+		 * The CM4 does support input interrupts.
+		 */
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;


### PR DESCRIPTION
For future developers to hopefully save some time trying to figure out why no GPIO interrupt callback is fired.