### PR TITLE
logging: backend: add KConfig option for SWO sync packets

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -164,6 +164,8 @@ New APIs and options
 
 * Logging:
 
+  * :kconfig:option:`CONFIG_LOG_BACKEND_SWO_SYNC_PACKETS`
+
   * Added options to skip timestamp and level in log backends.
 
     * :kconfig:option:`CONFIG_LOG_BACKEND_SHOW_TIMESTAMP`

--- a/subsys/logging/backends/Kconfig.swo
+++ b/subsys/logging/backends/Kconfig.swo
@@ -52,6 +52,15 @@ config LOG_BACKEND_SWO_PROTOCOL_MANCHESTER
 
 endchoice
 
+config LOG_BACKEND_SWO_SYNC_PACKETS
+	bool "Synchronization packet transmission"
+	default y
+	help
+	  Generate synchronization packets with a unique pattern in the bitstream.
+	  If the SWO pin is used for simple UART text output on a generic terminal application,
+	  these packets show up as special characters in regular intervals.
+	  You can avoid that by disabling this setting.
+
 backend = SWO
 backend-str = swo
 source "subsys/logging/Kconfig.template.log_format_config"

--- a/subsys/logging/backends/log_backend_swo.c
+++ b/subsys/logging/backends/log_backend_swo.c
@@ -112,9 +112,13 @@ static void log_backend_swo_init(struct log_backend const *const backend)
 	DWT->CTRL &= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk | DWT_CTRL_CYCCNTENA_Msk);
 	DWT->CTRL |= (DWT_CTRL_POSTPRESET_Msk | DWT_CTRL_POSTINIT_Msk);
 	/* Configure Formatter and Flush Control Register */
-	TPIU->FFCR = 0x00000100;
+	TPIU->FFCR = TPIU_FFCR_TrigIn_Msk;
 	/* Enable ITM, set TraceBusID=1, no local timestamp generation */
-	ITM->TCR  = 0x0001000D;
+	uint32_t tcr = ITM_TCR_ITMENA_Msk | ITM_TCR_DWTENA_Msk | (1 << ITM_TCR_TRACEBUSID_Pos);
+#if CONFIG_LOG_BACKEND_SWO_SYNC_PACKETS
+	tcr |= ITM_TCR_SYNCENA_Msk;
+#endif
+	ITM->TCR  = tcr;
 	/* Enable stimulus port used by the logger */
 	ITM->TER  = 1 << ITM_PORT_LOGGER;
 


### PR DESCRIPTION
Add KConfig LOG_BACKEND_SWO_SYNC_PACKET to allow disabling SWO synchronization packets. Useful if the SWO is used as a UART replacement to avoid that the sync packets show up as special characters in a terminal application.