### PR TITLE
drivers: i2c: ambiq: buffer overflow issue fixed

### DIFF
--- a/drivers/i2c/i2c_ambiq.c
+++ b/drivers/i2c/i2c_ambiq.c
@@ -124,11 +124,9 @@ static int i2c_ambiq_read(const struct device *dev, struct i2c_msg *hdr_msg,
 			return -E2BIG;
 		}
 #if defined(CONFIG_SOC_SERIES_APOLLO3X)
-		trans.ui32Instr = (*(uint32_t *)hdr_msg->buf)
-				   & (0xFFFFFFFFUL >> (32 - (hdr_msg->len * 8)));
+		memcpy(&trans.ui32Instr, hdr_msg->buf, hdr_msg->len);
 #else
-		trans.ui64Instr = (*(uint64_t *)hdr_msg->buf)
-				   & (0xFFFFFFFFFFFFFFFFULL >> (64 - (hdr_msg->len * 8)));
+		memcpy(&trans.ui64Instr, hdr_msg->buf, hdr_msg->len);
 #endif
 		trans.ui32InstrLen = hdr_msg->len;
 	}
@@ -179,11 +177,9 @@ static int i2c_ambiq_write(const struct device *dev, struct i2c_msg *hdr_msg,
 			return -E2BIG;
 		}
 #if defined(CONFIG_SOC_SERIES_APOLLO3X)
-		trans.ui32Instr = (*(uint32_t *)hdr_msg->buf)
-				   & (0xFFFFFFFFUL >> (32 - (hdr_msg->len * 8)));
+		memcpy(&trans.ui32Instr, hdr_msg->buf, hdr_msg->len);
 #else
-		trans.ui64Instr = (*(uint64_t *)hdr_msg->buf)
-				   & (0xFFFFFFFFFFFFFFFFULL >> (64 - (hdr_msg->len * 8)));
+		memcpy(&trans.ui64Instr, hdr_msg->buf, hdr_msg->len);
 #endif
 		trans.ui32InstrLen = hdr_msg->len;
 	}


### PR DESCRIPTION
Bugfix for possible out-of-bounds operation when buffer address is not 4 bytes aligned