### PR TITLE
drivers: display: st: allow-ltdc-callback-override

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022 Byte-Lab d.o.o. <dev@byte-lab.com>
  * Copyright 2023 NXP
- * Copyright (c) 2024 STMicroelectronics
+ * Copyright (c) 2025 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,6 +27,8 @@
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(display_stm32_ltdc, CONFIG_DISPLAY_LOG_LEVEL);
+
+#include "display_stm32_ltdc.h"
 
 /* Horizontal synchronization pulse polarity */
 #define LTDC_HSPOL_ACTIVE_LOW     0x00000000
@@ -84,7 +86,7 @@ struct display_stm32_ltdc_config {
 	const struct device *display_controller;
 };
 
-static void stm32_ltdc_global_isr(const struct device *dev)
+void __weak stm32_ltdc_global_isr(const struct device *dev)
 {
 	struct display_stm32_ltdc_data *data = dev->data;
 

--- a/drivers/display/display_stm32_ltdc.h
+++ b/drivers/display/display_stm32_ltdc.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025, STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _ZEPHYR_DRIVERS_DISPLAY_STM32_LTDC_H_
+#define _ZEPHYR_DRIVERS_DISPLAY_STM32_LTDC_H_
+
+void stm32_ltdc_global_isr(const struct device *dev);
+
+#endif /* _ZEPHYR_DRIVERS_DISPLAY_STM32_LTDC_H_ */


### PR DESCRIPTION
Allow overriding the LTDC callback for manual handling or extension In some cases, the default handling may not be desired, for example triggering handling of the next frame/block once the transfer has passed a certain line.