### PR TITLE
doc: develop: optimizations: tools: use latest puncover release

### DIFF
--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -168,7 +168,7 @@ the files and view their ROM, RAM, and stack usage.
 Before you can use this
 target, install the puncover Python module::
 
-    pip3 install git+https://github.com/HBehrens/puncover --user
+    pip3 install --user puncover
 
 .. warning::
 


### PR DESCRIPTION
Update the documentation to recommend installing the latest puncover release publiced to the Python Package Index (PyPI).

At the time of this commit, the latest release on PyPI is v0.4.2, which matches the latest release available on the puncover GitHub repo.