### PR TITLE
stm32: dts: l5: add fdcan node for stm32l5 series

### DIFF
--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -686,6 +686,17 @@
 			st,adc-oversampler = "OVERSAMPLER_MINIMAL";
 		};
 
+		fdcan1: can@4000a400 {
+			compatible = "st,stm32-fdcan";
+			reg = <0x4000a400 0x400>, <0x400ac000 0x350>;
+			reg-names = "m_can", "message_ram";
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
+			interrupts = <47 0>, <48 0>;
+			interrupt-names = "int0", "int1";
+			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
+			status = "disabled";
+		};
+
 		usb: usb@4000d400 {
 			compatible = "st,stm32-usb";
 			reg = <0x4000d400 0x400>;

--- a/dts/arm/st/l5/stm32l552Xc.dtsi
+++ b/dts/arm/st/l5/stm32l552Xc.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/l5/stm32l552.dtsi>
+
+/ {
+	sram0: memory@20000000 {
+		reg = <0x20000000 DT_SIZE_K(256)>;
+	};
+
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_K(256)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
The purpose of this PR is to provide minimal support for the FDCAN for the STM32L5 series.

This node will be used by the `stm32l552zc` board later. That is why we are adding a corresponding SoC file, `stm32l552XC.dtsi`.