### PR TITLE
shell: Fix warning for SHELL_SUBCMD_SET_END

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -510,7 +510,7 @@ static inline bool shell_help_is_structured(const char *help)
  * @brief Define ending subcommands set.
  *
  */
-#define SHELL_SUBCMD_SET_END {NULL}
+#define SHELL_SUBCMD_SET_END {0}
 
 /**
  * @brief Macro for creating a dynamic entry.


### PR DESCRIPTION
The macro `SHELL_SUBCMD_SET_END` was defined as `{NULL}`, which triggers a `-Wmissing-field-initializers` warning

```
shell.c:100:5: warning: missing field 'help' initializer [-Wmissing-field-initializers]
  100 |     SHELL_SUBCMD_SET_END
      |     ^
zephyr/include/zephyr/shell/shell.h:513:35: note: expanded from macro 'SHELL_SUBCMD_SET_END'
  513 | #define SHELL_SUBCMD_SET_END {NULL}
```

Replacing `{NULL}` with `{0}` silences this warning.

Usage of `{0}` is also a common pattern across the zephyr codebase.
```
$ grep -R "{0}" . | wc -l
1756

$ grep -R "{NULL}" . | wc -l
14
```