### PR TITLE
samples: counter: alarm: fix CI sample fail

### DIFF
--- a/samples/drivers/counter/alarm/sample.yaml
+++ b/samples/drivers/counter/alarm/sample.yaml
@@ -18,10 +18,15 @@ tests:
   sample.drivers.counter.alarm:
     platform_exclude:
       - mps2/an385
+      - mimxrt1050_evk/mimxrt1052/hyperflash
+      - mimxrt1050_evk/mimxrt1052/qspi
       - mimxrt1060_evk@A/mimxrt1062/qspi
       - mimxrt1060_evk@B/mimxrt1062/qspi
       - mimxrt1060_evk@C/mimxrt1062/hyperflash
       - mimxrt1060_evk@C/mimxrt1062/qspi
+      - mimxrt1064_evk/mimxrt1064
+      - mm_feather/mimxrt1062
+      - mm_swiftio/mimxrt1052
     integration_platforms:
       - nucleo_f746zg
   sample.drivers.counter.alarm.stm32_rtc:


### PR DESCRIPTION
- Fixes the alarm sample CI build errors.
- Adds mimxrt1050_evk, mimxrt1064_evk, mm_feather and mm_swiftio boards to the sample platform_exclude list. As this sample does not support these boards.