### PR TITLE
usb: device_next: allow to limit number or digits in serial number 

### DIFF
--- a/include/zephyr/usb/usbd.h
+++ b/include/zephyr/usb/usbd.h
@@ -629,8 +629,11 @@ static inline void *usbd_class_get_private(const struct usbd_class_data *const c
  *
  * This macro defines a descriptor node that, when added to the device context,
  * is automatically used as the serial number string descriptor. A valid serial
- * number is generated from HWID (HWINFO= whenever this string descriptor is
- * requested.
+ * number is obtained from @ref hwinfo_interface whenever this string
+ * descriptor is requested.
+ *
+ * @note The HWINFO driver must be available and the Kconfig option HWINFO
+ *       enabled.
  *
  * @param d_name   String descriptor node identifier.
  */

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -74,19 +74,19 @@ config USBD_MAX_UDC_MSG
 	help
 	  Maximum number of USB device controller events that can be queued.
 
-config USBD_MSG_SLAB_COUNT
-	int "Maximum number of USB device notification messages"
-	range 4 64
-	default 8
-	help
-	  Maximum number of USB device notification messages that can be queued.
-
 config USBD_MSG_DEFERRED_MODE
 	bool "Execute message callback from system workqueue"
 	default y
 	help
 	  Execute message callback from system workqueue. If disabled, message
 	  callback will be executed in the device stack context.
+
+config USBD_MSG_SLAB_COUNT
+	int "Maximum number of USB device notification messages" if USBD_MSG_DEFERRED_MODE
+	range 4 64
+	default 8
+	help
+	  Maximum number of USB device notification messages that can be queued.
 
 config USBD_MSG_WORK_DELAY
 	int "USB device notification messages work delay" if USBD_MSG_DEFERRED_MODE

--- a/subsys/usb/device_next/Kconfig
+++ b/subsys/usb/device_next/Kconfig
@@ -96,6 +96,16 @@ config USBD_MSG_WORK_DELAY
 	  Message work may need to be delayed because the device stack is not
 	  yet ready to publish the message. The delay unit is milliseconds.
 
+config USBD_HWINFO_DEVID_LENGTH
+	int "The length of the device ID requested from HWINFO in bytes"
+	depends on HWINFO
+	range 8 128
+	default 16
+	help
+	  Each byte represents two digits in the serial number string
+	  descriptor. This option can be used to limit the length requested
+	  from HWINFO to a meaningful number of digits.
+
 rsource "class/Kconfig"
 rsource "app/Kconfig.cdc_acm_serial"
 


### PR DESCRIPTION
Add Kconfig option to limit the length requested from HWINFO to a
meaningful number of digits. Also, check the length returned by the
HWINFO driver and rename the variables to a more suitable name.