### PR TITLE
dts: espressif: Restrict reference values in the adc dts bindings

### DIFF
--- a/dts/bindings/adc/espressif,esp32-adc.yaml
+++ b/dts/bindings/adc/espressif,esp32-adc.yaml
@@ -29,7 +29,11 @@ description: |
 
 compatible: "espressif,esp32-adc"
 
-include: [adc-controller.yaml]
+include:
+  - name: adc-controller.yaml
+    child-binding:
+      property-blocklist:
+        - zephyr,reference
 
 properties:
 
@@ -46,6 +50,15 @@ properties:
 
   "#io-channel-cells":
     const: 1
-
+child-binding:
+  properties:
+    zephyr,reference:
+      type: string
+      required: true
+      description: |
+        Reference selection:
+        - ADC_REF_INTERNAL:  Internal
+      enum:
+        - "ADC_REF_INTERNAL"
 io-channel-cells:
   - input


### PR DESCRIPTION
As it stands, the adc-esp32 driver only accepts ADC_REF_INTERNAL as a reference. This is only checked at runtime and notified through the logs. This PR moves this check at the device tree binding level for earlier notice.