### PR TITLE
soc: nordic: 54h20: bicr: Fix order of enum

### DIFF
--- a/soc/nordic/nrf54h/bicr/bicr-schema.json
+++ b/soc/nordic/nrf54h/bicr/bicr-schema.json
@@ -11,8 +11,8 @@
           "title": "Power supply scheme",
           "enumNames": [
             "Unconfigured (system will not boot)",
-            "VDDH supplied with 2.1-5.5 V and VDD regulated by the chip (inductor present)",
-            "Both VDD and VDDH supplied with 1.8 V (inductor present)"
+            "Both VDD and VDDH supplied with 1.8 V (inductor present)",
+            "VDDH supplied with 2.1-5.5 V and VDD regulated by the chip (inductor present)"
           ],
           "enum": [
             "UNCONFIGURED",


### PR DESCRIPTION
The order of the enumNames array needs to match the actual enum values array below it.