### PR TITLE
drivers: mcxc osc: use oscillator internal capacitance value from DT

### DIFF
--- a/soc/nxp/mcx/mcxc/soc.c
+++ b/soc/nxp/mcx/mcxc/soc.c
@@ -68,7 +68,7 @@ const sim_clock_config_t simConfig_BOARD_BootClockRUN = {
 
 const osc_config_t oscConfig_BOARD_BootClockRUN = {
 	.freq = DT_PROP(OSC_NODE, clock_frequency),
-	.capLoad = 0,
+	.capLoad = DT_PROP_OR(OSC_NODE, load_capacitance_picofarads, 0),
 #if DT_ENUM_HAS_VALUE(OSC_NODE, mode, external)
 	.workMode = kOSC_ModeExt,
 #elif DT_ENUM_HAS_VALUE(OSC_NODE, mode, low_power)


### PR DESCRIPTION
in order to tune the nxp mcxc crystal oscillator the load capacitance value must be set. the register field was always set to 0. this commit takes the load_capacitance_picofarads value from the device tree instead.