### PR TITLE
stm32: test: drivers: memc: ram: fix a specific SRAM memory overflow issue during the build process.

### DIFF
--- a/tests/drivers/memc/ram/boards/stm32h735g_disco.overlay
+++ b/tests/drivers/memc/ram/boards/stm32h735g_disco.overlay
@@ -1,0 +1,7 @@
+/delete-node/ &sram2;
+
+/* D2 domain, AHB SRAM */
+&sram1{
+	reg = <0x30000000 DT_SIZE_K(32)>;
+	zephyr,memory-region = "SRAM1-2";
+};


### PR DESCRIPTION
The D2 domain region of STM32H723/733, STM32H725/735 and STM32H730 has a 32KB memory size, initially separated into two domains.

Due to insufficient memory when building applications with a high footprint, SRAM1 or SRAM2 alone may not be sufficient to build the application.

For example, when building the `tests/drivers/memc/ram ` application on `stm32h735g_disco`, the following error may occur:

```
section `SRAM2' will not fit in region `SRAM2'
region `SRAM2' overflowed by 256 bytes
```