### PR TITLE
samples: counter: add esp32c2 soc overlay

### DIFF
--- a/samples/drivers/counter/alarm/socs/esp32c2.overlay
+++ b/samples/drivers/counter/alarm/socs/esp32c2.overlay
@@ -1,0 +1,6 @@
+&timer0 {
+	status = "okay";
+	counter {
+		status = "okay";
+	};
+};


### PR DESCRIPTION
esp8684_devkitm board build is failing due to
missing overlay file, which enables timer/counter.