### PR TITLE
scripts: do_not_merge: print the API limit stats

### DIFF
--- a/.github/workflows/pr_metadata_check.yml
+++ b/.github/workflows/pr_metadata_check.yml
@@ -33,6 +33,8 @@ jobs:
           pip install -r scripts/requirements-actions.txt --require-hashes
 
       - name: Run the check script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./scripts/ci/do_not_merge.py -p "${{ github.event.pull_request.number }}"
 

--- a/scripts/ci/do_not_merge.py
+++ b/scripts/ci/do_not_merge.py
@@ -12,6 +12,13 @@ import github
 DNM_LABELS = ["DNM", "DNM (manifest)", "TSC", "Architecture Review", "dev-review"]
 
 
+def print_rate_limit(gh, org):
+    response = gh.get_organization(org)
+    for header, value in response.raw_headers.items():
+        if header.startswith("x-ratelimit"):
+            print(f"{header}: {value}")
+
+
 def parse_args(argv):
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -29,6 +36,9 @@ def main(argv):
 
     token = os.environ.get('GITHUB_TOKEN', None)
     gh = github.Github(token)
+
+    print_rate_limit(gh, "zephyrproject-rtos")
+
     repo = gh.get_repo("zephyrproject-rtos/zephyr")
     pr = repo.get_pull(args.pull_request)
 


### PR DESCRIPTION
This information is useful for troubleshooting and not available anywhere else, does not quite belong to this script but this runs for every PR so it's not a bad place to have it.