### PR TITLE
nrf70: Improve powerdown sequence

### DIFF
--- a/modules/nrf_wifi/bus/qspi_if.c
+++ b/modules/nrf_wifi/bus/qspi_if.c
@@ -528,13 +528,9 @@ static int qspi_device_init(const struct device *dev)
 	return ret;
 }
 
-static void qspi_device_uninit(const struct device *dev)
+static void _qspi_device_uninit(const struct device *dev)
 {
 	bool last = true;
-
-	if (!IS_ENABLED(CONFIG_NRF70_QSPI_LOW_POWER)) {
-		return;
-	}
 
 	qspi_lock(dev);
 
@@ -566,6 +562,15 @@ static void qspi_device_uninit(const struct device *dev)
 	}
 
 	qspi_unlock(dev);
+}
+
+static void qspi_device_uninit(const struct device *dev)
+{
+	if (!IS_ENABLED(CONFIG_NRF70_QSPI_LOW_POWER)) {
+		return;
+	}
+
+	_qspi_device_uninit(dev);
 }
 
 /* QSPI send custom command.
@@ -1191,7 +1196,7 @@ struct device qspi_perip = {
 
 int qspi_deinit(void)
 {
-	LOG_DBG("TODO : %s", __func__);
+	_qspi_device_uninit(&qspi_perip);
 
 	return 0;
 }

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -503,6 +503,13 @@ int rpu_disable(void)
 {
 	int ret;
 
+	#ifdef CONFIG_NRF70_SR_COEX_RF_SWITCH
+	ret = sr_gpio_remove();
+	if (ret) {
+		goto out;
+	}
+#endif
+
 	ret = rpu_pwroff();
 	if (ret) {
 		goto out;
@@ -512,12 +519,7 @@ int rpu_disable(void)
 		goto out;
 	}
 
-#ifdef CONFIG_NRF70_SR_COEX_RF_SWITCH
-	ret = sr_gpio_remove();
-	if (ret) {
-		goto out;
-	}
-#endif
+
 	qdev = NULL;
 	cfg = NULL;
 

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -260,15 +260,15 @@ static int rpu_pwroff(void)
 {
 	int ret;
 
-	ret = gpio_pin_set_dt(&bucken_spec, 0); /* BUCKEN = 0 */
-	if (ret) {
-		LOG_ERR("BUCKEN GPIO set failed...");
-		return ret;
-	}
-
 	ret = gpio_pin_set_dt(&iovdd_ctrl_spec, 0); /* IOVDD CNTRL = 0 */
 	if (ret) {
 		LOG_ERR("IOVDD GPIO set failed...");
+		return ret;
+	}
+
+	ret = gpio_pin_set_dt(&bucken_spec, 0); /* BUCKEN = 0 */
+	if (ret) {
+		LOG_ERR("BUCKEN GPIO set failed...");
 		return ret;
 	}
 

--- a/modules/nrf_wifi/bus/spi_if.c
+++ b/modules/nrf_wifi/bus/spi_if.c
@@ -263,9 +263,7 @@ int spim_init(struct qspi_config *config)
 
 int spim_deinit(void)
 {
-	LOG_DBG("TODO : %s", __func__);
-
-	return 0;
+	return spi_release_dt(&spi_spec);
 }
 
 static void spim_addr_check(unsigned int addr, const void *data, unsigned int len)


### PR DESCRIPTION
Follow the precise order for powering down NR70

1. Drive all host side IO to GND (i.e. QSPI data lines, coex request)
2. Power down IOVDD
3. De-assert BUCKEN
4. Power down VBAT

Note

1. In order to perform $2 and $3, we cannot disconnect IOVDD and BUCKEN GPIOs in $2, they will be disconnected after $3.
2. $4 is implicit and done using power supply, not SW controlled.