### PR TITLE
lib: os: Fix function signature of str_out

### DIFF
--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -210,8 +210,9 @@ struct str_context {
 	int count;
 };
 
-static int str_out(int c, struct str_context *ctx)
+static int str_out(int c, void *context)
 {
+	struct str_context *ctx = context;
 	if ((ctx->str == NULL) || (ctx->count >= ctx->max)) {
 		++ctx->count;
 		return c;


### PR DESCRIPTION
Update the str_out function signature to match the expected `cbprintf_cb_local` type.
```
/* Create local cbprintf_cb type to make calng-based compilers happy when handles
 * OUTC() macro (see below). With strict rules (Wincompatible-function-pointer-types-strict)
 * it's prohibited to pass arguments with mismatched types.
 */
typedef int (*cbprintf_cb_local)(int c, void *ctx);
```

This fixes the following runtime error generated by UBSAN:
```
zephyr/lib/os/cbprintf_complete.c:1409:4: runtime error: call to function str_out through pointer to incorrect function type 'int (*)(int, void *)'
zephyr/lib/os/printk.c:214: note: str_out defined here
```