### PR TITLE
input: Fix function signature of input_thread

### DIFF
--- a/subsys/input/input.c
+++ b/subsys/input/input.c
@@ -73,8 +73,12 @@ int input_report(const struct device *dev,
 
 #ifdef CONFIG_INPUT_MODE_THREAD
 
-static void input_thread(void)
+static void input_thread(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	struct input_event evt;
 	int ret;
 


### PR DESCRIPTION
Update the input_thread function signature to match the expected k_thread_entry_t type
```
typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
```

This fixes the following runtime error generated by UBSAN:
```
zephyr/lib/os/thread_entry.c:48:2: runtime error: call to function input_thread through pointer to incorrect function type 'void (*)(void *, void *, void *)'
zephyr/subsys/input/input.c:77: note: input_thread defined here
```