### PR TITLE
drivers: stepper: add check for inval resolution in set_microstep_res

### DIFF
--- a/drivers/stepper/adi_tmc/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx.c
@@ -369,11 +369,6 @@ int tmc50xx_stepper_set_max_velocity(const struct device *dev, uint32_t velocity
 static int tmc50xx_stepper_set_micro_step_res(const struct device *dev,
 					      enum stepper_micro_step_resolution res)
 {
-	if (!VALID_MICRO_STEP_RES(res)) {
-		LOG_ERR("Invalid micro step resolution %d", res);
-		return -ENOTSUP;
-	}
-
 	const struct tmc50xx_stepper_config *config = dev->config;
 	uint32_t reg_value;
 	int err;

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -406,11 +406,6 @@ int tmc51xx_stepper_set_max_velocity(const struct device *dev, uint32_t velocity
 static int tmc51xx_stepper_set_micro_step_res(const struct device *dev,
 					      enum stepper_micro_step_resolution res)
 {
-	if (!VALID_MICRO_STEP_RES(res)) {
-		LOG_ERR("Invalid micro step resolution %d", res);
-		return -ENOTSUP;
-	}
-
 	uint32_t reg_value;
 	int err;
 

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -280,6 +280,7 @@ static inline int z_impl_stepper_disable(const struct device *dev)
  *
  * @retval -EIO General input / output error
  * @retval -ENOSYS If not implemented by device driver
+ * @retval -EINVAL If the requested resolution is invalid
  * @retval -ENOTSUP If the requested resolution is not supported
  * @retval 0 Success
  */
@@ -293,6 +294,10 @@ static inline int z_impl_stepper_set_micro_step_res(const struct device *dev,
 
 	if (api->set_micro_step_res == NULL) {
 		return -ENOSYS;
+	}
+
+	if (!VALID_MICRO_STEP_RES(resolution)) {
+		return -EINVAL;
 	}
 	return api->set_micro_step_res(dev, resolution);
 }

--- a/tests/drivers/stepper/stepper_api/src/main.c
+++ b/tests/drivers/stepper/stepper_api/src/main.c
@@ -88,11 +88,11 @@ static void stepper_before(void *f)
 
 ZTEST_SUITE(stepper, NULL, stepper_setup, stepper_before, NULL, NULL);
 
-ZTEST_F(stepper, test_set_micro_step_res_incorrect)
+ZTEST_F(stepper, test_set_micro_step_res_invalid)
 {
 	int ret = stepper_set_micro_step_res(fixture->dev, 127);
 
-	zassert_equal(ret, -ENOTSUP, "Incorrect micro step resolution should return -ENOTSUP");
+	zassert_equal(ret, -EINVAL, "Invalid micro step resolution should return -EINVAL");
 }
 
 ZTEST_F(stepper, test_get_micro_step_res)


### PR DESCRIPTION
Add check for invalid microstep resolution directly in api to avoid having the check in each and every driver and reduce lines of code