### PR TITLE
net: l2: wifi: fix ap rts_threshold cmd parameter count

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -3886,7 +3886,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		  "<rts_threshold: rts threshold/off>.\n"
 		  "[-i, --iface=<interface index>] : Interface index.\n",
 		  cmd_wifi_ap_set_rts_threshold,
-		  3,
+		  2,
 		  2),
 	SHELL_SUBCMD_SET_END);
 


### PR DESCRIPTION
fix the number of mandatory arguments for command Wi-Fi ap RTS threshold,
3 to 2.
Signed-off-by: Pan Gao <pan.gao@nxp.com>