### PR TITLE
i2c_shell: Only include target commands if I2C_TARGET

### DIFF
--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -320,8 +320,7 @@ static int cmd_i2c_speed(const struct shell *sh, size_t argc, char **argv)
 }
 
 /* i2c target register <device> */
-static int cmd_i2c_target_register(const struct shell *sh,
-				   size_t argc, char **argv)
+__maybe_unused static int cmd_i2c_target_register(const struct shell *sh, size_t argc, char **argv)
 {
 	char *s_dev_name = argv[ARGV_DEV];
 	const struct device *dev;
@@ -335,8 +334,7 @@ static int cmd_i2c_target_register(const struct shell *sh,
 
 	ret = i2c_target_driver_register(dev);
 	if (ret < 0) {
-		shell_error(sh, "I2C: Failed to register %s with err=%d",
-			    s_dev_name, ret);
+		shell_error(sh, "I2C: Failed to register %s with err=%d", s_dev_name, ret);
 		return ret;
 	}
 
@@ -346,8 +344,8 @@ static int cmd_i2c_target_register(const struct shell *sh,
 }
 
 /* i2c target unregister <device> */
-static int cmd_i2c_target_unregister(const struct shell *sh,
-				     size_t argc, char **argv)
+__maybe_unused static int cmd_i2c_target_unregister(const struct shell *sh, size_t argc,
+						    char **argv)
 {
 	char *s_dev_name = argv[ARGV_DEV];
 	const struct device *dev;
@@ -361,8 +359,7 @@ static int cmd_i2c_target_unregister(const struct shell *sh,
 
 	ret = i2c_target_driver_unregister(dev);
 	if (ret < 0) {
-		shell_error(sh, "I2C: Failed to unregister %s with err=%d",
-			    s_dev_name, ret);
+		shell_error(sh, "I2C: Failed to unregister %s with err=%d", s_dev_name, ret);
 		return ret;
 	}
 
@@ -392,6 +389,7 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
+#ifdef CONFIG_I2C_TARGET
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_i2c_target,
 	SHELL_CMD_ARG(register, &dsub_device_name,
@@ -404,6 +402,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      cmd_i2c_target_unregister, 2, 0),
 	SHELL_SUBCMD_SET_END     /* Array terminated. */
 );
+#endif /* CONFIG_I2C_TARGET */
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_i2c_cmds,
 	SHELL_CMD_ARG(scan, &dsub_device_name,
@@ -439,9 +438,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_i2c_cmds,
 		      "Configure I2C bus speed\n"
 		      "Usage: speed <device> <speed>",
 		      cmd_i2c_speed, 3, 0),
+#ifdef CONFIG_I2C_TARGET
 	SHELL_CMD_ARG(target, &sub_i2c_target,
 		      "Subcommands operating on i2c targets.",
 		      NULL, 3, 0),
+#endif /* CONFIG_I2C_TARGET */
 	SHELL_SUBCMD_SET_END     /* Array terminated. */
 );
 


### PR DESCRIPTION
The extra shell commands are useless unless you also enable I2C_TARGET. Conditionally include them based on the I2C_TARGET kconfig.