### PR TITLE
samples: fade_led: fix no led found error on rpi pico

### DIFF
--- a/samples/basic/fade_led/boards/rpi_pico.overlay
+++ b/samples/basic/fade_led/boards/rpi_pico.overlay
@@ -1,3 +1,9 @@
+/ {
+	pwm_leds {
+		status = "okay";
+	};
+};
+
 &pwm {
 	status = "okay";
 	divider-int-4 = <255>;


### PR DESCRIPTION
Set the status of the pwm_leds node in the Raspberry Pi Pico overlay to "okay". Without this change, the serial output shows "PWM-based LED fade. Found 0 LEDs" and the led doesn't light up on the Pico.