### PR TITLE
Add PTP timestamping support for NXP NETC ENETC

### DIFF
--- a/boards/nxp/imx943_evk/Kconfig.defconfig
+++ b/boards/nxp/imx943_evk/Kconfig.defconfig
@@ -6,3 +6,26 @@ config INTC_INIT_PRIORITY
 
 config MBOX_INIT_PRIORITY
 	default 3
+
+if ETH_NXP_IMX_NETC
+
+config ETH_NXP_IMX_RX_RING_LEN
+	default 16
+
+config ETH_NXP_IMX_TX_RING_LEN
+	default 16
+
+config NET_IF_MAX_IPV4_COUNT
+	default 6
+
+config NET_IF_MAX_IPV6_COUNT
+	default 6
+
+endif # ETH_NXP_IMX_NETC
+
+if NET_GPTP
+
+config NET_GPTP_MONITOR_SYNC_STATUS
+	default y
+
+endif # NET_GPTP

--- a/boards/nxp/imx943_evk/dts/enetc.overlay
+++ b/boards/nxp/imx943_evk/dts/enetc.overlay
@@ -21,13 +21,20 @@
 };
 
 &enetc_psi0 {
+	ptp-clock = <&netc_ptp_clock0>;
 	status = "okay";
 };
 
 &enetc_psi1 {
+	ptp-clock = <&netc_ptp_clock0>;
 	status = "okay";
 };
 
 &enetc_psi2 {
+	ptp-clock = <&netc_ptp_clock0>;
+	status = "okay";
+};
+
+&netc_ptp_clock0 {
 	status = "okay";
 };

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -938,7 +938,7 @@ static const struct ethernet_api api_funcs = {
 	NXP_ENET_INVALID_MII_MODE))
 
 #ifdef CONFIG_PTP_CLOCK_NXP_ENET
-#define NXP_ENET_PTP_DEV(n) .ptp_clock = DEVICE_DT_GET(DT_INST_PHANDLE(n, nxp_ptp_clock)),
+#define NXP_ENET_PTP_DEV(n) .ptp_clock = DEVICE_DT_GET(DT_INST_PHANDLE(n, ptp_clock)),
 #define NXP_ENET_FRAMEINFO_ARRAY(n)							\
 	static enet_frame_info_t							\
 		nxp_enet_##n##_tx_frameinfo_array[CONFIG_ETH_NXP_ENET_TX_BUFFERS];

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
@@ -92,6 +92,9 @@ struct netc_eth_config {
 	const struct pinctrl_dev_config *pincfg;
 	uint8_t tx_intr_msg_data;
 	uint8_t rx_intr_msg_data;
+#ifdef CONFIG_PTP_CLOCK_NXP_NETC
+	const struct device *ptp_clock;
+#endif
 };
 
 typedef uint8_t rx_buffer_t[NETC_RX_RING_BUF_SIZE_ALIGN];
@@ -117,5 +120,7 @@ int netc_eth_tx(const struct device *dev, struct net_pkt *pkt);
 enum ethernet_hw_caps netc_eth_get_capabilities(const struct device *dev);
 int netc_eth_set_config(const struct device *dev, enum ethernet_config_type type,
 			const struct ethernet_config *config);
-
+#ifdef CONFIG_PTP_CLOCK_NXP_NETC
+const struct device *netc_eth_get_ptp_clock(const struct device *dev);
+#endif
 #endif /* ZEPHYR_DRIVERS_ETHERNET_ETH_NXP_IMX_NETC_PRIV_H_ */

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_psi.c
@@ -128,6 +128,9 @@ static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_ifac
 						 .get_capabilities = netc_eth_get_capabilities,
 						 .get_phy = netc_eth_get_phy,
 						 .set_config = netc_eth_set_config,
+#ifdef CONFIG_PTP_CLOCK_NXP_NETC
+						 .get_ptp_clock = netc_eth_get_ptp_clock,
+#endif
 						 .send = netc_eth_tx};
 
 #define NETC_PSI_INSTANCE_DEFINE(n)                                                                \
@@ -199,6 +202,8 @@ static const struct ethernet_api netc_eth_api = {.iface_api.init = netc_eth_ifac
 		.si_idx = (DT_INST_PROP(n, mac_index) << 8) | DT_INST_PROP(n, si_index),           \
 		.tx_intr_msg_data = NETC_TX_INTR_MSG_DATA_START + n,                               \
 		.rx_intr_msg_data = NETC_RX_INTR_MSG_DATA_START + n,                               \
+		IF_ENABLED(CONFIG_PTP_CLOCK_NXP_NETC,				                   \
+			(.ptp_clock = DEVICE_DT_GET(DT_INST_PHANDLE(n, ptp_clock)),))              \
 	};                                                                                         \
 	ETH_NET_DEVICE_DT_INST_DEFINE(n, netc_eth_init, NULL, &netc_eth##n##_data,                 \
 				      &netc_eth##n##_config, CONFIG_ETH_INIT_PRIORITY,             \

--- a/dts/arm/nxp/nxp_imx943_m33.dtsi
+++ b/dts/arm/nxp/nxp_imx943_m33.dtsi
@@ -226,6 +226,27 @@
 				si-index = <2>;
 				status = "disabled";
 			};
+
+			netc_ptp_clock0: ptp_clock@4cd80000 {
+				compatible = "nxp,netc-ptp-clock";
+				reg = <0x4cd80000 0x10000>;
+				clocks = <&scmi_clk IMX943_CLK_ENET>;
+				status = "disabled";
+			};
+
+			netc_ptp_clock1: ptp_clock@4cda0000 {
+				compatible = "nxp,netc-ptp-clock";
+				reg = <0x4cda0000 0x10000>;
+				clocks = <&scmi_clk IMX943_CLK_ENET>;
+				status = "disabled";
+			};
+
+			netc_ptp_clock2: ptp_clock@4cdc0000 {
+				compatible = "nxp,netc-ptp-clock";
+				reg = <0x4cdc0000 0x10000>;
+				clocks = <&scmi_clk IMX943_CLK_ENET>;
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -483,7 +483,7 @@
 				interrupts = <83 0>, <84 0>, <85 0>;
 				interrupt-names = "TX", "RX", "ERR";
 				nxp,mdio = <&enet_mdio>;
-				nxp,ptp-clock = <&enet_ptp_clock>;
+				ptp-clock = <&enet_ptp_clock>;
 				phy-connection-type = "rmii";
 				status = "disabled";
 			};

--- a/dts/arm/nxp/nxp_rt1060.dtsi
+++ b/dts/arm/nxp/nxp_rt1060.dtsi
@@ -40,7 +40,7 @@
 				interrupts = <152 0>;
 				interrupt-names = "COMMON";
 				nxp,mdio = <&enet2_mdio>;
-				nxp,ptp-clock = <&enet2_ptp_clock>;
+				ptp-clock = <&enet2_ptp_clock>;
 				status = "disabled";
 			};
 			enet2_mdio: mdio {

--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -796,7 +796,7 @@
 				interrupts = <114 0>;
 				interrupt-names = "COMMON";
 				nxp,mdio = <&enet_mdio>;
-				nxp,ptp-clock = <&enet_ptp_clock>;
+				ptp-clock = <&enet_ptp_clock>;
 				status = "disabled";
 			};
 			enet_mdio: mdio {

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -796,7 +796,7 @@
 				interrupts = <137 0>;
 				interrupt-names = "COMMON";
 				nxp,mdio = <&enet_mdio>;
-				nxp,ptp-clock = <&enet_ptp_clock>;
+				ptp-clock = <&enet_ptp_clock>;
 				status = "disabled";
 			};
 			enet_mdio: mdio {
@@ -823,7 +823,7 @@
 				interrupts = <141 0>;
 				interrupt-names = "COMMON";
 				nxp,mdio = <&enet1g_mdio>;
-				nxp,ptp-clock = <&enet1g_ptp_clock>;
+				ptp-clock = <&enet1g_ptp_clock>;
 				status = "disabled";
 			};
 			enet1g_mdio: mdio {

--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -609,7 +609,7 @@
 			interrupts = <115 0>;
 			interrupt-names = "COMMON";
 			nxp,mdio = <&enet_mdio>;
-			nxp,ptp-clock = <&enet_ptp_clock>;
+			ptp-clock = <&enet_ptp_clock>;
 			status = "disabled";
 			power-domains = <&power_mode3_domain>;
 		};

--- a/dts/arm/nxp/nxp_s32k148.dtsi
+++ b/dts/arm/nxp/nxp_s32k148.dtsi
@@ -41,7 +41,7 @@
 				interrupts = <73 0>, <74 0>, <75 0>;
 				interrupt-names = "TX", "RX", "ERR";
 				nxp,mdio = <&enet_mdio>;
-				nxp,ptp-clock = <&enet_ptp_clock>;
+				ptp-clock = <&enet_ptp_clock>;
 				phy-connection-type = "rmii";
 			};
 

--- a/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mm_a53.dtsi
@@ -275,7 +275,7 @@
 			interrupt-names = "COMMON";
 			interrupt-parent = <&gic>;
 			nxp,mdio = <&enet_mdio>;
-			nxp,ptp-clock = <&enet_ptp_clock>;
+			ptp-clock = <&enet_ptp_clock>;
 			status = "disabled";
 		};
 		enet_mdio: mdio {

--- a/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mn_a53.dtsi
@@ -276,7 +276,7 @@
 			interrupt-names = "COMMON";
 			interrupt-parent = <&gic>;
 			nxp,mdio = <&enet_mdio>;
-			nxp,ptp-clock = <&enet_ptp_clock>;
+			ptp-clock = <&enet_ptp_clock>;
 			status = "disabled";
 		};
 		enet_mdio: mdio {

--- a/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_mimx8mp_a53.dtsi
@@ -274,7 +274,7 @@
 				interrupt-names = "COMMON";
 				interrupt-parent = <&gic>;
 				nxp,mdio = <&enet_mdio>;
-				nxp,ptp-clock = <&enet_ptp_clock>;
+				ptp-clock = <&enet_ptp_clock>;
 				status = "disabled";
 			};
 			enet_mdio: mdio {

--- a/dts/arm64/nxp/nxp_mimx93_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx93_a55.dtsi
@@ -413,7 +413,7 @@
 			interrupt-names = "COMMON";
 			interrupt-parent = <&gic>;
 			nxp,mdio = <&enet_mdio>;
-			nxp,ptp-clock = <&enet_ptp_clock>;
+			ptp-clock = <&enet_ptp_clock>;
 			status = "disabled";
 		};
 		enet_mdio: mdio {

--- a/dts/bindings/ethernet/ethernet-controller.yaml
+++ b/dts/bindings/ethernet/ethernet-controller.yaml
@@ -38,3 +38,8 @@ properties:
       - "gmii"
       - "rgmii"
       - "internal"
+
+  ptp-clock:
+    type: phandle
+    description: |
+      Corresponding ptp clock device.

--- a/dts/bindings/ethernet/nxp,enet-mac.yaml
+++ b/dts/bindings/ethernet/nxp,enet-mac.yaml
@@ -17,12 +17,6 @@ properties:
     description: |
       Corresponding mdio device
 
-  nxp,ptp-clock:
-    type: phandle
-    required: true
-    description: |
-      Corresponding ptp clock device
-
   nxp,unique-mac:
     type: boolean
     description: |


### PR DESCRIPTION
This PR is to add PTP timestamping support for NXP NETC ENETC driver.
Also enabled PTP clock for i.MX943 EVK to verify gPTP stack. The test result was good.  Here was some log.

```
[00:00:00.086,000] <inf> nxp_imx_eth_psi: ENETC0 MAC: 00:04:9f:00:11:00
[00:00:00.086,000] <inf> nxp_imx_eth_psi: ENETC0 Link down
[00:00:00.087,000] <inf> nxp_imx_eth_psi: ENETC1 MAC: 00:04:9f:00:11:01
[00:00:00.087,000] <inf> nxp_imx_eth_psi: ENETC1 Link down
[00:00:00.088,000] <inf> nxp_imx_eth_psi: ENETC2 MAC: 00:04:9f:00:11:02
[00:00:00.088,000] <inf> nxp_imx_eth_psi: ENETC2 Link down
*** Booting Zephyr OS build v4.1.0-5886-gc7031b133e90 ***
[00:00:00.103,000] <inf> net_config: Initializing network
[00:00:00.103,000] <inf> net_config: Waiting interface 1 (0x8604fcb8) to be up...
[00:00:00.106,000] <wrn> net_if: iface 1 is down
[00:00:01.109,000] <wrn> net_gptp: Reset Pdelay requests
[00:00:01.113,000] <wrn> net_if: iface 1 is down
[00:00:02.114,000] <wrn> net_gptp: Reset Pdelay requests
[00:00:02.118,000] <wrn> net_if: iface 1 is down
[00:00:02.518,000] <inf> phy_rt_rtl8211f: PHY 5 is up
[00:00:02.519,000] <inf> phy_rt_rtl8211f: PHY (5) Link speed 1000 Mb, full duplex
[00:00:02.519,000] <inf> nxp_imx_eth_psi: ENETC0 Link up
[00:00:02.526,000] <inf> net_config: Interface 1 (0x8604fcb8) coming up
[00:00:02.530,000] <inf> net_config: IPv4 address: 192.0.2.1
[00:00:02.639,000] <inf> net_config: IPv6 address: 2001:db8::1
[00:00:03.120,000] <wrn> net_gptp: Reset Pdelay requests
[00:00:06.116,000] <inf> net_gptp: Set local clock 3.778215417
[00:00:06.117,000] <dbg> net_gptp_sample: gptp_phase_dis_cb: GM FA:FA:62:FF:FE:FE:A2:11 last phase 0.0
[00:00:07.215,000] <inf> net_gptp: sync offset    273892 ns, freq offset 273892.000000 ppb
[00:00:08.208,000] <inf> net_gptp: sync offset    -77641 ns, freq offset 4526.600000 ppb
[00:00:09.204,000] <inf> net_gptp: sync offset    -97058 ns, freq offset -38182.700000 ppb
[00:00:10.200,000] <inf> net_gptp: sync offset    -61385 ns, freq offset -31627.100000 ppb
[00:00:11.197,000] <inf> net_gptp: sync offset    -33722 ns, freq offset -22379.600000 ppb
[00:00:12.192,000] <inf> net_gptp: sync offset    -17594 ns, freq offset -16368.200000 ppb
[00:00:13.188,000] <inf> net_gptp: sync offset     -8998 ns, freq offset -13050.400000 ppb
[00:00:14.185,000] <inf> net_gptp: sync offset     -4571 ns, freq offset -11322.800000 ppb
[00:00:15.180,000] <inf> net_gptp: sync offset     -2304 ns, freq offset -10427.100000 ppb
[00:00:16.176,000] <inf> net_gptp: sync offset     -1167 ns, freq offset -9981.300000 ppb
[00:00:17.174,000] <inf> net_gptp: sync offset      -581 ns, freq offset -9745.400000 ppb
[00:00:18.269,000] <inf> net_gptp: sync offset      -250 ns, freq offset -9588.700000 ppb
[00:00:19.264,000] <inf> net_gptp: sync offset      -153 ns, freq offset -9566.700000 ppb
[00:00:20.260,000] <inf> net_gptp: sync offset       -60 ns, freq offset -9519.600000 ppb
[00:00:21.255,000] <inf> net_gptp: sync offset       -36 ns, freq offset -9513.600000 ppb
[00:00:22.253,000] <inf> net_gptp: sync offset       -15 ns, freq offset -9503.400000 ppb
[00:00:23.247,000] <inf> net_gptp: sync offset        -1 ns, freq offset -9493.900000 ppb
[00:00:24.244,000] <inf> net_gptp: sync offset         1 ns, freq offset -9492.200000 ppb
[00:00:25.238,000] <inf> net_gptp: sync offset         0 ns, freq offset -9492.900000 ppb
[00:00:26.236,000] <inf> net_gptp: sync offset        11 ns, freq offset -9481.900000 ppb
[00:00:27.230,000] <inf> net_gptp: sync offset        16 ns, freq offset -9473.600000 ppb
[00:00:28.227,000] <inf> net_gptp: sync offset         9 ns, freq offset -9475.800000 ppb
[00:00:29.222,000] <inf> net_gptp: sync offset        24 ns, freq offset -9458.100000 ppb
[00:00:30.219,000] <inf> net_gptp: sync offset         5 ns, freq offset -9469.900000 ppb
[00:00:31.214,000] <inf> net_gptp: sync offset        18 ns, freq offset -9455.400000 ppb
[00:00:32.214,000] <inf> net_gptp: sync offset         7 ns, freq offset -9461.000000 ppb
[00:00:33.305,000] <inf> net_gptp: sync offset        17 ns, freq offset -9448.900000 ppb
[00:00:34.301,000] <inf> net_gptp: sync offset        16 ns, freq offset -9444.800000 ppb
[00:00:35.297,000] <inf> net_gptp: sync offset        21 ns, freq offset -9435.000000 ppb
[00:00:36.293,000] <inf> net_gptp: sync offset        11 ns, freq offset -9438.700000 ppb
[00:00:37.289,000] <inf> net_gptp: sync offset         2 ns, freq offset -9444.400000 ppb
[00:00:38.284,000] <inf> net_gptp: sync offset        -1 ns, freq offset -9446.800000 ppb
[00:00:39.280,000] <inf> net_gptp: sync offset        13 ns, freq offset -9433.100000 ppb
[00:00:40.276,000] <inf> net_gptp: sync offset        20 ns, freq offset -9422.200000 ppb
[00:00:41.272,000] <inf> net_gptp: sync offset         6 ns, freq offset -9430.200000 ppb
[00:00:42.267,000] <inf> net_gptp: sync offset        19 ns, freq offset -9415.400000 ppb
[00:00:43.263,000] <inf> net_gptp: sync offset        -5 ns, freq offset -9433.700000 ppb
[00:00:44.260,000] <inf> net_gptp: sync offset        20 ns, freq offset -9410.200000 ppb
[00:00:45.255,000] <inf> net_gptp: sync offset        13 ns, freq offset -9411.200000 ppb
[00:00:46.252,000] <inf> net_gptp: sync offset        15 ns, freq offset -9405.300000 ppb
[00:00:47.347,000] <inf> net_gptp: sync offset        15 ns, freq offset -9400.800000 ppb
[00:00:48.342,000] <inf> net_gptp: sync offset         9 ns, freq offset -9402.300000 ppb
[00:00:49.339,000] <inf> net_gptp: sync offset        19 ns, freq offset -9389.600000 ppb
[00:00:50.334,000] <inf> net_gptp: sync offset         4 ns, freq offset -9398.900000 ppb

```


Thanks.