### PR TITLE
drivers: mdio: adin2111: move lock in read/write functions

### DIFF
--- a/drivers/mdio/mdio_adin2111.c
+++ b/drivers/mdio/mdio_adin2111.c
@@ -173,27 +173,11 @@ static int mdio_adin2111_write(const struct device *dev, uint8_t prtad,
 	return ret;
 }
 
-static void mdio_adin2111_bus_enable(const struct device *dev)
-{
-	const struct mdio_adin2111_config *const cfg = dev->config;
-
-	eth_adin2111_lock(cfg->adin, K_FOREVER);
-}
-
-static void mdio_adin2111_bus_disable(const struct device *dev)
-{
-	const struct mdio_adin2111_config *const cfg = dev->config;
-
-	eth_adin2111_unlock(cfg->adin);
-}
-
 static DEVICE_API(mdio, mdio_adin2111_api) = {
 	.read = mdio_adin2111_read,
 	.write = mdio_adin2111_write,
 	.read_c45 = mdio_adin2111_read_c45,
 	.write_c45 = mdio_adin2111_write_c45,
-	.bus_enable = mdio_adin2111_bus_enable,
-	.bus_disable = mdio_adin2111_bus_disable
 };
 
 #define ADIN2111_MDIO_INIT(n)							\

--- a/include/zephyr/drivers/ethernet/eth_adin2111.h
+++ b/include/zephyr/drivers/ethernet/eth_adin2111.h
@@ -43,8 +43,7 @@ int eth_adin2111_unlock(const struct device *dev);
 /**
  * @brief Writes host MAC interface register over SPI
  *
- * @note The caller is responsible for device lock.
- *       Shall not be called from ISR.
+ * @note Shall not be called from ISR.
  *
  * @param[in] dev ADIN2111 device.
  * @param reg Register address.
@@ -58,8 +57,7 @@ int eth_adin2111_reg_write(const struct device *dev, const uint16_t reg, uint32_
 /**
  * @brief Reads host MAC interface register over SPI
  *
- * @note The caller is responsible for device lock.
- *       Shall not be called from ISR.
+ * @note Shall not be called from ISR.
  *
  * @param[in] dev ADIN2111 device.
  * @param reg Register address.
@@ -73,8 +71,7 @@ int eth_adin2111_reg_read(const struct device *dev, const uint16_t reg, uint32_t
 /**
  * @brief Update host MAC interface register over SPI
  *
- * @note The caller is responsible for device lock.
- *       Shall not be called from ISR.
+ * @note Shall not be called from ISR.
  *
  * @param[in] dev ADIN2111 device.
  * @param reg Register address.


### PR DESCRIPTION
move lock in read/write functions as it
also locks the ethernet mac, which should
only be done when needed and automaticly.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>