### PR TITLE
tracing: Allow disabling idle traces

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -356,6 +356,12 @@ config TRACING_GPIO
 	help
 	  Enable tracing GPIO.
 
+config TRACING_IDLE
+	bool "Tracing Idle"
+	default y
+	help
+	  Enable tracing Idle state.
+
 endmenu  # Tracing Configuration
 
 endif

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -189,7 +189,9 @@ void sys_trace_isr_exit_to_scheduler(void)
 
 void sys_trace_idle(void)
 {
+#ifdef CONFIG_TRACING_IDLE
 	ctf_top_idle();
+#endif
 	if (IS_ENABLED(CONFIG_CPU_LOAD)) {
 		cpu_load_on_enter_idle();
 	}

--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -64,7 +64,9 @@ void sys_trace_isr_exit_to_scheduler(void)
 
 void sys_trace_idle(void)
 {
+#ifdef CONFIG_TRACING_IDLE
 	SEGGER_SYSVIEW_OnIdle();
+#endif
 
 	if (IS_ENABLED(CONFIG_CPU_LOAD)) {
 		cpu_load_on_enter_idle();

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -201,12 +201,16 @@ void sys_trace_isr_exit_to_scheduler(void)
 
 void sys_trace_idle(void)
 {
+#ifdef CONFIG_TRACING_IDLE
 	TRACING_STRING("%s\n", __func__);
+#endif
 }
 
 void sys_trace_idle_exit(void)
 {
+#ifdef CONFIG_TRACING_IDLE
 	TRACING_STRING("%s\n", __func__);
+#endif
 }
 
 void sys_trace_k_condvar_broadcast_enter(struct k_condvar *condvar)


### PR DESCRIPTION
This PR adds the possibility of turning off/on the idle traces the same way you can turn off/on other traces. The idle traces can be a bit too verbose, which can clog the tracing ring buffer, leading to some traces not showing up.