### PR TITLE
doc: _templates: show correct version in sidebar in case of releases

### DIFF
--- a/doc/_templates/zversions.html
+++ b/doc/_templates/zversions.html
@@ -2,7 +2,7 @@
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
       <span class="fa fa-book"> Zephyr Project</span>
-      v: latest
+      v: {{ current_version if is_release else "latest" }}
       <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">


### PR DESCRIPTION
Ensure that version indicator in sidebar is correct in case of releases.

Fixes zephyrproject-rtos/zephyr#91799.

Backporting this commit on e.g. 4.1 will give the following:

<img width="323" alt="image" src="https://github.com/user-attachments/assets/fa348120-4c12-48c4-b89e-fbfadef1f431" />