### PR TITLE
treewide: fix missing use of underscores

### DIFF
--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -138,7 +138,7 @@ zephyr_uhc1: &usbhhs {
 	pinctrl-0 = <&pinmux_usbhhs>;
 	pinctrl-names = "default";
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 &usbphy1 {

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69_lpc55s69_cpu0.dts
@@ -165,7 +165,7 @@ zephyr_uhc1: &usbhhs {
 	pinctrl-0 = <&pinmux_usbhhs>;
 	pinctrl-names = "default";
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 &usbphy1 {

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -213,12 +213,12 @@ zephyr_udc0: &usb1 {
 
 zephyr_uhc0: &usbh1 {
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 zephyr_uhc1: &usbh2 {
 	status = "okay";
-	phy_handle = <&usbphy2>;
+	phy-handle = <&usbphy2>;
 };
 
 &usbphy1 {

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -190,12 +190,12 @@ zephyr_udc0: &usb1 {
 
 zephyr_uhc0: &usbh1 {
 	status = "okay";
-	phy_handle = <&usbphy1>;
+	phy-handle = <&usbphy1>;
 };
 
 zephyr_uhc1: &usbh2 {
 	status = "okay";
-	phy_handle = <&usbphy2>;
+	phy-handle = <&usbphy2>;
 };
 
 &usbphy1 {

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -102,7 +102,7 @@ Devicetree
 
 * Property names in devicetree and bindings use hyphens(``-``) as separators, and replacing
   all previously used underscores(``_``). For local code, you can migrate property names in
-  bindings to use hyphens by running the ``scripts/migrate_bindings_style.py`` script.
+  bindings to use hyphens by running the ``scripts/utils/migrate_bindings_style.py`` script.
 
 
 DAI

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -326,7 +326,7 @@
 			interrupt-names = "pwm";
 			clocks = <&clock0 SIWX91X_CLK_PWM>;
 			#pwm-cells = <2>;
-			silabs,ch_prescaler = <64 64 64 64>;
+			silabs,ch-prescaler = <64 64 64 64>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/display/solomon,ssd1309fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1309fb-spi.yaml
@@ -8,7 +8,7 @@ compatible: "solomon,ssd1309fb"
 include: ["solomon,ssd1306fb-common.yaml", "spi-device.yaml"]
 
 properties:
-  data_cmd-gpios:
+  data-cmd-gpios:
     type: phandle-array
     required: true
     description: D/C# pin.

--- a/dts/bindings/led/ti,lp50xx.yaml
+++ b/dts/bindings/led/ti,lp50xx.yaml
@@ -12,7 +12,7 @@ properties:
     type: boolean
     description: |
       If enabled the maximum current output is set to 35 mA (25.5 mA else).
-  log_scale_en:
+  log-scale-en:
     type: boolean
     description: |
       If enabled a logarithmic dimming scale curve is used for LED brightness

--- a/dts/bindings/pwm/silabs,siwx91x-pwm.yaml
+++ b/dts/bindings/pwm/silabs,siwx91x-pwm.yaml
@@ -12,7 +12,7 @@ properties:
   "#pwm-cells":
     const: 2
 
-  silabs,ch_prescaler:
+  silabs,ch-prescaler:
     type: array
     required: true
     description: |
@@ -26,7 +26,7 @@ properties:
       - 32
       - 64
 
-  silabs,pwm_polarity:
+  silabs,pwm-polarity:
     type: int
     required: true
     description: |

--- a/dts/bindings/usb/nxp,uhc-ehci.yaml
+++ b/dts/bindings/usb/nxp,uhc-ehci.yaml
@@ -8,5 +8,5 @@ compatible: "nxp,uhc-ehci"
 include: [usb-controller.yaml]
 
 properties:
-  phy_handle:
+  phy-handle:
     type: phandle

--- a/dts/bindings/usb/nxp,uhc-ip3516hs.yaml
+++ b/dts/bindings/usb/nxp,uhc-ip3516hs.yaml
@@ -8,5 +8,5 @@ compatible: "nxp,uhc-ip3516hs"
 include: [usb-controller.yaml, pinctrl-device.yaml]
 
 properties:
-  phy_handle:
+  phy-handle:
     type: phandle

--- a/dts/bindings/watchdog/nxp,ewm.yaml
+++ b/dts/bindings/watchdog/nxp,ewm.yaml
@@ -19,13 +19,13 @@ properties:
     description: Watchdog clock divider
     required: true
 
-  input_trigger_en:
+  input-trigger-en:
     type: boolean
     description: |
       When enabled the ewm_in signal can be used
       to assert the ewm.
 
-  input_trigger_active_high:
+  input-trigger-active-high:
     type: boolean
     description: |
       When enabled the ewm_in signal is active high.

--- a/scripts/utils/migrate_bindings_style.py
+++ b/scripts/utils/migrate_bindings_style.py
@@ -17,7 +17,7 @@ import yaml
 # bindings base
 BINDINGS_PATH = [Path("dts/bindings/")]
 BINDINGS_PROPERTIES_AL = None
-with open(Path(__file__).parent / 'bindings_properties_allowlist.yaml') as f:
+with open(Path(__file__).parents[1] / 'bindings_properties_allowlist.yaml') as f:
     allowlist = yaml.safe_load(f.read())
     if allowlist is not None:
         BINDINGS_PROPERTIES_AL = set(allowlist)

--- a/tests/drivers/pwm/pwm_api/boards/siwx917_rb4338a.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/siwx917_rb4338a.overlay
@@ -26,6 +26,6 @@
 	pwm_channel1: pwm_channel1 {
 		pwms = <&pwm 0 1000000>;
 	};
-	silabs,pwm_polarity = <PWM_POLARITY_NORMAL>;
+	silabs,pwm-polarity = <PWM_POLARITY_NORMAL>;
 	status = "okay";
 };


### PR DESCRIPTION
in  https://github.com/zephyrproject-rtos/zephyr/pull/83352 a few bindings were not migrated,
fix that, as it will lead to ci fails.

CI fails here f.e. https://github.com/zephyrproject-rtos/zephyr/actions/runs/15729004034/job/44325466927?pr=91572