### PR TITLE
drivers: video: fix NULL dereference in mipid02_get_fmt

### DIFF
--- a/drivers/video/video_st_mipid02.c
+++ b/drivers/video/video_st_mipid02.c
@@ -189,7 +189,7 @@ static int mipid02_get_fmt(const struct device *dev, struct video_format *fmt)
 		}
 
 		desc = mipid02_get_format_desc(fmt->pixelformat);
-		if (desc) {
+		if (desc == NULL) {
 			LOG_ERR("Sensor format not supported by the ST-MIPID02");
 			return -EIO;
 		}


### PR DESCRIPTION
Category: Null pointer dereference (CWE-476)

Corrects the logic that validates the result of mipid04_get_format_desc(). Previously, the check was inverted, which could lead to a NULL pointer dereference when accessing desc->pixelformat.

Fixes Coverity CID: 525183