### PR TITLE
iar: linker_script: fix bug with alphabetical order

### DIFF
--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -815,7 +815,12 @@ function(section_to_string)
       string(REGEX REPLACE "(block[ \t\r\n]+)([^ \t\r\n]+)" "\\1\\2_init" INIT_TEMP "${TEMP}")
       string(REGEX REPLACE "(rw)([ \t\r\n]+)(section[ \t\r\n]+)([^ \t\r\n,]+)" "\\1\\2\\3\\4_init" INIT_TEMP "${INIT_TEMP}")
       string(REGEX REPLACE "(rw)([ \t\r\n]+)(section[ \t\r\n]+)" "ro\\2\\3" INIT_TEMP "${INIT_TEMP}")
-      string(REGEX REPLACE "alphabetical order, " "" INIT_TEMP "${INIT_TEMP}")
+
+      # No alphabetical orders on initializers
+      # Only alphabetical attribute.
+      string(REGEX REPLACE "with alphabetical order {" " {" INIT_TEMP "${INIT_TEMP}")
+      # Respect other attributes.
+      string(REGEX REPLACE "(, alphabetical order|alphabetical order, )" "" INIT_TEMP "${INIT_TEMP}")
       string(REGEX REPLACE "{ readwrite }" "{ }" INIT_TEMP "${INIT_TEMP}")
       set(TEMP "${TEMP}\n${INIT_TEMP}\n")
 


### PR DESCRIPTION
ff8b24b6bd172bd0d374816395f31b02058830e6 triggered a bug in the IAR linker script generator. 
Causing linking failure in most cases for IAR.

Having alphabetical order on an init block causes a linker error. So it is one of the things replaced when translating a block to its corresponding init block.
The recent changes in ff8b24b6bd172bd0d374816395f31b02058830e6 caused iterable sections having ONLY alphabetical order as an attribute, triggering a bug in this regexp.