### PR TITLE
drivers: adc: esp32: check reference at compile time

### DIFF
--- a/drivers/adc/adc_esp32.c
+++ b/drivers/adc/adc_esp32.c
@@ -751,7 +751,13 @@ static DEVICE_API(adc, api_esp32_driver_api) = {
 
 #endif /* defined(CONFIG_ADC_ESP32_DMA) */
 
+#define ADC_ESP32_CHECK_CHANNEL_REF(chan)                                                          \
+	BUILD_ASSERT(DT_ENUM_HAS_VALUE(chan, zephyr_reference, adc_ref_internal),                  \
+		     "adc_esp32 only supports ADC_REF_INTERNAL as a reference");
+
 #define ESP32_ADC_INIT(inst)                                                                       \
+                                                                                                   \
+	DT_INST_FOREACH_CHILD(inst, ADC_ESP32_CHECK_CHANNEL_REF)                                   \
                                                                                                    \
 	static const struct adc_esp32_conf adc_esp32_conf_##inst = {                               \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst)),                             \


### PR DESCRIPTION
Currently, only ADC_REF_INTERNAL is supported as a reference in the adc-esp32 driver. The earliest check is at runtime through the log. This commit moves the check at compile time through device tree instance checks in the driver. 
This was implemented as a device tree binding check in #91772, but @maass-hamburg suggested to do it in the driver using device tree checks, which is the reason I'm making this PR.