### PR TITLE
Improve gpio driver for Renesas RZ/A2M

### DIFF
--- a/drivers/gpio/gpio_renesas_rza2m.c
+++ b/drivers/gpio/gpio_renesas_rza2m.c
@@ -320,43 +320,30 @@ static int gpio_rza2m_pin_configure(const struct device *port_dev, gpio_pin_t pi
 		return -ENOTSUP;
 	}
 
-	/* Configure pin direction */
-	if (flags & GPIO_OUTPUT) {
-		gpio_rza2m_pin_configure_as_gpio(port_dev, pin, RZA2M_PDR_OUTPUT);
-	} else if (flags & GPIO_INPUT) {
-		gpio_rza2m_pin_configure_as_gpio(port_dev, pin, RZA2M_PDR_INPUT);
-	} else {
-		return -ENOTSUP;
-	}
-
-	/* Configure pin drive strength */
-	ret = gpio_rza2m_pin_drive_set(port_dev, pin, flags);
-	if (ret) {
-		LOG_ERR("unable to set gpio drive level");
-		return ret;
-	}
-
-	/* Configure pin initial value */
-	if (flags & GPIO_OUTPUT_INIT_HIGH) {
-		ret = gpio_rza2m_port_set_bits_raw(port_dev, BIT(pin));
-	} else if (flags & GPIO_OUTPUT_INIT_LOW) {
-		ret = gpio_rza2m_port_clear_bits_raw(port_dev, BIT(pin));
-	}
-
-	/* Configure pin interrupt */
-	if (flags & GPIO_INT_ENABLE) {
-		if (flags & GPIO_INT_LOW_0) {
-			return -ENOTSUP;
+	if (!flags) {
+		/* Disconnected mode */
+		gpio_rza2m_pin_configure_as_gpio(port_dev, pin, RZA2M_PDR_HIZ);
+	} else if (!(flags & GPIO_OPEN_DRAIN)) {
+		/* Configure pin direction */
+		if (flags & GPIO_OUTPUT) {
+			gpio_rza2m_pin_configure_as_gpio(port_dev, pin, RZA2M_PDR_OUTPUT);
+		} else if (flags & GPIO_INPUT) {
+			gpio_rza2m_pin_configure_as_gpio(port_dev, pin, RZA2M_PDR_INPUT);
 		}
 
-		enum gpio_int_mode mode =
-			(flags & GPIO_INT_EDGE) ? GPIO_INT_MODE_EDGE : GPIO_INT_MODE_LEVEL;
-		enum gpio_int_trig trig = GPIO_INT_TRIG_HIGH;
+		/* Configure pin drive strength */
+		ret = gpio_rza2m_pin_drive_set(port_dev, pin, flags);
+		if (ret) {
+			LOG_ERR("unable to set gpio drive level");
+			return ret;
+		}
 
-		ret = gpio_rza2m_pin_interrupt_configure(port_dev, pin, mode, trig);
-	} else if (flags & GPIO_INT_DISABLE) {
-		ret = gpio_rza2m_pin_interrupt_configure(port_dev, pin, GPIO_INT_MODE_DISABLED,
-							 GPIO_INT_TRIG_HIGH);
+		/* Configure pin initial value */
+		if (flags & GPIO_OUTPUT_INIT_HIGH) {
+			ret = gpio_rza2m_port_set_bits_raw(port_dev, BIT(pin));
+		} else if (flags & GPIO_OUTPUT_INIT_LOW) {
+			ret = gpio_rza2m_port_clear_bits_raw(port_dev, BIT(pin));
+		}
 	}
 
 	return ret;

--- a/drivers/gpio/gpio_renesas_rza2m.h
+++ b/drivers/gpio/gpio_renesas_rza2m.h
@@ -31,6 +31,7 @@
 #define RZA2M_GPIO_DRIVE_STRENGTH_NORMAL 0x01
 #define RZA2M_DSCR_MASK                  0x03
 #define RZA2M_PDR_MASK                   0x03
+#define RZA2M_PDR_HIZ                    0x00
 #define RZA2M_PDR_INPUT                  0x02
 #define RZA2M_PDR_OUTPUT                 0x03
 #define RZA2M_PWPR_PFSWE_MASK            0x40


### PR DESCRIPTION
After the https://github.com/zephyrproject-rtos/zephyr/pull/89878/ merged, the `gpio_basic_api` test is failing, so this PR is to fix and improve the RZ/A2M GPIO driver:
- Adding support for `GPIO_DISCONNECTED` mode.
- Removing redundant interrupt configuration logic from the `.pin_configure` API (already handled in `pin_interrupt_configure`).

Fail test case in `gpio_basic_api` test:
```
START - test_gpio_config_trigger
NOTE: cannot configure pin as disconnected; trying as input
    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c:93: after_flash_gpio_config_trigger_test_gpio_config_trigger: (ret is non-zero)
config PIN_OUT failed
 FAIL - test_gpio_config_trigger in 0.026 seconds
START - test_gpio_config_twice_trigger
NOTE: cannot configure pin as disconnected; trying as input
    Assertion failed at WEST_TOPDIR/zephyr/tests/drivers/gpio/gpio_basic_api/src/test_config_trigger.c:37: after_flash_gpio_config_trigger_test_gpio_config_twice_trigger: (ret is non-zero)
config PIN_OUT failed
 FAIL - test_gpio_config_twice_trigger in 0.027 seconds
... 
SUITE FAIL -   0.00% [after_flash_gpio_config_trigger]: pass = 0, fail = 2, skip = 0, total = 2 duration = 0.053 seconds
 - FAIL - [after_flash_gpio_config_trigger.test_gpio_config_trigger] duration = 0.026 seconds
 - FAIL - [after_flash_gpio_config_trigger.test_gpio_config_twice_trigger] duration = 0.027 seconds
```
