### PR TITLE
drivers: wifi: nxp: only enable NXP_WIFI_TC_RELOCATE for RW612

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -1055,7 +1055,7 @@ config NXP_WIFI_OWE
 
 config NXP_WIFI_TC_RELOCATE
 	bool "Traffic api relocate to RAM"
-	default y
+	default y if NXP_RW610
 	help
 	  Relocate Wi-Fi transmit and receive api to RAM to increase
 	  traffic throughput.


### PR DESCRIPTION
Only by default enable NXP_WIFI_TC_RELOCATE for RW612, which will relocate traffic API into RAM. But for other platform, for example the RT series, the ITCM/DTCM is a more suitable place for critical code.