### PR TITLE
drivers: i2c: ii2c: fix hang on addressing with nak return

### DIFF
--- a/drivers/i2c/i2c_nxp_ii2c.c
+++ b/drivers/i2c/i2c_nxp_ii2c.c
@@ -207,7 +207,6 @@ static int nxp_ii2c_transfer(const struct device *dev, struct i2c_msg *msgs,
 		 * successfully. e.g., nak, timeout, lost arbitration
 		 */
 		if (data->callback_status != kStatus_Success) {
-			I2C_MasterTransferAbort(base, &data->handle);
 			ret = -EIO;
 			break;
 		}


### PR DESCRIPTION
The NXP ii2c driver has a problem at the moment: if addressing a device that is not on the bus, defective or in general not answering on its address, the driver hangs because it tries to actiuvely wait for a flag that will never be set in this context.

To fix this behavior I propose to remove the call to `I2C_MasterTransferAbort()` on abortion because of a received ``nak``.
This is because everything that needs to be done in such a case is already done inside the ``I2C_MasterTransferHandleIRQ`` function.

Zephyr uses the `fsl_ii2c` driver only in interrupt mode, so the IRQ function will be used.

More information an the process of detecting of this bug can be found in PR #87137.

I tested the fix with a phyBOARD Pollux and the NXP i.MX8MP EVK Board.