### PR TITLE
subsys/tracing: do not select (RTT_)CONSOLE in SEGGER_SYSTEMVIEW

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -41,8 +41,6 @@ config PERCEPIO_TRACERECORDER
 
 config SEGGER_SYSTEMVIEW
 	bool "Segger SystemView support"
-	select CONSOLE
-	select RTT_CONSOLE
 	select USE_SEGGER_RTT
 	select THREAD_MONITOR
 	select SEGGER_RTT_CUSTOM_LOCKING


### PR DESCRIPTION
Tracing using Segger's SystemView works fine without enabling RTT_CONSOLE (or CONSOLE, in general).
SEGGER_SYSTEMVIEW was automatically selecting RTT_CONSOLE, which prevents applications from using another console backend (e.g. UART_CONSOLE).

My application uses `UART_CONSOLE` (routed to the USB serial port using snippet `cdc-acm-console`) and `LOG_BACKEND_RTT`.
Thus, `printk()` statements go to the USB serial port and log output to the RTT console.
When enabling tracing with Segger's SystemView using snippet `rtt-tracing`, the snippet enables `RTT_CONSOLE`,
which in turn enables `LOG_BACKEND_RTT_FORCE_PRINTK`, which selects `LOG_PRINTK`.
This routes `printk()` output to the logging system, which I don't want.
As `RTT_CONSOLE` isn't needed to use SystemView, I have removed the dependency in subsys\tracing\Kconfig.

Tested using
`west build samples\philosophers -S rtt-tracing` (UART console)
and
`west build samples\philosophers -S rtt-tracing -- -DCONFIG_CONSOLE=n -DCONFIG_UART_CONSOLE=n` (no console)
