### PR TITLE
drivers: spi_rtio: Fix potential null pointer dereference

### DIFF
--- a/drivers/spi/spi_rtio.c
+++ b/drivers/spi/spi_rtio.c
@@ -192,7 +192,7 @@ int spi_rtio_copy(struct rtio *r,
 		rx_len = rx_bufs->buffers[rx].len;
 	} else {
 		rx_buf = NULL;
-		rx_len = tx_bufs->buffers[tx].len;
+		rx_len = (tx_bufs != NULL && tx < tx_count) ? tx_bufs->buffers[tx].len : 0;
 	}
 
 


### PR DESCRIPTION
Avoid accessing tx_bufs or rx_bufs when they are NULL by adding proper conditional checks before dereferencing. This addresses Coverity issue

CID 516225 (CWE-476).