### PR TITLE
drivers: sensors: fxls8974: fix compilation error in fxls8974_transceive

### DIFF
--- a/drivers/sensor/nxp/fxls8974/fxls8974.c
+++ b/drivers/sensor/nxp/fxls8974/fxls8974.c
@@ -25,7 +25,7 @@ int fxls8974_transceive(const struct device *dev,
 {
 		const struct fxls8974_config *cfg = dev->config;
 		const struct spi_buf buf = { .buf = data, .len = length };
-		const struct spi_buf_set s = { .bufs = &buf, .count = 1 };
+		const struct spi_buf_set s = { .buffers = &buf, .count = 1 };
 
 		return spi_transceive_dt(&cfg->bus_cfg.spi, &s, &s);
 }
@@ -43,8 +43,8 @@ int fxls8974_read_spi(const struct device *dev,
 				{ .buf = reg_buf, .len = 3 },
 				{ .buf = data, .len = length }
 		};
-		const struct spi_buf_set tx = { .bufs = buf, .count = 1 };
-		const struct spi_buf_set rx = { .bufs = buf, .count = 2 };
+		const struct spi_buf_set tx = { .buffers = buf, .count = 1 };
+		const struct spi_buf_set rx = { .buffers = buf, .count = 2 };
 
 		return spi_transceive_dt(&cfg->bus_cfg.spi, &tx, &rx);
 }

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -441,3 +441,12 @@ test_spi_ad2s1210: ad2s1210@35 {
 	reset-gpios = <&test_gpio 7 (GPIO_ACTIVE_LOW)>;
 	clock-frequency = <8192000>;
 };
+
+test_spi_fxls8974: fxls8974@36 {
+	compatible = "nxp,fxls8974";
+	reg = <0x36>;
+	spi-max-frequency = <0>;
+	reset-gpios = <&test_gpio 0 0>;
+	int1-gpios = <&test_gpio 0 0>;
+	int2-gpios = <&test_gpio 0 0>;
+};


### PR DESCRIPTION
SPI code wasn't tested in CI so this compilation error was missed.