### PR TITLE
cmake: llvm: Use '=' for --config to improve compatibility

### DIFF
--- a/cmake/toolchain/llvm/target.cmake
+++ b/cmake/toolchain/llvm/target.cmake
@@ -55,7 +55,5 @@ elseif(CONFIG_COMPILER_RT_RTLIB)
   set(runtime_lib "compiler_rt")
 endif()
 
-list(APPEND TOOLCHAIN_C_FLAGS --config
-	${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)
-list(APPEND TOOLCHAIN_LD_FLAGS --config
-	${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)
+list(APPEND TOOLCHAIN_C_FLAGS --config=${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)
+list(APPEND TOOLCHAIN_LD_FLAGS --config=${ZEPHYR_BASE}/cmake/toolchain/llvm/clang_${runtime_lib}.cfg)


### PR DESCRIPTION
This PR replaces the space with an equal sign when assigning the clang configuration file to the --config parameter.

This change improves compatibility with tools, such as CodeChecker, that parse the compilation database and expect compiler arguments to be separated by space.