### PR TITLE
boards: beagle: pocketbeagle_2: Add main_uart0 pinmux

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4-pinctrl.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4-pinctrl.dtsi
@@ -24,4 +24,11 @@
 		/* (E5) MCU_MCAN1_TX.MCU_GPIO0_15 */
 		pinmux = <K3_PINMUX(0x003c, PIN_INPUT, MUX_MODE_7)>;
 	};
+
+	main_uart0_pins_default: main-uart0-default-pins {
+		pinmux = <
+			K3_PINMUX(0x1c8, PIN_INPUT, MUX_MODE_0) /* (D14/A13) UART0_RXD */
+			K3_PINMUX(0x1cc, PIN_OUTPUT, MUX_MODE_0) /* (E14/E11) UART0_TXD */
+		>;
+	};
 };


### PR DESCRIPTION
- Add pinmux for main_uart0 (P1.30 and P1.32).
- This is the UART in techlab cape and is great for m4 development.