### PR TITLE
stm32: boards: st: nucleo_wba65ri: update arduino spi node

### DIFF
--- a/boards/st/nucleo_wba65ri/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wba65ri/arduino_r3_connector.dtsi
@@ -36,4 +36,4 @@
 };
 
 arduino_i2c: &i2c1 {};
-arduino_spi: &spi1 {};
+arduino_spi: &spi2 {};

--- a/boards/st/nucleo_wba65ri/doc/nucleo_wba65ri.rst
+++ b/boards/st/nucleo_wba65ri/doc/nucleo_wba65ri.rst
@@ -168,10 +168,10 @@ Default Zephyr Peripheral Mapping:
 - I2C_1_SDA : PB1
 - USER_PB : PC13
 - LD1 : PD8
-- SPI_1_NSS : PA12 (arduino_spi)
-- SPI_1_SCK : PB4 (arduino_spi)
-- SPI_1_MISO : PB3 (arduino_spi)
-- SPI_1_MOSI : PA15 (arduino_spi)
+- SPI_2_NSS : PB9 (arduino_spi)
+- SPI_2_SCK : PB10 (arduino_spi)
+- SPI_2_MISO : PA9 (arduino_spi)
+- SPI_2_MOSI : PC3 (arduino_spi)
 
 System Clock
 ------------

--- a/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
+++ b/boards/st/nucleo_wba65ri/nucleo_wba65ri.dts
@@ -123,9 +123,9 @@
 	status = "okay";
 };
 
-&spi1 {
-	pinctrl-0 = <&spi1_nss_pa12 &spi1_sck_pb4
-		     &spi1_miso_pb3 &spi1_mosi_pa15>;
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pb9 &spi2_sck_pb10
+		     &spi2_miso_pa9 &spi2_mosi_pc3>;
 	pinctrl-names = "default";
 	status = "okay";
 };


### PR DESCRIPTION
According to user manual UM3448 https://www.st.com/resource/en/user_manual/um3448-stm32wba-nucleo64-board-mb1801-and-mb2130-stmicroelectronics.pdf, SPI2 is connected to the ST Arduino header instead of SPI1.

This has been confirmed using the spi_loopback test driver.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/91743
