### PR TITLE
manifest: Update bsim to version v2.7 & nRF hw models to latest 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
       remote: babblesim
       repo-path: base
       path: tools/bsim/components
-      revision: d562cd57317d33531ee3655d84660c57b8dc64c9
+      revision: 2cfac3dca2071452ae481d115d8541880568753d
       groups:
         - babblesim
     - name: babblesim_ext_2G4_channel_NtNcable
@@ -79,7 +79,7 @@ manifest:
       remote: babblesim
       repo-path: ext_2G4_libPhyComv1
       path: tools/bsim/components/ext_2G4_libPhyComv1
-      revision: 15ae0f87fa049e04cbec48a866f3bc37d903f950
+      revision: e18e41e8e3fa9f996559ed98b9238a5702dcdd36
       groups:
         - babblesim
     - name: babblesim_ext_2G4_modem_BLE_simple
@@ -100,7 +100,7 @@ manifest:
       remote: babblesim
       repo-path: ext_2G4_phy_v1
       path: tools/bsim/components/ext_2G4_phy_v1
-      revision: dbfd6b068f3bde8e56dcea58b4e686a8efc01cbe
+      revision: 8964ed1eb94606c2ea555340907bdc5171793e65
       groups:
         - babblesim
     - name: babblesim_ext_libCryptov1
@@ -112,7 +112,7 @@ manifest:
         - babblesim
     - name: bsim
       repo-path: babblesim-manifest
-      revision: 193b8ba94cdc6ecbc3bb7fe80b87dee456e5eab0
+      revision: 2ba22a0608ad9f46da1b96ee5121af357053c791
       path: tools/bsim
       groups:
         - babblesim

--- a/west.yml
+++ b/west.yml
@@ -325,7 +325,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 9eb489fdcde23d4f69ded78bca872bfc31b5ee79
+      revision: 968d55ff22579080466bf2f482596dd6e35361c6
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 294314b8622bfa582f43b229504d42201e1a3443


### PR DESCRIPTION
    manifest: Update bsim to version v2.7
    
    Main changes since v2.6:
    * ext_2G4_phy_v1: Runtime performance optimizations
    * ext_2G4_libPhyComv1: Add BT LE HDT support
    * ext_2G4_channel_Indoorv1: Add BT LE HDT support
    
    Note: Like before, bsim remains fully backwards compatible

-------

    manifest: Update nRF hw models to latest
    
    Update the HW models module to:
    968d55ff22579080466bf2f482596dd6e35361c6
    
    Including the following:
    968d55f 54LM20: Also build CRACEN RNG
    2c6d49d CRACEN RNG: Add model of the new version of the IP
    914b475 54LM20: Add first version
    fb68cc6 grtc hal replacement: Remove pointless macro use
    ef2f63e Fix wrong NRF_UARTE register reference
    63a2e85 README: Clarify the models are not perfect, and correct links
    
