### PR TITLE
cmake: Add a new no_deprecation_warning compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,11 +159,17 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_str
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,no_strict_aliasing>>)
 
 # Extra warnings options for twister run
-if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
+if(CONFIG_COMPILER_WARNINGS_AS_ERRORS)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,warnings_as_errors>>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
+endif()
+
+if(CONFIG_DEPRECATION_TEST)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_deprecation_warning>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,no_deprecation_warning>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,no_deprecation_warning>>)
 endif()
 
 # @Intent: Set compiler flags to enable buffer overflow checks in libc functions

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -542,7 +542,6 @@ config LTO
 
 config COMPILER_WARNINGS_AS_ERRORS
 	bool "Treat warnings as errors"
-	depends on !DEPRECATION_TEST
 	help
 	  Turn on "warning as error" toolchain flags
 

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -76,6 +76,9 @@ set_compiler_property(PROPERTY no_strict_aliasing)
 set_property(TARGET compiler PROPERTY warnings_as_errors)
 set_property(TARGET asm PROPERTY warnings_as_errors)
 
+set_property(TARGET compiler PROPERTY no_deprecation_warning)
+set_property(TARGET asm PROPERTY no_deprecation_warning)
+
 # Flag for disabling exceptions in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -154,6 +154,10 @@ set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)
 set_property(TARGET compiler PROPERTY warnings_as_errors -Werror)
 set_property(TARGET asm PROPERTY warnings_as_errors -Werror -Wa,--fatal-warnings)
 
+# Deprecation warning
+set_property(TARGET compiler PROPERTY no_deprecation_warning -Wno-deprecated-declarations)
+set_property(TARGET asm PROPERTY no_deprecation_warning -Wno-deprecated-declarations)
+
 # Disable exceptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")
 

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -334,11 +334,13 @@ do {                                                                    \
 #define __WARN1(s) _Pragma(#s)
 
 /* Generic message */
-#ifndef __DEPRECATED_MACRO
+#ifndef CONFIG_DEPRECATION_TEST
 #define __DEPRECATED_MACRO __WARN("Macro is deprecated")
 /* When adding this, remember to follow the instructions in
  * https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated
  */
+#else
+#define __DEPRECATED_MACRO
 #endif
 
 /* These macros allow having ARM asm functions callable from thumb */

--- a/include/zephyr/toolchain/iar/iccarm.h
+++ b/include/zephyr/toolchain/iar/iccarm.h
@@ -243,9 +243,13 @@ do {                                                                    \
 #define __WARN1(s) __PRAGMA(message = #s)
 
 /* Generic message */
-#ifndef __DEPRECATED_MACRO
+#ifndef CONFIG_DEPRECATION_TEST
 #define __DEPRECATED_MACRO __WARN("Macro is deprecated")
+#else
+#define __DEPRECATED_MACRO
 #endif
+
+
 
 /* These macros allow having ARM asm functions callable from thumb */
 

--- a/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
+++ b/tests/kernel/pipe/deprecated/pipe/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-set(CMAKE_C_FLAGS "-D__deprecated=\"/* deprecated */\" -D__DEPRECATED_MACRO=\"/* deprecated_macro*/\"")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pipe)
 

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -8,11 +8,6 @@
  * about the use of that API.
  */
 #include <zephyr/toolchain.h>
-#undef __deprecated
-#define __deprecated
-#undef __DEPRECATED_MACRO
-#define __DEPRECATED_MACRO
-
 #include <zephyr/ztest.h>
 
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -10,11 +10,6 @@
  * about the use of that API.
  */
 #include <zephyr/toolchain.h>
-#undef __deprecated
-#define __deprecated
-#undef __DEPRECATED_MACRO
-#define __DEPRECATED_MACRO
-
 #include <zephyr/kernel.h>
 #include <zephyr/ztest.h>
 #include <zephyr/tc_util.h>


### PR DESCRIPTION
Commit be40d854c2ccacf14ca3fcfb01bffdc9b075c6c9 introduced the ability of building Zephyr with deprecation warnings enabled, by making COMPILER_WARNINGS_AS_ERRORS depend on the newly added DEPRECATION_TEST Kconfig option. This has the downside of disabling **all** warnings, not only the deprecation ones.

This patch instead makes DEPRECATION_TEST disable only the deprecation warning, but leaves COMPILER_WARNINGS_AS_ERRORS enabled. This has the advantage of being able to see other unrelated warnings (and fail if they appear) but has the disadvantage of not printing out the deprecation warnings themselves (since they are disabled).