### PR TITLE
soc: rockchip: rk35: update MMU region permissions for GIC entries

### DIFF
--- a/soc/rockchip/rk35/rk3568/mmu_regions.c
+++ b/soc/rockchip/rk35/rk3568/mmu_regions.c
@@ -14,12 +14,12 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 0),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 0),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_RW | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_RW | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
 };
 


### PR DESCRIPTION
Change the permissions for GIC MMU region entries from MT_P_RW_U_RW to MT_P_RW_U_NA to restrict user access.

This aligns with how it's done for all other rockchip socs