### PR TITLE
drivers: nxp: flexspi: fix hyper flash hang issue

### DIFF
--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk_mimxrt1052_hyperflash.dts
@@ -34,7 +34,7 @@
 		word-addressable;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;
-		cs-hold-time = <0>;
+		cs-hold-time = <3>;
 		cs-setup-time = <3>;
 		data-valid-time = <1>;
 		column-space = <3>;

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_hyperflash.dts
@@ -32,7 +32,7 @@
 		word-addressable;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;
-		cs-hold-time = <0>;
+		cs-hold-time = <3>;
 		cs-setup-time = <3>;
 		data-valid-time = <1>;
 		column-space = <3>;

--- a/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
+++ b/boards/nxp/mimxrt1062_fmurt6/mimxrt1062_fmurt6.dts
@@ -193,7 +193,7 @@
 		word-addressable;
 		cs-interval-unit = <1>;
 		cs-interval = <2>;
-		cs-hold-time = <0>;
+		cs-hold-time = <3>;
 		cs-setup-time = <3>;
 		data-valid-time = <1>;
 		column-space = <3>;

--- a/soc/nxp/imxrt/imxrt10xx/flexspi.c
+++ b/soc/nxp/imxrt/imxrt10xx/flexspi.c
@@ -11,13 +11,15 @@
 #include <zephyr/irq.h>
 #include <zephyr/dt-bindings/clock/imx_ccm.h>
 
+/* Use FlexSPi internal divider for clock modification.
+ * This function only updates the freq, but does not update DLL.
+ * Use function memc_flexspi_update_clock to update both of them.
+ */
 uint32_t flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate)
 {
 	uint8_t divider;
 	uint32_t root_rate;
 	FLEXSPI_Type *flexspi;
-	clock_div_t div_sel;
-	clock_ip_name_t clk_name;
 
 	switch (clock_name) {
 	case IMX_CCM_FLEXSPI_CLK:
@@ -25,8 +27,6 @@ uint32_t flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate)
 		root_rate = CLOCK_GetClockRootFreq(kCLOCK_FlexspiClkRoot) *
 					(CLOCK_GetDiv(kCLOCK_FlexspiDiv) + 1);
 		flexspi = (FLEXSPI_Type *)DT_REG_ADDR(DT_NODELABEL(flexspi));
-		div_sel = kCLOCK_FlexspiDiv;
-		clk_name = kCLOCK_FlexSpi;
 		break;
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexspi2))
 	case IMX_CCM_FLEXSPI2_CLK:
@@ -34,13 +34,12 @@ uint32_t flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate)
 		root_rate = CLOCK_GetClockRootFreq(kCLOCK_Flexspi2ClkRoot) *
 					(CLOCK_GetDiv(kCLOCK_Flexspi2Div) + 1);
 		flexspi = (FLEXSPI_Type *)DT_REG_ADDR(DT_NODELABEL(flexspi2));
-		div_sel = kCLOCK_Flexspi2Div;
-		clk_name = kCLOCK_FlexSpi2;
 		break;
 #endif
 	default:
 		return -ENOTSUP;
 	}
+
 	/* Select a divider based on root frequency.
 	 * if we can't get an exact divider, round down
 	 */
@@ -52,13 +51,9 @@ uint32_t flexspi_clock_set_freq(uint32_t clock_name, uint32_t rate)
 		/* Spin */
 	}
 	FLEXSPI_Enable(flexspi, false);
-
-	CLOCK_DisableClock(clk_name);
-
-	CLOCK_SetDiv(div_sel, divider);
-
-	CLOCK_EnableClock(clk_name);
-
+	/* Update the internal divider*/
+	flexspi->MCR0 &= ~FLEXSPI_MCR0_SERCLKDIV_MASK;
+	flexspi->MCR0 |= FLEXSPI_MCR0_SERCLKDIV(divider);
 	FLEXSPI_Enable(flexspi, true);
 
 	FLEXSPI_SoftwareReset(flexspi);


### PR DESCRIPTION
CS hold time parameter is not correct which may cause bus fault randomly.
System hang during status register reading after flash progromming which is caused by parameter accessing in XIP mode.
Add dummy delay for READ command according the flash datasheet which is required for SDR mode.
Use FlexSPI internal divider for clock updating instead of register in CCM to avoid potential risk caused by flash access during clock updating procedure.

fix: https://github.com/zephyrproject-rtos/zephyr/issues/90676
replace this PR: https://github.com/zephyrproject-rtos/zephyr/pull/91518
