### PR TITLE
modules: lvgl: LVGL flush thread should indicate when it's done flushing

### DIFF
--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -29,6 +29,7 @@ void lvgl_flush_thread_entry(void *arg1, void *arg2, void *arg3)
 
 		flush.desc.frame_incomplete = !lv_display_flush_is_last(flush.display);
 		display_write(data->display_dev, flush.x, flush.y, &flush.desc, flush.buf);
+		lv_display_flush_ready(flush.display);
 
 		k_sem_give(&flush_complete);
 	}


### PR DESCRIPTION
The LVGL flush thread should indicate when it's done so that LVGL knows it can render new content into the buffer.