### PR TITLE
tests: modules: nanopb: fix typo in assert

### DIFF
--- a/tests/modules/nanopb/src/main.c
+++ b/tests/modules/nanopb/src/main.c
@@ -36,7 +36,7 @@ ZTEST(nanopb_tests, test_nanopb_simple)
 	pb_istream_t istream = pb_istream_from_buffer(buffer, ostream.bytes_written);
 
 	zassert_true(pb_decode(&istream, SimpleMessage_fields, &msg),
-		     "Decoding failed: %s", PB_GET_ERROR(&ostream));
+		     "Decoding failed: %s", PB_GET_ERROR(&istream));
 
 	for (size_t i = 0; i < sizeof(msg.buffer); ++i) {
 		zassert_equal(msg.buffer[i], i);


### PR DESCRIPTION
Fix a typo / copy-paste error in the assert message.