### PR TITLE
stm32: pinctrl: introduce I/O synchronization support

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -345,12 +345,13 @@ zephyr_udc0: &usbotg_hs1 {
 };
 
 /**
- * Board-specific configuration, required to ensure that
- * the Tx CLK and DAT signals arrive in sync at the PHY.
- * Without this, the Tx will be unreliable
+ * Per the RGMII specification, the Tx clock signal must be skewed
+ * from the Tx data signals by 1~2 ns. On this board, the SoC must
+ * be configured to add the required delay via pinctrl.
  */
 &eth1_rgmii_gtx_clk_pf0 {
-	slew-rate = "medium-speed";
+	st,io-delay-path = "output";
+	st,io-delay-ps = <2000>;
 };
 
 &mac {

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -266,7 +266,7 @@
 		};
 
 		pinctrl: pin-controller@56020000 {
-			compatible = "st,stm32-pinctrl";
+			compatible = "st,stm32n6-pinctrl", "st,stm32-pinctrl";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x56020000 0x2000>;

--- a/dts/bindings/pinctrl/st,stm32n6-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32n6-pinctrl.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 pin controller with "I/O synchronization"
+
+  Identical to the "regular" pin controller with "st,stm32-pinctrl" compatible,
+  with an additional "I/O synchronization" feature. This feature allows addition
+  of a programmable delay to the signal input or output path ("I/O delay"), and
+  synchronization of GPIO data with configuration clock edge(s) ("I/O retime").
+
+  This pin controller can be found on STM32N6 series.
+
+compatible: "st,stm32n6-pinctrl"
+
+include: "st,stm32-pinctrl.yaml"
+
+child-binding:
+  properties:
+    st,io-retime-edge:
+      type: string
+      description: |
+        Clock edges on which input/output should be retimed
+
+        If this property is present, I/O retiming is enabled,
+        and this property selects whether the input/output data
+        is retimed on rising, falling or both edges of clock.
+
+        If this property is not present, I/O retiming is disabled.
+      enum:
+        - "rising"
+        - "falling"
+        - "both"
+
+    st,io-delay-ps:
+      type: int
+      default: 0
+      description: |
+        Delay applied to input or output path (in picoseconds)
+
+        The default value matches hardware default, and allows to keep
+        the property unspecified on most pinctrl nodes which do not use
+        the I/O delay feature.
+      enum:
+        - 0
+        - 300
+        - 500
+        - 750
+        - 1000
+        - 1250
+        - 1500
+        - 1750
+        - 2000
+        - 2250
+        - 2500
+        - 2750
+        - 3000
+        - 3250
+
+    st,io-delay-path:
+      type: string
+      default: "output"
+      description: |
+        Direction in which the I/O delay should be applied
+
+        The default value corresponds to hardware default.
+      enum:
+        - "output"
+        - "input"

--- a/include/zephyr/dt-bindings/pinctrl/stm32-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/stm32-pinctrl.h
@@ -69,13 +69,23 @@
  *
  * Pin configuration is coded with the following
  * fields
- *    Alternate Functions [ 0 : 3 ]
- *    GPIO Mode           [ 4 : 5 ]
- *    GPIO Output type    [ 6 ]
- *    GPIO Speed          [ 7 : 8 ]
- *    GPIO PUPD config    [ 9 : 10 ]
- *    GPIO Output data     [ 11 ]
+ *	[03:00] Alternate Functions
+ *	[05:04] GPIO Mode
+ *	[   06] GPIO Output type
+ *	[08:07] GPIO Speed
+ *	[10:09] GPIO PUPD config
+ *	[   11] GPIO Output data
  *
+ * These fields are only used when pinctrl with compatible
+ * "st,stm32n6-pinctrl" is in use:
+ *	[15:12] I/O delay length
+ *	[   16] I/O delay direction
+ *	[18:17] I/O retime edge
+ *	[   19]	I/O retime enable
+ *
+ * NOTE: the values for these fields are not defined in this file
+ * because they depend on hardware definitions. The values can be
+ * found in `soc/st/stm32/common/pinctrl_soc.h` instead.
  */
 
 /* GPIO Mode */
@@ -112,5 +122,17 @@
 #define STM32_ODR_1			(0x1 << STM32_ODR_SHIFT)
 #define STM32_ODR_MASK			0x1
 #define STM32_ODR_SHIFT			11
+
+/* I/O delay length (DELAYR) */
+#define STM32_IODELAY_LENGTH_MASK	0xFU
+#define STM32_IODELAY_LENGTH_SHIFT	12
+
+/* I/O delay & retime configuration (ADVCFGR) */
+#define STM32_IORETIME_ADVCFGR_MASK	0xFU
+#define STM32_IORETIME_ADVCFGR_SHIFT	16
+
+#define STM32_IODELAY_DIRECTION_SHIFT	STM32_IORETIME_ADVCFGR_SHIFT
+#define STM32_IORETIME_EDGE_SHIFT	17
+#define STM32_IORETIME_ENABLE_SHIFT	19
 
 #endif	/* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_STM32_PINCTRL_H_ */


### PR DESCRIPTION
Add support for the "I/O synchronization" feature of the STM32N6 GPIO to the STM32 pinctrl driver.

A new `st,stm32n6-pinctrl` binding is introduced for series with this feature, which adds new properties on the pinctrl nodes to allow configuring the I/O synchronization feature on a per-pin basis. The pinctrl driver is updated to take these new properties into account and apply them appropriately.

Additionally, the `stm32n6570_dk` board DTS is updated to replace the `slew-rate` hack from 91445 with these new properties.