### PR TITLE
Bluetooth: Host: Introduce bt_hci_cmd_alloc()

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -392,6 +392,10 @@ Bluetooth HCI
   have been deprecated, but are still usable, with the exception that they can only be
   called once per buffer.
 
+* The :c:func:`bt_hci_cmd_create` function has been depracated and the new :c:func:`bt_hci_cmd_alloc`
+  function should be used instead. The new function takes no parameters because the command
+  sending functions have been updated to do the command header encoding.
+
 Bluetooth Host
 ==============
 

--- a/drivers/bluetooth/hci/apollox_blue.c
+++ b/drivers/bluetooth/hci/apollox_blue.c
@@ -396,8 +396,7 @@ static int bt_apollo_set_nvds(void)
 #else
 	uint8_t *p;
 
-	buf = bt_hci_cmd_create(HCI_VSC_UPDATE_NVDS_CFG_CMD_OPCODE,
-				HCI_VSC_UPDATE_NVDS_CFG_CMD_LENGTH);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
+++ b/drivers/bluetooth/hci/h4_ifx_cyw43xxx.c
@@ -122,8 +122,7 @@ static int bt_update_controller_baudrate(const struct device *bt_uart_dev, uint3
 	/* Allocate buffer for update uart baudrate command.
 	 * It will be BT_HCI_OP_RESET with extra parameters.
 	 */
-	buf = bt_hci_cmd_create(BT_HCI_VND_OP_UPDATE_BAUDRATE,
-				HCI_VSC_UPDATE_BAUD_RATE_LENGTH);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (buf == NULL) {
 		LOG_ERR("Unable to allocate command buffer");
 		return -ENOMEM;
@@ -172,7 +171,7 @@ static int bt_firmware_download(const uint8_t *firmware_image, uint32_t size)
 		uint16_t op_code = *(uint16_t *)data;
 
 		/* Allocate buffer for hci_write_ram/hci_launch_ram command. */
-		buf = bt_hci_cmd_create(op_code, data_length);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (buf == NULL) {
 			LOG_ERR("Unable to allocate command buffer");
 			return err;

--- a/drivers/bluetooth/hci/hci_ifx_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_ifx_cyw208xx.c
@@ -146,7 +146,7 @@ static int cyw208xx_bt_firmware_download(const uint8_t *firmware_image, uint32_t
 		}
 
 		/* Allocate buffer for hci_write_ram/hci_launch_ram command. */
-		buf = bt_hci_cmd_create(op_code, data_length);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (buf == NULL) {
 			LOG_ERR("Unable to allocate command buffer");
 			return -ENOBUFS;
@@ -211,7 +211,7 @@ static int cyw208xx_setup(const struct device *dev, const struct bt_hci_setup_pa
 	cybt_platform_hci_wait_for_boot_fully_up(false);
 
 	/* Set public address */
-	buf = bt_hci_cmd_create(BT_HCI_VND_OP_SET_LOCAL_DEV_ADDR, BTM_SET_LOCAL_DEV_ADDR_LENGTH);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (buf == NULL) {
 		LOG_ERR("Unable to allocate command buffer");
 		cyhal_syspm_unlock_deepsleep();
@@ -375,7 +375,7 @@ wiced_bt_dev_vendor_specific_command(uint16_t opcode, uint8_t param_len, uint8_t
 	struct net_buf *buf = NULL;
 
 	/* Allocate a HCI command buffer */
-	buf = bt_hci_cmd_create(opcode, param_len);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Unable to allocate buffer");
 		return WICED_NO_MEMORY;

--- a/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
@@ -203,7 +203,7 @@ static int psoc6_bless_setup(const struct device *dev, const struct bt_hci_setup
 		addr[5], addr[4], addr[3], addr[2], addr[1], addr[0], BT_ADDR_LE_PUBLIC,
 	};
 
-	buf = bt_hci_cmd_create(PSOC6_BLESS_OP_SET_PUBLIC_ADDR, sizeof(hci_data));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (buf == NULL) {
 		LOG_ERR("Unable to allocate command buffer");
 		return -ENOMEM;

--- a/drivers/bluetooth/hci/hci_nxp.c
+++ b/drivers/bluetooth/hci/hci_nxp.c
@@ -94,7 +94,7 @@ static int nxp_bt_send_vs_command(uint16_t opcode, const uint8_t *params, uint8_
 		struct net_buf *buf;
 
 		/* Allocate buffer for the hci command */
-		buf = bt_hci_cmd_create(opcode, params_len);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (buf == NULL) {
 			LOG_ERR("Unable to allocate command buffer");
 			return -ENOMEM;

--- a/drivers/bluetooth/hci/hci_nxp_setup.c
+++ b/drivers/bluetooth/hci/hci_nxp_setup.c
@@ -1281,7 +1281,7 @@ static int bt_nxp_set_calibration_data_annex55(void)
 	if (IS_ENABLED(CONFIG_BT_HCI_HOST)) {
 		struct net_buf *buf;
 
-		buf = bt_hci_cmd_create(opcode, HCI_CMD_STORE_BT_CAL_DATA_PARAM_LENGTH);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (buf == NULL) {
 			LOG_ERR("Unable to allocate command buffer");
 			return -ENOMEM;
@@ -1346,7 +1346,7 @@ static int bt_nxp_set_calibration_data_annex100(void)
 	if (IS_ENABLED(CONFIG_BT_HCI_HOST)) {
 		struct net_buf *buf;
 
-		buf = bt_hci_cmd_create(opcode, HCI_CMD_STORE_BT_CAL_DATA_PARAM_ANNEX100_LENGTH);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (buf == NULL) {
 			LOG_ERR("Unable to allocate command buffer");
 			return -ENOMEM;
@@ -1387,8 +1387,7 @@ static int bt_hci_baudrate_update(const struct device *dev, uint32_t baudrate)
 	int err;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_VSC_BAUDRATE_UPDATE_OPCODE,
-				BT_HCI_VSC_BAUDRATE_UPDATE_LENGTH);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Fail to allocate buffer");
 		return -ENOBUFS;

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -335,7 +335,7 @@ static int bt_spi_send_aci_config(uint8_t offset, const uint8_t *value, size_t v
 	hdr.param_len = data_len;
 	buf = bt_buf_get_tx(BT_BUF_CMD, K_NO_WAIT, &hdr, sizeof(hdr));
 #else
-	buf = bt_hci_cmd_create(BLUENRG_ACI_WRITE_CONFIG_DATA, data_len);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 #endif /* CONFIG_BT_HCI_RAW */
 
 	if (!buf) {

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -432,7 +432,7 @@ static int bt_hci_stm32wba_setup(const struct device *dev,
 		return -ENOMSG;
 	}
 
-	buf = bt_hci_cmd_create(ACI_HAL_WRITE_CONFIG_DATA, sizeof(*param));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -433,8 +433,7 @@ static int bt_ipm_set_addr(void)
 		return -ENOMSG;
 	}
 
-	buf = bt_hci_cmd_create(ACI_HAL_WRITE_CONFIG_DATA, sizeof(*param));
-
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -468,7 +467,7 @@ static int bt_ipm_ble_init(void)
 		LOG_ERR("Can't set BLE UID addr");
 	}
 	/* Send ACI_WRITE_SET_TX_POWER_LEVEL */
-	buf = bt_hci_cmd_create(ACI_WRITE_SET_TX_POWER_LEVEL, 3);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -56,12 +56,14 @@ static inline const char *bt_hci_err_to_str(uint8_t hci_err)
   * of the parameters. Upon successful return the buffer is ready to have
   * the parameters encoded into it.
   *
+  * @deprecated Use bt_hci_cmd_alloc() instead.
+  *
   * @param opcode     Command OpCode.
   * @param param_len  Length of command parameters.
   *
   * @return Newly allocated buffer.
   */
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len);
+__deprecated struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len);
 
 /** Allocate an HCI command buffer.
  *
@@ -80,7 +82,7 @@ struct net_buf *bt_hci_cmd_alloc(k_timeout_t timeout);
 /** Send a HCI command asynchronously.
   *
   * This function is used for sending a HCI command asynchronously. It can
-  * either be called for a buffer created using bt_hci_cmd_create(), or
+  * either be called for a buffer created using bt_hci_cmd_alloc(), or
   * if the command has no parameters a NULL can be passed instead. The
   * sending of the command will happen asynchronously, i.e. upon successful
   * return from this function the caller only knows that it was queued
@@ -99,7 +101,7 @@ int bt_hci_cmd_send(uint16_t opcode, struct net_buf *buf);
 /** Send a HCI command synchronously.
   *
   * This function is used for sending a HCI command synchronously. It can
-  * either be called for a buffer created using bt_hci_cmd_create(), or
+  * either be called for a buffer created using bt_hci_cmd_alloc(), or
   * if the command has no parameters a NULL can be passed instead.
   *
   * The function will block until a Command Status or a Command Complete

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -63,6 +63,20 @@ static inline const char *bt_hci_err_to_str(uint8_t hci_err)
   */
 struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len);
 
+/** Allocate an HCI command buffer.
+ *
+ * This function allocates a new buffer for an HCI command. Upon successful
+ * return the buffer is ready to have the command parameters encoded into it.
+ * Sufficient headroom gets automatically reserved in the buffer, allowing
+ * the actual command and H:4 headers to be encoded later, as part of
+ * calling bt_hci_cmd_send() or bt_hci_cmd_send_sync().
+ *
+ * @param timeout Timeout for the allocation.
+ *
+ * @return Newly allocated buffer or NULL if allocation failed.
+ */
+struct net_buf *bt_hci_cmd_alloc(k_timeout_t timeout);
+
 /** Send a HCI command asynchronously.
   *
   * This function is used for sending a HCI command asynchronously. It can

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -57,7 +57,7 @@ static void read_conn_rssi(uint16_t handle, int8_t *rssi)
 
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_RSSI, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		printk("Unable to allocate command buffer\n");
 		return;
@@ -86,8 +86,7 @@ static void set_tx_power(uint8_t handle_type, uint16_t handle, int8_t tx_pwr_lvl
 	struct net_buf *buf, *rsp = NULL;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		printk("Unable to allocate command buffer\n");
 		return;
@@ -119,8 +118,7 @@ static void get_tx_power(uint8_t handle_type, uint16_t handle, int8_t *tx_pwr_lv
 	int err;
 
 	*tx_pwr_lvl = 0xFF;
-	buf = bt_hci_cmd_create(BT_HCI_OP_VS_READ_TX_POWER_LEVEL,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		printk("Unable to allocate command buffer\n");
 		return;

--- a/samples/bluetooth/hci_vs_scan_req/src/main.c
+++ b/samples/bluetooth/hci_vs_scan_req/src/main.c
@@ -65,7 +65,7 @@ static void enable_legacy_adv_scan_request_event(bool enable)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_VS_SET_SCAN_REQ_REPORTS, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		printk("%s: Unable to allocate HCI command buffer\n", __func__);
 		return;

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -335,7 +335,7 @@ int bt_le_adv_set_enable_legacy(struct bt_le_ext_adv *adv, bool enable)
 	struct bt_hci_cmd_state_set state;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -364,7 +364,7 @@ int bt_le_adv_set_enable_ext(struct bt_le_ext_adv *adv,
 	struct bt_hci_cmd_state_set state;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_EXT_ADV_ENABLE, 6);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -551,7 +551,7 @@ static int hci_set_ad(uint16_t hci_op, const struct bt_ad *ad, size_t ad_len)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(hci_op, sizeof(*set_data));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -585,7 +585,7 @@ static int hci_set_adv_ext_complete(struct bt_le_ext_adv *adv, uint16_t hci_op,
 
 	cmd_size = sizeof(*set_data) + total_data_len;
 
-	buf = bt_hci_cmd_create(hci_op, cmd_size);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -625,7 +625,7 @@ static int hci_set_adv_ext_fragmented(struct bt_le_ext_adv *adv, uint16_t hci_op
 		const size_t data_len = MIN(BT_HCI_LE_EXT_ADV_FRAG_MAX_LEN, stream.remaining_size);
 		const size_t cmd_size = sizeof(*set_data) + data_len;
 
-		buf = bt_hci_cmd_create(hci_op, cmd_size);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -738,7 +738,7 @@ static int hci_set_per_adv_data(const struct bt_le_ext_adv *adv,
 		const size_t data_len = MIN(BT_HCI_LE_PER_ADV_FRAG_MAX_LEN, stream.remaining_size);
 		const size_t cmd_size = sizeof(*set_data) + data_len;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_DATA, cmd_size);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -1056,7 +1056,7 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 		set_param.type = BT_HCI_ADV_NONCONN_IND;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1168,7 +1168,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 		size = sizeof(struct bt_hci_cp_le_set_ext_adv_param);
 	}
 
-	buf = bt_hci_cmd_create(opcode, size);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1854,7 +1854,7 @@ int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv)
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_REMOVE_ADV_SET, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_WRN("No HCI buffers");
 		return -ENOBUFS;
@@ -1953,7 +1953,7 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 		return -ENOTSUP;
 	}
 
-	buf = bt_hci_cmd_create(opcode, size);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2062,7 +2062,7 @@ int bt_le_per_adv_set_subevent_data(const struct bt_le_ext_adv *adv, uint8_t num
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_SUBEVENT_DATA, (uint8_t)cmd_length);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2109,7 +2109,7 @@ static int bt_le_per_adv_enable(struct bt_le_ext_adv *adv, bool enable)
 		return -EALREADY;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2263,8 +2263,7 @@ int bt_le_per_adv_set_info_transfer(const struct bt_le_ext_adv *adv,
 		return -ENOTSUP;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PER_ADV_SET_INFO_TRANSFER,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -41,7 +41,7 @@ static int reject_conn(const bt_addr_t *bdaddr, uint8_t reason)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_REJECT_CONN_REQ, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -64,7 +64,7 @@ static int accept_conn(const bt_addr_t *bdaddr)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_ACCEPT_CONN_REQ, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -118,7 +118,7 @@ static bool br_sufficient_key_size(struct bt_conn *conn)
 	uint8_t key_size;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Failed to allocate command buffer");
 		return false;
@@ -254,7 +254,7 @@ void bt_hci_conn_complete(struct net_buf *buf)
 
 	bt_conn_unref(conn);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_REMOTE_FEATURES, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return;
 	}
@@ -270,7 +270,7 @@ static int request_name(const bt_addr_t *addr, uint8_t pscan, uint16_t offset)
 	struct bt_hci_cp_remote_name_request *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_REMOTE_NAME_REQUEST, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -637,7 +637,7 @@ void bt_hci_read_remote_features_complete(struct net_buf *buf)
 		goto done;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_REMOTE_EXT_FEATURES, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		goto done;
 	}
@@ -711,7 +711,7 @@ static int read_ext_features(void)
 		struct net_buf *buf, *rsp;
 		int err;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_READ_LOCAL_EXT_FEATURES, sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -800,7 +800,6 @@ int bt_br_init(void)
 	struct bt_hci_cp_write_ssp_mode *ssp_cp;
 	struct bt_hci_cp_write_inquiry_mode *inq_cp;
 	struct bt_hci_write_local_name *name_cp;
-	struct bt_hci_cp_write_class_of_device *cod;
 	int err;
 
 	/* Read extended local features */
@@ -824,7 +823,7 @@ int bt_br_init(void)
 	net_buf_unref(buf);
 
 	/* Set SSP mode */
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_SSP_MODE, sizeof(*ssp_cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -837,7 +836,7 @@ int bt_br_init(void)
 	}
 
 	/* Enable Inquiry results with RSSI or extended Inquiry */
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_INQUIRY_MODE, sizeof(*inq_cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -850,7 +849,7 @@ int bt_br_init(void)
 	}
 
 	/* Set local name */
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_LOCAL_NAME, sizeof(*name_cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -864,7 +863,7 @@ int bt_br_init(void)
 	}
 
 	/* Set Class of device */
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_CLASS_OF_DEVICE, sizeof(*cod));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -877,7 +876,7 @@ int bt_br_init(void)
 	}
 
 	/* Set page timeout*/
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_PAGE_TIMEOUT, sizeof(uint16_t));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -893,7 +892,7 @@ int bt_br_init(void)
 	if (BT_FEAT_SC(bt_dev.features)) {
 		struct bt_hci_cp_write_sc_host_supp *sc_cp;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_SC_HOST_SUPP, sizeof(*sc_cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -916,7 +915,7 @@ static int br_start_inquiry(const struct bt_br_discovery_param *param)
 	struct bt_hci_op_inquiry *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_INQUIRY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1005,7 +1004,7 @@ int bt_br_discovery_stop(void)
 			continue;
 		}
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_REMOTE_NAME_CANCEL, sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			continue;
 		}
@@ -1042,7 +1041,7 @@ static int write_scan_enable(uint8_t scan)
 
 	LOG_DBG("type %u", scan);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_SCAN_ENABLE, 1);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1090,7 +1089,7 @@ static int bt_br_write_current_iac_lap(bool limited)
 
 	param_len = sizeof(*iac_lap) + (num_current_iac * sizeof(struct bt_hci_iac_lap));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_CURRENT_IAC_LAP, param_len);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1142,8 +1141,7 @@ static int bt_br_write_cod(uint32_t cod)
 	struct net_buf *buf;
 
 	/* Set Class of device */
-	buf = bt_hci_cmd_create(BT_HCI_OP_WRITE_CLASS_OF_DEVICE,
-				sizeof(struct bt_hci_cp_write_class_of_device));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/classic/conn_br.c
+++ b/subsys/bluetooth/host/classic/conn_br.c
@@ -73,7 +73,7 @@ struct bt_conn *bt_conn_create_br(const bt_addr_t *peer,
 		return NULL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_CONNECT, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		bt_conn_unref(conn);
 		return NULL;
@@ -107,7 +107,7 @@ int bt_hci_connect_br_cancel(struct bt_conn *conn)
 	struct net_buf *buf, *rsp;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_CONNECT_CANCEL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/classic/sco.c
+++ b/subsys/bluetooth/host/classic/sco.c
@@ -258,7 +258,7 @@ static int accept_sco_conn(const bt_addr_t *bdaddr, struct bt_conn *sco_conn)
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_ACCEPT_SYNC_CONN_REQ, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -334,7 +334,7 @@ static int sco_setup_sync_conn(struct bt_conn *sco_conn)
 	struct bt_hci_cp_setup_sync_conn *cp;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_SETUP_SYNC_CONN, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/classic/ssp.c
+++ b/subsys/bluetooth/host/classic/ssp.c
@@ -50,7 +50,7 @@ static int pin_code_neg_reply(const bt_addr_t *bdaddr)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_PIN_CODE_NEG_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -68,7 +68,7 @@ static int pin_code_reply(struct bt_conn *conn, const char *pin, uint8_t len)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_PIN_CODE_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -186,7 +186,7 @@ static int ssp_confirm_reply(struct bt_conn *conn)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_USER_CONFIRM_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -204,7 +204,7 @@ static int ssp_confirm_neg_reply(struct bt_conn *conn)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_USER_CONFIRM_NEG_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -313,7 +313,7 @@ static int ssp_passkey_reply(struct bt_conn *conn, unsigned int passkey)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_USER_PASSKEY_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -332,7 +332,7 @@ static int ssp_passkey_neg_reply(struct bt_conn *conn)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_USER_PASSKEY_NEG_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -351,7 +351,7 @@ static int conn_auth(struct bt_conn *conn)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_AUTH_REQUESTED, sizeof(*auth));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -539,7 +539,7 @@ void link_key_neg_reply(const bt_addr_t *bdaddr)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LINK_KEY_NEG_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Out of command buffers");
 		return;
@@ -557,7 +557,7 @@ void link_key_reply(const bt_addr_t *bdaddr, const uint8_t *lk)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LINK_KEY_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Out of command buffers");
 		return;
@@ -613,8 +613,7 @@ void io_capa_neg_reply(const bt_addr_t *bdaddr, const uint8_t reason)
 	struct bt_hci_cp_io_capability_neg_reply *cp;
 	struct net_buf *resp_buf;
 
-	resp_buf = bt_hci_cmd_create(BT_HCI_OP_IO_CAPABILITY_NEG_REPLY,
-				     sizeof(*cp));
+	resp_buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!resp_buf) {
 		LOG_ERR("Out of command buffers");
 		return;
@@ -769,7 +768,7 @@ void bt_hci_io_capa_req(struct net_buf *buf)
 
 	conn->br.local_auth = auth;
 
-	resp_buf = bt_hci_cmd_create(BT_HCI_OP_IO_CAPABILITY_REPLY, sizeof(*cp));
+	resp_buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!resp_buf) {
 		LOG_ERR("Out of command buffers");
 		bt_conn_unref(conn);
@@ -865,7 +864,7 @@ static void link_encr(const uint16_t handle)
 
 	LOG_DBG("");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_SET_CONN_ENCRYPT, sizeof(*encr));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Out of command buffers");
 		return;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2472,7 +2472,7 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, uint8_t rand[8],
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_START_ENCRYPTION, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2511,8 +2511,7 @@ uint8_t bt_conn_enc_key_size(const struct bt_conn *conn)
 		struct net_buf *rsp;
 		uint8_t key_size;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_READ_ENCRYPTION_KEY_SIZE,
-					sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return 0;
 		}
@@ -2978,7 +2977,7 @@ static int bt_conn_get_tx_power_level(struct bt_conn *conn, uint8_t type,
 	struct bt_hci_cp_read_tx_power_level *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_TX_POWER_LEVEL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3037,7 +3036,7 @@ int bt_conn_le_enhanced_get_tx_power_level(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3075,7 +3074,7 @@ int bt_conn_le_get_remote_tx_power_level(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3099,7 +3098,7 @@ int bt_conn_le_set_tx_power_report_enable(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3175,7 +3174,7 @@ int bt_conn_le_set_path_loss_mon_param(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_PARAMETERS, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3201,7 +3200,7 @@ int bt_conn_le_set_path_loss_mon_enable(struct bt_conn *conn, bool reporting_ena
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PATH_LOSS_REPORTING_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3276,7 +3275,7 @@ int bt_conn_le_subrate_set_defaults(const struct bt_conn_le_subrate_param *param
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_DEFAULT_SUBRATE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3306,7 +3305,7 @@ int bt_conn_le_subrate_request(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SUBRATE_REQUEST, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3936,8 +3935,7 @@ int bt_conn_le_conn_update(struct bt_conn *conn,
 	struct hci_cp_le_conn_update *conn_update;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_UPDATE,
-				sizeof(*conn_update));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -522,7 +522,7 @@ int bt_le_cs_start_test(const struct bt_le_cs_test_param *params)
 	struct bt_hci_op_le_cs_test *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_TEST, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -616,10 +616,6 @@ int bt_le_cs_start_test(const struct bt_le_cs_test_param *params)
 	}
 
 	cp->override_parameters_length = override_parameters_length;
-
-	struct bt_hci_cmd_hdr *hdr = (struct bt_hci_cmd_hdr *)buf->data;
-
-	hdr->param_len += override_parameters_length;
 
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_CS_TEST, buf, NULL);
 }

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -296,7 +296,7 @@ int bt_le_cs_read_remote_supported_capabilities(struct bt_conn *conn)
 	struct bt_hci_cp_le_read_remote_supported_capabilities *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -439,7 +439,7 @@ int bt_le_cs_set_default_settings(struct bt_conn *conn,
 	struct bt_hci_cp_le_cs_set_default_settings *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_SET_DEFAULT_SETTINGS, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -466,7 +466,7 @@ int bt_le_cs_read_remote_fae_table(struct bt_conn *conn)
 	struct bt_hci_cp_le_read_remote_fae_table *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_READ_REMOTE_FAE_TABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -884,7 +884,7 @@ int bt_le_cs_create_config(struct bt_conn *conn, struct bt_le_cs_create_config_p
 	struct bt_hci_cp_le_cs_create_config *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_CREATE_CONFIG, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -917,7 +917,7 @@ int bt_le_cs_remove_config(struct bt_conn *conn, uint8_t config_id)
 	struct bt_hci_cp_le_cs_remove_config *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_REMOVE_CONFIG, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -934,7 +934,7 @@ int bt_le_cs_security_enable(struct bt_conn *conn)
 	struct bt_hci_cp_le_security_enable *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_SECURITY_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -951,7 +951,7 @@ int bt_le_cs_procedure_enable(struct bt_conn *conn,
 	struct bt_hci_cp_le_procedure_enable *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_PROCEDURE_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -970,7 +970,7 @@ int bt_le_cs_set_procedure_parameters(struct bt_conn *conn,
 	struct bt_hci_cp_le_set_procedure_parameters *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_SET_PROCEDURE_PARAMETERS, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -999,7 +999,7 @@ int bt_le_cs_set_channel_classification(uint8_t channel_classification[10])
 	uint8_t *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_SET_CHANNEL_CLASSIFICATION, 10);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1111,9 +1111,7 @@ int bt_le_cs_write_cached_remote_supported_capabilities(
 	struct bt_hci_cp_le_write_cached_remote_supported_capabilities *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_WRITE_CACHED_REMOTE_SUPPORTED_CAPABILITIES,
-				sizeof(*cp));
-
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1210,7 +1208,7 @@ int bt_le_cs_write_cached_remote_fae_table(struct bt_conn *conn, int8_t remote_f
 	struct bt_hci_cp_le_write_cached_remote_fae_table *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_WRITE_CACHED_REMOTE_FAE_TABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1308,7 +1306,7 @@ int bt_le_cs_stop_test(void)
 {
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CS_TEST_END, 0);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -129,8 +129,7 @@ static int hci_df_set_cl_cte_tx_params(const struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_TX_PARAMS,
-				sizeof(*cp) + params->num_ant_ids);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -216,7 +215,7 @@ static int hci_df_set_adv_cte_tx_enable(struct bt_le_ext_adv *adv,
 	struct bt_hci_cmd_state_set state;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_TX_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -296,9 +295,7 @@ prepare_cl_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt_le_per_adv_s
 	/* If CTE Rx is enabled, command parameters total length must include
 	 * antenna ids, so command size if extended by num_and_ids.
 	 */
-	*buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE,
-				 (sizeof(struct bt_hci_cp_le_set_cl_cte_sampling_enable) +
-				 (enable ? switch_pattern_len : 0)));
+	*buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!(*buf)) {
 		return -ENOBUFS;
 	}
@@ -528,7 +525,6 @@ static int hci_df_set_conn_cte_tx_param(struct bt_conn *conn,
 	struct bt_hci_rp_le_set_conn_cte_tx_params *rp;
 	struct bt_hci_cmd_state_set state;
 	struct net_buf *buf, *rsp;
-	uint8_t num_ant_ids;
 	int err;
 
 	/* If AoD is not enabled, ant_ids are ignored by controller:
@@ -538,11 +534,7 @@ static int hci_df_set_conn_cte_tx_param(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	num_ant_ids = ((params->cte_types & (BT_DF_CTE_TYPE_AOD_1US | BT_DF_CTE_TYPE_AOD_2US)) ?
-				params->num_ant_ids : 0);
-
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CONN_CTE_TX_PARAMS,
-				sizeof(struct bt_hci_cp_le_set_conn_cte_tx_params) + num_ant_ids);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -587,9 +579,7 @@ static int prepare_conn_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt
 	/* If CTE Rx is enabled, command parameters total length must include
 	 * antenna ids, so command size if extended by num_and_ids.
 	 */
-	*buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS,
-				 (sizeof(struct bt_hci_cp_le_set_conn_cte_rx_params) +
-				 (enable ? switch_pattern_len : 0)));
+	*buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!(*buf)) {
 		return -ENOBUFS;
 	}
@@ -823,8 +813,7 @@ static int hci_df_set_conn_cte_req_enable(struct bt_conn *conn, bool enable,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE,
-				sizeof(struct bt_hci_cp_le_conn_cte_req_enable));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -909,8 +898,7 @@ static int hci_df_set_conn_cte_rsp_enable(struct bt_conn *conn, bool enable)
 	struct net_buf *buf, *rsp;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_CTE_RSP_ENABLE,
-				sizeof(struct bt_hci_cp_le_conn_cte_rsp_enable));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -268,8 +268,7 @@ void bt_send_one_host_num_completed_packets(uint16_t handle)
 
 	LOG_DBG("Reporting completed packet for handle %u", handle);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS,
-				sizeof(*cp) + sizeof(*hc));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	BT_ASSERT_MSG(buf, "Unable to alloc for Host NCP");
 
 	cp = net_buf_add(buf, sizeof(*cp));
@@ -326,8 +325,7 @@ void bt_hci_host_num_completed_packets(struct net_buf *buf)
 
 	LOG_DBG("Reporting completed packet for handle %u", handle);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_HOST_NUM_COMPLETED_PACKETS,
-				sizeof(*cp) + sizeof(*hc));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Unable to allocate new HCI command");
 		return;
@@ -778,8 +776,7 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 		   ((bt_dev.create_param.options &
 		      BT_CONN_LE_OPT_CODED) ? 1 : 0);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_EXT_CREATE_CONN, sizeof(*cp) +
-				num_phys * sizeof(*phy));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -849,7 +846,7 @@ int bt_le_create_conn_synced(const struct bt_conn *conn, const struct bt_le_ext_
 	}
 
 	/* There shall only be one Initiating_PHYs */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_EXT_CREATE_CONN_V2, sizeof(*cp) + sizeof(*phy));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -899,7 +896,7 @@ static int bt_le_create_conn_legacy(const struct bt_conn *conn)
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_CONN, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -954,7 +951,7 @@ int bt_le_create_conn_cancel(void)
 	struct net_buf *buf;
 	struct bt_hci_cmd_state_set state;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_CONN_CANCEL, 0);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -971,7 +968,7 @@ int bt_hci_disconnect(uint16_t handle, uint8_t reason)
 	struct net_buf *buf;
 	struct bt_hci_cp_disconnect *disconn;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_DISCONNECT, sizeof(*disconn));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1109,8 +1106,7 @@ int bt_hci_le_read_remote_features(struct bt_conn *conn)
 	struct bt_hci_cp_le_read_remote_features *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_READ_REMOTE_FEATURES,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1135,8 +1131,7 @@ int bt_hci_read_remote_version(struct bt_conn *conn)
 		return 0;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_REMOTE_VERSION_INFO,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1156,7 +1151,7 @@ int bt_le_set_data_len(struct bt_conn *conn, uint16_t tx_octets, uint16_t tx_tim
 	struct bt_hci_cp_le_set_data_len *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_DATA_LEN, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1177,7 +1172,7 @@ static int hci_le_read_phy(struct bt_conn *conn)
 	struct net_buf *buf, *rsp;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_READ_PHY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1205,7 +1200,7 @@ int bt_le_set_phy(struct bt_conn *conn, uint8_t all_phys,
 	struct bt_hci_cp_le_set_phy *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PHY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1908,8 +1903,7 @@ static void le_conn_param_neg_reply(uint16_t handle, uint8_t reason)
 	struct bt_hci_cp_le_conn_param_req_neg_reply *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_PARAM_REQ_NEG_REPLY,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Unable to allocate buffer");
 		return;
@@ -1928,7 +1922,7 @@ static int le_conn_param_req_reply(uint16_t handle,
 	struct bt_hci_cp_le_conn_param_req_reply *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_PARAM_REQ_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2063,8 +2057,7 @@ static int set_flow_control(void)
 		return 0;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_HOST_BUFFER_SIZE,
-				sizeof(*hbs));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2079,7 +2072,7 @@ static int set_flow_control(void)
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_SET_CTL_TO_HOST_FLOW, 1);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2403,7 +2396,7 @@ static void le_ltk_neg_reply(uint16_t handle)
 	struct bt_hci_cp_le_ltk_req_neg_reply *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_LTK_REQ_NEG_REPLY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Out of command buffers");
 
@@ -2421,8 +2414,7 @@ static void le_ltk_reply(uint16_t handle, uint8_t *ltk)
 	struct bt_hci_cp_le_ltk_req_reply *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_LTK_REQ_REPLY,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		LOG_ERR("Out of command buffers");
 		return;
@@ -3257,7 +3249,7 @@ static int le_set_host_feature(uint8_t bit_number, uint8_t bit_value)
 	struct bt_hci_cp_le_set_host_feature *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_HOST_FEATURE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3384,7 +3376,7 @@ static int le_set_event_mask(void)
 	uint64_t mask = 0U;
 
 	/* Set LE event mask */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_EVENT_MASK, sizeof(*cp_mask));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3638,8 +3630,7 @@ static int le_init(void)
 #endif /* CONFIG_BT_BROADCASTER */
 
 	if (BT_FEAT_BREDR(bt_dev.features)) {
-		buf = bt_hci_cmd_create(BT_HCI_OP_LE_WRITE_LE_HOST_SUPP,
-					sizeof(*cp_le));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -3680,8 +3671,7 @@ static int le_init(void)
 			return err;
 		}
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN,
-					sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -3702,8 +3692,7 @@ static int le_init(void)
 #if defined(CONFIG_BT_PRIVACY)
 		struct bt_hci_cp_le_set_rpa_timeout *cp;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RPA_TIMEOUT,
-					sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -3798,7 +3787,7 @@ static int set_event_mask(void)
 	struct net_buf *buf;
 	uint64_t mask = 0U;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_SET_EVENT_MASK, sizeof(*ev));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -4652,7 +4641,7 @@ int bt_le_filter_accept_list_add(const bt_addr_le_t *addr)
 		return -EAGAIN;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_ADD_DEV_TO_FAL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -4680,7 +4669,7 @@ int bt_le_filter_accept_list_remove(const bt_addr_le_t *addr)
 		return -EAGAIN;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_REM_DEV_FROM_FAL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -4730,8 +4719,7 @@ int bt_le_set_chan_map(uint8_t chan_map[5])
 		return -ENOTSUP;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_HOST_CHAN_CLASSIF,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -4772,8 +4760,7 @@ int bt_configure_data_path(uint8_t dir, uint8_t id, uint8_t vs_config_len,
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_CONFIGURE_DATA_PATH, sizeof(*cp) +
-				vs_config_len);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -142,7 +142,7 @@ static int set_random_address(const bt_addr_t *addr)
 		return 0;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(*addr));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -193,8 +193,7 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 		return 0;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_SET_RANDOM_ADDR,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -314,8 +313,7 @@ static void le_rpa_timeout_update(void)
 		struct net_buf *buf;
 		struct bt_hci_cp_le_set_rpa_timeout *cp;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RPA_TIMEOUT,
-					sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			LOG_ERR("Failed to create HCI RPA timeout command");
 			err = -ENOBUFS;
@@ -850,7 +848,7 @@ static int le_set_privacy_mode(const bt_addr_le_t *addr, uint8_t mode)
 	bt_addr_le_copy(&cp.id_addr, addr);
 	cp.mode = mode;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PRIVACY_MODE, sizeof(cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -871,7 +869,7 @@ static int addr_res_enable(uint8_t enable)
 
 	LOG_DBG("%s", enable ? "enabled" : "disabled");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADDR_RES_ENABLE, 1);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -893,7 +891,7 @@ static int hci_id_add(uint8_t id, const bt_addr_le_t *addr, uint8_t peer_irk[16]
 
 	LOG_DBG("addr %s", bt_addr_le_str(addr));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_ADD_DEV_TO_RL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1152,7 +1150,7 @@ static int hci_id_del(const bt_addr_le_t *addr)
 
 	LOG_DBG("addr %s", bt_addr_le_str(addr));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_REM_DEV_FROM_RL, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -196,7 +196,7 @@ static int hci_le_setup_iso_data_path(const struct bt_conn *iso, uint8_t dir,
 	uint8_t *cc;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SETUP_ISO_PATH, sizeof(*cp) + path->cc_len);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -345,7 +345,7 @@ static int hci_le_remove_iso_data_path(struct bt_conn *iso, uint8_t dir)
 	struct net_buf *buf, *rsp;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_REMOVE_ISO_PATH, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1061,7 +1061,7 @@ int bt_iso_chan_get_tx_sync(const struct bt_iso_chan *chan, struct bt_iso_tx_inf
 		return -ENOTCONN;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_READ_ISO_TX_SYNC, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOMEM;
 	}
@@ -1491,7 +1491,7 @@ static int hci_le_reject_cis(uint16_t handle, uint8_t reason)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_REJECT_CIS, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1514,7 +1514,7 @@ static int hci_le_accept_cis(uint16_t handle)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_ACCEPT_CIS, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1683,7 +1683,7 @@ static int hci_le_remove_cig(uint8_t cig_id)
 	struct bt_hci_cp_le_remove_cig *req;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_REMOVE_CIG, sizeof(*req));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1706,8 +1706,7 @@ static struct net_buf *hci_le_set_cig_params(const struct bt_iso_cig *cig,
 	struct net_buf *rsp;
 	int i, err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CIG_PARAMS,
-				sizeof(*req) + sizeof(*cis_param) * param->num_cis);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return NULL;
 	}
@@ -1795,8 +1794,7 @@ static struct net_buf *hci_le_set_cig_test_params(const struct bt_iso_cig *cig,
 	struct net_buf *rsp;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CIG_PARAMS_TEST,
-				sizeof(*req) + sizeof(*cis_param) * param->num_cis);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return NULL;
 	}
@@ -2444,7 +2442,7 @@ static int hci_le_create_cis(const struct bt_iso_connect_param *param, size_t co
 	struct bt_hci_cp_le_create_cis *req;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_CIS, sizeof(*req) + sizeof(*cis) * count);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2784,7 +2782,7 @@ static int hci_le_create_big(struct bt_le_ext_adv *padv, struct bt_iso_big *big,
 	int err;
 	struct bt_iso_chan *bis;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_BIG, sizeof(*req));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 
 	if (!buf) {
 		return -ENOBUFS;
@@ -2844,7 +2842,7 @@ static int hci_le_create_big_test(const struct bt_le_ext_adv *padv, struct bt_is
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CREATE_BIG_TEST, sizeof(*req));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 
 	if (!buf) {
 		return -ENOBUFS;
@@ -3198,7 +3196,7 @@ static int hci_le_terminate_big(struct bt_iso_big *big)
 	struct bt_hci_cp_le_terminate_big *req;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_TERMINATE_BIG, sizeof(*req));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3218,7 +3216,7 @@ static int hci_le_big_sync_term(struct bt_iso_big *big)
 	struct net_buf *rsp;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_BIG_TERMINATE_SYNC, sizeof(*req));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -3391,7 +3389,7 @@ static int hci_le_big_create_sync(const struct bt_le_per_adv_sync *sync, struct 
 	int err;
 	uint8_t bit_idx = 0;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_BIG_CREATE_SYNC, sizeof(*req) + big->num_bis);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -133,7 +133,7 @@ static int cmd_le_set_ext_scan_enable(bool enable, bool filter_duplicates, uint1
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_EXT_SCAN_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -163,7 +163,7 @@ static int cmd_le_set_scan_enable_legacy(bool enable, bool filter_duplicates)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_SCAN_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -252,10 +252,7 @@ static int start_le_scan_ext(struct bt_le_scan_param *scan_param)
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_EXT_SCAN_PARAM,
-				sizeof(*set_param) +
-				(phy_1m ? sizeof(*phy_1m) : 0) +
-				(phy_coded ? sizeof(*phy_coded) : 0));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -322,7 +319,7 @@ static int start_le_scan_legacy(struct bt_le_scan_param *param)
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_SCAN_PARAM, sizeof(set_param));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1166,8 +1163,7 @@ static int per_adv_sync_terminate(uint16_t handle)
 	struct bt_hci_cp_le_per_adv_terminate_sync *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PER_ADV_TERMINATE_SYNC,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1359,9 +1355,7 @@ int bt_le_per_adv_sync_subevent(struct bt_le_per_adv_sync *per_adv_sync,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_SYNC_SUBEVENT,
-				sizeof(*cp) + params->num_subevents);
-
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1399,9 +1393,7 @@ int bt_le_per_adv_set_response_data(struct bt_le_per_adv_sync *per_adv_sync,
 		return -EINVAL;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_RESPONSE_DATA,
-				sizeof(*cp) + data->len);
-
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -1927,7 +1919,7 @@ int bt_le_per_adv_sync_create(const struct bt_le_per_adv_sync_param *param,
 		return -ENOMEM;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PER_ADV_CREATE_SYNC, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		per_adv_sync_delete(per_adv_sync);
 		return -ENOBUFS;
@@ -2034,7 +2026,7 @@ static int bt_le_per_adv_sync_create_cancel(
 		return err;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PER_ADV_CREATE_SYNC_CANCEL, 0);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2130,8 +2122,7 @@ static int bt_le_set_per_adv_recv_enable(
 		return -EALREADY;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_RECV_ENABLE,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2189,8 +2180,7 @@ int bt_le_per_adv_sync_transfer(const struct bt_le_per_adv_sync *per_adv_sync,
 		return -ENOTSUP;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PER_ADV_SYNC_TRANSFER,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2230,7 +2220,7 @@ static int past_param_set(const struct bt_conn *conn, uint8_t mode,
 	struct bt_hci_cp_le_past_param *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_PAST_PARAM, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2253,7 +2243,7 @@ static int default_past_param_set(uint8_t mode, uint16_t skip, uint16_t timeout,
 	struct bt_hci_cp_le_default_past_param *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_DEFAULT_PAST_PARAM, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2381,8 +2371,7 @@ int bt_le_per_adv_list_add(const bt_addr_le_t *addr, uint8_t sid)
 		return -EAGAIN;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_ADD_DEV_TO_PER_ADV_LIST,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}
@@ -2412,8 +2401,7 @@ int bt_le_per_adv_list_remove(const bt_addr_le_t *addr, uint8_t sid)
 		return -EAGAIN;
 	}
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_REM_DEV_FROM_PER_ADV_LIST,
-				sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1432,7 +1432,7 @@ static int cmd_hci_cmd(const struct shell *sh, size_t argc, char *argv[])
 			return -ENOEXEC;
 		}
 
-		buf = bt_hci_cmd_create(BT_OP(ogf, ocf), len);
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (buf == NULL) {
 			shell_error(sh, "Unable to allocate HCI buffer");
 			return -ENOMEM;

--- a/subsys/bluetooth/mesh/shell/hci.c
+++ b/subsys/bluetooth/mesh/shell/hci.c
@@ -30,9 +30,7 @@ int cmd_mesh_adv(const struct shell *sh, size_t argc, char *argv[])
 	if (!strcmp(argv[1], "on")) {
 		struct bt_hci_cp_mesh_advertise *cp;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_VS_MESH,
-					sizeof(struct bt_hci_cp_mesh) +
-					sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}
@@ -58,9 +56,7 @@ int cmd_mesh_adv(const struct shell *sh, size_t argc, char *argv[])
 	} else if (!strcmp(argv[1], "off")) {
 		struct bt_hci_cp_mesh_advertise_cancel *cp;
 
-		buf = bt_hci_cmd_create(BT_HCI_OP_VS_MESH,
-					sizeof(struct bt_hci_cp_mesh) +
-					sizeof(*cp));
+		buf = bt_hci_cmd_alloc(K_FOREVER);
 		if (!buf) {
 			return -ENOBUFS;
 		}

--- a/tests/bluetooth/df/connection_cte_req/src/test_cte_req_enable.c
+++ b/tests/bluetooth/df/connection_cte_req/src/test_cte_req_enable.c
@@ -63,7 +63,7 @@ int send_conn_cte_req_enable(uint16_t conn_handle,
 	struct bt_hci_cp_le_conn_cte_req_enable *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/tests/bluetooth/df/connection_cte_req/src/test_cte_set_rx_params.c
+++ b/tests/bluetooth/df/connection_cte_req/src/test_cte_set_rx_params.c
@@ -48,7 +48,7 @@ int send_set_conn_cte_rx_params(uint16_t conn_handle,
 
 	uint8_t ant_ids_num = (params != NULL ? params->switch_pattern_len : 0);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS, sizeof(*cp) + ant_ids_num);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/tests/bluetooth/df/connection_cte_tx_params/src/test_set_conn_cte_tx_params.c
+++ b/tests/bluetooth/df/connection_cte_tx_params/src/test_set_conn_cte_tx_params.c
@@ -59,8 +59,7 @@ static int send_set_conn_cte_tx_params(uint16_t conn_handle,
 	uint8_t *dest_ant_ids;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CONN_CTE_TX_PARAMS,
-				sizeof(*cp) + params->switch_pattern_len);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/tests/bluetooth/df/connectionless_cte_rx/src/test_set_iq_sampling_enable.c
+++ b/tests/bluetooth/df/connectionless_cte_rx/src/test_set_iq_sampling_enable.c
@@ -56,8 +56,7 @@ int send_set_scan_cte_rx_enable(uint16_t sync_handle,
 	struct bt_hci_cp_le_set_cl_cte_sampling_enable *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_SAMPLING_ENABLE,
-				sizeof(*cp) + params->num_ant_ids);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/tests/bluetooth/df/connectionless_cte_tx/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_tx/src/common.c
@@ -59,8 +59,7 @@ void common_set_cl_cte_tx_params(void)
 	struct net_buf *buf;
 	int err;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_TX_PARAMS,
-				sizeof(*cp) + ARRAY_SIZE(ant_ids));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	zassert_not_null(buf, "Failed to create HCI cmd object");
 
 	cp = net_buf_add(buf, sizeof(*cp));

--- a/tests/bluetooth/df/connectionless_cte_tx/src/test_set_cl_cte_tx_enable.c
+++ b/tests/bluetooth/df/connectionless_cte_tx/src/test_set_cl_cte_tx_enable.c
@@ -35,7 +35,7 @@ int send_set_cl_cte_tx_enable(uint8_t adv_handle, atomic_t *adv_flags,
 	struct bt_hci_cmd_state_set state;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_TX_ENABLE, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	if (!buf) {
 		return -ENOBUFS;
 	}

--- a/tests/bluetooth/df/connectionless_cte_tx/src/test_set_cl_cte_tx_param.c
+++ b/tests/bluetooth/df/connectionless_cte_tx/src/test_set_cl_cte_tx_param.c
@@ -54,8 +54,7 @@ int send_set_cl_cte_tx_params(uint8_t adv_handle, uint8_t cte_len,
 	struct bt_hci_cp_le_set_cl_cte_tx_params *cp;
 	struct net_buf *buf;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_CL_CTE_TX_PARAMS,
-				sizeof(*cp) + switch_pattern_len);
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	zassert_not_null(buf, "Failed to create HCI cmd object");
 
 	cp = net_buf_add(buf, sizeof(*cp));

--- a/tests/bluetooth/hci_codecs_info/src/main.c
+++ b/tests/bluetooth/hci_codecs_info/src/main.c
@@ -185,7 +185,7 @@ ZTEST(test_hci_codecs_info, test_read_codec_capabilities)
 	bt_enable(NULL);
 
 	/* Read Local Supported Codec Capabilities */
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_CODEC_CAPABILITIES, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	cp = net_buf_add(buf, sizeof(*cp));
 
 	cp->codec_id.coding_format = READ_CAPABS_CODING_FMT;
@@ -268,7 +268,7 @@ ZTEST(test_hci_codecs_info, test_read_ctlr_delay)
 	bt_enable(NULL);
 
 	/* Read Local Supported Controller Delay */
-	buf = bt_hci_cmd_create(BT_HCI_OP_READ_CTLR_DELAY, sizeof(*cp));
+	buf = bt_hci_cmd_alloc(K_FOREVER);
 	cp = net_buf_add(buf, sizeof(*cp) + sizeof(read_delay_codec_config));
 
 	cp->codec_id.coding_format = READ_DELAY_CODING_FMT;

--- a/tests/bluetooth/host/conn/mocks/hci_core.c
+++ b/tests/bluetooth/host/conn/mocks/hci_core.c
@@ -11,7 +11,7 @@
 
 #include "hci_core.h"
 
-DEFINE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_create, uint16_t, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_alloc, k_timeout_t);
 DEFINE_FAKE_VALUE_FUNC(int, bt_hci_cmd_send_sync, uint16_t, struct net_buf *, struct net_buf **);
 DEFINE_FAKE_VALUE_FUNC(int, bt_hci_le_read_remote_features, struct bt_conn *);
 DEFINE_FAKE_VALUE_FUNC(int, bt_hci_disconnect, uint16_t, uint8_t);

--- a/tests/bluetooth/host/conn/mocks/hci_core.h
+++ b/tests/bluetooth/host/conn/mocks/hci_core.h
@@ -9,7 +9,7 @@
 
 /* List of fakes used by this unit tester */
 #define HCI_CORE_MOCKS_FFF_FAKES_LIST(FAKE)                                                        \
-	FAKE(bt_hci_cmd_create)                                                                    \
+	FAKE(bt_hci_cmd_alloc)                                                                     \
 	FAKE(bt_hci_cmd_send_sync)                                                                 \
 	FAKE(bt_hci_le_read_remote_features)                                                       \
 	FAKE(bt_hci_disconnect)                                                                    \
@@ -24,7 +24,7 @@
 	FAKE(bt_lookup_id_addr)                                                                    \
 	FAKE(bt_le_set_phy)
 
-DECLARE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_create, uint16_t, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_alloc, k_timeout_t);
 DECLARE_FAKE_VALUE_FUNC(int, bt_hci_cmd_send_sync, uint16_t, struct net_buf *, struct net_buf **);
 DECLARE_FAKE_VALUE_FUNC(int, bt_hci_le_read_remote_features, struct bt_conn *);
 DECLARE_FAKE_VALUE_FUNC(int, bt_hci_disconnect, uint16_t, uint8_t);

--- a/tests/bluetooth/host/cs/mocks/hci_core.c
+++ b/tests/bluetooth/host/cs/mocks/hci_core.c
@@ -9,5 +9,5 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/kernel.h>
 
-DEFINE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_create, uint16_t, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_alloc, k_timeout_t);
 DEFINE_FAKE_VALUE_FUNC(int, bt_hci_cmd_send_sync, uint16_t, struct net_buf *, struct net_buf **);

--- a/tests/bluetooth/host/cs/mocks/hci_core.h
+++ b/tests/bluetooth/host/cs/mocks/hci_core.h
@@ -9,8 +9,8 @@
 
 /* List of fakes used by this unit tester */
 #define HCI_CORE_FFF_FAKES_LIST(FAKE)                                                              \
-	FAKE(bt_hci_cmd_create)                                                                    \
+	FAKE(bt_hci_cmd_alloc)                                                                    \
 	FAKE(bt_hci_cmd_send_sync)
 
-DECLARE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_create, uint16_t, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_alloc, k_timeout_t);
 DECLARE_FAKE_VALUE_FUNC(int, bt_hci_cmd_send_sync, uint16_t, struct net_buf *, struct net_buf **);

--- a/tests/bluetooth/host/id/bt_id_add/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_add/src/main.c
@@ -218,7 +218,7 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
 	bt_conn_lookup_state_le_fake.return_val = NULL;
 
 	/* This makes addr_res_enable() succeeds and returns 0 */
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	bt_id_add(&keys);
@@ -268,7 +268,7 @@ ZTEST(bt_id_add, test_conn_lookup_returns_null_no_ext_adv_no_resolving_entries)
 
 	/* This makes hci_id_add() succeeds and returns 0 */
 	net_buf_simple_add_fake.return_val = &cp;
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	bt_id_add(&keys);
@@ -326,7 +326,7 @@ ZTEST(bt_id_add, test_scan_re_enabled_observer_enabled_ext_adv)
 
 	/* This makes hci_id_add() succeeds and returns 0 */
 	net_buf_simple_add_fake.return_val = &cp;
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	bt_id_add(&keys);

--- a/tests/bluetooth/host/id/bt_id_del/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_del/src/main.c
@@ -232,7 +232,7 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv)
 	keys.state |= BT_KEYS_ID_ADDED;
 
 	/* This makes addr_res_enable() succeeds and returns 0 */
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	bt_id_del(&keys);
@@ -284,7 +284,7 @@ ZTEST(bt_id_del, test_conn_lookup_returns_null_broadcaster_no_ext_adv_privacy_en
 	keys.state |= BT_KEYS_ID_ADDED;
 
 	/* This makes addr_res_enable() succeeds and returns 0 */
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	bt_id_del(&keys);
@@ -333,7 +333,7 @@ ZTEST(bt_id_del, test_send_hci_id_del)
 
 	/* This makes hci_id_del() succeeds and returns 0 */
 	net_buf_simple_add_fake.return_val = &cp;
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	bt_id_del(&keys);
@@ -388,7 +388,7 @@ ZTEST(bt_id_del, test_scan_re_enabled_observer_enabled_ext_adv)
 
 	/* This makes hci_id_del() succeeds and returns 0 */
 	net_buf_simple_add_fake.return_val = &cp;
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	bt_id_del(&keys);

--- a/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
+++ b/tests/bluetooth/host/id/bt_id_init/src/test_suite_setup_static_random_identity.c
@@ -202,7 +202,7 @@ ZTEST(bt_id_init_setup_static_random_identity, test_init_dev_identity_set_random
 			  rp->num_addrs * sizeof(struct bt_hci_vs_static_addr);
 
 	/* This will make set_random_address() returns a negative number error code */
-	bt_hci_cmd_create_fake.return_val = NULL;
+	bt_hci_cmd_alloc_fake.return_val = NULL;
 	bt_hci_cmd_send_sync_fake.custom_fake = bt_hci_cmd_send_sync_custom_fake;
 
 	err = bt_id_init();

--- a/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_private_addr/src/test_suite_invalid_cases.c
@@ -86,7 +86,7 @@ ZTEST(bt_id_set_adv_private_addr_invalid_cases, test_set_adv_address_set_adv_ran
 
 	bt_rand_fake.custom_fake = bt_rand_custom_fake;
 	/* This will make set_random_address() returns a negative number error code */
-	bt_hci_cmd_create_fake.return_val = NULL;
+	bt_hci_cmd_alloc_fake.return_val = NULL;
 
 	err = bt_id_set_adv_private_addr(&adv_param);
 
@@ -158,7 +158,7 @@ ZTEST(bt_id_set_adv_private_addr_invalid_cases, test_set_adv_address_if_set_adv_
 
 	/* This will make bt_id_set_adv_random_addr() returns a negative number error code */
 	atomic_set_bit(adv_param.flags, BT_ADV_PARAMS_SET);
-	bt_hci_cmd_create_fake.return_val = NULL;
+	bt_hci_cmd_alloc_fake.return_val = NULL;
 
 	err = bt_id_set_adv_private_addr(&adv_param);
 

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/main.c
@@ -52,7 +52,7 @@ ZTEST(bt_id_set_adv_random_addr, test_no_ext_adv)
 
 	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
 
-	expect_not_called_bt_hci_cmd_create();
+	expect_not_called_bt_hci_cmd_alloc();
 	expect_not_called_bt_hci_cmd_send_sync();
 	expect_not_called_net_buf_simple_add();
 
@@ -82,7 +82,7 @@ ZTEST(bt_id_set_adv_random_addr, test_ext_adv_enabled)
 
 	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
 
-	expect_not_called_bt_hci_cmd_create();
+	expect_not_called_bt_hci_cmd_alloc();
 	expect_not_called_bt_hci_cmd_send_sync();
 	expect_not_called_net_buf_simple_add();
 
@@ -102,7 +102,7 @@ ZTEST(bt_id_set_adv_random_addr, test_ext_adv_enabled)
  *  Constraints:
  *   - 'CONFIG_BT_EXT_ADV' is enabled
  *   - 'BT_ADV_PARAMS_SET' flag in advertising parameters reference is set
- *   - bt_hci_cmd_create() returns a valid buffer pointer
+ *   - bt_hci_cmd_alloc() returns a valid buffer pointer
  *   - bt_hci_cmd_send_sync() returns 0 (success)
  *
  *  Expected behaviour:
@@ -120,13 +120,13 @@ ZTEST(bt_id_set_adv_random_addr, test_ext_adv_enabled_hci_set_adv_set_random_add
 	atomic_set_bit(adv_param.flags, BT_ADV_PARAMS_SET);
 
 	net_buf_simple_add_fake.return_val = &cp;
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = 0;
 
 	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
 
 	expect_single_call_net_buf_simple_add(&net_buff.b, sizeof(cp));
-	expect_single_call_bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_SET_RANDOM_ADDR, sizeof(cp));
+	expect_single_call_bt_hci_cmd_alloc();
 	expect_single_call_bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_ADV_SET_RANDOM_ADDR);
 
 	zassert_ok(err, "Unexpected error code '%d' was returned", err);

--- a/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_adv_random_addr/src/test_suite_invalid_cases.c
@@ -73,17 +73,17 @@ ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_null_arguments)
 /*
  *  Test setting advertising random address while 'CONFIG_BT_EXT_ADV' is enabled
  *  and 'BT_ADV_PARAMS_SET' flag in advertising parameters reference is set.
- *  bt_hci_cmd_create() fails to allocate buffers and returns NULL.
+ *  bt_hci_cmd_alloc() fails to allocate buffers and returns NULL.
  *
  *  Constraints:
  *   - 'CONFIG_BT_EXT_ADV' is enabled
  *   - 'BT_ADV_PARAMS_SET' flag in advertising parameters reference is set
- *   - bt_hci_cmd_create() returns null
+ *   - bt_hci_cmd_alloc() returns null
  *
  *  Expected behaviour:
  *   - bt_id_set_adv_random_addr() returns a negative error code (failure)
  */
-ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_bt_hci_cmd_create_returns_null)
+ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_bt_hci_cmd_alloc_returns_null)
 {
 	int err;
 	struct bt_le_ext_adv adv_param = {0};
@@ -92,7 +92,7 @@ ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_bt_hci_cmd_create_returns_nu
 
 	atomic_set_bit(adv_param.flags, BT_ADV_PARAMS_SET);
 
-	bt_hci_cmd_create_fake.return_val = NULL;
+	bt_hci_cmd_alloc_fake.return_val = NULL;
 
 	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);
 
@@ -107,7 +107,7 @@ ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_bt_hci_cmd_create_returns_nu
  *  Constraints:
  *   - 'CONFIG_BT_EXT_ADV' is enabled
  *   - 'BT_ADV_PARAMS_SET' flag in advertising parameters reference is set
- *   - bt_hci_cmd_create() returns a valid buffer pointer
+ *   - bt_hci_cmd_alloc() returns a valid buffer pointer
  *   - bt_hci_cmd_send_sync() fails and returns a negative error code.
  *
  *  Expected behaviour:
@@ -125,7 +125,7 @@ ZTEST(bt_id_set_adv_random_addr_invalid_cases, test_bt_hci_cmd_send_sync_fails)
 	atomic_set_bit(adv_param.flags, BT_ADV_PARAMS_SET);
 
 	net_buf_simple_add_fake.return_val = &cp;
-	bt_hci_cmd_create_fake.return_val = &net_buff;
+	bt_hci_cmd_alloc_fake.return_val = &net_buff;
 	bt_hci_cmd_send_sync_fake.return_val = -1;
 
 	err = bt_id_set_adv_random_addr(&adv_param, &BT_RPA_LE_ADDR->a);

--- a/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_create_conn_own_addr/src/test_suite_invalid_inputs.c
@@ -59,7 +59,7 @@ ZTEST(bt_id_set_create_conn_own_addr_invalid_inputs, test_set_random_address_fai
 	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	/* This will cause set_random_address() to return (-ENOBUFS) */
-	bt_hci_cmd_create_fake.return_val = NULL;
+	bt_hci_cmd_alloc_fake.return_val = NULL;
 
 	err = bt_id_set_create_conn_own_addr(false, &own_addr_type);
 

--- a/tests/bluetooth/host/id/bt_id_set_private_addr/src/test_suite_invalid_cases.c
+++ b/tests/bluetooth/host/id/bt_id_set_private_addr/src/test_suite_invalid_cases.c
@@ -110,7 +110,7 @@ ZTEST(bt_id_set_private_addr_invalid_cases, test_setting_address_set_random_addr
 	}
 
 	/* This will make set_random_address() returns a negative number error code */
-	bt_hci_cmd_create_fake.return_val = NULL;
+	bt_hci_cmd_alloc_fake.return_val = NULL;
 
 	err = bt_id_set_private_addr(BT_ID_DEFAULT);
 

--- a/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/id/bt_id_set_scan_own_addr/src/test_suite_invalid_inputs.c
@@ -91,7 +91,7 @@ ZTEST(bt_id_set_scan_own_addr_invalid_inputs, test_set_random_address_fails)
 	bt_addr_le_copy(&bt_dev.id_addr[BT_ID_DEFAULT], BT_RPA_LE_ADDR);
 
 	/* This will cause set_random_address() to return (-ENOBUFS) */
-	bt_hci_cmd_create_fake.return_val = NULL;
+	bt_hci_cmd_alloc_fake.return_val = NULL;
 
 	err = bt_id_set_scan_own_addr(false, &own_addr_type);
 

--- a/tests/bluetooth/host/id/mocks/hci_core.c
+++ b/tests/bluetooth/host/id/mocks/hci_core.c
@@ -16,5 +16,5 @@ struct bt_dev bt_dev = {
 };
 
 DEFINE_FAKE_VALUE_FUNC(int, bt_unpair, uint8_t, const bt_addr_le_t *);
-DEFINE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_create, uint16_t, uint8_t);
+DEFINE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_alloc, k_timeout_t);
 DEFINE_FAKE_VALUE_FUNC(int, bt_hci_cmd_send_sync, uint16_t, struct net_buf *, struct net_buf **);

--- a/tests/bluetooth/host/id/mocks/hci_core.h
+++ b/tests/bluetooth/host/id/mocks/hci_core.h
@@ -11,9 +11,9 @@
 /* List of fakes used by this unit tester */
 #define HCI_CORE_FFF_FAKES_LIST(FAKE)                                                              \
 	FAKE(bt_unpair)                                                                            \
-	FAKE(bt_hci_cmd_create)                                                                    \
+	FAKE(bt_hci_cmd_alloc)                                                                    \
 	FAKE(bt_hci_cmd_send_sync)
 
 DECLARE_FAKE_VALUE_FUNC(int, bt_unpair, uint8_t, const bt_addr_le_t *);
-DECLARE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_create, uint16_t, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(struct net_buf *, bt_hci_cmd_alloc, k_timeout_t);
 DECLARE_FAKE_VALUE_FUNC(int, bt_hci_cmd_send_sync, uint16_t, struct net_buf *, struct net_buf **);

--- a/tests/bluetooth/host/id/mocks/hci_core_expects.c
+++ b/tests/bluetooth/host/id/mocks/hci_core_expects.c
@@ -35,24 +35,19 @@ void expect_not_called_bt_unpair(void)
 	zassert_equal(bt_unpair_fake.call_count, 0, "'%s()' was called unexpectedly", func_name);
 }
 
-void expect_single_call_bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
+void expect_single_call_bt_hci_cmd_alloc(void)
 {
-	const char *func_name = "bt_hci_cmd_create";
+	const char *func_name = "bt_hci_cmd_alloc";
 
-	zassert_equal(bt_hci_cmd_create_fake.call_count, 1, "'%s()' was called more than once",
+	zassert_equal(bt_hci_cmd_alloc_fake.call_count, 1, "'%s()' was called more than once",
 		      func_name);
-
-	zassert_equal(bt_hci_cmd_create_fake.arg0_val, opcode,
-		      "'%s()' was called with incorrect '%s' value", func_name, "opcode");
-	zassert_equal(bt_hci_cmd_create_fake.arg1_val, param_len,
-		      "'%s()' was called with incorrect '%s' value", func_name, "param_len");
 }
 
-void expect_not_called_bt_hci_cmd_create(void)
+void expect_not_called_bt_hci_cmd_alloc(void)
 {
-	const char *func_name = "bt_hci_cmd_create";
+	const char *func_name = "bt_hci_cmd_alloc";
 
-	zassert_equal(bt_hci_cmd_create_fake.call_count, 0, "'%s()' was called unexpectedly",
+	zassert_equal(bt_hci_cmd_alloc_fake.call_count, 0, "'%s()' was called unexpectedly",
 		      func_name);
 }
 

--- a/tests/bluetooth/host/id/mocks/hci_core_expects.h
+++ b/tests/bluetooth/host/id/mocks/hci_core_expects.h
@@ -23,20 +23,20 @@ void expect_single_call_bt_unpair(uint8_t id, const bt_addr_le_t *addr);
 void expect_not_called_bt_unpair(void);
 
 /*
- *  Validate expected behaviour when bt_hci_cmd_create() is called
+ *  Validate expected behaviour when bt_hci_cmd_alloc() is called
  *
  *  Expected behaviour:
- *   - bt_hci_cmd_create() to be called once with correct parameters
+ *   - bt_hci_cmd_alloc() to be called once with correct parameters
  */
-void expect_single_call_bt_hci_cmd_create(uint16_t opcode, uint8_t param_len);
+void expect_single_call_bt_hci_cmd_alloc(void);
 
 /*
- *  Validate expected behaviour when bt_hci_cmd_create() isn't called
+ *  Validate expected behaviour when bt_hci_cmd_alloc() isn't called
  *
  *  Expected behaviour:
- *   - bt_hci_cmd_create() isn't called at all
+ *   - bt_hci_cmd_alloc() isn't called at all
  */
-void expect_not_called_bt_hci_cmd_create(void);
+void expect_not_called_bt_hci_cmd_alloc(void);
 
 /*
  *  Validate expected behaviour when bt_hci_cmd_send_sync() is called

--- a/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
@@ -66,7 +66,7 @@ static uint16_t conn_handle;
 static volatile uint16_t active_opcode = 0xFFFF;
 static struct net_buf *cmd_rsp;
 
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
+static struct net_buf *create_cmd(uint16_t opcode, uint8_t param_len)
 {
 	struct bt_hci_cmd_hdr *hdr;
 	struct net_buf *buf;
@@ -349,7 +349,7 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
-		cmd = bt_hci_cmd_create(opcode, 0);
+		cmd = create_cmd(opcode, 0);
 	}
 
 	k_sem_take(&cmd_sem, K_FOREVER);
@@ -420,7 +420,7 @@ static void read_max_data_len(uint16_t *tx_octets, uint16_t *tx_time)
 static void write_default_data_len(uint16_t tx_octets, uint16_t tx_time)
 {
 	struct bt_hci_cp_le_write_default_data_len *cp;
-	struct net_buf *buf = bt_hci_cmd_create(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
+	struct net_buf *buf = create_cmd(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
 
 	TEST_ASSERT_NO_MSG(buf);
 
@@ -446,7 +446,7 @@ static void set_event_mask(uint16_t opcode)
 	uint64_t mask = 0U;
 
 	/* The two commands have the same length/params */
-	buf = bt_hci_cmd_create(opcode, sizeof(*cp_mask));
+	buf = create_cmd(opcode, sizeof(*cp_mask));
 	TEST_ASSERT_NO_MSG(buf);
 
 	/* Forward all events */
@@ -464,7 +464,7 @@ static void set_random_address(void)
 
 	LOG_DBG("%s", bt_addr_str(&addr.a));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
+	buf = create_cmd(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
 	TEST_ASSERT_NO_MSG(buf);
 
 	net_buf_add_mem(buf, &addr.a, sizeof(addr.a));
@@ -487,12 +487,12 @@ void start_adv(void)
 	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	/* configure */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	net_buf_add_mem(buf, &set_param, sizeof(set_param));
 	send_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, buf, NULL);
 
 	/* start */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
 	net_buf_add_u8(buf, BT_HCI_LE_ADV_ENABLE);
 	send_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, buf, NULL);
 }

--- a/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
@@ -61,7 +61,7 @@ static uint16_t conn_handle;
 static volatile uint16_t active_opcode = 0xFFFF;
 static struct net_buf *cmd_rsp;
 
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
+static struct net_buf *create_cmd(uint16_t opcode, uint8_t param_len)
 {
 	struct bt_hci_cmd_hdr *hdr;
 	struct net_buf *buf;
@@ -326,7 +326,7 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
-		cmd = bt_hci_cmd_create(opcode, 0);
+		cmd = create_cmd(opcode, 0);
 	}
 
 	k_sem_take(&cmd_sem, K_FOREVER);
@@ -397,7 +397,7 @@ static void read_max_data_len(uint16_t *tx_octets, uint16_t *tx_time)
 static void write_default_data_len(uint16_t tx_octets, uint16_t tx_time)
 {
 	struct bt_hci_cp_le_write_default_data_len *cp;
-	struct net_buf *buf = bt_hci_cmd_create(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
+	struct net_buf *buf = create_cmd(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
 
 	TEST_ASSERT_NO_MSG(buf);
 
@@ -423,7 +423,7 @@ static void set_event_mask(uint16_t opcode)
 	uint64_t mask = 0U;
 
 	/* The two commands have the same length/params */
-	buf = bt_hci_cmd_create(opcode, sizeof(*cp_mask));
+	buf = create_cmd(opcode, sizeof(*cp_mask));
 	TEST_ASSERT_NO_MSG(buf);
 
 	/* Forward all events */
@@ -441,7 +441,7 @@ static void set_random_address(void)
 
 	LOG_DBG("%s", bt_addr_str(&addr.a));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
+	buf = create_cmd(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
 	TEST_ASSERT_NO_MSG(buf);
 
 	net_buf_add_mem(buf, &addr.a, sizeof(addr.a));
@@ -464,12 +464,12 @@ void start_adv(void)
 	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	/* configure */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	net_buf_add_mem(buf, &set_param, sizeof(set_param));
 	send_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, buf, NULL);
 
 	/* start */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
 	net_buf_add_u8(buf, BT_HCI_LE_ADV_ENABLE);
 	send_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, buf, NULL);
 }

--- a/tests/bsim/bluetooth/host/central/src/main.c
+++ b/tests/bsim/bluetooth/host/central/src/main.c
@@ -78,7 +78,7 @@ static void test_central_connect_timeout_with_timeout(uint32_t timeout_ms, bool 
 	if (stack_load) {
 		/* Claim all the buffers so that the stack cannot handle the timeout */
 		for (int i = 0; i < BT_BUF_CMD_TX_COUNT; i++) {
-			bufs[i] = bt_hci_cmd_create(BT_HCI_LE_ADV_ENABLE, 0);
+			bufs[i] = bt_hci_cmd_alloc(K_FOREVER);
 			TEST_ASSERT(bufs[i] != NULL, "Failed to claim all command buffers");
 		}
 		/* Hold all the buffers until after we expect the connection to timeout */

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
@@ -57,7 +57,7 @@ static uint16_t conn_handle;
 static volatile uint16_t active_opcode = 0xFFFF;
 static struct net_buf *cmd_rsp;
 
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
+static struct net_buf *create_cmd(uint16_t opcode, uint8_t param_len)
 {
 	struct bt_hci_cmd_hdr *hdr;
 	struct net_buf *buf;
@@ -279,7 +279,7 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
-		cmd = bt_hci_cmd_create(opcode, 0);
+		cmd = create_cmd(opcode, 0);
 	}
 
 	k_sem_take(&cmd_sem, K_FOREVER);
@@ -352,7 +352,7 @@ static void set_event_mask(uint16_t opcode)
 	uint64_t mask = 0U;
 
 	/* The two commands have the same length/params */
-	buf = bt_hci_cmd_create(opcode, sizeof(*cp_mask));
+	buf = create_cmd(opcode, sizeof(*cp_mask));
 	TEST_ASSERT_NO_MSG(buf);
 
 	/* Forward all events */
@@ -370,7 +370,7 @@ static void set_random_address(void)
 
 	LOG_DBG("%s", bt_addr_str(&addr.a));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
+	buf = create_cmd(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
 	TEST_ASSERT_NO_MSG(buf);
 
 	net_buf_add_mem(buf, &addr.a, sizeof(addr.a));
@@ -392,7 +392,7 @@ static void start_adv(uint16_t interval, const char *name, size_t name_len)
 	data.data[1] = BT_DATA_NAME_COMPLETE;
 	memcpy(&data.data[2], name, name_len);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_DATA, sizeof(data));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_DATA, sizeof(data));
 	__ASSERT_NO_MSG(buf);
 	net_buf_add_mem(buf, &data, sizeof(data));
 	send_cmd(BT_HCI_OP_LE_SET_ADV_DATA, buf, NULL);
@@ -405,13 +405,13 @@ static void start_adv(uint16_t interval, const char *name, size_t name_len)
 	set_param.type = BT_HCI_ADV_IND;
 	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	__ASSERT_NO_MSG(buf);
 	net_buf_add_mem(buf, &set_param, sizeof(set_param));
 
 	send_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, buf, NULL);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
 	__ASSERT_NO_MSG(buf);
 
 	net_buf_add_u8(buf, BT_HCI_LE_ADV_ENABLE);
@@ -427,7 +427,7 @@ static void disconnect(void)
 
 	LOG_INF("Disconnecting");
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_DISCONNECT, sizeof(*disconn));
+	buf = create_cmd(BT_HCI_OP_DISCONNECT, sizeof(*disconn));
 	TEST_ASSERT(buf);
 
 	disconn = net_buf_add(buf, sizeof(*disconn));

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
@@ -49,7 +49,7 @@ static uint16_t conn_handle;
 static uint16_t active_opcode = 0xFFFF;
 static struct net_buf *cmd_rsp;
 
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
+static struct net_buf *create_cmd(uint16_t opcode, uint8_t param_len)
 {
 	struct bt_hci_cmd_hdr *hdr;
 	struct net_buf *buf;
@@ -306,7 +306,7 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
-		cmd = bt_hci_cmd_create(opcode, 0);
+		cmd = create_cmd(opcode, 0);
 	}
 
 	k_sem_take(&cmd_sem, K_FOREVER);
@@ -377,7 +377,7 @@ static void read_max_data_len(uint16_t *tx_octets, uint16_t *tx_time)
 static void write_default_data_len(uint16_t tx_octets, uint16_t tx_time)
 {
 	struct bt_hci_cp_le_write_default_data_len *cp;
-	struct net_buf *buf = bt_hci_cmd_create(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
+	struct net_buf *buf = create_cmd(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
 
 	__ASSERT_NO_MSG(buf);
 
@@ -403,7 +403,7 @@ static void set_event_mask(uint16_t opcode)
 	uint64_t mask = 0U;
 
 	/* The two commands have the same length/params */
-	buf = bt_hci_cmd_create(opcode, sizeof(*cp_mask));
+	buf = create_cmd(opcode, sizeof(*cp_mask));
 	__ASSERT_NO_MSG(buf);
 
 	/* Forward all events */
@@ -421,7 +421,7 @@ static void set_random_address(void)
 
 	LOG_DBG("%s", bt_addr_str(&addr.a));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
+	buf = create_cmd(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
 	__ASSERT_NO_MSG(buf);
 
 	net_buf_add_mem(buf, &addr.a, sizeof(addr.a));
@@ -442,13 +442,13 @@ void start_adv(uint16_t interval)
 	set_param.type = BT_HCI_ADV_IND;
 	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	__ASSERT_NO_MSG(buf);
 	net_buf_add_mem(buf, &set_param, sizeof(set_param));
 
 	send_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, buf, NULL);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
 	__ASSERT_NO_MSG(buf);
 
 	net_buf_add_u8(buf, BT_HCI_LE_ADV_ENABLE);

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
@@ -59,7 +59,7 @@ static uint16_t conn_handle;
 static volatile uint16_t active_opcode = 0xFFFF;
 static struct net_buf *cmd_rsp;
 
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
+static struct net_buf *create_cmd(uint16_t opcode, uint8_t param_len)
 {
 	struct bt_hci_cmd_hdr *hdr;
 	struct net_buf *buf;
@@ -303,7 +303,7 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
-		cmd = bt_hci_cmd_create(opcode, 0);
+		cmd = create_cmd(opcode, 0);
 	}
 
 	k_sem_take(&cmd_sem, K_FOREVER);
@@ -374,7 +374,7 @@ static void read_max_data_len(uint16_t *tx_octets, uint16_t *tx_time)
 static void write_default_data_len(uint16_t tx_octets, uint16_t tx_time)
 {
 	struct bt_hci_cp_le_write_default_data_len *cp;
-	struct net_buf *buf = bt_hci_cmd_create(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
+	struct net_buf *buf = create_cmd(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
 
 	TEST_ASSERT_NO_MSG(buf);
 
@@ -400,7 +400,7 @@ static void set_event_mask(uint16_t opcode)
 	uint64_t mask = 0U;
 
 	/* The two commands have the same length/params */
-	buf = bt_hci_cmd_create(opcode, sizeof(*cp_mask));
+	buf = create_cmd(opcode, sizeof(*cp_mask));
 	TEST_ASSERT_NO_MSG(buf);
 
 	/* Forward all events */
@@ -418,7 +418,7 @@ static void set_random_address(void)
 
 	LOG_DBG("%s", bt_addr_str(&addr.a));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
+	buf = create_cmd(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
 	TEST_ASSERT_NO_MSG(buf);
 
 	net_buf_add_mem(buf, &addr.a, sizeof(addr.a));
@@ -441,12 +441,12 @@ void start_adv(void)
 	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
 	/* configure */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	net_buf_add_mem(buf, &set_param, sizeof(set_param));
 	send_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, buf, NULL);
 
 	/* start */
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
 	net_buf_add_u8(buf, BT_HCI_LE_ADV_ENABLE);
 	send_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, buf, NULL);
 }

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
@@ -50,7 +50,7 @@ static uint16_t conn_handle;
 static uint16_t active_opcode = 0xFFFF;
 static struct net_buf *cmd_rsp;
 
-struct net_buf *bt_hci_cmd_create(uint16_t opcode, uint8_t param_len)
+static struct net_buf *create_cmd(uint16_t opcode, uint8_t param_len)
 {
 	struct bt_hci_cmd_hdr *hdr;
 	struct net_buf *buf;
@@ -317,7 +317,7 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
-		cmd = bt_hci_cmd_create(opcode, 0);
+		cmd = create_cmd(opcode, 0);
 	}
 
 	k_sem_take(&cmd_sem, K_FOREVER);
@@ -388,7 +388,7 @@ static void read_max_data_len(uint16_t *tx_octets, uint16_t *tx_time)
 static void write_default_data_len(uint16_t tx_octets, uint16_t tx_time)
 {
 	struct bt_hci_cp_le_write_default_data_len *cp;
-	struct net_buf *buf = bt_hci_cmd_create(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
+	struct net_buf *buf = create_cmd(BT_HCI_OP_LE_WRITE_DEFAULT_DATA_LEN, sizeof(*cp));
 
 	__ASSERT_NO_MSG(buf);
 
@@ -414,7 +414,7 @@ static void set_event_mask(uint16_t opcode)
 	uint64_t mask = 0U;
 
 	/* The two commands have the same length/params */
-	buf = bt_hci_cmd_create(opcode, sizeof(*cp_mask));
+	buf = create_cmd(opcode, sizeof(*cp_mask));
 	__ASSERT_NO_MSG(buf);
 
 	/* Forward all events */
@@ -435,7 +435,7 @@ static void set_random_address(void)
 
 	LOG_DBG("%s", bt_addr_str(&addr.a));
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
+	buf = create_cmd(BT_HCI_OP_LE_SET_RANDOM_ADDRESS, sizeof(addr.a));
 	__ASSERT_NO_MSG(buf);
 
 	net_buf_add_mem(buf, &addr.a, sizeof(addr.a));
@@ -457,7 +457,7 @@ static void start_adv(uint16_t interval, const char *name, size_t name_len)
 	data.data[1] = BT_DATA_NAME_COMPLETE;
 	memcpy(&data.data[2], name, name_len);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_DATA, sizeof(data));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_DATA, sizeof(data));
 	__ASSERT_NO_MSG(buf);
 	net_buf_add_mem(buf, &data, sizeof(data));
 	send_cmd(BT_HCI_OP_LE_SET_ADV_DATA, buf, NULL);
@@ -470,13 +470,13 @@ static void start_adv(uint16_t interval, const char *name, size_t name_len)
 	set_param.type = BT_HCI_ADV_IND;
 	set_param.own_addr_type = BT_HCI_OWN_ADDR_RANDOM;
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, sizeof(set_param));
 	__ASSERT_NO_MSG(buf);
 	net_buf_add_mem(buf, &set_param, sizeof(set_param));
 
 	send_cmd(BT_HCI_OP_LE_SET_ADV_PARAM, buf, NULL);
 
-	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
+	buf = create_cmd(BT_HCI_OP_LE_SET_ADV_ENABLE, 1);
 	__ASSERT_NO_MSG(buf);
 
 	net_buf_add_u8(buf, BT_HCI_LE_ADV_ENABLE);


### PR DESCRIPTION
Introduce a new `bt_hci_cmd_alloc()` API which only allocates a command buffer and reserves sufficient headroom for H:4 and command headers, but doesn't actually encode any of those headers into the buffer. Additionally, modify bt_hci_cmd_send() and bt_hci_cmd_send_sync() so that they handle such buffers and perform the header encoding correctly. To avoid duplication, `bt_hci_cmd_send_sync()` now builds upon (i.e. calls internally) the `bt_hci_cmd_send()` API.

The `bt_hci_cmd_create()` API becomes deprecated by this change.

The way `bt_hci_cmd_create()` and `bt_hci_cmd_send()`/`bt_hci_cmd_send_sync()` were designed was always a bit awkward, since you had to pass the opcode twice, and the code didn't take any advantage of `buf->len` to encode the command header. This PR resolves those issues.