### PR TITLE
bindesc: fix typo in errno (ENONET->ENOENT)

### DIFF
--- a/subsys/bindesc/bindesc_read.c
+++ b/subsys/bindesc/bindesc_read.c
@@ -118,7 +118,7 @@ int bindesc_open_ram(struct bindesc_handle *handle, const uint8_t *address, size
 
 	if (*(uint64_t *)address != BINDESC_MAGIC) {
 		LOG_ERR("Magic not found in given address");
-		return -ENONET;
+		return -ENOENT;
 	}
 
 	handle->address = address;


### PR DESCRIPTION
Fix typo in errno which isn't caught when building since ENONET is also a valid code, despite not being defined (nor allowed?) in Zephyr proper.