### PR TITLE
scripts: ci: check_compliance: disable trailing-whitespace check in SphinxLint

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1720,7 +1720,11 @@ class SphinxLint(ComplianceTest):
     doc = "Check Sphinx/reStructuredText files with sphinx-lint."
 
     # Checkers added/removed to sphinx-lint's default set
-    DISABLE_CHECKERS = ["horizontal-tab", "missing-space-before-default-role"]
+    DISABLE_CHECKERS = [
+        "horizontal-tab",
+        "missing-space-before-default-role",
+        "trailing-whitespace",
+    ]
     ENABLE_CHECKERS = ["default-role"]
 
     def run(self):


### PR DESCRIPTION
SphinxLint doesn't need to report trailing whitespace errors as it's already checked by checkpatch.pl.