### PR TITLE
tests: boot: add Espressif boards to MCUboot test case

### DIFF
--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -49,6 +49,12 @@ tests:
       - nrf52840dk/nrf52840
       - rd_rw612_bga
       - nucleo_wba55cg
+      - esp32_devkitc/esp32/procpu
+      - esp32s2_saola
+      - esp32s3_devkitm/esp32s3/procpu
+      - esp32c3_devkitm
+      - esp32c6_devkitc/esp32c6/hpcore
+      - esp8684_devkitm
     integration_platforms:
       - frdm_k64f
       - nrf52840dk/nrf52840


### PR DESCRIPTION
Include all supported Espressif SoC variants in the MCUboot test suite to ensure proper CI coverage.