### PR TITLE
microchip: sama7g5: dts: add TRNG (Random Number Generator) support

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -30,6 +30,7 @@
 	chosen {
 		zephyr,sram = &ddram;
 		zephyr,console = &usart3;
+		zephyr,entropy = &trng;
 		zephyr,shell-uart = &usart3;
 	};
 
@@ -248,4 +249,8 @@
 		disk-name = "SD";
 		status = "okay";
 	};
+};
+
+&trng {
+	status = "okay";
 };

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
@@ -9,6 +9,7 @@ toolchain:
   - zephyr
 ram: 128
 supported:
+  - entropy
   - pwm
   - sdhc
   - shell

--- a/dts/arm/microchip/sam/sama7g5.dtsi
+++ b/dts/arm/microchip/sam/sama7g5.dtsi
@@ -535,5 +535,14 @@
 			assigned-clock-rates = <200000000>;
 			status = "disabled";
 		};
+
+		trng: rng@e2010000 {
+			compatible = "atmel,sam-trng";
+			reg = <0xe2010000 0x100>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 97>;
+			status = "disabled";
+		};
 	};
 };

--- a/soc/microchip/sam/sama7g5/soc.c
+++ b/soc/microchip/sam/sama7g5/soc.c
@@ -45,6 +45,10 @@ static const struct arm_mmu_region mmu_regions[] = {
 
 	MMU_REGION_FLAT_ENTRY("sdmmc1", SDMMC1_BASE_ADDRESS, 0x4000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
+
+	IF_ENABLED(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(trng)),
+		   (MMU_REGION_FLAT_ENTRY("trng", TRNG_BASE_ADDRESS, 0x100,
+					  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
Changes in this PR includes:
- set TRNG registers with strong ordered, read and write access
- add TRNG node to `dts/arm/microchip/sam/sama7g5.dtsi`
- enable TRNG in `boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts`