### PR TITLE
tests: fs: fat_fs_api: add native_sim to platform_allow

### DIFF
--- a/tests/subsys/fs/fat_fs_api/testcase.yaml
+++ b/tests/subsys/fs/fat_fs_api/testcase.yaml
@@ -20,6 +20,7 @@ tests:
     filter: dt_compat_enabled("zephyr,sdmmc-disk")
   filesystem.fat.ram.api:
     platform_allow:
+      - native_sim
       - frdm_mcxa156
       - frdm_mcxn236
       - frdm_mcxn947/mcxn947/cpu0


### PR DESCRIPTION
Native sim was inadvertently forgotten from the platform_allow list with commit 257e56c (PR #91582). It should be in there as it is an integration platform.