### PR TITLE
Use CONFIG_ATOMIC_OPERATIONS_C for atomic operations on Renesas RZ/A2M

### DIFF
--- a/soc/renesas/rz/rza2m/Kconfig
+++ b/soc/renesas/rz/rza2m/Kconfig
@@ -4,3 +4,4 @@
 config SOC_SERIES_RZA2M
 	select ARM
 	select CPU_CORTEX_A9
+	select ATOMIC_OPERATIONS_C


### PR DESCRIPTION
Use `CONFIG_ATOMIC_OPERATIONS_C` for atomic operations on Renesas RZ/A2M