### PR TITLE
ci: workflows: remove unsupported Python version from test matrices

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
         os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
     - name: checkout

--- a/.github/workflows/pylib_tests.yml
+++ b/.github/workflows/pylib_tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
         os: [ubuntu-24.04]
     steps:
     - name: checkout

--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
         os: [ubuntu-24.04]
     steps:
       - name: checkout

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
         os: [ubuntu-24.04]
     steps:
     - name: checkout

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -26,7 +26,7 @@ jobs:
     name: Twister Black Box Tests
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
         os: [ubuntu-24.04, macos-14, windows-2022]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
         os: [ubuntu-22.04, macos-14, windows-2022]
     steps:
     - name: checkout


### PR DESCRIPTION
Python 3.10 and 3.11 are no longer supported so drop them from the GitHub Actions test matrices.