### PR TITLE
video: common: prevent divide-by-zero in video_closest_frmival_stepwi…

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -136,6 +136,11 @@ void video_closest_frmival_stepwise(const struct video_frmival_stepwise *stepwis
 	step *= stepwise->min.denominator * stepwise->max.denominator * desired->denominator;
 	goal *= stepwise->min.denominator * stepwise->max.denominator * stepwise->step.denominator;
 
+	__ASSERT_NO_MSG(step != 0U);
+	/* Prevent division by zero */
+	if (step == 0U) {
+		return;
+	}
 	/* Saturate the desired value to the min/max supported */
 	goal = CLAMP(goal, min, max);
 

--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -27,7 +27,8 @@ LOG_MODULE_REGISTER(video_common, CONFIG_VIDEO_LOG_LEVEL);
 	shared_multi_heap_aligned_alloc(CONFIG_VIDEO_BUFFER_SMH_ATTRIBUTE, align, size)
 #define VIDEO_COMMON_FREE(block) shared_multi_heap_free(block)
 #else
-K_HEAP_DEFINE(video_buffer_pool, CONFIG_VIDEO_BUFFER_POOL_SZ_MAX*CONFIG_VIDEO_BUFFER_POOL_NUM_MAX);
+K_HEAP_DEFINE(video_buffer_pool,
+		CONFIG_VIDEO_BUFFER_POOL_SZ_MAX * CONFIG_VIDEO_BUFFER_POOL_NUM_MAX);
 #define VIDEO_COMMON_HEAP_ALLOC(align, size, timeout)                                              \
 	k_heap_aligned_alloc(&video_buffer_pool, align, size, timeout);
 #define VIDEO_COMMON_FREE(block) k_heap_free(&video_buffer_pool, block)


### PR DESCRIPTION
…se()

Adds a check to ensure 'step' is not zero before using it in division, to prevent potential undefined behavior.

CID: 444378