### PR TITLE
drivers: i2c: renesas_rz_riic: fix apply state in init code

### DIFF
--- a/drivers/i2c/i2c_renesas_rz_riic.c
+++ b/drivers/i2c/i2c_renesas_rz_riic.c
@@ -263,7 +263,7 @@ static int i2c_rz_riic_init(const struct device *dev)
 	int ret = 0;
 
 	/* Configure dt provided device signals when available */
-	if (!config->pin_config) {
+	if (config->pin_config->state_cnt > 0) {
 		ret = pinctrl_apply_state(config->pin_config, PINCTRL_STATE_DEFAULT);
 
 		if (ret < 0) {


### PR DESCRIPTION
Fixed the reverse logic of checking if `pin_config` is set in the init code.