### PR TITLE
twister: Enable 'flash-before' mode on serial-pty

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -222,6 +222,7 @@ Artificially long but functional example:
                         help="""Flash device before attaching to serial port.
                         This is useful for devices that share the same port for programming
                         and serial console, or use soft-USB, where flash must come first.
+                        Also, it skips reading remaining logs from the old image run.
                         """)
 
     test_or_build.add_argument(
@@ -969,10 +970,6 @@ def parse_arguments(
 
     if options.flash_before and options.device_flash_with_test:
         logger.error("--device-flash-with-test does not apply when --flash-before is used")
-        sys.exit(1)
-
-    if options.flash_before and options.device_serial_pty:
-        logger.error("--device-serial-pty cannot be used when --flash-before is set (for now)")
         sys.exit(1)
 
     if options.shuffle_tests and options.subset is None:

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -212,7 +212,7 @@ class HardwareMap:
                                 True,
                                 flash_timeout=self.options.device_flash_timeout,
                                 flash_with_test=self.options.device_flash_with_test,
-                                flash_before=False,
+                                flash_before=self.options.flash_before,
                                 )
 
             # the fixtures given by twister command explicitly should be assigned to each DUT
@@ -275,7 +275,7 @@ class HardwareMap:
             serial_pty = dut.get('serial_pty')
             flash_before = dut.get('flash_before')
             if flash_before is None:
-                flash_before = self.options.flash_before and (not (flash_with_test or serial_pty))
+                flash_before = self.options.flash_before and (not flash_with_test)
             platform = dut.get('platform')
             if isinstance(platform, str):
                 platforms = platform.split()


### PR DESCRIPTION
Enable `flash-before` mode for devices connected via serial-pty the same way, as for physical serial.

This mode allows Twister to start reading from the DUT's serial connection only after the flashing stage has been completed, thus excluding an early part of the log stream not directly related to the current test.

It can help in situations, when the device is connected via some serial-over-network harness which is still transferring device logs or keeping in its buffer a tail with different RunID etc. from the previous test image run.