### PR TITLE
bluetooth: stm32wba: add temperature calibration of the linklayer

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -304,6 +304,7 @@ config BT_AIROC
 source "drivers/bluetooth/hci/Kconfig.esp32"
 source "drivers/bluetooth/hci/Kconfig.infineon"
 source "drivers/bluetooth/hci/Kconfig.nxp"
+source "drivers/bluetooth/hci/Kconfig.stm32"
 
 config BT_DRIVER_QUIRK_NO_AUTO_DLE
 	bool "Host auto-initiated Data Length Update quirk"

--- a/drivers/bluetooth/hci/Kconfig.stm32
+++ b/drivers/bluetooth/hci/Kconfig.stm32
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menu "STM32WBA Bluetooth configuration"
-		depends on BT_STM32WBA
+	depends on BT_STM32WBA
 
-config BT_STM32WBA_USE_TEMPERATURE_BASED_RADIO_CALIBRATION
+config BT_STM32WBA_USE_TEMP_BASED_CALIB
 	bool "STM32WBA Radio calibration based on temperature sensor"
 	default y
 	select SENSOR
 	select STM32_TEMP
 	help
-		Allows the linklayer to calibrate itself on the current temperature read on the ADC4
+	  Allows the linklayer to calibrate itself on the current temperature read on the ADC4
 endmenu

--- a/drivers/bluetooth/hci/Kconfig.stm32
+++ b/drivers/bluetooth/hci/Kconfig.stm32
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+menu "STM32WBA Bluetooth configuration"
+		depends on BT_STM32WBA
+
+config BT_STM32WBA_USE_TEMPERATURE_BASED_RADIO_CALIBRATION
+	bool "STM32WBA Radio calibration based on temperature sensor"
+	default y
+	select SENSOR
+	select STM32_TEMP
+	help
+		Allows the linklayer to calibrate itself on the current temperature read on the ADC4
+endmenu

--- a/drivers/bluetooth/hci/hci_stm32wba.c
+++ b/drivers/bluetooth/hci/hci_stm32wba.c
@@ -361,8 +361,6 @@ static int bt_hci_stm32wba_open(const struct device *dev, bt_hci_recv_t recv)
 
 	link_layer_register_isr();
 
-	ll_sys_config_params();
-
 	ret = bt_ble_ctlr_init();
 	if (ret == 0) {
 		data->recv = recv;

--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
@@ -270,9 +270,6 @@ void LINKLAYER_PLAT_RCOStopClbr(void)
 /* Required only for RCO module usage in the context of LSI2 calibration */
 }
 
-/* TODO: To do when porting the temperature measurement function and thread */
-void LINKLAYER_PLAT_RequestTemperature(void) {}
-
 void LINKLAYER_PLAT_SCHLDR_TIMING_UPDATE_NOT(Evnt_timing_t *p_evnt_timing) {}
 
 void LINKLAYER_PLAT_EnableOSContextSwitch(void)

--- a/soc/st/stm32/stm32wbax/hci_if/ll_sys_if_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/ll_sys_if_adapt.c
@@ -11,10 +11,19 @@
 LOG_MODULE_REGISTER(ll_sys_if_adapt);
 
 #include "ll_sys.h"
+#include "ll_intf_cmn.h"
+#if defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB)
+#include <zephyr/drivers/sensor.h>
+#endif /* defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB) */
 
 extern struct k_mutex ble_ctrl_stack_mutex;
 extern struct k_work_q ll_work_q;
 struct k_work ll_sys_work;
+
+#if defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB)
+static const struct device *dev_temp_sensor = DEVICE_DT_GET(DT_ALIAS(die_temp0));
+static struct k_work temp_calibration_work;
+#endif /* defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB) */
 
 static void ll_sys_bg_process_handler(struct k_work *work)
 {
@@ -38,6 +47,76 @@ void ll_sys_bg_process_init(void)
 	k_work_init(&ll_sys_work, &ll_sys_bg_process_handler);
 }
 
-/* TODO: Implement temperature measurement thread after
- * implementing temperature measurement request function
- **/
+ #if defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB)
+
+/**
+ * @brief  Link Layer temperature calibration function
+ * @param  None
+ * @retval None
+ */
+static void ll_sys_temperature_calibration_measurement(void)
+{
+	struct sensor_value val;
+
+	int rc = sensor_sample_fetch(dev_temp_sensor);
+
+	if (rc) {
+		LOG_ERR("Failed to fetch sample (%d)", rc);
+		return;
+	}
+
+	rc = sensor_channel_get(dev_temp_sensor, SENSOR_CHAN_DIE_TEMP, &val);
+	if (rc) {
+		LOG_ERR("Failed to get data (%d)", rc);
+		return;
+	}
+
+	LOG_DBG("Radio calibration, temperature : %u °C", val.val1);
+	ll_intf_cmn_set_temperature_value(val.val1);
+}
+
+/**
+ * @brief  Link Layer temperature calibration work handler task
+ * @param  work
+ * @retval None
+ */
+void ll_sys_temperature_calibration_measurement_work_handler(struct k_work *work)
+{
+	ll_sys_temperature_calibration_measurement();
+}
+
+/**
+ * @brief  Link Layer temperature request background process initialization
+ * @param  None
+ * @retval None
+ */
+void ll_sys_bg_temperature_measurement_init(void)
+{
+	if (!device_is_ready(dev_temp_sensor)) {
+		LOG_ERR("dev_temp_sensor: device %s not ready", dev_temp_sensor->name);
+		k_panic();
+	} else {
+		/* Register Temperature Measurement task */
+		k_work_init(&temp_calibration_work,
+			ll_sys_temperature_calibration_measurement_work_handler);
+	}
+}
+
+/**
+ * @brief  Request background task processing for temperature measurement
+ * @param  None
+ * @retval None
+ */
+void ll_sys_bg_temperature_measurement(void)
+{
+	static uint8_t initial_temperature_acquisition;
+
+	if (initial_temperature_acquisition == 0) {
+		ll_sys_temperature_calibration_measurement();
+		initial_temperature_acquisition = 1;
+	} else {
+		k_work_submit_to_queue(&ll_work_q, &temp_calibration_work);
+	}
+}
+
+#endif /* defined(CONFIG_BT_STM32WBA_USE_TEMP_BASED_CALIB) */

--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 55b5d9a04432e57df3e63dcb83c78bb09f038da8
+      revision: 126cbbee19208b7aaca5ad8b287cf104e8bc837a
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This feature add the ability for the linklayer to calibrate itself using the current die temperature.
This feature can be enabled/disabled using a dedicated config.