### PR TITLE
cmake: targets: support overriding puncover port and host

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -87,6 +87,15 @@ endif()
 find_program(PUNCOVER puncover)
 
 if(NOT ${PUNCOVER} STREQUAL PUNCOVER-NOTFOUND)
+  set(PUNCOVER_ARGS "")
+  zephyr_get(PUNCOVER_PORT)
+  zephyr_get(PUNCOVER_HOST)
+  if(DEFINED PUNCOVER_PORT)
+    list(APPEND PUNCOVER_ARGS "--port=${PUNCOVER_PORT}")
+  endif()
+  if(DEFINED PUNCOVER_HOST)
+    list(APPEND PUNCOVER_ARGS "--host=${PUNCOVER_HOST}")
+  endif()
   add_custom_target(
     puncover
     ${PUNCOVER}
@@ -94,6 +103,7 @@ if(NOT ${PUNCOVER} STREQUAL PUNCOVER-NOTFOUND)
     --gcc_tools_base ${CROSS_COMPILE}
     --src_root       ${ZEPHYR_BASE}
     --build_dir      ${CMAKE_BINARY_DIR}
+    ${PUNCOVER_ARGS}
     DEPENDS ${logical_target_for_zephyr_elf}
             $<TARGET_PROPERTY:zephyr_property_target,${report}_DEPENDENCIES>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/doc/develop/optimizations/tools.rst
+++ b/doc/develop/optimizations/tools.rst
@@ -186,6 +186,9 @@ If you are using :ref:`sysbuild`, see :ref:`sysbuild_dedicated_image_build_targe
     :board: reel_board
     :goals: puncover
 
+The ``puncover`` target will start a local web server on ``localhost:5000`` by default.
+The host IP and port the HTTP server runs on can be changed by setting the environment
+variables ``PUNCOVER_HOST`` and ``PUNCOVER_PORT``.
 
 To view worst-case stack usage analysis, build this with the
 :kconfig:option:`CONFIG_STACK_USAGE` enabled.


### PR DESCRIPTION
Allow overriding puncover default port. Using PUNCOVER_PORT it is
possible now to set the port to something else other than the default.

Resolves zephyrproject-rtos/zephyr#30678

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
