### PR TITLE
arch: arc: replace "master"/"slave" terminology with inclusive language

### DIFF
--- a/arch/arc/core/reset.S
+++ b/arch/arc/core/reset.S
@@ -163,20 +163,20 @@ hw_pf_setup_done:
 
 #if defined(CONFIG_SMP) || CONFIG_MP_MAX_NUM_CPUS  > 1
 	_get_cpu_id r0
-	breq r0, 0, _master_core_startup
+	breq r0, 0, _primary_core_startup
 
 /*
- * Non-masters wait for master core (core 0) to boot enough
+ * Non-primary cores wait for primary core (core 0) to boot enough
  */
-_slave_core_wait:
+_secondary_core_wait:
 #if CONFIG_MP_MAX_NUM_CPUS == 1
 	kflag	1
 #endif
 	ld r1, [arc_cpu_wake_flag]
-	brne r0, r1, _slave_core_wait
+	brne r0, r1, _secondary_core_wait
 
 	LDR sp, arc_cpu_sp
-	/* signal master core that slave core runs */
+	/* signal primary core that secondary core runs */
 	st 0, [arc_cpu_wake_flag]
 
 #if defined(CONFIG_ARC_FIRQ_STACK)
@@ -186,7 +186,7 @@ _slave_core_wait:
 #endif
 	j arch_secondary_cpu_init
 
-_master_core_startup:
+_primary_core_startup:
 #endif
 
 #ifdef CONFIG_INIT_STACKS

--- a/arch/arc/core/smp.c
+++ b/arch/arc/core/smp.c
@@ -25,10 +25,10 @@ volatile struct {
 } arc_cpu_init[CONFIG_MP_MAX_NUM_CPUS];
 
 /*
- * arc_cpu_wake_flag is used to sync up master core and slave cores
- * Slave core will spin for arc_cpu_wake_flag until master core sets
- * it to the core id of slave core. Then, slave core clears it to notify
- * master core that it's waken
+ * arc_cpu_wake_flag is used to sync up primary core and secondary cores
+ * Secondary core will spin for arc_cpu_wake_flag until primary core sets
+ * it to the core id of secondary core. Then, secondary core clears it to notify
+ * primary core that it's waken
  *
  */
 volatile uint32_t arc_cpu_wake_flag;
@@ -50,13 +50,13 @@ void arch_cpu_start(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	/* set the initial sp of target sp through arc_cpu_sp
 	 * arc_cpu_wake_flag will protect arc_cpu_sp that
-	 * only one slave cpu can read it per time
+	 * only one secondary cpu can read it per time
 	 */
 	arc_cpu_sp = K_KERNEL_STACK_BUFFER(stack) + sz;
 
 	arc_cpu_wake_flag = cpu_num;
 
-	/* wait slave cpu to start */
+	/* wait secondary cpu to start */
 	while (arc_cpu_wake_flag != 0U) {
 		;
 	}
@@ -90,7 +90,7 @@ static void arc_connect_debug_mask_update(int cpu_num)
 
 void arc_core_private_intc_init(void);
 
-/* the C entry of slave cores */
+/* the C entry of secondary cores */
 void arch_secondary_cpu_init(int cpu_num)
 {
 	arch_cpustart_t fn;
@@ -162,7 +162,7 @@ int arch_smp_init(void)
 {
 	struct arc_connect_bcr bcr;
 
-	/* necessary master core init */
+	/* necessary primary core init */
 	_curr_cpu[0] = &(_kernel.cpus[0]);
 
 	bcr.val = z_arc_v2_aux_reg_read(_ARC_V2_CONNECT_BCR);
@@ -173,7 +173,7 @@ int arch_smp_init(void)
 	}
 
 	if (bcr.ipi) {
-	/* register ici interrupt, just need master core to register once */
+	/* register ici interrupt, just need primary core to register once */
 		z_arc_connect_ici_clear();
 		IRQ_CONNECT(DT_IRQN(DT_NODELABEL(ici)),
 			    DT_IRQ(DT_NODELABEL(ici), priority),


### PR DESCRIPTION
As per Zephyr guidelines regarding the use of inclusive language, apply the following replacements:

- s/master/primary/g
- s/slave/secondary/g