### PR TITLE
drivers: stepper: seperate stepper_stop from stepper_disable

### DIFF
--- a/doc/hardware/peripherals/stepper.rst
+++ b/doc/hardware/peripherals/stepper.rst
@@ -23,6 +23,7 @@ Control Stepper
 - **Move to** a specific position also known as **absolute movement** using :c:func:`stepper_move_to`.
 - Run continuously with a **constant step interval** in a specific direction until
   a stop is detected using :c:func:`stepper_run`.
+- **Stop** the stepper using :c:func:`stepper_stop`.
 - Check if the stepper is **moving** using :c:func:`stepper_is_moving`.
 - Register an **event callback** using :c:func:`stepper_set_event_callback`.
 

--- a/drivers/stepper/adi_tmc/tmc50xx.c
+++ b/drivers/stepper/adi_tmc/tmc50xx.c
@@ -176,7 +176,6 @@ static void stallguard_work_handler(struct k_work *work)
 	}
 }
 
-
 static void execute_callback(const struct device *dev, const enum stepper_event event)
 {
 	struct tmc50xx_stepper_data *data = dev->data;
@@ -543,6 +542,25 @@ static int tmc50xx_stepper_run(const struct device *dev, const enum stepper_dire
 	return 0;
 }
 
+static int tmc50xx_stepper_stop(const struct device *dev)
+{
+	const struct tmc50xx_stepper_config *config = dev->config;
+	int err;
+
+	err = tmc50xx_write(config->controller, TMC50XX_RAMPMODE(config->index),
+			    TMC5XXX_RAMPMODE_POSITIVE_VELOCITY_MODE);
+	if (err != 0) {
+		return -EIO;
+	}
+
+	err = tmc50xx_write(config->controller, TMC50XX_VMAX(config->index), 0);
+	if (err != 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
 #ifdef CONFIG_STEPPER_ADI_TMC50XX_RAMP_GEN
 
 int tmc50xx_stepper_set_ramp(const struct device *dev,
@@ -704,6 +722,7 @@ static DEVICE_API(stepper, tmc50xx_stepper_api) = {
 	.get_actual_position = tmc50xx_stepper_get_actual_position,
 	.move_to = tmc50xx_stepper_move_to,
 	.run = tmc50xx_stepper_run,
+	.stop = tmc50xx_stepper_stop,
 	.set_event_callback = tmc50xx_stepper_set_event_callback,
 };
 

--- a/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
+++ b/drivers/stepper/adi_tmc/tmc51xx/tmc51xx.c
@@ -781,6 +781,23 @@ static int tmc51xx_init(const struct device *dev)
 	return 0;
 }
 
+static int tmc51xx_stepper_stop(const struct device *dev)
+{
+	int err;
+
+	err = tmc51xx_write(dev, TMC51XX_RAMPMODE, TMC5XXX_RAMPMODE_POSITIVE_VELOCITY_MODE);
+	if (err != 0) {
+		return -EIO;
+	}
+
+	err = tmc51xx_write(dev, TMC51XX_VMAX, 0);
+	if (err != 0) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
 static DEVICE_API(stepper, tmc51xx_api) = {
 	.enable = tmc51xx_stepper_enable,
 	.disable = tmc51xx_stepper_disable,
@@ -792,6 +809,7 @@ static DEVICE_API(stepper, tmc51xx_api) = {
 	.get_actual_position = tmc51xx_stepper_get_actual_position,
 	.move_to = tmc51xx_stepper_move_to,
 	.run = tmc51xx_stepper_run,
+	.stop = tmc51xx_stepper_stop,
 	.set_event_callback = tmc51xx_stepper_set_event_callback,
 };
 

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -237,7 +237,7 @@ __subsystem struct stepper_driver_api {
 /**
  * @brief Enable stepper driver
  *
- * @details Enabling the driver will energize the coils, however not set the stepper in motion.
+ * @details Enabling the driver shall switch on the power stage and energize the coils.
  *
  * @param dev pointer to the stepper driver instance
  *
@@ -256,7 +256,9 @@ static inline int z_impl_stepper_enable(const struct device *dev)
 /**
  * @brief Disable stepper driver
  *
- * @details Disabling the driver shall cancel all active movements and de-energize the coils.
+ * @details Disabling the driver shall switch off the power stage and de-energize the coils.
+ * Disabling the stepper does not implicitly stop the stepper. If the motor shall not move after
+ * re-enabling the stepper than consider calling stepper_stop() before.
  *
  * @param dev pointer to the stepper driver instance
  *
@@ -477,7 +479,7 @@ static inline int z_impl_stepper_move_to(const struct device *dev, const int32_t
  * @brief Run the stepper with a given step interval in a given direction
  *
  * @details The stepper shall be set into motion and run continuously until
- * stalled or stopped using some other command, for instance, stepper_enable(false). This
+ * stalled or stopped using some other command, for instance, stepper_stop(). This
  * function is non-blocking.
  *
  * @param dev pointer to the stepper driver instance

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -262,6 +262,7 @@ static inline int z_impl_stepper_enable(const struct device *dev)
  *
  * @param dev pointer to the stepper driver instance
  *
+ * @retval  -ENOTSUP Disabling of driver is not supported.
  * @retval -EIO Error during Disabling
  * @retval 0 Success
  */
@@ -436,7 +437,6 @@ static inline int z_impl_stepper_set_microstep_interval(const struct device *dev
  * @param dev pointer to the stepper driver instance
  * @param micro_steps target micro-steps to be moved from the current position
  *
- * @retval -ECANCELED If the stepper is disabled
  * @retval -EIO General input / output error
  * @retval 0 Success
  */
@@ -458,7 +458,6 @@ static inline int z_impl_stepper_move_by(const struct device *dev, const int32_t
  * @param dev pointer to the stepper driver instance
  * @param micro_steps target position to set in micro-steps
  *
- * @retval -ECANCELED If the stepper is disabled
  * @retval -EIO General input / output error
  * @retval -ENOSYS If not implemented by device driver
  * @retval 0 Success
@@ -485,7 +484,6 @@ static inline int z_impl_stepper_move_to(const struct device *dev, const int32_t
  * @param dev pointer to the stepper driver instance
  * @param direction The direction to set
  *
- * @retval -ECANCELED If the stepper is disabled
  * @retval -EIO General input / output error
  * @retval -ENOSYS If not implemented by device driver
  * @retval 0 Success

--- a/tests/drivers/stepper/drv84xx/api/src/main.c
+++ b/tests/drivers/stepper/drv84xx/api/src/main.c
@@ -87,72 +87,6 @@ ZTEST_F(drv84xx_api, test_actual_position_set)
 	zassert_equal(pos, 100u, "Actual position should be %u but is %u", 100u, pos);
 }
 
-ZTEST_F(drv84xx_api, test_is_not_moving_when_disabled)
-{
-	int32_t steps = 100;
-	bool moving = true;
-
-	(void)stepper_enable(fixture->dev);
-	(void)stepper_set_microstep_interval(fixture->dev, 20000000);
-	(void)stepper_move_by(fixture->dev, steps);
-	(void)stepper_disable(fixture->dev);
-	(void)stepper_is_moving(fixture->dev, &moving);
-	zassert_false(moving, "Driver should not be in state is_moving after being disabled");
-}
-
-ZTEST_F(drv84xx_api, test_position_not_updating_when_disabled)
-{
-	int32_t steps = 1000;
-	int32_t position_1 = 0;
-	int32_t position_2 = 0;
-
-	(void)stepper_enable(fixture->dev);
-	(void)stepper_set_microstep_interval(fixture->dev, 20000000);
-	(void)stepper_move_by(fixture->dev, steps);
-	(void)stepper_disable(fixture->dev);
-	(void)stepper_get_actual_position(fixture->dev, &position_1);
-	k_msleep(100);
-	(void)stepper_get_actual_position(fixture->dev, &position_2);
-	zassert_equal(position_2, position_1,
-		      "Actual position should not have changed from %d but is %d", position_1,
-		      position_2);
-}
-
-ZTEST_F(drv84xx_api, test_is_not_moving_when_reenabled_after_movement)
-{
-	int32_t steps = 1000;
-	bool moving = true;
-
-	(void)stepper_enable(fixture->dev);
-	(void)stepper_set_microstep_interval(fixture->dev, 20000000);
-	(void)stepper_move_by(fixture->dev, steps);
-	(void)stepper_disable(fixture->dev);
-	(void)k_msleep(100);
-	(void)stepper_enable(fixture->dev);
-	(void)k_msleep(100);
-	(void)stepper_is_moving(fixture->dev, &moving);
-	zassert_false(moving, "Driver should not be in state is_moving after being reenabled");
-}
-ZTEST_F(drv84xx_api, test_position_not_updating_when_reenabled_after_movement)
-{
-	int32_t steps = 1000;
-	int32_t position_1 = 0;
-	int32_t position_2 = 0;
-
-	(void)stepper_enable(fixture->dev);
-	(void)stepper_set_microstep_interval(fixture->dev, 20000000);
-	(void)stepper_move_by(fixture->dev, steps);
-	(void)stepper_disable(fixture->dev);
-	(void)stepper_get_actual_position(fixture->dev, &position_1);
-	(void)k_msleep(100);
-	(void)stepper_enable(fixture->dev);
-	(void)k_msleep(100);
-	(void)stepper_get_actual_position(fixture->dev, &position_2);
-	zassert_equal(position_2, position_1,
-		      "Actual position should not have changed from %d but is %d", position_1,
-		      position_2);
-}
-
 ZTEST_F(drv84xx_api, test_move_to_positive_direction_movement)
 {
 	int32_t pos = 50;
@@ -247,23 +181,6 @@ ZTEST_F(drv84xx_api, test_move_to_is_moving_false_when_completed)
 	zassert_false(moving, "Driver should not be in state is_moving after finishing");
 }
 
-ZTEST_F(drv84xx_api, test_move_to_no_movement_when_disabled)
-{
-	int32_t pos = 50;
-	int32_t curr_pos = 50;
-	int32_t ret = 0;
-
-	(void)stepper_set_microstep_interval(fixture->dev, 20000000);
-	(void)stepper_disable(fixture->dev);
-
-	ret = stepper_move_to(fixture->dev, pos);
-	zassert_equal(ret, -ECANCELED, "Move_to should fail with error code %d but returned %d",
-		      -ECANCELED, ret);
-	(void)stepper_get_actual_position(fixture->dev, &curr_pos);
-	zassert_equal(curr_pos, 0, "Current position should not have changed from %d but is %d", 0,
-		      curr_pos);
-}
-
 ZTEST_F(drv84xx_api, test_move_by_zero_steps_no_movement)
 {
 	int32_t steps = 0;
@@ -282,22 +199,6 @@ ZTEST_F(drv84xx_api, test_move_by_zero_steps_no_movement)
 		      "Event was not STEPPER_EVENT_STEPS_COMPLETED event");
 	(void)stepper_get_actual_position(fixture->dev, &steps);
 	zassert_equal(steps, 0, "Target position should be %d but is %d", 0, steps);
-}
-
-ZTEST_F(drv84xx_api, test_move_by_zero_step_interval)
-{
-	int32_t steps = 100;
-	int32_t ret = 0;
-	int32_t pos = 100;
-
-	(void)stepper_enable(fixture->dev);
-	(void)stepper_disable(fixture->dev);
-	ret = stepper_move_by(fixture->dev, steps);
-
-	zassert_not_equal(ret, 0, "Command should fail with an error code, but returned 0");
-	k_msleep(100);
-	(void)stepper_get_actual_position(fixture->dev, &pos);
-	zassert_equal(pos, 0, "Target position should not have changed from %d but is %d", 0, pos);
 }
 
 ZTEST_F(drv84xx_api, test_move_by_is_moving_true_while_moving)
@@ -332,23 +233,6 @@ ZTEST_F(drv84xx_api, test_move_by_is_moving_false_when_completed)
 		      "Event was not STEPPER_EVENT_STEPS_COMPLETED event");
 	(void)stepper_is_moving(fixture->dev, &moving);
 	zassert_false(moving, "Driver should not be in state is_moving after completion");
-}
-
-ZTEST_F(drv84xx_api, test_move_by_no_movement_when_disabled)
-{
-	int32_t steps = 100;
-	int32_t curr_pos = 100;
-	int32_t ret = 0;
-
-	(void)stepper_set_microstep_interval(fixture->dev, 20000000);
-	(void)stepper_disable(fixture->dev);
-
-	ret = stepper_move_by(fixture->dev, steps);
-	zassert_equal(ret, -ECANCELED, "Move_by should fail with error code %d but returned %d",
-		      -ECANCELED, ret);
-	(void)stepper_get_actual_position(fixture->dev, &curr_pos);
-	zassert_equal(curr_pos, 0, "Current position should not have changed from %d but is %d", 0,
-		      curr_pos);
 }
 
 ZTEST_F(drv84xx_api, test_run_positive_direction_correct_position)
@@ -406,23 +290,6 @@ ZTEST_F(drv84xx_api, test_run_is_moving_true_when_step_interval_greater_zero)
 	(void)stepper_is_moving(fixture->dev, &moving);
 	zassert_true(moving, "Driver should be in state is_moving");
 	(void)stepper_disable(fixture->dev);
-}
-
-ZTEST_F(drv84xx_api, test_run_no_movement_when_disabled)
-{
-	uint64_t step_interval = 20000000;
-	int32_t steps = 50;
-	int32_t ret = 0;
-
-	(void)stepper_disable(fixture->dev);
-	(void)stepper_set_microstep_interval(fixture->dev, step_interval);
-
-	ret = stepper_run(fixture->dev, STEPPER_DIRECTION_POSITIVE);
-	zassert_equal(ret, -ECANCELED, "Run should fail with error code %d but returned %d",
-		      -ECANCELED, ret);
-	(void)stepper_get_actual_position(fixture->dev, &steps);
-	zassert_equal(steps, 0, "Current position should not have changed from %d but is %d", 0,
-		      steps);
 }
 
 ZTEST_SUITE(drv84xx_api, NULL, drv84xx_api_setup, drv84xx_api_before, drv84xx_api_after, NULL);


### PR DESCRIPTION
stepper_stop() shall be used be used explicitly to cancel stepper step counting.
stepper_disable() is responsible for turning off power stages.

Attached along with is the trace from tmc50xx stepper motion controller + driver.
It shows that disabling the stepper driver does not implicitly stop the motion control part.

```
uart:~$ stepper run tmc_stepper@0 positive 
uart:~$ stepper get_actual_position tmc_stepper@0 
Actual Position: -6512577
uart:~$ stepper disable tmc_stepper@0 
uart:~$ stepper get_actual_position tmc_stepper@0
Actual Position: -6030449
uart:~$ stepper enable tmc_stepper@0 
uart:~$ stepper get_actual_position tmc_stepper@0
Actual Position: -5278472
uart:~$ stepper get_actual_position tmc_stepper@0
Actual Position: -4574999
uart:~$ stepper disable tmc_stepper@0
uart:~$ stepper get_actual_position tmc_stepper@0
Actual Position: -4282534
uart:~$ stepper get_actual_position tmc_stepper@0
Actual Position: -4112518
```

Originally stepper_stop() was missing in the stepper api and hence while disabling the motor was stopped implicitly by stopping counter or work.
However, there is a dedicated stop() function now,
hence enable<->disable should be concerned with turning power stages on and off
while move<->stop should be concerned with setting the stepper in motion and stopping it