### PR TITLE
soc : ti: Soc layer power domain and clock nodes init

### DIFF
--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0_defconfig
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0_defconfig
@@ -15,3 +15,12 @@ CONFIG_UART_CONSOLE=y
 
 # Enable MPU
 CONFIG_ARM_MPU=y
+
+#Enable runtime power management
+CONFIG_PM_DEVICE=y
+CONFIG_POWER_DOMAIN=y
+CONFIG_PM=y
+CONFIG_PM_DEVICE_RUNTIME=y
+
+#Enable clock control
+CONFIG_CLOCK_CONTROL=y

--- a/drivers/power_domain/power_domain_tisci.c
+++ b/drivers/power_domain/power_domain_tisci.c
@@ -14,7 +14,7 @@ LOG_MODULE_REGISTER(tisci_pd);
 
 #define DT_DRV_COMPAT ti_sci_pm_domain
 
-const struct device *dmsc = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(dmsc));
+static const struct device *dmsc = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(dmsc));
 
 struct power_domain {
 	uint32_t devid;

--- a/soc/ti/k3/am6x/r5/soc.c
+++ b/soc/ti/k3/am6x/r5/soc.c
@@ -5,10 +5,18 @@
  */
 
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 #include <zephyr/fatal.h>
-
+#include <zephyr/logging/log.h>
 #include "soc.h"
+#include "zephyr/sys/util_macro.h"
+#include <zephyr/device.h>
 #include <common/ctrl_partitions.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/tisci_clock_control.h>
+LOG_MODULE_REGISTER(soc, LOG_LEVEL_DBG);
 
 unsigned int z_soc_irq_get_active(void)
 {
@@ -53,3 +61,57 @@ void soc_early_init_hook(void)
 {
 	k3_unlock_all_ctrl_partitions();
 }
+
+#if defined(CONFIG_POWER_DOMAIN)
+int soc_power_domain_init(void)
+{
+	LOG_INF("Starting power domain initialization\n");
+
+	int error_count = 0;
+
+#define CHECK_NODE_POWER_DOMAIN(child)                                                             \
+	COND_CODE_1(DT_NODE_HAS_PROP(child, power_domains), ({		\
+		const struct device *dev_##child =                                                 \
+			DEVICE_DT_GET(DT_PHANDLE(child, power_domains));                   \
+			LOG_INF("Turning on power domain: %s\n", dev_##child->name);               \
+			int err = pm_device_runtime_get(dev_##child);                              \
+			if (err < 0) {                                                             \
+				LOG_INF("Failed to get power domain: %s\n", dev_##child->name);    \
+				error_count++;                                                     \
+			}                                                                          \
+		}), (/* Do nothing */))
+
+	DT_FOREACH_CHILD(DT_ROOT, CHECK_NODE_POWER_DOMAIN);
+
+	return error_count;
+}
+SYS_INIT(soc_power_domain_init, POST_KERNEL, 0);
+#endif /* CONFIG_POWER_DOMAIN  */
+
+#if defined(CONFIG_CLOCK_CONTROL)
+int soc_clock_init(void)
+{
+	LOG_INF("Starting clock initialization\n");
+
+	int error_count = 0;
+
+#define CHECK_NODE_CLOCK(child)                                                                    \
+	COND_CODE_1(DT_NODE_HAS_PROP(child, clocks), \
+		({ \
+			const struct device *dev_##child = TISCI_GET_CLOCK(child); \
+			struct tisci_clock_config req_##child = TISCI_GET_CLOCK_DETAILS(child); \
+			uint64_t freq_##child = DT_PROP(child, clock_frequency);	\
+			if (clock_control_set_rate(dev_##child, &req_##child, &freq_##child)) {	\
+				printf("Failed to set clock rate for %s\n", dev_##child->name);	\
+				error_count++; \
+			} \
+		}), \
+		(/* Do nothing */) \
+	)
+
+	DT_FOREACH_CHILD(DT_ROOT, CHECK_NODE_CLOCK);
+
+	return error_count;
+}
+SYS_INIT(soc_clock_init, POST_KERNEL, 0);
+#endif /* CONFIG_CLOCK_CONTROL  */


### PR DESCRIPTION
Power domains are added to the device tree.
The enabled nodes with power domains assigned to them have them turn on in the SOC layer.
Init for enabled clock nodes.
This PR waits on #90216 to be merged.