### PR TITLE
drivers: wifi: nrf7002: Add support for multiple virtual interfaces

### DIFF
--- a/boards/nordic/nrf7002dk/nrf70_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf70_common.dtsi
@@ -13,6 +13,10 @@ wifi-max-tx-pwr-2g-dsss = <21>;
 wifi-max-tx-pwr-2g-mcs0 = <16>;
 wifi-max-tx-pwr-2g-mcs7 = <16>;
 
-wlan0: wlan {
+wlan0: wlan0 {
+	compatible = "nordic,wlan";
+};
+
+wlan1: wlan1 {
 	compatible = "nordic,wlan";
 };

--- a/boards/shields/nrf7002eb/nrf7002eb.overlay
+++ b/boards/shields/nrf7002eb/nrf7002eb.overlay
@@ -30,6 +30,10 @@
 			compatible = "nordic,wlan";
 		};
 
+		wlan1: wlan1 {
+			compatible = "nordic,wlan";
+		};
+
 		wifi-max-tx-pwr-2g-dsss = <21>;
 		wifi-max-tx-pwr-2g-mcs0 = <16>;
 		wifi-max-tx-pwr-2g-mcs7 = <16>;

--- a/boards/shields/nrf7002ek/nrf7002ek_common.dtsi
+++ b/boards/shields/nrf7002ek/nrf7002ek_common.dtsi
@@ -24,3 +24,7 @@ wifi-max-tx-pwr-2g-mcs7 = <16>;
 wlan0: wlan0 {
 	compatible = "nordic,wlan";
 };
+
+wlan1: wlan1 {
+	compatible = "nordic,wlan";
+};

--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -108,6 +108,15 @@ config NRF70_AP_MODE
 	depends on WIFI_NM_WPA_SUPPLICANT_AP
 	default y if WIFI_USAGE_MODE_AP || WIFI_USAGE_MODE_STA_AP
 
+config NRF70_ENABLE_DUAL_VIF
+	bool "Dual virtual Wi-Fi interfaces"
+	default y if WIFI_NM_MAX_MANAGED_INTERFACES = 2
+	depends on (WIFI_NRF7002 || WIFI_NRF7001) && NET_L2_ETHERNET
+	help
+	  Enable support for two virtual Wi-Fi interfaces (VIFs).
+	  When enabled, the driver can operate two VIFs simultaneously,
+	  allowing use cases such as one interface in AP mode and another in STA mode.
+
 config NRF70_P2P_MODE
 	bool "P2P support in driver"
 

--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -743,8 +743,20 @@ static int nrf_wifi_drv_main_zep(const struct device *dev)
 	struct nrf_wifi_data_config_params data_config = { 0 };
 	struct rx_buf_pool_params rx_buf_pools[MAX_NUM_OF_RX_QUEUES];
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = dev->data;
+	static unsigned char fixed_vif_cnt;
 
+	if (fixed_vif_cnt >= MAX_NUM_VIFS) {
+		LOG_ERR("%s: Max number of VIFs reached", __func__);
+		return -ENOMEM;
+	}
+
+	/* Setup the linkage between the FMAC and the VIF contexts */
 	vif_ctx_zep->rpu_ctx_zep = &rpu_drv_priv_zep.rpu_ctx_zep;
+
+	if (fixed_vif_cnt++ > 0) {
+		/* FMAC is already initialized for VIF-0 */
+		return 0;
+	}
 
 #ifdef CONFIG_NRF70_DATA_TX
 	data_config.aggregation = aggregation;
@@ -979,6 +991,21 @@ ETH_NET_DEVICE_DT_INST_DEFINE(0,
 		    CONFIG_WIFI_INIT_PRIORITY, /* prio */
 		    &wifi_offload_ops, /* api */
 		    CONFIG_NRF_WIFI_IFACE_MTU); /*mtu */
+#ifdef CONFIG_NRF70_ENABLE_DUAL_VIF
+/* Register second interface */
+ETH_NET_DEVICE_DT_INST_DEFINE(1,
+		    nrf_wifi_drv_main_zep, /* init_fn */
+		    NULL, /* pm_action_cb */
+		    &rpu_drv_priv_zep.rpu_ctx_zep.vif_ctx_zep[1], /* data */
+#ifdef CONFIG_NRF70_STA_MODE
+		    &wpa_supp_ops, /* cfg */
+#else /* CONFIG_NRF70_STA_MODE */
+		    NULL, /* cfg */
+#endif /* !CONFIG_NRF70_STA_MODE */
+		    CONFIG_WIFI_INIT_PRIORITY, /* prio */
+		    &wifi_offload_ops, /* api */
+		    CONFIG_NRF_WIFI_IFACE_MTU); /*mtu */
+#endif /* NRF70_ENABLE_DUAL_VIF */
 #else
 DEVICE_DT_INST_DEFINE(0,
 	      nrf_wifi_drv_main_zep, /* init_fn */

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -824,8 +824,7 @@ int nrf_wifi_if_start_zep(const struct device *dev)
 	}
 
 	k_mutex_init(&vif_ctx_zep->vif_lock);
-	rpu_ctx_zep->vif_ctx_zep[vif_ctx_zep->vif_idx].if_type =
-		add_vif_info.iftype;
+	vif_ctx_zep->if_type = add_vif_info.iftype;
 
 	/* Check if user has provided a valid MAC address, if not
 	 * fetch it from OTP.

--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -447,7 +447,10 @@ void *nrf_wifi_wpa_supp_dev_init(void *supp_drv_if_ctx, const char *iface_name,
 				 struct zep_wpa_supp_dev_callbk_fns *supp_callbk_fns)
 {
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
-	const struct device *device = DEVICE_DT_GET(DT_CHOSEN(zephyr_wifi));
+	/* Get device for each interface */
+	int if_idx = net_if_get_by_name(iface_name);
+	struct net_if *iface = net_if_get_by_index(if_idx);
+	const struct device *device = net_if_get_device(iface);
 
 	if (!device) {
 		LOG_ERR("%s: Interface %s not found", __func__, iface_name);

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -12,6 +12,7 @@ config FDTABLE
 
 config ZVFS_OPEN_MAX
 	int "Maximum number of open file descriptors"
+	default 24 if NRF70_ENABLE_DUAL_VIF
 	default 16 if WIFI_NM_WPA_SUPPLICANT
 	default 16 if POSIX_API
 	default 4

--- a/lib/os/zvfs/Kconfig
+++ b/lib/os/zvfs/Kconfig
@@ -45,6 +45,7 @@ if ZVFS_POLL
 config ZVFS_POLL_MAX
 	int "Max number of supported zvfs_poll() entries"
 	default NET_SOCKETS_POLL_MAX if NET_SOCKETS_POLL_MAX > 0
+	default 8 if NRF70_ENABLE_DUAL_VIF
 	default 6 if WIFI_NM_WPA_SUPPLICANT
 	default 4 if SHELL_BACKEND_TELNET
 	default 3

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -34,9 +34,11 @@ if !WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
 config WIFI_NM_WPA_SUPPLICANT_HEAP
 	int "Dedicated memory pool for wpa_supplicant"
 	def_int 66560 if WIFI_NM_HOSTAPD_AP
+	def_int 60000 if WIFI_USAGE_MODE_STA_AP
 	def_int 55000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE && WIFI_CREDENTIALS
 	def_int 48000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	def_int 41808 if WIFI_NM_WPA_SUPPLICANT_AP
+	def_int 40000 if WIFI_NM_MAX_MANAGED_INTERFACES=2
 	# 30K is mandatory, but might need more for long duration use cases
 	def_int 30000
 endif # !WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
@@ -44,6 +46,7 @@ endif # !WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
 if WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
 config HEAP_MEM_POOL_ADD_SIZE_HOSTAP
 	def_int 66560 if WIFI_NM_HOSTAPD_AP
+	def_int 60000 if WIFI_USAGE_MODE_STA_AP
 	def_int 55000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE && WIFI_CREDENTIALS
 	def_int 48000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
 	def_int 41808 if WIFI_NM_WPA_SUPPLICANT_AP
@@ -56,7 +59,7 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	int "Stack size for wpa_supplicant thread"
 	# TODO: Providing higher stack size for Enterprise mode to fix stack
 	# overflow issues. Need to identify the cause for higher stack usage.
-	default 8192 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+	default 8192 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE || WIFI_USAGE_MODE_STA_AP
 	# This is needed to handle stack overflow issues on nRF Wi-Fi drivers.
 	default 5900 if WIFI_NM_WPA_SUPPLICANT_AP
 	default 5800

--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -319,6 +319,7 @@ config WIFI_NM_WPA_SUPPLICANT_WPA3
 
 config WIFI_NM_WPA_SUPPLICANT_AP
 	bool "SoftAP mode support based on WPA supplicant"
+	default y if WIFI_USAGE_MODE_AP || WIFI_USAGE_MODE_STA_AP
 
 config WIFI_NM_WPA_SUPPLICANT_WPS
 	bool "WPS support"

--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -376,7 +376,7 @@ bool hostapd_ap_reg_domain(const struct device *dev,
 		return false;
 	}
 
-	return hostapd_cli_cmd_v(iface->ctrl_conn, "set country_code %s", reg_domain->country_code);
+	return hostapd_cli_cmd_v("set country_code %s", reg_domain->country_code);
 }
 
 static int hapd_config_chan_center_seg0(struct hostapd_iface *iface,

--- a/modules/hostap/src/hapd_api.c
+++ b/modules/hostap/src/hapd_api.c
@@ -38,7 +38,7 @@ static struct wifi_enterprise_creds_params hapd_enterprise_creds;
 #define hostapd_cli_cmd_v(cmd, ...) ({					\
 	bool status;							\
 									\
-	if (zephyr_hostapd_cli_cmd_v(cmd, ##__VA_ARGS__) < 0) {		\
+	if (zephyr_hostapd_cli_cmd_v(iface->ctrl_conn, cmd, ##__VA_ARGS__) < 0) {		\
 		wpa_printf(MSG_ERROR,					\
 			   "Failed to execute wpa_cli command: %s",	\
 			   cmd);					\
@@ -365,12 +365,22 @@ out:
 }
 #endif
 
-bool hostapd_ap_reg_domain(struct wifi_reg_domain *reg_domain)
+bool hostapd_ap_reg_domain(const struct device *dev,
+	struct wifi_reg_domain *reg_domain)
 {
-	return hostapd_cli_cmd_v("set country_code %s", reg_domain->country_code);
+	struct hostapd_iface *iface;
+
+	iface = get_hostapd_handle(dev);
+	if (iface == NULL) {
+		wpa_printf(MSG_ERROR, "Interface %s not found", dev->name);
+		return false;
+	}
+
+	return hostapd_cli_cmd_v(iface->ctrl_conn, "set country_code %s", reg_domain->country_code);
 }
 
-static int hapd_config_chan_center_seg0(struct wifi_connect_req_params *params)
+static int hapd_config_chan_center_seg0(struct hostapd_iface *iface,
+	struct wifi_connect_req_params *params)
 {
 	int ret = 0;
 	uint8_t center_freq_seg0_idx = 0;
@@ -472,7 +482,7 @@ int hapd_config_network(struct hostapd_iface *iface,
 		goto out;
 	}
 
-	ret = hapd_config_chan_center_seg0(params);
+	ret = hapd_config_chan_center_seg0(iface, params);
 	if (ret) {
 		goto out;
 	}

--- a/modules/hostap/src/hapd_api.h
+++ b/modules/hostap/src/hapd_api.h
@@ -25,9 +25,11 @@ int hostapd_ap_config_params(const struct device *dev, struct wifi_ap_config_par
  * @brief Set Wi-Fi AP region domain
  *
  * @param reg_domain region domain parameters
+ * @param dev Wi-Fi device
  * @return true for OK; false for ERROR
  */
-bool hostapd_ap_reg_domain(struct wifi_reg_domain *reg_domain);
+bool hostapd_ap_reg_domain(const struct device *dev,
+	struct wifi_reg_domain *reg_domain);
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_WPS
 /** Start AP WPS PBC/PIN

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1733,7 +1733,7 @@ int supplicant_reg_domain(const struct device *dev,
 		}
 
 		if (IS_ENABLED(CONFIG_WIFI_NM_HOSTAPD_AP)) {
-			if (!hostapd_ap_reg_domain(reg_domain)) {
+			if (!hostapd_ap_reg_domain(dev, reg_domain)) {
 				goto out;
 			}
 		}

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -80,20 +80,19 @@ static void supp_shell_connect_status(struct k_work *work);
 static K_WORK_DELAYABLE_DEFINE(wpa_supp_status_work,
 		supp_shell_connect_status);
 
-#define wpa_cli_cmd_v(cmd, ...)	({					\
-	bool status;							\
-									\
-	if (zephyr_wpa_cli_cmd_v(cmd, ##__VA_ARGS__) < 0) {		\
-		wpa_printf(MSG_ERROR,					\
-			   "Failed to execute wpa_cli command: %s",	\
-			   cmd);					\
-		status = false;						\
-	} else {							\
-		status = true;						\
-	}								\
-									\
-	status;								\
-})
+#define wpa_cli_cmd_v(cmd, ...)                                                                    \
+	({                                                                                         \
+		bool status;                                                                       \
+                                                                                                   \
+		if (zephyr_wpa_cli_cmd_v(wpa_s->ctrl_conn, cmd, ##__VA_ARGS__) < 0) {              \
+			wpa_printf(MSG_ERROR, "Failed to execute wpa_cli command: %s", cmd);       \
+			status = false;                                                            \
+		} else {                                                                           \
+			status = true;                                                             \
+		}                                                                                  \
+                                                                                                   \
+		status;                                                                            \
+	})
 
 static struct wpa_supplicant *get_wpa_s_handle(const struct device *dev)
 {
@@ -626,7 +625,7 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 		goto out;
 	}
 
-	ret = z_wpa_ctrl_add_network(&resp);
+	ret = z_wpa_ctrl_add_network(wpa_s->ctrl_conn, &resp);
 	if (ret) {
 		wpa_printf(MSG_ERROR, "Failed to add network");
 		goto out;
@@ -1365,7 +1364,7 @@ int supplicant_status(const struct device *dev, struct wifi_iface_status *status
 		status->channel = channel;
 
 		if (ssid_len == 0) {
-			int _res = z_wpa_ctrl_status(&cli_status);
+			int _res = z_wpa_ctrl_status(wpa_s->ctrl_conn, &cli_status);
 
 			if (_res < 0) {
 				ssid_len = 0;
@@ -1394,7 +1393,7 @@ int supplicant_status(const struct device *dev, struct wifi_iface_status *status
 
 		status->rssi = -WPA_INVALID_NOISE;
 		if (status->iface_mode == WIFI_MODE_INFRA) {
-			ret = z_wpa_ctrl_signal_poll(&signal_poll);
+			ret = z_wpa_ctrl_signal_poll(wpa_s->ctrl_conn, &signal_poll);
 			if (!ret) {
 				status->rssi = signal_poll.rssi;
 				status->current_phy_tx_rate = signal_poll.current_txrate;
@@ -2007,7 +2006,7 @@ static int supplicant_wps_pin(const struct device *dev, struct wifi_wps_config_p
 	}
 
 	if (params->oper == WIFI_WPS_PIN_GET) {
-		if (zephyr_wpa_cli_cmd_resp(get_pin_cmd, params->pin)) {
+		if (zephyr_wpa_cli_cmd_resp(wpa_s->ctrl_conn, get_pin_cmd, params->pin)) {
 			goto out;
 		}
 	} else if (params->oper == WIFI_WPS_PIN_SET) {
@@ -2440,6 +2439,7 @@ int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *pa
 {
 	int ret;
 	char *cmd = NULL;
+	struct wpa_supplicant *wpa_s = get_wpa_s_handle(dev);
 
 	if (params == NULL) {
 		return -EINVAL;
@@ -2458,7 +2458,7 @@ int supplicant_dpp_dispatch(const struct device *dev, struct wifi_dpp_params *pa
 	}
 
 	wpa_printf(MSG_DEBUG, "wpa_cli %s", cmd);
-	if (zephyr_wpa_cli_cmd_resp(cmd, params->resp)) {
+	if (zephyr_wpa_cli_cmd_resp(wpa_s->ctrl_conn, cmd, params->resp)) {
 		os_free(cmd);
 		return -ENOEXEC;
 	}

--- a/modules/hostap/src/supp_main.h
+++ b/modules/hostap/src/supp_main.h
@@ -58,8 +58,6 @@ struct wpa_supplicant *zephyr_get_handle_by_ifname(const char *ifname);
 struct hapd_interfaces *zephyr_get_default_hapd_context(void);
 #endif
 
-struct wpa_supplicant *zephyr_get_handle_by_ifname(const char *ifname);
-
 struct wpa_supplicant_event_msg {
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 	int hostapd;

--- a/modules/hostap/src/wpa_cli.c
+++ b/modules/hostap/src/wpa_cli.c
@@ -9,9 +9,11 @@
  */
 
 #include <stdlib.h>
+#include <sys/types.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/net/net_if.h>
+#include <zephyr/net/socket.h>
 #include <zephyr/init.h>
 
 
@@ -21,28 +23,64 @@
 #include "wpa_supplicant_i.h"
 #include "wpa_cli_zephyr.h"
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
+#include "hostapd.h"
+#include "hapd_main.h"
 #include "hostapd_cli_zephyr.h"
 #endif
 
-static int cmd_wpa_cli(const struct shell *sh,
-			  size_t argc,
-			  const char *argv[])
+static int cmd_wpa_cli(const struct shell *sh, size_t argc, const char *argv[])
 {
-	struct net_if *iface = net_if_get_first_wifi();
+	struct net_if *iface = NULL;
 	char if_name[CONFIG_NET_INTERFACE_NAME_LEN + 1];
 	struct wpa_supplicant *wpa_s = NULL;
+	size_t arg_offset = 1;
+	int idx = -1;
+	bool iface_found = false;
 
-	ARG_UNUSED(sh);
-
-	if (iface == NULL) {
-		shell_error(sh, "No Wifi interface found");
-		return -ENOENT;
+	if (argc > 2 &&
+	    ((strcmp(argv[1], "-i") == 0) ||
+	     (strncmp(argv[1], "-i", 2) == 0 && argv[1][2] != '\0'))) {
+		/* Handle both "-i 2" and "-i2" */
+		if (strcmp(argv[1], "-i") == 0) {
+			idx = strtol(argv[2], NULL, 10);
+			arg_offset = 3;
+		} else {
+			idx = strtol(&argv[1][2], NULL, 10);
+			arg_offset = 2;
+		}
+		iface = net_if_get_by_index(idx);
+		if (!iface) {
+			shell_error(sh, "Interface index %d not found", idx);
+			return -ENODEV;
+		}
+		net_if_get_name(iface, if_name, sizeof(if_name));
+		if_name[sizeof(if_name) - 1] = '\0';
+		iface_found = true;
+	} else {
+		/* Default to first Wi-Fi interface */
+		iface = net_if_get_first_wifi();
+		if (!iface) {
+			shell_error(sh, "No Wi-Fi interface found");
+			return -ENOENT;
+		}
+		net_if_get_name(iface, if_name, sizeof(if_name));
+		if_name[sizeof(if_name) - 1] = '\0';
+		arg_offset = 1;
+		iface_found = true;
 	}
 
-	net_if_get_name(iface, if_name, sizeof(if_name));
-	wpa_s = zephyr_get_handle_by_ifname(if_name);
+	if (!iface_found) {
+		shell_error(sh, "No interface found");
+		return -ENODEV;
+	}
 
-	if (argc == 1) {
+	wpa_s = zephyr_get_handle_by_ifname(if_name);
+	if (!wpa_s) {
+		shell_error(sh, "No wpa_supplicant context for interface '%s'", if_name);
+		return -ENODEV;
+	}
+
+	if (argc <= arg_offset) {
 		shell_error(sh, "Missing argument");
 		return -EINVAL;
 	}
@@ -51,15 +89,65 @@ static int cmd_wpa_cli(const struct shell *sh,
 	argc++;
 
 	/* Remove wpa_cli from the argument list */
-	return zephyr_wpa_ctrl_zephyr_cmd(wpa_s->ctrl_conn, argc - 1, &argv[1]);
+	return zephyr_wpa_ctrl_zephyr_cmd(wpa_s->ctrl_conn, argc - arg_offset, &argv[arg_offset]);
 }
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 static int cmd_hostapd_cli(const struct shell *sh, size_t argc, const char *argv[])
 {
-	ARG_UNUSED(sh);
+	struct net_if *iface = NULL;
+	size_t arg_offset = 1;
+	struct hostapd_iface *hapd_iface;
+	int idx = -1;
+	bool iface_found = false;
+	char if_name[CONFIG_NET_INTERFACE_NAME_LEN + 1];
+	int ret;
 
-	if (argc == 1) {
+	if (argc > 2 &&
+	    ((strcmp(argv[1], "-i") == 0) ||
+	     (strncmp(argv[1], "-i", 2) == 0 && argv[1][2] != '\0'))) {
+		/* Handle both "-i 2" and "-i2" */
+		if (strcmp(argv[1], "-i") == 0) {
+			idx = strtol(argv[2], NULL, 10);
+			arg_offset = 3;
+		} else {
+			idx = strtol(&argv[1][2], NULL, 10);
+			arg_offset = 2;
+		}
+		iface = net_if_get_by_index(idx);
+		if (!iface) {
+			shell_error(sh, "Interface index %d not found", idx);
+			return -ENODEV;
+		}
+		iface_found = true;
+	} else {
+		iface = net_if_get_first_wifi();
+		if (!iface) {
+			shell_error(sh, "No Wi-Fi interface found");
+			return -ENOENT;
+		}
+		arg_offset = 1;
+		iface_found = true;
+	}
+
+	if (!iface_found) {
+		shell_error(sh, "No interface found");
+		return -ENODEV;
+	}
+
+	ret = net_if_get_name(iface, if_name, sizeof(if_name));
+	if (!ret) {
+		shell_error(sh, "Cannot get interface name (%d)", ret);
+		return -ENODEV;
+	}
+
+	hapd_iface = zephyr_get_hapd_handle_by_ifname(if_name);
+	if (!hapd_iface) {
+		shell_error(sh, "No hostapd context for interface '%s'", if_name);
+		return -ENODEV;
+	}
+
+	if (argc <= arg_offset) {
 		shell_error(sh, "Missing argument");
 		return -EINVAL;
 	}
@@ -68,7 +156,8 @@ static int cmd_hostapd_cli(const struct shell *sh, size_t argc, const char *argv
 	argc++;
 
 	/* Remove hostapd_cli from the argument list */
-	return zephyr_hostapd_ctrl_zephyr_cmd(argc - 1, &argv[1]);
+	return zephyr_hostapd_ctrl_zephyr_cmd(hapd_iface->ctrl_conn, argc - arg_offset,
+					      &argv[arg_offset]);
 }
 #endif
 
@@ -77,9 +166,10 @@ static int cmd_hostapd_cli(const struct shell *sh, size_t argc, const char *argv
  */
 SHELL_CMD_REGISTER(wpa_cli,
 		   NULL,
-		   "wpa_cli commands (only for internal use)",
+		   "wpa_cli [-i idx] <command> (only for internal use)",
 		   cmd_wpa_cli);
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
-SHELL_CMD_REGISTER(hostapd_cli, NULL, "hostapd_cli commands (only for internal use)",
+SHELL_CMD_REGISTER(hostapd_cli, NULL,
+		   "hostapd_cli [-i idx] <command> (only for internal use)",
 		   cmd_hostapd_cli);
 #endif

--- a/modules/hostap/src/wpa_cli.c
+++ b/modules/hostap/src/wpa_cli.c
@@ -8,10 +8,17 @@
  * @brief wpa_cli implementation for Zephyr OS
  */
 
+#include <stdlib.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/net/net_if.h>
 #include <zephyr/init.h>
 
+
+#include "supp_main.h"
+
+#include "common.h"
+#include "wpa_supplicant_i.h"
 #include "wpa_cli_zephyr.h"
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP
 #include "hostapd_cli_zephyr.h"
@@ -21,7 +28,19 @@ static int cmd_wpa_cli(const struct shell *sh,
 			  size_t argc,
 			  const char *argv[])
 {
+	struct net_if *iface = net_if_get_first_wifi();
+	char if_name[CONFIG_NET_INTERFACE_NAME_LEN + 1];
+	struct wpa_supplicant *wpa_s = NULL;
+
 	ARG_UNUSED(sh);
+
+	if (iface == NULL) {
+		shell_error(sh, "No Wifi interface found");
+		return -ENOENT;
+	}
+
+	net_if_get_name(iface, if_name, sizeof(if_name));
+	wpa_s = zephyr_get_handle_by_ifname(if_name);
 
 	if (argc == 1) {
 		shell_error(sh, "Missing argument");
@@ -32,7 +51,7 @@ static int cmd_wpa_cli(const struct shell *sh,
 	argc++;
 
 	/* Remove wpa_cli from the argument list */
-	return zephyr_wpa_ctrl_zephyr_cmd(argc - 1, &argv[1]);
+	return zephyr_wpa_ctrl_zephyr_cmd(wpa_s->ctrl_conn, argc - 1, &argv[1]);
 }
 
 #ifdef CONFIG_WIFI_NM_HOSTAPD_AP

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -14,6 +14,7 @@ if NET_IPV4
 config NET_IF_MAX_IPV4_COUNT
 	int "Max number of IPv4 network interfaces in the system"
 	default NET_VLAN_COUNT if NET_VLAN && NET_VLAN_COUNT > 0
+	default 2 if NRF70_ENABLE_DUAL_VIF
 	default 2 if NET_LOOPBACK
 	default 1
 	help

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -16,6 +16,7 @@ if NET_IPV6
 config NET_IF_MAX_IPV6_COUNT
 	int "Max number of IPv6 network interfaces in the system"
 	default NET_VLAN_COUNT if NET_VLAN && NET_VLAN_COUNT > 0
+	default 2 if NRF70_ENABLE_DUAL_VIF
 	default 2 if NET_LOOPBACK
 	default 1
 	help

--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: f707b19c1733ebe401a50450494e5ebdd2e71b5f
+      revision: 0798bf0faff40919bd577f1c8f75a2f9baae6299
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3

--- a/west.yml
+++ b/west.yml
@@ -337,7 +337,7 @@ manifest:
       revision: 40403f5f2805cca210d2a47c8717d89c4e816cda
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 5fffeab6496932abb10f9dae53ed3686967aa050
+      revision: acb24fe26f479df9dba3c4bd97ea653ad3086ee7
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637


### PR DESCRIPTION
**Description:**
The nRF7002 firmware supports two virtual interfaces (VIFs) that can operate in different modes (e.g., AP and STA). However, the existing Zephyr driver only utilizes a single VIF, preventing full multi-interface support.

This PR extends the nRF7002 driver to support multiple VIFs by making the following modifications:

- VIF Context Handling: The driver already contains an array of vif_ctx_zep, but only the first element was being used. Now, a second Ethernet device is registered using vif_ctx_zep[1], enabling multi-VIF operation.
- Tracking Interfaces: Introduced vif_ctx_cnt to keep track of active interfaces and manage their state effectively.
- FMAC Initialization: Ensured that FMAC (Firmware MAC) is initialized only once, avoiding redundant initializations when multiple VIFs are present.

**Testing:**
Verified that two virtual interfaces can be registered and operate simultaneously.
Tested AP mode on one VIF and STA mode on another VIF concurrently.
Ensured that UMAC command responses are correctly matched to their respective VIFs.
**Dependencies:**
This PR depends on the corresponding hostap PR, which introduces multiple control channels in WPA supplicant to handle separate interfaces.