### PR TITLE
scripts: Bump Python target version for ruff

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -4,7 +4,7 @@
 extend = ".ruff-excludes.toml"
 
 line-length = 100
-target-version = "py310"
+target-version = "py312"
 
 [lint]
 select = [

--- a/scripts/footprint/pack_as_twister.py
+++ b/scripts/footprint/pack_as_twister.py
@@ -33,7 +33,7 @@ test suite name ('dot separated' format).
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 import argparse
 import os
 import sys
@@ -163,7 +163,7 @@ def main():
     skipped = 0
     filtered = 0
 
-    run_date = datetime.now(timezone.utc).isoformat(timespec='seconds')
+    run_date = datetime.now(UTC).isoformat(timespec='seconds')
 
     init_logs()
 
@@ -251,7 +251,7 @@ def main():
         res['environment'] = {
             'zephyr_version': data_id['version'],
             'commit_date':
-                git_commit.committed_datetime.astimezone(timezone.utc).isoformat(timespec='seconds'),
+                git_commit.committed_datetime.astimezone(UTC).isoformat(timespec='seconds'),
             'run_date': run_date,
             'options': {
                 'testsuite_root': [ plan[r_plan]['application'] ],

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Generator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
 
@@ -1107,7 +1107,7 @@ class TwisterEnv:
     def discover(self):
         self.check_zephyr_version()
         self.get_toolchain()
-        self.run_date = datetime.now(timezone.utc).isoformat(timespec='seconds')
+        self.run_date = datetime.now(UTC).isoformat(timespec='seconds')
 
     def check_zephyr_version(self):
         try:


### PR DESCRIPTION
Now that Python 3.12 is the minimum required version for Zephyr, ruff should target that instead of 3.10.