### PR TITLE
drivers: sensor: battery: Type mismatch in `battery_soc_lookup()`

### DIFF
--- a/include/zephyr/drivers/sensor/battery.h
+++ b/include/zephyr/drivers/sensor/battery.h
@@ -68,7 +68,7 @@ enum battery_chemistry {
  * @returns Battery state of charge in milliPercent
  */
 static inline int32_t battery_soc_lookup(const int32_t ocv_table[BATTERY_OCV_TABLE_LEN],
-					 uint32_t voltage_uv)
+					 int32_t voltage_uv)
 {
 	static const int32_t soc_axis[BATTERY_OCV_TABLE_LEN] = {
 		0, 10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000};


### PR DESCRIPTION
`linear_interpolate()` expects `int32_t` as `x` parameter. So, `voltage_uv` must be of the same type.