### PR TITLE
lib: smf: fix missing execution of ancestor state run

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -267,6 +267,12 @@ void smf_set_initial(struct smf_ctx *ctx, const struct smf_state *init_state)
 		init_state->entry(ctx);
 	}
 #endif
+
+	/* entry action may have transitioned to new state, which must be
+	 * treated as initial state. Otherwise, the subsequent call to
+	 * smf_run_state() won't execute ancestor run actions.
+	 */
+	internal->new_state = false;
 }
 
 void smf_set_state(struct smf_ctx *const ctx, const struct smf_state *new_state)


### PR DESCRIPTION
The internal->new_state is introduced to avoid propagation of events to ancestor states in case one of its child states transitions to a different state because of such an event. In case of a call to smf_run_state() the internal->new_state is always reset after executing all the run-actions. However, it's also possible that an initial state transitions to a new state in its entry action in which case, resetting the internal->new_state is omitted. This causes (application code that is structured as such) that the first subsequent call to smf_run_state() after smf_set_intial() does not propagate events to ancestors.

Fix #89950