### PR TITLE
drivers: uhc: uhc_mcux_common: add direction handling for non-setup packet

### DIFF
--- a/drivers/usb/uhc/uhc_mcux_common.c
+++ b/drivers/usb/uhc/uhc_mcux_common.c
@@ -352,6 +352,8 @@ int uhc_mcux_hal_init_transfer_common(const struct device *dev, usb_host_transfe
 		mcux_xfer->direction = USB_REQTYPE_GET_DIR(mcux_xfer->setupPacket->bmRequestType)
 					       ? USB_IN
 					       : USB_OUT;
+	} else {
+		mcux_xfer->direction = USB_EP_DIR_IS_IN(xfer->ep) ? USB_IN : USB_OUT;
 	}
 
 	return 0;


### PR DESCRIPTION
to ensure proper processing by the SDK, logic has been enhanced to correctly determine the direction of non-setup USB transfers using the endpoint direction. This guarantees that USB_IN and USB_OUT directions are handled accurately, especially for bulk and other non-setup request packets.