### PR TITLE
tests: drivers: build_all: sensor: add adi,adxl366

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1331,3 +1331,11 @@ test_i2c_bh1730: bh1730@b4 {
 	compatible = "rohm,bh1730";
 	reg = <0xb4>;
 };
+
+test_i2c_adxl366: adxl366@b5 {
+	compatible = "adi,adxl366";
+	reg = <0xb5>;
+	int1-gpios = <&test_gpio 0 0>;
+	odr = <4>;
+	fifo-mode = <0>;
+};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -441,3 +441,12 @@ test_spi_ad2s1210: ad2s1210@35 {
 	reset-gpios = <&test_gpio 7 (GPIO_ACTIVE_LOW)>;
 	clock-frequency = <8192000>;
 };
+
+test_spi_adxl366: adxl366@36 {
+	compatible = "adi,adxl366";
+	reg = <0x36>;
+	spi-max-frequency = <0>;
+	int1-gpios = <&test_gpio 0 0>;
+	odr = <4>;
+	fifo-mode = <0>;
+};


### PR DESCRIPTION
This was missed when the driver was contributed in 756e699a41