### PR TITLE
i2c: stm32: RTIO: add target mode and transfers cases without START/STOP in between

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -114,14 +114,6 @@ struct i2c_stm32_data {
 		unsigned int len;
 		uint8_t *buf;
 	} current;
-#ifdef CONFIG_I2C_TARGET
-	bool master_active;
-	struct i2c_target_config *slave_cfg;
-#ifdef CONFIG_I2C_STM32_V2
-	struct i2c_target_config *slave2_cfg;
-#endif /* CONFIG_I2C_STM32_V2 */
-	bool slave_attached;
-#endif /* CONFIG_I2C_TARGET */
 	bool is_configured;
 	bool smbalert_active;
 	enum i2c_stm32_mode mode;
@@ -135,6 +127,15 @@ struct i2c_stm32_data {
 	struct dma_block_config dma_blk_cfg;
 #endif /* CONFIG_I2C_STM32_V2_DMA */
 #endif /* CONFIG_I2C_RTIO */
+
+#ifdef CONFIG_I2C_TARGET
+	bool master_active;
+	bool slave_attached;
+	struct i2c_target_config *slave_cfg;
+#ifdef CONFIG_I2C_STM32_V2
+	struct i2c_target_config *slave2_cfg;
+#endif /* CONFIG_I2C_STM32_V2 */
+#endif /* CONFIG_I2C_TARGET */
 };
 
 #ifdef CONFIG_I2C_RTIO
@@ -145,13 +146,14 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
 int i2c_stm32_transaction(const struct device *dev,
 			  struct i2c_msg msg, uint8_t *next_msg_flags,
 			  uint16_t periph);
+#endif /* CONFIG_I2C_RTIO */
+
 int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config);
 
 #ifdef CONFIG_I2C_TARGET
 int i2c_stm32_target_register(const struct device *dev, struct i2c_target_config *config);
 int i2c_stm32_target_unregister(const struct device *dev, struct i2c_target_config *config);
 #endif /* CONFIG_I2C_TARGET */
-#endif /* CONFIG_I2C_RTIO */
 
 int i2c_stm32_activate(const struct device *dev);
 int i2c_stm32_configure_timing(const struct device *dev, uint32_t clk);

--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -24,6 +24,11 @@
 
 typedef void (*irq_config_func_t)(const struct device *port);
 
+#ifdef CONFIG_I2C_STM32_V2
+/*  Private I2C_MSG_* flags for STM32 I2C */
+#define I2C_MSG_STM32_USE_RELOAD_MODE	BIT(7)
+#endif
+
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_i2c_v2)
 /**
  * @brief structure to convey optional i2c timings settings
@@ -79,6 +84,9 @@ struct i2c_stm32_data {
 	size_t msg_len;
 	uint8_t is_restart;
 	uint16_t slave_address;
+#else
+	uint8_t burst_flags;
+	uint8_t burst_len;
 #endif /* CONFIG_I2C_STM32_V1 */
 #else /* CONFIG_I2C_RTIO */
 #ifdef CONFIG_I2C_STM32_INTERRUPT

--- a/drivers/i2c/i2c_ll_stm32_rtio.c
+++ b/drivers/i2c/i2c_ll_stm32_rtio.c
@@ -16,6 +16,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
+#include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/util.h>
 
 #define LOG_LEVEL CONFIG_I2C_LOG_LEVEL
@@ -96,19 +97,29 @@ bool i2c_stm32_start(const struct device *dev)
 	struct i2c_rtio *ctx = data->ctx;
 	struct rtio_sqe *sqe = &ctx->txn_curr->sqe;
 	struct i2c_dt_spec *dt_spec = sqe->iodev->data;
-
+	uint8_t flags = sqe->iodev_flags;
 	int res = 0;
+
+#ifdef CONFIG_I2C_STM32_V2
+	struct rtio_iodev_sqe *iodev_sqe_next = rtio_txn_next(ctx->txn_curr);
+
+	if ((iodev_sqe_next != NULL) &&
+	    ((sqe->iodev_flags & I2C_MSG_STOP) == 0U) &&
+	    ((iodev_sqe_next->sqe.iodev_flags & I2C_MSG_RESTART) == 0U)) {
+		flags |= I2C_MSG_STM32_USE_RELOAD_MODE;
+	}
+#endif
 
 	switch (sqe->op) {
 	case RTIO_OP_RX:
-		return i2c_stm32_msg_start(dev, I2C_MSG_READ | sqe->iodev_flags,
-					   sqe->rx.buf, sqe->rx.buf_len, dt_spec->addr);
+		return i2c_stm32_msg_start(dev, I2C_MSG_READ | flags, sqe->rx.buf,
+					   sqe->rx.buf_len, dt_spec->addr);
 	case RTIO_OP_TINY_TX:
-		return i2c_stm32_msg_start(dev,  sqe->iodev_flags,
-					   sqe->tiny_tx.buf, sqe->tiny_tx.buf_len, dt_spec->addr);
+		return i2c_stm32_msg_start(dev, flags, sqe->tiny_tx.buf,
+					   sqe->tiny_tx.buf_len, dt_spec->addr);
 	case RTIO_OP_TX:
-		return i2c_stm32_msg_start(dev, sqe->iodev_flags,
-					   (uint8_t *)sqe->tx.buf, sqe->tx.buf_len, dt_spec->addr);
+		return i2c_stm32_msg_start(dev, flags, (uint8_t *)sqe->tx.buf,
+					   sqe->tx.buf_len, dt_spec->addr);
 	case RTIO_OP_I2C_CONFIGURE:
 		res = i2c_stm32_do_configure(dev, sqe->i2c_config);
 		return i2c_rtio_complete(data->ctx, res);
@@ -138,7 +149,29 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msgs,
 	/* Always set I2C_MSG_RESTART flag on first message in order to send start condition */
 	msgs[0].flags |= I2C_MSG_RESTART;
 
+#ifdef CONFIG_I2C_STM32_V2
+	/*
+	 * If a message has no STOP flag and next has no RESTART flag, set private flag
+	 * I2C_MSG_STM32_USE_RELOAD_MODE in message flag to force STM32 v2 driver to enable
+	 * reload mode for the message so that there is no Stop or Start conditions emited
+	 * in between. This means that flags shall not be used by the generic I2C framework.
+	 */
+	if ((msgs[0].flags & I2C_MSG_STM32_USE_RELOAD_MODE) != 0U) {
+		LOG_ERR("Unexpected bit mask 0x%02lx set in I2C message",
+			I2C_MSG_STM32_USE_RELOAD_MODE);
+		return -EINVAL;
+	}
+#endif
+
 	for (size_t n = 1; n < num_msgs; n++) {
+#ifdef CONFIG_I2C_STM32_V2
+		if ((msgs[n].flags & I2C_MSG_STM32_USE_RELOAD_MODE) != 0U) {
+			LOG_ERR("Unexpected bit mask 0x%02lx set in I2C message",
+				I2C_MSG_STM32_USE_RELOAD_MODE);
+			return -EINVAL;
+		}
+#endif
+
 		if ((OPERATION(msgs + n - 1) != OPERATION(msgs + n)) &&
 		    ((msgs[n].flags & I2C_MSG_RESTART) == 0U)) {
 			LOG_ERR("Missing restart flag between message of different directions");

--- a/drivers/i2c/i2c_ll_stm32_v1_rtio.c
+++ b/drivers/i2c/i2c_ll_stm32_v1_rtio.c
@@ -338,7 +338,9 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
 
 	LL_I2C_DisableBitPOS(i2c);
 	LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
-	i2c_stm32_generate_start_condition(i2c);
+	if ((flags & I2C_MSG_RESTART) != 0U) {
+		i2c_stm32_generate_start_condition(i2c);
+	}
 
 	i2c_stm32_enable_transfer_interrupts(dev);
 	if (flags & I2C_MSG_READ) {

--- a/drivers/i2c/i2c_ll_stm32_v2_rtio.c
+++ b/drivers/i2c/i2c_ll_stm32_v2_rtio.c
@@ -61,7 +61,259 @@ static void i2c_stm32_master_mode_end(const struct device *dev)
 	if (LL_I2C_IsEnabledReloadMode(i2c)) {
 		LL_I2C_DisableReloadMode(i2c);
 	}
+
+#if defined(CONFIG_I2C_TARGET)
+	struct i2c_stm32_data *data = dev->data;
+
+	data->master_active = false;
+	if (!data->slave_attached) {
+		LL_I2C_Disable(i2c);
+	}
+#else
+	LL_I2C_Disable(i2c);
+#endif
+
 }
+
+#if defined(CONFIG_I2C_TARGET)
+static void i2c_stm32_target_event(const struct device *dev)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
+	I2C_TypeDef *i2c = cfg->i2c;
+	const struct i2c_target_callbacks *target_cb;
+	struct i2c_target_config *target_cfg;
+
+	if (data->slave_cfg->flags != I2C_TARGET_FLAGS_ADDR_10_BITS) {
+		uint8_t target_address;
+
+		/* Choose the right target from the address match code */
+		target_address = LL_I2C_GetAddressMatchCode(i2c) >> 1;
+		if (data->slave_cfg != NULL &&
+		    target_address == data->slave_cfg->address) {
+			target_cfg = data->slave_cfg;
+		} else if (data->slave2_cfg != NULL &&
+			   target_address == data->slave2_cfg->address) {
+			target_cfg = data->slave2_cfg;
+		} else {
+			__ASSERT_NO_MSG(0);
+			return;
+		}
+	} else {
+		/* On STM32 the LL_I2C_GetAddressMatchCode & (ISR register) returns
+		 * only 7bits of address match so 10 bit dual addressing is broken.
+		 * Revert to assuming single address match.
+		 */
+		if (data->slave_cfg != NULL) {
+			target_cfg = data->slave_cfg;
+		} else {
+			__ASSERT_NO_MSG(0);
+			return;
+		}
+	}
+
+	target_cb = target_cfg->callbacks;
+
+	if (LL_I2C_IsActiveFlag_TXIS(i2c)) {
+		uint8_t val;
+
+		if (target_cb->read_processed(target_cfg, &val) < 0) {
+			LOG_ERR("Error continuing reading");
+		} else {
+			LL_I2C_TransmitData8(i2c, val);
+		}
+		return;
+	}
+
+	if (LL_I2C_IsActiveFlag_RXNE(i2c)) {
+		uint8_t val = LL_I2C_ReceiveData8(i2c);
+
+		if (target_cb->write_received(target_cfg, val)) {
+			LL_I2C_AcknowledgeNextData(i2c, LL_I2C_NACK);
+		}
+		return;
+	}
+
+	if (LL_I2C_IsActiveFlag_NACK(i2c)) {
+		LL_I2C_ClearFlag_NACK(i2c);
+	}
+
+	if (LL_I2C_IsActiveFlag_STOP(i2c)) {
+		i2c_stm32_disable_transfer_interrupts(dev);
+
+		/* Flush remaining TX byte before clearing Stop Flag */
+		LL_I2C_ClearFlag_TXE(i2c);
+
+		LL_I2C_ClearFlag_STOP(i2c);
+
+		target_cb->stop(target_cfg);
+
+		/* Prepare to ACK next transmissions address byte */
+		LL_I2C_AcknowledgeNextData(i2c, LL_I2C_ACK);
+	}
+
+	if (LL_I2C_IsActiveFlag_ADDR(i2c)) {
+		uint32_t dir;
+
+		LL_I2C_ClearFlag_ADDR(i2c);
+
+		dir = LL_I2C_GetTransferDirection(i2c);
+		if (dir == LL_I2C_DIRECTION_WRITE) {
+			if (target_cb->write_requested(target_cfg) < 0) {
+				LOG_ERR("Error initiating writing");
+			} else {
+				LL_I2C_EnableIT_RX(i2c);
+			}
+		} else {
+			uint8_t val;
+
+			if (target_cb->read_requested(target_cfg, &val) < 0) {
+				LOG_ERR("Error initiating reading");
+			} else {
+				LL_I2C_TransmitData8(i2c, val);
+				LL_I2C_EnableIT_TX(i2c);
+			}
+		}
+
+		i2c_stm32_enable_transfer_interrupts(dev);
+	}
+}
+
+/* Attach and start I2C as target */
+int i2c_stm32_target_register(const struct device *dev,
+			      struct i2c_target_config *config)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
+	I2C_TypeDef *i2c = cfg->i2c;
+	uint32_t bitrate_cfg;
+	int ret;
+
+	if (config == NULL) {
+		return -EINVAL;
+	}
+
+	if (data->slave_cfg && data->slave2_cfg) {
+		return -EBUSY;
+	}
+
+	if (data->master_active) {
+		return -EBUSY;
+	}
+
+	bitrate_cfg = i2c_map_dt_bitrate(cfg->bitrate);
+
+	ret = i2c_stm32_runtime_configure(dev, bitrate_cfg);
+	if (ret < 0) {
+		LOG_ERR("i2c: failure initializing");
+		return ret;
+	}
+
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	if (pm_device_wakeup_is_capable(dev)) {
+		/* Mark device as active */
+		(void)pm_device_runtime_get(dev);
+		/* Enable wake-up from stop */
+		LOG_DBG("i2c: enabling wakeup from stop");
+		LL_I2C_EnableWakeUpFromStop(cfg->i2c);
+	}
+#endif /* defined(CONFIG_PM_DEVICE_RUNTIME) */
+
+	LL_I2C_Enable(i2c);
+
+	if (!data->slave_cfg) {
+		data->slave_cfg = config;
+		if (data->slave_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+			LL_I2C_SetOwnAddress1(i2c, config->address, LL_I2C_OWNADDRESS1_10BIT);
+			LOG_DBG("i2c: target #1 registered with 10-bit address");
+		} else {
+			LL_I2C_SetOwnAddress1(i2c, config->address << 1U, LL_I2C_OWNADDRESS1_7BIT);
+			LOG_DBG("i2c: target #1 registered with 7-bit address");
+		}
+
+		LL_I2C_EnableOwnAddress1(i2c);
+
+		LOG_DBG("i2c: target #1 registered");
+	} else {
+		data->slave2_cfg = config;
+
+		if (data->slave2_cfg->flags == I2C_TARGET_FLAGS_ADDR_10_BITS)	{
+			return -EINVAL;
+		}
+		LL_I2C_SetOwnAddress2(i2c, config->address << 1U,
+				      LL_I2C_OWNADDRESS2_NOMASK);
+		LL_I2C_EnableOwnAddress2(i2c);
+		LOG_DBG("i2c: target #2 registered");
+	}
+
+	data->slave_attached = true;
+
+	LL_I2C_EnableIT_ADDR(i2c);
+
+	return 0;
+}
+
+int i2c_stm32_target_unregister(const struct device *dev,
+				struct i2c_target_config *config)
+{
+	const struct i2c_stm32_config *cfg = dev->config;
+	struct i2c_stm32_data *data = dev->data;
+	I2C_TypeDef *i2c = cfg->i2c;
+
+	if (!data->slave_attached) {
+		return -EINVAL;
+	}
+
+	if (data->master_active) {
+		return -EBUSY;
+	}
+
+	if (config == data->slave_cfg) {
+		LL_I2C_DisableOwnAddress1(i2c);
+		data->slave_cfg = NULL;
+
+		LOG_DBG("i2c: target #1 unregistered");
+	} else if (config == data->slave2_cfg) {
+		LL_I2C_DisableOwnAddress2(i2c);
+		data->slave2_cfg = NULL;
+
+		LOG_DBG("i2c: target #2 unregistered");
+	} else {
+		return -EINVAL;
+	}
+
+	/* Return if there is a target remaining */
+	if (data->slave_cfg || data->slave2_cfg) {
+		LOG_DBG("i2c: target#%c still registered", data->slave_cfg?'1':'2');
+		return 0;
+	}
+
+	/* Otherwise disable I2C */
+	LL_I2C_DisableIT_ADDR(i2c);
+	i2c_stm32_disable_transfer_interrupts(dev);
+
+	LL_I2C_ClearFlag_NACK(i2c);
+	LL_I2C_ClearFlag_STOP(i2c);
+	LL_I2C_ClearFlag_ADDR(i2c);
+
+	LL_I2C_Disable(i2c);
+
+#if defined(CONFIG_PM_DEVICE_RUNTIME)
+	if (pm_device_wakeup_is_capable(dev)) {
+		/* Disable wake-up from STOP */
+		LOG_DBG("i2c: disabling wakeup from stop");
+		LL_I2C_DisableWakeUpFromStop(i2c);
+		/* Release the device */
+		(void)pm_device_runtime_put(dev);
+	}
+#endif /* defined(CONFIG_PM_DEVICE_RUNTIME) */
+
+	data->slave_attached = false;
+
+	return 0;
+}
+
+#endif /* defined(CONFIG_I2C_TARGET) */
 
 static void i2c_stm32_reload_burst(const struct device *dev)
 {
@@ -97,6 +349,13 @@ void i2c_stm32_event(const struct device *dev)
 	struct i2c_rtio *ctx = data->ctx;
 	I2C_TypeDef *i2c = cfg->i2c;
 	int ret = 0;
+
+#if defined(CONFIG_I2C_TARGET)
+	if (data->slave_attached && !data->master_active) {
+		i2c_stm32_target_event(dev);
+		return;
+	}
+#endif
 
 	if (data->burst_len != 0U) {
 		/* Send next byte */
@@ -166,6 +425,13 @@ int i2c_stm32_error(const struct device *dev)
 	I2C_TypeDef *i2c = cfg->i2c;
 	int ret = 0;
 
+#if defined(CONFIG_I2C_TARGET)
+	if (data->slave_attached && !data->master_active) {
+		/* No need for a target error function right now. */
+		return 0;
+	}
+#endif
+
 	if (LL_I2C_IsActiveFlag_ARLO(i2c)) {
 		LL_I2C_ClearFlag_ARLO(i2c);
 		ret = -EIO;
@@ -232,6 +498,10 @@ int i2c_stm32_msg_start(const struct device *dev, uint8_t flags,
 	LL_I2C_DisableAutoEndMode(i2c);
 	LL_I2C_SetTransferRequest(i2c, transfer);
 	LL_I2C_SetTransferSize(i2c, data->burst_len);
+
+#if defined(CONFIG_I2C_TARGET)
+	data->master_active = true;
+#endif
 
 	LL_I2C_Enable(i2c);
 

--- a/samples/drivers/i2c/rtio_loopback/boards/nucleo_f401re.overlay
+++ b/samples/drivers/i2c/rtio_loopback/boards/nucleo_f401re.overlay
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* I2C bus pins are exposed on the ST morpho and Arduino headers.
+ *
+ *  Bus        SDA               SCL
+ *          Pin   Hdr         Pin   Hdr
+ *  i2c1    PB9   CN5:9       PB8   CN5:10
+ *  i2c3    PC9   CN10:1      PA8   CN9:8
+ *
+ * Short Pin PB9 to PC9, and PB8 to PA8, for the test to pass.
+ */
+
+/ {
+	aliases {
+		i2c-controller = &i2c1;
+		i2c-controller-target = &i2c3;
+	};
+};

--- a/samples/drivers/i2c/rtio_loopback/boards/nucleo_h503rb.overlay
+++ b/samples/drivers/i2c/rtio_loopback/boards/nucleo_h503rb.overlay
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* I2C bus pins are exposed on the ST morpho and Arduino headers.
+ *
+ *  Bus        SDA                    SCL
+ *          Pin   Hdr              Pin   Hdr
+ *  i2c1    PB7   CN5:9            PB6   CN5:10/CN10:3
+ *  i2c2    PB4   CN9:6/CN10:27     PB5   CN9:5/CN10:29
+ *
+ * Short Pin PB7 to PB4, and PB6 to PB5, for the test to pass.
+ */
+
+/ {
+	aliases {
+		i2c-controller = &i2c1;
+		i2c-controller-target = &i2c2;
+	};
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pb5 &i2c2_sda_pb4>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+};

--- a/samples/drivers/i2c/rtio_loopback/sample.yaml
+++ b/samples/drivers/i2c/rtio_loopback/sample.yaml
@@ -16,4 +16,6 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
+      - nucleo_f401re
+      - nucleo_h503rb
       - ophelia4ev/nrf54l15/cpuapp


### PR DESCRIPTION
Implement target mode in STM32 I2C v1 and v2 drivers for RTIO. The target mode implementation is dumped from the non-RTIO related drivers (*i2c_ll_stm32_v1.c* and *i2c_ll_stm32_v2.c*).

Fix write request issues found testing against *i2c/rtio_loopback* sample.

This series also adds 2 STM32 boards to the *i2c/rtio_loopback* sample: one based on STM32 I2C v1 and one based on STM32 I2C v2.