### PR TITLE
tests: drivers: build_all: sensor: add more sensors

### DIFF
--- a/dts/bindings/sensor/brcm,afbr-s50.yaml
+++ b/dts/bindings/sensor/brcm,afbr-s50.yaml
@@ -15,6 +15,8 @@ description: |
 
     Example:
 
+    #include <zephyr/dt-bindings/sensor/afbr_s50.h>
+
     &spi_bus {
         status = "okay";
         pinctrl-0 = <&spi_bus_default>;
@@ -26,6 +28,9 @@ description: |
           compatible = "brcm,afbr-s50";
           reg = <0>;
           spi-max-frequency = <10000000>;
+          measurement-mode = <AFBR_S50_DT_MODE_SHORT_RANGE>;
+          dual-freq-mode = <AFBR_S50_DT_DFM_MODE_OFF>;
+          odr = <10>;
           int-gpios = <&gpio0 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
           spi-mosi-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
           spi-sck-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;

--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -127,3 +127,9 @@ test_veaa_x_3: test_veaa_x_3 {
 	dac-resolution = <12>;
 	pressure-range-type = "D2";
 };
+
+test_als_pt19: test_als-pt19 {
+	compatible = "everlight,als-pt19";
+	io-channels = <&test_adc 0>;
+	load-resistor = <10000>;
+};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1369,3 +1369,11 @@ test_i2c_ds3231: ds3231@b7 {
 		compatible = "maxim,ds3231-sensor";
 	};
 };
+
+test_i2c_adxl366: adxl366@b8 {
+	compatible = "adi,adxl366";
+	reg = <0xb8>;
+	int1-gpios = <&test_gpio 0 0>;
+	odr = <4>;
+	fifo-mode = <0>;
+};

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1360,3 +1360,12 @@ test_i2c_npm1304: npm1304@b6 {
 		current-microamp = <10000>;
 	};
 };
+
+test_i2c_ds3231: ds3231@b7 {
+	compatible = "maxim,ds3231-mfd";
+	reg = <0xb7>;
+
+	test_i2c_ds3231_sensor: ds3231_sensor {
+		compatible = "maxim,ds3231-sensor";
+	};
+};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -450,3 +450,12 @@ test_spi_fxls8974: fxls8974@36 {
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
 };
+
+test_spi_adxl366: adxl366@37 {
+	compatible = "adi,adxl366";
+	reg = <0x37>;
+	spi-max-frequency = <0>;
+	int1-gpios = <&test_gpio 0 0>;
+	odr = <4>;
+	fifo-mode = <0>;
+};


### PR DESCRIPTION
add previously untested sensors

- `adi,adxl366`
- `everlight,als-pt19`
- `maxim,ds3231-sensor`

I was going to also add `brcm,afbr-s50` but it requires an Arm target ; it might still make sense to add a config for testing such kind of sensors, but this is for another PR I guess. However, I kept the commit that is fixing the yaml file for this sensor's binding so that the snippet in the documentation is complete (cc @ubieda @bperseghetti )