### PR TITLE
misc. inclusive language fixes

### DIFF
--- a/drivers/wifi/nxp/Kconfig.nxp
+++ b/drivers/wifi/nxp/Kconfig.nxp
@@ -659,7 +659,7 @@ config NXP_WIFI_CAPA
 	  This option enables uAP Wi-Fi Capability in the Wi-Fi driver.
 
 config NXP_WIFI_UAP_STA_MAC_ADDR_FILTER
-	bool "Wi-Fi SoftAP clients white/black list"
+	bool "Wi-Fi SoftAP clients allow/block list"
 	default y
 	help
 	  Allow/Block MAC addresses specified in the allowed list.

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2037,7 +2037,7 @@ class EDT:
           A dict mapping vendor prefixes in compatible properties to their
           descriptions. If given, compatibles in the form "manufacturer,device"
           for which "manufacturer" is neither a key in the dict nor a specially
-          exempt set of grandfathered-in cases will cause warnings.
+          exempt set of legacy cases will cause warnings.
 
         werror (default: False):
           If True, some edtlib specific warnings become errors. This currently

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -685,7 +685,7 @@ config BT_CTLR_PRIVACY
 	  in the Controller.
 
 config BT_CTLR_FAL_SIZE
-	int "LE Controller-based Privacy White List size"
+	int "LE Controller-based Privacy Accept List size"
 	depends on BT_CTLR_FILTER_ACCEPT_LIST
 	default 8
 	range 1 8  if  (SOC_COMPATIBLE_NRF || SOC_OPENISA_RV32M1)


### PR DESCRIPTION
A few fixes across the tree to align with inclusive language guidelines.