### PR TITLE
soc: nxp: kinetis: Add SoC support for k32lx platforms.

### DIFF
--- a/dts/arm/nxp/nxp_k32l2b3.dtsi
+++ b/dts/arm/nxp/nxp_k32l2b3.dtsi
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2025 Ishraq Ibne Ashraf <ishraq.i.ashraf@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <arm/armv6-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	chosen {
+		zephyr,flash-controller = &ftfa;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <0>;
+		};
+	};
+
+	sram0: memory@1FFFF000 {
+		compatible = "mmio-sram";
+	};
+
+	/* Dummy pinctrl node, filled with pin mux options at board level */
+	pinctrl: pinctrl {
+		compatible = "nxp,port-pinctrl";
+		status = "okay";
+	};
+
+	clocks {
+		osc: osc {
+			compatible = "nxp,mcxc-osc";
+			#clock-cells = <0>;
+			load-capacitance-picofarads = <0>;
+			mode = "external";
+		};
+	};
+
+	temp0: temp0 {
+		compatible = "nxp,kinetis-temperature";
+		io-channels = <&adc0 26>, <&adc0 27>;
+		io-channel-names = "SENSOR", "BANDGAP";
+		bandgap-voltage = <1000000>;
+		vtemp25 = <716000>;
+		sensor-slope-cold = <1620>;
+		sensor-slope-hot = <1620>;
+		status = "disabled";
+	};
+
+	soc {
+		ftfa: flash-controller@40020000 {
+			compatible = "nxp,kinetis-ftfa";
+			reg = <0x40020000 0x14>;
+			interrupts = <5 0>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			fsec = <0xfe>;
+			fopt = <0x3d>;
+			config-field-offset = <0x400>;
+
+			flash0: flash@0 {
+				compatible = "soc-nv-flash";
+				erase-block-size = <1024>;
+				write-block-size = <4>;
+			};
+		};
+
+		mcg: clock-controller@40064000 {
+			compatible = "nxp,kinetis-mcg";
+			reg = <0x40064000 0xd>;
+			fcrdiv = <0>;
+			lircdiv2 = <0>;
+			#clock-cells = <1>;
+		};
+
+		sim: sim@40047000 {
+			compatible = "nxp,kinetis-sim";
+			reg = <0x40047000 0x1060>;
+			#clock-cells = <3>;
+
+			core_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&mcg KINETIS_MCG_OUT_CLK>;
+				clock-div = <1>;
+				#clock-cells = <0>;
+			};
+
+			flash_clk {
+				compatible = "fixed-factor-clock";
+				clocks = <&mcg KINETIS_MCG_OUT_CLK>;
+				clock-div = <2>;
+				#clock-cells = <0>;
+			};
+		};
+
+		porta: pinmux@40049000 {
+			compatible = "nxp,port-pinmux";
+			reg = <0x40049000 0xd0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 9>;
+		};
+
+		portb: pinmux@4004a000 {
+			compatible = "nxp,port-pinmux";
+			reg = <0x4004a000 0xd0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 10>;
+		};
+
+		portc: pinmux@4004b000 {
+			compatible = "nxp,port-pinmux";
+			reg = <0x4004b000 0xd0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 11>;
+		};
+
+		portd: pinmux@4004c000 {
+			compatible = "nxp,port-pinmux";
+			reg = <0x4004c000 0xd0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 12>;
+		};
+
+		porte: pinmux@4004d000 {
+			compatible = "nxp,port-pinmux";
+			reg = <0x4004d000 0xd0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1038 13>;
+		};
+
+		gpioa: gpio@400ff000 {
+			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
+			reg = <0x400ff000 0x40>;
+			interrupts = <30 2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			nxp,kinetis-port = <&porta>;
+		};
+
+		gpiob: gpio@400ff040 {
+			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
+			reg = <0x400ff040 0x40>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			nxp,kinetis-port = <&portb>;
+		};
+
+		gpioc: gpio@400ff080 {
+			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
+			reg = <0x400ff080 0x40>;
+			interrupts = <31 2>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			nxp,kinetis-port = <&portc>;
+		};
+
+		gpiod: gpio@400ff0c0 {
+			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
+			reg = <0x400ff0c0 0x40>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			nxp,kinetis-port = <&portd>;
+		};
+
+		gpioe: gpio@400ff100 {
+			compatible = "nxp,kinetis-gpio";
+			status = "disabled";
+			reg = <0x400ff100 0x40>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			nxp,kinetis-port = <&porte>;
+		};
+
+		adc0: adc@4003b000{
+			compatible = "nxp,kinetis-adc16";
+			reg = <0x4003b000 0x70>;
+			interrupts = <15 0>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
+		i2c0: i2c@40066000 {
+			compatible = "nxp,kinetis-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40066000 0x1000>;
+			interrupts = <8 0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 6>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@40067000 {
+			compatible = "nxp,kinetis-i2c";
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40067000 0x1000>;
+			interrupts = <9 0>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 7>;
+			status = "disabled";
+		};
+
+		usb: usbd@40072000 {
+			compatible = "nxp,kinetis-usbd";
+			reg = <0x40072000 0x1000>;
+			interrupts = <24 1>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <16>;
+			status = "disabled";
+		};
+
+		lpuart0: uart@40054000 {
+			compatible = "nxp,lpuart";
+			reg = <0x40054000 0x1000>;
+			interrupts = <12 0>;
+			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 20>;
+			status = "disabled";
+		};
+
+		lpuart1: uart@40055000 {
+			compatible = "nxp,lpuart";
+			reg = <0x40055000 0x1000>;
+			interrupts = <13 0>;
+			clocks = <&sim KINETIS_SIM_MCGPCLK 0x1038 21>;
+			status = "disabled";
+		};
+
+		uart2: uart@4006c000 {
+			compatible = "nxp,kinetis-uart";
+			reg = <0x4006c000 0x1000>;
+			interrupts = <14 0>;
+			interrupt-names = "status";
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x1034 12>;
+			status = "disabled";
+		};
+
+		tpm0: pwm@40038000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x40038000 0x88>;
+			interrupts = <17 0>;
+			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103C 24>;
+			prescaler = <16>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
+		tpm1: pwm@40039000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x40039000 0x88>;
+			interrupts = <18 0>;
+			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103C 25>;
+			prescaler = <16>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
+		tpm2: pwm@4003a000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x4003a000 0x88>;
+			interrupts = <19 0>;
+			clocks = <&sim KINETIS_SIM_MCGPCLK 0x103C 26>;
+			prescaler = <16>;
+			status = "disabled";
+			#pwm-cells = <3>;
+		};
+
+		lptmr0: lptmr@40040000 {
+			compatible = "nxp,lptmr";
+			reg = <0x40040000 0x1000>;
+			interrupts = <28 0>;
+			clock-frequency = <1000>;
+			prescaler = <1>;
+			prescale-glitch-filter = <1>;
+			clk-source = <1>;
+			resolution = <16>;
+			status = "disabled";
+		};
+
+		rtc: rtc@4003d000 {
+			compatible = "nxp,rtc";
+			reg = <0x4003d000 0x1000>;
+			interrupts = <20 0>, <21 0>;
+			interrupt-names = "alarm", "seconds";
+			clock-frequency = <32768>;
+			prescaler = <32768>;
+			status = "disabled";
+		};
+
+		pit0: pit@40037000 {
+			compatible = "nxp,pit";
+			reg = <0x40037000 0x1000>;
+			clocks = <&sim KINETIS_SIM_BUS_CLK 0x103c 23>;
+			interrupts = <22 0>;
+			max-load-value = <0xffffffff>;
+			status = "disabled";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pit0_channel0: pit0_channel@0 {
+				compatible = "nxp,pit-channel";
+				reg = <0>;
+				status = "disabled";
+			};
+
+			pit0_channel1: pit0_channel@1 {
+				compatible = "nxp,pit-channel";
+				reg = <1>;
+				status = "disabled";
+			};
+		};
+	};
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <2>;
+};
+
+&sram0 {
+	reg = <0x1FFFE000 DT_SIZE_K(32)>;
+};
+
+&flash0 {
+	reg = <0 DT_SIZE_K(256)>;
+};

--- a/soc/nxp/kinetis/k32lx/CMakeLists.txt
+++ b/soc/nxp/kinetis/k32lx/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Ishraq Ibne Ashraf <ishraq.i.ashraf@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(.)
+
+zephyr_sources(soc.c)
+
+set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/nxp/kinetis/k32lx/Kconfig
+++ b/soc/nxp/kinetis/k32lx/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Ishraq Ibne Ashraf <ishraq.i.ashraf@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Kinetis K32Lx MCU series
+
+config SOC_SERIES_K32LX
+	select ARM
+	select CPU_CORTEX_M0PLUS
+	select CPU_CORTEX_M_HAS_VTOR
+	select CPU_CORTEX_M_HAS_SYSTICK
+	select HAS_MCUX
+	select HAS_MCUX_ADC16
+	select HAS_MCUX_SIM
+	select HAS_MCUX_RCM
+	select HAS_MCUX_FTFX
+	select HAS_MCUX_LPUART
+	select HAS_MCUX_LPI2C
+	select HAS_MCUX_TPM
+	select CLOCK_CONTROL
+	select SOC_RESET_HOOK
+	select SOC_EARLY_INIT_HOOK

--- a/soc/nxp/kinetis/k32lx/Kconfig.defconfig
+++ b/soc/nxp/kinetis/k32lx/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Ishraq Ibne Ashraf <ishraq.i.ashraf@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_SERIES_K32LX
+
+config NUM_IRQS
+	default 32
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if CORTEX_M_SYSTICK
+
+endif # SOC_SERIES_K32LX

--- a/soc/nxp/kinetis/k32lx/Kconfig.soc
+++ b/soc/nxp/kinetis/k32lx/Kconfig.soc
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 Ishraq Ibne Ashraf <ishraq.i.ashraf@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC_SERIES_K32LX
+	bool
+	select SOC_FAMILY_KINETIS
+
+config SOC_SERIES
+	default "k32lx" if SOC_SERIES_K32LX
+
+config SOC_K32L2B31A
+	bool
+	select SOC_SERIES_K32LX
+
+config SOC
+	default "k32l2b31a" if SOC_K32L2B31A
+
+config SOC_PART_NUMBER_K32L2B31VLH0A
+	bool
+
+config SOC_PART_NUMBER
+	default "K32L2B31VLH0A" if SOC_PART_NUMBER_K32L2B31VLH0A

--- a/soc/nxp/kinetis/k32lx/soc.c
+++ b/soc/nxp/kinetis/k32lx/soc.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <soc.h>
+#include <fsl_common.h>
+#include <fsl_clock.h>
+#include <zephyr/arch/cpu.h>
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define IRC48M_CLK_FREQ (48000000UL)
+
+#define MCG_NODE DT_NODELABEL(mcg)
+#define OSC_NODE DT_NODELABEL(osc)
+
+#define SIM_MODULE_CLK_SEL_DISABLED     0U /*!< Module clock select: Disabled */
+#define SIM_MODULE_CLK_SEL_IRC48M_CLK   1U /*!< Module clock select: IRC48M clock */
+#define SIM_MODULE_CLK_SEL_OSCERCLK_CLK 2U /*!< Module clock select: OSCERCLK clock */
+#define SIM_MODULE_CLK_SEL_MCGIRCLK_CLK 3U /*!< Module clock select: MCGIRCLK clock */
+
+#define CLOCK_NODEID(clk) DT_CHILD(DT_INST(0, nxp_kinetis_sim), clk)
+
+#define CLOCK_DIVIDER(clk) DT_PROP_OR(CLOCK_NODEID(clk), clock_div, 1) - 1
+
+#define LPUART_CLOCK_SEL(label) \
+	(DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_McgIrc48MClk \
+		 ? SIM_MODULE_CLK_SEL_IRC48M_CLK                                                   \
+	 : DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_Osc0ErClk \
+		 ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK                                                 \
+	 : DT_PHA(DT_NODELABEL(label), clocks, name) == kCLOCK_McgInternalRefClk \
+		 ? SIM_MODULE_CLK_SEL_MCGIRCLK_CLK                                                 \
+		 : SIM_MODULE_CLK_SEL_DISABLED)
+
+#define TPM_CLOCK_SEL(node_id)                                                                     \
+	(DT_PHA(node_id, clocks, name) == kCLOCK_McgIrc48MClk ? SIM_MODULE_CLK_SEL_IRC48M_CLK      \
+	 : DT_PHA(node_id, clocks, name) == kCLOCK_Osc0ErClk  ? SIM_MODULE_CLK_SEL_OSCERCLK_CLK    \
+	 : DT_PHA(node_id, clocks, name) == kCLOCK_McgInternalRefClk                               \
+		 ? SIM_MODULE_CLK_SEL_MCGIRCLK_CLK                                                 \
+		 : SIM_MODULE_CLK_SEL_DISABLED)
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+const mcglite_config_t mcgliteConfig_BOARD_BootClockRUN = {
+	.outSrc = kMCGLITE_ClkSrcHirc, /* MCGOUTCLK source is HIRC */
+	.irclkEnableMode = kMCGLITE_IrclkEnable, /* MCGIRCLK enabled */
+	.ircs = kMCGLITE_Lirc8M, /* Slow internal reference (LIRC) 8 MHz clock */
+	/* Low-frequency Reference Clock Divider */
+	.fcrdiv = DT_PROP_OR(MCG_NODE, fcrdiv, 0),
+	/* Second Low-frequency Reference Clock Divider */
+	.lircDiv2 = DT_PROP_OR(MCG_NODE, lircdiv2, 0),
+	.hircEnableInNotHircMode = true, /* HIRC source is enabled */
+};
+
+const sim_clock_config_t simConfig_BOARD_BootClockRUN = {
+	.er32kSrc = DT_PROP(DT_INST(0, nxp_kinetis_sim), er32k_select),
+	.clkdiv1 = SIM_CLKDIV1_OUTDIV1(CLOCK_DIVIDER(core_clk)) |
+		   SIM_CLKDIV1_OUTDIV4(CLOCK_DIVIDER(flash_clk)),
+};
+
+const osc_config_t oscConfig_BOARD_BootClockRUN = {
+	.freq = DT_PROP(OSC_NODE, clock_frequency),
+	.capLoad = 0,
+#if DT_ENUM_HAS_VALUE(OSC_NODE, mode, external)
+	.workMode = kOSC_ModeExt,
+#elif DT_ENUM_HAS_VALUE(OSC_NODE, mode, low_power)
+	.workMode = kOSC_ModeOscLowPower,
+#elif DT_ENUM_HAS_VALUE(OSC_NODE, mode, high_gain)
+	.workMode = kOSC_ModeOscHighGain,
+#else
+	#error "An oscillator mode must be defined"
+#endif
+	.oscerConfig = {
+		.enableMode = kOSC_ErClkEnable,
+	}
+};
+
+__weak void clock_init(void)
+{
+	/* Set the system clock dividers in SIM to safe value. */
+	CLOCK_SetSimSafeDivs();
+	/* Initializes OSC0 according to board configuration. */
+	CLOCK_InitOsc0(&oscConfig_BOARD_BootClockRUN);
+	CLOCK_SetXtal0Freq(oscConfig_BOARD_BootClockRUN.freq);
+	/* Set MCG to HIRC mode. */
+	CLOCK_SetMcgliteConfig(&mcgliteConfig_BOARD_BootClockRUN);
+	/* Set the clock configuration in SIM module. */
+	CLOCK_SetSimConfig(&simConfig_BOARD_BootClockRUN);
+	/* Set SystemCoreClock variable. */
+	SystemCoreClock = DT_PROP(DT_NODELABEL(cpu0), clock_frequency);
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpuart0))
+	/* Set LPUART0 clock source. */
+	CLOCK_SetLpuart0Clock(LPUART_CLOCK_SEL(lpuart0));
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpuart1))
+	/* Set LPUART1 clock source. */
+	CLOCK_SetLpuart1Clock(LPUART_CLOCK_SEL(lpuart1));
+#endif
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_kinetis_tpm)
+	/* All TPM instances share common clock source for counter clock.
+	 * Select the clock source using an arbitrary enabled TPM node.
+	 * All TPM nodes should use the same clock source in device tree.
+	 */
+	CLOCK_SetTpmClock(TPM_CLOCK_SEL(DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_kinetis_tpm)));
+#endif
+#if CONFIG_USB_KINETIS || CONFIG_UDC_KINETIS
+	CLOCK_EnableUsbfs0Clock(kCLOCK_UsbSrcIrc48M, IRC48M_CLK_FREQ);
+#endif
+}
+
+void soc_early_init_hook(void)
+{
+#ifdef CONFIG_TEMP_KINETIS
+	/* enable bandgap buffer */
+	PMC->REGSC |= PMC_REGSC_BGBE_MASK;
+#endif /* CONFIG_TEMP_KINETIS */
+
+	clock_init();
+}
+
+#ifdef CONFIG_SOC_RESET_HOOK
+
+void soc_reset_hook(void)
+{
+	SystemInit();
+}
+
+#endif /* CONFIG_SOC_RESET_HOOK */

--- a/soc/nxp/kinetis/k32lx/soc.h
+++ b/soc/nxp/kinetis/k32lx/soc.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SOC__H_
+#define _SOC__H_
+
+#include <zephyr/sys/util.h>
+#include <fsl_port.h>
+
+#define UART0_CLK_SRC kCLOCK_CoreSysClk
+
+#define PORT_MUX_GPIO kPORT_MuxAsGpio /* GPIO setting for the Port Mux Register */
+
+#ifndef _ASMLANGUAGE
+
+#include <fsl_common.h>
+
+#endif /* !_ASMLANGUAGE */
+
+#endif /* _SOC__H_ */

--- a/soc/nxp/kinetis/soc.yml
+++ b/soc/nxp/kinetis/soc.yml
@@ -34,6 +34,9 @@ family:
     - name: mke15z7
     - name: mke17z7
     - name: mke17z9
+  - name: k32lx
+    socs:
+    - name: k32l2b31a
 runners:
   run_once:
     '--erase':


### PR DESCRIPTION
Hi,

This PR adds support for NXP [FRDM-K32L2B3](https://www.nxp.com/design/design-center/development-boards-and-designs/general-purpose-mcus/nxp-frdm-development-platform-for-k32-l2b-mcus:FRDM-K32L2B3) board with [K32L2B31A](https://www.nxp.com/products/K32-L2) SoC. It can be reused and extended to support other K32 L2 and K32 L3 SoCs. 

This PR adds only the SoC support.

I also have working board support with working [hello_world](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/hello_world) and [blinky](https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/basic/blinky) samples. I intend to add the board support as a separate PR.

Cheers.