### PR TITLE
drivers: sensor: sht3xd: fix threshold low clear command

### DIFF
--- a/drivers/sensor/sensirion/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sensirion/sht3xd/sht3xd_trigger.c
@@ -233,7 +233,7 @@ int sht3xd_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-	if (sht3xd_write_reg(dev, SHT3XD_CMD_WRITE_TH_LOW_SET, 0) < 0) {
+	if (sht3xd_write_reg(dev, SHT3XD_CMD_WRITE_TH_LOW_CLEAR, 0) < 0) {
 		LOG_DBG("Failed to write threshold low clear value!");
 		return -EIO;
 	}


### PR DESCRIPTION
Fix copy-paste error causing update to SHT3XD_CMD_WRITE_TH_LOW_CLEAR to be missing