### PR TITLE
Bluetooth: Classic: AVCTP browsing channel support

### DIFF
--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -264,6 +264,19 @@ int bt_avrcp_connect(struct bt_conn *conn);
  */
 int bt_avrcp_disconnect(struct bt_conn *conn);
 
+/**
+ * @brief Allocate a net_buf for AVRCP PDU transmission, reserving headroom
+ *        for AVRCP, AVRCTP, L2CAP, and ACL headers.
+ *
+ * This function allocates a buffer from the specified pool and reserves
+ * sufficient headroom for protocol headers required by AVRCP over Bluetooth.
+ *
+ * @param pool The buffer pool to allocate from.
+ *
+ * @return A newly allocated net_buf with reserved headroom.
+ */
+struct net_buf *bt_avrcp_create_pdu(struct net_buf_pool *pool);
+
 /** @brief Register callback.
  *
  *  Register AVRCP callbacks to monitor the state and interact with the remote device.

--- a/include/zephyr/bluetooth/classic/avrcp.h
+++ b/include/zephyr/bluetooth/classic/avrcp.h
@@ -141,6 +141,124 @@ typedef enum __packed {
 	BT_AVRCP_BUTTON_RELEASED = 1,
 } bt_avrcp_button_state_t;
 
+/**
+ * @brief AVRCP status and error codes.
+ *
+ * These status codes are used in AVRCP responses to indicate the result of a command.
+ */
+typedef enum __packed {
+	/** Invalid command.
+	 * Valid for Commands: All
+	 */
+	BT_AVRCP_STATUS_INVALID_COMMAND = 0x00,
+
+	/** Invalid parameter.
+	 * Valid for Commands: All
+	 */
+	BT_AVRCP_STATUS_INVALID_PARAMETER = 0x01,
+
+	/** Parameter content error.
+	 * Valid for Commands: All
+	 */
+	BT_AVRCP_STATUS_PARAMETER_CONTENT_ERROR = 0x02,
+
+	/** Internal error.
+	 * Valid for Commands: All
+	 */
+	BT_AVRCP_STATUS_INTERNAL_ERROR = 0x03,
+
+	/** Operation completed without error.
+	 * Valid for Commands: All except where the response CType is AV/C REJECTED
+	 */
+	BT_AVRCP_STATUS_OPERATION_COMPLETED = 0x04,
+
+	/** The UIDs on the device have changed.
+	 * Valid for Commands: All
+	 */
+	BT_AVRCP_STATUS_UID_CHANGED = 0x05,
+
+	/** The Direction parameter is invalid.
+	 * Valid for Commands: ChangePath
+	 */
+	BT_AVRCP_STATUS_INVALID_DIRECTION = 0x07,
+
+	/** The UID provided does not refer to a folder item.
+	 * Valid for Commands: ChangePath
+	 */
+	BT_AVRCP_STATUS_NOT_A_DIRECTORY = 0x08,
+
+	/** The UID provided does not refer to any currently valid item.
+	 * Valid for Commands: ChangePath, PlayItem, AddToNowPlaying, GetItemAttributes
+	 */
+	BT_AVRCP_STATUS_DOES_NOT_EXIST = 0x09,
+
+	/** Invalid scope.
+	 * Valid for Commands: GetFolderItems, PlayItem, AddToNowPlayer, GetItemAttributes,
+	 * GetTotalNumberOfItems
+	 */
+	BT_AVRCP_STATUS_INVALID_SCOPE = 0x0a,
+
+	/** Range out of bounds.
+	 * Valid for Commands: GetFolderItems
+	 */
+	BT_AVRCP_STATUS_RANGE_OUT_OF_BOUNDS = 0x0b,
+
+	/** Folder item is not playable.
+	 * Valid for Commands: Play Item, AddToNowPlaying
+	 */
+	BT_AVRCP_STATUS_FOLDER_ITEM_IS_NOT_PLAYABLE = 0x0c,
+
+	/** Media in use.
+	 * Valid for Commands: PlayItem, AddToNowPlaying
+	 */
+	BT_AVRCP_STATUS_MEDIA_IN_USE = 0x0d,
+
+	/** Now Playing List full.
+	 * Valid for Commands: AddToNowPlaying
+	 */
+	BT_AVRCP_STATUS_NOW_PLAYING_LIST_FULL = 0x0e,
+
+	/** Search not supported.
+	 * Valid for Commands: Search
+	 */
+	BT_AVRCP_STATUS_SEARCH_NOT_SUPPORTED = 0x0f,
+
+	/** Search in progress.
+	 * Valid for Commands: Search
+	 */
+	BT_AVRCP_STATUS_SEARCH_IN_PROGRESS = 0x10,
+
+	/** The specified Player Id does not refer to a valid player.
+	 * Valid for Commands: SetAddressedPlayer, SetBrowsedPlayer
+	 */
+	BT_AVRCP_STATUS_INVALID_PLAYER_ID = 0x11,
+
+	/** Player not browsable.
+	 * Valid for Commands: SetBrowsedPlayer
+	 */
+	BT_AVRCP_STATUS_PLAYER_NOT_BROWSABLE = 0x12,
+
+	/** Player not addressed.
+	 * Valid for Commands: Search, SetBrowsedPlayer
+	 */
+	BT_AVRCP_STATUS_PLAYER_NOT_ADDRESSED = 0x13,
+
+	/** No valid search results.
+	 * Valid for Commands: GetFolderItems
+	 */
+	BT_AVRCP_STATUS_NO_VALID_SEARCH_RESULTS = 0x14,
+
+	/** No available players.
+	 * Valid for Commands: ALL
+	 */
+	BT_AVRCP_STATUS_NO_AVAILABLE_PLAYERS = 0x15,
+
+	/** Addressed player changed.
+	 * Valid for Commands: All Register Notification commands
+	 */
+	BT_AVRCP_STATUS_ADDRESSED_PLAYER_CHANGED = 0x16,
+} bt_avrcp_status_t;
+
 /** @brief AVRCP CT structure */
 struct bt_avrcp_ct;
 /** @brief AVRCP TG structure */
@@ -167,13 +285,34 @@ struct bt_avrcp_passthrough_rsp {
 	uint8_t byte0; /**< [7]: state_flag, [6:0]: opid */
 	uint8_t data_len;
 	uint8_t data[];
-};
+} __packed;
 
 struct bt_avrcp_get_cap_rsp {
 	uint8_t cap_id;  /**< bt_avrcp_cap_t */
 	uint8_t cap_cnt; /**< number of items contained in *cap */
 	uint8_t cap[];   /**< 1 or 3 octets each depends on cap_id */
-};
+} __packed;
+
+/** @brief AVRCP Character Set IDs */
+typedef enum __packed {
+	BT_AVRCP_CHARSET_UTF8 = 0x006a,
+} bt_avrcp_charset_t;
+
+/** @brief get folder name (response) */
+struct bt_avrcp_folder_name {
+	uint16_t folder_name_len;
+	uint8_t folder_name[];
+} __packed;
+
+/** @brief Set browsed player response structure */
+struct bt_avrcp_set_browsed_player_rsp {
+	uint8_t status;                              /**< Status see bt_avrcp_status_t.*/
+	uint16_t uid_counter;                        /**< UID counter */
+	uint32_t num_items;                          /**< Number of items in the folder */
+	uint16_t charset_id;                         /**< Character set ID */
+	uint8_t folder_depth;                        /**< Folder depth */
+	struct bt_avrcp_folder_name folder_names[0]; /**< Folder names data */
+} __packed;
 
 struct bt_avrcp_ct_cb {
 	/** @brief An AVRCP CT connection has been established.
@@ -194,6 +333,25 @@ struct bt_avrcp_ct_cb {
 	 *  @param ct AVRCP CT connection object.
 	 */
 	void (*disconnected)(struct bt_avrcp_ct *ct);
+
+	/** @brief An AVRCP CT browsing connection has been established.
+	 *
+	 *  This callback notifies the application of an avrcp browsing connection,
+	 *  i.e., an AVCTP browsing L2CAP connection.
+	 *
+	 *  @param conn Connection object.
+	 *  @param ct AVRCP CT connection object.
+	 */
+	void (*browsing_connected)(struct bt_conn *conn, struct bt_avrcp_ct *ct);
+
+	/** @brief An AVRCP CT browsing connection has been disconnected.
+	 *
+	 *  This callback notifies the application that an avrcp browsing connection
+	 *  has been disconnected.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 */
+	void (*browsing_disconnected)(struct bt_avrcp_ct *ct);
 
 	/** @brief Callback function for bt_avrcp_get_cap().
 	 *
@@ -239,6 +397,19 @@ struct bt_avrcp_ct_cb {
 	 */
 	void (*passthrough_rsp)(struct bt_avrcp_ct *ct, uint8_t tid, bt_avrcp_rsp_t result,
 				const struct bt_avrcp_passthrough_rsp *rsp);
+
+	/** @brief Callback function for bt_avrcp_ct_set_browsed_player().
+	 *
+	 *  Called when the set browsed player process is completed.
+	 *
+	 *  @param ct AVRCP CT connection object.
+	 *  @param tid The transaction label of the response.
+	 *  @param buf The response buffer containing the set browsed player response data.
+	 *             The application can parse this payload according to the format defined in
+	 *             @ref bt_avrcp_set_browsed_player_rsp. Note that the data is encoded in
+	 *             big-endian format.
+	 */
+	void (*browsed_player_rsp)(struct bt_avrcp_ct *ct, uint8_t tid, struct net_buf *buf);
 };
 
 /** @brief Connect AVRCP.
@@ -276,6 +447,27 @@ int bt_avrcp_disconnect(struct bt_conn *conn);
  * @return A newly allocated net_buf with reserved headroom.
  */
 struct net_buf *bt_avrcp_create_pdu(struct net_buf_pool *pool);
+
+/** @brief Connect AVRCP browsing channel.
+ *
+ *  This function is to be called after the AVRCP control channel is established.
+ *  The API is to be used to establish AVRCP browsing connection between devices.
+ *
+ *  @param conn Pointer to bt_conn structure.
+ *
+ *  @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_browsing_connect(struct bt_conn *conn);
+
+/** @brief Disconnect AVRCP browsing channel.
+ *
+ *  This function close AVCTP browsing channel L2CAP connection.
+ *
+ *  @param conn Pointer to bt_conn structure.
+ *
+ *  @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_browsing_disconnect(struct bt_conn *conn);
 
 /** @brief Register callback.
  *
@@ -339,6 +531,18 @@ int bt_avrcp_ct_get_subunit_info(struct bt_avrcp_ct *ct, uint8_t tid);
 int bt_avrcp_ct_passthrough(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t opid, uint8_t state,
 			    const uint8_t *payload, uint8_t len);
 
+/** @brief Set browsed player.
+ *
+ *  This function sets the browsed player on the remote device.
+ *
+ *  @param ct The AVRCP CT instance.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param player_id The player ID to be set as browsed player.
+ *
+ *  @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_ct_set_browsed_player(struct bt_avrcp_ct *ct, uint8_t tid, uint16_t player_id);
+
 struct bt_avrcp_tg_cb {
 	/** @brief An AVRCP TG connection has been established.
 	 *
@@ -367,6 +571,35 @@ struct bt_avrcp_tg_cb {
 	 *  @param tg AVRCP TG connection object.
 	 */
 	void (*unit_info_req)(struct bt_avrcp_tg *tg, uint8_t tid);
+
+	/** @brief An AVRCP TG browsing connection has been established.
+	 *
+	 *  This callback notifies the application of an avrcp browsing connection,
+	 *  i.e., an AVCTP browsing L2CAP connection.
+	 *
+	 *  @param conn Connection object.
+	 *  @param tg AVRCP TG connection object.
+	 */
+	void (*browsing_connected)(struct bt_conn *conn, struct bt_avrcp_tg *tg);
+
+	/** @brief An AVRCP TG browsing connection has been disconnected.
+	 *
+	 *  This callback notifies the application that an avrcp browsing connection
+	 *  has been disconnected.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 */
+	void (*browsing_disconnected)(struct bt_avrcp_tg *tg);
+
+	/** @brief Set browsed player request callback.
+	 *
+	 *  This callback is called whenever an AVRCP set browsed player request is received.
+	 *
+	 *  @param tg AVRCP TG connection object.
+	 *  @param tid The transaction label of the request.
+	 *  @param player_id The player ID to be set as browsed player.
+	 */
+	void (*set_browsed_player_req)(struct bt_avrcp_tg *tg, uint8_t tid, uint16_t player_id);
 };
 
 /** @brief Register callback.
@@ -391,6 +624,19 @@ int bt_avrcp_tg_register_cb(const struct bt_avrcp_tg_cb *cb);
  */
 int bt_avrcp_tg_send_unit_info_rsp(struct bt_avrcp_tg *tg, uint8_t tid,
 				   struct bt_avrcp_unit_info_rsp *rsp);
+
+/** @brief Send the set browsed player response.
+ *
+ *  This function is called by the application to send the set browsed player response.
+ *
+ *  @param tg The AVRCP TG instance.
+ *  @param tid The transaction label of the response, valid from 0 to 15.
+ *  @param buf The response buffer containing the set browsed player response data.
+ *
+ *  @return 0 in case of success or error code in case of error.
+ */
+int bt_avrcp_tg_send_set_browsed_player_rsp(struct bt_avrcp_tg *tg, uint8_t tid,
+					    struct net_buf *buf);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -490,6 +490,14 @@ config BT_AVRCP_CONTROLLER
 	help
 	  This option enables the AVRCP profile controller function
 
+config BT_AVRCP_BROWSING
+	bool "Bluetooth AVRCP Browsing channel support [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	select BT_L2CAP_ENH_RET
+	help
+	  This option enables support for the AVRCP Browsing channel
+	  over Bluetooth BR/EDR.
+
 endif # BT_AVRCP
 
 config BT_PAGE_TIMEOUT

--- a/subsys/bluetooth/host/classic/avctp.c
+++ b/subsys/bluetooth/host/classic/avctp.c
@@ -31,8 +31,9 @@
 LOG_MODULE_REGISTER(bt_avctp);
 
 #define AVCTP_CHAN(_ch) CONTAINER_OF(_ch, struct bt_avctp, br_chan.chan)
-
-static const struct bt_avctp_event_cb *event_cb;
+/* L2CAP Server list */
+static sys_slist_t avctp_l2cap_server = SYS_SLIST_STATIC_INIT(&avctp_l2cap_server);
+static struct k_sem avctp_server_lock;
 
 static void avctp_l2cap_connected(struct bt_l2cap_chan *chan)
 {
@@ -80,7 +81,6 @@ static int avctp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	struct bt_avctp *session = AVCTP_CHAN(chan);
 	struct bt_avctp_header *hdr = (void *)buf->data;
 	uint8_t tid;
-	bt_avctp_pkt_type_t pkt_type;
 	bt_avctp_cr_t cr;
 	int err;
 
@@ -90,46 +90,34 @@ static int avctp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 	}
 
 	tid = BT_AVCTP_HDR_GET_TRANSACTION_LABLE(hdr);
-	pkt_type = BT_AVCTP_HDR_GET_PACKET_TYPE(hdr);
 	cr = BT_AVCTP_HDR_GET_CR(hdr);
 
-	switch (pkt_type) {
-	case BT_AVCTP_PKT_TYPE_SINGLE:
-		break;
-	case BT_AVCTP_PKT_TYPE_START:
-	case BT_AVCTP_PKT_TYPE_CONTINUE:
-	case BT_AVCTP_PKT_TYPE_END:
-	default:
-		LOG_ERR("fragmented AVCTP message is not supported, pkt_type = %d", pkt_type);
-		return -EINVAL;
+	LOG_DBG("AVCTP msg received, cr:0x%X, tid:0x%X, pid: 0x%04X",
+		cr, tid, sys_be16_to_cpu(hdr->pid));
+
+	if (sys_be16_to_cpu(hdr->pid) == session->pid) {
+		return session->ops->recv(session, buf);
 	}
 
-	switch (hdr->pid) {
-#if defined(CONFIG_BT_AVRCP)
-	case sys_cpu_to_be16(BT_SDP_AV_REMOTE_SVCLASS):
-		break;
-#endif
-	default:
-		LOG_ERR("unsupported AVCTP PID received: 0x%04x", sys_be16_to_cpu(hdr->pid));
-		if (cr == BT_AVCTP_CMD) {
-			rsp = bt_avctp_create_pdu(session, BT_AVCTP_RESPONSE,
-						  BT_AVCTP_PKT_TYPE_SINGLE, BT_AVCTP_IPID_INVALID,
-						  tid, hdr->pid);
-			if (!rsp) {
-				return -ENOMEM;
-			}
-
-			err = bt_avctp_send(session, rsp);
-			if (err < 0) {
-				net_buf_unref(rsp);
-				LOG_ERR("AVCTP send fail, err = %d", err);
-				return err;
-			}
+	LOG_ERR("unsupported AVCTP PID received: 0x%04x", sys_be16_to_cpu(hdr->pid));
+	if (cr == BT_AVCTP_CMD) {
+		rsp = bt_avctp_create_pdu(session, BT_AVCTP_RESPONSE,
+					  BT_AVCTP_PKT_TYPE_SINGLE, BT_AVCTP_IPID_INVALID,
+					  tid, hdr->pid);
+		if (rsp == NULL) {
+			__ASSERT(0, "Failed to create AVCTP response PDU");
+			return -ENOMEM;
 		}
-		return 0; /* No need to report to the upper layer */
-	}
 
-	return session->ops->recv(session, buf);
+		err = bt_avctp_send(session, rsp);
+		if (err < 0) {
+			net_buf_unref(rsp);
+			LOG_ERR("AVCTP send fail, err = %d", err);
+			bt_avctp_disconnect(session);
+			return err;
+		}
+	}
+	return 0; /* No need to report to the upper layer */
 }
 
 static const struct bt_l2cap_chan_ops ops = {
@@ -139,17 +127,14 @@ static const struct bt_l2cap_chan_ops ops = {
 	.recv = avctp_l2cap_recv,
 };
 
-int bt_avctp_connect(struct bt_conn *conn, struct bt_avctp *session)
+int bt_avctp_connect(struct bt_conn *conn, uint16_t psm, struct bt_avctp *session)
 {
 	if (!session) {
 		return -EINVAL;
 	}
 
-	session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
 	session->br_chan.chan.ops = &ops;
-	session->br_chan.required_sec_level = BT_SECURITY_L2;
-
-	return bt_l2cap_chan_connect(conn, &session->br_chan.chan, BT_L2CAP_PSM_AVCTP);
+	return bt_l2cap_chan_connect(conn, &session->br_chan.chan, psm);
 }
 
 int bt_avctp_disconnect(struct bt_avctp *session)
@@ -161,6 +146,19 @@ int bt_avctp_disconnect(struct bt_avctp *session)
 	LOG_DBG("session %p", session);
 
 	return bt_l2cap_chan_disconnect(&session->br_chan.chan);
+}
+
+void bt_avctp_set_header(struct bt_avctp_header *avctp_hdr, bt_avctp_cr_t cr,
+			 bt_avctp_pkt_type_t pkt_type, bt_avctp_ipid_t ipid,
+			 uint8_t tid, uint16_t pid)
+{
+	LOG_DBG("");
+
+	BT_AVCTP_HDR_SET_TRANSACTION_LABLE(avctp_hdr, tid);
+	BT_AVCTP_HDR_SET_PACKET_TYPE(avctp_hdr, pkt_type);
+	BT_AVCTP_HDR_SET_CR(avctp_hdr, cr);
+	BT_AVCTP_HDR_SET_IPID(avctp_hdr, ipid);
+	avctp_hdr->pid = pid;
 }
 
 struct net_buf *bt_avctp_create_pdu(struct bt_avctp *session, bt_avctp_cr_t cr,
@@ -179,11 +177,7 @@ struct net_buf *bt_avctp_create_pdu(struct bt_avctp *session, bt_avctp_cr_t cr,
 	}
 
 	hdr = net_buf_add(buf, sizeof(*hdr));
-	BT_AVCTP_HDR_SET_TRANSACTION_LABLE(hdr, tid);
-	BT_AVCTP_HDR_SET_PACKET_TYPE(hdr, pkt_type);
-	BT_AVCTP_HDR_SET_CR(hdr, cr);
-	BT_AVCTP_HDR_SET_IPID(hdr, ipid);
-	hdr->pid = pid;
+	bt_avctp_set_header(hdr, cr, pkt_type, ipid, tid, pid);
 
 	LOG_DBG("cr:0x%lX, tid:0x%02lX", BT_AVCTP_HDR_GET_CR(hdr),
 		BT_AVCTP_HDR_GET_TRANSACTION_LABLE(hdr));
@@ -195,63 +189,78 @@ int bt_avctp_send(struct bt_avctp *session, struct net_buf *buf)
 	return bt_l2cap_chan_send(&session->br_chan.chan, buf);
 }
 
-int bt_avctp_register(const struct bt_avctp_event_cb *cb)
-{
-	LOG_DBG("");
-
-	if (event_cb) {
-		return -EALREADY;
-	}
-
-	event_cb = cb;
-
-	return 0;
-}
-
 static int avctp_l2cap_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
 			      struct bt_l2cap_chan **chan)
 {
 	struct bt_avctp *session = NULL;
+	struct bt_avctp_server *avctp_server;
 	int err;
 
 	LOG_DBG("conn %p", conn);
 
-	if (!event_cb) {
-		LOG_WRN("AVCTP server is unsupported");
-		return -ENOTSUP;
+	avctp_server = CONTAINER_OF(server, struct bt_avctp_server, l2cap);
+
+	k_sem_take(&avctp_server_lock, K_FOREVER);
+
+	if (!sys_slist_find(&avctp_l2cap_server, &avctp_server->node, NULL)) {
+		LOG_WRN("Invalid l2cap server");
+		k_sem_give(&avctp_server_lock);
+		return -EINVAL;
 	}
 
+	k_sem_give(&avctp_server_lock);
+
 	/* Get the AVCTP session from upper layer */
-	err = event_cb->accept(conn, &session);
+	err = avctp_server->accept(conn, &session);
 	if (err < 0) {
-		LOG_ERR("Get the AVCTP session failed %d", err);
+		LOG_ERR("Incoming connection rejected");
 		return err;
 	}
 
-	session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
-	session->br_chan.psm = BT_L2CAP_PSM_AVCTP;
 	session->br_chan.chan.ops = &ops;
 	*chan = &session->br_chan.chan;
 
 	return 0;
 }
 
-int bt_avctp_init(void)
+int bt_avctp_server_register(struct bt_avctp_server *server)
 {
 	int err;
-	static struct bt_l2cap_server avctp_l2cap = {
-		.psm = BT_L2CAP_PSM_AVCTP,
-		.sec_level = BT_SECURITY_L2,
-		.accept = avctp_l2cap_accept,
-	};
-
 	LOG_DBG("");
 
-	/* Register AVCTP PSM with L2CAP */
-	err = bt_l2cap_br_server_register(&avctp_l2cap);
-	if (err < 0) {
-		LOG_ERR("AVCTP L2CAP registration failed %d", err);
+	if ((server == NULL) || (server->accept == NULL)) {
+		LOG_DBG("Invalid parameter");
+		return -EINVAL;
 	}
 
+	k_sem_take(&avctp_server_lock, K_FOREVER);
+
+	if (sys_slist_find(&avctp_l2cap_server, &server->node, NULL)) {
+		LOG_WRN("L2CAP server has been registered");
+		k_sem_give(&avctp_server_lock);
+		return -EEXIST;
+	}
+
+	server->l2cap.accept = avctp_l2cap_accept;
+	err = bt_l2cap_br_server_register(&server->l2cap);
+	if (err < 0) {
+		LOG_ERR("AVCTP L2CAP registration failed %d", err);
+		k_sem_give(&avctp_server_lock);
+		return err;
+	}
+
+	LOG_DBG("Register L2CAP server %p", server);
+	sys_slist_append(&avctp_l2cap_server, &server->node);
+
+	k_sem_give(&avctp_server_lock);
+
 	return err;
+}
+
+int bt_avctp_init(void)
+{
+	LOG_DBG("Initializing AVCTP");
+	/* Locking semaphore initialized to 1 (unlocked) */
+	k_sem_init(&avctp_server_lock, 1, 1);
+	return 0;
 }

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -35,6 +35,8 @@ struct bt_avrcp {
 	struct bt_avctp session;
 	/* ACL connection handle */
 	struct bt_conn *acl_conn;
+
+	struct bt_avctp browsing_session;
 };
 
 struct bt_avrcp_ct {
@@ -50,7 +52,14 @@ struct avrcp_handler {
 	void (*func)(struct bt_avrcp *avrcp, uint8_t tid, struct net_buf *buf);
 };
 
+struct avrcp_pdu_handler {
+	bt_avrcp_pdu_id_t pdu_id;
+	uint8_t min_len;
+	int (*func)(struct bt_avrcp *avrcp, uint8_t tid, struct net_buf *buf);
+};
+
 #define AVRCP_AVCTP(_avctp) CONTAINER_OF(_avctp, struct bt_avrcp, session)
+#define AVRCP_BROW_AVCTP(_avctp) CONTAINER_OF(_avctp, struct bt_avrcp, browsing_session)
 
 /*
  * This macros returns true if the CT/TG has been initialized, which
@@ -66,6 +75,10 @@ static struct bt_avrcp avrcp_connection[CONFIG_BT_MAX_CONN];
 static struct bt_avrcp_ct bt_avrcp_ct_pool[CONFIG_BT_MAX_CONN];
 static struct bt_avrcp_tg bt_avrcp_tg_pool[CONFIG_BT_MAX_CONN];
 
+static struct bt_avctp_server avctp_server;
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+static struct bt_avctp_server avctp_browsing_server;
+#endif /* CONFIG_BT_AVRCP_BROWSING */
 #if defined(CONFIG_BT_AVRCP_TARGET)
 static struct bt_sdp_attribute avrcp_tg_attrs[] = {
 	BT_SDP_NEW_SERVICE,
@@ -108,7 +121,42 @@ static struct bt_sdp_attribute avrcp_tg_attrs[] = {
 		},
 		)
 	),
-	/* C1: Browsing not supported */
+	/* Browsing channel */
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+	BT_SDP_LIST(
+		BT_SDP_ATTR_ADD_PROTO_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 18),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 16),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+				BT_SDP_DATA_ELEM_LIST(
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+					BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)
+				},
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+					BT_SDP_ARRAY_16(BT_L2CAP_PSM_AVRCP_BROWSING)
+				})
+			},
+			{
+				BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+				BT_SDP_DATA_ELEM_LIST(
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+					BT_SDP_ARRAY_16(BT_UUID_AVCTP_VAL)
+				},
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+					BT_SDP_ARRAY_16(AVCTP_VER_1_4)
+				})
+			})
+		})
+	),
+#endif /* CONFIG_BT_AVRCP_BROWSING */
 	/* C2: Cover Art not supported */
 	BT_SDP_LIST(
 		BT_SDP_ATTR_PROFILE_DESC_LIST,
@@ -129,7 +177,7 @@ static struct bt_sdp_attribute avrcp_tg_attrs[] = {
 		},
 		)
 	),
-	BT_SDP_SUPPORTED_FEATURES(AVRCP_CAT_1 | AVRCP_CAT_2),
+	BT_SDP_SUPPORTED_FEATURES(AVRCP_CAT_1 | AVRCP_CAT_2 | AVRCP_BROWSING_ENABLE),
 	/* O: Provider Name not presented */
 	BT_SDP_SERVICE_NAME("AVRCP Target"),
 };
@@ -186,7 +234,43 @@ static struct bt_sdp_attribute avrcp_ct_attrs[] = {
 		},
 		)
 	),
-	/* C1: Browsing not supported */
+	/* Browsing channel */
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+	BT_SDP_LIST(
+		BT_SDP_ATTR_ADD_PROTO_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 18),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 16),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+				BT_SDP_DATA_ELEM_LIST(
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+					BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)
+				},
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+					BT_SDP_ARRAY_16(BT_L2CAP_PSM_AVRCP_BROWSING)
+				})
+			},
+			{
+				BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+				BT_SDP_DATA_ELEM_LIST(
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+					BT_SDP_ARRAY_16(BT_UUID_AVCTP_VAL)
+				},
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+					BT_SDP_ARRAY_16(AVCTP_VER_1_4)
+				})
+			})
+		})
+	),
+#endif /* CONFIG_BT_AVRCP_BROWSING */
+	/* C2: Cover Art not supported */
 	BT_SDP_LIST(
 		BT_SDP_ATTR_PROFILE_DESC_LIST,
 		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8),
@@ -206,8 +290,7 @@ static struct bt_sdp_attribute avrcp_ct_attrs[] = {
 		},
 		)
 	),
-	BT_SDP_SUPPORTED_FEATURES(AVRCP_CAT_1 | AVRCP_CAT_2),
-	/* O: Provider Name not presented */
+	BT_SDP_SUPPORTED_FEATURES(AVRCP_CAT_1 | AVRCP_CAT_2 | AVRCP_BROWSING_ENABLE),
 	BT_SDP_SERVICE_NAME("AVRCP Controller"),
 };
 
@@ -404,6 +487,34 @@ static int avrcp_send(struct bt_avrcp *avrcp, struct net_buf *buf)
 	if (err < 0) {
 		net_buf_unref(buf);
 		LOG_ERR("AVCTP send fail, err = %d", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static struct net_buf *avrcp_create_browsing_pdu(struct bt_avrcp *avrcp, uint8_t tid,
+						 bt_avctp_cr_t cr)
+{
+	return bt_avctp_create_pdu(&(avrcp->browsing_session), cr, BT_AVCTP_PKT_TYPE_SINGLE,
+				   BT_AVCTP_IPID_NONE, tid,
+				   sys_cpu_to_be16(BT_SDP_AV_REMOTE_SVCLASS));
+}
+
+static int avrcp_browsing_send(struct bt_avrcp *avrcp, struct net_buf *buf)
+{
+	int err;
+	struct bt_avctp_header *avctp_hdr = (struct bt_avctp_header *)(buf->data);
+	struct bt_avrcp_avc_brow_pdu *hdr =
+		(struct bt_avrcp_avc_brow_pdu *)(buf->data + sizeof(*avctp_hdr));
+	uint8_t tid = BT_AVCTP_HDR_GET_TRANSACTION_LABLE(avctp_hdr);
+	bt_avctp_cr_t cr = BT_AVCTP_HDR_GET_CR(avctp_hdr);
+
+	LOG_DBG("AVRCP browsing send cr:0x%X, tid:0x%X, pdu_id:0x%02X\n", cr, tid,
+		hdr->pdu_id);
+	err = bt_avctp_send(&(avrcp->browsing_session), buf);
+	if (err < 0) {
+		LOG_ERR("AVCTP browsing send fail, err = %d", err);
 		return err;
 	}
 
@@ -701,6 +812,15 @@ static int avrcp_recv(struct bt_avctp *session, struct net_buf *buf)
 	return 0;
 }
 
+static void init_avctp_control_channel(struct bt_avctp *session)
+{
+	LOG_DBG("session %p", session);
+
+	session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
+	session->br_chan.required_sec_level = BT_SECURITY_L2;
+	session->pid = BT_SDP_AV_REMOTE_SVCLASS;
+}
+
 static const struct bt_avctp_ops_cb avctp_ops = {
 	.connected = avrcp_connected,
 	.disconnected = avrcp_disconnected,
@@ -720,6 +840,7 @@ static int avrcp_accept(struct bt_conn *conn, struct bt_avctp **session)
 		return -EALREADY;
 	}
 
+	init_avctp_control_channel(&(avrcp->session));
 	*session = &(avrcp->session);
 	avrcp->session.ops = &avctp_ops;
 	avrcp->acl_conn = bt_conn_ref(conn);
@@ -729,20 +850,234 @@ static int avrcp_accept(struct bt_conn *conn, struct bt_avctp **session)
 	return 0;
 }
 
-static struct bt_avctp_event_cb avctp_cb = {
-	.accept = avrcp_accept,
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+static void init_avctp_browsing_channel(struct bt_avctp *session)
+{
+	LOG_DBG("session %p", session);
+
+	session->br_chan.rx.mtu = BT_L2CAP_RX_MTU;
+	session->br_chan.required_sec_level = BT_SECURITY_L2;
+	session->br_chan.rx.optional = false;
+	session->br_chan.rx.max_window = CONFIG_BT_L2CAP_MAX_WINDOW_SIZE;
+	session->br_chan.rx.max_transmit = 3;
+	session->br_chan.rx.mode = BT_L2CAP_BR_LINK_MODE_ERET;
+	session->br_chan.tx.monitor_timeout = CONFIG_BT_L2CAP_BR_MONITOR_TIMEOUT;
+	session->pid = BT_SDP_AV_REMOTE_SVCLASS;
+}
+
+/* The AVCTP L2CAP channel established */
+static void browsing_avrcp_connected(struct bt_avctp *session)
+{
+	struct bt_avrcp *avrcp = AVRCP_BROW_AVCTP(session);
+
+	if ((avrcp_ct_cb != NULL) && (avrcp_ct_cb->browsing_connected != NULL)) {
+		avrcp_ct_cb->browsing_connected(session->br_chan.chan.conn, get_avrcp_ct(avrcp));
+	}
+
+	if ((avrcp_tg_cb != NULL) && (avrcp_tg_cb->browsing_connected != NULL)) {
+		avrcp_tg_cb->browsing_connected(session->br_chan.chan.conn, get_avrcp_tg(avrcp));
+	}
+}
+
+/* The AVCTP L2CAP channel released */
+static void browsing_avrcp_disconnected(struct bt_avctp *session)
+{
+	struct bt_avrcp *avrcp = AVRCP_BROW_AVCTP(session);
+
+	if ((avrcp_ct_cb != NULL) && (avrcp_ct_cb->disconnected != NULL)) {
+		avrcp_ct_cb->browsing_disconnected(get_avrcp_ct(avrcp));
+	}
+	if ((avrcp_tg_cb != NULL) && (avrcp_tg_cb->disconnected != NULL)) {
+		avrcp_tg_cb->browsing_disconnected(get_avrcp_tg(avrcp));
+	}
+}
+
+static int avrcp_ct_handle_set_browsed_player(struct bt_avrcp *avrcp,
+					      uint8_t tid, struct net_buf *buf)
+{
+	if ((avrcp_ct_cb == NULL) || (avrcp_ct_cb->browsed_player_rsp == NULL)) {
+		return -EINVAL;
+	}
+
+	avrcp_ct_cb->browsed_player_rsp(get_avrcp_ct(avrcp), tid, buf);
+
+	return 0;
+}
+
+static const struct avrcp_pdu_handler rsp_brow_handlers[] = {
+	{BT_AVRCP_PDU_ID_SET_BROWSED_PLAYER, sizeof(struct bt_avrcp_set_browsed_player_rsp),
+	 avrcp_ct_handle_set_browsed_player},
 };
+
+static int avrcp_tg_handle_set_browsed_player_req(struct bt_avrcp *avrcp,
+						  uint8_t tid, struct net_buf *buf)
+{
+	uint16_t player_id;
+	struct net_buf *rsp_buf;
+	int err;
+
+	if ((avrcp_tg_cb == NULL) || (avrcp_tg_cb->set_browsed_player_req == NULL)) {
+		goto error_rsp;
+	}
+
+	player_id = net_buf_pull_be16(buf);
+
+	LOG_DBG("Set browsed player request: player_id=0x%04x", player_id);
+
+	avrcp_tg_cb->set_browsed_player_req(get_avrcp_tg(avrcp), tid, player_id);
+	return 0;
+
+error_rsp:
+	rsp_buf = bt_avrcp_create_pdu(NULL);
+	__ASSERT(rsp_buf != NULL, "Failed to allocate response buffer");
+
+	if (net_buf_tailroom(rsp_buf) < sizeof(uint8_t)) {
+		LOG_ERR("Insufficient space in response buffer");
+		net_buf_unref(rsp_buf);
+		return -ENOMEM;
+	}
+	net_buf_add_u8(rsp_buf, BT_AVRCP_STATUS_INTERNAL_ERROR);
+
+	err = bt_avrcp_tg_send_set_browsed_player_rsp(get_avrcp_tg(avrcp), tid, rsp_buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send browsed player error response (err: %d)", err);
+		net_buf_unref(rsp_buf);
+	}
+	return err;
+}
+
+static const struct avrcp_pdu_handler cmd_brow_handlers[] = {
+	{BT_AVRCP_PDU_ID_SET_BROWSED_PLAYER, sizeof(uint16_t),
+	 avrcp_tg_handle_set_browsed_player_req},
+};
+
+static int handle_pdu(struct bt_avrcp *avrcp, uint8_t tid, struct net_buf *buf,
+		      uint8_t pdu_id, const struct avrcp_pdu_handler *handlers, size_t num_handlers)
+{
+	for (size_t i = 0; i < num_handlers; i++) {
+		const struct avrcp_pdu_handler *handler = &handlers[i];
+
+		if (handler->pdu_id != pdu_id) {
+			continue;
+		}
+
+		if (buf->len < handler->min_len) {
+			LOG_ERR("Too small (%u bytes) pdu_id 0x%02x", buf->len, pdu_id);
+			return -EINVAL;
+		}
+
+		return handler->func(avrcp, tid, buf);
+	}
+
+	return -EOPNOTSUPP;
+}
+
+static int browsing_avrcp_recv(struct bt_avctp *session, struct net_buf *buf)
+{
+	struct bt_avrcp *avrcp = AVRCP_BROW_AVCTP(session);
+	struct bt_avctp_header *avctp_hdr;
+	bt_avctp_pkt_type_t pkt_type;
+	struct bt_avrcp_avc_brow_pdu *brow;
+	uint8_t tid;
+	bt_avctp_cr_t cr;
+
+	if (buf->len < sizeof(*avctp_hdr) + sizeof(struct bt_avrcp_avc_brow_pdu)) {
+		LOG_ERR("Invalid AVRCP browsing header received: buffer too short (%u)", buf->len);
+		return -EMSGSIZE;
+	}
+
+	avctp_hdr = net_buf_pull_mem(buf, sizeof(*avctp_hdr));
+	pkt_type = BT_AVCTP_HDR_GET_PACKET_TYPE(avctp_hdr);
+	tid = BT_AVCTP_HDR_GET_TRANSACTION_LABLE(avctp_hdr);
+	cr = BT_AVCTP_HDR_GET_CR(avctp_hdr);
+
+	brow = net_buf_pull_mem(buf, sizeof(struct bt_avrcp_avc_brow_pdu));
+
+	if (pkt_type != BT_AVCTP_PKT_TYPE_SINGLE) {
+		LOG_ERR("Invalid packet type: 0x%02X", pkt_type);
+		return -EINVAL;
+	}
+
+	if (avctp_hdr->pid != sys_cpu_to_be16(BT_SDP_AV_REMOTE_SVCLASS)) {
+		return -EINVAL; /* Ignore other profile */
+	}
+
+	if (buf->len != sys_be16_to_cpu(brow->param_len)) {
+		LOG_ERR("Invalid AVRCP browsing PDU length: expected %u, got %u",
+			sys_be16_to_cpu(brow->param_len), buf->len);
+		return -EMSGSIZE;
+	}
+
+	LOG_DBG("AVRCP browsing msg received, cr:0x%X, tid:0x%X, pdu_id:0x%02X", cr,
+		tid, brow->pdu_id);
+
+	if (cr == BT_AVCTP_RESPONSE) {
+		return handle_pdu(avrcp, tid, buf, brow->pdu_id, rsp_brow_handlers,
+				  ARRAY_SIZE(rsp_brow_handlers));
+	}
+
+	return handle_pdu(avrcp, tid, buf, brow->pdu_id, cmd_brow_handlers,
+			  ARRAY_SIZE(cmd_brow_handlers));
+}
+
+static const struct bt_avctp_ops_cb browsing_avctp_ops = {
+	.connected = browsing_avrcp_connected,
+	.disconnected = browsing_avrcp_disconnected,
+	.recv = browsing_avrcp_recv,
+};
+
+static int avrcp_browsing_accept(struct bt_conn *conn, struct bt_avctp **session)
+{
+	struct bt_avrcp *avrcp;
+
+	avrcp = avrcp_get_connection(conn);
+	if (avrcp == NULL) {
+		LOG_ERR("Cannot allocate memory");
+		return -ENOTCONN;
+	}
+
+	if (avrcp->acl_conn == NULL) {
+		LOG_ERR("The control channel not established");
+		return -ENOTCONN;
+	}
+
+	if (avrcp->browsing_session.br_chan.chan.conn != NULL) {
+		LOG_ERR("Browsing session already connected");
+		return -EALREADY;
+	}
+
+	init_avctp_browsing_channel(&(avrcp->browsing_session));
+	avrcp->browsing_session.ops = &browsing_avctp_ops;
+	*session = &(avrcp->browsing_session);
+
+	LOG_DBG("browsing_session: %p", &(avrcp->browsing_session));
+
+	return 0;
+}
+#endif /* CONFIG_BT_AVRCP_BROWSING */
 
 int bt_avrcp_init(void)
 {
 	int err;
 
 	/* Register event handlers with AVCTP */
-	err = bt_avctp_register(&avctp_cb);
+	avctp_server.l2cap.psm = BT_L2CAP_PSM_AVRCP;
+	avctp_server.accept = avrcp_accept;
+	err = bt_avctp_server_register(&avctp_server);
 	if (err < 0) {
 		LOG_ERR("AVRCP registration failed");
 		return err;
 	}
+
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+	avctp_browsing_server.l2cap.psm = BT_L2CAP_PSM_AVRCP_BROWSING;
+	avctp_browsing_server.accept = avrcp_browsing_accept;
+	err = bt_avctp_server_register(&avctp_browsing_server);
+	if (err < 0) {
+		LOG_ERR("AVRCP browsing registration failed");
+		return err;
+	}
+#endif /* CONFIG_BT_AVRCP_BROWSING */
 
 #if defined(CONFIG_BT_AVRCP_TARGET)
 	bt_sdp_register_service(&avrcp_tg_rec);
@@ -781,7 +1116,8 @@ int bt_avrcp_connect(struct bt_conn *conn)
 	}
 
 	avrcp->session.ops = &avctp_ops;
-	err = bt_avctp_connect(conn, &(avrcp->session));
+	init_avctp_control_channel(&(avrcp->session));
+	err = bt_avctp_connect(conn, BT_L2CAP_PSM_AVRCP, &(avrcp->session));
 	if (err < 0) {
 		/* If error occurs, undo the saving and return the error */
 		memset(avrcp, 0, sizeof(struct bt_avrcp));
@@ -805,6 +1141,15 @@ int bt_avrcp_disconnect(struct bt_conn *conn)
 		return -ENOTCONN;
 	}
 
+	if (avrcp->browsing_session.br_chan.chan.conn != NULL) {
+		/* If browsing session is still active, disconnect it first */
+		err = bt_avrcp_browsing_disconnect(conn);
+		if (err < 0) {
+			LOG_ERR("Browsing session disconnect failed: %d", err);
+			return err;
+		}
+	}
+
 	err = bt_avctp_disconnect(&(avrcp->session));
 	if (err < 0) {
 		LOG_DBG("AVCTP Disconnect failed");
@@ -821,6 +1166,61 @@ struct net_buf *bt_avrcp_create_pdu(struct net_buf_pool *pool)
 				  sizeof(struct bt_avctp_header) +
 				  sizeof(struct bt_avrcp_header));
 }
+
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+int bt_avrcp_browsing_connect(struct bt_conn *conn)
+{
+	struct bt_avrcp *avrcp;
+	int err;
+
+	avrcp = avrcp_get_connection(conn);
+	if (avrcp == NULL) {
+		LOG_ERR("Cannot allocate memory");
+		return -ENOTCONN;
+	}
+
+	if (avrcp->acl_conn == NULL) {
+		LOG_ERR("The control channel not established");
+		return -ENOTCONN;
+	}
+
+	if (avrcp->browsing_session.br_chan.chan.conn != NULL) {
+		return -EALREADY;
+	}
+
+	avrcp->browsing_session.ops = &browsing_avctp_ops;
+	init_avctp_browsing_channel(&(avrcp->browsing_session));
+	err = bt_avctp_connect(conn, BT_L2CAP_PSM_AVRCP_BROWSING, &(avrcp->browsing_session));
+	if (err < 0) {
+		LOG_ERR("AVCTP browsing connect failed");
+		return err;
+	}
+
+	LOG_DBG("Browsing connection request sent");
+
+	return 0;
+}
+
+int bt_avrcp_browsing_disconnect(struct bt_conn *conn)
+{
+	int err;
+	struct bt_avrcp *avrcp;
+
+	avrcp = avrcp_get_connection(conn);
+	if (avrcp == NULL) {
+		LOG_ERR("Get avrcp connection failure");
+		return -ENOTCONN;
+	}
+
+	err = bt_avctp_disconnect(&(avrcp->browsing_session));
+	if (err < 0) {
+		LOG_ERR("AVCTP browsing disconnect failed");
+		return err;
+	}
+
+	return err;
+}
+#endif /* CONFIG_BT_AVRCP_BROWSING */
 
 int bt_avrcp_ct_get_cap(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t cap_id)
 {
@@ -927,6 +1327,51 @@ int bt_avrcp_ct_passthrough(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t opid, u
 	return avrcp_send(ct->avrcp, buf);
 }
 
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+int bt_avrcp_ct_set_browsed_player(struct bt_avrcp_ct *ct, uint8_t tid, uint16_t player_id)
+{
+	struct net_buf *buf;
+	struct bt_avrcp_avc_brow_pdu *pdu;
+	int err;
+
+	if ((ct == NULL) || (ct->avrcp == NULL)) {
+		return -EINVAL;
+	}
+
+	if (!IS_CT_ROLE_SUPPORTED()) {
+		return -ENOTSUP;
+	}
+
+	if (ct->avrcp->browsing_session.br_chan.chan.conn == NULL) {
+		LOG_ERR("Browsing session not connected");
+		return -ENOTCONN;
+	}
+
+	buf = avrcp_create_browsing_pdu(ct->avrcp, tid, BT_AVCTP_CMD);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	if (net_buf_tailroom(buf) < sizeof(*pdu) + sizeof(player_id)) {
+		LOG_ERR("Not enough tailroom in buffer for browsing PDU");
+		net_buf_unref(buf);
+		return -ENOMEM;
+	}
+
+	pdu = net_buf_add(buf, sizeof(*pdu));
+	pdu->pdu_id = BT_AVRCP_PDU_ID_SET_BROWSED_PLAYER;
+	pdu->param_len = sys_cpu_to_be16(sizeof(player_id));
+	net_buf_add_be16(buf, player_id);
+
+	err = avrcp_browsing_send(ct->avrcp, buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP browsing PDU (err: %d)", err);
+		net_buf_unref(buf);
+	}
+	return err;
+}
+#endif /* CONFIG_BT_AVRCP_BROWSING */
+
 int bt_avrcp_ct_register_cb(const struct bt_avrcp_ct_cb *cb)
 {
 	if (!cb) {
@@ -985,3 +1430,57 @@ int bt_avrcp_tg_send_unit_info_rsp(struct bt_avrcp_tg *tg, uint8_t tid,
 
 	return avrcp_send(tg->avrcp, buf);
 }
+
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+int bt_avrcp_tg_send_set_browsed_player_rsp(struct bt_avrcp_tg *tg, uint8_t tid,
+					    struct net_buf *buf)
+{
+	struct bt_avrcp_avc_brow_pdu *hdr;
+	struct bt_avctp_header *avctp_hdr;
+	uint16_t param_len;
+	int err;
+
+	if ((tg == NULL) || (tg->avrcp == NULL) || (buf == NULL)) {
+		LOG_ERR("Invalid AVRCP target");
+		return -EINVAL;
+	}
+
+	if (!IS_TG_ROLE_SUPPORTED()) {
+		LOG_ERR("Target role not supported");
+		return -ENOTSUP;
+	}
+
+	if (tg->avrcp->browsing_session.br_chan.chan.conn == NULL) {
+		LOG_ERR("Browsing session not connected");
+		return -ENOTCONN;
+	}
+
+	param_len = buf->len;
+
+	if (net_buf_headroom(buf) < sizeof(struct bt_avrcp_avc_brow_pdu)) {
+		LOG_ERR("Not enough headroom in buffer for bt_avrcp_avc_brow_pdu");
+		return -ENOMEM;
+	}
+	hdr = net_buf_push(buf, sizeof(struct bt_avrcp_avc_brow_pdu));
+	memset(hdr, 0, sizeof(struct bt_avrcp_avc_brow_pdu));
+	hdr->pdu_id = BT_AVRCP_PDU_ID_SET_BROWSED_PLAYER;
+	hdr->param_len = sys_cpu_to_be16(param_len);
+
+	if (net_buf_headroom(buf) < sizeof(struct bt_avctp_header)) {
+		LOG_ERR("Not enough headroom in buffer for bt_avctp_header");
+		return -ENOMEM;
+	}
+	avctp_hdr = net_buf_push(buf, sizeof(struct bt_avctp_header));
+	memset(avctp_hdr, 0, sizeof(struct bt_avctp_header));
+
+	bt_avctp_set_header(avctp_hdr, BT_AVCTP_RESPONSE, BT_AVCTP_PKT_TYPE_SINGLE,
+			    BT_AVCTP_IPID_NONE, tid,
+			    sys_cpu_to_be16(BT_SDP_AV_REMOTE_SVCLASS));
+
+	err = avrcp_browsing_send(tg->avrcp, buf);
+	if (err < 0) {
+		LOG_ERR("Failed to send AVRCP browsing PDU (err: %d)", err);
+	}
+	return err;
+}
+#endif /* CONFIG_BT_AVRCP_BROWSING */

--- a/subsys/bluetooth/host/classic/avrcp.c
+++ b/subsys/bluetooth/host/classic/avrcp.c
@@ -814,6 +814,14 @@ int bt_avrcp_disconnect(struct bt_conn *conn)
 	return err;
 }
 
+struct net_buf *bt_avrcp_create_pdu(struct net_buf_pool *pool)
+{
+	return bt_conn_create_pdu(pool,
+				  sizeof(struct bt_l2cap_hdr) +
+				  sizeof(struct bt_avctp_header) +
+				  sizeof(struct bt_avrcp_header));
+}
+
 int bt_avrcp_ct_get_cap(struct bt_avrcp_ct *ct, uint8_t tid, uint8_t cap_id)
 {
 	struct net_buf *buf;

--- a/subsys/bluetooth/host/classic/avrcp_internal.h
+++ b/subsys/bluetooth/host/classic/avrcp_internal.h
@@ -12,16 +12,30 @@
 #define AVCTP_VER_1_4 (0x0104u)
 #define AVRCP_VER_1_6 (0x0106u)
 
-#define AVRCP_CAT_1 BIT(0) /* Player/Recorder */
-#define AVRCP_CAT_2 BIT(1) /* Monitor/Amplifier */
-#define AVRCP_CAT_3 BIT(2) /* Tuner */
-#define AVRCP_CAT_4 BIT(3) /* Menu */
+#define AVRCP_CAT_1                       BIT(0) /* Player/Recorder */
+#define AVRCP_CAT_2                       BIT(1) /* Monitor/Amplifier */
+#define AVRCP_CAT_3                       BIT(2) /* Tuner */
+#define AVRCP_CAT_4                       BIT(3) /* Menu */
+#define AVRCP_PLAYER_APPLICATION_SETTINGS BIT(4) /* Bit 0 must also be set */
+#define AVRCP_GROUP_NAVIGATION            BIT(5) /* Bit 0 must also be set */
+#define AVRCP_BROWSING_SUPPORT            BIT(6)
+#define AVRCP_MULTIPLE_MEDIA_PLAYERS      BIT(7)
+#define AVRCP_COVER_ART_SUPPORT           BIT(8)
 
 #define AVRCP_SUBUNIT_PAGE              (0) /* Fixed value according to AVRCP */
 #define AVRCP_SUBUNIT_EXTENSION_CODE    (7) /* Fixed value according to TA Document 2001012 */
 #define BT_AVRCP_UNIT_INFO_CMD_SIZE     (5)
 #define BT_AVRCP_UNIT_INFO_RSP_SIZE     (5)
 #define BT_AVRCP_SUBUNIT_INFO_RSP_SIZE  (5)
+
+#define BT_L2CAP_PSM_AVRCP 0x0017
+#define BT_L2CAP_PSM_AVRCP_BROWSING 0x001b
+
+#if defined(CONFIG_BT_AVRCP_BROWSING)
+#define AVRCP_BROWSING_ENABLE AVRCP_BROWSING_SUPPORT
+#else
+#define AVRCP_BROWSING_ENABLE 0
+#endif /* CONFIG_BT_AVRCP_BROWSING */
 
 typedef enum __packed {
 	BT_AVRCP_SUBUNIT_ID_ZERO = 0x0,
@@ -118,6 +132,12 @@ struct bt_avrcp_header {
 struct bt_avrcp_avc_pdu {
 	uint8_t pdu_id;
 	uint8_t pkt_type; /**< [7:2]: Reserved, [1:0]: Packet Type */
+	uint16_t param_len;
+	uint8_t param[];
+} __packed;
+
+struct bt_avrcp_avc_brow_pdu {
+	uint8_t pdu_id;
 	uint16_t param_len;
 	uint8_t param[];
 } __packed;

--- a/subsys/bluetooth/host/classic/shell/avrcp.c
+++ b/subsys/bluetooth/host/classic/shell/avrcp.c
@@ -29,6 +29,12 @@
 #include "host/shell/bt.h"
 #include "common/bt_shell_private.h"
 
+NET_BUF_POOL_DEFINE(avrcp_tx_pool, CONFIG_BT_MAX_CONN,
+		    BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
+		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+#define FOLDER_NAME_HEX_BUF_LEN 80
+
 struct bt_avrcp_ct *default_ct;
 struct bt_avrcp_tg *default_tg;
 static bool avrcp_ct_registered;
@@ -58,6 +64,16 @@ static void avrcp_ct_disconnected(struct bt_avrcp_ct *ct)
 	bt_shell_print("AVRCP CT disconnected");
 	local_tid = 0;
 	default_ct = NULL;
+}
+
+static void avrcp_ct_browsing_connected(struct bt_conn *conn, struct bt_avrcp_ct *ct)
+{
+	bt_shell_print("AVRCP CT browsing connected");
+}
+
+static void avrcp_ct_browsing_disconnected(struct bt_avrcp_ct *ct)
+{
+	bt_shell_print("AVRCP CT browsing disconnected");
 }
 
 static void avrcp_get_cap_rsp(struct bt_avrcp_ct *ct, uint8_t tid,
@@ -115,13 +131,70 @@ static void avrcp_passthrough_rsp(struct bt_avrcp_ct *ct, uint8_t tid, bt_avrcp_
 	}
 }
 
+static void avrcp_browsed_player_rsp(struct bt_avrcp_ct *ct, uint8_t tid,
+				     struct net_buf *buf)
+{
+	struct bt_avrcp_set_browsed_player_rsp *rsp;
+	struct bt_avrcp_folder_name *folder_name;
+
+	rsp = net_buf_pull_mem(buf, sizeof(*rsp));
+	if (rsp->status != BT_AVRCP_STATUS_OPERATION_COMPLETED) {
+		bt_shell_print("AVRCP set browsed player failed, tid = %d, status = 0x%02x",
+			       tid, rsp->status);
+		return;
+	}
+
+	bt_shell_print("AVRCP set browsed player success, tid = %d", tid);
+	bt_shell_print("  UID Counter: %u", sys_be16_to_cpu(rsp->uid_counter));
+	bt_shell_print("  Number of Items: %u", sys_be32_to_cpu(rsp->num_items));
+	bt_shell_print("  Charset ID: 0x%04X", sys_be16_to_cpu(rsp->charset_id));
+	bt_shell_print("  Folder Depth: %u", rsp->folder_depth);
+
+	while (buf->len > 0) {
+		if (buf->len < sizeof(struct bt_avrcp_folder_name)) {
+			bt_shell_print("incompleted message");
+			break;
+		}
+		folder_name = net_buf_pull_mem(buf, sizeof(struct bt_avrcp_folder_name));
+		folder_name->folder_name_len = sys_be16_to_cpu(folder_name->folder_name_len);
+		if (buf->len < folder_name->folder_name_len) {
+			bt_shell_print("incompleted message for folder_name");
+			break;
+		}
+		net_buf_pull_mem(buf, folder_name->folder_name_len);
+
+		if (sys_be16_to_cpu(rsp->charset_id) == BT_AVRCP_CHARSET_UTF8) {
+			bt_shell_print("Raw folder name:");
+			for (int i = 0; i < folder_name->folder_name_len; i++) {
+				bt_shell_print("%c", folder_name->folder_name[i]);
+			}
+		} else {
+			bt_shell_print(" Get folder Name : ");
+			bt_shell_hexdump(folder_name->folder_name, folder_name->folder_name_len);
+		}
+		if (rsp->folder_depth > 0) {
+			rsp->folder_depth--;
+		} else {
+			bt_shell_warn("Folder depth is mismatched with received data");
+			break;
+		}
+	}
+
+	if (rsp->folder_depth > 0) {
+		bt_shell_print("folder depth mismatch: expected 0, got %u", rsp->folder_depth);
+	}
+}
+
 static struct bt_avrcp_ct_cb app_avrcp_ct_cb = {
 	.connected = avrcp_ct_connected,
 	.disconnected = avrcp_ct_disconnected,
+	.browsing_connected = avrcp_ct_browsing_connected,
+	.browsing_disconnected = avrcp_ct_browsing_disconnected,
 	.get_cap_rsp = avrcp_get_cap_rsp,
 	.unit_info_rsp = avrcp_unit_info_rsp,
 	.subunit_info_rsp = avrcp_subunit_info_rsp,
 	.passthrough_rsp = avrcp_passthrough_rsp,
+	.browsed_player_rsp = avrcp_browsed_player_rsp,
 };
 
 static void avrcp_tg_connected(struct bt_conn *conn, struct bt_avrcp_tg *tg)
@@ -136,16 +209,36 @@ static void avrcp_tg_disconnected(struct bt_avrcp_tg *tg)
 	default_tg = NULL;
 }
 
+static void avrcp_tg_browsing_connected(struct bt_conn *conn, struct bt_avrcp_tg *tg)
+{
+	bt_shell_print("AVRCP TG browsing connected");
+}
+
 static void avrcp_unit_info_req(struct bt_avrcp_tg *tg, uint8_t tid)
 {
 	bt_shell_print("AVRCP unit info request received");
 	tg_tid = tid;
 }
 
+static void avrcp_tg_browsing_disconnected(struct bt_avrcp_tg *tg)
+{
+	bt_shell_print("AVRCP TG browsing disconnected");
+}
+
+static void avrcp_set_browsed_player_req(struct bt_avrcp_tg *tg, uint8_t tid,
+					 uint16_t player_id)
+{
+	bt_shell_print("AVRCP set browsed player request received, player_id = %u", player_id);
+	tg_tid = tid;
+}
+
 static struct bt_avrcp_tg_cb app_avrcp_tg_cb = {
 	.connected = avrcp_tg_connected,
 	.disconnected = avrcp_tg_disconnected,
+	.browsing_connected = avrcp_tg_browsing_connected,
+	.browsing_disconnected = avrcp_tg_browsing_disconnected,
 	.unit_info_req = avrcp_unit_info_req,
+	.set_browsed_player_req = avrcp_set_browsed_player_req,
 };
 
 static int register_ct_cb(const struct shell *sh)
@@ -256,6 +349,53 @@ static int cmd_disconnect(const struct shell *sh, int32_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_browsing_connect(const struct shell *sh, int32_t argc, char *argv[])
+{
+	int err;
+
+	if (!avrcp_ct_registered && register_ct_cb(sh) != 0) {
+		return -ENOEXEC;
+	}
+
+	if (default_conn == NULL) {
+		shell_error(sh, "BR/EDR not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_avrcp_browsing_connect(default_conn);
+	if (err < 0) {
+		shell_error(sh, "fail to connect AVRCP browsing");
+	} else {
+		shell_print(sh, "AVRCP browsing connect request sent");
+	}
+
+	return err;
+}
+
+static int cmd_browsing_disconnect(const struct shell *sh, int32_t argc, char *argv[])
+{
+	int err;
+
+	if (default_conn == NULL) {
+		shell_print(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	if ((default_ct != NULL) || (default_tg != NULL)) {
+		err = bt_avrcp_browsing_disconnect(default_conn);
+		if (err < 0) {
+			shell_error(sh, "fail to disconnect AVRCP browsing");
+		} else {
+			shell_print(sh, "AVRCP browsing disconnect request sent");
+		}
+	} else {
+		shell_error(sh, "AVRCP is not connected");
+		err = -ENOEXEC;
+	}
+
+	return err;
+}
+
 static int cmd_get_unit_info(const struct shell *sh, int32_t argc, char *argv[])
 {
 	if (!avrcp_ct_registered && register_ct_cb(sh) != 0) {
@@ -364,6 +504,139 @@ static int cmd_get_cap(const struct shell *sh, int32_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_set_browsed_player(const struct shell *sh, int32_t argc, char *argv[])
+{
+	uint16_t player_id;
+	int err;
+
+	if (!avrcp_ct_registered && register_ct_cb(sh) != 0) {
+		return -ENOEXEC;
+	}
+
+	if (default_ct == NULL) {
+		shell_error(sh, "AVRCP is not connected");
+		return -ENOEXEC;
+	}
+
+	player_id = (uint16_t)strtoul(argv[1], NULL, 0);
+
+	err = bt_avrcp_ct_set_browsed_player(default_ct, get_next_tid(), player_id);
+	if (err < 0) {
+		shell_error(sh, "fail to set browsed player");
+	} else {
+		shell_print(sh, "AVRCP send set browsed player req");
+	}
+
+	return 0;
+}
+
+static int cmd_send_set_browsed_player_rsp(const struct shell *sh, int32_t argc, char *argv[])
+{
+	struct bt_avrcp_set_browsed_player_rsp *rsp;
+	struct bt_avrcp_folder_name *folder_name;
+	char *folder_name_str = "Music";
+	uint8_t folder_name_hex[FOLDER_NAME_HEX_BUF_LEN];
+	uint16_t folder_name_len = 0;
+	struct net_buf *buf;
+	uint16_t param_len;
+	int err;
+
+	if (!avrcp_tg_registered && register_tg_cb(sh) != 0) {
+		return -ENOEXEC;
+	}
+
+	if (default_tg == NULL) {
+		shell_error(sh, "AVRCP TG is not connected");
+		return -ENOEXEC;
+	}
+
+	buf = bt_avrcp_create_pdu(&avrcp_tx_pool);
+	if (buf == NULL) {
+		shell_error(sh, "Failed to allocate buffer for AVRCP browsing response");
+		return -ENOMEM;
+	}
+
+	if (net_buf_tailroom(buf) < sizeof(struct bt_avrcp_set_browsed_player_rsp)) {
+		shell_error(sh, "Not enough tailroom in buffer for browsed player rsp");
+		goto failed;
+	}
+
+	rsp = net_buf_add(buf, sizeof(*rsp));
+	/* Set default rsp */
+	rsp->status = BT_AVRCP_STATUS_OPERATION_COMPLETED;
+	rsp->uid_counter = sys_cpu_to_be16(0x0001U);
+	rsp->num_items = sys_cpu_to_be32(100U);
+	rsp->charset_id = sys_cpu_to_be16(BT_AVRCP_CHARSET_UTF8);
+	rsp->folder_depth = 1;
+
+	/* Parse command line arguments or use default values */
+	if (argc >= 2) {
+		rsp->status = (uint8_t)strtoul(argv[1], NULL, 0);
+	}
+
+	if (argc >= 3) {
+		rsp->uid_counter = sys_cpu_to_be16((uint16_t)strtoul(argv[2], NULL, 0));
+	}
+
+	if (argc >= 4) {
+		rsp->num_items = sys_cpu_to_be32((uint32_t)strtoul(argv[3], NULL, 0));
+	}
+
+	if (argc >= 5) {
+		rsp->charset_id = sys_cpu_to_be16((uint16_t)strtoul(argv[4], NULL, 0));
+	}
+
+	if (rsp->charset_id == sys_cpu_to_be16(BT_AVRCP_CHARSET_UTF8)) {
+		if (argc >= 6) {
+			folder_name_str = argv[5];
+		}
+		folder_name_len = strlen(folder_name_str);
+	} else {
+		if (argc >= 6) {
+			folder_name_len = hex2bin(argv[5], strlen(argv[5]), folder_name_hex,
+						  sizeof(folder_name_hex));
+			if (folder_name_len == 0) {
+				shell_error(sh, "Failed to get folder_name from  %s", argv[5]);
+			}
+		} else {
+			shell_error(sh, "Please input hex string for folder_name");
+			goto failed;
+		}
+	}
+
+	param_len = folder_name_len + sizeof(struct bt_avrcp_folder_name);
+	if (net_buf_tailroom(buf) < param_len) {
+		shell_error(sh, "Not enough tailroom in buffer for param");
+		goto failed;
+	}
+
+	folder_name = net_buf_add(buf, sizeof(*folder_name));
+	folder_name->folder_name_len = sys_cpu_to_be16(folder_name_len);
+	if (rsp->charset_id == sys_cpu_to_be16(BT_AVRCP_CHARSET_UTF8)) {
+		net_buf_add_mem(buf, folder_name_str, folder_name_len);
+	} else {
+		net_buf_add_mem(buf, folder_name_hex, folder_name_len);
+	}
+
+	err = bt_avrcp_tg_send_set_browsed_player_rsp(default_tg, tg_tid, buf);
+	if (err == 0) {
+		shell_print(sh, "Send set browsed player response, status = 0x%02x", rsp->status);
+	} else {
+		shell_error(sh, "Failed to send set browsed player response, err = %d", err);
+		goto failed;
+	}
+
+	return 0;
+failed:
+	net_buf_unref(buf);
+	return -ENOEXEC;
+}
+
+#define HELP_BROWSED_PLAYER_RSP                                                      \
+	"Send SetBrowsedPlayer response\n"					     \
+	"Usage: send_browsed_player_rsp [status] [uid_counter] [num_items] "         \
+	"[charset_id] [folder_name]"
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	ct_cmds,
 	SHELL_CMD_ARG(register_cb, NULL, "register avrcp ct callbacks", cmd_register_ct_cb, 1, 0),
@@ -373,12 +646,16 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      0),
 	SHELL_CMD_ARG(play, NULL, "request a play at the remote player", cmd_play, 1, 0),
 	SHELL_CMD_ARG(pause, NULL, "request a pause at the remote player", cmd_pause, 1, 0),
+	SHELL_CMD_ARG(set_browsed_player, NULL, "set browsed player <player_id>",
+		      cmd_set_browsed_player, 2, 0),
 	SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	tg_cmds,
 	SHELL_CMD_ARG(register_cb, NULL, "register avrcp tg callbacks", cmd_register_tg_cb, 1, 0),
 	SHELL_CMD_ARG(send_unit_rsp, NULL, "send unit info response", cmd_send_unit_info_rsp, 1, 0),
+	SHELL_CMD_ARG(send_browsed_player_rsp, NULL, HELP_BROWSED_PLAYER_RSP,
+		      cmd_send_set_browsed_player_rsp, 1, 5),
 	SHELL_SUBCMD_SET_END);
 
 static int cmd_avrcp(const struct shell *sh, size_t argc, char **argv)
@@ -398,6 +675,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	avrcp_cmds,
 	SHELL_CMD_ARG(connect, NULL, "connect AVRCP", cmd_connect, 1, 0),
 	SHELL_CMD_ARG(disconnect, NULL, "disconnect AVRCP", cmd_disconnect, 1, 0),
+	SHELL_CMD_ARG(browsing_connect, NULL, "connect browsing AVRCP", cmd_browsing_connect, 1, 0),
+	SHELL_CMD_ARG(browsing_disconnect, NULL, "disconnect browsing AVRCP",
+		      cmd_browsing_disconnect, 1, 0),
 	SHELL_CMD(ct, &ct_cmds, "AVRCP CT shell commands", cmd_avrcp),
 	SHELL_CMD(tg, &tg_cmds, "AVRCP TG shell commands", cmd_avrcp),
 	SHELL_SUBCMD_SET_END);


### PR DESCRIPTION
This patch introduces AVCTP Browsing channel support over L2CAP BR/EDR,
including implementation of L2CAP channel callbacks and browsing
operation APIs, and also add Kconfig for BT_AVCTP_BROWSING.
