### PR TITLE
doc: services: storage: fcb: remove deprecated settings recommendation

### DIFF
--- a/doc/services/storage/fcb/fcb.rst
+++ b/doc/services/storage/fcb/fcb.rst
@@ -7,12 +7,6 @@ Flash circular buffer provides an abstraction through which you can treat
 flash like a FIFO. You append entries to the end, and read data from the
 beginning.
 
-.. note::
-
-   As of Zephyr release 2.1 the :ref:`NVS <nvs_api>` storage API is
-   recommended over FCB for use as a back-end for the :ref:`settings API
-   <settings_api>`.
-
 Description
 ***********
 


### PR DESCRIPTION
The recommended back-end depends on the use case. There exists another note (recommendation) in doc/services/storage/settings/index.rst which is up to date.