### PR TITLE
driver: flash: enable stm32 read-back protection at runtime

### DIFF
--- a/drivers/flash/flash_stm32_ex_op.c
+++ b/drivers/flash/flash_stm32_ex_op.c
@@ -24,6 +24,13 @@ int flash_stm32_option_bytes_lock(const struct device *dev, bool enable)
 {
 	FLASH_TypeDef *regs = FLASH_STM32_REGS(dev);
 
+#if defined(FLASH_CR_OBL_LAUNCH)
+	/* Force the option byte loading before locking */
+	if (enable) {
+		regs->CR |= FLASH_CR_OBL_LAUNCH;
+	}
+#endif
+
 #if defined(FLASH_OPTCR_OPTLOCK) /* F2, F4, F7 or H7 */
 	if (enable) {
 		regs->OPTCR |= FLASH_OPTCR_OPTLOCK;

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -17,6 +17,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <zephyr/init.h>
 #include <soc.h>
 #include <stm32_ll_system.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include "flash_stm32.h"
 
@@ -318,6 +320,15 @@ void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
 	flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
 				       (uint32_t)level << FLASH_OPTR_RDP_Pos);
+
+	/*
+	 * POR needed to reload option bytes, done at runtime by entering standby mode
+	 * /!\ make sure a wakeup source is configured!
+	 */
+	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+	LL_LPM_EnableDeepSleep();
+	/* enter SLEEP mode : WFE or WFI */
+	k_cpu_idle();
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32g4x.c
+++ b/drivers/flash/flash_stm32g4x.c
@@ -280,14 +280,6 @@ int flash_stm32_option_bytes_write(const struct device *dev, uint32_t mask,
 	/* Make sure previous write is completed. */
 	barrier_dsync_fence_full();
 
-	rc = flash_stm32_wait_flash_idle(dev);
-	if (rc < 0) {
-		return rc;
-	}
-
-	/* Force the option byte loading */
-	regs->CR |= FLASH_CR_OBL_LAUNCH;
-
 	return flash_stm32_wait_flash_idle(dev);
 }
 

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -19,8 +19,8 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <zephyr/init.h>
 #include <soc.h>
 #include <stm32_ll_system.h>
-#include <stm32l4xx_ll_cortex.h>
-#include <stm32l4xx_ll_pwr.h>
+#include <stm32_ll_cortex.h>
+#include <stm32_ll_pwr.h>
 
 #include "flash_stm32.h"
 
@@ -312,6 +312,15 @@ void flash_stm32_set_rdp_level(const struct device *dev, uint8_t level)
 {
 	flash_stm32_option_bytes_write(dev, FLASH_OPTR_RDP_Msk,
 				       (uint32_t)level << FLASH_OPTR_RDP_Pos);
+
+	/*
+	 * POR needed to reload option bytes, done at runtime by entering standby mode
+	 * /!\ make sure a wakeup source is configured!
+	 */
+	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+	LL_LPM_EnableDeepSleep();
+	/* enter SLEEP mode : WFE or WFI */
+	k_cpu_idle();
 }
 #endif /* CONFIG_FLASH_STM32_READOUT_PROTECTION */
 

--- a/drivers/flash/flash_stm32l4x.c
+++ b/drivers/flash/flash_stm32l4x.c
@@ -18,6 +18,9 @@ LOG_MODULE_REGISTER(LOG_DOMAIN);
 #include <zephyr/sys/barrier.h>
 #include <zephyr/init.h>
 #include <soc.h>
+#include <stm32_ll_system.h>
+#include <stm32l4xx_ll_cortex.h>
+#include <stm32l4xx_ll_pwr.h>
 
 #include "flash_stm32.h"
 
@@ -270,14 +273,6 @@ int flash_stm32_option_bytes_write(const struct device *dev, uint32_t mask,
 
 	/* Make sure previous write is completed. */
 	barrier_dsync_fence_full();
-
-	rc = flash_stm32_wait_flash_idle(dev);
-	if (rc < 0) {
-		return rc;
-	}
-
-	/* Force the option byte loading */
-	regs->CR |= FLASH_CR_OBL_LAUNCH;
 
 	return flash_stm32_wait_flash_idle(dev);
 }


### PR DESCRIPTION
when writing the read-back protection option byte, the stm32 target must go through a power-on reset to reload the option bytes correctly, which is achieved by going into Standby or Shutdown mode.

using the OBL bit locks the microcontroller in a bad state waiting for a full power cycle, this buggy behavior has been added in [that PR](https://github.com/zephyrproject-rtos/zephyr/pull/83561). 

Instead of force-reloading when writing _any_ option byte, it's now performed when re-locking the option bytes, and if OBL bit is defined. Locking doesn't apply when changing the RDP level, since it goes through a POR, so this solution allows to set and reload any option byte correctly.

see extract from stm32g4xx datasheet:

<img width="844" alt="image" src="https://github.com/user-attachments/assets/14077454-285c-46cc-9ba7-b715079914c7" />

a few concerns:

- the user must have a wakeup source configured for the microcontroller to reset, this can be through the reset pin, iwdg, rtc alarm or wakeup pins. ideally we should have a way to ensure this.
- to fully work, the debugger must be detached, which can be achieved by these lines:
   ```
        /* Clear the low-power debug bits */
        if (DBGMCU->CR & (DBGMCU_CR_DBG_SLEEP | DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_STANDBY)) {
            LOG_WRN("Clearing low-power debug bits before RDP change");
            DBGMCU->CR &= ~(DBGMCU_CR_DBG_SLEEP | DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_STANDBY);
        }
   ```
 