### PR TITLE
soc: imxrt10xx: fix SAI3 pll clock config

### DIFF
--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -326,9 +326,9 @@ void imxrt_audio_codec_pll_init(uint32_t clock_name, uint32_t clk_src,
 		CLOCK_SetDiv(kCLOCK_Sai2Div, clk_src_div);
 		break;
 	case IMX_CCM_SAI3_CLK:
-		CLOCK_SetMux(kCLOCK_Sai2Mux, clk_src);
-		CLOCK_SetDiv(kCLOCK_Sai2PreDiv, clk_pre_div);
-		CLOCK_SetDiv(kCLOCK_Sai2Div, clk_src_div);
+		CLOCK_SetMux(kCLOCK_Sai3Mux, clk_src);
+		CLOCK_SetDiv(kCLOCK_Sai3PreDiv, clk_pre_div);
+		CLOCK_SetDiv(kCLOCK_Sai3Div, clk_src_div);
 		break;
 	default:
 		return;


### PR DESCRIPTION
Fix the sai3 case in imxrt_audio_codec_pll_init which was using sai2 constants.