### PR TITLE
drivers: flash: STM32WBA Flash Manager flash_stm32wba_fm.c: fix secto…

### DIFF
--- a/drivers/flash/flash_stm32wba_fm.c
+++ b/drivers/flash/flash_stm32wba_fm.c
@@ -95,7 +95,7 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 			     size_t len)
 {
 	int rc;
-	int sect_num = (len / FLASH_PAGE_SIZE) + 1;
+	int sect_num;
 
 	if (!flash_stm32_valid_range(dev, offset, len, true)) {
 		LOG_ERR("Erase range invalid. Offset: %p, len: %zu",
@@ -106,6 +106,9 @@ static int flash_stm32_erase(const struct device *dev, off_t offset,
 	if (!len) {
 		return 0;
 	}
+
+	/* len is a multiple of FLASH_PAGE_SIZE */
+	sect_num = len / FLASH_PAGE_SIZE;
 
 	flash_stm32_sem_take(dev);
 


### PR DESCRIPTION
…r erase error

The STM32WBA Flash Manager driver is failing to erase a sector, instead of erasing one sector, two sectors are erased.
Fix it by correctly calculating the number of sectors to erase