### PR TITLE
Add TI RTI watchdog driver

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4.dts
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am6232_m4.dts
@@ -22,6 +22,10 @@
 		zephyr,sram1 = &ddr1;
 	};
 
+	aliases {
+		watchdog0 = &mcu_rti0;
+	};
+
 	cpus {
 		cpu@0 {
 			status = "okay";
@@ -57,5 +61,9 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&mcu_uart0_rx_default &mcu_uart0_tx_default>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mcu_rti0 {
 	status = "okay";
 };

--- a/drivers/watchdog/CMakeLists.txt
+++ b/drivers/watchdog/CMakeLists.txt
@@ -64,4 +64,6 @@ zephyr_library_sources_ifdef(CONFIG_WDT_SHELL wdt_shell.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_RENESAS_RA wdt_renesas_ra.c)
 zephyr_library_sources_ifdef(CONFIG_WDT_NXP_EWM wdt_nxp_ewm.c)
 
+zephyr_library_sources_ifdef(CONFIG_WDT_TI_RTI wdt_ti_rti.c)
+
 zephyr_library_sources_ifdef(CONFIG_USERSPACE wdt_handlers.c)

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -159,4 +159,6 @@ source "drivers/watchdog/Kconfig.nxp_ewm"
 
 source "drivers/watchdog/Kconfig.xilinx_wwdt"
 
+source "drivers/watchdog/Kconfig.ti_rti"
+
 endif # WATCHDOG

--- a/drivers/watchdog/Kconfig.ti_rti
+++ b/drivers/watchdog/Kconfig.ti_rti
@@ -1,0 +1,10 @@
+# Copyright (c) 2025, Ayush Singh BeagleBoard.org Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+config WDT_TI_RTI
+	bool "Watchdog Driver for TI K3"
+	default y
+	depends on DT_HAS_TI_J7_RTI_WDT_ENABLED
+	select HAS_WDT_DISABLE_AT_BOOT
+	help
+	  Enable support for K3 Watchdog timer (RTI module) available in the K3 generation of processors.

--- a/drivers/watchdog/wdt_ti_rti.c
+++ b/drivers/watchdog/wdt_ti_rti.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2025 Ayush Singh, BeagleBoard.org Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT ti_j7_rti_wdt
+
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/kernel.h>
+#include <stdint.h>
+
+#define WDENABLE_KEY  0xa98559da
+#define WDDISABLE_KEY 0x5312aced
+
+#define WDKEY_SEQ0 0xe51a
+#define WDKEY_SEQ1 0xa35c
+
+#define WDT_PRELOAD_SHIFT 13
+
+#define WDT_PRELOAD_MAX 0xfff
+
+#define RTIWWDRX_NMI   0xa
+#define RTIWWDRX_RESET 0x5
+
+#define RTIGCTRL_HALT_BY_DBG 0
+#define RTIGCTRL_RUN_BY_DBG  BIT(15)
+
+#define RTIWWDSIZE_100P  0x5
+#define RTIWWDSIZE_50P   0x50
+#define RTIWWDSIZE_25P   0x500
+#define RTIWWDSIZE_12P5  0x5000
+#define RTIWWDSIZE_6P25  0x50000
+#define RTIWWDSIZE_3P125 0x500000
+
+#define DEV_CFG(dev)  ((const struct wdt_ti_rti_config *)(dev)->config)
+#define DEV_DATA(dev) ((struct wdt_ti_rti_data *)(dev)->data)
+#define DEV_REGS(dev) ((struct wdt_ti_rti_regs *)DEVICE_MMIO_GET(dev))
+
+struct wdt_ti_rti_regs {
+	/* RTI Global Control Register, offset: 0x00 */
+	volatile uint32_t GCTRL;
+	uint32_t pad[35];
+	/* Digital Watchdog Control Register, offset: 0x90 */
+	volatile uint32_t DWDCTRL;
+	/* Digital Watchdog Preload Register, offset: 0x94 */
+	volatile uint32_t DWDPRLD;
+	/* Watchdog Status Register, offset: 0x98 */
+	volatile uint32_t WDSTATUS;
+	/* Watchdog Key Register, offset: 0x9C */
+	volatile uint32_t WDKEY;
+	/* Digital Watchdog Down Counter, offset: 0xA0 */
+	volatile uint32_t DWDCNTR;
+	/* Digital Windowed Watchdog Reaction Control, offset: 0xA4 */
+	volatile uint32_t WWDRXNCTRL;
+	/* Digital Windowed Watchdog Window Size Control, offset: 0xA8 */
+	volatile uint32_t WWDSIZECTRL;
+};
+
+struct wdt_ti_rti_data {
+	DEVICE_MMIO_RAM;
+};
+
+struct wdt_ti_rti_config {
+	DEVICE_MMIO_ROM;
+
+	uint64_t freq;
+};
+
+static int wdt_ti_rti_setup(const struct device *dev, uint8_t options)
+{
+	ARG_UNUSED(options);
+
+	struct wdt_ti_rti_regs *regs = DEV_REGS(dev);
+
+	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
+		regs->GCTRL = RTIGCTRL_HALT_BY_DBG;
+	} else {
+		regs->GCTRL = RTIGCTRL_RUN_BY_DBG;
+	}
+
+	regs->DWDCTRL = WDENABLE_KEY;
+
+	return 0;
+}
+
+static int wdt_ti_rti_disable(const struct device *dev)
+{
+	struct wdt_ti_rti_regs *regs = DEV_REGS(dev);
+
+	regs->DWDCTRL = WDDISABLE_KEY;
+	regs->WDKEY = 0;
+
+	return 0;
+}
+
+static int wdt_ti_rti_window_size(const struct wdt_window window)
+{
+	const int window_sizes[] = {RTIWWDSIZE_100P, RTIWWDSIZE_50P,  RTIWWDSIZE_25P,
+				    RTIWWDSIZE_12P5, RTIWWDSIZE_6P25, RTIWWDSIZE_3P125};
+
+	if (window.max < window.min || window.max == 0) {
+		return -EINVAL;
+	}
+
+	for (uint32_t idx = 0; idx < ARRAY_SIZE(window_sizes); idx++) {
+		uint32_t temp = (window.max - window.min) << idx;
+
+		if (temp == window.max) {
+			return window_sizes[idx];
+		} else if (temp > window.max) {
+			break;
+		}
+	}
+
+	return -EINVAL;
+}
+
+static int wdt_ti_rti_timeout(const struct device *dev, const struct wdt_timeout_cfg *cfg)
+{
+	const struct wdt_ti_rti_config *config = DEV_CFG(dev);
+	struct wdt_ti_rti_regs *regs = DEV_REGS(dev);
+	uint32_t timer_margin;
+	int window_size;
+
+	window_size = wdt_ti_rti_window_size(cfg->window);
+	if (window_size < 0) {
+		return window_size;
+	}
+
+	timer_margin = (cfg->window.max * config->freq) / MSEC_PER_SEC;
+	timer_margin >>= WDT_PRELOAD_SHIFT;
+	if (timer_margin > WDT_PRELOAD_MAX) {
+		return -EINVAL;
+	}
+
+	if (cfg->flags == WDT_FLAG_RESET_SOC) {
+		regs->WWDRXNCTRL = RTIWWDRX_NMI;
+	}
+
+	regs->DWDPRLD = timer_margin;
+	regs->WWDSIZECTRL = (uint32_t)window_size;
+
+	return 0;
+}
+
+static int wdt_ti_rti_feed(const struct device *dev, int channel_id)
+{
+	struct wdt_ti_rti_regs *regs = DEV_REGS(dev);
+
+	if (channel_id != 0) {
+		return -EINVAL;
+	}
+
+	regs->WDKEY = WDKEY_SEQ0;
+	regs->WDKEY = WDKEY_SEQ1;
+
+	return 0;
+}
+
+static int wdt_ti_rti_init(const struct device *dev)
+{
+	struct wdt_ti_rti_regs *regs;
+
+	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
+	regs = DEV_REGS(dev);
+	if (!regs) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static DEVICE_API(wdt, wdt_ti_rti_api) = {
+	.setup = wdt_ti_rti_setup,
+	.disable = wdt_ti_rti_disable,
+	.feed = wdt_ti_rti_feed,
+	.install_timeout = wdt_ti_rti_timeout,
+};
+
+#define WDT_TI_RTI_INIT(i)                                                                         \
+	static struct wdt_ti_rti_data wdt_ti_rti_data_##i = {};                                    \
+                                                                                                   \
+	static struct wdt_ti_rti_config wdt_ti_rti_config_##i = {                                  \
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(i)),                                              \
+		.freq = DT_INST_PROP(i, clock_frequency),                                          \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(i, wdt_ti_rti_init, NULL, &wdt_ti_rti_data_##i,                      \
+			      &wdt_ti_rti_config_##i, POST_KERNEL,                                 \
+			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &wdt_ti_rti_api);
+
+DT_INST_FOREACH_STATUS_OKAY(WDT_TI_RTI_INIT)

--- a/dts/arm/ti/am62x_m4.dtsi
+++ b/dts/arm/ti/am62x_m4.dtsi
@@ -85,6 +85,13 @@
 		ngpios = <24>;
 		status = "disabled";
 	};
+
+	mcu_rti0: watchdog@4880000 {
+		compatible = "ti,j7-rti-wdt";
+		reg = <0x04880000 0x100>;
+		clock-frequency = <DT_FREQ_M(25)>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/dts/bindings/watchdog/ti,j7-rti-wdt.yaml
+++ b/dts/bindings/watchdog/ti,j7-rti-wdt.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2025, Ayush Singh BeagleBoard.org Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+description: K3 Watchdog timer (RTI module) available in the K3 generation of processors.
+
+compatible: "ti,j7-rti-wdt"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  clock-frequency:
+    type: int
+    required: true


### PR DESCRIPTION
- This watchdog timer is used in the k3 generation of CPUs.
- Tested on PocketBeagle 2 with the `samples/drivers/watchdog`.
- Callbacks are not supported right now since I could not figure out how to implement them.