### PR TITLE
bindings: uart-bridge: add PM hooks

### DIFF
--- a/dts/bindings/serial/zephyr,uart-bridge.yaml
+++ b/dts/bindings/serial/zephyr,uart-bridge.yaml
@@ -15,6 +15,8 @@ description: |
            peers = <&cdc_acm_uart0 &uart1>;
   };
 
+include: base.yaml
+
 compatible: "zephyr,uart-bridge"
 
 properties:


### PR DESCRIPTION
Add PM hooks to release or reattach the serial ports from the bridge. Does not save power per se but allows switch the lower level serial ports for something else in runtime.