### PR TITLE
Introduce device deinit support for I2C subsystem

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -144,6 +144,8 @@ New APIs and options
 * I2C
 
   * :c:func:`i2c_configure_dt`.
+  * :c:macro:`I2C_DEVICE_DT_DEINIT_DEFINE`
+  * :c:macro:`I2C_DEVICE_DT_INST_DEINIT_DEFINE`
 
 ..
   Link to new APIs here, in a group if you think it's necessary, no need to get

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -224,6 +224,11 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 	return i2c_nrfx_twim_common_init(dev);
 }
 
+static int i2c_nrfx_twim_deinit(const struct device *dev)
+{
+	return i2c_nrfx_twim_common_deinit(dev);
+}
+
 static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 	.configure = i2c_nrfx_twim_configure,
 	.transfer = i2c_nrfx_twim_transfer,
@@ -280,8 +285,9 @@ static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 	};								       \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action,                     \
 			PM_DEVICE_ISR_SAFE);                                   \
-	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
+	I2C_DEVICE_DT_DEINIT_DEFINE(I2C(idx),				       \
 		      i2c_nrfx_twim_init,				       \
+		      i2c_nrfx_twim_deinit,				       \
 		      PM_DEVICE_DT_GET(I2C(idx)),			       \
 		      &twim_##idx##_data,				       \
 		      &twim_##idx##z_config,				       \

--- a/drivers/i2c/i2c_nrfx_twim_common.c
+++ b/drivers/i2c/i2c_nrfx_twim_common.c
@@ -102,18 +102,30 @@ int i2c_nrfx_twim_msg_transfer(const struct device *dev, uint8_t flags, uint8_t 
 	return ret;
 }
 
-int twim_nrfx_pm_action(const struct device *dev, enum pm_device_action action)
+void twim_nrfx_pm_resume(const struct device *dev)
 {
 	const struct i2c_nrfx_twim_common_config *config = dev->config;
 
+	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+	nrfx_twim_enable(&config->twim);
+}
+
+void twim_nrfx_pm_suspend(const struct device *dev)
+{
+	const struct i2c_nrfx_twim_common_config *config = dev->config;
+
+	nrfx_twim_disable(&config->twim);
+	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+}
+
+int twim_nrfx_pm_action(const struct device *dev, enum pm_device_action action)
+{
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
-		nrfx_twim_enable(&config->twim);
+		twim_nrfx_pm_resume(dev);
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_twim_disable(&config->twim);
-		(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+		twim_nrfx_pm_suspend(dev);
 		break;
 	default:
 		return -ENOTSUP;
@@ -137,4 +149,32 @@ int i2c_nrfx_twim_common_init(const struct device *dev)
 	}
 
 	return pm_device_driver_init(dev, twim_nrfx_pm_action);
+}
+
+int i2c_nrfx_twim_common_deinit(const struct device *dev)
+{
+	const struct i2c_nrfx_twim_common_config *config = dev->config;
+#if CONFIG_PM_DEVICE
+	enum pm_device_state state;
+#endif
+
+#if CONFIG_PM_DEVICE
+	/*
+	 * PM must have suspended the device before driver can
+	 * be deinitialized
+	 */
+	(void)pm_device_state_get(dev, &state);
+	if (state != PM_DEVICE_STATE_SUSPENDED &&
+	    state != PM_DEVICE_STATE_OFF) {
+		LOG_ERR("device active");
+		return -EBUSY;
+	}
+#else
+	/* Suspend device */
+	twim_nrfx_pm_suspend(dev);
+#endif
+
+	/* Uninit device hardware */
+	nrfx_twim_uninit(&config->twim);
+	return 0;
 }

--- a/drivers/i2c/i2c_nrfx_twim_common.h
+++ b/drivers/i2c/i2c_nrfx_twim_common.h
@@ -43,6 +43,7 @@ struct i2c_nrfx_twim_common_config {
 };
 
 int i2c_nrfx_twim_common_init(const struct device *dev);
+int i2c_nrfx_twim_common_deinit(const struct device *dev);
 int i2c_nrfx_twim_configure(const struct device *dev, uint32_t i2c_config);
 int i2c_nrfx_twim_recover_bus(const struct device *dev);
 int i2c_nrfx_twim_msg_transfer(const struct device *dev, uint8_t flags, uint8_t *buf,

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -203,12 +203,17 @@ static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 	.iodev_submit = i2c_nrfx_twim_rtio_submit,
 };
 
-int i2c_nrfx_twim_rtio_init(const struct device *dev)
+static int i2c_nrfx_twim_rtio_init(const struct device *dev)
 {
 	const struct i2c_nrfx_twim_rtio_config *config = dev->config;
 
 	i2c_rtio_init(config->ctx, dev);
 	return i2c_nrfx_twim_common_init(dev);
+}
+
+static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
+{
+	return i2c_nrfx_twim_common_deinit(dev);
 }
 
 #define CONCAT_BUF_SIZE(idx)                                                                       \
@@ -282,9 +287,10 @@ int i2c_nrfx_twim_rtio_init(const struct device *dev)
 		.ctx = &_i2c##idx##_twim_rtio,                                                     \
 	};                                                                                         \
 	PM_DEVICE_DT_DEFINE(I2C(idx), twim_nrfx_pm_action, PM_DEVICE_ISR_SAFE);                    \
-	I2C_DEVICE_DT_DEFINE(I2C(idx), i2c_nrfx_twim_rtio_init, PM_DEVICE_DT_GET(I2C(idx)),        \
-			     &twim_##idx##z_data, &twim_##idx##z_config, POST_KERNEL,              \
-			     CONFIG_I2C_INIT_PRIORITY, &i2c_nrfx_twim_driver_api);
+	I2C_DEVICE_DT_DEINIT_DEFINE(I2C(idx), i2c_nrfx_twim_rtio_init, i2c_nrfx_twim_rtio_deinit,  \
+			     PM_DEVICE_DT_GET(I2C(idx)), &twim_##idx##z_data,                      \
+			     &twim_##idx##z_config, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,         \
+			     &i2c_nrfx_twim_driver_api);
 
 #ifdef CONFIG_HAS_HW_NRF_TWIM0
 I2C_NRFX_TWIM_RTIO_DEVICE(0);

--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -73,6 +73,15 @@ static bool shim_nrf_twis_is_resumed(const struct device *dev)
 	(void)pm_device_state_get(dev, &state);
 	return state == PM_DEVICE_STATE_ACTIVE;
 }
+
+static bool shim_nrf_twis_is_suspended(const struct device *dev)
+{
+	enum pm_device_state state;
+
+	(void)pm_device_state_get(dev, &state);
+	return state == PM_DEVICE_STATE_SUSPENDED ||
+	       state == PM_DEVICE_STATE_OFF;
+}
 #else
 static bool shim_nrf_twis_is_resumed(const struct device *dev)
 {
@@ -199,7 +208,7 @@ static int shim_nrf_twis_pm_action_cb(const struct device *dev,
 
 #if CONFIG_PM_DEVICE
 	case PM_DEVICE_ACTION_SUSPEND:
-		shim_nrf_twis_disable();
+		shim_nrf_twis_disable(dev);
 		break;
 #endif
 
@@ -283,6 +292,35 @@ static int shim_nrf_twis_init(const struct device *dev)
 	return pm_device_driver_init(dev, shim_nrf_twis_pm_action_cb);
 }
 
+static int shim_nrf_twis_deinit(const struct device *dev)
+{
+	const struct shim_nrf_twis_config *dev_config = dev->config;
+	struct shim_nrf_twis_data *dev_data = dev->data;
+
+	if (dev_data->target_config != NULL) {
+		LOG_ERR("target registered");
+		return -EPERM;
+	}
+
+#if CONFIG_PM_DEVICE
+	/*
+	 * PM must have suspended the device before driver can
+	 * be deinitialized
+	 */
+	if (!shim_nrf_twis_is_suspended(dev)) {
+		LOG_ERR("device active");
+		return -EBUSY;
+	}
+#else
+	/* Suspend device */
+	shim_nrf_twis_disable(dev);
+#endif
+
+	/* Uninit device hardware */
+	nrfx_twis_uninit(&dev_config->twis);
+	return 0;
+}
+
 #define SHIM_NRF_TWIS_NAME(id, name) \
 	_CONCAT_4(shim_nrf_twis_, name, _, id)
 
@@ -323,9 +361,10 @@ static int shim_nrf_twis_init(const struct device *dev)
 		shim_nrf_twis_pm_action_cb,							\
 	);											\
 												\
-	DEVICE_DT_DEFINE(									\
+	DEVICE_DT_DEINIT_DEFINE(								\
 		SHIM_NRF_TWIS_NODE(id),								\
 		shim_nrf_twis_init,								\
+		shim_nrf_twis_deinit,								\
 		PM_DEVICE_DT_GET(SHIM_NRF_TWIS_NODE(id)),					\
 		&SHIM_NRF_TWIS_NAME(id, data),							\
 		&SHIM_NRF_TWIS_NAME(id, config),						\

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -635,7 +635,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 /** @endcond */
 
 /**
- * @brief Like DEVICE_DT_DEFINE() with I2C specifics.
+ * @brief Like DEVICE_DT_DEINIT_DEFINE() with I2C specifics.
  *
  * @details Defines a device which implements the I2C API. May
  * generate a custom device_state container struct and init_fn
@@ -644,6 +644,8 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * @param node_id The devicetree node identifier.
  *
  * @param init_fn Name of the init function of the driver. Can be `NULL`.
+ *
+ * @param deinit_fn Name of the deinit function of the driver. Can be `NULL`.
  *
  * @param pm PM device resources reference (NULL if device does not use PM).
  *
@@ -661,14 +663,14 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  * @param api Provides an initial pointer to the API function struct
  * used by the driver. Can be NULL.
  */
-#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
-			     prio, api, ...)				\
+#define I2C_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn, pm,	\
+				    data, config, level, prio, api, ...)\
 	Z_I2C_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));		\
 	Z_I2C_INIT_FN(Z_DEVICE_DT_DEV_ID(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			NULL, Z_DEVICE_DT_FLAGS(node_id), pm, data,	\
+			deinit_fn, Z_DEVICE_DT_FLAGS(node_id), pm, data,\
 			config,	level, prio, api,			\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
@@ -683,12 +685,32 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 	ARG_UNUSED(num_msgs);
 }
 
-#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
-			     prio, api, ...)				\
-	DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
-			 prio, api, __VA_ARGS__)
+#define I2C_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn, pm,	\
+				    data, config, level, prio, api, ...)\
+	DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn, pm, data,	\
+				config, level, prio, api, __VA_ARGS__)
 
 #endif /* CONFIG_I2C_STATS */
+
+/**
+ * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() but without deinit_fn
+ */
+#define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level,	\
+			     prio, api, ...)				\
+	I2C_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, NULL, pm, data,	\
+				    config, level, prio, api,		\
+				    __VA_ARGS__)
+
+/**
+ * @brief Like I2C_DEVICE_DT_DEINIT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
+ *
+ * @param inst instance number. This is replaced by
+ * <tt>DT_DRV_COMPAT(inst)</tt> in the call to I2C_DEVICE_DT_DEINIT_DEFINE().
+ *
+ * @param ... other parameters as expected by I2C_DEVICE_DT_DEINIT_DEFINE().
+ */
+#define I2C_DEVICE_DT_INST_DEINIT_DEFINE(inst, ...)		\
+	I2C_DEVICE_DT_DEINIT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
  * @brief Like I2C_DEVICE_DT_DEFINE() for an instance of a DT_DRV_COMPAT compatible
@@ -700,7 +722,6 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  */
 #define I2C_DEVICE_DT_INST_DEFINE(inst, ...)		\
 	I2C_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
-
 
 /**
  * @brief Configure operation of a host controller.

--- a/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -9,6 +9,23 @@
  * SCL = P1.2 and P1.3
  */
 
+/ {
+	zephyr,user {
+		sda0-gpios = <&gpio2 8 0>;
+		scl0-gpios = <&gpio1 2 0>;
+		sda1-gpios = <&gpio2 9 0>;
+		scl1-gpios = <&gpio1 3 0>;
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
 &pinctrl {
 	i2c130_default: i2c130_default {
 		group1 {


### PR DESCRIPTION
* Introduce DEINIT variants of I2C_DEVICE_DEFINE macros and impl deinit for select drivers.
* Extend the i2c_target_api test to validate I2C deinit/init.