### PR TITLE
Introduce device deinit to SPI subsystem

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -145,6 +145,11 @@ New APIs and options
 
   * :c:func:`i2c_configure_dt`.
 
+* SPI
+
+  * :c:macro:`SPI_DEVICE_DT_DEINIT_DEFINE`
+  * :c:macro:`SPI_DEVICE_DT_INST_DEINIT_DEFINE`
+
 ..
   Link to new APIs here, in a group if you think it's necessary, no need to get
   fancy just list the link, that should contain the documentation. If you feel

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -657,16 +657,16 @@ struct spi_device_state {
 	}
 /** @endcond */
 
-#define SPI_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
-			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
+#define SPI_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn,	\
+				    pm_device, data_ptr, cfg_ptr,	\
+				    level, prio, api_ptr, ...)		\
 	Z_SPI_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));		\
 	Z_SPI_INIT_FN(Z_DEVICE_DT_DEV_ID(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),		\
 			DEVICE_DT_NAME(node_id),			\
 			&UTIL_CAT(Z_DEVICE_DT_DEV_ID(node_id), _init),	\
-			NULL, Z_DEVICE_DT_FLAGS(node_id), pm_device,	\
-			data_ptr, cfg_ptr, level, prio,			\
+			deinit_fn, Z_DEVICE_DT_FLAGS(node_id),		\
+			pm_device, data_ptr, cfg_ptr, level, prio,	\
 			api_ptr,					\
 			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)).devstate), \
 			__VA_ARGS__)
@@ -700,8 +700,49 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
  * @name SPI DT Device Macros
  * @{
  */
+
 /**
- * @brief Like DEVICE_DT_DEFINE() with SPI specifics.
+ * @brief Like DEVICE_DT_DEINIT_DEFINE() with SPI specifics.
+ *
+ * @details Defines a device which implements the SPI API. May
+ * generate a custom device_state container struct and init_fn
+ * wrapper when needed depending on SPI @kconfig{CONFIG_SPI_STATS}.
+ *
+ * @param node_id The devicetree node identifier.
+ * @param init_fn Name of the init function of the driver.
+ * @param deinit_fn Name of the deinit function of the driver.
+ * @param pm PM device resources reference (NULL if device does not use PM).
+ * @param data Pointer to the device's private data.
+ * @param config The address to the structure containing the configuration
+ *                information for this instance of the driver.
+ * @param level The initialization level. See SYS_INIT() for details.
+ * @param prio Priority within the selected initialization level. See SYS_INIT()
+ *             for details.
+ * @param api Provides an initial pointer to the API function struct used by
+ *                the driver. Can be NULL.
+ */
+#define SPI_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, deinit_fn, pm, data,	\
+				    config, level, prio, api, ...)		\
+	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));			\
+	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),			\
+			DEVICE_DT_NAME(node_id), init_fn, deinit_fn,		\
+			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,		\
+			level, prio, api,					\
+			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)),	\
+			__VA_ARGS__)
+
+/** @} */
+
+#define SPI_STATS_RX_BYTES_INC(dev_)
+#define SPI_STATS_TX_BYTES_INC(dev_)
+#define SPI_STATS_TRANSFER_ERROR_INC(dev_)
+
+#define spi_transceive_stats(dev, error, tx_bufs, rx_bufs)
+
+#endif /*CONFIG_SPI_STATS*/
+
+/**
+ * @brief Like DEVICE_DT_DEINIT_DEFINE() without deinit function.
  *
  * @details Defines a device which implements the SPI API. May
  * generate a custom device_state container struct and init_fn
@@ -719,26 +760,21 @@ static inline void spi_transceive_stats(const struct device *dev, int error,
  * @param api Provides an initial pointer to the API function struct used by
  *                the driver. Can be NULL.
  */
-#define SPI_DEVICE_DT_DEFINE(node_id, init_fn, pm,		\
-				data, config, level, prio,	\
-				api, ...)			\
-	Z_DEVICE_STATE_DEFINE(Z_DEVICE_DT_DEV_ID(node_id));			\
-	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_ID(node_id),			\
-			DEVICE_DT_NAME(node_id), init_fn, NULL,			\
-			Z_DEVICE_DT_FLAGS(node_id), pm, data, config,		\
-			level, prio, api,					\
-			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_ID(node_id)),	\
-			__VA_ARGS__)
-/** @} */
+#define SPI_DEVICE_DT_DEFINE(node_id, init_fn, pm, data, config, level, prio,	\
+			     api, ...)						\
+	SPI_DEVICE_DT_DEINIT_DEFINE(node_id, init_fn, NULL, pm, data, config,	\
+				    level, prio, api, __VA_ARGS__)
 
-#define SPI_STATS_RX_BYTES_INC(dev_)
-#define SPI_STATS_TX_BYTES_INC(dev_)
-#define SPI_STATS_TRANSFER_ERROR_INC(dev_)
-
-#define spi_transceive_stats(dev, error, tx_bufs, rx_bufs)
-
-#endif /*CONFIG_SPI_STATS*/
-
+/**
+ * @brief Like SPI_DEVICE_DT_DEINIT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`
+ * compatible instead of a node identifier.
+ *
+ * @param inst Instance number. The `node_id` argument to SPI_DEVICE_DT_DEINIT_DEFINE() is
+ * set to `DT_DRV_INST(inst)`.
+ * @param ... Other parameters as expected by SPI_DEVICE_DT_DEFINE().
+ */
+#define SPI_DEVICE_DT_INST_DEINIT_DEFINE(inst, ...) \
+	SPI_DEVICE_DT_DEINIT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
  * @brief Like SPI_DEVICE_DT_DEFINE(), but uses an instance of a `DT_DRV_COMPAT`

--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/ {
+	zephyr,user {
+		miso-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &pinctrl {
 	spi130_default: spi130_default {
 		group1 {

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -16,6 +16,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/drivers/spi.h>
 #include <zephyr/pm/device_runtime.h>
+#include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -56,7 +57,8 @@ static int spec_idx;
  */
 struct spi_dt_spec spec_copies[5];
 
-
+const struct gpio_dt_spec miso_pin = GPIO_DT_SPEC_GET_OR(DT_PATH(zephyr_user), miso_gpios, {});
+const struct gpio_dt_spec mosi_pin = GPIO_DT_SPEC_GET_OR(DT_PATH(zephyr_user), mosi_gpios, {});
 
 /*
  ********************
@@ -820,6 +822,35 @@ ZTEST(spi_loopback, test_spi_concurrent_transfer_different_spec)
 	spec_copies[2] = *loopback_specs[spec_idx];
 
 	test_spi_concurrent_transfer_helper(specs);
+}
+
+ZTEST(spi_loopback, test_spi_deinit)
+{
+	struct spi_dt_spec *spec = loopback_specs[0];
+	const struct device *dev = spec->bus;
+	int ret;
+
+	if (miso_pin.port == NULL || mosi_pin.port == NULL) {
+		TC_PRINT("  zephyr,user miso-gpios or mosi-gpios are not defined\n");
+		ztest_test_skip();
+	}
+
+	ret = device_deinit(dev);
+	if (ret == -ENOTSUP) {
+		TC_PRINT("  device deinit not supported\n");
+		ztest_test_skip();
+	}
+
+	zassert_ok(ret);
+	zassert_ok(gpio_pin_configure_dt(&miso_pin, GPIO_INPUT));
+	zassert_ok(gpio_pin_configure_dt(&mosi_pin, GPIO_OUTPUT_INACTIVE));
+	zassert_equal(gpio_pin_get_dt(&miso_pin), 0);
+	zassert_ok(gpio_pin_set_dt(&mosi_pin, 1));
+	zassert_equal(gpio_pin_get_dt(&miso_pin), 1);
+	zassert_ok(gpio_pin_set_dt(&mosi_pin, 0));
+	zassert_equal(gpio_pin_get_dt(&miso_pin), 0);
+	zassert_ok(gpio_pin_configure_dt(&mosi_pin, GPIO_INPUT));
+	zassert_ok(device_init(dev));
 }
 
 #if (CONFIG_SPI_ASYNC)


### PR DESCRIPTION
* Introduce DEINIT variants of SPI_DEVICE_DEFINE macros and impl deinit for select drivers.
* Extend the spi_loopback test to validate SPI deinit/init.