### PR TITLE
net: lwm2m: Make Bootstrap on Registration Failure configurable with Kconfig

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -520,6 +520,12 @@ config LWM2M_SECONDS_TO_UPDATE_EARLY
 	  round trip times (like NB-IoT), it might be needed to set this value
 	  higher, in order to allow the response to arrive before timeout.
 
+config LWM2M_SERVER_BOOTSTRAP_ON_FAIL
+	bool "Bootstrap on Registration Failure"
+	default y
+	help
+	  If set to true, the LwM2M client will attempt to re-bootstrap if the registration fails.
+
 config LWM2M_SHELL
 	bool "LwM2M shell utilities"
 	select SHELL

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -55,7 +55,7 @@ static char  transport_binding[MAX_INSTANCE_COUNT][TRANSPORT_BINDING_LEN];
 /* Server object version 1.1 */
 static uint8_t priority[MAX_INSTANCE_COUNT];
 static bool mute_send[MAX_INSTANCE_COUNT];
-static bool boostrap_on_fail[MAX_INSTANCE_COUNT];
+static bool bootstrap_on_fail[MAX_INSTANCE_COUNT];
 
 static struct lwm2m_engine_obj server;
 static struct lwm2m_engine_obj_field fields[] = {
@@ -355,7 +355,7 @@ static struct lwm2m_engine_obj_inst *server_create(uint16_t obj_inst_id)
 	default_min_period[index] = CONFIG_LWM2M_SERVER_DEFAULT_PMIN;
 	default_max_period[index] = CONFIG_LWM2M_SERVER_DEFAULT_PMAX;
 	disabled_timeout[index] = 86400U;
-	boostrap_on_fail[index] = true;
+	bootstrap_on_fail[index] = true;
 
 	lwm2m_engine_get_binding(transport_binding[index]);
 
@@ -410,7 +410,7 @@ static struct lwm2m_engine_obj_inst *server_create(uint16_t obj_inst_id)
 		INIT_OBJ_RES_OPTDATA(SERVER_REGISTRATION_FAILURE_BLOCK_ID, res[index], i,
 				     res_inst[index], j);
 		INIT_OBJ_RES_DATA(SERVER_BOOTSTRAP_ON_REGISTRATION_FAILURE_ID, res[index], i,
-				  res_inst[index], j, &boostrap_on_fail[index], sizeof(bool));
+				  res_inst[index], j, &bootstrap_on_fail[index], sizeof(bool));
 		INIT_OBJ_RES_OPTDATA(SERVER_COMMUNICATION_RETRY_COUNT_ID, res[index], i,
 				     res_inst[index], j);
 		INIT_OBJ_RES_OPTDATA(SERVER_COMMUNICATION_RETRY_TIMER_ID, res[index], i,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -355,7 +355,7 @@ static struct lwm2m_engine_obj_inst *server_create(uint16_t obj_inst_id)
 	default_min_period[index] = CONFIG_LWM2M_SERVER_DEFAULT_PMIN;
 	default_max_period[index] = CONFIG_LWM2M_SERVER_DEFAULT_PMAX;
 	disabled_timeout[index] = 86400U;
-	bootstrap_on_fail[index] = true;
+	bootstrap_on_fail[index] = IS_ENABLED(CONFIG_LWM2M_SERVER_BOOTSTRAP_ON_FAIL);
 
 	lwm2m_engine_get_binding(transport_binding[index]);
 

--- a/tests/net/lib/lwm2m/interop/pytest/conftest.py
+++ b/tests/net/lib/lwm2m/interop/pytest/conftest.py
@@ -138,7 +138,7 @@ def endpoint_bootstrap(request, shell: Shell, dut: DeviceAdapter, leshan: Leshan
             passwd = ''.join(random.choice(string.ascii_lowercase) for i in range(16))
 
         logger.debug('Endpoint: %s', ep)
-        logger.debug('Boostrap PSK: %s', binascii.b2a_hex(bs_passwd.encode()).decode())
+        logger.debug('Bootstrap PSK: %s', binascii.b2a_hex(bs_passwd.encode()).decode())
         logger.debug('PSK: %s', binascii.b2a_hex(passwd.encode()).decode())
 
         # Create device entries in Leshan and Bootstrap server


### PR DESCRIPTION
The fallback to Bootstrap on a Registration Failure might not be desirable for some applications. This change makes the default behavior configure through `Kconfig`.
    
An alternative to configure "Bootstrap on Registration Failure" would be to set the server object resource id 16 at runtime. However, this is tedious and error-prone, as it will be reset when the server object is deleted and might have to be set at different locations in the client code.

This patch does not change the default behavior of the client.

Plus: Fix bootstrap typos