### PR TITLE
workflows: drop the cron explanation comments

### DIFF
--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -10,7 +10,6 @@ on:
   workflow_dispatch:
     branches: [main]
   schedule:
-  # Run daily at 00:05
   - cron: '5 00 * * *'
 
 permissions:

--- a/.github/workflows/stale-workflow-queue-cleanup.yml
+++ b/.github/workflows/stale-workflow-queue-cleanup.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
     branches: [main]
   schedule:
-  # everyday at 15:00
   - cron: '0 15 * * *'
 
 permissions:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -12,7 +12,6 @@ on:
       - v*-branch
       - collab-*
   schedule:
-    # Run at 02:00 UTC on every Sunday
     - cron: '0 2 * * 0'
 
 permissions:


### PR DESCRIPTION
Drop the comments above the cron specs, these are a pain to keep in sync and are not very useful, it's safe to assume that if one is editing the specs they know how to read/write a crontab entry, and if not there's always man 5 crontab.