### PR TITLE
west.yml: Update cmsis_6

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       path: modules/lib/cmsis-nn
     - name: cmsis_6
       repo-path: CMSIS_6
-      revision: 6dd50439a9b83398ff2ae1376eef0a2a0b95913b
+      revision: 06d952b6713a2ca41c9224a62075e4059402a151
       path: modules/hal/cmsis_6
       groups:
         - hal


### PR DESCRIPTION
Currently CMSIS_6 is based on https://github.com/ARM-software/CMSIS_6/commit/783317a3072554acbac86cca2ff24928cbf98d30, a commit between v6.1.0 and v6.2.0, which is not an official release. As recommended by the upstream repository, "For stable versions ready for productive use please refer to tagged releases, like CMSIS 6.2.0." This update ensures that our project is aligned with a stable, supported, and production-ready version of CMSIS6.

This upgrade is a proactive measure to prepare for the upcoming Zephyr 4.2.0 release.

The pull request for the zephyr fork of CMSIS_6 is https://github.com/zephyrproject-rtos/CMSIS_6/pull/4.

Fixes #91978