### PR TITLE
soc: nxp: s32k3: use `MPU_REGION_ENTRY` macro

### DIFF
--- a/soc/nxp/s32/s32k3/mpu_regions.c
+++ b/soc/nxp/s32/s32k3/mpu_regions.c
@@ -20,45 +20,22 @@ extern char _rom_attr[];
 static struct arm_mpu_region mpu_regions[] = {
 
 	/* ERR011573: use first region to prevent speculative access in entire memory space */
-	{
-		.name = "UNMAPPED",
-		.base = 0,
-		.attr = {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk},
-	},
+	MPU_REGION_ENTRY("UNMAPPED", 0, {REGION_4G | MPU_RASR_XN_Msk | P_NA_U_NA_Msk}),
 
 	/* Keep before CODE region so it can be overlapped by SRAM CODE in non-XIP systems */
-	{
-		.name = "SRAM",
-		.base = CONFIG_SRAM_BASE_ADDRESS,
-		.attr = REGION_RAM_ATTR(REGION_SRAM_SIZE),
-	},
+	MPU_REGION_ENTRY("SRAM", CONFIG_SRAM_BASE_ADDRESS, REGION_RAM_ATTR(REGION_SRAM_SIZE)),
 
 #ifdef CONFIG_XIP
-	{
-		.name = "FLASH",
-		.base = CONFIG_FLASH_BASE_ADDRESS,
-		.attr = REGION_FLASH_ATTR(REGION_FLASH_SIZE),
-	},
+	MPU_REGION_ENTRY("FLASH", CONFIG_FLASH_BASE_ADDRESS, REGION_FLASH_ATTR(REGION_FLASH_SIZE)),
 #else
 	/* Run from SRAM */
-	{
-		.name = "CODE",
-		.base = CONFIG_SRAM_BASE_ADDRESS,
-		.attr = {(uint32_t)_rom_attr},
-	},
+	MPU_REGION_ENTRY("CODE", CONFIG_SRAM_BASE_ADDRESS, {(uint32_t)_rom_attr}),
 #endif
 
-	{
-		.name = "PERIPHERALS",
-		.base = REGION_PERIPHERAL_BASE_ADDRESS,
-		.attr = REGION_IO_ATTR(REGION_PERIPHERAL_SIZE),
-	},
+	MPU_REGION_ENTRY("PERIPHERALS", REGION_PERIPHERAL_BASE_ADDRESS,
+			 REGION_IO_ATTR(REGION_PERIPHERAL_SIZE)),
 
-	{
-		.name = "PPB",
-		.base = REGION_PPB_BASE_ADDRESS,
-		.attr = REGION_PPB_ATTR(REGION_PPB_SIZE),
-	},
+	MPU_REGION_ENTRY("PPB", REGION_PPB_BASE_ADDRESS, REGION_PPB_ATTR(REGION_PPB_SIZE)),
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
Align MPU region definitions with other SoCs by using the `MPU_REGION_ENTRY` macro.