### PR TITLE
mgmt: mcumgr: remove redundant arguments for zephyr_library

### DIFF
--- a/subsys/mgmt/mcumgr/grp/enum_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/enum_mgmt/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Enumeration management group public API is exported by MCUmgr interface API,
 # when Enumeration Management is enabled.
-zephyr_library(mgmt_mcumgr_grp_enum)
+zephyr_library()
 zephyr_library_sources(src/enum_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # File System management group public API is exposed by MCUmgr API
 # interface, when File System management is enabled.
-zephyr_library(mgmt_mcumgr_grp_fs)
+zephyr_library()
 zephyr_library_sources(src/fs_mgmt.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_HASH src/fs_mgmt_hash_checksum.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_FS_CHECKSUM_IEEE_CRC32 src/fs_mgmt_hash_checksum_crc32.c)

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Image management group public API is exported by MCUmgr interface API,
 # when Image Management is enabled.
-zephyr_library(mgmt_mcumgr_grp_img)
+zephyr_library()
 zephyr_library_sources(
   src/zephyr_img_mgmt.c
   src/img_mgmt_state.c

--- a/subsys/mgmt/mcumgr/grp/img_mgmt_client/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt_client/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Image management client group public API is exported by MCUmgr interface API,
 # when Image Management client is enabled.
 
-zephyr_library(mcumgr_grp_img_client)
+zephyr_library()
 zephyr_library_sources(
   src/img_mgmt_client.c
 )

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # OS Management group public API is exposed through zephyr_interface,
 # when OS Management is enabled.
-zephyr_library(mgmt_mcumgr_grp_os)
+zephyr_library()
 zephyr_library_sources(src/os_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/os_mgmt_client/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt_client/CMakeLists.txt
@@ -6,6 +6,6 @@
 
 # OS Management client group public API is exposed through zephyr_interface,
 # when OS Management is enabled.
-zephyr_library(mgmt_mcumgr_grp_os_client)
+zephyr_library()
 zephyr_library_sources(src/os_mgmt_client.c)
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/settings_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/settings_mgmt/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Settings management group public API is exposed by MCUmgr API
 # interface, when settings management is enabled.
-zephyr_library(mgmt_mcumgr_grp_settings)
+zephyr_library()
 zephyr_library_sources(src/settings_mgmt.c)
 
 if(CONFIG_MCUMGR_GRP_SETTINGS AND NOT CONFIG_MCUMGR_GRP_SETTINGS_ACCESS_HOOK)

--- a/subsys/mgmt/mcumgr/grp/shell_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/shell_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Shell Management group public API is exposed by MCUmgr API
 # interface, when Shell Management is enabled.
-zephyr_library(mgmt_mcumgr_grp_shell)
+zephyr_library()
 zephyr_library_sources(src/shell_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/stat_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/stat_mgmt/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Statistics management group public API is exposed by MCUmgr API
 # interface, when Statistics management is enabled.
-zephyr_library(mgmt_mcumgr_grp_stat)
+zephyr_library()
 zephyr_library_sources(src/stat_mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/grp/zephyr_basic/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/zephyr_basic/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-zephyr_library(mgmt_mcumgr_grp_zephyr)
+zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_GRP_ZBASIC_STORAGE_ERASE src/basic_mgmt.c)

--- a/subsys/mgmt/mcumgr/mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/mgmt/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Provides MCUmgr services, group registration, event handling etc.
-zephyr_library(mgmt_mcumgr_mgmt)
+zephyr_library()
 zephyr_library_sources(src/mgmt.c)
 
 zephyr_library_include_directories(include)

--- a/subsys/mgmt/mcumgr/smp/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/smp/CMakeLists.txt
@@ -5,5 +5,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Protocol API is only exposed to MCUmgr internals.
-zephyr_library(mgmt_mcumgr_protocol)
+zephyr_library()
 zephyr_library_sources(src/smp.c)

--- a/subsys/mgmt/mcumgr/smp_client/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/smp_client/CMakeLists.txt
@@ -5,5 +5,5 @@
 #
 # Protocol API is only exposed to MCUmgr internals.
 
-zephyr_library(mgmt_mcumgr_client_protocol)
+zephyr_library()
 zephyr_library_sources(src/client.c)

--- a/subsys/mgmt/mcumgr/transport/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/transport/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # mgmt_mcumgr_transport covers interface API, allowing to implement transports.
 # It is exposed with mgmt_mcumgr interface.
-zephyr_library(mgmt_mcumgr_transport)
+zephyr_library()
 zephyr_library_sources(src/smp.c)
 
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_REASSEMBLY

--- a/subsys/mgmt/mcumgr/util/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/util/CMakeLists.txt
@@ -8,7 +8,7 @@
 # MCUmgr utilities, for use within the library.
 # API interface for utilities is exposed by mgmt_mcumgr_util,
 # and should not be exposed outside of mgmt_mcumgr.
-zephyr_library(mgmt_mcumgr_util)
+zephyr_library()
 zephyr_library_sources(src/zcbor_bulk.c)
 
 zephyr_include_directories(include)

--- a/tests/subsys/mgmt/mcumgr/handler_demo/example_as_module/CMakeLists.txt
+++ b/tests/subsys/mgmt/mcumgr/handler_demo/example_as_module/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_MCUMGR_GRP_EXAMPLE_MODULE)
-  zephyr_library(mgmt_mcumgr_grp_example)
+  zephyr_library()
   # The below should be updated with the real name of the file
   zephyr_library_sources(src/example_mgmt.c)
   zephyr_include_directories(include)


### PR DESCRIPTION
No argument is needed for zephyr_library and a directory-inferred name will be generated by default.