### PR TITLE
boards: sparkfun: fix the LED active state on the ThingPlus Matter

### DIFF
--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -33,8 +33,8 @@
 	leds {
 		compatible = "gpio-leds";
 
-		blue_led: led_1 {
-			gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
+		blue_led: led_0 {
+			gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
 		};
 	};
 


### PR DESCRIPTION
The LED on The Sparkfun ThingPlus Matter is active high.

Schematics for reference: https://cdn.sparkfun.com/assets/0/f/8/4/9/Thing_Plus_MGM240P.pdf