### PR TITLE
boards: seeed: fix the flash partition layout on the XIAO MG24

### DIFF
--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -176,15 +176,15 @@
 			read-only;
 		};
 
-		/* Reserve 720 kB for the application in slot 0 */
+		/* Reserve 736 kB for the application in slot 0 */
 		slot0_partition: partition@c000 {
 			reg = <0x0000c000 0x000B8000>;
 			label = "image-0";
 		};
 
-		/* Reserve 720 kB for the application in slot 1 */
+		/* Reserve 736 kB for the application in slot 1 */
 		slot1_partition: partition@C4000 {
-			reg = <0x000C0000 0x000B8000>;
+			reg = <0x000C4000 0x000B8000>;
 			label = "image-1";
 		};
 


### PR DESCRIPTION
 - Fixed the partition sizes in the comments
 - Updated the second partition base address to be correct

The layout now matches the Arduino Nano Matter which was used for reference.