### PR TITLE
drivers: sensor: paj7620: fix return value of paj7620_get_hw_id()

### DIFF
--- a/drivers/sensor/pixart/paj7620/paj7620.c
+++ b/drivers/sensor/pixart/paj7620/paj7620.c
@@ -48,7 +48,7 @@ static int paj7620_select_register_bank(const struct device *dev, enum paj7620_m
 
 static int paj7620_get_hw_id(const struct device *dev, uint16_t *result)
 {
-	uint8_t ret;
+	int ret;
 	uint8_t hw_id[2];
 	const struct paj7620_config *config = dev->config;
 


### PR DESCRIPTION
Use a local signed variable to store negative return values instead of unsigned previously so that errors are actually detected/returned.