### PR TITLE
drivers: gpio: max149xx: fix error handling

### DIFF
--- a/drivers/gpio/gpio_max14906.c
+++ b/drivers/gpio/gpio_max14906.c
@@ -82,7 +82,7 @@ static int max14906_reg_trans_spi_diag(const struct device *dev, uint8_t addr, u
 		LOG_ERR("[FAULT] pin triggered");
 	}
 
-	uint8_t ret = max149x6_reg_transceive(dev, addr, tx, rx_diag_buff, rw);
+	int ret = max149x6_reg_transceive(dev, addr, tx, rx_diag_buff, rw);
 
 	if (max14906_pars_spi_diag(dev, rx_diag_buff, rw)) {
 		ret = -EIO;

--- a/drivers/gpio/gpio_max14916.c
+++ b/drivers/gpio/gpio_max14916.c
@@ -85,7 +85,7 @@ static int max14916_reg_trans_spi_diag(const struct device *dev, uint8_t addr, u
 		LOG_ERR(" >>> FLT PIN");
 	}
 
-	uint8_t ret = max149x6_reg_transceive(dev, addr, tx, rx_diag_buff, rw);
+	int ret = max149x6_reg_transceive(dev, addr, tx, rx_diag_buff, rw);
 
 	if (max14916_pars_spi_diag(dev, rx_diag_buff, rw)) {
 		ret = -EIO;


### PR DESCRIPTION
Use signed variable for negative error codes so that potential errors are actually detected and returned properly.