### PR TITLE
drivers: display: ssd1322: fix out-of-bound access

### DIFF
--- a/drivers/display/ssd1322.c
+++ b/drivers/display/ssd1322.c
@@ -118,7 +118,7 @@ static int ssd1322_conv_mono01_grayscale(const uint8_t **buf_in, uint32_t *pixel
 		}
 	}
 
-	buf_in += pixels_in_chunk / 8;
+	*buf_in += pixels_in_chunk / 8;
 	*pixel_count -= pixels_in_chunk;
 	return pixels_in_chunk * segments_per_pixel / SEGMENTS_PER_BYTE;
 }


### PR DESCRIPTION
Fix memory corruption issue where buffer pointer was not being advanced properly due to missing dereference.

Fixes Coverity issue CID 434607
Fixes zephyrproject-rtos/zephyr#81957