### PR TITLE
ci: twister: run with '--overflow-as-errors'

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -142,7 +142,7 @@ jobs:
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
+      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 --overflow-as-errors'
       WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered -j 32'
       PR_OPTIONS: ' --clobber-output --integration -j 16'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'


### PR DESCRIPTION
Execute Twister with `--overflow-as-errors` to treat all memory overflows (FLASH,ROM,RAM,ICCM,DCCM,SRAM) detected on build as errors instead of skipped.

This CI change was discussed on the Zephyr Testing WG meeting 14/Nov/2024 as a proposal to recommend it to activate.
@zephyrproject-rtos/testing - could we add this to the WG meeting agenda again ?