### PR TITLE
drivers: video: use inclusive language

### DIFF
--- a/drivers/video/video_ctrls.c
+++ b/drivers/video/video_ctrls.c
@@ -226,17 +226,17 @@ int video_init_int_menu_ctrl(struct video_ctrl *ctrl, const struct device *dev, 
 	return 0;
 }
 
-/* By definition, the cluster is in manual mode if the master control value is 0 */
-static inline bool is_cluster_manual(const struct video_ctrl *master)
+/* By definition, the cluster is in manual mode if the primary control value is 0 */
+static inline bool is_cluster_manual(const struct video_ctrl *primary)
 {
-	return master->type == VIDEO_CTRL_TYPE_INTEGER64 ? master->val64 == 0 : master->val == 0;
+	return primary->type == VIDEO_CTRL_TYPE_INTEGER64 ? primary->val64 == 0 : primary->val == 0;
 }
 
 void video_cluster_ctrl(struct video_ctrl *ctrls, uint8_t sz)
 {
 	bool has_volatiles = false;
 
-	__ASSERT(!sz && !ctrls, "The 1st control, i.e. the master, must not be NULL");
+	__ASSERT(!sz && !ctrls, "The 1st control, i.e. the primary control, must not be NULL");
 
 	for (uint8_t i = 0; i < sz; i++) {
 		ctrls[i].cluster_sz = sz;

--- a/drivers/video/video_ctrls.h
+++ b/drivers/video/video_ctrls.h
@@ -17,7 +17,7 @@
 #define VIDEO_CTRL_FLAG_VOLATILE   BIT(2)
 /** Control is inactive, e.g. manual controls of an autocluster in automatic mode */
 #define VIDEO_CTRL_FLAG_INACTIVE   BIT(3)
-/** Control that affects other controls, e.g. the master control of a cluster */
+/** Control that affects other controls, e.g. the primary control of a cluster */
 #define VIDEO_CTRL_FLAG_UPDATE     BIT(4)
 
 enum video_ctrl_type {

--- a/drivers/video/video_esp32_dvp.c
+++ b/drivers/video/video_esp32_dvp.c
@@ -432,7 +432,7 @@ DEVICE_DT_INST_DEFINE(0, video_esp32_init, NULL, &esp32_data, &esp32_config, POS
 
 VIDEO_DEVICE_DEFINE(esp32, DEVICE_DT_INST_GET(0), SOURCE_DEV(0));
 
-static int video_esp32_cam_init_master_clock(void)
+static int video_esp32_cam_init_main_clock(void)
 {
 	int ret = 0;
 
@@ -459,11 +459,11 @@ static int video_esp32_cam_init_master_clock(void)
 		return -EINVAL;
 	}
 
-	/* Enable camera master clock output */
+	/* Enable camera main clock output */
 	cam_ll_select_clk_src(0, LCD_CLK_SRC_PLL160M);
 	cam_ll_set_group_clock_coeff(0, ESP32_CLK_CPU_PLL_160M / esp32_config.cam_clk, 0, 0);
 
 	return 0;
 }
 
-SYS_INIT(video_esp32_cam_init_master_clock, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(video_esp32_cam_init_main_clock, PRE_KERNEL_2, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Fixes in video drivers to follow Zephyr guidelines w.r.t. using inclusive language.