### PR TITLE
drivers: pwm: silabs: efr32 series 2 support

### DIFF
--- a/dts/bindings/pwm/silabs,gecko-pwm.yaml
+++ b/dts/bindings/pwm/silabs,gecko-pwm.yaml
@@ -8,7 +8,9 @@ properties:
   pin-location:
     type: array
     required: true
-    description: pwm pin configuration defined as <location port pin>
+    description: |
+      pwm pin configuration defined as <location port pin>
+      For Series 2 devices, location is the timer instance number (0, 1, 2, ...)
 
   prescaler:
     type: int


### PR DESCRIPTION
Routing of timer output to GPIO pin for devices where this is done from GPIO TIMERROUTE register.