### PR TITLE
boards: frdm_mcxa166, frdm_mcxa276: add i3c support

### DIFF
--- a/boards/nxp/frdm_mcxa276/board.c
+++ b/boards/nxp/frdm_mcxa276/board.c
@@ -192,6 +192,11 @@ void board_early_init_hook(void)
 	CLOCK_SetClockDiv(kCLOCK_DivADC, 1u);
 	CLOCK_AttachClk(kFRO_LF_DIV_to_ADC);
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(i3c0))
+	CLOCK_SetClockDiv(kCLOCK_DivI3C0_FCLK, 15U);
+	CLOCK_AttachClk(kFRO_HF_DIV_to_I3C0FCLK);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpadc0))
 	CLOCK_EnableClock(kCLOCK_GateADC0);
 #endif

--- a/boards/nxp/frdm_mcxa276/frdm_mcxa276-pinctrl.dtsi
+++ b/boards/nxp/frdm_mcxa276/frdm_mcxa276-pinctrl.dtsi
@@ -27,6 +27,22 @@
 		};
 	};
 
+	pinmux_i3c0: pinmux_i3c0 {
+		group0 {
+			pinmux = <I3C0_SDA_P1_8>,
+				<I3C0_SCL_P1_9>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+			bias-pull-up;
+		};
+		group1 {
+			pinmux = <I3C0_PUR_P0_2>;
+			slew-rate = "fast";
+			drive-strength = "low";
+			input-enable;
+		};
+	};
 	pinmux_lpadc0: pinmux_lpadc0 {
 		group0 {
 			pinmux = <ADC0_A7_P2_7>;

--- a/boards/nxp/frdm_mcxa276/frdm_mcxa276.dts
+++ b/boards/nxp/frdm_mcxa276/frdm_mcxa276.dts
@@ -9,6 +9,7 @@
 #include <nxp/nxp_mcxa276.dtsi>
 #include "frdm_mcxa276-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <freq.h>
 
 / {
 	model = "NXP FRDM_MCXA276 board";
@@ -21,6 +22,7 @@
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		watchdog0 = &wwdt0;
+		ambient-temp0 = &p3t1755;
 	};
 
 	chosen {
@@ -118,6 +120,22 @@
 
 &edma0 {
 	status = "okay";
+};
+
+&i3c0 {
+	status = "okay";
+	pinctrl-0 = <&pinmux_i3c0>;
+	pinctrl-names = "default";
+
+	i2c-scl-hz = <DT_FREQ_K(400)>;
+	i3c-scl-hz = <DT_FREQ_M(4)>;
+	i3c-od-scl-hz = <DT_FREQ_K(1500)>;
+
+	p3t1755: p3t1755@4800000236152a0090 {
+		compatible = "nxp,p3t1755";
+		reg = <0x48 0x0236 0x152a0090>;
+		status = "okay";
+	};
 };
 
 &lpadc0 {

--- a/boards/nxp/frdm_mcxa276/frdm_mcxa276.yaml
+++ b/boards/nxp/frdm_mcxa276/frdm_mcxa276.yaml
@@ -23,4 +23,5 @@ supported:
   - watchdog
   - counter
   - dma
+  - i3c
 vendor: nxp

--- a/dts/arm/nxp/nxp_mcxa276.dtsi
+++ b/dts/arm/nxp/nxp_mcxa276.dtsi
@@ -292,6 +292,19 @@
 			status = "disabled";
 		};
 
+		i3c0: i3c@40002000 {
+			compatible = "nxp,mcux-i3c";
+			reg = <0x40002000 0x1000>;
+			interrupts = <24 0>;
+			clocks = <&syscon MCUX_I3C_CLK>;
+			clk-divider = <4>;
+			clk-divider-slow = <1>;
+			clk-divider-tc = <1>;
+			status = "disabled";
+			#address-cells = <3>;
+			#size-cells = <0>;
+		};
+
 		lpadc0: lpadc@400af000 {
 			compatible = "nxp,lpc-lpadc";
 			reg = <0x400af000 0x1000>;


### PR DESCRIPTION
1. enable i3c driver and sensor p3t1755
2. verified samples/sensor/thermometer