### PR TITLE
west.yml: stm32wbax : Link Layer and LE Host libraries dynamic selection

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 468e5ad450a75d4baa3eed80e4f77a7700b71203
+      revision: 41952fe9eff787337c5b03ccbc3a437c0dd1330c
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Add stm32wbax BLE BASIC Link Layer and Host libraries references. Add mechanism in CMakeLists file of hal_stm32 module to select appropriate type of LL and LE Host libraries according to LE features.