### PR TITLE
MAINTAINERS: include Arduino shields in the Arduino category

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -183,6 +183,7 @@ Arduino Platforms:
     - facchinm
   files:
     - boards/arduino/
+    - boards/shields/arduino_*/
     - drivers/*/*modulino*
 
 ARM arch:


### PR DESCRIPTION
Include the Arduino shields under the same assignees as the rest of the Arduino platforms so PRs like #91980 get assigned automatically.