### PR TITLE
drivers: video: dcmi: fix DMA channel configuration

### DIFF
--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -155,11 +155,11 @@ static int stm32_dma_init(const struct device *dev)
 	hdma.Init.MemDataAlignment	= DMA_MDATAALIGN_WORD;
 	hdma.Init.Mode			= DMA_CIRCULAR;
 	hdma.Init.Priority		= DMA_PRIORITY_HIGH;
-#if defined(CONFIG_SOC_SERIES_STM32F7X)
+#if defined(CONFIG_SOC_SERIES_STM32F7X) || defined(CONFIG_SOC_SERIES_STM32H7X)
 	hdma.Init.FIFOMode		= DMA_FIFOMODE_DISABLE;
 #endif
 
-#if defined(CONFIG_SOC_SERIES_STM32F7X)
+#if defined(CONFIG_SOC_SERIES_STM32F7X) || defined(CONFIG_SOC_SERIES_STM32H7X)
 	hdma.Instance = __LL_DMA_GET_STREAM_INSTANCE(config->dma.reg,
 						config->dma.channel);
 #elif defined(CONFIG_SOC_SERIES_STM32L4X)


### PR DESCRIPTION
Commit 64149e4df6d4c2873e222f6bf118a9ee6cb2bdb1 added an `#if defined()` for configuring DMA channels differently depending on SOC family of the STM32 HAL, but did not include the STM32H7 family in the same group as STM32F7. Fix it by adding the STM32H7 in the same `#ifdef` filter.

Fixes #92015