### PR TITLE
manifest: update hal_nordic to have SAADC samples aligned to 3.12 API

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 6e39d4f2b078afaebdb84875089486152fcacb9c
+      revision: 71308dc6d8c021887ce5d98a36cafe9517375a91
       path: modules/hal/nordic
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 71308dc6d8c021887ce5d98a36cafe9517375a91
+      revision: pull/304/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
NRFX_SAADC_SAMPLE_GET() macro takes two arguments now instead of three.