### PR TITLE
drivers: stm32: always call runtime_get when registering targets

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -194,9 +194,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 	k_sem_take(&data->bus_mutex, K_FOREVER);
 
 	/* Prevent driver from being suspended by PM until I2C transaction is complete */
-#ifdef CONFIG_PM_DEVICE_RUNTIME
 	(void)pm_device_runtime_get(dev);
-#endif
 
 	/* Prevent the clocks to be stopped during the i2c transaction */
 	pm_policy_state_lock_get(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
@@ -220,9 +218,7 @@ static int i2c_stm32_transfer(const struct device *dev, struct i2c_msg *msg,
 
 	pm_policy_state_lock_put(PM_STATE_SUSPEND_TO_IDLE, PM_ALL_SUBSTATES);
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
 	(void)pm_device_runtime_put(dev);
-#endif
 
 	k_sem_give(&data->bus_mutex);
 
@@ -388,9 +384,7 @@ static int i2c_stm32_init(const struct device *dev)
 		return ret;
 	}
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
 	(void)pm_device_runtime_enable(dev);
-#endif
 
 	data->is_configured = true;
 

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -437,9 +437,10 @@ int i2c_stm32_target_register(const struct device *dev,
 	}
 
 #if defined(CONFIG_PM_DEVICE_RUNTIME)
+	/* Mark device as active */
+	(void)pm_device_runtime_get(dev);
+
 	if (pm_device_wakeup_is_capable(dev)) {
-		/* Mark device as active */
-		(void)pm_device_runtime_get(dev);
 		/* Enable wake-up from stop */
 		LOG_DBG("i2c: enabling wakeup from stop");
 		LL_I2C_EnableWakeUpFromStop(cfg->i2c);
@@ -532,9 +533,10 @@ int i2c_stm32_target_unregister(const struct device *dev,
 		/* Disable wake-up from STOP */
 		LOG_DBG("i2c: disabling wakeup from stop");
 		LL_I2C_DisableWakeUpFromStop(i2c);
-		/* Release the device */
-		(void)pm_device_runtime_put(dev);
 	}
+
+	/* Release the device */
+	(void)pm_device_runtime_put(dev);
 #endif /* defined(CONFIG_PM_DEVICE_RUNTIME) */
 
 	data->slave_attached = false;

--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -436,7 +436,6 @@ int i2c_stm32_target_register(const struct device *dev,
 		return ret;
 	}
 
-#if defined(CONFIG_PM_DEVICE_RUNTIME)
 	/* Mark device as active */
 	(void)pm_device_runtime_get(dev);
 
@@ -445,7 +444,6 @@ int i2c_stm32_target_register(const struct device *dev,
 		LOG_DBG("i2c: enabling wakeup from stop");
 		LL_I2C_EnableWakeUpFromStop(cfg->i2c);
 	}
-#endif /* defined(CONFIG_PM_DEVICE_RUNTIME) */
 
 	LL_I2C_Enable(i2c);
 
@@ -528,7 +526,6 @@ int i2c_stm32_target_unregister(const struct device *dev,
 		LL_I2C_Disable(i2c);
 	}
 
-#if defined(CONFIG_PM_DEVICE_RUNTIME)
 	if (pm_device_wakeup_is_capable(dev)) {
 		/* Disable wake-up from STOP */
 		LOG_DBG("i2c: disabling wakeup from stop");
@@ -537,7 +534,6 @@ int i2c_stm32_target_unregister(const struct device *dev,
 
 	/* Release the device */
 	(void)pm_device_runtime_put(dev);
-#endif /* defined(CONFIG_PM_DEVICE_RUNTIME) */
 
 	data->slave_attached = false;
 


### PR DESCRIPTION
Current code only calls pm_device_runtime_get when registering target devices if the device is marked as wakeup capable by the application.

This does quite work for a setup with PM=n and PM_DEVICE=y and PM_DEVICE_RUNTIME=y, where the CPU does not really go in stop mode ever, and results in the i2c target device not working at all.

Fix this by always claiming the device when PM_DEVICE_RUNTIME is enabled.