### PR TITLE
cmake: add option to force raw instruction mnemonics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1899,10 +1899,13 @@ if(CONFIG_BUILD_OUTPUT_S19)
 endif()
 
 if(CONFIG_OUTPUT_DISASSEMBLY)
-if(CONFIG_OUTPUT_DISASSEMBLE_ALL)
+  if(CONFIG_OUTPUT_DISASSEMBLE_ALL)
     set(disassembly_type "$<TARGET_PROPERTY:bintools,disassembly_flag_all>")
-  elseif (CONFIG_OUTPUT_DISASSEMBLY_WITH_SOURCE)
+  elseif(CONFIG_OUTPUT_DISASSEMBLY_WITH_SOURCE)
     set(disassembly_type "$<TARGET_PROPERTY:bintools,disassembly_flag_inline_source>")
+  endif()
+  if(CONFIG_OUTPUT_DISASSEMBLY_NO_ALIASES)
+    list(APPEND disassembly_type "$<TARGET_PROPERTY:bintools,disassembly_flag_no_aliases>")
   endif()
   list(APPEND
     post_build_commands

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -698,6 +698,13 @@ config OUTPUT_DISASSEMBLY_WITH_SOURCE
 	  the .lst file that can vary across platforms because
 	  of reasons such as having ".." include paths.
 
+config OUTPUT_DISASSEMBLY_NO_ALIASES
+	bool "Disassemble with raw instruction mnemonics"
+	depends on OUTPUT_DISASSEMBLY
+	help
+	  The .lst file will contain raw instruction mnemonic instead of
+	  pseudo instructions.
+
 config OUTPUT_PRINT_MEMORY_USAGE
 	bool "Print memory usage to stdout"
 	default y

--- a/cmake/bintools/arcmwdt/target_bintools.cmake
+++ b/cmake/bintools/arcmwdt/target_bintools.cmake
@@ -47,6 +47,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_outfile "-DOUTFILE=")
 #   disassembly_flag               : -T
 #   disassembly_flag_final         : empty
 #   disassembly_flag_inline_source : -S
+#   disassembly_flag_no_aliases    : empty
 #   disassembly_flag_all           : empty
 #   disassembly_flag_infile        : empty
 #   disassembly_flag_outfile       : '>'
@@ -54,6 +55,7 @@ set_property(TARGET bintools PROPERTY disassembly_command ${CMAKE_OBJDUMP})
 set_property(TARGET bintools PROPERTY disassembly_flag -T)
 set_property(TARGET bintools PROPERTY disassembly_flag_final "")
 set_property(TARGET bintools PROPERTY disassembly_flag_inline_source -S)
+set_property(TARGET bintools PROPERTY disassembly_flag_no_aliases "")
 set_property(TARGET bintools PROPERTY disassembly_flag_all "") # No support for all ?
 
 set_property(TARGET bintools PROPERTY disassembly_flag_infile "")

--- a/cmake/bintools/armclang/target_bintools.cmake
+++ b/cmake/bintools/armclang/target_bintools.cmake
@@ -38,6 +38,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_outfile "-DOUTFILE=")
 #   disassembly_flag               : --disassemble
 #   disassembly_flag_final         : empty
 #   disassembly_flag_inline_source : --interleave=source
+#   disassembly_flag_no_aliases    : empty
 #   disassembly_flag_all           : empty, fromelf does not differentiate on this.
 #   disassembly_flag_infile        : empty, fromelf doesn't take arguments for filenames
 #   disassembly_flag_outfile       : --output
@@ -46,6 +47,7 @@ set_property(TARGET bintools PROPERTY disassembly_command ${CMAKE_FROMELF})
 set_property(TARGET bintools PROPERTY disassembly_flag --disassemble)
 set_property(TARGET bintools PROPERTY disassembly_flag_final "")
 set_property(TARGET bintools PROPERTY disassembly_flag_inline_source --interleave=source)
+set_property(TARGET bintools PROPERTY disassembly_flag_no_aliases "")
 set_property(TARGET bintools PROPERTY disassembly_flag_all "")
 
 set_property(TARGET bintools PROPERTY disassembly_flag_infile "")

--- a/cmake/bintools/bintools_template.cmake
+++ b/cmake/bintools/bintools_template.cmake
@@ -86,6 +86,7 @@
 #   disassembly_flag               : Flags that must always be applied when calling disassembly command
 #   disassembly_flag_final         : Flags that must always be applied last at the disassembly command
 #   disassembly_flag_inline_source : Flag to use to display source code mixed with disassembly
+#   disassembly_flag_no_aliases    : Flag to use to disassemble with raw instruction mnemonics
 #   disassembly_flag_all           : Flag to use for disassemble everything, including zeroes
 #   disassembly_flag_infile        : Flag for specifying the input file
 #   disassembly_flag_outfile       : Flag for specifying the output file
@@ -135,6 +136,7 @@ set_property(TARGET bintools PROPERTY disassembly_command ${CMAKE_COMMAND} -E ec
 set_property(TARGET bintools PROPERTY disassembly_flag "")
 set_property(TARGET bintools PROPERTY disassembly_flag_final "")
 set_property(TARGET bintools PROPERTY disassembly_flag_inline_source "")
+set_property(TARGET bintools PROPERTY disassembly_flag_no_aliases "")
 set_property(TARGET bintools PROPERTY disassembly_flag_infile "")
 set_property(TARGET bintools PROPERTY disassembly_flag_outfile "")
 

--- a/cmake/bintools/gnu/target_bintools.cmake
+++ b/cmake/bintools/gnu/target_bintools.cmake
@@ -64,6 +64,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_outfile "")
 #   disassembly_flag               : -d
 #   disassembly_flag_final         : empty
 #   disassembly_flag_inline_source : -S
+#   disassembly_flag_no_aliases    : -M no-aliases
 #   disassembly_flag_all           : -SDz
 #   disassembly_flag_infile        : empty, objdump doesn't take arguments for filenames
 #   disassembly_flag_outfile       : '>', objdump doesn't take arguments for output file, but result is printed to standard out, and is redirected.
@@ -72,6 +73,7 @@ set_property(TARGET bintools PROPERTY disassembly_command ${CMAKE_OBJDUMP})
 set_property(TARGET bintools PROPERTY disassembly_flag -d)
 set_property(TARGET bintools PROPERTY disassembly_flag_final "")
 set_property(TARGET bintools PROPERTY disassembly_flag_inline_source -S)
+set_property(TARGET bintools PROPERTY disassembly_flag_no_aliases -M no-aliases)
 set_property(TARGET bintools PROPERTY disassembly_flag_all -SDz)
 
 set_property(TARGET bintools PROPERTY disassembly_flag_infile "")

--- a/cmake/bintools/iar/target_bintools.cmake
+++ b/cmake/bintools/iar/target_bintools.cmake
@@ -61,6 +61,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_outfile "")
 #   disassembly_flag               : -d
 #   disassembly_flag_final         : empty
 #   disassembly_flag_inline_source : -S
+#   disassembly_flag_no_aliases    : empty
 #   disassembly_flag_all           : -SDz
 #   disassembly_flag_infile        : empty, objdump doesn't take arguments for filenames
 #   disassembly_flag_outfile       : '>', objdump doesn't take arguments for output file, but result is printed to standard out, and is redirected.
@@ -69,6 +70,7 @@ set_property(TARGET bintools PROPERTY disassembly_command ${CMAKE_OBJDUMP})
 set_property(TARGET bintools PROPERTY disassembly_flag -d)
 set_property(TARGET bintools PROPERTY disassembly_flag_final "")
 set_property(TARGET bintools PROPERTY disassembly_flag_inline_source -S)
+set_property(TARGET bintools PROPERTY disassembly_flag_no_aliases "")
 set_property(TARGET bintools PROPERTY disassembly_flag_all -SDz)
 
 set_property(TARGET bintools PROPERTY disassembly_flag_infile "")

--- a/cmake/bintools/llvm/target_bintools.cmake
+++ b/cmake/bintools/llvm/target_bintools.cmake
@@ -61,6 +61,7 @@ set_property(TARGET bintools PROPERTY elfconvert_flag_outfile "")
 #   disassembly_flag               : -d
 #   disassembly_flag_final         : empty
 #   disassembly_flag_inline_source : -S
+#   disassembly_flag_no_aliases    : empty
 #   disassembly_flag_all           : -SDz
 #   disassembly_flag_infile        : empty, objdump doesn't take arguments for filenames
 #   disassembly_flag_outfile       : '>', objdump doesn't take arguments for output file, but result is printed to standard out, and is redirected.
@@ -69,6 +70,7 @@ set_property(TARGET bintools PROPERTY disassembly_command ${CMAKE_OBJDUMP})
 set_property(TARGET bintools PROPERTY disassembly_flag -d)
 set_property(TARGET bintools PROPERTY disassembly_flag_final "")
 set_property(TARGET bintools PROPERTY disassembly_flag_inline_source "")
+set_property(TARGET bintools PROPERTY disassembly_flag_no_aliases "")
 set_property(TARGET bintools PROPERTY disassembly_flag_all "")
 
 set_property(TARGET bintools PROPERTY disassembly_flag_infile "")


### PR DESCRIPTION
Some architectures use pseudo instructions in assembly. Introduce an option that allows forcing raw instruction mnemonics. Currently implemented for GNU binutils.