### PR TITLE
boards/ezurio & raytac: Change Nordic license to Apache

### DIFF
--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns.yaml
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # Copyright (c) 2025 Ezurio LLC
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+# SPDX-License-Identifier: Apache-2.0
 
 identifier: bl54l15u_dvk/nrf54l15/cpuapp/ns
 name: BL54L15u-DVK-nRF54l15-Application-Non-Secure

--- a/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns_defconfig
+++ b/boards/ezurio/bl54l15u_dvk/bl54l15u_dvk_nrf54l15_cpuapp_ns_defconfig
@@ -1,6 +1,6 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # Copyright (c) 2025 Ezurio LLC
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+# SPDX-License-Identifier: Apache-2.0
 
 CONFIG_ARM_MPU=y
 CONFIG_HW_STACK_PROTECTION=y

--- a/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp_ns.yaml
+++ b/boards/raytac/an54l15q_db/raytac_an54l15q_db_nrf54l15_cpuapp_ns.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # Copyright (c) 2025 Raytac Corporation.
-# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+# SPDX-License-Identifier: Apache-2.0
 
 identifier: raytac_an54l15q_db/nrf54l15/cpuapp/ns
 name: Raytac-AN54L15Q-DB-nRF54l15-Application-Non-Secure


### PR DESCRIPTION
For yaml files we do not normally even add a license, but if any it should be Apache2 and not the Nordic one.
Note there is plenty of examples of yaml files very similar to this in the Zephyr tree. So even if the author/submitter of the original commit could have used as starting point a file from NCS, it would have been the same if he would have used a Zephyr one.