### PR TITLE
dts: arm: adi: Enable SPI for MAX32657

### DIFF
--- a/boards/adi/max32657evkit/max32657evkit_max32657.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.yaml
@@ -14,5 +14,6 @@ supported:
   - dma
   - counter
   - pwm
+  - spi
 ram: 256
 flash: 960

--- a/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
@@ -65,3 +65,9 @@
 &wdt0 {
 	status = "okay";
 };
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&spi0_mosi_p0_2 &spi0_miso_p0_4 &spi0_sck_p0_6 &spi0_ss0_p0_3>;
+	pinctrl-names = "default";
+};

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
@@ -13,5 +13,6 @@ supported:
   - dma
   - counter
   - pwm
+  - spi
 ram: 192
 flash: 576

--- a/drivers/spi/spi_max32.c
+++ b/drivers/spi/spi_max32.c
@@ -382,7 +382,7 @@ static int transceive(const struct device *dev, const struct spi_config *config,
 		spi_context_cs_control(ctx, true);
 	} else {
 		cfg->regs->ctrl0 =
-			(cfg->regs->ctrl0 & ~MXC_F_SPI_CTRL0_START) | MXC_F_SPI_CTRL0_SS_CTRL;
+			(cfg->regs->ctrl0 & ~MXC_F_SPI_CTRL0_START) | ADI_MAX32_SPI_CTRL0_SS_CTRL;
 	}
 
 #ifdef CONFIG_SPI_MAX32_INTERRUPT
@@ -412,7 +412,7 @@ static int transceive(const struct device *dev, const struct spi_config *config,
 		if (!hw_cs_ctrl) {
 			spi_context_cs_control(ctx, false);
 		} else {
-			cfg->regs->ctrl0 &= ~(MXC_F_SPI_CTRL0_START | MXC_F_SPI_CTRL0_SS_CTRL |
+			cfg->regs->ctrl0 &= ~(MXC_F_SPI_CTRL0_START | ADI_MAX32_SPI_CTRL0_SS_CTRL |
 					      ADI_MAX32_SPI_CTRL_EN);
 			cfg->regs->ctrl0 |= ADI_MAX32_SPI_CTRL_EN;
 		}
@@ -571,7 +571,7 @@ static int transceive_dma(const struct device *dev, const struct spi_config *con
 	if (!hw_cs_ctrl) {
 		spi_context_cs_control(ctx, true);
 	} else {
-		spi->ctrl0 = (spi->ctrl0 & ~MXC_F_SPI_CTRL0_START) | MXC_F_SPI_CTRL0_SS_CTRL;
+		spi->ctrl0 = (spi->ctrl0 & ~MXC_F_SPI_CTRL0_START) | ADI_MAX32_SPI_CTRL0_SS_CTRL;
 	}
 
 	MXC_SPI_SetSlave(cfg->regs, ctx->config->slave);
@@ -620,7 +620,7 @@ unlock:
 	if (!hw_cs_ctrl) {
 		spi_context_cs_control(ctx, false);
 	} else {
-		spi->ctrl0 &= ~(MXC_F_SPI_CTRL0_START | MXC_F_SPI_CTRL0_SS_CTRL |
+		spi->ctrl0 &= ~(MXC_F_SPI_CTRL0_START | ADI_MAX32_SPI_CTRL0_SS_CTRL |
 				ADI_MAX32_SPI_CTRL_EN);
 		spi->ctrl0 |= ADI_MAX32_SPI_CTRL_EN;
 	}
@@ -772,7 +772,7 @@ static void spi_max32_callback(mxc_spi_req_t *req, int error)
 		if (spi_cs_is_gpio(ctx->config)) {
 			spi_context_cs_control(ctx, false);
 		} else {
-			req->spi->ctrl0 &= ~(MXC_F_SPI_CTRL0_START | MXC_F_SPI_CTRL0_SS_CTRL |
+			req->spi->ctrl0 &= ~(MXC_F_SPI_CTRL0_START | ADI_MAX32_SPI_CTRL0_SS_CTRL |
 					     ADI_MAX32_SPI_CTRL_EN);
 			req->spi->ctrl0 |= ADI_MAX32_SPI_CTRL_EN;
 		}

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -268,6 +268,16 @@
 			status = "disabled";
 		};
 	};
+
+	spi0: spi@46000 {
+		compatible = "adi,max32-spi";
+		reg = <0x46000 0x1000>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clocks = <&gcr ADI_MAX32_CLOCK_BUS0 6>;
+		interrupts = <12 0>;
+		status = "disabled";
+	};
 };
 
 &nvic {

--- a/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657.conf
+++ b/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_SPI_MAX32_INTERRUPT=y

--- a/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dma1 {
+	status = "okay";
+};
+
+&spi0 {
+	dmas = <&dma1 1 MAX32_DMA_SLOT_SPI_TX>, <&dma1 2 MAX32_DMA_SLOT_SPI_RX>;
+	dma-names = "tx", "rx";
+
+	slow@1 {
+		compatible = "test-spi-loopback-slow";
+		reg = <1>;
+		spi-max-frequency = <128000>;
+	};
+	fast@1 {
+		compatible = "test-spi-loopback-fast";
+		reg = <1>;
+		spi-max-frequency = <500000>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657_ns.conf
+++ b/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657_ns.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_SPI_MAX32_INTERRUPT=y

--- a/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657_ns.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/max32657evkit_max32657_ns.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&spi0 {
+	slow@1 {
+		compatible = "test-spi-loopback-slow";
+		reg = <1>;
+		spi-max-frequency = <128000>;
+	};
+	fast@1 {
+		compatible = "test-spi-loopback-fast";
+		reg = <1>;
+		spi-max-frequency = <500000>;
+	};
+};


### PR DESCRIPTION
Enable SPI support for MAX32657 and add test overlays to `spi_loopback` for both secure and nonsecure variants of MAX32657EVKIT.