### PR TITLE
boards: nordic: Use dts for non-secure partitions

### DIFF
--- a/boards/nordic/nrf5340dk/Kconfig.defconfig
+++ b/boards/nordic/nrf5340dk/Kconfig.defconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2019-2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
 # Code Partition:
 #
@@ -29,29 +29,19 @@ if  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 # For the non-secure version of the board, the firmware image SRAM is
 # always restricted to the allocated non-secure SRAM partition.
 #
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 
 if BOARD_NRF5340DK_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
 
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
 
 config SRAM_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K)
 
 endif # BOARD_NRF5340DK_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
 
-if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_NRF5340DK_NRF5340_CPUAPP_NS
+config BOARD_NRF5340DK
+	select USE_DT_CODE_PARTITION if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
 config BT_HCI_IPC
 	default y if BT
@@ -60,8 +50,4 @@ config HEAP_MEM_POOL_ADD_SIZE_BOARD
 	int
 	default 4096 if BT_HCI_IPC
 
-endif #  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
-
-if BOARD_NRF5340DK_NRF5340_CPUNET
-
-endif # BOARD_NRF5340DK_NRF5340_CPUNET
+endif # BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS

--- a/boards/nordic/nrf54l15dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54l15dk/Kconfig.defconfig
@@ -1,10 +1,6 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
-
 if BOARD_NRF54L15DK_NRF54L05_CPUAPP || BOARD_NRF54L15DK_NRF54L10_CPUAPP || \
 	BOARD_NRF54L15DK_NRF54L15_CPUAPP
 
@@ -16,14 +12,12 @@ endif # BOARD_NRF54L15DK_NRF54L05_CPUAPP || BOARD_NRF54L15DK_NRF54L10_CPUAPP || 
 
 if BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS || BOARD_NRF54L15DK_NRF54L10_CPUAPP_NS
 
+config BOARD_NRF54L15DK
+	select USE_DT_CODE_PARTITION if BOARD_NRF54L15DK_NRF54L15_CPUAPP_NS || \
+		BOARD_NRF54L15DK_NRF54L10_CPUAPP_NS
+
 config BT_CTLR
 	default BT
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
 
 # By default, if we build for a Non-Secure version of the board,
 # enable building with TF-M as the Secure Execution Environment.

--- a/boards/nordic/nrf9131ek/Kconfig.defconfig
+++ b/boards/nordic/nrf9131ek/Kconfig.defconfig
@@ -3,33 +3,5 @@
 # Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-if BOARD_NRF9131EK_NRF9131 || BOARD_NRF9131EK_NRF9131_NS
-
-# For the secure version of the board the firmware is linked at the beginning
-# of the flash, or into the code-partition defined in DT if it is intended to
-# be loaded by MCUboot. If the secure firmware is to be combined with a non-
-# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
-# be restricted to the size of its code partition.
-# For the non-secure version of the board, the firmware
-# must be linked into the code-partition (non-secure) defined in DT, regardless.
-# Apply this configuration below by setting the Kconfig symbols used by
-# the linker according to the information extracted from DT partitions.
-
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-	depends on BOARD_NRF9131EK_NRF9131 && TRUSTED_EXECUTION_SECURE
-
-if BOARD_NRF9131EK_NRF9131_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_NRF9131EK_NRF9131_NS
-
-endif # BOARD_NRF9131EK_NRF9131 || BOARD_NRF9131EK_NRF9131_NS
+config BOARD_NRF9131EK
+	select USE_DT_CODE_PARTITION if BOARD_NRF9131EK_NRF9131_NS

--- a/boards/nordic/nrf9151dk/Kconfig.defconfig
+++ b/boards/nordic/nrf9151dk/Kconfig.defconfig
@@ -5,32 +5,8 @@
 
 if BOARD_NRF9151DK_NRF9151 || BOARD_NRF9151DK_NRF9151_NS
 
-# For the secure version of the board the firmware is linked at the beginning
-# of the flash, or into the code-partition defined in DT if it is intended to
-# be loaded by MCUboot. If the secure firmware is to be combined with a non-
-# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
-# be restricted to the size of its code partition.
-# For the non-secure version of the board, the firmware
-# must be linked into the code-partition (non-secure) defined in DT, regardless.
-# Apply this configuration below by setting the Kconfig symbols used by
-# the linker according to the information extracted from DT partitions.
-
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-	depends on BOARD_NRF9151DK_NRF9151 && TRUSTED_EXECUTION_SECURE
-
-if BOARD_NRF9151DK_NRF9151_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_NRF9151DK_NRF9151_NS
+config BOARD_NRF9151DK
+	select USE_DT_CODE_PARTITION if BOARD_NRF9151DK_NRF9151_NS
 
 config BT_HCI_VS
 	default y if BT

--- a/boards/nordic/nrf9160dk/Kconfig.defconfig
+++ b/boards/nordic/nrf9160dk/Kconfig.defconfig
@@ -5,32 +5,8 @@
 
 if BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160_NS
 
-# For the secure version of the board the firmware is linked at the beginning
-# of the flash, or into the code-partition defined in DT if it is intended to
-# be loaded by MCUboot. If the secure firmware is to be combined with a non-
-# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
-# be restricted to the size of its code partition.
-# For the non-secure version of the board, the firmware
-# must be linked into the code-partition (non-secure) defined in DT, regardless.
-# Apply this configuration below by setting the Kconfig symbols used by
-# the linker according to the information extracted from DT partitions.
-
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-	depends on BOARD_NRF9160DK_NRF9160 && TRUSTED_EXECUTION_SECURE
-
-if BOARD_NRF9160DK_NRF9160_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_NRF9160DK_NRF9160_NS
+config BOARD_NRF9160DK
+	select USE_DT_CODE_PARTITION if BOARD_NRF9160DK_NRF9160_NS
 
 config BT_HCI_VS
 	default y if BT

--- a/boards/nordic/nrf9161dk/Kconfig.defconfig
+++ b/boards/nordic/nrf9161dk/Kconfig.defconfig
@@ -5,32 +5,8 @@
 
 if BOARD_NRF9161DK_NRF9161 || BOARD_NRF9161DK_NRF9161_NS
 
-# For the secure version of the board the firmware is linked at the beginning
-# of the flash, or into the code-partition defined in DT if it is intended to
-# be loaded by MCUboot. If the secure firmware is to be combined with a non-
-# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
-# be restricted to the size of its code partition.
-# For the non-secure version of the board, the firmware
-# must be linked into the code-partition (non-secure) defined in DT, regardless.
-# Apply this configuration below by setting the Kconfig symbols used by
-# the linker according to the information extracted from DT partitions.
-
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-	depends on BOARD_NRF9161DK_NRF9161 && TRUSTED_EXECUTION_SECURE
-
-if BOARD_NRF9161DK_NRF9161_NS
-
-config FLASH_LOAD_OFFSET
-	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-config FLASH_LOAD_SIZE
-	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
-
-endif # BOARD_NRF9161DK_NRF9161_NS
+config BOARD_NRF9161DK
+	select USE_DT_CODE_PARTITION if BOARD_NRF9161DK_NRF9161_NS
 
 config BT_HCI_VS
 	default y if BT


### PR DESCRIPTION
Replaces using an odd mix of Kconfig dts for partition offsets with just use dts for non-secure board targets