### PR TITLE
net: lwm2m: Stop the LwM2M engine in case of fatal network error

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -391,6 +391,7 @@ static void socket_fault_cb(int error)
 		sm_handle_timeout_state(ENGINE_NETWORK_ERROR);
 	} else if (client.engine_state != ENGINE_SUSPENDED &&
 		   !client.server_disabled) {
+		lwm2m_engine_stop(client.ctx);
 		sm_handle_timeout_state(ENGINE_IDLE);
 	}
 }
@@ -1413,6 +1414,7 @@ static void sm_do_network_error(void)
 stop_engine:
 
 	/* We are out of options, stop engine */
+	lwm2m_engine_stop(client.ctx);
 	if (client.ctx->event_cb) {
 		if (client.ctx->bootstrap_mode) {
 			client.ctx->event_cb(client.ctx,


### PR DESCRIPTION
In case of fatal network error (i.e. when the LwM2M client runs out of retries), call lwm2m_engine_stop() to cleanup any allocated resources for the client. The engine is dead at that point anyway so the application needs to recover.

If this isn't done, it is theoretically possible to restart the LwM2M client (with lwm2m_rd_client_start() which does not report an error in such case), which in turn could lead to resource leaks (like for example the observer list is reinitialized) if the application didn't call lwm2m_rd_client_stop() first. Calling lwm2m_engine_stop() ensures that all resources are freed even if the application doesn't call stop before restarting.

Potentially fixes #91383