### PR TITLE
drivers: sensor: asahi_kasei: akm09918c: Null check before dereference

### DIFF
--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
@@ -138,15 +138,16 @@ void akm09918_async_fetch(struct k_work *work)
 
 	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(data->rtio_ctx);
 
-	rtio_sqe_prep_callback_no_cqe(cb_sqe, akm09918_complete_cb, (void *)ctx->iodev_sqe, NULL);
-
-	if (burstRead_sqe != NULL && cb_sqe != NULL) {
-		burstRead_sqe->flags |= RTIO_SQE_CHAINED;
-		rtio_submit(data->rtio_ctx, 0);
-	} else {
+	if (burstRead_sqe == NULL || cb_sqe == NULL) {
 		rtio_sqe_drop_all(data->rtio_ctx);
 		rtio_iodev_sqe_err(ctx->iodev_sqe, -ENOMEM);
+		return;
 	}
+
+	rtio_sqe_prep_callback_no_cqe(cb_sqe, akm09918_complete_cb, (void *)ctx->iodev_sqe, NULL);
+
+	burstRead_sqe->flags |= RTIO_SQE_CHAINED;
+	rtio_submit(data->rtio_ctx, 0);
 }
 
 void akm09918_complete_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg0)


### PR DESCRIPTION
cb_sqe could have been NULL before being passed into the callback function, which expects cb_sqe to be non-NULL.

Add NULL check before the callback function with cb_sqe is called. The reordering of the callback function after the sqe drop is okay as the sqe drop is called when cb_sqe is NULL and the callback function isn't expected to work when cb_sqe is NULL.

Fixes: #90536 