### PR TITLE
tests: do not use "sanity" word

### DIFF
--- a/tests/arch/xtensa/save_restore_hifi/src/main.c
+++ b/tests/arch/xtensa/save_restore_hifi/src/main.c
@@ -54,7 +54,7 @@ static void thread_entry(void *p1, void *p2, void *p3)
 	}
 }
 
-ZTEST(hifi, test_register_sanity)
+ZTEST(hifi, test_register_coherence)
 {
 	int       priority;
 	uint32_t  i;

--- a/tests/boards/intel_adsp/cache/src/main.c
+++ b/tests/boards/intel_adsp/cache/src/main.c
@@ -18,7 +18,7 @@ ZTEST(adsp_cache, test_adsp_cache_flush_inv_all)
 	*cached = 42;
 	*uncached = 40;
 
-	/* Just some sanity checks */
+	/* Just some coherence checks */
 	zassert_equal(*cached, 42);
 	zassert_equal(*uncached, 40);
 

--- a/tests/drivers/mm/sys_mm_drv_api/src/main.c
+++ b/tests/drivers/mm/sys_mm_drv_api/src/main.c
@@ -6,7 +6,7 @@
 #include <zephyr/ztest.h>
 #include <zephyr/drivers/mm/system_mm.h>
 
-ZTEST(sys_mm_drv_api, test_query_memory_region_sanity)
+ZTEST(sys_mm_drv_api, test_query_memory_region_coherence)
 {
 	const struct sys_mm_drv_region *regions, *region;
 

--- a/tests/kernel/obj_tracking/src/main.c
+++ b/tests/kernel/obj_tracking/src/main.c
@@ -27,7 +27,7 @@ char __aligned(4) slab_buffer[8 * 4];
 stack_data_t stack_array[8 * 4];
 int msgq_buffer[64];
 
-ZTEST(obj_tracking, test_obj_tracking_sanity)
+ZTEST(obj_tracking, test_obj_tracking_coherence)
 {
 	struct k_timer timer;
 	struct k_mem_slab slab;

--- a/tests/lib/cbprintf_fp/README.txt
+++ b/tests/lib/cbprintf_fp/README.txt
@@ -6,7 +6,7 @@ minimal libc and newlib versions with printk, printf, and cbprintf.
 
 Footprint data can be obtained with:
 
-    for f in sanity-out/*/tests/lib/cbprintf_fp/benchmark.cbprintf_fp.*/build.log ; do
+    for f in coherence-out/*/tests/lib/cbprintf_fp/benchmark.cbprintf_fp.*/build.log ; do
       basename $(dirname $f)
       sed -n '/Memory/,/^\[/p' < $f
     done

--- a/tests/modules/nanopb/src/main.c
+++ b/tests/modules/nanopb/src/main.c
@@ -30,7 +30,7 @@ ZTEST(nanopb_tests, test_nanopb_simple)
 	zassert_true(pb_encode(&ostream, SimpleMessage_fields, &msg),
 		     "Encoding failed: %s", PB_GET_ERROR(&ostream));
 
-	/* Sanity check, clear data */
+	/* Coherence check, clear data */
 	memset(&msg, 0, sizeof(SimpleMessage));
 
 	pb_istream_t istream = pb_istream_from_buffer(buffer, ostream.bytes_written);
@@ -57,7 +57,7 @@ ZTEST(nanopb_tests, test_nanopb_nested)
 	zassert_true(pb_encode(&ostream, ComplexMessage_fields, &msg),
 		     "Encoding failed: %s", PB_GET_ERROR(&ostream));
 
-	/* Sanity check, clear data */
+	/* Coherence check, clear data */
 	memset(&msg, 0, sizeof(ComplexMessage));
 
 	pb_istream_t istream = pb_istream_from_buffer(buffer, ostream.bytes_written);

--- a/tests/net/icmp/src/main.c
+++ b/tests/net/icmp/src/main.c
@@ -188,7 +188,7 @@ static int get_ipv4_reply(struct net_if *iface,
 
 	/* The code below should not be used in real life scenarios
 	 * as it is missing filling the ICMP params etc. We just create
-	 * a basic IPv4 header here in order to pass sanity checks
+	 * a basic IPv4 header here in order to pass coherence checks
 	 * in IP packet parsing.
 	 */
 	reply = net_pkt_alloc_with_buffer(iface, sizeof(struct net_ipv4_hdr) +

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -559,7 +559,7 @@ ZTEST_F(nvs, test_nvs_full_sector)
 	len = nvs_write(&fixture->fs, filling_id, &filling_id, sizeof(filling_id));
 	zassert_true(len == sizeof(filling_id), "nvs_write failed: %d", len);
 
-	/* sanitycheck on NVS content */
+	/* coherence check on NVS content */
 	for (i = 0; i <= filling_id; i++) {
 		len = nvs_read(&fixture->fs, i, &data_read, sizeof(data_read));
 		if (i == 1) {

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -487,7 +487,7 @@ ZTEST_F(zms, test_zms_full_sector)
 	len = zms_write(&fixture->fs, filling_id, &filling_id, sizeof(filling_id));
 	zassert_true(len == sizeof(filling_id), "zms_write failed: %d", len);
 
-	/* sanitycheck on ZMS content */
+	/* coherence check on ZMS content */
 	for (int i = 0; i <= filling_id; i++) {
 		len = zms_read(&fixture->fs, i, &data_read, sizeof(data_read));
 		if (i == 1) {

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -22,7 +22,7 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 	switch (sleep_count) {
 	case 1:
-		/* Just  a sanity check that the system is the right state.
+		/* Just  a coherence check that the system is the right state.
 		 * Devices are suspended before SoC on PM_STATE_SUSPEND_TO_RAM, that is why
 		 * we can check the device state here.
 		 */


### PR DESCRIPTION
Fix to align with guidelines regarding the use of inclusive language.