### PR TITLE
Revert "modules: nrf_wifi: Disable anomalies for both QSPIs"

### DIFF
--- a/modules/nrf_wifi/bus/CMakeLists.txt
+++ b/modules/nrf_wifi/bus/CMakeLists.txt
@@ -8,18 +8,16 @@ set(NRF_WIFI_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
 if (CONFIG_NRF70_BUSLIB)
 
-  if(CONFIG_NRF70_ON_QSPI OR CONFIG_NORDIC_QSPI_NOR)
-    zephyr_compile_definitions(
-    # These are XIP related anomalies and aren't applicable for nRF7002 and cause
-    # throughput issues.
-      -DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
-      -DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
-    # nRF70 QSPI doesn't use 192MHz clock and most samples use 128MHz, this can cause anomaly 159
-    # but as its rare and not seen in most cases, we can disable it.
-    # Alternative is 128MHz CPU should be disabled that impacts Wi-Fi performance.
-      -DNRF53_ERRATA_159_ENABLE_WORKAROUND=0
-    )
-  endif()
+  zephyr_compile_definitions_ifdef(CONFIG_NRF70_ON_QSPI
+  # These are XIP related anomalies and aren't applicable for nRF7002 and cause
+  # throughput issues.
+    -DNRF53_ERRATA_43_ENABLE_WORKAROUND=0
+    -DNRF52_ERRATA_215_ENABLE_WORKAROUND=0
+  # nRF70 QSPI doesn't use 192MHz clock and most samples use 128MHz, this can cause anomaly 159
+  # but as its rare and not seen in most cases, we can disable it.
+  # Alternative is 128MHz CPU should be disabled that impacts Wi-Fi performance.
+    -DNRF53_ERRATA_159_ENABLE_WORKAROUND=0
+  )
 
   zephyr_library_named(nrf70-buslib)
   zephyr_library_include_directories(


### PR DESCRIPTION
Revert "modules: nrf_wifi: Disable anomalies for both QSPIs"

This reverts commit 4660f4c2445bb3e4f91d1edac51a772714f23b6d.

The reverted commit disabled workarounds for XIP-related anomalies for
configurations where CONFIG_NORDIC_QSPI_NOR was enabled. This caused
memory issues on custom boards that were using a combination of nRF5340
SOC, nRF7002 WiFi chip and XIP over QSPI.

Memory issues manifested as usage faults, where the PC in the esf
pointer given to the k_sys_fatal_error_handler would always point to
an address somewhere in the external flash, however the address would
slightly change between reboots.

The memory issues were discovered during NCS migration, migrating from
v2.7.0 to v3.0.1.

By reverting the commit we re-enable the workarounds for the cases where
CONFIG_NORDIC_QSPI_NOR is enabled.



---

Tagging @krish2718, as he will probably have the most knowledge if this revert makes sense.

I have also found a recent DevZone issue that was solved by applying the 159 workaround, although their symptoms looked different from mine: https://devzone.nordicsemi.com/f/nordic-q-a/122110/nrf5340-nrfx_qspi-sdk-v3-0-1-peripheral-issue/538508