### PR TITLE
drivers: mipi_dbi: spi: add tearing effect support

### DIFF
--- a/boards/shields/x_nucleo_gfx01m2/x_nucleo_gfx01m2.overlay
+++ b/boards/shields/x_nucleo_gfx01m2/x_nucleo_gfx01m2.overlay
@@ -56,6 +56,7 @@
 		compatible = "zephyr,mipi-dbi-spi";
 		spi-dev = <&st_morpho_lcd_spi>;
 		dc-gpios = <&st_morpho_header ST_MORPHO_R_25 GPIO_ACTIVE_HIGH>;
+		te-gpios = <&st_morpho_header ST_MORPHO_L_28 GPIO_ACTIVE_HIGH>;
 		reset-gpios = <&st_morpho_header ST_MORPHO_L_30 GPIO_ACTIVE_LOW>;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -65,6 +66,10 @@
 			compatible = "ilitek,ili9341";
 			mipi-max-frequency = <DT_FREQ_M(32)>;
 			mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
+			/* Transmit on falling edge to avoid tearing, since display
+			 * reads pixels faster than we can transfer.
+			 */
+			te-mode = "MIPI_DBI_TE_FALLING_EDGE";
 			reg = <0>;
 			width = <240>;
 			height = <320>;

--- a/drivers/display/display_ili9xxx.h
+++ b/drivers/display/display_ili9xxx.h
@@ -24,6 +24,7 @@
 #define ILI9XXX_RAMWR 0x2c
 #define ILI9XXX_RGBSET 0x2d
 #define ILI9XXX_RAMRD 0x2e
+#define ILI9XXX_TEON 0x35
 #define ILI9XXX_MADCTL 0x36
 #define ILI9XXX_PIXSET 0x3A
 #define ILI9XXX_RAMRD_CONT 0x3e
@@ -74,6 +75,7 @@ struct ili9xxx_config {
 	uint16_t x_resolution;
 	uint16_t y_resolution;
 	bool inversion;
+	uint8_t te_mode;
 	const void *regs;
 	int (*regs_init_fn)(const struct device *dev);
 };

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -4,7 +4,11 @@
 
 description: ILI9XXX display controllers common properties.
 
-include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
+include:
+  - display-controller.yaml
+  - name: mipi-dbi-spi-device.yaml
+    property-blocklist:
+      - te-delay
 
 properties:
   pixel-format:

--- a/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
+++ b/dts/bindings/mipi-dbi/zephyr,mipi-dbi-spi.yaml
@@ -22,6 +22,12 @@ properties:
       Data/command gpio pin. Required when using 4 wire SPI mode (Mode C1).
       Set to low when sending a command, or high when sending data.
 
+  te-gpios:
+    type: phandle-array
+    description: |
+      Tearing Effect GPIO pin. Set to high when the display is blanking
+      (i.e., not actively reading pixels from its RAM).
+
   reset-gpios:
     type: phandle-array
     description: |


### PR DESCRIPTION
Add tearing effect support for better display synchronization. This
allows users to configure an external interrupt on falling/rising edges
of the gpio connected to the display controllers tearing effect pin.
See dt-bindings/mipi_dbi/mipi_dbi.h for details of how this works for
mipi_dbi display interfaces.