### PR TITLE
Add GPIO support for i.MX943 M33

### DIFF
--- a/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
+++ b/boards/nxp/imx943_evk/imx943_evk_mimx94398_m33.yaml
@@ -16,4 +16,5 @@ toolchain:
 supported:
   - uart
   - netif:eth
+  - gpio
 vendor: nxp

--- a/dts/arm/nxp/nxp_imx943_m33.dtsi
+++ b/dts/arm/nxp/nxp_imx943_m33.dtsi
@@ -70,6 +70,11 @@
 					compatible = "nxp,imx943-pinctrl", "nxp,imx93-pinctrl";
 				};
 			};
+
+			scmi_cpu: protocol@82 {
+				compatible = "nxp,scmi-cpu";
+				reg = <0x82>;
+			};
 		};
 	};
 

--- a/dts/arm/nxp/nxp_imx943_m33.dtsi
+++ b/dts/arm/nxp/nxp_imx943_m33.dtsi
@@ -169,6 +169,67 @@
 			status = "disabled";
 		};
 
+		gpio2: gpio@43810000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43810000 DT_SIZE_K(64)>;
+			interrupts = <54 0>, <55 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <32>;
+			status = "disabled";
+		};
+
+		gpio3: gpio@43820000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43820000 DT_SIZE_K(64)>;
+			interrupts = <56 0>, <57 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <26>;
+			status = "disabled";
+		};
+
+		gpio4: gpio@43840000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43840000 DT_SIZE_K(64)>;
+			interrupts = <58 0>, <59 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <32>;
+			status = "disabled";
+		};
+
+		gpio5: gpio@43850000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43850000 DT_SIZE_K(64)>;
+			interrupts = <60 0>, <61 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <32>;
+			status = "disabled";
+		};
+
+		gpio6: gpio@43860000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43860000 DT_SIZE_K(64)>;
+			interrupts = <62 0>, <63 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <32>;
+			status = "disabled";
+		};
+
+		gpio7: gpio@43870000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x43870000 DT_SIZE_K(64)>;
+			interrupts = <64 0>, <65 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <28>;
+			gpio-reserved-ranges = <10 6>;
+			status = "disabled";
+		};
+
 		lpuart1: serial@44380000 {
 			compatible = "nxp,imx-lpuart", "nxp,lpuart";
 			reg = <0x44380000 DT_SIZE_K(64)>;
@@ -190,6 +251,16 @@
 			reg = <0x44720000 DT_SIZE_K(64)>;
 			interrupts = <273 0>;
 			#mbox-cells = <1>;
+		};
+
+		gpio1: gpio@47400000 {
+			compatible = "nxp,imx-rgpio";
+			reg = <0x47400000 DT_SIZE_K(64)>;
+			interrupts = <12 0>, <13 0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <16>;
+			status = "disabled";
 		};
 
 		netc: ethernet@4ca00000 {
@@ -237,4 +308,239 @@
 
 &nvic {
 	arm,num-irq-priority-bits = <4>;
+};
+
+/*
+ * GPIO pinmux options. These options define the pinmux settings
+ * for GPIO ports on the package, so that the GPIO driver can
+ * select GPIO mux options during GPIO configuration.
+ */
+
+&gpio1{
+	pinmux = <&iomuxc_i2c1_scl_gpio_io_gpio1_io0>,
+		<&iomuxc_i2c1_sda_gpio_io_gpio1_io1>,
+		<&iomuxc_i2c2_scl_gpio_io_gpio1_io2>,
+		<&iomuxc_i2c2_sda_gpio_io_gpio1_io3>,
+		<&iomuxc_uart1_rxd_gpio_io_gpio1_io4>,
+		<&iomuxc_uart1_txd_gpio_io_gpio1_io5>,
+		<&iomuxc_uart2_rxd_gpio_io_gpio1_io6>,
+		<&iomuxc_uart2_txd_gpio_io_gpio1_io7>,
+		<&iomuxc_pdm_clk_gpio_io_gpio1_io8>,
+		<&iomuxc_pdm_bit_stream0_gpio_io_gpio1_io9>,
+		<&iomuxc_pdm_bit_stream1_gpio_io_gpio1_io10>,
+		<&iomuxc_sai1_txfs_gpio_io_gpio1_io11>,
+		<&iomuxc_sai1_txc_gpio_io_gpio1_io12>,
+		<&iomuxc_sai1_txd0_gpio_io_gpio1_io13>,
+		<&iomuxc_sai1_rxd0_gpio_io_gpio1_io14>,
+		<&iomuxc_wdog_any_gpio_io_gpio1_io15>;
+};
+
+&gpio2{
+	pinmux = <&iomuxc_gpio_io00_gpio_io_gpio2_io0>,
+		<&iomuxc_gpio_io01_gpio_io_gpio2_io1>,
+		<&iomuxc_gpio_io02_gpio_io_gpio2_io2>,
+		<&iomuxc_gpio_io03_gpio_io_gpio2_io3>,
+		<&iomuxc_gpio_io04_gpio_io_gpio2_io4>,
+		<&iomuxc_gpio_io05_gpio_io_gpio2_io5>,
+		<&iomuxc_gpio_io06_gpio_io_gpio2_io6>,
+		<&iomuxc_gpio_io07_gpio_io_gpio2_io7>,
+		<&iomuxc_gpio_io08_gpio_io_gpio2_io8>,
+		<&iomuxc_gpio_io09_gpio_io_gpio2_io9>,
+		<&iomuxc_gpio_io10_gpio_io_gpio2_io10>,
+		<&iomuxc_gpio_io11_gpio_io_gpio2_io11>,
+		<&iomuxc_gpio_io12_gpio_io_gpio2_io12>,
+		<&iomuxc_gpio_io13_gpio_io_gpio2_io13>,
+		<&iomuxc_gpio_io14_gpio_io_gpio2_io14>,
+		<&iomuxc_gpio_io15_gpio_io_gpio2_io15>,
+		<&iomuxc_gpio_io16_gpio_io_gpio2_io16>,
+		<&iomuxc_gpio_io17_gpio_io_gpio2_io17>,
+		<&iomuxc_gpio_io18_gpio_io_gpio2_io18>,
+		<&iomuxc_gpio_io19_gpio_io_gpio2_io19>,
+		<&iomuxc_gpio_io20_gpio_io_gpio2_io20>,
+		<&iomuxc_gpio_io21_gpio_io_gpio2_io21>,
+		<&iomuxc_gpio_io22_gpio_io_gpio2_io22>,
+		<&iomuxc_gpio_io23_gpio_io_gpio2_io23>,
+		<&iomuxc_gpio_io24_gpio_io_gpio2_io24>,
+		<&iomuxc_gpio_io25_gpio_io_gpio2_io25>,
+		<&iomuxc_gpio_io26_gpio_io_gpio2_io26>,
+		<&iomuxc_gpio_io27_gpio_io_gpio2_io27>,
+		<&iomuxc_gpio_io28_gpio_io_gpio2_io28>,
+		<&iomuxc_gpio_io29_gpio_io_gpio2_io29>,
+		<&iomuxc_gpio_io30_gpio_io_gpio2_io30>,
+		<&iomuxc_gpio_io31_gpio_io_gpio2_io31>;
+};
+
+&gpio3{
+	pinmux = <&iomuxc_gpio_io32_gpio_io_gpio3_io0>,
+		<&iomuxc_gpio_io33_gpio_io_gpio3_io1>,
+		<&iomuxc_gpio_io34_gpio_io_gpio3_io2>,
+		<&iomuxc_gpio_io35_gpio_io_gpio3_io3>,
+		<&iomuxc_gpio_io36_gpio_io_gpio3_io4>,
+		<&iomuxc_gpio_io37_gpio_io_gpio3_io5>,
+		<&iomuxc_gpio_io38_gpio_io_gpio3_io6>,
+		<&iomuxc_gpio_io39_gpio_io_gpio3_io7>,
+		<&iomuxc_gpio_io40_gpio_io_gpio3_io8>,
+		<&iomuxc_gpio_io41_gpio_io_gpio3_io9>,
+		<&iomuxc_gpio_io42_gpio_io_gpio3_io10>,
+		<&iomuxc_gpio_io43_gpio_io_gpio3_io11>,
+		<&iomuxc_gpio_io44_gpio_io_gpio3_io12>,
+		<&iomuxc_gpio_io45_gpio_io_gpio3_io13>,
+		<&iomuxc_gpio_io46_gpio_io_gpio3_io14>,
+		<&iomuxc_gpio_io47_gpio_io_gpio3_io15>,
+		<&iomuxc_gpio_io48_gpio_io_gpio3_io16>,
+		<&iomuxc_gpio_io49_gpio_io_gpio3_io17>,
+		<&iomuxc_gpio_io50_gpio_io_gpio3_io18>,
+		<&iomuxc_gpio_io51_gpio_io_gpio3_io19>,
+		<&iomuxc_gpio_io52_gpio_io_gpio3_io20>,
+		<&iomuxc_gpio_io53_gpio_io_gpio3_io21>,
+		<&iomuxc_gpio_io54_gpio_io_gpio3_io22>,
+		<&iomuxc_gpio_io55_gpio_io_gpio3_io23>,
+		<&iomuxc_gpio_io56_gpio_io_gpio3_io24>,
+		<&iomuxc_gpio_io57_gpio_io_gpio3_io25>;
+};
+
+&gpio4{
+	pinmux = <&iomuxc_ccm_clko1_gpio_io_gpio4_io0>,
+		<&iomuxc_ccm_clko2_gpio_io_gpio4_io1>,
+		<&iomuxc_ccm_clko3_gpio_io_gpio4_io2>,
+		<&iomuxc_ccm_clko4_gpio_io_gpio4_io3>,
+		<&iomuxc_dap_tdi_gpio_io_gpio4_io4>,
+		<&iomuxc_dap_tms_swdio_gpio_io_gpio4_io5>,
+		<&iomuxc_dap_tclk_swclk_gpio_io_gpio4_io6>,
+		<&iomuxc_dap_tdo_traceswo_gpio_io_gpio4_io7>,
+		<&iomuxc_sd1_clk_gpio_io_gpio4_io8>,
+		<&iomuxc_sd1_cmd_gpio_io_gpio4_io9>,
+		<&iomuxc_sd1_data0_gpio_io_gpio4_io10>,
+		<&iomuxc_sd1_data1_gpio_io_gpio4_io11>,
+		<&iomuxc_sd1_data2_gpio_io_gpio4_io12>,
+		<&iomuxc_sd1_data3_gpio_io_gpio4_io13>,
+		<&iomuxc_sd1_data4_gpio_io_gpio4_io14>,
+		<&iomuxc_sd1_data5_gpio_io_gpio4_io15>,
+		<&iomuxc_sd1_data6_gpio_io_gpio4_io16>,
+		<&iomuxc_sd1_data7_gpio_io_gpio4_io17>,
+		<&iomuxc_sd1_strobe_gpio_io_gpio4_io18>,
+		<&iomuxc_sd2_vselect_gpio_io_gpio4_io19>,
+		<&iomuxc_sd2_cd_b_gpio_io_gpio4_io20>,
+		<&iomuxc_sd2_clk_gpio_io_gpio4_io21>,
+		<&iomuxc_sd2_cmd_gpio_io_gpio4_io22>,
+		<&iomuxc_sd2_data0_gpio_io_gpio4_io23>,
+		<&iomuxc_sd2_data1_gpio_io_gpio4_io24>,
+		<&iomuxc_sd2_data2_gpio_io_gpio4_io25>,
+		<&iomuxc_sd2_data3_gpio_io_gpio4_io26>,
+		<&iomuxc_sd2_reset_b_gpio_io_gpio4_io27>,
+		<&iomuxc_sd2_gpio0_gpio_io_gpio4_io28>,
+		<&iomuxc_sd2_gpio1_gpio_io_gpio4_io29>,
+		<&iomuxc_sd2_gpio2_gpio_io_gpio4_io30>,
+		<&iomuxc_sd2_gpio3_gpio_io_gpio4_io31>;
+};
+
+&gpio5{
+	pinmux = <&iomuxc_eth0_txd0_gpio_io_gpio5_io0>,
+		<&iomuxc_eth0_txd1_gpio_io_gpio5_io1>,
+		<&iomuxc_eth0_tx_en_gpio_io_gpio5_io2>,
+		<&iomuxc_eth0_tx_clk_gpio_io_gpio5_io3>,
+		<&iomuxc_eth0_rxd0_gpio_io_gpio5_io4>,
+		<&iomuxc_eth0_rxd1_gpio_io_gpio5_io5>,
+		<&iomuxc_eth0_rx_dv_gpio_io_gpio5_io6>,
+		<&iomuxc_eth0_txd2_gpio_io_gpio5_io7>,
+		<&iomuxc_eth0_txd3_gpio_io_gpio5_io8>,
+		<&iomuxc_eth0_rxd2_gpio_io_gpio5_io9>,
+		<&iomuxc_eth0_rxd3_gpio_io_gpio5_io10>,
+		<&iomuxc_eth0_rx_clk_gpio_io_gpio5_io11>,
+		<&iomuxc_eth0_rx_er_gpio_io_gpio5_io12>,
+		<&iomuxc_eth0_tx_er_gpio_io_gpio5_io13>,
+		<&iomuxc_eth0_crs_gpio_io_gpio5_io14>,
+		<&iomuxc_eth0_col_gpio_io_gpio5_io15>,
+		<&iomuxc_eth1_txd0_gpio_io_gpio5_io16>,
+		<&iomuxc_eth1_txd1_gpio_io_gpio5_io17>,
+		<&iomuxc_eth1_tx_en_gpio_io_gpio5_io18>,
+		<&iomuxc_eth1_tx_clk_gpio_io_gpio5_io19>,
+		<&iomuxc_eth1_rxd0_gpio_io_gpio5_io20>,
+		<&iomuxc_eth1_rxd1_gpio_io_gpio5_io21>,
+		<&iomuxc_eth1_rx_dv_gpio_io_gpio5_io22>,
+		<&iomuxc_eth1_txd2_gpio_io_gpio5_io23>,
+		<&iomuxc_eth1_txd3_gpio_io_gpio5_io24>,
+		<&iomuxc_eth1_rxd2_gpio_io_gpio5_io25>,
+		<&iomuxc_eth1_rxd3_gpio_io_gpio5_io26>,
+		<&iomuxc_eth1_rx_clk_gpio_io_gpio5_io27>,
+		<&iomuxc_eth1_rx_er_gpio_io_gpio5_io28>,
+		<&iomuxc_eth1_tx_er_gpio_io_gpio5_io29>,
+		<&iomuxc_eth1_crs_gpio_io_gpio5_io30>,
+		<&iomuxc_eth1_col_gpio_io_gpio5_io31>;
+};
+
+&gpio6{
+	pinmux = <&iomuxc_eth2_mdc_gpio1_gpio_io_gpio6_io0>,
+		<&iomuxc_eth2_mdio_gpio2_gpio_io_gpio6_io1>,
+		<&iomuxc_eth2_txd3_gpio_io_gpio6_io2>,
+		<&iomuxc_eth2_txd2_gpio_io_gpio6_io3>,
+		<&iomuxc_eth2_txd1_gpio_io_gpio6_io4>,
+		<&iomuxc_eth2_txd0_gpio_io_gpio6_io5>,
+		<&iomuxc_eth2_tx_ctl_gpio_io_gpio6_io6>,
+		<&iomuxc_eth2_tx_clk_gpio_io_gpio6_io7>,
+		<&iomuxc_eth2_rx_ctl_gpio_io_gpio6_io8>,
+		<&iomuxc_eth2_rx_clk_gpio_io_gpio6_io9>,
+		<&iomuxc_eth2_rxd0_gpio_io_gpio6_io10>,
+		<&iomuxc_eth2_rxd1_gpio_io_gpio6_io11>,
+		<&iomuxc_eth2_rxd2_gpio_io_gpio6_io12>,
+		<&iomuxc_eth2_rxd3_gpio_io_gpio6_io13>,
+		<&iomuxc_eth3_mdc_gpio1_gpio_io_gpio6_io14>,
+		<&iomuxc_eth3_mdio_gpio2_gpio_io_gpio6_io15>,
+		<&iomuxc_eth3_txd3_gpio_io_gpio6_io16>,
+		<&iomuxc_eth3_txd2_gpio_io_gpio6_io17>,
+		<&iomuxc_eth3_txd1_gpio_io_gpio6_io18>,
+		<&iomuxc_eth3_txd0_gpio_io_gpio6_io19>,
+		<&iomuxc_eth3_tx_ctl_gpio_io_gpio6_io20>,
+		<&iomuxc_eth3_tx_clk_gpio_io_gpio6_io21>,
+		<&iomuxc_eth3_rx_ctl_gpio_io_gpio6_io22>,
+		<&iomuxc_eth3_rx_clk_gpio_io_gpio6_io23>,
+		<&iomuxc_eth3_rxd0_gpio_io_gpio6_io24>,
+		<&iomuxc_eth3_rxd1_gpio_io_gpio6_io25>,
+		<&iomuxc_eth3_rxd2_gpio_io_gpio6_io26>,
+		<&iomuxc_eth3_rxd3_gpio_io_gpio6_io27>,
+		<&iomuxc_eth4_mdc_gpio1_gpio_io_gpio6_io28>,
+		<&iomuxc_eth4_mdio_gpio2_gpio_io_gpio6_io29>,
+		<&iomuxc_eth4_tx_clk_gpio_io_gpio6_io30>,
+		<&iomuxc_eth4_tx_ctl_gpio_io_gpio6_io31>;
+};
+
+/*
+ * Use the NULL pinmux for the GPIO io port which is not available to
+ * make the driver to be easy.
+ */
+&scmi_iomuxc {
+	/omit-if-no-ref/ null_pinmux: NULL_PINMUX {
+		pinmux = <0x0 0 0x0 0 0x0>;
+	};
+};
+
+&gpio7{
+	pinmux = <&iomuxc_eth4_txd0_gpio_io_gpio7_io0>,
+		<&iomuxc_eth4_txd1_gpio_io_gpio7_io1>,
+		<&iomuxc_eth4_txd2_gpio_io_gpio7_io2>,
+		<&iomuxc_eth4_txd3_gpio_io_gpio7_io3>,
+		<&iomuxc_eth4_rxd0_gpio_io_gpio7_io4>,
+		<&iomuxc_eth4_rxd1_gpio_io_gpio7_io5>,
+		<&iomuxc_eth4_rxd2_gpio_io_gpio7_io6>,
+		<&iomuxc_eth4_rxd3_gpio_io_gpio7_io7>,
+		<&iomuxc_eth4_rx_ctl_gpio_io_gpio7_io8>,
+		<&iomuxc_eth4_rx_clk_gpio_io_gpio7_io9>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&null_pinmux>,
+		<&iomuxc_xspi1_data0_gpio_io_gpio7_io16>,
+		<&iomuxc_xspi1_data1_gpio_io_gpio7_io17>,
+		<&iomuxc_xspi1_data2_gpio_io_gpio7_io18>,
+		<&iomuxc_xspi1_data3_gpio_io_gpio7_io19>,
+		<&iomuxc_xspi1_data4_gpio_io_gpio7_io20>,
+		<&iomuxc_xspi1_data5_gpio_io_gpio7_io21>,
+		<&iomuxc_xspi1_data6_gpio_io_gpio7_io22>,
+		<&iomuxc_xspi1_data7_gpio_io_gpio7_io23>,
+		<&iomuxc_xspi1_dqs_gpio_io_gpio7_io24>,
+		<&iomuxc_xspi1_sclk_gpio_io_gpio7_io25>,
+		<&iomuxc_xspi1_ss0_b_gpio_io_gpio7_io26>,
+		<&iomuxc_xspi1_ss1_b_gpio_io_gpio7_io27>;
 };

--- a/soc/nxp/imx/imx9/imx943/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.c
@@ -9,6 +9,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/firmware/scmi/clk.h>
 #include <zephyr/drivers/firmware/scmi/power.h>
+#include <zephyr/drivers/firmware/scmi/nxp/cpu.h>
 #include <zephyr/dt-bindings/clock/imx943_clock.h>
 #include <zephyr/dt-bindings/power/imx943_power.h>
 #include <soc.h>
@@ -43,6 +44,9 @@ static int soc_netc_clock_init(int clk_id)
 
 static int soc_init(void)
 {
+#if defined(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS)
+	struct scmi_cpu_sleep_mode_config cpu_cfg = {0};
+#endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
 	int ret = 0;
 
 #if defined(CONFIG_ETH_NXP_IMX_NETC) && (DT_CHILD_NUM_STATUS_OKAY(DT_NODELABEL(netc)) != 0)
@@ -101,6 +105,15 @@ static int soc_init(void)
 	}
 #endif
 
+#if defined(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS)
+	cpu_cfg.cpu_id = CPU_IDX_M33P_S;
+	cpu_cfg.sleep_mode = CPU_SLEEP_MODE_RUN;
+
+	ret = scmi_cpu_sleep_mode_set(&cpu_cfg);
+	if (ret) {
+		return ret;
+	}
+#endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
 	return ret;
 }
 

--- a/soc/nxp/imx/imx9/imx943/scmi_cpu_soc.h
+++ b/soc/nxp/imx/imx9/imx943/scmi_cpu_soc.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_NXP_IMX943_SCMI_CPU_SOC_H_
+#define ZEPHYR_NXP_IMX943_SCMI_CPU_SOC_H_
+
+#define CPU_IDX_M33P            0U
+#define CPU_IDX_M7P_0           1U
+#define CPU_IDX_A55C0           2U
+#define CPU_IDX_A55C1           3U
+#define CPU_IDX_A55C2           4U
+#define CPU_IDX_A55C3           5U
+#define CPU_IDX_A55P            6U
+#define CPU_IDX_M7P_1           7U
+#define CPU_IDX_M33P_S          8U
+
+#define CPU_SLEEP_MODE_RUN      0U
+#define CPU_SLEEP_MODE_WAIT     1U
+#define CPU_SLEEP_MODE_STOP     2U
+#define CPU_SLEEP_MODE_SUSPEND  3U
+
+#endif /* ZEPHYR_NXP_IMX943_SCMI_CPU_SOC_H_ */

--- a/tests/drivers/gpio/gpio_basic_api/boards/imx943_evk_mimx94398_m33.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/imx943_evk_mimx94398_m33.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/{
+	resources {
+		compatible = "test-gpio-basic-api";
+		/*
+		 * Use connector J44 Pin10 M1_LED_TP1 which connects to GPIO2 Pin31 as output
+		 * GPIO, and connector J52 Pin16 M1_PWM_PFC2 which connect to GPIO2 Pin21 as
+		 * input GPIO, connect these two pins with a Dupont Line.
+		 */
+		out-gpios = <&gpio2 31 0>;
+		in-gpios = <&gpio2 21 0>;
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};


### PR DESCRIPTION
This PR is to add GPIO support for i.MX943 M33.
Also, it addresses a problem that SYSTICK stops during CPU sleep to make the test case pass.

Thanks.