### PR TITLE
sca: Fix undefined behavior during preprocessing

### DIFF
--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -615,10 +615,8 @@ static int uart_console_init(void)
 }
 
 /* UART console initializes after the UART device itself */
-SYS_INIT(uart_console_init,
 #if defined(CONFIG_EARLY_CONSOLE)
-	 PRE_KERNEL_1,
+SYS_INIT(uart_console_init, PRE_KERNEL_1, CONFIG_CONSOLE_INIT_PRIORITY);
 #else
-	 POST_KERNEL,
-#endif
-	 CONFIG_CONSOLE_INIT_PRIORITY);
+SYS_INIT(uart_console_init, POST_KERNEL, CONFIG_CONSOLE_INIT_PRIORITY);
+#endif /* CONFIG_EARLY_CONSOLE */

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -902,16 +902,17 @@ static inline int z_impl_gpio_pin_interrupt_configure(const struct device *port,
 		 "Only one of GPIO_INT_LOW_0, GPIO_INT_HIGH_1 can be "
 		 "enabled for a level interrupt.");
 
-	__ASSERT(((flags & GPIO_INT_ENABLE) == 0) ||
 #ifdef CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT
-			 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) != 0) ||
-			 (flags & GPIO_INT_ENABLE_DISABLE_ONLY) != 0,
+#define GPIO_INT_ENABLE_DISABLE_ONLY_VALUE  GPIO_INT_ENABLE_DISABLE_ONLY
 #else
-			 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) != 0),
+#define GPIO_INT_ENABLE_DISABLE_ONLY_VALUE  0
 #endif /* CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT */
-		 "At least one of GPIO_INT_LOW_0, GPIO_INT_HIGH_1 has to be "
-		 "enabled.");
 
+	__ASSERT(((flags & GPIO_INT_ENABLE) == 0) ||
+			 ((flags & (GPIO_INT_LOW_0 | GPIO_INT_HIGH_1)) != 0) ||
+			 (flags & GPIO_INT_ENABLE_DISABLE_ONLY_VALUE) != 0,
+		 "At least one of GPIO_INT_LOW_0, GPIO_INT_HIGH_1 has to be enabled.");
+#undef GPIO_INT_ENABLE_DISABLE_ONLY_VALUE
 	__ASSERT((cfg->port_pin_mask & (gpio_port_pins_t)BIT(pin)) != 0U,
 		 "Unsupported pin");
 

--- a/include/zephyr/kernel/internal/mm.h
+++ b/include/zephyr/kernel/internal/mm.h
@@ -44,6 +44,25 @@
 #define K_MEM_VIRT_OFFSET	0
 #endif /* CONFIG_MMU */
 
+#if CONFIG_SRAM_BASE_ADDRESS != 0
+#define IS_SRAM_ADDRESS_LOWER(ADDR)  ((ADDR) >= CONFIG_SRAM_BASE_ADDRESS)
+#else
+#define IS_SRAM_ADDRESS_LOWER(ADDR)  true
+#endif /* CONFIG_SRAM_BASE_ADDRESS != 0 */
+
+
+#if (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0
+#define IS_SRAM_ADDRESS_UPPER(ADDR)              \
+	((ADDR) < (CONFIG_SRAM_BASE_ADDRESS +    \
+		  (CONFIG_SRAM_SIZE * 1024UL)))
+#else
+#define IS_SRAM_ADDRESS_UPPER(ADDR)  false
+#endif
+
+#define IS_SRAM_ADDRESS(ADDR)            \
+	(IS_SRAM_ADDRESS_LOWER(ADDR) &&  \
+	 IS_SRAM_ADDRESS_UPPER(ADDR))
+
 /**
  * @brief Get physical address from virtual address.
  *
@@ -115,16 +134,7 @@ static inline uintptr_t k_mem_phys_addr(void *virt)
 		 "address %p not in permanent mappings", virt);
 #else
 	/* Should be identity-mapped */
-	__ASSERT(
-#if CONFIG_SRAM_BASE_ADDRESS != 0
-		 (addr >= CONFIG_SRAM_BASE_ADDRESS) &&
-#endif /* CONFIG_SRAM_BASE_ADDRESS != 0 */
-#if (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0
-		 (addr < (CONFIG_SRAM_BASE_ADDRESS +
-			  (CONFIG_SRAM_SIZE * 1024UL))),
-#else
-		 false,
-#endif /* (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0 */
+	__ASSERT(IS_SRAM_ADDRESS(addr),
 		 "physical address 0x%lx not in RAM",
 		 (unsigned long)addr);
 #endif /* CONFIG_MMU */
@@ -153,16 +163,7 @@ static inline void *k_mem_virt_addr(uintptr_t phys)
 	__ASSERT(sys_mm_is_phys_addr_in_range(phys),
 		"physical address 0x%lx not in RAM", (unsigned long)phys);
 #else
-	__ASSERT(
-#if CONFIG_SRAM_BASE_ADDRESS != 0
-		 (phys >= CONFIG_SRAM_BASE_ADDRESS) &&
-#endif /* CONFIG_SRAM_BASE_ADDRESS != 0 */
-#if (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0
-		 (phys < (CONFIG_SRAM_BASE_ADDRESS +
-			  (CONFIG_SRAM_SIZE * 1024UL))),
-#else
-		 false,
-#endif /* (CONFIG_SRAM_BASE_ADDRESS + (CONFIG_SRAM_SIZE * 1024UL)) != 0 */
+	__ASSERT(IS_SRAM_ADDRESS(phys),
 		 "physical address 0x%lx not in RAM", (unsigned long)phys);
 #endif /* CONFIG_KERNEL_VM_USE_CUSTOM_MEM_RANGE_CHECK */
 


### PR DESCRIPTION
Fixes #92082 

According to the C standard it is undefined behavior to use preprocessor directives inside macro invocations.

Cppcheck stops when it see this UB with an error message, and so this change will improve Cppcheck analysis.

This is a refactoring to fix UB, no logical change is intended

Signed-off-by: Daniel Marjamäki <daniel.marjamaki@cppchecksolutions.com>
