### PR TITLE
boards: remove the adafruit_feather alias

### DIFF
--- a/boards/deprecated.cmake
+++ b/boards/deprecated.cmake
@@ -13,9 +13,6 @@
 # https://docs.zephyrproject.org/latest/develop/api/api_lifecycle.html#deprecated,
 # so these aliases are eventually removed
 
-set(adafruit_feather_DEPRECATED
-    adafruit_feather_nrf52840/nrf52840
-)
 set(arduino_uno_r4_minima_DEPRECATED
     arduino_uno_r4@minima
 )


### PR DESCRIPTION
Remove the adafruit_feather alias as it has been deprecated for 2 releases.
