### PR TITLE
arch: arm: cortex_m: linker: fix mpu setup failure when XIP disabled

### DIFF
--- a/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/cortex_m/scripts/linker.ld
@@ -225,7 +225,7 @@ SECTIONS
 
 #include <zephyr/linker/cplusplus-rom.ld>
 
-#if defined(CONFIG_BUILD_ALIGN_LMA)
+#if defined(CONFIG_BUILD_ALIGN_LMA) || !defined(CONFIG_XIP)
     /*
      * Include a padding section here to make sure that the LMA address
      * of the sections in the RAMABLE_REGION are aligned with those


### PR DESCRIPTION
RODATA must be the last section, so that the size of the entire read only region will be filled to a power of 2 for non-XIP systems, as required by the MPU alignment constraints.

Fix: https://github.com/zephyrproject-rtos/zephyr/issues/92066