### PR TITLE
soc: intel_adsp: fix debug window number

### DIFF
--- a/soc/intel/intel_adsp/common/include/adsp_debug_window.h
+++ b/soc/intel/intel_adsp/common/include/adsp_debug_window.h
@@ -74,7 +74,7 @@ struct adsp_dw_desc {
 struct adsp_debug_window {
 	struct adsp_dw_desc descs[ADSP_DW_DESC_COUNT];
 	uint8_t reserved[ADSP_DW_SLOT_SIZE - ADSP_DW_DESC_COUNT * sizeof(struct adsp_dw_desc)];
-	uint8_t slots[ADSP_DW_DESC_COUNT][ADSP_DW_SLOT_SIZE];
+	uint8_t slots[ADSP_DW_SLOT_COUNT][ADSP_DW_SLOT_SIZE];
 } __packed;
 
 #define WIN2_MBASE DT_REG_ADDR(DT_PHANDLE(DT_NODELABEL(mem_window2), memory))


### PR DESCRIPTION
Fixes: commit 5f4b51f9b179 ("soc: intel_adsp: add a debug window slot descriptor") - restore the maximum debug slot number. The added slot resides in page 0, not at the end of the array. The bug didn't have any run-time implications - no access to those high index value slots is performed, all platforms so far have 3 slots at most, so this is a pure correctness fix. Thanks to @ujfalusi for spotting