### PR TITLE
stm32:  tests: drivers: uart_async_api :  update uart_async_var_buf_length testsuite 

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nucleo_wba55cg.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nucleo_wba55cg.overlay
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&rcc {
+	clocks = <&clk_hsi>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};
+
 dut: &lpuart1 {
 	dmas = <&gpdma1 0 16 STM32_DMA_PERIPH_TX
 		&gpdma1 1 15 STM32_DMA_PERIPH_RX>;

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -1068,7 +1068,12 @@ static void *var_buf_length_setup(void)
 static void test_uart_async_var_buf(size_t buf_len, size_t tx_len)
 {
 	int ret;
-	uint8_t tx_buffer[VAR_LENGTH_TX_BUF_SIZE];
+
+#if NOCACHE_MEM
+static __aligned(sizeof(void *)) uint8_t tx_buffer[VAR_LENGTH_TX_BUF_SIZE] __used __NOCACHE;
+#else
+static ZTEST_BMEM uint8_t tx_buffer[VAR_LENGTH_TX_BUF_SIZE];
+#endif /* NOCACHE_MEM */
 
 	for (size_t i = 0; i < VAR_LENGTH_TX_BUF_SIZE; ++i) {
 		tx_buffer[i] = tx_len;


### PR DESCRIPTION


Following [PR #89300](https://github.com/zephyrproject-rtos/zephyr/pull/89300), which adds a new testsuite in the uart_async_api test drivers, some modifications are needed for the `uart_async_var_buf_length` testsuite to pass on platforms like `nucleo_f746zg` and `nucleo_wba55cg`.

