### PR TITLE
tests: boards: nrf: qdec: Disable testing of 2nd instance until fixed

### DIFF
--- a/tests/boards/nrf/qdec/src/main.c
+++ b/tests/boards/nrf/qdec/src/main.c
@@ -17,7 +17,11 @@ static const struct gpio_dt_spec phase_b = GPIO_DT_SPEC_GET(DT_ALIAS(qencb), gpi
 static const struct device *const qdec_dev = DEVICE_DT_GET(DT_ALIAS(qdec0));
 static const uint32_t qdec_config_step = DT_PROP(DT_ALIAS(qdec0), steps);
 
-#if DT_NODE_EXISTS(DT_ALIAS(qdec1))
+/* Disable testing second QDEC instance
+ * until the issue with multiple
+ * QDEC instances support is resolved
+ */
+#if DT_NODE_EXISTS(DT_ALIAS(qdecX))
 #define SECOND_QDEC_INSTANCE
 
 static const struct gpio_dt_spec phase_a1 = GPIO_DT_SPEC_GET(DT_ALIAS(qenca1), gpios);


### PR DESCRIPTION
Disable testing second QDEC instance until the issue with multiple QDEC instances support is resolved