### PR TITLE
soc: st: stm32wbax: refcount backup domain accesses requests

### DIFF
--- a/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
+++ b/soc/st/stm32/stm32wbax/hci_if/linklayer_plat_adapt.c
@@ -8,6 +8,8 @@
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/logging/log.h>
 
+#include <stm32_backup_domain.h>
+
 #include "scm.h"
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
@@ -287,4 +289,14 @@ void LINKLAYER_PLAT_DisableOSContextSwitch(void)
 	 * that the link layer is running a critical radio job (radio channels' calibration);
 	 * A sequence of radio ISRs will appear in the next few milli seconds.
 	 **/
+}
+
+void LINKLAYER_PLAT_EnableBackupDomainAccess(void)
+{
+	stm32_backup_domain_enable_access();
+}
+
+void LINKLAYER_PLAT_DisableBackupDomainAccess(void)
+{
+	stm32_backup_domain_disable_access();
 }

--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 468e5ad450a75d4baa3eed80e4f77a7700b71203
+      revision: pull/290/head
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Add LINKLAYER_PLAT_EnableBackupDomainAccess()  and LINKLAYER_PLAT_DisableBackupDomainAccess() to use Zephyr resources that use a reference counter for access requests, for enabling and disabling access the BackupDomain resources.