### PR TITLE
boards: st: add ST-Link GDB Server runner to N6 boards

### DIFF
--- a/boards/st/nucleo_n657x0_q/board.cmake
+++ b/boards/st/nucleo_n657x0_q/board.cmake
@@ -12,4 +12,8 @@ else()
   board_runner_args(stm32cubeprogrammer "--download-address=0x70000000")
 endif()
 
+board_runner_args(stlink_gdbserver "--apid=1")
+board_runner_args(stlink_gdbserver "--extload=MX25UM51245G_STM32N6570-NUCLEO.stldr")
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)

--- a/boards/st/nucleo_n657x0_q/doc/index.rst
+++ b/boards/st/nucleo_n657x0_q/doc/index.rst
@@ -245,20 +245,28 @@ You should see the following message on the console:
 Debugging
 =========
 
-For now debugging is only available through STM32CubeIDE:
+You can debug an application in the usual way using the :ref:`ST-LINK GDB Server <runner_stlink_gdbserver>`.
+Here is an example for the :zephyr:code-sample:`hello_world` application.
 
-* Go to File > Import and select C/C++ > STM32 Cortex-M Executable.
-* In Executable field, browse to your <ZEPHYR_PATH>/build/zephyr/zephyr.elf.
-* In MCU field, select STM32N657X0HxQ.
-* Click on Finish.
-* Finally, click on Debug to start the debugging session.
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: nucleo_n657x0_q
+   :maybe-skip-config:
+   :goals: debug
 
 .. note::
-   For debugging, before powering on the board, set the boot pins in the following configuration:
+   To enable debugging, before powering on the board, set the boot pins in the following configuration:
 
    * BOOT0: 0
    * BOOT1: 1
 
+Another solution for debugging is to use STM32CubeIDE:
+
+* Go to :menuselection:`File --> Import` and select :menuselection:`C/C++ --> STM32 Cortex-M Executable`.
+* In the :guilabel:`Executable` field, browse to your ``<ZEPHYR_PATH>/build/zephyr/zephyr.elf``.
+* In :guilabel:`MCU` field, select ``STM32N657X0HxQ``.
+* Click on :guilabel:`Finish`.
+* Finally, click on :guilabel:`Debug` to start the debugging session.
 
 Running tests with twister
 ==========================

--- a/boards/st/stm32n6570_dk/board.cmake
+++ b/boards/st/stm32n6570_dk/board.cmake
@@ -19,5 +19,9 @@ else()
     board_runner_args(stm32cubeprogrammer "--download-address=${app_base_addr}")
 endif()
 
+board_runner_args(stlink_gdbserver "--apid=1")
+board_runner_args(stlink_gdbserver "--extload=MX66UW1G45G_STM32N6570-DK.stldr")
+
 
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stlink_gdbserver.board.cmake)

--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -301,20 +301,28 @@ You should see the following message on the console:
 Debugging
 =========
 
-For now debugging is only available through STM32CubeIDE:
+You can debug an application in the usual way using the :ref:`ST-LINK GDB Server <runner_stlink_gdbserver>`.
+Here is an example for the :zephyr:code-sample:`hello_world` application.
 
-* Go to File > Import and select C/C++ > STM32 Cortex-M Executable.
-* In Executable field, browse to your <ZEPHYR_PATH>/build/zephyr/zephyr.elf.
-* In MCU field, select STM32N657X0HxQ.
-* Click on Finish.
-* Finally, click on Debug to start the debugging session.
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: stm32n6570_dk
+   :maybe-skip-config:
+   :goals: debug
 
 .. note::
-   For debugging, before powering on the board, set the boot pins in the following configuration:
+   To enable debugging, before powering on the board, set the boot pins in the following configuration:
 
    * BOOT0: 0
    * BOOT1: 1
 
+Another solution for debugging is to use STM32CubeIDE:
+
+* Go to :menuselection:`File --> Import` and select :menuselection:`C/C++ --> STM32 Cortex-M Executable`.
+* In the :guilabel:`Executable` field, browse to your ``<ZEPHYR_PATH>/build/zephyr/zephyr.elf``.
+* In :guilabel:`MCU` field, select ``STM32N657X0HxQ``.
+* Click on :guilabel:`Finish`.
+* Finally, click on :guilabel:`Debug` to start the debugging session.
 
 Running tests with twister
 ==========================


### PR DESCRIPTION
Enable the ST-Link GDB Server runner for STM32N6-based boards currently supported in Zephyr.
This enables debugging images on these boards, which was not possible via `west` before.
Additionally, update the boards' documentation to reflect this new possibility (and reformat the existing paragraph with tags to make it prettier).

Tested on both boards with `samples/basic/blinky`.

N.B.: because images are built to execute from RAM, `west debug` does not flash image to the target. This feature *should* work thanks to the external loader, but has not been tested due to this limitation. 