### PR TITLE
manifest: Update hal_nordic with updated cracen hal and rng driver

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 71308dc6d8c021887ce5d98a36cafe9517375a91
+      revision: 9587b1dcb83d24ab74e89837843a5f7d573f7059
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update with the latest nordic hal which includes an updated CRACEN driver which supports the 54LM20 and newer devices