### PR TITLE
boards: nxp: fix flash jedec-id

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -101,6 +101,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(64 * 8)>;
 		status = "okay";
+		jedec-id = [ef 40 20];
 		erase-block-size = <4096>;
 		write-block-size = <1>;
 		spi-max-frequency = <104000000>;

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -97,11 +97,11 @@ arduino_serial: &lpuart2 {
 	reg = <0x402a8000 0x4000>, <0x60000000 DT_SIZE_M(8)>;
 	is25lp064: is25lp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
-		size = <67108864>;
+		size = <DT_SIZE_M(8*8)>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";
-		jedec-id = [9d 70 17];
+		jedec-id = [9d 60 17];
 		erase-block-size = <4096>;
 		write-block-size = <1>;
 

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -97,7 +97,7 @@
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";
-		jedec-id = [9d 70 17];
+		jedec-id = [9d 70 18];
 		erase-block-size = <4096>;
 		write-block-size = <1>;
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -259,7 +259,7 @@ arduino_spi: &lpspi1 {
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		status = "okay";
-		jedec-id = [9d 70 17];
+		jedec-id = [9d 70 18];
 		erase-block-size = <4096>;
 		write-block-size = <1>;
 


### PR DESCRIPTION
Fixes/adds jedec-id for is25wp128, is25lp064 and w25q512jvfiq flashes, according to information from Flash data-sheets.