### PR TITLE
drivers: gpio: nrfx: extend pin retain to every pin

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -64,20 +64,15 @@ static nrf_gpio_pin_pull_t get_pull(gpio_flags_t flags)
 	return NRF_GPIO_PIN_NOPULL;
 }
 
-static void gpio_nrfx_gpd_retain_set(const struct device *port, uint32_t mask, gpio_flags_t flags)
+static void gpio_nrfx_gpd_retain_set(const struct device *port, uint32_t mask)
 {
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
-
-	if (cfg->pad_pd != NRF_GPD_FAST_ACTIVE1 || !(flags & GPIO_OUTPUT)) {
-		return;
-	}
 
 	nrf_gpio_port_retain_enable(cfg->port, mask);
 #else
 	ARG_UNUSED(port);
 	ARG_UNUSED(mask);
-	ARG_UNUSED(flags);
 #endif
 }
 
@@ -85,10 +80,6 @@ static void gpio_nrfx_gpd_retain_clear(const struct device *port, uint32_t mask)
 {
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	const struct gpio_nrfx_cfg *cfg = get_port_cfg(port);
-
-	if (cfg->pad_pd != NRF_GPD_FAST_ACTIVE1) {
-		return;
-	}
 
 	nrf_gpio_port_retain_disable(cfg->port, mask);
 #else
@@ -225,7 +216,7 @@ static int gpio_nrfx_pin_configure(const struct device *port, gpio_pin_t pin,
 	}
 
 end:
-	gpio_nrfx_gpd_retain_set(port, BIT(pin), flags);
+	gpio_nrfx_gpd_retain_set(port, BIT(pin));
 	return pm_device_runtime_put(port);
 }
 
@@ -329,7 +320,7 @@ static int gpio_nrfx_port_set_masked_raw(const struct device *port,
 	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_set(reg, set_mask);
 	nrf_gpio_port_out_clear(reg, clear_mask);
-	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask);
 	return pm_device_runtime_put(port);
 }
 
@@ -346,7 +337,7 @@ static int gpio_nrfx_port_set_bits_raw(const struct device *port,
 
 	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_set(reg, mask);
-	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask);
 	return pm_device_runtime_put(port);
 }
 
@@ -363,7 +354,7 @@ static int gpio_nrfx_port_clear_bits_raw(const struct device *port,
 
 	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_clear(reg, mask);
-	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask);
 	return pm_device_runtime_put(port);
 }
 
@@ -384,7 +375,7 @@ static int gpio_nrfx_port_toggle_bits(const struct device *port,
 	gpio_nrfx_gpd_retain_clear(port, mask);
 	nrf_gpio_port_out_set(reg, set_mask);
 	nrf_gpio_port_out_clear(reg, clear_mask);
-	gpio_nrfx_gpd_retain_set(port, mask, GPIO_OUTPUT);
+	gpio_nrfx_gpd_retain_set(port, mask);
 	return pm_device_runtime_put(port);
 }
 

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -483,9 +483,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 					}
 					gpd_requested = true;
 				}
-
-				nrf_gpio_pin_retain_disable(pin);
 			}
+
+			/*
+			 * Pad power domain now on, retain no longer needed
+			 * as pad config will be persists as pad is powered.
+			 */
+			nrf_gpio_pin_retain_disable(pin);
 #endif /* CONFIG_SOC_NRF54H20_GPD */
 
 			if (write != NO_WRITE) {
@@ -504,7 +508,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			nrf_gpio_pin_clock_set(pin, NRF_GET_CLOCKPIN_ENABLE(pins[i]));
 #endif
 #ifdef CONFIG_SOC_NRF54H20_GPD
-			if (NRF_GET_GPD_FAST_ACTIVE1(pins[i]) == 1U) {
+			if (NRF_GET_LP(pins[i]) == NRF_LP_ENABLE) {
+				/*
+				 * Pad power domain may be turned off, and pad is not
+				 * actively used as pincnf is low-power. Enable retain
+				 * to ensure pad output and config persists if pad
+				 * power domain is suspended.
+				 */
 				nrf_gpio_pin_retain_enable(pin);
 			}
 #endif /* CONFIG_SOC_NRF54H20_GPD */


### PR DESCRIPTION
The usage of nrf_gpio_port_retain_disable/_enable, in cases where the soc pins support retention, every pin must be
retained/unretained regardless of what power domain the pad is in.

This patch ensures retain is applied to all pins in all domains by the gpio_nrfx device driver, not only pins specifically in the fast_active_1 domain. Without this patch, pinctrl will correctly retain pins, while gpio_nrfx will fail to unretain them again.