### PR TITLE
Bluetooth: Fix MTU calculation in rfcomm&l2cap

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -4664,11 +4664,16 @@ int bt_l2cap_br_chan_connect(struct bt_conn *conn, struct bt_l2cap_chan *chan, u
 		return -EBUSY;
 	}
 
+	if (!br_chan->rx.mtu) {
+		br_chan->rx.mtu = BT_L2CAP_RX_MTU;
+	}
 #if defined(CONFIG_BT_L2CAP_RET_FC)
 	err = l2cap_br_check_chan_config(conn, br_chan);
 	if (err) {
 		return err;
 	}
+#else
+	br_chan->rx.mtu = MIN(br_chan->rx.mtu, BT_L2CAP_RX_MTU);
 #endif /* CONFIG_BT_L2CAP_RET_FC */
 
 	if (!l2cap_br_chan_add(conn, chan, l2cap_br_chan_destroy)) {

--- a/subsys/bluetooth/host/classic/rfcomm.c
+++ b/subsys/bluetooth/host/classic/rfcomm.c
@@ -430,7 +430,7 @@ static void rfcomm_connected(struct bt_l2cap_chan *chan)
 	/* Need to include UIH header and FCS*/
 	session->mtu = MIN(session->br_chan.rx.mtu,
 			   session->br_chan.tx.mtu) -
-			   BT_RFCOMM_HDR_SIZE + BT_RFCOMM_FCS_SIZE;
+			   BT_RFCOMM_HDR_SIZE - BT_RFCOMM_FCS_SIZE;
 
 	if (session->state == BT_RFCOMM_STATE_CONNECTING) {
 		rfcomm_send_sabm(session, 0);


### PR DESCRIPTION
Overflow occurs when mtu is set to l2cap mtu critical value.


In L2CAP
Ensure that the BR/EDR L2CAP RX MTU is limited to the configured
BT_L2CAP_RX_MTU value during channel configuration.

This change prevent potential buffer overflow issues when receiving
data larger than the configured buffer size.

In RFCOMM
The MTU calculation in rfcomm_connected() was incorrectly adding the FCS
size instead of subtracting it.
This could lead to buffer overflows when sending data that exceeds
the actual available space.

Fix the calculation by properly subtracting both the RFCOMM header size and
the FCS size from the L2CAP MTU to get the correct RFCOMM session MTU.

