### PR TITLE
net: dns: Save info about DHCP when configuring DNS servers

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -549,6 +549,11 @@ Networking
   the previously used ``NET_REQUEST_ETHERNET_GET_QAV_PARAM`` and
   ``NET_REQUEST_ETHERNET_GET_QAV_PARAM`` options.
 
+* The DNS server resolver configuration functions :c:func:`dns_resolve_reconfigure` and
+  :c:func:`dns_resolve_reconfigure_with_interfaces` now require that the user supplies
+  the source of the DNS server information. For example when DNS server information is
+  received via DHCPv4, then :c:enumerator:`DNS_SOURCE_DHCPV4` needs to be specified.
+
 LwM2M
 =====
 

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1966,7 +1966,8 @@ static void dns_work_cb(struct k_work *work)
 			}
 		} else {
 			LOG_DBG("Reconfiguring DNS resolver");
-			ret = dns_resolve_reconfigure(dnsCtx, (const char **)dns_servers_str, NULL);
+			ret = dns_resolve_reconfigure(dnsCtx, (const char **)dns_servers_str, NULL,
+						      DNS_SOURCE_MANUAL);
 			if (ret < 0) {
 				LOG_ERR("dns_resolve_reconfigure fail (%d)", ret);
 				retry = true;

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -506,7 +506,8 @@ static void esp_dns_work(struct k_work *work)
 
 	dnsctx = dns_resolve_get_default();
 	err = dns_resolve_reconfigure_with_interfaces(dnsctx, NULL, dns_servers,
-						      interfaces);
+						      interfaces,
+						      DNS_SOURCE_MANUAL);
 	if (err) {
 		LOG_ERR("Could not set DNS servers: %d", err);
 	}

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -44,6 +44,24 @@ enum dns_query_type {
 	DNS_QUERY_TYPE_AAAA = 28
 };
 
+/**
+ * Entity that added the DNS server.
+ */
+enum dns_server_source {
+	/** Source is unknown */
+	DNS_SOURCE_UNKNOWN = 0,
+	/** Server information is added manually, for example by an application */
+	DNS_SOURCE_MANUAL,
+	/** Server information is from DHCPv4 server */
+	DNS_SOURCE_DHCPV4,
+	/** Server information is from DHCPv6 server */
+	DNS_SOURCE_DHCPV6,
+	/** Server information is from IPv6 SLAAC (router advertisement) */
+	DNS_SOURCE_IPV6_RA,
+	/** Server information is from PPP */
+	DNS_SOURCE_PPP,
+};
+
 /** Max size of the resolved name. */
 #if defined(CONFIG_DNS_RESOLVER_MAX_NAME_LEN)
 #define DNS_MAX_NAME_SIZE CONFIG_DNS_RESOLVER_MAX_NAME_LEN
@@ -353,6 +371,9 @@ struct dns_resolve_context {
 		 */
 		int if_index;
 
+		/** Source of the DNS server, e.g., manual, DHCPv4/6, etc. */
+		enum dns_server_source source;
+
 		/** Is this server mDNS one */
 		uint8_t is_mdns : 1;
 
@@ -526,12 +547,14 @@ int dns_resolve_close(struct dns_resolve_context *ctx);
  * @param servers_sa DNS server addresses as struct sockaddr. The array
  * is NULL terminated. Port numbers are optional in struct sockaddr, the
  * default will be used if set to 0.
+ * @param source Source of the DNS servers, e.g., manual, DHCPv4/6, etc.
  *
  * @return 0 if ok, <0 if error.
  */
 int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
 			    const char *servers_str[],
-			    const struct sockaddr *servers_sa[]);
+			    const struct sockaddr *servers_sa[],
+			    enum dns_server_source source);
 
 /**
  * @brief Reconfigure DNS resolving context with new server list and
@@ -551,13 +574,15 @@ int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
  * @param interfaces Network interfaces to which the DNS servers are bound.
  *        This is an array of network interface indices. The array must be
  *        the same length as the servers_str and servers_sa arrays.
+ * @param source Source of the DNS servers, e.g., manual, DHCPv4/6, etc.
  *
  * @return 0 if ok, <0 if error.
  */
 int dns_resolve_reconfigure_with_interfaces(struct dns_resolve_context *ctx,
 					    const char *servers_str[],
 					    const struct sockaddr *servers_sa[],
-					    int interfaces[]);
+					    int interfaces[],
+					    enum dns_server_source source);
 
 /**
  * @brief Remove servers from the DNS resolving context.
@@ -746,6 +771,15 @@ static inline int dns_cancel_addr_info(uint16_t dns_id)
  */
 
 /** @cond INTERNAL_HIDDEN */
+
+/**
+ * @brief Get string representation of the DNS server source.
+ *
+ * @param source Source of the DNS server.
+ *
+ * @return String representation of the DNS server source.
+ */
+const char *dns_get_source_str(enum dns_server_source source);
 
 /**
  * @brief Initialize DNS subsystem.

--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -595,6 +595,19 @@ int dns_resolve_reconfigure_with_interfaces(struct dns_resolve_context *ctx,
 int dns_resolve_remove(struct dns_resolve_context *ctx, int if_index);
 
 /**
+ * @brief Remove servers from the DNS resolving context that were added by
+ *        a specific source.
+ *
+ * @param ctx DNS context
+ * @param if_index Network interface from which the DNS servers are removed.
+ * @param source Source of the DNS servers, e.g., manual, DHCPv4/6, etc.
+ *
+ * @return 0 if ok, <0 if error.
+ */
+int dns_resolve_remove_source(struct dns_resolve_context *ctx, int if_index,
+			      enum dns_server_source source);
+
+/**
  * @brief Cancel a pending DNS query.
  *
  * @details This releases DNS resources used by a pending query.

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2509,7 +2509,8 @@ static inline bool handle_ra_rdnss(struct net_pkt *pkt, uint8_t len)
 	/* TODO: Handle lifetime. */
 	ctx = dns_resolve_get_default();
 	ret = dns_resolve_reconfigure_with_interfaces(ctx, NULL, dns_servers,
-						      interfaces);
+						      interfaces,
+						      DNS_SOURCE_IPV6_RA);
 	if (ret < 0) {
 		NET_DBG("Failed to set RDNSS resolve address: %d", ret);
 	}

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -341,7 +341,8 @@ static void ipcp_set_dns_servers(struct ppp_fsm *fsm)
 
 	dnsctx = dns_resolve_get_default();
 	ret = dns_resolve_reconfigure_with_interfaces(dnsctx, NULL, dns_servers,
-						      interfaces);
+						      interfaces,
+						      DNS_SOURCE_PPP);
 	if (ret < 0) {
 		NET_ERR("Could not set DNS servers");
 		return;

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1194,9 +1194,11 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 
 				status = dns_resolve_reconfigure_with_interfaces(ctx, NULL,
 										 dns_servers,
-										 interfaces);
+										 interfaces,
+										 DNS_SOURCE_DHCPV4);
 			} else {
-				status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
+				status = dns_resolve_reconfigure(ctx, NULL, dns_servers,
+								 DNS_SOURCE_DHCPV4);
 			}
 
 			if (status < 0) {

--- a/subsys/net/lib/dhcpv4/dhcpv4.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4.c
@@ -1691,8 +1691,9 @@ static void dhcpv4_iface_event_handler(struct net_mgmt_event_callback *cb,
 			 * comes back up.
 			 */
 			if (IS_ENABLED(CONFIG_NET_DHCPV4_DNS_SERVER_VIA_INTERFACE)) {
-				dns_resolve_remove(dns_resolve_get_default(),
-						   net_if_get_by_iface(iface));
+				dns_resolve_remove_source(dns_resolve_get_default(),
+							  net_if_get_by_iface(iface),
+							  DNS_SOURCE_DHCPV4);
 			}
 		}
 	} else if (mgmt_event == NET_EVENT_IF_UP) {
@@ -1965,6 +1966,12 @@ void net_dhcpv4_stop(struct net_if *iface)
 		iface->config.dhcpv4.state = NET_DHCPV4_DISABLED;
 		NET_DBG("state=%s",
 			net_dhcpv4_state_name(iface->config.dhcpv4.state));
+
+		if (IS_ENABLED(CONFIG_NET_DHCPV4_DNS_SERVER_VIA_INTERFACE)) {
+			dns_resolve_remove_source(dns_resolve_get_default(),
+						  net_if_get_by_iface(iface),
+						  DNS_SOURCE_DHCPV4);
+		}
 
 		sys_slist_find_and_remove(&dhcpv4_ifaces,
 					  &iface->config.dhcpv4.node);

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -1426,9 +1426,11 @@ static int dhcpv6_handle_dns_server_option(struct net_pkt *pkt)
 
 		status = dns_resolve_reconfigure_with_interfaces(ctx, NULL,
 								 dns_servers,
-								 interfaces);
+								 interfaces,
+								 DNS_SOURCE_DHCPV6);
 	} else {
-		status = dns_resolve_reconfigure(ctx, NULL, dns_servers);
+		status = dns_resolve_reconfigure(ctx, NULL, dns_servers,
+						 DNS_SOURCE_DHCPV6);
 	}
 
 	if (status < 0) {

--- a/subsys/net/lib/dhcpv6/dhcpv6.c
+++ b/subsys/net/lib/dhcpv6/dhcpv6.c
@@ -2226,8 +2226,9 @@ static void dhcpv6_iface_event_handler(struct net_mgmt_event_callback *cb,
 		 * comes back up.
 		 */
 		if (IS_ENABLED(CONFIG_NET_DHCPV6_DNS_SERVER_VIA_INTERFACE)) {
-			dns_resolve_remove(dns_resolve_get_default(),
-					   net_if_get_by_iface(iface));
+			dns_resolve_remove_source(dns_resolve_get_default(),
+						  net_if_get_by_iface(iface),
+						  DNS_SOURCE_DHCPV6);
 		}
 	} else if (mgmt_event == NET_EVENT_IF_UP) {
 		NET_DBG("Interface %p coming up", iface);
@@ -2322,6 +2323,12 @@ void net_dhcpv6_stop(struct net_if *iface)
 			net_dhcpv6_state_name(iface->config.dhcpv6.state));
 
 		(void)dhcpv6_enter_state(iface, NET_DHCPV6_DISABLED);
+
+		if (IS_ENABLED(CONFIG_NET_DHCPV6_DNS_SERVER_VIA_INTERFACE)) {
+			dns_resolve_remove_source(dns_resolve_get_default(),
+						  net_if_get_by_iface(iface),
+						  DNS_SOURCE_DHCPV6);
+		}
 
 		sys_slist_find_and_remove(&dhcpv6_ifaces,
 					  &iface->config.dhcpv6.node);

--- a/subsys/net/lib/shell/dns.c
+++ b/subsys/net/lib/shell/dns.c
@@ -100,22 +100,30 @@ static void print_dns_info(const struct shell *sh,
 		}
 
 		if (ctx->servers[i].dns_server.sa_family == AF_INET) {
-			PR("\t%s:%u%s%s\n",
+			PR("\t%s:%u%s%s%s%s%s\n",
 			   net_sprint_ipv4_addr(
 				   &net_sin(&ctx->servers[i].dns_server)->
 				   sin_addr),
 			   ntohs(net_sin(&ctx->servers[i].dns_server)->sin_port),
 			   printable_iface(iface_name, " via ", ""),
-			   printable_iface(iface_name, iface_name, ""));
+			   printable_iface(iface_name, iface_name, ""),
+			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ? " (" : "",
+			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ?
+					dns_get_source_str(ctx->servers[i].source) : "",
+			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ? ")" : "");
 
 		} else if (ctx->servers[i].dns_server.sa_family == AF_INET6) {
-			PR("\t[%s]:%u%s%s\n",
+			PR("\t[%s]:%u%s%s%s%s%s\n",
 			   net_sprint_ipv6_addr(
 				   &net_sin6(&ctx->servers[i].dns_server)->
 				   sin6_addr),
 			   ntohs(net_sin6(&ctx->servers[i].dns_server)->sin6_port),
 			   printable_iface(iface_name, " via ", ""),
-			   printable_iface(iface_name, iface_name, ""));
+			   printable_iface(iface_name, iface_name, ""),
+			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ? " (" : "",
+			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ?
+					dns_get_source_str(ctx->servers[i].source) : "",
+			   ctx->servers[i].source != DNS_SOURCE_UNKNOWN ? ")" : "");
 		}
 	}
 

--- a/tests/net/dhcpv4/client/src/main.c
+++ b/tests/net/dhcpv4/client/src/main.c
@@ -746,17 +746,14 @@ ZTEST(dhcpv4_tests, test_dhcp)
 			      "Missing DHCP vendor option(s) %08x", evt);
 #endif
 
-		if (loop == 0) {
-			/* Associated DNS servers aren't deleted on DHCP stop */
-			evt = k_event_wait_all(&events,
-					       EVT_DNS_SERVER1_ADD | EVT_DNS_SERVER2_ADD |
-						       EVT_DNS_SERVER3_ADD,
-					       false, WAIT_TIME);
-			zassert_equal(evt,
-				      EVT_DNS_SERVER1_ADD | EVT_DNS_SERVER2_ADD |
-					      EVT_DNS_SERVER3_ADD,
-				      "Missing DNS server(s) %08x", evt);
-		}
+		evt = k_event_wait_all(&events,
+				       EVT_DNS_SERVER1_ADD | EVT_DNS_SERVER2_ADD |
+				       EVT_DNS_SERVER3_ADD,
+				       false, WAIT_TIME);
+		zassert_equal(evt,
+			      EVT_DNS_SERVER1_ADD | EVT_DNS_SERVER2_ADD |
+			      EVT_DNS_SERVER3_ADD,
+			      "Missing DNS server(s) %08x", evt);
 
 		evt = k_event_wait(&events, EVT_DHCP_BOUND, false, WAIT_TIME);
 		zassert_equal(evt, EVT_DHCP_BOUND, "Missing DHCP bound");

--- a/tests/net/dhcpv4/client/src/main.c
+++ b/tests/net/dhcpv4/client/src/main.c
@@ -252,6 +252,9 @@ static uint32_t request_xid;
 #define EVT_VENDOR_EMPTY    BIT(12)
 #define EVT_DHCP_OFFER      BIT(13)
 #define EVT_DHCP_ACK        BIT(14)
+#define EVT_DNS_SERVER1_DEL BIT(15)
+#define EVT_DNS_SERVER2_DEL BIT(16)
+#define EVT_DNS_SERVER3_DEL BIT(17)
 
 static K_EVENT_DEFINE(events);
 
@@ -538,6 +541,18 @@ static void receiver_cb(uint64_t nm_event, struct net_if *iface, void *info, siz
 			zassert_unreachable("Unknown DNS server");
 		}
 		break;
+	case NET_EVENT_DNS_SERVER_DEL:
+		zassert_equal(info_length, sizeof(struct sockaddr));
+		if (net_sin(info)->sin_addr.s_addr == dns_addrs[0].s_addr) {
+			k_event_post(&events, EVT_DNS_SERVER1_DEL);
+		} else if (net_sin(info)->sin_addr.s_addr == dns_addrs[1].s_addr) {
+			k_event_post(&events, EVT_DNS_SERVER2_DEL);
+		} else if (net_sin(info)->sin_addr.s_addr == dns_addrs[2].s_addr) {
+			k_event_post(&events, EVT_DNS_SERVER3_DEL);
+		} else {
+			zassert_unreachable("Unknown DNS server");
+		}
+		break;
 	case NET_EVENT_IPV4_DHCP_START:
 		k_event_post(&events, EVT_DHCP_START);
 		break;
@@ -781,8 +796,15 @@ ZTEST(dhcpv4_tests, test_dhcp)
 
 		net_dhcpv4_stop(iface);
 
-		evt = k_event_wait_all(&events, EVT_DHCP_STOP | EVT_ADDR_DEL, false, WAIT_TIME);
-		zassert_equal(evt, EVT_DHCP_STOP | EVT_ADDR_DEL,
+		evt = k_event_wait_all(&events,
+				       EVT_DHCP_STOP | EVT_ADDR_DEL |
+				       EVT_DNS_SERVER1_DEL | EVT_DNS_SERVER2_DEL |
+				       EVT_DNS_SERVER3_DEL,
+				       false, WAIT_TIME);
+		zassert_equal(evt,
+			      EVT_DHCP_STOP | EVT_ADDR_DEL |
+			      EVT_DNS_SERVER1_DEL | EVT_DNS_SERVER2_DEL |
+			      EVT_DNS_SERVER3_DEL,
 			      "Missing DHCP stop or deleted address");
 	}
 }

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -466,7 +466,8 @@ ZTEST(dns_addremove, test_dns_reconfigure_callback)
 			     "Timeout while waiting for DNS added callback");
 	}
 
-	ret = dns_resolve_reconfigure(&resv_ipv4, dns2_servers_str, NULL);
+	ret = dns_resolve_reconfigure(&resv_ipv4, dns2_servers_str, NULL,
+				      DNS_SOURCE_MANUAL);
 	zassert_equal(ret, 0, "Cannot reconfigure DNS server");
 
 	/* Wait for DNS removed callback after reconfiguring DNS */


### PR DESCRIPTION
Remember which DNS server was added by a DHCPv4 or v6 message. This will allow system to remove DNS servers that were added by DHCPv4/6. Then when stopping DHCP, we are not leaving DNS servers hanging in the system.
