### PR TITLE
drivers: udc_dwc2: Disable endpoints asynchronously

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -101,6 +101,7 @@ struct dwc2_reg_backup {
 
 /* Driver private data per instance */
 struct udc_dwc2_data {
+	struct k_spinlock lock;
 	struct k_thread thread_data;
 	/* Main events the driver thread waits for */
 	struct k_event drv_evt;
@@ -461,7 +462,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 	uint32_t max_xfersize, max_pktcnt, pktcnt;
 	const uint32_t addnl = USB_MPS_ADDITIONAL_TRANSACTIONS(cfg->mps);
 	const size_t d = sizeof(uint32_t);
-	unsigned int key;
+	k_spinlock_key_t key;
 	uint32_t len;
 	const bool is_periodic = dwc2_ep_is_periodic(cfg);
 	const bool is_iso = dwc2_ep_is_iso(cfg);
@@ -536,7 +537,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 	priv->tx_len[ep_idx] = len;
 
 	/* Lock and write to endpoint FIFO */
-	key = irq_lock();
+	key = k_spin_lock(&priv->lock);
 
 	/* Set number of packets and transfer size */
 	sys_write32((is_periodic ? usb_dwc2_set_dieptsizn_mc(1 + addnl) : 0) |
@@ -548,7 +549,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 			/* Cannot continue unless buffer is bounced. Device will
 			 * cease to function. Is fatal error appropriate here?
 			 */
-			irq_unlock(key);
+			k_spin_unlock(&priv->lock, key);
 			return -ENOTSUP;
 		}
 
@@ -564,7 +565,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 		 * no fifo is assigned to inactive endpoint and therefore it is
 		 * possible that the write will corrupt other endpoint fifo.
 		 */
-		irq_unlock(key);
+		k_spin_unlock(&priv->lock, key);
 		return -ENOENT;
 	}
 
@@ -614,7 +615,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 		}
 	}
 
-	irq_unlock(key);
+	k_spin_unlock(&priv->lock, key);
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -105,6 +105,8 @@ struct udc_dwc2_data {
 	struct k_thread thread_data;
 	/* Main events the driver thread waits for */
 	struct k_event drv_evt;
+	/* Endpoint is considered disabled when there is no active transfer */
+	struct k_event ep_disabled;
 	/* Transfer triggers (IN on bits 0-15, OUT on bits 16-31) */
 	atomic_t xfer_new;
 	/* Finished transactions (IN on bits 0-15, OUT on bits 16-31) */
@@ -117,6 +119,9 @@ struct udc_dwc2_data {
 	uint32_t rx_siz[16];
 	/* Isochronous endpoint enabled (IN on bits 0-15, OUT on bits 16-31) */
 	uint32_t iso_enabled;
+	uint16_t iso_in_rearm;
+	uint16_t ep_out_disable;
+	uint16_t ep_out_stall;
 	uint16_t txf_set;
 	uint16_t pending_tx_flush;
 	uint16_t dfifodepth;
@@ -144,7 +149,8 @@ struct udc_dwc2_data {
 };
 
 static void udc_dwc2_ep_disable(const struct device *dev,
-				struct udc_ep_config *const cfg, bool stall);
+				struct udc_ep_config *const cfg,
+				bool stall, bool wait);
 
 #if defined(CONFIG_PINCTRL)
 #include <zephyr/drivers/pinctrl.h>
@@ -617,6 +623,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 		}
 	}
 
+	k_event_clear(&priv->ep_disabled, BIT(ep_idx));
 	k_spin_unlock(&priv->lock, key);
 
 	return 0;
@@ -760,6 +767,8 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 
 	sys_write32(doepctl, doepctl_reg);
 
+	k_event_clear(&priv->ep_disabled, BIT(16 + ep_idx));
+
 	LOG_INF("Prepare RX 0x%02x doeptsiz 0x%x", cfg->addr, doeptsiz);
 }
 
@@ -826,7 +835,7 @@ static int dwc2_handle_evt_setup(const struct device *dev)
 	 * transfer beforehand. In Buffer DMA the SETUP can be copied to any EP0
 	 * OUT buffer. If there is any buffer queued, it is obsolete now.
 	 */
-	udc_dwc2_ep_disable(dev, cfg_in, false);
+	udc_dwc2_ep_disable(dev, cfg_in, false, true);
 	atomic_and(&priv->xfer_finished, ~(BIT(0) | BIT(16)));
 
 	buf = udc_buf_get_all(cfg_out);
@@ -1521,16 +1530,19 @@ static int dwc2_unset_dedicated_fifo(const struct device *dev,
  * incoming OUT data (or HS PING) even if there is space available in RxFIFO.
  *
  * Set stall parameter to true if caller wants to send STALL instead of NAK.
+ * Set wait parameter to true to caller wants the function to return only after
+ * the requested operation is effective (or after 100 ms timeout).
  */
 static void udc_dwc2_ep_disable(const struct device *dev,
-				struct udc_ep_config *const cfg, bool stall)
+				struct udc_ep_config *const cfg,
+				bool stall, bool wait)
 {
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	uint8_t ep_idx = USB_EP_GET_IDX(cfg->addr);
+	uint8_t ep_bit = ep_idx + (USB_EP_DIR_IS_OUT(cfg->addr) ? 16 : 0);
 	mem_addr_t dxepctl_reg;
 	uint32_t dxepctl;
-	const bool is_iso = dwc2_ep_is_iso(cfg);
 
 	dxepctl_reg = dwc2_get_dxepctl_reg(dev, cfg->addr);
 	dxepctl = sys_read32(dxepctl_reg);
@@ -1566,104 +1578,55 @@ static void udc_dwc2_ep_disable(const struct device *dev,
 			priv->pending_tx_flush |= BIT(usb_dwc2_get_depctl_txfnum(dxepctl));
 		}
 
+		k_event_post(&priv->ep_disabled, BIT(ep_bit));
 		udc_ep_set_busy(cfg, false);
 		return;
 	}
 
-	if (!is_iso && (dxepctl & USB_DWC2_DEPCTL_NAKSTS) &&
-	    !(dxepctl & USB_DWC2_DEPCTL_EPENA)) {
-		/* Endpoint already sends forced NAKs. STALL if necessary. */
+	if (k_event_test(&priv->ep_disabled, BIT(ep_bit))) {
+		/* There is no active transfer, STALL if necessary */
 		if (stall) {
 			dxepctl |= USB_DWC2_DEPCTL_STALL;
 			sys_write32(dxepctl, dxepctl_reg);
 		}
 
+		/* Do not start pending transfers (if any) */
+		atomic_clear_bit(&priv->xfer_new, ep_bit);
+
 		return;
 	}
 
-	/* FIXME: This function needs to be changed to not synchronously wait
-	 * for the events to happen because the actions here are racing against
-	 * the USB host packets. It is possible that the IN token or OUT DATA
-	 * gets sent shortly before this function disables the endpoint. If this
-	 * happens, the XferCompl would be set and driver will incorrectly think
-	 * that either:
-	 *   * never queued transfer finished, OR
-	 *   * transfer queued in incompisoin handler finished (before it really
-	 *     does and then it'll "double"-finish when it actually finishes)
-	 *
-	 * For the time being XferCompl is cleared as a workaround.
-	 */
-
 	if (USB_EP_DIR_IS_OUT(cfg->addr)) {
-		mem_addr_t dctl_reg, gintsts_reg, doepint_reg;
-		uint32_t dctl;
+		k_spinlock_key_t key = k_spin_lock(&priv->lock);
 
-		dctl_reg = (mem_addr_t)&base->dctl;
-		gintsts_reg = (mem_addr_t)&base->gintsts;
-		doepint_reg = (mem_addr_t)&base->out_ep[ep_idx].doepint;
-
-		dctl = sys_read32(dctl_reg);
-
-		if (sys_read32(gintsts_reg) & USB_DWC2_GINTSTS_GOUTNAKEFF) {
-			LOG_ERR("GOUTNAKEFF already active");
-		} else {
-			dctl |= USB_DWC2_DCTL_SGOUTNAK;
-			sys_write32(dctl, dctl_reg);
-			dctl &= ~USB_DWC2_DCTL_SGOUTNAK;
-		}
-
-		dwc2_wait_for_bit(dev, gintsts_reg, USB_DWC2_GINTSTS_GOUTNAKEFF);
-
-		/* The application cannot disable control OUT endpoint 0. */
-		if (ep_idx != 0) {
-			dxepctl |= USB_DWC2_DEPCTL_EPENA | USB_DWC2_DEPCTL_EPDIS;
-		}
-
+		priv->ep_out_disable |= BIT(ep_idx);
 		if (stall) {
-			/* For OUT endpoints STALL is set instead of SNAK */
-			dxepctl |= USB_DWC2_DEPCTL_STALL;
-		} else {
-			dxepctl |= USB_DWC2_DEPCTL_SNAK;
-		}
-		sys_write32(dxepctl, dxepctl_reg);
-
-		if (ep_idx != 0) {
-			dwc2_wait_for_bit(dev, doepint_reg, USB_DWC2_DOEPINT_EPDISBLD);
+			priv->ep_out_stall |= BIT(ep_idx);
 		}
 
-		/* Clear Endpoint Disabled interrupt */
-		sys_write32(USB_DWC2_DOEPINT_EPDISBLD | USB_DWC2_DOEPINT_XFERCOMPL, doepint_reg);
+		sys_set_bits((mem_addr_t)&base->dctl, USB_DWC2_DCTL_SGOUTNAK);
 
-		dctl |= USB_DWC2_DCTL_CGOUTNAK;
-		sys_write32(dctl, dctl_reg);
+		k_spin_unlock(&priv->lock, key);
+
+		/* Endpoint gets disabled in GOUTNAKEFF handler */
 	} else {
-		mem_addr_t diepint_reg;
-
-		diepint_reg = (mem_addr_t)&base->in_ep[ep_idx].diepint;
-
-		dxepctl |= USB_DWC2_DEPCTL_EPENA | USB_DWC2_DEPCTL_SNAK;
+		dxepctl |= USB_DWC2_DEPCTL_SNAK;
 		if (stall) {
 			/* For IN endpoints STALL is set in addition to SNAK */
 			dxepctl |= USB_DWC2_DEPCTL_STALL;
 		}
 		sys_write32(dxepctl, dxepctl_reg);
 
-		dwc2_wait_for_bit(dev, diepint_reg, USB_DWC2_DIEPINT_INEPNAKEFF);
+		/* Endpoint gets disabled in INEPNAKEFF handler */
+	}
 
-		dxepctl |= USB_DWC2_DEPCTL_EPENA | USB_DWC2_DEPCTL_EPDIS;
-		sys_write32(dxepctl, dxepctl_reg);
+	if (wait) {
+		uint32_t ret;
 
-		dwc2_wait_for_bit(dev, diepint_reg, USB_DWC2_DIEPINT_EPDISBLD);
-
-		/* Clear Endpoint Disabled interrupt */
-		sys_write32(USB_DWC2_DIEPINT_EPDISBLD | USB_DWC2_DIEPINT_XFERCOMPL, diepint_reg);
-
-		/* TODO: Read DIEPTSIZn here? Programming Guide suggest it to
-		 * let application know how many bytes of interrupted transfer
-		 * were transferred to the host.
-		 */
-
-		dwc2_flush_tx_fifo(dev, usb_dwc2_get_depctl_txfnum(dxepctl));
+		ret = k_event_wait(&priv->ep_disabled, BIT(ep_bit), false, K_MSEC(100));
+		if (ret == 0) {
+			LOG_ERR("Endpoint 0x%02x disable timeout", cfg->addr);
+		}
 	}
 
 	udc_ep_set_busy(cfg, false);
@@ -1687,7 +1650,7 @@ static int udc_dwc2_ep_deactivate(const struct device *dev,
 		LOG_DBG("Disable ep 0x%02x DxEPCTL%u %x",
 			cfg->addr, ep_idx, dxepctl);
 
-		udc_dwc2_ep_disable(dev, cfg, false);
+		udc_dwc2_ep_disable(dev, cfg, false, true);
 
 		dxepctl = sys_read32(dxepctl_reg);
 		dxepctl &= ~USB_DWC2_DEPCTL_USBACTEP;
@@ -1718,7 +1681,7 @@ static int udc_dwc2_ep_set_halt(const struct device *dev,
 {
 	uint8_t ep_idx = USB_EP_GET_IDX(cfg->addr);
 
-	udc_dwc2_ep_disable(dev, cfg, true);
+	udc_dwc2_ep_disable(dev, cfg, true, true);
 
 	LOG_DBG("Set halt ep 0x%02x", cfg->addr);
 	if (ep_idx != 0) {
@@ -1793,7 +1756,7 @@ static int udc_dwc2_ep_dequeue(const struct device *dev,
 {
 	struct net_buf *buf;
 
-	udc_dwc2_ep_disable(dev, cfg, false);
+	udc_dwc2_ep_disable(dev, cfg, false, true);
 
 	buf = udc_buf_get_all(cfg);
 	if (buf) {
@@ -2183,7 +2146,8 @@ static int udc_dwc2_init_controller(const struct device *dev)
 						       USB_DWC2_GINTSTS_INCOMPISOIN |))
 		    USB_DWC2_GINTSTS_OEPINT | USB_DWC2_GINTSTS_IEPINT |
 		    USB_DWC2_GINTSTS_ENUMDONE | USB_DWC2_GINTSTS_USBRST |
-		    USB_DWC2_GINTSTS_WKUPINT | USB_DWC2_GINTSTS_USBSUSP,
+		    USB_DWC2_GINTSTS_WKUPINT | USB_DWC2_GINTSTS_USBSUSP |
+		    USB_DWC2_GINTSTS_GOUTNAKEFF,
 		    (mem_addr_t)&base->gintmsk);
 
 	return 0;
@@ -2320,6 +2284,10 @@ static int dwc2_driver_preinit(const struct device *dev)
 	k_event_init(&priv->drv_evt);
 	atomic_clear(&priv->xfer_new);
 	atomic_clear(&priv->xfer_finished);
+	k_event_init(&priv->ep_disabled);
+	k_event_set(&priv->ep_disabled, UINT32_MAX);
+	priv->ep_out_disable = 0;
+	priv->ep_out_stall = 0;
 	priv->iso_enabled = 0;
 
 	data->caps.rwup = true;
@@ -2438,6 +2406,7 @@ static void dwc2_on_bus_reset(const struct device *dev)
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	uint32_t doepmsk;
+	uint32_t diepmsk;
 
 	/* Set the NAK bit for all OUT endpoints */
 	for (uint8_t i = 0U; i < priv->numdeveps; i++) {
@@ -2452,13 +2421,16 @@ static void dwc2_on_bus_reset(const struct device *dev)
 		}
 	}
 
-	doepmsk = USB_DWC2_DOEPINT_SETUP | USB_DWC2_DOEPINT_XFERCOMPL;
+	doepmsk = USB_DWC2_DOEPINT_SETUP | USB_DWC2_DOEPINT_EPDISBLD | USB_DWC2_DOEPINT_XFERCOMPL;
 	if (dwc2_in_buffer_dma_mode(dev)) {
 		doepmsk |= USB_DWC2_DOEPINT_STSPHSERCVD;
 	}
 
 	sys_write32(doepmsk, (mem_addr_t)&base->doepmsk);
-	sys_set_bits((mem_addr_t)&base->diepmsk, USB_DWC2_DIEPINT_XFERCOMPL);
+
+	diepmsk = USB_DWC2_DIEPINT_INEPNAKEFF | USB_DWC2_DIEPINT_EPDISBLD |
+		  USB_DWC2_DIEPINT_XFERCOMPL;
+	sys_write32(diepmsk, (mem_addr_t)&base->diepmsk);
 
 	/* Software has to handle RxFLvl interrupt only in Completer mode */
 	if (dwc2_in_completer_mode(dev)) {
@@ -2582,11 +2554,13 @@ static inline void dwc2_handle_in_xfercompl(const struct device *dev,
 	}
 
 	atomic_set_bit(&priv->xfer_finished, ep_idx);
+	k_event_post(&priv->ep_disabled, BIT(ep_idx));
 	k_event_post(&priv->drv_evt, BIT(DWC2_DRV_EVT_EP_FINISHED));
 }
 
 static inline void dwc2_handle_iepint(const struct device *dev)
 {
+	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
 	uint32_t diepmsk;
 	uint32_t epint;
@@ -2597,6 +2571,7 @@ static inline void dwc2_handle_iepint(const struct device *dev)
 	while (epint) {
 		uint8_t n = find_lsb_set(epint) - 1;
 		mem_addr_t diepint_reg = (mem_addr_t)&base->in_ep[n].diepint;
+		mem_addr_t diepctl_reg = (mem_addr_t)&base->in_ep[n].diepctl;
 		uint32_t diepint;
 		uint32_t status;
 
@@ -2610,6 +2585,33 @@ static inline void dwc2_handle_iepint(const struct device *dev)
 
 		if (status & USB_DWC2_DIEPINT_XFERCOMPL) {
 			dwc2_handle_in_xfercompl(dev, n);
+		}
+
+		if (status & USB_DWC2_DIEPINT_INEPNAKEFF) {
+			sys_set_bits(diepctl_reg, USB_DWC2_DEPCTL_EPDIS);
+		}
+
+		if (status & USB_DWC2_DIEPINT_EPDISBLD) {
+			uint32_t diepctl = sys_read32(diepctl_reg);
+
+			k_event_post(&priv->ep_disabled, BIT(n));
+
+			/* TODO: Read DIEPTSIZn here? Programming Guide suggest it to
+			 * let application know how many bytes of interrupted transfer
+			 * were transferred to the host.
+			 */
+
+			dwc2_flush_tx_fifo(dev, usb_dwc2_get_depctl_txfnum(diepctl));
+
+			if ((usb_dwc2_get_depctl_eptype(diepctl) == USB_DWC2_DEPCTL_EPTYPE_ISO) &&
+			    (priv->iso_in_rearm & BIT(n))) {
+				struct udc_ep_config *cfg = udc_get_ep_cfg(dev, n | USB_EP_DIR_IN);
+
+				/* Try to queue next packet before SOF */
+				dwc2_handle_xfer_next(dev, cfg);
+
+				priv->iso_in_rearm &= ~BIT(n);
+			}
 		}
 
 		epint &= ~BIT(n);
@@ -2687,6 +2689,7 @@ static inline void dwc2_handle_out_xfercompl(const struct device *dev,
 		dwc2_prep_rx(dev, buf, ep_cfg);
 	} else {
 		atomic_set_bit(&priv->xfer_finished, 16 + ep_idx);
+		k_event_post(&priv->ep_disabled, BIT(16 + ep_idx));
 		k_event_post(&priv->drv_evt, BIT(DWC2_DRV_EVT_EP_FINISHED));
 	}
 }
@@ -2753,6 +2756,10 @@ static inline void dwc2_handle_oepint(const struct device *dev)
 			dwc2_handle_out_xfercompl(dev, n);
 		}
 
+		if (status & USB_DWC2_DOEPINT_EPDISBLD) {
+			k_event_post(&priv->ep_disabled, BIT(16 + n));
+		}
+
 		epint &= ~BIT(n);
 	}
 
@@ -2778,6 +2785,7 @@ static void dwc2_handle_incompisoin(const struct device *dev)
 		usb_dwc2_set_depctl_eptype(USB_DWC2_DEPCTL_EPTYPE_ISO) |
 		USB_DWC2_DEPCTL_USBACTEP;
 	uint32_t eps = priv->iso_enabled & 0x0000FFFFUL;
+	uint16_t rearm = 0;
 
 	while (eps) {
 		uint8_t i = find_lsb_set(eps) - 1;
@@ -2795,20 +2803,22 @@ static void dwc2_handle_incompisoin(const struct device *dev)
 			__ASSERT_NO_MSG(cfg && cfg->stat.enabled &&
 					dwc2_ep_is_iso(cfg));
 
-			udc_dwc2_ep_disable(dev, cfg, false);
+			udc_dwc2_ep_disable(dev, cfg, false, false);
 
 			buf = udc_buf_get(cfg);
 			if (buf) {
 				/* Data is no longer relevant */
 				udc_submit_ep_event(dev, buf, 0);
 
-				/* Try to queue next packet before SOF */
-				dwc2_handle_xfer_next(dev, cfg);
+				rearm |= BIT(i);
 			}
 		}
 
 		eps &= ~BIT(i);
 	}
+
+	/* Mark endpoints to re-arm in EPDISBLD handler */
+	priv->iso_in_rearm = rearm;
 
 	sys_write32(USB_DWC2_GINTSTS_INCOMPISOIN, gintsts_reg);
 }
@@ -2849,7 +2859,7 @@ static void dwc2_handle_incompisoout(const struct device *dev)
 			__ASSERT_NO_MSG(cfg && cfg->stat.enabled &&
 					dwc2_ep_is_iso(cfg));
 
-			udc_dwc2_ep_disable(dev, cfg, false);
+			udc_dwc2_ep_disable(dev, cfg, false, false);
 
 			buf = udc_buf_get(cfg);
 			if (buf) {
@@ -2861,6 +2871,51 @@ static void dwc2_handle_incompisoout(const struct device *dev)
 	}
 
 	sys_write32(USB_DWC2_GINTSTS_INCOMPISOOUT, gintsts_reg);
+}
+
+static void dwc2_handle_goutnakeff(const struct device *dev)
+{
+	const struct udc_dwc2_config *const config = dev->config;
+	struct usb_dwc2_reg *const base = config->base;
+	struct udc_dwc2_data *const priv = udc_get_private(dev);
+	k_spinlock_key_t key;
+	mem_addr_t doepctl_reg;
+	uint32_t doepctl;
+
+	key = k_spin_lock(&priv->lock);
+
+	while (priv->ep_out_disable) {
+		uint8_t ep_idx = find_lsb_set(priv->ep_out_disable) - 1;
+
+		priv->ep_out_disable &= ~BIT(ep_idx);
+
+		doepctl_reg = (mem_addr_t)&base->out_ep[ep_idx].doepctl;
+		doepctl = sys_read32(doepctl_reg);
+
+		/* The application cannot disable control OUT endpoint 0. */
+		if (ep_idx != 0) {
+			doepctl |= USB_DWC2_DEPCTL_EPDIS;
+		}
+
+		if (priv->ep_out_stall & BIT(ep_idx)) {
+			/* For OUT endpoints STALL is set instead of SNAK */
+			doepctl |= USB_DWC2_DEPCTL_STALL;
+			priv->ep_out_stall &= ~BIT(ep_idx);
+		} else {
+			doepctl |= USB_DWC2_DEPCTL_SNAK;
+		}
+
+		sys_write32(doepctl, doepctl_reg);
+
+		if (ep_idx == 0) {
+			/* Consider endpoint to be disabled */
+			k_event_post(&priv->ep_disabled, BIT(16));
+		}
+	}
+
+	sys_set_bits((mem_addr_t)&base->dctl, USB_DWC2_DCTL_CGOUTNAK);
+
+	k_spin_unlock(&priv->lock, key);
 }
 
 static void udc_dwc2_isr_handler(const struct device *dev)
@@ -2966,6 +3021,13 @@ static void udc_dwc2_isr_handler(const struct device *dev)
 		if (IS_ENABLED(CONFIG_UDC_ENABLE_SOF) &&
 		    int_status & USB_DWC2_GINTSTS_INCOMPISOOUT) {
 			dwc2_handle_incompisoout(dev);
+		}
+
+		if (int_status & USB_DWC2_GINTSTS_GOUTNAKEFF) {
+			/* Clear Global OUT NAK Effective interrupt. */
+			sys_write32(USB_DWC2_GINTSTS_GOUTNAKEFF, gintsts_reg);
+
+			dwc2_handle_goutnakeff(dev);
 		}
 
 		if (int_status & USB_DWC2_GINTSTS_USBSUSP) {


### PR DESCRIPTION
Do not synchronously wait for endpoint interrupt bits when disarming endpoints. Introduce ep_disabled k_event that makes it possible for application to wait for the action to take effect which is necessary when handling SetFeature(ENDPOINT_HALT) or SetInterface() requests.

This change improves incomplete iso IN and OUT handling performance, especially when there are multiple isochronous endpoints that need servicing.