### PR TITLE
bluetooth: bap_unicast_client: fix BAP/UCL/SCC/BV-103-C testcase failure

### DIFF
--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -483,10 +483,11 @@ bool bt_bap_stream_can_disconnect(const struct bt_bap_stream *stream)
 
 		pair_ep = bt_bap_iso_get_paired_ep(stream_ep);
 
-		/* If there are no paired endpoint, or the paired endpoint is
-		 * not in the streaming state, we can disconnect the CIS
+		/* If there are no paired endpoint, or the paired endpoint is in the QoS Configured
+		 * or Codec Configured state, we can disconnect the CIS
 		 */
-		if (pair_ep == NULL || pair_ep->status.state != BT_BAP_EP_STATE_STREAMING) {
+		if (pair_ep == NULL || pair_ep->status.state == BT_BAP_EP_STATE_QOS_CONFIGURED ||
+			pair_ep->status.state == BT_BAP_EP_STATE_CODEC_CONFIGURED) {
 			return true;
 		}
 	}

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2025 Nordic Semiconductor ASA
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -2389,13 +2390,11 @@ void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)
 		proc_param->in_progress = true;
 
 		err = bt_bap_stream_stop(next_bap_stream);
-		if (err != 0 && err != -EALREADY) {
+		if (err != 0) {
 			LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
 
 			bt_cap_common_abort_proc(next_bap_stream->conn, err);
 			cap_initiator_unicast_audio_proc_complete();
-		} else if (err == -EALREADY) {
-			proc_param->in_progress = false;
 		} /* else wait for server notification*/
 	}
 }
@@ -2449,13 +2448,11 @@ void bt_cap_initiator_stopped(struct bt_cap_stream *cap_stream)
 			proc_param->in_progress = true;
 
 			err = bt_bap_stream_stop(next_bap_stream);
-			if (err != 0 && err != -EALREADY) {
+			if (err != 0) {
 				LOG_DBG("Failed to stop stream %p: %d", next_cap_stream, err);
 
 				bt_cap_common_abort_proc(next_bap_stream->conn, err);
 				cap_initiator_unicast_audio_proc_complete();
-			} else if (err == -EALREADY) {
-				proc_param->in_progress = false;
 			}
 		} /* else await notification from server */
 	} else {


### PR DESCRIPTION
- In bap_unicast_client, it was assumed that ASE is binded with CIS handler during sending "received_stop_ready" to unicast_server.
- In case where unicast_client has not started the stream with "receiver_start_ready" att command to server, but wants to disable ASE which was Enabled previously (but not stream!) causes failure since there is no cis_create has happened and linked to ASE.
- In BAP_TS, "BAP/UCL/SCC/BV-103-C" has a same test conditions where client first enables the ASE, disable the ASE, and expecting "receiver_stop_ready" att command from client to server followed by server notification to enter its ASE in QoS_configured state.
- Removed this condition checks to send expected att command to server from Enabling ASE state to Disable ASE.

<img width="560" alt="image" src="https://github.com/user-attachments/assets/a86cb4be-2a31-4c02-a379-6a6680129244" />

<img width="484" alt="image" src="https://github.com/user-attachments/assets/2d71621f-c3ff-4cbc-93c5-b0cd4799f8a5" />


Fail and Pass logs are attached here, 

[BAP_UCL_SCC_BV_103_C.zip](https://github.com/user-attachments/files/20883505/BAP_UCL_SCC_BV_103_C.zip)

Regards,
Nirav