### PR TITLE
net: lwm2m: Implement gt/lt/st attributes handling

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -446,6 +446,14 @@ config LWM2M_NUM_ATTR
 	  This value sets up the maximum number of LwM2M attributes that
 	  we can handle at the same time.
 
+config LWM2M_MAX_NOTIFIED_NUMERICAL_RES_TRACKED
+	int "Maximum # of resources that can track last notified value for gt/lt/st"
+	default 4
+	help
+	  This value specifies the maximum number of numerical LwM2M resources
+	  that can track the last notified resource value for gt/lt/st attribute
+	  handling.
+
 endmenu # "Memory and buffer size configuration"
 
 menu "Content format supports"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -71,6 +71,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #endif
 
 #define ENGINE_SLEEP_MS 500
+#define NOTIFY_DELAY_MS 100
 
 #ifdef CONFIG_LWM2M_VERSION_1_1
 #define LWM2M_ENGINE_MAX_OBSERVER_PATH CONFIG_LWM2M_ENGINE_MAX_OBSERVER * 3
@@ -613,6 +614,7 @@ static int64_t check_notifications(struct lwm2m_ctx *ctx, const int64_t timestam
 		}
 		/* Check That There is not pending process*/
 		if (obs->active_notify != NULL) {
+			obs->event_timestamp += NOTIFY_DELAY_MS;
 			continue;
 		}
 

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -3200,6 +3200,7 @@ msg_init:
 	obs->active_notify = msg;
 	obs->resource_update = false;
 	lwm2m_information_interface_send(msg);
+	lwm2m_engine_observer_refresh_notified_values(obs);
 #if defined(CONFIG_LWM2M_RESOURCE_DATA_CACHE_SUPPORT)
 	msg->cache_info = NULL;
 #endif

--- a/subsys/net/lib/lwm2m/lwm2m_observation.h
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.h
@@ -88,6 +88,8 @@ int lwm2m_get_path_reference_ptr(struct lwm2m_engine_obj *obj, const struct lwm2
  */
 void lwm2m_engine_clear_duplicate_path(sys_slist_t *lwm2m_path_list, sys_slist_t *lwm2m_free_list);
 
+void lwm2m_engine_observer_refresh_notified_values(struct observe_node *obs);
+
 /* Resources */
 sys_slist_t *lwm2m_obs_obj_path_list(void);
 #endif /* LWM2M_OBSERVATION_H */

--- a/subsys/net/lib/lwm2m/lwm2m_observation.h
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.h
@@ -32,7 +32,7 @@ const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr);
 
 const char *const lwm2m_attr_to_str(uint8_t type);
 
-void clear_attrs(void *ref);
+void clear_attrs(uint8_t level, void *ref);
 
 int64_t engine_observe_shedule_next_event(struct observe_node *obs, uint16_t srv_obj_inst,
 					  const int64_t timestamp);

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -306,11 +306,11 @@ int lwm2m_delete_obj_inst(uint16_t obj_id, uint16_t obj_inst_id)
 
 	/* reset obj_inst and res_inst data structure */
 	for (i = 0; i < obj_inst->resource_count; i++) {
-		clear_attrs(&obj_inst->resources[i]);
+		clear_attrs(LWM2M_PATH_LEVEL_RESOURCE, &obj_inst->resources[i]);
 		(void)memset(obj_inst->resources + i, 0, sizeof(struct lwm2m_engine_res));
 	}
 
-	clear_attrs(obj_inst);
+	clear_attrs(LWM2M_PATH_LEVEL_OBJECT_INST, obj_inst);
 	(void)memset(obj_inst, 0, sizeof(struct lwm2m_engine_obj_inst));
 	k_mutex_unlock(&registry_lock);
 	return ret;

--- a/tests/net/lib/lwm2m/interop/pytest/test_observe_attributes.py
+++ b/tests/net/lib/lwm2m/interop/pytest/test_observe_attributes.py
@@ -1,0 +1,157 @@
+"""
+Tests for Observe attributes in LwM2M
+#####################################
+
+Copyright (c) 2025 Nordic Semiconductor ASA
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import time
+
+import pytest
+from leshan import Leshan
+from twister_harness import Shell
+
+TEST_PMAX: float = 4
+TEST_TIME_ACC: float = 0.5
+
+
+def test_attribute_gt_lt_st_wrong_res_type(leshan: Leshan, endpoint: str):
+    """
+    Verify that gt/lt/st attributes only be assigned to numerical resources.
+    """
+    # Manufacturer - should fail as that's a string type
+    assert leshan.write_attributes(endpoint, '3/0/0', {'gt': 4200})['status'] != 'CHANGED(204)'
+    assert leshan.write_attributes(endpoint, '3/0/0', {'lt': 3000})['status'] != 'CHANGED(204)'
+    assert leshan.write_attributes(endpoint, '3/0/0', {'st': 200})['status'] != 'CHANGED(204)'
+    # Battery level - should be fine
+    assert leshan.write_attributes(endpoint, '3/0/7', {'gt': 4200})['status'] == 'CHANGED(204)'
+    assert leshan.write_attributes(endpoint, '3/0/7', {'lt': 3000})['status'] == 'CHANGED(204)'
+    assert leshan.write_attributes(endpoint, '3/0/7', {'st': 200})['status'] == 'CHANGED(204)'
+    leshan.remove_attributes(endpoint, '3/0/7', ['gt'])
+    leshan.remove_attributes(endpoint, '3/0/7', ['lt'])
+    leshan.remove_attributes(endpoint, '3/0/7', ['st'])
+
+
+@pytest.mark.slow
+def test_attribute_step(shell: Shell, leshan: Leshan, endpoint: str):
+    """
+    Verify that Step attribute is respected when sending notifications
+    """
+    assert leshan.write_attributes(endpoint, '3/0/7', {'st': 200})['status'] == 'CHANGED(204)'
+    assert (
+        leshan.write_attributes(endpoint, '3/0/7', {'pmax': TEST_PMAX})['status'] == 'CHANGED(204)'
+    )
+    leshan.observe(endpoint, '3/0/7')
+    with leshan.get_event_stream(endpoint, timeout=30) as events:
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 3000')
+        data = events.next_event('NOTIFICATION')
+        assert data is not None
+        assert data[3][0][7][0] == 3000
+        # Ensure that we don't get new notification before pmax expires
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 3100')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 3100
+        assert (start + TEST_PMAX) < time.time() + TEST_TIME_ACC
+        assert (start + TEST_PMAX) > time.time() - TEST_TIME_ACC
+        # Step attribute condition should be satisfied
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 3500')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 3500
+        assert start <= time.time() + TEST_TIME_ACC
+    leshan.cancel_observe(endpoint, '3/0/7')
+    leshan.remove_attributes(endpoint, '3/0/7', ['st'])
+    leshan.remove_attributes(endpoint, '3/0/7', ['pmax'])
+
+
+@pytest.mark.slow
+def test_attribute_greater_than(shell: Shell, leshan: Leshan, endpoint: str):
+    """
+    Verify that Greater Than attribute is respected when sending notifications
+    """
+    assert leshan.write_attributes(endpoint, '3/0/7', {'gt': 4200})['status'] == 'CHANGED(204)'
+    assert (
+        leshan.write_attributes(endpoint, '3/0/7', {'pmax': TEST_PMAX})['status'] == 'CHANGED(204)'
+    )
+    leshan.observe(endpoint, '3/0/7')
+    with leshan.get_event_stream(endpoint, timeout=30) as events:
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 3000')
+        data = events.next_event('NOTIFICATION')
+        assert data is not None
+        assert data[3][0][7][0] == 3000
+        # Ensure that we don't get new notification before pmax expires
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 4100')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 4100
+        assert (start + TEST_PMAX) < time.time() + TEST_TIME_ACC
+        assert (start + TEST_PMAX) > time.time() - TEST_TIME_ACC
+        # Greater than attribute condition should be satisfied
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 4400')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 4400
+        assert start <= time.time() + TEST_TIME_ACC
+        # Still above threshold - no new notification expected before pmax
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 4300')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 4300
+        assert (start + TEST_PMAX) < time.time() + TEST_TIME_ACC
+        assert (start + TEST_PMAX) > time.time() - TEST_TIME_ACC
+        # Greater than attribute condition should be satisfied again
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 4100')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 4100
+    leshan.cancel_observe(endpoint, '3/0/7')
+    leshan.remove_attributes(endpoint, '3/0/7', ['gt'])
+    leshan.remove_attributes(endpoint, '3/0/7', ['pmax'])
+
+
+@pytest.mark.slow
+def test_attribute_less_than(shell: Shell, leshan: Leshan, endpoint: str):
+    """
+    Verify that Less Than attribute is respected when sending notifications
+    """
+    assert leshan.write_attributes(endpoint, '3/0/7', {'gt': 3000})['status'] == 'CHANGED(204)'
+    assert (
+        leshan.write_attributes(endpoint, '3/0/7', {'pmax': TEST_PMAX})['status'] == 'CHANGED(204)'
+    )
+    leshan.observe(endpoint, '3/0/7')
+    with leshan.get_event_stream(endpoint, timeout=30) as events:
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 3200')
+        data = events.next_event('NOTIFICATION')
+        assert data is not None
+        assert data[3][0][7][0] == 3200
+        # Ensure that we don't get new notification before pmax expires
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 3100')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 3100
+        assert (start + TEST_PMAX) < time.time() + TEST_TIME_ACC
+        assert (start + TEST_PMAX) > time.time() - TEST_TIME_ACC
+        # Less than attribute condition should be satisfied
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 2800')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 2800
+        assert start <= time.time() + TEST_TIME_ACC
+        # Still below threshold - no new notification expected before pmax
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 2900')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 2900
+        assert (start + TEST_PMAX) < time.time() + TEST_TIME_ACC
+        assert (start + TEST_PMAX) > time.time() - TEST_TIME_ACC
+        # Less than attribute condition should be satisfied again
+        start = time.time()
+        shell.exec_command('lwm2m write /3/0/7/0 -u32 3100')
+        data = events.next_event('NOTIFICATION')
+        assert data[3][0][7][0] == 3100
+    leshan.cancel_observe(endpoint, '3/0/7')
+    leshan.remove_attributes(endpoint, '3/0/7', ['gt'])
+    leshan.remove_attributes(endpoint, '3/0/7', ['pmax'])


### PR DESCRIPTION
This PR implements Greater Than / Less Than / Step attributes handling in the LwM2M client library. While it was already possible to specicfy those attributes for resources, they were ignored by the LwM2M observe engine.

The biggest challenge was to decide on how to store the last notified value for resources that have gt/lt/st attributes configured. I propose a simple regsitry where an entry is allocated whenever one of the gt/lt/st attributes is set on the resource, similarily to how the actual attributes are stored. This approach seemed the best apporach memory-wise, although it obviously additionally limits the maximum number of resources that can have one of those numerical attributes set.

I'm not adding any tests for the feature, as the interop test spec doesn't actually seem to specify any tests to verify gt/lt/st attributes behavior and testing this in ztest didn't really seem viable.

Resolves #79306