### PR TITLE
usb: device_next: uac2: Do not leak double buffered endpoint

### DIFF
--- a/subsys/usb/device_next/class/usbd_uac2.c
+++ b/subsys/usb/device_next/class/usbd_uac2.c
@@ -816,6 +816,9 @@ static int uac2_request(struct usbd_class_data *const c_data, struct net_buf *bu
 				       ctx->user_data);
 	} else if (!is_feedback) {
 		ctx->ops->buf_release_cb(dev, terminal, buf->__buf, ctx->user_data);
+		if (buf->frags) {
+			ctx->ops->buf_release_cb(dev, terminal, buf->frags->__buf, ctx->user_data);
+		}
 	}
 
 	usbd_ep_buf_free(uds_ctx, buf);


### PR DESCRIPTION
UDC drivers use udc_buf_get_all() when dequeueing endpoint. On drivers that require double buffering for isochronous IN endpoint, the dequeue on interface disable will result in class request API called on net_buf with frags set. Call release callback on the buffer pointed in frags because it was passed in using usbd_uac2_send().