### PR TITLE
libc: minimal: Add "prohibit_lto" flag to avoid problems with LTO

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -12,6 +12,7 @@ set(GEN_DIR ${ZEPHYR_BINARY_DIR}/include/generated)
 set(STRERROR_TABLE_H ${GEN_DIR}/libc/minimal/strerror_table.h)
 
 zephyr_library_compile_options($<TARGET_PROPERTY:compiler,no_builtin>)
+zephyr_library_compile_options($<TARGET_PROPERTY:compiler,prohibit_lto>)
 
 zephyr_library_sources(
   source/stdlib/atoi.c


### PR DESCRIPTION
The compiler requires that much of the C library be built without using LTO so that various symbols are available for use by generated code, including things like memset and memcpy.

Add the "prohibit_lto" CMake target compiler property to avoid LTO when activated.

Should close https://github.com/zephyrproject-rtos/zephyr/issues/90319