### PR TITLE
soc: microchip: mec: Add Kconfig for Segger RTT debug support

### DIFF
--- a/soc/microchip/mec/Kconfig
+++ b/soc/microchip/mec/Kconfig
@@ -4,6 +4,9 @@
 # Copyright (c) 2022, Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+config SOC_FAMILY_MICROCHIP_MEC
+	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
+
 if SOC_FAMILY_MICROCHIP_MEC
 
 menuconfig MCHP_MEC_UNSIGNED_HEADER


### PR DESCRIPTION
All parts in the Microchip MEC family support ARM JTAG/SWD/SWO. We add Kconfig logic to allow building projects with Segger's RTT debug for Cortex-M.