### PR TITLE
include: cbprintf: Fix call to memcpy with null pointer

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -529,6 +529,10 @@ static inline int z_cbprintf_cpy(const void *buf, size_t len, void *ctx)
 {
 	struct z_cbprintf_buf_desc *desc = (struct z_cbprintf_buf_desc *)ctx;
 
+	if (len == 0) {
+		return 0;
+	}
+
 	if ((desc->size - desc->off) < len) {
 		return -ENOSPC;
 	}


### PR DESCRIPTION
`cbprintf_package_convert` may invoke `z_cbprintf_cpy` with a null pointer to buf and zero length to indicate a flush operation.

https://github.com/zephyrproject-rtos/zephyr/blob/f2c37c4b13252352472cbab98907c0a3fce2b2d4/lib/os/cbprintf_packaged.c#L1166-L1167

This triggers an error from the undefined behavior sanitizer due to memcpy being called with a null src:

```
zephyr/include/zephyr/sys/cbprintf.h:536:45: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
    #0 0x8186fa9 in z_cbprintf_cpy zephyr/include/zephyr/sys/cbprintf.h:536:2
    #1 0x816bd79 in cbprintf_package_convert zephyr/lib/os/cbprintf_packaged.c:1167:8
    #2 0x81865c7 in cbprintf_package_copy zephyr/include/zephyr/sys/cbprintf.h:586:9
    #3 0x81865c7 in z_impl_z_log_msg_static_create zephyr/subsys/logging/log_msg.c:323:10
<snip>

SUMMARY: UndefinedBehaviorSanitizer: invalid-null-argument zephyr/include/zephyr/sys/cbprintf.h:536:45
```
Passing a null pointer as source to `memcpy` is undefined behavior according to the C standard.
> The behavior is undefined if either dest or src is an invalid or null pointer.

This PR adds a fix by exiting early in `z_cbprintf_cpy` when length is zero.