### PR TITLE
logging: fix storage size of 'tspec' isn't known

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <time.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_backend.h>
 #include <zephyr/logging/log_ctrl.h>


### PR DESCRIPTION
fix storage size of 'tspec' isn't known
struct timespec wasn't defined anymore.

forgotten here: #90096