### PR TITLE
net: openthread: Add missing include for logging in diag.c

### DIFF
--- a/modules/openthread/platform/diag.c
+++ b/modules/openthread/platform/diag.c
@@ -10,6 +10,7 @@
 #include <openthread/error.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/logging.h>
 #include <openthread/platform/radio.h>
 
 #include "platform-zephyr.h"


### PR DESCRIPTION
This commit adds logging.h header to the diag.c file to ensure all symbols are declared.