### PR TITLE
twister: Fix tests statuses if quarantine is verified

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -607,8 +607,7 @@ class TestPlan:
                 instance.reason = "Quarantine: " + matched_quarantine
                 return
             if not matched_quarantine and self.options.quarantine_verify:
-                instance.status = TwisterStatus.SKIP
-                instance.reason = "Not under quarantine"
+                instance.add_filter("Not under quarantine", Filters.CMD_LINE)
 
     def load_from_file(self, file, filter_platform=None):
         if filter_platform is None:

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -342,7 +342,7 @@ def test_quarantine_short(class_testplan, platforms_list, test_data,
             if testname in expected_val:
                 assert instance.status == TwisterStatus.NONE
             else:
-                assert instance.status == TwisterStatus.SKIP
+                assert instance.status == TwisterStatus.FILTER
                 assert instance.reason == "Not under quarantine"
         else:
             if testname in expected_val:


### PR DESCRIPTION
If test configuration is not quarantined and `--quarantine-verify` mode is enabled, these should be filtered and not attached to reports.

Proposed change applies this approach.