### PR TITLE
drivers: spi: stm32: fix h7 issue with spi_hold_on_cs

### DIFF
--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -24,6 +24,9 @@ struct spi_stm32_config {
 	const struct pinctrl_dev_config *pcfg;
 #ifdef CONFIG_SPI_STM32_INTERRUPT
 	irq_config_func_t irq_config;
+#ifdef CONFIG_SOC_SERIES_STM32H7X
+	uint32_t irq_line;
+#endif /* CONFIG_SOC_SERIES_STM32H7X */
 #endif
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_subghz)
 	bool use_subghzspi_nss;


### PR DESCRIPTION
STM32H7 spi_loopback test fails since the introduction of a test enabling SPI_HOLD_ON_CS.
This uncovered an issue where the SPI ISR is constantly called if the SPI is not disabled, even if the interrupt enable register is completely cleared.
A workaround is to disable the SPI IRQ at the NVIC level when SPI_HOLD_ON_CS is used.