### PR TITLE
sys: clock: re-apply change to Z_IS_TIMEOUT_RELATIVE

### DIFF
--- a/include/zephyr/sys/clock.h
+++ b/include/zephyr/sys/clock.h
@@ -151,7 +151,14 @@ typedef struct {
 
 /* Test for relative timeout */
 #if CONFIG_TIMEOUT_64BIT
-#define Z_IS_TIMEOUT_RELATIVE(timeout) (Z_TICK_ABS((timeout).ticks) < 0)
+/* Positive values are relative/delta timeouts and negative values are absolute
+ * timeouts, except -1 which is reserved for K_TIMEOUT_FOREVER. 0 is K_NO_WAIT,
+ * which is historically considered a relative timeout.
+ * K_TIMEOUT_FOREVER is not considered a relative timeout and neither is it
+ * considerd an absolute timeouts (so !Z_IS_TIMEOUT_RELATIVE() does not
+ * necessarily mean it is an absolute timeout if ticks == -1);
+ */
+#define Z_IS_TIMEOUT_RELATIVE(timeout) (((timeout).ticks) >= 0)
 #else
 #define Z_IS_TIMEOUT_RELATIVE(timeout) true
 #endif


### PR DESCRIPTION
A mid-air collision / bad rebase between two different changes to sys_clock.h resulted in a test failure.

```shell
tests/kernel/timer/timer_api/src/main.c:763:
  timer_api_test_timeout_abs: Z_IS_TIMEOUT_RELATIVE(t2) is false
```

Re-apply the change that was added in 9075d5335596080291ebcc448819fed2110dcb9a to keep tests running smoothly.

Testing Done:
```shell
west build -p auto -b mps2/an385 -t run tests/kernel/timer/timer_api/
...
*** Booting Zephyr OS build v4.1.0-6606-g6c17c5deed69 ***
Running TESTSUITE timer_api
===================================================================
START - test_sleep_abs
 PASS - test_sleep_abs in 1.020 seconds
===================================================================
START - test_time_conversions
 PASS - test_time_conversions in 0.301 seconds
===================================================================
START - test_timeout_abs
 PASS - test_timeout_abs in 0.078 seconds
===================================================================
START - test_timer_duration_period
 PASS - test_timer_duration_period in 0.345 seconds
===================================================================
START - test_timer_expirefn_null
 PASS - test_timer_expirefn_null in 0.340 seconds
===================================================================
START - test_timer_k_define
 PASS - test_timer_k_define in 0.730 seconds
===================================================================
START - test_timer_period_0
 PASS - test_timer_period_0 in 0.215 seconds
===================================================================
START - test_timer_period_k_forever
 PASS - test_timer_period_k_forever in 0.220 seconds
===================================================================
START - test_timer_periodicity
 PASS - test_timer_periodicity in 0.289 seconds
===================================================================
START - test_timer_remaining
 PASS - test_timer_remaining in 0.070 seconds
===================================================================
START - test_timer_restart
 PASS - test_timer_restart in 0.295 seconds
===================================================================
START - test_timer_status_get
 PASS - test_timer_status_get in 0.015 seconds
===================================================================
START - test_timer_status_get_anytime
 PASS - test_timer_status_get_anytime in 0.345 seconds
===================================================================
START - test_timer_status_sync
 PASS - test_timer_status_sync in 0.385 seconds
===================================================================
START - test_timer_user_data
 PASS - test_timer_user_data in 0.310 seconds
===================================================================
TESTSUITE timer_api succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [timer_api]: pass = 15, fail = 0, skip = 0, total = 15 duration = 4.958 seconds
 - PASS - [timer_api.test_sleep_abs] duration = 1.020 seconds
 - PASS - [timer_api.test_time_conversions] duration = 0.301 seconds
 - PASS - [timer_api.test_timeout_abs] duration = 0.078 seconds
 - PASS - [timer_api.test_timer_duration_period] duration = 0.345 seconds
 - PASS - [timer_api.test_timer_expirefn_null] duration = 0.340 seconds
 - PASS - [timer_api.test_timer_k_define] duration = 0.730 seconds
 - PASS - [timer_api.test_timer_period_0] duration = 0.215 seconds
 - PASS - [timer_api.test_timer_period_k_forever] duration = 0.220 seconds
 - PASS - [timer_api.test_timer_periodicity] duration = 0.289 seconds
 - PASS - [timer_api.test_timer_remaining] duration = 0.070 seconds
 - PASS - [timer_api.test_timer_restart] duration = 0.295 seconds
 - PASS - [timer_api.test_timer_status_get] duration = 0.015 seconds
 - PASS - [timer_api.test_timer_status_get_anytime] duration = 0.345 seconds
 - PASS - [timer_api.test_timer_status_sync] duration = 0.385 seconds
 - PASS - [timer_api.test_timer_user_data] duration = 0.310 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```