### PR TITLE
xtensa: gdbstub: fix code stepping

### DIFF
--- a/include/zephyr/arch/xtensa/gdbstub.h
+++ b/include/zephyr/arch/xtensa/gdbstub.h
@@ -102,6 +102,9 @@ struct gdb_ctx {
 
 	/** Index in register descriptions of AR0 register */
 	uint8_t			ar_idx;
+
+	/** Index in register descriptions of PS register */
+	uint8_t			ps_idx;
 };
 
 /**


### PR DESCRIPTION
The ICOUNTLEVEL register needs to be manipulated carefully according to where we want to stop.