### PR TITLE
drivers: i2c: sam: fix the exception when transferring without data

### DIFF
--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -293,7 +293,7 @@ static void i2c_sam_twi_isr(const struct device *dev)
 
 	/* Byte sent */
 	if (isr_status & TWI_SR_TXRDY) {
-		if (msg->idx == msg->len) {
+		if (msg->idx == msg->len || msg->len == 0) {
 			if (msg->flags & I2C_MSG_STOP) {
 				/* Send a STOP condition on the TWI */
 				twi->TWI_CR = TWI_CR_STOP;


### PR DESCRIPTION
The issue is found when doing shell command "i2c scan" on sama7g54-ek.

In this case no data will be transferred besides START and STOP. Data abort would occur on accessing "msg->buf[msg->idx++]" when MMU is enabled and "msg->idx" is very large.