### PR TITLE
usb: device_next: uac2: support higher bInterval values

### DIFF
--- a/dts/bindings/usb/uac2/zephyr,uac2-audio-streaming.yaml
+++ b/dts/bindings/usb/uac2/zephyr,uac2-audio-streaming.yaml
@@ -78,3 +78,11 @@ properties:
     type: int
     description: |
       Number of effectively used bits in audio subslot.
+
+  polling-period-us:
+    type: int
+    description: |
+      Input or output endpoint polling period in microseconds. For USB full
+      speed this could be clamped to 1ms or 32768ms depending on the value. For
+      USB high speed this could be clamped to 125us or 4096ms depending on the
+      value.

--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -354,8 +354,8 @@ struct usb_association_descriptor {
 /** Calculate high speed interrupt endpoint bInterval from a value in microseconds */
 #define USB_HS_INT_EP_INTERVAL(us)	CLAMP((ilog2((us) / 125U) + 1U), 1U, 16U)
 
-/** Calculate high speed isochronous endpoint bInterval from a value in microseconds */
-#define USB_FS_ISO_EP_INTERVAL(us)	CLAMP(((us) / 1000U), 1U, 16U)
+/** Calculate full speed isochronous endpoint bInterval from a value in microseconds */
+#define USB_FS_ISO_EP_INTERVAL(us)	CLAMP((ilog2((us) / 1000U) + 1U), 1U, 16U)
 
 /** Calculate high speed isochronous endpoint bInterval from a value in microseconds */
 #define USB_HS_ISO_EP_INTERVAL(us)	CLAMP((ilog2((us) / 125U) + 1U), 1U, 16U)


### PR DESCRIPTION
This PR adds support to specify higher bInterval values for the UAC2 USB Class Driver via the Device Tree.

The intent is reduce the frequency of USB Device Controller events and its impact to performance.

Signed-off-by: Victor Brzeski <vbrzeski@gmail.com>