### PR TITLE
soc: microchip: sama7g5: optimize get_rate(), get_status() for clocks, update config NUM_IRQS

### DIFF
--- a/soc/microchip/sam/common/clk-generated.c
+++ b/soc/microchip/sam/common/clk-generated.c
@@ -135,6 +135,8 @@ static int clk_generated_get_rate(const struct device *dev,
 		LOG_ERR("get parent clock rate failed.");
 		return ret;
 	}
+
+	gck->gckdiv = FIELD_GET(PMC_PCR_GCLKDIV_Msk, status);
 	*rate /= (gck->gckdiv + 1);
 
 	return 0;

--- a/soc/microchip/sam/sama7g5/Kconfig.defconfig
+++ b/soc/microchip/sam/sama7g5/Kconfig.defconfig
@@ -6,7 +6,7 @@
 if SOC_SERIES_SAMA7G5
 
 config NUM_IRQS
-	default 155
+	default 187
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/soc/timer@e1800000,clock-frequency)


### PR DESCRIPTION
Changes in this PR list bellow:
- optimize get_rate(), get_status() for SCKC (Slow Clock Controller)
- optimize get_rate() for MCKx clocks and generic clocks
- update config `NUM_IRQS` with SGI & PPI interrupts counted