### PR TITLE
cmake: extensions: Add macro helper for functions to have no arguments

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5739,6 +5739,20 @@ macro(zephyr_check_flags_exclusive function prefix)
   endif()
 endmacro()
 
+#
+# Helper macro for verifying that no unexpected arguments are provided.
+#
+# A FATAL_ERROR will be raised if any unexpected argument is given.
+#
+# Usage:
+#   zephyr_check_no_arguments(<function_name> ${ARGN})
+#
+macro(zephyr_check_no_arguments function)
+  if(${ARGC} GREATER 1)
+    message(FATAL_ERROR "${function} called with unexpected argument(s): ${ARGN}")
+  endif()
+endmacro()
+
 ########################################################
 # 7. Linkable loadable extensions (llext)
 ########################################################

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -428,6 +428,8 @@ endmacro()
 
 # Constructor with a directory-inferred name
 macro(zephyr_library)
+  zephyr_check_no_arguments(zephyr_library ${ARGN})
+
   zephyr_library_get_current_dir_lib_name(${ZEPHYR_BASE} lib_name)
   zephyr_library_named(${lib_name})
 endmacro()
@@ -452,6 +454,8 @@ endmacro()
 
 # Constructor with an explicitly given name.
 macro(zephyr_library_named name)
+  zephyr_check_no_arguments(zephyr_library_named ${ARGN})
+
   # This is a macro because we need add_library() to be executed
   # within the scope of the caller.
   set(ZEPHYR_CURRENT_LIBRARY ${name})


### PR DESCRIPTION
Add `zephyr_check_no_arguments` that macros and functions can call to check that no arguments are given.