### PR TITLE
doc: contribute: guidelines: update copyright notice guidelines

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -101,20 +101,37 @@ this contributing and review process for imported components.
 
 .. _copyrights:
 
-Copyrights Notices
-******************
+Copyright and License Notices
+=============================
 
-The Zephyr Project follows the `Community Best Practice`_ for Copyright Notices from the Linux
-Foundation.
+Zephyr follows SPDX/REUSE-style file headers. Add a machine-readable copyright notice and a license
+identifier at the top of each file so tooling can detect them (for example
+:ref:`west spdx <west-spdx>`, which uses the `REUSE tool`_).
 
-We recommend using the following copyright notice:
+The Zephyr Project follows the `Community Best Practice`_ for copyright notices from the Linux
+Foundation, therefore we recommend using the following copyright notice:
 
-.. code-block:: C
+.. code-block:: none
 
-    Copyright The Zephyr Project Contributors
+   SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+Include the license identifier alongside it:
+
+.. code-block:: none
+
+   SPDX-License-Identifier: Apache-2.0
+
+Practical guidance:
+
+- Place both lines at the very top of the file using the file's native comment syntax.
+- If you authored substantial, original content, you *may* add an additional line for yourself or
+  your organization.
 
 .. _Community Best Practice:
    https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/
+
+.. _REUSE tool:
+   https://github.com/fsfe/reuse-tool
 
 .. _DCO:
 


### PR DESCRIPTION
Similar to `SPDX-License-Identifier`, there is a standard way to add copyright notices to source code so update the guidelines so that recommendation is that copyright notices are added using `SPDX-FileCopyrightText`.