### PR TITLE
driver: serial: uart_shell: read: Return correct return code

### DIFF
--- a/drivers/serial/uart_shell.c
+++ b/drivers/serial/uart_shell.c
@@ -69,13 +69,13 @@ static int cmd_uart_read(const struct shell *sh, size_t argc, char **argv)
 		}
 		if (ret != 0 && ret != -1) {
 			shell_error(sh, "Failed to read from UART (%d)", ret);
-			break;
+			return ret;
 		}
 	}
 
 	shell_fprintf_normal(sh, "\n");
 
-	return ret;
+	return 0;
 }
 
 


### PR DESCRIPTION
Always return exit code 0 when cmd_uart_read stopped reading data from UART. Instead, return with a error code in case reading from the UART interface failed.

Currently, this command might return with exit code -1 because uart_poll_in didn't return data and the read duration expired.