### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 11982df962e2314f4e0c73b7ebc17172026c9266
+      revision: 07222c1929e1d79d303baa8fde7f977a79e48e9a
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  07222c1929e1d79d303baa8fde7f977a79e48e9a

Brings following Zephyr relevant fixes:

  - 07222c19 boot_serial: Avoid re-initializing state in boot_image_validate_encrypted
  - a18f635a boot: Remove now superfluous start_off parameters
  - c62c19db boot_serial: Use flash sectors from bootloader state when possible
  - 13edc5fb boot_serial: Use flash area from bootloader state when possible
  - f1aa499c boot_serial: Initialize a bootloader state for bs_list and bs_set
  - f1efd483 bootutil: loader: Expose routine to determine sector layout
  - 72166868 bootutil: loader: Expose routine to open/close all flash areas
  - 0319e91c boot: bootutil: Fix encryption/decryption size during copy
  - a36f9513 imgtool: Add support for HMAC/HKDF-SHA512 with ECIES-X25519
  - 37719169 zephyr: Support for HKDF/HMAC with SHA512
  - 1d83177c bootutil: Add support for HAMC-SHA512 with ECIES-X25519
  - 7de064ea boot: zephyr: add support for booting ARC processors
  - 72459ec0 boot: zephyr: stm32n6570_dk: define CONFIG_MULTIPLE_EXECUTABLE_RAM_REGIONS
  - be8b3abc boot: Zephyr: Add a Kconfig for MULTIPLE_EXECUTABLE_RAM_REGIONS define
  - c5011f2b zephyr: Improve logging
  - 11f9c6f2 bootutil: Improve logging coverage
  - adbe1cfb boot: stm32n6: Define specific executable region
  - 93c2b50a boot: zephyr: boards: Add configuration for stm32n6570_dk
  - fca80b41 boot: zephyr: defines FLASH device for external NOR
  - 78d94cf4 imgtool: bump minimal required version to 2.2.0
  - af602f81 bootutil: Replace local identifiers with common definitions
  - e5756df5 bootutil: Remove redundant ALIGN definitions
  - e3a271c9 bootutil: Move all encryption TLV helper identifiers into one place
  - 68a4c962 boot: bootutil: avoid full erase on BOOT_MAGIC_BAD in boot_set_next
  - 1ed0218c scripts: imgtool: Add hash for ECDSA256P1Public
  - a90ddfc7 zephyr: Fix pinreset trigger
  - e56cecc4 bootutil: Small cleanup in image.h
  - 402d3f7f boot: zephyr: Refactor DFU entry logic
  - 687dc8c5 bootutil: boot_decrypt_key: Only one bootutil_hmac_sha256_drop needed
  - a0065f8f bootutil: Fix boot_scramble_region escaping flash area
  - bb644c7c bootutil: loader: overwrite-only mode fix for trailer erase

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.