### PR TITLE
stm32: tests: drivers: adc: adc_api: increase adc prescaler for nucleo_f746zg 

### DIFF
--- a/tests/drivers/adc/adc_api/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_f746zg.overlay
@@ -17,6 +17,7 @@
 	dma-names = "dma";
 
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in3_pa3>;
+	st,adc-prescaler = <4>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 


### PR DESCRIPTION
Fix regression on the nucleo_f746zg board for the adc_api test driver.

