### PR TITLE
drivers: ethernet: dont require mac address in dts

### DIFF
--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1699,7 +1699,7 @@ static const struct ethernet_api eth_dwc_xgmac_apis = {
 /* Device run-time data declaration macro */
 #define ETH_DWC_XGMAC_DEV_DATA(port)                                                               \
 	static struct eth_dwc_xgmac_dev_data eth_dwc_xgmac##port##_dev_data = {                    \
-		.mac_addr = DT_INST_PROP(port, local_mac_address),                                 \
+		.mac_addr = DT_INST_PROP_OR(port, local_mac_address, {0}),                         \
 		.link_speed = DT_INST_PROP(port, max_speed),                                       \
 		.enable_full_duplex = DT_INST_PROP(port, full_duplex_mode_en),                     \
 		.dma_rx_desc = &eth_dwc_xgmac##port##_rx_desc[0u][0u],                             \

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -472,7 +472,7 @@ static const struct ethernet_api lan865x_api_func = {
 	struct oa_tc6 oa_tc6_##inst = {                                                            \
 		.cps = 64, .protected = 0, .spi = &lan865x_config_##inst.spi};                     \
 	static struct lan865x_data lan865x_data_##inst = {                                         \
-		.mac_address = DT_INST_PROP(inst, local_mac_address),                              \
+		.mac_address = DT_INST_PROP_OR(inst, local_mac_address, {0}),                      \
 		.tx_rx_sem = Z_SEM_INITIALIZER((lan865x_data_##inst).tx_rx_sem, 1, 1),             \
 		.int_sem = Z_SEM_INITIALIZER((lan865x_data_##inst).int_sem, 0, 1),                 \
 		.tc6 = &oa_tc6_##inst};                                                            \

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -702,7 +702,7 @@ static int lan9250_init(const struct device *dev)
 
 #define LAN9250_DEFINE(inst)                                                                       \
 	static struct lan9250_runtime lan9250_##inst##_runtime = {                                 \
-		.mac_address = DT_INST_PROP(inst, local_mac_address),                              \
+		.mac_address = DT_INST_PROP_OR(inst, local_mac_address, {0}),                      \
 		.tx_rx_sem = Z_SEM_INITIALIZER(lan9250_##inst##_runtime.tx_rx_sem, 1, UINT_MAX),   \
 		.int_sem = Z_SEM_INITIALIZER(lan9250_##inst##_runtime.int_sem, 0, UINT_MAX),       \
 	};                                                                                         \

--- a/drivers/ethernet/eth_litex_liteeth.c
+++ b/drivers/ethernet/eth_litex_liteeth.c
@@ -331,7 +331,8 @@ static const struct ethernet_api eth_api = {
 	}                                                                                          \
                                                                                                    \
 	static struct eth_litex_dev_data eth_data##n = {                                           \
-		.mac_addr = DT_INST_PROP(n, local_mac_address)};                                   \
+		.mac_addr = DT_INST_PROP_OR(n, local_mac_address, {0}),			           \
+	};                                                                                         \
                                                                                                    \
 	static const struct eth_litex_config eth_config##n = {                                     \
 		.phy_dev = DEVICE_DT_GET_OR_NULL(DT_INST_PHANDLE(n, phy_handle)),                  \

--- a/drivers/ethernet/eth_nxp_enet.c
+++ b/drivers/ethernet/eth_nxp_enet.c
@@ -738,8 +738,6 @@ static int eth_nxp_enet_init(const struct device *dev)
 	k_work_init(&data->rx_work, eth_nxp_enet_rx_thread);
 
 	switch (config->mac_addr_source) {
-	case MAC_ADDR_SOURCE_LOCAL:
-		break;
 	case MAC_ADDR_SOURCE_RANDOM:
 		gen_random_mac(data->mac_addr,
 			FREESCALE_OUI_B0, FREESCALE_OUI_B1, FREESCALE_OUI_B2);
@@ -751,7 +749,7 @@ static int eth_nxp_enet_init(const struct device *dev)
 		nxp_enet_fused_mac(data->mac_addr);
 		break;
 	default:
-		return -ENOTSUP;
+		break;
 	}
 
 	err = clock_control_get_rate(config->clock_dev, config->clock_subsys,
@@ -966,12 +964,12 @@ BUILD_ASSERT(NXP_ENET_PHY_MODE(DT_DRV_INST(n)) != NXP_ENET_RGMII_MODE ||		\
 			" and CONFIG_ETH_NXP_ENET_1G enabled");
 
 #define NXP_ENET_MAC_ADDR_SOURCE(n)							\
-	COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), local_mac_address),		\
-			(MAC_ADDR_SOURCE_LOCAL),					\
-	(COND_CODE_1(DT_INST_PROP(n, zephyr_random_mac_address),			\
+	COND_CODE_1(DT_INST_PROP(n, zephyr_random_mac_address),				\
 			(MAC_ADDR_SOURCE_RANDOM),					\
 	(COND_CODE_1(DT_INST_PROP(n, nxp_unique_mac), (MAC_ADDR_SOURCE_UNIQUE),		\
 	(COND_CODE_1(DT_INST_PROP(n, nxp_fused_mac), (MAC_ADDR_SOURCE_FUSED),		\
+	(COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), local_mac_address),		\
+			(MAC_ADDR_SOURCE_LOCAL),					\
 	(MAC_ADDR_SOURCE_INVALID))))))))
 
 #define NXP_ENET_MAC_INIT(n)								\

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -641,13 +641,17 @@ static int eth_nxp_enet_qos_mac_init(const struct device *dev)
 		return ret;
 	}
 
-	if (config->mac_addr_source == NXP_ENET_QOS_MAC_ADDR_SOURCE_LOCAL) {
-		/* Use the mac address provided in the devicetree */
-	} else if (config->mac_addr_source == NXP_ENET_QOS_MAC_ADDR_SOURCE_UNIQUE) {
+	switch (config->mac_addr_source) {
+	case NXP_ENET_QOS_MAC_ADDR_SOURCE_RANDOM:
+		gen_random_mac(data->mac_addr.addr, NXP_OUI_BYTE_0, NXP_OUI_BYTE_1, NXP_OUI_BYTE_2);
+		break;
+
+	case NXP_ENET_QOS_MAC_ADDR_SOURCE_UNIQUE:
 		nxp_enet_unique_mac(data->mac_addr.addr);
-	} else {
-		gen_random_mac(data->mac_addr.addr,
-			       NXP_OUI_BYTE_0, NXP_OUI_BYTE_1, NXP_OUI_BYTE_2);
+		break;
+
+	default:
+		break;
 	}
 
 	/* This driver cannot work without interrupts. */
@@ -776,12 +780,12 @@ static const struct ethernet_api api_funcs = {
 		     "MAC address not specified on ENET QOS DT node");
 
 #define NXP_ENET_QOS_MAC_ADDR_SOURCE(n)                                                            \
-	COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), local_mac_address),		\
-			(NXP_ENET_QOS_MAC_ADDR_SOURCE_LOCAL),					\
-	(COND_CODE_1(DT_INST_PROP(n, zephyr_random_mac_address),			\
-			(NXP_ENET_QOS_MAC_ADDR_SOURCE_RANDOM),					\
-	(COND_CODE_1(DT_INST_PROP(n, nxp_unique_mac),	\
-			(NXP_ENET_QOS_MAC_ADDR_SOURCE_UNIQUE),	\
+	COND_CODE_1(DT_INST_PROP(n, zephyr_random_mac_address),					   \
+			(NXP_ENET_QOS_MAC_ADDR_SOURCE_RANDOM),					   \
+	(COND_CODE_1(DT_INST_PROP(n, nxp_unique_mac),						   \
+			(NXP_ENET_QOS_MAC_ADDR_SOURCE_UNIQUE),					   \
+	(COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(n), local_mac_address),			   \
+			(NXP_ENET_QOS_MAC_ADDR_SOURCE_LOCAL),					   \
 	(NXP_ENET_QOS_MAC_ADDR_SOURCE_INVALID))))))
 
 #define NXP_ENET_QOS_CONNECT_IRQS(node_id, prop, idx)                                              \

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -586,7 +586,7 @@ static const struct ethernet_api xilinx_axienet_api = {
 	}                                                                                          \
                                                                                                    \
 	static struct xilinx_axienet_data data_##inst = {                                          \
-		.mac_addr = DT_INST_PROP(inst, local_mac_address),                                 \
+		.mac_addr = DT_INST_PROP_OR(inst, local_mac_address, {0}),                         \
 		.dma_is_configured_rx = false,                                                     \
 		.dma_is_configured_tx = false};                                                    \
 	static const struct xilinx_axienet_config config_##inst = {                                \

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -476,7 +476,7 @@ static const struct eth_xlnx_gem_dev_cfg eth_xlnx_gem##port##_dev_cfg = {\
 /* Device run-time data declaration macro */
 #define ETH_XLNX_GEM_DEV_DATA(port) \
 static struct eth_xlnx_gem_dev_data eth_xlnx_gem##port##_dev_data = {\
-	.mac_addr        = DT_INST_PROP(port, local_mac_address),\
+	.mac_addr        = DT_INST_PROP_OR(port, local_mac_address, {0}),\
 	.started         = 0,\
 	.eff_link_speed  = LINK_DOWN,\
 	.phy_addr        = 0,\

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -866,7 +866,7 @@ static int eth_xmc4xxx_init(const struct device *dev)
 
 	eth_xmc4xxx_mask_unused_interrupts(dev_cfg->regs);
 
-#if !DT_INST_NODE_HAS_PROP(0, local_mac_address)
+#if DT_INST_PROP(0, zephyr_random_mac_address)
 	gen_random_mac(dev_data->mac_addr, INFINEON_OUI_B0, INFINEON_OUI_B1, INFINEON_OUI_B2);
 #endif
 	eth_xmc4xxx_set_mac_address(dev_cfg->regs, dev_data->mac_addr);


### PR DESCRIPTION
- don't require `local-mac-address` to be present in the dt
- fix cases where `zephyr,random-mac-address` was only used if `local-mac-address` was not valid. `zephyr,random-mac-address` has priority over `local-mac-address` according to `ethernet-controller.yaml`.