### PR TITLE
modules: Update FAT FS to version 0.15b and version check in Zephyr modules

### DIFF
--- a/modules/fatfs/zephyr_fatfs_config.h
+++ b/modules/fatfs/zephyr_fatfs_config.h
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#if FFCONF_DEF != 5380
+#if FFCONF_DEF != 5385
 #error "Configuration version mismatch"
 #endif
 

--- a/west.yml
+++ b/west.yml
@@ -139,7 +139,7 @@ manifest:
       groups:
         - tools
     - name: fatfs
-      revision: 16245c7c41d2b79e74984f49b5202551786b8a9b
+      revision: pull/20/head
       path: modules/fs/fatfs
       groups:
         - fs


### PR DESCRIPTION
Update FAT FS to version 0.15b and version check in Zephyr modules