### PR TITLE
am243x_evm/am2434/r5f0_0: TI ADC cleanup

### DIFF
--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0-pinctrl.dtsi
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0-pinctrl.dtsi
@@ -25,6 +25,38 @@
 		pinmux = <K3_PINMUX(0x264, PIN_INPUT_PULLUP, MUX_MODE_0)>;
 	};
 
+	main_adc0_ain0: adc0_ain0_default {
+		pinmux = <K3_PINMUX(0x2b0, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_adc0_ain1: adc0_ain1_default {
+		pinmux = <K3_PINMUX(0x2b4, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_adc0_ain2: adc0_ain2_default {
+		pinmux = <K3_PINMUX(0x2b8, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_adc0_ain3: adc0_ain3_default {
+		pinmux = <K3_PINMUX(0x2bc, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_adc0_ain4: adc0_ain4_default {
+		pinmux = <K3_PINMUX(0x2c0, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_adc0_ain5: adc0_ain5_default {
+		pinmux = <K3_PINMUX(0x2c4, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_adc0_ain6: adc0_ain6_default {
+		pinmux = <K3_PINMUX(0x2c8, PIN_INPUT, MUX_MODE_0)>;
+	};
+
+	main_adc0_ain7: adc0_ain7_default {
+		pinmux = <K3_PINMUX(0x2cc, PIN_INPUT, MUX_MODE_0)>;
+	};
+
 	spi0_cs0: spi0_cs0_default {
 		pinmux = <K3_PINMUX(0x208, PIN_OUTPUT, MUX_MODE_0)>;
 	};

--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -97,7 +97,6 @@
 };
 
 &main_adc0 {
-	ti,vrefp = <1800>;
 	ti,fifo = <0>;
 	status = "okay";
 	power-domains = <&adc0_pd>;
@@ -106,80 +105,88 @@
 		reg = <0>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 
 	channel@1 {
 		reg = <1>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 
 	channel@2 {
 		reg = <2>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 
 	channel@3 {
 		reg = <3>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 
 	channel@4 {
 		reg = <4>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 
 	channel@5 {
 		reg = <5>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 
 	channel@6 {
 		reg = <6>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 
 	channel@7 {
 		reg = <7>;
 		ti,open-delay = <0>;
 		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,reference = "ADC_REF_VDD_1";
 		zephyr,acquisition-time = <0>;
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <4>;
+		zephyr,vref-mv = <1800>;
 	};
 };
 

--- a/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
+++ b/boards/ti/am243x_evm/am243x_evm_am2434_r5f0_0.dts
@@ -98,6 +98,15 @@
 
 &main_adc0 {
 	ti,fifo = <0>;
+	pinctrl-0 = <&main_adc0_ain0
+		     &main_adc0_ain1
+		     &main_adc0_ain2
+		     &main_adc0_ain3
+		     &main_adc0_ain4
+		     &main_adc0_ain5
+		     &main_adc0_ain6
+		     &main_adc0_ain7>;
+	pinctrl-names = "default";
 	status = "okay";
 	power-domains = <&adc0_pd>;
 

--- a/drivers/adc/adc_ti_am335x.c
+++ b/drivers/adc/adc_ti_am335x.c
@@ -191,6 +191,12 @@ static int ti_adc_channel_setup(const struct device *dev, const struct adc_chann
 		return -EINVAL;
 	}
 
+	if (chan_cfg->reference == ADC_REF_INTERNAL &&
+	    DEVICE_API_GET(adc, dev)->ref_internal == 0) {
+		LOG_ERR("Voltage reference must be provided for ADC_REF_INTERNAL");
+		return -EINVAL;
+	}
+
 	if (cfg->oversampling[chan] > TI_ADC_STEPCONFIG_AVERAGING_MAX) {
 		LOG_ERR("Invalid oversampling value");
 		return -EINVAL;
@@ -374,7 +380,7 @@ static void ti_adc_isr(const struct device *dev)
 	static DEVICE_API(adc, ti_adc_driver_api_##n) = {                                          \
 		.channel_setup = ti_adc_channel_setup,                                             \
 		.read = ti_adc_read,                                                               \
-		.ref_internal = DT_INST_PROP(n, ti_vrefp),                                         \
+		.ref_internal = DT_INST_PROP_OR(n, ti_vrefp, 0),                                   \
 		IF_ENABLED(CONFIG_ADC_ASYNC, (.read_async = ti_adc_read_async,)) };                \
                                                                                                    \
 	static void ti_adc_irq_setup_##n(const struct device *dev)                                 \

--- a/drivers/adc/adc_ti_am335x.c
+++ b/drivers/adc/adc_ti_am335x.c
@@ -8,6 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/adc.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
@@ -97,6 +98,7 @@ enum ti_adc_irq {
 
 struct ti_adc_cfg {
 	DEVICE_MMIO_ROM;
+	const struct pinctrl_dev_config *pinctrl;
 	void (*irq_func)(const struct device *dev);
 	uint32_t open_delay[TI_ADC_TOTAL_CHANNELS];
 	uint8_t oversampling[TI_ADC_TOTAL_CHANNELS];
@@ -295,8 +297,15 @@ static int ti_adc_init(const struct device *dev)
 	const struct ti_adc_cfg *cfg = DEV_CFG(dev);
 	struct ti_adc_data *data = DEV_DATA(dev);
 	struct ti_adc_regs *regs = DEV_REGS(dev);
+	int ret;
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
+	ret = pinctrl_apply_state(cfg->pinctrl, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("failed to apply pinctrl");
+		return ret;
+	}
 
 	cfg->irq_func(dev);
 
@@ -390,8 +399,10 @@ static void ti_adc_isr(const struct device *dev)
 		irq_enable(DT_INST_IRQN(n));                                                       \
 	}                                                                                          \
                                                                                                    \
+	PINCTRL_DT_INST_DEFINE(n);                                                                 \
 	static const struct ti_adc_cfg ti_adc_cfg_##n = {                                          \
 		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),                                              \
+		.pinctrl = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                      \
 		.irq_func = &ti_adc_irq_setup_##n,                                                 \
 		.open_delay = CHAN_PROP_LIST(n, ti_open_delay),                                    \
 		.oversampling = CHAN_PROP_LIST(n, zephyr_oversampling),                            \

--- a/drivers/adc/adc_ti_am335x.c
+++ b/drivers/adc/adc_ti_am335x.c
@@ -296,10 +296,12 @@ static int ti_adc_init(const struct device *dev)
 {
 	const struct ti_adc_cfg *cfg = DEV_CFG(dev);
 	struct ti_adc_data *data = DEV_DATA(dev);
-	struct ti_adc_regs *regs = DEV_REGS(dev);
+	struct ti_adc_regs *regs;
 	int ret;
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
+
+	regs = DEV_REGS(dev);
 
 	ret = pinctrl_apply_state(cfg->pinctrl, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {

--- a/dts/bindings/adc/ti,am335x-adc.yaml
+++ b/dts/bindings/adc/ti,am335x-adc.yaml
@@ -6,7 +6,7 @@ description: TI AM335X ADC
 
 compatible: "ti,am335x-adc"
 
-include: [adc-controller.yaml]
+include: [adc-controller.yaml, pinctrl-device.yaml]
 
 properties:
   interrupts:

--- a/dts/bindings/adc/ti,am335x-adc.yaml
+++ b/dts/bindings/adc/ti,am335x-adc.yaml
@@ -14,7 +14,6 @@ properties:
 
   ti,vrefp:
     type: int
-    required: true
     description: Reference Voltage (in mV)
 
   ti,fifo:


### PR DESCRIPTION
- Allow ADC to have any voltage reference instead of only internal reference
    
- Edit DT to reflect the change above

- Add pinctrl support for the TI ADC driver

-  Add pins for ADC0 channels 