### PR TITLE
soc: ti: k3: am6x: split Kconfig.defconfig

### DIFF
--- a/soc/ti/k3/am6x/Kconfig.defconfig
+++ b/soc/ti/k3/am6x/Kconfig.defconfig
@@ -3,6 +3,8 @@
 
 if SOC_SERIES_AM6X
 
+rsource "Kconfig.defconfig.*"
+
 config KERNEL_ENTRY
 	default "_vector_table" if SOC_SERIES_AM6X_R5
 
@@ -14,16 +16,6 @@ config FLASH_SIZE
 
 config FLASH_BASE_ADDRESS
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
-
-config NUM_IRQS
-	default 64 if SOC_SERIES_AM6X_M4
-	default 280 if SOC_SERIES_AM6X_A53
-	default 512 if SOC_SERIES_AM6X_R5
-
-config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 400000000 if SOC_SERIES_AM6X_M4
-	default 200000000 if SOC_SERIES_AM6X_A53
-	default 19200000 if SOC_SERIES_AM6X_R5
 
 if SERIAL
 

--- a/soc/ti/k3/am6x/Kconfig.defconfig.am2434_m4
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.am2434_m4
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_AM2434_M4
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 400000000
+
+config NUM_IRQS
+	default 64
+
+endif # SOC_AM2434_M4

--- a/soc/ti/k3/am6x/Kconfig.defconfig.am2434_r5
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.am2434_r5
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_AM2434_R5F0_0
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 25000000
+
+config NUM_IRQS
+	default 256
+
+endif # SOC_AM2434_R5F0_0

--- a/soc/ti/k3/am6x/Kconfig.defconfig.am6232_a53
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.am6232_a53
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_AM6232_A53
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 200000000
+
+config NUM_IRQS
+	default 280
+
+endif # SOC_AM6232_A53

--- a/soc/ti/k3/am6x/Kconfig.defconfig.am6232_m4
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.am6232_m4
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_AM6232_M4
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 400000000
+
+config NUM_IRQS
+	default 64
+
+endif # SOC_AM6232_M4

--- a/soc/ti/k3/am6x/Kconfig.defconfig.am6234_a53
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.am6234_a53
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_AM6234_A53
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 200000000
+
+config NUM_IRQS
+	default 280
+
+endif # SOC_AM6234_A53

--- a/soc/ti/k3/am6x/Kconfig.defconfig.am6234_m4
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.am6234_m4
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_AM6234_M4
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 400000000
+
+config NUM_IRQS
+	default 64
+
+endif # SOC_AM6234_M4

--- a/soc/ti/k3/am6x/Kconfig.defconfig.am6442_m4
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.am6442_m4
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_AM6442_M4
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 400000000
+
+config NUM_IRQS
+	default 64
+
+endif # SOC_AM6442_M4

--- a/soc/ti/k3/am6x/Kconfig.defconfig.j721e_main_r5
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.j721e_main_r5
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_J721E_MAIN_R5F0_0
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 19200000
+
+config NUM_IRQS
+	default 512
+
+endif # SOC_J721E_MAIN_R5F0_0

--- a/soc/ti/k3/am6x/Kconfig.defconfig.j722s_main_r5
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.j722s_main_r5
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_J722S_MAIN_R5F0_0
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 19200000
+
+config NUM_IRQS
+	default 512
+
+endif # SOC_J722S_MAIN_R5F0_0

--- a/soc/ti/k3/am6x/Kconfig.defconfig.j722s_mcu_r5
+++ b/soc/ti/k3/am6x/Kconfig.defconfig.j722s_mcu_r5
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Texas Instruments
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_J722S_MCU_R5F0_0
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default 19200000
+
+config NUM_IRQS
+	default 512
+
+endif # SOC_J722S_MCU_R5F0_0


### PR DESCRIPTION
Split the Kconfig.defconfig file into per-soc files, for soc-specific configuration such as system clock frequency and NUM_IRQ. Any new SoC added to the family will need to create its own Kconfig.defconfig.* file.'

Motivation was that the current frequency for R5 was defined to be 19.2 MHz which is not true for AM243x EVM that has the HF oscillator running at 25MHz. Similar case with the disparity in `NUM_IRQ`.