### PR TITLE
boards: add PWM support for third-party Silicon Labs boards

### DIFF
--- a/boards/arduino/nano_matter/arduino_nano_matter-pinctrl.dtsi
+++ b/boards/arduino/nano_matter/arduino_nano_matter-pinctrl.dtsi
@@ -44,6 +44,14 @@
 		};
 	};
 
+	timer0_default: timer0_default {
+		group0 {
+			pins = <TIMER0_CC0_PC1>, <TIMER0_CC1_PC2>, <TIMER0_CC2_PC3>;
+			drive-push-pull;
+			output-high;
+		};
+	};
+
 	usart0_default: usart0_default {
 		group0 {
 			pins = <USART0_TX_PC4>;

--- a/boards/arduino/nano_matter/arduino_nano_matter.dts
+++ b/boards/arduino/nano_matter/arduino_nano_matter.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <silabs/xg24/mgm240sd22vna.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "arduino_nano_matter-pinctrl.dtsi"
 #include "arduino_nano_matter_connector.dtsi"
 
@@ -30,6 +31,9 @@
 		led0 = &led0;
 		led1 = &led1;
 		led2 = &led2;
+		pwm-led0 = &red_pwm_led;
+		pwm-led1 = &green_pwm_led;
+		pwm-led2 = &blue_pwm_led;
 		sw0 = &button0;
 		watchdog0 = &wdog0;
 	};
@@ -53,6 +57,25 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: pwm_led_0 {
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "red";
+		};
+
+		green_pwm_led: pwm_led_1 {
+			pwms = <&timer0_pwm 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "green";
+		};
+
+		blue_pwm_led: pwm_led_2 {
+			pwms = <&timer0_pwm 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "blue";
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 
@@ -60,6 +83,16 @@
 			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
+	};
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_default>;
+		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/seeed/xiao_mg24/xiao_mg24-pinctrl.dtsi
+++ b/boards/seeed/xiao_mg24/xiao_mg24-pinctrl.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Pete Johanson
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -54,6 +55,14 @@
 			pins = <I2C0_SCL_PC4>, <I2C0_SDA_PC5>;
 			drive-open-drain;
 			bias-pull-up;
+		};
+	};
+
+	timer0_default: timer0_default {
+		group0 {
+			pins = <TIMER0_CC0_PA7>;
+			drive-push-pull;
+			output-high;
 		};
 	};
 };

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2025 Pete Johanson
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /dts-v1/;
 #include <silabs/xg24/efr32mg24b220f1536im48.dtsi>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "xiao_mg24-pinctrl.dtsi"
 #include "seeed_xiao_connector.dtsi"
 
@@ -26,6 +28,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		pwm-led0 = &pwm_led0;
 		watchdog0 = &wdog0;
 	};
 
@@ -36,6 +39,25 @@
 			gpios = <&gpioa 7 GPIO_ACTIVE_LOW>;
 			label = "LED 0";
 		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+			label = "PWM LED 0";
+		};
+	};
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_default>;
+		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi
@@ -29,6 +29,14 @@
 		};
 	};
 
+	timer0_default: timer0_default {
+		group0 {
+			pins = <TIMER0_CC0_PA8>;
+			drive-push-pull;
+			output-high;
+		};
+	};
+
 	/* configuration for uart0 device, default state */
 	usart0_default: usart0_default {
 		group0 {

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p.dts
@@ -1,12 +1,14 @@
 /*
  * Copyright (c) 2024 Daikin Comfort Technologies North America, Inc.
  * Copyright (c) 2020 TriaGnoSys GmbH
+ * Copyright (c) 2025 Silicon Laboratories Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /dts-v1/;
 #include <silabs/xg24/mgm240pb32vna.dtsi>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/regulator/silabs_dcdc.h>
@@ -26,6 +28,7 @@
 
 	aliases {
 		led0 = &blue_led;
+		pwm-led0 = &blue_pwm_led;
 		spi0 = &eusart1;
 		watchdog0 = &wdog0;
 	};
@@ -38,9 +41,28 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		blue_pwm_led: pwm_led_0 {
+			pwms = <&timer0_pwm 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "blue";
+		};
+	};
+
 	wake_up_trigger: gpio-wake-up  {
 		compatible = "silabs,gecko-wake-up-trigger";
 		gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&timer0 {
+	status = "okay";
+
+	timer0_pwm: pwm {
+		pinctrl-0 = <&timer0_default>;
+		pinctrl-names = "default";
+		status = "okay";
 	};
 };
 


### PR DESCRIPTION
Adding PWM support for the following boards:
- Arduino Nano Matter
- Sparkfun ThingPlus Matter MGM240P
- Seeed Studio XIAO MG24