### PR TITLE
scripts: kconfig: functions: add dt_compat_enabled_num function

### DIFF
--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -42,6 +42,7 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_compat_any_has_prop,<compatible string>,<prop>[,<value>])
    $(dt_compat_any_on_bus,<compatible string>,<prop>)
    $(dt_compat_enabled,<compatible string>)
+   $(dt_compat_enabled_num,<compatible string>)
    $(dt_compat_on_bus,<compatible string>,<bus>)
    $(dt_gpio_hogs_enabled)
    $(dt_has_compat,<compatible string>)

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -771,6 +771,17 @@ def dt_compat_enabled(kconf, _, compat):
     return "y" if compat in edt.compat2okay else "n"
 
 
+def dt_compat_enabled_num(kconf, _, compat):
+    """
+    This function takes a 'compat' and the returns number of status "okay"
+    compatible nodes in the EDT.
+    """
+    if doc_mode or edt is None:
+        return "0"
+
+    return str(len(edt.compat2okay[compat]))
+
+
 def dt_compat_on_bus(kconf, _, compat, bus):
     """
     This function takes a 'compat' and returns "y" if we find an enabled
@@ -1074,6 +1085,7 @@ def inc_dec(kconf, name, *args):
 functions = {
         "dt_has_compat": (dt_has_compat, 1, 1),
         "dt_compat_enabled": (dt_compat_enabled, 1, 1),
+        "dt_compat_enabled_num": (dt_compat_enabled_num, 1, 1),
         "dt_compat_on_bus": (dt_compat_on_bus, 2, 2),
         "dt_compat_any_has_prop": (dt_compat_any_has_prop, 2, 3),
         "dt_compat_any_not_has_prop": (dt_compat_any_not_has_prop, 2, 2),

--- a/tests/kconfig/functions/Kconfig
+++ b/tests/kconfig/functions/Kconfig
@@ -113,4 +113,22 @@ config KCONFIG_MAX_10_3_2
 	int
 	default $(max, 0xa, 3, 0b10)
 
+DT_COMPAT_VND_GPIO := vnd,gpio
+
+config KCONFIG_VND_GPIO_ENABLED_NUM_4
+	int
+	default $(dt_compat_enabled_num,$(DT_COMPAT_VND_GPIO))
+
+DT_COMPAT_VND_CAN_CONTROLLER := vnd,can-controller
+
+config KCONFIG_VND_CAN_CONTROLLER_ENABLED_NUM_2
+	int
+	default $(dt_compat_enabled_num,$(DT_COMPAT_VND_CAN_CONTROLLER))
+
+DT_COMPAT_VND_PWM := vnd,pwm
+
+config KCONFIG_VND_PWM_ENABLED_NUM_0
+	int
+	default $(dt_compat_enabled_num,$(DT_COMPAT_VND_PWM))
+
 source "Kconfig.zephyr"

--- a/tests/kconfig/functions/app.overlay
+++ b/tests/kconfig/functions/app.overlay
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	test {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		test_gpio_0: gpio@1000 {
+			compatible = "vnd,gpio";
+			reg = <0x1000 0x1000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "okay";
+		};
+
+		test_gpio_1: gpio@2000 {
+			compatible = "vnd,gpio";
+			reg = <0x2000 0x1000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "okay";
+		};
+
+		test_gpio_2: gpio@3000 {
+			compatible = "vnd,gpio";
+			reg = <0x3000 0x1000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "okay";
+		};
+
+		test_gpio_3: gpio@4000 {
+			compatible = "vnd,gpio";
+			reg = <0x4000 0x1000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			status = "okay";
+		};
+
+		test_can_0: gpio@5000 {
+			compatible = "vnd,can-controller";
+			reg = <0x5000 0x1000>;
+			status = "okay";
+		};
+
+		test_can_1: gpio@6000 {
+			compatible = "vnd,can-controller";
+			reg = <0x6000 0x1000>;
+			status = "okay";
+		};
+
+		test_can_2: gpio@7000 {
+			compatible = "vnd,can-controller";
+			reg = <0x7000 0x1000>;
+			status = "disabled";
+		};
+	};
+};

--- a/tests/kconfig/functions/src/main.c
+++ b/tests/kconfig/functions/src/main.c
@@ -45,4 +45,11 @@ ZTEST(test_kconfig_functions, test_min_max)
 	zassert_equal(CONFIG_KCONFIG_MAX_10_3_2, MAX(MAX(10, 3), 2));
 }
 
+ZTEST(test_kconfig_functions, test_dt_num_compat_enabled)
+{
+	zassert_equal(CONFIG_KCONFIG_VND_GPIO_ENABLED_NUM_4, 4);
+	zassert_equal(CONFIG_KCONFIG_VND_CAN_CONTROLLER_ENABLED_NUM_2, 2);
+	zassert_equal(CONFIG_KCONFIG_VND_PWM_ENABLED_NUM_0, 0);
+}
+
 ZTEST_SUITE(test_kconfig_functions, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add dt_compat_enabled_num Kconfig helper function for counting the number of compatible nodes with status okay.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>