### PR TITLE
Bluetooth: Controller: Fix peripheral role assertion on conn update

### DIFF
--- a/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
+++ b/subsys/bluetooth/controller/flash/soc_flash_nrf_ticker.c
@@ -250,14 +250,24 @@ void nrf_flash_sync_get_timestamp_begin(void)
 
 bool nrf_flash_sync_check_time_limit(uint32_t iteration)
 {
-	uint32_t ticks_diff;
+	if (IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF54LX)) {
+		/* Write operations are not constant time depending on the previous value present
+		 * versus new value to be written. Hence, perform no more than one iteration.
+		 */
 
-	ticks_diff = ticker_ticks_diff_get(ticker_ticks_now_get(),
-					   _ticker_sync_context.ticks_begin);
-	if (ticks_diff + ticks_diff/iteration >
-	    HAL_TICKER_US_TO_TICKS(_ticker_sync_context.slot)) {
+		ARG_UNUSED(iteration);
+
 		return true;
-	}
+	} else {
+		uint32_t ticks_diff;
 
-	return false;
+		ticks_diff = ticker_ticks_diff_get(ticker_ticks_now_get(),
+						   _ticker_sync_context.ticks_begin);
+		if (ticks_diff + ticks_diff/iteration >
+		    HAL_TICKER_US_TO_TICKS(_ticker_sync_context.slot)) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2363,7 +2363,7 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 	periodic_us = conn_interval_us;
 
 	conn_interval_old_us = conn_interval_old * conn_interval_unit_old;
-	latency_upd = conn_interval_old_us / conn_interval_us;
+	latency_upd = DIV_ROUND_UP(conn_interval_old_us, conn_interval_us);
 	conn_interval_new_us = latency_upd * conn_interval_us;
 	if (conn_interval_new_us > conn_interval_old_us) {
 		ticks_at_expire += HAL_TICKER_US_TO_TICKS(


### PR DESCRIPTION
Fix peripheral role assertion during connection update and simultaneous flash operations.

prepare_cb: Actual EVENT_OVERHEAD_START_US = 6149

This happens due to instant latency at connection update where the ticks_at_expire was in the past.

Write operations are not constant time on nRF54Lx SoCs and depend on the previous value present versus new value to be written. Hence, perform no more than one iteration.