### PR TITLE
tests: drivers: pwm: add config to skip zero duty cycle test

### DIFF
--- a/tests/drivers/pwm/pwm_api/Kconfig
+++ b/tests/drivers/pwm/pwm_api/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+mainmenu "PWM API test"
+
+config SKIP_ZERO_DUTY_CYCLE_TEST
+	bool "Skip zero duty cycle_test"
+	default n
+	help
+	  Will skip test attempting to set zero duty cycle
+
+source "Kconfig.zephyr"

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -163,10 +163,12 @@ ZTEST_USER(pwm_basic, test_pwm_nsec)
 				DEFAULT_PERIOD_NSEC, UNIT_NSECS) == TC_PASS);
 	k_sleep(K_MSEC(1000));
 
+#ifndef CONFIG_SKIP_ZERO_DUTY_CYCLE_TEST
 	/* Period : Pulse (2000000 : 0), unit (nsec). Voltage : 0V */
 	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_NSEC,
 				0, UNIT_NSECS) == TC_PASS);
 	k_sleep(K_MSEC(1000));
+#endif
 }
 
 ZTEST_USER(pwm_basic, test_pwm_cycle)
@@ -181,10 +183,12 @@ ZTEST_USER(pwm_basic, test_pwm_cycle)
 				DEFAULT_PERIOD_CYCLE, UNIT_CYCLES) == TC_PASS);
 	k_sleep(K_MSEC(1000));
 
+#ifndef CONFIG_SKIP_ZERO_DUTY_CYCLE_TEST
 	/* Period : Pulse (64000 : 0), unit (cycle). Voltage : 0V */
 	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_CYCLE,
 				0, UNIT_CYCLES) == TC_PASS);
 	k_sleep(K_MSEC(1000));
+#endif
 }
 
 #if defined INVALID_PWM_PORT


### PR DESCRIPTION
Adds a Kconfig option to skip test task of setting zero duty cycle