### PR TITLE
boards: nordic: nrf54h20dk: Fix FLASH_LOAD_SIZE

### DIFF
--- a/boards/nordic/nrf54h20dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54h20dk/Kconfig.defconfig
@@ -1,6 +1,9 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+
 if BOARD_NRF54H20DK_NRF54H20_CPUAPP
 
 config BT_HCI_IPC
@@ -25,6 +28,9 @@ config ROM_START_OFFSET
 
 config FLASH_LOAD_OFFSET
 	default 0x2c000 if !USE_DT_CODE_PARTITION
+
+config FLASH_LOAD_SIZE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if !USE_DT_CODE_PARTITION
 
 endif # BOARD_NRF54H20DK_NRF54H20_CPUAPP_IRON
 


### PR DESCRIPTION
Fix FLASH_LOAD_SIZE setting for builds with !USE_DT_CODE_PARTITION (for e.g. with no MCUBoot).
Having it wrongly set to 0x0 caused problems when running multiple images (radio core, application core) on the same board.