### PR TITLE
Bluetooth: Controller: Fix peripheral assert under single timer use

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1164,6 +1164,11 @@ static void isr_tx(void *param)
 		node_rx_prof = lll_prof_reserve();
 	}
 
+	/* Call to ensure packet/event timer accumulates the elapsed time
+	 * under single timer use.
+	 */
+	(void)radio_is_tx_done();
+
 	/* Clear radio tx status and events */
 	lll_isr_tx_status_reset();
 


### PR DESCRIPTION
Fix peripheral EVENT_OVERHEAD_START_US assertion due to missing packet timer timestamp accumulation under single timer use in nRF54Lx SoCs.

Fixes #92142.