### PR TITLE
sys: cbprintf: Fix static code analysis (clang-tidy) warnings

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -572,7 +572,7 @@ extern "C" {
 	size_t __arg_size = _Generic((v), \
 		float : sizeof(double), \
 		default : \
-			sizeof((__v)) \
+			sizeof((__v)) /* NOLINT(bugprone-sizeof-expression) */ \
 		); \
 	__arg_size; \
 })

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -560,7 +560,11 @@ extern "C" {
 #ifdef __cplusplus
 #define Z_CBPRINTF_ARG_SIZE(v) z_cbprintf_cxx_arg_size(v)
 #else
-#define Z_CONSTIFY(v) (_Generic((v), char * : (const char *)(uintptr_t)(v), default : (v)))
+#define Z_CONSTIFY(v) ({ \
+	__auto_type _uv = (v); \
+	__typeof__(_uv) const _cv = _uv; \
+	_cv; \
+})
 #define Z_CBPRINTF_ARG_SIZE(v) ({\
 	__auto_type __v = Z_ARGIFY(Z_CONSTIFY(v)); \
 	/* Static code analysis may complain about unused variable. */ \


### PR DESCRIPTION
clang-tidy reports a `performance-no-int-to-ptr` warning due to the cast `(const char *)(uintptr_t)(v)`.

Previously, only `char *` was cast to `const char *`, but there's no downside to constifying all pointer types.

This PR updates the `Z_CONSTIFY` macro to apply `const` consistently, which even aligns better with its name and resolves the warning.

In addition, clang-tidy reports a `bugprone-sizeof-expression` warning for `sizeof((__v))` when `__v` is a pointer type. This is a false-positive in contexts like logging with `%p`, where using a pointer is intentional and expected.

This PR adds a NOLINT comment to suppress the warning in static analysis.