### PR TITLE
modules: hal_nxp: add timeout for ii2c status polling

### DIFF
--- a/modules/hal_nxp/mcux/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/CMakeLists.txt
@@ -101,6 +101,11 @@ zephyr_compile_definitions_ifdef(
   FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL=1
   )
 
+zephyr_compile_definitions_ifdef(
+  CONFIG_I2C_NXP_II2C
+  I2C_RETRY_TIMES=40000
+  )
+
 # note: if FSL_IRQSTEER_ENABLE_MASTER_INT is not
 # defined then it will automatically be defined
 # and set to 1 via fsl_irqsteer.h


### PR DESCRIPTION
Enalbe II2C hal driver status polling timeout in order to avoid blocking of some driver API, such as kernel hang during i2c scanning.

This PR is to fix the bug discussed in https://github.com/zephyrproject-rtos/zephyr/pull/91829