### PR TITLE
drivers/pinctrl: ite: Don't clear FUNC3 setting unless alt_func is FUNC3

### DIFF
--- a/drivers/pinctrl/pinctrl_ite_it8xxx2.c
+++ b/drivers/pinctrl/pinctrl_ite_it8xxx2.c
@@ -176,12 +176,14 @@ static int pinctrl_gpio_it8xxx2_configure_pins(const pinctrl_soc_pin_t *pins)
 	/*
 	 * Handle alternate function.
 	 */
-	if (reg_func3_gcr != NULL) {
-		*reg_func3_gcr &= ~gpio->func3_en_mask[pin];
-	}
-	/* Ensure that func3-ext setting is in default state. */
-	if (reg_func3_ext != NULL) {
-		*reg_func3_ext &= ~gpio->func3_ext_mask[pin];
+	if (pins->alt_func == IT8XXX2_ALT_FUNC_3) {
+		if (reg_func3_gcr != NULL) {
+			*reg_func3_gcr &= ~gpio->func3_en_mask[pin];
+		}
+		/* Ensure that func3-ext setting is in default state. */
+		if (reg_func3_ext != NULL) {
+			*reg_func3_ext &= ~gpio->func3_ext_mask[pin];
+		}
 	}
 
 	switch (pins->alt_func) {


### PR DESCRIPTION
Previously, FUNC_3 related setting were cleared unconditionally, regardless of the selected alternate function. This could unintentionally disable FUNC_3 settings when configuring other alternate functions.

This change ensures that FUNC_3 gcr/ext bits are only cleared when alt_func is IT8XXX2_ALT_FUNC_3.