### PR TITLE
soc: nordic: 54h20: fix typo ETX -> EXT

### DIFF
--- a/soc/nordic/nrf54h/bicr/bicr-schema.json
+++ b/soc/nordic/nrf54h/bicr/bicr-schema.json
@@ -193,7 +193,7 @@
                       ],
                       "enum": [
                         "CRYSTAL",
-                        "ETX_SINE",
+                        "EXT_SINE",
                         "EXT_SQUARE"
                       ],
                       "default": "CRYSTAL"


### PR DESCRIPTION
non-empty description of fixing the typo