### PR TITLE
subsys: net: lib: zperf: Fix 'kbps' in output

### DIFF
--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -809,8 +809,9 @@ static int execute_upload(const struct shell *sh,
 	shell_fprintf(sh, SHELL_NORMAL, "\n");
 	shell_fprintf(sh, SHELL_NORMAL, "Packet size:\t%u bytes\n",
 		      param->packet_size);
-	shell_fprintf(sh, SHELL_NORMAL, "Rate:\t\t%u kbps\n",
-		      param->rate_kbps);
+	shell_fprintf(sh, SHELL_NORMAL, "Rate:\t\t");
+	print_number(sh, param->rate_kbps, KBPS, KBPS_UNIT);
+	shell_fprintf(sh, SHELL_NORMAL, "\n");
 
 	if (IS_ENABLED(CONFIG_ZPERF_SESSION_PER_THREAD) &&
 	    COND_CODE_1(CONFIG_ZPERF_SESSION_PER_THREAD,
@@ -1646,8 +1647,9 @@ static void session_cb(struct session *ses,
 		print_number_64(sh,
 				(uint64_t)ses->async_upload_ctx.param.duration_ms * USEC_PER_MSEC,
 				TIME_US, TIME_US_UNIT);
-		shell_fprintf(sh, SHELL_NORMAL, "\t\t%u kbps\n",
-			      ses->async_upload_ctx.param.rate_kbps);
+		shell_fprintf(sh, SHELL_NORMAL, "\t\t");
+		print_number(sh, ses->async_upload_ctx.param.rate_kbps, KBPS, KBPS_UNIT);
+		shell_fprintf(sh, SHELL_NORMAL, "\n");
 
 		data->finalized_count++;
 	}


### PR DESCRIPTION
zperf should only return 'Kbps'. There are still two left-overs from converting shell prints to 'Kbps'.

Align all prints to make it easier for scripting and parsing content from console output.