### PR TITLE
STM32H7: Set voltage scaling before PLL configuration to fix early usage fault

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -1016,14 +1016,14 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 
+	/* Configure Voltage scale to comply with the desired system frequency */
+	prepare_regulator_voltage_scale();
+
 	/* Set up PLLs */
 	r = set_up_plls();
 	if (r < 0) {
 		return r;
 	}
-
-	/* Configure Voltage scale to comply with the desired system frequency */
-	prepare_regulator_voltage_scale();
 
 	/* Current hclk value */
 	old_hclk_freq = get_hclk_frequency();


### PR DESCRIPTION
set voltage scaling before PLL configuration to prevent early usage fault on STM32H7:

Move the call to prepare_regulator_voltage_scale() before PLL setup in clock_stm32_ll_h7.c.

This ensures the voltage regulator is configured to the appropriate voltage scale before increasing
the system clock frequency via PLLs. Without this change, the CPU could run at a frequency unsupported
by the current voltage level, causing z_arm_usage_fault() during early boot on boards like NUCLEO_H723ZG.

This fix resolves stability issues observed in high-frequency workloads such as the zperf sample.