### PR TITLE
boards: nordic: nrf54l15dk: Fix wrong indent

### DIFF
--- a/boards/nordic/nrf54l15dk/board.cmake
+++ b/boards/nordic/nrf54l15dk/board.cmake
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_SOC_NRF54L05_CPUAPP OR CONFIG_SOC_NRF54L10_CPUAPP OR CONFIG_SOC_NRF54L15_CPUAPP)
-	board_runner_args(jlink "--device=nRF54L15_M33" "--speed=4000")
+  board_runner_args(jlink "--device=nRF54L15_M33" "--speed=4000")
 elseif(CONFIG_SOC_NRF54L15_CPUFLPR)
   board_runner_args(jlink "--device=nRF54L15_RV32")
 elseif(CONFIG_SOC_NRF54L05_CPUFLPR OR CONFIG_SOC_NRF54L10_CPUFLPR)


### PR DESCRIPTION
Fixes an indent which wrongly used a tab instead of 2 spaces