### PR TITLE
drivers: spi: cc23x0: Add power management

### DIFF
--- a/dts/arm/ti/cc23x0.dtsi
+++ b/dts/arm/ti/cc23x0.dtsi
@@ -121,6 +121,7 @@
 			reg = <0x40026000 0x524>;
 			interrupts = <8 0>;
 			#dma-cells = <2>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 
@@ -132,6 +133,7 @@
 			interrupts = <10 0>;
 			dmas = <&dma 0 0>, <&dma 1 1>;
 			dma-names = "tx", "rx";
+			zephyr,disabling-power-states = <&state0 &state1>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
This patch adds PM support to SPI driver for the TI cc23x0 SoC.

Datasheet: https://www.ti.com/lit/ds/symlink/cc2340r5.pdf

Another PR, introducing system PM for this SoC, must be merged before: https://github.com/zephyrproject-rtos/zephyr/pull/91401
**[Update]** PR for system PM mentioned above is now merged.

Let's remind that this peripheral may use DMA. A PR is submitted to add PM support in DMA driver: https://github.com/zephyrproject-rtos/zephyr/pull/92219
**[Update]** PR for DMA PM mentioned above is now merged.