### PR TITLE
soc: imxrt: mimxrt1011 i2s clock fix

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -449,21 +449,27 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 #endif
 
 #ifdef CONFIG_I2S_MCUX_SAI
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai1))
 	case IMX_CCM_SAI1_CLK:
 		*rate = CLOCK_GetFreq(kCLOCK_AudioPllClk)
 				/ (CLOCK_GetDiv(kCLOCK_Sai1PreDiv) + 1)
 				/ (CLOCK_GetDiv(kCLOCK_Sai1Div) + 1);
 		break;
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai2))
 	case IMX_CCM_SAI2_CLK:
 		*rate = CLOCK_GetFreq(kCLOCK_AudioPllClk)
 				/ (CLOCK_GetDiv(kCLOCK_Sai2PreDiv) + 1)
 				/ (CLOCK_GetDiv(kCLOCK_Sai2Div) + 1);
 		break;
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai3))
 	case IMX_CCM_SAI3_CLK:
 		*rate = CLOCK_GetFreq(kCLOCK_AudioPllClk)
 				/ (CLOCK_GetDiv(kCLOCK_Sai3PreDiv) + 1)
 				/ (CLOCK_GetDiv(kCLOCK_Sai3Div) + 1);
 		break;
+#endif
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(flexspi))
 	case IMX_CCM_FLEXSPI_CLK:

--- a/soc/nxp/imxrt/imxrt10xx/soc.c
+++ b/soc/nxp/imxrt/imxrt10xx/soc.c
@@ -315,21 +315,27 @@ void imxrt_audio_codec_pll_init(uint32_t clock_name, uint32_t clk_src,
 					uint32_t clk_pre_div, uint32_t clk_src_div)
 {
 	switch (clock_name) {
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai1))
 	case IMX_CCM_SAI1_CLK:
 		CLOCK_SetMux(kCLOCK_Sai1Mux, clk_src);
 		CLOCK_SetDiv(kCLOCK_Sai1PreDiv, clk_pre_div);
 		CLOCK_SetDiv(kCLOCK_Sai1Div, clk_src_div);
 		break;
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai2))
 	case IMX_CCM_SAI2_CLK:
 		CLOCK_SetMux(kCLOCK_Sai2Mux, clk_src);
 		CLOCK_SetDiv(kCLOCK_Sai2PreDiv, clk_pre_div);
 		CLOCK_SetDiv(kCLOCK_Sai2Div, clk_src_div);
 		break;
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(sai3))
 	case IMX_CCM_SAI3_CLK:
 		CLOCK_SetMux(kCLOCK_Sai3Mux, clk_src);
 		CLOCK_SetDiv(kCLOCK_Sai3PreDiv, clk_pre_div);
 		CLOCK_SetDiv(kCLOCK_Sai3Div, clk_src_div);
 		break;
+#endif
 	default:
 		return;
 	}


### PR DESCRIPTION
Added fix for compiling i2s drivers on the NXP mimxrt1010_evk board.
 
The particular board does not have this peripheral (sai2 in devicetree) and in the header file included for it, does not have these defines: kCLOCK_Sai2Mux, kCLOCK_Sai2PreDiv, kCLOCK_Sai2Div. This change only includes code if the sai2 node exists in the devicetree and is okay. Have not tested with other nxp boards but I think it should work.

Previously created a PR [here](https://github.com/zephyrproject-rtos/hal_nxp/pull/569) but thanks @lucien-nxp, @ZhaoxiangJin for pointing me in the right direction.


