### PR TITLE
soc: riscv: disable local isr location

### DIFF
--- a/soc/lowrisc/opentitan/Kconfig.defconfig
+++ b/soc/lowrisc/opentitan/Kconfig.defconfig
@@ -9,6 +9,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config RISCV_SOC_INTERRUPT_INIT
 	default y
 
+config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
+	default n
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 32
 

--- a/soc/sensry/ganymed/sy1xx/Kconfig.defconfig
+++ b/soc/sensry/ganymed/sy1xx/Kconfig.defconfig
@@ -18,6 +18,9 @@ config INCLUDE_RESET_VECTOR
 config GEN_IRQ_VECTOR_TABLE
 	default y
 
+config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
+	default n
+
 config RISCV_GENERIC_TOOLCHAIN
 	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr"
 

--- a/soc/sifive/sifive_freedom/fe300/Kconfig.defconfig
+++ b/soc/sifive/sifive_freedom/fe300/Kconfig.defconfig
@@ -10,6 +10,9 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config RISCV_SOC_INTERRUPT_INIT
 	default y
 
+config ISR_TABLES_LOCAL_DECLARATION_SUPPORTED
+	default n
+
 config 2ND_LVL_ISR_TBL_OFFSET
 	default 12
 

--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -40,6 +40,10 @@ extern const uintptr_t _irq_vector_table[];
 #error "Target not supported"
 #endif
 
+#elif defined(CONFIG_VEXRISCV_LITEX_IRQ) && defined(CONFIG_LITEX_TIMER)
+#define ISR3_OFFSET	10
+#define TRIG_CHECK_SIZE	11
+
 #elif defined(CONFIG_RISCV_HAS_CLIC)
 #define ISR1_OFFSET	3
 #define ISR3_OFFSET	17


### PR DESCRIPTION
build for some risc-v SoCs is now failing due to #91018.
Use this workaround to fix the issue and keep ISR location
feature as not-supported for now.

Fixes: #92194
