### PR TITLE
soc: nordic: Remove prompt from deprecated Kconfigs NFCT_PINS_AS_GPIOS and GPIO_AS_PINRESET

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -167,7 +167,7 @@ if(CONFIG_NRFX_TWI OR CONFIG_NRFX_TWIM)
   zephyr_library_sources(${SRC_DIR}/nrfx_twi_twim.c)
 endif()
 
-# Inject HAL "CONFIG_NFCT_PINS_AS_GPIOS" definition if user requests to
+# Inject HAL "NFCT_PINS_AS_GPIOS" definition if user requests to
 # configure the NFCT pins as GPIOS. Do the same with "CONFIG_GPIO_AS_PINRESET"
 # to configure the reset GPIO as nRESET. This way, the HAL will take care of
 # doing the proper configuration sequence during system init
@@ -177,7 +177,6 @@ if(DEFINED uicr_path)
   dt_prop(nfct_pins_as_gpios PATH ${uicr_path} PROPERTY "nfct-pins-as-gpios")
   if(${nfct_pins_as_gpios})
     zephyr_library_compile_definitions(
-      CONFIG_NFCT_PINS_AS_GPIOS
       NRF_CONFIG_NFCT_PINS_AS_GPIOS
     )
   endif()

--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -75,28 +75,6 @@ config NRF_ACL_FLASH_REGION_SIZE
 	help
 	  FLASH region size for the NRF_ACL peripheral.
 
-config NFCT_PINS_AS_GPIOS
-	bool "[DEPRECATED] NFCT pins as GPIOs"
-	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_NFCT))
-	select DEPRECATED
-	help
-	  Two pins are usually reserved for NFC in SoCs that implement the
-	  NFCT peripheral. This option switches them to normal GPIO mode.
-	  HW enabling happens once in the device lifetime, during the first
-	  system startup. Disabling this option will not switch back these
-	  pins to NFCT mode. Doing this requires UICR erase prior to
-	  flashing device using the image which has this option disabled.
-
-	  NFC pins in nRF52 series: P0.09 and P0.10
-	  NFC pins in nRF5340: P0.02 and P0.03
-
-	  This option is deprecated, please use devicetree to configure NFCT
-	  pins as GPIOS like this:
-
-	  &uicr {
-	      nfct-pins-as-gpios;
-	  };
-
 choice NRF_APPROTECT_HANDLING
 	bool "APPROTECT handling"
 	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF53X || SOC_NRF54L_CPUAPP_COMMON || \

--- a/soc/nordic/nrf52/Kconfig
+++ b/soc/nordic/nrf52/Kconfig
@@ -59,7 +59,7 @@ config SOC_DCDC_NRF52X_HV
 	  Enable nRF52 series System on Chip High Voltage DC/DC converter.
 
 config GPIO_AS_PINRESET
-	bool "[DEPRECATED] GPIO as pin reset (reset button)"
+	bool
 	select DEPRECATED
 	help
 	  This option is deprecated, use devicetree instead. Example


### PR DESCRIPTION
These Kconfig were deprecated in Zephyr 3.5