### PR TITLE
iar: linker_script: zero-init BSS

### DIFF
--- a/cmake/linker/iar/config_file_script.cmake
+++ b/cmake/linker/iar/config_file_script.cmake
@@ -98,7 +98,7 @@ function(process_region)
         )
     endif()
     # Treat BSS to be noinit
-    if(type STREQUAL BSS)
+    if(CONFIG_IAR_ZEPHYR_INIT AND type STREQUAL BSS)
       set_property(GLOBAL PROPERTY ${section}_NOINIT TRUE)
     endif()
   endforeach() # all sections


### PR DESCRIPTION
CONFIG_IAR_DATA_INIT did inadvertently not initialize BSS.