### PR TITLE
Fix `benchmark.kernel.footprints.pm` for `siwx91x`

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
@@ -114,6 +114,10 @@
 	};
 };
 
+&sysrtc0  {
+	status = "okay";
+};
+
 &memc {
 	clocks = <&clock0 SIWX91X_CLK_QSPI>;
 	pinctrl-0 = <&psram_default>;

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 921041808ba4843f72a617f9ad90e0d3beb52bbd
+      revision: 190a144a16bed9a938a94543ed5bbc70c0552e0f
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Currently, twister complains about `benchmark.kernel.footprints.pm` when compiled for `siwx917_rb4338a` or for `siwx917_rb4342a`:

        - 9) cpp.main.picolibc on siwx917_rb4338a/siwg917m111mgtba error (Build failure - 
             ld.bfd: warning: orphan section `.udma_addr1' from `zephyr/libzephyr.a(UDMA.c.obj)'
             being placed in section `.udma_addr1')
        - 10) benchmark.kernel.footprints.pm on siwx917_rb4342a/siwg917m111mgtba error (CMake build failure -
               warning: SILABS_SLEEPTIMER_TIMER (defined at soc/silabs/silabs_s2/Kconfig.defconfig:17, drivers/timer/Kconfig.silabs:4)
               has direct dependencies (SOC_FAMILY_SILABS_S2 || SOC_FAMILY_SILABS_SIWX91X) && DT_HAS_SILABS_GECKO_STIMER_ENABLED && SYS_CLOCK_EXISTS
               with value n, but is currently being y-selected by the following symbols:)

The result of the CI can be found here:
    https://github.com/zephyrproject-rtos/zephyr/actions/runs/15878009558/job/44770806412?pr=92181

This PR fix these issues.
