### PR TITLE
tests: drivers: mbox_data: exclude the drivers.mbox_data testcase on S32Z

### DIFF
--- a/tests/drivers/mbox/mbox_data/testcase.yaml
+++ b/tests/drivers/mbox/mbox_data/testcase.yaml
@@ -9,6 +9,11 @@ tests:
     integration_platforms:
       - mimxrt1170_evk/mimxrt1176/cm7
       - lpcxpresso55s69/lpc55s69/cpu0
+    platform_exclude:
+      - s32z2xxdc2/s32z270/rtu0
+      - s32z2xxdc2/s32z270/rtu1
+      - s32z2xxdc2@D/s32z270/rtu0
+      - s32z2xxdc2@D/s32z270/rtu1
   drivers.mbox_data.single_cpu:
     platform_allow:
       - s32z2xxdc2/s32z270/rtu0


### PR DESCRIPTION
This test case is not supported on the S32Z platform, as it requires execution across two CPU cores