### PR TITLE
[v3.7-branch] Fix ES-Wifi driver include when CONFIG_TLS_CREDENTIALS is set

### DIFF
--- a/drivers/wifi/eswifi/CMakeLists.txt
+++ b/drivers/wifi/eswifi/CMakeLists.txt
@@ -8,6 +8,10 @@ if(CONFIG_WIFI_ESWIFI)
   ${ZEPHYR_BASE}/subsys/net/lib/sockets
   )
 
+  zephyr_library_include_directories_ifdef(CONFIG_TLS_CREDENTIALS
+  ${ZEPHYR_BASE}/subsys/net/lib/tls_credentials
+  )
+
   zephyr_library_sources(
     eswifi_core.c
     eswifi_offload.c


### PR DESCRIPTION
Include path is missing when CONFIG_TLS_CREDENTIALS is set.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92243