### PR TITLE
soc: intel_adsp: (cosmetic) make a function static

### DIFF
--- a/soc/intel/intel_adsp/common/include/intel_adsp_ipc.h
+++ b/soc/intel/intel_adsp/common/include/intel_adsp_ipc.h
@@ -73,8 +73,6 @@ struct intel_adsp_ipc_data {
 	bool tx_ack_pending;
 };
 
-void z_intel_adsp_ipc_isr(const void *devarg);
-
 /**
  * @brief Register message callback handler.
  *

--- a/soc/intel/intel_adsp/common/ipc.c
+++ b/soc/intel/intel_adsp/common/ipc.c
@@ -35,7 +35,7 @@ void intel_adsp_ipc_set_done_handler(const struct device *dev,
 	k_spin_unlock(&devdata->lock, key);
 }
 
-void z_intel_adsp_ipc_isr(const void *devarg)
+static void intel_adsp_ipc_isr(const void *devarg)
 {
 	const struct device *dev = devarg;
 	const struct intel_adsp_ipc_config *config = dev->config;
@@ -224,7 +224,7 @@ static inline void ace_ipc_intc_unmask(void) {}
 
 static int dt_init(const struct device *dev)
 {
-	IRQ_CONNECT(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE), 0, z_intel_adsp_ipc_isr,
+	IRQ_CONNECT(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE), 0, intel_adsp_ipc_isr,
 		INTEL_ADSP_IPC_HOST_DEV, 0);
 	irq_enable(DT_IRQN(INTEL_ADSP_IPC_HOST_DTNODE));
 


### PR DESCRIPTION
z_intel_adsp_ipc_isr() doesn't need to be global, make it static.