### PR TITLE
net: events: Add missing net_mgmt.h include

### DIFF
--- a/include/zephyr/net/net_event.h
+++ b/include/zephyr/net/net_event.h
@@ -13,6 +13,7 @@
 #define ZEPHYR_INCLUDE_NET_NET_EVENT_H_
 
 #include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/hostname.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
net_event.h header makes use of macros defined in net_mgmt.h, therefore it should include that header.