### PR TITLE
drivers: modem_cellular: fix quectel_eg25_g dial script cmd response

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -525,9 +525,8 @@ MODEM_CHAT_MATCHES_DEFINE(dial_abort_matches,
 			  MODEM_CHAT_MATCH("NO CARRIER", "", NULL),
 			  MODEM_CHAT_MATCH("NO DIALTONE", "", NULL));
 
-#if DT_HAS_COMPAT_STATUS_OKAY(swir_hl7800) || \
-	DT_HAS_COMPAT_STATUS_OKAY(sqn_gm02s) ||		   \
-	DT_HAS_COMPAT_STATUS_OKAY(quectel_eg800q) || \
+#if DT_HAS_COMPAT_STATUS_OKAY(swir_hl7800) || DT_HAS_COMPAT_STATUS_OKAY(sqn_gm02s) ||              \
+	DT_HAS_COMPAT_STATUS_OKAY(quectel_eg800q) || DT_HAS_COMPAT_STATUS_OKAY(quectel_eg25_g) ||  \
 	DT_HAS_COMPAT_STATUS_OKAY(simcom_a76xx)
 MODEM_CHAT_MATCH_DEFINE(connect_match, "CONNECT", "", NULL);
 #endif
@@ -2006,10 +2005,10 @@ MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_init_chat_script, quectel_eg25_g_init_ch
 MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_eg25_g_dial_chat_script_cmds,
 			      MODEM_CHAT_SCRIPT_CMD_RESP_MULT("AT+CGACT=0,1", allow_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CGDCONT=1,\"IP\","
-							 "\""CONFIG_MODEM_CELLULAR_APN"\"",
+							 "\"" CONFIG_MODEM_CELLULAR_APN "\"",
 							 ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("ATD*99***1#", 0),);
+			      MODEM_CHAT_SCRIPT_CMD_RESP("ATD*99***1#", connect_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_eg25_g_dial_chat_script, quectel_eg25_g_dial_chat_script_cmds,
 			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);


### PR DESCRIPTION
quectel_eg25_g modem should respond "CONNECT <text> " when run dial cmd "ATD" according to the  AT Command Manual.
![image](https://github.com/user-attachments/assets/e6f58fd0-0cf1-4303-a4a7-fd4aa476e64d)

**Before the change, the log output:**
```
[00:00:17.907,392] <inf> modem_at_shell: pipe connected
[00:00:17.907,420] <inf> modem_at_shell: opening pipe
[00:00:17.929,198] <inf> modem_at_shell: pipe opened
[00:00:17.929,246] <inf> modem_at_shell: chat attached
[00:00:18.050,579] <dbg> modem_chat: modem_chat_script_start: running script: quectel_eg25_g_dial_chat_script
[00:00:18.050,604] <dbg> modem_chat: modem_chat_script_next: quectel_eg25_g_dial_chat_script: step: 0
[00:00:18.050,633] <dbg> modem_chat: modem_chat_script_next: sending: AT+CGACT=0,1
[00:00:18.075,850] <dbg> modem_chat: modem_chat_log_received_command: OK
[00:00:18.075,865] <dbg> modem_chat: modem_chat_script_next: quectel_eg25_g_dial_chat_script: step: 1
[00:00:18.075,878] <dbg> modem_chat: modem_chat_script_next: sending: AT+CGDCONT=1,"IP","cmiot"
[00:00:18.101,577] <dbg> modem_chat: modem_chat_log_received_command: OK
[00:00:18.101,591] <dbg> modem_chat: modem_chat_script_next: quectel_eg25_g_dial_chat_script: step: 2
[00:00:18.101,604] <dbg> modem_chat: modem_chat_script_next: sending: AT+CFUN=1
[00:00:18.129,249] <dbg> modem_chat: modem_chat_log_received_command: OK
[00:00:18.129,276] <dbg> modem_chat: modem_chat_script_next: quectel_eg25_g_dial_chat_script: step: 3
[00:00:18.129,290] <dbg> modem_chat: modem_chat_script_next: sending: ATD*99***1#
[00:00:18.129,352] <dbg> modem_chat: modem_chat_script_stop: quectel_eg25_g_dial_chat_script: complete
[00:00:18.162,730] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x0d because 0x7e was expected.
[00:00:18.162,763] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x0a because 0x7e was expected.
[00:00:18.162,770] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x43 because 0x7e was expected.
[00:00:18.162,777] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x4f because 0x7e was expected.
[00:00:18.162,783] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x4e because 0x7e was expected.
[00:00:18.162,789] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x4e because 0x7e was expected.
[00:00:18.162,795] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x45 because 0x7e was expected.
[00:00:18.162,801] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x43 because 0x7e was expected.
[00:00:18.162,808] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x54 because 0x7e was expected.
[00:00:18.162,814] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x20 because 0x7e was expected.
[00:00:18.162,830] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x31 because 0x7e was expected.
[00:00:18.162,837] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x35 because 0x7e was expected.
[00:00:18.162,843] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x30 because 0x7e was expected.
[00:00:18.162,849] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x30 because 0x7e was expected.
[00:00:18.162,855] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x30 because 0x7e was expected.
[00:00:18.162,862] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x30 because 0x7e was expected.
[00:00:18.162,868] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x30 because 0x7e was expected.
[00:00:18.162,874] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x30 because 0x7e was expected.
[00:00:18.162,880] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x30 because 0x7e was expected.
[00:00:18.162,886] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x0d because 0x7e was expected.
[00:00:18.162,893] <dbg> modem_ppp: modem_ppp_is_byte_expected: Dropping byte 0x0a because 0x7e was expected.
```

**After the change:**
```
[00:00:15.926,487] <dbg> modem_chat: modem_chat_script_next: quectel_eg25_g_dial_chat_script: step: 2
[00:00:15.926,501] <dbg> modem_chat: modem_chat_script_next: sending: AT+CFUN=1
[00:00:15.953,546] <dbg> modem_chat: modem_chat_log_received_command: OK
[00:00:15.953,573] <dbg> modem_chat: modem_chat_script_next: quectel_eg25_g_dial_chat_script: step: 3
[00:00:15.953,587] <dbg> modem_chat: modem_chat_script_next: sending: ATD*99***1#
[00:00:15.986,939] <dbg> modem_chat: modem_chat_log_received_command: CONNECT  150000000
[00:00:15.986,965] <dbg> modem_chat: modem_chat_script_stop: quectel_eg25_g_dial_chat_script: complete
```
