### PR TITLE
soc: esp32: increase ble command TX buffer

### DIFF
--- a/soc/espressif/esp32/Kconfig.defconfig
+++ b/soc/espressif/esp32/Kconfig.defconfig
@@ -38,3 +38,12 @@ config GDBSTUB_BUF_SZ
 endif # GDBSTUB config
 
 endif # SOC_SERIES_ESP32 config
+
+if BT_ESP32
+
+# Temporary workaround to prevent HCI command timeouts on ESP32.
+# A proper fix will be implemented in the BLE proprietary blobs.
+config BT_BUF_CMD_TX_COUNT
+	default 2
+
+endif


### PR DESCRIPTION
Increase the number of HCI command transmit buffers on ESP32 to prevent
sporadic command timeouts. This is a temporary workaround.
Upcoming changes to the BLE proprietary blobs will address the root cause.

Fix #85942