### PR TITLE
drivers: sensor: bmm350: fix redundant return logic in init_chip

### DIFF
--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -900,7 +900,7 @@ static int bmm350_init_chip(const struct device *dev)
 err_poweroff:
 	ret = bmm350_set_powermode(dev, BMM350_SUSPEND_MODE);
 	if (ret != 0) {
-		return -EIO;
+		LOG_ERR("failed to set suspend mode");
 	}
 	return -EIO;
 }


### PR DESCRIPTION
Add an explicit log message if setting suspend mode fails during error handling in bmm350_init_chip(), to improve debuggability.

This addresses Coverity issue CID 520279 (Incorrect expression - CWE-398), which flagged a conditional block where both branches effectively led to the same outcome (return -EIO), making it appear redundant.

By adding a log before returning, we clarify the purpose of the condition and avoid the issue of "identical code for different branches", while keeping the functional behavior unchanged.

Coverity-CID: 520279

Fix https://github.com/zephyrproject-rtos/zephyr/issues/90510