### PR TITLE
arch: arc: support CONFIG_ROM_START_OFFSET

### DIFF
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -389,6 +389,11 @@ config ARC_EARLY_SOC_INIT
 	  (before C runtime initialization). Setup code is called in form of
 	  soc_early_asm_init_percpu assembler macro.
 
+# ARC vector table must be aligned to 1KiB boundary, and will be at the
+# start of the ROM region.
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 config MAIN_STACK_SIZE
 	default 4096 if 64BIT
 

--- a/arch/common/CMakeLists.txt
+++ b/arch/common/CMakeLists.txt
@@ -83,8 +83,7 @@ zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
   nocache.ld
 )
 
-# Only ARM, X86 and RISCV use ROM_START_OFFSET.
-if (DEFINED CONFIG_ARM OR DEFINED CONFIG_X86 OR DEFINED CONFIG_ARM64 OR DEFINED CONFIG_RISCV)
+if (DEFINED CONFIG_ARCH_SUPPORTS_ROM_OFFSET)
   # Exclamation mark is printable character with lowest number in ASCII table.
   # We are sure that this file will be included as a first.
   zephyr_linker_sources(ROM_START SORT_KEY ! rom_start_address.ld)

--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -23,6 +23,14 @@ config ISR_TABLE_SHELL
 	help
 	  This option enables a shell command to dump the ISR tables.
 
+config ARCH_SUPPORTS_ROM_OFFSET
+	bool
+	default y
+	depends on  (ARM || X86 || ARM64 || RISCV)
+	help
+	  Hidden option to enable support for ROM offset within the linker
+	  script, which will place a block of 0x0 of size
+	  CONFIG_ROM_START_OFFSET at the start of the ROM region.
 
 config ARM_MPU
 	bool "ARM MPU Support"

--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -26,7 +26,7 @@ config ISR_TABLE_SHELL
 config ARCH_SUPPORTS_ROM_OFFSET
 	bool
 	default y
-	depends on  (ARM || X86 || ARM64 || RISCV)
+	depends on  (ARM || X86 || ARM64 || RISCV || ARC)
 	help
 	  Hidden option to enable support for ROM offset within the linker
 	  script, which will place a block of 0x0 of size


### PR DESCRIPTION
Add support for CONFIG_ROM_START_OFFSET on ARC processors. Note that the
arc ISA requires vector table offset to be at a 1024 KiB boundary, so
the default ROM_START_OFFSET when using MCUBoot must be increased.