### PR TITLE
tests: lib: timespec_util: support tick period not multiples of 100ms

### DIFF
--- a/tests/lib/timespec_util/src/main.c
+++ b/tests/lib/timespec_util/src/main.c
@@ -298,7 +298,7 @@ static const struct tospec {
 	{K_NSEC(2000000000), {2, 0}, 0},
 	{K_USEC(0), {0, 0}, 0},
 	{K_USEC(2000000), {2, 0}, 0},
-	{K_MSEC(100), {0, 100000000}, 0},
+	{K_MSEC(100), {0, k_ticks_to_ns_ceil64(k_ms_to_ticks_ceil32(100))}, 0},
 	{K_MSEC(2000), {2, 0}, 0},
 	{K_SECONDS(0), {0, 0}, 0},
 	{K_SECONDS(1), {1, 0}, 0},


### PR DESCRIPTION
If the system tick period is not a multiple of 100ms, then `K_MSEC(100)` does not correspond exactly to 100000000 ns after going through tick conversion.

Convert 100ms to ticks and then to ns to account for this within the testsuite.

Fixes #92158

Testing Done:
```shell
west build -p auto -b nrf52_bsim -t run tests/lib/timespec_util -T libraries.timespec_utils.picolibc
...
d_00: @00:00:00.000000  *** Booting Zephyr OS build v4.1.0-6916-g38cd1da16c1f ***
d_00: @00:00:00.000000  Running TESTSUITE timeutil_api
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  CONFIG_TIMEOUT_64BIT=y
d_00: @00:00:00.000000  K_TICK_MAX: 9223372036854775807
d_00: @00:00:00.000000  minimum timeout: {0, 30517}
d_00: @00:00:00.000000  maximum timeout: {9223372036, 854745291}
d_00: @00:00:00.000000  START - test_timespec_add
d_00: @00:00:00.000000   PASS - test_timespec_add in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_compare
d_00: @00:00:00.000000   PASS - test_timespec_compare in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_equal
d_00: @00:00:00.000000   PASS - test_timespec_equal in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_from_timeout
d_00: @00:00:00.000000   PASS - test_timespec_from_timeout in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_is_valid
d_00: @00:00:00.000000   PASS - test_timespec_is_valid in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_negate
d_00: @00:00:00.000000   PASS - test_timespec_negate in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_normalize
d_00: @00:00:00.000000   PASS - test_timespec_normalize in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_sub
d_00: @00:00:00.000000   PASS - test_timespec_sub in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  START - test_timespec_to_timeout
d_00: @00:00:00.000000   PASS - test_timespec_to_timeout in 0.000 seconds
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  TESTSUITE timeutil_api succeeded
d_00: @00:00:00.000000  
d_00: @00:00:00.000000  ------ TESTSUITE SUMMARY START ------
d_00: @00:00:00.000000  
d_00: @00:00:00.000000  SUITE PASS - 100.00% [timeutil_api]: pass = 9, fail = 0, skip = 0, total = 9 duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_add] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_compare] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_equal] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_from_timeout] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_is_valid] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_negate] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_normalize] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_sub] duration = 0.000 seconds
d_00: @00:00:00.000000   - PASS - [timeutil_api.test_timespec_to_timeout] duration = 0.000 seconds
d_00: @00:00:00.000000  
d_00: @00:00:00.000000  ------ TESTSUITE SUMMARY END ------
d_00: @00:00:00.000000  
d_00: @00:00:00.000000  ===================================================================
d_00: @00:00:00.000000  PROJECT EXECUTION SUCCESSFUL
```