### PR TITLE
drivers: sensors: apds9253: remove unnecessary check

### DIFF
--- a/drivers/sensor/apds9253/apds9253.c
+++ b/drivers/sensor/apds9253/apds9253.c
@@ -136,7 +136,7 @@ static int apds9253_attr_set_gain(const struct device *dev, uint8_t gain)
 		APDS9253_LS_GAIN_RANGE_9, APDS9253_LS_GAIN_RANGE_18,
 	};
 
-	if (gain < APDS9253_LS_GAIN_RANGE_1 || gain > APDS9253_LS_GAIN_RANGE_18) {
+	if (gain > APDS9253_LS_GAIN_RANGE_18) {
 		return -EINVAL;
 	}
 	value = value_map[gain];


### PR DESCRIPTION
gain is an unsigned int so it can't be negative.

Fixes CID 516230

Fix https://github.com/zephyrproject-rtos/zephyr/issues/90546