### PR TITLE
samples: Bluetooth: PAWR: Fix Response Slot Delay Value is too Small

### DIFF
--- a/samples/bluetooth/periodic_adv_conn/src/main.c
+++ b/samples/bluetooth/periodic_adv_conn/src/main.c
@@ -20,7 +20,7 @@ static const struct bt_le_per_adv_param per_adv_params = {
 	.options = 0,
 	.num_subevents = NUM_SUBEVENTS,
 	.subevent_interval = SUBEVENT_INTERVAL,
-	.response_slot_delay = 0x5,
+	.response_slot_delay = 0x8,
 	.response_slot_spacing = 0x50,
 	.num_response_slots = NUM_RSP_SLOTS,
 };

--- a/samples/bluetooth/periodic_adv_rsp/src/main.c
+++ b/samples/bluetooth/periodic_adv_rsp/src/main.c
@@ -36,7 +36,7 @@ static const struct bt_le_per_adv_param per_adv_params = {
 	.options = 0,
 	.num_subevents = NUM_SUBEVENTS,
 	.subevent_interval = 0x30,
-	.response_slot_delay = 0x5,
+	.response_slot_delay = 0x8,
 	.response_slot_spacing = 0x50,
 	.num_response_slots = NUM_RSP_SLOTS,
 };


### PR DESCRIPTION
Previously, reponse slot value is 5* 1.25ms = 6.25ms , on nxp rw61x platform, host got the periodic adv report v2 and after about 6ms, send reponse data cmd,  it is too late , so always rpt the 0x46 too late err code to host , in order to send the response , so make rsp delay update to 10ms