### PR TITLE
ipc_service: ipc_icbmsg: fix unchecked error in icmsg_open()

### DIFF
--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -436,6 +436,9 @@ int icmsg_open(const struct icmsg_config_t *conf,
 			MAKE_RX_HANDSHAKE(dev_data->local_sid, SID_DISCONNECTED));
 	} else if (UNBOUND_DISABLED) {
 		ret = initialize_tx_with_sid_disabled(dev_data);
+		if (ret < 0) {
+			goto cleanup_and_exit;
+		}
 	}
 
 	if (old_state == ICMSG_STATE_OFF && (UNBOUND_ENABLED || UNBOUND_DETECT)) {


### PR DESCRIPTION
Coverity (CID 516253) reported that the return value of initialize_tx_with_sid_disabled() was set but not used, leading to potential silent failures.

Check if the return value is negative and propagate the error through the existing cleanup path.

Fixes: CID 516253

Fix https://github.com/zephyrproject-rtos/zephyr/issues/90524