### PR TITLE
drivers: intc_dw: support multiple instances

### DIFF
--- a/drivers/interrupt_controller/intc_dw.h
+++ b/drivers/interrupt_controller/intc_dw.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-typedef void (*dw_ictl_config_irq_t)(const struct device *dev);
+typedef void (*dw_ictl_config_irq_t)(void);
 
 struct dw_ictl_config {
 	uint32_t base_addr;


### PR DESCRIPTION
Update the initializers to support platforms with multiple instances of the DesignWare interrupt aggregator. Also ensure that the initialize function calls `irq_enable()`. The calculation of the `_sw_isr_table` entry also now takes `CONFIG_GEN_IRQ_START_VECTOR` into account.