### PR TITLE
arch: arc: add support for multilevel interrupts

### DIFF
--- a/arch/arc/core/CMakeLists.txt
+++ b/arch/arc/core/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 zephyr_library()
 
+zephyr_library_include_directories(${ZEPHYR_BASE}/arch/common/include)
 zephyr_library_sources(
   thread.c
   thread_entry_wrapper.S

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -17,6 +17,8 @@
  * number from 16 to last IRQ number on the platform.
  */
 
+#include "sw_isr_common.h"
+
 #include <zephyr/kernel.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/sys/__assert.h>
@@ -25,7 +27,8 @@
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/printk.h>
-
+#include <zephyr/irq_multilevel.h>
+#include <zephyr/irq_nextlevel.h>
 
 /*
  * storage space for the interrupt stack of fast_irq
@@ -187,11 +190,50 @@ int arch_irq_is_enabled(unsigned int irq)
 #else
 void arch_irq_enable(unsigned int irq)
 {
+#ifdef CONFIG_MULTI_LEVEL_INTERRUPTS
+	unsigned int level = irq_get_level(irq);
+	const struct device *dev;
+
+#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
+	if (level == 3) {
+		dev = z_get_sw_isr_device_from_irq(irq);
+		irq_enable_next_level(dev, irq_from_level_3(irq));
+		return;
+	}
+#endif
+#ifdef CONFIG_2ND_LEVEL_INTERRUPTS
+	if (level == 2) {
+		dev = z_get_sw_isr_device_from_irq(irq);
+		irq_enable_next_level(dev, irq_from_level_2(irq));
+		return;
+	}
+#endif
+#endif
 	z_arc_v2_irq_unit_int_enable(irq);
 }
 
 void arch_irq_disable(unsigned int irq)
 {
+#ifdef CONFIG_MULTI_LEVEL_INTERRUPTS
+	unsigned int level = irq_get_level(irq);
+	const struct device *dev;
+
+#ifdef CONFIG_3RD_LEVEL_INTERRUPTS
+	if (level == 3) {
+		dev = z_get_sw_isr_device_from_irq(irq);
+		irq_disable_next_level(dev, irq_from_level_3(irq));
+		return;
+	}
+#endif
+#ifdef CONFIG_2ND_LEVEL_INTERRUPTS
+	if (level == 2) {
+		dev = z_get_sw_isr_device_from_irq(irq);
+		irq_disable_next_level(dev, irq_from_level_2(irq));
+		return;
+	}
+#endif
+#endif
+
 	z_arc_v2_irq_unit_int_disable(irq);
 }
 


### PR DESCRIPTION
Update the arch_irq_enable/disable functions to support multilevel interrupts on the ARC architecture.