### PR TITLE
west.yml: hal_espressif: reserve BLE IRQ in interrupt descriptor

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: c8d2da183298c147f40f3563e2c4fd1a81dbd92f
+      revision: 3339ff2f85edb3edb1188873d3dcd25d9a544ee8
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Ensure that the BLE interrupt remains marked as reserved in the interrupt table descriptor when it’s in use. This prevents accidental reassignment of the BLE IRQ in downstream configurations.

Depends on #92144

Fix #90336
Fix #85318
