### PR TITLE
arch: riscv: Fix incorrect Zalrsc extension name

### DIFF
--- a/arch/riscv/Kconfig.isa
+++ b/arch/riscv/Kconfig.isa
@@ -34,7 +34,7 @@ config RISCV_ISA_EXT_M
 config RISCV_ISA_EXT_A
 	bool
 	imply RISCV_ISA_EXT_ZAAMO
-	imply RISCV_ISA_EXT_ZLRSC
+	imply RISCV_ISA_EXT_ZALRSC
 	help
 	  (A) - Standard Extension for Atomic Instructions
 
@@ -120,12 +120,12 @@ config RISCV_ISA_EXT_ZAAMO
 
 	  The Zaamo extension enables support for AMO*.W/D-style instructions.
 
-config RISCV_ISA_EXT_ZLRSC
+config RISCV_ISA_EXT_ZALRSC
 	bool
 	help
-	  (Zlrsc) - Load-Reserved/Store-Conditional subset of the A extension
+	  (Zalrsc) - Load-Reserved/Store-Conditional subset of the A extension
 
-	  The Zlrsc extension enables support for LR.W/D and SC.W/D-style instructions.
+	  The Zalrsc extension enables support for LR.W/D and SC.W/D-style instructions.
 
 config RISCV_ISA_EXT_ZBA
 	bool

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -54,15 +54,15 @@ if(CONFIG_RISCV_ISA_EXT_ZIFENCEI)
   string(CONCAT riscv_march ${riscv_march} "_zifencei")
 endif()
 
-# Check whether we already imply Zaamo/Zlrsc by selecting the A extension; if not - check them
+# Check whether we already imply Zaamo/Zalrsc by selecting the A extension; if not - check them
 # individually and enable them as needed
 if(NOT CONFIG_RISCV_ISA_EXT_A)
   if(CONFIG_RISCV_ISA_EXT_ZAAMO)
     string(CONCAT riscv_march ${riscv_march} "_zaamo")
   endif()
 
-  if(CONFIG_RISCV_ISA_EXT_ZLRSC)
-    string(CONCAT riscv_march ${riscv_march} "_zlrsc")
+  if(CONFIG_RISCV_ISA_EXT_ZALRSC)
+    string(CONCAT riscv_march ${riscv_march} "_zalrsc")
   endif()
 endif()
 

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -4,53 +4,54 @@ set(riscv_mabi "lp")
 set(riscv_march "rv")
 
 if(CONFIG_64BIT)
-    string(CONCAT riscv_mabi  ${riscv_mabi} "64")
-    string(CONCAT riscv_march ${riscv_march} "64")
-    list(APPEND TOOLCHAIN_C_FLAGS -mcmodel=medany)
-    list(APPEND TOOLCHAIN_LD_FLAGS -mcmodel=medany)
+  string(CONCAT riscv_mabi  ${riscv_mabi} "64")
+  string(CONCAT riscv_march ${riscv_march} "64")
+  list(APPEND TOOLCHAIN_C_FLAGS -mcmodel=medany)
+  list(APPEND TOOLCHAIN_LD_FLAGS -mcmodel=medany)
 else()
-    string(CONCAT riscv_mabi  "i" ${riscv_mabi} "32")
-    string(CONCAT riscv_march ${riscv_march} "32")
+  string(CONCAT riscv_mabi  "i" ${riscv_mabi} "32")
+  string(CONCAT riscv_march ${riscv_march} "32")
 endif()
 
-if (CONFIG_RISCV_ISA_RV32E)
-    string(CONCAT riscv_mabi ${riscv_mabi} "e")
-    string(CONCAT riscv_march ${riscv_march} "e")
+if(CONFIG_RISCV_ISA_RV32E)
+  string(CONCAT riscv_mabi ${riscv_mabi} "e")
+  string(CONCAT riscv_march ${riscv_march} "e")
 else()
-    string(CONCAT riscv_march ${riscv_march} "i")
+  string(CONCAT riscv_march ${riscv_march} "i")
 endif()
 
-if (CONFIG_RISCV_ISA_EXT_M)
-    string(CONCAT riscv_march ${riscv_march} "m")
+if(CONFIG_RISCV_ISA_EXT_M)
+  string(CONCAT riscv_march ${riscv_march} "m")
 endif()
-if (CONFIG_RISCV_ISA_EXT_A)
-    string(CONCAT riscv_march ${riscv_march} "a")
+
+if(CONFIG_RISCV_ISA_EXT_A)
+  string(CONCAT riscv_march ${riscv_march} "a")
 endif()
 
 if(CONFIG_FPU)
-    if(CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION)
-        if(CONFIG_FLOAT_HARD)
-            string(CONCAT riscv_mabi ${riscv_mabi} "d")
-        endif()
-        string(CONCAT riscv_march ${riscv_march} "fd")
-    else()
-        if(CONFIG_FLOAT_HARD)
-            string(CONCAT riscv_mabi ${riscv_mabi} "f")
-        endif()
-        string(CONCAT riscv_march ${riscv_march} "f")
+  if(CONFIG_CPU_HAS_FPU_DOUBLE_PRECISION)
+    if(CONFIG_FLOAT_HARD)
+      string(CONCAT riscv_mabi ${riscv_mabi} "d")
     endif()
+    string(CONCAT riscv_march ${riscv_march} "fd")
+  else()
+    if(CONFIG_FLOAT_HARD)
+      string(CONCAT riscv_mabi ${riscv_mabi} "f")
+    endif()
+    string(CONCAT riscv_march ${riscv_march} "f")
+  endif()
 endif()
 
 if(CONFIG_RISCV_ISA_EXT_C)
-    string(CONCAT riscv_march ${riscv_march} "c")
+  string(CONCAT riscv_march ${riscv_march} "c")
 endif()
 
 if(CONFIG_RISCV_ISA_EXT_ZICSR)
-    string(CONCAT riscv_march ${riscv_march} "_zicsr")
+  string(CONCAT riscv_march ${riscv_march} "_zicsr")
 endif()
 
 if(CONFIG_RISCV_ISA_EXT_ZIFENCEI)
-    string(CONCAT riscv_march ${riscv_march} "_zifencei")
+  string(CONCAT riscv_march ${riscv_march} "_zifencei")
 endif()
 
 # Check whether we already imply Zaamo/Zlrsc by selecting the A extension; if not - check them
@@ -66,26 +67,26 @@ if(NOT CONFIG_RISCV_ISA_EXT_A)
 endif()
 
 if(CONFIG_RISCV_ISA_EXT_ZBA)
-    string(CONCAT riscv_march ${riscv_march} "_zba")
+  string(CONCAT riscv_march ${riscv_march} "_zba")
 endif()
 
 if(CONFIG_RISCV_ISA_EXT_ZBB)
-    string(CONCAT riscv_march ${riscv_march} "_zbb")
+  string(CONCAT riscv_march ${riscv_march} "_zbb")
 endif()
 
 if(CONFIG_RISCV_ISA_EXT_ZBC)
-    string(CONCAT riscv_march ${riscv_march} "_zbc")
+  string(CONCAT riscv_march ${riscv_march} "_zbc")
 endif()
 
 if(CONFIG_RISCV_ISA_EXT_ZBS)
-    string(CONCAT riscv_march ${riscv_march} "_zbs")
+  string(CONCAT riscv_march ${riscv_march} "_zbs")
 endif()
 
 # Check whether we already imply Zmmul by selecting the M extension; if not - enable it
 if(NOT CONFIG_RISCV_ISA_EXT_M AND
    CONFIG_RISCV_ISA_EXT_ZMMUL AND
    "${GCC_COMPILER_VERSION}" VERSION_GREATER_EQUAL 13.0.0)
-    string(CONCAT riscv_march ${riscv_march} "_zmmul")
+  string(CONCAT riscv_march ${riscv_march} "_zmmul")
 endif()
 
 list(APPEND TOOLCHAIN_C_FLAGS -mabi=${riscv_mabi} -march=${riscv_march})
@@ -100,7 +101,7 @@ set(LLEXT_REMOVE_FLAGS
   -fdata-sections
   -g.*
   -Os
-)
+  )
 
 # Flags to be added to llext code compilation
 # mno-relax is needed to stop gcc from generating R_RISCV_ALIGN relocations,
@@ -113,4 +114,4 @@ set(LLEXT_APPEND_FLAGS
   -march=${riscv_march}
   -mno-relax
   -msmall-data-limit=0
-)
+  )


### PR DESCRIPTION
`Zlrsc` is not a thing and the correct name for it is `Zalrsc`.

This series also includes an overall re-formatting of `target_riscv.cmake` to comply with the Zephyr repository-wide convention.