### PR TITLE
modem: backend: uart: Retransmit aborted UART TX

### DIFF
--- a/include/zephyr/modem/backend/uart.h
+++ b/include/zephyr/modem/backend/uart.h
@@ -31,8 +31,6 @@ struct modem_backend_uart_isr {
 };
 
 struct modem_backend_uart_async_common {
-	uint8_t *transmit_buf;
-	uint32_t transmit_buf_size;
 	struct k_work rx_disabled_work;
 	atomic_t state;
 };
@@ -46,6 +44,7 @@ struct rx_queue_event {
 
 struct modem_backend_uart_async {
 	struct modem_backend_uart_async_common common;
+	struct ring_buf transmit_rb;
 	struct k_mem_slab rx_slab;
 	struct k_msgq rx_queue;
 	struct rx_queue_event rx_event;
@@ -58,6 +57,8 @@ struct modem_backend_uart_async {
 
 struct modem_backend_uart_async {
 	struct modem_backend_uart_async_common common;
+	uint8_t *transmit_buf;
+	uint32_t transmit_buf_size;
 	uint8_t *receive_bufs[2];
 	uint32_t receive_buf_size;
 	struct ring_buf receive_rb;

--- a/subsys/modem/backends/modem_backend_uart_async.c
+++ b/subsys/modem/backends/modem_backend_uart_async.c
@@ -198,7 +198,7 @@ static void advertise_receive_buf_stats(struct modem_backend_uart *backend)
 
 static uint32_t get_transmit_buf_size(struct modem_backend_uart *backend)
 {
-	return backend->async.common.transmit_buf_size;
+	return backend->async.transmit_buf_size;
 }
 
 static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, size_t size)
@@ -218,9 +218,9 @@ static int modem_backend_uart_async_transmit(void *data, const uint8_t *buf, siz
 	bytes_to_transmit = MIN(size, get_transmit_buf_size(backend));
 
 	/* Copy buf to transmit buffer which is passed to UART */
-	memcpy(backend->async.common.transmit_buf, buf, bytes_to_transmit);
+	memcpy(backend->async.transmit_buf, buf, bytes_to_transmit);
 
-	ret = uart_tx(backend->uart, backend->async.common.transmit_buf, bytes_to_transmit,
+	ret = uart_tx(backend->uart, backend->async.transmit_buf, bytes_to_transmit,
 		      CONFIG_MODEM_BACKEND_UART_ASYNC_TRANSMIT_TIMEOUT_MS * 1000L);
 
 #if CONFIG_MODEM_STATS
@@ -328,8 +328,8 @@ int modem_backend_uart_async_init(struct modem_backend_uart *backend,
 	ring_buf_init(&backend->async.receive_rb, (receive_buf_size_quarter * 2),
 		      &config->receive_buf[receive_buf_size_quarter * 2]);
 
-	backend->async.common.transmit_buf = config->transmit_buf;
-	backend->async.common.transmit_buf_size = config->transmit_buf_size;
+	backend->async.transmit_buf = config->transmit_buf;
+	backend->async.transmit_buf_size = config->transmit_buf_size;
 	k_work_init(&backend->async.common.rx_disabled_work,
 		    modem_backend_uart_async_notify_closed);
 	modem_pipe_init(&backend->pipe, backend, &modem_backend_uart_async_api);


### PR DESCRIPTION
When we are closing the UART and abort, the data that was not transmitted, will be re-send when the UART is re-opened.

When we are aborting due to timeout, which likely means that HWFC is active in the host device, we will re-send the data that was not transmitted, if any data made it through. If no data was transmitted, we will work as previously and discard the data.