### PR TITLE
soc : realtek: ec: rts5912: fix VIN polarity issue

### DIFF
--- a/soc/realtek/ec/rts5912/rts5912_ulpm.c
+++ b/soc/realtek/ec/rts5912/rts5912_ulpm.c
@@ -146,7 +146,7 @@ void rts5912_ulpm_enable(void)
 		if (wkup_pins_cfgs[i].pin_mode == RTS5912_ULPM_WKUP_PIN_MODE_VIN) {
 			LOG_DBG("setup VIN%d in ", id);
 			/* Configure Polarity */
-			if (wkup_pins_cfgs[i].pin_pol == RTS5912_ULPM_WKUP_PIN_POL_RISING) {
+			if (wkup_pins_cfgs[i].pin_pol == RTS5912_ULPM_WKUP_PIN_POL_FALLING) {
 				/* Falling Edge */
 				sys_reg->VIVOCTRL |= BIT(SYSTEM_VIVOCTRL_VIN0POL_Pos + id);
 				LOG_DBG("Falling Edge\n");


### PR DESCRIPTION
fix ulpm driver polarity issue.
when pin-pol set to falling need to set the POL bit to 1.
when pin-pol set to rising need to set the POL bit to 0.