### PR TITLE
drivers: Place device APIs in linker sections

### DIFF
--- a/drivers/adc/adc_cc23x0.c
+++ b/drivers/adc/adc_cc23x0.c
@@ -497,7 +497,7 @@ static int adc_cc23x0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct adc_driver_api adc_cc23x0_driver_api = {
+static DEVICE_API(adc, adc_cc23x0_driver_api) = {
 	.channel_setup = adc_cc23x0_channel_setup,
 	.read = adc_cc23x0_read,
 #ifdef CONFIG_ADC_ASYNC

--- a/drivers/adc/adc_ch32v00x.c
+++ b/drivers/adc/adc_ch32v00x.c
@@ -143,7 +143,7 @@ static int adc_ch32v00x_init(const struct device *dev)
 #define ADC_CH32V00X_DEVICE(n)                                                                     \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
                                                                                                    \
-	static const struct adc_driver_api adc_ch32v00x_api_##n = {                                \
+	static DEVICE_API(adc, adc_ch32v00x_api_##n) = {                                           \
 		.channel_setup = adc_ch32v00x_channel_setup,                                       \
 		.read = adc_ch32v00x_read,                                                         \
 		.ref_internal = DT_INST_PROP(n, vref_mv),                                          \

--- a/drivers/can/can_max32.c
+++ b/drivers/can/can_max32.c
@@ -682,7 +682,7 @@ static int can_max32_init(const struct device *dev)
 	return ret;
 }
 
-static const struct can_driver_api can_max32_api = {
+static DEVICE_API(can, can_max32_api) = {
 	.get_capabilities = can_max32_get_capabilities,
 	.set_mode = can_max32_set_mode,
 	.set_timing = can_max32_set_timing,

--- a/drivers/clock_control/clock_control_mspm0.c
+++ b/drivers/clock_control/clock_control_mspm0.c
@@ -237,7 +237,7 @@ static int clock_mspm0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct clock_control_driver_api clock_mspm0_driver_api = {
+static DEVICE_API(clock_control, clock_mspm0_driver_api) = {
 	.on = clock_mspm0_on,
 	.off = clock_mspm0_off,
 	.get_rate = clock_mspm0_get_rate,

--- a/drivers/counter/counter_cc23x0_lgpt.c
+++ b/drivers/counter/counter_cc23x0_lgpt.c
@@ -243,7 +243,7 @@ static int counter_cc23x0_lgpt_stop(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api cc23x0_lgpt_api = {
+static DEVICE_API(counter, cc23x0_lgpt_api) = {
 	.start = counter_cc23x0_lgpt_start,
 	.stop = counter_cc23x0_lgpt_stop,
 	.get_value = counter_cc23x0_lgpt_get_value,

--- a/drivers/counter/counter_cc23x0_rtc.c
+++ b/drivers/counter/counter_cc23x0_rtc.c
@@ -208,7 +208,7 @@ static int counter_cc23x0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct counter_driver_api rtc_cc23x0_api = {
+static DEVICE_API(counter, rtc_cc23x0_api) = {
 	.start = counter_cc23x0_start,
 	.stop = counter_cc23x0_stop,
 	.get_value = counter_cc23x0_get_value,

--- a/drivers/dac/dac_mcux_dac12.c
+++ b/drivers/dac/dac_mcux_dac12.c
@@ -84,7 +84,7 @@ static int mcux_dac12_write_value(const struct device *dev, uint8_t channel, uin
 	return 0;
 }
 
-static const struct dac_driver_api mcux_dac12_driver_api = {
+static DEVICE_API(dac, mcux_dac12_driver_api) = {
 	.channel_setup = mcux_dac12_channel_setup,
 	.write_value = mcux_dac12_write_value,
 };

--- a/drivers/gpio/gpio_mspm0.c
+++ b/drivers/gpio/gpio_mspm0.c
@@ -277,7 +277,7 @@ static int gpio_mspm0_init(const struct device *dev)
 	return 0;
 }
 
-static const struct gpio_driver_api gpio_mspm0_driver_api = {
+static DEVICE_API(gpio, gpio_mspm0_driver_api) = {
 	.pin_configure = gpio_mspm0_pin_configure,
 	.port_get_raw = gpio_mspm0_port_get_raw,
 	.port_set_masked_raw = gpio_mspm0_port_set_masked_raw,

--- a/drivers/pwm/pwm_wch_gptm.c
+++ b/drivers/pwm/pwm_wch_gptm.c
@@ -131,7 +131,7 @@ static int pwm_wch_gptm_get_cycles_per_sec(const struct device *dev, uint32_t ch
 	return 0;
 }
 
-static const struct pwm_driver_api pwm_wch_gptm_driver_api = {
+static DEVICE_API(pwm, pwm_wch_gptm_driver_api) = {
 	.set_cycles = pwm_wch_gptm_set_cycles,
 	.get_cycles_per_sec = pwm_wch_gptm_get_cycles_per_sec,
 };

--- a/drivers/sdhc/xlnx_sdhc.c
+++ b/drivers/sdhc/xlnx_sdhc.c
@@ -1294,7 +1294,7 @@ static int xlnx_sdhc_init(const struct device *dev)
 	return xlnx_sdhc_host_reset(dev);
 }
 
-static const struct sdhc_driver_api xlnx_sdhc_api = {
+static DEVICE_API(sdhc, xlnx_sdhc_api) = {
 	.reset = xlnx_sdhc_host_reset,
 	.request = xlnx_sdhc_request,
 	.set_io = xlnx_sdhc_set_io,

--- a/drivers/serial/uart_aesc.c
+++ b/drivers/serial/uart_aesc.c
@@ -98,7 +98,7 @@ static int uart_aesc_init(const struct device *dev)
 	return 0;
 }
 
-static const struct uart_driver_api uart_aesc_driver_api = {
+static DEVICE_API(uart, uart_aesc_driver_api) = {
 	.poll_in          = uart_aesc_poll_in,
 	.poll_out         = uart_aesc_poll_out,
 	.err_check        = NULL,

--- a/drivers/serial/uart_bflb.c
+++ b/drivers/serial/uart_bflb.c
@@ -275,7 +275,7 @@ static int uart_bflb_pm_control(const struct device *dev,
 }
 #endif /* CONFIG_PM_DEVICE */
 
-static const struct uart_driver_api uart_bflb_driver_api = {
+static DEVICE_API(uart, uart_bflb_driver_api) = {
 	.poll_in = uart_bflb_poll_in,
 	.poll_out = uart_bflb_poll_out,
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_mspm0.c
+++ b/drivers/serial/uart_mspm0.c
@@ -95,7 +95,7 @@ static void uart_mspm0_poll_out(const struct device *dev, unsigned char c)
 	DL_UART_Main_transmitDataBlocking(config->regs, c);
 }
 
-static const struct uart_driver_api uart_mspm0_driver_api = {
+static DEVICE_API(uart, uart_mspm0_driver_api) = {
 	.poll_in = uart_mspm0_poll_in,
 	.poll_out = uart_mspm0_poll_out,
 };

--- a/drivers/serial/uart_renesas_rx_sci_qemu.c
+++ b/drivers/serial/uart_renesas_rx_sci_qemu.c
@@ -97,7 +97,7 @@ static void uart_renesas_rx_sci_qemu_poll_out(const struct device *dev, unsigned
 	uart_renesas_rx_qemu_write_8(dev, TDR, c);
 }
 
-static const struct uart_driver_api uart_rx_driver_api = {
+static DEVICE_API(uart, uart_rx_driver_api) = {
 	.poll_in = uart_renesas_rx_sci_qemu_poll_in,
 	.poll_out = uart_renesas_rx_sci_qemu_poll_out,
 };

--- a/drivers/video/ov9655.c
+++ b/drivers/video/ov9655.c
@@ -414,7 +414,7 @@ static int ov9655_enum_frmival(const struct device *dev, struct video_frmival_en
 	return 0;
 }
 
-static const struct video_driver_api ov9655_api = {
+static DEVICE_API(video, ov9655_api) = {
 	.set_format = ov9655_set_fmt,
 	.get_format = ov9655_get_fmt,
 	.get_caps = ov9655_get_caps,

--- a/drivers/virtio/virtio_mmio.c
+++ b/drivers/virtio/virtio_mmio.c
@@ -260,7 +260,7 @@ static void virtio_mmio_finalize_init(const struct device *dev)
 	virtio_mmio_write_status_bit(dev, DEVICE_STATUS_DRIVER_OK);
 }
 
-static const struct virtio_driver_api virtio_mmio_driver_api = {
+static DEVICE_API(virtio, virtio_mmio_driver_api) = {
 	.get_virtqueue = virtio_mmio_get_virtqueue,
 	.notify_virtqueue = virtio_mmio_notify_queue,
 	.get_device_specific_config = virtio_mmio_get_device_specific_config,

--- a/drivers/virtio/virtio_pci.c
+++ b/drivers/virtio/virtio_pci.c
@@ -568,7 +568,7 @@ int virtio_pci_commit_feature_bits(const struct device *dev)
 	return 0;
 }
 
-static const struct virtio_driver_api virtio_pci_driver_api = {
+static DEVICE_API(virtio, virtio_pci_driver_api) = {
 	.get_virtqueue = virtio_pci_get_virtqueue,
 	.notify_virtqueue = virtio_pci_notify_queue,
 	.get_device_specific_config = virtio_pci_get_device_specific_config,

--- a/drivers/watchdog/wdt_iwdg_wch.c
+++ b/drivers/watchdog/wdt_iwdg_wch.c
@@ -77,7 +77,7 @@ static int iwdg_wch_feed(const struct device *dev, int channel_id)
 	return 0;
 }
 
-static const struct wdt_driver_api iwdg_wch_api = {
+static DEVICE_API(wdt, iwdg_wch_api) = {
 	.setup = iwdg_wch_setup,
 	.disable = iwdg_wch_disable,
 	.install_timeout = iwdg_wch_install_timeout,


### PR DESCRIPTION
Another round for the 4.2 release.

Use DEVICE_API macro to place driver API instances into a linker section.