### PR TITLE
Fix DPP soft AP security mode show issue

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -113,6 +113,8 @@ enum wifi_security_type {
 	WIFI_SECURITY_TYPE_FT_EAP_SHA384,
 	/** SAE Extended key (uses group-dependent hashing) */
 	WIFI_SECURITY_TYPE_SAE_EXT_KEY,
+	/** DPP WPA-PSK security */
+	WIFI_SECURITY_TYPE_DPP_WPA_PSK,
 
 	/** @cond INTERNAL_HIDDEN */
 	__WIFI_SECURITY_TYPE_AFTER_LAST,

--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -421,6 +421,8 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 		return WIFI_SECURITY_TYPE_FT_EAP_SHA384;
 	case WPA_KEY_MGMT_SAE_EXT_KEY:
 		return WIFI_SECURITY_TYPE_SAE_EXT_KEY;
+	case WPA_KEY_MGMT_DPP | WPA_KEY_MGMT_PSK:
+		return WIFI_SECURITY_TYPE_DPP_WPA_PSK;
 	default:
 		return WIFI_SECURITY_TYPE_UNKNOWN;
 	}

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -93,6 +93,8 @@ const char *wifi_security_txt(enum wifi_security_type security)
 		return "FT-EAP-SHA384";
 	case WIFI_SECURITY_TYPE_SAE_EXT_KEY:
 		return "WPA3-SAE-EXT-KEY";
+	case WIFI_SECURITY_TYPE_DPP_WPA_PSK:
+		return "DPP (WPA2-PSK)";
 	case WIFI_SECURITY_TYPE_UNKNOWN:
 	default:
 		return "UNKNOWN";


### PR DESCRIPTION
[Description]
After starting a DPP soft ap, enter 'wifi ap status'.
Security is shown as 'UNKNOW'.

[Root Cause]
1, Start a DPP soft ap:
wifi ap enable -s xxx -c x -p xxx -k 11
The parameter '-k 11' corresponds to zephyr security mode 'WIFI_SECURITY_TYPE_DPP'.
2. hapd_config_network() will be called to config a new hostap bss.
3. Filed 'bss->wpa' is set to 2.
Filed 'bss->wpa_key_mgmt' is set to WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_DPP.
4. When try to get security mode of DPP soft ap, there is no corresponding zephyr security mode.

[Analysis]
1. Analyze beacon frame of the DPP soft ap, AKM Suite is PSK and AKM type is 2.
2. DPP IE also can be found from beacon frame. 
3. DUT can connect this AP by entering password directly, also can connect to it through DPP.
4. Should show both DPP and IEEE 802.11 security to inform user can connect this AP in different ways.

[Fix]
1. New add zephyr security mode 'WIFI_SECURITY_TYPE_DPP_WPA_PSK' to show both DPP and IEEE 802.11 security mode.
2. Add enhance code to convert this DPP soft ap security type to zephyr security type.
