### PR TITLE
tests: arm_sw_vector_relay: Take into account CONFIG_SRAM_VECTOR_TABLE

### DIFF
--- a/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
+++ b/tests/arch/arm/arm_sw_vector_relay/src/arm_sw_vector_relay.c
@@ -57,7 +57,11 @@ ZTEST(arm_sw_vector_relay, test_arm_sw_vector_relay)
 	/* Verify that the VTOR points to the real vector table,
 	 * NOT the table that contains the forwarding function.
 	 */
+#ifdef CONFIG_SRAM_VECTOR_TABLE
+	zassert_true(SCB->VTOR == (uint32_t)&_sram_vector_start,
+#else
 	zassert_true(SCB->VTOR == (uint32_t)_vector_start,
+#endif
 		     "VTOR not pointing to the real vector table\n");
 #else
 	/* If VTOR is not present then we already need to forward interrupts

--- a/tests/arch/arm/arm_sw_vector_relay/testcase.yaml
+++ b/tests/arch/arm/arm_sw_vector_relay/testcase.yaml
@@ -6,3 +6,12 @@ tests:
     arch_allow: arm
     integration_platforms:
       - mps2/an385
+  arch.arm.sw_vector_relay.sram_vector_table:
+    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    tags:
+      - vector_relay
+    arch_allow: arm
+    integration_platforms:
+      - mps2/an385
+    extra_configs:
+      - CONFIG_SRAM_VECTOR_TABLE=y


### PR DESCRIPTION
Test arm_sw_vector_relay started to fail on our internal CI when we selected CONFIG_SRAM_VECTOR_TABLE as a default option for our (unreleased yet) SoC.

Test needs to take into account vector table RAM relocation.
New test case was added and tested on `qemu_cortex_m3` platform.