### PR TITLE
Fix/dtc-version-regex-generic

### DIFF
--- a/cmake/host-tools.cmake
+++ b/cmake/host-tools.cmake
@@ -22,7 +22,7 @@ if(DTC)
     )
 
   if(${dtc_status} EQUAL 0)
-    string(REGEX MATCH "Version: DTC ([0-9]+[.][0-9]+[.][0-9]+).*" out_var ${dtc_version_output})
+    string(REGEX MATCH "Version: DTC v?([0-9]+[.][0-9]+[.][0-9]+).*" out_var ${dtc_version_output})
 
     # Since it is optional, an outdated version is not an error. If an
     # outdated version is discovered, print a warning and proceed as if


### PR DESCRIPTION
cmake: Make DTC version regex more generic for version parsing.

Update the regex used to parse the DTC version in host-tools.cmake to handle version string formats. This increases compatibility with latest and older Zephyr toolchains.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92298

Signed-off-by: Suraj Patil <surajpatil3715@gmail.com>