### PR TITLE
dtlib: use filename and line number on all messages

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/dtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/dtlib.py
@@ -247,7 +247,7 @@ class Node:
         Returns some information about the Node instance. Called automatically
         if the Node instance is evaluated.
         """
-        return f"<Node {self.path} in '{self.dt.filename}'>"
+        return f"<Node {self.path} in {self.filename}:{self.lineno}>"
 
 # See Property.type
 class Type(enum.IntEnum):
@@ -437,7 +437,7 @@ class Property:
         """
         if self.type is not Type.NUM:
             _err(f"expected property '{self.name}' on {self.node.path} in "
-                 f"{self.node.dt.filename} to be assigned with "
+                 f"{self.filename}:{self.lineno} to be assigned with "
                  f"'{self.name} = < (number) >;', not '{self}'")
 
         return int.from_bytes(self.value, "big", signed=signed)
@@ -457,7 +457,7 @@ class Property:
         """
         if self.type not in (Type.NUM, Type.NUMS):
             _err(f"expected property '{self.name}' on {self.node.path} in "
-                 f"{self.node.dt.filename} to be assigned with "
+                 f"{self.filename}:{self.lineno} to be assigned with "
                  f"'{self.name} = < (number) (number) ... >;', not '{self}'")
 
         return [int.from_bytes(self.value[i:i + 4], "big", signed=signed)
@@ -475,7 +475,7 @@ class Property:
         """
         if self.type is not Type.BYTES:
             _err(f"expected property '{self.name}' on {self.node.path} "
-                 f"in {self.node.dt.filename} to be assigned with "
+                 f"in {self.filename}:{self.lineno} to be assigned with "
                  f"'{self.name} = [ (byte) (byte) ... ];', not '{self}'")
 
         return self.value
@@ -494,14 +494,14 @@ class Property:
         """
         if self.type is not Type.STRING:
             _err(f"expected property '{self.name}' on {self.node.path} "
-                 f"in {self.node.dt.filename} to be assigned with "
+                 f"in {self.filename}:{self.lineno} to be assigned with "
                  f"'{self.name} = \"string\";', not '{self}'")
 
         try:
             ret = self.value.decode("utf-8")[:-1]  # Strip null
         except UnicodeDecodeError:
             _err(f"value of property '{self.name}' ({self.value!r}) "
-                 f"on {self.node.path} in {self.node.dt.filename} "
+                 f"on {self.node.path} in {self.filename}:{self.lineno} "
                  "is not valid UTF-8")
 
         return ret  # The separate 'return' appeases the type checker.
@@ -519,14 +519,14 @@ class Property:
         """
         if self.type not in (Type.STRING, Type.STRINGS):
             _err(f"expected property '{self.name}' on {self.node.path} in "
-                 f"{self.node.dt.filename} to be assigned with "
+                 f"{self.filename}:{self.lineno} to be assigned with "
                  f"'{self.name} = \"string\", \"string\", ... ;', not '{self}'")
 
         try:
             ret = self.value.decode("utf-8").split("\0")[:-1]
         except UnicodeDecodeError:
             _err(f"value of property '{self.name}' ({self.value!r}) "
-                 f"on {self.node.path} in {self.node.dt.filename} "
+                 f"on {self.node.path} in {self.filename}:{self.lineno} "
                  "is not valid UTF-8")
 
         return ret  # The separate 'return' appeases the type checker.
@@ -542,7 +542,7 @@ class Property:
         """
         if self.type is not Type.PHANDLE:
             _err(f"expected property '{self.name}' on {self.node.path} in "
-                 f"{self.node.dt.filename} to be assigned with "
+                 f"{self.filename}:{self.lineno} to be assigned with "
                  f"'{self.name} = < &foo >;', not '{self}'")
 
         return self.node.dt.phandle2node[int.from_bytes(self.value, "big")]
@@ -567,7 +567,7 @@ class Property:
 
         if not type_ok():
             _err(f"expected property '{self.name}' on {self.node.path} in "
-                 f"{self.node.dt.filename} to be assigned with "
+                 f"{self.filename}:{self.lineno} to be assigned with "
                  f"'{self.name} = < &foo &bar ... >;', not '{self}'")
 
         return [self.node.dt.phandle2node[int.from_bytes(self.value[i:i + 4],
@@ -588,7 +588,7 @@ class Property:
         """
         if self.type not in (Type.PATH, Type.STRING):
             _err(f"expected property '{self.name}' on {self.node.path} in "
-                 f"{self.node.dt.filename} to be assigned with either "
+                 f"{self.filename}:{self.lineno} to be assigned with either "
                  f"'{self.name} = &foo' or '{self.name} = \"/path/to/node\"', "
                  f"not '{self}'")
 
@@ -596,15 +596,15 @@ class Property:
             path = self.value.decode("utf-8")[:-1]
         except UnicodeDecodeError:
             _err(f"value of property '{self.name}' ({self.value!r}) "
-                 f"on {self.node.path} in {self.node.dt.filename} "
+                 f"on {self.node.path} in {self.filename}:{self.lineno} "
                  "is not valid UTF-8")
 
         try:
             ret = self.node.dt.get_node(path)
         except DTError:
             _err(f"property '{self.name}' on {self.node.path} in "
-                 f"{self.node.dt.filename} points to the non-existent node "
-                 f'"{path}"')
+                 f"{self.filename}:{self.lineno} points to the non-existent "
+                 f'node "{path}"')
 
         return ret  # The separate 'return' appeases the type checker.
 
@@ -678,8 +678,8 @@ class Property:
         return s + ";"
 
     def __repr__(self):
-        return (f"<Property '{self.name}' at '{self.node.path}' in "
-                f"'{self.node.dt.filename}'>")
+        return (f"<Property '{self.name}' on {self.node.path} in "
+                f"{self.filename}:{self.lineno}>")
 
     #
     # Internal functions

--- a/scripts/dts/python-devicetree/tests/test_dtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_dtlib.py
@@ -2166,9 +2166,9 @@ def test_reprs():
 
     assert re.fullmatch(r"DT\(filename='.*', include_path=.'foo', 'bar'.\)",
                         repr(dt))
-    assert re.fullmatch("<Property 'x' at '/' in '.*'>",
+    assert re.fullmatch("<Property 'x' on / in .*:5>",
                         repr(dt.root.props["x"]))
-    assert re.fullmatch("<Node /sub in '.*'>",
+    assert re.fullmatch("<Node /sub in .*:6>",
                         repr(dt.root.nodes["sub"]))
 
     dt = parse(dts, include_path=iter(("foo", "bar")))

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -826,7 +826,7 @@ def test_slice_errs(tmp_path):
 };
 """,
                  dts_file,
-                 f"'reg' property in <Node /sub in '{dts_file}'> has length 4, which is not evenly divisible by 12 (= 4*(<#address-cells> (= 1) + <#size-cells> (= 2))). Note that #*-cells properties come either from the parent node or from the controller (in the case of 'interrupts').")
+                 f"'reg' property in <Node /sub in {dts_file}:8> has length 4, which is not evenly divisible by 12 (= 4*(<#address-cells> (= 1) + <#size-cells> (= 2))). Note that #*-cells properties come either from the parent node or from the controller (in the case of 'interrupts').")
 
     verify_error("""
 /dts-v1/;
@@ -843,7 +843,7 @@ def test_slice_errs(tmp_path):
 };
 """,
                  dts_file,
-                 f"'interrupts' property in <Node /sub in '{dts_file}'> has length 4, which is not evenly divisible by 8 (= 4*<#interrupt-cells>). Note that #*-cells properties come either from the parent node or from the controller (in the case of 'interrupts').")
+                 f"'interrupts' property in <Node /sub in {dts_file}:5> has length 4, which is not evenly divisible by 8 (= 4*<#interrupt-cells>). Note that #*-cells properties come either from the parent node or from the controller (in the case of 'interrupts').")
 
     verify_error("""
 /dts-v1/;
@@ -863,7 +863,7 @@ def test_slice_errs(tmp_path):
 };
 """,
                  dts_file,
-                 f"'ranges' property in <Node /sub-1 in '{dts_file}'> has length 8, which is not evenly divisible by 24 (= 4*(<#address-cells> (= 2) + <#address-cells for parent> (= 1) + <#size-cells> (= 3))). Note that #*-cells properties come either from the parent node or from the controller (in the case of 'interrupts').")
+                 f"'ranges' property in <Node /sub-1 in {dts_file}:7> has length 8, which is not evenly divisible by 24 (= 4*(<#address-cells> (= 2) + <#address-cells for parent> (= 1) + <#size-cells> (= 3))). Note that #*-cells properties come either from the parent node or from the controller (in the case of 'interrupts').")
 
 def test_bad_compatible(tmp_path):
     # An invalid compatible should cause an error, even on a node with


### PR DESCRIPTION
Take advantage of the new 'filename' and 'lineno' attributes of `Node` and `Property` objects to provide more informative error and status messages than a `zephyr/misc/empty_file.c` reference.

For example the error:

```
devicetree error: 'remote-endpoint-label' is marked as required in 'properties:' 
in .../zephyr/dts/bindings/video/galaxycore,gc2145.yaml, but does not appear 
in <Node /soc/i2c@58001c00/gc2145@3c/port/endpoint in '.../zephyr/misc/empty_file.c'>
```

is modified with this change to:

```
devicetree error: 'remote-endpoint-label' is marked as required in 'properties:' 
in .../zephyr/dts/bindings/video/galaxycore,gc2145.yaml, but does not appear 
in <Node /soc/i2c@58001c00/gc2145@3c/port/endpoint in .../arduino_giga_r1_stm32h747xx_m7.overlay:39>
```

As this applies to the above objects' representation, this information is available on all messages where a `<Node ...>` or `<Property ...>` reference is present. 

(paths shortened and message wrapped for readability)