### PR TITLE
tests: Bluetooth: BR: Add test suite RFCOMM_client

### DIFF
--- a/tests/bluetooth/classic/rfcomm_c/pytest/rfcomm_utility.py
+++ b/tests/bluetooth/classic/rfcomm_c/pytest/rfcomm_utility.py
@@ -22,7 +22,7 @@ from bumble.rfcomm import (
 )
 
 mcc_test_data = bytes.fromhex('01 02 03 04 05')
-send_value = bytes.fromhex('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+send_value = bytes([0xFF])
 
 
 class LogCaptureHandler(logging.Handler):

--- a/tests/bluetooth/classic/rfcomm_c/testcase.yaml
+++ b/tests/bluetooth/classic/rfcomm_c/testcase.yaml
@@ -11,7 +11,7 @@ tests:
     harness_config:
       pytest_dut_scope: session
       fixture: usb_hci
-    timeout: 700
+    timeout: 800
   bluetooth.classic.rfcomm.client.no_blobs:
     platform_allow:
     - mimxrt1170_evk@B/mimxrt1176/cm7
@@ -20,5 +20,5 @@ tests:
     - rfcomm
     extra_args:
     - CONFIG_BUILD_ONLY_NO_BLOBS=y
-    timeout: 700
+    timeout: 800
     build_only: true


### PR DESCRIPTION
IUT works as an RFCOMM Client. The peer device, RFCOMM server, is a PC running bumble.

Add following test cases:

Case 6, RFCOMM MTU Size Data Send/Receive Test. To verify that the RFCOMM client can correctly send and receive data packets that are exactly equal to the negotiated MTU size.

Case 7, RFCOMM Data Transfer Exceeding MTU Size Test. To verify that the RFCOMM client can reject sending and receiving data packets that exceed the negotiated MTU size.

Case 8, RFCOMM Disconnect and Reconnect Test. To verify that the RFCOMM client can properly handle a normal RFCOMM disconnection and successfully reestablish the connection.

Case 9, RFCOMM Recovery After ACL Disconnection Test. To verify that the RFCOMM client can properly recover when the underlying ACL connection is abruptly disconnected, by reestablishing both ACL and RFCOMM connections.