### PR TITLE
stm32: boards: st: stm32n6570_dk: exclude stm32n6_fsbl variant from twister ci

### DIFF
--- a/boards/st/stm32n6570_dk/twister.yaml
+++ b/boards/st/stm32n6570_dk/twister.yaml
@@ -21,6 +21,8 @@ supported:
 variants:
   stm32n6570_dk/stm32n657xx:
     twister: false
+  stm32n6570_dk/stm32n657xx/fsbl:
+    twister: false
   stm32n6570_dk/stm32n657xx/sb:
     toolchain:
       - zephyr


### PR DESCRIPTION
Make the stm32n6_dk variant (stm32n6570_dk/stm32n657xx/fsbl) unable to execute tests in CI with Twister.

This change will help avoid many CI build failures caused by this variant.