### PR TITLE
modules: hostap: Fix DPP soft AP security type show issue.

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -421,6 +421,8 @@ enum wifi_security_type wpas_key_mgmt_to_zephyr(bool is_hapd, void *config, int 
 		return WIFI_SECURITY_TYPE_FT_EAP_SHA384;
 	case WPA_KEY_MGMT_SAE_EXT_KEY:
 		return WIFI_SECURITY_TYPE_SAE_EXT_KEY;
+	case WPA_KEY_MGMT_DPP | WPA_KEY_MGMT_PSK:
+		return WIFI_SECURITY_TYPE_DPP;
 	default:
 		return WIFI_SECURITY_TYPE_UNKNOWN;
 	}


### PR DESCRIPTION
[Description]
After starting a DPP soft ap, enter 'wifi ap status'. Security is shown as 'UNKNOW'.

[Root Cause]
1. Start a DPP soft ap: wifi ap enable -s xxx -c x -p xxx -k 11 The parameter '-k 11' corresponds to zephyr security type 'WIFI_SECURITY_TYPE_DPP'.
2. hapd_config_network() will be called to config a new hostap bss.
3. Filed 'bss->wpa_key_mgmt' is set to WPA_KEY_MGMT_PSK | WPA_KEY_MGMT_DPP.
4. When try to get security type of DPP soft ap, there is no corresponding zephyr security type.

[Fix]
Add enhance code to convert the security type
to zephyr DPP security type.