### PR TITLE
tests: net: ppp: Compile test with PPP statistics

### DIFF
--- a/tests/net/ppp/driver/testcase.yaml
+++ b/tests/net/ppp/driver/testcase.yaml
@@ -6,3 +6,8 @@ common:
 tests:
   net.ppp:
     min_ram: 21
+  net.ppp.statistics:
+    extra_args:
+      - CONFIG_NET_STATISTICS=y
+      - CONFIG_NET_STATISTICS_PPP=y
+      - CONFIG_NET_STATISTICS_USER_API=y


### PR DESCRIPTION
Make sure the compilation is ok if PPP statistics is enabled.

This is related to commit 3e704256e308
("net: ppp: stats: Fix net_mgmt request handler format") which was needed because earlier commit 5a9a39caf3bf
("net: mgmt: Convert the mgmt API to use 64-bit masks") missed an compile problem because there was no compile test that enabled CONFIG_NET_STATISTICS_PPP option.