### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -325,7 +325,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 968d55ff22579080466bf2f482596dd6e35361c6
+      revision: 6e5961223f81aa2707c555db138819a5c1b7942c
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 7cb2f44f46dfc86e4f97477ee90022944e138dd8


### PR DESCRIPTION
Update the HW models module to:
6e5961223f81aa2707c555db138819a5c1b7942c

Including the following:
6e59612 CLOCK (52,53): Fix test interface with multiple instances 
ecf2292 54 CRACEN: Improve model
1277b16 irq controller: Remove out of date comment