### PR TITLE
tests: kernel: interrupt: generic ISR offset definition for nrf54h20 …

### DIFF
--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -66,7 +66,7 @@
 
 #define IRQ0_PRIO	1
 #define IRQ1_PRIO	2
-#elif defined(CONFIG_SOC_NRF54H20_CPUPPR)
+#elif defined(CONFIG_SOC_SERIES_NRF54HX) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
 #define IRQ0_LINE	14
 #define IRQ1_LINE	15
 


### PR DESCRIPTION
…VPRs

All VPRs in nrf54h20 can have same ISR offset configuration.