### PR TITLE
samples: i2s echo: guard audio_codec configuration

### DIFF
--- a/samples/drivers/i2s/echo/src/main.c
+++ b/samples/drivers/i2s/echo/src/main.c
@@ -258,7 +258,7 @@ int main(void)
 		return 0;
 	}
 
-#else
+#elif DT_NODE_HAS_STATUS(DT_NODELABEL(audio_codec), okay)
 	const struct device *const codec_dev = DEVICE_DT_GET(DT_NODELABEL(audio_codec));
 	struct audio_codec_cfg audio_cfg;
 
@@ -273,7 +273,6 @@ int main(void)
 	audio_cfg.dai_cfg.i2s.block_size = BLOCK_SIZE;
 	audio_codec_configure(codec_dev, &audio_cfg);
 	k_msleep(1000);
-
 #endif
 
 	if (!init_buttons()) {


### PR DESCRIPTION
Ensure the I2S echo sample only configures the audio_codec driver when the `audio_codec` node is defined and enabled in the devicetree.

Fixes a possible regression caused by #90031.