### PR TITLE
drivers: reset: rpi_pico: wait for reset deassertion

### DIFF
--- a/drivers/reset/reset_rpi_pico.c
+++ b/drivers/reset/reset_rpi_pico.c
@@ -1,122 +1,36 @@
 /*
  * Copyright (c) 2022 Andrei-Edward Popa
+ * Copyright (c) 2025 Dmitrii Sharshakov <d3dx12.xx@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #define DT_DRV_COMPAT raspberrypi_pico_reset
 
-#include <limits.h>
-
-#include <zephyr/arch/cpu.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/reset.h>
 
-struct reset_rpi_config {
-	DEVICE_MMIO_ROM;
-	uint8_t reg_width;
-	uint8_t active_low;
-	uintptr_t base_address;
-};
-
-static int reset_rpi_read_register(const struct device *dev, uint16_t offset, uint32_t *value)
-{
-	const struct reset_rpi_config *config = dev->config;
-	uint32_t base_address = config->base_address;
-
-	switch (config->reg_width) {
-	case 1:
-		*value = sys_read8(base_address + offset);
-		break;
-	case 2:
-		*value = sys_read16(base_address + offset);
-		break;
-	case 4:
-		*value = sys_read32(base_address + offset);
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-static int reset_rpi_write_register(const struct device *dev, uint16_t offset, uint32_t value)
-{
-	const struct reset_rpi_config *config = dev->config;
-	uint32_t base_address = config->base_address;
-
-	switch (config->reg_width) {
-	case 1:
-		sys_write8(value, base_address + offset);
-		break;
-	case 2:
-		sys_write16(value, base_address + offset);
-		break;
-	case 4:
-		sys_write32(value, base_address + offset);
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	return 0;
-}
+#include <hardware/resets.h>
 
 static int reset_rpi_status(const struct device *dev, uint32_t id, uint8_t *status)
 {
-	const struct reset_rpi_config *config = dev->config;
-	uint16_t offset;
-	uint32_t value;
-	uint8_t regbit;
-	int ret;
+	*status = !!(resets_hw->reset & (1u << id));
 
-	offset = id / (config->reg_width * CHAR_BIT);
-	regbit = id % (config->reg_width * CHAR_BIT);
-
-	ret = reset_rpi_read_register(dev, offset, &value);
-	if (ret) {
-		return ret;
-	}
-
-	*status = !(value & BIT(regbit)) ^ !config->active_low;
-
-	return ret;
-}
-
-static int reset_rpi_update(const struct device *dev, uint32_t id, uint8_t assert)
-{
-	const struct reset_rpi_config *config = dev->config;
-	uint16_t offset;
-	uint32_t value;
-	uint8_t regbit;
-	int ret;
-
-	offset = id / (config->reg_width * CHAR_BIT);
-	regbit = id % (config->reg_width * CHAR_BIT);
-
-	ret = reset_rpi_read_register(dev, offset, &value);
-	if (ret) {
-		return ret;
-	}
-
-	if (assert ^ config->active_low) {
-		value |= BIT(regbit);
-	} else {
-		value &= ~BIT(regbit);
-	}
-
-	return reset_rpi_write_register(dev, offset, value);
+	return 0;
 }
 
 static int reset_rpi_line_assert(const struct device *dev, uint32_t id)
 {
-	return reset_rpi_update(dev, id, 1);
+	reset_block_num(id);
+
+	return 0;
 }
 
 static int reset_rpi_line_deassert(const struct device *dev, uint32_t id)
 {
-	return reset_rpi_update(dev, id, 0);
+	unreset_block_num_wait_blocking(id);
+
+	return 0;
 }
 
 static int reset_rpi_line_toggle(const struct device *dev, uint32_t id)
@@ -131,13 +45,6 @@ static int reset_rpi_line_toggle(const struct device *dev, uint32_t id)
 	return reset_rpi_line_deassert(dev, id);
 }
 
-static int reset_rpi_init(const struct device *dev)
-{
-	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);
-
-	return 0;
-}
-
 static DEVICE_API(reset, reset_rpi_driver_api) = {
 	.status = reset_rpi_status,
 	.line_assert = reset_rpi_line_assert,
@@ -146,16 +53,10 @@ static DEVICE_API(reset, reset_rpi_driver_api) = {
 };
 
 #define RPI_RESET_INIT(idx)							\
-	static const struct reset_rpi_config reset_rpi_config_##idx = {		\
-		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(idx)),				\
-		.reg_width = DT_INST_PROP_OR(idx, reg_width, 4),		\
-		.active_low = DT_INST_PROP_OR(idx, active_low, 0),		\
-		.base_address = DT_INST_REG_ADDR(idx),				\
-	};									\
 										\
-	DEVICE_DT_INST_DEFINE(idx, reset_rpi_init,				\
+	DEVICE_DT_INST_DEFINE(idx, NULL,				\
 			      NULL, NULL,					\
-			      &reset_rpi_config_##idx, PRE_KERNEL_1,		\
+			      NULL, PRE_KERNEL_1,		\
 			      CONFIG_RESET_INIT_PRIORITY,			\
 			      &reset_rpi_driver_api);
 

--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -211,8 +211,6 @@
 		reset: reset-controller@4000c000 {
 			compatible = "raspberrypi,pico-reset";
 			reg = <0x4000c000 DT_SIZE_K(4)>;
-			reg-width = <4>;
-			active-low = <0>;
 			#reset-cells = <1>;
 		};
 

--- a/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
@@ -207,8 +207,6 @@
 		reset: reset-controller@40020000 {
 			compatible = "raspberrypi,pico-reset";
 			reg = <0x40020000 DT_SIZE_K(4)>;
-			reg-width = <4>;
-			active-low = <0>;
 			#reset-cells = <1>;
 		};
 

--- a/dts/bindings/reset/raspberrypi,pico-reset.yaml
+++ b/dts/bindings/reset/raspberrypi,pico-reset.yaml
@@ -10,12 +10,7 @@ include: [base.yaml, reset-controller.yaml]
 properties:
   reg:
     required: true
-  reg-width:
-    type: int
-    description: The width of the reset registers in bytes. Default is 4 bytes.
-  active-low:
-    type: int
-    description: Set if reset is active low. Default is 0, which means active-high.
+
   "#reset-cells":
     const: 1
 


### PR DESCRIPTION
Failing to do so can lead to e.g. PIO not being ready by the time
a driver tries to use it.

pico-sdk also does block on this register in
its reset deassertion routines.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
