### PR TITLE
cmake: clang: Enable -Waddress-of-packed-member

### DIFF
--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -103,7 +103,6 @@ check_set_compiler_property(APPEND PROPERTY warning_dw_3
 check_set_compiler_property(PROPERTY warning_extended
                             #FIXME: need to fix all of those
                             -Wno-self-assign
-                            -Wno-address-of-packed-member
                             -Wno-initializer-overrides
                             -Wno-section
                             -Wno-gnu


### PR DESCRIPTION
Several years ago we started enabling the -Waddress-of-packed-member warning in commit cf111962e0d0c388bf806bbd9f17d49732daa264 for GCC.

Do the same for Clang, since there is no reason not to and the warning is very useful, especially in protocol stacks.