### PR TITLE
kconfig: series of fix typo

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -507,7 +507,7 @@ config SIZE_OPTIMIZATIONS
 config SIZE_OPTIMIZATIONS_AGGRESSIVE
 	bool "Aggressively optimize for size"
 	help
-	  Compiler optimizations wil be set to -Oz independently of other
+	  Compiler optimizations will be set to -Oz independently of other
 	  options.
 
 config SPEED_OPTIMIZATIONS

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -258,10 +258,10 @@ config ARC_CURRENT_THREAD_USE_NO_TLS
 	select CURRENT_THREAD_USE_NO_TLS
 	default y if (RGF_NUM_BANKS > 1) || ("$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt")
 	help
-	  Disable current Thread Local Storage for ARC. For cores with more then one
-	  RGF_NUM_BANKS the parameter is disabled by-default because banks syncronization
+	  Disable current Thread Local Storage for ARC. For cores with more than one
+	  RGF_NUM_BANKS the parameter is disabled by-default because banks synchronization
 	  requires significant time, and it slows down performance.
-	  ARCMWDT works with tls pointer in different way then GCC. Optimized access to
+	  ARCMWDT works with TLS pointer in different way then GCC. Optimized access to
 	  TLS pointer via the _current symbol does not provide significant advantages
 	  in case of MetaWare.
 
@@ -274,7 +274,7 @@ config GEN_IRQ_START_VECTOR
 config HARVARD
 	bool "Harvard Architecture"
 	help
-	  The ARC CPU can be configured to have two busses;
+	  The ARC CPU can be configured to have two buses;
 	  one for instruction fetching and another that serves as a data bus.
 
 config CODE_DENSITY

--- a/arch/arc/core/dsp/Kconfig
+++ b/arch/arc/core/dsp/Kconfig
@@ -39,7 +39,7 @@ config ARC_XY_ENABLE
 	bool "ARC address generation unit registers"
 	help
 	  Processors with XY memory and AGU registers can configure this
-	  option to accelerate DSP instrctions.
+	  option to accelerate DSP instructions.
 
 config ARC_AGU_SHARING
 	bool "ARC address generation unit register sharing"

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -49,7 +49,7 @@ config ROMSTART_RELOCATION_ROM
 
 	  Most SOCs include an alias for the boot-vector at address 0x00000000
 	  so a default which might be supported by the corresponding Linux rproc driver.
-	  If it is not, additionnal options allows to specify the addresses.
+	  If it is not, additional options allow to specify the addresses.
 
 	  In general this option should be chosen if the zephyr,flash chosen node
 	  is not placed into the boot-vector memory area.

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -273,7 +273,7 @@ config RISCV_RESERVED_IRQ_ISR_TABLES_OFFSET
 	default 0
 	depends on GEN_ISR_TABLES
 	help
-	  On some RISCV platform the first interrupt vectors are primarly
+	  On some RISCV platform the first interrupt vectors are primarily
 	  intended for inter-hart interrupt signaling and so retained for that
 	  purpose and not available. When this option is set, all the IRQ
 	  vectors are shifted by this offset value when installed into the

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -205,7 +205,7 @@ config XTENSA_MMU_NUM_L1_TABLES
 	default 1 if !USERSPACE
 	default 4
 	help
-	  This option specifies the maximum number of traslation tables.
+	  This option specifies the maximum number of translation tables.
 	  Translation tables are directly related to the number of
 	  memory domains in the target, considering the kernel itself requires one.
 

--- a/boards/qemu/cortex_m3/Kconfig.defconfig
+++ b/boards/qemu/cortex_m3/Kconfig.defconfig
@@ -13,7 +13,7 @@ choice NULL_POINTER_EXCEPTION_DETECTION
 endchoice
 
 # BT relies on PSA Crypto API to perform crypto operations and, on this platform,
-# these APIs are provided thougth Mbed TLS. Unfortunately this platform is not
+# these APIs are provided through Mbed TLS. Unfortunately, this platform is not
 # provided with a true random number generator which is required to properly
 # initialize the PSA Crypto core, so we need to enable the fake TEST_RANDOM_GENERATOR.
 config TEST_RANDOM_GENERATOR

--- a/boards/telink/tlsr9518adk80d/Kconfig.defconfig
+++ b/boards/telink/tlsr9518adk80d/Kconfig.defconfig
@@ -12,7 +12,7 @@ DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 config FLASH_LOAD_OFFSET
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
 
-# Buffer for image writter shall be less(multiple of access alignment) or
+# Buffer for image written shall be less(multiple of access alignment) or
 # equal to flash page. tlsr9518adk80d boards use external P25Q16 IC as
 # flesh memory. Flash page size of the IC is 256 bytes. So that, it is
 # maximum image writer buffer size for such kind of boards.

--- a/drivers/audio/Kconfig.dmic_ambiq_pdm
+++ b/drivers/audio/Kconfig.dmic_ambiq_pdm
@@ -24,6 +24,6 @@ config PDM_AMBIQ_BUFFER_ALIGNMENT
 	int "Set the PDM DMA TCB buffer alignment"
 	default DCACHE_LINE_SIZE if DCACHE
 	help
-	  PDM buffer should be 32bytes aligned when placed in cachable region.
+	  PDM buffer should be 32bytes aligned when placed in cacheable region.
 
 endif

--- a/drivers/auxdisplay/Kconfig
+++ b/drivers/auxdisplay/Kconfig
@@ -6,7 +6,7 @@
 menuconfig AUXDISPLAY
 	bool "Auxiliary (textual) Display Drivers"
 	help
-	  Enable auxiliary/texual display drivers (e.g. alphanumerical displays)
+	  Enable auxiliary/textual display drivers (e.g. alphanumerical displays)
 
 if AUXDISPLAY
 

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -371,7 +371,7 @@ config BT_H4_NXP_CTLR
 	depends on DT_HAS_NXP_BT_HCI_UART_ENABLED
 	help
 	  Enables support for NXP Bluetooth Controller.
-	  More inforamtion about NXP Bluetooth profuct could be found on
+	  More information about NXP Bluetooth products could be found on
 	  https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4:WIFI-BLUETOOTH
 
 if BT_H4_NXP_CTLR

--- a/drivers/clock_control/Kconfig.siwx91x
+++ b/drivers/clock_control/Kconfig.siwx91x
@@ -7,7 +7,7 @@ config CLOCK_CONTROL_SILABS_SIWX91X
 	depends on DT_HAS_SILABS_SIWX91X_CLOCK_ENABLED
 	help
 	 Enable clock management on Silicon Labs SiWx91x chips. This driver
-	 includes support for HP (High Performace), ULP (Ultra Low Power), and
+	 includes support for HP (High Performance), ULP (Ultra Low Power), and
 	 ULP VBAT clocks.
 
 	 The original hardware allow to customize the various clocks offered for

--- a/drivers/crypto/Kconfig.xec
+++ b/drivers/crypto/Kconfig.xec
@@ -7,6 +7,6 @@ config CRYPTO_MCHP_XEC_SYMCR
 	default y
 	depends on DT_HAS_MICROCHIP_XEC_SYMCR_ENABLED
 	help
-	  Enable Microchip XEC symmetic crypto (AES/Hash) driver.
+	  Enable Microchip XEC symmetric crypto (AES/Hash) driver.
 	  Symmetric crypto provides a single hardware interface
 	  to AES and hash engines.

--- a/drivers/dma/Kconfig.dw_common
+++ b/drivers/dma/Kconfig.dw_common
@@ -37,7 +37,7 @@ config DMA_DW_HOST_MASK
 	default 0
 	help
 	  Some instances of the DesignWare DMAC require a mask applied to source/destination
-	  addresses to signifiy the memory space the address is in.
+	  addresses to signify the memory space the address is in.
 
 config DMA_DW_CHANNEL_COUNT
 	int "dw max channel count"

--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -17,7 +17,7 @@ config DMA_STM32
 	  Driver for STM32 DMA V1, V2, V2bis and BDMA types.
 
 config DMA_STM32U5
-	bool "STM32U5 serie DMA driver"
+	bool "STM32U5 series DMA driver"
 	select USE_STM32_LL_DMA
 	default y
 	depends on DT_HAS_ST_STM32U5_DMA_ENABLED

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -68,7 +68,7 @@ config EEPROM_AT24
 	  - ST M24xxx
 
 config EEPROM_AT25
-	bool "SPI EEPROMs compatibile with Atmel's AT25 family"
+	bool "SPI EEPROMs compatible with Atmel's AT25 family"
 	default y
 	depends on DT_HAS_ATMEL_AT25_ENABLED
 	select SPI

--- a/drivers/entropy/Kconfig.npcx
+++ b/drivers/entropy/Kconfig.npcx
@@ -54,6 +54,6 @@ config ENTROPY_NPCX_DRBG_RESEED_INTERVAL
 	int "DRBG Reseed Interval"
 	default 100
 	help
-	   Number of gererations allowed until next reseeding.
+	   Number of generations allowed until next reseeding.
 
 endif

--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -61,7 +61,7 @@ config ENTROPY_STM32_CLK_CHECK
 	  configuration depends on STM32 series. Check reference manual if an
 	  error is reported.
 	  This check assumes CED (Clock Error Detected) bit is enabled (when
-	  available, CED is enabeld by default). Disable this check if CED is
+	  available, CED is enabled by default). Disable this check if CED is
 	  disabled.
 
 endif # ENTROPY_STM32_RNG

--- a/drivers/espi/Kconfig.it8xxx2
+++ b/drivers/espi/Kconfig.it8xxx2
@@ -132,7 +132,7 @@ config ESPI_IT8XXX2_PNPCFG_DEVICE_KBC_MOUSE
 # status bit to indicate which cycle triggered the interrupt and data registers
 # of these two ports are read only. Hence EC have to read these two data
 # registers at the same time in the ISR.
-# It means that the Host must alwasy write 2 bytes of data to port 80 otherwise
+# It means that the Host must always write 2 bytes of data to port 80 otherwise
 # port 81 data will not be updated.
 config ESPI_IT8XXX2_PORT_81_CYCLE
 	bool "EC accepts 0x81 I/O cycle from eSPI transaction"

--- a/drivers/firmware/nrf_ironside/Kconfig
+++ b/drivers/firmware/nrf_ironside/Kconfig
@@ -63,7 +63,7 @@ config NRF_IRONSIDE_DVFS_OPPOINT_CHANGE_MUTEX_TIMEOUT_MS
 	int "IRONSside DVFS change oppoint mutex timeout"
 	default 100
 	help
-	  Maximum tiemout when waiting for DVFS oppoint change mutex lock.
+	  Maximum timeout when waiting for DVFS oppoint change mutex lock.
 
 endif # NRF_IRONSIDE_DVFS_SERVICE
 

--- a/drivers/fuel_gauge/bq27z746/Kconfig
+++ b/drivers/fuel_gauge/bq27z746/Kconfig
@@ -12,7 +12,7 @@ config BQ27Z746
 	  Enable I2C-based driver for BQ27Z746 Fuel Gauge.
 
 config EMUL_BQ27Z746
-	bool "Emulate an BQ27Z746 fuel gague"
+	bool "Emulate a BQ27Z746 fuel gauge"
 	default y
 	depends on EMUL
 	depends on BQ27Z746

--- a/drivers/fuel_gauge/max17048/Kconfig
+++ b/drivers/fuel_gauge/max17048/Kconfig
@@ -13,7 +13,7 @@ config MAX17048
 	  Enable driver for the MAX17048 fuel gauge device.
 
 config EMUL_MAX17048
-	bool "Emulate an MAX17048 fuel gague"
+	bool "Emulate a MAX17048 fuel gauge"
 	default y
 	depends on EMUL
 	depends on MAX17048

--- a/drivers/gnss/Kconfig
+++ b/drivers/gnss/Kconfig
@@ -12,7 +12,7 @@ if GNSS
 config GNSS_SATELLITES
 	bool "GNSS satellites support"
 	help
-	  Enable GNSS sattelites callback.
+	  Enable GNSS satellites callback.
 
 config GNSS_DUMP
 	bool "GNSS dump support"

--- a/drivers/gpio/Kconfig.max14906
+++ b/drivers/gpio/Kconfig.max14906
@@ -9,7 +9,7 @@ menuconfig GPIO_MAX14906
 	default y
 	depends on DT_HAS_ADI_MAX14906_GPIO_ENABLED && SPI
 	help
-	  Enabe MAX14906 quad industrial digital
+	  Enable MAX14906 quad industrial digital
 	  input/output with diagnostics
 
 config GPIO_MAX14906_INIT_PRIORITY

--- a/drivers/gpio/Kconfig.max14916
+++ b/drivers/gpio/Kconfig.max14916
@@ -9,7 +9,7 @@ menuconfig GPIO_MAX14916
 	default y
 	depends on (DT_HAS_ADI_MAX14916_GPIO_ENABLED || DT_HAS_ADI_MAX14915_GPIO_ENABLED) && SPI
 	help
-	  Enabe MAX1416 octal industrial digital
+	  Enable MAX1416 octal industrial digital
 	  output with diagnostics
 
 config GPIO_MAX14916_INIT_PRIORITY

--- a/drivers/gpio/Kconfig.max2219x
+++ b/drivers/gpio/Kconfig.max2219x
@@ -10,7 +10,7 @@ menuconfig GPIO_MAX2219X
 	depends on SPI
 	depends on DT_HAS_ADI_MAX22190_GPIO_ENABLED || DT_HAS_ADI_MAX22199_GPIO_ENABLED
 	help
-	  Enabe MAX2219X Octal industrial digital
+	  Enable MAX2219X Octal industrial digital
 	  input with diagnostics
 
 config GPIO_MAX22190_INIT_PRIORITY

--- a/drivers/i2s/Kconfig.ambiq
+++ b/drivers/i2s/Kconfig.ambiq
@@ -24,7 +24,7 @@ config I2S_AMBIQ_BUFFER_ALIGNMENT
 	int "Set the I2S DMA TCB buffer alignment"
 	default DCACHE_LINE_SIZE if DCACHE
 	help
-	  I2S buffer should be 32bytes aligned when placed in cachable region.
+	  I2S buffer should be 32bytes aligned when placed in cacheable region.
 
 config I2S_AMBIQ_RX_BLOCK_COUNT
 	int "RX queue length"

--- a/drivers/i3c/Kconfig
+++ b/drivers/i3c/Kconfig
@@ -72,7 +72,7 @@ config I3C_IBI_MAX_PAYLOAD_SIZE
 	int "Maximum IBI Payload Size"
 	default 16
 	help
-	  Maxmium IBI payload size.
+	  Maximum IBI payload size.
 
 menuconfig I3C_IBI_WORKQUEUE
 	bool "Use IBI Workqueue"
@@ -144,7 +144,7 @@ config I3C_NUM_OF_DESC_MEM_SLABS
 	default 3
 	help
 	  This is the number of memory slabs allocated from when
-	  there is a device encounted through ENTDAA or DEFTGTS that
+	  there is a device encountered through ENTDAA or DEFTGTS that
 	  is not within known I3C devices.
 
 config I3C_I2C_NUM_OF_DESC_MEM_SLABS
@@ -152,7 +152,7 @@ config I3C_I2C_NUM_OF_DESC_MEM_SLABS
 	default 3
 	help
 	  This is the number of memory slabs allocated from when
-	  there is a device encounted through DEFTGTS that is not
+	  there is a device encountered through DEFTGTS that is not
 	  within known I2C devices.
 
 endif # I3C_CONTROLLER && I3C_TARGET

--- a/drivers/input/Kconfig.sbus
+++ b/drivers/input/Kconfig.sbus
@@ -42,13 +42,13 @@ config INPUT_SBUS_CHANNEL_VALUE_ONE
 	default 1800
 	help
 	  SBUS sends analogue values for digital switches. This config value
-	  sets the threshold to interperted the analogue value as an logic 1
+	  sets the threshold to interpret the analogue value as a logic 1
 
 config INPUT_SBUS_CHANNEL_VALUE_ZERO
 	int "Threshold value < for INPUT_EV_KEY value 0"
 	default 1200
 	help
 	  SBUS sends analogue values for digital switches. This config value
-	  sets the threshold to interperted the analogue value as an logic 0
+	  sets the threshold to interpret the analogue value as a logic 0
 
 endif # INPUT_SBUS

--- a/drivers/mspi/Kconfig.ambiq
+++ b/drivers/mspi/Kconfig.ambiq
@@ -60,7 +60,7 @@ config MSPI_AMBIQ_TIMING_SCAN_BUFFER_SIZE
 	help
 	  This option specifies the memory buffer size used for timing scan,
 	  carefully adjust this size between a few KBs to hundreds of KBs to achieve
-	  balance between time and accurary
+	  balance between time and accuracy
 
 config MSPI_AMBIQ_TIMING_SCAN_DATA_SIZE
 	int "Total data sizes in bytes used in timing scan"

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -193,9 +193,9 @@ menuconfig NET_LOOPBACK
 if NET_LOOPBACK
 
 config NET_LOOPBACK_SIMULATE_PACKET_DROP
-	bool "Controlable packet drop"
+	bool "Controllable packet drop"
 	help
-	  Enable interface to have a controlable packet drop rate, only for
+	  Enable interface to have a controllable packet drop rate, only for
 	  testing, should not be enabled for normal applications
 
 config NET_LOOPBACK_MTU

--- a/drivers/sdhc/Kconfig.ambiq
+++ b/drivers/sdhc/Kconfig.ambiq
@@ -26,6 +26,6 @@ config SDHC_BUFFER_ALIGNMENT
 	default 32 if DCACHE
 	default 16
 	help
-	  SDHC buffer should be 32bytes aligned when placed in cachable region.
+	  SDHC buffer should be 32bytes aligned when placed in cacheable region.
 
 endif

--- a/drivers/sdhc/Kconfig.sam_hsmci
+++ b/drivers/sdhc/Kconfig.sam_hsmci
@@ -31,7 +31,7 @@ config SAM_HSMCI_PWRSAVE_DIV
 	int "Divisor value of clock when in power-save mode"
 	default 7
 	help
-	  SD clock freqeuncy is divided by 2**(N+1) where N
+	  SD clock frequency is divided by 2**(N+1) where N
 	  is the divisor value. Valid values are 0 to 7.
 
 endif # SAM_HSMCI_PWRSAVE

--- a/drivers/sdhc/Kconfig.xlnx
+++ b/drivers/sdhc/Kconfig.xlnx
@@ -20,9 +20,9 @@ config SDHC_BUFFER_ALIGNMENT
 	default 32
 
 config HOST_ADMA2_DESC_SIZE
-	int "Max discripter SIZE"
+	int "Max descriptor SIZE"
 	default 32
 	help
-	  Set max number of discriptor support
+	  Set max number of descriptors supported
 
 endif

--- a/drivers/sensor/memsic/mc3419/Kconfig
+++ b/drivers/sensor/memsic/mc3419/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2023 Linumiz
 
 menuconfig MC3419
-	bool "MC3419 acclerometer driver"
+	bool "MC3419 accelerometer driver"
 	default y
 	depends on DT_HAS_MEMSIC_MC3419_ENABLED
 	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_MEMSIC_MC3419),i2c)

--- a/drivers/serial/Kconfig.npcx
+++ b/drivers/serial/Kconfig.npcx
@@ -17,8 +17,8 @@ config UART_NPCX
 	  processors.
 	  Say y if you wish to use serial port on NPCX MCU.
 
-# Expose this option when the reg porperty has two register base address.
-# i.e. One UART register bass address and one MDMA register base address.
+# Expose this option when the reg property has two register base addresses.
+# i.e. One UART register base address and one MDMA register base address.
 config UART_NPCX_USE_MDMA
 	bool "Nuvoton NPCX embedded controller (EC) serial driver DMA support"
 	depends on UART_NPCX && "$(dt_node_reg_addr_hex,$(DT_UART_NPCX),1)" != 0

--- a/drivers/spi/Kconfig.ambiq
+++ b/drivers/spi/Kconfig.ambiq
@@ -55,7 +55,7 @@ config SPI_AMBIQ_BLEIF_TIMING_TRACE
 	bool "Ambiq SPI-BLEIF timing trace"
 	help
 	  The pins for the SPI transceiver are not exposed from the chips
-	  and no need for user to confiugre them. But the chips design the
+	  and no need for user to configure them. But the chips design the
 	  configurable BLEIF timing observation functions on other exposed
 	  pins. The user can enable it to configure the pins for timing
 	  trace purpose.

--- a/drivers/usb/bc12/Kconfig.pi3usb9201
+++ b/drivers/usb/bc12/Kconfig.pi3usb9201
@@ -35,7 +35,7 @@ config USB_BC12_PI3USB9201_CDP_ERRATA
 	  Downstream Port).
 
 	  This is a workaround for a glitch seen on the USB data lines when
-	  operating in CDP mode. Note that the BC1.2 negotiation compeletes
+	  operating in CDP mode. Note that the BC1.2 negotiation completes
 	  before switching to SDP mode, so the attached portable device can
 	  continue to draw up to 1.5 A.
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -943,7 +943,7 @@ config STACK_CANARIES_STRONG
 	select REQUIRES_STACK_CANARIES
 	help
 	  This option enables compiler stack canaries in functions that call alloca,
-	  functions that have local array definitiion or have references to local
+	  functions that have local array definition or have references to local
 	  frame addresses.
 
 config STACK_CANARIES_ALL

--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -208,7 +208,7 @@ config MCUBOOT_BOOTLOADER_MODE_RAM_LOAD
 	  will select the image with the higher version number, copy it to RAM and begin execution
 	  from there. The image must be linked to execute from RAM, the address that it is copied
 	  to is specified using the load-addr argument when running imgtool.
-	  This option automatically selectes MCUBOOT_BOOTLOADER_NO_DOWNGRADE as it is not possible
+	  This option automatically selects MCUBOOT_BOOTLOADER_NO_DOWNGRADE as it is not possible
 	  to swap back to older version of the application.
 
 config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
@@ -221,7 +221,7 @@ config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
 	  select one with higher application image version, which usually
 	  means major.minor.patch triple, unless BOOT_VERSION_CMP_USE_BUILD_NUMBER
 	  is also selected that enables comparison of build number.
-	  This option automatically selectes
+	  This option automatically selects
 	  MCUBOOT_BOOTLOADER_NO_DOWNGRADE as it is not possible
 	  to swap back to older version of application.
 

--- a/modules/hal_nxp/mcux/Kconfig.mcux
+++ b/modules/hal_nxp/mcux/Kconfig.mcux
@@ -15,7 +15,7 @@ if	HAS_MCUX
 config MCUX_CORE_SUFFIX
 	string
 	help
-	  String describing the core identifer used by MCUX SDK when using
+	  String describing the core identifier used by MCUX SDK when using
 	  dual core parts
 
 config HAS_MCUX_ADC12
@@ -373,7 +373,7 @@ config HAS_NXP_MONOLITHIC_NBU
 config NXP_FW_LOADER
 	bool "Include firmware loader component"
 	help
-	   The firmware loader is used to load firmwares to embedded tranceivers.
+	   The firmware loader is used to load firmwares to embedded transceivers.
 	   It is needed to enable connectivity features.
 
 config NXP_MONOLITHIC_WIFI

--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -505,11 +505,11 @@ config MBEDTLS_SSL_CACHE_C
 if MBEDTLS_SSL_CACHE_C
 
 config MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT
-	int "Default timeout for SSL cache entires"
+	int "Default timeout for SSL cache entries"
 	default 86400
 
 config MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES
-	int "Maximum number of SSL cache entires"
+	int "Maximum number of SSL cache entries"
 	default 5
 
 endif # MBEDTLS_SSL_CACHE_C
@@ -564,7 +564,7 @@ config MBEDTLS_PSA_CRYPTO_LEGACY_RNG
 	  used, then the generated data will only be pseudo random. Strong
 	  entropy sources are strongly recommended (if possible) to have real
 	  random data.
-	  Another difference betwen this implementation and the
+	  Another difference between this implementation and the
 	  MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG counterpart is the memory footprint:
 	  this implementation brings in legacy modules which are not required
 	  in the "external" version, so the footprint is larger.
@@ -612,7 +612,7 @@ config MBEDTLS_PSA_P256M_DRIVER_ENABLED
 	bool "P256-M driver"
 	imply PSA_WANT_ALG_SHA_256
 	help
-	  Enable support for the optimized sofware implementation of the secp256r1
+	  Enable support for the optimized software implementation of the secp256r1
 	  curve through the standard PSA API.
 
 config MBEDTLS_PSA_P256M_DRIVER_RAW
@@ -621,7 +621,7 @@ config MBEDTLS_PSA_P256M_DRIVER_RAW
 	help
 	  Allow direct access to the p256-m driver interface.
 	  Warning: Usage of this Kconfig option is prohibited in Zephyr's codebase.
-	           Users can enable it in case of very memory-constrained devices, but be aware that the p256-m interface is absolutely not guaranted to remain stable over time.
+	           Users can enable it in case of very memory-constrained devices, but be aware that the p256-m interface is absolutely not guaranteed to remain stable over time.
 
 config MBEDTLS_PSA_CRYPTO_STORAGE_C
 	bool

--- a/modules/trusted-firmware-m/Kconfig.tfm.partitions
+++ b/modules/trusted-firmware-m/Kconfig.tfm.partitions
@@ -7,7 +7,7 @@ if BUILD_WITH_TFM
 
 config TFM_PARTITION_PROTECTED_STORAGE
 	bool "Secure partition 'Protected Storage'"
-	depends on TFM_PARTITION_PLATFORM # Specfically TFM_SP_PLATFORM_NV_COUNTER service
+	depends on TFM_PARTITION_PLATFORM # Specifically TFM_SP_PLATFORM_NV_COUNTER service
 	depends on TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
 	depends on TFM_PARTITION_CRYPTO
 	default y
@@ -65,7 +65,7 @@ config TFM_PARTITION_PLATFORM
 	  repository.
 
 config TFM_PARTITION_FIRMWARE_UPDATE
-	bool "Include the secure parition 'Firmware Update'"
+	bool "Include the secure partition 'Firmware Update'"
 	select TFM_MCUBOOT_DATA_SHARING
 	default n
 	help

--- a/samples/drivers/i2s/i2s_codec/Kconfig
+++ b/samples/drivers/i2s/i2s_codec/Kconfig
@@ -9,7 +9,7 @@ config I2S_INIT_BUFFERS
 	help
 	  Controls the initial count of audio data blocks, which are (optionally)
 	  filled by data from the DMIC peripheral and played back by the I2S
-	  output perihperal.
+	  output peripheral.
 
 config SAMPLE_FREQ
 	int "Sample rate"

--- a/samples/net/syslog_net/Kconfig
+++ b/samples/net/syslog_net/Kconfig
@@ -17,8 +17,8 @@ config NET_SAMPLE_SERVER_RUNTIME
 	string "Syslog server IP address set at runtime"
 	help
 	  Server address for the syslog server.
-	  This server address gets set at rumtime by the sample
-	  app defore the backend is initialized. This can be
+	  This server address gets set at runtime by the sample
+	  app before the backend is initialized. This can be
 	  either IPv4 or IPv6 address. Server listen UDP port
 	  number can be configured here too.
 	  Following syntax is supported:

--- a/share/sysbuild/images/bootloader/Kconfig
+++ b/share/sysbuild/images/bootloader/Kconfig
@@ -91,7 +91,7 @@ config MCUBOOT_MODE_DIRECT_XIP
 	  can boot from either partition and will select one with higher application image version,
 	  which usually means major.minor.patch triple, unless BOOT_VERSION_CMP_USE_BUILD_NUMBER is
 	  also selected in MCUboot that enables comparison of build number.
-	  This option automatically selectes MCUBOOT_BOOTLOADER_NO_DOWNGRADE as it is not possible
+	  This option automatically selects MCUBOOT_BOOTLOADER_NO_DOWNGRADE as it is not possible
 	  to swap back to older version of application.
 
 config MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT

--- a/soc/atmel/sam0/common/Kconfig.samd2x
+++ b/soc/atmel/sam0/common/Kconfig.samd2x
@@ -8,7 +8,7 @@ config SOC_ATMEL_SAMD_NVM_WAIT_STATES
 	default 1
 	help
 	  Wait states to set for NVM. Consult the datasheet as these are highly
-	  dependent on the device operationg conditions.
+	  dependent on the device operating conditions.
 
 config SOC_ATMEL_SAMD_OSC32K
 	bool "Internal 32.768 kHz RC oscillator"

--- a/soc/espressif/esp32s3/Kconfig
+++ b/soc/espressif/esp32s3/Kconfig
@@ -152,7 +152,8 @@ config MAC_BB_PD
 	help
 	  If enabled, the MAC and baseband of Wi-Fi and Bluetooth will be powered
 	  down when PHY is disabled. Enabling this setting reduces power consumption
-	  by a small amount but increases RAM use by approximat
+	  by a small amount but increases RAM use by approximately 4KB (Wi-Fi only),
+	  2KB (Bluetooth only) or 5.3KB (Wi-Fi + Bluetooth).
 
 endmenu  # Cache config
 

--- a/soc/intel/intel_adsp/Kconfig
+++ b/soc/intel/intel_adsp/Kconfig
@@ -142,8 +142,8 @@ config XTENSA_WAITI_BUG
 config ADSP_IDLE_CLOCK_GATING
 	bool "DSP clock gating in Idle"
 	help
-	  When true, FW will run with enabled clock gating. This options change
-	  HW configuration of a DSP. Evry time core goes to the WAITI state
+	  When true, FW will run with enabled clock gating. This option changes
+	  HW configuration of a DSP. Every time core goes to the WAITI state
 	  (wait for interrupt) during idle, the clock can be gated (however, this
 	  does not mean that this will happen).
 

--- a/soc/intel/intel_adsp/Kconfig.defconfig
+++ b/soc/intel/intel_adsp/Kconfig.defconfig
@@ -18,7 +18,7 @@ config XTENSA_RPO_CACHE
 	def_bool y
 
 # console can't handle the amount of data coming from many tests, so introduce
-# a delay beween testcases.
+# a delay between testcases.
 if ZTEST
 config ZTEST_TEST_DELAY_MS
 	default 100

--- a/soc/nxp/imxrt/imxrt118x/Kconfig
+++ b/soc/nxp/imxrt/imxrt118x/Kconfig
@@ -40,11 +40,11 @@ config IMAGE_CONTAINER_OFFSET
 	default 0x1000
 	help
 	  Image container is a boot image format that is used by ROM. Container
-	  format consists container header, image arrary entry, signature block
+	  format consists of container header, image array entry, signature block
 	  and user program images and data. The boot ROM expects container data
 	  to be saved in external memory.
 
-# Note- This config present the offest between container header and user
+# Note- This config presents the offset between container header and user
 # image. If ROM_START_OFFSET changed, you also need to change CONTAINER_USER_IMAGE_OFFSET
 # value. CONTAINER_USER_IMAGE_OFFSET = ROM_START_OFFSET - IMAGE_CONTAINER_OFFSET.
 config CONTAINER_USER_IMAGE_OFFSET

--- a/soc/nxp/rw/Kconfig
+++ b/soc/nxp/rw/Kconfig
@@ -39,7 +39,7 @@ config FLASH_CONFIG_OFFSET
 	default 0x400
 	help
 	  The flash config offset provides the boot ROM with the on-board
-	  flash type and parameters. The boot ROM requires a fixed flash conifg
+	  flash type and parameters. The boot ROM requires a fixed flash config
 	  offset for FlexSPI device.
 
 config IMAGE_VECTOR_TABLE_OFFSET

--- a/soc/renesas/rx/Kconfig
+++ b/soc/renesas/rx/Kconfig
@@ -10,7 +10,7 @@ config RENESAS_NONE_USED_PORT_INIT
 	bool "Initialize unused ports"
 	default y
 	help
-	  Initialize the unsed pins of RX MCU followed by in the "Handling of
+	  Initialize the unused pins of RX MCU followed by in the "Handling of
 	  Unused Pins" section of PORT chapter of RX MCU of User's manual.
 	  Note: please MUST set "BSP_PACKAGE_PINS" definition to your device
 	  of pin type in r_bsp_config.h.

--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -9,7 +9,7 @@ if SOC_FAMILY_SILABS_S0 || SOC_FAMILY_SILABS_S1 || SOC_FAMILY_SILABS_S2
 config SOC_GECKO_SDID
 	int
 	help
-	  Gecko SDK sometime refere to the chipset using the internal ID. This
+	  Sometimes, Gecko SDK refers to the chipset using the internal ID. This
 	  entry reflects this ID.
 
 config SOC_GECKO_BURTC

--- a/soc/st/stm32/Kconfig
+++ b/soc/st/stm32/Kconfig
@@ -36,7 +36,7 @@ config STM32_ENABLE_DEBUG_SLEEP_STOP
 	  Some STM32 parts disable the DBGMCU in sleep/stop modes because
 	  of power consumption. As a side-effects this prevents
 	  debuggers from attaching w/o resetting the target. This
-	  effectivly destroys the use-case of `west attach`. Also
+	  effectively destroys the use-case of `west attach`. Also
 	  SEGGER RTT and similar technologies need this.
 
 config SWJ_ANALOG_PRIORITY

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2017, I-SENSE group of ICCS
 # SPDX-License-Identifier: Apache-2.0
 
-# Default configurations appplied tp the whole STM32 family
+# Default configurations applied to the whole STM32 family
 
 if SOC_FAMILY_STM32
 

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -128,7 +128,7 @@ config BT_CTLR_SUBRATING_SUPPORT
 config BT_CTLR_CHANNEL_SOUNDING_SUPPORT
 	bool
 
-# Virtual option that all local LL implemenations should select
+# Virtual option that all local LL implementations should select
 config HAS_BT_CTLR
 	bool
 

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -87,7 +87,7 @@ config ISOTP_RX_SF_FF_BUF_COUNT
 	default 4
 	help
 	  This buffer is used for first and single frames. It is extra because the
-	  buffer has to be ready for the first reception in isr context and therefor
+	  buffer has to be ready for the first reception in isr context and therefore
 	  is allocated when binding.
 	  Each buffer will occupy CAN_MAX_DLEN - 1 byte + header (sizeof(struct net_buf))
 	  amount of data.

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -45,7 +45,7 @@ config DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW
 	help
 	  Core dump is done via memory window slot[1].
 	  It is Intel ADSP memory region shared with xtensa DSP.
-	  Window 2 slot [1] is reserved for debuging information.
+	  Window 2 slot [1] is reserved for debugging information.
 
 config DEBUG_COREDUMP_BACKEND_OTHER
 	bool "Backend subsystem for coredump defined out of tree"

--- a/subsys/ipc/ipc_service/backends/Kconfig
+++ b/subsys/ipc/ipc_service/backends/Kconfig
@@ -23,7 +23,7 @@ config IPC_SERVICE_BACKEND_ICMSG
 	depends on DT_HAS_ZEPHYR_IPC_ICMSG_ENABLED
 	select IPC_SERVICE_ICMSG
 	help
-	  Chosing this backend results in single endpoint implementation based
+	  Choosing this backend results in single endpoint implementation based
 	  on circular packet buffer.
 
 config IPC_SERVICE_BACKEND_ICMSG_ME_INITIATOR
@@ -33,8 +33,8 @@ config IPC_SERVICE_BACKEND_ICMSG_ME_INITIATOR
 	depends on DT_HAS_ZEPHYR_IPC_ICMSG_ME_INITIATOR_ENABLED
 	select IPC_SERVICE_ICMSG_ME
 	help
-	  Chosing this backend results in multi endpoint implementation based
-	  on circular packet buffer. This enables enpoint discovery initiator
+	  Choosing this backend results in multi endpoint implementation based
+	  on circular packet buffer. This enables endpoint discovery initiator
 	  role.
 
 config IPC_SERVICE_BACKEND_ICMSG_ME_FOLLOWER
@@ -44,8 +44,8 @@ config IPC_SERVICE_BACKEND_ICMSG_ME_FOLLOWER
 	depends on DT_HAS_ZEPHYR_IPC_ICMSG_ME_FOLLOWER_ENABLED
 	select IPC_SERVICE_ICMSG_ME
 	help
-	  Chosing this backend results in multi endpoint implementation based
-	  on circular packet buffer. This enables enpoint discovery follower
+	  Choosing this backend results in multi endpoint implementation based
+	  on circular packet buffer. This enables endpoint discovery follower
 	  role.
 
 rsource "Kconfig.icmsg_me"

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -114,7 +114,7 @@ config LOG_PROCESS_THREAD_PRIORITY
 	depends on LOG_PROCESS_THREAD_CUSTOM_PRIORITY
 	help
 	  The priority of the log processing thread.
-	  When not set the prority is set to K_LOWEST_APPLICATION_THREAD_PRIO.
+	  When not set the priority is set to K_LOWEST_APPLICATION_THREAD_PRIO.
 
 endif # LOG_PROCESS_THREAD
 

--- a/subsys/mgmt/ec_host_cmd/Kconfig.logging
+++ b/subsys/mgmt/ec_host_cmd/Kconfig.logging
@@ -8,7 +8,7 @@ config EC_HOST_CMD_LOG_DBG_BUFFERS
 	depends on EC_HC_LOG_LEVEL_DBG
 	help
 	  Every command is logged with the debug logging level. Use this config
-	  to decide, if full reqest and response buffers are logged alongside
+	  to decide if full request and response buffers are logged alongside
 	  other command parameters.
 
 config EC_HOST_CMD_LOG_SUPPRESSED_NUMBER

--- a/subsys/mgmt/mcumgr/smp/Kconfig
+++ b/subsys/mgmt/mcumgr/smp/Kconfig
@@ -31,7 +31,7 @@ config MCUMGR_SMP_CBOR_MIN_DECODING_LEVELS
 	help
 	  Minimal decoding levels, map/list encapsulation, required
 	  to be supported by zcbor decoding of SMP responses
-	  is auto genereated from MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_? options.
+	  is auto generated from MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_? options.
 	  A group or command that adds additional maps/lists above the
 	  base map, which is already taken into account, should
 	  select one of the MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_?.
@@ -87,7 +87,7 @@ config MCUMGR_SMP_CBOR_MIN_ENCODING_LEVELS
 	help
 	  Minimal encoding levels, map/list encapsulation, required
 	  to be supported by zcbor encoding of SMP responses
-	  is auto genereated from MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_? options.
+	  is auto generated from MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_? options.
 	  A group or command that adds additional maps/lists above the
 	  base map, which is already taken into account, should
 	  select one of the MCUMGR_SMP_CBOR_MIN_ENCODING_LEVEL_?.


### PR DESCRIPTION
Utilize a code spell-checking tool to scan for and correct spelling errors, focusing on `Kconfig` files.
