### PR TITLE
net: lib: ptp: fix memory slab alignment issue

### DIFF
--- a/subsys/net/lib/ptp/msg.c
+++ b/subsys/net/lib/ptp/msg.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(ptp_msg, CONFIG_PTP_LOG_LEVEL);
 
 static struct k_mem_slab msg_slab;
 
-K_MEM_SLAB_DEFINE_STATIC(msg_slab, sizeof(struct ptp_msg), CONFIG_PTP_MSG_POLL_SIZE, 8);
+K_MEM_SLAB_DEFINE_STATIC(msg_slab, sizeof(struct ptp_msg), CONFIG_PTP_MSG_POLL_SIZE, 4);
 
 static const char *msg_type_str(struct ptp_msg *msg)
 {

--- a/subsys/net/lib/ptp/port.c
+++ b/subsys/net/lib/ptp/port.c
@@ -38,7 +38,7 @@ BUILD_ASSERT(CONFIG_PTP_FOREIGN_TIME_TRANSMITTER_RECORD_SIZE >= 5 * CONFIG_PTP_N
 K_MEM_SLAB_DEFINE_STATIC(foreign_tts_slab,
 			 sizeof(struct ptp_foreign_tt_clock),
 			 CONFIG_PTP_FOREIGN_TIME_TRANSMITTER_RECORD_SIZE,
-			 8);
+			 4);
 #endif
 
 char str_port_id[] = "FF:FF:FF:FF:FF:FF:FF:FF-FFFF";


### PR DESCRIPTION
Commit 3c47f91be4f879c9f1eac4c2be0a1bdd2de426ff introduced alignment validation in K_MEM_SLAB_DEFINE macros.
A couple PTP message slabs were using alignment 8, while the size of the elements wasn't a multiple of 8, causing a static assertion failure.

Fix by changing the alignment from 8 to 4 bytes.