### PR TITLE
scripts: pylib: fix twister report handling for junitparser >= 4.0.2

### DIFF
--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -1124,7 +1124,8 @@ class Ctest(Harness):
             self.instance.reason = 'No tests collected'
             return
 
-        assert isinstance(suite, junit.TestSuite)
+        if not isinstance(suite, junit.TestSuite):
+            suite = junit.TestSuite.fromelem(suite)
 
         if suite.failures and suite.failures > 0:
             self.status = TwisterStatus.FAIL


### PR DESCRIPTION
With junitparser 4.0.2, the JunitXml.fromfile() now returns a JUnitXml instance. In order to access the junit.TestSuite instance, we must use TestSuite.fromelem() to convert it back.

Fixes the ci failure seen here. Tested with the following commands:
```
pip install junitparser==4.0.2
west twister -p native_sim/native -s testing.ctest.base --no-detailed-test-id
```

Fixes failure seen here: https://github.com/zephyrproject-rtos/zephyr/actions/runs/15936757806/job/44958135039
