### PR TITLE
zephyr: sw_isr_table: Fix compilation error

### DIFF
--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -243,10 +243,12 @@ struct z_shared_isr_table_entry z_shared_sw_isr_table[];
 			__attribute__((section(sect)))                                             \
 			__used _MK_IRQ_ELEMENT_NAME(func, __COUNTER__) = ((uintptr_t)(func));      \
 		), (                                                                               \
-			static void __attribute__((section(sect))) __attribute__((naked))          \
-			__used _MK_IRQ_ELEMENT_NAME(func, __COUNTER__)(void) {                     \
+			void __attribute__((section(sect))) __attribute__((naked))                 \
+			/* clang-format off */                                                     \
+			__used _MK_IRQ_ELEMENT_NAME(func, __COUNTER__) (void) {                    \
 				__asm(ARCH_IRQ_VECTOR_JUMP_CODE(func));                            \
 			}                                                                          \
+			/* clang-format on */                                                      \
 		))
 
 #define Z_ISR_DECLARE_DIRECT_C(irq, flags, func, counter) \


### PR DESCRIPTION
The IRQ_DIRECT_CONNECT macro eventually uses _Z_ISR_DIRECT_TABLE_ENTRY,
which defines a function. IRQ_DIRECT_CONNECT is meant to be used
inside functions. While nested functions are supported as an extension
in GNU C, the nested function cannot have static storage.

https://gcc.gnu.org/onlinedocs/gcc/Nested-Functions.html:

> A nested function always has no linkage. Declaring one with extern or
> static is erroneous.

```
./scripts/twister -c -s arch.interrupt.gen_isr_table_local.riscv --all

tests/kernel/gen_isr_table/src/main.c: In function
'gen_isr_table_test_build_time_direct_interrupt':
include/zephyr/sw_isr_table.h:197:41: error: invalid storage class for
function '__isr_table_entry_isr1_irq_2'
#define __MK_ISR_ELEMENT_NAME(func, id) __isr_table_entry_ ## func ## _irq_ ## id
                                        ^~~~~~~~~~~~~~~~~~
```

Issue https://github.com/zephyrproject-rtos/zephyr/issues/92194