### PR TITLE
arch: riscv: Increase IDT_LIST size

### DIFF
--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -117,7 +117,7 @@ MEMORY
     LINKER_DT_REGIONS()
 
     /* Used by and documented in include/linker/intlist.ld */
-    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF7FF, LENGTH = 2K
+    IDT_LIST  (wx)      : ORIGIN = 0xFFFFF000, LENGTH = 4K
 }
 
 ENTRY(CONFIG_KERNEL_ENTRY)


### PR DESCRIPTION
Some boards fail to build arch.interrupt.gen_isr_table_local.riscv test
since this region is too small:

riscv64-zephyr-elf/bin/ld.bfd: zephyr/zephyr_pre0.elf section `.intList'
will not fit in region `IDT_LIST'

riscv64-zephyr-elf/bin/ld.bfd: region `IDT_LIST' overflowed by 239 bytes

This is a bogus memory region, so increasing it has no effect on the
final binary size.

Issue #92194