### PR TITLE
drivers: akm09918c: fix null dereference in submit function

### DIFF
--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
@@ -60,10 +60,10 @@ void akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe
 		data->rtio_ctx, data->iodev, AKM09918C_REG_CNTL2, AKM09918C_CNTL2_SINGLE_MEASURE);
 	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(data->rtio_ctx);
 
-	writeByte_sqe->flags |= RTIO_SQE_CHAINED;
-	rtio_sqe_prep_callback_no_cqe(cb_sqe, akm09918_after_start_cb, (void *)iodev_sqe, NULL);
-
 	if (writeByte_sqe != NULL && cb_sqe != NULL) {
+		writeByte_sqe->flags |= RTIO_SQE_CHAINED;
+		rtio_sqe_prep_callback_no_cqe(cb_sqe, akm09918_after_start_cb, (void *)iodev_sqe,
+					      NULL);
 		rtio_submit(data->rtio_ctx, 0);
 	} else {
 		rtio_sqe_drop_all(data->rtio_ctx);


### PR DESCRIPTION
Fix a null pointer dereference in akm09918c_submit(), where writeByte_sqe was dereferenced before checking if it was NULL.

Coverity reported this as CID 516247: the pointer returned by i2c_rtio_copy_reg_write_byte() may be NULL, and accessing its `flags` field before checking leads to undefined behavior.

Move the access to writeByte_sqe->flags after confirming both writeByte_sqe and cb_sqe are valid.

Fixes: CID 516247, 516233

Fix https://github.com/zephyrproject-rtos/zephyr/issues/90530
FIx https://github.com/zephyrproject-rtos/zephyr/issues/90543