### PR TITLE
doc: semihosting: update semihosting spec link

### DIFF
--- a/arch/common/Kconfig
+++ b/arch/common/Kconfig
@@ -12,7 +12,7 @@ config SEMIHOST
 	  a host computer that is running a debugger.
 	  Additional information can be found in:
 	  https://developer.arm.com/documentation/dui0471/m/what-is-semihosting-
-	  https://github.com/riscv/riscv-semihosting-spec/blob/main/riscv-semihosting-spec.adoc
+	  https://github.com/riscv-non-isa/riscv-semihosting/blob/main/riscv-semihosting.adoc
 	  This option is compatible with hardware and with QEMU, through the
 	  (automatic) use of the -semihosting-config switch when invoking it.
 

--- a/doc/hardware/arch/semihost.rst
+++ b/doc/hardware/arch/semihost.rst
@@ -68,5 +68,5 @@ API Reference
 .. doxygengroup:: semihost
 
 .. _ARM Github documentation: https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst
-.. _RISC-V Github documentation: https://github.com/riscv/riscv-semihosting-spec/blob/main/riscv-semihosting-spec.adoc
+.. _RISC-V Github documentation: https://github.com/riscv-non-isa/riscv-semihosting/blob/main/riscv-semihosting.adoc
 .. _GDB File-I/O Remote Protocol: https://sourceware.org/gdb/current/onlinedocs/gdb.html/File_002dI_002fO-Remote-Protocol-Extension.html

--- a/include/zephyr/arch/common/semihost.h
+++ b/include/zephyr/arch/common/semihost.h
@@ -8,7 +8,7 @@
  * https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst
  *
  * RISC-V semihosting also follows these conventions:
- * https://github.com/riscv/riscv-semihosting-spec/blob/main/riscv-semihosting-spec.adoc
+ * https://github.com/riscv-non-isa/riscv-semihosting/blob/main/riscv-semihosting.adoc
  */
 
 /**


### PR DESCRIPTION
Replace dead link in semihosting documentation, arch/common/Kconfig and include/zephyr/arch/common/semihost.h.

Fix #88206