### PR TITLE
doc: release-notes-4.2: add mentions to the new UVC class

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -295,6 +295,10 @@ New APIs and options
 
   * :c:func:`updatehub_report_error`
 
+* USB
+
+  * :c:func:`uvc_set_video_dev`
+
 * Other
 
   * :kconfig:option:`CONFIG_LV_Z_COLOR_MONO_HW_INVERSION`
@@ -965,6 +969,7 @@ New Drivers
    * :dtcompatible:`nxp,uhc-khci`
    * :dtcompatible:`nxp,uhc-ohci`
    * :dtcompatible:`st,stm32n6-otghs`
+   * :dtcompatible:`zephyr,uvc-device`
 
 * Video
 
@@ -1023,6 +1028,7 @@ New Samples
 * :zephyr:code-sample:`uart_async`
 * :zephyr:code-sample:`usb-cdc-acm-bridge`
 * :zephyr:code-sample:`uuid`
+* :zephyr:code-sample:`uvc`
 * :zephyr:code-sample:`veml6031`
 
 Other notable changes


### PR DESCRIPTION
Now that UVC is merged, there might need to be a release note.

I realize that [`uvc_set_video_dev()`](https://github.com/zephyrproject-rtos/zephyr/blob/ad4c3e3e9afe1385ab80adf3fa2d3309fad68c60/include/zephyr/usb/class/usbd_uvc.h#L41) might need to be renamed `usbd_uvc_set_video_dev()` to stay consistent with [UAC2](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/usb/class/usbd_uac2.h) (`usbd_uac2_send()`) or [MIDI](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/usb/class/usbd_midi2.h) (`usbd_midi_send()`)

Doc preview: https://builds.zephyrproject.io/zephyr/pr/92348/docs/releases/release-notes-4.2.html