### PR TITLE
linker_script: Remove some remaining SUBALIGN in iterable sections

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -118,7 +118,7 @@ if(CONFIG_SENSING)
 endif()
 
 if(CONFIG_ZBUS)
-  zephyr_iterable_section(NAME zbus_channel_observation_mask GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 1)
+  zephyr_iterable_section(NAME zbus_channel_observation_mask GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT})
 endif()
 
 if(CONFIG_UVB)

--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -216,7 +216,7 @@ if (CONFIG_LOG)
 endif()
 
 if (CONFIG_MULTI_LEVEL_INTERRUPTS)
-  zephyr_iterable_section(NAME intc_table KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
+  zephyr_iterable_section(NAME intc_table KVMA RAM_REGION GROUP RODATA_REGION)
 endif()
 
 if (CONFIG_HTTP_SERVER)

--- a/samples/net/prometheus/CMakeLists.txt
+++ b/samples/net/prometheus/CMakeLists.txt
@@ -31,12 +31,10 @@ target_link_libraries(app PRIVATE zephyr_interface zephyr)
 zephyr_linker_sources(SECTIONS sections-rom.ld)
 zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_HTTPS_SERVICE NAME
 				http_resource_desc_test_https_service
-				KVMA RAM_REGION GROUP RODATA_REGION
-				SUBALIGN Z_LINK_ITERABLE_SUBALIGN)
+				KVMA RAM_REGION GROUP RODATA_REGION)
 zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_HTTP_SERVICE NAME
 				http_resource_desc_test_http_service
-				KVMA RAM_REGION GROUP RODATA_REGION
-				SUBALIGN Z_LINK_ITERABLE_SUBALIGN)
+				KVMA RAM_REGION GROUP RODATA_REGION)
 
 foreach(inc_file
 	ca.der

--- a/samples/net/sockets/echo_server/CMakeLists.txt
+++ b/samples/net/sockets/echo_server/CMakeLists.txt
@@ -59,10 +59,8 @@ endif()
 if(CONFIG_NET_SAMPLE_HTTPS_SERVICE)
   zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE NAME
 			      http_resource_desc_wss_console_service
-			      KVMA RAM_REGION GROUP RODATA_REGION
-			      SUBALIGN Z_LINK_ITERABLE_SUBALIGN)
+			      KVMA RAM_REGION GROUP RODATA_REGION)
 endif()
 zephyr_linker_section_ifdef(CONFIG_NET_SAMPLE_WEBSOCKET_CONSOLE NAME
 			    http_resource_desc_ws_console_service
-			    KVMA RAM_REGION GROUP RODATA_REGION
-			    SUBALIGN Z_LINK_ITERABLE_SUBALIGN)
+			    KVMA RAM_REGION GROUP RODATA_REGION)

--- a/tests/net/lib/http_client/CMakeLists.txt
+++ b/tests/net/lib/http_client/CMakeLists.txt
@@ -9,5 +9,4 @@ target_sources(app PRIVATE ${app_sources})
 
 zephyr_linker_sources(SECTIONS sections-rom.ld)
 zephyr_iterable_section(NAME http_resource_desc_test_http_service KVMA
-			RAM_REGION GROUP RODATA_REGION SUBALIGN $
-			{CONFIG_LINKER_ITERABLE_SUBALIGN})
+			RAM_REGION GROUP RODATA_REGION)


### PR DESCRIPTION
The #91219 miss some entries when doing the clean-up. This removes some of remaining SUBALIGN entries in the iterable sections. It do not consider SECTION_PROLOGUE and zephyr_linker_section entries.

Fixes #92349