### PR TITLE
mcumgr: relocate uart transport

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -203,34 +203,26 @@ config IPM_CONSOLE_LINE_BUF_LEN
 	  where characters are stored before sending the whole line.
 
 config UART_MCUMGR
-	bool "Mcumgr UART driver"
-	select UART_INTERRUPT_DRIVEN
+	bool "Mcumgr UART driver [DEPRECATED]"
+	select DEPRECATED
 	help
-	  Enable the mcumgr UART driver. This driver allows the application to
-	  communicate over UART using the mcumgr protocol for image upgrade and
-	  device management. The driver doesn't inspect received data (as
-	  contrary to console UART driver) and all aspects of received protocol
-	  data are handled by an application provided callback.
+	  This option is deprecated.
 
 if UART_MCUMGR
 
 config UART_MCUMGR_RX_BUF_SIZE
-	int "Size of receive buffer for mcumgr fragments received over UART, in bytes"
-	default 128
+	int "Size of receive buffer for mcumgr fragments received over UART, in bytes [DEPRECATED]"
+	default 0
 	help
-	  Specifies the size of the mcumgr UART receive buffer, in bytes. This
-	  value must be large enough to accommodate any line sent by an mcumgr
-	  client.
+	  This option is deprecated.
+	  Please use MCUMGR_TRANSPORT_UART_RX_BUF_SIZE instead.
 
 config UART_MCUMGR_RX_BUF_COUNT
-	int "Number of receive buffers for mcumgr fragments received over UART"
-	default 2
+	int "Number of receive buffers for mcumgr fragments received over UART [DEPRECATED]"
+	default 0
 	help
-	  Specifies the number of the mcumgr UART receive buffers.  Receive
-	  buffers hold received mcumgr fragments prior to reassembly.  This
-	  setting's value must satisfy the following relation:
-	  UART_MCUMGR_RX_BUF_COUNT * UART_MCUMGR_RX_BUF_SIZE >=
-	  MCUMGR_TRANSPORT_UART_MTU
+	  This option is deprecated.
+	  Please use MCUMGR_TRANSPORT_UART_RX_BUF_COUNT instead.
 
 endif # UART_MCUMGR
 

--- a/subsys/mgmt/mcumgr/transport/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/transport/CMakeLists.txt
@@ -21,6 +21,7 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_SHELL
 )
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_UART
   src/smp_uart.c
+  src/uart_mcumgr.c
 )
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_TRANSPORT_UDP
   src/smp_udp.c

--- a/subsys/mgmt/mcumgr/transport/Kconfig.uart
+++ b/subsys/mgmt/mcumgr/transport/Kconfig.uart
@@ -14,7 +14,6 @@ menuconfig MCUMGR_TRANSPORT_UART
 	depends on CONSOLE
 	depends on BASE64
 	depends on CRC
-	select UART_MCUMGR
 	help
 	  Enables handling of SMP commands received over UART.  This is a
 	  lightweight alternative to MCUMGR_TRANSPORT_SHELL.  It allows mcumgr
@@ -59,5 +58,23 @@ config MCUMGR_TRANSPORT_UART_MTU
 	  Maximum size of SMP frames sent and received over UART, in bytes.
 	  This value must satisfy the following relation:
 	  MCUMGR_TRANSPORT_UART_MTU <= MCUMGR_TRANSPORT_NETBUF_SIZE + 2
+
+config MCUMGR_TRANSPORT_UART_RX_BUF_SIZE
+	int "Size of receive buffer for mcumgr fragments received over UART, in bytes"
+	default 128
+	help
+	  Specifies the size of the mcumgr UART receive buffer, in bytes. This
+	  value must be large enough to accommodate any line sent by an mcumgr
+	  client.
+
+config MCUMGR_TRANSPORT_UART_RX_BUF_COUNT
+	int "Number of receive buffers for mcumgr fragments received over UART"
+	default 2
+	help
+	  Specifies the number of the mcumgr UART receive buffers.  Receive
+	  buffers hold received mcumgr fragments prior to reassembly.  This
+	  setting's value must satisfy the following relation:
+	  MCUMGR_TRANSPORT_UART_RX_BUF_COUNT * MCUMGR_TRANSPORT_UART_RX_BUF_SIZE >=
+	  MCUMGR_TRANSPORT_UART_MTU
 
 endif # MCUMGR_TRANSPORT_UART

--- a/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/uart_mcumgr.h
+++ b/subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/uart_mcumgr.h
@@ -10,8 +10,8 @@
  * @see include/mgmt/serial.h
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_CONSOLE_UART_MCUMGR_H_
-#define ZEPHYR_INCLUDE_DRIVERS_CONSOLE_UART_MCUMGR_H_
+#ifndef ZEPHYR_INCLUDE_MGMT_SMP_UART_MCUMGR_H_
+#define ZEPHYR_INCLUDE_MGMT_SMP_UART_MCUMGR_H_
 
 #include <stdlib.h>
 #include <zephyr/types.h>
@@ -25,7 +25,7 @@ extern "C" {
  */
 struct uart_mcumgr_rx_buf {
 	void *fifo_reserved;   /* 1st word reserved for use by fifo */
-	uint8_t data[CONFIG_UART_MCUMGR_RX_BUF_SIZE];
+	uint8_t data[CONFIG_MCUMGR_TRANSPORT_UART_RX_BUF_SIZE];
 	int length;
 };
 

--- a/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_dummy.c
@@ -10,16 +10,16 @@
  */
 
 /* Define required for uart_mcumgr.h functionality reuse */
-#define CONFIG_UART_MCUMGR_RX_BUF_SIZE CONFIG_MCUMGR_TRANSPORT_DUMMY_RX_BUF_SIZE
+#define CONFIG_MCUMGR_TRANSPORT_UART_RX_BUF_SIZE CONFIG_MCUMGR_TRANSPORT_DUMMY_RX_BUF_SIZE
 #define MCUMGR_DUMMY_MAX_FRAME CONFIG_MCUMGR_TRANSPORT_DUMMY_RX_BUF_SIZE
 
+#include <mgmt/mcumgr/transport/uart_mcumgr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/net_buf.h>
 #include <zephyr/sys/base64.h>
-#include <zephyr/drivers/console/uart_mcumgr.h>
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp/smp.h>
 #include <zephyr/mgmt/mcumgr/transport/smp.h>

--- a/subsys/mgmt/mcumgr/transport/src/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_uart.c
@@ -9,10 +9,10 @@
  */
 
 #include <string.h>
+#include <mgmt/mcumgr/transport/uart_mcumgr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/net_buf.h>
-#include <zephyr/drivers/console/uart_mcumgr.h>
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp/smp.h>
 #include <zephyr/mgmt/mcumgr/transport/smp.h>

--- a/subsys/mgmt/mcumgr/transport/src/uart_mcumgr.c
+++ b/subsys/mgmt/mcumgr/transport/src/uart_mcumgr.c
@@ -10,10 +10,10 @@
  */
 
 #include <string.h>
+#include <mgmt/mcumgr/transport/uart_mcumgr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/mgmt/mcumgr/transport/serial.h>
-#include <zephyr/drivers/console/uart_mcumgr.h>
 
 static const struct device *const uart_mcumgr_dev =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
@@ -32,7 +32,7 @@ static bool uart_mcumgr_ignoring;
 
 /** Contains buffers to hold incoming request fragments. */
 K_MEM_SLAB_DEFINE(uart_mcumgr_slab, sizeof(struct uart_mcumgr_rx_buf),
-		  CONFIG_UART_MCUMGR_RX_BUF_COUNT, 1);
+		  CONFIG_MCUMGR_TRANSPORT_UART_RX_BUF_COUNT, 1);
 
 #if defined(CONFIG_MCUMGR_TRANSPORT_UART_ASYNC)
 uint8_t async_buffer[CONFIG_MCUMGR_TRANSPORT_UART_ASYNC_BUFS]


### PR DESCRIPTION
The uart_mcumgr.c implements the APIs used by the smp_uart.c but lives in the drivers/console folder which is kinda awkward, as the files in the drivers/console generally implements the stdout & printk hooks.

Relocate it into subsys/mgmt/mcumgr/transport/src/ alongside smp_uart.c instead.

TODO:
- [ ] update migration guide and changelog for 4.3