### PR TITLE
wifi: nrf_wifi: ignore interface if TX disabled

### DIFF
--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -18,6 +18,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(wifi_nrf, CONFIG_WIFI_NRF70_LOG_LEVEL);
 
+#include <zephyr/net/conn_mgr_monitor.h>
 #include <zephyr/sys/reboot.h>
 
 #include "net_private.h"
@@ -677,6 +678,11 @@ void nrf_wifi_if_init_zep(struct net_if *iface)
 	k_work_init(&vif_ctx_zep->nrf_wifi_net_iface_work,
 		    nrf_wifi_net_iface_work_handler);
 #endif /* CONFIG_NRF70_DATA_TX */
+
+#ifdef CONFIG_NRF70_SCAN_ONLY
+	/* In scan only mode this interface should be ignored by the connectivity manager */
+	conn_mgr_ignore_iface(iface);
+#endif /* CONFIG_NRF70_SCAN_ONLY */
 
 #ifdef CONFIG_NRF_WIFI_RPU_RECOVERY
 	k_work_init(&vif_ctx_zep->nrf_wifi_rpu_recovery_work,

--- a/subsys/net/conn_mgr/conn_mgr_monitor.c
+++ b/subsys/net/conn_mgr/conn_mgr_monitor.c
@@ -32,7 +32,7 @@ static struct k_thread conn_mgr_mon_thread;
  * conn_mgr_mon_get_if_by_index and conn_mgr_get_index_for_if are used to go back and forth between
  * iface_states indices and Zephyr iface pointers.
  */
-uint16_t iface_states[CONN_MGR_IFACE_MAX];
+static uint16_t iface_states[CONN_MGR_IFACE_MAX];
 
 /* Tracks the most recent total quantity of L4-ready ifaces (any, IPv4, IPv6) */
 static uint16_t last_ready_count;
@@ -49,6 +49,11 @@ K_SEM_DEFINE(conn_mgr_mon_updated, 1, 1);
 
 /* Used to protect conn_mgr_monitor state */
 K_MUTEX_DEFINE(conn_mgr_mon_lock);
+
+uint16_t *conn_mgr_if_state_internal(void)
+{
+	return iface_states;
+}
 
 /**
  * @brief Retrieves pointer to an iface by the index that corresponds to it in iface_states
@@ -400,12 +405,6 @@ void conn_mgr_watch_l2(const struct net_l2 *l2)
 
 static int conn_mgr_mon_init(void)
 {
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(iface_states); i++) {
-		iface_states[i] = 0;
-	}
-
 	k_thread_create(&conn_mgr_mon_thread, conn_mgr_mon_stack,
 			CONFIG_NET_CONNECTION_MANAGER_MONITOR_STACK_SIZE,
 			conn_mgr_mon_thread_fn,

--- a/subsys/net/conn_mgr/conn_mgr_private.h
+++ b/subsys/net/conn_mgr/conn_mgr_private.h
@@ -63,6 +63,9 @@ void conn_mgr_init_events_handler(void);
 /* Cause conn_mgr_connectivity to Initialize all connectivity implementation bindings */
 void conn_mgr_conn_init(void);
 
+/* Retrieve the raw pointer to the state array of size CONN_MGR_IFACE_MAX */
+uint16_t *conn_mgr_if_state_internal(void);
+
 /* Internal helper function to allow the shell net cm command to safely read conn_mgr state. */
 uint16_t conn_mgr_if_state(struct net_if *iface);
 

--- a/subsys/net/conn_mgr/events_handler.c
+++ b/subsys/net/conn_mgr/events_handler.c
@@ -12,8 +12,6 @@ LOG_MODULE_DECLARE(conn_mgr, CONFIG_NET_CONNECTION_MANAGER_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 #include "conn_mgr_private.h"
 
-extern uint16_t iface_states[CONN_MGR_IFACE_MAX];
-
 static struct net_mgmt_event_callback iface_events_cb;
 static struct net_mgmt_event_callback ipv6_events_cb;
 static struct net_mgmt_event_callback ipv4_events_cb;
@@ -22,6 +20,7 @@ static void conn_mgr_iface_events_handler(struct net_mgmt_event_callback *cb,
 					  uint64_t mgmt_event,
 					  struct net_if *iface)
 {
+	uint16_t *iface_states = conn_mgr_if_state_internal();
 	int idx;
 
 	NET_DBG("%s event 0x%" PRIx64 " received on iface %d (%p)", "Iface", mgmt_event,
@@ -58,6 +57,7 @@ static void conn_mgr_ipv6_events_handler(struct net_mgmt_event_callback *cb,
 					 uint64_t mgmt_event,
 					 struct net_if *iface)
 {
+	uint16_t *iface_states = conn_mgr_if_state_internal();
 	int idx;
 
 	NET_DBG("%s event 0x%" PRIx64 " received on iface %d (%p)", "IPv6", mgmt_event,
@@ -115,6 +115,7 @@ static void conn_mgr_ipv4_events_handler(struct net_mgmt_event_callback *cb,
 					 uint64_t mgmt_event,
 					 struct net_if *iface)
 {
+	uint16_t *iface_states = conn_mgr_if_state_internal();
 	int idx;
 
 	NET_DBG("%s event 0x%" PRIx64 " received on iface %d (%p)", "IPv4", mgmt_event,


### PR DESCRIPTION
Automatically hide the nRF7x interface from the connection manager if the TX path is disabled (scan only mode). This prevents function calls like `conn_mgr_all_if_up(true)` from bringing up the interface which can never result in a connection.