### PR TITLE
Tests: kernel: device: increase test coverage

### DIFF
--- a/tests/kernel/device/app.overlay
+++ b/tests/kernel/device/app.overlay
@@ -17,7 +17,7 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	fakedriver@E0000000 {
+	fake_driver_label: fakedriver@E0000000 {
 		compatible = "fakedriver";
 		reg = <0xE0000000 0x2000>;
 		status = "okay";

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -26,6 +26,9 @@
 #define FAKEDEFERDRIVER0	DEVICE_DT_GET(DT_PATH(fakedeferdriver_e7000000))
 #define FAKEDEFERDRIVER1	DEVICE_DT_GET(DT_PATH(fakedeferdriver_e8000000))
 
+#define FAKEDRIVER0_NODEID    DT_PATH(fakedriver_e0000000)
+#define FAKEDRIVER0_NODELABEL "fake_driver_label"
+
 /* A device without init call */
 DEVICE_DEFINE(dummy_noinit, DUMMY_NOINIT, NULL, NULL, NULL, NULL,
 	      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
@@ -475,6 +478,26 @@ ZTEST(device, test_deinit_success_and_redeinit)
 	ret = device_deinit(dev);
 	zassert_equal(ret, -EPERM, "device_deinit should fail when not init or already deinit");
 }
+
+#ifdef CONFIG_DEVICE_DT_METADATA
+DEVICE_DT_DEFINE(FAKEDRIVER0_NODEID, NULL, NULL, NULL, NULL, POST_KERNEL,
+		 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+
+ZTEST(device, test_device_get_by_dt_nodelabel)
+{
+	const struct device *dev = DEVICE_DT_GET(FAKEDRIVER0_NODEID);
+
+	zassert_not_null(dev);
+
+	const struct device *valid = device_get_by_dt_nodelabel(FAKEDRIVER0_NODELABEL);
+
+	zassert_not_null(valid, "Valid DT nodelabel should return a device");
+
+	const struct device *invalid = device_get_by_dt_nodelabel("does_not_exist");
+
+	zassert_is_null(invalid, "Invalid DT nodelabel should return NULL");
+}
+#endif
 
 void *user_setup(void)
 {

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -258,8 +258,19 @@ ZTEST(device, test_device_list)
 {
 	struct device const *devices;
 	size_t devcount = z_device_get_all_static(&devices);
+	bool found = false;
 
-	zassert_false((devcount == 0));
+	zassert_true(devcount > 0, "Should have at least one static device");
+	zassert_not_null(devices);
+	for (size_t i = 0; i < devcount; i++) {
+		struct device const *dev = devices + i;
+
+		if (strcmp(dev->name, DUMMY_NOINIT) == 0) {
+			found = true;
+			break;
+		}
+	}
+	zassert_true(found, "%s should be present in static device list", DUMMY_NOINIT);
 }
 
 static int sys_init_counter;

--- a/tests/kernel/device/testcase.yaml
+++ b/tests/kernel/device/testcase.yaml
@@ -13,6 +13,7 @@ tests:
   kernel.device.metadata:
     platform_allow:
       - qemu_x86
+      - native_sim
     extra_configs:
       - CONFIG_DEVICE_DT_METADATA=y
   kernel.device.minimallibc:


### PR DESCRIPTION
Add tests for `device_get_by_dt_nodelabel()` and device de-initialization.
Enhance `z_device_get_all_static()` testing.