### PR TITLE
wifi: nrf70: Fix system work queue stack size override

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -599,10 +599,8 @@ endif
 
 if NETWORKING
 # Finetune defaults for certain system components used by the driver
-
-config SYSTEM_WORKQUEUE_STACK_SIZE
-	default 4096
-
+# Note: These will take effect only if the symbol is not defined already
+# (i.e., the original symbol is processed after "drivers/Kconfig")
 config NET_TX_STACK_SIZE
 	default 4096
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -585,7 +585,7 @@ config WORKQUEUE_WORK_TIMEOUT
 menu "System Work Queue Options"
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int "System workqueue stack size"
-	default 4096 if COVERAGE_GCOV
+	default 4096 if COVERAGE_GCOV || WIFI_NRF70
 	default 2560 if WIFI_NM_WPA_SUPPLICANT
 	default 1024
 


### PR DESCRIPTION
Defaults cannot be overidden (even with configdefault extension), they only work if the original symbol is defined after the override e.g., "drivers and then subsys/net" but for kernel symbols,the default value overrides don't work due "kernel and drivers" order, the kernel defines the original symbol with the default and then it cannot be overridden.

Move the kernel symbol override to the original definition to make it affect. Else any sample that uses nRF70 but doesn't enable WPA supplicant ends up with 1024 and crashes.