### PR TITLE
modules: nrf_wifi: Fix raw TX handling

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -328,7 +328,7 @@ manifest:
       revision: 6e5961223f81aa2707c555db138819a5c1b7942c
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 7cb2f44f46dfc86e4f97477ee90022944e138dd8
+      revision: 52286f111b4765e0dd40f43124e7bb5c14758dff
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637


### PR DESCRIPTION
Redesign raw TX handling that   fixes the issue of leave the packets in the pending queue till a new TX  comes. This always sends out all frames.