### PR TITLE
bluetooth: AVDTP: in Set Configuration Reject rsp, LOSC can 't be added.

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -486,8 +486,6 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 		LOG_DBG("set configuration err code:%d", avdtp_err_code);
 		/* Service Category: Media Codec */
 		net_buf_add_u8(rsp_buf, BT_AVDTP_SERVICE_MEDIA_CODEC);
-		/* Length Of Service Capability */
-		net_buf_add_u8(rsp_buf, 0);
 		/* ERROR CODE */
 		net_buf_add_u8(rsp_buf, avdtp_err_code);
 	}


### PR DESCRIPTION
The current logic will result in rsp always being 
accept because LOSC added is 0. 

According to the spec, LOSC should not be added
 to the Set Configuration Reject response.