### PR TITLE
drivers: wifi: esp_at: fix AT+CIPSEND premature timeout

### DIFF
--- a/drivers/wifi/esp_at/Kconfig.esp_at
+++ b/drivers/wifi/esp_at/Kconfig.esp_at
@@ -99,6 +99,14 @@ config WIFI_ESP_AT_RX_NET_PKT_ALLOC_TIMEOUT
 	help
 	  Network interface RX net_pkt allocation timeout in milliseconds.
 
+config WIFI_ESP_AT_TCP_SEND_TIMEOUT
+	int "TCP socket send timeout"
+	default 30000
+	help
+	  For TCP socket, how long to wait in milliseconds for device
+	  to reply SEND OK/SEND FAIL after AT+CIPSEND has been sent.
+	  This can vary with network traffic condition.
+
 choice
 	prompt "ESP IP Address configuration"
 	default WIFI_ESP_AT_IP_DHCP


### PR DESCRIPTION
For TCP socket, this fixes `AT+CIPSEND` command with too short timeout. ESP modem replies send result `SEND OK`/`SEND FAIL` dependent on network traffic condition, so this timeout config changes as Kconfig option for being configurable by user.