### PR TITLE
net: tcp: Set the right th_win value in tester_prepare_tcp_pkt

### DIFF
--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -293,7 +293,7 @@ static struct net_pkt *tester_prepare_tcp_pkt(sa_family_t af,
 	}
 
 	th->th_flags = flags;
-	th->th_win = NET_IPV6_MTU;
+	th->th_win = htons(NET_IPV6_MTU);
 	th->th_seq = htonl(seq);
 
 	if (ACK & flags) {


### PR DESCRIPTION
The 16bit th_win in the TCP header was not set a value via htons(). It will bring issues of wrong th_win value in the peer end. For example, the 1280 (0x0500) TCP window size would be taken as 5 (0x0005) by the peer end.
Fix: #92376 