### PR TITLE
drivers: wdt: npcx: add wdt driver support for npck3

### DIFF
--- a/drivers/watchdog/Kconfig.npcx
+++ b/drivers/watchdog/Kconfig.npcx
@@ -21,3 +21,11 @@ config WDT_NPCX_WARNING_LEADING_TIME_MS
 	  This option defines the window in which a watchdog event must be
 	  handled. After this time window, the watchdog reset triggers
 	  immediately.
+
+config WDT_NPCX_EX
+	bool "Extended NPCX watchdog driver support"
+	default y
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NUVOTON_NPCX_WATCHDOG),support-npckn-v1,True)
+	help
+	  This option enables the extended Watchdog Timer driver for NPCKn variant
+	  of processors.

--- a/drivers/watchdog/wdt_npcx.c
+++ b/drivers/watchdog/wdt_npcx.c
@@ -379,6 +379,11 @@ static int wdt_npcx_init(const struct device *dev)
 	inst->WDCP = 0x05; /* Prescaler is 32 in Watchdog Timer */
 	inst->TWCP = 0x05; /* Prescaler is 32 in T0 Timer */
 
+#if defined(CONFIG_WDT_NPCX_EX)
+	/* Enable T0OUT if extended driver is enabled */
+	inst->T0CSR |= BIT(NPCX_T0CSR_T0EN);
+#endif /* CONFIG_WDT_NPCX_EX */
+
 	return 0;
 }
 

--- a/dts/arm/nuvoton/npck/npck.dtsi
+++ b/dts/arm/nuvoton/npck/npck.dtsi
@@ -379,6 +379,7 @@
 			compatible = "nuvoton,npcx-watchdog";
 			reg = <0x400d8000 0x2000>;
 			t0-out = <&wui_t0out>;
+			support-npckn-v1;
 		};
 
 		espi0: espi@4000a000 {

--- a/dts/bindings/watchdog/nuvoton,npcx-watchdog.yaml
+++ b/dts/bindings/watchdog/nuvoton,npcx-watchdog.yaml
@@ -16,4 +16,8 @@ properties:
     description: |
         Mapping table between Wake-Up Input (WUI) and t0-out timer expired signal.
         For example, the WUI mapping on NPCX7 t0-out timer would be
-           t0-out = <&wui_t0out>;
+        t0-out = <&wui_t0out>;
+  support-npckn-v1:
+    type: boolean
+    description: |
+        This option enables the extended Watchdog Timer driver for NPCKn.


### PR DESCRIPTION
Enables the extended Watchdog Timer driver for npck3.