### PR TITLE
drivers: memc: add driver for stm32 ospi psram

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021 Linaro Limited
  * Copyright (c) 2024 STMicroelectronics
+ * Copyright (c) 2025 ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +10,7 @@
 #include <st/u5/stm32u585aiixq-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
 
 / {
 	leds {
@@ -41,6 +43,13 @@
 		volt-sensor0 = &vref1;
 		volt-sensor1 = &vbat4;
 		eeprom-0 = &eeprom0;
+	};
+
+	psram: memory@90000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x90000000 DT_SIZE_M(8)>;
+		zephyr,memory-region = "PSRAM";
+		zephyr,memory-attr = <(DT_MEM_ARM(ATTR_MPU_RAM))>;
 	};
 };
 
@@ -122,6 +131,27 @@ stm32_lp_tick_source: &lptim1 {
 		status = "okay";
 		pinctrl-0 = <&tim3_ch2_pe4>;
 		pinctrl-names = "default";
+	};
+};
+
+&octospi1 {
+	pinctrl-0 = <&octospim_p1_clk_pb10 &octospim_p1_ncs_pb11
+		     &octospim_p1_io0_pf8 &octospim_p1_io1_pf9
+		     &octospim_p1_io2_pf7 &octospim_p1_io3_pf6
+		     &octospim_p1_io4_ph2 &octospim_p1_io5_pi0
+		     &octospim_p1_io6_pc3 &octospim_p1_io7_pd7
+		     &octospim_p1_dqs_pe3>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	memc: aps6408l: memory@0 {
+		compatible = "st,stm32-ospi-psram";
+		reg = <0>;
+		size = <DT_SIZE_M(64)>; /* 64 Mbits */
+		max-frequency = <DT_FREQ_M(133)>;
+		fixed-latency;
+		burst-length = <3>;
+		status = "okay";
 	};
 };
 

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -24,4 +24,5 @@ supported:
   - i2c
   - rtc
   - usbd
+  - memc
 vendor: st

--- a/drivers/memc/CMakeLists.txt
+++ b/drivers/memc/CMakeLists.txt
@@ -28,3 +28,4 @@ zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_NOR_PSRAM         memc_stm32_nor_
 zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_SDRAM             memc_stm32_sdram.c)
 
 zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_XSPI_PSRAM        memc_stm32_xspi_psram.c)
+zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_OSPI_PSRAM        memc_stm32_ospi_psram.c)

--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Teslabs Engineering S.L.
+# Copyright (c) 2025 ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 config MEMC_STM32
@@ -40,3 +41,16 @@ config MEMC_STM32_XSPI_PSRAM
 	select PINCTRL
 	help
 	  Enable STM32 XSPI Memory Controller.
+
+config MEMC_STM32_OSPI_PSRAM
+	bool "STM32 OSPI PSRAM"
+	default y
+	depends on DT_HAS_ST_STM32_OSPI_PSRAM_ENABLED
+	depends on SOC_SERIES_STM32U5X
+	select USE_STM32_HAL_OSPI
+	select USE_STM32_LL_DLYB
+	select USE_STM32_HAL_DMA
+	select USE_STM32_HAL_DMA_EX
+	select PINCTRL
+	help
+	  Enable STM32 OSPI PSRAM Controller driver.

--- a/drivers/memc/memc_stm32_ospi_psram.c
+++ b/drivers/memc/memc_stm32_ospi_psram.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2025 ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
+ * Copyright (c) 2025 Mario Paja
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT st_stm32_ospi_psram
+
+#include <errno.h>
+#include <soc.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/pinctrl.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/multi_heap/shared_multi_heap.h>
+
+#define STM32_OSPI_CLOCK_PRESCALER_MIN                1U
+#define STM32_OSPI_CLOCK_PRESCALER_MAX                256U
+#define STM32_OSPI_CLOCK_COMPUTE(bus_freq, prescaler) ((bus_freq) / (prescaler))
+
+LOG_MODULE_REGISTER(memc_stm32_ospi_psram, CONFIG_MEMC_LOG_LEVEL);
+
+#define STM32_OSPI_NODE DT_INST_PARENT(0)
+
+#ifdef CONFIG_SHARED_MULTI_HEAP
+static const struct shared_multi_heap_region smh_psram = {
+	.addr = DT_REG_ADDR(DT_NODELABEL(psram)),
+	.size = DT_REG_SIZE(DT_NODELABEL(psram)),
+	.attr = SMH_REG_ATTR_EXTERNAL,
+};
+#endif
+
+/* Memory registers definition */
+#define MR0 0x00000000U
+#define MR1 0x00000001U
+#define MR2 0x00000002U
+#define MR3 0x00000003U
+#define MR4 0x00000004U
+#define MR8 0x00000008U
+
+/* Memory commands */
+#define SYNC_READ_CMD   0x00U
+#define SYNC_WRITE_CMD  0x80U
+#define BURST_READ_CMD  0x20U
+#define BURST_WRITE_CMD 0xA0U
+#define READ_REG_CMD    0x40U
+#define WRITE_REG_CMD   0xC0U
+#define RESET_CMD       0xFFU
+
+/* Write Operations */
+#define WRITE_CMD 0x8080
+
+/* Read Operations */
+#define READ_CMD 0x0000
+
+/* Default dummy clocks cycles */
+#define DUMMY_CLOCK_CYCLES_READ  8
+#define DUMMY_CLOCK_CYCLES_WRITE 4
+
+struct memc_stm32_ospi_psram_config {
+	OCTOSPI_TypeDef *regs;
+	const struct pinctrl_dev_config *pcfg;
+	const struct stm32_pclken pclken;
+#if DT_CLOCKS_HAS_NAME(STM32_OSPI_NODE, ospi_ker)
+	const struct stm32_pclken pclken_ker; /* clock subsystem */
+#endif
+#if DT_CLOCKS_HAS_NAME(STM32_OSPI_NODE, ospi_mgr)
+	const struct stm32_pclken pclken_mgr; /* clock subsystem */
+#endif
+	size_t memory_size;
+	uint32_t max_frequency;
+};
+
+struct memc_stm32_ospi_psram_data {
+	OSPI_HandleTypeDef hospi;
+	OSPIM_CfgTypeDef ospim_cfg;
+	HAL_OSPI_DLYB_CfgTypeDef dlyb_cfg;
+};
+
+static int ap_memory_write_reg(OSPI_HandleTypeDef *hospi, uint32_t address, uint8_t *value)
+{
+	OSPI_RegularCmdTypeDef cmd = {0};
+
+	/* Initialize the write register command */
+	cmd.OperationType = HAL_OSPI_OPTYPE_COMMON_CFG;
+	cmd.InstructionMode = HAL_OSPI_INSTRUCTION_8_LINES;
+	cmd.InstructionSize = HAL_OSPI_INSTRUCTION_8_BITS;
+	cmd.InstructionDtrMode = HAL_OSPI_INSTRUCTION_DTR_DISABLE;
+	cmd.Instruction = WRITE_REG_CMD;
+	cmd.AddressMode = HAL_OSPI_ADDRESS_8_LINES;
+	cmd.AddressSize = HAL_OSPI_ADDRESS_32_BITS;
+	cmd.AddressDtrMode = HAL_OSPI_ADDRESS_DTR_ENABLE;
+	cmd.Address = address;
+	cmd.AlternateBytesMode = HAL_OSPI_ALTERNATE_BYTES_NONE;
+	cmd.DataMode = HAL_OSPI_DATA_8_LINES;
+	cmd.DataDtrMode = HAL_OSPI_DATA_DTR_ENABLE;
+	cmd.NbData = 2;
+	cmd.DummyCycles = 0;
+	cmd.DQSMode = HAL_OSPI_DQS_DISABLE;
+	cmd.SIOOMode = HAL_OSPI_SIOO_INST_EVERY_CMD;
+
+	/* Configure the command */
+	if (HAL_OSPI_Command(hospi, &cmd, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("OSPI write command failed");
+		return -EIO;
+	}
+
+	/* Transmission of the data */
+	if (HAL_OSPI_Transmit(hospi, value, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("OSPI transmit failed");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int ap_memory_read_reg(OSPI_HandleTypeDef *hospi, uint32_t address, uint8_t *value,
+			      uint32_t latency_cycles)
+{
+	OSPI_RegularCmdTypeDef cmd = {0};
+
+	/* Initialize the read register command */
+	cmd.OperationType = HAL_OSPI_OPTYPE_COMMON_CFG;
+	cmd.InstructionMode = HAL_OSPI_INSTRUCTION_8_LINES;
+	cmd.InstructionSize = HAL_OSPI_INSTRUCTION_8_BITS;
+	cmd.InstructionDtrMode = HAL_OSPI_INSTRUCTION_DTR_DISABLE;
+	cmd.Instruction = READ_REG_CMD;
+	cmd.AddressMode = HAL_OSPI_ADDRESS_8_LINES;
+	cmd.AddressSize = HAL_OSPI_ADDRESS_32_BITS;
+	cmd.AddressDtrMode = HAL_OSPI_ADDRESS_DTR_ENABLE;
+	cmd.Address = address;
+	cmd.AlternateBytesMode = HAL_OSPI_ALTERNATE_BYTES_NONE;
+	cmd.DataMode = HAL_OSPI_DATA_8_LINES;
+	cmd.DataDtrMode = HAL_OSPI_DATA_DTR_ENABLE;
+	cmd.NbData = 2;
+	cmd.DummyCycles = latency_cycles;
+	cmd.DQSMode = HAL_OSPI_DQS_ENABLE;
+	cmd.SIOOMode = HAL_OSPI_SIOO_INST_EVERY_CMD;
+
+	/* Configure the command */
+	if (HAL_OSPI_Command(hospi, &cmd, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("OSPI read command failed");
+		return -EIO;
+	}
+
+	/* Reception of the data */
+	if (HAL_OSPI_Receive(hospi, value, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("OSPI receive failed");
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int ap_memory_configure(OSPI_HandleTypeDef *hospi)
+{
+	uint8_t read_latency_code = DT_INST_PROP(0, read_latency);
+	uint8_t read_latency_cycles = read_latency_code + 3U; /* Code 0 <=> 3 cycles... */
+
+	/* MR0 register for read and write */
+	uint8_t regW_MR0[2] = {(DT_INST_PROP(0, fixed_latency) ? 0x20U : 0x00U) |
+				       (read_latency_code << 2) | (DT_INST_PROP(0, drive_strength)),
+			       0x0D};
+	uint8_t regR_MR0[2] = {0};
+
+	/* MR4 register for read and write */
+	uint8_t regW_MR4[2] = {(DT_INST_PROP(0, write_latency) << 5) |
+				       (DT_INST_PROP(0, adaptive_refresh_rate) << 3) |
+				       (DT_INST_PROP(0, pasr)),
+			       0x05U};
+	uint8_t regR_MR4[2] = {0};
+
+	/* MR8 register for read and write */
+	uint8_t regW_MR8[2] = {(DT_INST_PROP(0, rbx) ? 0x08U : 0x00U) |
+				       (DT_INST_PROP(0, burst_type_hybrid_wrap) ? 0x04U : 0x00U) |
+				       (DT_INST_PROP(0, burst_length)),
+			       0x08U};
+	uint8_t regR_MR8[2] = {0};
+
+	/* Configure Read Latency and drive Strength */
+	if (ap_memory_write_reg(hospi, MR0, regW_MR0) != 0) {
+		return -EIO;
+	}
+
+	if (ap_memory_read_reg(hospi, MR0, regR_MR0, read_latency_cycles) != 0) {
+		return -EIO;
+	}
+
+	if (regR_MR0[0] != regW_MR0[0]) {
+		return -EIO;
+	}
+
+	/* Configure Write Latency and refresh rate */
+	if (ap_memory_write_reg(hospi, MR4, regW_MR4) != 0) {
+		return -EIO;
+	}
+
+	/* Check MR4 configuration */
+	if (ap_memory_read_reg(hospi, MR4, regR_MR4, read_latency_cycles) != 0) {
+		return -EIO;
+	}
+	if (regR_MR4[0] != regW_MR4[0]) {
+		return -EIO;
+	}
+
+	/* Configure Burst Length */
+	if (ap_memory_write_reg(hospi, MR8, regW_MR8) != HAL_OK) {
+		return -EIO;
+	}
+
+	/* Check MR8 configuration */
+	if (ap_memory_read_reg(hospi, MR8, regR_MR8, read_latency_cycles) != HAL_OK) {
+		return -EIO;
+	}
+
+	if (regR_MR8[0] != regW_MR8[0]) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int config_memory_mapped(const struct device *dev)
+{
+	struct memc_stm32_ospi_psram_data *dev_data = dev->data;
+	OSPI_HandleTypeDef *hospi = &dev_data->hospi;
+	OSPI_RegularCmdTypeDef cmd = {0};
+	OSPI_MemoryMappedTypeDef mem_mapped_cfg = {0};
+
+	/*Configure Memory Mapped mode*/
+	cmd.OperationType = HAL_OSPI_OPTYPE_WRITE_CFG;
+	cmd.FlashId = HAL_OSPI_FLASH_ID_1;
+	cmd.Instruction = WRITE_CMD;
+	cmd.InstructionMode = HAL_OSPI_INSTRUCTION_8_LINES;
+	cmd.InstructionSize = HAL_OSPI_INSTRUCTION_16_BITS;
+	cmd.InstructionDtrMode = HAL_OSPI_INSTRUCTION_DTR_ENABLE;
+	cmd.AddressMode = HAL_OSPI_ADDRESS_8_LINES;
+	cmd.AddressSize = HAL_OSPI_ADDRESS_32_BITS;
+	cmd.AddressDtrMode = HAL_OSPI_ADDRESS_DTR_ENABLE;
+	cmd.AlternateBytesMode = HAL_OSPI_ALTERNATE_BYTES_NONE;
+	cmd.DataMode = HAL_OSPI_DATA_8_LINES;
+	cmd.DataDtrMode = HAL_OSPI_DATA_DTR_ENABLE;
+	cmd.DummyCycles = DUMMY_CLOCK_CYCLES_WRITE;
+	cmd.DQSMode = HAL_OSPI_DQS_ENABLE;
+	cmd.SIOOMode = HAL_OSPI_SIOO_INST_EVERY_CMD;
+
+	if (HAL_OSPI_Command(hospi, &cmd, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		return -EIO;
+	}
+
+	cmd.OperationType = HAL_OSPI_OPTYPE_READ_CFG;
+	cmd.Instruction = READ_CMD;
+	cmd.DummyCycles = DUMMY_CLOCK_CYCLES_READ;
+
+	if (HAL_OSPI_Command(hospi, &cmd, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		return -EIO;
+	}
+
+	mem_mapped_cfg.TimeOutActivation = HAL_OSPI_TIMEOUT_COUNTER_ENABLE;
+	mem_mapped_cfg.TimeOutPeriod = 0x34;
+
+	if (HAL_OSPI_MemoryMapped(hospi, &mem_mapped_cfg) != HAL_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int memc_stm32_ospi_psram_init(const struct device *dev)
+{
+	const struct memc_stm32_ospi_psram_config *dev_cfg = dev->config;
+	struct memc_stm32_ospi_psram_data *dev_data = dev->data;
+	OSPI_HandleTypeDef *hospi = &dev_data->hospi;
+	OSPIM_CfgTypeDef *ospim_cfg = &dev_data->ospim_cfg;
+	HAL_OSPI_DLYB_CfgTypeDef *dlyb_cfg = &dev_data->dlyb_cfg;
+	LL_DLYB_CfgTypeDef ll_dlyb_cfg, ll_dlyb_cfg_test;
+	uint32_t ahb_clock_freq;
+	uint32_t prescaler;
+	int ret;
+
+	ret = pinctrl_apply_state(dev_cfg->pcfg, PINCTRL_STATE_DEFAULT);
+	if (ret < 0) {
+		LOG_ERR("OSPI pinctrl setup failed (%d)", ret);
+		return ret;
+	}
+
+	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			     (clock_control_subsys_t)&dev_cfg->pclken) != 0) {
+		LOG_ERR("Could not enable OSPI clock");
+		return -EIO;
+	}
+
+	/* Alternate clock config for peripheral if any */
+#if DT_CLOCKS_HAS_NAME(STM32_OSPI_NODE, ospi_ker)
+	if (clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				    (clock_control_subsys_t)&dev_cfg->pclken_ker, NULL) != 0) {
+		LOG_ERR("Could not select OSPI domain clock");
+		return -EIO;
+	}
+	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				   (clock_control_subsys_t)&dev_cfg->pclken_ker,
+				   &ahb_clock_freq) < 0) {
+		LOG_ERR("Failed call clock_control_get_rate(pclken_ker)");
+		return -EIO;
+	}
+#else
+	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				   (clock_control_subsys_t)&dev_cfg->pclken, &ahb_clock_freq) < 0) {
+		return -EIO;
+	}
+#endif
+#if DT_CLOCKS_HAS_NAME(STM32_OSPI_NODE, ospi_mgr)
+	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			     (clock_control_subsys_t)&dev_cfg->pclken_mgr) != 0) {
+		LOG_ERR("Could not enable OSPI Manager clock");
+		return -EIO;
+	}
+#endif
+
+	LOG_DBG("OSPI AHB clock frequency: %d Hz", ahb_clock_freq);
+	LOG_DBG("OSPI max frequency: %d Hz", dev_cfg->max_frequency);
+
+	prescaler = STM32_OSPI_CLOCK_PRESCALER_MIN;
+	for (; prescaler <= STM32_OSPI_CLOCK_PRESCALER_MAX; prescaler++) {
+		uint32_t clk = STM32_OSPI_CLOCK_COMPUTE(ahb_clock_freq, prescaler);
+
+		if (clk <= dev_cfg->max_frequency) {
+			LOG_DBG("clk: %d, prescaler: %d", clk, prescaler);
+			break;
+		}
+	}
+
+	if (prescaler > STM32_OSPI_CLOCK_PRESCALER_MAX) {
+		LOG_ERR("OSPI could not find valid prescaler value");
+		return -EINVAL;
+	}
+
+	hospi->Init.ClockPrescaler = prescaler;
+
+	LOG_DBG("MSB set: %d", find_msb_set(dev_cfg->memory_size) - 1);
+	hospi->Init.DeviceSize = find_msb_set(dev_cfg->memory_size) - 1;
+
+	/* OSPI Init */
+	if (HAL_OSPI_Init(hospi) != HAL_OK) {
+		LOG_ERR("HAL_OSPI_Init(): <FAILED>");
+		return -EIO;
+	}
+
+	if (HAL_OSPIM_Config(hospi, ospim_cfg, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
+		LOG_ERR("HAL_OSPIM_Config(): <FAILED>");
+		return -EIO;
+	}
+
+	if (HAL_OSPI_DLYB_SetConfig(hospi, dlyb_cfg) != HAL_OK) {
+		LOG_ERR("HAL_OSPI_DLYB_SetConfig(): <FAILED>");
+		return -EIO;
+	}
+
+	if (HAL_OSPI_DLYB_GetClockPeriod(hospi, &ll_dlyb_cfg) != HAL_OK) {
+		LOG_ERR("HAL_OSPI_DLYB_GetClockPeriod(): <FAILED>");
+		return -EIO;
+	}
+
+	/* When DTR, PhaseSel is divided by 4 (emperic value) */
+	ll_dlyb_cfg.PhaseSel /= 4;
+	ll_dlyb_cfg_test = ll_dlyb_cfg;
+
+	HAL_OSPI_DLYB_SetConfig(hospi, &ll_dlyb_cfg);
+	HAL_OSPI_DLYB_GetConfig(hospi, &ll_dlyb_cfg);
+
+	if ((ll_dlyb_cfg.PhaseSel != ll_dlyb_cfg_test.PhaseSel) ||
+	    (ll_dlyb_cfg.Units != ll_dlyb_cfg_test.Units)) {
+		LOG_ERR("PhaseSel: <FAILED>");
+		return -EIO;
+	}
+
+	if (ap_memory_configure(hospi) != 0) {
+		LOG_ERR("ap_memory_configure(): <FAILED>");
+		return -EIO;
+	}
+	if (config_memory_mapped(dev) != 0) {
+		LOG_ERR("config_memory_mapped(): <FAILED>");
+		return -EIO;
+	}
+
+#ifdef CONFIG_SHARED_MULTI_HEAP
+	ret = shared_multi_heap_pool_init();
+	if (ret < 0) {
+		return ret;
+	}
+	ret = shared_multi_heap_add(&smh_psram, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+#endif
+
+	return 0;
+}
+
+PINCTRL_DT_DEFINE(STM32_OSPI_NODE);
+
+static struct memc_stm32_ospi_psram_config memc_stm32_ospi_config = {
+	.pclken = {.bus = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospix, bus),
+		   .enr = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospix, bits)},
+	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_OSPI_NODE),
+	.memory_size = DT_INST_PROP(0, size) / 8, /* In Bytes */
+	.max_frequency = DT_INST_PROP(0, max_frequency),
+#if DT_CLOCKS_HAS_NAME(STM32_OSPI_NODE, ospi_ker)
+	.pclken_ker = {.bus = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospi_ker, bus),
+		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospi_ker, bits)},
+#endif
+#if DT_CLOCKS_HAS_NAME(STM32_OSPI_NODE, ospi_mgr)
+	.pclken_mgr = {.bus = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospi_mgr, bus),
+		       .enr = DT_CLOCKS_CELL_BY_NAME(STM32_OSPI_NODE, ospi_mgr, bits)},
+#endif
+};
+
+static struct memc_stm32_ospi_psram_data memc_stm32_ospi_data = {
+	.hospi = {
+		.Instance = (OCTOSPI_TypeDef *)DT_REG_ADDR(STM32_OSPI_NODE),
+		.Init = {
+			.FifoThreshold = 1,
+			.DualQuad = HAL_OSPI_DUALQUAD_DISABLE,
+			.MemoryType = HAL_OSPI_MEMTYPE_APMEMORY,
+			.ChipSelectHighTime = 2,
+			.FreeRunningClock = HAL_OSPI_FREERUNCLK_DISABLE,
+			.ClockMode = HAL_OSPI_CLOCK_MODE_0,
+			.WrapSize = HAL_OSPI_WRAP_NOT_SUPPORTED,
+			.SampleShifting = HAL_OSPI_SAMPLE_SHIFTING_NONE,
+			.DelayHoldQuarterCycle = HAL_OSPI_DHQC_ENABLE,
+			.ChipSelectBoundary = 10,
+			.DelayBlockBypass = HAL_OSPI_DELAY_BLOCK_USED,
+			.MaxTran = 0,
+			.Refresh = 320,
+		},
+	},
+	.ospim_cfg = {
+		.ClkPort = 1,
+		.DQSPort = 1,
+		.NCSPort = 1,
+		.IOLowPort = HAL_OSPIM_IOPORT_1_LOW,
+		.IOHighPort = HAL_OSPIM_IOPORT_1_HIGH,
+		.Req2AckTime = 0,
+	},
+	.dlyb_cfg = {
+		.Units = 0,
+		.PhaseSel = 0,
+	},
+};
+
+DEVICE_DT_INST_DEFINE(0, &memc_stm32_ospi_psram_init, NULL, &memc_stm32_ospi_data,
+		      &memc_stm32_ospi_config, POST_KERNEL,
+		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);

--- a/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-ospi-psram.yaml
@@ -1,0 +1,149 @@
+# Copyright (c) 2025 ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
+# SPDX-License-Identifier: Apache-2.0
+
+title: STM32 OSPI PSRAM Controller
+
+description: |
+  STM32 OSPI PSRAM memory controller.
+  Provides a communication interface allowing the microcontroller
+  to communicate with an external PSRAM memory via the OSPI peripheral.
+  The PSRAM can be configured as memory mapped and allows read/write
+  operations like an internal device.
+
+compatible: "st,stm32-ospi-psram"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  size:
+    type: int
+    required: true
+    description: Memory size in bits
+
+  max-frequency:
+    type: int
+    required: true
+    description: Maximum clock frequency of device's OSPI interface in Hz
+
+  fixed-latency:
+    type: boolean
+    description: Read latency — fixed when set, variable otherwise.
+
+  drive-strength:
+    type: int
+    default: 0
+    description: |
+      Drive strength code:
+      - 0: Full
+      - 1: Half
+      - 2: 1/4
+      - 3: 1/8
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  read-latency:
+    type: int
+    default: 5
+    description: |
+      Read latency code
+      - 0: LCx2 3 / Fmax 66 MHz
+      - 1: LCx2 4 / Fmax 104 MHz
+      - 2: LCx2 5 / Fmax 133 MHz
+      - 3: LCx2 6 / Fmax 133 MHz
+      - 4: LCx2 7 / Fmax 133 MHz
+      - 5: LCx2 8 / Fmax 133 MHz
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+
+  write-latency:
+    type: int
+    default: 2
+    description: |
+      Write latency code:
+      - 0: LC 3 / Fmax 66 MHz
+      - 1: LC 4 / Fmax 104 MHz
+      - 2: LC 5 / Fmax 133 MHz
+      - 3: LC 6 / Fmax 133 MHz
+      - 4: LC 7 / Fmax 133 MHz
+      - 5: LC 8 / Fmax 133 MHz
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+
+  adaptive-refresh-rate:
+    type: int
+    default: 0
+    description: |
+      - 0: Fast Refresh
+      - 1: Enables Slow Refresh when temperature allows
+    enum:
+      - 0
+      - 1
+
+  pasr:
+    type: int
+    default: 0
+    description: |
+      Partial Array Self-Refresh coverage:
+      - 0: Full array
+      - 1: Bottom 1/2 array
+      - 2: Bottom 1/4 array
+      - 3: Bottom 1/8 array
+      - 4: None
+      - 5: Top 1/2 array
+      - 6: Top 1/4 array
+      - 7: Top 1/8 array
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+
+  rbx:
+    type: boolean
+    description: |
+      If not enabled, reads stay within page (row) boundary.
+      If enabled, allows reads cross page (row) boundary.
+
+  burst-length:
+    type: int
+    default: 1
+    description: |
+      Burst length:
+      0: 16 Byte/Word Wrap
+      1: 32 Byte/Word Wrap
+      2: 64 Byte/Word Wrap
+      3: 1K Word Wrap
+    enum:
+      - 0
+      - 1
+      - 2
+      - 3
+
+  burst-type-hybrid-wrap:
+    type: boolean
+    description: |
+      If not enabled, burst-length sets the burst address space in which the
+      device will continually wrap within.
+      If enabled, the device will burst through the initial wrapped burst length
+      once, then continue to burst incrementally up to maximum column address
+      (1K) before wrapping around within the entire column address space.

--- a/tests/drivers/memc/ram/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/memc/ram/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&sram1 {
+	status = "disabled";
+};

--- a/tests/drivers/memc/ram/src/main.c
+++ b/tests/drivers/memc/ram/src/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Teslabs Engineering S.L.
  * Copyright (c) 2022, Basalte bv
+ * Copyright (c) 2025, ZAL Zentrum für Angewandte Luftfahrtforschung GmbH
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,7 +11,12 @@
 #include <zephyr/ztest.h>
 
 /** Buffer size. */
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(psram))
+#define BUF_SIZE 524288U
+#else
 #define BUF_SIZE 64U
+#endif
+
 #define BUF_DEF(label) static uint32_t buf_##label[BUF_SIZE]			\
 	Z_GENERIC_SECTION(LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(label)))
 


### PR DESCRIPTION
## Add  STM32 OSPI PSRAM driver support in memory mapped mode

Current driver configuration based on `aps6408l` on **STM32U5xx** series

## Test application 1
https://github.com/mariopaja/hello_psram


**Custom U575 Board:**
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       23572 B         2 MB      1.12%
             RAM:        4864 B       768 KB      0.62%
           PSRAM:       2000 KB         8 MB     24.41%
        IDT_LIST:          0 GB        32 KB      0.00%
```

**b_u585i_iot02a:**
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       34680 B         2 MB      1.65%
             RAM:        6960 B       768 KB      0.89%
           PSRAM:       8000 KB         8 MB     97.66%
          EXTMEM:          0 GB        64 MB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
```

```
Hello STM32 OSPI PSRAM!
Verifying PSRAM Buffer size: 2048000 ...
PSRAM verification successful!
[00:00:00.000,000] <dbg> memc_stm32_ospi_psram: memc_stm32_ospi_psram_init: OSPI AHB clock frequency: 160000000 Hz
[00:00:00.000,000] <dbg> memc_stm32_ospi_psram: memc_stm32_ospi_psram_init: OSPI max frequency: 133000000 Hz
[00:00:00.000,000] <dbg> memc_stm32_ospi_psram: memc_stm32_ospi_psram_init: clk: 80000000, prescaler: 2
[00:00:00.000,000] <dbg> memc_stm32_ospi_psram: memc_stm32_ospi_psram_init: MSB set: 23
*** Booting Zephyr OS build v4.2.0-rc1-130-gd97aff3f8f32 ***
```

## Test application 2
`tests/drivers/memc/ram`

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       36384 B         2 MB      1.73%
             RAM:        5984 B       768 KB      0.76%
           PSRAM:          8 MB         8 MB    100.00%
          EXTMEM:          0 GB        64 MB      0.00%
        IDT_LIST:          0 GB        32 KB      0.00%
```

```
*** Booting Zephyr OS build v4.2.0-3146-gea283133abd3 ***
Running TESTSUITE test_ram
===================================================================
START - test_psram
 PASS - test_psram in 0.138 seconds
===================================================================
START - test_ram0
 SKIP - test_ram0 in 0.001 seconds
===================================================================
START - test_sdram1
 SKIP - test_sdram1 in 0.001 seconds
===================================================================
START - test_sdram2
 SKIP - test_sdram2 in 0.001 seconds
===================================================================
START - test_sram1
 SKIP - test_sram1 in 0.001 seconds
===================================================================
START - test_sram2
 SKIP - test_sram2 in 0.001 seconds
===================================================================
TESTSUITE test_ram succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [test_ram]: pass = 1, fail = 0, skip = 5, total = 6 duration = 0.143 seconds
 - PASS - [test_ram.test_psram] duration = 0.138 seconds
 - SKIP - [test_ram.test_ram0] duration = 0.001 seconds
 - SKIP - [test_ram.test_sdram1] duration = 0.001 seconds
 - SKIP - [test_ram.test_sdram2] duration = 0.001 seconds
 - SKIP - [test_ram.test_sram1] duration = 0.001 seconds
 - SKIP - [test_ram.test_sram2] duration = 0.001 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

