### PR TITLE
cmake: Fix support for "ninja flash"

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -196,7 +196,7 @@ foreach(target flash debug debugserver attach rtt)
         -DDEPENDENCIES="$<TARGET_PROPERTY:${target},MANUALLY_ADDED_DEPENDENCIES>"
         -P ${CMAKE_CURRENT_LIST_DIR}/check_runner_dependencies.cmake
       COMMAND
-        ${CMAKE_COMMAND} -E env
+        ${CMAKE_COMMAND} -E env ZEPHYR_BASE=${ZEPHYR_BASE}
         ${WEST}
         ${RUNNER_VERBOSE}
         ${target}


### PR DESCRIPTION
By default west looks at the parents directory to find Zephyr base directory. However, in the case the build directory is not a subdirectory of zephyr base and the user run "ninja flash" directly from the build directory, west fails to detect Zephyr base.

So, this patch explicitly add ZEPHYR_BASE in the environment.

Implementation notes:
  * ZEPHYR_BASE is already set for ninja menuconfig in cmake/modules/kconfig.cmake:201
  * ZEPHYR_BASE seems better than --zephyr-base since the environment in inherited
  * BTW, --zephyr-base seems to not have any impact and seems broken