### PR TITLE
soc nrf54lm20a: Fix entropy source

### DIFF
--- a/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
@@ -17,7 +17,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
-		zephyr,entropy = &prng;
+		zephyr,entropy = &rng;
 	};
 
 	soc {
@@ -31,9 +31,9 @@ nvic: &cpuapp_nvic {};
 		status = "disabled";
 	};
 
-	prng: prng {
-		compatible = "nordic,entropy-prng";
+	rng: rng {
 		status = "okay";
+		compatible = "nordic,nrf-cracen-ctrdrbg";
 	};
 };
 


### PR DESCRIPTION
nordic,entropy-prng does not exist in Zephyr (it is part of NCS) but we have in both the nordic,nrf-cracen-ctrdrbg which is an actual source of true entropy. Let's use that instead.

Fixes failures to build targeting the nrf54lm20dk any test/sample which uses the entropy driver.

The failure can be reproduced with for ex.
```
cmake -GNinja -DBOARD=nrf54lm20dk/nrf54lm20a/cpuapp ../tests/drivers/entropy/api/ && ninja
...
arm-zephyr-eabi/bin/ld.bfd: app/libapp.a(main.c.obj): in function `random_entropy':
zephyr/tests/drivers/entropy/api/src/main.c:65: undefined reference to `__device_dts_ord_4'
```
