### PR TITLE
kernel: heap: Fix free_bytes calculation

### DIFF
--- a/lib/heap/heap.h
+++ b/lib/heap/heap.h
@@ -255,7 +255,7 @@ static inline chunksz_t min_chunk_size(struct z_heap *h)
 
 static inline size_t chunksz_to_bytes(struct z_heap *h, chunksz_t chunksz_in)
 {
-	return chunksz_in * CHUNK_UNIT - chunk_header_bytes(h);
+	return chunksz_in * CHUNK_UNIT;
 }
 
 static inline int bucket_idx(struct z_heap *h, chunksz_t sz)

--- a/samples/basic/sys_heap/sample.yaml
+++ b/samples/basic/sys_heap/sample.yaml
@@ -9,8 +9,8 @@ common:
     type: multi_line
     ordered: true
     regex:
-      - ".*allocated 15.,.*"
-      - ".*allocated 10.,.*"
+      - ".*allocated 16.,.*"
+      - ".*allocated 1..,.*"
       - ".*allocated 0, free ..., max allocated ..., heap size 256.*"
 tests:
   sample.basic.sys_heap:


### PR DESCRIPTION
This PR fixes free_bytes size calculation in the heap API.

Fixes: #92391.