### PR TITLE
boards/native: Remove NATIVE_SIM_NATIVE_POSIX_COMPAT kconfig option

### DIFF
--- a/boards/native/native_sim/Kconfig
+++ b/boards/native/native_sim/Kconfig
@@ -8,7 +8,6 @@ config BOARD_NATIVE_SIM
 	select NATIVE_LIBRARY
 	select NATIVE_SIM_TIMER
 	select 64BIT if BOARD_NATIVE_SIM_NATIVE_64
-	imply BOARD_NATIVE_POSIX if NATIVE_SIM_NATIVE_POSIX_COMPAT
 	help
 	  Native simulator (Single Core)
 	  Will produce a console Linux process which can be executed natively.
@@ -16,16 +15,6 @@ config BOARD_NATIVE_SIM
 if BOARD_NATIVE_SIM
 
 comment "Native Simular (Single Core) options"
-
-config NATIVE_SIM_NATIVE_POSIX_COMPAT
-	bool "Pretend to be a native_posix board"
-	select DEPRECATED
-	help
-	  When this option is set the native_sim board will pretend to be
-	  a native_posix board from kconfig point of view, to allow using it directly with
-	  code which was meant for the native_posix board and checks for the macro
-	  CONFIG_BOARD_NATIVE_POSIX, or requires other kconfig options which depend on it.
-	  This option is deprecated and will be removed in Zephyr v4.3
 
 config NATIVE_SIM_SLOWDOWN_TO_REAL_TIME
 	bool "Slow down execution to real time"
@@ -38,10 +27,6 @@ config NATIVE_SIM_SLOWDOWN_TO_REAL_TIME
 	  Note that this only decouples simulated time from real/wall time. In either
 	  case the zephyr kernel and application cannot tell the difference unless they
 	  interact with some other driver/device which runs at real time.
-
-# This option definition exists only to enable NATIVE_SIM_NATIVE_POSIX_COMPAT
-config BOARD_NATIVE_POSIX
-	bool
 
 config NATIVE_POSIX_SLOWDOWN_TO_REAL_TIME
 	bool "Slow down execution to real time (native_posix compat)"

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -231,7 +231,7 @@ endif # USB_DC_NUMAKER
 config USB_NATIVE_POSIX
 	bool "Native Posix USB Device Controller Driver"
 	depends on ARCH_POSIX && EXTERNAL_LIBC
-	default y if BOARD_NATIVE_SIM || BOARD_NATIVE_POSIX
+	default y if BOARD_NATIVE_SIM
 	help
 	  Native Posix USB Device Controller Driver.
 


### PR DESCRIPTION
This option was introduced together with native_sim in 3.5 to ease
the transition from native_posix, and was deprecated in 4.1.

Let's remove it now.

Also let's remove one straggler kconfig option which depended on the old BOARD_NATIVE_POSIX option.

This is following the native_posix deprecation plan #76895