### PR TITLE
IPv6 packet queuing while waiting NA

### DIFF
--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -176,6 +176,14 @@ config NET_IPV6_DAD
 	  The value depends on your network needs. DAD should normally
 	  be active.
 
+config NET_IPV6_NS_TIMEOUT
+	int "Timeout of Neighbor Solicitation messaging (in ms)"
+	depends on NET_IPV6_NBR_CACHE
+	default 1000
+	help
+	  The timeout in milliseconds between attempts to send a Neighbor
+	  Solicitation message.
+
 config NET_IPV6_RS_TIMEOUT
 	int "Timeout of Router Solicitation messaging"
 	depends on NET_IPV6_ND

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -85,7 +85,7 @@ const char *net_ipv6_nbr_state2str(enum net_ipv6_nbr_state state);
  */
 struct net_ipv6_nbr_data {
 	/** Any pending packet waiting ND to finish. */
-	struct net_pkt *pending;
+	struct k_fifo pending_queue;
 
 	/** IPv6 address. */
 	struct in6_addr addr;
@@ -109,7 +109,10 @@ struct net_ipv6_nbr_data {
 	uint8_t ns_count;
 
 	/** Is the neighbor a router */
-	bool is_router;
+	bool is_router : 1;
+
+	/** Have we initialized the pending queue */
+	bool pending_queue_initialized : 1;
 
 #if defined(CONFIG_NET_IPV6_NBR_CACHE) || defined(CONFIG_NET_IPV6_ND)
 	/** Stale counter used to removed oldest nbr in STALE state,

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -340,7 +340,11 @@ bool net_ipv6_nbr_rm(struct net_if *iface, struct in6_addr *addr)
 	return true;
 }
 
+#if defined(CONFIG_NET_IPV6_NBR_CACHE)
+#define NS_REPLY_TIMEOUT CONFIG_NET_IPV6_NS_TIMEOUT
+#else
 #define NS_REPLY_TIMEOUT (1 * MSEC_PER_SEC)
+#endif /* CONFIG_NET_IPV6_NBR_CACHE */
 
 static void ipv6_ns_reply_timeout(struct k_work *work)
 {

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -279,11 +279,17 @@ static struct net_nbr *nbr_lookup(struct net_nbr_table *table,
 
 static inline void nbr_clear_ns_pending(struct net_ipv6_nbr_data *data)
 {
+	struct net_pkt *pkt;
+
 	data->send_ns = 0;
 
-	if (data->pending) {
-		net_pkt_unref(data->pending);
-		data->pending = NULL;
+	while (!k_fifo_is_empty(&data->pending_queue)) {
+		pkt = k_fifo_get(&data->pending_queue, K_FOREVER);
+
+		NET_DBG("Releasing pending pkt %p (ref %ld)",
+			pkt, atomic_get(&pkt->atomic_ref) - 1);
+
+		net_pkt_unref(pkt);
 	}
 }
 
@@ -341,6 +347,7 @@ static void ipv6_ns_reply_timeout(struct k_work *work)
 	int64_t current = k_uptime_get();
 	struct net_nbr *nbr = NULL;
 	struct net_ipv6_nbr_data *data;
+	struct net_pkt *pending;
 	int i;
 
 	ARG_UNUSED(work);
@@ -379,26 +386,68 @@ static void ipv6_ns_reply_timeout(struct k_work *work)
 		data->send_ns = 0;
 
 		/* We did not receive reply to a sent NS */
-		if (!data->pending) {
+		if (k_fifo_is_empty(&net_ipv6_nbr_data(nbr)->pending_queue)) {
 			/* Silently return, this is not an error as the work
 			 * cannot be cancelled in certain cases.
 			 */
 			continue;
 		}
 
-		NET_DBG("NS nbr %p pending %p timeout to %s", nbr,
-			data->pending,
-			net_sprint_ipv6_addr(&NET_IPV6_HDR(data->pending)->dst));
+		while (!k_fifo_is_empty(&net_ipv6_nbr_data(nbr)->pending_queue)) {
+			enum net_verdict verdict;
 
-		/* To unref when pending variable was set */
-		net_pkt_unref(data->pending);
+			/* Remove the first pending packet from the queue
+			 * and unref it. If there are more pending packets,
+			 * they will be processed in the next round.
+			 */
+			pending = k_fifo_get(&net_ipv6_nbr_data(nbr)->pending_queue,
+					     K_FOREVER);
 
-		/* To unref the original pkt allocation */
-		net_pkt_unref(data->pending);
+			NET_DBG("NS nbr %p pending %p timeout to %s", nbr, pending,
+				net_sprint_ipv6_addr(&NET_IPV6_HDR(pending)->dst));
 
-		data->pending = NULL;
+			NET_DBG("Dropping pending pkt %p", pending);
 
-		net_nbr_unref(nbr);
+			/* This gets rid of the reference that was
+			 * added when the packet was put into the pending queue.
+			 */
+			net_pkt_unref(pending);
+
+			/* To unref the original pkt allocation */
+			net_pkt_unref(pending);
+
+			/* If there are no more pending packets, we can
+			 * unref the neighbor.
+			 */
+			if (k_fifo_is_empty(&net_ipv6_nbr_data(nbr)->pending_queue)) {
+				net_nbr_unref(nbr);
+
+				NET_DBG("Dropping neighbor %p", nbr);
+				break;
+			}
+
+			/* If there are more pending packets, we need to
+			 * reschedule the work so that we can process them and
+			 * send a new NS.
+			 */
+			pending = k_fifo_get(&net_ipv6_nbr_data(nbr)->pending_queue,
+					     K_FOREVER);
+
+			verdict = net_ipv6_prepare_for_send(pending);
+			if (verdict == NET_DROP) {
+				/* The ref when added to the pending queue */
+				net_pkt_unref(pending);
+
+				/* To unref the original pkt allocation */
+				net_pkt_unref(pending);
+
+				/* Get next packet from the list */
+				continue;
+			}
+
+			/* Now wait timeout again */
+			break;
+		}
 	}
 
 	net_ipv6_nbr_unlock();
@@ -414,8 +463,13 @@ static void nbr_init(struct net_nbr *nbr, struct net_if *iface,
 	net_ipaddr_copy(&net_ipv6_nbr_data(nbr)->addr, addr);
 	ipv6_nbr_set_state(nbr, state);
 	net_ipv6_nbr_data(nbr)->is_router = is_router;
-	net_ipv6_nbr_data(nbr)->pending = NULL;
 	net_ipv6_nbr_data(nbr)->send_ns = 0;
+
+	if (!net_ipv6_nbr_data(nbr)->pending_queue_initialized) {
+		/* Initialize the pending queue for this neighbor */
+		k_fifo_init(&net_ipv6_nbr_data(nbr)->pending_queue);
+		net_ipv6_nbr_data(nbr)->pending_queue_initialized = true;
+	}
 
 #if defined(CONFIG_NET_IPV6_ND)
 	net_ipv6_nbr_data(nbr)->reachable = 0;
@@ -1793,15 +1847,18 @@ static inline bool handle_na_neighbor(struct net_pkt *pkt,
 
 send_pending:
 	/* Next send any pending messages to the peer. */
-	pending = net_ipv6_nbr_data(nbr)->pending;
-	if (pending) {
+	while (!k_fifo_is_empty(&net_ipv6_nbr_data(nbr)->pending_queue)) {
+		pending = k_fifo_get(&net_ipv6_nbr_data(nbr)->pending_queue,
+				     K_FOREVER);
+
 		NET_DBG("Sending pending %p to lladdr %s", pending,
 			net_sprint_ll_addr(cached_lladdr->addr, cached_lladdr->len));
 
 		if (net_send_data(pending) < 0) {
 			nbr_clear_ns_pending(net_ipv6_nbr_data(nbr));
-		} else {
-			net_ipv6_nbr_data(nbr)->pending = NULL;
+
+			NET_DBG("Cannot send pkt %p, clearing pending queue", pending);
+			break;
 		}
 
 		net_pkt_unref(pending);
@@ -2030,35 +2087,49 @@ int net_ipv6_send_ns(struct net_if *iface,
 		goto drop;
 	}
 
-	if (pending) {
-		if (!net_ipv6_nbr_data(nbr)->pending) {
-			net_ipv6_nbr_data(nbr)->pending = net_pkt_ref(pending);
+	if (pending != NULL) {
+		if (k_fifo_is_empty(&net_ipv6_nbr_data(nbr)->pending_queue)) {
+			k_fifo_put(&net_ipv6_nbr_data(nbr)->pending_queue, pending);
+			pending = net_pkt_ref(pending);
+
+			NET_DBG("Setting timeout %d for NS", NS_REPLY_TIMEOUT);
+
+			net_ipv6_nbr_data(nbr)->send_ns = k_uptime_get();
+
+			/* Let's start the timer if necessary */
+			if (!k_work_delayable_remaining_get(&ipv6_ns_reply_timer)) {
+				k_work_reschedule(&ipv6_ns_reply_timer,
+						  K_MSEC(NS_REPLY_TIMEOUT));
+			}
 		} else {
-			NET_DBG("Packet %p already pending for "
-				"operation. Discarding pending %p and pkt %p",
-				net_ipv6_nbr_data(nbr)->pending, pending, pkt);
+			/* If there is already a pending packet
+			 * for this neighbor, we do not send the NS but just
+			 * add the packet to the pending queue.
+			 */
+			if (k_queue_unique_append(&net_ipv6_nbr_data(nbr)->pending_queue._queue,
+						  pending)) {
+				NET_DBG("Adding pending packet %p for NS to nbr %p",
+					pending, nbr);
+
+				pending = net_pkt_ref(pending);
+			} else {
+				NET_DBG("Packet %p already pending for "
+					"operation for nbr %p.",
+					pending, nbr);
+			}
+
+			/* Let the system timeout and then send the NS again */
 			net_ipv6_nbr_unlock();
-			goto drop;
-		}
-
-		NET_DBG("Setting timeout %d for NS", NS_REPLY_TIMEOUT);
-
-		net_ipv6_nbr_data(nbr)->send_ns = k_uptime_get();
-
-		/* Let's start the timer if necessary */
-		if (!k_work_delayable_remaining_get(&ipv6_ns_reply_timer)) {
-			k_work_reschedule(&ipv6_ns_reply_timer,
-					  K_MSEC(NS_REPLY_TIMEOUT));
+			return 0;
 		}
 	}
 
-	dbg_addr_sent_tgt("Neighbor Solicitation", src, dst, &ns_hdr->tgt,
-			  pkt);
+	dbg_addr_sent_tgt("Neighbor Solicitation", src, dst, &ns_hdr->tgt, pkt);
 
 	if (net_send_data(pkt) < 0) {
 		NET_DBG("Cannot send NS %p (pending %p)", pkt, pending);
 
-		if (pending) {
+		if (pending != NULL) {
 			nbr_clear_ns_pending(net_ipv6_nbr_data(nbr));
 			pending = NULL;
 		}
@@ -2075,7 +2146,7 @@ int net_ipv6_send_ns(struct net_if *iface,
 	return 0;
 
 drop:
-	if (pending) {
+	if (pending != NULL) {
 		net_pkt_unref(pending);
 	}
 
@@ -2734,17 +2805,26 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 	}
 
 	net_ipv6_nbr_lock();
-	if (nbr && net_ipv6_nbr_data(nbr)->pending) {
-		NET_DBG("Sending pending pkt %p to %s",
-			net_ipv6_nbr_data(nbr)->pending,
-			net_sprint_ipv6_addr(&NET_IPV6_HDR(net_ipv6_nbr_data(nbr)->pending)->dst));
 
-		if (net_send_data(net_ipv6_nbr_data(nbr)->pending) < 0) {
-			net_pkt_unref(net_ipv6_nbr_data(nbr)->pending);
+	if (nbr != NULL) {
+		while (!k_fifo_is_empty(&net_ipv6_nbr_data(nbr)->pending_queue)) {
+			struct net_pkt *pending;
+
+			pending = k_fifo_get(&net_ipv6_nbr_data(nbr)->pending_queue,
+					     K_FOREVER);
+
+			NET_DBG("Sending pending pkt %p to %s",
+				pending,
+				net_sprint_ipv6_addr(&NET_IPV6_HDR(pending)->dst));
+
+			if (net_send_data(pending) < 0) {
+				net_pkt_unref(pending);
+			}
 		}
 
 		nbr_clear_ns_pending(net_ipv6_nbr_data(nbr));
 	}
+
 	net_ipv6_nbr_unlock();
 
 	/* Cancel the RS timer on iface */

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -2948,6 +2948,26 @@ static struct net_icmp_ctx ra_ctx;
 static struct net_icmp_ctx ptb_ctx;
 #endif /* CONFIG_NET_IPV6_PMTU */
 
+#if defined(CONFIG_NET_TEST) && defined(CONFIG_NET_IPV6_NBR_CACHE)
+/* Check if the NS reply timer is pending and cancel it if so.
+ * Returns 1 if the timer was cancelled, 0 if it was not pending.
+ * This is only used by the tests to verify that we are not leaking
+ * any net_pkt/buf.
+ */
+int net_ipv6_nbr_test_cancel(void)
+{
+	if (k_work_delayable_is_pending(&ipv6_ns_reply_timer)) {
+		NET_DBG("Cancelling NS reply timer");
+
+		(void)k_work_cancel_delayable(&ipv6_ns_reply_timer);
+
+		return 1;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_NET_TEST */
+
 void net_ipv6_nbr_init(void)
 {
 	int ret;

--- a/tests/net/ipv6/prj.conf
+++ b/tests/net/ipv6/prj.conf
@@ -39,3 +39,6 @@ CONFIG_NET_RX_STACK_SIZE=1700
 
 # Make sure mbedTLS has access to heap
 CONFIG_MBEDTLS_ENABLE_HEAP=y
+
+# Track net_buf usage
+CONFIG_NET_BUF_POOL_USAGE=y

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -766,11 +766,11 @@ static void expect_nd_ns(struct net_pkt *pkt, void *user_data)
 
 ZTEST(net_ipv6, test_send_neighbor_discovery)
 {
-	struct test_nd_context ctx = {
+	static struct test_nd_context ctx = {
 		.exp_ns_addr = &test_router_addr,
 		.reply = true
 	};
-	struct test_ns_handler handler = {
+	static struct test_ns_handler handler = {
 		.fn = expect_nd_ns,
 		.user_data = &ctx
 	};
@@ -972,10 +972,10 @@ static void expect_dad_ns(struct net_pkt *pkt, void *user_data)
 static void verify_rs_on_iface_event(void (*action)(void))
 {
 	struct net_if_router *router;
-	struct test_dad_context ctx = {
+	static struct test_dad_context ctx = {
 		.exp_dad_addr = &test_ra_autoconf_addr
 	};
-	struct test_ns_handler handler = {
+	static struct test_ns_handler handler = {
 		.fn = expect_dad_ns,
 		.user_data = &ctx
 	};
@@ -1485,10 +1485,11 @@ ZTEST(net_ipv6, test_dad_timeout)
  */
 static void verify_dad_on_static_addr_on_iface_event(void (*action)(void))
 {
-	struct test_dad_context ctx = {
+	static struct test_dad_context ctx = {
 		.exp_dad_addr = &my_addr
 	};
-	struct test_ns_handler handler = {
+
+	static struct test_ns_handler handler = {
 		.fn = expect_dad_ns,
 		.user_data = &ctx
 	};
@@ -1523,11 +1524,11 @@ ZTEST(net_ipv6, test_dad_on_static_addr_after_carrier_toggle)
  */
 static void verify_dad_on_ll_addr_on_iface_event(void (*action)(void))
 {
-	struct in6_addr link_local_addr;
-	struct test_dad_context ctx = {
+	static struct in6_addr link_local_addr;
+	static struct test_dad_context ctx = {
 		.exp_dad_addr = &link_local_addr
 	};
-	struct test_ns_handler handler = {
+	static struct test_ns_handler handler = {
 		.fn = expect_dad_ns,
 		.user_data = &ctx
 	};
@@ -1562,13 +1563,13 @@ ZTEST(net_ipv6, test_dad_on_ll_addr_after_carrier_toggle)
 /* Verify that in case of DAD conflict, address is not used on the interface. */
 ZTEST(net_ipv6, test_dad_conflict)
 {
-	struct in6_addr addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+	static struct in6_addr addr = { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
 				     0, 0, 0, 0, 0, 0, 0x99, 0x4 } } };
-	struct test_dad_context ctx = {
+	static struct test_dad_context ctx = {
 		.exp_dad_addr = &addr,
 		.reply = true
 	};
-	struct test_ns_handler handler = {
+	static struct test_ns_handler handler = {
 		.fn = expect_dad_ns,
 		.user_data = &ctx
 	};

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -173,9 +173,11 @@ static struct k_sem wait_data;
 static bool recv_cb_called;
 struct net_if_addr *ifaddr_record;
 static struct test_ns_handler *ns_handler;
+static int pkt_num;
 
 #define WAIT_TIME 250
-#define WAIT_TIME_LONG MSEC_PER_SEC
+#define WAIT_TIME_LONG CONFIG_NET_IPV6_NS_TIMEOUT
+#define WAIT_TIME_NS_TIMEOUT (WAIT_TIME_LONG + WAIT_TIME)
 #define SENDING 93244
 #define MY_PORT 1969
 #define PEER_PORT 16233
@@ -336,6 +338,8 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	}
 
 	icmp = get_icmp_hdr(pkt);
+
+	pkt_num++;
 
 	/* Reply with RA message */
 	if (icmp->type == NET_ICMPV6_RS) {
@@ -764,6 +768,8 @@ static void expect_nd_ns(struct net_pkt *pkt, void *user_data)
 	}
 }
 
+extern int net_ipv6_nbr_test_cancel(void);
+
 ZTEST(net_ipv6, test_send_neighbor_discovery)
 {
 	static struct test_nd_context ctx = {
@@ -776,17 +782,37 @@ ZTEST(net_ipv6, test_send_neighbor_discovery)
 	};
 	enum net_verdict verdict;
 	struct net_nbr *nbr;
+	struct k_mem_slab *tx;
+	struct net_buf_pool *tx_data;
+	int avail_buf_count;
+	int avail_pkt_count;
+	int ret;
+
+	net_pkt_get_info(NULL, &tx, NULL, &tx_data);
 
 	k_sem_init(&ctx.wait_ns, 0, 1);
 	ns_handler = &handler;
 
 	(void)net_ipv6_nbr_rm(TEST_NET_IF, &test_router_addr);
 
+	/* Make sure we can queue two packets */
+	pkt_num = 0;
+
+	avail_buf_count = atomic_get(&tx_data->avail_count);
+	avail_pkt_count = k_mem_slab_num_free_get(tx);
+
 	verdict = send_msg(&my_addr, &test_router_addr);
 	zassert_equal(verdict, NET_OK, "Packet was dropped (%d)", verdict);
+
+	/* Second attempt should be queued and give no NS. */
+	verdict = send_msg(&my_addr, &test_router_addr);
+	zassert_equal(verdict, NET_OK, "Packet was dropped (%d)", verdict);
+
+	/* At this point we should have sent one NS and queued one packet. */
+	zassert_equal(pkt_num, 1, "Unexpected number of packets sent (%d)", pkt_num);
+
 	zassert_ok(k_sem_take(&ctx.wait_ns, K_MSEC(WAIT_TIME)),
 		   "Timeout while waiting for expected NS");
-
 	k_sleep(K_MSEC(10));
 
 	/* Neighbor should be here now. */
@@ -795,11 +821,77 @@ ZTEST(net_ipv6, test_send_neighbor_discovery)
 	zassert_equal(net_ipv6_nbr_data(nbr)->state, NET_IPV6_NBR_STATE_REACHABLE,
 		      "Neighbor should be reachable at this point.");
 
-	/* Second attempt (neighbor valid) should give no NS. */
+	/* Packet count should now be 3, one for the first NS and two
+	 * for the queued packets.
+	 */
+	zassert_equal(pkt_num, 3, "Unexpected number of packets sent (%d)", pkt_num);
+
+	/* Third attempt (neighbor valid) should give no NS. */
 	verdict = send_msg(&my_addr, &test_router_addr);
 	zassert_equal(verdict, NET_OK, "Packet was dropped (%d)", verdict);
 	zassert_equal(k_sem_take(&ctx.wait_ns, K_MSEC(10)), -EAGAIN,
 		      "Should not get NS");
+
+	/* Packet count should be 4 as we sent one more packet. */
+	zassert_equal(pkt_num, 4, "Unexpected number of packets sent (%d)", pkt_num);
+
+	/* If there are anything pending by the NS reply timer, then
+	 * then 1 is returned and we can update the buffer and packet
+	 * counts.
+	 */
+	ret = net_ipv6_nbr_test_cancel();
+	avail_pkt_count -= ret;
+	avail_buf_count -= ret;
+
+	zassert_equal(k_mem_slab_num_free_get(tx), avail_pkt_count,
+		      "Unexpected tx packet pool free count (%d vs %d)",
+		      k_mem_slab_num_free_get(tx), avail_pkt_count);
+
+	zassert_equal(atomic_get(&tx_data->avail_count), avail_buf_count,
+		      "Unexpected tx data pool available count (%d vs %d)",
+		      atomic_get(&tx_data->avail_count), avail_buf_count);
+}
+
+ZTEST(net_ipv6, test_send_neighbor_discovery_timeout)
+{
+	static struct test_nd_context ctx = {
+		.exp_ns_addr = &test_router_addr,
+		.reply = true
+	};
+	enum net_verdict verdict;
+	struct net_nbr *nbr;
+
+	k_sem_init(&ctx.wait_ns, 0, 1);
+
+	(void)net_ipv6_nbr_rm(TEST_NET_IF, &test_router_addr);
+
+	/* Make sure we can queue two packets */
+	pkt_num = 0;
+
+	verdict = send_msg(&my_addr, &test_router_addr);
+	zassert_equal(verdict, NET_OK, "Packet was dropped (%d)", verdict);
+
+	/* Second attempt should be queued and give no NS. */
+	verdict = send_msg(&my_addr, &test_router_addr);
+	zassert_equal(verdict, NET_OK, "Packet was dropped (%d)", verdict);
+
+	/* At this point we should have sent one NS and queued one packet. */
+	zassert_equal(pkt_num, 1, "Unexpected number of packets sent (%d)", pkt_num);
+
+	k_sleep(K_MSEC(10));
+
+	zassert_not_ok(k_sem_take(&ctx.wait_ns, K_MSEC(WAIT_TIME_NS_TIMEOUT)),
+		       "Timeout while waiting for expected NS");
+
+	nbr = net_ipv6_nbr_lookup(TEST_NET_IF, &test_router_addr);
+	zassert_not_null(nbr, "Neighbor not found.");
+
+	/* Packet count should be 2, one for the first NS and second for the
+	 * timeouted NS packet.
+	 */
+	zassert_equal(pkt_num, 2, "Unexpected number of packets sent (%d)", pkt_num);
+
+	(void)net_ipv6_nbr_rm(TEST_NET_IF, &test_router_addr);
 }
 
 /**


### PR DESCRIPTION
Allow system to queue packets while waiting answer to sent IPv6 neighbor solicitation message.

If the NS timeouts, the PR drops the first packet from the queue list and tries to send the next one. I am not sure if this is a proper thing here or should we just discard all the queued packets in this case. This is probably not very common scenario.

Fixes #92303 