### PR TITLE
cmake: flash: add support for using a custom flash command

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -186,7 +186,11 @@ foreach(target flash debug debugserver attach rtt)
     set(RUNNER_VERBOSE)
   endif()
 
-  if(WEST)
+  if(NOT FLASH_COMMAND)
+      set(FLASH_COMMAND ${WEST})
+  endif()
+
+  if(FLASH_COMMAND)
     add_custom_target(${target}
       # This script will print an error message and fail if <target> has added
       # dependencies. This is done using dedicated CMake script, as
@@ -197,7 +201,7 @@ foreach(target flash debug debugserver attach rtt)
         -P ${CMAKE_CURRENT_LIST_DIR}/check_runner_dependencies.cmake
       COMMAND
         ${CMAKE_COMMAND} -E env ZEPHYR_BASE=${ZEPHYR_BASE}
-        ${WEST}
+        ${FLASH_COMMAND}
         ${RUNNER_VERBOSE}
         ${target}
       WORKING_DIRECTORY
@@ -208,9 +212,11 @@ foreach(target flash debug debugserver attach rtt)
     )
   else()
     add_custom_target(${target}
-      COMMAND ${CMAKE_COMMAND} -E echo \"West was not found in path. To support
-          '${CMAKE_MAKE_PROGRAM} ${target}', please create a west workspace.\"
+      COMMAND ${CMAKE_COMMAND} -E echo \"West was not found in path and no
+          FLASH_COMMAND set. To support '${CMAKE_MAKE_PROGRAM} ${target}',
+          please create a west workspace or specify a custom flashing script
+          path in FLASH_COMMAND.\"
       USES_TERMINAL
       )
-  endif(WEST)
+  endif(FLASH_COMMAND)
 endforeach()

--- a/doc/develop/west/without-west.rst
+++ b/doc/develop/west/without-west.rst
@@ -79,12 +79,26 @@ Flashing and Debugging
 ----------------------
 
 Running build system targets like ``ninja flash``, ``ninja debug``,
-etc. is just a call to the corresponding :ref:`west command
-<west-build-flash-debug>`. For example, ``ninja flash`` calls ``west
-flash``\ [#wbninja]_. If you don't have west installed on your system, running
-those targets will fail. You can of course still flash and debug using
-any :ref:`flash-debug-host-tools` which work for your board (and which those
-west commands wrap).
+etc. by default is just a call to the corresponding :ref:`west command
+<west-build-flash-debug>`. For example, ``ninja flash`` calls ``west flash``\
+[#wbninja]_. If you don't have west installed on your system, running those
+targets will fail. You can of course still flash and debug using any
+:ref:`flash-debug-host-tools` which work for your board (and which those west
+commands wrap).
+
+Alternatively, the build system can be configured to call a custom script
+instead of ``west`` to handle targets such as ``flash`` and ``debug``. This can
+be done by setting the CMake ``FLASH_COMMAND`` variable to point to a custom
+script. The script is going to run from the build directory and will be called
+with the target name as its only argument, similarly to how ``west`` would be
+invoked.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :tool: cmake
+   :goals: flash
+   :gen-args: -DFLASH_COMMAND=/path/to/custom/flash/script
+   :compact:
 
 If you want to use these build system targets but do not want to
 install west on your system using ``pip``, it is possible to do so


### PR DESCRIPTION
Hi, playing with twister device testing, turns out it can operate in two ways, unless I miss something:
- default: flash using the `cmake flash` target, which uses `west`, or
- ``--west-flash``: flash using `west`, which uses, well, `west`

The rest of twister does not really require `west` and the `flash` cmake target does not really depend on anything west specific besides calling it and setting `runners.yaml`.

Adding an option to the generated flash (and friends) command(s) so that one could specify a custom script to run twister with device testing without having to rely on west for programming.

Default behavior is unchanged.

---

The "flash" (and other flash related) cmake targets are currently used by twister for device testing, and right now just look for the west command or fail. Add an option for specifying an external FLASH_COMMAND that gets called instead of west. This command can takes the same targets as west and can use the same files as west (runners.yaml or build_info.yml) to decide what to do.

This allows using twister for device testing without having to depend on west.