### PR TITLE
stm32 : power_mgmt : u0 : update dts property and add overlay for  blinky_pm test 

### DIFF
--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -134,6 +134,12 @@
 	};
 };
 
+stm32_lp_tick_source: &lptim2 {
+	clocks = <&rcc STM32_CLOCK(APB1, 30)>,
+		<&rcc STM32_SRC_LSI LPTIM2_SEL(1)>;
+	status = "okay";
+};
+
 &tsc {
 	status = "okay";
 	pinctrl-0 = <&tsc_g1_io1_pb12 &tsc_g1_io2_pb13 &tsc_g6_io1_pd10 &tsc_g6_io2_pd11>;

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -573,6 +573,7 @@
 			reg = <0x40009400 0x400>;
 			interrupts = <18 1>;
 			interrupt-names = "combined";
+			status = "disabled";
 		};
 
 		tsc: tsc@40024000 {


### PR DESCRIPTION
- Define stm32_lp_tick_source for STM32U0_DK board since PM is looking for this node and change clock source for LPTIM2 to LSI.

- Also disable LPTIM2 by default to avoid build failures caused by enabling multiple LPTIM peripherals. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92300