### PR TITLE
doc: drivers: display: add basic controller info

### DIFF
--- a/dts/bindings/display/frida,nt35510.yaml
+++ b/dts/bindings/display/frida,nt35510.yaml
@@ -1,7 +1,13 @@
 # Copyright (c) 2024 Erik Andersson <erian747@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: Frida Techshine Panel
+title: Novatek NT35510 Display Driver
+
+description: |
+    The Novatek NT35510 is a 16.7M colors TFT-LCD controller
+    with a maximum 480RGBx864 resolution.
+
+    It supports display panels such as Shenzhen Frida LCD FRD397B2509.
 
 compatible: "frida,nt35510"
 

--- a/dts/bindings/display/ftdi,ft800.yaml
+++ b/dts/bindings/display/ftdi,ft800.yaml
@@ -1,7 +1,13 @@
 # Copyright (c) 2020 Hubert Miś <hubert.mis@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: FTDI FT800 graphic controller
+title: FTDI FT800 graphic controller
+
+description: |
+    The FTDI FT800 graphic controller is a graphics accelerator,
+    able to drive LCD displays with RGB parallel output.
+    It communicates with MCU through SPI commands.
+    It also includes touchscreen and sound output support.
 
 compatible: "ftdi,ft800"
 

--- a/dts/bindings/display/galaxycore,gc9x01x.yaml
+++ b/dts/bindings/display/galaxycore,gc9x01x.yaml
@@ -3,13 +3,15 @@
 # Copyright (c) 2023 Martin Kiepfer <mrmarteng@teleschirm.org>
 # SPDX-License-Identifier: Apache-2.0
 
-description: |
-  GC9X01X display driver.
+title: |
+  Galaxycore GC9X01X display driver
 
+description: |
   This driver implements support for various GC9X01X graphics
   controllers and different display sizes. It has been validated
   for following controllers:
-   - GC9101A: (Waveshare 240x240, 1.28inch round lcd display 240x240)
+   - GC9101A: (Waveshare 240x240, 1.28inch round lcd display 240x240
+     with 65k colors)
 
   Here is an example to define a display interface:
 

--- a/dts/bindings/display/himax,hx8394.yaml
+++ b/dts/bindings/display/himax,hx8394.yaml
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: Himax HX8394 Panel
+title: Himax HX8394 display controller
+
+description: |
+    The Himax HX8394 is a 16.7M colors TFT-LCD controller
+    with a maximum 800RGBx1280 resolution.
 
 compatible: "himax,hx8394"
 

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -2,7 +2,11 @@
 # Copyright (c) 2020, Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9340 320x240 display controller
+title: Ilitek ILI9340 320x240 display controller
+
+description: |
+    The Ilitek ILI9340 is a 262K colors TFT-LCD controller
+    with a maximum 240RGBx320 resolution.
 
 compatible: "ilitek,ili9340"
 

--- a/dts/bindings/display/ilitek,ili9341.yaml
+++ b/dts/bindings/display/ilitek,ili9341.yaml
@@ -4,7 +4,11 @@
 # Copyright (c) 2022, Konstantinos Papadopulos <kostas.papadopulos@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9341 320x240 display controller
+title: Ilitek ILI9341 320x240 display controller
+
+description: |
+    The Ilitek ILI9341 is a 262K colors TFT-LCD controller
+    with a maximum 240RGBx360 resolution.
 
 compatible: "ilitek,ili9341"
 

--- a/dts/bindings/display/ilitek,ili9342c.yaml
+++ b/dts/bindings/display/ilitek,ili9342c.yaml
@@ -4,7 +4,11 @@
 # Copyright (c) 2022, Konstantinos Papadopulos <kostas.papadopulos@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9342C 320x240 display controller
+title: Ilitek ILI9342C display controller
+
+description: |
+  The Ilitek ILI9342C is a 262K colors TFT-LCD controller
+  with a maximum 240RGBx320 resolution.
 
 compatible: "ilitek,ili9342c"
 

--- a/dts/bindings/display/ilitek,ili9488.yaml
+++ b/dts/bindings/display/ilitek,ili9488.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2020, Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9488 320x480 display controller
+title: Ilitek ILI9488 display controller
+
+description: |
+   The Ilitek ILI9488 is a 16.7M colors TFT-LCD controller
+   with a maximum 320RGBx480 resolution.
 
 compatible: "ilitek,ili9488"
 

--- a/dts/bindings/display/ilitek,ili9806e.yaml
+++ b/dts/bindings/display/ilitek,ili9806e.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2024 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILITEK ILI9806E display controller
+title: Ilitek ILI9806E display controller
+
+description: |
+   The Ilitek ILI9806E is a 16.7M colors TFT-LCD controller
+   with a maximum 480RGBx864 resolution.
 
 compatible: "ilitek,ili9806e-dsi"
 

--- a/dts/bindings/display/ilitek,ili9xxx-common.yaml
+++ b/dts/bindings/display/ilitek,ili9xxx-common.yaml
@@ -2,7 +2,10 @@
 # Copyright (c) 2020, Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9XXX display controllers common properties.
+title: ILI9XXX display controllers common properties.
+
+description: |
+    Ilitek ILI9XXX is a color TFT-LCD controller series.
 
 include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 

--- a/dts/bindings/display/istech,ist3931.yaml
+++ b/dts/bindings/display/istech,ist3931.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2024 XuYang Shen  <shenxuyang@shlinyuantech.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: IST3931 65x132 display controller
+title: IST3931 65x132 display controller
+
+description: |
+    The Istech IST3931 is a monochrome STN LCD controller
+    with a maximum 132x65 resolution.
 
 compatible: "istech,ist3931"
 

--- a/dts/bindings/display/maxim,max7219.yaml
+++ b/dts/bindings/display/maxim,max7219.yaml
@@ -1,8 +1,12 @@
 # Copyright (c) 2022 Jimmy Ou <yanagiis@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+title: Maxim MAX7219 LED display driver
+
 description: |
-  Maxim MAX7219 LED display driver
+  The Maxim MAX7219 is a 8x8 dot-matrix LED controller.
+  It can drive 7-segment displays of up to 8 digits,
+  or 64 individual matrixed LEDs.
 
 compatible: "maxim,max7219"
 

--- a/dts/bindings/display/orisetech,otm8009a.yaml
+++ b/dts/bindings/display/orisetech,otm8009a.yaml
@@ -2,7 +2,11 @@
 # Copyright (c) 2020 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Orise Tech OTM8009A Panel
+title: Orisetech OTM8009A display controller
+
+description: |
+    The Orisetech OTM8009A is a 16.7M colors TFT-LCD controller
+    with a maximum 480RGBx864 resolution.
 
 compatible: "orisetech,otm8009a"
 

--- a/dts/bindings/display/raydium,rm67162.yaml
+++ b/dts/bindings/display/raydium,rm67162.yaml
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: Raydium RM67162 Panel
+title: Raydium RM67162 display controller
+
+description: |
+    The Raydium RM67162 is a 16.7M colors OLED controller
+    with a maximum 480RGBx480 resolution.
 
 compatible: "raydium,rm67162"
 

--- a/dts/bindings/display/raydium,rm68200.yaml
+++ b/dts/bindings/display/raydium,rm68200.yaml
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: Raydium RM68200 Panel
+title: Raydium RM68200 display controller
+
+description: |
+    The Raydium RM68200 is a 16.7M colors TFT-LCD controller
+    with a maximum 480RGBx864 resolution.
 
 compatible: "raydium,rm68200"
 

--- a/dts/bindings/display/sharp,ls0xx.yaml
+++ b/dts/bindings/display/sharp,ls0xx.yaml
@@ -1,7 +1,22 @@
 # Copyright (c) 2020, Rohit Gujarathi
 # SPDX-License-Identifier: Apache-2.0
 
-description: Sharp memory display controller
+title: Sharp LS0XX memory display controller
+
+description: |
+    Sharp LS0XX series has an eclectic range of TFT-LCD controllers,
+    mostly monochrome TFT-LCD controller up to 400x240 resolution.
+
+    Example supported references:
+    LS012B7DD01
+    LS013B7DH03
+    LS013B7DH05
+    LS027B7DH01A
+    LS032B7DD02
+    LS044Q7DH01
+
+    Adafruit 1.3" SHARP Memory LCD display is a breakout board for
+    LS013B4DN04, and 2.7" for LS027B7DH01.
 
 compatible: "sharp,ls0xx"
 

--- a/dts/bindings/display/sitronix,st7567-i2c.yaml
+++ b/dts/bindings/display/sitronix,st7567-i2c.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7567 132x65 dot-matrix LCD controller on I2C bus
+title: Sitronix ST7567 dot-matrix LCD controller on I2C bus
+
+description: |
+    The Sitronix ST7567 is a monochrome Dot-Matrix LCD controller
+    with a maximum 132x65 resolution.
 
 compatible: "sitronix,st7567"
 

--- a/dts/bindings/display/sitronix,st7567-spi.yaml
+++ b/dts/bindings/display/sitronix,st7567-spi.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7567 132x65 dot-matrix LCD controller on SPI bus
+title: Sitronix ST7567 dot-matrix LCD controller on SPI bus
+
+description: |
+    The Sitronix ST7567 is a monochrome Dot-Matrix LCD controller
+    with a maximum 132x65 resolution.
 
 compatible: "sitronix,st7567"
 

--- a/dts/bindings/display/sitronix,st7701.yaml
+++ b/dts/bindings/display/sitronix,st7701.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025 Arduino SA
 # SPDX-License-Identifier: Apache-2.0
 
-description: Sitronix ST7701 Panel
+title: Sitronix ST7701 display controller
+
+description: |
+    The Sitronix ST7701 is a 16.7M colors TFT-LCD controller
+    with a maximum 480RGBx864 resolution.
 
 compatible: "sitronix,st7701"
 

--- a/dts/bindings/display/sitronix,st7735r.yaml
+++ b/dts/bindings/display/sitronix,st7735r.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2020, Kim Bøndergaard <kim@fam-boendergaard.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7735R/ST7735S 160x128 (max) display controller
+title: Sitronix ST7735X display controller
+
+description: |
+    The Sitronix ST7735R and ST7735S are 262K colors TFT-LCD controllers
+    with a maximum 132RGBx162 resolution.
 
 compatible: "sitronix,st7735r"
 

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -2,7 +2,11 @@
 # Copyright (c) 2019, PHYTEC Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7789V 320x240 display controller
+title: Sitronix ST7789V display controller
+
+description: |
+    The Sitronix ST7789V is a 262K colors TFT-LCD controller
+    with a maximum 240RGBx320 resolution.
 
 compatible: "sitronix,st7789v"
 

--- a/dts/bindings/display/sitronix,st7796s.yaml
+++ b/dts/bindings/display/sitronix,st7796s.yaml
@@ -1,7 +1,11 @@
 # Copyright 2023 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7796S Display controller
+title: Sitronix ST7796S Display controller
+
+description: |
+  The Sitronix ST7796S is a 262K colors TFT-LCD controller
+  with a maximum 320RGBx480 resolution.
 
 compatible: "sitronix,st7796s"
 

--- a/dts/bindings/display/solomon,ssd1306fb-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-i2c.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2020, Marco Peter
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1306 128x64 dot-matrix display controller on I2C bus
+title: Solomon SSD1306 display controller on I2C bus
+
+description: |
+    The Solomon SSD1306 is a monochrome OLED controller
+    with a maximum 128x64 resolution.
 
 compatible: "solomon,ssd1306fb"
 

--- a/dts/bindings/display/solomon,ssd1306fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-spi.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2020, Marco Peter
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1306 128x64 dot-matrix display controller on SPI bus
+title: Solomon SSD1306 display controller on SPI bus
+
+description: |
+    The Solomon SSD1306 is a monochrome OLED controller
+    with a maximum 128x64 resolution.
 
 compatible: "solomon,ssd1306fb"
 

--- a/dts/bindings/display/solomon,ssd1309fb-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1309fb-i2c.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025, Marcio Ribeiro
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1309 128x64 dot-matrix display controller on I2C bus
+title: Solomon SSD1309 display controller on I2C bus
+
+description: |
+    The Solomon SSD1309 is a monochrome OLED controller
+    with a maximum 128x64 resolution.
 
 compatible: "solomon,ssd1309fb"
 

--- a/dts/bindings/display/solomon,ssd1309fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1309fb-spi.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025, Marcio Ribeiro
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1309 128x64 dot-matrix display controller on SPI bus
+title: Solomon SSD1309 display controller on SPI bus
+
+description: |
+    The Solomon SSD1309 is a monochrome OLED controller
+    with a maximum 128x64 resolution.
 
 compatible: "solomon,ssd1309fb"
 

--- a/dts/bindings/display/solomon,ssd1322.yaml
+++ b/dts/bindings/display/solomon,ssd1322.yaml
@@ -1,4 +1,8 @@
-description: SSD1322 display controller
+title: Solomon SSD1322 display controller
+
+description: |
+    The Solomon SSD1322 is a monochrome OLED controller
+    with a maximum 480x128 resolution.
 
 compatible: "solomon,ssd1322"
 

--- a/dts/bindings/display/solomon,ssd1327fb-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1327fb-i2c.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1327 128x128 dot-matrix display controller on I2C bus
+title: Solomon SSD1327 display controller on I2C bus
+
+description: |
+    The Solomon SSD1327 is a 4-bit greyscale OLED controller
+    with a maximum 128x128 resolution.
 
 include: ["solomon,ssd1327fb-common.yaml", "i2c-device.yaml"]
 

--- a/dts/bindings/display/solomon,ssd1327fb-mipi.yaml
+++ b/dts/bindings/display/solomon,ssd1327fb-mipi.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2025 MASSDRIVER EI (massdriver.space)
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1327 128x128 dot-matrix display controller on MIPI_DBI or SPI bus
+title: Solomon SSD1327 display controller on MIPI_DBI or SPI bus
+
+description: |
+    The Solomon SSD1327 is a 4-bit greyscale OLED controller
+    with a maximum 128x128 resolution.
 
 include: ["solomon,ssd1327fb-common.yaml", "mipi-dbi-spi-device.yaml"]
 

--- a/dts/bindings/display/solomon,ssd16xx-common.yaml
+++ b/dts/bindings/display/solomon,ssd16xx-common.yaml
@@ -1,7 +1,11 @@
 # Copyright (c) 2018, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD16XX EPD display controller
+title: Solomon SSD16XX EPD display controller
+
+description: |
+    The Solomon SSD16XX is a monochrome / 3-colors E-Ink
+    controller with a maximum 176x296 resolution.
 
 include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 

--- a/dts/bindings/display/ultrachip,uc81xx-common.yaml
+++ b/dts/bindings/display/ultrachip,uc81xx-common.yaml
@@ -3,7 +3,11 @@
 # Copyright 2024 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: UltraChip UC81xx EPD display controller common properties
+title: Ultrachip UC81xx EPD display controller common properties
+
+description: |
+    The Ultrachip UC81XX is a monochrome / 3-colors E-Ink controller
+    with a maximum 800x600 resolution.
 
 include: [mipi-dbi-spi-device.yaml, display-controller.yaml]
 


### PR DESCRIPTION
Add basic controller information (techno, resolution, color depth...) for display drivers.