### PR TITLE
sensor: adxl345: Add ability to use Streaming and Trigger with INT1

### DIFF
--- a/drivers/sensor/adi/adxl345/adxl345.h
+++ b/drivers/sensor/adi/adxl345/adxl345.h
@@ -237,6 +237,7 @@ struct adxl345_dev_config {
 	uint8_t bus_type;
 #ifdef CONFIG_ADXL345_TRIGGER
 	struct gpio_dt_spec interrupt;
+	bool route_to_int2;
 #endif
 };
 

--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -36,7 +36,7 @@ void adxl345_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 	if (fifo_watermark_irq != data->fifo_watermark_irq) {
 		data->fifo_watermark_irq = fifo_watermark_irq;
 		rc = adxl345_reg_write_mask(dev, ADXL345_INT_MAP, ADXL345_INT_MAP_WATERMARK_MSK,
-						int_value);
+					    cfg_345->route_to_int2 ? int_value : ~int_value);
 		if (rc < 0) {
 			return;
 		}

--- a/drivers/sensor/adi/adxl345/adxl345_trigger.c
+++ b/drivers/sensor/adi/adxl345/adxl345_trigger.c
@@ -133,7 +133,8 @@ int adxl345_trigger_set(const struct device *dev,
 		return ret;
 	}
 
-	ret = adxl345_reg_write_mask(dev, ADXL345_INT_MAP, int_mask, int_en);
+	ret = adxl345_reg_write_mask(dev, ADXL345_INT_MAP, int_mask,
+				     cfg->route_to_int2 ? int_en : ~int_en);
 	if (ret < 0) {
 		return ret;
 	}

--- a/dts/bindings/sensor/adi,adxl345-common.yaml
+++ b/dts/bindings/sensor/adi,adxl345-common.yaml
@@ -37,6 +37,15 @@ properties:
       Specify the FIFO watermark level in frame count.
       Valid range: 1 - 31
 
+  int1-gpios:
+    type: phandle-array
+    description: |
+      The INT1 signal defaults to active high as produced by the
+      sensor.  The property value should ensure the flags properly
+      describe the signal that is presented to the driver.
+      Either this or INT2 will be used to route interrupts. If both
+      are defined, then int1 is prioritized.
+
   int2-gpios:
     type: phandle-array
     description: |


### PR DESCRIPTION
This PR adds support for ADXL345 interrupts through INT1.
Only one is used for a given instance. INT1 is prioritized over INT2 if both are defined.

I introduced this feature because I've got some boards where only INT1 is exposed (ADXL345's MIKROE-1194).