### PR TITLE
soc: nxp: Allow disabling XIP for FlexSPI and XSPI

### DIFF
--- a/soc/nxp/common/Kconfig.flexspi_xip
+++ b/soc/nxp/common/Kconfig.flexspi_xip
@@ -21,7 +21,7 @@ config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)
 
 config FLASH_MCUX_FLEXSPI_XIP
-	bool
+	bool "XIP compatibility for FlexSPI"
 	default $(DT_FLASH_PARENT_IS_FLEXSPI)
 	select XIP
 	help

--- a/soc/nxp/common/Kconfig.xspi_xip
+++ b/soc/nxp/common/Kconfig.xspi_xip
@@ -19,7 +19,7 @@ config FLASH_SIZE
 	default $(dt_node_int_prop_int,$(DT_CHOSEN_FLASH_NODE),size,Kb)
 
 config FLASH_MCUX_XSPI_XIP
-	bool
+	bool "XIP compatibility for XSPI"
 	default $(DT_FLASH_PARENT_IS_XSPI)
 	select XIP
 	help


### PR DESCRIPTION
I'm uncertain if this is the best approach, but we needed to be able to disable `FLASH_MCUX_FLEXSPI_XIP` via prj.conf or similar in order to get RAM loading via MCUBoot to work on an NXP i.MX RT1170. As I understand it, all I'm doing is making this setting user selectable.