### PR TITLE
uart_bridge: log the device name on bitrate changes

### DIFF
--- a/drivers/serial/uart_bridge.c
+++ b/drivers/serial/uart_bridge.c
@@ -76,8 +76,8 @@ void uart_bridge_settings_update(const struct device *dev,
 		return;
 	}
 
-	LOG_INF("uart settings: baudrate=%d parity=%d", cfg.baudrate,
-		cfg.parity);
+	LOG_INF("uart settings: baudrate=%d parity=%d dev=%s",
+		cfg.baudrate, cfg.parity, bridge_dev->name);
 }
 
 static uint8_t uart_bridge_get_idx(const struct device *dev,


### PR DESCRIPTION
Add a log for the device name on bitrate changes, without this it's very hard to understand what's going on in a system with multiple bridges.