### PR TITLE
dts: arm: rp2350: add interrupts for PIO

### DIFF
--- a/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2040.dtsi
@@ -411,6 +411,9 @@
 			reg = <0x50200000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO0>;
+			interrupts = <7 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				    <8 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+			interrupt-names = "irq0", "irq1";
 			status = "disabled";
 		};
 
@@ -419,6 +422,9 @@
 			reg = <0x50300000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO1>;
+			interrupts = <9 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				    <10 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+			interrupt-names = "irq0", "irq1";
 			status = "disabled";
 		};
 

--- a/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
+++ b/dts/arm/raspberrypi/rpi_pico/rp2350.dtsi
@@ -429,6 +429,9 @@
 			reg = <0x50200000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO0>;
+			interrupts = <15 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				    <16 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+			interrupt-names = "irq0", "irq1";
 			status = "disabled";
 		};
 
@@ -437,6 +440,9 @@
 			reg = <0x50300000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO1>;
+			interrupts = <17 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				    <18 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+			interrupt-names = "irq0", "irq1";
 			status = "disabled";
 		};
 
@@ -445,6 +451,9 @@
 			reg = <0x50400000 DT_SIZE_K(4)>;
 			clocks = <&clocks RPI_PICO_CLKID_CLK_SYS>;
 			resets = <&reset RPI_PICO_RESETS_RESET_PIO2>;
+			interrupts = <19 RPI_PICO_DEFAULT_IRQ_PRIORITY>,
+				    <20 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
+			interrupt-names = "irq0", "irq1";
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
PIO interrupts are useful for some of the virtual
peripherals, so describe them in the DT.

This has no direct implications to existing drivers.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
