### PR TITLE
scripts: west_commands: openocd: run gdb in batch mode for RTT

### DIFF
--- a/scripts/west_commands/runners/openocd.py
+++ b/scripts/west_commands/runners/openocd.py
@@ -407,7 +407,12 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
                 + ['-c', f'rtt server start {self.rtt_port} 0']
             )
 
-        gdb_cmd = (self.gdb_cmd + self.tui_arg +
+        if command == 'rtt':
+            # Run GDB in batch mode. This will disable pagination automatically
+            gdb_args = ['--batch']
+        else:
+            gdb_args = []
+        gdb_cmd = (self.gdb_cmd + gdb_args + self.tui_arg +
                    ['-ex', f'target extended-remote :{self.gdb_client_port}',
                     self.elf_name])
         if command == 'debug':
@@ -421,8 +426,6 @@ class OpenOcdBinaryRunner(ZephyrBinaryRunner):
             if rtt_address is None:
                 raise ValueError("RTT Control block not found")
 
-            # cannot prompt the user to press return for automation purposes
-            gdb_cmd.extend(['-ex', 'set pagination off'])
             # start the internal openocd rtt service via gdb monitor commands
             gdb_cmd.extend(
                 ['-ex', f'monitor rtt setup 0x{rtt_address:x} 0x10 "SEGGER RTT"'])


### PR DESCRIPTION
Run GDB in batch mode when using RTT, so that pagination is never enabled. This fixes RTT support when using terminals with a very small row count.

Fixes #92417