### PR TITLE
tests: kernel: gen_isr_table: Don't use IRQ1 if already used

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -19,6 +19,12 @@ extern const uintptr_t _irq_vector_table[];
 #endif
 
 #if defined(CONFIG_RISCV)
+
+/* litex_timer0 (drivers/timer/litex_timer.c) uses IRQ 1, so the test can't use it. */
+#if defined(CONFIG_LITEX_TIMER)
+#define IRQ1_USED
+#endif
+
 #if defined(CONFIG_NRFX_CLIC)
 
 #if defined(CONFIG_SOC_SERIES_NRF54LX) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
@@ -47,8 +53,10 @@ extern const uintptr_t _irq_vector_table[];
 #define TRIG_CHECK_SIZE	19
 #else
 
+#if !defined(IRQ1_USED)
 /* RISC-V has very few IRQ lines which can be triggered from software */
 #define ISR3_OFFSET	1
+#endif
 
 /* Since we have so few lines we have to share the same line for two different
  * tests


### PR DESCRIPTION
IRQ 1 is used by the LiteX timer, so we can't use it for the test:

gen_isr_tables.py: error: multiple registrations at table_index 1 for irq 1 (0x1)
Existing section ['.irq.WEST_TOPDIR/zephyr/tests/kernel/gen_isr_table/src/main.c.0'],
new section .irq.WEST_TOPDIR/zephyr/drivers/timer/litex_timer.c.0
Has IRQ_CONNECT or IRQ_DIRECT_CONNECT accidentally been invoked on the
same irq multiple times?

Issue #92194