### PR TITLE
modules: nrf_wifi: Fix interface down hang

### DIFF
--- a/modules/nrf_wifi/bus/qspi_if.c
+++ b/modules/nrf_wifi/bus/qspi_if.c
@@ -1196,7 +1196,9 @@ struct device qspi_perip = {
 
 int qspi_deinit(void)
 {
-	_qspi_device_uninit(&qspi_perip);
+	if (nrfx_qspi_init_check()) {
+		_qspi_device_uninit(&qspi_perip);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
When QSPI LPM is enabled, QSPI will already be uninitialized, and during deinit if uninitialized is being called again then it leads to a hang as it waits for mem busy check to pass which it won't.

Fix by checking if the device is initialized before calling uninitialize.