### PR TITLE
Create dedicated heap for supplicant 

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -24,6 +24,24 @@ config WIFI_NM_WPA_SUPPLICANT
 
 if WIFI_NM_WPA_SUPPLICANT
 
+config WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
+	bool "Use Zephyr kernel heap for Wi-Fi driver"
+	default y
+	help
+	  Enable this option to use K_HEAP for memory allocations in supplicant.
+
+if !WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
+config WIFI_NM_WPA_SUPPLICANT_HEAP
+	int "Dedicated memory pool for wpa_supplicant"
+	def_int 66560 if WIFI_NM_HOSTAPD_AP
+	def_int 55000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE && WIFI_CREDENTIALS
+	def_int 48000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
+	def_int 41808 if WIFI_NM_WPA_SUPPLICANT_AP
+	# 30K is mandatory, but might need more for long duration use cases
+	def_int 30000
+endif # !WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
+
+if WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
 config HEAP_MEM_POOL_ADD_SIZE_HOSTAP
 	def_int 66560 if WIFI_NM_HOSTAPD_AP
 	def_int 55000 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE && WIFI_CREDENTIALS
@@ -31,6 +49,8 @@ config HEAP_MEM_POOL_ADD_SIZE_HOSTAP
 	def_int 41808 if WIFI_NM_WPA_SUPPLICANT_AP
 	# 30K is mandatory, but might need more for long duration use cases
 	def_int 30000
+endif # WIFI_NM_WPA_SUPPLICANT_GLOBAL_HEAP
+
 
 config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	int "Stack size for wpa_supplicant thread"

--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: bc5d22f5838d017b889d1452a5854f9a32895414
+      revision: pull/74/head
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Create dedicated heap for supplicant operations. Currently, WPA supplicant uses the k_malloc, which is shared across various subsystems, and we cannot enforce a minimum availability. Using a dedicated HEAP that can be pre-allocated solves this by always having necessary memory . 
Introduce an option for user to choose between dedicated heap and system heap.