### PR TITLE
boards: stm32n6570_dk: Update doc and migration guide.

### DIFF
--- a/boards/st/stm32n6570_dk/doc/index.rst
+++ b/boards/st/stm32n6570_dk/doc/index.rst
@@ -182,9 +182,10 @@ Board variants
 Three variants are available with STM32N6570_DK:
 
 - Default variant. Available as a chainloaded application which should be loaded by a
-  Boot Loader, it has access to the whole AXISRAM1 and AXISRAM2 regions.
+  bootloader, it has access to the whole AXISRAM1 and AXISRAM2 regions. It is expected to
+  be built using ``--sysbuild`` option exclusively.
 - ``fsbl``: First Stage Boot Loader (FSBL) which is available as an application loaded by the
-  Boot ROM and flashed using ST-Link. This is typically a Boot Loader image. It runs
+  Boot ROM and flashed using ST-Link. This is typically a bootloader image. It runs
   in RAM LOAD mode on second half of AXISRAM2. 511K are available for the whole image.
 - ``sb``: First Stage Boot Loader - Serial Boot. Equivalent to the FSBL image, but could be
   loaded using USB and doesn't require switching the bootpins. This is the most practical

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -88,6 +88,12 @@ Boards
   instead of ``openocd.board.cmake``. The ``openocd-stm32.board.cmake`` file extends the default
   OpenOCD runner with manufacturer-specific configuration like STM32 mass erase commands.
 
+* STM32N6570-DK boards's default variant (``stm32n6570_dk/stm32n657xx``) is now supposed to be a
+  chainloaded application and should be built using ``--sysbuild``. The old default,
+  which built applications to run as First Stage BootLoader, is now available as a dedicated
+  variant (``stm32n6570_dk/stm32n657xx/fsbl``) that must be selected explicitly.
+  See board documentation for more information about these variants.
+
 Device Drivers and Devicetree
 *****************************
 


### PR DESCRIPTION
Clarify expectations about the recently modified default variant of the board.
Update migration guide to warn existing users about the change.