### PR TITLE
Mbox mimxrt1160 evk cm4 fix

### DIFF
--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm4.dts
@@ -20,7 +20,7 @@
 		 * sram region is changed and DMA is in use, you will
 		 * encounter issues!
 		 */
-		zephyr,sram = &ocram;
+		zephyr,sram = &sram1;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,flash-controller = &is25wp128;


### PR DESCRIPTION
as in mbox cases the ocram is used as code area, so shall not be used as sram again. this is a typo introduced by
aec0355380e20ba5ea4cdf98d476a7113a138673.

fixes: #82841
