### PR TITLE
mgmt: ec_host_cmd: backend: shi_npcx: fix log message

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
+++ b/subsys/mgmt/ec_host_cmd/backends/ec_host_cmd_backend_shi_npcx.c
@@ -846,7 +846,7 @@ static int shi_npcx_enable(const struct device *dev)
 	/* Configure pin control for SHI */
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {
-		LOG_ERR("shi_npcx pinctrl setup failed (%d)", ret);
+		LOG_ERR("Pinctrl apply DEFAULT fail (%d)", ret);
 		return ret;
 	}
 
@@ -877,7 +877,7 @@ static int shi_npcx_disable(const struct device *dev)
 	/* Configure pin control back to GPIO */
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
 	if (ret < 0) {
-		LOG_ERR("KB Raw pinctrl setup failed (%d)", ret);
+		LOG_ERR("Pinctrl apply SLEEP fail (%d)", ret);
 		return ret;
 	}
 


### PR DESCRIPTION
This commit fixes the content of the log messages that appear when an error occurs while applying the pinctrl.