### PR TITLE
boards: shields: Fixes Stepper 19 Click GPIO Expander

### DIFF
--- a/boards/shields/mikroe_stepper_19_click/doc/index.rst
+++ b/boards/shields/mikroe_stepper_19_click/doc/index.rst
@@ -6,13 +6,9 @@ MikroElektronika Stepper 19 Click
 Overview
 ********
 
-Stepper 19 Click shield has a TI DRV8424 stepper driver accessed via GPIO and
-a TI TCA9538 GPIO expander accessed via I2C. Some DRV8424 pins are accessed
+The MikroElektronika `Stepper 19 Click`_ shield has a `TI DRV8424`_ stepper driver accessed via
+GPIO and a `NXP PCA9538A`_ GPIO expander accessed via I2C. Some DRV8424 pins are accessed
 via the GPIO expander.
-The DRV8424 uses by default the work-queue timing source, but that can be changed.
-
-More information about the shield can be found at
-`Mikroe Stepper 19 click`_.
 
 .. figure:: stepper_19_click.webp
    :align: center
@@ -41,5 +37,11 @@ References
 
 .. target-notes::
 
-.. _Mikroe Stepper 19 click:
+.. _Stepper 19 Click:
    https://www.mikroe.com/stepper-19-click
+
+.. _TI DRV8424:
+   https://www.ti.com/product/DRV8424
+
+.. _NXP PCA9538A:
+   https://www.nxp.com/products/interfaces/ic-spi-i3c-interface-devices/general-purpose-i-o-gpio/low-voltage-8-bit-ic-bus-i-o-port-with-interrupt-and-reset:PCA9538A

--- a/boards/shields/mikroe_stepper_19_click/mikroe_stepper_19_click.overlay
+++ b/boards/shields/mikroe_stepper_19_click/mikroe_stepper_19_click.overlay
@@ -12,9 +12,9 @@
 &mikrobus_i2c {
 	status = "okay";
 
-	tca9538a_mikroe_stepper_19_click: tca9538a@70 {
+	pca9538a_mikroe_stepper_19_click: pca9538a@70 {
 		status = "okay";
-		compatible = "ti,tca9538";
+		compatible = "nxp,pca9538";
 
 		reg = <0x70>;
 
@@ -45,7 +45,7 @@
 		sleep-gpios = <&mikrobus_header 1 GPIO_ACTIVE_LOW>;
 		en-gpios  = <&mikrobus_header 2 0>;
 		fault-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;
-		m0-gpios = <&tca9538a_mikroe_stepper_19_click 0 0>;
-		m1-gpios = <&tca9538a_mikroe_stepper_19_click 1 0>;
+		m0-gpios = <&pca9538a_mikroe_stepper_19_click 0 0>;
+		m1-gpios = <&pca9538a_mikroe_stepper_19_click 1 0>;
 	};
 };


### PR DESCRIPTION
The Stepper 19 Click shield actually uses the NXP PCA9538 instead of the TI TCA9538 that has been listed so far. These two chips are pin-to-pin compatible, which is why there have been no issues.
This PR updates the shield for the correct gpio expander and also adds some additional links to the readme.