### PR TITLE
drivers/espi: ite: Add support for ESPI_PERIPHERAL_HOST_IO_PVT

### DIFF
--- a/drivers/espi/Kconfig.it8xxx2
+++ b/drivers/espi/Kconfig.it8xxx2
@@ -20,6 +20,12 @@ config ESPI_PERIPHERAL_8042_KBC
 config ESPI_PERIPHERAL_HOST_IO
 	default y
 
+config ESPI_PERIPHERAL_HOST_IO_PVT
+	default y
+
+config ESPI_PERIPHERAL_HOST_IO_PVT_PORT_NUM
+	default 0x0068
+
 config ESPI_PERIPHERAL_DEBUG_PORT_80
 	default y
 

--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -1237,7 +1237,8 @@
 				      IT51XXX_IRQ_PMC1_IBF IRQ_TYPE_LEVEL_HIGH
 				      IT51XXX_IRQ_PCH_P80 IRQ_TYPE_LEVEL_HIGH
 				      IT51XXX_IRQ_PMC2_IBF IRQ_TYPE_LEVEL_HIGH
-				      IT51XXX_IRQ_WKINTD IRQ_TYPE_LEVEL_HIGH>;
+				      IT51XXX_IRQ_WKINTD IRQ_TYPE_LEVEL_HIGH
+				      IT51XXX_IRQ_PMC3_IBF IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			wucctrl = <&wuc_wu42>;
 			#address-cells = <1>;

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -441,7 +441,8 @@
 				      IT8XXX2_IRQ_PMC1_IBF IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_PCH_P80 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_PMC2_IBF IRQ_TYPE_LEVEL_HIGH
-				      IT8XXX2_IRQ_WKINTD IRQ_TYPE_LEVEL_HIGH>;
+				      IT8XXX2_IRQ_WKINTD IRQ_TYPE_LEVEL_HIGH
+				      IT8XXX2_IRQ_PMC3_IBF IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			wucctrl = <&wuc_wu42>;
 			#address-cells = <1>;

--- a/include/zephyr/dt-bindings/interrupt-controller/ite-intc.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/ite-intc.h
@@ -57,6 +57,8 @@
 #define IT8XXX2_IRQ_WU67        55
 /* Group 7 */
 #define IT8XXX2_IRQ_TIMER2      58
+/* Group 8 */
+#define IT8XXX2_IRQ_PMC3_IBF    67
 /* Group 9 */
 #define IT8XXX2_IRQ_WU70        72
 #define IT8XXX2_IRQ_WU71        73

--- a/include/zephyr/dt-bindings/interrupt-controller/ite-it51xxx-intc.h
+++ b/include/zephyr/dt-bindings/interrupt-controller/ite-it51xxx-intc.h
@@ -59,6 +59,8 @@
 #define IT51XXX_IRQ_WU67       55
 /* Group 7 */
 #define IT51XXX_IRQ_TIMER2     58
+/* Group 8 */
+#define IT51XXX_IRQ_PMC3_IBF   67
 /* Group 9 */
 #define IT51XXX_IRQ_WU70       72
 #define IT51XXX_IRQ_WU71       73


### PR DESCRIPTION
Add support the host I/O over eSPI peripheral channel for private channel.
The default port number of ESPI_PERIPHERAL_HOST_IO_PVT_PORT_NUM for ITE SoC is 0x68.