### PR TITLE
cmake: Merge in DTS_ROOT from sysbuild

### DIFF
--- a/cmake/modules/root.cmake
+++ b/cmake/modules/root.cmake
@@ -13,6 +13,7 @@
 # - BOARD_ROOT:      CMake list of board roots containing board and shield implementations
 # - MODULE_EXT_ROOT: CMake list of module external roots containing module glue code
 # - SCA_ROOT:        CMake list of SCA roots containing static code analysis integration code
+# - DTS_ROOT:        CMake list of DTS roots containing device tree bindings or includes
 #
 # If a root is defined it will check the list of paths in the root and convert
 # any relative path to absolute path and update the root list.
@@ -29,6 +30,7 @@ zephyr_get(SOC_ROOT MERGE SYSBUILD GLOBAL)
 zephyr_get(ARCH_ROOT MERGE SYSBUILD GLOBAL)
 zephyr_get(SCA_ROOT MERGE SYSBUILD GLOBAL)
 zephyr_get(SNIPPET_ROOT MERGE SYSBUILD GLOBAL)
+zephyr_get(DTS_ROOT MERGE SYSBUILD GLOBAL)
 
 # Convert paths to absolute, relative from APPLICATION_SOURCE_DIR
 zephyr_file(APPLICATION_ROOT MODULE_EXT_ROOT)
@@ -37,6 +39,7 @@ zephyr_file(APPLICATION_ROOT SOC_ROOT)
 zephyr_file(APPLICATION_ROOT ARCH_ROOT)
 zephyr_file(APPLICATION_ROOT SCA_ROOT)
 zephyr_file(APPLICATION_ROOT SNIPPET_ROOT)
+zephyr_file(APPLICATION_ROOT DTS_ROOT)
 
 if(unittest IN_LIST Zephyr_FIND_COMPONENTS)
   # Zephyr used in unittest mode, use dedicated unittest root.


### PR DESCRIPTION
Merging in DTS_ROOT from sysbuild allows applications to specify a custom DTS_ROOT path for the application via sysbuild. For example, in the application's sysbuild/CMakeLists.txt, `set(mcuboot_DTS_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." CACHE INTERNAL "DTS root for mcuboot")` could be use to specify a DTS_ROOT in the application directory, allowing for application-specific DTS bindings or vendor prefixes to be created for all images.

My use case: I have an application with `dts/bindings/vendor-prefixes.txt` containing a custom vendor prefix which I use in dts files. I could symlink to this from all custom boards (although the symlink then conflicts with the dts dir found in app dir, so I have to rename the dts dir), and possibly application config directories (for zephyr boards, not tested) but specifying the path once in `sysbuild/CMakeLists.txt` is easier to maintain and cleaner.