### PR TITLE
drivers:can:sam0: Fixed bug with clock configuration for SAM0 series

### DIFF
--- a/drivers/can/can_sam0.c
+++ b/drivers/can/can_sam0.c
@@ -113,20 +113,22 @@ static int can_sam0_get_core_clock(const struct device *dev, uint32_t *rate)
 
 static void can_sam0_clock_enable(const struct can_sam0_config *cfg)
 {
+	uint8_t gen_index = cfg->gclk_gen;
+
 	*cfg->mclk |= cfg->mclk_mask;
 
 	GCLK->PCHCTRL[cfg->gclk_id].reg = GCLK_PCHCTRL_CHEN
-					| GCLK_PCHCTRL_GEN(cfg->gclk_gen);
+					| GCLK_PCHCTRL_GEN(gen_index);
 
-	/* Enable the GLCK7 with DIV*/
+	/* Enable the GLCK<gen_index> with DIV*/
 #if defined(CONFIG_SOC_SERIES_SAME51) || defined(CONFIG_SOC_SERIES_SAME54)
 	/*DFFL has to be used as clock source for the ATSAME51/54 family of SoCs*/
-	GCLK->GENCTRL[7].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_DFLL)
+	GCLK->GENCTRL[gen_index].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_DFLL)
 			     | GCLK_GENCTRL_DIV(cfg->divider)
 			     | GCLK_GENCTRL_GENEN;
 #elif defined(CONFIG_SOC_SERIES_SAMC21)
 	/*OSC48M has to be used as clock source for the ATSAMC21 family of SoCs*/
-	GCLK->GENCTRL[7].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_OSC48M)
+	GCLK->GENCTRL[gen_index].reg = GCLK_GENCTRL_SRC(GCLK_GENCTRL_SRC_OSC48M)
 			     | GCLK_GENCTRL_DIV(cfg->divider)
 			     | GCLK_GENCTRL_GENEN;
 #endif

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -61,12 +61,12 @@
 			interrupt-names = "int0";
 			clocks = <&gclk 26>, <&mclk 0x10 8>;
 			clock-names = "GCLK", "MCLK";
-			atmel,assigned-clocks = <&gclk 0>;
+			atmel,assigned-clocks = <&gclk 7>;
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			divider = <12>;
+			divider = <1>;
 		};
 
 		can1: can@42002000 {
@@ -76,12 +76,12 @@
 			interrupt-names = "int0";
 			clocks = <&gclk 27>, <&mclk 0x10 9>;
 			clock-names = "GCLK", "MCLK";
-			atmel,assigned-clocks = <&gclk 0>;
+			atmel,assigned-clocks = <&gclk 7>;
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
-			divider = <12>;
+			divider = <1>;
 		};
 	};
 };

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -37,12 +37,12 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&gclk 27>, <&mclk 0x10 17>;
 			clock-names = "GCLK", "MCLK";
-			atmel,assigned-clocks = <&gclk 0>;
+			atmel,assigned-clocks = <&gclk 7>;
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
 			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
-			divider = <12>;
+			divider = <1>;
 		};
 
 		can1: can@42000400 {
@@ -52,12 +52,12 @@
 			interrupt-names = "int0", "int1";
 			clocks = <&gclk 28>, <&mclk 0x10 18>;
 			clock-names = "GCLK", "MCLK";
-			atmel,assigned-clocks = <&gclk 0>;
+			atmel,assigned-clocks = <&gclk 7>;
 			atmel,assigned-clock-names = "GCLK";
 			status = "disabled";
 
 			bosch,mram-cfg = <0x0 128 64 64 64 64 32 32>;
-			divider = <12>;
+			divider = <1>;
 		};
 	};
 };


### PR DESCRIPTION
Hi all,

This fix for unconfigured clocks were connected to the can interface in the device tree for samc21, causing the interface to work incorrectly.

I used for testing custom board with an ATSAMC21E18 microcontroller.

Let me know if you have any suggestions on this MR.