### PR TITLE
doc: project_roles: enhance maintainer responsibilities re: CoC

### DIFF
--- a/doc/project/project_roles.rst
+++ b/doc/project/project_roles.rst
@@ -137,7 +137,9 @@ in addition to those listed for Contributors and Collaborators:
   the TSC
 * Responsibility to ensure all contributions of the project have been reviewed
   within reasonable time.
-* Responsibility to enforce the code of conduct.
+* Responsibility to enforce the Code of Conduct. As leaders in the community,
+  maintainers are expected to be role models in upholding the project's code
+  of conduct and creating a welcoming and inclusive environment for everyone.
 * Responsibility to triage static analysis issues in their code area.
   See :ref:`static_analysis`.
 


### PR DESCRIPTION
Emphasize the role of maintainers in upholding the project's code of conduct and fostering an inclusive environment for all.