### PR TITLE
Bluetooth: CAP: Implement broadcast to unicast handover

### DIFF
--- a/doc/connectivity/bluetooth/api/audio/bluetooth-le-audio-arch.rst
+++ b/doc/connectivity/bluetooth/api/audio/bluetooth-le-audio-arch.rst
@@ -778,10 +778,10 @@ Bluetooth Audio Stack.
    |        |                               |         |                  | - BSIM test           |                                                  |
    |        |                               |         |                  | - Sample Application  |                                                  |
    |        +-------------------------------+---------+------------------+-----------------------+--------------------------------------------------+
-   |        | Commander                     |         |                  | - WIP                 | - Feature complete                               |
-   |        |                               |         |                  |                       | - Shell Module                                   |
-   |        |                               |         |                  |                       | - BSIM test                                      |
-   |        |                               |         |                  |                       | - Sample Application                             |
+   |        | Commander                     |         |                  | - Feature complete    | - Shell Module                                   |
+   |        |                               |         |                  | - BSIM test           | - Sample Application                             |
+   |        |                               |         |                  |                       |                                                  |
+   |        |                               |         |                  |                       |                                                  |
    +--------+-------------------------------+---------+------------------+-----------------------+--------------------------------------------------+
    | HAP    | Hearing Aid                   | 1.0.0   | 3.1              | - Feature complete    |                                                  |
    |        |                               |         |                  | - Shell Module        |                                                  |

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -2039,7 +2039,6 @@ int bt_bap_unicast_client_ep_qos(struct bt_bap_ep *ep, struct net_buf_simple *bu
 
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->ase = ep->id;
-	/* TODO: don't hardcode CIG and CIS, they should come from ISO */
 	req->cig = conn_iso->info.unicast.cig_id;
 	req->cis = conn_iso->info.unicast.cis_id;
 	sys_put_le24(qos->interval, req->interval);

--- a/subsys/bluetooth/audio/cap_commander.c
+++ b/subsys/bluetooth/audio/cap_commander.c
@@ -101,9 +101,6 @@ int bt_cap_commander_discover(struct bt_conn *conn)
 }
 
 #if defined(CONFIG_BT_BAP_BROADCAST_ASSISTANT)
-static struct bt_bap_broadcast_assistant_cb broadcast_assistant_cb;
-static bool broadcast_assistant_cb_registered;
-
 static void
 copy_broadcast_reception_start_param(struct bt_bap_broadcast_assistant_add_src_param *add_src_param,
 				     struct cap_broadcast_reception_start *start_param)
@@ -170,22 +167,6 @@ static void cap_commander_broadcast_assistant_add_src_cb(struct bt_conn *conn, i
 	} else {
 		cap_commander_proc_complete();
 	}
-}
-
-static int cap_commander_register_broadcast_assistant_cb(void)
-{
-	int err;
-
-	err = bt_bap_broadcast_assistant_register_cb(&broadcast_assistant_cb);
-	if (err != 0) {
-		LOG_DBG("Failed to register broadcast assistant callbacks: %d", err);
-
-		return -ENOEXEC;
-	}
-
-	broadcast_assistant_cb_registered = true;
-
-	return 0;
 }
 
 static bool valid_broadcast_reception_start_param(
@@ -335,11 +316,7 @@ int cap_commander_broadcast_reception_start(
 	struct bt_conn *conn;
 	int err;
 
-	broadcast_assistant_cb.add_src = cap_commander_broadcast_assistant_add_src_cb;
-	if (!broadcast_assistant_cb_registered) {
-		err = cap_commander_register_broadcast_assistant_cb();
-		__ASSERT(err == 0, "Failed to register broadcast assistant callbacks: %d", err);
-	}
+	cap_commander_register_broadcast_assistant_callbacks();
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START, param->count);
 
@@ -355,8 +332,6 @@ int cap_commander_broadcast_reception_start(
 		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->members[%zu]", i);
-
-			bt_cap_common_clear_active_proc();
 
 			return -EINVAL;
 		}
@@ -389,8 +364,6 @@ int cap_commander_broadcast_reception_start(
 	if (err != 0) {
 		LOG_DBG("Failed to start broadcast reception for conn %p: %d", (void *)conn, err);
 
-		bt_cap_common_clear_active_proc();
-
 		return -ENOEXEC;
 	}
 
@@ -400,6 +373,8 @@ int cap_commander_broadcast_reception_start(
 int bt_cap_commander_broadcast_reception_start(
 	const struct bt_cap_commander_broadcast_reception_start_param *param)
 {
+	int err;
+
 	if (!valid_broadcast_reception_start_param(param)) {
 		return -EINVAL;
 	}
@@ -410,7 +385,12 @@ int bt_cap_commander_broadcast_reception_start(
 		return -EBUSY;
 	}
 
-	return cap_commander_broadcast_reception_start(param);
+	err = cap_commander_broadcast_reception_start(param);
+	if (err != 0) {
+		bt_cap_common_clear_active_proc();
+	}
+
+	return err;
 }
 
 static void
@@ -434,6 +414,10 @@ static void cap_commander_broadcast_assistant_recv_state_cb(
 		/* Empty receive state, indicating that the source has been removed
 		 */
 		return;
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
+		bt_cap_handover_receive_state_updated(conn, state);
 	}
 
 	if (bt_cap_common_conn_in_active_proc(conn) &&
@@ -539,7 +523,7 @@ static void cap_commander_broadcast_assistant_mod_src_cb(struct bt_conn *conn, i
 	}
 }
 
-static bool valid_broadcast_reception_stop_param(
+bool bt_cap_commander_valid_broadcast_reception_stop_param(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param)
 {
 	CHECKIF(param == NULL) {
@@ -607,7 +591,7 @@ static bool valid_broadcast_reception_stop_param(
 	return true;
 }
 
-int bt_cap_commander_broadcast_reception_stop(
+int cap_commander_broadcast_reception_stop(
 	const struct bt_cap_commander_broadcast_reception_stop_param *param)
 {
 	struct bt_bap_broadcast_assistant_mod_src_param mod_src_param = {0};
@@ -616,23 +600,7 @@ int bt_cap_commander_broadcast_reception_stop(
 	struct bt_conn *conn;
 	int err;
 
-	if (!valid_broadcast_reception_stop_param(param)) {
-		return -EINVAL;
-	}
-
-	if (bt_cap_common_test_and_set_proc_active()) {
-		LOG_DBG("A CAP procedure is already in progress");
-
-		return -EBUSY;
-	}
-
-	broadcast_assistant_cb.mod_src = cap_commander_broadcast_assistant_mod_src_cb;
-	broadcast_assistant_cb.rem_src = cap_commander_broadcast_assistant_rem_src_cb;
-	broadcast_assistant_cb.recv_state = cap_commander_broadcast_assistant_recv_state_cb;
-	if (!broadcast_assistant_cb_registered) {
-		err = cap_commander_register_broadcast_assistant_cb();
-		__ASSERT(err == 0, "Failed to register broadcast assistant callbacks: %d", err);
-	}
+	cap_commander_register_broadcast_assistant_callbacks();
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP, param->count);
 
@@ -648,8 +616,6 @@ int bt_cap_commander_broadcast_reception_stop(
 		/* Perform extra check in case that connection state has changed */
 		if (member_conn == NULL) {
 			LOG_DBG("Invalid param->member[%zu]", i);
-
-			bt_cap_common_clear_active_proc();
 
 			return -EINVAL;
 		}
@@ -678,12 +644,33 @@ int bt_cap_commander_broadcast_reception_stop(
 	if (err != 0) {
 		LOG_DBG("Failed to stop broadcast reception for conn %p: %d", (void *)conn, err);
 
-		bt_cap_common_clear_active_proc();
-
 		return -ENOEXEC;
 	}
 
 	return 0;
+}
+
+int bt_cap_commander_broadcast_reception_stop(
+	const struct bt_cap_commander_broadcast_reception_stop_param *param)
+{
+	int err;
+
+	if (!bt_cap_commander_valid_broadcast_reception_stop_param(param)) {
+		return -EINVAL;
+	}
+
+	if (bt_cap_common_test_and_set_proc_active()) {
+		LOG_DBG("A CAP procedure is already in progress");
+
+		return -EBUSY;
+	}
+
+	err = cap_commander_broadcast_reception_stop(param);
+	if (err != 0) {
+		bt_cap_common_clear_active_proc();
+	}
+
+	return err;
 }
 
 static void cap_commander_broadcast_assistant_set_broadcast_code_cb(struct bt_conn *conn, int err)
@@ -811,12 +798,7 @@ int bt_cap_commander_distribute_broadcast_code(
 		return -EBUSY;
 	}
 
-	broadcast_assistant_cb.broadcast_code =
-		cap_commander_broadcast_assistant_set_broadcast_code_cb;
-	if (!broadcast_assistant_cb_registered) {
-		err = cap_commander_register_broadcast_assistant_cb();
-		__ASSERT(err == 0, "Failed to register broadcast assistant callbacks: %d", err);
-	}
+	cap_commander_register_broadcast_assistant_callbacks();
 
 	bt_cap_common_set_proc(BT_CAP_COMMON_PROC_TYPE_DISTRIBUTE_BROADCAST_CODE, param->count);
 
@@ -870,6 +852,26 @@ int bt_cap_commander_distribute_broadcast_code(
 	return 0;
 }
 
+void cap_commander_register_broadcast_assistant_callbacks(void)
+{
+	static bool broadcast_assistant_cb_registered;
+
+	if (!broadcast_assistant_cb_registered) {
+		static struct bt_bap_broadcast_assistant_cb broadcast_assistant_cb = {
+			.add_src = cap_commander_broadcast_assistant_add_src_cb,
+			.mod_src = cap_commander_broadcast_assistant_mod_src_cb,
+			.rem_src = cap_commander_broadcast_assistant_rem_src_cb,
+			.recv_state = cap_commander_broadcast_assistant_recv_state_cb,
+			.broadcast_code = cap_commander_broadcast_assistant_set_broadcast_code_cb,
+		};
+		int err;
+
+		err = bt_bap_broadcast_assistant_register_cb(&broadcast_assistant_cb);
+		__ASSERT(err == 0, "Failed to register broadcast assistant callbacks: %d", err);
+
+		broadcast_assistant_cb_registered = true;
+	}
+}
 #endif /* CONFIG_BT_BAP_BROADCAST_ASSISTANT */
 
 static void cap_commander_proc_complete(void)
@@ -884,13 +886,30 @@ static void cap_commander_proc_complete(void)
 	proc_type = active_proc->proc_type;
 
 	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
-		/* Complete handover procedure. At this point we do not know if the remote
-		 * device will attempt to use PAST or scan for itself, so it's best to leave
-		 * this up to the application layer
-		 */
-		__ASSERT_NO_MSG(proc_type == BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START);
+		if (proc_type == BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_START) {
+			/* Complete unicast to broadcast handover procedure. At this point we do not
+			 * know if the remote device will attempt to use PAST or scan for itself, so
+			 * it's best to leave this up to the application layer
+			 */
 
-		bt_cap_handover_proc_complete();
+			bt_cap_handover_complete();
+		} else if (proc_type == BT_CAP_COMMON_PROC_TYPE_BROADCAST_RECEPTION_STOP) {
+			if (err != 0) {
+				bt_cap_handover_complete();
+			} else {
+				/* We've successfully stopped broadcast reception on all the
+				 * acceptors. We can now stop and delete the broadcast source before
+				 * starting the unicast audio
+				 */
+				err = bt_cap_handover_broadcast_reception_stopped();
+				if (err != 0) {
+					bt_cap_handover_complete();
+				}
+			}
+		} else {
+			__ASSERT(false, "invalid proc_type %d", proc_type);
+		}
+
 		return;
 	}
 

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -140,9 +140,7 @@ static bool cap_initiator_valid_metadata(const uint8_t meta[], size_t meta_len)
 }
 
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
-static struct bt_cap_broadcast_source {
-	struct bt_bap_broadcast_source *bap_broadcast;
-} broadcast_sources[CONFIG_BT_BAP_BROADCAST_SRC_COUNT];
+static struct bt_cap_broadcast_source broadcast_sources[CONFIG_BT_BAP_BROADCAST_SRC_COUNT];
 
 bool bt_cap_initiator_broadcast_audio_start_valid_param(
 	const struct bt_cap_initiator_broadcast_create_param *param)
@@ -317,7 +315,7 @@ static void broadcast_source_started_cb(struct bt_bap_broadcast_source *bap_broa
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active() &&
+	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) &&
 	    bt_cap_handover_is_handover_broadcast_source(source)) {
 		bt_cap_handover_unicast_to_broadcast_reception_start();
 		return;
@@ -339,7 +337,7 @@ static void broadcast_source_stopped_cb(struct bt_bap_broadcast_source *bap_broa
 		return;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active() &&
+	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) &&
 	    bt_cap_handover_is_handover_broadcast_source(source)) {
 		bt_cap_handover_broadcast_source_stopped(reason);
 		return;
@@ -488,7 +486,7 @@ int bt_cap_initiator_broadcast_foreach_stream(struct bt_cap_broadcast_source *br
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT)
 static struct bt_cap_unicast_group unicast_groups[CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_COUNT];
 
-static enum bt_bap_ep_state stream_get_state(const struct bt_bap_stream *bap_stream)
+enum bt_bap_ep_state bt_cap_initiator_stream_get_state(const struct bt_bap_stream *bap_stream)
 {
 	struct bt_bap_ep_info ep_info;
 	int err;
@@ -507,13 +505,10 @@ static enum bt_bap_ep_state stream_get_state(const struct bt_bap_stream *bap_str
 	return ep_info.state;
 }
 
-static bool stream_is_in_state(const struct bt_bap_stream *bap_stream, enum bt_bap_ep_state state)
+bool bt_cap_initiator_stream_is_in_state(const struct bt_bap_stream *bap_stream,
+					 enum bt_bap_ep_state state)
 {
-	if (bap_stream->conn == NULL) {
-		return state == BT_BAP_EP_STATE_IDLE;
-	}
-
-	return stream_get_state(bap_stream) == state;
+	return bt_cap_initiator_stream_get_state(bap_stream) == state;
 }
 
 static bool stream_is_dir(const struct bt_bap_stream *bap_stream, enum bt_audio_dir dir)
@@ -618,7 +613,7 @@ static void update_proc_done_cnt(struct bt_cap_common_proc *active_proc)
 			cap_stream = proc_param->stream;
 			bap_stream = &cap_stream->bap_stream;
 
-			state = stream_get_state(bap_stream);
+			state = bt_cap_initiator_stream_get_state(bap_stream);
 
 			switch (subproc_type) {
 			case BT_CAP_COMMON_SUBPROC_TYPE_CODEC_CONFIG:
@@ -679,7 +674,7 @@ static void update_proc_done_cnt(struct bt_cap_common_proc *active_proc)
 			cap_stream = proc_param->stream;
 			bap_stream = &cap_stream->bap_stream;
 
-			state = stream_get_state(bap_stream);
+			state = bt_cap_initiator_stream_get_state(bap_stream);
 
 			switch (subproc_type) {
 			case BT_CAP_COMMON_SUBPROC_TYPE_DISABLE:
@@ -717,7 +712,7 @@ static void update_proc_done_cnt(struct bt_cap_common_proc *active_proc)
 		cap_stream = proc_param->stream;
 		bap_stream = &cap_stream->bap_stream;
 
-		state = stream_get_state(bap_stream);
+		state = bt_cap_initiator_stream_get_state(bap_stream);
 
 		switch (subproc_type) {
 		case BT_CAP_COMMON_SUBPROC_TYPE_META_UPDATE:
@@ -764,7 +759,7 @@ get_next_proc_param(struct bt_cap_common_proc *active_proc)
 
 		cap_stream = proc_param->stream;
 		bap_stream = &cap_stream->bap_stream;
-		state = stream_get_state(bap_stream);
+		state = bt_cap_initiator_stream_get_state(bap_stream);
 
 		switch (subproc_type) {
 		case BT_CAP_COMMON_SUBPROC_TYPE_CODEC_CONFIG:
@@ -873,7 +868,7 @@ valid_group_stream_pair_param(const struct bt_cap_unicast_group_stream_pair_para
 	return true;
 }
 
-static bool valid_unicast_group_param(const struct bt_cap_unicast_group_param *param)
+bool bt_cap_initiator_valid_unicast_group_param(const struct bt_cap_unicast_group_param *param)
 {
 	if (param == NULL) {
 		LOG_DBG("param is NULL");
@@ -968,7 +963,7 @@ int bt_cap_unicast_group_create(const struct bt_cap_unicast_group_param *param,
 		return -EINVAL;
 	}
 
-	if (!valid_unicast_group_param(param)) {
+	if (!bt_cap_initiator_valid_unicast_group_param(param)) {
 		return -EINVAL;
 	}
 
@@ -1011,7 +1006,7 @@ int bt_cap_unicast_group_reconfig(struct bt_cap_unicast_group *unicast_group,
 		return -EINVAL;
 	}
 
-	if (!valid_unicast_group_param(param)) {
+	if (!bt_cap_initiator_valid_unicast_group_param(param)) {
 		return -EINVAL;
 	}
 
@@ -1129,9 +1124,11 @@ int bt_cap_unicast_group_get_info(const struct bt_cap_unicast_group *unicast_gro
 	return 0;
 }
 
-static bool valid_unicast_audio_start_param(const struct bt_cap_unicast_audio_start_param *param)
+bool bt_cap_initiator_valid_unicast_audio_start_param(
+	const struct bt_cap_unicast_audio_start_param *param)
 {
-	struct bt_bap_unicast_group *unicast_group = NULL;
+	/* Group can either be a unicast group or a broadcast source (in the case of handover) */
+	void *group = NULL;
 
 	CHECKIF(param == NULL) {
 		LOG_DBG("param is NULL");
@@ -1203,17 +1200,18 @@ static bool valid_unicast_audio_start_param(const struct bt_cap_unicast_audio_st
 		bap_stream = &cap_stream->bap_stream;
 
 		CHECKIF(bap_stream->group == NULL) {
-			LOG_DBG("param->streams[%zu] is not in a unicast group", i);
+			LOG_DBG("param->streams[%zu] (%p) is not in a unicast group", i,
+				bap_stream);
 			return false;
 		}
 
 		/* Use the group of the first stream for comparison */
-		if (unicast_group == NULL) {
-			unicast_group = bap_stream->group;
+		if (group == NULL) {
+			group = bap_stream->group;
 		} else {
-			CHECKIF(bap_stream->group != unicast_group) {
-				LOG_DBG("param->streams[%zu] is not in this group %p", i,
-					unicast_group);
+			CHECKIF(bap_stream->group != group) {
+				LOG_DBG("param->streams[%zu] (%p) is not in this group %p", i,
+					group, bap_stream);
 				return false;
 			}
 		}
@@ -1244,7 +1242,7 @@ static void cap_initiator_unicast_audio_proc_complete(void)
 	proc_type = active_proc->proc_type;
 
 	if (IS_ENABLED(CONFIG_BT_CAP_HANDOVER) && bt_cap_common_handover_is_active()) {
-		bt_cap_handover_unicast_audio_stopped();
+		bt_cap_handover_unicast_proc_complete();
 		return;
 	}
 
@@ -1378,19 +1376,38 @@ cap_initiator_unicast_audio_configure(const struct bt_cap_unicast_audio_start_pa
 	err = bt_bap_stream_config(conn, bap_stream, ep, codec_cfg);
 	if (err != 0) {
 		LOG_DBG("Failed to config stream %p: %d", proc_param->stream, err);
-
-		bt_cap_common_clear_active_proc();
 	}
 
 	return err;
 }
 
-int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param)
+int cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param)
 {
 	bool all_streaming = true;
+
+	for (size_t i = 0U; i < param->count; i++) {
+		const struct bt_bap_stream *bap_stream =
+			&param->stream_params[i].stream->bap_stream;
+
+		if (!bt_cap_initiator_stream_is_in_state(bap_stream, BT_BAP_EP_STATE_STREAMING)) {
+			all_streaming = false;
+		}
+	}
+
+	if (all_streaming) {
+		LOG_DBG("All streams are already in the streaming state");
+
+		return -EALREADY;
+	}
+
+	return cap_initiator_unicast_audio_configure(param);
+}
+
+int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param)
+{
 	int err;
 
-	if (!valid_unicast_audio_start_param(param)) {
+	if (!bt_cap_initiator_valid_unicast_audio_start_param(param)) {
 		return -EINVAL;
 	}
 
@@ -1400,24 +1417,7 @@ int bt_cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start
 		return -EBUSY;
 	}
 
-	for (size_t i = 0U; i < param->count; i++) {
-		const struct bt_bap_stream *bap_stream =
-			&param->stream_params[i].stream->bap_stream;
-
-		if (!stream_is_in_state(bap_stream, BT_BAP_EP_STATE_STREAMING)) {
-			all_streaming = false;
-		}
-	}
-
-	if (all_streaming) {
-		LOG_DBG("All streams are already in the streaming state");
-
-		bt_cap_common_clear_active_proc();
-
-		return -EALREADY;
-	}
-
-	err = cap_initiator_unicast_audio_configure(param);
+	err = cap_initiator_unicast_audio_start(param);
 	if (err != 0) {
 		bt_cap_common_clear_active_proc();
 	}
@@ -1933,8 +1933,8 @@ void bt_cap_initiator_started(struct bt_cap_stream *cap_stream)
 
 static bool can_update_metadata(const struct bt_bap_stream *bap_stream)
 {
-	return stream_is_in_state(bap_stream, BT_BAP_EP_STATE_ENABLING) ||
-	       stream_is_in_state(bap_stream, BT_BAP_EP_STATE_STREAMING);
+	return bt_cap_initiator_stream_is_in_state(bap_stream, BT_BAP_EP_STATE_ENABLING) ||
+	       bt_cap_initiator_stream_is_in_state(bap_stream, BT_BAP_EP_STATE_STREAMING);
 }
 
 static bool valid_unicast_audio_update_param(const struct bt_cap_unicast_audio_update_param *param)
@@ -2163,7 +2163,7 @@ static bool can_release_stream(const struct bt_bap_stream *bap_stream)
 		return false;
 	}
 
-	state = stream_get_state(bap_stream);
+	state = bt_cap_initiator_stream_get_state(bap_stream);
 
 	/* We cannot release idle endpoints.
 	 * We do not know if we can release endpoints in the Codec Configured state as servers may
@@ -2180,7 +2180,7 @@ static bool can_disable_stream(const struct bt_bap_stream *bap_stream)
 		return false;
 	}
 
-	state = stream_get_state(bap_stream);
+	state = bt_cap_initiator_stream_get_state(bap_stream);
 
 	return state == BT_BAP_EP_STATE_STREAMING || state == BT_BAP_EP_STATE_ENABLING;
 }
@@ -2202,7 +2202,7 @@ static bool can_stop_stream(const struct bt_bap_stream *bap_stream)
 		return false;
 	}
 
-	return stream_is_in_state(bap_stream, BT_BAP_EP_STATE_DISABLING);
+	return bt_cap_initiator_stream_is_in_state(bap_stream, BT_BAP_EP_STATE_DISABLING);
 }
 
 bool bt_cap_initiator_valid_unicast_audio_stop_param(
@@ -2328,8 +2328,6 @@ int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_para
 						 : !can_stop  ? "stop"
 							      : "release");
 
-		bt_cap_common_clear_active_proc();
-
 		return -EALREADY;
 	}
 
@@ -2355,8 +2353,6 @@ int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_para
 		err = bt_bap_stream_disable(bap_stream);
 		if (err != 0) {
 			LOG_DBG("Failed to disable bap_stream %p: %d", proc_param->stream, err);
-
-			bt_cap_common_clear_active_proc();
 		}
 	} else if (can_stop) {
 		struct bt_cap_initiator_proc_param *proc_param;
@@ -2374,8 +2370,6 @@ int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_para
 		err = bt_bap_stream_stop(bap_stream);
 		if (err != 0) {
 			LOG_DBG("Failed to stop bap_stream %p: %d", proc_param->stream, err);
-
-			bt_cap_common_clear_active_proc();
 		}
 	} else {
 		struct bt_cap_initiator_proc_param *proc_param;
@@ -2393,8 +2387,6 @@ int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_para
 		err = bt_bap_stream_release(bap_stream);
 		if (err != 0) {
 			LOG_DBG("Failed to release bap_stream %p: %d", proc_param->stream, err);
-
-			bt_cap_common_clear_active_proc();
 		}
 	}
 
@@ -2403,6 +2395,8 @@ int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_para
 
 int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param)
 {
+	int err;
+
 	if (!bt_cap_initiator_valid_unicast_audio_stop_param(param)) {
 		return -EINVAL;
 	}
@@ -2413,7 +2407,12 @@ int bt_cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_p
 		return -EBUSY;
 	}
 
-	return cap_initiator_unicast_audio_stop(param);
+	err = cap_initiator_unicast_audio_stop(param);
+	if (err != 0) {
+		bt_cap_common_clear_active_proc();
+	}
+
+	return err;
 }
 
 void bt_cap_initiator_disabled(struct bt_cap_stream *cap_stream)

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -87,6 +87,10 @@ struct bt_cap_unicast_group {
 	struct bt_bap_unicast_group *bap_unicast_group;
 };
 
+struct bt_cap_broadcast_source {
+	struct bt_bap_broadcast_source *bap_broadcast;
+};
+
 struct bt_cap_initiator_proc_param {
 	struct bt_cap_stream *stream;
 	union {
@@ -198,8 +202,43 @@ struct bt_cap_handover_proc_param {
 			struct bt_cap_commander_broadcast_reception_start_member_param
 				reception_start_member_params[CONFIG_BT_MAX_CONN];
 		} unicast_to_broadcast;
-		/* TODO: Add unicast broadcast_to_unicast params */
+		struct {
+			/* The existing broadcast source */
+			struct bt_cap_broadcast_source *broadcast_source;
+
+			/* The resulting unicast group */
+			struct bt_cap_unicast_group *unicast_group;
+
+			/* Broadcast ID of broadcast_source*/
+			uint32_t broadcast_id;
+
+			/* Advertising SID of broadcast_source*/
+			uint8_t adv_sid;
+
+			/* Advertising type of broadcast_source*/
+			uint8_t adv_type;
+
+			/* States used to determine when the broadcast source can be deleted */
+			bool broadcast_stopped;
+			bool reception_stopped;
+
+			/* Array of connection objects that we are waiting for a receive state with
+			 * a BIG sync lost event
+			 */
+			struct bt_conn *pending_recv_state_conns[MIN(
+				CONFIG_BT_MAX_CONN,
+				CONFIG_BT_BAP_UNICAST_CLIENT_GROUP_STREAM_COUNT)];
+
+			/* Unicast group create param from caller */
+			struct bt_cap_unicast_group_param *unicast_group_param;
+
+			/* Unicast start param from caller */
+			struct bt_cap_unicast_audio_start_param *unicast_start_param;
+		} broadcast_to_unicast;
 	};
+
+	/* Flag to determine which of the two structs above to use */
+	bool is_unicast_to_broadcast;
 };
 #endif /* CONFIG_BT_CAP_HANDOVER */
 
@@ -276,17 +315,35 @@ int bt_cap_common_discover(struct bt_conn *conn, bt_cap_common_discover_func_t f
 
 bool bt_cap_initiator_broadcast_audio_start_valid_param(
 	const struct bt_cap_initiator_broadcast_create_param *param);
+bool bt_cap_initiator_valid_unicast_audio_start_param(
+	const struct bt_cap_unicast_audio_start_param *param);
+bool bt_cap_initiator_valid_unicast_group_param(const struct bt_cap_unicast_group_param *param);
+bool bt_cap_initiator_stream_is_in_state(const struct bt_bap_stream *bap_stream,
+					 enum bt_bap_ep_state state);
 bool bt_cap_initiator_valid_unicast_audio_stop_param(
 	const struct bt_cap_unicast_audio_stop_param *param);
+int cap_initiator_unicast_audio_start(const struct bt_cap_unicast_audio_start_param *param);
 int cap_initiator_unicast_audio_stop(const struct bt_cap_unicast_audio_stop_param *param);
+enum bt_bap_ep_state bt_cap_initiator_stream_get_state(const struct bt_bap_stream *bap_stream);
 
 int cap_commander_broadcast_reception_start(
 	const struct bt_cap_commander_broadcast_reception_start_param *param);
+int cap_commander_broadcast_reception_start(
+	const struct bt_cap_commander_broadcast_reception_start_param *param);
+int cap_commander_broadcast_reception_stop(
+	const struct bt_cap_commander_broadcast_reception_stop_param *param);
+bool bt_cap_commander_valid_broadcast_reception_stop_param(
+	const struct bt_cap_commander_broadcast_reception_stop_param *param);
+void cap_commander_register_broadcast_assistant_callbacks(void);
 
-void bt_cap_handover_proc_complete(void);
-bool bt_cap_handover_is_handover_broadcast_source(
-	const struct bt_cap_broadcast_source *cap_broadcast_source);
+void bt_cap_handover_complete(void);
 void bt_cap_handover_unicast_to_broadcast_setup_broadcast(void);
 void bt_cap_handover_unicast_to_broadcast_reception_start(void);
-void bt_cap_handover_unicast_audio_stopped(void);
+void bt_cap_handover_unicast_proc_complete(void);
 void bt_cap_handover_broadcast_source_stopped(uint8_t reason);
+void bt_cap_handover_broadcast_audio_stopped(void);
+void bt_cap_handover_receive_state_updated(const struct bt_conn *conn,
+					   const struct bt_bap_scan_delegator_recv_state *state);
+bool bt_cap_handover_is_handover_broadcast_source(
+	const struct bt_cap_broadcast_source *cap_broadcast_source);
+int bt_cap_handover_broadcast_reception_stopped(void);

--- a/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
+++ b/tests/bsim/bluetooth/audio/src/cap_handover_central_test.c
@@ -53,17 +53,23 @@ static struct bt_bap_lc3_preset unicast_preset_16_2_1 = BT_BAP_LC3_UNICAST_PRESE
 	BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 static struct bt_bap_lc3_preset broadcast_preset_16_2_1 = BT_BAP_LC3_BROADCAST_PRESET_16_2_1(
 	BT_AUDIO_LOCATION_FRONT_LEFT, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
+;
+static struct bt_cap_unicast_audio_start_param unicast_audio_start_param;
+static struct bt_cap_initiator_broadcast_create_param broadcast_create_param;
+static struct bt_cap_unicast_group_param unicast_group_param;
 
 static struct cap_acceptor {
 	struct audio_test_stream sink_stream;
 	struct audio_test_stream source_stream;
 	struct bt_bap_ep *unicast_sink_ep;
 	struct bt_bap_ep *unicast_source_ep;
+	uint8_t src_id;
 	struct bt_conn *conn;
 } cap_acceptors[CONFIG_BT_MAX_CONN];
 
 static size_t connected_conn_cnt;
 static struct bt_cap_broadcast_source *broadcast_source;
+static struct bt_cap_unicast_group *unicast_group;
 static bt_addr_le_t remote_dev_addr;
 
 CREATE_FLAG(flag_dev_found);
@@ -73,6 +79,7 @@ CREATE_FLAG(flag_endpoint_found);
 CREATE_FLAG(flag_started);
 CREATE_FLAG(flag_stopped);
 CREATE_FLAG(flag_handover_unicast_to_broadcast);
+CREATE_FLAG(flag_handover_broadcast_to_unicast);
 CREATE_FLAG(flag_mtu_exchanged);
 CREATE_FLAG(flag_sink_discovered);
 CREATE_FLAG(flag_source_discovered);
@@ -102,6 +109,30 @@ static void cap_discovery_complete_cb(struct bt_conn *conn, int err,
 	}
 
 	SET_FLAG(flag_discovered);
+}
+
+static void
+bap_broadcast_assistant_recv_state_cb(struct bt_conn *conn, int err,
+				      const struct bt_bap_scan_delegator_recv_state *state)
+{
+	if (conn == NULL) {
+		FAIL("conn was NULL");
+		return;
+	}
+
+	if (err != 0) {
+		FAIL("Unexpected error: %d", err);
+		return;
+	}
+
+	if (state != NULL) {
+		LOG_DBG("Received receive state notification from %p with pa_state %d and src_id "
+			"0x%02X",
+			(void *)conn, state->pa_sync_state, state->src_id);
+		cap_acceptors[bt_conn_index(conn)].src_id = state->src_id;
+	} else {
+		cap_acceptors[bt_conn_index(conn)].src_id = 0U;
+	}
 }
 
 static void bap_broadcast_assistant_discover_cb(struct bt_conn *conn, int err,
@@ -137,7 +168,7 @@ static void unicast_stop_complete_cb(int err, struct bt_conn *conn)
 }
 
 static void unicast_to_broadcast_complete_cb(int err, struct bt_conn *conn,
-					     struct bt_cap_unicast_group *unicast_group,
+					     struct bt_cap_unicast_group *group,
 					     struct bt_cap_broadcast_source *source)
 {
 	if (err != 0) {
@@ -146,8 +177,26 @@ static void unicast_to_broadcast_complete_cb(int err, struct bt_conn *conn,
 		return;
 	}
 
+	LOG_DBG("Unicast to broadcast handover completed with new source %p", source);
+
 	broadcast_source = source;
 	SET_FLAG(flag_handover_unicast_to_broadcast);
+}
+
+static void broadcast_to_unicast_complete_cb(int err, struct bt_conn *conn,
+					     struct bt_cap_broadcast_source *source,
+					     struct bt_cap_unicast_group *group)
+{
+	if (err != 0) {
+		FAIL("Failed to handover broadcast to unicast (failing conn %p): %d", conn, err);
+
+		return;
+	}
+
+	LOG_DBG("Broadcast to unicast handover completed with new unicast group %p", group);
+
+	unicast_group = group;
+	SET_FLAG(flag_handover_broadcast_to_unicast);
 }
 
 static void add_remote_sink(const struct bt_conn *conn, struct bt_bap_ep *ep)
@@ -342,9 +391,11 @@ static void init(void)
 	};
 	static struct bt_bap_broadcast_assistant_cb ba_cbs = {
 		.discover = bap_broadcast_assistant_discover_cb,
+		.recv_state = bap_broadcast_assistant_recv_state_cb,
 	};
 	static struct bt_cap_handover_cb cap_handover_cb = {
 		.unicast_to_broadcast_complete = unicast_to_broadcast_complete_cb,
+		.broadcast_to_unicast_complete = broadcast_to_unicast_complete_cb,
 	};
 	static struct bt_cap_initiator_cb cap_initiator_cb = {
 		.unicast_discovery_complete = cap_discovery_complete_cb,
@@ -526,12 +577,13 @@ static void discover_bass(struct bt_conn *conn)
 	WAIT_FOR_FLAG(flag_discovered);
 }
 
-static void unicast_group_create(struct bt_cap_unicast_group **out_unicast_group)
+static void unicast_group_create(void)
 {
-	struct bt_cap_unicast_group_stream_param group_source_stream_params[CONFIG_BT_MAX_CONN];
-	struct bt_cap_unicast_group_stream_param group_sink_stream_params[CONFIG_BT_MAX_CONN];
-	struct bt_cap_unicast_group_stream_pair_param pair_params[CONFIG_BT_MAX_CONN];
-	struct bt_cap_unicast_group_param group_param;
+	static struct bt_cap_unicast_group_stream_param
+		group_source_stream_params[CONFIG_BT_MAX_CONN];
+	static struct bt_cap_unicast_group_stream_param
+		group_sink_stream_params[CONFIG_BT_MAX_CONN];
+	static struct bt_cap_unicast_group_stream_pair_param pair_params[CONFIG_BT_MAX_CONN];
 	int err;
 
 	for (size_t i = 0U; i < connected_conn_cnt; i++) {
@@ -545,21 +597,21 @@ static void unicast_group_create(struct bt_cap_unicast_group **out_unicast_group
 		pair_params[i].rx_param = &group_source_stream_params[i];
 	}
 
-	group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	group_param.params_count = connected_conn_cnt;
-	group_param.params = pair_params;
+	unicast_group_param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	unicast_group_param.params_count = connected_conn_cnt;
+	unicast_group_param.params = pair_params;
 
-	err = bt_cap_unicast_group_create(&group_param, out_unicast_group);
+	err = bt_cap_unicast_group_create(&unicast_group_param, &unicast_group);
 	if (err != 0) {
 		FAIL("Failed to create group: %d\n", err);
 		return;
 	}
 }
 
-static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group)
+static void unicast_audio_start(void)
 {
-	struct bt_cap_unicast_audio_start_stream_param stream_param[2 * ARRAY_SIZE(cap_acceptors)];
-	struct bt_cap_unicast_audio_start_param param;
+	static struct bt_cap_unicast_audio_start_stream_param
+		stream_param[2 * ARRAY_SIZE(cap_acceptors)];
 	size_t stream_param_cnt = 0U;
 	int err;
 
@@ -581,13 +633,13 @@ static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group)
 		stream_param_cnt++;
 	}
 
-	param.type = BT_CAP_SET_TYPE_AD_HOC;
-	param.count = stream_param_cnt;
-	param.stream_params = stream_param;
+	unicast_audio_start_param.type = BT_CAP_SET_TYPE_AD_HOC;
+	unicast_audio_start_param.count = stream_param_cnt;
+	unicast_audio_start_param.stream_params = stream_param;
 
 	UNSET_FLAG(flag_started);
 
-	err = bt_cap_initiator_unicast_audio_start(&param);
+	err = bt_cap_initiator_unicast_audio_start(&unicast_audio_start_param);
 	if (err != 0) {
 		FAIL("Failed to start unicast audio: %d\n", err);
 		return;
@@ -598,14 +650,41 @@ static void unicast_audio_start(struct bt_cap_unicast_group *unicast_group)
 	backchannel_sync_send_all();
 }
 
-static void handover_unicast_to_broadcast(struct bt_cap_unicast_group *unicast_group,
-					  struct bt_le_ext_adv *ext_adv)
+static void unicast_audio_stop(void)
+{
+	struct bt_cap_stream *streams_to_stop[ARRAY_SIZE(cap_acceptors)];
+	struct bt_cap_unicast_audio_stop_param param = {0};
+	int err;
+
+	for (size_t i = 0U; i < connected_conn_cnt; i++) {
+		/* Sink param */
+		streams_to_stop[param.count++] =
+			cap_stream_from_audio_test_stream(&cap_acceptors[i].sink_stream);
+	}
+
+	param.type = BT_CAP_SET_TYPE_AD_HOC;
+	param.streams = streams_to_stop;
+	param.release = true;
+
+	/* Stop without release first to verify that we enter the QoS Configured state */
+	UNSET_FLAG(flag_stopped);
+	LOG_DBG("Stopping");
+
+	err = bt_cap_initiator_unicast_audio_stop(&param);
+	if (err != 0) {
+		FAIL("Failed to stop unicast audio: %d\n", err);
+		return;
+	}
+
+	WAIT_FOR_FLAG(flag_stopped);
+}
+
+static void handover_unicast_to_broadcast(struct bt_le_ext_adv *ext_adv, uint32_t broadcast_id)
 {
 	static struct bt_cap_initiator_broadcast_stream_param
 		stream_params[ARRAY_SIZE(cap_acceptors)];
 	static struct bt_cap_initiator_broadcast_subgroup_param subgroup_param = {0};
 	/* Struct containing the converted unicast group configuration */
-	static struct bt_cap_initiator_broadcast_create_param create_param = {0};
 	struct bt_cap_handover_unicast_to_broadcast_param param = {0};
 	size_t stream_cnt = 0U;
 	int err;
@@ -649,18 +728,18 @@ static void handover_unicast_to_broadcast(struct bt_cap_unicast_group *unicast_g
 	subgroup_param.stream_params = stream_params;
 	subgroup_param.codec_cfg = &broadcast_preset_16_2_1.codec_cfg;
 
-	create_param.subgroup_count = 1U;
-	create_param.subgroup_params = &subgroup_param;
-	create_param.qos = &broadcast_preset_16_2_1.qos;
-	create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
-	create_param.encryption = false;
+	broadcast_create_param.subgroup_count = 1U;
+	broadcast_create_param.subgroup_params = &subgroup_param;
+	broadcast_create_param.qos = &broadcast_preset_16_2_1.qos;
+	broadcast_create_param.packing = BT_ISO_PACKING_SEQUENTIAL;
+	broadcast_create_param.encryption = false;
 
 	param.type = BT_CAP_SET_TYPE_AD_HOC;
 	param.unicast_group = unicast_group;
-	param.broadcast_create_param = &create_param;
+	param.broadcast_create_param = &broadcast_create_param;
 	param.ext_adv = ext_adv;
 	param.pa_interval = BT_BAP_PA_INTERVAL_UNKNOWN;
-	param.broadcast_id = 0x123456;
+	param.broadcast_id = broadcast_id;
 
 	UNSET_FLAG(flag_handover_unicast_to_broadcast);
 
@@ -671,6 +750,59 @@ static void handover_unicast_to_broadcast(struct bt_cap_unicast_group *unicast_g
 	}
 
 	WAIT_FOR_FLAG(flag_handover_unicast_to_broadcast);
+}
+
+static void handover_broadcast_to_unicast(
+	const struct bt_le_ext_adv *ext_adv, uint8_t adv_sid, uint32_t broadcast_id,
+	struct bt_cap_commander_broadcast_reception_stop_param *reception_stop_param)
+{
+	struct bt_cap_unicast_audio_start_stream_param stream_params[ARRAY_SIZE(cap_acceptors)] = {
+		0};
+	struct bt_cap_handover_broadcast_to_unicast_param param = {0};
+	struct bt_le_ext_adv_info adv_info;
+	size_t stream_param_cnt = 0U;
+	int err;
+
+	err = bt_le_ext_adv_get_info(ext_adv, &adv_info);
+	if (err != 0) {
+		FAIL("Failed to get adv info: %d\n", err);
+		return;
+	}
+
+	/* We use the previous unicast audio start parameters restart it for sinks only */
+	for (size_t i = 0U; i < unicast_audio_start_param.count; i++) {
+		const struct bt_cap_unicast_audio_start_stream_param *stream_param =
+			&unicast_audio_start_param.stream_params[i];
+
+		/* A NULL group Indicates that is/was a source stream - Ignore source streams as
+		 * they cannot be handed over from broadcast
+		 */
+		if (stream_param->stream->bap_stream.group != NULL) {
+			(void)memcpy(&stream_params[stream_param_cnt++], stream_param,
+				     sizeof(*stream_param));
+		}
+	}
+
+	unicast_audio_start_param.count = stream_param_cnt;
+	unicast_audio_start_param.stream_params = stream_params;
+
+	param.adv_type = adv_info.addr->type;
+	param.adv_sid = adv_sid;
+	param.broadcast_id = broadcast_id;
+	param.broadcast_source = broadcast_source;
+	param.unicast_group_param = &unicast_group_param;
+	param.unicast_start_param = &unicast_audio_start_param;
+	param.reception_stop_param = reception_stop_param; /* may be NULL */
+
+	UNSET_FLAG(flag_handover_broadcast_to_unicast);
+
+	err = bt_cap_handover_broadcast_to_unicast(&param);
+	if (err != 0) {
+		FAIL("Failed to handover unicast audio to broadcast: %d\n", err);
+		return;
+	}
+
+	WAIT_FOR_FLAG(flag_handover_broadcast_to_unicast);
 	LOG_DBG("Handover procedure completed");
 }
 
@@ -697,33 +829,9 @@ static void set_base_data(struct bt_le_ext_adv *ext_adv)
 	}
 }
 
-static void stop_broadcast(void)
+static void test_main_cap_handover_central_common(const size_t acceptor_cnt, uint32_t broadcast_id,
+						  struct bt_le_ext_adv **ext_adv)
 {
-	int err;
-
-	/* Verify that it cannot be stopped twice */
-	err = bt_cap_initiator_broadcast_audio_stop(broadcast_source);
-	if (err != 0) {
-		FAIL("Failed to stop broadcast source: %d\n", err);
-		return;
-	}
-
-	WAIT_FOR_FLAG(flag_broadcast_stopped);
-
-	err = bt_cap_initiator_broadcast_audio_delete(broadcast_source);
-	if (err != 0) {
-		FAIL("Failed to delete broadcast source: %d\n", err);
-		return;
-	}
-
-	broadcast_source = NULL;
-}
-
-static void test_main_cap_handover_unicast_to_broadcast(void)
-{
-	const size_t acceptor_cnt = get_dev_cnt() - 1; /* Assume all other devices are acceptors */
-	struct bt_cap_unicast_group *unicast_group;
-	struct bt_le_ext_adv *ext_adv;
 
 	if (acceptor_cnt > CONFIG_BT_BAP_BROADCAST_SRC_STREAM_COUNT) {
 		FAIL("Cannot run test with %zu acceptors and maximum %d broadcast streams",
@@ -745,23 +853,72 @@ static void test_main_cap_handover_unicast_to_broadcast(void)
 		discover_source(cap_acceptors[i].conn);
 	}
 
-	unicast_group_create(&unicast_group);
+	unicast_group_create();
 
-	unicast_audio_start(unicast_group);
-
-	/* Wait for acceptors to receive some data */
-	backchannel_sync_wait_all();
-
-	setup_broadcast_adv(&ext_adv);
-
-	handover_unicast_to_broadcast(unicast_group, ext_adv);
-	set_base_data(ext_adv);
-	start_broadcast_adv(ext_adv);
+	unicast_audio_start();
 
 	/* Wait for acceptors to receive some data */
 	backchannel_sync_wait_all();
 
-	stop_broadcast();
+	setup_broadcast_adv(ext_adv);
+
+	handover_unicast_to_broadcast(*ext_adv, broadcast_id);
+	unicast_group = NULL;
+	set_base_data(*ext_adv);
+	start_broadcast_adv(*ext_adv);
+
+	/* Wait for acceptors to receive some data */
+	backchannel_sync_wait_all();
+}
+
+static void test_main_cap_handover_central(void)
+{
+	const size_t acceptor_cnt = get_dev_cnt() - 1; /* Assume all other devices are acceptors */
+	uint32_t broadcast_id = 0x123456;
+	struct bt_le_ext_adv *ext_adv;
+	uint8_t adv_sid = 0x00;
+
+	test_main_cap_handover_central_common(acceptor_cnt, broadcast_id, &ext_adv);
+
+	handover_broadcast_to_unicast(ext_adv, adv_sid, broadcast_id, NULL);
+	broadcast_source = NULL;
+
+	/* Wait for acceptors to receive some data */
+	backchannel_sync_wait_all();
+
+	unicast_audio_stop();
+
+	PASS("CAP initiator handover unicast to broadcast passed\n");
+}
+
+static void test_main_cap_handover_central_reception_stop(void)
+{
+	struct bt_cap_commander_broadcast_reception_stop_param reception_stop_param = {0};
+	struct bt_cap_commander_broadcast_reception_stop_member_param
+		member_param[CONFIG_BT_MAX_CONN] = {0};
+	const size_t acceptor_cnt = get_dev_cnt() - 1; /* Assume all other devices are acceptors */
+	uint32_t broadcast_id = 0x123456;
+	struct bt_le_ext_adv *ext_adv;
+	uint8_t adv_sid = 0x00;
+
+	test_main_cap_handover_central_common(acceptor_cnt, broadcast_id, &ext_adv);
+
+	reception_stop_param.type = BT_CAP_SET_TYPE_AD_HOC;
+	reception_stop_param.param = member_param;
+	reception_stop_param.count = acceptor_cnt;
+	for (size_t i = 0; i < acceptor_cnt; i++) {
+		reception_stop_param.param[i].member.member = cap_acceptors[i].conn;
+		reception_stop_param.param[i].src_id = cap_acceptors[i].src_id;
+		reception_stop_param.param[i].num_subgroups = broadcast_create_param.subgroup_count;
+	}
+
+	handover_broadcast_to_unicast(ext_adv, adv_sid, broadcast_id, &reception_stop_param);
+	broadcast_source = NULL;
+
+	/* Wait for acceptors to receive some data */
+	backchannel_sync_wait_all();
+
+	unicast_audio_stop();
 
 	PASS("CAP initiator handover unicast to broadcast passed\n");
 }
@@ -771,7 +928,13 @@ static const struct bst_test_instance test_cap_handover_central[] = {
 		.test_id = "cap_handover_central",
 		.test_pre_init_f = test_init,
 		.test_tick_f = test_tick,
-		.test_main_f = test_main_cap_handover_unicast_to_broadcast,
+		.test_main_f = test_main_cap_handover_central,
+	},
+	{
+		.test_id = "cap_handover_central_reception_stop",
+		.test_pre_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_main_cap_handover_central_reception_stop,
 	},
 	BSTEST_END_MARKER,
 };

--- a/tests/bsim/bluetooth/audio/test_scripts/_cap.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap.sh
@@ -10,3 +10,4 @@ set -e # Exit on error
 
 $dir_path/_cap_broadcast.sh
 $dir_path/_cap_unicast.sh
+$dir_path/_cap_handover.sh

--- a/tests/bsim/bluetooth/audio/test_scripts/_cap_handover.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap_handover.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+dir_path=$(dirname "$0")
+
+set -e # Exit on error
+
+# Run all cap_handover* tests
+for file in "$dir_path"/cap_handover*.sh; do
+    if [ -f "$file" ]; then
+        echo "Running $file"
+        $file
+    fi
+done

--- a/tests/bsim/bluetooth/audio/test_scripts/_cap_handover_reception_stop.sh
+++ b/tests/bsim/bluetooth/audio/test_scripts/_cap_handover_reception_stop.sh
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Temporarily been disabled due to assert in the controller
+# ASSERTION FAIL [instant_latency == 0U] @
+# WEST_TOPDIR/zephyr/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c:1025
+# See https://github.com/zephyrproject-rtos/zephyr/issues/82399
+
 SIMULATION_ID="cap_handover_central"
 VERBOSITY_LEVEL=2
 NR_OF_DEVICES=3
@@ -13,11 +18,11 @@ source ${ZEPHYR_BASE}/tests/bsim/sh_common.source
 
 cd ${BSIM_OUT_PATH}/bin
 
-printf "\n\n======== Running CAP handover unicast to broadcast =========\n\n"
+printf "\n\n======== Running CAP handover unicast to broadcast with reception stop =========\n\n"
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=0 \
-  -testid=cap_handover_central \
+  -testid=cap_handover_central_reception_stop \
   -RealEncryption=1 -rs=23 -D=${NR_OF_DEVICES}
 
 Execute ./bs_${BOARD_TS}_tests_bsim_bluetooth_audio_prj_conf \


### PR DESCRIPTION
Implement the broadcast to unicast handover procedure, as per the Bluetooth CAP specificiation.

One test has been disable due to an assert in the controller (see https://github.com/zephyrproject-rtos/zephyr/issues/82399)