### PR TITLE
MAINTAINERS: Remove inactive collabs for Bluetooth Audio

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -520,8 +520,6 @@ Bluetooth Audio:
     - Thalley
   collaborators:
     - jhedberg
-    - Casper-Bonde-Bose
-    - MariuszSkamra
     - sjanc
     - asbjornsabo
     - fredrikdanebjer


### PR DESCRIPTION
The two collaborators, Casper-Bonde-Bose and MariuszSkamra, are not actively collaborating on Zephyr anymore.
Remove to avoid assigning them as reviewer for PRs which gives a false sense of who may actually review PRs.