### PR TITLE
toolchain: compiler: IAR does not allow vla with C++

### DIFF
--- a/cmake/compiler/iar/target.cmake
+++ b/cmake/compiler/iar/target.cmake
@@ -86,7 +86,7 @@ endif()
 
 # Enable VLA if CONFIG_MISRA_SANE is not set and warnings are not enabled.
 if(NOT CONFIG_MISRA_SANE AND NOT DEFINED W)
-  list(APPEND IAR_COMMON_FLAGS --vla)
+  list(APPEND IAR_COMMON_FLAGS $<$<COMPILE_LANGUAGE:C>:--vla>)
 endif()
 
 # Minimal ASM compiler flags


### PR DESCRIPTION
Fixed a problem where the command line option --vla was used with C++ causing a command line error in the IAR ICCARM compiler.