### PR TITLE
sensor: adxl3xx: Clarify defgroup names in DT bindings

### DIFF
--- a/include/zephyr/dt-bindings/sensor/adxl345.h
+++ b/include/zephyr/dt-bindings/sensor/adxl345.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX345_H_
 
 /**
- * @defgroup ADXL345 ADI DT Options
+ * @defgroup ADXL345 ADXL345 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/adxl345.h
+++ b/include/zephyr/dt-bindings/sensor/adxl345.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX345_H_
 
 /**
- * @defgroup ADXL345 ADXL345 DT Options
+ * @defgroup adxl345 ADXL345 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/adxl362.h
+++ b/include/zephyr/dt-bindings/sensor/adxl362.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX362_H_
 
 /**
- * @defgroup ADXL362 ADXL362 DT Options
+ * @defgroup adxl362 ADXL362 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/adxl362.h
+++ b/include/zephyr/dt-bindings/sensor/adxl362.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX362_H_
 
 /**
- * @defgroup ADXL362 ADI DT Options
+ * @defgroup ADXL362 ADXL362 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/adxl367.h
+++ b/include/zephyr/dt-bindings/sensor/adxl367.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX367_H_
 
 /**
- * @defgroup ADXL367 ADI DT Options
+ * @defgroup ADXL367 ADXL367 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/adxl367.h
+++ b/include/zephyr/dt-bindings/sensor/adxl367.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX367_H_
 
 /**
- * @defgroup ADXL367 ADXL367 DT Options
+ * @defgroup adxl367 ADXL367 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/adxl372.h
+++ b/include/zephyr/dt-bindings/sensor/adxl372.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX372_H_
 
 /**
- * @defgroup ADXL372 ADI DT Options
+ * @defgroup ADXL372 ADXL372 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/adxl372.h
+++ b/include/zephyr/dt-bindings/sensor/adxl372.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_ADI_ADX372_H_
 
 /**
- * @defgroup ADXL372 ADXL372 DT Options
+ * @defgroup adxl372 ADXL372 DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/sensor_axis_align.h
+++ b/include/zephyr/dt-bindings/sensor/sensor_axis_align.h
@@ -6,7 +6,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_AXIS_ALIGN_H_
 
 /**
- * @defgroup SENSOR_AXIS_ALIGN DT Options
+ * @defgroup SENSOR_AXIS_ALIGN Sensor axis alignment DT Options
  * @ingroup sensor_interface
  * @{
  */

--- a/include/zephyr/dt-bindings/sensor/sensor_axis_align.h
+++ b/include/zephyr/dt-bindings/sensor/sensor_axis_align.h
@@ -6,13 +6,13 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENSOR_AXIS_ALIGN_H_
 
 /**
- * @defgroup SENSOR_AXIS_ALIGN Sensor axis alignment DT Options
+ * @defgroup sensor_axis_align Sensor axis alignment DT Options
  * @ingroup sensor_interface
  * @{
  */
 
 /**
- * @defgroup SENSOR_AXIS_ALIGN_INDEX_DT Axis description for sensor alignment
+ * @defgroup sensor_axis_align_index_dt Axis description for sensor alignment
  * @{
  */
 #define SENSOR_AXIS_ALIGN_DT_X		0
@@ -21,7 +21,7 @@
 /** @} */
 
 /**
- * @defgroup SENSOR_AXIS_ALIGN_DT Axis description for sensor alignment
+ * @defgroup sensor_axis_align_dt Axis description for sensor alignment
  * @{
  */
 #define SENSOR_AXIS_ALIGN_DT_NEG		0


### PR DESCRIPTION
Replace vague "ADI DT Options" titles with explicit, device-specific @defgroup names such as "ADXL345 DT Options", "ADXL362 DT Options", "ADXL367 DT Options", and "ADXL372 DT Options".

This improves clarity for developers and documentation readers by avoiding the unclear "ADI" abbreviation.

Fix: #92021