### PR TITLE
Runner fixes in xsdb

### DIFF
--- a/boards/amd/versal2_rpu/support/xsdb.cfg
+++ b/boards/amd/versal2_rpu/support/xsdb.cfg
@@ -33,6 +33,7 @@ proc rpu0_core0_rst { {mem "default"} } {
 
 proc load_image args  {
 	set elf_file [lindex $args 0]
+	set pdi_file [lindex $args 1]
 
 	if { [info exists ::env(HW_SERVER_URL)] } {
 		connect -url $::env(HW_SERVER_URL)
@@ -40,12 +41,7 @@ proc load_image args  {
 		connect
 	}
 
-	if { [info exists ::env(PDI_FILE_PATH)] } {
-		device program $::env(PDI_FILE_PATH)
-	} else {
-		puts "Error: env variable PDI_FILE_PATH is not set"
-		exit
-	}
+	device program $pdi_file
 
 	if { [info exists ::env(HW_SERVER_URL)] } {
 		set hw_server_url [split $::env(HW_SERVER_URL) ":"]

--- a/boards/amd/versal2_rpu/support/xsdb.cfg
+++ b/boards/amd/versal2_rpu/support/xsdb.cfg
@@ -3,27 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 proc rpu0_core0_rst { {mem "default"} } {
-	targets -set -filter {name =~ "DAP*"}
-	#CRL write protect
-	mwr -force 0xeb5e001c 0x0
-	mwr -force 0xEB580000 1
+	targets -set -filter {name =~ "Versal Gen 2*"}
+	# CRL write protect
+	mwr -force 0xeb5e001c 0
+	mwr -force 0xeb580000 1
 	mwr -force 0xbbf20000 0xeafffffe
 	# write BASE_HI and BASE_LO
-        if {$mem eq "ddr"} {
-            set addr 0x100000
-        } elseif {$mem eq "tcm"} {
-            set addr 0x0
-        } elseif {$mem eq "default"} {
-            set addr 0xbbf20000
-        }
-	mwr -force 0xEB588008 $addr
+	if {$mem eq "ddr"} {
+		set addr 0x100000
+	} elseif {$mem eq "tcm"} {
+		set addr 0
+	} elseif {$mem eq "default"} {
+		set addr 0xbbf20000
+	}
+	mwr -force 0xeb588008 $addr
 	# write TCMBOOT as one
-	mask_write 0xEB588000 0x10 0x10
+	mask_write 0xeb588000 0x10 0x10
 	# reset CORE0A_RESET out of reset A_TOPRESET and CORE0A_POR
-	mask_write 0xEB5E0310 0x10101 0x1
+	mask_write 0xeb5e0310 0x10101 0x1
 	# out of reset CORE0A_RESET
-	mask_write 0xEB5E0310 0x1 0x0
-	targets -set -filter {name =~ "Cortex-R52*0" && parent =~ "*0x00100000"}
+	mask_write 0xeb5e0310 0x1 0
+	targets -set -filter {name =~ "Cortex-R52*0.0"}
 	after 300
 	stop
 	after 1000
@@ -58,7 +58,7 @@ proc load_image args  {
 		ta
 	}
 	after 1000
-	targets -set -nocase -filter {name =~ "DAP*"}
+	targets -set -filter {name =~ "Versal Gen 2*"}
 	after 100
 	# Configure timestamp generator to run global timer gracefully
 	# Ideally these registers should be set from bootloader (cdo)

--- a/boards/amd/versalnet_rpu/support/xsdb.cfg
+++ b/boards/amd/versalnet_rpu/support/xsdb.cfg
@@ -4,6 +4,7 @@
 
 proc load_image args  {
 	set elf_file [lindex $args 0]
+	set pdi_file [lindex $args 1]
 
 	if { [info exists ::env(HW_SERVER_URL)] } {
 		connect -url $::env(HW_SERVER_URL)
@@ -17,12 +18,7 @@ proc load_image args  {
 	rst -system
 	after 100
 
-	if { [info exists ::env(PDI_FILE_PATH)] } {
-		device program $::env(PDI_FILE_PATH)
-	} else {
-		puts "Error: env variable PDI_FILE_PATH is not set"
-		exit
-	}
+	device program $pdi_file
 
 	after 100
 	targets -set -nocase -filter {name =~ "DPC"}

--- a/scripts/west_commands/tests/test_xsdb.py
+++ b/scripts/west_commands/tests/test_xsdb.py
@@ -13,31 +13,80 @@ TEST_CASES = [
         "config": None,
         "bitstream": None,
         "fsbl": None,
+        "pdi": None,
+        "bl31": None,
+        "dtb": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF],
     },
     {
         "config": "custom_cfg_path",
         "bitstream": None,
         "fsbl": None,
+        "pdi": None,
+        "bl31": None,
+        "dtb": None,
         "expected_cmd": ["xsdb", "custom_cfg_path", RC_KERNEL_ELF],
     },
     {
         "config": None,
         "bitstream": "bitstream_path",
         "fsbl": None,
+        "pdi": None,
+        "bl31": None,
+        "dtb": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "bitstream_path"],
     },
     {
         "config": None,
         "bitstream": None,
         "fsbl": "fsbl_path",
+        "pdi": None,
+        "bl31": None,
+        "dtb": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "fsbl_path"],
     },
     {
         "config": None,
         "bitstream": "bitstream_path",
         "fsbl": "fsbl_path",
+        "pdi": None,
+        "bl31": None,
+        "dtb": None,
         "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "bitstream_path", "fsbl_path"],
+    },
+    {
+        "config": None,
+        "bitstream": None,
+        "fsbl": None,
+        "pdi": "pdi_path",
+        "bl31": None,
+        "dtb": None,
+        "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "pdi_path"],
+    },
+    {
+        "config": None,
+        "bitstream": None,
+        "fsbl": None,
+        "pdi": "pdi_path",
+        "bl31": "bl31_path",
+        "dtb": None,
+        "expected_cmd": ["xsdb", "default_cfg_path", RC_KERNEL_ELF, "pdi_path", "bl31_path"],
+    },
+    {
+        "config": None,
+        "bitstream": None,
+        "fsbl": None,
+        "pdi": "pdi_path",
+        "bl31": "bl31_path",
+        "dtb": "dtb_path",
+        "expected_cmd": [
+            "xsdb",
+            "default_cfg_path",
+            RC_KERNEL_ELF,
+            "pdi_path",
+            "bl31_path",
+            "dtb_path",
+        ],
     },
 ]
 
@@ -54,6 +103,9 @@ def test_xsdbbinaryrunner_init(check_call, path_exists, tc, runner_config):
             config=tc["config"],
             bitstream=tc["bitstream"],
             fsbl=tc["fsbl"],
+            pdi=tc["pdi"],
+            bl31=tc["bl31"],
+            dtb=tc["dtb"],
         )
 
     runner.do_run("flash")
@@ -73,6 +125,12 @@ def test_xsdbbinaryrunner_create(check_call, path_exists, tc, runner_config):
         args.extend(["--bitstream", tc["bitstream"]])
     if tc["fsbl"]:
         args.extend(["--fsbl", tc["fsbl"]])
+    if tc["pdi"]:
+        args.extend(["--pdi", tc["pdi"]])
+    if tc["bl31"]:
+        args.extend(["--bl31", tc["bl31"]])
+    if tc["dtb"]:
+        args.extend(["--system-dtb", tc["dtb"]])
 
     parser = argparse.ArgumentParser(allow_abbrev=False)
     XSDBBinaryRunner.add_parser(parser)


### PR DESCRIPTION
This pull does the below
- Update the xsdb runner to support passing of bl31, pdi, and system.dtb
files.
- Update the PDI PATH variables in the RPU port to use runner argument
instead of environment variables.
