### PR TITLE
stm32: drivers: i2c_v2 : power_mgmt: exclude stm32f7 serie 

### DIFF
--- a/drivers/i2c/i2c_ll_stm32_v2.c
+++ b/drivers/i2c/i2c_ll_stm32_v2.c
@@ -439,11 +439,13 @@ int i2c_stm32_target_register(const struct device *dev,
 	/* Mark device as active */
 	(void)pm_device_runtime_get(dev);
 
+#if !defined(CONFIG_SOC_SERIES_STM32F7X)
 	if (pm_device_wakeup_is_capable(dev)) {
 		/* Enable wake-up from stop */
 		LOG_DBG("i2c: enabling wakeup from stop");
 		LL_I2C_EnableWakeUpFromStop(cfg->i2c);
 	}
+#endif /* CONFIG_SOC_SERIES_STM32F7X */
 
 	LL_I2C_Enable(i2c);
 
@@ -526,11 +528,13 @@ int i2c_stm32_target_unregister(const struct device *dev,
 		LL_I2C_Disable(i2c);
 	}
 
+#if !defined(CONFIG_SOC_SERIES_STM32F7X)
 	if (pm_device_wakeup_is_capable(dev)) {
 		/* Disable wake-up from STOP */
 		LOG_DBG("i2c: disabling wakeup from stop");
 		LL_I2C_DisableWakeUpFromStop(i2c);
 	}
+#endif /* CONFIG_SOC_SERIES_STM32F7X */
 
 	/* Release the device */
 	(void)pm_device_runtime_put(dev);
@@ -539,7 +543,6 @@ int i2c_stm32_target_unregister(const struct device *dev,
 
 	return 0;
 }
-
 #endif /* defined(CONFIG_I2C_TARGET) */
 
 void i2c_stm32_event(const struct device *dev)


### PR DESCRIPTION

The following changes  introduced here: https://github.com/zephyrproject-rtos/zephyr/commit/4f3523d9afcef5367b7a47daf9a2082357f78bda enable STM32F7 boards with I2C v2 compatibility to perform actions under CONFIG_PM_DEVICE_RUNTIME.

This PR adds a condition to exclude the STM32F7 series from executing these actions since power management is not yet supported.