### PR TITLE
scripts: requirements-base: pin patool to >=2.0.0

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -17,7 +17,7 @@ pykwalify
 canopen
 packaging
 progress
-patool
+patool>=2.0.0
 psutil>=5.6.6
 pylink-square
 pyserial


### PR DESCRIPTION
patool < 2.0.0 on macOS / gnutar fails to unpack .tar.xz archives causing `west sdk install` to fail. Fix by making sure folks install a version that includes a fix making patool more capable/flexible and handling the tar.xz files just fine