### PR TITLE
spi_nxp_lpspi: Fix extra byte sent issue

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -1017,6 +1017,8 @@ ZTEST(spi_extra_api_features, test_spi_hold_on_cs)
 early_exit:
 	hold_spec->config.operation &= ~SPI_HOLD_ON_CS;
 	zassert_false(ret, "SPI transceive failed, code %d", ret);
+	/* if there was no error then it was meant to be a skip at this point */
+	ztest_test_skip();
 }
 
 /*


### PR DESCRIPTION
 I think this should finally nail down these race conditions on the older LPSPI due to that stalling errata.

Also as a result of this PR, we can not longer (pretend to?) support the SPI_HOLD_ON_CS flag on LPSPI v1.

Fixes #90614 and maybe some others, pending investigations.