### PR TITLE
boards: Add missing zephyr_i2c to boards using STEMMA-QT

### DIFF
--- a/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3_procpu.dts
+++ b/boards/adafruit/qt_py_esp32s3/adafruit_qt_py_esp32s3_procpu.dts
@@ -71,7 +71,7 @@
 	pinctrl-names = "default";
 };
 
-&i2c1 {
+zephyr_i2c: &i2c1 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	pinctrl-0 = <&i2c1_default>;

--- a/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
+++ b/boards/adafruit/qt_py_rp2040/adafruit_qt_py_rp2040.dts
@@ -88,16 +88,16 @@
 };
 
 &i2c0 {
-	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-&i2c1 {
+zephyr_i2c: &i2c1 {
+	status = "okay";
 	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
-	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 


### PR DESCRIPTION
This adds the `zephyr_i2c` node label to the STEMMA-QT I2C connection(s) for the following boards:

- adafruit_qt_py_rp2040
- adafruit_qt_py_esp32s3

Based on my understanding of #89725, these board quality by having "pluggable i2c interfaces" in the form of their STEMMA-QT connectors.