### PR TITLE
display: stm32: ltdc: adjust BGR565/RGB565 format to match sample exp…

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -147,6 +147,14 @@ Counter
   And :kconfig:option:`CONFIG_COUNTER_NATIVE_POSIX` and its related options with
   :kconfig:option:`CONFIG_COUNTER_NATIVE_SIM` (:github:`86616`).
 
+Display
+=======
+
+* On STM32 devices, the LTDC driver (:dtcompatible:`st,stm32-ltdc`) RGB565 format
+  ``PIXEL_FORMAT_RGB565`` has been replaced by ``PIXEL_FORMAT_BGR565`` to match
+  the format expected by Zephyr. This change ensures proper behavior of both
+  display and video capture samples.
+
 Entropy
 =======
 

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -55,7 +55,7 @@ LOG_MODULE_REGISTER(display_stm32_ltdc, CONFIG_DISPLAY_LOG_LEVEL);
 #elif CONFIG_STM32_LTDC_RGB565
 #define STM32_LTDC_INIT_PIXEL_SIZE	2u
 #define STM32_LTDC_INIT_PIXEL_FORMAT	LTDC_PIXEL_FORMAT_RGB565
-#define DISPLAY_INIT_PIXEL_FORMAT	PIXEL_FORMAT_RGB_565
+#define DISPLAY_INIT_PIXEL_FORMAT	PIXEL_FORMAT_BGR_565
 #else
 #error "Invalid LTDC pixel format chosen"
 #endif
@@ -110,9 +110,9 @@ static int stm32_ltdc_set_pixel_format(const struct device *dev,
 	struct display_stm32_ltdc_data *data = dev->data;
 
 	switch (format) {
-	case PIXEL_FORMAT_RGB_565:
+	case PIXEL_FORMAT_BGR_565:
 		err = HAL_LTDC_SetPixelFormat(&data->hltdc, LTDC_PIXEL_FORMAT_RGB565, 0);
-		data->current_pixel_format = PIXEL_FORMAT_RGB_565;
+		data->current_pixel_format = PIXEL_FORMAT_BGR_565;
 		data->current_pixel_size = 2u;
 		break;
 	case PIXEL_FORMAT_RGB_888:
@@ -158,7 +158,7 @@ static void stm32_ltdc_get_capabilities(const struct device *dev,
 				     data->hltdc.LayerCfg[0].WindowY0;
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_ARGB_8888 |
 					PIXEL_FORMAT_RGB_888 |
-					PIXEL_FORMAT_RGB_565;
+					PIXEL_FORMAT_BGR_565;
 	capabilities->screen_info = 0;
 
 	capabilities->current_pixel_format = data->current_pixel_format;


### PR DESCRIPTION
…ectations

The LTDC RGB565 format corresponds to the PIXEL_FORMAT_BGR565 format. Update the LTDC driver to advertise PIXEL_FORMAT_BGR565 as the supported format instead of PIXEL_FORMAT_RGB565. This change ensures correct color rendering in the sample display application and enables usage of the video capture sample application.