### PR TITLE
drivers: i2c: gecko: Fix EFM32 I2C target

### DIFF
--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -325,23 +325,23 @@ void i2c_gecko_isr(const struct device *dev)
 #define GECKO_I2C_IRQ_DATA(idx)
 #endif
 
-#define I2C_INIT(idx)										\
-	PINCTRL_DT_INST_DEFINE(idx);								\
-	GECKO_I2C_IRQ_DEF(idx);									\
-												\
-	static const struct i2c_gecko_config i2c_gecko_config_##idx = {				\
-		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),					\
-		.base = (I2C_TypeDef *)DT_INST_REG_ADDR(idx),					\
-		.clock = cmuClock_I2C##idx,							\
-		.bitrate = DT_INST_PROP(idx, clock_frequency),					\
-		GECKO_I2C_IRQ_DATA(idx)};							\
-												\
-	static struct i2c_gecko_data i2c_gecko_data_##idx;					\
-												\
-	I2C_DEVICE_DT_INST_DEFINE(idx, i2c_gecko_init, NULL, &i2c_gecko_data_##idx,		\
-				  &i2c_gecko_config_##idx, POST_KERNEL,				\
-					CONFIG_I2C_INIT_PRIORITY, &i2c_gecko_driver_api);	\
-												\
+#define I2C_INIT(idx)                                                                              \
+	PINCTRL_DT_INST_DEFINE(idx);                                                               \
+	GECKO_I2C_IRQ_DEF(idx);                                                                    \
+                                                                                                   \
+	static const struct i2c_gecko_config i2c_gecko_config_##idx = {                            \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                       \
+		.base = (I2C_TypeDef *)DT_INST_REG_ADDR(idx),                                      \
+		.clock = cmuClock_I2C##idx,                                                        \
+		.bitrate = DT_INST_PROP(idx, clock_frequency),                                     \
+		GECKO_I2C_IRQ_DATA(idx)};                                                          \
+                                                                                                   \
+	static struct i2c_gecko_data i2c_gecko_data_##idx;                                         \
+                                                                                                   \
+	I2C_DEVICE_DT_INST_DEFINE(idx, i2c_gecko_init, NULL, &i2c_gecko_data_##idx,                \
+				  &i2c_gecko_config_##idx, POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,  \
+				  &i2c_gecko_driver_api);                                          \
+                                                                                                   \
 	GECKO_I2C_IRQ_HANDLER(idx)
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_INIT)

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -192,7 +192,7 @@ static int i2c_gecko_target_register(const struct device *dev, struct i2c_target
 
 	I2C_SlaveAddressSet(config->base, cfg->address << _I2C_SADDR_ADDR_SHIFT);
 	/* Match with specified address, no wildcards in address */
-	I2C_SlaveAddressMaskSet(config->base, _I2C_SADDRMASK_SADDRMASK_MASK);
+	I2C_SlaveAddressMaskSet(config->base, _I2C_SADDRMASK_MASK);
 
 	I2C_IntDisable(config->base, _I2C_IEN_MASK);
 	I2C_IntEnable(config->base, I2C_IEN_ADDR | I2C_IEN_RXDATAV | I2C_IEN_ACK | I2C_IEN_SSTOP |


### PR DESCRIPTION
Fix compile error due to misnamed macro.

Fix response to callback behavior so NACKs are issued if the callback returns an error. This allows for proper signaling to the I2C host when commands or data are invalid for the I2C target.