### PR TITLE
drivers: sensor: bma4xx: Avoid potential overflow

### DIFF
--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -203,7 +203,7 @@ void bma4xx_emul_set_accel_data(const struct emul *target, q31_t value, int8_t s
 	int16_t reg_val;
 
 	/* 0x00 -> +/-2g; 0x01 -> +/-4g; 0x02 -> +/-8g; 0x03 -> +/- 16g; */
-	int64_t accel_range = (2 << data->regs[BMA4XX_REG_ACCEL_RANGE]);
+	int64_t accel_range = 2LL << data->regs[BMA4XX_REG_ACCEL_RANGE];
 
 	unshifted = shift < 0 ? ((int64_t)value >> -shift) : ((int64_t)value << shift);
 


### PR DESCRIPTION
Coverity reports a potential integer overflow in the accel_range computation due to the use of a left shift on an int type.

CID 520269: Unintentional integer overflow (OVERFLOW_BEFORE_WIDEN)

Even though the register value is constrained to 0–3 by the BMA456 spec, and no real overflow occurs, an explicit cast to int64_t prevents false positives and aligns with safe coding practices.

Fixes: #90517