### PR TITLE
drivers: counter: Fix redundant identical condition

### DIFF
--- a/drivers/counter/counter_ifx_cat1.c
+++ b/drivers/counter/counter_ifx_cat1.c
@@ -189,10 +189,8 @@ static int ifx_cat1_counter_init(const struct device *dev)
 		rslt = cyhal_gpio_enable_output(config->external_pin, CYHAL_SIGNAL_TYPE_EDGE,
 						(cyhal_source_t *)&data->signal_source);
 		if (rslt != CY_RSLT_SUCCESS) {
-			if (rslt != CY_RSLT_SUCCESS) {
-				LOG_ERR("error in the enabling of Counter input pin output");
-				return -EIO;
-			}
+			LOG_ERR("error in the enabling of Counter input pin output");
+			return -EIO;
 		}
 
 		rslt = cyhal_timer_connect_digital(&data->counter_obj, data->signal_source,


### PR DESCRIPTION
There was an unnecessary nested `if` in `ifx_cat1_counter_init` with the same condition already checked in the outer block.

This results in dead and redundant code with no functional impact but harms readability.

The inner `if (rslt != CY_RSLT_SUCCESS)` was removed to clean up the function.