### PR TITLE
drivers: counter: Fix possible null pointer dereference

### DIFF
--- a/drivers/counter/counter_renesas_rz_gtm.c
+++ b/drivers/counter/counter_renesas_rz_gtm.c
@@ -190,8 +190,8 @@ static int counter_rz_gtm_set_alarm(const struct device *dev, uint8_t chan,
 	const struct counter_rz_gtm_config *cfg = dev->config;
 	struct counter_rz_gtm_data *data = dev->data;
 
-	bool absolute = alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE;
-	uint32_t val = alarm_cfg->ticks;
+	bool absolute;
+	uint32_t val;
 	k_spinlock_key_t key;
 	bool irq_on_late;
 	uint32_t max_rel_val;
@@ -201,6 +201,10 @@ static int counter_rz_gtm_set_alarm(const struct device *dev, uint8_t chan,
 	if (!alarm_cfg) {
 		return -EINVAL;
 	}
+
+	absolute = alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE;
+	val = alarm_cfg->ticks;
+
 	/* Alarm callback is mandatory */
 	if (!alarm_cfg->callback) {
 		return -EINVAL;


### PR DESCRIPTION
The function counter_rz_gtm_set_alarm was accessing alarm_cfg->flags and alarm_cfg->ticks before verifying that alarm_cfg is non-NULL.

This could lead to undefined behavior or crashes if a NULL pointer is passed.

The pointer check has been moved before any dereference to fix this bug.