### PR TITLE
drivers: modem_cellular: fix bg95dial cmd resp

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -527,7 +527,7 @@ MODEM_CHAT_MATCHES_DEFINE(dial_abort_matches,
 
 #if DT_HAS_COMPAT_STATUS_OKAY(swir_hl7800) || DT_HAS_COMPAT_STATUS_OKAY(sqn_gm02s) ||              \
 	DT_HAS_COMPAT_STATUS_OKAY(quectel_eg800q) || DT_HAS_COMPAT_STATUS_OKAY(quectel_eg25_g) ||  \
-	DT_HAS_COMPAT_STATUS_OKAY(simcom_a76xx)
+	DT_HAS_COMPAT_STATUS_OKAY(quectel_bg95) || DT_HAS_COMPAT_STATUS_OKAY(simcom_a76xx)
 MODEM_CHAT_MATCH_DEFINE(connect_match, "CONNECT", "", NULL);
 #endif
 
@@ -1973,7 +1973,7 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg95_dial_chat_script_cmds,
 							 "\""CONFIG_MODEM_CELLULAR_APN"\"",
 							 ok_match),
 			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+CFUN=1", ok_match),
-			      MODEM_CHAT_SCRIPT_CMD_RESP_NONE("ATD*99***1#", 0),);
+			      MODEM_CHAT_SCRIPT_CMD_RESP("ATD*99***1#", connect_match));
 
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg95_dial_chat_script, quectel_bg95_dial_chat_script_cmds,
 			 dial_abort_matches, modem_cellular_chat_callback_handler, 10);


### PR DESCRIPTION
bg95 modem should respond "CONNECT" when run dial cmd similar to eg25g modem (the fix was added recently). Tested on a custom board with actual bg95 modem.

<img width="637" alt="image" src="https://github.com/user-attachments/assets/0bafc9c2-1025-4dac-8f79-3943f8098287" />
