### PR TITLE
drivers: spi: context: check that config exists before reading it

### DIFF
--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -144,7 +144,7 @@ static inline void spi_context_release(struct spi_context *ctx, int status)
 {
 #ifdef CONFIG_MULTITHREADING
 #ifdef CONFIG_SPI_SLAVE
-	if (status >= 0 && (ctx->config->operation & SPI_LOCK_ON)) {
+	if (status >= 0 && ((ctx->config == NULL) || (ctx->config->operation & SPI_LOCK_ON))) {
 		return;
 	}
 #endif /* CONFIG_SPI_SLAVE */
@@ -155,7 +155,7 @@ static inline void spi_context_release(struct spi_context *ctx, int status)
 		k_sem_give(&ctx->lock);
 	}
 #else
-	if (!(ctx->config->operation & SPI_LOCK_ON)) {
+	if ((ctx->config == NULL) || !(ctx->config->operation & SPI_LOCK_ON)) {
 		ctx->owner = NULL;
 		k_sem_give(&ctx->lock);
 	}


### PR DESCRIPTION
Function spi_context_release reads the content of ctx->config without checking first if it is set. In many drivers (including STM32), when a bad configuration is made for the first transaction, ctx->config is not set, and spi_context_release is called, resulting in hard fault.

This commit adds a check that ctx->config exists before reading it to avoid this problem.

Fixes #92178