### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 07222c1929e1d79d303baa8fde7f977a79e48e9a
+      revision: 3430520d7080a8ac3e4b325cfde0ef18837209af
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  3430520d7080a8ac3e4b325cfde0ef18837209af

Brings following Zephyr relevant fixes:

  - d905a69e boot: boot_serial: Fix upload for swap using offset mode
  - 3fc94b38 boot: boot_serial: Fix slot info response on error
  - e2c97da3 boot: bootutil: Fix serial recovery issues
  - 2fcfba13 boot: bootutil: Fix wrong define for single loader mode
  - dc571f0b boot: bootutil: Fix single loader trailer size
  - cf92b6f6 boot: boot_serial: Fix wrong slot ID for hook calls
  - c4a7b250 zephyr: cleanup removed CONFIG_BOOT_MGMT_CUSTOM_IMG_LIST

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.