### PR TITLE
scripts: west_commands: canopen: replace progress by tqdm

### DIFF
--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -17,7 +17,6 @@ mock
 mypy
 natsort
 ply>=3.10
-progress
 psutil>=5.6.6
 pyelftools>=0.29
 pygithub
@@ -36,6 +35,7 @@ sphinx-lint
 tabulate
 tomli>=1.1.0
 tox
+tqdm>=4.67.1
 unidiff
 vermin
 west>=0.14.0

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -261,6 +261,7 @@ colorama==0.4.6 \
     #   pylint
     #   pytest
     #   tox
+    #   tqdm
     #   west
 cryptography==45.0.5 \
     --hash=sha256:0027d566d65a38497bc37e0dd7c2f8ceda73597d2ac9ba93810204f56f52ebc7 \
@@ -797,10 +798,6 @@ polib==1.2.0 \
     --hash=sha256:1c77ee1b81feb31df9bca258cbc58db1bbb32d10214b173882452c73af06d62d \
     --hash=sha256:f3ef94aefed6e183e342a8a269ae1fc4742ba193186ad76f175938621dbfc26b
     # via sphinx-lint
-progress==1.6.1 \
-    --hash=sha256:5239f22f305c12fdc8ce6e0e47f70f21622a935e16eafc4535617112e7c7ea0b \
-    --hash=sha256:c1ba719f862ce885232a759eab47971fe74dfc7bb76ab8a51ef5940bad35086c
-    # via -r requirements-actions.in
 psutil==7.0.0 \
     --hash=sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25 \
     --hash=sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e \
@@ -1230,6 +1227,10 @@ tomlkit==0.13.3 \
 tox==4.27.0 \
     --hash=sha256:2b8a7fb986b82aa2c830c0615082a490d134e0626dbc9189986da46a313c4f20 \
     --hash=sha256:b97d5ecc0c0d5755bcc5348387fef793e1bfa68eb33746412f4c60881d7f5f57
+    # via -r requirements-actions.in
+tqdm==4.67.1 \
+    --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2 \
+    --hash=sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
     # via -r requirements-actions.in
 typing-extensions==4.14.0 \
     --hash=sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4 \

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -16,7 +16,6 @@ pykwalify
 # used by west_commands
 canopen
 packaging
-progress
 patool>=2.0.0
 psutil>=5.6.6
 pylink-square

--- a/scripts/west_commands/runners/canopen_program.py
+++ b/scripts/west_commands/runners/canopen_program.py
@@ -12,7 +12,7 @@ from runners.core import RunnerCaps, ZephyrBinaryRunner
 
 try:
     import canopen
-    from progress.bar import Bar
+    from tqdm import tqdm
     MISSING_REQUIREMENTS = False
 except ImportError:
     MISSING_REQUIREMENTS = True
@@ -284,17 +284,17 @@ class CANopenProgramDownloader:
             outfile = self.data_sdo.open('wb', buffering=self.download_buffer_size,
                                          size=size, block_transfer=self.block_transfer)
 
-            progress = Bar('%(percent)d%%', max=size, suffix='%(index)d/%(max)dB')
+            progress = tqdm(total=size, unit='B', unit_scale=True)
             while True:
                 chunk = infile.read(self.download_buffer_size // 2)
                 if not chunk:
                     break
                 outfile.write(chunk)
-                progress.next(n=len(chunk))
+                progress.update(len(chunk))
         except Exception as err:
             raise ValueError('Failed to download program') from err
         finally:
-            progress.finish()
+            progress.close()
             infile.close()
             outfile.close()
 


### PR DESCRIPTION
progress has been unmaintained for years and [tqdm](https://tqdm.github.io/) is a more modern and faster alternative, which is already used by other commands. Replace progress by tqdm in the canopen_program.py script to minimize number of redundant dependencies.