### PR TITLE
stm32: fix backup domain access refcount integration

### DIFF
--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -379,6 +379,7 @@ static int rtc_stm32_init(const struct device *dev)
 		err = clock_control_configure(clk, (clock_control_subsys_t)&cfg->pclken[1], NULL);
 
 		if (err < 0) {
+			stm32_backup_domain_disable_access();
 			LOG_ERR("clock configure failed\n");
 			return -EIO;
 		}

--- a/drivers/rtc/rtc_ll_stm32.c
+++ b/drivers/rtc/rtc_ll_stm32.c
@@ -283,13 +283,13 @@ void rtc_stm32_isr(const struct device *dev)
 	struct rtc_stm32_alrm *p_rtc_alrm;
 	int id = 0;
 
-	stm32_backup_domain_enable_access();
-
 	for (id = 0; id < RTC_STM32_ALARMS_COUNT; id++) {
 		if (rtc_stm32_is_active_alarm(RTC, (uint16_t)id) != 0) {
+			stm32_backup_domain_enable_access();
 			LL_RTC_DisableWriteProtection(RTC);
 			rtc_stm32_clear_alarm_flag(RTC, (uint16_t)id);
 			LL_RTC_EnableWriteProtection(RTC);
+			stm32_backup_domain_disable_access();
 
 			if (id == RTC_STM32_ALRM_A) {
 				p_rtc_alrm = &(data->rtc_alrm_a);
@@ -304,8 +304,6 @@ void rtc_stm32_isr(const struct device *dev)
 			}
 		}
 	}
-
-	stm32_backup_domain_disable_access();
 
 	ll_func_exti_clear_rtc_alarm_flag(RTC_STM32_EXTI_LINE);
 }


### PR DESCRIPTION
Correct integration of the STM32 backup domain access request:
- Add missing access requests in STM32 RTC counter driver.
  (Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92511)
- Add missing access request release in STM32 RTC driver
- Remove useless access request in STM32 RTC counter driver.
- Narrow access window during RTC interrupt service