### PR TITLE
soc: nxp: imx95: Fix systick flooding by enabling cache earlier

### DIFF
--- a/soc/nxp/imx/imx9/imx95/Kconfig
+++ b/soc/nxp/imx/imx9/imx95/Kconfig
@@ -10,7 +10,7 @@ config SOC_MIMX9596_M7
 	select CPU_HAS_DCACHE
 	select CPU_HAS_ARM_MPU
 	select ARM_MPU
-	select SOC_LATE_INIT_HOOK
+	select SOC_EARLY_INIT_HOOK
 	select HAS_MCUX
 	select HAS_MCUX_CACHE
 

--- a/soc/nxp/imx/imx9/imx95/m7/soc.c
+++ b/soc/nxp/imx/imx9/imx95/m7/soc.c
@@ -19,7 +19,7 @@
 #define POWER_DOMAIN_STATE_ON  0x00000000
 #define POWER_DOMAIN_STATE_OFF 0x40000000
 
-void soc_late_init_hook(void)
+void soc_early_init_hook(void)
 {
 #ifdef CONFIG_CACHE_MANAGEMENT
 	sys_cache_data_enable();


### PR DESCRIPTION
Systick is already enabled before late hook got called. In certain circumstances systick could be flooding the core and thus only handling systicks interrupts instead of executing code.

Enabling cache earlier in soc_init ensures that systick get handled quicker.