### PR TITLE
drivers: spi_nxp_lpspi: Don't fetch clockrate from api during configure

### DIFF
--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_common.c
@@ -260,7 +260,6 @@ static void lpspi_basic_config(const struct device *dev, const struct spi_config
 
 int lpspi_configure(const struct device *dev, const struct spi_config *spi_cfg)
 {
-	const struct lpspi_config *config = dev->config;
 	struct lpspi_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	bool already_configured = spi_context_configured(ctx, spi_cfg);
@@ -306,10 +305,7 @@ int lpspi_configure(const struct device *dev, const struct spi_config *spi_cfg)
 
 	lpspi_basic_config(dev, spi_cfg);
 
-	ret = clock_control_get_rate(config->clock_dev, config->clock_subsys, &clock_freq);
-	if (ret) {
-		return ret;
-	}
+	clock_freq = data->clock_freq;
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) == SPI_OP_MODE_MASTER) {
 		uint32_t ccr = 0;
@@ -370,6 +366,11 @@ int spi_nxp_init_common(const struct device *dev)
 	}
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (err) {
+		return err;
+	}
+
+	err = clock_control_get_rate(config->clock_dev, config->clock_subsys, &data->clock_freq);
 	if (err) {
 		return err;
 	}

--- a/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
+++ b/drivers/spi/spi_nxp_lpspi/spi_nxp_lpspi_priv.h
@@ -51,6 +51,7 @@ struct lpspi_data {
 	void *driver_data;
 	size_t transfer_len;
 	uint8_t major_version;
+	uint32_t clock_freq;
 };
 
 /* Verifies spi_cfg validity and set up configuration of hardware for xfer


### PR DESCRIPTION
The clock get rate api can be slow in certain targets and thus slowing each SPI transaction. 

Instead on startup fetch the clock rate and store this in ram. Then each spi configure action is simply reading that variable.

Substantially improves LPSPI performance on IMX95 because clock_rate fetch goes over SCMI.