### PR TITLE
net: Correct function signatures of thread functions

### DIFF
--- a/samples/net/sockets/net_mgmt/src/main.c
+++ b/samples/net/sockets/net_mgmt/src/main.c
@@ -23,8 +23,12 @@ LOG_MODULE_REGISTER(net_mgmt_sock_sample, LOG_LEVEL_DBG);
 #endif
 
 /* A test thread that spits out events that we can catch and show to user */
-static void trigger_events(void)
+static void trigger_events(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int operation = 0;
 	struct net_if_addr *ifaddr_v6;
 	struct net_if *iface;

--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -165,8 +165,12 @@ static int trigger_work(struct zsock_pollfd *pev)
 	return call_work(pev, event);
 }
 
-static void socket_service_thread(void)
+static void socket_service_thread(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int ret, i, fd, count = 0;
 	zvfs_eventfd_t value;
 

--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -108,8 +108,12 @@ static bool check_dns_query(uint8_t *buf, int buf_len)
 	return true;
 }
 
-static int process_dns(void)
+static void process_dns(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	struct zsock_pollfd pollfds[2];
 	struct sockaddr *addr;
 	socklen_t addr_len;
@@ -164,8 +168,6 @@ static int process_dns(void)
 			}
 		}
 	}
-
-	return -errno;
 }
 
 K_THREAD_DEFINE(dns_server_thread_id, STACK_SIZE,

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -263,8 +263,12 @@ ETH_NET_DEVICE_INIT(eth_fake, "eth_fake", eth_fake_init, NULL,
 		    &eth_fake_api_funcs, NET_ETH_MTU);
 
 /* A test thread that spits out events that we can catch and show to user */
-static void trigger_events(void)
+static void trigger_events(void *p1, void *p2, void *p3)
 {
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	int operation = 0;
 	struct net_if_addr *ifaddr_v6, *ifaddr_v4;
 	struct net_if *iface;


### PR DESCRIPTION
Update several function signatures to match the expected k_thread_entry_t type
```
typedef void (*k_thread_entry_t)(void *p1, void *p2, void *p3);
```

This fixes the following runtime error generated by UBSAN:
```
zephyr/lib/os/thread_entry.c:48:2: runtime error: call to function socket_service_thread through pointer to incorrect function type 'void (*)(void *, void *, void *)'
zephyr/subsys/net/lib/sockets/sockets_service.c:169: note: socket_service_thread defined here
    #0 0x08084452 in z_thread_entry zephyr/lib/os/thread_entry.c:48:2

SUMMARY: UndefinedBehaviorSanitizer: function-type-mismatch zephyr/lib/os/thread_entry.c:48:2


zephyr/lib/os/thread_entry.c:48:2: runtime error: call to function trigger_events through pointer to incorrect function type 'void (*)(void *, void *, void *)'
zephyr/tests/net/socket/net_mgmt/src/main.c:267: note: trigger_events defined here
    #0 0x0808541a in z_thread_entry zephyr/lib/os/thread_entry.c:48:2

SUMMARY: UndefinedBehaviorSanitizer: function-type-mismatch zephyr/lib/os/thread_entry.c:48:2


zephyr/lib/os/thread_entry.c:48:2: runtime error: call to function process_dns through pointer to incorrect function type 'void (*)(void *, void *, void *)'
zephyr/tests/net/socket/getaddrinfo/src/main.c:112: note: process_dns defined here
    #0 0x0808bfca in z_thread_entry zephyr/lib/os/thread_entry.c:48:2

SUMMARY: UndefinedBehaviorSanitizer: function-type-mismatch zephyr/lib/os/thread_entry.c:48:2 
```


This is a step towards fixing #90882.