### PR TITLE
scripts: requirements: remove dependency to mock package

### DIFF
--- a/scripts/build/check_init_priorities_test.py
+++ b/scripts/build/check_init_priorities_test.py
@@ -6,7 +6,7 @@
 Tests for check_init_priorities
 """
 
-import mock
+from unittest import mock
 import pathlib
 import unittest
 

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -688,10 +688,6 @@ mccabe==0.7.0 \
     --hash=sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325 \
     --hash=sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e
     # via pylint
-mock==5.2.0 \
-    --hash=sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0 \
-    --hash=sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f
-    # via -r requirements-actions.in
 msgpack==1.1.1 ; sys_platform != 'win32' \
     --hash=sha256:196a736f0526a03653d829d7d4c5500a97eea3648aebfd4b6743875f28aa2af8 \
     --hash=sha256:1abfc6e949b352dadf4bce0eb78023212ec5ac42f6abfd469ce91d783c149c2a \

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -17,8 +17,5 @@ coverage
 pytest
 mypy
 
-# used for mocking functions in pytest
-mock>=4.0.1
-
 # used for JUnit XML parsing in CTest harness
 junitparser

--- a/scripts/tests/build_helpers/test_domains.py
+++ b/scripts/tests/build_helpers/test_domains.py
@@ -6,10 +6,10 @@
 Tests for domains.py classes
 """
 
-import mock
 import os
 import sys
 from contextlib import nullcontext
+from unittest import mock
 
 import pytest
 

--- a/scripts/tests/build_helpers/test_domains.py
+++ b/scripts/tests/build_helpers/test_domains.py
@@ -8,45 +8,49 @@ Tests for domains.py classes
 
 import mock
 import os
-import pytest
 import sys
+from contextlib import nullcontext
+
+import pytest
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/build_helpers"))
 
-import domains
-
-from contextlib import nullcontext
-
+import domains  # noqa: E402
 
 TESTDATA_1 = [
     ('', False, 1, ['domains.yaml file not found: domains.yaml']),
     (
-"""
+        """
 default: None
 build_dir: some/dir
 domains: []
 """,
-        True, None, []
+        True,
+        None,
+        [],
     ),
 ]
+
 
 @pytest.mark.parametrize(
     'f_contents, f_exists, exit_code, expected_logs',
     TESTDATA_1,
-    ids=['no file', 'valid']
+    ids=['no file', 'valid'],
 )
 def test_from_file(caplog, f_contents, f_exists, exit_code, expected_logs):
     def mock_open(*args, **kwargs):
         if f_exists:
             return mock.mock_open(read_data=f_contents)(args, kwargs)
-        raise FileNotFoundError(f'domains.yaml not found.')
+        raise FileNotFoundError('domains.yaml not found.')
 
     init_mock = mock.Mock(return_value=None)
 
-    with mock.patch('domains.Domains.__init__', init_mock), \
-         mock.patch('builtins.open', mock_open), \
-         pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit:
+    with (
+        mock.patch('domains.Domains.__init__', init_mock),
+        mock.patch('builtins.open', mock_open),
+        pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit,
+    ):
         result = domains.Domains.from_file('domains.yaml')
 
     if exit_code:
@@ -60,7 +64,7 @@ def test_from_file(caplog, f_contents, f_exists, exit_code, expected_logs):
 
 TESTDATA_2 = [
     (
-"""
+        """
 default: some default
 build_dir: my/dir
 domains:
@@ -70,10 +74,14 @@ domains:
   build_dir: dir/3
 flash_order: I don\'t think this is correct
 """,
-        1, None, None, None, None
+        1,
+        None,
+        None,
+        None,
+        None,
     ),
     (
-"""
+        """
 build_dir: build/dir
 domains:
 - name: a domain
@@ -89,16 +97,15 @@ flash_order:
         'build/dir',
         [('default_domain', 'dir/2'), ('a domain', 'dir/1')],
         ('default_domain', 'dir/2'),
-        {'a domain': ('a domain', 'dir/1'),
-         'default_domain': ('default_domain', 'dir/2')}
+        {'a domain': ('a domain', 'dir/1'), 'default_domain': ('default_domain', 'dir/2')},
     ),
 ]
 
+
 @pytest.mark.parametrize(
-    'data, exit_code, expected_build_dir, expected_flash_order,' \
-    ' expected_default, expected_domains',
+    'data, exit_code, expected_build_dir, expected_flash_order, expected_default, expected_domains',
     TESTDATA_2,
-    ids=['invalid', 'valid']
+    ids=['invalid', 'valid'],
 )
 def test_from_yaml(
     caplog,
@@ -107,13 +114,15 @@ def test_from_yaml(
     expected_build_dir,
     expected_flash_order,
     expected_default,
-    expected_domains
+    expected_domains,
 ):
     def mock_domain(name, build_dir, *args, **kwargs):
         return name, build_dir
 
-    with mock.patch('domains.Domain', side_effect=mock_domain), \
-         pytest.raises(SystemExit) if exit_code else nullcontext() as exit_st:
+    with (
+        mock.patch('domains.Domain', side_effect=mock_domain),
+        pytest.raises(SystemExit) if exit_code else nullcontext() as exit_st,
+    ):
         doms = domains.Domains.from_yaml(data)
 
     if exit_code:
@@ -133,35 +142,40 @@ TESTDATA_3 = [
     (
         None,
         True,
-        [('some', os.path.join('dir', '2')),
-         ('order', os.path.join('dir', '1'))]
+        [
+            ('some', os.path.join('dir', '2')),
+            ('order', os.path.join('dir', '1')),
+        ],
     ),
     (
         None,
         False,
-        [('order', os.path.join('dir', '1')),
-         ('some', os.path.join('dir', '2'))]
+        [
+            ('order', os.path.join('dir', '1')),
+            ('some', os.path.join('dir', '2')),
+        ],
     ),
     (
         ['some'],
         False,
-        [('some', os.path.join('dir', '2'))]
+        [('some', os.path.join('dir', '2'))],
     ),
 ]
+
 
 @pytest.mark.parametrize(
     'names, default_flash_order, expected_result',
     TESTDATA_3,
-    ids=['order only', 'no parameters', 'valid']
+    ids=['order only', 'no parameters', 'valid'],
 )
 def test_get_domains(
     caplog,
     names,
     default_flash_order,
-    expected_result
+    expected_result,
 ):
     doms = domains.Domains(
-"""
+        """
 domains:
 - name: dummy
   build_dir: dummy
@@ -171,11 +185,11 @@ build_dir: dummy
     )
     doms._flash_order = [
         ('some', os.path.join('dir', '2')),
-        ('order', os.path.join('dir', '1'))
+        ('order', os.path.join('dir', '1')),
     ]
     doms._domains = {
         'order': ('order', os.path.join('dir', '1')),
-        'some': ('some', os.path.join('dir', '2'))
+        'some': ('some', os.path.join('dir', '2')),
     }
 
     result = doms.get_domains(names, default_flash_order)
@@ -183,36 +197,36 @@ build_dir: dummy
     assert result == expected_result
 
 
-
 TESTDATA_3 = [
     (
         'other',
         1,
         ['domain "other" not found, valid domains are: order, some'],
-        None
+        None,
     ),
     (
         'some',
         None,
         [],
-        ('some', os.path.join('dir', '2'))
+        ('some', os.path.join('dir', '2')),
     ),
 ]
+
 
 @pytest.mark.parametrize(
     'name, exit_code, expected_logs, expected_result',
     TESTDATA_3,
-    ids=['domain not found', 'valid']
+    ids=['domain not found', 'valid'],
 )
 def test_get_domain(
     caplog,
     name,
     exit_code,
     expected_logs,
-    expected_result
+    expected_result,
 ):
     doms = domains.Domains(
-"""
+        """
 domains:
 - name: dummy
   build_dir: dummy
@@ -222,11 +236,11 @@ build_dir: dummy
     )
     doms._flash_order = [
         ('some', os.path.join('dir', '2')),
-        ('order', os.path.join('dir', '1'))
+        ('order', os.path.join('dir', '1')),
     ]
     doms._domains = {
         'order': ('order', os.path.join('dir', '1')),
-        'some': ('some', os.path.join('dir', '2'))
+        'some': ('some', os.path.join('dir', '2')),
     }
 
     with pytest.raises(SystemExit) if exit_code else nullcontext() as s_exit:

--- a/scripts/tests/twister/test_cmakecache.py
+++ b/scripts/tests/twister/test_cmakecache.py
@@ -6,7 +6,7 @@
 Tests for cmakecache.py classes' methods
 """
 
-import mock
+from unittest import mock
 import pytest
 
 from contextlib import nullcontext

--- a/scripts/tests/twister/test_config_parser.py
+++ b/scripts/tests/twister/test_config_parser.py
@@ -9,7 +9,7 @@ Tests for config_parser.py
 
 import os
 import pytest
-import mock
+from unittest import mock
 import scl
 
 from twisterlib.config_parser import TwisterConfigParser, extract_fields_from_arg_list, ConfigurationError

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -7,7 +7,7 @@
 Tests for environment.py classes' methods
 """
 
-import mock
+from unittest import mock
 import os
 import pytest
 import shutil

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -8,7 +8,7 @@ Tests for handlers.py classes' methods
 """
 
 import itertools
-import mock
+from unittest import mock
 import os
 import pytest
 import signal

--- a/scripts/tests/twister/test_hardwaremap.py
+++ b/scripts/tests/twister/test_hardwaremap.py
@@ -6,7 +6,7 @@
 Tests for hardwaremap.py classes' methods
 """
 
-import mock
+from unittest import mock
 import pytest
 import sys
 

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -6,7 +6,7 @@
 """
 This test file contains testsuites for the Harness classes of twister
 """
-import mock
+from unittest import mock
 import sys
 import os
 import pytest

--- a/scripts/tests/twister/test_jobserver.py
+++ b/scripts/tests/twister/test_jobserver.py
@@ -7,7 +7,7 @@ Tests for jobserver.py classes' methods
 """
 
 import functools
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister/test_log_helper.py
+++ b/scripts/tests/twister/test_log_helper.py
@@ -7,7 +7,7 @@ Tests for log_helper.py functions
 """
 
 import logging
-import mock
+from unittest import mock
 import pytest
 
 from importlib import reload

--- a/scripts/tests/twister/test_platform.py
+++ b/scripts/tests/twister/test_platform.py
@@ -8,7 +8,7 @@ This test file contains tests for platform.py module of twister
 '''
 import sys
 import os
-import mock
+from unittest import mock
 import pytest
 
 from contextlib import nullcontext

--- a/scripts/tests/twister/test_quarantine.py
+++ b/scripts/tests/twister/test_quarantine.py
@@ -6,7 +6,7 @@
 Tests for quarantine.py classes' methods
 """
 
-import mock
+from unittest import mock
 import os
 import pytest
 import textwrap

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -7,7 +7,7 @@ Tests for runner.py classes
 """
 
 import errno
-import mock
+from unittest import mock
 import os
 import pathlib
 import pytest

--- a/scripts/tests/twister/test_scl.py
+++ b/scripts/tests/twister/test_scl.py
@@ -7,7 +7,7 @@ Tests for scl.py functions
 """
 
 import logging
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -11,7 +11,7 @@ from contextlib import nullcontext
 import os
 import sys
 import pytest
-import mock
+from unittest import mock
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))

--- a/scripts/tests/twister/test_testplan.py
+++ b/scripts/tests/twister/test_testplan.py
@@ -8,7 +8,7 @@ This test file contains testsuites for testsuite.py module of twister
 '''
 import sys
 import os
-import mock
+from unittest import mock
 import pytest
 
 from contextlib import nullcontext

--- a/scripts/tests/twister/test_testsuite.py
+++ b/scripts/tests/twister/test_testsuite.py
@@ -7,7 +7,7 @@ Tests for testinstance class
 """
 
 import mmap
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister/test_twister.py
+++ b/scripts/tests/twister/test_twister.py
@@ -9,7 +9,7 @@ This test file contains foundational testcases for Twister tool
 
 import os
 import sys
-import mock
+from unittest import mock
 import pytest
 
 from pathlib import Path

--- a/scripts/tests/twister_blackbox/conftest.py
+++ b/scripts/tests/twister_blackbox/conftest.py
@@ -7,7 +7,7 @@
 
 import logging
 import shutil
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_addon.py
+++ b/scripts/tests/twister_blackbox/test_addon.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions concerning addons to normal 
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pkg_resources
 import pytest
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
 from twisterlib.testplan import TestPlan
 

--- a/scripts/tests/twister_blackbox/test_config.py
+++ b/scripts/tests/twister_blackbox/test_config.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions related to test configuratio
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_coverage.py
+++ b/scripts/tests/twister_blackbox/test_coverage.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions
 """
 import importlib
 import re
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_device.py
+++ b/scripts/tests/twister_blackbox/test_device.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions related to test filtering.
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_disable.py
+++ b/scripts/tests/twister_blackbox/test_disable.py
@@ -8,11 +8,12 @@ Blackbox tests for twister's command line functions related to disable features.
 
 import importlib
 import pytest
-import mock
+from unittest import mock
 import os
 import sys
 import re
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
 from twisterlib.testplan import TestPlan
 

--- a/scripts/tests/twister_blackbox/test_error.py
+++ b/scripts/tests/twister_blackbox/test_error.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions - simple does-error-out or n
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_filter.py
+++ b/scripts/tests/twister_blackbox/test_filter.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions related to test filtering.
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_footprint.py
+++ b/scripts/tests/twister_blackbox/test_footprint.py
@@ -8,7 +8,7 @@ Blackbox tests for twister's command line functions related to memory footprints
 
 import importlib
 import json
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_hardwaremap.py
+++ b/scripts/tests/twister_blackbox/test_hardwaremap.py
@@ -6,11 +6,12 @@
 Blackbox tests for twister's command line functions
 """
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
 from twisterlib.testplan import TestPlan
 

--- a/scripts/tests/twister_blackbox/test_outfile.py
+++ b/scripts/tests/twister_blackbox/test_outfile.py
@@ -8,7 +8,7 @@ Blackbox tests for twister's command line functions changing the output files.
 
 import importlib
 import re
-import mock
+from unittest import mock
 import os
 import shutil
 import pytest

--- a/scripts/tests/twister_blackbox/test_output.py
+++ b/scripts/tests/twister_blackbox/test_output.py
@@ -8,7 +8,7 @@ Blackbox tests for twister's command line functions changing test output.
 
 import importlib
 import re
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_platform.py
+++ b/scripts/tests/twister_blackbox/test_platform.py
@@ -8,7 +8,7 @@ Blackbox tests for twister's command line functions related to Zephyr platforms.
 
 import importlib
 import re
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_printouts.py
+++ b/scripts/tests/twister_blackbox/test_printouts.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_quarantine.py
+++ b/scripts/tests/twister_blackbox/test_quarantine.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions related to the quarantine.
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import re

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -8,7 +8,7 @@ Blackbox tests for twister's command line functions
 
 import importlib
 import json
-import mock
+from unittest import mock
 import os
 import pytest
 import shutil

--- a/scripts/tests/twister_blackbox/test_runner.py
+++ b/scripts/tests/twister_blackbox/test_runner.py
@@ -8,7 +8,7 @@ Blackbox tests for twister's command line functions
 # pylint: disable=duplicate-code
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import re

--- a/scripts/tests/twister_blackbox/test_shuffle.py
+++ b/scripts/tests/twister_blackbox/test_shuffle.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions related to the shuffling of 
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_testlist.py
+++ b/scripts/tests/twister_blackbox/test_testlist.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions related to saving and loadin
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_testplan.py
+++ b/scripts/tests/twister_blackbox/test_testplan.py
@@ -7,7 +7,7 @@ Blackbox tests for twister's command line functions - those requiring testplan.j
 """
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys

--- a/scripts/tests/twister_blackbox/test_tooling.py
+++ b/scripts/tests/twister_blackbox/test_tooling.py
@@ -8,12 +8,13 @@ Blackbox tests for twister's command line functions related to Twister's tooling
 # pylint: disable=duplicate-code
 
 import importlib
-import mock
+from unittest import mock
 import os
 import pytest
 import sys
 import json
 
+# pylint: disable=no-name-in-module
 from conftest import ZEPHYR_BASE, TEST_DATA, sample_filename_mock, testsuite_filename_mock
 from twisterlib.statuses import TwisterStatus
 from twisterlib.testplan import TestPlan


### PR DESCRIPTION
mock has been available in Python standard lib since Python 3.3, remove the unnecessary dependency to `mock` pip package