### PR TITLE
net: Fix various UBSAN reports

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1522,6 +1522,12 @@ int net_if_config_ipv6_get(struct net_if *iface,
  */
 int net_if_config_ipv6_put(struct net_if *iface);
 
+
+/** @cond INTERNAL_HIDDEN */
+struct net_if_addr *net_if_ipv6_addr_lookup_raw(const uint8_t *addr,
+						struct net_if **ret);
+/** @endcond */
+
 /**
  * @brief Check if this IPv6 address belongs to one of the interfaces.
  *
@@ -1532,6 +1538,11 @@ int net_if_config_ipv6_put(struct net_if *iface);
  */
 struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 					    struct net_if **iface);
+
+/** @cond INTERNAL_HIDDEN */
+struct net_if_addr *net_if_ipv6_addr_lookup_by_iface_raw(struct net_if *iface,
+							 const uint8_t *addr);
+/** @endcond */
 
 /**
  * @brief Check if this IPv6 address belongs to this specific interfaces.
@@ -1680,6 +1691,12 @@ typedef void (*net_if_ip_maddr_cb_t)(struct net_if *iface,
  */
 void net_if_ipv6_maddr_foreach(struct net_if *iface, net_if_ip_maddr_cb_t cb,
 			       void *user_data);
+
+
+/** @cond INTERNAL_HIDDEN */
+struct net_if_mcast_addr *net_if_ipv6_maddr_lookup_raw(const uint8_t *maddr,
+						       struct net_if **ret);
+/** @endcond */
 
 /**
  * @brief Check if this IPv6 multicast address belongs to a specific interface

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -404,26 +404,28 @@ struct cmsghdr {
 
 /** @endcond */
 
+#define SOCKADDR_ALIGN (4)
+
 /** Generic sockaddr struct. Must be cast to proper type. */
 struct sockaddr {
 	sa_family_t sa_family; /**< Address family */
 /** @cond INTERNAL_HIDDEN */
 	char data[NET_SOCKADDR_MAX_SIZE - sizeof(sa_family_t)];
 /** @endcond */
-};
+} __aligned(SOCKADDR_ALIGN);
 
 /** @cond INTERNAL_HIDDEN */
 
 struct sockaddr_ptr {
 	sa_family_t family;
 	char data[NET_SOCKADDR_PTR_MAX_SIZE - sizeof(sa_family_t)];
-};
+} __aligned(SOCKADDR_ALIGN);
 
 /* Same as sockaddr in our case */
 struct sockaddr_storage {
 	sa_family_t ss_family;
 	char data[NET_SOCKADDR_MAX_SIZE - sizeof(sa_family_t)];
-};
+} __aligned(SOCKADDR_ALIGN);
 
 /* Socket address struct for UNIX domain sockets */
 struct sockaddr_un {

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -1299,10 +1299,8 @@ static inline bool net_ipv6_is_addr_mcast_group(const struct in6_addr *addr,
 						const struct in6_addr *group)
 {
 	return UNALIGNED_GET(&addr->s6_addr16[1]) == group->s6_addr16[1] &&
-		UNALIGNED_GET(&addr->s6_addr16[2]) == group->s6_addr16[2] &&
-		UNALIGNED_GET(&addr->s6_addr16[3]) == group->s6_addr16[3] &&
 		UNALIGNED_GET(&addr->s6_addr32[1]) == group->s6_addr32[1] &&
-		UNALIGNED_GET(&addr->s6_addr32[2]) == group->s6_addr32[1] &&
+		UNALIGNED_GET(&addr->s6_addr32[2]) == group->s6_addr32[2] &&
 		UNALIGNED_GET(&addr->s6_addr32[3]) == group->s6_addr32[3];
 }
 

--- a/lib/os/zvfs/zvfs_select.c
+++ b/lib/os/zvfs/zvfs_select.c
@@ -19,7 +19,7 @@
 #define FD_SET_CALC_OFFSETS(set, word_idx, bit_mask) { \
 	unsigned int b_idx = fd % (sizeof(set->bitset[0]) * 8); \
 	word_idx = fd / (sizeof(set->bitset[0]) * 8); \
-	bit_mask = 1 << b_idx; \
+	bit_mask = 1UL << b_idx; \
 	}
 
 int zvfs_poll_internal(struct zvfs_pollfd *fds, int nfds, k_timeout_t timeout);

--- a/subsys/mgmt/mcumgr/transport/src/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_udp.c
@@ -154,7 +154,7 @@ static int smp_udp_ud_copy(struct net_buf *dst, const struct net_buf *src)
 	struct sockaddr *src_ud = net_buf_user_data(src);
 	struct sockaddr *dst_ud = net_buf_user_data(dst);
 
-	net_ipaddr_copy(dst_ud, src_ud);
+	memcpy(dst_ud, src_ud, sizeof(struct sockaddr));
 
 	return MGMT_ERR_EOK;
 }
@@ -249,7 +249,7 @@ static void smp_udp_receive_thread(void *p1, void *p2, void *p3)
 			}
 			net_buf_add_mem(nb, conf->recv_buffer, len);
 			ud = net_buf_user_data(nb);
-			net_ipaddr_copy(ud, &addr);
+			memcpy(ud, &addr, sizeof(addr));
 
 			smp_rx_req(&conf->smp_transport, nb);
 		} else if (len < 0) {

--- a/subsys/net/ip/6lo.c
+++ b/subsys/net/ip/6lo.c
@@ -119,40 +119,42 @@ static int get_ihpc_inlined_size(uint16_t iphc)
  *       Mesh header compression
  */
 
-static inline bool net_6lo_ll_prefix_padded_with_zeros(struct in6_addr *addr)
+static inline bool net_6lo_ll_prefix_padded_with_zeros(const uint8_t *addr)
 {
-	return (net_ipv6_is_ll_addr(addr) &&
-		(UNALIGNED_GET(&addr->s6_addr16[1]) == 0x00) &&
-		(UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00));
+	return (net_ipv6_is_ll_addr_raw(addr) &&
+		(UNALIGNED_GET((uint16_t *)addr + 1) == 0x00) &&
+		(UNALIGNED_GET((uint32_t *)addr + 1) == 0x00));
 }
 
-static inline bool net_6lo_addr_16_bit_compressible(struct in6_addr *addr)
+static inline bool net_6lo_addr_16_bit_compressible(const uint8_t *addr)
 {
-	return ((UNALIGNED_GET(&addr->s6_addr32[2]) == htonl(0xFFu)) &&
-		 (UNALIGNED_GET(&addr->s6_addr16[6]) == htons(0xFE00u)));
+	return ((UNALIGNED_GET((uint32_t *)addr + 2) == htonl(0xFFu)) &&
+		(UNALIGNED_GET((uint16_t *)addr + 6) == htons(0xFE00u)));
 }
 
-static inline bool net_6lo_maddr_8_bit_compressible(struct in6_addr *addr)
+static inline bool net_6lo_maddr_8_bit_compressible(const uint8_t *addr)
 {
-	return ((addr->s6_addr[1] == 0x02) &&
-		 (UNALIGNED_GET(&addr->s6_addr16[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr32[2]) == 0x00) &&
-		 (addr->s6_addr[14] == 0x00));
+	return ((addr[1] == 0x02) &&
+		(UNALIGNED_GET((uint16_t *)addr + 1) == 0x00) &&
+		(UNALIGNED_GET((uint32_t *)addr + 1) == 0x00) &&
+		(UNALIGNED_GET((uint32_t *)addr + 2) == 0x00) &&
+		(addr[14] == 0x00));
+
 }
 
-static inline bool net_6lo_maddr_32_bit_compressible(struct in6_addr *addr)
+static inline bool net_6lo_maddr_32_bit_compressible(const uint8_t *addr)
 {
-	return ((UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr32[2]) == 0x00) &&
-		 (addr->s6_addr[12] == 0x00));
+	return ((UNALIGNED_GET((uint32_t *)addr + 1) == 0x00) &&
+		(UNALIGNED_GET((uint32_t *)addr + 2) == 0x00) &&
+		(addr[12] == 0x00));
+
 }
 
-static inline bool net_6lo_maddr_48_bit_compressible(struct in6_addr *addr)
+static inline bool net_6lo_maddr_48_bit_compressible(const uint8_t *addr)
 {
-	return ((UNALIGNED_GET(&addr->s6_addr32[1]) == 0x00) &&
-		 (UNALIGNED_GET(&addr->s6_addr16[4]) == 0x00) &&
-		 (addr->s6_addr[10] == 0x00));
+	return ((UNALIGNED_GET((uint32_t *)addr + 1) == 0x00) &&
+		(UNALIGNED_GET((uint16_t *)addr + 4) == 0x00) &&
+		(addr[10] == 0x00));
 }
 
 #if defined(CONFIG_NET_6LO_CONTEXT)
@@ -366,8 +368,7 @@ static uint8_t *compress_sa(struct net_ipv6_hdr *ipv6, struct net_pkt *pkt,
 			 uint8_t *inline_ptr, uint16_t *iphc)
 {
 	/* Address is fully elided */
-	if (net_ipv6_addr_based_on_ll((struct in6_addr *)ipv6->src,
-				      net_pkt_lladdr_src(pkt))) {
+	if (net_ipv6_addr_based_on_ll_raw(ipv6->src, net_pkt_lladdr_src(pkt))) {
 		NET_DBG("SAM_11 src address is fully elided");
 
 		*iphc |= NET_6LO_IPHC_SAM_11;
@@ -375,7 +376,7 @@ static uint8_t *compress_sa(struct net_ipv6_hdr *ipv6, struct net_pkt *pkt,
 	}
 
 	/* Following 64 bits are 0000:00ff:fe00:XXXX */
-	if (net_6lo_addr_16_bit_compressible((struct in6_addr *)ipv6->src)) {
+	if (net_6lo_addr_16_bit_compressible(ipv6->src)) {
 		NET_DBG("SAM_10 src addr 16 bit compressible");
 		*iphc |= NET_6LO_IPHC_SAM_10;
 
@@ -412,8 +413,7 @@ static uint8_t *compress_sa_ctx(struct net_ipv6_hdr *ipv6, uint8_t *inline_ptr,
 	NET_DBG("SAC_1 src address context based");
 	*iphc |= NET_6LO_IPHC_SAC_1;
 
-	if (net_ipv6_addr_based_on_ll((struct in6_addr *)ipv6->src,
-				      net_pkt_lladdr_src(pkt))) {
+	if (net_ipv6_addr_based_on_ll_raw(ipv6->src, net_pkt_lladdr_src(pkt))) {
 		NET_DBG("SAM_11 src address is fully elided");
 
 		/* Address is fully elided */
@@ -422,7 +422,7 @@ static uint8_t *compress_sa_ctx(struct net_ipv6_hdr *ipv6, uint8_t *inline_ptr,
 	}
 
 	/* Following 64 bits are 0000:00ff:fe00:XXXX */
-	if (net_6lo_addr_16_bit_compressible((struct in6_addr *)ipv6->src)) {
+	if (net_6lo_addr_16_bit_compressible(ipv6->src)) {
 		NET_DBG("SAM_10 src addr 16 bit compressible");
 
 		*iphc |= NET_6LO_IPHC_SAM_10;
@@ -452,7 +452,7 @@ static uint8_t *compress_da_mcast(struct net_ipv6_hdr *ipv6, uint8_t *inline_ptr
 
 	NET_DBG("M_1 dst is mcast");
 
-	if (net_6lo_maddr_8_bit_compressible((struct in6_addr *)ipv6->dst)) {
+	if (net_6lo_maddr_8_bit_compressible(ipv6->dst)) {
 		NET_DBG("DAM_11 dst maddr 8 bit compressible");
 
 		/* last byte */
@@ -464,7 +464,7 @@ static uint8_t *compress_da_mcast(struct net_ipv6_hdr *ipv6, uint8_t *inline_ptr
 		return inline_ptr;
 	}
 
-	if (net_6lo_maddr_32_bit_compressible((struct in6_addr *)ipv6->dst)) {
+	if (net_6lo_maddr_32_bit_compressible(ipv6->dst)) {
 		NET_DBG("DAM_10 4 bytes: 2nd byte + last three bytes");
 
 		/* 4 bytes: 2nd byte + last three bytes */
@@ -479,7 +479,7 @@ static uint8_t *compress_da_mcast(struct net_ipv6_hdr *ipv6, uint8_t *inline_ptr
 		return inline_ptr;
 	}
 
-	if (net_6lo_maddr_48_bit_compressible((struct in6_addr *)ipv6->dst)) {
+	if (net_6lo_maddr_48_bit_compressible(ipv6->dst)) {
 		NET_DBG("DAM_01 6 bytes: 2nd byte + last five bytes");
 
 		/* 6 bytes: 2nd byte + last five bytes */
@@ -507,8 +507,7 @@ static uint8_t *compress_da(struct net_ipv6_hdr *ipv6, struct net_pkt *pkt,
 			 uint8_t *inline_ptr, uint16_t *iphc)
 {
 	/* Address is fully elided */
-	if (net_ipv6_addr_based_on_ll((struct in6_addr *)ipv6->dst,
-				      net_pkt_lladdr_dst(pkt))) {
+	if (net_ipv6_addr_based_on_ll_raw(ipv6->dst, net_pkt_lladdr_dst(pkt))) {
 		NET_DBG("DAM_11 dst addr fully elided");
 
 		*iphc |= NET_6LO_IPHC_DAM_11;
@@ -516,7 +515,7 @@ static uint8_t *compress_da(struct net_ipv6_hdr *ipv6, struct net_pkt *pkt,
 	}
 
 	/* Following 64 bits are 0000:00ff:fe00:XXXX */
-	if (net_6lo_addr_16_bit_compressible((struct in6_addr *)ipv6->dst)) {
+	if (net_6lo_addr_16_bit_compressible(ipv6->dst)) {
 		NET_DBG("DAM_10 dst addr 16 bit compressible");
 
 		*iphc |= NET_6LO_IPHC_DAM_10;
@@ -553,8 +552,7 @@ static uint8_t *compress_da_ctx(struct net_ipv6_hdr *ipv6, uint8_t *inline_ptr,
 {
 	*iphc |= NET_6LO_IPHC_DAC_1;
 
-	if (net_ipv6_addr_based_on_ll((struct in6_addr *)ipv6->dst,
-				      net_pkt_lladdr_dst(pkt))) {
+	if (net_ipv6_addr_based_on_ll_raw(ipv6->dst, net_pkt_lladdr_dst(pkt))) {
 		NET_DBG("DAM_11 dst addr fully elided");
 
 		*iphc |= NET_6LO_IPHC_DAM_11;
@@ -562,7 +560,7 @@ static uint8_t *compress_da_ctx(struct net_ipv6_hdr *ipv6, uint8_t *inline_ptr,
 	}
 
 	/* Following 64 bits are 0000:00ff:fe00:XXXX */
-	if (net_6lo_addr_16_bit_compressible((struct in6_addr *)ipv6->dst)) {
+	if (net_6lo_addr_16_bit_compressible(ipv6->dst)) {
 		NET_DBG("DAM_10 dst addr 16 bit compressible");
 
 		*iphc |= NET_6LO_IPHC_DAM_10;
@@ -753,12 +751,12 @@ static inline int compress_IPHC_header(struct net_pkt *pkt)
 		inline_pos = compress_nh_udp(udp, inline_pos, false);
 	}
 
-	if (net_6lo_ll_prefix_padded_with_zeros((struct in6_addr *)ipv6->dst)) {
+	if (net_6lo_ll_prefix_padded_with_zeros(ipv6->dst)) {
 		inline_pos = compress_da(ipv6, pkt, inline_pos, &iphc);
 		goto da_end;
 	}
 
-	if (net_ipv6_is_addr_mcast((struct in6_addr *)ipv6->dst)) {
+	if (net_ipv6_is_addr_mcast_raw(ipv6->dst)) {
 		inline_pos = compress_da_mcast(ipv6, inline_pos, &iphc);
 		goto da_end;
 	}
@@ -775,7 +773,7 @@ static inline int compress_IPHC_header(struct net_pkt *pkt)
 	inline_pos = set_da_inline(ipv6, inline_pos, &iphc);
 da_end:
 
-	if (net_6lo_ll_prefix_padded_with_zeros((struct in6_addr *)ipv6->src)) {
+	if (net_6lo_ll_prefix_padded_with_zeros(ipv6->src)) {
 		inline_pos = compress_sa(ipv6, pkt, inline_pos, &iphc);
 		goto sa_end;
 	}

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -581,8 +581,7 @@ static bool conn_are_endpoints_valid(struct net_pkt *pkt, uint8_t family,
 		is_same_src_and_dst_addr = net_ipv4_addr_cmp_raw(
 			ip_hdr->ipv4->src, ip_hdr->ipv4->dst);
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
-		is_my_src_addr = net_ipv6_is_my_addr(
-			(struct in6_addr *)ip_hdr->ipv6->src);
+		is_my_src_addr = net_ipv6_is_my_addr_raw(ip_hdr->ipv6->src);
 		is_same_src_and_dst_addr = net_ipv6_addr_cmp_raw(
 			ip_hdr->ipv6->src, ip_hdr->ipv6->dst);
 	} else {
@@ -933,7 +932,7 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 			is_bcast_pkt = true;
 		}
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && pkt_family == AF_INET6) {
-		is_mcast_pkt = net_ipv6_is_addr_mcast((struct in6_addr *)ip_hdr->ipv6->dst);
+		is_mcast_pkt = net_ipv6_is_addr_mcast_raw(ip_hdr->ipv6->dst);
 	}
 
 	k_mutex_lock(&conn_lock, K_FOREVER);

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -576,8 +576,7 @@ static bool conn_are_endpoints_valid(struct net_pkt *pkt, uint8_t family,
 	bool is_same_src_and_dst_addr;
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
-		is_my_src_addr = net_ipv4_is_my_addr(
-			(struct in_addr *)ip_hdr->ipv4->src);
+		is_my_src_addr = net_ipv4_is_my_addr_raw(ip_hdr->ipv4->src);
 		is_same_src_and_dst_addr = net_ipv4_addr_cmp_raw(
 			ip_hdr->ipv4->src, ip_hdr->ipv4->dst);
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && family == AF_INET6) {
@@ -925,10 +924,10 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 	 * need to deliver the packet to multiple recipients.
 	 */
 	if (IS_ENABLED(CONFIG_NET_IPV4) && pkt_family == AF_INET) {
-		if (net_ipv4_is_addr_mcast((struct in_addr *)ip_hdr->ipv4->dst)) {
+		if (net_ipv4_is_addr_mcast_raw(ip_hdr->ipv4->dst)) {
 			is_mcast_pkt = true;
-		} else if (net_if_ipv4_is_addr_bcast(pkt_iface,
-						     (struct in_addr *)ip_hdr->ipv4->dst)) {
+		} else if (net_if_ipv4_is_addr_bcast_raw(pkt_iface,
+							 ip_hdr->ipv4->dst)) {
 			is_bcast_pkt = true;
 		}
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && pkt_family == AF_INET6) {

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -104,15 +104,19 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 {
 	struct net_pkt *reply = NULL;
 	struct net_ipv6_hdr *ip_hdr = hdr->ipv6;
+	struct in6_addr req_src, req_dst;
 	const struct in6_addr *src;
 	int16_t payload_len;
 
 	ARG_UNUSED(user_data);
 	ARG_UNUSED(icmp_hdr);
 
+	net_ipv6_addr_copy_raw(req_src.s6_addr, ip_hdr->src);
+	net_ipv6_addr_copy_raw(req_dst.s6_addr, ip_hdr->dst);
+
 	NET_DBG("Received Echo Request from %s to %s",
-		net_sprint_ipv6_addr(&ip_hdr->src),
-		net_sprint_ipv6_addr(&ip_hdr->dst));
+		net_sprint_ipv6_addr(&req_src),
+		net_sprint_ipv6_addr(&req_dst));
 
 	payload_len = ntohs(ip_hdr->len) -
 		net_pkt_ipv6_ext_len(pkt) - NET_ICMPH_LEN;
@@ -129,16 +133,16 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 		goto drop;
 	}
 
-	if (net_ipv6_is_addr_mcast((struct in6_addr *)ip_hdr->dst)) {
+	if (net_ipv6_is_addr_mcast_raw(ip_hdr->dst)) {
 		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
-						  (struct in6_addr *)ip_hdr->src);
+						  &req_src);
 
 		if (net_ipv6_is_addr_unspecified(src)) {
 			NET_DBG("DROP: No src address match");
 			goto drop;
 		}
 	} else {
-		src = (struct in6_addr *)ip_hdr->dst;
+		src = &req_dst;
 	}
 
 	/* We must not set the destination ll address here but trust
@@ -151,7 +155,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 	net_pkt_set_ip_dscp(reply, net_pkt_ip_dscp(pkt));
 	net_pkt_set_ip_ecn(reply, net_pkt_ip_ecn(pkt));
 
-	if (net_ipv6_create(reply, src, (struct in6_addr *)ip_hdr->src)) {
+	if (net_ipv6_create(reply, src, &req_src)) {
 		NET_DBG("DROP: wrong buffer");
 		goto drop;
 	}
@@ -167,7 +171,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 
 	NET_DBG("Sending Echo Reply from %s to %s",
 		net_sprint_ipv6_addr(src),
-		net_sprint_ipv6_addr(&ip_hdr->src));
+		net_sprint_ipv6_addr(&req_src));
 
 	if (net_try_send_data(reply, K_NO_WAIT) < 0) {
 		goto drop;
@@ -192,6 +196,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv6_access, struct net_ipv6_hdr);
 	int err = -EIO;
+	struct in6_addr orig_src, orig_dst;
 	struct net_ipv6_hdr *ip_hdr;
 	const struct in6_addr *src;
 	struct net_pkt *pkt;
@@ -222,6 +227,9 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 
 		net_pkt_cursor_init(orig);
 	}
+
+	net_ipv6_addr_copy_raw(orig_src.s6_addr, ip_hdr->src);
+	net_ipv6_addr_copy_raw(orig_dst.s6_addr, ip_hdr->dst);
 
 	if (ip_hdr->nexthdr == IPPROTO_UDP) {
 		copy_len = sizeof(struct net_ipv6_hdr) +
@@ -284,14 +292,14 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 	net_pkt_lladdr_src(pkt)->len = net_pkt_lladdr_dst(orig)->len;
 	net_pkt_lladdr_dst(pkt)->len = net_pkt_lladdr_src(orig)->len;
 
-	if (net_ipv6_is_addr_mcast((struct in6_addr *)ip_hdr->dst)) {
+	if (net_ipv6_is_addr_mcast_raw(ip_hdr->dst)) {
 		src = net_if_ipv6_select_src_addr(net_pkt_iface(pkt),
-						  (struct in6_addr *)ip_hdr->dst);
+						  &orig_dst);
 	} else {
-		src = (struct in6_addr *)ip_hdr->dst;
+		src = &orig_dst;
 	}
 
-	if (net_ipv6_create(pkt, src, (struct in6_addr *)ip_hdr->src) ||
+	if (net_ipv6_create(pkt, src, &orig_src) ||
 	    net_icmpv6_create(pkt, type, code)) {
 		goto drop;
 	}
@@ -319,7 +327,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 	NET_DBG("Sending ICMPv6 Error Message type %d code %d param %d"
 		" from %s to %s", type, code, param,
 		net_sprint_ipv6_addr(src),
-		net_sprint_ipv6_addr(&ip_hdr->src));
+		net_sprint_ipv6_addr(&orig_src));
 
 	if (net_try_send_data(pkt, K_NO_WAIT) >= 0) {
 		net_stats_update_icmp_sent(net_pkt_iface(pkt));

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -302,30 +302,30 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	if (!is_loopback) {
-		if (net_ipv4_is_addr_loopback((struct in_addr *)hdr->dst) ||
-		    net_ipv4_is_addr_loopback((struct in_addr *)hdr->src)) {
+		if (net_ipv4_is_addr_loopback_raw(hdr->dst) ||
+		    net_ipv4_is_addr_loopback_raw(hdr->src)) {
 			NET_DBG("DROP: localhost packet");
 			goto drop;
 		}
 
-		if (net_ipv4_is_my_addr((struct in_addr *)hdr->src)) {
+		if (net_ipv4_is_my_addr_raw(hdr->src)) {
 			NET_DBG("DROP: src addr is %s", "mine");
 			goto drop;
 		}
 	}
 
-	if (net_ipv4_is_addr_mcast((struct in_addr *)hdr->src)) {
+	if (net_ipv4_is_addr_mcast_raw(hdr->src)) {
 		NET_DBG("DROP: src addr is %s", "mcast");
 		goto drop;
 	}
 
-	if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt), (struct in_addr *)hdr->src)) {
+	if (net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt), hdr->src)) {
 		NET_DBG("DROP: src addr is %s", "bcast");
 		goto drop;
 	}
 
-	if (net_ipv4_is_addr_unspecified((struct in_addr *)hdr->src) &&
-	    !net_ipv4_is_addr_bcast(net_pkt_iface(pkt), (struct in_addr *)hdr->dst) &&
+	if (net_ipv4_is_addr_unspecified_raw(hdr->src) &&
+	    !net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt), hdr->dst) &&
 	    (hdr->proto != IPPROTO_IGMP)) {
 		NET_DBG("DROP: src addr is %s", "unspecified");
 		goto drop;
@@ -347,17 +347,17 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt, bool is_loopback)
 		return NET_DROP;
 	}
 
-	if ((!net_ipv4_is_my_addr((struct in_addr *)hdr->dst) &&
-	     !net_ipv4_is_addr_mcast((struct in_addr *)hdr->dst) &&
+	if ((!net_ipv4_is_my_addr_raw(hdr->dst) &&
+	     !net_ipv4_is_addr_mcast_raw(hdr->dst) &&
 	     !(hdr->proto == IPPROTO_UDP &&
-	       (net_ipv4_addr_cmp((struct in_addr *)hdr->dst, net_ipv4_broadcast_address()) ||
+	       (net_ipv4_addr_cmp_raw(hdr->dst, net_ipv4_broadcast_address()->s4_addr) ||
 		/* RFC 1122 ch. 3.3.6 The 0.0.0.0 is non-standard bcast addr */
 		(IS_ENABLED(CONFIG_NET_IPV4_ACCEPT_ZERO_BROADCAST) &&
-		 net_ipv4_addr_cmp((struct in_addr *)hdr->dst,
-				   net_ipv4_unspecified_address())) ||
+		 net_ipv4_addr_cmp_raw(hdr->dst,
+				       net_ipv4_unspecified_address()->s4_addr)) ||
 		net_dhcpv4_accept_unicast(pkt)))) ||
 	    (hdr->proto == IPPROTO_TCP &&
-	     net_ipv4_is_addr_bcast(net_pkt_iface(pkt), (struct in_addr *)hdr->dst))) {
+	     net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt), hdr->dst))) {
 		NET_DBG("DROP: not for me");
 		goto drop;
 	}

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -32,16 +32,16 @@ static void reassembly_timeout(struct k_work *work);
 
 static struct net_ipv4_reassembly reassembly[CONFIG_NET_IPV4_FRAGMENT_MAX_COUNT];
 
-static struct net_ipv4_reassembly *reassembly_get(uint16_t id, struct in_addr *src,
-						  struct in_addr *dst, uint8_t protocol)
+static struct net_ipv4_reassembly *reassembly_get(uint16_t id, const uint8_t *src,
+						  const uint8_t *dst, uint8_t protocol)
 {
 	int i, avail = -1;
 
 	for (i = 0; i < CONFIG_NET_IPV4_FRAGMENT_MAX_COUNT; i++) {
 		if (k_work_delayable_remaining_get(&reassembly[i].timer) &&
 		    reassembly[i].id == id &&
-		    net_ipv4_addr_cmp(src, &reassembly[i].src) &&
-		    net_ipv4_addr_cmp(dst, &reassembly[i].dst) &&
+		    net_ipv4_addr_cmp_raw(src, reassembly[i].src.s4_addr) &&
+		    net_ipv4_addr_cmp_raw(dst, reassembly[i].dst.s4_addr) &&
 		    reassembly[i].protocol == protocol) {
 			return &reassembly[i];
 		}
@@ -61,8 +61,8 @@ static struct net_ipv4_reassembly *reassembly_get(uint16_t id, struct in_addr *s
 
 	k_work_reschedule(&reassembly[avail].timer, K_SECONDS(CONFIG_NET_IPV4_FRAGMENT_TIMEOUT));
 
-	net_ipaddr_copy(&reassembly[avail].src, src);
-	net_ipaddr_copy(&reassembly[avail].dst, dst);
+	net_ipv4_addr_copy_raw(reassembly[avail].src.s4_addr, src);
+	net_ipv4_addr_copy_raw(reassembly[avail].dst.s4_addr, dst);
 
 	reassembly[avail].protocol = protocol;
 	reassembly[avail].id = id;
@@ -331,8 +331,7 @@ enum net_verdict net_ipv4_handle_fragment_hdr(struct net_pkt *pkt, struct net_ip
 	flag = ntohs(*((uint16_t *)&hdr->offset));
 	id = ntohs(*((uint16_t *)&hdr->id));
 
-	reass = reassembly_get(id, (struct in_addr *)hdr->src,
-			       (struct in_addr *)hdr->dst, hdr->proto);
+	reass = reassembly_get(id, hdr->src, hdr->dst, hdr->proto);
 	if (!reass) {
 		LOG_ERR("Cannot get reassembly slot, dropping pkt %p", pkt);
 		goto drop;

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -186,7 +186,7 @@ static inline bool ipv6_drop_on_unknown_option(struct net_pkt *pkt,
 	case 0x40:
 		break;
 	case 0xc0:
-		if (net_ipv6_is_addr_mcast((struct in6_addr *)hdr->dst)) {
+		if (net_ipv6_is_addr_mcast_raw(hdr->dst)) {
 			break;
 		}
 
@@ -307,8 +307,8 @@ static struct net_route_entry *add_route(struct net_if *iface,
 #endif /* CONFIG_NET_ROUTE */
 
 static void ipv6_no_route_info(struct net_pkt *pkt,
-			       struct in6_addr *src,
-			       struct in6_addr *dst)
+			       const uint8_t *src,
+			       const uint8_t *dst)
 {
 	NET_DBG("Will not route pkt %p ll src %s to dst %s between interfaces",
 		pkt, net_sprint_ipv6_addr(src),
@@ -321,15 +321,17 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 {
 	struct net_route_entry *route;
 	struct in6_addr *nexthop;
+	struct in6_addr src_ip, dst_ip;
 	bool found;
+
+	net_ipv6_addr_copy_raw(src_ip.s6_addr, hdr->src);
+	net_ipv6_addr_copy_raw(dst_ip.s6_addr, hdr->dst);
 
 	/* Check if the packet can be routed */
 	if (IS_ENABLED(CONFIG_NET_ROUTING)) {
-		found = net_route_get_info(NULL, (struct in6_addr *)hdr->dst,
-					   &route, &nexthop);
+		found = net_route_get_info(NULL, &dst_ip, &route, &nexthop);
 	} else {
-		found = net_route_get_info(net_pkt_iface(pkt),
-					   (struct in6_addr *)hdr->dst,
+		found = net_route_get_info(net_pkt_iface(pkt), &dst_ip,
 					   &route, &nexthop);
 	}
 
@@ -337,11 +339,11 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 		int ret;
 
 		if (IS_ENABLED(CONFIG_NET_ROUTING) &&
-		    (net_ipv6_is_ll_addr((struct in6_addr *)hdr->src) ||
-		     net_ipv6_is_ll_addr((struct in6_addr *)hdr->dst))) {
+		    (net_ipv6_is_ll_addr(&src_ip) ||
+		     net_ipv6_is_ll_addr(&dst_ip))) {
 			/* RFC 4291 ch 2.5.6 */
-			ipv6_no_route_info(pkt, (struct in6_addr *)hdr->src,
-					   (struct in6_addr *)hdr->dst);
+			ipv6_no_route_info(pkt, hdr->src, hdr->dst);
+
 			goto drop;
 		}
 
@@ -365,8 +367,7 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 				pkt, net_pkt_orig_iface(pkt),
 				net_pkt_iface(pkt));
 
-			add_route(net_pkt_orig_iface(pkt),
-				  (struct in6_addr *)hdr->src, 128);
+			add_route(net_pkt_orig_iface(pkt), &src_ip, 128);
 		}
 
 		ret = net_route_packet(pkt, nexthop);
@@ -382,7 +383,7 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 		struct net_if *iface = NULL;
 		int ret;
 
-		if (net_if_ipv6_addr_onlink(&iface, (struct in6_addr *)hdr->dst)) {
+		if (net_if_ipv6_addr_onlink(&iface, &dst_ip)) {
 			ret = net_route_packet_if(pkt, iface);
 			if (ret < 0) {
 				NET_DBG("Cannot re-route pkt %p "
@@ -394,7 +395,7 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 		}
 
 		NET_DBG("No route to %s pkt %p dropped",
-			net_sprint_ipv6_addr(&hdr->dst), pkt);
+			net_sprint_ipv6_addr(&dst_ip), pkt);
 	}
 
 drop:
@@ -427,9 +428,9 @@ static enum net_verdict ipv6_forward_mcast_packet(struct net_pkt *pkt,
 	 *   3. is from link local source
 	 *   4. hop limit is or would become zero
 	 */
-	if (net_ipv6_is_addr_mcast((struct in6_addr *)hdr->src) ||
-	    net_ipv6_is_addr_mcast_iface((struct in6_addr *)hdr->dst) ||
-	    net_ipv6_is_ll_addr((struct in6_addr *)hdr->src) || hdr->hop_limit <= 1) {
+	if (net_ipv6_is_addr_mcast_raw(hdr->src) ||
+	    net_ipv6_is_addr_mcast_iface_raw(hdr->dst) ||
+	    net_ipv6_is_ll_addr_raw(hdr->src) || hdr->hop_limit <= 1) {
 		return NET_CONTINUE;
 	}
 
@@ -462,11 +463,11 @@ static uint8_t extension_to_bitmap(uint8_t header, uint8_t ext_bitmap)
 	}
 }
 
-static inline bool is_src_non_tentative_itself(struct in6_addr *src)
+static inline bool is_src_non_tentative_itself(const uint8_t *src)
 {
 	struct net_if_addr *ifaddr;
 
-	ifaddr = net_if_ipv6_addr_lookup(src, NULL);
+	ifaddr = net_if_ipv6_addr_lookup_raw(src, NULL);
 	if (ifaddr != NULL && ifaddr->addr_state != NET_ADDR_TENTATIVE) {
 		return true;
 	}
@@ -518,37 +519,37 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 		net_sprint_ipv6_addr(&hdr->src),
 		net_sprint_ipv6_addr(&hdr->dst));
 
-	if (net_ipv6_is_addr_unspecified((struct in6_addr *)hdr->src)) {
+	if (net_ipv6_is_addr_unspecified_raw(hdr->src)) {
 		/* If this is a possible DAD message, let it pass. Extra checks
 		 * are done in duplicate address detection code to verify that
 		 * the packet is ok.
 		 */
 		if (!(IS_ENABLED(CONFIG_NET_IPV6_DAD) &&
-		      net_ipv6_is_addr_solicited_node((struct in6_addr *)hdr->dst))) {
+		      net_ipv6_is_addr_solicited_node_raw(hdr->dst))) {
 			NET_DBG("DROP: src addr is %s", "unspecified");
 			goto drop;
 		}
 	}
 
-	if (net_ipv6_is_addr_mcast((struct in6_addr *)hdr->src) ||
-	    net_ipv6_is_addr_mcast_scope((struct in6_addr *)hdr->dst, 0)) {
+	if (net_ipv6_is_addr_mcast_raw(hdr->src) ||
+	    net_ipv6_is_addr_mcast_scope_raw(hdr->dst, 0)) {
 		NET_DBG("DROP: multicast packet");
 		goto drop;
 	}
 
 	if (!is_loopback) {
-		if (net_ipv6_is_addr_loopback((struct in6_addr *)hdr->dst) ||
-		    net_ipv6_is_addr_loopback((struct in6_addr *)hdr->src)) {
+		if (net_ipv6_is_addr_loopback_raw(hdr->dst) ||
+		    net_ipv6_is_addr_loopback_raw(hdr->src)) {
 			NET_DBG("DROP: ::1 packet");
 			goto drop;
 		}
 
-		if (net_ipv6_is_addr_mcast_iface((struct in6_addr *)hdr->dst) ||
-		    (net_ipv6_is_addr_mcast_group(
-			    (struct in6_addr *)hdr->dst,
-			    net_ipv6_unspecified_address()) &&
-		     (net_ipv6_is_addr_mcast_site((struct in6_addr *)hdr->dst) ||
-		      net_ipv6_is_addr_mcast_org((struct in6_addr *)hdr->dst)))) {
+		if (net_ipv6_is_addr_mcast_iface_raw(hdr->dst) ||
+		    (net_ipv6_is_addr_mcast_group_raw(
+			    hdr->dst,
+			    (const uint8_t *)net_ipv6_unspecified_address()) &&
+		     (net_ipv6_is_addr_mcast_site_raw(hdr->dst) ||
+		      net_ipv6_is_addr_mcast_org_raw(hdr->dst)))) {
 			NET_DBG("DROP: invalid scope multicast packet");
 			goto drop;
 		}
@@ -559,7 +560,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 		 * This check is done later on if routing features are enabled.
 		 */
 		if (!IS_ENABLED(CONFIG_NET_ROUTING) && !IS_ENABLED(CONFIG_NET_ROUTE_MCAST) &&
-		    is_src_non_tentative_itself((struct in6_addr *)hdr->src)) {
+		    is_src_non_tentative_itself(hdr->src)) {
 			NET_DBG("DROP: src addr is %s", "mine");
 			goto drop;
 		}
@@ -589,7 +590,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_ROUTE_MCAST) &&
-		net_ipv6_is_addr_mcast((struct in6_addr *)hdr->dst) && !net_pkt_forwarding(pkt)) {
+		net_ipv6_is_addr_mcast_raw(hdr->dst) && !net_pkt_forwarding(pkt)) {
 		/* If the packet is a multicast packet and multicast routing
 		 * is activated, we give the packet to the routing engine.
 		 *
@@ -603,14 +604,14 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 		}
 	}
 
-	if (!net_ipv6_is_addr_mcast((struct in6_addr *)hdr->dst)) {
-		if (!net_if_ipv6_addr_lookup_by_iface(pkt_iface, (struct in6_addr *)hdr->dst)) {
+	if (!net_ipv6_is_addr_mcast_raw(hdr->dst)) {
+		if (!net_if_ipv6_addr_lookup_by_iface_raw(pkt_iface, hdr->dst)) {
 			if (ipv6_route_packet(pkt, hdr) == NET_OK) {
 				return NET_OK;
 			}
 
 			NET_DBG("DROP: no such address %s in iface %d",
-				net_sprint_ipv6_addr((struct in6_addr *)hdr->dst),
+				net_sprint_ipv6_addr(hdr->dst),
 				net_if_get_by_iface(pkt_iface));
 			goto drop;
 		}
@@ -621,25 +622,23 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 		 * RFC 4291 ch 2.5.6
 		 */
 		if (IS_ENABLED(CONFIG_NET_ROUTING) &&
-		    net_ipv6_is_ll_addr((struct in6_addr *)hdr->src) &&
-		    !net_if_ipv6_addr_lookup_by_iface(
-				pkt_iface, (struct in6_addr *)hdr->dst)) {
-			ipv6_no_route_info(pkt, (struct in6_addr *)hdr->src,
-					   (struct in6_addr *)hdr->dst);
+		    net_ipv6_is_ll_addr_raw(hdr->src) &&
+		    !net_if_ipv6_addr_lookup_by_iface_raw(pkt_iface, hdr->dst)) {
+			ipv6_no_route_info(pkt, hdr->src, hdr->dst);
 			NET_DBG("DROP: cross interface boundary");
 			goto drop;
 		}
 	}
 
 	if ((IS_ENABLED(CONFIG_NET_ROUTING) || IS_ENABLED(CONFIG_NET_ROUTE_MCAST)) &&
-	    !is_loopback && is_src_non_tentative_itself((struct in6_addr *)hdr->src)) {
+	    !is_loopback && is_src_non_tentative_itself(hdr->src)) {
 		NET_DBG("DROP: src addr is %s", "mine");
 		goto drop;
 	}
 
-	if (net_ipv6_is_addr_mcast((struct in6_addr *)hdr->dst) &&
-	    !(net_ipv6_is_addr_mcast_iface((struct in6_addr *)hdr->dst) ||
-	      net_ipv6_is_addr_mcast_link_all_nodes((struct in6_addr *)hdr->dst))) {
+	if (net_ipv6_is_addr_mcast_raw(hdr->dst) &&
+	    !(net_ipv6_is_addr_mcast_iface_raw(hdr->dst) ||
+	      net_ipv6_is_addr_mcast_link_all_nodes_raw(hdr->dst))) {
 		/* If we receive a packet with a interface-local or
 		 * link-local all-nodes multicast destination address we
 		 * always have to pass it to the upper layer.
@@ -650,9 +649,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 		 * packet will be dropped.
 		 * RFC4291 ch 2.7.1, ch 2.8
 		 */
-		if_mcast_addr = net_if_ipv6_maddr_lookup(
-				    (struct in6_addr *)hdr->dst, &pkt_iface);
-
+		if_mcast_addr = net_if_ipv6_maddr_lookup_raw(hdr->dst, &pkt_iface);
 		if (!if_mcast_addr ||
 		    !net_if_ipv6_maddr_is_joined(if_mcast_addr)) {
 			NET_DBG("DROP: packet for unjoined multicast address");

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -121,16 +121,16 @@ fail:
 }
 
 static struct net_ipv6_reassembly *reassembly_get(uint32_t id,
-						  struct in6_addr *src,
-						  struct in6_addr *dst)
+						  const uint8_t *src,
+						  const uint8_t *dst)
 {
 	int i, avail = -1;
 
 	for (i = 0; i < CONFIG_NET_IPV6_FRAGMENT_MAX_COUNT; i++) {
 		if (k_work_delayable_remaining_get(&reassembly[i].timer) &&
 		    reassembly[i].id == id &&
-		    net_ipv6_addr_cmp(src, &reassembly[i].src) &&
-		    net_ipv6_addr_cmp(dst, &reassembly[i].dst)) {
+		    net_ipv6_addr_cmp_raw(src, reassembly[i].src.s6_addr) &&
+		    net_ipv6_addr_cmp_raw(dst, reassembly[i].dst.s6_addr)) {
 			return &reassembly[i];
 		}
 
@@ -149,8 +149,8 @@ static struct net_ipv6_reassembly *reassembly_get(uint32_t id,
 
 	k_work_reschedule(&reassembly[avail].timer, IPV6_REASSEMBLY_TIMEOUT);
 
-	net_ipaddr_copy(&reassembly[avail].src, src);
-	net_ipaddr_copy(&reassembly[avail].dst, dst);
+	net_ipv6_addr_copy_raw(reassembly[avail].src.s6_addr, src);
+	net_ipv6_addr_copy_raw(reassembly[avail].dst.s6_addr, dst);
 
 	reassembly[avail].id = id;
 
@@ -492,8 +492,7 @@ enum net_verdict net_ipv6_handle_fragment_hdr(struct net_pkt *pkt,
 		goto drop;
 	}
 
-	reass = reassembly_get(id, (struct in6_addr *)hdr->src,
-			       (struct in6_addr *)hdr->dst);
+	reass = reassembly_get(id, hdr->src, hdr->dst);
 	if (!reass) {
 		NET_DBG("Cannot get reassembly slot, dropping pkt %p", pkt);
 		goto drop;

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -782,6 +782,7 @@ enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 	struct in6_addr *nexthop = NULL;
 	struct net_if *iface = NULL;
 	struct net_ipv6_hdr *ip_hdr;
+	struct in6_addr dst_ip;
 	struct net_nbr *nbr;
 	int ret;
 
@@ -791,6 +792,8 @@ enum net_verdict net_ipv6_prepare_for_send(struct net_pkt *pkt)
 	if (!ip_hdr) {
 		return NET_DROP;
 	}
+
+	net_ipv6_addr_copy_raw(dst_ip.s6_addr, ip_hdr->dst);
 
 #if defined(CONFIG_NET_IPV6_FRAGMENT)
 	/* If we have already fragmented the packet, the fragment id will
@@ -849,11 +852,11 @@ use_interface_mtu:
 	 */
 	if ((net_pkt_lladdr_dst(pkt)->len > 0 &&
 	     ((IS_ENABLED(CONFIG_NET_ROUTING) &&
-	      (net_ipv6_is_ll_addr((struct in6_addr *)ip_hdr->dst) ||
-	       net_if_ipv6_addr_onlink(NULL, (struct in6_addr *)ip_hdr->dst) ||
+	      (net_ipv6_is_ll_addr(&dst_ip) ||
+	       net_if_ipv6_addr_onlink(NULL, &dst_ip) ||
 	       net_pkt_forwarding(pkt))) ||
 	      !IS_ENABLED(CONFIG_NET_ROUTING))) ||
-	    net_ipv6_is_addr_mcast((struct in6_addr *)ip_hdr->dst) ||
+	    net_ipv6_is_addr_mcast(&dst_ip) ||
 	    /* Workaround Linux bug, see:
 	     * https://github.com/zephyrproject-rtos/zephyr/issues/3111
 	     */
@@ -862,19 +865,18 @@ use_interface_mtu:
 		return NET_OK;
 	}
 
-	if (net_if_ipv6_addr_onlink(&iface, (struct in6_addr *)ip_hdr->dst)) {
-		nexthop = (struct in6_addr *)ip_hdr->dst;
+	if (net_if_ipv6_addr_onlink(&iface, &dst_ip)) {
+		nexthop = &dst_ip;
 		net_pkt_set_iface(pkt, iface);
-	} else if (net_ipv6_is_ll_addr((struct in6_addr *)ip_hdr->dst)) {
-		nexthop = (struct in6_addr *)ip_hdr->dst;
+	} else if (net_ipv6_is_ll_addr(&dst_ip)) {
+		nexthop = &dst_ip;
 	} else {
 		/* We need to figure out where the destination
 		 * host is located.
 		 */
 		bool try_route = false;
 
-		nexthop = check_route(NULL, (struct in6_addr *)ip_hdr->dst,
-				      &try_route);
+		nexthop = check_route(NULL, &dst_ip, &try_route);
 		if (!nexthop) {
 			return NET_DROP;
 		}
@@ -969,11 +971,15 @@ try_send:
 	net_ipv6_nbr_unlock();
 
 #if defined(CONFIG_NET_IPV6_ND)
+	struct in6_addr src_ip;
+
+	net_ipv6_addr_copy_raw(src_ip.s6_addr, ip_hdr->src);
+
 	/* We need to send NS and wait for NA before sending the packet. If the packet was
 	 * forwarded from another interface do not use the original source address.
 	 */
 	ret = net_ipv6_send_ns(net_pkt_iface(pkt), pkt,
-			       net_pkt_forwarding(pkt) ? NULL : (struct in6_addr *)ip_hdr->src,
+			       net_pkt_forwarding(pkt) ? NULL : &src_ip,
 			       NULL, nexthop, false);
 	if (ret < 0) {
 		/* In case of an error, the NS send function will unref
@@ -1212,6 +1218,7 @@ static int handle_ns_input(struct net_icmp_ctx *ctx,
 	const struct in6_addr *na_src;
 	const struct in6_addr *na_dst;
 	struct in6_addr *tgt;
+	struct in6_addr ns_tgt, ns_src, ns_dst;
 	struct net_linkaddr src_lladdr;
 
 	src_lladdr.len = 0;
@@ -1229,13 +1236,17 @@ static int handle_ns_input(struct net_icmp_ctx *ctx,
 	dbg_addr_recv_tgt("Neighbor Solicitation",
 			  &ip_hdr->src, &ip_hdr->dst, &ns_hdr->tgt, pkt);
 
+	net_ipv6_addr_copy_raw(ns_tgt.s6_addr, ns_hdr->tgt);
+	net_ipv6_addr_copy_raw(ns_src.s6_addr, ip_hdr->src);
+	net_ipv6_addr_copy_raw(ns_dst.s6_addr, ip_hdr->dst);
+
 	net_stats_update_ipv6_nd_recv(net_pkt_iface(pkt));
 
 	if (((length < (sizeof(struct net_ipv6_hdr) +
 			  sizeof(struct net_icmp_hdr) +
 			  sizeof(struct net_icmpv6_ns_hdr))) ||
 	    (ip_hdr->hop_limit != NET_IPV6_ND_HOP_LIMIT)) &&
-	    (net_ipv6_is_addr_mcast((struct in6_addr *)ns_hdr->tgt) &&
+	    (net_ipv6_is_addr_mcast(&ns_tgt) &&
 	     icmp_hdr->code != 0U)) {
 		goto drop;
 	}
@@ -1256,8 +1267,7 @@ static int handle_ns_input(struct net_icmp_ctx *ctx,
 
 		switch (nd_opt_hdr->type) {
 		case NET_ICMPV6_ND_OPT_SLLAO:
-			if (net_ipv6_is_addr_unspecified(
-					(struct in6_addr *)ip_hdr->src)) {
+			if (net_ipv6_is_addr_unspecified(&ns_src)) {
 				goto drop;
 			}
 
@@ -1288,29 +1298,25 @@ static int handle_ns_input(struct net_icmp_ctx *ctx,
 	}
 
 	if (IS_ENABLED(CONFIG_NET_ROUTING)) {
-		ifaddr = net_if_ipv6_addr_lookup((struct in6_addr *)ns_hdr->tgt,
-						 NULL);
+		ifaddr = net_if_ipv6_addr_lookup(&ns_tgt, NULL);
 	} else {
 		ifaddr = net_if_ipv6_addr_lookup_by_iface(
-			    net_pkt_iface(pkt), (struct in6_addr *)ns_hdr->tgt);
+			    net_pkt_iface(pkt), &ns_tgt);
 	}
 
 	if (!ifaddr) {
 		if (IS_ENABLED(CONFIG_NET_ROUTING)) {
 			struct in6_addr *nexthop;
 
-			nexthop = check_route(NULL,
-					      (struct in6_addr *)ns_hdr->tgt,
-					      NULL);
+			nexthop = check_route(NULL, &ns_tgt, NULL);
 			if (nexthop) {
-				ns_routing_info(pkt, nexthop,
-						(struct in6_addr *)ns_hdr->tgt);
-				na_dst = (struct in6_addr *)ip_hdr->dst;
+				ns_routing_info(pkt, nexthop, &ns_tgt);
+				na_dst = &ns_dst;
 				/* Note that the target is not the address of
 				 * the "nethop" as that is a link-local address
 				 * which is not routable.
 				 */
-				tgt = (struct in6_addr *)ns_hdr->tgt;
+				tgt = &ns_tgt;
 
 				/* Source address must be one of our real
 				 * interface address where the packet was
@@ -1318,11 +1324,11 @@ static int handle_ns_input(struct net_icmp_ctx *ctx,
 				 */
 				na_src = net_if_ipv6_select_src_addr(
 						net_pkt_iface(pkt),
-						(struct in6_addr *)ip_hdr->src);
+						&ns_src);
 				if (!na_src) {
 					NET_DBG("DROP: No interface address "
 						"for dst %s iface %p/%d",
-						net_sprint_ipv6_addr(&ip_hdr->src),
+						net_sprint_ipv6_addr(&ns_src),
 						net_pkt_iface(pkt),
 						net_if_get_by_iface(
 							net_pkt_iface(pkt)));
@@ -1335,28 +1341,28 @@ static int handle_ns_input(struct net_icmp_ctx *ctx,
 		}
 
 		NET_DBG("DROP: No such interface address %s",
-			net_sprint_ipv6_addr(&ns_hdr->tgt));
+			net_sprint_ipv6_addr(&ns_tgt));
 		goto silent_drop;
 	} else {
 		tgt = &ifaddr->address.in6_addr;
-		na_src = (struct in6_addr *)ip_hdr->dst;
+		na_src = &ns_dst;
 	}
 
 nexthop_found:
 
 #if !defined(CONFIG_NET_IPV6_DAD)
-	if (net_ipv6_is_addr_unspecified((struct in6_addr *)ip_hdr->src)) {
+	if (net_ipv6_is_addr_unspecified(&ns_src)) {
 		goto drop;
 	}
 
 #else /* CONFIG_NET_IPV6_DAD */
 
 	/* Do DAD */
-	if (net_ipv6_is_addr_unspecified((struct in6_addr *)ip_hdr->src)) {
+	if (net_ipv6_is_addr_unspecified(&ns_src)) {
 
-		if (!net_ipv6_is_addr_solicited_node((struct in6_addr *)ip_hdr->dst)) {
+		if (!net_ipv6_is_addr_solicited_node(&ns_dst)) {
 			NET_DBG("DROP: Not solicited node addr %s",
-				net_sprint_ipv6_addr(&ip_hdr->dst));
+				net_sprint_ipv6_addr(&ns_dst));
 			goto silent_drop;
 		}
 
@@ -1372,30 +1378,28 @@ nexthop_found:
 		}
 
 		/* We reuse the received packet for the NA addresses*/
-		net_ipv6_addr_create_ll_allnodes_mcast(
-					(struct in6_addr *)ip_hdr->dst);
+		net_ipv6_addr_create_ll_allnodes_mcast(&ns_dst);
 		net_ipaddr_copy((struct in6_addr *)ip_hdr->src,
 				net_if_ipv6_select_src_addr(
-					net_pkt_iface(pkt),
-					(struct in6_addr *)ip_hdr->dst));
+					net_pkt_iface(pkt), &ns_dst));
 
-		na_src = (struct in6_addr *)ip_hdr->src;
-		na_dst = (struct in6_addr *)ip_hdr->dst;
+		na_src = &ns_src;
+		na_dst = &ns_dst;
 		flags = NET_ICMPV6_NA_FLAG_OVERRIDE;
 		goto send_na;
 	}
 #endif /* CONFIG_NET_IPV6_DAD */
 
-	if (net_ipv6_is_my_addr((struct in6_addr *)ip_hdr->src)) {
+	if (net_ipv6_is_my_addr(&ns_src)) {
 		NET_DBG("DROP: Duplicate IPv6 %s address",
-			net_sprint_ipv6_addr(&ip_hdr->src));
+			net_sprint_ipv6_addr(&ns_src));
 		goto silent_drop;
 	}
 
 	/* Address resolution */
-	if (net_ipv6_is_addr_solicited_node((struct in6_addr *)ip_hdr->dst)) {
-		na_src = (struct in6_addr *)ns_hdr->tgt;
-		na_dst = (struct in6_addr *)ip_hdr->src;
+	if (net_ipv6_is_addr_solicited_node(&ns_dst)) {
+		na_src = &ns_tgt;
+		na_dst = &ns_src;
 		flags = NET_ICMPV6_NA_FLAG_SOLICITED |
 			NET_ICMPV6_NA_FLAG_OVERRIDE;
 		goto send_na;
@@ -1408,17 +1412,16 @@ nexthop_found:
 
 	/* Neighbor Unreachability Detection (NUD) */
 	if (IS_ENABLED(CONFIG_NET_ROUTING)) {
-		ifaddr = net_if_ipv6_addr_lookup((struct in6_addr *)ip_hdr->dst,
-						 NULL);
+		ifaddr = net_if_ipv6_addr_lookup(&ns_dst, NULL);
 	} else {
 		ifaddr = net_if_ipv6_addr_lookup_by_iface(
 						net_pkt_iface(pkt),
-						(struct in6_addr *)ip_hdr->dst);
+						&ns_dst);
 	}
 
 	if (ifaddr) {
-		na_src = (struct in6_addr *)ns_hdr->tgt;
-		na_dst = (struct in6_addr *)ip_hdr->src;
+		na_src = &ns_tgt;
+		na_dst = &ns_src;
 		tgt = &ifaddr->address.in6_addr;
 		flags = NET_ICMPV6_NA_FLAG_SOLICITED |
 			NET_ICMPV6_NA_FLAG_OVERRIDE;
@@ -1431,8 +1434,7 @@ nexthop_found:
 send_na:
 	if (src_lladdr.len > 0) {
 		if (!net_ipv6_nbr_add(net_pkt_iface(pkt),
-				      (struct in6_addr *)ip_hdr->src,
-				      &src_lladdr, false,
+				      &ns_src, &src_lladdr, false,
 				      NET_IPV6_NBR_STATE_INCOMPLETE)) {
 			goto drop;
 		}
@@ -1635,6 +1637,7 @@ void net_ipv6_nbr_reachability_hint(struct net_if *iface,
 #if defined(CONFIG_NET_IPV6_NBR_CACHE)
 static inline bool handle_na_neighbor(struct net_pkt *pkt,
 				      struct net_icmpv6_na_hdr *na_hdr,
+				      struct in6_addr *na_tgt,
 				      uint16_t tllao_offset)
 {
 	struct net_linkaddr lladdr = { 0 };
@@ -1645,12 +1648,11 @@ static inline bool handle_na_neighbor(struct net_pkt *pkt,
 
 	net_ipv6_nbr_lock();
 
-	nbr = nbr_lookup(&net_neighbor.table, net_pkt_iface(pkt),
-			 (struct in6_addr *)na_hdr->tgt);
+	nbr = nbr_lookup(&net_neighbor.table, net_pkt_iface(pkt), na_tgt);
 
 	NET_DBG("Neighbor lookup %p iface %p/%d addr %s", nbr,
 		net_pkt_iface(pkt), net_if_get_by_iface(net_pkt_iface(pkt)),
-		net_sprint_ipv6_addr(&na_hdr->tgt));
+		net_sprint_ipv6_addr(na_tgt));
 
 	if (!nbr) {
 		nbr_print();
@@ -1687,7 +1689,7 @@ static inline bool handle_na_neighbor(struct net_pkt *pkt,
 
 		NET_DBG("[%d] nbr %p state %d IPv6 %s ll %s",
 			nbr->idx, nbr, net_ipv6_nbr_data(nbr)->state,
-			net_sprint_ipv6_addr(&na_hdr->tgt),
+			net_sprint_ipv6_addr(na_tgt),
 			net_sprint_ll_addr(nbr_lladdr.addr, nbr_lladdr.len));
 	}
 
@@ -1711,8 +1713,7 @@ static inline bool handle_na_neighbor(struct net_pkt *pkt,
 
 		if (lladdr_changed) {
 			dbg_update_neighbor_lladdr_raw(
-				lladdr.addr, cached_lladdr,
-				(struct in6_addr *)na_hdr->tgt);
+				lladdr.addr, cached_lladdr, na_tgt);
 
 			net_linkaddr_set(cached_lladdr, lladdr.addr,
 					 cached_lladdr->len);
@@ -1756,8 +1757,7 @@ static inline bool handle_na_neighbor(struct net_pkt *pkt,
 
 		if (lladdr_changed) {
 			dbg_update_neighbor_lladdr_raw(
-				lladdr.addr, cached_lladdr,
-				(struct in6_addr *)na_hdr->tgt);
+				lladdr.addr, cached_lladdr, na_tgt);
 
 			net_linkaddr_set(cached_lladdr, lladdr.addr,
 					 cached_lladdr->len);
@@ -1829,6 +1829,7 @@ static int handle_na_input(struct net_icmp_ctx *ctx,
 	uint16_t tllao_offset = 0U;
 	struct net_icmpv6_nd_opt_hdr *nd_opt_hdr;
 	struct net_icmpv6_na_hdr *na_hdr;
+	struct in6_addr na_tgt, na_dst;
 	struct net_if_addr *ifaddr;
 
 	if (net_if_flag_is_set(net_pkt_iface(pkt), NET_IF_IPV6_NO_ND)) {
@@ -1846,14 +1847,17 @@ static int handle_na_input(struct net_icmp_ctx *ctx,
 
 	net_stats_update_ipv6_nd_recv(net_pkt_iface(pkt));
 
+	net_ipv6_addr_copy_raw(na_tgt.s6_addr, na_hdr->tgt);
+	net_ipv6_addr_copy_raw(na_dst.s6_addr, ip_hdr->dst);
+
 	if (((length < (sizeof(struct net_ipv6_hdr) +
 			sizeof(struct net_icmp_hdr) +
 			sizeof(struct net_icmpv6_na_hdr) +
 			sizeof(struct net_icmpv6_nd_opt_hdr))) ||
 	     (ip_hdr->hop_limit != NET_IPV6_ND_HOP_LIMIT) ||
-	     net_ipv6_is_addr_mcast((struct in6_addr *)na_hdr->tgt) ||
+	     net_ipv6_is_addr_mcast(&na_tgt) ||
 	     (na_hdr->flags & NET_ICMPV6_NA_FLAG_SOLICITED &&
-	      net_ipv6_is_addr_mcast((struct in6_addr *)ip_hdr->dst))) &&
+	      net_ipv6_is_addr_mcast(&na_dst))) &&
 	    (icmp_hdr->code != 0U)) {
 		goto drop;
 	}
@@ -1899,25 +1903,23 @@ static int handle_na_input(struct net_icmp_ctx *ctx,
 					net_pkt_get_data(pkt, &nd_access);
 	}
 
-	ifaddr = net_if_ipv6_addr_lookup_by_iface(net_pkt_iface(pkt),
-						  (struct in6_addr *)na_hdr->tgt);
+	ifaddr = net_if_ipv6_addr_lookup_by_iface(net_pkt_iface(pkt), &na_tgt);
 	if (ifaddr) {
 		NET_DBG("Interface %p/%d already has address %s",
 			net_pkt_iface(pkt),
 			net_if_get_by_iface(net_pkt_iface(pkt)),
-			net_sprint_ipv6_addr(&na_hdr->tgt));
+			net_sprint_ipv6_addr(&na_tgt));
 
 #if defined(CONFIG_NET_IPV6_DAD)
 		if (ifaddr->addr_state == NET_ADDR_TENTATIVE) {
-			dad_failed(net_pkt_iface(pkt),
-				   (struct in6_addr *)na_hdr->tgt);
+			dad_failed(net_pkt_iface(pkt), &na_tgt);
 		}
 #endif /* CONFIG_NET_IPV6_DAD */
 
 		goto drop;
 	}
 
-	if (!handle_na_neighbor(pkt, na_hdr, tllao_offset)) {
+	if (!handle_na_neighbor(pkt, na_hdr, &na_tgt, tllao_offset)) {
 		/* Update the statistics but silently drop NA msg if the sender
 		 * is not known or if there was an error in the message.
 		 * Returning <0 will cause error message to be printed which
@@ -2155,7 +2157,8 @@ int net_ipv6_start_rs(struct net_if *iface)
 	return net_ipv6_send_rs(iface);
 }
 
-static inline struct net_nbr *handle_ra_neighbor(struct net_pkt *pkt, uint8_t len)
+static inline struct net_nbr *handle_ra_neighbor(struct net_pkt *pkt, uint8_t len,
+						 struct in6_addr *ra_src)
 {
 	struct net_linkaddr lladdr;
 
@@ -2163,8 +2166,7 @@ static inline struct net_nbr *handle_ra_neighbor(struct net_pkt *pkt, uint8_t le
 		return NULL;
 	}
 
-	return net_ipv6_nbr_add(net_pkt_iface(pkt),
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->src,
+	return net_ipv6_nbr_add(net_pkt_iface(pkt), ra_src,
 				&lladdr, true,
 				NET_IPV6_NBR_STATE_STALE);
 }
@@ -2173,9 +2175,11 @@ static inline void handle_prefix_onlink(struct net_pkt *pkt,
 			struct net_icmpv6_nd_opt_prefix_info *prefix_info)
 {
 	struct net_if_ipv6_prefix *prefix;
+	struct in6_addr received_prefix;
 
-	prefix = net_if_ipv6_prefix_lookup(net_pkt_iface(pkt),
-					   (struct in6_addr *)prefix_info->prefix,
+	net_ipv6_addr_copy_raw(received_prefix.s6_addr, prefix_info->prefix);
+
+	prefix = net_if_ipv6_prefix_lookup(net_pkt_iface(pkt), &received_prefix,
 					   prefix_info->prefix_len);
 	if (!prefix) {
 		if (!prefix_info->valid_lifetime) {
@@ -2253,14 +2257,16 @@ static inline void handle_prefix_autonomous(struct net_pkt *pkt,
 			struct net_icmpv6_nd_opt_prefix_info *prefix_info)
 {
 	struct net_if *iface = net_pkt_iface(pkt);
+	struct in6_addr received_prefix;
 	struct in6_addr addr = { };
 	struct net_if_addr *ifaddr;
 	int ret;
 
+	net_ipv6_addr_copy_raw(received_prefix.s6_addr, prefix_info->prefix);
+
 	/* Create IPv6 address using the given prefix and iid.
 	 */
-	ret = net_ipv6_addr_generate_iid(iface,
-			 (struct in6_addr *)prefix_info->prefix,
+	ret = net_ipv6_addr_generate_iid(iface, &received_prefix,
 			 COND_CODE_1(CONFIG_NET_IPV6_IID_STABLE,
 				     ((uint8_t *)&iface->config.ip.ipv6->network_counter),
 				     (NULL)),
@@ -2318,8 +2324,7 @@ static inline void handle_prefix_autonomous(struct net_pkt *pkt,
 	 * too.
 	 */
 	if (IS_ENABLED(CONFIG_NET_IPV6_PE) && iface->pe_enabled) {
-		net_ipv6_pe_start(iface,
-				  (const struct in6_addr *)prefix_info->prefix,
+		net_ipv6_pe_start(iface, &received_prefix,
 				  prefix_info->valid_lifetime,
 				  prefix_info->preferred_lifetime);
 	}
@@ -2344,7 +2349,7 @@ static inline bool handle_ra_prefix(struct net_pkt *pkt)
 	preferred_lifetime = ntohl(pfx_info->preferred_lifetime);
 
 	if (valid_lifetime >= preferred_lifetime &&
-	    !net_ipv6_is_ll_addr((struct in6_addr *)pfx_info->prefix)) {
+	    !net_ipv6_is_ll_addr_raw(pfx_info->prefix)) {
 		if (pfx_info->flags & NET_ICMPV6_RA_FLAG_ONLINK) {
 			handle_prefix_onlink(pkt, pfx_info);
 		}
@@ -2400,7 +2405,8 @@ static inline bool handle_ra_6co(struct net_pkt *pkt, uint8_t len)
 }
 #endif
 
-static inline bool handle_ra_route_info(struct net_pkt *pkt, uint8_t len)
+static inline bool handle_ra_route_info(struct net_pkt *pkt, uint8_t len,
+					struct in6_addr *ra_src)
 {
 	NET_PKT_DATA_ACCESS_DEFINE(routeinfo_access,
 				   struct net_icmpv6_nd_opt_route_info);
@@ -2446,7 +2452,7 @@ static inline bool handle_ra_route_info(struct net_pkt *pkt, uint8_t len)
 		route = net_route_add(net_pkt_orig_iface(pkt),
 				      &prefix_buf,
 				      prefix_len,
-				      (struct in6_addr *)NET_IPV6_HDR(pkt)->src,
+				      ra_src,
 				      route_lifetime,
 				      preference);
 		if (route == NULL) {
@@ -2536,6 +2542,7 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 	struct net_if_router *router;
 	uint32_t mtu, reachable_time, retrans_timer;
 	uint16_t router_lifetime;
+	struct in6_addr ra_src;
 
 	ARG_UNUSED(user_data);
 
@@ -2553,12 +2560,14 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 
 	net_stats_update_ipv6_nd_recv(net_pkt_iface(pkt));
 
+	net_ipv6_addr_copy_raw(ra_src.s6_addr, ip_hdr->src);
+
 	if (((length < (sizeof(struct net_ipv6_hdr) +
 			sizeof(struct net_icmp_hdr) +
 			sizeof(struct net_icmpv6_ra_hdr) +
 			sizeof(struct net_icmpv6_nd_opt_hdr))) ||
 	     (ip_hdr->hop_limit != NET_IPV6_ND_HOP_LIMIT) ||
-	     !net_ipv6_is_ll_addr((struct in6_addr *)ip_hdr->src)) &&
+	     !net_ipv6_is_ll_addr(&ra_src)) &&
 		icmp_hdr->code != 0U) {
 		goto drop;
 	}
@@ -2602,7 +2611,7 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 		switch (nd_opt_hdr->type) {
 		case NET_ICMPV6_ND_OPT_SLLAO:
 			/* Update existing neighbor cache entry with link layer address. */
-			nbr = handle_ra_neighbor(pkt, nd_opt_hdr->len);
+			nbr = handle_ra_neighbor(pkt, nd_opt_hdr->len, &ra_src);
 			if (!nbr) {
 				goto drop;
 			}
@@ -2665,7 +2674,7 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 				goto drop;
 			}
 
-			if (!handle_ra_route_info(pkt, nd_opt_hdr->len)) {
+			if (!handle_ra_route_info(pkt, nd_opt_hdr->len, &ra_src)) {
 				goto drop;
 			}
 
@@ -2700,13 +2709,11 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 		/* Add neighbor cache entry using link local address, regardless
 		 * of link layer address presence in Router Advertisement.
 		 */
-		nbr = net_ipv6_nbr_add(net_pkt_iface(pkt),
-				       (struct in6_addr *)NET_IPV6_HDR(pkt)->src,
+		nbr = net_ipv6_nbr_add(net_pkt_iface(pkt), &ra_src,
 				       NULL, true, NET_IPV6_NBR_STATE_INCOMPLETE);
 	}
 
-	router = net_if_ipv6_router_lookup(net_pkt_iface(pkt),
-					   (struct in6_addr *)ip_hdr->src);
+	router = net_if_ipv6_router_lookup(net_pkt_iface(pkt), &ra_src);
 	if (router) {
 		if (!router_lifetime) {
 			/* TODO: Start rs_timer on iface if no routers
@@ -2722,8 +2729,7 @@ static int handle_ra_input(struct net_icmp_ctx *ctx,
 					router, router_lifetime);
 		}
 	} else {
-		net_if_ipv6_router_add(net_pkt_iface(pkt),
-				       (struct in6_addr *)ip_hdr->src,
+		net_if_ipv6_router_add(net_pkt_iface(pkt), &ra_src,
 				       router_lifetime);
 	}
 

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -230,8 +230,8 @@ static inline int check_ip(struct net_pkt *pkt)
 			return 0;
 		}
 #endif
-		if (net_ipv6_addr_cmp((struct in6_addr *)NET_IPV6_HDR(pkt)->dst,
-				      net_ipv6_unspecified_address())) {
+		if (net_ipv6_addr_cmp_raw(NET_IPV6_HDR(pkt)->dst,
+					  (const uint8_t *)net_ipv6_unspecified_address())) {
 			NET_DBG("DROP: IPv6 dst address missing");
 			ret = -EADDRNOTAVAIL;
 			goto drop;
@@ -240,10 +240,8 @@ static inline int check_ip(struct net_pkt *pkt)
 		/* If the destination address is our own, then route it
 		 * back to us (if it is not already forwarded).
 		 */
-		if ((net_ipv6_is_addr_loopback(
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst) ||
-		    net_ipv6_is_my_addr(
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst)) &&
+		if ((net_ipv6_is_addr_loopback_raw(NET_IPV6_HDR(pkt)->dst) ||
+		    net_ipv6_is_my_addr_raw(NET_IPV6_HDR(pkt)->dst)) &&
 		    !net_pkt_forwarding(pkt)) {
 			struct in6_addr addr;
 
@@ -267,8 +265,7 @@ static inline int check_ip(struct net_pkt *pkt)
 		 * in local host, so this is similar as how ::1 unicast
 		 * addresses are handled. See RFC 3513 ch 2.7 for details.
 		 */
-		if (net_ipv6_is_addr_mcast_iface(
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst)) {
+		if (net_ipv6_is_addr_mcast_iface_raw(NET_IPV6_HDR(pkt)->dst)) {
 			NET_DBG("IPv6 interface scope mcast dst address");
 			return 1;
 		}
@@ -276,8 +273,7 @@ static inline int check_ip(struct net_pkt *pkt)
 		/* The source check must be done after the destination check
 		 * as having src ::1 is perfectly ok if dst is ::1 too.
 		 */
-		if (net_ipv6_is_addr_loopback(
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->src)) {
+		if (net_ipv6_is_addr_loopback_raw(NET_IPV6_HDR(pkt)->src)) {
 			NET_DBG("DROP: IPv6 loopback src address");
 			ret = -EADDRNOTAVAIL;
 			goto drop;
@@ -378,9 +374,8 @@ static inline bool process_multicast(struct net_pkt *pkt)
 #endif
 #if defined(CONFIG_NET_IPV6)
 	if (family == AF_INET6) {
-		const struct in6_addr *dst = (const struct in6_addr *)&NET_IPV6_HDR(pkt)->dst;
-
-		return net_ipv6_is_addr_mcast(dst) && net_context_get_ipv6_mcast_loop(ctx);
+		return net_ipv6_is_addr_mcast_raw(NET_IPV6_HDR(pkt)->dst) &&
+		       net_context_get_ipv6_mcast_loop(ctx);
 	}
 #endif
 	return false;

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -300,8 +300,8 @@ static inline int check_ip(struct net_pkt *pkt)
 			return 0;
 		}
 #endif
-		if (net_ipv4_addr_cmp((struct in_addr *)NET_IPV4_HDR(pkt)->dst,
-				      net_ipv4_unspecified_address())) {
+		if (net_ipv4_addr_cmp_raw(NET_IPV4_HDR(pkt)->dst,
+					  net_ipv4_unspecified_address()->s4_addr)) {
 			NET_DBG("DROP: IPv4 dst address missing");
 			ret = -EADDRNOTAVAIL;
 			goto drop;
@@ -310,10 +310,10 @@ static inline int check_ip(struct net_pkt *pkt)
 		/* If the destination address is our own, then route it
 		 * back to us.
 		 */
-		if (net_ipv4_is_addr_loopback((struct in_addr *)NET_IPV4_HDR(pkt)->dst) ||
-		    (net_ipv4_is_addr_bcast(net_pkt_iface(pkt),
-				     (struct in_addr *)NET_IPV4_HDR(pkt)->dst) == false &&
-		     net_ipv4_is_my_addr((struct in_addr *)NET_IPV4_HDR(pkt)->dst))) {
+		if (net_ipv4_is_addr_loopback_raw(NET_IPV4_HDR(pkt)->dst) ||
+		    (net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt),
+						NET_IPV4_HDR(pkt)->dst) == false &&
+		     net_ipv4_is_my_addr_raw(NET_IPV4_HDR(pkt)->dst))) {
 			struct in_addr addr;
 
 			/* Swap the addresses so that in receiving side
@@ -334,7 +334,7 @@ static inline int check_ip(struct net_pkt *pkt)
 		 * as having src 127.0.0.0/8 is perfectly ok if dst is in
 		 * localhost subnet too.
 		 */
-		if (net_ipv4_is_addr_loopback((struct in_addr *)NET_IPV4_HDR(pkt)->src)) {
+		if (net_ipv4_is_addr_loopback_raw(NET_IPV4_HDR(pkt)->src)) {
 			NET_DBG("DROP: IPv4 loopback src address");
 			ret = -EADDRNOTAVAIL;
 			goto drop;

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -893,7 +893,7 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 
 			NET_DBG("interface %p router %s lifetime %u default %d "
 				"added", iface,
-				net_sprint_ipv6_addr((struct in6_addr *)addr),
+				net_sprint_ipv6_addr(addr),
 				lifetime, routers[i].is_default);
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
 			memcpy(net_if_router_ipv4(&routers[i]), addr,

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -1824,8 +1824,8 @@ static void address_start_timer(struct net_if_addr *ifaddr, uint32_t vlifetime)
 #define join_mcast_nodes(...)
 #endif /* CONFIG_NET_NATIVE_IPV6 */
 
-struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
-					    struct net_if **ret)
+struct net_if_addr *net_if_ipv6_addr_lookup_raw(const uint8_t *addr,
+						struct net_if **ret)
 {
 	struct net_if_addr *ifaddr = NULL;
 
@@ -1847,7 +1847,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
 			}
 
 			if (net_ipv6_is_prefix(
-				    addr->s6_addr,
+				    addr,
 				    ipv6->unicast[i].address.in6_addr.s6_addr,
 				    128)) {
 
@@ -1868,8 +1868,14 @@ out:
 	return ifaddr;
 }
 
-struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
-						     struct in6_addr *addr)
+struct net_if_addr *net_if_ipv6_addr_lookup(const struct in6_addr *addr,
+					    struct net_if **ret)
+{
+	return net_if_ipv6_addr_lookup_raw(addr->s6_addr, ret);
+}
+
+struct net_if_addr *net_if_ipv6_addr_lookup_by_iface_raw(struct net_if *iface,
+							 const uint8_t *addr)
 {
 	struct net_if_addr *ifaddr = NULL;
 	struct net_if_ipv6 *ipv6;
@@ -1888,7 +1894,7 @@ struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
 		}
 
 		if (net_ipv6_is_prefix(
-			    addr->s6_addr,
+			    addr,
 			    ipv6->unicast[i].address.in6_addr.s6_addr,
 			    128)) {
 			ifaddr = &ipv6->unicast[i];
@@ -1900,6 +1906,12 @@ out:
 	net_if_unlock(iface);
 
 	return ifaddr;
+}
+
+struct net_if_addr *net_if_ipv6_addr_lookup_by_iface(struct net_if *iface,
+						     struct in6_addr *addr)
+{
+	return net_if_ipv6_addr_lookup_by_iface_raw(iface, addr->s6_addr);
 }
 
 int z_impl_net_if_ipv6_addr_lookup_by_index(const struct in6_addr *addr)
@@ -2349,8 +2361,8 @@ out:
 	net_if_unlock(iface);
 }
 
-struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
-						   struct net_if **ret)
+struct net_if_mcast_addr *net_if_ipv6_maddr_lookup_raw(const uint8_t *maddr,
+						       struct net_if **ret)
 {
 	struct net_if_mcast_addr *ifmaddr = NULL;
 
@@ -2376,7 +2388,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
 			}
 
 			if (net_ipv6_is_prefix(
-				    maddr->s6_addr,
+				    maddr,
 				    ipv6->mcast[i].address.in6_addr.s6_addr,
 				    128)) {
 				if (ret) {
@@ -2394,6 +2406,12 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
 
 out:
 	return ifmaddr;
+}
+
+struct net_if_mcast_addr *net_if_ipv6_maddr_lookup(const struct in6_addr *maddr,
+						   struct net_if **ret)
+{
+	return net_if_ipv6_maddr_lookup_raw(maddr->s6_addr, ret);
 }
 
 void net_if_ipv6_maddr_leave(struct net_if *iface, struct net_if_mcast_addr *addr)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -3658,7 +3658,7 @@ out:
 }
 
 static bool ipv4_is_broadcast_address(struct net_if *iface,
-				      const struct in_addr *addr)
+				      const uint8_t *addr)
 {
 	struct net_if_ipv4 *ipv4;
 	bool ret = false;
@@ -3681,7 +3681,7 @@ static bool ipv4_is_broadcast_address(struct net_if *iface,
 		bcast.s_addr = ipv4->unicast[i].ipv4.address.in_addr.s_addr |
 			       ~ipv4->unicast[i].netmask.s_addr;
 
-		if (bcast.s_addr == UNALIGNED_GET(&addr->s_addr)) {
+		if (bcast.s_addr == UNALIGNED_GET((uint32_t *)addr)) {
 			ret = true;
 			goto out;
 		}
@@ -3692,8 +3692,8 @@ out:
 	return ret;
 }
 
-bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
-			       const struct in_addr *addr)
+bool net_if_ipv4_is_addr_bcast_raw(struct net_if *iface,
+				   const uint8_t *addr)
 {
 	bool ret = false;
 
@@ -3711,6 +3711,12 @@ bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
 
 out:
 	return ret;
+}
+
+bool net_if_ipv4_is_addr_bcast(struct net_if *iface,
+			       const struct in_addr *addr)
+{
+	return net_if_ipv4_is_addr_bcast_raw(iface, addr->s4_addr);
 }
 
 struct net_if *net_if_ipv4_select_src_iface_addr(const struct in_addr *dst,
@@ -3987,8 +3993,8 @@ out:
 	return ifaddr;
 }
 
-struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
-					    struct net_if **ret)
+struct net_if_addr *net_if_ipv4_addr_lookup_raw(const uint8_t *addr,
+						struct net_if **ret)
 {
 	struct net_if_addr *ifaddr = NULL;
 
@@ -4009,7 +4015,7 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 				continue;
 			}
 
-			if (UNALIGNED_GET(&addr->s4_addr32[0]) ==
+			if (UNALIGNED_GET((uint32_t *)addr) ==
 			    ipv4->unicast[i].ipv4.address.in_addr.s_addr) {
 
 				if (ret) {
@@ -4027,6 +4033,12 @@ struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
 
 out:
 	return ifaddr;
+}
+
+struct net_if_addr *net_if_ipv4_addr_lookup(const struct in_addr *addr,
+					    struct net_if **ret)
+{
+	return net_if_ipv4_addr_lookup_raw(addr->s4_addr, ret);
 }
 
 int z_impl_net_if_ipv4_addr_lookup_by_index(const struct in_addr *addr)

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1943,7 +1943,8 @@ int net_pkt_read_be32(struct net_pkt *pkt, uint32_t *data)
 
 	ret = net_pkt_read(pkt, d32, sizeof(uint32_t));
 
-	*data = d32[0] << 24 | d32[1] << 16 | d32[2] << 8 | d32[3];
+	*data = (uint32_t)d32[0] << 24 | (uint32_t)d32[1] << 16 |
+		(uint32_t)d32[2] << 8 | (uint32_t)d32[3];
 
 	return ret;
 }

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1360,10 +1360,8 @@ static bool is_destination_local(struct net_pkt *pkt)
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == AF_INET6) {
-		if (net_ipv6_is_addr_loopback(
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst) ||
-		    net_ipv6_is_my_addr(
-				(struct in6_addr *)NET_IPV6_HDR(pkt)->dst)) {
+		if (net_ipv6_is_addr_loopback_raw(NET_IPV6_HDR(pkt)->dst) ||
+		    net_ipv6_is_my_addr_raw(NET_IPV6_HDR(pkt)->dst)) {
 			return true;
 		}
 	}
@@ -1396,9 +1394,12 @@ void net_tcp_reply_rst(struct net_pkt *pkt)
 				      (struct in_addr *)NET_IPV4_HDR(pkt)->dst,
 				      (struct in_addr *)NET_IPV4_HDR(pkt)->src);
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == AF_INET6) {
-		ret =  net_ipv6_create(rst,
-				      (struct in6_addr *)NET_IPV6_HDR(pkt)->dst,
-				      (struct in6_addr *)NET_IPV6_HDR(pkt)->src);
+		struct in6_addr src, dst;
+
+		net_ipv6_addr_copy_raw(src.s6_addr, NET_IPV6_HDR(pkt)->src);
+		net_ipv6_addr_copy_raw(dst.s6_addr, NET_IPV6_HDR(pkt)->dst);
+
+		ret =  net_ipv6_create(rst, &dst, &src);
 	} else {
 		ret = -EINVAL;
 	}
@@ -2941,7 +2942,7 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 				break;
 			}
 
-			net_ipaddr_copy(&conn->context->remote, &conn->dst.sa);
+			memcpy(&conn->context->remote, &conn->dst.sa, sizeof(conn->dst.sa));
 
 			/* Check if v4-mapping-to-v6 needs to be done for
 			 * the accepted socket.

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -229,7 +229,7 @@ static void arp_request_timeout(struct k_work *work)
 }
 
 static inline struct in_addr *if_get_addr(struct net_if *iface,
-					  struct in_addr *addr)
+					  const uint8_t *addr)
 {
 	struct net_if_ipv4 *ipv4 = iface->config.ip.ipv4;
 
@@ -242,8 +242,8 @@ static inline struct in_addr *if_get_addr(struct net_if *iface,
 		    ipv4->unicast[i].ipv4.address.family == AF_INET &&
 		    ipv4->unicast[i].ipv4.addr_state == NET_ADDR_PREFERRED &&
 		    (!addr ||
-		     net_ipv4_addr_cmp(addr,
-				       &ipv4->unicast[i].ipv4.address.in_addr))) {
+		     net_ipv4_addr_cmp_raw(
+				addr, ipv4->unicast[i].ipv4.address.in_addr.s4_addr))) {
 			return &ipv4->unicast[i].ipv4.address.in_addr;
 		}
 	}
@@ -339,7 +339,7 @@ static inline struct net_pkt *arp_prepare(struct net_if *iface,
 	} else if (!entry) {
 		my_addr = (struct in_addr *)NET_IPV4_HDR(pending)->src;
 	} else {
-		my_addr = if_get_addr(entry->iface, current_ip);
+		my_addr = if_get_addr(entry->iface, (const uint8_t *)current_ip);
 	}
 
 	if (my_addr) {
@@ -372,10 +372,8 @@ int net_arp_prepare(struct net_pkt *pkt,
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4_AUTO)) {
-		is_ipv4_ll_used = net_ipv4_is_ll_addr((struct in_addr *)
-						&NET_IPV4_HDR(pkt)->src) ||
-				  net_ipv4_is_ll_addr((struct in_addr *)
-						&NET_IPV4_HDR(pkt)->dst);
+		is_ipv4_ll_used = net_ipv4_is_ll_addr_raw(NET_IPV4_HDR(pkt)->src) ||
+				  net_ipv4_is_ll_addr_raw(NET_IPV4_HDR(pkt)->dst);
 	}
 
 	/* Is the destination in the local network, if not route via
@@ -785,7 +783,7 @@ static bool arp_hdr_check(struct net_arp_hdr *arp_hdr)
 	    ntohs(arp_hdr->protocol) != NET_ETH_PTYPE_IP ||
 	    arp_hdr->hwlen != sizeof(struct net_eth_addr) ||
 	    arp_hdr->protolen != NET_ARP_IPV4_PTYPE_SIZE ||
-	    net_ipv4_is_addr_loopback((struct in_addr *)arp_hdr->src_ipaddr)) {
+	    net_ipv4_is_addr_loopback_raw(arp_hdr->src_ipaddr)) {
 		NET_DBG("DROP: Invalid ARP header");
 		return false;
 	}
@@ -799,6 +797,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 {
 	struct net_eth_addr *dst_hw_addr;
 	struct net_arp_hdr *arp_hdr;
+	struct in_addr src_ipaddr;
 	struct net_pkt *reply;
 	struct in_addr *addr;
 
@@ -833,8 +832,9 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 				/* If the IP address is in our cache,
 				 * then update it here.
 				 */
-				net_arp_update(net_pkt_iface(pkt),
-					       (struct in_addr *)arp_hdr->src_ipaddr,
+				net_ipv4_addr_copy_raw(src_ipaddr.s4_addr,
+						       arp_hdr->src_ipaddr);
+				net_arp_update(net_pkt_iface(pkt), &src_ipaddr,
 					       &arp_hdr->src_hwaddr,
 					       true, false);
 				break;
@@ -846,14 +846,13 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 		 */
 		if (memcmp(dst, net_eth_broadcast_addr(),
 			   sizeof(struct net_eth_addr)) == 0 &&
-		    net_ipv4_is_addr_mcast((struct in_addr *)arp_hdr->src_ipaddr)) {
+		    net_ipv4_is_addr_mcast_raw(arp_hdr->src_ipaddr)) {
 			NET_DBG("DROP: eth addr is bcast, src addr is mcast");
 			return NET_DROP;
 		}
 
 		/* Someone wants to know our ll address */
-		addr = if_get_addr(net_pkt_iface(pkt),
-				   (struct in_addr *)arp_hdr->dst_ipaddr);
+		addr = if_get_addr(net_pkt_iface(pkt), arp_hdr->dst_ipaddr);
 		if (!addr) {
 			/* Not for us so drop the packet silently */
 			return NET_DROP;
@@ -876,8 +875,9 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 						   arp_hdr->hwlen),
 				net_if_get_by_iface(net_pkt_iface(pkt)));
 
-			net_arp_update(net_pkt_iface(pkt),
-				       (struct in_addr *)arp_hdr->src_ipaddr,
+			net_ipv4_addr_copy_raw(src_ipaddr.s4_addr,
+					       arp_hdr->src_ipaddr);
+			net_arp_update(net_pkt_iface(pkt), &src_ipaddr,
 				       &arp_hdr->src_hwaddr,
 				       false, true);
 
@@ -896,13 +896,15 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 		break;
 
 	case NET_ARP_REPLY:
-		if (net_ipv4_is_my_addr((struct in_addr *)arp_hdr->dst_ipaddr)) {
+		if (net_ipv4_is_my_addr_raw(arp_hdr->dst_ipaddr)) {
 			NET_DBG("Received ll %s for IP %s",
 				net_sprint_ll_addr(arp_hdr->src_hwaddr.addr,
 						   sizeof(struct net_eth_addr)),
 				net_sprint_ipv4_addr(arp_hdr->src_ipaddr));
-			net_arp_update(net_pkt_iface(pkt),
-				       (struct in_addr *)arp_hdr->src_ipaddr,
+
+			net_ipv4_addr_copy_raw(src_ipaddr.s4_addr,
+					       arp_hdr->src_ipaddr);
+			net_arp_update(net_pkt_iface(pkt), &src_ipaddr,
 				       &arp_hdr->src_hwaddr,
 				       false, false);
 		}

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -524,7 +524,7 @@ static bool ethernet_fill_in_dst_on_ipv6_mcast(struct net_pkt *pkt,
 					       struct net_eth_addr *dst)
 {
 	if (net_pkt_family(pkt) == AF_INET6 &&
-	    net_ipv6_is_addr_mcast((struct in6_addr *)NET_IPV6_HDR(pkt)->dst)) {
+	    net_ipv6_is_addr_mcast_raw(NET_IPV6_HDR(pkt)->dst)) {
 		memcpy(dst, (uint8_t *)multicast_eth_addr.addr,
 		       sizeof(struct net_eth_addr) - 4);
 		memcpy((uint8_t *)dst + 2,

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -194,9 +194,9 @@ enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt,
 	}
 
 	if (net_eth_is_addr_broadcast(&hdr->dst) &&
-	    !(net_ipv4_is_addr_mcast((struct in_addr *)NET_IPV4_HDR(pkt)->dst) ||
-	      net_ipv4_is_addr_bcast(net_pkt_iface(pkt),
-				     (struct in_addr *)NET_IPV4_HDR(pkt)->dst))) {
+	    !(net_ipv4_is_addr_mcast_raw(NET_IPV4_HDR(pkt)->dst) ||
+	      net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt),
+					 NET_IPV4_HDR(pkt)->dst))) {
 		return NET_DROP;
 	}
 
@@ -465,9 +465,9 @@ ETH_NET_L3_REGISTER(IPv6, NET_ETH_PTYPE_IPV6, ethernet_ip_recv);
 #if defined(CONFIG_NET_IPV4)
 static inline bool ethernet_ipv4_dst_is_broadcast_or_mcast(struct net_pkt *pkt)
 {
-	if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt),
-				   (struct in_addr *)NET_IPV4_HDR(pkt)->dst) ||
-	    net_ipv4_is_addr_mcast((struct in_addr *)NET_IPV4_HDR(pkt)->dst)) {
+	if (net_ipv4_is_addr_bcast_raw(net_pkt_iface(pkt),
+				       NET_IPV4_HDR(pkt)->dst) ||
+	    net_ipv4_is_addr_mcast_raw(NET_IPV4_HDR(pkt)->dst)) {
 		return true;
 	}
 
@@ -478,7 +478,7 @@ static bool ethernet_fill_in_dst_on_ipv4_mcast(struct net_pkt *pkt,
 					       struct net_eth_addr *dst)
 {
 	if (net_pkt_family(pkt) == AF_INET &&
-	    net_ipv4_is_addr_mcast((struct in_addr *)NET_IPV4_HDR(pkt)->dst)) {
+	    net_ipv4_is_addr_mcast_raw(NET_IPV4_HDR(pkt)->dst)) {
 		/* Multicast address */
 		net_eth_ipv4_mcast_to_mac_addr(
 			(struct in_addr *)NET_IPV4_HDR(pkt)->dst, dst);

--- a/subsys/net/l2/ieee802154/ieee802154.c
+++ b/subsys/net/l2/ieee802154/ieee802154.c
@@ -293,7 +293,7 @@ static inline void swap_and_set_pkt_ll_addr(struct net_linkaddr *addr, bool has_
  */
 static bool ieee802154_check_dst_addr(struct net_if *iface, struct ieee802154_mhr *mhr)
 {
-	struct ieee802154_address_field_plain *dst_plain = &mhr->dst_addr->plain;
+	struct ieee802154_address_field_plain *dst_plain;
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	bool ret = false;
 
@@ -312,6 +312,8 @@ static bool ieee802154_check_dst_addr(struct net_if *iface, struct ieee802154_mh
 		/* also, macImplicitBroadcast is not implemented */
 		return false;
 	}
+
+	dst_plain = &mhr->dst_addr->plain;
 
 	k_sem_take(&ctx->ctx_lock, K_FOREVER);
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1951,7 +1951,7 @@ void coap_observer_init(struct coap_observer *observer,
 {
 	observer->tkl = coap_header_get_token(request, observer->token);
 
-	net_ipaddr_copy(&observer->addr, addr);
+	memcpy(&observer->addr, addr, sizeof(*addr));
 }
 
 static inline void coap_observer_raise_event(struct coap_resource *resource,

--- a/subsys/net/lib/sockets/socket_dispatcher.c
+++ b/subsys/net/lib/sockets/socket_dispatcher.c
@@ -393,8 +393,10 @@ static int sock_dispatch_setsockopt_vmeth(void *obj, int level, int optname,
 	return zsock_setsockopt(fd, level, optname, optval, optlen);
 }
 
-static int sock_dispatch_close_vmeth(void *obj)
+static int sock_dispatch_close_vmeth(void *obj, int fd)
 {
+	ARG_UNUSED(fd);
+
 	dispatcher_ctx_free(obj);
 
 	return 0;
@@ -428,7 +430,7 @@ static const struct socket_op_vtable sock_dispatch_fd_op_vtable = {
 	.fd_vtable = {
 		.read = sock_dispatch_read_vmeth,
 		.write = sock_dispatch_write_vmeth,
-		.close = sock_dispatch_close_vmeth,
+		.close2 = sock_dispatch_close_vmeth,
 		.ioctl = sock_dispatch_ioctl_vmeth,
 	},
 	.shutdown = sock_dispatch_shutdown_vmeth,

--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -1161,10 +1161,12 @@ static int spair_setsockopt(void *obj, int level, int optname,
 	return -1;
 }
 
-static int spair_close(void *obj)
+static int spair_close(void *obj, int fd)
 {
 	struct spair *const spair = (struct spair *)obj;
 	int res;
+
+	ARG_UNUSED(fd);
 
 	res = k_sem_take(&spair->sem, K_FOREVER);
 	__ASSERT(res == 0, "failed to take local sem: %d", res);
@@ -1181,7 +1183,7 @@ static const struct socket_op_vtable spair_fd_op_vtable = {
 	.fd_vtable = {
 		.read = spair_read,
 		.write = spair_write,
-		.close = spair_close,
+		.close2 = spair_close,
 		.ioctl = spair_ioctl,
 	},
 	.bind = spair_bind,

--- a/subsys/net/lib/websocket/websocket.c
+++ b/subsys/net/lib/websocket/websocket.c
@@ -842,7 +842,8 @@ static int websocket_parse(struct websocket_context *ctx, struct websocket_buffe
 				break;
 			case WEBSOCKET_PARSER_STATE_MASK:
 				ctx->parser_remaining--;
-				ctx->masking_value |= (data << (ctx->parser_remaining * 8));
+				ctx->masking_value |=
+					(uint32_t)((uint64_t)data << (ctx->parser_remaining * 8));
 				if (ctx->parser_remaining == 0) {
 					if (ctx->message_len == 0) {
 						ctx->parser_remaining = 0;

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -78,20 +78,24 @@ struct net_if_test {
 	struct net_linkaddr ll_addr;
 };
 
+static void test_create_mac(uint8_t *mac_buf)
+{
+	if (mac_buf[2] == 0x00) {
+		/* 00-00-5E-00-53-xx Documentation RFC 7042 */
+		mac_buf[0] = 0x00;
+		mac_buf[1] = 0x00;
+		mac_buf[2] = 0x5E;
+		mac_buf[3] = 0x00;
+		mac_buf[4] = 0x53;
+		mac_buf[5] = sys_rand8_get();
+	}
+}
+
 static uint8_t *net_iface_get_mac(const struct device *dev)
 {
 	struct net_if_test *data = dev->data;
 
-	if (data->mac_addr[2] == 0x00) {
-		/* 00-00-5E-00-53-xx Documentation RFC 7042 */
-		data->mac_addr[0] = 0x00;
-		data->mac_addr[1] = 0x00;
-		data->mac_addr[2] = 0x5E;
-		data->mac_addr[3] = 0x00;
-		data->mac_addr[4] = 0x53;
-		data->mac_addr[5] = sys_rand8_get();
-	}
-
+	test_create_mac(data->mac_addr);
 	memcpy(data->ll_addr.addr, data->mac_addr, sizeof(data->mac_addr));
 	data->ll_addr.len = 6U;
 
@@ -207,6 +211,7 @@ static void eth_fake_iface_init(struct net_if *iface)
 
 	ctx->iface = iface;
 
+	test_create_mac(ctx->mac_address);
 	net_if_set_link_addr(iface, ctx->mac_address,
 			     sizeof(ctx->mac_address),
 			     NET_LINK_ETHERNET);
@@ -1363,8 +1368,6 @@ static void generate_iid(struct net_if *iface,
 	struct net_linkaddr *lladdr = net_if_get_link_addr(iface);
 	uint8_t *mac;
 	int ret;
-
-	(void)net_iface_get_mac(net_if_get_device(iface));
 
 	lladdr = net_if_get_link_addr(eth_iface);
 	mac = lladdr->addr;

--- a/tests/net/socket/offload_dispatcher/src/main.c
+++ b/tests/net/socket/offload_dispatcher/src/main.c
@@ -61,9 +61,11 @@ static ssize_t offload_write(void *obj, const void *buffer, size_t count)
 	return 0;
 }
 
-static int offload_close(void *obj)
+static int offload_close(void *obj, int fd)
 {
 	struct test_socket_calls *ctx = obj;
+
+	ARG_UNUSED(fd);
 
 	ctx->close_called = true;
 
@@ -252,7 +254,7 @@ static const struct socket_op_vtable offload_1_socket_fd_op_vtable = {
 	.fd_vtable = {
 		.read = offload_read,
 		.write = offload_write,
-		.close = offload_close,
+		.close2 = offload_close,
 		.ioctl = offload_ioctl,
 	},
 	.shutdown = offload_shutdown,
@@ -314,7 +316,7 @@ static const struct socket_op_vtable offload_2_socket_fd_op_vtable = {
 	.fd_vtable = {
 		.read = offload_read,
 		.write = offload_write,
-		.close = offload_close,
+		.close2 = offload_close,
 		.ioctl = offload_ioctl,
 	},
 	.shutdown = offload_shutdown,

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1495,7 +1495,9 @@ static void comm_sendmsg_recvmsg(int client_sock,
 	io_vector[0].iov_len = sizeof(buf);
 
 	memset(msg, 0, sizeof(*msg));
-	memset(cmsgbuf, 0, cmsgbuf_len);
+	if (cmsgbuf != NULL) {
+		memset(cmsgbuf, 0, cmsgbuf_len);
+	}
 	msg->msg_control = cmsgbuf;
 	msg->msg_controllen = cmsgbuf_len;
 	msg->msg_iov = io_vector;
@@ -1572,7 +1574,9 @@ static void comm_sendmsg_recvmsg(int client_sock,
 	io_vector[1].iov_len = sizeof(buf);
 
 	memset(msg, 0, sizeof(*msg));
-	memset(cmsgbuf, 0, cmsgbuf_len);
+	if (cmsgbuf != NULL) {
+		memset(cmsgbuf, 0, cmsgbuf_len);
+	}
 	msg->msg_control = cmsgbuf;
 	msg->msg_controllen = cmsgbuf_len;
 	msg->msg_iov = io_vector;
@@ -1642,7 +1646,9 @@ static void comm_sendmsg_recvmsg(int client_sock,
 	io_vector[0].iov_len = sizeof(buf2);
 
 	memset(msg, 0, sizeof(*msg));
-	memset(cmsgbuf, 0, cmsgbuf_len);
+	if (cmsgbuf != NULL) {
+		memset(cmsgbuf, 0, cmsgbuf_len);
+	}
 	msg->msg_control = cmsgbuf;
 	msg->msg_controllen = cmsgbuf_len;
 	msg->msg_iov = io_vector;


### PR DESCRIPTION
Fix issues reported by UBSAN.  For details, please refer to individual commit messages.

This PR combined with https://github.com/zephyrproject-rtos/zephyr/pull/92317, https://github.com/zephyrproject-rtos/zephyr/pull/92304 and https://github.com/zephyrproject-rtos/zephyr/pull/92341 gave me an almost clear run over `tests/net` with UBSAN enabled (using gcc). Just two tests failed due to an issue apparently unrealted to the networking code:

> lib/os/cbprintf_complete.c:1678:36: runtime error: negation of -9223372036854775808 cannot be represented in type 'long long int'; cast to an unsigned type to negae this value to itself