### PR TITLE
STM32L0: fix PLL input frequency division by HSI clock divider

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -456,7 +456,11 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 #endif
 #if defined(STM32_SRC_HSI)
 	case STM32_SRC_HSI:
+#if defined(CONFIG_SOC_SERIES_STM32L0X)
+		*rate = STM32_HSI_FREQ / STM32_HSI_DIVISOR;
+#else
 		*rate = STM32_HSI_FREQ;
+#endif
 		break;
 #endif
 #if defined(STM32_SRC_MSI)
@@ -662,7 +666,15 @@ static void set_up_fixed_clock_sources(void)
 			}
 		}
 #if STM32_HSI_DIV_ENABLED
+#if defined(CONFIG_SOC_SERIES_STM32L0X)
+		if (STM32_HSI_DIVISOR == 4) {
+			LL_RCC_HSI_EnableDivider();
+		} else {
+			LL_RCC_HSI_DisableDivider();
+		}
+#else
 		LL_RCC_SetHSIDiv(hsi_divider(STM32_HSI_DIVISOR));
+#endif
 #endif
 	}
 

--- a/drivers/clock_control/clock_stm32l0_l1.c
+++ b/drivers/clock_control/clock_stm32l0_l1.c
@@ -49,7 +49,11 @@ __unused
 uint32_t get_pllsrc_frequency(void)
 {
 	if (IS_ENABLED(STM32_PLL_SRC_HSI)) {
+#if defined(CONFIG_SOC_SERIES_STM32L0X)
+		return STM32_HSI_FREQ / STM32_HSI_DIVISOR;
+#else
 		return STM32_HSI_FREQ;
+#endif
 	} else if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
 		return STM32_HSE_FREQ;
 	}

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -56,8 +56,9 @@
 
 		clk_hsi: clk-hsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32l0-hsi-clock";
 			clock-frequency = <DT_FREQ_M(16)>;
+			hsi-div = <1>;
 			status = "disabled";
 		};
 

--- a/dts/bindings/clock/st,stm32l0-hsi-clock.yaml
+++ b/dts/bindings/clock/st,stm32l0-hsi-clock.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: STM32L0 HSI Clock
+
+compatible: "st,stm32l0-hsi-clock"
+
+include: [fixed-clock.yaml]
+
+properties:
+  hsi-div:
+    type: int
+    required: true
+    description: |
+      HSI clock divider. Configures the output HSI clock frequency.
+      In that case, the HSI clock can be divided as follows:
+      hsi clk = 16MHz / hsi-div
+    enum:
+      - 1
+      - 4

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -485,6 +485,7 @@
 #define STM32_HSI_ENABLED	1
 #define STM32_HSI_FREQ		DT_PROP(DT_NODELABEL(clk_hsi), clock_frequency)
 #elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32h7_hsi_clock, okay) \
+	|| DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32l0_hsi_clock, okay) \
 	|| DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32g0_hsi_clock, okay) \
 	|| DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32c0_hsi_clock, okay) \
 	|| DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32n6_hsi_clock, okay)


### PR DESCRIPTION
In the STM32L0 clock driver the HSI clock divider is not considered when calculating the PLL source frequency (register value RCC_CR/HSIDIV).
Add new clocks bindings for stm32l0 series "st,stm32l0-hsi-clock" to use hsi-div property.
Updated the clk_hsi node to use the "st,stm32l0-hsi-clock" compatible to enable support for the HSI clock divider (hsi-div property).