### PR TITLE
tests: arch: arc: arc_vpx_lock: remove unused variable

### DIFF
--- a/tests/arch/arc/arc_vpx_lock/src/main.c
+++ b/tests/arch/arc/arc_vpx_lock/src/main.c
@@ -49,7 +49,6 @@ static void arc_vpx_lock_unlock_timed_payload(void *p1, void *p2, void *p3)
 {
 	int status;
 	unsigned int cpu_id;
-	unsigned int lock_id;
 
 	cpu_id = (unsigned int)(uintptr_t)(p1);
 	ARG_UNUSED(p2);


### PR DESCRIPTION
Remove the unused variable 'lock_id' from main.c in the arc_vpx_lock test.

No functional change intended.