### PR TITLE
tests: bluetooth: audio: fix null dereference

### DIFF
--- a/tests/bluetooth/audio/cap_commander/uut/aics.c
+++ b/tests/bluetooth/audio/cap_commander/uut/aics.c
@@ -56,9 +56,14 @@ struct bt_aics *bt_aics_client_free_instance_get(void)
 int bt_aics_discover(struct bt_conn *conn, struct bt_aics *aics,
 		     const struct bt_aics_discover_param *param)
 {
+
+	if (aics == NULL) {
+		return -EINVAL;
+	}
+
 	aics->conn = conn;
 
-	if (aics != NULL && aics->cb != NULL && aics->cb->discover != NULL) {
+	if (aics->cb != NULL && aics->cb->discover != NULL) {
 		aics->cb->discover(aics, 0);
 	}
 

--- a/tests/bluetooth/audio/cap_commander/uut/vocs.c
+++ b/tests/bluetooth/audio/cap_commander/uut/vocs.c
@@ -57,9 +57,14 @@ struct bt_vocs *bt_vocs_client_free_instance_get(void)
 int bt_vocs_discover(struct bt_conn *conn, struct bt_vocs *vocs,
 		     const struct bt_vocs_discover_param *param)
 {
+
+	if (vocs == NULL) {
+		return -EINVAL;
+	}
+
 	vocs->conn = conn;
 
-	if (vocs != NULL && vocs->cb != NULL && vocs->cb->discover != NULL) {
+	if (vocs->cb != NULL && vocs->cb->discover != NULL) {
 		vocs->cb->discover(vocs, 0);
 	}
 

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -214,11 +214,11 @@ int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 
 int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 {
-	printk("%s %p %d\n", __func__, stream, stream->ep->dir);
-
 	if (stream == NULL || stream->ep == NULL) {
 		return -EINVAL;
 	}
+
+	printk("%s %p %d\n", __func__, stream, stream->ep->dir);
 
 	switch (stream->ep->status.state) {
 	case BT_BAP_EP_STATE_ENABLING:


### PR DESCRIPTION
Avoid possible null pointer dereference by moving 'vocs->conn = conn'
after null check on 'vocs' in bt_vocs_discover().

Move assignment 'aics->conn = conn' after null check on 'aics' to avoid
undefined behavior.

Move 'printk' call after null checks on 'stream' and 'stream->ep' to avoid
potential null pointer dereference.