### PR TITLE
cmake: apply optimization flags to assembler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ SOC_* symbol.")
 endif()
 
 # Apply the final optimization flag(s)
+zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:${OPTIMIZATION_FLAG}>)
 zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:${OPTIMIZATION_FLAG}>)
 zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:${OPTIMIZATION_FLAG}>)
 


### PR DESCRIPTION
Commit 65471a6095fd46d537dd4b7ad0667b4f1018a1c2 separated compiler flags into ASM, C and CXX as those flags may not be universal to both assembler and compiler. Though, with that separation, the assembler no longer gets the optimization flags (e.g. speed/size optimizations). So adds this back so the assembler can optimize the code if it chooses to. For example, some instructions can be fused together to result in small code.

Fixes #92439