### PR TITLE
boards: nxp: mimxrt1060: Disable pwmleds for Rev B/C boards

### DIFF
--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_B.overlay
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	/* FLEXPWM not routed to LED on this EVK */
+	pwmleds {
+		status = "disabled";
+	};
+};
+
 /* FLEXPWM not routed to LED on this EVK */
 &flexpwm2_pwm3 {
 	status = "disabled";

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -9,6 +9,11 @@
 		i2s-codec-tx = &sai1;
 		i2s-tx = &sai1;
 	};
+
+	/* FLEXPWM not routed to LED on this EVK */
+	pwmleds {
+		status = "disabled";
+	};
 };
 
 /* FLEXPWM not routed to LED on this EVK */


### PR DESCRIPTION
Disable the pwmleds nodes in the dts overlay for rev B/C boards. The FLEXPWM is not routed to LED on these versions.

Fixes #92285