### PR TITLE
drivers: clock_control: esp32c6: Fix clock init at JTAG reset

### DIFF
--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -105,8 +105,7 @@ static void esp32_clock_perip_init(void)
 	soc_reset_reason_t rst_reason = esp_rom_get_reset_reason(0);
 
 	if ((rst_reason != RESET_REASON_CPU0_MWDT0) && (rst_reason != RESET_REASON_CPU0_MWDT1) &&
-	    (rst_reason != RESET_REASON_CPU0_SW) && (rst_reason != RESET_REASON_CPU0_RTC_WDT) &&
-	    (rst_reason != RESET_REASON_CPU0_JTAG)) {
+	    (rst_reason != RESET_REASON_CPU0_SW) && (rst_reason != RESET_REASON_CPU0_RTC_WDT)) {
 
 		periph_ll_disable_clk_set_rst(PERIPH_UART1_MODULE);
 		periph_ll_disable_clk_set_rst(PERIPH_I2C0_MODULE);


### PR DESCRIPTION
Peripheral clocks are currently not being disabled for JTAG reset condition, which causes driver init failures when debugging the SoC with JTAG. Fix by disabling all clocks for this reset type.