### PR TITLE
Remove lxml as a direct dependency of our Python scripts

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2251,14 +2251,6 @@ def main(argv=None):
     args = parse_args(argv)
 
     try:
-        # pylint: disable=unused-import
-        from lxml import etree
-    except ImportError:
-        print("\nERROR: Python module lxml not installed, unable to proceed")
-        print("See https://github.com/weiwei/junitparser/issues/99")
-        return 1
-
-    try:
         n_fails = _main(args)
     except BaseException:
         # Catch BaseException instead of Exception to include stuff like

--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -12,7 +12,6 @@ ijson
 intelhex
 junit2html
 junitparser>=4.0.1
-lxml>=5.3.0
 mypy
 natsort
 ply>=3.10

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -583,9 +583,7 @@ lxml==6.0.0 \
     --hash=sha256:f720a14aa102a38907c6d5030e3d66b3b680c3e6f6bc95473931ea3c00c59967 \
     --hash=sha256:f8d19565ae3eb956d84da3ef367aa7def14a2735d05bd275cd54c0301f0d0d6c \
     --hash=sha256:f97487996a39cb18278ca33f7be98198f278d0bc3c5d0fd4d7b3d63646ca3c8a
-    # via
-    #   -r requirements-actions.in
-    #   gcovr
+    # via gcovr
 markupsafe==3.0.2 \
     --hash=sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4 \
     --hash=sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30 \

--- a/scripts/requirements-build-test.txt
+++ b/scripts/requirements-build-test.txt
@@ -18,4 +18,4 @@ pytest
 mypy
 
 # used for JUnit XML parsing in CTest harness
-junitparser
+junitparser>=3.0.0

--- a/scripts/tests/twister_blackbox/test_report.py
+++ b/scripts/tests/twister_blackbox/test_report.py
@@ -14,8 +14,7 @@ import pytest
 import shutil
 import sys
 import re
-
-from lxml import etree
+import xml.etree.ElementTree as etree
 
 # pylint: disable=no-name-in-module
 from conftest import TEST_DATA, ZEPHYR_BASE, testsuite_filename_mock, clear_log_in_test
@@ -162,7 +161,7 @@ class TestReport:
 
             elif path.endswith(".xml"):
                 tree = etree.parse(path)
-                xml_text = etree.tostring(tree, encoding="utf-8").decode("utf-8")
+                xml_text = etree.tostring(tree.getroot(), encoding="unicode")
                 assert xml_text.strip(), f"XML file '{path}' is empty"
 
             elif path.endswith(".log"):


### PR DESCRIPTION
Remove lxml since the performance gain it might provide doesn't necessarily justify pulling it in given it's only used in a handful of places, for very very basic tasks.