### PR TITLE
doc: develop: gsg: have west init use pinned Zephyr version for releases

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -143,6 +143,9 @@ SDK_URL_BASE="https://github.com/zephyrproject-rtos/sdk-ng/releases/download"
 rst_epilog = f"""
 .. include:: /substitutions.txt
 
+.. |zephyr-version| replace:: ``{version}``
+.. |zephyr-version-ltrim| unicode:: {version}
+   :ltrim:
 .. |sdk-version-literal| replace:: ``{sdk_version}``
 .. |sdk-version-trim| unicode:: {sdk_version}
    :trim:

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -252,11 +252,25 @@ chosen. You'll also install Zephyr's additional Python dependencies in a
 
       #. Get the Zephyr source code:
 
-         .. code-block:: bash
+         .. only:: not release
 
-           west init ~/zephyrproject
-           cd ~/zephyrproject
-           west update
+            .. code-block:: bash
+
+               west init ~/zephyrproject
+               cd ~/zephyrproject
+               west update
+
+         .. only:: release
+
+            .. We need to use a parsed-literal here because substitutions do not work in code
+               blocks. This means users can't copy-paste these lines as easily as other blocks but
+               should be good enough still :)
+
+            .. parsed-literal::
+
+               west init ~/zephyrproject --mr v |zephyr-version-ltrim|
+               cd ~/zephyrproject
+               west update
 
       #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
          automatically load boilerplate code required for building Zephyr


### PR DESCRIPTION
When building the docs for a release, the section of the getting started that lets the user `west init` their workspace now has them check out the version matching the release.

<img width="712" alt="image" src="https://github.com/user-attachments/assets/495a188e-7d80-4e02-bb78-615db9c5680e" />

