### PR TITLE
Video RTIO demo

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -8,6 +8,7 @@
 #
 menuconfig VIDEO
 	bool "Video drivers"
+	imply RTIO
 	help
 	  Enable support for the VIDEO.
 

--- a/drivers/video/video_sw_generator.c
+++ b/drivers/video/video_sw_generator.c
@@ -10,6 +10,7 @@
 #include <zephyr/drivers/video.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/rtio/rtio.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
@@ -38,11 +39,9 @@ struct video_sw_generator_data {
 	const struct device *dev;
 	struct sw_ctrls ctrls;
 	struct video_format fmt;
-	struct k_fifo fifo_in;
-	struct k_fifo fifo_out;
+	struct mpsc io_q;
 	struct k_work_delayable work;
 	int pattern;
-	struct k_poll_signal *sig;
 	uint32_t frame_rate;
 };
 
@@ -291,15 +290,29 @@ static void video_sw_generator_worker(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct video_sw_generator_data *data;
 	struct video_buffer *vbuf;
+	struct mpsc_node *node;
+	struct rtio_iodev_sqe *iodev_sqe;
+	struct rtio_sqe *sqe;
 
 	data = CONTAINER_OF(dwork, struct video_sw_generator_data, work);
 
 	k_work_reschedule(&data->work, K_MSEC(1000 / data->frame_rate));
 
-	vbuf = k_fifo_get(&data->fifo_in, K_NO_WAIT);
-	if (vbuf == NULL) {
+	node = mpsc_pop(&data->io_q);
+	if (node == NULL) {
 		return;
 	}
+
+	iodev_sqe = CONTAINER_OF(node, struct rtio_iodev_sqe, q);
+	sqe = &iodev_sqe->sqe;
+	if (sqe->op != RTIO_OP_RX) {
+		LOG_ERR("Invalid operation %d of length %u for submission %p",
+			sqe->op, sqe->rx.buf_len, (void *)iodev_sqe);
+		rtio_iodev_sqe_err(iodev_sqe, -EINVAL);
+		return;
+	}
+
+	vbuf = sqe->userdata;
 
 	switch (data->pattern) {
 	case VIDEO_PATTERN_COLOR_BAR:
@@ -307,57 +320,15 @@ static void video_sw_generator_worker(struct k_work *work)
 		break;
 	}
 
-	k_fifo_put(&data->fifo_out, vbuf);
-
-	if (IS_ENABLED(CONFIG_POLL) && data->sig) {
-		k_poll_signal_raise(data->sig, VIDEO_BUF_DONE);
-	}
-
-	k_yield();
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
 }
 
-static int video_sw_generator_enqueue(const struct device *dev, struct video_buffer *vbuf)
+static void video_sw_generator_iodev_submit(const struct device *dev,
+					    struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct video_sw_generator_data *data = dev->data;
 
-	k_fifo_put(&data->fifo_in, vbuf);
-
-	return 0;
-}
-
-static int video_sw_generator_dequeue(const struct device *dev, struct video_buffer **vbuf,
-				      k_timeout_t timeout)
-{
-	struct video_sw_generator_data *data = dev->data;
-
-	*vbuf = k_fifo_get(&data->fifo_out, timeout);
-	if (*vbuf == NULL) {
-		return -EAGAIN;
-	}
-
-	return 0;
-}
-
-static int video_sw_generator_flush(const struct device *dev, bool cancel)
-{
-	struct video_sw_generator_data *data = dev->data;
-	struct video_buffer *vbuf;
-
-	if (!cancel) {
-		/* wait for all buffer to be processed */
-		do {
-			k_sleep(K_MSEC(1));
-		} while (!k_fifo_is_empty(&data->fifo_in));
-	} else {
-		while ((vbuf = k_fifo_get(&data->fifo_in, K_NO_WAIT))) {
-			k_fifo_put(&data->fifo_out, vbuf);
-			if (IS_ENABLED(CONFIG_POLL) && data->sig) {
-				k_poll_signal_raise(data->sig, VIDEO_BUF_ABORTED);
-			}
-		}
-	}
-
-	return 0;
+	mpsc_push(&data->io_q, &iodev_sqe->q);
 }
 
 static int video_sw_generator_get_caps(const struct device *dev, struct video_caps *caps)
@@ -370,21 +341,6 @@ static int video_sw_generator_get_caps(const struct device *dev, struct video_ca
 
 	return 0;
 }
-
-#ifdef CONFIG_POLL
-static int video_sw_generator_set_signal(const struct device *dev, struct k_poll_signal *sig)
-{
-	struct video_sw_generator_data *data = dev->data;
-
-	if (data->sig && sig != NULL) {
-		return -EALREADY;
-	}
-
-	data->sig = sig;
-
-	return 0;
-}
-#endif
 
 static int video_sw_generator_set_frmival(const struct device *dev, struct video_frmival *frmival)
 {
@@ -439,16 +395,11 @@ static DEVICE_API(video, video_sw_generator_driver_api) = {
 	.set_format = video_sw_generator_set_fmt,
 	.get_format = video_sw_generator_get_fmt,
 	.set_stream = video_sw_generator_set_stream,
-	.flush = video_sw_generator_flush,
-	.enqueue = video_sw_generator_enqueue,
-	.dequeue = video_sw_generator_dequeue,
 	.get_caps = video_sw_generator_get_caps,
 	.set_frmival = video_sw_generator_set_frmival,
 	.get_frmival = video_sw_generator_get_frmival,
 	.enum_frmival = video_sw_generator_enum_frmival,
-#ifdef CONFIG_POLL
-	.set_signal = video_sw_generator_set_signal,
-#endif
+	.iodev_submit = video_sw_generator_iodev_submit,
 };
 
 static int video_sw_generator_init_controls(const struct device *dev)
@@ -464,9 +415,9 @@ static int video_sw_generator_init(const struct device *dev)
 	struct video_sw_generator_data *data = dev->data;
 
 	data->dev = dev;
-	k_fifo_init(&data->fifo_in);
-	k_fifo_init(&data->fifo_out);
 	k_work_init_delayable(&data->work, video_sw_generator_worker);
+
+	mpsc_init(&data->io_q);
 
 	return video_sw_generator_init_controls(dev);
 }


### PR DESCRIPTION
In some area, RTIO is used to increase performance at a slight extra cost in code size.

For video, it seems like a partial RTIO-like flow was already adopted by @loicpoulain in video APIs out of kernel primitives (the same week RTIO was introduced), so switching to RTIO actually reduces the amount of code in drivers and simplify the video APIs.

```
 drivers/video/Kconfig                    |   1 +
 drivers/video/video_common.c             |  25 +++++-
 drivers/video/video_sw_generator.c       |  99 ++++++-----------------
 include/zephyr/drivers/video.h           | 192 +++++++++-----------------------------------
 samples/drivers/video/capture/src/main.c |  48 +++++++----
 5 files changed, 119 insertions(+), 246 deletions(-)
```

API functions removed as now available through RTIO APIs:

- `.enqueue`
- `.dequeue`
- `.flush`
- `.set_signal` (the polling API)

API function added:

- `.iodev_submit`

The sample `main.c` did not go down in size. This initial PR adds a naive implementation that exposes all the RTIO internals directly, allowing discussion with the RTIO developers and Video developers and users about what wrappers to implement.

Keeping the low-level exposed is also a good opportunity to allow application libraries to wrap video APIs in higher-level and efficient userspace APIs.