### PR TITLE
mgmt: Select PM_DEVICE_RUNTIME for NPCX SHI driver

### DIFF
--- a/subsys/mgmt/ec_host_cmd/backends/Kconfig
+++ b/subsys/mgmt/ec_host_cmd/backends/Kconfig
@@ -56,6 +56,7 @@ config EC_HOST_CMD_BACKEND_SHI_NPCX
 	depends on DT_HAS_NUVOTON_NPCX_SHI_ENABLED || \
 		   DT_HAS_NUVOTON_NPCX_SHI_ENHANCED_ENABLED
 	select PINCTRL
+	select PM_DEVICE_RUNTIME
 	help
 	  This option enables the driver for SHI backend in the
 	  Nuvoton NPCX chip.


### PR DESCRIPTION
This commit updates the Kconfig for the Nuvoton NPCX Serial Host Interface (EC_HOST_CMD_BACKEND_SHI_NPCX) driver to select `CONFIG_PM_DEVICE_RUNTIME`.

The NPCX SHI driver requires runtime power management capabilities to properly manage its power states. Explicitly selecting `PM_DEVICE_RUNTIME` ensures that the necessary power management infrastructure is enabled whenever the SHI driver is in use.