### PR TITLE
drivers: i3c: Fix NXP driver consuming a lot of CPU time

### DIFF
--- a/drivers/i3c/Kconfig.nxp
+++ b/drivers/i3c/Kconfig.nxp
@@ -17,3 +17,12 @@ config I3C_MCUX
 	default y
 	help
 	  Enable mcux I3C driver.
+
+config I3C_NXP_TRANSFER_TIMEOUT
+	int "Transfer timeout [ms]"
+	default 500
+	depends on I3C_MCUX
+	help
+	  Timeout in milliseconds used for each I3C transfer.
+	  0 means that the driver should use the K_FOREVER value,
+	  i.e. it should wait as long as necessary.


### PR DESCRIPTION
The I3C and I2C transactions are consuming a lot of CPU time. The stated polling check was is not completed in sub-microseconds as is stated in the comment.
Added a 1usec sleep between probes of status register.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/91134