### PR TITLE
arch: riscv: Add Zicntr extension support

### DIFF
--- a/arch/riscv/Kconfig.isa
+++ b/arch/riscv/Kconfig.isa
@@ -96,6 +96,16 @@ config RISCV_ISA_EXT_C
 	  which reduces static and dynamic code size by adding short 16-bit
 	  instruction encodings for common operations.
 
+config RISCV_ISA_EXT_ZICNTR
+	bool
+	depends on RISCV_ISA_EXT_ZICSR
+	help
+	  (Zicntr) - Standard Extension for Base Counters and Timers
+
+	  The Zicntr standard extension comprises the three counters (CYCLE, TIME, and INSTRET),
+	  which have dedicated functions (cycle count, real-time clock and instructions retired,
+	  respectively).
+
 config RISCV_ISA_EXT_ZICSR
 	bool
 	help

--- a/cmake/compiler/gcc/target_riscv.cmake
+++ b/cmake/compiler/gcc/target_riscv.cmake
@@ -46,6 +46,10 @@ if(CONFIG_RISCV_ISA_EXT_C)
   string(CONCAT riscv_march ${riscv_march} "c")
 endif()
 
+if(CONFIG_RISCV_ISA_EXT_ZICNTR)
+  string(CONCAT riscv_march ${riscv_march} "_zicntr")
+endif()
+
 if(CONFIG_RISCV_ISA_EXT_ZICSR)
   string(CONCAT riscv_march ${riscv_march} "_zicsr")
 endif()


### PR DESCRIPTION
This commit introduces the support for the standard Zicntr extension, which provides hardware counters.