### PR TITLE
sensor: adxlxxx: tmpxxx: Use lowercase for group name

### DIFF
--- a/include/zephyr/dt-bindings/sensor/adxl345.h
+++ b/include/zephyr/dt-bindings/sensor/adxl345.h
@@ -13,7 +13,7 @@
  */
 
 /**
- * @defgroup ADXL345_ODR Output Rate options
+ * @defgroup adxl345_odr Output Rate options
  * @{
  */
 #define ADXL345_DT_ODR_12_5		7

--- a/include/zephyr/dt-bindings/sensor/adxl362.h
+++ b/include/zephyr/dt-bindings/sensor/adxl362.h
@@ -13,7 +13,7 @@
  */
 
 /**
- * @defgroup ADXL362_FIFO_MODE FIFO mode options
+ * @defgroup adxl362_fifo_mode FIFO mode options
  * @{
  */
 #define ADXL362_FIFO_MODE_DISABLED        0x0

--- a/include/zephyr/dt-bindings/sensor/adxl367.h
+++ b/include/zephyr/dt-bindings/sensor/adxl367.h
@@ -13,7 +13,7 @@
  */
 
 /**
- * @defgroup ADXL367_FIFO_MODE FIFO mode options
+ * @defgroup adxl367_fifo_mode FIFO mode options
  * @{
  */
 #define ADXL367_FIFO_MODE_DISABLED        0x0

--- a/include/zephyr/dt-bindings/sensor/icm42688.h
+++ b/include/zephyr/dt-bindings/sensor/icm42688.h
@@ -8,13 +8,13 @@
 #include "sensor_axis_align.h"
 
 /**
- * @defgroup ICM42688 Invensense (TDK) ICM42688 DT Options
+ * @defgroup icm42688 Invensense (TDK) ICM42688 DT Options
  * @ingroup sensor_interface
  * @{
  */
 
 /**
- * @defgroup ICM42688_ACCEL_POWER_MODES Accelerometer power modes
+ * @defgroup icm42688_accel_power_modes Accelerometer power modes
  * @{
  */
 #define ICM42688_DT_ACCEL_OFF		0
@@ -23,7 +23,7 @@
 /** @} */
 
 /**
- * @defgroup ICM42688_GYRO_POWER_MODES Gyroscope power modes
+ * @defgroup icm42688_gyro_power_modes Gyroscope power modes
  * @{
  */
 #define ICM42688_DT_GYRO_OFF		0
@@ -32,7 +32,7 @@
 /** @} */
 
 /**
- * @defgroup ICM42688_ACCEL_SCALE Accelerometer scale options
+ * @defgroup icm42688_accel_scale Accelerometer scale options
  * @{
  */
 #define ICM42688_DT_ACCEL_FS_16	0
@@ -42,7 +42,7 @@
 /** @} */
 
 /**
- * @defgroup ICM42688_GYRO_SCALE Gyroscope scale options
+ * @defgroup icm42688_gyro_scale Gyroscope scale options
  * @{
  */
 #define ICM42688_DT_GYRO_FS_2000		0
@@ -56,7 +56,7 @@
 /** @} */
 
 /**
- * @defgroup ICM42688_ACCEL_DATA_RATE Accelerometer data rate options
+ * @defgroup icm42688_accel_data_rate Accelerometer data rate options
  * @{
  */
 #define ICM42688_DT_ACCEL_ODR_32000		1
@@ -77,7 +77,7 @@
 /** @} */
 
 /**
- * @defgroup ICM42688_GYRO_DATA_RATE Gyroscope data rate options
+ * @defgroup icm42688_gyro_data_rate Gyroscope data rate options
  * @{
  */
 #define ICM42688_DT_GYRO_ODR_32000		1

--- a/include/zephyr/dt-bindings/sensor/mc3419.h
+++ b/include/zephyr/dt-bindings/sensor/mc3419.h
@@ -7,13 +7,13 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_MEMSIC_MC3419_H_
 
 /**
- * @defgroup MC3419 Memsic DT Options
+ * @defgroup mc3419 Memsic DT Options
  * @ingroup sensor_interface
  * @{
  */
 
 /**
- * @defgroup MC3419_LPF_CONFIGS Lowe pass filter configurations
+ * @defgroup mc3419_lpf_configs Lowe pass filter configurations
  * @{
  */
 #define MC3419_LPF_DISABLE                 0
@@ -24,7 +24,7 @@
 /** @} */
 
 /**
- * @defgroup MC3419_DECIMATION_RATES decimate sampling rate by provided rate
+ * @defgroup mc3419_decimation_rates decimate sampling rate by provided rate
  * @{
  */
 #define MC3419_DECIMATE_IDR_BY_1    0

--- a/include/zephyr/dt-bindings/sensor/tmp114.h
+++ b/include/zephyr/dt-bindings/sensor/tmp114.h
@@ -7,13 +7,13 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP114_H_
 
 /**
- * @defgroup TMP114 Texas Instruments (TI) TMP114 DT Options
+ * @defgroup tmp114 Texas Instruments (TI) TMP114 DT Options
  * @ingroup sensor_interface
  * @{
  */
 
 /**
- * @defgroup TMP114_ODR Temperature output data rate
+ * @defgroup tmp114_odr Temperature output data rate
  * @{
  */
 #define TMP114_DT_ODR_6_4_MS   0

--- a/include/zephyr/dt-bindings/sensor/tmp11x.h
+++ b/include/zephyr/dt-bindings/sensor/tmp11x.h
@@ -7,13 +7,13 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_TI_TMP11X_H_
 
 /**
- * @defgroup TMP11X Texas Instruments (TI) TMP11X DT Options
+ * @defgroup tmp11x Texas Instruments (TI) TMP11X DT Options
  * @ingroup sensor_interface
  * @{
  */
 
 /**
- * @defgroup TMP11X_ODR Temperature output data rate
+ * @defgroup tmp11x_odr Temperature output data rate
  * @{
  */
 #define TMP11X_DT_ODR_15_5_MS  0
@@ -27,7 +27,7 @@
 /** @} */
 
 /**
- * @defgroup TMP11X_OS Temperature average sample count
+ * @defgroup tmp11x_os Temperature average sample count
  * @{
  */
 #define TMP11X_DT_OVERSAMPLING_1  0


### PR DESCRIPTION
If necessary I can break my PR in multiple PR.
Change are use lowercase for group name only but it change on sensor adxlxxx, sensor tmpxxx