### PR TITLE
drivers: ethernet: remove unused variable

### DIFF
--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -191,7 +191,6 @@ static int sy1xx_mac_start(const struct device *dev)
 {
 	struct sy1xx_mac_dev_config *cfg = (struct sy1xx_mac_dev_config *)dev->config;
 	struct sy1xx_mac_dev_data *data = (struct sy1xx_mac_dev_data *)dev->data;
-	uint8_t rand_mac_addr[6];
 
 	extern void sy1xx_udma_disable_clock(sy1xx_udma_module_t module, uint32_t instance);
 

--- a/drivers/ethernet/eth_xilinx_axienet.c
+++ b/drivers/ethernet/eth_xilinx_axienet.c
@@ -381,8 +381,6 @@ static int xilinx_axienet_get_config(const struct device *dev, enum ethernet_con
 {
 	const struct xilinx_axienet_config *dev_config = dev->config;
 	const struct xilinx_axienet_data *data = dev->data;
-	struct phy_link_state link_state;
-	int err;
 
 	switch (type) {
 	case ETHERNET_CONFIG_TYPE_RX_CHECKSUM_SUPPORT:


### PR DESCRIPTION
Remove unused variable in two files :
`eth_sensry_sy1xx_mac.c` and `eth_xilinx_axienet.c`