### PR TITLE
add NETC support on imx95 A55

### DIFF
--- a/boards/nxp/imx95_evk/Kconfig.defconfig
+++ b/boards/nxp/imx95_evk/Kconfig.defconfig
@@ -28,4 +28,39 @@ config ARM_SCMI_TRANSPORT_INIT_PRIORITY
 config CLOCK_CONTROL_INIT_PRIORITY
 	default 31
 
+# Enlarge default networking stack
+if NETWORKING
+
+config NET_L2_ETHERNET
+	default y
+
+config NET_TX_STACK_SIZE
+	default 8192
+
+config NET_RX_STACK_SIZE
+	default 8192
+
+if NET_TCP
+
+config NET_TCP_WORKQ_STACK_SIZE
+	default 8192
+
+endif # NET_TCP
+
+if NET_MGMT_EVENT
+
+config NET_MGMT_EVENT_STACK_SIZE
+	default 8192
+
+endif # NET_MGMT_EVENT
+
+if NET_SOCKETS_SERVICE
+
+config NET_SOCKETS_SERVICE_STACK_SIZE
+	default 8192
+
+endif # NET_SOCKETS_SERVICE
+
+endif # NETWORKING
+
 endif # SOC_MIMX9596_A55

--- a/boards/nxp/imx95_evk/Kconfig.defconfig
+++ b/boards/nxp/imx95_evk/Kconfig.defconfig
@@ -3,6 +3,13 @@
 
 if SOC_MIMX9596_A55
 
+if ETH_NXP_IMX_NETC
+
+config GIC_V3_ITS
+	default y
+
+endif # ETH_NXP_IMX_NETC
+
 # GIC ITS depends on kernel heap which init priority is 30, so set
 # GIC to be 31, mailbox and SCMI will be initialized by the order
 # according to dts dependency although they use the same init priority.
@@ -21,4 +28,4 @@ config ARM_SCMI_TRANSPORT_INIT_PRIORITY
 config CLOCK_CONTROL_INIT_PRIORITY
 	default 31
 
-endif
+endif # SOC_MIMX9596_A55

--- a/boards/nxp/imx95_evk/doc/index.rst
+++ b/boards/nxp/imx95_evk/doc/index.rst
@@ -106,8 +106,10 @@ Ethernet
 --------
 
 NETC driver supports to manage the Physical Station Interface (PSI).
-The first ENET1 port could be enabled on M7 DDR platform.
+The first ENET1 port could be enabled on M7 DDR and A55 platforms.
 
+For A55 Core, NETC depends on GIC ITS, so need to make sure to allocate heap memory to
+be larger than 851968 byes by setting CONFIG_HEAP_MEM_POOL_SIZE.
 
 Programming and Debugging (A55)
 *******************************

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.dts
@@ -47,6 +47,31 @@
 	};
 };
 
+&emdio {
+	pinctrl-0 = <&emdio_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	phy0: phy@1 {
+		compatible = "realtek,rtl8211f";
+		reg = <0x1>;
+		status = "okay";
+	};
+};
+
+&enetc_psi0 {
+	local-mac-address = [00 00 00 01 02 00];
+	pinctrl-0 = <&eth0_default>;
+	pinctrl-names = "default";
+	phy-handle = <&phy0>;
+	phy-connection-type = "rgmii";
+	status = "okay";
+};
+
+&enetc_ptp_clock {
+	status = "okay";
+};
+
 &lpi2c5 {
 	pinctrl-0 = <&lpi2c5_default>;
 	pinctrl-names = "default";

--- a/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
+++ b/boards/nxp/imx95_evk/imx95_evk_mimx9596_a55.yaml
@@ -16,6 +16,7 @@ supported:
   - counter
   - i2c
   - uart
+  - net
 testing:
   binaries:
     - flash.bin

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -478,4 +478,74 @@
 		ngpios = <16>;
 		status = "disabled";
 	};
+
+	netc_blk_ctrl: netc-blk-ctrl@4cde0000 {
+		compatible = "nxp,imx-netc-blk-ctrl";
+		reg = <0x4cde0000 0x10000>,
+			  <0x4cdf0000 0x10000>,
+			  <0x4c810000 0x18>;
+		reg-names = "ierb", "prb", "netcmix";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		netc: ethernet {
+			compatible = "nxp,imx-netc";
+			msi-parent = <&its>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			enetc_psi0: ethernet@4cc00000 {
+				compatible = "nxp,imx-netc-psi";
+				reg = <0x4cc00000 0x40000>,
+				      <0x4ca00000 0x1000>;
+				reg-names = "port", "pfconfig";
+				msi-device-id = <0x60>;
+				mac-index = <0>;
+				si-index = <0>;
+				status = "disabled";
+			};
+
+			enetc_psi1: ethernet@4cc40000 {
+				compatible = "nxp,imx-netc-psi";
+				reg = <0x4cc40000 0x40000>,
+				      <0x4ca40000 0x1000>;
+				reg-names = "port", "pfconfig";
+				msi-device-id = <0x63>;
+				mac-index = <1>;
+				si-index = <1>;
+				status = "disabled";
+			};
+
+			enetc_psi2: ethernet@4cc80000 {
+				compatible = "nxp,imx-netc-psi";
+				reg = <0x4cc80000 0x40000>,
+				      <0x4ca80000 0x1000>;
+				reg-names = "port", "pfconfig";
+				msi-device-id = <0x64>;
+				mac-index = <2>;
+				si-index = <2>;
+				status = "disabled";
+			};
+
+			emdio: mdio@4cb00000 {
+				compatible = "nxp,imx-netc-emdio";
+				reg = <0x4cce0000 0x2000>,
+					<0x4cb00000 0x100000>;
+				reg-names = "basic", "pfconfig";
+				clocks = <&scmi_clk IMX95_CLK_ENET>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				status = "disabled";
+			};
+
+			enetc_ptp_clock: ptp_clock@4ccc0000 {
+				compatible = "nxp,netc-ptp-clock";
+				reg = <0x4ccc0000 0x10000>;
+				clocks = <&scmi_clk IMX95_CLK_ENET>;
+				status = "disabled";
+			};
+		};
+	};
 };

--- a/dts/arm64/nxp/nxp_mimx95_a55.dtsi
+++ b/dts/arm64/nxp/nxp_mimx95_a55.dtsi
@@ -109,6 +109,12 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
+			scmi_devpd: protocol@11 {
+				compatible = "arm,scmi-power";
+				reg = <0x11>;
+				#power-domain-cells = <1>;
+			};
+
 			scmi_clk: protocol@14 {
 				compatible = "arm,scmi-clock";
 				reg = <0x14>;

--- a/samples/net/zperf/boards/imx95_evk_mimx9596_a55.conf
+++ b/samples/net/zperf/boards/imx95_evk_mimx9596_a55.conf
@@ -1,0 +1,15 @@
+# The GICv3 & ITS drivers allocation needs are:
+# - LPI prop table: global 1x64K aligned on 64K
+# - LPI pend table: for each redistributor/cpu 1x64K aligned on 64K
+# - Devices table: 128x4K aligned on 4K
+# - Interrupt Collections table: 1x4K aligned on 4K
+#
+# This makes 11x64K to permit all allocations to success.
+#
+# Note, will need 64K HEAP_MEM per CPUs added.
+#
+# This doesn't necessarily include the Interrupt Translation Table, which are
+# 256bytes aligned tables, for reference a 32 ITEs table needs 256bytes.
+#
+# To permit allocating 256 ITT tables of 32 ITEs, 13x64K HEAP_MEM is needed
+CONFIG_HEAP_MEM_POOL_SIZE=851968

--- a/soc/nxp/imx/imx9/imx95/a55/soc.c
+++ b/soc/nxp/imx/imx9/imx95/a55/soc.c
@@ -9,12 +9,18 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/firmware/scmi/clk.h>
+#include <zephyr/drivers/firmware/scmi/power.h>
 #include <zephyr/dt-bindings/clock/imx95_clock.h>
+#include <zephyr/dt-bindings/power/imx95_power.h>
 #include <soc.h>
 
 #define FREQ_24M_HZ 24000000 /* 24 MHz */
 
-static int soc_clk_init(void)
+/* SCMI power domain states */
+#define POWER_DOMAIN_STATE_ON  0x00000000
+#define POWER_DOMAIN_STATE_OFF 0x40000000
+
+static int lpuart_clk_init(void)
 {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart1), okay) ||                                             \
 	DT_NODE_HAS_STATUS(DT_NODELABEL(lpuart3), okay)
@@ -57,9 +63,65 @@ static int soc_clk_init(void)
 	return 0;
 }
 
+static int netc_init(void)
+{
+#if defined(CONFIG_ETH_NXP_IMX_NETC) && (DT_CHILD_NUM_STATUS_OKAY(DT_NODELABEL(netc)) != 0)
+	const struct device *clk_dev = DEVICE_DT_GET(DT_NODELABEL(scmi_clk));
+	struct scmi_protocol *proto = clk_dev->data;
+	struct scmi_clock_rate_config clk_cfg = {0};
+	struct scmi_power_state_config pwr_cfg = {0};
+	uint32_t power_state = POWER_DOMAIN_STATE_OFF;
+	uint64_t enetref_clk = 250000000; /* 250 MHz*/
+	int ret;
+
+	/* Power up NETCMIX */
+	pwr_cfg.domain_id = IMX95_PD_NETC;
+	pwr_cfg.power_state = POWER_DOMAIN_STATE_ON;
+
+	ret = scmi_power_state_set(&pwr_cfg);
+	if (ret) {
+		return ret;
+	}
+
+	while (power_state != POWER_DOMAIN_STATE_ON) {
+		ret = scmi_power_state_get(IMX95_PD_NETC, &power_state);
+		if (ret) {
+			return ret;
+		}
+	}
+
+	/* ENETREF clock init */
+	ret = scmi_clock_parent_set(proto, IMX95_CLK_ENETREF, IMX95_CLK_SYSPLL1_PFD0);
+	if (ret) {
+		return ret;
+	}
+
+	clk_cfg.flags = SCMI_CLK_RATE_SET_FLAGS_ROUNDS_AUTO;
+	clk_cfg.clk_id = IMX95_CLK_ENETREF;
+	clk_cfg.rate[0] = enetref_clk & 0xffffffff;
+	clk_cfg.rate[1] = (enetref_clk >> 32) & 0xffffffff;
+
+	ret = scmi_clock_rate_set(proto, &clk_cfg);
+	if (ret) {
+		return ret;
+	}
+#endif
+
+	return 0;
+}
+
 static int soc_init(void)
 {
-	return soc_clk_init();
+	int ret;
+
+	ret = lpuart_clk_init();
+	if (ret) {
+		return ret;
+	}
+
+	ret = netc_init();
+
+	return ret;
 }
 /*
  * Because platform is using ARM SCMI, drivers like scmi, mbox etc are

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2de68b601cc95417466707f1b99149820b0556ec
+      revision: 9b49fb1130209214a95d279b64e1efd5c87ec915
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
This PR is to enable NETC support on i.MX 95 A55.

This PR depends on hal PR: https://github.com/zephyrproject-rtos/hal_nxp/pull/571