### PR TITLE
maintainers: fuelgauge: add collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1531,6 +1531,8 @@ Release Notes:
   maintainers:
     - aaronemassey
     - teburd
+  collaborators:
+    - DBS06
   files:
     - drivers/fuel_gauge/
     - dts/bindings/fuel-gauge/


### PR DESCRIPTION
As discussed with @kartben [here](https://github.com/zephyrproject-rtos/zephyr/pull/92277#issuecomment-3031395720)  this PR adds myself as a collaborator for the fuel gauge (which is quite an honor for me btw).

