### PR TITLE
boards: nordic: nrf54h20dk: ipc to cpusys with unbound

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
@@ -32,6 +32,7 @@
 
 		cpuapp_cpusys_ipc: ipc-2-12 {
 			compatible = "zephyr,ipc-icmsg";
+			unbound = "detect";
 			status = "disabled";
 			dcache-alignment = <32>;
 			mboxes = <&cpuapp_bellboard 6>,
@@ -56,6 +57,7 @@
 
 		cpurad_cpusys_ipc: ipc-3-12 {
 			compatible = "zephyr,ipc-icmsg";
+			unbound = "detect";
 			status = "disabled";
 			dcache-alignment = <32>;
 			mboxes = <&cpurad_bellboard 6>,


### PR DESCRIPTION
Unbound feature in IPC with cpusys will be detected. This is needed to enable IPC link renewal.