### PR TITLE
 libc: remove POSIX_TIMERS dep from COMMON_LIBC_TIME 

### DIFF
--- a/cmake/toolchain/armclang/Kconfig
+++ b/cmake/toolchain/armclang/Kconfig
@@ -16,7 +16,7 @@ choice LIBC_IMPLEMENTATION
 config ARMCLANG_STD_LIBC
 	bool "ARM Compiler C library"
 	select COMMON_LIBC_STRNLEN
-	select COMMON_LIBC_TIME if POSIX_TIMERS
+	select COMMON_LIBC_TIME
 	help
 	  Use the full Arm Compiler runtime libraries.
 	  A reduced Zephyr minimal libc will be used for library functionality

--- a/doc/develop/languages/c/common_libc.rst
+++ b/doc/develop/languages/c/common_libc.rst
@@ -12,7 +12,7 @@ Time function
 *************
 
 This provides an implementation of the standard C function, :c:func:`time`,
-relying on the Zephyr function, :c:func:`clock_gettime`. This function can
+relying on the Zephyr function, :c:func:`sys_clock_gettime`. This function can
 be enabled by selecting :kconfig:option:`COMMON_LIBC_TIME`.
 
 Dynamic Memory Management

--- a/lib/libc/minimal/Kconfig
+++ b/lib/libc/minimal/Kconfig
@@ -37,7 +37,7 @@ config MINIMAL_LIBC_RAND
 
 config MINIMAL_LIBC_TIME
 	bool "Time functions"
-	select COMMON_LIBC_TIME if POSIX_TIMERS
+	select COMMON_LIBC_TIME
 	select POSIX_C_LANG_SUPPORT_R
 	select COMMON_LIBC_GMTIME_R
 	select COMMON_LIBC_ASCTIME
@@ -46,9 +46,6 @@ config MINIMAL_LIBC_TIME
 	default y
 	help
 	  Enable time() and gmtime_r() for the minimal libc.
-
-	  time() requires CONFIG_POSIX_TIMERS=y because it relies on the POSIX
-	  clock_gettime() function.
 
 	  In order to make use of the non-reentrant gmtime(), it is necessary
 	  to set CONFIG_MINIMAL_LIBC_NON_REENTRANT_FUNCTIONS=y.


### PR DESCRIPTION
remove POSIX_TIMERS dependency from
COMMON_LIBC_TIME, as no longer needed.

the time() implementation now uses
sys_clock_gettime(), change that in the docs.