### PR TITLE
boards: nxp: cleanup duplicate 'chosen' entry

### DIFF
--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -6,7 +6,6 @@
 
 / {
 	chosen {
-		zephyr,flash = &w25q512nw;
 		zephyr,flash-controller = &w25q512nw;
 		zephyr,flash = &w25q512nw;
 		zephyr,code-partition = &slot0_partition;


### PR DESCRIPTION
What looks to be a copy/paste error observed through inspection