### PR TITLE
drivers/sensor/: lis2dux12: fix ODR setting

### DIFF
--- a/drivers/sensor/st/lis2dux12/lis2dux12_api.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_api.c
@@ -17,7 +17,19 @@ static int32_t st_lis2dux12_set_odr_raw(const struct device *dev, uint8_t odr)
 	struct lis2dux12_data *data = dev->data;
 	const struct lis2dux12_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
-	lis2dux12_md_t mode = {.odr = odr, .fs = data->range};
+	lis2dux12_md_t mode;
+
+	/* handle high performance mode */
+	if (cfg->pm == LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE) {
+		if (odr < LIS2DUX12_DT_ODR_6Hz) {
+			odr = LIS2DUX12_DT_ODR_6Hz;
+		}
+
+		odr |= 0x10;
+	}
+
+	mode.odr = odr;
+	mode.fs = data->range;
 
 	data->odr = odr;
 	return lis2dux12_mode_set(ctx, &mode);

--- a/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
+++ b/drivers/sensor/st/lis2dux12/lis2duxs12_api.c
@@ -17,7 +17,19 @@ static int32_t st_lis2duxs12_set_odr_raw(const struct device *dev, uint8_t odr)
 	struct lis2dux12_data *data = dev->data;
 	const struct lis2dux12_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
-	lis2duxs12_md_t mode = {.odr = odr, .fs = data->range};
+	lis2duxs12_md_t mode;
+
+	/* handle high performance mode */
+	if (cfg->pm == LIS2DUX12_OPER_MODE_HIGH_PERFORMANCE) {
+		if (odr < LIS2DUX12_DT_ODR_6Hz) {
+			odr = LIS2DUX12_DT_ODR_6Hz;
+		}
+
+		odr |= 0x10;
+	}
+
+	mode.odr = odr;
+	mode.fs = data->range;
 
 	data->odr = odr;
 	return lis2duxs12_mode_set(ctx, &mode);


### PR DESCRIPTION
In lis2dux12_freq_to_odr_val, the loop through the array of possible ODR frequencies can break sooner than expected if power-mode is set to High Performance mode and the requested ODR is less than or equal to 25Hz.

Moreover, move the "odr |= 0x10" statement used for HP mode in the chip_api set_odr_raw() API, so that we enter the HP mode even when the ODR is set from DT only.

Fixes: #92393

Tested on x_nucleo_iks4a1 shield