### PR TITLE
tests: arch: common: ramfunc: fix the project's name in CMake

### DIFF
--- a/tests/arch/common/ramfunc/CMakeLists.txt
+++ b/tests/arch/common/ramfunc/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(zero_latency_irqs)
+project(ramfunc)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})


### PR DESCRIPTION
`CMakeLists.txt` for this test declares the project using `project(zero_latency_irqs)`, despite testing the ramfunc feature instead. This might be a copy-paste mistake: when introduced, `project(arm_zero_latency_irqs)` was used instead, and that is a test that exists elsewhere in tree.

Change the project name in `CMakeLists.txt` to match what the test truly is.