### PR TITLE
drivers: video: ov7670: Add support for PCLK free-run mode

### DIFF
--- a/drivers/video/Kconfig.ov7670
+++ b/drivers/video/Kconfig.ov7670
@@ -1,4 +1,5 @@
 # Copyright 2024 NXP
+# Copyright (c) 2025 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 config VIDEO_OV7670
@@ -8,3 +9,13 @@ config VIDEO_OV7670
 	default y
 	help
 	  Enable driver for OV7670 CMOS digital image sensor device.
+
+if VIDEO_OV7670
+
+config VIDEO_OV7670_PCLK_FREE_RUN
+	bool "OV7670 PCLK free-run mode"
+	help
+	  Clear COM10 bit 5 to allow the pixel clock (PCLK) to free-run continuously,
+	  even during horizontal blanking. By default, PCLK is gated during H-blank.
+
+endif

--- a/drivers/video/ov7670.c
+++ b/drivers/video/ov7670.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 NXP
+ * Copyright (c) 2025 Renesas Electronics Co.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -218,9 +219,13 @@ static const struct video_format_cap fmts[] = {
 static const struct ov7670_reg ov7670_init_regtbl[] = {
 	{OV7670_MVFP, 0x00}, /* MVFP: Mirror/VFlip,Normal image */
 
-	/* configure the output timing */
+#ifdef CONFIG_VIDEO_OV7670_PCLK_FREE_RUN
+	/* Free running PCLK, default VSYNC, HSYNC and PCLK */
+	{OV7670_COM10, 0x00}, /* COM10 */
+#else
 	/* PCLK does not toggle during horizontal blank, one PCLK, one pixel */
 	{OV7670_COM10, 0x20}, /* COM10 */
+#endif
 	{OV7670_COM12, 0x00}, /* COM12,No HREF when VSYNC is low */
 	/* Brightness Control, with signal -128 to +128, 0x00 is middle value */
 	{OV7670_BRIGHT, 0x2f},


### PR DESCRIPTION
- Add a Kconfig CONFIG_VIDEO_OV7670_PCLK_FREE_RUN for OV7670

- Update the OV7670 driver’s initialization register array

   - COM10 = 0x00 when CONFIG_VIDEO_OV7670_PCLK_FREE_RUN=y

   - COM10 = 0x20 when disabled

This update supports for peripherals which requiring an uninterrupted clock (ex. Renesas CEU)