### PR TITLE
STM32U3: Fix Flash write and erase blocks size

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -44,6 +45,39 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
+	};
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * The following partitioning is dedicated to the use of nucleo_u385rg_q
+		 * with TZEN=0 (i.e., without TF-M).
+		 * Place partitions within first 512 KiB to make use of the whole Bank1.
+		 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(192)>;
+		};
+
+		slot1_partition: partition@40000 {
+			label = "image-1";
+			reg = <0x00040000 DT_SIZE_K(192)>;
+		};
+
+		storage_partition: partition@70000 {
+			label = "storage";
+			reg = <0x00070000 DT_SIZE_K(64)>;
+		};
 	};
 };
 

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -99,9 +99,9 @@
 				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 
 				write-block-size = <16>;
-				erase-block-size = <8192>;
-				/* maximum erase time(ms) for a 8K sector */
-				max-erase-time = <5>;
+				erase-block-size = <4096>;
+				/* maximum erase time(ms) for a 4KB page */
+				max-erase-time = <14>;
 			};
 		};
 

--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - esp32c3_devkitm
       - esp32c6_devkitc/esp32c6/hpcore
       - nucleo_h7s3l8
+      - nucleo_u385rg_q
       - stm32h7s78_dk
     integration_platforms:
       - nrf52840dk/nrf52840

--- a/soc/st/stm32/stm32u3x/Kconfig.defconfig
+++ b/soc/st/stm32/stm32u3x/Kconfig.defconfig
@@ -8,4 +8,7 @@ if SOC_SERIES_STM32U3X
 config NUM_IRQS
 	default 125
 
+config ROM_START_OFFSET
+	default 0x400 if BOOTLOADER_MCUBOOT
+
 endif # SOC_SERIES_STM32U3X


### PR DESCRIPTION
- Change erase-block-size from 8192 to 4096 bytes to match the 4 KB page size of STM32U3 flash.
- Update max-erase-time from 5 ms to 14 ms according to datasheet specifications.
-  Define fixed partitions for bootloader (mcuboot), primary and secondary images, scratch, and storage.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92491