### PR TITLE
kernel: move z_sched_lock inside k_sched_lock

### DIFF
--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -138,16 +138,6 @@ static inline bool _is_valid_prio(int prio, k_thread_entry_t entry_point)
 	return true;
 }
 
-static inline void z_sched_lock(void)
-{
-	__ASSERT(!arch_is_in_isr(), "");
-	__ASSERT(_current->base.sched_locked != 1U, "");
-
-	--_current->base.sched_locked;
-
-	compiler_barrier();
-}
-
 static ALWAYS_INLINE _wait_q_t *pended_on_thread(struct k_thread *thread)
 {
 	__ASSERT_NO_MSG(thread->base.pended_on);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -771,7 +771,12 @@ void k_sched_lock(void)
 	K_SPINLOCK(&_sched_spinlock) {
 		SYS_PORT_TRACING_FUNC(k_thread, sched_lock);
 
-		z_sched_lock();
+		__ASSERT(!arch_is_in_isr(), "");
+		__ASSERT(_current->base.sched_locked != 1U, "");
+
+		--_current->base.sched_locked;
+
+		compiler_barrier();
 	}
 }
 


### PR DESCRIPTION
z_sched_lock() has exactly one user in tree which is k_sched_lock(). So combine them to make it easier to follow (or not, since there is no jumping to another file anymore).