### PR TITLE
manifest: nanopb: move nanopb to main manifest

### DIFF
--- a/doc/services/serialization/nanopb.rst
+++ b/doc/services/serialization/nanopb.rst
@@ -39,14 +39,6 @@ make sure the ``protoc`` executable is installed and available.
             choco install protoc
 
 
-Additionally, Nanopb is an optional module and needs to be added explicitly to the workspace:
-
-.. code-block:: shell
-
-   west config manifest.project-filter -- +nanopb
-   west update
-   west packages pip --install
-
 Configuration
 *************
 

--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -22,12 +22,6 @@ manifest:
       remote: upstream
       groups:
         - optional
-    - name: nanopb
-      revision: 7307ce399b81ddcb3c3a5dc862c52d4754328d38
-      path: modules/lib/nanopb
-      remote: upstream
-      groups:
-        - optional
     - name: psa-arch-tests
       revision: 2cadb02a72eacda7042505dcbdd492371e8ce024
       path: modules/tee/tf-m/psa-arch-tests

--- a/west.yml
+++ b/west.yml
@@ -319,6 +319,9 @@ manifest:
       groups:
         - debug
       revision: 33e5c23cbedda5ba12dbe50c4baefb362a791001
+    - name: nanopb
+      revision: 7307ce399b81ddcb3c3a5dc862c52d4754328d38
+      path: modules/lib/nanopb
     - name: net-tools
       revision: 986bfeb040df3d9029366de8aea4ce1f84e93780
       path: tools/net-tools


### PR DESCRIPTION
nanopb is used in tree now, so it should be part of the main manifest.

see drivers/wifi/esp_hosted/

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
