### PR TITLE
sensor: nrf-qdec: Allow sampleper register configurable through dts

### DIFF
--- a/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/dt-bindings/sensor/qdec_nrf.h>
 #include <soc.h>
 
 #include <nrfx_qdec.h>
@@ -24,6 +25,22 @@ LOG_MODULE_REGISTER(qdec_nrfx, CONFIG_SENSOR_LOG_LEVEL);
 #define ACC_MAX (INT_MAX / FULL_ANGLE)
 #define ACC_MIN (INT_MIN / FULL_ANGLE)
 
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_128US == SAMPLEPER_128US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_256US == SAMPLEPER_256US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_512US == SAMPLEPER_512US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_1024US == SAMPLEPER_1024US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_2048US == SAMPLEPER_2048US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_4096US == SAMPLEPER_4096US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_8192US == SAMPLEPER_8192US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
+BUILD_ASSERT(NRF_QDEC_SAMPLEPER_16384US == SAMPLEPER_16384US,
+	     "Different SAMPLEPER register values in devicetree binding and nRF HAL");
 
 struct qdec_nrfx_data {
 	int32_t fetched_acc;
@@ -272,7 +289,7 @@ static int qdec_nrfx_init(const struct device *dev)
 		.qdec = NRFX_QDEC_INSTANCE(idx),					     \
 		.config = {								     \
 			.reportper = NRF_QDEC_REPORTPER_40,				     \
-			.sampleper = NRF_QDEC_SAMPLEPER_2048US,				     \
+			.sampleper = DT_STRING_TOKEN(QDEC(idx), nordic_period),              \
 			.skip_gpio_cfg = true,						     \
 			.skip_psel_cfg = true,						     \
 			.ledpre  = QDEC_PROP(idx, led_pre),				     \

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -44,3 +44,19 @@ properties:
     type: int
     description: Number of steps on the rotating wheel
     required: true
+
+  nordic,period:
+    type: string
+    default: SAMPLEPER_2048US
+    enum:
+      - SAMPLEPER_128US
+      - SAMPLEPER_256US
+      - SAMPLEPER_512US
+      - SAMPLEPER_1024US
+      - SAMPLEPER_2048US
+      - SAMPLEPER_4096US
+      - SAMPLEPER_8192US
+      - SAMPLEPER_16384US
+    description: |
+      The sampling period of the QDEC device. The default value is SAMPLEPER_2048US, which
+      reflects the previously hardcoded configuration.

--- a/dts/vendor/nordic/nrf_common.dtsi
+++ b/dts/vendor/nordic/nrf_common.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pinctrl/nrf-pinctrl.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/sensor/qdec_nrf.h>
 
 #include <freq.h>
 #include <arm/nordic/override.dtsi>

--- a/include/zephyr/dt-bindings/sensor/qdec_nrf.h
+++ b/include/zephyr/dt-bindings/sensor/qdec_nrf.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Mark Geiger <MarkGeiger@posteo.de>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_NRF_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_NRF_H_
+
+#define SAMPLEPER_128US         0
+#define SAMPLEPER_256US         1
+#define SAMPLEPER_512US         2
+#define SAMPLEPER_1024US        3
+#define SAMPLEPER_2048US        4
+#define SAMPLEPER_4096US        5
+#define SAMPLEPER_8192US        6
+#define SAMPLEPER_16384US       7
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_QDEC_NRF_H_ */


### PR DESCRIPTION
Allow for users to define the sampling rate via the sampleper register on a per instance basis through device-tree properties. The previous value was hard coded. The same value is now the default value.