### PR TITLE
vmu_rt1170: Add axis alignment to ICM4268X with Right-Hand rule

### DIFF
--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -287,6 +287,7 @@
 		axis-align-x = <SENSOR_AXIS_ALIGN_DT_Y>;
 		axis-align-y = <SENSOR_AXIS_ALIGN_DT_X>;
 		axis-align-z = <SENSOR_AXIS_ALIGN_DT_Z>;
+		axis-align-x-sign = <SENSOR_AXIS_ALIGN_DT_NEG>;
 		fifo-hires;
 	};
 };

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -260,9 +260,11 @@
 		gyro-pwr-mode = <ICM42686_DT_GYRO_LN>;
 		gyro-odr = <ICM42686_DT_GYRO_ODR_1000>;
 		gyro-fs = <ICM42686_DT_GYRO_FS_2000>;
-		axis-align-x = <SENSOR_AXIS_ALIGN_DT_Y>;
-		axis-align-y = <SENSOR_AXIS_ALIGN_DT_X>;
+		axis-align-x = <SENSOR_AXIS_ALIGN_DT_X>;
+		axis-align-y = <SENSOR_AXIS_ALIGN_DT_Y>;
 		axis-align-z = <SENSOR_AXIS_ALIGN_DT_Z>;
+		axis-align-x-sign = <SENSOR_AXIS_ALIGN_DT_NEG>;
+		axis-align-z-sign = <SENSOR_AXIS_ALIGN_DT_NEG>;
 		fifo-hires;
 	};
 };


### PR DESCRIPTION
This PR sits on top of #92579 to add Axis Alignment to the VMU RT1170 so both on-board IMUs are aligned (ICM42686 and ICM42688).

This patch was co-authored by @bperseghetti

> [!NOTE]
> Marking this PR as DNM until #92579 is merged.