### PR TITLE
Doxygen housekeeping

### DIFF
--- a/include/zephyr/dsp/basicmath.h
+++ b/include/zephyr/dsp/basicmath.h
@@ -20,11 +20,13 @@ extern "C" {
 /**
  * @ingroup math_dsp
  * @defgroup math_dsp_basic Basic Math Functions
+ * Basic element-wise math operations for DSP.
+ * @{
  */
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_mult Vector Multiplication
+ * @defgroup math_dsp_basic_mult Vector Multiplication
  *
  * Element-by-element multiplication of two vectors.
  * <pre>
@@ -95,7 +97,7 @@ DSP_FUNC_SCOPE void zdsp_mult_f32(const DSP_DATA float32_t *src_a, const DSP_DAT
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_add Vector Addition
+ * @defgroup math_dsp_basic_add Vector Addition
  *
  * Element-by-element addition of two vectors.
  * <pre>
@@ -166,7 +168,7 @@ DSP_FUNC_SCOPE void zdsp_add_q31(const DSP_DATA q31_t *src_a, const DSP_DATA q31
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_sub Vector Subtraction
+ * @defgroup math_dsp_basic_sub Vector Subtraction
  *
  * Element-by-element subtraction of two vectors.
  * <pre>
@@ -237,7 +239,7 @@ DSP_FUNC_SCOPE void zdsp_sub_q31(const DSP_DATA q31_t *src_a, const DSP_DATA q31
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_scale Vector Scale
+ * @defgroup math_dsp_basic_scale Vector Scale
  *
  * Multiply a vector by a scalar value. For floating-point data, the algorithm used is:
  * <pre>
@@ -328,7 +330,7 @@ DSP_FUNC_SCOPE void zdsp_scale_q31(const DSP_DATA q31_t *src, q31_t scale_fract,
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_abs Vector Absolute Value
+ * @defgroup math_dsp_basic_abs Vector Absolute Value
  *
  * Computes the absolute value of a vector on an element-by-element basis.
  * <pre>
@@ -397,7 +399,7 @@ DSP_FUNC_SCOPE void zdsp_abs_q31(const DSP_DATA q31_t *src, DSP_DATA q31_t *dst,
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_dot Vector Dot Product
+ * @defgroup math_dsp_basic_dot Vector Dot Product
  *
  * Computes the dot product of two vectors. The vectors are multiplied element-by-element and then
  * summed.
@@ -477,7 +479,7 @@ DSP_FUNC_SCOPE void zdsp_dot_prod_q31(const DSP_DATA q31_t *src_a, const DSP_DAT
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_shift Vector Shift
+ * @defgroup math_dsp_basic_shift Vector Shift
  *
  * Shifts the elements of a fixed-point vector by a specified number of bits.
  * There are separate functions for Q7, Q15, and Q31 data types. The underlying algorithm used is:
@@ -546,7 +548,7 @@ DSP_FUNC_SCOPE void zdsp_shift_q31(const DSP_DATA q31_t *src, int8_t shift_bits,
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_offset Vector Offset
+ * @defgroup math_dsp_basic_offset Vector Offset
  *
  * Adds a constant offset to each element of a vector.
  * <pre>
@@ -620,7 +622,7 @@ DSP_FUNC_SCOPE void zdsp_offset_q31(const DSP_DATA q31_t *src, q31_t offset, DSP
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_negate Vector Negate
+ * @defgroup math_dsp_basic_negate Vector Negate
  *
  * Negates the elements of a vector.
  * <pre>
@@ -690,7 +692,7 @@ DSP_FUNC_SCOPE void zdsp_negate_q31(const DSP_DATA q31_t *src, DSP_DATA q31_t *d
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_and Vector bitwise AND
+ * @defgroup math_dsp_basic_and Vector bitwise AND
  *
  * Compute the logical bitwise AND.
  *
@@ -734,7 +736,7 @@ DSP_FUNC_SCOPE void zdsp_and_u32(const DSP_DATA uint32_t *src_a, const DSP_DATA 
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_or Vector bitwise OR
+ * @defgroup math_dsp_basic_or Vector bitwise OR
  *
  * Compute the logical bitwise OR.
  *
@@ -778,7 +780,7 @@ DSP_FUNC_SCOPE void zdsp_or_u32(const DSP_DATA uint32_t *src_a, const DSP_DATA u
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_not Vector bitwise NOT
+ * @defgroup math_dsp_basic_not Vector bitwise NOT
  *
  * Compute the logical bitwise NOT.
  *
@@ -819,7 +821,7 @@ DSP_FUNC_SCOPE void zdsp_not_u32(const DSP_DATA uint32_t *src, DSP_DATA uint32_t
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_xor Vector bitwise XOR
+ * @defgroup math_dsp_basic_xor Vector bitwise XOR
  *
  * Compute the logical bitwise XOR.
  *
@@ -863,7 +865,7 @@ DSP_FUNC_SCOPE void zdsp_xor_u32(const DSP_DATA uint32_t *src_a, const DSP_DATA 
 
 /**
  * @ingroup math_dsp_basic
- * @addtogroup math_dsp_basic_clip Vector Clipping
+ * @defgroup math_dsp_basic_clip Vector Clipping
  *
  * Element-by-element clipping of a value.
  *
@@ -916,6 +918,10 @@ DSP_FUNC_SCOPE void zdsp_clip_q15(const DSP_DATA q15_t *src, DSP_DATA q15_t *dst
  */
 DSP_FUNC_SCOPE void zdsp_clip_q7(const DSP_DATA q7_t *src, DSP_DATA q7_t *dst, q7_t low, q7_t high,
 				uint32_t num_samples);
+
+/**
+ * @}
+ */
 
 /**
  * @}

--- a/include/zephyr/dsp/dsp.h
+++ b/include/zephyr/dsp/dsp.h
@@ -30,8 +30,9 @@
 #endif
 
 /**
- * @brief DSP Interface
- * @defgroup math_dsp DSP Interface
+ * @brief Digital Signal Processing (DSP) math functions and utilities.
+ * @defgroup math_dsp DSP (Digital Signal Processing)
+ * @ingroup utilities
  * @since 3.3
  * @version 0.1.0
  */

--- a/include/zephyr/dsp/utils.h
+++ b/include/zephyr/dsp/utils.h
@@ -24,11 +24,15 @@ extern "C" {
 /**
  * @ingroup math_dsp
  * @defgroup math_dsp_utils_shifts Float/Fixed point shift conversion functions
+ *
+ * Convert number representation in Float or Double to/from Q31/Q15/Q7.
+ *
+ * @{
  */
 
 /**
  * @ingroup math_dsp_utils_shifts
- * @addtogroup math_dsp_basic_conv_to_float Fixed to Float point conversions
+ * @defgroup math_dsp_basic_conv_to_float Fixed to Float point conversions
  *
  * Convert number Q7/Q15/Q31 to Float or Double representation with shift.
  *
@@ -96,7 +100,7 @@ extern "C" {
 
 /**
  * @ingroup math_dsp_utils_shifts
- * @addtogroup math_dsp_basic_conv_to_fixed Float to Fixed point conversions
+ * @defgroup math_dsp_basic_conv_to_fixed Float to Fixed point conversions
  *
  * Convert number representation in Float or Double to Q31/Q15/Q7.
  *
@@ -163,6 +167,10 @@ extern "C" {
  */
 #define Z_SHIFT_F64_TO_Q31(src, m)                                                                 \
 	((q31_t)Z_CLAMP((int64_t)(src * (1U << 31)) >> m, INT32_MIN, INT32_MAX))
+
+/**
+ * @}
+ */
 
 /**
  * @}

--- a/include/zephyr/math/ilog2.h
+++ b/include/zephyr/math/ilog2.h
@@ -19,6 +19,13 @@
  */
 
 /**
+ * @defgroup math_ilog2 Math Ilog2 Functions
+ * @ingroup utilities
+ * @brief Integer log2 utilities for mathematical operations
+ * @{
+ */
+
+/**
  *
  * @brief Calculate the floor of log2 for compile time constant
  *
@@ -96,5 +103,9 @@
 		ilog2_compile_time_const_u32(n) :	\
 		find_msb_set(n) - 1			\
 	)
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_MATH_ILOG2_H_ */

--- a/include/zephyr/math/interpolation.h
+++ b/include/zephyr/math/interpolation.h
@@ -20,6 +20,13 @@ extern "C" {
  */
 
 /**
+ * @defgroup math_interpolation Math Interpolation Functions
+ * @ingroup utilities
+ * @brief Linear interpolation utilities for mathematical operations
+ * @{
+ */
+
+/**
  * @brief Perform a linear interpolation across an arbitrary curve
  *
  * @note Result rounding occurs away from 0, e.g:
@@ -67,6 +74,10 @@ static inline int32_t linear_interpolate(const int32_t *x_axis, const int32_t *y
 	/* Apply slope, undo origin shift and round */
 	return roundf(y_axis[idx_low] + (slope * x_shifted));
 }
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixing doxygen for various headers, mainly focusing on adding groups when missing and attaching "rogue" groups to the most appropriate section (vs. e.g. showing up as top level groups for no reason)