### PR TITLE
soc: nordic: nrf53: assign pin xl1,xl2 to app core if lfxo disabled

### DIFF
--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -210,69 +210,6 @@ config BOARD_ENABLE_CPUNET
 
 if !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 
-config SOC_ENABLE_LFXO
-	bool "LFXO"
-	select DEPRECATED
-	help
-	  This option is deprecated, use DT instead. For this option to apply,
-	  make sure to select either "internal" or "external" in the
-	  load-capacitors property.
-
-	  Enable the low-frequency oscillator (LFXO) functionality on XL1 and
-	  XL2 pins.
-	  This option must be enabled if either application or network core is
-	  to use the LFXO. Otherwise, XL1 and XL2 pins will behave as regular
-	  GPIOs.
-
-choice SOC_LFXO_LOAD_CAPACITANCE
-	prompt "LFXO load capacitance"
-	depends on SOC_ENABLE_LFXO
-
-config SOC_LFXO_CAP_EXTERNAL
-	bool "Use external load capacitors"
-	select DEPRECATED
-	help
-	  This option is deprecated, use DT instead. Example configuration:
-
-	  &lfxo {
-	      load-capacitors = "external";
-	  };
-
-config SOC_LFXO_CAP_INT_6PF
-	bool "6 pF internal load capacitance"
-	select DEPRECATED
-	help
-	  This option is deprecated, use DT instead. Example configuration:
-
-	  &lfxo {
-	      load-capacitors = "internal";
-	      load-capacitance-picofarad = <6>;
-	  };
-
-config SOC_LFXO_CAP_INT_7PF
-	bool "7 pF internal load capacitance"
-	select DEPRECATED
-	help
-	  This option is deprecated, use DT instead. Example configuration:
-
-	  &lfxo {
-	      load-capacitors = "internal";
-	      load-capacitance-picofarad = <7>;
-	  };
-
-config SOC_LFXO_CAP_INT_9PF
-	bool "9 pF internal load capacitance"
-	select DEPRECATED
-	help
-	  This option is deprecated, use DT instead. Example configuration:
-
-	  &lfxo {
-	      load-capacitors = "internal";
-	      load-capacitance-picofarad = <9>;
-	  };
-
-endchoice
-
 choice SOC_HFXO_LOAD_CAPACITANCE
 	prompt "HFXO load capacitance"
 	default SOC_HFXO_CAP_DEFAULT


### PR DESCRIPTION
I opened an issue #92663 where disabling LFXO for the nRF53 via devicetree or kconfig does not properly allow the pins from the LFXO (0.00 and 0.01) to be used as GPIO. This adds a few guards against those devicetree and kconfig properties, and if LFXO is disabled by the build configuration, will assign those pins to the nRF53 app core instead.