### PR TITLE
samples: shields: x_nucleo_iks02a1: Remove unused variable

### DIFF
--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -160,10 +160,7 @@ static void ism330dhcx_config(const struct device *ism330dhcx)
 
 int main(void)
 {
-#ifdef CONFIG_ISM330DHCX_ENABLE_TEMP
 	struct sensor_value die_temp;
-#endif
-	struct sensor_value die_temp2;
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
@@ -215,7 +212,7 @@ int main(void)
 
 		sensor_channel_get(iis2dlpc, SENSOR_CHAN_ACCEL_XYZ, accel2);
 		sensor_channel_get(iis2mdc, SENSOR_CHAN_MAGN_XYZ, magn);
-		sensor_channel_get(iis2mdc, SENSOR_CHAN_DIE_TEMP, &die_temp2);
+		sensor_channel_get(iis2mdc, SENSOR_CHAN_DIE_TEMP, &die_temp);
 		sensor_channel_get(ism330dhcx, SENSOR_CHAN_ACCEL_XYZ, accel1);
 		sensor_channel_get(ism330dhcx, SENSOR_CHAN_GYRO_XYZ, gyro);
 
@@ -237,8 +234,7 @@ int main(void)
 		       sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));
 
-		printf("IIS2MDC: Temperature: %.1f C\n",
-		       sensor_value_to_double(&die_temp2));
+		printf("IIS2MDC: Temperature: %.1f C\n", sensor_value_to_double(&die_temp));
 
 		printf("ISM330DHCX: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
 			sensor_value_to_double(&accel1[0]),

--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -13,8 +13,7 @@
 #ifdef CONFIG_IIS2DLPC_TRIGGER
 static int iis2dlpc_trig_cnt;
 
-static void iis2dlpc_trigger_handler(const struct device *dev,
-				     const struct sensor_trigger *trig)
+static void iis2dlpc_trigger_handler(const struct device *dev, const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ACCEL_XYZ);
 	iis2dlpc_trig_cnt++;
@@ -24,8 +23,7 @@ static void iis2dlpc_trigger_handler(const struct device *dev,
 #ifdef CONFIG_IIS2MDC_TRIGGER
 static int iis2mdc_trig_cnt;
 
-static void iis2mdc_trigger_handler(const struct device *dev,
-				    const struct sensor_trigger *trig)
+static void iis2mdc_trigger_handler(const struct device *dev, const struct sensor_trigger *trig)
 {
 	sensor_sample_fetch_chan(dev, SENSOR_CHAN_ALL);
 	iis2mdc_trig_cnt++;
@@ -59,16 +57,16 @@ static void iis2dlpc_config(const struct device *iis2dlpc)
 	odr_attr.val1 = 100;
 	odr_attr.val2 = 0;
 
-	if (sensor_attr_set(iis2dlpc, SENSOR_CHAN_ACCEL_XYZ,
-			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
+	if (sensor_attr_set(iis2dlpc, SENSOR_CHAN_ACCEL_XYZ, SENSOR_ATTR_SAMPLING_FREQUENCY,
+			    &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for IIS2DLPC accel\n");
 		return;
 	}
 
 	sensor_g_to_ms2(16, &fs_attr);
 
-	if (sensor_attr_set(iis2dlpc, SENSOR_CHAN_ACCEL_XYZ,
-			    SENSOR_ATTR_FULL_SCALE, &fs_attr) < 0) {
+	if (sensor_attr_set(iis2dlpc, SENSOR_CHAN_ACCEL_XYZ, SENSOR_ATTR_FULL_SCALE, &fs_attr) <
+	    0) {
 		printk("Cannot set sampling frequency for IIS2DLPC gyro\n");
 		return;
 	}
@@ -90,8 +88,8 @@ static void iis2mdc_config(const struct device *iis2mdc)
 	odr_attr.val1 = 100;
 	odr_attr.val2 = 0;
 
-	if (sensor_attr_set(iis2mdc, SENSOR_CHAN_ALL,
-			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
+	if (sensor_attr_set(iis2mdc, SENSOR_CHAN_ALL, SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) <
+	    0) {
 		printk("Cannot set sampling frequency for IIS2MDC\n");
 		return;
 	}
@@ -113,16 +111,16 @@ static void ism330dhcx_config(const struct device *ism330dhcx)
 	odr_attr.val1 = 416;
 	odr_attr.val2 = 0;
 
-	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_ACCEL_XYZ,
-			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
+	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_ACCEL_XYZ, SENSOR_ATTR_SAMPLING_FREQUENCY,
+			    &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for ISM330DHCX accel\n");
 		return;
 	}
 
 	sensor_g_to_ms2(16, &fs_attr);
 
-	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_ACCEL_XYZ,
-			    SENSOR_ATTR_FULL_SCALE, &fs_attr) < 0) {
+	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_ACCEL_XYZ, SENSOR_ATTR_FULL_SCALE, &fs_attr) <
+	    0) {
 		printk("Cannot set sampling frequency for ISM330DHCX accel\n");
 		return;
 	}
@@ -131,16 +129,16 @@ static void ism330dhcx_config(const struct device *ism330dhcx)
 	odr_attr.val1 = 208;
 	odr_attr.val2 = 0;
 
-	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_GYRO_XYZ,
-			    SENSOR_ATTR_SAMPLING_FREQUENCY, &odr_attr) < 0) {
+	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_GYRO_XYZ, SENSOR_ATTR_SAMPLING_FREQUENCY,
+			    &odr_attr) < 0) {
 		printk("Cannot set sampling frequency for ISM330DHCX gyro\n");
 		return;
 	}
 
 	sensor_degrees_to_rad(250, &fs_attr);
 
-	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_GYRO_XYZ,
-			    SENSOR_ATTR_FULL_SCALE, &fs_attr) < 0) {
+	if (sensor_attr_set(ism330dhcx, SENSOR_CHAN_GYRO_XYZ, SENSOR_ATTR_FULL_SCALE, &fs_attr) <
+	    0) {
 		printk("Cannot set fs for ISM330DHCX gyro\n");
 		return;
 	}
@@ -224,27 +222,23 @@ int main(void)
 		printf("X-NUCLEO-IKS02A1 sensor Mode 1 dashboard\n\n");
 
 		printf("IIS2DLPC: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
-			sensor_value_to_double(&accel2[0]),
-			sensor_value_to_double(&accel2[1]),
-			sensor_value_to_double(&accel2[2]));
+		       sensor_value_to_double(&accel2[0]), sensor_value_to_double(&accel2[1]),
+		       sensor_value_to_double(&accel2[2]));
 
 		/* iis2mdc */
 		printf("IIS2MDC: Magn (gauss): x: %.3f, y: %.3f, z: %.3f\n",
-		       sensor_value_to_double(&magn[0]),
-		       sensor_value_to_double(&magn[1]),
+		       sensor_value_to_double(&magn[0]), sensor_value_to_double(&magn[1]),
 		       sensor_value_to_double(&magn[2]));
 
 		printf("IIS2MDC: Temperature: %.1f C\n", sensor_value_to_double(&die_temp));
 
 		printf("ISM330DHCX: Accel (m.s-2): x: %.3f, y: %.3f, z: %.3f\n",
-			sensor_value_to_double(&accel1[0]),
-			sensor_value_to_double(&accel1[1]),
-			sensor_value_to_double(&accel1[2]));
+		       sensor_value_to_double(&accel1[0]), sensor_value_to_double(&accel1[1]),
+		       sensor_value_to_double(&accel1[2]));
 
 		printf("ISM330DHCX: GYro (dps): x: %.3f, y: %.3f, z: %.3f\n",
-			sensor_value_to_double(&gyro[0]),
-			sensor_value_to_double(&gyro[1]),
-			sensor_value_to_double(&gyro[2]));
+		       sensor_value_to_double(&gyro[0]), sensor_value_to_double(&gyro[1]),
+		       sensor_value_to_double(&gyro[2]));
 #ifdef CONFIG_IIS2DLPC_TRIGGER
 		printk("%d:: iis2dlpc trig %d\n", cnt, iis2dlpc_trig_cnt);
 #endif
@@ -257,7 +251,6 @@ int main(void)
 		printk("%d:: ism330dhcx acc trig %d\n", cnt, ism330dhcx_acc_trig_cnt);
 		printk("%d:: ism330dhcx gyr trig %d\n", cnt, ism330dhcx_gyr_trig_cnt);
 #endif
-
 
 		cnt++;
 		k_sleep(K_MSEC(2000));


### PR DESCRIPTION
Remove unused variable in shields sample x_nucleo_iks02a1, then rename the `die_temp2` variable to `die_temp`.
Run also clang-format on file.