### PR TITLE
drivers: mdio_nxp_enet_qos: fix CR overwrite

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -393,6 +393,10 @@ static void eth_nxp_enet_qos_phy_cb(const struct device *phy,
 
 static inline int enet_qos_dma_reset(enet_qos_t *base)
 {
+	/* Save off ENET->MAC_MDIO_ADDRESS: CR Field Prior to Reset */
+	int cr = 0;
+
+	cr = ENET_QOS_REG_GET(MAC_MDIO_ADDRESS, CR, base->MAC_MDIO_ADDRESS);
 	/* Set the software reset of the DMA */
 	base->DMA_MODE |= ENET_QOS_REG_PREP(DMA_MODE, SWR, 0b1);
 
@@ -426,6 +430,7 @@ static inline int enet_qos_dma_reset(enet_qos_t *base)
 	return -EIO;
 
 done:
+	base->MAC_MDIO_ADDRESS = ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, CR, cr);
 	return 0;
 }
 

--- a/drivers/mdio/mdio_nxp_enet_qos.c
+++ b/drivers/mdio/mdio_nxp_enet_qos.c
@@ -63,8 +63,13 @@ static int do_transaction(struct mdio_transaction *mdio)
 		ret = -EINVAL;
 		goto done;
 	}
+	base->MAC_MDIO_ADDRESS &= ~(
+		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, GOC_1, 0b1) |
+		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, GOC_0, 0b1) |
+		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, PA, 0b11111) |
+		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, RDA, 0b11111));
 
-	base->MAC_MDIO_ADDRESS =
+	base->MAC_MDIO_ADDRESS |=
 		/* OP command */
 		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, GOC_1, goc_1_code) |
 		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, GOC_0, 0b1) |
@@ -73,7 +78,7 @@ static int do_transaction(struct mdio_transaction *mdio)
 		/* Register address */
 		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, RDA, mdio->regaddr);
 
-	base->MAC_MDIO_ADDRESS =
+	base->MAC_MDIO_ADDRESS |=
 		/* Start the transaction */
 		ENET_QOS_REG_PREP(MAC_MDIO_ADDRESS, GB, 0b1);
 


### PR DESCRIPTION
Current Implementation to write to MAC_MDIO_ADDRESS causes CR to be set to 0. This leads to the divide always being 42 (on FRDM_MCXN947) so, by default the clock is running at ~3.6MHz which is out of spec range (1.0-2.5MHz)

This change modifies the writes to MAC_MDIO_ADDRESS to use only modify the fields associated with this function.