### PR TITLE
scripts: ci: Extend Kconfig check to current path

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -902,6 +902,11 @@ Found disallowed Kconfig symbol in SoC Kconfig files: {sym_name:35}
         grep_stdout = git("grep", "-I", "-h", "--perl-regexp", regex, "--",
                           ":samples", ":tests", cwd=ZEPHYR_BASE)
 
+        # Grep for symbol definitions in samples/ and tests/ located at the
+        # current path
+        grep_stdout += git("grep", "-I", "-h", "--perl-regexp", regex, "--",
+                          ":samples", ":tests", cwd=os.getcwd())
+
         # Generate combined list of configs and choices from the main Kconfig tree.
         kconf_syms = kconf.unique_defined_syms + kconf.unique_choices
 


### PR DESCRIPTION
The check_no_undef_outside_kconfig CI test previously only considered Kconfig definitions under ZEPHYR_BASE/samples and ZEPHYR_BASE/tests.

This PR extends the grep logic to also include samples/ and tests/ directories located relative to the execution path. This enables Kconfig checks to work properly for out-of-tree projects and modules that define their own sample and test folders.