### PR TITLE
samples: bluetooth: cap_acceptor: cap_initiator: Fix shadowed variable

### DIFF
--- a/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
+++ b/samples/bluetooth/cap_acceptor/src/cap_acceptor_broadcast.c
@@ -529,7 +529,6 @@ static void bap_pa_sync_synced_cb(struct bt_le_per_adv_sync *sync,
 		atomic_clear_bit(flags, FLAG_PA_SYNCING);
 
 		if (IS_ENABLED(CONFIG_SAMPLE_SCAN_SELF)) {
-			int err;
 
 			err = bt_le_scan_stop();
 			if (err != 0) {

--- a/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
+++ b/samples/bluetooth/cap_initiator/src/cap_initiator_unicast.c
@@ -786,7 +786,6 @@ static int reset_cap_initiator(void)
 	}
 
 	if (unicast_group != NULL) {
-		int err;
 
 		err = unicast_group_delete();
 		if (err != 0) {


### PR DESCRIPTION
Avoid redeclaring 'err' inside a nested block, which shadowed the outer
definition.

This cleanup prevents confusion and potential logical bugs.