### PR TITLE
soc: stm32f1x: fix typo/debug in stop/standby modes

### DIFF
--- a/soc/st/stm32/common/soc_config.c
+++ b/soc/st/stm32/common/soc_config.c
@@ -69,7 +69,7 @@ static int st_stm32_common_config(void)
 
 #if defined(CONFIG_STM32_ENABLE_DEBUG_SLEEP_STOP)
 
-#if defined(SOC_SERIES_STM32F1X)
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
 	LL_DBGMCU_EnableDBGSleepMode();
 	LL_DBGMCU_EnableDBGStopMode();
 	LL_DBGMCU_EnableDBGStandbyMode();
@@ -89,7 +89,7 @@ static int st_stm32_common_config(void)
 #else
 
 /* keeping in mind that debugging draws a lot of power we explcitly disable when not needed */
-#if defined(SOC_SERIES_STM32F1X)
+#if defined(CONFIG_SOC_SERIES_STM32F1X)
 	LL_DBGMCU_DisableDBGSleepMode();
 	LL_DBGMCU_DisableDBGStopMode();
 	LL_DBGMCU_DisableDBGStandbyMode();


### PR DESCRIPTION
Check for STM32F1 series was done with "#ifdef SOC_SERIES_STM32F1X" but this symbol comes from Kconfig.

Use the correct "CONFIG_SOC_SERIES_STM32F1X" instead.