### PR TITLE
stm32: drivers: pwm:  update code with stm32h7rs apb1/2 bus prescalers 

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -247,6 +247,8 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 	if (pclken->bus == STM32_CLOCK_BUS_APB1) {
 #if defined(CONFIG_SOC_SERIES_STM32MP1X)
 		apb_psc = (uint32_t)(READ_BIT(RCC->APB1DIVR, RCC_APB1DIVR_APB1DIV));
+#elif defined(CONFIG_SOC_SERIES_STM32H7RSX)
+		apb_psc = STM32_PPRE1;
 #else
 		apb_psc = STM32_APB1_PRESCALER;
 #endif
@@ -256,6 +258,8 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 	else {
 #if defined(CONFIG_SOC_SERIES_STM32MP1X)
 		apb_psc = (uint32_t)(READ_BIT(RCC->APB2DIVR, RCC_APB2DIVR_APB2DIV));
+#elif defined(CONFIG_SOC_SERIES_STM32H7RSX)
+		apb_psc = STM32_PPRE2;
 #else
 		apb_psc = STM32_APB2_PRESCALER;
 #endif


### PR DESCRIPTION
The clock tree of the STM32H7RS series uses the ppre1 and ppre2 naming conventions instead of apb1_prescaler and apb2_prescaler for bus prescalers.

These changes fix build failure encountered when you run:
` west build -p -b stm32h7s78_dk/stm32h7s7xx tests/drivers/build_all/led -T drivers.led.build`
 
```
error: 'DT_N_S_soc_S_rcc_58024400_P_apb1_prescaler' undeclared (first use in this function);
...
../zephyrproject/zephyr/drivers/pwm/pwm_stm32.c:251:27: note: in expansion of macro 'STM32_APB1_PRESCALER'
  251 |                 apb_psc = STM32_APB1_PRESCALER;
      |                           ^~~~~~~~~~~~~~~~~~~~
     
     ...
      
 ../zephyrproject/zephyr/drivers/pwm/pwm_stm32.c:260:27: note: in expansion of macro 'STM32_APB2_PRESCALER'
  260 |                 apb_psc = STM32_APB2_PRESCALER;
      |                           ^~~~~~~~~~~~~~~~~~~~
```

Issue introduced by this commit https://github.com/zephyrproject-rtos/zephyr/commit/aeb0c0aec18866edb74c89b101dc9f51d616db1b 