### PR TITLE
shell: mqtt: use topic levels

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -146,6 +146,16 @@ Logging
   used. The new script supports the same functionality (and more), but requires different command
   line arguments when invoked.
 
+Shell
+=====
+
+* The MQTT topics related to :kconfig:option:`SHELL_BACKEND_MQTT` have been renamed. Renamed
+  ``<device_id>_rx`` to ``<device_id>/sh/rx`` and ``<device_id>_tx`` to ``<device_id>/sh/rx``. The
+  part after the ``<device_id>`` is now configurable via :kconfig:option:`SHELL_MQTT_TOPIC_RX_ID`
+  and :kconfig:option:`SHELL_MQTT_TOPIC_TX_ID`. This allows keeping the previous topics for backward
+  compatibility.
+  (:github:`92677`).
+
 .. zephyr-keep-sorted-stop
 
 Modules

--- a/include/zephyr/shell/shell_mqtt.h
+++ b/include/zephyr/shell/shell_mqtt.h
@@ -25,7 +25,8 @@ extern "C" {
 #define SH_MQTT_BUFFER_SIZE 64
 #define DEVICE_ID_BIN_MAX_SIZE 3
 #define DEVICE_ID_HEX_MAX_SIZE ((DEVICE_ID_BIN_MAX_SIZE * 2) + 1)
-#define SH_MQTT_TOPIC_MAX_SIZE DEVICE_ID_HEX_MAX_SIZE + 3
+#define SH_MQTT_TOPIC_RX_MAX_SIZE DEVICE_ID_HEX_MAX_SIZE + sizeof(CONFIG_SHELL_MQTT_TOPIC_RX_ID)
+#define SH_MQTT_TOPIC_TX_MAX_SIZE DEVICE_ID_HEX_MAX_SIZE + sizeof(CONFIG_SHELL_MQTT_TOPIC_TX_ID)
 
 extern const struct shell_transport_api shell_mqtt_transport_api;
 
@@ -40,8 +41,8 @@ struct shell_mqtt_tx_buf {
 /** MQTT-based shell transport. */
 struct shell_mqtt {
 	char device_id[DEVICE_ID_HEX_MAX_SIZE];
-	char sub_topic[SH_MQTT_TOPIC_MAX_SIZE];
-	char pub_topic[SH_MQTT_TOPIC_MAX_SIZE];
+	char sub_topic[SH_MQTT_TOPIC_RX_MAX_SIZE];
+	char pub_topic[SH_MQTT_TOPIC_TX_MAX_SIZE];
 
 	/** Handler function registered by shell. */
 	shell_transport_handler_t shell_handler;

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -288,8 +288,7 @@ config SHELL_BACKEND_MQTT
 	select DNS_RESOLVER
 	select HWINFO
 	select MQTT_LIB
-	select NET_MGMT
-	select NET_MGMT_EVENT
+	select NET_CONNECTION_MANAGER
 	help
 	  Enable MQTT backend.
 

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -348,6 +348,18 @@ config SHELL_MQTT_LISTEN_TIMEOUT_MS
 	help
 	  Time to listen for incoming packets in milliseconds.
 
+config SHELL_MQTT_TOPIC_RX_ID
+	string "MQTT topic receive identifier"
+	default "/sh/rx"
+	help
+	  String used as receive identifier in the MQTT topic.
+
+config SHELL_MQTT_TOPIC_TX_ID
+	string "MQTT topic transmit identifier"
+	default "/sh/tx"
+	help
+	  String used as transmit identifier in the MQTT topic.
+
 module = SHELL_BACKEND_MQTT
 default-timeout = 100
 source "subsys/shell/Kconfig.template.shell_log_queue_timeout"

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -657,8 +657,10 @@ static int init(const struct shell_transport *transport, const void *config,
 
 	LOG_DBG("Client ID is %s", sh->device_id);
 
-	(void)snprintf(sh->pub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_tx", sh->device_id);
-	(void)snprintf(sh->sub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_rx", sh->device_id);
+	(void)snprintf(sh->pub_topic, SH_MQTT_TOPIC_TX_MAX_SIZE, "%s" CONFIG_SHELL_MQTT_TOPIC_TX_ID,
+		       sh->device_id);
+	(void)snprintf(sh->sub_topic, SH_MQTT_TOPIC_RX_MAX_SIZE, "%s" CONFIG_SHELL_MQTT_TOPIC_RX_ID,
+		       sh->device_id);
 
 	ring_buf_init(&sh->rx_rb, RX_RB_SIZE, sh->rx_rb_buf);
 


### PR DESCRIPTION
Change topic from <device_id>_rx (and tx) to <device_id>/sh/rx.

This allows use of wildcards. E.g. subscribe to all devices "+/sh/tx".

Level "sh" is added to the topic to make it less generic and prevent potential clashes with other topics.