### PR TITLE
tests: fix: limit platforms in boot.with_mcumgr.test_upgrade_ble

### DIFF
--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -25,6 +25,9 @@ tests:
   boot.with_mcumgr.test_upgrade_ble:
     platform_allow:
       - nrf52840dk/nrf52840
+    platform_exclude:
+      - nrf9160dk/nrf9160
+      - nucleo_wba55cg
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: EXTRA_CONF_FILE="overlay-bt.conf"


### PR DESCRIPTION
Missed in #91596 that more platforms are added in common part. Excluded nrf9160dk/nrf9160 and nucleo_wba55cg from configuration with BLE.