### PR TITLE
MAINTAINERS: exclude Wi-Fi related drivers from nRF Platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4118,6 +4118,9 @@ nRF Platforms:
     - tests/drivers/*/*nrf*/
     - snippets/nordic*/
     - tests/boards/nrf/
+  files-exclude:
+    - drivers/wifi/nrf_wifi/
+    - dts/bindings/wifi/
   labels:
     - "platform: nRF"
 


### PR DESCRIPTION
Separate entry (see `Drivers: Wi-Fi as nRF Wi-Fi`) handles Wi-Fi related reviews. Add files-exclude to decrease noise.