### PR TITLE
driver: spi: `spi_release()` implementations requires an owner check

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -733,6 +733,12 @@ static int spi_nrfx_release(const struct device *dev,
 {
 	struct spi_nrfx_data *dev_data = dev->data;
 
+#ifdef CONFIG_MULTITHREADING
+	if (dev_data->ctx.owner != spi_cfg) {
+		return -EALREADY;
+	}
+#endif
+
 	if (!spi_context_configured(&dev_data->ctx, spi_cfg)) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
Without this check, `spi_context_unlock_unconditionally()` is capable to release the SPI bus semaphore (ctx->lock) which might be taken by an other SPI slave device in the meantime.

Actually, this race condition happens when `spi_release()` is called when the SPI slave device in question (spi_cfg) has already released its chip select and also the SPI bus lock semaphore.

So, any not required call of `spi_release()` may result in a SPI communication issue where the SPI bus lock, hold by an other SPI slave device,  is prematurely released.
The observable result is the simultaneous engagement of two SPI chip selects after such a SPI release call.

Note: this PR fixes my issue with a Nordic SPI master. As far as I have seen, most vendor implementations have this issue.