### PR TITLE
shell: add app version command

### DIFF
--- a/doc/build/version/index.rst
+++ b/doc/build/version/index.rst
@@ -12,6 +12,7 @@ multiple scopes, including:
 * Code (C/C++)
 * Kconfig
 * CMake
+* Shell
 
 which makes it a very versatile system for lifecycle management of applications. In addition, it
 can be used when building applications which target supported bootloaders (e.g. MCUboot) allowing
@@ -195,3 +196,18 @@ Use in MCUboot-supported applications
 No additional configuration needs to be done to the target application so long as it is configured
 to support MCUboot and a signed image is generated, the version information will be automatically
 included in the image data.
+
+Use in Shell
+============
+
+When a shell interface is configured, the following commands are available to retrieve application version information:
+
++----------------------+-----------------------------+-------------------------+
+| Command              | Variable                    | Example                 |
++----------------------+-----------------------------+-------------------------+
+| app version          | APP_VERSION_STRING          | 1.2.3-unstable.5        |
++----------------------+-----------------------------+-------------------------+
+| app version-extended | APP_VERSION_EXTENDED_STRING | 1.2.3-unstable.5+4      |
++----------------------+-----------------------------+-------------------------+
+| app build-version    | APP_BUILD_VERSION           | v3.3.0-18-g2c85d9224fca |
++----------------------+-----------------------------+-------------------------+

--- a/subsys/shell/modules/CMakeLists.txt
+++ b/subsys/shell/modules/CMakeLists.txt
@@ -16,3 +16,7 @@ zephyr_sources_ifdef(
   CONFIG_DEVMEM_SHELL
   devmem_service.c
   )
+zephyr_sources_ifdef(
+  CONFIG_APP_VERSION_SHELL
+  app_version_service.c
+  )

--- a/subsys/shell/modules/Kconfig
+++ b/subsys/shell/modules/Kconfig
@@ -22,4 +22,11 @@ config DEVMEM_SHELL
 	help
 	  This shell command provides read/write access to physical memory.
 
+config APP_VERSION_SHELL
+	bool "Application version information shell"
+	default y if !SHELL_MINIMAL
+	depends on "$(APP_VERSION_EXTENDED_STRING)" != ""
+	help
+	  This shell command provides read access to application version information.
+
 rsource "kernel_service/Kconfig"

--- a/subsys/shell/modules/app_version_service.c
+++ b/subsys/shell/modules/app_version_service.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Alex Fabre
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app_version.h"
+#include <zephyr/shell/shell.h>
+
+static int cmd_app_version_string(const struct shell *sh)
+{
+	shell_print(sh, APP_VERSION_STRING);
+	return 0;
+}
+
+static int cmd_app_version_extended_string(const struct shell *sh)
+{
+	shell_print(sh, APP_VERSION_EXTENDED_STRING);
+	return 0;
+}
+
+static int cmd_app_build_version(const struct shell *sh)
+{
+	shell_print(sh, STRINGIFY(APP_BUILD_VERSION));
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_app,
+	SHELL_CMD(version, NULL, "Application version. (ex. \"1.2.3-unstable.5\")",
+		  cmd_app_version_string),
+	SHELL_CMD(version - extended, NULL,
+		  "Application version extended. (ex. \"1.2.3-unstable.5+4\")",
+		  cmd_app_version_extended_string),
+	SHELL_CMD(build - version, NULL,
+		  "Application build version. (ex. \"v3.3.0-18-g2c85d9224fca\")",
+		  cmd_app_build_version),
+	SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+
+SHELL_CMD_REGISTER(app, &sub_app, "Application version information commands", NULL);


### PR DESCRIPTION
This commit brings a shell command to retreive the following application version information:

- APP_VERSION_STRING
- APP_VERSION_EXTENDED_STRING
- APP_BUILD_VERSION

Exemple: 
```shell
$app version
1.2.3-unstable.5

$app version-extended
1.2.3-unstable.5+4

$app build-version
v3.3.0-18-g2c85d9224fca
```


