### PR TITLE
toolchain: linker: Make heap pool size available to linkers

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -190,6 +190,9 @@ if(${CONFIG_KERNEL_MEM_POOL})
   endif()
 
   zephyr_compile_definitions(K_HEAP_MEM_POOL_SIZE=${final_heap_size})
+  set_linker_property(TARGET linker PROPERTY heap_mem_pool_size
+                      ${final_heap_size}
+  )
 endif()
 
 # The last 2 files inside the target_sources_ifdef should be


### PR DESCRIPTION
Setting a target linker property heap_mem_pool_size to contain the calculated heap size so tool chains with separate linker also has access to the information. IAR need this info to allocate the heap correctly.