### PR TITLE
soc: riscv: Remove redundant __soc_is_irq implementations

### DIFF
--- a/soc/sensry/ganymed/sy1xx/Kconfig.defconfig
+++ b/soc/sensry/ganymed/sy1xx/Kconfig.defconfig
@@ -61,9 +61,6 @@ config USE_DT_CODE_PARTITION
 config RISCV_SOC_HAS_CUSTOM_IRQ_LOCK_OPS
 	default n
 
-config RISCV_SOC_EXCEPTION_FROM_IRQ
-	default y
-
 config INIT_STACKS
 	default y
 

--- a/soc/sensry/ganymed/sy1xx/common/crt0.S
+++ b/soc/sensry/ganymed/sy1xx/common/crt0.S
@@ -26,12 +26,6 @@ __prestart_routine:
     /* Call into Zephyr initialization. */
     jal x0, __start
 
-GTEXT(__soc_is_irq)
-SECTION_FUNC(exception.other, __soc_is_irq)
-	csrr a0, mcause
-	srli a0, a0, 31
-	ret
-
 GTEXT(__soc_handle_irq)
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	## clear pending interrupt

--- a/soc/wch/ch32v/ch32v00x/soc_irq.S
+++ b/soc/wch/ch32v/ch32v00x/soc_irq.S
@@ -8,13 +8,7 @@
 #include <zephyr/toolchain.h>
 
 /* Exports */
-GTEXT(__soc_is_irq)
 GTEXT(__soc_handle_irq)
-
-SECTION_FUNC(exception.other, __soc_is_irq)
-	csrr a0, mcause
-	srli a0, a0, 31
-	ret
 
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	ret

--- a/soc/wch/ch32v/qingke_v2a/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v2a/soc_irq.S
@@ -7,13 +7,7 @@
 #include <zephyr/toolchain.h>
 
 /* Exports */
-GTEXT(__soc_is_irq)
 GTEXT(__soc_handle_irq)
-
-SECTION_FUNC(exception.other, __soc_is_irq)
-	csrr a0, mcause
-	srli a0, a0, 31
-	ret
 
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	ret

--- a/soc/wch/ch32v/qingke_v4b/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v4b/soc_irq.S
@@ -7,13 +7,7 @@
 #include <zephyr/toolchain.h>
 
 /* Exports */
-GTEXT(__soc_is_irq)
 GTEXT(__soc_handle_irq)
-
-SECTION_FUNC(exception.other, __soc_is_irq)
-	csrr a0, mcause
-	srli a0, a0, 31
-	ret
 
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	ret

--- a/soc/wch/ch32v/qingke_v4c/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v4c/soc_irq.S
@@ -7,13 +7,7 @@
 #include <zephyr/toolchain.h>
 
 /* Exports */
-GTEXT(__soc_is_irq)
 GTEXT(__soc_handle_irq)
-
-SECTION_FUNC(exception.other, __soc_is_irq)
-	csrr a0, mcause
-	srli a0, a0, 31
-	ret
 
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	ret

--- a/soc/wch/ch32v/qingke_v4f/soc_irq.S
+++ b/soc/wch/ch32v/qingke_v4f/soc_irq.S
@@ -7,13 +7,7 @@
 #include <zephyr/toolchain.h>
 
 /* Exports */
-GTEXT(__soc_is_irq)
 GTEXT(__soc_handle_irq)
-
-SECTION_FUNC(exception.other, __soc_is_irq)
-	csrr a0, mcause
-	srli a0, a0, 31
-	ret
 
 SECTION_FUNC(exception.other, __soc_handle_irq)
 	ret


### PR DESCRIPTION
Remove __soc_is_irq from WCH, Bouffalolab, and Sensry Ganymed SoCs.

- For WCH and Bouffalolab SoCs, CONFIG_RISCV_SOC_EXCEPTION_FROM_IRQ is
  not enabled, so the function is never used. In both cases, the
  implementation matches the default fallback (though the Bouffalolab
  version is more complex).

- For Sensry Ganymed (SY1xx), the config is enabled, but the function's
  logic is identical to the default fallback, making it redundant.

I only tested with a WCH SoC (ch32v303), but for bouffalobab the code was dead and for ganymed SoCs the behaviour should be the exact same.