### PR TITLE
soc: nordic: ironside: Fix bleeding config

### DIFF
--- a/soc/nordic/CMakeLists.txt
+++ b/soc/nordic/CMakeLists.txt
@@ -47,4 +47,4 @@ endif()
 
 add_subdirectory(${SOC_SERIES})
 add_subdirectory(common)
-add_subdirectory(ironside)
+add_subdirectory_ifdef(CONFIG_NRF_IRONSIDE ironside)

--- a/soc/nordic/ironside/CMakeLists.txt
+++ b/soc/nordic/ironside/CMakeLists.txt
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(include)
-
 zephyr_library()
-
 zephyr_library_sources_ifdef(CONFIG_NRF_IRONSIDE_CALL call.c)
-
 zephyr_library_sources_ifdef(CONFIG_NRF_IRONSIDE_BOOT_REPORT boot_report.c)
 zephyr_library_sources_ifdef(CONFIG_NRF_IRONSIDE_CPUCONF_SERVICE cpuconf.c)
 zephyr_library_sources_ifdef(CONFIG_NRF_IRONSIDE_UPDATE_SERVICE update.c)

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -22,7 +22,10 @@
 #include <soc/nrfx_coredep.h>
 #include <soc_lrcconf.h>
 #include <dmm.h>
+
+#if defined(CONFIG_SOC_NRF54H20_CPURAD_ENABLE)
 #include <nrf_ironside/cpuconf.h>
+#endif
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 


### PR DESCRIPTION
Fixes generating a library for devices that do not need it which gives a cmake warning