### PR TITLE
tests: bsim: bluetooth: audio: Remove shadowed variable

### DIFF
--- a/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
+++ b/tests/bsim/bluetooth/audio/src/gmap_ugg_test.c
@@ -759,7 +759,7 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 			 * location bit accordingly
 			 */
 			if (param->conn_cnt > 1U || param->snk_cnt[i] > 1U) {
-				const int err = bt_audio_codec_cfg_set_chan_allocation(
+				err = bt_audio_codec_cfg_set_chan_allocation(
 					stream_param->codec_cfg, (enum bt_audio_location)BIT(i));
 
 				if (err < 0) {
@@ -785,7 +785,7 @@ static int gmap_ac_cap_unicast_start(const struct gmap_unicast_ac_param *param,
 			 * location bit accordingly
 			 */
 			if (param->conn_cnt > 1U || param->src_cnt[i] > 1U) {
-				const int err = bt_audio_codec_cfg_set_chan_allocation(
+				err = bt_audio_codec_cfg_set_chan_allocation(
 					stream_param->codec_cfg, (enum bt_audio_location)BIT(i));
 
 				if (err < 0) {


### PR DESCRIPTION
Avoids shadowing the outer 'err' variable by reusing it instead of redeclaring a new one inside conditional blocks.

This improves clarity and prevents confusion during debugging.