### PR TITLE
samples: drivers: i2s: i2s_codec: Remove shadowed variable

### DIFF
--- a/samples/drivers/i2s/i2s_codec/src/main.c
+++ b/samples/drivers/i2s/i2s_codec/src/main.c
@@ -166,7 +166,6 @@ int main(void)
 		while (1) {
 			void *mem_block;
 			uint32_t block_size = BLOCK_SIZE;
-			int ret;
 			int i;
 
 			for (i = 0; i < 2; i++) {


### PR DESCRIPTION
Avoids shadowing the outer 'ret' variable by reusing it instead of redeclaring it inside a conditional block.

This improves code clarity.