### PR TITLE
drivers: counter: Remove redundant alarm_cfg null check

### DIFF
--- a/drivers/counter/counter_renesas_rz_gtm.c
+++ b/drivers/counter/counter_renesas_rz_gtm.c
@@ -198,9 +198,6 @@ static int counter_rz_gtm_set_alarm(const struct device *dev, uint8_t chan,
 	uint32_t now, diff;
 	int err = 0;
 
-	if (!alarm_cfg) {
-		return -EINVAL;
-	}
 	/* Alarm callback is mandatory */
 	if (!alarm_cfg->callback) {
 		return -EINVAL;


### PR DESCRIPTION
Moved the null check for 'alarm_cfg' before accessing its fields to avoid undefined behavior in case of NULL.