### PR TITLE
boards: renesas: ek_ra8m1: added mikrobus spi node label

### DIFF
--- a/boards/renesas/ek_ra8m1/ek_ra8m1.dts
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.dts
@@ -300,6 +300,7 @@
 };
 
 mikrobus_serial: &uart3 {};
+mikrobus_spi: &spi1 {};
 
 &iic1 {
 	#address-cells = <1>;


### PR DESCRIPTION
Added mikrobus_spi node label to EK-RA8M1 device tree board definition, allowing compatible shield boards to be used.