### PR TITLE
drivers: lora: rylrxxx: fix `snprintf` usage

### DIFF
--- a/drivers/lora/rylrxxx.c
+++ b/drivers/lora/rylrxxx.c
@@ -172,7 +172,7 @@ static void on_rx(struct modem_chat *chat, char **argv, uint16_t argc, void *use
 
 	if (RYLR_IS_RX_PENDING(driver_data->pending_async_flags)) {
 		driver_data->async_rx_cb(driver_data->dev, msg.data, msg.length, msg.rssi, msg.snr,
-					     driver_data->async_user_data);
+					 driver_data->async_user_data);
 	} else {
 		err = k_msgq_put(&driver_data->rx_msgq, &msg, K_NO_WAIT);
 		if (err != 0) {
@@ -390,13 +390,15 @@ int rylr_send(const struct device *dev, uint8_t *payload, uint32_t payload_len)
 		goto exit;
 	}
 
-	if (cmd_len > CONFIG_LORA_RYLRXX_CMD_BUF_SIZE) {
+	/* snprintf requires an extra byte for the terminating NULL */
+	if (cmd_len > (CONFIG_LORA_RYLRXX_CMD_BUF_SIZE - 1)) {
 		LOG_ERR("payload too long");
 		err = -EINVAL;
 		goto exit;
 	}
 
-	snprintf(data->cmd_buffer, cmd_len + 1, RYLR_CMD_SEND_FORMAT, payload_len, payload);
+	snprintf(data->cmd_buffer, sizeof(data->cmd_buffer), RYLR_CMD_SEND_FORMAT, payload_len,
+		 payload);
 	data->curr_cmd_len = cmd_len;
 	err = rylr_send_cmd_buffer(dev);
 	if (err != 0) {
@@ -437,7 +439,8 @@ int rylr_send_async(const struct device *dev, uint8_t *payload, uint32_t payload
 	}
 
 	cmd_len = RYLR_CMD_SEND_LENGTH(payload_len);
-	if (cmd_len > CONFIG_LORA_RYLRXX_CMD_BUF_SIZE) {
+	/* snprintf requires an extra byte for the terminating NULL */
+	if (cmd_len > (CONFIG_LORA_RYLRXX_CMD_BUF_SIZE - 1)) {
 		LOG_ERR("payload too long");
 		err = -EINVAL;
 		goto bail;
@@ -450,8 +453,8 @@ int rylr_send_async(const struct device *dev, uint8_t *payload, uint32_t payload
 	}
 
 	data->async_tx_signal = async;
-	data->curr_cmd_len =
-		snprintf(data->cmd_buffer, cmd_len + 1, RYLR_CMD_SEND_FORMAT, payload_len, payload);
+	data->curr_cmd_len = snprintf(data->cmd_buffer, sizeof(data->cmd_buffer),
+				      RYLR_CMD_SEND_FORMAT, payload_len, payload);
 	rylr_reset_dynamic_script(data);
 	data->dynamic_chat.request = data->cmd_buffer;
 	data->dynamic_chat.request_size = data->curr_cmd_len;


### PR DESCRIPTION
The second argument should unconditionally be the size of the output memory area, not computationally derived from the input payload length. The previous length validations would be incorrect when `cmd_len == CONFIG_LORA_RYLRXX_CMD_BUF_SIZE`, as `snprintf` would be told the output buffer was `CONFIG_LORA_RYLRXX_CMD_BUF_SIZE + 1` bytes long.

Fixes #92619
Fixes #92624