### PR TITLE
docs: raspberrrypi: rpi_pico: Fix broken RP2040 datasheet link

### DIFF
--- a/boards/raspberrypi/rpi_pico/doc/index.rst
+++ b/boards/raspberrypi/rpi_pico/doc/index.rst
@@ -4,7 +4,7 @@ Overview
 ********
 
 The `Raspberry Pi Pico`_ and Pico W are small, low-cost, versatile boards from
-Raspberry Pi. They are equipped with an `RP2040 <RP2040_Datasheet>`_ SoC, an on-board LED,
+Raspberry Pi. They are equipped with an `RP2040 <RP2040 Datasheet_>`_ SoC, an on-board LED,
 a USB connector, and an SWD interface.
 
 The Pico W additionally contains an `Infineon CYW43439`_ 2.4 GHz Wi-Fi/Bluetooth module.


### PR DESCRIPTION
The RP2040 datasheet link (`RP2040_Datasheet`) in the rpi_pico board documentation was broken.

Since other boards do not include direct links to datasheets, and this one was not maintained, the reference was simply removed for consistency and clarity.

Fix https://github.com/zephyrproject-rtos/zephyr/issues/92711