### PR TITLE
tests: net: socket: getaddrinfo: Remove unused assignment

### DIFF
--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -63,7 +63,6 @@ static bool check_dns_query(uint8_t *buf, int buf_len)
 	 */
 	result = net_buf_alloc(&test_dns_msg_pool, K_FOREVER);
 	if (!result) {
-		ret = -ENOMEM;
 		return false;
 	}
 


### PR DESCRIPTION
In check_dns_query(), the assignment `ret = -ENOMEM` was never used since the function returns false immediately afterward.