### PR TITLE
net: l2: ieee802154: shell: fix scan argc validation

### DIFF
--- a/subsys/net/l2/ieee802154/ieee802154_shell.c
+++ b/subsys/net/l2/ieee802154/ieee802154_shell.c
@@ -227,7 +227,7 @@ static int cmd_ieee802154_scan(const struct shell *sh,
 	uint64_t scan_type;
 	int ret = 0;
 
-	if (argc < 3) {
+	if (argc < 4) {
 		shell_help(sh);
 		return -ENOEXEC;
 	}


### PR DESCRIPTION
Bump the argc check from 3 to 4 as the shell scan command has 3 required parameters, the last being the scan duration:
- argv[0]
- passive|active
- channels
- per-channel duration in ms