### PR TITLE
boards: phytec: reel board: update repo link to DAPLink fw

### DIFF
--- a/boards/phytec/reel_board/doc/index.rst
+++ b/boards/phytec/reel_board/doc/index.rst
@@ -563,4 +563,4 @@ References
    https://www.phytec.de/reelboard/
 
 .. _DAPLink reel board Firmware:
-   https://github.com/PHYTEC-Messtechnik-GmbH/DAPLink/tree/reel-board
+   https://github.com/phytec/DAPLink/tree/reel-board


### PR DESCRIPTION
This commit updates the link to the source of the firmware of the DAPLink on-board debug adapter.

Phytec migrates all repositories from the "PHYTEC-Messtechnik-GmbH" GitHub organization to the "phytec" GitHub organization. The code in the relevant branch remains unchanged and the branch has been pushed to the new organization.