### PR TITLE
tests: net: socket: net_mgmt: mark unused function argument

### DIFF
--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -87,6 +87,7 @@ static int eth_fake_send(const struct device *dev,
 
 static int eth_fake_get_total_bandwidth(struct eth_fake_context *ctx)
 {
+	ARG_UNUSED(ctx);
 	return 100 * 1000 * 1000 / 8;
 }
 
@@ -221,6 +222,7 @@ static int eth_fake_get_config(const struct device *dev,
 
 static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
 {
+	ARG_UNUSED(dev);
 	return ETHERNET_LINK_10BASE | ETHERNET_LINK_100BASE | ETHERNET_QAV |
 	       ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES;
 }


### PR DESCRIPTION
Use ARG_UNUSED() to mark unused function argument.