### PR TITLE
kernel: mmu: fix memory leak in virt_region_alloc()

### DIFF
--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -360,7 +360,7 @@ static void *virt_region_alloc(size_t size, size_t align)
 
 	/* Need to make sure this does not step into kernel memory */
 	if (dest_addr < POINTER_TO_UINT(Z_VIRT_REGION_START_ADDR)) {
-		(void)sys_bitarray_free(&virt_region_bitmap, size, offset);
+		(void)sys_bitarray_free(&virt_region_bitmap, num_bits, offset);
 		return NULL;
 	}
 


### PR DESCRIPTION
The error path for an invalid destination address in virt_region_alloc() frees the allocation using the originally requested 'size' instead of the 'num_bits' that were actually allocated from the bitmap. This leaks the virtual address space.

Pass 'num_bits' instead of 'size' to sys_bitarray_free() to ensure the allocated region is correctly freed.