### PR TITLE
arch: arm: core: cortex_a_r: mark unused function argument

### DIFF
--- a/arch/arm/core/cortex_a_r/thread.c
+++ b/arch/arm/core/cortex_a_r/thread.c
@@ -409,6 +409,8 @@ int arch_float_disable(struct k_thread *thread)
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
 	/* This is not supported in Cortex-A and Cortex-R */
 	return -ENOTSUP;
 }


### PR DESCRIPTION
Use ARG_UNUSED() to mark unused function argument.