### PR TITLE
net: http: service: enhance HTTP service with optional custom socket create

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -64,6 +64,11 @@ Ethernet
 Networking
 **********
 
+* The HTTP server now respects the configured ``_config`` value. Check that
+  you provide applicable value to :c:macro:`HTTP_SERVICE_DEFINE_EMPTY`,
+  :c:macro:`HTTPS_SERVICE_DEFINE_EMPTY`, :c:macro:`HTTP_SERVICE_DEFINE` and
+  :c:macro:`HTTPS_SERVICE_DEFINE`.
+
 .. zephyr-keep-sorted-start re(^\w)
 
 .. zephyr-keep-sorted-stop

--- a/include/zephyr/shell/shell_websocket.h
+++ b/include/zephyr/shell/shell_websocket.h
@@ -122,6 +122,7 @@ int shell_websocket_enable(const struct shell *sh);
 			     SHELL_WEBSOCKET_SERVICE_COUNT,		  \
 			     NULL,					  \
 			     NULL,                                        \
+			     NULL,                                        \
 			     _sec_tag_list,				  \
 			     _sec_tag_list_size);			  \
 	DEFINE_WEBSOCKET_SERVICE(_service);				  \
@@ -137,7 +138,7 @@ int shell_websocket_enable(const struct shell *sh);
 			    &SHELL_WS_PORT_NAME(_service),		\
 			    SHELL_WEBSOCKET_SERVICE_COUNT,		\
 			    SHELL_WEBSOCKET_SERVICE_COUNT,		\
-			    NULL, NULL);				\
+			    NULL, NULL, NULL);				\
 	DEFINE_WEBSOCKET_SERVICE(_service)
 
 #endif /* CONFIG_NET_SOCKETS_SOCKOPT_TLS */

--- a/samples/net/prometheus/src/main.c
+++ b/samples/net/prometheus/src/main.c
@@ -40,7 +40,7 @@ struct app_context {
 #if defined(CONFIG_NET_SAMPLE_HTTP_SERVICE)
 static uint16_t test_http_service_port = CONFIG_NET_SAMPLE_HTTP_SERVER_SERVICE_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, CONFIG_NET_CONFIG_MY_IPV4_ADDR, &test_http_service_port,
-		    CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL);
+		    CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL, NULL);
 
 static int dyn_handler(struct http_client_ctx *client, enum http_data_status status,
 		       const struct http_request_ctx *request_ctx,
@@ -99,7 +99,7 @@ const sec_tag_t sec_tag_list_verify_none[] = {
 
 static uint16_t test_https_service_port = CONFIG_NET_SAMPLE_HTTPS_SERVER_SERVICE_PORT;
 HTTPS_SERVICE_DEFINE(test_https_service, CONFIG_NET_CONFIG_MY_IPV4_ADDR, &test_https_service_port,
-		     CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL, sec_tag_list_verify_none,
+		     CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL, NULL, sec_tag_list_verify_none,
 		     sizeof(sec_tag_list_verify_none));
 
 HTTP_RESOURCE_DEFINE(index_html_gz_resource_https, test_https_service, "/metrics",

--- a/samples/net/sockets/http_server/src/main.c
+++ b/samples/net/sockets/http_server/src/main.c
@@ -248,7 +248,7 @@ struct http_resource_detail_websocket ws_netstats_resource_detail = {
 #if defined(CONFIG_NET_SAMPLE_HTTP_SERVICE)
 static uint16_t test_http_service_port = CONFIG_NET_SAMPLE_HTTP_SERVER_SERVICE_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, NULL, &test_http_service_port,
-		    CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL);
+		    CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL, NULL);
 
 HTTP_RESOURCE_DEFINE(index_html_gz_resource, test_http_service, "/",
 		     &index_html_gz_resource_detail);
@@ -281,7 +281,7 @@ static const sec_tag_t sec_tag_list_verify_none[] = {
 
 static uint16_t test_https_service_port = CONFIG_NET_SAMPLE_HTTPS_SERVER_SERVICE_PORT;
 HTTPS_SERVICE_DEFINE(test_https_service, NULL, &test_https_service_port,
-		     CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL, sec_tag_list_verify_none,
+		     CONFIG_HTTP_SERVER_MAX_CLIENTS, 10, NULL, NULL, NULL, sec_tag_list_verify_none,
 		     sizeof(sec_tag_list_verify_none));
 
 HTTP_RESOURCE_DEFINE(index_html_gz_resource_https, test_https_service, "/",

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -156,7 +156,11 @@ int http_server_init(struct http_server_ctx *ctx)
 			proto = IPPROTO_TCP;
 		}
 
-		fd = zsock_socket(af, SOCK_STREAM, proto);
+		if (svc->config != NULL && svc->config->socket_create != NULL) {
+			fd = svc->config->socket_create(svc, af, proto);
+		} else {
+			fd = zsock_socket(af, SOCK_STREAM, proto);
+		}
 		if (fd < 0) {
 			LOG_ERR("socket: %d", errno);
 			failed++;

--- a/tests/net/lib/http_client/src/main.c
+++ b/tests/net/lib/http_client/src/main.c
@@ -15,7 +15,7 @@
 
 static uint16_t test_http_service_port = SERVER_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, SERVER_IPV6_ADDR,
-		    &test_http_service_port, 1, 10, NULL, NULL);
+		    &test_http_service_port, 1, 10, NULL, NULL, NULL);
 
 static const char static_resource_payload[] = LOREM_IPSUM_SHORT;
 struct http_resource_detail_static static_resource_detail = {

--- a/tests/net/lib/http_server/common/src/main.c
+++ b/tests/net/lib/http_server/common/src/main.c
@@ -50,14 +50,14 @@ static struct http_resource_detail detail[] = {
  * the paths (and implementation-specific details) are known at compile time.
  */
 static const uint16_t service_A_port = 4242;
-HTTP_SERVICE_DEFINE(service_A, "a.service.com", &service_A_port, 4, 2, DETAIL(0), NULL);
+HTTP_SERVICE_DEFINE(service_A, "a.service.com", &service_A_port, 4, 2, DETAIL(0), NULL, NULL);
 HTTP_RESOURCE_DEFINE(resource_0, service_A, "/", RES(0));
 HTTP_RESOURCE_DEFINE(resource_1, service_A, "/index.html", RES(1));
 HTTP_RESOURCE_DEFINE(resource_2, service_A, "/fs/*", RES(5));
 
 /* ephemeral port of 0 */
 static uint16_t service_B_port;
-HTTP_SERVICE_DEFINE(service_B, "b.service.com", &service_B_port, 7, 3, DETAIL(1), NULL);
+HTTP_SERVICE_DEFINE(service_B, "b.service.com", &service_B_port, 7, 3, DETAIL(1), NULL, NULL);
 HTTP_RESOURCE_DEFINE(resource_3, service_B, "/foo.htm", RES(2));
 HTTP_RESOURCE_DEFINE(resource_4, service_B, "/bar/baz.php", RES(3));
 
@@ -67,11 +67,11 @@ HTTP_RESOURCE_DEFINE(resource_4, service_B, "/bar/baz.php", RES(3));
  * runtime.
  */
 static const uint16_t service_C_port = 5959;
-HTTP_SERVICE_DEFINE_EMPTY(service_C, "192.168.1.1", &service_C_port, 5, 9, DETAIL(2), NULL);
+HTTP_SERVICE_DEFINE_EMPTY(service_C, "192.168.1.1", &service_C_port, 5, 9, DETAIL(2), NULL, NULL);
 
 /* Wildcard resources */
 static uint16_t service_D_port = service_A_port + 1;
-HTTP_SERVICE_DEFINE(service_D, "2001:db8::1", &service_D_port, 7, 3, DETAIL(3), NULL);
+HTTP_SERVICE_DEFINE(service_D, "2001:db8::1", &service_D_port, 7, 3, DETAIL(3), NULL, NULL);
 HTTP_RESOURCE_DEFINE(resource_5, service_D, "/foo1.htm*", RES(0));
 HTTP_RESOURCE_DEFINE(resource_6, service_D, "/fo*", RES(1));
 HTTP_RESOURCE_DEFINE(resource_7, service_D, "/f[ob]o3.html", RES(1));
@@ -82,7 +82,7 @@ HTTP_RESOURCE_DEFINE(resource_12, service_D, "/foo/b?r", RES(3));
 
 /* Default resource in case of no match */
 static uint16_t service_E_port = 8080;
-HTTP_SERVICE_DEFINE(service_E, "192.0.2.1", &service_E_port, 1, 1, NULL, DETAIL(0));
+HTTP_SERVICE_DEFINE(service_E, "192.0.2.1", &service_E_port, 1, 1, NULL, DETAIL(0), NULL);
 HTTP_RESOURCE_DEFINE(resource_10, service_E, "/index.html", RES(4));
 
 ZTEST(http_service, test_HTTP_SERVICE_DEFINE)

--- a/tests/net/lib/http_server/core/src/main.c
+++ b/tests/net/lib/http_server/core/src/main.c
@@ -235,7 +235,7 @@ BUILD_ASSERT(sizeof(long_payload) - 1 > CONFIG_HTTP_SERVER_CLIENT_BUFFER_SIZE,
 
 static uint16_t test_http_service_port = SERVER_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, SERVER_IPV4_ADDR,
-		    &test_http_service_port, 1, 10, NULL, NULL);
+		    &test_http_service_port, 1, 10, NULL, NULL, NULL);
 
 static const char static_resource_payload[] = TEST_STATIC_PAYLOAD;
 struct http_resource_detail_static static_resource_detail = {

--- a/tests/net/lib/http_server/crime/src/main.c
+++ b/tests/net/lib/http_server/crime/src/main.c
@@ -46,7 +46,7 @@ static const unsigned char compressed_inc_file[] = {
 static uint16_t test_http_service_port = SERVER_PORT;
 HTTP_SERVICE_DEFINE(test_http_service, MY_IPV4_ADDR,
 		    &test_http_service_port, 1,
-		    10, NULL, NULL);
+		    10, NULL, NULL, NULL);
 
 struct http_resource_detail_static index_html_gz_resource_detail = {
 	.common = {

--- a/tests/net/lib/http_server/tls/src/main.c
+++ b/tests/net/lib/http_server/tls/src/main.c
@@ -43,7 +43,7 @@ static const sec_tag_t server_tag_list_verify[] = {
 
 static uint16_t test_http_service_port = SERVER_PORT;
 HTTPS_SERVICE_DEFINE(test_http_service, MY_IPV4_ADDR, &test_http_service_port,
-		     1, 10, NULL, NULL, server_tag_list_verify,
+		     1, 10, NULL, NULL, NULL, server_tag_list_verify,
 		     sizeof(server_tag_list_verify));
 
 static const unsigned char ca[] = {


### PR DESCRIPTION
Currently webserver does not support custom socket creation e.g. for offloaded socket.

Update the HTTP service API to allow custom socket creation through a function pointer in the service descriptor.
The existing socket creation method is retained as a fallback if no custom function is provided.

This functionality is per-service, i.e. it allows to specify which http services will work on which sockets.
Backwards-compatible.

Partially related to https://github.com/zephyrproject-rtos/zephyr/issues/89960