### PR TITLE
arch: arm64: core: fpu: mark unused function argument

### DIFF
--- a/arch/arm64/core/fpu.c
+++ b/arch/arm64/core/fpu.c
@@ -346,6 +346,8 @@ int arch_float_disable(struct k_thread *thread)
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
 	/* floats always gets enabled automatically at the moment */
 	return 0;
 }


### PR DESCRIPTION
Use ARG_UNUSED() to mark unused function argument.