### PR TITLE
arch: arm64: core: fatal: mark unused function argument

### DIFF
--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -362,6 +362,10 @@ static bool z_arm64_stack_corruption_check(struct arch_esf *esf, uint64_t esr, u
 static bool is_recoverable(struct arch_esf *esf, uint64_t esr, uint64_t far,
 			   uint64_t elr)
 {
+	ARG_UNUSED(esr);
+	ARG_UNUSED(far);
+	ARG_UNUSED(elr);
+
 	if (!esf) {
 		return false;
 	}


### PR DESCRIPTION
Use ARG_UNUSED() to mark unused function argument.