### PR TITLE
soc: stm32f1x: Remove redundant code and clear SB flag

### DIFF
--- a/soc/st/stm32/stm32f1x/poweroff.c
+++ b/soc/st/stm32/stm32f1x/poweroff.c
@@ -7,16 +7,13 @@
 #include <stm32f1xx_ll_cortex.h>
 #include <stm32f1xx_ll_pwr.h>
 
-#include <zephyr/drivers/misc/stm32_wkup_pins/stm32_wkup_pins.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/poweroff.h>
 
 void z_sys_poweroff(void)
 {
-#ifdef CONFIG_STM32_WKUP_PINS
-	stm32_pwr_wkup_pin_cfg_pupd();
-
+	LL_PWR_ClearFlag_SB();
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_LPM_DisableEventOnPend();
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);


### PR DESCRIPTION
There is no need to call stm32_pwr_wkup_pin_cfg_pupd() because the SoC does not have a pull-up/pull-down on the WKUP pin.

Call LL_PWR_ClearFlag_SB() before entering StandBy power mode.