### PR TITLE
drivers: flash: flash_stm32_qspi: Make CS high time configurable

### DIFF
--- a/boards/alientek/pandora_stm32l475/pandora_stm32l475.dts
+++ b/boards/alientek/pandora_stm32l475/pandora_stm32l475.dts
@@ -82,6 +82,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = <80000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		jedec-id = [ef 40 18];
 		spi-bus-width = <4>;
 		writeoc = "PP_1_1_4";

--- a/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
+++ b/boards/arduino/giga_r1/arduino_giga_r1_stm32h747xx_m7.dts
@@ -178,6 +178,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		status = "okay";
 
 		partitions {

--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -170,6 +170,7 @@ zephyr_i2c: &i2c1 {
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		status = "okay";
 
 		partitions {

--- a/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
+++ b/boards/arduino/portenta_h7/arduino_portenta_h7-common.dtsi
@@ -185,6 +185,7 @@ zephyr_i2c: &i2c1 {
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = < 40000000 >;
+		cs-high-time = <2>; /* >= 30 ns */
 		sfdp-bfp = [ e5 20 f1 ff  ff ff ff 07  44 eb 08 6b  08 3b 04 bb
 			     fe ff ff ff  ff ff 00 ff  ff ff 44 eb  0c 20 0f 52
 			     10 d8 00 ff  82 41 bd 00  81 e5 7b c6  44 03 67 38

--- a/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
+++ b/boards/fanke/fk743m5_xih6/fk743m5_xih6.dts
@@ -101,6 +101,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(64)>; /* 64 Mbits */
 		qspi-max-frequency = <40000000>;
+		cs-high-time = <2>; /* >= 50 ns */
 		status = "okay";
 		spi-bus-width = <4>;
 		writeoc = "PP_1_1_4";

--- a/boards/fanke/fk750m1_vbt6/fk750m1_vbt6.dts
+++ b/boards/fanke/fk750m1_vbt6/fk750m1_vbt6.dts
@@ -123,6 +123,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(64)>; /* 64 Mbits */
 		qspi-max-frequency = <40000000>;
+		cs-high-time = <2>; /* >= 50 ns */
 		status = "okay";
 		spi-bus-width = <4>;
 		writeoc = "PP_1_1_4";

--- a/boards/st/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/st/disco_l475_iot1/disco_l475_iot1.dts
@@ -330,6 +330,7 @@ zephyr_udc0: &usbotg_fs {
 		reg = <0>;
 		size = <DT_SIZE_M(64)>; /* 64 Mbits */
 		qspi-max-frequency = <50000000>;
+		cs-high-time = <2>; /* >= 30 ns */
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/st/stm32f412g_disco/stm32f412g_disco.dts
@@ -161,6 +161,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		status = "okay";
 	};
 };

--- a/boards/st/stm32f723e_disco/stm32f723e_disco.dts
+++ b/boards/st/stm32f723e_disco/stm32f723e_disco.dts
@@ -132,6 +132,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		qspi-max-frequency = <8000000>;
+		cs-high-time = <3>; /* >= 30 ns */
 		status = "okay";
 		spi-bus-width = <4>;
 		writeoc = "PP_1_4_4";

--- a/boards/st/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/st/stm32f746g_disco/stm32f746g_disco.dts
@@ -215,6 +215,7 @@ zephyr_udc0: &usbotg_fs {
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/st/stm32f7508_dk/stm32f7508_dk.dts
@@ -202,6 +202,7 @@ zephyr_udc0: &usbotg_fs {
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/st/stm32f769i_disco/stm32f769i_disco.dts
@@ -200,6 +200,7 @@ arduino_serial: &usart6 {};
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		qspi-max-frequency = <DT_FREQ_M(66)>;
+		cs-high-time = <2>; /* >= 30 ns */
 		status = "okay";
 
 		partitions {

--- a/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
+++ b/boards/st/stm32h745i_disco/stm32h745i_disco_stm32h745xx_m7.dts
@@ -185,6 +185,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		spi-bus-width = <4>;
 		reset-cmd;
 		status = "okay";

--- a/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
+++ b/boards/st/stm32h747i_disco/stm32h747i_disco_stm32h747xx_m7.dts
@@ -258,6 +258,7 @@ zephyr_udc0: &usbotg_hs {
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		spi-bus-width = <4>;
 		reset-cmd;
 		status = "okay";

--- a/boards/st/stm32h750b_dk/stm32h750b_dk.dts
+++ b/boards/st/stm32h750b_dk/stm32h750b_dk.dts
@@ -192,6 +192,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		spi-bus-width = <4>;
 		reset-cmd;
 		status = "okay";

--- a/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
+++ b/boards/st/stm32h757i_eval/stm32h757i_eval_stm32h757xx_m7.dts
@@ -273,6 +273,7 @@ zephyr_udc0: &usbotg_hs {
 		reg = <0>;
 		size = <DT_SIZE_M(512)>; /* 512 Mbits */
 		qspi-max-frequency = <72000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		spi-bus-width = <4>;
 		reset-cmd;
 		status = "okay";

--- a/boards/st/stm32l496g_disco/stm32l496g_disco.dts
+++ b/boards/st/stm32l496g_disco/stm32l496g_disco.dts
@@ -211,6 +211,7 @@ zephyr_udc0: &usbotg_fs {
 		reg = <0>;
 		size = <DT_SIZE_M(64)>; /* 64 Mbits */
 		qspi-max-frequency = <8000000>;
+		cs-high-time = <3>; /* >= 30 ns */
 		status = "okay";
 		spi-bus-width = <4>;
 		writeoc = "PP_1_4_4";

--- a/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb.dts
+++ b/boards/vcc-gnd/yd_stm32h750vb/yd_stm32h750vb.dts
@@ -119,6 +119,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(128)>; /* 128 Mbits */
 		qspi-max-frequency = <80000000>;
+		cs-high-time = <4>; /* >= 50 ns */
 		spi-bus-width = <4>;
 		status = "okay";
 

--- a/boards/weact/mini_stm32h743/mini_stm32h743.dts
+++ b/boards/weact/mini_stm32h743/mini_stm32h743.dts
@@ -171,6 +171,7 @@ zephyr_udc0: &usbotg_fs {
 		reg = <0>;
 		size = <DT_SIZE_M(64)>; /* 64 Mbits */
 		qspi-max-frequency = <40000000>;
+		cs-high-time = <2>; /* >= 50 ns */
 		status = "okay";
 		spi-bus-width = <4>;
 		writeoc = "PP_1_1_4";

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -188,6 +188,7 @@ struct flash_stm32_qspi_config {
 	irq_config_func_t irq_config;
 	size_t flash_size;
 	uint32_t max_frequency;
+	uint8_t cs_high_time;
 	const struct pinctrl_dev_config *pcfg;
 #if STM32_QSPI_RESET_GPIO
 	const struct gpio_dt_spec reset;
@@ -1641,8 +1642,8 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	/* Give a bit position from 0 to 31 to the HAL init minus 1 for the DCR1 reg */
 	dev_data->hqspi.Init.FlashSize = find_lsb_set(dev_cfg->flash_size) - 2;
 	dev_data->hqspi.Init.SampleShifting = QSPI_SAMPLE_SHIFTING_HALFCYCLE;
+	dev_data->hqspi.Init.ChipSelectHighTime = dev_cfg->cs_high_time - 1;
 #if STM32_QSPI_DOUBLE_FLASH
-	dev_data->hqspi.Init.ChipSelectHighTime = QSPI_CS_HIGH_TIME_3_CYCLE;
 	dev_data->hqspi.Init.DualFlash = QSPI_DUALFLASH_ENABLE;
 
 	/*
@@ -1828,6 +1829,7 @@ static const struct flash_stm32_qspi_config flash_stm32_qspi_cfg = {
 	.irq_config = flash_stm32_qspi_irq_config_func,
 	.flash_size = (DT_INST_PROP(0, size) / 8) << STM32_QSPI_DOUBLE_FLASH,
 	.max_frequency = DT_INST_PROP(0, qspi_max_frequency),
+	.cs_high_time = DT_INST_PROP(0, cs_high_time),
 	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(STM32_QSPI_NODE),
 #if STM32_QSPI_RESET_GPIO
 	.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1640,8 +1640,8 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	dev_data->hqspi.Init.ClockPrescaler = prescaler;
 	/* Give a bit position from 0 to 31 to the HAL init minus 1 for the DCR1 reg */
 	dev_data->hqspi.Init.FlashSize = find_lsb_set(dev_cfg->flash_size) - 2;
-#if STM32_QSPI_DOUBLE_FLASH
 	dev_data->hqspi.Init.SampleShifting = QSPI_SAMPLE_SHIFTING_HALFCYCLE;
+#if STM32_QSPI_DOUBLE_FLASH
 	dev_data->hqspi.Init.ChipSelectHighTime = QSPI_CS_HIGH_TIME_3_CYCLE;
 	dev_data->hqspi.Init.DualFlash = QSPI_DUALFLASH_ENABLE;
 

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -80,3 +80,26 @@ properties:
     type: int
     default: 8
     description: The number of dummy-cycles required when reading jedec id
+
+  cs-high-time:
+    type: int
+    default: 8
+    enum:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+    description: |
+      Minimum number of QSPI clock cycles the chip select signal must remain
+      high between commands issued to the flash memory.
+
+      The minimum acceptable value depends on the flash memory model and the
+      QSPI clock frequency. Using a value higher than the minimum required
+      by the flash memory would not lead to communication errors but is
+      suboptimal as it would reduce the throughput.
+
+      Defaults to 8 clock cycles, which is the maximum supported value.

--- a/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
@@ -47,6 +47,7 @@
 		reg = <0>;
 		size = <DT_SIZE_M(256)>; /* 256 Mbits */
 		qspi-max-frequency = <50000000>;
+		cs-high-time = <3>; /* >= 30 ns */
 		reset-gpios = <&gpiod 3 GPIO_ACTIVE_LOW>;
 		reset-gpios-duration = <1>;
 		spi-bus-width = <4>;


### PR DESCRIPTION
The STM32 QUADSPI peripheral allows to configure, in clock cycles, the duration the chip select signal must stay high between each command sent to the flash memory controller (`QUADSPI_DCR_CSHT`).

This value should be configured according to:
* The minimal duration specified by the flash memory's datasheet (usually denoted "tSHSL", typically 30-50 ns).
* The QSPI's clock frequency.

Currently, this value is set by the flash driver to 1 clock cycle in single flash mode and 3 clock cycles in dual flash mode. This may be too low for some configurations. In particular, in single flash mode, the current value is out-of-spec for all board configurations provided by Zephyr.

This MR adds a new devicetree property allowing to set the chip-select high time value according to the flash memory specifications and the QSPI configuration.

Secondarily, this MR also enables the 1/2 sample shift feature of the QUADSPI peripheral in both single and dual flash mode.

---
From RM0433:
![Screenshot From 2025-07-06 02-31-35](https://github.com/user-attachments/assets/134b455a-d4ea-441a-8352-6076b8dbb212)

From MT25QL512 datasheet (used on the STM32H747I-DISCO board):
![Screenshot From 2025-07-06 02-37-17](https://github.com/user-attachments/assets/e12fee79-b9e7-486c-900b-ebb0e1f6b6e6)
![Screenshot From 2025-07-06 02-35-47](https://github.com/user-attachments/assets/6251fef2-8859-4694-9cdf-f016424e7061)