### PR TITLE
drivers: flash: stm32_qspi: Fix flash not reset when in QPI mode

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1380,10 +1380,29 @@ static int flash_stm32_qspi_send_reset(const struct device *dev)
 {
 	QSPI_CommandTypeDef cmd = {
 		.Instruction = SPI_NOR_CMD_RESET_EN,
-		.InstructionMode = QSPI_INSTRUCTION_1_LINE,
+		.InstructionMode = QSPI_INSTRUCTION_4_LINES
 	};
 	int ret;
 
+	/*
+	 * The device might be in SPI or QPI mode, so to ensure the device is properly reset send
+	 * the reset commands in both QPI and SPI modes.
+	 */
+	ret = qspi_send_cmd(dev, &cmd);
+	if (ret != 0) {
+		LOG_ERR("%d: Failed to send RESET_EN", ret);
+		return ret;
+	}
+
+	cmd.Instruction = SPI_NOR_CMD_RESET_MEM;
+	ret = qspi_send_cmd(dev, &cmd);
+	if (ret != 0) {
+		LOG_ERR("%d: Failed to send RESET_MEM", ret);
+		return ret;
+	}
+
+	cmd.Instruction = SPI_NOR_CMD_RESET_EN;
+	cmd.InstructionMode = QSPI_INSTRUCTION_1_LINE;
 	ret = qspi_send_cmd(dev, &cmd);
 	if (ret != 0) {
 		LOG_ERR("%d: Failed to send RESET_EN", ret);


### PR DESCRIPTION
The STM32 QSPI driver was sending reset commands to the flash memory only in SPI mode, causing the device not to be properly reset when in QPI mode.

On the STM32H747I-DISCO boards, this was causing the issue described on https://github.com/zephyrproject-rtos/zephyr/discussions/56221, where the driver initialization systematically failed due to a bad SFDP magic after flashing the external memory using STM32CubeProgrammer since the external loader is configuring the flash memory in QPI mode.