### PR TITLE
xtensa: tracing: instrument thread switching

### DIFF
--- a/arch/xtensa/include/xtensa_asm2_s.h
+++ b/arch/xtensa/include/xtensa_asm2_s.h
@@ -606,6 +606,10 @@ _excint_noflush_\@:
 	/* Restore A1 stack pointer from "next" handle. */
 	mov a1, a6
 
+#ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
+	call4 z_thread_mark_switched_in
+#endif
+
 _restore_\@:
 	j _restore_context
 .endm

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -815,7 +815,12 @@ struct k_thread *z_swap_next_thread(void)
 /* Just a wrapper around z_current_thread_set(xxx) with tracing */
 static inline void set_current(struct k_thread *new_thread)
 {
-	z_thread_mark_switched_out();
+	/* If the new thread is the same as the current thread, we
+	 * don't need to do anything.
+	 */
+	if (IS_ENABLED(CONFIG_INSTRUMENT_THREAD_SWITCHING) && new_thread != _current) {
+		z_thread_mark_switched_out();
+	}
 	z_current_thread_set(new_thread);
 }
 


### PR DESCRIPTION
Add missing call to thread_switched_in for the purpose of tracing.

Fixes zephyrproject-rtos/zephyr#76057

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
