### PR TITLE
fs: fs.h: Fix get flags from devicetree

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -200,11 +200,11 @@ struct fs_statvfs {
  * @return a value suitable for initializing an fs_mount_t flags
  * member.
  */
-#define FSTAB_ENTRY_DT_MOUNT_FLAGS(node_id)				\
-	((DT_PROP(node_id, automount) ? FS_MOUNT_FLAG_AUTOMOUNT : 0)	\
-	 | (DT_PROP(node_id, read_only) ? FS_MOUNT_FLAG_READ_ONLY : 0)	\
-	 | (DT_PROP(node_id, no_format) ? FS_MOUNT_FLAG_NO_FORMAT : 0)  \
-	 | (DT_PROP(node_id, disk_access) ? FS_MOUNT_FLAG_USE_DISK_ACCESS : 0))
+#define FSTAB_ENTRY_DT_MOUNT_FLAGS(node_id)					\
+	((DT_NODE_HAS_PROP(node_id, automount)   ? FS_MOUNT_FLAG_AUTOMOUNT : 0) \
+	 | (DT_NODE_HAS_PROP(node_id, read_only) ? FS_MOUNT_FLAG_READ_ONLY : 0) \
+	 | (DT_NODE_HAS_PROP(node_id, no_format) ? FS_MOUNT_FLAG_NO_FORMAT : 0) \
+	 | (DT_NODE_HAS_PROP(node_id, disk_access) ? FS_MOUNT_FLAG_USE_DISK_ACCESS : 0))
 
 /**
  * @brief The name under which a zephyr,fstab entry mount structure is


### PR DESCRIPTION
The FSTAB_ENTRY_DT_MOUNT_FLAGS macro generate a int value combining all the mount flags defined at zephyr,fstab-common.yaml. The detail is that all those flags are defined as booleans. This means that only when a flags is added inside a devicetree node an entry will be generated in the devicetree_generated.h. This fixes the potential bug by testing the existence of the entry using the DT_NODE_HAS_PROP macro.