### PR TITLE
drivers: crypto: crypto_ataes132a fix memset undefined behavior

### DIFF
--- a/drivers/crypto/crypto_ataes132a.c
+++ b/drivers/crypto/crypto_ataes132a.c
@@ -634,7 +634,14 @@ int ataes132a_aes_ecb_block(const struct device *dev,
 	param_buffer[1] = key_id;
 	param_buffer[2] = 0x0;
 	memcpy(param_buffer + 3, pkt->in_buf, buf_len);
-	(void)memset(param_buffer + 3 + buf_len, 0x0, 16 - buf_len);
+	/* skip memset() if buf_len==16.
+	 * Indeed, calling memset(&param_buffer[19], 0x0, 0)
+	 * is an undefined behaviour in C as &param_buffer[19] is
+	 * an invalid pointer (even if size is 0).
+	 */
+	if (buf_len < 16) {
+		(void)memset(param_buffer + 3 + buf_len, 0x0, 16 - buf_len);
+	}
 
 	return_code = ataes132a_send_command(dev, ATAES_LEGACY_OP, 0x00,
 					     param_buffer, buf_len + 3,


### PR DESCRIPTION
Coverity reported a memory - illegal accesses when using memset in ataes132a_aes_ecb_block(). This can happen when the input block is exactly 16 bytes: memset(&param_buffer[19], 0x0, 0) is called. But this is an undefined behaviour in C even if size is 0, as &param_buffer[19] is an invalid pointer.

The fix consists of simply skipping memset() in this case, since there's nothing to zero out.

Coverity CID: 434642
Fixes: #81943 