### PR TITLE
drivers: hwinfo: rpi_pico: use bootrom method on RP2350

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -152,6 +152,18 @@ config HWINFO_RPI_PICO
 	help
 	  Enable Raspberry Pi Pico hwinfo driver.
 
+config HWINFO_RPI_PICO_CHIP_ID
+	bool "Use chip ID as device ID for RP2350"
+	default n
+	depends on SOC_SERIES_RP2350
+	depends on HWINFO_RPI_PICO
+	help
+	  Use the chip ID as device ID for RP2350 instead of the default
+	  flash RUID. This is useful for RP2350 boards that do not have a
+	  flash, or when OTP ID is preferred over flash RUID.
+	  This option is recommended for new RP2350 designs, but defaults to n
+	  to prevent existing devices from changing their serial numbers.
+
 config HWINFO_SAM_RSTC
 	bool "Atmel SAM reset cause"
 	default y


### PR DESCRIPTION
RP2350 provides a function to get OTP-backed chip ID. Prefer using this
on supported platforms for these reasons:
- a secure internal identifier, same as read by picotool
- works on flashless boards
- does not conflict with code running in XIP mode (e.g. when the other
 core tries to access device ID)
- when used with USB HWID serial number will match one BootROM has

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
