### PR TITLE
lib: os: clock: fix for CID 529870

### DIFF
--- a/lib/os/clock.c
+++ b/lib/os/clock.c
@@ -164,7 +164,8 @@ int z_impl_sys_clock_nanosleep(int clock_id, int flags, const struct timespec *r
 	}
 
 	/* sleep for relative time duration */
-	if (unlikely(rqtp->tv_sec >= UINT64_MAX / NSEC_PER_SEC)) {
+	if ((sizeof(rqtp->tv_sec) == sizeof(int64_t)) &&
+	    unlikely(rqtp->tv_sec >= (time_t)(UINT64_MAX / NSEC_PER_SEC))) {
 		uint64_t ns = (uint64_t)k_sleep(K_SECONDS(duration.tv_sec - 1)) * NSEC_PER_MSEC;
 		struct timespec rem = {
 			.tv_sec = (time_t)(ns / NSEC_PER_SEC),


### PR DESCRIPTION
Fix for CID 529870, where Coverity found an issue where `timespec.tv_sec` is never greater than `UINT64_MAX / NSEC_PER_SEC` (18446744073).

This is naturally true when `time_t` is only 32-bit, which is actually never the case for any Zephyr platform aside from `native_sim` (in 32-bit mode) and `unit_testing`.

When `time_t` is a signed 64-bit value, at some point in the future, but maybe not in our lifetimes, `timespec.tv_sec` could exceed 18446744073, since `INT64_MAX > UINT64_MAX / NSEC_PER_SEC`.

We should not see coverity errors like this in the future, once we have a consistent `time_t` representation across all Zephyr platforms.

Fixes #92598