### PR TITLE
Add shield for Adafruit Featherwing 128x32 OLED

### DIFF
--- a/boards/shields/adafruit_featherwing_128x32_oled/Kconfig.defconfig
+++ b/boards/shields/adafruit_featherwing_128x32_oled/Kconfig.defconfig
@@ -1,0 +1,30 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+if SHIELD_ADAFRUIT_FEATHERWING_128X32_OLED
+
+if DISPLAY
+
+if LVGL
+
+config LV_Z_VDB_SIZE
+	default 64
+
+config LV_DPI_DEF
+	default 148
+
+config LV_Z_BITS_PER_PIXEL
+	default 1
+
+config LV_Z_COLOR_MONO_HW_INVERSION
+	default y
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif # DISPLAY
+
+endif # SHIELD_ADAFRUIT_FEATHERWING_128X32_OLED

--- a/boards/shields/adafruit_featherwing_128x32_oled/Kconfig.shield
+++ b/boards/shields/adafruit_featherwing_128x32_oled/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+config SHIELD_ADAFRUIT_FEATHERWING_128X32_OLED
+	def_bool $(shields_list_contains,adafruit_featherwing_128x32_oled)

--- a/boards/shields/adafruit_featherwing_128x32_oled/adafruit_featherwing_128x32_oled.overlay
+++ b/boards/shields/adafruit_featherwing_128x32_oled/adafruit_featherwing_128x32_oled.overlay
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,display = &ssd1306_ssd1306_128x32;
+	};
+
+	aliases {
+		sw0 = &buttonA;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		buttonA: button_A {
+			gpios = <&feather_header 16 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>; /* D9 */
+			label = "Button A";
+			zephyr,code = <INPUT_KEY_A>;
+		};
+
+		buttonB: button_B {
+			/* Button B has a pull up resistor on board. */
+			gpios = <&feather_header 15 GPIO_ACTIVE_LOW>; /* D6 */
+			label = "Button B";
+			zephyr,code = <INPUT_KEY_B>;
+		};
+
+		buttonC: button_C {
+			gpios = <&feather_header 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;	/* D5 */
+			label = "Button C";
+			zephyr,code = <INPUT_KEY_C>;
+		};
+	};
+};
+
+&feather_i2c {
+	ssd1306_ssd1306_128x32: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+	};
+};

--- a/boards/shields/adafruit_featherwing_128x32_oled/doc/index.rst
+++ b/boards/shields/adafruit_featherwing_128x32_oled/doc/index.rst
@@ -1,0 +1,47 @@
+.. _adafruit_featherwing_128x32_oled:
+
+Adafruit FeatherWing 128x32 OLED Shield
+#######################################
+
+Overview
+********
+
+The `Adafruit OLED FeatherWing Shield`_ features a SSD1306 compatible OLED display
+with a resolution of 128x32 pixels and three user buttons.
+
+Pins Assignment of the Adafruit FeatherWing 128x32 OLED shield
+==============================================================
+
++-----------------------+---------------------------------------------+
+| Shield Connector Pin  | Function                                    |
++=======================+=============================================+
+| SDA                   | SSD1306 I2C SDA                             |
++-----------------------+---------------------------------------------+
+| SCL                   | SSD1306 I2C SCL                             |
++-----------------------+---------------------------------------------+
+| GPIO5                 | Button C (INPUT_KEY_C)                      |
++-----------------------+---------------------------------------------+
+| GPIO6                 | Button B (INPUT_KEY_B)                      |
++-----------------------+---------------------------------------------+
+| GPIO9                 | Button A (INPUT_KEY_A)                      |
++-----------------------+---------------------------------------------+
+
+Requirements
+************
+
+This shield can only be used with a board which provides a configuration for Feather connector and
+defines a node alias for I2C (see :ref:`shields` for more details).
+
+Programming
+***********
+
+Set ``--shield adafruit_featherwing_128x32_oled`` when you invoke ``west build``. For example:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/display/lvgl
+   :board: adafruit_feather_nrf52840
+   :shield: adafruit_featherwing_128x32_oled
+   :goals: build
+
+.. _Adafruit OLED FeatherWing Shield:
+   https://learn.adafruit.com/adafruit-oled-featherwing

--- a/boards/shields/adafruit_featherwing_128x32_oled/shield.yml
+++ b/boards/shields/adafruit_featherwing_128x32_oled/shield.yml
@@ -1,0 +1,7 @@
+shields:
+  - name: adafruit_featherwing_128x32_oled
+    full_name: Adafruit FeatherWing 128x32 OLED
+    vendor: adafruit
+    supported_features:
+      - display
+      - input


### PR DESCRIPTION
This PR adds support for a Adafruit Featherwing 128x32 OLED shield