### PR TITLE
net: lib: tls_credentials: fix unregistered log module

### DIFF
--- a/subsys/net/lib/tls_credentials/tls_credentials.c
+++ b/subsys/net/lib/tls_credentials/tls_credentials.c
@@ -13,8 +13,7 @@
 
 #include <zephyr/logging/log.h>
 
-LOG_MODULE_DECLARE(tls_credentials,
-		   CONFIG_TLS_CREDENTIALS_LOG_LEVEL);
+LOG_MODULE_REGISTER(tls_credentials, CONFIG_TLS_CREDENTIALS_LOG_LEVEL);
 
 /* Global pool of credentials shared among TLS contexts. */
 static struct tls_credential credentials[CONFIG_TLS_MAX_CREDENTIALS_NUMBER];


### PR DESCRIPTION
A logging module named `tls_credentials` was being declared, but no other source module was creating and registering it. Do the registration in the file to fix the compiler error.