### PR TITLE
tests/lib/timespec_util: Skip two tests by now

### DIFF
--- a/tests/lib/timespec_util/src/main.c
+++ b/tests/lib/timespec_util/src/main.c
@@ -308,6 +308,8 @@ static const struct tospec {
 
 ZTEST(timeutil_api, test_timespec_from_timeout)
 {
+	ztest_test_skip(); /* Provisionally disabled until #92158 is fixed */
+
 	ARRAY_FOR_EACH(tospecs, i) {
 		const struct tospec *const tspec = &tospecs[i];
 		struct timespec actual;
@@ -327,6 +329,8 @@ ZTEST(timeutil_api, test_timespec_from_timeout)
 
 ZTEST(timeutil_api, test_timespec_to_timeout)
 {
+	ztest_test_skip(); /* Provisionally disabled until #92158 is fixed */
+
 	ARRAY_FOR_EACH(tospecs, i) {
 		const struct tospec *const tspec = &tospecs[i];
 		k_timeout_t actual;


### PR DESCRIPTION
These two (sub)tests assume the system tick period divides evenly all time interval values being tested, but this is not the case in general, and when it is not, these tests fail.

Let's skip these 2 tests by now so we can release without a broken CI, and do not block other development while the tests themselves are being fixed.

Note that this happens at least for the majority of Nordic devices, and as such these tests fail in Nordic simulation in CI.

Mitigates #92158