### PR TITLE
drivers: bluetooth: hci: Enable LC3 codec for NXP FPU based platform for Bluetooth LE Audio

### DIFF
--- a/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
+++ b/boards/shields/nxp_m2_wifi_bt/Kconfig.defconfig
@@ -122,6 +122,15 @@ config BT_LONG_WQ_STACK_SIZE
 config MAIN_STACK_SIZE
 	default 2560
 
+configdefault FPU
+	default y if CPU_HAS_FPU
+
+configdefault LIBLC3
+	default y if BT_NXP_NW612 && BT_AUDIO && FPU
+
+configdefault BT_RX_STACK_SIZE
+	default 4096 if LIBLC3
+
 if SHELL
 
 config SHELL_STACK_SIZE


### PR DESCRIPTION
- To enable LC3 codec for BLE Audio based samples for iMXRT based platform which supports FPU.