### PR TITLE
drivers: gpio: silabs: add lookup table documentation

### DIFF
--- a/dts/bindings/gpio/silabs,siwx91x-gpio-uulp.yaml
+++ b/dts/bindings/gpio/silabs,siwx91x-gpio-uulp.yaml
@@ -1,4 +1,11 @@
-description: Silabs SiWx91x UULP (ultra ultra low power) GPIO Port
+description: |
+  Silabs SiWx91x UULP (ultra ultra low power) GPIO Port
+
+  Lookup table: Pin (dts) -> SoC Pin (ULP Pin from reference manual):
+
+  Pin : 0  1  2  3  4
+
+  ULP : 0  1  2  3  4
 
 compatible: "silabs,siwx91x-gpio-uulp"
 

--- a/dts/bindings/gpio/silabs,siwx91x-gpio.yaml
+++ b/dts/bindings/gpio/silabs,siwx91x-gpio.yaml
@@ -1,4 +1,12 @@
-description: Silabs SiWx91x GPIO
+description: |
+  Silabs SiWx91x GPIO
+
+  Lookup table:  Port-Pin (dts) -> SoC Pin (HP Pin from reference manual)
+
+  Port: A  A  A  A  B  B  B  B  B  B  B  C  C  C  C  C  D  D  D  D  D  D  D  D  D  D
+  Pin : 10 11 12 15 09 10 11 12 13 14 15 00 01 02 14 15 00 01 02 03 04 05 06 07 08 09
+
+  HP  : 10 11 12 15 25 26 27 28 29 30 31 32 33 34 46 47 48 49 50 51 52 53 54 55 56 57
 
 compatible: "silabs,siwx91x-gpio"
 


### PR DESCRIPTION
This commit only adds documentation. It will help a user to translate pinout from the reference manual to a device tree gpio (HP and ULP).