### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 3430520d7080a8ac3e4b325cfde0ef18837209af
+      revision: 4eba8087fa606db801455f14d185255bc8c49467
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  4eba8087fa606db801455f14d185255bc8c49467

Brings following Zephyr relevant fixes:

  - 4eba8087 boot: zephyr: boards config of the stm32h573 disco kit
  - 2dd7c655 boot: zephyr: boards config of the stm32h7rs target boards
  - cde66e17 boot: zephyr: defines FLASH device for external NOR
  - 6a178d29 bootutil: Use flash base address for direct hash

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.