### PR TITLE
drivers: wm8962, wm8904: Fix clock config logic

### DIFF
--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -504,7 +504,7 @@ static int wm8904_configure(const struct device *dev, struct audio_codec_cfg *cf
 
 	wm8904_audio_fmt_config(dev, &cfg->dai_cfg, cfg->mclk_freq);
 
-	if ((cfg->dai_cfg.i2s.options & I2S_OPT_FRAME_CLK_MASTER) == I2S_OPT_FRAME_CLK_MASTER) {
+	if ((cfg->dai_cfg.i2s.options & I2S_OPT_FRAME_CLK_SLAVE) == 0) {
 		wm8904_set_master_clock(dev, &cfg->dai_cfg, cfg->mclk_freq);
 	} else {
 		/* BCLK/LRCLK default direction input */

--- a/drivers/audio/wm8962.c
+++ b/drivers/audio/wm8962.c
@@ -506,7 +506,7 @@ static int wm8962_configure(const struct device *dev, struct audio_codec_cfg *cf
 	wm8962_write_reg(dev, WM8962_REG_POWER1, 0x1FE);
 	wm8962_write_reg(dev, WM8962_REG_POWER2, 0x1E0);
 
-	if ((cfg->dai_cfg.i2s.options & I2S_OPT_FRAME_CLK_SLAVE) == I2S_OPT_FRAME_CLK_SLAVE) {
+	if ((cfg->dai_cfg.i2s.options & I2S_OPT_FRAME_CLK_SLAVE) == 0) {
 		wm8962_set_master_clock(dev, &cfg->dai_cfg, cfg->mclk_freq);
 		wm8962_update_reg(dev, WM8962_REG_IFACE0, 1U << 6U, 1U << 6U);
 	}


### PR DESCRIPTION
Fix clock config logic of `wm8962` and `wm8904` drivers, so that both can be properly configured for master (generating BCK and WS) and slave (receiving those) operation.

Currently breaks the `i2s_codec` sample on platforms where codecs to respect master-slave selection and where master/master selection is functional by current logic (such as on the `mimxrt595_evk/mimxrt595s/cm33`). ~PR fixing that will follow.~ This is fixed in https://github.com/zephyrproject-rtos/zephyr/pull/92776.