### PR TITLE
MAINTAINERS: fix labels for intel platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3802,6 +3802,7 @@ Intel Platforms (X86):
     - drivers/timer/apic*
   labels:
     - "platform: X86"
+    - "platform: Intel"
 
 Intel Platforms (Xtensa):
   status: maintained
@@ -5367,7 +5368,7 @@ West:
   files:
     - modules/Kconfig.intel
   labels:
-    - "platform: Intel"
+    - "platform: Intel ISH"
 
 "West project: zephyr-lang-rust":
   status: maintained


### PR DESCRIPTION
'platform: Intel' goes to general X86 platforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
