### PR TITLE
bluetooth: mesh: removing gotten stuck persisted psa key if key id is reused

### DIFF
--- a/tests/bsim/bluetooth/mesh/tests_scripts/persistence/prov_with_stuck_key.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/persistence/prov_with_stuck_key.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2025 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test checks that mesh provisioning data is saved and loaded correctly
+# if a key with ID from mesh PSA key ID range exists in the PSA ITS,
+# it is destroyed and the correct key is used instead.
+#
+# Test must be added in pair and in sequence.
+# First test: saves data; second test: verifies it.
+#
+# Test procedure:
+# 1. Fake key is created in the PSA ITS to emulate gotten stuck key.
+# 2. Device Under Test (DUT) initializes the Mesh stack,
+#    and starts provisioning and configuration itself.
+# 3. Test scenario emulates hardware  reset by running the second test
+#    with stored data from the first test.
+# 4. DUT checks that the stuck key was substituted by the real key.
+# 5. DUT starts mesh with loading stored data and checks that if they were restored correctly.
+
+overlay=overlay_pst_conf
+RunTestFlash mesh_pst_prov_data_check_stuck_key persistence_provisioning_data_save -flash_erase \
+	-- -argstest persist-stuck-key=1
+
+overlay=overlay_pst_conf
+RunTestFlash mesh_pst_prov_data_check_stuck_key persistence_provisioning_data_load -flash_rm \
+	-- -argstest persist-stuck-key=1

--- a/tests/bsim/bluetooth/mesh/tests_scripts/persistence/provisioning.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/persistence/provisioning.sh
@@ -4,14 +4,22 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 
-# Note:
+# Test checks that mesh provisioning data is saved and loaded correctly.
+#
 # Tests must be added in pairs and in sequence.
 # First test: saves data; second test: verifies it.
+#
+# Test procedure:
+# 1. Device Under Test (DUT) initializes the Mesh stack,
+#    and starts provisioning and configuration itself.
+# 2. Test scenario emulates hardware  reset by running the second test
+#    with stored data from the first test.
+# 3. DUT starts mesh with loading stored data and checks that if they were restored correctly.
 
-# SKIP=(persistence_provisioning_data_save)
 overlay=overlay_pst_conf
-RunTestFlash mesh_pst_prov_data_check persistence_provisioning_data_save -flash_erase
+RunTestFlash mesh_pst_prov_data_check persistence_provisioning_data_save -flash_erase \
+	-- -argstest persist-stuck-key=0
 
-# SKIP=(persistence_provisioning_data_load)
 overlay=overlay_pst_conf
-RunTestFlash mesh_pst_prov_data_check persistence_provisioning_data_load -flash_rm
+RunTestFlash mesh_pst_prov_data_check persistence_provisioning_data_load -flash_rm \
+	-- -argstest persist-stuck-key=0


### PR DESCRIPTION
PR adds destruction of the persisted in PSA ITS key if mesh does not own it (zero bit in the bitmap of persisted keys).
This is not standard mesh behavior, but might happen if something happens between removing key data in mesh and in the crypto library (for example, power off in between).
    
Previously, mesh wasn't able to import key with gotten stuck key ID. The current fix reproduces more robust behavior.

Additionally, PR extends the existing mesh persistent provisioning bsim test to emulate gotten stuck key and checking this key was destroyed, and correct one was imported instead.