### PR TITLE
drivers: serial: nrfx_uarte: fix race condition in uart_rx_disable due to RXTO event

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1282,18 +1282,17 @@ static int uarte_nrfx_callback_set(const struct device *dev,
 
 static int uarte_nrfx_rx_disable(const struct device *dev)
 {
+	int key = irq_lock();
 	struct uarte_nrfx_data *data = dev->data;
 	struct uarte_async_rx *async_rx = &data->async->rx;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	int key;
 
 	if (async_rx->buf == NULL) {
+		irq_unlock(key);
 		return -EFAULT;
 	}
 
 	k_timer_stop(&async_rx->timer);
-
-	key = irq_lock();
 
 	if (async_rx->next_buf != NULL) {
 		nrf_uarte_shorts_disable(uarte, NRF_UARTE_SHORT_ENDRX_STARTRX);


### PR DESCRIPTION
Fixes a race condition where uart_rx_disable() is interrupted by RXTO ISR, which can corrupt internal driver state. The IRQ lock is now taken earlier to ensure atomic access to RX buffer and flags.

Tested on nRF52840 at 460800 baud using Modbus RTU.

Fixes: #92777