### PR TITLE
samples: display: Fix stm32n6570_dk fsbl variant

### DIFF
--- a/samples/drivers/display/boards/stm32n6570_dk_stm32n657xx_fsbl.conf
+++ b/samples/drivers/display/boards/stm32n6570_dk_stm32n657xx_fsbl.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 ST Microelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+# On STM32N6 DK board, display being larger, it requires
+# more memory to draw squares on the display (40K)
+CONFIG_HEAP_MEM_POOL_SIZE=65536


### PR DESCRIPTION
When adding new fsbl variant this sample Kconfig overlay was missed leading to non functional sample on this variant.