### PR TITLE
kconfig: avoid useless EXCEPTION_DEBUG code when LOG is disabled

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -611,7 +611,7 @@ config IRQ_OFFLOAD_NESTED
 config EXCEPTION_DEBUG
 	bool "Unhandled exception debugging"
 	default y
-	depends on PRINTK || LOG
+	depends on LOG || (ARC && PRINTK)
 	help
 	  Install handlers for various CPU exception/trap vectors to
 	  make debugging them easier, at a small expense in code size.


### PR DESCRIPTION
On most architectures, the code enabled by EXCEPTION_DEBUG uses the logging subsystem. If LOG is disabled, the exception debug handlers do nothing, and the option only wastes space (e.g. 28 bytes on RISC-V).

However, on ARC, the code still falls back to using printk when LOG is not available, so EXCEPTION_DEBUG remains useful.

Update the Kconfig dependency to reflect this:
 - Require LOG on all platforms
 - Allow ARC to use PRINTK as a fallback

This avoids enabling EXCEPTION_DEBUG when it would have no effect.