### PR TITLE
dts: bindings: mark power gpio in bg95 as optional

### DIFF
--- a/dts/bindings/modem/quectel,bg95.yaml
+++ b/dts/bindings/modem/quectel,bg95.yaml
@@ -10,4 +10,3 @@ include: uart-device.yaml
 properties:
   mdm-power-gpios:
     type: phandle-array
-    required: true


### PR DESCRIPTION
The Quectel BG95 binding currently marks `mdm-power-gpios` as required.  This fits designs that expose the PWRKEY pin, but the BG95-M3 in Mini PCIe form-factor boots automatically via its on-module “Automatic Power-On Circuit” and does not route PWRKEY to the card edge. Instead it routes the PERST pin (RESET_N on the module itself) that is indeed internally connected to PWRKEY, so the same `mdm-power-gpios` can be re-used, but still it is not required, as the module will automatically start if 3v3 is provided. 

This should not affect the `modem_cellular` driver, which already considers that `power-gpio` can be omitted

<img width="476" alt="image" src="https://github.com/user-attachments/assets/5f4c7aed-189a-4c41-8e54-c164e4100202" />
