### PR TITLE
drivers: spi: esp32: fix volatile array zeroing to use explicit loop

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -98,7 +98,9 @@ static int IRAM_ATTR spi_esp32_transfer(const struct device *dev)
 	}
 
 	/* clean up and prepare SPI hal */
-	memset((uint32_t *)hal->hw->data_buf, 0, sizeof(hal->hw->data_buf));
+	for (size_t i = 0; i < ARRAY_SIZE(hal->hw->data_buf); ++i) {
+		hal->hw->data_buf[i] = 0;
+	}
 	hal_trans->send_buffer = tx_temp ? tx_temp : (uint8_t *)ctx->tx_buf;
 	hal_trans->rcv_buffer = rx_temp ? rx_temp : ctx->rx_buf;
 	hal_trans->tx_bitlen = bit_len;


### PR DESCRIPTION
Replace memset() with an explicit loop to zero the data_buf array, which is part of a volatile struct. Standard memset does not guarantee volatile stores, which can lead to incorrect hardware access.

This fixes 3 test scenarios in `spi_loopback`:

```
 - FAIL - [spi_loopback.test_spi_null_tx_buf] duration = 0.016 seconds
 - FAIL - [spi_loopback.test_spi_null_tx_buf_set] duration = 0.016 seconds
 - PASS - [spi_loopback.test_spi_null_tx_rx_buf_set] duration = 0.001 seconds
 - FAIL - [spi_loopback.test_spi_rx_bigger_than_tx] duration = 0.013 seconds
```
