### PR TITLE
soc: esp32: loader: skip non-valid segment after the last valid one

### DIFF
--- a/soc/espressif/common/loader.c
+++ b/soc/espressif/common/loader.c
@@ -69,7 +69,8 @@
 #endif
 #define IS_SRAM(o) (IS_IRAM(o) || IS_DRAM(o))
 #define IS_MMAP(o) (IS_IROM(o) || IS_DROM(o))
-#define IS_LAST(o) (o.load_addr == 0xffffffff)
+#define IS_LAST(o) \
+	(!IS_IROM(o) && !IS_DROM(o) && !IS_IRAM(o) && !IS_DRAM(o) && !IS_PADD(o) && !IS_RTC(o))
 
 #define HDR_ATTR __attribute__((section(".entry_addr"))) __attribute__((used))
 


### PR DESCRIPTION
Some ESP32 images may not end with a segment whose load_addr is 0xFFFFFFFF, especially if the flash was not fully erased or the image tool does not write an explicit end marker. This can cause the loader to process leftover or unrelated data as additional segments, resulting in boot failures.

Update the IS_LAST() macro to treat any segment not matching a valid memory region as the end of the segment list. This ensures only valid segments are loaded and any trailing invalid data is safely skipped.

This fixes the following scenario where last `IRAM` region has invalid VMA and length:
```
I (69) boot: DRAM: lma 0x00000020 vma 0x3fc89a20 len 0x16f0   (5872)
I (75) boot: IRAM: lma 0x00001718 vma 0x40380000 len 0x9a10   (39440)
I (82) boot: IRAM: lma 0x0000b138 vma 0x00000000 len 0x4ec0   (20160)
I (88) boot: IMAP: lma 0x00010000 vma 0x42000000 len 0x420c   (16908)
I (94) boot: IRAM: lma 0x00014214 vma 0x00000000 len 0xbde4   (48612)
I (100) boot: DMAP: lma 0x00020000 vma 0x3c010000 len 0x2000   (8192)
I (106) boot: IRAM: lma 0x00022008 vma 0x4ad14b05 len 0xa8095a7d (2819185277)
E (113) bootloader_flash: bootloader_flash_read src_addr 0xa80b7a85 not 4-byte aligned
E (121) boot: Failed to read segment header at a80b7a85
```
