### PR TITLE
soc: infineon: cyw20829: Adding MPU memory permission to userspace app

### DIFF
--- a/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
+++ b/dts/arm/infineon/cat1b/cyw20829/cyw20829.dtsi
@@ -45,11 +45,11 @@
 		reg = <0x20000000 SRAM0_SIZE>;
 
 		/* SRAM aliased address path */
-		sram_sahb: sram_bus_alias@20000000 {
+		sram_sahb: sram_sahb@20000000 {
 			reg = <0x20000000 SRAM0_SIZE>;  /* SAHB address */
 		};
 
-		sram_cbus: sram_bus_alias@4000000 {
+		sram_cbus: sram_cbus@4000000 {
 			reg = <0x04000000 SRAM0_SIZE>;  /* CBUS address */
 		};
 	};
@@ -59,9 +59,20 @@
 	 * (e.g. 0x20000000 + 0x40000 - 12K (0x3000) = 0x2003D000)
 	 */
 	sram_bootstrap: memory@2003D000 {
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "BOOTSTRAP_RAM";
 		reg = <0x2003D000 BOOTSTRAP_SIZE>;
+
+		/* SRAM aliased address path */
+		sram_bootstrap_sahb: sram_bootstrap_sahb@2003D000 {
+			reg = <0x2003D000 BOOTSTRAP_SIZE>;  /* SAHB address */
+		};
+
+		sram_bootstrap_cbus: sram_bootstrap_cbus@403D000 {
+			reg = <0x0403D000 BOOTSTRAP_SIZE>;  /* CBUS address */
+		};
 	};
 
 	qspi_flash: qspi_flash@40890000 {

--- a/soc/infineon/cat1b/cyw20829/mpu_regions.c
+++ b/soc/infineon/cat1b/cyw20829/mpu_regions.c
@@ -7,8 +7,9 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/arm/cortex_m/arm_mpu_mem_cfg.h>
 
-#define BOOTSTRAP_RAM_BASE_ADDRESS DT_REG_ADDR(DT_NODELABEL(sram_bootstrap))
-#define BOOTSTRAP_RAM_SIZE         DT_REG_SIZE(DT_NODELABEL(sram_bootstrap))
+#define BOOTSTRAP_SAHB_RAM_BASE_ADDRESS DT_REG_ADDR(DT_NODELABEL(sram_bootstrap_sahb))
+#define BOOTSTRAP_CBUS_RAM_BASE_ADDRESS DT_REG_ADDR(DT_NODELABEL(sram_bootstrap_cbus))
+#define BOOTSTRAP_RAM_SIZE              DT_REG_SIZE(DT_NODELABEL(sram_bootstrap))
 
 #define REGION_BOOTSTRAP_RAM_ATTR(base, size)                                                 \
 	{                                                                                       \
@@ -24,8 +25,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 	MPU_REGION_ENTRY("SRAM", CONFIG_SRAM_BASE_ADDRESS,
 			 REGION_RAM_ATTR(CONFIG_SRAM_BASE_ADDRESS, CONFIG_SRAM_SIZE * 1024)),
 
-	MPU_REGION_ENTRY("BOOTSTRAP_RAM", BOOTSTRAP_RAM_BASE_ADDRESS,
-			 REGION_BOOTSTRAP_RAM_ATTR(BOOTSTRAP_RAM_BASE_ADDRESS, BOOTSTRAP_RAM_SIZE)),
+	MPU_REGION_ENTRY(
+		"BOOTSTRAP_SAHB_RAM", BOOTSTRAP_SAHB_RAM_BASE_ADDRESS,
+		REGION_BOOTSTRAP_RAM_ATTR(BOOTSTRAP_SAHB_RAM_BASE_ADDRESS, BOOTSTRAP_RAM_SIZE)),
+
+	MPU_REGION_ENTRY(
+		"BOOTSTRAP_CBUS_RAM", BOOTSTRAP_CBUS_RAM_BASE_ADDRESS,
+		REGION_BOOTSTRAP_RAM_ATTR(BOOTSTRAP_CBUS_RAM_BASE_ADDRESS, BOOTSTRAP_RAM_SIZE)),
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
Adds additional MPU memory permissions to userspace applications by default.  This change addresses an MPU fault encountered when running tests/kernel/common and tests/drivers/adc/adc_api.

To address the MPU fault in the userspace tests, additional permissions for memory locations are opened for user space access. This default memory permission is permissive to most tasks and should be tuned based on the end user needs of the system.  