### PR TITLE
samples: mgmt: hawkbit: force BOOT_MAX_IMG_SECTORS for stm32h573i_dk

### DIFF
--- a/samples/subsys/mgmt/hawkbit/sample.yaml
+++ b/samples/subsys/mgmt/hawkbit/sample.yaml
@@ -17,6 +17,8 @@ tests:
   sample.net.hawkbit.default: {}
   sample.net.hawkbit.sysbuild:
     sysbuild: true
+    extra_args:
+      - platform:stm32h573i_dk/stm32h573xx:mcuboot_CONFIG_BOOT_MAX_IMG_SECTORS=128
   sample.net.hawkbit.manual:
     extra_configs:
       - CONFIG_HAWKBIT_MANUAL=y


### PR DESCRIPTION
The stm32h573i_dk target had the default value of BOOT_MAX_IMG_SECTORS raised in efdd2a8ff2d (west.yml: MCUboot synchronization from upstream). This currently causes a build failure on some samples running with mcuboot because the platform has not been moved to use external flash (which was the reason for increasing BOOT_MAX_IMG_SECTORS)

To workaround this, force the value of BOOT_MAX_IMG_SECTORS for failing tests.


For more details, see the failure here: https://github.com/zephyrproject-rtos/zephyr/runs/45512566680