### PR TITLE
drivers: dma: sam: add support for sama7g5 DMA Controller (XDMAC)

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -94,6 +94,18 @@
 	};
 };
 
+&dma0 {
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
 &flx3 {
 	mchp,flexcom-mode = <SAM_FLEXCOM_MODE_USART>;
 	status = "okay";

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
@@ -9,6 +9,7 @@ toolchain:
   - zephyr
 ram: 128
 supported:
+  - dma
   - entropy
   - pwm
   - sdhc

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -243,6 +243,10 @@ static int sam_xdmac_config(const struct device *dev, uint32_t channel,
 			| XDMAC_CC_MBSIZE(burst_size == 0U ? 0 : burst_size - 1)
 			| XDMAC_CC_SAM_INCREMENTED_AM
 			| XDMAC_CC_DAM_INCREMENTED_AM;
+#if defined(CONFIG_SOC_SERIES_SAMA7G5)
+		/* When a memory-to-memory transfer is performed, configure PERID to 0x7F. */
+		cfg->dma_slot = 0x7F;
+#endif
 		break;
 	case MEMORY_TO_PERIPHERAL:
 		channel_cfg.cfg =
@@ -264,11 +268,14 @@ static int sam_xdmac_config(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	channel_cfg.cfg |=
-		  XDMAC_CC_DWIDTH(data_size)
-		| XDMAC_CC_SIF_AHB_IF1
-		| XDMAC_CC_DIF_AHB_IF1
-		| XDMAC_CC_PERID(cfg->dma_slot);
+	channel_cfg.cfg |= XDMAC_CC_DWIDTH(data_size) |
+#ifdef XDMAC_CC_SIF_AHB_IF1
+			   XDMAC_CC_SIF_AHB_IF1 |
+#endif
+#ifdef XDMAC_CC_DIF_AHB_IF1
+			   XDMAC_CC_DIF_AHB_IF1 |
+#endif
+			   XDMAC_CC_PERID(cfg->dma_slot);
 	channel_cfg.ds_msp = 0U;
 	channel_cfg.sus = 0U;
 	channel_cfg.dus = 0U;

--- a/dts/arm/microchip/sam/sama7g5.dtsi
+++ b/dts/arm/microchip/sam/sama7g5.dtsi
@@ -46,6 +46,39 @@
 			#clock-cells = <1>;
 		};
 
+		dma0: dma-controller@e2808000 {
+			compatible = "atmel,sam-xdmac";
+			reg = <0xe2808000 0x1000>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 112 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			#dma-cells = <2>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 22>;
+			clock-names = "dma_clk";
+			status = "disabled";
+		};
+
+		dma1: dma-controller@e280c000 {
+			compatible = "atmel,sam-xdmac";
+			reg = <0xe280c000 0x1000>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 113 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			#dma-cells = <2>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 23>;
+			clock-names = "dma_clk";
+			status = "disabled";
+		};
+
+		dma2: dma-controller@e1200000 {
+			compatible = "atmel,sam-xdmac";
+			reg = <0xe1200000 0x1000>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 114 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			#dma-cells = <2>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 24>;
+			clock-names = "dma_clk";
+			status = "disabled";
+		};
+
 		flx0: flexcom@e1818000 {
 			compatible = "microchip,sam-flexcom";
 			reg = <0xe1818000 0x200>;

--- a/soc/microchip/sam/sama7g5/Kconfig.defconfig
+++ b/soc/microchip/sam/sama7g5/Kconfig.defconfig
@@ -14,4 +14,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config MMU
 	default y
 
+config CACHE_MANAGEMENT
+	default y
+
 endif # SOC_SERIES_SAMA7G5

--- a/soc/microchip/sam/sama7g5/soc.c
+++ b/soc/microchip/sam/sama7g5/soc.c
@@ -15,6 +15,11 @@
 					       MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),),	\
 			())
 
+#define MMU_REGION_XDMAC_DEFN(idx, n)								\
+		IF_ENABLED(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(dma##n)),			\
+			   (MMU_REGION_FLAT_ENTRY("xdmac"#n, XDMAC##n##_BASE_ADDRESS, 0x4000,	\
+						  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
+
 static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("vectors", CONFIG_KERNEL_VM_BASE, 0x1000,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_X),
@@ -49,6 +54,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 	IF_ENABLED(DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(trng)),
 		   (MMU_REGION_FLAT_ENTRY("trng", TRNG_BASE_ADDRESS, 0x100,
 					  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
+
+	FOR_EACH_IDX(MMU_REGION_XDMAC_DEFN, (), 0, 1, 2)
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
Changes in this PR includes:
- enable MMU for sama7g5 XDMAC
- update driver to support multiple instances
- update driver for supporting for sama7g5 DMA
- update driver for DMA suspend and resume support
- add XDMAC nodes for sama7g5
