### PR TITLE
Bluetooth: Controller: Fix stuck forced continuation under throughput

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -236,7 +236,8 @@ struct lll_prepare_param {
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 	int8_t  prio;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
-	uint8_t force;
+	uint8_t force:1;
+	uint8_t defer:1;
 	void *param;
 };
 

--- a/subsys/bluetooth/controller/ll_sw/lll_common.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_common.c
@@ -62,6 +62,8 @@ int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	prepare_param->prio = prio;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 
+	prepare_param->defer = 0U;
+
 	err = lll_prepare_resolve(is_abort_cb, abort_cb, prepare_cb, prepare_param, 0U, 0U);
 
 	return err;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -805,6 +805,8 @@ void lll_isr_early_abort(void *param)
 {
 	int err;
 
+	radio_status_reset();
+
 	radio_isr_set(isr_race, param);
 	if (!radio_is_idle()) {
 		radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -247,12 +247,21 @@ static int prepare_cb(struct lll_prepare_param *p)
 	overhead = lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle), ticks_at_event);
 	/* check if preempt to start has changed */
 	if (overhead) {
-		LL_ASSERT_OVERHEAD(overhead);
+		int err;
+
+		if (p->defer == 1U) {
+			/* We accept the overlap as previous event elected to continue */
+			err = 0;
+		} else {
+			LL_ASSERT_OVERHEAD(overhead);
+
+			err = -ECANCELED;
+		}
 
 		radio_isr_set(lll_isr_abort, lll);
 		radio_disable();
 
-		return -ECANCELED;
+		return err;
 	}
 #endif /* !CONFIG_BT_CTLR_XTAL_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -165,15 +165,16 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 {
 	struct lll_conn *lll = curr;
 
-	/* Do not abort if near supervision timeout */
-	if (lll->forced) {
-		return 0;
-	}
+	if (next != curr) {
+		/* Do not be aborted by a different event if near supervision timeout */
+		if ((lll->forced == 1U) && (trx_cnt < 1U)) {
+			return 0;
+		}
 
-	/* Do not be aborted by same event if a single central trx has not been
-	 * exchanged.
-	 */
-	if ((next == curr) && (trx_cnt < 1U)) {
+	} else if (trx_cnt < 1U) {
+		/* Do not be aborted by same event if a single central's Rx has not completed.
+		 * Cases where single trx duration can be greater than connection interval.
+		 */
 		return -EBUSY;
 	}
 
@@ -187,15 +188,16 @@ int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 {
 	struct lll_conn *lll = curr;
 
-	/* Do not abort if near supervision timeout */
-	if (lll->forced) {
-		return 0;
-	}
+	if (next != curr) {
+		/* Do not be aborted by a different event if near supervision timeout */
+		if ((lll->forced == 1U) && (tx_cnt < 1U)) {
+			return 0;
+		}
 
-	/* Do not be aborted by same event if a single peripheral trx has not
-	 * been exchanged.
-	 */
-	if ((next == curr) && (tx_cnt < 1U)) {
+	} else if (tx_cnt < 1U) {
+		/* Do not be aborted by same event if a single peripheral's Tx has not completed.
+		 * Cases where single trx duration can be greater than connection interval.
+		 */
 		return -EBUSY;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -69,6 +69,7 @@ static uint8_t crc_valid;
 static uint8_t is_aborted;
 static uint16_t tx_cnt;
 static uint16_t trx_cnt;
+static uint8_t trx_busy_iteration;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 static uint8_t mic_state;
@@ -153,6 +154,7 @@ void lll_conn_prepare_reset(void)
 	crc_valid = 0U;
 	crc_expire = 0U;
 	is_aborted = 0U;
+	trx_busy_iteration = 0U;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	mic_state = LLL_CONN_MIC_NONE;
@@ -160,6 +162,13 @@ void lll_conn_prepare_reset(void)
 }
 
 #if defined(CONFIG_BT_CENTRAL)
+/* Number of times central event being aborted by same event instance be skipped */
+/* FIXME: Increasing this causes event pipeline overflow assertion, add LLL implementation to
+ *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
+ *        interface.
+ */
+#define CENTRAL_TRX_BUSY_ITERATION_MAX 0
+
 int lll_conn_central_is_abort_cb(void *next, void *curr,
 				 lll_prepare_cb_t *resume_cb)
 {
@@ -171,7 +180,9 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 			return 0;
 		}
 
-	} else if (trx_cnt < 1U) {
+	} else if ((trx_cnt < 1U) && (trx_busy_iteration < CENTRAL_TRX_BUSY_ITERATION_MAX)) {
+		trx_busy_iteration++;
+
 		/* Do not be aborted by same event if a single central's Rx has not completed.
 		 * Cases where single trx duration can be greater than connection interval.
 		 */
@@ -183,6 +194,13 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 #endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_PERIPHERAL)
+/* Number of times peripheral event being aborted by same event instance be skipped */
+/* FIXME: Increasing this causes event pipeline overflow assertion, add LLL implementation to
+ *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
+ *        interface.
+ */
+#define PERIPHERAL_TRX_BUSY_ITERATION_MAX 0
+
 int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 				    lll_prepare_cb_t *resume_cb)
 {
@@ -194,7 +212,9 @@ int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 			return 0;
 		}
 
-	} else if (tx_cnt < 1U) {
+	} else if ((tx_cnt < 1U) && (trx_busy_iteration < PERIPHERAL_TRX_BUSY_ITERATION_MAX)) {
+		trx_busy_iteration++;
+
 		/* Do not be aborted by same event if a single peripheral's Tx has not completed.
 		 * Cases where single trx duration can be greater than connection interval.
 		 */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -163,11 +163,10 @@ void lll_conn_prepare_reset(void)
 
 #if defined(CONFIG_BT_CENTRAL)
 /* Number of times central event being aborted by same event instance be skipped */
-/* FIXME: Increasing this causes event pipeline overflow assertion, add LLL implementation to
- *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
- *        interface.
+/* NOTE: Coded PHY S8 coding of 251 byte PDU at 7.5 ms connection interval need up to 4 events
+ *       to be skipped due to large connection event length.
  */
-#define CENTRAL_TRX_BUSY_ITERATION_MAX 0
+#define CENTRAL_TRX_BUSY_ITERATION_MAX 4
 
 int lll_conn_central_is_abort_cb(void *next, void *curr,
 				 lll_prepare_cb_t *resume_cb)
@@ -195,11 +194,10 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 
 #if defined(CONFIG_BT_PERIPHERAL)
 /* Number of times peripheral event being aborted by same event instance be skipped */
-/* FIXME: Increasing this causes event pipeline overflow assertion, add LLL implementation to
- *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
- *        interface.
+/* NOTE: Coded PHY S8 coding of 251 byte PDU at 7.5 ms connection interval need up to 4 events
+ *       to be skipped due to large connection event length.
  */
-#define PERIPHERAL_TRX_BUSY_ITERATION_MAX 0
+#define PERIPHERAL_TRX_BUSY_ITERATION_MAX 4
 
 int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 				    lll_prepare_cb_t *resume_cb)
@@ -436,11 +434,26 @@ void lll_conn_isr_rx(void *param)
 		cte_len = 0U;
 	}
 
+#if defined(CONFIG_BT_PERIPHERAL)
+	/* Lets close early so that drift compensation is calculated before this event overlaps
+	 * with next interval.
+	 * TODO: Optimize, to improve throughput, by removing this early close and using the drift
+	 *       compensation value in the overlapping next interval, if under high throughput
+	 *       scenarios.
+	 */
+	is_done = is_done || (lll->periph.window_size_event_us != 0U);
+#endif /* CONFIG_BT_PERIPHERAL */
+
 	/* Decide on event continuation and hence Radio Shorts to use */
 	is_done = is_done || ((crc_ok) &&
 			      (pdu_data_rx->md == 0) &&
 			      (pdu_data_tx->md == 0) &&
 			      (pdu_data_tx->len == 0));
+	/* Do not continue anymore if this event had continued despite an abort requested by same
+	 * connection instance when overlapping due to connection event length being larger than
+	 * the connection interval.
+	 */
+	is_done = is_done || (trx_busy_iteration != 0U);
 
 	if (is_done) {
 		radio_isr_set(isr_done, param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -339,12 +339,21 @@ static int prepare_cb(struct lll_prepare_param *p)
 	overhead = lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle), ticks_at_event);
 	/* check if preempt to start has changed */
 	if (overhead) {
-		LL_ASSERT_OVERHEAD(overhead);
+		int err;
+
+		if (p->defer == 1U) {
+			/* We accept the overlap as previous event elected to continue */
+			err = 0;
+		} else {
+			LL_ASSERT_OVERHEAD(overhead);
+
+			err = -ECANCELED;
+		}
 
 		radio_isr_set(lll_isr_abort, lll);
 		radio_disable();
 
-		return -ECANCELED;
+		return err;
 	}
 #endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1095,7 +1095,8 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn_lll->df_tx_cfg.is_initialized = 0U;
 		conn_lll->df_tx_cfg.cte_rsp_en = 0U;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
-		conn->connect_expire = 6;
+		conn->event_counter = 0U;
+		conn->connect_expire = CONN_ESTAB_COUNTDOWN;
 		conn->supervision_expire = 0;
 
 #if defined(CONFIG_BT_CTLR_LE_PING)

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -268,6 +268,7 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn_lll->df_tx_cfg.cte_rsp_en = 0U;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
 
+	conn->event_counter = 0U;
 	conn->connect_expire = CONN_ESTAB_COUNTDOWN;
 	conn->supervision_expire = 0U;
 	conn_interval_us = (uint32_t)interval * CONN_INT_UNIT_US;
@@ -944,6 +945,9 @@ void ull_central_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	/* Increment prepare reference count */
 	ref = ull_ref_inc(&conn->ull);
 	LL_ASSERT(ref);
+
+	/* Increment event counter */
+	conn->event_counter += (lazy + 1U);
 
 	/* De-mux 2 tx node from FIFO, sufficient to be able to set MD bit */
 	ull_conn_tx_demux(2);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -167,31 +167,6 @@ struct ll_conn {
 	struct ull_hdr  ull;
 	struct lll_conn lll;
 
-#if defined(CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER)
-	struct past_params past;
-#endif /* CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER */
-
-	struct ull_tx_q tx_q;
-	struct llcp_struct llcp;
-
-	struct {
-		uint8_t reason_final;
-		/* node rx type with dummy uint8_t to ensure room for terminate
-		 * reason.
-		 * HCI will reference the value using the pdu member of
-		 * struct node_rx_pdu.
-		 *
-		 */
-		struct {
-			struct node_rx_pdu rx;
-			uint8_t dummy_reason;
-		} node_rx;
-	} llcp_terminate;
-
-/*
- * TODO: all the following comes from the legacy LL llcp structure
- * and/or needs to be properly integrated in the control procedures
- */
 	union {
 		struct {
 #if defined(CONFIG_BT_CTLR_CONN_META)
@@ -220,13 +195,41 @@ struct ll_conn {
 #endif /* CONFIG_BT_CENTRAL */
 	};
 
+	struct ull_tx_q tx_q;
+	struct llcp_struct llcp;
+
+	/* ULL tracked connection event counter. Under LLL Prepare deferred cases this member
+	 * accumulates the connection event count, necessary for LLCP instant use in ULL.
+	 */
+	uint16_t event_counter;
+
 	/* Cancel the prepare in the instant a Connection Update takes place */
 	uint8_t cancel_prepare:1;
+
+	/*
+	 * TODO: all the following comes from the legacy LL llcp structure
+	 * and/or needs to be properly integrated in the control procedures
+	 */
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	/* Pause Rx data PDU's */
 	uint8_t pause_rx_data:1;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
+
+	/* Terminate Procedure reason and event memory per connection */
+	struct {
+		uint8_t reason_final;
+		/* node rx type with dummy uint8_t to ensure room for terminate
+		 * reason.
+		 * HCI will reference the value using the pdu member of
+		 * struct node_rx_pdu.
+		 *
+		 */
+		struct {
+			struct node_rx_pdu rx;
+			uint8_t dummy_reason;
+		} node_rx;
+	} llcp_terminate;
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	uint16_t appto_reload;
@@ -244,6 +247,7 @@ struct ll_conn {
 	uint8_t phy_pref_tx:3;
 	uint8_t phy_pref_rx:3;
 #endif /* CONFIG_BT_CTLR_PHY */
+
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	uint16_t default_tx_octets;
 
@@ -251,6 +255,10 @@ struct ll_conn {
 	uint16_t default_tx_time;
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+
+#if defined(CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER)
+	struct past_params past;
+#endif /* CONFIG_BT_CTLR_SYNC_TRANSFER_RECEIVER */
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_CONN)
 	uint8_t own_id_addr_type:1;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -580,6 +580,9 @@ void ull_periph_ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	ref = ull_ref_inc(&conn->ull);
 	LL_ASSERT(ref);
 
+	/* Increment event counter */
+	conn->event_counter += (lazy + 1U);
+
 	/* Append timing parameters */
 	p.ticks_at_expire = ticks_at_expire;
 	p.remainder = remainder;

--- a/tests/bluetooth/controller/common/src/helper_util.c
+++ b/tests/bluetooth/controller/common/src/helper_util.c
@@ -314,7 +314,7 @@ void test_set_role(struct ll_conn *conn, uint8_t role)
 
 void event_prepare(struct ll_conn *conn)
 {
-	struct lll_conn *lll;
+	struct lll_conn *lll = &conn->lll;
 	uint32_t *evt_active = &(event_active[find_idx(conn)]);
 
 	/* Can only be called with no active event */
@@ -323,11 +323,13 @@ void event_prepare(struct ll_conn *conn)
 
 	/*** ULL Prepare ***/
 
+	/* Event counter */
+	conn->event_counter = lll->event_counter + lll->latency_prepare;
+
 	/* Handle any LL Control Procedures */
 	ull_cp_run(conn);
 
 	/*** LLL Prepare ***/
-	lll = &conn->lll;
 
 	/* Save the latency for use in event */
 	lll->latency_prepare += lll->latency;


### PR DESCRIPTION
Fix stuck forced continuation of connection event under high throughput scenario. At near supervision timeout the force flag is set, but in the next connection event if full connection interval is used for data transmission and a subsequent request to abort happens it was not honoured causing the tx-rx chain to keep continuing until supervision timeout.
