### PR TITLE
west: spdx: make SBOM generation compatible with Python < 3.12

### DIFF
--- a/scripts/west_commands/zspdx/scanner.py
+++ b/scripts/west_commands/zspdx/scanner.py
@@ -241,7 +241,7 @@ def scanDocument(cfg, doc):
                 f.licenseInfoInFile = splitExpression(expression)
 
             if copyrights := getCopyrightInfo(f.abspath):
-                f.copyrightText = f"<text>\n{'\n'.join(copyrights)}\n</text>"
+                f.copyrightText = "<text>\n" + "\n".join(copyrights) + "\n</text>"
 
             # check if any custom license IDs should be flagged for document
             for lic in f.licenseInfoInFile:


### PR DESCRIPTION
Avoid f-strings with backslashes for Python < 3.12 compatibility, which fixes SBOM generation crashes on older Python versions.