### PR TITLE
drivers: bluetooth: silabs: Fix indicating support for 2M phy

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -170,6 +170,7 @@ config BT_SILABS_EFR32
 	select BT_CTLR_CONN_RSSI_SUPPORT
 	select BT_CTLR_ADV_EXT_SUPPORT
 	select BT_CTLR_PRIVACY_SUPPORT
+	select BT_CTLR_PHY_2M_SUPPORT
 	help
 	  Use Silicon Labs binary Bluetooth library to connect to the
 	  controller.


### PR DESCRIPTION
Previously we always had driver to support 2M PHY regardless of configuration. As this was fixed the missing support statemenent caused 2M support to miss regardless of configuration.