### PR TITLE
tests: ztest: add test hold status in DEVICE_PM

### DIFF
--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -101,7 +101,7 @@ config ZTEST_ASSERT_HOOK
 
 config ZTEST_NO_YIELD
 	bool "Do not yield to the idle thread after tests complete"
-	default y if PM
+	default y if (PM || PM_DEVICE || PM_DEVICE_RUNTIME)
 	help
 	  When the tests complete, do not yield to the idle thread and instead
 	  spin in a loop. This is useful for low power mode tests, where


### PR DESCRIPTION
for DEVICE_PM and DEVICE_PM_RUNTIME, ztest need
hold status like CONFIG_PM, otherwise the following flash will be blocked for some SOC