### PR TITLE
Update Interrupt Controller driver to support Renesas RZ/A3UL, V2L

### DIFF
--- a/drivers/interrupt_controller/Kconfig.renesas_rz
+++ b/drivers/interrupt_controller/Kconfig.renesas_rz
@@ -9,3 +9,14 @@ config RENESAS_RZ_EXT_IRQ
 	select PINCTRL
 	help
 	  Renesas RZ external interrupt controller driver
+
+if RENESAS_RZ_EXT_IRQ
+
+config RENESAS_RZ_INTC_HAS_NMI
+	bool "NMI (Non Maskable Interrupt) pin"
+	default y
+	depends on SOC_SERIES_RZG3S || SOC_SERIES_RZA3UL
+	help
+	  Renesas RZ interrupt controller has NMI (Non Maskable Interrupt) pin
+
+endif

--- a/dts/arm/renesas/rz/rzg/r9a08g045.dtsi
+++ b/dts/arm/renesas/rz/rzg/r9a08g045.dtsi
@@ -832,9 +832,11 @@
 			};
 		};
 
-		intc: interrupt-controller@41060000 {
-			reg = <0x41060000 0x18>;
-			#address-cells = <0>;
+		intc: intc@41060000 {
+			compatible = "renesas,rz-intc";
+			reg = <0x41060000 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
 			interrupt-parent = <&nvic>;
 
 			nmi: nmi {
@@ -845,57 +847,72 @@
 				status = "disabled";
 			};
 
-			irq0: irq0 {
+			irq0: irq@0 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x0>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <1 1>;
 				status = "disabled";
 			};
-			irq1: irq1 {
+
+			irq1: irq@1 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x1>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <2 1>;
 				status = "disabled";
 			};
-			irq2: irq2 {
+
+			irq2: irq@2 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <3 1>;
 				status = "disabled";
 			};
-			irq3: irq3 {
+
+			irq3: irq@3 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x3>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <4 1>;
 				status = "disabled";
 			};
-			irq4: irq4 {
+
+			irq4: irq@4 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x4>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <5 1>;
 				status = "disabled";
 			};
-			irq5: irq5 {
+
+			irq5: irq@5 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x5>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <6 1>;
 				status = "disabled";
 			};
-			irq6: irq6 {
+
+			irq6: irq@6 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x6>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <7 1>;
 				status = "disabled";
 			};
-			irq7: irq7 {
+
+			irq7: irq@7 {
 				compatible = "renesas,rz-ext-irq";
+				reg = <0x7>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
 				interrupts = <8 1>;

--- a/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
+++ b/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
@@ -114,6 +114,7 @@
 		};
 
 		icu: icu@81048000 {
+			compatible = "renesas,rz-icu";
 			reg = <0x81048000 0x1000>;
 			interrupt-parent = <&gic>;
 			#address-cells = <1>;

--- a/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g074.dtsi
@@ -90,6 +90,7 @@
 		};
 
 		icu: icu@81048000 {
+			compatible = "renesas,rz-icu";
 			reg = <0x81048000 0x1000>;
 			interrupt-parent = <&gic>;
 			#address-cells = <1>;

--- a/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
@@ -121,6 +121,7 @@
 		};
 
 		icu: icu@81048000 {
+			compatible = "renesas,rz-icu";
 			reg = <0x81048000 0x1000>;
 			interrupt-parent = <&gic>;
 			#address-cells = <1>;

--- a/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
@@ -695,6 +695,86 @@
 				status = "disabled";
 			};
 		};
+
+		intc: intc@410b0000 {
+			compatible = "renesas,rz-intc";
+			reg = <0x410b0000 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupt-parent = <&nvic>;
+
+			irq0: irq@0 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x0>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <1 1>;
+				status = "disabled";
+			};
+
+			irq1: irq@1 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x1>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <2 1>;
+				status = "disabled";
+			};
+
+			irq2: irq@2 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <3 1>;
+				status = "disabled";
+			};
+
+			irq3: irq@3 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x3>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <4 1>;
+				status = "disabled";
+			};
+
+			irq4: irq@4 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x4>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <5 1>;
+				status = "disabled";
+			};
+
+			irq5: irq@5 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x5>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <6 1>;
+				status = "disabled";
+			};
+
+			irq6: irq@6 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x6>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <7 1>;
+				status = "disabled";
+			};
+
+			irq7: irq@7 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x7>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <8 1>;
+				status = "disabled";
+			};
+		};
 	};
 };
 

--- a/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
+++ b/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
@@ -482,5 +482,93 @@
 				status = "disabled";
 			};
 		};
+
+		intc: intc@110a0000 {
+			compatible = "renesas,rz-intc";
+			reg = <0x110a0000 DT_SIZE_K(64)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			interrupt-parent = <&gic>;
+
+			nmi: nmi {
+				compatible = "renesas,rz-ext-irq";
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 0 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq0: irq@0 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x0>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq1: irq@1 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x1>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 2 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq2: irq@2 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 3 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq3: irq@3 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x3>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq4: irq@4 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x4>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 5 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq5: irq@5 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x5>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq6: irq@6 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x6>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 7 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+
+			irq7: irq@7 {
+				compatible = "renesas,rz-ext-irq";
+				reg = <0x7>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+				status = "disabled";
+			};
+		};
 	};
 };

--- a/dts/bindings/interrupt-controller/renesas,rz-icu.yaml
+++ b/dts/bindings/interrupt-controller/renesas,rz-icu.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RZ Interrupt Controller (ICU)
+compatible: "renesas,rz-icu"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/interrupt-controller/renesas,rz-intc.yaml
+++ b/dts/bindings/interrupt-controller/renesas,rz-intc.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RZ Interrupt Controller
+compatible: "renesas,rz-intc"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: c6fc0d018d28f197f6dfacccc762807e68e3d6fb
+      revision: c721e189e972cd0ede9b8e5321bce0be9d7ee8dc
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
This PR enables external interrupt feature on Renesas RZ/A3UL, V2L.
- Update `intc_renesas_rz_ext_irq.c` to using common source code for Renesas RZ devices
- Add device tree for Renesas RZ/A3UL, V2L
- Update interrupt nodes for Renesas RZ/G3S, N2L, T2M, T2L

Need: https://github.com/zephyrproject-rtos/hal_renesas/pull/117