### PR TITLE
net: coap_client: Don't send RST on unrecognized ACK response

### DIFF
--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -818,7 +818,10 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 	internal_req = get_request_with_token(client, response);
 	if (!internal_req) {
 		LOG_WRN("No matching request for response");
-		(void) send_rst(client, response); /* Ignore errors, unrelated to our queries */
+		if (response_type != COAP_TYPE_ACK) {
+			/* Ignore errors, unrelated to our queries */
+			(void)send_rst(client, response);
+		}
 		return 0;
 	}
 


### PR DESCRIPTION
According to CoAP RFC (7252, ch. 4.2), Reset cannot be sent in a response for an ACK reply, rejected ACKs should be silently ignored instead. Therefore, in case an unrecognized response is received, verify the response type before sending Reset.

Fixes #92721