### PR TITLE
drivers: counter: esp32: expose autoreload via dts

### DIFF
--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -379,7 +379,7 @@ static void counter_esp32_isr(void *arg)
 				.counter_en = TIMER_START,                                         \
 				.intr_type = TIMER_INTR_LEVEL,                                     \
 				.counter_dir = TIMER_COUNT_UP,                                     \
-				.auto_reload = TIMER_AUTORELOAD_DIS,                               \
+				.auto_reload = DT_INST_PROP(idx, autoreload),                      \
 				.divider = ESP32_COUNTER_GET_CLK_DIV(idx),                         \
 			},                                                                         \
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(TIMER(idx))),                            \

--- a/dts/bindings/counter/espressif,esp32-timer.yaml
+++ b/dts/bindings/counter/espressif,esp32-timer.yaml
@@ -54,4 +54,10 @@ properties:
     type: int
     default: 2
 
+  autoreload:
+    description: |
+      Autoreload causes the timer to never stop. After alarm event timer will
+      be reloaded automatically.
+    type: boolean
+
 compatible: "espressif,esp32-timer"


### PR DESCRIPTION
In my usecase `counter_set_channel_alarm()` stopped working after 100 seconds. (1ms period callback)
Using the autoreload feature fixes all my problems.