### PR TITLE
[Backport v3.7-branch] arch: common: fix copy for ramfunc region during XIP init + related fixup commit

### DIFF
--- a/arch/common/ramfunc.ld
+++ b/arch/common/ramfunc.ld
@@ -9,6 +9,7 @@
 
 SECTION_DATA_PROLOGUE(.ramfunc,,)
 {
+	__ramfunc_region_start = .;
 	MPU_ALIGN(__ramfunc_size);
 	__ramfunc_start = .;
 	*(.ramfunc)

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -144,6 +144,7 @@ endif()
 
 include(${COMMON_ZEPHYR_LINKER_DIR}/ram-end.cmake)
 
+zephyr_linker_symbol(SYMBOL __ramfunc_region_start EXPR "ADDR(.ramfunc)")
 zephyr_linker_symbol(SYMBOL __kernel_ram_start EXPR "(@__bss_start@)")
 zephyr_linker_symbol(SYMBOL __kernel_ram_end  EXPR "(${RAM_ADDR} + ${RAM_SIZE})")
 zephyr_linker_symbol(SYMBOL __kernel_ram_size EXPR "(@__kernel_ram_end@ - @__bss_start@)")

--- a/cmake/linker_script/arm/linker.cmake
+++ b/cmake/linker_script/arm/linker.cmake
@@ -144,7 +144,7 @@ endif()
 
 include(${COMMON_ZEPHYR_LINKER_DIR}/ram-end.cmake)
 
-zephyr_linker_symbol(SYMBOL __ramfunc_region_start EXPR "ADDR(.ramfunc)")
+zephyr_linker_symbol(SYMBOL __ramfunc_region_start EXPR "(@__ramfunc_start@)")
 zephyr_linker_symbol(SYMBOL __kernel_ram_start EXPR "(@__bss_start@)")
 zephyr_linker_symbol(SYMBOL __kernel_ram_end  EXPR "(${RAM_ADDR} + ${RAM_SIZE})")
 zephyr_linker_symbol(SYMBOL __kernel_ram_size EXPR "(@__kernel_ram_end@ - @__bss_start@)")

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -230,6 +230,7 @@ extern char _nocache_ram_size[];
  * section, stored in RAM instead of FLASH.
  */
 #ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
+extern char __ramfunc_region_start[];
 extern char __ramfunc_start[];
 extern char __ramfunc_end[];
 extern char __ramfunc_size[];

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -28,8 +28,8 @@ void z_data_copy(void)
 	z_early_memcpy(&__data_region_start, &__data_region_load_start,
 		       __data_region_end - __data_region_start);
 #ifdef CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
-	z_early_memcpy(&__ramfunc_start, &__ramfunc_load_start,
-		       (uintptr_t) &__ramfunc_size);
+	z_early_memcpy(&__ramfunc_region_start, &__ramfunc_load_start,
+		       __ramfunc_end - __ramfunc_region_start);
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ccm), okay)
 	z_early_memcpy(&__ccm_data_start, &__ccm_data_rom_start,


### PR DESCRIPTION
Backport 6023d6a1428d880a988f1be3ab1b5da5a6e86d61 (https://github.com/zephyrproject-rtos/zephyr/pull/80768) and b84076a192717894b09d6f4b643c727aa754673c  (https://github.com/zephyrproject-rtos/zephyr/pull/88599)

Fixes #88047