### PR TITLE
drivers: pwm: stm32: fix four channel pwm capture

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -621,7 +621,6 @@ static int pwm_stm32_enable_capture(const struct device *dev, uint32_t channel)
 
 	LL_TIM_CC_EnableChannel(cfg->timer, ch2ll[channel - 1]);
 	LL_TIM_CC_EnableChannel(cfg->timer, ch2ll[complimentary_channel[channel] - 1]);
-	LL_TIM_EnableIT_UPDATE(cfg->timer);
 	LL_TIM_GenerateEvent_UPDATE(cfg->timer);
 
 	return 0;
@@ -727,6 +726,8 @@ static void pwm_stm32_isr(const struct device *dev)
 			cpt->pulse = get_channel_capture[complimentary_channel[cpt->channel] - 1]
 					(cfg->timer);
 			cpt->period = get_channel_capture[cpt->channel - 1](cfg->timer);
+			/* Reset the counter manually for next cycle */
+			LL_TIM_GenerateEvent_UPDATE(cfg->timer);
 		}
 
 		clear_capture_interrupt[cpt->channel - 1](cfg->timer);
@@ -745,7 +746,7 @@ static void pwm_stm32_isr(const struct device *dev)
 		pwm_stm32_disable_capture(dev, cpt->channel);
 	} else {
 		cpt->overflows = 0u;
-		cpt->state = CAPTURE_STATE_WAIT_FOR_PULSE_START;
+		cpt->state = CAPTURE_STATE_WAIT_FOR_PERIOD_END;
 	}
 
 	if (cpt->callback != NULL) {


### PR DESCRIPTION
With the four-channel-capture-support property enabled, the STM32 PWM driver was missing every other frames during PWM capture.

The counter values are now reset just after getting the pulse and the period of the cycle, instead of waiting the next interrupt to do so, and thus missing a cycle.