### PR TITLE
drivers: udc_stm32: fix remote wakeup handling

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -65,7 +65,7 @@ void udc_set_suspended(const struct device *dev, const bool value)
 	struct udc_data *data = dev->data;
 
 	if (value == udc_is_suspended(dev)) {
-		LOG_WRN("Spurious suspend/resume event");
+		LOG_WRN("Spurious %s event", value ? "suspend" : "resume");
 	}
 
 	atomic_set_bit_to(&data->status, UDC_STATUS_SUSPENDED, value);

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -132,6 +132,7 @@ void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 				EP_TYPE_CTRL);
 	}
 
+	udc_set_suspended(dev, false);
 	udc_submit_event(priv->dev, UDC_EVT_RESET, 0);
 }
 
@@ -749,6 +750,9 @@ static int udc_stm32_host_wakeup(const struct device *dev)
 	if (status != HAL_OK) {
 		return -EIO;
 	}
+
+	udc_set_suspended(dev, false);
+	udc_submit_event(dev, UDC_EVT_RESUME, 0);
 
 	return 0;
 }


### PR DESCRIPTION
Clear the suspended status and submit the resume event once the remote
wakeup signaling is finished. Clear the suspended status on bus reset as
well.

Fixes: #89126