### PR TITLE
doc: twister: inline `twister --help` output into the docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,6 +76,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.graphviz",
     "sphinxcontrib.jquery",
+    "sphinxcontrib.programoutput",
     "zephyr.application",
     "zephyr.html_redirects",
     "zephyr.kconfig",

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -83,9 +83,8 @@ The list of command line options supported by twister can be viewed using:
 
    .. group-tab:: Linux
 
-      .. code-block:: bash
-
-         $ ./scripts/twister --help
+      .. command-output:: $ZEPHYR_BASE/scripts/twister --help
+         :shell:
 
    .. group-tab:: Windows
 

--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -10,6 +10,7 @@ sphinx-copybutton
 sphinx-togglebutton
 sphinx-sitemap
 sphinx-autobuild
+sphinxcontrib.programoutput
 
 # YAML validation. Used by zephyr_module.
 PyYAML>=6.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -508,6 +508,7 @@ sphinx==8.1.3 ; python_full_version < '3.11' \
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinxcontrib-jquery
+    #   sphinxcontrib-programoutput
     #   sphinxcontrib-svg2pdfconverter
 sphinx==8.2.3 ; python_full_version >= '3.11' \
     --hash=sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348 \
@@ -522,6 +523,7 @@ sphinx==8.2.3 ; python_full_version >= '3.11' \
     #   sphinx-tabs
     #   sphinx-togglebutton
     #   sphinxcontrib-jquery
+    #   sphinxcontrib-programoutput
     #   sphinxcontrib-svg2pdfconverter
 sphinx-autobuild==2024.10.3 \
     --hash=sha256:158e16c36f9d633e613c9aaf81c19b0fc458ca78b112533b20dafcda430d60fa \
@@ -575,6 +577,10 @@ sphinxcontrib-jsmath==1.0.1 \
     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178 \
     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8
     # via sphinx
+sphinxcontrib-programoutput==0.18 \
+    --hash=sha256:09e68b6411d937a80b6085f4fdeaa42e0dc5555480385938465f410589d2eed8 \
+    --hash=sha256:8a651bc85de69a808a064ff0e48d06c12b9347da4fe5fdb1e94914b01e1b0c36
+    # via -r requirements.in
 sphinxcontrib-qthelp==2.0.0 \
     --hash=sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab \
     --hash=sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb


### PR DESCRIPTION
In order to make it easier for folks to discover available twister options when using/searching the documentation, or when making external search in their favorite search engine, inline the output of `twister --help` into the docs so as to have an always up-to-date and searchable snapshot of it.

CI output [here](https://builds.zephyrproject.io/zephyr/pr/92854/docs/develop/test/twister.html#:~:text=The%20list%20of%20command%20line%20options%20supported%20by%20twister%20can%20be%20viewed%20using%3A)

<img width="884" alt="image" src="https://github.com/user-attachments/assets/d417a068-4301-4736-a4c9-273313f32e0b" />
