### PR TITLE
tests: spi_loopback: nxp_lpspi: Increase latency acceptance for DMA

### DIFF
--- a/tests/drivers/spi/spi_loopback/Kconfig
+++ b/tests/drivers/spi/spi_loopback/Kconfig
@@ -13,6 +13,7 @@ config SPI_LARGE_BUFFER_SIZE
 
 config SPI_IDEAL_TRANSFER_DURATION_SCALING
 	int "Scaling factor to compare ideal and measured SPI transfer duration"
+	default 40 if SPI_NXP_LPSPI_DMA
 	default 8
 
 if SOC_SERIES_STM32H7X


### PR DESCRIPTION
The DMA-based LPSPI driver is inherently going to have a high latency due to the requirement for setting up the DMA transfer and the actual DMA driver may be extremely bloated, this is no fault of the spi driver and not relevant to the test. The driver we want to test for latency is the CPU-based one, the DMA-based one is more prioritizing bandwidth over latency.

Fixes #92492