### PR TITLE
Set the DOZEN bit for MCUX_FLEXIO

### DIFF
--- a/drivers/misc/mcux_flexio/mcux_flexio.c
+++ b/drivers/misc/mcux_flexio/mcux_flexio.c
@@ -132,6 +132,8 @@ static int mcux_flexio_init(const struct device *dev)
 	k_mutex_init(&data->lock);
 
 	FLEXIO_GetDefaultConfig(&flexio_config);
+	flexio_config.enableInDoze = true;
+
 	FLEXIO_Init(config->base, &flexio_config);
 	config->irq_config_func(dev);
 


### PR DESCRIPTION
Setting the DOZEN bit in the flexio so the soc
does not force the peripheral to go into
low power mode when the soc is in idle.

Fixes #92863