### PR TITLE
libc: arcmwdt: grant all threads access to stdio locks

### DIFF
--- a/lib/libc/arcmwdt/threading.c
+++ b/lib/libc/arcmwdt/threading.c
@@ -40,6 +40,11 @@ void _mwmutex_create(_lock_t *mutex_ptr)
 		k_panic();
 	}
 
+#ifdef CONFIG_USERSPACE
+	/* Some of the locks are shared across the library */
+	k_object_access_all_grant(*mutex_ptr);
+#endif
+
 	k_mutex_init((struct k_mutex *)*mutex_ptr);
 }
 


### PR DESCRIPTION
Some of the locks are created in supervisor mode (i.e. stdout one), but should be accessed from user mode too. Unfortunately, there is no way to distinguish these locks, so grant the access to all of them as the actual reads and writes should end up as syscalls anyway.

Fixes: #92764