### PR TITLE
libc: arcmwdt: require static initializers

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -127,6 +127,7 @@ config ARCMWDT_LIBC
 	bool "ARC MWDT C library"
 	depends on !NATIVE_APPLICATION
 	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
+	select STATIC_INIT_GNU
 	help
 	  C library provided by ARC MWDT toolchain.
 


### PR DESCRIPTION
The ARC MWDT C library puts some constructors into .ctors section to initialize its internal stdio locks. Enable the initializers to make sure these constructors are actually executed.