### PR TITLE
drivers: dma_mcux_edma: Simple Refactoring

### DIFF
--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -58,6 +58,7 @@ config DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS
 	bool "Use DTCM for DMA descriptors"
 	default y
 	depends on DT_HAS_NXP_IMX_DTCM_ENABLED
+	depends on $(dt_chosen_enabled,zephyr_dtcm)
 	help
 	  When this option is activated, the descriptors for DMA transfer are
 	  located in the DTCM (Data Tightly Coupled Memory).

--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -35,6 +35,11 @@ config DMA_MCUX_EDMA_V5
 	help
 	  DMA version 5 driver for MCUX series SoCs.
 
+config DMA_MCUX_MAX_DATA_SIZE
+	int
+	default 64 if DMA_MCUX_EDMA_V5 || DMA_MCUX_EDMA_V4 || DMA_MCUX_EDMA_V3
+	default 32
+
 if DMA_MCUX_EDMA || DMA_MCUX_EDMA_V3 || DMA_MCUX_EDMA_V4 || DMA_MCUX_EDMA_V5
 
 config DMA_TCD_QUEUE_SIZE

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -150,6 +150,7 @@ struct dma_mcux_edma_data {
 #define EDMA_HW_TCD_CSR(dev, ch)   (DEV_BASE(dev)->CH[ch].TCD_CSR)
 #endif
 
+#if DMA_MCUX_HAS_CHANNEL_GAP
 /*
  * The hardware channel (takes the gap into account) is used when access DMA registers.
  * For data structures in the shim driver still use the primitive channel.
@@ -157,30 +158,24 @@ struct dma_mcux_edma_data {
 static ALWAYS_INLINE uint32_t dma_mcux_edma_add_channel_gap(const struct device *dev,
 							    uint32_t channel)
 {
-#if DMA_MCUX_HAS_CHANNEL_GAP
 	const struct dma_mcux_edma_config *config = DEV_CFG(dev);
 
 	return (channel < config->channel_gap[0]) ? channel :
 		(channel + 1 + config->channel_gap[1] - config->channel_gap[0]);
-#else
-	ARG_UNUSED(dev);
-	return channel;
-#endif
 }
 
 static ALWAYS_INLINE uint32_t dma_mcux_edma_remove_channel_gap(const struct device *dev,
 								uint32_t channel)
 {
-#if DMA_MCUX_HAS_CHANNEL_GAP
 	const struct dma_mcux_edma_config *config = DEV_CFG(dev);
 
 	return (channel < config->channel_gap[0]) ? channel :
 		(channel + config->channel_gap[0] - config->channel_gap[1] - 1);
-#else
-	ARG_UNUSED(dev);
-	return channel;
-#endif
 }
+#else
+#define dma_mcux_edma_add_channel_gap(dev, channel) channel
+#define dma_mcux_edma_remove_channel_gap(dev, channel) channel
+#endif /* DMA_MCUX_HAS_CHANNEL_GAP */
 
 static bool data_size_valid(const size_t data_size)
 {

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -179,14 +179,8 @@ static ALWAYS_INLINE uint32_t dma_mcux_edma_remove_channel_gap(const struct devi
 
 static bool data_size_valid(const size_t data_size)
 {
-	return (data_size == 4U || data_size == 2U ||
-		data_size == 1U || data_size == 8U ||
-		data_size == 16U || data_size == 32U
-#if defined(CONFIG_DMA_MCUX_EDMA_V3) || defined(CONFIG_DMA_MCUX_EDMA_V4) \
-		|| defined(CONFIG_DMA_MCUX_EDMA_V5)
-		|| data_size == 64U
-#endif
-		);
+	return IS_POWER_OF_TWO(data_size) &&
+	       (data_size <= CONFIG_DMA_MCUX_MAX_DATA_SIZE);
 }
 
 static void nxp_edma_callback(edma_handle_t *handle, void *param, bool transferDone,


### PR DESCRIPTION
This edma driver is extremely important for NXP platforms as it is used by many different drivers itself, and what I am noticing is that is always causing a lot of problems to debug through it because it is a mess.  So this PR is doing a basic refactor which should not change any logic of the program flow but just splitting things into helper functions to be more readable, etc.