### PR TITLE
Bluetooth: Classic: Add Bluetooth Device Identification Profile (DID)

### DIFF
--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -38,3 +38,8 @@ zephyr_library_sources_ifdef(
   obex.c
   goep.c
   )
+
+zephyr_library_sources_ifdef(
+  CONFIG_BT_DID
+  did.c
+  )

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -487,6 +487,36 @@ config BT_AVRCP_CONTROLLER
 
 endif # BT_AVRCP
 
+config BT_DID
+	bool "Bluetooth DID Profile [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  This option enables the DID profile
+
+if BT_DID
+config BT_DEVICE_VEDNOR_ID
+	hex "Bluetooth Device Vendor ID"
+	range 0x0000 $(UINT16_MAX)
+	default 0x0000
+	help
+	  This option sets the device vendor id
+
+config BT_DEVICE_PRODUCT_ID
+	hex "Bluetooth Device Product ID"
+	range 0x0000 $(UINT16_MAX)
+	default 0x0000
+	help
+	  This option sets the device product id
+
+config BT_DEVICE_VERSION
+	hex "Bluetooth Device Version"
+	range 0x0000 $(UINT16_MAX)
+	default 0x0000
+	help
+	  This option sets the device version
+
+endif # BT_DID
+
 config BT_PAGE_TIMEOUT
 	hex "Bluetooth Page Timeout"
 	default 0x2000

--- a/subsys/bluetooth/host/classic/did.c
+++ b/subsys/bluetooth/host/classic/did.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+
+#include "did_internal.h"
+
+#define DID_VER_1_3 (0x0103u)
+
+#define BLUETOOTH_DEVICE_IDENTIFY_SPEC_VERSION 0x0103
+#define BLUETOOTH_DEVICE_IDENTIFY_ATTR_VERSION 0x0100
+
+#define BLUETOOTH_DEVICE_VEDNOR_ID_SOURCE_BTSIG 0x0001 /* Bluetooth SIG assigned */
+#define BLUETOOTH_DEVICE_VENDOR_ID_SOURCE_USBIF 0x0002 /* USB Implementer's Forum */
+
+static struct bt_sdp_attribute did_attrs[] = {
+	BT_SDP_NEW_SERVICE,
+	BT_SDP_LIST(
+		BT_SDP_ATTR_SVCLASS_ID_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+			BT_SDP_ARRAY_16(BT_SDP_PNP_INFO_SVCLASS)
+		},
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_SPECIFICATION_ID,
+		BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+		BT_SDP_ARRAY_16(BLUETOOTH_DEVICE_IDENTIFY_SPEC_VERSION)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_VENDOR_ID,
+		BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+		BT_SDP_ARRAY_16(CONFIG_BT_DEVICE_VEDNOR_ID)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PRODUCT_ID,
+		BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+		BT_SDP_ARRAY_16(CONFIG_BT_DEVICE_PRODUCT_ID)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_VERSION,
+		BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+		BT_SDP_ARRAY_16(CONFIG_BT_DEVICE_VERSION)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PRIMARY_RECORD,
+		BT_SDP_TYPE_SIZE(BT_SDP_BOOL),
+		BT_SDP_ARRAY_8(1)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_VENDOR_ID_SOURCE,
+		BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+		BT_SDP_ARRAY_16(BLUETOOTH_DEVICE_VEDNOR_ID_SOURCE_BTSIG)
+	),
+};
+
+static struct bt_sdp_record did_rec = BT_SDP_RECORD(did_attrs);
+
+int bt_did_init(void)
+{
+	return bt_sdp_register_service(&did_rec);
+}

--- a/subsys/bluetooth/host/classic/did_internal.h
+++ b/subsys/bluetooth/host/classic/did_internal.h
@@ -1,0 +1,12 @@
+/** @file
+ *  @brief Device Identification Protocol handling.
+ */
+
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Device Identification Init. **/
+int bt_did_init(void);

--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -30,6 +30,7 @@
 #include "a2dp_internal.h"
 #include "avctp_internal.h"
 #include "avrcp_internal.h"
+#include "did_internal.h"
 #include "rfcomm_internal.h"
 #include "sdp_internal.h"
 
@@ -6180,6 +6181,10 @@ void bt_l2cap_br_init(void)
 
 	if (IS_ENABLED(CONFIG_BT_AVRCP)) {
 		bt_avrcp_init();
+	}
+
+	if (IS_ENABLED(CONFIG_BT_DID)) {
+		bt_did_init();
 	}
 }
 


### PR DESCRIPTION
**Implementation Overview**
This PR adds support for the Bluetooth Device Identification Service (DID) server as defined in the Bluetooth Assigned Numbers specification. The implementation enables devices to publish standardized identification information via SDP, allowing remote clients to retrieve vendor, product, and version details.

**Key Features**

- SDP Record Registration:

Implements a complete DID SDP record structure as per Bluetooth SIG requirements:

```
static struct bt_sdp_record did_rec = BT_SDP_RECORD(did_attrs);`
```

- Configuration-Driven Attributes:

Uses Kconfig options for dynamic device identification:

```
kconfig
CONFIG_BT_DEVICE_VENDOR              # Vendor ID (e.g., 0x000F for Bosch)
CONFIG_BT_DEVICE_PRODUCT_ID      # Product identifier
CONFIG_BT_DEVICE_PROTOCOL_ID    # Vendor ID source (USB/Bluetooth SIG)
```

- Specification Compliance:

   - Implements DID Specification v1.3 (0x0103)
   - Attribute version v1.0 (0x0100)
   - Primary record flag for service prioritization


- Simplified Integration:
Single initialization API:

```
Enable CONFIG_BT_DID, it would be inited int bt_l2cap_br_init
int bt_did_init(void); 
```

**Verification**

Test Method     &emsp; &emsp;        Platform &emsp; &emsp;  Result
SDP Query (Phone)  &emsp; &emsp;      Android  &emsp; &emsp;   ✅ Valid record
Attribute Validation  &emsp; &emsp;  Wireshark   &emsp; &emsp;   ✅ Correct field values
