### PR TITLE
Bluetooth: Controller: Fix flash sync start from starving connection

### DIFF
--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1380,6 +1380,7 @@ void ticker_worker(void *param)
 			 * ticker_job_reschedule_in_window when completed.
 			 */
 			ticker->lazy_current++;
+			ticker->force = 0U;
 
 			if ((ticker->must_expire == 0U) ||
 			    (ticker->lazy_periodic >= ticker->lazy_current) ||


### PR DESCRIPTION
Fix flash sync start from repeatedly forcing connection event be skipped. Space new flash operation to be spaced apart by flash slot write duration.