### PR TITLE
manifest: hostap: Fix the build warnings

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: e942f86e865d5b24bbbe8b0c333f030cbbe62bfb
+      revision: pull/90/head
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
This change is to fix the build warnings when config EC is disabled.