### PR TITLE
include: zephyr: dt-bindings: Fix USB_SEL mask

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -51,10 +51,10 @@
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 8, CSR1_REG)
 
 /** CFGR1 devices */
-#define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 0x7, 24, CFGR1_REG)
-#define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 0x7, 28, CFGR1_REG)
-#define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 0x7, 16, CFGR1_REG)
-#define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 0x7, 20, CFGR1_REG)
+#define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 0xf, 24, CFGR1_REG)
+#define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 0xf, 28, CFGR1_REG)
+#define MCO2_SEL(val)           STM32_DT_CLOCK_SELECT((val), 0xf, 16, CFGR1_REG)
+#define MCO2_PRE(val)           STM32_DT_CLOCK_SELECT((val), 0xf, 20, CFGR1_REG)
 
 /* MCO prescaler : division factor */
 #define MCO_PRE_DIV_1   0

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -46,7 +46,7 @@
 #define I2C2_I2S1_SEL(val)	STM32_DT_CLOCK_SELECT((val), 3, 14, CCIPR_REG)
 #define ADC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 30, CCIPR_REG)
 /** CCIPR2 devices */
-#define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 12, CCIPR2_REG)
+#define USB_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 12, CCIPR2_REG)
 /** CSR1 devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 3, 8, CSR1_REG)
 


### PR DESCRIPTION
Selecting the clock source for USB is only a bit value in the CCIPR2 register.
See [RM0490](https://www.st.com/resource/en/reference_manual/rm0490-stm32c0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) chapter 6.4.21 page 159.