### PR TITLE
doc: migration/release: 4.2: Add build system/sysbuild/MCUmgr changes

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -23,6 +23,9 @@ the :ref:`release notes<zephyr_4.2>`.
 Build System
 ************
 
+* HWMv1 support has been removed, any out-of-tree boards or SoCs in HWMv1 format must be migrated
+  to :ref:`HWMv2 <hw_model_v2>` to work with Zephyr v4.2 onwards.
+
 Kernel
 ******
 

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -212,6 +212,17 @@ New APIs and options
     * Remove query of the classic bonding information from :c:func:`bt_foreach_bond`, and add
       :c:func:`bt_br_foreach_bond`.
 
+* Build system
+
+  * Sysbuild
+
+    * Firmware loader image setup/selection support added to sysbuild when using
+      :kconfig:option:`SB_CONFIG_MCUBOOT_MODE_FIRMWARE_UPDATER` via
+      ``SB_CONFIG_FIRMWARE_LOADER`` e.g. :kconfig:option:`SB_CONFIG_FIRMWARE_LOADER_IMAGE_SMP_SVR`
+      for selecting :zephyr:code-sample:`smp-svr`.
+    * Single app RAM load support added to sysbuild using
+      :kconfig:option:`SB_CONFIG_MCUBOOT_MODE_SINGLE_APP_RAM_LOAD`.
+
 * Display
 
   * :c:func:`display_clear`

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -227,6 +227,15 @@ New APIs and options
 
   * :c:func:`display_clear`
 
+* Management
+
+  * MCUmgr
+
+    * Firmware loader support added to image mgmt group using
+      :kconfig:option:`CONFIG_MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER`.
+    * Optional boot mode (using retention boot mode) added to OS group reset command using
+      :kconfig:option:`CONFIG_MCUMGR_GRP_OS_RESET_BOOT_MODE`.
+
 * Networking:
 
   * IPv4


### PR DESCRIPTION
* Adds a note that HWMv1 support has now been dropped
* Adds new features for sysbuild
* Adds new features/APIs for MCUmgr