### PR TITLE
settings: Only use mutexes when multithreading is enabled

### DIFF
--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -14,8 +14,7 @@
 #include <zephyr/settings/settings.h>
 #include "settings/settings_file.h"
 #include <zephyr/kernel.h>
-
-extern struct k_mutex settings_lock;
+#include "settings_priv.h"
 
 bool settings_subsys_initialized;
 
@@ -28,7 +27,7 @@ int settings_subsys_init(void)
 
 	int err = 0;
 
-	k_mutex_lock(&settings_lock, K_FOREVER);
+	settings_lock_take();
 
 	if (!settings_subsys_initialized) {
 		settings_init();
@@ -40,7 +39,7 @@ int settings_subsys_init(void)
 		}
 	}
 
-	k_mutex_unlock(&settings_lock);
+	settings_lock_release();
 
 	return err;
 }

--- a/subsys/settings/src/settings_priv.h
+++ b/subsys/settings/src/settings_priv.h
@@ -111,6 +111,12 @@ extern sys_slist_t settings_load_srcs;
 extern sys_slist_t settings_handlers;
 extern struct settings_store *settings_save_dst;
 
+/** Takes the settings mutex lock (if multithreading is enabled) */
+void settings_lock_take(void);
+
+/** Releases the settings mutex lock (if multithreading is enabled) */
+void settings_lock_release(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Allows usage of settings when multithreading is disabled