### PR TITLE
drivers: spi: spi_context: exclude gpio code if no gpio cs

### DIFF
--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -398,17 +398,13 @@ static int spi_b91_transceive(const struct device *dev,
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
 	/* if cs is defined: software cs control, set active true */
-	if (spi_cs_is_gpio(config)) {
-		spi_context_cs_control(&data->ctx, true);
-	}
+	spi_context_cs_control(&data->ctx, true);
 
 	/* transceive data */
 	spi_b91_txrx(dev, txrx_len);
 
 	/* if cs is defined: software cs control, set active false */
-	if (spi_cs_is_gpio(config)) {
-		spi_context_cs_control(&data->ctx, false);
-	}
+	spi_context_cs_control(&data->ctx, false);
 
 	/* release context */
 	status = spi_context_wait_for_completion(&data->ctx);

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -37,7 +37,7 @@ static bool spi_esp32_transfer_ongoing(struct spi_esp32_data *data)
 }
 
 static inline void spi_esp32_complete(const struct device *dev,
-				      struct spi_esp32_data *data,
+				      struct spi_esp32_data *data __maybe_unused,
 				      spi_dev_t *spi, int status)
 {
 #ifdef CONFIG_SPI_ESP32_INTERRUPT
@@ -177,7 +177,7 @@ static int IRAM_ATTR spi_esp32_transfer(const struct device *dev)
 
 	/* keep cs line active until last transmission */
 	hal_trans->cs_keep_active =
-		(!ctx->num_cs_gpios &&
+		(UTIL_OR(IS_ENABLED(DT_SPI_CTX_HAS_NO_CS_GPIOS), (ctx->num_cs_gpios == 0)) &&
 		 (ctx->rx_count > 1 || ctx->tx_count > 1 || ctx->rx_len > transfer_len_frames ||
 		  ctx->tx_len > transfer_len_frames));
 
@@ -488,9 +488,10 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 	 * Workaround for ESP32S3 and ESP32Cx SoC's. This dummy transaction is needed
 	 * to sync CLK and software controlled CS when SPI is in mode 3
 	 */
-#if defined(CONFIG_SOC_SERIES_ESP32S3) || defined(CONFIG_SOC_SERIES_ESP32C2) ||                    \
-	defined(CONFIG_SOC_SERIES_ESP32C3) || defined(CONFIG_SOC_SERIES_ESP32C6)
-	if (ctx->num_cs_gpios && (hal_dev->mode & (SPI_MODE_CPOL | SPI_MODE_CPHA))) {
+#if (defined(CONFIG_SOC_SERIES_ESP32S3) || defined(CONFIG_SOC_SERIES_ESP32C2) ||                   \
+	defined(CONFIG_SOC_SERIES_ESP32C3) || defined(CONFIG_SOC_SERIES_ESP32C6)) &&               \
+	!defined(DT_SPI_CTX_HAS_NO_CS_GPIOS)
+	if ((ctx->num_cs_gpios != 0) && (hal_dev->mode & (SPI_MODE_CPOL | SPI_MODE_CPHA))) {
 		spi_esp32_transfer(dev);
 	}
 #endif

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -468,9 +468,9 @@ static int spi_stm32_shift_frames(const struct spi_stm32_config *cfg,
 	return spi_stm32_get_err(cfg->spi);
 }
 
-static void spi_stm32_cs_control(const struct device *dev, bool on)
+static void spi_stm32_cs_control(const struct device *dev, bool on __maybe_unused)
 {
-	struct spi_stm32_data *data = dev->data;
+	__maybe_unused struct spi_stm32_data *data = dev->data;
 
 	spi_context_cs_control(&data->ctx, on);
 

--- a/drivers/spi/spi_numaker.c
+++ b/drivers/spi/spi_numaker.c
@@ -129,7 +129,7 @@ static int spi_numaker_configure(const struct device *dev, const struct spi_conf
 	/* Enable the automatic hardware slave select function. Select the SS pin and configure as
 	 * low-active.
 	 */
-	if (data->ctx.num_cs_gpios == 0) {
+	if (UTIL_OR(IS_ENABLED(DT_SPI_CTX_HAS_NO_CS_GPIOS), (data->ctx.num_cs_gpios == 0))) {
 		SPI_EnableAutoSS(dev_cfg->spi, SPI_SS, SPI_SS_ACTIVE_LOW);
 	} else {
 		SPI_DisableAutoSS(dev_cfg->spi);

--- a/drivers/spi/spi_numaker.c
+++ b/drivers/spi/spi_numaker.c
@@ -251,9 +251,7 @@ static int spi_numaker_transceive(const struct device *dev, const struct spi_con
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, spi_dfs);
 
 	/* if cs is defined: software cs control, set active true */
-	if (spi_cs_is_gpio(config)) {
-		spi_context_cs_control(&data->ctx, true);
-	}
+	spi_context_cs_control(&data->ctx, true);
 
 	/* transceive tx/rx data */
 	do {
@@ -264,9 +262,7 @@ static int spi_numaker_transceive(const struct device *dev, const struct spi_con
 	} while (spi_numaker_remain_words(data));
 
 	/* if cs is defined: software cs control, set active false */
-	if (spi_cs_is_gpio(config)) {
-		spi_context_cs_control(&data->ctx, false);
-	}
+	spi_context_cs_control(&data->ctx, false);
 	SPI_DISABLE(dev_cfg->spi);
 
 done:


### PR DESCRIPTION
exclude gpio code if no gpio cs are used
for that spi driver. Because all of it is in a header and all functions and definitions are inline, we can optimize code out during build