### PR TITLE
counter: cmsdk_apb_dualtimer: Use clock freq from DT clocks

### DIFF
--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -19,6 +19,20 @@
 
 #include "dualtimer_cmsdk_apb.h"
 
+#define DTIMER_NODE(inst) DT_INST(inst, arm_cmsdk_dtimer)
+#define CLOCK_NODE(inst) DT_PHANDLE(DTIMER_NODE(inst), clocks)
+
+#define HAS_DTIMER_CLOCK(inst) DT_NODE_HAS_PROP(DTIMER_NODE(inst), clocks)
+#define HAS_CLOCK_FREQUENCY(inst) DT_NODE_HAS_PROP(CLOCK_NODE(inst), clock_frequency)
+
+#if HAS_DTIMER_CLOCK(inst) && HAS_CLOCK_FREQUENCY(inst)
+#define DTIMER_CMSDK_FREQ(inst) \
+	DT_INST_PROP_BY_PHANDLE(inst, clocks, clock_frequency)
+#else
+#define DTIMER_CMSDK_FREQ(inst) \
+	24000000U  /* fallback default */
+#endif /* HAS_DTIMER_CLOCK(inst) && HAS_CLOCK_FREQUENCY(inst) */
+
 typedef void (*dtimer_config_func_t)(const struct device *dev);
 
 struct dtmr_cmsdk_apb_cfg {
@@ -176,7 +190,7 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 	dtmr_cmsdk_apb_cfg_##inst = {					\
 		.info = {						\
 			.max_top_value = UINT32_MAX,			\
-			.freq = 24000000U,				\
+			.freq = DTIMER_CMSDK_FREQ(inst),				\
 			.flags = COUNTER_CONFIG_INFO_COUNT_UP,		\
 			.channels = 0U,					\
 		},							\


### PR DESCRIPTION
Previously, the CMSDK APB dual timer driver hardcoded the counter clock frequency to 24 MHz, which limits reuse across SoCs and boards with different timer clock sources.

This patch replaces the hardcoded frequency with a value derived from the device tree's `clocks` phandle, using the `clock-frequency` property of the referenced clock controller node.

If the property is missing, it falls back to a default 24 MHz.