### PR TITLE
dts: nordic: remove nordic,cryptocell compatible

### DIFF
--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -568,7 +568,7 @@
 		};
 
 		cryptocell: crypto@5002a000 {
-			compatible = "nordic,cryptocell", "arm,cryptocell-310";
+			compatible = "arm,cryptocell-310";
 			reg = <0x5002a000 0x1000>, <0x5002b000 0x1000>;
 			reg-names = "wrapper", "core";
 			interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -100,7 +100,7 @@
 		};
 
 		cryptocell: crypto@50844000 {
-			compatible = "nordic,cryptocell", "arm,cryptocell-312";
+			compatible = "arm,cryptocell-312";
 			reg = <0x50844000 0x1000>, <0x50845000 0x1000>;
 			reg-names = "wrapper", "core";
 			interrupts = <68 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf91.dtsi
+++ b/dts/arm/nordic/nrf91.dtsi
@@ -47,7 +47,7 @@
 
 		/* Additional Secure peripherals */
 		cryptocell: crypto@50840000 {
-			compatible = "nordic,cryptocell", "arm,cryptocell-310";
+			compatible = "arm,cryptocell-310";
 			reg = <0x50840000 0x1000>, <0x50841000 0x1000>;
 			reg-names = "wrapper", "core";
 			interrupts = <64 NRF_DEFAULT_IRQ_PRIORITY>;


### PR DESCRIPTION
It's unused.