### PR TITLE
twister: fix output path in error messages

### DIFF
--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -61,7 +61,7 @@ def twister(options: argparse.Namespace, default_options: argparse.Namespace):
             for i in range(1, 100):
                 new_out = options.outdir + f".{i}"
                 if not os.path.exists(new_out):
-                    print(f"Renaming output directory to {new_out}")
+                    print(f"Renaming previous output directory to {new_out}")
                     shutil.move(options.outdir, new_out)
                     break
             else:


### PR DESCRIPTION
When twister renames the output directory (e.g., from twister-out to twister-out.7), the error messages still reference files in the original directory path. This happens because TestInstance objects store the original output directory path when they're created, and this path isn't updated when the directory is renamed.

This patch fixes the issue by modifying the log_info method to correct the path in error messages. It detects when a path contains the old output directory and replaces it with the actual output directory path. This ensures that error messages point to files in the correct location, making it easier for users to find log files when debugging.