### PR TITLE
Update esptool v5 as a package

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -213,6 +213,7 @@ jobs:
       - name: Install Python packages
         run: |
           pip install -r scripts/requirements-actions.txt --require-hashes
+          west packages pip --install
 
       - name: Set up ccache
         run: |

--- a/scripts/west_commands/runners/esp32.py
+++ b/scripts/west_commands/runners/esp32.py
@@ -3,11 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-'''Runner for flashing ESP32 devices with esptool/espidf.'''
+'''Runner for flashing ESP32 devices with esptool.'''
 
 import os
-import sys
-from os import path
 
 from runners.core import RunnerCaps, ZephyrBinaryRunner
 
@@ -18,7 +16,7 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
     def __init__(self, cfg, device, boot_address, part_table_address,
                  app_address, erase=False, reset=False, baud=921600,
                  flash_size='detect', flash_freq='40m', flash_mode='dio',
-                 espidf='espidf', bootloader_bin=None, partition_table_bin=None,
+                 espidf=None, bootloader_bin=None, partition_table_bin=None,
                  encrypt=False, no_stub=False):
         super().__init__(cfg)
         self.elf = cfg.elf_file
@@ -71,10 +69,6 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
                             help='flash frequency, default "40m"')
         parser.add_argument('--esp-flash-mode', default='dio',
                             help='flash mode, default "dio"')
-        parser.add_argument(
-            '--esp-tool',
-            help='''if given, complete path to espidf. default is to search for
-            it in [ESP_IDF_PATH]/tools/esptool_py/esptool.py''')
         parser.add_argument('--esp-flash-bootloader',
                             help='Bootloader image to flash')
         parser.add_argument('--esp-flash-partition_table',
@@ -88,11 +82,6 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def do_create(cls, cfg, args):
-        if args.esp_tool:
-            espidf = args.esp_tool
-        else:
-            espidf = path.join(args.esp_idf_path, 'tools', 'esptool_py',
-                               'esptool.py')
 
         return Esp32BinaryRunner(
             cfg, args.esp_device, boot_address=args.esp_boot_address,
@@ -100,32 +89,30 @@ class Esp32BinaryRunner(ZephyrBinaryRunner):
             app_address=args.esp_app_address, erase=args.erase, reset=args.reset,
             baud=args.esp_baud_rate, flash_size=args.esp_flash_size,
             flash_freq=args.esp_flash_freq, flash_mode=args.esp_flash_mode,
-            espidf=espidf, bootloader_bin=args.esp_flash_bootloader,
+            espidf=args.esp_idf_path, bootloader_bin=args.esp_flash_bootloader,
             partition_table_bin=args.esp_flash_partition_table,
             encrypt=args.esp_encrypt, no_stub=args.esp_no_stub)
 
     def do_run(self, command, **kwargs):
-        self.require(self.espidf)
 
-        # Add Python interpreter
-        cmd_flash = [sys.executable, self.espidf, '--chip', 'auto']
+        cmd_flash = ['esptool']
 
         if self.device is not None:
             cmd_flash.extend(['--port', self.device])
 
         if self.erase is True:
-            cmd_erase = cmd_flash + ['erase_flash']
+            cmd_erase = cmd_flash + ['erase-flash']
             self.check_call(cmd_erase)
 
         if self.no_stub is True:
             cmd_flash.extend(['--no-stub'])
         cmd_flash.extend(['--baud', self.baud])
-        cmd_flash.extend(['--before', 'default_reset'])
+        cmd_flash.extend(['--before', 'default-reset'])
         if self.reset:
-            cmd_flash.extend(['--after', 'hard_reset', 'write_flash', '-u'])
-        cmd_flash.extend(['--flash_mode', self.flash_mode])
-        cmd_flash.extend(['--flash_freq', self.flash_freq])
-        cmd_flash.extend(['--flash_size', self.flash_size])
+            cmd_flash.extend(['--after', 'hard-reset', 'write-flash', '-u'])
+        cmd_flash.extend(['--flash-mode', self.flash_mode])
+        cmd_flash.extend(['--flash-freq', self.flash_freq])
+        cmd_flash.extend(['--flash-size', self.flash_size])
 
         if self.encrypt:
             cmd_flash.extend(['--encrypt'])

--- a/soc/espressif/common/CMakeLists.txt
+++ b/soc/espressif/common/CMakeLists.txt
@@ -1,6 +1,17 @@
 # Copyright (c) 2024 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
+# Make sure the esptool package is available
+find_program(ESPTOOL_EXECUTABLE esptool)
+
+if(NOT ESPTOOL_EXECUTABLE)
+  message(FATAL_ERROR
+    "esptool>=5.0.2 not found in PATH.\n"
+    "Please install it using:\n"
+    "  west packages pip --install")
+endif()
+
+# Continue to prepare the build environment
 zephyr_include_directories(include)
 
 if(NOT CONFIG_MCUBOOT AND NOT CONFIG_SOC_ESP32_APPCPU AND NOT CONFIG_SOC_ESP32S3_APPCPU)
@@ -20,20 +31,17 @@ message("-- Espressif HAL path: ${ESP_IDF_PATH}")
 
 if((CONFIG_ESP_SIMPLE_BOOT OR CONFIG_MCUBOOT) AND NOT CONFIG_SOC_ESP32C6_LPCORE)
   if(CONFIG_BUILD_OUTPUT_BIN)
-    set(ESPTOOL_PY ${ESP_IDF_PATH}/tools/esptool_py/esptool.py)
-    message("-- Use the esptool.py: ${ESPTOOL_PY}")
-
     set(ELF2IMAGE_ARG "")
     if(NOT CONFIG_MCUBOOT)
       set(ELF2IMAGE_ARG "--ram-only-header")
     endif()
 
     set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-      COMMAND ${PYTHON_EXECUTABLE} ${ESPTOOL_PY}
+      COMMAND esptool
       ARGS --chip ${CONFIG_SOC} elf2image ${ELF2IMAGE_ARG}
-      --flash_mode dio
-      --flash_freq ${CONFIG_ESPTOOLPY_FLASHFREQ}
-      --flash_size ${esptoolpy_flashsize}MB
+      --flash-mode dio
+      --flash-freq ${CONFIG_ESPTOOLPY_FLASHFREQ}
+      --flash-size ${esptoolpy_flashsize}MB
       -o ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_BIN_NAME}
       ${CMAKE_BINARY_DIR}/zephyr/${KERNEL_ELF_NAME})
   endif()
@@ -55,6 +63,7 @@ board_runner_args(esp32 "--esp-app-address=${image_off}")
 board_runner_args(esp32 "--esp-flash-size=${esptoolpy_flashsize}MB")
 board_runner_args(esp32 "--esp-flash-freq=${CONFIG_ESPTOOLPY_FLASHFREQ}")
 board_runner_args(esp32 "--esp-flash-mode=${CONFIG_ESPTOOLPY_FLASHMODE}")
+board_runner_args(esp32 "--esp-idf-path=${ESP_IDF_PATH}")
 board_finalize_runner_args(esp32 "--esp-monitor-baud=${monitor_baud}")
 
 message(STATUS "Image partition address: ${image_off}")

--- a/west.yml
+++ b/west.yml
@@ -169,7 +169,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: f3453bdeced28642424692aae32cce4eec3f2d7f
+      revision: 82bc519bb34dbd6aa4542f43c7fd0c9452d4c4a3
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This PR brings the changes in how the esptool is installed in the system. Instead of hard-copy in the hal/espressif, it put the esptool on the list of required packages. This reflects the new esptool v5.0.0, which comes with several breaking changes.