### PR TITLE
samples: rtxxx-amp: Add service_area section

### DIFF
--- a/samples/boards/nxp/adsp/rtxxx/common/remote-dsp-imgs.cmake
+++ b/samples/boards/nxp/adsp/rtxxx/common/remote-dsp-imgs.cmake
@@ -34,6 +34,7 @@ add_custom_command(
     --only-section=sw_isr_table
     --only-section=device_area
     --only-section=device_states
+    --only-section=service_area
     --only-section=.noinit
     --only-section=.data
     --only-section=.bss


### PR DESCRIPTION
Add the `service_area` section to the list of sections for which `objcopy` is executed. As this section was missing from the resulting data image, it prevents targets (right now, the `mimxrt685s/hifi4`) from booting.