### PR TITLE
modules: lvgl: Use Zephyr builtins instead of LVGL stdlib/string impls

### DIFF
--- a/modules/lvgl/CMakeLists.txt
+++ b/modules/lvgl/CMakeLists.txt
@@ -306,13 +306,7 @@ zephyr_library_sources(
     ${LVGL_DIR}/src/others/xml/parsers/lv_xml_tabview_parser.c
     ${LVGL_DIR}/src/others/xml/parsers/lv_xml_textarea_parser.c
 
-    ${LVGL_DIR}/src/stdlib/builtin/lv_sprintf_builtin.c
-    ${LVGL_DIR}/src/stdlib/builtin/lv_string_builtin.c
     ${LVGL_DIR}/src/stdlib/builtin/lv_tlsf.c
-
-    ${LVGL_DIR}/src/stdlib/clib/lv_mem_core_clib.c
-    ${LVGL_DIR}/src/stdlib/clib/lv_sprintf_clib.c
-    ${LVGL_DIR}/src/stdlib/clib/lv_string_clib.c
 
     ${LVGL_DIR}/src/stdlib/lv_mem.c
 

--- a/modules/lvgl/include/lv_conf.h
+++ b/modules/lvgl/include/lv_conf.h
@@ -9,6 +9,8 @@
 #define ZEPHYR_MODULES_LVGL_LV_CONF_H_
 
 #include <zephyr/toolchain.h>
+#include <string.h>
+#include <stdint.h>
 
 /* Memory manager settings */
 
@@ -26,9 +28,32 @@
 #define lv_free_core      lvgl_free
 #endif
 
-/* Misc settings */
+/* Stdlib wrappers */
+
+/* Needed because parameter types are not compatible */
+static __always_inline void zmemset(void *dst, uint8_t v, size_t len)
+{
+	memset(dst, v, len);
+}
+
 #define lv_snprintf               snprintf
 #define lv_vsnprintf              vsnprintf
+#define lv_memcpy                 memcpy
+#define lv_memmove                memmove
+#define lv_memset                 zmemset
+#define lv_memcmp                 memcmp
+#define lv_strdup                 strdup
+#define lv_strndup                strndup
+#define lv_strlen                 strlen
+#define lv_strnlen                strnlen
+#define lv_strcmp                 strcmp
+#define lv_strncmp                strncmp
+#define lv_strcpy                 strcpy
+#define lv_strncpy                strncpy
+#define lv_strlcpy                strlcpy
+#define lv_strcat                 strcat
+#define lv_strncat                strncat
+#define lv_strchr                 strchr
 #define LV_ASSERT_HANDLER         __ASSERT_NO_MSG(false);
 #define LV_ASSERT_HANDLER_INCLUDE "zephyr/sys/__assert.h"
 


### PR DESCRIPTION
Previously LVGL added its own version of several stdlib functions. Replace them with the Zephyr provided functions instead.

This saves quite a bit of ROM space, around 6KiB on the music demo.