### PR TITLE
boards: stm32n6570_dk: Disable cache on PSRAM

### DIFF
--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -42,7 +42,7 @@
 		compatible = "zephyr,memory-region";
 		reg = <0x90000000 DT_SIZE_M(32)>;
 		zephyr,memory-region = "PSRAM";
-		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM) )>;
+		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
 	};
 
 	leds: leds {


### PR DESCRIPTION
For unclear reason yet, cache activation on PSRAM causes stability issues when using LTDC.
Disable cache for now.
We'll re-enable once the issue is better understood and fixed.