### PR TITLE
soc: litex: change csr ordering

### DIFF
--- a/soc/litex/litex_vexriscv/Kconfig
+++ b/soc/litex/litex_vexriscv/Kconfig
@@ -16,4 +16,19 @@ config LITEX_CSR_DATA_WIDTH
 	int "Select Control/Status register width"
 	default 32
 
+choice LITEX_CSR_ORDERING
+	prompt "Select Control/Status register ordering"
+	default LITEX_CSR_ORDERING_BIG
+
+config LITEX_CSR_ORDERING_BIG
+	bool "Big-endian ordering"
+	help
+	  Use big-endian ordering for CSR accesses
+
+config LITEX_CSR_ORDERING_LITTLE
+	bool "Little-endian ordering"
+	help
+	  Use little-endian ordering for CSR accesses
+endchoice
+
 endif # SOC_LITEX_VEXRISCV

--- a/soc/litex/litex_vexriscv/soc.h
+++ b/soc/litex/litex_vexriscv/soc.h
@@ -24,8 +24,13 @@ static inline uint8_t litex_read8(mem_addr_t addr)
 static inline uint16_t litex_read16(mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	return (sys_read8(addr) << 8)
 		| sys_read8(addr + 0x4);
+#else
+	return sys_read8(addr)
+		| (sys_read8(addr + 0x4) << 8);
+#endif
 #else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	return sys_read16(addr);
 #endif
@@ -34,10 +39,17 @@ static inline uint16_t litex_read16(mem_addr_t addr)
 static inline uint32_t litex_read32(mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	return (sys_read8(addr) << 24)
 		| (sys_read8(addr + 0x4) << 16)
 		| (sys_read8(addr + 0x8) << 8)
 		| sys_read8(addr + 0xc);
+#else
+	return sys_read8(addr)
+		| (sys_read8(addr + 0x4) << 8)
+		| (sys_read8(addr + 0x8) << 16)
+		| (sys_read8(addr + 0xc) << 24);
+#endif
 #else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	return sys_read32(addr);
 #endif
@@ -46,6 +58,7 @@ static inline uint32_t litex_read32(mem_addr_t addr)
 static inline uint64_t litex_read64(mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	return (((uint64_t)sys_read8(addr)) << 56)
 		| ((uint64_t)sys_read8(addr + 0x4) << 48)
 		| ((uint64_t)sys_read8(addr + 0x8) << 40)
@@ -54,8 +67,22 @@ static inline uint64_t litex_read64(mem_addr_t addr)
 		| ((uint64_t)sys_read8(addr + 0x14) << 16)
 		| ((uint64_t)sys_read8(addr + 0x18) << 8)
 		| (uint64_t)sys_read8(addr + 0x1c);
+#else
+	return (uint64_t)sys_read8(addr)
+		| ((uint64_t)sys_read8(addr + 0x4) << 8)
+		| ((uint64_t)sys_read8(addr + 0x8) << 16)
+		| ((uint64_t)sys_read8(addr + 0xc) << 24)
+		| ((uint64_t)sys_read8(addr + 0x10) << 32)
+		| ((uint64_t)sys_read8(addr + 0x14) << 40)
+		| ((uint64_t)sys_read8(addr + 0x18) << 48)
+		| ((uint64_t)sys_read8(addr + 0x1c) << 56);
+#endif
 #else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	return ((uint64_t)sys_read32(addr) << 32) | (uint64_t)sys_read32(addr + 0x4);
+#else
+	return sys_read64(addr);
+#endif
 #endif
 }
 
@@ -67,8 +94,13 @@ static inline void litex_write8(uint8_t value, mem_addr_t addr)
 static inline void litex_write16(uint16_t value, mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	sys_write8(value >> 8, addr);
 	sys_write8(value, addr + 0x4);
+#else
+	sys_write8(value, addr);
+	sys_write8(value >> 8, addr + 0x4);
+#endif
 #else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	sys_write16(value, addr);
 #endif
@@ -77,10 +109,17 @@ static inline void litex_write16(uint16_t value, mem_addr_t addr)
 static inline void litex_write32(uint32_t value, mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	sys_write8(value >> 24, addr);
 	sys_write8(value >> 16, addr + 0x4);
 	sys_write8(value >> 8, addr + 0x8);
 	sys_write8(value, addr + 0xC);
+#else
+	sys_write8(value, addr);
+	sys_write8(value >> 8, addr + 0x4);
+	sys_write8(value >> 16, addr + 0x8);
+	sys_write8(value >> 24, addr + 0xC);
+#endif
 #else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	sys_write32(value, addr);
 #endif
@@ -89,6 +128,7 @@ static inline void litex_write32(uint32_t value, mem_addr_t addr)
 static inline void litex_write64(uint64_t value, mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	sys_write8(value >> 56, addr);
 	sys_write8(value >> 48, addr + 0x4);
 	sys_write8(value >> 40, addr + 0x8);
@@ -97,9 +137,23 @@ static inline void litex_write64(uint64_t value, mem_addr_t addr)
 	sys_write8(value >> 16, addr + 0x14);
 	sys_write8(value >> 8, addr + 0x18);
 	sys_write8(value, addr + 0x1C);
+#else
+	sys_write8(value, addr);
+	sys_write8(value >> 8, addr + 0x4);
+	sys_write8(value >> 16, addr + 0x8);
+	sys_write8(value >> 24, addr + 0xC);
+	sys_write8(value >> 32, addr + 0x10);
+	sys_write8(value >> 40, addr + 0x14);
+	sys_write8(value >> 48, addr + 0x18);
+	sys_write8(value >> 56, addr + 0x1C);
+#endif
 #else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
+#ifdef CONFIG_LITEX_CSR_ORDERING_BIG
 	sys_write32(value >> 32, addr);
 	sys_write32(value, addr + 0x4);
+#else
+	sys_write64(value, addr);
+#endif
 #endif /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 }
 

--- a/soc/litex/litex_vexriscv/soc.h
+++ b/soc/litex/litex_vexriscv/soc.h
@@ -13,13 +13,12 @@
 #ifndef _ASMLANGUAGE
 /* CSR access helpers */
 
+BUILD_ASSERT(CONFIG_LITEX_CSR_DATA_WIDTH == 8 || CONFIG_LITEX_CSR_DATA_WIDTH == 32,
+	     "CONFIG_LITEX_CSR_DATA_WIDTH must be 8 or 32 bits");
+
 static inline uint8_t litex_read8(mem_addr_t addr)
 {
-#if CONFIG_LITEX_CSR_DATA_WIDTH >= 8
 	return sys_read8(addr);
-#else
-#error CSR data width less than 8
-#endif
 }
 
 static inline uint16_t litex_read16(mem_addr_t addr)
@@ -27,10 +26,8 @@ static inline uint16_t litex_read16(mem_addr_t addr)
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	return (sys_read8(addr) << 8)
 		| sys_read8(addr + 0x4);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 16
+#else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	return sys_read16(addr);
-#else
-#error Unsupported CSR data width
 #endif
 }
 
@@ -41,10 +38,8 @@ static inline uint32_t litex_read32(mem_addr_t addr)
 		| (sys_read8(addr + 0x4) << 16)
 		| (sys_read8(addr + 0x8) << 8)
 		| sys_read8(addr + 0xc);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 32
+#else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	return sys_read32(addr);
-#else
-#error Unsupported CSR data width
 #endif
 }
 
@@ -59,22 +54,14 @@ static inline uint64_t litex_read64(mem_addr_t addr)
 		| ((uint64_t)sys_read8(addr + 0x14) << 16)
 		| ((uint64_t)sys_read8(addr + 0x18) << 8)
 		| (uint64_t)sys_read8(addr + 0x1c);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH == 32
+#else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	return ((uint64_t)sys_read32(addr) << 32) | (uint64_t)sys_read32(addr + 0x4);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 64
-	return sys_read64(addr);
-#else
-#error Unsupported CSR data width
 #endif
 }
 
 static inline void litex_write8(uint8_t value, mem_addr_t addr)
 {
-#if CONFIG_LITEX_CSR_DATA_WIDTH >= 8
 	sys_write8(value, addr);
-#else
-#error CSR data width less than 8
-#endif
 }
 
 static inline void litex_write16(uint16_t value, mem_addr_t addr)
@@ -82,10 +69,8 @@ static inline void litex_write16(uint16_t value, mem_addr_t addr)
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	sys_write8(value >> 8, addr);
 	sys_write8(value, addr + 0x4);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 16
+#else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	sys_write16(value, addr);
-#else
-#error Unsupported CSR data width
 #endif
 }
 
@@ -96,10 +81,8 @@ static inline void litex_write32(uint32_t value, mem_addr_t addr)
 	sys_write8(value >> 16, addr + 0x4);
 	sys_write8(value >> 8, addr + 0x8);
 	sys_write8(value, addr + 0xC);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 32
+#else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	sys_write32(value, addr);
-#else
-#error Unsupported CSR data width
 #endif
 }
 
@@ -114,14 +97,10 @@ static inline void litex_write64(uint64_t value, mem_addr_t addr)
 	sys_write8(value >> 16, addr + 0x14);
 	sys_write8(value >> 8, addr + 0x18);
 	sys_write8(value, addr + 0x1C);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH == 32
+#else /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 	sys_write32(value >> 32, addr);
 	sys_write32(value, addr + 0x4);
-#elif CONFIG_LITEX_CSR_DATA_WIDTH >= 64
-	sys_write64(value, addr);
-#else
-#error Unsupported CSR data width
-#endif
+#endif /* CONFIG_LITEX_CSR_DATA_WIDTH == 8 */
 }
 
 /*

--- a/soc/litex/litex_vexriscv/soc.h
+++ b/soc/litex/litex_vexriscv/soc.h
@@ -13,7 +13,7 @@
 #ifndef _ASMLANGUAGE
 /* CSR access helpers */
 
-static inline unsigned char litex_read8(unsigned long addr)
+static inline uint8_t litex_read8(mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH >= 8
 	return sys_read8(addr);
@@ -22,7 +22,7 @@ static inline unsigned char litex_read8(unsigned long addr)
 #endif
 }
 
-static inline unsigned short litex_read16(unsigned long addr)
+static inline uint16_t litex_read16(mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	return (sys_read8(addr) << 8)
@@ -34,7 +34,7 @@ static inline unsigned short litex_read16(unsigned long addr)
 #endif
 }
 
-static inline unsigned int litex_read32(unsigned long addr)
+static inline uint32_t litex_read32(mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	return (sys_read8(addr) << 24)
@@ -48,7 +48,7 @@ static inline unsigned int litex_read32(unsigned long addr)
 #endif
 }
 
-static inline uint64_t litex_read64(unsigned long addr)
+static inline uint64_t litex_read64(mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	return (((uint64_t)sys_read8(addr)) << 56)
@@ -68,7 +68,7 @@ static inline uint64_t litex_read64(unsigned long addr)
 #endif
 }
 
-static inline void litex_write8(unsigned char value, unsigned long addr)
+static inline void litex_write8(uint8_t value, mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH >= 8
 	sys_write8(value, addr);
@@ -77,7 +77,7 @@ static inline void litex_write8(unsigned char value, unsigned long addr)
 #endif
 }
 
-static inline void litex_write16(unsigned short value, unsigned long addr)
+static inline void litex_write16(uint16_t value, mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	sys_write8(value >> 8, addr);
@@ -89,7 +89,7 @@ static inline void litex_write16(unsigned short value, unsigned long addr)
 #endif
 }
 
-static inline void litex_write32(unsigned int value, unsigned long addr)
+static inline void litex_write32(uint32_t value, mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	sys_write8(value >> 24, addr);
@@ -103,7 +103,7 @@ static inline void litex_write32(unsigned int value, unsigned long addr)
 #endif
 }
 
-static inline void litex_write64(uint64_t value, unsigned long addr)
+static inline void litex_write64(uint64_t value, mem_addr_t addr)
 {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 	sys_write8(value >> 56, addr);
@@ -129,7 +129,7 @@ static inline void litex_write64(uint64_t value, unsigned long addr)
  * Size is in bytes and meaningful are 1, 2 or 4
  * Address must be aligned to 4 bytes
  */
-static inline void litex_write(uint32_t addr, uint32_t size, uint32_t value)
+static inline void litex_write(mem_addr_t addr, uint8_t size, uint32_t value)
 {
 	switch (size) {
 	case 1:
@@ -151,7 +151,7 @@ static inline void litex_write(uint32_t addr, uint32_t size, uint32_t value)
  * Size is in bytes and meaningful are 1, 2 or 4
  * Address must be aligned to 4 bytes
  */
-static inline uint32_t litex_read(uint32_t addr, uint32_t size)
+static inline uint32_t litex_read(mem_addr_t addr, uint32_t size)
 {
 	switch (size) {
 	case 1:


### PR DESCRIPTION
Litex supports big and little csr ordering (default: big), add support for little ordering to zephyr