### PR TITLE
boards: weact: mini_stm32h743: add pyocd support

### DIFF
--- a/boards/weact/mini_stm32h743/board.cmake
+++ b/boards/weact/mini_stm32h743/board.cmake
@@ -2,6 +2,8 @@
 
 board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32H743VI" "--speed=4000")
+board_runner_args(pyocd "--target" "stm32h743vitx")
 
 include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Add pyocd runner support to mini_stm32h743 board configuration.

Only added some lines to board.cmake