### PR TITLE
doc: doxygen: use STRIP_FROM_INC_PATH to keep #includes clean

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -189,7 +189,17 @@ STRIP_FROM_PATH        = @ZEPHYR_BASE@/include
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+# TODO: Once https://github.com/doxygen/doxygen/pull/11657 is accepted and
+# available in a released Doxygen version, the entry
+# "@ZEPHYR_BASE@/lib/libc/minimal/include/" should be added to this list.
+# In the meantime, API from headers contained in this folder (e.g. errno.h) will
+# continue to show incorrect include path in the generated docs.
+
+STRIP_FROM_INC_PATH    = @ZEPHYR_BASE@/include/ \
+                         @ZEPHYR_BASE@/kernel/include/ \
+                         @ZEPHYR_BASE@/subsys/testsuite/include/ \
+                         @ZEPHYR_BASE@/subsys/secure_storage/include/internal \
+                         @ZEPHYR_BASE@/subsys/secure_storage/include
 
 # If the SHORT_NAMES tag is set to YES, Doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -995,6 +1005,10 @@ WARN_LOGFILE           =
 # directories like /usr/src/myproject. Separate the files or directories with
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
+
+# Note that when adding paths to INPUT you most likely want to add them
+# to STRIP_FROM_INC_PATH as well, which will remove those parts from
+# the paths of the #include examples in the generated documentation.
 
 INPUT                  = @ZEPHYR_BASE@/doc/_doxygen/mainpage.md \
                          @ZEPHYR_BASE@/doc/_doxygen/groups.dox \


### PR DESCRIPTION
Another take on zephyrproject-rtos/zephyr#76953

This uses `STRIP_FROM_INC_PATH` to make sure #include snippets in the documentation are not absolute paths and reflect what one would actually use in their code.

This fixes a bunch of places in Doxygen where it would show an incorrect #include path that makes no sense for an end user (it's an absolute path to some file on the CI runner). This has been broken in like forever so I'm happy that there's apparently an easy fix that's been right in front of our eyes the whole time :)

Examples of things that now look good:
- https://builds.zephyrproject.io/zephyr/pr/92914/docs/doxygen/html/group__fff__extensions.html#ga4a4e81f6291e0bfbe7f60e0a03c2e9b1 -- `#include <zephyr/fff_extensions.h>` where before it was like this: https://docs.zephyrproject.org/4.1.0/doxygen/html/group__fff__extensions.html#ga4a4e81f6291e0bfbe7f60e0a03c2e9b1, i.e `#include </home/runner/work/zephyr/zephyr/zephyr/subsys/testsuite/include/zephyr/fff_extensions.h>`
- https://builds.zephyrproject.io/zephyr/pr/92914/docs/doxygen/html/group__arch-timing.html#gaffc9f3013d53e72c25243ce4f972549f -- `#include <kernel_arch_interface.h>` where before it was like this: https://docs.zephyrproject.org/4.1.0/doxygen/html/group__arch-timing.html#gaffc9f3013d53e72c25243ce4f972549f, i.e. `#include </home/runner/work/zephyr/zephyr/zephyr/kernel/include/kernel_arch_interface.h>`

Due to a Doxygen bug there are some instances where it gets confused by supposedly ambiguous files post-stripping so once https://github.com/doxygen/doxygen/pull/11657 is accepted/available in a new Doxygen release we'll also be able to fix the shown includes for headers in "lib/libc/minimal/include/" but for now it's commented out since warnings are treated as errors in CI.

<img width="733" alt="image" src="https://github.com/user-attachments/assets/ed25525c-7f82-42e1-85d6-21eff6651caf" />

will be:

<img width="677" alt="image" src="https://github.com/user-attachments/assets/e742ff2e-28c5-4b44-9360-d0f8cc5a3400" />