### PR TITLE
Bluetooth: Host: Make error messages unique

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1444,7 +1444,7 @@ int bt_le_adv_stop(void)
 	int err;
 
 	if (!adv) {
-		LOG_ERR("No valid legacy adv");
+		LOG_ERR("No valid legacy adv to stop");
 		return 0;
 	}
 
@@ -1529,7 +1529,7 @@ void bt_le_adv_resume(void)
 	int err;
 
 	if (!adv) {
-		LOG_ERR("No valid legacy adv");
+		LOG_ERR("No valid legacy adv to resume");
 		return;
 	}
 


### PR DESCRIPTION
Both bt_le_adv_stop() and bt_le_adv_resume() were logging same error message. Add aditional context to it so that logs are distinguishable.