### PR TITLE
net: http: service: check for uncompressed file correctly

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -800,11 +800,10 @@ int http_server_find_file(char *fname, size_t fname_size, size_t *file_size,
 			  uint8_t supported_compression, enum http_compression *chosen_compression)
 {
 	struct fs_dirent dirent;
-	size_t len;
 	int ret;
 
-	len = strlen(fname);
 	if (IS_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION)) {
+		const size_t len = strlen(fname);
 		*chosen_compression = HTTP_NONE;
 		if (IS_BIT_SET(supported_compression, HTTP_BR)) {
 			snprintk(fname + len, fname_size - len, ".br");
@@ -846,6 +845,8 @@ int http_server_find_file(char *fname, size_t fname_size, size_t *file_size,
 				goto return_filename;
 			}
 		}
+		/* No compressed file found, try the original filename */
+		fname[len] = '\0';
 	}
 	ret = fs_stat(fname, &dirent);
 	if (ret != 0) {


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92917

Correct not resetting compression extension,
when checking for an uncompressed file,
in case if compression is enabled, but no compressed file found.

So  if we have `CONFIG_HTTP_SERVER_COMPRESSION=y`, but for a specific file no compressed version is found in the filesystem, instead for checking for e.g. `index.html`, we will be checking for the last checked compressed version, `index.html.zz`

This happens because extension is not cleared.
Correct that.