### PR TITLE
sensor: lis2dw12: handle `SENSOR_CHAN_ALL` in `sample_fetch` callback

### DIFF
--- a/drivers/sensor/st/lis2dw12/lis2dw12.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12.c
@@ -408,6 +408,10 @@ static int lis2dw12_sample_fetch(const struct device *dev,
 	case SENSOR_CHAN_DIE_TEMP:
 		lis2dw12_sample_fetch_temp(dev);
 		break;
+	case SENSOR_CHAN_ALL:
+		lis2dw12_sample_fetch_accel(dev);
+		lis2dw12_sample_fetch_temp(dev);
+		break;
 	default:
 		LOG_DBG("Channel not supported");
 		return -ENOTSUP;


### PR DESCRIPTION
Handle `SENSOR_CHAN_ALL` case of the sample_fetch callback of the lis2dw12 driver. Without this, `sensor_sample_fetch()` does not work correctly for this device, e.g. rendering the rtio and the sensor shell unusable.