### PR TITLE
Bluetooth: Controller: Fix a potential NULL pointer dereference

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1394,7 +1394,6 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 		memcpy(target_hdr, source_hdr, source_hdr->ext_hdr_len + 1U);
 	} else {
 		/* Copy field by field */
-
 		source_dptr = source_hdr->ext_hdr.data;
 		target_dptr = target_hdr->ext_hdr.data;
 
@@ -1405,7 +1404,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 
 #if defined(CONFIG_BT_CTLR_DF_ADV_CTE_TX)
 		if (source_hdr->ext_hdr.cte_info) {
-			if (!skip_fields->cte_info) {
+			if (!skip_fields || !skip_fields->cte_info) {
 				memcpy(target_dptr, source_dptr, sizeof(struct pdu_cte_info));
 				target_dptr += sizeof(struct pdu_cte_info);
 				target_hdr->ext_hdr.cte_info = 1U;
@@ -1416,7 +1415,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 
 #if defined(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)
 		if (source_hdr->ext_hdr.adi) {
-			if (!skip_fields->adi) {
+			if (!skip_fields || !skip_fields->adi) {
 				memcpy(target_dptr, source_dptr, sizeof(struct pdu_adv_adi));
 				target_dptr += sizeof(struct pdu_adv_adi);
 				target_hdr->ext_hdr.adi = 1U;
@@ -1427,7 +1426,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 
 #if defined(CONFIG_BT_CTLR_ADV_SYNC_PDU_LINK)
 		if (source_hdr->ext_hdr.aux_ptr) {
-			if (!skip_fields->aux_ptr) {
+			if (!skip_fields || !skip_fields->aux_ptr) {
 				memcpy(target_dptr, source_dptr, sizeof(struct pdu_adv_aux_ptr));
 				target_dptr += sizeof(struct pdu_adv_aux_ptr);
 				target_hdr->ext_hdr.aux_ptr = 1U;
@@ -1439,7 +1438,7 @@ static void ull_adv_sync_copy_pdu_header(struct pdu_adv *target_pdu,
 		/* SyncInfo is RFU for periodic advertising */
 
 		if (source_hdr->ext_hdr.tx_pwr) {
-			if (!skip_fields->tx_pwr) {
+			if (!skip_fields || !skip_fields->tx_pwr) {
 				*target_dptr = *source_dptr;
 				target_dptr++;
 				target_hdr->ext_hdr.tx_pwr = 1U;


### PR DESCRIPTION
Fix a potential NULL pointer dereference for skip_fields in the function ull_adv_sync_copy_pdu_header. This issue been reported by Coverity.

Coverity CID: 392529
Fixes: #74738 