### PR TITLE
cmake: Define zephyr_generated_headers as an interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,9 +952,13 @@ add_custom_target(${DEVICE_API_LD_TARGET}
 zephyr_linker_include_generated(CMAKE ${DEVICE_API_LINKER_SECTIONS_CMAKE})
 
 # Add a pseudo-target that is up-to-date when all generated headers
-# are up-to-date.
+# are up-to-date. Libraries containing files that include these headers can use
+# add_dependencies or target_link_libraries against this target to ensure that
+# generated headers are up-to-date before the libraries are built. This ordering
+# dependency can be propagated to these libraries' dependenents via the PUBLIC
+# or INTERFACE option of target_link_libraries.
 
-add_custom_target(zephyr_generated_headers)
+add_library(zephyr_generated_headers INTERFACE)
 add_dependencies(zephyr_generated_headers
   offsets_h version_h
   )
@@ -1051,8 +1055,10 @@ if(CONFIG_LLEXT)
   # Weak definitions for these must be added at the end of the link order
   # to avoid shadowing actual implementations.
   add_library(syscall_weakdefs syscall_weakdefs_llext.c)
-  add_dependencies(syscall_weakdefs zephyr_generated_headers)
-  target_link_libraries(syscall_weakdefs zephyr_interface)
+  target_link_libraries(syscall_weakdefs
+    zephyr_generated_headers
+    zephyr_interface
+  )
   list(APPEND NO_WHOLE_ARCHIVE_LIBS syscall_weakdefs)
 endif()
 


### PR DESCRIPTION
Define `zephyr_generated_headers` as an interface library rather than a custom target. This allows CMake libraries to depend on this target AND propagate the dependency if needed using `target_link_libraries`.

Example:

If some user header `foo.h` includes `offsets.h`, even transitively, then `offsets.h` must be generated before any source file that includes `foo.h` is compiled. This can be captured by defining a library `foo` for the header with a public link dependency on `zephyr_generated_headers` using `target_link_libraries(foo zephyr_generated_headers)`. The ordering dependency on the generated `offsets.h` header will then propagate to `foo` and any libraries that link against `foo`, even transitively. This was not possible before this CL because one cannot use custom targets as public link dependencies with `target_link_libraries`.