### PR TITLE
cmake: extensions: fix argument order of zephyr_link_interface*()

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -521,7 +521,7 @@ macro(zephyr_library_amend)
 endmacro()
 
 function(zephyr_link_interface interface)
-  target_link_libraries(${interface} INTERFACE zephyr_interface)
+  target_link_libraries(zephyr_interface INTERFACE ${interface})
 endfunction()
 
 #
@@ -2124,7 +2124,7 @@ endfunction()
 
 function(zephyr_link_interface_ifdef feature_toggle interface)
   if(${${feature_toggle}})
-    target_link_libraries(${interface} INTERFACE zephyr_interface)
+    target_link_libraries(zephyr_interface INTERFACE ${interface})
   endif()
 endfunction()
 
@@ -2276,7 +2276,7 @@ endfunction()
 
 function(zephyr_link_interface_ifndef feature_toggle interface)
   if(NOT ${feature_toggle})
-    target_link_libraries(${interface} INTERFACE zephyr_interface)
+    target_link_libraries(zephyr_interface INTERFACE ${interface})
   endif()
 endfunction()
 


### PR DESCRIPTION
The order was backwards, causing zephyr_interface to be linked to the target rather than the target being linked to zephyr_interface.

I could not find any documentation or use of these functions in either the Zepyhr or NCS codebase, so this patch is based on my assumption as to how that they are intended to be used.