### PR TITLE
Bluetooth: Controller: Fix preemption of prepare under preempt race

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -251,6 +251,8 @@ struct lll_event {
 	lll_prepare_cb_t         prepare_cb;
 	lll_is_abort_cb_t        is_abort_cb;
 	lll_abort_cb_t           abort_cb;
+	uint8_t                  volatile prepare_req;
+	uint8_t                  prepare_ack;
 	uint8_t                  is_resume:1;
 	uint8_t                  is_aborted:1;
 };

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -1315,6 +1315,8 @@ preempt_find_preemptor:
 	}
 
 	if (ready->prepare_req != ready->prepare_ack) {
+		LL_ASSERT(0);
+
 		/* prepare_cb and preempt under race being called by mayfly at the same time.
 		 * Do not preempt a just called prepare under this race condition.
 		 */

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2203,6 +2203,17 @@ void ull_prepare_dequeue(uint8_t caller_id)
 
 		MFIFO_DEQUEUE(prep);
 
+		/* Ensure prepare pipeline indices are stored, and compiler does not re-order
+		 * instructions.
+		 */
+		cpu_dmb();
+
+		/* Reset prepare callback being called. This is used to detect race with preempt
+		 * called at same time and mayfly runs them together which a prepare element being
+		 * dequeued.
+		 */
+		next->prepare_ack = next->prepare_req;
+
 		/* Check for anymore more prepare elements in queue */
 		next = ull_prepare_dequeue_get();
 		if (!next) {


### PR DESCRIPTION
Fix preempting a called prepare under race when a lll_done call due to radio ISR being done and preempt call due to preempt timeout occur at the same time. Mayfly will execute them together leading to the prepare being immediately being asked to abort.

Under high throughput scenario this was leading to lll assertion, which is now fixed.