### PR TITLE
drivers: udc: support USB high speed for STM32U5

### DIFF
--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -10,6 +10,7 @@ config UDC_STM32
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
 	select PINCTRL
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
 	default y
 	help
 	  STM32 USB device controller driver.

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -51,7 +51,7 @@ LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
  * The following defines are used to map the value of the "maxiumum-speed"
  * DT property to the corresponding definition used by the STM32 HAL.
  */
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(USB_OTG_HS_EMB_PHY)
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || USB_OTG_HS_EMB_PHY
 #define UDC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH_IN_FULL
 #else
 #define UDC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH


### PR DESCRIPTION
USB_OTG_HS_EMB_PHY macro is always defined, so
`defined(USB_OTG_HS_EMB_PHY)` always results in true. This means that
driver always selected `USB_OTG_SPEED_HIGH_IN_FULL` and never
`USB_OTG_SPEED_HIGH`. Fix that by checking value of defined macro.

This driver support USB high-speed, so mark that on Kconfig level.

Adapt commit f72ef5c23724 ("drivers: usb: stm32: fix support of STM32U5
OTG_HS with embedded PHY") to "usb device next".

Tested with:

```
$ west build -p -b nucleo_u5a5zj_q/stm32u5a5xx \
  zephyr/samples/net/zperf/ \
  --extra-conf overlay-usbd_next.conf \
  --extra-dtc-overlay usbd_next_ecm.overlay
```

and Zephyr:

```
$ zperf tcp upload 192.0.2.2 5001 10 1K
```

where zperf upload speed increases from ~7 Mbps to ~22 Mbps.