### PR TITLE
boards: shields: x_nucleo_wb05kn1: add support for b_u585i_iot02a board

### DIFF
--- a/boards/shields/x_nucleo_wb05kn1/boards/b_u585i_iot02a.overlay
+++ b/boards/shields/x_nucleo_wb05kn1/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,6 @@
+/*
+ * Remove the WB5M Bluetooth HCI UART node from the board overlay.
+ */
+&uart4 {
+	/delete-node/ bt_hci_uart;
+};


### PR DESCRIPTION
Ported x_nucleo_wb05kn1 shield for st b_u585i_iot02a board