### PR TITLE
drivers: gpio: pca6416: fix dt get id

### DIFF
--- a/drivers/gpio/gpio_pca6416.c
+++ b/drivers/gpio/gpio_pca6416.c
@@ -472,7 +472,7 @@ static DEVICE_API(gpio, api_table) = {
 			.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),	\
 		},								\
 		.interrupt_enabled = DT_INST_NODE_HAS_PROP(n, interrupt_gpios),	\
-		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(inst, interrupt_gpios, {0}),	\
+		.gpio_int = GPIO_DT_SPEC_INST_GET_OR(n, interrupt_gpios, {0}),	\
 	};									\
 										\
 	static struct pca6416_drv_data pca6416_drvdata_##n = {			\


### PR DESCRIPTION
This PR is to fix the following issue in drivers/gpio/gpio_pca6416.c:
```
E: Cannot get pointer to gpio interrupt device
E: pca6416@20 init failed: -22

```
The issue is caused by the following commit:
https://github.com/zephyrproject-rtos/zephyr/commit/28052aa7f0eadd67a389f4501f3b82f3829c8784