### PR TITLE
samples: bluetooth: reduce RAM usage in hci_uart_async

### DIFF
--- a/samples/bluetooth/hci_uart_async/prj.conf
+++ b/samples/bluetooth/hci_uart_async/prj.conf
@@ -23,3 +23,6 @@ CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE=255
 # in case it has a interfering default. Those same boards set this
 # config and it must be undone or the build will fail.
 CONFIG_UART_CONSOLE=n
+
+# reduce RAM usage
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=512


### PR DESCRIPTION
This sample is used in BLE conformance EBQ tests.
Reduce RAM usage to make the sample work on nrf52810, nrf52811.