### PR TITLE
drivers: udc: stm32: fix USB_OTG_HS_EMB_PHY macro value check

### DIFF
--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -51,7 +51,7 @@ LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
  * The following defines are used to map the value of the "maxiumum-speed"
  * DT property to the corresponding definition used by the STM32 HAL.
  */
-#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(USB_OTG_HS_EMB_PHY)
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || USB_OTG_HS_EMB_PHY
 #define UDC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH_IN_FULL
 #else
 #define UDC_STM32_HIGH_SPEED             USB_OTG_SPEED_HIGH


### PR DESCRIPTION
USB_OTG_HS_EMB_PHY macro is always defined, so
`defined(USB_OTG_HS_EMB_PHY)` always results in true. This means that
driver always selected `USB_OTG_SPEED_HIGH_IN_FULL` and never
`USB_OTG_SPEED_HIGH`.

Fix that by checking value of defined macro.