### PR TITLE
drivers: adc: ambiq: fixed the error that caused adc_api test to fail

### DIFF
--- a/drivers/adc/adc_ambiq.c
+++ b/drivers/adc/adc_ambiq.c
@@ -43,8 +43,8 @@ struct adc_ambiq_config {
 struct adc_ambiq_data {
 	struct adc_context ctx;
 	void *adcHandle;
-	uint32_t *buffer;
-	uint32_t *repeat_buffer;
+	uint16_t *buffer;
+	uint16_t *repeat_buffer;
 	uint8_t active_channels;
 	struct k_sem dma_done_sem;
 	am_hal_adc_dma_config_t dma_cfg;
@@ -175,7 +175,7 @@ static void adc_ambiq_isr(const struct device *dev)
 						&Sample);
 			*data->buffer++ = Sample.ui32Sample;
 		}
-		adc_ambiq_disable(dev);
+		am_hal_adc_disable(data->adcHandle);
 		adc_context_on_sampling_done(&data->ctx, dev);
 	}
 

--- a/tests/drivers/adc/adc_api/boards/apollo510_evb.overlay
+++ b/tests/drivers/adc/adc_api/boards/apollo510_evb.overlay
@@ -5,25 +5,27 @@
  */
 / {
 	zephyr,user {
-		io-channels = <&adc0 4>, <&adc0 7>;
+		io-channels = <&adc0 5>, <&adc0 6>;
 	};
 };
 
 &adc0 {
 	status = "okay";
+	interrupt-parent = <&nvic>;
+	interrupts = <19 0>;
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	channel@4 {
-		reg = <4>;
+	channel@5 {
+		reg = <5>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
 	};
 
-	channel@7 {
-		reg = <7>;
+	channel@6 {
+		reg = <6>;
 		zephyr,gain = "ADC_GAIN_1";
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;


### PR DESCRIPTION
This commit fixed the failure of test_adc_asynchronous_call