### PR TITLE
drivers: dma: silabs: modify LDMA driver to handle large dma_block_config

### DIFF
--- a/drivers/dma/Kconfig.silabs
+++ b/drivers/dma/Kconfig.silabs
@@ -14,7 +14,7 @@ if DMA_SILABS_LDMA
 
 config DMA_MAX_DESCRIPTOR
 	int "Max Number of block_config (LDMA_Descriptor)"
-	default 8
+	default 16
 	help
 	  Max Number of block_config (LDMA_Descriptor)
 

--- a/tests/drivers/dma/loop_transfer/boards/sltb010a.conf
+++ b/tests/drivers/dma/loop_transfer/boards/sltb010a.conf
@@ -1,5 +1,4 @@
 # Copyright (c) 2024 Silicon Laboratories, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0
 CONFIG_DMA_LOOP_TRANSFER_SIZE=2048

--- a/tests/drivers/dma/loop_transfer/boards/slwrb4180a.conf
+++ b/tests/drivers/dma/loop_transfer/boards/slwrb4180a.conf
@@ -1,5 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0
-CONFIG_DMA_LOOP_TRANSFER_SIZE=2048

--- a/tests/drivers/dma/loop_transfer/boards/xg23_rb4210a.conf
+++ b/tests/drivers/dma/loop_transfer/boards/xg23_rb4210a.conf
@@ -1,5 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0
-CONFIG_DMA_LOOP_TRANSFER_SIZE=2048

--- a/tests/drivers/dma/loop_transfer/boards/xg24_dk2601b.conf
+++ b/tests/drivers/dma/loop_transfer/boards/xg24_dk2601b.conf
@@ -1,5 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0
-CONFIG_DMA_LOOP_TRANSFER_SIZE=2048

--- a/tests/drivers/dma/loop_transfer/boards/xg27_dk2602a.conf
+++ b/tests/drivers/dma/loop_transfer/boards/xg27_dk2602a.conf
@@ -1,5 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_LOOP_TRANSFER_CHANNEL_NR=0
-CONFIG_DMA_LOOP_TRANSFER_SIZE=2048

--- a/tests/drivers/dma/loop_transfer/boards/xg29_rb4412a.conf
+++ b/tests/drivers/dma/loop_transfer/boards/xg29_rb4412a.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2025 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_LOOP_TRANSFER_SIZE=2048

--- a/tests/drivers/dma/scatter_gather/boards/sltb010a.conf
+++ b/tests/drivers/dma/scatter_gather/boards/sltb010a.conf
@@ -1,5 +1,4 @@
 # Copyright (c) 2024 Silicon Laboratories, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_DMA_SG_CHANNEL_NR=0
 CONFIG_DMA_SG_XFER_SIZE=4096

--- a/tests/drivers/dma/scatter_gather/boards/slwrb4180a.conf
+++ b/tests/drivers/dma/scatter_gather/boards/slwrb4180a.conf
@@ -1,3 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-CONFIG_DMA_SG_CHANNEL_NR=0

--- a/tests/drivers/dma/scatter_gather/boards/xg23_rb4210a.conf
+++ b/tests/drivers/dma/scatter_gather/boards/xg23_rb4210a.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_SG_CHANNEL_NR=0

--- a/tests/drivers/dma/scatter_gather/boards/xg24_dk2601b.conf
+++ b/tests/drivers/dma/scatter_gather/boards/xg24_dk2601b.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_SG_CHANNEL_NR=0

--- a/tests/drivers/dma/scatter_gather/boards/xg27_dk2602a.conf
+++ b/tests/drivers/dma/scatter_gather/boards/xg27_dk2602a.conf
@@ -1,4 +1,0 @@
-# Copyright (c) 2024 Silicon Laboratories, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
-CONFIG_DMA_SG_CHANNEL_NR=0


### PR DESCRIPTION
The goal of this PR is to allows multiple hardware descriptors to be allocated for a single struct dma_block_config if the block size exceeds the transfer capacity of a single hardware LDMA descriptor. This is beneficial for other peripheral drivers: it is no longer necessary to split the payload by the transfer capacity of a single hardware LDMA descriptor.

It also contains cleanup for Silabs board DMA test files and update the default value for the max number of DMA descriptor.