### PR TITLE
litex: apply changes of zephyr-on-litex-vexriscv

### DIFF
--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -102,11 +102,11 @@
 				<0xe000c010 0x4>,
 				<0xe000c800 0x4>,
 				<0x60000000 0x1000000>;
-			reg-names = "core_mmap_dummy_bits",
-				"core_master_cs",
-				"core_master_phyconfig",
-				"core_master_rxtx",
-				"core_master_status",
+			reg-names = "mmap_dummy_bits",
+				"master_cs",
+				"master_phyconfig",
+				"master_rxtx",
+				"master_status",
 				"phy_clk_divisor",
 				"flash_mmap";
 			#address-cells = <1>;

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -95,20 +95,28 @@
 		};
 		spi1: spi@e000c000 {
 			compatible = "litex,spi-litespi";
+			interrupt-parent = <&intc0>;
 			reg = <0xe000c000 0x4>,
 				<0xe000c004 0x4>,
 				<0xe000c008 0x4>,
 				<0xe000c00c 0x4>,
 				<0xe000c010 0x4>,
-				<0xe000c800 0x4>,
+				<0xe000c014 0x4>,
+				<0xe000c018 0x4>,
+				<0xe000c01c 0x4>,
+				<0xe000c020 0x4>,
 				<0x60000000 0x1000000>;
-			reg-names = "mmap_dummy_bits",
+			reg-names = "phy_clk_divisor",
+				"mmap_dummy_bits",
 				"master_cs",
 				"master_phyconfig",
 				"master_rxtx",
 				"master_status",
-				"phy_clk_divisor",
+				"master_ev_status",
+				"master_ev_pending",
+				"master_ev_enable",
 				"flash_mmap";
+			interrupts = <9 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			spiflash0: flash@0 {
@@ -238,18 +246,26 @@
 		};
 		i2c1: i2c@e000d800 {
 			compatible = "litex,litei2c";
+			interrupt-parent = <&intc0>;
 			reg = <0xe000d800 0x4>,
 				<0xe000d804 0x4>,
 				<0xe000d808 0x4>,
 				<0xe000d80c 0x4>,
 				<0xe000d810 0x4>,
-				<0xe000d814 0x4>;
+				<0xe000d814 0x4>,
+				<0xe000d818 0x4>,
+				<0xe000d81c 0x4>,
+				<0xe000d820 0x4>;
 			reg-names = "phy_speed_mode",
 				"master_active",
 				"master_settings",
 				"master_addr",
 				"master_rxtx",
-				"master_status";
+				"master_status",
+				"master_ev_status",
+				"master_ev_pending",
+				"master_ev_enable";
+			interrupts = <10 0>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
- litespi and litex dropped the `core_` part in the name of the registers apply that here too, so the litex dts overlay generator will continue to work.
- https://github.com/litex-hub/zephyr-on-litex-vexriscv/pull/22 got merged and as the litex board and the `riscv32-litex-vexriscv.dtsi` are based on it, we chould apply these changes here too. It also has interrupt support for litespi and litei2c enabled by default, that's why the needed entries in the dts are already changed with this PR. The drivers supporting in will be added in https://github.com/zephyrproject-rtos/zephyr/pull/91050.