### PR TITLE
net: sockets: Move socket vtable definition

### DIFF
--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1217,6 +1217,30 @@ struct net_socket_register {
 #define NET_SOCKET_OFFLOAD_REGISTER(socket_name, prio, _family, _is_supported, _handler) \
 	_NET_SOCKET_REGISTER(socket_name, prio, _family, _is_supported, _handler, true)
 
+struct socket_op_vtable {
+	struct fd_op_vtable fd_vtable;
+	int (*shutdown)(void *obj, int how);
+	int (*bind)(void *obj, const struct sockaddr *addr, socklen_t addrlen);
+	int (*connect)(void *obj, const struct sockaddr *addr,
+		       socklen_t addrlen);
+	int (*listen)(void *obj, int backlog);
+	int (*accept)(void *obj, struct sockaddr *addr, socklen_t *addrlen);
+	ssize_t (*sendto)(void *obj, const void *buf, size_t len, int flags,
+			  const struct sockaddr *dest_addr, socklen_t addrlen);
+	ssize_t (*recvfrom)(void *obj, void *buf, size_t max_len, int flags,
+			    struct sockaddr *src_addr, socklen_t *addrlen);
+	int (*getsockopt)(void *obj, int level, int optname,
+			  void *optval, socklen_t *optlen);
+	int (*setsockopt)(void *obj, int level, int optname,
+			  const void *optval, socklen_t optlen);
+	ssize_t (*sendmsg)(void *obj, const struct msghdr *msg, int flags);
+	ssize_t (*recvmsg)(void *obj, struct msghdr *msg, int flags);
+	int (*getpeername)(void *obj, struct sockaddr *addr,
+			   socklen_t *addrlen);
+	int (*getsockname)(void *obj, struct sockaddr *addr,
+			   socklen_t *addrlen);
+};
+
 /** @endcond */
 
 #ifdef __cplusplus

--- a/subsys/net/lib/sockets/sockets_internal.h
+++ b/subsys/net/lib/sockets/sockets_internal.h
@@ -53,30 +53,6 @@ static inline bool net_socket_is_tls(void *obj)
 #define sock_is_error(ctx) sock_get_flag(ctx, SOCK_ERROR)
 #define sock_set_error(ctx) sock_set_flag(ctx, SOCK_ERROR, SOCK_ERROR)
 
-struct socket_op_vtable {
-	struct fd_op_vtable fd_vtable;
-	int (*shutdown)(void *obj, int how);
-	int (*bind)(void *obj, const struct sockaddr *addr, socklen_t addrlen);
-	int (*connect)(void *obj, const struct sockaddr *addr,
-		       socklen_t addrlen);
-	int (*listen)(void *obj, int backlog);
-	int (*accept)(void *obj, struct sockaddr *addr, socklen_t *addrlen);
-	ssize_t (*sendto)(void *obj, const void *buf, size_t len, int flags,
-			  const struct sockaddr *dest_addr, socklen_t addrlen);
-	ssize_t (*recvfrom)(void *obj, void *buf, size_t max_len, int flags,
-			    struct sockaddr *src_addr, socklen_t *addrlen);
-	int (*getsockopt)(void *obj, int level, int optname,
-			  void *optval, socklen_t *optlen);
-	int (*setsockopt)(void *obj, int level, int optname,
-			  const void *optval, socklen_t optlen);
-	ssize_t (*sendmsg)(void *obj, const struct msghdr *msg, int flags);
-	ssize_t (*recvmsg)(void *obj, struct msghdr *msg, int flags);
-	int (*getpeername)(void *obj, struct sockaddr *addr,
-			   socklen_t *addrlen);
-	int (*getsockname)(void *obj, struct sockaddr *addr,
-			   socklen_t *addrlen);
-};
-
 size_t msghdr_non_empty_iov_count(const struct msghdr *msg);
 
 #if defined(CONFIG_NET_SOCKETS_OBJ_CORE)


### PR DESCRIPTION
Offloaded socket implementations need to create the socket operations vtable, therefore need access to struct socket_op_vtable. So far this has been defined in a private header, so implementations needed to add the header location to the include path in CMake.

Therefore, move struct socket_op_vtable definition to the internal part of the public socket header, so it's no longer needed to include a private header. This is also more consistent with the rest of the public header content, as for example macros needed to register a socket implementation are already there.

Fixes #92950