### PR TITLE
stm32: boards: nucleo_u385rg_q: update clock domain source for rng peripheral 

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -110,6 +110,10 @@
 	status = "okay";
 };
 
+&clk_msik {
+	status = "okay";
+};
+
 &clk_msis {
 	status = "okay";
 	msi-pll-mode;
@@ -160,6 +164,8 @@
 };
 
 &rng {
+	clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
+		 <&rcc STM32_SRC_MSIK RNG_SEL(1)>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Several tests failed (crypto, random, jwt, uuid, ...) due to a `low clock frequency` for the RNG peripheral.
Increase the RNG clock frequency by providing MSIK with 96 MHz as the domain source.