### PR TITLE
samples: sensor: accel_trig: Fix harness configuration

### DIFF
--- a/samples/sensor/accel_trig/sample.yaml
+++ b/samples/sensor/accel_trig/sample.yaml
@@ -12,6 +12,10 @@ tests:
   sample.sensor.accel_trig:
     filter: dt_alias_exists("accel0")
     harness_config:
+      type: one_line
+      regex:
+        - "^\\s*[0-9A-Za-z_,+-.]*@[0-9A-Fa-f]* \\[m\/s\\^2\\]:    \
+          \\(\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*,\\s*-?[0-9\\.]*\\)$"
       fixture: fixture_sensor_accel_int
     integration_platforms:
       - frdm_k64f                       # fxos8700


### PR DESCRIPTION
HARNESS:Console:no regex patterns configured error is shown when sample.sensor.accel_trig sample is run.
Add console harness configuration for the test.