### PR TITLE
net: lib: http: allow configuring response chunk size

### DIFF
--- a/doc/connectivity/networking/api/http_server.rst
+++ b/doc/connectivity/networking/api/http_server.rst
@@ -261,6 +261,10 @@ content type text/html.
 
     HTTP_SERVER_CONTENT_TYPE(json, "application/json")
 
+When serving files from a static filesystem, the response chunk size can be configured
+using the :kconfig:option:`CONFIG_HTTP_SERVER_STATIC_FS_RESPONSE_SIZE` Kconfig option.
+This determines the size of individual chunks when transmitting file content to clients.
+
 Dynamic resources
 =================
 

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -44,6 +44,7 @@ if HTTP_SERVER
 
 config HTTP_SERVER_STACK_SIZE
 	int "HTTP server thread stack size"
+	default 4096 if FILE_SYSTEM
 	default 3072
 	help
 	  HTTP server thread stack size for processing RX/TX events.
@@ -218,6 +219,17 @@ config HTTP_SERVER_COMPRESSION
 	    4. compress -> .lzw
 	    5. deflate  -> .zz
 	    6. File without compression
+
+config HTTP_SERVER_STATIC_FS_RESPONSE_SIZE
+	int "Size of static file system response buffer"
+	depends on FILE_SYSTEM
+	default 1024
+	help
+	  The size of a single chunk when serving static files from the file system.
+	  This config value must be large enough to hold the headers in a single chunk.
+	  If set to 0, the server will use the minimal viable buffer size for the response.
+	  Please note that it is allocated on the stack of the HTTP server thread,
+	  so CONFIG_HTTP_SERVER_STACK_SIZE has to be sufficiently large.
 
 endif
 

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -482,11 +482,19 @@ int handle_http1_static_fs_resource(struct http_resource_detail_static_fs *stati
 		sizeof("Content-Length: 01234567890123456789\r\n")
 #define CONTENT_ENCODING_HEADER_SIZE                                                               \
 	sizeof(CONTENT_ENCODING_HEADER) + HTTP_COMPRESSION_MAX_STRING_LEN + sizeof("\r\n")
+/* Calculate the minimum size required for the headers */
 #define STATIC_FS_RESPONSE_SIZE                                                                    \
 	COND_CODE_1(                                                                               \
 		IS_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION),                                        \
 		(STATIC_FS_RESPONSE_BASE_SIZE + CONTENT_ENCODING_HEADER_SIZE),                     \
 		(STATIC_FS_RESPONSE_BASE_SIZE))
+#if CONFIG_HTTP_SERVER_STATIC_FS_RESPONSE_SIZE > 0
+BUILD_ASSERT(CONFIG_HTTP_SERVER_STATIC_FS_RESPONSE_SIZE >= STATIC_FS_RESPONSE_SIZE,
+			"CONFIG_HTTP_SERVER_STATIC_FS_RESPONSE_SIZE must be at least "
+			"large enough to hold HTTP headers");
+#undef STATIC_FS_RESPONSE_SIZE
+#define STATIC_FS_RESPONSE_SIZE CONFIG_HTTP_SERVER_STATIC_FS_RESPONSE_SIZE
+#endif
 
 	enum http_compression chosen_compression = 0;
 	int len;


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/92921

Introduce Kconfig HTTP_SERVER_STATIC_FS_RESPONSE_SIZE, size of individual chunks when serving files.