### PR TITLE
Stm32c071 add hsi48 support

### DIFF
--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -78,6 +78,11 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+	crs-usb-sof;
+};
+
 &rcc {
 	clocks = <&clk_hse>;
 	clock-frequency = <DT_FREQ_M(48)>;

--- a/drivers/clock_control/clock_stm32c0.c
+++ b/drivers/clock_control/clock_stm32c0.c
@@ -8,6 +8,7 @@
 
 #include <soc.h>
 #include <stm32_ll_bus.h>
+#include <stm32_ll_crs.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_utils.h>
 #include <zephyr/drivers/clock_control.h>
@@ -22,4 +23,11 @@ void config_enable_default_clocks(void)
 {
 	/* Enable the power interface clock */
 	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
+
+#if IS_ENABLED(STM32_HSI48_CRS_USB_SOF)
+	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_CRS);
+	LL_CRS_SetSyncSignalSource(LL_CRS_SYNC_SOURCE_USB);
+	LL_CRS_EnableAutoTrimming();
+	LL_CRS_EnableFreqErrorCounter();
+#endif
 }

--- a/dts/arm/st/c0/stm32c071.dtsi
+++ b/dts/arm/st/c0/stm32c071.dtsi
@@ -7,6 +7,16 @@
 #include <st/c0/stm32c031.dtsi>
 
 / {
+	clocks {
+		/* Node representing the HSIUSB48 generator */
+		clk_hsi48: clk-hsi48 {
+			#clock-cells = <0>;
+			compatible = "st,stm32-hsi48-clock";
+			clock-frequency = <DT_FREQ_M(48)>;
+			status = "disabled";
+		};
+	};
+
 	soc {
 		compatible = "st,stm32c071", "st,stm32c0", "simple-bus";
 

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -23,9 +23,13 @@
 /** System clock */
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
-/* Low speed clocks defined in stm32_common_clocks.h */
+/* Low speed clocks defined in stm32_common_clocks.h
+ * STM32_SRC_HSI relates to HSI48 clock mentioned in RM0490 Reference Manual
+ * STM32_SRC_HSI48 relates to HSIUSB48 mentioned in RM0490 Reference Manual
+ */
 #define STM32_SRC_HSI		(STM32_SRC_LSI + 1)
-#define STM32_SRC_HSE		(STM32_SRC_HSI + 1)
+#define STM32_SRC_HSI48		(STM32_SRC_HSI + 1)
+#define STM32_SRC_HSE		(STM32_SRC_HSI48 + 1)
 /** Peripheral bus clock */
 #define STM32_SRC_PCLK		(STM32_SRC_HSE + 1)
 


### PR DESCRIPTION
Create an HSI48 clock source (HSIUSB48) for the STM32C071 SOC.  Only the STM32C071xx SOC supports this clock, and it can be used in systems which do not have an HSE or the HSE value is not 48 MHz.