### PR TITLE
doc: _static: css: fix navtree +/- icon margins

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -738,21 +738,21 @@ kbd, .kbd,
     border: none;
 }
 
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a span.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a span.toctree-expand {
+.wy-menu-vertical a button.toctree-expand,
+.wy-menu-vertical li.toctree-l2 a button.toctree-expand {
     color: var(--navbar-level-3-color);
     opacity: 0.9;
-    margin-right: 8px;
+    margin-right: 6px;
 }
 
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:hover span.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a:hover span.toctree-expand {
+.wy-menu-vertical a:hover button.toctree-expand,
+.wy-menu-vertical li.toctree-l2 a:hover button.toctree-expand {
     color: var(--navbar-level-2-color);
     opacity: 1;
 }
 
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:active span.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a:active span.toctree-expand {
+.wy-menu-vertical a:active button.toctree-expand,
+.wy-menu-vertical li.toctree-l2 a:active button.toctree-expand {
     color: var(--navbar-level-1-color);
     opacity: 1;
 }


### PR DESCRIPTION
Fixed selectors that probably went stale overtime since the custom.css was adopted from Godot and RTD having evolved in the meantime and that were causing +/- icons to expand/collapse the navtree to be putting margins where they shouldn't have.

https://builds.zephyrproject.io/zephyr/pr/92978/docs/kernel/drivers/index.html

<img width="687" height="963" alt="image" src="https://github.com/user-attachments/assets/248176c3-1601-4be0-b5ab-93cca20b3249" />


Fixes zephyrproject-rtos/zephyr#78974.