### PR TITLE
ci: scripts: footprint: fix hifive1 rev.B board name

### DIFF
--- a/scripts/footprint/plan.txt
+++ b/scripts/footprint/plan.txt
@@ -4,7 +4,7 @@ footprints,default,disco_l475_iot1,tests/benchmarks/footprints,,benchmark.kernel
 footprints,userspace,disco_l475_iot1,tests/benchmarks/footprints,-DCONF_FILE=prj_userspace.conf,benchmark.kernel.footprints.userspace
 footprints,default,nrf5340dk/nrf5340/cpuapp,tests/benchmarks/footprints,,benchmark.kernel.footprints.default
 footprints,default,nrf51dk/nrf51822,tests/benchmarks/footprints,,benchmark.kernel.footprints.default
-footprints,default,hifive1@B,tests/benchmarks/footprints,,benchmark.kernel.footprints.default
+footprints,default,hifive1_revb,tests/benchmarks/footprints,,benchmark.kernel.footprints.default
 footprints,default,intel_ehl_crb,tests/benchmarks/footprints,,benchmark.kernel.footprints.default
 footprints,userspace,intel_ehl_crb,tests/benchmarks/footprints,-DCONF_FILE=prj_userspace.conf,benchmark.kernel.footprints.userspace
 footprints,power-management,frdm_k64f,tests/benchmarks/footprints,-DCONF_FILE=prj_pm.conf,benchmark.kernel.footprints.pm


### PR DESCRIPTION
Rev B of hifive1 is 'hifive1_revb' since 07e4ba42407f

Fix CI footprint-tracking workflow build failed:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/16183822920/job/45685636429#step:13:44
