### PR TITLE
NXP drivers: dma: mipi_dbi_nxp_lcdic: enable inputmux clock

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -773,10 +773,12 @@ static int mipi_dbi_lcdic_init_common(const struct device *dev)
 	/* Attach the LCDIC DMA request signal to the DMA channel we will
 	 * use with hardware triggering.
 	 */
+	INPUTMUX_Init(INPUTMUX);
 	INPUTMUX_AttachSignal(INPUTMUX, data->dma_stream.channel,
 			kINPUTMUX_LcdTxRegToDmaSingleToDma0);
 	INPUTMUX_EnableSignal(INPUTMUX,
 			kINPUTMUX_Dmac0InputTriggerLcdTxRegToDmaSingleEna, true);
+	INPUTMUX_Deinit(INPUTMUX);
 #endif
 
 	return 0;


### PR DESCRIPTION
To optimize power consumption, the inputmux clock is only enabled when a signal is attached.

Resolves #92987 