### PR TITLE
drivers: video: ov5640: Fix division by zero in frame rate calculation

### DIFF
--- a/drivers/video/ov5640.c
+++ b/drivers/video/ov5640.c
@@ -782,6 +782,10 @@ static int ov5640_set_frmival(const struct device *dev, struct video_frmival *fr
 		return -ENOTSUP;
 	}
 
+	if (frmival->numerator == 0) {
+		LOG_ERR("Numerator is zero, invalid frame rate values.");
+		return -EINVAL;
+	}
 	desired_frmrate = DIV_ROUND_CLOSEST(frmival->denominator, frmival->numerator);
 
 	/* Find the supported frame rate closest to the desired one */


### PR DESCRIPTION
Add a check to ensure the numerator is non-zero before performing division in the ov5640_set_frmival function to prevent division by zero errors.

Fixes: #92620