### PR TITLE
drivers: sensor: voltage_divider: fix unchecked pm_device_runtime_get()

### DIFF
--- a/drivers/sensor/voltage_divider/voltage.c
+++ b/drivers/sensor/voltage_divider/voltage.c
@@ -127,7 +127,11 @@ static int pm_action(const struct device *dev, enum pm_device_action action)
 		data->earliest_sample = K_TIMEOUT_ABS_TICKS(
 			k_uptime_ticks() + k_us_to_ticks_ceil32(config->sample_delay_us));
 		/* Power up ADC */
-		pm_device_runtime_get(config->voltage.port.dev);
+		ret = pm_device_runtime_get(config->voltage.port.dev);
+		if (ret != 0) {
+			LOG_ERR("failed to power up ADC (%d)", ret);
+			return ret;
+		}
 		break;
 #ifdef CONFIG_PM_DEVICE
 	case PM_DEVICE_ACTION_SUSPEND:
@@ -136,7 +140,11 @@ static int pm_action(const struct device *dev, enum pm_device_action action)
 			LOG_ERR("failed to set GPIO for PM suspend");
 		}
 		/* Power down ADC */
-		pm_device_runtime_put(config->voltage.port.dev);
+		ret = pm_device_runtime_put(config->voltage.port.dev);
+		if (ret != 0) {
+			LOG_ERR("failed to Power down ADC (%d)", ret);
+			return ret;
+		}
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		break;


### PR DESCRIPTION
Fix Coverity CID 529858 (CWE-252): Previously, the return value of pm_device_runtime_get() was not checked during PM resume, which could lead to missed error conditions.

This patch ensures proper error handling by checking and propagating the return status of the call.

Fixes: #92608