### PR TITLE
drivers: nrf_wifi: Fix rpu recovery debug info

### DIFF
--- a/drivers/wifi/nrf_wifi/inc/fmac_main.h
+++ b/drivers/wifi/nrf_wifi/inc/fmac_main.h
@@ -118,6 +118,8 @@ struct nrf_wifi_ctx_zep {
 	unsigned int rpu_recovery_retries;
 	int rpu_recovery_success;
 	int rpu_recovery_failure;
+	int wdt_irq_received;
+	int wdt_irq_ignored;
 #endif /* CONFIG_NRF_WIFI_RPU_RECOVERY */
 };
 

--- a/drivers/wifi/nrf_wifi/src/net_if.c
+++ b/drivers/wifi/nrf_wifi/src/net_if.c
@@ -72,6 +72,8 @@ static void nrf_wifi_rpu_recovery_work_handler(struct k_work *work)
 								struct nrf_wifi_vif_ctx_zep,
 								nrf_wifi_rpu_recovery_work);
 	struct nrf_wifi_ctx_zep *rpu_ctx_zep = NULL;
+	struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx = NULL;
+	struct nrf_wifi_hal_dev_ctx *hal_dev_ctx = NULL;
 	int ret;
 
 	if (!vif_ctx_zep) {
@@ -87,6 +89,18 @@ static void nrf_wifi_rpu_recovery_work_handler(struct k_work *work)
 	rpu_ctx_zep = vif_ctx_zep->rpu_ctx_zep;
 	if (!rpu_ctx_zep || !rpu_ctx_zep->rpu_ctx) {
 		LOG_ERR("%s: rpu_ctx_zep is NULL", __func__);
+		return;
+	}
+
+	fmac_dev_ctx = rpu_ctx_zep->rpu_ctx;
+	if (!fmac_dev_ctx) {
+		LOG_ERR("%s: fmac_dev_ctx is NULL", __func__);
+		return;
+	}
+
+	hal_dev_ctx = fmac_dev_ctx->hal_dev_ctx;
+	if (!hal_dev_ctx) {
+		LOG_ERR("%s: hal_dev_ctx is NULL", __func__);
 		return;
 	}
 
@@ -134,6 +148,8 @@ static void nrf_wifi_rpu_recovery_work_handler(struct k_work *work)
 	}
 #endif
 	rpu_ctx_zep->rpu_recovery_in_progress = true;
+	rpu_ctx_zep->wdt_irq_received += hal_dev_ctx->wdt_irq_received;
+	rpu_ctx_zep->wdt_irq_ignored += hal_dev_ctx->wdt_irq_ignored;
 #ifdef CONFIG_NRF_WIFI_RPU_RECOVERY_DEBUG
 	LOG_ERR("%s: Bringing the interface down", __func__);
 #else

--- a/drivers/wifi/nrf_wifi/src/wifi_util.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_util.c
@@ -938,10 +938,20 @@ static int nrf_wifi_util_rpu_recovery_info(const struct shell *sh,
 	}
 
 	fmac_dev_ctx = ctx->rpu_ctx;
-	hal_dev_ctx = fmac_dev_ctx->hal_dev_ctx;
+	if (!fmac_dev_ctx) {
+		shell_fprintf(sh, SHELL_ERROR, "FMAC context not initialized\n");
+		ret = -ENOEXEC;
+		goto unlock;
+	}
 
-	shell_fprintf(sh,
-		      SHELL_INFO,
+	hal_dev_ctx = fmac_dev_ctx->hal_dev_ctx;
+	if (!hal_dev_ctx) {
+		shell_fprintf(sh, SHELL_ERROR, "HAL context not initialized\n");
+		ret = -ENOEXEC;
+		goto unlock;
+	}
+
+	shell_fprintf(sh, SHELL_INFO,
 		      "wdt_irq_received: %d\n"
 		      "wdt_irq_ignored: %d\n"
 		      "last_wakeup_now_asserted_time_ms: %lu milliseconds\n"
@@ -950,14 +960,11 @@ static int nrf_wifi_util_rpu_recovery_info(const struct shell *sh,
 		      "current time: %lu milliseconds\n"
 		      "rpu_recovery_success: %d\n"
 		      "rpu_recovery_failure: %d\n\n",
-		      hal_dev_ctx->wdt_irq_received,
-		      hal_dev_ctx->wdt_irq_ignored,
+		      ctx->wdt_irq_received, ctx->wdt_irq_ignored,
 		      hal_dev_ctx->last_wakeup_now_asserted_time_ms,
 		      hal_dev_ctx->last_wakeup_now_deasserted_time_ms,
-		      hal_dev_ctx->last_rpu_sleep_opp_time_ms,
-		      current_time_ms,
-		      ctx->rpu_recovery_success,
-		      ctx->rpu_recovery_failure);
+		      hal_dev_ctx->last_rpu_sleep_opp_time_ms, current_time_ms,
+		      ctx->rpu_recovery_success, ctx->rpu_recovery_failure);
 
 	ret = 0;
 unlock:


### PR DESCRIPTION
Rpu recovey debug stats are stored in hal_dev_ctx which is not persistent in case of interface is brought down/up. Need to add in nrf_wifi_ctx_zep and update before interface goes down.