### PR TITLE
workflows: Add quarantine usage to twister runs

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -110,7 +110,7 @@ jobs:
           ./scripts/twister \
             -i --force-color -N -v --filter runnable -p ${{ matrix.platform }} --coverage \
             -T tests --coverage-tool gcovr -xCONFIG_TEST_EXTRA_STACK_SIZE=4096 -e nano \
-            --timeout-multiplier 2
+            --timeout-multiplier 2 --quarantine-list scripts/ci/quarantine.yaml
 
       - name: Print ccache stats
         if: always()

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -142,7 +142,11 @@ jobs:
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
+      TWISTER_COMMON: >
+        --test-config tests/test_config_ci.yaml
+        --force-color --inline-logs
+        -v -N -M --retry-failed 3 --timeout-multiplier 2
+        --quarantine-list scripts/ci/quarantine.yaml
       WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered -j 32'
       PR_OPTIONS: ' --clobber-output --integration -j 16'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'
@@ -276,6 +280,14 @@ jobs:
             fi
           fi
 
+      - if: matrix.subset == 1 && github.event_name == 'schedule'
+        name: Verify quarantine with Twister
+        id: run_quarantine_verify
+        run: |
+          export ZEPHYR_BASE=${PWD}
+          export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+          ./scripts/twister --quarantine-verify ${TWISTER_COMMON} ${WEEKLY_OPTIONS} --outdir quarantine_verify --report-suffix quarantine
+
       - name: Print ccache stats
         if: always()
         run: |
@@ -291,6 +303,7 @@ jobs:
             twister-out/twister.xml
             twister-out/twister.json
             module_tests/twister.xml
+            quarantine_verify/twister_quarantine.xml
             testplan.json
 
       - if: matrix.subset == 1 && github.event_name == 'push'

--- a/scripts/ci/quarantine.yaml
+++ b/scripts/ci/quarantine.yaml
@@ -1,0 +1,16 @@
+# Configurations being a product of scenarios and platforms fields
+# in a given entry will be skipped by twister if quarantine is used.
+# More details here:
+# https://docs.zephyrproject.org/latest/guides/test/twister.html#quarantine
+#
+# Example of entry:
+# - scenarios:
+#     - kernel.common
+#     - kernel.common.(misra|tls)
+#     - kernel.common.nano64
+#   platforms:
+#     - .*_cortex_.*
+#     - native_sim
+#   comment: "Link to the issue: https://github.com/zephyrproject-rtos/zephyr/pull/33287"
+#
+# IMPORTANT: Each entry must include a link to a reported issue in comment section


### PR DESCRIPTION
New quarantine file is added, currently empty.
Twister runs will load this file and skip quaranatined configurations.
Added weekly run which will verify quarantine
(run quarantined items).

fixes: #87694