### PR TITLE
modules: hostap: set the cipher suites for WPA2 & WPA3 SAE mode

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -756,6 +756,14 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 					goto out;
 				}
 			}
+
+			if (!wpa_cli_cmd_v("set_network %d group CCMP", resp.network_id)) {
+				goto out;
+			}
+
+			if (!wpa_cli_cmd_v("set_network %d pairwise CCMP", resp.network_id)) {
+				goto out;
+			}
 		} else if (params->security == WIFI_SECURITY_TYPE_PSK_SHA256) {
 			if (!wpa_cli_cmd_v("set_network %d psk \"%s\"",
 					   resp.network_id, psk_null_terminated)) {
@@ -764,6 +772,14 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 
 			if (!wpa_cli_cmd_v("set_network %d key_mgmt WPA-PSK-SHA256",
 					   resp.network_id)) {
+				goto out;
+			}
+
+			if (!wpa_cli_cmd_v("set_network %d group CCMP", resp.network_id)) {
+				goto out;
+			}
+
+			if (!wpa_cli_cmd_v("set_network %d pairwise CCMP", resp.network_id)) {
 				goto out;
 			}
 		} else if (params->security == WIFI_SECURITY_TYPE_PSK ||
@@ -780,6 +796,15 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 
 			if (params->security == WIFI_SECURITY_TYPE_WPA_PSK) {
 				if (!wpa_cli_cmd_v("set_network %d proto WPA",
+						   resp.network_id)) {
+					goto out;
+				}
+			} else {
+				if (!wpa_cli_cmd_v("set_network %d group CCMP", resp.network_id)) {
+					goto out;
+				}
+
+				if (!wpa_cli_cmd_v("set_network %d pairwise CCMP",
 						   resp.network_id)) {
 					goto out;
 				}
@@ -808,6 +833,14 @@ static int wpas_add_and_config_network(struct wpa_supplicant *wpa_s,
 
 			if (!wpa_cli_cmd_v("set_network %d key_mgmt WPA-PSK SAE",
 					   resp.network_id)) {
+				goto out;
+			}
+
+			if (!wpa_cli_cmd_v("set_network %d group CCMP", resp.network_id)) {
+				goto out;
+			}
+
+			if (!wpa_cli_cmd_v("set_network %d pairwise CCMP", resp.network_id)) {
 				goto out;
 			}
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE


### PR DESCRIPTION
When the external AP is in WPA3 SAE mode, the group cipher uses TKIP and the pairwise cipher uses TKIP and CCMP. Should not connect to the AP.
For WPA2 & WPA3 SAE & WPA2/WPA3 mixed mode, set group cipher to CCMP, pairwise cipher to CCMP.