### PR TITLE
dts: arm: st: u0: fix lpuart1/2 interrupts

### DIFF
--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -252,7 +252,7 @@
 			reg = <0x40008000 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
-			interrupts = <28 0>;
+			interrupts = <29 0>;
 			status = "disabled";
 		};
 
@@ -261,7 +261,7 @@
 			reg = <0x40008400 0x400>;
 			clocks = <&rcc STM32_CLOCK(APB1, 7U)>;
 			resets = <&rctl STM32_RESET(APB1L, 7U)>;
-			interrupts = <29 0>;
+			interrupts = <28 0>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Interrupt vectors for lpuart1 and lpuart2 are swapped according to the reference manual RM0503 table 54.
Fixes the usage of the interrupt-driven uart API.

Fixes zephyrproject-rtos/zephyr#93011.