### PR TITLE
linker: arc: add .rodata_in_data section to avoid unexpected placement

### DIFF
--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -193,6 +193,10 @@ SECTIONS {
 		*(".data.*")
 		*(".kernel.*")
 
+/* This is an MWDT-specific section, created when -Hccm option is enabled */
+		*(".rodata_in_data")
+		*(".rodata_in_data.*")
+
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */


### PR DESCRIPTION
The .rodata_in_data section is produced by MWDT toolchain with -Hccm option enabled. This option moves read-only data from the executable memory (ICCM) to the data memory (DCCM), improving performance by reducing conflicts between instruction fetches and data fetches.

Fixes #92557