### PR TITLE
Correct typo in STM32N6 XSPI2 clock selection

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -231,7 +231,7 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-		 <&rcc STM32_SRC_IC3 XSPI1_SEL(2)>,
+		 <&rcc STM32_SRC_IC3 XSPI2_SEL(2)>,
 		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -320,7 +320,7 @@ zephyr_udc0: &usbotg_hs1 {
 		     &xspim_p2_io6_pn10 &xspim_p2_io7_pn11>;
 	pinctrl-names = "default";
 	clocks = <&rcc STM32_CLOCK(AHB5, 12)>,
-		 <&rcc STM32_SRC_IC3 XSPI1_SEL(2)>,
+		 <&rcc STM32_SRC_IC3 XSPI2_SEL(2)>,
 		 <&rcc STM32_CLOCK(AHB5, 13)>;
 	status = "okay";
 


### PR DESCRIPTION
Correct a typo leading to not not configuring correctly the STM32N6 xspi2 input clock.