### PR TITLE
init: fix compilation for broken compilers

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -1260,7 +1260,7 @@ device_get_dt_nodelabels(const struct device *dev)
 #define Z_DEVICE_INIT_ENTRY_DEFINE(node_id, dev_id, level, prio)                                   \
 	Z_DEVICE_CHECK_INIT_LEVEL(level)                                                           \
                                                                                                    \
-	static const Z_DECL_ALIGN(struct init_entry) __used __noasan Z_INIT_ENTRY_SECTION(         \
+	static const Z_DECL_ALIGN(union init_entry) __used __noasan Z_INIT_ENTRY_SECTION(          \
 		level, prio, Z_DEVICE_INIT_SUB_PRIO(node_id))                                      \
 		Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(dev_id)) = {                                     \
 			.dev = (const struct device *)&DEVICE_NAME_GET(dev_id),                    \

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -52,7 +52,7 @@ extern "C" {
 struct device;
 
 /**
- * @brief Structure to store initialization entry information.
+ * @brief Type to store initialization entry information.
  *
  * @internal
  * Init entries need to be defined following these rules:
@@ -65,16 +65,14 @@ struct device;
  * See SYS_INIT_NAMED() for an example.
  * @endinternal
  */
-struct init_entry {
+union init_entry {
 	/**
 	 * An init entry can be about a device or a service, _init_object
 	 * will be used to differentiate depending on relative sections.
 	 */
-	union {
-		const void *_init_object;
-		const struct device *dev;
-		const struct service *srv;
-	};
+	const void *_init_object;
+	const struct device *dev;
+	const struct service *srv;
 };
 
 /** @cond INTERNAL_HIDDEN */
@@ -166,7 +164,7 @@ struct init_entry {
  */
 #define SYS_INIT_NAMED(name, init_fn_, level, prio)                                       \
 	Z_SERVICE_DEFINE(name, init_fn_, level, prio);                                    \
-	static const Z_DECL_ALIGN(struct init_entry)                                      \
+	static const Z_DECL_ALIGN(union init_entry)                                      \
 		Z_INIT_ENTRY_SECTION(level, prio, 0) __used __noasan                      \
 		Z_INIT_ENTRY_NAME(name) = {                                               \
 			.srv = (const struct service *)&Z_SERVICE_NAME_GET(name)          \

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -113,13 +113,13 @@ static void z_init_static_threads(void)
 #define z_init_static_threads() do { } while (false)
 #endif /* CONFIG_MULTITHREADING */
 
-extern const struct init_entry __init_start[];
-extern const struct init_entry __init_EARLY_start[];
-extern const struct init_entry __init_PRE_KERNEL_1_start[];
-extern const struct init_entry __init_PRE_KERNEL_2_start[];
-extern const struct init_entry __init_POST_KERNEL_start[];
-extern const struct init_entry __init_APPLICATION_start[];
-extern const struct init_entry __init_end[];
+extern const union init_entry __init_start[];
+extern const union init_entry __init_EARLY_start[];
+extern const union init_entry __init_PRE_KERNEL_1_start[];
+extern const union init_entry __init_PRE_KERNEL_2_start[];
+extern const union init_entry __init_POST_KERNEL_start[];
+extern const union init_entry __init_APPLICATION_start[];
+extern const union init_entry __init_end[];
 
 enum init_level {
 	INIT_LEVEL_EARLY = 0,
@@ -133,7 +133,7 @@ enum init_level {
 };
 
 #ifdef CONFIG_SMP
-extern const struct init_entry __init_SMP_start[];
+extern const union init_entry __init_SMP_start[];
 #endif /* CONFIG_SMP */
 
 TYPE_SECTION_START_EXTERN(struct service, service);
@@ -359,7 +359,7 @@ static inline bool is_entry_about_service(const void *obj)
  */
 static void z_sys_init_run_level(enum init_level level)
 {
-	static const struct init_entry *levels[] = {
+	static const union init_entry *levels[] = {
 		__init_EARLY_start,
 		__init_PRE_KERNEL_1_start,
 		__init_PRE_KERNEL_2_start,
@@ -371,7 +371,7 @@ static void z_sys_init_run_level(enum init_level level)
 		/* End marker */
 		__init_end,
 	};
-	const struct init_entry *entry;
+	const union init_entry *entry;
 
 	for (entry = levels[level]; entry < levels[level+1]; entry++) {
 		int result = 0;

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -24,8 +24,8 @@ void __weak sys_trace_thread_priority_set_user(struct k_thread *thread, int prio
 void __weak sys_trace_isr_enter_user(void) {}
 void __weak sys_trace_isr_exit_user(void) {}
 void __weak sys_trace_idle_user(void) {}
-void __weak sys_trace_sys_init_enter_user(const struct init_entry *entry, int level) {}
-void __weak sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result) {}
+void __weak sys_trace_sys_init_enter_user(const union init_entry *entry, int level) {}
+void __weak sys_trace_sys_init_exit_user(const union init_entry *entry, int level, int result) {}
 void __weak sys_trace_gpio_pin_interrupt_configure_enter_user(const struct device *port,
 							      gpio_pin_t pin, gpio_flags_t flags) {}
 void __weak sys_trace_gpio_pin_interrupt_configure_exit_user(const struct device *port,
@@ -157,12 +157,12 @@ void sys_trace_idle_exit(void)
 	}
 }
 
-void sys_trace_sys_init_enter(const struct init_entry *entry, int level)
+void sys_trace_sys_init_enter(const union init_entry *entry, int level)
 {
 	sys_trace_sys_init_enter_user(entry, level);
 }
 
-void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result)
+void sys_trace_sys_init_exit(const union init_entry *entry, int level, int result)
 {
 	sys_trace_sys_init_exit_user(entry, level, result);
 }

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -29,8 +29,8 @@ void sys_trace_thread_pend_user(struct k_thread *thread);
 void sys_trace_isr_enter_user(void);
 void sys_trace_isr_exit_user(void);
 void sys_trace_idle_user(void);
-void sys_trace_sys_init_enter_user(const struct init_entry *entry, int level);
-void sys_trace_sys_init_exit_user(const struct init_entry *entry, int level, int result);
+void sys_trace_sys_init_enter_user(const union init_entry *entry, int level);
+void sys_trace_sys_init_exit_user(const union init_entry *entry, int level, int result);
 
 void sys_trace_thread_create(struct k_thread *thread);
 void sys_trace_thread_abort(struct k_thread *thread);
@@ -47,8 +47,8 @@ void sys_trace_isr_enter(void);
 void sys_trace_isr_exit(void);
 void sys_trace_idle(void);
 void sys_trace_idle_exit(void);
-void sys_trace_sys_init_enter(const struct init_entry *entry, int level);
-void sys_trace_sys_init_exit(const struct init_entry *entry, int level, int result);
+void sys_trace_sys_init_enter(const union init_entry *entry, int level);
+void sys_trace_sys_init_exit(const union init_entry *entry, int level, int result);
 
 struct gpio_callback;
 typedef uint8_t gpio_pin_t;


### PR DESCRIPTION
Some (broken) compilers fail to handle

```
struct x {
	union {
		type_a *a;
		type_b *b;
	};
};
```

correctly. Replace that with an equivalent but simpler

```
union x {
	type_a *a;
	type_b *b;
};
```

Sample build failure log: https://sof-ci.01.org/sofpr/PR10113/build13856/build/firmware_community/tgl.log