### PR TITLE
Bluetooth: Controller: Introduce prepare deferred feature

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -236,7 +236,8 @@ struct lll_prepare_param {
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 	int8_t  prio;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
-	uint8_t force;
+	uint8_t force:1;
+	uint8_t defer:1;
 	void *param;
 };
 

--- a/subsys/bluetooth/controller/ll_sw/lll_common.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_common.c
@@ -62,6 +62,8 @@ int lll_prepare(lll_is_abort_cb_t is_abort_cb, lll_abort_cb_t abort_cb,
 	prepare_param->prio = prio;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */
 
+	prepare_param->defer = 0U;
+
 	err = lll_prepare_resolve(is_abort_cb, abort_cb, prepare_cb, prepare_param, 0U, 0U);
 
 	return err;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -1318,7 +1318,9 @@ preempt_find_preemptor:
 		/* Returns -EBUSY when same curr and next state/role, do not
 		 * abort same curr and next event.
 		 */
-		if (err != -EBUSY) {
+		if (err == -EBUSY) {
+			ready->prepare_param.defer = 1U;
+		} else {
 			/* Let preemptor LLL know about the cancelled prepare */
 			ready->is_aborted = 1;
 			ready->abort_cb(&ready->prepare_param, ready->prepare_param.param);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -807,6 +807,8 @@ void lll_isr_early_abort(void *param)
 {
 	int err;
 
+	radio_status_reset();
+
 	radio_isr_set(isr_race, param);
 	if (!radio_is_idle()) {
 		radio_disable();

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -247,12 +247,21 @@ static int prepare_cb(struct lll_prepare_param *p)
 	overhead = lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle), ticks_at_event);
 	/* check if preempt to start has changed */
 	if (overhead) {
-		LL_ASSERT_OVERHEAD(overhead);
+		int err;
+
+		if (p->defer == 1U) {
+			/* We accept the overlap as previous event elected to continue */
+			err = 0;
+		} else {
+			LL_ASSERT_OVERHEAD(overhead);
+
+			err = -ECANCELED;
+		}
 
 		radio_isr_set(lll_isr_abort, lll);
 		radio_disable();
 
-		return -ECANCELED;
+		return err;
 	}
 #endif /* !CONFIG_BT_CTLR_XTAL_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -127,7 +127,7 @@ int lll_hfclock_on_wait(void)
 
 int lll_hfclock_off(void)
 {
-	if (hf_refcnt < 1) {
+	if (atomic_get(&hf_refcnt) < 1) {
 		return -EALREADY;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -165,15 +165,16 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 {
 	struct lll_conn *lll = curr;
 
-	/* Do not abort if near supervision timeout */
-	if (lll->forced) {
-		return 0;
-	}
+	if (next != curr) {
+		/* Do not be aborted by a different event if near supervision timeout */
+		if ((lll->forced == 1U) && (trx_cnt < 1U)) {
+			return 0;
+		}
 
-	/* Do not be aborted by same event if a single central trx has not been
-	 * exchanged.
-	 */
-	if ((next == curr) && (trx_cnt < 1U)) {
+	} else if (trx_cnt < 1U) {
+		/* Do not be aborted by same event if a single central's Rx has not completed.
+		 * Cases where single trx duration can be greater than connection interval.
+		 */
 		return -EBUSY;
 	}
 
@@ -187,15 +188,16 @@ int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 {
 	struct lll_conn *lll = curr;
 
-	/* Do not abort if near supervision timeout */
-	if (lll->forced) {
-		return 0;
-	}
+	if (next != curr) {
+		/* Do not be aborted by a different event if near supervision timeout */
+		if ((lll->forced == 1U) && (tx_cnt < 1U)) {
+			return 0;
+		}
 
-	/* Do not be aborted by same event if a single peripheral trx has not
-	 * been exchanged.
-	 */
-	if ((next == curr) && (tx_cnt < 1U)) {
+	} else if (tx_cnt < 1U) {
+		/* Do not be aborted by same event if a single peripheral's Tx has not completed.
+		 * Cases where single trx duration can be greater than connection interval.
+		 */
 		return -EBUSY;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -167,7 +167,7 @@ void lll_conn_prepare_reset(void)
  *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
  *        interface.
  */
-#define CENTRAL_TRX_BUSY_ITERATION_MAX 0
+#define CENTRAL_TRX_BUSY_ITERATION_MAX 1
 
 int lll_conn_central_is_abort_cb(void *next, void *curr,
 				 lll_prepare_cb_t *resume_cb)
@@ -199,7 +199,7 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
  *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
  *        interface.
  */
-#define PERIPHERAL_TRX_BUSY_ITERATION_MAX 0
+#define PERIPHERAL_TRX_BUSY_ITERATION_MAX 1
 
 int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 				    lll_prepare_cb_t *resume_cb)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -69,6 +69,7 @@ static uint8_t crc_valid;
 static uint8_t is_aborted;
 static uint16_t tx_cnt;
 static uint16_t trx_cnt;
+static uint8_t trx_busy_iteration;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 static uint8_t mic_state;
@@ -153,6 +154,7 @@ void lll_conn_prepare_reset(void)
 	crc_valid = 0U;
 	crc_expire = 0U;
 	is_aborted = 0U;
+	trx_busy_iteration = 0U;
 
 #if defined(CONFIG_BT_CTLR_LE_ENC)
 	mic_state = LLL_CONN_MIC_NONE;
@@ -160,6 +162,13 @@ void lll_conn_prepare_reset(void)
 }
 
 #if defined(CONFIG_BT_CENTRAL)
+/* Number of times central event being aborted by same event instance be skipped */
+/* FIXME: Increasing this causes event pipeline overflow assertion, add LLL implementation to
+ *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
+ *        interface.
+ */
+#define CENTRAL_TRX_BUSY_ITERATION_MAX 0
+
 int lll_conn_central_is_abort_cb(void *next, void *curr,
 				 lll_prepare_cb_t *resume_cb)
 {
@@ -171,7 +180,9 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 			return 0;
 		}
 
-	} else if (trx_cnt < 1U) {
+	} else if ((trx_cnt < 1U) && (trx_busy_iteration < CENTRAL_TRX_BUSY_ITERATION_MAX)) {
+		trx_busy_iteration++;
+
 		/* Do not be aborted by same event if a single central's Rx has not completed.
 		 * Cases where single trx duration can be greater than connection interval.
 		 */
@@ -183,6 +194,13 @@ int lll_conn_central_is_abort_cb(void *next, void *curr,
 #endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_PERIPHERAL)
+/* Number of times peripheral event being aborted by same event instance be skipped */
+/* FIXME: Increasing this causes event pipeline overflow assertion, add LLL implementation to
+ *        gracefully abort the deferred next event when -EBUSY is returned in this is_abort_cb
+ *        interface.
+ */
+#define PERIPHERAL_TRX_BUSY_ITERATION_MAX 0
+
 int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 				    lll_prepare_cb_t *resume_cb)
 {
@@ -194,7 +212,9 @@ int lll_conn_peripheral_is_abort_cb(void *next, void *curr,
 			return 0;
 		}
 
-	} else if (tx_cnt < 1U) {
+	} else if ((tx_cnt < 1U) && (trx_busy_iteration < PERIPHERAL_TRX_BUSY_ITERATION_MAX)) {
+		trx_busy_iteration++;
+
 		/* Do not be aborted by same event if a single peripheral's Tx has not completed.
 		 * Cases where single trx duration can be greater than connection interval.
 		 */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -339,12 +339,21 @@ static int prepare_cb(struct lll_prepare_param *p)
 	overhead = lll_preempt_calc(ull, (TICKER_ID_CONN_BASE + lll->handle), ticks_at_event);
 	/* check if preempt to start has changed */
 	if (overhead) {
-		LL_ASSERT_OVERHEAD(overhead);
+		int err;
+
+		if (p->defer == 1U) {
+			/* We accept the overlap as previous event elected to continue */
+			err = 0;
+		} else {
+			LL_ASSERT_OVERHEAD(overhead);
+
+			err = -ECANCELED;
+		}
 
 		radio_isr_set(lll_isr_abort, lll);
 		radio_disable();
 
-		return -ECANCELED;
+		return err;
 	}
 #endif /* CONFIG_BT_CTLR_XTAL_ADVANCED */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2177,6 +2177,11 @@ void ull_conn_resume_rx_data(struct ll_conn *conn)
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+uint16_t ull_conn_event_counter_at_prepare(const struct ll_conn *conn)
+{
+	return conn->lll.event_counter + conn->lll.latency_prepare + conn->llcp.prep.lazy;
+}
+
 uint16_t ull_conn_event_counter(struct ll_conn *conn)
 {
 	struct lll_conn *lll;
@@ -2204,6 +2209,7 @@ uint16_t ull_conn_event_counter(struct ll_conn *conn)
 
 	return event_counter;
 }
+
 static void ull_conn_update_ticker(struct ll_conn *conn,
 				   uint32_t ticks_win_offset,
 				   uint32_t ticks_slot_overhead,
@@ -2281,7 +2287,7 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 	lll = &conn->lll;
 
 	/* Calculate current event counter */
-	event_counter = ull_conn_event_counter(conn);
+	event_counter = ull_conn_event_counter_at_prepare(conn);
 
 	instant_latency = (event_counter - instant) & 0xFFFF;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -84,6 +84,7 @@ static inline void cpr_active_reset(void)
 void ull_conn_past_sender_offset_request(struct ll_conn *conn);
 #endif /* CONFIG_BT_CTLR_SYNC_TRANSFER_SENDER */
 
+uint16_t ull_conn_event_counter_at_prepare(const struct ll_conn *conn);
 uint16_t ull_conn_event_counter(struct ll_conn *conn);
 
 void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc,

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -118,7 +118,8 @@ static void lp_chmu_send_channel_map_update_ind(struct ll_conn *conn, struct pro
 	} else {
 		llcp_rr_set_incompat(conn, INCOMPAT_RESOLVABLE);
 
-		ctx->data.chmu.instant = ull_conn_event_counter(conn) + CHMU_INSTANT_DELTA;
+		ctx->data.chmu.instant = ull_conn_event_counter(conn) + conn->lll.latency +
+					 CHMU_INSTANT_DELTA;
 
 		lp_chmu_tx(conn, ctx);
 
@@ -142,7 +143,7 @@ static void lp_chmu_st_wait_tx_chan_map_ind(struct ll_conn *conn, struct proc_ct
 static void lp_chmu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	uint16_t event_counter = ull_conn_event_counter(conn);
+	uint16_t event_counter = ull_conn_event_counter_at_prepare(conn);
 
 	if (is_instant_reached_or_passed(ctx->data.chmu.instant, event_counter)) {
 		llcp_rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
@@ -257,7 +258,7 @@ static void rp_chmu_st_wait_rx_channel_map_update_ind(struct ll_conn *conn, stru
 static void rp_chmu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				  void *param)
 {
-	uint16_t event_counter = ull_conn_event_counter(conn);
+	uint16_t event_counter = ull_conn_event_counter_at_prepare(conn);
 
 	if (((event_counter - ctx->data.chmu.instant) & 0xFFFF) <= 0x7FFF) {
 		rp_chmu_complete(conn, ctx, evt, param);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -637,7 +637,7 @@ static void lp_cu_st_wait_rx_conn_update_ind(struct ll_conn *conn, struct proc_c
 static void lp_cu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				void *param)
 {
-	uint16_t event_counter = ull_conn_event_counter(conn);
+	uint16_t event_counter = ull_conn_event_counter_at_prepare(conn);
 
 	if (is_instant_reached_or_passed(ctx->data.cu.instant, event_counter)) {
 		bool notify;
@@ -1222,7 +1222,7 @@ static void rp_cu_st_wait_tx_conn_update_ind(struct ll_conn *conn, struct proc_c
 static void rp_cu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				void *param)
 {
-	uint16_t event_counter = ull_conn_event_counter(conn);
+	uint16_t event_counter = ull_conn_event_counter_at_prepare(conn);
 
 	if (is_instant_reached_or_passed(ctx->data.cu.instant, event_counter)) {
 		bool notify;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -770,7 +770,9 @@ static void lp_pu_st_wait_rx_phy_update_ind(struct ll_conn *conn, struct proc_ct
 static void lp_pu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				void *param)
 {
-	if (is_instant_reached_or_passed(ctx->data.pu.instant, ull_conn_event_counter(conn))) {
+	uint16_t event_counter = ull_conn_event_counter_at_prepare(conn);
+
+	if (is_instant_reached_or_passed(ctx->data.pu.instant, event_counter)) {
 		const uint8_t phy_changed = pu_apply_phy_update(conn, ctx);
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 		if (phy_changed) {
@@ -1191,7 +1193,9 @@ static void rp_pu_st_wait_rx_phy_update_ind(struct ll_conn *conn, struct proc_ct
 static void rp_pu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt,
 				void *param)
 {
-	if (is_instant_reached_or_passed(ctx->data.pu.instant, ull_conn_event_counter(conn))) {
+	uint16_t event_counter = ull_conn_event_counter_at_prepare(conn);
+
+	if (is_instant_reached_or_passed(ctx->data.pu.instant, event_counter)) {
 		ctx->data.pu.error = BT_HCI_ERR_SUCCESS;
 		const uint8_t phy_changed = pu_apply_phy_update(conn, ctx);
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -1380,6 +1380,7 @@ void ticker_worker(void *param)
 			 * ticker_job_reschedule_in_window when completed.
 			 */
 			ticker->lazy_current++;
+			ticker->force = 0U;
 
 			if ((ticker->must_expire == 0U) ||
 			    (ticker->lazy_periodic >= ticker->lazy_current) ||


### PR DESCRIPTION
Introduce prepare being deferred due to previous events
desire to continue. In such case the deferred prepare param
will have the defer flag set.

Testing:
```
# Build and flash uart_hci onto nRF52840-DK
west build -p auto -d build_uart_hci/ --board nrf52840dk/nrf52840 samples/bluetooth/hci_uart
west flash -d build_uart_hci

# Build device firmware A
west build -p auto -d build_A --board nrf54l15dk/nrf54l15/cpuapp samples/subsys/mgmt/mcumgr/smp_svr/ -DCONFIG_DEBUG=y -DCONFIG_MCUMGR_TRANSPORT_BT_PERM_RW=y -DCONFIG_BT_DEVICE_NAME=\"firmwareA\" -DEXTRA_CONF_FILE="overlay-bt.conf" --sysbuild
# Build and flash device firmware B onto nRF54l15-DK
west build -p auto -d build_B --board nrf54l15dk/nrf54l15/cpuapp samples/subsys/mgmt/mcumgr/smp_svr/ -DCONFIG_DEBUG=y -DCONFIG_MCUMGR_TRANSPORT_BT_PERM_RW=y -DCONFIG_BT_DEVICE_NAME=\"firmwareB\" -DEXTRA_CONF_FILE="overlay-bt.conf" --sysbuild
west flash -d build_B

# Attach HCI
sudo btattach -S 1000000 -B /dev/ttyACM1 &
# Start FOTA to firmware A
sudo mcumgr --conntype ble --hci 1 --timeout 60 --connstring peer_name="firmwareA" image upload build_A/smp_svr/zephyr/zephyr.signed.bin
# Start FOTA to firmware B
sudo mcumgr --conntype ble --hci 1 --timeout 60 --connstring peer_name="firmwareB" image upload build_B/smp_svr/zephyr/zephyr.signed.bin

```

Script used for long duration testing:
```
#! /bin/sh

cnt=1
while [ $cnt -le 1000 ]
do
	echo "Count $cnt"
	/home/jack/go/bin/mcumgr --conntype ble --hci 1 --timeout 60 --connstring peer_name="firmwareB" image upload build_A/smp_svr/zephyr/zephyr.signed.bin
	((cnt++))
done
```