### PR TITLE
dts: add riscv wch ch32v307 boards

### DIFF
--- a/dts/riscv/wch/ch32v307/ch32v307.dtsi
+++ b/dts/riscv/wch/ch32v307/ch32v307.dtsi
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2025 Thomas Boje
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+#include <mem.h>
+#include <wch/qingke-v4f.dtsi>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/ch32v20x_30x-clocks.h>
+
+/ {
+	clocks {
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v00x-hse-clock";
+			clock-frequency = <DT_FREQ_M(32)>;
+			status = "disabled";
+		};
+
+		clk_hsi: clk-hsi {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v00x-hsi-clock";
+			clock-frequency = <DT_FREQ_M(8)>;
+			status = "disabled";
+		};
+
+		clk_lsi: clk-lsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_K(32)>;
+			status = "disabled";
+		};
+
+		pll: pll {
+			#clock-cells = <0>;
+			compatible = "wch,ch32v20x_30x-pll-clock";
+			mul = <18>;
+			status = "disabled";
+		};
+	};
+
+	soc {
+		sram0: memory@20000000 {
+			compatible = "mmio-sram";
+			reg = <0x20000000 DT_SIZE_K(32)>;
+		};
+
+		flash: flash-controller@40022000 {
+			compatible = "wch,ch32v20x_30x-flash-controller";
+			reg = <0x40022000 0x400>;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				reg = <0x08000000 DT_SIZE_K(480)>;
+			};
+		};
+
+		pwr: pwr@40007000 {
+			compatible = "wch,pwr";
+			reg = <0x40007000 16>;
+		};
+
+		exti: interrupt-controller@40010400 {
+			compatible = "wch,exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			reg = <0x40010400 16>;
+			interrupt-parent = <&pfic>;
+			num-lines = <16>;
+			line-ranges = <0 1>, <1 1>, <2 1>, <3 1>, <4 1>,
+					<5 5>, <10 6>;
+			interrupts = <22 23 24 25 26 39 56>;
+			interrupt-names = "line0",  "line1", "line2", "line3",
+					"line4", "line5-9", "line10-15";
+			status = "disabled";
+		};
+
+		pinctrl: pin-controller@40010000 {
+			compatible = "wch,20x_30x-afio";
+			reg = <0x40010000 16>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_AFIO>;
+
+			gpioa: gpio@40010800 {
+				compatible = "wch,gpio";
+				reg = <0x40010800 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPA>;
+			};
+
+			gpiob: gpio@40010C00 {
+				compatible = "wch,gpio";
+				reg = <0x40010C00 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPB>;
+			};
+
+			gpioc: gpio@40011000 {
+				compatible = "wch,gpio";
+				reg = <0x40011000 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPC>;
+			};
+
+			gpiod: gpio@40011400 {
+				compatible = "wch,gpio";
+				reg = <0x40011400 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPD>;
+			};
+
+			gpioe: gpio@40011800 {
+				compatible = "wch,gpio";
+				reg = <0x40011800 0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				ngpios = <8>;
+				clocks = <&rcc CH32V20X_V30X_CLOCK_IOPE>;
+			};
+		};
+
+		usart1: uart@40013800 {
+			compatible = "wch,usart";
+			reg = <0x40013800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <53>;
+			status = "disabled";
+		};
+
+		usart2: uart@40004400 {
+			compatible = "wch,usart";
+			reg = <0x40004400 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART2>;
+			interrupt-parent = <&pfic>;
+			interrupts = <54>;
+			status = "disabled";
+		};
+
+		usart3: uart@40004800 {
+			compatible = "wch,usart";
+			reg = <0x40004800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART3>;
+			interrupt-parent = <&pfic>;
+			interrupts = <55>;
+			status = "disabled";
+		};
+
+		usart4: uart@40004c00 {
+			compatible = "wch,usart";
+			reg = <0x40004C00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART4>;
+			interrupt-parent = <&pfic>;
+			interrupts = <68>;
+			status = "disabled";
+		};
+
+		usart5: uart@40005000 {
+			compatible = "wch,usart";
+			reg = <0x40005000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART5>;
+			interrupt-parent = <&pfic>;
+			interrupts = <69>;
+			status = "disabled";
+		};
+
+		usart6: uart@40001800 {
+			compatible = "wch,usart";
+			reg = <0x40001800 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART6>;
+			interrupt-parent = <&pfic>;
+			interrupts = <87>;
+			status = "disabled";
+		};
+
+		usart7: uart@40001c00 {
+			compatible = "wch,usart";
+			reg = <0x40001c00 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART7>;
+			interrupt-parent = <&pfic>;
+			interrupts = <88>;
+			status = "disabled";
+		};
+
+		usart8: uart@40002000 {
+			compatible = "wch,usart";
+			reg = <0x40002000 0x20>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_USART8>;
+			interrupt-parent = <&pfic>;
+			interrupts = <89>;
+			status = "disabled";
+		};
+
+		rcc: rcc@40021000 {
+			compatible = "wch,rcc";
+			reg = <0x40021000 16>;
+			#clock-cells = <1>;
+			status = "okay";
+		};
+
+		dma1: dma@40020000 {
+			compatible = "wch,wch-dma";
+			reg = <0x40020000 0x90>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA1>;
+			#dma-cells = <1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <27>, <28>, <29>, <30>, <31>, <32>, <33>;
+			dma-channels = <7>;
+		};
+
+		dma2: dma@40020400 {
+			compatible = "wch,wch-dma";
+			reg = <0x40020400 0x90>;
+			clocks = <&rcc CH32V20X_V30X_CLOCK_DMA2>;
+			#dma-cells = <1>;
+			interrupt-parent = <&pfic>;
+			interrupts = <72>, <73>, <74>, <75>, <76>, <98>, <99>, <100>,
+						 <101>, <102>, <103>;
+			dma-channels = <11>;
+		};
+	};
+};
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(127)>;
+};


### PR DESCRIPTION
Adding the devicetree including EXTI to the wch ch32v307 series
tested on wch ch32v307v-r2 with samples/basic/button
changes based on PR #89139