### PR TITLE
twister: harness: power: fix amp to milliamp conversion

### DIFF
--- a/scripts/pylib/power-twister-harness/test_power.py
+++ b/scripts/pylib/power-twister-harness/test_power.py
@@ -46,7 +46,7 @@ def test_power_harness(probe_class: PowerMonitor, test_data, request, dut: Devic
     )
 
     # # Convert measured values from amps to milliamps for comparison
-    rms_values_in_milliamps = [value * 1e4 for value in rms_values_measured]
+    rms_values_in_milliamps = [value * 1e3 for value in rms_values_measured]
 
     # # Log the calculated values in milliamps for debugging purposes
     logger.debug(f"Measured RMS values in mA: {rms_values_in_milliamps}")

--- a/tests/subsys/pm/power_residency_time/testcase.yaml
+++ b/tests/subsys/pm/power_residency_time/testcase.yaml
@@ -13,7 +13,7 @@ common:
       peak_padding: 40
       measurement_duration: 8
       num_of_transitions: 6
-      expected_rms_values: [56.0, 4.0, 4.0, 1.2, 1.2, 0.26, 91]
+      expected_rms_values: [5.6, 0.4, 0.4, 0.12, 0.12, 0.026, 9.1]
       tolerance_percentage: 20
     record:
       regex:

--- a/tests/subsys/pm/power_states/testcase.yaml
+++ b/tests/subsys/pm/power_states/testcase.yaml
@@ -13,7 +13,7 @@ common:
       peak_padding: 40
       measurement_duration: 6
       num_of_transitions: 4
-      expected_rms_values: [56.0, 4.0, 1.2, 0.26, 140]
+      expected_rms_values: [5.6, 0.4, 0.14, 0.026, 14]
       tolerance_percentage: 20
     record:
       regex:

--- a/tests/subsys/pm/power_wakeup_timer/testcase.yaml
+++ b/tests/subsys/pm/power_wakeup_timer/testcase.yaml
@@ -13,7 +13,7 @@ common:
       peak_padding: 40
       measurement_duration: 2
       num_of_transitions: 1
-      expected_rms_values: [0.26, 140]
+      expected_rms_values: [0.026, 14]
       tolerance_percentage: 20
     record:
       regex:


### PR DESCRIPTION
Fix amp to milliamp conversion where a 10^4 factor was applied instead of 10^3.
Adjust existing test cases accordingly (including a small change to one of the expected RMS values in pm.power_states that either changed since the test was introduced or was set too aggressively back then).