### PR TITLE
STM32 OSPI NOR: run application from external flash memory

### DIFF
--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -176,6 +176,8 @@ stm32_lp_tick_source: &lptim1 {
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
+
+		/* The partition of the external NOR is defined in each board variant. */
 	};
 };
 

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ext_flash_app.dts
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ext_flash_app.dts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include "b_u585i_iot02a-common.dtsi"
+#include <zephyr/dt-bindings/memory-attr/memory-attr.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+
+/ {
+	model = "STMicroelectronics B-U585I-IOT02A discovery kit";
+	compatible = "st,b-u585i-iot02a";
+
+	chosen {
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,bt-hci = &bt_hci_uart;
+	};
+
+	aliases {
+		led0 = &green_led_1;
+		led1 = &red_led_1;
+		sw0 = &user_button;
+		die-temp0 = &die_temp;
+	};
+
+	octo_nor: memory@70000000 {
+		compatible = "zephyr,memory-region";
+		reg = <0x70000000 DT_SIZE_M(64)>;
+		zephyr,memory-region = "EXTMEM";
+		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
+		zephyr,memory-attr = <DT_MEM_ARM(ATTR_MPU_IO)>;
+	};
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/*
+		 * Following flash partition is dedicated to the use of b_u585i_iot02a
+		 * with TZEN=0 (so w/o TFM).
+		 * Set the partitions with first MB to make use of the whole Bank1
+		 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		storage_partition: partition@f0000 {
+			label = "storage";
+			reg = <0x000f0000 DT_SIZE_K(64)>;
+		};
+	};
+};
+
+&gpdma1 {
+	status = "okay";
+};
+
+&uart4 {
+	pinctrl-0 = <&uart4_tx_pc10 &uart4_rx_pc11>;
+	pinctrl-names = "default";
+	current-speed = <100000>;
+	status = "okay";
+
+	bt_hci_uart: bt_hci_uart {
+		compatible = "zephyr,bt-hci-uart";
+		status = "okay";
+	};
+};
+
+&die_temp {
+	status = "okay";
+};
+
+&adc1 {
+	st,adc-prescaler = <4>;
+	status = "okay";
+};
+
+&mx25lm51245 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		slot0_partition: partition@0 {
+			label = "image-0";
+			reg = <0x00000000 DT_SIZE_K(416)>;
+		};
+
+		slot1_partition: partition@68000 {
+			label = "image-1";
+			reg = <0x00068000 DT_SIZE_K(416)>;
+		};
+
+		scratch_partition: partition@d0000 {
+			label = "image-scratch";
+			reg = <0x000d0000 DT_SIZE_K(192)>;
+		};
+	};
+};

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ext_flash_app.yaml
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ext_flash_app.yaml
@@ -1,0 +1,10 @@
+identifier: b_u585i_iot02a/stm32u585xx/ext_flash_app
+name: ST B_U585I_IOT02A Discovery kit ext_flash_app target
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+ram: 786
+flash: 416
+vendor: st

--- a/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ext_flash_app_defconfig
+++ b/boards/st/b_u585i_iot02a/b_u585i_iot02a_stm32u585xx_ext_flash_app_defconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# enable uart driver
+CONFIG_SERIAL=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y

--- a/boards/st/b_u585i_iot02a/board.cmake
+++ b/boards/st/b_u585i_iot02a/board.cmake
@@ -5,7 +5,7 @@ if(CONFIG_BUILD_WITH_TFM)
   # Flash merged TF-M + Zephyr binary
   set_property(TARGET runners_yaml_props_target PROPERTY hex_file tfm_merged.hex)
 
-  if (CONFIG_HAS_FLASH_LOAD_OFFSET)
+  if(CONFIG_HAS_FLASH_LOAD_OFFSET)
     MATH(EXPR TFM_HEX_BASE_ADDRESS_NS "${TFM_FLASH_BASE_ADDRESS}+${CONFIG_FLASH_LOAD_OFFSET}")
   else()
     set(TFM_HEX_BASE_ADDRESS_NS ${TFM_TFM_FLASH_BASE_ADDRESS})
@@ -13,11 +13,9 @@ if(CONFIG_BUILD_WITH_TFM)
 endif()
 
 # keep first
-if(CONFIG_STM32_MEMMAP)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
-board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32U585I-IOT02A.stldr")
-else()
-board_runner_args(stm32cubeprogrammer "--erase" "--port=swd" "--reset-mode=hw")
+if(CONFIG_STM32_MEMMAP OR (CONFIG_XIP AND CONFIG_BOOTLOADER_MCUBOOT))
+  board_runner_args(stm32cubeprogrammer "--extload=MX25LM51245G_STM32U585I-IOT02A.stldr")
 endif()
 
 board_runner_args(openocd "--tcl-port=6666")

--- a/boards/st/b_u585i_iot02a/board.yml
+++ b/boards/st/b_u585i_iot02a/board.yml
@@ -6,3 +6,4 @@ board:
     - name: stm32u585xx
       variants:
         - name: ns
+        - name: ext_flash_app

--- a/samples/sysbuild/with_mcuboot/boards/b_u585i_iot02a_stm32u585xx_ext_flash_app.conf
+++ b/samples/sysbuild/with_mcuboot/boards/b_u585i_iot02a_stm32u585xx_ext_flash_app.conf
@@ -1,0 +1,1 @@
+CONFIG_FLASH=y

--- a/samples/sysbuild/with_mcuboot/boards/b_u585i_iot02a_stm32u585xx_ext_flash_app.overlay
+++ b/samples/sysbuild/with_mcuboot/boards/b_u585i_iot02a_stm32u585xx_ext_flash_app.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Define the device, controller and partition to be the external memory
+ * for running the application in external NOR from MCUboot
+ */
+
+/ {
+	chosen {
+		zephyr,flash = &mx25lm51245;
+		zephyr,flash-controller = &mx25lm51245;
+	};
+};

--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -16,6 +16,7 @@ tests:
       - esp32c6_devkitc/esp32c6/hpcore
       - nucleo_h7s3l8
       - nucleo_u385rg_q
+      - b_u585i_iot02a/stm32u585xx/ext_flash_app
       - stm32h7s78_dk
       - stm32h573i_dk
     integration_platforms:


### PR DESCRIPTION
Following the [ stm32h5 run application in external flash memory XIP](https://github.com/zephyrproject-rtos/zephyr/pull/88579)

This PR makes the **samples/sysbuild/with_mcuboot --sysbuild**  running on a variant of the  stm32u585 disco kit.

Requires the ./bootloader/mcuboot/bootzephyr/boards/b_u585i_iot02a_stm32u585xx_ext_flash_app.conf : 
```
CONFIG_BOOT_DIRECT_XIP=y
CONFIG_STM32_MEMMAP=y
```


run the `west build -p -b b_u585i_iot02a/stm32u585xx/ext_flash_app samples/sysbuild/with_mcuboot --sysbuild`

```
*** Booting MCUboot v2.1.0-rc1-390-gfbc9aff5acc1 ***
*** Using Zephyr OS build v4.2.0-rc2-72-g8c58be376223 ***
*** Booting Zephyr OS build v4.2.0-rc2-72-g8c58be376223 ***
Address of sample 0x70000000
Hello sysbuild with mcuboot! b_u585i_iot02a
```


Requires boot/zephyr/boards/b_u585i_iot02a.conf
```
CONFIG_BOOT_DIRECT_XIP=y
CONFIG_STM32_MEMMAP=y
```