### PR TITLE
Drivers: max17055: retrieve the current value

### DIFF
--- a/drivers/sensor/maxim/max17055/max17055.c
+++ b/drivers/sensor/maxim/max17055/max17055.c
@@ -166,6 +166,13 @@ static int max17055_channel_get(const struct device *dev,
 		valp->val1 = tmp / 1000000;
 		valp->val2 = tmp % 1000000;
 		break;
+	case SENSOR_CHAN_CURRENT: {
+		int current_ma;
+
+		current_ma = current_to_ma(config->rsense_mohms, priv->current);
+		set_millis(valp, current_ma);
+		break;
+	}
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT: {
 		int current_ma;
 
@@ -250,6 +257,13 @@ static int max17055_sample_fetch(const struct device *dev,
 	if (chan == SENSOR_CHAN_ALL ||
 	    (enum sensor_channel_max17055)chan == SENSOR_CHAN_MAX17055_VFOCV) {
 		ret = max17055_reg_read(dev, VFOCV, &priv->ocv);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_CURRENT) {
+		ret = max17055_reg_read(dev, CURRENT, &priv->current);
 		if (ret < 0) {
 			return ret;
 		}

--- a/drivers/sensor/maxim/max17055/max17055.h
+++ b/drivers/sensor/maxim/max17055/max17055.h
@@ -16,6 +16,7 @@ enum {
 	REP_SOC         = 0x6,
 	INT_TEMP        = 0x8,
 	VCELL           = 0x9,
+	CURRENT         = 0xa,
 	AVG_CURRENT     = 0xb,
 	FULL_CAP_REP    = 0x10,
 	TTE             = 0x11,
@@ -49,6 +50,8 @@ struct max17055_data {
 	uint16_t voltage;
 	/* Current cell open circuit voltage in units of 1.25/16mV */
 	uint16_t ocv;
+	/* Current in units of 1.5625uV / Rsense */
+	int16_t current;
 	/* Average current in units of 1.5625uV / Rsense */
 	int16_t avg_current;
 	/* Remaining capacity as a %age */


### PR DESCRIPTION
The MAX17055 peripheral allows measuring the current value (which corresponds to the instantaneous value). Respond to the `SENSOR_CHAN_CURRENT` command, and retrieve the data from the `0x0a` device register.