### PR TITLE
k_heap_aligned_alloc: validate the alignment argument

### DIFF
--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -133,6 +133,10 @@ void *k_heap_aligned_alloc(struct k_heap *heap, size_t align, size_t bytes,
 {
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap, aligned_alloc, heap, timeout);
 
+	/* A power of 2 as well as 0 is OK */
+	__ASSERT((align & (align - 1)) == 0,
+		 "align must be a power of 2");
+
 	void *ret = z_heap_alloc_helper(heap, align, bytes, timeout,
 					sys_heap_aligned_alloc);
 


### PR DESCRIPTION
There is a special internal understanding between `z_alloc_helper()`
and `sys_heap_aligned_alloc()` for the meaning of non-power-of-two
alignment values. There was a time when `z_alloc_helper()` was expressed
in terms of `k_heap_aligned_alloc()` so the later had to accept special
alignment values from the former. This is no longer the case and
`k_heap_aligned_alloc()` should enforce proper alignment values now.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
