### PR TITLE
twister: make no-detailed-test-id default

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -109,7 +109,7 @@ jobs:
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=llvm
 
-          ./scripts/twister -p native_sim --no-detailed-test-id --force-color --inline-logs -M -N -v --retry-failed 2 \
+          ./scripts/twister -p native_sim --force-color --inline-logs -M -N -v --retry-failed 2 \
             -T tests --subset ${{matrix.subset}}/2 -j 16
 
       - name: Print ccache stats

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --no-detailed-test-id --pull-request -t $TESTS_PER_BUILDER
+          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request -t $TESTS_PER_BUILDER
           if [ -s .testplan ]; then
             cat .testplan >> $GITHUB_ENV
           else
@@ -142,7 +142,7 @@ jobs:
       CCACHE_IGNOREOPTIONS: '-specs=* --specs=*'
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components
-      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --no-detailed-test-id --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
+      TWISTER_COMMON: ' --test-config tests/test_config_ci.yaml --force-color --inline-logs -v -N -M --retry-failed 3 --timeout-multiplier 2 '
       WEEKLY_OPTIONS: ' -M --build-only --all --show-footprint --report-filtered -j 32'
       PR_OPTIONS: ' --clobber-output --integration -j 16'
       PUSH_OPTIONS: ' --clobber-output -M --show-footprint --report-filtered -j 16'
@@ -252,7 +252,7 @@ jobs:
           rm -f testplan.json
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request --no-detailed-test-id
+          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request
           ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} --load-tests testplan.json ${TWISTER_COMMON} ${PR_OPTIONS}
           if [ "${{matrix.subset}}" = "1" -a ${{needs.twister-build-prep.outputs.fullrun}} = 'True' ]; then
             ./scripts/zephyr_module.py --twister-out module_tests.args

--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -134,7 +134,7 @@ jobs:
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
         BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
-        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --create-rom-ram-report --footprint-report ROM --enable-size-report --footprint-from-buildlog $BASIC_FLAGS
+        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --create-rom-ram-report --footprint-report ROM --enable-size-report --footprint-from-buildlog $BASIC_FLAGS --detailed-test-id
 
     - name: Build firmware No. 7 - list tags
       working-directory: zephyr
@@ -146,7 +146,7 @@ jobs:
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
         BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
-        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --list-tags $BASIC_FLAGS
+        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --list-tags $BASIC_FLAGS --detailed-test-id
 
     - name: Build firmware No. 8 - list tests
       working-directory: zephyr
@@ -170,7 +170,7 @@ jobs:
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
         BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
-        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --report-dir . --report-name test_name --report-suffix suffix --report-summary 0 --report-all-options --report-filtered $BASIC_FLAGS
+        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --platform qemu_x86 --report-dir . --report-name test_name --report-suffix suffix --report-summary 0 --report-all-options --report-filtered $BASIC_FLAGS --detailed-test-id
 
     - name: Build firmware No. 10 - force platform and toolchain, log level, timestamps, logfile
       working-directory: zephyr
@@ -182,5 +182,5 @@ jobs:
           EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O /tmp/twister-out"
         fi
         BASIC_FLAGS="--runtime-artifact-cleanup --force-color --inline-logs -v $EXTRA_TWISTER_FLAGS"
-        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --force-platform --platform qemu_x86 --force-toolchain --log-level WARNING --log-file log.file $BASIC_FLAGS
+        ./scripts/twister --sub-test kernel.multiprocessing.spinlock.minimallibc.spinlock.spinlock_basic --force-platform --platform qemu_x86 --force-toolchain --log-level WARNING --log-file log.file $BASIC_FLAGS --detailed-test-id
         rm log.file

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -444,8 +444,8 @@ def parse_args():
                 "corresponding tests .yaml files. These scenarios "
                 "will be skipped with quarantine as the reason.")
 
-    # Include paths in names by default.
-    parser.set_defaults(detailed_test_id=True)
+    # Do not include paths in names by default.
+    parser.set_defaults(detailed_test_id=False)
 
     return parser.parse_args()
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -618,8 +618,8 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
              "and 'sleep.usleep' test Case (where 'sleep' is its Ztest suite name "
              "and 'usleep' is Ztest test name.")
 
-    # Include paths in names by default.
-    parser.set_defaults(detailed_test_id=True)
+    # Do not include paths in names by default.
+    parser.set_defaults(detailed_test_id=False)
 
     parser.add_argument(
         "--detailed-skipped-report", action="store_true",

--- a/scripts/tests/twister/conftest.py
+++ b/scripts/tests/twister/conftest.py
@@ -44,6 +44,7 @@ def tesenv_obj(test_data, testsuites_dir, tmpdir_factory):
     """ Pytest fixture to initialize and return the class TestPlan object"""
     parser = add_parse_arguments()
     options = parse_arguments(parser, [])
+    options.detailed_test_id = True
     env = TwisterEnv(options)
     env.board_roots = [os.path.join(test_data, "board_config", "1_level", "2_level")]
     env.test_roots = [os.path.join(testsuites_dir, 'tests', testsuites_dir, 'samples')]


### PR DESCRIPTION
Make this option default and reduce amount of details displayed by
twister.
This options has been enabled in CI for a while now with the intention
of making it default.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
