### PR TITLE
include: zephyr: bluetooth: uuid: fix typo in characteristic doxygen

### DIFF
--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -4221,7 +4221,7 @@ struct bt_uuid_128 {
  */
 #define BT_UUID_GATT_DEVT_VAL 0x2b90
 /**
- *  @brief GATT Characteristic String
+ *  @brief GATT Characteristic Device Time
  */
 #define BT_UUID_GATT_DEVT \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_DEVT_VAL)


### PR DESCRIPTION
Fixes correct GATT characteristic description for [Device Time](https://www.bluetooth.com/specifications/specs/html/?src=DTS_v1.0/out/en/index-en.html#UUID-644c288e-7a34-7dc8-2d6a-09be3bf2296b).