### PR TITLE
docs: device: remove action for device pm

### DIFF
--- a/doc/services/pm/device.rst
+++ b/doc/services/pm/device.rst
@@ -183,7 +183,6 @@ a :c:enum:`pm_device_state`.
 
             OFF -> SUSPENDED ["label"="PM_DEVICE_ACTION_TURN_ON"];
             SUSPENDED -> OFF ["label"="PM_DEVICE_ACTION_TURN_OFF"];
-            ACTIVE -> OFF ["label"="PM_DEVICE_ACTION_TURN_OFF"];
         }
     }
 


### PR DESCRIPTION
It is not possible to go from ACTIVE to OFF with device pm actions. Fix the state machine diagram to reflect that.