### PR TITLE
twister: match platform regex pattern

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -672,6 +672,14 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
              "specified. If this option is not used, then platforms marked "
              "as default in the platform metadata file will be chosen "
              "to build and test. ")
+    parser.add_argument(
+        "--platform-pattern", action="append", default=[],
+        help="""Platform regular expression filter for testing. This option may be used multiple
+        times. Test suites will only be built/run on the platforms
+        matching the specified patterns. If this option is not used, then platforms marked
+        as default in the platform metadata file will be chosen
+        to build and test.
+        """)
 
     parser.add_argument(
         "--platform-reports", action="store_true",


### PR DESCRIPTION
Use --platform-pattern <regex> to match platforms, something like

`twister -T samples/hello_world/ --platform-pattern ".*/stm32f4.*"`

will build/run all those platform targets with stm32f4 in them.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
