### PR TITLE
arch: arm: cortex_m: Update APIs to save and restore FPU context

### DIFF
--- a/arch/arm/core/cortex_m/fpu.c
+++ b/arch/arm/core/cortex_m/fpu.c
@@ -16,7 +16,7 @@
 
 void z_arm_save_fp_context(struct fpu_ctx_full *buffer)
 {
-#if defined(CONFIG_FPU_SHARING)
+#if defined(CONFIG_FPU)
 	__ASSERT_NO_MSG(buffer != NULL);
 
 	uint32_t CONTROL = __get_CONTROL();
@@ -44,7 +44,7 @@ void z_arm_save_fp_context(struct fpu_ctx_full *buffer)
 
 void z_arm_restore_fp_context(const struct fpu_ctx_full *buffer)
 {
-#if defined(CONFIG_FPU_SHARING)
+#if defined(CONFIG_FPU)
 	if (buffer->ctx_saved) {
 		/* Set FPCA first so it is set even if an interrupt happens
 		 * during restoration.

--- a/include/zephyr/arch/arm/cortex_m/fpu.h
+++ b/include/zephyr/arch/arm/cortex_m/fpu.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_FPU_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_CORTEX_M_FPU_H_
 
+#include <stdint.h>
+#include <stdbool.h>
+
 struct fpu_ctx_full {
 	uint32_t caller_saved[16];
 	uint32_t callee_saved[16];

--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -53,13 +53,17 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 #endif
 	}
 
+#if defined(CONFIG_FPU_SHARING)
 	struct fpu_ctx_full context_buffer;
 
 	z_arm_save_fp_context(&context_buffer);
+#endif
 
 	result = fn(arg0, arg1, arg2, arg3);
 
+#if defined(CONFIG_FPU_SHARING)
 	z_arm_restore_fp_context(&context_buffer);
+#endif
 
 	if (!isr_mode) {
 #if !defined(CONFIG_ARM_NONSECURE_PREEMPTIBLE_SECURE_CALLS)


### PR DESCRIPTION
Update API to save and restore FPU context to address suspend to ram use case.

The API is updated as follow:
- Existing APIs `z_arm_save_fp_context` and `z_arm_restore_fp_context` have been changed to always save/restore FPU context regardless of `FPU_SHARING` setting
- The only use case of the original API has been updated to retain original behaviour 

I also noticed by reading code and ARM documentation that the FPU context is preserved across threads by hardware on Cortex-M devices (via the FPCCR.ASPEN register field).

See also #90001, https://github.com/zephyrproject-rtos/zephyr/pull/92847#discussion_r2195238617