### PR TITLE
west: Look for STM32_Programmer_CLI in PATH on macOS

### DIFF
--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -122,6 +122,10 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             return Path(os.environ["PROGRAMW6432"]) / cli
 
         if platform.system() == "Darwin":
+            cmd = shutil.which("STM32_Programmer_CLI")
+            if cmd is not None:
+                return Path(cmd)
+
             return (
                 Path("/Applications")
                 / "STMicroelectronics"


### PR DESCRIPTION
On Windows and Linux, the stm32cubeprogrammer runner will use STM32_Programmer_CLI from PATH if it is available, but this was not implemented on macOS. Add PATH lookup for macOS as well, using the same approach as Windows and Linux.

Fixes zephyrproject-rtos/zephyr#93056

As I mentioned in the issue, I don't really want to just change the path as it may well break (many?) existing installs. This just ensures the `PATH`-based override works as it does on Windows and Linux. 