### PR TITLE
cmake: fix pristine.cmake to really clean the binary dir

### DIFF
--- a/cmake/pristine.cmake
+++ b/cmake/pristine.cmake
@@ -32,7 +32,7 @@ if(NOT INDEX EQUAL -1)
   message(FATAL_ERROR "Refusing to run pristine in in-source build folder.")
 endif()
 
-file(GLOB build_dir_contents ${BINARY_DIR}/*)
+file(GLOB build_dir_contents LIST_DIRECTORIES TRUE ${BINARY_DIR}/*)
 foreach(file ${build_dir_contents})
   if (EXISTS ${file})
      file(REMOVE_RECURSE ${file})


### PR DESCRIPTION
The way it is now pristine.cmake just deletes FILES in the  binary dir not folders so artifacts inside folders are not really cleaned including .config and CMakeCache.txt inside folders created for other images in a sysbuild. This is not a critical problem only because it is simple enough for users to manually delete the build folder. But having to manually delete the build folder defeats the purpose of having a "pristine" option to being with. The fix is trivial: just list directories in the glob as well.