### PR TITLE
drivers: modem_cellular: Add autostart support for BG95

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -2635,7 +2635,7 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 		.reset_pulse_duration_ms = (reset_ms),                                             \
 		.startup_time_ms  = (startup_ms),                                                  \
 		.shutdown_time_ms = (shutdown_ms),                                                 \
-		.autostarts       = (start),                                                       \
+		.autostarts = DT_INST_PROP_OR(inst, autostarts, (start)),                          \
 		.set_baudrate_chat_script    = (set_baudrate_script),                              \
 		.init_chat_script            = (init_script),                                      \
 		.dial_chat_script            = (dial_script),                                      \

--- a/dts/bindings/modem/quectel,bg95.yaml
+++ b/dts/bindings/modem/quectel,bg95.yaml
@@ -10,3 +10,11 @@ include: uart-device.yaml
 properties:
   mdm-power-gpios:
     type: phandle-array
+
+  autostarts:
+    type: boolean
+    description: |
+      Set for modem variants or carrier boards that start the module
+      automatically when supply voltage is applied—that is, the modem
+      asserts PWRKEY internally and does not require an external PWRKEY
+      pulse.


### PR DESCRIPTION
In PR #92794 we made `mdm-power-gpios` optional, as the BG95-M3 Mini-PCIe module boots automatically via its on-module “Automatic Power-On Circuit”.  In the current `modem_cellular` driver we have the `autostart` property for BG95 hardcoded to `false`, but that depends on the form factor.

This patch adds a simple `autostart` boolean to the *quectel,bg95* binding and a one-line change to the driver:

```c
.autostarts = DT_PROP_OR(DT_DRV_INST(inst), autostart, (start)),
```
If the board declares autostart; the driver skips the power-pulse routine; if the property is absent we fall back to the original hard-coded value so existing designs stay exactly as they are.

It might look convenient to assume “no `mdm-power-gpios` ⇒ autostart”, but in reality we can have `mdm-power-gpios` routed via `PERST#` pin of BG95-M3 to use as a reset, but still have the autostart functionality enabled.

<img width="952" height="668" alt="image" src="https://github.com/user-attachments/assets/1bfc22d7-af45-4e0b-a5ed-230e6804f155" />


Tested on a custom board with BG95-M3, with both `autostart` enabled and disabled.  When enabled the driver switches from idle to await power on state immediately. 