### PR TITLE
drivers: modem_cellular: Add shutdown script for BG95

### DIFF
--- a/drivers/modem/modem_cellular.c
+++ b/drivers/modem/modem_cellular.c
@@ -1986,6 +1986,13 @@ MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg95_periodic_chat_script_cmds,
 MODEM_CHAT_SCRIPT_DEFINE(quectel_bg95_periodic_chat_script,
 			 quectel_bg95_periodic_chat_script_cmds, abort_matches,
 			 modem_cellular_chat_callback_handler, 4);
+
+MODEM_CHAT_SCRIPT_CMDS_DEFINE(quectel_bg95_shutdown_chat_script_cmds,
+			      MODEM_CHAT_SCRIPT_CMD_RESP("AT+QPOWD=1", ok_match));
+
+MODEM_CHAT_SCRIPT_DEFINE(quectel_bg95_shutdown_chat_script,
+			 quectel_bg95_shutdown_chat_script_cmds, abort_matches,
+			 modem_cellular_chat_callback_handler, 10);
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(quectel_eg25_g)
@@ -2669,7 +2676,8 @@ MODEM_CHAT_SCRIPT_DEFINE(sqn_gm02s_periodic_chat_script,
 				       NULL,                                                       \
 				       &quectel_bg95_init_chat_script,                             \
 				       &quectel_bg95_dial_chat_script,                             \
-				       &quectel_bg95_periodic_chat_script, NULL)
+				       &quectel_bg95_periodic_chat_script,                         \
+				       &quectel_bg95_shutdown_chat_script)
 
 #define MODEM_CELLULAR_DEVICE_QUECTEL_EG25_G(inst)                                                 \
 	MODEM_PPP_DEFINE(MODEM_CELLULAR_INST_NAME(ppp, inst), NULL, 98, 1500, 64);                 \


### PR DESCRIPTION
This PR adds a shutdown chat-script for BG95 that simply transmits `AT+QPOWD=1` and completes as soon as the modem echoes `OK`. A graceful software power-down is preferable to yanking the supply, because it lets the module close the file system cleanly. This shutdown method is equivalent to the pulse shutdown via PWRKEY, but for the designs that do not have PWRKEY exposed this would be the only path: we can now shut the modem down cleanly without toggling a regulator and cutting the power too early.

According to the BG95 AT command manual the modem should print “POWERED DOWN” after the final OK, but on the BG95-M3 board I have tested (FW BG95M3LAR02A03_01.204.01.204) that URC never appears (maybe somehow related to CMUX). It appears if I try `AT+QPOWD=0`, which is the Immediate power-down. Since the UART stops replying at that point the lone OK is already a useful confirmation.

**Note**: Only tested on BG95-M3 miniPCIe module. Ideally, this should be also tested on a standard BG95 module, with PWRKEY to confirm that there is no regression

<img width="532" height="358" alt="image" src="https://github.com/user-attachments/assets/d7205f13-1d92-49c9-aa8e-221920597ca9" />

<img width="574" height="632" alt="image" src="https://github.com/user-attachments/assets/76147e72-47c3-4bea-991f-c7cd10f22019" />
