### PR TITLE
posix: Map CLOCK_REALTIME and CLOCK_MONOTONIC to Zephyr clock IDs

### DIFF
--- a/include/zephyr/sys/clock.h
+++ b/include/zephyr/sys/clock.h
@@ -378,6 +378,9 @@ static inline bool sys_timepoint_expired(k_timepoint_t timepoint)
 /** @cond INTERNAL_HIDDEN */
 /* forward declaration as workaround for time.h */
 struct timespec;
+
+/* Convert a POSIX clock (cast to int) to a sys_clock identifier */
+int sys_clock_from_clockid(int clock_id);
 /** @endcond INTERNAL_HIDDEN */
 
 /**

--- a/lib/os/clock.c
+++ b/lib/os/clock.c
@@ -50,6 +50,22 @@ static void timespec_from_ticks(uint64_t ticks, struct timespec *ts)
 	};
 }
 
+int sys_clock_from_clockid(int clock_id)
+{
+	switch (clock_id) {
+#if defined(CLOCK_REALTIME) || defined(_POSIX_C_SOURCE)
+	case (int)CLOCK_REALTIME:
+		return SYS_CLOCK_REALTIME;
+#endif
+#if defined(CLOCK_MONOTONIC) || defined(_POSIX_MONOTONIC_CLOCK)
+	case (int)CLOCK_MONOTONIC:
+		return SYS_CLOCK_MONOTONIC;
+#endif
+	default:
+		return -EINVAL;
+	}
+}
+
 int sys_clock_gettime(int clock_id, struct timespec *ts)
 {
 	if (!is_valid_clock_id(clock_id)) {

--- a/lib/posix/options/clock.c
+++ b/lib/posix/options/clock.c
@@ -18,7 +18,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts)
 {
 	int ret;
 
-	ret = sys_clock_gettime((int)clock_id, ts);
+	ret = sys_clock_gettime(sys_clock_from_clockid((int)clock_id), ts);
 	if (ret < 0) {
 		errno = -ret;
 		return -1;
@@ -61,7 +61,7 @@ int clock_settime(clockid_t clock_id, const struct timespec *tp)
 {
 	int ret;
 
-	ret = sys_clock_settime((int)clock_id, tp);
+	ret = sys_clock_settime(sys_clock_from_clockid((int)clock_id), tp);
 	if (ret < 0) {
 		errno = -ret;
 		return -1;

--- a/lib/posix/options/clock_selection.c
+++ b/lib/posix/options/clock_selection.c
@@ -26,7 +26,7 @@ int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
 		return -1;
 	}
 
-	ret = sys_clock_nanosleep((int)clock_id, flags, rqtp, rmtp);
+	ret = sys_clock_nanosleep(sys_clock_from_clockid((int)clock_id), flags, rqtp, rmtp);
 	if (ret < 0) {
 		errno = -ret;
 		return -1;

--- a/lib/posix/options/timespec_to_timeout.c
+++ b/lib/posix/options/timespec_to_timeout.c
@@ -17,7 +17,7 @@ uint32_t timespec_to_timeoutms(int clock_id, const struct timespec *abstime)
 {
 	struct timespec curtime;
 
-	if (sys_clock_gettime(clock_id, &curtime) < 0) {
+	if (sys_clock_gettime(sys_clock_from_clockid(clock_id), &curtime) < 0) {
 		return 0;
 	}
 


### PR DESCRIPTION
Some toolchains may define **CLOCK_REALTIME and 
CLOCK_MONOTONIC** in their libc headers
with values that differ from Zephyr's internal 
**SYS_CLOCK_REALTIME and SYS_CLOCK_MONOTONIC**.

To ensure consistent behavior across all toolchains, Introduce a helper function to map
**CLOCK_REALTIME and CLOCK_MONOTONIC** to Zephyr's internal
clock IDs **(SYS_CLOCK_REALTIME and SYS_CLOCK_MONOTONIC)**.

This prevents mismatched clock IDs being passed to  the kernel, avoiding invalid clockid errors when using  functions like **clock_gettime()**.

Fixing issue: https://github.com/zephyrproject-rtos/zephyr/issues/93073