### PR TITLE
sysbuild: bootloader: fix MCUboot Kconfig symbol placement

### DIFF
--- a/share/sysbuild/images/bootloader/Kconfig
+++ b/share/sysbuild/images/bootloader/Kconfig
@@ -126,8 +126,11 @@ config MCUBOOT_MODE_FIRMWARE_UPDATER
 	  mechanism defined for entering the slot1_partition which is a dedicated firmware updater
 	  application used to update the slot0_partition application.
 
+endchoice
+
 config MCUBOOT_MODE_SINGLE_APP_RAM_LOAD
 	bool "Single app RAM load mode"
+	depends on MCUBOOT_MODE_RAM_LOAD
 	help
 	  MCUboot can load the image to RAM from an arbitrary location. In this mode,
 	  MCUboot will copy the image to RAM and begin execution from there. The image
@@ -138,8 +141,6 @@ config MCUBOOT_MODE_SINGLE_APP_RAM_LOAD
 	  This option automatically selects MCUBOOT_BOOTLOADER_NO_DOWNGRADE as it is
 	  not possible to swap back to older version of the application. In fact, none
 	  of the swap operations are supported in this mode.
-
-endchoice
 
 config MCUBOOT_MODE_FIRMWARE_UPDATER_BOOT_MODE_ENTRANCE
 	bool "Firmware updater retention boot mode entrance"


### PR DESCRIPTION
`MCUBOOT_MODE_SINGLE_APP_RAM_LOAD` shoud not be a `MCUBOOT_MODE` choice because it is not a separate load mode but rather a specific case of `MCUBOOT_MODE_RAM_LOAD`

Without this change, building with `SB_CONFIG_MCUBOOT_MODE_SINGLE_APP_RAM_LOAD=y` leads to multiple modes being selected if a default mode is set on MCUboot side (for ex. https://github.com/mcu-tools/mcuboot/blob/5eaf190a8a9d8fc032b989bf96fc56b3b756dd55/boot/zephyr/boards/stm32h7s78_dk.conf#L1) and MCUboot build failing with the error
```
mcuboot/boot/bootutil/src/bootutil_priv.h:70:2: error: #error "Please enable only one of MCUBOOT_OVERWRITE_ONLY, MCUBOOT_SWAP_USING_MOVE, MCUBOOT_SWAP_USING_OFFSET, MCUBOOT_DIRECT_XIP, MCUBOOT_RAM_LOAD or MCUBOOT_FIRMWARE_LOADER"
```

Tested with
```
west build -p always -b stm32h7s78_dk samples/sysbuild/with_mcuboot --sysbuild -DSB_CONFIG_MCUBOOT_MODE_SINGLE_APP_RAM_LOAD=y
```
