### PR TITLE
boards: renesas: ek_ra8d1: added mikrobus node labels

### DIFF
--- a/boards/renesas/ek_ra8d1/ek_ra8d1-pinctrl.dtsi
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1-pinctrl.dtsi
@@ -25,6 +25,18 @@
 		};
 	};
 
+	sci3_default: sci3_default {
+		group1 {
+			/* tx */
+			psels = <RA_PSEL(RA_PSEL_SCI_3, 4, 9)>;
+			drive-strength = "medium";
+		};
+		group2 {
+			/* rx */
+			psels = <RA_PSEL(RA_PSEL_SCI_3, 4, 8)>;
+		};
+	};
+
 	spi1_default: spi1_default {
 		group1 {
 			/* MISO MOSI RSPCK SSL */

--- a/boards/renesas/ek_ra8d1/ek_ra8d1.dts
+++ b/boards/renesas/ek_ra8d1/ek_ra8d1.dts
@@ -44,6 +44,29 @@
 		};
 	};
 
+	mikrobus_header: mikrobus-connector {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &ioport0 4 0>,	/* AN  */
+				<1 0 &ioport5 7 0>,	/* RST */
+				<2 0 &ioport4 13 0>,	/* CS   */
+				<3 0 &ioport4 12 0>,	/* SCK  */
+				<4 0 &ioport4 10 0>,	/* MISO */
+				<5 0 &ioport4 11 0>,	/* MOSI */
+							/* +3.3V */
+							/* GND */
+				<6 0 &ioport9 7 0>,	/* PWM  */
+				<7 0 &ioport0 10 0>,	/* INT  */
+				<8 0 &ioport4 8 0>,	/* RX   */
+				<9 0 &ioport4 9 0>,	/* TX   */
+				<10 0 &ioport4 0 0>,	/* SCL  */
+				<11 0 &ioport4 1 0>;	/* SDA  */
+							/* +5V */
+							/* GND */
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: s1 {
@@ -193,6 +216,10 @@
 	status = "okay";
 };
 
+&ioport9 {
+	status = "okay";
+};
+
 &ioporta {
 	status = "okay";
 };
@@ -219,6 +246,17 @@
 		sda-output-delay = <300>;
 		noise-filter-clock-select = <1>;
 		bit-rate-modulation;
+	};
+};
+
+&sci3 {
+	pinctrl-0 = <&sci3_default>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	uart3: uart {
+		current-speed = <115200>;
+		status = "okay";
 	};
 };
 
@@ -436,3 +474,6 @@ pmod_sd_shield: &sdhc1 {};
 		};
 	};
 };
+
+mikrobus_serial: &uart3 {};
+mikrobus_spi: &spi1 {};


### PR DESCRIPTION
Added mikrobus_serial, mikrobus_spi and mikrobus_header node labels to EK-RA8D1 device tree board definition, allowing compatible shield boards to be used.