### PR TITLE
soc: imx: imx943: enable cache management for Cortex-M33 Core1 in NET…

### DIFF
--- a/soc/nxp/imx/imx9/imx943/Kconfig
+++ b/soc/nxp/imx/imx9/imx943/Kconfig
@@ -14,9 +14,11 @@ config SOC_MIMX94398_M33
 	select CPU_HAS_FPU
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_ARM_SAU
+	select CPU_HAS_ICACHE
 	select CPU_HAS_DCACHE
 	select ARM_MPU
 	select ARMV8_M_DSP
 	select HAS_MCUX
 	select HAS_MCUX_XCACHE
 	select INIT_ARCH_HW_AT_BOOT
+	select SOC_EARLY_INIT_HOOK

--- a/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
+++ b/soc/nxp/imx/imx9/imx943/Kconfig.defconfig.mimx94398.m33
@@ -27,4 +27,7 @@ endchoice
 config ETH_NXP_IMX_MSGINTR
 	default 2
 
+config CACHE_MANAGEMENT
+	default y
+
 endif # SOC_MIMX94398_M33

--- a/soc/nxp/imx/imx9/imx943/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx943/m33/soc.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/cache.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
@@ -17,6 +18,14 @@
 /* SCMI power domain states */
 #define POWER_DOMAIN_STATE_ON  0x00000000
 #define POWER_DOMAIN_STATE_OFF 0x40000000
+
+void soc_early_init_hook(void)
+{
+#ifdef CONFIG_CACHE_MANAGEMENT
+	sys_cache_data_enable();
+	sys_cache_instr_enable();
+#endif
+}
 
 #if defined(CONFIG_ETH_NXP_IMX_NETC) && (DT_CHILD_NUM_STATUS_OKAY(DT_NODELABEL(netc)) != 0)
 /* The function is to reuse code for 250MHz NETC system clock and MACs clocks initialization */


### PR DESCRIPTION
…CMIX

Enable cache management for Cortex-M33 Core1 of SoC i.MX943.