### PR TITLE
regulator-fixed, regulator-gpio: remove gpio_pin_get_dt calls

### DIFF
--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -90,7 +90,8 @@ static DEVICE_API(regulator, regulator_fixed_api) = {
 static int regulator_fixed_init(const struct device *dev)
 {
 	const struct regulator_fixed_config *cfg = dev->config;
-	bool is_enabled = false;
+	const bool should_enable = cfg->common.flags & REGULATOR_INIT_ENABLED;
+	int ret;
 
 	regulator_common_data_init(dev);
 
@@ -100,22 +101,15 @@ static int regulator_fixed_init(const struct device *dev)
 			return -ENODEV;
 		}
 
-		int ret = gpio_pin_configure_dt(&cfg->enable, GPIO_OUTPUT);
+		ret = gpio_pin_configure_dt(&cfg->enable, should_enable ? GPIO_OUTPUT_ACTIVE
+									: GPIO_OUTPUT_INACTIVE);
 
 		if (ret < 0) {
 			return ret;
 		}
-
-		ret = gpio_pin_get_dt(&cfg->enable);
-
-		if (ret < 0) {
-			return ret;
-		}
-
-		is_enabled = ret;
 	}
 
-	return regulator_common_init(dev, is_enabled);
+	return regulator_common_init(dev, should_enable);
 }
 
 #define REGULATOR_FIXED_DEFINE(inst)                                              \

--- a/drivers/regulator/regulator_gpio.c
+++ b/drivers/regulator/regulator_gpio.c
@@ -154,6 +154,7 @@ static DEVICE_API(regulator, regulator_gpio_api) = {
 static int regulator_gpio_init(const struct device *dev)
 {
 	const struct regulator_gpio_config *cfg = dev->config;
+	const bool should_enable = cfg->common.flags & REGULATOR_INIT_ENABLED;
 	int ret;
 
 	regulator_common_data_init(dev);
@@ -180,7 +181,8 @@ static int regulator_gpio_init(const struct device *dev)
 			return -ENODEV;
 		}
 
-		ret = gpio_pin_configure_dt(&cfg->enable, GPIO_OUTPUT | GPIO_OUTPUT_INIT_LOW);
+		ret = gpio_pin_configure_dt(&cfg->enable, should_enable ? GPIO_OUTPUT_ACTIVE
+									: GPIO_OUTPUT_INACTIVE);
 		if (ret < 0) {
 			LOG_ERR("%s: can't configure enable pin (%d) as output", dev->name,
 				cfg->enable.pin);
@@ -188,7 +190,7 @@ static int regulator_gpio_init(const struct device *dev)
 		}
 	}
 
-	return regulator_common_init(dev, false);
+	return regulator_common_init(dev, should_enable);
 }
 
 #define REG_GPIO_CONTEXT_GPIOS_SPEC_ELEM(_node_id, _prop, _idx)                                    \

--- a/drivers/regulator/regulator_gpio.c
+++ b/drivers/regulator/regulator_gpio.c
@@ -38,18 +38,10 @@ static int regulator_gpio_apply_state(const struct device *dev, uint32_t state)
 		int ret;
 		int new_state_of_gpio = (state >> gpio_idx) & 0x1;
 
-		ret = gpio_pin_get_dt(&cfg->gpios[gpio_idx]);
+		ret = gpio_pin_set_dt(&cfg->gpios[gpio_idx], new_state_of_gpio);
 		if (ret < 0) {
-			LOG_ERR("%s: can't get pin state", dev->name);
+			LOG_ERR("%s: can't set pin state", dev->name);
 			return ret;
-		}
-
-		if (ret != new_state_of_gpio) {
-			ret = gpio_pin_set_dt(&cfg->gpios[gpio_idx], new_state_of_gpio);
-			if (ret < 0) {
-				LOG_ERR("%s: can't set pin state", dev->name);
-				return ret;
-			}
 		}
 	}
 


### PR DESCRIPTION
On some platforms configuring a GPIO pin as OUTPUT disconnects the input buffer. In this case we cannot rely on reading the current pin state with a `gpio_pin_get_dt` call. This removes these calls as well as modifies the initialization procedure for `regulator-fixed` and `regulator-gpio` to configure the `enable` pin to a known state ~~(INACTIVE) without the need to read it before calling `regulator_common_init` (with `is_enabled=false`).~~ based on the `REGULATOR_INIT_ENABLED` flag before calling `regulator_common_init` with `is_enabled` reflecting the actual state

Fixes #93012 