### PR TITLE
boards: nxp: Add support for sdif on LPC55S28 and LPCXpresso55S28 board

### DIFF
--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28-pinctrl.dtsi
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28-pinctrl.dtsi
@@ -64,4 +64,23 @@
 			slew-rate = "standard";
 		};
 	};
+
+	pinmux_sdif_default: pinmux_sdif_default {
+		group0 {
+			pinmux = <SDIF_SD0_D0_PIO0_24>,
+				<SDIF_SD0_D1_PIO0_25>,
+				<SDIF_SD0_D2_PIO0_31>,
+				<SD0_CLK_PIO0_7>,
+				<SD0_CMD_PIO0_8>,
+				<SD0_POW_EN_PIO0_9>,
+				<SDIF_SD0_D3_PIO1_0>;
+			slew-rate = "fast";
+		};
+
+		group1 {
+			pinmux = <SD0_WR_PRT_PIO0_15>,
+				<SD0_CARD_DET_N_PIO0_17>;
+			slew-rate = "standard";
+		};
+	};
 };

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -148,3 +148,15 @@ zephyr_uhc1: &usbhhs {
 	tx-cal-45-dp-ohms = <10>;
 	tx-cal-45-dm-ohms = <10>;
 };
+
+&sdif {
+	status = "okay";
+	pinctrl-0 = <&pinmux_sdif_default>;
+	pinctrl-names = "default";
+
+	mmc {
+		compatible = "zephyr,sdmmc-disk";
+		status = "okay";
+		disk-name = "SD";
+	};
+};

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -266,6 +266,14 @@
 		#pwm-cells = <3>;
 	};
 
+	sdif: sdif@9b000 {
+		compatible = "nxp,lpc-sdif";
+		reg = <0x9b000 0x1000>;
+		interrupts = <42 0>;
+		clocks = <&syscon MCUX_SDIF_CLK>;
+		status = "disabled";
+	};
+
 	hs_lspi: spi@9f000 {
 		compatible = "nxp,lpc-spi";
 		/* Enabling cs-gpios below will allow using GPIO CS,


### PR DESCRIPTION
- Add sdif node to nxp_lpc55s2x_common.dtsi
- Add sdif pinmux configuration to LPCXpresso55S28 board
- Enable sdif and sdmmc disk on LPCXpresso55S28 board, providing SD card storage capabilities.