### PR TITLE
soc: stm32: fix FLASH_BASE_ADDR for apps linked in ext Q/OSPI Flash

### DIFF
--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -28,10 +28,14 @@ DT_STM32_LPTIM_PATH := $(dt_nodelabel_path,stm32_lp_tick_source)
 
 DT_CHOSEN_Z_FLASH := zephyr,flash
 DT_COMPAT_XSPI := st,stm32-xspi
+DT_COMPAT_OSPI := st,stm32-ospi
+DT_COMPAT_QSPI := st,stm32-qspi
 
 DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(DT_CHOSEN_Z_FLASH))
 DT_CHOSEN_FLASH_PARENT := $(dt_node_parent,$(DT_CHOSEN_FLASH_NODE))
 DT_FLASH_PARENT_IS_XSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_XSPI))
+DT_FLASH_PARENT_IS_OSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_OSPI))
+DT_FLASH_PARENT_IS_QSPI := $(dt_node_has_compat,$(DT_CHOSEN_FLASH_PARENT),$(DT_COMPAT_QSPI))
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default "$(DT_STM32_RCC_CLOCK_FREQ)" if "$(dt_nodelabel_enabled,rcc)"
@@ -82,7 +86,7 @@ config BUILD_WITH_TFM
 
 config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1) \
-		if $(DT_FLASH_PARENT_IS_XSPI)
+		if $(DT_FLASH_PARENT_IS_XSPI) || $(DT_FLASH_PARENT_IS_OSPI) || $(DT_FLASH_PARENT_IS_QSPI)
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
 
 # The XSPI PSRAM driver creates a SMH region with attribute SMH_REG_ATTR_EXTERNAL (2)


### PR DESCRIPTION
Following changes in e35ac8f and 14c1b4a to how external Q/OSPI Flash nodes are declared in DT for boards with STM32 SoCs, `FLASH_BASE_ADDRESS` needs to default to `$(dt_node_reg_addr_hex,$(DT_CHOSEN_FLASH_PARENT),1)` when apps are linked in external Flash, similar to XSPI Flash, instead of [`$(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))`](https://github.com/zephyrproject-rtos/zephyr/blob/0b1cff200fc45e618231f15d7e0a54e9262ffbbf/soc/st/stm32/Kconfig.defconfig#L86) which gives 0.
This change is critical for running apps with MCUboot from external Q/OSPI Flash.


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93162