### PR TITLE
Issue Fixes for Bap Broadcast Samples and Enable LC3 Codec For iMXRT1062 MCU

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/Kconfig
+++ b/samples/bluetooth/bap_broadcast_sink/Kconfig
@@ -48,7 +48,7 @@ config ENABLE_LC3
 	# By default let's enable it in the platforms we know are capable of supporting it
 	default y
 	depends on CPU_HAS_FPU && \
-		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP)
+		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP || SOC_MIMXRT1062)
 	select LIBLC3
 	select FPU
 

--- a/samples/bluetooth/bap_broadcast_source/Kconfig
+++ b/samples/bluetooth/bap_broadcast_source/Kconfig
@@ -25,7 +25,7 @@ config ENABLE_LC3
 	# By default let's enable it in the platforms we know are capable of supporting it
 	default y
 	depends on CPU_HAS_FPU && \
-		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP)
+		(ARCH_POSIX || SOC_COMPATIBLE_NRF52X || SOC_COMPATIBLE_NRF5340_CPUAPP || SOC_MIMXRT1062)
 	select LIBLC3
 	select FPU
 

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -172,6 +172,19 @@ config BT_BUF_EVT_DISCARDABLE_COUNT
 	  it will not cause the allocation for other critical events to
 	  block and may even eliminate deadlocks in some cases.
 
+config BT_BUF_EVT_SYNCHRONOUS_COUNT
+	int "Number of synchronous HCI Event buffers"
+	range 1 $(UINT8_MAX)
+	# number of buffer require for bap-broadcast BIS counts
+	default BT_BAP_BROADCAST_SRC_STREAM_COUNT if BT_BAP_BROADCAST_SOURCE
+	default 1
+	help
+	  Number of buffers in a separate pool for events which the HCI
+	  stack depedent to manage it's command buffer queue, host to
+	  controller buffer credits etc. The events command_complete,
+	  number of command processed(nocp) etc considered under this
+	  event pool and processed on priority.
+
 config BT_BUF_CMD_TX_SIZE
 	int "Maximum support HCI Command buffer length"
 	default $(UINT8_MAX) if (BT_EXT_ADV || BT_CLASSIC || BT_ISO_CENTRAL || BT_CHANNEL_SOUNDING)

--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -64,7 +64,8 @@ static void iso_rx_freed_cb(void)
  * the HCI transport to fill buffers in parallel with `bt_recv`
  * consuming them.
  */
-NET_BUF_POOL_FIXED_DEFINE(sync_evt_pool, 1, SYNC_EVT_SIZE, 0, NULL);
+NET_BUF_POOL_FIXED_DEFINE(sync_evt_pool, CONFIG_BT_BUF_EVT_SYNCHRONOUS_COUNT, SYNC_EVT_SIZE, 0,
+			  NULL);
 
 NET_BUF_POOL_FIXED_DEFINE(discardable_pool, CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT,
 			  BT_BUF_EVT_SIZE(CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE),


### PR DESCRIPTION
   **bluetooth: host: add kconfig for synchronous buffer count** 

>    a. adding kconfig for HCI synchronous cmds, or events responsible to manage host-controller credits to avoid discard complete event due to unavailability of synchronous buffer.
>     b. Issue was present while working with use cases like Broadcast-BAP where more than one stream (SDU per BIS) sent to controller over HCI, and controller sends NOCP events for both streams at the end of BIG sync anchor. The gap between two consecutive events in same BIG is within few micro-sec range causes HCI driver to drop successive event while processing current and if not freed.

**samples: bluetooth: bap_broadcast: enable LIBLC3 for NXP iMXRT Family**
> Added i. MXRT1062 MCU to enable LC3 Codec as it supports FPU and used to evaluate BLE Audio applications using LC3 based payload.
