### PR TITLE
drivers: sensor: adxl367: Fix log module declaration

### DIFF
--- a/drivers/sensor/adi/adxl367/adxl367_stream.c
+++ b/drivers/sensor/adi/adxl367/adxl367_stream.c
@@ -9,7 +9,7 @@
 #include <zephyr/drivers/sensor_clock.h>
 #include "adxl367.h"
 
-LOG_MODULE_DECLARE(ADXL362, CONFIG_SENSOR_LOG_LEVEL);
+LOG_MODULE_DECLARE(ADXL367, CONFIG_SENSOR_LOG_LEVEL);
 
 static void adxl367_sqe_done(const struct adxl367_dev_config *cfg,
 	struct rtio_iodev_sqe *iodev_sqe, int res)


### PR DESCRIPTION
Resolve a compilation issue caused by incorrect logging state declaration for ADXL367. The issue occurs specifically when both RTIO and logging are enabled simultaneously.