### PR TITLE
drivers: flash_mspi_nor: Apply a few improvements

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -279,6 +279,13 @@ slot3_partition: &cpurad_slot1_partition {
 			30 b0 30 b0  f4 bd d5 5c  00 00 00 ff  10 10 00 20
 			00 00 00 00  00 00 7c 23  48 00 00 00  00 00 88 88
 		];
+		sfdp-ff05 = [
+			00 ee c0 69  72 72 71 71  00 d8 f7 f6  00 0a 00 00
+			14 45 98 80
+		];
+		sfdp-ff84 = [
+			43 06 0f 00  21 dc ff ff
+		];
 		size = <67108864>;
 		has-dpd;
 		t-enter-dpd = <10000>;

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -259,6 +259,13 @@ ipc0: &cpuapp_cpurad_ipc {
 			30 b0 30 b0  f4 bd d5 5c  00 00 00 ff  10 10 00 20
 			00 00 00 00  00 00 7c 23  48 00 00 00  00 00 88 88
 		];
+		sfdp-ff05 = [
+			00 ee c0 69  72 72 71 71  00 d8 f7 f6  00 0a 00 00
+			14 45 98 80
+		];
+		sfdp-ff84 = [
+			43 06 0f 00  21 dc ff ff
+		];
 		size = <67108864>;
 		has-dpd;
 		t-enter-dpd = <10000>;

--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -49,6 +49,24 @@ menuconfig FLASH_MSPI_NOR
 
 if FLASH_MSPI_NOR
 
+config FLASH_MSPI_NOR_USE_SFDP
+	bool "Use Serial Flash Discoverable Parameters (SFDP)"
+	default $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),sfdp-bfp)
+	help
+	  Use information from SFDP for setting up flash command transfers
+	  and for configuring the flash chip.
+
+	  Currently, only build time processing of SFDP structures is supported,
+	  based on dts arrays provided as flash node properties like `sfdp-bfp`,
+	  `sfdp-ff05`, and `sfdp-ff84`. Depending on the IO mode used, some or
+	  all of these properties are required for building the flash driver.
+	  Data for these properties can be obtained with the `drivers/jesd216`
+	  sample. If a given SFDP table is not available in a flash chip,
+	  the related property can be defined as an empty array - this will
+	  prevent a related build assertion from failing and default values
+	  will be assigned to parameters that would otherwise be read from
+	  that SFDP table.
+
 config FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE
 	int "Page size to use for FLASH_LAYOUT feature"
 	depends on FLASH_PAGE_LAYOUT

--- a/drivers/flash/Kconfig.mspi
+++ b/drivers/flash/Kconfig.mspi
@@ -45,7 +45,8 @@ menuconfig FLASH_MSPI_NOR
 	select FLASH_MSPI
 	select FLASH_HAS_EXPLICIT_ERASE
 	select FLASH_JESD216
-	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),reset-gpios)
+	select GPIO if $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),reset-gpios) \
+		    || $(dt_compat_any_has_prop,$(DT_COMPAT_JEDEC_MSPI_NOR),supply-gpios)
 
 if FLASH_MSPI_NOR
 

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -962,7 +962,6 @@ static int flash_chip_init(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
-	enum mspi_io_mode io_mode = dev_config->mspi_nor_cfg.io_mode;
 	uint8_t id[JESD216_READ_ID_LEN] = {0};
 	uint16_t dts_cmd = 0;
 	uint32_t sfdp_signature;
@@ -977,28 +976,6 @@ static int flash_chip_init(const struct device *dev)
 	}
 
 	dev_data->in_target_io_mode = false;
-
-	/* Some chips reuse RESET pin for data in Quad modes:
-	 * force single line mode before resetting.
-	 */
-	if (dev_data->switch_info.quad_enable_req != JESD216_DW15_QER_VAL_NONE &&
-	    (io_mode == MSPI_IO_MODE_SINGLE ||
-	     io_mode == MSPI_IO_MODE_QUAD_1_1_4 ||
-	     io_mode == MSPI_IO_MODE_QUAD_1_4_4)) {
-		rc = quad_enable_set(dev, false);
-
-		if (rc < 0) {
-			LOG_ERR("Failed to switch to single line mode: %d", rc);
-			return rc;
-		}
-
-		rc = wait_until_ready(dev, K_USEC(1));
-
-		if (rc < 0) {
-			LOG_ERR("Failed waiting for device after switch to single line: %d", rc);
-			return rc;
-		}
-	}
 
 #if defined(WITH_RESET_GPIO)
 	rc = gpio_reset(dev);

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -887,6 +887,77 @@ static int gpio_reset(const struct device *dev)
 }
 #endif
 
+#if defined(WITH_SOFT_RESET)
+static int soft_reset_66_99(const struct device *dev)
+{
+	int rc;
+
+	set_up_xfer(dev, MSPI_TX);
+	rc = perform_xfer(dev, SPI_NOR_CMD_RESET_EN, false);
+	if (rc < 0) {
+		LOG_ERR("CMD_RESET_EN failed: %d", rc);
+		return rc;
+	}
+
+	set_up_xfer(dev, MSPI_TX);
+	rc = perform_xfer(dev, SPI_NOR_CMD_RESET_MEM, false);
+	if (rc < 0) {
+		LOG_ERR("CMD_RESET_MEM failed: %d", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
+static int soft_reset(const struct device *dev)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	int rc;
+
+	/* If the flash may expect commands sent in multi-line mode,
+	 * send additionally the reset sequence this way.
+	 */
+	if (dev_config->multi_io_cmd) {
+		rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
+				     MSPI_DEVICE_CONFIG_IO_MODE,
+				     &dev_config->mspi_nor_cfg);
+		if (rc < 0) {
+			LOG_ERR("%s: dev_config() failed: %d", __func__, rc);
+			return rc;
+		}
+
+		dev_data->in_target_io_mode = true;
+
+		rc = soft_reset_66_99(dev);
+		if (rc < 0) {
+			return rc;
+		}
+
+		rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
+				     MSPI_DEVICE_CONFIG_IO_MODE,
+				     &dev_config->mspi_nor_init_cfg);
+		if (rc < 0) {
+			LOG_ERR("%s: dev_config() failed: %d", __func__, rc);
+			return rc;
+		}
+
+		dev_data->in_target_io_mode = false;
+	}
+
+	rc = soft_reset_66_99(dev);
+	if (rc < 0) {
+		return rc;
+	}
+
+	if (dev_config->reset_recovery_us != 0) {
+		k_busy_wait(dev_config->reset_recovery_us);
+	}
+
+	return 0;
+}
+#endif /* WITH_SOFT_RESET */
+
 static int flash_chip_init(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
@@ -935,6 +1006,15 @@ static int flash_chip_init(const struct device *dev)
 	if (rc < 0) {
 		LOG_ERR("Failed to reset with GPIO: %d", rc);
 		return rc;
+	}
+#endif
+
+#if defined(WITH_SOFT_RESET)
+	if (dev_config->initial_soft_reset) {
+		rc = soft_reset(dev);
+		if (rc < 0) {
+			return rc;
+		}
 	}
 #endif
 
@@ -1212,10 +1292,10 @@ BUILD_ASSERT((FLASH_SIZE(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) == 0, \
 		(.xip_cfg = MSPI_XIP_CONFIG_DT_INST(inst),))			\
 	IF_ENABLED(WITH_RESET_GPIO,						\
 		(.reset = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {0}),	\
-		.reset_pulse_us = DT_INST_PROP_OR(inst, t_reset_pulse, 0)	\
-				/ 1000,						\
+		 .reset_pulse_us = DT_INST_PROP_OR(inst, t_reset_pulse, 0)	\
+				 / 1000,))					\
 		.reset_recovery_us = DT_INST_PROP_OR(inst, t_reset_recovery, 0)	\
-				   / 1000,))					\
+				   / 1000,					\
 		.transfer_timeout = DT_INST_PROP(inst, transfer_timeout),	\
 		FLASH_PAGE_LAYOUT_DEFINE(inst)					\
 		.jedec_id = DT_INST_PROP_OR(inst, jedec_id, {0}),		\
@@ -1228,6 +1308,7 @@ BUILD_ASSERT((FLASH_SIZE(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) == 0, \
 		.multiperipheral_bus = DT_PROP(DT_INST_BUS(inst),		\
 					       software_multiperipheral),	\
 		IO_MODE_FLAGS(DT_INST_ENUM_IDX(inst, mspi_io_mode)),		\
+		.initial_soft_reset = DT_INST_PROP(inst, initial_soft_reset),	\
 	};									\
 	FLASH_PAGE_LAYOUT_CHECK(inst)						\
 	DEVICE_DT_INST_DEFINE(inst,						\

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -20,9 +20,52 @@ extern "C" {
 #define WITH_RESET_GPIO 1
 #endif
 
+#define CMD_EXTENSION_NONE    0
+#define CMD_EXTENSION_SAME    1
+#define CMD_EXTENSION_INVERSE 2
+
+#define OCTAL_ENABLE_REQ_NONE 0
+#define OCTAL_ENABLE_REQ_S2B3 1
+
+#define ENTER_4BYTE_ADDR_NONE  0
+#define ENTER_4BYTE_ADDR_B7    1
+#define ENTER_4BYTE_ADDR_06_B7 2
+
+struct flash_mspi_nor_cmd_info {
+	uint8_t read_cmd;
+	uint8_t read_mode_bit_cycles : 3;
+	uint8_t read_dummy_cycles    : 5;
+	uint8_t pp_cmd;
+	bool    uses_4byte_addr : 1;
+	/* BFP, 18th DWORD, bits 30-29 */
+	uint8_t cmd_extension   : 2;
+	/* xSPI Profile 1.0 (ID FF05), 1st DWORD: */
+	/* - Read SFDP command address bytes: 4 (true) or 3 */
+	bool    sfdp_addr_4     : 1;
+	/* - Read SDFP command dummy cycles: 20 (true) or 8 */
+	bool    sfdp_dummy_20   : 1;
+	/* - Read Status Register command address bytes: 4 (true) or 0 */
+	bool    rdsr_addr_4     : 1;
+	/* - Read Status Register command dummy cycles: 0, 4, or 8 */
+	uint8_t rdsr_dummy      : 4;
+	/* - Read JEDEC ID command parameters; not sure where to get their
+	 *   values from, but since for many flash chips they are the same
+	 *   as for RDSR, those are taken as defaults, see DEFAULT_CMD_INFO()
+	 */
+	bool    rdid_addr_4     : 1;
+	uint8_t rdid_dummy      : 4;
+};
+
+struct flash_mspi_nor_switch_info {
+	uint8_t quad_enable_req  : 3;
+	uint8_t octal_enable_req : 3;
+	uint8_t enter_4byte_addr : 2;
+};
+
 struct flash_mspi_nor_config {
 	const struct device *bus;
 	uint32_t flash_size;
+	uint16_t page_size;
 	struct mspi_dev_id mspi_id;
 	struct mspi_dev_cfg mspi_nor_cfg;
 	struct mspi_dev_cfg mspi_nor_init_cfg;
@@ -42,7 +85,9 @@ struct flash_mspi_nor_config {
 	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
 	const struct flash_mspi_nor_cmds *jedec_cmds;
 	struct flash_mspi_nor_quirks *quirks;
-	uint8_t dw15_qer;
+	const struct jesd216_erase_type *default_erase_types;
+	struct flash_mspi_nor_cmd_info default_cmd_info;
+	struct flash_mspi_nor_switch_info default_switch_info;
 };
 
 struct flash_mspi_nor_data {
@@ -50,6 +95,9 @@ struct flash_mspi_nor_data {
 	struct mspi_xfer_packet packet;
 	struct mspi_xfer xfer;
 	struct mspi_dev_cfg *curr_cfg;
+	struct jesd216_erase_type erase_types[JESD216_NUM_ERASE_TYPES];
+	struct flash_mspi_nor_cmd_info cmd_info;
+	struct flash_mspi_nor_switch_info switch_info;
 };
 
 struct flash_mspi_nor_cmd {

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -16,6 +16,9 @@ extern "C" {
 #include "jesd216.h"
 #include "spi_nor.h"
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(supply_gpios)
+#define WITH_SUPPLY_GPIO 1
+#endif
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 #define WITH_RESET_GPIO 1
 #endif
@@ -74,6 +77,9 @@ struct flash_mspi_nor_config {
 	struct mspi_dev_cfg mspi_nor_init_cfg;
 #if defined(CONFIG_MSPI_XIP)
 	struct mspi_xip_cfg xip_cfg;
+#endif
+#if defined(WITH_SUPPLY_GPIO)
+	struct gpio_dt_spec supply;
 #endif
 #if defined(WITH_RESET_GPIO)
 	struct gpio_dt_spec reset;

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -19,6 +19,9 @@ extern "C" {
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(reset_gpios)
 #define WITH_RESET_GPIO 1
 #endif
+#if DT_ANY_INST_HAS_BOOL_STATUS_OKAY(initial_soft_reset)
+#define WITH_SOFT_RESET 1
+#endif
 
 #define CMD_EXTENSION_NONE    0
 #define CMD_EXTENSION_SAME    1
@@ -75,8 +78,8 @@ struct flash_mspi_nor_config {
 #if defined(WITH_RESET_GPIO)
 	struct gpio_dt_spec reset;
 	uint32_t reset_pulse_us;
-	uint32_t reset_recovery_us;
 #endif
+	uint32_t reset_recovery_us;
 	uint32_t transfer_timeout;
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	struct flash_pages_layout layout;
@@ -91,6 +94,7 @@ struct flash_mspi_nor_config {
 	bool multiperipheral_bus : 1;
 	bool multi_io_cmd        : 1;
 	bool single_io_addr      : 1;
+	bool initial_soft_reset  : 1;
 };
 
 struct flash_mspi_nor_data {

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -69,7 +69,6 @@ struct flash_mspi_nor_config {
 	struct mspi_dev_id mspi_id;
 	struct mspi_dev_cfg mspi_nor_cfg;
 	struct mspi_dev_cfg mspi_nor_init_cfg;
-	enum mspi_dev_cfg_mask mspi_nor_cfg_mask;
 #if defined(CONFIG_MSPI_XIP)
 	struct mspi_xip_cfg xip_cfg;
 #endif
@@ -83,212 +82,26 @@ struct flash_mspi_nor_config {
 	struct flash_pages_layout layout;
 #endif
 	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
-	const struct flash_mspi_nor_cmds *jedec_cmds;
 	struct flash_mspi_nor_quirks *quirks;
 	const struct jesd216_erase_type *default_erase_types;
 	struct flash_mspi_nor_cmd_info default_cmd_info;
 	struct flash_mspi_nor_switch_info default_switch_info;
+	bool jedec_id_specified  : 1;
+	bool rx_dummy_specified  : 1;
+	bool multiperipheral_bus : 1;
+	bool multi_io_cmd        : 1;
+	bool single_io_addr      : 1;
 };
 
 struct flash_mspi_nor_data {
 	struct k_sem acquired;
 	struct mspi_xfer_packet packet;
 	struct mspi_xfer xfer;
-	struct mspi_dev_cfg *curr_cfg;
 	struct jesd216_erase_type erase_types[JESD216_NUM_ERASE_TYPES];
 	struct flash_mspi_nor_cmd_info cmd_info;
 	struct flash_mspi_nor_switch_info switch_info;
+	bool in_target_io_mode;
 };
-
-struct flash_mspi_nor_cmd {
-	enum mspi_xfer_direction dir;
-	uint32_t cmd;
-	uint16_t tx_dummy;
-	uint16_t rx_dummy;
-	uint8_t cmd_length;
-	uint8_t addr_length;
-	bool force_single;
-};
-
-struct flash_mspi_nor_cmds {
-	struct flash_mspi_nor_cmd id;
-	struct flash_mspi_nor_cmd write_en;
-	struct flash_mspi_nor_cmd read;
-	struct flash_mspi_nor_cmd status;
-	struct flash_mspi_nor_cmd config;
-	struct flash_mspi_nor_cmd page_program;
-	struct flash_mspi_nor_cmd sector_erase;
-	struct flash_mspi_nor_cmd chip_erase;
-	struct flash_mspi_nor_cmd sfdp;
-};
-
-const struct flash_mspi_nor_cmds commands_single = {
-	.id = {
-		.dir = MSPI_RX,
-		.cmd = JESD216_CMD_READ_ID,
-		.cmd_length = 1,
-	},
-	.write_en = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_CMD_WREN,
-		.cmd_length = 1,
-	},
-	.read = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_CMD_READ_FAST,
-		.cmd_length = 1,
-		.addr_length = 3,
-		.rx_dummy = 8,
-	},
-	.status = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_CMD_RDSR,
-		.cmd_length = 1,
-	},
-	.config = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_CMD_RDCR,
-		.cmd_length = 1,
-	},
-	.page_program = {
-		.dir  = MSPI_TX,
-		.cmd = SPI_NOR_CMD_PP,
-		.cmd_length = 1,
-		.addr_length = 3,
-	},
-	.sector_erase = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_CMD_SE,
-		.cmd_length = 1,
-		.addr_length = 3,
-	},
-	.chip_erase = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_CMD_CE,
-		.cmd_length = 1,
-	},
-	.sfdp = {
-		.dir = MSPI_RX,
-		.cmd = JESD216_CMD_READ_SFDP,
-		.cmd_length = 1,
-		.addr_length = 3,
-		.rx_dummy = 8,
-	},
-};
-
-const struct flash_mspi_nor_cmds commands_quad_1_4_4 = {
-	.id = {
-		.dir = MSPI_RX,
-		.cmd = JESD216_CMD_READ_ID,
-		.cmd_length = 1,
-		.force_single = true,
-	},
-	.write_en = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_CMD_WREN,
-		.cmd_length = 1,
-	},
-	.read = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_CMD_4READ,
-		.cmd_length = 1,
-		.addr_length = 3,
-		.rx_dummy = 6,
-	},
-	.status = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_CMD_RDSR,
-		.cmd_length = 1,
-		.force_single = true,
-	},
-	.config = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_CMD_RDCR,
-		.cmd_length = 1,
-		.force_single = true,
-	},
-	.page_program = {
-		.dir  = MSPI_TX,
-		.cmd = SPI_NOR_CMD_PP_1_4_4,
-		.cmd_length = 1,
-		.addr_length = 3,
-	},
-	.sector_erase = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_CMD_SE,
-		.cmd_length = 1,
-		.addr_length = 3,
-		.force_single = true,
-	},
-	.chip_erase = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_CMD_CE,
-		.cmd_length = 1,
-	},
-	.sfdp = {
-		.dir = MSPI_RX,
-		.cmd = JESD216_CMD_READ_SFDP,
-		.cmd_length = 1,
-		.addr_length = 3,
-		.rx_dummy = 8,
-		.force_single = true,
-	},
-};
-
-const struct flash_mspi_nor_cmds commands_octal = {
-	.id = {
-		.dir = MSPI_RX,
-		.cmd = JESD216_OCMD_READ_ID,
-		.cmd_length = 2,
-		.addr_length = 4,
-		.rx_dummy = 4
-	},
-	.write_en = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_OCMD_WREN,
-		.cmd_length = 2,
-	},
-	.read = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_OCMD_RD,
-		.cmd_length = 2,
-		.addr_length = 4,
-		.rx_dummy = 20,
-	},
-	.status = {
-		.dir = MSPI_RX,
-		.cmd = SPI_NOR_OCMD_RDSR,
-		.cmd_length = 2,
-		.addr_length = 4,
-		.rx_dummy = 4,
-	},
-	.page_program = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_OCMD_PAGE_PRG,
-		.cmd_length = 2,
-		.addr_length = 4,
-	},
-	.sector_erase = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_OCMD_SE,
-		.cmd_length = 2,
-		.addr_length = 4,
-	},
-	.chip_erase = {
-		.dir = MSPI_TX,
-		.cmd = SPI_NOR_OCMD_CE,
-		.cmd_length = 2,
-	},
-	.sfdp = {
-		.dir = MSPI_RX,
-		.cmd = JESD216_OCMD_READ_SFDP,
-		.cmd_length = 2,
-		.addr_length = 4,
-		.rx_dummy = 20,
-	},
-};
-
-void flash_mspi_command_set(const struct device *dev, const struct flash_mspi_nor_cmd *cmd);
 
 #ifdef __cplusplus
 }

--- a/drivers/flash/flash_mspi_nor_quirks.h
+++ b/drivers/flash/flash_mspi_nor_quirks.h
@@ -70,12 +70,6 @@ static inline int mxicy_mx25r_post_switch_mode(const struct device *dev)
 		return 0;
 	}
 
-	/* Wait for previous write to finish */
-	rc = wait_until_ready(dev, K_USEC(1));
-	if (rc < 0) {
-		return rc;
-	}
-
 	/* Write enable */
 	rc = cmd_wren(dev);
 	if (rc < 0) {

--- a/drivers/flash/flash_mspi_nor_quirks.h
+++ b/drivers/flash/flash_mspi_nor_quirks.h
@@ -9,6 +9,13 @@
 
 /* Flash chip specific quirks */
 struct flash_mspi_nor_quirks {
+	/* Called at the beginning of the flash chip initialization,
+	 * right after reset if any is performed. Can be used to alter
+	 * structures that define communication with the chip, like
+	 * `cmd_info`, `switch_info`, and `erase_types`, which are set
+	 * to default values at this point.
+	 */
+	int (*pre_init)(const struct device *dev);
 	/* Called after switching to default IO mode. */
 	int (*post_switch_mode)(const struct device *dev);
 };
@@ -176,7 +183,56 @@ static inline int mxicy_mx25u_post_switch_mode(const struct device *dev)
 	return rc;
 }
 
+static int mxicy_mx25u_pre_init(const struct device *dev)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	static const uint8_t dummy_cycles[8] = {
+		20, 18, 16, 14, 12, 10, 8, 6
+	};
+	uint8_t cfg_reg;
+	int rc;
+
+	if (dev_config->mspi_nor_cfg.io_mode != MSPI_IO_MODE_OCTAL) {
+		return 0;
+	}
+
+	if (dev_config->mspi_nor_cfg.data_rate == MSPI_DATA_RATE_SINGLE) {
+		dev_data->cmd_info.cmd_extension = CMD_EXTENSION_INVERSE;
+	}
+
+	/*
+	 * TODO - replace this with a generic routine that uses information
+	 *        from SFDP header FF87 (Status, Control and Configuration
+	 *        Register Map)
+	 */
+
+	/* Read configured number of dummy cycles for memory reading commands. */
+	const struct flash_mspi_nor_cmd cmd_rd_cr2 = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_RD_CFGREG2,
+		.cmd_length = 1,
+		.addr_length = 4,
+	};
+
+	flash_mspi_command_set(dev, &cmd_rd_cr2);
+	dev_data->packet.address   = 0x300;
+	dev_data->packet.data_buf  = &cfg_reg;
+	dev_data->packet.num_bytes = sizeof(cfg_reg);
+	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id, &dev_data->xfer);
+	if (rc < 0) {
+		LOG_ERR("Failed to read Dummy Cycle from CFGREG2");
+		return rc;
+	}
+
+	dev_data->cmd_info.read_mode_bit_cycles = 0;
+	dev_data->cmd_info.read_dummy_cycles = dummy_cycles[cfg_reg & 0x7];
+
+	return 0;
+}
+
 struct flash_mspi_nor_quirks flash_quirks_mxicy_mx25u = {
+	.pre_init = mxicy_mx25u_pre_init,
 	.post_switch_mode = mxicy_mx25u_post_switch_mode,
 };
 

--- a/drivers/flash/flash_mspi_nor_sfdp.h
+++ b/drivers/flash/flash_mspi_nor_sfdp.h
@@ -6,6 +6,8 @@
 
 #ifdef CONFIG_FLASH_MSPI_NOR_USE_SFDP
 
+#define BFP_DW16_SOFT_RESET_66_99 BIT(4)
+
 #define BFP_DW16_4B_ADDR_ENTER_B7    BIT(0)
 #define BFP_DW16_4B_ADDR_ENTER_06_B7 BIT(1)
 #define BFP_DW16_4B_ADDR_PER_CMD     BIT(5)
@@ -359,6 +361,11 @@
 			 BFP_DW16_4B_ADDR_PER_CMD | \
 			 BFP_DW16_4B_ADDR_ALWAYS)), \
 		"No supported method of entering 4-byte addressing mode for " \
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst))); \
+	BUILD_ASSERT(!DT_INST_PROP(inst, initial_soft_reset) || \
+		     (SFDP_FIELD(inst, sfdp_bfp, 16, GENMASK(13, 8)) \
+		      & BFP_DW16_SOFT_RESET_66_99), \
+		"Cannot use 66h/99h soft reset sequence for " \
 			DT_NODE_FULL_NAME(DT_DRV_INST(inst)))
 
 #else

--- a/drivers/flash/flash_mspi_nor_sfdp.h
+++ b/drivers/flash/flash_mspi_nor_sfdp.h
@@ -98,6 +98,7 @@
 
 #define USES_4BYTE_ADDR(inst) \
 	(USES_OCTAL_IO(inst) || \
+	 DT_INST_PROP(inst, use_4byte_addressing) || \
 	 BFP_DW1_ADDRESS_BYTES(inst) == JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_4B)
 
 #define BFP_ENTER_4BYTE_ADDR_METHODS(inst) \
@@ -345,12 +346,26 @@
 	BUILD_ASSERT(!USES_8D_8D_8D(inst) || \
 		     BFP_DW18_CMD_EXT(inst) <= BFP_DW18_CMD_EXT_INV, \
 		"Unsupported Octal Command Extension mode in " \
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst))); \
+	BUILD_ASSERT(!DT_INST_PROP(inst, use_4byte_addressing) || \
+		     (BFP_DW1_ADDRESS_BYTES(inst) \
+		      != JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_3B), \
+		"Cannot use 4-byte addressing for " \
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst))); \
+	BUILD_ASSERT(!DT_INST_PROP(inst, use_4byte_addressing) || \
+		     (BFP_ENTER_4BYTE_ADDR_METHODS(inst) \
+		      & (BFP_DW16_4B_ADDR_ENTER_B7 | \
+			 BFP_DW16_4B_ADDR_ENTER_06_B7 | \
+			 BFP_DW16_4B_ADDR_PER_CMD | \
+			 BFP_DW16_4B_ADDR_ALWAYS)), \
+		"No supported method of entering 4-byte addressing mode for " \
 			DT_NODE_FULL_NAME(DT_DRV_INST(inst)))
 
 #else
 
 #define USES_4BYTE_ADDR(inst) \
-	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL)
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL || \
+	 DT_INST_PROP(inst, use_4byte_addressing))
 
 #define DEFAULT_CMD_INFO(inst) { \
 	.pp_cmd = USES_4BYTE_ADDR(inst) \

--- a/drivers/flash/flash_mspi_nor_sfdp.h
+++ b/drivers/flash/flash_mspi_nor_sfdp.h
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifdef CONFIG_FLASH_MSPI_NOR_USE_SFDP
+
+#define BFP_DW16_4B_ADDR_ENTER_B7    BIT(0)
+#define BFP_DW16_4B_ADDR_ENTER_06_B7 BIT(1)
+#define BFP_DW16_4B_ADDR_PER_CMD     BIT(5)
+#define BFP_DW16_4B_ADDR_ALWAYS      BIT(6)
+
+#define BFP_DW18_CMD_EXT_SAME 0
+#define BFP_DW18_CMD_EXT_INV  1
+
+/* 32-bit words in SFDP arrays in devicetree are stored in little-endian byte
+ * order. See jedec,jesd216.yaml
+ */
+#define SFDP_DW_BYTE_0_IDX(dw_no) \
+	UTIL_DEC(UTIL_DEC(UTIL_DEC(UTIL_DEC(UTIL_X2(UTIL_X2(dw_no))))))
+#define SFDP_DW_BYTE_1_IDX(dw_no) \
+	UTIL_DEC(UTIL_DEC(UTIL_DEC(UTIL_X2(UTIL_X2(dw_no)))))
+#define SFDP_DW_BYTE_2_IDX(dw_no) \
+	UTIL_DEC(UTIL_DEC(UTIL_X2(UTIL_X2(dw_no))))
+#define SFDP_DW_BYTE_3_IDX(dw_no) \
+	UTIL_DEC(UTIL_X2(UTIL_X2(dw_no)))
+#define SFDP_DW_BYTE(inst, prop, dw_no, byte_idx) \
+	DT_INST_PROP_BY_IDX(inst, prop, SFDP_DW_BYTE_##byte_idx##_IDX(dw_no))
+#define SFDP_DW_EXISTS(inst, prop, dw_no) \
+	DT_INST_PROP_HAS_IDX(inst, prop, SFDP_DW_BYTE_3_IDX(dw_no))
+
+#define SFDP_DW(inst, prop, dw_no) \
+	COND_CODE_1(SFDP_DW_EXISTS(inst, prop, dw_no), \
+		(((SFDP_DW_BYTE(inst, prop, dw_no, 3) << 24) | \
+		  (SFDP_DW_BYTE(inst, prop, dw_no, 2) << 16) | \
+		  (SFDP_DW_BYTE(inst, prop, dw_no, 1) << 8) | \
+		  (SFDP_DW_BYTE(inst, prop, dw_no, 0) << 0))), \
+		(0))
+
+#define SFDP_FIELD(inst, prop, dw_no, mask) \
+	FIELD_GET(mask, SFDP_DW(inst, prop, dw_no))
+
+#define USES_8D_8D_8D(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_DUAL)
+#define USES_8S_8S_8S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_1S_8D_8D(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL_1_8_8 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_DUAL)
+#define USES_1S_8S_8S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL_1_8_8 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_1S_1S_8S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL_1_1_8 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_4S_4D_4D(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_QUAD && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_DUAL)
+#define USES_4S_4S_4S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_QUAD && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_1S_4D_4D(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_QUAD_1_4_4 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_DUAL)
+#define USES_1S_4S_4S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_QUAD_1_4_4 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_1S_1S_4S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_QUAD_1_1_4 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_2S_2S_2S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_DUAL && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_1S_2D_2D(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_DUAL_1_2_2 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_DUAL)
+#define USES_1S_2S_2S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_DUAL_1_2_2 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_1S_1S_2S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_DUAL_1_1_2 && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+#define USES_1S_1D_1D(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_SINGLE && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_DUAL)
+#define USES_1S_1S_1S(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_SINGLE && \
+	 DT_INST_ENUM_IDX(inst, mspi_data_rate) == MSPI_DATA_RATE_SINGLE)
+
+#define USES_OCTAL_IO(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL)
+
+#define BFP_DW1_ADDRESS_BYTES(inst) \
+	SFDP_FIELD(inst, sfdp_bfp, 1, GENMASK(18, 17))
+
+#define USES_4BYTE_ADDR(inst) \
+	(USES_OCTAL_IO(inst) || \
+	 BFP_DW1_ADDRESS_BYTES(inst) == JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_4B)
+
+#define BFP_ENTER_4BYTE_ADDR_METHODS(inst) \
+	SFDP_FIELD(inst, sfdp_bfp, 16, GENMASK(31, 24))
+
+#define HAS_4BYTE_ADDR_CMDS(inst) \
+	(BFP_ENTER_4BYTE_ADDR_METHODS(inst) & BFP_DW16_4B_ADDR_PER_CMD)
+
+#define BFP_DW18_CMD_EXT(inst) \
+	SFDP_FIELD(inst, sfdp_bfp, 18, GENMASK(30, 29))
+
+#define CMD_EXTENSION(inst) \
+	(!USES_8D_8D_8D(inst) ?      CMD_EXTENSION_NONE : \
+	 (BFP_DW18_CMD_EXT(inst) \
+	  == BFP_DW18_CMD_EXT_INV) ? CMD_EXTENSION_INVERSE \
+				   : CMD_EXTENSION_SAME)
+
+/* 1st DWORD of 4-byte Address Instruction Table (ID FF84) indicates commands
+ * that are supported by the chip.
+ */
+#define FF84_DW1_BIT(inst, bit) (SFDP_DW(inst, sfdp_ff84, 1) & BIT(bit))
+
+#define SFDP_CMD_PP(inst) \
+	USES_1S_4S_4S(inst) ? SPI_NOR_CMD_PP_1_4_4 : \
+	USES_1S_1S_4S(inst) ? SPI_NOR_CMD_PP_1_1_4 : \
+	SPI_NOR_CMD_PP
+#define SFDP_CMD_PP_4B(inst) \
+	USES_1S_8S_8S(inst) && FF84_DW1_BIT(inst, 24) ? 0x8E : \
+	USES_1S_1S_8S(inst) && FF84_DW1_BIT(inst, 23) ? 0x84 : \
+	USES_1S_4S_4S(inst) && FF84_DW1_BIT(inst, 8) ? SPI_NOR_CMD_PP_1_4_4_4B : \
+	USES_1S_1S_4S(inst) && FF84_DW1_BIT(inst, 7) ? SPI_NOR_CMD_PP_1_1_4_4B : \
+	FF84_DW1_BIT(inst, 6) ? SPI_NOR_CMD_PP_4B \
+	: 0
+#define SFDP_CMD_FAST_READ(inst) \
+	USES_1S_8D_8D(inst) ? 0 : \
+	USES_1S_8S_8S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 17, GENMASK(15, 8)) : \
+	USES_1S_1S_8S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 17, GENMASK(31, 24)) : \
+	USES_4S_4D_4D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 23, GENMASK(31, 24)) : \
+	USES_4S_4S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 7, GENMASK(31, 24)) : \
+	USES_1S_4D_4D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 23, GENMASK(15, 8)) : \
+	USES_1S_4S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 3, GENMASK(15, 8)) : \
+	USES_1S_1S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 3, GENMASK(31, 24)) : \
+	USES_2S_2S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 6, GENMASK(31, 24)) : \
+	USES_1S_2D_2D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 22, GENMASK(31, 24)) : \
+	USES_1S_2S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 4, GENMASK(31, 24)) : \
+	USES_1S_1S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 4, GENMASK(15, 8)) : \
+	USES_1S_1D_1D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 22, GENMASK(15, 8)) : \
+	SPI_NOR_CMD_READ_FAST
+#define SFDP_CMD_FAST_READ_4B(inst) \
+	USES_8D_8D_8D(inst) ? 0xEE : \
+	USES_8S_8S_8S(inst) ? 0xEC : \
+	USES_1S_8D_8D(inst) && FF84_DW1_BIT(inst, 22) ? 0xFD : \
+	USES_1S_8S_8S(inst) && FF84_DW1_BIT(inst, 21) ? 0xCC : \
+	USES_1S_1S_8S(inst) && FF84_DW1_BIT(inst, 20) ? 0x7C : \
+	USES_4S_4D_4D(inst) ? 0 : \
+	USES_4S_4S_4S(inst) ? 0 : \
+	USES_1S_4D_4D(inst) && FF84_DW1_BIT(inst, 15) ? 0xEE : \
+	USES_1S_4S_4S(inst) && FF84_DW1_BIT(inst, 5) ? 0xEC : \
+	USES_1S_1S_4S(inst) && FF84_DW1_BIT(inst, 4) ? 0x6C : \
+	USES_2S_2S_2S(inst) ? 0 : \
+	USES_1S_2D_2D(inst) && FF84_DW1_BIT(inst, 14) ? 0xBE : \
+	USES_1S_2S_2S(inst) && FF84_DW1_BIT(inst, 3) ? 0xBC : \
+	USES_1S_1S_2S(inst) && FF84_DW1_BIT(inst, 2) ? 0x3C : \
+	USES_1S_1D_1D(inst) && FF84_DW1_BIT(inst, 13) ? 0x0E : \
+	FF84_DW1_BIT(inst, 1) ? SPI_NOR_CMD_READ_FAST_4B : \
+	0
+
+#define DEFAULT_CMD_INFO(inst) { \
+	.pp_cmd = USES_4BYTE_ADDR(inst) && HAS_4BYTE_ADDR_CMDS(inst) \
+		? SFDP_CMD_PP_4B(inst) \
+		: SFDP_CMD_PP(inst), \
+	.read_cmd = USES_4BYTE_ADDR(inst) && HAS_4BYTE_ADDR_CMDS(inst) \
+		  ? SFDP_CMD_FAST_READ_4B(inst) \
+		  : SFDP_CMD_FAST_READ(inst), \
+	.read_mode_bit_cycles = \
+		USES_1S_8S_8S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 17, GENMASK(7, 5)) : \
+		USES_1S_1S_8S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 17, GENMASK(23, 21)) : \
+		USES_4S_4D_4D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 23, GENMASK(23, 21)) : \
+		USES_4S_4S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 7, GENMASK(23, 21)) : \
+		USES_1S_4D_4D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 23, GENMASK(7, 5)) : \
+		USES_1S_4S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 3, GENMASK(7, 5)) : \
+		USES_1S_1S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 3, GENMASK(23, 21)) : \
+		USES_2S_2S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 6, GENMASK(23, 21)) : \
+		USES_1S_2D_2D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 22, GENMASK(23, 21)) : \
+		USES_1S_2S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 4, GENMASK(23, 21)) : \
+		USES_1S_1S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 4, GENMASK(7, 5)) : \
+		USES_1S_1D_1D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 22, GENMASK(7, 5)) : \
+		USES_1S_1S_1S(inst) ? 0 : \
+		0, \
+	.read_dummy_cycles = DT_INST_PROP_OR(inst, rx_dummy, \
+		USES_8D_8D_8D(inst) ? SFDP_FIELD(inst, sfdp_ff05, 6, GENMASK(4, 0)) : \
+		USES_8S_8S_8S(inst) ? SFDP_FIELD(inst, sfdp_ff05, 6, GENMASK(9, 5)) : \
+		USES_1S_8S_8S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 17, GENMASK(4, 0)) : \
+		USES_1S_1S_8S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 17, GENMASK(20, 16)) : \
+		USES_4S_4D_4D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 23, GENMASK(20, 16)) : \
+		USES_4S_4S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 7, GENMASK(20, 16)) : \
+		USES_1S_4D_4D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 23, GENMASK(4, 0)) : \
+		USES_1S_4S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 3, GENMASK(4, 0)) : \
+		USES_1S_1S_4S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 3, GENMASK(20, 16)) : \
+		USES_2S_2S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 6, GENMASK(20, 16)) : \
+		USES_1S_2D_2D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 22, GENMASK(20, 16)) : \
+		USES_1S_2S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 4, GENMASK(20, 16)) : \
+		USES_1S_1S_2S(inst) ? SFDP_FIELD(inst, sfdp_bfp, 4, GENMASK(4, 0)) : \
+		USES_1S_1D_1D(inst) ? SFDP_FIELD(inst, sfdp_bfp, 22, GENMASK(4, 0)) : \
+		USES_1S_1S_1S(inst) ? 8 : \
+		0), \
+	.uses_4byte_addr = USES_4BYTE_ADDR(inst), \
+	.cmd_extension = CMD_EXTENSION(inst), \
+	.sfdp_addr_4 = USES_OCTAL_IO(inst) \
+		     ? (SFDP_FIELD(inst, sfdp_ff05, 1, BIT(31)) == 0) \
+		     : false, \
+	.sfdp_dummy_20 = USES_OCTAL_IO(inst) \
+		       ? (SFDP_FIELD(inst, sfdp_ff05, 1, BIT(30)) == 1) \
+		       : false, \
+	.rdsr_addr_4 = USES_OCTAL_IO(inst) \
+		     ? (SFDP_FIELD(inst, sfdp_ff05, 1, BIT(29)) == 1) \
+		     : false, \
+	.rdsr_dummy = USES_OCTAL_IO(inst) \
+		    ? (SFDP_FIELD(inst, sfdp_ff05, 1, BIT(28)) ? 8 : 4) \
+		    : 0, \
+	.rdid_addr_4 = USES_OCTAL_IO(inst) \
+		     ? (SFDP_FIELD(inst, sfdp_ff05, 1, BIT(29)) == 1) \
+		     : false, \
+	.rdid_dummy = USES_OCTAL_IO(inst) \
+		    ? (SFDP_FIELD(inst, sfdp_ff05, 1, BIT(28)) ? 8 : 4) \
+		    : 0, }
+
+/* Erase Types, 8th and 9th DWORD of BSP */
+#define BFP_DW8_CMD_ET_1(inst) SFDP_FIELD(inst, sfdp_bfp, 8, GENMASK(15, 8))
+#define BFP_DW8_EXP_ET_1(inst) SFDP_FIELD(inst, sfdp_bfp, 8, GENMASK(7, 0))
+#define BFP_DW8_CMD_ET_2(inst) SFDP_FIELD(inst, sfdp_bfp, 8, GENMASK(31, 24))
+#define BFP_DW8_EXP_ET_2(inst) SFDP_FIELD(inst, sfdp_bfp, 8, GENMASK(23, 16))
+#define BFP_DW9_CMD_ET_3(inst) SFDP_FIELD(inst, sfdp_bfp, 9, GENMASK(15, 8))
+#define BFP_DW9_EXP_ET_3(inst) SFDP_FIELD(inst, sfdp_bfp, 9, GENMASK(7, 0))
+#define BFP_DW9_CMD_ET_4(inst) SFDP_FIELD(inst, sfdp_bfp, 9, GENMASK(31, 24))
+#define BFP_DW9_EXP_ET_4(inst) SFDP_FIELD(inst, sfdp_bfp, 9, GENMASK(23, 16))
+
+/* 4-byte Address instructions for Erase Types defined in 8th and 9th DWORD
+ * of BFP; 2nd DWORD of 4-byte Address Instruction Table (ID FF84)
+ */
+#define FF84_DW2_CMD_ET_1(inst) SFDP_FIELD(inst, sfdp_ff84, 2, GENMASK(7, 0))
+#define FF84_DW2_CMD_ET_2(inst) SFDP_FIELD(inst, sfdp_ff84, 2, GENMASK(15, 8))
+#define FF84_DW2_CMD_ET_3(inst) SFDP_FIELD(inst, sfdp_ff84, 2, GENMASK(23, 16))
+#define FF84_DW2_CMD_ET_4(inst) SFDP_FIELD(inst, sfdp_ff84, 2, GENMASK(31, 24))
+/* Support for Erase Types in 4-byte Address mode; table FF84, 1st DWORD */
+#define FF84_DW1_SUP_ET_1(inst) SFDP_FIELD(inst, sfdp_ff84, 1, BIT(9))
+#define FF84_DW1_SUP_ET_2(inst) SFDP_FIELD(inst, sfdp_ff84, 1, BIT(10))
+#define FF84_DW1_SUP_ET_3(inst) SFDP_FIELD(inst, sfdp_ff84, 1, BIT(11))
+#define FF84_DW1_SUP_ET_4(inst) SFDP_FIELD(inst, sfdp_ff84, 1, BIT(12))
+
+#define DEFAULT_ERASE_TYPES_DEFINE(inst) \
+	static const struct jesd216_erase_type \
+	dev##inst##_erase_types[JESD216_NUM_ERASE_TYPES] = \
+		COND_CODE_1(SFDP_DW_EXISTS(inst, sfdp_bfp, 8), \
+			({{ .cmd = BFP_DW8_CMD_ET_1(inst), \
+			    .exp = BFP_DW8_EXP_ET_1(inst), }, \
+			  { .cmd = BFP_DW8_CMD_ET_2(inst), \
+			    .exp = BFP_DW8_EXP_ET_2(inst), }, \
+			  { .cmd = BFP_DW9_CMD_ET_3(inst), \
+			    .exp = BFP_DW9_EXP_ET_3(inst), }, \
+			  { .cmd = BFP_DW9_CMD_ET_4(inst), \
+			    .exp = BFP_DW9_EXP_ET_4(inst), }}), \
+			({{ .cmd = SPI_NOR_CMD_SE, \
+			    .exp = 0x0C }})); \
+	static const struct jesd216_erase_type \
+	dev##inst##_erase_types_4b[JESD216_NUM_ERASE_TYPES] = \
+		COND_CODE_1(UTIL_AND(SFDP_DW_EXISTS(inst, sfdp_ff84, 2), \
+				     SFDP_DW_EXISTS(inst, sfdp_bfp, 9)), \
+			({{ .cmd = FF84_DW2_CMD_ET_1(inst), \
+			    .exp = FF84_DW1_SUP_ET_1(inst) \
+				 ? BFP_DW8_EXP_ET_1(inst) \
+				 : 0, }, \
+			  { .cmd = FF84_DW2_CMD_ET_2(inst), \
+			    .exp = FF84_DW1_SUP_ET_2(inst) \
+				 ? BFP_DW8_EXP_ET_2(inst) \
+				 : 0, }, \
+			  { .cmd = FF84_DW2_CMD_ET_3(inst), \
+			    .exp = FF84_DW1_SUP_ET_3(inst) \
+				 ? BFP_DW9_EXP_ET_3(inst) \
+				 : 0, }, \
+			  { .cmd = FF84_DW2_CMD_ET_4(inst), \
+			    .exp = FF84_DW1_SUP_ET_4(inst) \
+				 ? BFP_DW9_EXP_ET_4(inst) \
+				 : 0, }}), \
+			({{ .cmd = SPI_NOR_CMD_SE_4B, \
+			    .exp = 0x0C }}))
+
+#define DEFAULT_ERASE_TYPES(inst) \
+	USES_4BYTE_ADDR(inst) && HAS_4BYTE_ADDR_CMDS(inst) \
+	? dev##inst##_erase_types_4b \
+	: dev##inst##_erase_types
+
+#define BFP_DW15_QER(inst) \
+	SFDP_FIELD(inst, sfdp_bfp, 15, GENMASK(22, 20))
+
+#define BFP_DW19_OER(inst) \
+	SFDP_FIELD(inst, sfdp_bfp, 19, GENMASK(22, 20))
+
+#define ENTER_4BYTE_ADDR(inst) \
+	(!USES_4BYTE_ADDR(inst) ?           ENTER_4BYTE_ADDR_NONE : \
+	 (BFP_ENTER_4BYTE_ADDR_METHODS(inst) \
+	  & (BFP_DW16_4B_ADDR_PER_CMD | \
+	     BFP_DW16_4B_ADDR_ALWAYS)) ?    ENTER_4BYTE_ADDR_NONE : \
+	 (BFP_ENTER_4BYTE_ADDR_METHODS(inst) \
+	  & BFP_DW16_4B_ADDR_ENTER_B7) ?    ENTER_4BYTE_ADDR_B7 : \
+	 (BFP_ENTER_4BYTE_ADDR_METHODS(inst) \
+	  & BFP_DW16_4B_ADDR_ENTER_06_B7) ? ENTER_4BYTE_ADDR_06_B7 : \
+					    ENTER_4BYTE_ADDR_NONE)
+
+#define DEFAULT_SWITCH_INFO(inst) { \
+	.quad_enable_req = BFP_DW15_QER(inst), \
+	.octal_enable_req = BFP_DW19_OER(inst), \
+	.enter_4byte_addr = ENTER_4BYTE_ADDR(inst) }
+
+#define BFP_FLASH_SIZE(dw2) \
+	((dw2 & BIT(31)) \
+	 ? BIT(MIN(31, (dw2 & BIT_MASK(31)) - 3)) \
+	 : dw2 / 8)
+
+#define FLASH_SIZE(inst) \
+	(DT_INST_NODE_HAS_PROP(inst, size) \
+	 ? DT_INST_PROP(inst, size) / 8 \
+	 : BFP_FLASH_SIZE(SFDP_DW(inst, sfdp_bfp, 2)))
+
+#define BFP_FLASH_PAGE_EXP(inst) SFDP_FIELD(inst, sfdp_bfp, 11, GENMASK(7, 4))
+
+#define FLASH_PAGE_SIZE(inst) \
+	(BFP_FLASH_PAGE_EXP(inst) \
+	 ? BIT(BFP_FLASH_PAGE_EXP(inst)) \
+	 : SPI_NOR_PAGE_SIZE)
+
+#define SFDP_BUILD_ASSERTS(inst) \
+	BUILD_ASSERT(DT_INST_NODE_HAS_PROP(inst, sfdp_bfp), \
+		"sfdp-bfp property needed in " \
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst))); \
+	BUILD_ASSERT((DT_INST_ENUM_IDX(inst, mspi_io_mode) \
+		      != MSPI_IO_MODE_OCTAL) || \
+		     DT_INST_NODE_HAS_PROP(inst, sfdp_ff05), \
+		"sfdp-ff05 property needed in " \
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst))); \
+	BUILD_ASSERT(!USES_4BYTE_ADDR(inst) || \
+		     DT_INST_NODE_HAS_PROP(inst, sfdp_ff84), \
+		"sfdp-ff84 property needed in " \
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst))); \
+	BUILD_ASSERT(!USES_8D_8D_8D(inst) || \
+		     BFP_DW18_CMD_EXT(inst) <= BFP_DW18_CMD_EXT_INV, \
+		"Unsupported Octal Command Extension mode in " \
+			DT_NODE_FULL_NAME(DT_DRV_INST(inst)))
+
+#else
+
+#define USES_4BYTE_ADDR(inst) \
+	(DT_INST_ENUM_IDX(inst, mspi_io_mode) == MSPI_IO_MODE_OCTAL)
+
+#define DEFAULT_CMD_INFO(inst) { \
+	.pp_cmd = USES_4BYTE_ADDR(inst) \
+		? SPI_NOR_CMD_PP_4B \
+		: SPI_NOR_CMD_PP, \
+	.read_cmd = USES_4BYTE_ADDR(inst) \
+		  ? SPI_NOR_CMD_READ_FAST_4B \
+		  : SPI_NOR_CMD_READ_FAST, \
+	.read_mode_bit_cycles = 0, \
+	.read_dummy_cycles = 8, \
+	.uses_4byte_addr = USES_4BYTE_ADDR(inst), \
+	.cmd_extension = CMD_EXTENSION_NONE, \
+	.sfdp_addr_4 = false, \
+	.sfdp_dummy_20 = false, \
+	.rdsr_addr_4 = false, \
+	.rdsr_dummy = 0, \
+	.rdid_addr_4 = false, \
+	.rdid_dummy = 0, }
+
+#define DEFAULT_ERASE_TYPES_DEFINE(inst) \
+	static const struct jesd216_erase_type \
+	dev##inst##_erase_types[JESD216_NUM_ERASE_TYPES] = \
+		{{ .cmd = SPI_NOR_CMD_SE, \
+		   .exp = 0x0C }}; \
+	static const struct jesd216_erase_type \
+	dev##inst##_erase_types_4b[JESD216_NUM_ERASE_TYPES] = \
+		{{ .cmd = SPI_NOR_CMD_SE_4B, \
+		   .exp = 0x0C }}
+
+#define DEFAULT_ERASE_TYPES(inst) \
+	USES_4BYTE_ADDR(inst) ? dev##inst##_erase_types_4b \
+			      : dev##inst##_erase_types
+
+#define DEFAULT_SWITCH_INFO(inst) { \
+	.quad_enable_req = DT_INST_ENUM_IDX_OR(inst, quad_enable_requirements, \
+					       JESD216_DW15_QER_VAL_NONE), \
+	.octal_enable_req = OCTAL_ENABLE_REQ_NONE, \
+	.enter_4byte_addr = ENTER_4BYTE_ADDR_NONE }
+
+#define FLASH_SIZE(inst) (DT_INST_PROP(inst, size) / 8)
+
+#define FLASH_PAGE_SIZE(inst) SPI_NOR_PAGE_SIZE
+
+#define SFDP_BUILD_ASSERTS(inst)
+
+#endif /* CONFIG_FLASH_MSPI_NOR_USE_SFDP */

--- a/dts/bindings/mtd/jedec,jesd216.yaml
+++ b/dts/bindings/mtd/jedec,jesd216.yaml
@@ -35,6 +35,18 @@ properties:
       information in cases were runtime retrieval of SFDP data
       is not desired.
 
+  sfdp-ff05:
+    type: uint8-array
+    description: |
+      Contains the 32-bit words in little-endian byte order from the JESD216
+      SFDP xSPI Profile 1.0 table.
+
+  sfdp-ff84:
+    type: uint8-array
+    description: |
+      Contains the 32-bit words in little-endian byte order from the JESD216
+      SFDP 4-byte Address Instruction Parameter table.
+
   quad-enable-requirements:
     type: string
     enum:

--- a/dts/bindings/mtd/jedec,mspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,mspi-nor.yaml
@@ -5,7 +5,20 @@ description: Generic NOR flash on MSPI bus
 
 compatible: "jedec,mspi-nor"
 
-include: [mspi-device.yaml, "jedec,spi-nor-common.yaml"]
+include:
+  - name: mspi-device.yaml
+  - name: jedec,spi-nor-common.yaml
+    property-allowlist:
+      - jedec-id
+      - size
+      - sfdp-bfp
+      - sfdp-ff05
+      - sfdp-ff84
+      - quad-enable-requirements
+      - has-dpd
+      - dpd-wakeup-sequence
+      - t-enter-dpd
+      - t-exit-dpd
 
 properties:
   reset-gpios:
@@ -30,3 +43,12 @@ properties:
       Maximum time, in milliseconds, allowed for a single transfer on the MSPI
       bus in communication with the flash chip. The default value is the one
       that was previously hard-coded in the flash_mspi_nor driver.
+
+  use-4byte-addressing:
+    type: boolean
+    description: |
+      Indicates that 4-byte addressing is to be used in communication with
+      the flash chip. The driver will use dedicated 4-byte address instruction
+      codes for commands that require addresses (like Read, Page Program,
+      or Erase) if those are supported by the flash chip, or if necessary,
+      it will switch the chip to 4-byte addressing mode.

--- a/dts/bindings/mtd/jedec,mspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,mspi-nor.yaml
@@ -52,3 +52,9 @@ properties:
       codes for commands that require addresses (like Read, Page Program,
       or Erase) if those are supported by the flash chip, or if necessary,
       it will switch the chip to 4-byte addressing mode.
+
+  initial-soft-reset:
+    type: boolean
+    description: |
+      When set, the flash driver performs software reset of the flash chip
+      at initialization.

--- a/dts/bindings/mtd/jedec,mspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,mspi-nor.yaml
@@ -35,6 +35,8 @@ properties:
     type: int
     description: |
       Minimum time, in nanoseconds, the flash chip needs to recover after reset.
+      Such delay is performed when a GPIO or software reset is done, or after
+      power is supplied to the chip if the "supply-gpios" property is specified.
 
   transfer-timeout:
     type: int

--- a/samples/application_development/code_relocation_nocopy/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/application_development/code_relocation_nocopy/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -2,11 +2,16 @@
 	status = "okay";
 };
 
+&gpio6 {
+	status = "okay";
+};
+
+&exmif {
+	status = "okay";
+};
+
 &mx25uw63 {
-	read-command = <0xEC13>;
-	command-length = "INSTR_2_BYTE";
-	address-length = "ADDR_4_BYTE";
-	rx-dummy = <20>;
+	status = "okay";
 
 	xip-config = <1 0 0x20000000 0>;
 };

--- a/samples/application_development/code_relocation_nocopy/sample.yaml
+++ b/samples/application_development/code_relocation_nocopy/sample.yaml
@@ -6,6 +6,7 @@ tests:
     platform_allow:
       - qemu_cortex_m3
       - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
       - stm32f769i_disco
       - stm32h7b3i_dk
       - stm32h573i_dk


### PR DESCRIPTION
Apply a few improvements in the flash_mspi_nor driver, most notably:
- use parameters from SFDP for all the used flash commands with possibility to override those through dts (with the `read-command`, `write-command`, and `rx-dummy` properties)
- use all available erase types as specified by SFDP
- allow using all IO modes
- add support for switching to 4-byte addressing mode
- complete handling of Quad Enable Requirements and add handling of Octal Enable Requirements
- add Soft Reset.

See the individual commit messages for details.