### PR TITLE
arch: riscv: xtensa: sparc: arc: mark unused function argument

### DIFF
--- a/arch/riscv/core/fpu.c
+++ b/arch/riscv/core/fpu.c
@@ -341,6 +341,9 @@ int arch_float_disable(struct k_thread *thread)
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
+
 	/* floats always gets enabled automatically at the moment */
 	return 0;
 }

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -721,6 +721,8 @@ int arch_mem_domain_init(struct k_mem_domain *domain)
 int arch_mem_domain_partition_add(struct k_mem_domain *domain,
 				  uint32_t partition_id)
 {
+	ARG_UNUSED(partition_id);
+
 	/* Force resynchronization for every thread using this domain */
 	domain->arch.pmp_update_nr += 1;
 	return 0;
@@ -729,6 +731,8 @@ int arch_mem_domain_partition_add(struct k_mem_domain *domain,
 int arch_mem_domain_partition_remove(struct k_mem_domain *domain,
 				     uint32_t partition_id)
 {
+	ARG_UNUSED(partition_id);
+
 	/* Force resynchronization for every thread using this domain */
 	domain->arch.pmp_update_nr += 1;
 	return 0;
@@ -743,6 +747,8 @@ int arch_mem_domain_thread_add(struct k_thread *thread)
 
 int arch_mem_domain_thread_remove(struct k_thread *thread)
 {
+	ARG_UNUSED(thread);
+
 	return 0;
 }
 

--- a/arch/sparc/core/thread.c
+++ b/arch/sparc/core/thread.c
@@ -69,11 +69,16 @@ void *z_arch_get_next_switch_handle(struct k_thread **old_thread)
 #if defined(CONFIG_FPU_SHARING)
 int arch_float_disable(struct k_thread *thread)
 {
+	ARG_UNUSED(thread);
+
 	return -ENOTSUP;
 }
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
+
 	return -ENOTSUP;
 }
 #endif /* CONFIG_FPU_SHARING */

--- a/arch/xtensa/core/thread.c
+++ b/arch/xtensa/core/thread.c
@@ -130,12 +130,15 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 int arch_float_disable(struct k_thread *thread)
 {
+	ARG_UNUSED(thread);
 	/* xtensa always has FPU enabled so cannot be disabled */
 	return -ENOTSUP;
 }
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
 	/* xtensa always has FPU enabled so nothing to do here */
 	return 0;
 }


### PR DESCRIPTION
Use ARG_UNUSED() to mark unused function argument.