### PR TITLE
dts/boards: nordic: Fix some reg issues

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -267,7 +267,7 @@ ipc0: &cpuapp_cpurad_ipc {
 	status = "okay";
 
 	mx25uw63: mx25uw6345g@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "jedec,mspi-nor";
 		status = "disabled";
 		reg = <0>;
 		jedec-id = [c2 84 37];

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
@@ -8,6 +8,8 @@
 #include <nordic/nrf54l15_cpuflpr.dtsi>
 #include "nrf54l15dk_common.dtsi"
 
+/delete-node/ &cpuflpr_sram;
+
 / {
 	model = "Nordic nRF54L15 DK nRF54L15 FLPR MCU";
 	compatible = "nordic,nrf54l15dk_nrf54l15-cpuflpr";
@@ -19,13 +21,16 @@
 		zephyr,flash = &cpuflpr_rram;
 		zephyr,sram = &cpuflpr_sram;
 	};
-};
 
-&cpuflpr_sram {
-	status = "okay";
-	/* size must be increased due to booting from SRAM */
-	reg = <0x20028000 DT_SIZE_K(96)>;
-	ranges = <0x0 0x20028000 0x18000>;
+	cpuflpr_sram: memory@20028000 {
+		compatible = "mmio-sram";
+		/* Size must be increased due to booting from SRAM */
+		reg = <0x20028000 DT_SIZE_K(96)>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges = <0x0 0x20028000 0x18000>;
+		status = "okay";
+	};
 };
 
 &cpuflpr_rram {

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -249,7 +249,7 @@ ipc0: &cpuapp_cpurad_ipc {
 	status = "okay";
 
 	mx25uw63: mx25uw6345g@0 {
-		compatible = "mxicy,mx25u", "jedec,mspi-nor";
+		compatible = "jedec,mspi-nor";
 		status = "disabled";
 		reg = <0>;
 		jedec-id = [c2 84 37];

--- a/dts/arm/nordic/nrf51822_qfaa.dtsi
+++ b/dts/arm/nordic/nrf51822_qfaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf51822-qfaa", "nordic,nrf51822",
-			     "nordic,nrf51", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf51822_qfab.dtsi
+++ b/dts/arm/nordic/nrf51822_qfab.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf51822-qfab", "nordic,nrf51822",
-			     "nordic,nrf51", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf51822_qfac.dtsi
+++ b/dts/arm/nordic/nrf51822_qfac.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf51822-qfac", "nordic,nrf51822",
-			     "nordic,nrf51", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52805_caaa.dtsi
+++ b/dts/arm/nordic/nrf52805_caaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52805-caaa", "nordic,nrf52805",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -180,6 +180,7 @@
 			#io-channel-cells = <1>;
 			zephyr,pm-device-runtime-auto;
 		};
+
 		timer0: timer@40008000 {
 			compatible = "nordic,nrf-timer";
 			status = "disabled";

--- a/dts/arm/nordic/nrf52810_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52810_qfaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52810-qfaa", "nordic,nrf52810",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52811_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52811_qfaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52811-qfaa", "nordic,nrf52811",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52820_qdaa.dtsi
+++ b/dts/arm/nordic/nrf52820_qdaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52820-qdaa", "nordic,nrf52820",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52832_ciaa.dtsi
+++ b/dts/arm/nordic/nrf52832_ciaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52832-ciaa", "nordic,nrf52832",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52832_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52832_qfaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52832-qfaa", "nordic,nrf52832",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52832_qfab.dtsi
+++ b/dts/arm/nordic/nrf52832_qfab.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52832-qfab", "nordic,nrf52832",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52833_qdaa.dtsi
+++ b/dts/arm/nordic/nrf52833_qdaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52833-qdaa", "nordic,nrf52833",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52833_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52833_qiaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52833-qiaa", "nordic,nrf52833",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf52840_qfaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qfaa.dtsi
@@ -17,10 +17,8 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52840-qfaa", "nordic,nrf52840",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
-
 };
 
 /delete-node/ &usbd;

--- a/dts/arm/nordic/nrf52840_qiaa.dtsi
+++ b/dts/arm/nordic/nrf52840_qiaa.dtsi
@@ -26,7 +26,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf52840-qiaa", "nordic,nrf52840",
-			     "nordic,nrf52", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_qkaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf5340-cpuapp-qkaa", "nordic,nrf5340-cpuapp",
-			     "nordic,nrf53", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns_qkaa.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf5340-cpuapp-qkaa", "nordic,nrf5340-cpuapp",
-			     "nordic,nrf53", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet_qkaa.dtsi
@@ -21,7 +21,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf5340-cpunet-qkaa", "nordic,nrf5340-cpunet",
-			     "nordic,nrf53", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9131_laca.dtsi
+++ b/dts/arm/nordic/nrf9131_laca.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9131-laca", "nordic,nrf9120",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9131ns_laca.dtsi
+++ b/dts/arm/nordic/nrf9131ns_laca.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9131-laca", "nordic,nrf9120",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9151_laca.dtsi
+++ b/dts/arm/nordic/nrf9151_laca.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9151-laca", "nordic,nrf9120",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9151ns_laca.dtsi
+++ b/dts/arm/nordic/nrf9151ns_laca.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9151-laca", "nordic,nrf9120",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9160_sica.dtsi
+++ b/dts/arm/nordic/nrf9160_sica.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9160-sica", "nordic,nrf9160",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9160ns_sica.dtsi
+++ b/dts/arm/nordic/nrf9160ns_sica.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9160-sica", "nordic,nrf9160",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9161_laca.dtsi
+++ b/dts/arm/nordic/nrf9161_laca.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9161-laca", "nordic,nrf9120",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/arm/nordic/nrf9161ns_laca.dtsi
+++ b/dts/arm/nordic/nrf9161ns_laca.dtsi
@@ -17,7 +17,6 @@
 
 / {
 	soc {
-		compatible = "nordic,nrf9161-laca", "nordic,nrf9120",
-			     "nordic,nrf91", "simple-bus";
+		compatible = "simple-bus";
 	};
 };

--- a/dts/vendor/nordic/nrf54l09.dtsi
+++ b/dts/vendor/nordic/nrf54l09.dtsi
@@ -111,11 +111,13 @@
 
  #ifdef USE_NON_SECURE_ADDRESS_MAP
 		global_peripherals: peripheral@40000000 {
+			reg = <0x40000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x40000000 0x10000000>;
  #else
 		global_peripherals: peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x50000000 0x10000000>;

--- a/dts/vendor/nordic/nrf54l20.dtsi
+++ b/dts/vendor/nordic/nrf54l20.dtsi
@@ -118,6 +118,7 @@
 		};
 
 		global_peripherals: peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			ranges = <0x0 0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/dts/vendor/nordic/nrf54l_05_10_15.dtsi
+++ b/dts/vendor/nordic/nrf54l_05_10_15.dtsi
@@ -101,11 +101,13 @@
 
 #ifdef USE_NON_SECURE_ADDRESS_MAP
 		global_peripherals: peripheral@40000000 {
+			reg = <0x40000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x40000000 0x10000000>;
 #else
 		global_peripherals: peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x50000000 0x10000000>;

--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -118,6 +118,7 @@
 		};
 
 		global_peripherals: peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			ranges = <0x0 0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
    dts: vendor: nordic: Add missing reg parameters
    
    Adds missing reg parameters to DTS nodes


    boards: nordic: Remove invalid mxicy compatible
    
    This compatible does not exist


    boards: nordic: nrf54l15dk: Fix cpuflpr SRAM address
    
    Fixes the address of this peripheral
