### PR TITLE
llext: Drop unused memory domain member

### DIFF
--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -83,7 +83,6 @@ struct llext {
 
 #ifdef CONFIG_USERSPACE
 	struct k_mem_partition mem_parts[LLEXT_MEM_PARTITIONS];
-	struct k_mem_domain mem_domain;
 #endif
 
 	/** @endcond */

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -747,14 +747,6 @@ int do_llext_load(struct llext_loader *ldr, struct llext *ext,
 		goto out;
 	}
 
-#ifdef CONFIG_USERSPACE
-	ret = k_mem_domain_init(&ext->mem_domain, 0, NULL);
-	if (ret != 0) {
-		LOG_ERR("Failed to initialize extenion memory domain %d", ret);
-		goto out;
-	}
-#endif
-
 	LOG_DBG("Finding ELF tables...");
 	ret = llext_find_tables(ldr, ext);
 	if (ret != 0) {


### PR DESCRIPTION
Not sure why this vestigal struct member was here at this point (18 months ago...) but its unused and was causing problems for certain parts.