### PR TITLE
drivers: adc: nrfx_saadc: Fix SAADC shim for nRF54LV10A

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -283,7 +283,7 @@ static int gain_set(nrf_saadc_channel_config_t *ch_cfg, enum adc_gain gain)
 #endif
 	default:
 #else
-	if (ch_cfg->gain != ADC_GAIN_1) {
+	if (gain != ADC_GAIN_1) {
 #endif /* defined(NRF_SAADC_HAS_CH_GAIN) */
 		LOG_ERR("Selected ADC gain is not valid");
 		return -EINVAL;


### PR DESCRIPTION
GAIN field is not present on LV10A, so instead we need to check the input value to the function.