### PR TITLE
drivers: ieee802154: nrf5: prevent negative timestamps

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1114,8 +1114,12 @@ void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi,
 		nrf5_data.rx_frames[i].lqi = lqi;
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP)
-		nrf5_data.rx_frames[i].time =
-			nrf_802154_timestamp_end_to_phr_convert(time, data[0]);
+		if (time != NRF_802154_NO_TIMESTAMP) {
+			nrf5_data.rx_frames[i].time =
+				nrf_802154_timestamp_end_to_phr_convert(time, data[0]);
+		} else {
+			nrf5_data.rx_frames[i].time = 0;
+		}
 #endif
 
 		nrf5_data.rx_frames[i].ack_fpb = nrf5_data.last_frame_ack_fpb;


### PR DESCRIPTION
The nrf-802154 driver may be unable to acquire a valid timestamp under rare conditions. In such case, the nrf_802154_received_timestamp_raw reports time=NRF_802154_NO_TIMESTAMP.
The shim implementation must not calculate the PHR timestamp when receiving this value, because doing so results in an assert in ptp_packet.h due to a negative time value.
When the driver is unable to capture the timestamp, the packet is assigned zero as its timestamp.