### PR TITLE
drivers: udc_dwc2: Arm control out endpoint in DMA mode

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1753,7 +1753,10 @@ static int udc_dwc2_ep_set_halt(const struct device *dev,
 	if (ep_idx != 0) {
 		cfg->stat.halted = true;
 	} else {
+		struct udc_dwc2_data *const priv = udc_get_private(dev);
+
 		/* Data/Status stage is STALLed, allow receiving next SETUP */
+		priv->pending_dout_feed = 0;
 		dwc2_ensure_setup_ready(dev);
 	}
 
@@ -3320,6 +3323,8 @@ static ALWAYS_INLINE void dwc2_thread_handler(void *const arg)
 	if (evt & BIT(DWC2_DRV_EVT_ENUM_DONE)) {
 		k_event_clear(&priv->drv_evt, BIT(DWC2_DRV_EVT_ENUM_DONE));
 
+		/* Any potential transfer on control IN endpoint is cancelled */
+		priv->pending_dout_feed = 0;
 		dwc2_ensure_setup_ready(dev);
 	}
 


### PR DESCRIPTION
It was observed that device ceases to work in Buffer DMA mode after GET DEVICE QUALIFIER request is STALLed (when USB stack is limited to Full-Speed only operation). The issue is due to missing dout feed.

Clear pending dout feed flag after bus reset (enumeration done) and after stalled control read transfer to allow dout to be feed when necessary.