### PR TITLE
drivers: can: nrf: fix invalid pointer leading to undef behavior

### DIFF
--- a/drivers/can/can_nrf.c
+++ b/drivers/can/can_nrf.c
@@ -147,7 +147,7 @@ static int configure_hsfll(const struct device *dev, bool on)
 	if (on) {
 		int ret;
 
-		ret = clock_control_get_rate(dev, NULL, &spec.frequency);
+		ret = clock_control_get_rate(config->auxpll, NULL, &spec.frequency);
 		if (ret < 0) {
 			return ret;
 		}


### PR DESCRIPTION
The can_nrf device driver incorrectly passes its own device driver pointer to a call to clock_control_get_rate() to get the rate of the auxpll. The actual device driver which should be passed to clock_control_get_rate() is the auxpll.

Without this fix, the call jumps to the can_nrf_api and returns garbage (unfortunately it does not hardfault, which is why this issue has not been discovered yet).