### PR TITLE
script: logging: Fix small bugs and add support for live log parsing from a file

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -112,6 +112,15 @@ Other subsystems
 
 .. zephyr-keep-sorted-start re(^\w)
 
+Logging
+=======
+
+* The UART dictionary log parsing script
+  :zephyr_file:`scripts/logging/dictionary/log_parser_uart.py` has been deprecated. Instead, the
+  more generic script of :zephyr_file:`scripts/logging/dictionary/live_log_parser.py` should be
+  used. The new script supports the same functionality (and more), but requires different command
+  line arguments when invoked.
+
 .. zephyr-keep-sorted-stop
 
 Modules

--- a/scripts/logging/dictionary/dictionary_parser/log_parser.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser.py
@@ -9,6 +9,7 @@ Abstract Class for Dictionary-based Logging Parsers
 """
 
 import abc
+import re
 
 from colorama import Fore
 
@@ -36,13 +37,13 @@ def formalize_fmt_string(fmt_str):
 
     for spec in ['d', 'i', 'o', 'u', 'x', 'X']:
         # Python doesn't support %ll for integer specifiers, so remove extra 'l'
-        new_str = new_str.replace("%ll" + spec, "%l" + spec)
+        new_str = re.sub(r'%(\#?\d*)ll' + spec, r'%\1l' + spec, new_str)
 
         if spec in ['x', 'X']:
-            new_str = new_str.replace("%#ll" + spec, "%#l" + spec)
+            new_str = re.sub(r'%\#(\d*)ll' + spec, r'%#\1l' + spec, new_str)
 
         # Python doesn't support %hh for integer specifiers, so remove extra 'h'
-        new_str = new_str.replace("%hh" + spec, "%h" + spec)
+        new_str = re.sub(r'%(\#?\d*)hh' + spec, r'%\1h' + spec, new_str)
 
     # No %p for pointer either, so use %x
     new_str = new_str.replace("%p", "0x%x")

--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v3.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v3.py
@@ -260,6 +260,20 @@ class LogParserV3(LogParser):
             print(f"{color}%s%s%s|%s{Fore.RESET}" % ((" " * prefix_len),
                   hex_vals, hex_padding, chr_vals))
 
+    def get_full_msg_hdr_size(self):
+        """Get the size of the full message header"""
+        return struct.calcsize(self.fmt_msg_type) + \
+            struct.calcsize(self.fmt_msg_hdr) + \
+            struct.calcsize(self.fmt_msg_timestamp)
+
+    def get_normal_msg_size(self, logdata, offset):
+        """Get the needed size of the normal log message at offset"""
+        _, pkg_len, data_len, _ = struct.unpack_from(
+            self.fmt_msg_hdr,
+            logdata,
+            offset + struct.calcsize(self.fmt_msg_type),
+        )
+        return self.get_full_msg_hdr_size() + pkg_len + data_len
 
     def parse_one_normal_msg(self, logdata, offset):
         """Parse one normal log message and print the encoded message"""
@@ -350,33 +364,54 @@ class LogParserV3(LogParser):
         # Point to next message
         return next_msg_offset
 
+    def parse_one_msg(self, logdata, offset):
+        if offset + struct.calcsize(self.fmt_msg_type) > len(logdata):
+            return False, offset
+
+        # Get message type
+        msg_type = struct.unpack_from(self.fmt_msg_type, logdata, offset)[0]
+
+        if msg_type == MSG_TYPE_DROPPED:
+
+            if offset + struct.calcsize(self.fmt_dropped_cnt) > len(logdata):
+                return False, offset
+
+            offset += struct.calcsize(self.fmt_msg_type)
+
+            num_dropped = struct.unpack_from(self.fmt_dropped_cnt, logdata, offset)
+            offset += struct.calcsize(self.fmt_dropped_cnt)
+
+            print(f"--- {num_dropped} messages dropped ---")
+
+        elif msg_type == MSG_TYPE_NORMAL:
+
+            if ((offset + self.get_full_msg_hdr_size() > len(logdata)) or
+                (offset + self.get_normal_msg_size(logdata, offset) > len(logdata))):
+                return False, offset
+
+            offset += struct.calcsize(self.fmt_msg_type)
+
+            ret = self.parse_one_normal_msg(logdata, offset)
+            if ret is None:
+                raise ValueError("Error parsing normal log message")
+
+            offset = ret
+
+        else:
+            logger.error("------ Unknown message type: %s", msg_type)
+            raise ValueError(f"Unknown message type: {msg_type}")
+
+        return True, offset
 
     def parse_log_data(self, logdata, debug=False):
         """Parse binary log data and print the encoded log messages"""
         offset = 0
+        still_parsing = True
 
-        while offset < len(logdata):
-            # Get message type
-            msg_type = struct.unpack_from(self.fmt_msg_type, logdata, offset)[0]
-            offset += struct.calcsize(self.fmt_msg_type)
+        while offset < len(logdata) and still_parsing:
+            still_parsing, offset = self.parse_one_msg(logdata, offset)
 
-            if msg_type == MSG_TYPE_DROPPED:
-                num_dropped = struct.unpack_from(self.fmt_dropped_cnt, logdata, offset)
-                offset += struct.calcsize(self.fmt_dropped_cnt)
+        return offset
 
-                print(f"--- {num_dropped} messages dropped ---")
-
-            elif msg_type == MSG_TYPE_NORMAL:
-                ret = self.parse_one_normal_msg(logdata, offset)
-                if ret is None:
-                    return False
-
-                offset = ret
-
-            else:
-                logger.error("------ Unknown message type: %s", msg_type)
-                return False
-
-        return True
 
 colorama.init()

--- a/scripts/logging/dictionary/live_log_parser.py
+++ b/scripts/logging/dictionary/live_log_parser.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Log Parser for Dictionary-based Logging
+
+This uses the JSON database file to decode the binary
+log data taken directly from input serialport and print
+the log messages.
+"""
+
+import argparse
+import contextlib
+import logging
+import os
+import select
+import sys
+
+import parserlib
+import serial
+
+LOGGER_FORMAT = "%(message)s"
+logger = logging.getLogger("parser")
+
+
+class SerialReader:
+    """Class to read data from serial port and parse it"""
+
+    def __init__(self, serial_port, baudrate):
+        self.serial_port = serial_port
+        self.baudrate = baudrate
+        self.serial = None
+
+    @contextlib.contextmanager
+    def open(self):
+        try:
+            self.serial = serial.Serial(self.serial_port, self.baudrate)
+            yield
+        finally:
+            self.serial.close()
+
+    def fileno(self):
+        return self.serial.fileno()
+
+    def read_non_blocking(self):
+        size = self.serial.in_waiting
+        return self.serial.read(size)
+
+
+class FileReader:
+    """Class to read data from serial port and parse it"""
+
+    def __init__(self, filepath):
+        self.filepath = filepath
+        self.file = None
+
+    @contextlib.contextmanager
+    def open(self):
+        if self.filepath is not None:
+            with open(self.filepath, 'rb') as f:
+                self.file = f
+                yield
+        else:
+            sys.stdin = os.fdopen(sys.stdin.fileno(), 'rb', 0)
+            self.file = sys.stdin
+            yield
+
+    def fileno(self):
+        return self.file.fileno()
+
+    def read_non_blocking(self):
+        # Read available data using a reasonable buffer size (without buffer size, this blocks
+        # forever, but with buffer size it returns even when less data than the buffer read was
+        # available).
+        return self.file.read(1024)
+
+
+def parse_args():
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+
+    parser.add_argument("dbfile", help="Dictionary Logging Database file")
+    parser.add_argument("--debug", action="store_true", help="Print extra debugging information")
+
+    # Create subparsers for different input modes
+    subparsers = parser.add_subparsers(dest="mode", required=True, help="Input source mode")
+
+    # Serial subparser
+    serial_parser = subparsers.add_parser("serial", help="Read from serial port")
+    serial_parser.add_argument("port", help="Serial port")
+    serial_parser.add_argument("baudrate", type=int, help="Baudrate")
+
+    # File subparser
+    file_parser = subparsers.add_parser("file", help="Read from file")
+    file_parser.add_argument(
+        "filepath", nargs="?", default=None, help="Input file path, leave empty for stdin"
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    """function of serial parser"""
+    args = parse_args()
+
+    if args.dbfile is None or '.json' not in args.dbfile:
+        logger.error("ERROR: invalid log database path: %s, exiting...", args.dbfile)
+        sys.exit(1)
+
+    logging.basicConfig(format=LOGGER_FORMAT)
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    log_parser = parserlib.get_log_parser(args.dbfile, logger)
+
+    data = b''
+
+    if args.mode == "serial":
+        reader = SerialReader(args.port, args.baudrate)
+    elif args.mode == "file":
+        reader = FileReader(args.filepath)
+    else:
+        raise ValueError("Invalid mode selected. Use 'serial' or 'file'.")
+
+    with reader.open():
+        while True:
+            ready, _, _ = select.select([reader], [], [])
+            if ready:
+                data += reader.read_non_blocking()
+                parsed_data_offset = parserlib.parser(data, log_parser, logger)
+                data = data[parsed_data_offset:]
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/logging/dictionary/log_parser.py
+++ b/scripts/logging/dictionary/log_parser.py
@@ -109,12 +109,20 @@ def main():
     else:
         logger.setLevel(logging.INFO)
 
+    log_parser = parserlib.get_log_parser(args.dbfile, logger)
+
     logdata = read_log_file(args)
     if logdata is None:
         logger.error("ERROR: cannot read log from file: %s, exiting...", args.logfile)
         sys.exit(1)
 
-    parserlib.parser(logdata, args.dbfile, logger)
+    parsed_data_offset = parserlib.parser(logdata, log_parser, logger)
+    if parsed_data_offset != len(logdata):
+        logger.error(
+            'ERROR: Not all data was parsed, %d bytes left unparsed',
+            len(logdata) - parsed_data_offset,
+        )
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/scripts/logging/dictionary/log_parser_uart.py
+++ b/scripts/logging/dictionary/log_parser_uart.py
@@ -50,14 +50,18 @@ def main():
     else:
         logger.setLevel(logging.INFO)
 
+    log_parser = parserlib.get_log_parser(args.dbfile, logger)
+
     # Parse the log every second from serial port
+    data = b''
     with serial.Serial(args.serialPort, args.baudrate) as ser:
         ser.timeout = 2
         while True:
             size = ser.inWaiting()
             if size:
-                data = ser.read(size)
-                parserlib.parser(data, args.dbfile, logger)
+                data += ser.read(size)
+                parsed_data_offset = parserlib.parser(data, log_parser, logger)
+                data = data[parsed_data_offset:]
             time.sleep(1)
 
 if __name__ == "__main__":

--- a/scripts/logging/dictionary/log_parser_uart.py
+++ b/scripts/logging/dictionary/log_parser_uart.py
@@ -13,15 +13,10 @@ the log messages.
 """
 
 import argparse
-import logging
 import sys
-import time
 
-import parserlib
-import serial
+import live_log_parser
 
-LOGGER_FORMAT = "%(message)s"
-logger = logging.getLogger("parser")
 
 def parse_args():
     """Parse command line arguments"""
@@ -35,34 +30,31 @@ def parse_args():
 
     return argparser.parse_args()
 
+
 def main():
     """function of serial parser"""
+
+    print("This script is deprecated. Use 'live_log_parser.py' instead.",
+          file=sys.stderr)
+
+    # Convert the arguments to the format expected by live_log_parser, and invoke it directly.
     args = parse_args()
 
-    if args.dbfile is None or '.json' not in args.dbfile:
-        logger.error("ERROR: invalid log database path: %s, exiting...", args.dbfile)
-        sys.exit(1)
-
-    logging.basicConfig(format=LOGGER_FORMAT)
-
+    sys.argv = [
+        'live_log_parser.py',
+        args.dbfile,
+    ]
     if args.debug:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
+        sys.argv.append('--debug')
 
-    log_parser = parserlib.get_log_parser(args.dbfile, logger)
+    sys.argv += [
+        'serial',
+        args.serialPort,
+        args.baudrate
+    ]
 
-    # Parse the log every second from serial port
-    data = b''
-    with serial.Serial(args.serialPort, args.baudrate) as ser:
-        ser.timeout = 2
-        while True:
-            size = ser.inWaiting()
-            if size:
-                data += ser.read(size)
-                parsed_data_offset = parserlib.parser(data, log_parser, logger)
-                data = data[parsed_data_offset:]
-            time.sleep(1)
+    live_log_parser.main()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR contains 3 commits, all changing the log parser scripts.

The first commit add correct support to lengthed short-short and long-long arguments in the log ("%02hhX"). Currently, the log crashes when it tries to parse these valid formats, so this commit fixes this issue.

The second commit updates the current handling of non-full packets. This is an issue that exists when have live parsing of the logs - when the last read packet is not full, the parser would fail, and stop the parsing. This commit updates this handling to correctly handle this case, and keep parsing the packets correctly even when a non-full packet was received over the UART.

The third commit extends the functionality of the log_parser_uart to also support showing live log messages from files (and from stdin), making it possible to use the script with other interfaces than the UART interface.  
This commit changes the file name, and the way it receives arguments - so it breaks backward compatibility of this script - I believe that this is an improvement to the script, and that it can be used by many more developers this way. I can re-work it so it is done in it's own script, if that makes more sense to you.

All the changes I've done are made to create support for these scripts to the project I'm working on, which have zephyr logging over RTT which are read with J-Link. I believe these are universal improvement to the script, which can be utilised by other people working with Zephyr as well.