### PR TITLE
fs: shell: Fix FS shell using fixed storage_partition name instead of DT

### DIFF
--- a/subsys/fs/shell.c
+++ b/subsys/fs/shell.c
@@ -17,9 +17,6 @@
 #include <inttypes.h>
 #include <limits.h>
 
-#define STORAGE_PARTITION    storage_partition
-#define STORAGE_PARTITION_ID FIXED_PARTITION_ID(STORAGE_PARTITION)
-
 #ifdef CONFIG_FILE_SYSTEM_SHELL_MOUNT_COMMAND
 /* FAT */
 #ifdef CONFIG_FAT_FILESYSTEM_ELM
@@ -64,6 +61,15 @@ static struct fs_mount_t littlefs_mnt = {
 };
 #else
 #include <zephyr/storage/flash_map.h>
+
+#define STORAGE_PARTIION_NODE_ID DT_PHANDLE(DT_INST(0, zephyr_fstab_littlefs), partition)
+
+#if DT_FIXED_PARTITION_EXISTS(STORAGE_PARTIION_NODE_ID)
+#define STORAGE_PARTITION_ID DT_FIXED_PARTITION_ID(STORAGE_PARTIION_NODE_ID)
+#else
+#define STORAGE_PARTITION    storage_partition
+#define STORAGE_PARTITION_ID FIXED_PARTITION_ID(STORAGE_PARTITION)
+#endif
 
 FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(lfs_data);
 static struct fs_mount_t littlefs_mnt = {


### PR DESCRIPTION
Fix FS shell using fixed 'storage_partition' nodelabel instead of accessing the DT defined partition from the zephyr,fstab,littlefs node partition property.

Reproduce issue:
```
west build  -b nucleo_h7a3zi_q samples/subsys/fs/littlefs \
-- \
-DCONFIG_FILE_SYSTEM_SHELL=y \
-DCONFIG_SHELL=y \
-DCONFIG_HEAP_MEM_POOL_SIZE=1024
```

Compare these two boards partitions:

nucleo_h7a3zi_q.overlay:
```
/ {
	fstab {
		compatible = "zephyr,fstab";
		lfs1: lfs1 {
			compatible = "zephyr,fstab,littlefs";
			partition = <&lfs1_partition>;
                };
	};
};

&flash0 {
	partitions {
		compatible = "fixed-partitions";
		lfs1_partition: partition@100000 {
			label = "storage";
			reg = <0x100000 DT_SIZE_K(1024)>;
		};
	};
};
```
nucleo_h743zi.overlay
```
/ {
	fstab {
		compatible = "zephyr,fstab";
		lfs1: lfs1 {
			compatible = "zephyr,fstab,littlefs";
			partition = <&storage_partition>;
		};
	};
};

&quadspi {
	mx25l25645g: qspi-nor-flash@90000000 {
		compatible = "st,stm32-qspi-nor";
		partitions {
			   compatible = "fixed-partitions";
			   storage_partition: partition@0 {
			       label = "storage";
			       reg = <0 DT_SIZE_M(8)>;
			   };
		};
	};
};
