### PR TITLE
boards: Remove bootloader-led0 alias

### DIFF
--- a/boards/actinius/icarus/actinius_icarus_common.dtsi
+++ b/boards/actinius/icarus/actinius_icarus_common.dtsi
@@ -75,7 +75,6 @@
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
-		bootloader-led0 = &blue_led;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &blue_led;
 		watchdog0 = &wdt0;

--- a/boards/actinius/icarus_bee/actinius_icarus_bee_common.dtsi
+++ b/boards/actinius/icarus_bee/actinius_icarus_bee_common.dtsi
@@ -75,7 +75,6 @@
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
-		bootloader-led0 = &blue_led;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &blue_led;
 		watchdog0 = &wdt0;

--- a/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_common.dtsi
+++ b/boards/actinius/icarus_som_dk/actinius_icarus_som_dk_common.dtsi
@@ -50,7 +50,6 @@
 		pwm-led0 = &blue_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
-		bootloader-led0 = &blue_led;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &blue_led;
 		watchdog0 = &wdt0;

--- a/boards/ambiq/apollo3_evb/apollo3_evb.dts
+++ b/boards/ambiq/apollo3_evb/apollo3_evb.dts
@@ -28,7 +28,6 @@
 		led2 = &led2;
 		sw0 = &button0;
 		sw1 = &button1;
-		bootloader-led0 = &led0;
 		mcuboot-led0 = &led0;
 	};
 

--- a/boards/circuitdojo/feather/circuitdojo_feather_nrf9160_common.dtsi
+++ b/boards/circuitdojo/feather/circuitdojo_feather_nrf9160_common.dtsi
@@ -44,7 +44,6 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &blue_led;
-		bootloader-led0 = &blue_led;
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		mcuboot-button0 = &button0;

--- a/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.dts
+++ b/boards/croxel/croxel_cx1825/croxel_cx1825_nrf52840.dts
@@ -45,7 +45,6 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/ct/ctcc/ctcc_nrf9161_common.dtsi
+++ b/boards/ct/ctcc/ctcc_nrf9161_common.dtsi
@@ -33,7 +33,6 @@
 		led0 = &led1;
 		led1 = &led2;
 		mcuboot-led0 = &led1;
-		bootloader-led0 = &led1;
 		watchdog0 = &wdt0;
 		spi-flash0 = &mx25r6435;
 	};

--- a/boards/ebyte/e73_tbb/ebyte_e73_tbb_nrf52832.dts
+++ b/boards/ebyte/e73_tbb/ebyte_e73_tbb_nrf52832.dts
@@ -66,7 +66,7 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
-		bootloader-led0 = &led0;
+		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
 	};
 };

--- a/boards/google/twinkie_v2/google_twinkie_v2.dts
+++ b/boards/google/twinkie_v2/google_twinkie_v2.dts
@@ -80,7 +80,6 @@
 		led0 = &red_led_0;
 		led1 = &green_led_1;
 		led2 = &blue_led_2;
-		bootloader-led0 = &blue_led_2;
 		vcc1 = &cc1_buf;
 		vcc2 = &cc2_buf;
 		vbus = &vbus_read_buf;

--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
@@ -148,7 +148,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf51dk/nrf51dk_nrf51822.dts
+++ b/boards/nordic/nrf51dk/nrf51dk_nrf51822.dts
@@ -95,7 +95,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52820.dts
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52820.dts
@@ -95,7 +95,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
@@ -125,7 +125,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52811.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52811.dts
@@ -95,7 +95,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
@@ -135,7 +135,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52805.dts
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52805.dts
@@ -86,7 +86,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52810.dts
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52810.dts
@@ -88,7 +88,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
@@ -136,7 +136,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf5340dk/nrf5340dk_common.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340dk_common.dtsi
@@ -96,7 +96,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 	};

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -112,7 +112,6 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
@@ -101,7 +101,6 @@
 		led1 = &led1;
 		sw0 = &button0;
 		sw1 = &button1;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_common.dtsi
+++ b/boards/nordic/nrf9131ek/nrf9131ek_nrf9131_common.dtsi
@@ -70,7 +70,6 @@
 		pwm-led1 = &pwm_led1;
 		pwm-led2 = &pwm_led2;
 		sw0 = &button0;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common.dtsi
+++ b/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common.dtsi
@@ -133,7 +133,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common.dtsi
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common.dtsi
@@ -160,7 +160,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common.dtsi
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common.dtsi
@@ -133,7 +133,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_common.dts
+++ b/boards/others/promicro_nrf52840/promicro_nrf52840_nrf52840_common.dts
@@ -41,7 +41,6 @@
 		led0 = &led0;
 		pwm-led0 = &red_pwm_led;
 		red-pwm-led = &red_pwm_led;
-		bootloader-led0 = &led0;
 		mcuboot-led0 = &led0;
 		spi = &spi2;
 		watchdog0 = &wdt0;

--- a/boards/panasonic/pan1770_evb/pan1770_evb.dts
+++ b/boards/panasonic/pan1770_evb/pan1770_evb.dts
@@ -128,7 +128,7 @@
 		sw1 = &evb_sw2;
 		sw2 = &evb_sw3;
 		sw3 = &evb_sw4;
-		bootloader-led0 = &evb_led1;
+		mcuboot-led0 = &evb_led1;
 		watchdog0 = &wdt0;
 	};
 };

--- a/boards/panasonic/pan1780_evb/pan1780_evb.dts
+++ b/boards/panasonic/pan1780_evb/pan1780_evb.dts
@@ -128,7 +128,7 @@
 		sw1 = &evb_sw2;
 		sw2 = &evb_sw3;
 		sw3 = &evb_sw4;
-		bootloader-led0 = &evb_led1;
+		mcuboot-led0 = &evb_led1;
 		watchdog0 = &wdt0;
 	};
 };

--- a/boards/panasonic/pan1782_evb/pan1782_evb.dts
+++ b/boards/panasonic/pan1782_evb/pan1782_evb.dts
@@ -89,7 +89,7 @@
 		pwm-led0 = &pwm_evb_led1;
 		sw0 = &evb_sw1;
 		sw1 = &evb_sw2;
-		bootloader-led0 = &evb_led1;
+		mcuboot-led0 = &evb_led1;
 		watchdog0 = &wdt0;
 	};
 };

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
@@ -152,7 +152,6 @@
 		sw1 = &evb_sw2;
 		sw2 = &evb_sw3;
 		sw3 = &evb_sw4;
-		bootloader-led0 = &evb_led1;
 		mcuboot-button0 = &evb_sw1;
 		mcuboot-led0 = &evb_led1;
 		watchdog0 = &wdt0;

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
@@ -125,7 +125,6 @@
 		sw1 = &evb_sw2;
 		sw2 = &evb_sw3;
 		sw3 = &evb_sw4;
-		bootloader-led0 = &evb_led1;
 		mcuboot-button0 = &evb_sw1;
 		mcuboot-led0 = &evb_led1;
 		watchdog0 = &wdt0;

--- a/boards/rakwireless/rak11720/rak11720.dts
+++ b/boards/rakwireless/rak11720/rak11720.dts
@@ -32,7 +32,6 @@
 		led0 = &blue_led;
 		led1 = &green_led;
 		lora0 = &lora;
-		bootloader-led0 = &blue_led;
 		mcuboot-led0 = &blue_led;
 	};
 

--- a/boards/raytac/an7002q_db/nrf5340_cpuapp_common.dtsi
+++ b/boards/raytac/an7002q_db/nrf5340_cpuapp_common.dtsi
@@ -73,7 +73,6 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/raytac/an7002q_db/raytac_an7002q_db_nrf5340_cpunet.dts
+++ b/boards/raytac/an7002q_db/raytac_an7002q_db_nrf5340_cpunet.dts
@@ -73,7 +73,6 @@
 		led1 = &led1;
 		sw0 = &button0;
 		sw1 = &button1;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/raytac/mdbt50q_db_33/raytac_mdbt50q_db_33_nrf52833.dts
+++ b/boards/raytac/mdbt50q_db_33/raytac_mdbt50q_db_33_nrf52833.dts
@@ -82,7 +82,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/raytac/mdbt50q_db_40/raytac_mdbt50q_db_40_nrf52840.dts
+++ b/boards/raytac/mdbt50q_db_40/raytac_mdbt50q_db_40_nrf52840.dts
@@ -80,7 +80,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_common.dts
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_common.dts
@@ -89,7 +89,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
@@ -68,7 +68,6 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/seeed/xiao_ble/xiao_ble_common.dtsi
+++ b/boards/seeed/xiao_ble/xiao_ble_common.dtsi
@@ -44,7 +44,6 @@
 		led1 = &led1;
 		led2 = &led2;
 		pwm-led0 = &pwm_led0;
-		bootloader-led0 = &led0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
 	};

--- a/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_common.dtsi
+++ b/boards/sparkfun/thing_plus/sparkfun_thing_plus_nrf9160_common.dtsi
@@ -52,7 +52,6 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &blue_led;
-		bootloader-led0 = &blue_led;
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		mcuboot-button0 = &button0;

--- a/boards/u-blox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts
+++ b/boards/u-blox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts
@@ -126,7 +126,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/u-blox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts
+++ b/boards/u-blox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts
@@ -126,7 +126,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
+++ b/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
@@ -135,7 +135,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/u-blox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts
+++ b/boards/u-blox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts
@@ -126,7 +126,6 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/we/ophelia1ev/we_ophelia1ev_nrf52805.dts
+++ b/boards/we/ophelia1ev/we_ophelia1ev_nrf52805.dts
@@ -50,7 +50,6 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
-		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;

--- a/boards/we/proteus2ev/we_proteus2ev_nrf52832.dts
+++ b/boards/we/proteus2ev/we_proteus2ev_nrf52832.dts
@@ -47,7 +47,7 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
-		bootloader-led0 = &led0;
+		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
 	};
 };

--- a/boards/we/proteus3ev/we_proteus3ev_nrf52840.dts
+++ b/boards/we/proteus3ev/we_proteus3ev_nrf52840.dts
@@ -46,7 +46,7 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
-		bootloader-led0 = &led0;
+		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
 	};
 };


### PR DESCRIPTION
This alias has been removed from MCUboot, remove references to it