### PR TITLE
pm: Fix to prevent incorrect forever timeout

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -199,8 +199,12 @@ bool pm_system_suspend(int32_t kernel_ticks)
 		/*
 		 * We need to set the timer to interrupt a little bit early to
 		 * accommodate the time required by the CPU to fully wake up.
+		 *
+		 * Since K_TICKS_FOREVER is defined as -1, ensure that -1
+		 * is not passed as the next timeout.
+		 *
 		 */
-		sys_clock_set_timeout(ticks - exit_latency_ticks, true);
+		sys_clock_set_timeout(MAX(0, ticks - exit_latency_ticks), true);
 	}
 
 	/*


### PR DESCRIPTION
K_TICKS_FOREVER is defined as -1. Guard logic has been added for the case when `ticks - exit_latency_ticks == -1` to prevent sys_clock_set_timeout() from incorrectly setting a forever timeout.