### PR TITLE
tests: drivers: Add AT25XV021A Flash Device to Build Test Cases

### DIFF
--- a/tests/drivers/build_all/flash/spi.dtsi
+++ b/tests/drivers/build_all/flash/spi.dtsi
@@ -24,3 +24,15 @@ spi-nor@1 {
 	size = <1048576>;
 	jedec-id = [00 11 22];
 };
+
+at25xv021a@2 {
+	compatible = "atmel,at25xv021a";
+	reg = <0x2>;
+	status = "okay";
+	spi-max-frequency = <5000000>;
+	jedec-id = [00 11 22];
+	size = <262144>;
+	page_size = <1>;
+	timeout = <1>;
+	timeout-erase = <1>;
+};


### PR DESCRIPTION
Depends on in-progress pull request #92980 adding support for AT25XV021A driver. Dummy values mirror at45 and spi-nor implementation.