### PR TITLE
doc: migration: 4.2: typo: NET_REQUEST_ETHERNET_GET_QAV_PARAM used twice

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -562,7 +562,7 @@ Networking
   event types as those are now ``uint64_t`` and the socket option expects a normal 32 bit
   integer value. Because of this, a new ``SO_NET_MGMT_ETHERNET_SET_QAV_PARAM``
   and ``SO_NET_MGMT_ETHERNET_GET_QAV_PARAM`` socket options are created that will replace
-  the previously used ``NET_REQUEST_ETHERNET_GET_QAV_PARAM`` and
+  the previously used ``NET_REQUEST_ETHERNET_SET_QAV_PARAM`` and
   ``NET_REQUEST_ETHERNET_GET_QAV_PARAM`` options.
 
 * The DNS server resolver configuration functions :c:func:`dns_resolve_reconfigure` and


### PR DESCRIPTION
The migration guide mentions NET_REQUEST_ETHERNET_GET_QAV_PARAM twice in a row. One instance should be NET_REQUEST_ETHERNET_SET_QAV_PARAM.