### PR TITLE
shields: nucleo_iks01a1: add accel0 alias

### DIFF
--- a/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
+++ b/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
@@ -4,6 +4,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+/ {
+	aliases {
+		accel0 = &lsm6ds0_x_nucleo_iks01a1;
+	};
+};
 
 &arduino_i2c {
 


### PR DESCRIPTION
Add alias for accel0 to make it work with various samples we have that
rely on the alias.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
