### PR TITLE
fs/littlefs: clarify and validate storage_dev type as flash_area ID

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -87,6 +87,10 @@ enum {
 
 /**
  * @brief File system mount info structure
+ *
+ * For LittleFS, storage_dev must be a flash area ID cast to void*:
+ *     (void *)FIXED_PARTITION_ID(storage)
+ * NOT a pointer to a device.
  */
 struct fs_mount_t {
 	/** Entry for the fs_mount_list list */


### PR DESCRIPTION
This patch improves safety and clarity for the `.storage_dev` field in `fs_mount_t` when using the LittleFS backend.

Historically, `.storage_dev` is declared as a `void *`, and the LittleFS code path converts it via `POINTER_TO_UINT()` into a flash area ID (uint8_t), but many users mistakenly pass a `struct device *` pointer instead.

This patch adds:
- A runtime check to warn if the casted pointer exceeds valid ID range
- A static assertion in the documentation
- Cast-macros to make usage more explicit