### PR TITLE
dts/boards: nordic: Fix reg and ranges property issues

### DIFF
--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-memory_map.dtsi
@@ -7,6 +7,7 @@
 
 / {
 	reserved-memory {
+		ranges;
 		/* The first 64kb are reserved for SecDom.
 		 * The next 4kb are reserved for IPC between SecDom and Cellcore.
 		 */

--- a/dts/arm/nordic/nrf91.dtsi
+++ b/dts/arm/nordic/nrf91.dtsi
@@ -39,6 +39,7 @@
 		};
 
 		peripheral@50000000 {
+			reg = <0x50000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x50000000 0x10000000>;

--- a/dts/arm/nordic/nrf91_ns.dtsi
+++ b/dts/arm/nordic/nrf91_ns.dtsi
@@ -40,6 +40,7 @@
 		};
 
 		peripheral@40000000 {
+			reg = <0x40000000 0x10000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x40000000 0x10000000>;

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -165,6 +165,7 @@
 		};
 
 		cpuapp_peripherals: peripheral@52000000 {
+			reg = <0x52000000 0x1000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x52000000 0x1000000>;
@@ -388,6 +389,7 @@
 		};
 
 		global_peripherals: peripheral@5f000000 {
+			reg = <0x5f000000 0x1000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			ranges = <0x0 0x5f000000 0x1000000>;

--- a/dts/vendor/nordic/nrf9280.dtsi
+++ b/dts/vendor/nordic/nrf9280.dtsi
@@ -392,7 +392,8 @@
 			reg = <0x5f000000 0x1000000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x5f000000 0x1000000>;
+			ranges = <0x0 0x5f000000 0x1000000
+				0x2f700000 0x2f700000 0x40000>;
 
 			usbhs: usbhs@86000 {
 				compatible = "nordic,nrf-usbhs", "snps,dwc2";


### PR DESCRIPTION
dts/boards: nordic: fix register properties
Add missing reg property to peripherals.



boards: nordic: nrf9280pdk: add ranges to reserved  memory
 Add missing "ranges".

boards: nordic: nrf9280pdk: remove /delete-node line   
 Remove `/delete-node/ ipc-1-3;` as this has no effect on the context.
