### PR TITLE
drivers: nrf: add build asserts for memory-regions property

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -711,5 +711,7 @@ static DEVICE_API(adc, adc_nrfx_driver_api) = {
 /* Validate configuration of all channels. */
 DT_FOREACH_CHILD(DT_DRV_INST(0), VALIDATE_CHANNEL_CONFIG)
 
+NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(DT_DRV_INST(0));
+
 DEVICE_DT_INST_DEFINE(0, init_saadc, NULL, NULL, NULL, POST_KERNEL,
 		      CONFIG_ADC_INIT_PRIORITY, &adc_nrfx_driver_api);

--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -730,6 +730,7 @@ static const struct _dmic_ops dmic_ops = {
 		.clk_src = PDM_CLK_SRC(idx),				     \
 		.mem_reg = DMM_DEV_TO_REG(PDM(idx)),			     \
 	};								     \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(PDM(idx));	     \
 	BUILD_ASSERT(PDM_CLK_SRC(idx) != ACLK ||			     \
 		     NRF_PDM_HAS_SELECTABLE_CLOCK,			     \
 		"Clock source ACLK is not available.");			     \

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -253,6 +253,7 @@ static DEVICE_API(i2c, i2c_nrfx_twim_driver_api) = {
 
 #define I2C_NRFX_TWIM_DEVICE(idx)					       \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(I2C(idx));			       \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(I2C(idx));	       \
 	BUILD_ASSERT(I2C_FREQUENCY(idx) !=				       \
 		     I2C_NRFX_TWIM_INVALID_FREQUENCY,			       \
 		     "Wrong I2C " #idx " frequency setting in dts");	       \

--- a/drivers/i2c/i2c_nrfx_twim_rtio.c
+++ b/drivers/i2c/i2c_nrfx_twim_rtio.c
@@ -254,6 +254,7 @@ static int i2c_nrfx_twim_rtio_deinit(const struct device *dev)
 
 #define I2C_NRFX_TWIM_RTIO_DEVICE(idx)                                                             \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(I2C(idx));                                             \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(I2C(idx));                                   \
 	BUILD_ASSERT(I2C_FREQUENCY(idx) != I2C_NRFX_TWIM_INVALID_FREQUENCY,                        \
 		     "Wrong I2C " #idx " frequency setting in dts");                               \
 	static void irq_connect##idx(void)                                                         \

--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -325,6 +325,7 @@ static int shim_nrf_twis_deinit(const struct device *dev)
 	_CONCAT_4(shim_nrf_twis_, name, _, id)
 
 #define SHIM_NRF_TWIS_DEVICE_DEFINE(id)								\
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(SHIM_NRF_TWIS_NODE(id));			\
 	static void SHIM_NRF_TWIS_NAME(id, irq_connect)(void)					\
 	{											\
 		IRQ_CONNECT(									\

--- a/drivers/i2s/i2s_nrf_tdm.c
+++ b/drivers/i2s/i2s_nrf_tdm.c
@@ -1192,6 +1192,7 @@ static DEVICE_API(i2s, tdm_nrf_drv_api) = {
 	BUILD_ASSERT((TDM_SCK_CLK_SRC(idx) != ACLK && TDM_MCK_CLK_SRC(idx) != ACLK) ||             \
 			     DT_NODE_HAS_STATUS_OKAY(NODE_ACLK),                                   \
 		     "Clock source ACLK requires the audiopll node.");                             \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(TDM(idx));                                   \
 	DEVICE_DT_DEFINE(TDM(idx), tdm_nrf_init##idx, NULL, &tdm_nrf_data##idx, &tdm_nrf_cfg##idx, \
 			 POST_KERNEL, CONFIG_I2S_INIT_PRIORITY, &tdm_nrf_drv_api);
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -496,6 +496,7 @@ static int pwm_nrfx_init(const struct device *dev)
 
 #define PWM_NRFX_DEVICE(idx)						      \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(PWM(idx));			      \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(PWM(idx));	      \
 	static struct pwm_nrfx_data pwm_nrfx_##idx##_data;		      \
 	static uint16_t pwm_##idx##_seq_values[NRF_PWM_CHANNEL_COUNT]	      \
 			PWM_MEMORY_SECTION(idx);			      \

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2632,6 +2632,7 @@ static int uarte_instance_init(const struct device *dev,
 
 #define UART_NRF_UARTE_DEVICE(idx)					       \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(UARTE(idx));		       \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(UARTE(idx));	       \
 	UARTE_INT_DRIVEN(idx);						       \
 	PINCTRL_DT_DEFINE(UARTE(idx));					       \
 	IF_ENABLED(CONFIG_UART_##idx##_ASYNC, (				       \

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -830,6 +830,7 @@ static int spi_nrfx_deinit(const struct device *dev)
 
 #define SPI_NRFX_SPIM_DEFINE(idx)					       \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(SPIM(idx));			       \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(SPIM(idx));	       \
 	static void irq_connect##idx(void)				       \
 	{								       \
 		IRQ_CONNECT(DT_IRQN(SPIM(idx)), DT_IRQ(SPIM(idx), priority),   \

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -496,6 +496,7 @@ static int spi_nrfx_init(const struct device *dev)
 #define SPIS_PROP(idx, prop) DT_PROP(SPIS(idx), prop)
 
 #define SPI_NRFX_SPIS_DEFINE(idx)					       \
+	NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(SPIS(idx));	       \
 	static void irq_connect##idx(void)				       \
 	{								       \
 		IRQ_CONNECT(DT_IRQN(SPIS(idx)), DT_IRQ(SPIS(idx), priority),   \

--- a/samples/boards/nordic/clock_control/configs/uart135.overlay
+++ b/samples/boards/nordic/clock_control/configs/uart135.overlay
@@ -12,4 +12,5 @@
 
 &uart135 {
 	status = "okay";
+	memory-regions = <&cpuapp_dma_region>;
 };

--- a/soc/nordic/common/soc_nrf_common.h
+++ b/soc/nordic/common/soc_nrf_common.h
@@ -236,6 +236,19 @@
 		     DT_PINCTRL_HAS_NAME(node_id, sleep),		       \
 		     DT_NODE_PATH(node_id) " defined without sleep state")
 
+/**
+ * Error out the build if CONFIG_HAS_NORDIC_DMM=y and memory-regions property is not defined
+ * or the status of the selected memory region is not "okay"
+ *
+ * @param node Devicetree node.
+ */
+#define NRF_DT_CHECK_NODE_HAS_REQUIRED_MEMORY_REGIONS(node_id)					 \
+	IF_ENABLED(CONFIG_HAS_NORDIC_DMM,							 \
+		(BUILD_ASSERT((									 \
+			DT_NODE_HAS_PROP(node_id, memory_regions) &&				 \
+			DT_NODE_HAS_STATUS_OKAY(DT_PHANDLE_BY_IDX(node_id, memory_regions, 0))), \
+		DT_NODE_PATH(node_id) " defined without memory regions")))
+
 /** @brief Get clock frequency that is used for the given node.
  *
  * Macro checks if node has clock property and if yes then if clock has clock_frequency property


### PR DESCRIPTION
Add build asserts for "memory-regions" property in nrf drivers which is required on targets with DMM for saadc, pdm, pwm, twim, twim_rtio, twis, tdm, uarte, spim and spis. On targets where the property is not required the assertion macro expands to nothing.