### PR TITLE
shell: exchange k_poll for k_event

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -900,11 +900,10 @@ union shell_backend_ctx {
 };
 
 enum shell_signal {
-	SHELL_SIGNAL_RXRDY,
-	SHELL_SIGNAL_LOG_MSG,
-	SHELL_SIGNAL_KILL,
-	SHELL_SIGNAL_TXDONE, /* TXDONE must be last one before SHELL_SIGNALS */
-	SHELL_SIGNALS
+	SHELL_SIGNAL_RXRDY = BIT(0),
+	SHELL_SIGNAL_LOG_MSG = BIT(1),
+	SHELL_SIGNAL_KILL = BIT(2),
+	SHELL_SIGNAL_TXDONE = BIT(3),
 };
 
 /**
@@ -962,12 +961,7 @@ struct shell_ctx {
 	volatile union shell_backend_cfg cfg;
 	volatile union shell_backend_ctx ctx;
 
-	struct k_poll_signal signals[SHELL_SIGNALS];
-
-	/** Events that should be used only internally by shell thread.
-	 * Event for SHELL_SIGNAL_TXDONE is initialized but unused.
-	 */
-	struct k_poll_event events[SHELL_SIGNALS];
+	struct k_event signal_event;
 
 	struct k_mutex wr_mtx;
 	k_tid_t tid;

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -8,7 +8,7 @@
 menuconfig SHELL
 	bool "Shell"
 	imply LOG_RUNTIME_FILTERING
-	select POLL
+	select EVENTS
 
 if SHELL
 

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -232,7 +232,6 @@ static void process(const struct log_backend *const backend,
 	const struct log_output *log_output = log_backend->log_output;
 	bool colors = IS_ENABLED(CONFIG_SHELL_VT100_COLORS) &&
 			z_flag_use_colors_get(sh);
-	struct k_poll_signal *signal;
 
 	switch (sh->log_backend->control_block->state) {
 	case SHELL_LOG_BACKEND_ENABLED:
@@ -241,8 +240,8 @@ static void process(const struct log_backend *const backend,
 		} else {
 			if (copy_to_pbuffer(mpsc_buffer, msg, log_backend->timeout)) {
 				if (IS_ENABLED(CONFIG_MULTITHREADING)) {
-					signal = &sh->ctx->signals[SHELL_SIGNAL_LOG_MSG];
-					k_poll_signal_raise(signal, 0);
+					k_event_post(&sh->ctx->signal_event,
+						     SHELL_SIGNAL_LOG_MSG);
 				}
 			} else {
 				dropped(backend, 1);

--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -432,14 +432,8 @@ static void shell_pend_on_txdone(const struct shell *sh)
 {
 	if (IS_ENABLED(CONFIG_MULTITHREADING) &&
 	    (sh->ctx->state < SHELL_STATE_PANIC_MODE_ACTIVE)) {
-		struct k_poll_event event;
-
-		k_poll_event_init(&event,
-				  K_POLL_TYPE_SIGNAL,
-				  K_POLL_MODE_NOTIFY_ONLY,
-				  &sh->ctx->signals[SHELL_SIGNAL_TXDONE]);
-		k_poll(&event, 1, K_FOREVER);
-		k_poll_signal_reset(&sh->ctx->signals[SHELL_SIGNAL_TXDONE]);
+		k_event_wait(&sh->ctx->signal_event, SHELL_SIGNAL_TXDONE, false, K_FOREVER);
+		k_event_clear(&sh->ctx->signal_event, SHELL_SIGNAL_TXDONE);
 	} else {
 		/* Blocking wait in case of bare metal. */
 		while (!z_flag_tx_rdy_get(sh)) {


### PR DESCRIPTION
The shell subsystem currently uses k_poll for signalling. However, k_poll is only used for simple event signals, results are not used.

Replacing the k_poll with k_event greatly simplifies the code, and saves 4 struct k_poll_signal and 4 struct k_poll_event (one of which was entirely unused) while costing a single struct k_event, for every shell instance. It also allows us to not select POLL, as we are using the simpler EVENTS instead.

A quick test build of the shell test suite on an nrf54l15 produces the following build info:

using EVENTS:

           FLASH:       71592 B      1428 KB      4.90%
             RAM:        9872 B       188 KB      5.13%
        IDT_LIST:          0 GB        32 KB      0.00%

using POLL

           FLASH:       75524 B      1428 KB      5.16%
             RAM:       11224 B       188 KB      5.83%
        IDT_LIST:          0 GB        32 KB      0.00%