### PR TITLE
drivers: sam0: dac: add sam0 dac support to samc21 processors

### DIFF
--- a/drivers/dac/dac_sam0.c
+++ b/drivers/dac/dac_sam0.c
@@ -100,16 +100,26 @@ static int dac_sam0_init(const struct device *dev)
 
 	/* Reset then configure the DAC */
 	regs->CTRLA.bit.SWRST = 1;
+#if defined(DAC_STATUS_SYNCBUSY)
 	while (regs->STATUS.bit.SYNCBUSY) {
 	}
+#else
+	while (regs->SYNCBUSY.bit.SWRST) {
+	}
+#endif
 
 	regs->CTRLB.bit.REFSEL = cfg->refsel;
 	regs->CTRLB.bit.EOEN = 1;
 
 	/* Enable */
 	regs->CTRLA.bit.ENABLE = 1;
+#if defined(DAC_STATUS_SYNCBUSY)
 	while (regs->STATUS.bit.SYNCBUSY) {
 	}
+#else
+	while (regs->SYNCBUSY.bit.ENABLE) {
+	}
+#endif
 
 	return 0;
 }

--- a/dts/arm/atmel/samc21.dtsi
+++ b/dts/arm/atmel/samc21.dtsi
@@ -83,5 +83,18 @@
 			bosch,mram-cfg = <0x0 28 8 3 3 0 1 1>;
 			divider = <1>;
 		};
+
+		dac: dac@42005400 {
+			compatible = "atmel,sam0-dac";
+			reg = <0x42005400 0x10>;
+			interrupts = <28 0>;
+			status = "disabled";
+
+			#io-channel-cells = <0>;
+			clocks = <&gclk 36>, <&mclk 0x1c 21>;
+			clock-names = "GCLK", "MCLK";
+			atmel,assigned-clocks = <&gclk 0>;
+			atmel,assigned-clock-names = "GCLK";
+		};
 	};
 };


### PR DESCRIPTION
See previous work at #26649

The SAMC21 peripheral is a newer revision (0x201) which breaks the SYNCBUSY bits out into their own register.

This commit enables DAC support for SAMC21 parts. I have tested it using a custom board.

I would enable it for the `samc21n_xpro` board, but I don't have one to run tests on.