### PR TITLE
LPIT Support on Zephyr

### DIFF
--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -256,7 +256,25 @@ static int mcux_ccm_get_subsys_rate(const struct device *dev,
 		clock_root = kCLOCK_Root_Bus + instance;
 		break;
 #endif
-
+#ifdef CONFIG_COUNTER_MCUX_LPIT
+#if defined(CONFIG_SOC_SERIES_IMXRT118X)
+	case IMX_CCM_LPIT_CLK:
+		switch (instance) {
+		case 0:
+			clock_root = kCLOCK_Root_Bus_Aon;
+			break;
+		case 1:
+			clock_root = kCLOCK_Root_Bus_Wakeup;
+			break;
+		case 2:
+			clock_root = kCLOCK_Root_Lpit3;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+#endif
+#endif
 #ifdef CONFIG_ADC_MCUX_LPADC
 	case IMX_CCM_LPADC1_CLK:
 		clock_root = kCLOCK_Root_Adc1 + instance;

--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -33,6 +33,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_SNVS           counter_mcux_snv
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_TPM            counter_mcux_tpm.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_XEC                 counter_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPTMR          counter_mcux_lptmr.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPIT           counter_mcux_lpit.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MAXIM_DS3231        maxim_ds3231.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NATIVE_SIM          counter_native_sim.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE                   counter_handlers.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -70,6 +70,8 @@ source "drivers/counter/Kconfig.xec"
 
 source "drivers/counter/Kconfig.mcux_lptmr"
 
+source "drivers/counter/Kconfig.mcux_lpit"
+
 source "drivers/counter/Kconfig.maxim_ds3231"
 
 source "drivers/counter/Kconfig.native_sim"

--- a/drivers/counter/Kconfig.mcux_lpit
+++ b/drivers/counter/Kconfig.mcux_lpit
@@ -1,0 +1,11 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+# MCUXpresso SDK Low Power Periodic Interrupt Timer (LPIT)
+config COUNTER_MCUX_LPIT
+	bool "NXP LPIT driver"
+	default y
+	depends on DT_HAS_NXP_LPIT_CHANNEL_ENABLED && \
+			DT_HAS_NXP_LPIT_ENABLED
+	help
+	  Enable support for the NXP Low Power Periodic Interrupt Timer (LPIT).

--- a/drivers/counter/counter_mcux_lpit.c
+++ b/drivers/counter/counter_mcux_lpit.c
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2023, 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_lpit
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
+#include <fsl_lpit.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(counter_lpit, CONFIG_COUNTER_LOG_LEVEL);
+
+/* Device holds a pointer to pointer to data */
+#define LPIT_CHANNEL_DATA(dev) (*(struct mcux_lpit_channel_data *const *const)dev->data)
+
+/* dev->config->data is an array of data pointers ordered by channel number,
+ * dev->data is a pointer to one of these pointers in that array,
+ * so the value of the dev->data - dev->config->data is the channel index
+ */
+#define LPIT_CHANNEL_ID(dev)                                                                       \
+	(((struct mcux_lpit_channel_data *const *)dev->data) -                                     \
+	 ((const struct mcux_lpit_config *)dev->config)->data)
+
+struct mcux_lpit_channel_data {
+	uint32_t top;                        /* Top value of the counter */
+	counter_top_callback_t top_callback; /* Callback when counter turns around */
+	void *top_user_data;                 /* User data for top callback */
+};
+
+struct mcux_lpit_config {
+	struct counter_config_info info;
+	LPIT_Type *base;           /* Poniter to LPIT peripheral instance base address*/
+	lpit_config_t lpit_config; /* LPIT configuration structure */
+	int num_channels;          /* Number of channels for one LPIT instance*/
+	void (*irq_config_func)(const struct device *dev);
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+	/* Point to array of channels data for this LPIT instance */
+	struct mcux_lpit_channel_data *const *data;
+	/* Point to array of channel devices for this LPIT instance */
+	const struct device *const *channels;
+};
+
+static uint32_t mcux_lpit_get_top_value(const struct device *dev)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
+
+	/*
+	 * The underlying HAL driver function LPIT_SetTimerPeriod()
+	 * automatically subtracted 1 from the value that ends up in
+	 * TVAL so for reporting purposes we need to add it back in
+	 * here to by consistent.
+	 */
+	return (config->base->CHANNEL[channel_id].TVAL + 1U);
+}
+
+static int mcux_lpit_start(const struct device *dev)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
+
+	LOG_DBG("period is %d", mcux_lpit_get_top_value(dev));
+	LPIT_EnableInterrupts(config->base, (1U << channel_id));
+	LPIT_StartTimer(config->base, channel_id);
+	return 0;
+}
+
+static int mcux_lpit_stop(const struct device *dev)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
+
+	LPIT_DisableInterrupts(config->base, channel_id);
+	LPIT_StopTimer(config->base, channel_id);
+	return 0;
+}
+
+static int mcux_lpit_get_value(const struct device *dev, uint32_t *ticks)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
+
+	*ticks = LPIT_GetCurrentTimerCount(config->base, channel_id);
+
+	return 0;
+}
+
+static int mcux_lpit_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	struct mcux_lpit_channel_data *data = LPIT_CHANNEL_DATA(dev);
+	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
+
+	/* Note: The underlying HAL driver function LPIT_SetTimerPeriod() assert(ticks > 2U) */
+	if (cfg->ticks < 2U || cfg->ticks > config->info.max_top_value) {
+		return -EINVAL;
+	}
+
+	data->top_callback = cfg->callback;
+	data->top_user_data = cfg->user_data;
+
+	if ((config->base->CHANNEL[channel_id].TCTRL & LPIT_TCTRL_T_EN_MASK) != 0) {
+		/* Timer already enabled, check flags before resetting */
+		if ((cfg->flags & COUNTER_TOP_CFG_DONT_RESET) != 0) {
+			return -ENOTSUP;
+		}
+		mcux_lpit_stop(dev);
+		LPIT_SetTimerPeriod(config->base, channel_id, cfg->ticks);
+		mcux_lpit_start(dev);
+	} else {
+		LPIT_SetTimerPeriod(config->base, channel_id, cfg->ticks);
+	}
+
+	return 0;
+}
+
+static uint32_t mcux_lpit_get_pending_int(const struct device *dev)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
+
+	return (LPIT_GetStatusFlags(config->base) >> channel_id) & 0x1U;
+}
+
+static uint32_t mcux_lpit_get_frequency(const struct device *dev)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	uint32_t clock_rate;
+
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys, &clock_rate)) {
+		LOG_ERR("Failed to get clock rate");
+		return 0;
+	}
+
+	return clock_rate;
+}
+
+static void mcux_lpit_isr(const struct device *dev)
+{
+	const struct mcux_lpit_config *config = dev->config;
+
+	LOG_DBG("lpit counter isr");
+
+	uint32_t flags = LPIT_GetStatusFlags(config->base);
+
+	for (int channel_index = 0; channel_index < config->num_channels; channel_index++) {
+
+		if ((flags & (1U << channel_index)) == 0) {
+			continue;
+		}
+
+		/* Clear interrupt flag */
+		LPIT_ClearStatusFlags(config->base, (1U << channel_index));
+
+		struct mcux_lpit_channel_data *data =
+			LPIT_CHANNEL_DATA(config->channels[channel_index]);
+
+		if (data->top_callback != NULL) {
+			data->top_callback(dev, data->top_user_data);
+		}
+	}
+}
+
+static int mcux_lpit_init(const struct device *dev)
+{
+	const struct mcux_lpit_config *config = dev->config;
+	lpit_config_t lpit_config;
+	uint32_t clock_rate;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("Clock control device not ready");
+		return -ENODEV;
+	}
+
+	LPIT_GetDefaultConfig(&lpit_config);
+	lpit_config.enableRunInDebug = config->lpit_config.enableRunInDebug;
+	lpit_config.enableRunInDoze = config->lpit_config.enableRunInDoze;
+
+	LPIT_Init(config->base, &lpit_config);
+
+	clock_rate = mcux_lpit_get_frequency(dev);
+
+	config->irq_config_func(dev);
+
+	for (int channel_index = 0U; channel_index < config->num_channels; channel_index++) {
+		LPIT_SetTimerPeriod(config->base, channel_index, config->info.max_top_value);
+	}
+
+	return 0;
+}
+
+static DEVICE_API(counter, mcux_lpit_driver_api) = {
+	.start = mcux_lpit_start,
+	.stop = mcux_lpit_stop,
+	.get_value = mcux_lpit_get_value,
+	.set_top_value = mcux_lpit_set_top_value,
+	.get_pending_int = mcux_lpit_get_pending_int,
+	.get_top_value = mcux_lpit_get_top_value,
+	.get_freq = mcux_lpit_get_frequency,
+};
+
+/* Creates a device for a channel (needed for counter API) */
+#define MCUX_LPIT_CHANNEL_DEV_INIT(node, lpit_inst)                                                \
+	DEVICE_DT_DEFINE(node, NULL, NULL,                                                         \
+			 (void *)&mcux_lpit_##lpit_inst##_channel_datas[DT_REG_ADDR(node)],        \
+			 &mcux_lpit_##lpit_inst##_config, POST_KERNEL,                             \
+			 CONFIG_COUNTER_INIT_PRIORITY, &mcux_lpit_driver_api);
+
+/* Creates a decleration for each lpit channel */
+#define MCUX_LPIT_CHANNEL_DECLARATIONS(node)                                                       \
+	static struct mcux_lpit_channel_data mcux_lpit_channel_data_##node;
+
+/* Initializes an element of the channel data pointer array */
+#define MCUX_LPIT_INSERT_CHANNEL_INTO_ARRAY(node)                                                  \
+	[DT_REG_ADDR(node)] = &mcux_lpit_channel_data_##node,
+
+#define MCUX_LPIT_INSERT_CHANNEL_DEVICE_INTO_ARRAY(node) [DT_REG_ADDR(node)] = DEVICE_DT_GET(node),
+
+#define MCUX_LPIT_IRQ_CONFIG_DECLARATIONS(n)                                                       \
+	static void mcux_lpit_irq_config_func_##n(const struct device *dev)                        \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, 0, irq), DT_INST_IRQ_BY_IDX(n, 0, priority),     \
+			    mcux_lpit_isr, DEVICE_DT_INST_GET(n), 0);                              \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	};
+
+#define MCUX_LPIT_SETUP_IRQ_CONFIG(n) MCUX_LPIT_IRQ_CONFIG_DECLARATIONS(n);
+#define MCUX_LPIT_SETUP_IRQ_ARRAY(ignored)
+
+#define COUNTER_MCUX_LPIT_DEVICE_INIT(n)                                                           \
+                                                                                                   \
+	/* Setup the IRQ either for parent irq or per channel irq */                               \
+	MCUX_LPIT_SETUP_IRQ_CONFIG(n)                                                              \
+                                                                                                   \
+	/* Create channel declarations */                                                          \
+	DT_INST_FOREACH_CHILD_STATUS_OKAY(n, MCUX_LPIT_CHANNEL_DECLARATIONS)                       \
+                                                                                                   \
+	/* Array of channel devices */                                                             \
+	static struct mcux_lpit_channel_data                                                       \
+		*const mcux_lpit_##n##_channel_datas[DT_INST_FOREACH_CHILD_SEP_VARGS(              \
+			n, DT_NODE_HAS_COMPAT, (+), nxp_lpit_channel)] = {                         \
+			DT_INST_FOREACH_CHILD_STATUS_OKAY(n,                                       \
+							  MCUX_LPIT_INSERT_CHANNEL_INTO_ARRAY)};   \
+                                                                                                   \
+	/* forward declaration */                                                                  \
+	static const struct mcux_lpit_config mcux_lpit_##n##_config;                               \
+                                                                                                   \
+	/* Create all the channel/counter devices */                                               \
+	DT_INST_FOREACH_CHILD_STATUS_OKAY_VARGS(n, MCUX_LPIT_CHANNEL_DEV_INIT, n)                  \
+                                                                                                   \
+	/* This channel device array is needed by the module device ISR */                         \
+	const struct device *const mcux_lpit_##n##_channels[DT_INST_FOREACH_CHILD_SEP_VARGS(       \
+		n, DT_NODE_HAS_COMPAT, (+), nxp_lpit_channel)] = {                                 \
+		DT_INST_FOREACH_CHILD_STATUS_OKAY(n, MCUX_LPIT_INSERT_CHANNEL_DEVICE_INTO_ARRAY)}; \
+                                                                                                   \
+	MCUX_LPIT_SETUP_IRQ_ARRAY(n)                                                               \
+                                                                                                   \
+	/* This config struct is shared by all the channels and parent device */                   \
+	static const struct mcux_lpit_config mcux_lpit_##n##_config = {                            \
+		.info =                                                                            \
+			{                                                                          \
+				.max_top_value = DT_INST_PROP(n, max_load_value),                  \
+				.channels = 0U,                                                    \
+			},                                                                         \
+		.base = (LPIT_Type *)DT_INST_REG_ADDR(n),                                          \
+		.lpit_config =                                                                     \
+			{                                                                          \
+				.enableRunInDebug = DT_INST_PROP(n, enable_run_in_debug),          \
+				.enableRunInDoze = DT_INST_PROP(n, enable_run_in_doze),            \
+			},                                                                         \
+		.irq_config_func = mcux_lpit_irq_config_func_##n,                                  \
+		.num_channels = DT_INST_FOREACH_CHILD_SEP_VARGS(n, DT_NODE_HAS_COMPAT, (+),        \
+								nxp_lpit_channel),                 \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),              \
+		.data = mcux_lpit_##n##_channel_datas,                                             \
+		.channels = mcux_lpit_##n##_channels,                                              \
+	};                                                                                         \
+                                                                                                   \
+	/* Init parent device in order to handle ISR and init. */                                  \
+	DEVICE_DT_INST_DEFINE(n, &mcux_lpit_init, NULL, NULL, &mcux_lpit_##n##_config,             \
+			      POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_LPIT_DEVICE_INIT)

--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -716,6 +716,112 @@
 		status = "disabled";
 	};
 
+	lpit1: lpit@442f0000 {
+		compatible = "nxp,lpit";
+		reg = <0x442f0000 0x1000>;
+		interrupts = <15 0>;
+		clocks = <&ccm IMX_CCM_LPIT1_CLK 0x0 0>;
+		status = "disabled";
+		max-load-value = <0xffffffff>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lpit1_channel0: lpit_channel@0 {
+			compatible = "nxp,lpit-channel";
+			reg = <0>;
+			status = "disabled";
+		};
+
+		lpit1_channel1: lpit_channel@1 {
+			compatible = "nxp,lpit-channel";
+			reg = <1>;
+			status = "disabled";
+		};
+
+		lpit1_channel2: lpit_channel@2 {
+			compatible = "nxp,lpit-channel";
+			reg = <2>;
+			status = "disabled";
+		};
+
+		lpit1_channel3: lpit_channel@3 {
+			compatible = "nxp,lpit-channel";
+			reg = <3>;
+			status = "disabled";
+		};
+	};
+
+	lpit2: lpit@424c0000 {
+		compatible = "nxp,lpit";
+		reg = <0x424c0000 0x1000>;
+		interrupts = <64 0>;
+		clocks = <&ccm IMX_CCM_LPIT2_CLK 0x0 0>;
+		status = "disabled";
+		max-load-value = <0xffffffff>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lpit2_channel0: lpit_channel@0 {
+			compatible = "nxp,lpit-channel";
+			reg = <0>;
+			status = "disabled";
+		};
+
+		lpit2_channel1: lpit_channel@1 {
+			compatible = "nxp,lpit-channel";
+			reg = <1>;
+			status = "disabled";
+		};
+
+		lpit2_channel2: lpit_channel@2 {
+			compatible = "nxp,lpit-channel";
+			reg = <2>;
+			status = "disabled";
+		};
+
+		lpit2_channel3: lpit_channel@3 {
+			compatible = "nxp,lpit-channel";
+			reg = <3>;
+			status = "disabled";
+		};
+	};
+
+	lpit3: lpit@42cc0000 {
+		compatible = "nxp,lpit";
+		reg = <0x42cc0000 0x1000>;
+		interrupts = <149 0>;
+		clocks = <&ccm IMX_CCM_LPIT3_CLK 0x0 0>;
+		status = "disabled";
+		max-load-value = <0xffffffff>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lpit3_channel0: lpit_channel@0 {
+			compatible = "nxp,lpit-channel";
+			reg = <0>;
+			status = "disabled";
+		};
+
+		lpit3_channel1: lpit_channel@1 {
+			compatible = "nxp,lpit-channel";
+			reg = <1>;
+			status = "disabled";
+		};
+
+		lpit3_channel2: lpit_channel@2 {
+			compatible = "nxp,lpit-channel";
+			reg = <2>;
+			status = "disabled";
+		};
+
+		lpit3_channel3: lpit_channel@3 {
+			compatible = "nxp,lpit-channel";
+			reg = <3>;
+			status = "disabled";
+		};
+	};
+
+
 	lptmr1: lptmr@4300000 {
 		compatible = "nxp,lptmr";
 		reg = <0x4300000 0x1000>;

--- a/dts/bindings/counter/nxp,lpit-channel.yaml
+++ b/dts/bindings/counter/nxp,lpit-channel.yaml
@@ -1,0 +1,14 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier Apache-2.0
+
+description: |
+  Child node for the Low Power Periodic Interrupt Timer node, intended
+  for an individual timer channel
+
+compatible: "nxp,lpit-channel"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/bindings/counter/nxp,lpit.yaml
+++ b/dts/bindings/counter/nxp,lpit.yaml
@@ -1,0 +1,28 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP Low Power Periodic Interrupt Timer (LPIT)
+
+compatible: "nxp,lpit"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  max-load-value:
+    type: int
+    required: true
+    description: Maximum timeout ticks allowed for timer channels.
+
+  enable-run-in-debug:
+    type: boolean
+    description: Set 1 to allows timer channels to continue running when the chip enters Debug mode.
+
+  enable-run-in-doze:
+    type: boolean
+    description: Set 1 to allows timer channels to continue running when the chip enters Doze mode.

--- a/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
+++ b/include/zephyr/dt-bindings/clock/imx_ccm_rev2.h
@@ -149,6 +149,12 @@
 #define IMX_CCM_I3C1_CLK               0x2200UL
 #define IMX_CCM_I3C2_CLK               0x2201UL
 
+/* LPIT */
+#define IMX_CCM_LPIT_CLK  0x2300UL
+#define IMX_CCM_LPIT1_CLK 0x2300UL
+#define IMX_CCM_LPIT2_CLK 0x2301UL
+#define IMX_CCM_LPIT3_CLK 0x2302UL
+
 /* QTMR */
 #define IMX_CCM_QTMR_CLK               0x6000UL
 #define IMX_CCM_QTMR1_CLK              0x6000UL

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -90,6 +90,7 @@ set_variable_ifdef(CONFIG_WDT_MCUX_WDOG         CONFIG_MCUX_COMPONENT_driver.wdo
 set_variable_ifdef(CONFIG_WDT_MCUX_WDOG32       CONFIG_MCUX_COMPONENT_driver.wdog32)
 set_variable_ifdef(CONFIG_COUNTER_MCUX_GPT      CONFIG_MCUX_COMPONENT_driver.gpt)
 set_variable_ifdef(CONFIG_MCUX_GPT_TIMER        CONFIG_MCUX_COMPONENT_driver.gpt)
+set_variable_ifdef(CONFIG_COUNTER_MCUX_LPIT      CONFIG_MCUX_COMPONENT_driver.lpit)
 set_variable_ifdef(CONFIG_DISPLAY_MCUX_ELCDIF   CONFIG_MCUX_COMPONENT_driver.elcdif)
 set_variable_ifdef(CONFIG_MCUX_PXP              CONFIG_MCUX_COMPONENT_driver.pxp)
 set_variable_ifdef(CONFIG_LV_USE_GPU_NXP_PXP    CONFIG_MCUX_COMPONENT_driver.pxp)

--- a/soc/nxp/imxrt/imxrt118x/soc.c
+++ b/soc/nxp/imxrt/imxrt118x/soc.c
@@ -596,6 +596,16 @@ __weak void clock_init(void)
 
 #endif /* CONFIG_IMX_USDHC */
 
+#ifdef CONFIG_COUNTER_MCUX_LPIT
+	/* LPIT1 use BUS_AON, LPIT2 use BUS_WAKEUP, which have been configured */
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(lpit3), okay)
+	/* Configure LPIT3 using SysPll3Div2 */
+	rootCfg.mux = kCLOCK_LPIT3_ClockRoot_MuxSysPll3Div2;
+	rootCfg.div = 3;
+	CLOCK_SetRootClock(kCLOCK_Root_Lpit3, &rootCfg);
+#endif
+#endif /* CONFIG_COUNTER_MCUX_LPIT */
+
 	/* Keep core clock ungated during WFI */
 	CCM->LPCG[1].LPM0 = 0x33333333;
 	CCM->LPCG[1].LPM1 = 0x33333333;

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.conf
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.conf
@@ -1,6 +1,7 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_COUNTER_MCUX_QTMR=y
+CONFIG_COUNTER_MCUX_LPIT=y

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,4 +8,64 @@
 	status = "okay";
 	primary-source = "kQTMR_ClockDivide_128";
 	mode = "kQTMR_PriSrcRiseEdge";
+};
+
+&lpit1 {
+	status = "okay";
+};
+
+&lpit1_channel0 {
+	status = "okay";
+};
+
+&lpit1_channel1 {
+	status = "okay";
+};
+
+&lpit1_channel2 {
+	status = "okay";
+};
+
+&lpit1_channel3 {
+	status = "okay";
+};
+
+&lpit2 {
+	status = "okay";
+};
+
+&lpit2_channel0 {
+	status = "okay";
+};
+
+&lpit2_channel1 {
+	status = "okay";
+};
+
+&lpit2_channel2 {
+	status = "okay";
+};
+
+&lpit2_channel3 {
+	status = "okay";
+};
+
+&lpit3 {
+	status = "okay";
+};
+
+&lpit3_channel0 {
+	status = "okay";
+};
+
+&lpit3_channel1 {
+	status = "okay";
+};
+
+&lpit3_channel2 {
+	status = "okay";
+};
+
+&lpit3_channel3 {
+	status = "okay";
 };

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.conf
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.conf
@@ -1,6 +1,7 @@
 #
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_COUNTER_MCUX_QTMR=y
+CONFIG_COUNTER_MCUX_LPIT=y

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NXP
+ * Copyright 2024-2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,4 +8,64 @@
 	status = "okay";
 	primary-source = "kQTMR_ClockDivide_128";
 	mode = "kQTMR_PriSrcRiseEdge";
+};
+
+&lpit1 {
+	status = "okay";
+};
+
+&lpit1_channel0 {
+	status = "okay";
+};
+
+&lpit1_channel1 {
+	status = "okay";
+};
+
+&lpit1_channel2 {
+	status = "okay";
+};
+
+&lpit1_channel3 {
+	status = "okay";
+};
+
+&lpit2 {
+	status = "okay";
+};
+
+&lpit2_channel0 {
+	status = "okay";
+};
+
+&lpit2_channel1 {
+	status = "okay";
+};
+
+&lpit2_channel2 {
+	status = "okay";
+};
+
+&lpit2_channel3 {
+	status = "okay";
+};
+
+&lpit3 {
+	status = "okay";
+};
+
+&lpit3_channel0 {
+	status = "okay";
+};
+
+&lpit3_channel1 {
+	status = "okay";
+};
+
+&lpit3_channel2 {
+	status = "okay";
+};
+
+&lpit3_channel3 {
+	status = "okay";
 };

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -123,6 +123,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_MCUX_LPTMR
 	DEVS_FOR_DT_COMPAT(nxp_lptmr)
 #endif
+#ifdef CONFIG_COUNTER_MCUX_LPIT
+	DEVS_FOR_DT_COMPAT(nxp_lpit_channel)
+#endif
 #ifdef CONFIG_COUNTER_RENESAS_RZ_GTM
 	DEVS_FOR_DT_COMPAT(renesas_rz_gtm_counter)
 #endif


### PR DESCRIPTION
1. Provide counter driver based on lpit driver from NXP mcux-sdk-ng
2. Enable tests/drivers/counter/counter_nxp_lpit_api based on NXP mimxrt1180_evk, all channels test pass.