### PR TITLE
drivers: STM32 async flash erase and write

### DIFF
--- a/doc/releases/release-notes-4.4.rst
+++ b/doc/releases/release-notes-4.4.rst
@@ -80,6 +80,7 @@ New APIs and options
 
   * :dtcompatible:`jedec,mspi-nor` now allows MSPI configuration of read, write and
     control commands separately via devicetree.
+  * :kconfig:option:`CONFIG_FLASH_STM32_ASYNC`
 
 .. zephyr-keep-sorted-stop
 

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -17,6 +17,12 @@ config FLASH_HAS_EX_OP
 	  This option is selected by drivers that support flash extended
 	  operations.
 
+config FLASH_HAS_ASYNC_OPS
+	bool
+	help
+	  This option is selected by drivers that support asynchronous
+	  flash operations.
+
 config FLASH_HAS_EXPLICIT_ERASE
 	bool
 	help

--- a/drivers/flash/Kconfig.stm32
+++ b/drivers/flash/Kconfig.stm32
@@ -25,6 +25,9 @@ menuconfig SOC_FLASH_STM32
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select USE_STM32_HAL_FLASH if BT_STM32WBA
 	select USE_STM32_HAL_FLASH_EX if BT_STM32WBA
+	select FLASH_HAS_ASYNC_OPS if SOC_SERIES_STM32L4X || \
+	                              SOC_SERIES_STM32F4X || \
+	                              SOC_SERIES_STM32H7X
 	help
 	  Enable flash driver for STM32 series
 
@@ -101,5 +104,14 @@ config USE_MICROCHIP_QSPI_FLASH_WITH_STM32
 	help
 	  Set to use Microchip QSPI flash memories which use the PP_1_1_4 opcode
 	  (32H) for the PP_1_4_4 operation (usually 38H).
+
+config FLASH_STM32_ASYNC
+	bool "Use asynchronous flash operations"
+	depends on MULTITHREADING && FLASH_HAS_ASYNC_OPS
+	select USE_STM32_HAL_FLASH
+	select USE_STM32_HAL_FLASH_EX
+	help
+	  Use asynchronous flash operations to unblock other threads while
+	  flash is busy.
 
 endif # SOC_FLASH_STM32

--- a/drivers/flash/flash_stm32.h
+++ b/drivers/flash/flash_stm32.h
@@ -29,6 +29,12 @@ struct flash_stm32_priv {
 	struct stm32_pclken pclken;
 #endif
 	struct k_sem sem;
+#if defined(CONFIG_FLASH_STM32_ASYNC)
+	struct k_sem async_sem;
+	bool async_complete;
+	bool async_error;
+	uint32_t async_ret;
+#endif /* CONFIG_FLASH_STM32_ASYNC */
 };
 
 #if DT_PROP(DT_INST(0, soc_nv_flash), write_block_size)
@@ -310,6 +316,9 @@ static inline void _flash_stm32_sem_give(const struct device *dev)
 #define flash_stm32_sem_init(dev) k_sem_init(&FLASH_STM32_PRIV(dev)->sem, 1, 1)
 #define flash_stm32_sem_take(dev) _flash_stm32_sem_take(dev)
 #define flash_stm32_sem_give(dev) _flash_stm32_sem_give(dev)
+#if defined(CONFIG_FLASH_STM32_ASYNC)
+#define flash_stm32_async_sem_init(dev) k_sem_init(&FLASH_STM32_PRIV(dev)->async_sem, 0, 1)
+#endif /* CONFIG_FLASH_STM32_ASYNC */
 #else
 #define flash_stm32_sem_init(dev)
 #define flash_stm32_sem_take(dev)


### PR DESCRIPTION
- Implemented async flash erase and writes using the STM32 hal `HAL_FLASHEx_Erase_IT()` and `HAL_FLASH_Program_IT()` functions with their associated interrupt handler.
- I only implemented this for the h7, l4, and f4 stm32 families because that is the hardware I had available to test on.
- Async flash transactions can be enabled using the `FLASH_STM32_ASYNC` config option.
- Async transactions are implemented using a semaphore which blocks while waiting for the flash IRQ to indicate the end of a flash transaction. This allows other threads to take action while flash erase and write actions are taking place.