### PR TITLE
Bluetooth: Host: Add conn rsp param check

### DIFF
--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -111,6 +111,20 @@ extern "C" {
  */
 #define BT_L2CAP_ECRED_MIN_MPS 64
 
+/** @brief L2CAP maximum MTU
+ *
+ *  The maximum MTU for an L2CAP Based Connection. This is the same with or without ECRED. This
+ *  requirement is taken from text in Core 3.A.4.22 and 3.A.4.26 v6.0.
+ */
+#define BT_L2CAP_MAX_MTU UINT16_MAX
+
+/** @brief L2CAP maximum MPS
+ *
+ *  The maximum MPS for an L2CAP Based Connection. This is the same with or without ECRED. This
+ *  requirement is taken from text in Core 3.A.4.22 and 3.A.4.26 v6.0.
+ */
+#define BT_L2CAP_MAX_MPS 65533
+
 /** @brief The maximum number of channels in ECRED L2CAP signaling PDUs
  *
  *  Currently, this is the maximum number of channels referred to in the

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -125,6 +125,9 @@ struct bt_l2cap_le_credits {
 	uint16_t credits;
 } __packed;
 
+#define BT_L2CAP_ECRED_CREDITS_MIN      1
+#define BT_L2CAP_ECRED_CREDITS_MAX      UINT16_MAX
+
 #define BT_L2CAP_ECRED_CONN_REQ         0x17
 struct bt_l2cap_ecred_conn_req {
 	uint16_t psm;

--- a/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/many_conns/src/main.c
@@ -29,7 +29,7 @@ DEFINE_FLAG_STATIC(flag_l2cap_connected);
 #define NUM_PERIPHERALS CONFIG_BT_MAX_CONN
 #define L2CAP_CHANS     NUM_PERIPHERALS
 #define SDU_NUM         1
-#define SDU_LEN         10
+#define SDU_LEN         23
 
 /* Only one SDU per link will be transmitted */
 NET_BUF_POOL_DEFINE(sdu_tx_pool,


### PR DESCRIPTION
Check whether the connection response parameters both with and without ECRED are within the valid ranges from the Bluetooth Core Specification (part 3.A.4 v6.0).