### PR TITLE
Feature/impl a2dp get all cap

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -391,6 +391,15 @@ struct bt_a2dp_discover_param {
 	 *  it save endpoint info internally.
 	 */
 	struct bt_avdtp_sep_info *seps_info;
+	/** The AVDTP version of the peer's A2DP sdp service.
+	 *  Stack uses it to determine using get_all_cap or get_cap cmd. When both
+	 *  versions are v1.3 or bigger version, get_all_cap is used, otherwise
+	 *  get_cap is used.
+	 *  It is the same value of the avdtp sepcificaiton's version value.
+	 *  For example: 0x0103 means version 1.3
+	 *  If the value is 0 (unknown), stack process it as less than v1.3
+	 */
+	uint16_t avdtp_version;
 	/** The max count of seps (stream endpoint) that can be got in this call route */
 	uint8_t sep_count;
 };

--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -15,6 +15,10 @@
 extern "C" {
 #endif
 
+#define AVDTP_VERSION_1_3 0x0103 /**< AVDTP version 1.3 value */
+
+#define AVDTP_VERSION AVDTP_VERSION_1_3 /**< AVDTP version used by Zephyr */
+
 /**
  * @brief AVDTP error code
  */

--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -639,6 +639,7 @@ int bt_sdp_discover_cancel(struct bt_conn *conn,
 /** @brief Protocols to be asked about specific parameters */
 enum bt_sdp_proto {
 	BT_SDP_PROTO_RFCOMM = 0x0003,
+	BT_SDP_PROTO_AVDTP  = 0x0019,
 	BT_SDP_PROTO_L2CAP  = 0x0100,
 };
 

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -153,6 +153,7 @@ struct bt_avdtp_discover_params {
 struct bt_avdtp_get_capabilities_params {
 	struct bt_avdtp_req req;
 	uint8_t stream_endpoint_id;
+	bool get_all_caps;
 };
 
 struct bt_avdtp_set_configuration_params {
@@ -183,7 +184,7 @@ struct bt_avdtp_ops_cb {
 	int (*discovery_ind)(struct bt_avdtp *session, uint8_t *errcode);
 
 	int (*get_capabilities_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
-				    struct net_buf *rsp_buf, uint8_t *errcode);
+				    struct net_buf *rsp_buf, bool get_all_caps, uint8_t *errcode);
 
 	int (*set_configuration_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
 				     uint8_t int_seid, struct net_buf *buf, uint8_t *errcode);

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -3208,7 +3208,8 @@ int bt_sdp_get_proto_param(const struct net_buf *buf, enum bt_sdp_proto proto,
 	struct bt_sdp_uuid_desc pd;
 	int res;
 
-	if (proto != BT_SDP_PROTO_RFCOMM && proto != BT_SDP_PROTO_L2CAP) {
+	if (proto != BT_SDP_PROTO_RFCOMM && proto != BT_SDP_PROTO_L2CAP &&
+	    proto != BT_SDP_PROTO_AVDTP) {
 		LOG_ERR("Invalid protocol specifier");
 		return -EINVAL;
 	}
@@ -3235,7 +3236,8 @@ int bt_sdp_get_addl_proto_param(const struct net_buf *buf, enum bt_sdp_proto pro
 	struct bt_sdp_uuid_desc pd;
 	int res;
 
-	if (proto != BT_SDP_PROTO_RFCOMM && proto != BT_SDP_PROTO_L2CAP) {
+	if (proto != BT_SDP_PROTO_RFCOMM && proto != BT_SDP_PROTO_L2CAP &&
+	    proto != BT_SDP_PROTO_AVDTP) {
 		LOG_ERR("Invalid protocol specifier");
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/host/classic/shell/a2dp.c
+++ b/subsys/bluetooth/host/classic/shell/a2dp.c
@@ -99,7 +99,7 @@ static struct bt_sdp_attribute a2dp_sink_attrs[] = {
 			},
 			{
 				BT_SDP_TYPE_SIZE(BT_SDP_UINT16), /* 09 */
-				BT_SDP_ARRAY_16(0x0100U) /* AVDTP version: 01 00 */
+				BT_SDP_ARRAY_16(AVDTP_VERSION) /* AVDTP version: 01 03 */
 			},
 			)
 		},
@@ -168,7 +168,7 @@ static struct bt_sdp_attribute a2dp_source_attrs[] = {
 			},
 			{
 				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
-				BT_SDP_ARRAY_16(0x0100U)
+				BT_SDP_ARRAY_16(AVDTP_VERSION)
 			},
 			)
 		},
@@ -193,7 +193,7 @@ static struct bt_sdp_attribute a2dp_source_attrs[] = {
 		},
 		)
 	),
-	BT_SDP_SERVICE_NAME("A2DPSink"),
+	BT_SDP_SERVICE_NAME("A2DPSource"),
 	BT_SDP_SUPPORTED_FEATURES(0x0001U),
 };
 
@@ -677,13 +677,22 @@ struct bt_a2dp_discover_param discover_param = {
 
 static int cmd_get_peer_eps(const struct shell *sh, int32_t argc, char *argv[])
 {
+	int err = 0;
+
 	if (a2dp_initied == 0) {
 		shell_print(sh, "need to register a2dp connection callbacks");
 		return -ENOEXEC;
 	}
 
 	if (default_a2dp != NULL) {
-		int err = bt_a2dp_discover(default_a2dp, &discover_param);
+		discover_param.avdtp_version = (uint16_t)shell_strtoul(argv[1], 0, &err);
+		if (err != 0) {
+			shell_error(sh, "failed to parse avdtp version: %d", err);
+
+			return -ENOEXEC;
+		}
+
+		err = bt_a2dp_discover(default_a2dp, &discover_param);
 
 		if (err) {
 			shell_error(sh, "discover fail");
@@ -798,7 +807,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(a2dp_cmds,
 			cmd_register_ep, 3, 0),
 	SHELL_CMD_ARG(connect, NULL, HELP_NONE, cmd_connect, 1, 0),
 	SHELL_CMD_ARG(disconnect, NULL, HELP_NONE, cmd_disconnect, 1, 0),
-	SHELL_CMD_ARG(discover_peer_eps, NULL, HELP_NONE, cmd_get_peer_eps, 1, 0),
+	SHELL_CMD_ARG(discover_peer_eps, NULL, "<avdtp version value>", cmd_get_peer_eps, 2, 0),
 	SHELL_CMD_ARG(configure, NULL, "\"configure/enable the stream\"", cmd_configure, 1, 0),
 	SHELL_CMD_ARG(establish, NULL, "\"establish the stream\"", cmd_establish, 1, 0),
 	SHELL_CMD_ARG(reconfigure, NULL, "\"reconfigure the stream\"", cmd_reconfigure, 1, 0),

--- a/subsys/bluetooth/host/classic/shell/bredr.c
+++ b/subsys/bluetooth/host/classic/shell/bredr.c
@@ -950,48 +950,122 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn, struct bt_sdp_client_result 
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	if (result && result->resp_buf) {
-		bt_shell_print("SDP A2SRC data@%p (len %u) hint %u from remote %s",
-			       result->resp_buf, result->resp_buf->len, result->next_record_hint,
-			       addr);
-
-		/*
-		 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
-		 * get A2SRC Server PSM Number.
-		 */
-		err = bt_sdp_get_proto_param(result->resp_buf, BT_SDP_PROTO_L2CAP, &param);
-		if (err < 0) {
-			bt_shell_error("A2SRC PSM Number not found, err %d", err);
-			goto done;
-		}
-
-		bt_shell_print("A2SRC Server PSM Number param 0x%04x", param);
-
-		/*
-		 * Focus to get BT_SDP_ATTR_PROFILE_DESC_LIST attribute item to
-		 * get profile version number.
-		 */
-		err = bt_sdp_get_profile_version(result->resp_buf, BT_SDP_ADVANCED_AUDIO_SVCLASS,
-						 &version);
-		if (err < 0) {
-			bt_shell_error("A2SRC version not found, err %d", err);
-			goto done;
-		}
-		bt_shell_print("A2SRC version param 0x%04x", version);
-
-		/*
-		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
-		 * get profile supported features mask.
-		 */
-		err = bt_sdp_get_features(result->resp_buf, &features);
-		if (err < 0) {
-			bt_shell_error("A2SRC Features not found, err %d", err);
-			goto done;
-		}
-		bt_shell_print("A2SRC Supported Features param 0x%04x", features);
-	} else {
+	if (result == NULL || result->resp_buf == NULL) {
 		bt_shell_print("No SDP A2SRC data from remote %s", addr);
+		goto done;
 	}
+
+	bt_shell_print("SDP A2SRC data@%p (len %u) hint %u from remote %s",
+		       result->resp_buf, result->resp_buf->len, result->next_record_hint,
+		       addr);
+
+	/*
+	 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
+	 * get A2SRC Server PSM Number.
+	 */
+	err = bt_sdp_get_proto_param(result->resp_buf, BT_SDP_PROTO_L2CAP, &param);
+	if (err < 0) {
+		bt_shell_error("A2SRC PSM Number not found, err %d", err);
+		goto done;
+	}
+
+	bt_shell_print("A2SRC Server PSM Number param 0x%04x", param);
+
+	err = bt_sdp_get_proto_param(result->resp_buf, BT_UUID_AVDTP_VAL, &version);
+	if (err < 0) {
+		bt_shell_error("A2SRC AVDTP version not found, err %d", err);
+		goto done;
+	}
+
+	bt_shell_print("A2SRC Server AVDTP version 0x%04x", version);
+
+	/*
+	 * Focus to get BT_SDP_ATTR_PROFILE_DESC_LIST attribute item to
+	 * get profile version number.
+	 */
+	err = bt_sdp_get_profile_version(result->resp_buf, BT_SDP_ADVANCED_AUDIO_SVCLASS, &version);
+	if (err < 0) {
+		bt_shell_error("A2SRC version not found, err %d", err);
+		goto done;
+	}
+	bt_shell_print("A2SRC version param 0x%04x", version);
+
+	/*
+	 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
+	 * get profile supported features mask.
+	 */
+	err = bt_sdp_get_features(result->resp_buf, &features);
+	if (err < 0) {
+		bt_shell_error("A2SRC Features not found, err %d", err);
+		goto done;
+	}
+	bt_shell_print("A2SRC Supported Features param 0x%04x", features);
+
+done:
+	return BT_SDP_DISCOVER_UUID_CONTINUE;
+}
+
+static uint8_t sdp_a2snk_user(struct bt_conn *conn, struct bt_sdp_client_result *result,
+			      const struct bt_sdp_discover_params *params)
+{
+	char addr[BT_ADDR_STR_LEN];
+	uint16_t param, version;
+	uint16_t features;
+	int err;
+
+	conn_addr_str(conn, addr, sizeof(addr));
+
+	if (result == NULL || result->resp_buf == NULL) {
+		bt_shell_print("No SDP A2SNK data from remote %s", addr);
+		goto done;
+	}
+
+	bt_shell_print("SDP A2SNK data@%p (len %u) hint %u from remote %s",
+		       result->resp_buf, result->resp_buf->len, result->next_record_hint,
+		       addr);
+
+	/*
+	 * Focus to get BT_SDP_ATTR_PROTO_DESC_LIST attribute item to
+	 * get A2SNK Server PSM Number.
+	 */
+	err = bt_sdp_get_proto_param(result->resp_buf, BT_SDP_PROTO_L2CAP, &param);
+	if (err < 0) {
+		bt_shell_error("A2SNK PSM Number not found, err %d", err);
+		goto done;
+	}
+
+	bt_shell_print("A2SNK Server PSM Number param 0x%04x", param);
+
+	err = bt_sdp_get_proto_param(result->resp_buf, BT_UUID_AVDTP_VAL, &version);
+	if (err < 0) {
+		bt_shell_error("A2SNK AVDTP version not found, err %d", err);
+		goto done;
+	}
+
+	bt_shell_print("A2SNK Server AVDTP version 0x%04x", version);
+
+	/*
+	 * Focus to get BT_SDP_ATTR_PROFILE_DESC_LIST attribute item to
+	 * get profile version number.
+	 */
+	err = bt_sdp_get_profile_version(result->resp_buf, BT_SDP_ADVANCED_AUDIO_SVCLASS, &version);
+	if (err < 0) {
+		bt_shell_error("A2SNK version not found, err %d", err);
+		goto done;
+	}
+	bt_shell_print("A2SNK version param 0x%04x", version);
+
+	/*
+	 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
+	 * get profile supported features mask.
+	 */
+	err = bt_sdp_get_features(result->resp_buf, &features);
+	if (err < 0) {
+		bt_shell_error("A2SNK Features not found, err %d", err);
+		goto done;
+	}
+	bt_shell_print("A2SNK Supported Features param 0x%04x", features);
+
 done:
 	return BT_SDP_DISCOVER_UUID_CONTINUE;
 }
@@ -1052,6 +1126,13 @@ static struct bt_sdp_discover_params discov_a2src = {
 	.pool = &sdp_client_pool,
 };
 
+static struct bt_sdp_discover_params discov_a2snk = {
+	.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR,
+	.uuid = BT_UUID_DECLARE_16(BT_SDP_AUDIO_SINK_SVCLASS),
+	.func = sdp_a2snk_user,
+	.pool = &sdp_client_pool,
+};
+
 static struct bt_sdp_discover_params discov_pnp = {
 	.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR,
 	.uuid = BT_UUID_DECLARE_16(BT_SDP_PNP_INFO_SVCLASS),
@@ -1079,6 +1160,8 @@ static int cmd_sdp_find_record(const struct shell *sh, size_t argc, char *argv[]
 		discov = discov_hfphf;
 	} else if (!strcmp(action, "A2SRC")) {
 		discov = discov_a2src;
+	} else if (!strcmp(action, "A2SNK")) {
+		discov = discov_a2snk;
 	} else if (!strcmp(action, "PNP")) {
 		discov = discov_pnp;
 	} else {
@@ -1490,7 +1573,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(br_cmds,
 	SHELL_CMD(l2cap, &l2cap_cmds, HELP_NONE, cmd_default_handler),
 	SHELL_CMD_ARG(oob, NULL, NULL, cmd_oob, 1, 0),
 	SHELL_CMD_ARG(pscan, NULL, "<value: on, off>", cmd_connectable, 2, 0),
-	SHELL_CMD_ARG(sdp-find, NULL, "<HFPAG, HFPHF, PNP>", cmd_sdp_find_record, 2, 0),
+	SHELL_CMD_ARG(sdp-find, NULL, "<HFPAG, HFPHF, A2SRC, A2SNK, PNP>",
+		      cmd_sdp_find_record, 2, 0),
 	SHELL_CMD_ARG(switch-role, NULL, "<value: central, peripheral>", cmd_switch_role, 2, 0),
 	SHELL_CMD_ARG(set-role-switchable, NULL, "<value: enable, disable>",
 		      cmd_set_role_switchable, 2, 0),


### PR DESCRIPTION
Implement the avdtp/a2dp get_all_capabilities cmd and rsp.
From avdtp spec, the get_all_capablities should be used if the avdtp version is v1.3, otherwise the get_capabilities should be used.
Improve sdp to get the avdtp version through the bt_sdp_get_proto_param.