### PR TITLE
MAINTAINERS: Introduce SPDX Tooling area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4600,6 +4600,20 @@ Sensry Platforms:
   labels:
     - "platform: sensry"
 
+SPDX Tooling:
+  status: maintained
+  maintainers:
+    - kartben
+  collaborators:
+    - pdgendt
+    - swinslow
+  files:
+    - scripts/west_commands/spdx.py
+    - scripts/west_commands/zspdx/
+    - tests/application_development/software_bill_of_materials/
+  labels:
+    - "area: SPDX Tooling"
+
 Storage:
   status: odd fixes
   files:


### PR DESCRIPTION
Add SPDX Tooling area covering custom west command, zspdx library, and tests. Add kartben as maintainer, swinslow and pdgendt as collaborators.