### PR TITLE
net: ppp: ipcp: Improvements to DNS option negotiation

### DIFF
--- a/include/zephyr/net/ppp.h
+++ b/include/zephyr/net/ppp.h
@@ -353,7 +353,11 @@ struct ppp_my_option_data {
 	uint32_t flags;
 };
 
+#if defined(CONFIG_NET_L2_PPP_OPTION_DNS_USE)
 #define IPCP_NUM_MY_OPTIONS	3
+#else
+#define IPCP_NUM_MY_OPTIONS	1
+#endif
 #define IPV6CP_NUM_MY_OPTIONS	1
 
 enum ppp_flags {

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -228,6 +228,37 @@ static int ipcp_server_nak_ip_address(struct ppp_fsm *fsm,
 #endif
 
 #if defined(CONFIG_NET_L2_PPP_OPTION_SERVE_DNS)
+
+static int ipcp_dns1_address_parse(struct ppp_fsm *fsm, struct net_pkt *pkt,
+				  void *user_data)
+{
+	struct ppp_context *ctx =
+		CONTAINER_OF(fsm, struct ppp_context, ipcp.fsm);
+	int ret;
+
+	ret = ipcp_dns_address_parse(fsm, pkt, user_data);
+
+	if (ret == -EINVAL && ctx->ipcp.peer_options.dns1_address.s_addr == INADDR_ANY) {
+		return -ENOTSUP;
+	}
+	return ret;
+}
+
+static int ipcp_dns2_address_parse(struct ppp_fsm *fsm, struct net_pkt *pkt,
+				  void *user_data)
+{
+	struct ppp_context *ctx =
+		CONTAINER_OF(fsm, struct ppp_context, ipcp.fsm);
+	int ret;
+
+	ret = ipcp_dns_address_parse(fsm, pkt, user_data);
+
+	if (ret == -EINVAL && ctx->ipcp.peer_options.dns2_address.s_addr == INADDR_ANY) {
+		return -ENOTSUP;
+	}
+	return ret;
+}
+
 static int ipcp_server_nak_dns1_address(struct ppp_fsm *fsm,
 					struct net_pkt *ret_pkt,
 					void *user_data)
@@ -263,9 +294,9 @@ static const struct ppp_peer_option_info ipcp_peer_options[] = {
 	PPP_PEER_OPTION(IPCP_OPTION_IP_ADDRESS, ipcp_ip_address_parse, NULL),
 #endif
 #if defined(CONFIG_NET_L2_PPP_OPTION_SERVE_DNS)
-	PPP_PEER_OPTION(IPCP_OPTION_DNS1, ipcp_dns_address_parse,
+	PPP_PEER_OPTION(IPCP_OPTION_DNS1, ipcp_dns1_address_parse,
 			ipcp_server_nak_dns1_address),
-	PPP_PEER_OPTION(IPCP_OPTION_DNS2, ipcp_dns_address_parse,
+	PPP_PEER_OPTION(IPCP_OPTION_DNS2, ipcp_dns2_address_parse,
 			ipcp_server_nak_dns2_address),
 #endif
 };

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -42,16 +42,6 @@ static int ipcp_add_ip_address(struct ppp_context *ctx, struct net_pkt *pkt)
 	return ipcp_add_address(ctx, pkt, &ctx->ipcp.my_options.address);
 }
 
-static int ipcp_add_dns1(struct ppp_context *ctx, struct net_pkt *pkt)
-{
-	return ipcp_add_address(ctx, pkt, &ctx->ipcp.my_options.dns1_address);
-}
-
-static int ipcp_add_dns2(struct ppp_context *ctx, struct net_pkt *pkt)
-{
-	return ipcp_add_address(ctx, pkt, &ctx->ipcp.my_options.dns2_address);
-}
-
 static int ipcp_ack_check_address(struct net_pkt *pkt, size_t oplen,
 				  struct in_addr *addr)
 {
@@ -81,20 +71,6 @@ static int ipcp_ack_ip_address(struct ppp_context *ctx, struct net_pkt *pkt,
 				      &ctx->ipcp.my_options.address);
 }
 
-static int ipcp_ack_dns1(struct ppp_context *ctx, struct net_pkt *pkt,
-			 uint8_t oplen)
-{
-	return ipcp_ack_check_address(pkt, oplen,
-				      &ctx->ipcp.my_options.dns1_address);
-}
-
-static int ipcp_ack_dns2(struct ppp_context *ctx, struct net_pkt *pkt,
-			 uint8_t oplen)
-{
-	return ipcp_ack_check_address(pkt, oplen,
-				      &ctx->ipcp.my_options.dns2_address);
-}
-
 static int ipcp_nak_override_address(struct net_pkt *pkt, size_t oplen,
 				     struct in_addr *addr)
 {
@@ -112,6 +88,31 @@ static int ipcp_nak_ip_address(struct ppp_context *ctx, struct net_pkt *pkt,
 					 &ctx->ipcp.my_options.address);
 }
 
+#if defined(CONFIG_NET_L2_PPP_OPTION_DNS_USE)
+static int ipcp_add_dns1(struct ppp_context *ctx, struct net_pkt *pkt)
+{
+	return ipcp_add_address(ctx, pkt, &ctx->ipcp.my_options.dns1_address);
+}
+
+static int ipcp_add_dns2(struct ppp_context *ctx, struct net_pkt *pkt)
+{
+	return ipcp_add_address(ctx, pkt, &ctx->ipcp.my_options.dns2_address);
+}
+
+static int ipcp_ack_dns1(struct ppp_context *ctx, struct net_pkt *pkt,
+			 uint8_t oplen)
+{
+	return ipcp_ack_check_address(pkt, oplen,
+				      &ctx->ipcp.my_options.dns1_address);
+}
+
+static int ipcp_ack_dns2(struct ppp_context *ctx, struct net_pkt *pkt,
+			 uint8_t oplen)
+{
+	return ipcp_ack_check_address(pkt, oplen,
+				      &ctx->ipcp.my_options.dns2_address);
+}
+
 static int ipcp_nak_dns1(struct ppp_context *ctx, struct net_pkt *pkt,
 			 uint8_t oplen)
 {
@@ -125,21 +126,24 @@ static int ipcp_nak_dns2(struct ppp_context *ctx, struct net_pkt *pkt,
 	return ipcp_nak_override_address(pkt, oplen,
 					 &ctx->ipcp.my_options.dns2_address);
 }
+#endif /* CONFIG_NET_L2_PPP_OPTION_DNS_USE */
 
 static const struct ppp_my_option_info ipcp_my_options[] = {
 	PPP_MY_OPTION(IPCP_OPTION_IP_ADDRESS, ipcp_add_ip_address,
 		      ipcp_ack_ip_address, ipcp_nak_ip_address),
+#if defined(CONFIG_NET_L2_PPP_OPTION_DNS_USE)
 	PPP_MY_OPTION(IPCP_OPTION_DNS1, ipcp_add_dns1,
 		      ipcp_ack_dns1, ipcp_nak_dns1),
 	PPP_MY_OPTION(IPCP_OPTION_DNS2, ipcp_add_dns2,
 		      ipcp_ack_dns2, ipcp_nak_dns2),
+#endif
 };
 
 BUILD_ASSERT(ARRAY_SIZE(ipcp_my_options) == IPCP_NUM_MY_OPTIONS);
 
 static struct net_pkt *ipcp_config_info_add(struct ppp_fsm *fsm)
 {
-	return ppp_my_options_add(fsm, 3 * IP_ADDRESS_OPTION_LEN);
+	return ppp_my_options_add(fsm, IPCP_NUM_MY_OPTIONS * IP_ADDRESS_OPTION_LEN);
 }
 
 struct ipcp_peer_option_data {
@@ -232,7 +236,7 @@ static int ipcp_server_nak_dns1_address(struct ppp_fsm *fsm,
 		CONTAINER_OF(fsm, struct ppp_context, ipcp.fsm);
 
 	(void)net_pkt_write_u8(ret_pkt, IPCP_OPTION_DNS1);
-	ipcp_add_dns1(ctx, ret_pkt);
+	(void)ipcp_add_address(ctx, ret_pkt, &ctx->ipcp.peer_options.dns1_address);
 
 	return 0;
 }
@@ -245,7 +249,7 @@ static int ipcp_server_nak_dns2_address(struct ppp_fsm *fsm,
 		CONTAINER_OF(fsm, struct ppp_context, ipcp.fsm);
 
 	(void)net_pkt_write_u8(ret_pkt, IPCP_OPTION_DNS2);
-	ipcp_add_dns2(ctx, ret_pkt);
+	(void)ipcp_add_address(ctx, ret_pkt, &ctx->ipcp.peer_options.dns2_address);
 
 	return 0;
 }


### PR DESCRIPTION
When Kconfig option CONFIG_NET_L2_PPP_OPTION_DNS_USE is enabled, Zephyr should request two DNS addresses in IPCP negotiation by sending IPCP ConfReq for DNS otions using 0.0.0.0 as an address.

Remote peer may offer DNS by sending IPCP ConfNak with proper address. This is explained in RFC 1332 and RFC 1877 (DNS extension).

When no DNS is required, we should only send IPCP ConfReq for IP address, without having DNS fields in the same request.

However, when PPP is configured to serve a DNS using Kconfig option CONFIG_NET_L2_PPP_OPTION_SERVE_DNS it should serve the DNS address in the IPCP ConfNak message and from the ipcp.peer_options structure, not from the ipcp.my_options.

This might break backward compatibility outside this repository as DNS addresses used to be served from ipcp.my_options.