### PR TITLE
dts: binding: vendor-prefixes: Update Space Cubics legal entity

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -594,7 +594,7 @@ sancloud	Sancloud Ltd
 sandisk	Sandisk Corporation
 satoz	Satoz International Co., Ltd
 sbs	Smart Battery System
-sc	Space Cubics, LLC
+sc	Space Cubics Inc.
 schindler	Schindler
 sciosense	Sciosense B.V.
 seagate	Seagate Technology PLC


### PR DESCRIPTION
Space Cubics changed its legal entity status from "LLC" to "Inc." as of June 1st, 2025.

I don't know why but there is a duplicate of Space Cubics entry in vendor-prefixes.txt file :  introduce by @tejlmand 
https://github.com/zephyrproject-rtos/zephyr/blob/66acb364b1907751efe40e9a2cdf22080985d893/dts/bindings/vendor-prefixes.txt#L649