### PR TITLE
* Devicetree bindings: st,stm32wb-ble-rf.yaml: fix BD Address error

### DIFF
--- a/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
+++ b/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
@@ -15,3 +15,5 @@ properties:
     default: "BT IPM"
   bt-hci-bus:
     default: "ipm"
+  bt-hci-quirks:
+    default: ["no-reset"]


### PR DESCRIPTION
The HCI RESET done in common_init() function in the zephyr\subsys\bluetooth\host\hci_core.c file erase settings done before in the zephyr\drivers\bluetooth\hci\ipm_stm32wb.c in the bt_ipm_setup() function. HCI RESET can be avoided by set a default "no-reset" in the zephyr\dts\bindings\bluetooth\st,stm32wb-ble-rf.yaml