### PR TITLE
MAINTAINERS: Add Python Tooling area for ruff

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4556,6 +4556,19 @@ Panasonic Platforms:
   labels:
     - "platform: Panasonic"
 
+"Python Tooling: ruff":
+  status: maintained
+  maintainers:
+    - pdgendt
+  collaborators:
+    - kartben
+  files:
+    - .ruff.toml
+    - .ruff-excludes.toml
+    - scripts/ruff/
+  labels:
+    - "area: Python Tooling"
+
 RTIO:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add a maintainer area for ruff related files and introduce a label for Python tooling.