### PR TITLE
drivers: crypto: stm32: h7: add AES CCM and GCM support

### DIFF
--- a/boards/st/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.dts
@@ -106,6 +106,10 @@
 	power-supply = "smps-direct";
 };
 
+&cryp {
+	status = "okay";
+};
+
 &usart3 {
 	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9>;
 	pinctrl-names = "default";

--- a/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
+++ b/boards/st/stm32h735g_disco/stm32h735g_disco.yaml
@@ -14,5 +14,7 @@ supported:
   - adc
   - counter
   - can
+  - crypto
+  - aes
   - usb_device
 vendor: st

--- a/drivers/crypto/Kconfig.stm32
+++ b/drivers/crypto/Kconfig.stm32
@@ -13,13 +13,26 @@ menuconfig CRYPTO_STM32
 	help
 	  Enable STM32 HAL-based Cryptographic Accelerator driver.
 
+if CRYPTO_STM32
+
 config CRYPTO_STM32_MAX_SESSION
 	int "Maximum of sessions STM32 crypto driver can handle"
 	default 2
-	depends on CRYPTO_STM32
 	help
 	  This can be used to tweak the amount of sessions the driver
 	  can handle in parallel.
+
+config CRYPTO_STM32_USE_MBEDTLS_CT_MEMCMP
+	bool "Use mbedtls_ct_memcmp for constant-time comparisons"
+	default y
+	depends on MBEDTLS
+	help
+	  When disabled, operations such as authentication tag validation
+	  use memcmp, which is known to be vulnerable to timing attacks.
+	  It is recommended to use a constant-time comparison method
+	  to enhance security.
+
+endif # CRYPTO_STM32
 
 config CRYPTO_STM32_HASH
 	bool "STM32 Hash Accelerator driver"

--- a/drivers/crypto/Kconfig.stm32
+++ b/drivers/crypto/Kconfig.stm32
@@ -27,10 +27,9 @@ config CRYPTO_STM32_USE_MBEDTLS_CT_MEMCMP
 	default y
 	depends on MBEDTLS
 	help
-	  When disabled, operations such as authentication tag validation
-	  use memcmp, which is known to be vulnerable to timing attacks.
-	  It is recommended to use a constant-time comparison method
-	  to enhance security.
+	  When you enable this feature, the driver will use mbedtls_ct_memcmp
+	  to compare authentication tags. If it's disabled, it uses a simpler
+	  constant-time comparison function that isn't optimized.
 
 endif # CRYPTO_STM32
 

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -448,7 +448,7 @@ static int crypto_stm32_session_setup(const struct device *dev,
 			ctx->ops.ctr_crypt_hndlr = crypto_stm32_ctr_encrypt;
 			break;
 		default:
-			break;
+			CODE_UNREACHABLE;
 		}
 	} else {
 		switch (mode) {
@@ -471,7 +471,7 @@ static int crypto_stm32_session_setup(const struct device *dev,
 			ctx->ops.ctr_crypt_hndlr = crypto_stm32_ctr_decrypt;
 			break;
 		default:
-			break;
+			CODE_UNREACHABLE;
 		}
 	}
 

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -114,12 +114,8 @@ static int copy_words_adjust_endianness(uint8_t *dst_buf, int dst_len, const uin
 static int do_aes(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint8_t *in_buf, int in_len,
 		      uint8_t *out_buf)
 {
-	status_t status;
-
 	struct crypto_stm32_data *data = CRYPTO_STM32_DATA(ctx->device);
 	struct crypto_stm32_session *session = CRYPTO_STM32_SESSN(ctx);
-
-	k_sem_take(&data->device_sem, K_FOREVER);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes)
 	/* Device is initialized from the configuration in the encryption/decryption function
@@ -127,22 +123,16 @@ static int do_aes(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint8_t *in
 	 */
 	memcpy(&data->hcryp.Init, &session->config, sizeof(session->config));
 #else
-	status = HAL_CRYP_SetConfig(&data->hcryp, &session->config);
-	if (status != HAL_OK) {
+	if (HAL_CRYP_SetConfig(&data->hcryp, &session->config) != HAL_OK) {
 		LOG_ERR("Configuration error");
-		k_sem_give(&data->device_sem);
 		return -EIO;
 	}
 #endif
 
-	status = fn(&data->hcryp, in_buf, in_len, out_buf, HAL_MAX_DELAY);
-	if (status != HAL_OK) {
+	if (fn(&data->hcryp, in_buf, in_len, out_buf, HAL_MAX_DELAY) != HAL_OK) {
 		LOG_ERR("Encryption/decryption error");
-		k_sem_give(&data->device_sem);
 		return -EIO;
 	}
-
-	k_sem_give(&data->device_sem);
 
 	return 0;
 }
@@ -166,6 +156,7 @@ static status_t hal_decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uin
 static int crypto_stm32_ecb_encrypt(struct cipher_ctx *ctx,
 				    struct cipher_pkt *pkt)
 {
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
 	int ret;
 
 	/* For security reasons, ECB mode should not be used to encrypt
@@ -176,7 +167,12 @@ static int crypto_stm32_ecb_encrypt(struct cipher_ctx *ctx,
 		return -EINVAL;
 	}
 
+	k_sem_take(&data->device_sem, K_FOREVER);
+
 	ret = do_aes(ctx, hal_ecb_encrypt_op, pkt->in_buf, pkt->in_len, pkt->out_buf);
+
+	k_sem_give(&data->device_sem);
+
 	if (ret == 0) {
 		pkt->out_len = 16;
 	}
@@ -187,6 +183,7 @@ static int crypto_stm32_ecb_encrypt(struct cipher_ctx *ctx,
 static int crypto_stm32_ecb_decrypt(struct cipher_ctx *ctx,
 				    struct cipher_pkt *pkt)
 {
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
 	int ret;
 
 	/* For security reasons, ECB mode should not be used to encrypt
@@ -197,7 +194,12 @@ static int crypto_stm32_ecb_decrypt(struct cipher_ctx *ctx,
 		return -EINVAL;
 	}
 
+	k_sem_take(&data->device_sem, K_FOREVER);
+
 	ret = do_aes(ctx, hal_ecb_decrypt_op, pkt->in_buf, pkt->in_len, pkt->out_buf);
+
+	k_sem_give(&data->device_sem);
+
 	if (ret == 0) {
 		pkt->out_len = 16;
 	}
@@ -208,11 +210,11 @@ static int crypto_stm32_ecb_decrypt(struct cipher_ctx *ctx,
 static int crypto_stm32_cbc_encrypt(struct cipher_ctx *ctx,
 				    struct cipher_pkt *pkt, uint8_t *iv)
 {
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	struct crypto_stm32_session *const session = CRYPTO_STM32_SESSN(ctx);
 	int ret;
 	uint32_t vec[BLOCK_LEN_WORDS];
 	int out_offset = 0;
-
-	struct crypto_stm32_session *session = CRYPTO_STM32_SESSN(ctx);
 
 	(void)copy_words_adjust_endianness((uint8_t *)vec, sizeof(vec), iv, BLOCK_LEN_BYTES);
 
@@ -224,7 +226,12 @@ static int crypto_stm32_cbc_encrypt(struct cipher_ctx *ctx,
 		out_offset = 16;
 	}
 
+	k_sem_take(&data->device_sem, K_FOREVER);
+
 	ret = do_aes(ctx, hal_cbc_encrypt_op, pkt->in_buf, pkt->in_len, pkt->out_buf + out_offset);
+
+	k_sem_give(&data->device_sem);
+
 	if (ret == 0) {
 		pkt->out_len = pkt->in_len + out_offset;
 	}
@@ -235,11 +242,11 @@ static int crypto_stm32_cbc_encrypt(struct cipher_ctx *ctx,
 static int crypto_stm32_cbc_decrypt(struct cipher_ctx *ctx,
 				    struct cipher_pkt *pkt, uint8_t *iv)
 {
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	struct crypto_stm32_session *const session = CRYPTO_STM32_SESSN(ctx);
 	int ret;
 	uint32_t vec[BLOCK_LEN_WORDS];
 	int in_offset = 0;
-
-	struct crypto_stm32_session *session = CRYPTO_STM32_SESSN(ctx);
 
 	(void)copy_words_adjust_endianness((uint8_t *)vec, sizeof(vec), iv, BLOCK_LEN_BYTES);
 
@@ -249,7 +256,12 @@ static int crypto_stm32_cbc_decrypt(struct cipher_ctx *ctx,
 		in_offset = 16;
 	}
 
+	k_sem_take(&data->device_sem, K_FOREVER);
+
 	ret = do_aes(ctx, hal_cbc_decrypt_op, pkt->in_buf + in_offset, pkt->in_len, pkt->out_buf);
+
+	k_sem_give(&data->device_sem);
+
 	if (ret == 0) {
 		pkt->out_len = pkt->in_len - in_offset;
 	}
@@ -260,11 +272,11 @@ static int crypto_stm32_cbc_decrypt(struct cipher_ctx *ctx,
 static int crypto_stm32_ctr_encrypt(struct cipher_ctx *ctx,
 				    struct cipher_pkt *pkt, uint8_t *iv)
 {
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	struct crypto_stm32_session *const session = CRYPTO_STM32_SESSN(ctx);
 	int ret;
 	uint32_t ctr[BLOCK_LEN_WORDS] = {0};
 	int ivlen = BLOCK_LEN_BYTES - (ctx->mode_params.ctr_info.ctr_len >> 3);
-
-	struct crypto_stm32_session *session = CRYPTO_STM32_SESSN(ctx);
 
 	if (copy_words_adjust_endianness((uint8_t *)ctr, sizeof(ctr), iv, ivlen) != 0) {
 		return -EIO;
@@ -272,7 +284,12 @@ static int crypto_stm32_ctr_encrypt(struct cipher_ctx *ctx,
 
 	session->config.pInitVect = CAST_VEC(ctr);
 
+	k_sem_take(&data->device_sem, K_FOREVER);
+
 	ret = do_aes(ctx, hal_ctr_encrypt_op, pkt->in_buf, pkt->in_len, pkt->out_buf);
+
+	k_sem_give(&data->device_sem);
+
 	if (ret == 0) {
 		pkt->out_len = pkt->in_len;
 	}
@@ -283,11 +300,11 @@ static int crypto_stm32_ctr_encrypt(struct cipher_ctx *ctx,
 static int crypto_stm32_ctr_decrypt(struct cipher_ctx *ctx,
 				    struct cipher_pkt *pkt, uint8_t *iv)
 {
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	struct crypto_stm32_session *const session = CRYPTO_STM32_SESSN(ctx);
 	int ret;
 	uint32_t ctr[BLOCK_LEN_WORDS] = {0};
 	int ivlen = BLOCK_LEN_BYTES - (ctx->mode_params.ctr_info.ctr_len >> 3);
-
-	struct crypto_stm32_session *session = CRYPTO_STM32_SESSN(ctx);
 
 	if (copy_words_adjust_endianness((uint8_t *)ctr, sizeof(ctr), iv, ivlen) != 0) {
 		return -EIO;
@@ -295,7 +312,12 @@ static int crypto_stm32_ctr_decrypt(struct cipher_ctx *ctx,
 
 	session->config.pInitVect = CAST_VEC(ctr);
 
+	k_sem_take(&data->device_sem, K_FOREVER);
+
 	ret = do_aes(ctx, hal_ctr_decrypt_op, pkt->in_buf, pkt->in_len, pkt->out_buf);
+
+	k_sem_give(&data->device_sem);
+
 	if (ret == 0) {
 		pkt->out_len = pkt->in_len;
 	}

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -57,6 +57,14 @@ LOG_MODULE_REGISTER(crypto_stm32);
 #warning "CCM AD support requires CONFIG_HEAP_MEM_POOL_SIZE > 0"
 #endif
 
+#if IS_ENABLED(CONFIG_CRYPTO_STM32_USE_MBEDTLS_CT_MEMCMP)
+#include <mbedtls/constant_time.h>
+#define STM32_CRYPTO_MEMCMP(a, b, n) mbedtls_ct_memcmp((a), (b), (n))
+#else
+/* memcmp is vulnerable to timing attacks */
+#define STM32_CRYPTO_MEMCMP(a, b, n) memcmp((a), (b), (n))
+#endif
+
 struct crypto_stm32_session crypto_stm32_sessions[CRYPTO_MAX_SESSION];
 
 typedef HAL_StatusTypeDef status_t;
@@ -520,8 +528,7 @@ out:
 		return ret;
 	}
 
-	/* memcmp is vulnerable to timing attacks */
-	if (memcmp(tag, apkt->tag, ctx->mode_params.gcm_info.tag_len) != 0) {
+	if (STM32_CRYPTO_MEMCMP(tag, apkt->tag, ctx->mode_params.gcm_info.tag_len) != 0) {
 		/* auth/tag verification fails */
 		return -EFAULT;
 	}
@@ -706,8 +713,7 @@ static int crypto_stm32_ccm_decrypt(struct cipher_ctx *ctx, struct cipher_aead_p
 		return ret;
 	}
 
-	/* memcmp is vulnerable to timing attacks */
-	if (memcmp(tag, apkt->tag, ctx->mode_params.ccm_info.tag_len) != 0) {
+	if (STM32_CRYPTO_MEMCMP(tag, apkt->tag, ctx->mode_params.ccm_info.tag_len) != 0) {
 		/* auth/tag verification fails */
 		return -EFAULT;
 	}

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -53,17 +53,30 @@ LOG_MODULE_REGISTER(crypto_stm32);
 #define STM32_CRYPTO_HEAP 1
 #endif
 
-#if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) && !IS_ENABLED(STM32_CRYPTO_HEAP)
+#if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT)
+#if !IS_ENABLED(STM32_CRYPTO_HEAP)
 #warning "CCM AD support requires CONFIG_HEAP_MEM_POOL_SIZE > 0"
-#endif
-
+#endif /* !IS_ENABLED(STM32_CRYPTO_HEAP) */
 #if IS_ENABLED(CONFIG_CRYPTO_STM32_USE_MBEDTLS_CT_MEMCMP)
 #include <mbedtls/constant_time.h>
 #define STM32_CRYPTO_MEMCMP(a, b, n) mbedtls_ct_memcmp((a), (b), (n))
 #else
-/* memcmp is vulnerable to timing attacks */
-#define STM32_CRYPTO_MEMCMP(a, b, n) memcmp((a), (b), (n))
-#endif
+/* Returns 0 if the buffers are identical; otherwise, returns a non-zero value */
+static int crypto_stm32_ct_memcmp(const void *a, const void *b, size_t n)
+{
+	const uint8_t *pa;
+	const uint8_t *pb;
+	uint8_t diff = 0U;
+
+	for (pa = a, pb = b; n != 0U; n--, pa++, pb++) {
+		diff |= *pa ^ *pb;
+	}
+
+	return (int)diff;
+}
+#define STM32_CRYPTO_MEMCMP(a, b, n) crypto_stm32_ct_memcmp((a), (b), (n))
+#endif /* IS_ENABLED(CONFIG_CRYPTO_STM32_USE_MBEDTLS_CT_MEMCMP) */
+#endif /* IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) */
 
 struct crypto_stm32_session crypto_stm32_sessions[CRYPTO_MAX_SESSION];
 

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Markus Fuchs <markus.fuchs@de.sauter-bc.com>
+ * Copyright (c) 2025 Georgij Cernysiov <geo.cgv@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +14,7 @@
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/reset.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <soc.h>
 
 #include "crypto_stm32_priv.h"
@@ -43,6 +45,16 @@ LOG_MODULE_REGISTER(crypto_stm32);
 #define STM32_CRYPTO_TYPEDEF            CRYP_TypeDef
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_aes)
 #define STM32_CRYPTO_TYPEDEF            AES_TypeDef
+#endif
+
+#define STM32_CRYPTO_GCM_CCM_SUPPORT DT_INST_PROP(0, gcm_ccm_supported)
+
+#if (K_HEAP_MEM_POOL_SIZE > 0)
+#define STM32_CRYPTO_HEAP 1
+#endif
+
+#if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) && !IS_ENABLED(STM32_CRYPTO_HEAP)
+#warning "CCM AD support requires CONFIG_HEAP_MEM_POOL_SIZE > 0"
 #endif
 
 struct crypto_stm32_session crypto_stm32_sessions[CRYPTO_MAX_SESSION];
@@ -81,7 +93,7 @@ typedef status_t (*hal_cryp_aes_op_func_t)(CRYP_HandleTypeDef *hcryp, uint8_t *i
 #define hal_cbc_decrypt_op hal_decrypt
 #define hal_ctr_encrypt_op hal_encrypt
 #define hal_ctr_decrypt_op hal_decrypt
-#endif
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32l4_aes) */
 
 /* L4 HAL driver uses uint8_t pointers for input/output data while the generic HAL driver uses
  * uint32_t pointers.
@@ -325,6 +337,386 @@ static int crypto_stm32_ctr_decrypt(struct cipher_ctx *ctx,
 	return ret;
 }
 
+#if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT)
+static int do_aes_staged(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn, uint8_t *in_buf,
+			 size_t in_len, uint8_t *out_buf)
+{
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	uint8_t staging_in[BLOCK_LEN_BYTES] __aligned(4) = {0};
+	uint8_t staging_out[BLOCK_LEN_BYTES] __aligned(4);
+	int ret;
+
+	/* Zero payload is allowed.
+	 * Have to configure and execute the operation
+	 * to let the HAL go through required phases.
+	 */
+	if (in_len == 0) {
+		return do_aes(ctx, fn, staging_in, 0, staging_out);
+	}
+
+	/* must be valid */
+	if (in_buf == NULL) {
+		return -EINVAL;
+	}
+
+	/* Process complete 16-byte blocks first to avoid zero-padding in
+	 * the intermediate data within HAL.
+	 * Any trailing partial block is copied into a 4-byte aligned
+	 * stage buffer to avoid data corruption.
+	 * Trailing block shall be processed without key and nonce reloading
+	 * to preserve CRYP state.
+	 */
+	const size_t rem_len = in_len % BLOCK_LEN_BYTES;
+	const size_t aligned_len = in_len - rem_len;
+
+	if (aligned_len != 0) {
+		ret = do_aes(ctx, fn, in_buf, aligned_len, out_buf);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	if (rem_len == 0) {
+		return 0;
+	}
+
+	memcpy(staging_in, in_buf + aligned_len, rem_len);
+
+	if (aligned_len == 0) {
+		/* have to config, then execute the operation */
+		ret = do_aes(ctx, fn, staging_in, rem_len, staging_out);
+		if (ret < 0) {
+			return ret;
+		}
+	} else {
+		/* skip key and iv init
+		 * set to always by default in session setup
+		 */
+		data->hcryp.Init.KeyIVConfigSkip = CRYP_KEYIVCONFIG_ONCE;
+		data->hcryp.KeyIVConfig = 1;
+
+		const status_t fn_rc =
+			fn(&data->hcryp, staging_in, rem_len, staging_out, HAL_MAX_DELAY);
+
+		/* restore key and iv init */
+		data->hcryp.Init.KeyIVConfigSkip = CRYP_KEYIVCONFIG_ALWAYS;
+		data->hcryp.KeyIVConfig = 0;
+
+		if (fn_rc != HAL_OK) {
+			LOG_ERR("Encryption/decryption error");
+			return -EIO;
+		}
+	}
+
+	memcpy(out_buf + aligned_len, staging_out, rem_len);
+
+	return 0;
+}
+
+static int crypto_stm32_gcm(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn,
+			    struct cipher_aead_pkt *apkt, uint8_t *nonce)
+{
+	struct crypto_stm32_session *const session = CRYPTO_STM32_SESSN(ctx);
+	uint8_t *dst;
+	uint32_t iv[BLOCK_LEN_WORDS] = {0};
+
+	if (!IN_RANGE(apkt->pkt->in_len, 0, apkt->pkt->out_buf_max)) {
+		return -EINVAL;
+	}
+
+	if ((nonce == NULL) || (ctx->mode_params.gcm_info.nonce_len != 12U)) {
+		return -EINVAL;
+	}
+
+	if (ctx->mode_params.gcm_info.tag_len != BLOCK_LEN_BYTES) {
+		return -EINVAL;
+	}
+
+	/* in-place operation can have out_buf set to NULL */
+	dst = apkt->pkt->out_buf ? apkt->pkt->out_buf : apkt->pkt->in_buf;
+
+	if (copy_words_adjust_endianness((uint8_t *)iv, sizeof(iv), nonce,
+					 ctx->mode_params.gcm_info.nonce_len) != 0) {
+		return -EIO;
+	}
+
+	iv[3] = 2U;
+
+	session->config.pInitVect = CAST_VEC(iv);
+
+	if ((apkt->ad == NULL) || (apkt->ad_len == 0U)) {
+		session->config.Header = NULL;
+		session->config.HeaderSize = 0U;
+	} else {
+		session->config.Header = CAST_VEC(apkt->ad);
+		session->config.HeaderSize = apkt->ad_len;
+		session->config.HeaderWidthUnit = CRYP_HEADERWIDTHUNIT_BYTE;
+	}
+
+	return do_aes_staged(ctx, fn, apkt->pkt->in_buf, apkt->pkt->in_len, dst);
+}
+
+static int crypto_stm32_gcm_encrypt(struct cipher_ctx *ctx, struct cipher_aead_pkt *apkt,
+				    uint8_t *nonce)
+{
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	uint8_t tag[BLOCK_LEN_BYTES] = {0};
+	int ret;
+
+	if (apkt->tag == NULL) {
+		return -EINVAL;
+	}
+
+	k_sem_take(&data->device_sem, K_FOREVER);
+
+	ret = crypto_stm32_gcm(ctx, hal_encrypt, apkt, nonce);
+	if (ret < 0) {
+		goto out;
+	}
+
+	if (HAL_CRYPEx_AESGCM_GenerateAuthTAG(&data->hcryp, CAST_VEC(tag),
+					      HAL_MAX_DELAY) != HAL_OK) {
+		ret = -EIO;
+	}
+
+out:
+	k_sem_give(&data->device_sem);
+
+	if (ret == 0) {
+		memcpy(apkt->tag, tag, ctx->mode_params.gcm_info.tag_len);
+		apkt->pkt->out_len = apkt->pkt->in_len;
+	}
+
+	return ret;
+}
+
+static int crypto_stm32_gcm_decrypt(struct cipher_ctx *ctx, struct cipher_aead_pkt *apkt,
+				    uint8_t *nonce)
+{
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	uint8_t tag[BLOCK_LEN_BYTES] = {0};
+	int ret;
+
+	if (apkt->tag == NULL) {
+		return -EINVAL;
+	}
+
+	k_sem_take(&data->device_sem, K_FOREVER);
+
+	ret = crypto_stm32_gcm(ctx, hal_decrypt, apkt, nonce);
+	if (ret < 0) {
+		goto out;
+	}
+
+	if (HAL_CRYPEx_AESGCM_GenerateAuthTAG(&data->hcryp, CAST_VEC(tag),
+					      HAL_MAX_DELAY) != HAL_OK) {
+		ret = -EIO;
+	}
+
+out:
+	k_sem_give(&data->device_sem);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* memcmp is vulnerable to timing attacks */
+	if (memcmp(tag, apkt->tag, ctx->mode_params.gcm_info.tag_len) != 0) {
+		/* auth/tag verification fails */
+		return -EFAULT;
+	}
+
+	apkt->pkt->out_len = apkt->pkt->in_len;
+	return ret;
+}
+
+static int crypto_stm32_ccm(struct cipher_ctx *ctx, hal_cryp_aes_op_func_t fn,
+			    struct cipher_aead_pkt *apkt, uint8_t *nonce, uint8_t *tag)
+{
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	struct crypto_stm32_session *const session = CRYPTO_STM32_SESSN(ctx);
+	/* B1 - Associated Data (AD) */
+	uint8_t *b1 = NULL;
+	uint8_t *dst;
+	/* B0 - Authentication block */
+	uint8_t b0[BLOCK_LEN_BYTES] __aligned(4) = {0};
+	unsigned int idx;
+	int ret;
+	uint8_t q;
+
+	if (!IN_RANGE(apkt->pkt->in_len, 0, apkt->pkt->out_buf_max)) {
+		return -EINVAL;
+	}
+
+	/* in-place operation can have out_buf set to NULL */
+	dst = apkt->pkt->out_buf ? apkt->pkt->out_buf : apkt->pkt->in_buf;
+
+	/* tag length: 4, 6, 8, 10, 12, 14, 16 */
+	if ((ctx->mode_params.ccm_info.tag_len < 4U) ||
+	    (ctx->mode_params.ccm_info.tag_len > 16U) ||
+	    (ctx->mode_params.ccm_info.tag_len % 2U) != 0U) {
+		return -EINVAL;
+	}
+
+	/* nonce length [7, 13] */
+	if ((nonce == NULL) || (ctx->mode_params.ccm_info.nonce_len < 7U) ||
+	    (ctx->mode_params.ccm_info.nonce_len > 13U)) {
+		return -EINVAL;
+	}
+
+	/* bytes left for payload length */
+	q = 15U - ctx->mode_params.ccm_info.nonce_len;
+
+	/* check if payload length fits into q bytes */
+	if (apkt->pkt->in_len > BIT_MASK(8U * q)) {
+		return -EINVAL;
+	}
+
+	if ((apkt->ad == NULL) || (apkt->ad_len == 0U)) {
+		session->config.Header = NULL;
+		session->config.HeaderSize = 0U;
+	} else {
+#if IS_ENABLED(STM32_CRYPTO_HEAP)
+		size_t b1_padded_len;
+		uint8_t header_len;
+
+		if (apkt->ad_len < 0xFF00U) {
+			header_len = 2U;
+		} else {
+			/* ad_len is uint32_t (support len < 0xFFFFFFFFU) */
+			header_len = 6U;
+		}
+
+		if (apkt->ad_len > (UINT32_MAX - header_len - BLOCK_LEN_BYTES)) {
+			/* overflow */
+			return -EINVAL;
+		}
+
+		b1_padded_len = ROUND_UP(apkt->ad_len + header_len, BLOCK_LEN_BYTES);
+		if (b1_padded_len > UINT32_MAX) {
+			/* HeaderSize is uint32_t */
+			return -EINVAL;
+		}
+
+		b1 = k_calloc(1, b1_padded_len);
+		if (b1 == NULL) {
+			return -ENOMEM;
+		}
+
+		if (header_len == 2U) {
+			sys_put_be16(apkt->ad_len, b1);
+		} else {
+			b1[0] = 0xFFU;
+			b1[1] = 0xFEU;
+			sys_put_be32(apkt->ad_len, b1 + 2U);
+		}
+
+		memcpy(b1 + header_len, apkt->ad, apkt->ad_len);
+
+		session->config.Header = CAST_VEC(b1);
+		session->config.HeaderSize = b1_padded_len / sizeof(uint32_t);
+		session->config.HeaderWidthUnit = CRYP_HEADERWIDTHUNIT_WORD;
+
+		/* set AD presence flag */
+		b0[0] = BIT(6);
+#else
+		return -ENOMEM;
+#endif /* IS_ENABLED(STM32_CRYPTO_HEAP) */
+	}
+
+	/* encode leftover flags */
+	b0[0] |= ((ctx->mode_params.ccm_info.tag_len - 2U) / 2U) << 3U;
+	b0[0] |= q - 1U;
+
+	/* encode nonce */
+	memcpy(&b0[1], nonce, ctx->mode_params.ccm_info.nonce_len);
+
+	/* encode payload length */
+	for (idx = 0U; idx < q; idx++) {
+		b0[15U - idx] = (uint8_t)((apkt->pkt->in_len >> (8U * idx)) & 0xFFU);
+	}
+
+	/* set B0 */
+	for (idx = 0U; idx < sizeof(b0); idx += sizeof(uint32_t)) {
+		sys_cpu_to_be(&b0[idx], sizeof(uint32_t));
+	}
+
+	session->config.B0 = CAST_VEC(b0);
+
+	ret = do_aes_staged(ctx, fn, apkt->pkt->in_buf, apkt->pkt->in_len, dst);
+
+	k_free(b1);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* compute auth tag, b0 shall be valid; hcryp holds a pointer to it */
+	if (HAL_CRYPEx_AESCCM_GenerateAuthTAG(&data->hcryp, CAST_VEC(tag),
+					      HAL_MAX_DELAY) != HAL_OK) {
+		ret = -EIO;
+	}
+
+	return ret;
+}
+
+static int crypto_stm32_ccm_encrypt(struct cipher_ctx *ctx, struct cipher_aead_pkt *apkt,
+				    uint8_t *nonce)
+{
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	uint8_t tag[BLOCK_LEN_BYTES] = {0};
+	int ret;
+
+	if (apkt->tag == NULL) {
+		return -EINVAL;
+	}
+
+	k_sem_take(&data->device_sem, K_FOREVER);
+
+	ret = crypto_stm32_ccm(ctx, hal_encrypt, apkt, nonce, &tag[0]);
+
+	k_sem_give(&data->device_sem);
+
+	if (ret == 0) {
+		memcpy(apkt->tag, tag, ctx->mode_params.ccm_info.tag_len);
+		apkt->pkt->out_len = apkt->pkt->in_len;
+	}
+
+	return ret;
+}
+
+static int crypto_stm32_ccm_decrypt(struct cipher_ctx *ctx, struct cipher_aead_pkt *apkt,
+				    uint8_t *nonce)
+{
+	struct crypto_stm32_data *const data = CRYPTO_STM32_DATA(ctx->device);
+	uint8_t tag[BLOCK_LEN_BYTES] = {0};
+	int ret;
+
+	if (apkt->tag == NULL) {
+		return -EINVAL;
+	}
+
+	k_sem_take(&data->device_sem, K_FOREVER);
+
+	ret = crypto_stm32_ccm(ctx, hal_decrypt, apkt, nonce, &tag[0]);
+
+	k_sem_give(&data->device_sem);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* memcmp is vulnerable to timing attacks */
+	if (memcmp(tag, apkt->tag, ctx->mode_params.ccm_info.tag_len) != 0) {
+		/* auth/tag verification fails */
+		return -EFAULT;
+	}
+
+	apkt->pkt->out_len = apkt->pkt->in_len;
+	return ret;
+}
+#endif /* IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) */
+
 static int crypto_stm32_get_unused_session_index(const struct device *dev)
 {
 	int i;
@@ -365,18 +757,12 @@ static int crypto_stm32_session_setup(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	/* The CRYP peripheral supports the AES ECB, CBC, CTR, CCM and GCM
-	 * modes of operation, of which ECB, CBC, CTR and CCM are supported
-	 * through the crypto API. However, in CCM mode, although the STM32Cube
-	 * HAL driver follows the documentation (cf. RM0090, par. 23.3) by
-	 * padding incomplete input data blocks in software prior encryption,
-	 * incorrect authentication tags are returned for input data which is
-	 * not a multiple of 128 bits. Therefore, CCM mode is not supported by
-	 * this driver.
-	 */
 	if ((mode != CRYPTO_CIPHER_MODE_ECB) &&
 	    (mode != CRYPTO_CIPHER_MODE_CBC) &&
-	    (mode != CRYPTO_CIPHER_MODE_CTR)) {
+	    (mode != CRYPTO_CIPHER_MODE_CTR) &&
+	    (!IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) ||
+		((mode != CRYPTO_CIPHER_MODE_CCM) &&
+		 (mode != CRYPTO_CIPHER_MODE_GCM)))) {
 		LOG_ERR("Unsupported mode");
 		return -ENOTSUP;
 	}
@@ -447,6 +833,16 @@ static int crypto_stm32_session_setup(const struct device *dev,
 #endif
 			ctx->ops.ctr_crypt_hndlr = crypto_stm32_ctr_encrypt;
 			break;
+#if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT)
+		case CRYPTO_CIPHER_MODE_GCM:
+			session->config.Algorithm = CRYP_AES_GCM;
+			ctx->ops.gcm_crypt_hndlr = crypto_stm32_gcm_encrypt;
+			break;
+		case CRYPTO_CIPHER_MODE_CCM:
+			session->config.Algorithm = CRYP_AES_CCM;
+			ctx->ops.ccm_crypt_hndlr = crypto_stm32_ccm_encrypt;
+			break;
+#endif /* IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) */
 		default:
 			CODE_UNREACHABLE;
 		}
@@ -470,6 +866,16 @@ static int crypto_stm32_session_setup(const struct device *dev,
 #endif
 			ctx->ops.ctr_crypt_hndlr = crypto_stm32_ctr_decrypt;
 			break;
+#if IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT)
+		case CRYPTO_CIPHER_MODE_GCM:
+			session->config.Algorithm = CRYP_AES_GCM;
+			ctx->ops.gcm_crypt_hndlr = crypto_stm32_gcm_decrypt;
+			break;
+		case CRYPTO_CIPHER_MODE_CCM:
+			session->config.Algorithm = CRYP_AES_CCM;
+			ctx->ops.ccm_crypt_hndlr = crypto_stm32_ccm_decrypt;
+			break;
+#endif /* IS_ENABLED(STM32_CRYPTO_GCM_CCM_SUPPORT) */
 		default:
 			CODE_UNREACHABLE;
 		}

--- a/dts/arm/st/h7/stm32h730.dtsi
+++ b/dts/arm/st/h7/stm32h730.dtsi
@@ -16,6 +16,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
+			gcm-ccm-supported;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h755.dtsi
+++ b/dts/arm/st/h7/stm32h755.dtsi
@@ -17,6 +17,7 @@
 			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
+			gcm-ccm-supported;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/h7/stm32h7b0.dtsi
+++ b/dts/arm/st/h7/stm32h7b0.dtsi
@@ -21,6 +21,7 @@
 			resets = <&rctl STM32_RESET(AHB2, 4)>;
 			interrupts = <79 0>;
 			interrupt-names = "cryp";
+			gcm-ccm-supported;
 			status = "disabled";
 		};
 

--- a/dts/bindings/crypto/st,stm32-cryp.yaml
+++ b/dts/bindings/crypto/st,stm32-cryp.yaml
@@ -6,3 +6,8 @@ description: STM32 Cryptographic Accelerator
 compatible: "st,stm32-cryp"
 
 include: st,stm32-crypto-common.yaml
+
+properties:
+  gcm-ccm-supported:
+    type: boolean
+    description: Enables AES GCM and CCM support.

--- a/soc/st/stm32/Kconfig.defconfig
+++ b/soc/st/stm32/Kconfig.defconfig
@@ -215,4 +215,14 @@ endif # DT_HAS_ST_STM32_DMA2D_ENABLED
 
 endif # STM32_LTDC && LVGL
 
+if CRYPTO_STM32
+
+# Ensure minimal heap size needed to handle
+# AES CCM with up to 14 bytes of Additional Data (AD)
+config HEAP_MEM_POOL_ADD_SIZE_CRYPTO_STM32
+	int
+	default 16 if $(dt_nodelabel_enabled,cryp) && $(dt_nodelabel_has_prop,cryp,gcm-ccm-supported)
+
+endif # CRYPTO_STM32
+
 endif # SOC_FAMILY_STM32


### PR DESCRIPTION
Adds support for AES-CCM and AES-GCM cipher modes.

The support is limited to the following STM32 H7 SoCs:
`STM32H723XX`, `STM32H725XX`, `STM32H730XX`, `STM32H730XXQ`, and `STM32H735XX`, as they share the same reference manual.

Note: testing was performed on the `STM32H730XX`.

Crypto sample output:
```yml
Cipher Sample
ECB Mode
Output length (encryption): 16
ECB mode ENCRYPT - Match
Output length (decryption): 16
ECB mode DECRYPT - Match
CBC Mode
Output length (encryption): 80
CBC mode ENCRYPT - Match
Output length (decryption): 64
CBC mode DECRYPT - Match
CTR Mode
Output length (encryption): 64
CTR mode ENCRYPT - Match
Output length (decryption): 64
CTR mode DECRYPT - Match
CCM Mode
Output length (encryption): 23
CCM mode ENCRYPT - Match
Output length (decryption): 23
CCM mode DECRYPT - Match
GCM Mode
Output length (encryption): 42
GCM mode ENCRYPT - Match
Output length (decryption): 42
GCM mode DECRYPT - Match
```

The pull request is open for review but not yet ready to be merged (_therefore, labeled `DNM`_) due to an issue in the STM32 H7 HAL related to GCM tag generation during decryption: https://github.com/STMicroelectronics/stm32h7xx-hal-driver/issues/88.