### PR TITLE
ptp_clock: clarify ptp_clock_rate_adjust function

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -75,6 +75,15 @@ Display
   This has now been fixed. Boards and applications that were tested or developed based on the
   previous sample may be affected by this change (see :github:`79996` for more information).
 
+PTP Clock
+*********
+
+* The doc of :c:func:`ptp_clock_rate_adjust` API didn't provide proper and clear function description.
+  Drivers implemented it to adjust rate ratio relatively based on current frequency.
+  Now PI servo is introduced in both PTP and gPTP, and this API function is changed to use for rate
+  ratio adjusting based on nominal frequency. Drivers implementing :c:func:`ptp_clock_rate_adjust`
+  should be adjusted to account for the new behavior.
+
 Other subsystems
 ****************
 

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -382,21 +382,11 @@ static int ptp_clock_e1000_rate_adjust(const struct device *dev, double ratio)
 	int32_t mul;
 	float val;
 
-	/* No change needed. */
-	if (ratio == 1.0) {
-		return 0;
-	}
-
-	ratio *= context->clk_ratio;
-
 	/* Limit possible ratio. */
 	if ((ratio > 1.0 + 1.0/(2.0 * hw_inc)) ||
 			(ratio < 1.0 - 1.0/(2.0 * hw_inc))) {
 		return -EINVAL;
 	}
-
-	/* Save new ratio. */
-	context->clk_ratio = ratio;
 
 	if (ratio < 1.0) {
 		corr = hw_inc - 1;

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -92,7 +92,6 @@ struct e1000_dev {
 	uint8_t rxb[NET_ETH_MTU];
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)
 	const struct device *ptp_clock;
-	double clk_ratio;
 #endif
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	struct net_stats_eth stats;

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1503,14 +1503,7 @@ static int ptp_clock_stm32_rate_adjust(const struct device *dev, double ratio)
 	int key, ret;
 	uint32_t addend_val;
 
-	/* No change needed */
-	if (ratio == 1.0L) {
-		return 0;
-	}
-
 	key = irq_lock();
-
-	ratio *= (double)eth_dev_data->clk_ratio_adj;
 
 	/* Limit possible ratio */
 	if (ratio * 100 < CONFIG_ETH_STM32_HAL_PTP_CLOCK_ADJ_MIN_PCT ||
@@ -1518,9 +1511,6 @@ static int ptp_clock_stm32_rate_adjust(const struct device *dev, double ratio)
 		ret = -EINVAL;
 		goto error;
 	}
-
-	/* Save new ratio */
-	eth_dev_data->clk_ratio_adj = ratio;
 
 	/* Update addend register */
 	addend_val = UINT32_MAX * (double)eth_dev_data->clk_ratio * ratio;
@@ -1619,12 +1609,10 @@ static int ptp_stm32_init(const struct device *port)
 	 * clk_ratio is a ratio between desired PTP clock frequency and HCLK rate.
 	 * Because HCLK is defined by a physical oscillator, it might drift due
 	 * to manufacturing tolerances and environmental effects (e.g. temperature).
-	 * clk_ratio_adj compensates for such inaccuracies. It starts off as 1.0
-	 * and gets adjusted by calling ptp_clock_stm32_rate_adjust().
+	 * It gets adjusted by calling ptp_clock_stm32_rate_adjust().
 	 */
-	eth_dev_data->clk_ratio_adj = 1.0f;
 	addend_val =
-		UINT32_MAX * eth_dev_data->clk_ratio * eth_dev_data->clk_ratio_adj;
+		UINT32_MAX * eth_dev_data->clk_ratio;
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_ethernet)
 	heth->Instance->MACTSAR = addend_val;
 	heth->Instance->MACTSCR |= ETH_MACTSCR_TSADDREG;

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -60,7 +60,6 @@ struct eth_stm32_hal_dev_data {
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	const struct device *ptp_clock;
 	float clk_ratio;
-	float clk_ratio_adj;
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	struct net_stats_eth stats;

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -82,10 +82,10 @@ static inline int ptp_clock_adjust(const struct device *dev, int increment)
 }
 
 /**
- * @brief Adjust the PTP clock time change rate when compared to its neighbor.
+ * @brief Adjust the PTP clock rate ratio based on its nominal frequency
  *
  * @param dev PTP clock device
- * @param rate Rate of the clock time change
+ * @param rate Rate ratio based on its nominal frequency
  *
  * @return 0 if ok, <0 if error
  */


### PR DESCRIPTION
    It's not very clear about the function of ptp_clock_rate_adjust in doc.
    Previously, all device drivers used it to adjust rate ratio relatively
    based on current frequency.

    When PI servo was introduced in PTP and gPTP stacks, NXP ENET PTP driver
    started to use it to adjust rate ratio based on its nominal frequency.

    Rate ratio adjustment based on nominal frequency with PI servo could
    get stable frequency control. So, let's clarify ptp_clock_rate_adjust
    adjusting rate ratio based on nominal frequency, and convert other
    device drivers.

I am not able to verify these changes since I don't have these boards. If the platform owner could verify, the expected logs of ptp and gptp will be as below. The sync offset will be convergent.


gptp log

```
[00:00:02.822,000] <inf> phy_mc_ksz8081: PHY 0 is up
[00:00:02.822,000] <inf> phy_mc_ksz8081: PHY (0) Link speed 100 Mb, full duplex

[00:00:02.823,000] <inf> eth_nxp_enet_mac: Link is up
*** Booting Zephyr OS build v4.1.0-3062-g764340614802 ***
[00:00:02.826,000] <inf> net_config: Initializing network
[00:00:02.826,000] <inf> net_config: IPv4 address: 192.0.2.1
[00:00:02.928,000] <inf> net_config: IPv6 address: 2001:db8::1
[00:00:03.830,000] <wrn> net_gptp: Reset Pdelay requests
[00:00:05.268,000] <dbg> net_gptp_sample: gptp_phase_dis_cb: GM FA:FA:62:FF:FE:FE:A2:11 last phase 0.0
[00:00:06.893,000] <inf> net_gptp: sync offset   -117781 ns, freq offset -117781.000000 ppb
[00:00:07.894,000] <inf> net_gptp: sync offset    -73643 ns, freq offset -108977.300000 ppb
[00:00:08.894,000] <inf> net_gptp: sync offset    -37936 ns, freq offset -95363.200000 ppb
[00:00:09.894,000] <inf> net_gptp: sync offset    -15866 ns, freq offset -84674.000000 ppb
[00:00:10.895,000] <inf> net_gptp: sync offset     -4318 ns, freq offset -77885.800000 ppb
[00:00:11.895,000] <inf> net_gptp: sync offset       564 ns, freq offset -74299.200000 ppb
[00:00:12.895,000] <inf> net_gptp: sync offset      1731 ns, freq offset -72963.000000 ppb
[00:00:13.895,000] <inf> net_gptp: sync offset      1687 ns, freq offset -72487.700000 ppb
[00:00:14.896,000] <inf> net_gptp: sync offset      1098 ns, freq offset -72570.600000 ppb
[00:00:15.896,000] <inf> net_gptp: sync offset       540 ns, freq offset -72799.200000 ppb
[00:00:16.896,000] <inf> net_gptp: sync offset       181 ns, freq offset -72996.200000 ppb
[00:00:17.896,000] <inf> net_gptp: sync offset       127 ns, freq offset -72995.900000 ppb
[00:00:18.896,000] <inf> net_gptp: sync offset       -50 ns, freq offset -73134.800000 ppb
[00:00:19.897,000] <inf> net_gptp: sync offset        59 ns, freq offset -73040.800000 ppb
[00:00:20.897,000] <inf> net_gptp: sync offset       -39 ns, freq offset -73121.100000 ppb
[00:00:21.897,000] <inf> net_gptp: sync offset        41 ns, freq offset -73052.800000 ppb
[00:00:22.897,000] <inf> net_gptp: sync offset       -89 ns, freq offset -73170.500000 ppb
[00:00:23.897,000] <inf> net_gptp: sync offset        62 ns, freq offset -73046.200000 ppb
[00:00:24.897,000] <inf> net_gptp: sync offset       -64 ns, freq offset -73153.600000 ppb
[00:00:25.898,000] <inf> net_gptp: sync offset       -27 ns, freq offset -73135.800000 ppb
[00:00:26.898,000] <inf> net_gptp: sync offset        50 ns, freq offset -73066.900000 ppb
[00:00:27.898,000] <inf> net_gptp: sync offset        -3 ns, freq offset -73104.900000 ppb
[00:00:28.899,000] <inf> net_gptp: sync offset        66 ns, freq offset -73036.800000 ppb
[00:00:29.899,000] <inf> net_gptp: sync offset       -63 ns, freq offset -73146.000000 ppb
[00:00:30.899,000] <inf> net_gptp: sync offset       -28 ns, freq offset -73129.900000 ppb
[00:00:31.900,000] <inf> net_gptp: sync offset       132 ns, freq offset -72978.300000 ppb
[00:00:32.900,000] <inf> net_gptp: sync offset        -7 ns, freq offset -73077.700000 ppb
[00:00:33.900,000] <inf> net_gptp: sync offset      -139 ns, freq offset -73211.800000 ppb
[00:00:34.901,000] <inf> net_gptp: sync offset       -58 ns, freq offset -73172.500000 ppb
[00:00:35.901,000] <inf> net_gptp: sync offset         1 ns, freq offset -73130.900000 ppb
[00:00:36.901,000] <inf> net_gptp: sync offset        82 ns, freq offset -73049.600000 ppb
[00:00:37.901,000] <inf> net_gptp: sync offset        -4 ns, freq offset -73111.000000 ppb
[00:00:38.902,000] <inf> net_gptp: sync offset       109 ns, freq offset -72999.200000 ppb
```


ptp log

```
[00:00:45.452,000] <dbg> ptp_port: port_state_update: Port 1 changed state from TIME TRANSMITTER to TIME RECEIVER
[00:00:46.139,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:46.139,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 0 Delay_Req
[00:00:46.141,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:46.450,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:46.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:47.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:47.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:47.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:48.139,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:48.139,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 1 Delay_Req
[00:00:48.141,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:48.141,000] <dbg> ptp_clock: ptp_clock_delay: Delay -445ns
[00:00:48.450,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:48.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:48.452,000] <wrn> ptp_clock: Clock offset exceeds 1 second.
[00:00:48.452,000] <wrn> ptp_clock: Set clock time: 46.586880075
[00:00:49.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:49.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:49.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -6240ns
[00:00:49.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:50.139,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:50.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 2 Delay_Req
[00:00:50.141,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:50.141,000] <dbg> ptp_clock: ptp_clock_delay: Delay -2608ns
[00:00:50.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:50.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:50.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 8548ns
[00:00:51.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:51.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:51.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 8215ns
[00:00:51.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:52.139,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:52.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 3 Delay_Req
[00:00:52.141,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:52.141,000] <dbg> ptp_clock: ptp_clock_delay: Delay 2597ns
[00:00:52.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:52.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:52.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 508ns
[00:00:53.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:53.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:53.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 3152ns
[00:00:53.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:54.140,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:54.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 4 Delay_Req
[00:00:54.141,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:54.142,000] <dbg> ptp_clock: ptp_clock_delay: Delay 1748ns
[00:00:54.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:54.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:54.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 3948ns
[00:00:55.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:55.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:55.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 2068ns
[00:00:55.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:56.139,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:56.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 5 Delay_Req
[00:00:56.141,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:56.141,000] <dbg> ptp_clock: ptp_clock_delay: Delay 2137ns
[00:00:56.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:56.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:56.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 572ns
[00:00:57.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:57.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:57.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 259ns
[00:00:57.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:00:58.140,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:00:58.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 6 Delay_Req
[00:00:58.142,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:00:58.142,000] <dbg> ptp_clock: ptp_clock_delay: Delay 1787ns
[00:00:58.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:58.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:58.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 438ns
[00:00:59.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:00:59.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:00:59.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 92ns
[00:00:59.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:01:00.140,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:01:00.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 7 Delay_Req
[00:01:00.142,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:01:00.142,000] <dbg> ptp_clock: ptp_clock_delay: Delay 1801ns
[00:01:00.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:00.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:00.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -133ns
[00:01:01.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:01.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:01.453,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -68ns
[00:01:01.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:01:02.140,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:01:02.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 8 Delay_Req
[00:01:02.142,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:01:02.142,000] <dbg> ptp_clock: ptp_clock_delay: Delay 1737ns
[00:01:02.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:02.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:02.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -43ns
[00:01:03.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:03.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:03.453,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -88ns
[00:01:03.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:01:04.140,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:01:04.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 9 Delay_Req
[00:01:04.142,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:01:04.142,000] <dbg> ptp_clock: ptp_clock_delay: Delay 1719ns
[00:01:04.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:04.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:04.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 23ns
[00:01:05.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:05.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:05.453,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -48ns
[00:01:05.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:01:06.140,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:01:06.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 10 Delay_Req
[00:01:06.142,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:01:06.142,000] <dbg> ptp_clock: ptp_clock_delay: Delay 1731ns
[00:01:06.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:06.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:06.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 14ns
[00:01:07.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:07.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:07.453,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -41ns
[00:01:07.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Announce message
[00:01:08.140,000] <dbg> ptp_port: port_delay_req_msg_transmit: Port 1 sends Delay_Req message
[00:01:08.140,000] <dbg> ptp_port: port_delay_req_timestamp_cb: Port 1 registered timestamp for 11 Delay_Req
[00:01:08.142,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Delay_Resp message
[00:01:08.142,000] <dbg> ptp_clock: ptp_clock_delay: Delay 1729ns
[00:01:08.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:08.452,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:08.452,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset -42ns
[00:01:09.451,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Sync message
[00:01:09.453,000] <dbg> ptp_msg: ptp_msg_post_recv: Port 1 received Follow_Up message
[00:01:09.453,000] <dbg> ptp_clock: ptp_clock_synchronize: Offset 48ns
```