### PR TITLE
board: nrf: Fix nRF54LM20DK upstream Bluetooth Controller supported

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
@@ -18,7 +18,7 @@
 		zephyr,bt-c2h-uart = &uart20;
 		zephyr,flash-controller = &rram_controller;
 		zephyr,flash = &cpuapp_rram;
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,ieee802154 = &ieee802154;
 	};
 };

--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.dts
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.dts
@@ -18,12 +18,8 @@
 	};
 };
 
-&bt_hci_sdc {
-	status = "okay";
-};
-
 &bt_hci_controller {
-	status = "disabled";
+	status = "okay";
 };
 
 /* Get a node label for wi-fi spi to use in shield files */

--- a/dts/vendor/nordic/nrf54lm20a.dtsi
+++ b/dts/vendor/nordic/nrf54lm20a.dtsi
@@ -277,11 +277,6 @@
 				/* Note: In the nRF Connect SDK the SoftDevice Controller
 				 * is added and set as the default Bluetooth Controller.
 				 */
-				bt_hci_sdc: bt_hci_sdc {
-					compatible = "nordic,bt-hci-sdc";
-					status = "disabled";
-				};
-
 				bt_hci_controller: bt_hci_controller {
 					compatible = "zephyr,bt-hci-ll-sw-split";
 					status = "disabled";

--- a/samples/bluetooth/hci_uart/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/bluetooth/hci_uart/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart20 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};

--- a/samples/bluetooth/hci_uart/boards/nrf54lm20dk_nrf54lm20a_cpuapp_df.overlay
+++ b/samples/bluetooth/hci_uart/boards/nrf54lm20dk_nrf54lm20a_cpuapp_df.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&uart20 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <1000000>;
+	status = "okay";
+	hw-flow-control;
+};
+
+&radio {
+	status = "okay";
+	/* This is an example number of antennas that may be available
+	 * on antenna matrix board.
+	 */
+	dfe-antenna-num = <10>;
+	/* This is an example switch pattern that will be used to set an
+	 * antenna for Tx PDU (period before start of Tx CTE).
+	 */
+	dfe-pdu-antenna = <0x0>;
+
+	/* These are example GPIO pin numbers that are provided to
+	 * Radio peripheral. The pins will be acquired by Radio to
+	 * drive antenna switching when AoD is enabled.
+	 */
+	dfegpio0-gpios = <&gpio1 4 0>;
+	dfegpio1-gpios = <&gpio1 5 0>;
+	dfegpio2-gpios = <&gpio1 6 0>;
+	dfegpio3-gpios = <&gpio1 7 0>;
+};

--- a/samples/bluetooth/hci_uart/sample.yaml
+++ b/samples/bluetooth/hci_uart/sample.yaml
@@ -8,10 +8,14 @@ tests:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
       - nrf21540dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     tags:
       - uart
       - bluetooth
@@ -95,6 +99,17 @@ tests:
     extra_args:
       - EXTRA_CONF_FILE=overlay-all-bt_ll_sw_split.conf
       - DTC_OVERLAY_FILE=./boards/nrf54l15dk_nrf54l15_cpuapp_df.overlay
+    tags:
+      - uart
+      - bluetooth
+  sample.bluetooth.hci_uart.nrf54lm20a.all:
+    harness: bluetooth
+    platform_allow: nrf54lm20dk/nrf54lm20a/cpuapp
+    integration_platforms:
+      - nrf54lm20dk/nrf54lm20a/cpuapp
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-all-bt_ll_sw_split.conf
+      - DTC_OVERLAY_FILE=./boards/nrf54lm20dk_nrf54lm20a_cpuapp_df.overlay
     tags:
       - uart
       - bluetooth


### PR DESCRIPTION
Fix nRF54LM20DK upstream Bluetooth Controller supported.

Relates to commit 3d1fa8b333e8 ("board: nrf: Add nRF54LM20DK board").