### PR TITLE
MAINTAINERS: Sort areas by name

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -111,6 +111,7 @@
 
 # Areas are sorted by name
 
+# zephyr-keep-sorted-start strip(":) nofold
 ACPI:
   status: maintained
   maintainers:
@@ -126,32 +127,37 @@ ACPI:
   tests:
     - acpi
 
-Aesc Platform:
+ADI Platforms:
   status: maintained
   maintainers:
-    - dnltz
-  files:
-    - soc/aesc/
-    - dts/riscv/aesc/
-    - boards/aesc/
-  files-regex:
-    - ^drivers/.*aesc(\.c)?$
-  labels:
-    - "area: Aesc Silicon Platform"
-
-Antmicro platforms:
-  status: maintained
-  maintainers:
-    - fkokosinski
-    - tgorochowik
+    - MaureenHelm
   collaborators:
-    - kgugala
+    - ozersa
+    - ttmut
+    - yasinustunerg
+    - galak
+    - microbuilder
   files:
-    - boards/antmicro/
-    - soc/antmicro/
-    - dts/arm/antmicro/
+    - boards/adi/
+    - boards/shields/eval*ardz/
+    - boards/shields/pmod_acl/
+    - drivers/*/*max*
+    - drivers/*/*max*/
+    - drivers/dac/dac_ltc*
+    - drivers/ethernet/eth_adin*
+    - drivers/ethernet/phy/phy_adin*
+    - drivers/mdio/mdio_adin*
+    - drivers/sensor/adi/
+    - drivers/stepper/adi_tmc/
+    - dts/arm/adi/
+    - dts/bindings/*/adi,*
+    - dts/bindings/*/lltc,*
+    - dts/bindings/*/maxim,*
+    - soc/adi/
+  files-regex:
+    - ^drivers/(adc|dac|gpio|mfd|regulator)/.*adp?\d+
   labels:
-    - "platform: Antmicro"
+    - "platform: ADI"
 
 ARC arch:
   status: maintained
@@ -175,16 +181,40 @@ ARC arch:
   tests:
     - arch.arc
 
-Arduino Platforms:
+ARM Platforms:
   status: maintained
   maintainers:
-    - pillo79
+    - wearyzen
   collaborators:
-    - facchinm
+    - ithinuel
   files:
-    - boards/arduino/
-    - boards/shields/arduino_*/
-    - drivers/*/*modulino*
+    - boards/arm/mps*/
+    - boards/arm/v2m_*/
+    - boards/arm/fvp_base*/
+    - soc/arm/mps*/
+    - soc/arm/musca/
+    - soc/arm/beetle/
+    - soc/arm/designstart/
+    - soc/arm/fvp_aemv8*/
+    - dts/arm/armv*.dtsi
+    - dts/bindings/arm/arm*.yaml
+    - drivers/interrupt_controller/intc_gic*
+  labels:
+    - "platform: ARM"
+
+ARM SiP SVC:
+  status: odd fixes
+  files:
+    - subsys/sip_svc/
+    - tests/subsys/sip_svc/
+    - include/zephyr/sip_svc/
+    - include/zephyr/drivers/sip_svc/
+    - drivers/sip_svc/
+    - samples/subsys/sip_svc/
+  labels:
+    - "area: ARM SiP SVC"
+  tests:
+    - sip_svc
 
 ARM arch:
   status: maintained
@@ -233,27 +263,6 @@ ARM64 arch:
   tests:
     - arch.arm64
 
-ARM Platforms:
-  status: maintained
-  maintainers:
-    - wearyzen
-  collaborators:
-    - ithinuel
-  files:
-    - boards/arm/mps*/
-    - boards/arm/v2m_*/
-    - boards/arm/fvp_base*/
-    - soc/arm/mps*/
-    - soc/arm/musca/
-    - soc/arm/beetle/
-    - soc/arm/designstart/
-    - soc/arm/fvp_aemv8*/
-    - dts/arm/armv*.dtsi
-    - dts/bindings/arm/arm*.yaml
-    - drivers/interrupt_controller/intc_gic*
-  labels:
-    - "platform: ARM"
-
 ASPEED Platforms:
   status: odd fixes
   files:
@@ -264,30 +273,18 @@ ASPEED Platforms:
   labels:
     - "platform: ASPEED"
 
-ARM SiP SVC:
-  status: odd fixes
+Aesc Platform:
+  status: maintained
+  maintainers:
+    - dnltz
   files:
-    - subsys/sip_svc/
-    - tests/subsys/sip_svc/
-    - include/zephyr/sip_svc/
-    - include/zephyr/drivers/sip_svc/
-    - drivers/sip_svc/
-    - samples/subsys/sip_svc/
+    - soc/aesc/
+    - dts/riscv/aesc/
+    - boards/aesc/
+  files-regex:
+    - ^drivers/.*aesc(\.c)?$
   labels:
-    - "area: ARM SiP SVC"
-  tests:
-    - sip_svc
-
-MIPS arch:
-  status: odd fixes
-  files:
-    - arch/mips/
-    - include/zephyr/arch/mips/
-    - boards/qemu/malta/
-  labels:
-    - "area: MIPS"
-  tests:
-    - arch.mips
+    - "area: Aesc Silicon Platform"
 
 Ambiq Platforms:
   status: maintained
@@ -321,6 +318,60 @@ AndesTech Platforms:
     - soc/andestech/
   labels:
     - "platform: Andes Technology"
+
+Antmicro platforms:
+  status: maintained
+  maintainers:
+    - fkokosinski
+    - tgorochowik
+  collaborators:
+    - kgugala
+  files:
+    - boards/antmicro/
+    - soc/antmicro/
+    - dts/arm/antmicro/
+  labels:
+    - "platform: Antmicro"
+
+Arduino Platforms:
+  status: maintained
+  maintainers:
+    - pillo79
+  collaborators:
+    - facchinm
+  files:
+    - boards/arduino/
+    - boards/shields/arduino_*/
+    - drivers/*/*modulino*
+
+Base OS:
+  status: maintained
+  maintainers:
+    - andyross
+    - nashif
+  collaborators:
+    - dcpleung
+    - peter-mitsis
+  files:
+    - include/zephyr/sys/
+    - lib/os/
+    - tests/misc/print_format/
+    - tests/lib/p4workq/
+    - tests/lib/fdtable/
+  files-exclude:
+    - include/zephyr/sys/cbprintf*
+    - tests/unit/cbprintf/
+    - tests/lib/cbprintf_*/
+    - lib/os/cbprintf*
+    - lib/os/Kconfig.cbprintf
+    - include/zephyr/sys/mem_manage.h
+    - include/zephyr/sys/mpsc_pbuf.h
+    - include/zephyr/sys/mpsc_packet.h
+    - lib/os/mpsc_pbuf.c
+  labels:
+    - "area: Base OS"
+  tests:
+    - printk
 
 BeagleBoard Platforms:
   status: maintained
@@ -363,26 +414,63 @@ Binary Descriptors:
   tests:
     - bindesc
 
-Bluetooth HCI:
+Bluetooth Audio:
   status: maintained
   maintainers:
-    - jhedberg
-    - alwa-nordic
-  collaborators:
-    - hermabe
     - Thalley
+  collaborators:
+    - jhedberg
     - sjanc
-    - HoZHel
-    - cvinayak
+    - asbjornsabo
+    - fredrikdanebjer
+    - larsgk
+    - pin-zephyr
+    - niym-ot
+    - jthm-ot
+    - babrsn
   files:
-    - include/zephyr/drivers/bluetooth/
-    - include/zephyr/drivers/bluetooth.h
-    - drivers/bluetooth/
-    - samples/bluetooth/hci_*/
-    - tests/bsim/bluetooth/hci_uart/
-    - dts/bindings/bluetooth/
+    - subsys/bluetooth/audio/
+    - include/zephyr/bluetooth/audio/
+    - tests/bluetooth/audio/
+    - tests/bsim/bluetooth/audio/
+    - tests/bsim/bluetooth/audio_samples/
+    - tests/bsim/bluetooth/tester/src/audio/
+    - tests/bluetooth/shell/audio.conf
+    - tests/bluetooth/tester/overlay-le-audio.conf
+    - tests/bluetooth/tester/overlay-bt_ll_sw_split.conf
+    - tests/bluetooth/tester/src/audio/
+    - doc/connectivity/bluetooth/api/audio/
+    - doc/connectivity/bluetooth/shell/audio/
+    - samples/bluetooth/bap*/
+    - samples/bluetooth/cap*/
+    - samples/bluetooth/ccp*/
+    - samples/bluetooth/hap*/
+    - samples/bluetooth/pbp*/
+    - samples/bluetooth/tmap*/
   labels:
-    - "area: Bluetooth HCI"
+    - "area: Bluetooth Audio"
+    - "area: Bluetooth"
+  tests:
+    - bluetooth.audio
+
+Bluetooth Classic:
+  status: maintained
+  maintainers:
+    - lylezhu2012
+  collaborators:
+    - jhedberg
+    - MarkWangChinese
+    - gzh-terry
+    - makeshi
+  files:
+    - doc/connectivity/bluetooth/shell/classic/a2dp.rst
+    - subsys/bluetooth/common/
+    - subsys/bluetooth/host/classic/
+    - include/zephyr/bluetooth/classic/
+    - tests/bluetooth/classic/
+    - samples/bluetooth/classic/
+  labels:
+    - "area: Bluetooth Classic"
     - "area: Bluetooth"
   tests:
     - bluetooth
@@ -413,6 +501,30 @@ Bluetooth Controller:
     - "area: Bluetooth"
   tests:
     - bluetooth.controller
+
+Bluetooth HCI:
+  status: maintained
+  maintainers:
+    - jhedberg
+    - alwa-nordic
+  collaborators:
+    - hermabe
+    - Thalley
+    - sjanc
+    - HoZHel
+    - cvinayak
+  files:
+    - include/zephyr/drivers/bluetooth/
+    - include/zephyr/drivers/bluetooth.h
+    - drivers/bluetooth/
+    - samples/bluetooth/hci_*/
+    - tests/bsim/bluetooth/hci_uart/
+    - dts/bindings/bluetooth/
+  labels:
+    - "area: Bluetooth HCI"
+    - "area: Bluetooth"
+  tests:
+    - bluetooth
 
 Bluetooth Host:
   status: maintained
@@ -486,6 +598,27 @@ Bluetooth Host:
     - "area: Bluetooth Host"
     - "area: Bluetooth"
 
+Bluetooth ISO:
+  status: maintained
+  maintainers:
+    - Thalley
+  collaborators:
+    - jhedberg
+    - rugeGerritsen
+    - cvinayak
+  files:
+    - include/zephyr/bluetooth/iso.h
+    - doc/connectivity/bluetooth/shell/host/iso.rst
+    - samples/bluetooth/iso_*/
+    - subsys/bluetooth/host/iso.c
+    - subsys/bluetooth/host/iso_internal.h
+    - subsys/bluetooth/host/shell/iso.c
+  labels:
+    - "area: Bluetooth ISO"
+    - "area: Bluetooth"
+  tests:
+    - bluetooth
+
 Bluetooth Mesh:
   status: maintained
   maintainers:
@@ -514,88 +647,6 @@ Bluetooth Mesh:
   tests:
     - bluetooth.mesh
 
-Bluetooth Audio:
-  status: maintained
-  maintainers:
-    - Thalley
-  collaborators:
-    - jhedberg
-    - sjanc
-    - asbjornsabo
-    - fredrikdanebjer
-    - larsgk
-    - pin-zephyr
-    - niym-ot
-    - jthm-ot
-    - babrsn
-  files:
-    - subsys/bluetooth/audio/
-    - include/zephyr/bluetooth/audio/
-    - tests/bluetooth/audio/
-    - tests/bsim/bluetooth/audio/
-    - tests/bsim/bluetooth/audio_samples/
-    - tests/bsim/bluetooth/tester/src/audio/
-    - tests/bluetooth/shell/audio.conf
-    - tests/bluetooth/tester/overlay-le-audio.conf
-    - tests/bluetooth/tester/overlay-bt_ll_sw_split.conf
-    - tests/bluetooth/tester/src/audio/
-    - doc/connectivity/bluetooth/api/audio/
-    - doc/connectivity/bluetooth/shell/audio/
-    - samples/bluetooth/bap*/
-    - samples/bluetooth/cap*/
-    - samples/bluetooth/ccp*/
-    - samples/bluetooth/hap*/
-    - samples/bluetooth/pbp*/
-    - samples/bluetooth/tmap*/
-  labels:
-    - "area: Bluetooth Audio"
-    - "area: Bluetooth"
-  tests:
-    - bluetooth.audio
-
-Bluetooth Classic:
-  status: maintained
-  maintainers:
-    - lylezhu2012
-  collaborators:
-    - jhedberg
-    - MarkWangChinese
-    - gzh-terry
-    - makeshi
-  files:
-    - doc/connectivity/bluetooth/shell/classic/a2dp.rst
-    - subsys/bluetooth/common/
-    - subsys/bluetooth/host/classic/
-    - include/zephyr/bluetooth/classic/
-    - tests/bluetooth/classic/
-    - samples/bluetooth/classic/
-  labels:
-    - "area: Bluetooth Classic"
-    - "area: Bluetooth"
-  tests:
-    - bluetooth
-
-Bluetooth ISO:
-  status: maintained
-  maintainers:
-    - Thalley
-  collaborators:
-    - jhedberg
-    - rugeGerritsen
-    - cvinayak
-  files:
-    - include/zephyr/bluetooth/iso.h
-    - doc/connectivity/bluetooth/shell/host/iso.rst
-    - samples/bluetooth/iso_*/
-    - subsys/bluetooth/host/iso.c
-    - subsys/bluetooth/host/iso_internal.h
-    - subsys/bluetooth/host/shell/iso.c
-  labels:
-    - "area: Bluetooth ISO"
-    - "area: Bluetooth"
-  tests:
-    - bluetooth
-
 Bluetooth Qualification:
   status: maintained
   maintainers:
@@ -613,6 +664,21 @@ Bluetooth Qualification:
   tests:
     - bluetooth
 
+Board/SoC configuration:
+  status: maintained
+  maintainers:
+    - tejlmand
+  collaborators:
+    - galak
+    - nashif
+    - nordicjm
+    - "57300"
+  files:
+    - soc/Kconfig*
+    - boards/Kconfig*
+  labels:
+    - "area: Board/SoC configuration"
+
 Bootloaders:
   status: odd fixes
   files:
@@ -621,6 +687,27 @@ Bootloaders:
     - "area: Bootloader"
   tests:
     - bootloader
+
+Bouffalolab Platforms:
+  status: maintained
+  maintainers:
+    - nandojve
+    - VynDragon
+  files:
+    - boards/bflb/
+    - drivers/*/*bflb*
+    - dts/riscv/bflb/
+    - dts/bindings/*/bflb,*
+    - soc/bflb/
+  labels:
+    - "platform: bouffalolab"
+
+Broadcom Platforms:
+  status: odd fixes
+  files:
+    - dts/*/broadcom/
+    - soc/brcm/
+    - boards/brcm/
 
 Build system:
   status: maintained
@@ -655,54 +742,6 @@ Build system:
   tests:
     - buildsystem
 
-Board/SoC configuration:
-  status: maintained
-  maintainers:
-    - tejlmand
-  collaborators:
-    - galak
-    - nashif
-    - nordicjm
-    - "57300"
-  files:
-    - soc/Kconfig*
-    - boards/Kconfig*
-  labels:
-    - "area: Board/SoC configuration"
-
-"C++":
-  status: maintained
-  maintainers:
-    - stephanosio
-  collaborators:
-    - alexanderwachter
-    - cfriedt
-  files:
-    - lib/cpp/
-    - tests/lib/cpp/
-    - samples/cpp/
-  labels:
-    - "area: C++"
-  tests:
-    - cpp
-
-Cache:
-  status: maintained
-  maintainers:
-    - carlocaione
-  collaborators:
-    - nashif
-  files:
-    - include/zephyr/drivers/cache.h
-    - include/zephyr/cache.h
-    - doc/hardware/cache/index.rst
-    - drivers/cache/
-    - tests/kernel/cache/
-  labels:
-    - "area: Cache"
-  tests:
-    - kernel.cache
-
 C library:
   status: maintained
   maintainers:
@@ -721,6 +760,22 @@ C library:
   tests:
     - libraries.libc
 
+"C++":
+  status: maintained
+  maintainers:
+    - stephanosio
+  collaborators:
+    - alexanderwachter
+    - cfriedt
+  files:
+    - lib/cpp/
+    - tests/lib/cpp/
+    - samples/cpp/
+  labels:
+    - "area: C++"
+  tests:
+    - cpp
+
 CMSIS API layer:
   status: odd fixes
   collaborators:
@@ -737,39 +792,6 @@ CMSIS API layer:
   tests:
     - portability.cmsis_rtos_v1
     - portability.cmsis_rtos_v2
-
-DAP:
-  status: maintained
-  maintainers:
-    - jfischer-no
-  collaborators:
-    - maxd-nordic
-  files:
-    - include/zephyr/drivers/swdp.h
-    - drivers/dp/
-    - subsys/dap/
-    - samples/subsys/dap/
-  description: >-
-    Debug Access Port controller
-  labels:
-    - "area: dap"
-
-DSP subsystem:
-  status: maintained
-  maintainers:
-    - stephanosio
-    - yperess
-  files:
-    - subsys/dsp/
-    - tests/subsys/dsp/
-    - include/zephyr/dsp/dsp.h
-    - include/zephyr/dsp/types.h
-    - include/zephyr/dsp/
-    - doc/services/dsp/
-  labels:
-    - "area: DSP"
-  tests:
-    - zdsp
 
 CMSIS-DSP integration:
   status: maintained
@@ -802,6 +824,23 @@ CMSIS-NN integration:
     - "area: CMSIS-NN"
   tests:
     - libraries.cmsis_nn
+
+Cache:
+  status: maintained
+  maintainers:
+    - carlocaione
+  collaborators:
+    - nashif
+  files:
+    - include/zephyr/drivers/cache.h
+    - include/zephyr/cache.h
+    - doc/hardware/cache/index.rst
+    - drivers/cache/
+    - tests/kernel/cache/
+  labels:
+    - "area: Cache"
+  tests:
+    - kernel.cache
 
 Coding Guidelines:
   status: maintained
@@ -861,6 +900,72 @@ Console:
   tests:
     - sample.console
 
+Continuous Integration:
+  status: maintained
+  maintainers:
+    - stephanosio
+    - nashif
+  collaborators:
+    - fabiobaltieri
+    - kartben
+  files:
+    - .github/
+    - scripts/requirements-actions.*
+    - scripts/ci/
+    - scripts/make_bugs_pickle.py
+    - .checkpatch.conf
+    - scripts/gitlint/
+    - scripts/set_assignees.py
+  labels:
+    - "area: Continuous Integration"
+
+DAP:
+  status: maintained
+  maintainers:
+    - jfischer-no
+  collaborators:
+    - maxd-nordic
+  files:
+    - include/zephyr/drivers/swdp.h
+    - drivers/dp/
+    - subsys/dap/
+    - samples/subsys/dap/
+  description: >-
+    Debug Access Port controller
+  labels:
+    - "area: dap"
+
+DFU:
+  status: maintained
+  maintainers:
+    - de-nordic
+    - nordicjm
+  files:
+    - include/zephyr/dfu/
+    - subsys/dfu/
+    - tests/subsys/dfu/
+  labels:
+    - "area: DFU"
+  tests:
+    - dfu
+
+DSP subsystem:
+  status: maintained
+  maintainers:
+    - stephanosio
+    - yperess
+  files:
+    - subsys/dsp/
+    - tests/subsys/dsp/
+    - include/zephyr/dsp/dsp.h
+    - include/zephyr/dsp/types.h
+    - include/zephyr/dsp/
+    - doc/services/dsp/
+  labels:
+    - "area: DSP"
+  tests:
+    - zdsp
+
 Debug:
   status: maintained
   maintainers:
@@ -883,7 +988,6 @@ Debug:
     - "area: Debugging"
   tests:
     - debug
-
 
 "Debug: Symtab":
   status: maintained
@@ -933,20 +1037,6 @@ Device Driver Model:
   tests:
     - kernel.device
     - init
-
-DFU:
-  status: maintained
-  maintainers:
-    - de-nordic
-    - nordicjm
-  files:
-    - include/zephyr/dfu/
-    - subsys/dfu/
-    - tests/subsys/dfu/
-  labels:
-    - "area: DFU"
-  tests:
-    - dfu
 
 Devicetree:
   status: maintained
@@ -1079,19 +1169,6 @@ Documentation Infrastructure:
   labels:
     - "area: Documentation Infrastructure"
 
-Release Notes:
-  status: maintained
-  maintainers:
-    - danieldegrasse
-    - dkalowsk
-  collaborators:
-    - kartben
-  files:
-    - doc/releases/migration-guide-*
-    - doc/releases/release-notes-*
-  labels:
-    - "Release Notes"
-
 "Drivers: ADC":
   status: odd fixes
   collaborators:
@@ -1126,21 +1203,6 @@ Release Notes:
     - tests/drivers/audio/
   labels:
     - "area: Audio"
-
-"Drivers: bbram":
-  status: maintained
-  maintainers:
-    - yperess
-  files:
-    - tests/drivers/bbram/
-    - tests/drivers/build_all/bbram/
-    - drivers/bbram/
-    - include/zephyr/drivers/bbram.h
-    - doc/hardware/peripherals/bbram.rst
-  labels:
-    - "area: Battery Backed RAM (bbram)"
-  tests:
-    - drivers.bbram
 
 "Drivers: Aux display":
   status: maintained
@@ -1355,6 +1417,24 @@ Release Notes:
   labels:
     - "area: DAI"
 
+"Drivers: DMA":
+  status: maintained
+  maintainers:
+    - teburd
+  files:
+    - drivers/dma/
+    - tests/drivers/dma/
+    - include/zephyr/drivers/dma/
+    - dts/bindings/dma/
+    - include/zephyr/dt-bindings/dma/
+    - doc/hardware/peripherals/dma.rst
+    - include/zephyr/drivers/dma.h
+    - include/zephyr/dt-bindings/dma/
+  labels:
+    - "area: DMA"
+  tests:
+    - drivers.dma
+
 "Drivers: Debug":
   status: maintained
   maintainers:
@@ -1379,24 +1459,6 @@ Release Notes:
     - "area: Devmux"
   tests:
     - drivers.devmux
-
-"Drivers: DMA":
-  status: maintained
-  maintainers:
-    - teburd
-  files:
-    - drivers/dma/
-    - tests/drivers/dma/
-    - include/zephyr/drivers/dma/
-    - dts/bindings/dma/
-    - include/zephyr/dt-bindings/dma/
-    - doc/hardware/peripherals/dma.rst
-    - include/zephyr/drivers/dma.h
-    - include/zephyr/dt-bindings/dma/
-  labels:
-    - "area: DMA"
-  tests:
-    - drivers.dma
 
 "Drivers: EDAC":
   status: maintained
@@ -1433,22 +1495,6 @@ Release Notes:
   tests:
     - drivers.eeprom
 
-"Drivers: Entropy":
-  status: maintained
-  maintainers:
-    - ceolin
-  collaborators:
-    - tomi-font
-  files:
-    - drivers/entropy/
-    - include/zephyr/drivers/entropy.h
-    - tests/drivers/entropy/
-    - doc/hardware/peripherals/entropy.rst
-  labels:
-    - "area: Crypto / RNG"
-  tests:
-    - drivers.entropy
-
 "Drivers: ESPI":
   status: maintained
   maintainers:
@@ -1470,6 +1516,22 @@ Release Notes:
   tests:
     - sample.drivers.espi
     - drivers.espi
+
+"Drivers: Entropy":
+  status: maintained
+  maintainers:
+    - ceolin
+  collaborators:
+    - tomi-font
+  files:
+    - drivers/entropy/
+    - include/zephyr/drivers/entropy.h
+    - tests/drivers/entropy/
+    - doc/hardware/peripherals/entropy.rst
+  labels:
+    - "area: Crypto / RNG"
+  tests:
+    - drivers.entropy
 
 "Drivers: Ethernet":
   status: maintained
@@ -1496,6 +1558,25 @@ Release Notes:
   tests:
     - net.ethernet
 
+"Drivers: FPGA":
+  status: maintained
+  maintainers:
+    - cfriedt
+  collaborators:
+    - tgorochowik
+    - fkokosinski
+    - msierszulski
+  files:
+    - drivers/fpga/
+    - dts/bindings/fpga/
+    - include/zephyr/drivers/fpga.h
+    - samples/drivers/fpga/
+    - tests/drivers/build_all/fpga/
+  labels:
+    - "area: FPGA"
+  tests:
+    - drivers.fpga
+
 "Drivers: Flash":
   status: maintained
   maintainers:
@@ -1520,25 +1601,6 @@ Release Notes:
   tests:
     - drivers.flash
 
-"Drivers: FPGA":
-  status: maintained
-  maintainers:
-    - cfriedt
-  collaborators:
-    - tgorochowik
-    - fkokosinski
-    - msierszulski
-  files:
-    - drivers/fpga/
-    - dts/bindings/fpga/
-    - include/zephyr/drivers/fpga.h
-    - samples/drivers/fpga/
-    - tests/drivers/build_all/fpga/
-  labels:
-    - "area: FPGA"
-  tests:
-    - drivers.fpga
-
 "Drivers: Fuel Gauge":
   status: maintained
   maintainers:
@@ -1558,25 +1620,6 @@ Release Notes:
     - "area: Fuel Gauge"
   tests:
     - drivers.fuel_gauge
-
-"Drivers: GPIO":
-  status: odd fixes
-  collaborators:
-    - henrikbrixandersen
-    - mnkp
-  files:
-    - doc/hardware/peripherals/gpio.rst
-    - drivers/gpio/
-    - dts/bindings/gpio/
-    - include/zephyr/drivers/gpio/
-    - include/zephyr/drivers/gpio.h
-    - include/zephyr/dt-bindings/gpio/
-    - tests/drivers/gpio/
-    - tests/drivers/build_all/gpio/
-  labels:
-    - "area: GPIO"
-  tests:
-    - drivers.gpio
 
 "Drivers: GNSS":
   status: maintained
@@ -1601,21 +1644,24 @@ Release Notes:
   tests:
     - drivers.gnss
 
-"Drivers: Haptics":
-  status: maintained
-  maintainers:
-    - rriveramcrus
+"Drivers: GPIO":
+  status: odd fixes
+  collaborators:
+    - henrikbrixandersen
+    - mnkp
   files:
-    - drivers/haptics/
-    - dts/bindings/haptics/
-    - include/zephyr/drivers/haptics.h
-    - doc/hardware/peripherals/haptics.rst
-    - tests/drivers/build_all/haptics/
-    - samples/drivers/haptics/
+    - doc/hardware/peripherals/gpio.rst
+    - drivers/gpio/
+    - dts/bindings/gpio/
+    - include/zephyr/drivers/gpio/
+    - include/zephyr/drivers/gpio.h
+    - include/zephyr/dt-bindings/gpio/
+    - tests/drivers/gpio/
+    - tests/drivers/build_all/gpio/
   labels:
-    - "area: Haptics"
+    - "area: GPIO"
   tests:
-    - drivers.haptics
+    - drivers.gpio
 
 "Drivers: HW Info":
   status: maintained
@@ -1631,6 +1677,22 @@ Release Notes:
     - "area: HWINFO"
   tests:
     - drivers.hwinfo
+
+"Drivers: Haptics":
+  status: maintained
+  maintainers:
+    - rriveramcrus
+  files:
+    - drivers/haptics/
+    - dts/bindings/haptics/
+    - include/zephyr/drivers/haptics.h
+    - doc/hardware/peripherals/haptics.rst
+    - tests/drivers/build_all/haptics/
+    - samples/drivers/haptics/
+  labels:
+    - "area: Haptics"
+  tests:
+    - drivers.haptics
 
 "Drivers: Hardware Spinlock":
   status: odd fixes
@@ -1712,125 +1774,6 @@ Release Notes:
   tests:
     - drivers.ieee802154
 
-"Drivers: Mbox":
-  status: maintained
-  maintainers:
-    - carlocaione
-  collaborators:
-    - wearyzen
-    - ithinuel
-  files:
-    - include/zephyr/drivers/mbox.h
-    - drivers/mbox/
-    - samples/drivers/mbox/
-    - dts/bindings/mbox/
-    - doc/hardware/peripherals/mbox.rst
-    - tests/drivers/mbox/
-    - samples/drivers/mbox_data/
-  labels:
-    - "area: mbox"
-  tests:
-    - sample.drivers.mbox
-
-"Drivers: MEMC":
-  status: odd fixes
-  files:
-    - drivers/memc/
-    - samples/drivers/memc/
-    - tests/drivers/memc/
-    - include/zephyr/dt-bindings/memory-controller/
-    - dts/bindings/memory-controllers/
-  labels:
-    - "area: MEMC"
-  tests:
-    - samples.drivers.memc
-    - drivers.memc
-
-"Drivers: MDIO":
-  status: maintained
-  maintainers:
-    - maass-hamburg
-  collaborators:
-    - decsny
-  files:
-    - doc/hardware/peripherals/mdio.rst
-    - drivers/mdio/
-    - include/zephyr/drivers/mdio.h
-    - include/zephyr/net/mdio.h
-    - tests/drivers/build_all/mdio/
-    - dts/bindings/mdio/
-  labels:
-    - "area: MDIO"
-  tests:
-    - drivers.mdio
-
-"Drivers: MIPI-DSI":
-  status: odd fixes
-  files:
-    - drivers/mipi_dsi/
-    - doc/hardware/peripherals/mipi_dsi.rst
-    - include/zephyr/drivers/mipi_dsi.h
-    - include/zephyr/drivers/mipi_dsi/
-    - tests/drivers/mipi_dsi/
-    - include/zephyr/dt-bindings/mipi_dsi/
-    - dts/bindings/mipi-dsi/
-  labels:
-    - "area: MIPI-DSI"
-  tests:
-    - drivers.mipi_dsi
-
-"Drivers: MSPI":
-  status: maintained
-  maintainers:
-    - swift-tk
-  files:
-    - drivers/mspi/
-    - drivers/memc/*mspi*
-    - drivers/flash/*mspi*
-    - include/zephyr/drivers/mspi.h
-    - include/zephyr/drivers/mspi/
-    - samples/drivers/mspi/
-    - tests/drivers/mspi/
-    - doc/hardware/peripherals/mspi.rst
-    - dts/bindings/mspi/
-    - dts/bindings/mtd/mspi*
-  labels:
-    - "area: MSPI"
-  tests:
-    - drivers.mspi
-
-"Drivers: Reset":
-  status: odd fixes
-  collaborators:
-    - decsny
-  files:
-    - drivers/reset/
-    - include/zephyr/drivers/reset.h
-    - dts/bindings/reset/
-    - include/zephyr/dt-bindings/reset/
-    - tests/drivers/reset/
-
-"Interrupt Handling":
-  status: odd fixes
-  collaborators:
-    - ycsin
-    - dcpleung
-    - nashif
-  files:
-    - drivers/interrupt_controller/
-    - dts/bindings/interrupt-controller/
-    - include/zephyr/drivers/interrupt_controller/
-    - include/zephyr/dt-bindings/interrupt-controller/
-    - include/zephyr/irq*
-    - include/zephyr/sw_isr_table.h
-    - include/zephyr/shared_irq.h
-    - tests/drivers/interrupt_controller/
-    - tests/drivers/build_all/interrupt_controller/
-  labels:
-    - "area: Interrupt Controller"
-  tests:
-    - drivers.interrupt_controller
-
 "Drivers: IPM":
   status: odd fixes
   collaborators:
@@ -1891,6 +1834,38 @@ Release Notes:
   tests:
     - drivers.led_strip
 
+"Drivers: MDIO":
+  status: maintained
+  maintainers:
+    - maass-hamburg
+  collaborators:
+    - decsny
+  files:
+    - doc/hardware/peripherals/mdio.rst
+    - drivers/mdio/
+    - include/zephyr/drivers/mdio.h
+    - include/zephyr/net/mdio.h
+    - tests/drivers/build_all/mdio/
+    - dts/bindings/mdio/
+  labels:
+    - "area: MDIO"
+  tests:
+    - drivers.mdio
+
+"Drivers: MEMC":
+  status: odd fixes
+  files:
+    - drivers/memc/
+    - samples/drivers/memc/
+    - tests/drivers/memc/
+    - include/zephyr/dt-bindings/memory-controller/
+    - dts/bindings/memory-controllers/
+  labels:
+    - "area: MEMC"
+  tests:
+    - samples.drivers.memc
+    - drivers.memc
+
 "Drivers: MFD":
   status: odd fixes
   collaborators:
@@ -1907,6 +1882,88 @@ Release Notes:
   tests:
     - drivers.mfd
 
+"Drivers: MIPI DBI":
+  status: maintained
+  maintainers:
+    - danieldegrasse
+  files:
+    - drivers/mipi_dbi/
+    - dts/bindings/mipi-dbi/
+    - include/zephyr/dt-bindings/mipi_dbi/
+  labels:
+    - "area: Display Controller"
+
+"Drivers: MIPI-DSI":
+  status: odd fixes
+  files:
+    - drivers/mipi_dsi/
+    - doc/hardware/peripherals/mipi_dsi.rst
+    - include/zephyr/drivers/mipi_dsi.h
+    - include/zephyr/drivers/mipi_dsi/
+    - tests/drivers/mipi_dsi/
+    - include/zephyr/dt-bindings/mipi_dsi/
+    - dts/bindings/mipi-dsi/
+  labels:
+    - "area: MIPI-DSI"
+  tests:
+    - drivers.mipi_dsi
+
+"Drivers: MSPI":
+  status: maintained
+  maintainers:
+    - swift-tk
+  files:
+    - drivers/mspi/
+    - drivers/memc/*mspi*
+    - drivers/flash/*mspi*
+    - include/zephyr/drivers/mspi.h
+    - include/zephyr/drivers/mspi/
+    - samples/drivers/mspi/
+    - tests/drivers/mspi/
+    - doc/hardware/peripherals/mspi.rst
+    - dts/bindings/mspi/
+    - dts/bindings/mtd/mspi*
+  labels:
+    - "area: MSPI"
+  tests:
+    - drivers.mspi
+
+"Drivers: Mbox":
+  status: maintained
+  maintainers:
+    - carlocaione
+  collaborators:
+    - wearyzen
+    - ithinuel
+  files:
+    - include/zephyr/drivers/mbox.h
+    - drivers/mbox/
+    - samples/drivers/mbox/
+    - dts/bindings/mbox/
+    - doc/hardware/peripherals/mbox.rst
+    - tests/drivers/mbox/
+    - samples/drivers/mbox_data/
+  labels:
+    - "area: mbox"
+  tests:
+    - sample.drivers.mbox
+
+"Drivers: Memory Management":
+  status: maintained
+  maintainers:
+    - dcpleung
+  collaborators:
+    - ceolin
+    - edersondisouza
+    - jxstelter
+  files:
+    - include/zephyr/drivers/mm/
+    - drivers/mm/
+    - tests/boards/intel_adsp/mm/
+    - dts/bindings/mm/
+  labels:
+    - "area: Memory Management"
+
 "Drivers: Modem":
   status: maintained
   maintainers:
@@ -1921,62 +1978,6 @@ Release Notes:
     - "area: Modem Drivers"
   tests:
     - drivers.modem
-
-"Drivers: Regulators":
-  status: maintained
-  maintainers:
-    - nordic-auko
-    - seov-nordic
-  collaborators:
-    - danieldegrasse
-    - aasinclair
-  files:
-    - drivers/regulator/
-    - include/zephyr/drivers/regulator/
-    - include/zephyr/drivers/regulator.h
-    - include/zephyr/dt-bindings/regulator/
-    - tests/drivers/regulator/
-    - tests/drivers/build_all/regulator/
-    - doc/hardware/peripherals/regulators.rst
-    - dts/bindings/regulator/
-  labels:
-    - "area: Regulators"
-  tests:
-    - drivers.regulator
-
-"Drivers: Retained Memory":
-  status: maintained
-  maintainers:
-    - nordicjm
-  files:
-    - drivers/retained_mem/
-    - dts/bindings/retained_mem/
-    - include/zephyr/drivers/retained_mem.h
-    - tests/drivers/retained_mem/
-    - doc/hardware/peripherals/retained_mem.rst
-    - dts/bindings/retained_mem/
-  labels:
-    - "area: Retained Memory"
-  tests:
-    - drivers.retained_mem
-
-"Drivers: RTC":
-  status: maintained
-  maintainers:
-    - bjarki-andreasen
-  files:
-    - drivers/rtc/
-    - include/zephyr/drivers/rtc/
-    - tests/drivers/rtc/
-    - doc/hardware/peripherals/rtc.rst
-    - include/zephyr/drivers/rtc.h
-    - tests/drivers/build_all/rtc/
-    - dts/bindings/rtc/
-    - samples/drivers/rtc/
-  labels:
-    - "area: RTC"
-  tests:
-    - drivers.rtc
 
 "Drivers: PCI":
   status: maintained
@@ -2008,22 +2009,21 @@ Release Notes:
   tests:
     - samples.drivers.peci
 
-"Drivers: Pin Control":
-  status: odd fixes
+"Drivers: PM CPU ops":
+  status: maintained
+  maintainers:
+    - carlocaione
   collaborators:
-    - gmarull
+    - gdengi
+    - nbalabak
   files:
-    - doc/hardware/pinctrl/
-    - include/zephyr/drivers/pinctrl/
-    - include/zephyr/drivers/pinctrl.h
-    - drivers/pinctrl/
-    - tests/drivers/pinctrl/
-    - dts/bindings/pinctrl/
-    - include/zephyr/dt-bindings/pinctrl/
+    - drivers/pm_cpu_ops/
+    - include/zephyr/drivers/pm_cpu_ops/
+    - include/zephyr/drivers/pm_cpu_ops.h
+    - include/zephyr/arch/arm64/arm-smccc.h
+    - dts/bindings/pm_cpu_ops/
   labels:
-    - "area: Pinctrl"
-  tests:
-    - drivers.pinctrl
+    - "area: PM CPU ops"
 
 "Drivers: PS2":
   status: odd fixes
@@ -2067,22 +2067,6 @@ Release Notes:
   labels:
     - "area: Clocks"
 
-"Drivers: PM CPU ops":
-  status: maintained
-  maintainers:
-    - carlocaione
-  collaborators:
-    - gdengi
-    - nbalabak
-  files:
-    - drivers/pm_cpu_ops/
-    - include/zephyr/drivers/pm_cpu_ops/
-    - include/zephyr/drivers/pm_cpu_ops.h
-    - include/zephyr/arch/arm64/arm-smccc.h
-    - dts/bindings/pm_cpu_ops/
-  labels:
-    - "area: PM CPU ops"
-
 "Drivers: PWM":
   status: odd fixes
   collaborators:
@@ -2104,6 +2088,90 @@ Release Notes:
   tests:
     - drivers.pwm
 
+"Drivers: Pin Control":
+  status: odd fixes
+  collaborators:
+    - gmarull
+  files:
+    - doc/hardware/pinctrl/
+    - include/zephyr/drivers/pinctrl/
+    - include/zephyr/drivers/pinctrl.h
+    - drivers/pinctrl/
+    - tests/drivers/pinctrl/
+    - dts/bindings/pinctrl/
+    - include/zephyr/dt-bindings/pinctrl/
+  labels:
+    - "area: Pinctrl"
+  tests:
+    - drivers.pinctrl
+
+"Drivers: RTC":
+  status: maintained
+  maintainers:
+    - bjarki-andreasen
+  files:
+    - drivers/rtc/
+    - include/zephyr/drivers/rtc/
+    - tests/drivers/rtc/
+    - doc/hardware/peripherals/rtc.rst
+    - include/zephyr/drivers/rtc.h
+    - tests/drivers/build_all/rtc/
+    - dts/bindings/rtc/
+    - samples/drivers/rtc/
+  labels:
+    - "area: RTC"
+  tests:
+    - drivers.rtc
+
+"Drivers: Regulators":
+  status: maintained
+  maintainers:
+    - nordic-auko
+    - seov-nordic
+  collaborators:
+    - danieldegrasse
+    - aasinclair
+  files:
+    - drivers/regulator/
+    - include/zephyr/drivers/regulator/
+    - include/zephyr/drivers/regulator.h
+    - include/zephyr/dt-bindings/regulator/
+    - tests/drivers/regulator/
+    - tests/drivers/build_all/regulator/
+    - doc/hardware/peripherals/regulators.rst
+    - dts/bindings/regulator/
+  labels:
+    - "area: Regulators"
+  tests:
+    - drivers.regulator
+
+"Drivers: Reset":
+  status: odd fixes
+  collaborators:
+    - decsny
+  files:
+    - drivers/reset/
+    - include/zephyr/drivers/reset.h
+    - dts/bindings/reset/
+    - include/zephyr/dt-bindings/reset/
+    - tests/drivers/reset/
+
+"Drivers: Retained Memory":
+  status: maintained
+  maintainers:
+    - nordicjm
+  files:
+    - drivers/retained_mem/
+    - dts/bindings/retained_mem/
+    - include/zephyr/drivers/retained_mem.h
+    - tests/drivers/retained_mem/
+    - doc/hardware/peripherals/retained_mem.rst
+    - dts/bindings/retained_mem/
+  labels:
+    - "area: Retained Memory"
+  tests:
+    - drivers.retained_mem
+
 "Drivers: SDHC":
   status: maintained
   maintainers:
@@ -2118,55 +2186,6 @@ Release Notes:
     - "area: Disk Access"
   tests:
     - drivers.sdhc
-
-"Drivers: Serial/UART":
-  status: maintained
-  maintainers:
-    - dcpleung
-  files:
-    - drivers/serial/
-    - include/zephyr/drivers/uart.h
-    - include/zephyr/drivers/uart/
-    - dts/bindings/serial/
-    - samples/drivers/uart/
-    - tests/drivers/uart/
-    - tests/drivers/build_all/uart/
-    - doc/hardware/peripherals/uart.rst
-    - include/zephyr/drivers/serial/
-    - include/zephyr/drivers/uart_pipe.h
-  labels:
-    - "area: UART"
-  tests:
-    - drivers.uart
-
-"Drivers: Sensors":
-  status: maintained
-  maintainers:
-    - MaureenHelm
-  collaborators:
-    - avisconti
-    - teburd
-    - yperess
-    - tristan-google
-    - ubieda
-    - jeppenodgaard
-    - asemjonovs
-  files:
-    - drivers/sensor/
-    - include/zephyr/drivers/sensor.h
-    - include/zephyr/drivers/sensor_data_types.h
-    - samples/sensor/
-    - tests/drivers/sensor/
-    - dts/bindings/sensor/
-    - include/zephyr/drivers/sensor/
-    - include/zephyr/dt-bindings/sensor/
-    - doc/hardware/peripherals/sensor/
-    - tests/drivers/build_all/sensor/
-    - include/zephyr/drivers/sensor_*
-  labels:
-    - "area: Sensors"
-  tests:
-    - drivers.sensor
 
 "Drivers: SENT":
   status: maintained
@@ -2224,6 +2243,55 @@ Release Notes:
   tests:
     - drivers.spi
 
+"Drivers: Sensors":
+  status: maintained
+  maintainers:
+    - MaureenHelm
+  collaborators:
+    - avisconti
+    - teburd
+    - yperess
+    - tristan-google
+    - ubieda
+    - jeppenodgaard
+    - asemjonovs
+  files:
+    - drivers/sensor/
+    - include/zephyr/drivers/sensor.h
+    - include/zephyr/drivers/sensor_data_types.h
+    - samples/sensor/
+    - tests/drivers/sensor/
+    - dts/bindings/sensor/
+    - include/zephyr/drivers/sensor/
+    - include/zephyr/dt-bindings/sensor/
+    - doc/hardware/peripherals/sensor/
+    - tests/drivers/build_all/sensor/
+    - include/zephyr/drivers/sensor_*
+  labels:
+    - "area: Sensors"
+  tests:
+    - drivers.sensor
+
+"Drivers: Serial/UART":
+  status: maintained
+  maintainers:
+    - dcpleung
+  files:
+    - drivers/serial/
+    - include/zephyr/drivers/uart.h
+    - include/zephyr/drivers/uart/
+    - dts/bindings/serial/
+    - samples/drivers/uart/
+    - tests/drivers/uart/
+    - tests/drivers/build_all/uart/
+    - doc/hardware/peripherals/uart.rst
+    - include/zephyr/drivers/serial/
+    - include/zephyr/drivers/uart_pipe.h
+  labels:
+    - "area: UART"
+  tests:
+    - drivers.uart
+
 "Drivers: Stepper":
   status: maintained
   maintainers:
@@ -2248,6 +2316,17 @@ Release Notes:
   tests:
     - drivers.stepper
 
+"Drivers: Syscon":
+  status: maintained
+  maintainers:
+    - carlocaione
+  files:
+    - include/zephyr/drivers/syscon.h
+    - drivers/syscon/
+    - tests/drivers/syscon/
+  tests:
+    - drivers.syscon
+
 "Drivers: System timer":
   status: maintained
   maintainers:
@@ -2261,6 +2340,36 @@ Release Notes:
     - include/zephyr/dt-bindings/timer/
   labels:
     - "area: Timer"
+
+"Drivers: Time Aware GPIO":
+  status: maintained
+  maintainers:
+    - akanisetti
+  files:
+    - doc/hardware/peripherals/tgpio.rst
+    - drivers/misc/timeaware_gpio/
+    - include/zephyr/drivers/misc/timeaware_gpio/
+    - samples/drivers/misc/timeaware_gpio/
+  labels:
+    - "area: Time Aware GPIO"
+  tests:
+    - sample.drivers.misc.timeaware_gpio
+
+"Drivers: VIRTIO":
+  status: maintained
+  maintainers:
+    - fkokosinski
+    - tgorochowik
+  collaborators:
+    - kgugala
+  files:
+    - drivers/virtio/
+    - dts/bindings/virtio/
+    - include/zephyr/drivers/virtio.h
+    - include/zephyr/drivers/virtio/
+    - tests/drivers/build_all/virtio/
+  labels:
+    - "area: VIRTIO"
 
 "Drivers: Video":
   status: maintained
@@ -2284,21 +2393,20 @@ Release Notes:
   tests:
     - drivers.video
 
-"Drivers: VIRTIO":
-  status: maintained
-  maintainers:
-    - fkokosinski
-    - tgorochowik
-  collaborators:
-    - kgugala
+"Drivers: Virtualization":
+  status: odd fixes
   files:
-    - drivers/virtio/
-    - dts/bindings/virtio/
-    - include/zephyr/drivers/virtio.h
-    - include/zephyr/drivers/virtio/
-    - tests/drivers/build_all/virtio/
+    - drivers/virtualization/
+    - tests/drivers/virtualization/
+    - dts/bindings/virtualization/
+    - include/zephyr/drivers/virtualization/
+    - doc/services/virtualization/
+    - include/zephyr/drivers/virtualization/ivshmem.h
+    - samples/drivers/virtualization/
   labels:
-    - "area: VIRTIO"
+    - "area: Virtualization"
+  tests:
+    - drivers.virtualization
 
 "Drivers: W1":
   status: maintained
@@ -2354,18 +2462,6 @@ Release Notes:
   labels:
     - "area: Wi-Fi"
 
-"Drivers: Wi-Fi es-WiFi":
-  status: odd fixes
-  collaborators:
-    - loicpoulain
-  files:
-    - drivers/wifi/eswifi/
-  description: >-
-    Inventek es-WiFi
-
-  labels:
-    - "area: Wi-Fi"
-
 "Drivers: Wi-Fi as nRF Wi-Fi":
   status: maintained
   maintainers:
@@ -2389,47 +2485,31 @@ Release Notes:
   labels:
     - "area: Wi-Fi"
 
-"Drivers: Memory Management":
-  status: maintained
-  maintainers:
-    - dcpleung
-  collaborators:
-    - ceolin
-    - edersondisouza
-    - jxstelter
-  files:
-    - include/zephyr/drivers/mm/
-    - drivers/mm/
-    - tests/boards/intel_adsp/mm/
-    - dts/bindings/mm/
-  labels:
-    - "area: Memory Management"
-
-"Drivers: MIPI DBI":
-  status: maintained
-  maintainers:
-    - danieldegrasse
-  files:
-    - drivers/mipi_dbi/
-    - dts/bindings/mipi-dbi/
-    - include/zephyr/dt-bindings/mipi_dbi/
-  labels:
-    - "area: Display Controller"
-
-"Drivers: Virtualization":
+"Drivers: Wi-Fi es-WiFi":
   status: odd fixes
+  collaborators:
+    - loicpoulain
   files:
-    - drivers/virtualization/
-    - tests/drivers/virtualization/
-    - dts/bindings/virtualization/
-    - include/zephyr/drivers/virtualization/
-    - doc/services/virtualization/
-    - include/zephyr/drivers/virtualization/ivshmem.h
-    - samples/drivers/virtualization/
+    - drivers/wifi/eswifi/
+  description: >-
+    Inventek es-WiFi
   labels:
-    - "area: Virtualization"
+    - "area: Wi-Fi"
+
+"Drivers: bbram":
+  status: maintained
+  maintainers:
+    - yperess
+  files:
+    - tests/drivers/bbram/
+    - tests/drivers/build_all/bbram/
+    - drivers/bbram/
+    - include/zephyr/drivers/bbram.h
+    - doc/hardware/peripherals/bbram.rst
+  labels:
+    - "area: Battery Backed RAM (bbram)"
   tests:
-    - drivers.virtualization
+    - drivers.bbram
 
 EC Host Commands:
   status: maintained
@@ -2444,22 +2524,73 @@ EC Host Commands:
   tests:
     - mgmt.ec_host_cmd
 
-Xen Platform:
+Emulation:
   status: maintained
   maintainers:
-    - firscity
+    - yperess
   collaborators:
-    - lorc
-    - luca-fancellu
+    - aaronemassey
+    - jeremybettis
+    - alevkoy
+    - asemjonovs
+    - tristan-google
   files:
-    - include/zephyr/xen/
-    - drivers/xen/
-    - arch/arm64/core/xen/
-    - soc/xen/
-    - boards/xen/
-    - dts/bindings/xen/
+    - subsys/emul/
+    - include/zephyr/drivers/emul_*
+    - include/zephyr/drivers/emul.h
+    - include/zephyr/drivers/espi_emul.h
+    - include/zephyr/drivers/i2c_emul.h
+    - include/zephyr/drivers/spi_emul.h
+    - tests/subsys/emul/
+    - doc/hardware/emulator/
   labels:
-    - "area: Xen Platform"
+    - "area: HW Emulation"
+  tests:
+    - emul
+
+Enclustra Platforms:
+  status: maintained
+  maintainers:
+    - fkokosinski
+  collaborators:
+    - tgorochowik
+  files:
+    - boards/enclustra/
+  labels:
+    - "platform: Enclustra"
+
+Espressif Platforms:
+  status: maintained
+  maintainers:
+    - sylvioalves
+  collaborators:
+    - LucasTambor
+    - marekmatej
+    - uLipe
+    - raffarost
+    - wmrsouza
+  files:
+    - drivers/*/*esp32*.c
+    - boards/espressif/
+    - soc/espressif/
+    - dts/*/espressif/
+    - dts/bindings/*/*esp32*
+    - samples/boards/espressif/
+    - tests/boards/espressif/
+    - drivers/*/*esp32*/
+  labels:
+    - "platform: ESP32"
+
+Ezurio platforms:
+  status: maintained
+  maintainers:
+    - rerickson1
+  collaborators:
+    - greg-leach
+  files:
+    - boards/ezurio/
+  labels:
+    - "platform: Ezurio"
 
 Filesystems:
   status: maintained
@@ -2498,6 +2629,50 @@ Formatted Output:
     - utilities.prf
     - libraries.cbprintf
 
+GD32 Platforms:
+  status: maintained
+  maintainers:
+    - nandojve
+  collaborators:
+    - soburi
+    - cameled
+  files:
+    - boards/gd/
+    - drivers/*/*gd32*
+    - dts/*/gd/
+    - dts/bindings/*/*gd32*
+    - scripts/west_commands/*/*gd32*
+    - soc/gd/gd32/
+  labels:
+    - "platform: GD32"
+  description: >-
+    GigaDevice GD32 SOCs, dts files and related drivers. Starter and eval
+    boards.
+
+Gaisler Platforms:
+  status: odd fixes
+  collaborators:
+    - tbr-tt
+  files:
+    - dts/sparc/gaisler/
+    - soc/gaisler/
+    - boards/gaisler/
+  labels:
+    - "area: SPARC"
+
+Gardena Platforms:
+  status: maintained
+  maintainers:
+    - rettichschnidi
+  collaborators:
+    - M1cha
+  files:
+    - boards/gardena/
+  labels:
+    - "platform: Gardena"
+  description: >-
+    Gardena board(s).
+
 Google Platforms:
   status: maintained
   maintainers:
@@ -2526,6 +2701,89 @@ Hash Utilities:
     - libraries.hash_function
     - libraries.hash_map
 
+Heap Management:
+  status: maintained
+  maintainers:
+    - npitre
+    - andyross
+  files:
+    - tests/lib/shared_multi_heap/
+    - lib/heap/
+    - tests/lib/heap/
+    - tests/lib/heap_align/
+    - tests/lib/multi_heap/
+    - include/zephyr/multi_heap/
+
+IPC:
+  status: maintained
+  maintainers:
+    - doki-nordic
+  collaborators:
+    - carlocaione
+    - arnopo
+  files:
+    - include/zephyr/ipc/
+    - samples/subsys/ipc/
+    - subsys/ipc/
+    - tests/subsys/ipc/
+    - doc/services/ipc/
+    - dts/bindings/ipc/
+    - include/zephyr/dt-bindings/ipc_service/
+  description: >-
+    Inter-Processor Communication
+  labels:
+    - "area: IPC"
+  tests:
+    - ipc
+
+ITE Platforms:
+  status: maintained
+  maintainers:
+    - Dino-Li
+    - GTLin08
+    - RuibinChang
+    - Chenhongren
+  collaborators:
+    - jackrosenthal
+    - keith-zephyr
+    - fabiobaltieri
+  files:
+    - boards/ite/
+    - drivers/sensor/ite/
+    - drivers/usb/udc/*it82xx2*.c
+    - drivers/usb/device/*it82xx2*.c
+    - drivers/*/*it51xxx*.c
+    - drivers/*/*it8xxx2*.c
+    - drivers/*/*_ite_*
+    - dts/bindings/*/ite*
+    - dts/riscv/ite/
+    - soc/ite/
+  labels:
+    - "platform: ITE"
+
+Infineon Platforms:
+  status: maintained
+  maintainers:
+    - ifyall
+  collaborators:
+    - sreeramIfx
+    - mcatee-infineon
+    - talih0
+  files:
+    - boards/cypress/
+    - boards/infineon/
+    - drivers/*/*ifx_cat1*
+    - drivers/*/*xmc*
+    - drivers/sensor/infineon/
+    - dts/arm/infineon/
+    - dts/bindings/*/*infineon*
+    - soc/infineon/
+  labels:
+    - "platform: Infineon"
+  description: >-
+    Infineon SOCs, dts files and related drivers. Infineon Proto, Pioneer, Eval and Relax
+    boards.
+
 Input:
   status: maintained
   maintainers:
@@ -2549,27 +2807,109 @@ Input:
     - drivers.input
     - input
 
-IPC:
+Intel Platforms (Agilex):
   status: maintained
   maintainers:
-    - doki-nordic
+    - gdengi
   collaborators:
-    - carlocaione
-    - arnopo
+    - nbalabak
+    - teikheng
   files:
-    - include/zephyr/ipc/
-    - samples/subsys/ipc/
-    - subsys/ipc/
-    - tests/subsys/ipc/
-    - doc/services/ipc/
-    - dts/bindings/ipc/
-    - include/zephyr/dt-bindings/ipc_service/
-  description: >-
-    Inter-Processor Communication
+    - boards/intel/socfpga/
+    - soc/intel/intel_socfpga/
+    - dts/arm64/intel/
+    - dts/bindings/*/intel,agilex*
+    - dts/arm/intel_socfpga_std/
   labels:
-    - "area: IPC"
+    - "platform: Intel SoC FPGA Agilex"
+
+Intel Platforms (ISH):
+  status: maintained
+  maintainers:
+    - kwd-doodling
+  collaborators:
+    - teburd
+    - likongintel
+    - nashif
+  files:
+    - boards/intel/ish/
+    - soc/intel/intel_ish/
+    - dts/x86/intel/intel_ish*
+    - dts/bindings/*/intel,sedi*
+    - drivers/*/*sedi*
+  labels:
+    - "platform: Intel ISH"
+
+Intel Platforms (X86):
+  status: maintained
+  maintainers:
+    - edersondisouza
+  collaborators:
+    - najumon1980
+    - teburd
+    - dcpleung
+    - ceolin
+  files:
+    - boards/intel/adl/
+    - boards/intel/ehl/
+    - boards/intel/rpl/
+    - dts/x86/intel/
+    - soc/intel/atom/
+    - soc/intel/lakemont/
+    - soc/intel/*_lake/
+    - drivers/timer/Kconfig.x86
+    - drivers/timer/hpet.c
+    - drivers/timer/apic*
+  labels:
+    - "platform: X86"
+    - "platform: Intel"
+
+Intel Platforms (Xtensa):
+  status: maintained
+  maintainers:
+    - dcpleung
+  collaborators:
+    - andyross
+    - lyakh
+    - lgirdwood
+    - kv2019i
+    - ceolin
+    - tmleman
+    - softwarecki
+    - jxstelter
+    - marcinszkudlinski
+    - nashif
+  files:
+    - boards/intel/adsp/
+    - soc/intel/intel_adsp/
+    - dts/xtensa/intel/
+    - tests/boards/intel_adsp/
+    - samples/boards/intel/adsp/
+    - dts/bindings/*/intel,adsp*
+    - scripts/west_commands/runners/intel_adsp.py
+  labels:
+    - "platform: Intel ADSP"
+
+"Interrupt Handling":
+  status: odd fixes
+  collaborators:
+    - ycsin
+    - dcpleung
+    - nashif
+  files:
+    - drivers/interrupt_controller/
+    - dts/bindings/interrupt-controller/
+    - include/zephyr/drivers/interrupt_controller/
+    - include/zephyr/dt-bindings/interrupt-controller/
+    - include/zephyr/irq*
+    - include/zephyr/sw_isr_table.h
+    - include/zephyr/shared_irq.h
+    - tests/drivers/interrupt_controller/
+    - tests/drivers/build_all/interrupt_controller/
+  labels:
+    - "area: Interrupt Controller"
   tests:
-    - ipc
+    - drivers.interrupt_controller
 
 JSON Web Token:
   status: maintained
@@ -2605,8 +2945,7 @@ Kconfig:
   labels:
     - "area: Kconfig"
   description: >-
-    See https://docs.zephyrproject.org/latest/build/kconfig/index.html and
-    https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html#default-board-configuration
+    See https://docs.zephyrproject.org/latest/build/kconfig/index.html
   tests:
     - kconfig
 
@@ -2640,112 +2979,25 @@ Kernel:
   tests:
     - kernel
 
-Utilities:
+"Linkable Loadable Extensions":
   status: maintained
   maintainers:
-    - andyross
-    - nashif
+    - teburd
   collaborators:
-    - dcpleung
-    - peter-mitsis
+    - lyakh
+    - pillo79
   files:
-    - lib/crc/
-    - lib/utils/
-    - tests/unit/timeutil/
-    - tests/unit/time_units/
-    - tests/unit/rbtree/
-    - tests/unit/math_extras/
-    - tests/unit/crc/
-    - tests/unit/base64/
-    - tests/unit/math_extras/
-    - tests/unit/list/
-    - tests/unit/intmath/
-    - tests/unit/pot/
-    - tests/lib/onoff/
-    - tests/lib/sys_util/
-    - tests/lib/sprintf/
-    - tests/lib/ringbuffer/
-    - tests/lib/notify/
-    - tests/lib/linear_range/
+    - cmake/llext-edk.cmake
+    - samples/subsys/llext/
+    - include/zephyr/llext/
+    - tests/misc/llext-edk/
+    - tests/subsys/llext/
+    - subsys/llext/
+    - doc/services/llext/
   labels:
-    - "area: Utilities"
+    - "area: llext"
   tests:
-    - utilities
-    - libraries.ring_buffer
-    - libraries.linear_range
-
-Base OS:
-  status: maintained
-  maintainers:
-    - andyross
-    - nashif
-  collaborators:
-    - dcpleung
-    - peter-mitsis
-  files:
-    - include/zephyr/sys/
-    - lib/os/
-    - tests/misc/print_format/
-    - tests/lib/p4workq/
-    - tests/lib/fdtable/
-  files-exclude:
-    - include/zephyr/sys/cbprintf*
-    - tests/unit/cbprintf/
-    - tests/lib/cbprintf_*/
-    - lib/os/cbprintf*
-    - lib/os/Kconfig.cbprintf
-    - include/zephyr/sys/mem_manage.h
-    - include/zephyr/sys/mpsc_pbuf.h
-    - include/zephyr/sys/mpsc_packet.h
-    - lib/os/mpsc_pbuf.c
-  labels:
-    - "area: Base OS"
-  tests:
-    - printk
-
-Heap Management:
-  status: maintained
-  maintainers:
-    - npitre
-    - andyross
-  files:
-    - tests/lib/shared_multi_heap/
-    - lib/heap/
-    - tests/lib/heap/
-    - tests/lib/heap_align/
-    - tests/lib/multi_heap/
-    - include/zephyr/multi_heap/
-
-Memory Management:
-  status: maintained
-  maintainers:
-    - carlocaione
-    - dcpleung
-  files:
-    - subsys/mem_mgmt/
-    - lib/mem_blocks/
-    - tests/subsys/mem_mgmt/
-    - include/zephyr/mem_mgmt/mem_attr_heap.h
-    - tests/lib/mem_alloc/
-    - tests/lib/mem_blocks/
-    - doc/services/mem_mgmt/
-    - include/zephyr/mem_mgmt/mem_attr.h
-    - include/zephyr/dt-bindings/memory-attr/
-    - tests/lib/mem_blocks_stats/
-    - tests/drivers/mm/
-  tests:
-    - mem_mgmt
-
-Ezurio platforms:
-  status: maintained
-  maintainers:
-    - rerickson1
-  collaborators:
-    - greg-leach
-  files:
-    - boards/ezurio/
-  labels:
-    - "platform: Ezurio"
+    - llext
 
 Linker Scripts:
   status: maintained
@@ -2761,6 +3013,28 @@ Linker Scripts:
   tests:
     - linker
 
+LiteX Platforms:
+  status: maintained
+  maintainers:
+    - tgorochowik
+    - kgugala
+    - fkokosinski
+  collaborators:
+    - mateusz-holenko
+    - maass-hamburg
+  files:
+    - boards/enjoydigital/litex_vexriscv/
+    - drivers/*/*litex*
+    - drivers/*/Kconfig.litex
+    - dts/bindings/*/litex*
+    - dts/riscv/riscv32-litex-vexriscv.dtsi
+    - include/zephyr/drivers/*/*litex*
+    - samples/boards/enjoydigital/litex/
+    - samples/drivers/*litex/
+    - soc/litex/
+  labels:
+    - "platform: LiteX"
+
 Little FS:
   status: odd fixes
   files:
@@ -2773,30 +3047,6 @@ Little FS:
     - "area: File System"
   tests:
     - filesystem.littlefs
-
-Logging:
-  status: maintained
-  maintainers:
-    - nordic-krch
-  collaborators:
-    - dcpleung
-  files:
-    - include/zephyr/logging/
-    - include/zephyr/sys/mpsc_pbuf.h
-    - include/zephyr/sys/mpsc_packet.h
-    - lib/os/mpsc_pbuf.c
-    - doc/kernel/data_structures/mpsc_pbuf.rst
-    - tests/lib/mpsc_pbuf/
-    - samples/subsys/logging/
-    - subsys/logging/
-    - tests/subsys/logging/
-    - scripts/logging/
-    - doc/services/logging/
-    - tests/lib/spsc_pbuf/
-  labels:
-    - "area: Logging"
-  tests:
-    - logging
 
 LoRa and LoRaWAN:
   status: maintained
@@ -2823,6 +3073,30 @@ LoRa and LoRaWAN:
   tests:
     - sample.driver.lora
     - lorawan
+
+Logging:
+  status: maintained
+  maintainers:
+    - nordic-krch
+  collaborators:
+    - dcpleung
+  files:
+    - include/zephyr/logging/
+    - include/zephyr/sys/mpsc_pbuf.h
+    - include/zephyr/sys/mpsc_packet.h
+    - lib/os/mpsc_pbuf.c
+    - doc/kernel/data_structures/mpsc_pbuf.rst
+    - tests/lib/mpsc_pbuf/
+    - samples/subsys/logging/
+    - subsys/logging/
+    - tests/subsys/logging/
+    - scripts/logging/
+    - doc/services/logging/
+    - tests/lib/spsc_pbuf/
+  labels:
+    - "area: Logging"
+  tests:
+    - logging
 
 MAINTAINERS file:
   status: maintained
@@ -2855,6 +3129,88 @@ MCU Manager:
     - "area: mcumgr"
   tests:
     - mgmt.mcumgr
+
+MIPS arch:
+  status: odd fixes
+  files:
+    - arch/mips/
+    - include/zephyr/arch/mips/
+    - boards/qemu/malta/
+  labels:
+    - "area: MIPS"
+  tests:
+    - arch.mips
+
+Memory Management:
+  status: maintained
+  maintainers:
+    - carlocaione
+    - dcpleung
+  files:
+    - subsys/mem_mgmt/
+    - lib/mem_blocks/
+    - tests/subsys/mem_mgmt/
+    - include/zephyr/mem_mgmt/mem_attr_heap.h
+    - tests/lib/mem_alloc/
+    - tests/lib/mem_blocks/
+    - doc/services/mem_mgmt/
+    - include/zephyr/mem_mgmt/mem_attr.h
+    - include/zephyr/dt-bindings/memory-attr/
+    - tests/lib/mem_blocks_stats/
+    - tests/drivers/mm/
+  tests:
+    - mem_mgmt
+
+Microchip MEC Platforms:
+  status: maintained
+  maintainers:
+    - jvasanth1
+  collaborators:
+    - VenkatKotakonda
+    - albertofloyd
+  files:
+    - boards/microchip/mec*/
+    - dts/arm/microchip/
+    - soc/microchip/mec/
+    - drivers/*/*mchp*.c
+    - tests/boards/mec15xxevb_assy6853/
+    - tests/boards/mec172xevb_assy6906/
+    - dts/bindings/*/microchip,mec*
+    - dts/bindings/*/microchip,xec*
+    - samples/boards/microchip/
+  labels:
+    - "platform: Microchip MEC"
+
+Microchip RISC-V Platforms:
+  status: maintained
+  maintainers:
+    - fkokosinski
+    - kgugala
+    - tgorochowik
+  files:
+    - boards/microchip/m2gl025_miv/
+    - boards/microchip/mpfs_icicle/
+    - dts/riscv/microchip/
+    - soc/microchip/miv/
+  labels:
+    - "platform: Microchip RISC-V"
+
+Microchip SAM Platforms:
+  status: maintained
+  maintainers:
+    - nandojve
+  collaborators:
+    - pdgendt
+    - mnkp
+    - stephanosio
+  files:
+    - boards/atmel/
+    - dts/arm/atmel/
+    - soc/atmel/
+    - drivers/*/*sam*.c
+    - dts/bindings/*/atmel,*
+  labels:
+    - "platform: Microchip SAM"
 
 Modbus:
   status: maintained
@@ -2904,50 +3260,198 @@ NEORV32 platform:
   tests:
     - boards.neorv32
 
-OSDP:
+NXP Platform Drivers:
   status: maintained
   maintainers:
-    - sidcha
+    - dleach02
+    - mmahadevan108
   collaborators:
-    - adakus
-    - r2r0
+    - decsny
+    - manuargue
+    - dbaluta
+    - Raymond0225
+  files-regex:
+    - ^drivers/.*nxp.*
+    - ^drivers/.*mcux.*
   files:
-    - subsys/mgmt/osdp/
-    - include/zephyr/mgmt/osdp.h
-    - samples/subsys/mgmt/osdp/
+    - drivers/*/*imx*
+    - drivers/*/*lpc*.c
+    - drivers/*/*mcux*.c
+    - drivers/*/*.mcux
+    - drivers/*/*.nxp
+    - drivers/*/*nxp*
+    - drivers/*/*/*kinetis*
+    - drivers/misc/*/nxp*
+    - include/zephyr/dt-bindings/*/*nxp*
+    - include/zephyr/dt-bindings/*/*mcux*
+    - include/zephyr/dt-bindings/inputmux/
+    - include/zephyr/dt-bindings/rdc/
+    - include/zephyr/drivers/*/*nxp*
+    - include/zephyr/drivers/*/*nxp*/
+    - include/zephyr/drivers/*/*mcux*
+    - arch/arm/core/mpu/nxp_mpu.c
+    - dts/bindings/*/nxp*
+  files-exclude:
+    - drivers/wifi/
+    - drivers/bluetooth/
+    - drivers/usb/
+  files-regex-exclude:
+    - .*s32.*
   labels:
-    - "area: OSDP"
-  tests:
-    - sample.mgmt.osdp
+    - "platform: NXP Drivers"
+  description: NXP Drivers
 
-hawkBit:
+NXP Platform MCUX USB:
   status: maintained
   maintainers:
-    - maass-hamburg
+    - mmahadevan108
+    - MarkWangChinese
   files:
-    - subsys/mgmt/hawkbit/
-    - include/zephyr/mgmt/hawkbit/
-    - include/zephyr/mgmt/hawkbit.h
-    - samples/subsys/mgmt/hawkbit/
+    - drivers/usb/*/*mcux*
+    - boards/nxp/usb_kw24d512/
   labels:
-    - "area: hawkBit"
-  tests:
-    - sample.net.hawkbit
+    - "platform: NXP Drivers"
+  description: NXP MCUX USB shim drivers
 
-"mgmt: updatehub":
+NXP Platform Wireless:
   status: maintained
   maintainers:
-    - nandojve
+    - dleach02
+  collaborators:
+    - MaochenWang1
+    - axelnxp
+    - George-Stefan
   files:
-    - subsys/mgmt/updatehub/
-    - include/zephyr/mgmt/updatehub.h
-    - samples/subsys/mgmt/updatehub/
+    - boards/nxp/*mcxw*/
+    - boards/nxp/*rw*/
+    - drivers/*/*mcxw*.c
+    - drivers/bluetooth/hci/*nxp*
+    - drivers/hdlc_rcp_if/*nxp*
+    - drivers/ieee802154/ieee802154_kw41z.c
+    - drivers/wifi/nxp/
+    - samples/bluetooth/**/*rw*
+    - samples/net/**/*mcxw*
+    - samples/net/**/*nxp*
+    - samples/net/**/*rw*
+    - soc/nxp/mcx/mcxw/
+    - soc/nxp/rw/
   labels:
-    - "area: updatehub"
-  description: >-
-    UpdateHub embedded Firmware Over-The-Air (FOTA) upgrade agent
-  tests:
-    - sample.net.updatehub
+    - "platform: NXP Drivers"
+
+NXP Platforms (MCU):
+  status: maintained
+  maintainers:
+    - dleach02
+    - mmahadevan108
+  collaborators:
+    - DerekSnell
+    - EmilioCBen
+    - decsny
+    - butok
+  files:
+    - boards/nxp/mimxrt*/
+    - boards/nxp/frdm*/
+    - boards/nxp/lpcxpress*/
+    - boards/nxp/twr_*/
+    - boards/nxp/*rw*/
+    - boards/nxp/hexiwear/
+    - boards/nxp/common/
+    - boards/nxp/*
+    - soc/nxp/common/
+    - soc/nxp/imxrt/
+    - soc/nxp/kinetis/
+    - soc/nxp/lpc/
+    - soc/nxp/rw/
+    - soc/nxp/mcx/
+    - dts/arm/nxp/
+    - samples/boards/nxp*/
+  files-exclude:
+    - dts/arm/nxp/nxp_imx*
+  files-regex-exclude:
+    - .*s32.*
+  labels:
+    - "platform: NXP"
+  description: NXP MCU Platforms supported by MCUXpresso suite
+
+NXP Platforms (MPU):
+  status: maintained
+  maintainers:
+    - JiafeiPan
+  collaborators:
+    - dleach02
+    - dbaluta
+    - iuliana-prodan
+    - yangbolu1991
+    - Zhiqiang-Hou
+  files:
+    - dts/arm64/nxp/
+    - dts/arm/nxp/nxp_imx*
+    - soc/nxp/imx/
+    - soc/nxp/layerscape/
+    - boards/nxp/ls1046ardb/
+  files-regex:
+    - boards/nxp/m?imx[^(rt)].*/
+  labels:
+    - "platform: NXP MPU"
+  description: NXP MPU platforms
+
+NXP Platforms (Robotics Products):
+  status: maintained
+  maintainers:
+    - bperseghetti
+    - PetervdPerk-NXP
+  collaborators:
+    - manuargue
+  files:
+    - boards/nxp/vmu*/
+    - boards/nxp/rddrone_fmuk66/
+    - boards/nxp/mr_canhubk3/
+    - boards/nxp/ucans32k1sic/
+  labels:
+    - "platform: NXP Robotics"
+  description: NXP Robotics Module Platform Products
+
+NXP Platforms (S32):
+  status: maintained
+  maintainers:
+    - manuargue
+  collaborators:
+    - Dat-NguyenDuy
+    - congnguyenhuu
+  files:
+    - boards/nxp/*s32*/
+    - boards/common/*nxp_s32*
+    - soc/nxp/s32/
+    - drivers/*/*nxp_s32*
+    - drivers/misc/*nxp_s32*/
+    - dts/bindings/*/nxp,s32*
+    - dts/arm/nxp/*s32*
+    - samples/boards/nxp/s32/
+    - include/zephyr/dt-bindings/*/nxp-s32*
+    - include/zephyr/dt-bindings/*/nxp_s32*
+    - include/zephyr/drivers/*/*nxp_s32*
+  files-exclude:
+    - boards/nxp/ucans32k1sic/
+  labels:
+    - "platform: NXP S32"
+  description: NXP S32 platforms and S32-specific drivers
+
+NXP Platforms (Xtensa):
+  status: maintained
+  maintainers:
+    - dbaluta
+  collaborators:
+    - iuliana-prodan
+  files:
+    - soc/nxp/imx/*/adsp/
+    - soc/nxp/imxrt/imxrt5xx/f1/
+    - soc/nxp/imxrt/imxrt7xx/hifi1/
+    - soc/nxp/imxrt/*/hifi4/
+    - soc/nxp/imxrt/imxrt[567]xx/CMakeLists.txt
+    - soc/nxp/imxrt/imxrt[567]xx/Kconfig*
+  labels:
+    - "platform: NXP Xtensa"
+  description: NXP Xtensa platforms
 
 Native_sim and POSIX arch:
   status: maintained
@@ -3030,21 +3534,6 @@ Networking:
   tests:
     - net
 
-"Networking: BSD sockets":
-  status: maintained
-  maintainers:
-    - rlubos
-    - jukkar
-  files:
-    - samples/net/sockets/
-    - subsys/net/lib/sockets/
-    - tests/net/socket/
-  labels:
-    - "area: Networking"
-    - "area: Sockets"
-  tests:
-    - net.socket
-
 "Networking Buffers":
   status: maintained
   maintainers:
@@ -3061,6 +3550,36 @@ Networking:
     - "area: Networking Buffers"
   tests:
     - libraries.net_buf
+
+"Networking: BSD sockets":
+  status: maintained
+  maintainers:
+    - rlubos
+    - jukkar
+  files:
+    - samples/net/sockets/
+    - subsys/net/lib/sockets/
+    - tests/net/socket/
+  labels:
+    - "area: Networking"
+    - "area: Sockets"
+  tests:
+    - net.socket
+
+"Networking: CoAP":
+  status: maintained
+  maintainers:
+    - rlubos
+  collaborators:
+    - pdgendt
+  files:
+    - subsys/net/lib/coap/
+    - samples/net/sockets/coap_*/
+    - tests/net/lib/coap/
+  labels:
+    - "area: Networking"
+  tests:
+    - net.coap
 
 "Networking: Connection Manager":
   status: maintained
@@ -3080,21 +3599,6 @@ Networking:
   tests:
     - net.conn_mgr
 
-"Networking: CoAP":
-  status: maintained
-  maintainers:
-    - rlubos
-  collaborators:
-    - pdgendt
-  files:
-    - subsys/net/lib/coap/
-    - samples/net/sockets/coap_*/
-    - tests/net/lib/coap/
-  labels:
-    - "area: Networking"
-  tests:
-    - net.coap
-
 "Networking: DHCPv4":
   status: maintained
   maintainers:
@@ -3113,19 +3617,24 @@ Networking:
     - net.dhcpv4_client
     - net.dhcpv4_server
 
-"Networking: gPTP":
+"Networking: HTTP":
   status: maintained
   maintainers:
     - jukkar
+    - rlubos
+  collaborators:
+    - mrodgers-witekio
   files:
-    - doc/connectivity/networking/api/gptp.rst
-    - include/zephyr/net/gptp.h
-    - samples/net/gptp/
-    - subsys/net/l2/ethernet/gptp/
+    - doc/connectivity/networking/api/http*.rst
+    - include/zephyr/net/http/
+    - subsys/net/lib/http/
+    - samples/net/sockets/*http*/
+    - tests/net/lib/http*/
   labels:
     - "area: Networking"
+    - "area: HTTP"
   tests:
-    - sample.net.gptp
+    - net.http
 
 "Networking: LWM2M":
   status: maintained
@@ -3173,20 +3682,6 @@ Networking:
   tests:
     - net.mqtt_sn
 
-"Networking: PTP":
-  status: maintained
-  maintainers:
-    - awojasinski
-  files:
-    - doc/connectivity/networking/api/ptp.rst
-    - include/zephyr/net/ptp.h
-    - subsys/net/lib/ptp/
-    - samples/net/ptp/
-  labels:
-    - "area: PTP"
-  tests:
-    - sample.net.ptp
-
 "Networking: Native IEEE 802.15.4":
   status: odd fixes
   collaborators:
@@ -3223,6 +3718,20 @@ Networking:
   tests:
     - openthread
 
+"Networking: PTP":
+  status: maintained
+  maintainers:
+    - awojasinski
+  files:
+    - doc/connectivity/networking/api/ptp.rst
+    - include/zephyr/net/ptp.h
+    - subsys/net/lib/ptp/
+    - samples/net/ptp/
+  labels:
+    - "area: PTP"
+  tests:
+    - sample.net.ptp
+
 "Networking: Wi-Fi":
   status: maintained
   maintainers:
@@ -3243,42 +3752,102 @@ Networking:
   tests:
     - net.wifi
 
-"Networking: HTTP":
+"Networking: gPTP":
   status: maintained
   maintainers:
     - jukkar
-    - rlubos
-  collaborators:
-    - mrodgers-witekio
   files:
-    - doc/connectivity/networking/api/http*.rst
-    - include/zephyr/net/http/
-    - subsys/net/lib/http/
-    - samples/net/sockets/*http*/
-    - tests/net/lib/http*/
+    - doc/connectivity/networking/api/gptp.rst
+    - include/zephyr/net/gptp.h
+    - samples/net/gptp/
+    - subsys/net/l2/ethernet/gptp/
   labels:
     - "area: Networking"
-    - "area: HTTP"
   tests:
-    - net.http
+    - sample.net.gptp
 
-nRF BSIM:
+Nuvoton NPCM Platforms:
   status: maintained
   maintainers:
-    - aescolar
+    - maxdog988
+    - warp5tw
+    - jc849
   files:
-    - boards/native/nrf_bsim/
-    - tests/boards/nrf52_bsim/
-    - tests/bsim/
-    - doc/develop/test/bsim.rst
-    - .github/workflows/bsim-tests*
-  files-regex-exclude:
-    - tests\/bsim\/.*\/.*\.([ch]|conf)
-    - tests\/bsim\/.*\/(CMakeLists|Kconfig).*
+    - soc/nuvoton/npcm/
+    - boards/nuvoton/npcm*/
+    - dts/arm/nuvoton/
+    - drivers/*/*_npcm*
+    - include/zephyr/dt-bindings/*/npcm_*
   labels:
-    - "platform: nRF BSIM"
+    - "platform: Nuvoton NPCM"
+
+Nuvoton NPCX Platforms:
+  status: maintained
+  maintainers:
+    - MulinChao
+    - ChiHuaL
+  collaborators:
+    - TomChang19
+    - alvsun
+    - sjg20
+    - keith-zephyr
+    - jackrosenthal
+    - fabiobaltieri
+  files:
+    - soc/nuvoton/npcx/
+    - boards/nuvoton/npcx*/
+    - dts/arm/nuvoton/
+    - dts/bindings/*/*npcx*
+    - drivers/*/*_npcx*.c
+  labels:
+    - "platform: Nuvoton NPCX"
+
+Nuvoton Numicro Numaker Platforms:
+  status: maintained
+  maintainers:
+    - cyliangtw
+  collaborators:
+    - ssekar15
+  files:
+    - soc/nuvoton/numaker/
+    - soc/nuvoton/numicro/
+    - boards/nuvoton/numaker*/
+    - dts/arm/nuvoton/
+    - dts/bindings/*/*numicro*
+    - dts/bindings/*/*numaker*
+    - drivers/*/*_numicro*
+    - drivers/*/*_numaker*
+  labels:
+    - "platform: Nuvoton Numicro Numaker"
+
+OSDP:
+  status: maintained
+  maintainers:
+    - sidcha
+  collaborators:
+    - adakus
+    - r2r0
+  files:
+    - subsys/mgmt/osdp/
+    - include/zephyr/mgmt/osdp.h
+    - samples/subsys/mgmt/osdp/
+  labels:
+    - "area: OSDP"
   tests:
-    - boards.nrf52_bsim
+    - sample.mgmt.osdp
+
+Octavo Systems Platforms:
+  status: maintained
+  maintainers:
+    - fkokosinski
+    - tgorochowik
+  collaborators:
+    - kgugala
+  files:
+    - boards/oct/
+    - soc/oct/
+  labels:
+    - "platform: Octavo Systems"
 
 Open AMP:
   status: maintained
@@ -3296,6 +3865,21 @@ Open AMP:
     - "area: Open AMP"
   tests:
     - sample.ipc.openamp
+
+OpenTitan Platforms:
+  status: maintained
+  maintainers:
+    - snematbakhsh
+  files:
+    - boards/lowrisc/opentitan_earlgrey/
+    - drivers/*/*opentitan*
+    - dts/bindings/*/*opentitan*
+    - dts/riscv/lowrisc/*opentitan*
+    - soc/lowrisc/opentitan/
+  labels:
+    - "platform: OpenTitan"
+  description: >-
+    OpenTitan boards, SOCs, dts files and related drivers.
 
 PHYTEC Platforms:
   status: maintained
@@ -3341,6 +3925,24 @@ POSIX API layer:
   tests:
     - libraries.fdtable
     - portability.posix
+
+Panasonic Platforms:
+  status: maintained
+  maintainers:
+    - pideu-sj
+  files:
+    - boards/panasonic/
+  labels:
+    - "platform: Panasonic"
+
+Peregrine Platforms:
+  status: maintained
+  maintainers:
+    - nandojve
+  files:
+    - boards/peregrine/
+  labels:
+    - "platform: Peregrine"
 
 Power management:
   status: maintained
@@ -3413,323 +4015,53 @@ RISCV arch:
   tests:
     - arch.riscv
 
-Retention:
+RTIO:
   status: maintained
   maintainers:
-    - nordicjm
-  files:
-    - dts/bindings/retention/
-    - include/zephyr/retention/
-    - subsys/retention/
-    - doc/services/retention/
-  labels:
-    - "area: Retention"
-
-Samples:
-  status: maintained
-  maintainers:
-    - kartben
+    - teburd
   collaborators:
-    - nashif
-  files:
-    - samples/sample_definition_and_criteria.rst
-    - samples/
-  labels:
-    - "area: Samples"
-
-Sensor Subsystem:
-  status: maintained
-  maintainers:
-    - lixuzha
-    - ghu0510
     - yperess
-  collaborators:
-    - qianruh
+    - ubieda
   files:
-    - dts/bindings/sensor/zephyr,sensing.yaml
-    - dts/bindings/sensor/zephyr,sensing*.yaml
-    - include/zephyr/sensing/
-    - doc/services/sensing/
-    - subsys/sensing/
-    - samples/subsys/sensing/
-    - tests/subsys/sensing/
+    - samples/subsys/rtio/
+    - include/zephyr/rtio/
+    - tests/subsys/rtio/
+    - subsys/rtio/
+    - doc/services/rtio/
   labels:
-    - "area: Sensor Subsystem"
+    - "area: RTIO"
   tests:
-    - sample.sensing
-    - sensing.api
+    - rtio
 
-Stats:
-  status: odd fixes
-  files:
-    - subsys/stats/
-    - include/zephyr/stats/stats.h
-  labels:
-    - "area: Stats"
-
-Twister:
+RX arch:
   status: maintained
   maintainers:
-    - nashif
-  collaborators:
-    - PerMac
-    - hakehuang
-    - golowanow
-    - gchwier
-    - LukaszMrugala
-    - KamilxPaszkiet
+    - duynguyenxa
   files:
-    - scripts/twister
-    - scripts/schemas/twister/
-    - scripts/pylib/twister/
-    - scripts/tests/twister/
-    - scripts/tests/twister_blackbox/
-    - doc/develop/test/twister.rst
-    - scripts/pylib/pytest-twister-harness/
-    - doc/develop/test/pytest.rst
-    - tests/test_config.yaml
-    - scripts/utils/twister_to_list.py
-    - tests/robot/common.robot
-    - scripts/pylib/*-twister-harness/
+    - arch/rx/
+    - include/zephyr/arch/rx/
+    - dts/rx/
+    - boards/qemu/rx/
+    - soc/renesas/rx/
+    - tests/arch/rx/
+    - include/zephyr/drivers/misc/renesas_rx_external_interrupt/
   labels:
-    - "area: Twister"
-
-Settings:
-  status: odd fixes
-  files:
-    - include/zephyr/settings/
-    - subsys/settings/
-    - tests/subsys/settings/
-    - samples/subsys/settings/
-    - doc/services/storage/settings/
-    - tests/subsys/settings_commit_prio/
-  labels:
-    - "area: Settings"
+    - "area: RX"
   tests:
-    - settings
+    - arch.rx
 
-Shell:
+Random:
   status: maintained
   maintainers:
-    - jakub-uC
+    - ceolin
   collaborators:
-    - carlescufi
+    - tomi-font
   files:
-    - include/zephyr/shell/
-    - samples/subsys/shell/
-    - subsys/shell/
-    - tests/subsys/shell/
-    - doc/services/shell/
+    - subsys/random/
+    - include/zephyr/random/
+    - tests/subsys/random/
   labels:
-    - "area: Shell"
-  tests:
-    - shell
-
-Shields:
-  status: maintained
-  maintainers:
-    - kartben
-  collaborators:
-    - avisconti
-    - jfischer-no
-    - erwango
-  files:
-    - boards/shields/
-    - doc/hardware/porting/shields.rst
-    - samples/shields/
-  labels:
-    - "area: Shields"
-  tests:
-    - sample.shields
-
-SPARC arch:
-  status: odd fixes
-  collaborators:
-    - tbr-tt
-  files:
-    - arch/sparc/
-    - include/zephyr/arch/sparc/
-    - dts/sparc/
-    - boards/qemu/leon3/
-  labels:
-    - "area: SPARC"
-
-Gaisler Platforms:
-  status: odd fixes
-  collaborators:
-    - tbr-tt
-  files:
-    - dts/sparc/gaisler/
-    - soc/gaisler/
-    - boards/gaisler/
-  labels:
-    - "area: SPARC"
-
-State machine framework:
-  status: maintained
-  maintainers:
-    - sambhurst
-  collaborators:
-    - keith-zephyr
-    - glenn-andrews
-  files:
-    - doc/services/smf/
-    - include/zephyr/smf.h
-    - lib/smf/
-    - tests/lib/smf/
-    - samples/subsys/smf/
-  labels:
-    - "area: State Machine Framework"
-  tests:
-    - libraries.smf
-
-ADI Platforms:
-  status: maintained
-  maintainers:
-    - MaureenHelm
-  collaborators:
-    - ozersa
-    - ttmut
-    - yasinustunerg
-    - galak
-    - microbuilder
-  files:
-    - boards/adi/
-    - boards/shields/eval*ardz/
-    - boards/shields/pmod_acl/
-    - drivers/*/*max*
-    - drivers/*/*max*/
-    - drivers/dac/dac_ltc*
-    - drivers/ethernet/eth_adin*
-    - drivers/ethernet/phy/phy_adin*
-    - drivers/mdio/mdio_adin*
-    - drivers/sensor/adi/
-    - drivers/stepper/adi_tmc/
-    - dts/arm/adi/
-    - dts/bindings/*/adi,*
-    - dts/bindings/*/lltc,*
-    - dts/bindings/*/maxim,*
-    - soc/adi/
-  files-regex:
-    - ^drivers/(adc|dac|gpio|mfd|regulator)/.*adp?\d+
-  labels:
-    - "platform: ADI"
-
-Bouffalolab Platforms:
-  status: maintained
-  maintainers:
-    - nandojve
-    - VynDragon
-  files:
-    - boards/bflb/
-    - drivers/*/*bflb*
-    - dts/riscv/bflb/
-    - dts/bindings/*/bflb,*
-    - soc/bflb/
-  labels:
-    - "platform: bouffalolab"
-
-Broadcom Platforms:
-  status: odd fixes
-  files:
-    - dts/*/broadcom/
-    - soc/brcm/
-    - boards/brcm/
-
-GD32 Platforms:
-  status: maintained
-  maintainers:
-    - nandojve
-  collaborators:
-    - soburi
-    - cameled
-  files:
-    - boards/gd/
-    - drivers/*/*gd32*
-    - dts/*/gd/
-    - dts/bindings/*/*gd32*
-    - scripts/west_commands/*/*gd32*
-    - soc/gd/gd32/
-  labels:
-    - "platform: GD32"
-  description: >-
-    GigaDevice GD32 SOCs, dts files and related drivers. Starter and eval
-    boards.
-
-Synopsys Platforms:
-  status: maintained
-  maintainers:
-    - ruuddw
-    - evgeniy-paltsev
-  collaborators:
-    - abrodkin
-  files:
-    - soc/snps/
-    - boards/snps/
-    - boards/qemu/arc/
-    - samples/boards/arc_secure_services/
-    - scripts/west_commands/runners/mdb.py
-    - scripts/west_commands/tests/test_mdb.py
-    - scripts/west_commands/runners/nsim.py
-    - cmake/emu/nsim.cmake
-    - drivers/serial/uart_hostlink.c
-    - drivers/serial/Kconfig.hostlink
-  labels:
-    - "platform: Synopsys"
-
-Nuvoton NPCX Platforms:
-  status: maintained
-  maintainers:
-    - MulinChao
-    - ChiHuaL
-  collaborators:
-    - TomChang19
-    - alvsun
-    - sjg20
-    - keith-zephyr
-    - jackrosenthal
-    - fabiobaltieri
-  files:
-    - soc/nuvoton/npcx/
-    - boards/nuvoton/npcx*/
-    - dts/arm/nuvoton/
-    - dts/bindings/*/*npcx*
-    - drivers/*/*_npcx*.c
-  labels:
-    - "platform: Nuvoton NPCX"
-
-Nuvoton Numicro Numaker Platforms:
-  status: maintained
-  maintainers:
-    - cyliangtw
-  collaborators:
-    - ssekar15
-  files:
-    - soc/nuvoton/numaker/
-    - soc/nuvoton/numicro/
-    - boards/nuvoton/numaker*/
-    - dts/arm/nuvoton/
-    - dts/bindings/*/*numicro*
-    - dts/bindings/*/*numaker*
-    - drivers/*/*_numicro*
-    - drivers/*/*_numaker*
-  labels:
-    - "platform: Nuvoton Numicro Numaker"
-
-Nuvoton NPCM Platforms:
-  status: maintained
-  maintainers:
-    - maxdog988
-    - warp5tw
-    - jc849
-  files:
-    - soc/nuvoton/npcm/
-    - boards/nuvoton/npcm*/
-    - dts/arm/nuvoton/
-    - drivers/*/*_npcm*
-    - include/zephyr/dt-bindings/*/npcm_*
-  labels:
-    - "platform: Nuvoton NPCM"
+    - "area: Random"
 
 Raspberry Pi Pico Platforms:
   status: maintained
@@ -3758,451 +4090,6 @@ Raspberry Pi Pico Platforms:
   labels:
     - "platform: Raspberry Pi Pico"
 
-Silabs Platforms:
-  status: maintained
-  maintainers:
-    - jhedberg
-    - asmellby
-  collaborators:
-    - jerome-pouiller
-    - Martinhoff-maker
-  files:
-    - soc/silabs/
-    - boards/silabs/
-    - dts/arm/silabs/
-    - dts/bindings/*/silabs*
-    - drivers/*/*gecko*
-    - drivers/*/*silabs*
-    - drivers/*/*siwx91x*
-    - drivers/*/*/*silabs*
-    - drivers/*/*/*siwx91x*
-    - tests/boards/silabs/
-    - snippets/*silabs*/
-  labels:
-    - "platform: Silabs"
-
-Silabs SiM3U Platforms:
-  status: maintained
-  maintainers:
-    - rettichschnidi
-  collaborators:
-    - M1cha
-    - asmellby
-    - jerome-pouiller
-    - jhedberg
-  files:
-    - boards/silabs/dev_kits/sim3u1xx_dk/
-    - drivers/*/*_si32*
-    - drivers/*/Kconfig.si32
-    - dts/arm/silabs/sim3u*
-    - dts/bindings/*/*silabs,si32*
-    - include/zephyr/dt-bindings/pinctrl/*si32*
-    - soc/silabs/silabs_sim3/
-  labels:
-    - "platform: Silabs SiM3U"
-  description: >-
-    SiM3U SoCs, dts files, and related drivers. Boards based on SiM3U SoCs.
-
-Gardena Platforms:
-  status: maintained
-  maintainers:
-    - rettichschnidi
-  collaborators:
-    - M1cha
-  files:
-    - boards/gardena/
-  labels:
-    - "platform: Gardena"
-  description: >-
-    Gardena board(s).
-
-Intel Platforms (X86):
-  status: maintained
-  maintainers:
-    - edersondisouza
-  collaborators:
-    - najumon1980
-    - teburd
-    - dcpleung
-    - ceolin
-  files:
-    - boards/intel/adl/
-    - boards/intel/ehl/
-    - boards/intel/rpl/
-    - dts/x86/intel/
-    - soc/intel/atom/
-    - soc/intel/lakemont/
-    - soc/intel/*_lake/
-    - drivers/timer/Kconfig.x86
-    - drivers/timer/hpet.c
-    - drivers/timer/apic*
-  labels:
-    - "platform: X86"
-    - "platform: Intel"
-
-Intel Platforms (Xtensa):
-  status: maintained
-  maintainers:
-    - dcpleung
-  collaborators:
-    - andyross
-    - lyakh
-    - lgirdwood
-    - kv2019i
-    - ceolin
-    - tmleman
-    - softwarecki
-    - jxstelter
-    - marcinszkudlinski
-    - nashif
-  files:
-    - boards/intel/adsp/
-    - soc/intel/intel_adsp/
-    - dts/xtensa/intel/
-    - tests/boards/intel_adsp/
-    - samples/boards/intel/adsp/
-    - dts/bindings/*/intel,adsp*
-    - scripts/west_commands/runners/intel_adsp.py
-  labels:
-    - "platform: Intel ADSP"
-
-Intel Platforms (ISH):
-  status: maintained
-  maintainers:
-    - kwd-doodling
-  collaborators:
-    - teburd
-    - likongintel
-    - nashif
-  files:
-    - boards/intel/ish/
-    - soc/intel/intel_ish/
-    - dts/x86/intel/intel_ish*
-    - dts/bindings/*/intel,sedi*
-    - drivers/*/*sedi*
-  labels:
-    - "platform: Intel ISH"
-
-Intel Platforms (Agilex):
-  status: maintained
-  maintainers:
-    - gdengi
-  collaborators:
-    - nbalabak
-    - teikheng
-  files:
-    - boards/intel/socfpga/
-    - soc/intel/intel_socfpga/
-    - dts/arm64/intel/
-    - dts/bindings/*/intel,agilex*
-    - dts/arm/intel_socfpga_std/
-  labels:
-    - "platform: Intel SoC FPGA Agilex"
-
-NXP Platform Drivers:
-  status: maintained
-  maintainers:
-    - dleach02
-    - mmahadevan108
-  collaborators:
-    - decsny
-    - manuargue
-    - dbaluta
-    - Raymond0225
-  files-regex:
-    - ^drivers/.*nxp.*
-    - ^drivers/.*mcux.*
-  files:
-    - drivers/*/*imx*
-    - drivers/*/*lpc*.c
-    - drivers/*/*mcux*.c
-    - drivers/*/*.mcux
-    - drivers/*/*.nxp
-    - drivers/*/*nxp*
-    - drivers/*/*/*kinetis*
-    - drivers/misc/*/nxp*
-    - include/zephyr/dt-bindings/*/*nxp*
-    - include/zephyr/dt-bindings/*/*mcux*
-    - include/zephyr/dt-bindings/inputmux/
-    - include/zephyr/dt-bindings/rdc/
-    - include/zephyr/drivers/*/*nxp*
-    - include/zephyr/drivers/*/*nxp*/
-    - include/zephyr/drivers/*/*mcux*
-    - arch/arm/core/mpu/nxp_mpu.c
-    - dts/bindings/*/nxp*
-  files-exclude:
-    - drivers/wifi/
-    - drivers/bluetooth/
-    - drivers/usb/
-  files-regex-exclude:
-    - .*s32.*
-  labels:
-    - "platform: NXP Drivers"
-  description: NXP Drivers
-
-NXP Platform Wireless:
-  status: maintained
-  maintainers:
-    - dleach02
-  collaborators:
-    - MaochenWang1
-    - axelnxp
-    - George-Stefan
-  files:
-    - boards/nxp/*mcxw*/
-    - boards/nxp/*rw*/
-    - drivers/*/*mcxw*.c
-    - drivers/bluetooth/hci/*nxp*
-    - drivers/hdlc_rcp_if/*nxp*
-    - drivers/ieee802154/ieee802154_kw41z.c
-    - drivers/wifi/nxp/
-    - samples/bluetooth/**/*rw*
-    - samples/net/**/*mcxw*
-    - samples/net/**/*nxp*
-    - samples/net/**/*rw*
-    - soc/nxp/mcx/mcxw/
-    - soc/nxp/rw/
-  labels:
-    - "platform: NXP Drivers"
-
-NXP Platform MCUX USB:
-  status: maintained
-  maintainers:
-    - mmahadevan108
-    - MarkWangChinese
-  files:
-    - drivers/usb/*/*mcux*
-    - boards/nxp/usb_kw24d512/
-  labels:
-    - "platform: NXP Drivers"
-  description: NXP MCUX USB shim drivers
-
-NXP Platforms (MCU):
-  status: maintained
-  maintainers:
-    - dleach02
-    - mmahadevan108
-  collaborators:
-    - DerekSnell
-    - EmilioCBen
-    - decsny
-    - butok
-  files:
-    - boards/nxp/mimxrt*/
-    - boards/nxp/frdm*/
-    - boards/nxp/lpcxpress*/
-    - boards/nxp/twr_*/
-    - boards/nxp/*rw*/
-    - boards/nxp/hexiwear/
-    - boards/nxp/common/
-    - boards/nxp/*
-    - soc/nxp/common/
-    - soc/nxp/imxrt/
-    - soc/nxp/kinetis/
-    - soc/nxp/lpc/
-    - soc/nxp/rw/
-    - soc/nxp/mcx/
-    - dts/arm/nxp/
-    - samples/boards/nxp*/
-  files-exclude:
-    - dts/arm/nxp/nxp_imx*
-  files-regex-exclude:
-    - .*s32.*
-  labels:
-    - "platform: NXP"
-  description: NXP MCU Platforms supported by MCUXpresso suite
-
-NXP Platforms (S32):
-  status: maintained
-  maintainers:
-    - manuargue
-  collaborators:
-    - Dat-NguyenDuy
-    - congnguyenhuu
-  files:
-    - boards/nxp/*s32*/
-    - boards/common/*nxp_s32*
-    - soc/nxp/s32/
-    - drivers/*/*nxp_s32*
-    - drivers/misc/*nxp_s32*/
-    - dts/bindings/*/nxp,s32*
-    - dts/arm/nxp/*s32*
-    - samples/boards/nxp/s32/
-    - include/zephyr/dt-bindings/*/nxp-s32*
-    - include/zephyr/dt-bindings/*/nxp_s32*
-    - include/zephyr/drivers/*/*nxp_s32*
-  files-exclude:
-    - boards/nxp/ucans32k1sic/
-  labels:
-    - "platform: NXP S32"
-  description: NXP S32 platforms and S32-specific drivers
-
-NXP Platforms (MPU):
-  status: maintained
-  maintainers:
-    - JiafeiPan
-  collaborators:
-    - dleach02
-    - dbaluta
-    - iuliana-prodan
-    - yangbolu1991
-    - Zhiqiang-Hou
-  files:
-    - dts/arm64/nxp/
-    - dts/arm/nxp/nxp_imx*
-    - soc/nxp/imx/
-    - soc/nxp/layerscape/
-    - boards/nxp/ls1046ardb/
-  files-regex:
-    - boards/nxp/m?imx[^(rt)].*/
-  labels:
-    - "platform: NXP MPU"
-  description: NXP MPU platforms
-
-NXP Platforms (Xtensa):
-  status: maintained
-  maintainers:
-    - dbaluta
-  collaborators:
-    - iuliana-prodan
-  files:
-    - soc/nxp/imx/*/adsp/
-    - soc/nxp/imxrt/imxrt5xx/f1/
-    - soc/nxp/imxrt/imxrt7xx/hifi1/
-    - soc/nxp/imxrt/*/hifi4/
-    - soc/nxp/imxrt/imxrt[567]xx/CMakeLists.txt
-    - soc/nxp/imxrt/imxrt[567]xx/Kconfig*
-  labels:
-    - "platform: NXP Xtensa"
-  description: NXP Xtensa platforms
-
-NXP Platforms (Robotics Products):
-  status: maintained
-  maintainers:
-    - bperseghetti
-    - PetervdPerk-NXP
-  collaborators:
-    - manuargue
-  files:
-    - boards/nxp/vmu*/
-    - boards/nxp/rddrone_fmuk66/
-    - boards/nxp/mr_canhubk3/
-    - boards/nxp/ucans32k1sic/
-  labels:
-    - "platform: NXP Robotics"
-  description: NXP Robotics Module Platform Products
-
-Microchip MEC Platforms:
-  status: maintained
-  maintainers:
-    - jvasanth1
-  collaborators:
-    - VenkatKotakonda
-    - albertofloyd
-  files:
-    - boards/microchip/mec*/
-    - dts/arm/microchip/
-    - soc/microchip/mec/
-    - drivers/*/*mchp*.c
-    - tests/boards/mec15xxevb_assy6853/
-    - tests/boards/mec172xevb_assy6906/
-    - dts/bindings/*/microchip,mec*
-    - dts/bindings/*/microchip,xec*
-    - samples/boards/microchip/
-  labels:
-    - "platform: Microchip MEC"
-
-Microchip RISC-V Platforms:
-  status: maintained
-  maintainers:
-    - fkokosinski
-    - kgugala
-    - tgorochowik
-  files:
-    - boards/microchip/m2gl025_miv/
-    - boards/microchip/mpfs_icicle/
-    - dts/riscv/microchip/
-    - soc/microchip/miv/
-  labels:
-    - "platform: Microchip RISC-V"
-
-Microchip SAM Platforms:
-  status: maintained
-  maintainers:
-    - nandojve
-  collaborators:
-    - pdgendt
-    - mnkp
-    - stephanosio
-  files:
-    - boards/atmel/
-    - dts/arm/atmel/
-    - soc/atmel/
-    - drivers/*/*sam*.c
-    - dts/bindings/*/atmel,*
-  labels:
-    - "platform: Microchip SAM"
-
-nRF Platforms:
-  status: maintained
-  maintainers:
-    - anangl
-    - masz-nordic
-  collaborators:
-    - jaz1-nordic
-    - kl-cruz
-    - magp-nordic
-    - nika-nordic
-  files:
-    - boards/nordic/
-    - drivers/*/*nrf*.c
-    - drivers/*/*nrf*/
-    - drivers/*/*nordic*/
-    - soc/nordic/
-    - samples/boards/nordic/
-    - dts/*/nordic/
-    - dts/bindings/*/nordic,*
-    - include/zephyr/drivers/*/*nrf*.h
-    - include/zephyr/drivers/*/*nrf*/
-    - include/zephyr/dt-bindings/*/nordic*.h
-    - include/zephyr/dt-bindings/*/nrf*.h
-    - tests/drivers/*/*nrf*/
-    - snippets/nordic*/
-    - tests/boards/nrf/
-  files-exclude:
-    - drivers/wifi/nrf_wifi/
-    - dts/bindings/wifi/
-  labels:
-    - "platform: nRF"
-
-Octavo Systems Platforms:
-  status: maintained
-  maintainers:
-    - fkokosinski
-    - tgorochowik
-  collaborators:
-    - kgugala
-  files:
-    - boards/oct/
-    - soc/oct/
-  labels:
-    - "platform: Octavo Systems"
-
-OpenTitan Platforms:
-  status: maintained
-  maintainers:
-    - snematbakhsh
-  files:
-    - boards/lowrisc/opentitan_earlgrey/
-    - drivers/*/*opentitan*
-    - dts/bindings/*/*opentitan*
-    - dts/riscv/lowrisc/*opentitan*
-    - soc/lowrisc/opentitan/
-  labels:
-    - "platform: OpenTitan"
-  description: >-
-    OpenTitan boards, SOCs, dts files and related drivers.
-
 Realtek EC Platforms:
   status: maintained
   maintainers:
@@ -4216,26 +4103,41 @@ Realtek EC Platforms:
   labels:
     - "platform: Realtek EC"
 
-Renesas SmartBond Platforms:
+Release Notes:
   status: maintained
   maintainers:
-    - ioannis-karachalios
-    - andrzej-kaczmarek
-    - blauret
+    - danieldegrasse
+    - dkalowsk
   collaborators:
-    - ydamigos
+    - kartben
   files:
-    - boards/renesas/da14*/
-    - drivers/*/*smartbond*
-    - drivers/pinctrl/renesas/smartbond/
-    - dts/arm/renesas/smartbond/
-    - dts/bindings/*/renesas,smartbond*
-    - soc/renesas/smartbond/
+    - doc/releases/migration-guide-*
+    - doc/releases/release-notes-*
   labels:
-    - "platform: Renesas SmartBond"
+    - "Release Notes"
+
+Renesas R-Car Platforms:
+  status: maintained
+  maintainers:
+    - aaillet
+    - lorc
+  collaborators:
+    - xakep-amatop
+  files:
+    - boards/renesas/rcar_*/
+    - drivers/*/*rcar*
+    - drivers/clock_control/*cpg_mssr*
+    - drivers/pinctrl/renesas/rcar/
+    - dts/arm/renesas/rcar/
+    - dts/arm64/renesas/
+    - dts/bindings/*/*rcar*
+    - soc/renesas/rcar/
+  labels:
+    - "platform: Renesas R-Car"
   description: >-
-    Renesas SmartBond SOCs, dts files, and related drivers. Renesas boards based
-    on SmartBond SoCs.
+    Renesas R-Car SOCs, dts files (Cortex-R and Cortex-A sides).
+    Renesas boards based on R-Car SOCs (Cortex-R and Cortex-A sides).
+    Renesas R-Car related drivers.
 
 Renesas RA Platforms:
   status: maintained
@@ -4285,28 +4187,64 @@ Renesas RZ Platforms:
     Renesas RZ SOCs, dts files, and related drivers. Renesas boards based
     on RZ SoCs.
 
-Renesas R-Car Platforms:
+Renesas SmartBond Platforms:
   status: maintained
   maintainers:
-    - aaillet
-    - lorc
+    - ioannis-karachalios
+    - andrzej-kaczmarek
+    - blauret
   collaborators:
-    - xakep-amatop
+    - ydamigos
   files:
-    - boards/renesas/rcar_*/
-    - drivers/*/*rcar*
-    - drivers/clock_control/*cpg_mssr*
-    - drivers/pinctrl/renesas/rcar/
-    - dts/arm/renesas/rcar/
-    - dts/arm64/renesas/
-    - dts/bindings/*/*rcar*
-    - soc/renesas/rcar/
+    - boards/renesas/da14*/
+    - drivers/*/*smartbond*
+    - drivers/pinctrl/renesas/smartbond/
+    - dts/arm/renesas/smartbond/
+    - dts/bindings/*/renesas,smartbond*
+    - soc/renesas/smartbond/
   labels:
-    - "platform: Renesas R-Car"
+    - "platform: Renesas SmartBond"
   description: >-
-    Renesas R-Car SOCs, dts files (Cortex-R and Cortex-A sides).
-    Renesas boards based on R-Car SOCs (Cortex-R and Cortex-A sides).
-    Renesas R-Car related drivers.
+    Renesas SmartBond SOCs, dts files, and related drivers. Renesas boards based
+    on SmartBond SoCs.
+
+Retention:
+  status: maintained
+  maintainers:
+    - nordicjm
+  files:
+    - dts/bindings/retention/
+    - include/zephyr/retention/
+    - subsys/retention/
+    - doc/services/retention/
+  labels:
+    - "area: Retention"
+
+SPARC arch:
+  status: odd fixes
+  collaborators:
+    - tbr-tt
+  files:
+    - arch/sparc/
+    - include/zephyr/arch/sparc/
+    - dts/sparc/
+    - boards/qemu/leon3/
+  labels:
+    - "area: SPARC"
+
+SPDX Tooling:
+  status: maintained
+  maintainers:
+    - kartben
+  collaborators:
+    - pdgendt
+    - swinslow
+  files:
+    - scripts/west_commands/spdx.py
+    - scripts/west_commands/zspdx/
+    - tests/application_development/software_bill_of_materials/
+  labels:
+    - "area: SPDX Tooling"
 
 STM32 Platforms:
   status: maintained
@@ -4362,216 +4300,17 @@ STM32 Wireless Platforms:
     STM32WB SOCs, dts files and related drivers. STM32WB development boards
     and ST bluetooth shields.
 
-Enclustra Platforms:
+Samples:
   status: maintained
   maintainers:
-    - fkokosinski
+    - kartben
   collaborators:
-    - tgorochowik
+    - nashif
   files:
-    - boards/enclustra/
+    - samples/sample_definition_and_criteria.rst
+    - samples/
   labels:
-    - "platform: Enclustra"
-
-Espressif Platforms:
-  status: maintained
-  maintainers:
-    - sylvioalves
-  collaborators:
-    - LucasTambor
-    - marekmatej
-    - uLipe
-    - raffarost
-    - wmrsouza
-  files:
-    - drivers/*/*esp32*.c
-    - boards/espressif/
-    - soc/espressif/
-    - dts/*/espressif/
-    - dts/bindings/*/*esp32*
-    - samples/boards/espressif/
-    - tests/boards/espressif/
-    - drivers/*/*esp32*/
-  labels:
-    - "platform: ESP32"
-
-ITE Platforms:
-  status: maintained
-  maintainers:
-    - Dino-Li
-    - GTLin08
-    - RuibinChang
-    - Chenhongren
-  collaborators:
-    - jackrosenthal
-    - keith-zephyr
-    - fabiobaltieri
-  files:
-    - boards/ite/
-    - drivers/sensor/ite/
-    - drivers/usb/udc/*it82xx2*.c
-    - drivers/usb/device/*it82xx2*.c
-    - drivers/*/*it51xxx*.c
-    - drivers/*/*it8xxx2*.c
-    - drivers/*/*_ite_*
-    - dts/bindings/*/ite*
-    - dts/riscv/ite/
-    - soc/ite/
-  labels:
-    - "platform: ITE"
-
-TI MSPM0 Platforms:
-  status: maintained
-  maintainers:
-    - ssekar15
-  files:
-    - soc/ti/mspm0/
-    - boards/ti/lp_mspm0g3507/
-    - dts/arm/ti/mspm0/
-    - dts/bindings/*/*mspm0*
-    - drivers/*/*_mspm0*
-    - modules/Kconfig.mspm0
-  labels:
-    - "platform: Texas Instruments MSPM0"
-
-TI SimpleLink Platforms:
-  status: maintained
-  maintainers:
-    - vaishnavachath
-  collaborators:
-    - vanti
-  files:
-    - boards/ti/cc*/
-    - boards/ti/msp*/
-    - drivers/*/*cc13*
-    - drivers/*/*cc25*
-    - drivers/*/*cc26*
-    - drivers/*/*cc32*
-    - dts/arm/ti/cc*
-    - dts/bindings/*/ti,*
-    - soc/ti/simplelink/
-    - dts/bindings/*/ti,*
-    - modules/Kconfig.simplelink
-  labels:
-    - "platform: TI SimpleLink"
-
-TI K3 Platforms:
-  status: maintained
-  maintainers:
-    - vaishnavachath
-  collaborators:
-    - gramsay0
-    - dnltz
-    - glneo
-  files:
-    - boards/ti/*am62*/
-    - drivers/*/*davinci*
-    - drivers/*/*omap*
-    - drivers/*/*ti_k3*
-    - dts/arm/ti/am6*
-    - dts/arm/ti/j7*
-    - dts/bindings/*/ti,k3*
-    - soc/ti/k3/
-  labels:
-    - "platform: TI K3"
-
-TI Platforms:
-  status: odd fixes
-  files:
-    - soc/ti/lm3s6965/
-    - dts/arm/ti/lm3s6965.dtsi
-  labels:
-    - "platform: TI"
-
-Xilinx Platforms:
-  status: odd fixes
-  collaborators:
-    - henrikbrixandersen
-    - ibirnbaum
-    - michalsimek
-  files:
-    - boards/amd/
-    - drivers/*/*xilinx*
-    - drivers/*/*xlnx*
-    - drivers/*/*zynq*
-    - dts/*/xilinx/
-    - dts/bindings/*/*xlnx*
-    - include/zephyr/*/*/*xlnx*
-    - soc/xlnx/
-  labels:
-    - "platform: Xilinx"
-
-Infineon Platforms:
-  status: maintained
-  maintainers:
-    - ifyall
-  collaborators:
-    - sreeramIfx
-    - mcatee-infineon
-    - talih0
-  files:
-    - boards/cypress/
-    - boards/infineon/
-    - drivers/*/*ifx_cat1*
-    - drivers/*/*xmc*
-    - drivers/sensor/infineon/
-    - dts/arm/infineon/
-    - dts/bindings/*/*infineon*
-    - soc/infineon/
-  labels:
-    - "platform: Infineon"
-  description: >-
-    Infineon SOCs, dts files and related drivers. Infineon Proto, Pioneer, Eval and Relax
-    boards.
-
-LiteX Platforms:
-  status: maintained
-  maintainers:
-    - tgorochowik
-    - kgugala
-    - fkokosinski
-  collaborators:
-    - mateusz-holenko
-    - maass-hamburg
-  files:
-    - boards/enjoydigital/litex_vexriscv/
-    - drivers/*/*litex*
-    - drivers/*/Kconfig.litex
-    - dts/bindings/*/litex*
-    - dts/riscv/riscv32-litex-vexriscv.dtsi
-    - include/zephyr/drivers/*/*litex*
-    - samples/boards/enjoydigital/litex/
-    - samples/drivers/*litex/
-    - soc/litex/
-  labels:
-    - "platform: LiteX"
-
-Panasonic Platforms:
-  status: maintained
-  maintainers:
-    - pideu-sj
-  files:
-    - boards/panasonic/
-  labels:
-    - "platform: Panasonic"
-
-RTIO:
-  status: maintained
-  maintainers:
-    - teburd
-  collaborators:
-    - yperess
-    - ubieda
-  files:
-    - samples/subsys/rtio/
-    - include/zephyr/rtio/
-    - tests/subsys/rtio/
-    - subsys/rtio/
-    - doc/services/rtio/
-  labels:
-    - "area: RTIO"
-  tests:
-    - rtio
+    - "area: Samples"
 
 Secure storage:
   status: maintained
@@ -4588,6 +4327,28 @@ Secure storage:
   tests:
     - psa.secure_storage
 
+Sensor Subsystem:
+  status: maintained
+  maintainers:
+    - lixuzha
+    - ghu0510
+    - yperess
+  collaborators:
+    - qianruh
+  files:
+    - dts/bindings/sensor/zephyr,sensing.yaml
+    - dts/bindings/sensor/zephyr,sensing*.yaml
+    - include/zephyr/sensing/
+    - doc/services/sensing/
+    - subsys/sensing/
+    - samples/subsys/sensing/
+    - tests/subsys/sensing/
+  labels:
+    - "area: Sensor Subsystem"
+  tests:
+    - sample.sensing
+    - sensing.api
+
 Sensry Platforms:
   status: maintained
   maintainers:
@@ -4599,19 +4360,124 @@ Sensry Platforms:
   labels:
     - "platform: sensry"
 
-SPDX Tooling:
+Settings:
+  status: odd fixes
+  files:
+    - include/zephyr/settings/
+    - subsys/settings/
+    - tests/subsys/settings/
+    - samples/subsys/settings/
+    - doc/services/storage/settings/
+    - tests/subsys/settings_commit_prio/
+  labels:
+    - "area: Settings"
+  tests:
+    - settings
+
+Shell:
+  status: maintained
+  maintainers:
+    - jakub-uC
+  collaborators:
+    - carlescufi
+  files:
+    - include/zephyr/shell/
+    - samples/subsys/shell/
+    - subsys/shell/
+    - tests/subsys/shell/
+    - doc/services/shell/
+  labels:
+    - "area: Shell"
+  tests:
+    - shell
+
+Shields:
   status: maintained
   maintainers:
     - kartben
   collaborators:
-    - pdgendt
-    - swinslow
+    - avisconti
+    - jfischer-no
+    - erwango
   files:
-    - scripts/west_commands/spdx.py
-    - scripts/west_commands/zspdx/
-    - tests/application_development/software_bill_of_materials/
+    - boards/shields/
+    - doc/hardware/porting/shields.rst
+    - samples/shields/
   labels:
-    - "area: SPDX Tooling"
+    - "area: Shields"
+  tests:
+    - sample.shields
+
+Silabs Platforms:
+  status: maintained
+  maintainers:
+    - jhedberg
+    - asmellby
+  collaborators:
+    - jerome-pouiller
+    - Martinhoff-maker
+  files:
+    - soc/silabs/
+    - boards/silabs/
+    - dts/arm/silabs/
+    - dts/bindings/*/silabs*
+    - drivers/*/*gecko*
+    - drivers/*/*silabs*
+    - drivers/*/*siwx91x*
+    - drivers/*/*/*silabs*
+    - drivers/*/*/*siwx91x*
+    - tests/boards/silabs/
+    - snippets/*silabs*/
+  labels:
+    - "platform: Silabs"
+
+Silabs SiM3U Platforms:
+  status: maintained
+  maintainers:
+    - rettichschnidi
+  collaborators:
+    - M1cha
+    - asmellby
+    - jerome-pouiller
+    - jhedberg
+  files:
+    - boards/silabs/dev_kits/sim3u1xx_dk/
+    - drivers/*/*_si32*
+    - drivers/*/Kconfig.si32
+    - dts/arm/silabs/sim3u*
+    - dts/bindings/*/*silabs,si32*
+    - include/zephyr/dt-bindings/pinctrl/*si32*
+    - soc/silabs/silabs_sim3/
+  labels:
+    - "platform: Silabs SiM3U"
+  description: >-
+    SiM3U SoCs, dts files, and related drivers. Boards based on SiM3U SoCs.
+
+State machine framework:
+  status: maintained
+  maintainers:
+    - sambhurst
+  collaborators:
+    - keith-zephyr
+    - glenn-andrews
+  files:
+    - doc/services/smf/
+    - include/zephyr/smf.h
+    - lib/smf/
+    - tests/lib/smf/
+    - samples/subsys/smf/
+  labels:
+    - "area: State Machine Framework"
+  tests:
+    - libraries.smf
+
+Stats:
+  status: odd fixes
+  files:
+    - subsys/stats/
+    - include/zephyr/stats/stats.h
+  labels:
+    - "area: Stats"
 
 Storage:
   status: odd fixes
@@ -4636,6 +4502,27 @@ Storage ZMS:
     - tests/subsys/fs/zms/
     - doc/services/storage/zms/zms.rst
 
+Synopsys Platforms:
+  status: maintained
+  maintainers:
+    - ruuddw
+    - evgeniy-paltsev
+  collaborators:
+    - abrodkin
+  files:
+    - soc/snps/
+    - boards/snps/
+    - boards/qemu/arc/
+    - samples/boards/arc_secure_services/
+    - scripts/west_commands/runners/mdb.py
+    - scripts/west_commands/tests/test_mdb.py
+    - scripts/west_commands/runners/nsim.py
+    - cmake/emu/nsim.cmake
+    - drivers/serial/uart_hostlink.c
+    - drivers/serial/Kconfig.hostlink
+  labels:
+    - "platform: Synopsys"
+
 Sysbuild:
   status: maintained
   maintainers:
@@ -4651,31 +4538,6 @@ Sysbuild:
     - "area: Sysbuild"
   tests:
     - sample.sysbuild
-
-Task Watchdog:
-  status: maintained
-  maintainers:
-    - martinjaeger
-  files:
-    - include/zephyr/task_wdt/
-    - samples/subsys/task_wdt/
-    - subsys/task_wdt/
-    - doc/services/task_wdt/index.rst
-  labels:
-    - "area: Task Watchdog"
-  tests:
-    - sample.task_wdt
-
-"Drivers: Syscon":
-  status: maintained
-  maintainers:
-    - carlocaione
-  files:
-    - include/zephyr/drivers/syscon.h
-    - drivers/syscon/
-    - tests/drivers/syscon/
-  tests:
-    - drivers.syscon
 
 TDK Sensors:
   status: maintained
@@ -4694,19 +4556,146 @@ TDK Sensors:
   tests:
     - drivers.sensors
 
-"Drivers: Time Aware GPIO":
+TI K3 Platforms:
   status: maintained
   maintainers:
-    - akanisetti
+    - vaishnavachath
+  collaborators:
+    - gramsay0
+    - dnltz
+    - glneo
   files:
-    - doc/hardware/peripherals/tgpio.rst
-    - drivers/misc/timeaware_gpio/
-    - include/zephyr/drivers/misc/timeaware_gpio/
-    - samples/drivers/misc/timeaware_gpio/
+    - boards/ti/*am62*/
+    - drivers/*/*davinci*
+    - drivers/*/*omap*
+    - drivers/*/*ti_k3*
+    - dts/arm/ti/am6*
+    - dts/arm/ti/j7*
+    - dts/bindings/*/ti,k3*
+    - soc/ti/k3/
   labels:
-    - "area: Time Aware GPIO"
+    - "platform: TI K3"
+
+TI MSPM0 Platforms:
+  status: maintained
+  maintainers:
+    - ssekar15
+  files:
+    - soc/ti/mspm0/
+    - boards/ti/lp_mspm0g3507/
+    - dts/arm/ti/mspm0/
+    - dts/bindings/*/*mspm0*
+    - drivers/*/*_mspm0*
+    - modules/Kconfig.mspm0
+  labels:
+    - "platform: Texas Instruments MSPM0"
+
+TI Platforms:
+  status: odd fixes
+  files:
+    - soc/ti/lm3s6965/
+    - dts/arm/ti/lm3s6965.dtsi
+  labels:
+    - "platform: TI"
+
+TI SimpleLink Platforms:
+  status: maintained
+  maintainers:
+    - vaishnavachath
+  collaborators:
+    - vanti
+  files:
+    - boards/ti/cc*/
+    - boards/ti/msp*/
+    - drivers/*/*cc13*
+    - drivers/*/*cc25*
+    - drivers/*/*cc26*
+    - drivers/*/*cc32*
+    - dts/arm/ti/cc*
+    - dts/bindings/*/ti,*
+    - soc/ti/simplelink/
+    - dts/bindings/*/ti,*
+    - modules/Kconfig.simplelink
+  labels:
+    - "platform: TI SimpleLink"
+
+Task Watchdog:
+  status: maintained
+  maintainers:
+    - martinjaeger
+  files:
+    - include/zephyr/task_wdt/
+    - samples/subsys/task_wdt/
+    - subsys/task_wdt/
+    - doc/services/task_wdt/index.rst
+  labels:
+    - "area: Task Watchdog"
   tests:
-    - sample.drivers.misc.timeaware_gpio
+    - sample.task_wdt
+
+Test Framework (Ztest):
+  status: maintained
+  maintainers:
+    - nashif
+  collaborators:
+    - aaronemassey
+    - jeremybettis
+    - yperess
+    - asemjonovs
+  files:
+    - subsys/testsuite/
+    - tests/ztest/
+    - tests/unit/util/
+    - tests/subsys/testsuite/
+    - samples/subsys/testsuite/
+    - doc/develop/test/
+  labels:
+    - "area: Testsuite"
+  tests:
+    - testing
+
+Testing with Renode:
+  # This area is to be converted to a subarea
+  status: odd fixes
+  collaborators:
+    - mateusz-holenko
+    - fkokosinski
+  files:
+    - cmake/emu/renode.cmake
+    - soc/renode/
+    - boards/renode/
+    - boards/*/*/support/*.repl
+    - boards/*/*/support/*.resc
+  labels:
+    - "area: Renode"
+
+"Toolchain ARC MWDT":
+  status: maintained
+  maintainers:
+    - evgeniy-paltsev
+    - abrodkin
+  files:
+    - cmake/*/arcmwdt/
+    - include/zephyr/toolchain/mwdt.h
+    - include/zephyr/linker/linker-tool-mwdt.h
+    - lib/libc/arcmwdt/*
+  labels:
+    - "area: Toolchains"
+
+"Toolchain IAR":
+  status: maintained
+  maintainers:
+    - RobinKastberg
+  collaborators:
+    - bjorniuppsala
+    - LoveKarlsson
+  files:
+    - cmake/*/iar/
+    - include/zephyr/toolchain/iar.h
+    - include/zephyr/toolchain/iar/*
+    - lib/libc/iar/*
+  labels:
+    - "area: Toolchains"
 
 "Toolchain Integration":
   status: maintained
@@ -4724,19 +4713,6 @@ TDK Sensors:
   labels:
     - "area: Toolchains"
 
-"Toolchain ARC MWDT":
-  status: maintained
-  maintainers:
-    - evgeniy-paltsev
-    - abrodkin
-  files:
-    - cmake/*/arcmwdt/
-    - include/zephyr/toolchain/mwdt.h
-    - include/zephyr/linker/linker-tool-mwdt.h
-    - lib/libc/arcmwdt/*
-  labels:
-    - "area: Toolchains"
-
 "Toolchain arm compiler 6":
   status: maintained
   maintainers:
@@ -4746,21 +4722,6 @@ TDK Sensors:
     - cmake/linker/armlink/
     - include/zephyr/toolchain/armclang.h
     - lib/libc/armstdc/*
-  labels:
-    - "area: Toolchains"
-
-"Toolchain IAR":
-  status: maintained
-  maintainers:
-    - RobinKastberg
-  collaborators:
-    - bjorniuppsala
-    - LoveKarlsson
-  files:
-    - cmake/*/iar/
-    - include/zephyr/toolchain/iar.h
-    - include/zephyr/toolchain/iar/*
-    - lib/libc/iar/*
   labels:
     - "area: Toolchains"
 
@@ -4793,14 +4754,32 @@ Tracing:
   tests:
     - tracing
 
-u-blox Platforms:
+Twister:
   status: maintained
   maintainers:
-    - 3rang
+    - nashif
+  collaborators:
+    - PerMac
+    - hakehuang
+    - golowanow
+    - gchwier
+    - LukaszMrugala
+    - KamilxPaszkiet
   files:
-    - boards/u-blox/
+    - scripts/twister
+    - scripts/schemas/twister/
+    - scripts/pylib/twister/
+    - scripts/tests/twister/
+    - scripts/tests/twister_blackbox/
+    - doc/develop/test/twister.rst
+    - scripts/pylib/pytest-twister-harness/
+    - doc/develop/test/pytest.rst
+    - tests/test_config.yaml
+    - scripts/utils/twister_to_list.py
+    - tests/robot/common.robot
+    - scripts/pylib/*-twister-harness/
   labels:
-    - "platform: u-blox"
+    - "area: Twister"
 
 USB:
   status: maintained
@@ -4879,6 +4858,40 @@ Userspace:
   tests:
     - kernel.memory_protection
 
+Utilities:
+  status: maintained
+  maintainers:
+    - andyross
+    - nashif
+  collaborators:
+    - dcpleung
+    - peter-mitsis
+  files:
+    - lib/crc/
+    - lib/utils/
+    - tests/unit/timeutil/
+    - tests/unit/time_units/
+    - tests/unit/rbtree/
+    - tests/unit/math_extras/
+    - tests/unit/crc/
+    - tests/unit/base64/
+    - tests/unit/math_extras/
+    - tests/unit/list/
+    - tests/unit/intmath/
+    - tests/unit/pot/
+    - tests/lib/onoff/
+    - tests/lib/sys_util/
+    - tests/lib/sprintf/
+    - tests/lib/ringbuffer/
+    - tests/lib/notify/
+    - tests/lib/linear_range/
+  labels:
+    - "area: Utilities"
+  tests:
+    - utilities
+    - libraries.ring_buffer
+    - libraries.linear_range
+
 VFS:
   status: maintained
   maintainers:
@@ -4888,11 +4901,26 @@ VFS:
     - tests/subsys/fs/fat_fs_api/
   description: >-
     VFS implementation
-
   labels:
     - "area: File System"
   tests:
     - filesystem
+
+WCH Platforms:
+  status: maintained
+  maintainers:
+    - nzmichaelh
+    - kholia
+  collaborators:
+    - VynDragon
+  files:
+    - boards/wch/
+    - dts/riscv/wch/
+    - soc/wch/
+    - drivers/*/*wch*
+    - dts/bindings/*/wch,*
+  labels:
+    - "platform: WinChipHead"
 
 West:
   status: maintained
@@ -4919,31 +4947,7 @@ West:
   labels:
     - "area: ACPI"
 
-"West project: bsim":
-  status: maintained
-  maintainers:
-    - aescolar
-  files: []
-  labels:
-    - "platform: nRF BSIM"
-
 "West project: babblesim_base":
-  status: maintained
-  maintainers:
-    - aescolar
-  files: []
-  labels:
-    - "platform: nRF BSIM"
-
-"West project: babblesim_ext_2G4_libPhyComv1":
-  status: maintained
-  maintainers:
-    - aescolar
-  files: []
-  labels:
-    - "platform: nRF BSIM"
-
-"West project: babblesim_ext_2G4_phy_v1":
   status: maintained
   maintainers:
     - aescolar
@@ -4967,15 +4971,7 @@ West:
   labels:
     - "platform: nRF BSIM"
 
-"West project: babblesim_ext_2G4_modem_magic":
-  status: maintained
-  maintainers:
-    - aescolar
-  files: []
-  labels:
-    - "platform: nRF BSIM"
-
-"West project: babblesim_ext_2G4_modem_BLE_simple":
+"West project: babblesim_ext_2G4_device_WLAN_actmod":
   status: maintained
   maintainers:
     - aescolar
@@ -4991,14 +4987,6 @@ West:
   labels:
     - "platform: nRF BSIM"
 
-"West project: babblesim_ext_2G4_device_WLAN_actmod":
-  status: maintained
-  maintainers:
-    - aescolar
-  files: []
-  labels:
-    - "platform: nRF BSIM"
-
 "West project: babblesim_ext_2G4_device_playback":
   status: maintained
   maintainers:
@@ -5007,7 +4995,47 @@ West:
   labels:
     - "platform: nRF BSIM"
 
+"West project: babblesim_ext_2G4_libPhyComv1":
+  status: maintained
+  maintainers:
+    - aescolar
+  files: []
+  labels:
+    - "platform: nRF BSIM"
+
+"West project: babblesim_ext_2G4_modem_BLE_simple":
+  status: maintained
+  maintainers:
+    - aescolar
+  files: []
+  labels:
+    - "platform: nRF BSIM"
+
+"West project: babblesim_ext_2G4_modem_magic":
+  status: maintained
+  maintainers:
+    - aescolar
+  files: []
+  labels:
+    - "platform: nRF BSIM"
+
+"West project: babblesim_ext_2G4_phy_v1":
+  status: maintained
+  maintainers:
+    - aescolar
+  files: []
+  labels:
+    - "platform: nRF BSIM"
+
 "West project: babblesim_ext_libCryptov1":
+  status: maintained
+  maintainers:
+    - aescolar
+  files: []
+  labels:
+    - "platform: nRF BSIM"
+
+"West project: bsim":
   status: maintained
   maintainers:
     - aescolar
@@ -5219,6 +5247,18 @@ West:
   labels:
     - "platform: Infineon"
 
+"West project: hal_intel":
+  status: maintained
+  maintainers:
+    - kwd-doodling
+  collaborators:
+    - teburd
+    - likongintel
+  files:
+    - modules/Kconfig.intel
+  labels:
+    - "platform: Intel ISH"
+
 "West project: hal_microchip":
   status: maintained
   maintainers:
@@ -5413,25 +5453,32 @@ West:
   labels:
     - "area: Xtensa"
 
-"West project: hal_intel":
+"West project: hostap":
   status: maintained
   maintainers:
-    - kwd-doodling
+    - krish2718
+    - jukkar
   collaborators:
-    - teburd
-    - likongintel
+    - MaochenWang1
   files:
-    - modules/Kconfig.intel
+    - modules/hostap/
   labels:
-    - "platform: Intel ISH"
+    - "area: Wi-Fi"
+  tests:
+    - net.wifi
 
-"West project: zephyr-lang-rust":
+"West project: liblc3":
   status: maintained
   maintainers:
-    - d3zd3z
-  files: []
+    - Casper-Bonde-Bose
+    - MariuszSkamra
+  collaborators:
+    - thalley
+    - asbjornsabo
+  files:
+    - modules/liblc3/
   labels:
-    - "area: Rust"
+    - "area: Audio"
 
 "West project: libmctp":
   status: maintained
@@ -5453,19 +5500,6 @@ West:
     - modules/Kconfig.libmetal
   labels:
     - "area: AMP"
-
-"West project: liblc3":
-  status: maintained
-  maintainers:
-    - Casper-Bonde-Bose
-    - MariuszSkamra
-  collaborators:
-    - thalley
-    - asbjornsabo
-  files:
-    - modules/liblc3/
-  labels:
-    - "area: Audio"
 
 "West project: littlefs":
   status: odd fixes
@@ -5646,6 +5680,18 @@ West:
     - "area: C Library"
     - "area: picolibc"
 
+"West project: psa-arch-tests":
+  status: maintained
+  maintainers:
+    - d3zd3z
+  collaborators:
+    - Vge0rge
+    - wearyzen
+    - ithinuel
+  files: []
+  labels:
+    - "area: TF-M"
+
 "West project: segger":
   status: odd fixes
   collaborators:
@@ -5668,6 +5714,18 @@ West:
     - modules/Kconfig.sof
   labels:
     - "area: Audio"
+
+"West project: tf-m-tests":
+  status: maintained
+  maintainers:
+    - d3zd3z
+  collaborators:
+    - Vge0rge
+    - wearyzen
+    - ithinuel
+  files: []
+  labels:
+    - "area: TF-M"
 
 "West project: tflite-micro":
   status: maintained
@@ -5702,6 +5760,20 @@ West:
   labels:
     - "area: Crypto / RNG"
 
+"West project: trusted-firmware-a":
+  status: maintained
+  maintainers:
+    - povergoing
+    - sgrrzhf
+  collaborators:
+    - carlocaione
+    - wearyzen
+    - ithinuel
+  files:
+    - modules/trusted-firmware-a/
+  labels:
+    - "area: TF-A"
+
 "West project: trusted-firmware-m":
   status: maintained
   maintainers:
@@ -5721,44 +5793,6 @@ West:
   tests:
     - trusted-firmware-m
     - psa.secure_storage
-
-"West project: tf-m-tests":
-  status: maintained
-  maintainers:
-    - d3zd3z
-  collaborators:
-    - Vge0rge
-    - wearyzen
-    - ithinuel
-  files: []
-  labels:
-    - "area: TF-M"
-
-"West project: trusted-firmware-a":
-  status: maintained
-  maintainers:
-    - povergoing
-    - sgrrzhf
-  collaborators:
-    - carlocaione
-    - wearyzen
-    - ithinuel
-  files:
-    - modules/trusted-firmware-a/
-  labels:
-    - "area: TF-A"
-
-"West project: psa-arch-tests":
-  status: maintained
-  maintainers:
-    - d3zd3z
-  collaborators:
-    - Vge0rge
-    - wearyzen
-    - ithinuel
-  files: []
-  labels:
-    - "area: TF-M"
 
 "West project: uoscore-uedhoc":
   status: maintained
@@ -5781,25 +5815,54 @@ West:
   labels:
     - "area: CBOR"
 
+"West project: zephyr-lang-rust":
+  status: maintained
+  maintainers:
+    - d3zd3z
+  files: []
+  labels:
+    - "area: Rust"
+
 "West project: zscilib":
   status: maintained
   maintainers:
     - microbuilder
   files: []
 
-"West project: hostap":
+Xen Platform:
   status: maintained
   maintainers:
-    - krish2718
-    - jukkar
+    - firscity
   collaborators:
-    - MaochenWang1
+    - lorc
+    - luca-fancellu
   files:
-    - modules/hostap/
+    - include/zephyr/xen/
+    - drivers/xen/
+    - arch/arm64/core/xen/
+    - soc/xen/
+    - boards/xen/
+    - dts/bindings/xen/
   labels:
-    - "area: Wi-Fi"
-  tests:
-    - net.wifi
+    - "area: Xen Platform"
+
+Xilinx Platforms:
+  status: odd fixes
+  collaborators:
+    - henrikbrixandersen
+    - ibirnbaum
+    - michalsimek
+  files:
+    - boards/amd/
+    - drivers/*/*xilinx*
+    - drivers/*/*xlnx*
+    - drivers/*/*zynq*
+    - dts/*/xilinx/
+    - dts/bindings/*/*xlnx*
+    - include/zephyr/*/*/*xlnx*
+    - soc/xlnx/
+  labels:
+    - "platform: Xilinx"
 
 Xtensa arch:
   status: maintained
@@ -5821,6 +5884,94 @@ Xtensa arch:
     - doc/hardware/arch/xtensa.rst
   labels:
     - "area: Xtensa"
+
+hawkBit:
+  status: maintained
+  maintainers:
+    - maass-hamburg
+  files:
+    - subsys/mgmt/hawkbit/
+    - include/zephyr/mgmt/hawkbit/
+    - include/zephyr/mgmt/hawkbit.h
+    - samples/subsys/mgmt/hawkbit/
+  labels:
+    - "area: hawkBit"
+  tests:
+    - sample.net.hawkbit
+
+"mgmt: updatehub":
+  status: maintained
+  maintainers:
+    - nandojve
+  files:
+    - subsys/mgmt/updatehub/
+    - include/zephyr/mgmt/updatehub.h
+    - samples/subsys/mgmt/updatehub/
+  labels:
+    - "area: updatehub"
+  description: >-
+    UpdateHub embedded Firmware Over-The-Air (FOTA) upgrade agent
+  tests:
+    - sample.net.updatehub
+
+nRF BSIM:
+  status: maintained
+  maintainers:
+    - aescolar
+  files:
+    - boards/native/nrf_bsim/
+    - tests/boards/nrf52_bsim/
+    - tests/bsim/
+    - doc/develop/test/bsim.rst
+    - .github/workflows/bsim-tests*
+  files-regex-exclude:
+    - tests\/bsim\/.*\/.*\.([ch]|conf)
+    - tests\/bsim\/.*\/(CMakeLists|Kconfig).*
+  labels:
+    - "platform: nRF BSIM"
+  tests:
+    - boards.nrf52_bsim
+
+nRF Platforms:
+  status: maintained
+  maintainers:
+    - anangl
+    - masz-nordic
+  collaborators:
+    - jaz1-nordic
+    - kl-cruz
+    - magp-nordic
+    - nika-nordic
+  files:
+    - boards/nordic/
+    - drivers/*/*nrf*.c
+    - drivers/*/*nrf*/
+    - drivers/*/*nordic*/
+    - soc/nordic/
+    - samples/boards/nordic/
+    - dts/*/nordic/
+    - dts/bindings/*/nordic,*
+    - include/zephyr/drivers/*/*nrf*.h
+    - include/zephyr/drivers/*/*nrf*/
+    - include/zephyr/dt-bindings/*/nordic*.h
+    - include/zephyr/dt-bindings/*/nrf*.h
+    - tests/drivers/*/*nrf*/
+    - snippets/nordic*/
+    - tests/boards/nrf/
+  files-exclude:
+    - drivers/wifi/nrf_wifi/
+    - dts/bindings/wifi/
+  labels:
+    - "platform: nRF"
+
+u-blox Platforms:
+  status: maintained
+  maintainers:
+    - 3rang
+  files:
+    - boards/u-blox/
+  labels:
+    - "platform: u-blox"
 
 x86 arch:
   status: maintained
@@ -5844,123 +5995,6 @@ x86 arch:
   labels:
     - "area: X86"
 
-Continuous Integration:
-  status: maintained
-  maintainers:
-    - stephanosio
-    - nashif
-  collaborators:
-    - fabiobaltieri
-    - kartben
-  files:
-    - .github/
-    - scripts/requirements-actions.*
-    - scripts/ci/
-    - scripts/make_bugs_pickle.py
-    - .checkpatch.conf
-    - scripts/gitlint/
-    - scripts/set_assignees.py
-  labels:
-    - "area: Continuous Integration"
-
-Test Framework (Ztest):
-  status: maintained
-  maintainers:
-    - nashif
-  collaborators:
-    - aaronemassey
-    - jeremybettis
-    - yperess
-    - asemjonovs
-  files:
-    - subsys/testsuite/
-    - tests/ztest/
-    - tests/unit/util/
-    - tests/subsys/testsuite/
-    - samples/subsys/testsuite/
-    - doc/develop/test/
-  labels:
-    - "area: Testsuite"
-  tests:
-    - testing
-
-Emulation:
-  status: maintained
-  maintainers:
-    - yperess
-  collaborators:
-    - aaronemassey
-    - jeremybettis
-    - alevkoy
-    - asemjonovs
-    - tristan-google
-  files:
-    - subsys/emul/
-    - include/zephyr/drivers/emul_*
-    - include/zephyr/drivers/emul.h
-    - include/zephyr/drivers/espi_emul.h
-    - include/zephyr/drivers/i2c_emul.h
-    - include/zephyr/drivers/spi_emul.h
-    - tests/subsys/emul/
-    - doc/hardware/emulator/
-  labels:
-    - "area: HW Emulation"
-  tests:
-    - emul
-
-Random:
-  status: maintained
-  maintainers:
-    - ceolin
-  collaborators:
-    - tomi-font
-  files:
-    - subsys/random/
-    - include/zephyr/random/
-    - tests/subsys/random/
-  labels:
-    - "area: Random"
-
-Peregrine Platforms:
-  status: maintained
-  maintainers:
-    - nandojve
-  files:
-    - boards/peregrine/
-  labels:
-    - "platform: Peregrine"
-
-WCH Platforms:
-  status: maintained
-  maintainers:
-    - nzmichaelh
-    - kholia
-  collaborators:
-    - VynDragon
-  files:
-    - boards/wch/
-    - dts/riscv/wch/
-    - soc/wch/
-    - drivers/*/*wch*
-    - dts/bindings/*/wch,*
-  labels:
-    - "platform: WinChipHead"
-
-# This area is to be converted to a subarea
-Testing with Renode:
-  status: odd fixes
-  collaborators:
-    - mateusz-holenko
-    - fkokosinski
-  files:
-    - cmake/emu/renode.cmake
-    - soc/renode/
-    - boards/renode/
-    - boards/*/*/support/*.repl
-    - boards/*/*/support/*.resc
-  labels:
-    - "area: Renode"
-
 zbus:
   status: maintained
   maintainers:
@@ -5975,40 +6009,4 @@ zbus:
     - "area: zbus"
   tests:
     - message_bus.zbus
-
-"Linkable Loadable Extensions":
-  status: maintained
-  maintainers:
-    - teburd
-  collaborators:
-    - lyakh
-    - pillo79
-  files:
-    - cmake/llext-edk.cmake
-    - samples/subsys/llext/
-    - include/zephyr/llext/
-    - tests/misc/llext-edk/
-    - tests/subsys/llext/
-    - subsys/llext/
-    - doc/services/llext/
-  labels:
-    - "area: llext"
-  tests:
-    - llext
-
-RX arch:
-  status: maintained
-  maintainers:
-    - duynguyenxa
-  files:
-    - arch/rx/
-    - include/zephyr/arch/rx/
-    - dts/rx/
-    - boards/qemu/rx/
-    - soc/renesas/rx/
-    - tests/arch/rx/
-    - include/zephyr/drivers/misc/renesas_rx_external_interrupt/
-  labels:
-    - "area: RX"
-  tests:
-    - arch.rx
+# zephyr-keep-sorted-stop


### PR DESCRIPTION
The area entries in the maintainers file should be sorted by name, enforce with `zephyr-keep-sorted` comment annotations.

Required `KeepSorted` compliance check updates:
- `nofold` to ignore continued indented lines
- `strip(...)` to ignore leading/trailing characters in the line (for yaml map entries to ignore `"` and `:` characters)

Testing that the areas are still the same (checkout the sorting commit as HEAD):

```shell
$ diff <(git show HEAD^:MAINTAINERS.yml | yq -P 'sort_keys(.)' -) <(yq -P MAINTAINERS.yml)
113a114
> # zephyr-keep-sorted-start strip(":) nofold
2784c2785
<   description: See https://docs.zephyrproject.org/latest/build/kconfig/index.html and https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html#default-board-configuration
---
>   description: See https://docs.zephyrproject.org/latest/build/kconfig/index.html
4382d4382
< # This area is to be converted to a subarea
4383a4384
>   # This area is to be converted to a subarea
5629a5631
> # zephyr-keep-sorted-stop
```