### PR TITLE
dts: nordic: nrf54h20: add missing ranges to global_peripherals

### DIFF
--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -151,6 +151,7 @@
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;
+		ranges = <>;
 	};
 
 	clocks {

--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -494,7 +494,8 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			reg = <0x5f000000 0x1000000>;
-			ranges = <0x0 0x5f000000 0x1000000>;
+			ranges = <0x0 0x5f000000 0x1000000          /* registers */
+				  0x2f000000 0x2f000000 0x1000000>; /* ram */
 
 			usbhs: usbhs@86000 {
 				compatible = "nordic,nrf-usbhs", "snps,dwc2";


### PR DESCRIPTION
Add missing ranges to global_peripherals to explicitly translate child addresses of global_peripherals in ram (0x2f000000).