### PR TITLE
drivers: ieee802154: nrf5: drop packets that are too long

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -179,7 +179,12 @@ static void nrf5_rx_thread(void *arg1, void *arg2, void *arg3)
 		}
 
 #if defined(CONFIG_NET_BUF_DATA_SIZE)
-		__ASSERT_NO_MSG(pkt_len <= CONFIG_NET_BUF_DATA_SIZE);
+		if (pkt_len > CONFIG_NET_BUF_DATA_SIZE) {
+			LOG_ERR("Received a frame exceeding the buffer size (%u): %u",
+				CONFIG_NET_BUF_DATA_SIZE, pkt_len);
+			LOG_HEXDUMP_ERR(rx_frame->psdu, rx_frame->psdu[0] + 1, "Received PSDU");
+			goto drop;
+		}
 #endif
 
 		LOG_DBG("Frame received");
@@ -232,7 +237,9 @@ drop:
 		rx_frame->psdu = NULL;
 		nrf_802154_buffer_free_raw(psdu);
 
-		net_pkt_unref(pkt);
+		if (pkt) {
+			net_pkt_unref(pkt);
+		}
 	}
 }
 


### PR DESCRIPTION
There was an observed situation where the assert checking frame length is below 128 bytes was hit. While the nrf-802154 checks that the frame does not exceed that size, there might exists code paths that allow such packets to pass through.

The change removes the assert and drops the packet instead. An error is also printed to allow for further debugging.