### PR TITLE
drivers: timer: stm32 lptim: Various fixes around st-timeout property

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -453,25 +453,23 @@ static int sys_clock_driver_init(void)
 	}
 #endif
 
-#if DT_INST_NODE_HAS_PROP(0, st_timeout)
+#if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
+	uint32_t timeout = DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout);
+
 	/*
-	 * Check if prescaler corresponding to the DT_INST_PROP(0, st_timeout)
+	 * Check if prescaler corresponding to st,timeout
 	 * is matching the lptim_clock_presc calculated one from the lptim_clock_freq
 	 * max lptim period is 0xFFFF/(lptim_clock_freq/lptim_clock_presc)
 	 */
-	if (DT_INST_PROP(0, st_timeout) >
-		(lptim_clock_presc / lptim_clock_freq) * 0xFFFF) {
+	if (timeout > (lptim_clock_presc / lptim_clock_freq) * 0xFFFF) {
 		return -EIO;
 	}
 
 	/*
-	 * LPTIM is counting DT_INST_PROP(0, st_timeout),
-	 * seconds at lptim_clock_freq divided lptim_clock_presc) Hz",
-	 * lptim_time_base is the autoreload counter
+	 * Define the lptim_time_base that should be set to expire at "timeout" seconds
+	 * running counter at (lptim_clock_freq divided by lptim_clock_presc) Hz
 	 */
-	lptim_time_base = 2 * (lptim_clock_freq *
-		(uint32_t)DT_INST_PROP(0, st_timeout))
-		/ lptim_clock_presc;
+	lptim_time_base = (lptim_clock_freq * timeout) / lptim_clock_presc;
 #else
 	/* Set LPTIM time base based on clock source freq */
 	if (lptim_clock_freq == KHZ(32)) {

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -456,14 +456,12 @@ static int sys_clock_driver_init(void)
 #if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
 	uint32_t timeout = DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout);
 
-	/*
-	 * Check if prescaler corresponding to st,timeout
-	 * is matching the lptim_clock_presc calculated one from the lptim_clock_freq
-	 * max lptim period is 0xFFFF/(lptim_clock_freq/lptim_clock_presc)
-	 */
-	if (timeout > (lptim_clock_presc / lptim_clock_freq) * 0xFFFF) {
+	if (timeout > (lptim_clock_presc * 0xFFFF) / lptim_clock_freq) {
+		__ASSERT(0,
+			"st,timeout can't be higher than range defined by LPTIM presc and freq");
 		return -EIO;
 	}
+
 
 	/*
 	 * Define the lptim_time_base that should be set to expire at "timeout" seconds

--- a/samples/boards/st/power_mgmt/blinky/README.rst
+++ b/samples/boards/st/power_mgmt/blinky/README.rst
@@ -37,7 +37,7 @@ Build and flash Blinky as follows, changing ``stm32l562e_dk`` for your board:
    :compact:
 
 After flashing, the LED starts to blink with a fixed period (SLEEP_TIME_MS).
-When LPTIM input clock has a prescaler, longer perdiod (up to 64 seconds)
+When st,prescaler lptim property is defined, longer period (up to 64 seconds)
 of low power can be tested.
 
 .. warning::

--- a/samples/boards/st/power_mgmt/blinky/boards/b_u585i_iot02a.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/b_u585i_iot02a.overlay
@@ -1,9 +1,22 @@
- /*
-  * give a prescaler to the lptim clock : LSE / 16 = 2048Hz
-  * so that the sleep period is of 32s in the sample application
-  * with a LPTIM1 prescaler of <1> to <8>, CONFIG_SYS_CLOCK_TICKS_PER_SEC is 4096
-  * with a LPTIM1 prescaler >= <16>, CONFIG_SYS_CLOCK_TICKS_PER_SEC is LSE / prescaler
-  */
 &stm32_lp_tick_source {
+	/*
+	 * Default LPTIM period is 2 seconds. This means that application will
+	 * be woken up every 2 seconds to reload its counter.
+	 * This behavior can be tuned in 2 ways:
+	 *
+	 * A] Extend the default period by setting a prescaler.
+	 *    New period = 2sec * st,prescaler
+	 *    Check the lptim bindings to see the impact on CONFIG_SYS_CLOCK_TICKS_PER_SEC
+	 *    and LPTIM precision.
+	 * B] Provide the LPTIM timeout definition.
+	 *    In this case New period = st,timeout
+	 *    Then st,prescaler should be defined with the following constraint:
+	 *    st,timeout < st,prescaler * 2
+	 */
+
+	/* The following setting will define LPTIM period as 32 sec */
 	st,prescaler = <16>;
+
+	/* Uncomment this line to have LPTIM period of 5 seconds */
+	/* st,timeout = <5>; */
 };

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
@@ -1,10 +1,22 @@
- /*
-  * give a prescaler to the lptim clock : LSE / 32 = 1024Hz
-  * so that the sleep period is of 64s in the sample application
-  * with a LPTIM1 prescaler of <1> to <8>, CONFIG_SYS_CLOCK_TICKS_PER_SEC is 4096
-  * with a LPTIM1 prescaler >= <16>, CONFIG_SYS_CLOCK_TICKS_PER_SEC is LSE / prescaler
-  */
 &stm32_lp_tick_source {
-	st,timeout = <15>;
-	st,prescaler = <8>;
+	/*
+	 * Default LPTIM period is 2 seconds. This means that application will
+	 * be woken up every 2 seconds to reload its counter.
+	 * This behavior can be tuned in 2 ways:
+	 *
+	 * A] Extend the default period by setting a prescaler.
+	 *    New period = 2sec * st,prescaler
+	 *    Check the lptim bindings to see the impact on CONFIG_SYS_CLOCK_TICKS_PER_SEC
+	 *    and LPTIM precision.
+	 * B] Provide the LPTIM timeout definition.
+	 *    In this case New period = st,timeout
+	 *    Then st,prescaler should be defined with the following constraint:
+	 *    st,timeout < st,prescaler * 2
+	 */
+
+	/* The following setting will define LPTIM period as 8 sec */
+	st,prescaler = <4>;
+
+	/* Uncomment this line to have LPTIM period of 5 seconds */
+	/* st,timeout = <5>; */
 };

--- a/samples/boards/st/power_mgmt/blinky/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/power_mgmt/blinky/boards/nucleo_wba55cg.overlay
@@ -1,10 +1,22 @@
- /*
-  * give a prescaler to the lptim clock : LSE / 32 = 1024Hz
-  * so that the sleep period is of 64s in the sample application
-  * with a LPTIM1 prescaler of <1> to <8>, CONFIG_SYS_CLOCK_TICKS_PER_SEC is 4096
-  * with a LPTIM1 prescaler >= <16>, CONFIG_SYS_CLOCK_TICKS_PER_SEC is LSE / prescaler
-  */
 &stm32_lp_tick_source {
-	st,timeout = <15>;
-	st,prescaler = <8>;
+	/*
+	 * Default LPTIM period is 2 seconds. This means that application will
+	 * be woken up every 2 seconds to reload its counter.
+	 * This behavior can be tuned in 2 ways:
+	 *
+	 * A] Extend the default period by setting a prescaler.
+	 *    New period = 2sec * st,prescaler
+	 *    Check the lptim bindings to see the impact on CONFIG_SYS_CLOCK_TICKS_PER_SEC
+	 *    and LPTIM precision.
+	 * B] Provide the LPTIM timeout definition.
+	 *    In this case New period = st,timeout
+	 *    Then st,prescaler should be defined with the following constraint:
+	 *    st,timeout < st,prescaler * 2
+	 */
+
+	/* The following setting will define LPTIM period as 8 sec */
+	st,prescaler = <4>;
+
+	/* This line defines a LPTIM period of 5 seconds */
+	st,timeout = <5>;
 };

--- a/samples/boards/st/power_mgmt/blinky/src/main.c
+++ b/samples/boards/st/power_mgmt/blinky/src/main.c
@@ -11,9 +11,9 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/pm/device_runtime.h>
 
-/* define SLEEP_TIME_MS higher than <st,counter-value> in ms */
-#if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_counter_value)
-#define SLEEP_TIME_MS   (DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_counter_value) * 1400)
+#if DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout)
+/* st,timeout is set. Application can be woken up exaclty on expected tick */
+#define SLEEP_TIME_MS   (DT_PROP(DT_NODELABEL(stm32_lp_tick_source), st_timeout) * 1000)
 #else
 #define SLEEP_TIME_MS   2000
 #endif


### PR DESCRIPTION
Various fixes around lptim behavior when st-timeout is used.

Some other changes on the sample that help to demonstrate this property to better demonstrate the interest and make it hopefully easier to understand.