### PR TITLE
intc: esp32: fix race in critical section locking

### DIFF
--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -866,7 +866,7 @@ void IRAM_ATTR esp_intr_noniram_disable(void)
 	unsigned int key = irq_lock();
 	int oldint;
 	int cpu = esp_cpu_get_core_id();
-	int non_iram_ints = ~non_iram_int_mask[cpu];
+	int non_iram_ints = non_iram_int_mask[cpu];
 
 	if (non_iram_int_disabled_flag[cpu]) {
 		abort();

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -51,19 +51,6 @@ LOG_MODULE_REGISTER(intc_esp32, CONFIG_LOG_DEFAULT_LEVEL);
 /* Typedef for C-callable interrupt handler function */
 typedef void (*intc_dyn_handler_t)(const void *);
 
-/* shared critical section context */
-static int esp_intc_csec;
-
-static inline void esp_intr_lock(void)
-{
-	esp_intc_csec = irq_lock();
-}
-
-static inline void esp_intr_unlock(void)
-{
-	irq_unlock(esp_intc_csec);
-}
-
 /* Linked list of vector descriptions, sorted by cpu.intno value */
 static struct vector_desc_t *vector_desc_head; /* implicitly initialized to NULL */
 
@@ -185,18 +172,18 @@ int esp_intr_mark_shared(int intno, int cpu, bool is_int_ram)
 		return -EINVAL;
 	}
 
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	struct vector_desc_t *vd = get_desc_for_int(intno, cpu);
 
 	if (vd == NULL) {
-		esp_intr_unlock();
+		irq_unlock(key);
 		return -ENOMEM;
 	}
 	vd->flags = VECDESC_FL_SHARED;
 	if (is_int_ram) {
 		vd->flags |= VECDESC_FL_INIRAM;
 	}
-	esp_intr_unlock();
+	irq_unlock(key);
 
 	return 0;
 }
@@ -210,15 +197,15 @@ int esp_intr_reserve(int intno, int cpu)
 		return -EINVAL;
 	}
 
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	struct vector_desc_t *vd = get_desc_for_int(intno, cpu);
 
 	if (vd == NULL) {
-		esp_intr_unlock();
+		irq_unlock(key);
 		return -ENOMEM;
 	}
 	vd->flags = VECDESC_FL_RESERVED;
-	esp_intr_unlock();
+	irq_unlock(key);
 
 	return 0;
 }
@@ -459,7 +446,7 @@ static void IRAM_ATTR shared_intr_isr(void *arg)
 	struct vector_desc_t *vd = (struct vector_desc_t *)arg;
 	struct shared_vector_desc_t *sh_vec = vd->shared_vec_info;
 
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	while (sh_vec) {
 		if (!sh_vec->disabled) {
 			if (!(sh_vec->statusreg) || (*sh_vec->statusreg & sh_vec->statusmask)) {
@@ -468,7 +455,7 @@ static void IRAM_ATTR shared_intr_isr(void *arg)
 		}
 		sh_vec = sh_vec->next;
 	}
-	esp_intr_unlock();
+	irq_unlock(key);
 }
 
 int esp_intr_alloc_intrstatus(int source,
@@ -557,14 +544,14 @@ int esp_intr_alloc_intrstatus(int source,
 		return -ENOMEM;
 	}
 
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	int cpu = esp_cpu_get_core_id();
 	/* See if we can find an interrupt that matches the flags. */
 	int intr = get_available_int(flags, cpu, force, source);
 
 	if (intr == -1) {
 		/* None found. Bail out. */
-		esp_intr_unlock();
+		irq_unlock(key);
 		k_free(ret);
 		return -ENODEV;
 	}
@@ -572,7 +559,7 @@ int esp_intr_alloc_intrstatus(int source,
 	struct vector_desc_t *vd = get_desc_for_int(intr, cpu);
 
 	if (vd == NULL) {
-		esp_intr_unlock();
+		irq_unlock(key);
 		k_free(ret);
 		return -ENOMEM;
 	}
@@ -583,7 +570,7 @@ int esp_intr_alloc_intrstatus(int source,
 		struct shared_vector_desc_t *sv = k_malloc(sizeof(struct shared_vector_desc_t));
 
 		if (sv == NULL) {
-			esp_intr_unlock();
+			irq_unlock(key);
 			k_free(ret);
 			return -ENOMEM;
 		}
@@ -658,7 +645,7 @@ int esp_intr_alloc_intrstatus(int source,
 	RV_CLEAR_CSR(mideleg, BIT(intr));
 #endif
 
-	esp_intr_unlock();
+	irq_unlock(key);
 
 	/* Fill return handle if needed, otherwise free handle. */
 	if (ret_handle != NULL) {
@@ -696,7 +683,7 @@ int IRAM_ATTR esp_intr_set_in_iram(intr_handle_t handle, bool is_in_iram)
 	if (vd->flags & VECDESC_FL_SHARED) {
 		return -EINVAL;
 	}
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	uint32_t mask = (1 << vd->intno);
 
 	if (is_in_iram) {
@@ -706,7 +693,7 @@ int IRAM_ATTR esp_intr_set_in_iram(intr_handle_t handle, bool is_in_iram)
 		vd->flags &= ~VECDESC_FL_INIRAM;
 		non_iram_int_mask[vd->cpu] |= mask;
 	}
-	esp_intr_unlock();
+	irq_unlock(key);
 	return 0;
 }
 
@@ -718,7 +705,7 @@ int esp_intr_free(intr_handle_t handle)
 		return -EINVAL;
 	}
 
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	esp_intr_disable(handle);
 	if (handle->vector_desc->flags & VECDESC_FL_SHARED) {
 		/* Find and kill the shared int */
@@ -768,7 +755,7 @@ int esp_intr_free(intr_handle_t handle)
 		/* Also kill non_iram mask bit. */
 		non_iram_int_mask[handle->vector_desc->cpu] &= ~(1 << (handle->vector_desc->intno));
 	}
-	esp_intr_unlock();
+	irq_unlock(key);
 	k_free(handle);
 	return 0;
 }
@@ -802,7 +789,7 @@ int IRAM_ATTR esp_intr_enable(intr_handle_t handle)
 	if (!handle) {
 		return -EINVAL;
 	}
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	int source;
 
 	if (handle->shared_vector_desc) {
@@ -818,12 +805,12 @@ int IRAM_ATTR esp_intr_enable(intr_handle_t handle)
 	} else {
 		/* Re-enable using cpu int ena reg */
 		if (handle->vector_desc->cpu != esp_cpu_get_core_id()) {
-			esp_intr_unlock();
+			irq_unlock(key);
 			return -EINVAL; /* Can only enable these ints on this cpu */
 		}
 		irq_enable(handle->vector_desc->intno);
 	}
-	esp_intr_unlock();
+	irq_unlock(key);
 	return 0;
 }
 
@@ -832,7 +819,7 @@ int IRAM_ATTR esp_intr_disable(intr_handle_t handle)
 	if (!handle) {
 		return -EINVAL;
 	}
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	int source;
 	bool disabled = 1;
 
@@ -863,18 +850,18 @@ int IRAM_ATTR esp_intr_disable(intr_handle_t handle)
 	} else {
 		/* Disable using per-cpu regs */
 		if (handle->vector_desc->cpu != esp_cpu_get_core_id()) {
-			esp_intr_unlock();
+			irq_unlock(key);
 			return -EINVAL; /* Can only enable these ints on this cpu */
 		}
 		irq_disable(handle->vector_desc->intno);
 	}
-	esp_intr_unlock();
+	irq_unlock(key);
 	return 0;
 }
 
 void IRAM_ATTR esp_intr_noniram_disable(void)
 {
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	int oldint;
 	int cpu = esp_cpu_get_core_id();
 	int non_iram_ints = ~non_iram_int_mask[cpu];
@@ -888,12 +875,12 @@ void IRAM_ATTR esp_intr_noniram_disable(void)
 	rtc_isr_noniram_disable(cpu);
 	/* Save which ints we did disable */
 	non_iram_int_disabled[cpu] = oldint & non_iram_ints;
-	esp_intr_unlock();
+	irq_unlock(key);
 }
 
 void IRAM_ATTR esp_intr_noniram_enable(void)
 {
-	esp_intr_lock();
+	unsigned int key = irq_lock();
 	int cpu = esp_cpu_get_core_id();
 	int non_iram_ints = non_iram_int_disabled[cpu];
 
@@ -903,7 +890,7 @@ void IRAM_ATTR esp_intr_noniram_enable(void)
 	non_iram_int_disabled_flag[cpu] = false;
 	esp_cpu_intr_enable(non_iram_ints);
 	rtc_isr_noniram_enable(cpu);
-	esp_intr_unlock();
+	irq_unlock(key);
 }
 
 #if defined(CONFIG_RISCV)

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -751,7 +751,9 @@ int esp_intr_free(intr_handle_t handle)
 		 * few bytes of memory we save.(We can also not use the same exit path for empty
 		 * shared ints anymore if we delete the desc.) For now, just mark it as free.
 		 */
-		handle->vector_desc->flags &= !(VECDESC_FL_NONSHARED | VECDESC_FL_RESERVED);
+		handle->vector_desc->flags &=
+			~(VECDESC_FL_NONSHARED | VECDESC_FL_RESERVED | VECDESC_FL_SHARED);
+		handle->vector_desc->source = ETS_INTERNAL_UNUSED_INTR_SOURCE;
 		/* Also kill non_iram mask bit. */
 		non_iram_int_mask[handle->vector_desc->cpu] &= ~(1 << (handle->vector_desc->intno));
 	}


### PR DESCRIPTION
Replace global lock variable with function-local storage for irq_lock() state. This fixes a race condition when multiple access enter or exit the critical section at the same time. Now each lock/unlock pair uses its own key, making interrupt safe.

Fix #93209