### PR TITLE
tracing: ctf: take IRQ lock before generating timestamp

### DIFF
--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -52,9 +52,11 @@
 #ifdef CONFIG_TRACING_CTF_TIMESTAMP
 #define CTF_EVENT(...)                                                         \
 	{                                                                      \
+		int key = irq_lock();                                          \
 		const uint32_t tstamp = k_cyc_to_ns_floor64(k_cycle_get_32()); \
 									       \
 		CTF_GATHER_FIELDS(tstamp, __VA_ARGS__)                         \
+		irq_unlock(key);                                               \
 	}
 #else
 #define CTF_EVENT(...)                                                         \


### PR DESCRIPTION
CTF tracing relies on all packet timestamps being increasing- if a timestamp of a later packet is less than the prior packet, the CTF parser assumes the timestamp field has overflowed and adds to the overall timestamp to account for this.

When taking a timestamp for a CTF packet, it was possible for an interrupt to occur before the packet was submitted to the tracing core framework but after the timestamp was generated. The interrupt itself would generate a tracing event with a later timestamp then the packet in question, leading to the packets being recorded out of order.

To resolve this, take an IRQ lock before generating the timestamp and release it after submitting the packet to the tracing core.

Note that while this fixes a bug, I don't think it is critical enough for inclusion in 4.2