### PR TITLE
RW612: Add sleep-output property

### DIFF
--- a/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612-pinctrl.dtsi
@@ -63,13 +63,17 @@
 
 	pinmux_lcdic: pinmux_lcdic {
 		group0 {
-			pinmux = <IO_MUX_LCD_SPI_IO44
-				IO_MUX_LCD_SPI_IO45
+			pinmux = <IO_MUX_LCD_SPI_IO45
 				IO_MUX_LCD_SPI_IO46
 				IO_MUX_LCD_SPI_IO47
 				IO_MUX_LCD_SPI_IO48
 				IO_MUX_LCD_SPI_IO49>;
 			slew-rate = "ultra";
+		};
+		group1 {
+			pinmux = <IO_MUX_LCD_SPI_IO44>;
+			slew-rate = "ultra";
+			sleep-output = "high";
 		};
 	};
 
@@ -83,11 +87,18 @@
 	pinmux_hsgpio0: pinmux_hsgpio0 {
 		group0 {
 			pinmux = <IO_MUX_GPIO11
-				IO_MUX_GPIO12
 				IO_MUX_GPIO18
 				IO_MUX_GPIO21
 				>;
 			slew-rate = "normal";
+		};
+		group1 {
+			pinmux = <IO_MUX_GPIO0
+				IO_MUX_GPIO1
+				IO_MUX_GPIO12
+				>;
+			slew-rate = "normal";
+			sleep-output = "high";
 		};
 	};
 

--- a/boards/nxp/frdm_rw612/init.c
+++ b/boards/nxp/frdm_rw612/init.c
@@ -6,17 +6,6 @@
 #include <zephyr/pm/pm.h>
 #include <fsl_power.h>
 #include <fsl_common.h>
-#include <fsl_io_mux.h>
-
-#define NON_AON_PINS_START	0
-#define NON_AON_PINS_BREAK	21
-#define NON_AON_PINS_RESTART	28
-#define NON_AON_PINS_END	63
-#define RF_CNTL_PINS_START	0
-#define RF_CNTL_PINS_END	3
-#define LED_BLUE_GPIO		0
-#define LED_RED_GPIO		1
-#define LED_GREEN_GPIO		12
 
 static void frdm_rw612_power_init_config(void)
 {
@@ -53,26 +42,6 @@ void board_early_init_hook(void)
 	};
 
 	pm_notifier_register(&frdm_rw612_pm_notifier);
-
-	int32_t i;
-
-	/* Set all non-AON pins output low level in sleep mode. */
-	for (i = NON_AON_PINS_START; i <= NON_AON_PINS_BREAK; i++) {
-		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
-	}
-	for (i = NON_AON_PINS_RESTART; i <= NON_AON_PINS_END; i++) {
-		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
-	}
-
-	/* Set the LED GPIO output pins to be High in PM3 as these pins are Active Low */
-	IO_MUX_SetPinOutLevelInSleep(LED_BLUE_GPIO, IO_MUX_SleepPinLevelHigh);
-	IO_MUX_SetPinOutLevelInSleep(LED_RED_GPIO, IO_MUX_SleepPinLevelHigh);
-	IO_MUX_SetPinOutLevelInSleep(LED_GREEN_GPIO, IO_MUX_SleepPinLevelHigh);
-
-	/* Set RF_CNTL 0-3 output low level in sleep mode. */
-	for (i = RF_CNTL_PINS_START; i <= RF_CNTL_PINS_END; i++) {
-		IO_MUX_SetRfPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
-	}
 #endif
 
 #ifdef CONFIG_I2S_TEST_SEPARATE_DEVICES

--- a/boards/nxp/rd_rw612_bga/init.c
+++ b/boards/nxp/rd_rw612_bga/init.c
@@ -6,14 +6,6 @@
 #include <zephyr/pm/pm.h>
 #include <fsl_power.h>
 #include <fsl_common.h>
-#include <fsl_io_mux.h>
-
-#define NON_AON_PINS_START      0
-#define NON_AON_PINS_BREAK      21
-#define NON_AON_PINS_RESTART    28
-#define NON_AON_PINS_END        63
-#define RF_CNTL_PINS_START      0
-#define RF_CNTL_PINS_END        3
 
 static void rdrw61x_power_init_config(void)
 {
@@ -50,21 +42,6 @@ void board_early_init_hook(void)
 	};
 
 	pm_notifier_register(&rdrw61x_pm_notifier);
-
-	int32_t i;
-
-	/* Set all non-AON pins output low level in sleep mode. */
-	for (i = NON_AON_PINS_START; i <= NON_AON_PINS_BREAK; i++) {
-		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
-	}
-	for (i = NON_AON_PINS_RESTART; i <= NON_AON_PINS_END; i++) {
-		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
-	}
-
-	/* Set RF_CNTL 0-3 output low level in sleep mode. */
-	for (i = RF_CNTL_PINS_START; i <= RF_CNTL_PINS_END; i++) {
-		IO_MUX_SetRfPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
-	}
 #endif
 
 #ifdef CONFIG_I2S_TEST_SEPARATE_DEVICES

--- a/drivers/pinctrl/pinctrl_mci_io_mux.c
+++ b/drivers/pinctrl/pinctrl_mci_io_mux.c
@@ -1,11 +1,13 @@
 /*
- * Copyright 2022 NXP
+ * Copyright 2022, 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/drivers/pinctrl.h>
 #include <soc.h>
+
+#define NO_FORCE_OUTPUT 2
 
 static MCI_IO_MUX_Type *mci_iomux =
 	(MCI_IO_MUX_Type *)DT_REG_ADDR(DT_NODELABEL(pinctrl));
@@ -59,6 +61,19 @@ static void configure_pin_props(uint32_t pin_mux, uint8_t gpio_idx)
 	/* Set slew rate */
 	set = IOMUX_PAD_GET_SLEW(pin_mux) << ((gpio_idx & 0xF) << 1);
 	*slew_reg = (*slew_reg & ~mask) | set;
+
+	/* Set sleep force enable bit */
+	mask = (0x1 << (gpio_idx & 0x1F));
+	/* Check if we should force the pin to output in sleep mode */
+	if (IOMUX_PAD_GET_SLEEP_FORCE(pin_mux) == NO_FORCE_OUTPUT) {
+		/* Does not force output during sleep */
+		*sleep_force_en = (*sleep_force_en & ~mask);
+	} else {
+		/* Enable forcing output during sleep */
+		*sleep_force_en = (*sleep_force_en | mask);
+		set = (IOMUX_PAD_GET_SLEEP_FORCE_VAL(pin_mux) << (gpio_idx & 0x1F));
+		*sleep_force_val = (*sleep_force_val & ~mask) | set;
+	}
 }
 
 static void select_gpio_mode(uint8_t gpio_idx)

--- a/dts/bindings/pinctrl/nxp,mci-io-mux.yaml
+++ b/dts/bindings/pinctrl/nxp,mci-io-mux.yaml
@@ -69,3 +69,15 @@ child-binding:
           1 - normal slew rate
           2 - fast slew rate
           3 - fastest slew rate (ultra)
+      sleep-output:
+        type: string
+        default: "low"
+        enum:
+          - "low"
+          - "high"
+          - "disable"
+        description: |
+          Sets pin output level in sleep mode.
+          0 - output level low
+          1 - output level high
+          2 - disable force output in sleep mode.

--- a/soc/nxp/rw/pinctrl_defs.h
+++ b/soc/nxp/rw/pinctrl_defs.h
@@ -74,11 +74,10 @@
 /* Pin configuration settings */
 #define IOMUX_PAD_PULL(x) (((x) & 0x3) << 19)
 #define IOMUX_PAD_SLEW(x) (((x) & 0x3) << 21)
-#define IOMUX_PAD_SLEEP_FORCE(en, val) \
-	((((en) & 0x1) << 24) | (((val) & 0x1) << 23))
+#define IOMUX_PAD_SLEEP_FORCE(en) (((en) & 0x3) << 23)
 #define IOMUX_PAD_GET_PULL(mux) (((mux) >> 19) & 0x3)
 #define IOMUX_PAD_GET_SLEW(mux) (((mux) >> 21) & 0x3)
-#define IOMUX_PAD_GET_SLEEP_FORCE_EN(mux) (((mux) >> 24) & 0x1)
+#define IOMUX_PAD_GET_SLEEP_FORCE(mux) (((mux) >> 23) & 0x3)
 #define IOMUX_PAD_GET_SLEEP_FORCE_VAL(mux) (((mux) >> 23) & 0x1)
 
 /*

--- a/soc/nxp/rw/pinctrl_soc.h
+++ b/soc/nxp/rw/pinctrl_soc.h
@@ -20,16 +20,14 @@ extern "C" {
 
 typedef uint32_t pinctrl_soc_pin_t;
 
-
-#define Z_PINCTRL_IOMUX_PINCFG(node_id)						\
-	(IF_ENABLED(DT_PROP(node_id, bias_pull_down),				\
-	(IOMUX_PAD_PULL(0x2) |)) /* pull down */				\
-	IF_ENABLED(DT_PROP(node_id, bias_pull_up),				\
-	(IOMUX_PAD_PULL(0x1) |)) /* pull up */					\
-	IF_ENABLED(DT_NODE_HAS_PROP(node_id, sleep_output), /* force output */	\
-	IOMUX_PAD_SLEEP_FORCE(0x1, DT_ENUM_IDX(node_id, sleep_output)))		\
+#define Z_PINCTRL_IOMUX_PINCFG(node_id)								\
+	(IF_ENABLED(DT_PROP(node_id, bias_pull_down),						\
+	(IOMUX_PAD_PULL(0x2) |)) /* pull down */						\
+	IF_ENABLED(DT_PROP(node_id, bias_pull_up),						\
+	(IOMUX_PAD_PULL(0x1) |)) /* pull up */							\
+	IF_ENABLED(DT_NODE_HAS_PROP(node_id, sleep_output),					\
+	(IOMUX_PAD_SLEEP_FORCE(DT_ENUM_IDX(node_id, sleep_output)) |)) /* force output */	\
 	IOMUX_PAD_SLEW(DT_ENUM_IDX(node_id, slew_rate))) /* slew rate */
-
 
 #define Z_PINCTRL_STATE_PIN_INIT(group, pin_prop, idx)		\
 	DT_PROP_BY_IDX(group, pin_prop, idx) | Z_PINCTRL_IOMUX_PINCFG(group),

--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -17,9 +17,17 @@
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_device_registers.h>
+#include <fsl_io_mux.h>
 #include "soc.h"
 #include "flexspi_clock_setup.h"
 #include "fsl_ocotp.h"
+
+#define NON_AON_PINS_START      0
+#define NON_AON_PINS_BREAK      21
+#define NON_AON_PINS_RESTART    28
+#define NON_AON_PINS_END        63
+#define RF_CNTL_PINS_START      0
+#define RF_CNTL_PINS_END        3
 
 extern void nxp_nbu_init(void);
 #ifdef CONFIG_NXP_RW6XX_BOOT_HEADER
@@ -325,6 +333,20 @@ void soc_early_init_hook(void)
 #endif
 #if CONFIG_PM
 	nxp_rw6xx_power_init();
+
+	int32_t i;
+	/* Set all non-AON pins output low level in sleep mode. */
+	for (i = NON_AON_PINS_START; i <= NON_AON_PINS_BREAK; i++) {
+		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
+	for (i = NON_AON_PINS_RESTART; i <= NON_AON_PINS_END; i++) {
+		IO_MUX_SetPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
+
+	/* Set RF_CNTL 0-3 output low level in sleep mode. */
+	for (i = RF_CNTL_PINS_START; i <= RF_CNTL_PINS_END; i++) {
+		IO_MUX_SetRfPinOutLevelInSleep(i, IO_MUX_SleepPinLevelLow);
+	}
 #endif
 
 #if defined(CONFIG_BT) || defined(CONFIG_IEEE802154)


### PR DESCRIPTION
This property allows a user to specify the operation of a pin in sleep mode. By default, pins are configured to be output low in sleep mode.
This PR also fixes an issue where the LCD stops functioning on the RW612 FRDM board when entering PM3 power mode. The fix for this is to set the LCD RESET pin to output high in sleep modes.
