### PR TITLE
doc: migration: 4.2: Add Modbus related notes

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -761,6 +761,14 @@ State Machine Framework
 * Flat state machines ignore the return value; returning :c:enum:`SMF_EVENT_HANDLED`
   would be the most technically accurate response.
 
+Modbus
+======
+
+* The ``client_stop_bits`` field in :c:struct:`modbus_serial_param` has been renamed into ``stop_bits``.
+  The setting is valid in both client and server modes.
+* Custom stop-bit settings are disabled by default and should be enabled
+  by :kconfig:option:`CONFIG_MODBUS_NONCOMPLIANT_SERIAL_MODE`.
+
 Modules
 *******
 


### PR DESCRIPTION
Add notes regarding changes in Modbus  serial mode configuration.

The commit that introduced the change: https://github.com/zephyrproject-rtos/zephyr/commit/bdd94261a53f9922d8494ef5b1ae3a91cef4a315