### PR TITLE
twister: Fix exception if twister fails to create symlink

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -538,7 +538,7 @@ def try_making_symlink(source: str, link: str):
         os.symlink(source, link)
     except OSError as e:
         logger.error(
-            "Error creating symlink: %s, attempting to copy.". str(e)
+            "Error creating symlink: %s, attempting to copy.", str(e)
         )
         shutil.copy(source, link)
 


### PR DESCRIPTION
This fixes a typo in the formatting code that caused an exception if the symlink creation failed.

Fixes #93220