### PR TITLE
samples: tfm_integration: tfm_regression_test: add adi overlay file

### DIFF
--- a/samples/tfm_integration/tfm_regression_test/boards/max32657evkit_max32657_ns.conf
+++ b/samples/tfm_integration/tfm_regression_test/boards/max32657evkit_max32657_ns.conf
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Analog Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# MAX32657 only contains one UART.
+# It is allocated to NS.
+# Therefore, disable S side regression test.
+CONFIG_TFM_REGRESSION_S=n
+
+# MAX32657 currently only supports SFN
+# and isolation level 1
+CONFIG_TFM_SFN=y
+CONFIG_TFM_ISOLATION_LEVEL=1

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -33,6 +33,8 @@ tests:
     timeout: 200
 
   sample.tfm.regression_sfn:
+    platform_allow:
+      - max32657evkit/max32657/ns
     extra_args:
       - CONFIG_TFM_SFN=y
       - CONFIG_TFM_ISOLATION_LEVEL=1


### PR DESCRIPTION
ADI MAX32657 currently only supports SFN and isolation level 1.