### PR TITLE
rtio: More useful callback OPs

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -182,6 +182,14 @@ Logging
   used. The new script supports the same functionality (and more), but requires different command
   line arguments when invoked.
 
+RTIO
+====
+
+* Callback operations now take an additional argument corresponding to the result code of the first
+  error in the chain.
+* Callback operations are always called regardless of success/error status of previous submissions
+  in the chain.
+
 Secure storage
 ==============
 

--- a/drivers/sensor/adi/adxl345/adxl345_stream.c
+++ b/drivers/sensor/adi/adxl345/adxl345_stream.c
@@ -62,8 +62,10 @@ void adxl345_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 	data->sqe = iodev_sqe;
 }
 
-static void adxl345_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl345_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	const struct adxl345_dev_config *cfg = dev->config;
 
@@ -102,8 +104,11 @@ static void adxl345_fifo_flush_rtio(const struct device *dev)
 	rtio_submit(data->rtio_ctx, 0);
 }
 
-static void adxl345_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg)
+static void adxl345_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe,
+				 int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	struct adxl345_dev_data *data = (struct adxl345_dev_data *) dev->data;
 	const struct adxl345_dev_config *cfg = (const struct adxl345_dev_config *) dev->config;
@@ -117,8 +122,11 @@ static void adxl345_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *s
 
 }
 
-static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqe,
+					    int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	struct adxl345_dev_data *data = (struct adxl345_dev_data *) dev->data;
 	const struct adxl345_dev_config *cfg = (const struct adxl345_dev_config *) dev->config;
@@ -231,8 +239,11 @@ static void adxl345_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	}
 }
 
-static void adxl345_process_status1_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl345_process_status1_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				       int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	struct adxl345_dev_data *data = (struct adxl345_dev_data *) dev->data;
 	const struct adxl345_dev_config *cfg = (const struct adxl345_dev_config *) dev->config;

--- a/drivers/sensor/adi/adxl362/adxl362_stream.c
+++ b/drivers/sensor/adi/adxl362/adxl362_stream.c
@@ -11,9 +11,11 @@
 
 LOG_MODULE_DECLARE(ADXL362, CONFIG_SENSOR_LOG_LEVEL);
 
-static void adxl362_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl362_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg)
 {
-	const struct device *dev = (const struct device *)arg;
+	ARG_UNUSED(result);
+
+	const struct device *dev = arg;
 	const struct adxl362_config *cfg = dev->config;
 
 	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
@@ -134,9 +136,12 @@ void adxl362_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 	data->sqe = iodev_sqe;
 }
 
-static void adxl362_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg)
+static void adxl362_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe,
+				 int result, void *arg)
 {
-	const struct device *dev = (const struct device *)arg;
+	ARG_UNUSED(result);
+
+	const struct device *dev = arg;
 	const struct adxl362_config *cfg = (const struct adxl362_config *)dev->config;
 	struct rtio_iodev_sqe *iodev_sqe = sqe->userdata;
 
@@ -145,9 +150,12 @@ static void adxl362_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *s
 	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
 }
 
-static void adxl362_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl362_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqe,
+					    int result, void *arg)
 {
-	const struct device *dev = (const struct device *)arg;
+	ARG_UNUSED(result);
+
+	const struct device *dev = arg;
 	struct adxl362_data *data = (struct adxl362_data *)dev->data;
 	const struct adxl362_config *cfg = (const struct adxl362_config *)dev->config;
 	struct rtio_iodev_sqe *current_sqe = data->sqe;
@@ -247,9 +255,12 @@ static void adxl362_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	rtio_submit(data->rtio_ctx, 0);
 }
 
-static void adxl362_process_status_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl362_process_status_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				      int result, void *arg)
 {
-	const struct device *dev = (const struct device *)arg;
+	ARG_UNUSED(result);
+
+	const struct device *dev = arg;
 	struct adxl362_data *data = (struct adxl362_data *) dev->data;
 	const struct adxl362_config *cfg = (const struct adxl362_config *) dev->config;
 	struct rtio_iodev_sqe *current_sqe = data->sqe;
@@ -376,8 +387,7 @@ static void adxl362_process_status_cb(struct rtio *r, const struct rtio_sqe *sqr
 	rtio_sqe_prep_read(read_fifo_data, data->iodev, RTIO_PRIO_NORM, data->fifo_ent, 2,
 						current_sqe);
 	read_fifo_data->flags = RTIO_SQE_CHAINED;
-	rtio_sqe_prep_callback(complete_op, adxl362_process_fifo_samples_cb, (void *)dev,
-							current_sqe);
+	rtio_sqe_prep_callback(complete_op, adxl362_process_fifo_samples_cb, (void *)dev, NULL);
 
 	rtio_submit(data->rtio_ctx, 0);
 }

--- a/drivers/sensor/adi/adxl367/adxl367_stream.c
+++ b/drivers/sensor/adi/adxl367/adxl367_stream.c
@@ -23,8 +23,10 @@ static void adxl367_sqe_done(const struct adxl367_dev_config *cfg,
 	gpio_pin_interrupt_configure_dt(&cfg->interrupt, GPIO_INT_EDGE_TO_ACTIVE);
 }
 
-static void adxl367_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl367_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	const struct adxl367_dev_config *cfg = dev->config;
 
@@ -148,8 +150,11 @@ void adxl367_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 	data->sqe = iodev_sqe;
 }
 
-static void adxl367_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg)
+static void adxl367_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe,
+				 int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	const struct adxl367_dev_config *cfg = (const struct adxl367_dev_config *)dev->config;
 	struct rtio_iodev_sqe *iodev_sqe = sqe->userdata;
@@ -190,8 +195,11 @@ size_t adxl367_get_numb_of_samp_in_pkt(const struct adxl367_data *data)
 	return sample_numb;
 }
 
-static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqe,
+					    int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	struct adxl367_data *data = (struct adxl367_data *)dev->data;
 	const struct adxl367_dev_config *cfg = (const struct adxl367_dev_config *)dev->config;
@@ -401,13 +409,16 @@ static void adxl367_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	rtio_sqe_prep_read(read_fifo_data, data->iodev, RTIO_PRIO_NORM, read_buf, read_len,
 			   current_sqe);
 	read_fifo_data->flags = RTIO_SQE_CHAINED;
-	rtio_sqe_prep_callback(complete_op, adxl367_fifo_read_cb, (void *)dev, current_sqe);
+	rtio_sqe_prep_callback(complete_op, adxl367_fifo_read_cb, current_sqe, (void *)dev);
 
 	rtio_submit(data->rtio_ctx, 0);
 }
 
-static void adxl367_process_status_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl367_process_status_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				      int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = (const struct device *)arg;
 	struct adxl367_data *data = (struct adxl367_data *) dev->data;
 	const struct adxl367_dev_config *cfg = (const struct adxl367_dev_config *) dev->config;

--- a/drivers/sensor/adi/adxl372/adxl372_stream.c
+++ b/drivers/sensor/adi/adxl372/adxl372_stream.c
@@ -12,7 +12,7 @@
 
 LOG_MODULE_DECLARE(ADXL372, CONFIG_SENSOR_LOG_LEVEL);
 
-static void adxl372_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl372_irq_en_cb(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	const struct adxl372_dev_config *cfg = dev->config;
@@ -125,7 +125,8 @@ void adxl372_submit_stream(const struct device *dev, struct rtio_iodev_sqe *iode
 	data->sqe = iodev_sqe;
 }
 
-static void adxl372_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg)
+static void adxl372_fifo_read_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe,
+				 int result, void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	const struct adxl372_dev_config *cfg = (const struct adxl372_dev_config *)dev->config;
@@ -162,7 +163,8 @@ size_t adxl372_get_packet_size(const struct adxl372_dev_config *cfg)
 	return packet_size;
 }
 
-static void adxl372_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl372_process_fifo_samples_cb(struct rtio *r, const struct rtio_sqe *sqr,
+					    int result, void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct adxl372_data *data = (struct adxl372_data *)dev->data;
@@ -293,7 +295,8 @@ static void adxl372_process_fifo_samples_cb(struct rtio *r, const struct rtio_sq
 	rtio_submit(data->rtio_ctx, 0);
 }
 
-static void adxl372_process_status1_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void adxl372_process_status1_cb(struct rtio *r, const struct rtio_sqe *sqr,
+				       int result, void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct adxl372_data *data = (struct adxl372_data *)dev->data;

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c.h
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c.h
@@ -112,7 +112,9 @@ void akm09918_async_fetch(struct k_work *work);
 int akm09918c_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder);
 
 void akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe);
-void akm09918_after_start_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg0);
-void akm09918_complete_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg0);
+void akm09918_after_start_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, int result,
+			     void *arg0);
+void akm09918_complete_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, int result,
+			  void *arg0);
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_AKM09918C_AKM09918C_H_ */

--- a/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
+++ b/drivers/sensor/asahi_kasei/akm09918c/akm09918c_async.c
@@ -71,8 +71,11 @@ void akm09918c_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe
 	}
 }
 
-void akm09918_after_start_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg0)
+void akm09918_after_start_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe,
+			     int result, void *arg0)
 {
+	ARG_UNUSED(result);
+
 	const struct rtio_iodev_sqe *parent_iodev_sqe = (struct rtio_iodev_sqe *)arg0;
 	const struct sensor_read_config *cfg = parent_iodev_sqe->sqe.iodev->data;
 	const struct device *dev = cfg->sensor;
@@ -150,8 +153,10 @@ void akm09918_async_fetch(struct k_work *work)
 	rtio_submit(data->rtio_ctx, 0);
 }
 
-void akm09918_complete_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, void *arg0)
+void akm09918_complete_cb(struct rtio *rtio_ctx, const struct rtio_sqe *sqe, int result, void *arg0)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *parent_iodev_sqe = (struct rtio_iodev_sqe *)arg0;
 	struct rtio_sqe *parent_sqe = &parent_iodev_sqe->sqe;
 	struct akm09918c_encoded_data *edata =

--- a/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_rtio.c
@@ -19,8 +19,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(bma4xx, CONFIG_SENSOR_LOG_LEVEL);
 
-static void bma4xx_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg)
+static void bma4xx_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe,
+				   int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
 	struct rtio_cqe *cqe;
 	int err = 0;

--- a/drivers/sensor/bosch/bmm350/bmm350.c
+++ b/drivers/sensor/bosch/bmm350/bmm350.c
@@ -728,8 +728,11 @@ static int bmm350_attr_get(const struct device *dev, enum sensor_channel chan,
 
 #ifdef CONFIG_SENSOR_ASYNC_API
 
-static void bmm350_one_shot_complete(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg0)
+static void bmm350_one_shot_complete(struct rtio *ctx, const struct rtio_sqe *sqe,
+				     int result, void *arg0)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)arg0;
 	struct sensor_read_config *cfg = (struct sensor_read_config *)iodev_sqe->sqe.iodev->data;
 	const struct device *dev = (const struct device *)sqe->userdata;

--- a/drivers/sensor/bosch/bmm350/bmm350_stream.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_stream.c
@@ -33,8 +33,11 @@ static void bmm350_stream_result(const struct device *dev, int err)
 	}
 }
 
-static void bmm350_stream_event_complete(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg0)
+static void bmm350_stream_event_complete(struct rtio *ctx, const struct rtio_sqe *sqe,
+					 int result, void *arg0)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)arg0;
 	struct sensor_read_config *cfg = (struct sensor_read_config *)iodev_sqe->sqe.iodev->data;
 	const struct device *dev = (const struct device *)sqe->userdata;

--- a/drivers/sensor/bosch/bmp581/bmp581.c
+++ b/drivers/sensor/bosch/bmp581/bmp581.c
@@ -603,8 +603,11 @@ static int bmp581_init(const struct device *dev)
 
 #ifdef CONFIG_SENSOR_ASYNC_API
 
-static void bmp581_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg)
+static void bmp581_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe,
+				   int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)arg;
 	struct rtio_cqe *cqe;
 	int err = 0;

--- a/drivers/sensor/bosch/bmp581/bmp581_stream.c
+++ b/drivers/sensor/bosch/bmp581/bmp581_stream.c
@@ -35,8 +35,11 @@ static inline void bmp581_stream_result(const struct device *dev, int err)
 	}
 }
 
-static void bmp581_stream_event_complete(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg0)
+static void bmp581_stream_event_complete(struct rtio *ctx, const struct rtio_sqe *sqe,
+					 int result, void *arg0)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)arg0;
 	const struct device *dev = (const struct device *)sqe->userdata;
 	struct bmp581_data *data = dev->data;

--- a/drivers/sensor/pixart/paa3905/paa3905.c
+++ b/drivers/sensor/pixart/paa3905/paa3905.c
@@ -27,8 +27,11 @@ struct reg_val_pair {
 
 static void paa3905_complete_result(struct rtio *ctx,
 				    const struct rtio_sqe *sqe,
+				    int result,
 				    void *arg)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
 	struct rtio_cqe *cqe;
 	int err = 0;

--- a/drivers/sensor/pixart/pat9136/pat9136.c
+++ b/drivers/sensor/pixart/pat9136/pat9136.c
@@ -65,8 +65,11 @@ static int perform_reg_ops(const struct device *dev, const struct reg_val_pair *
 
 static void pat9136_complete_result(struct rtio *ctx,
 				    const struct rtio_sqe *sqe,
+				    int result,
 				    void *arg)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
 	struct rtio_cqe *cqe;
 	int err = 0;

--- a/drivers/sensor/pni/rm3100/rm3100.c
+++ b/drivers/sensor/pni/rm3100/rm3100.c
@@ -25,8 +25,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(RM3100, CONFIG_SENSOR_LOG_LEVEL);
 
-static void rm3100_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg)
+static void rm3100_complete_result(struct rtio *ctx, const struct rtio_sqe *sqe,
+				   int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
 	struct rtio_cqe *cqe;
 	int err = 0;

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -323,7 +323,8 @@ static int parse_sensor_value(const char *val_str, struct sensor_value *out)
 	return 0;
 }
 
-void sensor_shell_processing_callback(int result, uint8_t *buf, uint32_t buf_len, void *userdata)
+void sensor_shell_processing_callback(int result, uint8_t *buf, uint32_t buf_len,
+				      void *userdata)
 {
 	struct sensor_shell_processing_context *ctx = userdata;
 	const struct sensor_decoder_api *decoder;

--- a/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
+++ b/drivers/sensor/st/lis2dux12/lis2dux12_rtio_stream.c
@@ -102,8 +102,11 @@ void lis2dux12_submit_stream(const struct device *dev, struct rtio_iodev_sqe *io
 /*
  * Called by bus driver to complete the sqe.
  */
-static void lis2dux12_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void lis2dux12_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				     int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 	struct lis2dux12_data *lis2dux12 = dev->data;
 
@@ -119,8 +122,11 @@ static void lis2dux12_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe,
  * Called by bus driver to complete the LIS2DUX12_FIFO_STATUS read op (2 bytes).
  * If FIFO threshold or FIFO full events are active it reads all FIFO entries.
  */
-static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				   int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 	struct lis2dux12_data *lis2dux12 = dev->data;
 	const struct lis2dux12_config *cfg = dev->config;
@@ -316,8 +322,11 @@ static void lis2dux12_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, v
  * Called by bus driver to complete the LIS2DUX12_STATUS_REG read op.
  * If drdy_xl is active it reads XL data (6 bytes) from LIS2DUX12_OUTX_L_A reg.
  */
-static void lis2dux12_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void lis2dux12_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				     int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 	struct lis2dux12_data *lis2dux12 = dev->data;
 	struct rtio *rtio = lis2dux12->rtio_ctx;

--- a/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
+++ b/drivers/sensor/st/lsm6dsv16x/lsm6dsv16x_rtio_stream.c
@@ -251,8 +251,11 @@ void lsm6dsv16x_submit_stream(const struct device *dev, struct rtio_iodev_sqe *i
 /*
  * Called by bus driver to complete the sqe.
  */
-static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				      int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 #if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	const struct lsm6dsv16x_config *config = dev->config;
@@ -273,8 +276,11 @@ static void lsm6dsv16x_complete_op_cb(struct rtio *r, const struct rtio_sqe *sqe
  * Called by bus driver to complete the LSM6DSV16X_FIFO_STATUS read op (2 bytes).
  * If FIFO threshold or FIFO full events are active it reads all FIFO entries.
  */
-static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				    int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 	const struct lsm6dsv16x_config *config = dev->config;
 	struct lsm6dsv16x_data *lsm6dsv16x = dev->data;
@@ -494,8 +500,11 @@ static void lsm6dsv16x_read_fifo_cb(struct rtio *r, const struct rtio_sqe *sqe, 
  * Called by bus driver to complete the LSM6DSV16X_STATUS_REG read op.
  * If drdy_xl is active it reads XL data (6 bytes) from LSM6DSV16X_OUTX_L_A reg.
  */
-static void lsm6dsv16x_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void lsm6dsv16x_read_status_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				      int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 #if LSM6DSVXXX_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	const struct lsm6dsv16x_config *config = dev->config;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
@@ -55,8 +55,10 @@ void icm4268x_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *
 	data->streaming_sqe = iodev_sqe;
 }
 
-static void icm4268x_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void icm4268x_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 	struct icm4268x_dev_data *drv_data = dev->data;
 	const struct icm4268x_dev_cfg *drv_cfg = dev->config;
@@ -67,8 +69,11 @@ static void icm4268x_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, voi
 	gpio_pin_interrupt_configure_dt(&drv_cfg->gpio_int1, GPIO_INT_EDGE_TO_ACTIVE);
 }
 
-static void icm4268x_fifo_count_cb(struct rtio *r, const struct rtio_sqe *sqe, void *arg)
+static void icm4268x_fifo_count_cb(struct rtio *r, const struct rtio_sqe *sqe,
+				   int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 	struct icm4268x_dev_data *drv_data = dev->data;
 	const struct icm4268x_dev_cfg *drv_cfg = dev->config;
@@ -201,8 +206,11 @@ icm4268x_get_read_config_trigger(const struct sensor_read_config *cfg,
 	return NULL;
 }
 
-static void icm4268x_int_status_cb(struct rtio *r, const struct rtio_sqe *sqr, void *arg)
+static void icm4268x_int_status_cb(struct rtio *r, const struct rtio_sqe *sqr,
+				   int result, void *arg)
 {
+	ARG_UNUSED(result);
+
 	const struct device *dev = arg;
 	struct icm4268x_dev_data *drv_data = dev->data;
 	const struct icm4268x_dev_cfg *drv_cfg = dev->config;

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -123,8 +123,11 @@ static int icm45686_channel_get(const struct device *dev,
 
 static void icm45686_complete_result(struct rtio *ctx,
 				     const struct rtio_sqe *sqe,
+				     int result,
 				     void *arg)
 {
+	ARG_UNUSED(result);
+
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)sqe->userdata;
 	struct rtio_cqe *cqe;
 	int err = 0;

--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -277,9 +277,10 @@ struct rtio_iodev_sqe;
  * @brief Callback signature for RTIO_OP_CALLBACK
  * @param r RTIO context being used with the callback
  * @param sqe Submission for the callback op
+ * @param res Result of the previously linked submission.
  * @param arg0 Argument option as part of the sqe
  */
-typedef void (*rtio_callback_t)(struct rtio *r, const struct rtio_sqe *sqe, void *arg0);
+typedef void (*rtio_callback_t)(struct rtio *r, const struct rtio_sqe *sqe, int res, void *arg0);
 
 /**
  * @typedef rtio_signaled_t

--- a/samples/drivers/i2c/rtio_loopback/src/main.c
+++ b/samples/drivers/i2c/rtio_loopback/src/main.c
@@ -281,7 +281,8 @@ static int sample_rtio_write_read(void)
 	return 0;
 }
 
-static void rtio_write_read_done_callback(struct rtio *r, const struct rtio_sqe *sqe, void *arg0)
+static void rtio_write_read_done_callback(struct rtio *r, const struct rtio_sqe *sqe,
+					  int result, void *arg0)
 {
 	struct k_sem *sem = arg0;
 	struct rtio_cqe *wr_rd_cqe;

--- a/subsys/rtio/rtio_executor.c
+++ b/subsys/rtio/rtio_executor.c
@@ -31,13 +31,13 @@ static void rtio_executor_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, void *u
 /**
  * @brief Executor handled submissions
  */
-static void rtio_executor_op(struct rtio_iodev_sqe *iodev_sqe)
+static void rtio_executor_op(struct rtio_iodev_sqe *iodev_sqe, int last_result)
 {
 	const struct rtio_sqe *sqe = &iodev_sqe->sqe;
 
 	switch (sqe->op) {
 	case RTIO_OP_CALLBACK:
-		sqe->callback.callback(iodev_sqe->r, sqe, sqe->callback.arg0);
+		sqe->callback.callback(iodev_sqe->r, sqe, last_result, sqe->callback.arg0);
 		rtio_iodev_sqe_ok(iodev_sqe, 0);
 		break;
 	case RTIO_OP_DELAY:
@@ -59,7 +59,7 @@ static void rtio_executor_op(struct rtio_iodev_sqe *iodev_sqe)
  *
  * @param iodev_sqe Submission to work on
  */
-static inline void rtio_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
+static inline void rtio_iodev_submit(struct rtio_iodev_sqe *iodev_sqe, int last_result)
 {
 	if (FIELD_GET(RTIO_SQE_CANCELED, iodev_sqe->sqe.flags)) {
 		rtio_iodev_sqe_err(iodev_sqe, -ECANCELED);
@@ -68,7 +68,7 @@ static inline void rtio_iodev_submit(struct rtio_iodev_sqe *iodev_sqe)
 
 	/* No iodev means its an executor specific operation */
 	if (iodev_sqe->sqe.iodev == NULL) {
-		rtio_executor_op(iodev_sqe);
+		rtio_executor_op(iodev_sqe, last_result);
 		return;
 	}
 
@@ -135,7 +135,7 @@ void rtio_executor_submit(struct rtio *r)
 		curr->next = NULL;
 		curr->r = r;
 
-		rtio_iodev_submit(iodev_sqe);
+		rtio_iodev_submit(iodev_sqe, 0);
 
 		node = mpsc_pop(&r->sq);
 	}
@@ -193,12 +193,13 @@ static inline void rtio_executor_handle_multishot(struct rtio_iodev_sqe *iodev_s
  * @param[in] is_ok Whether or not the SQE's result was successful
  */
 static inline void rtio_executor_handle_oneshot(struct rtio_iodev_sqe *iodev_sqe,
-						int result, bool is_ok)
+						int last_result, bool is_ok)
 {
 	const bool is_canceled = FIELD_GET(RTIO_SQE_CANCELED, iodev_sqe->sqe.flags) == 1;
 	struct rtio_iodev_sqe *curr = iodev_sqe;
 	struct rtio *r = iodev_sqe->r;
 	uint32_t sqe_flags;
+	int result = last_result;
 
 	/** Single-shot items may be linked as transactions or be chained together.
 	 * Untangle the set of SQEs and act accordingly on each one.
@@ -226,7 +227,7 @@ static inline void rtio_executor_handle_oneshot(struct rtio_iodev_sqe *iodev_sqe
 
 	/* curr should now be the last sqe in the transaction if that is what completed */
 	if (FIELD_GET(RTIO_SQE_CHAINED, sqe_flags) == 1) {
-		rtio_iodev_submit(curr);
+		rtio_iodev_submit(curr, last_result);
 	}
 }
 


### PR DESCRIPTION
Callbacks now take a result parameter which may, if the callback was linked to by a previous submissions, have the result code from the first submission that failed.

Fixes #81014 