### PR TITLE
boards: nxp: Add arduino header definitions to multiple boards

### DIFF
--- a/boards/nxp/frdm_ke15z/frdm_ke15z.dts
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.dts
@@ -58,6 +58,35 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
+			   <1 0 &gpioa 1 0>,	/* A1 */
+			   <2 0 &gpioa 6 0>,	/* A2 */
+			   <3 0 &gpioa 7 0>,	/* A3 */
+			   <4 0 &gpioa 2 0>,	/* A4 */
+			   <5 0 &gpioa 3 0>,	/* A5 */
+			   <6 0 &gpioc 8 0>,	/* D0 */
+			   <7 0 &gpioc 9 0>,	/* D1 */
+			   <8 0 &gpiod 12 0>,	/* D2 */
+			   <9 0 &gpioc 15 0>,	/* D3 */
+			   <10 0 &gpioe 9 0>,	/* D4 */
+			   <11 0 &gpioc 5 0>,	/* D5 */
+			   <12 0 &gpioa 16 0>,	/* D6 */
+			   <13 0 &gpioa 17 0>,	/* D7 */
+			   <14 0 &gpioe 8 0>,	/* D8 */
+			   <15 0 &gpioe 7 0>,	/* D9 */
+			   <16 0 &gpioa 15 0>,	/* D10 */
+			   <17 0 &gpioe 2 0>,	/* D11 */
+			   <18 0 &gpioe 1 0>,	/* D12 */
+			   <19 0 &gpioe 0 0>,	/* D13 */
+			   <20 0 &gpiod 8 0>,	/* D14 */
+			   <21 0 &gpiod 9 0>;	/* D15 */
+	};
 };
 
 &lpuart1 {

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -82,6 +82,35 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioc 17 0>,	/* A0 */
+			   <1 0 &gpioc 16 0>,	/* A1 */
+			   <2 0 &gpiod 16 0>,	/* A2 */
+			   <3 0 &gpiod 15 0>,	/* A3 */
+			   <4 0 &gpioa 1 0>,	/* A4 */
+			   <5 0 &gpioa 0 0>,	/* A5 */
+			   <6 0 &gpiod 17 0>,	/* D0 */
+			   <7 0 &gpioe 12 0>,	/* D1 */
+			   <8 0 &gpiod 8 0>,	/* D2 */
+			   <9 0 &gpiod 9 0>,	/* D3 */
+			   <10 0 &gpioc 14 0>,	/* D4 */
+			   <11 0 &gpioa 15 0>,	/* D5 */
+			   <12 0 &gpioa 17 0>,	/* D6 */
+			   <13 0 &gpioa 14 0>,	/* D7 */
+			   <14 0 &gpioe 11 0>,	/* D8 */
+			   <15 0 &gpiob 11 0>,	/* D9 */
+			   <16 0 &gpiob 5 0>,	/* D10 */
+			   <17 0 &gpiob 4 0>,	/* D11 */
+			   <18 0 &gpiob 3 0>,	/* D12 */
+			   <19 0 &gpiob 2 0>,	/* D13 */
+			   <20 0 &gpioa 16 0>,	/* D14 */
+			   <21 0 &gpiob 8 0>;	/* D15 */
+	};
 };
 
 &idle {

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -82,6 +82,35 @@
 			zephyr,code = <INPUT_KEY_1>;
 		};
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
+			   <1 0 &gpioc 1 0>,	/* A1 */
+			   <2 0 &gpiob 4 0>,	/* A2 */
+			   <3 0 &gpioe 3 0>,	/* A3 */
+			   <4 0 &gpioc 16 0>,	/* A4 */
+			   <5 0 &gpioc 17 0>,	/* A5 */
+			   <6 0 &gpioc 6 0>,	/* D0 */
+			   <7 0 &gpioc 7 0>,	/* D1 */
+			   <8 0 &gpiob 9 0>,	/* D2 */
+			   <9 0 &gpioe 4 0>,	/* D3 */
+			   <10 0 &gpioc 14 0>,	/* D4 */
+			   <11 0 &gpioa 15 0>,	/* D5 */
+			   <12 0 &gpioa 17 0>,	/* D6 */
+			   <13 0 &gpioa 14 0>,	/* D7 */
+			   <14 0 &gpioa 9 0>,	/* D8 */
+			   <15 0 &gpiob 11 0>,	/* D9 */
+			   <16 0 &gpioe 6 0>,	/* D10 */
+			   <17 0 &gpioe 2 0>,	/* D11 */
+			   <18 0 &gpioe 1 0>,	/* D12 */
+			   <19 0 &gpioe 0 0>,	/* D13 */
+			   <20 0 &gpioa 2 0>,	/* D14 */
+			   <21 0 &gpioa 3 0>;	/* D15 */
+	};
 };
 
 &idle {

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -80,6 +80,35 @@
 				<10  0 &gpio3 22 0>,	/* Pin 10, LCD backlight control */
 				<11  0 &gpio3 0 0>;	/* Pin 11, LCD and touch reset */
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio1 10 0>,	/* A0 */
+			   <1 0 &gpio2 5 0>,	/* A1 */
+			   <2 0 &gpio2 3 0>,	/* A2 */
+			   <3 0 &gpio2 4 0>,	/* A3 */
+			   <4 0 &gpio1 12 0>,	/* A4 */
+			   <5 0 &gpio1 13 0>,	/* A5 */
+			   <6 0 &gpio2 11 0>,	/* D0 */
+			   <7 0 &gpio2 10 0>,	/* D1 */
+			   <8 0 &gpio3 1 0>,	/* D2 */
+			   <9 0 &gpio3 12 0>,	/* D3 */
+			   <10 0 &gpio3 31 0>,	/* D4 */
+			   <11 0 &gpio3 14 0>,	/* D5 */
+			   <12 0 &gpio3 16 0>,	/* D6 */
+			   <13 0 &gpio1 14 0>,	/* D7 */
+			   <14 0 &gpio1 15 0>,	/* D8 */
+			   <15 0 &gpio3 17 0>,	/* D9 */
+			   <16 0 &gpio3 13 0>,	/* D10 */
+			   <17 0 &gpio3 15 0>,	/* D11 */
+			   <18 0 &gpio2 16 0>,	/* D12 */
+			   <19 0 &gpio2 12 0>,	/* D13 */
+			   <20 0 &gpio0 16 0>,	/* D14 */
+			   <21 0 &gpio0 17 0>;	/* D15 */
+	};
 };
 
 &gpio0 {

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -29,6 +29,35 @@
 		pwm-0 = &flexpwm1_pwm0;
 		rtc = &rtc;
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio4 6 0>,	/* A0 */
+			   <1 0 &gpio4 15 0>,	/* A1 */
+			   <2 0 &gpio4 16 0>,	/* A2 */
+			   <3 0 &gpio4 17 0>,	/* A3 */
+			   <4 0 &gpio4 12 0>,	/* A4 */
+			   <5 0 &gpio4 13 0>,	/* A5 */
+			   <6 0 &gpio4 3 0>,	/* D0 */
+			   <7 0 &gpio4 2 0>,	/* D1 */
+			   <8 0 &gpio2 0 0>,	/* D2 */
+			   <9 0 &gpio3 12 0>,	/* D3 */
+			   <10 0 &gpio0 21 0>,	/* D4 */
+			   <11 0 &gpio2 7 0>,	/* D5 */
+			   <12 0 &gpio3 17 0>,	/* D6 */
+			   <13 0 &gpio0 22 0>,	/* D7 */
+			   <14 0 &gpio0 23 0>,	/* D8 */
+			   <15 0 &gpio3 14 0>,	/* D9 */
+			   <16 0 &gpio1 3 0>,	/* D10 */
+			   <17 0 &gpio1 0 0>,	/* D11 */
+			   <18 0 &gpio1 2 0>,	/* D12 */
+			   <19 0 &gpio1 1 0>,	/* D13 */
+			   <20 0 &gpio1 16 0>,	/* D14 */
+			   <21 0 &gpio1 17 0>;	/* D15 */
+	};
 };
 
 &sram0 {

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -67,6 +67,15 @@
 				<10  0 &gpio4 5 0>,	/* Pin 10, LCD backlight control */
 				<11  0 &gpio4 7 0>;	/* Pin 11, LCD and touch reset */
 	};
+
+	dvp_20pin_connector: dvp-20pin-connector {
+		compatible = "arducam,dvp-20pin-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
+		gpio-map =	<DVP_20PIN_PEN 0 &gpio1 19 0>,
+				<DVP_20PIN_PDN 0 &gpio1 18 0>;
+	};
 };
 
 &flexcomm1_lpspi1 {
@@ -281,21 +290,6 @@ zephyr_mipi_dbi_parallel: &flexio0_lcd {
 &sc_timer {
 	pinctrl-0 = <&pinmux_sctimer>;
 	pinctrl-names = "default";
-};
-
-/*
- * Connection with camera modules such as the dvp_20pin_ov7670 shield
- */
-
-/ {
-	dvp_20pin_connector: dvp-20pin-connector {
-		compatible = "arducam,dvp-20pin-connector";
-		#gpio-cells = <2>;
-		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0x0 GPIO_DT_FLAGS_MASK>;
-		gpio-map =	<DVP_20PIN_PEN 0 &gpio1 19 0>,
-				<DVP_20PIN_PDN 0 &gpio1 18 0>;
-	};
 };
 
 dvp_20pin_i2c: &flexcomm7_lpi2c7 {};

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -55,6 +55,33 @@
 		};
 	};
 
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <2 0 &gpio0 14 0>,	/* A2 */
+			   <3 0 &gpio0 22 0>,	/* A3 */
+			   <4 0 &gpio0 15 0>,	/* A4 */
+			   <5 0 &gpio0 23 0>,	/* A5 */
+			   <6 0 &gpio4 3 0>,	/* D0 */
+			   <7 0 &gpio4 2 0>,	/* D1 */
+			   <8 0 &gpio0 29 0>,	/* D2 */
+			   <9 0 &gpio1 23 0>,	/* D3 */
+			   <10 0 &gpio0 30 0>,	/* D4 */
+			   <11 0 &gpio1 21 0>,	/* D5 */
+			   <12 0 &gpio1 2 0>,	/* D6 */
+			   <13 0 &gpio0 31 0>,	/* D7 */
+			   <14 0 &gpio0 28 0>,	/* D8 */
+			   <15 0 &gpio0 10 0>,	/* D9 */
+			   <16 0 &gpio0 27 0>,	/* D10 */
+			   <17 0 &gpio0 24 0>,	/* D11 */
+			   <18 0 &gpio0 26 0>,	/* D12 */
+			   <19 0 &gpio0 25 0>,	/* D13 */
+			   <20 0 &gpio4 0 0>,	/* D14 */
+			   <21 0 &gpio4 1 0>;	/* D15 */
+	};
+
 	/*
 	 * This node describes the GPIO pins of the LCD-PAR-S035 panel 8080 interface.
 	 */

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -62,6 +62,35 @@
 			status = "okay";
 		};
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpiod 1 0>,	/* A0 */
+			   <1 0 &gpiod 2 0>,	/* A1 */
+			   <2 0 &gpiod 3 0>,	/* A2 */
+			   <3 0 &gpioa 4 0>,	/* A3 */
+			   <4 0 &gpioc 3 0>,	/* A4 */
+			   <5 0 &gpioc 2 0>,	/* A5 */
+			   <6 0 &gpioa 16 0>,	/* D0 */
+			   <7 0 &gpioa 17 0>,	/* D1 */
+			   <8 0 &gpioc 4 0>,	/* D2 */
+			   <9 0 &gpioc 5 0>,	/* D3 */
+			   <10 0 &gpioa 19 0>,	/* D4 */
+			   <11 0 &gpioc 1 0>,	/* D5 */
+			   <12 0 &gpioa 20 0>,	/* D6 */
+			   <13 0 &gpioa 21 0>,	/* D7 */
+			   <14 0 &gpioc 4 0>,	/* D8 */
+			   <15 0 &gpioa 18 0>,	/* D9 */
+			   <16 0 &gpiob 0 0>,	/* D10 */
+			   <17 0 &gpiob 3 0>,	/* D11 */
+			   <18 0 &gpiob 1 0>,	/* D12 */
+			   <19 0 &gpiob 2 0>,	/* D13 */
+			   <20 0 &gpiob 4 0>,	/* D14 */
+			   <21 0 &gpiob 5 0>;	/* D15 */
+	};
 };
 
 &vref {

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.dts
@@ -61,6 +61,35 @@
 			status = "okay";
 		};
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpiod 1 0>,	/* A0 */
+			   <1 0 &gpiod 2 0>,	/* A1 */
+			   <2 0 &gpiod 3 0>,	/* A2 */
+			   <3 0 &gpioa 4 0>,	/* A3 */
+			   <4 0 &gpioc 3 0>,	/* A4 */
+			   <5 0 &gpioc 2 0>,	/* A5 */
+			   <6 0 &gpioa 16 0>,	/* D0 */
+			   <7 0 &gpioa 17 0>,	/* D1 */
+			   <8 0 &gpioc 4 0>,	/* D2 */
+			   <9 0 &gpioc 5 0>,	/* D3 */
+			   <10 0 &gpioa 19 0>,	/* D4 */
+			   <11 0 &gpioc 1 0>,	/* D5 */
+			   <12 0 &gpioa 20 0>,	/* D6 */
+			   <13 0 &gpioa 21 0>,	/* D7 */
+			   <14 0 &gpioc 4 0>,	/* D8 */
+			   <15 0 &gpioa 18 0>,	/* D9 */
+			   <16 0 &gpiob 0 0>,	/* D10 */
+			   <17 0 &gpiob 3 0>,	/* D11 */
+			   <18 0 &gpiob 1 0>,	/* D12 */
+			   <19 0 &gpiob 2 0>,	/* D13 */
+			   <20 0 &gpiob 4 0>,	/* D14 */
+			   <21 0 &gpiob 5 0>;	/* D15 */
+	};
 };
 
 &gpioa {

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -55,6 +55,32 @@
 		gpio-map = <10  0 &hsgpio1 12 0>,  /* Pin 10, LCD and touch reset */
 			   <12  0 &hsgpio0 18 0>;  /* Pin 11, LCD touch INT */
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &hsgpio1 10 0>,	/* A0 */
+			   <1 0 &hsgpio1 11 0>,	/* A1 */
+			   <2 0 &hsgpio1 13 0>,	/* A2 */
+			   <6 0 &hsgpio0 9 0>,		/* D0 */
+			   <7 0 &hsgpio0 8 0>,		/* D1 */
+			   <8 0 &hsgpio0 11 0>,		/* D2 */
+			   <9 0 &hsgpio0 15 0>,		/* D3 */
+			   <10 0 &hsgpio0 18 0>,	/* D4 */
+			   <11 0 &hsgpio0 27 0>,	/* D5 */
+			   <12 0 &hsgpio0 0 0>,		/* D6 */
+			   <13 0 &hsgpio0 20 0>,	/* D7 */
+			   <14 0 &hsgpio1 18 0>,	/* D8 */
+			   <15 0 &hsgpio1 20 0>,	/* D9 */
+			   <16 0 &hsgpio0 6 0>,		/* D10 */
+			   <17 0 &hsgpio0 9 0>,		/* D11 */
+			   <18 0 &hsgpio0 8 0>,		/* D12 */
+			   <19 0 &hsgpio0 7 0>,		/* D13 */
+			   <20 0 &hsgpio0 16 0>,	/* D14 */
+			   <21 0 &hsgpio0 17 0>;	/* D15 */
+	};
 };
 
 &flexcomm3 {

--- a/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.dts
@@ -61,6 +61,35 @@
 			status = "okay";
 		};
 	};
+
+	arduino_header: arduino-connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpiod 1 0>,	/* A0 */
+			   <1 0 &gpiod 2 0>,	/* A1 */
+			   <2 0 &gpiod 3 0>,	/* A2 */
+			   <3 0 &gpioa 4 0>,	/* A3 */
+			   <4 0 &gpioc 3 0>,	/* A4 */
+			   <5 0 &gpioc 2 0>,	/* A5 */
+			   <6 0 &gpioa 16 0>,	/* D0 */
+			   <7 0 &gpioa 17 0>,	/* D1 */
+			   <8 0 &gpioc 4 0>,	/* D2 */
+			   <9 0 &gpioc 5 0>,	/* D3 */
+			   <10 0 &gpioa 19 0>,	/* D4 */
+			   <11 0 &gpioc 1 0>,	/* D5 */
+			   <12 0 &gpioa 20 0>,	/* D6 */
+			   <13 0 &gpioa 21 0>,	/* D7 */
+			   <14 0 &gpioc 4 0>,	/* D8 */
+			   <15 0 &gpioa 18 0>,	/* D9 */
+			   <16 0 &gpiob 0 0>,	/* D10 */
+			   <17 0 &gpiob 3 0>,	/* D11 */
+			   <18 0 &gpiob 1 0>,	/* D12 */
+			   <19 0 &gpiob 2 0>,	/* D13 */
+			   <20 0 &gpiob 4 0>,	/* D14 */
+			   <21 0 &gpiob 5 0>;	/* D15 */
+	};
 };
 
 &gpioa {


### PR DESCRIPTION
Most of the NXP boards are missing arduino header definitions. I am adding them here for the boards I already have schematics of, but still many left are missing it when it should be present.