### PR TITLE
shell: exchange k_mutex for k_sem

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -963,7 +963,7 @@ struct shell_ctx {
 
 	struct k_event signal_event;
 
-	struct k_mutex wr_mtx;
+	struct k_sem lock_sem;
 	k_tid_t tid;
 	int ret_val;
 };

--- a/subsys/shell/shell_log_backend.c
+++ b/subsys/shell/shell_log_backend.c
@@ -181,7 +181,7 @@ static void process_log_msg(const struct shell *sh,
 		if (k_is_in_isr()) {
 			key = irq_lock();
 		} else {
-			k_mutex_lock(&sh->ctx->wr_mtx, K_FOREVER);
+			z_shell_lock(sh);
 		}
 		if (!z_flag_cmd_ctx_get(sh)) {
 			z_shell_cmd_line_erase(sh);
@@ -197,7 +197,7 @@ static void process_log_msg(const struct shell *sh,
 		if (k_is_in_isr()) {
 			irq_unlock(key);
 		} else {
-			k_mutex_unlock(&sh->ctx->wr_mtx);
+			z_shell_unlock(sh);
 		}
 	}
 }

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -381,6 +381,21 @@ void z_shell_vfprintf(const struct shell *sh, enum shell_vt100_color color,
  */
 void z_shell_backend_rx_buffer_flush(const struct shell *sh);
 
+static inline bool z_shell_trylock(const struct shell *sh, k_timeout_t timeout)
+{
+	return k_sem_take(&sh->ctx->lock_sem, timeout) == 0;
+}
+
+static inline void z_shell_lock(const struct shell *sh)
+{
+	(void)k_sem_take(&sh->ctx->lock_sem, K_FOREVER);
+}
+
+static inline void z_shell_unlock(const struct shell *sh)
+{
+	k_sem_give(&sh->ctx->lock_sem);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The mutex is being used as a simple binary semaphore. It is not
recursed so we don't need to track thread ownership nor lock count.

Exchange the mutex for a binary semaphore to save resources and
speed up shell.

Building the shell test suite for nrf54l15 using k_mutex:

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       71592 B      1428 KB      4.90%
             RAM:        9872 B       188 KB      5.13%
        IDT_LIST:          0 GB        32 KB      0.00%
```

using k_sem:

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       70204 B      1428 KB      4.80%
             RAM:        9864 B       188 KB      5.12%
        IDT_LIST:          0 GB        32 KB      0.00%
```