### PR TITLE
ci: assigner: Use zephyrbot token

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Run assignment script
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ZB_PR_ASSIGNER_GITHUB_TOKEN }}
       run: |
         FLAGS="-v"
         FLAGS+=" -o ${{ github.event.repository.owner.login }}"

--- a/.github/workflows/maintainer_check.yml
+++ b/.github/workflows/maintainer_check.yml
@@ -1,7 +1,7 @@
 name: Maintainer file check
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
@@ -37,7 +37,7 @@ jobs:
 
       - name: Check maintainer file changes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ZB_PR_ASSIGNER_GITHUB_TOKEN }}
         run: |
           python  ./scripts/ci/check_maintainer_changes.py  \
             --repo zephyrproject-rtos/zephyr mainline_MAINTAINERS.yml MAINTAINERS.yml


### PR DESCRIPTION
This commit updates the pull request assigner workflow to use the zephyrbot
token instead of the workflow token.

Note that the workflow token, by design, cannot access the
organisation-level user membership information, and may cause the assigner
script to return `Skip 'user': not in collaborators` even for valid
collaborators.

In addition, the maintainer check with the same problem is also updated to use the same token.