### PR TITLE
drivers: flash: stm32_qspi: Fix configuration & erase in dual-flash mode

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -395,7 +395,7 @@ static int qspi_read_sfdp(const struct device *dev, off_t addr, void *data,
 
 	LOG_INF("Reading SFDP");
 
-#if DT_PROP(DT_NODELABEL(quadspi), dual_flash) && defined(QUADSPI_CR_DFM)
+#if STM32_QSPI_DOUBLE_FLASH
 	/*
 	 * In dual flash mode, reading the SFDP table would cause the parameters from both flash
 	 * memories to be read (first byte read would be the first SFDP byte from the first flash,
@@ -406,7 +406,7 @@ static int qspi_read_sfdp(const struct device *dev, off_t addr, void *data,
 	 */
 	MODIFY_REG(dev_data->hqspi.Instance->CR, QUADSPI_CR_DFM, QSPI_DUALFLASH_DISABLE);
 	LOG_DBG("Dual flash mode disabled while reading SFDP");
-#endif /* dual_flash */
+#endif /* STM32_QSPI_DOUBLE_FLASH */
 
 	QSPI_CommandTypeDef cmd = {
 		.Instruction = JESD216_CMD_READ_SFDP,
@@ -438,7 +438,7 @@ static int qspi_read_sfdp(const struct device *dev, off_t addr, void *data,
 	dev_data->cmd_status = 0;
 
 end:
-#if DT_PROP(DT_NODELABEL(quadspi), dual_flash) && defined(QUADSPI_CR_DFM)
+#if STM32_QSPI_DOUBLE_FLASH
 	/* Re-enable the dual flash mode */
 	MODIFY_REG(dev_data->hqspi.Instance->CR, QUADSPI_CR_DFM, QSPI_DUALFLASH_ENABLE);
 #endif /* dual_flash */
@@ -1551,7 +1551,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	dev_data->hqspi.Init.ClockPrescaler = prescaler;
 	/* Give a bit position from 0 to 31 to the HAL init minus 1 for the DCR1 reg */
 	dev_data->hqspi.Init.FlashSize = find_lsb_set(dev_cfg->flash_size) - 2;
-#if DT_PROP(DT_NODELABEL(quadspi), dual_flash) && defined(QUADSPI_CR_DFM)
+#if STM32_QSPI_DOUBLE_FLASH
 	dev_data->hqspi.Init.SampleShifting = QSPI_SAMPLE_SHIFTING_HALFCYCLE;
 	dev_data->hqspi.Init.ChipSelectHighTime = QSPI_CS_HIGH_TIME_3_CYCLE;
 	dev_data->hqspi.Init.DualFlash = QSPI_DUALFLASH_ENABLE;
@@ -1566,7 +1566,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	 * is disabled.
 	 */
 	dev_data->hqspi.Init.FlashID = QSPI_FLASH_ID_1;
-#endif /* dual_flash */
+#endif /* STM32_QSPI_DOUBLE_FLASH */
 
 	HAL_QSPI_Init(&dev_data->hqspi);
 

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1192,7 +1192,7 @@ static int setup_pages_layout(const struct device *dev)
 		return -ENOTSUP;
 	}
 
-	uint32_t erase_size = BIT(exp) << STM32_QSPI_DOUBLE_FLASH;
+	uint32_t erase_size = BIT(exp);
 
 	/* We need layout page size to be compatible with erase size */
 	if ((layout_page_size % erase_size) != 0) {
@@ -1364,6 +1364,13 @@ static int spi_nor_process_bfp(const struct device *dev,
 	memset(data->erase_types, 0, sizeof(data->erase_types));
 	for (uint8_t ti = 1; ti <= ARRAY_SIZE(data->erase_types); ++ti) {
 		if (jesd216_bfp_erase(bfp, ti, etp) == 0) {
+			/* In dual-flash mode, the erase size is doubled since each erase operation
+			 * is executed on both flash memories.
+			 */
+			if (IS_ENABLED(STM32_QSPI_DOUBLE_FLASH)) {
+				etp->exp++;
+			}
+
 			LOG_DBG("Erase %u with %02x",
 					(uint32_t)BIT(etp->exp), etp->cmd);
 		}

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -23,11 +23,15 @@
 #define SPI_FLASH_TEST_REGION_OFFSET 0x7F000
 #elif defined(CONFIG_BOARD_EK_RA8M1) || defined(CONFIG_BOARD_EK_RA8D1)
 #define SPI_FLASH_TEST_REGION_OFFSET 0x40000
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_qspi_nor) && DT_PROP(DT_NODELABEL(quadspi), dual_flash)
+#define SPI_FLASH_TEST_REGION_OFFSET 0xfe000
 #else
 #define SPI_FLASH_TEST_REGION_OFFSET 0xff000
 #endif
 #if defined(CONFIG_BOARD_EK_RA8M1) || defined(CONFIG_BOARD_EK_RA8D1)
 #define SPI_FLASH_SECTOR_SIZE 262144
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_qspi_nor) && DT_PROP(DT_NODELABEL(quadspi), dual_flash)
+#define SPI_FLASH_SECTOR_SIZE 8192
 #else
 #define SPI_FLASH_SECTOR_SIZE        4096
 #endif


### PR DESCRIPTION
When dual-flash mode is enabled, two identical flash memories are connected to the QUADSPI peripheral and are accessed in parallel. This means in particular that:
* Both flash memories must be configured the same way, so any write performed to the status register of a given flash memory must also be performed for the other flash memory.
* When performing a program or erase operation, the flash driver must wait for the operation to complete on both flash memories by polling both status registers.
* Page and erase size are doubled.

That was not properly handled by the QSPI flash driver, which might lead to errors when reading, erasing or programming data. In particular, this fixes #93153.

The changes were tested on a STM32H747I-DISCO board, in both single- and dual-flash configuration. It was ensured that the `drivers/spi_flash` sample runs without errors and that the status register can be properly read/written.