### PR TITLE
net: gptp: fix comparsion of stepsRemoved

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -1661,8 +1661,8 @@ static int compute_best_vector(void)
 				continue;
 			}
 
-			tmp = (int)challenger->steps_removed -
-				((int)ntohs(best_vector->steps_removed) + 1);
+			tmp = (int)(challenger->steps_removed + 1) -
+				(int)ntohs(best_vector->steps_removed);
 			if (tmp < 0) {
 				best_vector = challenger;
 				best_port = port;

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -1411,6 +1411,7 @@ static void copy_priority_vector(struct gptp_priority_vector *vector,
 	memcpy(&vector->src_port_id, &hdr->port_id,
 	       sizeof(struct gptp_port_identity));
 
+	vector->steps_removed = announce->steps_removed;
 	vector->port_number = htons(port);
 }
 


### PR DESCRIPTION
The original implementation selects the port as best_port when its stepsRemoved value is equal to that of the best_vector.
However, according to IEEE 802.1AS, a port is considered superior to another if its stepsRemoved value is less than that of the other port.
This fix https://github.com/zephyrproject-rtos/zephyr/issues/93180#issuecomment-3077716703.