### PR TITLE
Bluetooth: host: a2dp: Fix stream recv callback not be checked

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -283,6 +283,11 @@ static void bt_a2dp_media_data_callback(struct bt_avdtp_sep *sep, struct net_buf
 	stream = ep->stream;
 	media_hdr = net_buf_pull_mem(buf, sizeof(*media_hdr));
 
+	if (stream->ops == NULL || stream->ops->recv == NULL) {
+		LOG_WRN("No recv callback registered for stream");
+		return;
+	}
+
 	stream->ops->recv(stream, buf, sys_be16_to_cpu(media_hdr->sequence_number),
 			  sys_be32_to_cpu(media_hdr->time_stamp));
 }


### PR DESCRIPTION
Now when role is sink and source sends data, stream recv callback is not registered, apps works fail. so stream recv callback should be checked.