### PR TITLE
edtlib: Add the `binding_type` property to the Binding class

### DIFF
--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -159,6 +159,9 @@ class Binding:
     raw:
       The binding as an object parsed from YAML.
 
+    binding_type:
+      The type of device described by the binding.
+
     bus:
       If nodes with this binding's 'compatible' describe a bus, a string
       describing the bus type (like "i2c") or a list describing supported
@@ -234,6 +237,11 @@ class Binding:
         # inherited child binding definitions, so it has to be done
         # before initializing those.
         self.raw: dict = self._merge_includes(raw, self.path)
+
+        if path is not None:
+            type_match = re.search(r'dts/bindings/(\w+)',
+                                   str(path).replace('\\', '/'))
+            self.binding_type: str = type_match.group(1) if type_match else 'unknown'
 
         # Recursively initialize any child bindings. These don't
         # require a 'compatible', 'description' or 'title' to be well


### PR DESCRIPTION
Used to retrieve the type of device described by the binding, the device type follows `dts/bindings/<device_type>`.

```
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\can\kvaser,pcican.yaml can
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\cpu\intel,x86.yaml cpu
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\ethernet\intel,e1000.yaml ethernet
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\flash_controller\zephyr,sim-flash.yaml flash_controller
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\ieee802154\zephyr,ieee802154-uart-pipe.yaml ieee802154
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\interrupt-controller\intel,ioapic.yaml interrupt
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\interrupt-controller\intel,loapic.yaml interrupt
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\mtd\fixed-partitions.yaml mtd
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\mtd\fixed-partitions.yaml mtd
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\mtd\soc-nv-flash.yaml mtd
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\mtd\zephyr,emu-eeprom.yaml mtd
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\mtd\zephyr,sim-eeprom.yaml mtd
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\pcie\host\pcie-controller.yaml pcie
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\rtc\motorola,mc146818.yaml rtc
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\serial\ns16550.yaml serial
D:/Code/github/zephyr/zephyr-test/zephyr/dts/bindings\timer\intel,hpet.yaml timer
```

And they are in `binding-types.txt`