### PR TITLE
net: connection: Unconditionally forward packets when handling packet sockets

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -637,16 +637,14 @@ out:
 #endif /* defined(CONFIG_NET_SOCKETS_PACKET) || defined(CONFIG_NET_SOCKETS_INET_RAW) */
 
 #if defined(CONFIG_NET_SOCKETS_PACKET)
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
+void net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
 {
-	bool raw_sock_found = false;
-	bool raw_pkt_continue = false;
 	struct sockaddr_ll *local;
 	struct net_conn *conn;
 
 	/* Only accept input with AF_PACKET family. */
 	if (net_pkt_family(pkt) != AF_PACKET) {
-		return NET_CONTINUE;
+		return;
 	}
 
 	NET_DBG("Check proto 0x%04x listener for pkt %p family %d",
@@ -666,33 +664,22 @@ enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum
 		 * in this packet.
 		 */
 		if (conn->family != AF_PACKET) {
-			raw_pkt_continue = true;
 			continue; /* wrong family */
 		}
 
-		if (conn->type == SOCK_DGRAM && type == SOCK_RAW) {
-			/* If DGRAM packet sockets are present, we shall continue
-			 * with this packet regardless the result.
-			 */
-			raw_pkt_continue = true;
-			continue; /* L2 not processed yet */
-		}
-
-		if (conn->type == SOCK_RAW && type != SOCK_RAW) {
-			continue; /* L2 already processed */
+		if (conn->type != type) {
+			continue;
 		}
 
 		if (conn->proto == 0) {
 			continue; /* Local proto 0 doesn't forward any packets */
 		}
 
-		if (conn->proto != proto) {
-			/* Allow proto mismatch if socket was created with ETH_P_ALL, or it's raw
-			 * packet socket input (proto ETH_P_ALL).
-			 */
-			if (conn->proto != ETH_P_ALL && proto != ETH_P_ALL) {
-				continue; /* wrong protocol */
-			}
+		/* Allow proto mismatch if socket was created with ETH_P_ALL, or it's raw
+		 * packet socket input.
+		 */
+		if (conn->proto != proto && conn->proto != ETH_P_ALL && type != SOCK_RAW) {
+			continue; /* wrong protocol */
 		}
 
 		/* Apply protocol-specific matching criteria... */
@@ -708,32 +695,17 @@ enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum
 
 		conn_raw_socket_deliver(pkt, conn, false);
 
-		raw_sock_found = true;
 	}
 
 	k_mutex_unlock(&conn_lock);
 
-	if (!raw_pkt_continue && raw_sock_found) {
-		/* As one or more raw socket packets have already been delivered
-		 * in the loop above, report NET_OK.
-		 */
-		net_pkt_unref(pkt);
-		return NET_OK;
-	}
-
-	/* When there is open connection different than AF_PACKET this
-	 * packet shall be also handled in the upper net stack layers.
-	 */
-	return NET_CONTINUE;
 }
 #else
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
+void net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
 {
 	ARG_UNUSED(pkt);
 	ARG_UNUSED(proto);
 	ARG_UNUSED(type);
-
-	return NET_CONTINUE;
 }
 #endif /* defined(CONFIG_NET_SOCKETS_PACKET) */
 

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -191,12 +191,10 @@ int net_conn_update(struct net_conn_handle *handle,
  * @param proto LL protocol for the connection
  * @param type socket type
  *
- * @return NET_OK if the packet was consumed, NET_CONTINUE if the packet should
- * be processed further in the stack.
  */
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt,
-				       uint16_t proto,
-				       enum net_sock_type type);
+void net_conn_packet_input(struct net_pkt *pkt,
+			   uint16_t proto,
+			   enum net_sock_type type);
 
 /**
  * @brief Called by net_core.c when an IP packet is received

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -71,10 +71,7 @@ static inline enum net_verdict process_data(struct net_pkt *pkt)
 {
 	int ret;
 
-	ret = net_packet_socket_input(pkt, ETH_P_ALL, SOCK_RAW);
-	if (ret != NET_CONTINUE) {
-		return ret;
-	}
+	net_packet_socket_input(pkt, ETH_P_ALL, SOCK_RAW);
 
 	/* If there is no data, then drop the packet. */
 	if (!pkt->frags) {
@@ -104,10 +101,7 @@ static inline enum net_verdict process_data(struct net_pkt *pkt)
 	net_pkt_cursor_init(pkt);
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET_DGRAM)) {
-		ret = net_packet_socket_input(pkt, net_pkt_ll_proto_type(pkt), SOCK_DGRAM);
-		if (ret != NET_CONTINUE) {
-			return ret;
-		}
+		net_packet_socket_input(pkt, net_pkt_ll_proto_type(pkt), SOCK_DGRAM);
 	}
 
 	uint8_t family = net_pkt_family(pkt);

--- a/subsys/net/ip/packet_socket.c
+++ b/subsys/net/ip/packet_socket.c
@@ -22,12 +22,11 @@ LOG_MODULE_REGISTER(net_sockets_raw, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "connection.h"
 #include "packet_socket.h"
 
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
+void net_packet_socket_input(struct net_pkt *pkt,
 					 uint16_t proto,
 					 enum net_sock_type type)
 {
 	sa_family_t orig_family;
-	enum net_verdict net_verdict;
 
 #if defined(CONFIG_NET_DSA_DEPRECATED)
 	/*
@@ -35,7 +34,7 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
 	 * lan1..3 are working with them.
 	 */
 	if (dsa_is_port_master(net_pkt_iface(pkt))) {
-		return NET_CONTINUE;
+		return;
 	}
 #endif
 
@@ -43,9 +42,7 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
 
 	net_pkt_set_family(pkt, AF_PACKET);
 
-	net_verdict = net_conn_packet_input(pkt, proto, type);
+	net_conn_packet_input(pkt, proto, type);
 
 	net_pkt_set_family(pkt, orig_family);
-
-	return net_verdict;
 }

--- a/subsys/net/ip/packet_socket.h
+++ b/subsys/net/ip/packet_socket.h
@@ -20,21 +20,14 @@
  *
  * @param pkt Network packet
  *
- * @return NET_OK if the packet was consumed, NET_DROP if
- * the packet parsing failed and the caller should handle
- * the received packet. If corresponding IP protocol support is
- * disabled, the function will always return NET_DROP.
  */
 #if defined(CONFIG_NET_SOCKETS_PACKET)
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
-					 uint16_t proto,
-					 enum net_sock_type type);
+void net_packet_socket_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type);
 #else
-static inline enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
-						       uint16_t proto,
-						       enum net_sock_type type)
+static inline void net_packet_socket_input(struct net_pkt *pkt,
+					   uint16_t proto,
+					   enum net_sock_type type)
 {
-	return NET_CONTINUE;
 }
 #endif
 


### PR DESCRIPTION
When handling packets for inputing into raw-packet-sockets, unconditionally
forward them to upper layer, so that it can be handled by L2-handlers.

Based on: https://github.com/zephyrproject-rtos/zephyr/pull/93050
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/93245