### PR TITLE
scripts: ci: check_compliance: Capture failing tests

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -2182,6 +2182,8 @@ def _main(args):
             test.run()
         except EndTest:
             pass
+        except BaseException:
+            test.failure(f"An exception occurred in {test.name}:\n{traceback.format_exc()}")
 
         # Annotate if required
         if args.annotate:


### PR DESCRIPTION
If a compliance test itself throws an exception, the entire script is aborted.
Update this by capturing the exception and failing only the test itself.