### PR TITLE
Improvements on lan865x macphy and microchip t1s phy drivers

### DIFF
--- a/drivers/ethernet/Kconfig.lan865x
+++ b/drivers/ethernet/Kconfig.lan865x
@@ -21,7 +21,7 @@ if ETH_LAN865X
 
 config ETH_LAN865X_INIT_PRIORITY
 	int "LAN865X driver init priority"
-	default 72
+	default 50
 	help
 	  LAN865X device driver initialization priority.
 	  Must be initialized after SPI.

--- a/drivers/ethernet/eth_lan865x.c
+++ b/drivers/ethernet/eth_lan865x.c
@@ -478,7 +478,7 @@ static const struct ethernet_api lan865x_api_func = {
 		.tc6 = &oa_tc6_##inst};                                                            \
                                                                                                    \
 	ETH_NET_DEVICE_DT_INST_DEFINE(inst, lan865x_init, NULL, &lan865x_data_##inst,              \
-				      &lan865x_config_##inst, CONFIG_ETH_INIT_PRIORITY,            \
+				      &lan865x_config_##inst, CONFIG_ETH_LAN865X_INIT_PRIORITY,    \
 				      &lan865x_api_func, NET_ETH_MTU);
 
 DT_INST_FOREACH_STATUS_OKAY(LAN865X_DEFINE);

--- a/drivers/ethernet/phy/Kconfig.microchip_t1s
+++ b/drivers/ethernet/phy/Kconfig.microchip_t1s
@@ -1,7 +1,7 @@
 # Copyright 2025 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig PHY_MICROCHIP_T1S
+config PHY_MICROCHIP_T1S
 	bool "Microchip 10BASE-T1S Ethernet PHYs Driver"
 	default y
 	depends on DT_HAS_MICROCHIP_T1S_PHY_ENABLED
@@ -10,13 +10,3 @@ menuconfig PHY_MICROCHIP_T1S
 	help
 	  Enable Microchip's LAN8650/1 Rev.B0/B1 Internal PHYs and
 	  LAN8670/1/2 Rev.C1/C2 PHYs Driver.
-
-if PHY_MICROCHIP_T1S
-
-config PHY_MICROCHIP_T1S_INIT_PRIORITY
-	int "Microchip T1S PHY init priority"
-	default 82
-	help
-	  Microchip T1S phy device driver initialization priority.
-
-endif

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -551,6 +551,6 @@ static DEVICE_API(ethphy, mc_t1s_phy_api) = {
 	static struct mc_t1s_data mc_t1s_##n##_data;                                               \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, &phy_mc_t1s_init, NULL, &mc_t1s_##n##_data, &mc_t1s_##n##_config, \
-			      POST_KERNEL, CONFIG_PHY_MICROCHIP_T1S_INIT_PRIORITY, &mc_t1s_phy_api);
+			      POST_KERNEL, CONFIG_PHY_INIT_PRIORITY, &mc_t1s_phy_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MICROCHIP_T1S_PHY_INIT);

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -107,18 +107,32 @@ struct mc_t1s_data {
 static int phy_mc_t1s_read(const struct device *dev, uint16_t reg, uint32_t *data)
 {
 	const struct mc_t1s_config *cfg = dev->config;
+	int ret;
 
 	/* Make sure excessive bits 16-31 are reset */
 	*data = 0U;
 
-	return mdio_read(cfg->mdio, cfg->phy_addr, reg, (uint16_t *)data);
+	mdio_bus_enable(cfg->mdio);
+
+	ret = mdio_read(cfg->mdio, cfg->phy_addr, reg, (uint16_t *)data);
+
+	mdio_bus_disable(cfg->mdio);
+
+	return ret;
 }
 
 static int phy_mc_t1s_write(const struct device *dev, uint16_t reg, uint32_t data)
 {
 	const struct mc_t1s_config *cfg = dev->config;
+	int ret;
 
-	return mdio_write(cfg->mdio, cfg->phy_addr, reg, (uint16_t)data);
+	mdio_bus_enable(cfg->mdio);
+
+	ret = mdio_write(cfg->mdio, cfg->phy_addr, reg, (uint16_t)data);
+
+	mdio_bus_disable(cfg->mdio);
+
+	return ret;
 }
 
 static int mdio_setup_c45_indirect_access(const struct device *dev, uint16_t devad, uint16_t reg)
@@ -150,13 +164,20 @@ static int phy_mc_t1s_c45_read(const struct device *dev, uint8_t devad, uint16_t
 		return mdio_read_c45(cfg->mdio, cfg->phy_addr, devad, reg, val);
 	}
 
+	mdio_bus_enable(cfg->mdio);
+
 	/* Read C45 registers using C22 indirect access registers */
 	ret = mdio_setup_c45_indirect_access(dev, devad, reg);
 	if (ret) {
+		mdio_bus_disable(cfg->mdio);
 		return ret;
 	}
 
-	return mdio_read(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
+	ret = mdio_read(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
+
+	mdio_bus_disable(cfg->mdio);
+
+	return ret;
 }
 
 static int phy_mc_t1s_c45_write(const struct device *dev, uint8_t devad, uint16_t reg, uint16_t val)
@@ -170,13 +191,20 @@ static int phy_mc_t1s_c45_write(const struct device *dev, uint8_t devad, uint16_
 		return mdio_write_c45(cfg->mdio, cfg->phy_addr, devad, reg, val);
 	}
 
+	mdio_bus_enable(cfg->mdio);
+
 	/* Write C45 registers using C22 indirect access registers */
 	ret = mdio_setup_c45_indirect_access(dev, devad, reg);
 	if (ret) {
+		mdio_bus_disable(cfg->mdio);
 		return ret;
 	}
 
-	return mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
+	ret = mdio_write(cfg->mdio, cfg->phy_addr, MII_MMD_AADR, val);
+
+	mdio_bus_disable(cfg->mdio);
+
+	return ret;
 }
 
 static int phy_mc_t1s_get_link(const struct device *dev, struct phy_link_state *state)

--- a/drivers/ethernet/phy/phy_microchip_t1s.c
+++ b/drivers/ethernet/phy/phy_microchip_t1s.c
@@ -254,6 +254,7 @@ static void phy_monitor_work_handler(struct k_work *work)
 	const struct device *dev = data->dev;
 
 	if (!data->cb) {
+		k_work_reschedule(&data->phy_monitor_work, K_MSEC(CONFIG_PHY_MONITOR_PERIOD));
 		return;
 	}
 

--- a/drivers/mdio/Kconfig.lan865x
+++ b/drivers/mdio/Kconfig.lan865x
@@ -1,20 +1,10 @@
 # Copyright 2024 Microchip Technology Inc
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig MDIO_LAN865X
+config MDIO_LAN865X
 	bool "LAN865X MDIO driver"
 	default y
 	depends on DT_HAS_MICROCHIP_LAN865X_MDIO_ENABLED
 	depends on ETH_LAN865X
 	help
 	  Enable LAN865X MDIO driver.
-
-if MDIO_LAN865X
-
-config MDIO_LAN865X_INIT_PRIORITY
-	int "LAN865X MDIO init priority"
-	default 81
-	help
-	  LAN865X MDIO device driver initialization priority.
-
-endif

--- a/drivers/mdio/mdio_lan865x.c
+++ b/drivers/mdio/mdio_lan865x.c
@@ -64,6 +64,6 @@ static DEVICE_API(mdio, mdio_lan865x_api) = {
 		.dev = DEVICE_DT_GET(DT_INST_PARENT(n)),                                           \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(n, NULL, NULL, NULL, &mdio_lan865x_config_##n, POST_KERNEL,          \
-			      CONFIG_MDIO_LAN865X_INIT_PRIORITY, &mdio_lan865x_api);
+			      CONFIG_MDIO_INIT_PRIORITY, &mdio_lan865x_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MICROCHIP_LAN865X_MDIO_INIT)


### PR DESCRIPTION
Pull Request: LAN865x & microchip_t1s PHY Driver Improvements

Overview:
This pull request introduces several improvements and bug fixes to the LAN865x Ethernet driver and the microchip_t1s PHY driver, enhancing initialization reliability, register access correctness, MDIO bus handling, and PHY monitoring. These changes were validated using the evb-lan8670-rmii (external LAN8670 PHY) on the SAME54 Curiosity Ultra platform.

Summary of Changes:
1. Align LAN865x Driver Initialization Priority

- The LAN865x driver’s module initialization priority is now aligned with the default priorities of MDIO and PHY drivers in Zephyr.

- This ensures the correct initialization sequence, especially when using the microchip_t1s PHY driver with both internal (LAN865x) and external (LAN867x) PHYs.

- The eth_lan865x driver now uses a specific priority to guarantee proper order, while microchip_t1s retains the Zephyr default for compatibility with multiple MAC drivers.

2. Fix C45 Register Access in microchip_t1s PHY Driver

- Direct C45 register access is now restricted to the LAN865x internal PHY.

- The LAN867x external PHY only supports C45 registers via indirect access through C22 registers, preventing incorrect register operations.

- Ensure Proper MDIO Bus Handling

3. Added missing calls to mdio_bus_enable() and mdio_bus_disable() during clause 22 register read/write operations in the microchip_t1s driver.

- This change ensures correct MDIO bus management, preventing potential communication issues.

4. Always Reschedule PHY Monitor Work

- The PHY monitor work handler now always reschedules itself, even if the callback is not set.
- This prevents the periodic monitoring from stopping unexpectedly, ensuring consistent PHY state monitoring.

Testing:
All changes were tested on the SAME54 Curiosity Ultra platform with the evb-lan8670-rmii board, confirming improved initialization, correct register access, reliable MDIO bus handling, and robust PHY monitoring.

Motivation:
These fixes address observed issues with initialization order, register access, and monitoring reliability when using Microchip’s T1S PHYs in various configurations, improving overall driver robustness and compatibility.

