### PR TITLE
scripts: west: runners: stm32cubeprogrammer: fix possible dl_file usage before assignment

### DIFF
--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -270,6 +270,8 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             self.check_call(cmd + ["--erase", "all"])
 
         # Define binary to be loaded
+        dl_file = None
+
         if self._use_elf:
             # Use elf file if instructed to do so.
             dl_file = self.cfg.elf_file


### PR DESCRIPTION
Initialize `dl_file` to `None` before the logic that determines which binary file to load.

Resolves the E0606 Pylint warning - "_Possibly using variable 'dl_file' before assignment (possibly-used-before-assignment_".
