### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -310,7 +310,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 4eba8087fa606db801455f14d185255bc8c49467
+      revision: 461e060e8687c9a75074effcc61d7f68c5112cfd
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  461e060e8687c9a75074effcc61d7f68c5112cfd

Brings following Zephyr relevant fixes:

  - 461e060e zephyr: Improve SHA support selectors
  - b9ba2573 boot: zephyr: kconfig: Default to swap using offset
  - cc8f6aff boot: zephyr: Set prefer swap using move for aligned boards
  - 37bc4aa4 zephyr: boards: nrf54h20dk: disable power domains
  - 5a728be9 boot: zephyr: Add support for Cortex-R cleanup before final jump
  - 83e2f934 boot: zephyr: Add Cortex-R support
  - c136f4a8 boot: zephyr: Remove references to tinycrypt
  - 3bf79cbc boot: zephyr: Remove support for deprecated LED dts
  - 3e02536f boot: bootutil: declare fih_panic_loop() as noreturn
  - 5eaf190a boot: zephyr: RAM cleanup debug loop
  - ecf01da3 zephyr: Add zephyr samples folder to list of samples
  - 724a7514 boot: zephyr: boards: Reformat DTS files
  - f9db0194 bootutil: Unify app_max_size() implementations
  - 6ea7add6 zephyr: Remove legacy flash_area_get_sectors
  - 7271062e boot: zephyr: boards: Remove outdated nrf54l15pdk board config
  - 5ce11a3b zephyr: boards: nrf - remove redundant multithreading configuration
  - fa4ca87a mbedtls: Move local mbedtls to v3.6.0
  - a736efa7 boot: zephyr: add support for revert mode with ramload
  - 61c5547b boot: zephyr: add ram_load overlays for nrf52840dk and mimxrt1050_evk boards

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.