### PR TITLE
boards: silabs: siwx91x: expose real layout of the flash

### DIFF
--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -101,13 +101,13 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		code_partition: partition@0 {
-			reg = <0x0000000 DT_SIZE_K(2008)>;
+		code_partition: partition@202000 {
+			reg = <0x00202000 DT_SIZE_K(2008)>;
 			label = "code_partition";
 		};
 
-		storage_partition: partition@1f6000 {
-			reg = <0x001f6000 DT_SIZE_K(32)>;
+		storage_partition: partition@3f8000 {
+			reg = <0x003f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
@@ -102,13 +102,13 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		code_partition: partition@0 {
-			reg = <0x0000000 DT_SIZE_K(2008)>;
+		code_partition: partition@202000 {
+			reg = <0x00202000 DT_SIZE_K(2008)>;
 			label = "code_partition";
 		};
 
-		storage_partition: partition@1f6000 {
-			reg = <0x001f6000 DT_SIZE_K(32)>;
+		storage_partition: partition@3f8000 {
+			reg = <0x003f8000 DT_SIZE_K(32)>;
 			label = "storage";
 		};
 	};

--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -109,7 +109,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			flash0: flash@8202000 {
+			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
 				write-block-size = <1>;
 				erase-block-size = <4096>;

--- a/dts/arm/silabs/siwg917m111mgtba.dtsi
+++ b/dts/arm/silabs/siwg917m111mgtba.dtsi
@@ -16,5 +16,57 @@
 };
 
 &flash0 {
-	reg = <0x08202000 DT_SIZE_K(2048-8)>;
+	reg = <0x08000000 DT_SIZE_M(8)>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* See AN1416: SiWx917 SoC Memory Map, 3.1.4 Memory Map (8 MB) */
+		mbr_nwp_partition: partition@0 {
+			label = "mbr_nwp";
+			reg = <0x0000000 DT_SIZE_K(68)>;
+		};
+
+		code_nwp_partition: partition@11000 {
+			label = "code_nwp";
+			reg = <0x00011000 DT_SIZE_K(1916)>;
+		};
+
+		mbr_partition: partition@1f0000 {
+			label = "mbr";
+			reg = <0x001f0000 DT_SIZE_K(68)>;
+		};
+
+		hdr_partition: partition@201000 {
+			label = "hdr";
+			reg = <0x00201000 DT_SIZE_K(4)>;
+		};
+
+		/* 0x00202000-0x00400000: Free space for Zephyr */
+
+		ota_swap_partition: partition@400000 {
+			/* During the upgrade process, this area will be copied to
+			 * 0x011000-0x400000
+			 */
+			label = "ota_swap";
+			reg = <0x00400000 DT_SIZE_K(3900)>;
+		};
+
+		storage_nwp_partition: partition@7cf000 {
+			label = "storage_nwp";
+			reg = <0x007cf000 DT_SIZE_K(160)>;
+		};
+
+		storage_shared_partition: partition@7f7000 {
+			label = "storage_shared";
+			reg = <0x007f7000 DT_SIZE_K(20)>;
+		};
+
+		backup_bootloader_partition: partition@7fc000 {
+			label = "backup_bootloader";
+			reg = <0x007fc000 DT_SIZE_K(16)>;
+		};
+	};
 };


### PR DESCRIPTION
The Network Coprocessor on SiWx91x owns a large part of the flash. Zephyr is not expected to access to theses areas.

However, it is still technically possible to access these. In addition, we prefer the DTS contains a comprehensive and transparent description of the hardware. So update the DTS with the real partitioning of the SoC.

Reference documentation is available [here][1].

[1]: https://www.silabs.com/documents/public/application-notes/an1416-siwx917-soc-memory-map.pdf