### PR TITLE
Bluetooth: ISO: Fix issue with BIS tx_complete

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1501,8 +1501,11 @@ void bt_conn_unref(struct bt_conn *conn)
 
 	old = atomic_dec(&conn->ref);
 	/* Prevent from accessing connection object */
-	conn = NULL;
 	deallocated = (atomic_get(&old) == 1);
+	IF_ENABLED(CONFIG_BT_CONN_TX,
+		   (__ASSERT(!(deallocated && k_work_is_pending(&conn->tx_complete_work)),
+			     "tx_complete_work is pending when conn is deallocated")));
+	conn = NULL;
 
 	LOG_DBG("handle %u ref %ld -> %ld", conn_handle, old, (old - 1));
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -511,6 +511,15 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 			}
 #endif /* CONFIG_BT_ISO_CENTRAL */
 		}
+	} else if (IS_ENABLED(CONFIG_BT_ISO_BROADCASTER) &&
+		   conn_type == BT_ISO_CHAN_TYPE_BROADCASTER) {
+		/* BIS do not get a HCI Disconnected event and will not handle cleanup of pending TX
+		 * complete in the same way as ACL and CIS do. Call bt_conn_tx_notify directly here
+		 * to flush the chan->iso->tx_complete for each disconnected BIS
+		 */
+		bt_conn_tx_notify(chan->iso, true);
+	} else {
+		/* No special handling for BT_ISO_CHAN_TYPE_SYNC_RECEIVER */
 	}
 }
 

--- a/tests/bluetooth/host/conn/mocks/kernel.c
+++ b/tests/bluetooth/host/conn/mocks/kernel.c
@@ -1,9 +1,12 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdbool.h>
+
+#include <zephyr/fff.h>
 #include <zephyr/kernel.h>
 
 #include "kernel.h"
@@ -22,6 +25,7 @@ DEFINE_FAKE_VALUE_FUNC(int, k_work_submit, struct k_work *);
 DEFINE_FAKE_VALUE_FUNC(int, k_work_submit_to_queue, struct k_work_q *, struct k_work *);
 DEFINE_FAKE_VALUE_FUNC(int, k_work_reschedule, struct k_work_delayable *, k_timeout_t);
 DEFINE_FAKE_VALUE_FUNC(int, k_work_schedule, struct k_work_delayable *, k_timeout_t);
+DEFINE_FAKE_VALUE_FUNC(int, k_work_busy_get, const struct k_work *);
 DEFINE_FAKE_VOID_FUNC(k_queue_init, struct k_queue *);
 DEFINE_FAKE_VOID_FUNC(k_queue_append, struct k_queue *, void *);
 DEFINE_FAKE_VALUE_FUNC(int, k_queue_is_empty, struct k_queue *);

--- a/tests/bluetooth/host/conn/mocks/kernel.h
+++ b/tests/bluetooth/host/conn/mocks/kernel.h
@@ -1,8 +1,9 @@
 /*
- * Copyright (c) 2024 Nordic Semiconductor ASA
+ * Copyright (c) 2024-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdbool.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/fff.h>
@@ -42,6 +43,7 @@ DECLARE_FAKE_VOID_FUNC(k_sem_give, struct k_sem *);
 DECLARE_FAKE_VALUE_FUNC(k_tid_t, k_sched_current_thread_query);
 DECLARE_FAKE_VOID_FUNC(k_work_init, struct k_work *, k_work_handler_t);
 DECLARE_FAKE_VOID_FUNC(k_work_init_delayable, struct k_work_delayable *, k_work_handler_t);
+DECLARE_FAKE_VALUE_FUNC(int, k_work_busy_get, const struct k_work *);
 DECLARE_FAKE_VALUE_FUNC(int, k_work_cancel_delayable, struct k_work_delayable *);
 DECLARE_FAKE_VALUE_FUNC(bool, k_work_flush, struct k_work *, struct k_work_sync *);
 DECLARE_FAKE_VALUE_FUNC(int, k_work_submit, struct k_work *);


### PR DESCRIPTION
BIS termination as broadcaster is handled different than ACL and CIS, and in rare chances the
tx_complete for BIS may not have been completed in the system workqueue before iso_new was called for the same bt_conn struct (e.g. via bt_iso_cig_create), which would perform

k_work_init(&conn->tx_complete_work, tx_complete_work);

but where conn->tx_complete_work still existed in
the system workqueue, which would cause the list
of pending items on the system workqueue to be removed as the `next` pointer would be NULL.

This also adds an assert in bt_conn_new to prevent this issue from appearing again.