### PR TITLE
kernel: Add assert for init'ing pending k_work

### DIFF
--- a/kernel/work.c
+++ b/kernel/work.c
@@ -16,6 +16,7 @@
 #include <zephyr/spinlock.h>
 #include <errno.h>
 #include <ksched.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/logging/log.h>
 
@@ -155,6 +156,7 @@ void k_work_init(struct k_work *work,
 {
 	__ASSERT_NO_MSG(work != NULL);
 	__ASSERT_NO_MSG(handler != NULL);
+	__ASSERT_NO_MSG(!k_work_is_pending(work));
 
 	*work = (struct k_work)Z_WORK_INITIALIZER(handler);
 
@@ -986,6 +988,7 @@ void k_work_init_delayable(struct k_work_delayable *dwork,
 {
 	__ASSERT_NO_MSG(dwork != NULL);
 	__ASSERT_NO_MSG(handler != NULL);
+	__ASSERT_NO_MSG(!k_work_delayable_is_pending(dwork));
 
 	*dwork = (struct k_work_delayable){
 		.work = {

--- a/tests/kernel/workq/work_queue/src/start_stop.c
+++ b/tests/kernel/workq/work_queue/src/start_stop.c
@@ -24,9 +24,9 @@ static void work_handler(struct k_work *work)
 ZTEST(workqueue_api, test_k_work_queue_start_stop)
 {
 	size_t i;
-	struct k_work work;
+	struct k_work work = {0};
 	struct k_work_q work_q = {0};
-	struct k_work works[NUM_TEST_ITEMS];
+	struct k_work works[NUM_TEST_ITEMS] = {0};
 	struct k_work_queue_config cfg = {
 		.name = "test_work_q",
 		.no_yield = true,
@@ -82,9 +82,9 @@ ZTEST(workqueue_api, test_k_work_queue_run_stop)
 	int rc;
 	size_t i;
 	struct k_thread thread;
-	struct k_work work;
+	struct k_work work = {0};
 	struct k_work_q work_q = {0};
-	struct k_work works[NUM_TEST_ITEMS];
+	struct k_work works[NUM_TEST_ITEMS] = {0};
 	struct k_sem ret_sem;
 
 	k_sem_init(&ret_sem, 0, 1);


### PR DESCRIPTION
Adds asserts for both k_work and k_work_delayable to prevent users from initializing work items that are currently pending.

If a workqueue has e.g. 3 items pending, A, B and C, and work item B is provided to k_work_init, then the workqueue becomes corrupt and items B and C will be removed from the queue.