### PR TITLE
drivers: ethernet: ksz8081: support 25MHz RMII configuration

### DIFF
--- a/drivers/ethernet/phy/phy_microchip_ksz8081.c
+++ b/drivers/ethernet/phy/phy_microchip_ksz8081.c
@@ -235,7 +235,7 @@ static int phy_mc_ksz8081_static_cfg(const struct device *dev)
 
 	omso &= ~PHY_MC_KSZ8081_OMSO_FACTORY_MODE_MASK &
 		~PHY_MC_KSZ8081_OMSO_NAND_TREE_MASK;
-	if (config->phy_iface == KSZ8081_RMII) {
+	if (config->phy_iface == KSZ8081_RMII || config->phy_iface == KSZ8081_RMII_25MHZ) {
 		omso &= ~PHY_MC_KSZ8081_OMSO_MII_OVERRIDE_MASK;
 		omso |= PHY_MC_KSZ8081_OMSO_RMII_OVERRIDE_MASK;
 	}


### PR DESCRIPTION
Configure KSZ8081 phy drivers to set strapping mode override for RMII mode without setting reference clock to 50MHz when "RMII 25MHz" operation is selected in device tree node.