### PR TITLE
modules: lvgl: add automatic lv_timer_handler call

### DIFF
--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -153,6 +153,31 @@ config LV_Z_INIT_PRIORITY
 	help
 	  Priority used for the automatic initialization of LVGL.
 
+config LV_Z_RUN_LVGL_ON_WORKQUEUE
+	bool "Use a dedicated workqueue to run LVGL's core"
+	imply LV_Z_AUTO_INIT
+	help
+	  Runs the LVGL in a separate workqueue automatically
+	  without requiring user to add a timed loop for that. User can
+	  disable this option if managing when to call lv_timer_handler
+	  is application responsibillity
+
+if LV_Z_RUN_LVGL_ON_WORKQUEUE
+
+config LV_Z_LVGL_WORKQUEUE_STACK_SIZE
+	int "Stack size of LVGL's workqueue"
+	default 4096
+	help
+	  Stack size of the LVGL's dedicated workqueue
+
+config LV_Z_LVGL_WORKQUEUE_PRIORITY
+	int "Priority of the LVGL's workqueue"
+	default 0
+	help
+	  Priority of the LVGL's dedicated workequeue.
+
+endif # LV_Z_RUN_LVGL_ON_WORKQUEUE
+
 config LV_USE_DRAW_DMA2D
 	bool
 

--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -154,27 +154,27 @@ config LV_Z_INIT_PRIORITY
 	  Priority used for the automatic initialization of LVGL.
 
 config LV_Z_RUN_LVGL_ON_WORKQUEUE
-	bool "Use a dedicated workqueue to run LVGL's core"
+	bool "Use a dedicated workqueue to run LVGL core"
 	imply LV_Z_AUTO_INIT
 	help
 	  Runs the LVGL in a separate workqueue automatically
 	  without requiring user to add a timed loop for that. User can
-	  disable this option if managing when to call lv_timer_handler
+	  disable this option if periodic calls of LV timer
 	  is application responsibillity
 
 if LV_Z_RUN_LVGL_ON_WORKQUEUE
 
 config LV_Z_LVGL_WORKQUEUE_STACK_SIZE
-	int "Stack size of LVGL's workqueue"
+	int "Stack size of LVGL workqueue"
 	default 4096
 	help
-	  Stack size of the LVGL's dedicated workqueue
+	  Stack size of the LVGL dedicated workqueue
 
 config LV_Z_LVGL_WORKQUEUE_PRIORITY
-	int "Priority of the LVGL's workqueue"
+	int "Priority of the LVGL workqueue"
 	default 0
 	help
-	  Priority of the LVGL's dedicated workequeue.
+	  Priority of the LVGL dedicated workequeue.
 
 endif # LV_Z_RUN_LVGL_ON_WORKQUEUE
 

--- a/modules/lvgl/include/lvgl_zephyr.h
+++ b/modules/lvgl/include/lvgl_zephyr.h
@@ -32,6 +32,20 @@ extern "C" {
  */
 int lvgl_init(void);
 
+#ifdef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
+/**
+ * @brief Gets the instance of LVGL's workqueue
+ *
+ * This function returns the workqueue instance used
+ * by LVGL core, allowing user to submit their own
+ * work items to it.
+ *
+ * @return pointer to LVGL's workqueue instance
+ */
+struct k_work_q *lvgl_get_workqueue(void);
+
+#endif /* CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE */
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -219,6 +219,27 @@ static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 }
 #endif /* CONFIG_LV_Z_BUFFER_ALLOC_STATIC */
 
+#ifdef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
+
+K_THREAD_STACK_DEFINE(lvgl_workqueue_stack, CONFIG_LV_Z_LVGL_WORKQUEUE_STACK_SIZE);
+static struct k_work_q lvgl_workqueue;
+
+static void lvgl_timer_handler_work(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	uint32_t wait_time = lv_timer_handler();
+
+	/*schedule next timer verification*/
+	if (wait_time == LV_NO_TIMER_READY) {
+		wait_time = CONFIG_LV_DEF_REFR_PERIOD;
+	}
+
+	k_work_schedule_for_queue(&lvgl_workqueue, dwork, K_MSEC(wait_time));
+}
+K_WORK_DEFINE(lvgl_work, lvgl_timer_handler_work);
+
+#endif /* CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE */
+
 void lv_mem_init(void)
 {
 #ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP
@@ -325,6 +346,15 @@ int lvgl_init(void)
 		LOG_ERR("Failed to initialize input devices.");
 		return err;
 	}
+
+#ifdef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
+	k_work_queue_init(&lvgl_workqueue);
+	k_work_queue_start(&lvgl_workqueue, lvgl_workqueue_stack,
+			   K_THREAD_STACK_SIZEOF(lvgl_workqueue_stack),
+			   CONFIG_LV_Z_LVGL_WORKQUEUE_PRIORITY, NULL);
+
+	k_work_submit_to_queue(&lvgl_workqueue, &lvgl_work);
+#endif
 
 	return 0;
 }

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -221,7 +221,7 @@ static int lvgl_allocate_rendering_buffers(lv_display_t *display)
 
 #ifdef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
 
-K_THREAD_STACK_DEFINE(lvgl_workqueue_stack, CONFIG_LV_Z_LVGL_WORKQUEUE_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(lvgl_workqueue_stack, CONFIG_LV_Z_LVGL_WORKQUEUE_STACK_SIZE);
 static struct k_work_q lvgl_workqueue;
 
 static void lvgl_timer_handler_work(struct k_work *work)
@@ -229,15 +229,19 @@ static void lvgl_timer_handler_work(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	uint32_t wait_time = lv_timer_handler();
 
-	/*schedule next timer verification*/
+	/* schedule next timer verification */
 	if (wait_time == LV_NO_TIMER_READY) {
 		wait_time = CONFIG_LV_DEF_REFR_PERIOD;
 	}
 
 	k_work_schedule_for_queue(&lvgl_workqueue, dwork, K_MSEC(wait_time));
 }
-K_WORK_DEFINE(lvgl_work, lvgl_timer_handler_work);
+static K_WORK_DELAYABLE_DEFINE(lvgl_work, lvgl_timer_handler_work);
 
+struct k_work_q *lvgl_get_workqueue(void)
+{
+	return &lvgl_workqueue;
+}
 #endif /* CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE */
 
 void lv_mem_init(void)
@@ -353,7 +357,7 @@ int lvgl_init(void)
 			   K_THREAD_STACK_SIZEOF(lvgl_workqueue_stack),
 			   CONFIG_LV_Z_LVGL_WORKQUEUE_PRIORITY, NULL);
 
-	k_work_submit_to_queue(&lvgl_workqueue, &lvgl_work);
+	k_work_submit_to_queue(&lvgl_workqueue, &lvgl_work.work);
 #endif
 
 	return 0;

--- a/samples/modules/lvgl/demos/sample.yaml
+++ b/samples/modules/lvgl/demos/sample.yaml
@@ -41,6 +41,13 @@ tests:
   sample.modules.lvgl.demo_render:
     extra_configs:
       - CONFIG_LV_Z_DEMO_RENDER=y
+  sample.modules.lvgl.demo_benchmark.lvgl_auto:
+    extra_configs:
+      - CONFIG_LV_Z_DEMO_BENCHMARK=y
+      - CONFIG_LV_USE_DEMO_WIDGETS=y
+      - CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE=y
+      - CONFIG_LV_Z_LVGL_WORKQUEUE_STACK_SIZE=8192
+      - CONFIG_LV_Z_LVGL_WORKQUEUE_PRIORITY=0
   sample.modules.lvgl.demos.st_b_lcd40_dsi1_mb1166:
     filter: dt_compat_enabled("orisetech,otm8009a")
     platform_allow: stm32h747i_disco/stm32h747xx/m7

--- a/samples/modules/lvgl/demos/src/main.c
+++ b/samples/modules/lvgl/demos/src/main.c
@@ -53,7 +53,10 @@ int main(void)
 #error Enable one of the demos CONFIG_LV_Z_DEMO_*
 #endif
 
+#ifndef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
 	lv_timer_handler();
+#endif
+
 	display_blanking_off(display_dev);
 #ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP
 	lvgl_print_heap_info(false);
@@ -61,9 +64,13 @@ int main(void)
 	printf("lvgl in malloc mode\n");
 #endif
 	while (1) {
+#ifndef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
 		uint32_t sleep_ms = lv_timer_handler();
-
 		k_msleep(MIN(sleep_ms, INT32_MAX));
+#else
+		/* LVGL managed by dedicated workqueue, just put an application side delay */
+		k_msleep(10);
+#endif
 #ifdef CONFIG_LV_Z_DEMO_RENDER_SCENE_DYNAMIC
 		if (sys_timepoint_expired(next_scene_switch)) {
 			cur_scene = (cur_scene + 1) % LV_DEMO_RENDER_SCENE_NUM;


### PR DESCRIPTION
inside of its own thread when user enable it on
the LVGL Zephyr options menu, using this option makes the calling of the lv_timer_handler driven by an internal timer and thread. Options like priority and stack size for this thread are exposed making it configurable by the application.

Worth to mention, this option is disbaled by default due the nature of the current samples of the LVGL that invokes lv_timer_handler from the application