### PR TITLE
net: ip: Fix the warning in the data path

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -262,8 +262,8 @@ static bool net_if_tx(struct net_if *iface, struct net_pkt *pkt)
 		status = net_if_l2(iface)->send(iface, pkt);
 		net_if_tx_unlock(iface);
 		if (status < 0) {
-			NET_WARN("iface %d pkt %p send failure status %d",
-				 net_if_get_by_iface(iface), pkt, status);
+			NET_WARN_RATELIMIT("iface %d pkt %p send failure status %d",
+				     net_if_get_by_iface(iface), pkt, status);
 		}
 
 		if (IS_ENABLED(CONFIG_NET_PKT_TXTIME_STATS) ||


### PR DESCRIPTION
Instead of warning for every-packet, warn only once and let user debug the underlying cause.

Fix #49845.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/93536