### PR TITLE
boards: arduino: nicla_vision: fix VL53L1X I2C address

### DIFF
--- a/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
+++ b/boards/arduino/nicla_vision/arduino_nicla_vision_stm32h747xx_m7.dts
@@ -108,9 +108,9 @@ zephyr_i2c: &i2c1 {
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;
 
-	vl53l1x: vl53l1x@52 {
+	vl53l1x: vl53l1x@29 {
 		compatible = "st,vl53l1x";
-		reg = <0x52>;
+		reg = <0x29>;
 		status = "okay";
 		xshut-gpios = <&gpiog 10 GPIO_ACTIVE_HIGH>;
 		int-gpios = <&gpiod 8 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
Nicla Vision datasheet is referring to the 8-bit wire address (0x52) for the VL53L1X sensor, so that's likely what ended up being used in the board's devicetree. However, it's the 7-bit I2C address that should be used so fix that by changing the I2C address to 0x29. Successfully tested on actual hardware.