### PR TITLE
doc: releases: clean up entry order

### DIFF
--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -100,24 +100,20 @@ Boards
 Device Drivers and Devicetree
 *****************************
 
-Devicetree
-==========
+Audio
+=====
 
-* Many of the vendor-specific and arch-specific files that were in dts/common have been moved
-  to more specific locations. Therefore, any dts files which ``#include <common/some_file.dtsi>``
-  a file from in the zephyr tree will need to be changed to just ``#include <some_file.dtsi>``.
+* The binding file for :dtcompatible:`cirrus,cs43l22` has been renamed to have a name
+  matching the compatible string.
 
-* Silicon Labs SoC-level dts files for Series 2 have been reorganized in subdirectories per device
-  superfamily. Therefore, any dts files for boards that use Series 2 SoCs will need to change their
-  include from ``#include <silabs/some_soc.dtsi>`` to ``#include <silabs/xg2[1-9]/some_soc.dtsi>``.
+Counter
+=======
 
-* The :c:macro:`DT_ENUM_HAS_VALUE` and :c:macro:`DT_INST_ENUM_HAS_VALUE` macros are now
-  checking all values, when used on an array, not just the first one.
-
-* Property names in devicetree and bindings use hyphens(``-``) as separators, and replacing
-  all previously used underscores(``_``). For local code, you can migrate property names in
-  bindings to use hyphens by running the ``scripts/utils/migrate_bindings_style.py`` script.
-
+* ``counter_native_posix`` has been renamed ``counter_native_sim``, and with it its
+  kconfig options and DT binding. :dtcompatible:`zephyr,native-posix-counter`  has been deprecated
+  in favor of :dtcompatible:`zephyr,native-sim-counter`.
+  And :kconfig:option:`CONFIG_COUNTER_NATIVE_POSIX` and its related options with
+  :kconfig:option:`CONFIG_COUNTER_NATIVE_SIM` (:github:`86616`).
 
 DAI
 ===
@@ -138,23 +134,23 @@ DMA
 * The binding files for Xilinx DMA controllers have been renamed to use the proper vendor prefix
   (``xlnx`` instead of ``xilinx``) and to match their compatible string.
 
-Regulator
-=========
+Devicetree
+==========
 
-* :dtcompatible:`nordic,npm1300-regulator` BUCK and LDO node GPIO properties are now specified as an
-  integer array without a GPIO controller, removing the requirement for a
-  :dtcompatible:`nordic,npm1300-gpio` node to be present and enabled for GPIO control of the output
-  rails. For example, ``enable-gpios = <&pmic_gpios 3 GPIO_ACTIVE_LOW>;`` is now specified as
-  ``enable-gpio-config = <3 GPIO_ACTIVE_LOW>;``.
+* Many of the vendor-specific and arch-specific files that were in dts/common have been moved
+  to more specific locations. Therefore, any dts files which ``#include <common/some_file.dtsi>``
+  a file from in the zephyr tree will need to be changed to just ``#include <some_file.dtsi>``.
 
-Counter
-=======
+* Silicon Labs SoC-level dts files for Series 2 have been reorganized in subdirectories per device
+  superfamily. Therefore, any dts files for boards that use Series 2 SoCs will need to change their
+  include from ``#include <silabs/some_soc.dtsi>`` to ``#include <silabs/xg2[1-9]/some_soc.dtsi>``.
 
-* ``counter_native_posix`` has been renamed ``counter_native_sim``, and with it its
-  kconfig options and DT binding. :dtcompatible:`zephyr,native-posix-counter`  has been deprecated
-  in favor of :dtcompatible:`zephyr,native-sim-counter`.
-  And :kconfig:option:`CONFIG_COUNTER_NATIVE_POSIX` and its related options with
-  :kconfig:option:`CONFIG_COUNTER_NATIVE_SIM` (:github:`86616`).
+* The :c:macro:`DT_ENUM_HAS_VALUE` and :c:macro:`DT_INST_ENUM_HAS_VALUE` macros are now
+  checking all values, when used on an array, not just the first one.
+
+* Property names in devicetree and bindings use hyphens(``-``) as separators, and replacing
+  all previously used underscores(``_``). For local code, you can migrate property names in
+  bindings to use hyphens by running the ``scripts/utils/migrate_bindings_style.py`` script.
 
 Display
 =======
@@ -164,6 +160,24 @@ Display
   the format expected by Zephyr. This change ensures proper behavior of both
   display and video capture samples.
 
+EEPROM
+========
+
+* :dtcompatible:`ti,tmp116-eeprom` has been renamed to :dtcompatible:`ti,tmp11x-eeprom` because it
+  supports both tmp117 and tmp119.
+
+Enhanced Serial Peripheral Interface (eSPI)
+===========================================
+
+* Renamed the devicetree property ``io_girq`` to ``io-girq``.
+* Renamed the devicetree property ``vw_girqs`` to ``vw-girqs``.
+* Renamed the devicetree property ``pc_girq`` to ``pc-girq``.
+* Renamed the devicetree property ``poll_timeout`` to ``poll-timeout``.
+* Renamed the devicetree property ``poll_interval`` to ``poll-interval``.
+* Renamed the devicetree property ``consec_rd_timeout`` to ``consec-rd-timeout``.
+* Renamed the devicetree property ``sus_chk_delay`` to ``sus-chk-delay``.
+* Renamed the devicetree property ``sus_rsm_interval`` to ``sus-rsm-interval``.
+
 Entropy
 =======
 
@@ -172,12 +186,6 @@ Entropy
   in favor of :dtcompatible:`zephyr,native-sim-rng`.
   And :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_POSIX` and its related options with
   :kconfig:option:`CONFIG_FAKE_ENTROPY_NATIVE_SIM` (:github:`86615`).
-
-Eeprom
-========
-
-* :dtcompatible:`ti,tmp116-eeprom` has been renamed to :dtcompatible:`ti,tmp11x-eeprom` because it
-  supports both tmp117 and tmp119.
 
 Ethernet
 ========
@@ -228,17 +236,24 @@ Ethernet
 * :c:func:`phy_configure_link` got a ``flags`` parameter. Set it to ``0`` to preserve the old
   behavior (:github:`91354`).
 
-Enhanced Serial Peripheral Interface (eSPI)
-===========================================
+Flash
+=====
 
-* Renamed the devicetree property ``io_girq`` to ``io-girq``.
-* Renamed the devicetree property ``vw_girqs`` to ``vw-girqs``.
-* Renamed the devicetree property ``pc_girq`` to ``pc-girq``.
-* Renamed the devicetree property ``poll_timeout`` to ``poll-timeout``.
-* Renamed the devicetree property ``poll_interval`` to ``poll-interval``.
-* Renamed the devicetree property ``consec_rd_timeout`` to ``consec-rd-timeout``.
-* Renamed the devicetree property ``sus_chk_delay`` to ``sus-chk-delay``.
-* Renamed the devicetree property ``sus_rsm_interval`` to ``sus-rsm-interval``.
+* Renamed the file from ``flash_hp_ra.h`` to ``soc_flash_renesas_ra_hp.h``.
+* Renamed the file from ``flash_hp_ra.c`` to ``soc_flash_renesas_ra_hp.c``.
+* Renamed the file from ``flash_hp_ra_ex_op.c`` to ``soc_flash_renesas_ra_hp_ex_op.c``.
+
+* The Flash HP Renesas RA dual bank mode Kconfig symbol :kconfig:option:`CONFIG_DUAL_BANK_MODE`
+  has been removed.
+* The Flash HP Renesas RA Kconfig symbol :kconfig:option:`CONFIG_RA_FLASH_HP`
+  has been renamed to :kconfig:option:`CONFIG_SOC_FLASH_RENESAS_RA_HP`.
+* The Flash HP Renesas RA write protect Kconfig symbol :kconfig:option:`CONFIG_FLASH_RA_WRITE_PROTECT`
+  has been renamed to :kconfig:option:`CONFIG_FLASH_RENESAS_RA_HP_WRITE_PROTECT`.
+
+* Separate the file ``renesas,ra-nv-flash.yaml`` into 2 files ``renesas,ra-nv-code-flash.yaml``
+  and ``renesas,ra-nv-data-flash.yaml``.
+* Separate the ``compatible`` from ``renesas,ra-nv-flash`` to :dtcompatible:`renesas,ra-nv-code-flash.yaml`
+  and :dtcompatible:`renesas,ra-nv-data-flash.yaml`.
 
 GPIO
 ====
@@ -277,6 +292,26 @@ MFD
 * Renamed ``CONFIG_MFD_NPM1300`` to :kconfig:option:`CONFIG_MFD_NPM13XX`,
   ``CONFIG_MFD_NPM1300_INIT_PRIORITY`` to :kconfig:option:`CONFIG_MFD_NPM13XX_INIT_PRIORITY`
 
+Misc
+====
+
+* Moved file ``drivers/memc/memc_nxp_flexram.h`` to
+  :zephyr_file:`include/zephyr/drivers/misc/flexram/nxp_flexram.h` so that the
+  file can be included using ``<zephyr/drivers/misc/flexram/nxp_flexram.h>``.
+  Modification to CMakeList.txt to use include this driver is no longer
+  required.
+* All memc_flexram_* namespaced things including kconfigs and C API
+  have been changed to just flexram_*.
+
+* Select ``CONFIG_ETHOS_U`` instead ``CONFIG_ARM_ETHOS_U`` to enable Ethos-U NPU driver.
+* Rename all configs that have prefix ``CONFIG_ARM_ETHOS_U_`` to ``CONFIG_ETHOS_U_``.
+
+Modem
+=====
+
+* Removed Kconfig option :kconfig:option:`CONFIG_MODEM_CELLULAR_CMUX_MAX_FRAME_SIZE` in favor of
+  :kconfig:option:`CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE` and :kconfig:option:`CONFIG_MODEM_CMUX_MTU`.
+
 Regulator
 =========
 
@@ -286,6 +321,22 @@ Regulator
 * Renamed ``CONFIG_REGULATOR_NPM1300`` to :kconfig:option:`CONFIG_REGULATOR_NPM13XX`,
   ``CONFIG_REGULATOR_NPM1300_COMMON_INIT_PRIORITY`` to :kconfig:option:`REGULATOR_NPM13XX_COMMON_INIT_PRIORITY`,
   ``CONFIG_REGULATOR_NPM1300_INIT_PRIORITY`` to :kconfig:option:`CONFIG_REGULATOR_NPM13XX_INIT_PRIORITY`
+* :dtcompatible:`nordic,npm1300-regulator` BUCK and LDO node GPIO properties are now specified as an
+  integer array without a GPIO controller, removing the requirement for a
+  :dtcompatible:`nordic,npm1300-gpio` node to be present and enabled for GPIO control of the output
+  rails. For example, ``enable-gpios = <&pmic_gpios 3 GPIO_ACTIVE_LOW>;`` is now specified as
+  ``enable-gpio-config = <3 GPIO_ACTIVE_LOW>;``.
+
+SPI
+===
+
+* Renamed ``CONFIG_SPI_MCUX_LPSPI`` to :kconfig:option:`CONFIG_SPI_NXP_LPSPI`,
+  and similar for any child configs for that driver, including
+  :kconfig:option:`CONFIG_SPI_NXP_LPSPI_DMA` and :kconfig:option:`CONFIG_SPI_NXP_LPSPI_CPU`.
+* Renamed the device tree property ``port_sel`` to ``port-sel``.
+* Renamed the device tree property ``chip_select`` to ``chip-select``.
+* The binding file for :dtcompatible:`andestech,atcspi200` has been renamed to have a name
+  matching the compatible string.
 
 Sensors
 =======
@@ -349,6 +400,12 @@ Serial
   nothing now. Instead users should instantiate as many :dtcompatible:`zephyr,native-pty-uart` nodes
   as native PTY UART instances they want. (:github:`86739`)
 
+Stepper
+=======
+
+* Refactored the ``stepper_enable(const struct device * dev, bool enable)`` function to
+  :c:func:`stepper_enable` & :c:func:`stepper_disable`.
+
 Timer
 =====
 
@@ -382,56 +439,57 @@ Timer
   the value for :kconfig:option:`CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC` instead of
   using a value: :github:`91296`
 
+Video
+=====
+
+* 8 bit RAW Bayer formats BGGR8 / GBRG8 / GRBG8 / RGGB8 have been renamed by adding
+  a S prefix in front:
+
+  ``VIDEO_PIX_FMT_BGGR8`` becomes :c:macro:`VIDEO_PIX_FMT_SBGGR8`
+  ``VIDEO_PIX_FMT_GBRG8`` becomes :c:macro:`VIDEO_PIX_FMT_SGBRG8`
+  ``VIDEO_PIX_FMT_GRBG8`` becomes :c:macro:`VIDEO_PIX_FMT_SGRBG8`
+  ``VIDEO_PIX_FMT_RGGB8`` becomes :c:macro:`VIDEO_PIX_FMT_SRGGB8`
+
+* On STM32 devices, the DCMI driver (:dtcompatible:`st,stm32-dcmi`) now relies on endpoint based
+  video-interfaces.yaml bindings for sensor interface properties (such as bus width and
+  synchronization signals).
+  Also the ``capture-rate`` property has been replaced by the usage of the frame interval API
+  :c:func:`video_set_frmival`.
+  See (:github:`89627`).
+
+* :c:enum:`video_endpoint_id` has been dropped. It is no longer a parameter in any video API.
+
+* :c:enum:`video_buf_type` has been added. It is a required parameter in the following video APIs:
+  :c:func:`set_stream`, :c:func:`video_stream_start`, :c:func:`video_stream_stop`
+
+* ``video_format.pitch`` has been updated to be set explicitly by the driver, a task formerly
+  required by the application. This update enables the application to correctly allocate a buffer
+  size on a per driver basis. Existing applications will not be broken by this change but can be
+  simplified as performed in the sample in the commit ``33dcbe37cfd3593e8c6e9cfd218dd31fdd533598``.
+
+* Samples and projects using the :ref:`native simulator <native_sim>` now require specifying the
+  ``--snippet`` :ref:`video-sw-generator <snippet-video-sw-generator>` to build correctly.
+
+* :c:func:`video_query_ctrl` now takes a single argument with the :c:struct:`video_ctrl_query`,
+  which now contains a ``video_ctrl_query.dev`` field to specify and read back which device is
+  being queried (:github:`91265`).
+
 Watchdog
 ========
 * Renamed ``CONFIG_WDT_NPM1300`` to :kconfig:option:`CONFIG_WDT_NPM13XX`,
   ``CONFIG_WDT_NPM1300_INIT_PRIORITY`` to :kconfig:option:`CONFIG_WDT_NPM13XX_INIT_PRIORITY`
 
-Modem
-=====
+qSPI/oSPI/xSPI
+==============
 
-* Removed Kconfig option :kconfig:option:`CONFIG_MODEM_CELLULAR_CMUX_MAX_FRAME_SIZE` in favor of
-  :kconfig:option:`CONFIG_MODEM_CMUX_WORK_BUFFER_SIZE` and :kconfig:option:`CONFIG_MODEM_CMUX_MTU`.
+* On STM32 devices, external memories device tree descriptions for size and address are now split
+  in two separate properties to comply with specification recommendations.
 
-Flash
-=====
+  For instance, following external flash description ``reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits /``
+  is changed to ``reg = <0>;`` ``size = <DT_SIZE_M(512)>; / 512 Mbits */``.
 
-* Renamed the file from ``flash_hp_ra.h`` to ``soc_flash_renesas_ra_hp.h``.
-* Renamed the file from ``flash_hp_ra.c`` to ``soc_flash_renesas_ra_hp.c``.
-* Renamed the file from ``flash_hp_ra_ex_op.c`` to ``soc_flash_renesas_ra_hp_ex_op.c``.
-
-* The Flash HP Renesas RA dual bank mode Kconfig symbol :kconfig:option:`CONFIG_DUAL_BANK_MODE`
-  has been removed.
-* The Flash HP Renesas RA Kconfig symbol :kconfig:option:`CONFIG_RA_FLASH_HP`
-  has been renamed to :kconfig:option:`CONFIG_SOC_FLASH_RENESAS_RA_HP`.
-* The Flash HP Renesas RA write protect Kconfig symbol :kconfig:option:`CONFIG_FLASH_RA_WRITE_PROTECT`
-  has been renamed to :kconfig:option:`CONFIG_FLASH_RENESAS_RA_HP_WRITE_PROTECT`.
-
-* Separate the file ``renesas,ra-nv-flash.yaml`` into 2 files ``renesas,ra-nv-code-flash.yaml``
-  and ``renesas,ra-nv-data-flash.yaml``.
-* Separate the ``compatible`` from ``renesas,ra-nv-flash`` to :dtcompatible:`renesas,ra-nv-code-flash.yaml`
-  and :dtcompatible:`renesas,ra-nv-data-flash.yaml`.
-
-
-Stepper
-=======
-
-* Refactored the ``stepper_enable(const struct device * dev, bool enable)`` function to
-  :c:func:`stepper_enable` & :c:func:`stepper_disable`.
-
-Misc
-====
-
-* Moved file ``drivers/memc/memc_nxp_flexram.h`` to
-  :zephyr_file:`include/zephyr/drivers/misc/flexram/nxp_flexram.h` so that the
-  file can be included using ``<zephyr/drivers/misc/flexram/nxp_flexram.h>``.
-  Modification to CMakeList.txt to use include this driver is no longer
-  required.
-* All memc_flexram_* namespaced things including kconfigs and C API
-  have been changed to just flexram_*.
-
-* Select ``CONFIG_ETHOS_U`` instead ``CONFIG_ARM_ETHOS_U`` to enable Ethos-U NPU driver.
-* Rename all configs that have prefix ``CONFIG_ARM_ETHOS_U_`` to ``CONFIG_ETHOS_U_``.
+  Note that the property gives the actual size of the memory device in bits.
+  Previous mapping address information is now described in xspi, ospi or qspi nodes at SoC dtsi level.
 
 Bluetooth
 *********
@@ -447,6 +505,13 @@ Bluetooth Audio
 
 * ``BT_AUDIO_CONTEXT_TYPE_PROHIBITED`` has been renamed to
   :c:enumerator:`BT_AUDIO_CONTEXT_TYPE_NONE`. (:github:`89506`)
+
+Bluetooth Classic
+=================
+
+* The parameters of HFP AG callback ``sco_disconnected`` of the struct :c:struct:`bt_hfp_ag_cb`
+  have been changed to SCO connection object ``struct bt_conn *sco_conn`` and the disconnection
+  reason of the SCO connection ``uint8_t reason``.
 
 Bluetooth HCI
 =============
@@ -484,13 +549,6 @@ Bluetooth Host
 
 * The ``CONFIG_BT_ISO_TX_FRAG_COUNT`` Kconfig option was removed as it was completely unused.
   Any uses of it can simply be removed. (:github:`89836`)
-
-Bluetooth Classic
-=================
-
-* The parameters of HFP AG callback ``sco_disconnected`` of the struct :c:struct:`bt_hfp_ag_cb`
-  have been changed to SCO connection object ``struct bt_conn *sco_conn`` and the disconnection
-  reason of the SCO connection ``uint8_t reason``.
 
 Networking
 **********
@@ -680,80 +738,17 @@ OpenThread
   * You can now use OpenThread directly, without enabling Zephyr's L2 or IEEE802.15.4 layers, if
     your use case allows.
 
-SPI
-===
-
-* Renamed ``CONFIG_SPI_MCUX_LPSPI`` to :kconfig:option:`CONFIG_SPI_NXP_LPSPI`,
-  and similar for any child configs for that driver, including
-  :kconfig:option:`CONFIG_SPI_NXP_LPSPI_DMA` and :kconfig:option:`CONFIG_SPI_NXP_LPSPI_CPU`.
-* Renamed the device tree property ``port_sel`` to ``port-sel``.
-* Renamed the device tree property ``chip_select`` to ``chip-select``.
-* The binding file for :dtcompatible:`andestech,atcspi200` has been renamed to have a name
-  matching the compatible string.
-
-
-qSPI/oSPI/xSPI
-==============
-
-* On STM32 devices, external memories device tree descriptions for size and address are now split
-  in two separate properties to comply with specification recommendations.
-
-  For instance, following external flash description ``reg = <0x70000000 DT_SIZE_M(64)>; /* 512 Mbits /``
-  is changed to ``reg = <0>;`` ``size = <DT_SIZE_M(512)>; / 512 Mbits */``.
-
-  Note that the property gives the actual size of the memory device in bits.
-  Previous mapping address information is now described in xspi, ospi or qspi nodes at SoC dtsi level.
-
-Video
-=====
-
-* 8 bit RAW Bayer formats BGGR8 / GBRG8 / GRBG8 / RGGB8 have been renamed by adding
-  a S prefix in front:
-
-  ``VIDEO_PIX_FMT_BGGR8`` becomes :c:macro:`VIDEO_PIX_FMT_SBGGR8`
-  ``VIDEO_PIX_FMT_GBRG8`` becomes :c:macro:`VIDEO_PIX_FMT_SGBRG8`
-  ``VIDEO_PIX_FMT_GRBG8`` becomes :c:macro:`VIDEO_PIX_FMT_SGRBG8`
-  ``VIDEO_PIX_FMT_RGGB8`` becomes :c:macro:`VIDEO_PIX_FMT_SRGGB8`
-
-* On STM32 devices, the DCMI driver (:dtcompatible:`st,stm32-dcmi`) now relies on endpoint based
-  video-interfaces.yaml bindings for sensor interface properties (such as bus width and
-  synchronization signals).
-  Also the ``capture-rate`` property has been replaced by the usage of the frame interval API
-  :c:func:`video_set_frmival`.
-  See (:github:`89627`).
-
-* :c:enum:`video_endpoint_id` has been dropped. It is no longer a parameter in any video API.
-
-* :c:enum:`video_buf_type` has been added. It is a required parameter in the following video APIs:
-  :c:func:`set_stream`, :c:func:`video_stream_start`, :c:func:`video_stream_stop`
-
-* ``video_format.pitch`` has been updated to be set explicitly by the driver, a task formerly
-  required by the application. This update enables the application to correctly allocate a buffer
-  size on a per driver basis. Existing applications will not be broken by this change but can be
-  simplified as performed in the sample in the commit ``33dcbe37cfd3593e8c6e9cfd218dd31fdd533598``.
-
-* Samples and projects using the :ref:`native simulator <native_sim>` now require specifying the
-  ``--snippet`` :ref:`video-sw-generator <snippet-video-sw-generator>` to build correctly.
-
-* :c:func:`video_query_ctrl` now takes a single argument with the :c:struct:`video_ctrl_query`,
-  which now contains a ``video_ctrl_query.dev`` field to specify and read back which device is
-  being queried (:github:`91265`).
-
-Audio
-=====
-
-* The binding file for :dtcompatible:`cirrus,cs43l22` has been renamed to have a name
-  matching the compatible string.
 
 Other subsystems
 ****************
 
-hawkBit
-=======
+Modbus
+======
 
-* When :kconfig:option:`CONFIG_HAWKBIT_CUSTOM_DEVICE_ID` is enabled, device_id will no longer
-  be prepended with :kconfig:option:`CONFIG_BOARD`. It is the user's responsibility to write a
-  callback that prepends the board name if needed.
+* The ``client_stop_bits`` field in :c:struct:`modbus_serial_param` has been renamed into ``stop_bits``.
+  The setting is valid in both client and server modes.
+* Custom stop-bit settings are disabled by default and should be enabled
+  by :kconfig:option:`CONFIG_MODBUS_NONCOMPLIANT_SERIAL_MODE`.
 
 State Machine Framework
 =======================
@@ -766,13 +761,12 @@ State Machine Framework
 * Flat state machines ignore the return value; returning :c:enum:`SMF_EVENT_HANDLED`
   would be the most technically accurate response.
 
-Modbus
-======
+hawkBit
+=======
 
-* The ``client_stop_bits`` field in :c:struct:`modbus_serial_param` has been renamed into ``stop_bits``.
-  The setting is valid in both client and server modes.
-* Custom stop-bit settings are disabled by default and should be enabled
-  by :kconfig:option:`CONFIG_MODBUS_NONCOMPLIANT_SERIAL_MODE`.
+* When :kconfig:option:`CONFIG_HAWKBIT_CUSTOM_DEVICE_ID` is enabled, device_id will no longer
+  be prepended with :kconfig:option:`CONFIG_BOARD`. It is the user's responsibility to write a
+  callback that prepends the board name if needed.
 
 Modules
 *******

--- a/doc/releases/migration-guide-4.2.rst
+++ b/doc/releases/migration-guide-4.2.rst
@@ -100,6 +100,8 @@ Boards
 Device Drivers and Devicetree
 *****************************
 
+.. zephyr-keep-sorted-start re(^\w)
+
 Audio
 =====
 
@@ -491,8 +493,12 @@ qSPI/oSPI/xSPI
   Note that the property gives the actual size of the memory device in bits.
   Previous mapping address information is now described in xspi, ospi or qspi nodes at SoC dtsi level.
 
+.. zephyr-keep-sorted-stop
+
 Bluetooth
 *********
+
+.. zephyr-keep-sorted-start re(^\w)
 
 Bluetooth Audio
 ===============
@@ -549,6 +555,8 @@ Bluetooth Host
 
 * The ``CONFIG_BT_ISO_TX_FRAG_COUNT`` Kconfig option was removed as it was completely unused.
   Any uses of it can simply be removed. (:github:`89836`)
+
+.. zephyr-keep-sorted-stop
 
 Networking
 **********
@@ -632,6 +640,8 @@ Networking
   :c:func:`dns_resolve_reconfigure_with_interfaces` now require that the user supplies
   the source of the DNS server information. For example when DNS server information is
   received via DHCPv4, then :c:enumerator:`DNS_SOURCE_DHCPV4` needs to be specified.
+
+.. zephyr-keep-sorted-start re(^\w)
 
 LwM2M
 =====
@@ -738,9 +748,13 @@ OpenThread
   * You can now use OpenThread directly, without enabling Zephyr's L2 or IEEE802.15.4 layers, if
     your use case allows.
 
+.. zephyr-keep-sorted-stop
+
 
 Other subsystems
 ****************
+
+.. zephyr-keep-sorted-start re(^\w)
 
 Modbus
 ======
@@ -768,8 +782,12 @@ hawkBit
   be prepended with :kconfig:option:`CONFIG_BOARD`. It is the user's responsibility to write a
   callback that prepends the board name if needed.
 
+.. zephyr-keep-sorted-stop
+
 Modules
 *******
+
+.. zephyr-keep-sorted-start re(^\w)
 
 CMSIS
 =====
@@ -784,6 +802,8 @@ CMSIS
   which can be accessed via the :kconfig:option:`CONFIG_ZEPHYR_CMSIS_6_MODULE_DIR` configuration.
 
   Note: Zephyr will continue using the older ``cmsis`` module for Cortex-A and Cortex-R targets.
+
+.. zephyr-keep-sorted-stop
 
 Architectures
 *************

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -32,14 +32,30 @@ Boards
 Device Drivers and Devicetree
 *****************************
 
+.. zephyr-keep-sorted-start re(^\w)
+
+.. zephyr-keep-sorted-stop
+
 Bluetooth
 *********
+
+.. zephyr-keep-sorted-start re(^\w)
+
+.. zephyr-keep-sorted-stop
 
 Networking
 **********
 
+.. zephyr-keep-sorted-start re(^\w)
+
+.. zephyr-keep-sorted-stop
+
 Other subsystems
 ****************
+
+.. zephyr-keep-sorted-start re(^\w)
+
+.. zephyr-keep-sorted-stop
 
 Modules
 *******

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -177,6 +177,8 @@ New APIs and options
   like you need to add more details, add them in the API documentation code
   instead.
 
+.. zephyr-keep-sorted-start re(^\* \w)
+
 * Architectures
 
   * NIOS2 Architecture was removed from Zephyr.
@@ -486,6 +488,7 @@ New APIs and options
   * :kconfig:option:`CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_ALLOC_NONE`
   * :kconfig:option:`CONFIG_ZBUS_RUNTIME_OBSERVERS_NODE_POOL_SIZE`
 
+.. zephyr-keep-sorted-stop
 
 .. _boards_added_in_zephyr_4_2:
 

--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -171,50 +171,18 @@ Stable API changes in this release
 New APIs and options
 ====================
 
+..
+  Link to new APIs here, in a group if you think it's necessary, no need to get
+  fancy just list the link, that should contain the documentation. If you feel
+  like you need to add more details, add them in the API documentation code
+  instead.
+
 * Architectures
 
   * NIOS2 Architecture was removed from Zephyr.
   * :kconfig:option:`ARCH_HAS_VECTOR_TABLE_RELOCATION`
   * :kconfig:option:`CONFIG_SRAM_VECTOR_TABLE` moved from ``zephyr/Kconfig.zephyr`` to
     ``zephyr/arch/Kconfig`` and added dependencies to it.
-
-* Kernel
-
- * :c:macro:`K_TIMEOUT_ABS_SEC`
- * :c:func:`timespec_add`
- * :c:func:`timespec_compare`
- * :c:func:`timespec_equal`
- * :c:func:`timespec_is_valid`
- * :c:func:`timespec_negate`
- * :c:func:`timespec_normalize`
- * :c:func:`timespec_from_timeout`
- * :c:func:`timespec_to_timeout`
- * :c:func:`k_heap_array_get`
-
-* I2C
-
-  * :c:func:`i2c_configure_dt`.
-  * :c:macro:`I2C_DEVICE_DT_DEINIT_DEFINE`
-  * :c:macro:`I2C_DEVICE_DT_INST_DEINIT_DEFINE`
-
-* I3C
-
-  * :kconfig:option:`CONFIG_I3C_MODE`
-  * :kconfig:option:`CONFIG_I3C_CONTROLLER_ROLE_ONLY`
-  * :kconfig:option:`CONFIG_I3C_TARGET_ROLE_ONLY`
-  * :kconfig:option:`CONFIG_I3C_DUAL_ROLE`
-  * :c:func:`i3c_ccc_do_rstdaa`
-
-* SPI
-
-  * :c:macro:`SPI_DEVICE_DT_DEINIT_DEFINE`
-  * :c:macro:`SPI_DEVICE_DT_INST_DEINIT_DEFINE`
-
-..
-  Link to new APIs here, in a group if you think it's necessary, no need to get
-  fancy just list the link, that should contain the documentation. If you feel
-  like you need to add more details, add them in the API documentation code
-  instead.
 
 * Bluetooth
 
@@ -295,10 +263,49 @@ New APIs and options
     * Single app RAM load support added to sysbuild using
       :kconfig:option:`SB_CONFIG_MCUBOOT_MODE_SINGLE_APP_RAM_LOAD`.
 
+* Counter
+
+  * :c:func:`counter_reset`
+
+* Debug
+
+  * Core Dump
+
+    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP`, enabled by default for ARM Cortex M when :kconfig:option:`CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN` is selected.
+    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY`
+    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY_SIZE`
+
 * Display
 
     * Added :c:func:`display_clear` API to allow clearing the display content in a standardized way.
     * Character Frame Buffer (CFB) subsystem now supports drawing circles via :c:func:`cfb_draw_circle`.
+
+* I2C
+
+  * :c:func:`i2c_configure_dt`.
+  * :c:macro:`I2C_DEVICE_DT_DEINIT_DEFINE`
+  * :c:macro:`I2C_DEVICE_DT_INST_DEINIT_DEFINE`
+
+* I3C
+
+  * :kconfig:option:`CONFIG_I3C_MODE`
+  * :kconfig:option:`CONFIG_I3C_CONTROLLER_ROLE_ONLY`
+  * :kconfig:option:`CONFIG_I3C_TARGET_ROLE_ONLY`
+  * :kconfig:option:`CONFIG_I3C_DUAL_ROLE`
+  * :c:func:`i3c_ccc_do_rstdaa`
+
+* Kernel
+
+ * :c:macro:`K_TIMEOUT_ABS_SEC`
+ * :c:func:`timespec_add`
+ * :c:func:`timespec_compare`
+ * :c:func:`timespec_equal`
+ * :c:func:`timespec_is_valid`
+ * :c:func:`timespec_negate`
+ * :c:func:`timespec_normalize`
+ * :c:func:`timespec_from_timeout`
+ * :c:func:`timespec_to_timeout`
+ * :c:func:`k_heap_array_get`
 
 * LVGL (Light and Versatile Graphics Library)
 
@@ -306,6 +313,9 @@ New APIs and options
     * LVGL subsystem now supports multiple simultaneous displays, including proper input device-to-display binding.
     * Added L8/Y8 pixel format support for displays such as SSD1327, SSD1320, SSD1322, and ST75256.
     * :kconfig:option:`CONFIG_LV_Z_COLOR_MONO_HW_INVERSION`
+
+* LoRaWAN
+   * :c:func:`lorawan_request_link_check`
 
 * Management
 
@@ -396,6 +406,10 @@ New APIs and options
     * :c:member:`zperf_upload_params.data_loader`
     * :kconfig:option:`CONFIG_NET_ZPERF_SERVER`
 
+* PCIe
+
+   * :kconfig:option:`CONFIG_NVME_PRP_PAGE_SIZE`
+
 * Power management
 
     * :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_USE_SYSTEM_WQ`
@@ -405,6 +419,11 @@ New APIs and options
     * :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_DEDICATED_WQ_PRIO`
     * :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_DEDICATED_WQ_INIT_PRIO`
     * :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_ASYNC`
+
+* SPI
+
+  * :c:macro:`SPI_DEVICE_DT_DEINIT_DEFINE`
+  * :c:macro:`SPI_DEVICE_DT_INST_DEINIT_DEFINE`
 
 * Sensor
 
@@ -419,10 +438,6 @@ New APIs and options
 
   * :c:func:`flash_area_copy()`
 
-* Counter
-
-  * :c:func:`counter_reset`
-
 * Sys
 
   * :c:func:`util_eq`
@@ -431,8 +446,13 @@ New APIs and options
   * :c:func:`sys_clock_settime`
   * :c:func:`sys_clock_nanosleep`
 
-* LoRaWAN
-   * :c:func:`lorawan_request_link_check`
+* USB
+
+  * :c:func:`uvc_set_video_dev`
+
+* UpdateHub
+
+  * :c:func:`updatehub_report_error`
 
 * Video
 
@@ -452,26 +472,6 @@ New APIs and options
   * :c:member:`video_buffer.index` field
   * :c:member:`video_ctrl_query.int_menu` field
   * :c:macro:`VIDEO_MIPI_CSI2_DT_NULL` and other MIPI standard values
-
-* PCIe
-
-   * :kconfig:option:`CONFIG_NVME_PRP_PAGE_SIZE`
-
-* Debug
-
-  * Core Dump
-
-    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_THREAD_STACK_TOP`, enabled by default for ARM Cortex M when :kconfig:option:`CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN` is selected.
-    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY`
-    * :kconfig:option:`CONFIG_DEBUG_COREDUMP_BACKEND_IN_MEMORY_SIZE`
-
-* UpdateHub
-
-  * :c:func:`updatehub_report_error`
-
-* USB
-
-  * :c:func:`uvc_set_video_dev`
 
 * ZBus
 

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -63,6 +63,10 @@ New APIs and options
   like you need to add more details, add them in the API documentation code
   instead.
 
+.. zephyr-keep-sorted-start re(^\* \w)
+
+.. zephyr-keep-sorted-stop
+
 New Boards
 **********
 


### PR DESCRIPTION
Clean up order of entries in the migration guide and release notes to be alphabetical. Combine two duplicate regulator sections, and move driver sections mistakenly placed under networking where they ought to be.

Also, add zephyr-keep-sorted entries to migration guide and release notes to keep alphabetical order enforced.

Migration guide rendered from this PR: https://builds.zephyrproject.io/zephyr/pr/93290/docs/releases/migration-guide-4.2.html