### PR TITLE
drivers: pwm: sam: update to support Microchip sama7g5

### DIFF
--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.dts
@@ -12,6 +12,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/gpio/microchip-sam-gpio.h>
 #include <dt-bindings/input/input-event-codes.h>
+#include <dt-bindings/pwm/pwm.h>
 #include <microchip/sam/sama7g5.dtsi>
 
 / {
@@ -20,6 +21,7 @@
 
 	aliases {
 		led0 = &led_green;
+		pwm-led0 = &pwm_led_green;
 		sw0 = &button_user;
 		sdhc0 = &sdmmc0;
 		sdhc1 = &sdmmc1;
@@ -74,6 +76,19 @@
 			label = "PB_USER";
 			gpios = <&pioa 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	pwmleds: pwmleds {
+		compatible = "pwm-leds";
+		status = "disabled"; /* Conflict with leds. */
+
+		pwm_led_green: pwm_led_green {
+			pwms = <&pwm 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+
+		pwm_led_blue: pwm_led_blue {
+			pwms = <&pwm 3 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 };
@@ -138,6 +153,18 @@
 		};
 	};
 
+	pinctrl_mikrobus_pwm_default: pinctrl_mikrobus_pwm_default {
+		mikrobus1_pwm2 {
+			pinmux = <PIN_PA13__PWMH2>;
+			bias-disable;
+		};
+
+		mikrobus2_pwm3 {
+			pinmux = <PIN_PD20__PWMH3>;
+			bias-disable;
+		};
+	};
+
 	pinctrl_sdmmc0_default: sdmmc0_default {
 		cmd_data {
 			pinmux = <PIN_PA1__SDMMC0_CMD>,
@@ -183,6 +210,11 @@
 
 &pit64b0 {
 	clock-frequency = <DT_FREQ_M(10)>;
+};
+
+&pwm {
+	pinctrl-0 = <&pinctrl_mikrobus_pwm_default>;
+	pinctrl-names = "default";
 };
 
 &sdmmc0 {

--- a/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
+++ b/boards/microchip/sam/sama7g54_ek/sama7g54_ek.yaml
@@ -9,6 +9,7 @@ toolchain:
   - zephyr
 ram: 128
 supported:
+  - pwm
   - sdhc
   - shell
   - uart

--- a/dts/arm/microchip/sam/sama7g5.dtsi
+++ b/dts/arm/microchip/sam/sama7g5.dtsi
@@ -502,6 +502,18 @@
 			clock-names = "td_slck", "md_slck", "main_xtal";
 		};
 
+		pwm: pwm@e1604000 {
+			compatible = "atmel,sam-pwm";
+			reg = <0xe1604000 0x4000>;
+			interrupt-parent = <&gic>;
+			interrupts = <GIC_SPI 77 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
+			clocks = <&pmc PMC_TYPE_PERIPHERAL 77>;
+			prescaler = <10>;
+			divider = <1>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
 		sdmmc0: mmc@e1204000 {
 			compatible = "microchip,sama7g5-sdmmc";
 			reg = <0xe1204000 0x4000>;

--- a/samples/basic/blinky_pwm/boards/sama7g54_ek.overlay
+++ b/samples/basic/blinky_pwm/boards/sama7g54_ek.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 Microchip Technology Inc. and its subsidiaries
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+&pwmleds {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};

--- a/soc/microchip/sam/sama7g5/soc.c
+++ b/soc/microchip/sam/sama7g5/soc.c
@@ -33,6 +33,10 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("pmc", PMC_BASE_ADDRESS, 0x200,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
 
+	IF_ENABLED(DT_HAS_COMPAT_STATUS_OKAY(atmel_sam_pwm),
+		   (MMU_REGION_FLAT_ENTRY("pwm", PWM_BASE_ADDRESS, 0x500,
+					  MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),))
+
 	MMU_REGION_FLAT_ENTRY("sckc", SCKC_BASE_ADDRESS, 0x4,
 			      MT_STRONGLY_ORDERED | MPERM_R | MPERM_W),
 


### PR DESCRIPTION
The following changes are addressed in this PR:
- update the pwm driver for supporting Microchip sama7g5
- enable `samples/basic/blinky_pwm` for sama7g54_ek board