### PR TITLE
net_pkt: Store meta-information of processing in the net_pkt

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -237,6 +237,7 @@ struct net_pkt {
 	uint8_t chksum_done : 1; /* Checksum has already been computed for
 				  * the packet.
 				  */
+	uint8_t loopback : 1; /* Packet is a loop back packet. */
 #if defined(CONFIG_NET_IP_FRAGMENT)
 	uint8_t ip_reassembled : 1; /* Packet is a reassembled IP packet. */
 #endif
@@ -1019,6 +1020,17 @@ static inline void net_pkt_set_ipv6_fragment_id(struct net_pkt *pkt,
 	ARG_UNUSED(id);
 }
 #endif /* CONFIG_NET_IPV6_FRAGMENT */
+
+static inline bool net_pkt_is_loopback(struct net_pkt *pkt)
+{
+	return !!(pkt->loopback);
+}
+
+static inline void net_pkt_set_loopback(struct net_pkt *pkt,
+					bool loopback)
+{
+	pkt->loopback = loopback;
+}
 
 #if defined(CONFIG_NET_IP_FRAGMENT)
 static inline bool net_pkt_is_ip_reassembled(struct net_pkt *pkt)

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -231,8 +231,17 @@ struct net_pkt {
 				   * preserved. Useful only if
 				   * defined(CONFIG_NET_ETHERNET_BRIDGE).
 				   */
+	uint8_t raw_processed : 1; /* Set to 1 if this packet has already been
+				    * processed by SOCK_RAW
+				    */
+	uint8_t dgram_processed : 1; /* Set to 1 if this packet has already been
+				      * processed by SOCK_DGRAM
+				      */
 	uint8_t l2_processed : 1; /* Set to 1 if this packet has already been
 				   * processed by the L2
+				   */
+	uint8_t l3_processed : 1; /* Set to 1 if this packet has already been
+				   * processed by the L3
 				   */
 	uint8_t chksum_done : 1; /* Checksum has already been computed for
 				  * the packet.
@@ -554,6 +563,28 @@ static inline void net_pkt_set_l2_bridged(struct net_pkt *pkt, bool is_l2_bridge
 	}
 }
 
+static inline bool net_pkt_is_raw_processed(struct net_pkt *pkt)
+{
+	return !!(pkt->raw_processed);
+}
+
+static inline void net_pkt_set_raw_processed(struct net_pkt *pkt,
+					    bool is_raw_processed)
+{
+	pkt->raw_processed = is_raw_processed;
+}
+
+static inline bool net_pkt_is_dgram_processed(struct net_pkt *pkt)
+{
+	return !!(pkt->dgram_processed);
+}
+
+static inline void net_pkt_set_dgram_processed(struct net_pkt *pkt,
+					    bool is_dgram_processed)
+{
+	pkt->dgram_processed = is_dgram_processed;
+}
+
 static inline bool net_pkt_is_l2_processed(struct net_pkt *pkt)
 {
 	return !!(pkt->l2_processed);
@@ -563,6 +594,17 @@ static inline void net_pkt_set_l2_processed(struct net_pkt *pkt,
 					    bool is_l2_processed)
 {
 	pkt->l2_processed = is_l2_processed;
+}
+
+static inline bool net_pkt_is_l3_processed(struct net_pkt *pkt)
+{
+	return !!(pkt->l3_processed);
+}
+
+static inline void net_pkt_set_l3_processed(struct net_pkt *pkt,
+					    bool is_l3_processed)
+{
+	pkt->l3_processed = is_l3_processed;
 }
 
 static inline bool net_pkt_is_chksum_done(struct net_pkt *pkt)

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -637,16 +637,14 @@ out:
 #endif /* defined(CONFIG_NET_SOCKETS_PACKET) || defined(CONFIG_NET_SOCKETS_INET_RAW) */
 
 #if defined(CONFIG_NET_SOCKETS_PACKET)
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
+void net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
 {
-	bool raw_sock_found = false;
-	bool raw_pkt_continue = false;
 	struct sockaddr_ll *local;
 	struct net_conn *conn;
 
 	/* Only accept input with AF_PACKET family. */
 	if (net_pkt_family(pkt) != AF_PACKET) {
-		return NET_CONTINUE;
+		return;
 	}
 
 	NET_DBG("Check proto 0x%04x listener for pkt %p family %d",
@@ -666,33 +664,22 @@ enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum
 		 * in this packet.
 		 */
 		if (conn->family != AF_PACKET) {
-			raw_pkt_continue = true;
 			continue; /* wrong family */
 		}
 
-		if (conn->type == SOCK_DGRAM && type == SOCK_RAW) {
-			/* If DGRAM packet sockets are present, we shall continue
-			 * with this packet regardless the result.
-			 */
-			raw_pkt_continue = true;
-			continue; /* L2 not processed yet */
-		}
-
-		if (conn->type == SOCK_RAW && type != SOCK_RAW) {
-			continue; /* L2 already processed */
+		if (conn->type != type) {
+			continue;
 		}
 
 		if (conn->proto == 0) {
 			continue; /* Local proto 0 doesn't forward any packets */
 		}
 
-		if (conn->proto != proto) {
-			/* Allow proto mismatch if socket was created with ETH_P_ALL, or it's raw
-			 * packet socket input (proto ETH_P_ALL).
-			 */
-			if (conn->proto != ETH_P_ALL && proto != ETH_P_ALL) {
-				continue; /* wrong protocol */
-			}
+		/* Allow proto mismatch if socket was created with ETH_P_ALL, or it's raw
+		 * packet socket input.
+		 */
+		if (conn->proto != proto && conn->proto != ETH_P_ALL && type != SOCK_RAW) {
+			continue; /* wrong protocol */
 		}
 
 		/* Apply protocol-specific matching criteria... */
@@ -708,32 +695,17 @@ enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum
 
 		conn_raw_socket_deliver(pkt, conn, false);
 
-		raw_sock_found = true;
 	}
 
 	k_mutex_unlock(&conn_lock);
 
-	if (!raw_pkt_continue && raw_sock_found) {
-		/* As one or more raw socket packets have already been delivered
-		 * in the loop above, report NET_OK.
-		 */
-		net_pkt_unref(pkt);
-		return NET_OK;
-	}
-
-	/* When there is open connection different than AF_PACKET this
-	 * packet shall be also handled in the upper net stack layers.
-	 */
-	return NET_CONTINUE;
 }
 #else
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
+void net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
 {
 	ARG_UNUSED(pkt);
 	ARG_UNUSED(proto);
 	ARG_UNUSED(type);
-
-	return NET_CONTINUE;
 }
 #endif /* defined(CONFIG_NET_SOCKETS_PACKET) */
 

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -637,7 +637,7 @@ out:
 #endif /* defined(CONFIG_NET_SOCKETS_PACKET) || defined(CONFIG_NET_SOCKETS_INET_RAW) */
 
 #if defined(CONFIG_NET_SOCKETS_PACKET)
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto)
+enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
 {
 	bool raw_sock_found = false;
 	bool raw_pkt_continue = false;
@@ -670,7 +670,7 @@ enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto)
 			continue; /* wrong family */
 		}
 
-		if (conn->type == SOCK_DGRAM && !net_pkt_is_l2_processed(pkt)) {
+		if (conn->type == SOCK_DGRAM && type == SOCK_RAW) {
 			/* If DGRAM packet sockets are present, we shall continue
 			 * with this packet regardless the result.
 			 */
@@ -678,7 +678,7 @@ enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto)
 			continue; /* L2 not processed yet */
 		}
 
-		if (conn->type == SOCK_RAW && net_pkt_is_l2_processed(pkt)) {
+		if (conn->type == SOCK_RAW && type != SOCK_RAW) {
 			continue; /* L2 already processed */
 		}
 
@@ -727,10 +727,11 @@ enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto)
 	return NET_CONTINUE;
 }
 #else
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto)
+enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type)
 {
 	ARG_UNUSED(pkt);
 	ARG_UNUSED(proto);
+	ARG_UNUSED(type);
 
 	return NET_CONTINUE;
 }

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -189,11 +189,14 @@ int net_conn_update(struct net_conn_handle *handle,
  *
  * @param pkt Network packet holding received data
  * @param proto LL protocol for the connection
+ * @param type socket type
  *
  * @return NET_OK if the packet was consumed, NET_CONTINUE if the packet should
  * be processed further in the stack.
  */
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt, uint16_t proto);
+enum net_verdict net_conn_packet_input(struct net_pkt *pkt,
+				       uint16_t proto,
+				       enum net_sock_type type);
 
 /**
  * @brief Called by net_core.c when an IP packet is received

--- a/subsys/net/ip/connection.h
+++ b/subsys/net/ip/connection.h
@@ -191,10 +191,8 @@ int net_conn_update(struct net_conn_handle *handle,
  * @param proto LL protocol for the connection
  * @param type socket type
  *
- * @return NET_OK if the packet was consumed, NET_CONTINUE if the packet should
- * be processed further in the stack.
  */
-enum net_verdict net_conn_packet_input(struct net_pkt *pkt,
+void net_conn_packet_input(struct net_pkt *pkt,
 				       uint16_t proto,
 				       enum net_sock_type type);
 

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -240,7 +240,7 @@ int net_ipv4_parse_hdr_options(struct net_pkt *pkt,
 }
 #endif
 
-enum net_verdict net_ipv4_input(struct net_pkt *pkt, bool is_loopback)
+enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv4_access, struct net_ipv4_hdr);
 	NET_PKT_DATA_ACCESS_DEFINE(udp_access, struct net_udp_hdr);
@@ -301,7 +301,7 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt, bool is_loopback)
 		net_pkt_update_length(pkt, pkt_len);
 	}
 
-	if (!is_loopback) {
+	if (!net_pkt_is_loopback(pkt)) {
 		if (net_ipv4_is_addr_loopback_raw(hdr->dst) ||
 		    net_ipv4_is_addr_loopback_raw(hdr->src)) {
 			NET_DBG("DROP: localhost packet");

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -211,9 +211,9 @@ static void reassemble_packet(struct net_ipv4_reassembly *reass)
 	/* We need to use the queue when feeding the packet back into the
 	 * IP stack as we might run out of stack if we call processing_data()
 	 * directly. As the packet does not contain link layer header, we
-	 * MUST NOT pass it to L2 so there will be a special check for that
-	 * in process_data() when handling the packet.
+	 * MUST NOT pass it to L2 so mark it as l2_processed.
 	 */
+	net_pkt_set_l2_processed(pkt, true);
 	if (net_recv_data(net_pkt_iface(pkt), pkt) >= 0) {
 		return;
 	}

--- a/subsys/net/ip/ipv4_fragment.c
+++ b/subsys/net/ip/ipv4_fragment.c
@@ -214,6 +214,7 @@ static void reassemble_packet(struct net_ipv4_reassembly *reass)
 	 * MUST NOT pass it to L2 so mark it as l2_processed.
 	 */
 	net_pkt_set_l2_processed(pkt, true);
+	net_pkt_set_l3_processed(pkt, false);
 	if (net_recv_data(net_pkt_iface(pkt), pkt) >= 0) {
 		return;
 	}

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -475,7 +475,7 @@ static inline bool is_src_non_tentative_itself(const uint8_t *src)
 	return false;
 }
 
-enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
+enum net_verdict net_ipv6_input(struct net_pkt *pkt)
 {
 	NET_PKT_DATA_ACCESS_CONTIGUOUS_DEFINE(ipv6_access, struct net_ipv6_hdr);
 	NET_PKT_DATA_ACCESS_DEFINE(udp_access, struct net_udp_hdr);
@@ -537,7 +537,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 		goto drop;
 	}
 
-	if (!is_loopback) {
+	if (!net_pkt_is_loopback(pkt)) {
 		if (net_ipv6_is_addr_loopback_raw(hdr->dst) ||
 		    net_ipv6_is_addr_loopback_raw(hdr->src)) {
 			NET_DBG("DROP: ::1 packet");
@@ -631,7 +631,7 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	if ((IS_ENABLED(CONFIG_NET_ROUTING) || IS_ENABLED(CONFIG_NET_ROUTE_MCAST)) &&
-	    !is_loopback && is_src_non_tentative_itself(hdr->src)) {
+	    !net_pkt_is_loopback(pkt) && is_src_non_tentative_itself(hdr->src)) {
 		NET_DBG("DROP: src addr is %s", "mine");
 		goto drop;
 	}

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -346,9 +346,9 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 	/* We need to use the queue when feeding the packet back into the
 	 * IP stack as we might run out of stack if we call processing_data()
 	 * directly. As the packet does not contain link layer header, we
-	 * MUST NOT pass it to L2 so there will be a special check for that
-	 * in process_data() when handling the packet.
+	 * MUST NOT pass it to L2 so mark it as l2_processed.
 	 */
+	net_pkt_set_l2_processed(pkt, true);
 	if (net_recv_data(net_pkt_iface(pkt), pkt) >= 0) {
 		return;
 	}

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -349,6 +349,7 @@ static void reassemble_packet(struct net_ipv6_reassembly *reass)
 	 * MUST NOT pass it to L2 so mark it as l2_processed.
 	 */
 	net_pkt_set_l2_processed(pkt, true);
+	net_pkt_set_l3_processed(pkt, false);
 	if (net_recv_data(net_pkt_iface(pkt), pkt) >= 0) {
 		return;
 	}

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -68,10 +68,7 @@ static inline enum net_verdict process_data(struct net_pkt *pkt)
 {
 	int ret;
 
-	ret = net_packet_socket_input(pkt, ETH_P_ALL, SOCK_RAW);
-	if (ret != NET_CONTINUE) {
-		return ret;
-	}
+	net_packet_socket_input(pkt, ETH_P_ALL, SOCK_RAW);
 
 	/* If there is no data, then drop the packet. */
 	if (!pkt->frags) {
@@ -101,10 +98,7 @@ static inline enum net_verdict process_data(struct net_pkt *pkt)
 	net_pkt_cursor_init(pkt);
 
 	if (IS_ENABLED(CONFIG_NET_SOCKETS_PACKET_DGRAM)) {
-		ret = net_packet_socket_input(pkt, net_pkt_ll_proto_type(pkt), SOCK_DGRAM);
-		if (ret != NET_CONTINUE) {
-			return ret;
-		}
+		net_packet_socket_input(pkt, net_pkt_ll_proto_type(pkt), SOCK_DGRAM);
 	}
 
 	uint8_t family = net_pkt_family(pkt);

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2050,6 +2050,7 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_rx_timestamping(clone_pkt, net_pkt_is_rx_timestamping(pkt));
 	net_pkt_set_forwarding(clone_pkt, net_pkt_forwarding(pkt));
 	net_pkt_set_chksum_done(clone_pkt, net_pkt_is_chksum_done(pkt));
+	net_pkt_set_loopback(pkt, net_pkt_is_loopback(pkt));
 	net_pkt_set_ip_reassembled(pkt, net_pkt_is_ip_reassembled(pkt));
 	net_pkt_set_cooked_mode(clone_pkt, net_pkt_is_cooked_mode(pkt));
 	net_pkt_set_ipv4_pmtu(clone_pkt, net_pkt_ipv4_pmtu(pkt));

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -2055,7 +2055,10 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_cooked_mode(clone_pkt, net_pkt_is_cooked_mode(pkt));
 	net_pkt_set_ipv4_pmtu(clone_pkt, net_pkt_ipv4_pmtu(pkt));
 	net_pkt_set_l2_bridged(clone_pkt, net_pkt_is_l2_bridged(pkt));
+	net_pkt_set_raw_processed(clone_pkt, net_pkt_is_raw_processed(pkt));
+	net_pkt_set_dgram_processed(clone_pkt, net_pkt_is_dgram_processed(pkt));
 	net_pkt_set_l2_processed(clone_pkt, net_pkt_is_l2_processed(pkt));
+	net_pkt_set_l3_processed(clone_pkt, net_pkt_is_l3_processed(pkt));
 	net_pkt_set_ll_proto_type(clone_pkt, net_pkt_ll_proto_type(pkt));
 
 #if defined(CONFIG_NET_OFFLOAD) || defined(CONFIG_NET_L2_IPIP)

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -183,25 +183,21 @@ extern void loopback_enable_address_swap(bool swap_addresses);
 #endif /* CONFIG_NET_TEST */
 
 #if defined(CONFIG_NET_NATIVE)
-enum net_verdict net_ipv4_input(struct net_pkt *pkt, bool is_loopback);
-enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback);
+enum net_verdict net_ipv4_input(struct net_pkt *pkt);
+enum net_verdict net_ipv6_input(struct net_pkt *pkt);
 extern void net_tc_tx_init(void);
 extern void net_tc_rx_init(void);
 #else
-static inline enum net_verdict net_ipv4_input(struct net_pkt *pkt,
-					      bool is_loopback)
+static inline enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 {
 	ARG_UNUSED(pkt);
-	ARG_UNUSED(is_loopback);
 
 	return NET_CONTINUE;
 }
 
-static inline enum net_verdict net_ipv6_input(struct net_pkt *pkt,
-					      bool is_loopback)
+static inline enum net_verdict net_ipv6_input(struct net_pkt *pkt)
 {
 	ARG_UNUSED(pkt);
-	ARG_UNUSED(is_loopback);
 
 	return NET_CONTINUE;
 }

--- a/subsys/net/ip/packet_socket.c
+++ b/subsys/net/ip/packet_socket.c
@@ -22,12 +22,11 @@ LOG_MODULE_REGISTER(net_sockets_raw, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "connection.h"
 #include "packet_socket.h"
 
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
+void net_packet_socket_input(struct net_pkt *pkt,
 					 uint16_t proto,
 					 enum net_sock_type type)
 {
 	sa_family_t orig_family;
-	enum net_verdict net_verdict;
 
 #if defined(CONFIG_NET_DSA_DEPRECATED)
 	/*
@@ -35,7 +34,7 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
 	 * lan1..3 are working with them.
 	 */
 	if (dsa_is_port_master(net_pkt_iface(pkt))) {
-		return NET_CONTINUE;
+		return;
 	}
 #endif
 
@@ -43,9 +42,7 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
 
 	net_pkt_set_family(pkt, AF_PACKET);
 
-	net_verdict = net_conn_packet_input(pkt, proto, type);
+	net_conn_packet_input(pkt, proto, type);
 
 	net_pkt_set_family(pkt, orig_family);
-
-	return net_verdict;
 }

--- a/subsys/net/ip/packet_socket.c
+++ b/subsys/net/ip/packet_socket.c
@@ -22,7 +22,9 @@ LOG_MODULE_REGISTER(net_sockets_raw, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include "connection.h"
 #include "packet_socket.h"
 
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint16_t proto)
+enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
+					 uint16_t proto,
+					 enum net_sock_type type)
 {
 	sa_family_t orig_family;
 	enum net_verdict net_verdict;
@@ -41,7 +43,7 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint16_t proto)
 
 	net_pkt_set_family(pkt, AF_PACKET);
 
-	net_verdict = net_conn_packet_input(pkt, proto);
+	net_verdict = net_conn_packet_input(pkt, proto, type);
 
 	net_pkt_set_family(pkt, orig_family);
 

--- a/subsys/net/ip/packet_socket.h
+++ b/subsys/net/ip/packet_socket.h
@@ -26,10 +26,13 @@
  * disabled, the function will always return NET_DROP.
  */
 #if defined(CONFIG_NET_SOCKETS_PACKET)
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint16_t proto);
+enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
+					 uint16_t proto,
+					 enum net_sock_type type);
 #else
 static inline enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
-						       uint16_t proto)
+						       uint16_t proto,
+						       enum net_sock_type type)
 {
 	return NET_CONTINUE;
 }

--- a/subsys/net/ip/packet_socket.h
+++ b/subsys/net/ip/packet_socket.h
@@ -20,21 +20,14 @@
  *
  * @param pkt Network packet
  *
- * @return NET_OK if the packet was consumed, NET_DROP if
- * the packet parsing failed and the caller should handle
- * the received packet. If corresponding IP protocol support is
- * disabled, the function will always return NET_DROP.
  */
 #if defined(CONFIG_NET_SOCKETS_PACKET)
-enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
-					 uint16_t proto,
-					 enum net_sock_type type);
+void net_packet_socket_input(struct net_pkt *pkt, uint16_t proto, enum net_sock_type type);
 #else
-static inline enum net_verdict net_packet_socket_input(struct net_pkt *pkt,
-						       uint16_t proto,
-						       enum net_sock_type type)
+static inline void net_packet_socket_input(struct net_pkt *pkt,
+					   uint16_t proto,
+					   enum net_sock_type type)
 {
-	return NET_CONTINUE;
 }
 #endif
 

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -374,7 +374,10 @@ static enum net_verdict interface_recv(struct net_if *iface,
 
 		net_pkt_cursor_restore(pkt, &hdr_start);
 
-		return net_ipv6_input(pkt, false);
+		/* Ensure the loopback flag is no longer set */
+		net_pkt_set_loopback(pkt, false);
+
+		return net_ipv6_input(pkt);
 	}
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET) {
@@ -421,7 +424,10 @@ static enum net_verdict interface_recv(struct net_if *iface,
 
 		net_pkt_cursor_restore(pkt, &hdr_start);
 
-		return net_ipv4_input(pkt, false);
+		/* Ensure the loopback flag is no longer set */
+		net_pkt_set_loopback(pkt, false);
+
+		return net_ipv4_input(pkt);
 	}
 
 	return NET_CONTINUE;

--- a/tests/net/dhcpv6/src/main.c
+++ b/tests/net/dhcpv6/src/main.c
@@ -636,7 +636,7 @@ ZTEST(dhcpv6_tests, test_input_reject_client_initiated_messages)
 						 set_generic_client_options);
 		zassert_not_null(pkt, "Failed to create fake pkt");
 
-		result = net_ipv6_input(pkt, false);
+		result = net_ipv6_input(pkt);
 		zassert_equal(result, NET_DROP, "Should've drop the message");
 
 		net_pkt_unref(pkt);
@@ -719,7 +719,7 @@ ZTEST(dhcpv6_tests, test_input_advertise)
 						 set_advertise_options);
 		zassert_not_null(pkt, "Failed to create pkt");
 
-		result = net_ipv6_input(pkt, false);
+		result = net_ipv6_input(pkt);
 
 		switch (state) {
 		case NET_DHCPV6_SOLICITING:
@@ -826,7 +826,7 @@ ZTEST(dhcpv6_tests, test_input_reply)
 						 set_reply_options);
 		zassert_not_null(pkt, "Failed to create pkt");
 
-		result = net_ipv6_input(pkt, false);
+		result = net_ipv6_input(pkt);
 
 		switch (state) {
 		case NET_DHCPV6_CONFIRMING:
@@ -891,7 +891,7 @@ static void test_solicit_expect_request_send_reply(struct net_if *iface,
 					   set_reply_options);
 	zassert_not_null(reply, "Failed to create pkt");
 
-	result = net_ipv6_input(reply, false);
+	result = net_ipv6_input(reply);
 	zassert_equal(result, NET_OK, "Message should've been processed");
 
 	/* Verify client state */
@@ -936,7 +936,7 @@ static void test_solicit_expect_solicit_send_advertise(struct net_if *iface,
 					   set_advertise_options);
 	zassert_not_null(reply, "Failed to create pkt");
 
-	result = net_ipv6_input(reply, false);
+	result = net_ipv6_input(reply);
 	zassert_equal(result, NET_OK, "Message should've been processed");
 
 	/* Verify client state */
@@ -993,7 +993,7 @@ static void expect_request_send_reply(struct net_if *iface, struct net_pkt *pkt)
 					   set_reply_options);
 	zassert_not_null(reply, "Failed to create pkt");
 
-	result = net_ipv6_input(reply, false);
+	result = net_ipv6_input(reply);
 	zassert_equal(result, NET_OK, "Message should've been processed");
 
 	k_sem_give(&test_ctx.exchange_complete_sem);
@@ -1013,7 +1013,7 @@ static void expect_solicit_send_advertise(struct net_if *iface, struct net_pkt *
 					   set_advertise_options);
 	zassert_not_null(reply, "Failed to create pkt");
 
-	result = net_ipv6_input(reply, false);
+	result = net_ipv6_input(reply);
 	zassert_equal(result, NET_OK, "Message should've been processed");
 }
 
@@ -1058,7 +1058,7 @@ static void test_confirm_expect_confirm_send_reply(struct net_if *iface,
 					   set_reply_options);
 	zassert_not_null(reply, "Failed to create pkt");
 
-	result = net_ipv6_input(reply, false);
+	result = net_ipv6_input(reply);
 	zassert_equal(result, NET_OK, "Message should've been processed");
 
 	/* Verify client state */
@@ -1127,7 +1127,7 @@ static void test_rebind_expect_rebind_send_reply(struct net_if *iface,
 					   set_reply_options);
 	zassert_not_null(reply, "Failed to create pkt");
 
-	result = net_ipv6_input(reply, false);
+	result = net_ipv6_input(reply);
 	zassert_equal(result, NET_OK, "Message should've been processed");
 
 	/* Verify client state */
@@ -1201,7 +1201,7 @@ static void test_renew_expect_renew_send_reply(struct net_if *iface,
 					   set_reply_options);
 	zassert_not_null(reply, "Failed to create pkt");
 
-	result = net_ipv6_input(reply, false);
+	result = net_ipv6_input(reply);
 	zassert_equal(result, NET_OK, "Message should've been processed");
 
 	/* Verify client state */

--- a/tests/net/icmpv4/src/main.c
+++ b/tests/net/icmpv4/src/main.c
@@ -452,7 +452,7 @@ static void icmpv4_send_echo_req(void)
 		zassert_true(false, "EchoRequest packet prep failed");
 	}
 
-	if (net_ipv4_input(pkt, false)) {
+	if (net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
 		zassert_true(false, "Failed to send");
 	}
@@ -474,7 +474,7 @@ static void icmpv4_send_echo_rep(void)
 		zassert_true(false, "EchoReply packet prep failed");
 	}
 
-	if (net_ipv4_input(pkt, false)) {
+	if (net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
 		zassert_true(false, "Failed to send");
 	}
@@ -494,7 +494,7 @@ ZTEST(net_icmpv4, test_icmpv4_send_echo_req_opt)
 		zassert_true(false, "EchoRequest with opts packet prep failed");
 	}
 
-	if (net_ipv4_input(pkt, false)) {
+	if (net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
 		zassert_true(false, "Failed to send");
 	}
@@ -510,7 +510,7 @@ ZTEST(net_icmpv4, test_send_echo_req_bad_opt)
 			     "EchoRequest with bad opts packet prep failed");
 	}
 
-	if (net_ipv4_input(pkt, false)) {
+	if (net_ipv4_input(pkt)) {
 		net_pkt_unref(pkt);
 	}
 }

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -596,7 +596,7 @@ static void igmp_send_query(bool is_imgpv3)
 	pkt = prepare_igmp_query(net_iface, is_imgpv3);
 	zassert_not_null(pkt, "IGMPv2 query packet prep failed");
 
-	zassert_equal(net_ipv4_input(pkt, false), NET_OK, "Failed to send");
+	zassert_equal(net_ipv4_input(pkt), NET_OK, "Failed to send");
 
 	zassert_ok(k_sem_take(&wait_data, K_MSEC(WAIT_TIME)), "Timeout while waiting query event");
 

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -1735,7 +1735,7 @@ static enum net_verdict recv_msg(struct in6_addr *src, struct in6_addr *dst)
 	/* We by-pass the normal packet receiving flow in this case in order
 	 * to simplify the testing.
 	 */
-	return net_ipv6_input(pkt, false);
+	return net_ipv6_input(pkt);
 }
 
 static int send_msg(struct in6_addr *src, struct in6_addr *dst)

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -1067,9 +1067,9 @@ static void test_virtual_recv_data_from_tunnel(int remote_ip,
 	net_pkt_cursor_init(outer);
 
 	if (peer_addr.sa_family == AF_INET) {
-		verdict = net_ipv4_input(outer, false);
+		verdict = net_ipv4_input(outer);
 	} else {
-		verdict = net_ipv6_input(outer, false);
+		verdict = net_ipv6_input(outer);
 	}
 
 	if (expected_ok) {


### PR DESCRIPTION
Store a flag about which layer has already processed a packet in its meta
information. This enables deferred processing of it.

Based on: https://github.com/zephyrproject-rtos/zephyr/pull/93246
