### PR TITLE
modules: nrf_wifi: Fix bustest QSPI crash

### DIFF
--- a/include/zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h
+++ b/include/zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h
@@ -31,6 +31,11 @@ enum {
 	NUM_MEM_BLOCKS
 };
 
+/* Keeping it high to avoid changing it often, but modify this value
+ * if rpu_7002_memmap is changed.
+ */
+#define NRF_WIFI_QSPI_SLAVE_MAX_LATENCY 4
+
 extern char blk_name[][15];
 extern uint32_t rpu_7002_memmap[][3];
 


### PR DESCRIPTION
Commit 5e25283821a("drivers: wifi: Create dedicated mem pool for Wi-Fi driver") introduced OSAL dependecy in the Zephyr QSPI driver for HL read, but in bustest we don't enable nrf_wifi OS module, so, it crashes here. And we should not be using OSAL APIs in Zephyr code anyway.

And in this case we don't even need to use the heap, so, move the rx buffer to stack.