### PR TITLE
NXP Add SCMI P2A workflow and BBNSM protocol

### DIFF
--- a/doc/hardware/arch/arm-scmi.rst
+++ b/doc/hardware/arch/arm-scmi.rst
@@ -213,6 +213,17 @@ example, ``CPU_SLEEP_MODE_SET``.
 	This driver is NXP-specific. As such, it may only be used on NXP
 	system that uses SCMI for cpu domain management operations.
 
+NXP - BBNSM management
+***************************
+
+This protocol is intended provide access to the battery-backed module.
+This contains persistent storage (GPR), an RTC, and the ON/OFF button,
+for example, ``scmi_bbm_button_notify``.
+
+.. note::
+	This driver is NXP-specific. As such, it may only be used on NXP
+	system that uses SCMI for bbnsm domain management operations.
+
 Enabling the SCMI support
 *************************
 

--- a/drivers/clock_control/clock_control_arm_scmi.c
+++ b/drivers/clock_control/clock_control_arm_scmi.c
@@ -121,4 +121,4 @@ static struct scmi_clock_data data;
 
 DT_INST_SCMI_PROTOCOL_DEFINE(0, &scmi_clock_init, NULL, &data, NULL,
 			     PRE_KERNEL_1, CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-			     &scmi_clock_api, SCMI_CLK_PROTOCOL_SUPPORTED_VERSION);
+			     &scmi_clock_api, SCMI_CLK_PROTOCOL_SUPPORTED_VERSION, NULL);

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -62,11 +62,6 @@ static int scmi_core_setup_chan(const struct device *transport,
 		return 0;
 	}
 
-	/* no support for RX channels ATM */
-	if (!tx) {
-		return -ENOTSUP;
-	}
-
 	k_mutex_init(&chan->lock);
 	k_sem_init(&chan->sem, 0, 1);
 
@@ -264,6 +259,7 @@ static int scmi_core_protocol_setup(const struct device *transport)
 #ifndef CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS
 		/* no static channel allocation, attempt dynamic binding */
 		it->tx = scmi_transport_request_channel(transport, it->id, true);
+		it->rx = scmi_transport_request_channel(transport, it->id, false);
 #endif /* CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS */
 
 		if (!it->tx) {
@@ -273,6 +269,14 @@ static int scmi_core_protocol_setup(const struct device *transport)
 		ret = scmi_core_setup_chan(transport, it->tx, true);
 		if (ret < 0) {
 			return ret;
+		}
+
+		/* notification/delayed reply channel is optional */
+		if (it->rx) {
+			ret = scmi_core_setup_chan(transport, it->rx, false);
+			if (ret < 0) {
+				return ret;
+			}
 		}
 
 		ret = scmi_core_protocol_negotiate(it);

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -42,10 +42,24 @@ int scmi_status_to_errno(int scmi_status)
 	}
 }
 
-static void scmi_core_reply_cb(struct scmi_channel *chan)
+static void scmi_core_reply_cb(struct scmi_channel *chan, int hdr)
 {
-	if (!k_is_pre_kernel()) {
-		k_sem_give(&chan->sem);
+	int msg_type;
+
+	msg_type = SCMI_MESSAGE_HDR_TAKE_TYPE(hdr);
+
+	switch (msg_type) {
+	case SCMI_COMMAND:
+		if (!k_is_pre_kernel()) {
+			k_sem_give(&chan->sem);
+		}
+		break;
+	case SCMI_DELAYED_REPLY:
+		break;
+	case SCMI_NOTIFICATION:
+		break;
+	default:
+		LOG_WRN("Unexpected message type %u", msg_type);
 	}
 }
 

--- a/drivers/firmware/scmi/core.c
+++ b/drivers/firmware/scmi/core.c
@@ -295,6 +295,28 @@ static int scmi_core_protocol_negotiate(struct scmi_protocol *proto)
 	return 0;
 }
 
+int scmi_read_message(struct scmi_protocol *proto, struct scmi_message *msg)
+{
+	if (!proto->rx) {
+		return -ENODEV;
+	}
+
+	if (!proto->rx->ready) {
+		return -EINVAL;
+	}
+
+	/* read message from platform, such as notification event
+	 *
+	 * Unlike scmi_send_message, reading messages with scmi_read_message is not currently
+	 * required in the PRE_KERNEL stage. The interrupt-based logic is used here.
+	 */
+	if (k_is_pre_kernel()) {
+		return -EINVAL;
+	}
+
+	return scmi_transport_read_message(proto->transport, proto->rx, msg);
+}
+
 static int scmi_core_protocol_setup(const struct device *transport)
 {
 	int ret;

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -9,10 +9,10 @@
 
 LOG_MODULE_REGISTER(scmi_mbox);
 
-static void scmi_mbox_cb(const struct device *mbox,
-			 mbox_channel_id_t channel_id,
-			 void *user_data,
-			 struct mbox_msg *data)
+static void scmi_mbox_tx_reply_cb(const struct device *mbox,
+		mbox_channel_id_t channel_id,
+		void *user_data,
+		struct mbox_msg *data)
 {
 	struct scmi_channel *scmi_chan = user_data;
 
@@ -81,7 +81,7 @@ static int scmi_mbox_setup_chan(const struct device *transport,
 		tx_reply = &mbox_chan->tx;
 	}
 
-	ret = mbox_register_callback_dt(tx_reply, scmi_mbox_cb, chan);
+	ret = mbox_register_callback_dt(tx_reply, scmi_mbox_tx_reply_cb, chan);
 	if (ret < 0) {
 		LOG_ERR("failed to register tx reply cb");
 		return ret;

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -75,10 +75,6 @@ static int scmi_mbox_setup_chan(const struct device *transport,
 
 	mbox_chan = chan->data;
 
-	if (!tx) {
-		return -ENOTSUP;
-	}
-
 	if (mbox_chan->tx_reply.dev) {
 		tx_reply = &mbox_chan->tx_reply;
 	} else {

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -27,9 +27,12 @@ static void scmi_mbox_rx_notify_cb(const struct device *mbox,
 				struct mbox_msg *data)
 {
 	struct scmi_channel *scmi_chan = user_data;
+	struct scmi_mbox_channel *mbox_chan = scmi_chan->data;
+	const struct device *shmem = mbox_chan->shmem;
 
 	if (scmi_chan->cb) {
 		scmi_chan->cb(scmi_chan);
+		scmi_shmem_clear_channel_status(shmem);
 	}
 }
 

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -41,7 +41,7 @@ static void scmi_mbox_tx_reply_cb(const struct device *mbox,
 	scmi_mbox_read_msg_hdr(scmi_chan, &msg);
 
 	if (scmi_chan->cb) {
-		scmi_chan->cb(scmi_chan);
+		scmi_chan->cb(scmi_chan, msg.hdr);
 	}
 }
 
@@ -58,7 +58,7 @@ static void scmi_mbox_rx_notify_cb(const struct device *mbox,
 	scmi_mbox_read_msg_hdr(scmi_chan, &msg);
 
 	if (scmi_chan->cb) {
-		scmi_chan->cb(scmi_chan);
+		scmi_chan->cb(scmi_chan, msg.hdr);
 		scmi_shmem_clear_channel_status(shmem);
 	}
 }

--- a/drivers/firmware/scmi/mailbox.c
+++ b/drivers/firmware/scmi/mailbox.c
@@ -74,7 +74,7 @@ static bool scmi_mbox_channel_is_free(const struct device *transport,
 	struct scmi_mbox_channel *mbox_chan = chan->data;
 
 	return scmi_shmem_channel_status(mbox_chan->shmem) &
-		SCMI_SHMEM_CHAN_STATUS_BUSY_BIT;
+		SCMI_SHMEM_CHAN_STATUS_FREE_BIT;
 }
 
 static int scmi_mbox_setup_chan(const struct device *transport,

--- a/drivers/firmware/scmi/nxp/CMakeLists.txt
+++ b/drivers/firmware/scmi/nxp/CMakeLists.txt
@@ -5,3 +5,4 @@ zephyr_library_property(ALLOW_EMPTY TRUE)
 
 zephyr_library_sources_ifdef(CONFIG_ARM_SCMI_NXP_VENDOR_EXTENSIONS shmem.c)
 zephyr_library_sources_ifdef(CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS cpu.c)
+zephyr_library_sources_ifdef(CONFIG_NXP_SCMI_BBM bbm.c)

--- a/drivers/firmware/scmi/nxp/Kconfig
+++ b/drivers/firmware/scmi/nxp/Kconfig
@@ -16,4 +16,11 @@ config NXP_SCMI_CPU_DOMAIN_HELPERS
 	help
 	  Enable support for SCMI cpu domain protocol helper functions.
 
+config NXP_SCMI_BBM
+	bool "NXP BBM SCMI interface protocol"
+	default y
+	depends on DT_HAS_NXP_SCMI_BBM_ENABLED
+	help
+	Enable support for SCMI NXP BBM functions.
+
 endif # ARM_SCMI_NXP_VENDOR_EXTENSIONS

--- a/drivers/firmware/scmi/nxp/bbm.c
+++ b/drivers/firmware/scmi/nxp/bbm.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/firmware/scmi/nxp/bbm.h>
+#include <string.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(scmi_nxp_bbm);
+
+static uint32_t scmi_nxp_bbm_events[] = {
+	SCMI_PROTO_BBM_PROTOCOL_BUTTON_EVENT,
+};
+
+static struct scmi_protocol_event bbm_event = {
+	.evts = scmi_nxp_bbm_events,
+	.num_events = ARRAY_SIZE(scmi_nxp_bbm_events),
+	.cb = scmi_bbm_event_protocol_cb,
+};
+
+DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_bbm), NULL,
+		SCMI_NXP_BBM_PROTOCOL_SUPPORTED_VERSION, &bbm_event);
+
+int scmi_bbm_button_notify(uint32_t flags)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_BBM);
+	struct scmi_message msg, reply;
+	int32_t status, ret;
+
+	/* sanity checks */
+	if (proto->id != SCMI_PROTOCOL_NXP_BBM) {
+		return -EINVAL;
+	}
+
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_PROTO_BBM_BBM_BUTTON_NOTIFY, SCMI_COMMAND,
+					proto->id, 0);
+	msg.len = sizeof(flags);
+	msg.content = &flags;
+
+	reply.hdr = msg.hdr;
+	reply.len = sizeof(status);
+	reply.content = &status;
+
+	ret = scmi_send_message(proto, &msg, &reply, k_is_pre_kernel());
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+int scmi_bbm_button_event(uint32_t *flags)
+{
+	struct scmi_protocol *proto = &SCMI_PROTOCOL_NAME(SCMI_PROTOCOL_NXP_BBM);
+	struct scmi_message msg;
+	int32_t ret;
+
+	/* sanity checks */
+	if (proto->id != SCMI_PROTOCOL_NXP_BBM) {
+		return -EINVAL;
+	}
+
+	/* TODO: Implement token handling for P2A flow to correctly associate notifications */
+	msg.hdr = SCMI_MESSAGE_HDR_MAKE(SCMI_PROTO_BBM_PROTOCOL_BUTTON_EVENT, SCMI_NOTIFICATION,
+			proto->id, 0x0);
+	msg.len = sizeof(flags);
+	msg.content = flags;
+
+	ret = scmi_read_message(proto, &msg);
+	if (ret < 0) {
+		return ret;
+	}
+
+	return 0;
+}
+
+int scmi_bbm_event_protocol_cb(int32_t msg_id)
+{
+	uint32_t flags;
+	int32_t ret = 0;
+
+	if (msg_id == SCMI_PROTO_BBM_PROTOCOL_BUTTON_EVENT) {
+		ret = scmi_bbm_button_event(&flags);
+		if (ret < 0) {
+			LOG_ERR("failed to read bbm button event to shmem: %d", ret);
+		} else {
+			LOG_INF("SCMI BBM BUTTON notification: flags=0x%08X", flags);
+		}
+	}
+
+	return ret;
+}

--- a/drivers/firmware/scmi/nxp/cpu.c
+++ b/drivers/firmware/scmi/nxp/cpu.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, nxp_scmi_cpu), NULL,
-		SCMI_NXP_CPU_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_NXP_CPU_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 struct scmi_nxp_cpu_info_get_reply {
 	int32_t status;

--- a/drivers/firmware/scmi/pinctrl.c
+++ b/drivers/firmware/scmi/pinctrl.c
@@ -8,7 +8,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_pinctrl), NULL,
-		SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_PIN_CONTROL_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 int scmi_pinctrl_settings_configure(struct scmi_pinctrl_settings *settings)
 {

--- a/drivers/firmware/scmi/power.c
+++ b/drivers/firmware/scmi/power.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_power), NULL,
-		SCMI_POWER_DOMAIN_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_POWER_DOMAIN_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 struct scmi_power_state_get_reply {
 	int32_t status;

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -133,7 +133,7 @@ int scmi_shmem_write_message(const struct device *shmem, struct scmi_message *ms
 		return -EINVAL;
 	}
 
-	if (!(layout->chan_status & SCMI_SHMEM_CHAN_STATUS_BUSY_BIT)) {
+	if (!(layout->chan_status & SCMI_SHMEM_CHAN_STATUS_FREE_BIT)) {
 		return -EBUSY;
 	}
 
@@ -150,7 +150,7 @@ int scmi_shmem_write_message(const struct device *shmem, struct scmi_message *ms
 	}
 
 	/* done, mark channel as busy and proceed */
-	layout->chan_status &= ~SCMI_SHMEM_CHAN_STATUS_BUSY_BIT;
+	layout->chan_status &= ~SCMI_SHMEM_CHAN_STATUS_FREE_BIT;
 
 	return 0;
 }

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -59,6 +59,30 @@ static void scmi_shmem_memcpy(mm_reg_t dst, mm_reg_t src, uint32_t bytes)
 	}
 }
 
+int scmi_shmem_read_hdr(const struct device *shmem, struct scmi_message *msg)
+{
+	struct scmi_shmem_layout *layout;
+	struct scmi_shmem_data *data;
+
+	data = shmem->data;
+	layout = (struct scmi_shmem_layout *)data->regmap;
+
+	/* some sanity checks first */
+	if (!msg) {
+		return -EINVAL;
+	}
+
+	if (scmi_shmem_vendor_read_message(layout) < 0) {
+		LOG_ERR("vendor specific validation failed");
+		return -EINVAL;
+	}
+
+	scmi_shmem_memcpy(POINTER_TO_UINT(&msg->hdr),
+			data->regmap + SCMI_SHMEM_CHAN_MSG_HDR_OFFSET, sizeof(uint32_t));
+
+	return 0;
+}
+
 __weak int scmi_shmem_vendor_read_message(const struct scmi_shmem_layout *layout)
 {
 	return 0;

--- a/drivers/firmware/scmi/shmem.c
+++ b/drivers/firmware/scmi/shmem.c
@@ -39,6 +39,17 @@ int scmi_shmem_get_channel_status(const struct device *dev, uint32_t *status)
 	return 0;
 }
 
+void scmi_shmem_clear_channel_status(const struct device *dev)
+{
+	struct scmi_shmem_data *data;
+	struct scmi_shmem_layout *layout;
+
+	data = dev->data;
+	layout = (struct scmi_shmem_layout *)data->regmap;
+
+	layout->chan_status |= SCMI_SHMEM_CHAN_STATUS_FREE_BIT;
+}
+
 static void scmi_shmem_memcpy(mm_reg_t dst, mm_reg_t src, uint32_t bytes)
 {
 	int i;

--- a/drivers/firmware/scmi/system.c
+++ b/drivers/firmware/scmi/system.c
@@ -9,7 +9,7 @@
 #include <zephyr/kernel.h>
 
 DT_SCMI_PROTOCOL_DEFINE_NODEV(DT_INST(0, arm_scmi_system), NULL,
-		SCMI_SYSTEM_POWER_PROTOCOL_SUPPORTED_VERSION);
+		SCMI_SYSTEM_POWER_PROTOCOL_SUPPORTED_VERSION, NULL);
 
 int scmi_system_protocol_version(uint32_t *version)
 {

--- a/dts/arm/nxp/nxp_imx95_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx95_m7.dtsi
@@ -63,14 +63,19 @@
 			compatible = "arm,scmi-shmem";
 			reg = <0x44611000 0x80>;
 		};
+
+		scmi_shmem1: memory@44611080 {
+			compatible = "arm,scmi-shmem";
+			reg = <0x44611080 0x80>;
+		};
 	};
 
 	firmware {
 		scmi {
 			compatible = "arm,scmi";
-			shmem = <&scmi_shmem0>;
-			mboxes = <&mu5 0>;
-			mbox-names = "tx";
+			shmem = <&scmi_shmem0>, <&scmi_shmem1>;
+			mboxes = <&mu5 0>, <&mu5 1>;
+			mbox-names = "tx", "rx";
 
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -104,6 +109,11 @@
 			scmi_cpu: protocol@82 {
 				compatible = "nxp,scmi-cpu";
 				reg = <0x82>;
+			};
+
+			scmi_bbm: protocol@81 {
+				compatible = "nxp,scmi-bbm";
+				reg = <0x81>;
 			};
 		};
 	};

--- a/dts/bindings/firmware/arm,scmi.yaml
+++ b/dts/bindings/firmware/arm,scmi.yaml
@@ -48,11 +48,12 @@ include: [base.yaml]
 
 properties:
   shmem:
-    type: phandle
+    type: phandles
     required: true
     description: |
-      Phandle to node describing TX channel shared memory area.
-      This translates to a **single** SCMI transmit channel.
+      Phandle array to nodes describing shared memory areas for SCMI transport.
+      The first entry corresponds to the TX channel, and the second (if present)
+      corresponds to the RX channel.
 
   mboxes:
     required: true
@@ -62,6 +63,8 @@ properties:
         mailbox channel for signaling)
         2) tx_reply - 2 mbox / 1 shmem (platform and agent use different
         mailbox channels for signaling)
+        3) tx + rx - 2 mbox / 2 shmem (platform and agent use different mailbox
+        channels and shmem between scmi_command and scmi_notification)
 
   mbox-names:
     required: true

--- a/dts/bindings/firmware/nxp,scmi-bbm.yaml
+++ b/dts/bindings/firmware/nxp,scmi-bbm.yaml
@@ -1,0 +1,13 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: System Control and Management Interface (SCMI) bbm protocol
+
+compatible: "nxp,scmi-bbm"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+    const: [0x81]

--- a/include/zephyr/drivers/firmware/scmi/nxp/bbm.h
+++ b/include/zephyr/drivers/firmware/scmi/nxp/bbm.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief SCMI NXP BBNSM domain protocol helpers
+ */
+
+#ifndef _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_BBM_H_
+#define _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_BBM_H_
+
+#include <zephyr/drivers/firmware/scmi/protocol.h>
+
+#define SCMI_PROTOCOL_NXP_BBM	129
+
+#define SCMI_NXP_BBM_PROTOCOL_SUPPORTED_VERSION	0x10000
+
+/*!
+ * @name SCMI NXP BBM button notification flags
+ */
+/** @{ */
+/*! Enable button notifications */
+#define SCMI_BBM_NOTIFY_BUTTON_DETECT(x)  (((x) & 0x1U) << 0U)
+/** @} */
+
+/**
+ * @brief Bbm protocol command message IDs
+ */
+enum scmi_bbm_message {
+	SCMI_PROTO_BBM_PROTOCOL_RTC_EVENT = 0x0,
+	SCMI_PROTO_BBM_PROTOCOL_BUTTON_EVENT = 0x1,
+	SCMI_PROTO_BBM_BBM_GPR_SET = 0x3,
+	SCMI_PROTO_BBM_BBM_GPR_GET = 0x4,
+	SCMI_PROTO_BBM_BBM_RTC_ATTRIBUTES = 0x5,
+	SCMI_PROTO_BBM_BBM_RTC_TIME_SET = 0x6,
+	SCMI_PROTO_BBM_BBM_RTC_TIME_GET = 0x7,
+	SCMI_PROTO_BBM_BBM_RTC_ALARM_SET = 0x8,
+	SCMI_PROTO_BBM_BBM_BUTTON_GET = 0x9,
+	SCMI_PROTO_BBM_BBM_RTC_NOTIFY = 0xA,
+	SCMI_PROTO_BBM_BBM_BUTTON_NOTIFY = 0xB,
+	SCMI_PROTO_BBM_BBM_RTC_STATE = 0xC,
+	SCMI_PROTO_BBM_NEGOTIATE_PROTOCOL_VERSION = 0x10,
+};
+
+/**
+ * @brief Set up BBM button notify message
+ *
+ * @param flags to enable or disable button notify for agent
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_bbm_button_notify(uint32_t flags);
+
+/**
+ * @brief Read BBM button event message
+ *
+ * @param flags to get notification event from agent
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_bbm_button_event(uint32_t *flags);
+
+/**
+ * @brief BBM event notification callback
+ *
+ * @param msg_id to determine and handle the corresponding event.
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_bbm_event_protocol_cb(int32_t msg_id);
+#endif /* _INCLUDE_ZEPHYR_DRIVERS_FIRMWARE_SCMI_BBM_H_ */

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -128,6 +128,36 @@ struct scmi_protocol {
 	void *data;
 	/** protocol supported version */
 	uint32_t version;
+	/** protocol event */
+	struct scmi_protocol_event *events;
+};
+
+/**
+ * @typedef scmi_protocol_event_callback
+ * @brief Per‑protocol notification callback invoked by the SCMI core.
+ *
+ * Define event-specific information during the static registration phase
+ * of each SCMI protocol. When a P2A notification/interrupt is received,
+ * the SCMI core decodes the message and dispatches it to the corresponding
+ * protocol's callback.
+ *
+ * @param msg_id is the protocol specific message index.
+ * @return int 0 on success, negative error code on failure
+ */
+typedef int (*scmi_protocol_event_callback)(int32_t msg_id);
+
+/**
+ * @struct scmi_protocol_event
+ *
+ * @brief SCMI protocol event structure
+ */
+struct scmi_protocol_event {
+	/** events ids */
+	uint32_t *evts;
+	/** Number of supported protocol's events **/
+	uint32_t num_events;
+	/** protocol private event call back **/
+	scmi_protocol_event_callback cb;
 };
 
 /**

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -25,6 +25,19 @@
 #include <stdint.h>
 #include <errno.h>
 
+/* The composition and offset of scmi messages */
+#define SCMI_MSGID_SHIFT       0
+#define SCMI_MSGID_MASK        GENMASK(7, 0)
+
+#define SCMI_TYPE_SHIFT        8
+#define SCMI_TYPE_MASK         GENMASK(1, 0)
+
+#define SCMI_PROTOCOL_SHIFT    10
+#define SCMI_PROTOCOL_MASK     GENMASK(7, 0)
+
+#define SCMI_TOKEN_SHIFT       18
+#define SCMI_TOKEN_MASK        GENMASK(9, 0)
+
 /**
  * @brief Build an SCMI message header
  *
@@ -36,11 +49,24 @@
  * @param proto protocol ID
  * @param token message token
  */
-#define SCMI_MESSAGE_HDR_MAKE(id, type, proto, token)	\
-	(SCMI_FIELD_MAKE(id, GENMASK(7, 0), 0)     |	\
-	 SCMI_FIELD_MAKE(type, GENMASK(1, 0), 8)   |	\
-	 SCMI_FIELD_MAKE(proto, GENMASK(7, 0), 10) |	\
-	 SCMI_FIELD_MAKE(token, GENMASK(9, 0), 18))
+#define SCMI_MESSAGE_HDR_MAKE(id, type, proto, token)						\
+	(SCMI_FIELD_MAKE((id),          SCMI_MSGID_MASK,    SCMI_MSGID_SHIFT)           |       \
+	SCMI_FIELD_MAKE((type),         SCMI_TYPE_MASK,     SCMI_TYPE_SHIFT)            |       \
+	SCMI_FIELD_MAKE((proto),        SCMI_PROTOCOL_MASK, SCMI_PROTOCOL_SHIFT)        |       \
+	SCMI_FIELD_MAKE((token),        SCMI_TOKEN_MASK,    SCMI_TOKEN_SHIFT))
+
+/**
+ * @brief Extract a field from SCMI message header
+ * @param hdr   the 32-bit SCMI message header
+ * @param FIELD one of: MSGID, TYPE, PROTOCOL, TOKEN
+ */
+#define SCMI_MESSAGE_HDR_TAKE(hdr, FIELD) \
+	SCMI_FIELD_TAKE((hdr), SCMI_##FIELD##_MASK, SCMI_##FIELD##_SHIFT)
+
+#define SCMI_MESSAGE_HDR_TAKE_MSGID(hdr)    SCMI_MESSAGE_HDR_TAKE(hdr, MSGID)
+#define SCMI_MESSAGE_HDR_TAKE_TYPE(hdr)     SCMI_MESSAGE_HDR_TAKE(hdr, TYPE)
+#define SCMI_MESSAGE_HDR_TAKE_PROTOCOL(hdr) SCMI_MESSAGE_HDR_TAKE(hdr, PROTOCOL)
+#define SCMI_MESSAGE_HDR_TAKE_TOKEN(hdr)    SCMI_MESSAGE_HDR_TAKE(hdr, TOKEN)
 
 struct scmi_channel;
 

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -251,6 +251,19 @@ int scmi_protocol_message_attributes_get(struct scmi_protocol *proto,
 int scmi_protocol_version_negotiate(struct scmi_protocol *proto, uint32_t version);
 
 /**
+ * @brief Read an SCMI message
+ *
+ * Blocking function used to read an SCMI message over a given channel
+ *
+ * @param proto pointer to SCMI protocol
+ * @param msg pointer to SCMI message to read
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+int scmi_read_message(struct scmi_protocol *proto, struct scmi_message *msg);
+
+/**
  * @}
  */
 

--- a/include/zephyr/drivers/firmware/scmi/protocol.h
+++ b/include/zephyr/drivers/firmware/scmi/protocol.h
@@ -94,6 +94,8 @@ struct scmi_protocol {
 	uint32_t id;
 	/** TX channel */
 	struct scmi_channel *tx;
+	/** RX channel */
+	struct scmi_channel *rx;
 	/** transport layer device */
 	const struct device *transport;
 	/** protocol private data */

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -102,6 +102,13 @@ int scmi_shmem_vendor_write_message(struct scmi_shmem_layout *layout);
 int scmi_shmem_vendor_read_message(const struct scmi_shmem_layout *layout);
 
 /**
+ * @brief Clear a SHMEM area channel status
+ *
+ * @param dev pointer to shmem device
+ */
+void scmi_shmem_clear_channel_status(const struct device *dev);
+
+/**
  * @}
  */
 

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -24,7 +24,7 @@
  * @{
  */
 
-#define SCMI_SHMEM_CHAN_STATUS_BUSY_BIT BIT(0)
+#define SCMI_SHMEM_CHAN_STATUS_FREE_BIT BIT(0)
 #define SCMI_SHMEM_CHAN_FLAG_IRQ_BIT BIT(0)
 
 struct scmi_shmem_layout {

--- a/include/zephyr/drivers/firmware/scmi/shmem.h
+++ b/include/zephyr/drivers/firmware/scmi/shmem.h
@@ -27,6 +27,8 @@
 #define SCMI_SHMEM_CHAN_STATUS_FREE_BIT BIT(0)
 #define SCMI_SHMEM_CHAN_FLAG_IRQ_BIT BIT(0)
 
+#define SCMI_SHMEM_CHAN_MSG_HDR_OFFSET 0x18
+
 struct scmi_shmem_layout {
 	volatile uint32_t res0;
 	volatile uint32_t chan_status;
@@ -107,6 +109,18 @@ int scmi_shmem_vendor_read_message(const struct scmi_shmem_layout *layout);
  * @param dev pointer to shmem device
  */
 void scmi_shmem_clear_channel_status(const struct device *dev);
+
+/**
+ * @brief Read a message header from a SHMEM area
+ *
+ * @param shmem pointer to shmem device
+ * @param msg message to write the data into
+ *
+ * @retval 0 if successful
+ * @retval negative errno if failure
+ */
+
+int scmi_shmem_read_hdr(const struct device *shmem, struct scmi_message *msg);
 
 /**
  * @}

--- a/include/zephyr/drivers/firmware/scmi/transport.h
+++ b/include/zephyr/drivers/firmware/scmi/transport.h
@@ -39,8 +39,9 @@ struct scmi_channel;
  *
  * @param chan pointer to SCMI channel on which the reply
  * arrived
+ * @param hdr is the share memory Message header
  */
-typedef void (*scmi_channel_cb)(struct scmi_channel *chan);
+typedef void (*scmi_channel_cb)(struct scmi_channel *chan, int hdr);
 
 /**
  * @struct scmi_channel

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -317,6 +317,16 @@
 	(((uint32_t)(x) & (mask)) << (shift))
 
 /**
+ * @brief Extract an SCMI message field
+ *
+ * @param x value to encode
+ * @param mask value to perform bitwise-and with `x`
+ * @param shift value to left-shift masked `x`
+ */
+#define SCMI_FIELD_TAKE(x, mask, shift) \
+	((((uint32_t)(x)) >> (shift)) & (uint32_t)(mask))
+
+/**
  * @brief SCMI protocol IDs
  *
  * Each SCMI protocol is identified by an ID. Each

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -61,7 +61,7 @@
 #define SCMI_TRANSPORT_CHAN_NAME(proto, idx) CONCAT(scmi_channel_, proto, _, idx)
 
 /**
- * @brief Declare a TX SCMI channel
+ * @brief Declare TX SCMI channel
  *
  * Given a node_id for a protocol, this macro declares the SCMI
  * TX channel statically bound to said protocol via the "extern"
@@ -79,19 +79,40 @@
 		     SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 0);))		\
 
 /**
+ * @brief Declare RX SCMI channel
+ *
+ * Given a node_id for a protocol, this macro declares the SCMI
+ * RX channel statically bound to said protocol via the "extern" qualifier.
+ * The declaration depends on both the current protocol node
+ * and the SCMI parent node. The logic follows this priority:
+ * 1. First check if RX channel exists in the current protocol node
+ * 2. If not found, check the parent SCMI node for RX channel
+ * 3. If neither the current protocol node nor parent node has RX channel,
+ *    set it to NULL
+ *
+ * @param node_id protocol node identifier
+ */
+#define DT_SCMI_TRANSPORT_RX_CHAN_DECLARE(node_id)					\
+	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 1),			\
+		    (extern struct scmi_channel						\
+		     SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR_RAW(node_id), 1);),		\
+		     (COND_CODE_1(DT_PROP_HAS_IDX(DT_PARENT(node_id), shmem, 1),	\
+				  (extern struct scmi_channel				\
+				   SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 1);),	\
+				   (/* no decl when NULL */))))
+
+/**
  * @brief Declare SCMI TX/RX channels
  *
  * Given a node_id for a protocol, this macro declares the
  * SCMI TX and RX channels statically bound to said protocol via
- * the "extern" qualifier. Since RX channels are currently not
- * supported, this is equivalent to DT_SCMI_TRANSPORT_TX_CHAN_DECLARE().
- * Despite this, users should opt for this macro instead of the TX-specific
- * one.
+ * the "extern" qualifier.
  *
  * @param node_id protocol node identifier
  */
 #define DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
 	DT_SCMI_TRANSPORT_TX_CHAN_DECLARE(node_id)				\
+	DT_SCMI_TRANSPORT_RX_CHAN_DECLARE(node_id)				\
 
 /**
  * @brief Declare SCMI TX/RX channels using node instance number
@@ -120,6 +141,25 @@
 	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 0),		\
 		    (&SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR_RAW(node_id), 0)),	\
 		    (&SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 0)))
+
+/**
+ * @brief Get a reference to a protocol's SCMI RX channel
+ *
+ * Given a node_id for a protocol, this macro returns a
+ * reference to an SCMI RX channel statically bound to said
+ * protocol.
+ *
+ * @param node_id protocol node identifier
+ *
+ * @return reference to the struct scmi_channel of the RX channel
+ * bound to the protocol identifier by node_id
+ */
+#define DT_SCMI_TRANSPORT_RX_CHAN(node_id)						\
+	COND_CODE_1(DT_SCMI_TRANSPORT_PROTO_HAS_CHAN(node_id, 1),			\
+		    (&SCMI_TRANSPORT_CHAN_NAME(DT_REG_ADDR_RAW(node_id), 1)),		\
+			(COND_CODE_1(DT_PROP_HAS_IDX(DT_PARENT(node_id), shmem, 1),	\
+				(&SCMI_TRANSPORT_CHAN_NAME(SCMI_PROTOCOL_BASE, 1)),	\
+				(NULL))))
 
 /**
  * @brief Define an SCMI channel for a protocol
@@ -159,6 +199,7 @@
 	{									\
 		.id = proto,							\
 		.tx = DT_SCMI_TRANSPORT_TX_CHAN(node_id),			\
+		.rx = DT_SCMI_TRANSPORT_RX_CHAN(node_id),			\
 		.data = pdata,							\
 		.version = version_val						\
 	}

--- a/include/zephyr/drivers/firmware/scmi/util.h
+++ b/include/zephyr/drivers/firmware/scmi/util.h
@@ -194,14 +194,15 @@
  * @param proto protocol ID in decimal format
  * @param pdata protocol private data
  */
-#define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata, version_val)	\
-	STRUCT_SECTION_ITERABLE(scmi_protocol, SCMI_PROTOCOL_NAME(proto)) =	\
-	{									\
-		.id = proto,							\
-		.tx = DT_SCMI_TRANSPORT_TX_CHAN(node_id),			\
-		.rx = DT_SCMI_TRANSPORT_RX_CHAN(node_id),			\
-		.data = pdata,							\
-		.version = version_val						\
+#define DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, proto, pdata, version_val, pevents)	\
+	STRUCT_SECTION_ITERABLE(scmi_protocol, SCMI_PROTOCOL_NAME(proto)) =		\
+	{										\
+		.id = proto,								\
+		.tx = DT_SCMI_TRANSPORT_TX_CHAN(node_id),				\
+		.rx = DT_SCMI_TRANSPORT_RX_CHAN(node_id),				\
+		.data = pdata,								\
+		.version = version_val,							\
+		.events = pevents							\
 	}
 
 #else /* CONFIG_ARM_SCMI_TRANSPORT_HAS_STATIC_CHANNELS */
@@ -259,10 +260,10 @@
  * @param prio protocol's priority within its initialization level
  */
 #define DT_SCMI_PROTOCOL_DEFINE(node_id, init_fn, pm, data, config,		\
-				level, prio, api, version_val)			\
+				level, prio, api, version_val, events)		\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
 	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
-			version_val);						\
+			version_val, events);					\
 	DEVICE_DT_DEFINE(node_id, init_fn, pm,					\
 			 &SCMI_PROTOCOL_NAME(DT_REG_ADDR_RAW(node_id)),		\
 					     config, level, prio, api)
@@ -280,10 +281,10 @@
  * @param level protocol initialization level
  * @param prio protocol's priority within its initialization level
  */
-#define DT_INST_SCMI_PROTOCOL_DEFINE(inst, init_fn, pm, data, config,		\
-				     level, prio, api, version)			\
-	DT_SCMI_PROTOCOL_DEFINE(DT_INST(inst, DT_DRV_COMPAT), init_fn, pm,	\
-				data, config, level, prio, api, version)
+#define DT_INST_SCMI_PROTOCOL_DEFINE(inst, init_fn, pm, data, config,			\
+				     level, prio, api, version, events)			\
+	DT_SCMI_PROTOCOL_DEFINE(DT_INST(inst, DT_DRV_COMPAT), init_fn, pm,		\
+				data, config, level, prio, api, version, events)	\
 
 /**
  * @brief Define an SCMI protocol with no device
@@ -296,10 +297,10 @@
  * @param node_id protocol node identifier
  * @param data protocol private data
  */
-#define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data, version)			\
+#define DT_SCMI_PROTOCOL_DEFINE_NODEV(node_id, data, version, events_ptr)	\
 	DT_SCMI_TRANSPORT_CHANNELS_DECLARE(node_id)				\
 	DT_SCMI_PROTOCOL_DATA_DEFINE(node_id, DT_REG_ADDR_RAW(node_id), data,	\
-			version)						\
+			version, events_ptr)					\
 
 /**
  * @brief Create an SCMI message field

--- a/soc/nxp/imx/imx9/imx95/m7/soc.c
+++ b/soc/nxp/imx/imx9/imx95/m7/soc.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/firmware/scmi/clk.h>
 #include <zephyr/drivers/firmware/scmi/nxp/cpu.h>
 #include <zephyr/drivers/firmware/scmi/power.h>
+#include <zephyr/drivers/firmware/scmi/nxp/bbm.h>
 #include <zephyr/dt-bindings/clock/imx95_clock.h>
 #include <zephyr/dt-bindings/power/imx95_power.h>
 #include <soc.h>
@@ -81,6 +82,9 @@ static int soc_init(void)
 	}
 #endif /* CONFIG_NXP_SCMI_CPU_DOMAIN_HELPERS */
 
+#if defined(CONFIG_NXP_SCMI_BBM)
+	scmi_bbm_button_notify(SCMI_BBM_NOTIFY_BUTTON_DETECT(1));
+#endif
 	return ret;
 }
 


### PR DESCRIPTION
1. SCMI P2A support: Adds RX channel handling to support notifications from platform to agent, including callback categorization for different message types.
2. Shared memory separation: Extends SCMI shared memory to an phandles to allow TX and RX to use different memory regions, which is required on platforms like i.MX95.
3. BBNSM protocol support: Adds initial support for the BBNSM domain protocol
test pass in imx95 m7 hello_word sample, The M7 core can continuously receive button messages from the SCMI platform.

 