### PR TITLE
release-notes: 4.2: Add a clarification on a new compatible

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -924,7 +924,8 @@ New Drivers
    * :dtcompatible:`microchip,vsc8541`
    * :dtcompatible:`nxp,netc-ptp-clock`
    * :dtcompatible:`nxp,tja11xx`
-   * :dtcompatible:`st,stm32-ethernet-controller`
+   * :dtcompatible:`st,stm32-ethernet-controller` has been introduced to ease interoperability
+     with :dtcompatible:`st,stm32-mdio`.
    * :dtcompatible:`st,stm32n6-ethernet`
    * :dtcompatible:`ti,dp83867`
    * :dtcompatible:`xlnx,axi-ethernet-1.00.a`


### PR DESCRIPTION
Clarify the introduction of st,stm32-ethernet-controller compatible so that reader could not understand that this is the introduction of STM32 ethernet (while it is only dts shenanigans).