### PR TITLE
dts: Added BT HCI and enabled it by default

### DIFF
--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
@@ -20,6 +20,7 @@
 		zephyr,console = &uart;
 		zephyr,shell-uart = &uart;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,bt-hci = &bt_hci_da1469x;
 	};
 
 	leds {
@@ -213,6 +214,11 @@ zephyr_udc0: &usbd {
 	pinctrl-1 = <&spi2_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+&bt_hci_da1469x {
+	status = "okay";
+};
+
 
 mikrobus_1_i2c: &i2c {};
 


### PR DESCRIPTION
This PR enables the BT HCI by default on the DA14695 USB development Kit