### PR TITLE
Bluetooth: Classic: SDP: swap elem data before uuid128 compare

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -397,7 +397,7 @@ static uint32_t search_uuid(struct bt_sdp_data_elem *elem, struct bt_uuid *uuid,
 			}
 		} else if (seq_size == 16U) {
 			u.uuid.type = BT_UUID_TYPE_128;
-			memcpy(u.u128.val, cur_elem, seq_size);
+			sys_memcpy_swap(u.u128.val, cur_elem, seq_size);
 			if (!bt_uuid_cmp(&u.uuid, uuid)) {
 				*found = true;
 			}


### PR DESCRIPTION
SDP transfer multiple-byte fields in byte order big-endian, bt_uuid_128 UUID value 128-bit in little-endian format.

Refer to line 542 of the find_services function.