### PR TITLE
drivers: wifi: siwx91x: Simplify scan state check

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi_scan.c
@@ -170,8 +170,7 @@ int siwx91x_scan(const struct device *dev, struct wifi_scan_params *z_scan_confi
 		return -EINVAL;
 	}
 
-	if (sidev->state != WIFI_STATE_DISCONNECTED && sidev->state != WIFI_STATE_INACTIVE &&
-	    sidev->state != WIFI_STATE_COMPLETED) {
+	if (sidev->state == WIFI_STATE_INTERFACE_DISABLED) {
 		LOG_ERR("Command given in invalid state");
 		return -EBUSY;
 	}


### PR DESCRIPTION
The siwx91x driver previously restricted Wi-Fi scanning based on multiple interface states, synchronizing with previous scan results. However, the underlying SDK's `sl_wifi_start_scan` API is asynchronous and does not require such synchronization. This change updates the scan logic to only return `-EBUSY` if the interface is disabled.