### PR TITLE
samples: bluetooth: pbp_public_broadcast: Fix PACS register issue

### DIFF
--- a/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
+++ b/samples/bluetooth/pbp_public_broadcast_sink/src/main.c
@@ -327,14 +327,23 @@ static int reset(void)
 int bap_broadcast_sink_init(void)
 {
 	int err;
+	const struct bt_pacs_register_param pacs_param = {
+			.snk_pac = true,
+			.snk_loc = true,
+	};
 
 	bt_bap_broadcast_sink_register_cb(&broadcast_sink_cbs);
 	bt_le_per_adv_sync_cb_register(&broadcast_sync_cb);
 
-	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap);
-	if (err) {
-		printk("Capability register failed (err %d)\n", err);
+	err = bt_pacs_register(&pacs_param);
+	if (err != 0) {
+		printk("Could not register PACS (err %d)\n", err);
+		return err;
+	}
 
+	err = bt_pacs_cap_register(BT_AUDIO_DIR_SINK, &cap);
+	if (err != 0) {
+		printk("Capability register failed (err %d)\n", err);
 		return err;
 	}
 


### PR DESCRIPTION
- Add sink PACS register for PBP public broadcast sink example to make it work with PBP broadcast source