### PR TITLE
manifest: update hal_nordic revision to integrate nrfx 3.13.0

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -66,7 +66,7 @@ static const uint32_t saadc_psels[NRF_SAADC_DVDD + 1] = {
 	[NRF_SAADC_DVDD] = NRF_SAADC_INPUT_DVDD,
 };
 #elif defined(NRF54LV10A_ENGA_XXAA)
-static const uint32_t saadc_psels[NRF_SAADC_DVDD + 1] = {
+static const uint32_t saadc_psels[NRF_SAADC_AIN7 + 1] = {
 	[NRF_SAADC_AIN0] = NRF_PIN_PORT_TO_PIN_NUMBER(0U, 1),
 	[NRF_SAADC_AIN1] = NRF_PIN_PORT_TO_PIN_NUMBER(1U, 1),
 	[NRF_SAADC_AIN2] = NRF_PIN_PORT_TO_PIN_NUMBER(2U, 1),
@@ -75,8 +75,6 @@ static const uint32_t saadc_psels[NRF_SAADC_DVDD + 1] = {
 	[NRF_SAADC_AIN5] = NRF_PIN_PORT_TO_PIN_NUMBER(10U, 1),
 	[NRF_SAADC_AIN6] = NRF_PIN_PORT_TO_PIN_NUMBER(11U, 1),
 	[NRF_SAADC_AIN7] = NRF_PIN_PORT_TO_PIN_NUMBER(12U, 1),
-	[NRF_SAADC_VDD]  = NRF_SAADC_INPUT_VDD,
-	[NRF_SAADC_DVDD] = NRF_SAADC_INPUT_DVDD,
 };
 #endif
 

--- a/tests/boards/nrf/comp/src/test.c
+++ b/tests/boards/nrf/comp/src/test.c
@@ -93,8 +93,11 @@ ZTEST(comparator_runtime_configure, test_comp_config_se_vdd)
 
 #ifdef COMP_REFSEL_REFSEL_AVDDAO1V8
 	conf.refsel = COMP_NRF_COMP_REFSEL_AVDDAO1V8;
-#else
+#elif defined(COMP_REFSEL_REFSEL_VDD)
 	conf.refsel = COMP_NRF_COMP_REFSEL_VDD;
+#else
+	/* Use internal 1.2 V derived from VDD */
+	conf.refsel = COMP_NRF_COMP_REFSEL_INT_1V2;
 #endif
 	rc = comp_nrf_comp_configure_se(test_dev, &conf);
 	zassert_equal(rc, 0, "Cannot configure comparator.");

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 9587b1dcb83d24ab74e89837843a5f7d573f7059
+      revision: 2f5d4e5868ab573eac932fa4bc142565073c3c04
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New nrfx release contains MDK 8.72.1 and various fixes for nRF devices.