### PR TITLE
drivers: dma: dw: Add power management state check in get_status

### DIFF
--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -826,8 +826,15 @@ int dw_dma_get_status(const struct device *dev, uint32_t channel,
 	struct dw_dma_dev_data *const dev_data = dev->data;
 	const struct dw_dma_dev_cfg *const dev_cfg = dev->config;
 	struct dw_dma_chan_data *chan_data;
+	enum pm_device_state pm_state;
+	int ret;
 
 	if (channel >= DW_CHAN_COUNT) {
+		return -EINVAL;
+	}
+
+	ret = pm_device_state_get(dev, &pm_state);
+	if (!ret && pm_state != PM_DEVICE_STATE_ACTIVE) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Add power management state validation in dw_dma_get_status() to ensure the device is in active state before attempting to read DMA status. Returns -EINVAL if device is not active, preventing potential issues when accessing hardware registers while device is suspended.