### PR TITLE
gitlint: adapt configuration to deal with migration warnings

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,6 +1,7 @@
 # All these sections are optional, edit this file as you like.
 # Zephyr-specific defaults are located in scripts/gitlint/zephyr_commit_rules.py
 [general]
+regex-style-search=true
 ignore=title-trailing-punctuation, T3, title-max-length, T1, body-hard-tab, B3, B1
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 verbosity = 3


### PR DESCRIPTION
Get rid of this warning:

WARNING: I4 - ignore-by-author-name: gitlint will be switching from using
Python regex 'match' (match beginning) to 'search' (match anywhere) semantics.
Please review your ignore-by-author-name.regex option accordingly. To remove
this warning, set general.regex-style-search=True. More details:
https://jorisroovers.github.io/gitlint/configuration/#regex-style-search

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
