### PR TITLE
adsp: delegate creation of virtual memory regions to the application

### DIFF
--- a/drivers/mm/Kconfig
+++ b/drivers/mm/Kconfig
@@ -44,6 +44,13 @@ config MM_DRV_INTEL_ADSP_TLB
 	  Driver for the translation lookup buffer on
 	  Intel Audio DSP hardware.
 
+config MM_DRV_INTEL_VIRTUAL_REGION_COUNT
+	int "Maximum number of regions defined in virtual memory"
+	depends on MM_DRV_INTEL_ADSP_MTL_TLB
+	default 1
+	help
+	  This options defines a table size keeping all virtual memory region
+
 config EXTERNAL_ADDRESS_TRANSLATION
 	bool "Support for external address translation modules"
 	depends on !MMU

--- a/drivers/mm/mm_drv_common.c
+++ b/drivers/mm/mm_drv_common.c
@@ -29,6 +29,37 @@
 
 struct k_spinlock sys_mm_drv_common_lock;
 
+int sys_mm_drv_map_region_safe(const struct sys_mm_drv_region *virtual_region,
+			       void *virt, uintptr_t phys, size_t size,
+			       uint32_t flags)
+{
+	uintptr_t virtual_region_start = POINTER_TO_UINT(virtual_region->addr);
+	uintptr_t virtual_region_end = virtual_region_start + virtual_region->size;
+
+	/* check if memory to be mapped is within given virtual region */
+	if ((POINTER_TO_UINT(virt) >= virtual_region_start) &&
+	    (POINTER_TO_UINT(virt) + size < virtual_region_end)) {
+		return sys_mm_drv_map_region(virt, phys, size, flags);
+	}
+
+	return -EINVAL;
+}
+
+int sys_mm_drv_map_page_safe(const struct sys_mm_drv_region *virtual_region,
+			     void *virt, uintptr_t phys, uint32_t flags)
+{
+	uintptr_t virtual_region_start = POINTER_TO_UINT(virtual_region->addr);
+	uintptr_t virtual_region_end = virtual_region_start + virtual_region->size;
+
+	/* check if memory to be mapped is within given virtual region */
+	if ((POINTER_TO_UINT(virt) >= virtual_region_start) &&
+	    (POINTER_TO_UINT(virt) + CONFIG_MM_DRV_PAGE_SIZE < virtual_region_end)) {
+		return sys_mm_drv_map_page(virt, phys, flags);
+	}
+
+	return -EINVAL;
+}
+
 bool sys_mm_drv_is_addr_array_aligned(uintptr_t *addr, size_t cnt)
 {
 	size_t idx;

--- a/drivers/mm/mm_drv_intel_adsp.h
+++ b/drivers/mm/mm_drv_intel_adsp.h
@@ -79,13 +79,4 @@ static inline uintptr_t tlb_entry_to_pa(uint16_t tlb_entry)
 		CONFIG_MM_DRV_PAGE_SIZE) + TLB_PHYS_BASE);
 }
 
-/**
- * Calculate virtual memory regions allocation based on
- * info from linker script.
- *
- * @param End address of staticaly allocated memory.
- * @return Error Code.
- */
-int calculate_memory_regions(uintptr_t static_alloc_end_ptr);
-
 #endif /* ZEPHYR_DRIVERS_SYSTEM_MM_DRV_INTEL_MTL_ */

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -738,10 +738,6 @@ static int sys_mm_drv_mm_init(const struct device *dev)
 
 	L2_PHYS_SRAM_REGION.info.num_blocks = avalible_memory_size / CONFIG_MM_DRV_PAGE_SIZE;
 
-	ret = calculate_memory_regions(UNUSED_L2_START_ALIGNED);
-	CHECKIF(ret != 0) {
-		return ret;
-	}
 	/*
 	 * Initialize memblocks that will store physical
 	 * page usage. Initially all physical pages are

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -62,6 +62,11 @@ SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(
 		L2_SRAM_PAGES_NUM,
 		(uint8_t *) L2_SRAM_BASE);
 
+uintptr_t adsp_mm_get_unused_l2_start_aligned(void)
+{
+	return UNUSED_L2_START_ALIGNED;
+}
+
 /**
  * Calculate the index to the TLB table.
  *

--- a/drivers/mm/mm_drv_intel_adsp_regions.c
+++ b/drivers/mm/mm_drv_intel_adsp_regions.c
@@ -12,48 +12,50 @@
 
 #include "mm_drv_intel_adsp.h"
 
+
+/* virtual memory regions table, last item is an end marker */
 struct sys_mm_drv_region
-virtual_memory_regions[CONFIG_MP_MAX_NUM_CPUS + VIRTUAL_REGION_COUNT] = { {0} };
+virtual_memory_regions[CONFIG_MM_DRV_INTEL_VIRTUAL_REGION_COUNT+1] = { {0} };
 
 const struct sys_mm_drv_region *sys_mm_drv_query_memory_regions(void)
 {
 	return (const struct sys_mm_drv_region *) virtual_memory_regions;
 }
 
-static inline void append_region(void *address, uint32_t mem_size,
-	uint32_t attributes, uint32_t position, uint32_t *total_size)
+int adsp_add_virtual_memory_region(uintptr_t region_address, uint32_t region_size, uint32_t attr)
 {
-	virtual_memory_regions[position].addr = address;
-	virtual_memory_regions[position].size = mem_size;
-	virtual_memory_regions[position].attr = attributes;
-	total_size += mem_size;
-}
+	struct sys_mm_drv_region *region;
+	uint32_t pos = 0;
+	uintptr_t new_region_end = region_address + region_size;
 
-int calculate_memory_regions(uintptr_t static_alloc_end_ptr)
-{
-	int i, total_size = 0;
-
-	for (i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++)	{
-		append_region((void *)(static_alloc_end_ptr + i * CORE_HEAP_SIZE),
-			      CORE_HEAP_SIZE, MEM_REG_ATTR_CORE_HEAP, i, &total_size);
-	}
-
-	append_region((void *)((uintptr_t)virtual_memory_regions[i - 1].addr +
-			       virtual_memory_regions[i - 1].size),
-		      CORE_HEAP_SIZE, MEM_REG_ATTR_SHARED_HEAP, i, &total_size);
-	i++;
-	append_region((void *)((uintptr_t)virtual_memory_regions[i - 1].addr +
-			       virtual_memory_regions[i - 1].size),
-		      OPPORTUNISTIC_REGION_SIZE, MEM_REG_ATTR_OPPORTUNISTIC_MEMORY, i, &total_size);
-	i++;
-	/* Apending last region as 0 so iterators know where table is over
-	 * check is for size = 0;
-	 */
-	append_region(NULL, 0, 0, i, &total_size);
-
-	if (total_size > L2_VIRTUAL_SRAM_SIZE) {
+	/* check if the region fits to virtual memory */
+	if (region_address < L2_VIRTUAL_SRAM_BASE ||
+	    new_region_end > L2_VIRTUAL_SRAM_BASE + L2_VIRTUAL_SRAM_SIZE) {
 		return -EINVAL;
 	}
+
+	/* find an empty slot, verify if the region is not overlapping */
+	SYS_MM_DRV_MEMORY_REGION_FOREACH(virtual_memory_regions, region) {
+		uintptr_t region_start = (uintptr_t)region->addr;
+		uintptr_t region_end = region_start + region->size;
+
+		/* check region overlapping */
+		if (region_address < region_end && new_region_end > region_start) {
+			return -EINVAL;
+		}
+		pos++;
+	}
+
+	/* SYS_MM_DRV_MEMORY_REGION_FOREACH exits when an empty slot is found */
+	if (pos == CONFIG_MM_DRV_INTEL_VIRTUAL_REGION_COUNT) {
+		/* no more free slots */
+		return -ENOMEM;
+	}
+
+	/* add new region */
+	virtual_memory_regions[pos].addr = (void *)region_address;
+	virtual_memory_regions[pos].size = region_size;
+	virtual_memory_regions[pos].attr = attr;
 
 	return 0;
 }

--- a/include/zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h
+++ b/include/zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h
@@ -44,6 +44,11 @@ typedef uint32_t (*mm_get_storage_size)(void);
  */
 void adsp_mm_restore_context(void *storage_buffer);
 
+/*
+ * This procedure return a pointer to a first unused address in L2 virtual memory
+ */
+uintptr_t adsp_mm_get_unused_l2_start_aligned(void);
+
 struct intel_adsp_tlb_api {
 	mm_save_context save_context;
 	mm_get_storage_size get_storage_size;

--- a/include/zephyr/drivers/mm/system_mm.h
+++ b/include/zephyr/drivers/mm/system_mm.h
@@ -55,6 +55,18 @@ extern "C" {
 #define SYS_MM_MEM_CACHE_MASK		(BIT(3) - 1)
 
 /**
+ * @brief Represents an available memory region.
+ *
+ * A memory region that can be used by allocators. Driver defined
+ * attributes can be used to guide the proper usage of each region.
+ */
+struct sys_mm_drv_region {
+	void *addr; /**< @brief Address of the memory region */
+	size_t size; /**< @brief Size of the memory region */
+	uint32_t attr; /**< @brief Driver defined attributes of the memory region */
+};
+
+/**
  * @}
  */
 
@@ -110,6 +122,18 @@ extern "C" {
 int sys_mm_drv_map_page(void *virt, uintptr_t phys, uint32_t flags);
 
 /**
+ * @brief Map one physical page into the virtual address space with region check
+ *
+ * This maps one physical page into the virtual address space by calling
+ * sys_mm_drv_map_page. Refer to sys_mm_drv_map_page for references
+ *
+ * Before call it performs a safety check by verifying if the mapped virtual memory page
+ * fits into a given virtual region
+ */
+int sys_mm_drv_map_page_safe(const struct sys_mm_drv_region *virtual_region,
+			     void *virt, uintptr_t phys, uint32_t flags);
+
+/**
  * @brief Map a region of physical memory into the virtual address space
  *
  * This maps a region of physical memory into the virtual address space.
@@ -132,6 +156,19 @@ int sys_mm_drv_map_page(void *virt, uintptr_t phys, uint32_t flags);
  */
 int sys_mm_drv_map_region(void *virt, uintptr_t phys,
 			  size_t size, uint32_t flags);
+
+/**
+ * @brief Map a region of physical memory into the virtual address space with region check
+ *
+ * This maps a region of physical memory into the virtual address space by calling
+ * sys_mm_drv_map_region. Refer to sys_mm_drv_map_region for references
+ *
+ * Before call it performs a safety check by verifying if the mapped virtual memory pages
+ * fit into a given virtual region
+ */
+int sys_mm_drv_map_region_safe(const struct sys_mm_drv_region *virtual_region,
+			       void *virt, uintptr_t phys, size_t size,
+			       uint32_t flags);
 
 /**
  * @brief Map an array of physical memory into the virtual address space
@@ -401,18 +438,6 @@ int sys_mm_drv_update_region_flags(void *virt, size_t size, uint32_t flags);
  * @retval -EFAULT if virtual address is not mapped
  */
 int sys_mm_drv_page_phys_get(void *virt, uintptr_t *phys);
-
-/**
- * @brief Represents an available memory region.
- *
- * A memory region that can be used by allocators. Driver defined
- * attributes can be used to guide the proper usage of each region.
- */
-struct sys_mm_drv_region {
-	void *addr; /**< @brief Address of the memory region */
-	size_t size; /**< @brief Size of the memory region */
-	uint32_t attr; /**< @brief Driver defined attributes of the memory region */
-};
 
 /* TODO is it safe to assume no valid region has size == 0? */
 /**

--- a/soc/intel/intel_adsp/ace/include/adsp_memory_regions.h
+++ b/soc/intel/intel_adsp/ace/include/adsp_memory_regions.h
@@ -6,22 +6,21 @@
 #ifndef ZEPHYR_SOC_INTEL_ADSP_MEMORY_REGIONS_H_
 #define ZEPHYR_SOC_INTEL_ADSP_MEMORY_REGIONS_H_
 
-/* Define amount of regions other than core heaps that virtual memory will be split to
- * currently includes shared heap and oma region and one regions set to 0 as for table
- * iterator end value.
+/**
+ * Add a virtual memory region to the table
+ *
+ * @param virtual_address an address of a new region
+ * @param region_size a size of a new region
+ * @param attr an attribute of a new region, may not be unique
+ *
+ * @return 0 success
+ * @return -ENOMEM if there are no empty slots for virtual memory regions
+ * @return -EINVAL if virtual memory region overlaps with existing ones or exceeds memory size
  */
-#define VIRTUAL_REGION_COUNT 3
-
-#define CORE_HEAP_SIZE 0x100000
-#define SHARED_HEAP_SIZE 0x100000
-#define OPPORTUNISTIC_REGION_SIZE 0x100000
+int adsp_add_virtual_memory_region(uintptr_t region_address, uint32_t region_size, uint32_t attr);
 
 /* size of TLB table */
 #define TLB_SIZE DT_REG_SIZE_BY_IDX(DT_INST(0, intel_adsp_mtl_tlb), 0)
 
-/* Attribiutes for memory regions */
-#define MEM_REG_ATTR_CORE_HEAP 1U
-#define MEM_REG_ATTR_SHARED_HEAP 2U
-#define MEM_REG_ATTR_OPPORTUNISTIC_MEMORY 4U
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_MEMORY_REGIONS_H_ */


### PR DESCRIPTION
this PR removes creation of virtual memory regions from
Zephyr, allowing the application to create required regions

It is up the application to use virtual memory as needed,
zephyr however is keeping the table and ensures no memory
addresses overlaps
