### PR TITLE
stm32l562e_dk: map arduino_i2c to i2c1

### DIFF
--- a/boards/st/stm32l562e_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32l562e_dk/arduino_r3_connector.dtsi
@@ -36,3 +36,5 @@
 };
 
 arduino_spi: &spi3 {};
+
+arduino_i2c: &i2c1 {};


### PR DESCRIPTION
Mapping for i2c was missing, added that and mapped it to i2c1.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
