### PR TITLE
Add sensor firmware upload API support

### DIFF
--- a/drivers/sensor/sensor_handlers.c
+++ b/drivers/sensor/sensor_handlers.c
@@ -68,6 +68,15 @@ static inline int z_vrfy_sensor_get_decoder(const struct device *dev,
 }
 #include <zephyr/syscalls/sensor_get_decoder_mrsh.c>
 
+static inline int z_vrfy_sensor_upload_fw(const struct device *dev,
+					  const void *fw_buf, size_t fw_len)
+{
+	K_OOPS(K_SYSCALL_OBJ(dev, K_OBJ_DRIVER_SENSOR));
+	K_OOPS(K_SYSCALL_MEMORY_READ(fw_buf, fw_len));
+	return z_impl_sensor_upload_fw(dev, fw_buf, fw_len);
+}
+#include <zephyr/syscalls/sensor_upload_fw_mrsh.c>
+
 static inline int z_vrfy_sensor_reconfigure_read_iodev(struct rtio_iodev *iodev,
 						       const struct device *sensor,
 						       const struct sensor_chan_spec *channels,

--- a/drivers/sensor/st/lsm6dso16is/Kconfig
+++ b/drivers/sensor/st/lsm6dso16is/Kconfig
@@ -18,6 +18,10 @@ menuconfig LSM6DSO16IS
 
 if LSM6DSO16IS
 
+config LSM6DSO16IS_ISPU_ENABLE
+	bool "ISPU Enable"
+	select USE_ST_MEMS_ISPU
+
 choice LSM6DSO16IS_TRIGGER_MODE
 	prompt "Trigger mode"
 	help

--- a/drivers/sensor/st/lsm6dso16is/lsm6dso16is.h
+++ b/drivers/sensor/st/lsm6dso16is/lsm6dso16is.h
@@ -17,6 +17,8 @@
 #include <zephyr/sys/util.h>
 #include <stmemsc.h>
 #include "lsm6dso16is_reg.h"
+#include <zephyr/drivers/sensor/st_mems_conf_shared_types.h>
+#include <zephyr/drivers/sensor/st_embedded_cores.h>
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 #include <zephyr/drivers/spi.h>
@@ -77,6 +79,9 @@ struct lsm6dso16is_data {
 #if defined(CONFIG_LSM6DSO16IS_ENABLE_TEMP)
 	int16_t temp_sample;
 #endif
+#if defined(CONFIG_USE_ST_MEMS_ISPU)
+	uint8_t ispu[64];
+#endif
 #if defined(CONFIG_LSM6DSO16IS_SENSORHUB)
 	uint8_t ext_data[LSM6DSO16IS_SHUB_MAX_NUM_TARGETS][6];
 	uint16_t magn_gain;
@@ -105,6 +110,10 @@ struct lsm6dso16is_data {
 	const struct sensor_trigger *trig_drdy_gyr;
 	sensor_trigger_handler_t handler_drdy_temp;
 	const struct sensor_trigger *trig_drdy_temp;
+#if defined(CONFIG_USE_ST_MEMS_ISPU)
+	sensor_trigger_handler_t handler_ispu;
+	const struct sensor_trigger *trig_ispu;
+#endif
 
 #if defined(CONFIG_LSM6DSO16IS_TRIGGER_OWN_THREAD)
 	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_LSM6DSO16IS_THREAD_STACK_SIZE);

--- a/include/zephyr/drivers/sensor/st_embedded_cores.h
+++ b/include/zephyr/drivers/sensor/st_embedded_cores.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Extended Public API for STMicroelectronics embedded cores
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_ST_EMBEDDED_CORES_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_ST_EMBEDDED_CORES_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+#include <zephyr/drivers/sensor.h>
+
+enum sensor_channel_st_embedded_cores {
+	SENSOR_CHAN_ST_ISPU = SENSOR_CHAN_PRIV_START,
+};
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ST_EMBEDDED_CORES_H_ */

--- a/include/zephyr/drivers/sensor/st_mems_conf_shared_types.h
+++ b/include/zephyr/drivers/sensor/st_mems_conf_shared_types.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdint.h>
+
+/*
+ * This file contain the MEMS Configuration Shared Types v2.0 that are used inside
+ * the various algo configuration files.
+ */
+
+#ifndef MEMS_CONF_SHARED_TYPES
+#define MEMS_CONF_SHARED_TYPES
+
+#define MEMS_CONF_ARRAY_LEN(x) (sizeof(x) / sizeof(x[0]))
+
+/*
+ * MEMS_CONF_SHARED_TYPES format supports the following operations:
+ * - MEMS_CONF_OP_TYPE_TYPE_READ: read the register at the location specified
+ *   by the "address" field ("data" field is ignored)
+ * - MEMS_CONF_OP_TYPE_TYPE_WRITE: write the value specified by the "data"
+ *   field at the location specified by the "address" field
+ * - MEMS_CONF_OP_TYPE_TYPE_DELAY: wait the number of milliseconds specified by
+ *   the "data" field ("address" field is ignored)
+ * - MEMS_CONF_OP_TYPE_TYPE_POLL_SET: poll the register at the location
+ *   specified by the "address" field until all the bits identified by the mask
+ *   specified by the "data" field are set to 1
+ * - MEMS_CONF_OP_TYPE_TYPE_POLL_RESET: poll the register at the location
+ *   specified by the "address" field until all the bits identified by the mask
+ *   specified by the "data" field are reset to 0
+ */
+
+struct mems_conf_name_list {
+ const char *const *list;
+ uint16_t len;
+};
+
+enum {
+ MEMS_CONF_OP_TYPE_READ = 1,
+ MEMS_CONF_OP_TYPE_WRITE = 2,
+ MEMS_CONF_OP_TYPE_DELAY = 3,
+ MEMS_CONF_OP_TYPE_POLL_SET = 4,
+ MEMS_CONF_OP_TYPE_POLL_RESET = 5
+};
+
+struct mems_conf_op {
+ uint8_t type;
+ uint8_t address;
+ uint8_t data;
+};
+
+struct mems_conf_op_list {
+ const struct mems_conf_op *list;
+ uint32_t len;
+};
+
+#endif /* MEMS_CONF_SHARED_TYPES */
+
+#ifndef MEMS_CONF_METADATA_SHARED_TYPES
+#define MEMS_CONF_METADATA_SHARED_TYPES
+
+struct mems_conf_application {
+ char *name;
+ char *version;
+};
+
+struct mems_conf_result {
+ uint8_t code;
+ char *label;
+};
+
+enum {
+ MEMS_CONF_OUTPUT_CORE_HW = 1,
+ MEMS_CONF_OUTPUT_CORE_EMB = 2,
+ MEMS_CONF_OUTPUT_CORE_FSM = 3,
+ MEMS_CONF_OUTPUT_CORE_MLC = 4,
+ MEMS_CONF_OUTPUT_CORE_ISPU = 5
+};
+
+enum {
+ MEMS_CONF_OUTPUT_TYPE_UINT8_T = 1,
+ MEMS_CONF_OUTPUT_TYPE_INT8_T = 2,
+ MEMS_CONF_OUTPUT_TYPE_CHAR = 3,
+ MEMS_CONF_OUTPUT_TYPE_UINT16_T = 4,
+ MEMS_CONF_OUTPUT_TYPE_INT16_T = 5,
+ MEMS_CONF_OUTPUT_TYPE_UINT32_T = 6,
+ MEMS_CONF_OUTPUT_TYPE_INT32_T = 7,
+ MEMS_CONF_OUTPUT_TYPE_UINT64_T = 8,
+ MEMS_CONF_OUTPUT_TYPE_INT64_T = 9,
+ MEMS_CONF_OUTPUT_TYPE_HALF = 10,
+ MEMS_CONF_OUTPUT_TYPE_FLOAT = 11,
+ MEMS_CONF_OUTPUT_TYPE_DOUBLE = 12
+};
+
+struct mems_conf_output {
+ char *name;
+ uint8_t core;
+ uint8_t type;
+ uint16_t len;
+ uint8_t reg_addr;
+ char *reg_name;
+ uint8_t num_results;
+ const struct mems_conf_result *results;
+};
+
+struct mems_conf_output_list {
+ const struct mems_conf_output *list;
+ uint16_t len;
+};
+
+struct mems_conf_mlc_identifier {
+ uint8_t fifo_tag;
+ uint16_t id;
+ char *label;
+};
+
+struct mems_conf_mlc_identifier_list {
+ const struct mems_conf_mlc_identifier *list;
+ uint16_t len;
+};
+
+#endif /* MEMS_CONF_METADATA_SHARED_TYPES */

--- a/modules/hal_st/Kconfig
+++ b/modules/hal_st/Kconfig
@@ -202,3 +202,6 @@ config USE_STDC_STTS751
 	bool
 
 endif # HAS_STMEMSC
+
+config USE_ST_MEMS_ISPU
+	bool


### PR DESCRIPTION
Add sensor API to perform a "firmware upload". This new driver API is then used as a vehicle to upload a ISPU configuration into lsm6dso16is sensor (see [ST ISPU](https://github.com/STMicroelectronics/st-mems-ispu) for more details).

This PR is also changing the lsm6dso16is driver and modifying the x_nucleo_iks4a1 shield sample.
