### PR TITLE
doc: connectivity: networking: api: tftp: Fix wrong Kconfig option name

### DIFF
--- a/doc/connectivity/networking/api/tftp.rst
+++ b/doc/connectivity/networking/api/tftp.rst
@@ -4,7 +4,7 @@ TFTP
 ####
 
 Zephyr provides a simple TFTP client library that can enabled with
-:kconfig:option:`CONFIG_MQTT_SN_LIB` Kconfig option.
+:kconfig:option:`CONFIG_TFTP_LIB` Kconfig option.
 
 See :zephyr:code-sample:`TFTP client sample application <tftp-client>` for
 more information about the library usage.


### PR DESCRIPTION
Instead of `CONFIG_MQTT_SN_LIB`, correct Kconfig option to enable TFTP client library is `CONFIG_TFTP_LIB`

Closes #93342