### PR TITLE
doc: release: 4.2: Fix entry in new APIs

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -317,6 +317,7 @@ New APIs and options
     * :kconfig:option:`CONFIG_LV_Z_COLOR_MONO_HW_INVERSION`
 
 * LoRaWAN
+
    * :c:func:`lorawan_request_link_check`
 
 * Management


### PR DESCRIPTION
Add a missing newline to fix the formatting of the LoRaWAN entry.