### PR TITLE
soc: mimxrt11xx: Allow to override SYS PLL2/3 output divider(s).

### DIFF
--- a/soc/nxp/imxrt/imxrt11xx/Kconfig
+++ b/soc/nxp/imxrt/imxrt11xx/Kconfig
@@ -69,4 +69,44 @@ config ADJUST_LDO
 config INIT_VIDEO_PLL
 	default y
 
+config SYS_PLL2_PFD0_DIV
+	int "System PLL2 PFD0 divider"
+	default 27
+	range 13 35
+
+config SYS_PLL2_PFD1_DIV
+	int "System PLL2 PFD1 divider"
+	default 16
+	range 13 35
+
+config SYS_PLL2_PFD2_DIV
+	int "System PLL2 PFD2 divider"
+	default 24
+	range 13 35
+
+config SYS_PLL2_PFD3_DIV
+	int "System PLL2 PFD3 divider"
+	default 32
+	range 13 35
+
+config SYS_PLL3_PFD0_DIV
+	int "System PLL3 PFD0 divider"
+	default 13
+	range 13 35
+
+config SYS_PLL3_PFD1_DIV
+	int "System PLL3 PFD1 divider"
+	default 17
+	range 13 35
+
+config SYS_PLL3_PFD2_DIV
+	int "System PLL3 PFD2 divider"
+	default 32
+	range 13 35
+
+config SYS_PLL3_PFD3_DIV
+	int "System PLL3 PFD3 divider"
+	default 22
+	range 13 35
+
 endif # SOC_SERIES_IMXRT11XX

--- a/soc/nxp/imxrt/imxrt11xx/soc.c
+++ b/soc/nxp/imxrt/imxrt11xx/soc.c
@@ -228,31 +228,31 @@ __weak void clock_init(void)
 	CLOCK_InitSysPll2(&sysPll2Config);
 
 	/* Init System Pll2 pfd0. */
-	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd0, 27);
+	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd0, CONFIG_SYS_PLL2_PFD0_DIV);
 
 	/* Init System Pll2 pfd1. */
-	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd1, 16);
+	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd1, CONFIG_SYS_PLL2_PFD1_DIV);
 
 	/* Init System Pll2 pfd2. */
-	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd2, 24);
+	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd2, CONFIG_SYS_PLL2_PFD2_DIV);
 
 	/* Init System Pll2 pfd3. */
-	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd3, 32);
+	CLOCK_InitPfd(kCLOCK_PllSys2, kCLOCK_Pfd3, CONFIG_SYS_PLL2_PFD3_DIV);
 
 	/* Init Sys Pll3. */
 	CLOCK_InitSysPll3();
 
 	/* Init System Pll3 pfd0. */
-	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd0, 13);
+	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd0, CONFIG_SYS_PLL3_PFD0_DIV);
 
 	/* Init System Pll3 pfd1. */
-	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd1, 17);
+	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd1, CONFIG_SYS_PLL3_PFD1_DIV);
 
 	/* Init System Pll3 pfd2. */
-	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd2, 32);
+	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd2, CONFIG_SYS_PLL3_PFD2_DIV);
 
 	/* Init System Pll3 pfd3. */
-	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd3, 22);
+	CLOCK_InitPfd(kCLOCK_PllSys3, kCLOCK_Pfd3, CONFIG_SYS_PLL3_PFD3_DIV);
 
 	static const clock_video_pll_config_t videoPllConfig = {
 		/* PLL Loop divider, valid range for DIV_SELECT divider value: 27 ~ 54. */


### PR DESCRIPTION
To reduce the SEMC clock to a usable speed we had to divide down the output clock of System PLL2 PFD1. To do this I had to override the hardcoded defaults. This commit adds the flexibility to override them in your board files.