### PR TITLE
boards: st nucleo c071rb fix LED, Button, SPI configuration

### DIFF
--- a/boards/st/nucleo_c071rb/doc/index.rst
+++ b/boards/st/nucleo_c071rb/doc/index.rst
@@ -71,8 +71,9 @@ Default Zephyr Peripheral Mapping:
 - I2C1 SCL/SDA : PB8/PB9 (Arduino I2C)
 - LD1       : PA5
 - LD2       : PC9
-- SPI1 NSS/SCK/MISO/MOSI : PA4/PA5/PA11/PA12 (Arduino SPI)
-- UART_2 TX/RX : PA2/PA3 (ST-Link Virtual Port Com)
+- SPI1 NSS/SCK/MISO/MOSI : PA15/PA5/PA6/PA7 (Arduino SPI)
+- UART_1 TX/RX : PB6/PB7 (Arduino Serial)
+- UART_2 TX/RX : PA2/PA3 (ST-Link Virtual COM Port)
 - USER_PB : PC13
 
 

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -128,15 +128,16 @@
 };
 
 &i2c2 {
-	pinctrl-0 = <&i2c2_scl_pa7 &i2c2_sda_pa6>;
+	pinctrl-0 = <&i2c2_scl_pb13 &i2c2_sda_pb14>;
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &spi1 {
-	pinctrl-0 = <&spi1_nss_pb0 &spi1_sck_pb3
-		     &spi1_miso_pb4 &spi1_mosi_pb5>;
+	/* Note: PA5 is shared with green led0 */
+	pinctrl-0 = <&spi1_nss_pa15 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -30,7 +30,7 @@
 		};
 
 		blue_led: led_2 {
-			gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
 			label = "User LD2";
 		};
 	};
@@ -48,7 +48,7 @@
 
 		user_button: button {
 			label = "user button";
-			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioc 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 			status = "okay";
 			zephyr,code = <INPUT_KEY_0>;
 		};


### PR DESCRIPTION
Working with the `nucleo_c092rc` I noticed a few issues in the `nucleo_c071rb` board configuration that I propose to fix in this PR:
- set led2 pin to active low
- Enable the pull-up resistor for the USER button
- use the Arduino header pins for SPI1

I don't have a `nucleo_c071rb` to verify these changes, but tested it on a board that is basically only a different assembly option.