### PR TITLE
doc: migration_guide: 4.3 add entry for renaming zephyr,gpio-stepper

### DIFF
--- a/doc/hardware/peripherals/stepper.rst
+++ b/doc/hardware/peripherals/stepper.rst
@@ -38,7 +38,7 @@ be used in a boards devicetree to configure a stepper driver to its initial stat
 
 See examples in:
 
-- :dtcompatible:`zephyr,gpio-stepper`
+- :dtcompatible:`zephyr,h-bridge-stepper`
 - :dtcompatible:`adi,tmc50xx`
 
 Discord

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -34,6 +34,11 @@ Device Drivers and Devicetree
 
 .. zephyr-keep-sorted-start re(^\w)
 
+Stepper
+=======
+
+* :dtcompatible:`zephyr,gpio-stepper` has been replaced by :dtcompatible:`zephyr,h-bridge-stepper`.
+
 .. zephyr-keep-sorted-stop
 
 Bluetooth


### PR DESCRIPTION
- entry in migration guide for renaming zephyr,gpio-stepper to zephyr,h-bridge-stepper
- rename zephyr,gpio-stepper to zephyr,h-bridge-stepper in stepper.rst