### PR TITLE
drivers: adltc2990: use wrapper with semaphore for bus communication

### DIFF
--- a/drivers/sensor/adi/adltc2990/adltc2990_internal.h
+++ b/drivers/sensor/adi/adltc2990/adltc2990_internal.h
@@ -51,6 +51,7 @@ struct adltc2990_data {
 	int32_t supply_voltage;
 	int32_t pins_v1_v2_values[2];
 	int32_t pins_v3_v4_values[2];
+	struct k_sem sem;
 };
 
 struct adltc2990_config {


### PR DESCRIPTION
Use a semaphore for bus communication in order to ensure thread safety