### PR TITLE
dts: arm64: ti: ti_am62x_a53: Use GPIO Proxy

### DIFF
--- a/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
+++ b/boards/beagle/pocketbeagle_2/pocketbeagle_2_am62_a53-common.dtsi
@@ -93,9 +93,25 @@
 	status = "okay";
 };
 
-&main_gpio0 {
+&main_gpio0_0 {
 	pinctrl-0 = <&led_pins_default>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&main_gpio0_1 {
+	status = "okay";
+};
+
+&main_gpio0_2 {
+	status = "okay";
+};
+
+&main_gpio1_0 {
+	status = "okay";
+};
+
+&main_gpio1_1 {
 	status = "okay";
 };
 

--- a/dts/arm/ti/am62x_m4.dtsi
+++ b/dts/arm/ti/am62x_m4.dtsi
@@ -92,9 +92,9 @@
 		status = "disabled";
 	};
 
-	gpio0: gpio@4201000 {
+	gpio0: gpio@4201010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x4201000 0x100>;
+		reg = <0x4201010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <24>;

--- a/dts/arm/ti/j722s_main.dtsi
+++ b/dts/arm/ti/j722s_main.dtsi
@@ -19,18 +19,18 @@
 		status = "okay";
 	};
 
-	gpio0: gpio@600000 {
+	gpio0: gpio@600010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x00600000 0x100>;
+		reg = <0x00600010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <92>;
 		status = "disabled";
 	};
 
-	gpio1: gpio@601000 {
+	gpio1: gpio@601010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x00601000 0x100>;
+		reg = <0x00601010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <52>;

--- a/dts/arm/ti/j722s_mcu.dtsi
+++ b/dts/arm/ti/j722s_mcu.dtsi
@@ -13,9 +13,9 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	mcu_gpio0: gpio@4201000 {
+	mcu_gpio0: gpio@4201010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x4201000 0x100>;
+		reg = <0x4201010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <24>;

--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -197,17 +197,17 @@
 		status = "disabled";
 	};
 
-	main_gpio0: gpio@600000 {
+	main_gpio0: gpio@600010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x600000 0x100>;
+		reg = <0x600010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		status = "disabled";
 	};
 
-	main_gpio1: gpio@601000 {
+	main_gpio1: gpio@601010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x601000 0x100>;
+		reg = <0x601010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		status = "disabled";

--- a/dts/vendor/ti/am64x_mcu.dtsi
+++ b/dts/vendor/ti/am64x_mcu.dtsi
@@ -53,9 +53,9 @@
 		status = "disabled";
 	};
 
-	mcu_gpio0: gpio@4201000 {
+	mcu_gpio0: gpio@4201010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x4201000 0x100>;
+		reg = <0x4201010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <23>;

--- a/dts/vendor/ti/k3-am62-main.dtsi
+++ b/dts/vendor/ti/k3-am62-main.dtsi
@@ -106,23 +106,133 @@
 		status = "disabled";
 	};
 
-	main_gpio0: gpio@600000 {
+	main_gpio0: main-gpio0 {
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &main_gpio0_0 0 0>, <1 0 &main_gpio0_0 1 0>,
+			   <2 0 &main_gpio0_0 2 0>, <3 0 &main_gpio0_0 3 0>,
+			   <4 0 &main_gpio0_0 4 0>, <5 0 &main_gpio0_0 5 0>,
+			   <6 0 &main_gpio0_0 6 0>, <7 0 &main_gpio0_0 7 0>,
+			   <8 0 &main_gpio0_0 8 0>, <9 0 &main_gpio0_0 9 0>,
+			   <10 0 &main_gpio0_0 10 0>, <11 0 &main_gpio0_0 11 0>,
+			   <12 0 &main_gpio0_0 12 0>, <13 0 &main_gpio0_0 13 0>,
+			   <14 0 &main_gpio0_0 14 0>, <15 0 &main_gpio0_0 15 0>,
+			   <16 0 &main_gpio0_0 16 0>, <17 0 &main_gpio0_0 17 0>,
+			   <18 0 &main_gpio0_0 18 0>, <19 0 &main_gpio0_0 19 0>,
+			   <20 0 &main_gpio0_0 20 0>, <21 0 &main_gpio0_0 21 0>,
+			   <22 0 &main_gpio0_0 22 0>, <23 0 &main_gpio0_0 23 0>,
+			   <24 0 &main_gpio0_0 24 0>, <25 0 &main_gpio0_0 25 0>,
+			   <26 0 &main_gpio0_0 26 0>, <27 0 &main_gpio0_0 27 0>,
+			   <28 0 &main_gpio0_0 28 0>, <29 0 &main_gpio0_0 29 0>,
+			   <30 0 &main_gpio0_0 30 0>, <31 0 &main_gpio0_0 31 0>,
+			   <32 0 &main_gpio0_1 0 0>, <33 0 &main_gpio0_1 1 0>,
+			   <34 0 &main_gpio0_1 2 0>, <35 0 &main_gpio0_1 3 0>,
+			   <36 0 &main_gpio0_1 4 0>, <37 0 &main_gpio0_1 5 0>,
+			   <38 0 &main_gpio0_1 6 0>, <39 0 &main_gpio0_1 7 0>,
+			   <40 0 &main_gpio0_1 8 0>, <41 0 &main_gpio0_1 9 0>,
+			   <42 0 &main_gpio0_1 10 0>, <43 0 &main_gpio0_1 11 0>,
+			   <44 0 &main_gpio0_1 12 0>, <45 0 &main_gpio0_1 13 0>,
+			   <46 0 &main_gpio0_1 14 0>, <47 0 &main_gpio0_1 15 0>,
+			   <48 0 &main_gpio0_1 16 0>, <49 0 &main_gpio0_1 17 0>,
+			   <50 0 &main_gpio0_1 18 0>, <51 0 &main_gpio0_1 19 0>,
+			   <52 0 &main_gpio0_1 20 0>, <53 0 &main_gpio0_1 21 0>,
+			   <54 0 &main_gpio0_1 22 0>, <55 0 &main_gpio0_1 23 0>,
+			   <56 0 &main_gpio0_1 24 0>, <57 0 &main_gpio0_1 25 0>,
+			   <58 0 &main_gpio0_1 26 0>, <59 0 &main_gpio0_1 27 0>,
+			   <60 0 &main_gpio0_1 28 0>, <61 0 &main_gpio0_1 29 0>,
+			   <62 0 &main_gpio0_1 30 0>, <63 0 &main_gpio0_1 31 0>,
+			   <64 0 &main_gpio0_2 0 0>, <65 0 &main_gpio0_2 1 0>,
+			   <66 0 &main_gpio0_2 2 0>, <67 0 &main_gpio0_2 3 0>,
+			   <68 0 &main_gpio0_2 4 0>, <69 0 &main_gpio0_2 5 0>,
+			   <70 0 &main_gpio0_2 6 0>, <71 0 &main_gpio0_2 7 0>,
+			   <72 0 &main_gpio0_2 8 0>, <73 0 &main_gpio0_2 9 0>,
+			   <74 0 &main_gpio0_2 10 0>, <75 0 &main_gpio0_2 11 0>,
+			   <76 0 &main_gpio0_2 12 0>, <77 0 &main_gpio0_2 13 0>,
+			   <78 0 &main_gpio0_2 14 0>, <79 0 &main_gpio0_2 15 0>,
+			   <80 0 &main_gpio0_2 16 0>, <81 0 &main_gpio0_2 17 0>,
+			   <82 0 &main_gpio0_2 18 0>, <83 0 &main_gpio0_2 17 0>,
+			   <84 0 &main_gpio0_2 20 0>, <85 0 &main_gpio0_2 21 0>,
+			   <86 0 &main_gpio0_2 22 0>, <87 0 &main_gpio0_2 23 0>,
+			   <88 0 &main_gpio0_2 24 0>, <89 0 &main_gpio0_2 25 0>,
+			   <90 0 &main_gpio0_2 26 0>, <91 0 &main_gpio0_2 27 0>;
+		gpio-map-mask = <0xffff 0x0>;
+		gpio-map-pass-thru = <0x0 0x1>;
+	};
+
+	main_gpio0_0: gpio@600010 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x00600000 0x100>;
+		reg = <0x00600010 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		/* FIXME: Enable all 92 GPIOs */
 		ngpios = <32>;
 		status = "disabled";
 	};
 
-	main_gpio1: gpio@601000 {
+	main_gpio0_1: gpio@600038 {
 		compatible = "ti,davinci-gpio";
-		reg = <0x00601000 0x100>;
+		reg = <0x00600038 0x28>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		/* FIXME: Enable all 52 GPIOs */
 		ngpios = <32>;
+		status = "disabled";
+	};
+
+	main_gpio0_2: gpio@600060 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00600060 0x28>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <28>;
+		status = "disabled";
+	};
+
+	main_gpio1: main-gpio1 {
+		#gpio-cells = <2>;
+		gpio-map = <0 0 &main_gpio1_0 0 0>, <1 0 &main_gpio1_0 1 0>,
+			   <2 0 &main_gpio1_0 2 0>, <3 0 &main_gpio1_0 3 0>,
+			   <4 0 &main_gpio1_0 4 0>, <5 0 &main_gpio1_0 5 0>,
+			   <6 0 &main_gpio1_0 6 0>, <7 0 &main_gpio1_0 7 0>,
+			   <8 0 &main_gpio1_0 8 0>, <9 0 &main_gpio1_0 9 0>,
+			   <10 0 &main_gpio1_0 10 0>, <11 0 &main_gpio1_0 11 0>,
+			   <12 0 &main_gpio1_0 12 0>, <13 0 &main_gpio1_0 13 0>,
+			   <14 0 &main_gpio1_0 14 0>, <15 0 &main_gpio1_0 15 0>,
+			   <16 0 &main_gpio1_0 16 0>, <17 0 &main_gpio1_0 17 0>,
+			   <18 0 &main_gpio1_0 18 0>, <19 0 &main_gpio1_0 19 0>,
+			   <20 0 &main_gpio1_0 20 0>, <21 0 &main_gpio1_0 21 0>,
+			   <22 0 &main_gpio1_0 22 0>, <23 0 &main_gpio1_0 23 0>,
+			   <24 0 &main_gpio1_0 24 0>, <25 0 &main_gpio1_0 25 0>,
+			   <26 0 &main_gpio1_0 26 0>, <27 0 &main_gpio1_0 27 0>,
+			   <28 0 &main_gpio1_0 28 0>, <29 0 &main_gpio1_0 29 0>,
+			   <30 0 &main_gpio1_0 30 0>, <31 0 &main_gpio1_0 31 0>,
+			   <32 0 &main_gpio1_1 0 0>, <33 0 &main_gpio1_1 1 0>,
+			   <34 0 &main_gpio1_1 2 0>, <35 0 &main_gpio1_1 3 0>,
+			   <36 0 &main_gpio1_1 4 0>, <37 0 &main_gpio1_1 5 0>,
+			   <38 0 &main_gpio1_1 6 0>, <39 0 &main_gpio1_1 7 0>,
+			   <40 0 &main_gpio1_1 8 0>, <41 0 &main_gpio1_1 9 0>,
+			   <42 0 &main_gpio1_1 10 0>, <43 0 &main_gpio1_1 11 0>,
+			   <44 0 &main_gpio1_1 12 0>, <45 0 &main_gpio1_1 13 0>,
+			   <46 0 &main_gpio1_1 14 0>, <47 0 &main_gpio1_1 15 0>,
+			   <48 0 &main_gpio1_1 16 0>, <49 0 &main_gpio1_1 17 0>,
+			   <50 0 &main_gpio1_1 18 0>, <51 0 &main_gpio1_1 19 0>,
+			   <52 0 &main_gpio1_1 20 0>;
+		gpio-map-mask = <0xffff 0x0>;
+		gpio-map-pass-thru = <0x0 0x1>;
+	};
+
+	main_gpio1_0: gpio@601010 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00601010 0x28>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <32>;
+		status = "disabled";
+	};
+
+	main_gpio1_1: gpio@601038 {
+		compatible = "ti,davinci-gpio";
+		reg = <0x00601038 0x28>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		ngpios = <20>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
After trying out a few different approaches, I think having separate nodes for each bank in devicetree and having a GPIO proxy node for the controller is the best solution right now.

To be more specific, GPIO proxy solution still allows for bank level GPIO toggling. The Linux kernel GPIO davinci driver is currently limited to single pin operations. This might not be a problem in Linux, but I feel like embedded systems would prefer having support for bank level operations. Using a solution such as bitarray would inherently have more overhead than bit mask.

This also does not pose a problem for the future implementation of interrupts (for gpio-davinci driver) due to that fact that the interrupt router is a separate device and will require a separate driver. In fact, the GPIO interrupt router is shared between main_gpio0 and main_gpio1.

The patch has been tested on PocketBeagle 2.