### PR TITLE
drivers: mipi_dbi: stm32: fmc: add bank address property

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
+++ b/drivers/mipi_dbi/mipi_dbi_stm32_fmc.c
@@ -178,8 +178,9 @@ static DEVICE_API(mipi_dbi, mipi_dbi_stm32_fmc_driver_api) = {
 	.write_display = mipi_dbi_stm32_fmc_write_display,
 };
 
-#define MIPI_DBI_FMC_GET_ADDRESS(n) _CONCAT(FMC_BANK1_,                                            \
-					UTIL_INC(DT_REG_ADDR_RAW(DT_INST_PARENT(n))))
+#define MIPI_DBI_FMC_GET_ADDRESS(n)                                                                \
+	DT_INST_PROP_OR(n, bank_address,                                                           \
+			_CONCAT(FMC_BANK1_, UTIL_INC(DT_REG_ADDR_RAW(DT_INST_PARENT(n)))))
 
 #define MIPI_DBI_FMC_GET_DATA_ADDRESS(n)                                                           \
 	MIPI_DBI_FMC_GET_ADDRESS(n) + (1 << (DT_INST_PROP(n, register_select_pin) + 1))

--- a/dts/bindings/mipi-dbi/st,mipi-dbi-fmc.yaml
+++ b/dts/bindings/mipi-dbi/st,mipi-dbi-fmc.yaml
@@ -7,6 +7,11 @@ compatible: "st,stm32-fmc-mipi-dbi"
 include: ["mipi-dbi-controller.yaml"]
 
 properties:
+  bank-address:
+    type: int
+    description: |
+      Optional property to provide FMC Bank address.
+
   reset-gpios:
     type: phandle-array
     description: |


### PR DESCRIPTION
The driver gets the FMC bank address using the `FMC_BANK1_<parent_register_value>` macro.

This approach has some flaws:
1. The parent (bank) register's value might not correspond sequentially to the expected bank number. For example, `STM32_FMC_NORSRAM_BANK3` maps to `FMC_BANK1_5`, instead of `FMC_BANK1_3`, `STM32_FMC_NORSRAM_BANK4` to `FMC_BANK1_7`. It works for existing boards only because they define the bank as `STM32_FMC_NORSRAM_BANK1`, which has a value of `0`, and we get the desired `FMC_BANK1_1` in the driver.
2. Some families don't even define the necessary `FMC_BANK1_x` macros.

To address this, an optional `bank-address` property is added, providing a direct way to define the FMC bank address for the driver. If the property is undefined, then the original behavior is used.

Another approach could be to define missing `FMC_BANK1_x` base address macros; however, it seems like the majority of recent families don't have them. Also, we would need to move away from using the bank's `reg` for the macro construction, and account for possible bank remaps (_some families_).

However, this PR doesn't fix the 1st issue. It is more like a workaround for both problems.
Does someone have a better idea how to handle that?