### PR TITLE
drivers: mipi_dbi: stm32: get fmc frequency correctly

### DIFF
--- a/include/zephyr/drivers/memc/memc_stm32.h
+++ b/include/zephyr/drivers/memc/memc_stm32.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 Georgij Cernysiov <geo.cgv@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_MEMC_STM32_H_
+#define ZEPHYR_INCLUDE_MEMC_STM32_H_
+
+int memc_stm32_fmc_clock_rate(uint32_t *rate);
+
+#endif /* ZEPHYR_INCLUDE_MEMC_STM32_H_ */


### PR DESCRIPTION
The driver includes a check to ensure the panel’s maximum write frequency is not exceeded. This requires users to calculate and provide a `mipi-max-frequency` value based on the FMC clock and the panel's minimum write cycle time.

Currently, the driver hardcodes FMC clock frequency computation, which is not accurate across all targets, leading to build failures (_i.e, on STM32H7_).

Since the system provides a clock-control API, it makes sense to use it. However, the challenge is that `clock_control_get_rate` requires a clock subsystem, which is defined in another module (`memc_stm32.c`).

One possible workaround is to retrieve the FMC clock in the MIPI driver like this:
```c
const struct stm32_pclken fmc_pclken[] = STM32_DT_CLOCKS(DT_INST(0, FMC_DRV_COMPAT));
```
But this approach would require defining the `FMC_DRV_COMPAT` macro in the MIPI driver, duplicating what's already defined in `memc_stm32.c`. The MEMC already handles multiple compatibles, and this duplication could become difficult to maintain as the list grows.

This PR proposes one way to obtain the FMC clock frequency, though it’s not great. Ideally, we’d have a more generic and maintainable mechanism for accessing peripheral clock rates from other places.

Open to suggestions - does anyone have a cleaner solution for retrieving the FMC clock?