### PR TITLE
revert 92765 adding zephyr as a module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,0 @@
-samples:
-  - samples
-tests:
-  - tests


### PR DESCRIPTION
This reverts #92765

- **Revert "scripts: ci: check_compliance: Add support for module Kconfigs"**
- **Revert "zephyr: Add zephyr module file"**
