### PR TITLE
west: update hal_st to get embedded_cores support

### DIFF
--- a/modules/hal_st/Kconfig
+++ b/modules/hal_st/Kconfig
@@ -202,3 +202,6 @@ config USE_STDC_STTS751
 	bool
 
 endif # HAS_STMEMSC
+
+config USE_ST_MEMS_ISPU
+	bool

--- a/west.yml
+++ b/west.yml
@@ -240,7 +240,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 9f81b4427e955885398805b7bca0da3a8cd9109c
+      revision: pull/26/head
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
update hal_st to get embedded_cores support.
(The "submodules: true" key should be enabled in user's manifest file only)

(see https://github.com/zephyrproject-rtos/hal_st/pull/26)