### PR TITLE
tests: bt: host: mock k_heap_aligned_alloc

### DIFF
--- a/tests/bluetooth/host/conn/mocks/kernel.c
+++ b/tests/bluetooth/host/conn/mocks/kernel.c
@@ -31,5 +31,7 @@ DEFINE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout_
 DEFINE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
 DEFINE_FAKE_VOID_FUNC(k_sched_lock);
 DEFINE_FAKE_VOID_FUNC(k_sched_unlock);
+DEFINE_FAKE_VALUE_FUNC(void *, k_heap_aligned_alloc, struct k_heap *,
+			size_t, size_t, k_timeout_t);
 
 struct k_work_q k_sys_work_q;

--- a/tests/bluetooth/host/conn/mocks/kernel.h
+++ b/tests/bluetooth/host/conn/mocks/kernel.h
@@ -29,6 +29,7 @@
 	FAKE(k_queue_get)                                                                          \
 	FAKE(k_queue_prepend)                                                                      \
 	FAKE(k_heap_alloc)                                                                         \
+	FAKE(k_heap_aligned_alloc)                                                                 \
 	FAKE(k_heap_free)                                                                          \
 	FAKE(k_sched_lock)                                                                         \
 	FAKE(k_sched_unlock)                                                                       \
@@ -56,3 +57,5 @@ DECLARE_FAKE_VALUE_FUNC(void *, k_heap_alloc, struct k_heap *, size_t, k_timeout
 DECLARE_FAKE_VOID_FUNC(k_heap_free, struct k_heap *, void *);
 DECLARE_FAKE_VOID_FUNC(k_sched_lock);
 DECLARE_FAKE_VOID_FUNC(k_sched_unlock);
+DECLARE_FAKE_VALUE_FUNC(void *, k_heap_aligned_alloc, struct k_heap *,
+			size_t, size_t, k_timeout_t);


### PR DESCRIPTION
unit tests needs mocking for k_heap_aligned_alloc.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
