### PR TITLE
lib: libc: common: time: do not set errno in time()

### DIFF
--- a/lib/libc/common/source/time/time.c
+++ b/lib/libc/common/source/time/time.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <errno.h>
 #include <time.h>
 
 #include <zephyr/sys/clock.h>
@@ -17,7 +16,6 @@ time_t time(time_t *tloc)
 
 	ret = sys_clock_gettime(SYS_CLOCK_REALTIME, &ts);
 	if (ret < 0) {
-		errno = -ret;
 		return (time_t) -1;
 	}
 


### PR DESCRIPTION
The ISO C function `time()` is not specified to set `errno`, so remove that in case there are side-effects.

For reference:
https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf
https://en.cppreference.com/w/c/chrono/time