### PR TITLE
ztest: Fix the test_status variable to use the ztest_status enum

### DIFF
--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -538,7 +538,7 @@ out:
 	ret = get_final_test_result(test, ret);
 	Z_TC_END_RESULT(ret, test->name);
 	if (ret == TC_SKIP && current_test_failed_assumption) {
-		test_status = 1;
+		test_status = ZTEST_STATUS_HAS_FAILURE;
 	}
 
 	return ret;
@@ -741,7 +741,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	ret = get_final_test_result(test, ret);
 	Z_TC_END_RESULT(ret, test->name);
 	if (ret == TC_SKIP && current_test_failed_assumption) {
-		test_status = 1;
+		test_status = ZTEST_STATUS_HAS_FAILURE;
 	}
 
 	return ret;
@@ -1168,7 +1168,7 @@ void ztest_verify_all_test_suites_ran(void)
 		if (test->stats->fail_count + test->stats->pass_count + test->stats->skip_count !=
 		    test->stats->run_count) {
 			PRINT_DATA("Bad stats for %s.%s\n", test->test_suite_name, test->name);
-			test_status = 1;
+			test_status = ZTEST_STATUS_HAS_FAILURE;
 		}
 	}
 }


### PR DESCRIPTION
global variable `test_status` should use the enum instead of equivalent integers (such as `1`).