### PR TITLE
tests: net: http: also build with clang

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -102,7 +102,7 @@ class Tag:
 
 class Filters:
     def __init__(self, modified_files, ignore_path, alt_tags, testsuite_root,
-                 pull_request=False, platforms=[], detailed_test_id=True, quarantine_list=None, tc_roots_th=20):
+                 pull_request=False, platforms=[], detailed_test_id=False, quarantine_list=None, tc_roots_th=20):
         self.modified_files = modified_files
         self.testsuite_root = testsuite_root
         self.resolved_files = []
@@ -137,8 +137,8 @@ class Filters:
     def get_plan(self, options, integration=False, use_testsuite_root=True):
         fname = "_test_plan_partial.json"
         cmd = [f"{zephyr_base}/scripts/twister", "-c"] + options + ["--save-tests", fname ]
-        if not self.detailed_test_id:
-            cmd += ["--no-detailed-test-id"]
+        if self.detailed_test_id:
+            cmd += ["--detailed-test-id"]
         if self.testsuite_root and use_testsuite_root:
             for root in self.testsuite_root:
                 cmd+=["-T", root]

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -485,12 +485,13 @@ if __name__ == "__main__":
         n = ts.get("name")
         a = ts.get("arch")
         p = ts.get("platform")
+        t = ts.get("toolchain")
         if TwisterStatus(ts.get('status')) == TwisterStatus.ERROR:
             logging.info(f"Error found: {n} on {p} ({ts.get('reason')})")
             errors += 1
-        if (n, a, p,) not in dup_free_set:
+        if (n, a, p, t) not in dup_free_set:
             dup_free.append(ts)
-            dup_free_set.add((n, a, p,))
+            dup_free_set.add((n, a, p, t,))
 
     logging.info(f'Total tests to be run: {len(dup_free)}')
     with open(".testplan", "w") as tp:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -617,7 +617,7 @@ class Reporting:
 
             logger.info("")
             logger.info("To rerun the tests, call twister using the following commandline:")
-            extra_parameters = '' if detailed_test_id else ' --no-detailed-test-id'
+            extra_parameters = '' if not detailed_test_id else ' --detailed-test-id'
             logger.info(f"west twister -p <PLATFORM> -s <TEST ID>{extra_parameters}, for example:")
             logger.info("")
             logger.info(

--- a/tests/net/lib/http_server/tls/testcase.yaml
+++ b/tests/net/lib/http_server/tls/testcase.yaml
@@ -6,11 +6,17 @@ common:
     - net
     - server
     - socket
-  integration_platforms:
-    - native_sim
-    - qemu_x86
-  platform_allow:
-    - native_sim
-    - qemu_x86
 tests:
-  net.http.server.tls: {}
+  net.http.server.tls:
+    platform_allow:
+      - qemu_x86
+    integration_platforms:
+      - qemu_x86
+  net.http.server.tls.toolchain:
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim
+    integration_toolchains:
+      - host
+      - llvm


### PR DESCRIPTION
Build this test also with clang to increase coverage. This test is
selected because it had some issues with clang, however, there is
nothing special about this tests when it comes to clang, it will be one
of many to come to increase coverage.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
