### PR TITLE
dts: arm: st: stm32h5: fix flash erase timing

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -134,7 +134,7 @@
 				write-block-size = <16>;
 				erase-block-size = <8192>;
 				/* maximum erase time(ms) for a 8K sector */
-				max-erase-time = <5>;
+				max-erase-time = <10>;
 			};
 		};
 


### PR DESCRIPTION
According to the datasheet the flash erase timing for STM32H5 is typically 2ms, and max 10ms.

H503: DS14053 Rev 4: section 5.3.10, table 45, t_erase_max=10ms
H562/H563: DS14258 Rev 6: section 5.3.11, table 51, t_erase_max=10ms