### PR TITLE
cmake: include pre_dt_board.cmake from all board directories

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -5,6 +5,12 @@ include_guard(GLOBAL)
 include(extensions)
 include(python)
 include(boards)
+
+# Include board specific device-tree flags before parsing.
+foreach(dir IN LISTS BOARD_DIRECTORIES)
+  include("${dir}/pre_dt_board.cmake" OPTIONAL)
+endforeach()
+
 include(pre_dt)
 find_package(HostTools)
 find_package(Dtc 1.4.6)

--- a/cmake/modules/zephyr_default.cmake
+++ b/cmake/modules/zephyr_default.cmake
@@ -101,10 +101,6 @@ list(APPEND zephyr_cmake_modules hwm_v2)
 list(APPEND zephyr_cmake_modules configuration_files)
 list(APPEND zephyr_cmake_modules generated_file_directories)
 
-# Include board specific device-tree flags before parsing.
-set(pre_dt_board "\${BOARD_DIR}/pre_dt_board.cmake" OPTIONAL)
-list(APPEND zephyr_cmake_modules "\${pre_dt_board}")
-
 # DTS should be close to kconfig because CONFIG_ variables from
 # kconfig and dts should be available at the same time.
 list(APPEND zephyr_cmake_modules dts)


### PR DESCRIPTION
After https://github.com/zephyrproject-rtos/zephyr/pull/72857 the concept of board directory was expanded from a single path (BOARD_DIR) to a list of paths (BOARD_DIRECTORIES) which is taken into account in several places except when including `pre_dt_board.cmake` files. This patch moves the inclusion of `pre_dt_board.cmake` files into `dts.cmake` AFTER `boards.cmake` is included (so we can access `BOARD_DIRECTORIES`) but BEFORE `pre_dt.cmake`, which preserves the original inclusion order relative to pre DTC operations.

The original motivation of this patch was to address the practicality of defining board extensions that can re-use base board definitions.

In particular, one of the drawbacks of
https://github.com/zephyrproject-rtos/zephyr/pull/72857 is that board extensions are not really extending board definitions just the qualifier. There is still the need to create a DTS for each new board extension which is often a copy-and-paste of the base board DTS eventually with a few alterations. The problem is that except for toy examples, board DTS files are rarely self-contained and instead are composed of multiple dtsi includes using relative paths which then forces board extension files to either use hard coded paths to the base board directory OR recursively copy all included dtsi files from the base board directory into the board extension directory.

With this patch a board extension directory can define custom configuration steps like regular base boards can and then adjust CPP and DTC include search paths dynamically, for example with:
```
list(APPEND DTS_EXTRA_CPPFLAGS "-I${BOARD_DIR}")
list(APPEND EXTRA_DTC_FLAGS "-i${BOARD_DIR}")
```