### PR TITLE
migrate armv8a cache driver to mcux-sdk ng

### DIFF
--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -179,6 +179,8 @@ elseif((${MCUX_DEVICE} MATCHES "MIMXRT(5|6)") OR (${MCUX_DEVICE} MATCHES "RW61")
   set_variable_ifdef(CONFIG_HAS_MCUX_CACHE		CONFIG_MCUX_COMPONENT_driver.cache_cache64)
 elseif((${MCUX_DEVICE} MATCHES "MK(28|66)") OR (${MCUX_DEVICE} MATCHES "MKE(14|16|18)") OR (CONFIG_SOC_MIMXRT1166_CM4) OR (CONFIG_SOC_MIMXRT1176_CM4))
   set_variable_ifdef(CONFIG_HAS_MCUX_CACHE		CONFIG_MCUX_COMPONENT_driver.cache_lmem)
+elseif(CONFIG_CPU_CORTEX_A)
+  set_variable_ifdef(CONFIG_HAS_MCUX_CACHE              CONFIG_MCUX_COMPONENT_driver.cache_armv8_a)
 endif()
   set_variable_ifdef(CONFIG_HAS_MCUX_XCACHE		CONFIG_MCUX_COMPONENT_driver.cache_xcache)
 

--- a/modules/hal_nxp/mcux/mcux-sdk/CMakeLists.txt
+++ b/modules/hal_nxp/mcux/mcux-sdk/CMakeLists.txt
@@ -76,10 +76,6 @@ if (DEFINED CONFIG_SOC_RESET_HOOK)
   endif()
 endif()
 
-if(CONFIG_CPU_CORTEX_A)
-  include_driver_ifdef(CONFIG_HAS_MCUX_CACHE		cache/armv8-a	driver_cache_armv8a)
-endif()
-
 include(../mcux-sdk-ng/middleware/middleware.cmake)
 include(../mcux-sdk-ng/components/components.cmake)
 include(../mcux-sdk-ng/drivers/drivers.cmake)

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 1255d8b0da1e836d71531187e8b6c1100172672a
+      revision: 19c05e1835027a8576cd5ec6fc34381ca239153d
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
So that it could be used by devices both in mcux-sdk and mcux-sdk-ng.

depends on https://github.com/zephyrproject-rtos/hal_nxp/pull/577