### PR TITLE
drivers: usb: udc: numaker: fix some issues

### DIFF
--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -1205,7 +1205,7 @@ static void numaker_usbd_msg_handler(const struct device *dev)
 	}
 }
 
-static void numaker_udbd_isr(const struct device *dev)
+static void numaker_usbd_isr(const struct device *dev)
 {
 	const struct udc_numaker_config *config = dev->config;
 	struct udc_numaker_data *priv = udc_get_private(dev);
@@ -1747,7 +1747,7 @@ static const struct udc_api udc_numaker_api = {
                                                                                                    \
 	static void udc_numaker_irq_config_func_##inst(const struct device *dev)                   \
 	{                                                                                          \
-		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), numaker_udbd_isr,     \
+		IRQ_CONNECT(DT_INST_IRQN(inst), DT_INST_IRQ(inst, priority), numaker_usbd_isr,     \
 			    DEVICE_DT_INST_GET(inst), 0);                                          \
                                                                                                    \
 		irq_enable(DT_INST_IRQN(inst));                                                    \

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -172,7 +172,7 @@ static inline void numaker_usbd_sw_connect(const struct device *dev)
 
 	/* Enable relevant interrupts */
 	base->INTEN = USBD_INT_BUS | USBD_INT_USB | USBD_INT_FLDET |
-		      IF_ENABLED(CONFIG_UDC_ENABLE_SOF, (USBD_INT_SOF |))
+		      IF_ENABLED(CONFIG_UDC_ENABLE_SOF, (USBD_INT_SOF |)) /* CPU load concern */
 		      USBD_INT_WAKEUP;
 
 	/* Clear SE0 for connect */
@@ -558,8 +558,8 @@ static void numaker_usbd_ep_config_major(struct numaker_usbd_ep *ep_cur,
 	}
 
 	/* Endpoint index */
-	ep_cur->ep_hw_cfg |=
-		(USB_EP_GET_IDX(ep_cfg->addr) << USBD_CFG_EPNUM_Pos) & USBD_CFG_EPNUM_Msk;
+	ep_cur->ep_hw_cfg |= (USB_EP_GET_IDX(ep_cfg->addr) << USBD_CFG_EPNUM_Pos) &
+			     USBD_CFG_EPNUM_Msk;
 
 	ep_base->CFG = ep_cur->ep_hw_cfg;
 }
@@ -1371,8 +1371,8 @@ static void numaker_udbd_isr(const struct device *dev)
 			 */
 			if (ep == USB_EP_GET_ADDR(0, USB_EP_DIR_OUT)) {
 				struct numaker_usbd_ep *ep_ctrlout = priv->ep_pool + 0;
-				USBD_EP_T *ep_ctrlout_base =
-					numaker_usbd_ep_base(dev, ep_ctrlout->ep_hw_idx);
+				USBD_EP_T *ep_ctrlout_base = numaker_usbd_ep_base(
+					dev, ep_ctrlout->ep_hw_idx);
 
 				ep_ctrlout->mxpld_ctrlout = ep_ctrlout_base->MXPLD;
 			}

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -1214,8 +1214,8 @@ static void numaker_usbd_isr(const struct device *dev)
 
 	struct numaker_usbd_msg msg = {0};
 
-	uint32_t volatile usbd_intsts = base->INTSTS;
-	uint32_t volatile usbd_bus_state = base->ATTR;
+	uint32_t usbd_intsts = base->INTSTS;
+	uint32_t usbd_bus_state = base->ATTR;
 
 	/* Focus on enabled
 	 *

--- a/drivers/usb/udc/udc_numaker.c
+++ b/drivers/usb/udc/udc_numaker.c
@@ -176,6 +176,7 @@ static inline void numaker_usbd_sw_connect(const struct device *dev)
 		      USBD_INT_WAKEUP;
 
 	/* Clear SE0 for connect */
+	base->ATTR |= USBD_ATTR_DPPUEN_Msk;
 	base->SE0 &= ~USBD_DRVSE0;
 }
 
@@ -345,8 +346,8 @@ static int numaker_usbd_hw_setup(const struct device *dev)
 
 	/* Initialize USBD engine */
 	/* NOTE: BSP USBD driver: ATTR = 0x7D0 */
-	base->ATTR = USBD_ATTR_BYTEM_Msk | BIT(9) | USBD_ATTR_DPPUEN_Msk | USBD_ATTR_USBEN_Msk |
-		     BIT(6) | USBD_ATTR_PHYEN_Msk;
+	base->ATTR = USBD_ATTR_BYTEM_Msk | BIT(9) | USBD_ATTR_USBEN_Msk | BIT(6) |
+		     USBD_ATTR_PHYEN_Msk;
 
 	/* Set SE0 for S/W disconnect */
 	numaker_usbd_sw_disconnect(dev);


### PR DESCRIPTION
This fixes some issues of nuvoton numaker udc driver, including:
1. Fix timing to enable D+ pull-up so that device won't be recognized by host until user application invokes `udc_enable()`.
1. Refine interrupt handling sequence: clear interrupt flag first, then process it.
   This can avoid one race condition when interrupt flag is cleared but not processed for interrupts of the same type coming very closely.
1. Support VBUS detect (`caps.can_detect_vbus`). This requires enabling VBUS detect interrupt early.