### PR TITLE
scripts: ci: check_compliance: Add check for zephyr module file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ SysbuildKconfigBasic.txt
 SysbuildKconfigBasicNoModules.txt
 TextEncoding.txt
 YAMLLint.txt
+ZephyrModuleFile.txt

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1785,6 +1785,23 @@ class ModulesMaintainers(ComplianceTest):
                 self.failure(f"Missing {maintainers_file} entry for: \"{area}\"")
 
 
+class ZephyrModuleFile(ComplianceTest):
+    """
+    Check that no zephyr/module.yml file has been added to the Zephyr repository
+    """
+    name = "ZephyrModuleFile"
+    doc = "Check that no zephyr/module.yml file has been added to the Zephyr repository."
+
+    def run(self):
+        module_files = [ZEPHYR_BASE / 'zephyr' / 'module.yml',
+                        ZEPHYR_BASE / 'zephyr' / 'module.yaml']
+
+        for file in module_files:
+            if os.path.exists(file):
+                self.failure("A zephyr module file has been added to the Zephyr repository")
+                break
+
+
 class YAMLLint(ComplianceTest):
     """
     YAMLLint


### PR DESCRIPTION
Adds a check which fails CI if a zephyr module file is added to the zephyr repository itself