### PR TITLE
drivers: wifi: nxp: update the TX data API

### DIFF
--- a/drivers/wifi/nxp/nxp_wifi_drv.c
+++ b/drivers/wifi/nxp/nxp_wifi_drv.c
@@ -1945,7 +1945,7 @@ static NXP_WIFI_SET_FUNC_ATTR int nxp_wifi_send(const struct device *dev, struct
 #endif
 
 	/* Enqueue packet for transmission */
-	if (nxp_wifi_internal_tx(dev, pkt) != WM_SUCCESS) {
+	if (nxp_wifi_internal_tx(dev, pkt, 0) != WM_SUCCESS) {
 		goto out;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 19c05e1835027a8576cd5ec6fc34381ca239153d
+      revision: 2de68b601cc95417466707f1b99149820b0556ec
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
drivers: wifi: nxp: update the TX data API
Update the TX data API to support distinguishing if this packet is from
net stack or from internal packet forwarding case.

manifest: sync hal_nxp to update wifi driver version
upgrade wifi driver version to r52.p3 and update the TX API.
