### PR TITLE
drivers/i2c: ite: Avoid entering power policy during PIO transfers

### DIFF
--- a/drivers/i2c/i2c_ite_it51xxx.c
+++ b/drivers/i2c/i2c_ite_it51xxx.c
@@ -1455,6 +1455,10 @@ static int i2c_it51xxx_transfer(const struct device *dev, struct i2c_msg *msgs, 
 #endif
 	/* Lock mutex of i2c controller */
 	k_mutex_lock(&data->mutex, K_FOREVER);
+#ifdef CONFIG_PM
+	/* Block to enter power policy. */
+	i2c_ite_pm_policy_state_lock_get(data, I2CM_ITE_PM_POLICY_FLAG);
+#endif
 	/*
 	 * If the transaction of write to read is divided into two transfers, the repeat start
 	 * transfer uses this flag to exclude checking bus busy.
@@ -1469,9 +1473,8 @@ static int i2c_it51xxx_transfer(const struct device *dev, struct i2c_msg *msgs, 
 			 * (No external pull-up), drop the transaction.
 			 */
 			if (i2c_bus_not_available(dev)) {
-				/* Unlock mutex of i2c controller */
-				k_mutex_unlock(&data->mutex);
-				return -EIO;
+				ret = -EIO;
+				goto done;
 			}
 		}
 
@@ -1486,13 +1489,6 @@ static int i2c_it51xxx_transfer(const struct device *dev, struct i2c_msg *msgs, 
 	data->msg_index = 0;
 
 	bool fifo_mode_enable = fifo_mode_allowed(dev, msgs);
-
-	if (fifo_mode_enable) {
-#ifdef CONFIG_PM
-		/* Block to enter power policy. */
-		i2c_ite_pm_policy_state_lock_get(data, I2CM_ITE_PM_POLICY_FLAG);
-#endif
-	}
 #endif
 	for (int i = 0; i < num_msgs; i++) {
 		data->widx = 0;
@@ -1568,10 +1564,6 @@ static int i2c_it51xxx_transfer(const struct device *dev, struct i2c_msg *msgs, 
 		if (data->num_msgs == 2) {
 			i2c_fifo_en_w2r(dev, false);
 		}
-#ifdef CONFIG_PM
-		/* Permit to enter power policy. */
-		i2c_ite_pm_policy_state_lock_put(data, I2CM_ITE_PM_POLICY_FLAG);
-#endif
 	}
 #endif
 	/* Reset i2c channel status */
@@ -1582,6 +1574,11 @@ static int i2c_it51xxx_transfer(const struct device *dev, struct i2c_msg *msgs, 
 	/* Save return value. */
 	ret = i2c_parsing_return_value(dev);
 
+done:
+#ifdef CONFIG_PM
+	/* Permit to enter power policy. */
+	i2c_ite_pm_policy_state_lock_put(data, I2CM_ITE_PM_POLICY_FLAG);
+#endif
 	/* Unlock mutex of i2c controller */
 	k_mutex_unlock(&data->mutex);
 

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -944,6 +944,8 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 
 	/* Lock mutex of i2c controller */
 	k_mutex_lock(&data->mutex, K_FOREVER);
+	/* Block to enter power policy. */
+	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 	/*
 	 * If the transaction of write to read is divided into two
 	 * transfers, the repeat start transfer uses this flag to
@@ -961,9 +963,8 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 			 * (No external pull-up), drop the transaction.
 			 */
 			if (i2c_bus_not_available(dev)) {
-				/* Unlock mutex of i2c controller */
-				k_mutex_unlock(&data->mutex);
-				return -EIO;
+				ret = -EIO;
+				goto done;
 			}
 		}
 
@@ -975,11 +976,6 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 	/* Store msgs to data struct. */
 	data->msgs_list = msgs;
 	bool fifo_mode_enable = fifo_mode_allowed(dev, msgs);
-
-	if (fifo_mode_enable) {
-		/* Block to enter power policy. */
-		pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
-	}
 #endif
 	for (int i = 0; i < num_msgs; i++) {
 
@@ -1056,8 +1052,6 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 		if (data->num_msgs == 2) {
 			i2c_fifo_en_w2r(dev, 0);
 		}
-		/* Permit to enter power policy. */
-		pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 	}
 #endif
 	/* reset i2c channel status */
@@ -1066,6 +1060,10 @@ static int i2c_it8xxx2_transfer(const struct device *dev, struct i2c_msg *msgs,
 	}
 	/* Save return value. */
 	ret = i2c_parsing_return_value(dev);
+
+done:
+	/* Permit to enter power policy. */
+	pm_policy_state_lock_put(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 	/* Unlock mutex of i2c controller */
 	k_mutex_unlock(&data->mutex);
 


### PR DESCRIPTION
This PR contains three commits that fix I2C PIO mode power policy issues for the ITE SoCs(it81xx2, it82xx2, it51xxx):
Avoid entering low-power state during I2C host transfers in PIO mode. Entering a low-power state during an active PIO transfer may prevent the peripheral from generating the clock signal correctly, resulting in transmission errors.