### PR TITLE
dts: arm: adi: Enable RTC counter for MAX32657

### DIFF
--- a/boards/adi/max32657evkit/max32657evkit_max32657.dts
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.dts
@@ -50,8 +50,3 @@
 &trng {
 	status = "okay";
 };
-
-&rtc_counter {
-	status = "okay";
-	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
-};

--- a/boards/adi/max32657evkit/max32657evkit_max32657.dts
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.dts
@@ -50,3 +50,8 @@
 &trng {
 	status = "okay";
 };
+
+&rtc_counter {
+	status = "okay";
+	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
+};

--- a/boards/adi/max32657evkit/max32657evkit_max32657.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657.yaml
@@ -14,6 +14,7 @@ supported:
   - dma
   - counter
   - pwm
+  - rtc_counter
   - spi
 ram: 256
 flash: 960

--- a/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_common.dtsi
@@ -71,3 +71,8 @@
 	pinctrl-0 = <&spi0_mosi_p0_2 &spi0_miso_p0_4 &spi0_sck_p0_6 &spi0_ss0_p0_3>;
 	pinctrl-names = "default";
 };
+
+&rtc_counter {
+	status = "okay";
+	clock-source = <ADI_MAX32_PRPH_CLK_SRC_INRO>;
+};

--- a/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
+++ b/boards/adi/max32657evkit/max32657evkit_max32657_ns.yaml
@@ -13,6 +13,7 @@ supported:
   - dma
   - counter
   - pwm
+  - rtc_counter
   - spi
 ram: 192
 flash: 576

--- a/dts/arm/adi/max32/max32657_common.dtsi
+++ b/dts/arm/adi/max32/max32657_common.dtsi
@@ -269,6 +269,13 @@
 		};
 	};
 
+	rtc_counter: rtc_counter@6000 {
+		compatible = "adi,max32-rtc-counter";
+		reg = <0x6000 0x400>;
+		interrupts = <2 0>;
+		status = "disabled";
+	};
+
 	spi0: spi@46000 {
 		compatible = "adi,max32-spi";
 		reg = <0x46000 0x1000>;

--- a/dts/bindings/counter/adi,max32-rtc-counter.yaml
+++ b/dts/bindings/counter/adi,max32-rtc-counter.yaml
@@ -7,3 +7,18 @@ description: ADI MAX32 compatible Counter RTC
 compatible: "adi,max32-rtc-counter"
 
 include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  clock-source:
+    type: int
+    enum: [4, 5]
+    description: |
+      Clock source to be used by the RTC peripheral. The following options
+      are available:
+      - 4: "ADI_MAX32_PRPH_CLK_SRC_ERTCO" External Real-Time Clock Oscillator
+      - 5: "ADI_MAX32_PRPH_CLK_SRC_INRO" Internal Ring Oscillator
+      The target device might not support all option please take a look on
+      target device user guide


### PR DESCRIPTION
Adds RTC counter node to MAX32657 SoC and enable RTC counter for MAX32657EVKIT boards. RTC clock source is set to `ADI_MAX32_PRPH_CLK_SRC_INRO` as external crystal is not mounted by default on the evaluation kit.