### PR TITLE
led_strip: ws2812_spi: place buffer in __nocache for DMA

### DIFF
--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -17,6 +17,17 @@ config WS2812_STRIP_SPI
 	  The SPI driver is portable, but requires significantly more
 	  memory (1 byte of overhead per bit of pixel data).
 
+if WS2812_STRIP_SPI
+
+config WS2812_STRIP_SPI_FORCE_NOCACHE
+	bool "Place led buffer in __nocache section"
+	default y if DCACHE && DMA
+	help
+	  For SPI communication using DMA, place the WS2812 SPI buffer in the __nocache section to
+	  ensure it is stored in uncached memory, as DMA usually requires access to uncached regions.
+
+endif
+
 config WS2812_STRIP_I2S
 	bool "WS2812 LED strip I2S driver"
 	default y

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -198,30 +198,31 @@ static DEVICE_API(led_strip, ws2812_spi_api) = {
 /* Get the latch/reset delay from the "reset-delay" DT property. */
 #define WS2812_RESET_DELAY(idx) DT_INST_PROP(idx, reset_delay)
 
-#define WS2812_SPI_DEVICE(idx)						 \
-									 \
-	static uint8_t ws2812_spi_##idx##_px_buf[WS2812_SPI_BUFSZ(idx)]; \
-									 \
-	WS2812_COLOR_MAPPING(idx);					 \
-									 \
-	static const struct ws2812_spi_cfg ws2812_spi_##idx##_cfg = {	 \
-		.bus = SPI_DT_SPEC_INST_GET(idx, SPI_OPER(idx), 0),	 \
-		.px_buf = ws2812_spi_##idx##_px_buf,			 \
-		.one_frame = WS2812_SPI_ONE_FRAME(idx),			 \
-		.zero_frame = WS2812_SPI_ZERO_FRAME(idx),		 \
-		.num_colors = WS2812_NUM_COLORS(idx),			 \
-		.color_mapping = ws2812_spi_##idx##_color_mapping,	 \
-		.length = DT_INST_PROP(idx, chain_length),               \
-		.reset_delay = WS2812_RESET_DELAY(idx),			 \
-	};								 \
-									 \
-	DEVICE_DT_INST_DEFINE(idx,					 \
-			      ws2812_spi_init,				 \
-			      NULL,					 \
-			      NULL,					 \
-			      &ws2812_spi_##idx##_cfg,			 \
-			      POST_KERNEL,				 \
-			      CONFIG_LED_STRIP_INIT_PRIORITY,		 \
+#define WS2812_SPI_DEVICE(idx)							\
+										\
+	static uint8_t ws2812_spi_##idx##_px_buf[WS2812_SPI_BUFSZ(idx)]		\
+		IF_ENABLED(CONFIG_WS2812_STRIP_SPI_FORCE_NOCACHE, (__nocache)); \
+										\
+	WS2812_COLOR_MAPPING(idx);						\
+										\
+	static const struct ws2812_spi_cfg ws2812_spi_##idx##_cfg = {		\
+		.bus = SPI_DT_SPEC_INST_GET(idx, SPI_OPER(idx), 0),		\
+		.px_buf = ws2812_spi_##idx##_px_buf,				\
+		.one_frame = WS2812_SPI_ONE_FRAME(idx),				\
+		.zero_frame = WS2812_SPI_ZERO_FRAME(idx),			\
+		.num_colors = WS2812_NUM_COLORS(idx),				\
+		.color_mapping = ws2812_spi_##idx##_color_mapping,		\
+		.length = DT_INST_PROP(idx, chain_length),			\
+		.reset_delay = WS2812_RESET_DELAY(idx),				\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(idx,						\
+			      ws2812_spi_init,					\
+			      NULL,						\
+			      NULL,						\
+			      &ws2812_spi_##idx##_cfg,				\
+			      POST_KERNEL,					\
+			      CONFIG_LED_STRIP_INIT_PRIORITY,			\
 			      &ws2812_spi_api);
 
 DT_INST_FOREACH_STATUS_OKAY(WS2812_SPI_DEVICE)


### PR DESCRIPTION
This pull request introduces a new configuration option to place the memory buffer used for SPI communication with WS2812 LED strips in un-cached memory and updates the corresponding driver implementation. 

Without this fix, there is an error in the log for stm32 targets which uses SPI with DMA : `<err> spi_ll_stm32: SPI DMA transfers not supported on cached memory`.