### PR TITLE
net: tcp: Fix handling of keep-alive probes

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2859,7 +2859,9 @@ static enum net_verdict tcp_in(struct tcp *conn, struct net_pkt *pkt)
 		/* send ACK for non-RST packet */
 		if (FL(&fl, &, RST)) {
 			net_stats_update_tcp_seg_rsterr(net_pkt_iface(pkt));
-		} else if ((len > 0) || FL(&fl, &, FIN)) {
+		} else if ((len > 0) || FL(&fl, &, FIN) ||
+			   /* Keep-alive probe */
+			   ((len == 0) && FL(&fl, &, ACK))) {
 			tcp_out(conn, ACK);
 		}
 		k_mutex_unlock(&conn->lock);


### PR DESCRIPTION
Fix processing of a received keep-alive probe and add a test case that the connection remains alive after a keep-alive exchange.

Fixes #93350