### PR TITLE
hostap: Add CONFIG_HS20 option for Hotspot 2.0 support

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -569,6 +569,9 @@ config ACS
 config IEEE80211AC
 	bool
 
+config HS20
+	bool
+
 config IEEE80211R
 	bool
 	depends on !WIFI_NM_WPA_SUPPLICANT_CRYPTO_NONE


### PR DESCRIPTION
The Kconfig CONFIG_HS20 was undefined in zephyr hostap. Need to add config for Hotspot 2.0 feature.