### PR TITLE
modem: modules: remove EXPERIMENTAL

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -85,7 +85,7 @@
 @defgroup modem Modem APIs
 @ingroup connectivity
 @since 3.5
-@version 0.1.0
+@version 1.0.0
 @{
 @}
 

--- a/include/zephyr/modem/chat.h
+++ b/include/zephyr/modem/chat.h
@@ -19,6 +19,15 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Modem Chat
+ * @defgroup modem_chat Modem Chat
+ * @since 3.5
+ * @version 1.0.0
+ * @ingroup modem
+ * @{
+ */
+
 struct modem_chat;
 
 /**
@@ -519,6 +528,10 @@ void modem_chat_script_set_callback(struct modem_chat_script *script,
  * @param timeout_s Timeout in seconds
  */
 void modem_chat_script_set_timeout(struct modem_chat_script *script, uint32_t timeout_s);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/modem/cmux.h
+++ b/include/zephyr/modem/cmux.h
@@ -37,6 +37,8 @@ extern "C" {
 /**
  * @brief Modem CMUX
  * @defgroup modem_cmux Modem CMUX
+ * @since 3.5
+ * @version 1.0.0
  * @ingroup modem
  * @{
  */

--- a/include/zephyr/modem/pipe.h
+++ b/include/zephyr/modem/pipe.h
@@ -17,6 +17,8 @@ extern "C" {
 /**
  * @brief Modem Pipe
  * @defgroup modem_pipe Modem Pipe
+ * @since 3.5
+ * @version 1.0.0
  * @ingroup modem
  * @{
  */

--- a/include/zephyr/modem/pipelink.h
+++ b/include/zephyr/modem/pipelink.h
@@ -18,6 +18,8 @@ extern "C" {
 /**
  * @brief Modem pipelink
  * @defgroup modem_pipelink Modem pipelink
+ * @since 3.7
+ * @version 1.0.0
  * @ingroup modem
  * @{
  */

--- a/include/zephyr/modem/ppp.h
+++ b/include/zephyr/modem/ppp.h
@@ -24,6 +24,8 @@ extern "C" {
 /**
  * @brief Modem PPP
  * @defgroup modem_ppp Modem PPP
+ * @since 3.5
+ * @version 1.0.0
  * @ingroup modem
  * @{
  */

--- a/include/zephyr/modem/ubx.h
+++ b/include/zephyr/modem/ubx.h
@@ -23,6 +23,8 @@ extern "C" {
 /**
  * @brief Modem Ubx
  * @defgroup modem_ubx Modem Ubx
+ * @since 3.7
+ * @version 1.0.0
  * @ingroup modem
  * @{
  */

--- a/subsys/modem/Kconfig
+++ b/subsys/modem/Kconfig
@@ -3,7 +3,6 @@
 
 menuconfig MODEM_MODULES
 	bool "Modem modules"
-	select EXPERIMENTAL
 
 if MODEM_MODULES
 


### PR DESCRIPTION
Remove the EXPERIMENTAL label from the MODEM_MODULES. These modules are fully tested and widely used, and have been present for 2 years.