### PR TITLE
latmon: guard kconfigs to avoid leaks

### DIFF
--- a/subsys/net/lib/latmon/Kconfig
+++ b/subsys/net/lib/latmon/Kconfig
@@ -9,6 +9,7 @@ config NET_LATMON
 	help
 	  This option enables the latency monitoring support for Zephyr
 
+if NET_LATMON
 config NET_LATMON_PORT
 	int "Latmon - Latmus communication port"
 	default 2306
@@ -56,3 +57,5 @@ module-dep = NET_LOG
 module-str = Latency monitoring Service
 module-help = This option enables the latency monitoring support for Zephyr
 source "subsys/net/Kconfig.template.log_config.net"
+
+endif


### PR DESCRIPTION
Guard all kconfig options to avoid kconfig leakage when latmon is not
enabled.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
