### PR TITLE
boards: renesas: ek_ra2l1: Add support for flashing with probe-rs

### DIFF
--- a/boards/renesas/ek_ra2l1/board.cmake
+++ b/boards/renesas/ek_ra2l1/board.cmake
@@ -6,7 +6,9 @@ board_set_flasher_ifnset(jlink)
 
 board_runner_args(jlink "--device=r7fa2l1ab")
 board_runner_args(pyocd "--target=r7fa2l1ab")
+board_runner_args(probe-rs "--chip=r7fa2l1ab")
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)


### PR DESCRIPTION
Allow flashing the r7fa2l1ab chip found on the ek_ra2l1 board using the probe-rs runner.