### PR TITLE
stm32mp2x series: fix SystemCoreClock value

### DIFF
--- a/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_dk/stm32mp257f_dk_stm32mp257fxx_m33.dts
@@ -45,6 +45,15 @@
 	};
 };
 
+&clk_hsi {
+	status = "okay";
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(40)>;
+	status = "okay";
+};
+
 &rcc {
 	clock-frequency = <DT_FREQ_M(400)>;
 };

--- a/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
+++ b/boards/st/stm32mp257f_ev1/stm32mp257f_ev1_stm32mp257fxx_m33.dts
@@ -45,6 +45,15 @@
 	};
 };
 
+&clk_hsi {
+	status = "okay";
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(40)>;
+	status = "okay";
+};
+
 &rcc {
 	clock-frequency = <DT_FREQ_M(400)>;
 };

--- a/dts/arm/st/mp2/stm32mp2_m33.dtsi
+++ b/dts/arm/st/mp2/stm32mp2_m33.dtsi
@@ -241,6 +241,22 @@
 			status = "disabled";
 		};
 	};
+
+	clocks {
+
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			status = "disabled";
+		};
+
+		clk_hsi: clk-hsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <DT_FREQ_M(64)>;
+			status = "disabled";
+		};
+	};
 };
 
 &nvic {

--- a/soc/st/stm32/stm32mp2x/Kconfig
+++ b/soc/st/stm32/stm32mp2x/Kconfig
@@ -12,6 +12,7 @@ config SOC_STM32MP2X_M33
 	select ARMV8_M_DSP
 	select ARM_TRUSTZONE_M
 	select CPU_CORTEX_M33
+	select SOC_EARLY_INIT_HOOK
 	select CPU_CORTEX_M_HAS_DWT
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_ARM_SAU

--- a/soc/st/stm32/stm32mp2x/m33/CMakeLists.txt
+++ b/soc/st/stm32/stm32mp2x/m33/CMakeLists.txt
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(${ZEPHYR_BASE}/drivers)
+zephyr_sources(
+  soc.c
+)
 
 zephyr_include_directories(.)
 

--- a/soc/st/stm32/stm32mp2x/m33/soc.c
+++ b/soc/st/stm32/stm32mp2x/m33/soc.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief STM32MP25 Cortex-M33 initialization code
+ */
+
+#include <soc.h>
+
+/**
+ * @brief Perform basic hardware initialization at boot.
+ *
+ * This needs to be run from the very beginning.
+ */
+void soc_early_init_hook(void)
+{
+	/* Update CMSIS SystemCoreClock variable (HCLK) */
+	SystemCoreClockUpdate();
+}


### PR DESCRIPTION
The `SystemCoreClock` should be set to 400 MHz for the Cortex-M33, but the current implementation sets it to 64 MHz.  
This PR fixes the issue by:  
- Adding `soc_early_init_hook()` to compute the `SystemCoreClock` value based on the clock tree configured by the Cortex-A35  
- Declaring HSE and HSI clocks in the device tree to set their fixed frequencies

