### PR TITLE
MAINTAINERS: Remove carlocaione from Open AMP maintainers

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3857,7 +3857,6 @@ Octavo Systems Platforms:
 Open AMP:
   status: maintained
   maintainers:
-    - carlocaione
     - iuliana-prodan
   collaborators:
     - uLipe


### PR DESCRIPTION
Remove carlocaione from the OpenAMP maintainers list because he hasn't been active for a while.