### PR TITLE
dts: arm: silabs: instantiate acmp1 nodes for xg2x parts

### DIFF
--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -445,6 +445,14 @@
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
+
+		acmp1: acmp@5a00c000 {
+			compatible = "silabs,acmp";
+			reg = <0x5a00c000 0x4000>;
+			interrupts = <42 2>;
+			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_EM01GRPACLK>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -441,7 +441,7 @@
 		acmp0: acmp@5a008000 {
 			compatible = "silabs,acmp";
 			reg = <0x5a008000 0x4000>;
-			interrupts = <41 0>;
+			interrupts = <41 2>;
 			clocks = <&cmu CLOCK_AUTO CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -574,6 +574,14 @@
 			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
+
+		acmp1: acmp@5900c000 {
+			compatible = "silabs,acmp";
+			reg = <0x5900c000 0x4000>;
+			interrupts = <42 2>;
+			clocks = <&cmu CLOCK_ACMP1 CLOCK_BRANCH_EM01GRPACLK>;
+			status = "disabled";
+		};
 	};
 
 	hwinfo: hwinfo {

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -544,6 +544,14 @@
 			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
 			status = "disabled";
 		};
+
+		acmp1: acmp@5900c000 {
+			compatible = "silabs,acmp";
+			reg = <0x5900c000 0x4000>;
+			interrupts = <41 2>;
+			clocks = <&cmu CLOCK_ACMP0 CLOCK_BRANCH_EM01GRPACLK>;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
The goal of this PR is to instantiate the missing instance acmp1 for xg21, xg23 and xg24 devices and fix the interrupt priority for acmp0. acmp1 can be used with the comparator driver.