### PR TITLE
doc: releases: expose draft 4.3 release notes + migration guide in toc

### DIFF
--- a/doc/releases/eol_releases.rst
+++ b/doc/releases/eol_releases.rst
@@ -32,4 +32,5 @@ Migration Guides
    :glob:
    :reversed:
 
-   migration-guide-3.[5]
+   migration-guide-3.[5-6]
+   migration-guide-4.[0-0]

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -94,7 +94,7 @@ with the changes in the project.
    :reversed:
 
    release-notes-3.7
-   release-notes-4.[1-2]
+   release-notes-4.[1-3]
 
 Migration Guides
 ****************
@@ -125,8 +125,8 @@ to be able to understand the context of the change.
    :glob:
    :reversed:
 
-   migration-guide-3.[6-7]
-   migration-guide-4.[0-2]
+   migration-guide-3.7
+   migration-guide-4.[1-3]
 
 End-of-life Releases
 ********************


### PR DESCRIPTION
Update toctrees to show 4.3 documents in the release page
Also move migration guide to 3.6 and 4.0 to the attic, a.k.a EOL releases page.