### PR TITLE
doc: release: Add TF-M ITS settings backend to 4.3 release notes

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -65,6 +65,10 @@ New APIs and options
 
 .. zephyr-keep-sorted-start re(^\* \w)
 
+* Settings
+
+   * :kconfig:option:`CONFIG_SETTINGS_TFM_ITS`
+
 .. zephyr-keep-sorted-stop
 
 New Boards


### PR DESCRIPTION
Add TF-M ITS settings backend and enabling Kconfig to 4.3 release notes.