### PR TITLE
Excluding frdm_mcxw71 from the wdt_basic_api test due to retained memory variables

### DIFF
--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -32,6 +32,7 @@ tests:
       - bl54l15_dvk/nrf54l15/cpuapp/ns
       - bl54l15u_dvk/nrf54l15/cpuapp/ns
       - raytac_an54l15q_db/nrf54l15/cpuapp/ns
+      - frdm_mcxw71
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"


### PR DESCRIPTION
The wdt_basic_api test uses retained memory. Currently, uses sram0 for the ram space. This mostly does not retain memory. Since the test variables are unable to retain their value this platform test fails and should be excluded for now. Specifying the memory region that does contain retained memory does not seem user friendly at the moment an requires greater effort.
 Fixes #86849 