### PR TITLE
Revert "modules: nrf_wifi: Use spinlocks"

### DIFF
--- a/modules/nrf_wifi/os/shim.c
+++ b/modules/nrf_wifi/os/shim.c
@@ -195,14 +195,9 @@ static void zep_shim_qspi_cpy_to(void *priv, unsigned long addr, const void *src
 }
 #endif /* !CONFIG_NRF71_ON_IPC */
 
-struct zep_shim_spinlock {
-	struct k_spinlock lock;
-	k_spinlock_key_t key;
-};
-
 static void *zep_shim_spinlock_alloc(void)
 {
-	struct zep_shim_spinlock *slock = NULL;
+	struct k_mutex *lock = NULL;
 
 	slock = k_heap_aligned_alloc(wifi_ctrl_pool, WORD_SIZE, sizeof(*slock), K_FOREVER);
 	if (!slock) {
@@ -211,7 +206,7 @@ static void *zep_shim_spinlock_alloc(void)
 		memset(slock, 0, sizeof(*slock));
 	}
 
-	return slock;
+	return lock;
 }
 
 static void zep_shim_spinlock_free(void *lock)
@@ -223,38 +218,29 @@ static void zep_shim_spinlock_free(void *lock)
 
 static void zep_shim_spinlock_init(void *lock)
 {
-	/* No explicit initialization needed for k_spinlock_t */
-	ARG_UNUSED(lock);
+	k_mutex_init(lock);
 }
 
 static void zep_shim_spinlock_take(void *lock)
 {
-	struct zep_shim_spinlock *slock = (struct zep_shim_spinlock *)lock;
-
-	slock->key = k_spin_lock(&slock->lock);
+	k_mutex_lock(lock, K_FOREVER);
 }
 
 static void zep_shim_spinlock_rel(void *lock)
 {
-	struct zep_shim_spinlock *slock = (struct zep_shim_spinlock *)lock;
-
-	k_spin_unlock(&slock->lock, slock->key);
+	k_mutex_unlock(lock);
 }
 
 static void zep_shim_spinlock_irq_take(void *lock, unsigned long *flags)
 {
-	struct zep_shim_spinlock *slock = (struct zep_shim_spinlock *)lock;
-
 	ARG_UNUSED(flags);
-	slock->key = k_spin_lock(&slock->lock);
+	k_mutex_lock(lock, K_FOREVER);
 }
 
 static void zep_shim_spinlock_irq_rel(void *lock, unsigned long *flags)
 {
-	struct zep_shim_spinlock *slock = (struct zep_shim_spinlock *)lock;
-
 	ARG_UNUSED(flags);
-	k_spin_unlock(&slock->lock, slock->key);
+	k_mutex_unlock(lock);
 }
 
 static int zep_shim_pr_dbg(const char *fmt, va_list args)


### PR DESCRIPTION
This reverts commit 3e9dffbe2581e940178607a7ce5074a014c22dbb. Though this works fine, when CONFIG_ASSERT=y the spinlock validation fails as the underlying code though uses OSAL spinlock APIs is not ready

* sleeping with spinlock held
* multiple threads taking the same spinlock (might work on UP, but not on SMP on the same CPU)

Revert this for now, till the underyling is robust.