### PR TITLE
modem: pipelink: silence warning in modem_pipelink_is_connected

### DIFF
--- a/subsys/modem/modem_pipelink.c
+++ b/subsys/modem/modem_pipelink.c
@@ -27,7 +27,7 @@ void modem_pipelink_attach(struct modem_pipelink *link,
 
 bool modem_pipelink_is_connected(struct modem_pipelink *link)
 {
-	bool connected;
+	bool connected = false;
 
 	K_SPINLOCK(&link->spinlock) {
 		connected = link->connected;


### PR DESCRIPTION
Initialize local variable `connected` to false to quiet the GCC warning

```
/Users/vanpetrosyan/Projects/scs-firmware/zephyr/subsys/modem/modem_pipelink.c: In function 'modem_pipelink_is_connected':
/Users/vanpetrosyan/Projects/scs-firmware/zephyr/subsys/modem/modem_pipelink.c:36:16: warning: 'connected' may be used uninitialized [-Wmaybe-uninitialized]
   36 |         return connected;
      |                ^~~~~~~~~
/Users/vanpetrosyan/Projects/scs-firmware/zephyr/subsys/modem/modem_pipelink.c:30:14: note: 'connected' was declared here
   30 |         bool connected;
```

