### PR TITLE
boards: nordic: nrf7002dk: Fix DTS warning

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
@@ -73,12 +73,13 @@
 				<NRF_PSEL(QSPI_IO2, 0, 15)>,
 				<NRF_PSEL(QSPI_IO3, 0, 16)>;
 			bias-pull-down;
+			low-power-enable;
 		};
 		group2 {
 			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
 			bias-pull-up;
+			low-power-enable;
 		};
-		low-power-enable;
 	};
 
 	uart1_default: uart1_default {

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
@@ -59,6 +59,7 @@
 				<NRF_PSEL(QSPI_IO3, 0, 16)>;
 			bias-pull-down;
 		};
+
 		group2 {
 			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
 			bias-pull-up;
@@ -75,6 +76,7 @@
 			bias-pull-down;
 			low-power-enable;
 		};
+
 		group2 {
 			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
 			bias-pull-up;


### PR DESCRIPTION
the nRF connect device tree extension shows below warning: 'Property not mentioned in "nordic,nrf-pinctrl:child"'.

Fix this by applying the property to both groups separately.