### PR TITLE
samples: http_server: Fix warning about integer name

### DIFF
--- a/samples/net/sockets/http_server/src/ws.c
+++ b/samples/net/sockets/http_server/src/ws.c
@@ -321,7 +321,7 @@ int ws_echo_setup(int ws_socket, struct http_request_ctx *request_ctx, void *use
 			K_NO_WAIT);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
-#define MAX_NAME_LEN sizeof("ws[xx]")
+#define MAX_NAME_LEN (sizeof("ws[xxxxxxxxxx]"))
 		char name[MAX_NAME_LEN];
 
 		snprintk(name, sizeof(name), "ws[%d]", slot);


### PR DESCRIPTION
When building with CONFIG_DEBUG=y, there is a build warning about the name being truncated due to integer size is larger than MAX_NAME_LEN. So fix with modulo operator to be clear to the compiler what we expect.