### PR TITLE
Switch bootloaders to picolibc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -364,7 +364,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: cc800268f79779fa674b7085ecf507eb95b83ff9
+      revision: pull/134/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Switch rpi_pico, trusted-firmware-m and cmsis_6 to use picolibc instead of newlib.