### PR TITLE
boards: shields: adi: Fix broken images in catalog card view

### DIFF
--- a/boards/shields/eval_ad4052_ardz/doc/index.rst
+++ b/boards/shields/eval_ad4052_ardz/doc/index.rst
@@ -9,6 +9,10 @@ Overview
 The EVAL-AD4052-ARDZ is a 16-Bit SAR ADC Arduino shield powered
 by the Analog Devices AD4052.
 
+.. figure:: eval_ad4052_ardz.webp
+   :align: center
+   :alt: EVAL-AD4052-ARDZ
+
 Programming
 ***********
 

--- a/boards/shields/eval_adxl362_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl362_ardz/doc/index.rst
@@ -9,6 +9,10 @@ Overview
 The EVAL-ADXL362-ARDZ is a 3-axis digital accelerometer Arduino shield powered
 by the Analog Devices ADXL362.
 
+.. figure:: eval_adxl362_ardz.webp
+   :align: center
+   :alt: EVAL-ADXL362-ARDZ
+
 Programming
 ***********
 

--- a/boards/shields/eval_adxl367_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl367_ardz/doc/index.rst
@@ -9,6 +9,10 @@ Overview
 The EVAL-ADXL367-ARDZ is a 3-axis digital accelerometer Arduino shield powered
 by the Analog Devices ADXL367.
 
+.. figure:: eval_adxl367_ardz.webp
+   :align: center
+   :alt: EVAL-ADXL367-ARDZ
+
 Programming
 ***********
 

--- a/boards/shields/eval_adxl372_ardz/doc/index.rst
+++ b/boards/shields/eval_adxl372_ardz/doc/index.rst
@@ -9,6 +9,10 @@ Overview
 The EVAL-ADXL372-ARDZ is a 3-axis digital accelerometer Arduino shield powered
 by the Analog Devices ADXL372.
 
+.. figure:: eval_adxl372_ardz.webp
+   :align: center
+   :alt: EVAL-ADXL372-ARDZ
+
 Programming
 ***********
 


### PR DESCRIPTION
Image files for ADI shield boards were introduced in commit 25c7fa4e63626511d3ea007ed25d124501e4267b, but they weren't referenced anywhere in the documentation source and thus were deadstripped from the build, resulting in broken image references in the board catalog card view.