### PR TITLE
sensor: icm45686: Fix icm45686-xxx example node

### DIFF
--- a/dts/bindings/sensor/invensense,icm45686-i2c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-i2c.yaml
@@ -13,7 +13,7 @@ description: |
     &i2c0 {
       ...
 
-      icm42688: icm45686@68 {
+      icm45686: icm45686@68 {
         ...
 
         accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;

--- a/dts/bindings/sensor/invensense,icm45686-i3c.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-i3c.yaml
@@ -13,7 +13,7 @@ description: |
     &i3c1 {
       ...
 
-      icm42688: icm45686@680000046a00000011 {
+      icm45686: icm45686@680000046a00000011 {
         ...
 
         accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;

--- a/dts/bindings/sensor/invensense,icm45686-spi.yaml
+++ b/dts/bindings/sensor/invensense,icm45686-spi.yaml
@@ -13,7 +13,7 @@ description: |
     &spi0 {
       ...
 
-      icm42688: icm45686@0 {
+      icm45686: icm45686@0 {
         ...
 
         accel-pwr-mode = <ICM45686_DT_ACCEL_LN>;


### PR DESCRIPTION
The icm45686-xxx example nodes have incorrect node labels. The current node labels are for the icm42688.