### PR TITLE
MAINTAINERS: add 2 maintainers for hal_nuvoton

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5293,6 +5293,9 @@ West:
 "West project: hal_nuvoton":
   status: maintained
   maintainers:
+    - cyliangtw
+    - ccli8
+  collaborators:
     - ssekar15
   files:
     - modules/Kconfig.nuvoton


### PR DESCRIPTION
Add cyliangtw and ccli8 into maintainer list of hal_nuvoton.