### PR TITLE
hal_nxp: Removed MKV56F24.h wrong macro FLEXCAN2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 1255d8b0da1e836d71531187e8b6c1100172672a
+      revision: f63c98595f094f6374e4fab8528d3e5cebfb1d90
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93129