### PR TITLE
net: ethernet: e1000: add queue support

### DIFF
--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -43,4 +43,16 @@ config ETH_E1000_PTP_CLOCK_SRC_HZ
 	  Set the frequency in Hz sourced to the PTP timer.
 	  If the value is set properly, the timer will be accurate.
 
+config ETH_E1000_RX_QUEUE_SIZE
+	int "Size of receive queue"
+	default 8
+	help
+	  Sets size of receive descriptor queue. It has to be a multiple of 8.
+
+config ETH_E1000_TX_QUEUE_SIZE
+	int "Size of transmit queue"
+	default 8
+	help
+	  Sets size of transmit descriptor queue. It has to be a multiple of 8.
+
 endif # ETH_E1000

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -61,6 +61,7 @@ static const char *e1000_reg_to_string(enum e1000_reg_t r)
 	_(TDT);
 	_(RAL);
 	_(RAH);
+	_(ITR);
 	}
 #undef _
 	LOG_ERR("Unsupported register: 0x%x", r);
@@ -103,19 +104,23 @@ static int e1000_tx(struct e1000_dev *dev, void *buf, size_t len)
 {
 	hexdump(buf, len, "%zu byte(s)", len);
 
-	dev->tx.addr = POINTER_TO_INT(buf);
-	dev->tx.len = len;
-	dev->tx.cmd = TDESC_EOP | TDESC_RS;
+	dev->tx[dev->next_tx_desc].addr = POINTER_TO_INT(buf);
+	dev->tx[dev->next_tx_desc].len = len;
+	dev->tx[dev->next_tx_desc].cmd = TDESC_EOP | TDESC_RS;
+	dev->tx[dev->next_tx_desc].sta = 0;
 
-	iow32(dev, TDT, 1);
+	uint32_t old_tx_desc = dev->next_tx_desc;
 
-	while (!(dev->tx.sta)) {
+	dev->next_tx_desc = (dev->next_tx_desc + 1) % CONFIG_ETH_E1000_TX_QUEUE_SIZE;
+	iow32(dev, TDT, dev->next_tx_desc);
+
+	while (!(dev->tx[old_tx_desc].sta)) {
 		k_yield();
 	}
 
-	LOG_DBG("tx.sta: 0x%02hx", dev->tx.sta);
+	LOG_DBG("tx.sta: 0x%02hx", dev->tx[old_tx_desc].sta);
 
-	return (dev->tx.sta & TDESC_STA_DD) ? 0 : -EIO;
+	return (dev->tx[old_tx_desc].sta & TDESC_STA_DD) ? 0 : -EIO;
 }
 
 static int e1000_send(const struct device *ddev, struct net_pkt *pkt)
@@ -123,11 +128,11 @@ static int e1000_send(const struct device *ddev, struct net_pkt *pkt)
 	struct e1000_dev *dev = ddev->data;
 	size_t len = net_pkt_get_len(pkt);
 
-	if (net_pkt_read(pkt, dev->txb, len)) {
+	if (net_pkt_read(pkt, dev->txb[dev->next_tx_desc], len)) {
 		return -EIO;
 	}
 
-	return e1000_tx(dev, dev->txb, len);
+	return e1000_tx(dev, dev->txb[dev->next_tx_desc], len);
 }
 
 static struct net_pkt *e1000_rx(struct e1000_dev *dev)
@@ -136,19 +141,18 @@ static struct net_pkt *e1000_rx(struct e1000_dev *dev)
 	void *buf;
 	ssize_t len;
 
-	LOG_DBG("rx.sta: 0x%02hx", dev->rx.sta);
+	LOG_DBG("rx.sta: 0x%02hx", dev->rx[dev->next_rx_desc].sta);
 
-	if (!(dev->rx.sta & RDESC_STA_DD)) {
-		LOG_ERR("RX descriptor not ready");
-		goto out;
+	if (!(dev->rx[dev->next_rx_desc].sta & RDESC_STA_DD)) {
+		return NULL;
 	}
 
-	buf = INT_TO_POINTER((uint32_t)dev->rx.addr);
-	len = dev->rx.len - 4;
+	buf = INT_TO_POINTER((uint32_t)dev->rx[dev->next_rx_desc].addr);
+	len = dev->rx[dev->next_rx_desc].len - 4;
 
 	if (len <= 0) {
-		LOG_ERR("Invalid RX descriptor length: %hu", dev->rx.len);
-		goto out;
+		LOG_ERR("Invalid RX descriptor length: %hu", dev->rx[dev->next_rx_desc].len);
+		goto err;
 	}
 
 	hexdump(buf, len, "%zd byte(s)", len);
@@ -157,16 +161,24 @@ static struct net_pkt *e1000_rx(struct e1000_dev *dev)
 					   K_NO_WAIT);
 	if (!pkt) {
 		LOG_ERR("Out of buffers");
-		goto out;
+		goto err;
 	}
 
 	if (net_pkt_write(pkt, buf, len)) {
 		LOG_ERR("Out of memory for received frame");
 		net_pkt_unref(pkt);
 		pkt = NULL;
+	} else {
+		goto out;
 	}
 
+err:
+	eth_stats_update_errors_rx(get_iface(dev));
 out:
+	dev->rx[dev->next_rx_desc].sta = 0;
+	iow32(dev, RDT, dev->next_rx_desc);
+	dev->next_rx_desc = (dev->next_rx_desc + 1) % CONFIG_ETH_E1000_RX_QUEUE_SIZE;
+
 	return pkt;
 }
 
@@ -177,16 +189,14 @@ static void e1000_isr(const struct device *ddev)
 
 	icr &= ~(ICR_TXDW | ICR_TXQE);
 
-	if (icr & ICR_RXO) {
-		struct net_pkt *pkt = e1000_rx(dev);
+	if (icr & (ICR_RXO | ICR_RXDMT0 | ICR_RXT0)) {
+		struct net_pkt *pkt = NULL;
 
-		icr &= ~ICR_RXO;
-
-		if (pkt) {
+		while ((pkt = e1000_rx(dev))) {
 			net_recv_data(get_iface(dev), pkt);
-		} else {
-			eth_stats_update_errors_rx(get_iface(dev));
 		}
+
+		icr &= ~(ICR_RXO | ICR_RXDMT0 | ICR_RXT0);
 	}
 
 	if (icr) {
@@ -213,30 +223,34 @@ int e1000_probe(const struct device *ddev)
 	device_map(&dev->address, mbar.phys_addr, mbar.size,
 		   K_MEM_CACHE_NONE);
 
-	/* Setup TX descriptor */
+	/* Setup TX descriptors */
 
-	iow32(dev, TDBAL, (uint32_t)POINTER_TO_UINT(&dev->tx));
-	iow32(dev, TDBAH, (uint32_t)((POINTER_TO_UINT(&dev->tx) >> 16) >> 16));
-	iow32(dev, TDLEN, 1*16);
+	iow32(dev, TDBAL, (uint32_t)POINTER_TO_UINT(&dev->tx[0]));
+	iow32(dev, TDBAH, (uint32_t)((POINTER_TO_UINT(&dev->tx[0]) >> 16) >> 16));
+	iow32(dev, TDLEN, (uint32_t)(CONFIG_ETH_E1000_TX_QUEUE_SIZE * sizeof(struct e1000_tx)));
 
 	iow32(dev, TDH, 0);
 	iow32(dev, TDT, 0);
+	dev->next_tx_desc = 0;
 
 	iow32(dev, TCTL, TCTL_EN);
 
-	/* Setup RX descriptor */
+	/* Setup RX descriptors */
 
-	dev->rx.addr = POINTER_TO_INT(dev->rxb);
-	dev->rx.len = sizeof(dev->rxb);
+	for (int i = 0; i < CONFIG_ETH_E1000_RX_QUEUE_SIZE; i++) {
+		dev->rx[i].addr = POINTER_TO_INT(dev->rxb[i]);
+		dev->rx[i].len = sizeof(dev->rxb[i]);
+	}
 
-	iow32(dev, RDBAL, (uint32_t)POINTER_TO_UINT(&dev->rx));
-	iow32(dev, RDBAH, (uint32_t)((POINTER_TO_UINT(&dev->rx) >> 16) >> 16));
-	iow32(dev, RDLEN, 1*16);
+	iow32(dev, RDBAL, (uint32_t)POINTER_TO_UINT(&dev->rx[0]));
+	iow32(dev, RDBAH, (uint32_t)((POINTER_TO_UINT(&dev->rx[0]) >> 16) >> 16));
+	iow32(dev, RDLEN, (uint32_t)(CONFIG_ETH_E1000_RX_QUEUE_SIZE * sizeof(struct e1000_rx)));
 
 	iow32(dev, RDH, 0);
-	iow32(dev, RDT, 1);
+	iow32(dev, RDT, CONFIG_ETH_E1000_RX_QUEUE_SIZE - 1);
+	dev->next_rx_desc = 0;
 
-	iow32(dev, IMS, IMS_RXO);
+	iow32(dev, IMS, IMS_RXDMT0 | IMS_RXO | IMS_RXT0);
 
 	ral = ior32(dev, RAL);
 	rah = ior32(dev, RAH);
@@ -312,7 +326,8 @@ static const struct ethernet_api e1000_api = {
 									\
 		irq_enable(DT_INST_IRQN(inst));				\
 		iow32(dev, CTRL, CTRL_SLU); /* Set link up */		\
-		iow32(dev, RCTL, RCTL_EN | RCTL_MPE);			\
+		iow32(dev, RCTL, RCTL_EN | RCTL_MPE | DT_INST_PROP(inst, rdmts) << RDMTS_OFFSET); \
+		iow32(dev, ITR, DT_INST_PROP(inst, itr) & (uint32_t)GENMASK(15, 0)); \
 	}								\
 									\
 	static const struct e1000_config config_##inst = {		\

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -18,9 +18,13 @@ extern "C" {
 
 #define ICR_TXDW	     (1) /* Transmit Descriptor Written Back */
 #define ICR_TXQE	(1 << 1) /* Transmit Queue Empty */
+#define ICR_RXDMT0	(1 << 4) /* Receive Descriptor Minimum Threshold */
 #define ICR_RXO		(1 << 6) /* Receiver Overrun */
+#define ICR_RXT0	(1 << 7) /* Receiver Timer */
 
+#define IMS_RXDMT0	(1 << 4) /* Receive Descriptor Minimum Threshold */
 #define IMS_RXO		(1 << 6) /* Receiver FIFO Overrun */
+#define IMS_RXT0	(1 << 7) /* Receiver Timer */
 
 #define RCTL_MPE	(1 << 4) /* Multicast Promiscuous Enabled */
 
@@ -32,9 +36,12 @@ extern "C" {
 
 #define ETH_ALEN 6	/* TODO: Add a global reusable definition in OS */
 
+#define RDMTS_OFFSET 8
+
 enum e1000_reg_t {
 	CTRL	= 0x0000,	/* Device Control */
 	ICR	= 0x00C0,	/* Interrupt Cause Read */
+	ITR	= 0x00C4,	/* Interrupt Throttling Rate */
 	ICS	= 0x00C8,	/* Interrupt Cause Set */
 	IMS	= 0x00D0,	/* Interrupt Mask Set */
 	RCTL	= 0x0100,	/* Receive Control */
@@ -75,9 +82,12 @@ struct e1000_rx {
 };
 
 struct e1000_dev {
-	volatile struct e1000_tx tx __aligned(16);
-	volatile struct e1000_rx rx __aligned(16);
+	volatile struct e1000_tx tx[CONFIG_ETH_E1000_TX_QUEUE_SIZE] __aligned(16);
+	volatile struct e1000_rx rx[CONFIG_ETH_E1000_RX_QUEUE_SIZE] __aligned(16);
 	mm_reg_t address;
+
+	uint32_t next_rx_desc;
+	uint32_t next_tx_desc;
 
 	/* BDF & DID/VID */
 	struct pcie_dev *pcie;
@@ -88,8 +98,8 @@ struct e1000_dev {
 	 */
 	struct net_if *iface;
 	uint8_t mac[ETH_ALEN];
-	uint8_t txb[NET_ETH_MTU];
-	uint8_t rxb[NET_ETH_MTU];
+	uint8_t txb[CONFIG_ETH_E1000_TX_QUEUE_SIZE][NET_ETH_MTU];
+	uint8_t rxb[CONFIG_ETH_E1000_RX_QUEUE_SIZE][NET_ETH_MTU];
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)
 	const struct device *ptp_clock;
 	double clk_ratio;

--- a/dts/bindings/ethernet/intel,e1000.yaml
+++ b/dts/bindings/ethernet/intel,e1000.yaml
@@ -10,3 +10,28 @@ include: [base.yaml, pcie-device.yaml]
 properties:
   interrupts:
     required: true
+
+  rdmts:
+    type: int
+    default: 0
+    enum:
+      - 0
+      - 1
+      - 2
+    description: |
+      Receive Descriptor Minimum Threshold Size
+      Controls when RXDMT0 interrupt is set.
+      0: interrupt set when 1/2 of RDLEN is free
+      1: interrupt set when 1/4 of RDLEN is free
+      2: interrupt set when 1/8 of RDLEN is free
+      The default value is the hardware reset value
+
+  itr:
+    type: int
+    default: 0
+    description: |
+      Interrupt Throttling Rate
+      Controls inter-interrupt delay. Non-zero value
+      enables it and adjusts the interval in 256ns
+      increments. The maximum value is 2^16 - 1.
+      The default value is the hardware reset value


### PR DESCRIPTION
Currently the sizes of rx and tx queues are set to 1 by the driver and are not really used as queues. This PR introduces queue logic to e1000 driver and exposes configuration options for controlling rx interrupts (before this commit only the overrun interrupt was enabled).

This PR fixes two issues:

- it makes the driver conform to the specification with regard to the queue size, which cannot be one (reported in https://github.com/zephyrproject-rtos/zephyr/issues/74072)
- we've noticed that in some cases the QEMU was sending packets to the Zephyr guest fast enough that some of them were dropped; the ability to increase size of the rx queue addresses and fixes that

Note that this PR has to be tested with QEMU older than the one in recent SDKs, due to the other bug reported in https://github.com/zephyrproject-rtos/zephyr/issues/93490.

Also note that this PR doesn't really utilize the tx queue, while its size can be increased, only one packet will be present in it at a time - improving that would require more changes to the tx logic.