### PR TITLE
CI: Coverage: Fix: Change the source of component name.

### DIFF
--- a/scripts/ci/coverage/coverage_analysis.py
+++ b/scripts/ci/coverage/coverage_analysis.py
@@ -53,7 +53,7 @@ class Json_report:
                 for testsuite in element:
                     for testcase in testsuite['testcases']:
                         if testcase['status'] == 'None':
-                            testcase_name = testcase['identifier']
+                            testcase_name = testsuite['name']
                             component_name = testcase_name[:testcase_name.find('.')]
                             component = {
                                 "name": component_name,


### PR DESCRIPTION
**Getting Component Name from Testsuite Name Instead of Testcase Identifier**

This pr modifies the way the component name is derived for coverage report generation. Previously, the script extracted the component name from the testcase identifier, assuming it followed the format:
```
[component.subcomponent]
```
However, after commit 9219c81b66f48523f0cd3b7b7cac8cf3dadb84b2 (twister: make no-detailed-test-id default), the level of detail in test identifiers was reduced.
```
9219c81b66f48523f0cd3b7b7cac8cf3dadb84b2 is the first bad commit
commit 9219c81b66f48523f0cd3b7b7cac8cf3dadb84b2
Author: Anas Nashif <anas.nashif@intel.com>
Date:   Fri Jul 11 11:36:03 2025 -0400

    twister: make no-detailed-test-id default

    Make this option default and reduce amount of details displayed by
    twister.
    This options has been enabled in CI for a while now with the intention
    of making it default.

    Signed-off-by: Anas Nashif <anas.nashif@intel.com>

 .github/workflows/clang.yaml                    | 2 +-
 .github/workflows/twister.yaml                  | 6 +++---
 .github/workflows/twister_tests_blackbox.yml    | 8 ++++----
 scripts/ci/test_plan.py                         | 4 ++--
 scripts/pylib/twister/twisterlib/environment.py | 4 ++--
 scripts/tests/twister/conftest.py               | 1 +
 6 files changed, 13 insertions(+), 12 deletions(-)
root@acholewx-mobl:~/develop/repos/zephyr_upstream#
```

Example change in identifiers:

Before (detailed):
```
"identifier": "bluetooth.audio.cap_commander.test_default.cap_commander_test_broadcast_reception.commander_reception_stop_inval_no_subgroups"
```
After (reduced):
```
"identifier": "cap_commander_test_broadcast_reception.commander_reception_stop_inval_no_subgroups"
```
Because of this, the script incorrectly interprets `cap_commander_test_broadcast_reception` as the component name instead of the correct `bluetooth`. This leads to the following issue when generating the coverage report:

```
xlsxwriter.exceptions.InvalidWorksheetName: Excel worksheet name 'cap_commander_test_broadcast_reception' must be <= 31 chars.
```
(Example failure: [GitHub Actions log](https://github.com/zephyrproject-rtos/zephyr/actions/runs/16436658278/job/46451194676#step:10:34))

This change updates the logic to derive the component name from the testsuite name rather than testcase identifier, restoring correct component mapping and preventing coverage report generation failures.


Probe run:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/16442311600?pr=93496 