### PR TITLE
net: lwm2m: Verify pmin for updated resource on notify check 

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -632,7 +632,8 @@ static bool value_conditions_satisfied(const struct lwm2m_obj_path *path,
 int lwm2m_notify_observer_path(const struct lwm2m_obj_path *path)
 {
 	struct observe_node *obs;
-	struct notification_attrs nattrs = {0};
+	struct notification_attrs obs_attrs = {0};
+	struct notification_attrs res_attrs = {0};
 	int64_t timestamp;
 	int ret = 0;
 	int i;
@@ -647,8 +648,15 @@ int lwm2m_notify_observer_path(const struct lwm2m_obj_path *path)
 		SYS_SLIST_FOR_EACH_CONTAINER(&sock_ctx[i]->observer, obs, node) {
 			if (lwm2m_notify_observer_list(&obs->path_list, path)) {
 				/* update the event time for this observer */
-				ret = engine_observe_attribute_list_get(&obs->path_list, &nattrs,
+				ret = engine_observe_attribute_list_get(&obs->path_list, &obs_attrs,
 									sock_ctx[i]->srv_obj_inst);
+				if (ret < 0) {
+					return ret;
+				}
+
+				/* Read attributes for the updated resource path */
+				ret = engine_observe_get_attributes(path, &res_attrs,
+								    sock_ctx[i]->srv_obj_inst);
 				if (ret < 0) {
 					return ret;
 				}
@@ -657,9 +665,18 @@ int lwm2m_notify_observer_path(const struct lwm2m_obj_path *path)
 					continue;
 				}
 
-				if (nattrs.pmin) {
+				/* In case the lowest pmin value for the observation is smaller
+				 * than the pmin configured for the updated resource, use the
+				 * resource value to prevent notification from being generated
+				 * too early.
+				 */
+				if (obs_attrs.pmin < res_attrs.pmin) {
+					obs_attrs.pmin = res_attrs.pmin;
+				}
+
+				if (obs_attrs.pmin) {
 					timestamp =
-						obs->last_timestamp + MSEC_PER_SEC * nattrs.pmin;
+						obs->last_timestamp + MSEC_PER_SEC * obs_attrs.pmin;
 				} else {
 					/* Trig immediately */
 					timestamp = k_uptime_get();


### PR DESCRIPTION
When updating a resource, the LwM2M library verified pmin attribute on
all resources/objects in the observer path list and chose the smallest
value. While this make sense for determining the lower-boundary for the
next notification time, it could lead to unnecessary notifications being
generated too early if the updated resource had a higher pmin value
configured on it.

Therefore, when checking notification criteria for an updated resource,
check the pmin value for that resource path and if set and higher than
the lowest pmin value evaluated for the observer list, use it instead.

Fixes #93315