### PR TITLE
dts: arm: st: stm32g4: add quadspi node

### DIFF
--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -77,5 +77,15 @@
 			interrupts = <53 0>;
 			status = "disabled";
 		};
+
+		quadspi: spi@a0001000 {
+			compatible = "st,stm32-qspi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0xa0001000 0x400>, <0x90000000 DT_SIZE_M(256)>;
+			interrupts = <95 0>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
The STM32G4 variants g473, g474, g483, g484, g491 and g4a1 do support QuadSPI interface. All mentioned variants include the stm32g491.dtsi.