### PR TITLE
net: openthread: Fix build with CONFIG_OPENTHREAD_INTERFACE_EARLY_UP

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -75,6 +75,8 @@ static void ot_l2_state_changed_handler(uint32_t flags, void *context)
 	struct openthread_state_changed_cb *entry, *next;
 
 #if defined(CONFIG_OPENTHREAD_INTERFACE_EARLY_UP)
+	bool is_up = otIp6IsEnabled(openthread_get_default_instance());
+
 	if (is_up) {
 		net_if_dormant_off(ot_context->iface);
 	} else {


### PR DESCRIPTION
When building with CONFIG_OPENTHREAD_INTERFACE_EARLY_UP enabled, `is_up` is undefined (since 596844a).