### PR TITLE
modules/picolibc: Update to include C++ math.h compatibility fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -346,7 +346,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 560946f26db075c296beea5b39d99e6de43c9010
+      revision: c0902a4b372c969be10204a9945c2480a395681b
     - name: segger
       revision: cf56b1d9c80f81a26e2ac5727c9cf177116a4692
       path: modules/debug/segger


### PR DESCRIPTION
Fast forward to upstream version containing a fix for a C++ incompatibility where isinf and isnan were incorrectly declared as C functions.

This version also contains another useful change to disable the picolibc malloc implementation when built as a Zephyr module. This should improve error messages with Zephyr projects which use malloc but fail to define CONFIG_COMMON_LIBC_MALLOC.

There are also minor cleanups in a few math functions in how FE_INEXACT exceptions are generated and AArch32 A-profile aeabi memcpy functions.

This is not in SDK 0.17.3 as that only needed a minor fix for building modules that use crt0