### PR TITLE
rtio: Fix syscall verify misra-c:2004 12.4 issue

### DIFF
--- a/subsys/rtio/rtio_handlers.c
+++ b/subsys/rtio/rtio_handlers.c
@@ -19,8 +19,10 @@
  */
 static inline bool rtio_vrfy_sqe(struct rtio_sqe *sqe)
 {
-	if (sqe->iodev != NULL && K_SYSCALL_OBJ(sqe->iodev, K_OBJ_RTIO_IODEV)) {
-		return false;
+	if (sqe->iodev != NULL) {
+		if (K_SYSCALL_OBJ(sqe->iodev, K_OBJ_RTIO_IODEV)) {
+			return false;
+		}
 	}
 
 	bool valid_sqe = true;


### PR DESCRIPTION
MISRA-C says the right hand of a logical and should not contain side effect operations. Instead nest the branches to get the same logic without the MISRA-C rule breakage.