### PR TITLE
tests: kernel/smp: more timeout

### DIFF
--- a/tests/kernel/smp/testcase.yaml
+++ b/tests/kernel/smp/testcase.yaml
@@ -1,5 +1,5 @@
 common:
-  timeout: 120
+  timeout: 300
 tests:
   kernel.multiprocessing.smp:
     tags:


### PR DESCRIPTION
The concurrency and switching tests take quite some time to finish (relatively speaking). When running in emulator and under a heavily loaded system (e.g. twister-ing), it may time out as the emulator is not getting much CPU time. So make the base timeout longer, which can then be further adjusted by the board timeout multiplier.