### PR TITLE
maintainer: hal_nxp: align names to new management process

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5304,11 +5304,16 @@ West:
   maintainers:
     - dleach02
     - mmahadevan108
-  collaborators:
     - decsny
+  collaborators:
     - manuargue
     - PetervdPerk-NXP
     - bperseghetti
+    - JiafeiPan
+    - ZhaoxiangJin
+    - EmilioCBen
+    - MaochenWang1
+    - axelnxp
   files:
     - modules/hal_nxp/
   labels:


### PR DESCRIPTION
Align maintainers/collaborators to support new module management process.