### PR TITLE
MCXN ethernet fixes and improvements

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -156,7 +156,12 @@ static void tx_dma_done(const struct device *dev)
 	struct net_pkt *pkt = tx_data->pkt;
 	struct net_buf *fragment = pkt->frags;
 
-	LOG_DBG("TX DMA completed on packet %p", pkt);
+	if (pkt == NULL) {
+		LOG_DBG("%s TX DMA done on nonexistent packet?", dev->name);
+		goto skip;
+	} else {
+		LOG_DBG("TX DMA completed on packet %p", pkt);
+	}
 
 	/* Returning the buffers and packet to the pool */
 	while (fragment != NULL) {
@@ -169,6 +174,7 @@ static void tx_dma_done(const struct device *dev)
 
 	eth_stats_update_pkts_tx(data->iface);
 
+skip:
 	/* Allows another send */
 	k_sem_give(&data->tx.tx_sem);
 	LOG_DBG("Gave driver TX sem %p by thread %s", &data->tx.tx_sem,
@@ -667,13 +673,6 @@ static int eth_nxp_enet_qos_mac_init(const struct device *dev)
 		break;
 	}
 
-	/* This driver cannot work without interrupts. */
-	if (config->irq_config_func) {
-		config->irq_config_func();
-	} else {
-		return -ENOSYS;
-	}
-
 	/* Effectively reset of the peripheral */
 	ret = enet_qos_dma_reset(base);
 	if (ret) {
@@ -721,6 +720,13 @@ static int eth_nxp_enet_qos_mac_init(const struct device *dev)
 
 	/* Work upon a reception of a packet to a buffer */
 	k_work_init(&data->rx.rx_work, eth_nxp_enet_qos_rx);
+
+	/* This driver cannot work without interrupts. */
+	if (config->irq_config_func) {
+		config->irq_config_func();
+	} else {
+		return -ENOSYS;
+	}
 
 	return ret;
 }

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -186,6 +186,11 @@ static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct devi
 	return ETHERNET_LINK_100BASE | ETHERNET_LINK_10BASE | ENET_MAC_PACKET_FILTER_PM_MASK;
 }
 
+static bool software_owns_descriptor(volatile union nxp_enet_qos_rx_desc *desc)
+{
+	return (desc->write.control3 & OWN_FLAG) != OWN_FLAG;
+}
+
 static void eth_nxp_enet_qos_rx(struct k_work *work)
 {
 	struct nxp_enet_qos_rx_data *rx_data =
@@ -193,25 +198,20 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 	struct nxp_enet_qos_mac_data *data =
 		CONTAINER_OF(rx_data, struct nxp_enet_qos_mac_data, rx);
 	volatile union nxp_enet_qos_rx_desc *desc_arr = data->rx.descriptors;
-	volatile union nxp_enet_qos_rx_desc *desc;
-	uint32_t desc_idx;
+	uint32_t desc_idx = rx_data->next_desc_idx;
+	volatile union nxp_enet_qos_rx_desc *desc = &desc_arr[desc_idx];
 	struct net_pkt *pkt = NULL;
 	struct net_buf *new_buf;
 	struct net_buf *buf;
 	size_t pkt_len;
 	size_t processed_len;
 
-	LOG_DBG("iteration work:%p, rx_data:%p, data:%p", work, rx_data, data);
-	/* We are going to find all of the descriptors we own and update them */
-	for (int i = 0; i < NUM_RX_BUFDESC; i++) {
-		desc_idx = rx_data->next_desc_idx;
-		desc = &desc_arr[desc_idx];
+	LOG_DBG("RX work start: %p", work);
 
-		if (desc->write.control3 & OWN_FLAG) {
-			/* The DMA owns the descriptor, we have processed all */
-			break;
-		}
-
+	/* Walk through the descriptor ring and refresh the descriptors we own so that the
+	 * DMA can use them for receiving again. We stop when we reach DMA owned part of ring.
+	 */
+	while (software_owns_descriptor(desc)) {
 		rx_data->next_desc_idx = (desc_idx + 1U) % NUM_RX_BUFDESC;
 
 		if (pkt == NULL) {
@@ -222,7 +222,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 				LOG_ERR("Rx descriptor does not have first descriptor flag, drop");
 				desc->read.control = rx_desc_refresh_flags;
 				/* Error statistics for this packet already updated earlier */
-				continue;
+				goto next;
 			}
 
 			/* Otherwise, we found a packet that we need to process */
@@ -233,7 +233,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 				/* error: no new buffer, reuse previous immediately */
 				desc->read.control = rx_desc_refresh_flags;
 				eth_stats_update_errors_rx(data->iface);
-				continue;
+				goto next;
 			}
 
 			processed_len = 0U;
@@ -256,7 +256,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			pkt = NULL;
 			desc->read.control = rx_desc_refresh_flags;
 			eth_stats_update_errors_rx(data->iface);
-			continue;
+			goto next;
 		}
 
 		/* We need to know if we can replace the reserved fragment in advance.
@@ -276,7 +276,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			pkt = NULL;
 			desc->read.control = rx_desc_refresh_flags;
 			eth_stats_update_errors_rx(data->iface);
-			continue;
+			goto next;
 		}
 
 		/* Append buffer to a packet */
@@ -305,6 +305,10 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 		data->rx.reserved_bufs[desc_idx] = new_buf;
 		desc->read.buf1_addr = (uint32_t)new_buf->data;
 		desc->read.control = rx_desc_refresh_flags;
+
+next:
+		desc_idx = rx_data->next_desc_idx;
+		desc = &desc_arr[desc_idx];
 	}
 
 	if (pkt != NULL) {
@@ -332,7 +336,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			ENET_QOS_ALIGN_ADDR_SHIFT((uint32_t)&rx_data->descriptors[NUM_RX_BUFDESC]));
 	}
 
-	LOG_DBG("end loop normally");
+	LOG_DBG("End RX work normally");
 	return;
 }
 

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -92,6 +92,7 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 
 	/* One TX at a time in the current implementation */
 	k_sem_take(&data->tx.tx_sem, K_FOREVER);
+	LOG_DBG("Took driver TX sem %p by thread %p", &data->tx.tx_sem, k_current_get());
 
 	net_pkt_ref(pkt);
 
@@ -141,12 +142,10 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static void tx_dma_done(struct k_work *work)
+static void tx_dma_done(const struct device *dev)
 {
-	struct nxp_enet_qos_tx_data *tx_data =
-		CONTAINER_OF(work, struct nxp_enet_qos_tx_data, tx_done_work);
-	struct nxp_enet_qos_mac_data *data =
-		CONTAINER_OF(tx_data, struct nxp_enet_qos_mac_data, tx);
+	struct nxp_enet_qos_mac_data *data = dev->data;
+	struct nxp_enet_qos_tx_data *tx_data = &data->tx;
 	struct net_pkt *pkt = tx_data->pkt;
 	struct net_buf *fragment = pkt->frags;
 
@@ -165,6 +164,7 @@ static void tx_dma_done(struct k_work *work)
 
 	/* Allows another send */
 	k_sem_give(&data->tx.tx_sem);
+	LOG_DBG("Gave driver TX sem %p by thread %p", &data->tx.tx_sem, k_current_get());
 }
 
 static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct device *dev)
@@ -346,7 +346,7 @@ static void eth_nxp_enet_qos_mac_isr(const struct device *dev)
 	if (ENET_QOS_REG_GET(DMA_INTERRUPT_STATUS, DC0IS, dma_interrupts)) {
 		if (ENET_QOS_REG_GET(DMA_CH_DMA_CHX_STAT, TI, dma_ch0_interrupts)) {
 			/* add pending tx to queue */
-			k_work_submit(&data->tx.tx_done_work);
+			tx_dma_done(dev);
 		}
 
 		if (ENET_QOS_REG_GET(DMA_CH_DMA_CHX_STAT, RI, dma_ch0_interrupts)) {
@@ -713,9 +713,6 @@ static int eth_nxp_enet_qos_mac_init(const struct device *dev)
 
 	/* Work upon a reception of a packet to a buffer */
 	k_work_init(&data->rx.rx_work, eth_nxp_enet_qos_rx);
-
-	/* Work upon a complete transmission by a channel's TX DMA */
-	k_work_init(&data->tx.tx_done_work, tx_dma_done);
 
 	return ret;
 }

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -75,6 +75,7 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 
 	struct net_buf *fragment = pkt->frags;
 	int frags_count = 0, total_bytes = 0;
+	int ret;
 
 	/* Only allow send of the maximum normal packet size */
 	while (fragment != NULL) {
@@ -91,8 +92,14 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 
 
 	/* One TX at a time in the current implementation */
-	k_sem_take(&data->tx.tx_sem, K_FOREVER);
-	LOG_DBG("Took driver TX sem %p by thread %p", &data->tx.tx_sem, k_current_get());
+	ret = k_sem_take(&data->tx.tx_sem, K_NO_WAIT);
+	if (ret) {
+		LOG_DBG("%s TX busy, rejected thread %s", dev->name,
+							  k_thread_name_get(k_current_get()));
+		return ret;
+	}
+	LOG_DBG("Took driver TX sem %p by thread %s", &data->tx.tx_sem,
+						      k_thread_name_get(k_current_get()));
 
 	net_pkt_ref(pkt);
 
@@ -164,7 +171,8 @@ static void tx_dma_done(const struct device *dev)
 
 	/* Allows another send */
 	k_sem_give(&data->tx.tx_sem);
-	LOG_DBG("Gave driver TX sem %p by thread %p", &data->tx.tx_sem, k_current_get());
+	LOG_DBG("Gave driver TX sem %p by thread %s", &data->tx.tx_sem,
+						      k_thread_name_get(k_current_get()));
 }
 
 static enum ethernet_hw_caps eth_nxp_enet_qos_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -157,7 +157,7 @@ static void tx_dma_done(const struct device *dev)
 	struct net_buf *fragment = pkt->frags;
 
 	if (pkt == NULL) {
-		LOG_DBG("%s TX DMA done on nonexistent packet?", dev->name);
+		LOG_WRN("%s TX DMA done on nonexistent packet?", dev->name);
 		goto skip;
 	} else {
 		LOG_DBG("TX DMA completed on packet %p", pkt);
@@ -244,9 +244,9 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 				FIRST_DESCRIPTOR_FLAG) {
 				LOG_DBG("receive packet mask %X ",
 					(desc->write.control3 >> 28) & 0x0f);
-				LOG_ERR("Rx descriptor does not have first descriptor flag, drop");
-				desc->read.control = rx_desc_refresh_flags;
 				/* Error statistics for this packet already updated earlier */
+				LOG_DBG("dropping frame from errored packet");
+				desc->read.control = rx_desc_refresh_flags;
 				goto next;
 			}
 
@@ -254,7 +254,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			pkt = net_pkt_rx_alloc(K_NO_WAIT);
 
 			if (!pkt) {
-				LOG_ERR("Could not alloc new RX pkt");
+				LOG_WRN("Could not alloc new RX pkt");
 				/* error: no new buffer, reuse previous immediately */
 				desc->read.control = rx_desc_refresh_flags;
 				eth_stats_update_errors_rx(data->iface);
@@ -275,7 +275,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 		pkt_len = desc->write.control3 & DESC_RX_PKT_LEN;
 		if ((pkt_len < processed_len) ||
 			((pkt_len - processed_len) > ENET_QOS_RX_BUFFER_SIZE)) {
-			LOG_ERR("Invalid packet length in descriptor: pkt_len=%u, processed_len=%u",
+			LOG_WRN("Invalid packet length in descriptor: pkt_len=%u, processed_len=%u",
 				pkt_len, processed_len);
 			net_pkt_unref(pkt);
 			pkt = NULL;
@@ -296,7 +296,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			 * we don't know what the upper layer will do to our poor buffer.
 			 * drop this buffer, reuse allocated DMA buffer
 			 */
-			LOG_ERR("No new RX buf available");
+			LOG_WRN("No new RX buf available");
 			net_pkt_unref(pkt);
 			pkt = NULL;
 			desc->read.control = rx_desc_refresh_flags;
@@ -314,7 +314,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			/* Propagate completed packet to network stack */
 			LOG_DBG("Receiving RX packet");
 			if (net_recv_data(data->iface, pkt)) {
-				LOG_ERR("RECV failed");
+				LOG_WRN("RECV failed on pkt %p", pkt);
 				/* Error during processing, we continue with new buffer */
 				net_pkt_unref(pkt);
 				eth_stats_update_errors_rx(data->iface);
@@ -325,7 +325,7 @@ static void eth_nxp_enet_qos_rx(struct k_work *work)
 			pkt = NULL;
 		}
 
-		LOG_DBG("Swap RX buf");
+		LOG_DBG("Swap RX buf %p for %p", data->rx.reserved_bufs[desc_idx], new_buf);
 		/* Allow receive into a new buffer */
 		data->rx.reserved_bufs[desc_idx] = new_buf;
 		desc->read.buf1_addr = (uint32_t)new_buf->data;
@@ -784,7 +784,7 @@ static int eth_nxp_enet_qos_set_config(const struct device *dev,
 		net_if_set_link_addr(data->iface, data->mac_addr.addr,
 				     sizeof(data->mac_addr.addr),
 				     NET_LINK_ETHERNET);
-		LOG_DBG("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x",
+		LOG_INF("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x",
 			dev->name,
 			data->mac_addr.addr[0], data->mac_addr.addr[1],
 			data->mac_addr.addr[2], data->mac_addr.addr[3],

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -191,12 +191,37 @@ static bool software_owns_descriptor(volatile union nxp_enet_qos_rx_desc *desc)
 	return (desc->write.control3 & OWN_FLAG) != OWN_FLAG;
 }
 
+/* this function resumes the rx dma in case of underrun */
+static void enet_qos_dma_rx_resume(const struct device *dev)
+{
+	const struct nxp_enet_qos_mac_config *config = dev->config;
+	enet_qos_t *base = config->base;
+	struct nxp_enet_qos_mac_data *data = dev->data;
+	struct nxp_enet_qos_rx_data *rx_data = &data->rx;
+
+	if (!atomic_cas(&rx_data->rbu_flag, 1, 0)) {
+		/* no RBU flag means no underrun happened */
+		return;
+	}
+
+	LOG_DBG("Handle RX underrun");
+
+	/* We need to just touch the tail ptr to make sure it resumes if underrun happened.
+	 * Then it will resume if there are DMA owned descriptors queued up in the ring properly.
+	 */
+	base->DMA_CH[0].DMA_CHX_RXDESC_TAIL_PTR = ENET_QOS_REG_PREP(
+		DMA_CH_DMA_CHX_RXDESC_TAIL_PTR, RDTP,
+		ENET_QOS_ALIGN_ADDR_SHIFT((uint32_t)&rx_data->descriptors[NUM_RX_BUFDESC]));
+}
+
+
 static void eth_nxp_enet_qos_rx(struct k_work *work)
 {
 	struct nxp_enet_qos_rx_data *rx_data =
 		CONTAINER_OF(work, struct nxp_enet_qos_rx_data, rx_work);
 	struct nxp_enet_qos_mac_data *data =
 		CONTAINER_OF(rx_data, struct nxp_enet_qos_mac_data, rx);
+	const struct device *dev = data->iface->if_dev->dev;
 	volatile union nxp_enet_qos_rx_desc *desc_arr = data->rx.descriptors;
 	uint32_t desc_idx = rx_data->next_desc_idx;
 	volatile union nxp_enet_qos_rx_desc *desc = &desc_arr[desc_idx];
@@ -321,20 +346,8 @@ next:
 		eth_stats_update_errors_rx(data->iface);
 	}
 
-	/* try to restart if halted */
-	const struct device *dev = net_if_get_device(data->iface);
-
-	if (atomic_cas(&rx_data->rbu_flag, 1, 0)) {
-		LOG_DBG("handle RECEIVE BUFFER UNDERRUN in worker");
-
-		/* When the DMA reaches the tail pointer, it suspends. Set to last descriptor */
-		const struct nxp_enet_qos_mac_config *config = dev->config;
-		enet_qos_t *const base = config->base;
-
-		base->DMA_CH[0].DMA_CHX_RXDESC_TAIL_PTR = ENET_QOS_REG_PREP(
-			DMA_CH_DMA_CHX_RXDESC_TAIL_PTR, RDTP,
-			ENET_QOS_ALIGN_ADDR_SHIFT((uint32_t)&rx_data->descriptors[NUM_RX_BUFDESC]));
-	}
+	/* now that we updated the descriptors, resume in case we are suspended */
+	enet_qos_dma_rx_resume(dev);
 
 	LOG_DBG("End RX work normally");
 	return;
@@ -344,6 +357,7 @@ static void eth_nxp_enet_qos_mac_isr(const struct device *dev)
 {
 	const struct nxp_enet_qos_mac_config *config = dev->config;
 	struct nxp_enet_qos_mac_data *data = dev->data;
+	struct nxp_enet_qos_rx_data *rx_data = &data->rx;
 	enet_qos_t *base = config->base;
 
 	/* cleared on read */
@@ -369,23 +383,21 @@ static void eth_nxp_enet_qos_mac_isr(const struct device *dev)
 
 		if (ENET_QOS_REG_GET(DMA_CH_DMA_CHX_STAT, RI, dma_ch0_interrupts)) {
 			/* add pending rx to queue */
-			k_work_submit_to_queue(&rx_work_queue, &data->rx.rx_work);
+			k_work_submit_to_queue(&rx_work_queue, &rx_data->rx_work);
 		}
 		if (ENET_QOS_REG_GET(DMA_CH_DMA_CHX_STAT, FBE, dma_ch0_interrupts)) {
-			LOG_ERR("fatal bus error: RX:%x, TX:%x", (dma_ch0_interrupts >> 19) & 0x07,
+			LOG_ERR("Fatal bus error: RX:%x, TX:%x", (dma_ch0_interrupts >> 19) & 0x07,
 				(dma_ch0_interrupts >> 16) & 0x07);
 		}
 		if (ENET_QOS_REG_GET(DMA_CH_DMA_CHX_STAT, RBU, dma_ch0_interrupts)) {
-			LOG_ERR("RECEIVE BUFFER UNDERRUN in ISR");
+			LOG_WRN("RX buffer underrun");
 			if (!ENET_QOS_REG_GET(DMA_CH_DMA_CHX_STAT, RI, dma_ch0_interrupts)) {
-				/* RBU migth happen without RI, schedule worker */
-				k_work_submit_to_queue(&rx_work_queue, &data->rx.rx_work);
+				/* RBU might happen without RI, schedule worker */
+				k_work_submit_to_queue(&rx_work_queue, &rx_data->rx_work);
 			}
 		}
 		if (ENET_QOS_REG_GET(DMA_CH_DMA_CHX_STAT, TBU, dma_ch0_interrupts)) {
-			/* actually this is not an error
-			 * LOG_ERR("TRANSMIT BUFFER UNDERRUN");
-			 */
+			/* by design for now */
 		}
 	}
 }

--- a/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
+++ b/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
@@ -106,7 +106,6 @@ struct nxp_enet_qos_mac_config {
 struct nxp_enet_qos_tx_data {
 	struct k_sem tx_sem;
 	struct net_pkt *pkt;
-	struct k_work tx_done_work;
 	struct net_buf *tx_header;
 	volatile union nxp_enet_qos_tx_desc descriptors[NUM_TX_BUFDESC];
 };


### PR DESCRIPTION
Main commit is to fix the deadlock causing everything to lock up randomly. (Fixes #92652)
```
There was a deadlock occurring, exposed by http server sample because of
situations like this caused by tx done work being blocked in deadlock:
1) The TX would be started by some thread and the driver TX sem would be
   taken.
2) The http server socket would get scheduled on the system workqueue to
   send something, claim the network TX interface mutex,
   and be blocked taking the semaphore.
3) The RX traffic class handler would get blocked trying to claim the
   network interface TX mutex, while trying to send an ACK in the TCP
   callback. This means the RX packets would not be processed.
4) Lots of RX unable to allocate packets errors would happen, and all RX
   would be dropped. This was the main symptom of the deadlock, which
   made it look like a memory leak but actually had nothing to do with
   the RX code nor any memory leak.
5) The TX DMA would finish and schedule the TX DMA done work onto the
   system work queue, behind the http server socket which is blocked on
   the waiting for the driver TX semaphore.
6) If the TX DMA done work would have ran, that's what gives the TX
   driver semaphore. So this is the reason for the deadlock of all these
   different threads and work items, the misqueue in the system
   workqueue.

Fix by just calling the TX DMA done code directly from the ISR, it
should be ISR safe, and really not a lot of code to execute, just
freeing some net buffers and the packet and updating the stats.
An optimization can be made later if needed, but for now,
solving the deadlock is a more urgent priority.
```


Rest of the commits are refactoring the RX code path, and some optimizations in the RX code path, namely:
1) Process as many descriptors as possible during the RX work, by walking through the whole descriptor ring until a DMA owned descriptor is reached, meaning we can even process descriptors that are sent by DMA while we are in the RX work handler.
2) Don't drop packets just because we didn't receive all the frames by the time the RX work runs. We can receive the frames and finish the packet once we get the rest of the frames. I don't see any valid reason for dropping the packet in that case as it was.