### PR TITLE
ace: mmu: Add shared heap section

### DIFF
--- a/soc/intel/intel_adsp/ace/ace-link.ld
+++ b/soc/intel/intel_adsp/ace/ace-link.ld
@@ -499,6 +499,9 @@ SECTIONS {
   /* Heap start and end markers. Used to reserve system heap memory. */
   .heap_mem SEGSTART_UNCACHED (NOLOAD) :
   {
+    _shared_heap_start = .;
+    *(.shared_heap_mem)
+    _shared_heap_end = .;
     _heap_start = .;
     *(.heap_mem)
   } >ucram

--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -24,6 +24,8 @@ extern char __cold_end[];
 extern char __imr_data_start[];
 extern char __imr_data_end[];
 extern char __coldrodata_start[];
+extern char _shared_heap_start[];
+extern char _shared_heap_end[];
 
 
 const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
@@ -152,6 +154,12 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 		.end   = (uint32_t)(LP_SRAM_BASE + LP_SRAM_SIZE),
 		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB,
 		.name = "lpsram",
+	},
+	{
+		.start = (uint32_t)_shared_heap_start,
+		.end   = (uint32_t)_shared_heap_end,
+		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB | XTENSA_MMU_MAP_SHARED,
+		.name = "shared heap",
 	},
 	{
 		.start = (uint32_t)(ADSP_L1CC_ADDR),


### PR DESCRIPTION
Add a new `shared_heap` section. Update the `xtensa_soc_mmu_ranges` structure to include a new memory range for the shared heap.