### PR TITLE
lib/libc: Provide optional check for time_t size

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,9 +4,7 @@
 add_compile_options($<TARGET_PROPERTY:compiler,warning_shadow_variables>)
 
 add_subdirectory(crc)
-if(NOT CONFIG_EXTERNAL_LIBC)
 add_subdirectory(libc)
-endif()
 if(NOT CONFIG_NATIVE_LIBC)
 add_subdirectory(posix)
 endif()

--- a/lib/libc/CMakeLists.txt
+++ b/lib/libc/CMakeLists.txt
@@ -1,14 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_syscall_header(
-  ${ZEPHYR_BASE}/include/zephyr/sys/libc-hooks.h
-)
+if(NOT CONFIG_EXTERNAL_LIBC)
+  zephyr_syscall_header(
+    ${ZEPHYR_BASE}/include/zephyr/sys/libc-hooks.h
+    )
 
-add_subdirectory_ifdef(CONFIG_ARCMWDT_LIBC      arcmwdt)
-add_subdirectory_ifdef(CONFIG_ARMCLANG_STD_LIBC armstdc)
-add_subdirectory_ifdef(CONFIG_IAR_LIBC          iar)
-add_subdirectory_ifdef(CONFIG_MINIMAL_LIBC      minimal)
-add_subdirectory_ifdef(CONFIG_NEWLIB_LIBC       newlib)
-add_subdirectory_ifdef(CONFIG_PICOLIBC          picolibc)
+  add_subdirectory_ifdef(CONFIG_ARCMWDT_LIBC      arcmwdt)
+  add_subdirectory_ifdef(CONFIG_ARMCLANG_STD_LIBC armstdc)
+  add_subdirectory_ifdef(CONFIG_IAR_LIBC          iar)
+  add_subdirectory_ifdef(CONFIG_MINIMAL_LIBC      minimal)
+  add_subdirectory_ifdef(CONFIG_NEWLIB_LIBC       newlib)
+  add_subdirectory_ifdef(CONFIG_PICOLIBC          picolibc)
 
-add_subdirectory(common)
+  add_subdirectory(common)
+endif()
+
+zephyr_sources(
+  validate_libc.c
+  )

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -18,6 +18,18 @@ config REQUIRES_FLOAT_PRINTF
 	  Select a printf implementation that provides a complete
 	  implementation including floating point support.
 
+config LIBC_ALLOW_LESS_THAN_64BIT_TIME
+	bool "Don't require that time_t be at least 64-bits"
+	default y if NATIVE_LIBC
+	help
+	  When selected, time_t will not be required to be at least 64
+	  bits. Background: To avoid Y2038 issues time_t needs to be
+	  bigger than 32bits. But some C libraries do not provide or
+	  default to a type for time_t which is at least
+	  64bits. Enable this option if your C library defined time_t
+	  is more than 32bits (e.g. 48 bits) or are sure your project
+	  is not subject to Y2038 issues.
+
 config FULL_LIBC_SUPPORTED
 	bool
 	help

--- a/lib/libc/validate_libc.c
+++ b/lib/libc/validate_libc.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2025 Keith Packard <keithp@keithp.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+
+/* Validate various C library implementation characteristics */
+
+#ifndef CONFIG_LIBC_ALLOW_LESS_THAN_64BIT_TIME
+#include <time.h>
+/*
+ * Ensure that time_t can hold at least 64 bit values.
+ */
+BUILD_ASSERT(sizeof(time_t) >= 8, "time_t cannot hold 64-bit values");
+#endif


### PR DESCRIPTION
The ALLOW_NON_64_BIT_TIME_T option disables a compile-time check ensuring that time_t can hold 64-bit values. This check can prevent accidental builds on targets with 32-bit time_t and the consequent 2038 issues.