### PR TITLE
tests: Increase sched_userspace timeout

### DIFF
--- a/tests/benchmarks/sched_userspace/testcase.yaml
+++ b/tests/benchmarks/sched_userspace/testcase.yaml
@@ -6,10 +6,12 @@ tests:
       - benchmark
       - userspace
     filter: CONFIG_ARCH_HAS_USERSPACE
+    slow: true
     arch_exclude:
       - posix
+    timeout: 300
     harness: console
     harness_config:
-      type: multi_line
+      type: one_line
       regex:
         - "SUCCESS"


### PR DESCRIPTION
Increase the sched_userspace timeout from the default of 60 seconds to 300 seconds to account for variations in execution time caused by host system load.

(Variation observed on the qemu_cortex_a53/qemu_cortex_a53 platform.)