### PR TITLE
linker: noint memory region location

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -316,6 +316,16 @@ config USERSPACE
 	  privileged mode or handling a system call; to ensure these are always
 	  caught, enable CONFIG_HW_STACK_PROTECTION.
 
+config NOINIT_SNIPPET_FIRST
+	bool "Place the no-init linker script snippet first"
+	help
+	  By default the include/zephyr/linker/common-noinit.ld file inserts the
+	  snippets-noinit.ld file at the end of the section.  There are times when
+	  the directives in the snippets-noinit.ld file apply to the other directives
+	  in this file.  And in that case the include statement for the snippets-noinit.ld
+	  file needs to come at the start of the section.  This configuration option
+	  allows that to happen.
+
 config PRIVILEGED_STACK_SIZE
 	int "Size of privileged stack"
 	default 2048 if EMUL

--- a/include/zephyr/linker/common-noinit.ld
+++ b/include/zephyr/linker/common-noinit.ld
@@ -11,6 +11,14 @@ SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
          * This section is used for non-initialized objects that
          * will not be cleared during the boot process.
          */
+
+/* Located in generated directory. This file is populated by the
+ * zephyr_linker_sources() Cmake function.
+ */
+#ifdef CONFIG_NOINIT_SNIPPET_FIRST
+#include <snippets-noinit.ld>
+#endif
+
         *(.noinit)
         *(".noinit.*")
 #ifdef CONFIG_USERSPACE
@@ -22,7 +30,9 @@ SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
+#ifndef CONFIG_NOINIT_SNIPPET_FIRST
 #include <snippets-noinit.ld>
+#endif
 
 } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 


### PR DESCRIPTION
- There are linker file directives that must come at the start of the noinit region.  For example, the directive that allow that section to not exist in RAM before a certain address (. = MAX(ABSOLUTE(.), 0x34002000);).
- Before this update, those could only be added to the end of that region.  They will now have the option to be at the beginning or the end.