### PR TITLE
RTIO: fix CQE semaphore bypass when no CQE item was created

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -1309,6 +1309,9 @@ static inline void rtio_cqe_submit(struct rtio *r, int result, void *userdata, u
 		cqe->userdata = userdata;
 		cqe->flags = flags;
 		rtio_cqe_produce(r, cqe);
+#ifdef CONFIG_RTIO_CONSUME_SEM
+		k_sem_give(r->consume_sem);
+#endif
 	}
 
 	/* atomic_t isn't guaranteed to wrap correctly as it could be signed, so
@@ -1328,9 +1331,6 @@ static inline void rtio_cqe_submit(struct rtio *r, int result, void *userdata, u
 			k_sem_give(r->submit_sem);
 		}
 	}
-#endif
-#ifdef CONFIG_RTIO_CONSUME_SEM
-	k_sem_give(r->consume_sem);
 #endif
 }
 


### PR DESCRIPTION
Otherwise, calls to rtio_cqe_consume_block will bypass the semaphore and held back in a Z_SPIN_DELAY(1) indefinitely.

Reference:
https://github.com/zephyrproject-rtos/zephyr/blob/ddc43f0d353d8d8329f554583c7322cb06cec842/include/zephyr/rtio/rtio.h#L1154-L1161