### PR TITLE
dt-bindings: input: fix swapped comments for gear buttons

### DIFF
--- a/include/zephyr/dt-bindings/input/input-event-codes.h
+++ b/include/zephyr/dt-bindings/input/input-event-codes.h
@@ -206,8 +206,8 @@
 #define INPUT_BTN_EAST 0x131            /**< East button */
 #define INPUT_BTN_EXTRA 0x114		/**< Extra button */
 #define INPUT_BTN_FORWARD 0x115		/**< Forward button */
-#define INPUT_BTN_GEAR_DOWN 0x150       /**< Gear Up button */
-#define INPUT_BTN_GEAR_UP 0x151         /**< Gear Down button */
+#define INPUT_BTN_GEAR_DOWN 0x150       /**< Gear Down button */
+#define INPUT_BTN_GEAR_UP 0x151         /**< Gear Up button */
 #define INPUT_BTN_LEFT 0x110            /**< Left button */
 #define INPUT_BTN_MIDDLE 0x112          /**< Middle button */
 #define INPUT_BTN_MODE 0x13c            /**< Mode button */


### PR DESCRIPTION
The comments for INPUT_BTN_GEAR_DOWN and INPUT_BTN_GEAR_UP were incorrectly swapped. 
This commit fixes the documentation to match the actual button definitions.