### PR TITLE
boards: seeed: xiao_nrf54l15: fix openocd runner

### DIFF
--- a/boards/seeed/xiao_nrf54l15/board.cmake
+++ b/boards/seeed/xiao_nrf54l15/board.cmake
@@ -8,6 +8,7 @@ elseif(CONFIG_SOC_NRF54L15_CPUFLPR)
   board_runner_args(jlink "--device=nRF54L15_RV32")
 endif()
 
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/seeed/xiao_nrf54l15/doc/index.rst
+++ b/boards/seeed/xiao_nrf54l15/doc/index.rst
@@ -63,13 +63,10 @@ means Pin number 0 on PORT2, as used in the board's datasheets and manuals.
 Programming and Debugging
 *************************
 
-The XIAO nRF54L15 contains an SAMD11 with CMSIS-DAP, allowing flashing, debugging, logging, etc. over
-the USB port. Doing so requires a version of OpenOCD that includes support for the flash on the nRF54L15
-MCU. Until those changes are included in stock OpenOCD, the version bundled with Arduino can be
-used, or can be installed from the `OpenOCD Arduino`_.
+.. zephyr:board-supported-runners::
 
-When flashing, debugging, etc. you may need to include ``--openocd=/usr/local/bin/openocd
---openocd-search=/usr/local/share/openocd/scripts/`` options to the command.
+The XIAO nRF54L15 contains a SAMD11 with CMSIS-DAP, allowing flashing, debugging, logging, etc. over
+the USB port.
 
 Flashing
 ========


### PR DESCRIPTION
Zephyr's openOCD works just fine. Also make sure to actually enable openocd runner in the board.cmake file.

cc @is-qian