### PR TITLE
tracing: added KConfig config `CONFIG_TRACING_IDLE`

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -207,6 +207,12 @@ config TRACING_OBJECT_TRACKING
 
 menu "Tracing Configuration"
 
+config TRACING_IDLE
+	bool "Tracing Idle"
+	default y
+	help
+	  Enable tracing Idles.
+
 config TRACING_SYSCALL
 	bool "Tracing Syscalls"
 	default y

--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -188,7 +188,9 @@ void sys_trace_isr_exit_to_scheduler(void)
 
 void sys_trace_idle(void)
 {
-	ctf_top_idle();
+	if(IS_ENABLED(CONFIG_TRACING_IDLE)) {
+		ctf_top_idle();
+	}
 }
 
 /* Semaphore */

--- a/subsys/tracing/sysview/sysview.c
+++ b/subsys/tracing/sysview/sysview.c
@@ -63,7 +63,9 @@ void sys_trace_isr_exit_to_scheduler(void)
 
 void sys_trace_idle(void)
 {
-	SEGGER_SYSVIEW_OnIdle();
+	if(IS_ENABLED(CONFIG_TRACING_IDLE)) {
+		SEGGER_SYSVIEW_OnIdle();
+	}
 }
 
 void sys_trace_named_event(const char *name, uint32_t arg0, uint32_t arg1)

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -201,7 +201,9 @@ void sys_trace_isr_exit_to_scheduler(void)
 
 void sys_trace_idle(void)
 {
-	TRACING_STRING("%s\n", __func__);
+	if(IS_ENABLED(CONFIG_TRACING_IDLE)) {
+		TRACING_STRING("%s\n", __func__);
+	}
 }
 
 void sys_trace_k_condvar_broadcast_enter(struct k_condvar *condvar)


### PR DESCRIPTION
This PR continues #88246 

While using CTF tracing with backend RAM, our buffer was flooded with IDLE events. The buffer went full after only few seconds.
Therefore a new KConfig config `CONFIG_TRACING_IDLE` is added.

If `CONFIG_TRACING_IDLE` is enabled (default), `sys_trace_idle()` events are added to the tracing buffer. 
Consider disabling this option if you are not interested in idle events or if idle events flood your tracing buffer.