### PR TITLE
maintainers: add matt-rodgers as collaborator to http area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3628,7 +3628,7 @@ Networking:
     - jukkar
     - rlubos
   collaborators:
-    - mrodgers-witekio
+    - matt-rodgers
   files:
     - doc/connectivity/networking/api/http*.rst
     - include/zephyr/net/http/


### PR DESCRIPTION
Due to a new job, I won't have access to the `mrodgers-witekio` github account in a few weeks time.

But I'd like to keep contributing, so I've changed the entry in the maintainers file to my personal github account.

See also this role nomination: https://github.com/zephyrproject-rtos/zephyr/issues/93558 , I'm not sure if that has to be actioned first before this can be merged.