### PR TITLE
tests: uuid: fix malloc arena size for minimal libc configurations

### DIFF
--- a/tests/lib/uuid/testcase.yaml
+++ b/tests/lib/uuid/testcase.yaml
@@ -12,6 +12,8 @@ tests:
       - CONFIG_MBEDTLS_SHA1=y
       - CONFIG_UUID_BASE64=y
       - CONFIG_BASE64=y
+      # UUID utilities need some heap, but MINIMAL_LIBC has none by default.
+      - CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256
   libraries.uuid.v4:
     extra_configs:
       - CONFIG_UUID_V4=y


### PR DESCRIPTION
The UUID v5 test fails when using minimal libc with zero malloc arena size because uuid_generate_v5() requires dynamic memory allocation for mbedTLS cryptographic operations.
When CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE is 0
(default for minimal libc), malloc operations fail causing MBEDTLS_ERR_MD_ALLOC_FAILED errors.

Set CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256 to provide sufficient heap space for the cryptographic operations, following the pattern used in other test configurations.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/93564