### PR TITLE
Revert "driver: serial: uart_ns16550: Add pm support for uart_ns16550 driver"

### DIFF
--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -30,7 +30,6 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/policy.h>
-#include <zephyr/pm/device.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/spinlock.h>
 #include <zephyr/irq.h>
@@ -732,22 +731,6 @@ out:
 	k_spin_unlock(&dev_data->lock, key);
 	return ret;
 };
-
-__maybe_unused static int uart_ns16550_pm_action(const struct device *dev,
-						 enum pm_device_action action)
-{
-	struct uart_ns16550_dev_data *data = dev->data;
-	struct uart_config *uart_cfg = &data->uart_config;
-
-	switch (action) {
-	case PM_DEVICE_ACTION_RESUME:
-		return uart_ns16550_configure(dev, uart_cfg);
-	case PM_DEVICE_ACTION_SUSPEND:
-		return 0;
-	default:
-		return -ENOTSUP;
-	}
-}
 
 #ifdef CONFIG_UART_USE_RUNTIME_CONFIGURE
 static int uart_ns16550_config_get(const struct device *dev,
@@ -1996,8 +1979,7 @@ static DEVICE_API(uart, uart_ns16550_driver_api) = {
 	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {            \
 		UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                          \
 	};                                                                           \
-	PM_DEVICE_DT_INST_DEFINE(n, uart_ns16550_pm_action);                         \
-	DEVICE_DT_INST_DEFINE(n, uart_ns16550_init, PM_DEVICE_DT_INST_GET(n),	     \
+	DEVICE_DT_INST_DEFINE(n, uart_ns16550_init, NULL,                            \
 			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
 			      PRE_KERNEL_1, CONFIG_SERIAL_INIT_PRIORITY,             \
 			      &uart_ns16550_driver_api);                             \
@@ -2015,8 +1997,7 @@ static DEVICE_API(uart, uart_ns16550_driver_api) = {
 	static struct uart_ns16550_dev_data uart_ns16550_dev_data_##n = {            \
 		UART_NS16550_COMMON_DEV_DATA_INITIALIZER(n)                          \
 	};                                                                           \
-	PM_DEVICE_DT_INST_DEFINE(n, uart_ns16550_pm_action);			     \
-	DEVICE_DT_INST_DEFINE(n, uart_ns16550_init, PM_DEVICE_DT_INST_GET(n),	     \
+	DEVICE_DT_INST_DEFINE(n, uart_ns16550_init, NULL,                            \
 			      &uart_ns16550_dev_data_##n, &uart_ns16550_dev_cfg_##n, \
 			      PRE_KERNEL_1,            \
 			      CONFIG_SERIAL_INIT_PRIORITY,                           \


### PR DESCRIPTION
This reverts commit fd88386a9f42d961e185aeca32cc8c033eeef8e8, it breaks uart support on ITE platforms when PM is enabled but PM_RUNTIME is not, possibly others as well.

---

I folks, this caused a regression downstream, I'd normally figure out a workaround and fix forward but something seems off so I'd ask you folks to rework this: seems like the implementation is a no-op for suspend and a reconfigure for resume, I've no doubt it works in your case but it doesn't for ITE, not entirely sure what breaks specifically but since ITE uses (sadly) system managed runtime this causes the uart to be [reconfigued every time the CPU wakes up](https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/pm/device_system_managed.c#L71-L72) and there's no way of preventing it, so even if I figure how to make it cope with the continuous reconfiguration, I'd rather not do it in the first place.

fimohame@ could you rework this to add a property and only enable it on platforms that actually need it?

One more for https://github.com/zephyrproject-rtos/zephyr/issues/75963

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93572