### PR TITLE
Fix/wifi 11k roaming fail

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1528,13 +1528,26 @@ int supplicant_11k_cfg(const struct device *dev, struct wifi_11k_params *params)
 
 int supplicant_11k_neighbor_request(const struct device *dev, struct wifi_11k_params *params)
 {
+	struct wpa_supplicant *wpa_s;
 	int ssid_len;
 
-	if (params == NULL) {
+	wpa_s = get_wpa_s_handle(dev);
+	if (!wpa_s) {
+		wpa_printf(MSG_ERROR, "Device %s not found", dev->name);
 		return -1;
 	}
 
-	ssid_len = strlen(params->ssid);
+	if (wpa_s->reassociate || (wpa_s->wpa_state >= WPA_AUTHENTICATING &&
+	    wpa_s->wpa_state < WPA_COMPLETED)) {
+		wpa_printf(MSG_INFO, "Reassociation is in progress, skip");
+		return 0;
+	}
+
+	if (params) {
+		ssid_len = strlen(params->ssid);
+	} else {
+		ssid_len = 0;
+	}
 
 	if (ssid_len > 0) {
 		if (ssid_len > WIFI_SSID_MAX_LEN) {

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -442,7 +442,6 @@ static int wifi_connect(uint64_t mgmt_request, struct net_if *iface,
 	}
 
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
-	memset(&roaming_params, 0x0, sizeof(roaming_params));
 	roaming_params.is_11r_used = params->ft_used;
 #endif
 


### PR DESCRIPTION
233b6e8b404c6ff7f8bc8a4834ac38b40146b849
subsys: wifi: fix wifi 11k cannot be set before connection
    
    Support the case that 11k parameter can be set before wifi connection.
    This field should not be cleared by connection.
    Fix it by not clear it in wifi_connect api.

80d1d234965ca3429e6e1c5629f6bfaf1dab78a2
modules: hostap: fix wifi roaming aborted in few cases
    
    Add guard of supplicant state condition.
    Not send neighbor request in auth procedures.