### PR TITLE
Bluetooth: Host: Add l2cap credit param checks

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2154,6 +2154,17 @@ static void le_credits(struct bt_l2cap *l2cap, uint8_t ident,
 	cid = sys_le16_to_cpu(ev->cid);
 	credits = sys_le16_to_cpu(ev->credits);
 
+	if (!L2CAP_LE_CID_IS_DYN(cid)) {
+		LOG_WRN("Can't add credits to non-dynamic channel %p (cid 0x%04x)", &l2cap->chan,
+			cid);
+		return;
+	}
+
+	if (credits == 0U) {
+		LOG_WRN("Ignoring zero credit packet");
+		return;
+	}
+
 	LOG_DBG("cid 0x%04x credits %u", cid, credits);
 
 	chan = bt_l2cap_le_lookup_tx_cid(conn, cid);


### PR DESCRIPTION
Adds a missing requirement from Core Spec V6.0 Vol 3.A chapters 10.1 and 10.2 to ignore L2CAP_FLOW_CONTROL_CREDIT_IND packets with the credit value set to 0.

Matches existing credit-related functions by checking that the CID is in the dynamic range (you can't add credits to fixed channels).