### PR TITLE
dts: arm: st: u5: fix wkup-pin@8 referencing non-existent port gpiof

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -881,8 +881,7 @@
 
 			wkup-pin@8 {
 				reg = <0x8>;
-				wkup-gpios = <&gpiof 2 STM32_PWR_WKUP_EVT_SRC_0>,
-					     <&gpioa 7 STM32_PWR_WKUP_EVT_SRC_1>,
+				wkup-gpios = <&gpioa 7 STM32_PWR_WKUP_EVT_SRC_1>,
 					     <&gpiob 10 STM32_PWR_WKUP_EVT_SRC_2>;
 			};
 		};

--- a/dts/arm/st/u5/stm32u5_extra.dtsi
+++ b/dts/arm/st/u5/stm32u5_extra.dtsi
@@ -77,3 +77,11 @@
 		};
 	};
 };
+
+&pwr {
+	wkup-pin@8 {
+		wkup-gpios = <&gpiof 2 STM32_PWR_WKUP_EVT_SRC_0>,
+			     <&gpioa 7 STM32_PWR_WKUP_EVT_SRC_1>,
+			     <&gpiob 10 STM32_PWR_WKUP_EVT_SRC_2>;
+	};
+};


### PR DESCRIPTION
With commit d280d89 the gpiof port got moved from file stm32u5.dtsi to file stm32u5_extra.dtsi. stm32u5_extra.dtsi is not included for STM32U535/545. In same file stm32u5.dtsi still node wkup-pin@8 references non-existent port gpiof.

Fixes #93445