### PR TITLE
stm32: drivers: adc :  exclude differential input support on stm32u3 serie

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -498,7 +498,7 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 	const struct adc_stm32_cfg *config =
 		(const struct adc_stm32_cfg *)dev->config;
 	ADC_TypeDef *adc = config->base;
-#ifdef LL_ADC_SINGLE_ENDED
+#if defined(LL_ADC_SINGLE_ENDED) && defined(LL_ADC_DIFFERENTIAL_ENDED)
 	uint32_t calib_type = single_ended ? LL_ADC_SINGLE_ENDED : LL_ADC_DIFFERENTIAL_ENDED;
 #else
 	ARG_UNUSED(single_ended);


### PR DESCRIPTION
This PR add change to avoid following build error :  

```
zephyrproject/zephyr/drivers/adc/adc_stm32.c:503:68: error: 'LL_ADC_DIFFERENTIAL_ENDED' undeclared (first use in this function)
  503 |         uint32_t calib_type = single_ended ? LL_ADC_SINGLE_ENDED : LL_ADC_DIFFERENTIAL_ENDED;
      |                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~


```

To reproduce :  

`west build -p -b nucleo_u385rg_q tests/drivers/adc/adc_api/`