### PR TITLE
drivers: support direct ISRs in mbox_nrf_bellboard_rx and nrf_grtc_timer

### DIFF
--- a/drivers/timer/nrf_grtc_timer.c
+++ b/drivers/timer/nrf_grtc_timer.c
@@ -459,12 +459,24 @@ uint32_t sys_clock_elapsed(void)
 	return (uint32_t)(counter_sub(counter(), last_count) / CYC_PER_TICK);
 }
 
+#if !defined(CONFIG_GEN_SW_ISR_TABLE)
+ISR_DIRECT_DECLARE(grtc_direct_isr)
+{
+	nrfx_isr(nrfx_grtc_irq_handler);
+	return 1;
+}
+#endif
+
 static int sys_clock_driver_init(void)
 {
 	nrfx_err_t err_code;
 
+#if defined(CONFIG_GEN_SW_ISR_TABLE)
 	IRQ_CONNECT(DT_IRQN(GRTC_NODE), DT_IRQ(GRTC_NODE, priority), nrfx_isr,
 		    nrfx_grtc_irq_handler, 0);
+#else
+	IRQ_DIRECT_CONNECT(DT_IRQN(GRTC_NODE), DT_IRQ(GRTC_NODE, priority), grtc_direct_isr, 0);
+#endif
 
 #if defined(CONFIG_NRF_GRTC_TIMER_CLOCK_MANAGEMENT) && NRF_GRTC_HAS_CLKSEL
 #if defined(CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC)


### PR DESCRIPTION
Use direct ISRs whenever CONFIG_GEN_SW_ISR_TABLE=n in these drivers:
* drivers/mbox/mbox_nrf_bellboard_rx.c
* drivers/timer/nrf_grtc_timer.c