### PR TITLE
modules: hal_nordic: nrfx: Add support for custom NRFX_DIR on Sysbuild

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -5,6 +5,8 @@ zephyr_library()
 
 # The nrfx source directory can be override through the definition of the NRFX_DIR symbol
 # during the invocation of the build system
+zephyr_get(NRFX_DIR SYSBUILD GLOBAL)
+
 if(NOT DEFINED NRFX_DIR)
   set(NRFX_DIR ${ZEPHYR_CURRENT_MODULE_DIR}/nrfx CACHE PATH "nrfx Directory")
 endif()


### PR DESCRIPTION
Add support for custom NRFX_DIR for Sysbuild builds by checking if NRFX_DIR has been defined in Sysbuild.