### PR TITLE
tests: drivers: Add overlay for nRF54L15 FLPR core to build_all/gpio

### DIFF
--- a/tests/drivers/build_all/gpio/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/tests/drivers/build_all/gpio/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&cpuflpr_rram {
+	reg = <0x15D000 DT_SIZE_K(128)>;
+};
+
+&cpuflpr_code_partition {
+	reg = <0x0 DT_SIZE_K(128)>;
+};
+
+&cpuflpr_sram {
+	reg = <0x20020000 DT_SIZE_K(128)>;
+	ranges = <0x0 0x20020000 0x20000>;
+};

--- a/tests/drivers/build_all/gpio/testcase.yaml
+++ b/tests/drivers/build_all/gpio/testcase.yaml
@@ -6,7 +6,10 @@ common:
 tests:
   drivers.gpio.build:
     min_ram: 32
-    platform_exclude: serpente
+    platform_exclude:
+      - serpente
+      - nrf54l15dk/nrf54l15/cpuflpr
+      - nrf54l15dk/nrf54l15/cpuflpr/xip
     depends_on:
       - gpio
       - spi
@@ -66,3 +69,10 @@ tests:
     platform_allow: qemu_cortex_m3
     depends_on: gpio
     extra_args: DTC_OVERLAY_FILE="iproc.overlay"
+
+  drivers.gpio.build.nrf54l15_cpuflpr:
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuflpr
+      - nrf54l15dk/nrf54l15/cpuflpr/xip
+    depends_on: gpio
+    extra_args: DTC_OVERLAY_FILE="nrf54l15dk_nrf54l15_cpuflpr.overlay"


### PR DESCRIPTION
Add overlay to increase memory to make compilation works.