### PR TITLE
tests: drivers: clock_control: nrf_lf_clock_start: Run on nrf54lm20dk

### DIFF
--- a/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
@@ -51,6 +51,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf5340dk/nrf5340/cpunet
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
     integration_platforms:
       - nrf51dk/nrf51822


### PR DESCRIPTION
Fix mistake where one of test configurations was skipped on nrf54lm20dk board.