### PR TITLE
arm: irq: fail build if IRQ_CONNECT is used with ZLI

### DIFF
--- a/include/zephyr/arch/arm/irq.h
+++ b/include/zephyr/arch/arm/irq.h
@@ -118,8 +118,8 @@ extern void z_arm_interrupt_init(void);
  */
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \
-	BUILD_ASSERT(IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) || !(flags_p & IRQ_ZERO_LATENCY), \
-			"ZLI interrupt registered but feature is disabled"); \
+	BUILD_ASSERT(!(flags_p & IRQ_ZERO_LATENCY), \
+			"ZLI interrupts must be registered using IRQ_DIRECT_CONNECT()"); \
 	_CHECK_PRIO(priority_p, flags_p) \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 	z_arm_irq_priority_set(irq_p, priority_p, flags_p); \


### PR DESCRIPTION
Commit 3b8e1fa8df9a5507083805978103d639e2675126 updated the documentation to mention explicitly that ZLI must be registered using IRQ_DIRECT_CONNECT.

Update the ARM IRQ macros such that attempts to register a ZLI using IRQ_CONNECT becomes a build failure instead of silently succeeding.