### PR TITLE
modules: lvgl: Optional BGR888 to RGB888

### DIFF
--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -98,6 +98,11 @@ config LV_Z_COLOR_MONO_HW_INVERSION
 	bool "Hardware pixel inversion (disables software pixel inversion)."
 	depends on LV_COLOR_DEPTH_1
 
+config LV_Z_COLOR_24_BGR_TO_RGB
+	bool "Convert BGR888 to RGB888 color before flushing"
+	default y
+	depends on LV_COLOR_DEPTH_24
+
 config LV_Z_FLUSH_THREAD
 	bool "Flush LVGL frames in a separate thread"
 	help

--- a/modules/lvgl/lvgl_display_24bit.c
+++ b/modules/lvgl/lvgl_display_24bit.c
@@ -24,12 +24,14 @@ void lvgl_flush_cb_24bit(lv_display_t *display, const lv_area_t *area, uint8_t *
 	flush.desc.height = h;
 	flush.buf = (void *)px_map;
 
-	/* LVGL assumes BGR byte ordering, convert to RGB */
-	for (size_t i = 0; i < flush.desc.buf_size; i += 3) {
-		uint8_t tmp = px_map[i];
+	if (IS_ENABLED(CONFIG_LV_Z_COLOR_24_BGR_TO_RGB)) {
+		/* LVGL assumes BGR byte ordering, convert to RGB */
+		for (size_t i = 0; i < flush.desc.buf_size; i += 3) {
+			uint8_t tmp = px_map[i];
 
-		px_map[i] = px_map[i + 2];
-		px_map[i + 2] = tmp;
+			px_map[i] = px_map[i + 2];
+			px_map[i + 2] = tmp;
+		}
 	}
 
 	lvgl_flush_display(&flush);


### PR DESCRIPTION
Some display controllers allow to work with BGR888 directly, a significant reduction in CPU load is gained this way.