### PR TITLE
boards: stm32wb0: cleanup DTS

### DIFF
--- a/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
+++ b/boards/st/nucleo_wb05kz/nucleo_wb05kz.dts
@@ -151,7 +151,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 	/* Select 64MHz clock for SPI3 */
-	clocks = <&rcc STM32_CLOCK_BUS_APB1 (1 << 14)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 		<&rcc STM32_SRC_SYSCLK SPI3_I2S3_SEL(3)>;
 };
 

--- a/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
+++ b/boards/st/nucleo_wb09ke/nucleo_wb09ke.dts
@@ -151,7 +151,7 @@
 	pinctrl-names = "default";
 	status = "okay";
 	/* Select 64MHz clock for SPI3 */
-	clocks = <&rcc STM32_CLOCK_BUS_APB1 (1 << 14)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 		<&rcc STM32_SRC_SYSCLK SPI3_I2S3_SEL(3)>;
 };
 


### PR DESCRIPTION
Two of the STM32WB0 boards were introduced concurrently with the `STM32_CLOCK` macro, which was thus not used in their DTS.

Update the boards' DTS files to solve this inconsistency.