### PR TITLE
tests: arch: arm: arm_irq_vector_table: Microchip MEC build fix

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1743_qlj.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1743_qlj.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1743_qsz.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1743_qsz.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1753_qlj.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1753_qlj.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1753_qsz.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec_assy6941_mec1753_qsz.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};


### PR DESCRIPTION
Running twister with plaform Microchip mec_assy6941/<variant_name> builds the arm_irq_vector_table test. Microchip mec_assy6941 boards all use a 32-bit 32 KHz timer for the kernel. The test build fails due to any board using a custom kernel timer driver requires the test to include a chip specific interrupt table. We don't want to exclude the test. The MEC chips include Cortex-M4 SysTick. We added board overlays to the test turning off the 32KHz timer and enabling ARM SysTick. The test now builds.