### PR TITLE
samples: sensor: pressure_polling: Log altitude only if the sensor supports it

### DIFF
--- a/samples/sensor/pressure_polling/README.rst
+++ b/samples/sensor/pressure_polling/README.rst
@@ -10,7 +10,8 @@ Overview
 This sample application periodically reads the sensor
 temperature and pressure, displaying the
 values on the console along with a timestamp since startup.
-It also displays the estimated altitude if floating point is supported.
+It also displays the estimated altitude if floating point is supported
+and the sensor provides altitude data.
 
 Wiring
 *******
@@ -47,14 +48,14 @@ Sample Output
 ## Default configuration
 
    Found device "icp101xx@63", getting sensor data
-   [00:00:00.266,479] <inf> PRESSURE_POLLING: Starting pressure and altitude polling sample.
-   [00:00:00.273,803] <inf> PRESSURE_POLLING: temp 25.49 Cel, pressure 96.271438 kPa, altitude 447.208465 m
-   [00:00:00.280,914] <inf> PRESSURE_POLLING: temp 25.50 Cel, pressure 96.271331 kPa, altitude 447.234161 m
-   [00:00:00.288,024] <inf> PRESSURE_POLLING: temp 25.49 Cel, pressure 96.266685 kPa, altitude 447.636077 m
-   [00:00:00.295,135] <inf> PRESSURE_POLLING: temp 25.50 Cel, pressure 96.267951 kPa, altitude 447.537078 m
-   [00:00:00.302,246] <inf> PRESSURE_POLLING: temp 25.51 Cel, pressure 96.268577 kPa, altitude 447.488281 m
-   [00:00:00.309,356] <inf> PRESSURE_POLLING: temp 25.50 Cel, pressure 96.269340 kPa, altitude 447.414978 m
-   [00:00:00.316,467] <inf> PRESSURE_POLLING: temp 25.50 Cel, pressure 96.268562 kPa, altitude 447.473663 m
-   [00:00:00.323,547] <inf> PRESSURE_POLLING: temp 25.50 Cel, pressure 96.267341 kPa, altitude 447.596496 m
+   Starting pressure and altitude polling sample.
+   temp 25.49 Cel, pressure 96.271438 kPa, altitude 447.208465 m
+   temp 25.50 Cel, pressure 96.271331 kPa, altitude 447.234161 m
+   temp 25.49 Cel, pressure 96.266685 kPa, altitude 447.636077 m
+   temp 25.50 Cel, pressure 96.267951 kPa, altitude 447.537078 m
+   temp 25.51 Cel, pressure 96.268577 kPa, altitude 447.488281 m
+   temp 25.50 Cel, pressure 96.269340 kPa, altitude 447.414978 m
+   temp 25.50 Cel, pressure 96.268562 kPa, altitude 447.473663 m
+   temp 25.50 Cel, pressure 96.267341 kPa, altitude 447.596496 m
 
    <repeats endlessly>

--- a/samples/sensor/pressure_polling/src/main.c
+++ b/samples/sensor/pressure_polling/src/main.c
@@ -9,9 +9,6 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <zephyr/logging/log.h>
-
-LOG_MODULE_REGISTER(PRESSURE_POLLING, CONFIG_SENSOR_LOG_LEVEL);
 
 /*
  * Get a device structure from a devicetree node from alias
@@ -35,6 +32,7 @@ static const struct device *get_pressure_sensor_device(void)
 int main(void)
 {
 	const struct device *dev = get_pressure_sensor_device();
+	int ret;
 
 	if (dev == NULL) {
 		return 0;
@@ -43,18 +41,21 @@ int main(void)
 	struct sensor_value temperature;
 	struct sensor_value altitude;
 
-	LOG_INF("Starting pressure and altitude polling sample.\n");
+	printk("Starting pressure, temperature and altitude polling sample.\n");
 
 	while (1) {
 		if (sensor_sample_fetch_chan(dev, SENSOR_CHAN_ALL) == 0) {
 			sensor_channel_get(dev, SENSOR_CHAN_PRESS, &pressure);
 			sensor_channel_get(dev, SENSOR_CHAN_AMBIENT_TEMP, &temperature);
-			sensor_channel_get(dev, SENSOR_CHAN_ALTITUDE, &altitude);
+			ret = sensor_channel_get(dev, SENSOR_CHAN_ALTITUDE, &altitude);
 
-			LOG_INF("temp %.2f Cel, pressure %f kPa, altitude %f m",
-				sensor_value_to_double(&temperature),
-				sensor_value_to_double(&pressure),
-				sensor_value_to_double(&altitude));
+			printk("temp %.2f Cel, pressure %f kPa",
+			       sensor_value_to_double(&temperature),
+			       sensor_value_to_double(&pressure));
+			if (ret == 0) {
+				printk(", altitude %f m", sensor_value_to_double(&altitude));
+			}
+			printk("\n");
 		}
 	}
 	return 0;

--- a/samples/sensor/pressure_polling/src/main.c
+++ b/samples/sensor/pressure_polling/src/main.c
@@ -57,6 +57,8 @@ int main(void)
 			}
 			printk("\n");
 		}
+
+		k_msleep(1000);
 	}
 	return 0;
 }


### PR DESCRIPTION
Most pressure sensors in the Zephyr tree do not provide altitude data. This change adds a check to ensure altitude is printed only when the sensor supports it. A delay is also added between reads to avoid flooding the console.