### PR TITLE
scripts: check_init_priorities: fix device function name display

### DIFF
--- a/scripts/build/check_init_priorities.py
+++ b/scripts/build/check_init_priorities.py
@@ -49,6 +49,9 @@ _IGNORE_COMPATIBLES = frozenset([
         "zephyr,cdc-acm-uart",
         ])
 
+# The offset of the init pointer in "struct device", in number of pointers.
+DEVICE_INIT_OFFSET = 5
+
 class Priority:
     """Parses and holds a device initialization priority.
 
@@ -108,6 +111,7 @@ class ZephyrInitLevels:
     def _load_objects(self):
         """Initialize the object table."""
         self._objects = {}
+        self._object_addr = {}
 
         for section in self._elf.iter_sections():
             if not isinstance(section, SymbolTableSection):
@@ -119,6 +123,7 @@ class ZephyrInitLevels:
                     sym.entry.st_info.type in ["STT_OBJECT", "STT_FUNC"]):
                     self._objects[sym.entry.st_value] = (
                             sym.name, sym.entry.st_size, sym.entry.st_shndx)
+                    self._object_addr[sym.name] = sym.entry.st_value
 
     def _load_level_addr(self):
         """Find the address associated with known init levels."""
@@ -205,12 +210,17 @@ class ZephyrInitLevels:
                 arg0_name = self._object_name(self._initlevel_pointer(addr, 0, shidx))
                 arg1_name = self._object_name(self._initlevel_pointer(addr, 1, shidx))
 
-                self.initlevels[level].append(f"{obj}: {arg0_name}({arg1_name})")
-
                 ordinal = self._device_ord_from_name(arg1_name)
                 if ordinal:
+                    dev_addr = self._object_addr[arg1_name]
+                    _, _, shidx = self._objects[dev_addr]
+                    arg0_name = self._object_name(self._initlevel_pointer(
+                        dev_addr, DEVICE_INIT_OFFSET, shidx))
+
                     prio = Priority(level, priority)
                     self.devices[ordinal] = (prio, arg0_name)
+
+                self.initlevels[level].append(f"{obj}: {arg0_name}({arg1_name})")
 
                 addr += size
                 priority += 1

--- a/scripts/build/check_init_priorities_test.py
+++ b/scripts/build/check_init_priorities_test.py
@@ -210,15 +210,19 @@ class testZephyrInitLevels(unittest.TestCase):
                 0x04: ("b", 4, 0),
                 0x08: ("c", 4, 0),
                 }
+        obj._object_addr = {
+                "__device_dts_ord_11": 0x00,
+                "__device_dts_ord_22": 0x04,
+                }
 
         mock_ip.side_effect = lambda *args: args
 
         def mock_obj_name(*args):
-            if args[0] == (0, 0, 0):
+            if args[0] == (0, 5, 0):
                 return "i0"
             elif args[0] == (0, 1, 0):
                 return "__device_dts_ord_11"
-            elif args[0] == (4, 0, 0):
+            elif args[0] == (4, 5, 0):
                 return "i1"
             elif args[0] == (4, 1, 0):
                 return "__device_dts_ord_22"

--- a/tests/misc/check_init_priorities/CMakeLists.txt
+++ b/tests/misc/check_init_priorities/CMakeLists.txt
@@ -4,10 +4,11 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 set(output_file ${PROJECT_BINARY_DIR}/check_init_priorities_output.txt)
+set(output_file_initlevels ${PROJECT_BINARY_DIR}/check_init_priorities_output_initlevels.txt)
 
 add_custom_command(
 	COMMENT "Running check_init_priorities.py"
-	OUTPUT ${output_file}
+	OUTPUT ${output_file} ${output_file_initlevels}
 	DEPENDS
 	  ${logical_target_for_zephyr_elf}
 	  $<$<TARGET_EXISTS:native_runner_executable>:native_runner_executable>
@@ -16,11 +17,16 @@ add_custom_command(
 	  --verbose
 	  --output ${output_file}
 	  --always-succeed
+	COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/check_init_priorities.py
+	  --elf-file=$<IF:$<TARGET_EXISTS:native_runner_executable>,${BYPRODUCT_KERNEL_EXE_NAME},${BYPRODUCT_KERNEL_ELF_NAME}>
+	  --initlevels
+	  --always-succeed
+	  > ${output_file_initlevels}
 	COMMAND ${PYTHON_EXECUTABLE} ${APPLICATION_SOURCE_DIR}/validate_check_init_priorities_output.py
-	  ${output_file}
+	  ${output_file} ${output_file_initlevels}
 )
 
-add_custom_target(check_init_priorities_output ALL DEPENDS ${output_file})
+add_custom_target(check_init_priorities_output ALL DEPENDS ${output_file} ${output_file_initlevels})
 
 project(check_init_priorities)
 

--- a/tests/misc/check_init_priorities/src/main.c
+++ b/tests/misc/check_init_priorities/src/main.c
@@ -6,9 +6,19 @@
 
 #include <zephyr/device.h>
 
-DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio_device), NULL, NULL, NULL, NULL,
+static int init_fn_0(const struct device *dev)
+{
+	return 0;
+}
+
+static int init_fn_1(const struct device *dev)
+{
+	return 0;
+}
+
+DEVICE_DT_DEFINE(DT_INST(0, vnd_gpio_device), init_fn_0, NULL, NULL, NULL,
 		 PRE_KERNEL_1, 50, NULL);
-DEVICE_DT_DEFINE(DT_INST(0, vnd_i2c), NULL, NULL, NULL, NULL,
+DEVICE_DT_DEFINE(DT_INST(0, vnd_i2c), init_fn_1, NULL, NULL, NULL,
 		 PRE_KERNEL_1, 50, NULL);
 
 DEVICE_DT_DEFINE(DT_INST(0, vnd_i2c_device), NULL, NULL, NULL, NULL,

--- a/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
+++ b/tests/misc/check_init_priorities/validate_check_init_priorities_output.py
@@ -9,33 +9,52 @@ import sys
 
 REFERENCE_OUTPUT = [
         "ERROR: Device initialization priority validation failed, the sequence of initialization calls does not match the devicetree dependencies.",
-        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /gpio@ffff <NULL> (PRE_KERNEL_1+0 < PRE_KERNEL_1+1)",
-        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /i2c@11112222 <NULL> (PRE_KERNEL_1+0 < PRE_KERNEL_1+2)",
-        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /gpio@ffff <NULL> PRE_KERNEL_1+1",
-        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /i2c@11112222 <NULL> PRE_KERNEL_1+2",
+        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /gpio@ffff <init_fn_0> (PRE_KERNEL_1+0 < PRE_KERNEL_1+1)",
+        "ERROR: /i2c@11112222/test-i2c-dev@10 <NULL> is initialized before its dependency /i2c@11112222 <init_fn_1> (PRE_KERNEL_1+0 < PRE_KERNEL_1+2)",
+        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /gpio@ffff <init_fn_0> PRE_KERNEL_1+1",
+        "INFO: /i2c@11112222/test-i2c-dev@11 <NULL> PRE_KERNEL_1+3 > /i2c@11112222 <init_fn_1> PRE_KERNEL_1+2",
 ]
 
-if len(sys.argv) != 2:
-    print(f"usage: {sys.argv[0]} FILE_PATH")
+REFERENCE_OUTPUT_INITLEVELS = [
+        "EARLY",
+        "PRE_KERNEL_1",
+        "__init___device_dts_ord_32: init_fn_0(__device_dts_ord_32)",
+        "__init___device_dts_ord_33: init_fn_1(__device_dts_ord_33)",
+        "__init___device_dts_ord_34: NULL(__device_dts_ord_34)",
+        "__init___device_dts_ord_35: NULL(__device_dts_ord_35)",
+        "__init_posix_arch_console_init: posix_arch_console_init(NULL)",
+        "PRE_KERNEL_2",
+        "__init_sys_clock_driver_init: sys_clock_driver_init(NULL)",
+        "POST_KERNEL",
+        "APPLICATION",
+        "SMP",
+]
+
+if len(sys.argv) != 3:
+    print(f"usage: {sys.argv[0]} FILE_PATH FILE_PATH_INITLEVELS")
     sys.exit(1)
 
-output = []
-with open(sys.argv[1], "r") as file:
-    for line in file:
-        if line.startswith("INFO: check_init_priorities"):
-            continue
-        output.append(line.strip())
+def check_file(file_name, expect):
+    output = []
+    with open(file_name, "r") as file:
+        for line in file:
+            if line.startswith("INFO: check_init_priorities"):
+                continue
+            output.append(line.strip())
 
-if sorted(REFERENCE_OUTPUT) != sorted(output):
-    print("Mismatched otuput")
-    print()
-    print("expected:")
-    print("\n".join(sorted(REFERENCE_OUTPUT)))
-    print()
-    print("got:")
-    print("\n".join(sorted(output)))
-    print("TEST FAILED")
-    sys.exit(1)
+    if sorted(expect) != sorted(output):
+        print(f"Mismatched otuput from {file_name}")
+        print()
+        print("expected:")
+        print("\n".join(sorted(expect)))
+        print()
+        print("got:")
+        print("\n".join(sorted(output)))
+        print("TEST FAILED")
+        sys.exit(1)
+
+check_file(sys.argv[1], REFERENCE_OUTPUT)
+check_file(sys.argv[2], REFERENCE_OUTPUT_INITLEVELS)
 
 print("TEST PASSED")
 sys.exit(0)


### PR DESCRIPTION
Device init pointers have been moved off struct init_entry and into struct device in 766bfe7b2e2, but check_init_priorities.py have not been modified to check the new pointer so it's been showing NULL for all devices since.

Fix it by searching down the right pointer for device init entries.