### PR TITLE
twister: espressif: fix board_id set as port argument

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -73,9 +73,6 @@ class HardwareAdapter(DeviceAdapter):
             if runner == 'pyocd':
                 extra_args.append('--board-id')
                 extra_args.append(board_id)
-            elif runner == "esp32":
-                extra_args.append("--esp-device")
-                extra_args.append(board_id)
             elif runner in ('nrfjprog', 'nrfutil', 'nrfutil_next'):
                 extra_args.append('--dev-id')
                 extra_args.append(board_id)
@@ -95,6 +92,9 @@ class HardwareAdapter(DeviceAdapter):
                 base_args.append(f'--tool-opt=sn={board_id}')
             elif runner == 'linkserver':
                 base_args.append(f'--probe={board_id}')
+        if (serial_pty := self.device_config.serial_pty) and runner == 'esp32':
+            extra_args.append("--esp-device")
+            extra_args.append(serial_pty)
         return base_args, extra_args
 
     def _flash_and_run(self) -> None:

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -569,9 +569,6 @@ class DeviceHandler(Handler):
                     if runner in ("pyocd", "nrfjprog", "nrfutil", "nrfutil_next"):
                         command_extra_args.append("--dev-id")
                         command_extra_args.append(board_id)
-                    elif runner == "esp32":
-                        command_extra_args.append("--esp-device")
-                        command_extra_args.append(board_id)
                     elif (
                         runner == "openocd"
                         and product == "STM32 STLink"
@@ -596,7 +593,16 @@ class DeviceHandler(Handler):
                         command.append(f"--probe={board_id}")
                     elif runner == "stm32cubeprogrammer" and product != "BOOT-SERIAL":
                         command.append(f"--tool-opt=sn={board_id}")
+                    # Receive parameters from runner_params field.
+                    if hardware.runner_params:
+                        for param in hardware.runner_params:
+                            command.append(param)
 
+                serial_port = hardware.serial
+                if serial_port is not None:
+                    if runner == "esp32":
+                        command_extra_args.append("--esp-device")
+                        command_extra_args.append(serial_port)
                     # Receive parameters from runner_params field.
                     if hardware.runner_params:
                         for param in hardware.runner_params:


### PR DESCRIPTION
Removed esp32 board_id extra argument.
This argument set the identifier of the esp32 board to test, as the --port argument for the esptool.py flash command, what was not correct. This commit remove the device_id fetch to compose the flash command and use the default serial port instead.

FIXES #93601