### PR TITLE
manifest: nrf_wifi: Pull fix for raw TX

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -331,7 +331,7 @@ manifest:
       revision: 6e5961223f81aa2707c555db138819a5c1b7942c
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 00801cbaf83600ba9e39b010928401e817a93fdc
+      revision: 787eea1a3c8dd13c86214e204a919e6f9bcebf91
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: c30a6d8b92fcebdb797fc1a7698e8729e250f637


### PR DESCRIPTION
Pull fix for double pulling of raw TX header, fixes warnings seen during tests.