### PR TITLE
checkpatch: ignore UNNECESSARY_ELSE

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -29,3 +29,4 @@
 --ignore ENOSYS
 --ignore IS_ENABLED_CONFIG
 --ignore EXPORT_SYMBOL
+--ignore UNNECESSARY_ELSE


### PR DESCRIPTION
In order to allow the code to comply with MISRA 15.7, which states:
"All else if constructs shall be terminated with an else statement"

This is listed in our Coding Guidelines: https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html

Before this patch, the following message will pop-up and fail compliance checks:
```
-:147: WARNING:UNNECESSARY_ELSE: else is not generally useful after a break or return
#147: FILE: drivers/sensor/bosch/bmp581/bmp581_stream.c:285:
+               return;
+       } else {

- total: 0 errors, 1 warnings, 198 lines checked
```
Reference: https://github.com/zephyrproject-rtos/zephyr/actions/runs/16481684493/job/46597371633?pr=93166
