### PR TITLE
Fix nordic overlays license

### DIFF
--- a/samples/drivers/adc/adc_dt/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/drivers/adc/adc_dt/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 / {

--- a/samples/drivers/adc/adc_sequence/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 / {

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2025 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /*


### PR DESCRIPTION
I moved board overlay from downstream (sdk-nrf) to upstream (Zephyr RTOS).
I forgot to update License in three files.

This is follow-up to https://github.com/zephyrproject-rtos/zephyr/pull/92432 and https://github.com/zephyrproject-rtos/zephyr/pull/92901