### PR TITLE
bluetooth: remove the unnecessary macro wrapper in header files

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -830,7 +830,6 @@ int bt_a2dp_stream_abort(struct bt_a2dp_stream *stream);
  */
 uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream);
 
-#if defined(CONFIG_BT_A2DP_SOURCE)
 /** @brief send a2dp media data
  *
  * Only A2DP source side can call this function.
@@ -844,7 +843,6 @@ uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream);
  */
 int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			uint32_t ts);
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/bluetooth/services/ots.h
+++ b/include/zephyr/bluetooth/services/ots.h
@@ -1157,12 +1157,10 @@ void bt_ots_metadata_display(struct bt_ots_obj_metadata *metadata,
  * @return CRC32 value.
  *
  */
-#if defined(CONFIG_BT_OTS_OACP_CHECKSUM_SUPPORT)
 static inline uint32_t bt_ots_client_calc_checksum(const uint8_t *data, size_t len)
 {
 	return crc32_ieee(data, len);
 }
-#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -142,7 +142,6 @@ struct bt_conn_le {
 #endif
 };
 
-#if defined(CONFIG_BT_CLASSIC)
 /* For now reserve space for 2 pages of LMP remote features */
 #define LMP_MAX_PAGES 2
 
@@ -169,7 +168,6 @@ struct bt_conn_sco {
 	uint8_t                 dev_class[3];
 	uint8_t                 link_type;
 };
-#endif
 
 struct bt_conn_iso {
 	/* Reference to ACL Connection */
@@ -536,7 +534,6 @@ void notify_cs_procedure_enable_available(struct bt_conn *conn,
 					  uint8_t status,
 					  struct bt_conn_le_cs_procedure_enable_complete *params);
 
-#if defined(CONFIG_BT_SMP)
 /* If role specific LTK is present */
 bool bt_conn_ltk_present(const struct bt_conn *conn);
 
@@ -546,13 +543,10 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, uint8_t rand[8],
 
 /* Notify higher layers that RPA was resolved */
 void bt_conn_identity_resolved(struct bt_conn *conn);
-#endif /* CONFIG_BT_SMP */
 
-#if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
 /* Notify higher layers that connection security changed */
 void bt_conn_security_changed(struct bt_conn *conn, uint8_t hci_err,
 			      enum bt_security_err err);
-#endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
 /* Prepare a PDU to be sent over a connection */
 #if defined(CONFIG_NET_BUF_LOG)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -321,14 +321,12 @@ struct bt_dev_le {
 	sys_slist_t		conn_ready;
 };
 
-#if defined(CONFIG_BT_CLASSIC)
 struct bt_dev_br {
 	/* Max controller's acceptable ACL packet length */
 	uint16_t         mtu;
 	struct k_sem  pkts;
 	uint16_t         esco_pkt_type;
 };
-#endif
 
 /* The theoretical max for these is 8 and 64, but there's no point
  * in allocating the full memory if we only support a small subset.
@@ -445,11 +443,9 @@ struct bt_dev {
 };
 
 extern struct bt_dev bt_dev;
-#if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_CLASSIC)
 extern const struct bt_conn_auth_cb *bt_auth;
 extern sys_slist_t bt_auth_info_cbs;
 enum bt_security_err bt_security_err_get(uint8_t hci_err);
-#endif /* CONFIG_BT_SMP || CONFIG_BT_CLASSIC */
 
 int bt_hci_recv(const struct device *dev, struct net_buf *buf);
 


### PR DESCRIPTION
It eliminates the possibility of using IS_ENABLE(), so it is better to remove them.

@jhedberg mention this task in https://github.com/zephyrproject-rtos/zephyr/pull/90126#discussion_r2137533113

I don't handle ble audio and mesh.