### PR TITLE
samples: rtxxx-amp: Remove POST_BUILD

### DIFF
--- a/samples/boards/nxp/adsp/rtxxx/common/remote-dsp-imgs.cmake
+++ b/samples/boards/nxp/adsp/rtxxx/common/remote-dsp-imgs.cmake
@@ -4,7 +4,6 @@
 add_custom_command(
     OUTPUT ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.reset.bin
     DEPENDS ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf
-    POST_BUILD
     COMMAND ${CMAKE_OBJCOPY}
     -Obinary ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.reset.bin
     --only-section=.ResetVector.text
@@ -13,7 +12,6 @@ add_custom_command(
 add_custom_command(
     OUTPUT ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.text.bin
     DEPENDS ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf
-    POST_BUILD
     COMMAND ${CMAKE_OBJCOPY}
     -Obinary ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.text.bin
     --only-section=.WindowVectors.text
@@ -26,7 +24,6 @@ add_custom_command(
 add_custom_command(
     OUTPUT ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.data.bin
     DEPENDS ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf
-    POST_BUILD
     COMMAND ${CMAKE_OBJCOPY}
     -Obinary ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.elf ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.data.bin
     --only-section=.rodata


### PR DESCRIPTION
Remove POST_BUILD directives from `remote-dsp-imgs.cmake`.

Fixes #93651.