### PR TITLE
samples: rtxxx-amp: Enable for mimxrt700_evk/hifi4

### DIFF
--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.conf
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_DMA_TCD_QUEUE_SIZE=8

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.overlay
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		i2s-rx = &sai0;
+		i2s-tx = &sai0;
+	};
+};

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/src/main.c
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/remote/src/main.c
@@ -14,7 +14,7 @@
 #define I2S_RX_NODE  DT_ALIAS(i2s_rx)
 #define I2S_TX_NODE  DT_ALIAS(i2s_tx)
 
-#define SAMPLE_FREQUENCY    48000
+#define SAMPLE_FREQUENCY    16000
 #define SAMPLE_BIT_WIDTH    16
 #define BYTES_PER_SAMPLE    sizeof(int16_t)
 #define NUMBER_OF_CHANNELS  2
@@ -24,7 +24,7 @@
 #define TIMEOUT             1000
 
 #define BLOCK_SIZE  (BYTES_PER_SAMPLE * SAMPLES_PER_BLOCK)
-#define BLOCK_COUNT (INITIAL_BLOCKS + 2)
+#define BLOCK_COUNT (INITIAL_BLOCKS + 4)
 K_MEM_SLAB_DEFINE_STATIC(mem_slab, BLOCK_SIZE, BLOCK_COUNT, 4);
 
 static bool configure_streams(const struct device *i2s_dev_rx,

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/sample.yaml
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_loopback/sample.yaml
@@ -8,6 +8,7 @@ common:
   min_flash: 1024
   platform_allow:
     - mimxrt685_evk/mimxrt685s/cm33
+    - mimxrt700_evk/mimxrt798s/cm33_cpu0
   harness: console
   harness_config:
     type: one_line

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_output/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_output/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flexcomm2 {
+	status = "disabled";
+};
+
+&flexcomm2_lpi2c2 {
+	status = "disabled";
+};
+
+&gpio0 {
+	status = "disabled";
+};

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_output/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.conf
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_output/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_DMA_TCD_QUEUE_SIZE=4

--- a/samples/boards/nxp/adsp/rtxxx/amp_audio_output/sample.yaml
+++ b/samples/boards/nxp/adsp/rtxxx/amp_audio_output/sample.yaml
@@ -8,6 +8,7 @@ common:
   min_flash: 1024
   platform_allow:
     - mimxrt685_evk/mimxrt685s/cm33
+    - mimxrt700_evk/mimxrt798s/cm33_cpu0
   harness: console
   harness_config:
     type: one_line

--- a/samples/boards/nxp/adsp/rtxxx/amp_blinky/sample.yaml
+++ b/samples/boards/nxp/adsp/rtxxx/amp_blinky/sample.yaml
@@ -8,6 +8,7 @@ common:
   min_flash: 1024
   platform_allow:
     - mimxrt685_evk/mimxrt685s/cm33
+    - mimxrt700_evk/mimxrt798s/cm33_cpu0
   harness: console
   harness_config:
     type: one_line

--- a/samples/boards/nxp/adsp/rtxxx/amp_mbox/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
+++ b/samples/boards/nxp/adsp/rtxxx/amp_mbox/boards/mimxrt700_evk_mimxrt798s_cm33_cpu0.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		mbox = &mbox4;
+	};
+};

--- a/samples/boards/nxp/adsp/rtxxx/amp_mbox/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.overlay
+++ b/samples/boards/nxp/adsp/rtxxx/amp_mbox/remote/boards/mimxrt700_evk_mimxrt798s_hifi4.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		mbox = &mbox4;
+	};
+};

--- a/samples/boards/nxp/adsp/rtxxx/amp_mbox/sample.yaml
+++ b/samples/boards/nxp/adsp/rtxxx/amp_mbox/sample.yaml
@@ -8,6 +8,7 @@ common:
   min_flash: 1024
   platform_allow:
     - mimxrt685_evk/mimxrt685s/cm33
+    - mimxrt700_evk/mimxrt798s/cm33_cpu0
   harness: console
   harness_config:
     type: one_line

--- a/samples/boards/nxp/adsp/rtxxx/common/remote-dsp-board-select.cmake
+++ b/samples/boards/nxp/adsp/rtxxx/common/remote-dsp-board-select.cmake
@@ -1,8 +1,12 @@
 # Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-if(${BOARD} STREQUAL "mimxrt685_evk")
+set(TARGET "${BOARD}${BOARD_QUALIFIERS}")
+
+if(${TARGET} STREQUAL "mimxrt685_evk/mimxrt685s/cm33")
   set(REMOTE_BOARD "mimxrt685_evk/mimxrt685s/hifi4")
+elseif(${TARGET} STREQUAL "mimxrt700_evk/mimxrt798s/cm33_cpu0")
+  set(REMOTE_BOARD "mimxrt700_evk/mimxrt798s/hifi4")
 else()
   message(FATAL_ERROR "This example is not supported on the selected board.")
 endif()


### PR DESCRIPTION
This PR modifies the RTxxx AMP samples (`samples/boards/nxp/adsp/rtxxx/*`) for the `mimxrt700_evk/mimxrt798s/hifi4` domain and enables them there.

Hard prerequisites:

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/93647