### PR TITLE
MAINTAINERS: update `hal_nordic` maintainers and contributors

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5282,9 +5282,16 @@ West:
   status: maintained
   maintainers:
     - anangl
+    - nika-nordic
+    - masz-nordic
   collaborators:
     - hubertmis
     - nordic-krch
+    - kl-cruz
+    - magp-nordic
+    - jaz1-nordic
+    - mif1-nordic
+    - adamkondraciuk
   files:
     - modules/hal_nordic/
   labels:


### PR DESCRIPTION
Add missing maintainers and contributirs to `hal_nordic` area.