### PR TITLE
scripts: twister: handlers: Append dev-id for runner nrfutil_next

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -76,7 +76,7 @@ class HardwareAdapter(DeviceAdapter):
             elif runner == "esp32":
                 extra_args.append("--esp-device")
                 extra_args.append(board_id)
-            elif runner in ('nrfjprog', 'nrfutil'):
+            elif runner in ('nrfjprog', 'nrfutil', 'nrfutil_next'):
                 extra_args.append('--dev-id')
                 extra_args.append(board_id)
             elif runner == 'openocd' and self.device_config.product in ['STM32 STLink', 'STLINK-V3']:

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -566,7 +566,7 @@ class DeviceHandler(Handler):
                 board_id = hardware.probe_id or hardware.id
                 product = hardware.product
                 if board_id is not None:
-                    if runner in ("pyocd", "nrfjprog", "nrfutil"):
+                    if runner in ("pyocd", "nrfjprog", "nrfutil", "nrfutil_next"):
                         command_extra_args.append("--dev-id")
                         command_extra_args.append(board_id)
                     elif runner == "esp32":


### PR DESCRIPTION
appends the --dev-id argument when using nrfutil_next runner.