### PR TITLE
dts/boards: nordic: nrf5340: Split partition into s and ns versions

### DIFF
--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp.dts
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp.dts
@@ -24,3 +24,6 @@
 &uicr {
 	nfct-pins-as-gpios;
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -263,6 +263,4 @@ zephyr_udc0: &usbd {
 	};
 };
 
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>
 #include "nrf5340_audio_dk_nrf5340_shared.dtsi"

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.dts
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_ns.dts
@@ -18,3 +18,6 @@
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_ns_partition.dtsi>

--- a/boards/nordic/nrf5340dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340_cpuapp_common.dtsi
@@ -170,6 +170,3 @@ zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
 };
-
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.dts
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,3 +31,6 @@
 		reg = <0x0 0x1>;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.dts
+++ b/boards/nordic/nrf5340dk/nrf5340dk_nrf5340_cpuapp_ns.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,3 +18,6 @@
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_ns_partition.dtsi>

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -244,6 +244,3 @@ zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
 };
-
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp.dts
@@ -35,3 +35,6 @@
 		#include "nrf70_common_5g.dtsi"
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp_nrf7001.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpuapp_nrf7001.dts
@@ -34,3 +34,6 @@
 		#include "nrf70_common.dtsi"
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
@@ -325,6 +325,3 @@ zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
 };
-
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.dts
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp.dts
@@ -42,3 +42,6 @@
 	load-capacitors = "internal";
 	load-capacitance-picofarad = <7>;
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.dts
+++ b/boards/nordic/thingy53/thingy53_nrf5340_cpuapp_ns.dts
@@ -40,3 +40,6 @@
 	load-capacitors = "internal";
 	load-capacitance-picofarad = <7>;
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_ns_partition.dtsi>

--- a/boards/panasonic/pan1783/pan1783_evb_nrf5340_cpuapp.dts
+++ b/boards/panasonic/pan1783/pan1783_evb_nrf5340_cpuapp.dts
@@ -19,3 +19,6 @@
 		zephyr,sram-secure-partition = &sram0_s;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
@@ -268,6 +268,3 @@ zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
 };
-
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/panasonic/pan1783/pan1783a_evb_nrf5340_cpuapp.dts
+++ b/boards/panasonic/pan1783/pan1783a_evb_nrf5340_cpuapp.dts
@@ -19,3 +19,6 @@
 		zephyr,sram-secure-partition = &sram0_s;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/panasonic/pan1783/pan1783a_pa_evb_nrf5340_cpuapp.dts
+++ b/boards/panasonic/pan1783/pan1783a_pa_evb_nrf5340_cpuapp.dts
@@ -28,3 +28,6 @@
 		gpios = <&gpio0 19 0>, <&gpio0 21 0>;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/raytac/an7002q_db/nrf5340_cpuapp_common.dtsi
+++ b/boards/raytac/an7002q_db/nrf5340_cpuapp_common.dtsi
@@ -185,6 +185,3 @@ zephyr_udc0: &usbd {
 
 	status = "okay";
 };
-
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/raytac/an7002q_db/raytac_an7002q_db_nrf5340_cpuapp.dts
+++ b/boards/raytac/an7002q_db/raytac_an7002q_db_nrf5340_cpuapp.dts
@@ -35,3 +35,6 @@
 		#include "nrf70_common_5g.dtsi"
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp.dts
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp.dts
@@ -25,3 +25,6 @@ zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_common.dts
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_common.dts
@@ -204,6 +204,3 @@ zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
 };
-
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.dts
+++ b/boards/raytac/mdbt53_db_40/raytac_mdbt53_db_40_nrf5340_cpuapp_ns.dts
@@ -18,3 +18,6 @@
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_ns_partition.dtsi>

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp.dts
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp.dts
@@ -20,3 +20,6 @@
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_common.dts
@@ -157,6 +157,3 @@
 &ieee802154 {
 	status = "okay";
 };
-
-/* Include default memory partition configuration file */
-#include <nordic/nrf5340_cpuapp_partition.dtsi>

--- a/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_ns.dts
+++ b/boards/raytac/mdbt53v_db_40/raytac_mdbt53v_db_40_nrf5340_cpuapp_ns.dts
@@ -18,3 +18,6 @@
 		zephyr,code-partition = &slot0_ns_partition;
 	};
 };
+
+/* Include default memory partition configuration file */
+#include <nordic/nrf5340_cpuapp_ns_partition.dtsi>

--- a/dts/vendor/nordic/nrf5340_cpuapp_ns_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_cpuapp_ns_partition.dtsi
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Default memory partitioning for nRF5340 application CPU.
+ */
+
+&flash0 {
+	/*
+	 * Default Flash planning for nRF5340 series SoCs.
+	 * This layout matches (by necessity) that in the TF-M repository:
+	 *
+	 * 0x0000_0000 BL2 - MCUBoot (64 KB)
+	 * 0x0001_0000 Primary image area (448 KB):
+	 *    0x0001_0000 Secure     image primary (256 KB)
+	 *    0x0005_0000 Non-secure image primary (192 KB)
+	 * 0x0008_0000 Secondary image area (448 KB):
+	 *    0x0008_0000 Secure     image secondary (256 KB)
+	 *    0x000c_0000 Non-secure image secondary (192 KB)
+	 * 0x000f_0000 Protected Storage Area (16 KB)
+	 * 0x000f_4000 Internal Trusted Storage Area (8 KB)
+	 * 0x000f_6000 OTP / NV counters area (8 KB)
+	 * 0x000f_8000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+	 *             otherwise unused (32 KB)
+	 */
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x10000>;
+		};
+
+		slot0_partition: partition@10000 {
+			compatible = "fixed-subpartitions";
+			label = "image-0";
+			reg = <0x00010000 0x70000>;
+			ranges = <0x0 0x10000 0x70000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot0_s_partition: partition@0 {
+				label = "image-0-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot0_ns_partition: partition@40000 {
+				label = "image-0-nonsecure";
+				reg = <0x00040000 0x30000>;
+			};
+		};
+
+		slot1_partition: partition@80000 {
+			compatible = "fixed-subpartitions";
+			label = "image-1";
+			reg = <0x00080000 0x70000>;
+			ranges = <0x0 0x80000 0x70000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_s_partition: partition@0 {
+				label = "image-1-secure";
+				reg = <0x00000000 0x40000>;
+			};
+
+			slot1_ns_partition: partition@40000 {
+				label = "image-1-nonsecure";
+				reg = <0x00040000 0x30000>;
+			};
+		};
+
+		tfm_ps_partition: partition@f0000 {
+			label = "tfm-ps";
+			reg = <0x000f0000 0x00004000>;
+		};
+
+		tfm_its_partition: partition@f4000 {
+			label = "tfm-its";
+			reg = <0x000f4000 0x00002000>;
+		};
+
+		tfm_otp_partition: partition@f6000 {
+			label = "tfm-otp";
+			reg = <0x000f6000 0x00002000>;
+		};
+
+		storage_partition: partition@f8000 {
+			label = "storage";
+			reg = <0x000f8000 0x00008000>;
+		};
+	};
+};
+
+#include "nrf5340_sram_partition.dtsi"
+#include "nrf5340_shared_sram_partition.dtsi"

--- a/dts/vendor/nordic/nrf5340_cpuapp_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_cpuapp_partition.dtsi
@@ -1,5 +1,6 @@
 /*
  * Copyright 2024 Embeint Inc
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,23 +8,6 @@
  */
 
 &flash0 {
-	/*
-	 * Default Flash planning for nRF5340 series SoCs.
-	 * This layout matches (by necessity) that in the TF-M repository:
-	 *
-	 * 0x0000_0000 BL2 - MCUBoot (64 KB)
-	 * 0x0001_0000 Primary image area (448 KB):
-	 *    0x0001_0000 Secure     image primary (256 KB)
-	 *    0x0005_0000 Non-secure image primary (192 KB)
-	 * 0x0008_0000 Secondary image area (448 KB):
-	 *    0x0008_0000 Secure     image secondary (256 KB)
-	 *    0x000c_0000 Non-secure image secondary (192 KB)
-	 * 0x000f_0000 Protected Storage Area (16 KB)
-	 * 0x000f_4000 Internal Trusted Storage Area (8 KB)
-	 * 0x000f_6000 OTP / NV counters area (8 KB)
-	 * 0x000f_8000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
-	 *             otherwise unused (32 KB)
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -35,56 +19,13 @@
 		};
 
 		slot0_partition: partition@10000 {
-			compatible = "fixed-subpartitions";
 			label = "image-0";
-			reg = <0x00010000 0x70000>;
-			ranges = <0x0 0x10000 0x70000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			slot0_s_partition: partition@0 {
-				label = "image-0-secure";
-				reg = <0x00000000 0x40000>;
-			};
-
-			slot0_ns_partition: partition@40000 {
-				label = "image-0-nonsecure";
-				reg = <0x00040000 0x30000>;
-			};
+			reg = <0x00010000 0x74000>;
 		};
 
-		slot1_partition: partition@80000 {
-			compatible = "fixed-subpartitions";
+		slot1_partition: partition@84000 {
 			label = "image-1";
-			reg = <0x00080000 0x70000>;
-			ranges = <0x0 0x80000 0x70000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			slot1_s_partition: partition@0 {
-				label = "image-1-secure";
-				reg = <0x00000000 0x40000>;
-			};
-
-			slot1_ns_partition: partition@40000 {
-				label = "image-1-nonsecure";
-				reg = <0x00040000 0x30000>;
-			};
-		};
-
-		tfm_ps_partition: partition@f0000 {
-			label = "tfm-ps";
-			reg = <0x000f0000 0x00004000>;
-		};
-
-		tfm_its_partition: partition@f4000 {
-			label = "tfm-its";
-			reg = <0x000f4000 0x00002000>;
-		};
-
-		tfm_otp_partition: partition@f6000 {
-			label = "tfm-otp";
-			reg = <0x000f6000 0x00002000>;
+			reg = <0x00084000 0x74000>;
 		};
 
 		storage_partition: partition@f8000 {
@@ -94,40 +35,5 @@
 	};
 };
 
-/ {
-	/* Default SRAM planning when building for nRF5340 with ARM TF-M support
-	 * - Lowest 256 kB SRAM allocated to Secure image (sram0_s)
-	 * - Upper 256 kB allocated to Non-Secure image (sram0_ns)
-	 * Of the memory allocated to the Non-Secure image
-	 * - 192 kB SRAM allocated to the Non-Secure application (sram0_ns_app).
-	 * - 64 kB allocated to shared memory (sram0_shared).
-	 *   (See nrf5340_shared_sram_partition.dtsi)
-	 */
-	reserved-memory {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		ranges;
-
-		sram0_image: image@20000000 {
-			/* Zephyr image(s) memory */
-			reg = <0x20000000 DT_SIZE_K(448)>;
-		};
-
-		sram0_s: image_s@20000000 {
-			/* Secure image memory */
-			reg = <0x20000000 0x40000>;
-		};
-
-		sram0_ns: image_ns@20040000 {
-			/* Non-Secure image memory */
-			reg = <0x20040000 0x40000>;
-		};
-
-		sram0_ns_app: image_ns_app@20040000 {
-			/* Non-Secure image memory */
-			reg = <0x20040000 0x30000>;
-		};
-	};
-};
-
+#include "nrf5340_sram_partition.dtsi"
 #include "nrf5340_shared_sram_partition.dtsi"

--- a/dts/vendor/nordic/nrf5340_sram_partition.dtsi
+++ b/dts/vendor/nordic/nrf5340_sram_partition.dtsi
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Embeint Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/* Default SRAM planning when building for nRF5340 with ARM TF-M support
+	 * - Lowest 256 kB SRAM allocated to Secure image (sram0_s)
+	 * - Upper 256 kB allocated to Non-Secure image (sram0_ns)
+	 * Of the memory allocated to the Non-Secure image
+	 * - 192 kB SRAM allocated to the Non-Secure application (sram0_ns_app).
+	 * - 64 kB allocated to shared memory (sram0_shared).
+	 *   (See nrf5340_shared_sram_partition.dtsi)
+	 */
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_image: image@20000000 {
+			/* Zephyr image(s) memory */
+			reg = <0x20000000 DT_SIZE_K(448)>;
+		};
+
+		sram0_s: image_s@20000000 {
+			/* Secure image memory */
+			reg = <0x20000000 0x40000>;
+		};
+
+		sram0_ns: image_ns@20040000 {
+			/* Non-Secure image memory */
+			reg = <0x20040000 0x40000>;
+		};
+
+		sram0_ns_app: image_ns_app@20040000 {
+			/* Non-Secure image memory */
+			reg = <0x20040000 0x30000>;
+		};
+	};
+};


### PR DESCRIPTION
Splits up partition configuration for nrf5340-based cpuapp board targets for secure and non-secure versions, the secure version now has an extra 16KiB per slot which was previously wrongly reserved for TF-M partitions which the secure board target does not use