### PR TITLE
drivers: nrf_wifi: Fix defaults to avoid false recovery

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -748,11 +748,12 @@ config NRF_WIFI_RPU_RECOVERY_PS_ACTIVE_TIMEOUT_MS
 
 config NRF_WIFI_RPU_MIN_TIME_TO_ENTER_SLEEP_MS
 	int "Minimum idle time to enter sleep in milliseconds"
-	range 100 5000
-	default 1000
+	range 100 40000
+	default 5000
 	help
 	  Minimum time the host should de-assert WAKEUP_NOW and let RPU enter
-	  sleep mode, assuming there is no activity.
+	  sleep mode, assuming there is no activity. Please note that higher values
+	  of this value may increase the power consumption.
 
 config NRF_WIFI_RPU_RECOVERY_DEBUG
 	bool "RPU recovery debug logs"


### PR DESCRIPTION
In case of a busy environment and if STA is far, then we see many retries for the frames that cause the RPU to be awake though host has de-asserted wakeup_now signal, this leads to WDT interrupt and host thinks that it has given sleep opportunity to RPU and initiates a recovery.

To handle this, increase the sleep opportunity window to 5s to cover all the retries, this solves the false recovery problem. While at it, also increase the range, no reason to limit to lower window. And update the help text with the warning about power consumption.