### PR TITLE
tests: arm64_smc_call: Fix type of result

### DIFF
--- a/tests/arch/arm64/arm64_smc_call/src/main.c
+++ b/tests/arch/arm64/arm64_smc_call/src/main.c
@@ -38,7 +38,7 @@ ZTEST(arm64_smc_call, test_smc_call_func)
 		"Wrong smc call version");
 
 	smc_call(ARM_STD_SMC_UNKNOWN, 0, 0, 0, 0, 0, 0, 0, &res);
-	zassert_true(res.a0 == SMC_UNK, "Wrong return code from smc call");
+	zassert_true((int)res.a0 == SMC_UNK, "Wrong return code from smc call");
 }
 
 ZTEST_SUITE(arm64_smc_call, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The test function test_smc_call_func fails due to a return type mismatch. "res.a0" is an unsigned long that should be cast to the type of SMC_UNK.

Test execution log before applying this fix:
```
START - test_smc_call_func

Assertion failed at WEST_TOPDIR/zephyr/tests/arch/arm64/arm64_smc_call/src/main.c:41: arm64_smc_call_test_smc_call_func: (res.a0 == SMC_UNK is false)
Wrong return code from smc call
 FAIL - test_smc_call_func in 0.018 seconds
```
After applying this fix:
```
START - test_smc_call_func

PASS - test_smc_call_func in 0.001 seconds
```