### PR TITLE
drivers: nrf_wifi: Update default recovery min sleep time

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -749,7 +749,7 @@ config NRF_WIFI_RPU_RECOVERY_PS_ACTIVE_TIMEOUT_MS
 config NRF_WIFI_RPU_MIN_TIME_TO_ENTER_SLEEP_MS
 	int "Minimum idle time to enter sleep in milliseconds"
 	range 100 5000
-	default 1000
+	default 5000
 	help
 	  Minimum time the host should de-assert WAKEUP_NOW and let RPU enter
 	  sleep mode, assuming there is no activity.


### PR DESCRIPTION
Default recovery minimum sleep time set to 5000 ms.