### PR TITLE
include: zephyr: task_wdt: Easily disable Task Watchdog

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -193,6 +193,10 @@ New APIs and options
 
   * :c:func:`sys_count_bits`
 
+* Task Watchdog
+
+  * :kconfig:option:`CONFIG_TASK_WDT_DUMMY`
+
 .. zephyr-keep-sorted-stop
 
 New Boards

--- a/subsys/task_wdt/CMakeLists.txt
+++ b/subsys/task_wdt/CMakeLists.txt
@@ -1,4 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_sources_ifdef(CONFIG_TASK_WDT task_wdt.c)
+if (CONFIG_TASK_WDT_DUMMY)
+    zephyr_sources(task_wdt_dummy.c)
+    message(WARNING "Dummy Task Watchdog implementation is enabled.")
+else()
+    zephyr_sources_ifdef(CONFIG_TASK_WDT task_wdt.c)
+endif()
+
 zephyr_sources_ifdef(CONFIG_TASK_WDT_SHELL task_wdt_shell.c)

--- a/subsys/task_wdt/Kconfig
+++ b/subsys/task_wdt/Kconfig
@@ -13,6 +13,14 @@ menuconfig TASK_WDT
 	  per thread, even if the hardware supports only a single watchdog.
 
 if TASK_WDT
+
+config TASK_WDT_DUMMY
+	bool "Dummy implementation for testing"
+	help
+	  Allows the code to use all Task Watchdog APIs, but does nothing.
+	  This can be useful to temporarily disable the Task Watchdog while
+	  debugging.
+
 config TASK_WDT_CHANNELS
 	int "Maximum number of task watchdog channels"
 	default 5

--- a/subsys/task_wdt/task_wdt_dummy.c
+++ b/subsys/task_wdt/task_wdt_dummy.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 BayLibre SAS
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/logging/log.h>
+#include <zephyr/task_wdt/task_wdt.h>
+
+LOG_MODULE_REGISTER(task_wdt);
+
+int task_wdt_init(const struct device *hw_wdt)
+{
+	ARG_UNUSED(hw_wdt);
+
+	LOG_WRN("Dummy Task Watchdog implementation enabled.");
+
+	return 0;
+}
+
+int task_wdt_add(uint32_t reload_period, task_wdt_callback_t callback,
+		 void *user_data)
+{
+	ARG_UNUSED(reload_period);
+	ARG_UNUSED(callback);
+	ARG_UNUSED(user_data);
+
+	return 0;
+}
+
+int task_wdt_delete(int channel_id)
+{
+	ARG_UNUSED(channel_id);
+
+	return 0;
+}
+
+int task_wdt_feed(int channel_id)
+{
+	ARG_UNUSED(channel_id);
+
+	return 0;
+}
+
+void task_wdt_suspend(void)
+{
+}
+
+void task_wdt_resume(void)
+{
+}


### PR DESCRIPTION
The Task Watchdog can fire when a board is halted on a breakpoint during a debugging session.

These changes allow to easily neutralize the Task Watchdog by just setting `CONFIG_TASK_WDT=n` without having to comment all the Task Watchdog API function calls.

I used a `#ifdef` per function to avoid duplicating the comments.