### PR TITLE
drivers: dma: stm32: take "stream offset" into account when DMAV1 + DMAMUX is used

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -249,7 +249,7 @@ static int adc_stm32_dma_start(const struct device *dev,
 	dma->dma_cfg.head_block = blk_cfg;
 	dma->dma_cfg.user_data = data;
 
-	ret = dma_config(data->dma.dma_dev, data->dma.channel,
+	ret = dma_config(data->dma.dma_dev, data->dma.channel + STM32_DMA_STREAM_OFFSET,
 			 &dma->dma_cfg);
 	if (ret != 0) {
 		LOG_ERR("Problem setting up DMA: %d", ret);

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -105,8 +105,9 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		dma_stm32_clear_stream_irq(dev, id);
 		return;
 	}
+
 #ifdef CONFIG_DMAMUX_STM32
-	callback_arg = stream->mux_channel;
+	callback_arg = stream->mux_channel + STM32_DMA_STREAM_OFFSET;
 #else
 	callback_arg = id + STM32_DMA_STREAM_OFFSET;
 #endif /* CONFIG_DMAMUX_STM32 */

--- a/drivers/dma/dma_stm32u5.c
+++ b/drivers/dma/dma_stm32u5.c
@@ -265,9 +265,9 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 		dma_stm32_clear_stream_irq(dev, id);
 		return;
 	}
-	callback_arg = id + STM32_DMA_STREAM_OFFSET;
+	callback_arg = id;
 
-	/* The dma stream id is in range from STM32_DMA_STREAM_OFFSET..<dma-requests> */
+	/* The dma stream id is in range from 0..<dma-requests> */
 	if (stm32_dma_is_ht_irq_active(dma, id)) {
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
@@ -349,15 +349,11 @@ static int dma_stm32_configure(const struct device *dev,
 					     struct dma_config *config)
 {
 	const struct dma_stm32_config *dev_config = dev->config;
-	struct dma_stm32_stream *stream =
-				&dev_config->streams[id - STM32_DMA_STREAM_OFFSET];
+	struct dma_stm32_stream *stream = &dev_config->streams[id];
 	DMA_TypeDef *dma = (DMA_TypeDef *)dev_config->base;
 	uint32_t ll_priority;
 	uint32_t ll_direction;
 	int ret;
-
-	/* Give channel from index 0 */
-	id = id - STM32_DMA_STREAM_OFFSET;
 
 	if (id >= dev_config->max_streams) {
 		LOG_ERR("cannot configure the dma stream %d.", id);
@@ -553,9 +549,6 @@ static int dma_stm32_reload(const struct device *dev, uint32_t id,
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_stream *stream;
 
-	/* Give channel from index 0 */
-	id = id - STM32_DMA_STREAM_OFFSET;
-
 	if (id >= config->max_streams) {
 		return -EINVAL;
 	}
@@ -590,9 +583,6 @@ static int dma_stm32_start(const struct device *dev, uint32_t id)
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_stream *stream;
 
-	/* Give channel from index 0 */
-	id = id - STM32_DMA_STREAM_OFFSET;
-
 	/* Only M2P or M2M mode can be started manually. */
 	if (id >= config->max_streams) {
 		return -EINVAL;
@@ -619,9 +609,6 @@ static int dma_stm32_suspend(const struct device *dev, uint32_t id)
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 
-	/* Give channel from index 0 */
-	id = id - STM32_DMA_STREAM_OFFSET;
-
 	if (id >= config->max_streams) {
 		return -EINVAL;
 	}
@@ -642,9 +629,6 @@ static int dma_stm32_resume(const struct device *dev, uint32_t id)
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 
-	/* Give channel from index 0 */
-	id = id - STM32_DMA_STREAM_OFFSET;
-
 	if (id >= config->max_streams) {
 		return -EINVAL;
 	}
@@ -658,11 +642,8 @@ static int dma_stm32_resume(const struct device *dev, uint32_t id)
 static int dma_stm32_stop(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
-	struct dma_stm32_stream *stream = &config->streams[id - STM32_DMA_STREAM_OFFSET];
+	struct dma_stm32_stream *stream = &config->streams[id];
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
-
-	/* Give channel from index 0 */
-	id = id - STM32_DMA_STREAM_OFFSET;
 
 	if (id >= config->max_streams) {
 		return -EINVAL;
@@ -723,8 +704,6 @@ static int dma_stm32_get_status(const struct device *dev,
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 	struct dma_stm32_stream *stream;
 
-	/* Give channel from index 0 */
-	id = id - STM32_DMA_STREAM_OFFSET;
 	if (id >= config->max_streams) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
Depending on the series in use dma_config should take into account a stream offset for the channel in use.

Fixes #93617