### PR TITLE
tests: arm: sw_vector_table: only build mcxa test for MCXA platforms

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -257,11 +257,12 @@ const vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
 	[_ISR_OFFSET] = isr0,
 	[_ISR_OFFSET + 1] = isr1,
 	[_ISR_OFFSET + 2] = isr2,
-#ifndef CONFIG_CORTEX_M_SYSTICK
+#if defined(TIMER_IRQ_HANDLER) && !defined(CONFIG_CORTEX_M_SYSTICK)
 	[TIMER_IRQ_NUM] = TIMER_IRQ_HANDLER,
 #endif
 };
-#endif /* CONFIG_SOC_FAMILY_NORDIC_NRF */
+
+#endif
 
 /**
  * @}


### PR DESCRIPTION
There's some extra test code that has been introduced in 4c93fcd35b2, apparently for MCXA specifically, but it's been written in a way that it tries to build for all patforms.

In some cases it fails for TIMER_IRQ_NUM undeclared.

Wrap the new code in a CONFIG_SOC_FAMILY_MCXA so it's only build for the platform it was intended to.

Also drop a closing endif comment as that clearly became incorrect.