### PR TITLE
shell: Restore uninit_cb that was lost in #93154

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1393,6 +1393,7 @@ void shell_uninit(const struct shell *sh, shell_uninit_cb_t cb)
 	__ASSERT_NO_MSG(sh);
 
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
+		sh->ctx->uninit_cb = cb;
 		k_event_post(&sh->ctx->signal_event, SHELL_SIGNAL_KILL);
 		return;
 	}


### PR DESCRIPTION
The sh->ctx->uninit_cb needs to be set before posting the SHELL_SIGNAL_KILL to the event, like the k_poll based code did prior to