### PR TITLE
snippets: xen_dom0: Add qemu_cortex_a53/smp support

### DIFF
--- a/snippets/xen_dom0/snippet.yml
+++ b/snippets/xen_dom0/snippet.yml
@@ -7,6 +7,9 @@ boards:
   qemu_cortex_a53/qemu_cortex_a53:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/qemu_cortex_a53.overlay
+  qemu_cortex_a53/qemu_cortex_a53/smp:
+    append:
+      EXTRA_DTC_OVERLAY_FILE: boards/qemu_cortex_a53.overlay
   rcar_h3ulcb/r8a77951/a57:
     append:
       EXTRA_DTC_OVERLAY_FILE: boards/rcar_h3ulcb_r8a77951_a57.overlay


### PR DESCRIPTION
Make the SMP version of qemu_cortex_a53 applicable to the xen_dom0 snippet.