### PR TITLE
adc: Fix C++ initialization for channel cfg

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -259,10 +259,11 @@ struct adc_channel_cfg {
 	.reference        = DT_STRING_TOKEN(node_id, zephyr_reference), \
 	.acquisition_time = DT_PROP(node_id, zephyr_acquisition_time), \
 	.channel_id       = DT_REG_ADDR(node_id), \
-IF_ENABLED(UTIL_OR(DT_PROP(node_id, zephyr_differential), \
+COND_CODE_1(UTIL_OR(DT_PROP(node_id, zephyr_differential), \
 		   UTIL_AND(CONFIG_ADC_CONFIGURABLE_INPUTS, \
 			    DT_NODE_HAS_PROP(node_id, zephyr_input_negative))), \
-	(.differential    = true,)) \
+	(.differential    = true,), \
+	(.differential    = false,)) \
 IF_ENABLED(CONFIG_ADC_CONFIGURABLE_INPUTS, \
 	(.input_positive  = DT_PROP_OR(node_id, zephyr_input_positive, 0), \
 	 .input_negative  = DT_PROP_OR(node_id, zephyr_input_negative, 0),)) \


### PR DESCRIPTION
When compiling with -Werror=missing-field-initializers and the differential is disabled, we get a compilation error for the ADC drivers. We should still initialize the value to false.