### PR TITLE
bluetooth: settings: Make BT name persistance an option

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -278,6 +278,15 @@ config BT_SETTINGS_CCC_STORE_MAX
 	  Defines the max number of Client Characteristic Configuration (CCC)
 	  that the stack can handle
 
+config BT_SETTINGS_BT_NAME_STORE
+	bool "Store the BT name as setting"
+	depends on BT_DEVICE_NAME_DYNAMIC
+	default y
+	help
+	  When selected, the name that is set when calling @ref bt_set_name
+	  will be stored persistently and automatically set as BT name at
+	  each boot
+
 endif # BT_SETTINGS
 
 config BT_FILTER_ACCEPT_LIST

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -4563,7 +4563,7 @@ int bt_set_name(const char *name)
 	memcpy(bt_dev.name, name, len);
 	bt_dev.name[len] = '\0';
 
-	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+	if (IS_ENABLED(CONFIG_BT_SETTINGS_BT_NAME_STORE)) {
 		err = bt_settings_store_name(bt_dev.name, len);
 		if (err) {
 			LOG_WRN("Unable to store name");

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -180,7 +180,7 @@ static int set_setting(const char *name, size_t len_rd, settings_read_cb read_cb
 		return 0;
 	}
 
-#if defined(CONFIG_BT_DEVICE_NAME_DYNAMIC)
+#if defined(CONFIG_BT_SETTINGS_BT_NAME_STORE)
 	if (!strncmp(name, "name", len)) {
 		len = read_cb(cb_arg, &bt_dev.name, sizeof(bt_dev.name) - 1);
 		if (len < 0) {
@@ -414,10 +414,12 @@ int bt_settings_delete_hash(void)
 	return bt_settings_delete("hash", 0, NULL);
 }
 
+#if defined(CONFIG_BT_SETTINGS_BT_NAME_STORE)
 int bt_settings_store_name(const void *value, size_t val_len)
 {
 	return bt_settings_store("name", 0, NULL, value, val_len);
 }
+#endif
 
 int bt_settings_delete_name(void)
 {


### PR DESCRIPTION
The device's BT name can be set/changed using API call bt_set_name() when CONFIG_BT_DEVICE_NAME_DYNAMIC is enabled. If BT settings are also enabled, the BT name set through the above mentioned API call will also be stored peristently in the settings partition. Then at each boot, the name setting is restored and set as BT name.

This behavior of automatically setting the BT name at each boot from a value that was set in a previous boot is not be desired by all API users.

This commit introduces CONFIG_BT_SETTINGS_BT_NAME_STORE configuration option that gives the user the option to choose if it wants to restore the BT name from persistent memory.