### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -328,7 +328,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 6e5961223f81aa2707c555db138819a5c1b7942c
+      revision: 8b6001d6bdd9e2c8bb858fdb26f696f6d5f73db5
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 00801cbaf83600ba9e39b010928401e817a93fdc


### PR DESCRIPTION
Update the HW models module to:
8b6001d6bdd9e2c8bb858fdb26f696f6d5f73db5

Including the following:

- 8b6001d CLOCK (54): Fix XOTUNE subscription sideeffecting for nrf54L15 
- 9af1ac8 nRF54LM20: Bugfix: Add missing UART configuration 
- e6af4a7 RADIO: Fix register init for some devices (at least nRF54LM20) 
- 2fe99ab CLOCK (54): Add XO24M/PLL24M/HFCLK24M
- ffd578a CLOCK (54): Fixes around XOTUNE