### PR TITLE
modules: cmsis, cmsis_6: only add the intended cmsis module

### DIFF
--- a/arch/arm/include/cortex_m/dwt.h
+++ b/arch/arm/include/cortex_m/dwt.h
@@ -36,14 +36,11 @@ extern "C" {
  * update to CMSIS_6.
  */
 #if !defined DWT_LSR_Present_Msk
-#define DWT_LSR_Present_Msk \
-	IF_ENABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_Present_Msk)) \
-	IF_DISABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_PRESENT_Msk))
+#define DWT_LSR_Present_Msk ITM_LSR_PRESENT_Msk
 #endif
+
 #if !defined DWT_LSR_Access_Msk
-#define DWT_LSR_Access_Msk \
-	IF_ENABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_Access_Msk)) \
-	IF_DISABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_ACCESS_Msk))
+#define DWT_LSR_Access_Msk ITM_LSR_ACCESS_Msk
 #endif
 
 static inline void dwt_access(bool ena)

--- a/modules/cmsis/CMakeLists.txt
+++ b/modules/cmsis/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} cmsis)
-
 if(CONFIG_CPU_AARCH32_CORTEX_A OR CONFIG_CPU_AARCH32_CORTEX_R)
+  add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} cmsis)
   zephyr_include_directories(.)
 endif()

--- a/modules/cmsis_6/CMakeLists.txt
+++ b/modules/cmsis_6/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} cmsis_6)
-
 if(CONFIG_CPU_CORTEX_M)
+  add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR} cmsis_6)
   zephyr_include_directories(.)
 endif()

--- a/west.yml
+++ b/west.yml
@@ -154,7 +154,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 84ccbfc0b6041ba9f5688337c78bad99da5448ce
+      revision: e9212585cd7c4e1cc189f7d530b8a028d5e8ecf5
       path: modules/hal/ambiq
       groups:
         - hal
@@ -195,7 +195,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 32a79d481c056b2204a5701d5a5799f9e5130dd7
+      revision: 415c92d3c8bd3d62db35980729df42be1f178023
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
The current code base is meant to use cmsis for Cortex A and R and cmsis_6 for Cortex M, but the build system is configured to include the path for both when Cortex M is selected. This leaves us exposed to PR using the old headers, that would not get caught in CI but would fail the build on a project using Cortex M that only has the cmsis_6 module.
 
Change the cmsis module setting to only include the module files in the intended case.

Deps
- https://github.com/zephyrproject-rtos/hal_microchip/pull/35
- https://github.com/zephyrproject-rtos/hal_ambiq/pull/56
- https://github.com/zephyrproject-rtos/hal_silabs/pull/122