### PR TITLE
MAINTAINERS: add Seeed Studio platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4332,6 +4332,14 @@ Secure storage:
   tests:
     - psa.secure_storage
 
+Seeed Studio Platforms:
+  status: odd fixes
+  files:
+    - boards/seeed/
+    - boards/shields/seeed_*/
+  labels:
+    - "platform: Seeed Studio"
+
 Sensor Subsystem:
   status: maintained
   maintainers:


### PR DESCRIPTION
Add Seeed Studio as a platform initially unmaintained with rules to match boards and shields.

This should make it easier if someone (ideally from Seeed Studio) would like to step up to maintain that platform.