### PR TITLE
Introduce `CONFIG_PM_DEVICE_RUNTIME_DEFAULT_ENABLE`

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -173,6 +173,7 @@ New APIs and options
 * Power management
 
    * :c:func:`pm_device_driver_deinit`
+   * :kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_DEFAULT_ENABLE`
 
 * Settings
 

--- a/doc/services/pm/device_runtime.rst
+++ b/doc/services/pm/device_runtime.rst
@@ -32,8 +32,10 @@ in response to :c:func:`pm_device_runtime_get` and :c:func:`pm_device_runtime_pu
 calls on the child device.
 
 For the previous to automatically control the power domain state, device runtime PM must be enabled
-on the power domain device (either through the ``zephyr,pm-device-runtime-auto`` devicetree property
-or :c:func:`pm_device_runtime_enable`).
+on the power domain device. To enable device runtime PM globally, enable
+:kconfig:option:`CONFIG_PM_DEVICE_RUNTIME_DEFAULT_ENABLE`. To enable device runtime PM only for
+select devices, set the ``zephyr,pm-device-runtime-auto`` devicetree property, or use
+:c:func:`pm_device_runtime_enable` for the select devices.
 
 .. graphviz::
    :caption: Device states and transitions

--- a/soc/nordic/common/Kconfig.defconfig
+++ b/soc/nordic/common/Kconfig.defconfig
@@ -6,3 +6,6 @@ if RISCV_CORE_NORDIC_VPR
 rsource "vpr/Kconfig.defconfig"
 
 endif # RISCV_CORE_NORDIC_VPR
+
+config PM_DEVICE_RUNTIME_DEFAULT_ENABLE
+	default y if PM_DEVICE_RUNTIME

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -177,6 +177,15 @@ endif #PM_DEVICE_RUNTIME_USE_DEDICATED_WQ
 endchoice
 
 endif # PM_DEVICE_RUNTIME_ASYNC
+
+config PM_DEVICE_RUNTIME_DEFAULT_ENABLE
+	bool "PM device runtime enable by default"
+	help
+	  Enable PM device runtime by default for all devices when they are
+	  initialized. This option is identical to adding the devicetree
+	  property zephyr,pm-device-runtime-auto to all nodes in the
+	  devicetree.
+
 endif # PM_DEVICE_RUNTIME
 
 config PM_DEVICE_SHELL

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -388,7 +388,8 @@ int pm_device_driver_init(const struct device *dev,
 
 	/* If device will have PM device runtime enabled */
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) &&
-	    atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_AUTO)) {
+	    (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME_DEFAULT_ENABLE) ||
+	     atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_AUTO))) {
 		return 0;
 	}
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -401,10 +401,15 @@ int pm_device_runtime_auto_enable(const struct device *dev)
 {
 	struct pm_device_base *pm = dev->pm_base;
 
-	/* No action needed if PM_DEVICE_FLAG_RUNTIME_AUTO is not enabled */
-	if (!pm || !atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_AUTO)) {
+	if (!pm) {
 		return 0;
 	}
+
+	if (!IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME_DEFAULT_ENABLE) &&
+	    !atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_AUTO)) {
+		return 0;
+	}
+
 	return pm_device_runtime_enable(dev);
 }
 


### PR DESCRIPTION
Introduce the option `config PM_DEVICE_RUNTIME_DEFAULT_ENABLE` which effectively implicitly adds the devicetree flag `zephyr,pm-device-runtime-auto` to every node in the devicetree. In reality, it ignores the flag and enables PM_DEVICE_RUNTIME unconditionally, but the behavior is identical from the outside.

Typically, SoCs which utilize PM_DEVICE_RUNTIME need it enabled for every device. Having to add a flag manually to every node all of the devicetrees for these SoCs is tedious and error prone. It is also a software property being set in the devicetree, so in multiple ways a problematic pattern.

Most of nordics SoCs require all devices to enable `PM_DEVICE_RUNTIME` if `PM_DEVICE_RUNTIME` is enabled, and the rest are not harmed by it since they have additional logic in the drivers to deal with runtime not being enabled (which can be optimized away by this change). It looks like this also is the case for Ambiq Apollo (@AlessandroLuo @RichardSWheatley @aaronyegx) and Xtensa Ace (@dcpleung @andyross @nashif), please check if this option would be helpful for your platforms as well :)

With the addition in this PR, we will stop running into issues like:
* https://github.com/zephyrproject-rtos/zephyr/pull/93937
* https://github.com/zephyrproject-rtos/zephyr/pull/94399