### PR TITLE
drivers: flash_mspi_nor: Make transfer timeout configurable

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -27,7 +27,7 @@ void flash_mspi_command_set(const struct device *dev, const struct flash_mspi_no
 	dev_data->xfer.xfer_mode  = MSPI_PIO;
 	dev_data->xfer.packets    = &dev_data->packet;
 	dev_data->xfer.num_packet = 1;
-	dev_data->xfer.timeout    = 10;
+	dev_data->xfer.timeout    = dev_config->transfer_timeout;
 
 	dev_data->xfer.cmd_length = cmd->cmd_length;
 	dev_data->xfer.addr_length = cmd->addr_length;
@@ -887,6 +887,7 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 				/ 1000,						\
 		.reset_recovery_us = DT_INST_PROP_OR(inst, t_reset_recovery, 0)	\
 				   / 1000,))					\
+		.transfer_timeout = DT_INST_PROP(inst, transfer_timeout),	\
 		FLASH_PAGE_LAYOUT_DEFINE(inst)					\
 		.jedec_id = DT_INST_PROP(inst, jedec_id),			\
 		.jedec_cmds = FLASH_CMDS(inst),					\

--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -35,6 +35,7 @@ struct flash_mspi_nor_config {
 	uint32_t reset_pulse_us;
 	uint32_t reset_recovery_us;
 #endif
+	uint32_t transfer_timeout;
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 	struct flash_pages_layout layout;
 #endif

--- a/dts/bindings/mtd/jedec,mspi-nor.yaml
+++ b/dts/bindings/mtd/jedec,mspi-nor.yaml
@@ -22,3 +22,11 @@ properties:
     type: int
     description: |
       Minimum time, in nanoseconds, the flash chip needs to recover after reset.
+
+  transfer-timeout:
+    type: int
+    default: 10
+    description: |
+      Maximum time, in milliseconds, allowed for a single transfer on the MSPI
+      bus in communication with the flash chip. The default value is the one
+      that was previously hard-coded in the flash_mspi_nor driver.


### PR DESCRIPTION
Although the value currently hard-coded in the driver (10 ms) is quite high, it may turn out to be insufficient when there is a need to use some very low SCK frequency, like 250 kHz.
Make the timeout value configurable per-instance, via devicetree.