### PR TITLE
PM DEVICE RUNTIME: Ifdef out unused events if PM_DEVICE_RUNTIME_ASYNC=n

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -168,9 +168,9 @@ struct pm_device {
 	const struct device *dev;
 	/** Lock to synchronize the get/put operations */
 	struct k_sem lock;
+#if defined(CONFIG_PM_DEVICE_RUNTIME_ASYNC) || defined(__DOXYGEN__)
 	/** Event var to listen to the sync request events */
 	struct k_event event;
-#if defined(CONFIG_PM_DEVICE_RUNTIME_ASYNC) || defined(__DOXYGEN__)
 	/** Work object for asynchronous calls */
 	struct k_work_delayable work;
 #endif /* CONFIG_PM_DEVICE_RUNTIME_ASYNC */
@@ -199,10 +199,13 @@ BUILD_ASSERT(offsetof(struct pm_device_isr, base) == 0);
 
 /** @cond INTERNAL_HIDDEN */
 
-#ifdef CONFIG_PM_DEVICE_RUNTIME
+#ifdef CONFIG_PM_DEVICE_RUNTIME_ASYNC
 #define Z_PM_DEVICE_RUNTIME_INIT(obj)			\
 	.lock = Z_SEM_INITIALIZER(obj.lock, 1, 1),	\
 	.event = Z_EVENT_INITIALIZER(obj.event),
+#elif CONFIG_PM_DEVICE_RUNTIME
+#define Z_PM_DEVICE_RUNTIME_INIT(obj)			\
+	.lock = Z_SEM_INITIALIZER(obj.lock, 1, 1),
 #else
 #define Z_PM_DEVICE_RUNTIME_INIT(obj)
 #endif /* CONFIG_PM_DEVICE_RUNTIME */

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -115,7 +115,6 @@ config PM_DEVICE_POWER_DOMAIN_DYNAMIC_NUM
 
 config PM_DEVICE_RUNTIME
 	bool "Runtime Device Power Management"
-	select EVENTS
 	help
 	  Enable Runtime Power Management to save power. With device runtime PM
 	  enabled, devices can be suspended or resumed based on the device
@@ -128,6 +127,7 @@ config PM_DEVICE_DRIVER_NEEDS_DEDICATED_WQ
 
 config PM_DEVICE_RUNTIME_ASYNC
 	bool "Asynchronous device runtime power management"
+	select EVENTS
 	default y
 	help
 	  Use this option to enable support for asynchronous operation


### PR DESCRIPTION
The `struct k_event event` is only used if `CONFIG_PM_DEVICE_RUNTIME_ASYNC` is selected, but `EVENTS` is selected, and the `struct k_event` included in the `struct pm_device_base` if `CONFIG_PM_DEVICE_RUNTIME` is selected.

Correct to only include event and EVENTS if `CONFIG_PM_DEVICE_RUNTIME_ASYNC` is selected.