### PR TITLE
arch: arm: dwt: select the DWM macro based on the architecture

### DIFF
--- a/arch/arm/include/cortex_m/dwt.h
+++ b/arch/arm/include/cortex_m/dwt.h
@@ -36,15 +36,20 @@ extern "C" {
  * update to CMSIS_6.
  */
 #if !defined DWT_LSR_Present_Msk
-#define DWT_LSR_Present_Msk \
-	IF_ENABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_Present_Msk)) \
-	IF_DISABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_PRESENT_Msk))
+#ifdef CONFIG_CPU_CORTEX_M
+#define DWT_LSR_Present_Msk ITM_LSR_PRESENT_Msk
+#else
+#define DWT_LSR_Present_Msk ITM_LSR_Present_Msk
 #endif
+#endif /*!defined DWT_LSR_Present_Msk */
+
 #if !defined DWT_LSR_Access_Msk
-#define DWT_LSR_Access_Msk \
-	IF_ENABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_Access_Msk)) \
-	IF_DISABLED(CONFIG_ZEPHYR_CMSIS_MODULE, (ITM_LSR_ACCESS_Msk))
+#ifdef CONFIG_CPU_CORTEX_M
+#define DWT_LSR_Access_Msk ITM_LSR_ACCESS_Msk
+#else
+#define DWT_LSR_Access_Msk ITM_LSR_Access_Msk
 #endif
+#endif /* !defined DWT_LSR_Access_Msk */
 
 static inline void dwt_access(bool ena)
 {


### PR DESCRIPTION
Change the selector for the DWT_LSR_Present_Msk and DWT_LSR_Access_Msk aliases to be based on the architecture rather than which module is present in the system. This makes the module build correctly if the cmsis module is present but not used and cmsis_6 is supposed to be used instead (i.e. for Cortex-M).