### PR TITLE
tests: drivers: spi: drop non existing board

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -115,5 +115,4 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk/nrf54h20/cpuppr
-      - nrf54l20pdk/nrf54l20/cpuapp
       - ophelia4ev/nrf54l15/cpuapp


### PR DESCRIPTION
nrf54l20pdk has been dropped in 878ddbe2f6c.