### PR TITLE
arch: riscv: decouple mtval usefulness for FP traps from QEMU target

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -492,6 +492,26 @@ config ARCH_HAS_STACKWALK
 	  Internal config to indicate that the arch_stack_walk() API is implemented
 	  and it can be enabled.
 
+config RISCV_NO_MTVAL_ON_FP_TRAP
+	bool
+	default y if QEMU_TARGET
+	help
+	  This implementation does not provide useful information in the mtval
+	  CSR (Machine Trap Value register) when floating-point illegal
+	  instruction exceptions occur.
+
+	  The RISC-V specification allows implementations to decide on a
+	  case-by-case basis when mtval contains meaningful values. The spec
+	  states that mtval is "either set to zero or written with
+	  exception-specific information" on traps. However, this
+	  "exception-specific information" may not necessarily be the faulting
+	  instruction value, and implementations have flexibility in what they
+	  provide.
+
+	  When this option is enabled, the mtval content cannot be relied upon
+	  to contain the faulting FP instruction, requiring alternative methods
+	  to handle FP exceptions.
+
 rsource "Kconfig.isa"
 
 endmenu

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -225,7 +225,7 @@ SECTION_FUNC(exception.entry, _isr_wrapper)
 	bne t1, t2, no_fp
 	/* determine if we trapped on an FP instruction. */
 	csrr t2, mtval		/* get faulting instruction */
-#ifdef CONFIG_QEMU_TARGET
+#ifdef RISCV_NO_MTVAL_ON_FP_TRAP
 	/*
 	 * Some implementations may not support MTVAL in this capacity.
 	 * Notably QEMU when a CSR instruction is involved.


### PR DESCRIPTION
Introduce CONFIG_RISCV_NO_MTVAL_ON_FP_TRAP to handle implementations where the mtval CSR does not provide useful information during floating-point illegal instruction exceptions.

The RISC-V specification states that mtval is "either set to zero or written with exception-specific information" on traps. Some implementations, including QEMU, do not populate mtval with the faulting instruction value during FP-related illegal instruction exceptions, making it unusable for FP exception handling.

Previously, this behavior was hardcoded for QEMU targets only, but other CPU implementations may also lack useful mtval content for FP traps. Decoupling this from CONFIG_QEMU_TARGET and allows other platforms to properly declare this limitation.

The new Kconfig option defaults to enabled for QEMU targets to maintain backward compatibility.