### PR TITLE
drivers: spi: Fix twister invalid board

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -115,5 +115,6 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
       - nrf54h20dk/nrf54h20/cpuppr
-      - nrf54l20pdk/nrf54l20/cpuapp
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - ophelia4ev/nrf54l15/cpuapp


### PR DESCRIPTION
Fix the board name for 54L15.

Fixes CI twister failure: https://github.com/zephyrproject-rtos/zephyr/actions/runs/16526466682/job/46740958005?pr=93726