### PR TITLE
Bluetooth: Classic: SDP: Improve SDP discovery response

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -50,11 +50,13 @@ LOG_MODULE_REGISTER(bt_sdp);
 #define SDP_SS_CONT_STATE_SIZE 3
 
 /* 1 byte for the no. of attributes searched till this response */
-#define SDP_SA_CONT_STATE_SIZE 1
+/* 4 bytes for the index of current attribute searched till this response */
+#define SDP_SA_CONT_STATE_SIZE 5
 
 /* 1 byte for the no. of services searched till this response */
 /* 1 byte for the no. of attributes searched till this response */
-#define SDP_SSA_CONT_STATE_SIZE 2
+/* 4 bytes for the index of current attribute searched till this response */
+#define SDP_SSA_CONT_STATE_SIZE 6
 
 #define SDP_INVALID 0xff
 
@@ -121,6 +123,7 @@ struct search_state {
 	uint16_t att_list_size;
 	uint8_t  current_svc;
 	uint8_t  last_att;
+	uint32_t last_att_index;
 	bool     pkt_full;
 };
 
@@ -719,42 +722,106 @@ static uint16_t sdp_svc_search_req(struct bt_sdp *sdp, struct net_buf *buf,
 
 /* @brief Copies an attribute into an outgoing buffer
  *
+ * This function handles partial copying of attributes into a response buffer
+ * with careful management of offsets, indices, and remaining space.
+ *
+ * @param buf Destination network buffer for attribute data
+ * @param data Source attribute data
+ * @param length Total length of attribute data
+ * @param offset Current offset in the attribute data
+ * @param index Current index tracking progress
+ * @param space Remaining available space in the buffer
+ *
+ * @return Number of bytes copied or 0 if no bytes copied
+ */
+static uint16_t copy_attribute_from_buf(struct net_buf *buf, const uint8_t *data, uint32_t length,
+					uint32_t *offset, uint32_t *index, uint16_t *space)
+{
+	uint32_t end;
+	uint32_t start = *offset;
+	uint16_t len;
+
+	end = start + length;
+	*offset = end;
+
+	/* Copied data range is start ~ end */
+	if (*index < start) {
+		len = MIN(length, *space);
+		net_buf_add_mem(buf, data, len);
+		*space -= len;
+		*index += len;
+		return len;
+	}
+
+	/* Copied data range is *index ~ end */
+	if (*index < end) {
+		len = end - *index;
+		len = MIN(len, *space);
+		net_buf_add_mem(buf, &data[*index - start], len);
+		*space -= len;
+		*index += len;
+		return len;
+	}
+
+	return 0;
+}
+
+/* @brief Copies an attribute into an outgoing buffer
+ *
  *  Copies an attribute into a buffer. Recursively calls itself for complex
  *  attributes.
  *
  *  @param elem Attribute to be copied to the buffer
  *  @param buf Buffer where the attribute is to be copied
+ *  @param offset Pointer to the current offset in the attribute
+ *  @param index Pointer to the current index for partial copying
+ *  @param space Pointer to the remaining buffer space
+ *  @param nest_level Current nesting level of the attribute
  *
  *  @return Size of the last data element that has been searched
  *  (used in recursion)
  */
-static uint32_t copy_attribute(struct bt_sdp_data_elem *elem,
-			    struct net_buf *buf, uint8_t nest_level)
+static uint32_t copy_attribute(const struct bt_sdp_data_elem *elem, struct net_buf *buf,
+			       uint32_t *offset, uint32_t *index, uint16_t *space,
+			       uint8_t nest_level)
 {
-	const uint8_t *cur_elem;
+	const struct bt_sdp_data_elem *sub_elem;
 	uint32_t size, seq_size, total_size;
+	uint16_t copy_len = 0;
+	uint32_t total_len = 0;
+
+	NET_BUF_SIMPLE_DEFINE(attr_buf, 21); /* 1 + 4 + 16 bytes */
 
 	/* Limit recursion depth to avoid stack overflows */
 	if (nest_level == SDP_DATA_ELEM_NEST_LEVEL_MAX) {
 		return 0;
 	}
 
+	if (*space == 0) {
+		return 0;
+	}
+
 	seq_size = elem->data_size;
 	total_size = elem->total_size;
-	cur_elem = elem->data;
+	sub_elem = (const struct bt_sdp_data_elem *)elem->data;
+
+	__ASSERT(!((nest_level == 1) && (*index >= total_size)), "Invalid attr index %u >= %u",
+		 *index, total_size);
 
 	/* Copy the header */
-	net_buf_add_u8(buf, elem->type);
+	net_buf_simple_reset(&attr_buf);
+
+	net_buf_simple_add_u8(&attr_buf, elem->type);
 
 	switch (total_size - (seq_size + 1U)) {
 	case 1:
-		net_buf_add_u8(buf, elem->data_size);
+		net_buf_simple_add_u8(&attr_buf, elem->data_size);
 		break;
 	case 2:
-		net_buf_add_be16(buf, elem->data_size);
+		net_buf_simple_add_be16(&attr_buf, elem->data_size);
 		break;
 	case 4:
-		net_buf_add_be32(buf, elem->data_size);
+		net_buf_simple_add_be32(&attr_buf, elem->data_size);
 		break;
 	}
 
@@ -763,36 +830,73 @@ static uint32_t copy_attribute(struct bt_sdp_data_elem *elem,
 	 */
 	if ((elem->type & BT_SDP_TYPE_DESC_MASK) == BT_SDP_SEQ_UNSPEC ||
 	    (elem->type & BT_SDP_TYPE_DESC_MASK) == BT_SDP_ALT_UNSPEC) {
+		copy_len = copy_attribute_from_buf(buf, attr_buf.data, attr_buf.len, offset,
+						   index, space);
+		total_len += copy_len;
+		if (*space == 0) {
+			goto exit;
+		}
+
 		do {
-			size = copy_attribute((struct bt_sdp_data_elem *)
-					      cur_elem, buf, nest_level + 1);
-			cur_elem += sizeof(struct bt_sdp_data_elem);
-			seq_size -= size;
+			size = copy_attribute(sub_elem, buf, offset, index, space, nest_level + 1);
+			total_len += size;
+			if (*space == 0) {
+				goto exit;
+			}
+
+			__ASSERT(seq_size >= sub_elem->total_size, "Invalid sequence size %u < %u",
+				 seq_size, sub_elem->total_size);
+			seq_size -= sub_elem->total_size;
+			sub_elem++;
 		} while (seq_size);
 	} else if ((elem->type & BT_SDP_TYPE_DESC_MASK) == BT_SDP_UINT8 ||
 		   (elem->type & BT_SDP_TYPE_DESC_MASK) == BT_SDP_INT8 ||
 		   (elem->type & BT_SDP_TYPE_DESC_MASK) == BT_SDP_UUID_UNSPEC) {
 		if (seq_size == 1U) {
-			net_buf_add_u8(buf, *((uint8_t *)elem->data));
+			net_buf_simple_add_u8(&attr_buf, *((const uint8_t *)elem->data));
 		} else if (seq_size == 2U) {
-			net_buf_add_be16(buf, *((uint16_t *)elem->data));
+			net_buf_simple_add_be16(&attr_buf, *((const uint16_t *)elem->data));
 		} else if (seq_size == 4U) {
-			net_buf_add_be32(buf, *((uint32_t *)elem->data));
+			net_buf_simple_add_be32(&attr_buf, *((const uint32_t *)elem->data));
 		} else if (seq_size == 8U) {
-			net_buf_add_be64(buf, *((uint64_t *)elem->data));
+			net_buf_simple_add_be64(&attr_buf, *((const uint64_t *)elem->data));
 		} else {
 			__ASSERT(seq_size == 0x10, "Invalid sequence size");
 
 			uint8_t val[seq_size];
 
 			sys_memcpy_swap(val, elem->data, sizeof(val));
-			net_buf_add_mem(buf, val, seq_size);
+			net_buf_simple_add_mem(&attr_buf, val, seq_size);
+		}
+
+		copy_len = copy_attribute_from_buf(buf, attr_buf.data, attr_buf.len, offset,
+						   index, space);
+		total_len += copy_len;
+		if (*space == 0) {
+			goto exit;
 		}
 	} else {
-		net_buf_add_mem(buf, elem->data, seq_size);
+		copy_len = copy_attribute_from_buf(buf, attr_buf.data, attr_buf.len, offset,
+						   index, space);
+		total_len += copy_len;
+		if (*space == 0) {
+			goto exit;
+		}
+
+		copy_len = copy_attribute_from_buf(buf, (const uint8_t *)elem->data,
+						   elem->data_size, offset, index, space);
+		total_len += copy_len;
+		if (*space == 0) {
+			goto exit;
+		}
 	}
 
-	return total_size;
+exit:
+	if ((nest_level == 1) && (*index >= total_size)) {
+		/* Reset index to zero */
+		*index = 0;
+	}
+	return total_len;
 }
 
 /* @brief SDP attribute iterator.
@@ -837,8 +941,12 @@ static uint8_t select_attrs(struct bt_sdp_attribute *attr, uint8_t att_idx,
 {
 	struct select_attrs_data *sad = user_data;
 	uint16_t att_id_lower, att_id_upper, att_id_cur, space;
-	uint32_t attr_size, seq_size;
+	uint32_t attr_size = 0, seq_size;
+	uint32_t attr_data_index;
 	size_t idx_filter;
+	uint32_t offset = 0;
+	uint32_t copy_len;
+	uint32_t required_len;
 
 	for (idx_filter = 0U; idx_filter < sad->num_filters; idx_filter++) {
 
@@ -866,7 +974,7 @@ static uint8_t select_attrs(struct bt_sdp_attribute *attr, uint8_t att_idx,
 		 * to account for the space required to add the per-service
 		 * data element sequence header as well.
 		 */
-		if ((sad->state->current_svc != sad->rec->index) &&
+		if ((sad->state->last_att_index == 0) && (sad->state->last_att == 0) &&
 		    sad->new_service) {
 			/* 3 bytes for Per-Service Data Elem Seq declaration */
 			seq_size = attr_size + 3;
@@ -875,58 +983,116 @@ static uint8_t select_attrs(struct bt_sdp_attribute *attr, uint8_t att_idx,
 		}
 
 		if (sad->rsp_buf) {
-			space = MIN(SDP_MTU, sad->sdp->chan.tx.mtu) -
-				sad->rsp_buf->len - sizeof(struct bt_sdp_hdr);
+			space = MIN(SDP_MTU, sad->sdp->chan.tx.mtu) - sad->rsp_buf->len -
+				sizeof(struct bt_sdp_hdr);
+			space = MIN(space, sad->max_att_len);
 
-			if ((!sad->state->pkt_full) &&
-			    ((seq_size > sad->max_att_len) ||
-			     (space < seq_size + sad->cont_state_size))) {
+			if ((!sad->state->pkt_full) && (space <= sad->cont_state_size)) {
 				/* Packet exhausted */
 				sad->state->pkt_full = true;
+			} else {
+				space -= sad->cont_state_size;
 			}
 		}
 
 		/* Keep filling data only if packet is not exhausted */
 		if (!sad->state->pkt_full && sad->rsp_buf) {
+			attr_data_index = sad->state->last_att_index;
+			required_len = 0;
+
 			/* Add Per-Service Data Element Seq declaration once
 			 * only when we are starting from the first attribute
 			 */
 			if (!sad->seq &&
-			    (sad->state->current_svc != sad->rec->index)) {
+			    (sad->state->last_att_index == 0) && (sad->state->last_att == 0)) {
+				required_len += sizeof(*sad->seq);
+			}
+
+			if (attr_data_index == 0) {
+				required_len += sizeof(uint8_t) + sizeof(uint16_t);
+			}
+
+			if (space <= required_len) {
+				/* Packet exhausted */
+				sad->state->pkt_full = true;
+				goto out;
+			}
+
+			/* Add Per-Service Data Element Seq declaration once
+			 * only when we are starting from the first attribute
+			 */
+			if (!sad->seq &&
+			    (sad->state->last_att_index == 0) && (sad->state->last_att == 0)) {
 				sad->seq = net_buf_add(sad->rsp_buf,
 						       sizeof(*sad->seq));
 				sad->seq->type = BT_SDP_SEQ16;
 				sad->seq->size = 0U;
+				space -= sizeof(*sad->seq);
+
+				sad->max_att_len -= sizeof(*sad->seq);
+				sad->att_list_len += sizeof(*sad->seq);
 			}
 
-			/* Add attribute ID */
-			net_buf_add_u8(sad->rsp_buf, BT_SDP_UINT16);
-			net_buf_add_be16(sad->rsp_buf, att_id_cur);
+			if (attr_data_index == 0) {
+				/* Add attribute ID */
+				net_buf_add_u8(sad->rsp_buf, BT_SDP_UINT16);
+				net_buf_add_be16(sad->rsp_buf, att_id_cur);
+				space -= sizeof(uint8_t) + sizeof(uint16_t);
+
+				sad->max_att_len -= sizeof(uint8_t) + sizeof(uint16_t);
+				sad->att_list_len += sizeof(uint8_t) + sizeof(uint16_t);
+			}
 
 			/* Add attribute value */
-			copy_attribute(&attr->val, sad->rsp_buf, 1);
-
-			sad->max_att_len -= seq_size;
-			sad->att_list_len += seq_size;
+			copy_len = copy_attribute(&attr->val, sad->rsp_buf, &offset,
+						   &attr_data_index, &space, 1);
+			sad->max_att_len -= copy_len;
+			sad->att_list_len += copy_len;
 			sad->state->last_att = att_idx;
+			sad->state->last_att_index = attr_data_index;
 			sad->state->current_svc = sad->rec->index;
+
+			if (attr_data_index == 0) {
+				/* It means the all data of attribute is copied.
+				 * The att index needs to be incremented.
+				 */
+				sad->state->last_att++;
+			}
+
+			if (space == 0) {
+				/* Packet exhausted */
+				sad->state->pkt_full = true;
+				goto out;
+			}
 		}
 
+out:
 		if (sad->seq) {
 			/* Keep adding the sequence size if this packet contains
 			 * the Per-Service Data Element Seq declaration header
 			 */
 			sad->seq->size += attr_size;
-			sad->state->att_list_size += seq_size;
-		} else {
-			/* Keep adding the total attr lists size if:
-			 * It's a dry-run, calculating the total attr lists size
-			 */
-			sad->state->att_list_size += seq_size;
 		}
+
+		/* Calculate the total sequence size */
+		sad->state->att_list_size += seq_size;
 
 		sad->new_service = false;
 		break;
+	}
+
+	/* If the attribute ID is out of range, the continuation state should be updated. */
+	if (attr_size == 0) {
+		sad->state->last_att = att_idx + 1;
+		sad->state->last_att_index = 0;
+	}
+
+	/* If the attribute index is out of range, increase the service
+	 * index and reset attribute index.
+	 */
+	if (sad->state->last_att >= sad->rec->attr_count) {
+		sad->state->current_svc++;
+		sad->state->last_att = 0;
 	}
 
 	/* End the search if:
@@ -956,20 +1122,18 @@ static uint8_t select_attrs(struct bt_sdp_attribute *attr, uint8_t att_idx,
  *  @param max_att_len Maximum size of attributes to be included in the response
  *  @param cont_state_size No. of additional continuation state bytes to keep
  *   space for in the packet. This will vary based on the type of the request
- *  @param next_att Starting position of the search in the service's attr list
  *  @param state State of the overall search
  *  @param rsp_buf Response buffer which is filled in
  *
  *  @return len Length of the attribute list created
  */
 static uint16_t create_attr_list(struct bt_sdp *sdp, struct bt_sdp_record *record,
-			      uint32_t *filter, size_t num_filters,
-			      uint16_t max_att_len, uint8_t cont_state_size,
-			      uint8_t next_att, struct search_state *state,
-			      struct net_buf *rsp_buf)
+				 uint32_t *filter, size_t num_filters, uint16_t max_att_len,
+				 uint8_t cont_state_size, struct search_state *state,
+				 struct net_buf *rsp_buf)
 {
 	struct select_attrs_data sad;
-	uint8_t idx_att;
+	__maybe_unused uint8_t idx_att;
 
 	sad.num_filters = num_filters;
 	sad.rec = record;
@@ -983,7 +1147,7 @@ static uint16_t create_attr_list(struct bt_sdp *sdp, struct bt_sdp_record *recor
 	sad.att_list_len = 0U;
 	sad.new_service = true;
 
-	idx_att = bt_sdp_foreach_attr(sad.rec, next_att, select_attrs, &sad);
+	idx_att = bt_sdp_foreach_attr(sad.rec, state->last_att, select_attrs, &sad);
 
 	if (sad.seq) {
 		sad.seq->size = sys_cpu_to_be16(sad.seq->size);
@@ -1091,13 +1255,13 @@ static uint8_t find_handle(struct bt_sdp_record *rec, void *user_data)
  *
  *  @return 0 for success, or relevant error code
  */
-static uint16_t sdp_svc_att_req(struct bt_sdp *sdp, struct net_buf *buf,
-			     uint16_t tid)
+static uint16_t sdp_svc_att_req(struct bt_sdp *sdp, struct net_buf *buf, uint16_t tid)
 {
 	uint32_t filter[MAX_NUM_ATT_ID_FILTER];
 	struct search_state state = {
 		.current_svc = SDP_INVALID,
-		.last_att = SDP_INVALID,
+		.last_att = 0,
+		.last_att_index = 0,
 		.pkt_full = false
 	};
 	struct bt_sdp_record *record;
@@ -1106,7 +1270,7 @@ static uint16_t sdp_svc_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 	uint32_t svc_rec_hdl;
 	uint16_t max_att_len, res, att_list_len;
 	size_t num_filters;
-	uint8_t cont_state_size, next_att = 0U;
+	uint8_t cont_state_size;
 
 	if (buf->len < 6) {
 		LOG_WRN("Malformed packet");
@@ -1144,12 +1308,12 @@ static uint16_t sdp_svc_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 			return BT_SDP_INVALID_SYNTAX;
 		}
 
-		state.last_att = net_buf_pull_u8(buf) + 1;
-		next_att = state.last_att;
+		state.last_att = net_buf_pull_u8(buf);
+		state.last_att_index = net_buf_pull_be32(buf);
 	}
 
-	LOG_DBG("svc_rec_hdl %u, max_att_len 0x%04x, cont_state %u", svc_rec_hdl, max_att_len,
-		next_att);
+	LOG_DBG("svc_rec_hdl %u, max_att_len 0x%04x, cont_state %u %u", svc_rec_hdl, max_att_len,
+		state.last_att, state.last_att_index);
 
 	/* Find the service */
 	record = bt_sdp_foreach_svc(find_handle, &svc_rec_hdl);
@@ -1168,9 +1332,8 @@ static uint16_t sdp_svc_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 	rsp = net_buf_add(rsp_buf, sizeof(*rsp));
 
 	/* cont_state_size should include 1 byte header */
-	att_list_len = create_attr_list(sdp, record, filter, num_filters,
-					max_att_len, SDP_SA_CONT_STATE_SIZE + 1,
-					next_att, &state, rsp_buf);
+	att_list_len = create_attr_list(sdp, record, filter, num_filters, max_att_len,
+					SDP_SA_CONT_STATE_SIZE + 1, &state, rsp_buf);
 
 	if (!att_list_len) {
 		/* For empty responses, add an empty data element sequence */
@@ -1179,11 +1342,19 @@ static uint16_t sdp_svc_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 		att_list_len = 2U;
 	}
 
+	if (state.current_svc != record->index) {
+		/* It is a corner case that the remaining free space of the responding is emtpy,
+		 * and all attributes are sent, clear state.pkt_full to avoid further processing.
+		 */
+		state.pkt_full = false;
+	}
+
 	/* Add continuation state */
 	if (state.pkt_full) {
 		LOG_DBG("Packet full, state.last_att %u", state.last_att);
-		net_buf_add_u8(rsp_buf, 1);
+		net_buf_add_u8(rsp_buf, SDP_SA_CONT_STATE_SIZE);
 		net_buf_add_u8(rsp_buf, state.last_att);
+		net_buf_add_be32(rsp_buf, state.last_att_index);
 	} else {
 		net_buf_add_u8(rsp_buf, 0);
 	}
@@ -1214,7 +1385,8 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 	struct search_state state = {
 		.att_list_size = 0,
 		.current_svc = SDP_INVALID,
-		.last_att = SDP_INVALID,
+		.last_att = 0,
+		.last_att_index = 0,
 		.pkt_full = false
 	};
 	struct net_buf *rsp_buf, *rsp_buf_cpy;
@@ -1222,8 +1394,9 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 	struct bt_sdp_att_rsp *rsp;
 	struct bt_sdp_data_elem_seq *seq = NULL;
 	uint16_t max_att_len, res, att_list_len = 0U;
+	uint16_t sending_len;
 	size_t num_filters;
-	uint8_t cont_state_size, next_svc = 0U, next_att = 0U;
+	uint8_t cont_state_size, next_svc = 0U;
 	bool dry_run = false;
 
 	res = find_services(buf, matching_recs);
@@ -1231,12 +1404,16 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 		return res;
 	}
 
-	if (buf->len < 2) {
+	if (buf->len < sizeof(max_att_len)) {
 		LOG_WRN("Malformed packet");
 		return BT_SDP_INVALID_SYNTAX;
 	}
 
 	max_att_len = net_buf_pull_be16(buf);
+	if (max_att_len < sizeof(*seq)) {
+		LOG_WRN("Invalid maximum attribute byte count %u < %u", max_att_len, sizeof(*seq));
+		return BT_SDP_INVALID_SYNTAX;
+	}
 
 	/* Set up the filters */
 	res = get_att_search_list(buf, filter, ARRAY_SIZE(filter), &num_filters);
@@ -1246,7 +1423,7 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 		return res;
 	}
 
-	if (buf->len < 1) {
+	if (buf->len < sizeof(cont_state_size)) {
 		LOG_WRN("Malformed packet");
 		return BT_SDP_INVALID_SYNTAX;
 	}
@@ -1268,13 +1445,13 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 		}
 
 		state.current_svc = net_buf_pull_u8(buf);
-		state.last_att = net_buf_pull_u8(buf) + 1;
+		state.last_att = net_buf_pull_u8(buf);
+		state.last_att_index = net_buf_pull_be32(buf);
 		next_svc = state.current_svc;
-		next_att = state.last_att;
 	}
 
-	LOG_DBG("max_att_len 0x%04x, state.current_svc %u, state.last_att %u", max_att_len,
-		state.current_svc, state.last_att);
+	LOG_DBG("max_att_len 0x%04x, cont_state %u %u %u", max_att_len, next_svc,
+		state.last_att, state.last_att_index);
 
 	rsp_buf = bt_sdp_create_pdu();
 
@@ -1287,7 +1464,8 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 		seq->size = 0U;
 
 		/* 3 bytes for Outer Data Element Sequence declaration */
-		att_list_len = 3U;
+		att_list_len = sizeof(*seq);
+		max_att_len -= sizeof(*seq);
 	}
 
 	rsp_buf_cpy = rsp_buf;
@@ -1299,20 +1477,30 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 			continue;
 		}
 
-		att_list_len += create_attr_list(sdp, record, filter,
-						 num_filters, max_att_len,
-						 SDP_SSA_CONT_STATE_SIZE + 1,
-						 next_att, &state, rsp_buf_cpy);
+		sending_len = create_attr_list(sdp, record, filter, num_filters, max_att_len,
+					       SDP_SSA_CONT_STATE_SIZE + 1, &state, rsp_buf_cpy);
+		att_list_len += sending_len;
+
+		if (max_att_len < sending_len) {
+			LOG_ERR("Att len exceeds %u < %u", max_att_len, sending_len);
+			net_buf_unref(rsp_buf);
+			return BT_SDP_INVALID_SYNTAX;
+		}
+		max_att_len -= sending_len;
 
 		/* Check if packet is full and not dry run */
 		if (state.pkt_full && !dry_run) {
 			LOG_DBG("Packet full, state.last_att %u", state.last_att);
-			dry_run = true;
 
-			/* Add continuation state */
-			net_buf_add_u8(rsp_buf, 2);
-			net_buf_add_u8(rsp_buf, state.current_svc);
-			net_buf_add_u8(rsp_buf, state.last_att);
+			if (state.current_svc < num_services) {
+				dry_run = true;
+
+				/* Add continuation state */
+				net_buf_add_u8(rsp_buf, SDP_SSA_CONT_STATE_SIZE);
+				net_buf_add_u8(rsp_buf, state.current_svc);
+				net_buf_add_u8(rsp_buf, state.last_att);
+				net_buf_add_be32(rsp_buf, state.last_att_index);
+			}
 
 			/* Break if it's not a partial response, else dry-run
 			 * Dry run: Look for other services that match
@@ -1324,7 +1512,13 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 			rsp_buf_cpy = NULL;
 		}
 
-		next_att = 0U;
+		if (dry_run) {
+			/* Reset the state.last_att and state.last_att_index to calculate all
+			 * sequence size
+			 */
+			state.last_att = 0;
+			state.last_att_index = 0;
+		}
 	}
 
 	if (!dry_run) {
@@ -2069,7 +2263,7 @@ static int sdp_client_receive_ssa_sa(struct bt_sdp_client *session, struct net_b
 		return -EINVAL;
 	}
 	/* Check valid range of attributes length */
-	if (frame_len < 2) {
+	if (((session->cstate.length == 0) && (frame_len < 2)) || (frame_len == 0)) {
 		LOG_ERR("Invalid attributes data length");
 		return -EINVAL;
 	}

--- a/tests/bluetooth/classic/sdp_s/pytest/test_sdp.py
+++ b/tests/bluetooth/classic/sdp_s/pytest/test_sdp.py
@@ -263,7 +263,7 @@ async def br_connect(hci_port, shell, address) -> None:
                     if attribute.id == 0x100:
                         service_name_found = True
                 if service_record_handle == service_record_handles[-1]:
-                    assert service_name_found is False
+                    assert service_name_found is True
 
             # Install SDP large Record
             shell.exec_command("sdp_server register_sdp_large_valid")


### PR DESCRIPTION
In current implementation, the attribute of the registered SDP record will not be included in responding packet if the attribute data length is more than the MAX payload size (`MIN(SDP_MTU, sad->sdp->chan.tx.mtu) - sizeof(struct bt_sdp_hdr)`). And it causes the failure of ssa or sa discovery.

Improve the SDP server to support the case by extending the continuation state length. A 4 bytes space is extended to store the attribute offset.

In this way, the attribute can be transmitted in segments according to the reaming space of the responding buffer.