### PR TITLE
ICM4268X: fix typos missed going from ICM42688 to ICM4268X

### DIFF
--- a/drivers/sensor/tdk/icm4268x/icm4268x.h
+++ b/drivers/sensor/tdk/icm4268x/icm4268x.h
@@ -173,7 +173,7 @@ static inline void icm4268x_accel_reg_to_hz(uint8_t odr, struct sensor_value *ou
 		out->val2 = 0;
 		return;
 	case ICM4268X_DT_ACCEL_ODR_16000:
-		out->val1 = 1600;
+		out->val1 = 16000;
 		out->val2 = 0;
 		return;
 	case ICM4268X_DT_ACCEL_ODR_8000:

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.c
@@ -730,7 +730,7 @@ static int icm4268x_decoder_get_size_info(struct sensor_chan_spec chan_spec, siz
 	}
 }
 
-static bool icm24688_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
+static bool icm4268x_decoder_has_trigger(const uint8_t *buffer, enum sensor_trigger_type trigger)
 {
 	const struct icm4268x_fifo_data *edata = (const struct icm4268x_fifo_data *)buffer;
 
@@ -754,7 +754,7 @@ SENSOR_DECODER_API_DT_DEFINE() = {
 	.get_frame_count = icm4268x_decoder_get_frame_count,
 	.get_size_info = icm4268x_decoder_get_size_info,
 	.decode = icm4268x_decoder_decode,
-	.has_trigger = icm24688_decoder_has_trigger,
+	.has_trigger = icm4268x_decoder_has_trigger,
 };
 
 int icm4268x_get_decoder(const struct device *dev, const struct sensor_decoder_api **decoder)


### PR DESCRIPTION
Pointed out during #92579 review.