### PR TITLE
samples: bluetooth: typo in project name

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/CMakeLists.txt
+++ b/samples/bluetooth/bap_broadcast_sink/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(bap_unicast_sink)
+project(bap_broadcast_sink)
 
 target_sources(app PRIVATE
   src/main.c

--- a/samples/bluetooth/bap_broadcast_source/CMakeLists.txt
+++ b/samples/bluetooth/bap_broadcast_source/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(bap_unicast_server)
+project(bap_broadcast_source)
 
 target_sources(app PRIVATE
   src/main.c


### PR DESCRIPTION
Corrected a typo in the project name within the Bluetooth samples directory. The incorrect name was causing confusion in documentation and build processes. This change updates the relevant file(s) to use the correct project name, ensuring consistency across the Zephyr repository.