### PR TITLE
bluetooth: hci: spi: configurable CS delay

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -86,7 +86,8 @@ static K_KERNEL_STACK_DEFINE(spi_rx_stack, CONFIG_BT_DRV_RX_STACK_SIZE);
 static struct k_thread spi_rx_thread_data;
 
 static const struct spi_dt_spec bus = SPI_DT_SPEC_INST_GET(
-	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8), 0);
+	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8),
+	DT_INST_PROP(0, controller_cs_delay_us));
 
 static struct spi_buf spi_tx_buf;
 static struct spi_buf spi_rx_buf;

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -24,6 +24,13 @@ properties:
       Minimum duration to hold the reset-gpios pin low for.
       If not specified no delay beyond the code path execution time is guaranteed.
 
+  controller-cs-delay-us:
+    type: int
+    default: 0
+    description:
+      Delay in microseconds to wait after asserting the CS line before starting the
+      transmission and before releasing the CS line after the transmission.
+
   controller-data-delay-us:
     type: int
     default: 20


### PR DESCRIPTION
Make the common SPI CS delay property configurable from devicetree. This can be required for using a nRF54L as a Bluetooth controller, since it has an additional delay after waking up from the CS assertion until it is ready to accept and transmit data (see OPS t_START_HFINT).
<img width="1222" height="291" alt="image" src="https://github.com/user-attachments/assets/a8a2c697-058b-43be-b7da-6f903ecdc922" />
<img width="1227" height="49" alt="image" src="https://github.com/user-attachments/assets/fd6bd02e-671d-470d-ab22-e5fb250fa2f2" />
<img width="924" height="49" alt="image" src="https://github.com/user-attachments/assets/0c677314-70ce-4037-a027-58b37075f813" />
