### PR TITLE
tests: arch: arm: arm_irq_vector_table: Add remaining MEC boards

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/mec1501modular_assy6885.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec1501modular_assy6885.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/mec15xxevb_assy6853.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec15xxevb_assy6853.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/mec172xevb_assy6906.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec172xevb_assy6906.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/mec172xmodular_assy6930.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/mec172xmodular_assy6930.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Microchip MEC use its 32 KHz based RTOS timer by default.
+ * Allow the test to build by switching to Cortex-M4 SysTick.
+ */
+
+&rtimer {
+	status = "disabled";
+};
+
+&systick {
+	status = "okay";
+};


### PR DESCRIPTION
Any PR affecting all Microchip MEC SoC's causes twister to run the arm IRQ vector table test. Since all the MEC boards are using the MEC 32 KHz timer instead of ARM SysTick we added all the remaining boards to the test. Each overlay disables the MEC 32 KHz timer and enables SysTick as the kernel timer.