### PR TITLE
soc: st: stm32: fix ccm region name in linker

### DIFF
--- a/soc/st/stm32/common/ccm.ld
+++ b/soc/st/stm32/common/ccm.ld
@@ -9,7 +9,7 @@ GROUP_START(CCM)
 		*(.ccm_bss)
 		*(".ccm_bss.*")
 		__ccm_bss_end = .;
-	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ccm)))
+	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME_TOKEN(DT_CHOSEN(zephyr_ccm)))
 
 	SECTION_PROLOGUE(_CCM_NOINIT_SECTION_NAME, (NOLOAD),SUBALIGN(4))
 	{
@@ -17,7 +17,7 @@ GROUP_START(CCM)
 		*(.ccm_noinit)
 		*(".ccm_noinit.*")
 		__ccm_noinit_end = .;
-	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ccm)))
+	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME_TOKEN(DT_CHOSEN(zephyr_ccm)))
 
 	SECTION_PROLOGUE(_CCM_DATA_SECTION_NAME,,SUBALIGN(4))
 	{
@@ -25,7 +25,7 @@ GROUP_START(CCM)
 		*(.ccm_data)
 		*(".ccm_data.*")
 		__ccm_data_end = .;
-	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME(DT_CHOSEN(zephyr_ccm)) AT> ROMABLE_REGION)
+	} GROUP_LINK_IN(LINKER_DT_NODE_REGION_NAME_TOKEN(DT_CHOSEN(zephyr_ccm)) AT> ROMABLE_REGION)
 
 	__ccm_end = .;
 


### PR DESCRIPTION
Use the region name token to describe the location of sections. Because for some linkers (e.g. llvm lld) region_name and "region_name" are not the same.