### PR TITLE
kernel: fix message queue put front issue and increase message queue test coverage for put front

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4820,18 +4820,17 @@ __syscall int k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t time
  * pointer is not retained, so the message content will not be modified
  * by this function.
  *
+ * @note k_msgq_put_front() does not block.
+ *
  * @funcprops \isr_ok
  *
  * @param msgq Address of the message queue.
  * @param data Pointer to the message.
- * @param timeout Waiting period to add the message, or one of the special
- *                values K_NO_WAIT and K_FOREVER.
  *
  * @retval 0 Message sent.
  * @retval -ENOMSG Returned without waiting or queue purged.
- * @retval -EAGAIN Waiting period timed out.
  */
-__syscall int k_msgq_put_front(struct k_msgq *msgq, const void *data, k_timeout_t timeout);
+__syscall int k_msgq_put_front(struct k_msgq *msgq, const void *data);
 
 /**
  * @brief Receive a message from a message queue.

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -228,9 +228,9 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, k_timeout_t timeout
 	return put_msg_in_queue(msgq, data, timeout, true);
 }
 
-int z_impl_k_msgq_put_front(struct k_msgq *msgq, const void *data, k_timeout_t timeout)
+int z_impl_k_msgq_put_front(struct k_msgq *msgq, const void *data)
 {
-	return put_msg_in_queue(msgq, data, timeout, false);
+	return put_msg_in_queue(msgq, data, K_NO_WAIT, false);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -244,13 +244,12 @@ static inline int z_vrfy_k_msgq_put(struct k_msgq *msgq, const void *data,
 }
 #include <zephyr/syscalls/k_msgq_put_mrsh.c>
 
-static inline int z_vrfy_k_msgq_put_front(struct k_msgq *msgq, const void *data,
-				    k_timeout_t timeout)
+static inline int z_vrfy_k_msgq_put_front(struct k_msgq *msgq, const void *data)
 {
 	K_OOPS(K_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
 	K_OOPS(K_SYSCALL_MEMORY_READ(data, msgq->msg_size));
 
-	return z_impl_k_msgq_put_front(msgq, data, timeout);
+	return z_impl_k_msgq_put_front(msgq, data);
 }
 #include <zephyr/syscalls/k_msgq_put_front_mrsh.c>
 #endif /* CONFIG_USERSPACE */

--- a/samples/kernel/msg_queue/src/main.c
+++ b/samples/kernel/msg_queue/src/main.c
@@ -32,7 +32,7 @@ void producer_function(void *rec, void *p2, void *p3)
 			normal_data++;
 		}
 		printk("[producer] sending: %c (urgent)\n", urgent_data);
-		k_msgq_put_front(&my_msgq, &urgent_data, K_NO_WAIT);
+		k_msgq_put_front(&my_msgq, &urgent_data);
 		k_sleep(K_MSEC(100));
 		urgent_data++;
 

--- a/tests/kernel/msgq/msgq_api/Kconfig
+++ b/tests/kernel/msgq/msgq_api/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2024
+# SPDX-License-Identifier: Apache-2.0
+
+config TEST_MSGQ_PUT_FRONT
+	bool "Test message queue put front feature"
+	default n
+
+# Include Zephyr's Kconfig.
+source "Kconfig"

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -21,6 +21,7 @@ struct k_thread tdata2;
 static ZTEST_BMEM char __aligned(4) tbuffer[MSG_SIZE * MSGQ_LEN];
 static ZTEST_DMEM char __aligned(4) tbuffer1[MSG_SIZE];
 static ZTEST_DMEM uint32_t data[MSGQ_LEN] = { MSG0, MSG1 };
+static ZTEST_DMEM uint32_t msg3 = 0x2345;
 struct k_sem end_sema;
 
 static void put_msgq(struct k_msgq *pmsgq)
@@ -29,16 +30,16 @@ static void put_msgq(struct k_msgq *pmsgq)
 	uint32_t read_data;
 
 	for (int i = 0; i < MSGQ_LEN; i++) {
-		ret = k_msgq_put(pmsgq, (void *)&data[i], K_NO_WAIT);
+		ret = IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ?
+					k_msgq_put_front(pmsgq, (void *) &data[i]) :
+					k_msgq_put(pmsgq, (void *)&data[i], K_NO_WAIT);
 		zassert_equal(ret, 0);
 
-		/**TESTPOINT: Check if k_msgq_peek reads msgq
-		 * in FIFO manner.
-		 * Everytime msg is enqueued, msg read should
-		 * always be the first message
+		/**TESTPOINT: Check if k_msgq_peek reads msgq.
 		 */
 		zassert_equal(k_msgq_peek(pmsgq, &read_data), 0);
-		zassert_equal(read_data, data[0]);
+		zassert_equal(read_data, IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ?
+			data[i] : data[0]);
 
 		/**TESTPOINT: msgq free get*/
 		zassert_equal(k_msgq_num_free_get(pmsgq),
@@ -58,7 +59,8 @@ static void get_msgq(struct k_msgq *pmsgq)
 
 		ret = k_msgq_get(pmsgq, &rx_data, K_FOREVER);
 		zassert_equal(ret, 0);
-		zassert_equal(rx_data, data[i]);
+		zassert_equal(rx_data,
+			IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ? data[MSGQ_LEN - i - 1] : data[i]);
 
 		/**TESTPOINT: Check if msg read is the msg deleted*/
 		zassert_equal(read_data, rx_data);
@@ -138,7 +140,6 @@ static void msgq_thread_overflow(struct k_msgq *pmsgq)
 				  K_USER | K_INHERIT_PERMS, K_NO_WAIT);
 
 	ret = k_msgq_put(pmsgq, (void *)&data[1], K_FOREVER);
-
 	zassert_equal(ret, 0);
 
 	k_sem_take(&end_sema, K_FOREVER);
@@ -174,13 +175,19 @@ static void pend_thread_entry(void *p1, void *p2, void *p3)
 {
 	int ret;
 
-	ret = k_msgq_put(p1, &data[1], TIMEOUT);
-	zassert_equal(ret, 0);
+	ret = IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ?
+		k_msgq_put_front(p1, &data[1]) :
+		k_msgq_put(p1, &data[1], TIMEOUT);
+	zassert_equal(ret, IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ? -ENOMSG : 0);
 }
 
 static void msgq_thread_data_passing(struct k_msgq *pmsgq)
 {
-	while (k_msgq_put(pmsgq, &data[0], K_NO_WAIT) != 0) {
+	while (
+		IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ?
+			k_msgq_put_front(pmsgq, &data[0]) != 0 :
+			k_msgq_put(pmsgq, &data[0], K_NO_WAIT) != 0
+		) {
 	}
 
 	tids[0] = k_thread_create(&tdata2, tstack2, STACK_SIZE,
@@ -240,6 +247,21 @@ static void put_full_entry(void *p1, void *p2, void *p3)
 	/* blocked forever */
 	ret = k_msgq_put(p1, &data[1], K_FOREVER);
 	zassert_equal(ret, 0);
+}
+
+static void prepend_full_entry(void *p1, void *p2, void *p3)
+{
+	int ret;
+
+	/* make sure the queue is full */
+	zassert_equal(k_msgq_num_free_get(p1), 0);
+	zassert_equal(k_msgq_num_used_get(p1), 2);
+	k_sem_give(&end_sema);
+
+	/* prepend a new message */
+	ret = IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ? k_msgq_put_front(p1, &msg3) :
+		k_msgq_put(p1, &msg3, K_FOREVER);
+	zassert_equal(ret, IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ? -ENOMSG : 0);
 }
 
 /**
@@ -450,6 +472,52 @@ ZTEST(msgq_api_1cpu, test_msgq_full)
 	/* that putting thread is being blocked now */
 	zassert_equal(tids[0]->base.thread_state, _THREAD_PENDING);
 	k_thread_abort(tids[0]);
+}
+
+/**
+ * @brief Put a message to a full queue for behavior test
+ *
+ * @details
+ * - Thread A put message to a full message queue and go to sleep
+ * Thread B put a new message to the queue then pending on it.
+ * - Thread A get all messages from message queue and check the behavior.
+ *
+ * @see k_msgq_put(), k_msgq_put_front()
+ */
+ZTEST(msgq_api_1cpu, test_msgq_thread_pending)
+{
+	uint32_t rx_data;
+	int pri = k_thread_priority_get(k_current_get()) - 1;
+	int ret;
+
+	k_msgq_init(&msgq1, tbuffer, MSG_SIZE, 2);
+	ret = k_sem_init(&end_sema, 0, 1);
+	zassert_equal(ret, 0);
+
+	ret = IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ?
+		k_msgq_put_front(&msgq1, &data[1]) :
+		k_msgq_put(&msgq1, &data[0], K_NO_WAIT);
+	zassert_equal(ret, 0);
+	ret = IS_ENABLED(CONFIG_TEST_MSGQ_PUT_FRONT) ?
+		k_msgq_put(&msgq1, &data[0], K_NO_WAIT) :
+		k_msgq_put_front(&msgq1, &data[1]);
+	zassert_equal(ret, 0);
+
+	k_tid_t tid = k_thread_create(&tdata2, tstack2, STACK_SIZE,
+					prepend_full_entry, &msgq1, NULL,
+					NULL, pri, 0, K_NO_WAIT);
+
+	/* that putting thread is being blocked now */
+	k_sem_take(&end_sema, K_FOREVER);
+
+	ret = k_msgq_get(&msgq1, &rx_data, K_FOREVER);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_data, data[1]);
+
+	ret = k_msgq_get(&msgq1, &rx_data, K_FOREVER);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_data, data[0]);
+	k_thread_abort(tid);
 }
 
 /**

--- a/tests/kernel/msgq/msgq_api/testcase.yaml
+++ b/tests/kernel/msgq/msgq_api/testcase.yaml
@@ -1,5 +1,9 @@
+common:
+  tags:
+    - kernel
+    - userspace
 tests:
-  kernel.message_queue:
-    tags:
-      - kernel
-      - userspace
+  kernel.message_queue: {}
+  kernel.message_queue.put_front:
+    extra_configs:
+      - CONFIG_TEST_MSGQ_PUT_FRONT=y


### PR DESCRIPTION
A new test covers the behavior of putting a message into the message queue
when it is full.
The reason is that when the buffer is full, Thread A gets pended (blocked).
If Thread B later calls the get function, it will unpend Thread A,
allowing it to resume and put the message into the queue.
In this situation, we need to know whether Thread A should
continue with put to front or put to end.

related: https://github.com/zephyrproject-rtos/zephyr/pull/92865
