### PR TITLE
bluetooth: host: avdtp: Fix command and response format error

### DIFF
--- a/include/zephyr/bluetooth/classic/avdtp.h
+++ b/include/zephyr/bluetooth/classic/avdtp.h
@@ -120,6 +120,14 @@ enum bt_avdtp_service_category {
 	BT_AVDTP_SERVICE_DELAY_REPORTING = 0x08,
 };
 
+/** @brief service category Recovery Capabilities type*/
+enum bt_avdtp_recovery_type {
+	/** Forbidden */
+	BT_AVDTP_RECOVERY_TYPE_FORBIDDEN = 0x00,
+	/** RFC2733 */
+	BT_ADVTP_RECOVERY_TYPE_RFC2733 = 0x01,
+};
+
 /** @brief AVDTP Stream End Point */
 struct bt_avdtp_sep {
 	/** Stream End Point information */

--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -260,11 +260,11 @@ static int a2dp_set_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *se
 	return a2dp_process_config_ind(session, sep, int_seid, buf, errcode, false);
 }
 
-static int a2dp_re_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t int_seid,
+static int a2dp_re_config_ind(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
 			      struct net_buf *buf, uint8_t *errcode)
 {
 	__ASSERT(sep, "Invalid sep");
-	return a2dp_process_config_ind(session, sep, int_seid, buf, errcode, true);
+	return a2dp_process_config_ind(session, sep, 0, buf, errcode, true);
 }
 
 #if defined(CONFIG_BT_A2DP_SINK)
@@ -447,8 +447,8 @@ static int bt_a2dp_get_capabilities_cb(struct bt_avdtp_req *req, struct net_buf 
 		return 0;
 	}
 
-	err = bt_avdtp_parse_capability_codec(buf, &codec_type,
-					      &codec_info_element, &codec_info_element_len);
+	err = bt_avdtp_parse_capability_codec(buf, &codec_type, &codec_info_element,
+					      &codec_info_element_len);
 	if (err) {
 		LOG_DBG("codec capability parsing fail");
 		return 0;

--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -421,6 +421,99 @@ static void avdtp_get_capabilities_rsp(struct bt_avdtp *session, struct net_buf 
 	}
 }
 
+struct bt_avdtp_service_category_handler {
+	uint8_t min_len;
+	uint8_t max_len;
+	bool reconfig_support;
+	uint8_t err_code;
+	uint8_t (*handler)(struct net_buf *buf);
+};
+
+uint8_t bt_avdtp_check_media_recovery_type(struct net_buf *buf)
+{
+	struct bt_avdtp_recovery_capabilities *cap
+				= (struct bt_avdtp_recovery_capabilities *)buf->data;
+
+	if (cap->recovery_type != BT_AVDTP_RECOVERY_TYPE_FORBIDDEN &&
+	    cap->recovery_type != BT_ADVTP_RECOVERY_TYPE_RFC2733) {
+		return BT_AVDTP_BAD_RECOVERY_TYPE;
+	}
+	return BT_AVDTP_SUCCESS;
+}
+
+static struct bt_avdtp_service_category_handler category_handler[]  = {
+	{0, 0, false, 0, NULL},                             /*None*/
+	{0, 0, false, BT_AVDTP_BAD_MEDIA_TRANSPORT_FORMAT,
+	 NULL},                                             /*BT_AVDTP_SERVICE_MEDIA_TRANSPORT*/
+	{0, 0, false, BT_AVDTP_BAD_LENGTH, NULL},           /*BT_AVDTP_SERVICE_REPORTING*/
+	{sizeof(struct bt_avdtp_recovery_capabilities),
+	 sizeof(struct bt_avdtp_recovery_capabilities), false, BT_AVDTP_BAD_RECOVERY_FORMAT,
+	 bt_avdtp_check_media_recovery_type},               /*BT_AVDTP_SERVICE_MEDIA_RECOVERY*/
+	{sizeof(struct bt_avdtp_content_protection_capabilities), UINT8_MAX,
+	 true, BT_AVDTP_BAD_CP_FORMAT, NULL},             /*BT_AVDTP_SERVICE_CONTENT_PROTECTION*/
+	{sizeof(struct bt_avdtp_header_compression_capabilities),
+	 sizeof(struct bt_avdtp_header_compression_capabilities),
+	 false, BT_AVDTP_BAD_LENGTH, NULL},               /*BT_AVDTP_SERVICE_HEADER_COMPRESSION*/
+	{sizeof(struct bt_avdtp_multiplexing_capabilities),
+	 sizeof(struct bt_avdtp_multiplexing_capabilities),
+	 false, BT_AVDTP_BAD_MULTIPLEXING_FORMAT, NULL},  /*BT_AVDTP_SERVICE_MULTIPLEXING*/
+	{sizeof(struct bt_avdtp_media_codec_capabilities), UINT8_MAX,
+	 true, BT_AVDTP_BAD_LENGTH, NULL},                /*BT_AVDTP_SERVICE_MEDIA_CODEC*/
+	{0, 0, 0, BT_AVDTP_BAD_LENGTH, NULL},             /*BT_AVDTP_SERVICE_DELAY_REPORTING*/
+};
+
+uint8_t bt_avdtp_check_service_category(struct net_buf *buf, uint8_t *service_category,
+					bool reconfig)
+{
+	struct bt_avdtp_generic_service_cap *hdr;
+	uint8_t err;
+	struct bt_avdtp_service_category_handler *handler;
+	struct net_buf_simple_state state;
+
+	if (buf->len == 0U) {
+		LOG_DBG("Error: buf not valid");
+		return BT_AVDTP_BAD_LENGTH;
+	}
+
+	while (buf->len > 0U) {
+		if (buf->len < sizeof(*hdr)) {
+			LOG_DBG("Error: buf not valid");
+			return BT_AVDTP_BAD_LENGTH;
+		}
+
+		hdr = net_buf_pull_mem(buf, sizeof(*hdr));
+		*service_category = hdr->service_category;
+
+		if (hdr->service_category != 0 &&
+		    hdr->service_category < ARRAY_SIZE(category_handler)) {
+			handler = &category_handler[hdr->service_category];
+
+			if (hdr->losc > buf->len || hdr->losc > handler->max_len ||
+			    hdr->losc < handler->min_len) {
+				return handler->err_code;
+			}
+
+			if (!handler->reconfig_support && reconfig) {
+				return BT_AVDTP_INVALID_CAPABILITIES;
+			}
+
+			if (handler->handler != NULL) {
+				net_buf_simple_save(&buf->b, &state);
+				err = handler->handler(buf);
+				net_buf_simple_restore(&buf->b, &state);
+				if (err != BT_AVDTP_SUCCESS) {
+					return err;
+				}
+			}
+			net_buf_pull_mem(buf, hdr->losc);
+		} else {
+			return BT_AVDTP_BAD_SERV_CATEGORY;
+		}
+	}
+
+	return BT_AVDTP_SUCCESS;
+}
+
 static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net_buf *buf,
 					    uint8_t tid, bool reconfig)
 {
@@ -428,6 +521,8 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 	struct bt_avdtp_sep *sep;
 	struct net_buf *rsp_buf;
 	uint8_t avdtp_err_code = 0;
+	struct net_buf_simple_state state;
+	uint8_t service_category = 0;
 
 	sep = avdtp_get_cmd_sep(buf, &avdtp_err_code);
 	avdtp_sep_lock(sep);
@@ -438,6 +533,9 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 		err = -ENOTSUP;
 	} else if (reconfig && session->ops->re_configuration_ind == NULL) {
 		err = -ENOTSUP;
+	} else if (!reconfig && sep->sep_info.inuse == 1) {
+		avdtp_err_code = BT_AVDTP_SEP_IN_USE;
+		err = -EBUSY;
 	} else {
 		uint8_t expected_state;
 
@@ -451,17 +549,29 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 			err = -ENOTSUP;
 			avdtp_err_code = BT_AVDTP_BAD_STATE;
 		} else if (buf->len >= 1U) {
-			uint8_t int_seid;
+			uint8_t int_seid = 0;
+			uint8_t err_code = 0;
 
 			/* INT Stream Endpoint ID */
-			int_seid = net_buf_pull_u8(buf) >> 2;
-
 			if (!reconfig) {
-				err = session->ops->set_configuration_ind(session, sep, int_seid,
-									  buf, &avdtp_err_code);
+				/* int seid not in reconfig cmd*/
+				int_seid = net_buf_pull_u8(buf) >> 2;
+			}
+			net_buf_simple_save(&buf->b, &state);
+			err_code = bt_avdtp_check_service_category(buf, &service_category,
+								   reconfig);
+			net_buf_simple_restore(&buf->b, &state);
+			if (err_code) {
+				avdtp_err_code = err_code;
+				err = -ENOTSUP;
 			} else {
-				err = session->ops->re_configuration_ind(session, sep, int_seid,
-									 buf, &avdtp_err_code);
+				if (!reconfig) {
+					err = session->ops->set_configuration_ind(
+						session, sep, int_seid, buf, &avdtp_err_code);
+				} else {
+					err = session->ops->re_configuration_ind(session, sep, buf,
+										 &avdtp_err_code);
+				}
 			}
 		} else {
 			LOG_WRN("Invalid INT SEID");
@@ -484,8 +594,8 @@ static void avdtp_process_configuration_cmd(struct bt_avdtp *session, struct net
 		}
 
 		LOG_DBG("set configuration err code:%d", avdtp_err_code);
-		/* Service Category: Media Codec */
-		net_buf_add_u8(rsp_buf, BT_AVDTP_SERVICE_MEDIA_CODEC);
+		/* error Service Category*/
+		net_buf_add_u8(rsp_buf, service_category);
 		/* ERROR CODE */
 		net_buf_add_u8(rsp_buf, avdtp_err_code);
 	}
@@ -690,6 +800,7 @@ static void avdtp_start_cmd(struct bt_avdtp *session, struct net_buf *buf, uint8
 		}
 
 		LOG_DBG("start err code:%d", avdtp_err_code);
+		net_buf_add_u8(rsp_buf, sep->sep_info.id << 2);
 		net_buf_add_u8(rsp_buf, avdtp_err_code);
 	}
 
@@ -845,6 +956,7 @@ static void avdtp_suspend_cmd(struct bt_avdtp *session, struct net_buf *buf, uin
 		}
 
 		LOG_DBG("suspend err code:%d", avdtp_err_code);
+		net_buf_add_u8(rsp_buf, sep->sep_info.id << 2);
 		net_buf_add_u8(rsp_buf, avdtp_err_code);
 	}
 
@@ -1539,12 +1651,14 @@ static int avdtp_process_configure_command(struct bt_avdtp *session, uint8_t cmd
 	/* Body of the message */
 	/* ACP Stream Endpoint ID */
 	net_buf_add_u8(buf, (param->acp_stream_ep_id << 2U));
-	/* INT Stream Endpoint ID */
-	net_buf_add_u8(buf, (param->int_stream_endpoint_id << 2U));
-	/* Service Category: Media Transport */
-	net_buf_add_u8(buf, BT_AVDTP_SERVICE_MEDIA_TRANSPORT);
-	/* LOSC */
-	net_buf_add_u8(buf, 0);
+	if (cmd == BT_AVDTP_SET_CONFIGURATION) {
+		/* INT Stream Endpoint ID */
+		net_buf_add_u8(buf, (param->int_stream_endpoint_id << 2U));
+		/* Service Category: Media Transport */
+		net_buf_add_u8(buf, BT_AVDTP_SERVICE_MEDIA_TRANSPORT);
+		/* LOSC */
+		net_buf_add_u8(buf, 0);
+	}
 	/* Service Category: Media Codec */
 	net_buf_add_u8(buf, BT_AVDTP_SERVICE_MEDIA_CODEC);
 	/* LOSC */

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -173,6 +173,54 @@ struct bt_avdtp_ctrl_params {
 	uint8_t acp_stream_ep_id;
 };
 
+struct bt_avdtp_generic_service_cap {
+	uint8_t service_category;
+	uint8_t losc;
+} __packed;
+
+/* avdtp service capabilities*/
+struct bt_avdtp_recovery_capabilities {
+	uint8_t recovery_type;
+	uint8_t MRWS;
+	uint8_t MNMP;
+} __packed;
+
+struct bt_avdtp_media_codec_capabilities {
+	uint8_t media_type;
+	uint8_t media_code_type;
+	uint8_t media_codec_spec_info[0];
+} __packed;
+
+struct bt_avdtp_content_protection_capabilities {
+	uint8_t cp_type_lsb;
+	uint8_t cp_type_msb;
+	uint8_t cp_type_spec_value[0];
+} __packed;
+
+struct bt_avdtp_header_compression_capabilities {
+#ifdef CONFIG_LITTLE_ENDIAN
+	uint8_t reserved : 5;
+	uint8_t recovery : 1;
+	uint8_t media : 1;
+	uint8_t backch : 1;
+#else
+	uint8_t backch : 1;
+	uint8_t media : 1;
+	uint8_t recovery : 1;
+	uint8_t reserved : 5;
+#endif /* CONFIG_LITTLE_ENDIAN */
+} __packed;
+
+struct bt_avdtp_multiplexing_capabilities {
+	uint8_t frag;
+	uint8_t tsid_media;
+	uint8_t tcid_media;
+	uint8_t tsid_reporting;
+	uint8_t tcid_reporting;
+	uint8_t tsid_recovery;
+	uint8_t tcid_recovery;
+} __packed;
+
 struct bt_avdtp_ops_cb {
 	void (*connected)(struct bt_avdtp *session);
 
@@ -189,7 +237,7 @@ struct bt_avdtp_ops_cb {
 				     uint8_t int_seid, struct net_buf *buf, uint8_t *errcode);
 
 	int (*re_configuration_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep,
-				    uint8_t int_seid, struct net_buf *buf, uint8_t *errcode);
+				    struct net_buf *buf, uint8_t *errcode);
 
 	int (*open_ind)(struct bt_avdtp *session, struct bt_avdtp_sep *sep, uint8_t *errcode);
 


### PR DESCRIPTION
There are three aspects of changes involved:
1.  The format of Service Category should be checked  in set configuration cmd and error code and Service Category should be detailed in response.
2. There is no  INT Stream Endpoint ID in re_config cmd,.
3. Fail ACP SEID should be added to start and suspend rej rsp.