### PR TITLE
boards: st: stm32h7rs boards have no TrustZone

### DIFF
--- a/boards/st/nucleo_h7s3l8/doc/index.rst
+++ b/boards/st/nucleo_h7s3l8/doc/index.rst
@@ -46,16 +46,13 @@ The STM32H7S7xx devices are a high-performance microcontrollers family (STM32H7
 Series) based on the high-performance Arm |reg| Cortex |reg|-M7 32-bit RISC core.
 They operate at a frequency of up to 500 MHz.
 
-- Core: ARM |reg| 32-bit Cortex |reg| -M7 CPU with TrustZone |reg| and FPU.
+- Core: ARM |reg| 32-bit Cortex |reg| -M7 CPU with FPU.
 - Performance benchmark:
 
   - 1284 DMPIS/MHz (Dhrystone 2.1)
 
 - Security
 
-  - Arm |reg| TrustZone |reg| with ARMv8-M mainline security extension
-  - Up to 8 configurable SAU regions
-  - TrustZone |reg| aware and securable peripherals
   - Flexible lifecycle scheme with secure debug authentication
   - Preconfigured immutable root of trust (ST-iROT)
   - SFI (secure firmware installation)
@@ -65,7 +62,6 @@ They operate at a frequency of up to 500 MHz.
   - Public key accelerator, DPA resistant
   - On-the-fly decryption of Octo-SPI external memories
   - HASH hardware accelerator
-  - True random number generator, NIST SP800-90B compliant
   - 96-bit unique ID
   - Active tampers
   - True Random Number Generator (RNG) NIST SP800-90B compliant

--- a/boards/st/stm32h7s78_dk/doc/index.rst
+++ b/boards/st/stm32h7s78_dk/doc/index.rst
@@ -5,8 +5,7 @@ Overview
 
 The STM32H7S78-DK Discovery kit is designed as a complete demonstration and
 development platform for STMicroelectronics Arm |reg| Cortex |reg|-M7 core-based
-STM32H7S7L8H6H microcontroller with TrustZone |reg|. Here are some highlights of
-the STM32H7S78-DK Discovery board:
+STM32H7S7L8H6H microcontroller. Here are some highlights of the STM32H7S78-DK Discovery board:
 
 
 - STM32H7S7L8H6H microcontroller featuring 64Kbytes of Flash memory and 620 Kbytes of SRAM in 225-pin TFBGA package
@@ -47,16 +46,13 @@ The STM32H7S7xx devices are a high-performance microcontrollers family (STM32H7
 Series) based on the high-performance Arm |reg| Cortex |reg|-M7 32-bit RISC core.
 They operate at a frequency of up to 500 MHz.
 
-- Core: ARM |reg| 32-bit Cortex |reg| -M7 CPU with TrustZone |reg| and FPU.
+- Core: ARM |reg| 32-bit Cortex |reg| -M7 CPU with FPU.
 - Performance benchmark:
 
   - 1284 DMPIS/MHz (Dhrystone 2.1)
 
 - Security
 
-  - Arm |reg| TrustZone |reg| with ARMv8-M mainline security extension
-  - Up to 8 configurable SAU regions
-  - TrustZone |reg| aware and securable peripherals
   - Flexible lifecycle scheme with secure debug authentication
   - Preconfigured immutable root of trust (ST-iROT)
   - SFI (secure firmware installation)
@@ -66,7 +62,6 @@ They operate at a frequency of up to 500 MHz.
   - Public key accelerator, DPA resistant
   - On-the-fly decryption of Octo-SPI external memories
   - HASH hardware accelerator
-  - True random number generator, NIST SP800-90B compliant
   - 96-bit unique ID
   - Active tampers
   - True Random Number Generator (RNG) NIST SP800-90B compliant


### PR DESCRIPTION
Remove the reference to TrustZone for the stm32h7s3 nucleo and the stm32h7s7 disco.
They do not have the feature embedded

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93632

