### PR TITLE
Fix arm_irq_vector_table test fail on Ambiq platforms

### DIFF
--- a/boards/ambiq/apollo3_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo3_evb/Kconfig.defconfig
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+# Copyright (c) 2024-2025 Ambiq Micro Inc. <www.ambiq.com>
 
 if BOARD_APOLLO3_EVB
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if AMBIQ_STIMER_TIMER
+	default 48000000 if CORTEX_M_SYSTICK
 
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 1000000

--- a/boards/ambiq/apollo3p_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo3p_evb/Kconfig.defconfig
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+# Copyright (c) 2024-2025 Ambiq Micro Inc. <www.ambiq.com>
 
 if BOARD_APOLLO3P_EVB
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if AMBIQ_STIMER_TIMER
+	default 48000000 if CORTEX_M_SYSTICK
 
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 1000000

--- a/boards/ambiq/apollo4p_blue_kxr_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo4p_blue_kxr_evb/Kconfig.defconfig
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (c) 2023 Ambiq Micro Inc. <www.ambiq.com>
+# Copyright (c) 2023-2025 Ambiq Micro Inc. <www.ambiq.com>
 
 if BOARD_APOLLO4P_BLUE_KXR_EVB
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if AMBIQ_STIMER_TIMER
+	default 96000000 if CORTEX_M_SYSTICK
 
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 1000000

--- a/boards/ambiq/apollo4p_evb/Kconfig.defconfig
+++ b/boards/ambiq/apollo4p_evb/Kconfig.defconfig
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
+# Copyright (c) 2024-2025 Ambiq Micro Inc. <www.ambiq.com>
 
 if BOARD_APOLLO4P_EVB
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if AMBIQ_STIMER_TIMER
+	default 96000000 if CORTEX_M_SYSTICK
 
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 1000000

--- a/drivers/serial/uart_ambiq.c
+++ b/drivers/serial/uart_ambiq.c
@@ -105,6 +105,7 @@ static void uart_ambiq_pm_policy_state_lock_get(const struct device *dev)
 	}
 }
 
+#if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 static void uart_ambiq_pm_policy_state_lock_put_unconditional(void)
 {
 	if (IS_ENABLED(CONFIG_PM)) {
@@ -123,6 +124,7 @@ static void uart_ambiq_pm_policy_state_lock_put(const struct device *dev)
 		}
 	}
 }
+#endif
 
 static int uart_ambiq_configure(const struct device *dev, const struct uart_config *cfg)
 {

--- a/drivers/timer/ambiq_stimer.c
+++ b/drivers/timer/ambiq_stimer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Antmicro <www.antmicro.com>
+ * Copyright (c) 2025, Ambiq Micro Inc. <www.ambiq.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -94,7 +95,7 @@ static void ambiq_stimer_delta_set(uint32_t ui32Delta)
 #endif
 }
 
-static void stimer_isr(const void *arg)
+void stimer_isr(const void *arg)
 {
 	ARG_UNUSED(arg);
 

--- a/soc/ambiq/apollo5x/soc.c
+++ b/soc/ambiq/apollo5x/soc.c
@@ -48,9 +48,9 @@ void soc_early_init_hook(void)
 	/*
 	 * Set default temperature for spotmgr to room temperature
 	 */
-	am_hal_pwrctrl_temp_thresh_t dummy[32];
+	am_hal_pwrctrl_temp_thresh_t dummy;
 
-	am_hal_pwrctrl_temp_update(25.0f, dummy);
+	am_hal_pwrctrl_temp_update(25.0f, &dummy);
 
 	/* Enable Icache*/
 	sys_cache_instr_enable();

--- a/tests/arch/arm/arm_irq_vector_table/boards/apollo510_evb.conf
+++ b/tests/arch/arm/arm_irq_vector_table/boards/apollo510_evb.conf
@@ -1,0 +1,3 @@
+ # start of software interrupt number
+CONFIG_ISR_OFFSET=92
+CONFIG_UART_INTERRUPT_DRIVEN=n

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -243,6 +243,33 @@ const vth __irq_vector_table _irq_vector_table[] = {
 #else
 #error "GPT timer enabled, but no known SOC selected. ISR table needs rework"
 #endif
+
+#elif defined(CONFIG_SOC_FAMILY_AMBIQ)
+
+#if defined(CONFIG_AMBIQ_STIMER_TIMER)
+extern void stimer_isr(void);
+#define TIMER_IRQ_NUM DT_IRQN(DT_INST(0, ambiq_stimer))
+#define TIMER_IRQ_HANDLER stimer_isr
+#define IRQ_VECTOR_TABLE_SIZE _ISR_OFFSET > TIMER_IRQ_NUM ? (_ISR_OFFSET + 3) : (TIMER_IRQ_NUM + 2)
+#else
+#define IRQ_VECTOR_TABLE_SIZE (_ISR_OFFSET + 3)
+#endif /* CONFIG_AMBIQ_STIMER_TIMER */
+
+const vth __irq_vector_table _irq_vector_table[IRQ_VECTOR_TABLE_SIZE] = {
+	[_ISR_OFFSET] = isr0,
+	[_ISR_OFFSET + 1] = isr1,
+	[_ISR_OFFSET + 2] = isr2,
+#ifdef CONFIG_AMBIQ_STIMER_TIMER
+	[TIMER_IRQ_NUM] = TIMER_IRQ_HANDLER,
+#if defined(CONFIG_SOC_SERIES_APOLLO3X) || defined(CONFIG_SOC_SERIES_APOLLO4X)
+	[TIMER_IRQ_NUM + 1] = TIMER_IRQ_HANDLER,
+#endif
+#endif
+#ifdef CONFIG_SOC_SERIES_APOLLO5X
+	[TIMER0_IRQn + AM_HAL_INTERNAL_TIMER_NUM_A] = hal_internal_timer_isr,
+#endif
+};
+
 #else
 
 #if defined(CONFIG_MCUX_OS_TIMER)


### PR DESCRIPTION
Fixed build fail since 4c93fcd35b2.
Fixed test run fail on apollo510_evb.
Added Ambiq section in the test.