### PR TITLE
Bluetooth: CTS: Fix issue with writing without subscription

### DIFF
--- a/subsys/bluetooth/services/cts.c
+++ b/subsys/bluetooth/services/cts.c
@@ -16,6 +16,7 @@
 #include <zephyr/sys/timeutil.h>
 #endif
 
+#include <errno.h>
 #include <stdbool.h>
 #include <zephyr/sys/byteorder.h>
 
@@ -152,8 +153,8 @@ static ssize_t write_ct(struct bt_conn *conn, const struct bt_gatt_attr *attr, c
 	}
 
 	err = bt_cts_send_notification(BT_CTS_UPDATE_REASON_MANUAL);
-	if (err) {
-		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+	if (err != 0 && err != -ENOTCONN) {
+		LOG_WRN("New value was not notified to clients: %d", err);
 	}
 
 	return len;


### PR DESCRIPTION
The write_ct function calls bt_cts_send_notification and if bt_cts_send_notification fails to send a notification (e.g. if there are no clients subscribed), it would return an error, and thus send a ATT error response to the client, even if the value was actually written.

This commit changes the behavior so that the notification does not affect the return value (as it is not directly linked to the write itself), but rather just logs it if it fails to send the notification.

The notification can failed to be send for 2 main reasons: 1) The application returns an error on fill_current_cts_time 2) bt_gatt_notify fails to notify due to missing buffers

The first we cannot do much about. For the latter we can either just live with the missing notification, or implement a retry if we run out of buffers. For this simple fix the former was chosen, but can be revisited if it turns out to be a significant problem.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/93551