### PR TITLE
fs/ext2: Fix NULL dereference when fs_stat queries root.

### DIFF
--- a/subsys/fs/ext2/ext2_ops.c
+++ b/subsys/fs/ext2/ext2_ops.c
@@ -598,12 +598,11 @@ static int ext2_stat(struct fs_mount_t *mountp, const char *path, struct fs_dire
 	}
 
 	uint32_t offset = args.offset;
-	struct ext2_inode *parent = args.parent;
-	struct ext2_file dir = {.f_inode = parent, .f_off = offset};
+	struct ext2_file dir = {.f_inode = args.parent ? args.parent : args.inode, .f_off = offset};
 
 	rc = ext2_get_direntry(&dir, entry);
 
-	ext2_inode_drop(parent);
+	ext2_inode_drop(args.parent);
 	ext2_inode_drop(args.inode);
 	return rc;
 }


### PR DESCRIPTION
When fs_stat() queries the root / mountpoint it should return its root i_node but instead it tries to return the parent i_node which does not exist. Fix this by checking if parent is set otherwise return the root i_node.