### PR TITLE
llext: Use clang format on all llext files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -101,6 +101,11 @@ IndentGotoLabels: false
 IndentWidth: 8
 InsertBraces: true
 InsertNewlineAtEOF: true
+# Control when we break long lines by adjusting the penalty values for breaking on particular code elements
+PenaltyBreakAssignment: 120
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyBreakOpenParenthesis: 80
+PenaltyBreakString: 100
 SpaceBeforeInheritanceColon: False
 SpaceBeforeParens: ControlStatementsExceptControlMacros
 SortIncludes: Never

--- a/include/zephyr/llext/buf_loader.h
+++ b/include/zephyr/llext/buf_loader.h
@@ -73,10 +73,10 @@ void *llext_buf_peek(struct llext_loader *ldr, size_t pos);
  * @param _buf Buffer containing the ELF binary
  * @param _buf_len Buffer length in bytes
  */
-#define LLEXT_BUF_LOADER(_buf, _buf_len) \
+#define LLEXT_BUF_LOADER(_buf, _buf_len)                                                           \
 	Z_LLEXT_BUF_LOADER(_buf, _buf_len,                                                         \
-			   IS_ENABLED(CONFIG_LLEXT_STORAGE_WRITABLE) ?                             \
-				LLEXT_STORAGE_WRITABLE : LLEXT_STORAGE_PERSISTENT)
+			   IS_ENABLED(CONFIG_LLEXT_STORAGE_WRITABLE) ? LLEXT_STORAGE_WRITABLE      \
+								     : LLEXT_STORAGE_PERSISTENT)
 
 /* @brief Initialize an llext_buf_loader structure for a temporary buffer
  *
@@ -87,7 +87,7 @@ void *llext_buf_peek(struct llext_loader *ldr, size_t pos);
  * @param _buf Buffer containing the ELF binary
  * @param _buf_len Buffer length in bytes
  */
-#define LLEXT_TEMPORARY_BUF_LOADER(_buf, _buf_len) \
+#define LLEXT_TEMPORARY_BUF_LOADER(_buf, _buf_len)                                                 \
 	Z_LLEXT_BUF_LOADER(_buf, _buf_len, LLEXT_STORAGE_TEMPORARY)
 
 /**
@@ -100,7 +100,7 @@ void *llext_buf_peek(struct llext_loader *ldr, size_t pos);
  * @param _buf Buffer containing the ELF binary
  * @param _buf_len Buffer length in bytes
  */
-#define LLEXT_PERSISTENT_BUF_LOADER(_buf, _buf_len) \
+#define LLEXT_PERSISTENT_BUF_LOADER(_buf, _buf_len)                                                \
 	Z_LLEXT_BUF_LOADER(_buf, _buf_len, LLEXT_STORAGE_PERSISTENT)
 
 /**
@@ -113,7 +113,7 @@ void *llext_buf_peek(struct llext_loader *ldr, size_t pos);
  * @param _buf Buffer containing the ELF binary
  * @param _buf_len Buffer length in bytes
  */
-#define LLEXT_WRITABLE_BUF_LOADER(_buf, _buf_len) \
+#define LLEXT_WRITABLE_BUF_LOADER(_buf, _buf_len)                                                  \
 	Z_LLEXT_BUF_LOADER(_buf, _buf_len, LLEXT_STORAGE_WRITABLE)
 
 /**

--- a/include/zephyr/llext/elf.h
+++ b/include/zephyr/llext/elf.h
@@ -51,7 +51,6 @@ typedef int64_t elf64_sxword;
 /** Unsigned long integer */
 typedef uint64_t elf64_xword;
 
-
 /**
  * @brief ELF identifier block
  *
@@ -134,13 +133,13 @@ struct elf64_ehdr {
 };
 
 /** Relocatable (unlinked) ELF */
-#define ET_REL  1
+#define ET_REL 1
 
 /** Executable (without PIC/PIE) ELF */
 #define ET_EXEC 2
 
 /** Dynamic (executable with PIC/PIE or shared lib) ELF */
-#define ET_DYN  3
+#define ET_DYN 3
 
 /** Core Dump */
 #define ET_CORE 4
@@ -198,26 +197,26 @@ struct elf64_shdr {
 };
 
 /** ELF section types */
-#define SHT_NULL 0x0            /**< Unused section */
-#define SHT_PROGBITS 0x1        /**< Program data */
-#define SHT_SYMTAB 0x2          /**< Symbol table */
-#define SHT_STRTAB 0x3          /**< String table */
-#define SHT_RELA 0x4            /**< Relocation entries with addends */
-#define SHT_NOBITS 0x8          /**< Program data with no file image */
-#define SHT_REL 0x9             /**< Relocation entries without addends */
-#define SHT_DYNSYM 0xB          /**< Dynamic linking symbol table */
-#define SHT_INIT_ARRAY 0xe      /**< Array of pointers to init functions */
-#define SHT_FINI_ARRAY 0xf      /**< Array of pointers to termination functions */
-#define SHT_PREINIT_ARRAY 0x10  /**< Array of pointers to early init functions */
+#define SHT_NULL          0x0  /**< Unused section */
+#define SHT_PROGBITS      0x1  /**< Program data */
+#define SHT_SYMTAB        0x2  /**< Symbol table */
+#define SHT_STRTAB        0x3  /**< String table */
+#define SHT_RELA          0x4  /**< Relocation entries with addends */
+#define SHT_NOBITS        0x8  /**< Program data with no file image */
+#define SHT_REL           0x9  /**< Relocation entries without addends */
+#define SHT_DYNSYM        0xB  /**< Dynamic linking symbol table */
+#define SHT_INIT_ARRAY    0xe  /**< Array of pointers to init functions */
+#define SHT_FINI_ARRAY    0xf  /**< Array of pointers to termination functions */
+#define SHT_PREINIT_ARRAY 0x10 /**< Array of pointers to early init functions */
 
 /** ELF section flags */
-#define SHF_WRITE 0x1                   /**< Section is writable */
-#define SHF_ALLOC 0x2                   /**< Section is present in memory */
-#define SHF_EXECINSTR 0x4               /**< Section contains executable instructions */
-#define SHF_MASKOS 0x0ff00000           /**< OS specific flags */
+#define SHF_WRITE            0x1        /**< Section is writable */
+#define SHF_ALLOC            0x2        /**< Section is present in memory */
+#define SHF_EXECINSTR        0x4        /**< Section contains executable instructions */
+#define SHF_MASKOS           0x0ff00000 /**< OS specific flags */
 #define SHF_LLEXT_HAS_RELOCS 0x00100000 /**< Section is a target for relocations */
 
-#define SHF_BASIC_TYPE_MASK	(SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR)
+#define SHF_BASIC_TYPE_MASK (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR)
 
 /**
  * @brief Symbol table entry(32-bit)
@@ -256,32 +255,32 @@ struct elf64_sym {
 };
 
 /** ELF section numbers */
-#define SHN_UNDEF 0             /**< Undefined section */
-#define SHN_LORESERVE 0xff00    /**< Start of reserved section numbers */
-#define SHN_ABS 0xfff1          /**< Special value for absolute symbols */
-#define SHN_COMMON 0xfff2       /**< Common block */
-#define SHN_HIRESERVE 0xffff    /**< End of reserved section numbers */
+#define SHN_UNDEF     0      /**< Undefined section */
+#define SHN_LORESERVE 0xff00 /**< Start of reserved section numbers */
+#define SHN_ABS       0xfff1 /**< Special value for absolute symbols */
+#define SHN_COMMON    0xfff2 /**< Common block */
+#define SHN_HIRESERVE 0xffff /**< End of reserved section numbers */
 
 /** Symbol table entry types */
-#define STT_NOTYPE 0            /**< No type */
-#define STT_OBJECT 1            /**< Data or object */
-#define STT_FUNC 2              /**< Function */
-#define STT_SECTION 3           /**< Section */
-#define STT_FILE 4              /**< File name */
-#define STT_COMMON 5            /**< Common block */
-#define STT_LOOS 10             /**< Start of OS specific */
-#define STT_HIOS 12             /**< End of OS specific */
-#define STT_LOPROC 13           /**< Start of processor specific */
-#define STT_HIPROC 15           /**< End of processor specific */
+#define STT_NOTYPE  0  /**< No type */
+#define STT_OBJECT  1  /**< Data or object */
+#define STT_FUNC    2  /**< Function */
+#define STT_SECTION 3  /**< Section */
+#define STT_FILE    4  /**< File name */
+#define STT_COMMON  5  /**< Common block */
+#define STT_LOOS    10 /**< Start of OS specific */
+#define STT_HIOS    12 /**< End of OS specific */
+#define STT_LOPROC  13 /**< Start of processor specific */
+#define STT_HIPROC  15 /**< End of processor specific */
 
 /** Symbol table entry bindings */
-#define STB_LOCAL 0             /**< Local symbol */
-#define STB_GLOBAL 1            /**< Global symbol */
-#define STB_WEAK 2              /**< Weak symbol */
-#define STB_LOOS 10             /**< Start of OS specific */
-#define STB_HIOS 12             /**< End of OS specific */
-#define STB_LOPROC 13           /**< Start of processor specific */
-#define STB_HIPROC 15           /**< End of processor specific */
+#define STB_LOCAL  0  /**< Local symbol */
+#define STB_GLOBAL 1  /**< Global symbol */
+#define STB_WEAK   2  /**< Weak symbol */
+#define STB_LOOS   10 /**< Start of OS specific */
+#define STB_HIOS   12 /**< End of OS specific */
+#define STB_LOPROC 13 /**< Start of processor specific */
+#define STB_HIPROC 15 /**< End of processor specific */
 
 /**
  * @brief Symbol binding from 32bit st_info
@@ -303,7 +302,6 @@ struct elf64_sym {
  * @param i Value of st_info
  */
 #define ELF64_ST_BIND(i) ((i) >> 4)
-
 
 /**
  * @brief Symbol type from 32bit st_info
@@ -404,28 +402,28 @@ struct elf64_rela {
  * @brief Program header(32-bit)
  */
 struct elf32_phdr {
-	elf32_word p_type;      /**< Type of segment */
-	elf32_off p_offset;     /**< Offset in file */
-	elf32_addr p_vaddr;     /**< Virtual address in memory */
-	elf32_addr p_paddr;     /**< Physical address (usually reserved) */
-	elf32_word p_filesz;    /**< Size of segment in file */
-	elf32_word p_memsz;     /**< Size of segment in memory */
-	elf32_word p_flags;     /**< Segment flags */
-	elf32_word p_align;     /**< Alignment of segment */
+	elf32_word p_type;   /**< Type of segment */
+	elf32_off p_offset;  /**< Offset in file */
+	elf32_addr p_vaddr;  /**< Virtual address in memory */
+	elf32_addr p_paddr;  /**< Physical address (usually reserved) */
+	elf32_word p_filesz; /**< Size of segment in file */
+	elf32_word p_memsz;  /**< Size of segment in memory */
+	elf32_word p_flags;  /**< Segment flags */
+	elf32_word p_align;  /**< Alignment of segment */
 };
 
 /**
  * @brief Program header(64-bit)
  */
 struct elf64_phdr {
-	elf64_word p_type;      /**< Type of segment */
-	elf64_off p_offset;     /**< Offset in file */
-	elf64_addr p_vaddr;     /**< Virtual address in memory */
-	elf64_addr p_paddr;     /**< Physical address (usually reserved) */
-	elf64_xword p_filesz;   /**< Size of segment in file */
-	elf64_xword p_memsz;    /**< Size of segment in memory */
-	elf64_word p_flags;     /**< Segment flags */
-	elf64_xword p_align;    /**< Alignment of segment */
+	elf64_word p_type;    /**< Type of segment */
+	elf64_off p_offset;   /**< Offset in file */
+	elf64_addr p_vaddr;   /**< Virtual address in memory */
+	elf64_addr p_paddr;   /**< Physical address (usually reserved) */
+	elf64_xword p_filesz; /**< Size of segment in file */
+	elf64_xword p_memsz;  /**< Size of segment in memory */
+	elf64_word p_flags;   /**< Segment flags */
+	elf64_xword p_align;  /**< Alignment of segment */
 };
 
 /**
@@ -437,10 +435,10 @@ struct elf64_phdr {
  * @brief Dynamic section entry(32-bit)
  */
 struct elf32_dyn {
-	elf32_sword d_tag;              /**< Entry tag */
+	elf32_sword d_tag; /**< Entry tag */
 	union {
-		elf32_word d_val;       /**< Integer value */
-		elf32_addr d_ptr;       /**< Address value */
+		elf32_word d_val; /**< Integer value */
+		elf32_addr d_ptr; /**< Address value */
 	} d_un;
 };
 
@@ -448,10 +446,10 @@ struct elf32_dyn {
  * @brief Dynamic section entry(64-bit)
  */
 struct elf64_dyn {
-	elf64_sxword d_tag;             /**< Entry tag */
+	elf64_sxword d_tag; /**< Entry tag */
 	union {
-		elf64_xword d_val;      /**< Integer value */
-		elf64_addr d_ptr;       /**< Address value */
+		elf64_xword d_val; /**< Integer value */
+		elf64_addr d_ptr;  /**< Address value */
 	} d_un;
 };
 /** @endcond */
@@ -476,9 +474,9 @@ typedef struct elf64_rela elf_rela_t;
 /** Machine sized symbol struct */
 typedef struct elf64_sym elf_sym_t;
 /** Machine sized macro alias for obtaining a relocation symbol */
-#define ELF_R_SYM ELF64_R_SYM
+#define ELF_R_SYM   ELF64_R_SYM
 /** Machine sized macro alias for obtaining a relocation type */
-#define ELF_R_TYPE ELF64_R_TYPE
+#define ELF_R_TYPE  ELF64_R_TYPE
 /** Machine sized macro alias for obtaining a symbol bind */
 #define ELF_ST_BIND ELF64_ST_BIND
 /** Machine sized macro alias for obtaining a symbol type */
@@ -503,9 +501,9 @@ typedef struct elf32_rela elf_rela_t;
 /** Machine sized symbol struct */
 typedef struct elf32_sym elf_sym_t;
 /** Machine sized macro alias for obtaining a relocation symbol */
-#define ELF_R_SYM ELF32_R_SYM
+#define ELF_R_SYM   ELF32_R_SYM
 /** Machine sized macro alias for obtaining a relocation type */
-#define ELF_R_TYPE ELF32_R_TYPE
+#define ELF_R_TYPE  ELF32_R_TYPE
 /** Machine sized macro alias for obtaining a symbol bind */
 #define ELF_ST_BIND ELF32_ST_BIND
 /** Machine sized macro alias for obtaining a symbol type */

--- a/include/zephyr/llext/inspect.h
+++ b/include/zephyr/llext/inspect.h
@@ -45,10 +45,8 @@ extern "C" {
  *
  * @return 0 on success, -EINVAL if the region is invalid
  */
-static inline int llext_get_region_info(const struct llext_loader *ldr,
-					const struct llext *ext,
-					enum llext_mem region,
-					const elf_shdr_t **hdr,
+static inline int llext_get_region_info(const struct llext_loader *ldr, const struct llext *ext,
+					enum llext_mem region, const elf_shdr_t **hdr,
 					const void **addr, size_t *size)
 {
 	if ((unsigned int)region >= LLEXT_MEM_COUNT) {
@@ -84,7 +82,7 @@ static inline int llext_get_region_info(const struct llext_loader *ldr,
  *         -ENOTSUP if section data is not available.
  */
 int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
-			    const char *section_name);
+			const char *section_name);
 
 /**
  * @brief Get information about a section for the specified extension.
@@ -105,12 +103,9 @@ int llext_section_shndx(const struct llext_loader *ldr, const struct llext *ext,
  * @return 0 on success, -EINVAL if the section index is invalid,
  *         -ENOTSUP if section data is not available.
  */
-static inline int llext_get_section_info(const struct llext_loader *ldr,
-					 const struct llext *ext,
-					 unsigned int shndx,
-					 const elf_shdr_t **hdr,
-					 enum llext_mem *region,
-					 size_t *offset)
+static inline int llext_get_section_info(const struct llext_loader *ldr, const struct llext *ext,
+					 unsigned int shndx, const elf_shdr_t **hdr,
+					 enum llext_mem *region, size_t *offset)
 {
 	if (shndx < 0 || shndx >= ext->sect_cnt) {
 		return -EINVAL;

--- a/include/zephyr/llext/llext.h
+++ b/include/zephyr/llext/llext.h
@@ -42,25 +42,25 @@ extern "C" {
  * together into a single memory region.
  */
 enum llext_mem {
-	LLEXT_MEM_TEXT,         /**< Executable code */
-	LLEXT_MEM_DATA,         /**< Initialized data */
-	LLEXT_MEM_RODATA,       /**< Read-only data */
-	LLEXT_MEM_BSS,          /**< Uninitialized data */
-	LLEXT_MEM_EXPORT,       /**< Exported symbol table */
-	LLEXT_MEM_SYMTAB,       /**< Symbol table */
-	LLEXT_MEM_STRTAB,       /**< Symbol name strings */
-	LLEXT_MEM_SHSTRTAB,     /**< Section name strings */
-	LLEXT_MEM_PREINIT,      /**< Array of early setup functions */
-	LLEXT_MEM_INIT,         /**< Array of setup functions */
-	LLEXT_MEM_FINI,         /**< Array of cleanup functions */
+	LLEXT_MEM_TEXT,     /**< Executable code */
+	LLEXT_MEM_DATA,     /**< Initialized data */
+	LLEXT_MEM_RODATA,   /**< Read-only data */
+	LLEXT_MEM_BSS,      /**< Uninitialized data */
+	LLEXT_MEM_EXPORT,   /**< Exported symbol table */
+	LLEXT_MEM_SYMTAB,   /**< Symbol table */
+	LLEXT_MEM_STRTAB,   /**< Symbol name strings */
+	LLEXT_MEM_SHSTRTAB, /**< Section name strings */
+	LLEXT_MEM_PREINIT,  /**< Array of early setup functions */
+	LLEXT_MEM_INIT,     /**< Array of setup functions */
+	LLEXT_MEM_FINI,     /**< Array of cleanup functions */
 
-	LLEXT_MEM_COUNT,        /**< Number of regions managed by LLEXT */
+	LLEXT_MEM_COUNT, /**< Number of regions managed by LLEXT */
 };
 
 /** @cond ignore */
 
 /* Number of memory partitions used by LLEXT */
-#define LLEXT_MEM_PARTITIONS (LLEXT_MEM_BSS+1)
+#define LLEXT_MEM_PARTITIONS (LLEXT_MEM_BSS + 1)
 
 struct llext_loader;
 /** @endcond */
@@ -178,7 +178,10 @@ struct llext_load_param {
 };
 
 /** Default initializer for @ref llext_load_param */
-#define LLEXT_LOAD_PARAM_DEFAULT { .relocate_local = true, }
+#define LLEXT_LOAD_PARAM_DEFAULT                                                                   \
+	{                                                                                          \
+		.relocate_local = true,                                                            \
+	}
 
 /**
  * @brief Find an llext by name

--- a/include/zephyr/llext/llext_internal.h
+++ b/include/zephyr/llext/llext_internal.h
@@ -20,7 +20,6 @@ extern "C" {
 
 /** @cond ignore */
 
-
 struct llext_elf_sect_map {
 	enum llext_mem mem_idx;
 	size_t offset;
@@ -28,30 +27,26 @@ struct llext_elf_sect_map {
 
 const void *llext_loaded_sect_ptr(struct llext_loader *ldr, struct llext *ext, unsigned int sh_ndx);
 
-
 static inline const char *llext_string(const struct llext_loader *ldr, const struct llext *ext,
-	enum llext_mem mem_idx, unsigned int idx)
+				       enum llext_mem mem_idx, unsigned int idx)
 {
 	return (const char *)ext->mem[mem_idx] + idx;
 }
 
 static inline uintptr_t llext_get_reloc_instruction_location(struct llext_loader *ldr,
-							     struct llext *ext,
-							     int shndx,
+							     struct llext *ext, int shndx,
 							     const elf_rela_t *rela)
 {
-	return (uintptr_t) llext_loaded_sect_ptr(ldr, ext, shndx) + rela->r_offset;
+	return (uintptr_t)llext_loaded_sect_ptr(ldr, ext, shndx) + rela->r_offset;
 }
 
 static inline const char *llext_section_name(const struct llext_loader *ldr,
-					     const struct llext *ext,
-					     const elf_shdr_t *shdr)
+					     const struct llext *ext, const elf_shdr_t *shdr)
 {
 	return llext_string(ldr, ext, LLEXT_MEM_SHSTRTAB, shdr->sh_name);
 }
 
-static inline const char *llext_symbol_name(const struct llext_loader *ldr,
-					    const struct llext *ext,
+static inline const char *llext_symbol_name(const struct llext_loader *ldr, const struct llext *ext,
 					    const elf_sym_t *sym)
 {
 	if (ELF_ST_TYPE(sym->st_info) == STT_SECTION) {

--- a/include/zephyr/llext/symbol.h
+++ b/include/zephyr/llext/symbol.h
@@ -72,7 +72,6 @@ struct llext_symbol {
 	void *addr;
 };
 
-
 /**
  * @brief A symbol table
  *
@@ -86,15 +85,13 @@ struct llext_symtable {
 	struct llext_symbol *syms;
 };
 
-
 /** @cond ignore */
 #ifdef LL_EXTENSION_BUILD
 /* Extension build: add exported symbols to llext table */
-#define Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)			\
-	static const struct llext_const_symbol					\
-			Z_GENERIC_SECTION(.exported_sym) __used			\
-			__llext_sym_ ## sym_name = {				\
-		.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,	\
+#define Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)                                           \
+	static const struct llext_const_symbol Z_GENERIC_SECTION(.exported_sym)                    \
+		__used __llext_sym_##sym_name = {                                                  \
+			.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,             \
 	}
 #else
 /* No-op when not building an extension */
@@ -111,7 +108,7 @@ struct llext_symtable {
  * @param sym_ident Extension symbol to export to the base image
  * @param sym_name Name associated with the symbol
  */
-#define LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)				\
+#define LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)                                             \
 	Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)
 
 /**
@@ -130,24 +127,21 @@ struct llext_symtable {
 /** @cond ignore */
 #if defined(LL_EXTENSION_BUILD)
 /* Extension build: EXPORT_SYMBOL maps to LL_EXTENSION_SYMBOL */
-#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
-	Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)
+#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name) Z_LL_EXTENSION_SYMBOL_NAMED(sym_ident, sym_name)
 #elif defined(CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID)
 /* SLID-enabled LLEXT application: export symbols, names in separate section */
-#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
-	static const char Z_GENERIC_SECTION(llext_exports_strtab) __used	\
-		__llext_sym_name_ ## sym_name[] = STRINGIFY(sym_name);		\
-	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,		\
-					     __llext_sym_ ## sym_name) = {	\
-		.name = __llext_sym_name_ ## sym_name,				\
-		.addr = (const void *)&sym_ident,				\
+#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)                                                 \
+	static const char Z_GENERIC_SECTION(llext_exports_strtab)                                  \
+	__used __llext_sym_name_##sym_name[] = STRINGIFY(sym_name);                                \
+	static const STRUCT_SECTION_ITERABLE(llext_const_symbol, __llext_sym_##sym_name) = {       \
+		.name = __llext_sym_name_##sym_name,                                               \
+		.addr = (const void *)&sym_ident,                                                  \
 	}
 #elif defined(CONFIG_LLEXT)
 /* LLEXT application: export symbols */
-#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
-	static const STRUCT_SECTION_ITERABLE(llext_const_symbol,		\
-					     __llext_sym_ ## sym_name) = {	\
-		.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,	\
+#define Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)                                                 \
+	static const STRUCT_SECTION_ITERABLE(llext_const_symbol, __llext_sym_##sym_name) = {       \
+		.name = STRINGIFY(sym_name), .addr = (const void *)&sym_ident,                     \
 	}
 #else
 /* No extension support in this build */
@@ -166,8 +160,7 @@ struct llext_symtable {
  * @param sym_ident Symbol to export
  * @param sym_name Name associated with the symbol
  */
-#define EXPORT_SYMBOL_NAMED(sym_ident, sym_name)				\
-	Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
+#define EXPORT_SYMBOL_NAMED(sym_ident, sym_name) Z_EXPORT_SYMBOL_NAMED(sym_ident, sym_name)
 
 /**
  * @brief Export a constant symbol from the current build
@@ -189,6 +182,5 @@ struct llext_symtable {
 #ifdef __cplusplus
 }
 #endif
-
 
 #endif /* ZEPHYR_LLEXT_SYMBOL_H */

--- a/subsys/llext/llext.c
+++ b/subsys/llext/llext.c
@@ -59,8 +59,7 @@ ssize_t llext_find_section(struct llext_loader *ldr, const char *search_name)
 	unsigned int i;
 	size_t pos;
 
-	for (i = 0, pos = ldr->hdr.e_shoff;
-	     i < ldr->hdr.e_shnum;
+	for (i = 0, pos = ldr->hdr.e_shoff; i < ldr->hdr.e_shnum;
 	     i++, pos += ldr->hdr.e_shentsize) {
 		shdr = llext_peek(ldr, pos);
 		if (!shdr) {
@@ -68,9 +67,8 @@ ssize_t llext_find_section(struct llext_loader *ldr, const char *search_name)
 			return -ENOTSUP;
 		}
 
-		const char *name = llext_peek(ldr,
-					      ldr->sects[LLEXT_MEM_SHSTRTAB].sh_offset +
-					      shdr->sh_name);
+		const char *name = llext_peek(ldr, ldr->sects[LLEXT_MEM_SHSTRTAB].sh_offset +
+							   shdr->sh_name);
 
 		if (!strcmp(name, search_name)) {
 			return shdr->sh_offset;
@@ -90,8 +88,7 @@ struct llext *llext_by_name(const char *name)
 {
 	k_mutex_lock(&llext_lock, K_FOREVER);
 
-	for (sys_snode_t *node = sys_slist_peek_head(&llext_list);
-	     node != NULL;
+	for (sys_snode_t *node = sys_slist_peek_head(&llext_list); node != NULL;
 	     node = sys_slist_peek_next(node)) {
 		struct llext *ext = CONTAINER_OF(node, struct llext, llext_list);
 
@@ -112,9 +109,7 @@ int llext_iterate(int (*fn)(struct llext *ext, void *arg), void *arg)
 
 	k_mutex_lock(&llext_lock, K_FOREVER);
 
-	for (node = sys_slist_peek_head(&llext_list);
-	     node;
-	     node = sys_slist_peek_next(node)) {
+	for (node = sys_slist_peek_head(&llext_list); node; node = sys_slist_peek_next(node)) {
 		struct llext *ext = CONTAINER_OF(node, struct llext, llext_list);
 
 		ret = fn(ext, arg);
@@ -284,8 +279,8 @@ static int call_fn_table(struct llext *ext, bool is_init)
 	}
 
 	for (int i = 0; i < fn_count; i++) {
-		LOG_DBG("calling %s function %p()",
-			is_init ? "bringup" : "teardown", (void *)fn_table[i]);
+		LOG_DBG("calling %s function %p()", is_init ? "bringup" : "teardown",
+			(void *)fn_table[i]);
 		fn_table[i]();
 	}
 

--- a/subsys/llext/llext_experimental.c
+++ b/subsys/llext/llext_experimental.c
@@ -32,10 +32,10 @@ int llext_relink_dependency(struct llext *ext, unsigned int n_ext)
 		for (j = 0; ext[i].dependency[j] && j < ARRAY_SIZE(ext[i].dependency); j++) {
 			for (k = 0; k < n_ext; k++) {
 				if (!strncmp(ext[k].name, ext[i].dependency[j]->name,
-				    sizeof(ext[k].name))) {
+					     sizeof(ext[k].name))) {
 					ext[i].dependency[j] = ext + k;
-					LOG_DBG("backup %s depends on %s",
-						ext[i].name, ext[k].name);
+					LOG_DBG("backup %s depends on %s", ext[i].name,
+						ext[k].name);
 					break;
 				}
 			}
@@ -163,8 +163,7 @@ int llext_restore(struct llext **ext, struct llext_loader **ldr, unsigned int n_
 				goto free_locked;
 			}
 
-			LOG_DBG("restore %s depends on %s",
-				next->name, next->dependency[j]->name);
+			LOG_DBG("restore %s depends on %s", next->name, next->dependency[j]->name);
 		}
 	}
 

--- a/subsys/llext/llext_handlers.c
+++ b/subsys/llext/llext_handlers.c
@@ -24,8 +24,7 @@ ssize_t z_impl_llext_get_fn_table(struct llext *ext, bool is_init, void *buf, si
 	}
 
 	if (is_init) {
-		table_size = ext->mem_size[LLEXT_MEM_PREINIT] +
-			     ext->mem_size[LLEXT_MEM_INIT];
+		table_size = ext->mem_size[LLEXT_MEM_PREINIT] + ext->mem_size[LLEXT_MEM_INIT];
 	} else {
 		table_size = ext->mem_size[LLEXT_MEM_FINI];
 	}
@@ -39,14 +38,13 @@ ssize_t z_impl_llext_get_fn_table(struct llext *ext, bool is_init, void *buf, si
 
 		if (is_init) {
 			/* setup functions from preinit_array and init_array */
-			memcpy(byte_ptr,
-			       ext->mem[LLEXT_MEM_PREINIT], ext->mem_size[LLEXT_MEM_PREINIT]);
+			memcpy(byte_ptr, ext->mem[LLEXT_MEM_PREINIT],
+			       ext->mem_size[LLEXT_MEM_PREINIT]);
 			memcpy(byte_ptr + ext->mem_size[LLEXT_MEM_PREINIT],
 			       ext->mem[LLEXT_MEM_INIT], ext->mem_size[LLEXT_MEM_INIT]);
 		} else {
 			/* cleanup functions from fini_array */
-			memcpy(byte_ptr,
-			       ext->mem[LLEXT_MEM_FINI], ext->mem_size[LLEXT_MEM_FINI]);
+			memcpy(byte_ptr, ext->mem[LLEXT_MEM_FINI], ext->mem_size[LLEXT_MEM_FINI]);
 		}
 
 		/* Sanity check: pointers in this table must map inside the
@@ -61,8 +59,7 @@ ssize_t z_impl_llext_get_fn_table(struct llext *ext, bool is_init, void *buf, si
 		for (int i = 0; i < table_size / sizeof(void *); i++) {
 			if (fn_ptrs[i] < text_start || fn_ptrs[i] >= text_end) {
 				LOG_ERR("%s function %i (%p) outside text region",
-					is_init ? "bringup" : "teardown",
-					i, fn_ptrs[i]);
+					is_init ? "bringup" : "teardown", i, fn_ptrs[i]);
 				return -EFAULT;
 			}
 		}
@@ -78,8 +75,8 @@ static int ext_is_valid(struct llext *ext, void *arg)
 	return ext == arg;
 }
 
-static inline ssize_t z_vrfy_llext_get_fn_table(struct llext *ext, bool is_init,
-						void *buf, size_t size)
+static inline ssize_t z_vrfy_llext_get_fn_table(struct llext *ext, bool is_init, void *buf,
+						size_t size)
 {
 	/* Test that ext matches a loaded extension */
 	K_OOPS(llext_iterate(ext_is_valid, ext) == 0);

--- a/subsys/llext/llext_link.c
+++ b/subsys/llext/llext_link.c
@@ -21,7 +21,7 @@ LOG_MODULE_DECLARE(llext, CONFIG_LLEXT_LOG_LEVEL);
 #include "llext_priv.h"
 
 #ifdef CONFIG_LLEXT_EXPORT_BUILTINS_BY_SLID
-#define SYM_NAME_OR_SLID(name, slid) ((const char *) slid)
+#define SYM_NAME_OR_SLID(name, slid) ((const char *)slid)
 #else
 #define SYM_NAME_OR_SLID(name, slid) name
 #endif
@@ -33,8 +33,8 @@ __weak int arch_elf_relocate(struct llext_loader *ldr, struct llext *ext, elf_re
 }
 
 __weak int arch_elf_relocate_local(struct llext_loader *ldr, struct llext *ext,
-				    const elf_rela_t *rel, const elf_sym_t *sym, uint8_t *rel_addr,
-				    const struct llext_load_param *ldr_parm)
+				   const elf_rela_t *rel, const elf_sym_t *sym, uint8_t *rel_addr,
+				   const struct llext_load_param *ldr_parm)
 {
 	return -ENOTSUP;
 }
@@ -152,8 +152,8 @@ int llext_read_symbol(struct llext_loader *ldr, struct llext *ext, const elf_rel
 {
 	int ret;
 
-	ret = llext_seek(ldr, ldr->sects[LLEXT_MEM_SYMTAB].sh_offset
-		+ ELF_R_SYM(rel->r_info) * sizeof(elf_sym_t));
+	ret = llext_seek(ldr, ldr->sects[LLEXT_MEM_SYMTAB].sh_offset +
+				      ELF_R_SYM(rel->r_info) * sizeof(elf_sym_t));
 	if (ret != 0) {
 		return ret;
 	}
@@ -209,7 +209,8 @@ int llext_lookup_symbol(struct llext_loader *ldr, struct llext *ext, uintptr_t *
 
 				if (strncmp(name, dev_prefix, prefix_len) == 0) {
 					LOG_WRN("(Device objects are not available for import "
-						"because CONFIG_LLEXT_EXPORT_DEVICES is not enabled)");
+						"because CONFIG_LLEXT_EXPORT_DEVICES is not "
+						"enabled)");
 				}
 			}
 			return -ENODATA;
@@ -236,8 +237,8 @@ int llext_lookup_symbol(struct llext_loader *ldr, struct llext *ext, uintptr_t *
 		 * For regular symbols, the link address is obtained by adding st_value to the start
 		 * address of the section in which the target symbol resides.
 		 */
-		*link_addr =
-			(uintptr_t)llext_loaded_sect_ptr(ldr, ext, sym->st_shndx) + sym->st_value;
+		*link_addr = (uintptr_t)llext_loaded_sect_ptr(ldr, ext, sym->st_shndx) +
+			     sym->st_value;
 	} else {
 		LOG_ERR("cannot apply relocation: "
 			"target symbol has unexpected section index %d (%#x)",
@@ -260,8 +261,8 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 	int link_err = 0;
 
 	LOG_DBG("Found %p in PLT %u size %zu cnt %u text %p",
-		(void *)llext_section_name(ldr, ext, shdr),
-		shdr->sh_type, (size_t)shdr->sh_entsize, sh_cnt, (void *)text);
+		(void *)llext_section_name(ldr, ext, shdr), shdr->sh_type, (size_t)shdr->sh_entsize,
+		sh_cnt, (void *)text);
 
 	const elf_shdr_t *sym_shdr = ldr->sects + LLEXT_MEM_SYMTAB;
 	unsigned int sym_cnt = sym_shdr->sh_size / sym_shdr->sh_entsize;
@@ -303,9 +304,7 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 
 		uint32_t stt = ELF_ST_TYPE(sym.st_info);
 
-		if (stt != STT_FUNC &&
-		    stt != STT_SECTION &&
-		    stt != STT_OBJECT &&
+		if (stt != STT_FUNC && stt != STT_SECTION && stt != STT_OBJECT &&
 		    (stt != STT_NOTYPE || sym.st_shndx != SHN_UNDEF)) {
 			continue;
 		}
@@ -329,7 +328,7 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 		}
 
 		uint8_t *rel_addr = (uint8_t *)ext->mem[LLEXT_MEM_TEXT] -
-			ldr->sects[LLEXT_MEM_TEXT].sh_offset;
+				    ldr->sects[LLEXT_MEM_TEXT].sh_offset;
 
 		if (tgt) {
 			/* Relocatable / partially linked ELF. */
@@ -353,8 +352,7 @@ static int llext_link_plt(struct llext_loader *ldr, struct llext *ext, elf_shdr_
 		switch (stb) {
 		case STB_GLOBAL:
 			/* First try the global symbol table */
-			link_addr = llext_find_sym(NULL,
-				SYM_NAME_OR_SLID(name, sym.st_value));
+			link_addr = llext_find_sym(NULL, SYM_NAME_OR_SLID(name, sym.st_value));
 
 			if (!link_addr) {
 				/* Next try internal tables */
@@ -440,12 +438,10 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			continue;
 		}
 
-		if (shdr->sh_info >= ext->sect_cnt ||
-		    shdr->sh_size % shdr->sh_entsize != 0) {
+		if (shdr->sh_info >= ext->sect_cnt || shdr->sh_size % shdr->sh_entsize != 0) {
 			LOG_ERR("Sanity checks failed for section %d "
-				"(info %zd, size %zd, entsize %zd)", i,
-				(size_t)shdr->sh_info,
-				(size_t)shdr->sh_size,
+				"(info %zd, size %zd, entsize %zd)",
+				i, (size_t)shdr->sh_info, (size_t)shdr->sh_size,
 				(size_t)shdr->sh_entsize);
 			return -ENOEXEC;
 		}
@@ -463,8 +459,7 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 		if (IS_ENABLED(CONFIG_XTENSA)) {
 			elf_shdr_t *tgt;
 
-			if (strcmp(name, ".rela.plt") == 0 ||
-			    strcmp(name, ".rela.dyn") == 0) {
+			if (strcmp(name, ".rela.plt") == 0 || strcmp(name, ".rela.dyn") == 0) {
 				tgt = NULL;
 			} else {
 				/*
@@ -487,8 +482,8 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			continue;
 		}
 
-		LOG_DBG("relocation section %s (%d) acting on section %d has %zd relocations",
-			name, i, shdr->sh_info, (size_t)rel_cnt);
+		LOG_DBG("relocation section %s (%d) acting on section %d has %zd relocations", name,
+			i, shdr->sh_info, (size_t)rel_cnt);
 
 		enum llext_mem mem_idx = ldr->sect_map[shdr->sh_info].mem_idx;
 
@@ -497,7 +492,7 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			return -ENOEXEC;
 		}
 
-		sect_base = (uintptr_t) llext_loaded_sect_ptr(ldr, ext, shdr->sh_info);
+		sect_base = (uintptr_t)llext_loaded_sect_ptr(ldr, ext, shdr->sh_info);
 
 		for (int j = 0; j < rel_cnt; j++) {
 			/* get each relocation entry */
@@ -522,8 +517,8 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			ret = llext_read_symbol(ldr, ext, &rel, &sym);
 			if (ret == 0) {
 				name = llext_symbol_name(ldr, ext, &sym);
-				ret = llext_lookup_symbol(ldr, ext, &link_addr, &rel, &sym,
-							  name, shdr);
+				ret = llext_lookup_symbol(ldr, ext, &link_addr, &rel, &sym, name,
+							  shdr);
 			} else {
 				name = "<unknown>";
 			}
@@ -537,9 +532,8 @@ int llext_link(struct llext_loader *ldr, struct llext *ext, const struct llext_l
 			LOG_DBG("%srelocation %d:%d info %#zx (type %zd, sym %zd) offset %zd"
 				" sym_name %s sym_type %d sym_bind %d sym_ndx %d",
 				inv_str, i, j, (size_t)rel.r_info, (size_t)ELF_R_TYPE(rel.r_info),
-				(size_t)ELF_R_SYM(rel.r_info), (size_t)rel.r_offset,
-				name, ELF_ST_TYPE(sym.st_info),
-				ELF_ST_BIND(sym.st_info), sym.st_shndx);
+				(size_t)ELF_R_SYM(rel.r_info), (size_t)rel.r_offset, name,
+				ELF_ST_TYPE(sym.st_info), ELF_ST_BIND(sym.st_info), sym.st_shndx);
 
 			LOG_DBG("%swriting relocation type %d at %#lx with symbol %s (%#lx)",
 				inv_str, (int)ELF_R_TYPE(rel.r_info), op_loc, name, link_addr);

--- a/subsys/llext/llext_load.c
+++ b/subsys/llext/llext_load.c
@@ -164,16 +164,9 @@ static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 
 		LOG_DBG("section %d at %#zx: name %d, type %d, flags %#zx, "
 			"addr %#zx, align %#zx, size %zd, link %d, info %d",
-			i,
-			(size_t)shdr->sh_offset,
-			shdr->sh_name,
-			shdr->sh_type,
-			(size_t)shdr->sh_flags,
-			(size_t)shdr->sh_addr,
-			(size_t)shdr->sh_addralign,
-			(size_t)shdr->sh_size,
-			shdr->sh_link,
-			shdr->sh_info);
+			i, (size_t)shdr->sh_offset, shdr->sh_name, shdr->sh_type,
+			(size_t)shdr->sh_flags, (size_t)shdr->sh_addr, (size_t)shdr->sh_addralign,
+			(size_t)shdr->sh_size, shdr->sh_link, shdr->sh_info);
 
 		if (shdr->sh_type == SHT_SYMTAB && ldr->hdr.e_type == ET_REL) {
 			LOG_DBG("symtab at %d", i);
@@ -200,8 +193,7 @@ static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 		}
 	}
 
-	if (!ldr->sects[LLEXT_MEM_SHSTRTAB].sh_type ||
-	    !ldr->sects[LLEXT_MEM_STRTAB].sh_type ||
+	if (!ldr->sects[LLEXT_MEM_SHSTRTAB].sh_type || !ldr->sects[LLEXT_MEM_STRTAB].sh_type ||
 	    !ldr->sects[LLEXT_MEM_SYMTAB].sh_type) {
 		LOG_ERR("Some sections are missing or present multiple times!");
 		return -ENOEXEC;
@@ -215,8 +207,8 @@ static int llext_find_tables(struct llext_loader *ldr, struct llext *ext)
 #define REGION_TOP(reg, field) (size_t)(reg->field + reg->sh_size - 1)
 
 /* Check if two regions x and y have any overlap on a given field. Any shared value counts. */
-#define REGIONS_OVERLAP_ON(x, y, f) \
-	((REGION_BOT(x, f) <= REGION_BOT(y, f) && REGION_TOP(x, f) >= REGION_BOT(y, f)) || \
+#define REGIONS_OVERLAP_ON(x, y, f)                                                                \
+	((REGION_BOT(x, f) <= REGION_BOT(y, f) && REGION_TOP(x, f) >= REGION_BOT(y, f)) ||         \
 	 (REGION_BOT(y, f) <= REGION_BOT(x, f) && REGION_TOP(y, f) >= REGION_BOT(x, f)))
 
 /*
@@ -239,8 +231,8 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 		name = llext_section_name(ldr, ext, shdr);
 
 		if (ldr->sect_map[i].mem_idx != LLEXT_MEM_COUNT) {
-			LOG_DBG("section %d name %s already mapped to region %d",
-				i, name, ldr->sect_map[i].mem_idx);
+			LOG_DBG("section %d name %s already mapped to region %d", i, name,
+				ldr->sect_map[i].mem_idx);
 			continue;
 		}
 
@@ -279,8 +271,7 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 			mem_idx = LLEXT_MEM_EXPORT;
 		}
 
-		if (mem_idx == LLEXT_MEM_COUNT ||
-		    !(shdr->sh_flags & SHF_ALLOC) ||
+		if (mem_idx == LLEXT_MEM_COUNT || !(shdr->sh_flags & SHF_ALLOC) ||
 		    shdr->sh_size == 0) {
 			LOG_DBG("section %d name %s skipped", i, name);
 			continue;
@@ -327,8 +318,8 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 		if ((shdr->sh_flags & SHF_BASIC_TYPE_MASK) !=
 		    (region->sh_flags & SHF_BASIC_TYPE_MASK)) {
 			LOG_ERR("Unsupported section flags %#x / %#x for %s (region %d)",
-				(uint32_t)shdr->sh_flags, (uint32_t)region->sh_flags,
-				name, mem_idx);
+				(uint32_t)shdr->sh_flags, (uint32_t)region->sh_flags, name,
+				mem_idx);
 			return -ENOEXEC;
 		}
 
@@ -362,8 +353,8 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 			 */
 			if (shdr->sh_addr - region->sh_addr !=
 			    shdr->sh_offset - region->sh_offset) {
-				LOG_ERR("Incompatible section addresses for %s (region %d)",
-					name, mem_idx);
+				LOG_ERR("Incompatible section addresses for %s (region %d)", name,
+					mem_idx);
 				return -ENOEXEC;
 			}
 		}
@@ -430,12 +421,12 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 	 * different llext_mem type are interleaved in the ELF file or in VMAs.
 	 */
 	for (i = 0; i < LLEXT_MEM_COUNT; i++) {
-		for (j = i+1; j < LLEXT_MEM_COUNT; j++) {
+		for (j = i + 1; j < LLEXT_MEM_COUNT; j++) {
 			elf_shdr_t *x = ldr->sects + i;
 			elf_shdr_t *y = ldr->sects + j;
 
-			if (x->sh_type == SHT_NULL || x->sh_size == 0 ||
-			    y->sh_type == SHT_NULL || y->sh_size == 0) {
+			if (x->sh_type == SHT_NULL || x->sh_size == 0 || y->sh_type == SHT_NULL ||
+			    y->sh_size == 0) {
 				/* Skip empty regions */
 				continue;
 			}
@@ -458,8 +449,8 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 				continue;
 			}
 
-			if ((ldr->hdr.e_type == ET_DYN) &&
-			    (x->sh_flags & SHF_ALLOC) && (y->sh_flags & SHF_ALLOC)) {
+			if ((ldr->hdr.e_type == ET_DYN) && (x->sh_flags & SHF_ALLOC) &&
+			    (y->sh_flags & SHF_ALLOC)) {
 				/*
 				 * Test regions that have VMA ranges for overlaps
 				 */
@@ -484,8 +475,8 @@ static int llext_map_sections(struct llext_loader *ldr, struct llext *ext,
 			if (REGIONS_OVERLAP_ON(x, y, sh_offset)) {
 				LOG_ERR("Region %d ELF file range (%#zx-%#zx) "
 					"overlaps with %d (%#zx-%#zx)",
-					i, REGION_BOT(x, sh_offset), REGION_TOP(x, sh_offset),
-					j, REGION_BOT(y, sh_offset), REGION_TOP(y, sh_offset));
+					i, REGION_BOT(x, sh_offset), REGION_TOP(x, sh_offset), j,
+					REGION_BOT(y, sh_offset), REGION_TOP(y, sh_offset));
 				return -ENOEXEC;
 			}
 		}
@@ -529,8 +520,7 @@ static int llext_count_export_syms(struct llext_loader *ldr, struct llext *ext)
 	LOG_DBG("symbol count %u", sym_cnt);
 
 	ext->sym_tab.sym_cnt = 0;
-	for (i = 0, pos = ldr->sects[LLEXT_MEM_SYMTAB].sh_offset;
-	     i < sym_cnt;
+	for (i = 0, pos = ldr->sects[LLEXT_MEM_SYMTAB].sh_offset; i < sym_cnt;
 	     i++, pos += ent_size) {
 		if (!i) {
 			/* A dummy entry */
@@ -554,12 +544,12 @@ static int llext_count_export_syms(struct llext_loader *ldr, struct llext *ext)
 		name = llext_symbol_name(ldr, ext, &sym);
 
 		if ((stt == STT_FUNC || stt == STT_OBJECT) && stb == STB_GLOBAL) {
-			LOG_DBG("function symbol %d, name %s, type tag %d, bind %d, sect %d",
-				i, name, stt, stb, sect);
+			LOG_DBG("function symbol %d, name %s, type tag %d, bind %d, sect %d", i,
+				name, stt, stb, sect);
 			ext->sym_tab.sym_cnt++;
 		} else {
-			LOG_DBG("unhandled symbol %d, name %s, type tag %d, bind %d, sect %d",
-				i, name, stt, stb, sect);
+			LOG_DBG("unhandled symbol %d, name %s, type tag %d, bind %d, sect %d", i,
+				name, stt, stb, sect);
 		}
 	}
 
@@ -594,8 +584,8 @@ static int llext_export_symbols(struct llext_loader *ldr, struct llext *ext,
 		sym = ext->sym_tab.syms;
 	} else {
 		/* Only use symbols in the .exported_sym section */
-		exp_tab->sym_cnt = ldr->sects[LLEXT_MEM_EXPORT].sh_size
-				   / sizeof(struct llext_symbol);
+		exp_tab->sym_cnt = ldr->sects[LLEXT_MEM_EXPORT].sh_size /
+				   sizeof(struct llext_symbol);
 		sym = ext->mem[LLEXT_MEM_EXPORT];
 	}
 
@@ -647,8 +637,7 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 	int i, j, ret;
 	size_t pos;
 
-	for (i = 0, pos = ldr->sects[LLEXT_MEM_SYMTAB].sh_offset, j = 0;
-	     i < sym_cnt;
+	for (i = 0, pos = ldr->sects[LLEXT_MEM_SYMTAB].sh_offset, j = 0; i < sym_cnt;
 	     i++, pos += ent_size) {
 		if (!i) {
 			/* A dummy entry */
@@ -669,8 +658,8 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 		uint32_t stb = ELF_ST_BIND(sym.st_info);
 		unsigned int shndx = sym.st_shndx;
 
-		if ((stt == STT_FUNC || stt == STT_OBJECT) &&
-		    stb == STB_GLOBAL && shndx != SHN_UNDEF) {
+		if ((stt == STT_FUNC || stt == STT_OBJECT) && stb == STB_GLOBAL &&
+		    shndx != SHN_UNDEF) {
 			const char *name = llext_symbol_name(ldr, ext, &sym);
 
 			__ASSERT(j <= sym_tab->sym_cnt, "Miscalculated symbol number %u\n", j);
@@ -683,7 +672,8 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 			if (ldr_parm->pre_located &&
 			    (!ldr_parm->section_detached || !ldr_parm->section_detached(shdr))) {
 				sym_tab->syms[j].addr = (uint8_t *)sym.st_value +
-					(ldr->hdr.e_type == ET_REL ? section_addr : 0);
+							(ldr->hdr.e_type == ET_REL ? section_addr
+										   : 0);
 			} else {
 				const void *base;
 
@@ -703,11 +693,12 @@ static int llext_copy_symbols(struct llext_loader *ldr, struct llext *ext,
 				}
 
 				sym_tab->syms[j].addr = (uint8_t *)base + sym.st_value -
-					(ldr->hdr.e_type == ET_REL ? 0 : section_addr);
+							(ldr->hdr.e_type == ET_REL ? 0
+										   : section_addr);
 			}
 
-			LOG_DBG("function symbol %d name %s addr %p",
-				j, name, sym_tab->syms[j].addr);
+			LOG_DBG("function symbol %d name %s addr %p", j, name,
+				sym_tab->syms[j].addr);
 			j++;
 		}
 	}

--- a/subsys/llext/llext_mem.c
+++ b/subsys/llext/llext_mem.c
@@ -37,8 +37,8 @@ K_HEAP_DEFINE(llext_heap, CONFIG_LLEXT_HEAP_SIZE * 1024);
 /*
  * Initialize the memory partition associated with the specified memory region
  */
-static void llext_init_mem_part(struct llext *ext, enum llext_mem mem_idx,
-			uintptr_t start, size_t len)
+static void llext_init_mem_part(struct llext *ext, enum llext_mem mem_idx, uintptr_t start,
+				size_t len)
 {
 #ifdef CONFIG_USERSPACE
 	if (mem_idx < LLEXT_MEM_PARTITIONS) {
@@ -65,8 +65,8 @@ static void llext_init_mem_part(struct llext *ext, enum llext_mem mem_idx,
 	LOG_DBG("region %d: start %#zx, size %zd", mem_idx, (size_t)start, len);
 }
 
-static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
-			      enum llext_mem mem_idx, const struct llext_load_param *ldr_parm)
+static int llext_copy_region(struct llext_loader *ldr, struct llext *ext, enum llext_mem mem_idx,
+			     const struct llext_load_param *ldr_parm)
 {
 	int ret;
 	elf_shdr_t *region = ldr->sects + mem_idx;
@@ -102,10 +102,10 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 		}
 	}
 
-	if (ldr->storage == LLEXT_STORAGE_WRITABLE ||           /* writable storage         */
-	    (ldr->storage == LLEXT_STORAGE_PERSISTENT &&        /* || persistent storage    */
-	     !(region->sh_flags & SHF_WRITE) &&                 /*    && read-only region   */
-	     !(region->sh_flags & SHF_LLEXT_HAS_RELOCS))) {     /*    && no relocs to apply */
+	if (ldr->storage == LLEXT_STORAGE_WRITABLE ||       /* writable storage         */
+	    (ldr->storage == LLEXT_STORAGE_PERSISTENT &&    /* || persistent storage    */
+	     !(region->sh_flags & SHF_WRITE) &&             /*    && read-only region   */
+	     !(region->sh_flags & SHF_LLEXT_HAS_RELOCS))) { /*    && no relocs to apply */
 		/*
 		 * Try to reuse data areas from the ELF buffer, if possible.
 		 * If any of the following tests fail, a normal allocation
@@ -125,8 +125,8 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 					return 0;
 				}
 
-				LOG_WRN("Cannot peek region %d: %p not aligned to %#zx",
-					mem_idx, ext->mem[mem_idx], (size_t)region_align);
+				LOG_WRN("Cannot peek region %d: %p not aligned to %#zx", mem_idx,
+					ext->mem[mem_idx], (size_t)region_align);
 			}
 		} else if (ldr_parm->pre_located) {
 			/*
@@ -158,8 +158,7 @@ static int llext_copy_region(struct llext_loader *ldr, struct llext *ext,
 
 	ext->alloc_size += region_alloc;
 
-	llext_init_mem_part(ext, mem_idx, (uintptr_t)ext->mem[mem_idx],
-		region_alloc);
+	llext_init_mem_part(ext, mem_idx, (uintptr_t)ext->mem[mem_idx], region_alloc);
 
 	if (region->sh_type == SHT_NOBITS) {
 		memset(ext->mem[mem_idx], 0, region->sh_size);
@@ -289,8 +288,7 @@ void llext_free_regions(struct llext *ext)
 		if (ext->mmu_permissions_set && ext->mem_size[i] != 0 &&
 		    (i == LLEXT_MEM_TEXT || i == LLEXT_MEM_RODATA)) {
 			/* restore default RAM permissions of changed regions */
-			k_mem_update_flags(ext->mem[i],
-					   ROUND_UP(ext->mem_size[i], LLEXT_PAGE_SIZE),
+			k_mem_update_flags(ext->mem[i], ROUND_UP(ext->mem_size[i], LLEXT_PAGE_SIZE),
 					   K_MEM_PERM_RW);
 		}
 #endif
@@ -313,8 +311,7 @@ int llext_add_domain(struct llext *ext, struct k_mem_domain *domain)
 		}
 		ret = k_mem_domain_add_partition(domain, &ext->mem_parts[i]);
 		if (ret != 0) {
-			LOG_ERR("Failed adding memory partition %d to domain %p",
-				i, domain);
+			LOG_ERR("Failed adding memory partition %d to domain %p", i, domain);
 			return ret;
 		}
 	}

--- a/subsys/llext/shell.c
+++ b/subsys/llext/shell.c
@@ -22,13 +22,9 @@ LOG_MODULE_REGISTER(llext_shell, CONFIG_LLEXT_LOG_LEVEL);
 	SHELL_HELP("Load an elf file encoded in hex directly from the shell input.",               \
 		   "<ext_name> <ext_hex_string>")
 
-#define LLEXT_UNLOAD_HELP                                                                          \
-	SHELL_HELP("Unload an extension by name.",                                                 \
-		   "<ext_name>")
+#define LLEXT_UNLOAD_HELP SHELL_HELP("Unload an extension by name.", "<ext_name>")
 
-#define LLEXT_LIST_SYMBOLS_HELP                                                                    \
-	SHELL_HELP("List extension symbols.",                                                      \
-		   "<ext_name>")
+#define LLEXT_LIST_SYMBOLS_HELP SHELL_HELP("List extension symbols.", "<ext_name>")
 
 #define LLEXT_CALL_FN_HELP                                                                         \
 	SHELL_HELP("Call extension function with prototype void fn(void).",                        \
@@ -36,8 +32,8 @@ LOG_MODULE_REGISTER(llext_shell, CONFIG_LLEXT_LOG_LEVEL);
 
 #ifdef CONFIG_FILE_SYSTEM
 #define LLEXT_LOAD_FS_HELP                                                                         \
-	SHELL_HELP("Load an elf file directly from filesystem.",                                   \
-		   "<ext_name> <ext_llext_file_name>")
+	SHELL_HELP("Load an elf file directly from filesystem.", "<ext_name> "                     \
+								 "<ext_llext_file_name>")
 
 #endif /* CONFIG_FILE_SYSTEM */
 
@@ -53,8 +49,7 @@ static int cmd_llext_list_symbols(const struct shell *sh, size_t argc, char *arg
 	shell_print(sh, "Extension: %s symbols", m->name);
 	shell_print(sh, "| Symbol           | Address    |");
 	for (elf_word i = 0; i < m->exp_tab.sym_cnt; i++) {
-		shell_print(sh, "| %16s | %p |", m->exp_tab.syms[i].name,
-			    m->exp_tab.syms[i].addr);
+		shell_print(sh, "| %16s | %p |", m->exp_tab.syms[i].name, m->exp_tab.syms[i].addr);
 	}
 
 	return 0;
@@ -136,8 +131,8 @@ static int cmd_llext_load_hex(const struct shell *sh, size_t argc, char *argv[])
 		return -EINVAL;
 	}
 
-	if (hex_len > CONFIG_LLEXT_SHELL_MAX_SIZE*2) {
-		shell_print(sh, "Extension %d bytes too large to load, max %d bytes\n", hex_len/2,
+	if (hex_len > CONFIG_LLEXT_SHELL_MAX_SIZE * 2) {
+		shell_print(sh, "Extension %d bytes too large to load, max %d bytes\n", hex_len / 2,
 			    CONFIG_LLEXT_SHELL_MAX_SIZE);
 		return -ENOMEM;
 	}
@@ -146,8 +141,8 @@ static int cmd_llext_load_hex(const struct shell *sh, size_t argc, char *argv[])
 	struct llext_buf_loader buf_loader = LLEXT_BUF_LOADER(llext_buf, llext_buf_len);
 	struct llext_loader *ldr = &buf_loader.loader;
 
-	LOG_DBG("hex2bin hex len %d, llext buf sz %d, read %d",
-		hex_len, CONFIG_LLEXT_SHELL_MAX_SIZE, llext_buf_len);
+	LOG_DBG("hex2bin hex len %d, llext buf sz %d, read %d", hex_len,
+		CONFIG_LLEXT_SHELL_MAX_SIZE, llext_buf_len);
 	LOG_HEXDUMP_DBG(llext_buf, 4, "4 byte MAGIC");
 
 	struct llext_load_param ldr_parm = LLEXT_LOAD_PARAM_DEFAULT;


### PR DESCRIPTION
If we stick with clang-format we don't need to nitpick over little spacing issues for new contributions, we can simply ask people to run the formatting tool. Much simpler.

Noticed these files weren't formatted with the tool in #83423 and the result is nits over spacing which are not the kind of review comments I want to see, use the tool to ensure spacing/formatting nits are unnecessary.