### PR TITLE
subsys: pm: fix pm_device_runtime_get rollback

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -283,6 +283,9 @@ int pm_device_runtime_get(const struct device *dev)
 	ret = pm->base.action_cb(pm->dev, PM_DEVICE_ACTION_RESUME);
 	if (ret < 0) {
 		pm->base.usage--;
+		if (domain != NULL) {
+			(void)pm_device_runtime_put(domain);
+		}
 		goto unlock;
 	}
 


### PR DESCRIPTION
In a call to `pm_device_runtime_get()`, if the power domain is taken but `pm->base.action_cb()` fails in the case of `PM_DEVICE_ACTION_RESUME`, the power domain is not released.

This fix adds a call to `pm_device_runtime_put()` when rolling back after a failed call to `pm->base.action_cb()`.