### PR TITLE
tests: drivers: pwm_gpio_loopback: Test improvement

### DIFF
--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,45 +4,55 @@
  *
  * Test requires wire connection between:
  *  - PWM130 OUT[0] at P0.00 <-> GPIO input at P0.01
+ *  - PWM130 OUT[1] at P0.02 <-> GPIO input at P0.04
+ *  - PWM130 OUT[2] at P0.03 <-> GPIO input at P0.05
+ *  - PWM130 OUT[3] at P0.06 <-> GPIO input at P0.07
  *  - PWM120 OUT[0] at P7.00 <-> GPIO input at P1.09
- *  - PWM120 OUT[1] at P7.01 <-> GPIO input at P1.05
  */
 
 / {
 	zephyr,user {
 		pwms = <&pwm130 0 160000 PWM_POLARITY_NORMAL>,
-			<&pwm120 0 80000 PWM_POLARITY_NORMAL>,
-			<&pwm120 1 80000 PWM_POLARITY_NORMAL>;
+			<&pwm130 1 160000 PWM_POLARITY_NORMAL>,
+			<&pwm130 2 160000 PWM_POLARITY_NORMAL>,
+			<&pwm130 3 160000 PWM_POLARITY_NORMAL>,
+			<&pwm120 0 80000 PWM_POLARITY_NORMAL>;
 		gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>,
-			<&gpio1 9 GPIO_ACTIVE_HIGH>,
-			<&gpio1 5 GPIO_ACTIVE_HIGH>;
+			<&gpio0 4 GPIO_ACTIVE_HIGH>,
+			<&gpio0 5 GPIO_ACTIVE_HIGH>,
+			<&gpio0 7 GPIO_ACTIVE_HIGH>,
+			<&gpio1 9 GPIO_ACTIVE_HIGH>;
 	};
 };
 
 &pinctrl {
 	pwm130_default: pwm130_default {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>,
+				<NRF_PSEL(PWM_OUT1, 0, 2)>,
+				<NRF_PSEL(PWM_OUT2, 0, 3)>,
+				<NRF_PSEL(PWM_OUT3, 0, 6)>;
 		};
 	};
 
 	pwm130_sleep: pwm130_sleep {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>,
+				<NRF_PSEL(PWM_OUT1, 0, 2)>,
+				<NRF_PSEL(PWM_OUT2, 0, 3)>,
+				<NRF_PSEL(PWM_OUT3, 0, 6)>;
 			low-power-enable;
 		};
 	};
 
 	pwm120_default: pwm120_default {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>,
-				<NRF_PSEL(PWM_OUT1, 7, 1)>;
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
 		};
 	};
 	pwm120_sleep: pwm120_sleep {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>,
-				<NRF_PSEL(PWM_OUT1, 7, 1)>;
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
 			low-power-enable;
 		};
 	};

--- a/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_gpio_loopback/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -3,12 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Test requires jumper between:
- *  - PWM20 OUT[0] at P1.10 <-> GPIO input at P1.11
+ *  - PWM20 OUT[0] at P1.08 <-> GPIO input at P1.09
+ *  - PWM20 OUT[1] at P1.10 <-> GPIO input at P1.11
+ *  - PWM20 OUT[2] at P1.12 <-> GPIO input at P1.13
  */
 
 / {
 	zephyr,user {
-		pwms = <&pwm20 0 160000 PWM_POLARITY_NORMAL>;
-		gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		pwms = <&pwm20 0 160000 PWM_POLARITY_NORMAL>,
+			<&pwm20 1 160000 PWM_POLARITY_NORMAL>,
+			<&pwm20 2 160000 PWM_POLARITY_NORMAL>;
+		gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>,
+			<&gpio1 11 GPIO_ACTIVE_HIGH>,
+			<&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 8)>,
+				<NRF_PSEL(PWM_OUT1, 1, 10)>,
+				<NRF_PSEL(PWM_OUT2, 1, 12)>;
+		};
+	};
+
+	pwm20_sleep: pwm20_sleep {
+		group1 {
+		psels = <NRF_PSEL(PWM_OUT0, 1, 8)>,
+			<NRF_PSEL(PWM_OUT1, 1, 10)>,
+			<NRF_PSEL(PWM_OUT2, 1, 12)>;
+		};
 	};
 };

--- a/tests/drivers/pwm/pwm_gpio_loopback/src/main.c
+++ b/tests/drivers/pwm/pwm_gpio_loopback/src/main.c
@@ -234,16 +234,25 @@ ZTEST(pwm_gpio_loopback, test_pwm)
 
 ZTEST(pwm_gpio_loopback, test_pwm_cross)
 {
+	uint8_t duty[TEST_PWM_COUNT];
+	const int duty_step = 25;
+	const int duty_variations = 5;
+
+	/* Initial sweep with increasing duty cycles */
 	for (int i = 0; i < TEST_PWM_COUNT; i++) {
-		/* Test case: [Duty: 40%] */
-		test_run(&pwms_dt[i], &gpios_dt[i], 40, true);
+		duty[i] = (i % duty_variations) * duty_step;
+		test_run(&pwms_dt[i], &gpios_dt[i], duty[i], true);
 	}
 
-	/* Set all channels and check if they retain the original
-	 * configuration without calling pwm_set again
-	 */
-	for (int i = 0; i < TEST_PWM_COUNT; i++) {
-		test_run(&pwms_dt[i], &gpios_dt[i], 40, false);
+	/* Repeat test with persistent config checks and rotated duty cycles */
+	for (int j = 1; j < duty_variations; j++) {
+		for (int i = 0; i < TEST_PWM_COUNT; i++) {
+			test_run(&pwms_dt[i], &gpios_dt[i], duty[i], false);
+		}
+		for (int i = 0; i < TEST_PWM_COUNT; i++) {
+			duty[i] = ((j + i) % duty_variations) * duty_step;
+			test_run(&pwms_dt[i], &gpios_dt[i], duty[i], true);
+		}
 	}
 }
 


### PR DESCRIPTION
Improve corss-channel test by setting different
duty cycle on channels. This modification will enable
detection of inter-channel effects like crosstalk.