### PR TITLE
doc: update links to use https

### DIFF
--- a/doc/_extensions/zephyr/html_redirects.py
+++ b/doc/_extensions/zephyr/html_redirects.py
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/_extensions/zephyr/link-roles.py
+++ b/doc/_extensions/zephyr/link-roles.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# based on http://protips.readthedocs.io/link-roles.html
+# based on https://protips.readthedocs.io/link-roles.html
 
 import re
 import subprocess

--- a/doc/connectivity/networking/api/gptp.rst
+++ b/doc/connectivity/networking/api/gptp.rst
@@ -66,7 +66,7 @@ Testing
 
 The stack has been informally tested using the
 `OpenAVnu gPTP <https://github.com/AVnu/gptp>`_ and
-`Linux ptp4l <http://linuxptp.sourceforge.net/>`_ daemons.
+`Linux ptp4l <https://linuxptp.sourceforge.net/>`_ daemons.
 The :zephyr:code-sample:`gPTP sample application <gptp>` from the Zephyr
 source distribution can be used for testing.
 

--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -13,7 +13,7 @@ Overview
 Lightweight Machine to Machine (LwM2M) is an application layer protocol
 designed with device management, data reporting and device actuation in mind.
 Based on CoAP/UDP, `LwM2M`_ is a
-`standard <http://openmobilealliance.org/release/LightweightM2M/>`_ defined by
+`standard <https://openmobilealliance.org/release/LightweightM2M/>`_ defined by
 the Open Mobile Alliance and suitable for constrained devices by its use of
 CoAP packet-size optimization and a simple, stateless flow that supports a
 REST API.
@@ -807,13 +807,13 @@ API Reference
    https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/
 
 .. _LwM2M registry:
-   http://www.openmobilealliance.org/wp/OMNA/LwM2M/LwM2MRegistry.html
+   https://www.openmobilealliance.org/wp/OMNA/LwM2M/LwM2MRegistry.html
 
 .. _OMA Specworks LwM2M:
    https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/
 
 .. _LwM2M specification 1.0.2:
-   http://openmobilealliance.org/release/LightweightM2M/V1_0_2-20180209-A/OMA-TS-LightweightM2M-V1_0_2-20180209-A.pdf
+   https://www.openmobilealliance.org/release/LightweightM2M/V1_0_2-20180209-A/OMA-TS-LightweightM2M-V1_0_2-20180209-A.pdf
 
 .. _LwM2M specification 1.1.1:
-   http://openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/
+   https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/

--- a/doc/connectivity/networking/api/mqtt.rst
+++ b/doc/connectivity/networking/api/mqtt.rst
@@ -13,7 +13,7 @@ Overview
 MQTT (Message Queuing Telemetry Transport) is an application layer protocol
 which works on top of the TCP/IP stack. It is a lightweight
 publish/subscribe messaging transport for machine-to-machine communication.
-For more information about the protocol itself, see http://mqtt.org/.
+For more information about the protocol itself, see https://mqtt.org/.
 
 Zephyr provides an MQTT client library built on top of BSD sockets API. The
 library can be enabled with :kconfig:option:`CONFIG_MQTT_LIB` Kconfig option and

--- a/doc/connectivity/networking/api/ptp.rst
+++ b/doc/connectivity/networking/api/ptp.rst
@@ -127,7 +127,7 @@ Testing
 *******
 
 The stack has been informally tested using the
-`Linux ptp4l <http://linuxptp.sourceforge.net/>`_ daemons.
+`Linux ptp4l <https://linuxptp.sourceforge.net/>`_ daemons.
 The :zephyr:code-sample:`PTP sample application <ptp>` from the Zephyr
 source distribution can be used for testing.
 

--- a/doc/connectivity/networking/overview.rst
+++ b/doc/connectivity/networking/overview.rst
@@ -180,10 +180,10 @@ The networking stack source code tree is organized as follows:
   source for sample code (see ``samples/net`` instead).
 
 .. _LwM2M specification 1.0.2:
-   http://openmobilealliance.org/release/LightweightM2M/V1_0_2-20180209-A/OMA-TS-LightweightM2M-V1_0_2-20180209-A.pdf
+   https://www.openmobilealliance.org/release/LightweightM2M/V1_0_2-20180209-A/OMA-TS-LightweightM2M-V1_0_2-20180209-A.pdf
 
 .. _LwM2M specification 1.1.1:
-   http://openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/
+   https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/
 
 .. _RFC 2616:
    https://tools.ietf.org/html/rfc2616

--- a/doc/contribute/documentation/generation.rst
+++ b/doc/contribute/documentation/generation.rst
@@ -320,7 +320,7 @@ Once downloaded, the tag file can be used in a custom ``doxyfile.in`` as follows
 For additional information refer to `Doxygen External Documentation`_.
 
 
-.. _reStructuredText: http://sphinx-doc.org/rest.html
-.. _Sphinx: http://sphinx-doc.org/
+.. _reStructuredText: https://sphinx-doc.org/rest.html
+.. _Sphinx: https://sphinx-doc.org/
 .. _Windows Python Path: https://docs.python.org/3/using/windows.html#finding-the-python-executable
 .. _Doxygen External Documentation: https://www.doxygen.nl/manual/external.html

--- a/doc/contribute/documentation/guidelines.rst
+++ b/doc/contribute/documentation/guidelines.rst
@@ -21,9 +21,9 @@ then be viewed using a web browser. This same .rst content is served by the
 You can read details about `reStructuredText`_
 and about `Sphinx extensions`_ from their respective websites.
 
-.. _Sphinx extensions: http://www.sphinx-doc.org/en/stable/contents.html
-.. _reStructuredText: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
-.. _Sphinx Inline Markup:  http://sphinx-doc.org/markup/inline.html#inline-markup
+.. _Sphinx extensions: https://www.sphinx-doc.org/en/stable/contents.html
+.. _reStructuredText: https://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
+.. _Sphinx Inline Markup:  https://sphinx-doc.org/markup/inline.html#inline-markup
 .. _Zephyr documentation:  https://docs.zephyrproject.org
 
 This document provides a quick reference for commonly used reST and
@@ -187,7 +187,7 @@ Tables
 
 There are a few ways to create tables, each with their limitations or
 quirks.  `Grid tables
-<http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables>`_
+<https://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables>`_
 offer the most capability for defining merged rows and columns, but are
 hard to maintain::
 
@@ -220,7 +220,7 @@ This example would render as:
 +------------------------+------------+----------+----------+
 
 `List tables
-<http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_
+<https://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_
 are much easier to maintain, but don't support row or column spans::
 
    .. list-table:: Table title
@@ -345,7 +345,7 @@ reference for some of the most commonly used text formatting options in Zephyr d
 exhaustive list, refer to the `reStructuredText Quick Reference`_,
 `reStructuredText Interpreted Text Roles`_ as well as the `additional roles provided by Sphinx`_.
 
-.. _reStructuredText Quick Reference: http://docutils.sourceforge.io/docs/user/rst/quickref.html
+.. _reStructuredText Quick Reference: https://docutils.sourceforge.io/docs/user/rst/quickref.html
 .. _reStructuredText Interpreted Text Roles: https://docutils.sourceforge.io/docs/ref/rst/roles.html
 .. _additional roles provided by Sphinx: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html
 
@@ -472,7 +472,7 @@ This would be rendered as:
 Other languages are of course supported (see `languages supported by Pygments`_), and in particular,
 you are encouraged to make use of the following when appropriate:
 
-.. _`languages supported by Pygments`: http://pygments.org/languages/
+.. _`languages supported by Pygments`: https://pygments.org/languages/
 
 * ``c`` for C code
 * ``cpp`` for C++ code

--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -132,7 +132,7 @@ statement and thereby agrees to the DCO.
 
 When a developer submits a patch, it is a commitment that the contributor has
 the right to submit the patch per the license.  The DCO agreement is shown
-below and at http://developercertificate.org/.
+below and at https://developercertificate.org/.
 
 .. code-block:: none
 
@@ -874,7 +874,7 @@ For example, a copy of a locally maintained import::
 
       Origin: Contiki OS
       License: BSD 3-Clause
-      URL: http://www.contiki-os.org/
+      URL: https://www.contiki-os.org/
       commit: 853207acfdc6549b10eb3e44504b1a75ae1ad63a
       Purpose: Introduction of networking stack.
 

--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -602,7 +602,7 @@ when CMake is run in an empty build folder.
 For more details about the CMakeCache.txt file see the official CMake
 documentation `runningcmake`_ .
 
-.. _runningcmake: http://cmake.org/runningcmake/
+.. _runningcmake: https://cmake.org/runningcmake/
 
 Application Configuration
 *************************

--- a/doc/develop/debug/index.rst
+++ b/doc/develop/debug/index.rst
@@ -12,9 +12,9 @@ This section is a quick hands-on reference to start debugging your
 application with QEMU. Most content in this section is already covered in
 `QEMU`_ and `GNU_Debugger`_ reference manuals.
 
-.. _QEMU: http://wiki.qemu.org/Main_Page
+.. _QEMU: https://wiki.qemu.org/Main_Page
 
-.. _GNU_Debugger: http://www.gnu.org/software/gdb
+.. _GNU_Debugger: https://www.gnu.org/software/gdb
 
 In this quick reference, you'll find shortcuts, specific environmental
 variables, and parameters that can help you to quickly set up your debugging

--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -656,13 +656,13 @@ For more about the UF2 format and its tooling, see `USB Flashing Format (UF2)`_.
    https://github.com/pyocd/pyOCD/tree/main/pyocd/target/builtin
 
 .. _OpenOCD Windows:
-    http://gnutoolchains.com/arm-eabi/openocd/
+    https://gnutoolchains.com/arm-eabi/openocd/
 
 .. _Lauterbach TRACE32:
     https://www.lauterbach.com/
 
 .. _Lauterbach TRACE32 download website:
-   http://www.lauterbach.com/download_trace32.html
+   https://www.lauterbach.com/download_trace32.html
 
 .. _Lauterbach TRACE32 Installation Guide:
    https://www2.lauterbach.com/pdf/installation.pdf

--- a/doc/develop/sca/codechecker.rst
+++ b/doc/develop/sca/codechecker.rst
@@ -5,8 +5,8 @@ CodeChecker support
 
 `CodeChecker <https://codechecker.readthedocs.io/>`__ is a static analysis infrastructure.
 It executes analysis tools available on the build system, such as
-`Clang-Tidy <http://clang.llvm.org/extra/clang-tidy/>`__,
-`Clang Static Analyzer <http://clang-analyzer.llvm.org/>`__ and
+`Clang-Tidy <https://clang.llvm.org/extra/clang-tidy/>`__,
+`Clang Static Analyzer <https://clang-analyzer.llvm.org/>`__ and
 `Cppcheck <https://cppcheck.sourceforge.io/>`__. Refer to the analyzer's websites for installation
 instructions.
 

--- a/doc/develop/sca/coverity.rst
+++ b/doc/develop/sca/coverity.rst
@@ -30,4 +30,4 @@ and incremental scan results.
 Result Analysis
 ****************
 
-Follow the instructions on http://scan.coverity.com for uploading results.
+Follow the instructions on https://scan.coverity.com for uploading results.

--- a/doc/develop/tools/coccinelle.rst
+++ b/doc/develop/tools/coccinelle.rst
@@ -38,7 +38,7 @@ of many distributions, e.g. :
 
 Some distribution packages are obsolete and it is recommended
 to use the latest version released from the Coccinelle homepage at
-http://coccinelle.lip6.fr/
+https://coccinelle.lip6.fr/
 
 Or from Github at:
 

--- a/doc/develop/west/build-flash-debug.rst
+++ b/doc/develop/west/build-flash-debug.rst
@@ -765,7 +765,7 @@ From that point on Renode can be used normally in both console and window modes.
 For details on using Renode see `Renode - documentation`_.
 
 .. _Renode - documentation:
-   http://docs.renode.io
+   https://docs.renode.io
 
 Runner-Specific Overrides
 =========================

--- a/doc/hardware/peripherals/smbus.rst
+++ b/doc/hardware/peripherals/smbus.rst
@@ -61,4 +61,4 @@ API Reference
 
 .. doxygengroup:: smbus_interface
 
-.. _SMBus Specification: http://smbus.org/specs/smbus20.pdf
+.. _SMBus Specification: https://smbus.org/specs/smbus20.pdf

--- a/doc/security/secure-coding.rst
+++ b/doc/security/secure-coding.rst
@@ -216,7 +216,7 @@ and information disclosure vulnerabilities.
 .. Turn this into something specific. Can we find examples of
    mistakes.  Perhaps an example of things static analysis tool has sent us.
 
-.. _CWE/SANS top 25: http://cwe.mitre.org/top25/
+.. _CWE/SANS top 25: https://cwe.mitre.org/top25/
 
 .. _OWASP Top 10: https://owasp.org/www-project-top-ten/
 
@@ -285,4 +285,4 @@ and approved by consensus.
 .. [#attackf]  An attack_ resulted in a significant portion of DNS
    infrastructure being taken down.
 
-.. _attack: http://www.theverge.com/2016/10/21/13362354/dyn-dns-ddos-attack-cause-outage-status-explained
+.. _attack: https://www.theverge.com/2016/10/21/13362354/dyn-dns-ddos-attack-cause-outage-status-explained

--- a/doc/security/security-citations.rst
+++ b/doc/security/security-citations.rst
@@ -8,7 +8,7 @@ Security Document Citations
 .. [SALT75] J. H. Saltzer and M. D. Schroeder, "The protection of
    information in computer systems," Proceedings of the IEEE, vol. 63, no.
    9, pp. 1278-1308, Sep 1975. [Online].
-   Available: http://web.mit.edu/Saltzer/www/publications/protection/.
+   Available: https://web.mit.edu/Saltzer/www/publications/protection/.
 
 .. [PAUL09] M. Paul, "The Ten Best Practices for Secure Software
    Development," International Information Systems Security Certification

--- a/doc/services/portability/cmsis_rtos_v1.rst
+++ b/doc/services/portability/cmsis_rtos_v1.rst
@@ -8,4 +8,4 @@ hardware abstraction layer for the ARM Cortex-M processor series and defines
 generic tool interfaces. Though it was originally defined for ARM Cortex-M
 microcontrollers alone, it could be easily extended to other microcontrollers
 making it generic. For more information on CMSIS RTOS v1, please refer
-http://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html
+https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html

--- a/doc/services/portability/cmsis_rtos_v2.rst
+++ b/doc/services/portability/cmsis_rtos_v2.rst
@@ -8,7 +8,7 @@ hardware abstraction layer for the ARM Cortex-M processor series and defines
 generic tool interfaces. Though it was originally defined for ARM Cortex-M
 microcontrollers alone, it could be easily extended to other microcontrollers
 making it generic. For more information on CMSIS RTOS v2, please refer to the
-`CMSIS-RTOS2 Documentation <http://www.keil.com/pack/doc/CMSIS/RTOS2/html/index.html>`_.
+`CMSIS-RTOS2 Documentation <https://www.keil.com/pack/doc/CMSIS/RTOS2/html/index.html>`_.
 
 Features not supported in Zephyr implementation
 ***********************************************

--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -59,7 +59,7 @@ graphical (TraceCompass) variants already exist.
 
 CTF should look familiar to C programmers but adds stronger typing.
 See `CTF - A Flexible, High-performance Binary Trace Format
-<http://diamon.org/ctf/>`_.
+<https://diamon.org/ctf/>`_.
 
 
 CTF allows us to formally describe application specific payload and the

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -1295,7 +1295,7 @@ VERBATIM_HEADERS       = YES
 
 # If the CLANG_ASSISTED_PARSING tag is set to YES then Doxygen will use the
 # clang parser (see:
-# http://clang.llvm.org/) for more accurate parsing at the cost of reduced
+# https://clang.llvm.org/) for more accurate parsing at the cost of reduced
 # performance. This can be particularly helpful with template rich C++ code for
 # which Doxygen's built-in parser lacks the necessary type information.
 # Note: The availability of this option depends on whether or not Doxygen was
@@ -1323,7 +1323,7 @@ CLANG_OPTIONS          =
 # If clang assisted parsing is enabled you can provide the clang parser with the
 # path to the directory containing a file called compile_commands.json. This
 # file is the compilation database (see:
-# http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html) containing the
+# https://clang.llvm.org/docs/HowToSetupToolingForLLVM.html) containing the
 # options used when the source files were built. This is equivalent to
 # specifying the -p option to a clang tool, such as clang-check. These options
 # will then be passed to the parser. Any options specified with CLANG_OPTIONS
@@ -1612,7 +1612,7 @@ DOCSET_PUBLISHER_NAME  = Publisher
 # a.o. the download links, offline (the HTML help workshop was already many
 # years in maintenance mode). You can download the HTML help workshop from the
 # web archives at Installation executable (see:
-# http://web.archive.org/web/20160201063255/http://download.microsoft.com/downlo
+# https://web.archive.org/web/20160201063255/http://download.microsoft.com/downlo
 # ad/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe).
 #
 # The HTML Help Workshop contains a compiler that can convert all HTML output
@@ -1901,9 +1901,9 @@ MATHJAX_VERSION        = MathJax_2
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. For more details about the output format see MathJax
 # version 2 (see:
-# http://docs.mathjax.org/en/v2.7-latest/output.html) and MathJax version 3
+# https://docs.mathjax.org/en/v2.7-latest/output.html) and MathJax version 3
 # (see:
-# http://docs.mathjax.org/en/latest/web/components/output.html).
+# https://docs.mathjax.org/en/latest/web/components/output.html).
 # Possible values are: HTML-CSS (which is slower, but has the best
 # compatibility. This is the name for Mathjax version 2, for MathJax version 3
 # this will be translated into chtml), NativeMML (i.e. MathML. Only supported
@@ -1935,7 +1935,7 @@ MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@3
 # https://docs.mathjax.org/en/v2.7-latest/tex.html#tex-and-latex-extensions):
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # For example for MathJax version 3 (see
-# http://docs.mathjax.org/en/latest/input/tex/extensions/index.html):
+# https://docs.mathjax.org/en/latest/input/tex/extensions/index.html):
 # MATHJAX_EXTENSIONS = ams
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
@@ -1944,7 +1944,7 @@ MATHJAX_EXTENSIONS     =
 # The MATHJAX_CODEFILE tag can be used to specify a file with JavaScript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site
 # (see:
-# http://docs.mathjax.org/en/v2.7-latest/output.html) for more details. For an
+# https://docs.mathjax.org/en/v2.7-latest/output.html) for more details. For an
 # example see the documentation.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 


### PR DESCRIPTION
- Updated  a couple documentation links to use https:// instead of http://

Edit: dropped the second commit for now, so only http to https changes are included in this PR.
