### PR TITLE
arch/riscv: Enable NMI and regular interrupts/traps when the hardware includes SMRNMI extension

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -462,6 +462,17 @@ config RISCV_IMPRECISE_FPU_STATE_TRACKING
 	  the floating-point register state imprecisely by reporting the state to be
 	  dirty even when it has not been modified. This option reflects that.
 
+config RISCV_SMRNMI_ENABLE_NMI_DELIVERY
+	bool "NMI delivery on SMRNMI hardware (MNSTATUS.NMIE=1)"
+	select RISCV_ISA_EXT_ZICSR
+	help
+	  Set MNSTATUS.NMIE bit to 1 during boot to enable NMI delivery on
+	  RISC-V hardware implementing the SMRNMI extension.
+
+	  This option only enables NMI delivery. It does not provide RNMI
+	  handlers or mnret instruction support. Proper RNMI handlers must
+	  be implemented in SoC-specific code to handle NMI events.
+
 endmenu
 
 config MAIN_STACK_SIZE

--- a/arch/riscv/core/reset.S
+++ b/arch/riscv/core/reset.S
@@ -9,6 +9,7 @@
 #include <zephyr/linker/sections.h>
 #include <zephyr/arch/cpu.h>
 #include <zephyr/offsets.h>
+#include <zephyr/arch/riscv/csr.h>
 #include "asm_macros.inc"
 
 /* exports */
@@ -81,6 +82,10 @@ aa_loop:
 	la sp, z_interrupt_stacks
 	li t0, __z_interrupt_stack_SIZEOF
 	add sp, sp, t0
+
+#ifdef CONFIG_RISCV_SMRNMI_ENABLE_NMI_DELIVERY
+	csrs CSR_MNSTATUS, MNSTATUS_NMIE
+#endif
 
 #ifdef CONFIG_WDOG_INIT
 	call _WdogInit

--- a/include/zephyr/arch/riscv/csr.h
+++ b/include/zephyr/arch/riscv/csr.h
@@ -156,6 +156,17 @@
 #define IRQ_COP		12
 #define IRQ_HOST	13
 
+/* SMRNMI CSR addresses */
+#ifdef CONFIG_RISCV_SMRNMI_ENABLE_NMI_DELIVERY
+#define CSR_MNSCRATCH 0x740
+#define CSR_MNEPC     0x741
+#define CSR_MNCAUSE   0x742
+#define CSR_MNSTATUS  0x744
+
+/* MNSTATUS bit fields */
+#define MNSTATUS_NMIE 0x00000008 /* NMI Enable (bit 3) */
+#endif                           /* CONFIG_RISCV_SMRNMI_ENABLE_NMI_DELIVERY */
+
 #define DEFAULT_RSTVEC	0x00001000
 #define CLINT_BASE	0x02000000
 #define CLINT_SIZE	0x000c0000


### PR DESCRIPTION
Add RISC-V SMRNMI Extension Support to Zephyr

This PR adds support for the RISC-V SMRNMI (Resumable Non-Maskable Interrupt) extension.

Changes:
- Add CONFIG_RISCV_ISA_EXT_SMRNMI Kconfig option
- Enable NMIE bit in mnstatus CSR during boot when configured

The NMIE (NMI Enable) bit controls whether the CPU receives non-maskable interrupts. It defaults to 0 after reset, meaning NMIs are generated by hardware but never delivered to the CPU. This causes critical events like watchdog timeouts, ECC errors, and bus faults to be silently ignored.

Setting NMIE=1 during boot ensures the CPU can receive and handle these critical interrupts. This fixes both production issues where hardware events were missed and twister test failures on SMRNMI platforms.

Without this change, SMRNMI hardware cannot deliver any NMIs despite generating them, leaving systems vulnerable to undetected hardware failures.