### PR TITLE
soc: adsp: Adjust MEM_VECT_TEXT_SIZE in adsp-vectors.h

### DIFF
--- a/soc/intel/intel_adsp/common/include/adsp-vectors.h
+++ b/soc/intel/intel_adsp/common/include/adsp-vectors.h
@@ -49,7 +49,7 @@
 
 /* Vector and literal sizes */
 #define MEM_VECT_LIT_SIZE			0x8
-#define MEM_VECT_TEXT_SIZE			0x38
+#define MEM_VECT_TEXT_SIZE			0x3D
 
 #define MEM_ERROR_TEXT_SIZE			0x180
 #define MEM_ERROR_LIT_SIZE			0x8


### PR DESCRIPTION
Increase the `MEM_VECT_TEXT_SIZE` constant to fix "section will not fit in region" linker errors when building with `CONFIG_USERSPACE` enabled.

```
xtensa-elf-ld: zephyr/zephyr_pre0.elf section `.Level2InterruptVector.text' will not fit in region `vector_int2_text'
xtensa-elf-ld: zephyr/zephyr_pre0.elf section `.Level3InterruptVector.text' will not fit in region `vector_int3_text'
xtensa-elf-ld: zephyr/zephyr_pre0.elf section `.DebugExceptionVector.text' will not fit in region `vector_int4_text'
xtensa-elf-ld: zephyr/zephyr_pre0.elf section `.NMIExceptionVector.text' will not fit in region `vector_int7_text'
xtensa-elf-ld: region `vector_int2_text' overflowed by 5 bytes
xtensa-elf-ld: region `vector_int3_text' overflowed by 5 bytes
xtensa-elf-ld: region `vector_int4_text' overflowed by 5 bytes
xtensa-elf-ld: region `vector_int7_text' overflowed by 5 bytes
clang-10: error: Xtensa-ld command failed with exit code 1 (use -v to see invocation
```
