### PR TITLE
cmake: llext: Fix llext incremental build

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -5933,7 +5933,7 @@ function(add_llext_target target_name)
   # dynamic library.
   set(llext_proc_target ${target_name}_llext_proc)
   set(llext_pkg_input ${PROJECT_BINARY_DIR}/llext/${target_name}_debug.elf)
-  add_custom_target(${llext_proc_target} DEPENDS ${llext_pkg_input})
+  add_custom_target(${llext_proc_target} DEPENDS ${llext_lib_target} ${llext_lib_output})
   set_property(TARGET ${llext_proc_target} PROPERTY has_post_build_cmds 0)
 
   # By default this target must copy the `lib_output` binary file to the
@@ -5945,7 +5945,7 @@ function(add_llext_target target_name)
   add_custom_command(
     OUTPUT ${llext_pkg_input}
     COMMAND "$<IF:${has_post_build_cmds},${noop_cmd},${copy_cmd}>"
-    DEPENDS ${llext_lib_target} ${llext_lib_output}
+    DEPENDS ${llext_proc_target}
     COMMAND_EXPAND_LISTS
   )
 
@@ -5977,7 +5977,7 @@ function(add_llext_target target_name)
             $<TARGET_PROPERTY:bintools,elfconvert_flag_outfile>${llext_pkg_output}
             $<TARGET_PROPERTY:bintools,elfconvert_flag_final>
     COMMAND ${slid_inject_cmd}
-    DEPENDS ${llext_proc_target} ${llext_pkg_input}
+    DEPENDS ${llext_pkg_input}
     COMMAND_EXPAND_LISTS
   )
 


### PR DESCRIPTION
Before this commit, building llext packages with a `POST_BUILD` step added via `add_llext_command()` only worked for from-scratch builds (tested with Ninja).

When the client CMake script called `add_llext_command()` to add a custom `POST_BUILD` step, `has_post_build_cmds` was set to 1, and a `true` (do nothing) command was executed instead of `copy` for the `llext_pkg_input` target. Consequently, the timestamp of `llext_pkg_input` was not updated. Before executing `llext_proc_target`, Ninja seems to check the timestamp of `llext_pkg_input`. When the custom command added by `add_llext_command()` generated a new `llext_pkg_input`, Ninja was unaware that `llext_pkg_input` had been updated, and the dependent `llext_pkg_output` was not executed. Building only worked if `llext_pkg_input` was missing, i.e., only for from-scratch builds.

The fix replaces dependencies so the command for `llext_pkg_input` is executed after `llext_proc_target` (after `llext_proc_target` may generate a new `llext_pkg_input`).