### PR TITLE
bluetooth: host: add frame space update support

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -77,10 +77,11 @@ extern "C" {
  * The value of 8 correspond to page 0 in the LE Controller supported features.
  * 24 bytes are required for all subsequent supported feature pages.
  */
-#define BT_LE_LOCAL_SUPPORTED_FEATURES_SIZE                                                        \
-	(BT_HCI_LE_BYTES_PAGE_0_FEATURE_PAGE +                                                     \
-	 COND_CODE_1(CONFIG_BT_LE_MAX_LOCAL_SUPPORTED_FEATURE_PAGE,                                \
-		CONFIG_BT_LE_MAX_LOCAL_SUPPORTED_FEATURE_PAGE * BT_HCI_LE_BYTES_PER_FEATURE_PAGE,  \
+#define BT_LE_LOCAL_SUPPORTED_FEATURES_SIZE                         \
+	(BT_HCI_LE_BYTES_PAGE_0_FEATURE_PAGE +                      \
+	 COND_CODE_1(CONFIG_BT_LE_MAX_LOCAL_SUPPORTED_FEATURE_PAGE, \
+		(CONFIG_BT_LE_MAX_LOCAL_SUPPORTED_FEATURE_PAGE      \
+			* BT_HCI_LE_BYTES_PER_FEATURE_PAGE),        \
 		(0U)))
 
 /** Opaque type representing an advertiser. */

--- a/include/zephyr/bluetooth/hci_types.h
+++ b/include/zephyr/bluetooth/hci_types.h
@@ -208,6 +208,7 @@ struct bt_hci_cmd_hdr {
 #define BT_LE_FEAT_BIT_CHANNEL_SOUNDING_HOST    47
 #define BT_LE_FEAT_BIT_CHANNEL_SOUNDING_TONE_QUAL_IND    48
 #define BT_LE_FEAT_BIT_EXTENDED_FEAT_SET        63
+#define BT_LE_FEAT_BIT_FRAME_SPACE_UPDATE       65
 
 #define BT_LE_FEAT_TEST(feat, n)                (feat[(n) >> 3] & \
 						 BIT((n) & 7))
@@ -286,6 +287,8 @@ struct bt_hci_cmd_hdr {
 						  BT_LE_FEAT_BIT_CHANNEL_SOUNDING_HOST)
 #define BT_FEAT_LE_EXTENDED_FEAT_SET(feat)        BT_LE_FEAT_TEST(feat, \
 						  BT_LE_FEAT_BIT_EXTENDED_FEAT_SET)
+#define BT_FEAT_LE_FRAME_SPACE_UPDATE_SET(feat)   BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_FRAME_SPACE_UPDATE)
 
 #define BT_FEAT_LE_CIS(feat)            (BT_FEAT_LE_CIS_CENTRAL(feat) | \
 					BT_FEAT_LE_CIS_PERIPHERAL(feat))
@@ -2815,6 +2818,30 @@ struct bt_hci_cp_le_cs_remove_config {
 
 #define BT_HCI_OP_LE_CS_TEST_END BT_OP(BT_OGF_LE, 0x0096) /* 0x2096 */
 
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_PHY_1M_MASK    BIT(0)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_PHY_2M_MASK    BIT(1)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_PHY_CODED_MASK BIT(2)
+
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_SPACING_TYPE_IFS_ACL_CP_MASK BIT(0)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_SPACING_TYPE_IFS_ACL_PC_MASK BIT(1)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_SPACING_TYPE_MCES_MASK       BIT(2)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_SPACING_TYPE_IFS_CIS_MASK    BIT(3)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_SPACING_TYPE_MSS_CIS_MASK    BIT(4)
+
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_INITIATOR_LOCAL_HOST       (0)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_INITIATOR_LOCAL_CONTROLLER (1)
+#define BT_HCI_LE_FRAME_SPACE_UPDATE_INITIATOR_PEER             (2)
+
+struct bt_hci_cp_le_frame_space_update {
+	uint16_t handle;
+	uint16_t frame_space_min;
+	uint16_t frame_space_max;
+	uint8_t  phys;
+	uint16_t spacing_types;
+} __packed;
+
+#define BT_HCI_OP_LE_FRAME_SPACE_UPDATE BT_OP(BT_OGF_LE, 0x009D) /* 0x209D */
+
 /* Event definitions */
 
 #define BT_HCI_EVT_UNKNOWN                      0x00
@@ -4004,6 +4031,16 @@ struct bt_hci_evt_le_cs_procedure_enable_complete {
 	uint16_t max_procedure_len;
 } __packed;
 
+#define BT_HCI_EVT_LE_FRAME_SPACE_UPDATE_COMPLETE 0x35
+struct bt_hci_evt_le_frame_space_update_complete {
+	uint8_t  status;
+	uint16_t handle;
+	uint8_t  initiator;
+	uint16_t frame_space;
+	uint8_t  phys;
+	uint16_t spacing_types;
+} __packed;
+
 /* Event mask bits */
 
 #define BT_EVT_BIT(n) (1ULL << (n))
@@ -4104,6 +4141,8 @@ struct bt_hci_evt_le_cs_procedure_enable_complete {
 #define BT_EVT_MASK_LE_CS_SUBEVENT_RESULT                             BT_EVT_BIT(48)
 #define BT_EVT_MASK_LE_CS_SUBEVENT_RESULT_CONTINUE                    BT_EVT_BIT(49)
 #define BT_EVT_MASK_LE_CS_TEST_END_COMPLETE                           BT_EVT_BIT(50)
+
+#define BT_EVT_MASK_LE_FRAME_SPACE_UPDATE_COMPLETE BT_EVT_BIT(52)
 
 /** HCI Error Codes, BT Core Spec v5.4 [Vol 1, Part F]. */
 #define BT_HCI_ERR_SUCCESS                      0x00

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -115,10 +115,18 @@ config BT_CONN_TX
 	help
 	  Hidden configuration that is true if ACL or broadcast ISO is enabled
 
+config BT_LE_LOCAL_MINIMUM_REQUIRED_FEATURE_PAGE
+	int
+	default 1 if BT_FRAME_SPACE_UPDATE
+	default 0
+	depends on BT_LE_EXTENDED_FEAT_SET
+	help
+	  Minimum required feature page that must be supported.
+
 config BT_LE_MAX_LOCAL_SUPPORTED_FEATURE_PAGE
 	int "Maximum supported feature page"
-	default 0
-	range 0 10
+	default BT_LE_LOCAL_MINIMUM_REQUIRED_FEATURE_PAGE
+	range BT_LE_LOCAL_MINIMUM_REQUIRED_FEATURE_PAGE 10
 	depends on BT_LE_EXTENDED_FEAT_SET
 	help
 	  Maximum feature page that can be stored for local supported features.
@@ -211,6 +219,12 @@ config BT_SUBRATING
 	help
 	  Enable support for LE Connection Subrating feature that is defined in the
 	  Bluetooth Core specification, Version 5.4 | Vol 6, Part B, Section 4.6.35.
+
+config BT_FRAME_SPACE_UPDATE
+	bool "Frame Space Update"
+	depends on (!HAS_BT_CTLR || BT_CTLR_FRAME_SPACE_UPDATE_SUPPORT) && BT_CONN && BT_LE_EXTENDED_FEAT_SET
+	help
+	  Enable support for Bluetooth 6.0 Frame Space Update feature.
 
 config BT_CHANNEL_SOUNDING
 	bool "Channel Sounding [EXPERIMENTAL]"

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -121,8 +121,7 @@ config BT_LE_MAX_LOCAL_SUPPORTED_FEATURE_PAGE
 	range 0 10
 	depends on BT_LE_EXTENDED_FEAT_SET
 	help
-	  Maximum supported feature page that can be stored locally and fetched
-	  from the remote connection with the LL Extended Feature Set feature.
+	  Maximum feature page that can be stored for local supported features.
 
 config BT_LE_EXTENDED_FEAT_SET
 	bool "LL Extended Feature Set"

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -125,6 +125,9 @@ config BT_CTLR_LE_PATH_LOSS_MONITORING_SUPPORT
 config BT_CTLR_SUBRATING_SUPPORT
 	bool
 
+config BT_CTLR_FRAME_SPACE_UPDATE_SUPPORT
+	bool
+
 config BT_CTLR_CHANNEL_SOUNDING_SUPPORT
 	bool
 
@@ -1166,6 +1169,14 @@ config BT_CTLR_SUBRATING
 	default y if BT_SUBRATING
 	help
 	  Enable support for Bluetooth v5.3 LE Connection Subrating
+	  in the Controller.
+
+config BT_CTLR_FRAME_SPACE_UPDATE
+	bool "Frame Space Update"
+	depends on BT_CTLR_FRAME_SPACE_UPDATE_SUPPORT
+	default y if BT_FRAME_SPACE_UPDATE
+	help
+	  Enable support for Bluetooth 6.0 Frame Space Update
 	  in the Controller.
 
 config BT_CTLR_CHANNEL_SOUNDING

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3345,11 +3345,13 @@ int bt_conn_le_subrate_request(struct bt_conn *conn,
 void notify_read_all_remote_feat_complete(struct bt_conn *conn,
 					  struct bt_conn_le_read_all_remote_feat_complete *params)
 {
-	struct bt_conn_cb *callback;
+	if (IS_ENABLED(CONFIG_BT_CONN_DYNAMIC_CALLBACKS)) {
+		struct bt_conn_cb *callback;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
-		if (callback->read_all_remote_feat_complete != NULL) {
-			callback->read_all_remote_feat_complete(conn, params);
+		SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
+			if (callback->read_all_remote_feat_complete != NULL) {
+				callback->read_all_remote_feat_complete(conn, params);
+			}
 		}
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3390,6 +3390,78 @@ int bt_conn_le_read_all_remote_features(struct bt_conn *conn, uint8_t pages_requ
 }
 #endif /* CONFIG_BT_LE_EXTENDED_FEAT_SET */
 
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+void notify_frame_space_update_complete(struct bt_conn *conn,
+					struct bt_conn_le_frame_space_updated *params)
+{
+	if (IS_ENABLED(CONFIG_BT_CONN_DYNAMIC_CALLBACKS)) {
+		struct bt_conn_cb *callback;
+
+		SYS_SLIST_FOR_EACH_CONTAINER(&conn_cbs, callback, _node) {
+			if (callback->frame_space_updated != NULL) {
+				callback->frame_space_updated(conn, params);
+			}
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb)
+	{
+		if (cb->frame_space_updated != NULL) {
+			cb->frame_space_updated(conn, params);
+		}
+	}
+}
+
+static bool frame_space_update_param_valid(const struct bt_conn_le_frame_space_update_param *param)
+{
+	if (param->frame_space_min > BT_CONN_LE_FRAME_SPACE_MAX ||
+	    param->frame_space_max > BT_CONN_LE_FRAME_SPACE_MAX ||
+	    param->frame_space_min > param->frame_space_max) {
+		return false;
+	}
+
+	if (param->spacing_types == 0) {
+		return false;
+	}
+
+	if (param->phys == 0) {
+		return false;
+	}
+
+	return true;
+}
+
+int bt_conn_le_frame_space_update(struct bt_conn *conn,
+				  const struct bt_conn_le_frame_space_update_param *param)
+{
+	struct bt_hci_cp_le_frame_space_update *cp;
+	struct net_buf *buf;
+
+	if (!bt_conn_is_type(conn, BT_CONN_TYPE_LE)) {
+		LOG_DBG("Invalid connection type: %u for %p", conn->type, conn);
+		return -EINVAL;
+	}
+
+	if (!frame_space_update_param_valid(param)) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_alloc(K_FOREVER);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->frame_space_min = sys_cpu_to_le16(param->frame_space_min);
+	cp->frame_space_max = sys_cpu_to_le16(param->frame_space_max);
+	cp->spacing_types = sys_cpu_to_le16(param->spacing_types);
+	cp->phys = param->phys;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_FRAME_SPACE_UPDATE, buf, NULL);
+}
+#endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
+
 #if defined(CONFIG_BT_CHANNEL_SOUNDING)
 void notify_remote_cs_capabilities(struct bt_conn *conn, uint8_t status,
 				   struct bt_conn_le_cs_capabilities *params)

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -515,6 +515,9 @@ void notify_subrate_change(struct bt_conn *conn,
 void notify_read_all_remote_feat_complete(struct bt_conn *conn,
 					  struct bt_conn_le_read_all_remote_feat_complete *params);
 
+void notify_frame_space_update_complete(struct bt_conn *conn,
+					struct bt_conn_le_frame_space_updated *params);
+
 void notify_remote_cs_capabilities(struct bt_conn *conn,
 				   uint8_t status,
 				   struct bt_conn_le_cs_capabilities *params);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1849,6 +1849,33 @@ static void le_read_all_remote_feat_complete(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_LE_EXTENDED_FEAT_SET */
 
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+static void le_frame_space_update_complete(struct net_buf *buf)
+{
+	struct bt_hci_evt_le_frame_space_update_complete *evt = (void *)buf->data;
+	struct bt_conn *conn;
+	struct bt_conn_le_frame_space_updated params;
+	uint16_t handle = sys_le16_to_cpu(evt->handle);
+
+	conn = bt_conn_lookup_handle(handle, BT_CONN_TYPE_LE);
+	if (conn == NULL) {
+		LOG_ERR("Unknown conn handle 0x%04X", handle);
+		return;
+	}
+
+	params.status = evt->status;
+
+	if (params.status == BT_HCI_ERR_SUCCESS) {
+		params.phys = evt->phys;
+		params.spacing_types = evt->spacing_types;
+		params.frame_space = evt->frame_space;
+		params.initiator = evt->initiator;
+	}
+
+	notify_frame_space_update_complete(conn, &params);
+}
+#endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
+
 #if defined(CONFIG_BT_DATA_LEN_UPDATE)
 static void le_data_len_change(struct net_buf *buf)
 {
@@ -2976,6 +3003,11 @@ static const struct event_handler meta_events[] = {
 		      le_read_all_remote_feat_complete,
 		      sizeof(struct bt_hci_evt_le_read_all_remote_feat_complete)),
 #endif /* CONFIG_BT_LE_EXTENDED_FEAT_SET */
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+	EVENT_HANDLER(BT_HCI_EVT_LE_FRAME_SPACE_UPDATE_COMPLETE,
+		      le_frame_space_update_complete,
+		      sizeof(struct bt_hci_evt_le_frame_space_update_complete)),
+#endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
 #endif /* CONFIG_BT_CONN */
 #if defined(CONFIG_BT_CHANNEL_SOUNDING)
 	EVENT_HANDLER(BT_HCI_EVT_LE_CS_READ_REMOTE_SUPPORTED_CAPABILITIES_COMPLETE,
@@ -3541,6 +3573,11 @@ static int le_set_event_mask(void)
 		if (IS_ENABLED(CONFIG_BT_LE_EXTENDED_FEAT_SET) &&
 		    BT_FEAT_LE_EXTENDED_FEAT_SET(bt_dev.le.features)) {
 			mask |= BT_EVT_MASK_LE_READ_ALL_REMOTE_FEAT_COMPLETE;
+		}
+
+		if (IS_ENABLED(CONFIG_BT_FRAME_SPACE_UPDATE) &&
+		    BT_FEAT_LE_FRAME_SPACE_UPDATE_SET(bt_dev.le.features)) {
+			mask |= BT_EVT_MASK_LE_FRAME_SPACE_UPDATE_COMPLETE;
 		}
 	}
 

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1041,6 +1041,38 @@ void read_all_remote_feat_complete(struct bt_conn *conn,
 }
 #endif
 
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+static const char *frame_space_initiator_to_str(
+	enum bt_conn_le_frame_space_update_initiator initiator)
+{
+	switch (initiator) {
+	case BT_CONN_LE_FRAME_SPACE_UPDATE_INITIATOR_LOCAL_HOST:
+		return "Local Host";
+	case BT_CONN_LE_FRAME_SPACE_UPDATE_INITIATOR_LOCAL_CONTROLLER:
+		return "Local Controller";
+	case BT_CONN_LE_FRAME_SPACE_UPDATE_INITIATOR_PEER:
+		return "Peer";
+	default:
+		return "Unknown";
+	}
+}
+
+void frame_space_updated(struct bt_conn *conn,
+			 const struct bt_conn_le_frame_space_updated *params)
+{
+	if (params->status != BT_HCI_ERR_SUCCESS) {
+		bt_shell_print("Frame space update failed (HCI status 0x%02x)",
+			       params->status);
+		return;
+	}
+
+	bt_shell_print(
+		"Frame space updated: frame space %d us, PHYs 0x%04x, spacing types 0x%04x, initiator %s",
+		params->frame_space, params->phys, params->spacing_types,
+		frame_space_initiator_to_str(params->initiator));
+}
+#endif
+
 #if defined(CONFIG_BT_CHANNEL_SOUNDING)
 void print_remote_cs_capabilities(struct bt_conn *conn,
 				  uint8_t status,
@@ -1222,6 +1254,9 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 #endif
 #if defined(CONFIG_BT_LE_EXTENDED_FEAT_SET)
 	.read_all_remote_feat_complete = read_all_remote_feat_complete,
+#endif
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+	.frame_space_updated = frame_space_updated,
 #endif
 #if defined(CONFIG_BT_CHANNEL_SOUNDING)
 	.le_cs_read_remote_capabilities_complete = print_remote_cs_capabilities,
@@ -3348,6 +3383,55 @@ static int cmd_read_all_remote_features(const struct shell *sh, size_t argc, cha
 }
 #endif
 
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+static int cmd_frame_space_update(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err = 0;
+	struct bt_conn_le_frame_space_update_param params;
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Conn handle error, at least one connection is required.");
+		return -ENOEXEC;
+	}
+
+	params.frame_space_min = shell_strtoul(argv[1], 10, &err);
+	if (err) {
+		shell_help(sh);
+		shell_error(sh, "Could not parse frame_space_min input");
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	params.frame_space_max = shell_strtoul(argv[2], 10, &err);
+	if (err) {
+		shell_help(sh);
+		shell_error(sh, "Could not parse frame_space_max input");
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	params.phys = shell_strtoul(argv[3], 16, &err);
+	if (err) {
+		shell_help(sh);
+		shell_error(sh, "Could not parse phys input");
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	params.spacing_types = shell_strtoul(argv[4], 16, &err);
+	if (err) {
+		shell_help(sh);
+		shell_error(sh, "Could not parse spacing_types input");
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	err = bt_conn_le_frame_space_update(default_conn, &params);
+	if (err != 0) {
+		shell_error(sh, "bt_conn_le_frame_space_update returned error %d", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+#endif
+
 #if defined(CONFIG_BT_CONN)
 #if defined(CONFIG_BT_CENTRAL)
 static int bt_do_connect_le(int *ercd, size_t argc, char *argv[])
@@ -5102,6 +5186,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_LE_EXTENDED_FEAT_SET)
 	SHELL_CMD_ARG(read-all-remote-features, NULL, "<pages_requested>",
 		cmd_read_all_remote_features, 2, 0),
+#endif
+#if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
+	SHELL_CMD_ARG(frame-space-update, NULL,
+		      "[frame_space_min <us>] [frame_space_max <us>] [phys <phy mask>] "
+		      "[spacing_types <spacing types mask>]",
+		      cmd_frame_space_update, 5, 0),
 #endif
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advertise, NULL,

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -40,6 +40,12 @@ tests:
       - CONFIG_BT_LE_EXTENDED_FEAT_SET=y
       - CONFIG_BT_LL_SW_SPLIT=n
     build_only: true
+  bluetooth.shell.frame_space_update:
+    extra_configs:
+      - CONFIG_BT_FRAME_SPACE_UPDATE=y
+      - CONFIG_BT_LE_EXTENDED_FEAT_SET=y
+      - CONFIG_BT_LL_SW_SPLIT=n
+    build_only: true
   bluetooth.shell.channel_sounding:
     extra_configs:
       - CONFIG_BT_CHANNEL_SOUNDING=y


### PR DESCRIPTION
This commit adds support for the frame space update feature to the bluetooth host.

This is mainly just a wrapper around the frame space update HCI command and event.

Fix BT_LE_LOCAL_SUPPORTED_FEATURES_SIZE define, as this was not working correctly without brackets around
CONFIG_BT_LE_MAX_LOCAL_SUPPORTED_FEATURE_PAGE.