### PR TITLE
drivers: wifi: esp_at: return WIFI_STATUS_* connect error codes

### DIFF
--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -221,6 +221,7 @@ struct esp_data {
 	uint8_t mode;
 
 	char conn_cmd[CONN_CMD_MAX_LEN];
+	enum wifi_conn_status conn_status;
 
 	/* addresses  */
 	struct in_addr ip;


### PR DESCRIPTION
Return `enum wifi_conn_status` after failed connection attempt. Parse
`+CWJAP:` messages to get failure reason.