### PR TITLE
drivers: console: posix_arch_console: remove build warning

### DIFF
--- a/drivers/console/posix_arch_console.c
+++ b/drivers/console/posix_arch_console.c
@@ -14,6 +14,7 @@
 static char stdout_buff[_STDOUT_BUF_SIZE];
 static int n_pend; /* Number of pending characters in buffer */
 
+#if defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE)
 static int print_char(int c)
 {
 	int printnow = 0;
@@ -36,6 +37,7 @@ static int print_char(int c)
 	}
 	return c;
 }
+#endif /* defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE) */
 
 /**
  * Ensure that whatever was written thru printk is displayed now


### PR DESCRIPTION
Remove build warning when building the posix_arch_console driver with CONFIG_PRINTK=n and CONFIG_STDOUT_CONSOLE=n.

Fixes: #93790