### PR TITLE
drivers: udc: Fix max32 driver high speed support

### DIFF
--- a/drivers/usb/udc/Kconfig.max32
+++ b/drivers/usb/udc/Kconfig.max32
@@ -5,6 +5,7 @@ config UDC_MAX32
 	bool "MAX32 USB device controller driver"
 	default y
 	depends on DT_HAS_ADI_MAX32_USBHS_ENABLED
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT
 	help
 	  MAX32 USB device controller driver.
 


### PR DESCRIPTION
High speed support has been broken for the max32 driver since commit faeabc63c98d62871928387d038f890c5569d712.

Fixes #93792

cc: @hfakkiz 