### PR TITLE
Updated LPADC indexing. Addresses #89671

### DIFF
--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk-pinctrl.dtsi
@@ -141,7 +141,7 @@
 		};
 	};
 
-	pinmux_lpadc0: pinmux_lpadc0 {
+	pinmux_lpadc1: pinmux_lpadc1 {
 		group0 {
 			pinmux = <&iomuxc_gpio_ad_06_adc1_ch0a>;
 			drive-strength = "high";

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -201,8 +201,8 @@
 	pinctrl-names = "default";
 };
 
-&lpadc0 {
-	pinctrl-0 = <&pinmux_lpadc0>;
+&lpadc1 {
+	pinctrl-0 = <&pinmux_lpadc1>;
 	pinctrl-names = "default";
 };
 

--- a/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
+++ b/boards/nxp/mimxrt1160_evk/mimxrt1160_evk_mimxrt1166_cm7.dts
@@ -108,7 +108,7 @@
 	status = "okay";
 };
 
-&lpadc0 {
+&lpadc1 {
 	status = "okay";
 };
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk-pinctrl.dtsi
@@ -201,7 +201,7 @@
 		};
 	};
 
-	pinmux_lpadc0: pinmux_lpadc0 {
+	pinmux_lpadc1: pinmux_lpadc1 {
 		group0 {
 			pinmux = <&iomuxc_gpio_ad_06_adc1_ch0a>;
 			drive-strength = "high";

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -231,8 +231,8 @@ arduino_spi: &lpspi1 {
 	pinctrl-names = "default";
 };
 
-&lpadc0 {
-	pinctrl-0 = <&pinmux_lpadc0>;
+&lpadc1 {
+	pinctrl-0 = <&pinmux_lpadc1>;
 	pinctrl-names = "default";
 };
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk_mimxrt1176_cm7.dts
@@ -118,7 +118,7 @@ nxp_mipi_i2c: &lpi2c5 {
 	#size-cells = <0>;
 };
 
-&lpadc0 {
+&lpadc1 {
 	status = "okay";
 };
 

--- a/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
@@ -179,7 +179,7 @@
 		};
 	};
 
-	pinmux_lpadc1: pinmux_lpadc1 {
+	pinmux_lpadc2: pinmux_lpadc2 {
 		group0 {
 			pinmux = <&iomuxc_gpio_ad_10_adc1_ch2a>;
 			drive-strength = "normal";

--- a/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170.dtsi
@@ -176,8 +176,8 @@
 	pinctrl-names = "default";
 };
 
-&lpadc1 {
-	pinctrl-0 = <&pinmux_lpadc1>;
+&lpadc2 {
+	pinctrl-0 = <&pinmux_lpadc2>;
 	pinctrl-names = "default";
 };
 

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -478,7 +478,7 @@
 	status = "okay";
 };
 
-&lpadc1 {
+&lpadc2 {
 	status = "okay";
 };
 

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -29,6 +29,8 @@ Kernel
 Boards
 ******
 
+* mimxrt11x0: renamed lpadc1 to lpadc2 and renamed lpadc0 to lpadc1.
+
 Device Drivers and Devicetree
 *****************************
 

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -956,7 +956,7 @@
 			reg = <0x202c0000 DT_SIZE_K(512)>;
 		};
 
-		lpadc0: adc@40050000 {
+		lpadc1: adc@40050000 {
 			compatible = "nxp,lpc-lpadc";
 			reg = <0x40050000 0x304>;
 			interrupts = <88 0>;
@@ -970,7 +970,7 @@
 			clocks = <&ccm IMX_CCM_LPADC1_CLK 0 0>;
 		};
 
-		lpadc1: adc@40054000 {
+		lpadc2: adc@40054000 {
 			compatible = "nxp,lpc-lpadc";
 			reg = <0x40054000 0x304>;
 			interrupts = <89 0>;

--- a/samples/drivers/adc/adc_dt/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
+++ b/samples/drivers/adc/adc_dt/boards/mimxrt1160_evk_mimxrt1166_cm7.overlay
@@ -9,11 +9,11 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&lpadc0 0>;
+		io-channels = <&lpadc1 0>;
 	};
 };
 
-&lpadc0 {
+&lpadc1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/samples/drivers/adc/adc_dt/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/samples/drivers/adc/adc_dt/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -9,11 +9,11 @@
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
-		io-channels = <&lpadc0 0>;
+		io-channels = <&lpadc1 0>;
 	};
 };
 
-&lpadc0 {
+&lpadc1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
+++ b/tests/drivers/adc/adc_api/boards/mimxrt1170_evk_mimxrt1176_cm7.overlay
@@ -8,11 +8,11 @@
 
 / {
 	zephyr,user {
-		io-channels = <&lpadc0 0>, <&lpadc0 1>;
+		io-channels = <&lpadc1 0>, <&lpadc1 1>;
 	};
 };
 
-&lpadc0 {
+&lpadc1 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/tests/drivers/adc/adc_api/boards/vmu_rt1170_mimxrt1176_cm7.overlay
+++ b/tests/drivers/adc/adc_api/boards/vmu_rt1170_mimxrt1176_cm7.overlay
@@ -8,11 +8,11 @@
 
 / {
 	zephyr,user {
-		io-channels = <&lpadc1 0>, <&lpadc1 1>;
+		io-channels = <&lpadc2 0>, <&lpadc2 1>;
 	};
 };
 
-&lpadc1 {
+&lpadc2 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 


### PR DESCRIPTION
Updated the LPADC instance numbers in the device tree to line up with the indexing
done in the RM. 
Fixes #89671 