### PR TITLE
VIDEO: GC2145/stm32_dcmi support for CROP/Snapshot

### DIFF
--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -768,13 +768,22 @@ struct gc2145_ctrls {
 struct gc2145_data {
 	struct gc2145_ctrls ctrls;
 	struct video_format fmt;
+	struct video_rect crop;
+	uint16_t format_width;
+	uint16_t format_height;
+	uint8_t ratio;
 };
 
-#define GC2145_VIDEO_FORMAT_CAP(width, height, format)                                             \
-	{                                                                                          \
-		.pixelformat = format, .width_min = width, .width_max = width,                     \
-		.height_min = height, .height_max = height, .width_step = 0, .height_step = 0,     \
+#define GC2145_VIDEO_FORMAT_CAP_HL(width_l, width_h, height_l, height_h, format, step_w, step_h) \
+	{										\
+		.pixelformat = (format),						\
+		.width_min = (width_l), .width_max = (width_h),				\
+		.height_min = (height_l), .height_max = (height_h),			\
+		.width_step = (step_w), .height_step = (step_h),			\
 	}
+
+#define GC2145_VIDEO_FORMAT_CAP(width, height, format)	\
+	GC2145_VIDEO_FORMAT_CAP_HL((width), (width), (height), (height), (format), 0, 0)
 
 #define RESOLUTION_QVGA_W	320
 #define RESOLUTION_QVGA_H	240
@@ -785,6 +794,13 @@ struct gc2145_data {
 #define RESOLUTION_UXGA_W	1600
 #define RESOLUTION_UXGA_H	1200
 
+#define RESOLUTION_MAX_W	RESOLUTION_UXGA_W
+#define RESOLUTION_MAX_H	RESOLUTION_UXGA_H
+
+/* Min not defined - smallest seen implementation is for QQVGA */
+#define RESOLUTION_MIN_W	160
+#define RESOLUTION_MIN_H	120
+
 static const struct video_format_cap fmts[] = {
 	GC2145_VIDEO_FORMAT_CAP(RESOLUTION_QVGA_W, RESOLUTION_QVGA_H, VIDEO_PIX_FMT_RGB565),
 	GC2145_VIDEO_FORMAT_CAP(RESOLUTION_VGA_W, RESOLUTION_VGA_H, VIDEO_PIX_FMT_RGB565),
@@ -792,6 +808,11 @@ static const struct video_format_cap fmts[] = {
 	GC2145_VIDEO_FORMAT_CAP(RESOLUTION_QVGA_W, RESOLUTION_QVGA_H, VIDEO_PIX_FMT_YUYV),
 	GC2145_VIDEO_FORMAT_CAP(RESOLUTION_VGA_W, RESOLUTION_VGA_H, VIDEO_PIX_FMT_YUYV),
 	GC2145_VIDEO_FORMAT_CAP(RESOLUTION_UXGA_W, RESOLUTION_UXGA_H, VIDEO_PIX_FMT_YUYV),
+	/* Add catchall resolution  */
+	GC2145_VIDEO_FORMAT_CAP_HL(RESOLUTION_MIN_W, RESOLUTION_MAX_W, RESOLUTION_MIN_H,
+				   RESOLUTION_MAX_H, VIDEO_PIX_FMT_RGB565, 1, 1),
+	GC2145_VIDEO_FORMAT_CAP_HL(RESOLUTION_MIN_W, RESOLUTION_MAX_W, RESOLUTION_MIN_H,
+				   RESOLUTION_MAX_H, VIDEO_PIX_FMT_YUYV, 1, 1),
 	{0},
 };
 
@@ -843,44 +864,74 @@ static int gc2145_set_output_format(const struct device *dev, int output_format)
 	return 0;
 }
 
+static int gc2145_set_crop_registers(const struct gc2145_config *cfg, uint16_t x, uint16_t y,
+				     uint16_t w, uint16_t h)
+{
+	int ret;
+
+	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_ROW_START, y);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_COL_START, x);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_HEIGHT, h);
+	if (ret < 0) {
+		return ret;
+	}
+	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_WIDTH, w);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Enable crop */
+	return video_write_cci_reg(&cfg->i2c, GC2145_REG_CROP_ENABLE, GC2145_CROP_SET_ENABLE);
+}
+
 static int gc2145_set_resolution(const struct device *dev, uint32_t w, uint32_t h)
 {
 	const struct gc2145_config *cfg = dev->config;
+	struct gc2145_data *drv_data = dev->data;
 	int ret;
 
 	uint16_t win_w;
 	uint16_t win_h;
-	uint16_t c_ratio;
-	uint16_t r_ratio;
-	uint16_t x;
-	uint16_t y;
 	uint16_t win_x;
 	uint16_t win_y;
 
-	/* Add the subsampling factor depending on resolution */
-	switch (w) {
-	case RESOLUTION_QVGA_W:
-		c_ratio = 3;
-		r_ratio = 3;
-		break;
-	case RESOLUTION_VGA_W:
-		c_ratio = 2;
-		r_ratio = 2;
-		break;
-	case RESOLUTION_UXGA_W:
-		c_ratio = 1;
-		r_ratio = 1;
-		break;
-	default:
-		LOG_ERR("Unsupported resolution %d %d", w, h);
+	if ((w == 0) || (h == 0)) {
 		return -EIO;
-	};
+	}
+
+	/* If we are called from set_format, then we compute ratio and initialize crop */
+	drv_data->ratio = MIN(RESOLUTION_UXGA_W / w, RESOLUTION_UXGA_H / h);
+
+	/* make sure we don't end up with ratio of 0 */
+	if (drv_data->ratio == 0) {
+		return -EIO;
+	}
+
+	/* Restrict ratio to 3 for faster refresh ? */
+	if (drv_data->ratio > 3) {
+		drv_data->ratio = 3;
+	}
+
+	/* remember the width and height passed in */
+	drv_data->format_width = w;
+	drv_data->format_height = h;
+
+	/* Default to crop rectangle being same size as passed in resolution */
+	drv_data->crop.left = 0;
+	drv_data->crop.top = 0;
+	drv_data->crop.width = w;
+	drv_data->crop.height = h;
 
 	/* Calculates the window boundaries to obtain the desired resolution */
-	win_w = w * c_ratio;
-	win_h = h * r_ratio;
-	x = (((win_w / c_ratio) - w) / 2);
-	y = (((win_h / r_ratio) - h) / 2);
+
+	win_w = w * drv_data->ratio;
+	win_h = h * drv_data->ratio;
 	win_x = ((UXGA_HSIZE - win_w) / 2);
 	win_y = ((UXGA_VSIZE - win_h) / 2);
 
@@ -909,31 +960,14 @@ static int gc2145_set_resolution(const struct device *dev, uint32_t w, uint32_t 
 	}
 
 	/* Set cropping window next. */
-	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_ROW_START, y);
-	if (ret < 0) {
-		return ret;
-	}
-	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_COL_START, x);
-	if (ret < 0) {
-		return ret;
-	}
-	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_HEIGHT, h);
-	if (ret < 0) {
-		return ret;
-	}
-	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_OUT_WIN_WIDTH, w);
-	if (ret < 0) {
-		return ret;
-	}
-
-	/* Enable crop */
-	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_CROP_ENABLE, GC2145_CROP_SET_ENABLE);
+	ret = gc2145_set_crop_registers(cfg, 0, 0, w, h);
 	if (ret < 0) {
 		return ret;
 	}
 
 	/* Set Sub-sampling ratio and mode */
-	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_SUBSAMPLE, ((r_ratio << 4) | c_ratio));
+	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG_SUBSAMPLE,
+				  (drv_data->ratio << 4) | drv_data->ratio);
 	if (ret < 0) {
 		return ret;
 	}
@@ -950,6 +984,52 @@ static int gc2145_set_resolution(const struct device *dev, uint32_t w, uint32_t 
 	 * give some time time to apply the changes before the next instruction.
 	 */
 	k_sleep(K_MSEC(30));
+
+	return 0;
+}
+
+static int gc2145_set_crop(const struct device *dev, struct video_selection *sel)
+{
+	/* set the crop, start off with most of a duplicate of set resolution */
+	int ret;
+	const struct gc2145_config *cfg = dev->config;
+	struct gc2145_data *drv_data = dev->data;
+
+	/* Verify the passed in rectangle is valid */
+	if (((sel->rect.left + sel->rect.width) > drv_data->format_width) ||
+	    ((sel->rect.top + sel->rect.height) > drv_data->format_height)) {
+		LOG_INF("(%u %u) %ux%u > %ux%u", sel->rect.left, sel->rect.top,
+				sel->rect.width, sel->rect.height,
+				drv_data->format_width, drv_data->format_height);
+		return -EINVAL;
+	}
+
+	/* if rectangle passed in is same as current, simply return */
+	if ((drv_data->crop.left == sel->rect.left) && (drv_data->crop.top == sel->rect.top) &&
+	    (drv_data->crop.width == sel->rect.width) &&
+	    (drv_data->crop.height == sel->rect.height)) {
+		return 0;
+	}
+
+	/* save out the updated crop window registers */
+	ret = video_write_cci_reg(&cfg->i2c, GC2145_REG8(GC2145_REG_RESET),
+				  GC2145_REG_RESET_P0_REGS);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = gc2145_set_crop_registers(cfg, sel->rect.left, sel->rect.top,
+					sel->rect.width, sel->rect.height);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Only if valid do we update our crop rectangle */
+	drv_data->crop = sel->rect;
+
+	/* enqueue/dequeue depend on this being set as well as the crop */
+	drv_data->fmt.width = drv_data->crop.width;
+	drv_data->fmt.height = drv_data->crop.height;
 
 	return 0;
 }
@@ -1047,7 +1127,7 @@ static int gc2145_set_fmt(const struct device *dev, struct video_format *fmt)
 {
 	struct gc2145_data *drv_data = dev->data;
 	const struct gc2145_config *cfg = dev->config;
-	size_t res = ARRAY_SIZE(fmts);
+	size_t idx;
 	int ret;
 
 	if (memcmp(&drv_data->fmt, fmt, sizeof(drv_data->fmt)) == 0) {
@@ -1056,14 +1136,7 @@ static int gc2145_set_fmt(const struct device *dev, struct video_format *fmt)
 	}
 
 	/* Check if camera is capable of handling given format */
-	for (int i = 0; i < ARRAY_SIZE(fmts) - 1; i++) {
-		if (fmts[i].width_min == fmt->width && fmts[i].height_min == fmt->height &&
-		    fmts[i].pixelformat == fmt->pixelformat) {
-			res = i;
-			break;
-		}
-	}
-	if (res == ARRAY_SIZE(fmts)) {
+	if (video_format_caps_index(fmts, fmt, &idx) < 0) {
 		LOG_ERR("Image format not supported");
 		return -ENOTSUP;
 	}
@@ -1171,12 +1244,55 @@ static int gc2145_set_ctrl(const struct device *dev, uint32_t id)
 	}
 }
 
+static int gc2145_set_selection(const struct device *dev, struct video_selection *sel)
+{
+	LOG_DBG("called: (%u %u)", sel->type, sel->target);
+	if (sel->type != VIDEO_BUF_TYPE_OUTPUT) {
+		return -EINVAL;
+	}
+
+	if (sel->target != VIDEO_SEL_TGT_CROP) {
+		return -EINVAL;
+	}
+
+	return gc2145_set_crop(dev, sel);
+}
+
+static int gc2145_get_selection(const struct device *dev, struct video_selection *sel)
+{
+	LOG_DBG("called: (%u %u)", sel->type, sel->target);
+	if (sel->type != VIDEO_BUF_TYPE_OUTPUT) {
+		return -EINVAL;
+	}
+
+	struct gc2145_data *drv_data = dev->data;
+
+	switch (sel->target) {
+	case VIDEO_SEL_TGT_CROP:
+		sel->rect = drv_data->crop;
+		break;
+
+	case VIDEO_SEL_TGT_NATIVE_SIZE:
+		sel->rect.top = 0;
+		sel->rect.left = 0;
+		sel->rect.width = drv_data->format_width;
+		sel->rect.height = drv_data->format_height;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static DEVICE_API(video, gc2145_driver_api) = {
 	.set_format = gc2145_set_fmt,
 	.get_format = gc2145_get_fmt,
 	.get_caps = gc2145_get_caps,
 	.set_stream = gc2145_set_stream,
 	.set_ctrl = gc2145_set_ctrl,
+	.set_selection = gc2145_set_selection,
+	.get_selection = gc2145_get_selection,
 };
 
 static int gc2145_init_controls(const struct device *dev)

--- a/drivers/video/video_stm32_dcmi.c
+++ b/drivers/video/video_stm32_dcmi.c
@@ -315,7 +315,8 @@ static int video_stm32_dcmi_enqueue(const struct device *dev, struct video_buffe
 	return 0;
 }
 
-static int video_stm32_restart_dma_after_error(struct video_stm32_dcmi_data *data) {
+static int video_stm32_restart_dma_after_error(struct video_stm32_dcmi_data *data)
+{
 	LOG_DBG("Restart DMA after Error!");
 	/* Lets try to recover by stopping and maybe restart */
 	if (HAL_DCMI_Stop(&data->hdcmi) != HAL_OK) {

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -46,6 +46,10 @@ properties:
               STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
               STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
 
+  snapshot-mode:
+    type: boolean
+    description: set the driver into snapshot mode, default is off.
+
 child-binding:
   child-binding:
     include: video-interfaces.yaml

--- a/dts/bindings/video/st,stm32-dcmi.yaml
+++ b/dts/bindings/video/st,stm32-dcmi.yaml
@@ -48,7 +48,12 @@ properties:
 
   snapshot-mode:
     type: boolean
-    description: set the driver into snapshot mode, default is off.
+    description: Set DCMI to Snapshot mode, instead of the default Capture mode.
+
+  snapshot-timeout:
+    type: int
+    description: Set capture timeout in microseconds, default is 1000.
+    default: 1000
 
 child-binding:
   child-binding:


### PR DESCRIPTION
Added support to video_stm32_dcmi for the new
set and get selection.  These implementations simply forward the message to the underlying 
camera object if they support these messages.

Also added support for a snapshot mode instead of
always using continuous capture mode.  Tried
to make it semi-transparent when you desire it to be

The  stm32_dcmi code now also allows you to work
with only one buffer.  This will force it into snap shot mode.  There is also new calls added to the api for: video_get_snapshot_mode and video_set_snapshot_mode.

That allows you to set it with more than one buffer and query what mode you are in.

GC2145 was updated first to try out these changes. The camera now allows me to follow the call order
that @josuah mentioned in another pr/issue.

With this driver I also updated it to allow more or less any video resolution:
	{                                                                                          \
		.pixelformat = format, .width_min = width_l, .width_max = width_h,                     \
		.height_min = height_l, .height_max = height_h, .width_step = 0, .height_step = 0,     \
	}

```
static const struct video_format_cap fmts[] = {
	GC2145_VIDEO_FORMAT_CAP_HL(128, 1600, 128, 1200, VIDEO_PIX_FMT_RGB565),
	GC2145_VIDEO_FORMAT_CAP_HL(128, 1600, 128, 1200, VIDEO_PIX_FMT_YUYV),
```
When  resolution is set, it computes the scale factor. If you then later call set_crop, the same code is 
used except it uses the ratios computed from the set_resolution.

With these changes: I was able to setup a test app, for the Arduino Nicla vision and send out a 480x320 image over USB.

More to come

Note: this is a replacement for #91975

My current test sketch/app is up at:
https://github.com/KurtE/zephyr_test_sketches/tree/master/camera_capture_to_usb
built using:
```
west build -p -b arduino_nicla_vision//m7
west flash

```
I am using the Arducam viewer with this on my PC.  I am using the one at:
https://github.com/mjs513/Teensy_Camera/tree/main/extras/host_app

Picture using GC2145 on Arduino Nicla Vision shown on Arducam mini viewer.
<img width="655" height="833" alt="image" src="https://github.com/user-attachments/assets/52a6ab87-8ab9-4092-bc44-ec90742c0f0c" />

**Edit:  current summary of changes:** 
There are several changes some of which will likely change if/when code reviews happen.  Things like:
a) The stm_dcmi driver handles the get/set selection APIs and if the camera has also implemented these APIs, it 
forwards the messages to them, else return error not implemented. 

a1) GC2145 camera implements them.

b) Currently I allow arbitrary size of the frame GC2145, that is I have one fmt (per RGB...) which sets min and max versus the 
ones where it current code which has 3 arbitrary sizes (1600x1200 - ratio 1, 640x480 ratio 2, 320x240 ratio 3).  I instead
compute ratio and allow you to choose for example 800x600 which is less arbitrary than the 640x480...  Note 320x240
computes  ratio=5, except I currently limit to max ratio=3 per seeing other implementations that do so... Maybe should
make that max configurable. 

c) Setting to allow the code to run in SNAPSHOT mode, which starts the camera, waits for one frame to come back and then deactivates. 

This is the way that Arduino library works at least on MBED.  Note snapshot mode also has some ability to recover from
failures...

d) Allow you to configure to only have one buffer, before it required at least two, If set to 1, it set forces SNAPSHOT mode.

With this running on Zephyr, I for example was able to program a Nicla Vision, which has no SDRAM and output at
480x320 over USB to an Arducam viewer.  My test sketch (not sure what to call them on Zephyr)
is up at https://github.com/KurtE/zephyr_test_sketches/tree/master/camera_capture_to_usb 

Also have others that output to Portenta H7 to an ST7796 display...
