### PR TITLE
hostap: Update 11k roaming mechanism

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -1594,6 +1594,14 @@ struct wifi_mgmt_ops {
 	 * @return 0 if ok, < 0 if error
 	 */
 	int (*btm_query)(const struct device *dev, uint8_t reason);
+
+	/** Check if ap support Neighbor Report or not.
+	 * @param dev Pointer to the device structure for the driver instance.
+	 *
+	 * @return true if support, false if not support
+	 */
+	bool (*bss_support_neighbor_rep)(const struct device *dev);
+
 	/** Judge ap whether support the capability
 	 *
 	 * @param dev Pointer to the device structure for the driver instance.

--- a/modules/hostap/src/supp_api.h
+++ b/modules/hostap/src/supp_api.h
@@ -277,6 +277,14 @@ int supplicant_btm_query(const struct device *dev, uint8_t reason);
  */
 int supplicant_legacy_roam(const struct device *dev);
 
+/** Check if ap supports Neighbor report or not.
+ *
+ * @param dev Pointer to the device structure for the driver instance.
+ *
+ * @return true if support, false if not support
+ */
+bool supplicant_bss_support_neighbor_rep(const struct device *dev);
+
 /** Judge ap whether support the capability
  *
  * @param dev Pointer to the device structure for the driver instance.

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -76,6 +76,7 @@ static const struct wifi_mgmt_ops mgmt_ops = {
 	.channel = supplicant_channel,
 	.set_rts_threshold = supplicant_set_rts_threshold,
 	.get_rts_threshold = supplicant_get_rts_threshold,
+	.bss_support_neighbor_rep = supplicant_bss_support_neighbor_rep,
 	.bss_ext_capab = supplicant_bss_ext_capab,
 	.legacy_roam = supplicant_legacy_roam,
 #ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_WNM

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -41,7 +41,6 @@ struct wifi_rrm_neighbor_report_t {
 
 struct wifi_roaming_params {
 	bool is_11r_used;
-	bool is_11k_enabled;
 	struct wifi_rrm_neighbor_report_t neighbor_rep;
 };
 
@@ -565,7 +564,7 @@ static int wifi_start_roaming(uint64_t mgmt_request, struct net_if *iface,
 		}
 
 		return wifi_mgmt_api->start_11r_roaming(dev);
-	} else if (roaming_params.is_11k_enabled) {
+	} else if (wifi_mgmt_api->bss_support_neighbor_rep(dev)) {
 		memset(&roaming_params.neighbor_rep, 0x0, sizeof(roaming_params.neighbor_rep));
 		if (wifi_mgmt_api->send_11k_neighbor_request == NULL) {
 			return -ENOTSUP;
@@ -889,12 +888,6 @@ static int wifi_11k_cfg(uint64_t mgmt_request, struct net_if *iface,
 	if (!net_if_is_admin_up(iface)) {
 		return -ENETDOWN;
 	}
-
-#ifdef CONFIG_WIFI_NM_WPA_SUPPLICANT_ROAMING
-	if (params->oper == WIFI_MGMT_SET) {
-		roaming_params.is_11k_enabled = params->enable_11k;
-	}
-#endif
 
 	return wifi_mgmt_api->cfg_11k(dev, params);
 }


### PR DESCRIPTION
With this changes, device will check if AP support Neighbor Report or not before trigger roaming. No need to issue 11k command to enable 11k, if AP supports Neighbor Report, device will trigger 11k roaming with priority.