### PR TITLE
display: fix rgb565 / bgr565 displays and add documentation

### DIFF
--- a/drivers/display/display_st7796s.c
+++ b/drivers/display/display_st7796s.c
@@ -102,18 +102,18 @@ static int st7796s_get_pixelfmt(const struct device *dev)
 	/*
 	 * Invert the pixel format for 8-bit 8080 Parallel Interface.
 	 *
-	 * Zephyr uses big endian byte order when the pixel format has
+	 * Zephyr uses little endian byte order when the pixel format has
 	 * multiple bytes.
 	 *
-	 * For RGB565, Red is placed in byte 1 and Blue in byte 0.
-	 * For BGR565, Red is placed in byte 0 and Blue in byte 1.
+	 * For BGR565, Red is placed in byte 1 and Blue in byte 0.
+	 * For RGB565, Red is placed in byte 0 and Blue in byte 1.
 	 *
 	 * This is not an issue when using a 16-bit interface.
 	 * For RGB565, this would map to Red being in D[11:15] and
 	 * Blue in D[0:4] and vice versa for BGR565.
 	 *
 	 * However this is an issue when using a 8-bit interface.
-	 * For RGB565, Blue is placed in byte 0 as mentioned earlier.
+	 * For BGR565, Blue is placed in byte 0 as mentioned earlier.
 	 * However the controller expects Red to be in D[3:7] of byte 0.
 	 *
 	 * Hence we report pixel format as RGB when MADCTL setting is BGR
@@ -143,9 +143,9 @@ static int st7796s_get_pixelfmt(const struct device *dev)
 	 */
 	if (((bool)(config->madctl & ST7796S_MADCTL_BGR)) !=
 	    config->rgb_is_inverted) {
-		return PIXEL_FORMAT_BGR_565;
-	} else {
 		return PIXEL_FORMAT_RGB_565;
+	} else {
+		return PIXEL_FORMAT_BGR_565;
 	}
 }
 

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -55,7 +55,7 @@ LOG_MODULE_REGISTER(display_stm32_ltdc, CONFIG_DISPLAY_LOG_LEVEL);
 #elif CONFIG_STM32_LTDC_RGB565
 #define STM32_LTDC_INIT_PIXEL_SIZE	2u
 #define STM32_LTDC_INIT_PIXEL_FORMAT	LTDC_PIXEL_FORMAT_RGB565
-#define DISPLAY_INIT_PIXEL_FORMAT	PIXEL_FORMAT_BGR_565
+#define DISPLAY_INIT_PIXEL_FORMAT	PIXEL_FORMAT_RGB_565
 #else
 #error "Invalid LTDC pixel format chosen"
 #endif
@@ -110,9 +110,9 @@ static int stm32_ltdc_set_pixel_format(const struct device *dev,
 	struct display_stm32_ltdc_data *data = dev->data;
 
 	switch (format) {
-	case PIXEL_FORMAT_BGR_565:
+	case PIXEL_FORMAT_RGB_565:
 		err = HAL_LTDC_SetPixelFormat(&data->hltdc, LTDC_PIXEL_FORMAT_RGB565, 0);
-		data->current_pixel_format = PIXEL_FORMAT_BGR_565;
+		data->current_pixel_format = PIXEL_FORMAT_RGB_565;
 		data->current_pixel_size = 2u;
 		break;
 	case PIXEL_FORMAT_RGB_888:
@@ -158,7 +158,7 @@ static void stm32_ltdc_get_capabilities(const struct device *dev,
 				     data->hltdc.LayerCfg[0].WindowY0;
 	capabilities->supported_pixel_formats = PIXEL_FORMAT_ARGB_8888 |
 					PIXEL_FORMAT_RGB_888 |
-					PIXEL_FORMAT_BGR_565;
+					PIXEL_FORMAT_RGB_565;
 	capabilities->screen_info = 0;
 
 	capabilities->current_pixel_format = data->current_pixel_format;

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -44,8 +44,28 @@ enum display_pixel_format {
 	PIXEL_FORMAT_MONO01		= BIT(1), /**< Monochrome (0=Black 1=White) */
 	PIXEL_FORMAT_MONO10		= BIT(2), /**< Monochrome (1=Black 0=White) */
 	PIXEL_FORMAT_ARGB_8888		= BIT(3), /**< 32-bit ARGB */
-	PIXEL_FORMAT_RGB_565		= BIT(4), /**< 16-bit RGB */
-	PIXEL_FORMAT_BGR_565		= BIT(5), /**< 16-bit BGR */
+	/**
+	 * 16-bit RGB format packed into two bytes: 5 red bits [15:11], 6
+	 * green bits [10:5], 5 blue bits [4:0]. For example, in little-endian machine:
+	 *
+	 * @code{.unparsed}
+	 *   7......0 15.....8
+	 * | gggBbbbb RrrrrGgg | ...
+	 * @endcode
+	 *
+	 */
+	PIXEL_FORMAT_RGB_565		= BIT(4),
+	/**
+	 * 16-bit RGB format packed into two bytes: 5 blue bits [15:11], 6
+	 * green bits [10:5], 5 red bits [4:0]. For example, in little-endian machine:
+	 *
+	 * @code{.unparsed}
+	 *   7......0 15.....8
+	 * | gggRrrrr BbbbbGgg | ...
+	 * @endcode
+	 *
+	 */
+	PIXEL_FORMAT_BGR_565		= BIT(5),
 	PIXEL_FORMAT_L_8		= BIT(6), /**< 8-bit Grayscale/Luminance, equivalent to */
 						  /**< GRAY, GREY, GRAY8, Y8, R8, etc...        */
 };


### PR DESCRIPTION
After https://github.com/zephyrproject-rtos/zephyr/pull/79996 merged, this PR continues to 

- fix the display_st7796s and st's ltdc display drivers affected by the changes and
- add some more documentation for the rgb565/bgr565 display formats.