### PR TITLE
Silabs DTS format

### DIFF
--- a/boards/arduino/nano_matter/arduino_nano_matter-pinctrl.dtsi
+++ b/boards/arduino/nano_matter/arduino_nano_matter-pinctrl.dtsi
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
 	eusart0_default: eusart0_default {

--- a/boards/seeed/xiao_mg24/xiao_mg24-pinctrl.dtsi
+++ b/boards/seeed/xiao_mg24/xiao_mg24-pinctrl.dtsi
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
 	eusart0_default: eusart0_default {

--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
 
 &pinctrl0 {
 	psram_default: psram_default {

--- a/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
+++ b/boards/silabs/dev_kits/siwx917_dk2605a/siwx917_dk2605a.dts
@@ -5,10 +5,10 @@
 
 /dts-v1/;
 #include <silabs/siwg917m111mgtba.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
-#include <dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
-#include <common/freq.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
+#include <freq.h>
 #include "siwx917_dk2605a-pinctrl.dtsi"
 
 / {

--- a/boards/silabs/dev_kits/sltb004a/sltb004a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb004a/sltb004a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	/* configuration for uart0 device, default state */

--- a/boards/silabs/dev_kits/sltb009a/sltb009a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb009a/sltb009a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/silabs/dev_kits/sltb010a/sltb010a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/sltb010a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg22-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg22-pinctrl.h>
 
 &pinctrl {
 	itm_default: itm_default {

--- a/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg24_dk2601b/xg24_dk2601b-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
 	eusart1_default: eusart1_default {

--- a/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg24_ek2703a/xg24_ek2703a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
 	itm_default: itm_default {

--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a-pinctrl.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg27-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg27-pinctrl.h>
 
 &pinctrl {
 	itm_default: itm_default {

--- a/boards/silabs/radio_boards/common/efr32-series1-common-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/common/efr32-series1-common-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	/* configuration for usart0 device, default state - operating as UART */

--- a/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4338a/siwx917_rb4338a.dts
@@ -6,10 +6,10 @@
 
 /dts-v1/;
 #include <silabs/siwg917m111mgtba.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
-#include <dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
-#include <common/freq.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
+#include <freq.h>
 
 / {
 	model = "Silicon Labs BRD4338A (SiWG917 Radio Board)";

--- a/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
+++ b/boards/silabs/radio_boards/siwx917_rb4342a/siwx917_rb4342a.dts
@@ -6,11 +6,11 @@
 
 /dts-v1/;
 #include <silabs/siwg917m111mgtba.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input-event-codes.h>
-#include <dt-bindings/memory-attr/memory-attr-arm.h>
-#include <dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
-#include <common/freq.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/memory-attr/memory-attr-arm.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/siwx91x-pinctrl.h>
+#include <freq.h>
 
 / {
 	model = "Silicon Labs BRD4342A (SiWG917 Radio Board)";

--- a/boards/silabs/radio_boards/slwrb4180a/slwrb4180a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4180a/slwrb4180a-pinctrl.dtsi
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg21-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg21-pinctrl.h>
 
 &pinctrl {
 	usart0_default: usart0_default {

--- a/boards/silabs/radio_boards/slwrb4180b/slwrb4180b-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4180b/slwrb4180b-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg21-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg21-pinctrl.h>
 
 &pinctrl {
 	usart0_default: usart0_default {

--- a/boards/silabs/radio_boards/slwrb4250b/slwrb4250b-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4250b/slwrb4250b-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	/* configuration for uart0 device, default state */

--- a/boards/silabs/radio_boards/slwrb4255a/slwrb4255a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4255a/slwrb4255a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	/* configuration for uart0 device, default state */

--- a/boards/silabs/radio_boards/slwrb4321a/slwrb4321a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/slwrb4321a/slwrb4321a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg23-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg23-pinctrl.h>
 
 &pinctrl {
 	itm_default: itm_default {

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c-pinctrl.dtsi
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
 	eusart1_default: eusart1_default {

--- a/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a-pinctrl.dtsi
+++ b/boards/silabs/radio_boards/xg29_rb4412a/xg29_rb4412a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/silabs/xg29-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg29-pinctrl.h>
 
 &pinctrl {
 	eusart1_default: eusart1_default {

--- a/boards/silabs/starter_kits/slstk3401a/slstk3401a-pinctrl.dtsi
+++ b/boards/silabs/starter_kits/slstk3401a/slstk3401a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/silabs/starter_kits/slstk3402a/slstk3402a-pinctrl.dtsi
+++ b/boards/silabs/starter_kits/slstk3402a/slstk3402a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/silabs/starter_kits/slstk3701a/slstk3701a-pinctrl.dtsi
+++ b/boards/silabs/starter_kits/slstk3701a/slstk3701a-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/gecko-pinctrl-s1.h>
+#include <zephyr/dt-bindings/pinctrl/gecko-pinctrl-s1.h>
 
 &pinctrl {
 	i2c0_default: i2c0_default {

--- a/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/sparkfun_thing_plus_matter_mgm240p-pinctrl.dtsi
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/dt-bindings/input/input-event-codes.h>
-#include <dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h>
 
 &pinctrl {
 	eusart1_default: eusart1_default {

--- a/dts/arm/silabs/sim3u.dtsi
+++ b/dts/arm/silabs/sim3u.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/silabs/xg21/efr32mg21a020f1024im32.dtsi
+++ b/dts/arm/silabs/xg21/efr32mg21a020f1024im32.dtsi
@@ -8,17 +8,15 @@
 #include <silabs/xg21/efr32mg21.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(96)>;
-	};
-
 	soc {
 		compatible = "silabs,efr32mg21a020f1024im32", "silabs,efr32mg21", "silabs,efr32", "simple-bus";
-
-		flash-controller@50030000 {
-			flash0: flash@0 {
-				reg = <0 DT_SIZE_K(1024)>;
-			};
-		};
 	};
+};
+
+&flash0 {
+	reg = <0 DT_SIZE_K(1024)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(96)>;
 };

--- a/dts/arm/silabs/xg21/xg21.dtsi
+++ b/dts/arm/silabs/xg21/xg21.dtsi
@@ -6,10 +6,10 @@
  */
 
 #include <arm/armv8-m.dtsi>
+#include <zephyr/dt-bindings/clock/silabs/xg21-clock.h>
+#include <zephyr/dt-bindings/dma/silabs/xg21-dma.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <dt-bindings/clock/silabs/xg21-clock.h>
-#include <dt-bindings/dma/silabs/xg21-dma.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/silabs/xg22-clock.h>
-#include <dt-bindings/dma/silabs/xg22-dma.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/silabs/xg22-clock.h>
+#include <zephyr/dt-bindings/dma/silabs/xg22-dma.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/silabs/xg23/efr32zg23b020f512im48.dtsi
+++ b/dts/arm/silabs/xg23/efr32zg23b020f512im48.dtsi
@@ -8,10 +8,6 @@
 #include <silabs/xg23/efr32zg23.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(64)>;
-	};
-
 	soc {
 		compatible = "silabs,efr32zg23b020f512im48", "silabs,efr32zg23", "silabs,xg23",
 			     "silabs,efr32", "simple-bus";
@@ -20,4 +16,8 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(512)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(64)>;
 };

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -5,11 +5,11 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/adc/adc.h>
-#include <dt-bindings/clock/silabs/xg23-clock.h>
-#include <dt-bindings/dma/silabs/xg23-dma.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/silabs/xg23-clock.h>
+#include <zephyr/dt-bindings/dma/silabs/xg23-dma.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/silabs/xg24/efr32mg24b020f1536im40.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b020f1536im40.dtsi
@@ -8,10 +8,6 @@
 #include <silabs/xg24/efr32mg24.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
-
 	soc {
 		compatible = "silabs,efr32mg24b020f1536im40", "silabs,efr32mg24", "silabs,xg24",
 			     "silabs,efr32", "simple-bus";
@@ -20,4 +16,8 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b210f1536im48.dtsi
@@ -8,10 +8,6 @@
 #include <silabs/xg24/efr32mg24.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
-
 	soc {
 		compatible = "silabs,efr32mg24b210f1536im48", "silabs,efr32mg24", "silabs,xg24",
 			     "silabs,efr32", "simple-bus";
@@ -20,4 +16,8 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b220f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b220f1536im48.dtsi
@@ -8,10 +8,6 @@
 #include <silabs/xg24/efr32mg24.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
-
 	soc {
 		compatible = "silabs,efr32mg24b220f1536im48", "silabs,efr32mg24", "silabs,xg24",
 			     "silabs,efr32", "simple-bus";
@@ -20,4 +16,8 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
+++ b/dts/arm/silabs/xg24/efr32mg24b310f1536im48.dtsi
@@ -8,10 +8,6 @@
 #include <silabs/xg24/efr32mg24.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
-
 	soc {
 		compatible = "silabs,efr32mg24b310f1536im48", "silabs,efr32mg24", "silabs,xg24",
 			     "silabs,efr32", "simple-bus";
@@ -20,4 +16,8 @@
 
 &flash0 {
 	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240pb32vna.dtsi
@@ -9,10 +9,6 @@
 #include <silabs/xg24/efr32mg24.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
-
 	soc {
 		compatible = "silabs,mgm240pb32vna", "silabs,efr32mg24", "silabs,xg24",
 			     "silabs,efr32", "simple-bus";
@@ -25,4 +21,8 @@
 
 &radio {
 	pa-voltage-mv = <3300>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
+++ b/dts/arm/silabs/xg24/mgm240sd22vna.dtsi
@@ -9,10 +9,6 @@
 #include <silabs/xg24/efr32mg24.dtsi>
 
 / {
-	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(256)>;
-	};
-
 	soc {
 		compatible = "silabs,mgm240sd22vna", "silabs,efr32mg24", "silabs,xg24",
 			     "silabs,efr32", "simple-bus";
@@ -25,4 +21,8 @@
 
 &radio {
 	pa-voltage-mv = <1800>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
 };

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -5,11 +5,11 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/adc/adc.h>
-#include <dt-bindings/clock/silabs/xg24-clock.h>
-#include <dt-bindings/dma/silabs/xg24-dma.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/silabs/xg24-clock.h>
+#include <zephyr/dt-bindings/dma/silabs/xg24-dma.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -5,12 +5,11 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/silabs/xg27-clock.h>
-#include <dt-bindings/dma/silabs/xg27-dma.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pinctrl/gecko-pinctrl.h>
-#include <dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/silabs/xg27-clock.h>
+#include <zephyr/dt-bindings/dma/silabs/xg27-dma.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/silabs/xg29/xg29.dtsi
+++ b/dts/arm/silabs/xg29/xg29.dtsi
@@ -5,11 +5,11 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/adc/adc.h>
-#include <dt-bindings/clock/silabs/xg29-clock.h>
-#include <dt-bindings/dma/silabs/xg29-dma.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/silabs/xg29-clock.h>
+#include <zephyr/dt-bindings/dma/silabs/xg29-dma.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {

--- a/include/zephyr/dt-bindings/pinctrl/silabs/xg21-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/silabs/xg21-pinctrl.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG21_PINCTRL_H_
 #define ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG21_PINCTRL_H_
 
-#include <dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
+#include <zephyr/dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
 
 #define SILABS_DBUS_ACMP0_ACMPOUT(port, pin) SILABS_DBUS(port, pin, 4, 1, 0, 1)
 

--- a/include/zephyr/dt-bindings/pinctrl/silabs/xg22-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/silabs/xg22-pinctrl.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG22_PINCTRL_H_
 #define ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG22_PINCTRL_H_
 
-#include <dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
+#include <zephyr/dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
 
 #define SILABS_DBUS_CMU_CLKOUT0(port, pin) SILABS_DBUS(port, pin, 4, 1, 0, 2)
 #define SILABS_DBUS_CMU_CLKOUT1(port, pin) SILABS_DBUS(port, pin, 4, 1, 1, 3)

--- a/include/zephyr/dt-bindings/pinctrl/silabs/xg23-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/silabs/xg23-pinctrl.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG23_PINCTRL_H_
 #define ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG23_PINCTRL_H_
 
-#include <dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
+#include <zephyr/dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
 
 #define SILABS_DBUS_ACMP0_ACMPOUT(port, pin) SILABS_DBUS(port, pin, 16, 1, 0, 1)
 

--- a/include/zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/silabs/xg24-pinctrl.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG24_PINCTRL_H_
 #define ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG24_PINCTRL_H_
 
-#include <dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
+#include <zephyr/dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
 
 #define SILABS_DBUS_ACMP0_ACMPOUT(port, pin) SILABS_DBUS(port, pin, 4, 1, 0, 1)
 

--- a/include/zephyr/dt-bindings/pinctrl/silabs/xg27-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/silabs/xg27-pinctrl.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG27_PINCTRL_H_
 #define ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG27_PINCTRL_H_
 
-#include <dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
+#include <zephyr/dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
 
 #define SILABS_DBUS_ACMP0_ACMPOUT(port, pin) SILABS_DBUS(port, pin, 4, 1, 0, 1)
 

--- a/include/zephyr/dt-bindings/pinctrl/silabs/xg29-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/silabs/xg29-pinctrl.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG29_PINCTRL_H_
 #define ZEPHYR_DT_BINDINGS_PINCTRL_SILABS_XG29_PINCTRL_H_
 
-#include <dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
+#include <zephyr/dt-bindings/pinctrl/silabs-pinctrl-dbus.h>
 
 #define SILABS_DBUS_ACMP0_ACMPOUT(port, pin) SILABS_DBUS(port, pin, 4, 1, 0, 1)
 


### PR DESCRIPTION
Formatted Silabs DTS files:
* Made the definition of sram in the dtsi consistant across the socs.
* Migrated includes to <zephyr/...> (https://github.com/zephyrproject-rtos/hal_silabs/pull/124 was opened to update the gen_pinctrl.py script)