### PR TITLE
driver: bbram: npcx: update bbram status register bit offset for npck3

### DIFF
--- a/drivers/bbram/Kconfig.npcx
+++ b/drivers/bbram/Kconfig.npcx
@@ -24,3 +24,11 @@ config BBRAM_NPCX_STATUS_REG_WRITE_WORKAROUND
 	  A write operation to the BKUP_STS register might disable write to all
 	  the Battery-Backed RAM. The workaround is to read the BKUP_STS
 	  register after every write to this register.
+
+config BBRAM_NPCX_EX
+	bool "Extended NPCX BBRAM driver support"
+	default y
+	depends on $(dt_compat_any_has_prop,$(DT_COMPAT_NUVOTON_NPCX_BBRAM),support-npckn-v1,True)
+	help
+	  This option enables extended BBRAM support for NPCKn variant of
+	  processors.

--- a/dts/arm/nuvoton/npck/npck.dtsi
+++ b/dts/arm/nuvoton/npck/npck.dtsi
@@ -74,6 +74,7 @@
 			reg = <0x400af000 0x100
 			       0x400af100 0x1>;
 			reg-names = "memory", "status";
+			support-npckn-v1;
 		};
 
 		pcc: clock-controller@4000d000 {

--- a/dts/bindings/memory-controllers/nuvoton,npcx-bbram.yaml
+++ b/dts/bindings/memory-controllers/nuvoton,npcx-bbram.yaml
@@ -10,3 +10,7 @@ include: base.yaml
 properties:
   reg:
     required: true
+  support-npckn-v1:
+    type: boolean
+    description: |
+        This option enables the bbram driver for NPCKn.

--- a/soc/nuvoton/npcx/common/npckn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npckn/include/reg_def.h
@@ -1955,4 +1955,8 @@ struct gdma_reg {
 #define NPCX_DMACTL_GDMAERR              20
 #define NPCX_DMACTL_BUSY_EN              23
 
+/* BBRM register fields */
+#define NPCX_BKUPSTS_VCC1_STS BIT(5)
+#define NPCX_BKUPSTS_IBBR     BIT(7)
+
 #endif /* _NUVOTON_NPCX_REG_DEF_H */

--- a/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
+++ b/soc/nuvoton/npcx/common/npcxn/include/reg_def.h
@@ -2186,4 +2186,9 @@ struct mdma_reg {
 /* Channel 0/1 Current Transfer Count Register (MDMA_CTCNT0/MDMA_CTCNT1) */
 #define NPCX_MDMA_CTCNT_CURRENT_TFR_CNT FIELD(0, 13)
 
+/* BBRM register fields */
+#define NPCX_BKUPSTS_VCC1_STS BIT(0)
+#define NPCX_BKUPSTS_VSBY_STS BIT(1)
+#define NPCX_BKUPSTS_IBBR     BIT(7)
+
 #endif /* _NUVOTON_NPCX_REG_DEF_H */


### PR DESCRIPTION
Update the bit offset of bit VCC_STS in the BKUP_STS register for npck3.