### PR TITLE
cmake: mcuboot: SHA512/pure image signing

### DIFF
--- a/cmake/mcuboot.cmake
+++ b/cmake/mcuboot.cmake
@@ -153,6 +153,13 @@ function(zephyr_mcuboot_tasks)
     set(imgtool_args --align ${write_block_size} ${imgtool_args})
   endif()
 
+  # Set proper hash calculation algorithm for signing
+  if(CONFIG_MCUBOOT_BOOTLOADER_SIGNATURE_TYPE_PURE)
+    set(imgtool_args --pure ${imgtool_args})
+  elseif(CONFIG_MCUBOOT_BOOTLOADER_USES_SHA512)
+    set(imgtool_args --sha 512 ${imgtool_args})
+  endif()
+
   # Extensionless prefix of any output file.
   set(output ${ZEPHYR_BINARY_DIR}/${KERNEL_NAME})
 

--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -289,6 +289,18 @@ config MCUBOOT_BOOTLOADER_NO_DOWNGRADE
 	  MCUBOOT_DOWNGRADE_PREVENTION option enabled.
 endif
 
+config MCUBOOT_BOOTLOADER_USES_SHA512
+	bool "MCUboot uses SHA512 for image hash"
+	help
+	  MCUboot has been compiled to verify images using SHA512.
+
+config MCUBOOT_BOOTLOADER_SIGNATURE_TYPE_PURE
+	bool "Signature is verified over an image rather than sha of an image"
+	help
+	  MCUboot has been compiled to verify images using pure signature
+	  verification, i.e., the signature is verified over the image rather
+	  than the SHA of the image.
+
 config MCUBOOT_APPLICATION_FIRMWARE_UPDATER
 	bool "Application is firmware updater image"
 	depends on MCUBOOT_BOOTLOADER_MODE_FIRMWARE_UPDATER


### PR DESCRIPTION
Update signing script to use proper arguments for imgtool when SHA512 or pure signature is needed.