### PR TITLE
ethernet: eth_sam_gmac: enable multiple TX pkt support for max throughput

### DIFF
--- a/drivers/ethernet/eth_sam_gmac_priv.h
+++ b/drivers/ethernet/eth_sam_gmac_priv.h
@@ -16,12 +16,8 @@
 #define ATMEL_OUI_B1 0x04
 #define ATMEL_OUI_B2 0x25
 
-/* This option enables support to push multiple packets to the DMA engine.
- * This currently doesn't work given the current version of net_pkt or
- * net_buf does not allowed access from multiple threads. This option is
- * therefore currently disabled.
- */
-#define GMAC_MULTIPLE_TX_PACKETS 0
+/* This option enables support to push multiple packets to the DMA engine. */
+#define GMAC_MULTIPLE_TX_PACKETS 1
 
 #define GMAC_MTU NET_ETH_MTU
 #define GMAC_FRAME_SIZE_MAX (GMAC_MTU + 18)


### PR DESCRIPTION
Summary
-------
This PR enables support for pushing multiple TX packets to the DMA engine
in the SAM GMAC Ethernet driver by setting GMAC_MULTIPLE_TX_PACKETS to 1
in eth_sam_gmac_priv.h.

Background
----------
Testing on SAME54 Curiosity Ultra with EVB-LAN8670-RMII and KSZ8061 PHY
daughter card at 10Mbps previously showed a TX performance drop, achieving
only 9.1Mbps instead of the expected 9.5Mbps. The root cause was the lack
of thread-safe handling in net_pkt and net_buf in Zephyr versions before
v2.6.0, which prevented reliable multiple TX enqueuing.

Issue #32564 (“net_buf reference count not protected”) was fixed in Zephyr
v2.6.0, making net_pkt and net_buf reference handling thread-safe and
suitable for multi-threaded use.

Change Details
--------------
With the fix for #32564 in place, it is now safe to enable
GMAC_MULTIPLE_TX_PACKETS, allowing the driver to push multiple packets to
the DMA engine and improve TX throughput.

Testing
-------
The change has been tested on SAME54 Curiosity Ultra with
EVB-LAN8670-RMII and KSZ8061 PHY daughter card. The expected performance
of 9.5Mbps at 10Mbps PHY link speed was observed.