### PR TITLE
soc: nordic: nrf54h: Add DT_NODE_EXISTS check

### DIFF
--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -196,7 +196,7 @@ void soc_late_init_hook(void)
 				 DT_REG_ADDR(DT_NODELABEL(cpurad_slot0_partition)) +
 				 CONFIG_ROM_START_OFFSET);
 	}
-#else
+#elif DT_NODE_EXISTS(DT_NODELABEL(cpurad_slot0_partition))
 	radiocore_address =
 		(void *)(DT_REG_ADDR(DT_GPARENT(DT_NODELABEL(cpurad_slot0_partition))) +
 			 DT_REG_ADDR(DT_NODELABEL(cpurad_slot0_partition)) +


### PR DESCRIPTION
Add `DT_NODE_EXISTS` check to ensure cpurad partition nodes exist before referencing their addresses.
This prevents build errors when these partitions are not defined in the devicetree.