### PR TITLE
Optional context memeory section section for suspend to RAM CPU context.

### DIFF
--- a/arch/arm/core/cortex_m/pm_s2ram.c
+++ b/arch/arm/core/cortex_m/pm_s2ram.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Carlo Caione <ccaione@baylibre.com>
+ * Copyright (c) 2025 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +15,18 @@
 /**
  * CPU context for S2RAM
  */
-__noinit _cpu_context_t _cpu_context;
+
+#if DT_NODE_EXISTS(DT_NODELABEL(pm_s2ram)) &&\
+	DT_NODE_HAS_COMPAT(DT_NODELABEL(pm_s2ram), zephyr_memory_region)
+
+/* Linker section name is given by `zephyr,memory-region` property of
+ * `zephyr,memory-region` compatible DT node with nodelabel `pm_s2ram`.
+ */
+__attribute__((section(DT_PROP(DT_NODELABEL(pm_s2ram), zephyr_memory_region))))
+#else
+__noinit
+#endif
+_cpu_context_t _cpu_context;
 
 #ifndef CONFIG_PM_S2RAM_CUSTOM_MARKING
 /**

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -327,3 +327,20 @@ zephyr_udc0: &usbhs {
 	memory-regions = <&cpuapp_dma_region>;
 	status = "okay";
 };
+
+/* Trim this RAM block for making room on all run-time common S2RAM cpu context. */
+&cpuapp_ram0 {
+	reg = <0x22000000 (DT_SIZE_K(32)-32)>;
+	ranges = <0x0 0x22000000 (0x8000-0x20)>;
+};
+
+/ {
+	soc {
+		/* run-time common S2RAM cpu context RAM */
+		pm_s2ram: cpuapp_s2ram@22007fe0  {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x22007fe0 32>;
+			zephyr,memory-region = "pm_s2ram_context";
+		};
+	};
+};

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -38,6 +38,9 @@ config PM_S2RAM
 	depends on ARCH_HAS_SUSPEND_TO_RAM
 	help
 	  This option enables suspend-to-RAM (S2RAM).
+	  When enabled on Cortex-M, and a 'zephyr,memory-region' compatible node with nodelabel
+	  'pm_s2ram' is defined in DT, _cpu_context symbol (located in arch/arm/core/cortex_m/pm_s2ram.c)
+	  is placed in linker section given by 'zephyr,memory-region' property of aforementioned node.
 
 config PM_S2RAM_CUSTOM_MARKING
 	bool "Use custom marking functions"


### PR DESCRIPTION
More complex suspend and resume scheme might require exactly defined
location of this variable due to platform peculiar SW and HW requirement.

DTS zephyr,memory-region node with nodelabel `pm_s2ram` shall be used to
automatic definition of linker section for such objective.

Described such section for nRF54h20dk/nrf54h20/cpuapp target..
