### PR TITLE
boards: fix typo in stm32f303Xe i2c device tree definition

### DIFF
--- a/dts/arm/st/f3/stm32f303Xe.dtsi
+++ b/dts/arm/st/f3/stm32f303Xe.dtsi
@@ -121,7 +121,7 @@
 			};
 		};
 
-		i2c3: i2c@4007800 {
+		i2c3: i2c@40007800 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;


### PR DESCRIPTION
i2c3 address is incorrect and raises a warning