### PR TITLE
sys: cbprintf: logging: fix equivalent branches in argify macro

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -86,7 +86,7 @@ extern "C" {
  * opaque struct pointers. Alternative is to add + 0 but that requires suppressing
  * compiler warning about pointer arithmetic and does not cover opaque structs.
  */
-#define Z_ARGIFY(arg) ((0) ? (arg) : (arg))
+#define Z_ARGIFY(arg) ((0) ? 0 : (arg))
 
 /** @brief Return 1 if argument is a pointer to char or wchar_t
  *


### PR DESCRIPTION
The `((0) ? (arg) : (arg))` compiler trick introduced in https://github.com/zephyrproject-rtos/zephyr/pull/87461 leads to a codechecker violation: "conditional operator with identical true and false expressions"

I don't fully understand the purpose of this trick. Replacing it by `((0) ? (0) : (arg))` is just what works for me.
Please let me know if there is a better way.

Fix issue https://github.com/zephyrproject-rtos/zephyr/issues/93824
