### PR TITLE
Bluetooth: Classic: SDP: Doc comment and explicit size

### DIFF
--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -340,7 +340,7 @@ struct bt_sdp_record {
  *  Helper macro to initialize a 128-bit UUID array value from the readable form
  *  of UUIDs.
  *
- *  Example of how to declare the UUID `00001101-0000-1000-8000-00805F9B34FB`
+ *  Example of how to declare the UUID `6E400001-B5A3-F393-E0A9-E50E24DCCA9E`
  *
  *  @code
  *  BT_SDP_ARRAY_UUID_128(0x6E400001, 0xB5A3, 0xF393, 0xE0A9, 0xE50E24DCCA9E)

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1523,19 +1523,19 @@ static int sdp_client_ss_search(struct bt_sdp_client *session,
 	switch (param->uuid->type) {
 	case BT_UUID_TYPE_16:
 		/* Seq length */
-		net_buf_add_u8(buf, 0x03);
+		net_buf_add_u8(buf, sizeof(uint8_t) + BT_UUID_SIZE_16);
 		/* Seq type */
 		net_buf_add_u8(buf, BT_SDP_UUID16);
 		/* Seq value */
 		net_buf_add_be16(buf, BT_UUID_16(param->uuid)->val);
 		break;
 	case BT_UUID_TYPE_32:
-		net_buf_add_u8(buf, 0x05);
+		net_buf_add_u8(buf, sizeof(uint8_t) + BT_UUID_SIZE_32);
 		net_buf_add_u8(buf, BT_SDP_UUID32);
 		net_buf_add_be32(buf, BT_UUID_32(param->uuid)->val);
 		break;
 	case BT_UUID_TYPE_128:
-		net_buf_add_u8(buf, 0x11);
+		net_buf_add_u8(buf, sizeof(uint8_t) + BT_UUID_SIZE_128);
 		net_buf_add_u8(buf, BT_SDP_UUID128);
 		sys_memcpy_swap(uuid128, BT_UUID_128(param->uuid)->val, sizeof(uuid128));
 		net_buf_add_mem(buf, uuid128, sizeof(uuid128));
@@ -1630,19 +1630,19 @@ static int sdp_client_ssa_search(struct bt_sdp_client *session,
 	switch (param->uuid->type) {
 	case BT_UUID_TYPE_16:
 		/* Seq length */
-		net_buf_add_u8(buf, 0x03);
+		net_buf_add_u8(buf, sizeof(uint8_t) + BT_UUID_SIZE_16);
 		/* Seq type */
 		net_buf_add_u8(buf, BT_SDP_UUID16);
 		/* Seq value */
 		net_buf_add_be16(buf, BT_UUID_16(param->uuid)->val);
 		break;
 	case BT_UUID_TYPE_32:
-		net_buf_add_u8(buf, 0x05);
+		net_buf_add_u8(buf, sizeof(uint8_t) + BT_UUID_SIZE_32);
 		net_buf_add_u8(buf, BT_SDP_UUID32);
 		net_buf_add_be32(buf, BT_UUID_32(param->uuid)->val);
 		break;
 	case BT_UUID_TYPE_128:
-		net_buf_add_u8(buf, 0x11);
+		net_buf_add_u8(buf, sizeof(uint8_t) + BT_UUID_SIZE_128);
 		net_buf_add_u8(buf, BT_SDP_UUID128);
 		sys_memcpy_swap(uuid128, BT_UUID_128(param->uuid)->val, sizeof(uuid128));
 		net_buf_add_mem(buf, uuid128, sizeof(uuid128));
@@ -2494,23 +2494,23 @@ static inline ssize_t sdp_get_uuid_len(const uint8_t *data, size_t len)
 
 	switch (data[0]) {
 	case BT_SDP_UUID16:
-		if (len < 3) {
+		if (len < (sizeof(uint8_t) + BT_UUID_SIZE_16)) {
 			break;
 		}
 
-		return 3;
+		return sizeof(uint8_t) + BT_UUID_SIZE_16;
 	case BT_SDP_UUID32:
-		if (len < 5) {
+		if (len < (sizeof(uint8_t) + BT_UUID_SIZE_32)) {
 			break;
 		}
 
-		return 5;
+		return sizeof(uint8_t) + BT_UUID_SIZE_32;
 	case BT_SDP_UUID128:
-		if (len < (BT_UUID_SIZE_128 + sizeof(uint8_t))) {
+		if (len < (sizeof(uint8_t) + BT_UUID_SIZE_128)) {
 			break;
 		}
 
-		return BT_UUID_SIZE_128 + sizeof(uint8_t);
+		return sizeof(uint8_t) + BT_UUID_SIZE_128;
 	default:
 		LOG_ERR("Invalid/unhandled DTD 0x%02x", data[0]);
 		return -EINVAL;


### PR DESCRIPTION
Two small changes to Bluetooth: Classic: SDP

* Adjust doc comment, such that code example and comment UUID match
* Use explicit size calculations