### PR TITLE
Allow getaddrinfo to resolve localhost or local hostname

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1827,6 +1827,65 @@ try_resolve:
 	ARG_UNUSED(use_cache);
 #endif /* CONFIG_DNS_RESOLVER_CACHE */
 
+	if (IS_ENABLED(CONFIG_NET_HOSTNAME_ENABLE)) {
+		const char *hostname = net_hostname_get();
+		struct dns_addrinfo info = { 0 };
+
+		/* If the hostname is the same as the query, then
+		 * return a local address.
+		 */
+		if (strcmp(hostname, query) == 0) {
+
+			if (type == DNS_QUERY_TYPE_A) {
+				if (!IS_ENABLED(CONFIG_NET_IPV4)) {
+					return -EAFNOSUPPORT;
+				}
+
+				struct in_addr addr4 = INADDR_LOOPBACK_INIT;
+				const struct in_addr *paddr;
+
+				paddr = net_if_ipv4_select_src_addr(NULL, &addr4);
+				if (paddr == NULL) {
+					return -ENOENT;
+				}
+
+				memcpy(&net_sin(&info.ai_addr)->sin_addr, paddr,
+				       sizeof(struct in_addr));
+
+				info.ai_family = AF_INET;
+				info.ai_addr.sa_family = AF_INET;
+				info.ai_addrlen = sizeof(struct sockaddr_in);
+
+			} else if (type == DNS_QUERY_TYPE_AAAA) {
+				if (!IS_ENABLED(CONFIG_NET_IPV6)) {
+					return -EAFNOSUPPORT;
+				}
+
+				struct in6_addr addr6 = IN6ADDR_LOOPBACK_INIT;
+				const struct in6_addr *paddr;
+
+				paddr = net_if_ipv6_select_src_addr(NULL, &addr6);
+				if (paddr == NULL) {
+					return -ENOENT;
+				}
+
+				memcpy(&net_sin6(&info.ai_addr)->sin6_addr, paddr,
+				       sizeof(struct in6_addr));
+
+				info.ai_family = AF_INET6;
+				info.ai_addr.sa_family = AF_INET6;
+				info.ai_addrlen = sizeof(struct sockaddr_in6);
+			} else {
+				return -EINVAL;
+			}
+
+			cb(DNS_EAI_INPROGRESS, &info, user_data);
+			cb(DNS_EAI_ALLDONE, NULL, user_data);
+
+			return 0;
+		}
+	}
+
 	k_mutex_lock(&ctx->lock, K_FOREVER);
 
 	if (ctx->state != DNS_RESOLVE_CONTEXT_ACTIVE) {

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -42,7 +42,7 @@ config NET_SOCKETS_CONNECT_TIMEOUT
 config NET_SOCKETS_DNS_TIMEOUT
 	int "Timeout value in milliseconds for DNS queries"
 	default 2000
-	range 1000 300000
+	range 1000 300000 if !NET_TEST
 	depends on DNS_RESOLVER
 	help
 	  This variable specifies time in milliseconds after which DNS

--- a/tests/net/lib/dns_resolve/testcase.yaml
+++ b/tests/net/lib/dns_resolve/testcase.yaml
@@ -21,3 +21,10 @@ tests:
       - CONFIG_MDNS_RESPONDER=n
       - CONFIG_NET_IPV6_MLD=y
       - CONFIG_NET_IPV4_IGMP=y
+  net.dns.resolve.hostname:
+    extra_configs:
+      - CONFIG_NET_HOSTNAME_ENABLE=y
+      - CONFIG_NET_HOSTNAME="test-zephyr"
+      - CONFIG_NET_IPV6=y
+      - CONFIG_NET_IPV4=y
+      - CONFIG_NET_SOCKETS_DNS_TIMEOUT=5


### PR DESCRIPTION
Allow user to query localhost name and get a localhost address 127.0.0.1 or ::1 back. This is only enabled if loopback driver is used as the use case does not make much sense otherwise.
    
Make sure that if user has enabled hostname support, we are able to query it and get a local IP address back.

Fixes #93822

