### PR TITLE
wifi: nrf70: Extend bustest to QSPI

### DIFF
--- a/include/zephyr/drivers/wifi/nrf_wifi/bus/qspi_if.h
+++ b/include/zephyr/drivers/wifi/nrf_wifi/bus/qspi_if.h
@@ -98,6 +98,26 @@ int qspi_RDSR1(const struct device *dev, uint8_t *rdsr1);
 int qspi_RDSR2(const struct device *dev, uint8_t *rdsr2);
 int qspi_WRSR2(const struct device *dev, const uint8_t wrsr2);
 
+/**
+ * @brief Read a register via QSPI
+ *
+ * @param dev QSPI device
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Pointer to store the read value
+ * @return int 0 on success, negative error code on failure
+ */
+int qspi_read_reg(const struct device *dev, uint8_t reg_addr, uint8_t *reg_value);
+
+/**
+ * @brief Write a register via QSPI
+ *
+ * @param dev QSPI device
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Value to write
+ * @return int 0 on success, negative error code on failure
+ */
+int qspi_write_reg(const struct device *dev, uint8_t reg_addr, uint8_t reg_value);
+
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 int func_rpu_sleep(void);
 int func_rpu_wake(void);

--- a/include/zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h
+++ b/include/zephyr/drivers/wifi/nrf_wifi/bus/rpu_hw_if.h
@@ -54,6 +54,24 @@ int rpu_rdsr2(void);
 int rpu_rdsr1(void);
 int rpu_clks_on(void);
 
+/**
+ * @brief Read a register via RPU hardware interface
+ *
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Pointer to store the read value
+ * @return int 0 on success, negative error code on failure
+ */
+int rpu_read_reg(uint8_t reg_addr, uint8_t *reg_value);
+
+/**
+ * @brief Write a register via RPU hardware interface
+ *
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Value to write
+ * @return int 0 on success, negative error code on failure
+ */
+int rpu_write_reg(uint8_t reg_addr, uint8_t reg_value);
+
 int rpu_init(void);
 int rpu_enable(void);
 int rpu_disable(void);

--- a/modules/nrf_wifi/bus/rpu_hw_if.c
+++ b/modules/nrf_wifi/bus/rpu_hw_if.c
@@ -395,6 +395,37 @@ int rpu_rdsr1(void)
 #endif
 }
 
+/**
+ * @brief Read a register via RPU hardware interface
+ *
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Pointer to store the read value
+ * @return int 0 on success, negative error code on failure
+ */
+int rpu_read_reg(uint8_t reg_addr, uint8_t *reg_value)
+{
+#if CONFIG_NRF70_ON_QSPI
+	return qspi_read_reg(&qspi_perip, reg_addr, reg_value);
+#else
+	return spim_read_reg_wrapper(NULL, reg_addr, reg_value);
+#endif
+}
+
+/**
+ * @brief Write a register via RPU hardware interface
+ *
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Value to write
+ * @return int 0 on success, negative error code on failure
+ */
+int rpu_write_reg(uint8_t reg_addr, uint8_t reg_value)
+{
+#if CONFIG_NRF70_ON_QSPI
+	return qspi_write_reg(&qspi_perip, reg_addr, reg_value);
+#else
+	return spim_write_reg_wrapper(NULL, reg_addr, reg_value);
+#endif
+}
 
 int rpu_clks_on(void)
 {

--- a/modules/nrf_wifi/bus/spi_if.c
+++ b/modules/nrf_wifi/bus/spi_if.c
@@ -156,6 +156,34 @@ int spim_WRSR2(const struct device *dev, const uint8_t wrsr2)
 	return spim_write_reg(&spi_spec, 0x3F, wrsr2);
 }
 
+/**
+ * @brief Read a register via SPI (wrapper for compatibility)
+ *
+ * @param dev SPI device (unused, kept for compatibility)
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Pointer to store the read value
+ * @return int 0 on success, negative error code on failure
+ */
+int spim_read_reg_wrapper(const struct device *dev, uint8_t reg_addr, uint8_t *reg_value)
+{
+	ARG_UNUSED(dev);
+	return spim_read_reg(reg_addr, reg_value);
+}
+
+/**
+ * @brief Write a register via SPI (wrapper for compatibility)
+ *
+ * @param dev SPI device (unused, kept for compatibility)
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Value to write
+ * @return int 0 on success, negative error code on failure
+ */
+int spim_write_reg_wrapper(const struct device *dev, uint8_t reg_addr, uint8_t reg_value)
+{
+	ARG_UNUSED(dev);
+	return spim_write_reg(&spi_spec, reg_addr, reg_value);
+}
+
 int _spim_wait_while_rpu_awake(void)
 {
 	int ret;

--- a/modules/nrf_wifi/bus/spi_if.h
+++ b/modules/nrf_wifi/bus/spi_if.h
@@ -9,6 +9,8 @@
  * Zephyr OS layer of the Wi-Fi driver.
  */
 
+#include <zephyr/drivers/spi.h>
+
 /* SPIM driver config */
 
 int spim_init(struct qspi_config *config);
@@ -34,3 +36,42 @@ int spim_RDSR1(const struct device *dev, uint8_t *rdsr1);
 int spim_RDSR2(const struct device *dev, uint8_t *rdsr2);
 
 int spim_WRSR2(const struct device *dev, const uint8_t wrsr2);
+
+/**
+ * @brief Read a register via SPI
+ *
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Pointer to store the read value
+ * @return int 0 on success, negative error code on failure
+ */
+int spim_read_reg(uint32_t reg_addr, uint8_t *reg_value);
+
+/**
+ * @brief Write a register via SPI
+ *
+ * @param spi_spec SPI device specification
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Value to write
+ * @return int 0 on success, negative error code on failure
+ */
+int spim_write_reg(const struct spi_dt_spec *spi_spec, uint32_t reg_addr, const uint8_t reg_value);
+
+/**
+ * @brief Read a register via SPI (wrapper for compatibility)
+ *
+ * @param dev SPI device (unused, kept for compatibility)
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Pointer to store the read value
+ * @return int 0 on success, negative error code on failure
+ */
+int spim_read_reg_wrapper(const struct device *dev, uint8_t reg_addr, uint8_t *reg_value);
+
+/**
+ * @brief Write a register via SPI (wrapper for compatibility)
+ *
+ * @param dev SPI device (unused, kept for compatibility)
+ * @param reg_addr Register address (opcode)
+ * @param reg_value Value to write
+ * @return int 0 on success, negative error code on failure
+ */
+int spim_write_reg_wrapper(const struct device *dev, uint8_t reg_addr, uint8_t reg_value);

--- a/tests/boards/nrf/nrf70/bustest/src/main.c
+++ b/tests/boards/nrf/nrf70/bustest/src/main.c
@@ -180,6 +180,158 @@ static int test_peripbus(void)
 	return 0;
 }
 
+/* Register address macros for testing */
+#define RDSR0_ADDR    0x05
+#define RDSR1_ADDR    0x1F
+#define RDSR2_ADDR    0x2F
+#define WRSR2_ADDR    0x3F
+
+static int test_rdsr0(void)
+{
+	int ret;
+	uint8_t val;
+
+	LOG_INF("Testing RDSR0");
+
+	ret = rpu_read_reg(RDSR0_ADDR, &val);
+	if (ret) {
+		LOG_ERR("Failed to read RDSR0: %d", ret);
+		return -1;
+	}
+
+	LOG_INF("RDSR0 value: 0x%x", val);
+
+	if (val == 0x42) {
+		return 0;
+	}
+	LOG_ERR("RDSR0 test failed: expected 0x42, got 0x%x", val);
+	return -1;
+}
+
+/* Helper function to write and verify a test pattern */
+static int test_rdsr2_pattern(uint8_t test_pattern, const char *pattern_name)
+{
+	int ret;
+	uint8_t read_val;
+	uint8_t masked_pattern = test_pattern & 0xFE;  /* Ensure bit 0 is 0 */
+
+	LOG_INF("Testing RDSR2 pattern %s (0x%02x)", pattern_name, masked_pattern);
+
+	ret = rpu_write_reg(WRSR2_ADDR, masked_pattern);
+	if (ret) {
+		LOG_ERR("Failed to write RDSR2 pattern %s", pattern_name);
+		return -1;
+	}
+
+	ret = rpu_read_reg(RDSR2_ADDR, &read_val);
+	if (ret) {
+		LOG_ERR("Failed to read RDSR2 after writing pattern %s", pattern_name);
+		return -1;
+	}
+
+	/* Compare only bits 7:1 */
+	if ((read_val & 0xFE) != masked_pattern) {
+		LOG_ERR("RDSR2 pattern %s test failed: wrote 0x%02x, read 0x%02x (bits 7:1)",
+				pattern_name, masked_pattern, read_val & 0xFE);
+		return -1;
+	}
+
+	LOG_INF("RDSR2 pattern %s test passed: wrote 0x%02x, read 0x%02x",
+			pattern_name, masked_pattern, read_val);
+	return 0;
+}
+
+/* Individual test for pattern 0xAA (10101010) */
+static int test_rdsr2_pattern_0xAA(void)
+{
+	return test_rdsr2_pattern(0xAA, "0xAA (10101010)");
+}
+
+/* Individual test for pattern 0x54 (01010100) */
+static int test_rdsr2_pattern_0x54(void)
+{
+	return test_rdsr2_pattern(0x54, "0x54 (01010100)");
+}
+
+/* Helper function to test walking bit patterns */
+static int test_rdsr2_walking_pattern(bool walking_ones, const char *test_name)
+{
+	int ret, i;
+	uint8_t read_val, test_val;
+
+	LOG_INF("Starting %s test for RDSR2 bits 7:1", test_name);
+
+	for (i = 1; i <= 7; i++) {
+		if (walking_ones) {
+			test_val = (1 << i);  /* Set walking bit */
+		} else {
+			test_val = (0xFE & ~(1 << i));  /* Clear walking bit */
+		}
+
+		ret = rpu_write_reg(WRSR2_ADDR, test_val & 0xFE);
+		/* Ensure bit 0 is 0 when writing */
+		if (ret) {
+			LOG_ERR("Failed to write RDSR2 %s bit %d", test_name, i);
+			return -1;
+		}
+
+		ret = rpu_read_reg(RDSR2_ADDR, &read_val);
+		if (ret) {
+			LOG_ERR("Failed to read RDSR2 after writing %s bit %d", test_name, i);
+			return -1;
+		}
+
+		/* Compare only bits 7:1 */
+		if ((read_val & 0xFE) != (test_val & 0xFE)) {
+			LOG_ERR("RDSR2 %s bit %d test failed: wrote 0x%02x, read 0x%02x (bits 7:1)",
+					test_name, i, test_val & 0xFE, read_val & 0xFE);
+			return -1;
+		}
+		LOG_DBG("RDSR2 %s bit %d passed: wrote 0x%02x, read 0x%02x",
+				test_name, i, test_val & 0xFE, read_val);
+	}
+
+	LOG_INF("%s test completed successfully", test_name);
+	return 0;
+}
+
+/* Individual test for walking '1' pattern */
+static int test_rdsr2_walking_ones(void)
+{
+	return test_rdsr2_walking_pattern(true, "walking '1'");
+}
+
+/* Individual test for walking '0' pattern */
+static int test_rdsr2_walking_zeros(void)
+{
+	return test_rdsr2_walking_pattern(false, "walking '0'");
+}
+
+/* Test for RDSR1 register */
+static int test_rdsr1(void)
+{
+	int ret;
+	uint8_t val;
+
+	LOG_INF("Testing RDSR1");
+
+	ret = rpu_read_reg(RDSR1_ADDR, &val);
+	if (ret) {
+		LOG_ERR("Failed to read RDSR1: %d", ret);
+		return -1;
+	}
+
+	LOG_INF("RDSR1 value: 0x%x", val);
+
+	/* RDSR1 should have RPU_AWAKE_BIT set when RPU is awake */
+	if (val & 0x02) {  /* RPU_AWAKE_BIT = BIT(1) */
+		LOG_INF("RDSR1 test passed: RPU is awake");
+		return 0;
+	}
+	LOG_ERR("RDSR1 test failed: RPU is not awake (0x%x)", val);
+	return -1;
+}
+
 ZTEST_SUITE(bustest_suite, NULL, (void *)wifi_on, NULL, NULL, wifi_off);
 
 ZTEST(bustest_suite, test_sysbus)
@@ -195,4 +347,34 @@ ZTEST(bustest_suite, test_peripbus)
 ZTEST(bustest_suite, test_dataram)
 {
 	zassert_equal(0, memtest(DATARAM_ADDR, "DATA RAM"), "DATA RAM memtest failed!!!");
+}
+
+ZTEST(bustest_suite, test_rdsr0)
+{
+	zassert_equal(0, test_rdsr0(), "RDSR0 test failed!!!");
+}
+
+ZTEST(bustest_suite, test_rdsr2_pattern_0xAA)
+{
+	zassert_equal(0, test_rdsr2_pattern_0xAA(), "RDSR2 pattern 0xAA test failed!!!");
+}
+
+ZTEST(bustest_suite, test_rdsr2_pattern_0x54)
+{
+	zassert_equal(0, test_rdsr2_pattern_0x54(), "RDSR2 pattern 0x54 test failed!!!");
+}
+
+ZTEST(bustest_suite, test_rdsr2_walking_ones)
+{
+	zassert_equal(0, test_rdsr2_walking_ones(), "RDSR2 walking '1' test failed!!!");
+}
+
+ZTEST(bustest_suite, test_rdsr2_walking_zeros)
+{
+	zassert_equal(0, test_rdsr2_walking_zeros(), "RDSR2 walking '0' test failed!!!");
+}
+
+ZTEST(bustest_suite, test_rdsr1)
+{
+	zassert_equal(0, test_rdsr1(), "RDSR1 test failed!!!");
 }


### PR DESCRIPTION
Add few QSPI command registers to the bustest, helpful in debugging QSPI vs nRF70 internal memory during HW bringup.