### PR TITLE
fuel_gauge: restructure cmake libraries

### DIFF
--- a/drivers/fuel_gauge/CMakeLists.txt
+++ b/drivers/fuel_gauge/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/fuel_gauge.h)
 
+zephyr_library()
+
 add_subdirectory_ifdef(CONFIG_SBS_GAUGE_NEW_API		sbs_gauge)
 add_subdirectory_ifdef(CONFIG_FUEL_GAUGE_COMPOSITE	composite)
 add_subdirectory_ifdef(CONFIG_MAX17048		max17048)

--- a/drivers/fuel_gauge/axp2101/CMakeLists.txt
+++ b/drivers/fuel_gauge/axp2101/CMakeLists.txt
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
 zephyr_library_sources(fuel_gauge_axp2101.c)

--- a/drivers/fuel_gauge/bq27z746/CMakeLists.txt
+++ b/drivers/fuel_gauge/bq27z746/CMakeLists.txt
@@ -1,5 +1,3 @@
-zephyr_library()
-
 zephyr_library_sources(bq27z746.c)
 
 zephyr_include_directories_ifdef(CONFIG_EMUL_BQ27Z746 .)

--- a/drivers/fuel_gauge/composite/CMakeLists.txt
+++ b/drivers/fuel_gauge/composite/CMakeLists.txt
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
 zephyr_library_sources(fuel_gauge_composite.c)

--- a/drivers/fuel_gauge/lc709203f/CMakeLists.txt
+++ b/drivers/fuel_gauge/lc709203f/CMakeLists.txt
@@ -1,5 +1,3 @@
-zephyr_library()
-
 zephyr_library_sources(lc709203f.c)
 
 zephyr_include_directories_ifdef(CONFIG_EMUL_LC709203F .)

--- a/drivers/fuel_gauge/max17048/CMakeLists.txt
+++ b/drivers/fuel_gauge/max17048/CMakeLists.txt
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources(max17048.c)
 
 zephyr_include_directories_ifdef(CONFIG_EMUL_MAX17048 .)

--- a/drivers/fuel_gauge/sbs_gauge/CMakeLists.txt
+++ b/drivers/fuel_gauge/sbs_gauge/CMakeLists.txt
@@ -1,5 +1,3 @@
-zephyr_library()
-
 zephyr_library_sources(sbs_gauge.c)
 
 zephyr_include_directories_ifdef(CONFIG_EMUL_SBS_GAUGE .)


### PR DESCRIPTION
Adjusted drivers to include sources into a single library inline with other drivers cmake structure