### PR TITLE
kernel: k_pipe: Fixed initializer order

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5345,11 +5345,11 @@ struct k_pipe {
  */
 #define Z_PIPE_INITIALIZER(obj, pipe_buffer, pipe_buffer_size)	\
 {								\
+	.waiting = 0,						\
 	.buf = RING_BUF_INIT(pipe_buffer, pipe_buffer_size),	\
 	.data = Z_WAIT_Q_INIT(&obj.data),			\
 	.space = Z_WAIT_Q_INIT(&obj.space),			\
 	.flags = PIPE_FLAG_OPEN,				\
-	.waiting = 0,						\
 	Z_POLL_EVENT_OBJ_INIT(obj)				\
 }
 /**


### PR DESCRIPTION
I got the Error `designator order for field 'k_pipe::waiting' does not match declaration order in 'k_pipe'`, if C++ is enabled.

Changed order of [Z_PIPE_INITIALIZER](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/kernel.h#L5346) to match with [k_pipe struct](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/kernel.h#L5328) fixed the error.