### PR TITLE
BMM350: Set streaming handle to NULL when done

### DIFF
--- a/drivers/sensor/bosch/bmm350/bmm350_stream.c
+++ b/drivers/sensor/bosch/bmm350/bmm350_stream.c
@@ -20,6 +20,19 @@ enum bmm350_stream_state {
 	BMM350_STREAM_BUSY = 2,
 };
 
+static void bmm350_stream_result(const struct device *dev, int err)
+{
+	struct bmm350_data *data = dev->data;
+	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
+
+	data->stream.iodev_sqe = NULL;
+	if (err < 0) {
+		rtio_iodev_sqe_err(iodev_sqe, err);
+	} else {
+		rtio_iodev_sqe_ok(iodev_sqe, 0);
+	}
+}
+
 static void bmm350_stream_event_complete(struct rtio *ctx, const struct rtio_sqe *sqe, void *arg0)
 {
 	struct rtio_iodev_sqe *iodev_sqe = (struct rtio_iodev_sqe *)arg0;
@@ -69,13 +82,7 @@ static void bmm350_stream_event_complete(struct rtio *ctx, const struct rtio_sqe
 
 bmm350_stream_evt_finish:
 	atomic_set(&data->stream.state, BMM350_STREAM_ON);
-
-	if (err < 0) {
-		rtio_iodev_sqe_err(iodev_sqe, err);
-	} else {
-		rtio_iodev_sqe_ok(iodev_sqe, 0);
-	}
-
+	bmm350_stream_result(dev, err);
 }
 
 static void bmm350_event_handler(const struct device *dev)
@@ -115,7 +122,7 @@ static void bmm350_event_handler(const struct device *dev)
 			      &buf, &buf_len);
 	CHECKIF(err != 0 || buf_len < sizeof(struct bmm350_encoded_data)) {
 		LOG_ERR("Failed to allocate BMM350 encoded buffer: %d", err);
-		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		bmm350_stream_result(dev, -ENOMEM);
 		return;
 	}
 
@@ -127,7 +134,7 @@ static void bmm350_event_handler(const struct device *dev)
 					 edata->payload.buf, sizeof(edata->payload.buf),
 					 &read_sqe);
 	CHECKIF(err < 0 || !read_sqe) {
-		rtio_iodev_sqe_err(iodev_sqe, err);
+		bmm350_stream_result(dev, err);
 		return;
 	}
 	read_sqe->flags |= RTIO_SQE_CHAINED;
@@ -169,14 +176,14 @@ void bmm350_stream_submit(const struct device *dev,
 		/* Set PMU command configuration */
 		err = bmm350_prep_reg_write_async(dev, BMM350_REG_INT_CTRL, cfg->int_flags, NULL);
 		if (err < 0) {
-			rtio_iodev_sqe_err(iodev_sqe, err);
+			bmm350_stream_result(dev, err);
 			return;
 		}
 		rtio_submit(cfg->bus.rtio.ctx, 0);
 
 		err = gpio_pin_interrupt_configure_dt(&cfg->drdy_int, GPIO_INT_EDGE_TO_ACTIVE);
 		if (err < 0) {
-			rtio_iodev_sqe_err(iodev_sqe, err);
+			bmm350_stream_result(dev, err);
 			return;
 		}
 	}


### PR DESCRIPTION
To follow with error-handling of multi-shot items, they won't be marked as cancelled. Instead, we expect them to stop being submitted, hence we should dispose the handle upon finishing every shot.

> [!NOTE]
> Depends on #93543. Marking as DNM until it lands.