### PR TITLE
[Backport v3.7-branch] drivers: console: posix_arch_console: remove build warning

### DIFF
--- a/drivers/console/posix_arch_console.c
+++ b/drivers/console/posix_arch_console.c
@@ -12,6 +12,7 @@
 static char stdout_buff[_STDOUT_BUF_SIZE];
 static int n_pend; /* Number of pending characters in buffer */
 
+#if defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE)
 static int print_char(int c)
 {
 	int printnow = 0;
@@ -34,6 +35,7 @@ static int print_char(int c)
 	}
 	return c;
 }
+#endif /* defined(CONFIG_PRINTK) || defined(CONFIG_STDOUT_CONSOLE) */
 
 /**
  * Ensure that whatever was written thru printk is displayed now


### PR DESCRIPTION
Backport 3eedebe03139343104dd5b015159717a67215f42 from #93791.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/93790