### PR TITLE
snippets: add snippet for enabling SocketCAN support on native_sim

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1251,6 +1251,7 @@ Documentation Infrastructure:
     - samples/net/sockets/can/
     - samples/subsys/canbus/
     - scripts/west_commands/runners/canopen_program.py
+    - snippets/socketcan-native-sim/
     - subsys/canbus/
     - subsys/net/l2/canbus/
     - tests/drivers/build_all/can/

--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -504,9 +504,12 @@ The following peripherals are currently provided with this board:
   enabled with :kconfig:option:`CONFIG_CAN_NATIVE_LINUX` and configured with the device tree binding
   :dtcompatible:`zephyr,native-linux-can`.
 
-  It is possible to specify which CAN interface will be used by the app using the ``--can-if``
-  command-line option. This option overrides **every** Linux SocketCAN driver instance to use the specified
-  interface.
+  By default, the native simulator expects a SocketCAN network device called ``zcan0``. It is
+  possible to specify which SocketCAN network device will be used by the app by using the
+  ``--can-if`` command-line option. This option overrides **every** Linux SocketCAN driver instance
+  to use the specified interface.
+
+  SocketCAN support can be enabled by using the :ref:`snippet-socketcan-native-sim`.
 
 .. _native_ptty_uart:
 

--- a/snippets/socketcan-native-sim/README.rst
+++ b/snippets/socketcan-native-sim/README.rst
@@ -1,0 +1,31 @@
+.. _snippet-socketcan-native-sim:
+
+SocketCAN on Native Simulator Snippet (socketcan-native-sim)
+############################################################
+
+.. code-block:: console
+
+   west build -S socketcan-native-sim [...]
+
+Overview
+********
+
+This snippet allows to configure Controller Area Network (CAN) samples with Linux SocketCAN support
+on :ref:`native_sim`.
+
+By default, the native simulator expects a SocketCAN network device called ``zcan0`` (specified in
+:zephyr_file:`boards/native/native_sim/native_sim.dts`). This name can be added as an alternative
+name for an existing SocketCAN network device (here, a newly created virtual CAN network device
+``vcan0``) using a command like the following:
+
+.. code-block:: console
+
+   sudo modprobe vcan
+   sudo ip link add dev vcan0 type vcan
+   sudo ip link property add dev vcan0 altname zcan0
+
+The SocketCAN device must be configured and brought up before running the native simulator:
+
+.. code-block:: console
+
+   sudo ip link set vcan0 up

--- a/snippets/socketcan-native-sim/snippet.yml
+++ b/snippets/socketcan-native-sim/snippet.yml
@@ -1,0 +1,4 @@
+name: socketcan-native-sim
+append:
+  EXTRA_CONF_FILE: socketcan-native-sim.conf
+  EXTRA_DTC_OVERLAY_FILE: socketcan-native-sim.overlay

--- a/snippets/socketcan-native-sim/socketcan-native-sim.conf
+++ b/snippets/socketcan-native-sim/socketcan-native-sim.conf
@@ -1,0 +1,1 @@
+CONFIG_CAN=y

--- a/snippets/socketcan-native-sim/socketcan-native-sim.overlay
+++ b/snippets/socketcan-native-sim/socketcan-native-sim.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Henrik Brix Andersen <henrik@brixandersen.dk>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,canbus = &can0;
+	};
+};
+
+&can0 {
+	status = "okay";
+};


### PR DESCRIPTION
Add snippet for enabling Linux SocketCAN support on the native simulator.
