### PR TITLE
drivers: can: can_native_linux: set max bitrate

### DIFF
--- a/drivers/can/can_native_linux.c
+++ b/drivers/can/can_native_linux.c
@@ -478,10 +478,16 @@ static int can_native_linux_init(const struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_CAN_FD_MODE
+#define CAN_NATIVE_LINUX_MAX_BITRATE 8000000
+#else /* CONFIG_CAN_FD_MODE */
+#define CAN_NATIVE_LINUX_MAX_BITRATE 1000000
+#endif /* CONFIG_CAN_FD_MODE */
+
 #define CAN_NATIVE_LINUX_INIT(inst)						\
 										\
 static const struct can_native_linux_config can_native_linux_cfg_##inst = {	\
-	.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0, 0),			\
+	.common = CAN_DT_DRIVER_CONFIG_INST_GET(inst, 0, CAN_NATIVE_LINUX_MAX_BITRATE),	\
 	.if_name = DT_INST_PROP(inst, host_interface),				\
 };										\
 										\


### PR DESCRIPTION
This enables samples to call timing configuration functions,
which enables CanOpenNode to work on native_sim.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
