### PR TITLE
arch: arm: cortex_m: Add debug.h header

### DIFF
--- a/arch/arm/core/cortex_m/debug.c
+++ b/arch/arm/core/cortex_m/debug.c
@@ -13,6 +13,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <cortex_m/dwt.h>
+#include <cortex_m/debug.h>
 
 /**
  * @brief Assess whether a debug monitor event should be treated as an error

--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -20,6 +20,8 @@
 #include <zephyr/linker/linker-defs.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/barrier.h>
+#include <cortex_m/debug.h>
+
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)

--- a/arch/arm/core/cortex_m/prep_c.c
+++ b/arch/arm/core/cortex_m/prep_c.c
@@ -22,6 +22,7 @@
 #include <zephyr/sys/barrier.h>
 #include <zephyr/platform/hooks.h>
 #include <zephyr/arch/cache.h>
+#include <cortex_m/debug.h>
 
 /*
  * GCC can detect if memcpy is passed a NULL argument, however one of

--- a/arch/arm/include/cortex_m/debug.h
+++ b/arch/arm/include/cortex_m/debug.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ARM Cortex-M debug monitor functions interface based on DWT
+ *
+ */
+
+#ifndef ZEPHYR_ARCH_ARM_INCLUDE_CORTEX_M_DEBUG_H_
+#define ZEPHYR_ARCH_ARM_INCLUDE_CORTEX_M_DEBUG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Assess whether a debug monitor event should be treated as an error
+ *
+ * This routine checks the status of a debug_monitor() exception, and
+ * evaluates whether this needs to be considered as a processor error.
+ *
+ * @return true if the DM exception is a processor error, otherwise false
+ */
+bool z_arm_debug_monitor_event_error_check(void);
+
+int z_arm_debug_enable_null_pointer_detection(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_ARCH_ARM_INCLUDE_CORTEX_M_DEBUG_H_ */

--- a/arch/arm/include/cortex_m/exception.h
+++ b/arch/arm/include/cortex_m/exception.h
@@ -261,16 +261,6 @@ static ALWAYS_INLINE void z_arm_set_fault_sp(const struct arch_esf *esf, uint32_
 #endif /* CONFIG_DEBUG_COREDUMP */
 }
 
-/**
- * @brief Assess whether a debug monitor event should be treated as an error
- *
- * This routine checks the status of a debug_monitor() exception, and
- * evaluates whether this needs to be considered as a processor error.
- *
- * @return true if the DM exception is a processor error, otherwise false
- */
-bool z_arm_debug_monitor_event_error_check(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/misc/test_build/testcase.yaml
+++ b/tests/misc/test_build/testcase.yaml
@@ -36,3 +36,9 @@ tests:
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
       - CONFIG_LTO=y
       - CONFIG_PICOLIBC_USE_MODULE=y
+  buildsystem.arm.null_pointer_exception_detection_dwt:
+    build_only: true
+    platform_allow:
+      - qemu_cortex_m3
+    extra_configs:
+      - CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT=y


### PR DESCRIPTION
Since #75677, it has not been possible to build with
CONFIG_NULL_POINTER_EXCEPTION_DETECTION_DWT enabled since there was no
declaration of z_arm_debug_enable_null_pointer_detection before its use
in arch/arm/core/cortex_m/prep_c.c.

This change creates an arch/arm/include/cortex_m/debug.h header that
contains declarations for the functions in
arch/arm/core/cortex_m/debug.c.