### PR TITLE
AFR-S50: Improve error-handling + Build-time assert fixes

### DIFF
--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -362,12 +362,13 @@ BUILD_ASSERT(CONFIG_MAIN_STACK_SIZE >= 4096,
 #define AFBR_S50_INIT(inst)									   \
 												   \
 	BUILD_ASSERT(DT_INST_PROP(inst, odr) > 0, "Please set valid ODR");			   \
-	BUILD_ASSERT((DT_INST_PROP(inst, dual_freq_mode) != 0) ^				   \
-		     ((DT_INST_PROP(inst, measurement_mode) & ARGUS_MODE_FLAG_HIGH_SPEED) != 0),   \
+	BUILD_ASSERT(DT_INST_PROP(inst, dual_freq_mode == 0) ||					   \
+		     ((DT_INST_PROP(inst, dual_freq_mode) != 0) ^				   \
+		      ((DT_INST_PROP(inst, measurement_mode) & ARGUS_MODE_FLAG_HIGH_SPEED) != 0)), \
 		     "High Speed mode is not compatible with Dual-Frequency mode enabled. "	   \
 		     "Please disable it on device-tree or change measurement modes");		   \
-	BUILD_ASSERT((DT_INST_PROP(inst, dual_freq_mode) != 0) ^				   \
-		     (DT_INST_PROP(inst, odr) > 100),						   \
+	BUILD_ASSERT(DT_INST_PROP(inst, dual_freq_mode) == 0 ||					   \
+		     ((DT_INST_PROP(inst, dual_freq_mode) != 0) ^ (DT_INST_PROP(inst, odr) > 100)),\
 		     "ODR is too high for Dual-Frequency mode. Please reduce it to "		   \
 		     "100Hz or less");								   \
 												   \

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -153,7 +153,7 @@ static status_t data_ready_callback(status_t status, argus_hnd_t *hnd)
 	 */
 	err = afbr_s50_platform_get_by_hnd(hnd, &platform);
 	CHECKIF(err) {
-		__ASSERT(false, "Failed to get platform data SQE response can't be sent");
+		LOG_ERR("Failed to get platform data SQE response can't be sent");
 		return ERROR_FAIL;
 	}
 

--- a/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
+++ b/drivers/sensor/broadcom/afbr_s50/afbr_s50.c
@@ -190,7 +190,8 @@ static void afbr_s50_submit_single_shot(const struct device *dev,
 	struct afbr_s50_data *data = dev->data;
 
 	/** If there's an op in process, reject ignore requests */
-	if (data->rtio.iodev_sqe != NULL) {
+	if (data->rtio.iodev_sqe != NULL &&
+	    FIELD_GET(RTIO_SQE_CANCELED, data->rtio.iodev_sqe->sqe.flags) == 0) {
 		LOG_WRN("Operation in progress. Rejecting request");
 
 		rtio_iodev_sqe_err(iodev_sqe, -EBUSY);
@@ -215,7 +216,8 @@ static void afbr_s50_submit_streaming(const struct device *dev,
 	const struct sensor_read_config *read_cfg = iodev_sqe->sqe.iodev->data;
 
 	/** If there's an op in process, reject ignore requests */
-	if (data->rtio.iodev_sqe != NULL) {
+	if (data->rtio.iodev_sqe != NULL &&
+	    FIELD_GET(RTIO_SQE_CANCELED, data->rtio.iodev_sqe->sqe.flags) == 0) {
 		LOG_WRN("Operation in progress");
 
 		rtio_iodev_sqe_err(iodev_sqe, -EBUSY);


### PR DESCRIPTION
This PR incorporates improvements in error-handling, taking advantage of #93543 improvements. Additionally, expanded build-time asserts to allow selecting config-sets without dual-frequency mode.

> [!NOTE]
> Depends on #93543. Marking as DNM until it lands.