### PR TITLE
Nxp imx93 support pwm

### DIFF
--- a/boards/nxp/imx93_evk/doc/index.rst
+++ b/boards/nxp/imx93_evk/doc/index.rst
@@ -48,6 +48,13 @@ Supported Features
 
 .. zephyr:board-supported-hw::
 
+TPM
+---
+
+TPM2 is enabled for PWM for M33 core. Signals can be observerd with
+oscilloscope or logic analyzer.
+Connect J1005-3 and J1005-7(GND) to Oscilloscope or logic analyzer
+
 Devices
 ========
 System Clock

--- a/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
+++ b/boards/nxp/imx93_evk/imx93_evk-pinctrl.dtsi
@@ -323,4 +323,15 @@
 			bias-pull-up;
 		};
 	};
+
+	tpm2_default: tpm2_default {
+		group0 {
+			pinmux = <&iomuxc1_i2c1_scl_tpm_ch_tpm2_ch0>,
+				<&iomuxc1_i2c1_sda_tpm_ch_tpm2_ch1>;
+			drive-open-drain;
+			slew-rate = "slightly_fast";
+			drive-strength = "x4";
+			input-enable;
+		};
+	};
 };

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.dts
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.dts
@@ -84,3 +84,9 @@
 &gpio4 {
 	status = "okay";
 };
+
+&tpm2 {
+	pinctrl-0 = <&tpm2_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.yaml
+++ b/boards/nxp/imx93_evk/imx93_evk_mimx9352_m33.yaml
@@ -13,4 +13,5 @@ flash: 128
 supported:
   - gpio
   - uart
+  - pwm
 vendor: nxp

--- a/dts/arm/nxp/nxp_imx93_m33.dtsi
+++ b/dts/arm/nxp/nxp_imx93_m33.dtsi
@@ -96,6 +96,66 @@
 			clocks = <&ccm IMX_CCM_LPUART2_CLK 0x6c 24>;
 			status = "disabled";
 		};
+
+		tpm1: pwm@44310000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x44310000 0x88>;
+			interrupts = <36 0>;
+			clocks = <&ccm IMX_CCM_TPM1_CLK 0x3b 0>;
+			prescaler = <16>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		tpm2: pwm@44320000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x44320000 0x88>;
+			interrupts = <37 0>;
+			clocks = <&ccm IMX_CCM_TPM2_CLK 0x3c 0>;
+			prescaler = <16>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		tpm3: pwm@424e0000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x424e0000 0x88>;
+			interrupts = <75 0>;
+			clocks = <&ccm IMX_CCM_TPM3_CLK 0x3d 0>;
+			prescaler = <16>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		tpm4: pwm@424f0000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x424f0000 0x88>;
+			interrupts = <76 0>;
+			clocks = <&ccm IMX_CCM_TPM4_CLK 0x3e 0>;
+			prescaler = <16>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		tpm5: pwm@42500000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x42500000 0x88>;
+			interrupts = <77 0>;
+			clocks = <&ccm IMX_CCM_TPM5_CLK 0x3f 0>;
+			prescaler = <16>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		tpm6: pwm@42510000 {
+			compatible = "nxp,kinetis-tpm";
+			reg = <0x42510000 0x88>;
+			interrupts = <78 0>;
+			clocks = <&ccm IMX_CCM_TPM6_CLK 0x40 0>;
+			prescaler = <16>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/soc/nxp/imx/imx9/imx93/m33/soc.c
+++ b/soc/nxp/imx/imx9/imx93/m33/soc.c
@@ -17,5 +17,8 @@ void soc_early_init_hook(void)
 	GPIO2->PCNS = 0x0;
 	GPIO3->PCNS = 0x0;
 	GPIO4->PCNS = 0x0;
+
+	/* keep system tick work fine during idle task */
+	GPC_CTRL_CM33->CM_MISC &= ~GPC_CPU_CTRL_CM_MISC_SLEEP_HOLD_EN_MASK;
 }
 #endif

--- a/tests/drivers/pwm/pwm_api/boards/imx93_evk_mimx9352_m33.conf
+++ b/tests/drivers/pwm/pwm_api/boards/imx93_evk_mimx9352_m33.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_TEST_USERSPACE=n

--- a/tests/drivers/pwm/pwm_api/boards/imx93_evk_mimx9352_m33.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/imx93_evk_mimx9352_m33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		pwm-0 = &tpm2;
+	};
+};


### PR DESCRIPTION
1. enabled tpm interface for pwm api test base, test passed on log and logic analyzer
2. fixed m33 system tick fail issue when enter idle task by disabled gpc interface flag
3. disabled user space setting for this case, there are some issue about this, debug it on onging, temporarily set it as disabled for this case