### PR TITLE
dts: arm: Add CAN1 and CAN2 nodes to stm32f207

### DIFF
--- a/boards/st/nucleo_f207zg/doc/index.rst
+++ b/boards/st/nucleo_f207zg/doc/index.rst
@@ -49,6 +49,7 @@ Nucleo F207ZG provides the following hardware components:
 - I2C (3)
 - SPI (3)
 - SDIO
+- CAN (2)
 - USB 2.0 OTG FS
 - DMA Controller
 - 10/100 Ethernet MAC with dedicated DMA
@@ -96,6 +97,8 @@ Default Zephyr Peripheral Mapping:
 - I2C1 SCL/SDA : PB8/PB9 (Arduino I2C)
 - SPI1 NSS/SCK/MISO/MOSI : PD14/PA5/PA6/PA7 (Arduino SPI)
 - ETH : PA1, PA2, PA7, PB13, PC1, PC4, PC5, PG11, PG13
+- CAN1 TX/RX : PD1/PD0
+- CAN2 TX/RX : PB6/PB5
 - USB_DM : PA11
 - USB_DP : PA12
 - USER_PB : PC13

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -17,6 +17,7 @@
 	chosen {
 		zephyr,console = &usart3;
 		zephyr,shell-uart = &usart3;
+		zephyr,canbus = &can1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};
@@ -149,6 +150,18 @@
 
 zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&can1 {
+	pinctrl-0 = <&can1_rx_pd0 &can1_tx_pd1>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&can2 {
+	pinctrl-0 = <&can2_rx_pb5 &can2_tx_pb6>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.yaml
@@ -14,6 +14,7 @@ supported:
   - i2c
   - spi
   - gpio
+  - can
   - usb_device
   - watchdog
   - counter

--- a/dts/arm/st/f2/stm32f207.dtsi
+++ b/dts/arm/st/f2/stm32f207.dtsi
@@ -34,5 +34,23 @@
 				status = "disabled";
 			};
 		};
+
+		can1: can@40006400 {
+			compatible = "st,stm32-bxcan";
+			reg = <0x40006400 0x400>;
+			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
+			status = "disabled";
+		};
+
+		can2: can@40006800 {
+			compatible = "st,stm32-bxcan";
+			reg = <0x40006800 0x400>;
+			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
+			status = "disabled";
+		};
 	};
 };


### PR DESCRIPTION
Add CAN1 and CAN2 device tree nodes for STM32F207

Signed-off-by: Taeyoun Park <nvnv0422@gmail.com>