### PR TITLE
dts: intel_ish: Update UART1/2 and DMA nodes

### DIFF
--- a/dts/x86/intel/intel_ish5.dtsi
+++ b/dts/x86/intel/intel_ish5.dtsi
@@ -108,6 +108,30 @@
 			status = "okay";
 		};
 
+		uart1: uart@8102000 {
+			compatible = "intel,sedi-uart";
+			reg = <0x08102000 0x1000>;
+			interrupt-parent = <&intc>;
+			peripheral-id = <1>;
+			interrupts = <24 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
+			interrupt-names = "uart1";
+			current-speed = <115200>;
+
+			status = "disabled";
+		};
+
+		uart2: uart@8104000 {
+			compatible = "intel,sedi-uart";
+			reg = <0x08104000 0x1000>;
+			interrupt-parent = <&intc>;
+			peripheral-id = <2>;
+			interrupts = <25 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
+			interrupt-names = "uart2";
+			current-speed = <115200>;
+
+			status = "disabled";
+		};
+
 		i2c0: i2c@0 {
 			compatible = "intel,sedi-i2c";
 			#address-cells = <1>;

--- a/dts/x86/intel/intel_ish5_8.dtsi
+++ b/dts/x86/intel/intel_ish5_8.dtsi
@@ -18,6 +18,18 @@
 	status = "okay";
 };
 
+&uart1 {
+	interrupts = <29 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
+
+	status = "disabled";
+};
+
+&uart2 {
+	interrupts = <30 IRQ_TYPE_LOWEST_EDGE_RISING 6>;
+
+	status = "disabled";
+};
+
 &i2c0 {
 	interrupts = <18 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
@@ -52,4 +64,10 @@
 	interrupts = <24 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
 
 	status = "disabled";
+};
+
+&dma0 {
+	interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_HIGH 2>;
+
+	status = "okay";
 };


### PR DESCRIPTION
Added UART1/2 nodes to both intel_ish5.dtsi and intel_ish5_8.dtsi.
Update intel_ish5_8.dtsi to override DMA interrupt number.