### PR TITLE
boards: frdm_mcxa153, frdm_mcxa156: add ostimer support

### DIFF
--- a/boards/nxp/frdm_mcxa153/board.c
+++ b/boards/nxp/frdm_mcxa153/board.c
@@ -173,6 +173,10 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kFRO12M_to_LPUART2);
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ostimer0))
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(porta))
 	RESET_ReleasePeripheralReset(kPORT0_RST_SHIFT_RSTn);
 #endif

--- a/boards/nxp/frdm_mcxa153/doc/index.rst
+++ b/boards/nxp/frdm_mcxa153/doc/index.rst
@@ -55,6 +55,7 @@ System Clock
 
 The MCX-A153 SoC is configured to use FRO running at 96MHz as a source for
 the system clock.
+The MCX-A153 uses OS timer as the kernel timer.
 
 Serial Port
 ===========

--- a/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
+++ b/boards/nxp/frdm_mcxa153/frdm_mcxa153.dts
@@ -186,6 +186,13 @@
 	pinctrl-names = "default";
 };
 
+/*
+ * Uses OS timer as the kernel timer
+ */
+&ostimer0 {
+	status = "okay";
+};
+
 zephyr_udc0: &usb {
 	status = "okay";
 };

--- a/boards/nxp/frdm_mcxa156/board.c
+++ b/boards/nxp/frdm_mcxa156/board.c
@@ -235,6 +235,10 @@ void board_early_init_hook(void)
 
 #endif
 
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ostimer0))
+	CLOCK_AttachClk(kCLK_1M_to_OSTIMER);
+#endif
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb))
 	RESET_PeripheralReset(kUSB0_RST_SHIFT_RSTn);
 	CLOCK_EnableUsbfsClock();

--- a/boards/nxp/frdm_mcxa156/doc/index.rst
+++ b/boards/nxp/frdm_mcxa156/doc/index.rst
@@ -55,6 +55,7 @@ System Clock
 
 The MCX-A156 SoC is configured to use FRO running at 96MHz as a source for
 the system clock.
+The MCX-A156 uses OS timer as the kernel timer.
 
 Serial Port
 ===========

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -247,6 +247,13 @@ zephyr_mipi_dbi_parallel: &flexio0_lcd {
 	status = "okay";
 };
 
+/*
+ * Uses OS timer as the kernel timer
+ */
+&ostimer0 {
+	status = "okay";
+};
+
 zephyr_udc0: &usb {
 	status = "okay";
 	num-bidir-endpoints = <8>;

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -303,6 +303,13 @@
 			dma-names = "rx", "tx";
 		};
 
+		ostimer0: timers@400ad000 {
+			compatible = "nxp,os-timer";
+			reg = <0x400ad000 0x1000>;
+			interrupts = <57 0>;
+			status = "disabled";
+		};
+
 		porta: pinmux@400bc000 {
 			compatible = "nxp,port-pinmux";
 			reg = <0x400bc000 0x1000>;

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -493,6 +493,13 @@
 			status = "disabled";
 		};
 
+		ostimer0: timers@400ad000 {
+			compatible = "nxp,os-timer";
+			reg = <0x400ad000 0x1000>;
+			interrupts = <57 0>;
+			status = "disabled";
+		};
+
 		temp0: temp0 {
 			compatible = "nxp,lpadc-temp40";
 			status = "disabled";

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -14,6 +14,7 @@ config SOC_MCXA153
 	select CPU_CORTEX_M33
 	select HAS_MCUX_CACHE
 	select HAS_MCUX_MCX_CMC
+	select HAS_MCUX_OS_TIMER
 
 config SOC_MCXA156
 	select CPU_CORTEX_M33
@@ -21,6 +22,7 @@ config SOC_MCXA156
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
 	select HAS_MCUX_MCX_CMC
+	select HAS_MCUX_OS_TIMER
 
 config SOC_MCXA166
 	select CPU_CORTEX_M33

--- a/soc/nxp/mcx/mcxa/Kconfig.defconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SOC_FAMILY_MCXA
 
 config CORTEX_M_SYSTICK
-	default n if MCUX_LPTMR_TIMER
+	default n if (MCUX_LPTMR_TIMER || MCUX_OS_TIMER)
 
 config NUM_IRQS
 	default 88


### PR DESCRIPTION
1. add ostimer support
2. by default, the systick is used.
3. The ostimer could be tested with below configure in xxx.overlay: &systick {
    status = "disabled";
};
&ostimer0 {
    status = "okay";
};
And below configure in xxx.conf:
CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=1000000