### PR TITLE
stm32: mcuboot: add support  for mcuboot tests and samples

### DIFF
--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -177,4 +178,33 @@ zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(30)>;
+		};
+
+		slot1_partition: partition@17800 {
+			label = "image-1";
+			reg = <0x00017800 DT_SIZE_K(30)>;
+		};
+
+		/* Set 4KB of storage at the end of 128KB flash */
+		storage_partition: partition@1f000 {
+			label = "storage";
+			reg = <0x0001f000 DT_SIZE_K(4)>;
+		};
+	};
 };

--- a/boards/st/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/st/nucleo_f091rc/nucleo_f091rc.dts
@@ -21,6 +21,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &can1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -149,10 +150,25 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 6Kb of storage at the end of the 256Kb of flash */
-		storage_partition: partition@3e800 {
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(94)>;
+		};
+
+		slot1_partition: partition@27800 {
+			label = "image-1";
+			reg = <0x00027800 DT_SIZE_K(94)>;
+		};
+
+		/* Set 4Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3f000 {
 			label = "storage";
-			reg = <0x0003e800 DT_SIZE_K(6)>;
+			reg = <0x0003f000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/boards/st/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/st/nucleo_f103rb/nucleo_f103rb.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -166,6 +167,21 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(32)>;
+		};
+
+		slot1_partition: partition@18000 {
+			label = "image-1";
+			reg = <0x00018000 DT_SIZE_K(30)>;
+		};
 
 		/* Set 2KB of storage at the end of 128KB flash */
 		storage_partition: partition@1f800 {

--- a/boards/st/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/st/nucleo_f207zg/nucleo_f207zg.dts
@@ -19,6 +19,7 @@
 		zephyr,shell-uart = &usart3;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {

--- a/boards/st/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/st/nucleo_f746zg/nucleo_f746zg.dts
@@ -28,6 +28,7 @@
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;
 		zephyr,canbus = &can1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -234,4 +235,32 @@ zephyr_udc0: &usbotg_fs {
 
 &vbat {
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		storage_partition: partition@10000 {
+			label = "storage";
+			reg = <0x00010000 DT_SIZE_K(192)>;
+		};
+
+		slot0_partition: partition@40000 {
+			label = "image-0";
+			reg = <0x00040000 DT_SIZE_K(448)>;
+		};
+
+		slot1_partition: partition@b0000 {
+			label = "image-1";
+			reg = <0x000b0000 DT_SIZE_K(320)>;
+		};
+	};
 };

--- a/boards/st/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/st/nucleo_g071rb/nucleo_g071rb.dts
@@ -21,6 +21,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -170,6 +171,21 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(30)>;
+		};
+
+		slot1_partition: partition@17800 {
+			label = "image-1";
+			reg = <0x00017800 DT_SIZE_K(30)>;
+		};
 
 		/* Set 4KB of storage at the end of 128KB flash */
 		storage_partition: partition@1f000 {

--- a/boards/st/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/st/nucleo_g474re/nucleo_g474re.dts
@@ -177,17 +177,17 @@ stm32_lp_tick_source: &lptim1 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(34)>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
 
-		slot0_partition: partition@8800 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00008800 DT_SIZE_K(240)>;
+			reg = <0x000010000 DT_SIZE_K(192)>;
 		};
 
-		slot1_partition: partition@44800 {
+		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00044800 DT_SIZE_K(234)>;
+			reg = <0x00040000 DT_SIZE_K(192)>;
 		};
 
 		/* Set 4Kb of storage at the end of the 512Kb of flash */

--- a/boards/st/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/st/nucleo_h743zi/nucleo_h743zi.dts
@@ -252,28 +252,19 @@ zephyr_udc0: &usbotg_fs {
 			read-only;
 		};
 
-		/* storage: 128KB for settings */
-		storage_partition: partition@20000 {
-			label = "storage";
-			reg = <0x00020000 DT_SIZE_K(128)>;
-		};
-
-		/* application image slot: 256KB */
-		slot0_partition: partition@40000 {
+		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00040000 DT_SIZE_K(256)>;
+			reg = <0x00020000 DT_SIZE_K(384)>;
 		};
 
-		/* backup slot: 256KB */
 		slot1_partition: partition@80000 {
 			label = "image-1";
-			reg = <0x00080000 DT_SIZE_K(256)>;
+			reg = <0x00080000 DT_SIZE_K(384)>;
 		};
 
-		/* swap slot: 128KB */
-		scratch_partition: partition@c0000 {
-			label = "image-scratch";
-			reg = <0x000c0000 DT_SIZE_K(128)>;
+		storage_partition: partition@e0000 {
+			label = "storage";
+			reg = <0x000e0000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/st/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/st/nucleo_l073rz/nucleo_l073rz.dts
@@ -21,6 +21,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -184,4 +185,33 @@ stm32_lp_tick_source: &lptim1 {
 
 &vref {
 	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(64)>;
+		};
+
+		slot1_partition: partition@20000 {
+			label = "image-1";
+			reg = <0x00020000 DT_SIZE_K(62)>;
+		};
+
+		/* Set 2KB of storage at the end of 128KB flash */
+		storage_partition: partition@2f800 {
+			label = "storage";
+			reg = <0x0001f800 DT_SIZE_K(2)>;
+		};
+	};
 };

--- a/boards/st/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/st/nucleo_l152re/nucleo_l152re.dts
@@ -20,6 +20,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -146,6 +147,21 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(220)>;
+		};
+
+		slot1_partition: partition@47000 {
+			label = "image-1";
+			reg = <0x00047000 DT_SIZE_K(220)>;
+		};
 
 		/* Set 8KB of storage at the end of 512KB flash */
 		storage_partition: partition@7e000 {

--- a/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/st/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -232,27 +232,22 @@ zephyr_udc0: &usb {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(48)>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
 
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x0000c000 DT_SIZE_K(400)>;
+			reg = <0x00010000 DT_SIZE_K(484)>;
 		};
 
-		slot1_partition: partition@70000 {
+		slot1_partition: partition@89000{
 			label = "image-1";
-			reg = <0x00070000 DT_SIZE_K(400)>;
+			reg = <0x00089000 DT_SIZE_K(476)>;
 		};
 
-		scratch_partition: partition@d4000 {
-			label = "image-scratch";
-			reg = <0x000d4000 DT_SIZE_K(16)>;
-		};
-
-		storage_partition: partition@d8000 {
+		storage_partition: partition@100000 {
 			label = "storage";
-			reg = <0x000d8000 DT_SIZE_K(8)>;
+			reg = <0x00100000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/st/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -205,18 +205,18 @@ stm32_lp_tick_source: &lptim1 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 DT_SIZE_K(32)>;
+			reg = <0x00000000 DT_SIZE_K(40)>;
 			read-only;
 		};
 
-		slot0_partition: partition@8000 {
+		slot0_partition: partition@a000 {
 			label = "image-0";
-			reg = <0x00008000 DT_SIZE_K(104)>;
+			reg = <0x0000a000 DT_SIZE_K(100)>;
 		};
 
-		slot1_partition: partition@22000 {
+		slot1_partition: partition@23000 {
 			label = "image-1";
-			reg = <0x00022000 DT_SIZE_K(104)>;
+			reg = <0x00023000 DT_SIZE_K(100)>;
 		};
 
 		/*

--- a/boards/st/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/st/stm32f3_disco/stm32f3_disco.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,canbus = &can1;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds {
@@ -201,6 +202,21 @@ zephyr_udc0: &usb {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(96)>;
+		};
+
+		slot1_partition: partition@28000 {
+			label = "image-1";
+			reg = <0x00028000 DT_SIZE_K(90)>;
+		};
 
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {

--- a/boards/st/stm32u083c_dk/stm32u083c_dk.dts
+++ b/boards/st/stm32u083c_dk/stm32u083c_dk.dts
@@ -23,6 +23,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	leds: leds {
@@ -172,6 +173,35 @@ stm32_lp_tick_source: &lptim2 {
 			noise-threshold = <50>;
 			sticky-key-timeout-ms = <10000>;
 			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 DT_SIZE_K(94)>;
+		};
+
+		slot1_partition: partition@27800 {
+			label = "image-1";
+			reg = <0x00027800 DT_SIZE_K(94)>;
+		};
+
+		/* Set 4KB of storage at the end of 256KB flash */
+		storage_partition: partition@3f000 {
+			label = "storage";
+			reg = <0x0003f000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/samples/sysbuild/with_mcuboot/sample.yaml
+++ b/samples/sysbuild/with_mcuboot/sample.yaml
@@ -14,10 +14,27 @@ tests:
       - esp32s3_devkitm/esp32s3/procpu
       - esp32c3_devkitm
       - esp32c6_devkitc/esp32c6/hpcore
+      - disco_l475_iot1
+      - nucleo_c071rb
+      - nucleo_f091rc
+      - nucleo_f103rb
+      - nucleo_f207zg
+      - nucleo_f429zi
+      - nucleo_f746zg
+      - nucleo_g071rb
+      - nucleo_g474re
+      - nucleo_h743zi
       - nucleo_h7s3l8
+      - nucleo_l073rz
+      - nucleo_l152re
+      - nucleo_u083rc
       - nucleo_u385rg_q
-      - stm32h7s78_dk
+      - nucleo_wb55rg
+      - nucleo_wba55cg
+      - nucleo_wl55jc
+      - stm32f3_disco@B
       - stm32h573i_dk
+      - stm32h7s78_dk
     integration_platforms:
       - nrf52840dk/nrf52840
       - esp32_devkitc/esp32/procpu

--- a/tests/boot/test_mcuboot/testcase.yaml
+++ b/tests/boot/test_mcuboot/testcase.yaml
@@ -48,6 +48,12 @@ tests:
       - vmu_rt1170/mimxrt1176/cm7
       - nrf52840dk/nrf52840
       - rd_rw612_bga
+      - nucleo_c071rb
+      - nucleo_g474re
+      - nucleo_u385rg_q
+      - nucleo_wba55cg
+      - nucleo_wl55jc
+      - stm32u083c_dk
       - esp32_devkitc/esp32/procpu
       - esp32s2_saola
       - esp32s3_devkitm/esp32s3/procpu

--- a/tests/boot/with_mcumgr/testcase.yaml
+++ b/tests/boot/with_mcumgr/testcase.yaml
@@ -4,7 +4,10 @@ common:
     - nrf5340dk/nrf5340/cpuapp
     - nrf54l15dk/nrf54l15/cpuapp
     - nrf9160dk/nrf9160
-    - nucleo_wba55cg
+    - nucleo_f091rc
+    - nucleo_g474re
+    - nucleo_u385rg_q
+    - nucleo_wl55jc
   timeout: 600
   slow: true
   tags:
@@ -15,6 +18,7 @@ tests:
   boot.with_mcumgr.test_upgrade:
     platform_allow:
       - nrf52840dk/nrf52840
+      - nucleo_wba55cg
     integration_platforms:
       - nrf52840dk/nrf52840
     harness: pytest
@@ -28,6 +32,10 @@ tests:
     platform_exclude:
       - nrf9160dk/nrf9160
       - nucleo_wba55cg
+      - nucleo_f091rc
+      - nucleo_g474re
+      - nucleo_u385rg_q
+      - nucleo_wl55jc
     integration_platforms:
       - nrf52840dk/nrf52840
     extra_args: EXTRA_CONF_FILE="overlay-bt.conf"
@@ -40,6 +48,7 @@ tests:
   boot.with_mcumgr.test_downgrade_prevention:
     platform_allow:
       - nrf52840dk/nrf52840
+      - stm32u083c_dk
     integration_platforms:
       - nrf52840dk/nrf52840
     harness: pytest

--- a/tests/drivers/flash/stm32/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/flash/stm32/boards/nucleo_f746zg.overlay
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/delete-node/ &storage_partition;
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";


### PR DESCRIPTION
This PR adds support for testing MCUboot tests and samples. However, not all series are supported yet due to some limitations and hardware incapacity.

Related tests and samples : 
- zephyr/samples/sysbuild/with_mcuboot
- zephyr/tests/boot/test_mcuboot
- zephyr/tests/boot/with_mcumgr


