### PR TITLE
drivers: gpio: esp32: correct comment about pin drive strength

### DIFF
--- a/include/zephyr/dt-bindings/gpio/espressif-esp32-gpio.h
+++ b/include/zephyr/dt-bindings/gpio/espressif-esp32-gpio.h
@@ -14,8 +14,8 @@
  * ESP32 SoCs.
  *
  * The interface supports two different drive strengths:
- * `DFLT` - The lowest drive strength supported by the HW
- * `ALT` - The highest drive strength supported by the HW
+ * `DFLT` - The highest drive strength supported by the HW
+ * `ALT` - The lowest drive strength supported by the HW
  *
  * @{
  */


### PR DESCRIPTION
The comment about which drive strength option is high or low was wrong and this commit fixes it. For example, ESP32_GPIO_DS_ALT results in GPIO_DRIVE_CAP_0 being used which is the weakest option according to the NXP HAL file espressif-esp32-gpio.h.

**Zephyr GPIO Driver**
https://github.com/zephyrproject-rtos/zephyr/blob/5d42408efa41e459baf3d352ab3592d362dbaf60/drivers/gpio/gpio_esp32.c#L216-L240

**NXP HAL**
https://github.com/zephyrproject-rtos/hal_espressif/blob/114bdcb05136403d84e3529809c3e8044153a86c/components/hal/include/hal/gpio_types.h#L388-L395
```C
    GPIO_DRIVE_CAP_0       = 0,    /*!< Pad drive capability: weak          */
    GPIO_DRIVE_CAP_1       = 1,    /*!< Pad drive capability: stronger      */
    GPIO_DRIVE_CAP_2       = 2,    /*!< Pad drive capability: medium */
    GPIO_DRIVE_CAP_DEFAULT = 2,    /*!< Pad drive capability: medium */
    GPIO_DRIVE_CAP_3       = 3,    /*!< Pad drive capability: strongest     */
```
**Reference manual p514** [link](https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf)
<img width="398" height="305" alt="image" src="https://github.com/user-attachments/assets/b95674ec-4672-4bce-b59b-0e9773c4527b" />
