### PR TITLE
dts: phy: Add clock-reference prop in stm32u5-otghs-phy

### DIFF
--- a/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
+++ b/boards/st/nucleo_u5a5zj_q/nucleo_u5a5zj_q.dts
@@ -83,3 +83,7 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+&otghs_phy {
+	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+};

--- a/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
+++ b/boards/st/stm32u5a9j_dk/stm32u5a9j_dk.dts
@@ -257,6 +257,10 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 };
 
+&otghs_phy {
+	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
+++ b/boards/st/stm32u5g9j_dk1/stm32u5g9j_dk1.dts
@@ -257,6 +257,10 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 };
 
+&otghs_phy {
+	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -296,6 +296,10 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 };
 
+&otghs_phy {
+	clock-reference = "SYSCFG_OTG_HS_PHY_CLK_16MHz";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -36,6 +36,14 @@ Device Drivers and Devicetree
 
 .. zephyr-keep-sorted-start re(^\w)
 
+Phy
+===
+
+* Nodes with compatible property :dtcompatible:`st,stm32u5-otghs-phy` now need to select the
+  CLKSEL (phy reference clock) in the SYSCFG_OTGHSPHYCR register using the new property
+  clock-reference. The selection directly depends on the value on OTGHSSEL (OTG_HS PHY kernel
+  clock source selection) located in the RCC_CCIPR2 register.
+
 Sensors
 =======
 

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -67,6 +67,17 @@ LOG_MODULE_REGISTER(udc_stm32, CONFIG_UDC_DRIVER_LOG_LEVEL);
 #define USB_USBPHYC_CR_FSEL_24MHZ        USB_USBPHYC_CR_FSEL_1
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otghs) && defined(CONFIG_SOC_SERIES_STM32U5X)
+static const int syscfg_otg_hs_phy_clk[] = {
+	SYSCFG_OTG_HS_PHY_CLK_SELECT_1,	/* 16Mhz   */
+	SYSCFG_OTG_HS_PHY_CLK_SELECT_2,	/* 19.2Mhz */
+	SYSCFG_OTG_HS_PHY_CLK_SELECT_3,	/* 20Mhz   */
+	SYSCFG_OTG_HS_PHY_CLK_SELECT_4,	/* 24Mhz   */
+	SYSCFG_OTG_HS_PHY_CLK_SELECT_5,	/* 26Mhz   */
+	SYSCFG_OTG_HS_PHY_CLK_SELECT_6,	/* 32Mhz   */
+};
+#endif
+
 struct udc_stm32_data  {
 	PCD_HandleTypeDef pcd;
 	const struct device *dev;
@@ -1063,7 +1074,9 @@ static int priv_clock_enable(void)
 
 	/* Set the OTG PHY reference clock selection (through SYSCFG) block */
 	LL_APB3_GRP1_EnableClock(LL_APB3_GRP1_PERIPH_SYSCFG);
-	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(SYSCFG_OTG_HS_PHY_CLK_SELECT_1);
+	HAL_SYSCFG_SetOTGPHYReferenceClockSelection(
+		syscfg_otg_hs_phy_clk[DT_ENUM_IDX(DT_NODELABEL(otghs_phy), clock_reference)]
+	);
 	/* Configuring the SYSCFG registers OTG_HS PHY : OTG_HS PHY enable*/
 	HAL_SYSCFG_EnableOTGPHY(SYSCFG_OTG_HS_PHY_ENABLE);
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32n6_otghs)

--- a/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
+++ b/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
@@ -36,3 +36,20 @@ properties:
         /* PLL1_P_CK/2 */
         clocks = <&rcc STM32_CLOCK(AHB2, 15U)>,
                  <&rcc (STM32_SRC_PLL1_P | STM32_CLOCK_DIV(2)) OTGHS_SEL(3)>;
+
+  clock-reference:
+    type: string
+    required: true
+    enum:
+      - "SYSCFG_OTG_HS_PHY_CLK_16MHz"
+      - "SYSCFG_OTG_HS_PHY_CLK_19.2MHz"
+      - "SYSCFG_OTG_HS_PHY_CLK_20MHz"
+      - "SYSCFG_OTG_HS_PHY_CLK_24MHz"
+      - "SYSCFG_OTG_HS_PHY_CLK_26MHz"
+      - "SYSCFG_OTG_HS_PHY_CLK_32MHz"
+    description: |
+      OTG_HS PHY reference clock frequency selection.
+
+      This value selects the reference clock frequency to be used in the OTG_HS PHY PLL
+      in the SYSCFG OTG_HS PHY register (SYSCFG_OTGHSPHYCR). The selection of this value
+      should take in consideration the OTGHSSEL dependency to avoid miss configurations.


### PR DESCRIPTION
The OTG_HS PHY from `stm32u5a5xx` device require the correct reference clock frequency selction in `SYSCFG_OTGHSPHYCR`. The current default is hard coded to `16Mhz` (which matches the development board crystal). However, a custom board my require a different crystal and then the USB will not work. This add a required field in the `st,stm32u5-otghs-phy` binding to force user to select the correct clock reference. The current `nucleo_u5a5zj_q` baord was updated to reflect the mandatory field.