### PR TITLE
net: if: Fix net_if_list iteration issue for offloaded interfaces

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -3475,7 +3475,7 @@ extern int net_stats_prometheus_scrape(struct prometheus_collector *collector,
 	};								\
 	static Z_DECL_ALIGN(struct net_if)				\
 		NET_IF_GET_NAME(dev_id, sfx)[NET_IF_MAX_CONFIGS]	\
-		       __used __in_section(_net_if, static,		\
+		       __used __noasan __in_section(_net_if, static,	\
 					   dev_id) = {			\
 		[0 ... (NET_IF_MAX_CONFIGS - 1)] = {			\
 			.if_dev = &(NET_IF_DEV_GET_NAME(dev_id, sfx)),	\


### PR DESCRIPTION
Disable ASAN for net_if config to avoid iteration issues caused by AddressSanitizer padding.

This was previously fixed in #83903 for `NET_IF_INIT` but not for `NET_IF_OFFLOAD_INIT`.

Closes #83863