### PR TITLE
soc: wch: use an unified entry for the vector table

### DIFF
--- a/soc/wch/ch32v/qingke_v4b/vector.S
+++ b/soc/wch/ch32v/qingke_v4b/vector.S
@@ -6,10 +6,6 @@
 
 #include <zephyr/toolchain.h>
 
-#ifndef CONFIG_VECTOR_TABLE_SIZE
-#error "VECTOR_TABLE_SIZE must be defined"
-#endif
-
 /* Exports */
 GTEXT(__start)
 
@@ -22,11 +18,9 @@ SECTION_FUNC(vectors, ivt)
 	lui	x5, 0x8000
 	jr	0x8(x5)
 	j       __start
-	.rept   CONFIG_VECTOR_TABLE_SIZE
 	.word	_isr_wrapper
-	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 0xf
+	li 	a0, 0xe
 	csrw	mtvec, a0
 	j	__initialize

--- a/soc/wch/ch32v/qingke_v4c/vector.S
+++ b/soc/wch/ch32v/qingke_v4c/vector.S
@@ -6,10 +6,6 @@
 
 #include <zephyr/toolchain.h>
 
-#ifndef CONFIG_VECTOR_TABLE_SIZE
-#error "VECTOR_TABLE_SIZE must be defined"
-#endif
-
 /* Exports */
 GTEXT(__start)
 
@@ -22,11 +18,9 @@ SECTION_FUNC(vectors, ivt)
 	lui	x5, 0x8000
 	jr	0x8(x5)
 	j       __start
-	.rept   CONFIG_VECTOR_TABLE_SIZE
 	.word	_isr_wrapper
-	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 0xf
+	li 	a0, 0xe
 	csrw	mtvec, a0
 	j	__initialize

--- a/soc/wch/ch32v/qingke_v4f/vector.S
+++ b/soc/wch/ch32v/qingke_v4f/vector.S
@@ -6,10 +6,6 @@
 
 #include <zephyr/toolchain.h>
 
-#ifndef CONFIG_VECTOR_TABLE_SIZE
-#error "VECTOR_TABLE_SIZE must be defined"
-#endif
-
 /* Exports */
 GTEXT(__start)
 
@@ -22,11 +18,9 @@ SECTION_FUNC(vectors, ivt)
 	lui	x5, 0x8000
 	jr	0x8(x5)
 	j       __start
-	.rept   CONFIG_VECTOR_TABLE_SIZE
 	.word	_isr_wrapper
-	.endr
 
 SECTION_FUNC(vectors, __start)
-	li 	a0, 0xf
+	li 	a0, 0xe
 	csrw	mtvec, a0
 	j	__initialize


### PR DESCRIPTION
Currently, all SoC based on Qingke v4 use a big vector table, with the same entry duplicated 104 times.
Use an unified entry for the vector table by not writing the bit 0 of mtvec.

This allows to save 408 bytes of ROM.

Unfortunately, I don't think this commit can work for the Qingke V2, as the vector table base address needs to be 1KB aligned, but I don't have one to test with.