### PR TITLE
add FMC/PSRAM support for stm32f469i-disco board

### DIFF
--- a/boards/st/stm32f469i_disco/stm32f469i_disco.dts
+++ b/boards/st/stm32f469i_disco/stm32f469i_disco.dts
@@ -22,6 +22,13 @@
 		zephyr,ccm = &ccm0;
 	};
 
+	sdram1: sdram@c0000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		device_type = "memory";
+		reg = <0xc0000000 DT_SIZE_M(16)>;
+		zephyr,memory-region = "SDRAM1";
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -143,4 +150,51 @@ zephyr_udc0: &usbotg_fs {
 	pinctrl-names = "default";
 	cd-gpios = <&gpiog 2 GPIO_ACTIVE_LOW>;
 	disk-name = "SD";
+};
+
+&fmc {
+	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1 &fmc_nbl2_pi4 &fmc_nbl3_pi5
+		     &fmc_sdclk_pg8 &fmc_sdnwe_pc0 &fmc_sdcke0_ph2
+		     &fmc_sdne0_ph3 &fmc_sdnras_pf11 &fmc_sdncas_pg15
+		     &fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
+		     &fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
+		     &fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1 &fmc_a12_pg2
+			 &fmc_a14_pg4 &fmc_a15_pg5
+		     &fmc_d0_pd14 &fmc_d1_pd15
+		     &fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
+		     &fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
+		     &fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
+		     &fmc_d15_pd10 &fmc_d16_ph8 &fmc_d17_ph9 &fmc_d18_ph10
+			 &fmc_d19_ph11 &fmc_d20_ph12 &fmc_d21_ph13 &fmc_d22_ph14
+			 &fmc_d23_ph15 &fmc_d24_pi0 &fmc_d25_pi1 &fmc_d26_pi2
+			 &fmc_d27_pi3 &fmc_d28_pi6 &fmc_d29_pi7 &fmc_d30_pi9
+			 &fmc_d31_pi10>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sdram {
+		compatible = "st,stm32-fmc-sdram";
+		status = "okay";
+		power-up-delay = <100>;
+		num-auto-refresh = <8>;
+		mode-register = <0x230>;
+		/*
+		 * Auto refresh command shall be issued every 15.625 us
+		 * and is calculated as ((15.625 * SDRAM_CLK_MHZ) - 20)
+		 * Note: SDRAM_CLK_MHZ = HCLK_MHZ / 2
+		 */
+		refresh-rate = <1292>;
+		bank@0 {
+			reg = <0>;
+			st,sdram-control = <STM32_FMC_SDRAM_NC_8
+						STM32_FMC_SDRAM_NR_12
+						STM32_FMC_SDRAM_MWID_32
+						STM32_FMC_SDRAM_NB_4
+						STM32_FMC_SDRAM_CAS_3
+						STM32_FMC_SDRAM_SDCLK_PERIOD_2
+						STM32_FMC_SDRAM_RBURST_ENABLE
+						STM32_FMC_SDRAM_RPIPE_0>;
+			st,sdram-timing = <2 6 4 6 2 2 2>;
+		};
+	};
 };

--- a/samples/drivers/memc/boards/stm32f469i_disco.overlay
+++ b/samples/drivers/memc/boards/stm32f469i_disco.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright Philippe Peurichard <p.peurichard@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		sram-ext = &sdram1;
+	};
+};

--- a/samples/drivers/memc/src/main.c
+++ b/samples/drivers/memc/src/main.c
@@ -28,6 +28,10 @@
 #define mspi_get_xip_address(controller) DT_REG_ADDR_BY_IDX(controller, 1)
 #define MEMC_BASE (void *)(mspi_get_xip_address(MSPI_BUS))
 #define MEMC_SIZE (DT_PROP(MEMC_DEV, size) / 8)
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_fmc_sdram)
+#define MEMC_DEV  DT_ALIAS(sram_ext)
+#define MEMC_BASE DT_REG_ADDR(MEMC_DEV)
+#define MEMC_SIZE DT_REG_SIZE(MEMC_DEV)
 #else
 #error At least one driver should be selected!
 #endif


### PR DESCRIPTION
On stm32f469i-disco board there is a 16MBytes PSRAM connected to STM32F4 SoC using FMC peripheral
This PR enables FMC peripheral and SDRAM on this board.
It also adds support of this board in samples/drivers/memc