### PR TITLE
tests: spi_loopback: Add delay props to RT series

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1010_evk.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1015_evk.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1020_evk.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1024_evk.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1040_evk.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1060_evk_mimxrt1062_qspi_C.overlay
@@ -16,4 +16,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1064_evk.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm4_B.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_A.overlay
@@ -19,4 +19,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1170_evk_mimxrt1176_cm7_B.overlay
@@ -15,4 +15,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -23,4 +23,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -16,6 +16,9 @@
 
 &ocram1 {
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };
 
 &lpspi3 {


### PR DESCRIPTION
RT series have LPSPI data input setup and hold requirements and CS lead/lag requirements not being met on the current configuration for this test, causing flaky data transfer on CPHA 0 and 2 tests. Fix by adding delay properties to test configuration.

Fixes #90767