### PR TITLE
doc: bindings: auxdisplay: add supported series

### DIFF
--- a/dts/bindings/auxdisplay/noritake,itron.yaml
+++ b/dts/bindings/auxdisplay/noritake,itron.yaml
@@ -4,7 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-description: Noritake Itron VFD
+title: Noritake Itron VFD module
+
+description: |
+    Noritake Itron VFD character display module
+    from series CU-TE, CU-Y, GU-3000, GU-7000
+    and GU-D.
+
+    Example references:
+    GU280X16G-7000
+    CU20029-TE200K
+    CU24043-Y100
+    GU128X32D-D903S
 
 compatible: "noritake,itron"
 


### PR DESCRIPTION
Add details on series supported by Noritake Itron driver. Upon reading datasheets, series CU-TE and CU-Y have commands matching the driver, whereas series CU-U, CU-TW, and GU-* use different command sets.