### PR TITLE
fs: zms: Add FLASH_MAP dependency

### DIFF
--- a/subsys/fs/zms/Kconfig
+++ b/subsys/fs/zms/Kconfig
@@ -7,6 +7,7 @@
 
 config ZMS
 	bool "Zephyr Memory Storage"
+	depends on FLASH_MAP
 	select CRC
 	help
 	  Enable Zephyr Memory Storage, which is a key-value storage system designed to work with


### PR DESCRIPTION
ZMS does not work without this and gives compilation errors, fix this by adding the correct dependency