### PR TITLE
Bluetooth: host: fix bluetooth Kconfig issue in BT_DEVICE_NAME

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -873,6 +873,7 @@ config BT_DEVICE_NAME_MAX
 
 config BT_DEVICE_NAME
 	string "Bluetooth device name"
+	depends on !BT_DEVICE_NAME_DYNAMIC
 	default "Zephyr"
 	help
 	  Bluetooth device name. Name can be up to 248 bytes long (excluding


### PR DESCRIPTION

BT_DEVICE_NAME and BT_DEVICE_NAME_DYNAMIC should be mutually exclusive. This commit only allows BT_DEVICE_NAME to be set if BT_DEVICE_NAME_DYNAMIC is not set. Fixes zephyrproject-rtos/zephyr#93769