### PR TITLE
soc: silabs: Add RAIL Multiprotocol support

### DIFF
--- a/modules/hal_silabs/gecko/CMakeLists.txt
+++ b/modules/hal_silabs/gecko/CMakeLists.txt
@@ -50,8 +50,11 @@ if(${CONFIG_SOC_GECKO_HAS_RADIO})
 
     # prebuilt libs
     if(CONFIG_SILABS_GECKO_RAIL_MULTIPROTOCOL)
+      zephyr_compile_definitions(SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT=1)
       add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
+
     else()
+      zephyr_compile_definitions(SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT=0)
       add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
     endif()
 

--- a/modules/hal_silabs/gecko/CMakeLists.txt
+++ b/modules/hal_silabs/gecko/CMakeLists.txt
@@ -49,7 +49,11 @@ if(${CONFIG_SOC_GECKO_HAS_RADIO})
     zephyr_library_sources(${RADIO_DIR}/rail_lib/plugin/pa-conversions/pa_curves_efr32.c)
 
     # prebuilt libs
-    add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
+    if(CONFIG_SILABS_GECKO_RAIL_MULTIPROTOCOL)
+      add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
+    else()
+      add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_efr32xg${GECKO_SERIES_NUMBER}_gcc_release.a)
+    endif()
 
     if(CONFIG_SOC_GECKO_CUSTOM_RADIO_PHY)
       zephyr_include_directories(

--- a/modules/hal_silabs/gecko/CMakeLists.txt
+++ b/modules/hal_silabs/gecko/CMakeLists.txt
@@ -11,7 +11,7 @@ set(EMLIB_DIR ${ZEPHYR_HAL_SILABS_MODULE_DIR}/gecko/emlib)
 set(COMMON_DIR ${ZEPHYR_HAL_SILABS_MODULE_DIR}/gecko/common)
 set(DEVICE_DIR ${ZEPHYR_HAL_SILABS_MODULE_DIR}/gecko/Device)
 set(RADIO_DIR ${ZEPHYR_HAL_SILABS_MODULE_DIR}/gecko/platform/radio)
-set(BLOBS_DIR ${ZEPHYR_HAL_SILABS_MODULE_DIR/zephyr/blobs})
+set(BLOBS_DIR ${ZEPHYR_HAL_SILABS_MODULE_DIR}/zephyr/blobs/gecko)
 
 # Translate the SoC name and part number into the gecko device and cpu name
 # respectively.

--- a/modules/hal_silabs/gecko/Kconfig
+++ b/modules/hal_silabs/gecko/Kconfig
@@ -1,0 +1,15 @@
+# Copyright The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+menu "Gecko SDK configuration"
+	depends on HAS_SILABS_GECKO
+
+config SILABS_GECKO_RAIL_MULTIPROTOCOL
+	bool "Use RAIL Multiprotocol library"
+	depends on SOC_GECKO_USE_RAIL
+	help
+	  Enable the Silicon Labs RAIL multiprotocol library, which provides
+	  coexistence and arbitration between multiple wireless protocols (for
+	  example, Bluetooth LE and a proprietary 2.4 GHz stack) on Gecko SoCs.
+
+endmenu

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -103,11 +103,20 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
 
     if(CONFIG_SILABS_DEVICE_IS_MODULE)
       # RAIL lib and config for modules
-      add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg${SILABS_DEVICE_FAMILY_NUMBER}_gcc_release.a)
+      if(CONFIG_SILABS_SISDK_RAIL_MULTIPROTOCOL)
+        add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_module_efr32xg${SILABS_DEVICE_FAMILY_NUMBER}_gcc_release.a)
+      else()
+        add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_module_efr32xg${SILABS_DEVICE_FAMILY_NUMBER}_gcc_release.a)
+      endif()
+
       add_prebuilt_library(librail_config platform/radio/rail_lib/autogen/librail_release/librail_config_${CONFIG_SOC}_gcc.a)
     else()
       # generic RAIL lib for SoCs
-      add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_efr32xg${SILABS_DEVICE_FAMILY_NUMBER}_gcc_release.a)
+      if(CONFIG_SILABS_SISDK_RAIL_MULTIPROTOCOL)
+        add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg${SILABS_DEVICE_FAMILY_NUMBER}_gcc_release.a)
+      else()
+        add_prebuilt_library(librail platform/radio/rail_lib/autogen/librail_release/librail_efr32xg${SILABS_DEVICE_FAMILY_NUMBER}_gcc_release.a)
+      endif()
     endif()
 
     zephyr_include_directories_ifdef(CONFIG_SOC_GECKO_CUSTOM_RADIO_PHY

--- a/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
+++ b/modules/hal_silabs/simplicity_sdk/CMakeLists.txt
@@ -101,6 +101,12 @@ if(CONFIG_SOC_GECKO_HAS_RADIO)
     endif()
     zephyr_library_sources(${RADIO_DIR}/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c)
 
+    if(CONFIG_SILABS_SISDK_RAIL_MULTIPROTOCOL)
+      zephyr_compile_definitions(SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT=1)
+    else()
+      zephyr_compile_definitions(SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT=0)
+    endif()
+
     if(CONFIG_SILABS_DEVICE_IS_MODULE)
       # RAIL lib and config for modules
       if(CONFIG_SILABS_SISDK_RAIL_MULTIPROTOCOL)

--- a/modules/hal_silabs/simplicity_sdk/Kconfig
+++ b/modules/hal_silabs/simplicity_sdk/Kconfig
@@ -34,4 +34,12 @@ config RAIL_PA_ENABLE_CALIBRATION
 	  calibration. This option is enabled by default, and is recommended for all
 	  Series 2 devices.
 
+config SILABS_SISDK_RAIL_MULTIPROTOCOL
+	bool "Use RAIL Multiprotocol library"
+	depends on SOC_GECKO_USE_RAIL
+	help
+	  Enable the Silicon Labs RAIL multiprotocol library, which provides
+	  coexistence and arbitration between multiple wireless protocols (for
+	  example, Bluetooth LE and a proprietary 2.4 GHz stack) on Gecko SoCs.
+
 endmenu

--- a/modules/hal_silabs/simplicity_sdk/config/ll/sl_btctrl_config.h
+++ b/modules/hal_silabs/simplicity_sdk/config/ll/sl_btctrl_config.h
@@ -138,7 +138,6 @@
 #undef SL_CATALOG_BLUETOOTH_FEATURE_USER_POWER_CONTROL_PRESENT
 #undef SL_CATALOG_KERNEL_PRESENT /* Only relevant in the SiSDK RTOS adaptation */
 #undef SL_CATALOG_RAIL_UTIL_COEX_PRESENT
-#undef SL_RAIL_LIB_MULTIPROTOCOL_SUPPORT
 
 /* Maps the controller configuration options from Kconfig to Silabs defines */
 #define SL_BT_CONTROLLER_BUFFER_MEMORY      CONFIG_BT_SILABS_EFR32_BUFFER_MEMORY

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 95e957408ddd967ac4b69dc32096bd3793abb76c
+      revision: 295caf37909d2ff01688b1c4bd34c9b3584e8333
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This PR adds support for the Silicon Labs RAIL Multiprotocol library, which provides coexistence and arbitration between multiple wireless protocols (for example, Bluetooth LE and a proprietary 2.4 GHz stack) on Gecko SoCs.

Depends on https://github.com/zephyrproject-rtos/hal_silabs/pull/126