### PR TITLE
arch: xtensa: Fix arch_is_in_isr() race condition

### DIFF
--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -278,7 +278,25 @@ static ALWAYS_INLINE void arch_cohere_stacks(struct k_thread *old_thread,
 
 static inline bool arch_is_in_isr(void)
 {
-	return arch_curr_cpu()->nested != 0U;
+	uint32_t nested;
+
+#if defined(CONFIG_SMP)
+	/*
+	 * Lock interrupts on SMP to ensure that the caller does not migrate
+	 * to another CPU before we get to read the nested field.
+	 */
+	unsigned int key;
+
+	key = arch_irq_lock();
+#endif
+
+	nested = arch_curr_cpu()->nested;
+
+#if defined(CONFIG_SMP)
+	arch_irq_unlock(key);
+#endif
+
+	return nested != 0U;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes a flaw in the the Xtensa implementation of arch_is_in_isr() that could manifest on SMP systems. If the reading of the current CPU's nested interrupt count is not fully atomic on an SMP system, then an ill-timed context switch could occur leaving the caller reading the nested interrupt of a different CPU.

Fixes #92237.

Other architectures that support SMP have yet to be double checked for this implementation error. This fix should be back-ported to relevant versions.