### PR TITLE
west: Update silabs hal for both cmsis-6 and cmsis-5 compatibility

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 190a144a16bed9a938a94543ed5bbc70c0552e0f
+      revision: 95e957408ddd967ac4b69dc32096bd3793abb76c
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Move the manifest rev to make this module compatible with either cmsis-5 or cmsis-6 by adapting to the CMSIS version when accessing NVIC and SCB registers.