### PR TITLE
boards: adi: Enable usb on additional max32690-based boards

### DIFF
--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -331,3 +331,7 @@ pmod_spi: &spi4 {
 		writeoc = "PP_1_1_4";
 	};
 };
+
+zephyr_udc0: &usbhs {
+	status = "okay";
+};

--- a/boards/adi/apard32690/apard32690_max32690_m4.yaml
+++ b/boards/adi/apard32690/apard32690_max32690_m4.yaml
@@ -16,6 +16,7 @@ supported:
   - serial
   - spi
   - trng
+  - usbd
   - counter
   - w1
   - memc

--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4.dts
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4.dts
@@ -140,3 +140,7 @@ feather_spi: &spi0 {
 	pinctrl-0 = <&spi0b_mosi_p2_28 &spi0b_miso_p2_27 &spi0b_sck_p2_29>;
 	pinctrl-names = "default";
 };
+
+zephyr_udc0: &usbhs {
+	status = "okay";
+};

--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4.yaml
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4.yaml
@@ -15,5 +15,6 @@ supported:
   - feather_i2c
   - feather_spi
   - flash
+  - usbd
 ram: 1024
 flash: 3072


### PR DESCRIPTION
USB support was previously introduced for the max32 soc family on the max32690evkit board; this change extends that support to two additional boards with the same soc: apard32690 and max32690fthr.

cc: @hfakkiz