### PR TITLE
llext: add a section reordering script

### DIFF
--- a/cmake/linker/ld/linker_flags.cmake
+++ b/cmake/linker/ld/linker_flags.cmake
@@ -7,6 +7,9 @@ check_set_linker_property(TARGET linker PROPERTY base
                           ${LINKERFLAGPREFIX},--build-id=none
 )
 
+# Used to retrieve individual flag
+set_property(TARGET linker PROPERTY gc_sections "${LINKERFLAGPREFIX},--gc-sections")
+
 check_set_linker_property(TARGET linker PROPERTY baremetal
                           -nostdlib
                           -static
@@ -39,6 +42,8 @@ if("${GNULD_VERSION_STRING}" VERSION_GREATER_EQUAL 2.37)
 else()
   set_property(TARGET linker PROPERTY no_position_independent)
 endif()
+
+set_property(TARGET linker PROPERTY no_gc_sections "${LINKERFLAGPREFIX},--no-gc-sections")
 
 set_property(TARGET linker PROPERTY partial_linking "-r")
 

--- a/cmake/linker/xt-ld/linker_flags.cmake
+++ b/cmake/linker/xt-ld/linker_flags.cmake
@@ -7,6 +7,9 @@ check_set_linker_property(TARGET linker PROPERTY base
                           ${LINKERFLAGPREFIX},--build-id=none
 )
 
+# Used to retrieve individual flag
+set_property(TARGET linker PROPERTY gc_sections "${LINKERFLAGPREFIX},--gc-sections")
+
 if(NOT CONFIG_NATIVE_LIBRARY AND NOT CONFIG_EXTERNAL_MODULE_LIBCPP)
   set_property(TARGET linker PROPERTY cpp_base -lstdc++)
 endif()
@@ -25,6 +28,8 @@ check_set_linker_property(TARGET linker PROPERTY orphan_warning
 check_set_linker_property(TARGET linker PROPERTY orphan_error
                           ${LINKERFLAGPREFIX},--orphan-handling=error
 )
+
+set_property(TARGET linker PROPERTY no_gc_sections "${LINKERFLAGPREFIX},--no-gc-sections")
 
 set_property(TARGET linker PROPERTY partial_linking "-r")
 

--- a/subsys/llext/llext_reorder_sections.ld
+++ b/subsys/llext/llext_reorder_sections.ld
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+SECTIONS {
+	.pinned_text : {
+		*(.pinned_text .pinned_text.*)
+	}
+
+	.text : {
+		*(.text .text.*)
+	}
+
+	.bss : {
+		*(.bss .bss.*)
+	}
+
+	.data : {
+		*(.data .data.*)
+	}
+
+	.rodata_in_data : {
+		*(.rodata_in_data .rodata_in_data.*)
+	}
+
+	.rodata : {
+		*(.rodata .rodata.*)
+	}
+}

--- a/tests/subsys/llext/src/syscalls_ext.c
+++ b/tests/subsys/llext/src/syscalls_ext.c
@@ -8,24 +8,11 @@
  * This code demonstrates syscall support.
  */
 
- /* This include directive must appear first in the file.
-  *
-  * On x86 platforms with demand paging on, Zephyr generates a
-  * .pinned_text section containing syscalls. The LLEXT loader
-  * requires .text-like sections to appear close to .text at the
-  * start of the object file, before .rodata, so they can be
-  * grouped into a contiguous text region.
-  *
-  * Including syscalls_ext.h first ensures the first instance of
-  * data to be placed in .pinned_text appears before the first instance
-  * of data for .rodata. As a result, .pinned_text will appear
-  * before .rodata.
-  */
-#include "syscalls_ext.h"
-
 #include <zephyr/llext/symbol.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/ztest_assert.h>
+
+#include "syscalls_ext.h"
 
 void test_entry(void)
 {

--- a/tests/subsys/llext/src/test_llext.c
+++ b/tests/subsys/llext/src/test_llext.c
@@ -267,8 +267,7 @@ LLEXT_LOAD_UNLOAD(hello_world,
 	.kernel_only = true
 )
 
-/* When compiled with CCAC, init_fini's sections are unfixably out of order */
-#if !defined(CONFIG_LLEXT_TYPE_ELF_SHAREDLIB) && !defined(__CCAC__)
+#if !defined(CONFIG_LLEXT_TYPE_ELF_SHAREDLIB)
 static LLEXT_CONST uint8_t init_fini_ext[] ELF_ALIGN = {
 	#include "init_fini.inc"
 };


### PR DESCRIPTION
UPDATE: This PR has replaced the custom Python script for reordering with a linker script instead.

---

In some cases, the compiler generates objects that have sections "out of order" for the LLEXT loader, i.e. regions overlap. Reordering variable declarations, code, header includes, etc. rarely fixes the issue. This script detects if the LLEXT loader will reject an ET_REL object and reorders the sections to match LLEXT regions.

Originally included in https://github.com/zephyrproject-rtos/zephyr/pull/93627.

Below is a list of test extensions that the compiler generated with sections in an invalid order.

    syscalls for x86 platforms with MMU (can be corrected by changing header order)
    init_fini for nsim/nsim_vpx5 with arcmwdt (can't be corrected)
    All extensions on qemu_malta*
    All extensions on qemu_leon3/leon3*

*We don't support these architectures yet, and currently just build at the moment, but the extensions as-is would fail to load if we tried

A key point to note about the reordering script is that it would require users using detached sections to name the section in the form ".detached.*", because there is no other way for a Python script invoked from CMake to detect a section is detached without it and forego reordering.

Another key point to note: I looked into the suggestion of replacing this script with an extra step calling the linker with a linker script. I mistakenly thought this wasn't possible with ET_REL objects, but it is, theoretically. For example:

```
$ readelf -S syscalls.llext.bak 
There are 14 section headers, starting at offset 0x430:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        00000000 000034 0000f2 00  AX  0   0  1
  [ 2] .rel.text         REL             00000000 00033c 000078 08   I 11   1  4
  [ 3] .data             PROGBITS        00000000 000126 000000 00  WA  0   0  1
  [ 4] .bss              NOBITS          00000000 000128 000008 00  WA  0   0  4
  [ 5] .rodata           PROGBITS        00000000 000128 0000ef 00   A  0   0  4
  [ 6] .pinned_text      PROGBITS        00000000 000217 000012 00  AX  0   0  1
  [ 7] .rel.pinned_text  REL             00000000 0003b4 000008 08   I 11   6  4
  [ 8] .exported_sym     PROGBITS        00000000 00022c 000008 00   A  0   0  4
  [ 9] .rel.exported_sym REL             00000000 0003bc 000010 08   I 11   8  4
  [10] .comment          PROGBITS        00000000 000234 000021 01  MS  0   0  1
  [11] .symtab           SYMTAB          00000000 000258 000090 10     12   3  4
  [12] .strtab           STRTAB          00000000 0002e8 000052 00      0   0  1
  [13] .shstrtab         STRTAB          00000000 0003cc 000064 00      0   0  1
...
...

$ cat link.ld 
SECTIONS {
        .pinned_text : {
                *(.pinned_text .pinned_text.*)
        }

        .text : {
                *(.text .text.*)
        }
}

$ /home/laurenmu/zephyr-sdk-0.17.0/x86_64-zephyr-elf/bin/x86_64-zephyr-elf-gcc -m32 -r -T link.ld syscalls.llex
t.bak -o syscalls.llext.reorder

$ readelf -S syscalls.llext.reorder 
There are 14 section headers, starting at offset 0x47c:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .pinned_text      PROGBITS        00000000 000034 000012 00  AX  0   0  1
  [ 2] .rel.pinned_text  REL             00000000 000388 000008 08   I 11   1  4
  [ 3] .text             PROGBITS        00000012 000046 0000f2 00  AX  0   0  1
  [ 4] .rel.text         REL             00000000 000390 000078 08   I 11   3  4
  [ 5] .rodata           PROGBITS        00000000 000138 0000ef 00   A  0   0  4
  [ 6] .exported_sym     PROGBITS        00000000 000228 000008 00   A  0   0  4
  [ 7] .rel.exported_sym REL             00000000 000408 000010 08   I 11   6  4
  [ 8] .data             PROGBITS        00000000 000230 000000 00  WA  0   0  1
  [ 9] .bss              NOBITS          00000000 000230 000008 00  WA  0   0  4
  [10] .comment          PROGBITS        00000000 000230 000021 01  MS  0   0  1
  [11] .symtab           SYMTAB          00000000 000254 0000e0 10     12   8  4
  [12] .strtab           STRTAB          00000000 000334 000052 00      0   0  1
  [13] .shstrtab         STRTAB          00000000 000418 000064 00      0   0  1
...
```

One issue is that various architectures, toolchains, Zephyr features, and users may generate custom sections with names that don't match the usual linker section names. The second is that in relocatable mode (-r), the linker merges sections of the same name. For example, I can't match the individual .text.subname sections to order them without combining them into one section. This might be undesirable. I don't know. 

I will try implementing a linker script that works with x86's MMU's pinned_text at least, maybe fix NSIM ARCMWDT's init_fini issue too once the other PR (link above) is merged. I'm submitting this PR now mostly to run the script through SonarQube again.