### PR TITLE
 arch: Update arch_is_in_isr() SMP implementations

### DIFF
--- a/arch/arm/include/cortex_a_r/exception.h
+++ b/arch/arm/include/cortex_a_r/exception.h
@@ -32,15 +32,24 @@ extern "C" {
 extern volatile irq_offload_routine_t offload_routine;
 #endif
 
-/* Check the CPSR mode bits to see if we are in IRQ or FIQ mode */
 static ALWAYS_INLINE bool arch_is_in_isr(void)
 {
-	return (arch_curr_cpu()->nested != 0U);
+	uint32_t nested;
+#ifdef CONFIG_SMP
+	unsigned int key;
+
+	key = arch_irq_lock();
+#endif
+	nested = arch_curr_cpu()->nested;
+#ifdef CONFIG_SMP
+	arch_irq_unlock(key);
+#endif
+	return nested != 0U;
 }
 
 static ALWAYS_INLINE bool arch_is_in_nested_exception(const struct arch_esf *esf)
 {
-	return (arch_curr_cpu()->arch.exc_depth > 1U) ? (true) : (false);
+	return (_current_cpu->arch.exc_depth > 1U) ? (true) : (false);
 }
 
 /**

--- a/arch/arm64/include/exception.h
+++ b/arch/arm64/include/exception.h
@@ -28,7 +28,17 @@ extern "C" {
 
 static ALWAYS_INLINE bool arch_is_in_isr(void)
 {
-	return arch_curr_cpu()->nested != 0U;
+	uint32_t nested;
+#ifdef CONFIG_SMP
+	unsigned int key;
+
+	key = arch_irq_lock();
+#endif
+	nested = arch_curr_cpu()->nested;
+#ifdef CONFIG_SMP
+	arch_irq_unlock(key);
+#endif
+	return nested != 0U;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Updates the implementation of arch_is_in_isr() for arm/cortex_a_r and arm64 architectures to properly handle SMP.

Fixes a flaw in implementations of arch_is_in_isr() that could manifest on SMP systems. If the reading of the current CPU's nested interrupt count is not fully atomic on an SMP system, then an ill-timed context switch could occur leaving the caller reading the nested interrupt count of a different CPU.

The other architectures that support SMP already handle arch_is_in_isr() properly.