### PR TITLE
Bluetooth: Classic: SCO: Get SCO conn info

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -895,6 +895,12 @@ struct bt_conn_br_info {
 	const bt_addr_t *dst; /**< Destination (Remote) BR/EDR address */
 };
 
+/** SCO Connection Info Structure */
+struct bt_conn_sco_info {
+	uint8_t link_type; /**< SCO link type */
+	uint8_t air_mode;  /**< SCO air mode (codec type) */
+};
+
 enum {
 	BT_CONN_ROLE_CENTRAL = 0,
 	BT_CONN_ROLE_PERIPHERAL = 1,
@@ -961,6 +967,8 @@ struct bt_conn_info {
 		struct bt_conn_le_info le;
 		/** BR/EDR Connection specific Info. */
 		struct bt_conn_br_info br;
+		/** SCO Connection specific Info. */
+		struct bt_conn_sco_info sco;
 	};
 	/** Connection state. */
 	enum bt_conn_state state;

--- a/subsys/bluetooth/host/classic/br.c
+++ b/subsys/bluetooth/host/classic/br.c
@@ -211,6 +211,12 @@ void bt_hci_synchronous_conn_complete(struct net_buf *buf)
 	}
 
 	sco_conn->handle = handle;
+	sco_conn->sco.air_mode = evt->air_mode;
+
+	if (sco_conn->sco.link_type != evt->link_type) {
+		LOG_WRN("link type mismatch %u != %u", sco_conn->sco.link_type, evt->link_type);
+		sco_conn->sco.link_type = evt->link_type;
+	}
 	bt_conn_set_state(sco_conn, BT_CONN_CONNECTED);
 	bt_conn_unref(sco_conn);
 }

--- a/subsys/bluetooth/host/classic/shell/hfp.c
+++ b/subsys/bluetooth/host/classic/shell/hfp.c
@@ -86,6 +86,9 @@ static void hf_disconnected(struct bt_hfp_hf *hf)
 
 static void hf_sco_connected(struct bt_hfp_hf *hf, struct bt_conn *sco_conn)
 {
+	struct bt_conn_info info;
+	uint16_t handle;
+
 	bt_shell_print("HF SCO connected %p", sco_conn);
 
 	if (hf_sco_conn != NULL) {
@@ -94,6 +97,19 @@ static void hf_sco_connected(struct bt_hfp_hf *hf, struct bt_conn *sco_conn)
 	}
 
 	hf_sco_conn = bt_conn_ref(sco_conn);
+	if (bt_hci_get_conn_handle(sco_conn, &handle) < 0) {
+		bt_shell_warn("Failed to get SCO connection handle");
+		return;
+	}
+
+	if (bt_conn_get_info(sco_conn, &info) < 0) {
+		bt_shell_warn("Failed to get SCO connection info");
+		return;
+	}
+	bt_shell_print("HF SCO info:");
+	bt_shell_print("  SCO handle 0x%04X", handle);
+	bt_shell_print("  SCO air mode %u", info.sco.air_mode);
+	bt_shell_print("  SCO link type %u", info.sco.link_type);
 }
 
 static void hf_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)
@@ -1064,6 +1080,9 @@ static void ag_disconnected(struct bt_hfp_ag *ag)
 
 static void ag_sco_connected(struct bt_hfp_ag *ag, struct bt_conn *sco_conn)
 {
+	struct bt_conn_info info;
+	uint16_t handle;
+
 	bt_shell_print("AG SCO connected %p", sco_conn);
 
 	if (hfp_ag_sco_conn != NULL) {
@@ -1072,6 +1091,19 @@ static void ag_sco_connected(struct bt_hfp_ag *ag, struct bt_conn *sco_conn)
 	}
 
 	hfp_ag_sco_conn = bt_conn_ref(sco_conn);
+	if (bt_hci_get_conn_handle(sco_conn, &handle) < 0) {
+		bt_shell_warn("Failed to get SCO connection handle");
+		return;
+	}
+
+	if (bt_conn_get_info(sco_conn, &info) < 0) {
+		bt_shell_warn("Failed to get SCO connection info");
+		return;
+	}
+	bt_shell_print("AG SCO info:");
+	bt_shell_print("  SCO handle 0x%04X", handle);
+	bt_shell_print("  SCO air mode %u", info.sco.air_mode);
+	bt_shell_print("  SCO link type %u", info.sco.link_type);
 }
 
 static void ag_sco_disconnected(struct bt_conn *sco_conn, uint8_t reason)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2876,6 +2876,10 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 	case BT_CONN_TYPE_BR:
 		info->br.dst = &conn->br.dst;
 		return 0;
+	case BT_CONN_TYPE_SCO:
+		info->sco.air_mode = conn->sco.air_mode;
+		info->sco.link_type = conn->sco.link_type;
+		return 0;
 #endif
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -167,6 +167,8 @@ struct bt_conn_sco {
 	uint16_t                pkt_type;
 	uint8_t                 dev_class[3];
 	uint8_t                 link_type;
+	/* Reference to BT_HCI_CODING_FORMAT_* */
+	uint8_t                 air_mode;
 };
 
 struct bt_conn_iso {


### PR DESCRIPTION
Save the air_mode to SCO connect object.

Add a structure `struct bt_conn_sco_info` to return the SCO conn info.

Return SCO info through `struct bt_conn_sco_info` when calling the function `bt_conn_get_info()`.