### PR TITLE
tests: app_dev: ram_context_for_isr: update IRQ configuration

### DIFF
--- a/tests/application_development/ram_context_for_isr/include/fake_driver.h
+++ b/tests/application_development/ram_context_for_isr/include/fake_driver.h
@@ -11,6 +11,25 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_BOARD_QEMU_CORTEX_M3
+
+#define TEST_IRQ_NUM  42
+#define TEST_IRQ_PRIO 1
+
+#elif defined(CONFIG_GIC)
+/*
+ * For the platforms that use the ARM GIC, use the SGI (software generated
+ * interrupt) line 14 for testing.
+ */
+#define TEST_IRQ_NUM  14
+#define TEST_IRQ_PRIO IRQ_DEFAULT_PRIORITY
+
+#else
+/* For all the other platforms, use the last available IRQ line for testing. */
+#define TEST_IRQ_NUM  (CONFIG_NUM_IRQS - 1)
+#define TEST_IRQ_PRIO 1
+#endif
+
 typedef void (*fake_driver_irq_callback_t)(const struct device *dev, void *user_data);
 
 struct fake_driver_config {

--- a/tests/application_development/ram_context_for_isr/src/fake_driver.c
+++ b/tests/application_development/ram_context_for_isr/src/fake_driver.c
@@ -10,9 +10,6 @@
 
 #define DT_DRV_COMPAT fakedriver
 
-#define TEST_IRQ_NUM  27
-#define TEST_IRQ_PRIO 4
-
 static void fake_driver_isr(const void *arg)
 {
 	const struct device *dev = (const struct device *)arg;

--- a/tests/application_development/ram_context_for_isr/src/main.c
+++ b/tests/application_development/ram_context_for_isr/src/main.c
@@ -72,7 +72,7 @@ ZTEST(ram_context_for_isr, test_fake_driver_in_ram)
 	api->register_irq_callback(dev, test_irq_callback, NULL);
 	test_flag = false;
 
-	NVIC_SetPendingIRQ(27);
+	NVIC_SetPendingIRQ(TEST_IRQ_NUM);
 
 	k_busy_wait(1000);
 


### PR DESCRIPTION
This PR modifies the IRQ number and priority definitions in the fake_driver.c file. The new condition is based on the nested_irq test file.
It breaks the CI here https://github.com/zephyrproject-rtos/zephyr/actions/runs/16631653812/job/47095435938?pr=93285.