### PR TITLE
manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -328,7 +328,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 8b6001d6bdd9e2c8bb858fdb26f696f6d5f73db5
+      revision: 40403f5f2805cca210d2a47c8717d89c4e816cda
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 787eea1a3c8dd13c86214e204a919e6f9bcebf91


### PR DESCRIPTION
Update the HW models module to:
40403f5f2805cca210d2a47c8717d89c4e816cda

Including the following:
40403f5 TIMER: Bugfix: Be sure to not use more than BITMODE bits
e1a976c RTC: Bugfix: Be sure to not use more than 24bits of CC like the HW 
bfb5309 doc: Add nRF54LM20 to table of supported HW