### PR TITLE
net: sockets: ensure socket obj core is only linked once

### DIFF
--- a/subsys/net/lib/sockets/socket_obj_core.c
+++ b/subsys/net/lib/sockets/socket_obj_core.c
@@ -66,15 +66,15 @@ static void sock_obj_core_init_and_link(struct sock_obj *sock)
 		type_init_done = true;
 	}
 
-	k_obj_core_init_and_link(K_OBJ_CORE(sock), &sock_obj_type);
-	k_obj_core_stats_register(K_OBJ_CORE(sock), &sock->stats,
-				  sizeof(struct sock_obj_type_raw_stats));
-
 	/* If the socket was closed and we re-opened it again, then clear
 	 * the statistics.
 	 */
 	if (sock->init_done) {
 		k_obj_core_stats_reset(K_OBJ_CORE(sock));
+	} else {
+		k_obj_core_init_and_link(K_OBJ_CORE(sock), &sock_obj_type);
+		k_obj_core_stats_register(K_OBJ_CORE(sock), &sock->stats,
+					  sizeof(struct sock_obj_type_raw_stats));
 	}
 
 	sock->init_done = true;


### PR DESCRIPTION
Repeated linking of socket object cores can corrupt the linked list.

Fixes: #93587