### PR TITLE
STM32: remove "U" suffix from `clocks` in Device Tree

### DIFF
--- a/boards/fanke/fk723m1_zgt6/fk723m1_zgt6.dts
+++ b/boards/fanke/fk723m1_zgt6/fk723m1_zgt6.dts
@@ -120,7 +120,7 @@ zephyr_udc0: &usbotg_hs {
 	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9 &sdmmc1_d2_pc10
 		&sdmmc1_d3_pc11 &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK(AHB3, 16U)>,
+	clocks = <&rcc STM32_CLOCK(AHB3, 16)>,
 		<&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
 	disk-name = "SD";
 	status = "okay";

--- a/boards/makerbase/mks_canable_v20/mks_canable_v20.dts
+++ b/boards/makerbase/mks_canable_v20/mks_canable_v20.dts
@@ -73,7 +73,7 @@ stm32_lp_tick_source: &lptim1 {
 zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 23)>,
 		 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 	status = "okay";
 };
@@ -81,7 +81,7 @@ zephyr_udc0: &usb {
 &fdcan1 {
 	pinctrl-0 = <&fdcan1_rx_pb8 &fdcan1_tx_pb9>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK(APB1, 25U)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 25)>,
 		 <&rcc STM32_SRC_PLL_Q FDCAN_SEL(1)>;
 	status = "okay";
 };

--- a/boards/st/nucleo_c071rb/nucleo_c071rb.dts
+++ b/boards/st/nucleo_c071rb/nucleo_c071rb.dts
@@ -150,7 +150,7 @@
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1 &adc1_in4_pa4>;
 	pinctrl-names = "default";
 	st,adc-clock-source = "ASYNC";
-	clocks = <&rcc STM32_CLOCK(APB1_2, 20U)>,
+	clocks = <&rcc STM32_CLOCK(APB1_2, 20)>,
 		 <&rcc STM32_SRC_HSI ADC_SEL(2)>;
 	st,adc-prescaler = <4>;
 	status = "okay";

--- a/boards/st/nucleo_l476rg/nucleo_l476rg.dts
+++ b/boards/st/nucleo_l476rg/nucleo_l476rg.dts
@@ -199,7 +199,7 @@ stm32_lp_tick_source: &lptim1 {
 
 &rng {
 	/* Change clock source to avoid using MSI */
-	clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+	clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 		 <&rcc STM32_SRC_PLL_Q CLK48_SEL(2)>;
 	status = "okay";
 };

--- a/boards/st/nucleo_u083rc/nucleo_u083rc.dts
+++ b/boards/st/nucleo_u083rc/nucleo_u083rc.dts
@@ -148,7 +148,7 @@
 };
 
 stm32_lp_tick_source: &lptim1 {
-	clocks = <&rcc STM32_CLOCK(APB1, 31U)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 31)>,
 		<&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";
 };
@@ -169,7 +169,7 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 &rng {
-	clocks = <&rcc STM32_CLOCK(AHB1, 18U)>,
+	clocks = <&rcc STM32_CLOCK(AHB1, 18)>,
 		<&rcc STM32_SRC_HSI48 CLK48_SEL(1)>;
 	status = "okay";
 };
@@ -179,7 +179,7 @@ stm32_lp_tick_source: &lptim1 {
 };
 
 zephyr_udc0: &usb {
-	clocks = <&rcc STM32_CLOCK(APB1, 13U)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 13)>,
 		 <&rcc STM32_SRC_HSI48 CLK48_SEL(1)>;
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
@@ -187,7 +187,7 @@ zephyr_udc0: &usb {
 };
 
 &rtc {
-	clocks = <&rcc STM32_CLOCK(APB1, 10U)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 10)>,
 		 <&rcc STM32_SRC_LSE RTC_SEL(1)>;
 	status = "okay";
 };

--- a/boards/st/sensortile_box/sensortile_box.dts
+++ b/boards/st/sensortile_box/sensortile_box.dts
@@ -252,7 +252,7 @@ zephyr_udc0: &usbotg_fs {
 
 &rng {
 	/* Change clock source to avoid using MSI */
-	clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+	clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 		 <&rcc STM32_SRC_PLL_Q CLK48_SEL(2)>;
 	status = "okay";
 };

--- a/boards/st/stm32f4_disco/stm32f4_disco.dts
+++ b/boards/st/stm32f4_disco/stm32f4_disco.dts
@@ -203,7 +203,7 @@ zephyr_udc0: &usbotg_fs {
 	mck-enabled;
 	pinctrl-0 = <&i2s3_ws_pa4 &i2s3_ck_pc10 &i2s3_sd_pc12 &i2s3_mck_pc7>;
 	pinctrl-names = "default";
-	clocks = <&rcc STM32_CLOCK(APB1, 15U)>,
+	clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 		 <&rcc STM32_SRC_PLLI2S_R I2S_SEL(0)>;
 	status = "okay";
 };

--- a/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
+++ b/boards/st/stm32u5g9j_dk2/stm32u5g9j_dk2.dts
@@ -332,7 +332,7 @@ zephyr_udc0: &usbotg_hs {
 };
 
 &xspi1 {
-	clocks = <&rcc STM32_CLOCK(AHB2_2, 12U)>,
+	clocks = <&rcc STM32_CLOCK(AHB2_2, 12)>,
 			 <&rcc STM32_SRC_PLL2_Q HSPI_SEL(2)>;
 
 	pinctrl-0 = <&hspi1_dqs0_pi2 &hspi1_ncs_ph9

--- a/dts/arm/st/c0/stm32c0.dtsi
+++ b/dts/arm/st/c0/stm32c0.dtsi
@@ -155,7 +155,7 @@
 			compatible = "st,stm32-flash-controller" , "st,stm32g0-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -205,7 +205,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 0U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 0)>;
 			};
 
 			gpiob: gpio@50000400 {
@@ -213,7 +213,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 1U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 1)>;
 			};
 
 			gpioc: gpio@50000800 {
@@ -221,7 +221,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 2U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 2)>;
 			};
 
 			gpiof: gpio@50001400 {
@@ -229,7 +229,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 5U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 5)>;
 			};
 		};
 
@@ -277,7 +277,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <2 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 10)>;
 			prescaler = <32768>;
 			alarms-count = <1>;
 			alrm-exti-line = <19>;
@@ -287,7 +287,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";
 		};
@@ -301,7 +301,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 14)>;
 			resets = <&rctl STM32_RESET(APB1H, 14U)>;
 			interrupts = <27 0>;
 			status = "disabled";
@@ -310,7 +310,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -437,7 +437,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -448,7 +448,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 12)>;
 			interrupts = <25 0>;
 			status = "disabled";
 		};
@@ -456,7 +456,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 20)>;
 			interrupts = <12 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -475,7 +475,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <9 0 10 0 10 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-requests = <3>;
 			dma-offset = <0>;
 			status = "disabled";

--- a/dts/arm/st/c0/stm32c031.dtsi
+++ b/dts/arm/st/c0/stm32c031.dtsi
@@ -16,7 +16,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 3U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 3)>;
 			};
 		};
 	};

--- a/dts/arm/st/c0/stm32c071.dtsi
+++ b/dts/arm/st/c0/stm32c071.dtsi
@@ -49,7 +49,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "global";
 			status = "disabled";
@@ -74,7 +74,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 0>;
 			interrupt-names = "global";
 			status = "disabled";

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -86,7 +86,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32f1-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 4)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -135,7 +135,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 17U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 17)>;
 			};
 
 			gpiob: gpio@48000400 {
@@ -143,7 +143,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			};
 
 			gpioc: gpio@48000800 {
@@ -151,7 +151,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 19U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 19)>;
 			};
 
 			gpiod: gpio@48000c00 {
@@ -159,7 +159,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 20U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 20)>;
 			};
 
 			gpiof: gpio@48001400 {
@@ -167,14 +167,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 22U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 22)>;
 			};
 		};
 
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <27 0>;
 			status = "disabled";
@@ -186,7 +186,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>,
 				 /* I2C1 clock source should always be defined,
 				  * even for the default value
 				  */
@@ -201,7 +201,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <25 3>;
 			status = "disabled";
 		};
@@ -209,7 +209,7 @@
 		rtc: rtc@40002800 {
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			interrupts = <2 0>;
 			prescaler = <32768>;
 			alarms-count = <1>;
@@ -226,7 +226,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";
 		};
@@ -344,7 +344,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <12 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -362,7 +362,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f030X8.dtsi
+++ b/dts/arm/st/f0/stm32f030X8.dtsi
@@ -21,7 +21,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -33,7 +33,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -44,7 +44,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f030Xc.dtsi
+++ b/dts/arm/st/f0/stm32f030Xc.dtsi
@@ -29,7 +29,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -38,7 +38,7 @@
 		usart4: serial@40004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -47,7 +47,7 @@
 		usart5: serial@40005000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -56,7 +56,7 @@
 		usart6: serial@40011400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			resets = <&rctl STM32_RESET(APB2, 5U)>;
 			interrupts = <29 0>;
 			status = "disabled";

--- a/dts/arm/st/f0/stm32f042.dtsi
+++ b/dts/arm/st/f0/stm32f042.dtsi
@@ -24,7 +24,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -35,7 +35,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};
@@ -44,7 +44,7 @@
 			compatible = "st,stm32-bxcan";
 			reg = <0x40006400 0x400>;
 			interrupts = <30 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -75,7 +75,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>,
 				 <&rcc STM32_SRC_PLLCLK USB_SEL(1)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f051.dtsi
+++ b/dts/arm/st/f0/stm32f051.dtsi
@@ -13,7 +13,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -25,7 +25,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -36,7 +36,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};
@@ -74,7 +74,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/f0/stm32f070.dtsi
+++ b/dts/arm/st/f0/stm32f070.dtsi
@@ -13,7 +13,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -46,7 +46,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>,
 				 <&rcc STM32_SRC_PLLCLK USB_SEL(1)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f070Xb.dtsi
+++ b/dts/arm/st/f0/stm32f070Xb.dtsi
@@ -28,7 +28,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -37,7 +37,7 @@
 		usart4: serial@40004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -49,7 +49,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -60,7 +60,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f071.dtsi
+++ b/dts/arm/st/f0/stm32f071.dtsi
@@ -31,7 +31,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 21U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			};
 		};
 
@@ -44,7 +44,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -53,7 +53,7 @@
 		usart4: serial@40004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <29 0>;
 			status = "disabled";

--- a/dts/arm/st/f0/stm32f072.dtsi
+++ b/dts/arm/st/f0/stm32f072.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-bxcan";
 			reg = <0x40006400 0x400>;
 			interrupts = <30 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -27,7 +27,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>,
 				 <&rcc STM32_SRC_PLLCLK USB_SEL(1)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f0/stm32f091.dtsi
+++ b/dts/arm/st/f0/stm32f091.dtsi
@@ -19,7 +19,7 @@
 		usart5: serial@40005000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -28,7 +28,7 @@
 		usart6: serial@40011400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			resets = <&rctl STM32_RESET(APB2, 5U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -37,7 +37,7 @@
 		usart7: serial@40011800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 6U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 6)>;
 			resets = <&rctl STM32_RESET(APB2, 6U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -46,7 +46,7 @@
 		usart8: serial@40011c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 7)>;
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -56,7 +56,7 @@
 			compatible = "st,stm32-bxcan";
 			reg = <0x40006400 0x400>;
 			interrupts = <30 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -65,7 +65,7 @@
 			#dma-cells = <2>;
 			reg = <0x40020400 0x400>;
 			interrupts = <10 0 10 0 11 0 11 0 11 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -106,7 +106,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32f1-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 4)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -157,7 +157,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40010800 0x400>;
-				clocks = <&rcc STM32_CLOCK(APB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(APB2, 2)>;
 			};
 
 			gpiob: gpio@40010c00 {
@@ -165,7 +165,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40010c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(APB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(APB2, 3)>;
 			};
 
 			gpioc: gpio@40011000 {
@@ -173,7 +173,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011000 0x400>;
-				clocks = <&rcc STM32_CLOCK(APB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(APB2, 4)>;
 			};
 
 			gpiod: gpio@40011400 {
@@ -181,7 +181,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011400 0x400>;
-				clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+				clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			};
 
 			gpioe: gpio@40011800 {
@@ -189,14 +189,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011800 0x400>;
-				clocks = <&rcc STM32_CLOCK(APB2, 6U)>;
+				clocks = <&rcc STM32_CLOCK(APB2, 6)>;
 			};
 		};
 
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -205,7 +205,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -214,7 +214,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -226,7 +226,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -238,7 +238,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -249,7 +249,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			status = "disabled";
 		};
@@ -263,7 +263,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -359,7 +359,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
 			status = "disabled";
 		};
@@ -367,7 +367,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32f1-adc", "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -381,7 +381,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f100Xb.dtsi
+++ b/dts/arm/st/f1/stm32f100Xb.dtsi
@@ -39,7 +39,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -47,7 +47,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/f1/stm32f100Xe.dtsi
+++ b/dts/arm/st/f1/stm32f100Xe.dtsi
@@ -26,7 +26,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f103X8.dtsi
+++ b/dts/arm/st/f1/stm32f103X8.dtsi
@@ -30,7 +30,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -44,7 +44,7 @@
 			ram-size = <512>;
 			maximum-speed = "full-speed";
 			status = "disabled";
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			phys = <&usb_fs_phy>;
 		};
 
@@ -53,7 +53,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -26,7 +26,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -35,7 +35,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -88,7 +88,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0X40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -96,7 +96,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -109,7 +109,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(APB2, 7U)>;
+				clocks = <&rcc STM32_CLOCK(APB2, 7)>;
 			};
 
 			gpiog: gpio@40012000 {
@@ -117,14 +117,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40012000 0x400>;
-				clocks = <&rcc STM32_CLOCK(APB2, 8U)>;
+				clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			};
 		};
 
 		adc2: adc@40012800 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			/* Shares vector with ADC1 */
 			interrupts = <18 0>;
 			status = "disabled";
@@ -134,7 +134,7 @@
 		adc3: adc@40013c00 {
 			compatible = "st,stm32-adc";
 			reg = <0x40013c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 15)>;
 			interrupts = <47 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -143,7 +143,7 @@
 		timers8: timers@40013400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			resets = <&rctl STM32_RESET(APB2, 13U)>;
 			interrupts = <43 0>, <44 0>, <45 0>, <46 0>;
 			interrupt-names = "brk", "up", "trgcom", "cc";
@@ -161,7 +161,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			interrupts = < 56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -39,7 +39,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -56,7 +56,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -64,7 +64,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -73,7 +73,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -84,7 +84,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -94,7 +94,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -148,7 +148,7 @@
 			interrupt-names = "otgfs";
 			num-bidir-endpoints = <4>;
 			ram-size = <1280>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 12U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 12)>;
 			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
 			status = "disabled";

--- a/dts/arm/st/f1/stm32f107.dtsi
+++ b/dts/arm/st/f1/stm32f107.dtsi
@@ -14,7 +14,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -131,7 +131,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			};
 
 			gpiob: gpio@40020400 {
@@ -139,7 +139,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			};
 
 			gpioc: gpio@40020800 {
@@ -147,7 +147,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			};
 
 			gpiod: gpio@40020c00 {
@@ -155,7 +155,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 3)>;
 			};
 
 			gpioe: gpio@40021000 {
@@ -163,7 +163,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 4)>;
 			};
 
 			gpiof: gpio@40021400 {
@@ -171,7 +171,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			};
 
 			gpiog: gpio@40021800 {
@@ -179,7 +179,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 6)>;
 			};
 
 			gpioh: gpio@40021c00 {
@@ -187,7 +187,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 7)>;
 			};
 
 			gpioi: gpio@40022000 {
@@ -195,14 +195,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 			};
 		};
 
 		rtc: rtc@40002800 {
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			interrupts = <41 0>;
 			prescaler = <32768>;
 			alarms-count = <2>;
@@ -225,7 +225,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -233,7 +233,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
 			resets = <&rctl STM32_RESET(APB2, 4U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -242,7 +242,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -251,7 +251,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -260,7 +260,7 @@
 		usart6: serial@40011400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			resets = <&rctl STM32_RESET(APB2, 5U)>;
 			interrupts = <71 0>;
 			status = "disabled";
@@ -269,7 +269,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -278,7 +278,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -289,7 +289,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			status = "disabled";
 		};
@@ -299,7 +299,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -309,7 +309,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -320,7 +320,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -332,7 +332,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -344,7 +344,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -358,7 +358,7 @@
 			num-bidir-endpoints = <4>;
 			ram-size = <1280>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB2, 7U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q NO_SEL>;
 			phys = <&otgfs_phy>;
 			status = "disabled";
@@ -367,7 +367,7 @@
 		adc1: adc@40012000 {
 			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -386,7 +386,7 @@
 			#dma-cells = <4>;
 			reg = <0x40026000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0 47 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			status = "disabled";
 		};
 
@@ -395,7 +395,7 @@
 			#dma-cells = <4>;
 			reg = <0x40026400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0 70 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 22)>;
 			st,mem2mem;
 			status = "disabled";
 		};
@@ -403,7 +403,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -743,14 +743,14 @@
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;
 			interrupts = <80 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			status = "disabled";
 		};
 
 		backup_sram: memory@40024000 {
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -79,7 +79,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32f1-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <4 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 4)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -132,7 +132,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 17U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 17)>;
 			};
 
 			gpiob: gpio@48000400 {
@@ -140,7 +140,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			};
 
 			gpioc: gpio@48000800 {
@@ -148,7 +148,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 19U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 19)>;
 			};
 
 			gpiod: gpio@48000c00 {
@@ -156,7 +156,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 20U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 20)>;
 			};
 
 			gpiof: gpio@48001400 {
@@ -164,7 +164,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 22U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 22)>;
 			};
 		};
 
@@ -177,7 +177,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -185,7 +185,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -194,7 +194,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -203,7 +203,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -212,7 +212,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -224,7 +224,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>,
 				 /* I2C clock source should always be defined,
 				  * even for the default value
 				  */
@@ -239,7 +239,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			status = "disabled";
 		};
@@ -247,7 +247,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -261,7 +261,7 @@
 			ram-size = <512>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			status = "disabled";
 		};
 
@@ -377,7 +377,7 @@
 		rtc: rtc@40002800 {
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			interrupts = <41 0>;
 			prescaler = <32768>;
 			alarms-count = <2>;
@@ -390,7 +390,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -398,7 +398,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f302.dtsi
+++ b/dts/arm/st/f3/stm32f302.dtsi
@@ -22,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>,
 				 /* I2C clock source should always be defined,
 				  * even for the default value
 				  */
@@ -38,7 +38,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>,
 				 /* I2C clock source should always be defined,
 				  * even for the default value
 				  */
@@ -53,7 +53,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -63,7 +63,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0X40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -104,7 +104,7 @@
 		adc1: adc@50000000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;

--- a/dts/arm/st/f3/stm32f302Xc.dtsi
+++ b/dts/arm/st/f3/stm32f302Xc.dtsi
@@ -69,7 +69,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
 		};
@@ -77,7 +77,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			interrupts = <53 0>;
 			status = "disabled";
 		};
@@ -88,7 +88,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 21U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			};
 		};
 	};

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -22,7 +22,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>,
 				 /* I2C clock source should always be defined,
 				  * even for the default value
 				  */
@@ -37,7 +37,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -47,7 +47,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -55,7 +55,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -68,7 +68,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 21U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			};
 		};
 
@@ -133,7 +133,7 @@
 		adc1: adc@50000000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			vref-mv = <3000>;
@@ -150,7 +150,7 @@
 		adc2: adc@50000100 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000100 0x4c>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			vref-mv = <3000>;

--- a/dts/arm/st/f3/stm32f303X8.dtsi
+++ b/dts/arm/st/f3/stm32f303X8.dtsi
@@ -28,7 +28,7 @@
 		dac2: dac@40009800 {
 			compatible = "st,stm32-dac";
 			reg = <0x40009800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/f3/stm32f303Xb.dtsi
+++ b/dts/arm/st/f3/stm32f303Xb.dtsi
@@ -65,7 +65,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f303Xe.dtsi
+++ b/dts/arm/st/f3/stm32f303Xe.dtsi
@@ -108,7 +108,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40020400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f3/stm32f334.dtsi
+++ b/dts/arm/st/f3/stm32f334.dtsi
@@ -72,7 +72,7 @@
 		adc1: adc@50000000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;

--- a/dts/arm/st/f3/stm32f334X8.dtsi
+++ b/dts/arm/st/f3/stm32f334X8.dtsi
@@ -28,7 +28,7 @@
 		dac2: dac@40009800 {
 			compatible = "st,stm32-dac";
 			reg = <0x40009800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/f3/stm32f373.dtsi
+++ b/dts/arm/st/f3/stm32f373.dtsi
@@ -25,7 +25,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 21U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			};
 		};
 
@@ -35,7 +35,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>,
 				 /* I2C clock source should always be defined,
 				  * even for the default value
 				  */
@@ -50,7 +50,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -60,7 +60,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -234,7 +234,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32f1-adc", "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;

--- a/dts/arm/st/f3/stm32f373Xc.dtsi
+++ b/dts/arm/st/f3/stm32f373Xc.dtsi
@@ -22,7 +22,7 @@
 		dma2: dma@40020400 {
 			compatible = "st,stm32-dma-v2bis";
 			reg = <0x40020400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0>;
 			status = "disabled";
 		};
@@ -30,7 +30,7 @@
 		dac2: dac@40009800 {
 			compatible = "st,stm32-dac";
 			reg = <0x40009800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -162,7 +162,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			};
 
 			gpiob: gpio@40020400 {
@@ -170,7 +170,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			};
 
 			gpioc: gpio@40020800 {
@@ -178,7 +178,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			};
 
 			gpiod: gpio@40020c00 {
@@ -186,7 +186,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 3)>;
 			};
 
 			gpioe: gpio@40021000 {
@@ -194,7 +194,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 4)>;
 			};
 
 			gpiof: gpio@40021400 {
@@ -202,7 +202,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			};
 
 			gpiog: gpio@40021800 {
@@ -210,7 +210,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 6)>;
 			};
 
 			gpioh: gpio@40021c00 {
@@ -218,7 +218,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 7)>;
 			};
 		};
 
@@ -231,7 +231,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -239,7 +239,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
 			resets = <&rctl STM32_RESET(APB2, 4U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -248,7 +248,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -257,7 +257,7 @@
 		usart6: serial@40011400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			resets = <&rctl STM32_RESET(APB2, 5U)>;
 			interrupts = <71 0>;
 			status = "disabled";
@@ -269,7 +269,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -281,7 +281,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -293,7 +293,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -304,7 +304,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			status = "disabled";
 		};
@@ -318,7 +318,7 @@
 			ram-size = <1280>;
 			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 7U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q NO_SEL>;
 			status = "disabled";
 		};
@@ -536,7 +536,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -552,7 +552,7 @@
 		adc1: adc@40012000 {
 			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -571,7 +571,7 @@
 			#dma-cells = <4>;
 			reg = <0x40026000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0 47 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			status = "disabled";
 		};
 
@@ -580,7 +580,7 @@
 			#dma-cells = <4>;
 			reg = <0x40026400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0 70 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 22)>;
 			st,mem2mem;
 			status = "disabled";
 		};
@@ -588,7 +588,7 @@
 		sdmmc1: sdmmc@40012c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 11U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_PLL_Q NO_SEL>;
 			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;

--- a/dts/arm/st/f4/stm32f401.dtsi
+++ b/dts/arm/st/f4/stm32f401.dtsi
@@ -23,7 +23,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -33,7 +33,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -43,7 +43,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
 			status = "disabled";
 		};
@@ -53,7 +53,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -66,7 +66,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			dmas = <&dma1 5 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma1 0 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -27,7 +27,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			};
 
 			gpiog: gpio@40021800 {
@@ -35,7 +35,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 6)>;
 			};
 
 			gpioi: gpio@40022000 {
@@ -43,14 +43,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 			};
 		};
 
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -59,7 +59,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -68,7 +68,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -210,7 +210,7 @@
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
 			phys = <&otghs_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 29U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 29)>,
 				 <&rcc STM32_SRC_PLL_Q NO_SEL>;
 			status = "disabled";
 		};
@@ -220,7 +220,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -239,14 +239,14 @@
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;
 			interrupts = <80 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			status = "disabled";
 		};
 
 		backup_sram: memory@40024000 {
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};
@@ -254,7 +254,7 @@
 		adc2: adc@40012100 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012100 0x050>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -271,7 +271,7 @@
 		adc3: adc@40012200 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012200 0x050>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -288,7 +288,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -20,7 +20,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -30,7 +30,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
 			status = "disabled";
 		};
@@ -40,7 +40,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -53,7 +53,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			dmas = <&dma1 4 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma1 3 0 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -66,7 +66,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
 			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -94,7 +94,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -103,7 +103,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x40080000 0x400>;
 			interrupts = <80 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 31)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -23,7 +23,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
 			status = "disabled";
 		};
@@ -33,7 +33,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -46,7 +46,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
 			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -59,7 +59,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
 			dmas = <&dma2 6 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma2 5 7 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;

--- a/dts/arm/st/f4/stm32f412.dtsi
+++ b/dts/arm/st/f4/stm32f412.dtsi
@@ -36,7 +36,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			};
 
 			gpiog: gpio@40021800 {
@@ -44,14 +44,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 6)>;
 			};
 		};
 
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -62,7 +62,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -72,7 +72,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
 			status = "disabled";
 		};
@@ -82,7 +82,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
 			dmas = <&dma2 1 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma2 0 4 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -204,7 +204,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;
 			interrupts = <80 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			status = "disabled";
 		};
 
@@ -213,7 +213,7 @@
 		};
 
 		sdmmc1: sdmmc@40012c00 {
-			clocks = <&rcc STM32_CLOCK(APB2, 11U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_CK48 SDIO_SEL(0)>;
 		};
 
@@ -223,7 +223,7 @@
 			#size-cells = <0>;
 			reg = <0xa0001000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <92 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 1)>;
 			status = "disabled";
 		};
 
@@ -232,7 +232,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f4/stm32f413.dtsi
+++ b/dts/arm/st/f4/stm32f413.dtsi
@@ -13,7 +13,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -22,7 +22,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -31,7 +31,7 @@
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			resets = <&rctl STM32_RESET(APB1, 30U)>;
 			interrupts = <82 0>;
 			status = "disabled";
@@ -40,7 +40,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			resets = <&rctl STM32_RESET(APB1, 31U)>;
 			interrupts = <83 0>;
 			status = "disabled";
@@ -49,7 +49,7 @@
 		uart9: serial@40011800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40011800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 6U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 6)>;
 			resets = <&rctl STM32_RESET(APB2, 6U)>;
 			interrupts = <88 0>;
 			status = "disabled";
@@ -58,7 +58,7 @@
 		uart10: serial@40011c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 7)>;
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <89 0>;
 			status = "disabled";
@@ -67,7 +67,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -77,7 +77,7 @@
 			reg = <0x40006c00 0x400>;
 			interrupts = <74 0>, <75 0>, <76 0>, <77 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 27U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 27)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f4/stm32f415.dtsi
+++ b/dts/arm/st/f4/stm32f415.dtsi
@@ -13,7 +13,7 @@
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f417.dtsi
+++ b/dts/arm/st/f4/stm32f417.dtsi
@@ -13,7 +13,7 @@
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f423.dtsi
+++ b/dts/arm/st/f4/stm32f423.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -24,7 +24,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 9U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 9)>;
 			};
 
 			gpiok: gpio@40022800 {
@@ -32,14 +32,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 10U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 10)>;
 			};
 		};
 
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			resets = <&rctl STM32_RESET(APB1, 30U)>;
 			interrupts = <82 0>;
 			status = "disabled";
@@ -48,7 +48,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			resets = <&rctl STM32_RESET(APB1, 31U)>;
 			interrupts = <83 0>;
 			status = "disabled";
@@ -59,7 +59,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
 			status = "disabled";
 		};
@@ -72,7 +72,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
 			status = "disabled";
 		};
@@ -85,7 +85,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 			interrupts = <86 5>;
 			status = "disabled";
 		};
@@ -93,7 +93,7 @@
 		fmc: memory-controller@a0000000 {
 			compatible = "st,stm32-fmc";
 			reg = <0xa0000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
 			status = "disabled";
 
 			sdram: sdram {

--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -14,7 +14,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -24,7 +24,7 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK(APB2, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
 			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -14,7 +14,7 @@
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f439.dtsi
+++ b/dts/arm/st/f4/stm32f439.dtsi
@@ -13,7 +13,7 @@
 		cryp: cryp@50060000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -23,7 +23,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			dmas = <&dma2 3 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL
 				&dma2 2 3 STM32_DMA_MEM_INC STM32_DMA_FIFO_FULL>;
@@ -34,7 +34,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -43,7 +43,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -52,7 +52,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -63,7 +63,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -80,7 +80,7 @@
 
 		usbotg_fs: usb@50000000 {
 			num-bidir-endpoints = <6>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 7U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q CK48M_SEL(0)>;
 		};
 
@@ -93,7 +93,7 @@
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
 			phys = <&otghs_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 29U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 29)>,
 				 <&rcc STM32_SRC_PLL_Q CK48M_SEL(0)>;
 			status = "disabled";
 		};
@@ -101,7 +101,7 @@
 		backup_sram: memory@40024000 {
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};
@@ -109,7 +109,7 @@
 		adc2: adc@40012100 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012100 0x050>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -126,7 +126,7 @@
 		adc3: adc@40012200 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012200 0x050>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -143,7 +143,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -151,7 +151,7 @@
 		fmc: memory-controller@a0000000 {
 			compatible = "st,stm32-fmc";
 			reg = <0xa0000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
 			status = "disabled";
 
 			sdram: sdram {

--- a/dts/arm/st/f4/stm32f469.dtsi
+++ b/dts/arm/st/f4/stm32f469.dtsi
@@ -11,13 +11,13 @@
 		compatible = "st,stm32f469", "st,stm32f4", "simple-bus";
 
 		sdmmc1: sdmmc@40012c00 {
-			clocks = <&rcc STM32_CLOCK(APB2, 11U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_SYSCLK SDMMC_SEL(1)>;
 		};
 
 		usbotg_fs: usb@50000000 {
 			num-bidir-endpoints = <6>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 7U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q CLK48M_SEL(0)>;
 		};
 

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -104,7 +104,7 @@
 		fmc: memory-controller@a0000000 {
 			compatible = "st,stm32-fmc";
 			reg = <0xa0000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
 			status = "disabled";
 
 			sdram: sdram {
@@ -170,7 +170,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			};
 
 			gpiob: gpio@40020400 {
@@ -178,7 +178,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			};
 
 			gpioc: gpio@40020800 {
@@ -186,7 +186,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			};
 
 			gpiod: gpio@40020C00 {
@@ -194,7 +194,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020C00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 3)>;
 			};
 
 			gpioe: gpio@40021000 {
@@ -202,7 +202,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 4)>;
 			};
 
 			gpiof: gpio@40021400 {
@@ -210,7 +210,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			};
 
 			gpiog: gpio@40021800 {
@@ -218,7 +218,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 6)>;
 			};
 
 			gpioh: gpio@40021C00 {
@@ -226,7 +226,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021C00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 7)>;
 			};
 
 			gpioi: gpio@40022000 {
@@ -234,7 +234,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 			};
 		};
 
@@ -247,7 +247,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -255,7 +255,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
 			resets = <&rctl STM32_RESET(APB2, 4U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -264,7 +264,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -273,7 +273,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -282,7 +282,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -291,7 +291,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -300,7 +300,7 @@
 		usart6: serial@40011400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			resets = <&rctl STM32_RESET(APB2, 5U)>;
 			interrupts = <71 0>;
 			status = "disabled";
@@ -309,7 +309,7 @@
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			resets = <&rctl STM32_RESET(APB1, 30U)>;
 			interrupts = <82 0>;
 			status = "disabled";
@@ -318,7 +318,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			resets = <&rctl STM32_RESET(APB1, 31U)>;
 			interrupts = <83 0>;
 			status = "disabled";
@@ -330,7 +330,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -342,7 +342,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -354,7 +354,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -365,7 +365,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 5>;
 			status = "disabled";
 		};
@@ -375,7 +375,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -385,7 +385,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -395,7 +395,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 5>;
 			status = "disabled";
 		};
@@ -405,7 +405,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 5>;
 			status = "disabled";
 		};
@@ -415,7 +415,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			status = "disabled";
 		};
 
@@ -728,7 +728,7 @@
 			ram-size = <1280>;
 			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 7U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q CK48M_SEL(0)>;
 			status = "disabled";
 		};
@@ -741,7 +741,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB1, 29U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 29)>,
 				 <&rcc STM32_SRC_PLL_Q CK48M_SEL(0)>;
 			phys = <&otghs_fs_phy>;
 			status = "disabled";
@@ -751,7 +751,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x300>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -767,7 +767,7 @@
 		adc1: adc@40012000 {
 			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012000 0x50>;
-			clocks = <&rcc STM32_CLOCK(APB2, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -784,7 +784,7 @@
 		adc2: adc@40012100 {
 			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012100 0x50>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -801,7 +801,7 @@
 		adc3: adc@40012200 {
 			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012200 0x50>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -818,7 +818,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -828,7 +828,7 @@
 			#dma-cells = <4>;
 			reg = <0x40026000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0 47 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 21)>;
 			status = "disabled";
 		};
 
@@ -837,7 +837,7 @@
 			#dma-cells = <4>;
 			reg = <0x40026400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0 70 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 22)>;
 			st,mem2mem;
 			status = "disabled";
 		};
@@ -846,7 +846,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;
 			interrupts = <80 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 6U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 6)>,
 				 <&rcc STM32_SRC_PLL_Q CK48M_SEL(0)>;
 			status = "disabled";
 		};
@@ -854,7 +854,7 @@
 		sdmmc1: sdmmc@40012c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 11U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 				 <&rcc STM32_SRC_PLL_Q SDMMC1_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 11U)>;
 			interrupts = <49 0>;
@@ -864,7 +864,7 @@
 		backup_sram: memory@40024000 {
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40024000 DT_SIZE_K(4)>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};
@@ -875,7 +875,7 @@
 			#size-cells = <0>;
 			reg = <0xa0001000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <92 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 1)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/f7/stm32f722.dtsi
+++ b/dts/arm/st/f7/stm32f722.dtsi
@@ -35,7 +35,7 @@
 		sdmmc2: sdmmc@40011c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 7U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 7)>,
 				<&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -32,7 +32,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 9U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 9)>;
 			};
 
 			gpiok: gpio@40022800 {
@@ -40,7 +40,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 10U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 10)>;
 			};
 		};
 
@@ -50,7 +50,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40006000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 24U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 24)>;
 			interrupts = <95 0>, <96 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -61,7 +61,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 			interrupts = <86 5>;
 			status = "disabled";
 		};
@@ -71,7 +71,7 @@
 			reg = <0x40006800 0x400>;
 			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/f7/stm32f746.dtsi
+++ b/dts/arm/st/f7/stm32f746.dtsi
@@ -16,7 +16,7 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_err";
-			clocks = <&rcc STM32_CLOCK(APB2, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
 			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/f7/stm32f765.dtsi
+++ b/dts/arm/st/f7/stm32f765.dtsi
@@ -34,7 +34,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 9U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 9)>;
 			};
 
 			gpiok: gpio@40022800 {
@@ -42,7 +42,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40022800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 10U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 10)>;
 			};
 		};
 
@@ -52,7 +52,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40006000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 24U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 24)>;
 			interrupts = <95 0>, <96 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -63,7 +63,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 21)>;
 			interrupts = <86 5>;
 			status = "disabled";
 		};
@@ -96,7 +96,7 @@
 		sdmmc2: sdmmc@40011c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 7U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 7)>,
 				 <&rcc STM32_SRC_PLL_Q SDMMC2_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <103 0>;

--- a/dts/arm/st/f7/stm32f767.dtsi
+++ b/dts/arm/st/f7/stm32f767.dtsi
@@ -17,7 +17,7 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_err";
-			clocks = <&rcc STM32_CLOCK(APB2, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
 			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -111,7 +111,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32g0-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -161,7 +161,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 0U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 0)>;
 			};
 
 			gpiob: gpio@50000400 {
@@ -169,7 +169,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 1U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 1)>;
 			};
 
 			gpioc: gpio@50000800 {
@@ -177,7 +177,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 2U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 2)>;
 			};
 
 			gpiod: gpio@50000c00 {
@@ -185,7 +185,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 3U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 3)>;
 			};
 
 			gpiof: gpio@50001400 {
@@ -193,7 +193,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 5U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 5)>;
 			};
 		};
 
@@ -201,7 +201,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <2 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 10)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <19>;
@@ -229,7 +229,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";
 		};
@@ -237,7 +237,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 14)>;
 			resets = <&rctl STM32_RESET(APB1H, 14U)>;
 			interrupts = <27 0>;
 			status = "disabled";
@@ -246,7 +246,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -254,7 +254,7 @@
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -384,7 +384,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -396,7 +396,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -407,7 +407,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 12)>;
 			interrupts = <25 0>;
 			status = "disabled";
 		};
@@ -417,7 +417,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 0>;
 			status = "disabled";
 		};
@@ -425,7 +425,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 20)>;
 			interrupts = <12 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -450,7 +450,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-requests = <5>;
 			dma-offset = <0>;
 			status = "disabled";

--- a/dts/arm/st/g0/stm32g031.dtsi
+++ b/dts/arm/st/g0/stm32g031.dtsi
@@ -14,7 +14,7 @@
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <29 0>;
 			status = "disabled";

--- a/dts/arm/st/g0/stm32g051.dtsi
+++ b/dts/arm/st/g0/stm32g051.dtsi
@@ -69,7 +69,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/g0/stm32g070.dtsi
+++ b/dts/arm/st/g0/stm32g070.dtsi
@@ -14,7 +14,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -23,7 +23,7 @@
 		usart4: serial@40004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <29 0>;
 			status = "disabled";

--- a/dts/arm/st/g0/stm32g071.dtsi
+++ b/dts/arm/st/g0/stm32g071.dtsi
@@ -15,7 +15,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -24,7 +24,7 @@
 		usart4: serial@40004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -37,7 +37,7 @@
 		ucpd1: ucpd@4000a000 {
 			compatible = "st,stm32-ucpd";
 			reg = <0x4000a000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			interrupts = <8 0>;
 			status = "disabled";
 		};
@@ -45,7 +45,7 @@
 		ucpd2: ucpd@4000a400 {
 			compatible = "st,stm32-ucpd";
 			reg = <0x4000a400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
 			interrupts = <8 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0_crypt.dtsi
+++ b/dts/arm/st/g0/stm32g0_crypt.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@40026000 {
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;
 			resets = <&rctl STM32_RESET(AHB1, 16U)>;
 			interrupts = <31 0>;
 			status = "disabled";
@@ -23,7 +23,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x40025000 0x400>;
 			interrupts = <31 1>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/g0/stm32g0b0.dtsi
+++ b/dts/arm/st/g0/stm32g0b0.dtsi
@@ -16,14 +16,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 4U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 4)>;
 			};
 		};
 
 		usart5: serial@40005000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 8)>;
 			resets = <&rctl STM32_RESET(APB1L, 8U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -32,7 +32,7 @@
 		usart6: serial@40013c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
 			resets = <&rctl STM32_RESET(APB1L, 9U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -62,7 +62,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40008800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -73,7 +73,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};
@@ -83,7 +83,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
 			interrupts = <11 0 11 0 11 0 11 0 11 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-requests = <5>;
 			dma-offset = <7>;
 			status = "disabled";
@@ -102,7 +102,7 @@
 			ram-size = <2048>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 13U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 13)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(0)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -29,7 +29,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 4U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 4)>;
 			};
 		};
 
@@ -39,7 +39,7 @@
 			reg-names = "m_can", "message_ram";
 			interrupts = <21 0>, <22 0>;
 			interrupt-names = "int0", "int1";
-			clocks = <&rcc STM32_CLOCK(APB1, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
@@ -50,7 +50,7 @@
 			reg-names = "m_can", "message_ram";
 			interrupts = <21 0>, <22 0>;
 			interrupt-names = "int0", "int1";
-			clocks = <&rcc STM32_CLOCK(APB1, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
@@ -58,7 +58,7 @@
 		usart5: serial@40005000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 8)>;
 			resets = <&rctl STM32_RESET(APB1L, 8U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -67,7 +67,7 @@
 		usart6: serial@40013c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
 			resets = <&rctl STM32_RESET(APB1L, 9U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -76,7 +76,7 @@
 		lpuart2: serial@40008400 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 7)>;
 			resets = <&rctl STM32_RESET(APB1L, 7U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -106,7 +106,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40008800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -117,7 +117,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};
@@ -127,7 +127,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
 			interrupts = <11 0 11 0 11 0 11 0 11 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-requests = <5>;
 			dma-offset = <7>;
 			status = "disabled";
@@ -147,7 +147,7 @@
 			ram-size = <2048>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 13U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 13)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(0)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -106,7 +106,7 @@
 		adc1: adc@50000000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000000 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -122,7 +122,7 @@
 		adc2: adc@50000100 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000100 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -138,7 +138,7 @@
 		dac1: dac@50000800 {
 			compatible = "st,stm32-dac";
 			reg = <0x50000800 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -146,7 +146,7 @@
 		dac3: dac@50001000 {
 			compatible = "st,stm32-dac";
 			reg = <0x50001000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -155,7 +155,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32g4-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <3 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -209,7 +209,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			};
 
 			gpiob: gpio@48000400 {
@@ -217,7 +217,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			};
 
 			gpioc: gpio@48000800 {
@@ -225,7 +225,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			};
 
 			gpiod: gpio@48000c00 {
@@ -233,7 +233,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioe: gpio@48001000 {
@@ -241,7 +241,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 
 			gpiof: gpio@48001400 {
@@ -249,7 +249,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
 			};
 
 			gpiog: gpio@48001800 {
@@ -257,14 +257,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			};
 		};
 
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -273,7 +273,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -282,7 +282,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -291,7 +291,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -300,7 +300,7 @@
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
 			resets = <&rctl STM32_RESET(APB1H, 0U)>;
 			interrupts = <91 0>;
 			status = "disabled";
@@ -315,7 +315,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -326,7 +326,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -338,7 +338,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -350,7 +350,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			interrupts = <92 0>, <93 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -362,7 +362,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <35 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			status = "disabled";
 		};
 
@@ -371,7 +371,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -381,7 +381,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -392,14 +392,14 @@
 			reg-names = "m_can", "message_ram";
 			interrupts = <21 0>, <22 0>;
 			interrupt-names = "int0", "int1";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -610,7 +610,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 10)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -621,7 +621,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;
 			interrupts = <90 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 26U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 26)>;
 			status = "disabled";
 		};
 
@@ -634,7 +634,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			status = "disabled";
 		};
@@ -643,7 +643,7 @@
 			compatible = "st,stm32-dma-v2";
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-offset = <0>;
 			status = "disabled";
 		};
@@ -652,7 +652,7 @@
 			compatible = "st,stm32-dma-v2";
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			status = "disabled";
 		};
 
@@ -661,7 +661,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020800 0x400>;
 			interrupts = <94 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			dma-generators = <4>;
 			dma-requests= <111>;
 			status = "disabled";
@@ -670,7 +670,7 @@
 		ucpd1: ucpd@4000a000 {
 			compatible = "st,stm32-ucpd";
 			reg = <0x4000a000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 4U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 4)>;
 			interrupts = <63 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -31,7 +31,7 @@
 		adc4: adc@50000500 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000500 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			interrupts = <61 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -47,7 +47,7 @@
 		adc5: adc@50000600 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000600 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			interrupts = <62 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -65,7 +65,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 15)>;
 			interrupts = <84 5>;
 			status = "disabled";
 		};
@@ -73,7 +73,7 @@
 		dac2: dac@50000c00 {
 			compatible = "st,stm32-dac";
 			reg = <0x50000c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 17U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -81,7 +81,7 @@
 		dac4: dac@50001400 {
 			compatible = "st,stm32-dac";
 			reg = <0x50001400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 19U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 19)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -92,7 +92,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40008400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 1U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 1)>;
 			interrupts = <82 0>, <83 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -104,7 +104,7 @@
 			reg-names = "m_can", "message_ram";
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "int0", "int1";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -16,7 +16,7 @@
 			reg-names = "m_can", "message_ram";
 			interrupts = <86 0>, <87 0>;
 			interrupt-names = "int0", "int1";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
@@ -57,7 +57,7 @@
 		adc3: adc@50000400 {
 			compatible = "st,stm32-adc";
 			reg = <0x50000400 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			interrupts = <47 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -73,7 +73,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -85,7 +85,7 @@
 			#size-cells = <0>;
 			reg = <0xa0001000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <95 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 8)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -141,7 +141,7 @@
 		backup_sram: memory@40036400 {
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x40036400 DT_SIZE_K(2)>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 28)>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};
@@ -191,7 +191,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			};
 
 			gpiob: gpio@42020400 {
@@ -199,7 +199,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			};
 
 			gpioc: gpio@42020800 {
@@ -207,7 +207,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			};
 
 			gpiod: gpio@42020c00 {
@@ -215,7 +215,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioh: gpio@42021c00 {
@@ -223,13 +223,13 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 7)>;
 			};
 		};
 
 		lptim1: timers@44004400 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB3, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 11)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004400 0x400>;
@@ -240,7 +240,7 @@
 
 		lptim2: timers@40009400 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
@@ -252,7 +252,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <58 0>;
 			status = "disabled";
@@ -261,7 +261,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <59 0>;
 			status = "disabled";
@@ -270,7 +270,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <60 0>;
 			status = "disabled";
@@ -279,7 +279,7 @@
 		lpuart1: serial@44002400 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x44002400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB3, 6U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 6)>;
 			resets = <&rctl STM32_RESET(APB3, 6U)>;
 			interrupts = <63 0>;
 			status = "disabled";
@@ -294,7 +294,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -302,7 +302,7 @@
 		dac1: dac@42028400 {
 			compatible = "st,stm32-dac";
 			reg = <0x42028400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 11U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 11)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -310,7 +310,7 @@
 		adc1: adc@42028000 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 10U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
 			interrupts = <37 0>;
 			status = "disabled";
 			vref-mv = <3300>;
@@ -328,7 +328,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x44007800 0x400>;
 			interrupts = <2 0>;
-			clocks = <&rcc STM32_CLOCK(APB3, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 21)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -446,7 +446,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <51 0>, <52 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -458,7 +458,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <53 0>, <54 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -471,7 +471,7 @@
 			interrupt-names = "event", "error";
 			#address-cells = <3>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			resets = <&rctl STM32_RESET(APB1L, 23U)>;
 			zephyr,pm-device-runtime-auto;
 			status = "disabled";
@@ -484,7 +484,7 @@
 			interrupt-names = "event", "error";
 			#address-cells = <3>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB3, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 9)>;
 			resets = <&rctl STM32_RESET(APB3, 9U)>;
 			zephyr,pm-device-runtime-auto;
 			status = "disabled";
@@ -496,7 +496,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <55 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
 			status = "disabled";
 		};
@@ -507,7 +507,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			interrupts = <56 5>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI2_SEL(0)>;
 			status = "disabled";
 		};
@@ -518,7 +518,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			interrupts = <57 5>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI3_SEL(0)>;
 			status = "disabled";
 		};
@@ -529,7 +529,7 @@
 			reg-names = "m_can", "message_ram";
 			interrupts = <39 0>, <40 0>;
 			interrupt-names = "int0", "int1";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
@@ -537,7 +537,7 @@
 		rng: rng@420c0800 {
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
 			interrupts = <114 0>;
 			nist-config = <0xf00d00>;
 			health-test-config = <0xaac7>;
@@ -572,7 +572,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x1000>;
 			interrupts = <27 0 28 0 29 0 30 0 31 0 32 0 33 0 34 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <8>;
 			dma-requests = <140>;
 			dma-offset = <0>;
@@ -584,7 +584,7 @@
 			#dma-cells = <3>;
 			reg = <0x40021000 0x1000>;
 			interrupts = <90 0 91 0 92 0 93 0 94 0 95 0 96 0 97 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-channels = <8>;
 			dma-requests = <140>;
 			dma-offset = <8>;
@@ -596,7 +596,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				<&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
 			dmas = <&gpdma1 0 7 (STM32_DMA_PERIPH_TX |STM32_DMA_16BITS | \
 					STM32_DMA_PRIORITY_HIGH)
@@ -612,7 +612,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				<&rcc STM32_SRC_PLL1_Q SPI2_SEL(0)>;
 			dmas = <&gpdma1 2 9 (STM32_DMA_PERIPH_TX | STM32_DMA_16BITS | \
 					STM32_DMA_PRIORITY_HIGH)
@@ -628,7 +628,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				<&rcc STM32_SRC_PLL1_Q SPI3_SEL(0)>;
 			dmas = <&gpdma1 4 11 (STM32_DMA_PERIPH_TX  | STM32_DMA_16BITS | \
 					STM32_DMA_PRIORITY_HIGH)
@@ -672,7 +672,7 @@
 			ram-size = <2048>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB2, 24U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
 			status = "disabled";
 		};
@@ -682,7 +682,7 @@
 			reg = <0x40008c00 0x400>;
 			interrupts = <113 0>;
 			interrupt-names = "digi_temp";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 3U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 3)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h5/stm32h562.dtsi
+++ b/dts/arm/st/h5/stm32h562.dtsi
@@ -29,7 +29,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 
 			gpiof: gpio@42021400 {
@@ -37,7 +37,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
 			};
 
 			gpiog: gpio@42021800 {
@@ -45,7 +45,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			};
 
 			gpioi: gpio@42022000 {
@@ -53,7 +53,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42022000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 8)>;
 			};
 		};
 
@@ -81,7 +81,7 @@
 
 		lptim3: timers@44004800 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB3, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004800 0x400>;
@@ -92,7 +92,7 @@
 
 		lptim4: timers@44004c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB3, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 13)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44004c00 0x400>;
@@ -103,7 +103,7 @@
 
 		lptim5: timers@44005000 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB3, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 14)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44005000 0x400>;
@@ -114,7 +114,7 @@
 
 		lptim6: timers@44005400 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB3, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 15)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44005400 0x400>;
@@ -126,7 +126,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <61 0>;
 			status = "disabled";
@@ -135,7 +135,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <62 0>;
 			status = "disabled";
@@ -144,7 +144,7 @@
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			resets = <&rctl STM32_RESET(APB1L, 30U)>;
 			interrupts = <98 0>;
 			status = "disabled";
@@ -153,7 +153,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			resets = <&rctl STM32_RESET(APB1L, 31U)>;
 			interrupts = <99 0>;
 			status = "disabled";
@@ -162,7 +162,7 @@
 		uart9: serial@40008000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
 			resets = <&rctl STM32_RESET(APB1H, 0U)>;
 			interrupts = <100 0>;
 			status = "disabled";
@@ -171,7 +171,7 @@
 		usart6: serial@40006400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40006400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			resets = <&rctl STM32_RESET(APB1L, 25U)>;
 			interrupts = <85 0>;
 			status = "disabled";
@@ -180,7 +180,7 @@
 		usart10: serial@40006800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40006800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
 			resets = <&rctl STM32_RESET(APB1L, 26U)>;
 			interrupts = <86 0>;
 			status = "disabled";
@@ -189,7 +189,7 @@
 		usart11: serial@40006c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40006c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 27U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 27)>;
 			resets = <&rctl STM32_RESET(APB1L, 27U)>;
 			interrupts = <87 0>;
 			status = "disabled";
@@ -198,7 +198,7 @@
 		uart12: serial@40008400 {
 			compatible = "st,stm32-uart";
 			reg = <0x40008400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 1U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 1)>;
 			resets = <&rctl STM32_RESET(APB1H, 1U)>;
 			interrupts = <101 0>;
 			status = "disabled";
@@ -210,7 +210,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44002800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB3, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 7)>;
 			interrupts = <80 0>, <81 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -222,7 +222,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x44002c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB3, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 8)>;
 			interrupts = <125 0>, <126 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -234,7 +234,7 @@
 			#size-cells = <0>;
 			reg = <0x40014c00 0x400>;
 			interrupts = <82 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 19)>;
 			status = "disabled";
 		};
 
@@ -244,7 +244,7 @@
 			#size-cells = <0>;
 			reg = <0x44002000 0x400>;
 			interrupts = <83 5>;
-			clocks = <&rcc STM32_CLOCK(APB3, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 5)>;
 			status = "disabled";
 		};
 
@@ -254,7 +254,7 @@
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
 			interrupts = <84 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			status = "disabled";
 		};
 
@@ -263,7 +263,7 @@
 			reg = <0x47001400 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <78 0>;
 			clock-names = "xspix", "xspi-ker";
-			clocks = <&rcc STM32_CLOCK(AHB4, 20U)>,
+			clocks = <&rcc STM32_CLOCK(AHB4, 20)>,
 				<&rcc STM32_SRC_PLL1_Q OCTOSPI1_SEL(1)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -273,7 +273,7 @@
 		adc2: adc@42028100 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028100 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 10U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 10)>;
 			interrupts = <69 0>;
 			status = "disabled";
 			vref-mv = <3300>;
@@ -483,7 +483,7 @@
 		aes: aes@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <116 0>;
 			status = "disabled";
@@ -496,7 +496,7 @@
 			interrupts = <109 0>, <110 0>;
 			interrupt-names = "int0", "int1";
 			/* common clock FDCAN 1 & 2 */
-			clocks = <&rcc STM32_CLOCK(APB1_2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 9)>;
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
 			status = "disabled";
 		};
@@ -504,7 +504,7 @@
 		sdmmc1: sdmmc@46008000 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x46008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 11U)>,
+			clocks = <&rcc STM32_CLOCK(AHB4, 11)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC1_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB4, 11U)>;
 			interrupts = <79 0>;
@@ -514,7 +514,7 @@
 		fmc: memory-controller@47000400 {
 			compatible = "st,stm32-fmc";
 			reg = <0x47000400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB4, 16)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h5/stm32h563.dtsi
+++ b/dts/arm/st/h5/stm32h563.dtsi
@@ -13,7 +13,7 @@
 		sdmmc2: sdmmc@46008c00 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x46008c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 12U)>,
+			clocks = <&rcc STM32_CLOCK(AHB4, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC2_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB4, 12U)>;
 			interrupts = <102 0>;

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -189,7 +189,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 0)>;
 			};
 
 			gpiob: gpio@58020400 {
@@ -197,7 +197,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 1)>;
 			};
 
 			gpioc: gpio@58020800 {
@@ -205,7 +205,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 2)>;
 			};
 
 			gpiod: gpio@58020C00 {
@@ -213,7 +213,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020C00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 3)>;
 			};
 
 			gpioe: gpio@58021000 {
@@ -221,7 +221,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 4)>;
 			};
 
 			gpiof: gpio@58021400 {
@@ -229,7 +229,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 5)>;
 			};
 
 			gpiog: gpio@58021800 {
@@ -237,7 +237,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 6)>;
 			};
 
 			gpioh: gpio@58021C00 {
@@ -245,7 +245,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021C00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 7)>;
 			};
 
 			gpioi: gpio@58022000 {
@@ -253,7 +253,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58022000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 8)>;
 			};
 
 			gpioj: gpio@58022400 {
@@ -261,7 +261,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58022400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 9U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 9)>;
 			};
 
 			gpiok: gpio@58022800 {
@@ -269,7 +269,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58022800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 10U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 10)>;
 			};
 		};
 
@@ -282,7 +282,7 @@
 		wwdg: wwdg1: watchdog@50003000 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x50003000 0x1000>;
-			clocks = <&rcc STM32_CLOCK(APB3, 6U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 6)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -290,7 +290,7 @@
 		usart1: serial@40011000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
 			resets = <&rctl STM32_RESET(APB2, 4U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -298,7 +298,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -306,7 +306,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -314,7 +314,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -322,7 +322,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -330,7 +330,7 @@
 		usart6: serial@40011400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			resets = <&rctl STM32_RESET(APB2, 5U)>;
 			interrupts = <71 0>;
 			status = "disabled";
@@ -338,7 +338,7 @@
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			resets = <&rctl STM32_RESET(APB1L, 30U)>;
 			interrupts = <82 0>;
 			status = "disabled";
@@ -346,7 +346,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			resets = <&rctl STM32_RESET(APB1L, 31U)>;
 			interrupts = <83 0>;
 			status = "disabled";
@@ -355,7 +355,7 @@
 		lpuart1: serial@58000c00 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x58000c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB4, 3U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 3)>;
 			resets = <&rctl STM32_RESET(APB4, 3U)>;
 			interrupts = <142 0>;
 			status = "disabled";
@@ -365,7 +365,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x58004000 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB4, 16U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 16)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -378,7 +378,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -390,7 +390,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -402,7 +402,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -414,7 +414,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x58001c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB4, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 7)>;
 			interrupts = <95 0>, <96 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -425,7 +425,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				<&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			interrupts = <35 0>;
 			status = "disabled";
@@ -436,7 +436,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				<&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			interrupts = <36 0>;
 			status = "disabled";
@@ -447,7 +447,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				<&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			interrupts = <51 0>;
 			status = "disabled";
@@ -458,7 +458,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <84 0>;
 			status = "disabled";
 		};
@@ -468,7 +468,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <85 0>;
 			status = "disabled";
 		};
@@ -478,7 +478,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x58001400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB4, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 5)>;
 			interrupts = <86 0>;
 			status = "disabled";
 		};
@@ -488,7 +488,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			dmas = <&dmamux1 0 38 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
 				&dmamux1 1 37 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
@@ -502,7 +502,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			dmas = <&dmamux1 0 40 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
 				&dmamux1 1 39 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
@@ -516,7 +516,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
 			dmas = <&dmamux1 0 62 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
 				&dmamux1 1 61 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
@@ -529,7 +529,7 @@
 			compatible = "st,stm32h7-fdcan";
 			reg = <0x4000a000 0x400>, <0x4000ac00 0x350>;
 			reg-names = "m_can", "message_ram";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <19 0>, <21 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x0 28 8 3 3 0 3 3>;
@@ -540,7 +540,7 @@
 			compatible = "st,stm32h7-fdcan";
 			reg = <0x4000a400 0x400>, <0x4000ac00 0x6a0>;
 			reg-names = "m_can", "message_ram";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <20 0>, <22 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x350 28 8 3 3 0 3 3>;
@@ -849,7 +849,7 @@
 
 		lptim1: timers@40002400 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40002400 0x400>;
@@ -868,7 +868,7 @@
 		adc1: adc@40022000 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -885,7 +885,7 @@
 		adc2: adc@40022100 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022100 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -903,7 +903,7 @@
 		adc1_2: adc@40022300 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022300 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -920,7 +920,7 @@
 		adc3: adc@58026000 {
 			compatible = "st,stm32-adc";
 			reg = <0x58026000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 24U)>;
+			clocks = <&rcc STM32_CLOCK(AHB4, 24)>;
 			interrupts = <127 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -937,7 +937,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -948,7 +948,7 @@
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0>, <12 0>, <13 0>, <14 0>, <15 0>, <16 0>,
 						 <17 0>, <47 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			st,mem2mem;
 			dma-offset = <0>;
 			dma-requests = <8>;
@@ -961,7 +961,7 @@
 			reg = <0x40020400 0x400>;
 			interrupts = <56 0>, <57 0>, <58 0>, <59 0>, <60 0>, <68 0>,
 						<69 0>, <70 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			st,mem2mem;
 			dma-offset = <8>;
 			dma-requests = <8>;
@@ -974,7 +974,7 @@
 			reg = <0x58025400 0x400>;
 			interrupts = <129 0>, <130 0>, <131 0>, <132 0>, <133 0>, <134 0>,
 						 <135 0>, <136 0>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 21U)>;
+			clocks = <&rcc STM32_CLOCK(AHB4, 21)>;
 			st,mem2mem;
 			dma-offset = <0>;
 			dma-requests = <8>;
@@ -987,7 +987,7 @@
 			reg = <0x40020800 0x400>;
 			interrupts = <102 0>;
 			/* dmamux1 has no dedicated clock, so we enable dma1 clock */
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <16>;
 			dma-generators = <8>;
 			status = "disabled";
@@ -1003,7 +1003,7 @@
 			reg = <0x58025800 0x400>;
 			interrupts = <128 0>;
 			/* dmamux2 has no dedicated clock, so we enable bdma clock */
-			clocks = <&rcc STM32_CLOCK(AHB4, 21U)>;
+			clocks = <&rcc STM32_CLOCK(AHB4, 21)>;
 			dma-channels = <8>;
 			dma-generators = <8>;
 			status = "disabled";
@@ -1016,7 +1016,7 @@
 		rng: rng@48021800 {
 			compatible = "st,stm32-rng";
 			reg = <0x48021800 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			interrupts = <80 0>;
 			status = "disabled";
 		};
@@ -1024,7 +1024,7 @@
 		sdmmc1: sdmmc@52007000 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x52007000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 16U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 16)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB3, 16U)>;
 			interrupts = <49 0>;
@@ -1034,7 +1034,7 @@
 		sdmmc2: sdmmc@48022400 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x48022400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 9U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 9)>,
 				 <&rcc STM32_SRC_PLL1_Q SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 9U)>;
 			interrupts = <124 0>;
@@ -1067,7 +1067,7 @@
 		fmc: memory-controller@52004000 {
 			compatible = "st,stm32h7-fmc";
 			reg = <0x52004000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 12U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 12)>;
 			status = "disabled";
 
 			sdram: sdram {
@@ -1081,7 +1081,7 @@
 		backup_sram: memory@38800000 {
 			compatible = "zephyr,memory-region", "st,stm32-backup-sram";
 			reg = <0x38800000 DT_SIZE_K(4)>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 28U)>;
+			clocks = <&rcc STM32_CLOCK(AHB4, 28)>;
 			zephyr,memory-region = "BACKUP_SRAM";
 			status = "disabled";
 		};
@@ -1092,7 +1092,7 @@
 			#size-cells = <0>;
 			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <92 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 14)>;
 			status = "disabled";
 		};
 
@@ -1101,7 +1101,7 @@
 			reg = <0x48020000 0x400>;
 			interrupts = <78 0>;
 			interrupt-names = "dcmi";
-			clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			dmas = <&dma1 0 75 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 				STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
 				STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -27,7 +27,7 @@
 		uart9: serial@40011800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40011800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 6U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 6)>;
 			resets = <&rctl STM32_RESET(APB2, 6U)>;
 			interrupts = <155 0>;
 			status = "disabled";
@@ -36,7 +36,7 @@
 		usart10: serial@40011c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 7)>;
 			resets = <&rctl STM32_RESET(APB2, 7U)>;
 			interrupts = <156 0>;
 			status = "disabled";
@@ -77,7 +77,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <DT_SIZE_K(4)>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
 			phys = <&otghs_fs_phy>;
 			status = "disabled";
@@ -88,7 +88,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 3)>;
 			resets = <&rctl STM32_RESET(APB3, 3U)>;
 			status = "disabled";
 		};
@@ -98,7 +98,7 @@
 			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <92 0>;
 			clock-names = "ospix", "ospi-ker";
-			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 14)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -110,7 +110,7 @@
 			reg = <0x5200a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <150 0>;
 			clock-names = "ospix", "ospi-ker";
-			clocks = <&rcc STM32_CLOCK(AHB3, 19U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 19)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -121,7 +121,7 @@
 			compatible = "st,stm32h7-fdcan";
 			reg = <0x4000d400 0x400>, <0x4000ac00 0x9f0>;
 			reg-names = "m_can", "message_ram";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 8)>;
 			interrupts = <159 0>, <160 0>, <63 0>;
 			interrupt-names = "int0", "int1", "calib";
 			bosch,mram-cfg = <0x6a0 28 8 3 3 0 3 3>;
@@ -187,7 +187,7 @@
 			reg = <0x58006800 0x400>;
 			interrupts = <147 0>;
 			interrupt-names = "digi_temp";
-			clocks = <&rcc STM32_CLOCK(APB4, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 26)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7/stm32h730.dtsi
+++ b/dts/arm/st/h7/stm32h730.dtsi
@@ -13,7 +13,7 @@
 		cryp: cryp@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			status = "disabled";

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -41,7 +41,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 3)>;
 			resets = <&rctl STM32_RESET(APB3, 3U)>;
 			status = "disabled";
 		};
@@ -54,7 +54,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
 			phys = <&otghs_fs_phy>;
 			status = "disabled";
@@ -68,7 +68,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB1, 27U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
 			phys = <&otghs_fs_phy>;
 			status = "disabled";

--- a/dts/arm/st/h7/stm32h747.dtsi
+++ b/dts/arm/st/h7/stm32h747.dtsi
@@ -17,7 +17,7 @@
 			#size-cells = <0>;
 			reg = <0x50000000 0x1000>;
 			clock-names = "dsiclk", "refclk", "pixelclk";
-			clocks = <&rcc STM32_CLOCK(APB3, 4U)>,
+			clocks = <&rcc STM32_CLOCK(APB3, 4)>,
 				 <&rcc STM32_SRC_HSE NO_SEL>,
 				 <&rcc STM32_SRC_PLL3_R NO_SEL>;
 			resets = <&rctl STM32_RESET(APB3, 4U)>;

--- a/dts/arm/st/h7/stm32h755.dtsi
+++ b/dts/arm/st/h7/stm32h755.dtsi
@@ -14,7 +14,7 @@
 		cryp: cryp@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};
@@ -22,7 +22,7 @@
 		hash: cryp@48021400 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
 			interrupts = <80 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h757.dtsi
+++ b/dts/arm/st/h7/stm32h757.dtsi
@@ -13,7 +13,7 @@
 		cryp: cryp@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			interrupts = <79 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7_dualcore.dtsi
+++ b/dts/arm/st/h7/stm32h7_dualcore.dtsi
@@ -19,7 +19,7 @@
 		mailbox: mailbox@58026400 {
 			compatible = "st,stm32-hsem-mailbox", "st,mbox-stm32-hsem";
 			reg = <0x58026400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 25U)>;
+			clocks = <&rcc STM32_CLOCK(AHB4, 25)>;
 			#mbox-cells = <1>;
 			status = "disabled";
 		};
@@ -27,5 +27,5 @@
 };
 
 &flash {
-	clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
+	clocks = <&rcc STM32_CLOCK(AHB3, 8)>;
 };

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -40,7 +40,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB1, 25U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 25)>,
 				 <&rcc STM32_SRC_HSI48 USB_SEL(3)>;
 			phys = <&otghs_fs_phy>;
 			status = "disabled";
@@ -51,7 +51,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK(APB3, 3U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 3)>;
 			resets = <&rctl STM32_RESET(APB3, 3U)>;
 			status = "disabled";
 		};
@@ -61,7 +61,7 @@
 			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <92 0>;
 			clock-names = "ospix", "ospi-ker";
-			clocks = <&rcc STM32_CLOCK(AHB3, 14U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 14)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -73,7 +73,7 @@
 			reg = <0x5200a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <150 0>;
 			clock-names = "ospix", "ospi-ker";
-			clocks = <&rcc STM32_CLOCK(AHB3, 19U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 19)>,
 				<&rcc STM32_SRC_PLL1_Q OSPI_SEL(1)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -85,7 +85,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x58001400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB4, 5U)>,
+			clocks = <&rcc STM32_CLOCK(APB4, 5)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI6_SEL(0)>;
 			dmas = <&dmamux2 0 12 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)
 				&dmamux2 1 11 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
@@ -105,7 +105,7 @@
 			reg = <0x58006800 0x400>;
 			interrupts = <147 0>;
 			interrupt-names = "digi_temp";
-			clocks = <&rcc STM32_CLOCK(APB4, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 26)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/h7/stm32h7b0.dtsi
+++ b/dts/arm/st/h7/stm32h7b0.dtsi
@@ -18,7 +18,7 @@
 		cryp: cryp@48021000 {
 			compatible = "st,stm32-cryp";
 			reg = <0x48021000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			resets = <&rctl STM32_RESET(AHB2, 4U)>;
 			interrupts = <79 0>;
 			interrupt-names = "cryp";

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -180,7 +180,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32h7-flash-controller";
 			reg = <0x52002000 0x400>;
 			interrupts = <8 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 8)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -239,7 +239,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 0)>;
 			};
 
 			gpiob: gpio@58020400 {
@@ -247,7 +247,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 1)>;
 			};
 
 			gpioc: gpio@58020800 {
@@ -255,7 +255,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 2)>;
 			};
 
 			gpiod: gpio@58020C00 {
@@ -263,7 +263,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58020C00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 3)>;
 			};
 
 			gpioe: gpio@58021000 {
@@ -271,7 +271,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 4)>;
 			};
 
 			gpiof: gpio@58021400 {
@@ -279,7 +279,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 5)>;
 			};
 
 			gpiog: gpio@58021800 {
@@ -287,7 +287,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 6)>;
 			};
 
 			gpioh: gpio@58021c00 {
@@ -295,7 +295,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58021c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 7)>;
 			};
 
 			gpiom: gpio@58023000 {
@@ -303,7 +303,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58023000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 12U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 12)>;
 			};
 
 			gpion: gpio@58023400 {
@@ -311,7 +311,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58023400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 13U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 13)>;
 			};
 
 			gpioo: gpio@58023800 {
@@ -319,7 +319,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58023800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 14U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 14)>;
 			};
 
 			gpiop: gpio@58023c00 {
@@ -327,14 +327,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x58023c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 15U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 15)>;
 			};
 		};
 
 		usart1: serial@42001000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x42001000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 4U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 4)>;
 			resets = <&rctl STM32_RESET(APB2, 4U)>;
 			interrupts = <82 0>;
 			status = "disabled";
@@ -342,7 +342,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <83 0>;
 			status = "disabled";
@@ -350,7 +350,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <84 0>;
 			status = "disabled";
@@ -358,7 +358,7 @@
 		uart4: serial@40004c00 {
 			compatible ="st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <85 0>;
 			status = "disabled";
@@ -366,7 +366,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <86 0>;
 			status = "disabled";
@@ -374,7 +374,7 @@
 		uart7: serial@40007800 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			resets = <&rctl STM32_RESET(APB1L, 30U)>;
 			interrupts = <87 0>;
 			status = "disabled";
@@ -382,7 +382,7 @@
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			resets = <&rctl STM32_RESET(APB1L, 31U)>;
 			interrupts = <88 0>;
 			status = "disabled";
@@ -391,7 +391,7 @@
 		lpuart1: serial@58000c00 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x58000c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB4, 3U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 3)>;
 			resets = <&rctl STM32_RESET(APB4, 3U)>;
 			interrupts = <131 0>;
 			status = "disabled";
@@ -403,7 +403,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <76 0>, <77 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -415,7 +415,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <78 0>, <79 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -427,7 +427,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <80 0>, <81 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -438,7 +438,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x42003000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				<&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
 			interrupts = <58 0>;
 			status = "disabled";
@@ -449,7 +449,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>,
 				<&rcc STM32_SRC_PLL1_Q SPI23_SEL(0)>;
 			interrupts = <59 0>;
 			status = "disabled";
@@ -460,7 +460,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>,
 				<&rcc STM32_SRC_PLL1_Q SPI23_SEL(0)>;
 			interrupts = <60 0>;
 			status = "disabled";
@@ -471,7 +471,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x42003400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			interrupts = <61 0>;
 			status = "disabled";
 		};
@@ -481,7 +481,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x42005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 20)>;
 			interrupts = <62 0>;
 			status = "disabled";
 		};
@@ -491,7 +491,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>,
 				 <&rcc STM32_SRC_PLL1_Q SPI1_SEL(0)>;
 			interrupts = <35 3>;
 			status = "disabled";
@@ -502,7 +502,7 @@
 			reg = <0x52005000 0x1000>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <105 0>;
 			clock-names = "xspix";
-			clocks = <&rcc STM32_CLOCK(AHB5, 5U)>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 5)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -513,7 +513,7 @@
 			reg = <0x5200a000 0x1000>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <106 0>;
 			clock-names = "xspix";
-			clocks = <&rcc STM32_CLOCK(AHB5, 12U)>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 12)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -529,7 +529,7 @@
 		wwdg: wwdg1: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x1000>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <4 7>;
 			status = "disabled";
 		};
@@ -766,7 +766,7 @@
 
 		lptim1: timers@40002400 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 9)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40002400 0x400>;
@@ -778,7 +778,7 @@
 		adc1: adc@40022000 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <38 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -794,7 +794,7 @@
 		adc2: adc@40022100 {
 			compatible = "st,stm32-adc";
 			reg = <0x40022100 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			interrupts = <38 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -810,7 +810,7 @@
 		rng: rng@48020000 {
 			compatible = "st,stm32-rng";
 			reg = <0x48020000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
 			interrupts = <37 0>;
 			status = "disabled";
 		};
@@ -824,7 +824,7 @@
 			ram-size = <1280>;
 			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 27U)>,
+			clocks = <&rcc STM32_CLOCK(AHB1, 27)>,
 				 <&rcc STM32_SRC_HSI48 OTGFS_SEL(0)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -96,7 +96,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <2 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -162,7 +162,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 0U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 0)>;
 			};
 
 			gpiob: gpio@50000400 {
@@ -170,7 +170,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 1U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 1)>;
 			};
 
 			gpioc: gpio@50000800 {
@@ -178,7 +178,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 2U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 2)>;
 			};
 
 			gpiod: gpio@50000c00 {
@@ -186,7 +186,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 3U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 3)>;
 			};
 
 			gpioh: gpio@50001c00 {
@@ -194,7 +194,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 7U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 7)>;
 			};
 		};
 
@@ -207,7 +207,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 2>;
 			status = "disabled";
 		};
@@ -215,7 +215,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -224,7 +224,7 @@
 		lpuart1: serial@40004800 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -236,7 +236,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -247,7 +247,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <25 3>;
 			status = "disabled";
 		};
@@ -300,7 +300,7 @@
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -312,7 +312,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <12 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -331,7 +331,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0 11 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/l0/stm32l031.dtsi
+++ b/dts/arm/st/l0/stm32l031.dtsi
@@ -13,7 +13,7 @@
 		timers22: timers@40011400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40011400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 5)>;
 			resets = <&rctl STM32_RESET(APB2, 5U)>;
 			interrupts = <22 0>;
 			interrupt-names = "global";

--- a/dts/arm/st/l0/stm32l051.dtsi
+++ b/dts/arm/st/l0/stm32l051.dtsi
@@ -16,7 +16,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -27,7 +27,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};
@@ -35,7 +35,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <27 0>;
 			status = "disabled";

--- a/dts/arm/st/l0/stm32l053.dtsi
+++ b/dts/arm/st/l0/stm32l053.dtsi
@@ -29,7 +29,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>,
 				 <&rcc STM32_SRC_HSI48 HSI48_SEL(1)>;
 			status = "disabled";
 		};
@@ -37,7 +37,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/l0/stm32l071.dtsi
+++ b/dts/arm/st/l0/stm32l071.dtsi
@@ -16,7 +16,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 4U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 4)>;
 			};
 		};
 
@@ -26,7 +26,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -38,7 +38,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			interrupts = <21 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -49,7 +49,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 3>;
 			status = "disabled";
 		};
@@ -137,7 +137,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <27 0>;
 			status = "disabled";
@@ -146,7 +146,7 @@
 		usart4: serial@40004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <14 0>;
 			status = "disabled";
@@ -155,7 +155,7 @@
 		usart5: serial@40005000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <14 0>;
 			status = "disabled";

--- a/dts/arm/st/l0/stm32l072.dtsi
+++ b/dts/arm/st/l0/stm32l072.dtsi
@@ -32,7 +32,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>,
 				 <&rcc STM32_SRC_HSI48 HSI48_SEL(1)>;
 			status = "disabled";
 		};
@@ -41,7 +41,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x40025000 0x400>;
 			interrupts = <29 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 20)>;
 			status = "disabled";
 		};
 	};
@@ -54,7 +54,7 @@
 	dac1: dac@40007400 {
 		compatible = "st,stm32-dac";
 		reg = <0x40007400 0x400>;
-		clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+		clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 		status = "disabled";
 		#io-channel-cells = <1>;
 	};

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -104,7 +104,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32f1-flash-controller";
 			reg = <0x40023c00 0x400>;
 			interrupts = <4 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 15)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -135,7 +135,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -145,7 +145,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -154,7 +154,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -163,7 +163,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <48 0>;
 			status = "disabled";
@@ -172,7 +172,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1, 20U)>;
 			interrupts = <49 0>;
 			status = "disabled";
@@ -184,7 +184,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -196,7 +196,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -233,7 +233,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			interrupts = <35 0>;
 			status = "disabled";
 		};
@@ -243,7 +243,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 0>;
 			status = "disabled";
 		};
@@ -251,7 +251,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -260,7 +260,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32f4-adc", "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>,
 				 <&rcc STM32_SRC_HSI NO_SEL>;
 			interrupts = <18 0>;
 			status = "disabled";
@@ -278,7 +278,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -448,7 +448,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			};
 
 			gpiob: gpio@40020400 {
@@ -456,7 +456,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			};
 
 			gpioc: gpio@40020800 {
@@ -464,7 +464,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			};
 
 			gpiod: gpio@40020c00 {
@@ -472,7 +472,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40020c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 3)>;
 			};
 
 			gpioe: gpio@40021000 {
@@ -480,7 +480,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 4)>;
 			};
 
 			gpioh: gpio@40021400 {
@@ -488,7 +488,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB1, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB1, 5)>;
 			};
 		};
 
@@ -501,7 +501,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -515,7 +515,7 @@
 			compatible = "st,stm32-dma-v2bis";
 			#dma-cells = <2>;
 			reg = <0x40026000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 24U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 24)>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l1/stm32l151Xc.dtsi
+++ b/dts/arm/st/l1/stm32l151Xc.dtsi
@@ -42,7 +42,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <47 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l1/stm32l152Xc.dtsi
+++ b/dts/arm/st/l1/stm32l152Xc.dtsi
@@ -42,7 +42,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <47 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l1/stm32l152Xe.dtsi
+++ b/dts/arm/st/l1/stm32l152Xe.dtsi
@@ -42,7 +42,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <47 0>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -125,7 +125,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32l4-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <4 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -178,7 +178,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			};
 
 			gpiob: gpio@48000400 {
@@ -186,7 +186,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			};
 
 			gpioc: gpio@48000800 {
@@ -194,7 +194,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			};
 
 			gpioh: gpio@48001c00 {
@@ -202,7 +202,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 7)>;
 			};
 		};
 
@@ -215,7 +215,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -223,7 +223,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -232,7 +232,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -241,7 +241,7 @@
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
 			resets = <&rctl STM32_RESET(APB1H, 0U)>;
 			interrupts = <70 0>;
 			status = "disabled";
@@ -253,7 +253,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <31 0>, <32 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -265,7 +265,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <72 0>, <73 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -277,7 +277,7 @@
 			#size-cells = <0>;
 			reg = <0xa0001000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <71 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 8)>;
 			status = "disabled";
 		};
 
@@ -287,7 +287,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <35 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			status = "disabled";
 		};
 
@@ -400,7 +400,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 28U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 28)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <18>;
@@ -410,7 +410,7 @@
 		adc1: adc@50040000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50040000 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -426,7 +426,7 @@
 		adc2: adc@50040100 {
 			compatible = "st,stm32-adc";
 			reg = <0x50040100 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -444,7 +444,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-requests = <7>;
 			status = "disabled";
 		};
@@ -454,14 +454,14 @@
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-requests = <7>;
 			status = "disabled";
 		};
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -475,7 +475,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
 			interrupts = <66 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
@@ -485,7 +485,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x50060800 0x400>;
 			interrupts = <80 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				/* Following domain clock setting requires MSI
 				 * clock to be enabled with msi-range = <11>;
 				 */

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -22,7 +22,7 @@
 
 
 		rng: rng@50060800 {
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 
@@ -35,7 +35,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			status = "disabled";
 		};
@@ -45,7 +45,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
@@ -58,14 +58,14 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			interrupts = <36 5>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			status = "disabled";
 		};
 
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l422.dtsi
+++ b/dts/arm/st/l4/stm32l422.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@50060000 {
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";

--- a/dts/arm/st/l4/stm32l431.dtsi
+++ b/dts/arm/st/l4/stm32l431.dtsi
@@ -25,7 +25,7 @@
 			gpiod: gpio@48000c00 {
 				compatible = "st,stm32-gpio";
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 				gpio-controller;
 				#gpio-cells = <2>;
 			};
@@ -33,7 +33,7 @@
 			gpioe: gpio@48001000 {
 				compatible = "st,stm32-gpio";
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 				gpio-controller;
 				#gpio-cells = <2>;
 			};
@@ -41,7 +41,7 @@
 		};
 
 		rng: rng@50060800 {
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 
@@ -50,7 +50,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
@@ -62,7 +62,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -72,7 +72,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -80,7 +80,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -106,7 +106,7 @@
 		can1: can@40006400 {
 			compatible = "st,stm32-bxcan";
 			reg = <0x40006400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
 			status = "disabled";
@@ -115,7 +115,7 @@
 		sdmmc1: sdmmc@40012800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;
@@ -125,7 +125,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			#io-channel-cells = <1>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -21,7 +21,7 @@
 		compatible = "st,stm32l432", "st,stm32l4", "simple-bus";
 
 		rng: rng@50060800 {
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 
@@ -30,7 +30,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -57,7 +57,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>; //RCC_APB1ENR1_CAN1EN
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 		};
 
@@ -70,7 +70,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			status = "disabled";
 		};
@@ -78,7 +78,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/st/l4/stm32l433.dtsi
+++ b/dts/arm/st/l4/stm32l433.dtsi
@@ -16,7 +16,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioe: gpio@48001000 {
@@ -24,7 +24,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 		};
 
@@ -34,7 +34,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -45,7 +45,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -53,7 +53,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -62,7 +62,7 @@
 		sdmmc1: sdmmc@40012800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			interrupts = <49 0>;
 			status = "disabled";

--- a/dts/arm/st/l4/stm32l451.dtsi
+++ b/dts/arm/st/l4/stm32l451.dtsi
@@ -26,7 +26,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioe: gpio@48001000 {
@@ -34,12 +34,12 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 		};
 
 		rng: rng@50060800 {
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 
@@ -49,7 +49,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -61,7 +61,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40008400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 1U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 1)>;
 			interrupts = <83 0>, <84 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -72,7 +72,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -82,7 +82,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -90,7 +90,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -99,7 +99,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -131,7 +131,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -141,14 +141,14 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>; //RCC_APB1ENR1_CAN1EN
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 		};
 
 		sdmmc1: sdmmc@40012800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -19,7 +19,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l462.dtsi
+++ b/dts/arm/st/l4/stm32l462.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@50060000 {
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -25,7 +25,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioe: gpio@48001000 {
@@ -33,7 +33,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 
 			gpiof: gpio@48001400 {
@@ -41,7 +41,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
 			};
 
 			gpiog: gpio@48001800 {
@@ -49,14 +49,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			};
 		};
 
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -65,7 +65,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -74,7 +74,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -86,7 +86,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -97,7 +97,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -107,7 +107,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -244,14 +244,14 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>; //RCC_APB1ENR1_CAN1EN
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 		};
 
 		sdmmc1: sdmmc@40012800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x40012800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_MSI CLK48_SEL(3)>;
 			resets = <&rctl STM32_RESET(APB2, 10U)>;
 			interrupts = <49 0>;
@@ -261,7 +261,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -269,7 +269,7 @@
 		adc3: adc@50040200 {
 			compatible = "st,stm32-adc";
 			reg = <0x50040200 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <47 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;

--- a/dts/arm/st/l4/stm32l475.dtsi
+++ b/dts/arm/st/l4/stm32l475.dtsi
@@ -19,7 +19,7 @@
 			ram-size = <1280>;
 			maximum-speed = "full-speed";
 			phys = <&otgfs_phy>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 12)>,
 				 <&rcc STM32_SRC_MSI CLK48_SEL(3)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l486.dtsi
+++ b/dts/arm/st/l4/stm32l486.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@50060000 {
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -21,7 +21,7 @@
 		compatible = "st,stm32l496", "st,stm32l4", "simple-bus";
 
 		rng: rng@50060800 {
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 
@@ -31,7 +31,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40008400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 1U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 1)>;
 			interrupts = <83 0>, <84 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -46,7 +46,7 @@
 				#gpio-cells = <2>;
 				ngpios = <12>;
 				reg = <0x48002000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 8)>;
 			};
 		};
 
@@ -55,18 +55,18 @@
 			reg = <0x40006800 0x400>;
 			interrupts = <86 0>, <87 0>, <88 0>, <89 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>; //RCC_APB1ENR1_CAN2EN
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>; //RCC_APB1ENR1_CAN2EN
 			master-can-reg = <0x40006400>;
 			status = "disabled";
 		};
 
 		usbotg_fs: otgfs@50000000 {
-			clocks = <&rcc STM32_CLOCK(AHB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 12)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 
 		sdmmc1: sdmmc@40012800 {
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 	};

--- a/dts/arm/st/l4/stm32l4a6.dtsi
+++ b/dts/arm/st/l4/stm32l4a6.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@50060000 {
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";

--- a/dts/arm/st/l4/stm32l4p5.dtsi
+++ b/dts/arm/st/l4/stm32l4p5.dtsi
@@ -53,7 +53,7 @@
 		};
 
 		rng: rng@50060800 {
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 		};
 
@@ -65,7 +65,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioe: gpio@48001000 {
@@ -73,7 +73,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 
 			gpiof: gpio@48001400 {
@@ -81,7 +81,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
 			};
 
 			gpiog: gpio@48001800 {
@@ -89,7 +89,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			};
 
 			gpioi: gpio@48002000 {
@@ -97,14 +97,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48002000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 8)>;
 			};
 		};
 
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -113,7 +113,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -122,7 +122,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -134,7 +134,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <33 0>, <34 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -146,7 +146,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40008400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 1U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 1)>;
 			interrupts = <84 0>, <83 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -157,7 +157,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -167,7 +167,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -310,7 +310,7 @@
 			reg = <0x40006400 0x400>;
 			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>; //RCC_APB1ENR1_CAN1EN
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>; //RCC_APB1ENR1_CAN1EN
 			status = "disabled";
 		};
 
@@ -322,7 +322,7 @@
 			num-bidir-endpoints = <6>;
 			ram-size = <1280>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK(AHB2, 12U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 12)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			phys = <&otgfs_phy>;
 			status = "disabled";
@@ -341,7 +341,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020800 0x400>;
 			interrupts = <94 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			dma-channels = <14>;
 			dma-generators = <4>;
 			dma-requests= <89>;
@@ -353,7 +353,7 @@
 			reg = <0x50050000 0x400>;
 			interrupts = <85 0>;
 			interrupt-names = "dcmi";
-			clocks = <&rcc STM32_CLOCK(AHB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 14)>;
 			dmas = <&dma1 0 91 (STM32_DMA_PERIPH_TO_MEMORY | STM32_DMA_PERIPH_NO_INC |
 				STM32_DMA_MEM_INC | STM32_DMA_PERIPH_8BITS | STM32_DMA_MEM_32BITS |
 				STM32_DMA_PRIORITY_HIGH) STM32_DMA_FIFO_1_4>;
@@ -363,7 +363,7 @@
 		sdmmc1: sdmmc@50062400 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x50062400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 22U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 22)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <49 0>;
@@ -374,7 +374,7 @@
 		sdmmc2: sdmmc@50062800 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x50062800 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 23U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 23)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 23U)>;
 			interrupts = <47 0>;
@@ -385,7 +385,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -395,9 +395,9 @@
 			reg = <0xa0001000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <71 0>;
 			clock-names = "ospix", "ospi-ker", "ospi-mgr";
-			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 8)>,
 				<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>,
-				<&rcc STM32_CLOCK(AHB2, 20U)>;
+				<&rcc STM32_CLOCK(AHB2, 20)>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -409,9 +409,9 @@
 			reg = <0xa0001400 0x400>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <76 0>;
 			clock-names = "ospix", "ospi-ker", "ospi-mgr";
-			clocks = <&rcc STM32_CLOCK(AHB3, 9U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 9)>,
 				<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>,
-				<&rcc STM32_CLOCK(AHB2, 20U)>;
+				<&rcc STM32_CLOCK(AHB2, 20)>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/st/l4/stm32l4q5.dtsi
+++ b/dts/arm/st/l4/stm32l4q5.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@50060000 {
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";

--- a/dts/arm/st/l4/stm32l4r9.dtsi
+++ b/dts/arm/st/l4/stm32l4r9.dtsi
@@ -17,7 +17,7 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <91 0>, <92 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK(APB2, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 26)>;
 			resets = <&rctl STM32_RESET(APB2, 26U)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l4s5.dtsi
+++ b/dts/arm/st/l4/stm32l4s5.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@50060000 {
 			compatible = "st,stm32l4-aes", "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <79 0>;
 			interrupt-names = "aes";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -125,7 +125,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32l5-flash-controller";
 			reg = <0x40022000 0x400>;
 			interrupts = <6 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 8)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -188,7 +188,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			};
 
 			gpiob: gpio@42020400 {
@@ -196,7 +196,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			};
 
 			gpioc: gpio@42020800 {
@@ -204,7 +204,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			};
 
 			gpiod: gpio@42020c00 {
@@ -212,7 +212,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioe: gpio@42021000 {
@@ -220,7 +220,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 
 			gpiof: gpio@42021400 {
@@ -228,7 +228,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 5)>;
 			};
 
 			gpiog: gpio@42021800 {
@@ -236,7 +236,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 6)>;
 			};
 
 			gpioh: gpio@42021c00 {
@@ -244,7 +244,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 7)>;
 			};
 		};
 
@@ -257,7 +257,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 6>;
 			status = "disabled";
 		};
@@ -265,7 +265,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <61 0>;
 			status = "disabled";
@@ -274,7 +274,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <62 0>;
 			status = "disabled";
@@ -283,7 +283,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <63 0>;
 			status = "disabled";
@@ -292,7 +292,7 @@
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <64 0>;
 			status = "disabled";
@@ -301,7 +301,7 @@
 		uart5: serial@40005000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40005000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <65 0>;
 			status = "disabled";
@@ -310,7 +310,7 @@
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
 			resets = <&rctl STM32_RESET(APB1H, 0U)>;
 			interrupts = <66 0>;
 			status = "disabled";
@@ -318,7 +318,7 @@
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -332,7 +332,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <29 0 30 0 31 0 32 0 33 0 34 0 35 0 36 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-requests = <8>;
 			dma-offset = <0>;
 			status = "disabled";
@@ -343,7 +343,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
 			interrupts = <80 0 81 0 82 0 83 0 84 0 85 0 86 0 87 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-requests = <8>;
 			dma-offset = <8>;
 			status = "disabled";
@@ -354,7 +354,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020800 0x400>;
 			interrupts = <27 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			dma-channels = <16>;
 			dma-generators = <4>;
 			dma-requests= <90>;
@@ -367,7 +367,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <55 0>, <56 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -379,7 +379,7 @@
 			#size-cells = <0>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <57 0>, <58 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -391,14 +391,14 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <59 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			status = "disabled";
 		};
 
 		sdmmc1: sdmmc@420c8000 {
 			compatible = "st,stm32-sdmmc";
 			reg = <0x420c8000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 22U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 22)>,
 				 <&rcc STM32_SRC_HSI48 SDMMC_SEL(0)>;
 			resets = <&rctl STM32_RESET(AHB2, 22U)>;
 			interrupts = <78 0>;
@@ -408,7 +408,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -419,7 +419,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			interrupts = <60 5>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			status = "disabled";
 		};
 
@@ -429,7 +429,7 @@
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
 			interrupts = <99 5>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			status = "disabled";
 		};
 
@@ -438,7 +438,7 @@
 			reg = <0x44021000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <76 0>;
 			clock-names = "ospix", "ospi-ker";
-			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>,
+			clocks = <&rcc STM32_CLOCK(AHB3, 8)>,
 					<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -449,7 +449,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;
 			interrupts = <94 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>;
 			nist-config = <0xf00d00>;
 			health-test-magic = <0x17590abc>;
 			health-test-config = <0xa2b3>;
@@ -460,7 +460,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <2 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 10)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -667,7 +667,7 @@
 		adc1: adc@42028000 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028000 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <37 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -683,7 +683,7 @@
 		adc2: adc@42028100 {
 			compatible = "st,stm32-adc";
 			reg = <0x42028100 0x100>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <37 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -716,7 +716,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			status = "disabled";
-			clocks = <&rcc STM32_CLOCK(APB1_2, 21U)>,
+			clocks = <&rcc STM32_CLOCK(APB1_2, 21)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			phys = <&usb_fs_phy>;
 		};
@@ -724,7 +724,7 @@
 		ucpd1: ucpd@4000dc00 {
 			compatible = "st,stm32-ucpd";
 			reg = <0x4000dc00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <106 0>;
 			status = "disabled";
 		};
@@ -732,7 +732,7 @@
 		fmc: fmc@44020000 {
 			compatible = "st,stm32-fmc";
 			reg = <0x44020000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/l5/stm32l562.dtsi
+++ b/dts/arm/st/l5/stm32l562.dtsi
@@ -13,7 +13,7 @@
 		aes: aes@420c0000 {
 			compatible = "st,stm32-aes";
 			reg = <0x420c0000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <93 0>;
 			status = "disabled";

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -87,7 +87,7 @@
 				reg = <0x50002000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 0)>;
 			};
 
 			gpiob: gpio@50003000 {
@@ -95,7 +95,7 @@
 				reg = <0x50003000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 1)>;
 			};
 
 			gpioc: gpio@50004000 {
@@ -103,7 +103,7 @@
 				reg = <0x50004000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 2)>;
 			};
 
 			gpiod: gpio@50005000 {
@@ -111,7 +111,7 @@
 				reg = <0x50005000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 3)>;
 			};
 
 			gpioe: gpio@50006000 {
@@ -119,7 +119,7 @@
 				reg = <0x50006000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 4)>;
 			};
 
 			gpiof: gpio@50007000 {
@@ -127,7 +127,7 @@
 				reg = <0x50007000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 5U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 5)>;
 			};
 
 			gpiog: gpio@50008000 {
@@ -135,7 +135,7 @@
 				reg = <0x50008000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 6U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 6)>;
 			};
 
 			gpioh: gpio@50009000 {
@@ -143,7 +143,7 @@
 				reg = <0x50009000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 7)>;
 			};
 
 			gpioi: gpio@5000a000 {
@@ -151,7 +151,7 @@
 				reg = <0x5000a000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 8U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 8)>;
 			};
 
 			gpioj: gpio@5000b000 {
@@ -159,7 +159,7 @@
 				reg = <0x5000b000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 9U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 9)>;
 			};
 
 			gpiok: gpio@5000c000 {
@@ -167,14 +167,14 @@
 				reg = <0x5000c000 0x400>;
 				gpio-controller;
 				#gpio-cells = <2>;
-				clocks = <&rcc STM32_CLOCK(AHB4, 10U)>;
+				clocks = <&rcc STM32_CLOCK(AHB4, 10)>;
 			};
 		};
 
 		wwdg: wwdg1: watchdog@4000a000 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x4000a000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -183,7 +183,7 @@
 			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x48000000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0 47 0>;
 			dma-offset = <0>;
 			dma-requests = <8>;
@@ -194,7 +194,7 @@
 			compatible = "st,stm32-dma-v1";
 			#dma-cells = <4>;
 			reg = <0x48001000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			interrupts = <56 0 57 0 58 0 59 0 60 0 68 0 69 0 70 0>;
 			dma-offset = <8>;
 			dma-requests = <8>;
@@ -205,7 +205,7 @@
 			compatible = "st,stm32-dmamux";
 			#dma-cells = <3>;
 			reg = <0x48002000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			interrupts = <102 0>;
 			dma-channels = <16>;
 			dma-generators = <8>;
@@ -218,7 +218,7 @@
 			reg = <0x44004000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB2, 8U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 8)>;
 			interrupts = <35 5>;
 			status = "disabled";
 		};
@@ -228,7 +228,7 @@
 			reg = <0x4000b000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <36 5>;
 			status = "disabled";
 		};
@@ -238,7 +238,7 @@
 			reg = <0x4000c000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
 			interrupts = <51 5>;
 			status = "disabled";
 		};
@@ -248,7 +248,7 @@
 			reg = <0x44005000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <84 5>;
 			status = "disabled";
 		};
@@ -258,7 +258,7 @@
 			reg = <0x44009000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB2, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 10)>;
 			interrupts = <85 5>;
 			status = "disabled";
 		};
@@ -266,7 +266,7 @@
 		usart2: serial@4000e000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x4000e000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			resets = <&rctl STM32_RESET(APB1, 14U)>;
 			interrupts = <38 0>;
 			status = "disabled";
@@ -275,7 +275,7 @@
 		usart3: serial@4000f000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x4000f000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			resets = <&rctl STM32_RESET(APB1, 15U)>;
 			interrupts = <39 0>;
 			status = "disabled";
@@ -284,7 +284,7 @@
 		uart4: serial@40010000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40010000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 16U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 16)>;
 			resets = <&rctl STM32_RESET(APB1, 16U)>;
 			interrupts = <52 0>;
 			status = "disabled";
@@ -293,7 +293,7 @@
 		uart5: serial@40011000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40011000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1, 17U)>;
 			interrupts = <53 0>;
 			status = "disabled";
@@ -302,7 +302,7 @@
 		usart6: serial@44003000 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x44003000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 13)>;
 			resets = <&rctl STM32_RESET(APB2, 13U)>;
 			interrupts = <71 0>;
 			status = "disabled";
@@ -311,7 +311,7 @@
 		uart7: serial@40018000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40018000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1, 18U)>;
 			interrupts = <82 0>;
 			status = "disabled";
@@ -320,7 +320,7 @@
 		uart8: serial@40019000 {
 			compatible = "st,stm32-uart";
 			reg = <0x40019000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1, 19U)>;
 			interrupts = <83 0>;
 			status = "disabled";
@@ -332,7 +332,7 @@
 			reg = <0x40015000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 24U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 24)>;
 			interrupt-names = "event", "error";
 			interrupts = <107 0>, <108 0>;
 			status = "disabled";
@@ -341,7 +341,7 @@
 		timers3: timers@40001000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40001000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 1)>;
 			resets = <&rctl STM32_RESET(APB1, 1U)>;
 			interrupts = <29 0>;
 			interrupt-names = "global";
@@ -363,7 +363,7 @@
 		timers5: timers@40003000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40003000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 3U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 3)>;
 			resets = <&rctl STM32_RESET(APB1, 3U)>;
 			interrupts = <50 0>;
 			interrupt-names = "global";
@@ -385,7 +385,7 @@
 		mailbox: mailbox@4c001000 {
 			compatible = "st,stm32-ipcc-mailbox";
 			reg = <0x4c001000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 12U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 12)>;
 			interrupts = <103 0>, <104 0>;
 			interrupt-names = "rxo", "txf";
 			status = "disabled";
@@ -396,7 +396,7 @@
 			reg = <0x5a001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK(APB4, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB4, 0)>;
 			resets = <&rctl STM32_RESET(APB4, 26U)>;
 			status = "disabled";
 		};

--- a/dts/arm/st/u0/stm32u0.dtsi
+++ b/dts/arm/st/u0/stm32u0.dtsi
@@ -168,7 +168,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 0U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 0)>;
 			};
 
 			gpiob: gpio@50000400 {
@@ -176,7 +176,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 1U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 1)>;
 			};
 
 			gpioc: gpio@50000800 {
@@ -184,7 +184,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 2U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 2)>;
 			};
 
 			gpiod: gpio@50000C00 {
@@ -192,7 +192,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50000C00 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 3U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 3)>;
 			};
 
 			gpioe: gpio@50001000 {
@@ -200,7 +200,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 4U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 4)>;
 			};
 
 			gpiof: gpio@50001400 {
@@ -208,14 +208,14 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x50001400 0x400>;
-				clocks = <&rcc STM32_CLOCK(IOP, 5U)>;
+				clocks = <&rcc STM32_CLOCK(IOP, 5)>;
 			};
 		};
 
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 14)>;
 			resets = <&rctl STM32_RESET(APB1H, 14U)>;
 			interrupts = <27 0>;
 			status = "disabled";
@@ -224,7 +224,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -233,7 +233,7 @@
 		usart3: serial@40004800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 18)>;
 			resets = <&rctl STM32_RESET(APB1L, 18U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -242,7 +242,7 @@
 		usart4: serial@40004c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 19U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 19)>;
 			resets = <&rctl STM32_RESET(APB1L, 19U)>;
 			interrupts = <30 0>;
 			status = "disabled";
@@ -251,7 +251,7 @@
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 20)>;
 			resets = <&rctl STM32_RESET(APB1L, 20U)>;
 			interrupts = <29 0>;
 			status = "disabled";
@@ -260,7 +260,7 @@
 		lpuart2: serial@40008400 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 7)>;
 			resets = <&rctl STM32_RESET(APB1L, 7U)>;
 			interrupts = <28 0>;
 			status = "disabled";
@@ -275,7 +275,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -283,7 +283,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 20U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 20)>;
 			interrupts = <12 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -300,7 +300,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -311,7 +311,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <23 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -323,7 +323,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -335,7 +335,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40008800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -346,7 +346,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <9 0 10 0 10 0 11 0 11 0 11 0 11 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-requests = <7>;
 			dma-offset = <0>;
 			status = "disabled";
@@ -368,7 +368,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 12)>;
 			interrupts = <25 0>;
 			status = "disabled";
 		};
@@ -378,7 +378,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			interrupts = <26 0>;
 			status = "disabled";
 		};
@@ -388,7 +388,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 15U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 15)>;
 			interrupts = <26 0>;
 			status = "disabled";
 		};
@@ -396,7 +396,7 @@
 		rng: rng@40025000 {
 			compatible = "st,stm32-rng";
 			reg = <0x40025000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 18)>;
 			interrupts = <31 0>;
 			status = "disabled";
 		};
@@ -404,7 +404,7 @@
 		aes: aes@40026000 {
 			compatible = "st,stm32-aes";
 			reg = <0x40026000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 16)>;
 			resets = <&rctl STM32_RESET(AHB1, 16U)>;
 			interrupts = <31 0>;
 			interrupt-names = "aes";
@@ -415,7 +415,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <2 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 10)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <28>;
@@ -563,7 +563,7 @@
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -575,7 +575,7 @@
 
 		lptim2: timers@40009400 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 30U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 30)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
@@ -587,7 +587,7 @@
 		tsc: tsc@40024000 {
 			compatible = "st,stm32-tsc";
 			reg = <0x40024000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 24U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 24)>;
 			resets = <&rctl STM32_RESET(AHB1, 24U)>;
 			interrupts = <21 0>;
 			interrupt-names = "global";

--- a/dts/arm/st/u0/stm32u073.dtsi
+++ b/dts/arm/st/u0/stm32u073.dtsi
@@ -16,7 +16,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x4000a000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 25U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 25)>;
 			interrupts = <24 0>;
 			interrupt-names = "combined";
 			status = "disabled";
@@ -24,7 +24,7 @@
 
 		lptim3: timers@40009000 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009000 0x400>;
@@ -38,7 +38,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
 			interrupts = <11 0 11 0 11 0 11 0 11 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-requests = <5>;
 			dma-offset = <7>;
 			status = "disabled";
@@ -57,7 +57,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 13U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 13)>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/st/u0/stm32u083.dtsi
+++ b/dts/arm/st/u0/stm32u083.dtsi
@@ -13,7 +13,7 @@
 		lpuart3: serial@40008c00 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 12)>;
 			resets = <&rctl STM32_RESET(APB1L, 12U)>;
 			interrupts = <30 0>;
 			status = "disabled";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -476,7 +476,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015404 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 					 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
 			dmas = <&gpdma1 1 36 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;
@@ -488,7 +488,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015424 0x20>;
-			clocks = <&rcc STM32_CLOCK(APB2, 21U)>,
+			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 					 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
 			dmas = <&gpdma1 0 37 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
 				STM32_DMA_16BITS)>;
@@ -725,9 +725,9 @@
 			reg = <0x420d2400 0x400>, <0x70000000 DT_SIZE_M(256)>;
 			interrupts = <120 0>;
 			clock-names = "ospix", "ospi-ker", "ospi-mgr";
-			clocks = <&rcc STM32_CLOCK(AHB2_2, 8U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2_2, 8)>,
 				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>,
-				<&rcc STM32_CLOCK(AHB2, 21U)>;
+				<&rcc STM32_CLOCK(AHB2, 21)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -145,7 +145,7 @@
 			compatible = "st,stm32-flash-controller", "st,stm32wb-flash-controller";
 			reg = <0x58004000 0x400>;
 			interrupts = <4 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 25U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 25)>;
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -197,7 +197,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			};
 
 			gpiob: gpio@48000400 {
@@ -205,7 +205,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			};
 
 			gpioc: gpio@48000800 {
@@ -213,7 +213,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			};
 
 			gpiod: gpio@48000c00 {
@@ -221,7 +221,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 3U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 3)>;
 			};
 
 			gpioe: gpio@48001000 {
@@ -230,7 +230,7 @@
 				#gpio-cells = <2>;
 				ngpios = <5>;
 				reg = <0x48001000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 4U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 4)>;
 			};
 
 			gpioh: gpio@48001c00 {
@@ -239,14 +239,14 @@
 				#gpio-cells = <2>;
 				ngpios = <4>;
 				reg = <0x48001c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 7)>;
 			};
 		};
 
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -254,7 +254,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <36 0>;
 			status = "disabled";
@@ -266,7 +266,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <30 0>, <31 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -278,7 +278,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <32 0>, <33 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -288,7 +288,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <41 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 10)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -307,7 +307,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <34 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			status = "disabled";
 		};
 
@@ -317,14 +317,14 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			interrupts = <35 5>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			status = "disabled";
 		};
 
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
 			resets = <&rctl STM32_RESET(APB1H, 0U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -420,7 +420,7 @@
 		adc1: adc@50040000 {
 			compatible = "st,stm32-adc";
 			reg = <0x50040000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 13U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 13)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -441,7 +441,7 @@
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -455,7 +455,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-requests = <7>;
 			dma-offset = <0>;
 			status = "disabled";
@@ -466,7 +466,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
 			interrupts = <55 0 56 0 57 0 58 0 59 0 60 0 61 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-requests = <7>;
 			dma-offset = <7>;
 			status = "disabled";
@@ -477,7 +477,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020800 0x400>;
 			interrupts = <62 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			dma-channels = <14>;
 			dma-generators = <4>;
 			dma-requests= <36>;
@@ -493,7 +493,7 @@
 			ram-size = <1024>;
 			maximum-speed = "full-speed";
 			phys = <&usb_fs_phy>;
-			clocks = <&rcc STM32_CLOCK(APB1, 26U)>,
+			clocks = <&rcc STM32_CLOCK(APB1, 26)>,
 				 <&rcc STM32_SRC_HSI48 CLK48_SEL(0)>;
 			status = "disabled";
 		};
@@ -504,7 +504,7 @@
 			#size-cells = <0>;
 			reg = <0xa0001000 0x400>, <0x90000000 DT_SIZE_M(256)>;
 			interrupts = <0x32 0x0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 8U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 8)>;
 			status = "disabled";
 		};
 
@@ -512,14 +512,14 @@
 			compatible = "st,stm32-rng";
 			reg = <0x58001000 0x400>;
 			interrupts = <53 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 18)>;
 			status = "disabled";
 		};
 
 		aes1: aes@50060000 {
 			compatible = "st,stm32-aes";
 			reg = <0x50060000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 16U)>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 16)>;
 			resets = <&rctl STM32_RESET(AHB2, 16U)>;
 			interrupts = <51 0>;
 			status = "disabled";
@@ -582,7 +582,7 @@
 
 	ble_rf: ble_rf {
 		compatible = "st,stm32wb-rf";
-		clocks = <&rcc STM32_CLOCK(AHB3, 20U)>,
+		clocks = <&rcc STM32_CLOCK(AHB3, 20)>,
 				<&rcc STM32_SRC_LSE RFWKP_SEL(1)>;
 	};
 

--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -250,7 +250,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			};
 
 			gpiob: gpio@42020400 {
@@ -258,7 +258,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			};
 
 			gpioc: gpio@42020800 {
@@ -266,7 +266,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42020800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			};
 
 			gpioh: gpio@42021c00 {
@@ -274,7 +274,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x42021c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 7)>;
 			};
 		};
 
@@ -282,7 +282,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x46007800 0x400>;
 			interrupts = <2 0>;
-			clocks = <&rcc STM32_CLOCK(APB7, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB7, 21)>;
 			alarms-count = <2>;
 			status = "disabled";
 		};
@@ -296,7 +296,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -304,7 +304,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <46 0>;
 			status = "disabled";
@@ -313,7 +313,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <47 0>;
 			status = "disabled";
@@ -322,7 +322,7 @@
 		lpuart1: serial@46002400 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x46002400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB7, 6U)>;
+			clocks = <&rcc STM32_CLOCK(APB7, 6)>;
 			resets = <&rctl STM32_RESET(APB7, 6U)>;
 			interrupts = <48 0>;
 			status = "disabled";
@@ -334,7 +334,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <45 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			status = "disabled";
 		};
 
@@ -344,7 +344,7 @@
 			#size-cells = <0>;
 			reg = <0x46002000 0x400>;
 			interrupts = <63 5>;
-			clocks = <&rcc STM32_CLOCK(APB7, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB7, 5)>;
 			status = "disabled";
 		};
 
@@ -354,7 +354,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <43 0>, <44 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -366,7 +366,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x46002800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB7, 7U)>;
+			clocks = <&rcc STM32_CLOCK(APB7, 7)>;
 			interrupts = <54 0>, <55 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -488,7 +488,7 @@
 		adc4: adc@46021000 {
 			compatible = "st,stm32-adc";
 			reg = <0x46021000 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB4, 5U)>,
+			clocks = <&rcc STM32_CLOCK(AHB4, 5)>,
 				 <&rcc STM32_SRC_HCLK1 ADC_SEL(0)>;
 			interrupts = <65 0>;
 			status = "disabled";
@@ -509,7 +509,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x46004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB7, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB7, 11)>;
 			interrupts = <49 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
@@ -520,7 +520,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40009400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 5U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 5)>;
 			interrupts = <50 1>;
 			interrupt-names = "wakeup";
 			status = "disabled";
@@ -530,7 +530,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x420c0800 0x400>;
 			interrupts = <59 0>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 18U)>,
+			clocks = <&rcc STM32_CLOCK(AHB2, 18)>,
 				 <&rcc STM32_SRC_HSI16 RNG_SEL(2)>;
 			nist-config = <0xf00d>;
 			health-test-config = <0xaac7>;
@@ -542,7 +542,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x1000>;
 			interrupts = <29 0 30 0 31 0 32 0 33 0 34 0 35 0 36 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-channels = <8>;
 			dma-requests = <52>;
 			dma-offset = <0>;

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -170,7 +170,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000000 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 0U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 0)>;
 			};
 
 			gpiob: gpio@48000400 {
@@ -178,7 +178,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000400 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 1U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 1)>;
 			};
 
 			gpioc: gpio@48000800 {
@@ -186,7 +186,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48000800 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 2U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 2)>;
 			};
 
 			gpioh: gpio@48001c00 {
@@ -194,13 +194,13 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x48001c00 0x400>;
-				clocks = <&rcc STM32_CLOCK(AHB2, 7U)>;
+				clocks = <&rcc STM32_CLOCK(AHB2, 7)>;
 			};
 		};
 
 		lptim1: timers@40007c00 {
 			compatible = "st,stm32-lptim";
-			clocks = <&rcc STM32_CLOCK(APB1, 31U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 31)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40007c00 0x400>;
@@ -213,7 +213,7 @@
 			compatible = "st,stm32-rtc";
 			reg = <0x40002800 0x400>;
 			interrupts = <42 0>;
-			clocks = <&rcc STM32_CLOCK(APB1, 10U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 10)>;
 			prescaler = <32768>;
 			alarms-count = <2>;
 			alrm-exti-line = <17>;
@@ -241,7 +241,7 @@
 		wwdg: watchdog@40002c00 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x40002C00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 11U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 11)>;
 			interrupts = <0 7>;
 			status = "disabled";
 		};
@@ -249,7 +249,7 @@
 		usart1: serial@40013800 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40013800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 14)>;
 			resets = <&rctl STM32_RESET(APB2, 14U)>;
 			interrupts = <36 0>;
 			status = "disabled";
@@ -258,7 +258,7 @@
 		usart2: serial@40004400 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40004400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 17U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 17)>;
 			resets = <&rctl STM32_RESET(APB1L, 17U)>;
 			interrupts = <37 0>;
 			status = "disabled";
@@ -267,7 +267,7 @@
 		lpuart1: serial@40008000 {
 			compatible = "st,stm32-lpuart", "st,stm32-uart";
 			reg = <0x40008000 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1_2, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB1_2, 0)>;
 			resets = <&rctl STM32_RESET(APB1H, 0U)>;
 			interrupts = <38 0>;
 			wakeup-line = <28>;
@@ -280,7 +280,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 21U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 21)>;
 			interrupts = <30 0>, <31 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -292,7 +292,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005800 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 22U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 22)>;
 			interrupts = <32 0>, <33 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -304,7 +304,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40005c00 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 23U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 23)>;
 			interrupts = <48 0>, <49 0>;
 			interrupt-names = "event", "error";
 			status = "disabled";
@@ -316,7 +316,7 @@
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
 			interrupts = <34 5>;
-			clocks = <&rcc STM32_CLOCK(APB2, 12U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 12)>;
 			status = "disabled";
 		};
 
@@ -326,7 +326,7 @@
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
 			interrupts = <35 5>;
-			clocks = <&rcc STM32_CLOCK(APB1, 14U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 14)>;
 			status = "disabled";
 		};
 
@@ -336,7 +336,7 @@
 			#size-cells = <0>;
 			reg = <0x58010000 0x400>;
 			interrupts = <44 5>;
-			clocks = <&rcc STM32_CLOCK(APB3, 0U)>;
+			clocks = <&rcc STM32_CLOCK(APB3, 0)>;
 			status = "disabled";
 			use-subghzspi-nss;
 
@@ -352,7 +352,7 @@
 		adc1: adc@40012400 {
 			compatible = "st,stm32-adc";
 			reg = <0x40012400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB2, 9U)>;
+			clocks = <&rcc STM32_CLOCK(APB2, 9)>;
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -369,7 +369,7 @@
 		dac1: dac@40007400 {
 			compatible = "st,stm32-dac";
 			reg = <0x40007400 0x400>;
-			clocks = <&rcc STM32_CLOCK(APB1, 29U)>;
+			clocks = <&rcc STM32_CLOCK(APB1, 29)>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -464,7 +464,7 @@
 		aes: aes@58001800 {
 			compatible = "st,stm32-aes";
 			reg = <0x58001800 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 17U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 17)>;
 			resets = <&rctl STM32_RESET(AHB3, 16U)>;
 			interrupts = <51 0>;
 			status = "disabled";
@@ -474,7 +474,7 @@
 			compatible = "st,stm32-rng";
 			reg = <0x58001000 0x400>;
 			interrupts = <52 0>;
-			clocks = <&rcc STM32_CLOCK(AHB3, 18U)>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 18)>;
 			health-test-magic = <0x17590abc>;
 			health-test-config = <0xaa74>;
 			status = "disabled";
@@ -485,7 +485,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020000 0x400>;
 			interrupts = <11 0 12 0 13 0 14 0 15 0 16 0 17 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 0U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 0)>;
 			dma-requests = <7>;
 			dma-offset = <0>;
 			status = "disabled";
@@ -496,7 +496,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020400 0x400>;
 			interrupts = <54 0 55 0 56 0 57 0 58 0 59 0 60 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 1U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 1)>;
 			dma-requests = <7>;
 			dma-offset = <7>;
 			status = "disabled";
@@ -507,7 +507,7 @@
 			#dma-cells = <3>;
 			reg = <0x40020800 0x400>;
 			interrupts = <61 0>;
-			clocks = <&rcc STM32_CLOCK(AHB1, 2U)>;
+			clocks = <&rcc STM32_CLOCK(AHB1, 2)>;
 			dma-channels = <14>;
 			dma-generators = <4>;
 			dma-requests= <38>;

--- a/dts/bindings/clock/st,stm32-rcc.yaml
+++ b/dts/bindings/clock/st,stm32-rcc.yaml
@@ -27,19 +27,30 @@ description: |
 
   Specifying a gated clock:
 
-  To specify a gated clock, a peripheral should define a "clocks" property encoded
-  in the following way:
+  To specify a gated clock, a peripheral should define a "clocks" property such as:
   ... {
            ...
-           clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>;
+           clocks = <&rcc STM32_CLOCK(APB2, 5)>;
            ...
   }
-  After the phandle referring to rcc node, the first index specifies the registers of
-  the bus controlling the peripheral and the second index specifies the bit used to
-  control the peripheral clock in that bus register.
+
+  After the phandle referring to rcc node, use the STM32_CLOCK() macro which accepts
+  two parameters: the first specifies the bus on which the peripheral is attached, and
+  the second indicates the bit number controlling the peripheral clock gate in that
+  bus's control register in RCC. As an example, the snippet above indicates that the
+  peripheral gate is controlled by bit 5 in RCC_APB2ENR (USART6EN on STM32F401).
   The gated clock is required when accessing to the peripheral controller is needed
   (generally for configuring the device). If dual clock domain is not used, it is
   also used for peripheral operation.
+
+  Note: in situations where more than one bit is required, use the explicit form:
+  ... {
+           ...
+           clocks = <&rcc STM32_CLOCK_BUS_APB2 ((1 << 14) | (1 << 7))>;
+           ...
+  }
+  where 14 and 7 are the bits that control the peripheral clock gate.
+  (You can have more than two bits, and they do not have to be contiguous).
 
   Specifying a domain clock source:
 
@@ -47,7 +58,7 @@ description: |
   clock property:
   ... {
            ...
-           clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>,
+           clocks = <&rcc STM32_CLOCK(APB2, 5)>,
                         <&rcc STM32_SRC_HSI I2C1_SEL(2)>;
            ...
   }

--- a/dts/bindings/clock/st,stm32wba-rcc.yaml
+++ b/dts/bindings/clock/st,stm32wba-rcc.yaml
@@ -28,16 +28,31 @@ description: |
 
   Specifying a gated clock:
 
-  To specify a gated clock, a peripheral should define a "clocks" property encoded
-  in the following way:
+  To specify a gated clock, a peripheral should define a "clocks" property such as:
   ... {
            ...
-           clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>;
+           clocks = <&rcc STM32_CLOCK(APB2, 5)>;
            ...
   }
-  After the phandle referring to rcc node, the first index specifies the registers of
-  the bus controlling the peripheral and the second index specifies the bit used to
-  control the peripheral clock in that bus register.
+
+  After the phandle referring to rcc node, use the STM32_CLOCK() macro which accepts
+  two parameters: the first specifies the bus on which the peripheral is attached, and
+  the second indicates the bit number controlling the peripheral clock gate in that
+  bus's control register in RCC. As an example, the snippet above indicates that the
+  peripheral gate is controlled by bit 5 in RCC_APB2ENR (USART6EN on STM32F401).
+  The gated clock is required when accessing to the peripheral controller is needed
+  (generally for configuring the device). If dual clock domain is not used, it is
+  also used for peripheral operation.
+
+  Note: in situations where more than one bit is required, use the explicit form:
+  ... {
+           ...
+           clocks = <&rcc STM32_CLOCK_BUS_APB2 ((1 << 14) | (1 << 7))>;
+           ...
+  }
+  where 14 and 7 are the bits that control the peripheral clock gate.
+  (You can have more than two bits, and they do not have to be contiguous).
+
 
   Specifying an alternate clock source:
 
@@ -45,7 +60,7 @@ description: |
   clock property:
   ... {
            ...
-           clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>,
+           clocks = <&rcc STM32_CLOCK(APB2, 5)>,
                         <&rcc STM32_SRC_HSI I2C1_SEL(2)>;
            ...
   }

--- a/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
+++ b/dts/bindings/phy/st,stm32u5-otghs-phy.yaml
@@ -22,19 +22,19 @@ properties:
       Supported configurations:
 
         /* HSE */
-        clocks = <&rcc STM32_CLOCK(AHB2, 15U)>,
+        clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
                  <&rcc STM32_SRC_HSE OTGHS_SEL(0)>;
 
         /* HSE/2 */
-        clocks = <&rcc STM32_CLOCK(AHB2, 15U)>,
+        clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
                  <&rcc (STM32_SRC_HSE | STM32_CLOCK_DIV(2)) OTGHS_SEL(2)>;
 
         /* PLL1_P_CK */
-        clocks = <&rcc STM32_CLOCK(AHB2, 15U)>,
+        clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
                  <&rcc STM32_SRC_PLL1_P OTGHS_SEL(1)>;
 
         /* PLL1_P_CK/2 */
-        clocks = <&rcc STM32_CLOCK(AHB2, 15U)>,
+        clocks = <&rcc STM32_CLOCK(AHB2, 15)>,
                  <&rcc (STM32_SRC_PLL1_P | STM32_CLOCK_DIV(2)) OTGHS_SEL(3)>;
 
   clock-reference:

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f4_sdmmc48_pll.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f4_sdmmc48_pll.overlay
@@ -22,7 +22,7 @@
 };
 
 &sdmmc1 {
-	clocks = <&rcc STM32_CLOCK(APB2, 11U)>,
+	clocks = <&rcc STM32_CLOCK(APB2, 11)>,
 		 /* select one source for the sdmmc domain clock */
 		 <&rcc STM32_SRC_SYSCLK SDIO_SEL(1)>;
 	/*		 <&rcc STM32_SRC_CK48 SDIO_SEL(0)>; */


### PR DESCRIPTION
PR #79683 introduced the `STM32_CLOCK()` macro for STM32 DTS... along with unnecessarily suffixing the bit index constants with `U`.

This isn't a problem per-se as `python-devicetree` [silently](https://github.com/zephyrproject-rtos/zephyr/blob/eb09070b8c5c98ffce45ab9f0238248f5eb7cbc3/scripts/dts/python-devicetree/src/devicetree/dtlib.py#L2198) [discards](https://github.com/zephyrproject-rtos/zephyr/blob/eb09070b8c5c98ffce45ab9f0238248f5eb7cbc3/scripts/dts/python-devicetree/src/devicetree/dtlib.py#L1646-L1653) the suffix and everything works fine, but it's nonetheless a maintenance burden.

Clean up all such suffixes from both SoC DTSI and boards DTS, and also update the help text in some bindings to reflect new "best practices" for STM32 DT writing.


Split in one commit per series to make reviewing easier.