### PR TITLE
soc: intel: ace: fix GDB stub

### DIFF
--- a/soc/intel/intel_adsp/ace/ace-link.ld
+++ b/soc/intel/intel_adsp/ace/ace-link.ld
@@ -194,6 +194,11 @@ SECTIONS {
     KEEP (*(.Level4InterruptVector.text))
     _Level4InterruptVector_text_end = .;
   } >vector_int4_text
+  .DebugExceptionVector.text : {
+    _DebugExceptionVector_text_start = .;
+    KEEP (*(.DebugExceptionVector.text))
+    _DebugExceptionVector_text_end = .;
+  } >vector_int4_text
   .NMIExceptionVector.text : {
     _NMIExceptionVector_text_start = .;
     KEEP (*(.NMIExceptionVector.text))


### PR DESCRIPTION
A recent commit inadvertently broke GDB stub on ACE. Revert that part of the faulty commit.

Fixes: commit cfd6a0673cf2 ("SoC: Intel: ACE: remove unused litelals parts in interrupt vectors")