### PR TITLE
samples: bluetooth: Add support for nRF54lm20a to two samples

### DIFF
--- a/samples/bluetooth/beacon/sample.yaml
+++ b/samples/bluetooth/beacon/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf52dk/nrf52832
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     tags: bluetooth
     integration_platforms:
       - qemu_cortex_m3
@@ -17,6 +18,7 @@ tests:
       - nrf52dk/nrf52832
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
   sample.bluetooth.beacon-coex:
     extra_args: CONF_FILE="prj-coex.conf"
     harness: bluetooth

--- a/samples/bluetooth/peripheral_hr/sample.yaml
+++ b/samples/bluetooth/peripheral_hr/sample.yaml
@@ -15,6 +15,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     integration_platforms:
       - qemu_cortex_m3
       - nrf52_bsim
@@ -25,6 +26,7 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
     tags: bluetooth
     sysbuild: true
   sample.bluetooth.peripheral_hr.minimal:


### PR DESCRIPTION
Add support for nRF54lm20a to the beacon and peripheral_hr samples.