### PR TITLE
tests: boards: nrf: qdec: Fix test for multiple instances

### DIFF
--- a/tests/boards/nrf/qdec/boards/bl54l15_dvk_nrf54l15_common.dtsi
+++ b/tests/boards/nrf/qdec/boards/bl54l15_dvk_nrf54l15_common.dtsi
@@ -5,12 +5,6 @@
  */
 
 / {
-	aliases {
-		qdec0 = &qdec20;
-		qenca = &phase_a;
-		qencb = &phase_b;
-	};
-
 	encoder-emulate {
 		compatible = "gpio-leds";
 
@@ -20,6 +14,14 @@
 
 		phase_b: phase_b {
 			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	qdec_loopbacks: loopbacks {
+		compatible = "test-qdec-loopbacks";
+		loopback0 {
+			qdec = <&qdec20>;
+			qenc-emul-gpios = <&phase_a &phase_b>;
 		};
 	};
 };

--- a/tests/boards/nrf/qdec/boards/bl54l15u_dvk_nrf54l15_common.dtsi
+++ b/tests/boards/nrf/qdec/boards/bl54l15u_dvk_nrf54l15_common.dtsi
@@ -5,12 +5,6 @@
  */
 
 / {
-	aliases {
-		qdec0 = &qdec20;
-		qenca = &phase_a;
-		qencb = &phase_b;
-	};
-
 	encoder-emulate {
 		compatible = "gpio-leds";
 
@@ -20,6 +14,14 @@
 
 		phase_b: phase_b {
 			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	qdec_loopbacks: loopbacks {
+		compatible = "test-qdec-loopbacks";
+		loopback0 {
+			qdec = <&qdec20>;
+			qenc-emul-gpios = <&phase_a &phase_b>;
 		};
 	};
 };

--- a/tests/boards/nrf/qdec/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/boards/nrf/qdec/boards/nrf52840dk_nrf52840.overlay
@@ -21,6 +21,14 @@
 			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	qdec_loopbacks: loopbacks {
+		compatible = "test-qdec-loopbacks";
+		loopback0 {
+			qdec = <&qdec0>;
+			qenc-emul-gpios = <&phase_a &phase_b>;
+		};
+	};
 };
 
 &pinctrl {

--- a/tests/boards/nrf/qdec/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/boards/nrf/qdec/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,12 +4,6 @@
  */
 
 / {
-	aliases {
-		qdec0 = &qdec1;
-		qenca = &phase_a;
-		qencb = &phase_b;
-	};
-
 	encoder-emulate {
 		compatible = "gpio-leds";
 		phase_a: phase_a {
@@ -19,6 +13,14 @@
 		phase_b: phase_b {
 			/* Arduino A3 */
 			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	qdec_loopbacks: loopbacks {
+		compatible = "test-qdec-loopbacks";
+		loopback0 {
+			qdec = <&qdec1>;
+			qenc-emul-gpios = <&phase_a &phase_b>;
 		};
 	};
 };

--- a/tests/boards/nrf/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/boards/nrf/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -11,21 +11,12 @@
  */
 
 / {
-	aliases {
-		qdec0 = &qdec130;
-		qdec1 = &qdec131;
-		qenca = &phase_a;
-		qencb = &phase_b;
-		qenca1 = &phase_a1;
-		qencb1 = &phase_b1;
-	};
-
 	encoder-emulate {
 		compatible = "gpio-leds";
-		phase_a: phase_a {
+		phase_a0: phase_a0 {
 			gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
 		};
-		phase_b: phase_b {
+		phase_b0: phase_b0 {
 			gpios = <&gpio2 11 GPIO_ACTIVE_HIGH>;
 		};
 		phase_a1: phase_a1 {
@@ -33,6 +24,18 @@
 		};
 		phase_b1: phase_b1 {
 			gpios = <&gpio7 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	qdec_loopbacks: loopbacks {
+		compatible = "test-qdec-loopbacks";
+		loopback0 {
+			qdec = <&qdec130>;
+			qenc-emul-gpios = <&phase_a0 &phase_b0>;
+		};
+		loopback1 {
+			qdec = <&qdec131>;
+			qenc-emul-gpios = <&phase_a1 &phase_b1>;
 		};
 	};
 };

--- a/tests/boards/nrf/qdec/boards/nrf54l15dk_nrf54l15_common.dtsi
+++ b/tests/boards/nrf/qdec/boards/nrf54l15dk_nrf54l15_common.dtsi
@@ -4,35 +4,38 @@
  */
 
 /* Required loopbacks
- * P1.8 <-> P1.9
- * P1.10 >-> P1.11
- * P2.8 <-> P2.9
- * P2.10 <-> P1.14
+ * P1.8  <-> P1.9
+ * P1.10 <-> P1.11
+ * P1.12 <-> P1.13
+ * P1.14 <-> P2.10
  */
 
 / {
-	aliases {
-		qdec0 = &qdec20;
-		qdec1 = &qdec21;
-		qenca = &phase_a;
-		qencb = &phase_b;
-		qenca1 = &phase_a1;
-		qencb1 = &phase_b1;
-	};
-
 	encoder-emulate {
 		compatible = "gpio-leds";
-		phase_a: phase_a {
+		phase_a0: phase_a0 {
 			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 		};
-		phase_b: phase_b {
+		phase_b0: phase_b0 {
 			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
 		};
 		phase_a1: phase_a1 {
-			gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
 		};
 		phase_b1: phase_b1 {
-			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	qdec_loopbacks: loopbacks {
+		compatible = "test-qdec-loopbacks";
+		loopback0 {
+			qdec = <&qdec20>;
+			qenc-emul-gpios = <&phase_a0 &phase_b0>;
+		};
+		loopback1 {
+			qdec = <&qdec21>;
+			qenc-emul-gpios = <&phase_a1 &phase_b1>;
 		};
 	};
 };
@@ -55,15 +58,15 @@
 
 	qdec_21_pinctrl: qdec_21_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 2, 8)>,
-				<NRF_PSEL(QDEC_B, 2, 10)>;
+			psels = <NRF_PSEL(QDEC_A, 1, 12)>,
+				<NRF_PSEL(QDEC_B, 1, 14)>;
 		};
 	};
 
 	qdec_21_sleep_pinctrl: qdec_21_sleep_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 2, 8)>,
-				<NRF_PSEL(QDEC_B, 2, 10)>;
+			psels = <NRF_PSEL(QDEC_A, 1, 12)>,
+				<NRF_PSEL(QDEC_B, 1, 14)>;
 			low-power-enable;
 		};
 	};

--- a/tests/boards/nrf/qdec/boards/nrf54lm20dk_nrf54lm20_common.dtsi
+++ b/tests/boards/nrf/qdec/boards/nrf54lm20dk_nrf54lm20_common.dtsi
@@ -11,12 +11,6 @@
  */
 
 / {
-	aliases {
-		qdec0 = &qdec20;
-		qenca = &phase_a;
-		qencb = &phase_b;
-	};
-
 	encoder-emulate {
 		compatible = "gpio-leds";
 		phase_a: phase_a {
@@ -24,6 +18,14 @@
 		};
 		phase_b: phase_b {
 			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	qdec_loopbacks: loopbacks {
+		compatible = "test-qdec-loopbacks";
+		loopback0 {
+			qdec = <&qdec20>;
+			qenc-emul-gpios = <&phase_a &phase_b>;
 		};
 	};
 };

--- a/tests/boards/nrf/qdec/dts/bindings/test-qdec-loopback.yaml
+++ b/tests/boards/nrf/qdec/dts/bindings/test-qdec-loopback.yaml
@@ -1,0 +1,20 @@
+description: |
+  Binding describing loopbacks required to run tests/boards/nrf/qdec test in Zephyr.
+
+compatible: "test-qdec-loopbacks"
+
+child-binding:
+  description: |
+    Binding describing a single loopback pair consisting of a QDEC device and two "gpio-leds" pins
+    working as a quadrature encoder for the test.
+  properties:
+    qdec:
+      type: phandle
+      required: true
+      description: Node of the QDEC device used to capture quadrature signal in the loopback.
+    qenc-emul-gpios:
+      type: phandles
+      required: true
+      description: |
+        Children nodes of "gpio-leds" compatible used to generate quadrature signal. The first
+        phandles outputs phase A signal, the second one outputs phase B signal.

--- a/tests/boards/nrf/qdec/src/main.c
+++ b/tests/boards/nrf/qdec/src/main.c
@@ -11,27 +11,40 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/pm/device_runtime.h>
 
-static K_SEM_DEFINE(sem, 0, 1);
-static const struct gpio_dt_spec phase_a = GPIO_DT_SPEC_GET(DT_ALIAS(qenca), gpios);
-static const struct gpio_dt_spec phase_b = GPIO_DT_SPEC_GET(DT_ALIAS(qencb), gpios);
-static const struct device *const qdec_dev = DEVICE_DT_GET(DT_ALIAS(qdec0));
-static const uint32_t qdec_config_step = DT_PROP(DT_ALIAS(qdec0), steps);
-
-/* Disable testing second QDEC instance
- * until the issue with multiple
- * QDEC instances support is resolved
+/**
+ * Structure grouping gpio pins used for QENC emulation connected with a QDEC device
+ * with a loopback.
  */
-#if DT_NODE_EXISTS(DT_ALIAS(qdecX))
-#define SECOND_QDEC_INSTANCE
+struct qdec_qenc_loopback {
+	struct gpio_dt_spec qenc_phase_a;
+	struct gpio_dt_spec qenc_phase_b;
 
-static const struct gpio_dt_spec phase_a1 = GPIO_DT_SPEC_GET(DT_ALIAS(qenca1), gpios);
-static const struct gpio_dt_spec phase_b1 = GPIO_DT_SPEC_GET(DT_ALIAS(qencb1), gpios);
-static const struct device *const qdec_1_dev = DEVICE_DT_GET(DT_ALIAS(qdec1));
-static const uint32_t qdec_1_config_step = DT_PROP(DT_ALIAS(qdec1), steps);
-#endif
+	const struct device *qdec;
+	uint32_t qdec_config_step;
+};
+
+static K_SEM_DEFINE(sem, 0, 1);
+
+#define GET_QDEC_QENC_LOOPBACK(x)								   \
+	{											   \
+		.qenc_phase_a = GPIO_DT_SPEC_GET(DT_PHANDLE_BY_IDX(x, qenc_emul_gpios, 0), gpios), \
+		.qenc_phase_b = GPIO_DT_SPEC_GET(DT_PHANDLE_BY_IDX(x, qenc_emul_gpios, 1), gpios), \
+		.qdec = DEVICE_DT_GET(DT_PHANDLE(x, qdec)),					   \
+		.qdec_config_step = DT_PROP_BY_PHANDLE(x, qdec, steps)				   \
+	}
+
+
+struct qdec_qenc_loopback loopbacks[] = {
+	DT_FOREACH_CHILD_SEP(DT_NODELABEL(qdec_loopbacks), GET_QDEC_QENC_LOOPBACK, (,))
+};
+
+#define TESTED_QDEC_COUNT ARRAY_SIZE(loopbacks)
+
 static struct sensor_trigger qdec_trigger = {.type = SENSOR_TRIG_DATA_READY,
 					     .chan = SENSOR_CHAN_ROTATION};
+
 static bool toggle_a = true;
+static struct qdec_qenc_loopback *loopback_currently_under_test;
 
 static void qdec_trigger_handler(const struct device *dev, const struct sensor_trigger *trigger)
 {
@@ -48,15 +61,9 @@ static void qdec_trigger_handler(const struct device *dev, const struct sensor_t
 static void qenc_emulate_work_handler(struct k_work *work)
 {
 	if (toggle_a) {
-		gpio_pin_toggle_dt(&phase_a);
-#if defined(SECOND_QDEC_INSTANCE)
-		gpio_pin_toggle_dt(&phase_a1);
-#endif
+		gpio_pin_toggle_dt(&loopback_currently_under_test->qenc_phase_a);
 	} else {
-		gpio_pin_toggle_dt(&phase_b);
-#if defined(SECOND_QDEC_INSTANCE)
-		gpio_pin_toggle_dt(&phase_b1);
-#endif
+		gpio_pin_toggle_dt(&loopback_currently_under_test->qenc_phase_b);
 	}
 	toggle_a = !toggle_a;
 }
@@ -89,52 +96,46 @@ static void qenc_emulate_setup_pin(const struct gpio_dt_spec *gpio_dt)
 	zassert_true(rc == 0, "%s: pin configure failed: %d", gpio_dt->port->name, rc);
 }
 
-static void qenc_emulate_start(k_timeout_t period, bool forward)
+static void qenc_emulate_start(struct qdec_qenc_loopback *loopback, k_timeout_t period,
+		bool forward)
 {
-	qenc_emulate_reset_pin(&phase_a);
-	qenc_emulate_reset_pin(&phase_b);
-#if defined(SECOND_QDEC_INSTANCE)
-	qenc_emulate_reset_pin(&phase_a1);
-	qenc_emulate_reset_pin(&phase_b1);
-#endif
+	qenc_emulate_reset_pin(&loopback->qenc_phase_a);
+	qenc_emulate_reset_pin(&loopback->qenc_phase_b);
 
 	toggle_a = !forward;
-
+	loopback_currently_under_test = loopback;
 	k_timer_start(&qenc_emulate_timer, period, period);
 }
 
 static void qenc_emulate_stop(void)
 {
-	k_timer_stop(&qenc_emulate_timer);
-
-	qenc_emulate_reset_pin(&phase_a);
-	qenc_emulate_reset_pin(&phase_b);
-#if defined(SECOND_QDEC_INSTANCE)
-	qenc_emulate_reset_pin(&phase_a1);
-	qenc_emulate_reset_pin(&phase_b1);
-#endif
+	if (loopback_currently_under_test) {
+		k_timer_stop(&qenc_emulate_timer);
+		qenc_emulate_reset_pin(&loopback_currently_under_test->qenc_phase_a);
+		qenc_emulate_reset_pin(&loopback_currently_under_test->qenc_phase_b);
+	}
 }
 
-static void qenc_emulate_verify_reading(const struct device *const dev, int emulator_period_ms,
-		int emulation_duration_ms, bool forward, bool overflow_expected,
-		const uint32_t config_step)
+static void qenc_emulate_verify_reading(struct qdec_qenc_loopback *loopback,
+		int emulator_period_ms, int emulation_duration_ms, bool forward,
+		bool overflow_expected)
 {
 	int rc;
 	struct sensor_value val = {0};
 	int32_t expected_steps = emulation_duration_ms / emulator_period_ms;
-	int32_t expected_reading = 360 * expected_steps / config_step;
-	int32_t delta = expected_reading / 5;
+	int32_t expected_reading = 360 * expected_steps / loopback->qdec_config_step;
+	int32_t delta = expected_reading / 4;
 
 	if (!forward) {
 		expected_reading *= -1;
 	}
 
-	qenc_emulate_start(K_MSEC(emulator_period_ms), forward);
+	qenc_emulate_start(loopback, K_MSEC(emulator_period_ms), forward);
 
 	/* wait for some readings */
 	k_msleep(emulation_duration_ms);
 
-	rc = sensor_sample_fetch(dev);
+	rc = sensor_sample_fetch(loopback->qdec);
 
 	if (!overflow_expected) {
 		zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
@@ -142,7 +143,7 @@ static void qenc_emulate_verify_reading(const struct device *const dev, int emul
 		zassert_true(rc == -EOVERFLOW, "Failed to detect overflow");
 	}
 
-	rc = sensor_channel_get(dev, SENSOR_CHAN_ROTATION, &val);
+	rc = sensor_channel_get(loopback->qdec, SENSOR_CHAN_ROTATION, &val);
 	zassert_true(rc == 0, "Failed to get sample (%d)", rc);
 
 	TC_PRINT("Expected reading: %d, actual value: %d, delta: %d\n",
@@ -157,31 +158,31 @@ static void qenc_emulate_verify_reading(const struct device *const dev, int emul
 	/* wait and get readings to clear state */
 	k_msleep(100);
 
-	rc = sensor_sample_fetch(dev);
+	rc = sensor_sample_fetch(loopback->qdec);
 	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 
-	rc = sensor_channel_get(dev, SENSOR_CHAN_ROTATION, &val);
+	rc = sensor_channel_get(loopback->qdec, SENSOR_CHAN_ROTATION, &val);
 	zassert_true(rc == 0, "Failed to get sample (%d)", rc);
 }
 
-static void sensor_trigger_set_and_disable(const struct device *const dev)
+static void sensor_trigger_set_and_disable(struct qdec_qenc_loopback *loopback)
 {
 	int rc;
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(dev);
+		pm_device_runtime_get(loopback->qdec);
 	}
 
 	k_sem_give(&sem);
 
 	qdec_trigger.type = SENSOR_TRIG_DATA_READY;
 	qdec_trigger.chan = SENSOR_CHAN_ALL;
-	rc = sensor_trigger_set(dev, &qdec_trigger, qdec_trigger_handler);
+	rc = sensor_trigger_set(loopback->qdec, &qdec_trigger, qdec_trigger_handler);
 	zassume_true(rc != -ENOSYS, "sensor_trigger_set not supported");
 
 	zassert_true(rc == 0, "sensor_trigger_set failed: %d", rc);
 
-	qenc_emulate_start(K_MSEC(10), true);
+	qenc_emulate_start(loopback, K_MSEC(10), true);
 
 	/* emulation working, handler should be called */
 	rc = k_sem_take(&sem, K_MSEC(200));
@@ -193,7 +194,7 @@ static void sensor_trigger_set_and_disable(const struct device *const dev)
 	rc = k_sem_take(&sem, K_MSEC(200));
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(dev);
+		pm_device_runtime_put(loopback->qdec);
 	}
 
 	/* there should be no triggers now*/
@@ -201,21 +202,21 @@ static void sensor_trigger_set_and_disable(const struct device *const dev)
 	zassert_true(rc == -EAGAIN, "qdec handler should not be triggered (%d)", rc);
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(dev);
+		pm_device_runtime_get(loopback->qdec);
 	}
 
 	/* register empty trigger - disable trigger */
-	rc = sensor_trigger_set(dev, &qdec_trigger, NULL);
+	rc = sensor_trigger_set(loopback->qdec, &qdec_trigger, NULL);
 	zassert_true(rc == 0, "sensor_trigger_set failed: %d", rc);
 
-	qenc_emulate_start(K_MSEC(10), true);
+	qenc_emulate_start(loopback, K_MSEC(10), true);
 
 	/* emulation working, but handler not set, thus should not be called */
 	rc = k_sem_take(&sem, K_MSEC(200));
 	zassert_true(rc == -EAGAIN, "qdec handler should not be triggered (%d)", rc);
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(dev);
+		pm_device_runtime_put(loopback->qdec);
 	}
 }
 
@@ -227,49 +228,50 @@ static void sensor_trigger_set_and_disable(const struct device *const dev)
  */
 ZTEST(qdec_sensor, test_sensor_trigger_set_and_disable)
 {
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	sensor_trigger_set_and_disable(qdec_dev);
-#if defined(SECOND_QDEC_INSTANCE)
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	sensor_trigger_set_and_disable(qdec_1_dev);
-#endif
-
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		sensor_trigger_set_and_disable(&loopbacks[i]);
+	}
 }
 
-static void sensor_trigger_set_test(const struct device *const dev)
+static void sensor_trigger_set_test(struct qdec_qenc_loopback *loopback)
 {
 	int rc;
 	struct sensor_value val = {0};
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(dev);
+		pm_device_runtime_get(loopback->qdec);
 	}
 
 	qdec_trigger.type = SENSOR_TRIG_DATA_READY;
 	qdec_trigger.chan = SENSOR_CHAN_ROTATION;
-	rc = sensor_trigger_set(dev, &qdec_trigger, qdec_trigger_handler);
+	rc = sensor_trigger_set(loopback->qdec, &qdec_trigger, qdec_trigger_handler);
 	zassume_true(rc != -ENOSYS, "sensor_trigger_set not supported");
 
 	zassert_true(rc == 0, "sensor_trigger_set failed: %d", rc);
 
-	qenc_emulate_start(K_MSEC(10), true);
+	qenc_emulate_start(loopback, K_MSEC(10), true);
 
 	/* emulation working now */
 	rc = k_sem_take(&sem, K_MSEC(200));
 	zassert_true(rc == 0, "qdec handler should be triggered (%d)", rc);
 
-	rc = sensor_sample_fetch(dev);
+	rc = sensor_sample_fetch(loopback->qdec);
 	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 
-	rc = sensor_channel_get(dev, SENSOR_CHAN_ROTATION, &val);
+	rc = sensor_channel_get(loopback->qdec, SENSOR_CHAN_ROTATION, &val);
 	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 
 	TC_PRINT("QDEC reading: %d\n", val.val1);
 	zassert_true(val.val1 != 0, "No readings from QDEC");
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(dev);
+		pm_device_runtime_put(loopback->qdec);
 	}
+
+	qenc_emulate_stop();
+	/* emulation not working, but there may be old trigger which needs to be cleaned up */
+	rc = k_sem_take(&sem, K_MSEC(200));
 }
 
 /**
@@ -280,39 +282,37 @@ static void sensor_trigger_set_test(const struct device *const dev)
  */
 ZTEST(qdec_sensor, test_sensor_trigger_set)
 {
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	sensor_trigger_set_test(qdec_dev);
-#if defined(SECOND_QDEC_INSTANCE)
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	sensor_trigger_set_test(qdec_1_dev);
-#endif
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		sensor_trigger_set_test(&loopbacks[i]);
+	}
 }
 
-static void sensor_trigger_set_negative(const struct device *const dev)
+static void sensor_trigger_set_negative(struct qdec_qenc_loopback *loopback)
 {
 	int rc;
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(dev);
+		pm_device_runtime_get(loopback->qdec);
 	}
 
-	rc = sensor_trigger_set(dev, &qdec_trigger, qdec_trigger_handler);
+	rc = sensor_trigger_set(loopback->qdec, &qdec_trigger, qdec_trigger_handler);
 	zassume_true(rc != -ENOSYS, "sensor_trigger_set not supported");
 
 	qdec_trigger.type = SENSOR_TRIG_MAX;
 	qdec_trigger.chan = SENSOR_CHAN_ROTATION;
 
-	rc = sensor_trigger_set(dev, &qdec_trigger, qdec_trigger_handler);
+	rc = sensor_trigger_set(loopback->qdec, &qdec_trigger, qdec_trigger_handler);
 	zassume_true(rc < 0, "sensor_trigger_set should fail due to invalid trigger type");
 
 	qdec_trigger.type = SENSOR_TRIG_DATA_READY;
 	qdec_trigger.chan = SENSOR_CHAN_MAX;
 
-	rc = sensor_trigger_set(dev, &qdec_trigger, qdec_trigger_handler);
+	rc = sensor_trigger_set(loopback->qdec, &qdec_trigger, qdec_trigger_handler);
 	zassume_true(rc < 0, "sensor_trigger_set should fail due to invalid channel");
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(dev);
+		pm_device_runtime_put(loopback->qdec);
 	}
 }
 
@@ -324,12 +324,10 @@ static void sensor_trigger_set_negative(const struct device *const dev)
  */
 ZTEST(qdec_sensor, test_sensor_trigger_set_negative)
 {
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	sensor_trigger_set_negative(qdec_dev);
-#if defined(SECOND_QDEC_INSTANCE)
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	sensor_trigger_set_negative(qdec_1_dev);
-#endif
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		sensor_trigger_set_negative(&loopbacks[i]);
+	}
 }
 
 /**
@@ -340,37 +338,22 @@ ZTEST(qdec_sensor, test_sensor_trigger_set_negative)
  */
 ZTEST(qdec_sensor, test_qdec_readings)
 {
-	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(qdec_dev);
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+			pm_device_runtime_get(loopbacks[i].qdec);
+		}
+
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		qenc_emulate_verify_reading(&loopbacks[i], 10,  100,  true, false);
+		qenc_emulate_verify_reading(&loopbacks[i],  2,  500,  true, false);
+		qenc_emulate_verify_reading(&loopbacks[i], 10,  200, false, false);
+		qenc_emulate_verify_reading(&loopbacks[i],  1, 1000, false,  true);
+		qenc_emulate_verify_reading(&loopbacks[i],  1, 1000,  true,  true);
+
+		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+			pm_device_runtime_put(loopbacks[i].qdec);
+		}
 	}
-
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	qenc_emulate_verify_reading(qdec_dev, 10, 100, true, false, qdec_config_step);
-	qenc_emulate_verify_reading(qdec_dev, 2, 500, true, false, qdec_config_step);
-	qenc_emulate_verify_reading(qdec_dev, 10, 200, false, false, qdec_config_step);
-	qenc_emulate_verify_reading(qdec_dev, 1, 1000, false, true, qdec_config_step);
-	qenc_emulate_verify_reading(qdec_dev, 1, 1000, true, true, qdec_config_step);
-
-	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(qdec_dev);
-	}
-
-#if defined(SECOND_QDEC_INSTANCE)
-	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(qdec_1_dev);
-	}
-
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	qenc_emulate_verify_reading(qdec_1_dev, 10, 100, true, false, qdec_1_config_step);
-	qenc_emulate_verify_reading(qdec_1_dev, 2, 500, true, false, qdec_1_config_step);
-	qenc_emulate_verify_reading(qdec_1_dev, 10, 200, false, false, qdec_1_config_step);
-	qenc_emulate_verify_reading(qdec_1_dev, 1, 1000, false, true, qdec_1_config_step);
-	qenc_emulate_verify_reading(qdec_1_dev, 1, 1000, true, true, qdec_1_config_step);
-
-	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(qdec_1_dev);
-	}
-#endif
 }
 
 static void sensor_channel_get_empty(const struct device *const dev)
@@ -419,40 +402,38 @@ static void sensor_channel_get_empty(const struct device *const dev)
  */
 ZTEST(qdec_sensor, test_sensor_channel_get_empty)
 {
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	sensor_channel_get_empty(qdec_dev);
-#if defined(SECOND_QDEC_INSTANCE)
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	sensor_channel_get_empty(qdec_1_dev);
-#endif
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		sensor_channel_get_empty(loopbacks[i].qdec);
+	}
 }
 
-static void sensor_channel_get_test(const struct device *const dev)
+static void sensor_channel_get_test(struct qdec_qenc_loopback *loopback)
 {
 	int rc;
 	struct sensor_value val_first = {0};
 	struct sensor_value val_second = {0};
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(qdec_dev);
+		pm_device_runtime_get(loopback->qdec);
 	}
 
-	qenc_emulate_start(K_MSEC(10), true);
+	qenc_emulate_start(loopback, K_MSEC(10), true);
 
 	/* wait for some readings*/
 	k_msleep(100);
 
-	rc = sensor_sample_fetch(qdec_dev);
+	rc = sensor_sample_fetch(loopback->qdec);
 	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 
-	rc = sensor_channel_get(qdec_dev, SENSOR_CHAN_ROTATION, &val_first);
+	rc = sensor_channel_get(loopback->qdec, SENSOR_CHAN_ROTATION, &val_first);
 	zassert_true(rc == 0, "Failed to get sample (%d)", rc);
 	zassert_true(val_first.val1 != 0, "No readings from QDEC");
 
 	/* wait for more readings*/
 	k_msleep(200);
 
-	rc = sensor_channel_get(qdec_dev, SENSOR_CHAN_ROTATION, &val_second);
+	rc = sensor_channel_get(loopback->qdec, SENSOR_CHAN_ROTATION, &val_second);
 	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 	zassert_true(val_second.val1 != 0, "No readings from QDEC");
 
@@ -470,7 +451,7 @@ static void sensor_channel_get_test(const struct device *const dev)
 		     val_second.val2);
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(qdec_dev);
+		pm_device_runtime_put(loopback->qdec);
 	}
 }
 
@@ -482,38 +463,36 @@ static void sensor_channel_get_test(const struct device *const dev)
  */
 ZTEST(qdec_sensor, test_sensor_channel_get)
 {
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	sensor_channel_get_test(qdec_dev);
-#if defined(SECOND_QDEC_INSTANCE)
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	sensor_channel_get_test(qdec_1_dev);
-#endif
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		sensor_channel_get_test(&loopbacks[i]);
+	}
 }
 
-static void sensor_channel_get_negative(const struct device *const dev)
+static void sensor_channel_get_negative(struct qdec_qenc_loopback *loopback)
 {
 	int rc;
 	struct sensor_value val = {0};
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_get(dev);
+		pm_device_runtime_get(loopback->qdec);
 	}
 
-	qenc_emulate_start(K_MSEC(10), true);
+	qenc_emulate_start(loopback, K_MSEC(10), true);
 
 	/* wait for some readings*/
 	k_msleep(100);
 
-	rc = sensor_sample_fetch(dev);
+	rc = sensor_sample_fetch(loopback->qdec);
 	zassert_true(rc == 0, "Failed to fetch sample (%d)", rc);
 
-	rc = sensor_channel_get(dev, SENSOR_CHAN_MAX, &val);
+	rc = sensor_channel_get(loopback->qdec, SENSOR_CHAN_MAX, &val);
 	zassert_true(rc < 0, "Should failed to get sample (%d)", rc);
 	zassert_true(val.val1 == 0, "Some readings from QDEC: %d", val.val1);
 	zassert_true(val.val2 == 0, "Some readings from QDEC: %d", val.val2);
 
 	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
-		pm_device_runtime_put(dev);
+		pm_device_runtime_put(loopback->qdec);
 	}
 }
 
@@ -525,12 +504,10 @@ static void sensor_channel_get_negative(const struct device *const dev)
  */
 ZTEST(qdec_sensor, test_sensor_channel_get_negative)
 {
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	sensor_channel_get_negative(qdec_dev);
-#if defined(SECOND_QDEC_INSTANCE)
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	sensor_channel_get_negative(qdec_1_dev);
-#endif
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		sensor_channel_get_negative(&loopbacks[i]);
+	}
 }
 
 static void sensor_sample_fetch_test(const struct device *const dev)
@@ -563,32 +540,22 @@ static void sensor_sample_fetch_test(const struct device *const dev)
  */
 ZTEST(qdec_sensor, test_sensor_sample_fetch)
 {
-	TC_PRINT("Testing QDEC-0, address: %p\n", qdec_dev);
-	sensor_sample_fetch_test(qdec_dev);
-#if defined(SECOND_QDEC_INSTANCE)
-	TC_PRINT("Testing QDEC-1, address: %p\n", qdec_1_dev);
-	sensor_sample_fetch_test(qdec_1_dev);
-#endif
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		TC_PRINT("Testing QDEC index %d, address: %p\n", i, loopbacks[i].qdec);
+		sensor_sample_fetch_test(loopbacks[i].qdec);
+	}
 }
 
 static void *setup(void)
 {
-	int rc;
+	for (size_t i = 0; i < TESTED_QDEC_COUNT; i++) {
+		int rc = device_is_ready(loopbacks[i].qdec);
 
-	rc = device_is_ready(qdec_dev);
-	zassert_true(rc, "QDEC device not ready: %d", rc);
+		zassert_true(rc, "QDEC index %d not ready: %d", i, rc);
 
-	qenc_emulate_setup_pin(&phase_a);
-	qenc_emulate_setup_pin(&phase_b);
-
-#if defined(SECOND_QDEC_INSTANCE)
-	rc = device_is_ready(qdec_1_dev);
-	zassert_true(rc, "QDEC 1 device not ready: %d", rc);
-
-	qenc_emulate_setup_pin(&phase_a1);
-	qenc_emulate_setup_pin(&phase_b1);
-#endif
-
+		qenc_emulate_setup_pin(&loopbacks[i].qenc_phase_a);
+		qenc_emulate_setup_pin(&loopbacks[i].qenc_phase_b);
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
- Fixed pin configuration for nRF54L15 (on nRF54L15 QDECs can use only port 1)
- Changed the way the test handles testing multiple instances to make it possible to output quadrature signal to one QDEC instance at a time - this was making QDECs receive signal also when another instance was being tested which resulted in wrong readings and overflows