### PR TITLE
linker: arc: support MWDT-specific input section naming scheme

### DIFF
--- a/include/zephyr/arch/arc/v2/linker.ld
+++ b/include/zephyr/arch/arc/v2/linker.ld
@@ -95,7 +95,10 @@ SECTIONS {
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-rom-start.ld>
-		*(.text .text.*)
+
+		*(.text)
+		*(.text.*)
+		*(.text$*)
 		*(.gnu.linkonce.t.*)
 
 	. = ALIGN(4);
@@ -113,7 +116,9 @@ SECTIONS {
 #ifdef __MWDT_LINKER_CMD__
 	SECTION_DATA_PROLOGUE(tdata,,)
 	{
-		*(.tls .tls.*);
+		*(.tls);
+		*(.tls.*);
+		*(.tls$*);
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 	#ifdef CONFIG_XIP
@@ -134,6 +139,7 @@ SECTIONS {
 	SECTION_PROLOGUE(_RODATA_SECTION_NAME,,) {
 		*(".rodata")
 		*(".rodata.*")
+		*(".rodata$*")
 		*(.gnu.linkonce.r.*)
 
 /* Located in generated directory. This file is populated by the
@@ -189,13 +195,16 @@ SECTIONS {
 		__data_region_start = .;
 		__data_start = .;
 		__kernel_ram_start = .;
+
 		*(".data")
 		*(".data.*")
+		*(".data$*")
 		*(".kernel.*")
 
 /* This is an MWDT-specific section, created when -Hccm option is enabled */
 		*(".rodata_in_data")
 		*(".rodata_in_data.*")
+		*(".rodata_in_data$*")
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
@@ -235,8 +244,10 @@ SECTIONS {
 		 */
 		. = ALIGN(4);
 		__bss_start = .;
+
 		*(".bss")
 		*(".bss.*")
+		*(".bss$*")
 		*(COMMON)
 		*(".kernel_bss.*")
 
@@ -295,6 +306,7 @@ SECTIONS {
 	SECTION_PROLOGUE(.arcextmap, 0,) {
 		*(.arcextmap)
 		*(.arcextmap.*)
+		*(.arcextmap$*)
 		*(.gnu.linkonce.arcextmap.*)
 	}
 


### PR DESCRIPTION
The MWDT linker has a specific input section sorting mechanism, designated as x$y. Some prebuilt ARC libraries actually use it, causing a lot of warnings when the linker decides where to place their symbols. Provide explicit instructions in the linker script instead of making the linker guess.