### PR TITLE
lib: libc: arcmwdt: add a declaration for the strnlen function

### DIFF
--- a/lib/libc/arcmwdt/include/string.h
+++ b/lib/libc/arcmwdt/include/string.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Synopsys
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LIB_LIBC_ARCMWDT_INCLUDE_STRING_H_
+#define LIB_LIBC_ARCMWDT_INCLUDE_STRING_H_
+
+#include_next <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern size_t strnlen(const char *s, size_t maxlen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_LIBC_ARCMWDT_INCLUDE_STRING_H_ */


### PR DESCRIPTION
ARC MWDT C library does not have an implementation of the strnlen function, so we have a wrapper over standard-compliant strnlen_s. However, there is no declaration of the wrapper, so add one.