### PR TITLE
net: lwm2m: Suppress many LOG_ERR() that are not fatal

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -380,18 +380,15 @@ int path_to_objs(const struct lwm2m_obj_path *path, struct lwm2m_engine_obj_inst
 
 	oi = get_engine_obj_inst(path->obj_id, path->obj_inst_id);
 	if (!oi) {
-		LOG_ERR("obj instance %d/%d not found", path->obj_id, path->obj_inst_id);
 		return -ENOENT;
 	}
 
 	if (!oi->resources || oi->resource_count == 0U) {
-		LOG_ERR("obj instance has no resources");
 		return -EINVAL;
 	}
 
 	of = lwm2m_get_engine_obj_field(oi->obj, path->res_id);
 	if (!of) {
-		LOG_ERR("obj field %d not found", path->res_id);
 		return -ENOENT;
 	}
 
@@ -403,12 +400,6 @@ int path_to_objs(const struct lwm2m_obj_path *path, struct lwm2m_engine_obj_inst
 	}
 
 	if (!r) {
-		if (LWM2M_HAS_PERM(of, BIT(LWM2M_FLAG_OPTIONAL))) {
-			LOG_DBG("resource %d not found", path->res_id);
-		} else {
-			LOG_ERR("resource %d not found", path->res_id);
-		}
-
 		return -ENOENT;
 	}
 
@@ -477,7 +468,6 @@ int lwm2m_set_res_buf(const struct lwm2m_obj_path *path, void *buffer_ptr, uint1
 	}
 
 	if (!res_inst) {
-		LOG_ERR("res instance %d not found", path->res_inst_id);
 		k_mutex_unlock(&registry_lock);
 		return -ENOENT;
 	}
@@ -562,7 +552,6 @@ static int lwm2m_engine_set(const struct lwm2m_obj_path *path, const void *value
 	}
 
 	if (!res_inst) {
-		LOG_ERR("res instance %d not found", path->res_inst_id);
 		k_mutex_unlock(&registry_lock);
 		return -ENOENT;
 	}
@@ -835,7 +824,6 @@ int lwm2m_get_res_buf(const struct lwm2m_obj_path *path, void **buffer_ptr, uint
 	}
 
 	if (!res_inst) {
-		LOG_ERR("res instance %d not found", path->res_inst_id);
 		k_mutex_unlock(&registry_lock);
 		return -ENOENT;
 	}
@@ -883,7 +871,6 @@ static int lwm2m_engine_get(const struct lwm2m_obj_path *path, void *buf, uint16
 	}
 
 	if (!res_inst) {
-		LOG_ERR("res instance %d not found", path->res_inst_id);
 		k_mutex_unlock(&registry_lock);
 		return -ENOENT;
 	}
@@ -1245,7 +1232,6 @@ int lwm2m_delete_res_inst(const struct lwm2m_obj_path *path)
 	}
 
 	if (!res_inst) {
-		LOG_ERR("res instance %u not found", path->res_inst_id);
 		k_mutex_unlock(&registry_lock);
 		return -ENOENT;
 	}


### PR DESCRIPTION
Suppress many LOG_ERR() messages from LwM2M registry that are not necessary runtime errors.

Libraries and applications should be able to do following without causing LOG_ERR to be produced:

* Checking existence of object, resource or resource instance using lwm2m_engine_get_res(), lwm2m_engine_get_res_inst() or path_to_objs(). These are only exposed in internal header.
* Delete object instance or resource instance without checking if it exits.

As there is no public API to check existence of some path, application is much easier to write in a way that it directly calls just lwm2m_get...(), lwm2m_set...(), lwm2m_delete...() and trust the return code of -ENOENT.