### PR TITLE
tests: drivers: spi_loopback: nrf54h20/cpurad add missing pm runtime

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
+++ b/tests/drivers/spi/spi_loopback/boards/nrf54h20dk_nrf54h20_common.dtsi
@@ -37,6 +37,7 @@
 	pinctrl-1 = <&spi130_sleep>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
+	zephyr,pm-device-runtime-auto;
 	status = "okay";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";


### PR DESCRIPTION
Add missing zephyr,pm-device-runtime-auto; property to spi130 of nrf54h20/cpurad required for device pm runtime to work.