### PR TITLE
drivers uart_native_posix: mention that pty supports async

### DIFF
--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -551,7 +551,8 @@ option ``-attach_uart_cmd=<"cmd">``, or for each individual UART with
 :kconfig:option:`CONFIG_UART_NATIVE_PTY_AUTOATTACH_DEFAULT_CMD`.
 Note that the default command assumes both ``xterm`` and ``screen`` are installed in the system.
 
-This driver only supports poll mode. Interrupt and async mode are not supported.
+This driver supports poll mode or async mode with :kconfig:option:`CONFIG_UART_ASYNC_API`.
+Interrupt mode is not supported.
 Neither runtime configuration or line control are supported.
 
 .. _native_tty_uart:


### PR DESCRIPTION
With CONFIG_UART_ASYNC_API pty driver for native sim now supports async