### PR TITLE
twister: add a --flash-command flag

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1443,6 +1443,32 @@ work. It is equivalent to following west and twister commands.
   manually according to above example. This is because the serial port
   of the PTY is not fixed and being allocated in the system at runtime.
 
+If west is not available or does not know how to flash your system, a custom
+flash command can be specified using the ``flash-command`` flag. The script is
+called with a ``--build-dir`` with the path of the current build, as well as a
+``--board-id`` flag to identify the specific device when multiple are available
+in a hardware map.
+
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         twister -p npcx9m6f_evb --device-testing --device-serial /dev/ttyACM0
+         --flash-command './custom_flash_script.py,--flag,"complex,argument"'
+
+   .. group-tab:: Windows
+
+      .. note::
+
+         python .\scripts\twister -p npcx9m6f_evb --device-testing
+         --device-serial COM1
+         --flash-command 'custom_flash_script.py,--flag,"complex,argument"'
+
+Would result in calling ``./custom_flash_script.py --flag complex,argument --build-dir
+<build directory> --board-id <board identification>``.
+
 Fixtures
 +++++++++
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -38,8 +38,23 @@ class HardwareAdapter(DeviceAdapter):
         self.device_log_path: Path = device_config.build_dir / 'device.log'
         self._log_files.append(self.device_log_path)
 
+    def _generate_flash_command(self) -> None:
+        command = [self.device_config.flash_command[0]]
+        command.extend(['--build-dir', str(self.device_config.build_dir)])
+
+        if self.device_config.id:
+            command.extend(['--board-id', self.device_config.id])
+
+        command.extend(self.device_config.flash_command[1:])
+
+        self.command = command
+
     def generate_command(self) -> None:
         """Return command to flash."""
+        if self.device_config.flash_command:
+            self._generate_flash_command()
+            return
+
         command = [
             self.west,
             'flash',

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -103,6 +103,10 @@ def pytest_addoption(parser: pytest.Parser):
              'will translate to "west flash -- --board-id=foobar --erase".'
     )
     twister_harness_group.addoption(
+        '--flash-command',
+        help='Use a custom flash command for flashing.'
+    )
+    twister_harness_group.addoption(
         '--pre-script',
         metavar='PATH',
         help='Script executed before flashing and connecting to serial.'

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import csv
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -30,6 +31,7 @@ class DeviceConfig:
     serial_pty: str = ''
     flash_before: bool = False
     west_flash_extra_args: list[str] = field(default_factory=list, repr=False)
+    flash_command: str = ''
     name: str = ''
     pre_script: Path | None = None
     post_script: Path | None = None
@@ -60,6 +62,9 @@ class TwisterHarnessConfig:
         west_flash_extra_args: list[str] = []
         if config.option.west_flash_extra_args:
             west_flash_extra_args = [w.strip() for w in config.option.west_flash_extra_args.split(',')]
+        flash_command: list[str] = []
+        if config.option.flash_command:
+            flash_command = [w.strip() for w in next(csv.reader([config.option.flash_command]))]
         runner_params: list[str] = []
         if config.option.runner_params:
             runner_params = [w.strip() for w in config.option.runner_params]
@@ -78,6 +83,7 @@ class TwisterHarnessConfig:
             serial_pty=config.option.device_serial_pty,
             flash_before=bool(config.option.flash_before),
             west_flash_extra_args=west_flash_extra_args,
+            flash_command=flash_command,
             pre_script=_cast_to_path(config.option.pre_script),
             post_script=_cast_to_path(config.option.post_script),
             post_flash_script=_cast_to_path(config.option.post_flash_script),

--- a/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/hardware_adapter_test.py
@@ -25,6 +25,7 @@ def fixture_adapter(tmp_path) -> HardwareAdapter:
         platform='platform',
         id='p_id',
         base_timeout=5.0,
+        flash_command='',
     )
     return HardwareAdapter(device_config)
 
@@ -179,6 +180,14 @@ def test_if_get_command_returns_proper_string_with_west_flash_extra_args(
         'west', 'flash', '--skip-rebuild', '--build-dir', 'build', '--runner', 'pyocd',
         '--', '--board-id=foobar', '--erase'
     ]
+
+
+def test_if_get_command_flash_command(device: HardwareAdapter) -> None:
+    device.device_config.build_dir = Path('build')
+    device.device_config.flash_command = ['flash_command', '--with-arg']
+    device.generate_command()
+    assert isinstance(device.command, list)
+    assert device.command == ['flash_command', '--build-dir', 'build', '--board-id', 'p_id', '--with-arg']
 
 
 def test_if_hardware_adapter_raises_exception_empty_command(device: HardwareAdapter) -> None:

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -836,6 +836,15 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
         will translate to "west flash --runner pyocd"
         """
     )
+    parser.add_argument(
+        "--flash-command",
+        help="""Instead of 'west flash', uses a custom flash command to flash
+            when running with --device-testing. Supports comma-separated
+            argument list, the script is also passed a --build-dir flag with
+            the build directory as an argument, and a --board-id flag with the
+            board or probe id if available.
+        """
+    )
 
     parser.add_argument(
         "-X", "--fixture", action="append", default=[],

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -9,6 +9,7 @@
 
 import argparse
 import contextlib
+import csv
 import logging
 import math
 import os
@@ -564,7 +565,24 @@ class DeviceHandler(Handler):
                 proc.communicate()
                 logger.error(f"{script} timed out")
 
+    def _create_flash_command(self, hardware):
+        flash_command = next(csv.reader([self.options.flash_command]))
+
+        command = [flash_command[0]]
+        command.extend(['--build-dir', self.build_dir])
+
+        board_id = hardware.probe_id or hardware.id
+        if board_id:
+            command.extend(['--board-id', board_id])
+
+        command.extend(flash_command[1:])
+
+        return command
+
     def _create_command(self, runner, hardware):
+        if self.options.flash_command:
+            return self._create_flash_command(hardware)
+
         command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
         command_extra_args = []
 

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -479,6 +479,9 @@ class Pytest(Harness):
         if options.west_flash and options.west_flash != []:
             command.append(f'--west-flash-extra-args={options.west_flash}')
 
+        if options.flash_command:
+            command.append(f'--flash-command={options.flash_command}')
+
         if board_id := hardware.probe_id or hardware.id:
             command.append(f'--device-id={board_id}')
 

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1049,10 +1049,12 @@ TESTDATA_13 = [
         None,
         None,
         None,
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir']
     ),
     (
         [],
+        None,
         None,
         None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir']
@@ -1061,11 +1063,13 @@ TESTDATA_13 = [
         '--dummy',
         None,
         None,
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--', '--dummy']
     ),
     (
         '--dummy1,--dummy2',
+        None,
         None,
         None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
@@ -1076,6 +1080,7 @@ TESTDATA_13 = [
         None,
         'runner',
         'product',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'runner', 'param1', 'param2']
     ),
@@ -1084,6 +1089,7 @@ TESTDATA_13 = [
         None,
         'pyocd',
         'product',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'pyocd', 'param1', 'param2', '--', '--dev-id', 12345]
     ),
@@ -1091,6 +1097,7 @@ TESTDATA_13 = [
         None,
         'nrfjprog',
         'product',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'nrfjprog', 'param1', 'param2', '--', '--dev-id', 12345]
     ),
@@ -1098,6 +1105,7 @@ TESTDATA_13 = [
         None,
         'openocd',
         'STM32 STLink',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'openocd', 'param1', 'param2',
          '--', '--cmd-pre-init', 'hla_serial 12345']
@@ -1106,6 +1114,7 @@ TESTDATA_13 = [
         None,
         'openocd',
         'STLINK-V3',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'openocd', 'param1', 'param2',
          '--', '--cmd-pre-init', 'hla_serial 12345']
@@ -1114,6 +1123,7 @@ TESTDATA_13 = [
         None,
         'openocd',
         'EDBG CMSIS-DAP',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'openocd', 'param1', 'param2',
          '--', '--cmd-pre-init', 'cmsis_dap_serial 12345']
@@ -1122,6 +1132,7 @@ TESTDATA_13 = [
         None,
         'jlink',
         'product',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'jlink', '--dev-id', 12345,
          'param1', 'param2']
@@ -1130,23 +1141,39 @@ TESTDATA_13 = [
         None,
         'stm32cubeprogrammer',
         'product',
+        None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
          '--runner', 'stm32cubeprogrammer', '--tool-opt=sn=12345',
          'param1', 'param2']
     ),
-
+    (
+        None,
+        None,
+        None,
+        'flash_command',
+        ['flash_command', '--build-dir', '$build_dir', '--board-id', 12345]
+    ),
+    (
+        None,
+        None,
+        None,
+        'path to/flash_command,with,args,"1,2,3",4',
+        ['path to/flash_command', '--build-dir', '$build_dir', '--board-id',
+         12345, 'with', 'args', '1,2,3', '4']
+    ),
 ]
 
 TESTDATA_13_2 = [(True), (False)]
 
 @pytest.mark.parametrize(
     'self_west_flash, runner,' \
-    ' hardware_product_name, expected',
+    ' hardware_product_name, self_flash_command, expected',
     TESTDATA_13,
     ids=['default', '--west-flash', 'one west flash value',
          'multiple west flash values', 'generic runner', 'pyocd',
          'nrfjprog', 'openocd, STM32 STLink', 'openocd, STLINK-v3',
-         'openocd, EDBG CMSIS-DAP', 'jlink', 'stm32cubeprogrammer']
+         'openocd, EDBG CMSIS-DAP', 'jlink', 'stm32cubeprogrammer',
+         'flash_command', 'flash_command with args']
 )
 @pytest.mark.parametrize('hardware_probe', TESTDATA_13_2, ids=['probe', 'id'])
 def test_devicehandler_create_command(
@@ -1155,10 +1182,12 @@ def test_devicehandler_create_command(
     runner,
     hardware_probe,
     hardware_product_name,
+    self_flash_command,
     expected
 ):
     handler = DeviceHandler(mocked_instance, 'build', mock.Mock())
-    handler.options = mock.Mock(west_flash=self_west_flash)
+    handler.options = mock.Mock(west_flash=self_west_flash,
+                                flash_command=self_flash_command)
     handler.generator_cmd = 'generator_cmd'
 
     expected = [handler.build_dir if val == '$build_dir' else \

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -564,6 +564,7 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
 
     options = handler.options
     options.west_flash = "args"
+    options.flash_command = "flash_command"
 
     hardware.probe_id = "123"
     hardware.product = "product"
@@ -597,6 +598,7 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
         assert "--runner-params=--runner-param1" in command
         assert "--runner-params=runner-param2" in command
         assert "--west-flash-extra-args=args" in command
+        assert "--flash-command=flash_command" in command
         assert "--device-id=123" in command
         assert "--device-product=product" in command
         assert "--pre-script=pre_script" in command


### PR DESCRIPTION
Currently twister requires west to flash a board, either directly using west-flash or indirectly through the cmake flash target.

Add an option to specify a custom flash script, this is passed a build-dir and board-id flags so it can be used to implement custom flashing scripts in a system that does not use west.