### PR TITLE
lib/crc: Add CRC32 POSIX version support

### DIFF
--- a/include/zephyr/sys/crc.h
+++ b/include/zephyr/sys/crc.h
@@ -70,6 +70,7 @@ enum crc_type {
 	CRC24_PGP,   /**< Use @ref crc24_pgp */
 	CRC32_C,     /**< Use @ref crc32_c */
 	CRC32_IEEE,  /**< Use @ref crc32_ieee */
+	CRC32_POSIX, /**< Use @ref crc32_posix */
 	CRC32_K_4_2, /**< Use @ref crc32_k_4_2_update */
 };
 
@@ -249,6 +250,29 @@ uint32_t crc32_ieee(const uint8_t *data, size_t len);
  *
  */
 uint32_t crc32_ieee_update(uint32_t crc, const uint8_t *data, size_t len);
+
+/**
+ * @brief Generate POSIX conform CRC32 checksum.
+ *
+ * @param  data         Pointer to data on which the CRC should be calculated.
+ * @param  len          Data length.
+ *
+ * @return CRC32 value.
+ *
+ */
+uint32_t crc32_posix(const uint8_t *data, size_t len);
+
+/**
+ * @brief Update an POSIX conforming CRC32 checksum.
+ *
+ * @param crc   CRC32 checksum that needs to be updated.
+ * @param data  Pointer to data on which the CRC should be calculated.
+ * @param len   Data length.
+ *
+ * @return CRC32 value.
+ *
+ */
+uint32_t crc32_posix_update(uint32_t crc, const uint8_t *data, size_t len);
 
 /**
  * @brief Calculate CRC32C (Castagnoli) checksum.
@@ -465,6 +489,8 @@ static inline uint32_t crc_by_type(enum crc_type type, const uint8_t *src, size_
 		return crc32_c(seed, src, len, first, last);
 	case CRC32_IEEE:
 		return crc32_ieee_update(seed, src, len);
+	case CRC32_POSIX:
+		return crc32_posix_update(seed, src, len);
 	case CRC32_K_4_2:
 		return crc32_k_4_2_update(seed, src, len);
 	default:

--- a/lib/crc/crc32_sw.c
+++ b/lib/crc/crc32_sw.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Workaround GmbH.
+ * Copyright (c) 2025 Arch-Embedded B.V.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,6 +29,34 @@ uint32_t crc32_ieee_update(uint32_t crc, const uint8_t *data, size_t len)
 
 		crc = (crc >> 4) ^ table[(crc ^ byte) & 0x0f];
 		crc = (crc >> 4) ^ table[(crc ^ ((uint32_t)byte >> 4)) & 0x0f];
+	}
+
+	return (~crc);
+}
+
+uint32_t crc32_posix(const uint8_t *data, size_t len)
+{
+	return crc32_posix_update(0x0, data, len);
+}
+
+uint32_t crc32_posix_update(uint32_t crc, const uint8_t *data, size_t len)
+{
+	/**
+	 * CRC table generated from polynomial 0x04c11db7
+	 *
+	 * pycrc --width 32 --poly 0x04c11db7 --reflect-in False --xor-in 0xFFFFFFFF
+	 * --reflect-out False --xor-out 0 --generate table --table-idx-width 4
+	 */
+	static const uint32_t table[16] = {
+		0x00000000U, 0x04c11db7U, 0x09823b6eU, 0x0d4326d9U,
+		0x130476dcU, 0x17c56b6bU, 0x1a864db2U, 0x1e475005U,
+		0x2608edb8U, 0x22c9f00fU, 0x2f8ad6d6U, 0x2b4bcb61U,
+		0x350c9b64U, 0x31cd86d3U, 0x3c8ea00aU, 0x384fbdbdU,
+	};
+
+	for (size_t i = 0; i < len; i++) {
+		crc = (crc << 4) ^ table[((crc >> 28) ^ (data[i] >> 4)) & 0x0f];
+		crc = (crc << 4) ^ table[((crc >> 28) ^ data[i]) & 0x0f];
 	}
 
 	return (~crc);

--- a/lib/crc/crc_shell.c
+++ b/lib/crc/crc_shell.c
@@ -32,6 +32,7 @@ static const char *const crc_types[] = {
 	[CRC24_PGP] = "24_pgp",
 	[CRC32_C] = "32_c",
 	[CRC32_IEEE] = "32_ieee",
+	[CRC32_POSIX] = "32_posix",
 	[CRC32_K_4_2] = "32_k_4_2",
 };
 


### PR DESCRIPTION
It adds CRC32 POSIX support. This could serve as a replacement for the open coded CRC32 implementation in the NXP HCI bluetooth module.