### PR TITLE
drivers: net: ppp: Fix link-layer address configuration

### DIFF
--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -974,17 +974,9 @@ static int ppp_driver_init(const struct device *dev)
 	return 0;
 }
 
-static inline struct net_linkaddr *ppp_get_mac(struct ppp_driver_context *ppp)
-{
-	(void)net_linkaddr_set(&ppp->ll_addr, ppp->mac_addr, sizeof(ppp->mac_addr));
-
-	return &ppp->ll_addr;
-}
-
 static void ppp_iface_init(struct net_if *iface)
 {
 	struct ppp_driver_context *ppp = net_if_get_device(iface)->data;
-	struct net_linkaddr *ll_addr;
 
 	LOG_DBG("[%p] iface %p", ppp, iface);
 
@@ -996,11 +988,6 @@ static void ppp_iface_init(struct net_if *iface)
 
 	ppp->init_done = true;
 	ppp->iface = iface;
-
-	/* The mac address is not really used but network interface expects
-	 * to find one.
-	 */
-	ll_addr = ppp_get_mac(ppp);
 
 	if (CONFIG_PPP_MAC_ADDR[0] != 0) {
 		if (net_bytes_from_str(ppp->mac_addr, sizeof(ppp->mac_addr),
@@ -1018,7 +1005,10 @@ use_random_mac:
 		ppp->mac_addr[5] = sys_rand8_get();
 	}
 
-	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
+	/* The MAC address is not really used, but the network interface expects to find one. */
+	(void)net_linkaddr_set(&ppp->ll_addr, ppp->mac_addr, sizeof(ppp->mac_addr));
+
+	net_if_set_link_addr(iface, ppp->ll_addr.addr, ppp->ll_addr.len,
 			     NET_LINK_ETHERNET);
 
 	if (IS_ENABLED(CONFIG_NET_PPP_CAPTURE)) {


### PR DESCRIPTION
Restore setting the ppp link-local address either to `CONFIG_PPP_MAC_ADDR` or to a random value 00:00:5e:00:53:XX instead of leaving it uninitialized.

Recently the memory handling for the link-layer addresses was changed from an approach of copying pointers to managing the memory as a member of the `net_linkaddr` struct (ref ac3cb9dac0be48a2be120aa0ee82051f8fff4001).

The piece of code this patch touches however, relied on the use of the pointers to function properly.

With the recent change, the MAC address was copied to the new member location before it was even set (either from Kconfig or selected randomly). As a result, the link-layer address was kept initialized to zero, which resulted in a IPv6 address of fe80::ff:fe00:0 which is exactly the link-local EUI-64 representation of the MAC address 00:00:00:00:00:00 (without flipping the "universal/local" bit).

The bug was introduced with the recent Zephyr 4.2.