### PR TITLE
drivers: bluetooth: hci: silabs: Implement hci_close

### DIFF
--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -327,6 +327,18 @@ deinit:
 	return ret;
 }
 
+static int slz_bt_close(const struct device *dev)
+{
+	k_thread_abort(&slz_ll_thread);
+	k_thread_abort(&slz_rx_thread);
+
+	sl_btctrl_deinit();
+
+	LOG_DBG("SiLabs BT HCI stopped");
+
+	return 0;
+}
+
 bool sli_pending_btctrl_events(void)
 {
 	return false; /* TODO: check if this should really return false! */
@@ -346,6 +358,7 @@ void BTLE_LL_EventRaise(uint32_t events)
 
 static DEVICE_API(bt_hci, drv) = {
 	.open           = slz_bt_open,
+	.close          = slz_bt_close,
 	.send           = slz_bt_send,
 };
 


### PR DESCRIPTION
Implements HCI close support for the silabs efr32 HCI driver.

Calling `bt_disable()` now works as expected, which is particularly important for multiprotocol applications.