### PR TITLE
MAINTAINERS: update `hal_espressif` contributors

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5224,6 +5224,8 @@ West:
   collaborators:
     - LucasTambor
     - marekmatej
+    - raffarost
+    - wmrsouza
   files:
     - modules/Kconfig.esp32
   labels:


### PR DESCRIPTION
Add missing contributors to `hal_espressif` area.