### PR TITLE
requirements: update pyOCD requirement to 0.37.0

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -3,7 +3,7 @@
 # things used by twister or related in run time testing
 
 # used to flash & debug various boards
-pyocd>=0.35.0
+pyocd>=0.37.0
 
 # used by twister for board/hardware map
 tabulate


### PR DESCRIPTION
Updates pyOCD to 0.37.0 to permit use with nRF54L15.

Signed-off-by: Kelly Helmut Lord <kellyhlord@gmail.com>
