### PR TITLE
twister: reset ESP32 via RTS/DTR to capture early boot logs

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -806,7 +806,27 @@ class DeviceHandler(Handler):
             try:
                 logger.debug(f"Attach serial device {serial_device} @ {hardware.baud} baud")
                 ser.port = serial_device
-                ser.open()
+
+                # Apply ESP32-specific RTS/DTR reset logic
+                if runner == "esp32":
+                    logger.debug("Applying ESP32 RTS/DTR reset sequence")
+
+                    # Prepare: IO0=HIGH (DTR=True), EN=HIGH (RTS=False)
+                    ser.dtr = True
+                    ser.rts = False
+
+                    ser.open()
+
+                    # Reset pulse: IO0=LOW (DTR=False), EN=LOW (RTS=True)
+                    ser.dtr = False
+                    ser.rts = True
+                    time.sleep(0.01)
+
+                    # Return to normal boot
+                    ser.rts = False
+                else:
+                    ser.open()
+
             except serial.SerialException as e:
                 self._handle_serial_exception(e, hardware, serial_pty, ser_pty_process)
                 return


### PR DESCRIPTION
When testing ESP32-based platforms in CI, early boot logs can be missed if the serial connection isn't reset properly. This patch applies the standard RTS/DTR toggle sequence to reset the ESP32 after flashing, ensuring consistent log capture from the very beginning.

The logic is applied conditionally when the runner is "esp32".