### PR TITLE
boards: st: stm32h7RS target boards has pyocd runner

### DIFF
--- a/boards/st/nucleo_h7s3l8/board.cmake
+++ b/boards/st/nucleo_h7s3l8/board.cmake
@@ -5,9 +5,13 @@ board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 if(CONFIG_XIP AND (CONFIG_STM32_MEMMAP OR CONFIG_BOOTLOADER_MCUBOOT))
   board_runner_args(stm32cubeprogrammer "--extload=MX25UW25645G_NUCLEO-H7S3L8.stldr")
 endif()
-
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
+
+board_runner_args(pyocd "--target=stm32h7s3l8hx")
+board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
+board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
 
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)

--- a/boards/st/stm32h7s78_dk/board.cmake
+++ b/boards/st/stm32h7s78_dk/board.cmake
@@ -8,7 +8,11 @@ endif()
 
 board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
+board_runner_args(pyocd "--target=stm32h7s7l8hxh")
+board_runner_args(pyocd "--flash-opt=-O reset_type=hw")
+board_runner_args(pyocd "--flash-opt=-O connect_mode=under-reset")
+
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
-# FIXME: openocd runner not yet available.
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)


### PR DESCRIPTION
Add the pyocd as runner for the stm32h7s3l8 nucleo or stm32h7s78 dk so that debugging becomes possible if openocd is not available. 
Check with 'pyocd list --target'

expecting : Keil.STM32H7RSxx_DFP     minimum "1.0.0"