### PR TITLE
drivers: misc: ethos_u: support default dcache flush/invalidate

### DIFF
--- a/drivers/misc/ethos_u/Kconfig
+++ b/drivers/misc/ethos_u/Kconfig
@@ -18,3 +18,8 @@ config ETHOS_U_NUMAKER
 	  Enables Nuvoton NuMaker frontend of Arm Ethos-U NPU driver
 
 endchoice
+
+config ETHOS_U_DCACHE
+	bool "Override Ethos-U driver DCache functions"
+	depends on ETHOS_U
+	default y if CACHE_MANAGEMENT

--- a/drivers/misc/ethos_u/ethos_u_common.c
+++ b/drivers/misc/ethos_u/ethos_u_common.c
@@ -9,6 +9,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/cache.h>
 
 #include <ethosu_driver.h>
 
@@ -100,3 +101,19 @@ int ethosu_semaphore_give(void *sem)
 	k_sem_give((struct k_sem *)sem);
 	return 0;
 }
+
+#if defined(CONFIG_ETHOS_U_DCACHE)
+void ethosu_flush_dcache(uint32_t *p, size_t bytes)
+{
+	if (p && bytes) {
+		sys_cache_data_flush_range((void *)p, bytes);
+	}
+}
+
+void ethosu_invalidate_dcache(uint32_t *p, size_t bytes)
+{
+	if (p && bytes) {
+		sys_cache_data_invd_range((void *)p, bytes);
+	}
+}
+#endif


### PR DESCRIPTION
This provides default `ethosu_flush_dcache` and `ethosu_invalidate_dcache` overrides for ethos_u driver. User application can disable them if it needs to provide its own.