### PR TITLE
do not test the stm32h5 wwdg if the sram is erased

### DIFF
--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -265,7 +265,9 @@ void wwdg_stm32_isr(const struct device *dev)
 	if (LL_WWDG_IsEnabledIT_EWKUP(wwdg)) {
 		if (LL_WWDG_IsActiveFlag_EWKUP(wwdg)) {
 			LL_WWDG_ClearFlag_EWKUP(wwdg);
-			data->callback(dev, 0);
+			if (data->callback != NULL) {
+				data->callback(dev, 0);
+			}
 		}
 	}
 }

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -55,7 +55,6 @@ tests:
       - nucleo_u385rg_q
       - nucleo_u575zi_q
       - nucleo_c031c6
-      - stm32h573i_dk
       - nucleo_wba55cg
     integration_platforms:
       - nucleo_f091rc


### PR DESCRIPTION
This PR removes the stm32h573 disco kit from the list of tests/drivers/watchdog/wdt_basic_api/
The testcase is using a variable `m_state` which is stored in the sram1 (ex. 0x20001698)
On the stm32h573 mcu, the "SRAM1 and SRAM3 are erased when a system
reset occurs if the SRAM13_RST option bit is selected in the flash memory user option bytes."

When checking the bit "SRAM1 and SRAM3 not erased when a system reset occurs"  with a stm32cubeprogrammer tool, then can the test pass : 
```
Running TESTSUITE wdt_basic_test_suite
===================================================================
START - test_wdt
Testcase: test_wdt_no_callback
Testcase passed
Testcase: test_wdt_enable_wait_mode
 SKIP - test_wdt in 0.008 seconds
===================================================================
TESTSUITE wdt_basic_test_suite succeeded

------ TESTSUITE SUMMARY START ------

SUITE SKIP -   0.00% [wdt_basic_test_suite]: pass = 0, fail = 0, skip = 1, total = 1 duration = 0.008 seconds
 - SKIP - [wdt_basic_test_suite.test_wdt] duration = 0.008 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```

By default the SRAM13_RST is "0" SRAM1 and SRAM3 erased when a system reset occurs

- Another change could be to use the BKPSRAM of the stm32h573 to store the m_state variable.
- Another change could be  to detect if the reset is caused by the watchdog during this test, using the `z_impl_hwinfo_get_reset_cause`  function


Additionnaly fixes an error during test execution : 
```
START - test_wdt
Testcase: test_wdt_no_callback
Waiting to restart MCU
E: ***** BUS FAULT *****
E:   Instruction bus err�
```