### PR TITLE
dts: binding: vendor-prefixes: Remove duplicate vendor prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -646,7 +646,6 @@ solderparty	Solder Party AB
 solidrun	SolidRun
 solomon	Solomon Systech Limited
 sony	Sony Corporation
-spacecubics	Space Cubics, LLC
 spansion	Spansion Inc.
 sparkfun	SparkFun Electronics
 sprd	Spreadtrum Communications Inc.


### PR DESCRIPTION
The "spacecubics" entry was redundant as we use the "sc" prefix for Space Cubics, Inc.

Removing this duplicate to avoid confusion and maintain consistency in vendor naming.

From that PR discussion https://github.com/zephyrproject-rtos/zephyr/pull/93182