### PR TITLE
drivers: display: elcdif: Fix zero-length array warning

### DIFF
--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -26,13 +26,6 @@ config MCUX_ELCDIF_FB_NUM
 	  implements double framebuffering by always calling display_write with
 	  a buffer equal in size to the connected panel.
 
-	  NOTE: when no framebuffers are allocated, the ELCDIF will be
-	  set to display an empty buffer during initialization. This means
-	  the display will show what is effectively a dump of
-	  system RAM until a new framebuffer is written. If the security
-	  implications of this concern you, leave at least one driver
-	  framebuffer enabled.
-
 config MCUX_ELCDIF_FB_SIZE
 	int "Framebuffer size required by the eLCDIF driver"
 	default 3686400

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -54,6 +54,7 @@ struct mcux_elcdif_data {
 	struct k_sem sem;
 	/* Tracks index of next active driver framebuffer */
 	uint8_t next_idx;
+	bool running;
 #ifdef CONFIG_MCUX_ELCDIF_PXP
 	/* Given to when PXP completes operation */
 	struct k_sem pxp_done;
@@ -215,6 +216,12 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x, const u
 	/* Update index of active framebuffer */
 	dev_data->next_idx = (dev_data->next_idx + 1) % CONFIG_MCUX_ELCDIF_FB_NUM;
 #endif
+
+	if (unlikely(!dev_data->running)) {
+		ELCDIF_RgbModeStart(config->base);
+		dev_data->running = true;
+	}
+
 	/* Enable frame buffer completion interrupt */
 	ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
 	/* Wait for frame send to complete */
@@ -361,10 +368,11 @@ static int mcux_elcdif_init(const struct device *dev)
 	/* Set default pixel format obtained from device tree */
 	mcux_elcdif_set_pixel_format(dev, dev_data->pixel_format);
 
+#if CONFIG_MCUX_ELCDIF_FB_NUM != 0
 	dev_data->active_fb = dev_data->fb[0];
+#endif
 
 	ELCDIF_RgbModeInit(config->base, &dev_data->rgb_mode);
-	ELCDIF_RgbModeStart(config->base);
 
 	return 0;
 }


### PR DESCRIPTION
When setting `CONFIG_MCUX_ELCDIF_FB_NUM=0` we can't assign the active pointer to any framebuffer.