### PR TITLE
net: l2: wifi: fix the build error of hostapd enterprise

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -2027,7 +2027,7 @@ static int cmd_wifi_ap_enable(const struct shell *sh, size_t argc,
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_GTC ||
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_TTLS_MSCHAPV2 ||
 	    cnx_params.security == WIFI_SECURITY_TYPE_EAP_PEAP_TLS) {
-		wifi_set_enterprise_creds(sh, iface, 1);
+		wifi_set_enterprise_credentials(iface, 1);
 	}
 #endif
 

--- a/tests/net/wifi/configs/testcase.yaml
+++ b/tests/net/wifi/configs/testcase.yaml
@@ -54,6 +54,12 @@ tests:
     extra_configs:
       - CONFIG_WIFI_NM_HOSTAPD_AP=y
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_INF_MON=n
+  wifi.build.hostapd_ap_enterprise:
+    extra_configs:
+      - CONFIG_WIFI_NM_HOSTAPD_AP=y
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_INF_MON=n
+      - CONFIG_WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE=y
+      - CONFIG_WIFI_NM_HOSTAPD_CRYPTO_ENTERPRISE=y
   wifi.build.dpp:
     extra_configs:
       - CONFIG_WIFI_NM_WPA_SUPPLICANT_DPP=y


### PR DESCRIPTION
Fix the build error when hostapd enterprise is enabled, it should use new wifi_set_enterprise_credentials API, instead of wifi_set_enterprise_credentials.