### PR TITLE
net: lib: tls_credentials: add invalid sec tag value

### DIFF
--- a/include/zephyr/net/tls_credentials.h
+++ b/include/zephyr/net/tls_credentials.h
@@ -79,6 +79,8 @@ enum tls_credential_type {
  */
 typedef int sec_tag_t;
 
+#define SEC_TAG_TLS_INVALID (-1) /**< Invalid secure tag value. */
+
 /**
  * @brief Add a TLS credential.
  *


### PR DESCRIPTION
Add a definition for an invalid secure tag value to be used as a placeholder. Negative values are reserved for internal use, but some of them should be considered valid.
To be able to check against a value, we need to define an invalid one.