### PR TITLE
net: tcp: Avoid casting unaligned address to struct in_addr

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1390,9 +1390,12 @@ void net_tcp_reply_rst(struct net_pkt *pkt)
 
 	/* IP header */
 	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET) {
-		ret = net_ipv4_create(rst,
-				      (struct in_addr *)NET_IPV4_HDR(pkt)->dst,
-				      (struct in_addr *)NET_IPV4_HDR(pkt)->src);
+		struct in_addr src, dst;
+
+		net_ipv4_addr_copy_raw(src.s4_addr, NET_IPV4_HDR(pkt)->src);
+		net_ipv4_addr_copy_raw(dst.s4_addr, NET_IPV4_HDR(pkt)->dst);
+
+		ret = net_ipv4_create(rst, &dst, &src);
 	} else if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == AF_INET6) {
 		struct in6_addr src, dst;
 


### PR DESCRIPTION
This change addresses an alignment problem reported by UBSAN by using a copy of the address. This avoids the need for extensive rework to support *_raw variants in the routing layer. This follows the same approach that we have taken for IPv6.

Bug reported by UBSAN:
```
include/zephyr/net/net_ip.h:888:42: runtime error: member access within misaligned address 0x08cbcfba for type 'const struct in_addr', which requires 4 byte alignment
0x08cbcfba: note: pointer points here
 80 06  0b eb c0 00 02 02 c0 00  02 32 f1 09 00 50 5f 59  e5 ac e6 73 69 f8 50 10  f8 b3 ac 1e 00 00
              ^
    #0 0x082a857b in net_ipv4_is_addr_mcast include/zephyr/net/net_ip.h:888:42
    #1 0x082a857b in net_ipv4_create_full subsys/net/ip/ipv4.c:62:7
    #2 0x082a892f in net_ipv4_create subsys/net/ip/ipv4.c:106:9
    #3 0x082ad4b8 in net_tcp_reply_rstsubsys/net/ip/tcp.c:1393:9
    #4 0x082b6d6d in tcp_recv subsys/net/ip/tcp.c:2248:3
    #5 0x082a296e in net_conn_input subsys/net/ip/connection.c:1072:7
    #6 0x082a9e2a in net_ipv4_input subsys/net/ip/ipv4.c:452:12
    #7 0x08263c79 in process_data subsys/net/ip/net_core.c:136:11
    #8 0x08263c79 in processing_data subsys/net/ip/net_core.c:154:10
    #9 0x0829a9b4 in tc_rx_handler subsys/net/ip/net_tc.c:310:3
    #10 0x08176726 in z_thread_entry lib/os/thread_entry.c:48:2
    #11 0x081d45b3 in posix_arch_thread_entry arch/posix/core/thread.c:96:2
    #12 0x0888b7c5 in nct_thread_starter scripts/native_simulator/common/src/nct.c:290:2
    #13 0x080fc66c in asan_thread_start(void*) asan_interceptors.cpp.o

SUMMARY: UndefinedBehaviorSanitizer: misaligned-pointer-use include/zephyr/net/net_ip.h:888:42
```

Related: #90882 