### PR TITLE
net: lwm2m: Do not truncate strings

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_cbor.c
@@ -302,10 +302,12 @@ static int get_string(struct lwm2m_input_context *in, uint8_t *value, size_t buf
 		return -EBADMSG;
 	}
 
-	len = MIN(buflen-1, hndl.len);
+	len = hndl.len;
+	if (len >= buflen) {
+		return -ENOMEM;
+	}
 
 	memcpy(value, hndl.value, len);
-
 	value[len] = '\0';
 
 	len = ICTX_CBOR_R_SZ(states[0].payload, in);

--- a/subsys/net/lib/lwm2m/lwm2m_rw_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_json.c
@@ -723,8 +723,8 @@ static int get_string(struct lwm2m_input_context *in, uint8_t *buf,
 	string_length = strlen(fd->array_object.val_string);
 
 	if (string_length > buflen) {
-		LOG_WRN("Buffer too small to accommodate string, truncating");
-		string_length = buflen - 1;
+		LOG_WRN("Buffer too small to accommodate string");
+		return -ENOMEM;
 	}
 	memcpy(buf, fd->array_object.val_string, string_length);
 

--- a/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_plain_text.c
@@ -255,9 +255,9 @@ static int get_string(struct lwm2m_input_context *in, uint8_t *value,
 
 	coap_packet_get_payload(in->in_cpkt, &in_len);
 
-	if (in_len > buflen) {
-		LOG_ERR("Buffer too small to accommodate string, truncating");
-		in_len = buflen - 1;
+	if (in_len + 1 > buflen) {
+		LOG_ERR("Buffer too small to accommodate string");
+		return -ENOMEM;
 	}
 
 	if (buf_read(value, in_len, CPKT_BUF_READ(in->in_cpkt),

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -643,10 +643,11 @@ static int get_string(struct lwm2m_input_context *in, uint8_t *buf, size_t bufle
 		return -EINVAL;
 	}
 
-	len = MIN(buflen-1, fd->current->record_union.union_vs.len);
-	if (len > 0) {
-		memcpy(buf, fd->current->record_union.union_vs.value, len);
+	len = fd->current->record_union.union_vs.len;
+	if (len >= buflen) {
+		return -ENOMEM;
 	}
+	memcpy(buf, fd->current->record_union.union_vs.value, len);
 	buf[len] = '\0';
 
 	fd->current = NULL;

--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
@@ -1096,9 +1096,9 @@ static int get_string(struct lwm2m_input_context *in, uint8_t *buf, size_t bufle
 
 	string_length = strlen(fd->senml_object.val_string);
 
-	if (string_length > buflen) {
-		LOG_WRN("Buffer too small to accommodate string, truncating");
-		string_length = buflen - 1;
+	if (string_length >= buflen) {
+		LOG_WRN("Buffer too small to accommodate string");
+		return -ENOMEM;
 	}
 	memcpy(buf, fd->senml_object.val_string, string_length);
 

--- a/tests/net/lib/lwm2m/content_json/src/main.c
+++ b/tests/net/lib/lwm2m/content_json/src/main.c
@@ -574,6 +574,37 @@ ZTEST(net_content_json, test_get_string)
 	zassert_true(ret >= 0, "Error reported");
 	zassert_mem_equal(test_string, expected_value, strlen(expected_value),
 			  "Invalid value parsed");
+
+	/* Should not truncate but return an error */
+	const char *long_payload =
+		TEST_PAYLOAD(TEST_RES_STRING, "sv", "\"test_stringtest_string\"");
+	test_payload_set(long_payload);
+	ret = do_write_op_json(&test_msg);
+	zassert_equal(ret, -ENOMEM);
+}
+
+ZTEST(net_content_json, test_get_string_utf8)
+{
+	int ret;
+	const char *payload =
+		TEST_PAYLOAD(TEST_RES_STRING, "sv", "\"👨‍👩🤡\"");
+	static const char expected_value[] = "👨‍👩🤡";
+
+	test_msg.path.res_id = TEST_RES_STRING;
+
+	test_payload_set(payload);
+
+	ret = do_write_op_json(&test_msg);
+	zassert_true(ret >= 0, "Error reported");
+	zassert_mem_equal(test_string, expected_value, strlen(expected_value),
+			  "Invalid value parsed");
+
+	/* Should not truncate but return an error */
+	const char *long_payload =
+		TEST_PAYLOAD(TEST_RES_STRING, "sv", "\"👨‍👩🤡🤴\"");
+	test_payload_set(long_payload);
+	ret = do_write_op_json(&test_msg);
+	zassert_equal(ret, -ENOMEM);
 }
 
 ZTEST(net_content_json_nodata, test_get_string_nodata)

--- a/tests/net/lib/lwm2m/content_plain_text/src/main.c
+++ b/tests/net/lib/lwm2m/content_plain_text/src/main.c
@@ -52,6 +52,7 @@ static void test_prepare_nodata(void *dummy)
 
 	context_reset();
 
+	test_packet.hdr_len = sizeof(test_payload);
 	test_packet.offset = sizeof(test_payload);
 	test_in.offset = sizeof(test_payload);
 }
@@ -401,6 +402,18 @@ ZTEST(net_content_plain_text, test_get_string)
 			  "Invalid value parsed");
 	zassert_equal(test_in.offset, strlen(test_string) + 1,
 		      "Invalid packet offset");
+}
+
+ZTEST(net_content_plain_text, test_get_string_truncate)
+{
+	int ret;
+	static const char test_string[] = "test_string";
+	uint8_t buf[16];
+
+	test_payload_set(test_string);
+
+	ret = plain_text_reader.get_string(&test_in, buf, sizeof(test_string) - 1);
+	zassert_equal(ret, -ENOMEM, "Invalid error returned %d", ret);
 }
 
 ZTEST(net_content_plain_text_nodata, test_get_string_nodata)

--- a/tests/net/lib/lwm2m/content_raw_cbor/src/main.c
+++ b/tests/net/lib/lwm2m/content_raw_cbor/src/main.c
@@ -890,6 +890,31 @@ ZTEST(net_content_raw_cbor, test_get_string)
 			  "Invalid packet offset");
 }
 
+ZTEST(net_content_raw_cbor, test_get_string_truncate)
+{
+	int ret;
+	static const char long_string[] = "test_string_that_is_a_bit_longer";
+	uint8_t buf[40];
+	struct test_payload_buffer long_payload = {
+		.data = {
+			(0x03 << 5) | 0x18,
+			(sizeof("test_string_that_is_a_bit_longer") - 1),
+			't', 'e', 's', 't', '_', 's',
+			't', 'r', 'i', 'n', 'g', '_',
+			't', 'h', 'a', 't', '_', 'i',
+			's', '_', 'a', '_', 'b', 'i',
+			't', '_', 'l', 'o', 'n', 'g',
+			'e', 'r'
+		},
+		.len = sizeof("test_string_that_is_a_bit_longer") - 1 + 2
+	};
+
+	test_payload_set(long_payload.data, long_payload.len);
+
+	ret = cbor_reader.get_string(&test_in, buf, sizeof(long_string) - 1);
+	zassert_equal(ret, -ENOMEM, "Invalid error returned %d", ret);
+}
+
 ZTEST(net_content_raw_cbor_nodata, test_get_string_nodata)
 {
 	int ret;
@@ -1007,25 +1032,25 @@ ZTEST(net_content_raw_cbor, test_get_objlnk)
 	struct test_payload_buffer payload[] = {
 		{
 			.data = {
-			(0x03 << 5) | (sizeof("0:0")),
-			'0', ':', '0', '\0'
+			(0x03 << 5) | (sizeof("0:0") - 1),
+			'0', ':', '0'
 			},
-			.len = sizeof("0:0") + 1
+			.len = sizeof("0:0")
 		},
 		{
 			.data = {
-			(0x03 << 5) | (sizeof("1:2")),
-			'1', ':', '2', '\0'
+			(0x03 << 5) | (sizeof("1:2") - 1),
+			'1', ':', '2'
 			},
-			.len = sizeof("1:2") + 1
+			.len = sizeof("1:2")
 		},
 		{
 			.data = {
-			(0x03 << 5) | (sizeof("65535:65535")),
+			(0x03 << 5) | (sizeof("65535:65535") - 1),
 			'6', '5', '5', '3', '5', ':',
-			'6', '5', '5', '3', '5', '\0'
+			'6', '5', '5', '3', '5'
 			},
-			.len = sizeof("65535:65535") + 1
+			.len = sizeof("65535:65535")
 		}
 	};
 	struct lwm2m_objlnk expected_value[] = {

--- a/tests/net/lib/lwm2m/lwm2m_registry/src/test_obj.c
+++ b/tests/net/lib/lwm2m/lwm2m_registry/src/test_obj.c
@@ -106,4 +106,4 @@ static int obj_init(void)
 	return lwm2m_create_obj_inst(TEST_OBJ_ID, 0, &obj_inst);
 }
 
-SYS_INIT(obj_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+LWM2M_OBJ_INIT(obj_init);


### PR DESCRIPTION
lwm2m_get_string() and lwm2m_set_string() API does not allow strings to be truncated and ensures NUL termination regardles of using string or opaque resources to store the string.

Add tests to verify that is also true on multi-byte UTF-8 strings.

I amended this PR now to refactor most of content formatters not to truncate strings.
As discussed here: https://github.com/zephyrproject-rtos/zephyr/pull/90719 LwM2M engine does not allow truncation of strings as it would break multi-byte UTF-8 strings. However, seemed that some content formatters did truncate, instead of reporting error.

I fixed at least  these

* plain text
* TLV
* SenML CBOR
* SenML JSON
* JSON
* CBOR

Those that had testcases, I added a test to verify that it return -ENOMEM and even with multibyte UTF-8 strings.