### PR TITLE
drivers: charger: add generic struct charger_value to property union

### DIFF
--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -121,6 +121,31 @@ enum charger_property {
 typedef uint16_t charger_prop_t;
 
 /**
+ * @typedef charger_custom_value_int_t
+ * @brief Type for custom signed integer property values.
+ *
+ * Used only by downstream custom properties (>= CHARGER_PROP_CUSTOM_BEGIN).
+ */
+typedef int32_t charger_custom_value_int_t;
+
+/**
+ * @typedef charger_custom_value_uint_t
+ * @brief Type for custom unsigned integer property values.
+ *
+ * Used only by downstream custom properties (>= CHARGER_PROP_CUSTOM_BEGIN).
+ */
+typedef uint32_t charger_custom_value_uint_t;
+
+/**
+ * @typedef charger_custom_value_bool_t
+ * @brief Type for custom boolean property values.
+ *
+ * Used only by downstream custom properties (>= CHARGER_PROP_CUSTOM_BEGIN),
+ * typically for feature/status flags (e.g. jeita_active).
+ */
+typedef bool charger_custom_value_bool_t;
+
+/**
  * @brief External supply states
  */
 enum charger_online {
@@ -297,6 +322,12 @@ union charger_propval {
 	charger_status_notifier_t status_notification;
 	/** CHARGER_PROP_ONLINE_NOTIFICATION */
 	charger_online_notifier_t online_notification;
+	/** Generic integer value for downstream custom properties */
+	charger_custom_value_int_t custom_int;
+	/** Generic unsigned value for downstream custom properties */
+	charger_custom_value_uint_t custom_uint;
+	/** Generic boolean value for downstream custom properties */
+	charger_custom_value_bool_t custom_bool;
 };
 
 /**


### PR DESCRIPTION
The charger interface already exposes **CHARGER_PROP_CUSTOM_BEGIN** so that down-stream drivers can publish vendor-specific properties without forcing them into the common enumeration.  What is missing is a generic storage container for those values, as today each driver has to abuse one of the fixed-purpose union members (e.g. `const_charge_current_ua`) or introduce a private out-of-tree patch.  

This patch introduces
```
struct charger_value {
    int32_t val1;   /* integral part   */
    int32_t val2;   /* fractional */
};
```
and adds it to `union charger_propval` under the name `custom_prop`. The fixed-point representation is identical to the `sensor_value` used by the sensor subsystem. The largest existing union member is `struct charger_current_notifier` (12 bytes, padded to 12) and the new struct is 8 bytes, therefore the union’s size does not increase.

I was also thinking to add the helpers, e.g. `charger_value_to_double()` and so on, like in sensor API, but I am not sure if it's a good idea to have that much of a duplicate code around. Nevertheless, just having this `custom_prop` will already allow the drivers to expose their custom properties if needed. 

UPDATE:
Instead of integral and fractional parts, we'll use `charger_custom_value_int_t` (signed), `charger_custom_value_uint_t` (unsigned) to cover numeric properties (e.g. IBAT) and `charger_custom_value_bool_t` to cover boolean properties (e.g. JEITA enabled)
