### PR TITLE
cmake: deprecate the flash debug debugserver attach rtt targets

### DIFF
--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -188,6 +188,7 @@ foreach(target flash debug debugserver attach rtt)
 
   if(WEST)
     add_custom_target(${target}
+      cmake -E echo "WARNING: CMake ${target} target is deprecated, call west directly instead"
       # This script will print an error message and fail if <target> has added
       # dependencies. This is done using dedicated CMake script, as
       # `cmake -E {true|false}` is not available until CMake 3.16.

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -818,14 +818,12 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
 
     parser.add_argument(
         "--west-flash", nargs='?', const=[],
-        help="""Uses west instead of ninja or make to flash when running with
-             --device-testing. Supports comma-separated argument list.
+        help="""Comma separated list of additional flags passed to west when
+            running with --device-testing.
 
         E.g "twister --device-testing --device-serial /dev/ttyACM0
                          --west-flash="--board-id=foobar,--erase"
         will translate to "west flash -- --board-id=foobar --erase"
-
-        NOTE: device-testing must be enabled to use this option.
         """
     )
     parser.add_argument(
@@ -836,8 +834,6 @@ structure in the main Zephyr tree: boards/<vendor>/<board_name>/""")
         E.g "twister --device-testing --device-serial /dev/ttyACM0
                          --west-flash --west-runner=pyocd"
         will translate to "west flash --runner pyocd"
-
-        NOTE: west-flash must be enabled to use this option.
         """
     )
 
@@ -895,14 +891,6 @@ def parse_arguments(
 
     if options.device_serial_pty and os.name == "nt":  # OS is Windows
         logger.error("--device-serial-pty is not supported on Windows OS")
-        sys.exit(1)
-
-    if options.west_runner and options.west_flash is None:
-        logger.error("west-runner requires west-flash to be enabled")
-        sys.exit(1)
-
-    if options.west_flash and not options.device_testing:
-        logger.error("west-flash requires device-testing to be enabled")
         sys.exit(1)
 
     if not options.testsuite_root:

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -828,23 +828,6 @@ class FilterBuilder(CMake):
             filter_data.update(self.defconfig)
         filter_data.update(self.cmake_cache)
 
-        # Verify that twister's arguments support sysbuild.
-        # Twister sysbuild flashing currently only works with west,
-        # so --west-flash must be passed.
-        if (
-            self.instance.sysbuild
-            and self.env.options.device_testing
-            and self.env.options.west_flash is None
-        ):
-            logger.warning("Sysbuild test will be skipped. West must be used for flashing.")
-            return {
-                os.path.join(
-                    self.platform.name,
-                    self.instance.toolchain,
-                    self.testsuite.name
-                ): True
-            }
-
         if self.testsuite and self.testsuite.filter:
             try:
                 if os.path.exists(edt_pickle):

--- a/scripts/tests/twister/test_environment.py
+++ b/scripts/tests/twister/test_environment.py
@@ -34,20 +34,6 @@ TESTDATA_1 = [
     ),
     (
         None,
-        None,
-        None,
-        ['--west-runner=dummy'],
-        'west-runner requires west-flash to be enabled'
-    ),
-    (
-        None,
-        None,
-        None,
-        ['--west-flash=\"--board-id=dummy\"'],
-        'west-flash requires device-testing to be enabled'
-    ),
-    (
-        None,
         {
             'exist': [],
             'missing': ['valgrind']
@@ -136,8 +122,6 @@ TESTDATA_1 = [
     ids=[
         'short build path without ninja',
         'device-serial-pty on Windows',
-        'west runner without west flash',
-        'west-flash without device-testing',
         'valgrind without executable',
         'device serial without platform',
         'device serial with multiple platforms',

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1061,7 +1061,7 @@ TESTDATA_13 = [
         None,
         None,
         None,
-        ['generator_cmd', '-C', '$build_dir', 'flash']
+        ['west', 'flash', '--skip-rebuild', '-d', '$build_dir']
     ),
     (
         [],
@@ -1155,7 +1155,7 @@ TESTDATA_13_2 = [(True), (False)]
     'self_west_flash, runner,' \
     ' hardware_product_name, expected',
     TESTDATA_13,
-    ids=['generator', '--west-flash', 'one west flash value',
+    ids=['default', '--west-flash', 'one west flash value',
          'multiple west flash values', 'generic runner', 'pyocd',
          'nrfjprog', 'openocd, STM32 STLink', 'openocd, STLINK-v3',
          'openocd, EDBG CMSIS-DAP', 'jlink', 'stm32cubeprogrammer']

--- a/scripts/tests/twister/test_runner.py
+++ b/scripts/tests/twister/test_runner.py
@@ -558,19 +558,6 @@ TESTDATA_3 = [
         {os.path.join('other', 'zephyr', 'dummy.testsuite.name'): False}
     ),
     (
-        'other', ['other'], True,
-        False, None, True,
-        'Dummy parse results', True,
-        None,
-        None,
-        {},
-        {},
-        {},
-        None,
-        ['Sysbuild test will be skipped. West must be used for flashing.'],
-        {os.path.join('other', 'zephyr', 'dummy.testsuite.name'): True}
-    ),
-    (
         'other', ['other'], False,
         True, None, False,
         'Dummy parse results', True,
@@ -652,8 +639,7 @@ TESTDATA_3 = [
     ' expected_edt,' \
     ' expected_logs, expected_return',
     TESTDATA_3,
-    ids=['unit testing', 'domain', 'kconfig', 'no cache',
-         'no west options', 'no edt',
+    ids=['unit testing', 'domain', 'kconfig', 'no cache', 'no edt',
          'parse result', 'no parse result', 'no testsuite filter', 'parse err']
 )
 def test_filterbuilder_parse_generated(


### PR DESCRIPTION
Deprecate the flash debug debugserver attach rtt targets generator targets, tell the user to call west instead, drop the logic from twister as well so it behaves consistently, removes few chances of invalid flags, `west-flash` has to stay as sadly it was doubling as "extra arguments"