### PR TITLE
Bluetooth: Classic: RFCOMM: Remove TX thread from DLC

### DIFF
--- a/include/zephyr/bluetooth/classic/rfcomm.h
+++ b/include/zephyr/bluetooth/classic/rfcomm.h
@@ -106,6 +106,9 @@ struct bt_rfcomm_dlc {
 	/* TX credits, Reuse as a binary sem for MSC FC if CFC is not enabled */
 	struct k_sem               tx_credits;
 
+	/* Worker for RFCOMM TX */
+	struct k_work              tx_work;
+
 	struct bt_rfcomm_session  *session;
 	struct bt_rfcomm_dlc_ops  *ops;
 	struct bt_rfcomm_dlc      *_next;
@@ -113,16 +116,10 @@ struct bt_rfcomm_dlc {
 	bt_security_t              required_sec_level;
 	bt_rfcomm_role_t           role;
 
-	uint16_t                      mtu;
-	uint8_t                       dlci;
-	uint8_t                       state;
-	uint8_t                       rx_credit;
-
-	/* Stack & kernel data for TX thread */
-	struct k_thread            tx_thread;
-#if defined(CONFIG_BT_RFCOMM_DLC_STACK_SIZE)
-	K_KERNEL_STACK_MEMBER(stack, CONFIG_BT_RFCOMM_DLC_STACK_SIZE);
-#endif /* CONFIG_BT_RFCOMM_DLC_STACK_SIZE */
+	uint16_t                   mtu;
+	uint8_t                    dlci;
+	uint8_t                    state;
+	uint8_t                    rx_credit;
 };
 
 struct bt_rfcomm_server {

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -147,17 +147,6 @@ config BT_RFCOMM_TX_MAX
 	  sending buf. Normally this can be left to the default value, which
 	  is equal to the number of session in the stack-internal pool.
 
-config BT_RFCOMM_DLC_STACK_SIZE
-	int "Stack size of DLC for RFCOMM"
-	default 512
-	help
-	  Stack size of DLC for RFCOMM. This is the context from which
-	  all data of upper layer are sent and disconnect
-	  callback to the upper layer. The default value is sufficient
-	  for basic operation, but if the application needs to do
-	  advanced things in its callbacks that require extra stack
-	  space, this value can be increased to accommodate for that.
-
 config BT_HFP_HF
 	bool "Bluetooth Handsfree profile HF Role support [EXPERIMENTAL]"
 	depends on PRINTK


### PR DESCRIPTION
There are two main issues found with using DLC TX thread, 
- Issue 1, the RAM consumption. Every DLC will have a dedicated thread and thread stack.
- Issue 2, the thread stack overflow issue. There is no way to strike a balance between stack size and RAM consumption. Since the deep of call stack is depended on the upper layer, the thread stack needs to set by application. Due to the thread stack of DLC is dedicated, RAM consumption is the product of the added value and the number of DLCs.

Use a TX worker to replace DLC TX thread.