### PR TITLE
PM Device Runtime: Introduce request/release reference APIs

### DIFF
--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -8,6 +8,8 @@ description: |
 
 compatible: "pwm-leds"
 
+include: base.yaml
+
 child-binding:
   description: PWM LED child node
 

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -606,6 +606,63 @@ int pm_device_runtime_usage(const struct device *dev)
 	return dev->pm_base->usage;
 }
 
+void pm_device_runtime_reference_init(struct pm_device_runtime_reference *ref)
+{
+	ref->active = false;
+}
+
+int pm_device_runtime_request(const struct device *dev,
+			      struct pm_device_runtime_reference *ref)
+{
+	int ret;
+
+	if (ref->active) {
+		ret = 0;
+	} else {
+		ret = pm_device_runtime_get(dev);
+		if (ret == 0) {
+			ref->active = true;
+		}
+	}
+
+	return ret;
+}
+
+int pm_device_runtime_release(const struct device *dev,
+			      struct pm_device_runtime_reference *ref)
+{
+	int ret;
+
+	if (!ref->active) {
+		ret = 0;
+	} else {
+		ret = pm_device_runtime_put(dev);
+		if (ret == 0) {
+			ref->active = false;
+		}
+	}
+
+	return ret;
+}
+
+int pm_device_runtime_release_async(const struct device *dev,
+				    struct pm_device_runtime_reference *ref,
+				    k_timeout_t timeout)
+{
+	int ret;
+
+	if (!ref->active) {
+		ret = 0;
+	} else {
+		ret = pm_device_runtime_put_async(dev, timeout);
+		if (ret == 0) {
+			ref->active = false;
+		}
+	}
+
+	return ret;
+}
+
 #ifdef CONFIG_PM_DEVICE_RUNTIME_ASYNC
 #ifdef CONFIG_PM_DEVICE_RUNTIME_USE_DEDICATED_WQ
 


### PR DESCRIPTION
Applications migrating from using `pm_device_action_run()` to the reference counted `pm_device_runtime_get()`/`pm_device_runtime_put()` APIs are typically built around a pattern like:
```
/* resume if not already resumed */   
ret = pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
if (ret == 0 || ret == -EALREADY) {
        return 0;
};

/* suspend if not already suspended */   
ret = pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
if (ret == 0 || ret == -EALREADY) {
        return 0;
};
```
which allows multiple re-entrant paths to "force" the PM state if a device. This pattern is problematic if the reference counted APIs are used as it relies on balanced calls to get()/put(). To help applications migrate, and to provide an implementation of this pattern for applications to continue to use this pattern if they so wish, introduce the new APIs:
* `void pm_device_runtime_reference_init(struct pm_device_runtime_reference *ref);`
* `int pm_device_runtime_request(const struct device *dev,
			      struct pm_device_runtime_reference *ref);`
* `int pm_device_runtime_release(const struct device *dev,
			      struct pm_device_runtime_reference *ref);`
* `int pm_device_runtime_release_async(const struct device *dev,
				    struct pm_device_runtime_reference *ref,
				    k_timeout_t delay);`

These APIs let the application create references which can be "activated" and "deactivated", which use the reference counted APIs internally. The new pattern looks like:
```
/* reference used to balance reference counted calls internally  */
struct pm_device_runtime_reference ref;

pm_device_runtime_reference_init(&ref);

/* resume if not already resumed */   
return pm_device_runtime_request(dev, &ref);

/* suspend if not already suspended */   
return pm_device_runtime_release(dev, &ref);
```
The pattern is slightly different given `pm_device_runtime_release` does not ensure the device is actually suspended, this is by design as its based on `PM_DEVICE_RUNTIME` within which this is not possible to force. If applications where using `pm_device_action_run()` safely before, meaning no racing/conflicting calls to `pm_device_action_run()`, the new pattern should not introduce regressions :)

Like the `pm_device_runtime_get()/_put()` APIs, the structs, macros, and functions have stubs which completely optimize away if `CONFIG_PM_DEVICE_RUNTIME` is not enabled, so applications can be built with support for these new APIs with no ifdefs.

Includes bug fix from #94052