### PR TITLE
soc: imx8m: adsp: Add NonCacheable linker section

### DIFF
--- a/soc/nxp/imx/imx8m/adsp/linker.ld
+++ b/soc/nxp/imx/imx8m/adsp/linker.ld
@@ -408,6 +408,7 @@ SECTIONS
     _trace_ctx_end = ABSOLUTE(.);
     . = ALIGN(4);
     *(.gna_model)
+    *(NonCacheable)
     __data_end = ABSOLUTE(.);
     . = ALIGN(4096);
   } >sdram0 :sdram0_phdr


### PR DESCRIPTION
There are some drivers like NXP SDMA that need a NonCacheable data region to put data like channel control or buffer descriptors.

So far, we haven't added such a section because the linker created one default orphan section at the end of the data section.

But this generates a warning in the build system:
xtensa-nxp_imx8m_adsp_zephyr-elf/12.2.0/../../../../xtensa-nxp_imx8m_adsp_zephyr-elf/bin/ld.bfd: warning: orphan section NonCacheable' from modules/hal_nxp/libmodules__hal_nxp.a(fsl_sdma.c.obj)' being placed in section `NonCacheable'

So fix this by explicitly define a NonCacheable area at the end of data section.

This works because imx8mp cache attributes are
_memmap_cacheattr_imx8_wt_allvalid = 0x22212222
and the area where the NonCacheable section is allocated is write-through.

So all the configuration for the SDMA core is not-cached at write.