### PR TITLE
snps: nsim: arc_v: update RMX100 configuration and naming

### DIFF
--- a/boards/snps/nsim/arc_v/Kconfig.nsim_arc_v
+++ b/boards/snps/nsim/arc_v/Kconfig.nsim_arc_v
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_NSIM_ARC_V
-	select SOC_RMX100 if BOARD_NSIM_ARC_V_RMX100
+	select SOC_NSIM_ARC_V_RMX100 if BOARD_NSIM_ARC_V_RMX100

--- a/boards/snps/nsim/arc_v/rmx1xx.dtsi
+++ b/boards/snps/nsim/arc_v/rmx1xx.dtsi
@@ -30,17 +30,17 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			clint: clint@2000000 {
+			clint: clint@a0010000 {
 				compatible = "sifive,clint0";
-				reg = <0x2000000 0x1000>;
+				reg = <0xa0010000 0x1000>;
 				interrupts-extended = <&cpu0_intc 3 &cpu0_intc 7>;
 				interrupt-names = "soft0", "timer0";
 			};
 
-			mtimer: timer@200bff8 {
+			mtimer: timer@a001bff8 {
 				compatible = "riscv,machine-timer";
 				interrupts-extended = <&cpu0_intc 7>;
-				reg = <0x200bff8 0x8 0x2004000 0x8>;
+				reg = <0xa001bff8 0x8 0xa0014000 0x8>;
 				reg-names = "mtime", "mtimecmp";
 			};
 

--- a/boards/snps/nsim/arc_v/support/rmx100.props
+++ b/boards/snps/nsim/arc_v/support/rmx100.props
@@ -1,9 +1,6 @@
 	nsim_isa_family=rv32
 	nsim_isa_ext=-all.i.zicsr.zifencei.zihintpause.a.m.zba.zbb.zbs.zca.zcb.zcmp.zcmt.zicbom
 	nsim_isa_big_endian=0
-	nsim_mem-dev=clint,base=0x2000000,size=4096
+	nsim_mmio_base=2560
 	nsim_mem-dev=uart0,kind=16550,base=0x10000000,irq=24
-	nsim_mem-dev=plic,base=0xc000000,size=0x04000000,interrupts=128,priorities=16
-	mpu_version=64
-	mpu_regions=16
-	mpu_granule=0
+	nsim_mem-interface=ARCV_PMP,num_regions=16,granule=1

--- a/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
+++ b/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 if(COMPILER STREQUAL arcmwdt)
 # CCAC:
-  zephyr_compile_options_ifdef(CONFIG_SOC_SERIES_RMX
+  zephyr_compile_options_ifdef(CONFIG_SOC_SERIES_NSIM_ARC_V_RMX
 					-av5rmx -Zicsr -Zifencei -Zihintpause -Zba -Zbb
 					-Zbs -Zca -Zcb -Zcmp -Zcmt -Za -Zm -Zicbom)
 

--- a/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
+++ b/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
@@ -2,9 +2,8 @@
 
 if(COMPILER STREQUAL arcmwdt)
 # CCAC:
-  zephyr_compile_options_ifdef(CONFIG_SOC_SERIES_NSIM_ARC_V_RMX
-					-av5rmx -Zicsr -Zifencei -Zihintpause -Zba -Zbb
-					-Zbs -Zca -Zcb -Zcmp -Zcmt -Za -Zm -Zicbom)
+  zephyr_compile_options(-av5rmx -Zicsr -Zifencei -Zihintpause -Zba -Zbb
+                         -Zbs -Zca -Zcb -Zcmp -Zcmt -Za -Zm -Zicbom)
 
   zephyr_ld_options(-Hlib=rmx100)
 endif()

--- a/soc/snps/nsim/arc_v/rmx/Kconfig
+++ b/soc/snps/nsim/arc_v/rmx/Kconfig
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Synopsys, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-config SOC_SERIES_RMX
+config SOC_SERIES_NSIM_ARC_V_RMX
 	bool
 
 	select RISCV

--- a/soc/snps/nsim/arc_v/rmx/Kconfig.defconfig
+++ b/soc/snps/nsim/arc_v/rmx/Kconfig.defconfig
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Synopsys, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-if SOC_SERIES_RMX
+if SOC_SERIES_NSIM_ARC_V_RMX
 
 config RISCV_SOC_INTERRUPT_INIT
 	default y
@@ -18,4 +18,4 @@ config RISCV_PMP
 config PMP_SLOTS
 	default 16
 
-endif # SOC_SERIES_RMX
+endif # SOC_SERIES_NSIM_ARC_V_RMX

--- a/soc/snps/nsim/arc_v/rmx/Kconfig.soc
+++ b/soc/snps/nsim/arc_v/rmx/Kconfig.soc
@@ -1,16 +1,16 @@
 # Copyright (c) 2024 Synopsys, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-config SOC_SERIES_RMX
+config SOC_SERIES_NSIM_ARC_V_RMX
 	bool
 	select SOC_FAMILY_NSIM_ARC_V
 
 config SOC_SERIES
-	default "rmx" if SOC_SERIES_RMX
+	default "rmx" if SOC_SERIES_NSIM_ARC_V_RMX
 
-config SOC_RMX100
+config SOC_NSIM_ARC_V_RMX100
 	bool
-	select SOC_SERIES_RMX
+	select SOC_SERIES_NSIM_ARC_V_RMX
 
 config SOC
-	default "rmx100" if SOC_RMX100
+	default "rmx100" if SOC_NSIM_ARC_V_RMX100


### PR DESCRIPTION
This PR updates the Synopsys nSIM ARC-V RMX100 platform with improved naming conventions - that match arc classic - and updated hardware configuration and nsim options.

Changes include:
- Rename SOC configuration symbols to include vendor and platform information for better clarity and to prevent naming conflicts
- Update CLINT base address to match the default RMX100 configuration
- Update nSIM MMIO base address for proper memory mapping
- Remove PLIC support as ARC-V RMX only supports APLIC

These changes align the platform with the latest ARC-V RMX100 hardware specifications.