### PR TITLE
drives: fuel_gauge: Remove unused battery_cutoff property

### DIFF
--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -39,8 +39,6 @@ enum fuel_gauge_prop_type {
 	 */
 	FUEL_GAUGE_AVG_CURRENT = 0,
 
-	/** Used to cutoff the battery from the system - useful for storage/shipping of devices */
-	FUEL_GAUGE_BATTERY_CUTOFF,
 	/** Battery current (uA); negative=discharging */
 	FUEL_GAUGE_CURRENT,
 	/** Whether the battery underlying the fuel-gauge is cut off from charge */

--- a/samples/drivers/fuel_gauge/README.rst
+++ b/samples/drivers/fuel_gauge/README.rst
@@ -25,7 +25,7 @@ Features
 ********
 By using this fuel gauge you can get the following information:
 
-  * Read all public fuel gauge properties except ``FUEL_GAUGE_BATTERY_CUTOFF``
+  * Read all public fuel gauge properties
   * Battery charge status as percentage (periodically)
   * Battery voltage (periodically)
 

--- a/samples/drivers/fuel_gauge/src/main.c
+++ b/samples/drivers/fuel_gauge/src/main.c
@@ -20,8 +20,6 @@ const char *fuel_gauge_prop_to_str(enum fuel_gauge_prop_type prop)
 	switch (prop) {
 	case FUEL_GAUGE_AVG_CURRENT:
 		return "FUEL_GAUGE_AVG_CURRENT";
-	case FUEL_GAUGE_BATTERY_CUTOFF:
-		return "FUEL_GAUGE_BATTERY_CUTOFF";
 	case FUEL_GAUGE_CURRENT:
 		return "FUEL_GAUGE_CURRENT";
 	case FUEL_GAUGE_CHARGE_CUTOFF:
@@ -115,12 +113,6 @@ int main(void)
 	{
 		LOG_INF("Test-Read generic fuel gauge properties to verify which are supported");
 		LOG_INF("Info: not all properties are supported by all fuel gauges!");
-
-		/*
-		 * FUEL_GAUGE_BATTERY_CUTOFF will not be tested because this is a special property
-		 * and is intended to be used to cutoff the battery from the system - useful for
-		 * storage/shipping of devices
-		 */
 
 		fuel_gauge_prop_t test_props[] = {
 			FUEL_GAUGE_AVG_CURRENT,


### PR DESCRIPTION
The FUEL_GAUGE_BATTERY_CUTOFF enum property was never used and never tested nor was it intended to be. This property unfortunately made it past review.

Remove it. This is unlikely to cause a breakage since no upstream driver ever implemented it as a property.