### PR TITLE
drivers: usb: stm32: Fix USB FS/HS linux compliance tests

### DIFF
--- a/drivers/usb/udc/Kconfig.stm32
+++ b/drivers/usb/udc/Kconfig.stm32
@@ -9,6 +9,7 @@ config UDC_STM32
 	select USE_STM32_LL_USB
 	select USE_STM32_HAL_PCD
 	select USE_STM32_HAL_PCD_EX
+	select UDC_DRIVER_HAS_HIGH_SPEED_SUPPORT if DT_HAS_ST_STM32_OTGHS_ENABLED
 	select PINCTRL
 	default y
 	help

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -1223,7 +1223,7 @@ static int udc_stm32_driver_init0(const struct device *dev)
 			ep_cfg_out[i].caps.bulk = 1;
 			ep_cfg_out[i].caps.interrupt = 1;
 			ep_cfg_out[i].caps.iso = 1;
-			ep_cfg_out[i].caps.mps = cfg->ep_mps;
+			ep_cfg_out[i].caps.mps = (cfg->speed_idx == 2) ? 1024 : 1023;
 		}
 
 		ep_cfg_out[i].addr = USB_EP_DIR_OUT | i;
@@ -1243,7 +1243,7 @@ static int udc_stm32_driver_init0(const struct device *dev)
 			ep_cfg_in[i].caps.bulk = 1;
 			ep_cfg_in[i].caps.interrupt = 1;
 			ep_cfg_in[i].caps.iso = 1;
-			ep_cfg_in[i].caps.mps = 1023;
+			ep_cfg_in[i].caps.mps = (cfg->speed_idx == 2) ? 1024 : 1023;
 		}
 
 		ep_cfg_in[i].addr = USB_EP_DIR_IN | i;


### PR DESCRIPTION
This is an attempt to show how to fix the issue #93924. This work still requires the following patches and still may require some adjusts:

* #89866
* reverting 9493af93
* #93796
* #93882

This was tested on the following boards using Full Speed:
* nucleo_f767zi
* nucleo_h753zi
* nucleo_u5a5zj_q
* b_u585i_iot02a

This was tested on the following board using High Speed:
* nucleo_u5a5zj_q

Test data:

* Full Speed Results (nucleo_u5a5zj_q)

```shell
[35083.802054] usb 3-11: USB disconnect, device number 83
[35087.081986] usb 3-11: new full-speed USB device number 84 using xhci_hcd
[35087.477747] usb 3-11: New USB device found, idVendor=2fe3, idProduct=0009, bcdDevice= 4.02
[35087.477754] usb 3-11: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[35087.477756] usb 3-11: Product: Zephyr testusb sample
[35087.477758] usb 3-11: Manufacturer: Zephyr Project
[35087.477759] usb 3-11: SerialNumber: 203131483936500700240013
[35087.514892] usbtest 3-11:1.0: Linux gadget zero
[35087.514898] usbtest 3-11:1.0: full-speed {control in/out bulk-in bulk-out} tests (+alt)
[35087.515030] usbtest 3-11:1.1: Linux gadget zero
[35087.515032] usbtest 3-11:1.1: full-speed {control in/out int-in int-out} tests (+alt)
[35087.515150] usbtest 3-11:1.2: Linux gadget zero
[35087.515152] usbtest 3-11:1.2: full-speed {control in/out iso-in iso-out} tests (+alt)

[35095.054639] usbtest 3-11:1.0: TEST 0:  NOP
[35095.063680] usbtest 3-11:1.0: TEST 1:  write 1024 bytes 1000 times
[35096.526601] usbtest 3-11:1.0: TEST 2:  read 1024 bytes 1000 times
[35097.672586] usbtest 3-11:1.0: TEST 3:  write/512 0..1024 bytes 1000 times
[35098.252579] usbtest 3-11:1.0: TEST 4:  read/512 0..1024 bytes 1000 times
[35098.877572] usbtest 3-11:1.0: TEST 5:  write 1000 sglists 32 entries of 1024 bytes
[35142.675176] usbtest 3-11:1.0: TEST 6:  read 1000 sglists 32 entries of 1024 bytes
[35185.999669] usbtest 3-11:1.0: TEST 7:  write/512 1000 sglists 32 entries 0..1024 bytes
[35209.788436] usbtest 3-11:1.0: TEST 8:  read/512 1000 sglists 32 entries 0..1024 bytes
[35233.483208] usbtest 3-11:1.0: TEST 9:  ch9 (subset) control tests, 1000 times
[35259.492878] usbtest 3-11:1.0: TEST 10:  queue 32 control calls, 1000 times
[35381.500629] usbtest 3-11:1.0: TEST 11:  unlink 1000 reads of 1024
[35381.766249] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35383.246243] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35383.342254] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35383.430253] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35384.846252] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35384.902258] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35384.958251] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35386.382264] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35387.558252] xhci_hcd 0000:66:00.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state.
[35389.380517] usbtest 3-11:1.0: TEST 12:  unlink 1000 writes of 1024
[35395.062457] usbtest 3-11:1.0: TEST 13:  set/clear 1000 halts
[35432.071050] usbtest 3-11:1.0: TEST 14:  1000 ep0out, 1..1024 vary 512
[35448.108892] usbtest 3-11:1.0: TEST 17:  write odd addr 1024 bytes 1000 times core map
[35449.571875] usbtest 3-11:1.0: TEST 18:  read odd addr 1024 bytes 1000 times core map
[35450.712852] usbtest 3-11:1.0: TEST 19:  write odd addr 1024 bytes 1000 times premapped
[35452.174847] usbtest 3-11:1.0: TEST 20:  read odd addr 1024 bytes 1000 times premapped
[35453.317825] usbtest 3-11:1.0: TEST 21:  1000 ep0out odd addr, 1..1024 vary 512
[35469.358714] usbtest 3-11:1.0: TEST 24:  unlink from 1000 queues of 32 1024-byte writes
[35518.328147] usbtest 3-11:1.0: TEST 27: bulk write 31Mbytes
[35564.881662] usbtest 3-11:1.0: TEST 28: bulk read 31Mbytes
[35611.435168] usbtest 3-11:1.0: TEST 29: Clear toggle between bulk writes 1000 times

sudo ./testusb -v 512 -D /dev/bus/usb/003/084
./testusb: /dev/bus/usb/003/084 may see only control tests
full speed	/dev/bus/usb/003/084	0
/dev/bus/usb/003/084 test 0,    0.000006 secs
/dev/bus/usb/003/084 test 1,    1.454497 secs
/dev/bus/usb/003/084 test 2,    1.137670 secs
/dev/bus/usb/003/084 test 3,    0.571899 secs
/dev/bus/usb/003/084 test 4,    0.616621 secs
/dev/bus/usb/003/084 test 5,   43.788449 secs
/dev/bus/usb/003/084 test 6,   43.316416 secs
/dev/bus/usb/003/084 test 7,   23.780035 secs
/dev/bus/usb/003/084 test 8,   23.685946 secs
/dev/bus/usb/003/084 test 9,   26.001673 secs
/dev/bus/usb/003/084 test 10,  121.999076 secs
/dev/bus/usb/003/084 test 11,    7.871149 secs
/dev/bus/usb/003/084 test 12,    5.673251 secs
/dev/bus/usb/003/084 test 13,   37.000264 secs
/dev/bus/usb/003/084 test 14,   16.013883 secs
/dev/bus/usb/003/084 test 17,    1.454561 secs
/dev/bus/usb/003/084 test 18,    1.132923 secs
/dev/bus/usb/003/084 test 19,    1.454151 secs
/dev/bus/usb/003/084 test 20,    1.134785 secs
/dev/bus/usb/003/084 test 21,   16.014184 secs
/dev/bus/usb/003/084 test 24,   48.945604 secs
/dev/bus/usb/003/084 test 27,   46.544738 secs
/dev/bus/usb/003/084 test 28,   46.545085 secs
/dev/bus/usb/003/084 test 29,    6.001107 secs
```

* High Speed Results (nucleo_u5a5zj_q)

```shell
[34602.014310] usb 3-11: new high-speed USB device number 83 using xhci_hcd
[34602.246387] usb 3-11: New USB device found, idVendor=2fe3, idProduct=0009, bcdDevice= 4.02
[34602.246394] usb 3-11: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[34602.246397] usb 3-11: Product: Zephyr testusb sample
[34602.246399] usb 3-11: Manufacturer: Zephyr Project
[34602.246401] usb 3-11: SerialNumber: 203131483936500700240013
[34602.285531] usbtest 3-11:1.0: Linux gadget zero
[34602.285536] usbtest 3-11:1.0: high-speed {control in/out bulk-in bulk-out} tests (+alt)
[34602.285652] usbtest 3-11:1.1: Linux gadget zero
[34602.285653] usbtest 3-11:1.1: high-speed {control in/out int-in int-out} tests (+alt)
[34602.285750] usbtest 3-11:1.2: Linux gadget zero
[34602.285751] usbtest 3-11:1.2: high-speed {control in/out iso-in iso-out} tests (+alt)

[34626.442994] usbtest 3-11:1.0: halts failed, iterations left 998
[34636.776331] usbtest 3-11:1.0: TEST 0:  NOP
[34636.786025] usbtest 3-11:1.0: TEST 1:  write 1024 bytes 1000 times
[34639.242949] usbtest 3-11:1.0: TEST 2:  read 1024 bytes 1000 times
[34639.355937] usbtest 3-11:1.0: TEST 3:  write/512 0..1024 bytes 1000 times
[34639.449937] usbtest 3-11:1.0: TEST 4:  read/512 0..1024 bytes 1000 times
[34639.517936] usbtest 3-11:1.0: TEST 5:  write 1000 sglists 32 entries of 1024 bytes
[34646.454903] usbtest 3-11:1.0: TEST 6:  read 1000 sglists 32 entries of 1024 bytes
[34650.036863] usbtest 3-11:1.0: TEST 7:  write/512 1000 sglists 32 entries 0..1024 bytes
[34653.931839] usbtest 3-11:1.0: TEST 8:  read/512 1000 sglists 32 entries 0..1024 bytes
[34655.686774] usbtest 3-11:1.0: TEST 9:  ch9 (subset) control tests, 1000 times
[34681.696529] usbtest 3-11:1.0: TEST 10:  queue 32 control calls, 1000 times
[34806.054191] usbtest 3-11:1.0: TEST 11:  unlink 1000 reads of 1024
[34806.661991] usbtest 3-11:1.0: unlink retry
[34807.073989] usbtest 3-11:1.0: unlink retry
[34807.093986] usbtest 3-11:1.0: unlink retry
[34807.125989] usbtest 3-11:1.0: unlink retry
[34807.141989] usbtest 3-11:1.0: unlink retry
[34807.225987] usbtest 3-11:1.0: unlink retry
[34807.413987] usbtest 3-11:1.0: unlink retry
[34807.493987] usbtest 3-11:1.0: unlink retry
[34807.785983] usbtest 3-11:1.0: unlink retry
[34807.825985] usbtest 3-11:1.0: unlink retry
[34807.981981] usbtest 3-11:1.0: unlink retry
[34808.153982] usbtest 3-11:1.0: unlink retry
[34808.297974] usbtest 3-11:1.0: unlink retry
[34809.975123] usbtest 3-11:1.0: TEST 12:  unlink 1000 writes of 1024
[34815.045073] usbtest 3-11:1.0: TEST 13:  set/clear 1000 halts
[34825.099438] usb 3-11: verify_not_halted failed, iterations left 0, status -110 (not 0)
[34825.099449] usbtest 3-11:1.0: halts failed, iterations left 998
[34825.108982] usbtest 3-11:1.0: TEST 14:  1000 ep0out, 1..1024 vary 512
[34841.150807] usbtest 3-11:1.0: TEST 17:  write odd addr 1024 bytes 1000 times core map
[34843.608768] usbtest 3-11:1.0: TEST 18:  read odd addr 1024 bytes 1000 times core map
[34843.721766] usbtest 3-11:1.0: TEST 19:  write odd addr 1024 bytes 1000 times premapped
[34846.111753] usbtest 3-11:1.0: TEST 20:  read odd addr 1024 bytes 1000 times premapped
[34846.226739] usbtest 3-11:1.0: TEST 21:  1000 ep0out odd addr, 1..1024 vary 512
[34862.267611] usbtest 3-11:1.0: TEST 24:  unlink from 1000 queues of 32 1024-byte writes
[34932.309285] usbtest 3-11:1.0: TEST 27: bulk write 31Mbytes
[34938.916768] usbtest 3-11:1.0: TEST 28: bulk read 31Mbytes
[34942.263734] usbtest 3-11:1.0: TEST 29: Clear toggle between bulk writes 1000 times

sudo ./testusb -v 512 -D /dev/bus/usb/003/083
./testusb: /dev/bus/usb/003/083 may see only control tests
high speed	/dev/bus/usb/003/083	0
/dev/bus/usb/003/083 test 0,    0.000009 secs
/dev/bus/usb/003/083 test 1,    2.448244 secs
/dev/bus/usb/003/083 test 2,    0.104186 secs
/dev/bus/usb/003/083 test 3,    0.084968 secs
/dev/bus/usb/003/083 test 4,    0.059397 secs
/dev/bus/usb/003/083 test 5,    6.927873 secs
/dev/bus/usb/003/083 test 6,    3.573163 secs
/dev/bus/usb/003/083 test 7,    3.884923 secs
/dev/bus/usb/003/083 test 8,    1.746267 secs
/dev/bus/usb/003/083 test 9,   26.000073 secs
/dev/bus/usb/003/083 test 10,  124.347945 secs
/dev/bus/usb/003/083 test 11,    3.911814 secs
/dev/bus/usb/003/083 test 12,    5.060911 secs
/dev/bus/usb/003/083 test 13 --> 22 (error 22)
/dev/bus/usb/003/083 test 14,   16.014181 secs
/dev/bus/usb/003/083 test 17,    2.448836 secs
/dev/bus/usb/003/083 test 18,    0.104087 secs
/dev/bus/usb/003/083 test 19,    2.380734 secs
/dev/bus/usb/003/083 test 20,    0.105992 secs
/dev/bus/usb/003/083 test 21,   16.013873 secs
/dev/bus/usb/003/083 test 24,   70.013240 secs
/dev/bus/usb/003/083 test 27,    6.598648 secs
/dev/bus/usb/003/083 test 28,    3.338004 secs
/dev/bus/usb/003/083 test 29,    7.943988 secs
```
