### PR TITLE
Bluetooth: Classic: HID: Implement HID Device profile

### DIFF
--- a/include/zephyr/bluetooth/classic/hid_device.h
+++ b/include/zephyr/bluetooth/classic/hid_device.h
@@ -1,0 +1,339 @@
+/** @file
+ *  @brief HID Device Protocol handling.
+ */
+
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_CLASSIC_HID_DEVICE_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_CLASSIC_HID_DEVICE_H_
+
+/**
+ * @brief Bluetooth HID Device
+ * @defgroup bt_hid_device Bluetooth HID Device
+ * @ingroup bluetooth
+ * @{
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/net_buf.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @name HID protocol mode values
+ *
+ * These values indicate which HID protocol the host requests the device
+ * to use. BOOT_MODE is the legacy boot protocol; REPORT_MODE indicates
+ * normal report protocol operation.
+ * @{
+ */
+/** Boot protocol mode (legacy). */
+#define BT_HID_PROTOCOL_BOOT_MODE   0x00
+/** Report protocol mode (default). */
+#define BT_HID_PROTOCOL_REPORT_MODE 0x01
+/** @} */
+
+/** @name HID report types used for Get/Set/Data operations
+ *
+ * These map to report type fields in HID messages. INPUT reports are
+ * typically device->host, OUTPUT are host->device, and FEATURE are
+ * device-specific feature reports.
+ * @{
+ */
+/** Report type for input reports (1) - device->host. */
+#define BT_HID_REPORT_TYPE_INPUT   0x01
+/** Report type for output reports (2) - host->device. */
+#define BT_HID_REPORT_TYPE_OUTPUT  0x02
+/** Report type for feature reports (3) - device-specific. */
+#define BT_HID_REPORT_TYPE_FEATURE 0x03
+/** @} */
+
+struct bt_hid_device;
+
+/** @brief Callbacks supplied by the HID application
+ *
+ * Applications should register one instance of this callback table via
+ * `bt_hid_device_register()` to receive events and requests from the
+ * HID host. Only the callbacks the application needs must be provided;
+ * unimplemented callbacks should be set to NULL.
+ */
+struct bt_hid_device_cb {
+	/** @brief connected callback to application
+	 *
+	 * If this callback is provided it will be called whenever the HID
+	 * association completes. Both control and interrupt channels are
+	 * established and the device is ready for HID traffic.
+	 *
+	 * @param hid HID device object.
+	 */
+	void (*connected)(struct bt_hid_device *hid);
+
+	/** @brief disconnected callback to application
+	 *
+	 * If this callback is provided it will be called whenever the HID
+	 * association gets disconnected, including rejected or cancelled
+	 * connections and errors during setup. The HID device object remains
+	 * valid until this callback returns.
+	 *
+	 * @param hid HID device object.
+	 */
+	void (*disconnected)(struct bt_hid_device *hid);
+
+	/** @brief Set_Report request callback
+	 *
+	 * This callback provides report data sent by the HID host. This
+	 * callback is mandatory (SET_REPORT must be supported per HID spec
+	 * v1.1.2) and must be provided at registration.
+	 *
+	 * The buffer contains the raw Report Data Payload as received,
+	 * including the Report ID byte if declared in the descriptor.
+	 * Return 0 to accept the report. Return a negative errno to trigger
+	 * a corresponding handshake error response.
+	 *
+	 * @param hid HID device object.
+	 * @param type Report type (see BT_HID_REPORT_TYPE_*).
+	 * @param buf Report payload buffer (ownership retained by stack).
+	 *
+	 * @return 0 on success or a negative errno on failure.
+	 */
+	int (*set_report)(struct bt_hid_device *hid, uint8_t type, struct net_buf *buf);
+
+	/** @brief Get_Report request callback
+	 *
+	 * Called synchronously when the host sends a GET_REPORT request. This
+	 * callback is mandatory (GET_REPORT must be supported per HID spec
+	 * v1.1.2) and must be provided at registration.
+	 *
+	 * The application responds from within the callback by appending the
+	 * report payload to @p rsp (including the Report ID byte if the report
+	 * descriptor declares Report IDs) and returning 0. The stack then
+	 * prepends the HIDP DATA header and sends the response.
+	 *
+	 * If no data is available yet, return -EAGAIN; the stack replies with a
+	 * NOT_READY handshake and the host may retry (HID spec v1.1.2 Section
+	 * 3.2.1.1). Any other negative errno triggers the matching handshake
+	 * error response.
+	 *
+	 * @p req contains the remaining GET_REPORT parameters after the HIDP
+	 * header: an optional Report ID (present per the report descriptor)
+	 * followed, when @p size_present is true, by a 2-byte little-endian
+	 * BufferSize (the maximum response length the host expects). When
+	 * @p size_present is false no BufferSize is present.
+	 *
+	 * @param hid HID device object.
+	 * @param type Report type (see BT_HID_REPORT_TYPE_*).
+	 * @param size_present true if the request's Size bit is set, meaning a
+	 *                     2-byte BufferSize follows the optional Report ID
+	 *                     in @p req.
+	 * @param req Remaining request parameters (ownership retained by stack).
+	 * @param rsp Response buffer to fill with the report payload (ownership
+	 *            retained by stack; sent by the stack on a 0 return).
+	 *
+	 * @return 0 if @p rsp was filled with the response, -EAGAIN to reply
+	 *         with NOT_READY, or another negative errno for a handshake
+	 *         error.
+	 */
+	int (*get_report)(struct bt_hid_device *hid, uint8_t type, bool size_present,
+			  struct net_buf *req, struct net_buf *rsp);
+
+	/** @brief Set_Protocol request callback
+	 *
+	 * Called when the host sends a SET_PROTOCOL request. The application
+	 * should return 0 if the protocol mode is supported, or a negative
+	 * errno if it is not. The driver updates the internal protocol mode
+	 * flag and sends the appropriate HANDSHAKE response based on the
+	 * return value.
+	 *
+	 * @param hid HID device object.
+	 * @param protocol Requested protocol mode (BT_HID_PROTOCOL_BOOT_MODE
+	 *                 or BT_HID_PROTOCOL_REPORT_MODE).
+	 *
+	 * @return 0 if the protocol mode is accepted, negative errno otherwise.
+	 */
+	int (*set_protocol)(struct bt_hid_device *hid, uint8_t protocol);
+
+	/** @brief Output report callback
+	 *
+	 * This callback provides output report data received on the
+	 * interrupt channel from the HID host. The buffer contains
+	 * the raw report payload including Report ID if declared in
+	 * the descriptor.
+	 *
+	 * @param hid HID device object.
+	 * @param buf Report payload buffer (ownership retained by stack).
+	 */
+	void (*output_report)(struct bt_hid_device *hid, struct net_buf *buf);
+
+	/** @brief Virtual Cable Unplug notification callback
+	 *
+	 * Invoked when the HID host sends a VIRTUAL_CABLE_UNPLUG HID_CONTROL
+	 * message. Per HID spec v1.1.2 Section 3.1.2.2.3, the recipient shall
+	 * destroy all bonding and Virtual Cable information stored for the peer.
+	 *
+	 * The stack tears down the INTR and CTRL channels on the application's
+	 * behalf, but does not clear bonding: doing so requires dropping the
+	 * link key (and conditionally the ACL), which may affect other profiles
+	 * sharing the same ACL. The application is therefore responsible for
+	 * clearing the bonding information when appropriate, for example:
+	 *
+	 * @code
+	 * struct bt_conn *conn = bt_hid_device_get_conn(hid);
+	 *
+	 * if (conn != NULL) {
+	 *         bt_br_unpair(bt_conn_get_dst_br(conn));
+	 *         bt_conn_unref(conn);
+	 * }
+	 * @endcode
+	 *
+	 * @param hid HID device object.
+	 */
+	void (*vc_unplug)(struct bt_hid_device *hid);
+
+	/** @brief Suspend/Exit-Suspend notification callback
+	 *
+	 * SUSPEND and EXIT_SUSPEND are unidirectional HID_CONTROL messages
+	 * owned by the HID host. This callback simply relays each such message
+	 * to the application as it is received; the device does not maintain
+	 * any suspend state machine of its own. Per the HID profile, a
+	 * suspended device that detects local user activity wakes the host by
+	 * reconnecting, after which the host (optionally) issues EXIT_SUSPEND.
+	 * Note EXIT_SUSPEND is not mandatory, so the application must not rely
+	 * on it to leave the suspended state.
+	 *
+	 * Because the messages are relayed verbatim, the callback may fire on
+	 * every SUSPEND/EXIT_SUSPEND the host sends, including duplicates. If
+	 * the application needs idempotent or per-peer suspend behaviour across
+	 * reconnect (e.g. HID DRE/BV-09-C), it tracks that itself, keyed on the
+	 * peer identity it obtains from the ACL connection.
+	 *
+	 * @param hid HID device object.
+	 * @param suspended true if entering suspend, false if exiting.
+	 */
+	void (*suspend)(struct bt_hid_device *hid, bool suspended);
+};
+
+/** @brief Register HID device callbacks.
+ *
+ * The callback pointer must remain valid until bt_hid_device_unregister() is
+ * called. A second registration without an intervening unregister is rejected
+ * with -EALREADY; the callbacks are not replaced.
+ *
+ * @param cb  Callbacks to register. Must not be NULL, and the mandatory
+ *            @ref bt_hid_device_cb.get_report and
+ *            @ref bt_hid_device_cb.set_report callbacks must be provided.
+ *
+ * @retval 0 on success.
+ * @retval -EINVAL if @p cb is NULL or a mandatory callback is missing.
+ * @retval -EALREADY if a callback set is already registered.
+ */
+int bt_hid_device_register(const struct bt_hid_device_cb *cb);
+
+/** @brief Unregister HID device callbacks and disable HID services.
+ *
+ * This clears the callbacks and unregisters the L2CAP servers. The
+ * caller must disconnect any active HID session before calling this
+ * function; otherwise -EBUSY is returned and no action is taken.
+ *
+ * @retval 0 on success.
+ * @retval -EBUSY if an HID session is still active.
+ */
+int bt_hid_device_unregister(void);
+
+/** @brief Initiate an outgoing HID association on the given connection.
+ *
+ * On success the bt_hid_device instance is stored in @p hid. The caller
+ * must not free this object.
+ *
+ * @param conn Bluetooth connection to use for the association.
+ * @param hid  Pointer to store the HID device instance on success.
+ *
+ * @return 0 on success or a negative errno on failure.
+ */
+int bt_hid_device_connect(struct bt_conn *conn, struct bt_hid_device **hid);
+
+/** @brief Disconnect a previously connected HID association.
+ *
+ * The disconnect is asynchronous. Callers should not free the @p hid
+ * instance until the disconnected callback is invoked.
+ *
+ * @param hid HID device instance to disconnect.
+ *
+ * @return 0 on success or a negative errno on failure.
+ */
+int bt_hid_device_disconnect(struct bt_hid_device *hid);
+
+/** @brief Allocate/create a PDU buffer suitable for HID over L2CAP.
+ *
+ * If @p pool is NULL a default pool may be used by the implementation.
+ *
+ * @note Callers should use net_buf_add_*() to append report payload
+ *       to the returned buffer.
+ *
+ * @param pool Buffer pool to allocate from, or NULL to use the
+ *             default connection TX pool.
+ *
+ * @return A new net_buf instance or NULL on failure.
+ */
+struct net_buf *bt_hid_device_create_pdu(struct net_buf_pool *pool);
+
+/** @brief Send a HID interrupt input report to the HID host.
+ *
+ * The buffer should contain the full report payload including the
+ * Report ID byte if the descriptor declares Report IDs
+ * (HID spec v1.1.2 Section 3.1.2.8).
+ *
+ * The HID device can transmit interrupt channel messages to the host
+ * at any time.
+ *
+ * @note The buffer must be allocated with bt_hid_device_create_pdu()
+ * to ensure sufficient headroom for the HID and L2CAP headers.
+ *
+ * @param hid HID device instance to send data on.
+ * @param buf Buffer containing the report payload (consumed on success).
+ *
+ * @return 0 on success or a negative errno on failure.
+ */
+int bt_hid_device_input_report(struct bt_hid_device *hid, struct net_buf *buf);
+
+/** @brief Trigger a virtual cable unplug procedure for the given HID association.
+ *
+ * This will request the remote host to treat the device as unplugged.
+ *
+ * @param hid HID device instance to unplug.
+ *
+ * @return 0 on success or a negative errno on failure.
+ */
+int bt_hid_device_virtual_cable_unplug(struct bt_hid_device *hid);
+
+/** @brief Obtain the ACL connection associated with a HID device.
+ *
+ * Useful from callbacks that only receive the HID device object (for
+ * example @ref bt_hid_device_cb.vc_unplug) but need the peer identity, e.g.
+ * to clear bonding information.
+ *
+ * @param hid HID device object.
+ *
+ * @return Connection object associated with the HID device, or NULL if the
+ *         device is not connected. The caller gets a new reference to the
+ *         connection object which must be released with bt_conn_unref() once
+ *         done using the object.
+ */
+struct bt_conn *bt_hid_device_get_conn(struct bt_hid_device *hid);
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_CLASSIC_HID_DEVICE_H_ */

--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -208,6 +208,8 @@ extern "C" {
 #define BT_SDP_ATTR_HID_SUPERVISION_TIMEOUT     0x020c /**< HID Supervision Timeout */
 #define BT_SDP_ATTR_HID_NORMALLY_CONNECTABLE    0x020d /**< HID Normally Connectable */
 #define BT_SDP_ATTR_HID_BOOT_DEVICE             0x020e /**< HID Boot Device */
+#define BT_SDP_ATTR_HID_SSR_HOST_MAX_LATENCY    0x020f /**< HID SSR Host Max Latency */
+#define BT_SDP_ATTR_HID_SSR_HOST_MIN_TIMEOUT    0x0210 /**< HID SSR Host Min Timeout */
 /**
  * @}
  */

--- a/subsys/bluetooth/host/classic/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/CMakeLists.txt
@@ -46,6 +46,11 @@ zephyr_library_sources_ifdef(
   did.c
   )
 
+zephyr_library_sources_ifdef(
+  CONFIG_BT_HID_DEVICE
+  hid_device.c
+  )
+
 if(CONFIG_BT_AVRCP_CT_COVER_ART OR CONFIG_BT_AVRCP_TG_COVER_ART)
   zephyr_library_sources(avrcp_cover_art.c)
 endif()

--- a/subsys/bluetooth/host/classic/Kconfig
+++ b/subsys/bluetooth/host/classic/Kconfig
@@ -638,6 +638,13 @@ config BT_DEVICE_VERSION
 
 endif # BT_DID
 
+config BT_HID_DEVICE
+	bool "Bluetooth HID Device Profile [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	select BT_DID
+	help
+	  This option enables the HID Device profile.
+
 config BT_PAGE_TIMEOUT
 	hex "Bluetooth Page Timeout"
 	default 0x2000

--- a/subsys/bluetooth/host/classic/hid_device.c
+++ b/subsys/bluetooth/host/classic/hid_device.c
@@ -1,0 +1,970 @@
+/* hid_device.c - HID Profile - HID Device side handling */
+
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <string.h>
+#include <errno.h>
+#include <zephyr/sys/util.h>
+
+#include "common/assert.h"
+
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/classic/hid_device.h>
+#include <zephyr/bluetooth/classic/classic.h>
+#include <zephyr/bluetooth/l2cap.h>
+
+#include "host/hci_core.h"
+#include "host/conn_internal.h"
+#include "host/l2cap_internal.h"
+
+#include "hid_internal.h"
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(bt_hid_device);
+
+/* Get the HID device from CTRL L2CAP channel */
+#define HID_DEVICE_BY_CTRL_CHAN(ch) \
+	CONTAINER_OF(ch, struct bt_hid_device, ctrl_session.br_chan.chan)
+
+/* Get the HID device from INTR L2CAP channel */
+#define HID_DEVICE_BY_INTR_CHAN(ch) \
+	CONTAINER_OF(ch, struct bt_hid_device, intr_session.br_chan.chan)
+
+/* Get the HID session from L2CAP channel */
+#define HID_SESSION_BY_CHAN(ch) \
+	CONTAINER_OF(ch, struct bt_hid_session, br_chan.chan)
+
+#define HID_CHAN_TYPE(ch) \
+	(((ch) == NULL) ? BT_HID_CHANNEL_UNKNOWN : HID_SESSION_BY_CHAN((ch))->type)
+
+/* Timeout for INTR channel connection after CTRL is established (seconds) */
+#define HID_INTR_CONN_TIMEOUT K_SECONDS(30)
+
+/* Dedicated buffer pool for HANDSHAKE responses.  HANDSHAKE is a mandatory
+ * protocol response (HID spec v1.1.2 Section 3.2) that must not fail due to
+ * buffer contention with data traffic.  2 buffers covers back-to-back error
+ * handshakes before the first TX completes.  Payload is a single-byte header.
+ */
+NET_BUF_POOL_FIXED_DEFINE(hid_hs_pool, 2,
+			  BT_L2CAP_BUF_SIZE(sizeof(struct bt_hid_hdr)),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+/* HID device callback */
+static const struct bt_hid_device_cb *hid_cb;
+
+/* HID L2CAP servers registration state */
+static bool hid_l2cap_registered;
+
+/* HID device connection (single session only) */
+static struct bt_hid_device hid_device_conn;
+
+static void bt_hid_device_cleanup(struct bt_hid_device *hid);
+
+static struct bt_hid_device *hid_allocate(void)
+{
+	if (hid_device_conn.state == BT_HID_STATE_DISCONNECTED) {
+		return &hid_device_conn;
+	}
+
+	return NULL;
+}
+
+static struct bt_hid_device *hid_find(const struct bt_conn *conn, uint8_t state)
+{
+	if (hid_device_conn.state != state) {
+		return NULL;
+	}
+
+	if (hid_device_conn.ctrl_session.br_chan.chan.conn != conn) {
+		return NULL;
+	}
+
+	return &hid_device_conn;
+}
+
+struct bt_conn *bt_hid_device_get_conn(struct bt_hid_device *hid)
+{
+	struct bt_conn *conn;
+
+	if (hid == NULL) {
+		return NULL;
+	}
+
+	conn = hid->ctrl_session.br_chan.chan.conn;
+	if (conn == NULL) {
+		return NULL;
+	}
+
+	return bt_conn_ref(conn);
+}
+
+struct net_buf *bt_hid_device_create_pdu(struct net_buf_pool *pool)
+{
+	return bt_l2cap_create_pdu(pool, sizeof(struct bt_hid_hdr));
+}
+
+static void hid_send_handshake(struct bt_hid_device *hid, uint8_t result_code)
+{
+	struct net_buf *buf;
+	struct bt_hid_hdr *hdr;
+	int err;
+
+	buf = bt_l2cap_create_pdu(&hid_hs_pool, sizeof(struct bt_hid_hdr));
+	if (buf == NULL) {
+		LOG_ERR("Handshake buf alloc failed");
+		return;
+	}
+
+	hdr = net_buf_add(buf, sizeof(struct bt_hid_hdr));
+	hdr->header = BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_HANDSHAKE, result_code);
+
+	/* HANDSHAKE is only ever sent on the Control channel. */
+	err = bt_l2cap_chan_send(&hid->ctrl_session.br_chan.chan, buf);
+	if (err < 0) {
+		LOG_ERR("Handshake send failed (%d)", err);
+		net_buf_unref(buf);
+	}
+}
+
+static uint8_t hid_err_to_handshake(int err)
+{
+	switch (err) {
+	case 0:
+		return BT_HID_HS_RSP_SUCCESS;
+	case -EOPNOTSUPP:
+	case -ENOSYS:
+		return BT_HID_HS_RSP_ERR_UNSUPPORTED_REQ;
+	case -EINVAL:
+		return BT_HID_HS_RSP_ERR_INVALID_PARAM;
+	case -ENOENT:
+		return BT_HID_HS_RSP_ERR_INVALID_REPORT_ID;
+	case -EBUSY:
+	case -EAGAIN:
+		return BT_HID_HS_RSP_NOT_READY;
+	default:
+		return BT_HID_HS_RSP_ERR_UNKNOWN;
+	}
+}
+
+static int hid_control_handle(struct bt_hid_device *hid, struct net_buf *buf, uint8_t control)
+{
+	int err;
+
+	switch (control) {
+	case BT_HID_CONTROL_VIRTUAL_CABLE_UNPLUG:
+		if ((hid_cb != NULL) && (hid_cb->vc_unplug != NULL)) {
+			hid_cb->vc_unplug(hid);
+		}
+
+		/* HID spec v1.1.2 Section 3.1.2.2.3 requires the recipient to
+		 * destroy bonding/Virtual Cable info on VC unplug, then
+		 * disconnect INTR followed by CTRL without sending HANDSHAKE.
+		 * Clearing bonding is delegated to the application through the
+		 * vc_unplug callback above: the only host API, bt_br_unpair(),
+		 * unconditionally disconnects the whole ACL, which would tear
+		 * down any co-located profile (A2DP/AVRCP/HFP) sharing it. The
+		 * spec only allows the ACL to be dropped "if there are no other
+		 * profiles using the ACL", so the stack does not clear bonding
+		 * here; the application decides when it is safe to do so (see
+		 * bt_hid_device_get_conn()).
+		 */
+		err = bt_hid_device_disconnect(hid);
+		if ((err != 0) && (err != -ENOTCONN)) {
+			/* Disconnect is requested as part of VC unplug teardown.
+			 * There is no recovery path here and no HANDSHAKE is sent
+			 * for VC unplug, so only log the failure for diagnostics.
+			 * -ENOTCONN means teardown is already in progress, which
+			 * matches the intent and is not treated as an error.
+			 */
+			LOG_WRN("VC unplug: disconnect failed (%d)", err);
+		}
+		break;
+	case BT_HID_CONTROL_SUSPEND:
+		/* Suspend is host-owned state; the device only relays the
+		 * request to the application. No local state is tracked here
+		 * (see the suspend callback documentation).
+		 */
+		if ((hid_cb != NULL) && (hid_cb->suspend != NULL)) {
+			hid_cb->suspend(hid, true);
+		}
+		break;
+	case BT_HID_CONTROL_EXIT_SUSPEND:
+		if ((hid_cb != NULL) && (hid_cb->suspend != NULL)) {
+			hid_cb->suspend(hid, false);
+		}
+		break;
+	default:
+		/* HID spec v1.1.2 Section 3.1.2.2: unsupported HID_CONTROL
+		 * operations shall be silently ignored.
+		 */
+		LOG_WRN("control %u not handled, ignoring", control);
+		break;
+	}
+
+	return 0;
+}
+
+static int hid_get_report_handle(struct bt_hid_device *hid, struct net_buf *buf, uint8_t param)
+{
+	struct bt_hid_hdr *hdr;
+	struct net_buf *rsp;
+	uint8_t report_type;
+	bool size_present;
+	int err;
+
+	report_type = FIELD_GET(BT_HID_PARAM_REPORT_TYPE_MASK, param);
+	size_present = (param & BT_HID_PARAM_REPORT_SIZE_MASK) != 0;
+
+	if (size_present && (buf->len < sizeof(uint16_t))) {
+		return -EINVAL;
+	}
+
+	if ((hid_cb == NULL) || (hid_cb->get_report == NULL)) {
+		return -EOPNOTSUPP;
+	}
+
+	rsp = bt_hid_device_create_pdu(NULL);
+	if (rsp == NULL) {
+		return -EAGAIN;
+	}
+
+	/* GET_REPORT is synchronous: the application fills rsp with the report
+	 * payload and returns 0, or returns a negative errno (e.g. -EAGAIN for
+	 * NOT_READY). The transaction is fully resolved on return, so no pending
+	 * state needs to be tracked here. The error handshake is sent by the
+	 * dispatcher; on success the DATA response below is the reply.
+	 */
+	err = hid_cb->get_report(hid, report_type, size_present, buf, rsp);
+	if (err < 0) {
+		LOG_ERR("Get_Report cb err %d", err);
+		net_buf_unref(rsp);
+		return err;
+	}
+
+	hdr = net_buf_push(rsp, sizeof(struct bt_hid_hdr));
+	hdr->header = BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_DATA, report_type);
+
+	err = bt_l2cap_chan_send(&hid->ctrl_session.br_chan.chan, rsp);
+	if (err < 0) {
+		LOG_ERR("Get_Report rsp send failed (%d)", err);
+		net_buf_unref(rsp);
+		return err;
+	}
+
+	return 0;
+}
+
+static int hid_set_report_handle(struct bt_hid_device *hid, struct net_buf *buf, uint8_t param)
+{
+	uint8_t report_type;
+	int err;
+
+	report_type = FIELD_GET(BT_HID_PARAM_REPORT_TYPE_MASK, param);
+
+	if ((hid_cb == NULL) || (hid_cb->set_report == NULL)) {
+		return -EOPNOTSUPP;
+	}
+
+	err = hid_cb->set_report(hid, report_type, buf);
+	if (err < 0) {
+		LOG_ERR("Set_Report cb err %d", err);
+		return err;
+	}
+
+	hid_send_handshake(hid, BT_HID_HS_RSP_SUCCESS);
+	return 0;
+}
+
+static int hid_get_protocol_handle(struct bt_hid_device *hid, struct net_buf *buf, uint8_t param)
+{
+	struct net_buf *rsp;
+	struct bt_hid_hdr *hdr;
+	int err;
+
+	rsp = bt_hid_device_create_pdu(NULL);
+	if (rsp == NULL) {
+		return -EAGAIN;
+	}
+
+	hdr = net_buf_add(rsp, sizeof(struct bt_hid_hdr));
+	hdr->header = BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_DATA, BT_HID_PAR_REP_TYPE_OTHER);
+	net_buf_add_u8(rsp, hid->boot_mode ? BT_HID_PROTOCOL_BOOT_MODE
+					     : BT_HID_PROTOCOL_REPORT_MODE);
+
+	err = bt_l2cap_chan_send(&hid->ctrl_session.br_chan.chan, rsp);
+	if (err < 0) {
+		LOG_ERR("Get_Protocol rsp send failed (%d)", err);
+		net_buf_unref(rsp);
+		return err;
+	}
+
+	return 0;
+}
+
+static int hid_set_protocol_handle(struct bt_hid_device *hid, struct net_buf *buf, uint8_t param)
+{
+	uint8_t protocol;
+	int err;
+
+	protocol = FIELD_GET(BT_HID_PROTOCOL_MASK, param);
+
+	if ((hid_cb == NULL) || (hid_cb->set_protocol == NULL)) {
+		return -EOPNOTSUPP;
+	}
+
+	err = hid_cb->set_protocol(hid, protocol);
+	if (err != 0) {
+		return err;
+	}
+
+	hid->boot_mode = (protocol == BT_HID_PROTOCOL_BOOT_MODE);
+	hid_send_handshake(hid, BT_HID_HS_RSP_SUCCESS);
+
+	return 0;
+}
+
+static int hid_intr_handle(struct bt_hid_device *hid, struct net_buf *buf)
+{
+	if ((hid_cb != NULL) && (hid_cb->output_report != NULL)) {
+		hid_cb->output_report(hid, buf);
+	}
+
+	return 0;
+}
+
+typedef int (*hid_ctrl_handler_t)(struct bt_hid_device *hid, struct net_buf *buf, uint8_t param);
+
+static const struct {
+	uint8_t type;
+	hid_ctrl_handler_t handler;
+} hid_ctrl_handlers[] = {
+	{BT_HID_MSG_TYPE_CONTROL, hid_control_handle},
+	{BT_HID_MSG_TYPE_GET_REPORT, hid_get_report_handle},
+	{BT_HID_MSG_TYPE_SET_REPORT, hid_set_report_handle},
+	{BT_HID_MSG_TYPE_GET_PROTOCOL, hid_get_protocol_handle},
+	{BT_HID_MSG_TYPE_SET_PROTOCOL, hid_set_protocol_handle},
+};
+
+static void hid_intr_timeout_handler(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct bt_hid_device *hid = CONTAINER_OF(dwork, struct bt_hid_device, intr_timeout);
+	int err;
+
+	LOG_WRN("INTR connection timeout");
+
+	/* Timer is started when CTRL connects and cancelled when INTR connects
+	 * or when cleanup runs.  If this fires, the HID connection did not
+	 * complete in time — tear down whatever is up.
+	 */
+	err = bt_hid_device_disconnect(hid);
+	if (err != 0) {
+		LOG_WRN("INTR timeout: disconnect failed (%d)", err);
+	}
+}
+
+static void hid_vcu_disconnect_work(struct k_work *work)
+{
+	struct bt_hid_device *hid = CONTAINER_OF(work, struct bt_hid_device, vcu_disconnect);
+	int err;
+
+	LOG_DBG("VCU disconnect");
+
+	err = bt_hid_device_disconnect(hid);
+	if (err != 0) {
+		LOG_WRN("VCU disconnect failed (%d)", err);
+	}
+}
+
+static void bt_hid_l2cap_ctrl_connected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_device *hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	__maybe_unused enum bt_hid_channel_type chtype;
+	int err;
+
+	chtype = HID_CHAN_TYPE(chan);
+
+	LOG_DBG("session %d connected (state %d)", chtype, hid->state);
+
+	__ASSERT_NO_MSG(chtype == BT_HID_CHANNEL_CTRL);
+
+	hid->state = BT_HID_STATE_CTRL_CONNECTED;
+	hid->ctrl_connected = true;
+
+	if (hid->role == BT_HID_ROLE_ACCEPTOR) {
+		/* Wait for INTR channel connection from remote */
+		LOG_DBG("wait for INTR connection");
+		k_work_schedule(&hid->intr_timeout, HID_INTR_CONN_TIMEOUT);
+		return;
+	}
+
+	err = bt_l2cap_chan_connect(hid->ctrl_session.br_chan.chan.conn,
+				    &hid->intr_session.br_chan.chan, BT_L2CAP_PSM_HID_INTR);
+	if (err != 0) {
+		LOG_ERR("INTR connect failed");
+		hid->state = BT_HID_STATE_DISCONNECTING;
+		bt_l2cap_chan_disconnect(&hid->ctrl_session.br_chan.chan);
+		return;
+	}
+
+	hid->state = BT_HID_STATE_INTR_CONNECTING;
+}
+
+static void bt_hid_l2cap_intr_connected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_device *hid = HID_DEVICE_BY_INTR_CHAN(chan);
+	__maybe_unused enum bt_hid_channel_type chtype;
+
+	chtype = HID_CHAN_TYPE(chan);
+
+	LOG_DBG("session %d connected (state %d)", chtype, hid->state);
+
+	__ASSERT_NO_MSG(chtype == BT_HID_CHANNEL_INTR);
+
+	/* HID spec v1.1.1 Section 5.2.2: both CTRL and INTR channels
+	 * must be established for the HID connection to be valid.
+	 */
+	if (!hid->ctrl_connected) {
+		LOG_WRN("CTRL not connected, reject INTR");
+		bt_l2cap_chan_disconnect(chan);
+		return;
+	}
+
+	hid->state = BT_HID_STATE_CONNECTED;
+	hid->intr_connected = true;
+	k_work_cancel_delayable(&hid->intr_timeout);
+
+	if ((hid_cb != NULL) && (hid_cb->connected != NULL)) {
+		hid_cb->connected(hid);
+	}
+}
+
+static void bt_hid_l2cap_ctrl_disconnected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_device *hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	__maybe_unused enum bt_hid_channel_type chtype;
+
+	chtype = HID_CHAN_TYPE(chan);
+
+	LOG_DBG("session %d disconnected (state %d)", chtype, hid->state);
+
+	__ASSERT_NO_MSG(chtype == BT_HID_CHANNEL_CTRL);
+
+	hid->ctrl_connected = false;
+
+	/* HID spec v1.1.2 Section 5.2.2: INTR shall be disconnected before
+	 * CTRL. If remote disconnects CTRL first, clean up INTR.
+	 */
+	if (hid->intr_connected) {
+		int err = bt_l2cap_chan_disconnect(&hid->intr_session.br_chan.chan);
+
+		if ((err != 0) && (err != -EALREADY)) {
+			LOG_WRN("INTR disconnect failed (%d)", err);
+		}
+		return;
+	}
+
+	if ((hid_cb != NULL) && (hid_cb->disconnected != NULL)) {
+		hid_cb->disconnected(hid);
+	}
+
+	bt_hid_device_cleanup(hid);
+}
+
+static void bt_hid_l2cap_intr_disconnected(struct bt_l2cap_chan *chan)
+{
+	struct bt_hid_device *hid = HID_DEVICE_BY_INTR_CHAN(chan);
+	__maybe_unused enum bt_hid_channel_type chtype;
+
+	chtype = HID_CHAN_TYPE(chan);
+
+	LOG_DBG("session %d disconnected (state %d)", chtype, hid->state);
+
+	__ASSERT_NO_MSG(chtype == BT_HID_CHANNEL_INTR);
+
+	hid->intr_connected = false;
+
+	/* Local disconnect of INTR must be followed by disconnecting CTRL. */
+	if (hid->state == BT_HID_STATE_DISCONNECTING && hid->ctrl_connected) {
+		int err = bt_l2cap_chan_disconnect(&hid->ctrl_session.br_chan.chan);
+
+		if ((err != 0) && (err != -EALREADY)) {
+			LOG_WRN("CTRL disconnect failed (%d)", err);
+		}
+
+		return;
+	}
+
+	/* Wait for remote to disconnect CTRL. */
+	if (hid->ctrl_connected) {
+		hid->state = BT_HID_STATE_CTRL_CONNECTED;
+		LOG_DBG("wait for remote CTRL disconnect");
+		return;
+	}
+
+	if ((hid_cb != NULL) && (hid_cb->disconnected != NULL)) {
+		hid_cb->disconnected(hid);
+	}
+
+	bt_hid_device_cleanup(hid);
+}
+
+static int bt_hid_l2cap_ctrl_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	struct bt_hid_hdr *hdr;
+	struct bt_hid_device *hid = HID_DEVICE_BY_CTRL_CHAN(chan);
+	uint8_t type;
+	uint8_t param;
+
+	__ASSERT_NO_MSG(HID_CHAN_TYPE(chan) == BT_HID_CHANNEL_CTRL);
+
+	/* HID spec v1.1.2 Section 5.2.2: once the Control channel is open the
+	 * host may send Control channel commands; the Interrupt channel need
+	 * not be established for them. Drop anything received before the
+	 * Control channel itself is connected.
+	 */
+	if (hid->state < BT_HID_STATE_CTRL_CONNECTED) {
+		LOG_WRN("CTRL recv in state %d, ignoring", hid->state);
+		return 0;
+	}
+
+	if (buf->len < sizeof(*hdr)) {
+		LOG_ERR("CTRL buf len %u invalid", buf->len);
+		hid_send_handshake(hid, BT_HID_HS_RSP_ERR_INVALID_PARAM);
+		return 0;
+	}
+
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
+	param = BT_HID_HDR_GET_PARAM(hdr->header);
+	type = BT_HID_HDR_GET_TYPE(hdr->header);
+
+	LOG_DBG("CTRL recv type 0x%x param 0x%x", type, param);
+
+	ARRAY_FOR_EACH(hid_ctrl_handlers, i) {
+		if (hid_ctrl_handlers[i].type == type) {
+			int err = hid_ctrl_handlers[i].handler(hid, buf, param);
+
+			/* HID_CONTROL has no handshake response (HID spec v1.1.2
+			 * Section 3.2.1.3): errors are ignored. For every other
+			 * transaction an error handshake is sent here, so the
+			 * handlers only need to return the result code. SUCCESS
+			 * handshakes remain in the SET_* handlers, and the GET_*
+			 * handlers send their own DATA response.
+			 */
+			if ((type != BT_HID_MSG_TYPE_CONTROL) && (err != 0)) {
+				hid_send_handshake(hid, hid_err_to_handshake(err));
+			}
+
+			return 0;
+		}
+	}
+
+	LOG_WRN("type %u not supported", type);
+	hid_send_handshake(hid, BT_HID_HS_RSP_ERR_UNSUPPORTED_REQ);
+
+	return 0;
+}
+
+static int bt_hid_l2cap_intr_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
+{
+	struct bt_hid_hdr *hdr;
+	struct bt_hid_device *hid = HID_DEVICE_BY_INTR_CHAN(chan);
+	uint8_t type;
+	uint8_t param;
+	uint8_t report_type;
+
+	if (buf->len < sizeof(*hdr)) {
+		LOG_ERR("INTR buf len %u invalid", buf->len);
+		return 0;
+	}
+
+	__ASSERT_NO_MSG(HID_CHAN_TYPE(chan) == BT_HID_CHANNEL_INTR);
+
+	if (hid->state != BT_HID_STATE_CONNECTED) {
+		LOG_WRN("INTR recv in state %d, ignoring", hid->state);
+		return 0;
+	}
+
+	hdr = net_buf_pull_mem(buf, sizeof(*hdr));
+	type = BT_HID_HDR_GET_TYPE(hdr->header);
+	param = BT_HID_HDR_GET_PARAM(hdr->header);
+
+	LOG_DBG("INTR recv type 0x%x param 0x%x", type, param);
+
+	if (type != BT_HID_MSG_TYPE_DATA) {
+		LOG_WRN("INTR type %u not supported", type);
+		return 0;
+	}
+
+	/* HID spec v1.1.2 Section 7.4.3: only Output reports are sent from the
+	 * host to the device on the Interrupt channel. The Interrupt channel has
+	 * no handshake mechanism, so a non-Output report is silently dropped.
+	 */
+	report_type = FIELD_GET(BT_HID_PARAM_REPORT_TYPE_MASK, param);
+	if (report_type != BT_HID_PAR_REP_TYPE_OUTPUT) {
+		LOG_WRN("INTR DATA report type %u not Output, ignoring", report_type);
+		return 0;
+	}
+
+	return hid_intr_handle(hid, buf);
+}
+
+static const struct bt_l2cap_chan_ops ctrl_ops = {
+	.connected = bt_hid_l2cap_ctrl_connected,
+	.disconnected = bt_hid_l2cap_ctrl_disconnected,
+	.recv = bt_hid_l2cap_ctrl_recv,
+};
+
+static const struct bt_l2cap_chan_ops intr_ops = {
+	.connected = bt_hid_l2cap_intr_connected,
+	.disconnected = bt_hid_l2cap_intr_disconnected,
+	.recv = bt_hid_l2cap_intr_recv,
+};
+
+static void bt_hid_session_init(struct bt_hid_device *hid, enum bt_hid_role role)
+{
+	hid->ctrl_session.br_chan.chan.ops = &ctrl_ops;
+	hid->ctrl_session.br_chan.rx.mtu = BT_L2CAP_RX_MTU;
+	hid->ctrl_session.type = BT_HID_CHANNEL_CTRL;
+
+	hid->intr_session.br_chan.chan.ops = &intr_ops;
+	hid->intr_session.br_chan.rx.mtu = BT_L2CAP_RX_MTU;
+	hid->intr_session.type = BT_HID_CHANNEL_INTR;
+
+	hid->role = role;
+	hid->boot_mode = false;
+	hid->ctrl_connected = false;
+	hid->intr_connected = false;
+
+	k_work_init_delayable(&hid->intr_timeout, hid_intr_timeout_handler);
+	k_work_init(&hid->vcu_disconnect, hid_vcu_disconnect_work);
+}
+
+static void bt_hid_device_cleanup(struct bt_hid_device *hid)
+{
+	k_work_cancel_delayable(&hid->intr_timeout);
+	k_work_cancel(&hid->vcu_disconnect);
+
+	/* HID spec v1.1.2 Section 2.1.2: default protocol mode is Report
+	 * Protocol Mode. Reset on disconnect for next connection.
+	 */
+	hid->boot_mode = false;
+	hid->ctrl_connected = false;
+	hid->intr_connected = false;
+	hid->state = BT_HID_STATE_DISCONNECTED;
+}
+
+static int hid_l2cap_ctrl_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+				 struct bt_l2cap_chan **chan)
+{
+	struct bt_hid_device *hid;
+
+	hid = hid_allocate();
+	if (hid == NULL) {
+		return -EBUSY;
+	}
+
+	bt_hid_session_init(hid, BT_HID_ROLE_ACCEPTOR);
+	hid->state = BT_HID_STATE_CTRL_CONNECTING;
+
+	*chan = &hid->ctrl_session.br_chan.chan;
+	return 0;
+}
+
+static int hid_l2cap_intr_accept(struct bt_conn *conn, struct bt_l2cap_server *server,
+				 struct bt_l2cap_chan **chan)
+{
+	struct bt_hid_device *hid;
+
+	/* HID spec v1.1.2 Section 5.2.1: the control channel must be fully
+	 * established (and belong to this conn) before the interrupt channel.
+	 */
+	hid = hid_find(conn, BT_HID_STATE_CTRL_CONNECTED);
+	if (hid == NULL) {
+		LOG_ERR("CTRL channel not connected");
+		return -ENOTCONN;
+	}
+
+	hid->state = BT_HID_STATE_INTR_CONNECTING;
+
+	*chan = &hid->intr_session.br_chan.chan;
+	return 0;
+}
+
+static struct bt_l2cap_server hid_server_ctrl = {
+	.psm = BT_L2CAP_PSM_HID_CTRL,
+	.sec_level = BT_SECURITY_L2,
+	.accept = hid_l2cap_ctrl_accept,
+};
+
+static struct bt_l2cap_server hid_server_intr = {
+	.psm = BT_L2CAP_PSM_HID_INTR,
+	.sec_level = BT_SECURITY_L2,
+	.accept = hid_l2cap_intr_accept,
+};
+
+static int bt_hid_device_init(void)
+{
+	int err;
+
+	LOG_DBG("init");
+
+	err = bt_l2cap_br_server_register(&hid_server_ctrl);
+	if (err < 0) {
+		LOG_ERR("CTRL L2CAP register failed (%d)", err);
+		return err;
+	}
+
+	err = bt_l2cap_br_server_register(&hid_server_intr);
+	if (err < 0) {
+		LOG_ERR("INTR L2CAP register failed (%d)", err);
+		bt_l2cap_br_server_unregister(&hid_server_ctrl);
+		return err;
+	}
+
+	return 0;
+}
+
+static void bt_hid_device_deinit(void)
+{
+	int err;
+
+	LOG_DBG("deinit");
+
+	err = bt_l2cap_br_server_unregister(&hid_server_ctrl);
+	if (err < 0) {
+		LOG_ERR("CTRL L2CAP unregister failed (%d)", err);
+	}
+
+	err = bt_l2cap_br_server_unregister(&hid_server_intr);
+	if (err < 0) {
+		LOG_ERR("INTR L2CAP unregister failed (%d)", err);
+	}
+}
+
+int bt_hid_device_register(const struct bt_hid_device_cb *cb)
+{
+	int err;
+
+	LOG_DBG("register");
+
+	/* GET_REPORT and SET_REPORT are mandatory HID Device transactions
+	 * (HID Profile spec v1.1.2), so both callbacks are required.
+	 */
+	if ((cb == NULL) || (cb->get_report == NULL) || (cb->set_report == NULL)) {
+		return -EINVAL;
+	}
+
+	if (hid_cb != NULL) {
+		return -EALREADY;
+	}
+
+	if (!hid_l2cap_registered) {
+		err = bt_hid_device_init();
+		if (err < 0) {
+			return err;
+		}
+
+		hid_l2cap_registered = true;
+	}
+
+	hid_cb = cb;
+	return 0;
+}
+
+int bt_hid_device_unregister(void)
+{
+	LOG_DBG("unregister");
+
+	if (hid_device_conn.state != BT_HID_STATE_DISCONNECTED) {
+		LOG_ERR("cannot unregister while connected (state %d)",
+			hid_device_conn.state);
+		return -EBUSY;
+	}
+
+	hid_cb = NULL;
+
+	if (hid_l2cap_registered) {
+		bt_hid_device_deinit();
+		hid_l2cap_registered = false;
+	}
+
+	return 0;
+}
+
+int bt_hid_device_connect(struct bt_conn *conn, struct bt_hid_device **hid)
+{
+	struct bt_hid_device *inst;
+	int err;
+
+	LOG_DBG("connect");
+
+	if (conn == NULL || hid == NULL) {
+		return -EINVAL;
+	}
+
+	inst = hid_allocate();
+	if (inst == NULL) {
+		LOG_ERR("busy (state %d)", hid_device_conn.state);
+		return -EBUSY;
+	}
+
+	bt_hid_session_init(inst, BT_HID_ROLE_INITIATOR);
+
+	inst->state = BT_HID_STATE_CTRL_CONNECTING;
+
+	err = bt_l2cap_chan_connect(conn, &inst->ctrl_session.br_chan.chan, BT_L2CAP_PSM_HID_CTRL);
+	if (err != 0) {
+		LOG_ERR("connect failed (%d)", err);
+		bt_hid_device_cleanup(inst);
+		return err;
+	}
+
+	*hid = inst;
+	return 0;
+}
+
+int bt_hid_device_disconnect(struct bt_hid_device *hid)
+{
+	int err;
+
+	if (hid == NULL) {
+		return -EINVAL;
+	}
+
+	LOG_DBG("disconnect");
+
+	if (hid->state == BT_HID_STATE_DISCONNECTED ||
+	    hid->state == BT_HID_STATE_DISCONNECTING) {
+		LOG_ERR("not connected (state %d)", hid->state);
+		return -ENOTCONN;
+	}
+
+	if (hid->intr_connected) {
+		err = bt_l2cap_chan_disconnect(&hid->intr_session.br_chan.chan);
+	} else if (hid->ctrl_connected) {
+		err = bt_l2cap_chan_disconnect(&hid->ctrl_session.br_chan.chan);
+	} else {
+		return -ENOTCONN;
+	}
+
+	/* -EALREADY means the channel is already tearing down, which matches
+	 * the intent of this call; only update state once the request is
+	 * accepted so a failed disconnect leaves the state untouched.
+	 */
+	if ((err != 0) && (err != -EALREADY)) {
+		LOG_ERR("chan disconnect failed (%d)", err);
+		return err;
+	}
+
+	hid->state = BT_HID_STATE_DISCONNECTING;
+
+	return 0;
+}
+
+int bt_hid_device_input_report(struct bt_hid_device *hid, struct net_buf *buf)
+{
+	struct bt_hid_hdr *hdr;
+	int err;
+
+	if (hid == NULL || buf == NULL) {
+		return -EINVAL;
+	}
+
+	if (hid->state != BT_HID_STATE_CONNECTED) {
+		LOG_ERR("not connected (state %d)", hid->state);
+		return -ENOTCONN;
+	}
+
+	if (net_buf_headroom(buf) < sizeof(struct bt_hid_hdr)) {
+		return -ENOMEM;
+	}
+
+	hdr = net_buf_push(buf, sizeof(struct bt_hid_hdr));
+	hdr->header = BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_DATA, BT_HID_REPORT_TYPE_INPUT);
+
+	err = bt_l2cap_chan_send(&hid->intr_session.br_chan.chan, buf);
+	if (err < 0) {
+		LOG_ERR("Input_Report send failed (%d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static void virtual_cable_unplug_tx_cb(struct bt_conn *conn, void *user_data, int err)
+{
+	struct bt_hid_device *hid;
+
+	if (conn == NULL || user_data == NULL) {
+		return;
+	}
+
+	hid = (struct bt_hid_device *)user_data;
+
+	/* VC unplug is a one-way teardown of the HID connection: disconnect
+	 * regardless of the send result. If the PDU failed to reach the
+	 * controller the host may not see the unplug, but the local link must
+	 * still be torn down. Defer the disconnect to the system workqueue
+	 * because this callback runs in the TX context.
+	 */
+	if (err != 0) {
+		LOG_WRN("VCU control message send failed (%d)", err);
+	}
+
+	k_work_submit(&hid->vcu_disconnect);
+}
+
+int bt_hid_device_virtual_cable_unplug(struct bt_hid_device *hid)
+{
+	struct net_buf *buf;
+	struct bt_hid_hdr *hdr;
+	int err;
+
+	LOG_DBG("virtual cable unplug");
+
+	if (hid == NULL) {
+		return -EINVAL;
+	}
+
+	if (hid->state != BT_HID_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	buf = bt_hid_device_create_pdu(NULL);
+	if (buf == NULL) {
+		return -ENOBUFS;
+	}
+
+	hdr = net_buf_add(buf, sizeof(struct bt_hid_hdr));
+	hdr->header = BT_HID_BUILD_HDR(BT_HID_MSG_TYPE_CONTROL,
+				       BT_HID_CONTROL_VIRTUAL_CABLE_UNPLUG);
+
+	/* Disconnect only after the VCU PDU has actually been sent: the
+	 * tx callback tears down the L2CAP channel so the PDU is not lost to
+	 * an early disconnect. If the remote host disconnects first
+	 * (spec-correct behavior), cleanup cancels the pending work.
+	 */
+	err = bt_l2cap_br_chan_send_cb(&hid->ctrl_session.br_chan.chan, buf,
+				       virtual_cable_unplug_tx_cb, hid);
+	if (err < 0) {
+		net_buf_unref(buf);
+		return err;
+	}
+
+	/* HID spec v1.1.2 Section 3.1.2.2.3: the VCU initiator shall also
+	 * destroy bonding/Virtual Cable info. This is intentionally left out
+	 * for now for the same reason as in hid_control_handle() — see the
+	 * note there: bt_br_unpair() would drop the shared ACL, and clearing
+	 * the key without an ACL disconnect needs a new host API pending
+	 * community agreement.
+	 */
+
+	return 0;
+}

--- a/subsys/bluetooth/host/classic/hid_internal.h
+++ b/subsys/bluetooth/host/classic/hid_internal.h
@@ -1,0 +1,138 @@
+/** @file
+ *  @brief Internal APIs for Bluetooth HID Device handling.
+ */
+
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/bluetooth/classic/hid_device.h>
+#include <zephyr/bluetooth/l2cap.h>
+
+/** @brief HID header size (1 byte). */
+#define BT_HID_HDR_SIZE 1U
+
+/** @brief HID PSM values for control/interrupt channels. */
+#define BT_L2CAP_PSM_HID_CTRL 0x0011
+#define BT_L2CAP_PSM_HID_INTR 0x0013
+
+/** @brief HIDP message types (upper nibble of HID header). */
+#define BT_HID_MSG_TYPE_HANDSHAKE    0x00
+#define BT_HID_MSG_TYPE_CONTROL      0x01
+#define BT_HID_MSG_TYPE_GET_REPORT   0x04
+#define BT_HID_MSG_TYPE_SET_REPORT   0x05
+#define BT_HID_MSG_TYPE_GET_PROTOCOL 0x06
+#define BT_HID_MSG_TYPE_SET_PROTOCOL 0x07
+#define BT_HID_MSG_TYPE_GET_IDLE     0x08
+#define BT_HID_MSG_TYPE_SET_IDLE     0x09
+#define BT_HID_MSG_TYPE_DATA         0x0a
+#define BT_HID_MSG_TYPE_DATAC        0x0b
+
+/** @brief HID handshake result codes (4-bit param field). */
+#define BT_HID_HS_RSP_SUCCESS               0x00
+#define BT_HID_HS_RSP_NOT_READY             0x01
+#define BT_HID_HS_RSP_ERR_INVALID_REPORT_ID 0x02
+#define BT_HID_HS_RSP_ERR_UNSUPPORTED_REQ   0x03
+#define BT_HID_HS_RSP_ERR_INVALID_PARAM     0x04
+#define BT_HID_HS_RSP_ERR_UNKNOWN           0x0e
+#define BT_HID_HS_RSP_ERR_FATAL             0x0f
+
+/** @brief HID_CONTROL operations (lower nibble of HID header). */
+#define BT_HID_CONTROL_NOP                  0x00
+#define BT_HID_CONTROL_HARD_RESET           0x01
+#define BT_HID_CONTROL_SOFT_RESET           0x02
+#define BT_HID_CONTROL_SUSPEND              0x03
+#define BT_HID_CONTROL_EXIT_SUSPEND         0x04
+#define BT_HID_CONTROL_VIRTUAL_CABLE_UNPLUG 0x05
+
+/** @brief Mask for HID protocol parameter in SET/GET_PROTOCOL (bit 0). */
+#define BT_HID_PROTOCOL_MASK GENMASK(0, 0)
+
+/** @brief Report type field mask (lower two bits of parameter). */
+#define BT_HID_PARAM_REPORT_TYPE_MASK GENMASK(1, 0)
+/** @brief Report size present flag in parameter field. */
+#define BT_HID_PARAM_REPORT_SIZE_MASK BIT(2)
+
+/** @brief Report type values used in GET/SET/DATA messages. */
+#define BT_HID_PAR_REP_TYPE_OTHER   0x00
+#define BT_HID_PAR_REP_TYPE_INPUT   0x01
+#define BT_HID_PAR_REP_TYPE_OUTPUT  0x02
+#define BT_HID_PAR_REP_TYPE_FEATURE 0x03
+
+/** @brief HID header field masks (1 byte): upper nibble = message type,
+ *  lower nibble = parameter.
+ */
+#define BT_HID_HDR_TYPE_MASK  GENMASK(7, 4)
+#define BT_HID_HDR_PARAM_MASK GENMASK(3, 0)
+
+/** @brief HID header encoding/decoding helpers. */
+#define BT_HID_BUILD_HDR(t, p)                                                                 \
+	(uint8_t)(FIELD_PREP(BT_HID_HDR_TYPE_MASK, (t)) | FIELD_PREP(BT_HID_HDR_PARAM_MASK, (p)))
+#define BT_HID_HDR_GET_TYPE(x)  FIELD_GET(BT_HID_HDR_TYPE_MASK, (x))
+#define BT_HID_HDR_GET_PARAM(x) FIELD_GET(BT_HID_HDR_PARAM_MASK, (x))
+
+/** @brief HID header byte stored in a packed struct for buffer access. */
+struct bt_hid_hdr {
+	uint8_t header;
+} __packed;
+
+/** @brief Type of the HID channel */
+enum bt_hid_channel_type {
+	/** Channel type unknown or not initialized. */
+	BT_HID_CHANNEL_UNKNOWN = 0,
+	/** Control channel. */
+	BT_HID_CHANNEL_CTRL,
+	/** Interrupt channel. */
+	BT_HID_CHANNEL_INTR,
+};
+
+/** @brief Role of the HID device relative to the remote peer */
+enum bt_hid_role {
+	/** Local device accepted an incoming connection (server role). */
+	BT_HID_ROLE_ACCEPTOR = 0,
+	/** Local device initiated the connection (client role). */
+	BT_HID_ROLE_INITIATOR
+};
+
+/** @brief HID device state machine values. */
+enum bt_hid_state {
+	BT_HID_STATE_DISCONNECTED = 0x00,
+	BT_HID_STATE_CTRL_CONNECTING = 0x01,
+	BT_HID_STATE_CTRL_CONNECTED = 0x02,
+	BT_HID_STATE_INTR_CONNECTING = 0x03,
+	BT_HID_STATE_CONNECTED = 0x04,
+	BT_HID_STATE_DISCONNECTING = 0x05,
+};
+
+/** @brief HID session wrapper for an L2CAP channel */
+struct bt_hid_session {
+	/** Underlying BR/EDR L2CAP channel. */
+	struct bt_l2cap_br_chan br_chan;
+	/** Channel type (control or interrupt). */
+	enum bt_hid_channel_type type;
+};
+
+/** @brief HID device instance (opaque to applications) */
+struct bt_hid_device {
+	/** Role of this device (initiator or acceptor). */
+	enum bt_hid_role role;
+	/** Control channel session. */
+	struct bt_hid_session ctrl_session;
+	/** Interrupt channel session. */
+	struct bt_hid_session intr_session;
+
+	/** True when the HID device is in Boot Protocol Mode. */
+	bool boot_mode;
+	/** Runtime connection state. */
+	uint8_t state;
+
+	/** True while the control channel is connected. */
+	bool ctrl_connected;
+	/** True while the interrupt channel is connected. */
+	bool intr_connected;
+
+	struct k_work_delayable intr_timeout;
+	struct k_work vcu_disconnect;
+};

--- a/subsys/bluetooth/host/classic/shell/CMakeLists.txt
+++ b/subsys/bluetooth/host/classic/shell/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_BT_GOEP goep.c)
 zephyr_library_sources_ifdef(CONFIG_BT_BIP bip.c)
+zephyr_library_sources_ifdef(CONFIG_BT_HID_DEVICE hid_device.c)
 if(CONFIG_BT_AVRCP_TG_COVER_ART OR CONFIG_BT_AVRCP_CT_COVER_ART)
   zephyr_library_sources(avrcp_cover_art.c)
 endif()

--- a/subsys/bluetooth/host/classic/shell/hid_device.c
+++ b/subsys/bluetooth/host/classic/shell/hid_device.c
@@ -1,0 +1,645 @@
+/*
+ * Copyright 2025 Xiaomi Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <zephyr/types.h>
+#include <stddef.h>
+#include <string.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/classic/hid_device.h>
+#include <zephyr/bluetooth/classic/sdp.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/usb/class/hid.h>
+
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_string_conv.h>
+
+#include "host/shell/bt.h"
+#include "common/bt_shell_private.h"
+
+#define BT_HID_DEVICE_VERSION      0x0101
+#define BT_HID_PARSER_VERSION      0x0111
+#define BT_HID_DEVICE_SUBCLASS     0x80 /* Pointing device (mouse) */
+#define BT_HID_DEVICE_COUNTRY_CODE 0x21
+#define BT_L2CAP_PSM_HID_CONTROL   0x0011
+#define BT_L2CAP_PSM_HID_INTERRUPT 0x0013
+
+#define BT_HID_LANG_ID_ENGLISH 0x0409
+#define BT_HID_LANG_ID_OFFSET  0x0100
+
+#define BT_HID_SUPERVISION_TIMEOUT 1000
+#define BT_HID_SSR_HOST_MAX_LATENCY 240
+#define BT_HID_SSR_HOST_MIN_TIMEOUT 0
+
+NET_BUF_POOL_FIXED_DEFINE(pool, 1, BT_L2CAP_BUF_SIZE(CONFIG_BT_L2CAP_TX_MTU),
+			  CONFIG_BT_CONN_TX_USER_DATA_SIZE, NULL);
+
+/* Shell mouse descriptor declares a single Report ID */
+#define SHELL_MOUSE_REPORT_ID 2
+
+static const uint8_t mouse_descriptor[] = {
+	HID_USAGE_PAGE(HID_USAGE_GEN_DESKTOP),
+	HID_USAGE(HID_USAGE_GEN_DESKTOP_MOUSE),
+	HID_COLLECTION(HID_COLLECTION_APPLICATION),
+		HID_REPORT_ID(SHELL_MOUSE_REPORT_ID),
+		HID_USAGE(HID_USAGE_GEN_DESKTOP_POINTER),
+		HID_COLLECTION(HID_COLLECTION_PHYSICAL),
+			HID_USAGE_PAGE(HID_USAGE_GEN_BUTTON),
+			HID_USAGE_MIN8(1),
+			HID_USAGE_MAX8(8),
+			HID_LOGICAL_MIN8(0),
+			HID_LOGICAL_MAX8(1),
+			HID_REPORT_COUNT(8),
+			HID_REPORT_SIZE(1),
+			HID_INPUT(0x02),
+			HID_USAGE_PAGE(HID_USAGE_GEN_DESKTOP),
+			HID_USAGE(HID_USAGE_GEN_DESKTOP_X),
+			HID_USAGE(HID_USAGE_GEN_DESKTOP_Y),
+			HID_USAGE(HID_USAGE_GEN_DESKTOP_WHEEL),
+			HID_LOGICAL_MIN8(-127),
+			HID_LOGICAL_MAX8(127),
+			HID_REPORT_SIZE(8),
+			HID_REPORT_COUNT(3),
+			HID_INPUT(0x06),
+		HID_END_COLLECTION,
+	HID_END_COLLECTION,
+};
+
+static struct bt_sdp_attribute hid_attrs[] = {
+	BT_SDP_NEW_SERVICE,
+	BT_SDP_LIST(
+		BT_SDP_ATTR_SVCLASS_ID_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+			BT_SDP_ARRAY_16(BT_SDP_HID_SVCLASS)
+		}
+	    )
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_PROTO_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 13),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+				BT_SDP_ARRAY_16(BT_L2CAP_PSM_HID_CONTROL)
+			}
+			)
+		},
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_PROTO_HID)
+			}
+			)
+		},
+		)
+	),
+	BT_SDP_LIST(BT_SDP_ATTR_PROFILE_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+				BT_SDP_ARRAY_16(BT_SDP_HID_SVCLASS)},
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+					BT_SDP_ARRAY_16(BT_HID_DEVICE_VERSION)
+				}
+			)
+		}
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_ADD_PROTO_DESC_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 15),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 13),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+				BT_SDP_DATA_ELEM_LIST(
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+					BT_SDP_ARRAY_16(BT_SDP_PROTO_L2CAP)
+				},
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+					BT_SDP_ARRAY_16(BT_L2CAP_PSM_HID_INTERRUPT)
+				}
+				)
+			},
+			{
+				BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 3),
+				BT_SDP_DATA_ELEM_LIST(
+				{
+					BT_SDP_TYPE_SIZE(BT_SDP_UUID16),
+					BT_SDP_ARRAY_16(BT_SDP_PROTO_HID)
+				}
+				)
+			}
+			)
+		}
+		)
+	),
+	BT_SDP_SERVICE_NAME("HID CONTROL"),
+	{
+		BT_SDP_ATTR_HID_DEVICE_RELEASE_NUMBER,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+			BT_SDP_ARRAY_16(BT_HID_DEVICE_VERSION)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_PARSER_VERSION,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+			BT_SDP_ARRAY_16(BT_HID_PARSER_VERSION)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_DEVICE_SUBCLASS,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT8),
+			BT_SDP_ARRAY_8(BT_HID_DEVICE_SUBCLASS)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_COUNTRY_CODE,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT8),
+			BT_SDP_ARRAY_8(BT_HID_DEVICE_COUNTRY_CODE)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_VIRTUAL_CABLE,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_BOOL),
+			BT_SDP_ARRAY_8(0x01)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_RECONNECT_INITIATE,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_BOOL),
+			BT_SDP_ARRAY_8(0x01)
+		}
+	},
+	BT_SDP_LIST(
+		BT_SDP_ATTR_HID_DESCRIPTOR_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ16, sizeof(mouse_descriptor) + 8),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ16, sizeof(mouse_descriptor) + 5),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT8),
+				BT_SDP_ARRAY_8(0x22),
+			},
+			{
+				BT_SDP_TYPE_SIZE_VAR(BT_SDP_TEXT_STR16,
+					sizeof(mouse_descriptor)
+				),
+				mouse_descriptor,
+			}
+			)
+		}
+		)
+	),
+	BT_SDP_LIST(
+		BT_SDP_ATTR_HID_LANG_ID_BASE_LIST,
+		BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 8),
+		BT_SDP_DATA_ELEM_LIST(
+		{
+			BT_SDP_TYPE_SIZE_VAR(BT_SDP_SEQ8, 6),
+			BT_SDP_DATA_ELEM_LIST(
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+				BT_SDP_ARRAY_16(BT_HID_LANG_ID_ENGLISH),
+			},
+			{
+				BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+				BT_SDP_ARRAY_16(BT_HID_LANG_ID_OFFSET),
+			}
+			),
+		}
+		)
+	),
+	{
+		BT_SDP_ATTR_HID_BOOT_DEVICE,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_BOOL),
+			BT_SDP_ARRAY_8(0x01)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_PROFILE_VERSION,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+			BT_SDP_ARRAY_16(0x0101)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_BATTERY_POWER,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_BOOL),
+			BT_SDP_ARRAY_8(0x01)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_REMOTE_WAKEUP,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_BOOL),
+			BT_SDP_ARRAY_8(0x01)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_NORMALLY_CONNECTABLE,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_BOOL),
+			BT_SDP_ARRAY_8(0x01)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_SUPERVISION_TIMEOUT,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+			BT_SDP_ARRAY_16(BT_HID_SUPERVISION_TIMEOUT)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_SSR_HOST_MAX_LATENCY,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+			BT_SDP_ARRAY_16(BT_HID_SSR_HOST_MAX_LATENCY)
+		}
+	},
+	{
+		BT_SDP_ATTR_HID_SSR_HOST_MIN_TIMEOUT,
+		{
+			BT_SDP_TYPE_SIZE(BT_SDP_UINT16),
+			BT_SDP_ARRAY_16(BT_HID_SSR_HOST_MIN_TIMEOUT)
+		}
+	},
+};
+
+static struct bt_hid_device *default_hid;
+static bool hid_registered;
+static bool hid_boot_mode;
+static bool vcu_unplug_pending;
+static bt_addr_t vcu_peer;
+static struct bt_sdp_record hid_rec = BT_SDP_RECORD(hid_attrs);
+
+static void hid_connect_cb(struct bt_hid_device *hid)
+{
+	bt_shell_print("HID: connected (%p)", hid);
+	default_hid = hid;
+}
+
+static void hid_disconnected_cb(struct bt_hid_device *hid)
+{
+	bt_shell_print("HID: disconnected (%p)", hid);
+
+	default_hid = NULL;
+
+	if (vcu_unplug_pending) {
+		vcu_unplug_pending = false;
+		bt_br_unpair(&vcu_peer);
+	}
+}
+
+static int hid_set_report_cb(struct bt_hid_device *hid, uint8_t type, struct net_buf *buf)
+{
+	uint8_t report_id;
+
+	if (buf->len < sizeof(report_id)) {
+		return -EINVAL;
+	}
+
+	report_id = net_buf_pull_u8(buf);
+	bt_shell_print("HID: set report type %u id %u len %u", type, report_id, buf->len);
+
+	if (report_id != SHELL_MOUSE_REPORT_ID) {
+		return -ENOENT;
+	}
+
+	bt_shell_hexdump(buf->data, buf->len);
+	return 0;
+}
+
+static int hid_get_report_cb(struct bt_hid_device *hid, uint8_t type, bool size_present,
+			     struct net_buf *req, struct net_buf *rsp)
+{
+	uint8_t report_id = 0;
+
+	ARG_UNUSED(hid);
+	ARG_UNUSED(type);
+
+	if (req->len < sizeof(report_id)) {
+		return -EINVAL;
+	}
+
+	report_id = net_buf_pull_u8(req);
+	bt_shell_print("HID: get report type %u id %u", type, report_id);
+
+	if (size_present) {
+		if (req->len < sizeof(uint16_t)) {
+			return -EINVAL;
+		}
+
+		/* Size bit set: the host caps the response at this BufferSize.
+		 * The fixed mouse report below is always shorter, so this
+		 * sample only logs it; a real device must trim its response
+		 * to not exceed BufferSize.
+		 */
+		bt_shell_print("HID: requested buffer size %u", net_buf_pull_le16(req));
+	}
+
+	if (report_id != SHELL_MOUSE_REPORT_ID) {
+		return -ENOENT;
+	}
+
+	/* Fill the stack-provided response buffer; the stack prepends the HIDP
+	 * header and sends it on return.
+	 */
+	net_buf_add_u8(rsp, SHELL_MOUSE_REPORT_ID); /* Report ID */
+	net_buf_add_u8(rsp, 0x00);                  /* buttons */
+	net_buf_add_u8(rsp, 0x00);                  /* X displacement */
+	net_buf_add_u8(rsp, 0x00);                  /* Y displacement */
+
+	if (!hid_boot_mode) {
+		net_buf_add_u8(rsp, 0x00);          /* wheel (report mode only) */
+	}
+
+	return 0;
+}
+
+static int hid_set_protocol_cb(struct bt_hid_device *hid, uint8_t protocol)
+{
+	bt_shell_print("HID: set protocol %u", protocol);
+	hid_boot_mode = (protocol == BT_HID_PROTOCOL_BOOT_MODE);
+	return 0;
+}
+
+static void hid_output_report_cb(struct bt_hid_device *hid, struct net_buf *buf)
+{
+	uint8_t report_id;
+
+	if (buf->len < sizeof(report_id)) {
+		bt_shell_warn("HID: malformed output report (len %u)", buf->len);
+		return;
+	}
+
+	report_id = net_buf_pull_u8(buf);
+	bt_shell_print("HID: output report id %u len %u", report_id, buf->len);
+	bt_shell_hexdump(buf->data, buf->len);
+}
+
+static void hid_vc_unplug_cb(struct bt_hid_device *hid)
+{
+	struct bt_conn *conn = bt_hid_device_get_conn(hid);
+
+	bt_shell_print("HID: virtual cable unplug");
+
+	/* HID spec v1.1.2 Section 3.1.2.2.3: destroy the bonding information
+	 * for the peer that requested the Virtual Cable Unplug. Defer the
+	 * unpair until the HID connection is fully torn down (disconnected
+	 * callback): bt_br_unpair() drops the ACL, so doing it here would kill
+	 * the still-open HID channels instead of letting them close in order.
+	 */
+	if (conn != NULL) {
+		bt_addr_copy(&vcu_peer, bt_conn_get_dst_br(conn));
+		vcu_unplug_pending = true;
+		bt_conn_unref(conn);
+	}
+}
+
+static void hid_suspend_cb(struct bt_hid_device *hid, bool suspended)
+{
+	bt_shell_print("HID: %s", suspended ? "suspended" : "exit suspend");
+}
+
+static const struct bt_hid_device_cb hid_cb = {
+	.connected = hid_connect_cb,
+	.disconnected = hid_disconnected_cb,
+	.set_report = hid_set_report_cb,
+	.get_report = hid_get_report_cb,
+	.set_protocol = hid_set_protocol_cb,
+	.output_report = hid_output_report_cb,
+	.vc_unplug = hid_vc_unplug_cb,
+	.suspend = hid_suspend_cb,
+};
+
+static int cmd_hid_register(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (hid_registered) {
+		shell_error(sh, "HID: already registered");
+		return -EALREADY;
+	}
+
+	err = bt_hid_device_register(&hid_cb);
+	if (err != 0) {
+		shell_error(sh, "HID: register failed (%d)", err);
+		return err;
+	}
+
+	err = bt_sdp_register_service(&hid_rec);
+	if (err != 0 && err != -EEXIST) {
+		shell_error(sh, "HID: SDP register failed (%d)", err);
+		bt_hid_device_unregister();
+		return err;
+	}
+
+	hid_registered = true;
+	shell_print(sh, "HID: registered");
+	return 0;
+}
+
+static int cmd_hid_unregister(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!hid_registered) {
+		shell_error(sh, "HID: not registered");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_device_unregister();
+	if (err != 0) {
+		shell_error(sh, "HID: unregister failed (%d)", err);
+		return err;
+	}
+
+	hid_registered = false;
+	default_hid = NULL;
+	shell_print(sh, "HID: unregistered");
+	return 0;
+}
+
+static int cmd_hid_connect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!hid_registered) {
+		shell_error(sh, "HID: not registered");
+		return -ENOEXEC;
+	}
+
+	if (default_conn == NULL) {
+		shell_error(sh, "HID: not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_device_connect(default_conn, &default_hid);
+	if (err != 0) {
+		shell_error(sh, "HID: connect failed (%d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_hid_disconnect(const struct shell *sh, size_t argc, char *argv[])
+{
+	int err;
+
+	if (!hid_registered) {
+		shell_error(sh, "HID: not registered");
+		return -ENOEXEC;
+	}
+
+	if (default_hid == NULL) {
+		shell_error(sh, "HID: not connected");
+		return -ENOEXEC;
+	}
+
+	err = bt_hid_device_disconnect(default_hid);
+	if (err != 0) {
+		shell_error(sh, "HID: disconnect failed (%d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_hid_send_report(const struct shell *sh, size_t argc, char *argv[])
+{
+	long button, dx, dy, wheel = 0;
+	struct net_buf *buf;
+	int err = 0;
+
+	if (!hid_registered) {
+		shell_error(sh, "HID: not registered");
+		return -ENOEXEC;
+	}
+
+	if (default_hid == NULL) {
+		shell_error(sh, "HID: not connected");
+		return -ENOEXEC;
+	}
+
+	button = shell_strtol(argv[1], 0, &err);
+	dx = shell_strtol(argv[2], 0, &err);
+	dy = shell_strtol(argv[3], 0, &err);
+	if (argc >= 5U) {
+		wheel = shell_strtol(argv[4], 0, &err);
+	}
+
+	if (err != 0) {
+		shell_error(sh, "HID: invalid parameter");
+		return -EINVAL;
+	}
+
+	if ((button < 0) || (button > 0xFF) ||
+	    (dx < -127) || (dx > 127) ||
+	    (dy < -127) || (dy > 127) ||
+	    (!hid_boot_mode && ((wheel < -127) || (wheel > 127)))) {
+		shell_error(sh, "HID: value out of bounds");
+		return -ERANGE;
+	}
+
+	buf = bt_hid_device_create_pdu(&pool);
+	if (buf == NULL) {
+		shell_error(sh, "HID: failed to create PDU");
+		return -ENOEXEC;
+	}
+
+	/* BDIT/BV-01-C: Boot Protocol mouse = buttons(1) + X(1) + Y(1).
+	 * Report Protocol mouse = Report ID(1) + buttons(1) + X(1) + Y(1) + wheel(1).
+	 *
+	 * Button byte (bit fields):
+	 *  bit0 = Left, bit1 = Right, bit2 = Middle, bit3..7 = Button 4..8
+	 * X/Y: signed 8-bit relative displacement
+	 * Wheel: signed 8-bit scroll (Report Protocol only)
+	 */
+	if (hid_boot_mode) {
+		net_buf_add_u8(buf, (uint8_t)button); /* buttons */
+		net_buf_add_u8(buf, (uint8_t)dx);     /* X displacement */
+		net_buf_add_u8(buf, (uint8_t)dy);     /* Y displacement */
+	} else {
+		net_buf_add_u8(buf, SHELL_MOUSE_REPORT_ID); /* Report ID */
+		net_buf_add_u8(buf, (uint8_t)button);        /* buttons */
+		net_buf_add_u8(buf, (uint8_t)dx);            /* X displacement */
+		net_buf_add_u8(buf, (uint8_t)dy);            /* Y displacement */
+		net_buf_add_u8(buf, (uint8_t)wheel);         /* wheel scroll */
+	}
+
+	err = bt_hid_device_input_report(default_hid, buf);
+	if (err != 0) {
+		net_buf_unref(buf);
+		shell_error(sh, "HID: send report failed (%d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(hid_device_cmds,
+	SHELL_CMD_ARG(register, NULL, "register hid mouse device", cmd_hid_register, 1, 0),
+	SHELL_CMD_ARG(unregister, NULL, "unregister hid mouse device", cmd_hid_unregister, 1, 0),
+	SHELL_CMD_ARG(connect, NULL, "hid connect", cmd_hid_connect, 1, 0),
+	SHELL_CMD_ARG(disconnect, NULL, "hid disconnect", cmd_hid_disconnect, 1, 0),
+	SHELL_CMD_ARG(send, NULL,
+			  "send mouse report: <(button bits: "
+			  "0=Left,1=Right,2=Middle,b3..7=4..8)> <X> <Y> [wheel]",
+			  cmd_hid_send_report, 4, 1),
+	SHELL_SUBCMD_SET_END
+);
+
+static int cmd_hid_device(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc == 1U) {
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
+
+	shell_print(sh, "%s unknown parameter: %s", argv[0], argv[1]);
+
+	return -ENOEXEC;
+}
+
+SHELL_CMD_ARG_REGISTER(hid_device, &hid_device_cmds, "Bluetooth HID Device sh commands",
+		       cmd_hid_device, 1, 1);


### PR DESCRIPTION
**Implementation Summary**
This PR adds full HID Device protocol support to Zephyr's Bluetooth stack, enabling Zephyr devices to function as Bluetooth HID peripherals (e.g., keyboards, mice). The implementation includes:

**Core Protocol Infrastructure**

- Dual L2CAP channel management (Control PSM=0x11, Interrupt PSM=0x13)
- Connection manager
- Resource initialization system (bt_hid_device_init)
- Standardized API for device registration and callbacks

**Data Handling**

- Control channel command processing (SET_REPORT/GET_REPORT)
- Interrupt channel report transmission
- Input report reception with validation
- Support for all HID report types (Input/Output/Feature)

Shell Tool

shell
# Connection management
br connect DC:41:A9:XX:XX:XX
hid_device register
hid_device connect 
hid_device disconnect

# Data operations
hid_device send     # Send mouse report

**Security & Compliance**

HID Spec v1.1.1 compliance
Bonding and pairing integration