### PR TITLE
posix: do not rely on PAGE_SIZE being defined in limits.h

### DIFF
--- a/lib/posix/options/mmap.c
+++ b/lib/posix/options/mmap.c
@@ -15,7 +15,7 @@
 #include <zephyr/posix/sys/mman.h>
 #include <zephyr/posix/unistd.h>
 
-#define _page_size COND_CODE_1(CONFIG_MMU, (CONFIG_MMU_PAGE_SIZE), (PAGE_SIZE))
+#define _page_size COND_CODE_1(CONFIG_MMU, (CONFIG_MMU_PAGE_SIZE), (CONFIG_POSIX_PAGE_SIZE))
 
 int zvfs_ioctl(int fd, int cmd, va_list args);
 

--- a/lib/posix/options/shm.c
+++ b/lib/posix/options/shm.c
@@ -20,7 +20,7 @@
 #include <zephyr/sys/fdtable.h>
 #include <zephyr/sys/hash_function.h>
 
-#define _page_size COND_CODE_1(CONFIG_MMU, (CONFIG_MMU_PAGE_SIZE), (PAGE_SIZE))
+#define _page_size COND_CODE_1(CONFIG_MMU, (CONFIG_MMU_PAGE_SIZE), (CONFIG_POSIX_PAGE_SIZE))
 
 static const struct fd_op_vtable shm_vtable;
 


### PR DESCRIPTION
Since an implementation may omit definitions of runtime invariant values in `limits.h` if the corresponding value is equal to or greater than the minimum, is unspecified, and may be queried at runtime [1], do not rely on `PAGE_SIZE` being declared in `limits.h`.

Since we still prefer to use a compile-time constant in Zephyr, use the Kconfig option directly.

[1]
https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/limits.h.html