### PR TITLE
posix: signals: use Kconfig options instead of _NSIG

### DIFF
--- a/include/zephyr/posix/signal.h
+++ b/include/zephyr/posix/signal.h
@@ -47,13 +47,15 @@ extern "C" {
 #define SIGSYS    31 /**< Bad system call */
 
 #define SIGRTMIN 32
-#define SIGRTMAX (SIGRTMIN + RTSIG_MAX)
-#define _NSIG (SIGRTMAX + 1)
-
-BUILD_ASSERT(RTSIG_MAX >= 0);
+#if defined(CONFIG_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
+BUILD_ASSERT(CONFIG_POSIX_RTSIG_MAX >= 0);
+#define SIGRTMAX (SIGRTMIN + CONFIG_POSIX_RTSIG_MAX)
+#else
+#define SIGRTMAX SIGRTMIN
+#endif
 
 typedef struct {
-	unsigned long sig[DIV_ROUND_UP(_NSIG, BITS_PER_LONG)];
+	unsigned long sig[DIV_ROUND_UP(SIGRTMAX + 1, BITS_PER_LONG)];
 } sigset_t;
 
 #ifndef SIGEV_NONE

--- a/lib/posix/options/signal.c
+++ b/lib/posix/options/signal.c
@@ -14,11 +14,9 @@
 #define SIGNO_WORD_IDX(_signo) (_signo / BITS_PER_LONG)
 #define SIGNO_WORD_BIT(_signo) (_signo & BIT_MASK(LOG2(BITS_PER_LONG)))
 
-BUILD_ASSERT(CONFIG_POSIX_RTSIG_MAX >= 0);
-
 static inline bool signo_valid(int signo)
 {
-	return ((signo > 0) && (signo < _NSIG));
+	return ((signo > 0) && (signo <= SIGRTMAX));
 }
 
 static inline bool signo_is_rt(int signo)

--- a/tests/posix/headers/src/signal_h.c
+++ b/tests/posix/headers/src/signal_h.c
@@ -46,8 +46,7 @@ ZTEST(posix_headers, test_signal_h)
 	zassert_not_equal(-1, offsetof(union sigval, sival_int));
 	zassert_not_equal(-1, offsetof(union sigval, sival_ptr));
 
-	zassert_not_equal(-1, RTSIG_MAX);
-	zassert_true(SIGRTMAX - SIGRTMIN >= RTSIG_MAX);
+	zassert_true(SIGRTMAX - SIGRTMIN >= 0);
 
 	zassert_not_equal(-1, SIG_BLOCK);
 	zassert_not_equal(-1, SIG_UNBLOCK);

--- a/tests/posix/signals/src/main.c
+++ b/tests/posix/signals/src/main.c
@@ -48,7 +48,7 @@ ZTEST(posix_signals, test_sigaddset_oor)
 	zassert_equal(sigaddset(&set, 0), -1, "rc should be -1");
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 
-	zassert_equal(sigaddset(&set, _NSIG), -1, "rc should be -1");
+	zassert_equal(sigaddset(&set, SIGRTMAX + 1), -1, "rc should be -1");
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 }
 
@@ -109,7 +109,7 @@ ZTEST(posix_signals, test_sigdelset_oor)
 	zassert_equal(sigdelset(&set, 0), -1, "rc should be -1");
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 
-	zassert_equal(sigdelset(&set, _NSIG), -1, "rc should be -1");
+	zassert_equal(sigdelset(&set, SIGRTMAX + 1), -1, "rc should be -1");
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 }
 
@@ -170,7 +170,7 @@ ZTEST(posix_signals, test_sigismember_oor)
 	zassert_equal(sigismember(&set, 0), -1, "rc should be -1");
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 
-	zassert_equal(sigismember(&set, _NSIG), -1, "rc should be -1");
+	zassert_equal(sigismember(&set, SIGRTMAX + 1), -1, "rc should be -1");
 	zassert_equal(errno, EINVAL, "errno should be %s", "EINVAL");
 }
 
@@ -202,7 +202,7 @@ ZTEST(posix_signals, test_signal_strsignal)
 
 	zassert_mem_equal(strsignal(-1), "Invalid signal", sizeof("Invalid signal"));
 	zassert_mem_equal(strsignal(0), "Invalid signal", sizeof("Invalid signal"));
-	zassert_mem_equal(strsignal(_NSIG), "Invalid signal", sizeof("Invalid signal"));
+	zassert_mem_equal(strsignal(SIGRTMAX + 1), "Invalid signal", sizeof("Invalid signal"));
 
 	zassert_mem_equal(strsignal(30), "Signal 30", sizeof("Signal 30"));
 	snprintf(buf, sizeof(buf), "RT signal %d", SIGRTMIN - SIGRTMIN);


### PR DESCRIPTION
Use `CONFIG_POSIX_RTSIG_MAX` instead of `_NSIG`, since `RTSIG_MAX` isn't always going to be defined [1].

[1]
https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/limits.h.html