### PR TITLE
posix: disable clang-format where checkpatch disagrees

### DIFF
--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -252,6 +252,13 @@ __PICOLIBC_MINOR__ == 8 && __PICOLIBC_PATCHLEVEL__ >= 9)))
 #include <limits.h>
 #else
 
+/*
+ * clang-format and checkpatch disagree on formatting here, so rely on checkpatch and disable
+ * clang-format since checkpatch cannot be selectively disabled.
+ */
+
+/* clang-format off */
+
 /* Maximum values */
 #define _POSIX_CLOCKRES_MIN (20000000L)
 
@@ -363,5 +370,7 @@ __PICOLIBC_MINOR__ == 8 && __PICOLIBC_PATCHLEVEL__ >= 9)))
 #define POSIX_REC_MIN_XFER_SIZE  (1)
 #define POSIX_REC_XFER_ALIGN     (4)
 #define SYMLINK_MAX              _POSIX_SYMLINK_MAX
+
+/* clang-format on */
 
 #endif /* INCLUDE_ZEPHYR_POSIX_POSIX_FEATURES_H_ */

--- a/include/zephyr/posix/sys/sysconf.h
+++ b/include/zephyr/posix/sys/sysconf.h
@@ -141,6 +141,13 @@ enum {
 	_SC_TZNAME_MAX,
 };
 
+/*
+ * clang-format and checkpatch disagree on formatting here, so rely on checkpatch and disable
+ * clang-format since checkpatch cannot be selectively disabled.
+ */
+
+/* clang-format off */
+
 #define __z_posix_sysconf_SC_ADVISORY_INFO (-1L)
 #define __z_posix_sysconf_SC_ASYNCHRONOUS_IO                                                       \
 	COND_CODE_1(CONFIG_POSIX_ASYNCHRONOUS_IO, (_POSIX_ASYNCHRONOUS_IO), (-1L))
@@ -298,6 +305,8 @@ enum {
 #ifdef CONFIG_POSIX_SYSCONF_IMPL_MACRO
 #define sysconf(x) (long)CONCAT(__z_posix_sysconf, x)
 #endif
+
+/* clang-format on */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
checkpatch and clang-format have conflicting formatting requirements for these files for whatever reason.

Since it is not possible to selectively disable checkpatch, but it is possible to selectively disable clang-format, disable clang-format surrounding some macros in `posix_features.h` and `sys/sysconf.h` in order to eliminate linter noise.

The code is still checked by checkpatch, which should be sufficient.