### PR TITLE
tests: application_development: ram_context_for_isr: update irq number variable type

### DIFF
--- a/tests/application_development/ram_context_for_isr/include/fake_driver.h
+++ b/tests/application_development/ram_context_for_isr/include/fake_driver.h
@@ -34,7 +34,7 @@ typedef void (*fake_driver_irq_callback_t)(const struct device *dev, void *user_
 
 struct fake_driver_config {
 	void (*irq_config_func)(void);
-	uint8_t irq_num;
+	uint16_t irq_num;
 	uint8_t irq_priority;
 };
 


### PR DESCRIPTION
This PR modifies the type of `irq_num` in the `fake_driver_config` structure to consider the case where the expected `TEST_IRQ_NUM = (CONFIG_NUM_IRQS - 1)` on platforms with more than 256 IRQ lines. 
This breaks the CI [here](https://github.com/zephyrproject-rtos/zephyr/actions/runs/16678927106/job/47212872539?pr=93945#step:13:1133).