### PR TITLE
ipm: clarify `wait` parameter interpretation

### DIFF
--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -126,9 +126,10 @@ __subsystem struct ipm_driver_api {
  * data read back.
  *
  * @param ipmdev Driver instance
- * @param wait If nonzero, busy-wait for remote to consume the message. The
- *	       message is considered consumed once the remote interrupt handler
- *	       finishes. If there is deferred processing on the remote side,
+ * @param wait If non-zero, busy-wait indefinitely for the remote to consume
+ *	       the message. The message is considered consumed
+ *	       once the remote interrupt handler finishes.
+ *	       If there is deferred processing on the remote side,
  *	       or you would like to queue outgoing messages and wait on an
  *	       event/semaphore, you can implement that in a high-level driver
  * @param id Message identifier. Values are constrained by


### PR DESCRIPTION
Wait acts as a boolean, make this clear to avoid implementations
interpreting this as a duration to wait for.

See https://github.com/zephyrproject-rtos/zephyr/pull/92923#discussion_r2248817502 for the reference

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
