### PR TITLE
soc: microchip: mec: Add common ECIA GIRQ and MMCR routines

### DIFF
--- a/soc/microchip/mec/common/CMakeLists.txt
+++ b/soc/microchip/mec/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_include_directories(.)
+zephyr_library_sources(soc_ecia.c)
 zephyr_library_sources_ifdef(CONFIG_SOC_SERIES_MEC172X
   soc_i2c.c
 )

--- a/soc/microchip/mec/common/soc_cmn_init.c
+++ b/soc/microchip/mec/common/soc_cmn_init.c
@@ -8,7 +8,6 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
-#include <mec_ecia_api.h>
 #include <mec_ecs_api.h>
 
 static void mec5_soc_init_debug_interface(void)
@@ -35,7 +34,7 @@ static void mec5_soc_init_debug_interface(void)
 int mec5_soc_common_init(void)
 {
 	mec5_soc_init_debug_interface();
-	mec_hal_ecia_init(MEC5_ECIA_DIRECT_BITMAP, 1, 0);
+	soc_ecia_init(MCHP_MEC_ECIA_GIRQ_AGGR_ONLY_BM, MCHP_MEC_ECIA_GIRQ_DIRECT_CAP_BM, 0);
 
 	return 0;
 }

--- a/soc/microchip/mec/common/soc_ecia.c
+++ b/soc/microchip/mec/common/soc_ecia.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/arch/common/sys_bitops.h>
+#include <zephyr/arch/common/sys_io.h>
+#include <soc.h>
+#include "soc_ecia.h"
+
+/* EC Subsystem */
+#define MCHP_XEC_ECS_REG_BASE      (mem_addr_t) DT_REG_ADDR(DT_NODELABEL(ecs))
+#define MCHP_XEC_ECS_ICR_OFS       0x18u
+#define MCHP_XEC_ECS_ICR_DM_EN_POS 0 /* direct mode enable */
+
+/* EC Interrupt Aggregator. It is not real interrupt controller. */
+#define MCHP_XEC_ECIA_REG_BASE        (mem_addr_t) DT_REG_ADDR(DT_NODELABEL(ecia))
+#define MCHP_XEC_ECIA_GIRQ_SIZE       20u /* 5 32-bit registers */
+#define MCHP_XEC_ECIA_GIRQ_ALL_MSK    GENMASK(MCHP_MEC_ECIA_GIRQ_LAST, MCHP_MEC_ECIA_GIRQ_FIRST)
+#define MCHP_XEC_ECIA_GIRQ_DIRECT_MSK (GENMASK(21, 13) | BIT(23))
+#define MCHP_XEC_ECIA_GIRQ_AGGR_MSK   (GENMASK(12, 8) | BIT(22) | GENMASK(26, 24))
+
+#define MCHP_XEC_ECIA_ZGIRQ_OFS(zgirq) ((uint32_t)(zgirq) * MCHP_XEC_ECIA_GIRQ_SIZE)
+#define MCHP_XEC_ECIA_GIRQ_OFS(girq)                                                               \
+	MCHP_XEC_ECIA_ZGIRQ_OFS((uint32_t)(girq) - MCHP_MEC_ECIA_GIRQ_FIRST)
+
+#define MCHP_XEC_ECIA_GIRQ_SRC_OFS    0
+#define MCHP_XEC_ECIA_GIRQ_ENSET_OFS  4u
+#define MCHP_XEC_ECIA_GIRQ_RESULT_OFS 8u
+#define MCHP_XEC_ECIA_GIRQ_ENCLR_OFS  12u
+/* offset 16 (0x10) is reserved read-only 0 */
+
+/* aggregated enable set/clear registers */
+#define MCHP_XEC_ECIA_AGGR_ENSET_OFS 0x200u /* r/w1s */
+#define MCHP_XEC_ECIA_AGGR_ENCLR_OFS 0x204u /* r/w1c */
+#define MCHP_XEC_ECIA_AGGR_ACTV_OFS  0x208u /* read-only */
+
+#define MCHP_XEC_ECIA_GIRQ_REG_OFS(girq, regofs)                                                   \
+	(MCHP_XEC_ECIA_ZGIRQ_OFS((uint32_t)(girq) - MCHP_MEC_ECIA_GIRQ_FIRST) + (uint32_t)regofs)
+
+#define MCHP_XEC_ECIA_GIRQ_SRC_REG_OFS(girq)                                                       \
+	MCHP_XEC_ECIA_GIRQ_REG_OFS(girq, MCHP_XEC_ECIA_GIRQ_SRC_OFS)
+
+#define MCHP_XEC_ECIA_GIRQ_ENSET_REG_OFS(girq)                                                     \
+	MCHP_XEC_ECIA_GIRQ_REG_OFS(girq, MCHP_XEC_ECIA_GIRQ_ENSET_OFS)
+
+#define MCHP_XEC_ECIA_GIRQ_RESULT_REG_OFS(girq)                                                    \
+	MCHP_XEC_ECIA_GIRQ_REG_OFS(girq, MCHP_XEC_ECIA_GIRQ_RESULT_OFS)
+
+#define MCHP_XEC_ECIA_GIRQ_ENCLR_REG_OFS(girq)                                                     \
+	MCHP_XEC_ECIA_GIRQ_REG_OFS(girq, MCHP_XEC_ECIA_GIRQ_ENCLR_OFS)
+
+int soc_ecia_init(uint32_t aggr_girq_bm, uint32_t direct_girq_bm, uint32_t flags)
+{
+	mem_addr_t ecia_base = MCHP_XEC_ECIA_REG_BASE;
+	mem_addr_t ecs_base = MCHP_XEC_ECS_REG_BASE;
+	uint32_t amsk = 0, dmsk = 0, bm = 0, girq = 0, raddr = 0;
+
+	amsk = aggr_girq_bm & MCHP_XEC_ECIA_GIRQ_AGGR_MSK;
+	dmsk = direct_girq_bm & MCHP_XEC_ECIA_GIRQ_DIRECT_MSK;
+
+	bm = aggr_girq_bm | direct_girq_bm;
+	while (bm != 0) {
+		girq = find_lsb_set(bm) - 1u;
+
+		raddr = ecia_base + MCHP_XEC_ECIA_GIRQ_OFS(girq);
+
+		if ((flags & MCHP_MEC_ECIA_INIT_CLR_ENABLES) != 0) { /* clear enables? */
+			sys_write32(UINT32_MAX, raddr + MCHP_XEC_ECIA_GIRQ_ENCLR_OFS);
+		}
+
+		if ((flags & MCHP_MEC_ECIA_INIT_CLR_STATUS) != 0) { /* clear status */
+			sys_write32(UINT32_MAX, raddr + MCHP_XEC_ECIA_GIRQ_SRC_OFS);
+		}
+
+		bm &= (uint32_t)~BIT(girq);
+	}
+
+	sys_write32(UINT32_MAX, ecia_base + MCHP_XEC_ECIA_AGGR_ENCLR_OFS);
+	sys_write32(amsk, ecia_base + MCHP_XEC_ECIA_AGGR_ENSET_OFS);
+
+	if (dmsk != 0) {
+		sys_set_bit(ecs_base + MCHP_XEC_ECS_ICR_OFS, MCHP_XEC_ECS_ICR_DM_EN_POS);
+	} else {
+		sys_clear_bit(ecs_base + MCHP_XEC_ECS_ICR_OFS, MCHP_XEC_ECS_ICR_DM_EN_POS);
+	}
+
+	return 0;
+}
+
+int soc_ecia_girq_ctrl_bm(uint8_t girq, uint32_t bitmap, uint8_t enable)
+{
+	mem_addr_t raddr = MCHP_XEC_ECIA_REG_BASE;
+
+	if ((girq < MCHP_MEC_ECIA_GIRQ_FIRST) || (girq > MCHP_MEC_ECIA_GIRQ_LAST)) {
+		return -EINVAL;
+	}
+
+	raddr += MCHP_XEC_ECIA_GIRQ_OFS(girq);
+
+	if (enable != 0) {
+		raddr += MCHP_XEC_ECIA_GIRQ_ENSET_OFS;
+	} else {
+		raddr += MCHP_XEC_ECIA_GIRQ_ENCLR_OFS;
+	}
+
+	sys_write32(bitmap, raddr);
+
+	return 0;
+}
+
+int soc_ecia_girq_ctrl(uint8_t girq, uint8_t srcpos, uint8_t enable)
+{
+	uint32_t bitmap = BIT(srcpos);
+
+	return soc_ecia_girq_ctrl_bm(girq, bitmap, enable);
+}
+
+uint32_t soc_ecia_girq_get_enable_bm(uint8_t girq)
+{
+	mem_addr_t raddr = MCHP_XEC_ECIA_REG_BASE;
+
+	if ((girq < MCHP_MEC_ECIA_GIRQ_FIRST) || (girq > MCHP_MEC_ECIA_GIRQ_LAST)) {
+		return 0;
+	}
+
+	raddr += MCHP_XEC_ECIA_GIRQ_ENSET_REG_OFS(girq);
+
+	return sys_read32(raddr);
+}
+
+int soc_ecia_girq_status_clear_bm(uint8_t girq, uint32_t bitmap)
+{
+	mem_addr_t raddr = MCHP_XEC_ECIA_REG_BASE;
+
+	if ((girq < MCHP_MEC_ECIA_GIRQ_FIRST) || (girq > MCHP_MEC_ECIA_GIRQ_LAST)) {
+		return -EINVAL;
+	}
+
+	raddr += MCHP_XEC_ECIA_GIRQ_SRC_REG_OFS(girq);
+
+	sys_write32(bitmap, raddr);
+
+	return 0;
+}
+
+int soc_ecia_girq_status_clear(uint8_t girq, uint8_t srcpos)
+{
+	uint32_t bitmap = BIT(srcpos);
+
+	return soc_ecia_girq_status_clear_bm(girq, bitmap);
+}
+
+int soc_ecia_girq_status(uint8_t girq, uint32_t *status)
+{
+	mem_addr_t raddr = MCHP_XEC_ECIA_REG_BASE;
+
+	if ((girq < MCHP_MEC_ECIA_GIRQ_FIRST) || (girq > MCHP_MEC_ECIA_GIRQ_LAST)) {
+		return -EINVAL;
+	}
+
+	raddr += MCHP_XEC_ECIA_GIRQ_SRC_REG_OFS(girq);
+
+	if (status != NULL) {
+		*status = sys_read32(raddr);
+	}
+
+	return 0;
+}
+
+int soc_ecia_girq_result(uint8_t girq, uint32_t *result)
+{
+	mem_addr_t raddr = MCHP_XEC_ECIA_REG_BASE;
+
+	if ((girq < MCHP_MEC_ECIA_GIRQ_FIRST) || (girq > MCHP_MEC_ECIA_GIRQ_LAST)) {
+		return -EINVAL;
+	}
+
+	raddr += MCHP_XEC_ECIA_GIRQ_RESULT_REG_OFS(girq);
+
+	if (result != NULL) {
+		*result = sys_read32(raddr);
+	}
+
+	return 0;
+}
+
+int soc_ecia_girq_is_result(uint8_t girq, uint32_t bitmap)
+{
+	uint32_t result = 0;
+
+	if (soc_ecia_girq_result(girq, &result) != 0) {
+		return 0;
+	}
+
+	return (result & bitmap);
+}
+
+int soc_ecia_girq_aggr_ctrl_bm(uint32_t girq_bitmap, uint8_t enable)
+{
+	mem_addr_t raddr = MCHP_XEC_ECIA_REG_BASE;
+
+	if (enable != 0) {
+		raddr += MCHP_XEC_ECIA_AGGR_ENSET_OFS;
+	} else {
+		raddr += MCHP_XEC_ECIA_AGGR_ENCLR_OFS;
+	}
+
+	sys_write32(girq_bitmap, raddr);
+
+	return 0;
+}
+
+int soc_ecia_girq_aggr_ctrl(uint8_t girq, uint8_t enable)
+{
+	uint32_t girq_bitmap = BIT(girq);
+
+	return soc_ecia_girq_aggr_ctrl_bm(girq_bitmap, enable);
+}

--- a/soc/microchip/mec/common/soc_ecia.h
+++ b/soc/microchip/mec/common/soc_ecia.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief Microchip XEC MCU family EC Interrupt Aggregator support.
+ *
+ */
+
+#ifndef _MICROCHIP_MEC_SOC_ECIA_H_
+#define _MICROCHIP_MEC_SOC_ECIA_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <zephyr/arch/common/sys_bitops.h>
+
+/* zero based GIRQ numbering. 19 total GIRQ units in the aggregator */
+#define MCHP_MEC_ECIA_ZGIRQ_MAX 19
+
+/* Historically, GIRQ's have been numbered starting with 8 */
+#define MCHP_MEC_ECIA_GIRQ_FIRST 8
+#define MCHP_MEC_ECIA_GIRQ_LAST  26
+
+/* MEC ECIA GIRQ's are numbered 8 - 26 for historical reasons.
+ * GIRQ's 8 - 12, 22, 24 - 26 interrupt sources are only connected to the GIRQ source bits.
+ * GIRQ's 13 - 21, and 23 result bits can be connected to the NVIC.
+ */
+#define MCHP_MEC_ECIA_GIRQ_ALL_BM        GENMASK(26, 8)
+#define MCHP_MEC_ECIA_GIRQ_AGGR_ONLY_BM  (GENMASK(12, 8) | BIT(22) | GENMASK(26, 24))
+#define MCHP_MEC_ECIA_GIRQ_DIRECT_CAP_BM (GENMASK(21, 13) | BIT(23))
+
+enum mchp_mec_ecia_girq {
+	MCHP_MEC_ECIA_GIRQ8 = MCHP_MEC_ECIA_GIRQ_FIRST,
+	MCHP_MEC_ECIA_GIRQ9,
+	MCHP_MEC_ECIA_GIRQ10,
+	MCHP_MEC_ECIA_GIRQ11,
+	MCHP_MEC_ECIA_GIRQ12,
+	MCHP_MEC_ECIA_GIRQ13,
+	MCHP_MEC_ECIA_GIRQ14,
+	MCHP_MEC_ECIA_GIRQ15,
+	MCHP_MEC_ECIA_GIRQ16,
+	MCHP_MEC_ECIA_GIRQ17,
+	MCHP_MEC_ECIA_GIRQ18,
+	MCHP_MEC_ECIA_GIRQ19,
+	MCHP_MEC_ECIA_GIRQ20,
+	MCHP_MEC_ECIA_GIRQ21,
+	MCHP_MEC_ECIA_GIRQ22,
+	MCHP_MEC_ECIA_GIRQ23,
+	MCHP_MEC_ECIA_GIRQ24,
+	MCHP_MEC_ECIA_GIRQ25,
+	MCHP_MEC_ECIA_GIRQ26,
+	MCHP_MEC_ECIA_GIRQ_MAX,
+};
+
+#define MCHP_MEC_ECIA_INIT_CLR_ENABLES 0x01u
+#define MCHP_MEC_ECIA_INIT_CLR_STATUS  0x02u
+
+int soc_ecia_init(uint32_t aggr_girq_bm, uint32_t direct_girq_bm, uint32_t flags);
+
+int soc_ecia_girq_ctrl_bm(uint8_t girq, uint32_t bitmap, uint8_t enable);
+int soc_ecia_girq_ctrl(uint8_t girq, uint8_t srcpos, uint8_t enable);
+
+uint32_t soc_ecia_girq_get_enable_bm(uint8_t girq);
+
+int soc_ecia_girq_status_clear_bm(uint8_t girq, uint32_t bitmap);
+int soc_ecia_girq_status_clear(uint8_t girq, uint8_t srcpos);
+
+int soc_ecia_girq_status(uint8_t girq, uint32_t *status);
+int soc_ecia_girq_result(uint8_t girq, uint32_t *result);
+int soc_ecia_girq_is_result(uint8_t girq, uint32_t bitmap);
+
+int soc_ecia_girq_aggr_ctrl_bm(uint32_t girq_bitmap, uint8_t enable);
+int soc_ecia_girq_aggr_ctrl(uint8_t girq, uint8_t enable);
+
+#endif /* _MICROCHIP_MEC_SOC_ECIA_H_ */

--- a/soc/microchip/mec/common/soc_mmcr.h
+++ b/soc/microchip/mec/common/soc_mmcr.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025 Microchip Technology Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @file
+ * @brief Microchip MEC MCU family memory mapped control register access
+ *
+ */
+
+#ifndef _SOC_MICROCHIP_MEC_COMMON_MMCR_H_
+#define _SOC_MICROCHIP_MEC_COMMON_MMCR_H_
+
+#include <zephyr/sys/sys_io.h> /* mem_addr_t definition */
+
+/* Zephyr only provides 32-bit version of these routines. We need these for memory
+ * mapped control registers located on 16 and 8 bit address boundaries.
+ */
+
+static ALWAYS_INLINE void soc_set_bit8(mem_addr_t addr, unsigned int bit)
+{
+	uint8_t temp = *(volatile uint8_t *)addr;
+
+	*(volatile uint8_t *)addr = temp | (1U << bit);
+}
+
+static ALWAYS_INLINE void soc_clear_bit8(mem_addr_t addr, unsigned int bit)
+{
+	uint8_t temp = *(volatile uint8_t *)addr;
+
+	*(volatile uint8_t *)addr = temp & ~(1U << bit);
+}
+
+static ALWAYS_INLINE int soc_test_bit8(mem_addr_t addr, unsigned int bit)
+{
+	uint8_t temp = *(volatile uint8_t *)addr;
+
+	return temp & (1U << bit);
+}
+
+static ALWAYS_INLINE void soc_set_bits8(mem_addr_t addr, unsigned int mask)
+{
+	uint8_t temp = *(volatile uint8_t *)addr;
+
+	*(volatile uint8_t *)addr = temp | mask;
+}
+
+static ALWAYS_INLINE void soc_clear_bits8(mem_addr_t addr, unsigned int mask)
+{
+	uint8_t temp = *(volatile uint8_t *)addr;
+
+	*(volatile uint8_t *)addr = temp & ~mask;
+}
+
+static ALWAYS_INLINE int soc_test_and_set_bit8(mem_addr_t addr, unsigned int bit)
+{
+	int ret;
+
+	ret = soc_test_bit8(addr, bit);
+	soc_set_bit8(addr, bit);
+
+	return ret;
+}
+
+static ALWAYS_INLINE int soc_test_and_clear_bit8(mem_addr_t addr, unsigned int bit)
+{
+	int ret;
+
+	ret = soc_test_bit8(addr, bit);
+	soc_clear_bit8(addr, bit);
+
+	return ret;
+}
+
+static ALWAYS_INLINE void soc_set_bit16(mem_addr_t addr, unsigned int bit)
+{
+	uint16_t temp = *(volatile uint16_t *)addr;
+
+	*(volatile uint16_t *)addr = temp | (1U << bit);
+}
+
+static ALWAYS_INLINE void soc_clear_bit16(mem_addr_t addr, unsigned int bit)
+{
+	uint16_t temp = *(volatile uint16_t *)addr;
+
+	*(volatile uint16_t *)addr = temp & ~(1U << bit);
+}
+
+static ALWAYS_INLINE int soc_test_bit16(mem_addr_t addr, unsigned int bit)
+{
+	uint16_t temp = *(volatile uint16_t *)addr;
+
+	return temp & (1U << bit);
+}
+
+static ALWAYS_INLINE void soc_set_bits16(mem_addr_t addr, unsigned int mask)
+{
+	uint16_t temp = *(volatile uint16_t *)addr;
+
+	*(volatile uint16_t *)addr = temp | mask;
+}
+
+static ALWAYS_INLINE void soc_clear_bits16(mem_addr_t addr, unsigned int mask)
+{
+	uint16_t temp = *(volatile uint16_t *)addr;
+
+	*(volatile uint16_t *)addr = temp & ~mask;
+}
+
+static ALWAYS_INLINE int soc_test_and_set_bit16(mem_addr_t addr, unsigned int bit)
+{
+	int ret;
+
+	ret = soc_test_bit16(addr, bit);
+	soc_set_bit16(addr, bit);
+
+	return ret;
+}
+
+static ALWAYS_INLINE int soc_test_and_clear_bit16(mem_addr_t addr, unsigned int bit)
+{
+	int ret;
+
+	ret = soc_test_bit16(addr, bit);
+	soc_clear_bit16(addr, bit);
+
+	return ret;
+}
+
+#endif /* SOC_MICROCHIP_MEC_COMMON_MMCR_H_ */

--- a/soc/microchip/mec/mec15xx/soc.c
+++ b/soc/microchip/mec/mec15xx/soc.c
@@ -12,41 +12,6 @@
 #include <zephyr/arch/cpu.h>
 #include <cmsis_core.h>
 
-/*
- * Initialize MEC1501 EC Interrupt Aggregator (ECIA) and external NVIC
- * inputs.
- */
-static int soc_ecia_init(void)
-{
-	GIRQ_Type *pg;
-	uint32_t n;
-
-	mchp_pcr_periph_slp_ctrl(PCR_ECIA, MCHP_PCR_SLEEP_DIS);
-
-	ECS_REGS->INTR_CTRL |= MCHP_ECS_ICTRL_DIRECT_EN;
-
-	/* gate off all aggregated outputs */
-	ECIA_REGS->BLK_EN_CLR = 0xFFFFFFFFul;
-	/* gate on GIRQ's that are aggregated only */
-	ECIA_REGS->BLK_EN_SET = MCHP_ECIA_AGGR_BITMAP;
-
-	/* Clear all GIRQn source enables and source status */
-	pg = &ECIA_REGS->GIRQ08;
-	for (n = MCHP_FIRST_GIRQ; n <= MCHP_LAST_GIRQ; n++) {
-		pg->EN_CLR = 0xFFFFFFFFul;
-		pg->SRC = 0xFFFFFFFFul;
-		pg++;
-	}
-
-	/* Clear all external NVIC enables and pending status */
-	for (n = 0u; n < MCHP_NUM_NVIC_REGS; n++) {
-		NVIC->ICER[n] = 0xFFFFFFFFul;
-		NVIC->ICPR[n] = 0xFFFFFFFFul;
-	}
-
-	return 0;
-}
-
 static void configure_debug_interface(void)
 {
 	/* No debug support */
@@ -75,11 +40,12 @@ void soc_early_init_hook(void)
 {
 	uint32_t isave;
 
-
 	isave = __get_PRIMASK();
 	__disable_irq();
 
-	soc_ecia_init();
+	configure_debug_interface();
+
+	soc_ecia_init(MCHP_MEC_ECIA_GIRQ_AGGR_ONLY_BM, MCHP_MEC_ECIA_GIRQ_DIRECT_CAP_BM, 0);
 
 	/* Configure GPIO bank before usage
 	 * VTR1 is not configurable
@@ -88,8 +54,6 @@ void soc_early_init_hook(void)
 #ifdef CONFIG_SOC_MEC1501_VTR3_1_8V
 	ECS_REGS->GPIO_BANK_PWR |= MCHP_ECS_VTR3_LVL_18;
 #endif
-
-	configure_debug_interface();
 
 	if (!isave) {
 		__enable_irq();

--- a/soc/microchip/mec/mec15xx/soc.h
+++ b/soc/microchip/mec/mec15xx/soc.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __MEC_SOC_H
-#define __MEC_SOC_H
+#ifndef __SOC_MICROCHIP_MEC_MEC15XX_SOC_H
+#define __SOC_MICROCHIP_MEC_MEC15XX_SOC_H
 
 #define SYSCLK_DEFAULT_IOSC_HZ MHZ(48)
 
@@ -15,16 +15,18 @@
 #include "regaccess.h"
 
 /* common SoC API */
-#include "../common/soc_dt.h"
-#include "../common/soc_gpio.h"
-#include "../common/soc_pcr.h"
-#include "../common/soc_pins.h"
-#include "../common/soc_espi_channels.h"
-#include "soc_espi_saf_v1.h"
+#include <soc_dt.h>
+#include <soc_ecia.h>
+#include <soc_espi_channels.h>
+#include <soc_gpio.h>
+#include <soc_mmcr.h>
+#include <soc_pcr.h>
+#include <soc_pins.h>
 
 /* common peripheral register defines */
-#include "../common/reg/mec_gpio.h"
+#include <reg/mec_gpio.h>
+
+#include "soc_espi_saf_v1.h"
 
 #endif
-
 #endif

--- a/soc/microchip/mec/mec172x/soc.c
+++ b/soc/microchip/mec/mec172x/soc.c
@@ -40,6 +40,6 @@ static void configure_debug_interface(void)
 
 void soc_early_init_hook(void)
 {
-
 	configure_debug_interface();
+	soc_ecia_init(MCHP_MEC_ECIA_GIRQ_AGGR_ONLY_BM, MCHP_MEC_ECIA_GIRQ_DIRECT_CAP_BM, 0);
 }

--- a/soc/microchip/mec/mec172x/soc.h
+++ b/soc/microchip/mec/mec172x/soc.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __MEC_SOC_H
-#define __MEC_SOC_H
+#ifndef __SOC_MICROCHIP_MEC_MEC172X_SOC_H
+#define __SOC_MICROCHIP_MEC_MEC172X_SOC_H
 
 #ifndef _ASMLANGUAGE
 
@@ -246,7 +246,7 @@ typedef enum {
 
 #include <zephyr/sys/util.h>
 
-/* chip specific register defines */
+/* local chip specific register defines */
 #include "reg/mec172x_defs.h"
 #include "reg/mec172x_ecia.h"
 #include "reg/mec172x_ecs.h"
@@ -262,33 +262,34 @@ typedef enum {
 #include "reg/mec172x_emi.h"
 
 /* common peripheral register defines */
-#include "../common/reg/mec_acpi_ec.h"
-#include "../common/reg/mec_adc.h"
-#include "../common/reg/mec_global_cfg.h"
-#include "../common/reg/mec_kbc.h"
-#include "../common/reg/mec_keyscan.h"
-#include "../common/reg/mec_peci.h"
-#include "../common/reg/mec_ps2.h"
-#include "../common/reg/mec_pwm.h"
-#include "../common/reg/mec_tach.h"
-#include "../common/reg/mec_tfdp.h"
-#include "../common/reg/mec_timers.h"
-#include "../common/reg/mec_uart.h"
-#include "../common/reg/mec_vci.h"
-#include "../common/reg/mec_wdt.h"
-#include "../common/reg/mec_gpio.h"
+#include <reg/mec_acpi_ec.h>
+#include <reg/mec_adc.h>
+#include <reg/mec_global_cfg.h>
+#include <reg/mec_kbc.h>
+#include <reg/mec_keyscan.h>
+#include <reg/mec_peci.h>
+#include <reg/mec_ps2.h>
+#include <reg/mec_pwm.h>
+#include <reg/mec_tach.h>
+#include <reg/mec_tfdp.h>
+#include <reg/mec_timers.h>
+#include <reg/mec_uart.h>
+#include <reg/mec_vci.h>
+#include <reg/mec_wdt.h>
+#include <reg/mec_gpio.h>
 
 /* common SoC API */
-#include "../common/soc_dt.h"
-#include "../common/soc_gpio.h"
-#include "../common/soc_pcr.h"
-#include "../common/soc_pins.h"
-#include "../common/soc_espi_channels.h"
-#include "../common/soc_i2c.h"
+#include <soc_dt.h>
+#include <soc_ecia.h>
+#include <soc_espi_channels.h>
+#include <soc_gpio.h>
+#include <soc_i2c.h>
+#include <soc_mmcr.h>
+#include <soc_pcr.h>
+#include <soc_pins.h>
 
 /* MEC172x SAF V2 */
 #include "soc_espi_saf_v2.h"
 
 #endif
-
 #endif

--- a/soc/microchip/mec/mec174x/soc.h
+++ b/soc/microchip/mec/mec174x/soc.h
@@ -4,22 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __MEC5_SOC_H
-#define __MEC5_SOC_H
+#ifndef __SOC_MICROCHIP_MEC_MEC174X_SOC_H
+#define __SOC_MICROCHIP_MEC_MEC174X_SOC_H
 
 #define SYSCLK_DEFAULT_IOSC_HZ MHZ(96)
 
 #ifndef _ASMLANGUAGE
 
-#include "device_mec5.h"
+#include <device_mec5.h>
 
 /* common SoC API */
-#include "soc_dt.h"
-#include "soc_espi_channels.h"
-#include "soc_gpio.h"
-#include "soc_pcr.h"
-#include "soc_pins.h"
+#include <soc_dt.h>
+#include <soc_ecia.h>
+#include <soc_espi_channels.h>
+#include <soc_gpio.h>
+#include <soc_mmcr.h>
+#include <soc_pcr.h>
+#include <soc_pins.h>
 
 #endif
-
 #endif

--- a/soc/microchip/mec/mec175x/soc.h
+++ b/soc/microchip/mec/mec175x/soc.h
@@ -4,22 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __MEC5_SOC_H
-#define __MEC5_SOC_H
+#ifndef __SOC_MICROCHIP_MEC_MEC175X_SOC_H
+#define __SOC_MICROCHIP_MEC_MEC175X_SOC_H
 
 #define SYSCLK_DEFAULT_IOSC_HZ MHZ(96)
 
 #ifndef _ASMLANGUAGE
 
-#include "device_mec5.h"
+#include <device_mec5.h>
 
 /* common SoC API */
-#include "soc_dt.h"
-#include "soc_espi_channels.h"
-#include "soc_gpio.h"
-#include "soc_pcr.h"
-#include "soc_pins.h"
+#include <soc_dt.h>
+#include <soc_ecia.h>
+#include <soc_espi_channels.h>
+#include <soc_gpio.h>
+#include <soc_mmcr.h>
+#include <soc_pcr.h>
+#include <soc_pins.h>
 
 #endif
-
 #endif

--- a/soc/microchip/mec/mech172x/soc.h
+++ b/soc/microchip/mec/mech172x/soc.h
@@ -4,22 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef __MEC5_SOC_H
-#define __MEC5_SOC_H
+#ifndef __SOC_MICROCHIP_MEC_MECH172X_SOC_H
+#define __SOC_MICROCHIP_MEC_MECH172X_SOC_H
 
 #define SYSCLK_DEFAULT_IOSC_HZ MHZ(96)
 
 #ifndef _ASMLANGUAGE
 
-#include "device_mec5.h"
+#include <device_mec5.h>
 
 /* common SoC API */
-#include "soc_dt.h"
-#include "soc_espi_channels.h"
-#include "soc_gpio.h"
-#include "soc_pcr.h"
-#include "soc_pins.h"
+#include <soc_dt.h>
+#include <soc_ecia.h>
+#include <soc_espi_channels.h>
+#include <soc_gpio.h>
+#include <soc_mmcr.h>
+#include <soc_pcr.h>
+#include <soc_pins.h>
 
 #endif
-
 #endif


### PR DESCRIPTION
We added ECIA GIRQ get/set/clear functions avaiable for all MEC parts. Drivers can make use of these functions to get, set, and clear GIRQ status and enables for their peripheral. In cases where code requires 8/16 bit access to these or other SoC registers we added inline helpers modeled after Zephyr's 32-bit sys_read/write/test routines. This commit is part of a long term goal to share drivers among all the MEC parts.