### PR TITLE
drivers: sensor: add common UNIQUE_ID attribute and first driver support (SHT4X) 

### DIFF
--- a/drivers/sensor/sensirion/sht4x/sht4x.h
+++ b/drivers/sensor/sensirion/sht4x/sht4x.h
@@ -14,6 +14,7 @@
 
 #define SHT4X_RESET_WAIT_MS	1
 #define SHT4X_POR_WAIT_MS	1
+#define SHT4X_CMD_WAIT_MS	1
 
 #define SHT4X_HEATER_POWER_IDX_MAX	3
 #define SHT4X_HEATER_DURATION_IDX_MAX	2
@@ -35,6 +36,7 @@ struct sht4x_data {
 	uint16_t rh_sample;
 	uint8_t heater_power;
 	uint8_t heater_duration;
+	uint32_t unique_id;
 };
 
 static const uint8_t measure_cmd[3] = {

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -360,6 +360,12 @@ enum sensor_attribute {
 	SENSOR_ATTR_GAIN,
 	/* Configure the resolution of a sensor. */
 	SENSOR_ATTR_RESOLUTION,
+	/** Factory-programmed unique identifier.
+	 * Any sensor that exposes a fixed 32-/48-/64-bit chip/lot/serial number
+	 * can report it through this attribute.  The value is returned in a
+	 * single sensor_value using the helper `sensor_value_from_uid`.
+	 */
+	SENSOR_ATTR_UNIQUE_ID,
 	/**
 	 * Number of all common sensor attributes.
 	 */
@@ -1551,6 +1557,32 @@ static inline int sensor_value_from_micro(struct sensor_value *val, int64_t micr
 	val->val1 = (int32_t)(micro / 1000000LL);
 	val->val2 = (int32_t)(micro % 1000000LL);
 
+	return 0;
+}
+
+/**
+ * @brief Helper function for converting struct sensor_value to uint64_t UID.
+ *
+ * @param val A pointer to a sensor_value struct.
+ * @return The converted value.
+ */
+static inline uint64_t sensor_value_to_uid(const struct sensor_value *val)
+{
+	/* Cast through uint32_t to avoid sign-extension on the shift. */
+	return ((uint64_t)(uint32_t)val->val1 << 32) | (uint32_t)val->val2;
+}
+
+/**
+ * @brief Helper function for converting uint64_t UID to struct sensor_value.
+ *
+ * @param val A pointer to a sensor_value struct.
+ * @param inp The converted value.
+ * @return 0 (always succeeds).
+ */
+static inline int sensor_value_from_uid(struct sensor_value *val, uint64_t inp)
+{
+	val->val1 = (int32_t)(inp >> 32);
+	val->val2 = (int32_t)inp;
 	return 0;
 }
 

--- a/samples/sensor/sht4x/src/main.c
+++ b/samples/sensor/sht4x/src/main.c
@@ -18,7 +18,7 @@
 int main(void)
 {
 	const struct device *const sht = DEVICE_DT_GET_ANY(sensirion_sht4x);
-	struct sensor_value temp, hum;
+	struct sensor_value temp, hum, uid;
 
 	if (!device_is_ready(sht)) {
 		printf("Device %s is not ready.\n", sht->name);
@@ -34,6 +34,10 @@ int main(void)
 	sensor_attr_set(sht, SENSOR_CHAN_ALL, SENSOR_ATTR_SHT4X_HEATER_POWER, &heater_p);
 	sensor_attr_set(sht, SENSOR_CHAN_ALL, SENSOR_ATTR_SHT4X_HEATER_DURATION, &heater_d);
 #endif
+
+	if (!sensor_attr_get(sht, SENSOR_CHAN_ALL, SENSOR_ATTR_UNIQUE_ID, &uid)) {
+		printf("SHT4X UID: 0x%" PRIx64 "\n", sensor_value_to_uid(&uid));
+	}
 
 	while (true) {
 		if (sensor_sample_fetch(sht)) {

--- a/tests/drivers/sensor/generic/src/main.c
+++ b/tests/drivers/sensor/generic/src/main.c
@@ -393,6 +393,12 @@ ZTEST(sensor_api, test_sensor_unit_conversion)
 			"the result does not match");
 	zassert_equal(sensor_value_to_micro(&data), 5432109876543LL,
 			"the result does not match");
+	/* Test UID helpers (round-trip) */
+	sensor_value_from_uid(&data, 0x0123456789ABCDEFULL);
+	zassert_equal(sensor_value_to_uid(&data), 0x0123456789ABCDEFULL,
+			"the result does not match");
+	zassert_equal(data.val1, 0x01234567, "the data does not match");
+	zassert_equal(data.val2, (int32_t)0x89ABCDEF, "the data does not match");
 }
 
 ZTEST_SUITE(sensor_api, NULL, NULL, ztest_simple_1cpu_before, ztest_simple_1cpu_after, NULL);


### PR DESCRIPTION
Every time a board can host swap-in sensor modules you eventually need to know which physical device is on the bus so you can tie sensor-health data to the right unit. This is especially useful for IoT controllers with plug-and-play external sensors: a probe might be unplugged from one device, plugged into another, yet you still want its lifetime metrics to stay consistent in the cloud.

This series introduces SENSOR_ATTR_UNIQUE_ID, a single attribute any driver can expose to return the factory-programmed serial or chip ID. Because a serial number never changes, it belongs in the attribute namespace, so existing user code can simply call sensor_attr_get().

For 32-, 48-, or 64-bit IDs the new header helpers pack the value into struct sensor_value. The patch shows the full path by adding support to the SHT4x driver and printing the ID in the sample app.

This covers sensors whose serial fits into sensor_value; devices that return long ASCII strings will still need an extension, but the current change keeps the API minimal while solving the most common use-case today.

Tested on a custom board with nrf54l15 + SHT4X