### PR TITLE
docs: update cmsis rtos and cmake cache link

### DIFF
--- a/doc/develop/application/index.rst
+++ b/doc/develop/application/index.rst
@@ -599,10 +599,11 @@ storage used to cache values between runs, including compile and build
 options and paths to library dependencies. This cache file is created
 when CMake is run in an empty build folder.
 
-For more details about the CMakeCache.txt file see the official CMake
-documentation `runningcmake`_ .
+For more details about the CMakeCache.txt file see the official `CMake Cache`_
+documentation.
 
-.. _runningcmake: https://cmake.org/runningcmake/
+.. _CMake Cache: https://cmake.org/cmake/help/book/mastering-cmake/chapter/CMake%20Cache.html
+
 
 Application Configuration
 *************************

--- a/doc/services/portability/cmsis_rtos_v1.rst
+++ b/doc/services/portability/cmsis_rtos_v1.rst
@@ -7,5 +7,5 @@ Cortex-M Software Interface Standard (CMSIS) RTOS is a vendor-independent
 hardware abstraction layer for the ARM Cortex-M processor series and defines
 generic tool interfaces. Though it was originally defined for ARM Cortex-M
 microcontrollers alone, it could be easily extended to other microcontrollers
-making it generic. For more information on CMSIS RTOS v1, please refer
-https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html
+making it generic. For more information on CMSIS RTOS v1, please refer to the
+`CMSIS-RTOS1 Documentation <https://arm-software.github.io/CMSIS_5/latest/RTOS/html/index.html>`_.

--- a/doc/services/portability/cmsis_rtos_v2.rst
+++ b/doc/services/portability/cmsis_rtos_v2.rst
@@ -8,7 +8,7 @@ hardware abstraction layer for the ARM Cortex-M processor series and defines
 generic tool interfaces. Though it was originally defined for ARM Cortex-M
 microcontrollers alone, it could be easily extended to other microcontrollers
 making it generic. For more information on CMSIS RTOS v2, please refer to the
-`CMSIS-RTOS2 Documentation <https://www.keil.com/pack/doc/CMSIS/RTOS2/html/index.html>`_.
+`CMSIS-RTOS2 Documentation <https://arm-software.github.io/CMSIS_6/latest/RTOS2/index.html>`_.
 
 Features not supported in Zephyr implementation
 ***********************************************


### PR DESCRIPTION
- CMSIS RTOS v1: link to the dedicated page in arm-software cmsis 5 docs
  - the old link was forwarded to the overview page of CMSIS v6
- CMSIS RTOS v2: link to the dedicated page in arm-software cmsis 6 docs
  - the old link was forwarded to the overview page of CMSIS v6

- CMake Cache: link to the mastering cmake - cmake cache section
  - the old link was forwarded to the generic https://cmake.org/resources/