### PR TITLE
testsuite: optional limiting of coverage dumps

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -95,6 +95,15 @@ config COVERAGE_DUMP
 
 endchoice
 
+config COVERAGE_DUMP_PATH_EXCLUDE
+	string "Exclude files matching this pattern from the coverage data"
+	default ""
+	help
+	  Filenames are matched against the pattern using the POSIX fnmatch
+	  function. Filenames are based on their path in the build folder, not the
+	  original source tree. The empty string "" disables the pattern
+	  matching.
+
 endif # COVERAGE_GCOV
 
 config FORCE_COVERAGE

--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <string.h>
+#include <fnmatch.h>
 #include "coverage.h"
 
 K_HEAP_DEFINE(gcov_heap, CONFIG_COVERAGE_GCOV_HEAP_SIZE);
@@ -315,6 +316,11 @@ void gcov_coverage_dump(void)
 	}
 	printk("\nGCOV_COVERAGE_DUMP_START");
 	while (gcov_list) {
+		if ((strlen(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE) > 0) &&
+		    (fnmatch(CONFIG_COVERAGE_DUMP_PATH_EXCLUDE, gcov_list->filename, 0) == 0)) {
+			/* Don't print a note here, it would be interpreted as dump data */
+			goto file_dump_end;
+		}
 
 		dump_on_console_start(gcov_list->filename);
 		size = gcov_calculate_buff_size(gcov_list);
@@ -334,6 +340,7 @@ void gcov_coverage_dump(void)
 		dump_on_console_data(buffer, size);
 
 		k_heap_free(&gcov_heap, buffer);
+file_dump_end:
 		gcov_list = gcov_list->next;
 		if (gcov_list_first == gcov_list) {
 			goto coverage_dump_end;


### PR DESCRIPTION
Add an option that excludes generation of a given path of `.gcda` files when running coverage testing. This can be useful when running testing coverage on downstream repos, which would otherwise result in large `.gcda` files for paths we don't care about filling up the disk.

The issue triggering this PR was huge portions of coverage dumps for my downstream repo being just MbedTLS data, which was ignored at the next processing step due to `--coverage-basedir`. The dumped data ended up being so large that something between QEMU and `handler.log` was having trouble actually saving it all, leading to test failures due to "GCOV_COVERAGE_DUMP_END" not being found in the file.