### PR TITLE
dts: adi: Add wut nodes to MAX32 SoCs that have wake-up timers

### DIFF
--- a/drivers/counter/counter_max32_wut.c
+++ b/drivers/counter/counter_max32_wut.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT adi_max32_wut
 
 #include <zephyr/drivers/counter.h>
+#include <zephyr/dt-bindings/clock/adi_max32_clock.h>
 #include <zephyr/irq.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>

--- a/dts/arm/adi/max32/max32655.dtsi
+++ b/dts/arm/adi/max32/max32655.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -148,6 +148,18 @@
 			clocks = <&gcr ADI_MAX32_CLOCK_BUS1 13>;
 			interrupts = <67 0>;
 			status = "disabled";
+		};
+
+		wut0: timer@40006400 {
+			compatible = "adi,max32-timer";
+			reg = <0x40006400 0x400>;
+			interrupts = <53 0>;
+			status = "disabled";
+			prescaler = <1>;
+			counter {
+				compatible = "adi,max32-wut";
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/adi/max32/max32666.dtsi
+++ b/dts/arm/adi/max32/max32666.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Analog Devices, Inc.
+ * Copyright (c) 2023-2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -187,6 +187,18 @@
 			};
 			power-delay-ms = <1500>;
 			clocks = <&gcr ADI_MAX32_CLOCK_BUS1 10>;
+		};
+
+		wut0: timer@40006400 {
+			compatible = "adi,max32-timer";
+			reg = <0x40006400 0x400>;
+			interrupts = <53 0>;
+			status = "disabled";
+			prescaler = <1>;
+			counter {
+				compatible = "adi,max32-wut";
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/adi/max32/max32680.dtsi
+++ b/dts/arm/adi/max32/max32680.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -130,6 +130,18 @@
 			clocks = <&gcr ADI_MAX32_CLOCK_BUS1 13>;
 			interrupts = <67 0>;
 			status = "disabled";
+		};
+
+		wut0: timer@40006400 {
+			compatible = "adi,max32-timer";
+			reg = <0x40006400 0x400>;
+			interrupts = <53 0>;
+			status = "disabled";
+			prescaler = <1>;
+			counter {
+				compatible = "adi,max32-wut";
+				status = "disabled";
+			};
 		};
 	};
 };

--- a/dts/arm/adi/max32/max32690.dtsi
+++ b/dts/arm/adi/max32/max32690.dtsi
@@ -282,5 +282,29 @@
 			interrupts = <108 0>;
 			clocks = <&gcr ADI_MAX32_CLOCK_BUS1 19>;
 		};
+
+		wut0: timer@40006400 {
+			compatible = "adi,max32-timer";
+			reg = <0x40006400 0x200>;
+			interrupts = <53 0>;
+			status = "disabled";
+			prescaler = <1>;
+			counter {
+				compatible = "adi,max32-wut";
+				status = "disabled";
+			};
+		};
+
+		wut1: timer@40006600 {
+			compatible = "adi,max32-timer";
+			reg = <0x40006600 0x200>;
+			interrupts = <109 0>;
+			status = "disabled";
+			prescaler = <1>;
+			counter {
+				compatible = "adi,max32-wut";
+				status = "disabled";
+			};
+		};
 	};
 };

--- a/dts/arm/adi/max32/max78002.dtsi
+++ b/dts/arm/adi/max32/max78002.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Analog Devices, Inc.
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -206,6 +206,18 @@
 			clocks = <&gcr ADI_MAX32_CLOCK_BUS1 13>;
 			interrupts = <67 0>;
 			status = "disabled";
+		};
+
+		wut0: timer@40006400 {
+			compatible = "adi,max32-timer";
+			reg = <0x40006400 0x400>;
+			interrupts = <53 0>;
+			status = "disabled";
+			prescaler = <1>;
+			counter {
+				compatible = "adi,max32-wut";
+				status = "disabled";
+			};
 		};
 	};
 };


### PR DESCRIPTION
Adds Wake-up Timer nodes to MAX32 SoCs that have Wake-up Timers. 

- MAX32655
- MAX32666
- MAX32680
- MAX32690
- MAX78002