### PR TITLE
lorawan: Imply soft-se instead of selecting it

### DIFF
--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -9,7 +9,7 @@ menuconfig LORAWAN
 	depends on SYSTEM_WORKQUEUE_STACK_SIZE >= 2048
 	select REQUIRES_FULL_LIBC
 	select HAS_SEMTECH_LORAMAC
-	select HAS_SEMTECH_SOFT_SE
+	imply HAS_SEMTECH_SOFT_SE
 	select EXPERIMENTAL
 	help
 	  This option enables LoRaWAN support.


### PR DESCRIPTION
This allows the software secure enclave to be changed to a different implementation, which currently is not possible