### PR TITLE
soc: snps: rmx: replace custom buildlib with generic RMX linker option

### DIFF
--- a/cmake/linker/arcmwdt/linker_flags.cmake
+++ b/cmake/linker/arcmwdt/linker_flags.cmake
@@ -5,7 +5,6 @@
 set_property(TARGET linker PROPERTY cpp_base -Hcplus)
 
 check_set_linker_property(TARGET linker PROPERTY baremetal
-                          -Hlld
                           -Hnosdata
                           -Xtimer0 # to suppress the warning message
                           -Hnoxcheck_obj
@@ -15,6 +14,12 @@ check_set_linker_property(TARGET linker PROPERTY baremetal
                           -Hnoivt
                           -Hnocrt
 )
+
+if(CONFIG_ARC)
+  check_set_linker_property(TARGET linker APPEND PROPERTY baremetal
+                            -Hlld
+  )
+endif()
 
 # There are two options:
 # - We have full MWDT libc support and we link MWDT libc - this is default

--- a/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
+++ b/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
@@ -6,7 +6,7 @@ if(COMPILER STREQUAL arcmwdt)
 					-av5rmx -Zicsr -Zifencei -Zihintpause -Zba -Zbb
 					-Zbs -Zca -Zcb -Zcmp -Zcmt -Za -Zm -Zicbom)
 
-  zephyr_ld_options(-Hlib=rmx100)
+  zephyr_ld_options(-av5rmx)
 endif()
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")


### PR DESCRIPTION
Do not use the custom buildlib configuration for the RMX series as it was replaced with several even more specific configurations in the recent MWDT release. Pass the generic RMX series option to the linker instead, and, to make it work, don't pass -Hlld to the linker if the architecture is not ARC.

Fixes #94037
