### PR TITLE
[v4.2-branch] west: Update picolibc to version being proposed for SDK 0.17.4

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -343,7 +343,7 @@ manifest:
         - debug
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 560946f26db075c296beea5b39d99e6de43c9010
+      revision: ca8b6ebba5226a75545e57a140443168a26ba664
     - name: segger
       revision: cf56b1d9c80f81a26e2ac5727c9cf177116a4692
       path: modules/debug/segger


### PR DESCRIPTION
We're trying to re-synchronize picolibc bits across Zephyr and the Zephyr SDK. At this point, SDK 0.17.3 is missing some minor updates found in the module and the module is missing a commit from the SDK.

SDK PR: https://github.com/zephyrproject-rtos/sdk-ng/pull/991

Fixes #94774 