### PR TITLE
tests: application_development: ram_context_for_isr: allow more inter…

### DIFF
--- a/tests/application_development/ram_context_for_isr/include/fake_driver.h
+++ b/tests/application_development/ram_context_for_isr/include/fake_driver.h
@@ -34,7 +34,7 @@ typedef void (*fake_driver_irq_callback_t)(const struct device *dev, void *user_
 
 struct fake_driver_config {
 	void (*irq_config_func)(void);
-	uint8_t irq_num;
+	uint16_t irq_num;
 	uint8_t irq_priority;
 };
 


### PR DESCRIPTION
…rupts

Make possible to build test for platforms with more than 256 interrupts. Fixes: fake_driver.h:29:23: error: unsigned conversion from 'int' to 'unsigned char' changes value from '270' to '14' [-Werror=overflow] (from nrf54l15dk/nrf54l15/cpuapp)