### PR TITLE
doc: migration guide: Bluetooth: Add guide for target latency and PHY

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -52,6 +52,17 @@ Bluetooth
 
 .. zephyr-keep-sorted-start re(^\w)
 
+Bluetooth Audio
+===============
+
+* :c:struct:`bt_audio_codec_cfg` now requires setting the target latency and target PHY explicitly,
+  rather than always setting the target latency to "Balanced" and the target PHY to LE 2M.
+  To keep current functionality, set the ``target_latency`` to
+  :c:enumerator:`BT_AUDIO_CODEC_CFG_TARGET_LATENCY_BALANCED` and ``target_phy`` to
+  :c:enumerator:`BT_AUDIO_CODEC_CFG_TARGET_PHY_2M`.
+  The :c:macro:`BT_AUDIO_CODEC_CFG` macro defaults to these values.
+  (:github:`93825``)
+
 .. zephyr-keep-sorted-stop
 
 Ethernet


### PR DESCRIPTION
Some applications may need to modify their code to account for the changes to struct bt_audio_codec_cfg.