### PR TITLE
pm: device_runtime: put_sync_locked: fix usage count on err

### DIFF
--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -318,6 +318,7 @@ static int put_sync_locked(const struct device *dev)
 	if (pm->base.usage == 0U) {
 		ret = pm->base.action_cb(dev, PM_DEVICE_ACTION_SUSPEND);
 		if (ret < 0) {
+			pm->base.usage++;
 			return ret;
 		}
 		pm->base.state = PM_DEVICE_STATE_SUSPENDED;

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -42,6 +42,8 @@ void test_api_setup(void *data)
 	int ret;
 	enum pm_device_state state;
 
+	test_driver_pm_retval(test_dev, 0);
+
 	/* check API always returns 0 when runtime PM is disabled */
 	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
@@ -107,6 +109,12 @@ ZTEST(device_runtime_api, test_api)
 
 	/*** get + put ***/
 
+	/* usage: 0, 0, resume: no */
+	test_driver_pm_retval(test_dev, -EIO);
+	ret = pm_device_runtime_get(test_dev);
+	zassert_equal(ret, -EIO);
+	test_driver_pm_retval(test_dev, 0);
+
 	/* usage: 0, +1, resume: yes */
 	ret = pm_device_runtime_get(test_dev);
 	zassert_equal(ret, 0);
@@ -125,6 +133,12 @@ ZTEST(device_runtime_api, test_api)
 
 	(void)pm_device_state_get(test_dev, &state);
 	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
+
+	/* usage: 1, 0, suspend: no */
+	test_driver_pm_retval(test_dev, -EIO);
+	ret = pm_device_runtime_put(test_dev);
+	zassert_equal(ret, -EIO);
+	test_driver_pm_retval(test_dev, 0);
 
 	/* usage: 1, -1, suspend: yes */
 	ret = pm_device_runtime_put(test_dev);

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.c
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.c
@@ -14,6 +14,7 @@ struct test_driver_data {
 	bool ongoing;
 	bool async;
 	struct k_sem sync;
+	int ret;
 };
 
 static int test_driver_action(const struct device *dev,
@@ -34,7 +35,7 @@ static int test_driver_action(const struct device *dev,
 
 	data->count++;
 
-	return 0;
+	return data->ret;
 }
 
 void test_driver_pm_async(const struct device *dev)
@@ -63,6 +64,13 @@ size_t test_driver_pm_count(const struct device *dev)
 	struct test_driver_data *data = dev->data;
 
 	return data->count;
+}
+
+void test_driver_pm_retval(const struct device *dev, int ret)
+{
+	struct test_driver_data *data = dev->data;
+
+	data->ret = ret;
 }
 
 int test_driver_init(const struct device *dev)

--- a/tests/subsys/pm/device_runtime_api/src/test_driver.h
+++ b/tests/subsys/pm/device_runtime_api/src/test_driver.h
@@ -45,4 +45,13 @@ bool test_driver_pm_ongoing(const struct device *dev);
  */
 size_t test_driver_pm_count(const struct device *dev);
 
+/**
+ * @brief Configure the return value of pm actions.
+ *
+ * @param dev Device instance.
+ *
+ * @return The number of state changes the device made.
+ */
+void test_driver_pm_retval(const struct device *dev, int ret);
+
 #endif /* TESTS_SUBSYS_PM_DEVICE_RUNTIME_TEST_DRIVER_H_ */


### PR DESCRIPTION
If pm action fails within put_sync_locked, usage count should be reset to reflect the state of the device.