### PR TITLE
tests: Bluetooth: Tester: Add missing target latency and PHY

### DIFF
--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -1340,6 +1340,8 @@ uint8_t btp_ascs_configure_codec(const void *cmd, uint16_t cmd_len, void *rsp, u
 
 	memset(&codec_cfg, 0, sizeof(codec_cfg));
 
+	codec_cfg.target_latency = BT_AUDIO_CODEC_CFG_TARGET_LATENCY_BALANCED;
+	codec_cfg.target_phy = BT_AUDIO_CODEC_CFG_TARGET_PHY_2M;
 	codec_cfg.id = cp->coding_format;
 	codec_cfg.vid = cp->vid;
 	codec_cfg.cid = cp->cid;

--- a/tests/bluetooth/tester/src/audio/btp_cap.c
+++ b/tests/bluetooth/tester/src/audio/btp_cap.c
@@ -293,6 +293,8 @@ static uint8_t btp_cap_unicast_setup_ase(const void *cmd, uint16_t cmd_len,
 	qos.pd = sys_get_le24(cp->presentation_delay);
 
 	memset(&codec_cfg, 0, sizeof(codec_cfg));
+	codec_cfg.target_latency = BT_AUDIO_CODEC_CFG_TARGET_LATENCY_BALANCED;
+	codec_cfg.target_phy = BT_AUDIO_CODEC_CFG_TARGET_PHY_2M;
 	codec_cfg.id = cp->coding_format;
 	codec_cfg.vid = cp->vid;
 	codec_cfg.cid = cp->cid;


### PR DESCRIPTION
The struct bt_audio_codec_cfg recently got new fields that previously defaulted to
BT_AUDIO_CODEC_CFG_TARGET_LATENCY_BALANCED and
BT_AUDIO_CODEC_CFG_TARGET_PHY_2M but was not set by the BTP commands.

For now we restore the previous functionality by setting the values to the same as we did before, until the BTP commands are changed (if they are changed).