### PR TITLE
samples: modules: lvgl: Add Kconfig guard for LV_Z_DEMO_RENDER

### DIFF
--- a/samples/modules/lvgl/demos/Kconfig
+++ b/samples/modules/lvgl/demos/Kconfig
@@ -48,6 +48,8 @@ config LV_Z_DEMO_RENDER
 
 endchoice
 
+if LV_Z_DEMO_RENDER
+
 config LV_Z_DEMO_RENDER_SCENE_DYNAMIC
 	bool "Switch scenes dynamically"
 	help
@@ -67,5 +69,7 @@ config LV_Z_DEMO_RENDER_DYNAMIC_SCENE_TIMEOUT
 	default 3
 	help
 	  Seconds each rendered scenar is shown
+
+endif
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
Add a guard to the Kconfig symbols that are available for the render demo.