### PR TITLE
drivers: wifi: siwx91x: Add compile-time support for setting max TX power

### DIFF
--- a/drivers/wifi/siwx91x/siwx91x_wifi.c
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.c
@@ -182,9 +182,21 @@ bool siwx91x_param_changed(struct wifi_iface_status *prev_params,
 	return false;
 }
 
+static int siwx91x_set_max_tx_power(const struct siwx91x_config *siwx91x_cfg)
+{
+	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
+	sl_wifi_max_tx_power_t max_tx_power = {
+		.scan_tx_power = siwx91x_cfg->scan_tx_power,
+		.join_tx_power = siwx91x_cfg->join_tx_power,
+	};
+
+	return sl_wifi_set_max_tx_power(interface, max_tx_power);
+}
+
 static int siwx91x_mode(const struct device *dev, struct wifi_mode_info *mode)
 {
 	sl_wifi_interface_t interface = sl_wifi_get_default_interface();
+	const struct siwx91x_config *siwx91x_cfg = dev->config;
 	struct siwx91x_dev *sidev = dev->data;
 	int cur_mode;
 	int ret = 0;
@@ -203,6 +215,12 @@ static int siwx91x_mode(const struct device *dev, struct wifi_mode_info *mode)
 			ret = siwx91x_nwp_mode_switch(mode->mode, false, 0);
 			if (ret < 0) {
 				return ret;
+			}
+
+			ret = siwx91x_set_max_tx_power(siwx91x_cfg);
+			if (ret != SL_STATUS_OK) {
+				LOG_ERR("Failed to set max tx power:%x", ret);
+				return -EINVAL;
 			}
 		}
 		sidev->state = WIFI_STATE_INACTIVE;
@@ -350,6 +368,7 @@ static int siwx91x_get_version(const struct device *dev, struct wifi_version *pa
 
 static void siwx91x_iface_init(struct net_if *iface)
 {
+	const struct siwx91x_config *siwx91x_cfg = iface->if_dev->dev->config;
 	struct siwx91x_dev *sidev = iface->if_dev->dev->data;
 	int ret;
 
@@ -365,6 +384,12 @@ static void siwx91x_iface_init(struct net_if *iface)
 			     sidev);
 	sl_wifi_set_callback(SL_WIFI_STATS_RESPONSE_EVENTS, siwx91x_wifi_module_stats_event_handler,
 			     sidev);
+
+	ret = siwx91x_set_max_tx_power(siwx91x_cfg);
+	if (ret != SL_STATUS_OK) {
+		LOG_ERR("Failed to set max tx power:%x", ret);
+		return;
+	}
 
 	ret = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, &sidev->macaddr);
 	if (ret) {
@@ -416,6 +441,11 @@ static const struct net_wifi_mgmt_offload siwx91x_api = {
 	.wifi_mgmt_api = &siwx91x_mgmt,
 };
 
+static const struct siwx91x_config siwx91x_cfg = {
+	.scan_tx_power = DT_INST_PROP(0, wifi_max_tx_pwr_scan),
+	.join_tx_power = DT_INST_PROP(0, wifi_max_tx_pwr_join),
+};
+
 static struct siwx91x_dev sidev = {
 	.ps_params.enabled = WIFI_PS_DISABLED,
 	.ps_params.exit_strategy = WIFI_PS_EXIT_EVERY_TIM,
@@ -424,9 +454,9 @@ static struct siwx91x_dev sidev = {
 };
 
 #ifdef CONFIG_WIFI_SILABS_SIWX91X_NET_STACK_NATIVE
-ETH_NET_DEVICE_DT_INST_DEFINE(0, siwx91x_dev_init, NULL, &sidev, NULL,
+ETH_NET_DEVICE_DT_INST_DEFINE(0, siwx91x_dev_init, NULL, &sidev, &siwx91x_cfg,
 			      CONFIG_WIFI_INIT_PRIORITY, &siwx91x_api, NET_ETH_MTU);
 #else
-NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, siwx91x_dev_init, NULL, &sidev, NULL,
+NET_DEVICE_DT_INST_OFFLOAD_DEFINE(0, siwx91x_dev_init, NULL, &sidev, &siwx91x_cfg,
 				  CONFIG_WIFI_INIT_PRIORITY, &siwx91x_api, NET_ETH_MTU);
 #endif

--- a/drivers/wifi/siwx91x/siwx91x_wifi.h
+++ b/drivers/wifi/siwx91x/siwx91x_wifi.h
@@ -9,6 +9,11 @@
 
 #include "sl_si91x_types.h"
 
+struct siwx91x_config {
+	uint8_t scan_tx_power;
+	uint8_t join_tx_power;
+};
+
 struct siwx91x_dev {
 	struct net_if *iface;
 	sl_mac_address_t macaddr;

--- a/dts/bindings/wifi/silabs,siwx91x-wifi.yaml
+++ b/dts/bindings/wifi/silabs,siwx91x-wifi.yaml
@@ -5,3 +5,19 @@
 description: Silabs SiWx91x SoC WiFi
 
 compatible: "silabs,siwx91x-wifi"
+
+properties:
+  wifi-max-tx-pwr-scan:
+    type: int
+    default: 31
+    description: |
+      Maximum TX power (in dBm) used during Wi‑Fi scanning. Actual
+      output may be capped by regulatory or hardware constraints.
+      Note: SiWx91x firmware does **not** support per‑rate power.
+  wifi-max-tx-pwr-join:
+    type: int
+    default: 31
+    description: |
+      Maximum TX power (in dBm) used when joining a Wi‑Fi network.
+      Actual output may be capped by regulatory or hardware constraints.
+      Note: SiWx91x firmware does **not** support per‑rate power.


### PR DESCRIPTION
Added support for configuring maximum transmit power for STA and AP modes at compile time using Kconfig, since Zephyr does not support runtime configuration for this via a standard API.