### PR TITLE
modules: lvgl: API mutex

### DIFF
--- a/modules/lvgl/Kconfig
+++ b/modules/lvgl/Kconfig
@@ -158,9 +158,15 @@ config LV_Z_INIT_PRIORITY
 	help
 	  Priority used for the automatic initialization of LVGL.
 
+config LV_Z_LVGL_MUTEX
+	bool "Provide LVGL API mutex (un)locking functions"
+	help
+	  LVGL API functions are not thread-safe, provide functions for locking and unlocking.
+
 config LV_Z_RUN_LVGL_ON_WORKQUEUE
 	bool "Use a dedicated workqueue to run LVGL core"
 	imply LV_Z_AUTO_INIT
+	imply LV_Z_LVGL_MUTEX
 	help
 	  Runs the LVGL in a separate workqueue automatically
 	  without requiring user to add a timed loop for that. User can

--- a/modules/lvgl/include/lvgl_zephyr.h
+++ b/modules/lvgl/include/lvgl_zephyr.h
@@ -32,7 +32,7 @@ extern "C" {
  */
 int lvgl_init(void);
 
-#ifdef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
+#if defined(CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE) || defined(__DOXYGEN__)
 /**
  * @brief Gets the instance of LVGL's workqueue
  *

--- a/modules/lvgl/include/lvgl_zephyr.h
+++ b/modules/lvgl/include/lvgl_zephyr.h
@@ -46,6 +46,58 @@ struct k_work_q *lvgl_get_workqueue(void);
 
 #endif /* CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE */
 
+
+#if (defined(CONFIG_LV_Z_LVGL_MUTEX) && !defined(CONFIG_LV_Z_USE_OSAL)) || defined(__DOXYGEN__)
+/**
+ * @brief Lock internal mutex before accessing LVGL API.
+ *
+ * @details LVGL API is not thread-safe. Therefore, before accessing any
+ * API function, you need to lock the internal mutex, to prevent the
+ * LVGL thread from pre-empting the API call.
+ */
+void lvgl_lock(void);
+
+/**
+ * @brief Try to lock internal mutex before accessing LVGL API.
+ *
+ * @details This function behaves like lvgl_lock(), provided that
+ * the internal mutex is unlocked. Otherwise, it returns false without
+ * waiting.
+ */
+bool lvgl_trylock(void);
+
+/**
+ * @brief Unlock internal mutex after accessing LVGL API.
+ */
+void lvgl_unlock(void);
+
+#elif defined(CONFIG_LV_Z_LVGL_MUTEX) && defined(CONFIG_LV_Z_USE_OSAL)
+
+#include <osal/lv_os.h>
+
+static inline void lvgl_lock(void)
+{
+	lv_lock();
+}
+
+static inline bool lvgl_trylock(void)
+{
+	return lv_lock_isr() == LV_RESULT_OK;
+}
+
+static inline void lvgl_unlock(void)
+{
+	lv_unlock();
+}
+
+#else /* CONFIG_LV_Z_LVGL_MUTEX */
+
+#define lvgl_lock(...) (void)0
+#define lvgl_trylock(...) true
+#define lvgl_unlock(...) (void)0
+
+#endif /* CONFIG_LV_Z_LVGL_MUTEX */
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/lvgl/lvgl.c
+++ b/modules/lvgl/lvgl.c
@@ -227,7 +227,11 @@ static struct k_work_q lvgl_workqueue;
 static void lvgl_timer_handler_work(struct k_work *work)
 {
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
-	uint32_t wait_time = lv_timer_handler();
+	uint32_t wait_time;
+
+	lvgl_lock();
+	wait_time = lv_timer_handler();
+	lvgl_unlock();
 
 	/* schedule next timer verification */
 	if (wait_time == LV_NO_TIMER_READY) {
@@ -243,6 +247,27 @@ struct k_work_q *lvgl_get_workqueue(void)
 	return &lvgl_workqueue;
 }
 #endif /* CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE */
+
+#if defined(CONFIG_LV_Z_LVGL_MUTEX) && !defined(CONFIG_LV_Z_USE_OSAL)
+
+static K_MUTEX_DEFINE(lvgl_mutex);
+
+void lvgl_lock(void)
+{
+	(void)k_mutex_lock(&lvgl_mutex, K_FOREVER);
+}
+
+bool lvgl_trylock(void)
+{
+	return k_mutex_lock(&lvgl_mutex, K_NO_WAIT) == 0;
+}
+
+void lvgl_unlock(void)
+{
+	(void)k_mutex_unlock(&lvgl_mutex);
+}
+
+#endif /* CONFIG_LV_Z_LVGL_MUTEX */
 
 void lv_mem_init(void)
 {

--- a/samples/modules/lvgl/demos/src/main.c
+++ b/samples/modules/lvgl/demos/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/display.h>
 #include <lvgl.h>
 #include <lvgl_mem.h>
+#include <lvgl_zephyr.h>
 #include <lv_demos.h>
 #include <stdio.h>
 
@@ -28,6 +29,8 @@ int main(void)
 		LOG_ERR("Device not ready, aborting test");
 		return 0;
 	}
+
+	lvgl_lock();
 
 #if defined(CONFIG_LV_Z_DEMO_MUSIC)
 	lv_demo_music();
@@ -56,6 +59,7 @@ int main(void)
 #ifndef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
 	lv_timer_handler();
 #endif
+	lvgl_unlock();
 
 	display_blanking_off(display_dev);
 #ifdef CONFIG_LV_Z_MEM_POOL_SYS_HEAP
@@ -65,7 +69,12 @@ int main(void)
 #endif
 	while (1) {
 #ifndef CONFIG_LV_Z_RUN_LVGL_ON_WORKQUEUE
-		uint32_t sleep_ms = lv_timer_handler();
+		uint32_t sleep_ms;
+
+		lvgl_lock();
+		sleep_ms = lv_timer_handler();
+		lvgl_unlock();
+
 		k_msleep(MIN(sleep_ms, INT32_MAX));
 #else
 		/* LVGL managed by dedicated workqueue, just put an application side delay */
@@ -74,7 +83,9 @@ int main(void)
 #ifdef CONFIG_LV_Z_DEMO_RENDER_SCENE_DYNAMIC
 		if (sys_timepoint_expired(next_scene_switch)) {
 			cur_scene = (cur_scene + 1) % LV_DEMO_RENDER_SCENE_NUM;
+			lvgl_lock();
 			lv_demo_render(cur_scene, 255);
+			lvgl_unlock();
 			next_scene_switch = sys_timepoint_calc(
 				K_SECONDS(CONFIG_LV_Z_DEMO_RENDER_DYNAMIC_SCENE_TIMEOUT));
 		}


### PR DESCRIPTION
~~If LVGL uses a work queue thread, we can't call LVGL functions from the main thread. Use a `k_event` variable to signal between threads.~~

Alternatively, the LVGL thread could use an actual locking mechanism and we could expose `lvgl_lock/lvgl_unlock` to the users, WDYT @faxe1008 @uLipe ?

EDIT: Updated by adding locking API functions.