### PR TITLE
iar: ltorg directive not supported

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -569,7 +569,9 @@ void arch_switch_to_main_thread(struct k_thread *main_thread, char *stack_ptr,
 			 /* We don’t intend to return, so there is no need to link. */
 			 "bx    r4\n"
 			 /* Force a literal pool placement for the addresses referenced above */
+#ifndef __IAR_SYSTEMS_ICC__
 			 ".ltorg\n"
+#endif
 			 :
 			 : "r"(_main), "r"(stack_ptr)
 			 : "r0", "r1", "r2", "r3", "r4", "ip", "lr", "memory");
@@ -637,7 +639,9 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(k_thread_entry_t main_
 		"blx r0\n"
 		"loop: b loop\n\t" /* while (true); */
 		/* Force a literal pool placement for the addresses referenced above */
+#ifndef __IAR_SYSTEMS_ICC__
 		".ltorg\n"
+#endif
 		:
 		: [_p1] "r"(p1), [_p2] "r"(p2), [_p3] "r"(p3), [_psp] "r"(psp),
 		  [_main_entry] "r"(main_entry)


### PR DESCRIPTION
Introduced by d7d3ae5c3b06617bce8d6c2ebcc99d4355ce94d9
Currently this directive is not supported in EWARM 9.70.1, it will be in future versions, but we want Zephyr 4.2 to work with IAR EWARM 9.70.1.

A more proper solution would be moving inline assembly to separate assembly files, which will greatly help portability. but is also a bigger project than just working-around this.

