### PR TITLE
Bluetooth: AICS: Remove bad check in handle_set_gain_op

### DIFF
--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -293,8 +293,7 @@ static uint8_t handle_set_gain_op(struct bt_aics *inst, const struct bt_aics_gai
 		return BT_AICS_ERR_OUT_OF_RANGE;
 	}
 
-	if (BT_AICS_INPUT_MODE_SETTABLE(inst->srv.state.gain_mode) &&
-	    inst->srv.state.gain != cp->gain_setting) {
+	if (inst->srv.state.gain != cp->gain_setting) {
 		inst->srv.state.gain = cp->gain_setting;
 		*state_change = true;
 	}

--- a/subsys/bluetooth/audio/aics_internal.h
+++ b/subsys/bluetooth/audio/aics_internal.h
@@ -41,9 +41,6 @@
 #define BT_AICS_INPUT_MODE_IMMUTABLE(gain_mode) \
 	((gain_mode) == BT_AICS_MODE_MANUAL_ONLY || (gain_mode) == BT_AICS_MODE_AUTO_ONLY)
 
-#define BT_AICS_INPUT_MODE_SETTABLE(gain_mode) \
-	((gain_mode) == BT_AICS_MODE_AUTO || (gain_mode) == BT_AICS_MODE_MANUAL)
-
 struct bt_aics_control {
 	uint8_t opcode;
 	uint8_t counter;


### PR DESCRIPTION
AICS gain mode does not prevent local nor remote operations from changing the gain setting value. The gain setting value shall simply be ignored if in the BT_AICS_MODE_AUTO_ONLY or BT_AICS_MODE_AUTO modes, but the local application and remote devices can still modify the gain setting value.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/94050