### PR TITLE
MAINTAINERS: use common label for the Bouffalo Lab platform areas

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -700,7 +700,7 @@ Bouffalolab Platforms:
     - dts/bindings/*/bflb,*
     - soc/bflb/
   labels:
-    - "platform: bouffalolab"
+    - "platform: Bouffalo Lab"
 
 Broadcom Platforms:
   status: odd fixes


### PR DESCRIPTION
Use a common label for the Bouffalo Lab platform areas.