### PR TITLE
drivers: wifi: nrf_wifi: add NULL check in parse_sband

### DIFF
--- a/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
+++ b/drivers/wifi/nrf_wifi/src/wpa_supp_if.c
@@ -1516,7 +1516,7 @@ enum nrf_wifi_status nrf_wifi_parse_sband(
 {
 	int count;
 
-	if (event && (event->nrf_wifi_n_bitrates == 0 || event->nrf_wifi_n_channels == 0)) {
+	if (event == NULL || (event->nrf_wifi_n_bitrates == 0 || event->nrf_wifi_n_channels == 0)) {
 		return NRF_WIFI_STATUS_FAIL;
 	}
 	memset(band, 0, sizeof(*band));


### PR DESCRIPTION
Ensure event is not NULL before accessing its members in nrf_wifi_parse_sband().

This adds a defensive check to avoid potential null dereference and ensures the function returns early when event data is invalid (i.e., zero channels or bitrates).