### PR TITLE
stm32: samples: drivers: i2s: output: board: update nucleo_u385rg_q sa1 pins node

### DIFF
--- a/samples/drivers/i2s/output/boards/nucleo_u385rg_q.overlay
+++ b/samples/drivers/i2s/output/boards/nucleo_u385rg_q.overlay
@@ -9,17 +9,11 @@
 	aliases {
 		i2s-tx = &sai1_a;
 	};
-
-	chosen {
-		zephyr,console = &lpuart1;
-		zephyr,shell-uart = &lpuart1;
-	};
 };
 
 /* 46.875KHz (6.29% Error) */
 &sai1_a {
-	pinctrl-0 = <&sai1_mclk_a_pb8 &sai1_sd_a_pc1
-		     &sai1_fs_a_pa9 &sai1_sck_a_pb10>;
+	pinctrl-0 = <&sai1_mclk_a_pb8 &sai1_sd_a_pc3 &sai1_fs_a_pb9 &sai1_sck_a_pb10>;
 	pinctrl-names = "default";
 	status = "okay";
 	mclk-enable;
@@ -33,12 +27,4 @@
 
 &clk_msik {
 	status = "okay";
-};
-
-&i2c3 {
-	status = "disabled";
-};
-
-&usart1 {
-	status = "disabled";
 };


### PR DESCRIPTION
This PR adds changes related to an issue observed in the I2S output test on the NUCLEO_U385RG_Q.

See here for more details :  https://github.com/zephyrproject-rtos/zephyr/pull/92575#issuecomment-3150664447 


required:  https://github.com/zephyrproject-rtos/hal_stm32/pull/301 