### PR TITLE
tests: Bluetooth: CAP: Add unittest for bt_cap_handover_[un]register

### DIFF
--- a/tests/bluetooth/audio/cap_handover/CMakeLists.txt
+++ b/tests/bluetooth/audio/cap_handover/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(app PRIVATE
 
 target_sources(app PRIVATE
   # Test source files
+  src/callbacks.c
   src/unicast_to_broadcast.c
   src/test_common.c
 

--- a/tests/bluetooth/audio/cap_handover/src/callbacks.c
+++ b/tests/bluetooth/audio/cap_handover/src/callbacks.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stddef.h>
+
+#include <zephyr/bluetooth/audio/cap.h>
+#include <zephyr/fff.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/ztest_assert.h>
+#include <zephyr/ztest_test.h>
+
+#include "cap_handover.h"
+#include "test_common.h"
+
+static void cap_handover_callbacks_test_suite_after(void *f)
+{
+	int err;
+
+	ARG_UNUSED(f);
+
+	err = bt_cap_handover_unregister_cb(&mock_cap_handover_cb);
+	zassert_true(err == 0 || err == -EINVAL, "Unexpected error: %d", err);
+}
+
+ZTEST_SUITE(cap_handover_callbacks_test_suite, NULL, NULL, NULL,
+	    cap_handover_callbacks_test_suite_after, NULL);
+
+static ZTEST(cap_handover_callbacks_test_suite, test_handover_register_cb)
+{
+	int err;
+
+	err = bt_cap_handover_register_cb(&mock_cap_handover_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+}
+
+static ZTEST(cap_handover_callbacks_test_suite, test_handover_register_cb_inval_param_null)
+{
+	int err;
+
+	err = bt_cap_handover_register_cb(NULL);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+static ZTEST(cap_handover_callbacks_test_suite, test_handover_register_cb_inval_double_register)
+{
+	int err;
+
+	err = bt_cap_handover_register_cb(&mock_cap_handover_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	err = bt_cap_handover_register_cb(&mock_cap_handover_cb);
+	zassert_equal(-EALREADY, err, "Unexpected return value %d", err);
+}
+
+static ZTEST(cap_handover_callbacks_test_suite, test_handover_unregister_cb)
+{
+	int err;
+
+	err = bt_cap_handover_register_cb(&mock_cap_handover_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	err = bt_cap_handover_unregister_cb(&mock_cap_handover_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+}
+
+static ZTEST(cap_handover_callbacks_test_suite, test_handover_unregister_cb_inval_param_null)
+{
+	int err;
+
+	err = bt_cap_handover_unregister_cb(NULL);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}
+
+static ZTEST(cap_handover_callbacks_test_suite, test_handover_unregister_cb_inval_double_unregister)
+{
+	int err;
+
+	err = bt_cap_handover_register_cb(&mock_cap_handover_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	err = bt_cap_handover_unregister_cb(&mock_cap_handover_cb);
+	zassert_equal(0, err, "Unexpected return value %d", err);
+
+	err = bt_cap_handover_unregister_cb(&mock_cap_handover_cb);
+	zassert_equal(-EINVAL, err, "Unexpected return value %d", err);
+}


### PR DESCRIPTION
Add unittests for the bt_cap_handover_register_cb and bt_cap_handover_unregister_cb functions.