### PR TITLE
drivers: mspi: mspi_dw: support configuration of TXD_DRIVE_EDGE setting

### DIFF
--- a/drivers/mspi/Kconfig.dw
+++ b/drivers/mspi/Kconfig.dw
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
+# Copyright (c) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 config MSPI_DW
@@ -7,3 +8,23 @@ config MSPI_DW
 	depends on DT_HAS_SNPS_DESIGNWARE_SSI_ENABLED
 	select PINCTRL if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_SSI),pinctrl-0)
 	imply MSPI_XIP
+
+if MSPI_DW
+
+config MSPI_DW_TXD_DIV
+	int "Designware SSI TX Drive edge divisor"
+	default 4
+	help
+	  Division factor to apply to calculated BAUDR value when writing it
+	  to the TXD_DRIVE_EDGE register in DDR mode. Note that the maximum
+	  value of this register is (BAUDR / 2) - 1.
+
+config MSPI_DW_TXD_MUL
+	int "Designware SSI TX Drive edge multiplier"
+	default 1
+	help
+	  Multiplication factor to apply to calculated BAUDR value when writing
+	  it to the TXD_DRIVE_EDGE register in DDR mode. Note that the maximum
+	  value of this register is (BAUDR / 2) - 1.
+
+endif # MSPI_DW

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -956,7 +956,10 @@ static int start_next_packet(const struct device *dev, k_timeout_t timeout)
 	write_rx_sample_dly(dev, dev_data->rx_sample_dly);
 	if (dev_data->spi_ctrlr0 & (SPI_CTRLR0_SPI_DDR_EN_BIT |
 				    SPI_CTRLR0_INST_DDR_EN_BIT)) {
-		write_txd_drive_edge(dev, dev_data->baudr / 4);
+		int txd = (CONFIG_MSPI_DW_TXD_MUL * dev_data->baudr) /
+			CONFIG_MSPI_DW_TXD_DIV;
+
+		write_txd_drive_edge(dev, txd);
 	} else {
 		write_txd_drive_edge(dev, 0);
 	}


### PR DESCRIPTION
TXD_DRIVE_EDGE setting will typically be set to BAUDR/4 for DDR mode, but this may not cover all cases. Add a configurable multiplier and divisor to apply to the BAUDR value so the value's relation to BAUDR can be customized.