### PR TITLE
boards: adi: Corrected `ram` metadata based on chosen RAM bank.

### DIFF
--- a/boards/adi/ad_swiot1l_sl/ad_swiot1l_sl.yaml
+++ b/boards/adi/ad_swiot1l_sl/ad_swiot1l_sl.yaml
@@ -9,5 +9,5 @@ toolchain:
 supported:
   - gpio
   - serial
-ram: 1024
+ram: 32
 flash: 3072

--- a/boards/adi/apard32690/apard32690_max32690_m4.yaml
+++ b/boards/adi/apard32690/apard32690_max32690_m4.yaml
@@ -20,5 +20,5 @@ supported:
   - counter
   - w1
   - memc
-ram: 1024
+ram: 128
 flash: 3072

--- a/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.yaml
+++ b/boards/adi/eval_adin1110ebz/adi_eval_adin1110ebz.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 640
+ram: 192
 flash: 2048
 supported:
   - arduino_gpio

--- a/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.yaml
+++ b/boards/adi/eval_adin2111ebz/adi_eval_adin2111ebz.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 640
+ram: 192
 flash: 2048
 supported:
   - gpio

--- a/boards/adi/max32650evkit/max32650evkit.yaml
+++ b/boards/adi/max32650evkit/max32650evkit.yaml
@@ -15,5 +15,5 @@ supported:
   - watchdog
   - counter
   - rtc_counter
-ram: 1024
+ram: 256
 flash: 3072

--- a/boards/adi/max32650fthr/max32650fthr.yaml
+++ b/boards/adi/max32650fthr/max32650fthr.yaml
@@ -15,5 +15,5 @@ supported:
   - watchdog
   - counter
   - rtc_counter
-ram: 1024
+ram: 256
 flash: 3072

--- a/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
+++ b/boards/adi/max32655evkit/max32655evkit_max32655_m4.yaml
@@ -20,5 +20,5 @@ supported:
   - pwm
   - w1
   - flash
-ram: 128
+ram: 48
 flash: 512

--- a/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
+++ b/boards/adi/max32655fthr/max32655fthr_max32655_m4.yaml
@@ -19,5 +19,5 @@ supported:
   - rtc_counter
   - pwm
   - flash
-ram: 128
+ram: 48
 flash: 512

--- a/boards/adi/max32660evsys/max32660evsys.yaml
+++ b/boards/adi/max32660evsys/max32660evsys.yaml
@@ -9,5 +9,5 @@ toolchain:
 supported:
   - gpio
   - serial
-ram: 96
+ram: 32
 flash: 256

--- a/boards/adi/max32662evkit/max32662evkit.yaml
+++ b/boards/adi/max32662evkit/max32662evkit.yaml
@@ -20,5 +20,5 @@ supported:
   - pwm
   - flash
   - can
-ram: 80
+ram: 16
 flash: 256

--- a/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.yaml
+++ b/boards/adi/max32666evkit/max32666evkit_max32666_cpu0.yaml
@@ -19,5 +19,5 @@ supported:
   - pwm
   - w1
   - flash
-ram: 560
+ram: 128
 flash: 1024

--- a/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
+++ b/boards/adi/max32666fthr/max32666fthr_max32666_cpu0.yaml
@@ -21,5 +21,5 @@ supported:
   - w1
   - flash
   - sdhc
-ram: 560
+ram: 128
 flash: 1024

--- a/boards/adi/max32670evkit/max32670evkit.yaml
+++ b/boards/adi/max32670evkit/max32670evkit.yaml
@@ -18,5 +18,5 @@ supported:
   - rtc_counter
   - pwm
   - flash
-ram: 160
+ram: 64
 flash: 384

--- a/boards/adi/max32672evkit/max32672evkit.yaml
+++ b/boards/adi/max32672evkit/max32672evkit.yaml
@@ -19,5 +19,5 @@ supported:
   - rtc_counter
   - pwm
   - flash
-ram: 200
+ram: 64
 flash: 1024

--- a/boards/adi/max32672fthr/max32672fthr.yaml
+++ b/boards/adi/max32672fthr/max32672fthr.yaml
@@ -19,5 +19,5 @@ supported:
   - rtc_counter
   - pwm
   - flash
-ram: 200
+ram: 64
 flash: 1024

--- a/boards/adi/max32675evkit/max32675evkit.yaml
+++ b/boards/adi/max32675evkit/max32675evkit.yaml
@@ -15,5 +15,5 @@ supported:
   - spi
   - pwm
   - flash
-ram: 160
+ram: 64
 flash: 384

--- a/boards/adi/max32680evkit/max32680evkit_max32680_m4.yaml
+++ b/boards/adi/max32680evkit/max32680evkit_max32680_m4.yaml
@@ -18,5 +18,5 @@ supported:
   - counter
   - w1
   - flash
-ram: 128
+ram: 48
 flash: 512

--- a/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
+++ b/boards/adi/max32690evkit/max32690evkit_max32690_m4.yaml
@@ -23,5 +23,5 @@ supported:
   - usbd
   - memc
   - can
-ram: 1024
+ram: 128
 flash: 3072

--- a/boards/adi/max32690fthr/max32690fthr_max32690_m4.yaml
+++ b/boards/adi/max32690fthr/max32690fthr_max32690_m4.yaml
@@ -16,5 +16,5 @@ supported:
   - feather_spi
   - flash
   - usbd
-ram: 1024
+ram: 128
 flash: 3072

--- a/boards/adi/max78000evkit/max78000evkit_max78000_m4.yaml
+++ b/boards/adi/max78000evkit/max78000evkit_max78000_m4.yaml
@@ -19,5 +19,5 @@ supported:
   - trng
   - w1
   - watchdog
-ram: 128
+ram: 48
 flash: 512

--- a/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
+++ b/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
@@ -19,5 +19,5 @@ supported:
   - trng
   - w1
   - watchdog
-ram: 128
+ram: 48
 flash: 512

--- a/boards/adi/max78002evkit/max78002evkit_max78002_m4.yaml
+++ b/boards/adi/max78002evkit/max78002evkit_max78002_m4.yaml
@@ -20,5 +20,5 @@ supported:
   - pwm
   - w1
   - flash
-ram: 384
+ram: 64
 flash: 2560

--- a/boards/adi/sdp_k1/adi_sdp_k1.yaml
+++ b/boards/adi/sdp_k1/adi_sdp_k1.yaml
@@ -5,7 +5,7 @@ arch: arm
 toolchain:
   - zephyr
   - gnuarmemb
-ram: 384
+ram: 320
 flash: 2048
 supported:
   - gpio


### PR DESCRIPTION
Correct the boad YAML files for the ADI boards, using the correct RAM size based on the selected RAM bank, not the total RAM present on the given SoC.