### PR TITLE
drivers: counter: Fix MAX32 guard checks for max tick

### DIFF
--- a/drivers/counter/counter_max32_rtc.c
+++ b/drivers/counter/counter_max32_rtc.c
@@ -146,8 +146,8 @@ static int api_set_alarm(const struct device *dev, uint8_t chan,
 		ticks = 1;
 	}
 
-	if (alarm_cfg->ticks > api_get_top_value(dev)) {
-		return -EINVAL;
+	if (alarm_cfg->ticks >= api_get_top_value(dev)) {
+		return -ETIME;
 	}
 
 	if (data->alarm_callback != NULL) {

--- a/drivers/counter/counter_max32_timer.c
+++ b/drivers/counter/counter_max32_timer.c
@@ -157,8 +157,8 @@ static int api_set_alarm(const struct device *dev, uint8_t chan,
 	const struct max32_tmr_config *cfg = dev->config;
 	struct max32_tmr_ch_data *chdata = &cfg->ch_data[chan];
 
-	if (alarm_cfg->ticks > api_get_top_value(dev)) {
-		return -EINVAL;
+	if (alarm_cfg->ticks >= api_get_top_value(dev)) {
+		return -ETIME;
 	}
 
 	if (chdata->callback) {


### PR DESCRIPTION
Properly check for a tick matching the top value, and return the correct errno when detected.