### PR TITLE
tests: drivers: gpio: add overlay to run test on IFX kit_psc3m5_evk

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/kit_psc3m5_evk.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Infineon Technologies AG, or an affiliate of
+ * Infineon Technologies AG.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		out-gpios = <&gpio_prt3 0 0>;
+		in-gpios = <&gpio_prt3 1 0>;
+	};
+};


### PR DESCRIPTION
Adds an overlay to enable the GPIO api tests to run on the kit_psc3m5_evk board. GPIO 3.0 is used as an output, 3.1 is used as an input for the test and should be jumpered together.