### PR TITLE
tests: kernel: timer tests for kit_psc3m5_evk board

### DIFF
--- a/tests/kernel/common/boards/kit_psc3m5_evk.overlay
+++ b/tests/kernel/common/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,24 @@
+/*
+ *==================================================================================================
+ * Copyright (c) 2025 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *==================================================================================================
+ */
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};
+
+&slot0_partition {
+	label = "image-0";
+	reg = <0x12000000 DT_SIZE_K(150)>; /* 150k for secure test application */
+};
+
+&slot0_ns_partition {
+	label = "image-1";
+	reg = <0x2025800 DT_SIZE_K(106)>; /* 106k for nonsecure test application */
+};

--- a/tests/kernel/timer/timer_api/boards/kit_psc3m5_evk.overlay
+++ b/tests/kernel/timer/timer_api/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,24 @@
+/*
+ *==================================================================================================
+ * Copyright (c) 2025 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *==================================================================================================
+ */
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};
+
+&slot0_partition {
+	label = "image-0";
+	reg = <0x12000000 DT_SIZE_K(150)>; /* 150k for secure test application */
+};
+
+&slot0_ns_partition {
+	label = "image-1";
+	reg = <0x2025800 DT_SIZE_K(106)>; /* 106k for nonsecure test application */
+};

--- a/tests/kernel/timer/timer_error_case/boards/kit_psc3m5_evk.overlay
+++ b/tests/kernel/timer/timer_error_case/boards/kit_psc3m5_evk.overlay
@@ -1,0 +1,24 @@
+/*
+ *==================================================================================================
+ * Copyright (c) 2025 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *==================================================================================================
+ */
+
+/ {
+	chosen {
+		zephyr,code-partition = &slot0_partition;
+	};
+};
+
+&slot0_partition {
+	label = "image-0";
+	reg = <0x12000000 DT_SIZE_K(150)>; /* 150k for secure test application */
+};
+
+&slot0_ns_partition {
+	label = "image-1";
+	reg = <0x2025800 DT_SIZE_K(106)>; /* 106k for nonsecure test application */
+};


### PR DESCRIPTION
Adds overlays for Infineon kit_psc3m5_evk board to kernel/common, kernel/timer/timer_error_case and kernel/timer/timer_api tests when run in secure mode.  These tests require more memory than the board assigns to secure mode by default.