### PR TITLE
modules: systemview: Systemview section move to .dtcm_bss

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -348,7 +348,7 @@ manifest:
       path: modules/lib/picolibc
       revision: 560946f26db075c296beea5b39d99e6de43c9010
     - name: segger
-      revision: cf56b1d9c80f81a26e2ac5727c9cf177116a4692
+      revision: 9f08435a79d41133d7046b7c59d1b25929eda450
       path: modules/debug/segger
       groups:
         - debug


### PR DESCRIPTION
Move to dtcm.bss to reduce flash usage.
When increasing SEGGER_SYSVIEW_RTT_BUFFER_SIZE,
it will waste a large amount of flash space.