### PR TITLE
tracing: systemview: Add isr name for Segger-sysview

### DIFF
--- a/subsys/tracing/sysview/sysview_config.c
+++ b/subsys/tracing/sysview/sysview_config.c
@@ -7,6 +7,10 @@
 #include <zephyr/kernel.h>
 #include <SEGGER_SYSVIEW.h>
 #include <ksched.h>
+#ifdef CONFIG_SYMTAB
+#include <zephyr/debug/symtab.h>
+#include <zephyr/sw_isr_table.h>
+#endif
 
 extern const SEGGER_SYSVIEW_OS_API SYSVIEW_X_OS_TraceAPI;
 
@@ -53,6 +57,23 @@ static void cbSendSystemDesc(void)
 	SEGGER_SYSVIEW_SendSysDesc("D=" CONFIG_BOARD " "
 				   CONFIG_SOC_FAMILY " " CONFIG_ARCH);
 	SEGGER_SYSVIEW_SendSysDesc("O=Zephyr");
+
+#ifdef CONFIG_SYMTAB
+	char isr_desc[SEGGER_SYSVIEW_MAX_STRING_LEN];
+
+	for (int idx = 0; idx < IRQ_TABLE_SIZE; idx++) {
+		const struct _isr_table_entry *entry = &_sw_isr_table[idx];
+
+		if ((entry->isr == z_irq_spurious) || (entry->isr == NULL)) {
+			continue;
+		}
+		const char *name = symtab_find_symbol_name((uintptr_t)entry->isr, NULL);
+
+		snprintf(isr_desc, SEGGER_SYSVIEW_MAX_STRING_LEN, "I#%d=%s", idx + 16, name);
+
+		SEGGER_SYSVIEW_SendSysDesc(isr_desc);
+	}
+#endif
 }
 
 static void send_task_list_cb(void)


### PR DESCRIPTION
With symtab enabled, the isr name is collected by symbol table

This is particularly useful when the isr function names are meaningful.

Disadvantage: By default, SystemView only displays activated ISRs. This will display all the used ISRs. 

Inspiration comes from "isr_tables_shell.c"

test: west build -S rtt-tracing -b nucleo_h743zi/stm32h743xx samples/net/zperf/ --pristine

before:
[
<img width="710" height="120" alt="no_isr_name" src="https://github.com/user-attachments/assets/b85d904b-891e-4e8f-9059-08845b1a702d" />
](url)

after:
<img width="746" height="252" alt="has_isr_name" src="https://github.com/user-attachments/assets/997ff1b5-cc89-41fb-b20f-8df1eac134d2" />
