### PR TITLE
sensor: add SENSOR_CHAN_PM_4 enum value

### DIFF
--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -75,6 +75,7 @@ static const char *const sensor_channel_name[SENSOR_CHAN_COMMON_COUNT] = {
 	[SENSOR_CHAN_ALTITUDE] = "altitude",
 	[SENSOR_CHAN_PM_1_0] = "pm_1_0",
 	[SENSOR_CHAN_PM_2_5] = "pm_2_5",
+	[SENSOR_CHAN_PM_4] = "pm_4",
 	[SENSOR_CHAN_PM_10] = "pm_10",
 	[SENSOR_CHAN_DISTANCE] = "distance",
 	[SENSOR_CHAN_CO2] = "co2",

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -113,6 +113,8 @@ enum sensor_channel {
 	SENSOR_CHAN_PM_1_0,
 	/** 2.5 micro-meters Particulate Matter, in ug/m^3 */
 	SENSOR_CHAN_PM_2_5,
+	/** 4 micro-meters Particulate Matter, in ug/m^3 */
+	SENSOR_CHAN_PM_4,
 	/** 10 micro-meters Particulate Matter, in ug/m^3 */
 	SENSOR_CHAN_PM_10,
 	/** Distance. From sensor to target, in meters */


### PR DESCRIPTION
Adds enum value for 4um particulate matter
as seen in Sensirion's SEN6x

Signed-off-by: Kelly Helmut Lord <kellyhlord@gmail.com>
