### PR TITLE
tests: lib: cobs: Fix test setup failure with minimal libc

### DIFF
--- a/tests/lib/cobs/prj.conf
+++ b/tests/lib/cobs/prj.conf
@@ -1,2 +1,4 @@
 CONFIG_COBS=y
 CONFIG_ZTEST=y
+# cobs test needs some heap, but MINIMAL_LIBC has none by default.
+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256


### PR DESCRIPTION
Set CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=256 for COBS tests to ensure malloc() succeeds during test fixture allocation in cobs_test_setup().

When using minimal libc, CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE defaults to 0, causing malloc() to fail and the zassume_not_null(fixture) assertion to trigger test setup failure.

Fixes test execution with minimal libc configurations.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/94108