### PR TITLE
soc: nordic: Use default SYS_CLOCK_TICKS_PER_SEC for PPR core

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
@@ -6,8 +6,6 @@ if SOC_NRF54H20_CPUPPR
 config NUM_IRQS
 	default 496
 
-config SYS_CLOCK_TICKS_PER_SEC
-	default 1000
 #
 # As PPR has limited memory most of tests does not fit with asserts enabled.
 config ASSERT

--- a/soc/nordic/nrf92/Kconfig.defconfig.nrf9280_cpuppr
+++ b/soc/nordic/nrf92/Kconfig.defconfig.nrf9280_cpuppr
@@ -6,9 +6,6 @@ if SOC_NRF9280_CPUPPR
 config NUM_IRQS
 	default 496
 
-config SYS_CLOCK_TICKS_PER_SEC
-	default 1000
-
 config RV_BOOT_HART
 	default 13 if SOC_NRF9230_ENGB
 


### PR DESCRIPTION
PPR was using 1 kHz system clock frequency instead of default 31250 Hz used on other cores with GRTC. Low frequency impacts system clock accuracy. There is no reason to use different frequency for PPR.