### PR TITLE
test_dma_loop: Fix fail with dma_mcux_lpc

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -33,6 +33,7 @@ struct dma_mcux_lpc_config {
 	uint32_t otrig_base_address;
 	uint32_t itrig_base_address;
 	uint8_t num_of_channels;
+	uint8_t num_of_allocated_channels;
 	uint8_t num_of_otrigs;
 	void (*irq_config_func)(const struct device *dev);
 };
@@ -482,6 +483,12 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 
 	/* If needed, allocate a slot to store dma channel data */
 	if (dma_data->channel_index[channel] == -1) {
+		/* Not enough items in channel data array */
+		if (dma_data->num_channels_used >= dev_config->num_of_allocated_channels) {
+			LOG_ERR("No free DMA channels available");
+			return -ENOMEM;
+		}
+
 		dma_data->channel_index[channel] = dma_data->num_channels_used;
 		dma_data->num_channels_used++;
 		/* Get the slot number that has the dma channel data */
@@ -944,6 +951,7 @@ static DEVICE_API(dma, dma_mcux_lpc_api) = {
 static const struct dma_mcux_lpc_config dma_##n##_config = {		\
 	.base = (DMA_Type *)DT_INST_REG_ADDR(n),			\
 	.num_of_channels = DT_INST_PROP(n, dma_channels),		\
+	.num_of_allocated_channels = DMA_MCUX_LPC_NUM_USED_CHANNELS(n),	\
 	.num_of_otrigs = DT_INST_PROP_OR(n, nxp_dma_num_of_otrigs, 0),			\
 	.otrig_base_address = DT_INST_PROP_OR(n, nxp_dma_otrig_base_address, 0x0),	\
 	.itrig_base_address = DT_INST_PROP_OR(n, nxp_dma_itrig_base_address, 0x0),	\

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -169,6 +169,8 @@ static int test_loop(const struct device *dma)
 		}
 	}
 
+	dma_release_channel(dma, chan_id);
+
 	TC_PRINT("Finished DMA: %s\n", dma->name);
 	return TC_PASS;
 }
@@ -313,6 +315,8 @@ static int test_loop_suspend_resume(const struct device *dma)
 			return TC_FAIL;
 		}
 	}
+
+	dma_release_channel(dma, chan_id);
 
 	TC_PRINT("Finished DMA: %s\n", dma->name);
 	return TC_PASS;
@@ -467,6 +471,8 @@ static int test_loop_repeated_start_stop(const struct device *dma)
 		TC_PRINT("ERROR: repeated transfer stop (%d)\n", chan_id);
 		return TC_FAIL;
 	}
+
+	dma_release_channel(dma, chan_id);
 
 	return TC_PASS;
 }


### PR DESCRIPTION
Modify the `dma_mcux_lpc` driver to include a sanity check when allocating channels. Release channels upon concluding the `test_dma_loop` test.

Fixes #91670.

The condition was instigated with the DMA driver context being added to the `dma_mcux_lpc` driver (with eeaf860dfabfc90ccba92db229cb46241139c5be, yes, I acknowledge that I broke this), which enables channels to be requested (allocated). The `test_dma_loop` test requested multiple channels (only a single one was used at a time, but they didn't get released) and as the driver was configured to hold internal state only for a limited number of channels (`CONFIG_DMA_MCUX_LPC_NUMBER_OF_CHANNELS_ALLOCATED`) without a sanity check when allocating it for each channel, the array holding that state structs was overrun, resulting in memory corruption and system crash.