### PR TITLE
net: context: Don't assert on address family mismatch

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1358,10 +1358,8 @@ int net_context_connect(struct net_context *context,
 	}
 
 	if (addr->sa_family != net_context_get_family(context)) {
-		NET_ASSERT(addr->sa_family == net_context_get_family(context),
-			   "Family mismatch %d should be %d",
-			   addr->sa_family,
-			   net_context_get_family(context));
+		NET_ERR("Address family %d does not match network context family %d",
+			addr->sa_family, net_context_get_family(context));
 		ret = -EINVAL;
 		goto unlock;
 	}


### PR DESCRIPTION
Providing a wrong address to the connect() call by the application is no reason to assert, connect() should just return an error in such case. Therefore remove the faulty assert and replace it with error log instead.