### PR TITLE
doc: coverage: fix twister coverage-basedir option syntax

### DIFF
--- a/doc/develop/test/coverage.rst
+++ b/doc/develop/test/coverage.rst
@@ -167,7 +167,7 @@ command line option, for example:
 
 .. code-block:: console
 
-   $ $ZEPHYR_BASE/scripts/twister --coverage -p native_sim --coverage_basedir $ZEPHYR_BASE -T your_project_dir
+   $ $ZEPHYR_BASE/scripts/twister --coverage -p native_sim --coverage-basedir $ZEPHYR_BASE -T your_project_dir
 
 .. note::
 


### PR DESCRIPTION
Correct the command line option from --coverage_basedir to --coverage-basedir to match the actual twister argument syntax.