### PR TITLE
drivers: gpio: pca953x: add pull-up/pull-down support

### DIFF
--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -38,6 +38,10 @@ properties:
       enabling interrupts. Setting corresponding mask bits to logic
       0 to enable the interrupts.
 
+  has-pud:
+    type: boolean
+    description: Supports pull-up/pull-down resistors
+
 gpio-cells:
   - pin
   - flags


### PR DESCRIPTION
Some variants of the PCA953x family support pull-up / pull-down resistors through registers 0x43 and 0x44 (mostly the TCAL9538 variant). We already support input latching and interrupt masking (which is also only present on a few variants), so let's also add support for pull-up and pull-down resistors.

The feature can be enabled with the has-pud property in the device tree.