### PR TITLE
west.yml: hal_nxp: Remove unused SOCs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2de68b601cc95417466707f1b99149820b0556ec
+      revision: pull/583/head
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Now that part of the hal_nxp is not synchronized to upstream MCU SDK anymore, we can remove the devices that are not used in zephyr from it. This will save ~150MB of space in the nxp_hal.

Note: this PR is mostly for compliance of having zephyr PR to confirm passed CI, this hal change can go in with any other PR updating nxp hal