### PR TITLE
scripts: twister: pylib: twister: pytest-twister-harness: not needed board id with BOOT-SERIAL mode

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -91,7 +91,7 @@ class HardwareAdapter(DeviceAdapter):
             elif runner == 'jlink':
                 base_args.append('--dev-id')
                 base_args.append(board_id)
-            elif runner == 'stm32cubeprogrammer':
+            elif runner == 'stm32cubeprogrammer' and self.device_config.product != "BOOT-SERIAL":
                 base_args.append(f'--tool-opt=sn={board_id}')
             elif runner == 'linkserver':
                 base_args.append(f'--probe={board_id}')


### PR DESCRIPTION
STM32 boards like the STM32N6-DK are configured in BOOT-SERIAL mode to perform non-regression tests.

See this commit for more details on programming with STM32CubeProgrammer: https://github.com/zephyrproject-rtos/zephyr/pull/84869/commits/9c9baf3cb5703028dc04ea3e0f1da0336ad300fd 

This change is also required to enable tests with pytest and the shell harness.