### PR TITLE
tests: kernel: mem_map: fix qemu_x86_tiny/atom failing test

### DIFF
--- a/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
+++ b/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
@@ -5,4 +5,4 @@
 # Adjust this so that test_k_mem_map_unmap memory exhaustion
 # test can run without failure, as we may run of free pages
 # when there are changes in code and data size.
-CONFIG_DEMAND_PAGING_PAGE_FRAMES_RESERVE=30
+CONFIG_DEMAND_PAGING_PAGE_FRAMES_RESERVE=26


### PR DESCRIPTION
qemu_x86_tiny/atom is failing the memory mapping exhaustion test again due to not having enough memory for mapping. The test_k_mem_map_unmap test requires some free physical pages to work correctly. Lower the amount of reserved memory for paging to leave some pages for the test.