### PR TITLE
tests/kernel/mem_protect/mem_map: Fix memory exhaustion on qemu_x86_tiny

### DIFF
--- a/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
+++ b/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
@@ -5,4 +5,4 @@
 # Adjust this so that test_k_mem_map_unmap memory exhaustion
 # test can run without failure, as we may run of free pages
 # when there are changes in code and data size.
-CONFIG_DEMAND_PAGING_PAGE_FRAMES_RESERVE=30
+CONFIG_DEMAND_PAGING_PAGE_FRAMES_RESERVE=29


### PR DESCRIPTION
As Zephyr text area grows, less memory is available for test on the artificially constrained qemu_x86_tiny. This patch reserves one less page so that more can be used for the tests.

Fixes: #93913