### PR TITLE
tests: drivers: counter: Correct tick value for late test.

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -868,7 +868,7 @@ static void test_late_alarm_error_instance(const struct device *dev)
 
 	k_busy_wait(2*tick_us);
 
-	alarm_cfg.ticks = counter_get_top_value(dev);
+	alarm_cfg.ticks = counter_is_counting_up(dev) ? 0 : counter_get_top_value(dev);
 	err = counter_set_channel_alarm(dev, 0, &alarm_cfg);
 	zassert_equal(-ETIME, err,
 			"%s: Failed to detect late setting (err: %d)",


### PR DESCRIPTION
Fix a small regression introduced in
37b4cff8f2f0555f2582b6e781658fe431cf7b07 and properly set the "late ticks" depending on if the counter is counting up/down.

This supersedes #94094 which assumed, in error, that the issue was with the driver, instead of the test itself.