### PR TITLE
dp: add option to keep reset deasserted

### DIFF
--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -48,6 +48,7 @@ struct sw_config {
 	void *dnoe_reg;
 	struct gpio_dt_spec noe;
 	struct gpio_dt_spec reset;
+	bool keep_reset_deast;
 	uint32_t port_write_cycles;
 	void *clk_reg;
 };
@@ -668,7 +669,10 @@ static int sw_port_off(const struct device *dev)
 	}
 
 	if (config->reset.port) {
-		ret = gpio_pin_configure_dt(&config->reset, GPIO_DISCONNECTED);
+		ret = gpio_pin_configure_dt(&config->reset,
+					    config->keep_reset_deast
+						    ? GPIO_OUTPUT_ACTIVE
+						    : GPIO_DISCONNECTED);
 		if (ret) {
 			return ret;
 		}
@@ -729,6 +733,7 @@ static struct swdp_api swdp_bitbang_api = {
 		.dnoe_reg = SW_GPIOS_GET_REG(n, dnoe_gpios),				\
 		.noe = GPIO_DT_SPEC_INST_GET_OR(n, noe_gpios, {0}),			\
 		.reset = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),			\
+		.keep_reset_deast = DT_INST_PROP(n, keep_reset_deasserted),             \
 		.port_write_cycles = DT_INST_PROP(n, port_write_cycles),		\
 	};										\
 											\

--- a/dts/bindings/misc/zephyr,swdp-gpio.yaml
+++ b/dts/bindings/misc/zephyr,swdp-gpio.yaml
@@ -92,6 +92,14 @@ properties:
     description: |
       Optional GPIO pin used for RESET output.
 
+  keep-reset-deasserted:
+    type: boolean
+    description: |
+      When present, the driver will actively keep the target's RESET line
+      in its de-asserted (inactive) state even when no SWD communication
+      is occurring. This prevents the target from being unintentionally
+      reset. This property requires 'reset-gpios' to be defined.
+
   port-write-cycles:
     type: int
     required: true


### PR DESCRIPTION
Adds a property to keep reset deasserted even when the SWD port is disconnected.

Continuation of https://github.com/zephyrproject-rtos/zephyr/pull/87934