### PR TITLE
usb: hid: Mark the hid interface as not ready when the device is suspended.

### DIFF
--- a/subsys/usb/device_next/class/usbd_hid.c
+++ b/subsys/usb/device_next/class/usbd_hid.c
@@ -473,6 +473,17 @@ static void usbd_hid_disable(struct usbd_class_data *const c_data)
 static void usbd_hid_suspended(struct usbd_class_data *const c_data)
 {
 	const struct device *dev = usbd_class_get_private(c_data);
+	struct hid_device_data *ddata = dev->data;
+	const struct hid_device_ops *const ops = ddata->ops;
+
+	/*
+	 * When the device is suspended, mark the interface as not ready
+	 * until the enable hook is called.
+	 */
+	atomic_clear_bit(&ddata->state, HID_DEV_CLASS_ENABLED);
+	if (ops->iface_ready) {
+		ops->iface_ready(dev, false);
+	}
 
 	LOG_DBG("Configuration suspended, device %s", dev->name);
 }


### PR DESCRIPTION
When the usb link was disconnected, the usbd device would be marked as suspended, however the iface_ready callback was never called. This can make clients of this module unaware of the fact the usb device was not ready and that they should not be submitting new reports. This commit fixes this problem by marking the interface as not ready when the device is suspended, but we do not mark it as ready when the device is resumed. Instead we wait for the enabled hook to be called since it's a better indication of the hid interface being ready.

Signed-off-by: Zak Essadaoui <zak0@meta.com>