### PR TITLE
drivers: counter: nrfx_timer: Handle fast instances without GDFS

### DIFF
--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -35,8 +35,22 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 #define MAYBE_CONST_CONFIG const
 #endif
 
-#if NRF_DT_INST_ANY_IS_FAST
+/* Only cores with access to GDFS can control clocks and power domains, so if a fast instance is
+ * used by other cores, treat the TIMER like a normal one. This presumes cores with access to GDFS
+ * have requested the clocks and power domains needed by the fast instance to be ACTIVE before
+ * other cores use the fast instance.
+ */
+#if CONFIG_NRFS_GDFS_SERVICE_ENABLED
+#define INSTANCE_IS_FAST(idx)						\
+	UTIL_AND(							\
+		NRF_DT_IS_FAST(DT_DRV_INST(idx)),			\
+		IS_ENABLED(CONFIG_COUNTER_NRFX_TIMER_USE_CLOCK_CONTROL)	\
+	)
+#define INSTANCE_IS_FAST_OR(idx) INSTANCE_IS_FAST(idx) ||
+
+#if DT_INST_FOREACH_STATUS_OKAY(INSTANCE_IS_FAST_OR) 0
 #define COUNTER_ANY_FAST 1
+#endif
 #endif
 
 struct counter_nrfx_data {
@@ -460,13 +474,13 @@ static DEVICE_API(counter, counter_nrfx_driver_api) = {
  * which is using nrfs (IPC) are initialized later.
  */
 #define TIMER_INIT_LEVEL(idx) \
-	COND_CODE_1(NRF_DT_INST_IS_FAST(idx), (POST_KERNEL), (PRE_KERNEL_1))
+	COND_CODE_1(INSTANCE_IS_FAST(idx), (POST_KERNEL), (PRE_KERNEL_1))
 
 /* Get initialization priority of an instance. Instances that requires clock control
  * which is using nrfs (IPC) are initialized later.
  */
 #define TIMER_INIT_PRIO(idx)								\
-	COND_CODE_1(NRF_DT_INST_IS_FAST(idx),						\
+	COND_CODE_1(INSTANCE_IS_FAST(idx),						\
 		    (UTIL_INC(CONFIG_CLOCK_CONTROL_NRF_HSFLL_GLOBAL_INIT_PRIORITY)),	\
 		    (CONFIG_COUNTER_INIT_PRIORITY))
 
@@ -522,7 +536,7 @@ static DEVICE_API(counter, counter_nrfx_driver_api) = {
 		},										\
 		.ch_data = counter##idx##_ch_data,						\
 		.timer = (NRF_TIMER_Type *)DT_INST_REG_ADDR(idx),				\
-		IF_ENABLED(NRF_DT_INST_IS_FAST(idx),						\
+		IF_ENABLED(INSTANCE_IS_FAST(idx),						\
 			(.clk_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_DRV_INST(idx))),		\
 			 .clk_spec = {								\
 				.frequency = NRF_PERIPH_GET_FREQUENCY(DT_DRV_INST(idx)),	\


### PR DESCRIPTION
Add support to case where fast instance (e.g. timer120) is used on a core that does not has clock control (FLPR).