### PR TITLE
[Backport v4.1-branch] drivers: regulator: shell: Fix regulator parent name completion

### DIFF
--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -527,7 +527,12 @@ static bool device_is_regulator(const struct device *dev)
 	return DEVICE_API_IS(regulator, dev);
 }
 
-static void device_name_get(size_t idx, struct shell_static_entry *entry)
+static bool device_is_regulator_parent(const struct device *dev)
+{
+	return DEVICE_API_IS(regulator_parent, dev);
+}
+
+static void device_name_get_regulator(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_filter(idx, device_is_regulator);
 
@@ -537,7 +542,18 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = NULL;
 }
 
-SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+static void device_name_get_regulator_parent(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_filter(idx, device_is_regulator_parent);
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get_regulator);
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name_parent, device_name_get_regulator_parent);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_regulator_cmds,
@@ -601,11 +617,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Get errors\n"
 		      "Usage: errors <device>",
 		      cmd_errors, 2, 0),
-	SHELL_CMD_ARG(dvsset, &dsub_device_name,
+	SHELL_CMD_ARG(dvsset, &dsub_device_name_parent,
 		      "Set regulator dynamic voltage scaling state\n"
 		      "Usage: dvsset <device> <state identifier>",
 		      cmd_dvsset, 3, 0),
-	SHELL_CMD_ARG(shipmode, &dsub_device_name,
+	SHELL_CMD_ARG(shipmode, &dsub_device_name_parent,
 		      "Enable regulator ship mode\n"
 		      "Usage: shipmode <device>",
 		      cmd_shipmode, 2, 0),


### PR DESCRIPTION
Shell functions targeting regulator parents used the auto-completion of regulator devices instead.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94047
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94134