### PR TITLE
dts: bindings: regulator: fix npm13xx soft start current enum

### DIFF
--- a/dts/bindings/regulator/nordic,npm13xx-regulator-common.yaml
+++ b/dts/bindings/regulator/nordic,npm13xx-regulator-common.yaml
@@ -61,10 +61,10 @@ child-binding:
     soft-start-microamp:
       type: int
       enum:
-        - 10000
-        - 20000
-        - 35000
+        - 25000
         - 50000
+        - 75000
+        - 100000
       description: |
         Soft start current limit in microamps.
 


### PR DESCRIPTION
The nPM1300 datasheet featured wrong soft start current values which were also used in the DTS bindings for its regulator driver. This fixes the values aligning them with the next release of the document.