### PR TITLE
MAINTAINERS: Update nrf_hw_models project collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5663,8 +5663,7 @@ West:
   maintainers:
     - aescolar
   collaborators:
-    - wopu-ot
-    - thoh-ot
+    - rugeGerritsen
   files: []
   labels:
     - "area: native port"


### PR DESCRIPTION
Let's update this west module/project collaborators: wopu-ot & thoh-ot have been out of the picture for these HW models for quite a while now, while rugeGerritsen has been much more active.