### PR TITLE
manifest: update hal_ti to work with cmsis_6

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -260,7 +260,7 @@ manifest:
       groups:
         - hal
     - name: hal_ti
-      revision: cac5fd6a63a40eacb3b009a0903dce087334afb1
+      revision: 391f7cb740b59c077ddd49411f043161597b10aa
       path: modules/hal/ti
       groups:
         - hal


### PR DESCRIPTION
Pick up a commit to drop a hal cmsis 5 copy and fix it to work with cmsis 6.

dep
- https://github.com/zephyrproject-rtos/hal_ti/pull/65