### PR TITLE
scripts: west: commands: completion: bash: add --domain completion

### DIFF
--- a/scripts/west_commands/completion/west-completion.bash
+++ b/scripts/west_commands/completion/west-completion.bash
@@ -751,6 +751,7 @@ __comp_west_build()
 		--target -t
 		--test-item -T
 		--build-opt -o
+		--domain
 	"
 
 	all_opts="$bool_opts $special_opts $dir_opts $other_opts"


### PR DESCRIPTION
Add completion support for "west build --domain" under the Bash shell.