### PR TITLE
MAINTAINERS: add Xen Domain-0 snippet to Xen Platform

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -5897,6 +5897,7 @@ Xen Platform:
     - soc/xen/
     - boards/xen/
     - dts/bindings/xen/
+    - snippets/xen_dom0/
   labels:
     - "area: Xen Platform"
 


### PR DESCRIPTION
The snippet for Zephyr as Xen Domain-0 was missing in the Xen Platform section of MAINTAINERS.yml.

Add the missing entry to ensure that future pull requests for this component are correctly tracked and assigned.