### PR TITLE
mcuboot: kconfig: fix failed mcuboot_test for swap using offset mode

### DIFF
--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -134,7 +134,8 @@ menu "On board MCUboot operation mode"
 
 choice MCUBOOT_BOOTLOADER_MODE
 	prompt "Application assumed MCUboot mode of operation"
-	default MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE
+	default MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE if SOC_FAMILY_STM32
+	default MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET
 	help
 	  Informs application build on assumed MCUboot mode of operation.
 	  This is important for validataing application against DT configuration,


### PR DESCRIPTION
- Fixes the failed mcuboot_test after switching to the default swap using offset mode.
- Fixes #94059