### PR TITLE
Bluetooth: BAP: Broadcast: Remove LOG_WRN for missing callbacks

### DIFF
--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -381,8 +381,6 @@ static void broadcast_sink_iso_connected(struct bt_iso_chan *chan)
 
 	if (ops != NULL && ops->started != NULL) {
 		ops->started(stream);
-	} else {
-		LOG_WRN("No callback for started set");
 	}
 
 	if (broadcast_sink_is_in_state(sink, BT_BAP_EP_STATE_STREAMING)) {
@@ -430,8 +428,6 @@ static void broadcast_sink_iso_disconnected(struct bt_iso_chan *chan,
 
 	if (ops != NULL && ops->stopped != NULL) {
 		ops->stopped(stream, reason);
-	} else {
-		LOG_WRN("No callback for stopped set");
 	}
 }
 

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -203,8 +203,6 @@ static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 
 	if (ops != NULL && ops->started != NULL) {
 		ops->started(stream);
-	} else {
-		LOG_WRN("No callback for started set");
 	}
 }
 
@@ -237,8 +235,6 @@ static void broadcast_source_iso_disconnected(struct bt_iso_chan *chan, uint8_t 
 
 	if (ops != NULL && ops->stopped != NULL) {
 		ops->stopped(stream, reason);
-	} else {
-		LOG_WRN("No callback for stopped set");
 	}
 }
 


### PR DESCRIPTION
The callbacks may be omitted without loss of functionality. 