### PR TITLE
twister: scripts: sharing of built applications

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -746,6 +746,43 @@ required_snippets: <list of needed snippets>
               - cdc-acm-console
               - user-snippet-example
 
+required_applications: <list of required applications> (default empty)
+    Specify a list of test applications that must be built before current test can run.
+    It enables sharing of built applications between test scenarios, allowing tests
+    to access build artifacts from other applications.
+
+    Each required application entry supports:
+    - ``name``: Test scenario identifier (required)
+    - ``platform``: Target platform (optional, defaults to current test's platform)
+
+    Required applications must be available in the source tree (specified with ``-T``
+    and/or ``-s`` options). When reusing build directories (e.g., with ``--no-clean``),
+    Twister can find required applications in the current build directory.
+
+    How it works:
+
+    - Twister builds the required applications first
+    - The main test application waits for required applications to complete
+    - Build directories of required applications are made available to the test harness
+    - For pytest harness, build directories are passed via ``--required-build`` arguments
+      and accessible through the ``required_build_dirs`` fixture
+
+    Example configuration:
+
+    .. code-block:: yaml
+
+        tests:
+          sample.required_app_demo:
+            harness: pytest
+            required_applications:
+              - name: sample.shared_app
+              - name: sample.basic.helloworld
+                platform: native_sim
+          sample.shared_app:
+            build_only: true
+
+    Limitations: Not supported with ``--subset`` or ``--runtime-artifact-cleanup`` options.
+
 expect_reboot: <True|False> (default False)
     Notify twister that the test scenario is expected to reboot while executing.
     When enabled, twister will suppress warnings about unexpected multiple runs

--- a/samples/subsys/testsuite/pytest/shell/pytest_shared_app/test_shared_app.py
+++ b/samples/subsys/testsuite/pytest/shell/pytest_shared_app/test_shared_app.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from twister_harness import DeviceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+def test_required_build_dirs_found(dut: DeviceAdapter, required_build_dirs):
+    logger.info(f"Required build directories: {required_build_dirs}")
+    assert len(required_build_dirs) == 2, "Expected two required build directories"
+    assert Path(required_build_dirs[0]).is_dir()
+    assert Path(Path(required_build_dirs[0]) / 'build.log').exists()

--- a/samples/subsys/testsuite/pytest/shell/testcase.yaml
+++ b/samples/subsys/testsuite/pytest/shell/testcase.yaml
@@ -33,3 +33,11 @@ tests:
       - CONFIG_SHELL_VT100_COLORS=n
     harness_config:
       shell_commands: *kernel_commands
+  sample.pytest.required_app_demo:
+    required_applications:
+      - name: sample.pytest.shell
+      - name: sample.harness.shell
+    harness: pytest
+    harness_config:
+      pytest_root:
+        - "pytest_shared_app/test_shared_app.py"

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -87,6 +87,11 @@ def shell(dut: DeviceAdapter) -> Shell:
     return shell
 
 
+@pytest.fixture(scope='session')
+def required_build_dirs(request: pytest.FixtureRequest) -> list[str]:
+    return request.config.getoption('--required-build')
+
+
 @pytest.fixture()
 def mcumgr(device_object: DeviceAdapter) -> Generator[MCUmgr, None, None]:
     """Fixture to create an MCUmgr instance for serial connection."""

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -123,6 +123,11 @@ def pytest_addoption(parser: pytest.Parser):
         help='The scope for which `dut` and `shell` fixtures are shared.'
     )
     twister_harness_group.addoption(
+        '--required-build', action='append', default=[], metavar='PATH',
+        help='Required build directory / shared applications for the test. '
+             'May be given multiple times.'
+    )
+    twister_harness_group.addoption(
         '--twister-fixture', action='append', dest='fixtures', metavar='FIXTURE', default=[],
         help='Twister fixture supported by this platform. May be given multiple times.'
     )

--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -55,6 +55,7 @@ class TwisterConfigParser:
         "extra_conf_files": {"type": "list", "default": []},
         "extra_overlay_confs": {"type": "list", "default": []},
         "extra_dtc_overlay_files": {"type": "list", "default": []},
+        "required_applications": {"type": "list"},
         "required_snippets": {"type": "list"},
         "build_only": {"type": "bool", "default": False},
         "build_on_all": {"type": "bool", "default": False},

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -434,6 +434,9 @@ class Pytest(Harness):
                 f'Support for handler {handler.type_str} not implemented yet'
             )
 
+        for req_build in self.instance.required_build_dirs:
+            command.append(f'--required-build={req_build}')
+
         if handler.type_str != 'device':
             for fixture in handler.options.fixture:
                 command.append(f'--twister-fixture={fixture}')

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -97,6 +97,8 @@ class TestInstance:
         self.init_cases()
         self.filters = []
         self.filter_type = None
+        self.required_applications = []
+        self.required_build_dirs = []
 
     def setup_run_id(self):
         self.run_id = self._get_run_id()

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -73,6 +73,17 @@ schema;scenario-schema:
     "expect_reboot":
       type: bool
       required: false
+    "required_applications":
+      type: seq
+      required: false
+      sequence:
+        - type: map
+          mapping:
+            "name":
+              type: str
+              required: true
+            "platform":
+              type: str
     "required_snippets":
       type: seq
       required: false


### PR DESCRIPTION
This feature enables sharing of built applications between test scenarios, allowing tests to access build artifacts from other applications.

from twister.rst:

  Required applications must be available in the source tree (specified with ``-T``
  and/or ``-s`` options). When reusing build directories (e.g., with ``--no-clean``),
  Twister can find required applications in the current build directory.

  How it works:
  - Twister builds the required applications first
  - The main test application waits for required applications to complete
  - Build directories of required applications are made available to the test harness
  - For pytest harness, build directories are passed via ``--required-build`` arguments
    and accessible through the ``required_build_dirs`` fixture

 Limitations: Not supported with ``--subset`` or ``--runtime-artifact-cleanup`` options.

`samples/subsys/testsuite/pytest/shell` is extended to show how to use that feature.
To test one can run:
`./scripts/twister -c -vv -ll info -T samples/subsys/testsuite/pytest/shell -G`

if samples were built, one can run it with `--no-clean`  (required builds will be found in build directory):
`./scripts/twister --no-clean -vv -ll debug -T samples/subsys/testsuite/pytest/shell -s sample.pytest.required_app_demo -p native_sim`

To run on the hardware (must have hardware map or change the command with platform and serial parameters):
`./scripts/twister -vv -ll debug -T samples/subsys/testsuite/pytest/shell -s sample.pytest.required_app_demo --device-testing --hardware-map ~/tmp/hardware_map.yml --west-flash -s sample.harness.shell -s sample.pytest.shell`

-----

Related to RFC: https://github.com/zephyrproject-rtos/zephyr/issues/62649
Based on that PR: #75291 (but removed `no_own_image` part and added option to re-use previously built applications from outdir)




