### PR TITLE
tests: kconfig: functions: add tests for dt_compat_enabled

### DIFF
--- a/tests/kconfig/functions/Kconfig
+++ b/tests/kconfig/functions/Kconfig
@@ -115,6 +115,10 @@ config KCONFIG_MAX_10_3_2
 
 DT_COMPAT_VND_GPIO := vnd,gpio
 
+config KCONFIG_VND_GPIO_ENABLED_Y
+	bool
+	default $(dt_compat_enabled,$(DT_COMPAT_VND_GPIO))
+
 config KCONFIG_VND_GPIO_ENABLED_NUM_4
 	int
 	default $(dt_compat_enabled_num,$(DT_COMPAT_VND_GPIO))
@@ -125,7 +129,15 @@ config KCONFIG_VND_CAN_CONTROLLER_ENABLED_NUM_2
 	int
 	default $(dt_compat_enabled_num,$(DT_COMPAT_VND_CAN_CONTROLLER))
 
+config KCONFIG_VND_CAN_CONTROLLER_ENABLED_Y
+	bool
+	default $(dt_compat_enabled,$(DT_COMPAT_VND_CAN_CONTROLLER))
+
 DT_COMPAT_VND_PWM := vnd,pwm
+
+config KCONFIG_VND_PWM_ENABLED_N
+	bool
+	default $(dt_compat_enabled,$(DT_COMPAT_VND_PWM))
 
 config KCONFIG_VND_PWM_ENABLED_NUM_0
 	int

--- a/tests/kconfig/functions/src/main.c
+++ b/tests/kconfig/functions/src/main.c
@@ -45,6 +45,13 @@ ZTEST(test_kconfig_functions, test_min_max)
 	zassert_equal(CONFIG_KCONFIG_MAX_10_3_2, MAX(MAX(10, 3), 2));
 }
 
+ZTEST(test_kconfig_functions, test_dt_compat_enabled)
+{
+	zassert_true(IS_ENABLED(CONFIG_KCONFIG_VND_GPIO_ENABLED_Y));
+	zassert_true(IS_ENABLED(CONFIG_KCONFIG_VND_CAN_CONTROLLER_ENABLED_Y));
+	zassert_false(IS_ENABLED(CONFIG_KCONFIG_VND_PWM_ENABLED_N));
+}
+
 ZTEST(test_kconfig_functions, test_dt_num_compat_enabled)
 {
 	zassert_equal(CONFIG_KCONFIG_VND_GPIO_ENABLED_NUM_4, 4);


### PR DESCRIPTION
Add tests for the dt_compat_enabled Kconfig function.