### PR TITLE
tests: ram_context_for_isr: exclude interrupt conflict platforms

### DIFF
--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -13,3 +13,9 @@ tests:
       - mps4/corstone320/fvp
       - imx943_evk/mimx94398/m33
       - imx943_evk/mimx94398/m33/ddr
+      - frdm_mcxc444/mcxc444
+      - frdm_mcxc242/mcxc242
+      - frdm_mcxn947/mcxn947/cpu0/qspi
+      - hexiwear/mkw40z4
+      - frdm_kw41z/mkw41z4
+      - frdm_kl25z/mkl25z4


### PR DESCRIPTION
some NXP platform last interrupt is not free for testing, need skip

fixes: #94169