### PR TITLE
Revert "drivers: counter: sam_tc: Big fix for alarm 1"

### DIFF
--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -356,7 +356,6 @@ static DEVICE_API(counter, counter_sam_driver_api) = {
 
 #define COUNTER_SAM_TC_CMR(n)	\
 		 (TC_CMR_TCCLKS(DT_INST_PROP_OR(n, clk, 0)) \
-		| TC_CMR_WAVEFORM_EEVT_XC0 \
 		| TC_CMR_WAVEFORM_WAVSEL_UP_RC \
 		| TC_CMR_WAVE)
 


### PR DESCRIPTION
This reverts commit 8f5daca5e56514284a45a19964a25a9c52b9d783. The CI is failing on sam4l_wm400_cape after this commit.

https://github.com/zephyrproject-rtos/zephyr/pull/93755
https://github.com/zephyrproject-rtos/zephyr/actions/runs/16775544341/job/47501188595?pr=87269