### PR TITLE
dts: arm: nxp: rt10xx: Add power state for soft-off

### DIFF
--- a/dts/arm/nxp/nxp_rt10xx.dtsi
+++ b/dts/arm/nxp/nxp_rt10xx.dtsi
@@ -31,7 +31,7 @@
 			compatible = "arm,cortex-m7";
 			d-cache-line-size = <32>;
 			reg = <0>;
-			cpu-power-states = <&idle &suspend>;
+			cpu-power-states = <&idle &suspend &off>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -59,6 +59,12 @@
 				power-state-name = "suspend-to-idle";
 				exit-latency-us = <5000>;
 				min-residency-us = <10000>;
+			};
+			off: off {
+				/* PM_STATE_SOFT_OFF is entered only by calling pm_state_force */
+				status = "disabled";
+				compatible = "zephyr,power-state";
+				power-state-name = "soft-off";
 			};
 		};
 	};

--- a/samples/boards/nxp/mimxrt1060_evk/system_off/src/main.c
+++ b/samples/boards/nxp/mimxrt1060_evk/system_off/src/main.c
@@ -41,8 +41,7 @@ int main(void)
 	}
 
 	/* Configure to generate PORT event (wakeup) on button press. */
-	/* No external pull-up on the user button, so configure one here */
-	int ret = gpio_pin_configure_dt(&button, GPIO_INPUT | GPIO_PULL_UP);
+	int ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 
 	if (ret != 0) {
 		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
@@ -50,7 +49,7 @@ int main(void)
 		return 0;
 	}
 
-	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_LEVEL_LOW);
+	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
 		       button.port->name, button.pin);


### PR DESCRIPTION
In order for samples/boards/nxp/mimxrt1060_evk/system_off to work, a soft-off power state is needed.