### PR TITLE
boards: beagle: beagleconnect_freedom: Fix SPI flash size

### DIFF
--- a/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
+++ b/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
@@ -169,7 +169,8 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <2000000>;
-		size = <0x200000>;
+		// Size (2 MiB) is in bits
+		size = <0x1000000>;
 		//has-be32k;
 		has-dpd;
 		t-enter-dpd = <20000>;

--- a/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.yaml
+++ b/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.yaml
@@ -15,4 +15,5 @@ supported:
   - hwinfo
   - adc
   - pwm
+  - flash
 vendor: beagle

--- a/tests/drivers/flash/common/testcase.yaml
+++ b/tests/drivers/flash/common/testcase.yaml
@@ -153,6 +153,8 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
   drivers.flash.common.disable_spi_nor:
     filter: dt_compat_enabled("soc-nv-flash") and dt_compat_enabled("jedec,spi-nor")
+    platform_exclude:
+      - beagleconnect_freedom/cc1352p7
     extra_args:
       - CONFIG_SPI_NOR=n
   drivers.flash.common.ra_ospi_b_nor:


### PR DESCRIPTION
- SPI flash size should be given in bits, not bytes.
- Tested with samples/drivers/spi_flash