### PR TITLE
drivers: can: add Kconfig option for specifying the sample point margin

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -38,6 +38,14 @@ config CAN_DEFAULT_BITRATE_DATA
 	  Default initial CAN data phase bitrate in bits/s. This can be overridden per CAN controller
 	  using the "bitrate-data" devicetree property.
 
+config CAN_SAMPLE_POINT_MARGIN
+	int "Maximum acceptable sample point location deviation"
+	default 50
+	range 0 1000
+	help
+	  Maximum acceptable deviation in sample point location (permille). A value of 50 means +/-
+	  5 percentage points margin allowed.
+
 config CAN_SHELL
 	bool "CAN shell"
 	depends on SHELL

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -12,9 +12,6 @@
 
 LOG_MODULE_REGISTER(can_common, CONFIG_CAN_LOG_LEVEL);
 
-/* Maximum acceptable deviation in sample point location (permille) */
-#define SAMPLE_POINT_MARGIN 50
-
 /* CAN sync segment is always one time quantum */
 #define CAN_SYNC_SEG 1
 
@@ -402,7 +399,7 @@ int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 		return ret;
 	}
 
-	if (ret > SAMPLE_POINT_MARGIN) {
+	if (ret > CONFIG_CAN_SAMPLE_POINT_MARGIN) {
 		return -ERANGE;
 	}
 
@@ -448,7 +445,7 @@ int z_impl_can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data)
 		return ret;
 	}
 
-	if (ret > SAMPLE_POINT_MARGIN) {
+	if (ret > CONFIG_CAN_SAMPLE_POINT_MARGIN) {
 		return -ERANGE;
 	}
 

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -17,11 +17,6 @@
  */
 
 /**
- * @brief Allowed sample point calculation margin in permille.
- */
-#define SAMPLE_POINT_MARGIN 50
-
-/**
  * @brief Defines a set of CAN timing test values
  */
 struct can_timing_test {
@@ -176,8 +171,8 @@ static bool test_timing_values(const struct device *dev, const struct can_timing
 		return false;
 	} else {
 		zassert_true(sp_err >= 0, "unknown error %d", sp_err);
-		zassert_true(sp_err <= SAMPLE_POINT_MARGIN, "sample point error %d too large",
-			     sp_err);
+		zassert_true(sp_err <= CONFIG_CAN_SAMPLE_POINT_MARGIN,
+			     "sample point error %d too large", sp_err);
 
 		printk("sjw = %u, prop_seg = %u, phase_seg1 = %u, phase_seg2 = %u, prescaler = %u ",
 			timing.sjw, timing.prop_seg, timing.phase_seg1, timing.phase_seg2,
@@ -185,7 +180,7 @@ static bool test_timing_values(const struct device *dev, const struct can_timing
 
 		assert_bitrate_correct(dev, &timing, test->bitrate);
 		assert_timing_within_bounds(&timing, min, max);
-		assert_sp_within_margin(&timing, test->sp, SAMPLE_POINT_MARGIN);
+		assert_sp_within_margin(&timing, test->sp, CONFIG_CAN_SAMPLE_POINT_MARGIN);
 
 		if (IS_ENABLED(CONFIG_CAN_FD_MODE) && data_phase) {
 			err = can_set_timing_data(dev, &timing);
@@ -257,7 +252,8 @@ void *can_timing_setup(void)
 	err = can_get_core_clock(dev, &core_clock);
 	zassert_equal(err, 0, "failed to get core CAN clock");
 
-	printk("testing on device %s @ %u Hz\n", dev->name, core_clock);
+	printk("testing on device %s @ %u Hz, sample point margin +/-%u permille\n", dev->name,
+		core_clock, CONFIG_CAN_SAMPLE_POINT_MARGIN);
 
 	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
 		can_mode_t cap;


### PR DESCRIPTION
Add a Kconfig option for setting the maximum acceptable deviation in sample point location (permille).