### PR TITLE
Bluetooth: Controller: Allow default to maximum DLE value

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -617,7 +617,7 @@ config BT_CTLR_DATA_LENGTH
 config BT_CTLR_DATA_LENGTH_MAX
 	int "Maximum data length supported"
 	depends on BT_CTLR_DATA_LENGTH
-	default BT_BUF_ACL_RX_SIZE if BT_BUF_ACL_RX_SIZE < 251
+	default BT_BUF_ACL_RX_SIZE if BT_BUF_ACL_RX_SIZE <= 251
 	default 27
 	range 27 BT_BUF_ACL_RX_SIZE if BT_BUF_ACL_RX_SIZE < 251
 	range 27 251


### PR DESCRIPTION
CONFIG_BT_CTLR_DATA_LENGTH_MAX should set its default value up to and including the maximum value supported by the Bluetooth spec (251 bytes).