### PR TITLE
Handle polarity flag in pca9685 driver and remove unimplement/unused invert property

### DIFF
--- a/boards/shields/adafruit_pca9685/adafruit_pca9685.overlay
+++ b/boards/shields/adafruit_pca9685/adafruit_pca9685.overlay
@@ -13,7 +13,7 @@
 		status = "okay";
 		compatible = "nxp,pca9685-pwm";
 		reg = <0x40>;
-		#pwm-cells = <2>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -65,6 +65,14 @@ MFD
   kconfig symbol ``MFD_AXP192_AXP2101`` is removed. :kconfig:option:`MFD_AXP192` is now to be
   used for AXP192 device while :kconfig:option:`MFD_AXP2101` for the AXP2101 one.
 
+PWM
+===
+
+* :dtcompatible:`nxp,pca9685` ``invert`` property has been removed and you can now use the
+  :c:macro:`PWM_POLARITY_INVERTED` or :c:macro:`PWM_POLARITY_NORMAL` flags as specifier cells for
+  space "pwm" are now named: ``['channel', 'period', 'flags']`` (old value:
+  ``['channel', 'period']``) and ``#pwm-cells`` const value changed from 2 to 3.
+
 Phy
 ===
 

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -173,7 +173,9 @@ static int pca9685_set_cycles(const struct device *dev,
 	int32_t pre_scale;
 	int ret;
 
-	ARG_UNUSED(flags);
+	if (flags & PWM_POLARITY_INVERTED) {
+		pulse_count = period_count - pulse_count;
+	}
 
 	if (channel >= CHANNEL_CNT) {
 		LOG_WRN("channel out of range: %u", channel);

--- a/drivers/pwm/pwm_pca9685.c
+++ b/drivers/pwm/pwm_pca9685.c
@@ -78,7 +78,6 @@ struct pca9685_config {
 	struct i2c_dt_spec i2c;
 	bool outdrv_open_drain;
 	bool och_on_ack;
-	bool invrt;
 };
 
 struct pca9685_data {
@@ -277,7 +276,6 @@ static int pca9685_init(const struct device *dev)
 		.i2c = I2C_DT_SPEC_INST_GET(inst),                      \
 		.outdrv_open_drain = DT_INST_PROP(inst, open_drain),    \
 		.och_on_ack = DT_INST_PROP(inst, och_on_ack),           \
-		.invrt = DT_INST_PROP(inst, invert),                    \
 	};                                                              \
                                                                         \
 	static struct pca9685_data pca9685_##inst##_data;               \

--- a/dts/bindings/pwm/nxp,pca9685.yaml
+++ b/dts/bindings/pwm/nxp,pca9685.yaml
@@ -23,12 +23,6 @@ properties:
       Outputs change on ACK.  Otherwise the outputs change on STOP
       command.
 
-  invert:
-    type: boolean
-    description:
-      Output logic state inverted. Value to use when no external driver
-      used.
-
   "#pwm-cells":
     const: 3
 

--- a/dts/bindings/pwm/nxp,pca9685.yaml
+++ b/dts/bindings/pwm/nxp,pca9685.yaml
@@ -30,8 +30,9 @@ properties:
       used.
 
   "#pwm-cells":
-    const: 2
+    const: 3
 
 pwm-cells:
   - channel
   - period
+  - flags

--- a/tests/drivers/build_all/pwm/boards/native_sim.overlay
+++ b/tests/drivers/build_all/pwm/boards/native_sim.overlay
@@ -33,7 +33,7 @@
 				status = "okay";
 				compatible = "nxp,pca9685-pwm";
 				reg = <0x1>;
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 	};


### PR DESCRIPTION
Handle polarity flag in pca9685 driver and remove unimplement/unused invert property