### PR TITLE
drivers: counter: add set value and 64b ticks

### DIFF
--- a/doc/releases/migration-guide-4.4.rst
+++ b/doc/releases/migration-guide-4.4.rst
@@ -148,6 +148,10 @@ Controller Area Network (CAN)
 Counter
 =======
 
+* Drivers that implement ``get_value_64`` API will now need to select
+  :kconfig:option:`CONFIG_COUNTER_SUPPORTS_64BITS_TICKS` and applications will need
+  :kconfig:option:`CONFIG_COUNTER_64BITS_TICKS` to enable the API. (:github:`94189`).
+
 * The NXP LPTMR driver (:dtcompatible:`nxp,lptmr`) has been updated to fix incorrect
   prescaler and glitch filter configuration:
 

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -22,6 +22,13 @@ config COUNTER_SHELL
 	help
 	  Enable Shell Commands for Counter and Timer
 
+config COUNTER_64BITS_FREQ
+	bool
+	help
+	  Select this option if the counter driver should use 64-bits for frequency.
+	  This is typically set by drivers that have frequencies greater than
+	  4,294,967,295 Hz.
+
 module = COUNTER
 module-str = counter
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -29,6 +29,13 @@ config COUNTER_64BITS_FREQ
 	  This is typically set by drivers that have frequencies greater than
 	  4,294,967,295 Hz.
 
+config COUNTER_64BITS_TICKS
+	bool
+	help
+	  Select this option if the counter driver should use 64-bits for ticks.
+	  This is typically set by drivers that require extended
+	  tick ranges beyond the 32-bit limit.
+
 module = COUNTER
 module-str = counter
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -29,12 +29,20 @@ config COUNTER_64BITS_FREQ
 	  This is typically set by drivers that have frequencies greater than
 	  4,294,967,295 Hz.
 
-config COUNTER_64BITS_TICKS
+config COUNTER_SUPPORTS_64BITS_TICKS
 	bool
 	help
-	  Select this option if the counter driver should use 64-bits for ticks.
+	  Select this option if the counter driver supports 64-bits for ticks.
 	  This is typically set by drivers that require extended
 	  tick ranges beyond the 32-bit limit.
+
+config COUNTER_64BITS_TICKS
+	bool "API to support ticks longer than 32-bits"
+	depends on COUNTER_SUPPORTS_64BITS_TICKS
+	help
+	  This enables APIs to handle ticks larger than 32-bits with a
+	  64-bit typedef. It is up to the driver to implement the necessary
+	  functions to supports.
 
 module = COUNTER
 module-str = counter

--- a/drivers/counter/Kconfig.ace
+++ b/drivers/counter/Kconfig.ace
@@ -5,6 +5,7 @@
 config ACE_V1X_ART_COUNTER
 	bool "DSP ART Wall Clock for ACE V1X"
 	depends on DT_HAS_INTEL_ACE_ART_COUNTER_ENABLED
+	select COUNTER_64BITS_TICKS
 	default y
 	help
 	  DSP ART Wall Clock used by ACE V1X.
@@ -12,6 +13,7 @@ config ACE_V1X_ART_COUNTER
 config ACE_V1X_RTC_COUNTER
 	bool "DSP RTC Wall Clock for ACE V1X"
 	depends on DT_HAS_INTEL_ACE_RTC_COUNTER_ENABLED
+	select COUNTER_64BITS_TICKS
 	default y
 	help
 	  DSP RTC Wall Clock used by ACE V1X.

--- a/drivers/counter/Kconfig.ace
+++ b/drivers/counter/Kconfig.ace
@@ -5,7 +5,7 @@
 config ACE_V1X_ART_COUNTER
 	bool "DSP ART Wall Clock for ACE V1X"
 	depends on DT_HAS_INTEL_ACE_ART_COUNTER_ENABLED
-	select COUNTER_64BITS_TICKS
+	select COUNTER_SUPPORTS_64BITS_TICKS
 	default y
 	help
 	  DSP ART Wall Clock used by ACE V1X.
@@ -13,7 +13,7 @@ config ACE_V1X_ART_COUNTER
 config ACE_V1X_RTC_COUNTER
 	bool "DSP RTC Wall Clock for ACE V1X"
 	depends on DT_HAS_INTEL_ACE_RTC_COUNTER_ENABLED
-	select COUNTER_64BITS_TICKS
+	select COUNTER_SUPPORTS_64BITS_TICKS
 	default y
 	help
 	  DSP RTC Wall Clock used by ACE V1X.

--- a/drivers/counter/Kconfig.cc23x0_rtc
+++ b/drivers/counter/Kconfig.cc23x0_rtc
@@ -6,6 +6,6 @@ config COUNTER_CC23X0_RTC
 	default y
 	depends on DT_HAS_TI_CC23X0_RTC_ENABLED
 	depends on CC23X0_SYSTIM_TIMER
-	select COUNTER_64BITS_TICKS
+	select COUNTER_SUPPORTS_64BITS_TICKS
 	help
 	  Enable counter driver based on RTC timer for cc23x0

--- a/drivers/counter/Kconfig.cc23x0_rtc
+++ b/drivers/counter/Kconfig.cc23x0_rtc
@@ -6,5 +6,6 @@ config COUNTER_CC23X0_RTC
 	default y
 	depends on DT_HAS_TI_CC23X0_RTC_ENABLED
 	depends on CC23X0_SYSTIM_TIMER
+	select COUNTER_64BITS_TICKS
 	help
 	  Enable counter driver based on RTC timer for cc23x0

--- a/drivers/counter/Kconfig.esp32_tmr
+++ b/drivers/counter/Kconfig.esp32_tmr
@@ -7,6 +7,7 @@ config COUNTER_TMR_ESP32
 	bool "ESP32 Counter Driver based on GP-Timers"
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_COUNTER_ENABLED
+	select COUNTER_64BITS_TICKS
 	help
 	  Enables the Counter driver API based on Espressif's General
 	  Purpose Timers for ESP32 series devices.

--- a/drivers/counter/Kconfig.esp32_tmr
+++ b/drivers/counter/Kconfig.esp32_tmr
@@ -7,7 +7,7 @@ config COUNTER_TMR_ESP32
 	bool "ESP32 Counter Driver based on GP-Timers"
 	default y
 	depends on DT_HAS_ESPRESSIF_ESP32_COUNTER_ENABLED
-	select COUNTER_64BITS_TICKS
+	select COUNTER_SUPPORTS_64BITS_TICKS
 	help
 	  Enables the Counter driver API based on Espressif's General
 	  Purpose Timers for ESP32 series devices.

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -23,6 +23,7 @@ config COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS
 config COUNTER_RTC_STM32_SUBSECONDS
 	bool "Use the subseconds as a basic tick."
 	depends on !SOC_SERIES_STM32F1X
+	select COUNTER_SUPPORTS_64BITS_TICKS
 	select COUNTER_64BITS_TICKS
 	help
 	  Use the subseconds as the basic time tick. It increases resolution

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -23,6 +23,7 @@ config COUNTER_RTC_STM32_SAVE_VALUE_BETWEEN_RESETS
 config COUNTER_RTC_STM32_SUBSECONDS
 	bool "Use the subseconds as a basic tick."
 	depends on !SOC_SERIES_STM32F1X
+	select COUNTER_64BITS_TICKS
 	help
 	  Use the subseconds as the basic time tick. It increases resolution
 	  of the counter. The frequency of the time is RTC Source Clock divided

--- a/drivers/counter/counter_ace_v1x_rtc.c
+++ b/drivers/counter/counter_ace_v1x_rtc.c
@@ -11,6 +11,16 @@
 #include <soc.h>
 #include <counter/counter_ace_v1x_rtc_regs.h>
 
+static int counter_ace_v1x_rtc_get_value_32(const struct device *dev,
+		uint32_t *value)
+{
+	ARG_UNUSED(dev);
+
+	*value = sys_read32(ACE_RTCWC_LO);
+
+	return 0;
+}
+
 static int counter_ace_v1x_rtc_get_value(const struct device *dev,
 		uint64_t *value)
 {
@@ -36,7 +46,10 @@ int counter_ace_v1x_rtc_init(const struct device *dev)
 }
 
 static DEVICE_API(counter, ace_v1x_rtc_counter_apis) = {
-	.get_value_64 = counter_ace_v1x_rtc_get_value
+	.get_value = counter_ace_v1x_rtc_get_value_32,
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	.get_value_64 = counter_ace_v1x_rtc_get_value,
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 };
 
 DEVICE_DT_DEFINE(DT_NODELABEL(ace_rtc_counter), counter_ace_v1x_rtc_init, NULL, NULL, NULL,

--- a/drivers/counter/counter_cc23x0_rtc.c
+++ b/drivers/counter/counter_cc23x0_rtc.c
@@ -42,6 +42,7 @@ static int counter_cc23x0_get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 static int counter_cc23x0_get_value_64(const struct device *dev, uint64_t *ticks)
 {
 	const struct counter_cc23x0_config *config = dev->config;
@@ -61,6 +62,7 @@ static int counter_cc23x0_get_value_64(const struct device *dev, uint64_t *ticks
 
 	return 0;
 }
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 static void counter_cc23x0_isr(const struct device *dev)
 {
@@ -230,7 +232,9 @@ static DEVICE_API(counter, rtc_cc23x0_api) = {
 	.start = counter_cc23x0_start,
 	.stop = counter_cc23x0_stop,
 	.get_value = counter_cc23x0_get_value,
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 	.get_value_64 = counter_cc23x0_get_value_64,
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 	.set_alarm = counter_cc23x0_set_alarm,
 	.cancel_alarm = counter_cc23x0_cancel_alarm,
 	.get_top_value = counter_cc23x0_get_top_value,

--- a/drivers/counter/counter_esp32_rtc.c
+++ b/drivers/counter/counter_esp32_rtc.c
@@ -279,7 +279,9 @@ static DEVICE_API(counter, rtc_timer_esp32_api) = {
 	.start = counter_esp32_start,
 	.stop = counter_esp32_stop,
 	.get_value = counter_esp32_get_value,
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 	.get_value_64 = counter_esp32_get_value_64,
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 	.set_alarm = counter_esp32_set_alarm,
 	.cancel_alarm = counter_esp32_cancel_alarm,
 	.set_top_value = counter_esp32_set_top_value,

--- a/drivers/counter/counter_esp32_tmr.c
+++ b/drivers/counter/counter_esp32_tmr.c
@@ -26,10 +26,10 @@ typedef bool (*timer_isr_t)(void *);
 
 struct counter_esp32_top_data {
 	counter_top_callback_t callback;
-	uint32_t ticks;
+	uint64_t ticks;
 	void *user_data;
 	bool auto_reload;
-	uint32_t guard_period;
+	uint64_t guard_period;
 };
 
 struct counter_esp32_config {
@@ -45,9 +45,10 @@ struct counter_esp32_config {
 };
 
 struct counter_esp32_data {
-	struct counter_alarm_cfg alarm_cfg;
+	struct counter_alarm_cfg_64 alarm_cfg;
+	counter_alarm_callback_t alarm_callback_32;
 	struct counter_esp32_top_data top_data;
-	uint32_t ticks;
+	uint64_t ticks;
 	uint32_t clock_src_hz;
 	timer_hal_context_t hal_ctx;
 };
@@ -140,18 +141,18 @@ static int counter_esp32_get_value_64(const struct device *dev, uint64_t *ticks)
 	return 0;
 }
 
-static int counter_esp32_set_alarm(const struct device *dev, uint8_t chan_id,
-				   const struct counter_alarm_cfg *alarm_cfg)
+static int counter_esp32_set_alarm_64(const struct device *dev, uint8_t chan_id,
+				      const struct counter_alarm_cfg_64 *alarm_cfg)
 {
 	ARG_UNUSED(chan_id);
 	struct counter_esp32_data *data = dev->data;
 	bool absolute = alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE;
-	uint32_t ticks = alarm_cfg->ticks;
-	uint32_t top = data->top_data.ticks;
-	uint32_t max_rel_val = data->top_data.ticks;
+	uint64_t ticks = alarm_cfg->ticks;
+	uint64_t top = data->top_data.ticks;
+	uint64_t max_rel_val = data->top_data.ticks;
 	uint64_t now;
 	uint64_t target;
-	uint32_t diff;
+	uint64_t diff;
 	int err = 0;
 	bool irq_on_late = 0;
 
@@ -177,7 +178,7 @@ static int counter_esp32_set_alarm(const struct device *dev, uint8_t chan_id,
 
 	timer_ll_set_alarm_value(data->hal_ctx.dev, data->hal_ctx.timer_id, target);
 
-	diff = (alarm_cfg->ticks - (uint32_t)now);
+	diff = (alarm_cfg->ticks - now);
 	if (diff > max_rel_val) {
 		if (absolute) {
 			err = -ETIME;
@@ -216,21 +217,22 @@ static int counter_esp32_cancel_alarm(const struct device *dev, uint8_t chan_id)
 	return 0;
 }
 
-static int counter_esp32_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
+static int counter_esp32_set_top_value_64(const struct device *dev,
+					  const struct counter_top_cfg_64 *cfg)
 {
 	const struct counter_esp32_config *config = dev->config;
 	struct counter_esp32_data *data = dev->data;
-	uint32_t now;
+	uint64_t now;
 
 	if (data->alarm_cfg.callback) {
 		return -EBUSY;
 	}
 
-	if (cfg->ticks > config->counter_info.max_top_value) {
+	if (cfg->ticks > config->counter_info.max_top_value_64) {
 		return -ENOTSUP;
 	}
 
-	counter_esp32_get_value(dev, &now);
+	counter_esp32_get_value_64(dev, &now);
 
 	if (!(cfg->flags & COUNTER_TOP_CFG_DONT_RESET)) {
 		timer_hal_set_counter_value(&data->hal_ctx, 0);
@@ -267,7 +269,7 @@ static uint32_t counter_esp32_get_pending_int(const struct device *dev)
 	return timer_ll_get_intr_status(data->hal_ctx.dev);
 }
 
-static uint32_t counter_esp32_get_top_value(const struct device *dev)
+static uint64_t counter_esp32_get_top_value_64(const struct device *dev)
 {
 	struct counter_esp32_data *data = dev->data;
 
@@ -291,7 +293,7 @@ static int counter_esp32_reset(const struct device *dev)
 	return 0;
 }
 
-static uint32_t counter_esp32_get_guard_period(const struct device *dev, uint32_t flags)
+static uint64_t counter_esp32_get_guard_period_64(const struct device *dev, uint32_t flags)
 {
 	struct counter_esp32_data *data = dev->data;
 
@@ -300,7 +302,8 @@ static uint32_t counter_esp32_get_guard_period(const struct device *dev, uint32_
 	return data->top_data.guard_period;
 }
 
-static int counter_esp32_set_guard_period(const struct device *dev, uint32_t ticks, uint32_t flags)
+static int counter_esp32_set_guard_period_64(const struct device *dev, uint64_t ticks,
+					     uint32_t flags)
 {
 	struct counter_esp32_data *data = dev->data;
 
@@ -314,6 +317,76 @@ static int counter_esp32_set_guard_period(const struct device *dev, uint32_t tic
 	return 0;
 }
 
+static int counter_esp32_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
+{
+	struct counter_top_cfg_64 alarm_cfg_64 = {
+		.callback = cfg->callback,
+		.ticks = (uint64_t)cfg->ticks,
+		.user_data = cfg->user_data,
+		.flags = cfg->flags,
+	};
+
+	return counter_esp32_set_top_value_64(dev, &alarm_cfg_64);
+}
+
+static void counter_esp32_callback_32_trampoline(const struct device *dev,
+						 uint8_t chan_id,
+						 uint64_t ticks,
+						 void *user_data)
+{
+	struct counter_esp32_data *data = dev->data;
+
+	/* Safely call the original 32-bit callback */
+	data->alarm_callback_32(dev, chan_id, (uint32_t)ticks, user_data);
+}
+
+static int counter_esp32_set_alarm(const struct device *dev, uint8_t chan_id,
+				   const struct counter_alarm_cfg *alarm_cfg)
+{
+	struct counter_esp32_data *data = dev->data;
+	struct counter_alarm_cfg_64 alarm_cfg_64 = {
+		.callback = counter_esp32_callback_32_trampoline,
+		.ticks = (uint64_t)alarm_cfg->ticks,
+		.user_data = alarm_cfg->user_data,
+		.flags = alarm_cfg->flags,
+	};
+
+	/* use trampoline function to handle the function pointer type difference */
+	data->alarm_callback_32 = alarm_cfg->callback;
+
+	return counter_esp32_set_alarm_64(dev, chan_id, &alarm_cfg_64);
+}
+
+static uint32_t counter_esp32_get_top_value(const struct device *dev)
+{
+	struct counter_esp32_data *data = dev->data;
+
+	return (uint32_t)data->top_data.ticks;
+}
+
+static uint32_t counter_esp32_get_guard_period(const struct device *dev, uint32_t flags)
+{
+	struct counter_esp32_data *data = dev->data;
+
+	ARG_UNUSED(flags);
+
+	return (uint32_t)data->top_data.guard_period;
+}
+
+static int counter_esp32_set_guard_period(const struct device *dev, uint32_t ticks, uint32_t flags)
+{
+	struct counter_esp32_data *data = dev->data;
+
+	ARG_UNUSED(flags);
+
+	if (ticks > data->top_data.ticks) {
+		return -EINVAL;
+	}
+
+	data->top_data.guard_period = (uint64_t)ticks;
+	return 0;
+}
+
 static DEVICE_API(counter, counter_api) = {
 	.start = counter_esp32_start,
 	.stop = counter_esp32_stop,
@@ -321,24 +394,29 @@ static DEVICE_API(counter, counter_api) = {
 	.reset = counter_esp32_reset,
 	.get_value_64 = counter_esp32_get_value_64,
 	.set_alarm = counter_esp32_set_alarm,
+	.set_alarm_64 = counter_esp32_set_alarm_64,
 	.cancel_alarm = counter_esp32_cancel_alarm,
 	.set_top_value = counter_esp32_set_top_value,
+	.set_top_value_64 = counter_esp32_set_top_value_64,
 	.get_pending_int = counter_esp32_get_pending_int,
 	.get_top_value = counter_esp32_get_top_value,
+	.get_top_value_64 = counter_esp32_get_top_value_64,
 	.get_freq = counter_esp32_get_freq,
 	.get_guard_period = counter_esp32_get_guard_period,
+	.get_guard_period_64 = counter_esp32_get_guard_period_64,
 	.set_guard_period = counter_esp32_set_guard_period,
+	.set_guard_period_64 = counter_esp32_set_guard_period_64,
 };
 
 static void IRAM_ATTR counter_esp32_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
 	struct counter_esp32_data *data = dev->data;
-	counter_alarm_callback_t cb = data->alarm_cfg.callback;
+	counter_alarm_callback_64_t cb = data->alarm_cfg.callback;
 	void *cb_data = data->alarm_cfg.user_data;
-	uint32_t now;
+	uint64_t now;
 
-	counter_esp32_get_value(dev, &now);
+	counter_esp32_get_value_64(dev, &now);
 
 	if (cb) {
 		timer_ll_enable_intr(data->hal_ctx.dev,
@@ -374,7 +452,7 @@ static void IRAM_ATTR counter_esp32_isr(void *arg)
 	static struct counter_esp32_data counter_data_##idx;                                       \
                                                                                                    \
 	static const struct counter_esp32_config counter_config_##idx = {                          \
-		.counter_info = {.max_top_value = UINT32_MAX,                                      \
+		.counter_info = {.max_top_value_64 = UINT64_MAX,                                   \
 				 .flags = COUNTER_CONFIG_INFO_COUNT_UP,                            \
 				 .channels = 1},                                                   \
 		.config =                                                                          \

--- a/drivers/counter/counter_handlers.c
+++ b/drivers/counter/counter_handlers.c
@@ -73,6 +73,7 @@ static inline int z_vrfy_counter_get_value(const struct device *dev,
 }
 #include <zephyr/syscalls/counter_get_value_mrsh.c>
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 static inline int z_vrfy_counter_get_value_64(const struct device *dev,
 					   uint64_t *ticks)
 {
@@ -81,6 +82,7 @@ static inline int z_vrfy_counter_get_value_64(const struct device *dev,
 	return z_impl_counter_get_value_64((const struct device *)dev, ticks);
 }
 #include <zephyr/syscalls/counter_get_value_64_mrsh.c>
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 static inline int z_vrfy_counter_set_channel_alarm(const struct device *dev,
 						   uint8_t chan_id,

--- a/drivers/counter/counter_mchp_sam_pit64b.c
+++ b/drivers/counter/counter_mchp_sam_pit64b.c
@@ -134,6 +134,7 @@ static int sam_pit_get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 static int sam_pit_get_value_64(const struct device *dev, uint64_t *ticks)
 {
 	const struct sam_pit_config *config = dev->config;
@@ -148,6 +149,7 @@ static int sam_pit_get_value_64(const struct device *dev, uint64_t *ticks)
 
 	return 0;
 }
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 
 static int sam_pit_set_alarm(const struct device *dev, uint8_t chan_id,
 			     const struct counter_alarm_cfg *alarm_cfg)
@@ -389,7 +391,9 @@ static DEVICE_API(counter, sam_pit_driver_api) = {
 	.start = sam_pit_start,
 	.stop = sam_pit_stop,
 	.get_value = sam_pit_get_value,
+#ifdef CONFIG_COUNTER_64BITS_TICKS
 	.get_value_64 = sam_pit_get_value_64,
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 	.set_alarm = sam_pit_set_alarm,
 	.cancel_alarm = sam_pit_cancel_alarm,
 	.set_top_value = sam_pit_set_top_value,

--- a/drivers/counter/counter_rv3032.c
+++ b/drivers/counter/counter_rv3032.c
@@ -59,11 +59,6 @@ int rv3032_counter_get_value(const struct device *dev, uint32_t *ticks)
 	return 0;
 }
 
-int rv3032_counter_get_value_64(const struct device *dev, uint64_t *ticks)
-{
-	return -ENOTSUP;
-}
-
 int rv3032_counter_reset(const struct device *dev)
 {
 	const struct rv3032_counter_config *config = dev->config;
@@ -301,7 +296,6 @@ static DEVICE_API(counter, rv3032_counter_api) = {
 	.start = rv3032_counter_start,
 	.stop = rv3032_counter_stop,
 	.get_value = rv3032_counter_get_value,
-	.get_value_64 = rv3032_counter_get_value_64,
 	.reset = rv3032_counter_reset,
 	.set_alarm = rv3032_counter_set_alarm,
 	.cancel_alarm = rv3032_counter_cancel_alarm,

--- a/drivers/counter/counter_stm32_timer.c
+++ b/drivers/counter/counter_stm32_timer.c
@@ -474,6 +474,16 @@ static int counter_stm32_reset_timer(const struct device *dev)
 	return 0;
 }
 
+static int counter_stm32_set_value(const struct device *dev, uint32_t ticks)
+{
+	const struct counter_stm32_config *config = dev->config;
+	TIM_TypeDef *timer = config->timer;
+
+	LL_TIM_SetCounter(timer, ticks);
+
+	return 0;
+}
+
 static void counter_stm32_top_irq_handle(const struct device *dev)
 {
 	struct counter_stm32_data *data = dev->data;
@@ -521,6 +531,7 @@ static DEVICE_API(counter, counter_stm32_driver_api) = {
 	.set_guard_period = counter_stm32_set_guard_period,
 	.get_freq = counter_stm32_get_freq,
 	.reset = counter_stm32_reset_timer,
+	.set_value = counter_stm32_set_value,
 };
 
 #define TIM_IRQ_HANDLE_CC(timx, cc)						\

--- a/drivers/counter/counter_stm32_timer.c
+++ b/drivers/counter/counter_stm32_timer.c
@@ -464,6 +464,16 @@ static uint32_t counter_stm32_get_freq(const struct device *dev)
 	return data->freq;
 }
 
+static int counter_stm32_reset_timer(const struct device *dev)
+{
+	const struct counter_stm32_config *config = dev->config;
+	TIM_TypeDef *timer = config->timer;
+
+	LL_TIM_SetCounter(timer, 0);
+
+	return 0;
+}
+
 static void counter_stm32_top_irq_handle(const struct device *dev)
 {
 	struct counter_stm32_data *data = dev->data;
@@ -510,6 +520,7 @@ static DEVICE_API(counter, counter_stm32_driver_api) = {
 	.get_guard_period = counter_stm32_get_guard_period,
 	.set_guard_period = counter_stm32_set_guard_period,
 	.get_freq = counter_stm32_get_freq,
+	.reset = counter_stm32_reset_timer,
 };
 
 #define TIM_IRQ_HANDLE_CC(timx, cc)						\

--- a/drivers/sensor/sensor_clock_external.c
+++ b/drivers/sensor/sensor_clock_external.c
@@ -40,12 +40,15 @@ int sensor_clock_get_cycles(uint64_t *cycles)
 	__ASSERT_NO_MSG(counter_is_counting_up(external_sensor_clock));
 
 	int rc;
+#ifdef COUNTER_64BITS_TICKS
 	const struct counter_driver_api *api =
 		(const struct counter_driver_api *)external_sensor_clock->api;
 
 	if (api->get_value_64) {
 		rc = counter_get_value_64(external_sensor_clock, cycles);
-	} else {
+	} else
+#endif /* COUNTER_64BITS_TICKS */
+	{
 		uint32_t result_32;
 
 		rc = counter_get_value(external_sensor_clock, &result_32);

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -345,6 +345,23 @@ static inline uint64_t z_impl_counter_ticks_to_us(const struct device *dev,
 }
 
 /**
+ * @brief Function to convert nanoseconds to ticks.
+ *
+ * @param[in]  dev    Pointer to the device structure for the driver instance.
+ * @param[in]  ns     Nanoseconds.
+ *
+ * @return Converted ticks. Ticks will be saturated if exceed 32 bits.
+ */
+__syscall uint32_t counter_ns_to_ticks(const struct device *dev, uint64_t ns);
+
+static inline uint32_t z_impl_counter_ns_to_ticks(const struct device *dev, uint64_t ns)
+{
+	uint64_t ticks = (ns * get_frequency(dev)) / NSEC_PER_SEC;
+
+	return (ticks > (uint64_t)UINT32_MAX) ? UINT32_MAX : ticks;
+}
+
+/**
  * @brief Function to convert ticks to nanoseconds.
  *
  * @param[in]  dev    Pointer to the device structure for the driver instance.

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -479,6 +479,21 @@ static inline uint32_t z_impl_counter_us_to_ticks(const struct device *dev, uint
 }
 
 /**
+ * @brief Function to convert microseconds to ticks with 64 bits.
+ *
+ * @param[in]  dev    Pointer to the device structure for the driver instance.
+ * @param[in]  us     Microseconds.
+ *
+ * @return Converted ticks as a uint64_t
+ */
+__syscall uint64_t counter_us_to_ticks_64(const struct device *dev, uint64_t us);
+
+static inline uint64_t z_impl_counter_us_to_ticks_64(const struct device *dev, uint64_t us)
+{
+	return (us * z_counter_get_frequency(dev)) / USEC_PER_SEC;
+}
+
+/**
  * @brief Function to convert ticks to microseconds.
  *
  * @param[in]  dev    Pointer to the device structure for the driver instance.
@@ -491,6 +506,21 @@ __syscall uint64_t counter_ticks_to_us(const struct device *dev, uint32_t ticks)
 static inline uint64_t z_impl_counter_ticks_to_us(const struct device *dev, uint32_t ticks)
 {
 	return ((uint64_t)ticks * USEC_PER_SEC) / z_counter_get_frequency(dev);
+}
+
+/**
+ * @brief Function to convert ticks with 64 bits to microseconds.
+ *
+ * @param[in]  dev    Pointer to the device structure for the driver instance.
+ * @param[in]  ticks  Ticks in 64 bits.
+ *
+ * @return Converted microseconds.
+ */
+__syscall uint64_t counter_ticks_to_us_64(const struct device *dev, uint64_t ticks);
+
+static inline uint64_t z_impl_counter_ticks_to_us_64(const struct device *dev, uint64_t ticks)
+{
+	return (ticks * USEC_PER_SEC) / z_counter_get_frequency(dev);
 }
 
 /**
@@ -511,6 +541,21 @@ static inline uint32_t z_impl_counter_ns_to_ticks(const struct device *dev, uint
 }
 
 /**
+ * @brief Function to convert nanoseconds to ticks with 64 bits.
+ *
+ * @param[in]  dev    Pointer to the device structure for the driver instance.
+ * @param[in]  ns     Nanoseconds.
+ *
+ * @return Converted ticks as a uint64_t.
+ */
+__syscall uint64_t counter_ns_to_ticks_64(const struct device *dev, uint64_t ns);
+
+static inline uint64_t z_impl_counter_ns_to_ticks_64(const struct device *dev, uint64_t ns)
+{
+	return (ns * z_counter_get_frequency(dev)) / NSEC_PER_SEC;
+}
+
+/**
  * @brief Function to convert ticks to nanoseconds.
  *
  * @param[in]  dev    Pointer to the device structure for the driver instance.
@@ -523,6 +568,21 @@ __syscall uint64_t counter_ticks_to_ns(const struct device *dev, uint32_t ticks)
 static inline uint64_t z_impl_counter_ticks_to_ns(const struct device *dev, uint32_t ticks)
 {
 	return ((uint64_t)ticks * NSEC_PER_SEC) / z_counter_get_frequency(dev);
+}
+
+/**
+ * @brief Function to convert ticks with 64 bits to nanoseconds.
+ *
+ * @param[in]  dev    Pointer to the device structure for the driver instance.
+ * @param[in]  ticks  Ticks in 64 bits.
+ *
+ * @return Converted nanoseconds.
+ */
+__syscall uint64_t counter_ticks_to_ns_64(const struct device *dev, uint64_t ticks);
+
+static inline uint64_t z_impl_counter_ticks_to_ns_64(const struct device *dev, uint64_t ticks)
+{
+	return (ticks * NSEC_PER_SEC) / z_counter_get_frequency(dev);
 }
 
 /**

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -199,7 +199,22 @@ struct counter_config_info {
 	/**
 	 * Maximal (default) top value on which counter is reset (cleared or reloaded).
 	 */
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	union {
+		uint64_t max_top_value_64;
+		struct {
+#ifdef CONFIG_BIG_ENDIAN
+			uint32_t reserved;
+			uint32_t max_top_value;
+#else
+			uint32_t max_top_value;
+			uint32_t reserved;
+#endif /* CONFIG_BIG_ENDIAN */
+		};
+	};
+#else
 	uint32_t max_top_value;
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 	/**
 	 * Flags (see @ref COUNTER_FLAGS).
 	 */
@@ -212,13 +227,76 @@ struct counter_config_info {
 	uint8_t channels;
 };
 
+/** @brief Alarm callback
+ *
+ * @param dev       Pointer to the device structure for the driver instance.
+ * @param chan_id   Channel ID.
+ * @param ticks     Counter value that triggered the alarm.
+ * @param user_data User data.
+ */
+typedef void (*counter_alarm_callback_64_t)(const struct device *dev, uint8_t chan_id,
+					    uint64_t ticks, void *user_data);
+
+/** @brief Alarm callback structure.
+ */
+struct counter_alarm_cfg_64 {
+	/**
+	 * Number of ticks that triggers the alarm.
+	 *
+	 * It can be relative (to now) or an absolute value (see @ref
+	 * COUNTER_ALARM_CFG_ABSOLUTE). Both, relative and absolute, alarm
+	 * values can be any value between zero and the current top value (see
+	 * @ref counter_get_top_value). When setting an absolute alarm value
+	 * close to the current counter value there is a risk that the counter
+	 * will have counted past the given absolute value before the driver
+	 * manages to activate the alarm. Therefore a guard period can be
+	 * defined that lets the driver decide unambiguously whether it is late
+	 * or not (see @ref counter_set_guard_period). If the counter is clock
+	 * driven then ticks can be converted to microseconds (see @ref
+	 * counter_ticks_to_us). Alternatively, the counter implementation may
+	 * count asynchronous events.
+	 */
+	uint64_t ticks;
+	/**
+	 * Callback called on alarm (cannot be NULL).
+	 */
+	counter_alarm_callback_64_t callback;
+	/**
+	 * User data returned in callback.
+	 */
+	void *user_data;
+	/**
+	 * Alarm flags (see @ref COUNTER_ALARM_FLAGS).
+	 */
+	uint32_t flags;
+};
+
+/** @brief Top value configuration structure.
+ */
+struct counter_top_cfg_64 {
+	/**
+	 * Top value.
+	 */
+	uint64_t ticks;
+	/**
+	 * Callback function (can be NULL).
+	 */
+	counter_top_callback_t callback;
+	/**
+	 * User data passed to callback function (not valid if callback is NULL).
+	 */
+	void *user_data;
+	/**
+	 * Flags (see @ref COUNTER_TOP_FLAGS).
+	 */
+	uint32_t flags;
+};
+
 typedef int (*counter_api_start)(const struct device *dev);
 typedef int (*counter_api_stop)(const struct device *dev);
 typedef int (*counter_api_get_value)(const struct device *dev, uint32_t *ticks);
-typedef int (*counter_api_get_value_64)(const struct device *dev, uint64_t *ticks);
 typedef int (*counter_api_reset)(const struct device *dev);
 typedef int (*counter_api_set_value)(const struct device *dev, uint32_t ticks);
-typedef int (*counter_api_set_value_64)(const struct device *dev, uint64_t ticks);
 typedef int (*counter_api_set_alarm)(const struct device *dev, uint8_t chan_id,
 				     const struct counter_alarm_cfg *alarm_cfg);
 typedef int (*counter_api_cancel_alarm)(const struct device *dev, uint8_t chan_id);
@@ -232,14 +310,23 @@ typedef int (*counter_api_set_guard_period)(const struct device *dev, uint32_t t
 typedef uint32_t (*counter_api_get_freq)(const struct device *dev);
 typedef uint64_t (*counter_api_get_freq_64)(const struct device *dev);
 
+typedef int (*counter_api_get_value_64)(const struct device *dev, uint64_t *ticks);
+typedef int (*counter_api_set_value_64)(const struct device *dev, uint64_t ticks);
+typedef int (*counter_api_set_alarm_64)(const struct device *dev, uint8_t chan_id,
+					const struct counter_alarm_cfg_64 *alarm_cfg);
+typedef uint64_t (*counter_api_get_guard_period_64)(const struct device *dev, uint32_t flags);
+typedef int (*counter_api_set_guard_period_64)(const struct device *dev, uint64_t ticks,
+					       uint32_t flags);
+typedef uint64_t (*counter_api_get_top_value_64)(const struct device *dev);
+typedef int (*counter_api_set_top_value_64)(const struct device *dev,
+					    const struct counter_top_cfg_64 *cfg);
+
 __subsystem struct counter_driver_api {
 	counter_api_start start;
 	counter_api_stop stop;
 	counter_api_get_value get_value;
-	counter_api_get_value_64 get_value_64;
 	counter_api_reset reset;
 	counter_api_set_value set_value;
-	counter_api_set_value_64 set_value_64;
 	counter_api_set_alarm set_alarm;
 	counter_api_cancel_alarm cancel_alarm;
 	counter_api_set_top_value set_top_value;
@@ -251,6 +338,15 @@ __subsystem struct counter_driver_api {
 #ifdef CONFIG_COUNTER_64BITS_FREQ
 	counter_api_get_freq_64 get_freq_64;
 #endif /* CONFIG_COUNTER_64BITS_FREQ */
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	counter_api_get_value_64 get_value_64;
+	counter_api_set_value_64 set_value_64;
+	counter_api_set_alarm_64 set_alarm_64;
+	counter_api_get_guard_period_64 get_guard_period_64;
+	counter_api_set_guard_period_64 set_guard_period_64;
+	counter_api_get_top_value_64 get_top_value_64;
+	counter_api_set_top_value_64 set_top_value_64;
+#endif /* CONFIG_COUNTER_64BITS_TICKS */
 };
 
 /**
@@ -434,6 +530,10 @@ static inline uint64_t z_impl_counter_ticks_to_ns(const struct device *dev, uint
  *
  * @param[in]  dev    Pointer to the device structure for the driver instance.
  *
+ * @warning With `CONFIG_COUNTER_64BITS_TICKS` enabled this function returns only the lower
+ *          32 bits of the max top value. Use `counter_get_max_top_value_64()` to get
+ *          the full 64 bit value if it is expected to exceed 32 bits.
+ *
  * @return Max top value.
  */
 __syscall uint32_t counter_get_max_top_value(const struct device *dev);
@@ -498,27 +598,6 @@ static inline int z_impl_counter_get_value(const struct device *dev, uint32_t *t
 }
 
 /**
- * @brief Get current counter 64-bit value.
- * @param dev Pointer to the device structure for the driver instance.
- * @param ticks Pointer to where to store the current counter value
- *
- * @retval 0 If successful.
- * @retval <0 Negative error code on failure getting the counter value
- */
-__syscall int counter_get_value_64(const struct device *dev, uint64_t *ticks);
-
-static inline int z_impl_counter_get_value_64(const struct device *dev, uint64_t *ticks)
-{
-	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
-
-	if (!api->get_value_64) {
-		return -ENOSYS;
-	}
-
-	return api->get_value_64(dev, ticks);
-}
-
-/**
  * @brief Reset the counter to the initial value.
  * @param dev Pointer to the device structure for the driver instance.
  *
@@ -557,27 +636,6 @@ static inline int z_impl_counter_set_value(const struct device *dev, uint32_t ti
 	}
 
 	return api->set_value(dev, ticks);
-}
-
-/**
- * @brief Set current counter 64-bit value.
- * @param dev Pointer to the device structure for the driver instance.
- * @param ticks Tick value to set
- *
- * @retval 0 If successful.
- * @retval Negative error code on failure setting the counter value
- */
-__syscall int counter_set_value_64(const struct device *dev, uint64_t ticks);
-
-static inline int z_impl_counter_set_value_64(const struct device *dev, uint64_t ticks)
-{
-	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
-
-	if (!api->set_value_64) {
-		return -ENOSYS;
-	}
-
-	return api->set_value_64(dev, ticks);
 }
 
 /**
@@ -652,6 +710,10 @@ static inline int z_impl_counter_cancel_channel_alarm(const struct device *dev, 
  * running while top value is updated, it is possible that counter progresses
  * outside the new top value. In that case, error is returned and optionally
  * driver can reset the counter (see @ref COUNTER_TOP_CFG_RESET_WHEN_LATE).
+ *
+ * @warning With `CONFIG_COUNTER_64BITS_TICKS` enabled this function sets the lower
+ *          32 bits of the max top value. Use `counter_set_top_value_64()` to get
+ *          the full 64 bit value if it is expected to exceed 32 bits.
  *
  * @param dev		Pointer to the device structure for the driver instance.
  * @param cfg		Configuration. Cannot be NULL.
@@ -800,6 +862,288 @@ static inline uint32_t z_impl_counter_get_guard_period(const struct device *dev,
 	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return (api->get_guard_period) ? api->get_guard_period(dev, flags) : 0;
+}
+
+/**
+ * @brief Function to retrieve maximum top value that can be set for 64 bits.
+ *
+ * @param[in]  dev    Pointer to the device structure for the driver instance.
+ *
+ * @return Max top value in 64 bits.
+ */
+__syscall uint64_t counter_get_max_top_value_64(const struct device *dev);
+
+static inline uint64_t z_impl_counter_get_max_top_value_64(const struct device *dev)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_config_info *config = (const struct counter_config_info *)dev->config;
+
+	return config->max_top_value_64;
+#else
+	ARG_UNUSED(dev);
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Set counter top value for 64 bits.
+ *
+ * Function sets top value and optionally resets the counter to 0 or top value
+ * depending on counter direction. On turnaround, counter can be reset and
+ * optional callback is periodically called. Top value can only be changed when
+ * there is no active channel alarm.
+ *
+ * @ref COUNTER_TOP_CFG_DONT_RESET prevents counter reset. When counter is
+ * running while top value is updated, it is possible that counter progresses
+ * outside the new top value. In that case, error is returned and optionally
+ * driver can reset the counter (see @ref COUNTER_TOP_CFG_RESET_WHEN_LATE).
+ *
+ * @param dev		Pointer to the device structure for the driver instance.
+ * @param cfg		Configuration. Cannot be NULL.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP if request is not supported (e.g. top value cannot be
+ *		    changed or counter cannot/must be reset during top value
+		    update).
+ * @retval -EBUSY if any alarm is active.
+ * @retval -ETIME if @ref COUNTER_TOP_CFG_DONT_RESET was set and new top value
+ *		  is smaller than current counter value (counter counting up).
+ */
+__syscall int counter_set_top_value_64(const struct device *dev,
+				       const struct counter_top_cfg_64 *cfg);
+
+static inline int z_impl_counter_set_top_value_64(const struct device *dev,
+						  const struct counter_top_cfg_64 *cfg)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
+
+	if (cfg->ticks > counter_get_max_top_value_64(dev)) {
+		return -EINVAL;
+	}
+
+	return api->set_top_value_64(dev, cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cfg);
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Set a single shot alarm on a channel for 64 bits.
+ *
+ * After expiration alarm can be set again, disabling is not needed. When alarm
+ * expiration handler is called, channel is considered available and can be
+ * set again in that context.
+ *
+ * @note API is not thread safe.
+ *
+ * @param dev		Pointer to the device structure for the driver instance.
+ * @param chan_id	Channel ID.
+ * @param alarm_cfg	Alarm configuration.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOTSUP if request is not supported (device does not support
+ *		    interrupts or requested channel).
+ * @retval -EINVAL if alarm settings are invalid.
+ * @retval -ETIME  if absolute alarm was set too late.
+ * @retval -EBUSY  if alarm is already active.
+ */
+__syscall int counter_set_channel_alarm_64(const struct device *dev, uint8_t chan_id,
+					   const struct counter_alarm_cfg_64 *alarm_cfg);
+
+static inline int z_impl_counter_set_channel_alarm_64(const struct device *dev, uint8_t chan_id,
+						      const struct counter_alarm_cfg_64 *alarm_cfg)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
+
+	if (chan_id >= counter_get_num_of_channels(dev)) {
+		return -ENOTSUP;
+	}
+
+	return api->set_alarm_64(dev, chan_id, alarm_cfg);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(chan_id);
+	ARG_UNUSED(alarm_cfg);
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Function to retrieve current top value for 64 bits.
+ *
+ * @param[in]  dev    Pointer to the device structure for the driver instance.
+ *
+ * @return Top value in 64 bits.
+ */
+__syscall uint64_t counter_get_top_value_64(const struct device *dev);
+
+static inline uint64_t z_impl_counter_get_top_value_64(const struct device *dev)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
+
+	return api->get_top_value_64(dev);
+#else
+	ARG_UNUSED(dev);
+	return 0;
+#endif
+}
+
+/**
+ * @brief Set guard period in counter ticks for 64 bits.
+ *
+ * When setting an absolute alarm value close to the current counter value there
+ * is a risk that the counter will have counted past the given absolute value
+ * before the driver manages to activate the alarm. If this would go unnoticed
+ * then the alarm would only expire after the timer has wrapped and reached the
+ * given absolute value again after a full timer period. This could take a long
+ * time in case of a 32 bit timer. Setting a sufficiently large guard period will
+ * help the driver detect unambiguously whether it is late or not.
+ *
+ * The guard period should be as many counter ticks as the driver will need at
+ * most to actually activate the alarm after the driver API has been called. If
+ * the driver finds that the counter has just passed beyond the given absolute
+ * tick value but is still close enough to fall within the guard period, it will
+ * assume that it is "late", i.e. that the intended expiry time has already passed.
+ * Depending on the @ref COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE flag the driver will
+ * either ignore the alarm or expire it immediately in such a case.
+ *
+ * If, however, the counter is past the given absolute tick value but outside
+ * the guard period, then the driver will assume that this is intentional and
+ * let the counter wrap around to/from zero before it expires.
+ *
+ * More precisely:
+ *
+ * - When counting upwards (see @ref COUNTER_CONFIG_INFO_COUNT_UP) the given
+ *   absolute tick value must be above (now + guard_period) % top_value to be
+ *   accepted by the driver.
+ * - When counting downwards, the given absolute tick value must be less than
+ *   (now + top_value - guard_period) % top_value to be accepted.
+ *
+ * Examples:
+ *
+ * - counting upwards, now = 4950, top value = 5000, guard period = 100:
+ *      absolute tick value >= (4950 + 100) % 5000 = 50
+ * - counting downwards, now = 50, top value = 5000, guard period = 100:
+ *      absolute tick value <= (50 + 5000 - * 100) % 5000 = 4950
+ *
+ * If you need only short alarm periods, you can set the guard period very high
+ * (e.g. half of the counter top value) which will make it highly unlikely that
+ * the counter will ever unintentionally wrap.
+ *
+ * The guard period is set to 0 on initialization (no protection).
+ *
+ * @param dev		Pointer to the device structure for the driver instance.
+ * @param ticks		Guard period in counter ticks of 64 bits.
+ * @param flags		See @ref COUNTER_GUARD_PERIOD_FLAGS.
+ *
+ * @retval 0 if successful.
+ * @retval -ENOSYS if function or flags are not supported.
+ * @retval -EINVAL if ticks value is invalid.
+ */
+__syscall int counter_set_guard_period_64(const struct device *dev, uint64_t ticks, uint32_t flags);
+
+static inline int z_impl_counter_set_guard_period_64(const struct device *dev, uint64_t ticks,
+						     uint32_t flags)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
+
+	if (!api->set_guard_period_64) {
+		return -ENOSYS;
+	}
+
+	return api->set_guard_period_64(dev, ticks, flags);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ticks);
+	ARG_UNUSED(flags);
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Return guard period for 64 bits.
+ *
+ * @see counter_set_guard_period_64.
+ *
+ * @param dev	Pointer to the device structure for the driver instance.
+ * @param flags	See @ref COUNTER_GUARD_PERIOD_FLAGS.
+ *
+ * @return Guard period given in counter ticks or 0 if function or flags are
+ *	   not supported.
+ */
+__syscall uint64_t counter_get_guard_period_64(const struct device *dev, uint32_t flags);
+
+static inline uint64_t z_impl_counter_get_guard_period_64(const struct device *dev, uint32_t flags)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
+
+	return (api->get_guard_period_64) ? api->get_guard_period_64(dev, flags) : 0;
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(flags);
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Get current counter 64-bit value.
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param ticks Pointer to where to store the current counter value in 64 bits.
+ *
+ * @retval 0 If successful.
+ * @retval <0 Negative error code on failure getting the counter value
+ */
+__syscall int counter_get_value_64(const struct device *dev, uint64_t *ticks);
+
+static inline int z_impl_counter_get_value_64(const struct device *dev, uint64_t *ticks)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
+
+	if (!api->get_value_64) {
+		return -ENOSYS;
+	}
+
+	return api->get_value_64(dev, ticks);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ticks);
+	return -ENOTSUP;
+#endif
+}
+
+/**
+ * @brief Set current counter 64-bit value.
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param ticks Tick value to set in 64 bits
+ *
+ * @retval 0 If successful.
+ * @retval <0 Negative error code on failure setting the counter value
+ */
+__syscall int counter_set_value_64(const struct device *dev, uint64_t ticks);
+
+static inline int z_impl_counter_set_value_64(const struct device *dev, uint64_t ticks)
+{
+#ifdef CONFIG_COUNTER_64BITS_TICKS
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
+
+	if (!api->set_value_64) {
+		return -ENOSYS;
+	}
+
+	return api->set_value_64(dev, ticks);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ticks);
+	return -ENOTSUP;
+#endif
 }
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -93,7 +93,7 @@ extern "C" {
  *
  * Alarm callback must be called from the same context as if it was set on time.
  */
-#define COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE  BIT(1)
+#define COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE BIT(1)
 
 /**@} */
 
@@ -120,8 +120,7 @@ extern "C" {
  * @param ticks     Counter value that triggered the alarm.
  * @param user_data User data.
  */
-typedef void (*counter_alarm_callback_t)(const struct device *dev,
-					 uint8_t chan_id, uint32_t ticks,
+typedef void (*counter_alarm_callback_t)(const struct device *dev, uint8_t chan_id, uint32_t ticks,
 					 void *user_data);
 
 /** @brief Alarm callback structure.
@@ -163,8 +162,7 @@ struct counter_alarm_cfg {
  * @param dev       Pointer to the device structure for the driver instance.
  * @param user_data User data provided in @ref counter_set_top_value.
  */
-typedef void (*counter_top_callback_t)(const struct device *dev,
-				       void *user_data);
+typedef void (*counter_top_callback_t)(const struct device *dev, void *user_data);
 
 /** @brief Top value configuration structure.
  */
@@ -216,29 +214,21 @@ struct counter_config_info {
 
 typedef int (*counter_api_start)(const struct device *dev);
 typedef int (*counter_api_stop)(const struct device *dev);
-typedef int (*counter_api_get_value)(const struct device *dev,
-				     uint32_t *ticks);
-typedef int (*counter_api_get_value_64)(const struct device *dev,
-			uint64_t *ticks);
+typedef int (*counter_api_get_value)(const struct device *dev, uint32_t *ticks);
+typedef int (*counter_api_get_value_64)(const struct device *dev, uint64_t *ticks);
 typedef int (*counter_api_reset)(const struct device *dev);
-typedef int (*counter_api_set_value)(const struct device *dev,
-				     uint32_t ticks);
-typedef int (*counter_api_set_value_64)(const struct device *dev,
-					uint64_t ticks);
-typedef int (*counter_api_set_alarm)(const struct device *dev,
-				     uint8_t chan_id,
+typedef int (*counter_api_set_value)(const struct device *dev, uint32_t ticks);
+typedef int (*counter_api_set_value_64)(const struct device *dev, uint64_t ticks);
+typedef int (*counter_api_set_alarm)(const struct device *dev, uint8_t chan_id,
 				     const struct counter_alarm_cfg *alarm_cfg);
-typedef int (*counter_api_cancel_alarm)(const struct device *dev,
-					uint8_t chan_id);
+typedef int (*counter_api_cancel_alarm)(const struct device *dev, uint8_t chan_id);
 typedef int (*counter_api_set_top_value)(const struct device *dev,
 					 const struct counter_top_cfg *cfg);
 typedef uint32_t (*counter_api_get_pending_int)(const struct device *dev);
 typedef uint32_t (*counter_api_get_top_value)(const struct device *dev);
-typedef uint32_t (*counter_api_get_guard_period)(const struct device *dev,
-						 uint32_t flags);
-typedef int (*counter_api_set_guard_period)(const struct device *dev,
-						uint32_t ticks,
-						uint32_t flags);
+typedef uint32_t (*counter_api_get_guard_period)(const struct device *dev, uint32_t flags);
+typedef int (*counter_api_set_guard_period)(const struct device *dev, uint32_t ticks,
+					    uint32_t flags);
 typedef uint32_t (*counter_api_get_freq)(const struct device *dev);
 typedef uint64_t (*counter_api_get_freq_64)(const struct device *dev);
 
@@ -275,8 +265,7 @@ __syscall bool counter_is_counting_up(const struct device *dev);
 
 static inline bool z_impl_counter_is_counting_up(const struct device *dev)
 {
-	const struct counter_config_info *config =
-			(const struct counter_config_info *)dev->config;
+	const struct counter_config_info *config = (const struct counter_config_info *)dev->config;
 
 	return config->flags & COUNTER_CONFIG_INFO_COUNT_UP;
 }
@@ -292,8 +281,7 @@ __syscall uint8_t counter_get_num_of_channels(const struct device *dev);
 
 static inline uint8_t z_impl_counter_get_num_of_channels(const struct device *dev)
 {
-	const struct counter_config_info *config =
-			(const struct counter_config_info *)dev->config;
+	const struct counter_config_info *config = (const struct counter_config_info *)dev->config;
 
 	return config->channels;
 }
@@ -313,10 +301,8 @@ __syscall uint32_t counter_get_frequency(const struct device *dev);
  */
 static inline uint32_t z_impl_counter_get_frequency(const struct device *dev)
 {
-	const struct counter_config_info *config =
-			(const struct counter_config_info *)dev->config;
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_config_info *config = (const struct counter_config_info *)dev->config;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (api->get_freq) {
 		return api->get_freq(dev);
@@ -337,10 +323,8 @@ static inline uint32_t z_impl_counter_get_frequency(const struct device *dev)
  */
 static inline uint32_t z_impl_counter_get_frequency(const struct device *dev)
 {
-	const struct counter_config_info *config =
-			(const struct counter_config_info *)dev->config;
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_config_info *config = (const struct counter_config_info *)dev->config;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return api->get_freq ? api->get_freq(dev) : config->freq;
 }
@@ -359,10 +343,8 @@ __syscall uint64_t counter_get_frequency_64(const struct device *dev);
 static inline uint64_t z_impl_counter_get_frequency_64(const struct device *dev)
 {
 #ifdef CONFIG_COUNTER_64BITS_FREQ
-	const struct counter_config_info *config =
-			(const struct counter_config_info *)dev->config;
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_config_info *config = (const struct counter_config_info *)dev->config;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (api->get_freq_64) {
 		return api->get_freq_64(dev);
@@ -393,8 +375,7 @@ static inline uint64_t z_impl_counter_get_frequency_64(const struct device *dev)
  */
 __syscall uint32_t counter_us_to_ticks(const struct device *dev, uint64_t us);
 
-static inline uint32_t z_impl_counter_us_to_ticks(const struct device *dev,
-					       uint64_t us)
+static inline uint32_t z_impl_counter_us_to_ticks(const struct device *dev, uint64_t us)
 {
 	uint64_t ticks = (us * z_counter_get_frequency(dev)) / USEC_PER_SEC;
 
@@ -411,8 +392,7 @@ static inline uint32_t z_impl_counter_us_to_ticks(const struct device *dev,
  */
 __syscall uint64_t counter_ticks_to_us(const struct device *dev, uint32_t ticks);
 
-static inline uint64_t z_impl_counter_ticks_to_us(const struct device *dev,
-					       uint32_t ticks)
+static inline uint64_t z_impl_counter_ticks_to_us(const struct device *dev, uint32_t ticks)
 {
 	return ((uint64_t)ticks * USEC_PER_SEC) / z_counter_get_frequency(dev);
 }
@@ -444,8 +424,7 @@ static inline uint32_t z_impl_counter_ns_to_ticks(const struct device *dev, uint
  */
 __syscall uint64_t counter_ticks_to_ns(const struct device *dev, uint32_t ticks);
 
-static inline uint64_t z_impl_counter_ticks_to_ns(const struct device *dev,
-					       uint32_t ticks)
+static inline uint64_t z_impl_counter_ticks_to_ns(const struct device *dev, uint32_t ticks)
 {
 	return ((uint64_t)ticks * NSEC_PER_SEC) / z_counter_get_frequency(dev);
 }
@@ -461,8 +440,7 @@ __syscall uint32_t counter_get_max_top_value(const struct device *dev);
 
 static inline uint32_t z_impl_counter_get_max_top_value(const struct device *dev)
 {
-	const struct counter_config_info *config =
-			(const struct counter_config_info *)dev->config;
+	const struct counter_config_info *config = (const struct counter_config_info *)dev->config;
 
 	return config->max_top_value;
 }
@@ -479,8 +457,7 @@ __syscall int counter_start(const struct device *dev);
 
 static inline int z_impl_counter_start(const struct device *dev)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return api->start(dev);
 }
@@ -498,8 +475,7 @@ __syscall int counter_stop(const struct device *dev);
 
 static inline int z_impl_counter_stop(const struct device *dev)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return api->stop(dev);
 }
@@ -514,11 +490,9 @@ static inline int z_impl_counter_stop(const struct device *dev)
  */
 __syscall int counter_get_value(const struct device *dev, uint32_t *ticks);
 
-static inline int z_impl_counter_get_value(const struct device *dev,
-					   uint32_t *ticks)
+static inline int z_impl_counter_get_value(const struct device *dev, uint32_t *ticks)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return api->get_value(dev, ticks);
 }
@@ -533,11 +507,9 @@ static inline int z_impl_counter_get_value(const struct device *dev,
  */
 __syscall int counter_get_value_64(const struct device *dev, uint64_t *ticks);
 
-static inline int z_impl_counter_get_value_64(const struct device *dev,
-					   uint64_t *ticks)
+static inline int z_impl_counter_get_value_64(const struct device *dev, uint64_t *ticks)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (!api->get_value_64) {
 		return -ENOSYS;
@@ -557,8 +529,7 @@ __syscall int counter_reset(const struct device *dev);
 
 static inline int z_impl_counter_reset(const struct device *dev)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (!api->reset) {
 		return -ENOSYS;
@@ -577,11 +548,9 @@ static inline int z_impl_counter_reset(const struct device *dev)
  */
 __syscall int counter_set_value(const struct device *dev, uint32_t ticks);
 
-static inline int z_impl_counter_set_value(const struct device *dev,
-					   uint32_t ticks)
+static inline int z_impl_counter_set_value(const struct device *dev, uint32_t ticks)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (!api->set_value) {
 		return -ENOSYS;
@@ -600,11 +569,9 @@ static inline int z_impl_counter_set_value(const struct device *dev,
  */
 __syscall int counter_set_value_64(const struct device *dev, uint64_t ticks);
 
-static inline int z_impl_counter_set_value_64(const struct device *dev,
-					      uint64_t ticks)
+static inline int z_impl_counter_set_value_64(const struct device *dev, uint64_t ticks)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (!api->set_value_64) {
 		return -ENOSYS;
@@ -633,16 +600,13 @@ static inline int z_impl_counter_set_value_64(const struct device *dev,
  * @retval -ETIME  if absolute alarm was set too late.
  * @retval -EBUSY  if alarm is already active.
  */
-__syscall int counter_set_channel_alarm(const struct device *dev,
-					uint8_t chan_id,
+__syscall int counter_set_channel_alarm(const struct device *dev, uint8_t chan_id,
 					const struct counter_alarm_cfg *alarm_cfg);
 
-static inline int z_impl_counter_set_channel_alarm(const struct device *dev,
-						   uint8_t chan_id,
+static inline int z_impl_counter_set_channel_alarm(const struct device *dev, uint8_t chan_id,
 						   const struct counter_alarm_cfg *alarm_cfg)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (chan_id >= counter_get_num_of_channels(dev)) {
 		return -ENOTSUP;
@@ -663,14 +627,11 @@ static inline int z_impl_counter_set_channel_alarm(const struct device *dev,
  * @retval -ENOTSUP if request is not supported or the counter was not started
  *		    yet.
  */
-__syscall int counter_cancel_channel_alarm(const struct device *dev,
-					   uint8_t chan_id);
+__syscall int counter_cancel_channel_alarm(const struct device *dev, uint8_t chan_id);
 
-static inline int z_impl_counter_cancel_channel_alarm(const struct device *dev,
-						      uint8_t chan_id)
+static inline int z_impl_counter_cancel_channel_alarm(const struct device *dev, uint8_t chan_id)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (chan_id >= counter_get_num_of_channels(dev)) {
 		return -ENOTSUP;
@@ -703,15 +664,12 @@ static inline int z_impl_counter_cancel_channel_alarm(const struct device *dev,
  * @retval -ETIME if @ref COUNTER_TOP_CFG_DONT_RESET was set and new top value
  *		  is smaller than current counter value (counter counting up).
  */
-__syscall int counter_set_top_value(const struct device *dev,
-				    const struct counter_top_cfg *cfg);
+__syscall int counter_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg);
 
 static inline int z_impl_counter_set_top_value(const struct device *dev,
-					       const struct counter_top_cfg
-					       *cfg)
+					       const struct counter_top_cfg *cfg)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (cfg->ticks > counter_get_max_top_value(dev)) {
 		return -EINVAL;
@@ -737,8 +695,7 @@ __syscall int counter_get_pending_int(const struct device *dev);
 
 static inline int z_impl_counter_get_pending_int(const struct device *dev)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return api->get_pending_int(dev);
 }
@@ -754,8 +711,7 @@ __syscall uint32_t counter_get_top_value(const struct device *dev);
 
 static inline uint32_t z_impl_counter_get_top_value(const struct device *dev)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return api->get_top_value(dev);
 }
@@ -812,15 +768,12 @@ static inline uint32_t z_impl_counter_get_top_value(const struct device *dev)
  * @retval -ENOSYS if function or flags are not supported.
  * @retval -EINVAL if ticks value is invalid.
  */
-__syscall int counter_set_guard_period(const struct device *dev,
-					uint32_t ticks,
-					uint32_t flags);
+__syscall int counter_set_guard_period(const struct device *dev, uint32_t ticks, uint32_t flags);
 
-static inline int z_impl_counter_set_guard_period(const struct device *dev,
-						   uint32_t ticks, uint32_t flags)
+static inline int z_impl_counter_set_guard_period(const struct device *dev, uint32_t ticks,
+						  uint32_t flags)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	if (!api->set_guard_period) {
 		return -ENOSYS;
@@ -840,14 +793,11 @@ static inline int z_impl_counter_set_guard_period(const struct device *dev,
  * @return Guard period given in counter ticks or 0 if function or flags are
  *	   not supported.
  */
-__syscall uint32_t counter_get_guard_period(const struct device *dev,
-					    uint32_t flags);
+__syscall uint32_t counter_get_guard_period(const struct device *dev, uint32_t flags);
 
-static inline uint32_t z_impl_counter_get_guard_period(const struct device *dev,
-							uint32_t flags)
+static inline uint32_t z_impl_counter_get_guard_period(const struct device *dev, uint32_t flags)
 {
-	const struct counter_driver_api *api =
-				(struct counter_driver_api *)dev->api;
+	const struct counter_driver_api *api = (struct counter_driver_api *)dev->api;
 
 	return (api->get_guard_period) ? api->get_guard_period(dev, flags) : 0;
 }

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -217,6 +217,10 @@ typedef int (*counter_api_get_value)(const struct device *dev,
 typedef int (*counter_api_get_value_64)(const struct device *dev,
 			uint64_t *ticks);
 typedef int (*counter_api_reset)(const struct device *dev);
+typedef int (*counter_api_set_value)(const struct device *dev,
+				     uint32_t ticks);
+typedef int (*counter_api_set_value_64)(const struct device *dev,
+					uint64_t ticks);
 typedef int (*counter_api_set_alarm)(const struct device *dev,
 				     uint8_t chan_id,
 				     const struct counter_alarm_cfg *alarm_cfg);
@@ -239,6 +243,8 @@ __subsystem struct counter_driver_api {
 	counter_api_get_value get_value;
 	counter_api_get_value_64 get_value_64;
 	counter_api_reset reset;
+	counter_api_set_value set_value;
+	counter_api_set_value_64 set_value_64;
 	counter_api_set_alarm set_alarm;
 	counter_api_cancel_alarm cancel_alarm;
 	counter_api_set_top_value set_top_value;
@@ -469,6 +475,52 @@ static inline int z_impl_counter_reset(const struct device *dev)
 	}
 
 	return api->reset(dev);
+}
+
+/**
+ * @brief Set current counter value.
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param ticks Tick value to set
+ *
+ * @retval 0 If successful.
+ * @retval Negative error code on failure setting the counter value
+ */
+__syscall int counter_set_value(const struct device *dev, uint32_t ticks);
+
+static inline int z_impl_counter_set_value(const struct device *dev,
+					   uint32_t ticks)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (!api->set_value) {
+		return -ENOSYS;
+	}
+
+	return api->set_value(dev, ticks);
+}
+
+/**
+ * @brief Set current counter 64-bit value.
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param ticks Tick value to set
+ *
+ * @retval 0 If successful.
+ * @retval Negative error code on failure setting the counter value
+ */
+__syscall int counter_set_value_64(const struct device *dev, uint64_t ticks);
+
+static inline int z_impl_counter_set_value_64(const struct device *dev,
+					      uint64_t ticks)
+{
+	const struct counter_driver_api *api =
+				(struct counter_driver_api *)dev->api;
+
+	if (!api->set_value_64) {
+		return -ENOSYS;
+	}
+
+	return api->set_value_64(dev, ticks);
 }
 
 /**


### PR DESCRIPTION
This also introduces an api for set the counter time.

Also, this set frequency to be 64 bits rather than 32 bits, as counters,
such as those that use fractional adders, tick at resolutions
greater than 4294967295Hz. This changes the freq in the common info
to a uint64_t. This retains the existing counter_get_freq function which
will still return a 32bit value. This also adds a counter_get_freq_64
function to get a 64bit value for the frequency. Unfortunately, I do not
have a 'public' driver that uses this.

Add inline helper functions for converting ticks to nanoseconds.

Also implement an inline helper for converting microseconds or
nanoseconds with a 64bit tick value.

_this was a split from https://github.com/zephyrproject-rtos/zephyr/pull/89127_