### PR TITLE
Bluetooth: Remove _node field of bt_conn_cb if not used

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -2175,8 +2175,10 @@ struct bt_conn_cb {
 	void (*role_changed)(struct bt_conn *conn, uint8_t status);
 #endif
 
+#if defined(CONFIG_BT_CONN_DYNAMIC_CALLBACKS)
 	/** @internal Internally used field for list handling */
 	sys_snode_t _node;
+#endif
 };
 
 /** @brief Register connection callbacks.


### PR DESCRIPTION
After the #93703 PR was merged we get a possibility to remove _node field from bt_conn_cb struct if the BT_CONN_DYNAMIC_CALLBACKS option is disabled. The list conn_cbs can also be safely removed by more macro usage.