### PR TITLE
Add CPU load support for Cortex-A

### DIFF
--- a/arch/arm64/core/cpu_idle.S
+++ b/arch/arm64/core/cpu_idle.S
@@ -23,6 +23,11 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 #endif
 	dsb	sy
 	wfi
+#ifdef CONFIG_TRACING
+	str	lr, [sp, #-16]!
+	bl	sys_trace_idle_exit
+	ldr	lr, [sp], #16
+#endif
 	msr	daifclr, #(DAIFCLR_IRQ_BIT)
 	ret
 #endif
@@ -38,6 +43,11 @@ SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 	msr	daifset, #(DAIFSET_IRQ_BIT)
 	isb
 	wfe
+#ifdef CONFIG_TRACING
+	str	lr, [sp, #-16]!
+	bl	sys_trace_idle_exit
+	ldr	lr, [sp], #16
+#endif
 	tst	x0, #(DAIF_IRQ_BIT)
 	beq	_irq_disabled
 	msr	daifclr, #(DAIFCLR_IRQ_BIT)

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -353,7 +353,7 @@ config CS_TRACE_DEFMT
 
 config CPU_LOAD
 	select TRACING
-	depends on CPU_CORTEX_M || RISCV
+	depends on CPU_CORTEX_M || RISCV || CPU_CORTEX_A
 	depends on !SMP
 	bool "CPU load measurement"
 

--- a/tests/subsys/debug/cpu_load/testcase.yaml
+++ b/tests/subsys/debug/cpu_load/testcase.yaml
@@ -2,6 +2,7 @@ common:
   tags: cpu_load
   arch_allow:
     - arm
+    - arm64
     - riscv
   filter: CONFIG_CPU_LOAD
 tests:


### PR DESCRIPTION
This PR adds `sys_trace_idle_exit` hook before leaving idle state to support CPU load for Cortex-A. This hook is used to track CPU load if CONFIG_CPU_LOAD=y but missing in the current implementation.

Note that the CPU load is used by LVGL for CPU usage measurement. Without `sys_trace_idle_exit`, the CPU usage is always showed as 100%