### PR TITLE
drivers: input: it8xxx2: resolve runtime assertion failure

### DIFF
--- a/drivers/input/input_ite_it8xxx2_kbd.c
+++ b/drivers/input/input_ite_it8xxx2_kbd.c
@@ -171,15 +171,15 @@ static int it8xxx2_kbd_init(const struct device *dev)
 		 *   Bit[7:6] = 00b: Select alternate KSO function
 		 *   Bit[2] = 1b: Enable the internal pull-up of KSO pin
 		 *
-		 * NOTE: Set input temporarily for gpio_pin_configure(), after
-		 * that pinctrl_apply_state() set to alternate function
-		 * immediately.
+		 * NOTE: Set (output | dt_flag) temporarily for kso16 and
+		 * kso17 pins, after that pinctrl_apply_state() set to
+		 * alternate function immediately.
 		 */
 		if (!(config->kso_ignore_mask & BIT(16))) {
-			gpio_pin_configure_dt(&config->kso16_gpios, GPIO_INPUT);
+			gpio_pin_configure_dt(&config->kso16_gpios, GPIO_OUTPUT);
 		}
 		if (common->col_size > 17 && !(config->kso_ignore_mask & BIT(17))) {
-			gpio_pin_configure_dt(&config->kso17_gpios, GPIO_INPUT);
+			gpio_pin_configure_dt(&config->kso17_gpios, GPIO_OUTPUT);
 		}
 	}
 	/*


### PR DESCRIPTION
When the kso[17:16] lines are enabled and `CONFIG_ASSERT` is configured, the following error occurs: "Input cannot be enabled for 'Open Drain', 'Open Source' modes without Output." This pr resolves the issue.

Tested with: no abnormal keyscan occurs during initialization