### PR TITLE
net: lib: http_server: prevent busfault if socket family is AF_UNSPEC

### DIFF
--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -276,8 +276,9 @@ static int accept_new_client(int server_fd)
 		return new_socket;
 	}
 
-	LOG_DBG("New client from %s:%d",
-		net_sprint_addr(sa.ss_family, &net_sin((struct sockaddr *)&sa)->sin_addr),
+	const char * const addrstr =
+		net_sprint_addr(sa.ss_family, &net_sin((struct sockaddr *)&sa)->sin_addr);
+	LOG_DBG("New client from %s:%d", addrstr != NULL ? addrstr : "<unknown>",
 		ntohs(net_sin((struct sockaddr *)&sa)->sin_port));
 
 	return new_socket;


### PR DESCRIPTION
If webserver uses custom socket creation,
and it's family is AF_UNSPEC, net_sprint_addr will return NULL, which leads to LOG_DBG crashing with busfault.
Add NULL check for that.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94181