### PR TITLE
crypto: hash: in_buf should be constant

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -325,6 +325,13 @@ Cellular
  * :c:enum:`cellular_access_technology` values have been redefined to align with 3GPP TS 27.007.
  * :c:enum:`cellular_registration_status` values have been extended to align with 3GPP TS 27.007.
 
+Crypto
+======
+
+* Hashing operations now require a constant input in the :c:struct:`hash_pkt`.
+  This shouldn't affect any existing code, unless an out-of-tree hashing backend actually
+  performs that operation in-place (see :github:`94218`)
+
 Flash Map
 =========
 

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -51,6 +51,10 @@ API Changes
 ..
   Only removed, deprecated and new APIs, changes go in migration guide.
 
+* Crypto
+
+  * The input buffer in :c:struct:`hash_pkt` is now constant
+
 Removed APIs and options
 ========================
 

--- a/drivers/crypto/crypto_mchp_xec_symcr.c
+++ b/drivers/crypto/crypto_mchp_xec_symcr.c
@@ -358,7 +358,7 @@ static int xec_symcr_do_hash(struct hash_ctx *ctx, struct hash_pkt *pkt, bool fi
 		hs->blklen = 0; /* consumed */
 	}
 
-	ret = mchp_xec_rom_hash_feed_wrapper(c, (const uint8_t *)pkt->in_buf, fill_len);
+	ret = mchp_xec_rom_hash_feed_wrapper(c, pkt->in_buf, fill_len);
 	if (ret) {
 		LOG_ERR("ROM hash feed error %d", ret);
 		return ret;

--- a/drivers/crypto/crypto_rts5912_sha.c
+++ b/drivers/crypto/crypto_rts5912_sha.c
@@ -122,7 +122,7 @@ static int rts5912_sha256_process(const struct device *dev, uint8_t *input, size
 	return 0;
 }
 
-static int rts5912_sha256_update(const struct device *dev, uint8_t *input, size_t len)
+static int rts5912_sha256_update(const struct device *dev, const uint8_t *input, size_t len)
 {
 	struct rts5912_sha256_context *rts5912_sha256_ctx = dev->data;
 	uint32_t remain, fill, blk_size = 0, ret_val = 0;

--- a/drivers/crypto/crypto_smartbond.c
+++ b/drivers/crypto/crypto_smartbond.c
@@ -390,7 +390,7 @@ static int crypto_smartbond_hash_set_algo(enum hash_algo algo)
 	return 0;
 }
 
-static int crypto_smartbond_set_in_out_buf(uint8_t *in_buf, uint8_t *out_buf, int len)
+static int crypto_smartbond_set_in_out_buf(const uint8_t *in_buf, uint8_t *out_buf, int len)
 {
 	if (in_buf == NULL) {
 		return -EIO;

--- a/include/zephyr/crypto/hash.h
+++ b/include/zephyr/crypto/hash.h
@@ -88,7 +88,7 @@ struct hash_ctx {
 struct hash_pkt {
 
 	/** Start address of input buffer */
-	uint8_t *in_buf;
+	const uint8_t *in_buf;
 
 	/** Bytes to be operated upon */
 	size_t  in_len;

--- a/samples/boards/microchip/mec172xevb_assy6906/rom_api/src/main.c
+++ b/samples/boards/microchip/mec172xevb_assy6906/rom_api/src/main.c
@@ -441,7 +441,7 @@ static int test_zephyr_hash_chunk_block_size(const struct hash_tp *htbl, size_t 
 			/* SHA algorithms block sizes are powers of 2 */
 			updatesz = msgsz & ~(blocksz - 1u);
 			printf("  Update size is %d\n", updatesz);
-			zhash_pkt.in_buf = (uint8_t *)msgptr;
+			zhash_pkt.in_buf = msgptr;
 			zhash_pkt.in_len = updatesz;
 			zhash_pkt.out_buf = digest;
 			zhash_pkt.ctx = &zhash_ctx;
@@ -459,7 +459,7 @@ static int test_zephyr_hash_chunk_block_size(const struct hash_tp *htbl, size_t 
 
 		printf("  Final size is %u\n", msgsz);
 
-		zhash_pkt.in_buf = (uint8_t *)msgptr;
+		zhash_pkt.in_buf = msgptr;
 		zhash_pkt.in_len = msgsz;
 		zhash_pkt.out_buf = digest;
 		zhash_pkt.ctx = &zhash_ctx;
@@ -536,7 +536,7 @@ static int test_zephyr_hash_chunk(const struct hash_tp *htbl, size_t nentries, s
 		while (chunksz && ((msgsz - total_updatesz) > chunksz)) {
 			chunk_cnt++;
 
-			zhash_pkt.in_buf = (uint8_t *)msgptr;
+			zhash_pkt.in_buf = msgptr;
 			zhash_pkt.in_len = updatesz;
 			zhash_pkt.out_buf = digest;
 			zhash_pkt.ctx = &zhash_ctx;
@@ -553,7 +553,7 @@ static int test_zephyr_hash_chunk(const struct hash_tp *htbl, size_t nentries, s
 		}
 
 		remsz = msgsz - total_updatesz;
-		zhash_pkt.in_buf = (uint8_t *)msgptr;
+		zhash_pkt.in_buf = msgptr;
 		zhash_pkt.in_len = remsz;
 		zhash_pkt.out_buf = digest;
 		zhash_pkt.ctx = &zhash_ctx;


### PR DESCRIPTION
Hashing takes an input buffer, and writes the result in a separate
output buffer. Therefore, the input can be marked as constant, so that
constants can be supplied directly to the hashing context without any
intermediate copy, and without having to perform a type-unsafe cast
from (const uint8_t *) to (uint8_t *)

Signed-off-by: Titouan Christophe <titouan.christophe@mind.be>
