### PR TITLE
Test and Fix MCUboot for BeagleConnect Freedom

### DIFF
--- a/boards/beagle/beagleconnect_freedom/Kconfig.sysbuild
+++ b/boards/beagle/beagleconnect_freedom/Kconfig.sysbuild
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Ayush Singh, BeagleBoard.org Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+if BOOTLOADER_MCUBOOT
+
+choice MCUBOOT_MODE
+	prompt "Mode of operation"
+	default MCUBOOT_MODE_SWAP_SCRATCH
+
+endchoice
+
+endif # BOOTLOADER_MCUBOOT

--- a/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
+++ b/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
@@ -100,17 +100,19 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Allocate 128 KiB for mcuboot */
+		/* Allocate 56 KiB for mcuboot */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00020000>;
+			reg = <0x00000000 DT_SIZE_K(56)>;
 		};
 
-		/* Allocate 568 KiB for application (avoid touching CCFG) */
-		slot0_partition: partition@20000 {
+		/* Allocate 640 KiB for application */
+		slot0_partition: partition@e000 {
 			label = "image-0";
-			reg = <0x00020000 0x0008e000>;
+			reg = <0x0000e000 DT_SIZE_K(640)>;
 		};
+
+		/* (avoid touching CCFG) */
 	};
 };
 
@@ -182,22 +184,21 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			/* Allocate 568 KiB for application */
+			/* Allocate 640 KiB for application */
 			slot1_partition: partition@0 {
 				label = "image-1";
-				reg = <0x00000000 0x0008e000>;
+				reg = <0x00000000 DT_SIZE_K(640)>;
 			};
 
 			/* Allocate 128 KiB scratch for image swap */
-			scratch_partition: partition@8e000 {
+			scratch_partition: partition@A0000 {
 				label = "image-scratch";
-				reg = <0x0008e000 0x00020000>;
+				reg = <0x000a0000 DT_SIZE_K(128)>;
 			};
 
-			/* Allocate 1 MiB storage partition */
-			storage_partition: partition@ae000 {
+			storage_partition: partition@c0000 {
 				label = "storage";
-				reg = <0x000ae000 DT_SIZE_K(1024)>;
+				reg = <0x000c0000 DT_SIZE_K(1280)>;
 			};
 		};
 	};

--- a/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
+++ b/boards/beagle/beagleconnect_freedom/beagleconnect_freedom.dts
@@ -33,6 +33,7 @@
 		zephyr,flash = &flash0;
 		zephyr,ieee802154 = &ieee802154g;
 		zephyr,code-partition = &slot0_partition;
+		zephyr,uart-mcumgr = &uart0;
 	};
 
 	gpio_keys {


### PR DESCRIPTION
- Tested using `samples/subsys/mgmt/mcumgr/smp_svr`.
- Enabling fs causes the application to not run, so only tested with `overlay-serial.conf` right now.
- The reason for using swap with scratch is as follows:
  - slot0 and slot1 are on different flash (say A and B).
  - flash A and B have different sector sizes (8K and 4K).
  - slot1 should be >= slot0. This is due to the fact that slot0 is in
    the soc flash. Hence, want to have as much usable space as possible.
- Requires: https://github.com/zephyrproject-rtos/zephyr/pull/94174
