### PR TITLE
Add option to get hoplimit from ancillary data using recvmsg()

### DIFF
--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2016 Intel Corporation
  * Copyright (c) 2021 Nordic Semiconductor
  * Copyright (c) 2025 Aerlync Labs Inc.
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -369,6 +370,10 @@ __net_socket struct net_context {
 #if defined(CONFIG_NET_CONTEXT_RECV_PKTINFO)
 		/** Receive network packet information in recvmsg() call */
 		bool recv_pktinfo;
+#endif
+#if defined(CONFIG_NET_CONTEXT_RECV_HOPLIMIT)
+		/** Receive IPv6 hop limit or IPv4 TTL as ancillary data in recvmsg() call */
+		bool recv_hoplimit;
 #endif
 #if defined(CONFIG_NET_IPV6)
 		/**
@@ -1399,6 +1404,7 @@ enum net_context_option {
 	NET_OPT_LOCAL_PORT_RANGE  = 21, /**< Clamp local port range */
 	NET_OPT_IPV6_MCAST_LOOP	  = 22, /**< IPV6 multicast loop */
 	NET_OPT_IPV4_MCAST_LOOP	  = 23, /**< IPV4 multicast loop */
+	NET_OPT_RECV_HOPLIMIT     = 24, /**< Receive hop limit information */
 };
 
 /**

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -1092,6 +1092,9 @@ struct ipv6_mreq {
  */
 #define IPV6_RECVPKTINFO 49
 
+/** Option which returns an in6_pktinfo structure in ancillary data */
+#define IPV6_PKTINFO 50
+
 /** Pass an IPV6_RECVHOPLIMIT ancillary message that contains information
  *  about the hop limit of the incoming packet. See RFC 3542.
  */

--- a/include/zephyr/net/socket.h
+++ b/include/zephyr/net/socket.h
@@ -9,6 +9,7 @@
  * Copyright (c) 2017-2018 Linaro Limited
  * Copyright (c) 2021 Nordic Semiconductor
  * Copyright (c) 2025 Aerlync Labs Inc.
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -991,6 +992,11 @@ struct in_pktinfo {
 	struct in_addr ipi_addr;     /**< Header Destination address */
 };
 
+/** Pass an IP_RECVTTL ancillary message that contains information
+ *  about the time to live of the incoming packet.
+ */
+#define IP_RECVTTL 12
+
 /** Retrieve the current known path MTU of the current socket. Returns an
  *  integer. IP_MTU is valid only for getsockopt and can be employed only when
  *  the socket has been connected.
@@ -1085,6 +1091,14 @@ struct ipv6_mreq {
  *  incoming packet. See RFC 3542.
  */
 #define IPV6_RECVPKTINFO 49
+
+/** Pass an IPV6_RECVHOPLIMIT ancillary message that contains information
+ *  about the hop limit of the incoming packet. See RFC 3542.
+ */
+#define IPV6_RECVHOPLIMIT 51
+
+/** Set or receive the hoplimit value for an outgoing packet. */
+#define IPV6_HOPLIMIT 52
 
 /** RFC5014: Source address selection. */
 #define IPV6_ADDR_PREFERENCES   72

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -3,6 +3,7 @@
 # Copyright (c) 2016 Intel Corporation.
 # Copyright (c) 2021 Nordic Semiconductor
 # Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
+# Copyright 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 menu "IP stack"
@@ -606,6 +607,14 @@ config NET_CONTEXT_RECV_PKTINFO
 	help
 	  Allow to set the IP_PKTINFO or IPV6_RECVPKTINFO flags on a socket.
 	  This way user can get extra information about the received data in the
+	  socket.
+
+config NET_CONTEXT_RECV_HOPLIMIT
+	bool "Add receive hop limit (IPv6) or TTL (IPv4) support to net_context"
+	depends on NET_UDP
+	help
+	  Allow to set the IPV6_RECVHOPLIMIT or IP_RECVTTL flags on a socket.
+	  This way user can get extra information about hop limit (IPv6) or TTL (IPv4) in the
 	  socket.
 
 config NET_CONTEXT_TIMESTAMPING

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -96,6 +96,7 @@ extern bool net_context_is_reuseaddr_set(struct net_context *context);
 extern bool net_context_is_reuseport_set(struct net_context *context);
 extern bool net_context_is_v6only_set(struct net_context *context);
 extern bool net_context_is_recv_pktinfo_set(struct net_context *context);
+extern bool net_context_is_recv_hoplimit_set(struct net_context *context);
 extern bool net_context_is_timestamping_set(struct net_context *context);
 extern void net_pkt_init(void);
 int net_context_get_local_addr(struct net_context *context,
@@ -120,6 +121,11 @@ static inline bool net_context_is_reuseport_set(struct net_context *context)
 	return false;
 }
 static inline bool net_context_is_recv_pktinfo_set(struct net_context *context)
+{
+	ARG_UNUSED(context);
+	return false;
+}
+static inline bool net_context_is_recv_hoplimit_set(struct net_context *context)
 {
 	ARG_UNUSED(context);
 	return false;

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Nordic Semiconductor
  * Copyright (c) 2023 Arm Limited (or its affiliates). All rights reserved.
  * Copyright (c) 2025 Aerlync Labs Inc.
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1061,6 +1062,35 @@ out:
 	return ret;
 }
 
+static int add_hoplimit(struct net_context *ctx,
+			struct net_pkt *pkt,
+			struct msghdr *msg)
+{
+	int ret = -ENOTSUP;
+
+	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET) {
+		int ttl = net_pkt_ipv4_ttl(pkt);
+
+		ret = insert_pktinfo(msg, IPPROTO_IP, IP_TTL,
+				     &ttl, sizeof(ttl));
+
+		goto out;
+	}
+
+	if (IS_ENABLED(CONFIG_NET_IPV6) && net_pkt_family(pkt) == AF_INET6) {
+		int hop_limit = net_pkt_ipv6_hop_limit(pkt);
+
+		ret = insert_pktinfo(msg, IPPROTO_IPV6, IPV6_HOPLIMIT,
+				     &hop_limit, sizeof(hop_limit));
+
+		goto out;
+	}
+
+out:
+
+	return ret;
+}
+
 static int update_msg_controllen(struct msghdr *msg)
 {
 	struct cmsghdr *cmsg;
@@ -1227,6 +1257,13 @@ static ssize_t zsock_recv_dgram(struct net_context *ctx,
 				if (IS_ENABLED(CONFIG_NET_CONTEXT_RECV_PKTINFO) &&
 				    net_context_is_recv_pktinfo_set(ctx)) {
 					if (add_pktinfo(ctx, pkt, msg) < 0) {
+						msg->msg_flags |= ZSOCK_MSG_CTRUNC;
+					}
+				}
+
+				if (IS_ENABLED(CONFIG_NET_CONTEXT_RECV_HOPLIMIT) &&
+				    net_context_is_recv_hoplimit_set(ctx)) {
+					if (add_hoplimit(ctx, pkt, msg) < 0) {
 						msg->msg_flags |= ZSOCK_MSG_CTRUNC;
 					}
 				}
@@ -2584,6 +2621,23 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 
 			break;
 
+		case IP_RECVTTL:
+			if (IS_ENABLED(CONFIG_NET_IPV4) &&
+			    IS_ENABLED(CONFIG_NET_CONTEXT_RECV_HOPLIMIT)) {
+				ret = net_context_set_option(ctx,
+							     NET_OPT_RECV_HOPLIMIT,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
+
 		case IP_MULTICAST_IF:
 			if (IS_ENABLED(CONFIG_NET_IPV4)) {
 				return ipv4_multicast_if(ctx, optval, optlen, false);
@@ -2692,6 +2746,23 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 			    IS_ENABLED(CONFIG_NET_CONTEXT_RECV_PKTINFO)) {
 				ret = net_context_set_option(ctx,
 							     NET_OPT_RECV_PKTINFO,
+							     optval,
+							     optlen);
+				if (ret < 0) {
+					errno  = -ret;
+					return -1;
+				}
+
+				return 0;
+			}
+
+			break;
+
+		case IPV6_RECVHOPLIMIT:
+			if (IS_ENABLED(CONFIG_NET_IPV6) &&
+			    IS_ENABLED(CONFIG_NET_CONTEXT_RECV_HOPLIMIT)) {
+				ret = net_context_set_option(ctx,
+							     NET_OPT_RECV_HOPLIMIT,
 							     optval,
 							     optlen);
 				if (ret < 0) {

--- a/subsys/net/lib/sockets/sockets_inet.c
+++ b/subsys/net/lib/sockets/sockets_inet.c
@@ -1050,7 +1050,7 @@ static int add_pktinfo(struct net_context *ctx,
 		net_ipv6_addr_copy_raw((uint8_t *)&info.ipi6_addr, ipv6_hdr->dst);
 		info.ipi6_ifindex = ctx->iface;
 
-		ret = insert_pktinfo(msg, IPPROTO_IPV6, IPV6_RECVPKTINFO,
+		ret = insert_pktinfo(msg, IPPROTO_IPV6, IPV6_PKTINFO,
 				     &info, sizeof(info));
 
 		goto out;

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1806,7 +1806,11 @@ static void run_ancillary_recvmsg_test(int client_sock,
 
 	opt = 1;
 	optlen = sizeof(opt);
-	rv = zsock_setsockopt(server_sock, IPPROTO_IP, IP_PKTINFO, &opt, optlen);
+	if (server_addr->sa_family == AF_INET) {
+		rv = zsock_setsockopt(server_sock, IPPROTO_IP, IP_PKTINFO, &opt, optlen);
+	} else {
+		rv = zsock_setsockopt(server_sock, IPPROTO_IPV6, IPV6_RECVPKTINFO, &opt, optlen);
+	}
 	zassert_equal(rv, 0, "setsockopt failed (%d)", -errno);
 
 	memset(&cmsgbuf, 0, sizeof(cmsgbuf));
@@ -1840,7 +1844,7 @@ static void run_ancillary_recvmsg_test(int client_sock,
 		}
 
 		if (cmsg->cmsg_level == IPPROTO_IPV6 &&
-		    cmsg->cmsg_type == IPV6_RECVPKTINFO) {
+		    cmsg->cmsg_type == IPV6_PKTINFO) {
 			net_ipaddr_copy(&net_sin6(&addr)->sin6_addr,
 					&((struct in6_pktinfo *)CMSG_DATA(cmsg))->ipi6_addr);
 			ifindex = ((struct in6_pktinfo *)CMSG_DATA(cmsg))->ipi6_ifindex;

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017 Linaro Limited
  * Copyright (c) 2021 Nordic Semiconductor
+ * Copyright 2025 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -3212,6 +3213,268 @@ ZTEST(net_socket_udp, test_42_v6_dgram_peer_addr_reset)
 				   (struct sockaddr *)&client_addr, sizeof(client_addr),
 				   (struct sockaddr *)&server_addr_1, sizeof(server_addr_1),
 				   (struct sockaddr *)&server_addr_2, sizeof(server_addr_2));
+}
+
+static void comm_sendmsg_recvmsg_hop_limit(int client_sock,
+					   struct sockaddr *client_addr,
+					   socklen_t client_addrlen,
+					   const struct msghdr *client_msg,
+					   int server_sock,
+					   struct sockaddr *server_addr,
+					   socklen_t server_addrlen,
+					   struct msghdr *msg,
+					   void *cmsgbuf, int cmsgbuf_len,
+					   bool expect_control_data)
+{
+#define MAX_BUF_LEN 64
+	char buf[MAX_BUF_LEN];
+	struct iovec io_vector[1];
+	ssize_t sent;
+	ssize_t recved;
+	struct sockaddr addr;
+	socklen_t addrlen = server_addrlen;
+	int len, i;
+
+	zassert_not_null(client_addr, "null client addr");
+	zassert_not_null(server_addr, "null server addr");
+
+	/*
+	 * Test client -> server sending
+	 */
+
+	sent = zsock_sendmsg(client_sock, client_msg, 0);
+	zassert_true(sent > 0, "sendmsg failed, %s (%d)", strerror(errno), -errno);
+
+	/* One negative test with invalid msg_iov */
+	memset(msg, 0, sizeof(*msg));
+	recved = zsock_recvmsg(server_sock, msg, 0);
+	zassert_true(recved < 0 && errno == ENOMEM, "Wrong errno (%d)", errno);
+
+	for (i = 0, len = 0; i < client_msg->msg_iovlen; i++) {
+		len += client_msg->msg_iov[i].iov_len;
+	}
+
+	zassert_equal(sent, len, "iovec len (%d) vs sent (%d)", len, sent);
+
+	/* Test first with one iovec */
+	io_vector[0].iov_base = buf;
+	io_vector[0].iov_len = sizeof(buf);
+
+	memset(msg, 0, sizeof(*msg));
+	if (cmsgbuf != NULL) {
+		memset(cmsgbuf, 0, cmsgbuf_len);
+	}
+	msg->msg_control = cmsgbuf;
+	msg->msg_controllen = cmsgbuf_len;
+	msg->msg_iov = io_vector;
+	msg->msg_iovlen = 1;
+	msg->msg_name = &addr;
+	msg->msg_namelen = addrlen;
+
+	/* Test normal recvmsg() */
+	clear_buf(rx_buf);
+	recved = zsock_recvmsg(server_sock, msg, 0);
+	zassert_true(recved > 0, "recvfrom fail");
+	zassert_equal(recved, len, "unexpected received bytes");
+	zassert_equal(msg->msg_iovlen, 1, "recvmsg should not modify msg_iovlen");
+	zassert_equal(msg->msg_iov[0].iov_len, sizeof(buf),
+		      "recvmsg should not modify buffer length");
+	zassert_mem_equal(buf, TEST_STR_SMALL, len,
+			  "wrong data (%s)", rx_buf);
+	zassert_equal(addrlen, client_addrlen, "unexpected addrlen");
+
+	/* Control data should be empty */
+	if (!expect_control_data) {
+		zassert_equal(msg->msg_controllen, 0,
+			      "We received control data (%u vs %zu)",
+			      0U, msg->msg_controllen);
+	}
+}
+
+static void run_ancillary_recvmsg_hoplimit_test(int client_sock,
+						struct sockaddr *client_addr,
+						int client_addr_len,
+						int server_sock,
+						struct sockaddr *server_addr,
+						int server_addr_len)
+{
+	int rv;
+	int opt;
+	socklen_t optlen;
+	struct msghdr msg;
+	struct msghdr server_msg;
+	struct iovec io_vector[1];
+	struct cmsghdr *cmsg, *prevcmsg;
+	int send_hop_limit = 90, recv_hop_limit = 0;
+	union {
+		struct cmsghdr hdr;
+		unsigned char  buf[CMSG_SPACE(sizeof(int))];
+	} cmsgbuf;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_NET_CONTEXT_RECV_HOPLIMIT);
+
+	rv = zsock_bind(server_sock, server_addr, server_addr_len);
+	zassert_equal(rv, 0, "server bind failed");
+
+	rv = zsock_bind(client_sock, client_addr, client_addr_len);
+	zassert_equal(rv, 0, "client bind failed");
+
+	io_vector[0].iov_base = TEST_STR_SMALL;
+	io_vector[0].iov_len = strlen(TEST_STR_SMALL);
+
+	memset(&cmsgbuf, 0, sizeof(cmsgbuf));
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_name = server_addr;
+	msg.msg_namelen = server_addr_len;
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = 1;
+	msg.msg_control = &cmsgbuf.buf;
+	msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	if (client_addr->sa_family == AF_INET) {
+		cmsg->cmsg_level = IPPROTO_IP;
+		cmsg->cmsg_type = IP_TTL;
+	} else {
+		cmsg->cmsg_level = IPPROTO_IPV6;
+		cmsg->cmsg_type = IPV6_HOPLIMIT;
+	}
+
+	*(int *)CMSG_DATA(cmsg) = send_hop_limit;
+
+	comm_sendmsg_recvmsg_hop_limit(client_sock,
+				       client_addr,
+				       client_addr_len,
+				       &msg,
+				       server_sock,
+				       server_addr,
+				       server_addr_len,
+				       &server_msg,
+				       &cmsgbuf.buf,
+				       sizeof(cmsgbuf.buf),
+				       true);
+
+	for (prevcmsg = NULL, cmsg = CMSG_FIRSTHDR(&server_msg);
+	     cmsg != NULL && prevcmsg != cmsg;
+	     prevcmsg = cmsg, cmsg = CMSG_NXTHDR(&server_msg, cmsg)) {
+		if (client_addr->sa_family == AF_INET) {
+			if (cmsg->cmsg_level == IPPROTO_IP &&
+			    cmsg->cmsg_type == IP_TTL) {
+				recv_hop_limit = *(int *)CMSG_DATA(cmsg);
+				break;
+			}
+		} else {
+			if (cmsg->cmsg_level == IPPROTO_IPV6 &&
+			    cmsg->cmsg_type == IPV6_HOPLIMIT) {
+				recv_hop_limit = *(int *)CMSG_DATA(cmsg);
+				break;
+			}
+		}
+	}
+
+	/* As we have not set the socket option, the hop_limit should not be set */
+	zassert_equal(recv_hop_limit, 0, "Hop limit set!");
+
+	opt = 1;
+	optlen = sizeof(opt);
+	if (server_addr->sa_family == AF_INET) {
+		rv = zsock_setsockopt(server_sock, IPPROTO_IP, IP_RECVTTL, &opt, optlen);
+	} else {
+		rv = zsock_setsockopt(server_sock, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &opt, optlen);
+	}
+	zassert_equal(rv, 0, "setsockopt failed (%d)", -errno);
+
+	memset(&cmsgbuf, 0, sizeof(cmsgbuf));
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_name = server_addr;
+	msg.msg_namelen = server_addr_len;
+	msg.msg_iov = io_vector;
+	msg.msg_iovlen = 1;
+	msg.msg_control = &cmsgbuf.buf;
+	msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	if (client_addr->sa_family == AF_INET) {
+		cmsg->cmsg_level = IPPROTO_IP;
+		cmsg->cmsg_type = IP_TTL;
+	} else {
+		cmsg->cmsg_level = IPPROTO_IPV6;
+		cmsg->cmsg_type = IPV6_HOPLIMIT;
+	}
+
+	*(int *)CMSG_DATA(cmsg) = send_hop_limit;
+
+	comm_sendmsg_recvmsg_hop_limit(client_sock,
+				       client_addr,
+				       client_addr_len,
+				       &msg,
+				       server_sock,
+				       server_addr,
+				       server_addr_len,
+				       &server_msg,
+				       &cmsgbuf.buf,
+				       sizeof(cmsgbuf.buf),
+				       true);
+
+	for (prevcmsg = NULL, cmsg = CMSG_FIRSTHDR(&server_msg);
+	     cmsg != NULL && prevcmsg != cmsg;
+	     prevcmsg = cmsg, cmsg = CMSG_NXTHDR(&server_msg, cmsg)) {
+		if (client_addr->sa_family == AF_INET) {
+			if (cmsg->cmsg_level == IPPROTO_IP &&
+			    cmsg->cmsg_type == IP_TTL) {
+				recv_hop_limit = *(int *)CMSG_DATA(cmsg);
+				break;
+			}
+		} else {
+			if (cmsg->cmsg_level == IPPROTO_IPV6 &&
+			    cmsg->cmsg_type == IPV6_HOPLIMIT) {
+				recv_hop_limit = *(int *)CMSG_DATA(cmsg);
+				break;
+			}
+		}
+	}
+
+	zassert_equal(send_hop_limit, recv_hop_limit, "Hop limit not parsed correctly");
+}
+
+ZTEST_USER(net_socket_udp, test_43_recvmsg_ancillary_ipv4_hoplimit_data_user)
+{
+	struct sockaddr_in client_addr;
+	struct sockaddr_in server_addr;
+	int client_sock;
+	int server_sock;
+
+	prepare_sock_udp_v4(MY_IPV4_ADDR, ANY_PORT, &client_sock, &client_addr);
+	prepare_sock_udp_v4(MY_IPV4_ADDR, SERVER_PORT, &server_sock, &server_addr);
+
+	run_ancillary_recvmsg_hoplimit_test(client_sock,
+					    (struct sockaddr *)&client_addr,
+					    sizeof(client_addr),
+					    server_sock,
+					    (struct sockaddr *)&server_addr,
+					    sizeof(server_addr));
+}
+
+ZTEST_USER(net_socket_udp, test_44_recvmsg_ancillary_ipv6_hoplimit_data_user)
+{
+	struct sockaddr_in6 client_addr;
+	struct sockaddr_in6 server_addr;
+	int client_sock;
+	int server_sock;
+
+	prepare_sock_udp_v6(MY_IPV6_ADDR, ANY_PORT, &client_sock, &client_addr);
+	prepare_sock_udp_v6(MY_IPV6_ADDR, SERVER_PORT, &server_sock, &server_addr);
+
+	run_ancillary_recvmsg_hoplimit_test(client_sock,
+					    (struct sockaddr *)&client_addr,
+					    sizeof(client_addr),
+					    server_sock,
+					    (struct sockaddr *)&server_addr,
+					    sizeof(server_addr));
 }
 
 static void after(void *arg)

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -20,6 +20,9 @@ tests:
   net.socket.udp.pktinfo:
     extra_configs:
       - CONFIG_NET_CONTEXT_RECV_PKTINFO=y
+  net.socket.udp.hoplimit:
+    extra_configs:
+      - CONFIG_NET_CONTEXT_RECV_HOPLIMIT=y
   net.socket.udp.port_range:
     extra_configs:
       - CONFIG_NET_CONTEXT_CLAMP_PORT_RANGE=y


### PR DESCRIPTION
This PR adds support for retrieving hop limit/ttl values from ancillary data when using recvmsg() function.

Relates to #94156 