### PR TITLE
tests: kernel: interrupt: generic ISR offset definition for nrf54h20 …

### DIFF
--- a/tests/kernel/gen_isr_table/src/main.c
+++ b/tests/kernel/gen_isr_table/src/main.c
@@ -32,7 +32,7 @@ extern const uintptr_t _irq_vector_table[];
 #define ISR3_OFFSET	17
 #define ISR5_OFFSET	18
 #define TRIG_CHECK_SIZE	19
-#elif defined(CONFIG_SOC_NRF54H20_CPUPPR) || defined(CONFIG_SOC_NRF54H20_CPUFLPR)
+#elif defined(CONFIG_SOC_SERIES_NRF54HX) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
 #define ISR1_OFFSET	14
 #define ISR3_OFFSET	15
 #define ISR5_OFFSET	16


### PR DESCRIPTION
…VPRs

All VPRs in nrf54h20 can have same ISR offset configuration.