### PR TITLE
net: context: Reset peer address on connect with AF_UNSPEC 

### DIFF
--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -970,22 +970,22 @@ enum net_verdict net_conn_input(struct net_pkt *pkt,
 			/* Is the candidate connection matching the packet's TCP/UDP
 			 * address and port?
 			 */
-			if (net_sin(&conn->remote_addr)->sin_port &&
+			if ((conn->flags & NET_CONN_REMOTE_PORT_SPEC) != 0 &&
 			    net_sin(&conn->remote_addr)->sin_port != src_port) {
 				continue; /* wrong remote port */
 			}
 
-			if (net_sin(&conn->local_addr)->sin_port &&
+			if ((conn->flags & NET_CONN_LOCAL_PORT_SPEC) != 0 &&
 			    net_sin(&conn->local_addr)->sin_port != dst_port) {
 				continue; /* wrong local port */
 			}
 
-			if ((conn->flags & NET_CONN_REMOTE_ADDR_SET) &&
+			if ((conn->flags & NET_CONN_REMOTE_ADDR_SET) != 0 &&
 			    !conn_addr_cmp(pkt, ip_hdr, &conn->remote_addr, true)) {
 				continue; /* wrong remote address */
 			}
 
-			if ((conn->flags & NET_CONN_LOCAL_ADDR_SET) &&
+			if ((conn->flags & NET_CONN_LOCAL_ADDR_SET) != 0 &&
 			    !conn_addr_cmp(pkt, ip_hdr, &conn->local_addr, false)) {
 
 				/* Check if we could do a v4-mapping-to-v6 and the IPv6 socket

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -42,16 +42,16 @@ LOG_MODULE_REGISTER(net_conn, CONFIG_NET_CONN_LOG_LEVEL);
 /** Local address set */
 #define NET_CONN_LOCAL_ADDR_SET		BIT(2)
 
-/** Local port set */
+/** Remote port set */
 #define NET_CONN_REMOTE_PORT_SPEC	BIT(3)
 
-/** Remote port set */
+/** Local port set */
 #define NET_CONN_LOCAL_PORT_SPEC	BIT(4)
 
-/** Local address specified */
+/** Remote address specified */
 #define NET_CONN_REMOTE_ADDR_SPEC	BIT(5)
 
-/** Remote address specified */
+/** Local address specified */
 #define NET_CONN_LOCAL_ADDR_SPEC	BIT(6)
 
 #define NET_CONN_RANK(_flags)		(_flags & 0x78)


### PR DESCRIPTION
As per POSIX (newer versions of the standard), for non-connection-mode sockets the peer address should be reset if AF_UNSPEC family type is provided to the connect() call:
  "If the sa_family member of address is AF_UNSPEC, the socket's peer address shall be reset."

Fix this, one minor issue found in connection layer related to peer address resetting, and add a test for this case.

Fixes #94210