### PR TITLE
stm32: tests: usart: extend usart driver test coverage 

### DIFF
--- a/samples/drivers/uart/async_api/boards/b_u585i_iot02a.overlay
+++ b/samples/drivers/uart/async_api/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	dmas = <&gpdma1 0 25 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 24 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/uart/async_api/boards/disco_l475_iot1.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	dmas = <&dma2 6 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma2 7 2 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+};
+
+&dma2 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_c071rb.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_c071rb.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart2 {
+	dmas = <&dmamux1 3 53 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 52 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_f091rc.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_f091rc.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	dmas = <&dma1 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_f103rb.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_f103rb.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	dmas = <&dma1 4 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 5 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_f207zg.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_f207zg.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	dmas = <&dma1 3 4 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
+	       <&dma1 1 4 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_f429zi.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_f429zi.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	dmas = <&dma1 3 4 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
+	       <&dma1 1 4 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_f746zg.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_f746zg.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	dmas = <&dma1 3 4 STM32_DMA_PERIPH_TX STM32_DMA_FIFO_FULL>,
+	       <&dma1 1 4 STM32_DMA_PERIPH_RX STM32_DMA_FIFO_FULL>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_g071rb.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_g071rb.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart2 {
+	dmas = <&dmamux1 5 53 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 52 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_g474re.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_g474re.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &lpuart1 {
+	dmas = <&dmamux1 2 35 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 1 34 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_h753zi.conf
+++ b/samples/drivers/uart/async_api/boards/nucleo_h753zi.conf
@@ -1,0 +1,1 @@
+CONFIG_DCACHE=n

--- a/samples/drivers/uart/async_api/boards/nucleo_h753zi.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_h753zi.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	dmas = <&dmamux1 2 46 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 3 45 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_l152re.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_l152re.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	dmas = <&dma1 7 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 6 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_u385rg_q.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_u385rg_q.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	dmas = <&gpdma1 0 25 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 24 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&gpdma1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_wb55rg.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_wb55rg.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	dmas = <&dmamux1 0 15 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 14 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_wba55cg.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_wba55cg.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rcc {
+	clocks = <&clk_hsi>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};
+
+dut: &usart1 {
+	dmas = <&gpdma1 0 12 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 11 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	fifo-enable;
+};
+
+&gpdma1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/nucleo_wl55jc.overlay
+++ b/samples/drivers/uart/async_api/boards/nucleo_wl55jc.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &lpuart1 {
+	dmas = <&dmamux1 2 22 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 1 21 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/stm32h573i_dk.overlay
+++ b/samples/drivers/uart/async_api/boards/stm32h573i_dk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	dmas = <&gpdma1 0 22 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 21 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};

--- a/samples/drivers/uart/async_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
+++ b/samples/drivers/uart/async_api/boards/stm32n6570_dk_stm32n657xx_sb.conf
@@ -1,0 +1,1 @@
+CONFIG_DCACHE=n

--- a/samples/drivers/uart/async_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/samples/drivers/uart/async_api/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&usart1 {
+	dmas = <&gpdma1 0 108 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 107 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&gpdma1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/boards/stm32u083c_dk.overlay
+++ b/samples/drivers/uart/async_api/boards/stm32u083c_dk.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	dmas = <&dmamux1 5 70 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 69 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/samples/drivers/uart/async_api/sample.yaml
+++ b/samples/drivers/uart/async_api/sample.yaml
@@ -23,3 +23,17 @@ tests:
             not CONFIG_CPU_HAS_DCACHE
     depends_on: dma
     harness: keyboard
+  sample.drivers.uart.async_api.console:
+    integration_platforms:
+      - nucleo_g071rb/stm32g071xx
+    filter: CONFIG_SERIAL and
+            CONFIG_UART_ASYNC_API and
+            dt_chosen_enabled("zephyr,shell-uart")
+    harness: console
+    harness_config:
+      type: multi_line
+      regex:
+        - "Loop (.*) Sending (.*)"
+        - "RX is now enabled"
+        - "Loop (.*) Sending (.*)"
+        - "RX is now disabled"

--- a/tests/drivers/uart/uart_async_api/boards/stm32h573i_dk.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/stm32h573i_dk.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+dut: &usart3 {
+	dmas = <&gpdma1 0 26 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 25 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+};

--- a/tests/drivers/uart/uart_elementary/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	pinctrl-0 = <&usart3_tx_pd8 &usart3_rx_pd9 &usart3_rts_pd2 &usart3_cts_pb13>;
+	dmas = <&gpdma1 0 29 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 28 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	hw-flow-control;
+};

--- a/tests/drivers/uart/uart_elementary/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nucleo_f091rc.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	pinctrl-0 = <&usart3_tx_pc10 &usart3_rx_pc11 &usart3_rts_pb14 &usart3_cts_pb13>;
+	pinctrl-names = "default";
+	dmas = <&dma1 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 1 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	hw-flow-control;
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nucleo_g071rb.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7 &usart1_rts_pa12 &usart1_cts_pa11>;
+	dmas = <&dmamux1 3 51 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 50 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	hw-flow-control;
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};
+
+&usb {
+	status = "disabled"
+};

--- a/tests/drivers/uart/uart_elementary/boards/nucleo_g474re.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nucleo_g474re.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart1 {
+	pinctrl-0 = <&usart1_tx_pc4 &usart1_rx_pc5  &usart1_rts_pa12 &usart1_cts_pa11>;
+	dmas = <&dmamux1 2 25 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 1 24 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	hw-flow-control;
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/boards/nucleo_h753zi.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nucleo_h753zi.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	dmas = <&dmamux1 2 44 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 3 43 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	hw-flow-control;
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/boards/nucleo_l152re.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/nucleo_l152re.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	pinctrl-0 = <&usart3_tx_pc10 &usart3_rx_pc11 &usart3_rts_pb14 &usart3_cts_pb13>;
+	pinctrl-names = "default";
+	dmas = <&dma1 2 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dma1 3 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+	hw-flow-control;
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/boards/stm32n6570_dk_stm32n657xx_sb.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/stm32n6570_dk_stm32n657xx_sb.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart2 {
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pf6 &usart2_rts_pg14 &usart2_cts_pg5>;
+	dmas = <&gpdma1 0 110 STM32_DMA_PERIPH_TX>,
+	       <&gpdma1 1 109 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	hw-flow-control;
+};
+
+&gpdma1 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/boards/stm32u083c_dk.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/stm32u083c_dk.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+dut: &usart3 {
+	pinctrl-0 = <&usart3_tx_pc4 &usart3_rx_pc5 &usart3_rts_pb14 &usart3_cts_pb13>;
+	dmas = <&dmamux1 5 74 STM32_DMA_PERIPH_TX>,
+	       <&dmamux1 4 73 STM32_DMA_PERIPH_RX>;
+	dma-names = "tx", "rx";
+	hw-flow-control;
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dma2 {
+	status = "okay";
+};
+
+&dmamux1 {
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -28,6 +28,14 @@ tests:
       - xg24_rb4187c
       - bg29_rb4420a
       - xg29_rb4412a
+      - b_u585i_iot02a
+      - nucleo_f091rc
+      - nucleo_g071rb
+      - nucleo_g474re
+      - nucleo_h743zi
+      - nucleo_l152re
+      - stm32n6570_dk/stm32n657xx/sb
+      - stm32u083c_dk
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
   drivers.uart.uart_elementary_dual_nrf54h:


### PR DESCRIPTION
This PR adds support for STM32 USART driver tests and samples.

Adds the possibility to test the STM32 USART driver with hardware flow control.
Provides a sample for the asynchronous UART API, even on platforms with limited RAM and flash size.

Related tests: 
-  tests/drivers/uart/uart_elementary
-  samples/drivers/uart/async_api