### PR TITLE
scripts: kconfig: optimize `write_kconfig_filenames`

### DIFF
--- a/scripts/kconfig/kconfig.py
+++ b/scripts/kconfig/kconfig.py
@@ -294,7 +294,7 @@ def write_kconfig_filenames(kconf, kconfig_list_path):
 
     with open(kconfig_list_path, 'w') as out:
         for path in sorted({os.path.realpath(os.path.join(kconf.srctree, path))
-                            for path in kconf.kconfig_filenames}):
+                            for path in set(kconf.kconfig_filenames)}):
             print(path, file=out)
 
 


### PR DESCRIPTION
Summary:

* Speed up `write_kconfig_filenames()` method by filtering duplicate entries in `kconf.kconfig_filenames` before calling `os.path.realpath`.

----

`write_kconfig_filenames()` creates a file `<build-dir>/<application>/zephyr/kconfig/sources.txt` which contains thousands of unique absolute file paths. `kconf.kconfig_filenames` contains a lot of duplicate paths and majority of them are Kconfig template files like `Kconfig.template.log_config`

Before vs After behavior:
* **Before**: all entries in `kconf.kconfig_filenames` go through `os.path.realpath`, including all duplicate entries.
* **After**: the duplicate entries are removed before calling `os.path.realpath`.

The final contents of `<build-dir>/<application>/zephyr/kconfig/sources.txt` remain unchanged before and after this PR.