### PR TITLE
boards: qemu/xtensa: ignore FPU and SMP testing tags

### DIFF
--- a/boards/qemu/xtensa/qemu_xtensa_dc233c.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_dc233c.yaml
@@ -9,8 +9,10 @@ toolchain:
 testing:
   default: true
   ignore_tags:
-    - net
     - bluetooth
+    - fpu
+    - net
+    - smp
 vendor: cdns
 ram: 16384
 flash: 32768

--- a/boards/qemu/xtensa/qemu_xtensa_dc233c_mmu.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_dc233c_mmu.yaml
@@ -9,5 +9,7 @@ toolchain:
 testing:
   default: true
   ignore_tags:
-    - net
     - bluetooth
+    - fpu
+    - net
+    - smp

--- a/boards/qemu/xtensa/qemu_xtensa_sample_controller32_mpu.yaml
+++ b/boards/qemu/xtensa/qemu_xtensa_sample_controller32_mpu.yaml
@@ -9,5 +9,7 @@ toolchain:
 testing:
   default: true
   ignore_tags:
-    - net
     - bluetooth
+    - fpu
+    - net
+    - smp


### PR DESCRIPTION
Ignore FPU and SMP for QEMU Xtensa boards as they do not support these features, and been filtered out already. Add both tags to the ignore list so twister will not even try to run cmake on them just to filter them out later.