### PR TITLE
mcux_os_timer: Handle counter overflow in Power Mode 3

### DIFF
--- a/include/zephyr/drivers/timer/nxp_os_timer.h
+++ b/include/zephyr/drivers/timer/nxp_os_timer.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_TIMER_NXP_OS_TIMER_H
+#define ZEPHYR_INCLUDE_DRIVERS_TIMER_NXP_OS_TIMER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief The timer may have overflowed and triggered a wakeup.
+ *
+ * OS Timer for certain low power modes switches to a counter maintain
+ * system time as it is powered off. These counters could overflow for
+ * certain tick values like K_TICKS_FOREVER. This could trigger a wakeup
+ * event which the system could ignore and go back to sleep.
+ *
+ * @retval true  if the PM subsystem should ignore wakeup events and go back
+ *               to sleep.
+ *         false if the timer wakeup event is as expected
+ */
+bool z_nxp_os_timer_ignore_timer_wakeup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_TIMER_NXP_OS_TIMER_H */

--- a/include/zephyr/drivers/timer/system_timer.h
+++ b/include/zephyr/drivers/timer/system_timer.h
@@ -22,6 +22,9 @@
 extern "C" {
 #endif
 
+#define SYS_CLOCK_MAX_WAIT (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) \
+			    ? K_TICKS_FOREVER : INT_MAX)
+
 /**
  * @brief System Clock APIs
  * @defgroup clock_apis System Clock APIs

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -22,9 +22,6 @@ static sys_dlist_t timeout_list = SYS_DLIST_STATIC_INIT(&timeout_list);
  */
 static struct k_spinlock timeout_lock;
 
-#define MAX_WAIT (IS_ENABLED(CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE) \
-		  ? K_TICKS_FOREVER : INT_MAX)
-
 /* Ticks left to process in the currently-executing sys_clock_announce() */
 static int announce_remaining;
 
@@ -91,7 +88,7 @@ static int32_t next_timeout(int32_t ticks_elapsed)
 
 	if ((to == NULL) ||
 	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
-		ret = MAX_WAIT;
+		ret = SYS_CLOCK_MAX_WAIT;
 	} else {
 		ret = MAX(0, to->dticks - ticks_elapsed);
 	}

--- a/soc/nxp/rw/power.c
+++ b/soc/nxp/rw/power.c
@@ -6,6 +6,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
 #include <fsl_clock.h>
+#include <fsl_rtc.h>
 #include <zephyr/init.h>
 #include <zephyr/drivers/pinctrl.h>
 #if CONFIG_GPIO && (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin0)) || \
@@ -13,11 +14,11 @@
 #include <zephyr/drivers/gpio/gpio_mcux_lpc.h>
 #endif
 #include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/drivers/timer/nxp_os_timer.h>
 
 #include "fsl_power.h"
 
 #include <zephyr/logging/log.h>
-#include <zephyr/drivers/timer/system_timer.h>
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
@@ -143,15 +144,26 @@ static void restore_mpu_state(void)
 }
 
 #endif /* CONFIG_MPU */
+static void config_wakeup_gpio_pins(void)
+{
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin0))
+	pin_cfg = IOMUX_GPIO_IDX(24) | IOMUX_TYPE(IOMUX_GPIO);
+	pinctrl_configure_pins(&pin_cfg, 1, 0);
+#endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin1))
+	pin_cfg = IOMUX_GPIO_IDX(25) | IOMUX_TYPE(IOMUX_GPIO);
+	pinctrl_configure_pins(&pin_cfg, 1, 0);
+#endif
+}
 
 /* Invoke Low Power/System Off specific Tasks */
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(substate_id);
 
+	config_wakeup_gpio_pins();
+
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin0))
-	pin_cfg = IOMUX_GPIO_IDX(24) | IOMUX_TYPE(IOMUX_GPIO);
-	pinctrl_configure_pins(&pin_cfg, 1, 0);
 	POWER_ConfigWakeupPin(kPOWER_WakeupPin0, DT_ENUM_IDX(DT_NODELABEL(pin0), wakeup_level));
 	POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(pin0)));
 	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin0)));
@@ -159,8 +171,6 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 	POWER_EnableWakeup(DT_IRQN(DT_NODELABEL(pin0)));
 #endif
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pin1))
-	pin_cfg = IOMUX_GPIO_IDX(25) | IOMUX_TYPE(IOMUX_GPIO);
-	pinctrl_configure_pins(&pin_cfg, 1, 0);
 	POWER_ConfigWakeupPin(kPOWER_WakeupPin1, DT_ENUM_IDX(DT_NODELABEL(pin1), wakeup_level));
 	POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(pin1)));
 	NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(pin1)));
@@ -202,6 +212,22 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		sys_clock_set_timeout(0, true);
 
 		if (POWER_EnterPowerMode(POWER_MODE3, &slp_cfg)) {
+			/* Go back to PM Mode 3 if RTC wakeup is to be ignored.*/
+			while (z_nxp_os_timer_ignore_timer_wakeup() &&
+			       (PMU->WAKEUP_STATUS & PMU_WAKEUP_STATUS_RTC_MASK)) {
+				config_wakeup_gpio_pins();
+				/* Reinitialize the OS Timer */
+				CLOCK_AttachClk(kLPOSC_to_OSTIMER_CLK);
+				/* Clear the RTC wakeup bits */
+				POWER_ClearWakeupStatus(DT_IRQN(DT_NODELABEL(rtc)));
+				RTC_ClearStatusFlags(RTC, kRTC_WakeupFlag);
+				NVIC_ClearPendingIRQ(DT_IRQN(DT_NODELABEL(rtc)));
+				sys_clock_idle_exit();
+				sys_clock_set_timeout(0, true);
+				if (!(POWER_EnterPowerMode(POWER_MODE3, &slp_cfg))) {
+					break;
+				}
+			}
 #ifdef CONFIG_MPU
 			/* Restore MPU as is lost after PM3 exit*/
 			restore_mpu_state();


### PR DESCRIPTION
The counter that is used in Power Mode 3 to track System time could overflow for large timeouts. Add logic to ignore wakeup events from the timer due to counter overflows.
