### PR TITLE
manifest: hal_rpi_pico: Update to SDK 2.2.0

### DIFF
--- a/dts/bindings/clock/raspberrypi,pico-xosc.yaml
+++ b/dts/bindings/clock/raspberrypi,pico-xosc.yaml
@@ -11,6 +11,7 @@ include: raspberrypi,pico-clock.yaml
 properties:
   startup-delay-multiplier:
     type: int
-    default: 1
+    default: 6
     description: |
-      Startup delay multiplier. The default value matches the Pico SDK.
+      Startup delay multiplier. The default value matches the Pico SDK used
+      as the basis for hal_rpi_pico (currently v2.1.1).

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -78,6 +78,7 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_clocks/include
     ${rp2_common_dir}/hardware_irq/include
     ${rp2_common_dir}/hardware_pll/include
+    ${rp2_common_dir}/hardware_rcp/include
     ${rp2_common_dir}/hardware_resets/include
     ${rp2_common_dir}/hardware_sync_spin_lock/include
     ${rp2_common_dir}/hardware_sync/include
@@ -87,6 +88,7 @@ if(CONFIG_HAS_RPI_PICO)
     ${rp2_common_dir}/hardware_xosc/include
     ${rp2_common_dir}/pico_bootrom/include
     ${rp2_common_dir}/pico_flash/include
+    ${rp2_common_dir}/pico_platform_common/include
     ${rp2_common_dir}/pico_platform_compiler/include
     ${rp2_common_dir}/pico_platform_panic/include
     ${rp2_common_dir}/pico_platform_sections/include

--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -68,31 +68,31 @@ if(CONFIG_HAS_RPI_PICO)
   )
 
   zephyr_include_directories(
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${common_dir}/boot_picobin_headers/include
+    ${common_dir}/boot_picoboot_headers/include
     ${common_dir}/pico_base_headers/include
     ${rp2_common_dir}/boot_bootrom_headers/include
     ${rp2_common_dir}/hardware_base/include
+    ${rp2_common_dir}/hardware_boot_lock/include
     ${rp2_common_dir}/hardware_clocks/include
+    ${rp2_common_dir}/hardware_irq/include
+    ${rp2_common_dir}/hardware_pll/include
+    ${rp2_common_dir}/hardware_resets/include
+    ${rp2_common_dir}/hardware_sync_spin_lock/include
+    ${rp2_common_dir}/hardware_sync/include
+    ${rp2_common_dir}/hardware_ticks/include
+    ${rp2_common_dir}/hardware_timer/include
     ${rp2_common_dir}/hardware_watchdog/include
     ${rp2_common_dir}/hardware_xosc/include
-    ${rp2_common_dir}/hardware_pll/include
-    ${rp2_common_dir}/hardware_irq/include
-    ${rp2_common_dir}/hardware_sync/include
-    ${rp2_common_dir}/hardware_timer/include
-    ${rp2_common_dir}/hardware_resets/include
-    ${rp2_common_dir}/hardware_boot_lock/include
-    ${rp2_common_dir}/hardware_ticks/include
-    ${rp2_common_dir}/hardware_sync_spin_lock/include
     ${rp2_common_dir}/pico_bootrom/include
     ${rp2_common_dir}/pico_flash/include
     ${rp2_common_dir}/pico_platform_compiler/include
-    ${rp2_common_dir}/pico_platform_sections/include
     ${rp2_common_dir}/pico_platform_panic/include
-    ${common_dir}/boot_picoboot_headers/include
-    ${common_dir}/boot_picobin_headers/include
+    ${rp2_common_dir}/pico_platform_sections/include
     ${rp2xxx_dir}/hardware_regs/include
     ${rp2xxx_dir}/hardware_structs/include
     ${rp2xxx_dir}/pico_platform/include
-    ${CMAKE_CURRENT_LIST_DIR}
   )
 
   zephyr_library_sources_ifdef(CONFIG_PICOSDK_USE_GPIO

--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(boot_stage2 PUBLIC
   ${rp2040_dir}/pico_platform/include
   ${rp2040_dir}/hardware_regs/include
   ${common_dir}/pico_base_headers/include
+  ${rp2_common_dir}/pico_platform_common/include
   ${rp2_common_dir}/pico_platform_compiler/include
   ${rp2_common_dir}/pico_platform_sections/include
   ${rp2_common_dir}/pico_platform_panic/include

--- a/west.yml
+++ b/west.yml
@@ -231,7 +231,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: b547a36a722af7787e5f55b551fd6ce72dcba5a4
+      revision: 09e957522da60581cf7958b31f8e625d969c69a5
       groups:
         - hal
     - name: hal_sifli


### PR DESCRIPTION
Update the Raspberry Pi Pico HAL to be based on the latest release of the upstream SDK (v2.2.0).

This PR also changes the default delay multiplier for the external oscillator to match the SDK's default, which first changed in SDK v2.1.1.

#87513 is superseded by this PR.
