### PR TITLE
tests: mimxrt1060_evk: adjust i2s testing for NXP mimxrt1060 board

### DIFF
--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk_mimxrt1062_qspi_C.yaml
@@ -25,6 +25,7 @@ supported:
   - dma
   - gpio
   - i2c
+  - i2s
   - netif:eth
   - sdhc
   - spi

--- a/samples/drivers/i2s/i2s_codec/sample.yaml
+++ b/samples/drivers/i2s/i2s_codec/sample.yaml
@@ -7,6 +7,7 @@ tests:
       - mimxrt595_evk/mimxrt595s/cm33
       - mimxrt1170_evk@B/mimxrt1176/cm7
       - mimxrt700_evk/mimxrt798s/cm33_cpu0
+      - mimxrt1060_evk/mimxrt1062/qspi
     harness: console
     harness_config:
       type: one_line

--- a/tests/drivers/i2s/i2s_api/testcase.yaml
+++ b/tests/drivers/i2s/i2s_api/testcase.yaml
@@ -11,6 +11,7 @@ tests:
       - mimxrt595_evk/mimxrt595s/cm33
       - mimxrt685_evk/mimxrt685s/cm33
       - nrf54h20dk/nrf54h20/cpuapp
+      - mimxrt1060_evk/mimxrt1062/qspi
   drivers.i2s.gpio_loopback:
     depends_on:
       - i2s

--- a/tests/drivers/i2s/i2s_speed/testcase.yaml
+++ b/tests/drivers/i2s/i2s_speed/testcase.yaml
@@ -7,6 +7,7 @@ tests:
     filter: not CONFIG_I2S_TEST_USE_GPIO_LOOPBACK
     platform_exclude:
       - nrf54h20dk/nrf54h20/cpuapp
+      - mimxrt1060_evk/mimxrt1062/qspi
   drivers.i2s.speed.gpio_loopback:
     depends_on:
       - i2s


### PR DESCRIPTION
1. enable the codec + i2s sample
2. skip i2s loopback as this conflicts with lcd