### PR TITLE
net: l2: wifi: Fix get RTS threshold in Wi-Fi shell

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -4022,7 +4022,7 @@ SHELL_SUBCMD_ADD((wifi), rts_threshold, NULL,
 	"<rts_threshold: rts threshold/off>.\n"
 		 "[-i, --iface=<interface index>] : Interface index.\n",
 		 cmd_wifi_set_rts_threshold,
-		 2, 2);
+		 1, 2);
 
 SHELL_SUBCMD_ADD((wifi), scan, NULL,
 		 "Scan for Wi-Fi APs\n"


### PR DESCRIPTION
Changed the number of mandatory options of `rts threshold` to 1, so as to allow no arguments for querying.

The implementation of `cmd_wifi_set_rts_threshold()` expects no args for get RTS threshold, but the subcommand addition expected a minimum of one additional argument.