### PR TITLE
spi: rtio: null pointer dereference in spi_rtio_transceive

### DIFF
--- a/drivers/spi/spi_rtio.c
+++ b/drivers/spi/spi_rtio.c
@@ -427,6 +427,11 @@ int spi_rtio_transceive(struct spi_rtio *ctx,
 
 	while (ret > 0) {
 		cqe = rtio_cqe_consume(ctx->r);
+		if (cqe == NULL) {
+			err = -EIO;
+			break;
+		}
+
 		if (cqe->result < 0) {
 			err = cqe->result;
 		}


### PR DESCRIPTION
Check if cqe is NULL before accessing cqe->result in spi_rtio_transceive(). Prevents possible null pointer dereference from rtio_cqe_consume() return value.

CID: 516229
Fixes: #90547