### PR TITLE
STM32: drivers: i2c: make dma config field conditional

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -496,7 +496,8 @@ void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 }
 
 #define I2C_DMA_DATA_INIT(index, dir, src, dest)						\
-	.dma_##dir##_cfg = {									\
+	IF_ENABLED(DT_INST_DMAS_HAS_NAME(index, dir),						\
+		(.dma_##dir##_cfg = {								\
 		.dma_slot = STM32_DMA_SLOT(index, dir, slot),					\
 		.channel_direction = STM32_DMA_CONFIG_DIRECTION(				\
 					STM32_DMA_CHANNEL_CONFIG(index, dir)),			\
@@ -511,7 +512,7 @@ void i2c_stm32_dma_rx_cb(const struct device *dma_dev, void *user_data,
 		.source_burst_length = 1,							\
 		.dest_burst_length = 1,								\
 		.dma_callback = i2c_stm32_dma_##dir##_cb,					\
-	},											\
+	},))
 
 #else
 


### PR DESCRIPTION
This commit updates I2C_DMA_DATA_INIT() macro to use
IF_ENABLED(DT_INST_DMAS_HAS_NAME(...), (...)),
so that the DMA configuration field is only generated if the corresponding DMA property exists in the Device Tree. This prevents macro expansion errors and allows a mix of I2C peripherals with and without DMA support in the same build.

fixes #94010