### PR TITLE
FTM counter driver support on zephyr

### DIFF
--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -34,6 +34,7 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_TPM            counter_mcux_tpm
 zephyr_library_sources_ifdef(CONFIG_COUNTER_XEC                 counter_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPTMR          counter_mcux_lptmr.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_LPIT           counter_mcux_lpit.c)
+zephyr_library_sources_ifdef(CONFIG_COUNTER_MCUX_FTM            counter_mcux_ftm.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MAXIM_DS3231        maxim_ds3231.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_NATIVE_SIM          counter_native_sim.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE                   counter_handlers.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -72,6 +72,8 @@ source "drivers/counter/Kconfig.mcux_lptmr"
 
 source "drivers/counter/Kconfig.mcux_lpit"
 
+source "drivers/counter/Kconfig.mcux_ftm"
+
 source "drivers/counter/Kconfig.maxim_ds3231"
 
 source "drivers/counter/Kconfig.native_sim"

--- a/drivers/counter/Kconfig.mcux_ftm
+++ b/drivers/counter/Kconfig.mcux_ftm
@@ -1,0 +1,12 @@
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# MCUXpresso SDK FlexTimer (FTM)
+
+config COUNTER_MCUX_FTM
+	bool "MCUX FTM driver"
+	default y
+	depends on DT_HAS_NXP_FTM_ENABLED
+	help
+	  Enable support for the MCUX FlexTimer (FTM).

--- a/drivers/counter/counter_mcux_ftm.c
+++ b/drivers/counter/counter_mcux_ftm.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_ftm
+
+#include <zephyr/drivers/counter.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log.h>
+
+#include <fsl_ftm.h>
+
+LOG_MODULE_REGISTER(mcux_ftm, CONFIG_COUNTER_LOG_LEVEL);
+
+struct mcux_ftm_config {
+	struct counter_config_info info;
+	FTM_Type *base;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
+	ftm_clock_source_t ftm_clock_source;
+	ftm_clock_prescale_t prescale;
+	void (*irq_config_func)(const struct device *dev);
+};
+
+struct mcux_ftm_data {
+	uint32_t freq;
+	counter_top_callback_t top_callback;
+	void *top_user_data;
+};
+
+static int mcux_ftm_start(const struct device *dev)
+{
+	const struct mcux_ftm_config *config = dev->config;
+
+	FTM_StartTimer(config->base, config->ftm_clock_source);
+
+	return 0;
+}
+
+static int mcux_ftm_stop(const struct device *dev)
+{
+	const struct mcux_ftm_config *config = dev->config;
+
+	FTM_StopTimer(config->base);
+
+	return 0;
+}
+
+static int mcux_ftm_get_value(const struct device *dev, uint32_t *ticks)
+{
+	const struct mcux_ftm_config *config = dev->config;
+
+	*ticks = FTM_GetCurrentTimerCount(config->base);
+
+	return 0;
+}
+
+static uint32_t mcux_ftm_get_top_value(const struct device *dev)
+{
+	const struct mcux_ftm_config *config = dev->config;
+
+	return config->base->MOD;
+}
+
+void mcux_ftm_isr(const struct device *dev)
+{
+	const struct mcux_ftm_config *config = dev->config;
+	struct mcux_ftm_data *data = dev->data;
+	uint32_t status = FTM_GetStatusFlags(config->base);
+
+	FTM_ClearStatusFlags(config->base, status);
+
+	if (((status & kFTM_TimeOverflowFlag) != 0) && (data->top_callback != NULL)) {
+		data->top_callback(dev, data->top_user_data);
+	}
+}
+
+static uint32_t mcux_ftm_get_pending_int(const struct device *dev)
+{
+	const struct mcux_ftm_config *config = dev->config;
+
+	return FTM_GetStatusFlags(config->base);
+}
+
+static int mcux_ftm_set_top_value(const struct device *dev, const struct counter_top_cfg *cfg)
+{
+	const struct mcux_ftm_config *config = dev->config;
+	struct mcux_ftm_data *data = dev->data;
+
+	if (cfg->ticks > config->info.max_top_value) {
+		return -ENOTSUP;
+	}
+
+	/* Check if timer already enabled. */
+	if ((config->base->SC & FTM_SC_CLKS_MASK) != 0) {
+		/* Timer already enabled, check flags before resetting */
+		if ((cfg->flags & COUNTER_TOP_CFG_DONT_RESET) != 0) {
+			return -ENOTSUP;
+		}
+
+		FTM_StopTimer(config->base);
+		config->base->CNT = 0;
+		FTM_SetTimerPeriod(config->base, cfg->ticks);
+		FTM_StartTimer(config->base, config->ftm_clock_source);
+	} else {
+		config->base->CNT = 0;
+		FTM_SetTimerPeriod(config->base, cfg->ticks);
+	}
+
+	data->top_callback = cfg->callback;
+	data->top_user_data = cfg->user_data;
+
+	FTM_EnableInterrupts(config->base, kFTM_TimeOverflowInterruptEnable);
+
+	return 0;
+}
+
+static uint32_t mcux_ftm_get_freq(const struct device *dev)
+{
+	struct mcux_ftm_data *data = dev->data;
+
+	return data->freq;
+}
+
+static int mcux_ftm_init(const struct device *dev)
+{
+	const struct mcux_ftm_config *config = dev->config;
+	struct mcux_ftm_data *data = dev->data;
+	ftm_config_t ftmConfig;
+	uint32_t clk_freq;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
+	if (clock_control_get_rate(config->clock_dev, config->clock_subsys, &clk_freq)) {
+		LOG_ERR("Could not get clock frequency");
+		return -EINVAL;
+	}
+
+	data->freq = clk_freq / (1U << config->prescale);
+
+	FTM_GetDefaultConfig(&ftmConfig);
+	ftmConfig.prescale = config->prescale;
+	FTM_Init(config->base, &ftmConfig);
+
+	config->irq_config_func(dev);
+
+	FTM_SetTimerPeriod(config->base, config->info.max_top_value);
+
+	return 0;
+}
+
+static DEVICE_API(counter, mcux_ftm_driver_api) = {
+	.start = mcux_ftm_start,
+	.stop = mcux_ftm_stop,
+	.get_value = mcux_ftm_get_value,
+	.set_top_value = mcux_ftm_set_top_value,
+	.get_pending_int = mcux_ftm_get_pending_int,
+	.get_top_value = mcux_ftm_get_top_value,
+	.get_freq = mcux_ftm_get_freq,
+};
+
+#define TO_FTM_PRESCALE_DIVIDE(val) _DO_CONCAT(kFTM_Prescale_Divide_, val)
+
+#define COUNTER_MCUX_FTM_DEVICE_INIT(n)                                                            \
+	static struct mcux_ftm_data mcux_ftm_data_##n;                                             \
+	static void mcux_ftm_irq_config_##n(const struct device *dev);                             \
+                                                                                                   \
+	static const struct mcux_ftm_config mcux_ftm_config_##n = {                                \
+		.info =                                                                            \
+			{                                                                          \
+				.max_top_value = 0xFFFFU,                                          \
+				.flags = COUNTER_CONFIG_INFO_COUNT_UP,                             \
+			},                                                                         \
+		.base = (FTM_Type *)DT_INST_REG_ADDR(n),                                           \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),                                \
+		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),              \
+		.ftm_clock_source = (ftm_clock_source_t)(DT_INST_ENUM_IDX(n, clock_source) + 1U),  \
+		.prescale = TO_FTM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),                    \
+		.irq_config_func = mcux_ftm_irq_config_##n,                                        \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(n, mcux_ftm_init, NULL, &mcux_ftm_data_##n, &mcux_ftm_config_##n,    \
+			      POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY, &mcux_ftm_driver_api);    \
+                                                                                                   \
+	static void mcux_ftm_irq_config_##n(const struct device *dev)                              \
+	{                                                                                          \
+		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mcux_ftm_isr,               \
+			    DEVICE_DT_INST_GET(n), 0);                                             \
+		irq_enable(DT_INST_IRQN(n));                                                       \
+	}
+
+DT_INST_FOREACH_STATUS_OKAY(COUNTER_MCUX_FTM_DEVICE_INIT)

--- a/dts/bindings/pwm/nxp,ftm-pwm.yaml
+++ b/dts/bindings/pwm/nxp,ftm-pwm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017, 2024 NXP
+# Copyright 2017, 2024-2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP FlexTimer Module (FTM) PWM controller
@@ -13,25 +13,6 @@ properties:
 
   pinctrl-0:
     required: true
-
-  clock-source:
-    type: string
-    required: true
-    enum:
-      - "system"
-      - "fixed"
-      - "external"
-    description: |
-      Select one of three possible clock sources for the FTM counter:
-        * system: it's the bus interface clock driving the FTM module. Usually
-          provides higher timer resolution than the other two clock sources.
-        * fixed: it's a fixed clock defined by chip integration.
-        * external: it's a clock that can be accessed externally to the chip and
-          passes through a sychronizer clocked by the FTM bus interface clock.
-
-      This clock source selection is independent of the bus interface clock
-      driving the FTM module. Refer to the chip specific documentation for
-      further information.
 
 pwm-cells:
   - channel

--- a/dts/bindings/timer/nxp,ftm.yaml
+++ b/dts/bindings/timer/nxp,ftm.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, NXP
+# Copyright (c) 2017, 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP FlexTimer Module (FTM)
@@ -27,3 +27,22 @@ properties:
       - 64
       - 128
     description: Input clock prescaler
+
+  clock-source:
+    type: string
+    required: true
+    enum:
+      - "system"
+      - "fixed"
+      - "external"
+    description: |
+      Select one of three possible clock sources for the FTM counter:
+        * system: it's the bus interface clock driving the FTM module. Usually
+          provides higher timer resolution than the other two clock sources.
+        * fixed: it's a fixed clock defined by chip integration.
+        * external: it's a clock that can be accessed externally to the chip and
+          passes through a sychronizer clocked by the FTM bus interface clock.
+
+      This clock source selection is independent of the bus interface clock
+      driving the FTM module. Refer to the chip specific documentation for
+      further information.

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/drivers/drivers.cmake
@@ -51,6 +51,7 @@ set_variable_ifdef(CONFIG_ADC_MCUX_ADC16        CONFIG_MCUX_COMPONENT_driver.adc
 set_variable_ifdef(CONFIG_CAN_MCUX_FLEXCAN      CONFIG_MCUX_COMPONENT_driver.flexcan)
 set_variable_ifdef(CONFIG_CAN_MCUX_FLEXCAN_FD   CONFIG_MCUX_COMPONENT_driver.flexcan)
 set_variable_ifdef(CONFIG_COUNTER_NXP_PIT       CONFIG_MCUX_COMPONENT_driver.pit)
+set_variable_ifdef(CONFIG_COUNTER_MCUX_FTM      CONFIG_MCUX_COMPONENT_driver.ftm)
 set_variable_ifdef(CONFIG_COUNTER_MCUX_RTC      CONFIG_MCUX_COMPONENT_driver.rtc)
 set_variable_ifdef(CONFIG_DAC_MCUX_DAC          CONFIG_MCUX_COMPONENT_driver.dac)
 set_variable_ifdef(CONFIG_DAC_MCUX_DAC12        CONFIG_MCUX_COMPONENT_driver.dac12)

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.conf
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.conf
@@ -1,0 +1,6 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_COUNTER_MCUX_FTM=y

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&ftm0 {
+	status = "okay";
+	compatible = "nxp,ftm";
+	prescaler = <128>;
+	clocks = <&scg KINETIS_SCG_FIRC_CLK>;
+	clock-source = "system";
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -126,6 +126,9 @@ static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_MCUX_LPIT
 	DEVS_FOR_DT_COMPAT(nxp_lpit_channel)
 #endif
+#ifdef CONFIG_COUNTER_MCUX_FTM
+	DEVS_FOR_DT_COMPAT(nxp_ftm)
+#endif
 #ifdef CONFIG_COUNTER_RENESAS_RZ_GTM
 	DEVS_FOR_DT_COMPAT(renesas_rz_gtm_counter)
 #endif


### PR DESCRIPTION
1. Update dts bindings to move clock-source properties from nxp,ftm-pwm.yaml to nxp,ftm.yaml.

2. Provide counter driver based on FTM driver from NXP mcux-sdk-ng

3. Enable FTM test for frdm_ke17z