### PR TITLE
drivers: spi_nor: limit JESD216 api speed

### DIFF
--- a/drivers/flash/jesd216.h
+++ b/drivers/flash/jesd216.h
@@ -27,6 +27,12 @@
 #define JESD216_CMD_BURST_SFDP  0x5B
 #define JESD216_OCMD_READ_SFDP  0x5AA5
 
+/* The maximum frequency, that all SFDP compliant devices have to support,
+ * at which the JESD216 read SFDP command may be issued is 50 MHz, according
+ * to JESD216 section 4.4.
+ */
+#define JESD216_CMD_READ_SFDP_MAX_FREQUENCY  MHZ(50)
+
 /* Layout of a JESD216 parameter header. */
 struct jesd216_param_header {
 	uint8_t id_lsb;		/* ID LSB */


### PR DESCRIPTION
according to Paragraph 4.4 of the JESD216G, the max frequency, that all complient devices must support is 50 MHz, limit it to it.

Fixes: #90930