### PR TITLE
shell: mqtt: add configurable delays

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -330,6 +330,24 @@ config SHELL_MQTT_TX_BUF_SIZE
 	help
 	  Buffer size for the MQTT data transmission.
 
+config SHELL_MQTT_CONNECT_TIMEOUT_MS
+	int "MQTT connect timeout [ms]"
+	default 2000
+	help
+	  Time to await MQTT connect acknowlegde in milliseconds.
+
+config SHELL_MQTT_WORK_DELAY_MS
+	int "MQTT work delay [ms]"
+	default 1000
+	help
+	  Period between MQTT work in milliseconds.
+
+config SHELL_MQTT_LISTEN_TIMEOUT_MS
+	int "MQTT listen timeout [ms]"
+	default 500
+	help
+	  Time to listen for incoming packets in milliseconds.
+
 module = SHELL_BACKEND_MQTT
 default-timeout = 100
 source "subsys/shell/Kconfig.template.shell_log_queue_timeout"

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -20,10 +20,10 @@ SHELL_DEFINE(shell_mqtt, "", &shell_transport_mqtt,
 LOG_MODULE_REGISTER(shell_mqtt, CONFIG_SHELL_MQTT_LOG_LEVEL);
 
 #define NET_EVENT_MASK (NET_EVENT_L4_CONNECTED | NET_EVENT_L4_DISCONNECTED)
-#define CONNECT_TIMEOUT_MS 2000
-#define LISTEN_TIMEOUT_MS 500
+#define CONNECT_TIMEOUT_MS CONFIG_SHELL_MQTT_CONNECT_TIMEOUT_MS
+#define LISTEN_TIMEOUT_MS CONFIG_SHELL_MQTT_LISTEN_TIMEOUT_MS
 #define MQTT_SEND_DELAY_MS K_MSEC(100)
-#define PROCESS_INTERVAL K_SECONDS(2)
+#define PROCESS_INTERVAL K_MSEC(CONFIG_SHELL_MQTT_WORK_DELAY_MS)
 #define SHELL_MQTT_WORKQ_STACK_SIZE 2048
 
 #ifdef CONFIG_SHELL_MQTT_SERVER_USERNAME
@@ -274,14 +274,14 @@ static void sh_mqtt_process_handler(struct k_work *work)
 
 	/* Reschedule the process work */
 	LOG_DBG("Scheduling %s work", "process");
-	(void)sh_mqtt_work_reschedule(&sh->process_dwork, K_SECONDS(2));
+	(void)sh_mqtt_work_reschedule(&sh->process_dwork, PROCESS_INTERVAL);
 	sh_mqtt_context_unlock();
 	return;
 
 process_error:
 	LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "connect");
 	sh_mqtt_close_and_cleanup(sh);
-	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(1));
+	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, PROCESS_INTERVAL);
 	sh_mqtt_context_unlock();
 }
 
@@ -350,7 +350,7 @@ static void sh_mqtt_subscribe_handler(struct k_work *work)
 subscribe_error:
 	LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "subscribe");
 	sh_mqtt_close_and_cleanup(sh);
-	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(2));
+	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, PROCESS_INTERVAL);
 	sh_mqtt_context_unlock();
 }
 
@@ -383,7 +383,7 @@ static void sh_mqtt_connect_handler(struct k_work *work)
 	LOG_DBG("Resolving DNS");
 	rc = get_mqtt_broker_addrinfo(sh);
 	if (rc != 0) {
-		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(1));
+		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, PROCESS_INTERVAL);
 		sh_mqtt_context_unlock();
 		return;
 	}
@@ -424,14 +424,14 @@ static void sh_mqtt_connect_handler(struct k_work *work)
 	}
 
 	LOG_DBG("Scheduling %s work", "subscribe");
-	(void)sh_mqtt_work_reschedule(&sh->subscribe_dwork, K_SECONDS(2));
+	(void)sh_mqtt_work_reschedule(&sh->subscribe_dwork, PROCESS_INTERVAL);
 	sh_mqtt_context_unlock();
 	return;
 
 connect_error:
 	LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "connect");
 	sh_mqtt_close_and_cleanup(sh);
-	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(2));
+	(void)sh_mqtt_work_reschedule(&sh->connect_dwork, PROCESS_INTERVAL);
 	sh_mqtt_context_unlock();
 }
 
@@ -475,7 +475,7 @@ static void sh_mqtt_publish_handler(struct k_work *work)
 	if (rc != 0) {
 		LOG_DBG("%s: close MQTT, cleanup socket & reconnect", "publish");
 		sh_mqtt_close_and_cleanup(sh);
-		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(2));
+		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, PROCESS_INTERVAL);
 	}
 
 	sh_mqtt_context_unlock();
@@ -517,7 +517,7 @@ static void network_evt_handler(struct net_mgmt_event_callback *cb, uint64_t mgm
 	    (sh->network_state == SHELL_MQTT_NETWORK_DISCONNECTED)) {
 		LOG_WRN("Network %s", "connected");
 		sh->network_state = SHELL_MQTT_NETWORK_CONNECTED;
-		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, K_SECONDS(1));
+		(void)sh_mqtt_work_reschedule(&sh->connect_dwork, PROCESS_INTERVAL);
 	} else if ((mgmt_event == NET_EVENT_L4_DISCONNECTED) &&
 		   (sh->network_state == SHELL_MQTT_NETWORK_CONNECTED)) {
 		(void)sh_mqtt_work_submit(&sh->net_disconnected_work);
@@ -764,8 +764,7 @@ static int write_data(const struct shell_transport *transport, const void *data,
 			rc = sh_mqtt_publish_tx_buf(sh, false);
 			if (rc != 0) {
 				sh_mqtt_close_and_cleanup(sh);
-				(void)sh_mqtt_work_reschedule(&sh->connect_dwork,
-							      K_SECONDS(2));
+				(void)sh_mqtt_work_reschedule(&sh->connect_dwork, PROCESS_INTERVAL);
 				*cnt = length;
 				return rc;
 			}


### PR DESCRIPTION
Allow changing delays via Kconfig values.

Use identical delay (`SHELL_MQTT_WORK_DELAY_MS`) for connect, subscribe and process work instead of varying 1 or 2 second delay.