### PR TITLE
bluetooth: classic: shell: mitigate label followed by declaration

### DIFF
--- a/subsys/bluetooth/host/classic/shell/goep.c
+++ b/subsys/bluetooth/host/classic/shell/goep.c
@@ -98,14 +98,14 @@ static bool goep_parse_headers_cb(struct bt_obex_hdr *hdr, void *user_data)
 	switch (hdr->id) {
 	case BT_OBEX_HEADER_ID_APP_PARAM:
 	case BT_OBEX_HEADER_ID_AUTH_CHALLENGE:
-	case BT_OBEX_HEADER_ID_AUTH_RSP:
+	case BT_OBEX_HEADER_ID_AUTH_RSP: {
 		int err;
 
 		err = bt_obex_tlv_parse(hdr->len, hdr->data, goep_parse_tlvs_cb, NULL);
 		if (err) {
 			bt_shell_error("Fail to parse OBEX TLV triplet");
 		}
-		break;
+	} break;
 	default:
 		bt_shell_hexdump(hdr->data, hdr->len);
 		break;


### PR DESCRIPTION
A recent change triggered a warning in LLVM that was promoted to error when run with twister.

```shell
goep.c:102:3: error: label followed by a declaration is a C23 extension
  [-Werror,-Wc23-extensions]
  102 |                 int err;
```

Add a scope to the switch case so that the declaration has proper scope.

https://github.com/zephyrproject-rtos/zephyr/actions/runs/16834645711/job/47690926504