### PR TITLE
tests: kernel: mem_map: reduce reserved pages for qemu_x86 tiny

### DIFF
--- a/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
+++ b/tests/kernel/mem_protect/mem_map/boards/qemu_x86_tiny.conf
@@ -5,4 +5,4 @@
 # Adjust this so that test_k_mem_map_unmap memory exhaustion
 # test can run without failure, as we may run of free pages
 # when there are changes in code and data size.
-CONFIG_DEMAND_PAGING_PAGE_FRAMES_RESERVE=30
+CONFIG_DEMAND_PAGING_PAGE_FRAMES_RESERVE=27


### PR DESCRIPTION
A recent change caused tests to start failing for `qemu_x86_tiny/atom`.

Similarly to bda38f033ab52d2711a676783905987251452394, reduce the number of reserved pages so that the test suite can pass for this platform.

Fixes #94269