### PR TITLE
Samples: Fix ID for VCNL4040 sensor sample

### DIFF
--- a/samples/sensor/vcnl4040/README.rst
+++ b/samples/sensor/vcnl4040/README.rst
@@ -1,4 +1,4 @@
-.. zephyr:code-sample:: vcml4040
+.. zephyr:code-sample:: vcnl4040
    :name: VCNL4040 Proximity and Ambient Light Sensor
    :relevant-api: sensor_interface
 


### PR DESCRIPTION
The ID of the sample is wrong, so it is not possible to link to the sample documentation. I found this issue when working on a shield for the VCNL4040 proximity sensor.

To my knowledge, there are no references to the invalid ID yet.