### PR TITLE
Drivers: GPIO: Allow AW9523 to be used without interrupts

### DIFF
--- a/drivers/gpio/gpio_aw9523b.c
+++ b/drivers/gpio/gpio_aw9523b.c
@@ -239,6 +239,7 @@ static int gpio_aw9523b_port_toggle_bits(const struct device *dev, gpio_port_pin
 	return gpio_aw9523b_port_read_write_toggle(dev, pins, NULL, TOGGLE);
 }
 
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(int_gpios)
 static __maybe_unused void gpio_aw9523b_interrupt_worker(struct k_work *work)
 {
 	struct gpio_aw9523b_data *const data =
@@ -355,6 +356,7 @@ static __maybe_unused void gpio_aw9523b_int_handler(const struct device *gpio_de
 
 	k_work_submit(&data->intr_worker);
 }
+#endif
 
 static DEVICE_API(gpio, gpio_aw9523b_api) = {
 	.pin_configure = gpio_aw9523b_pin_configure,


### PR DESCRIPTION
There will be an compilation error if there is no interrupt GPIO defined in the device tree file, as parts of the config and data structs have #if that depends on the presence of interrupt GPIO.

Use the same #if constructs also on the functions that use those structs.