### PR TITLE
dts: arm: st: u3: Add USB

### DIFF
--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.dts
@@ -107,6 +107,10 @@
 	status = "okay";
 };
 
+&clk_hsi48 {
+	status = "okay";
+};
+
 &clk_lse {
 	status = "okay";
 };
@@ -188,5 +192,11 @@
 };
 
 &wwdg {
+	status = "okay";
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
 	status = "okay";
 };

--- a/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
+++ b/boards/st/nucleo_u385rg_q/nucleo_u385rg_q.yaml
@@ -17,6 +17,8 @@ supported:
   - spi
   - uart
   - usart
+  - usb_device
+  - usbd
   - watchdog
 ram: 256
 flash: 1024

--- a/dts/arm/st/u3/stm32u3.dtsi
+++ b/dts/arm/st/u3/stm32u3.dtsi
@@ -412,6 +412,25 @@
 				STM32_DMA_16BITS)>;
 			status = "disabled";
 		};
+
+		usb: usb@40016000 {
+			compatible = "st,stm32-usb";
+			reg = <0x40016000 0x400>;
+			interrupts = <73 0>;
+			interrupt-names = "usb";
+			num-bidir-endpoints = <8>;
+			ram-size = <2048>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK(APB2, 24)>,
+				 <&rcc STM32_SRC_HSI48 ICLK_SEL(0)>;
+			phys = <&usb_fs_phy>;
+			status = "disabled";
+		};
+	};
+
+	usb_fs_phy: usb_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
 	};
 };
 


### PR DESCRIPTION
Added a USB node for STM32U3 SoCs, and configured USB for the Nucleo U385RG-Q, enabling the USB samples.