### PR TITLE
tests: drivers: spi: spi_loopback: move SPI delays to lpspi3 node

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.overlay
@@ -16,9 +16,6 @@
 
 &ocram1 {
 	zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_RAM_NOCACHE) )>;
-	transfer-delay = <100>;
-	pcs-sck-delay = <100>;
-	sck-pcs-delay = <100>;
 };
 
 &lpspi3 {
@@ -32,4 +29,7 @@
 		reg = <0>;
 		spi-max-frequency = <16000000>;
 	};
+	transfer-delay = <100>;
+	pcs-sck-delay = <100>;
+	sck-pcs-delay = <100>;
 };


### PR DESCRIPTION
Place SPI delay properties under LPSPI instead of OCRAM for mimxrt1180_evk_mimxrt1189_cm7.

Fixes: [94303](https://github.com/zephyrproject-rtos/zephyr/issues/94303)