### PR TITLE
shell: date_service: make clear that leap seconds are not supported

### DIFF
--- a/subsys/shell/modules/date_service.c
+++ b/subsys/shell/modules/date_service.c
@@ -123,8 +123,10 @@ static int get_h_m_s(const struct shell *sh, struct tm *t, char *time_str)
 		return -EINVAL;
 	}
 
-	/* Note range allows for a leap second */
-	if ((t->tm_sec < 0) || (t->tm_sec > 60)) {
+	/* Note that leap seconds are not accepted because
+	 * SYS_CLOCK_REALTIME uses Unix time which doesn't support them.
+	 */
+	if ((t->tm_sec < 0) || (t->tm_sec > 59)) {
 		shell_error(sh, "Invalid second");
 		return -EINVAL;
 	}


### PR DESCRIPTION
SYS_CLOCK_REALTIME is following Unix time so, even if tm_sec == 60 is accepted, make very clear that leap seconds are not supported.