### PR TITLE
mimxrt798s: Revert GPIO0 support for HiFi 4

### DIFF
--- a/boards/nxp/mimxrt700_evk/board.c
+++ b/boards/nxp/mimxrt700_evk/board.c
@@ -308,14 +308,9 @@ void board_early_init_hook(void)
 	CLOCK_SetClkDiv(kCLOCK_DivFlexioClk, 1U);
 #endif
 
-#if CONFIG_BOARD_MIMXRT700_EVK_MIMXRT798S_CM33_CPU0
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)
 	CLOCK_EnableClock(kCLOCK_Gpio0);
 	RESET_ClearPeripheralReset(kGPIO0_RST_SHIFT_RSTn);
-
-	GPIO0->PCNS = 0xFFFFFFFFU;
-	GPIO0->PCNP = 0xFFFFFFFFU;
-	GPIO0->ICNP = 0xFFFFFFFFU;
-	GPIO0->ICNS = 0xFFFFFFFFU;
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio1), okay)
@@ -459,9 +454,7 @@ void board_early_init_hook(void)
 	CLOCK_AttachClk(kLPOSC_to_WWDT0);
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(sai0), okay) \
-		|| DT_NODE_HAS_STATUS(DT_NODELABEL(sai1), okay) \
-		|| DT_NODE_HAS_STATUS(DT_NODELABEL(sai2), okay)
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(sai0), okay)
 	/* SAI clock 368.64 / 15 = 24.576MHz */
 	CLOCK_AttachClk(kAUDIO_PLL_PFD3_to_AUDIO_VDD2);
 	CLOCK_AttachClk(kAUDIO_VDD2_to_SAI012);
@@ -561,12 +554,10 @@ static void GlikeyClearConfig(GLIKEY_Type *base)
 static void BOARD_InitAHBSC(void)
 {
 #if defined(CONFIG_SOC_MIMXRT798S_CM33_CPU0)
-	GlikeyWriteEnable(GLIKEY0, 0U);
 	GlikeyWriteEnable(GLIKEY0, 1U);
-	GlikeyWriteEnable(GLIKEY0, 2U);
+	AHBSC0->MISC_CTRL_DP_REG = 0x000086aa;
 	/* AHBSC0 MISC_CTRL_REG, disable Privilege & Secure checking. */
 	AHBSC0->MISC_CTRL_REG = 0x000086aa;
-	AHBSC0->MISC_CTRL_DP_REG = 0x000086aa;
 
 	GlikeyWriteEnable(GLIKEY0, 7U);
 	/* Enable arbiter0 accessing SRAM */
@@ -575,14 +566,6 @@ static void BOARD_InitAHBSC(void)
 	AHBSC0->MEDIA_ARB0RAM_ACCESS_ENABLE = 0x3FFFFFFF;
 	AHBSC0->NPU_ARB0RAM_ACCESS_ENABLE = 0x3FFFFFFF;
 	AHBSC0->HIFI4_ARB0RAM_ACCESS_ENABLE = 0x3FFFFFFF;
-
-	GlikeyWriteEnable(GLIKEY0, 6U);
-	AHBSC0->MASTER_SEC_LEVEL        = 0x3;
-	AHBSC0->MASTER_SEC_ANTI_POL_REG = 0xFFC;
-
-	AHBSC0->APB_SLAVE_GROUP0_RULE0 = 0x00000000;
-	AHBSC0->AHB_PERIPHERAL0_SLAVE_RULE1 = 0x00000000;
-	AHBSC0->AIPS1_BRIDGE_GROUP0_MEM_RULE2 = 0x00000000;
 #endif
 
 	GlikeyWriteEnable(GLIKEY1, 1U);

--- a/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.dts
+++ b/boards/nxp/mimxrt700_evk/mimxrt700_evk_mimxrt798s_hifi4.dts
@@ -19,8 +19,6 @@
 	compatible = "nxp,mimxrt798s";
 
 	aliases {
-		led1 = &blue_led;
-		sw0 = &user_button_1;
 		i2s-codec-tx = &sai0;
 		i2s-tx = &sai0;
 	};
@@ -30,27 +28,6 @@
 		zephyr,console = &flexcomm0_lpuart0;
 		zephyr,shell-uart = &flexcomm0_lpuart0;
 	};
-
-	leds {
-		compatible = "gpio-leds";
-		blue_led: led_1 {
-			gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
-			label = "User LED_BLUE";
-		};
-	};
-
-	gpio_keys {
-		compatible = "gpio-keys";
-		user_button_1: button_0 {
-			label = "User SW5";
-			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
-			zephyr,code = <INPUT_KEY_0>;
-		};
-	};
-};
-
-&gpio0 {
-	status = "okay";
 };
 
 &flexcomm0 {

--- a/dts/xtensa/nxp/nxp_imxrt700_hifi4.dtsi
+++ b/dts/xtensa/nxp/nxp_imxrt700_hifi4.dtsi
@@ -124,20 +124,6 @@
 		reg = <0xa5000 0x1000>;
 	};
 
-	gpio0: gpio@100000 {
-		#gpio-cells = <2>;
-
-		reg = <0x100000 0x1000>;
-
-		interrupts = <9 0 0>, <10 0 0>;
-
-		nxp,kinetis-port = <&gpio0>;
-		gpio-controller;
-
-		compatible = "nxp,kinetis-gpio";
-		status = "disabled";
-	};
-
 	flexcomm0: flexcomm@110000 {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/samples/boards/nxp/adsp/rtxxx/amp_blinky/CMakeLists.txt
+++ b/samples/boards/nxp/adsp/rtxxx/amp_blinky/CMakeLists.txt
@@ -9,3 +9,7 @@ project(amp_blinky)
 target_sources(app PRIVATE src/main.c)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../common/dsp-load.cmake")
+
+if(CONFIG_BOARD_MIMXRT700_EVK_MIMXRT798S_CM33_CPU0)
+  message(FATAL_ERROR "This example is not supported on the selected board.")
+endif()

--- a/samples/boards/nxp/adsp/rtxxx/amp_blinky/sample.yaml
+++ b/samples/boards/nxp/adsp/rtxxx/amp_blinky/sample.yaml
@@ -8,7 +8,6 @@ common:
   min_flash: 1024
   platform_allow:
     - mimxrt685_evk/mimxrt685s/cm33
-    - mimxrt700_evk/mimxrt798s/cm33_cpu0
   harness: console
   harness_config:
     type: one_line

--- a/soc/nxp/imxrt/imxrt7xx/hifi4/soc.c
+++ b/soc/nxp/imxrt/imxrt7xx/hifi4/soc.c
@@ -49,16 +49,16 @@ __weak void mimxrt798s_hifi4_irq_init(void)
 	 * - IRQ 6  (SEL 1):  FLEXCOMM0
 	 * - IRQ 7  (SEL 2):  FLEXCOMM2
 	 * - IRQ 8  (SEL 3):  WWDT1
-	 * - IRQ 9  (SEL 4):  PINT0
-	 * - IRQ 10 (SEL 5):  PINT1
-	 * - IRQ 11 (SEL 6):  PINT2
-	 * - IRQ 12 (SEL 7):  PINT3
-	 * - IRQ 13 (SEL 8):  PINT4
-	 * - IRQ 14 (SEL 9):  PINT5
-	 * - IRQ 15 (SEL 10): PINT6
+	 * - IRQ 9  (SEL 4):  Unmapped
+	 * - IRQ 10 (SEL 5):  Unmapped
+	 * - IRQ 11 (SEL 6):  Unmapped
+	 * - IRQ 12 (SEL 7):  Unmapped
+	 * - IRQ 13 (SEL 8):  Unmapped
+	 * - IRQ 14 (SEL 9):  Unmapped
+	 * - IRQ 15 (SEL 10): Unmapped
 	 *
 	 * L2:
-	 * - IRQ 16 (SEL 11): PINT7
+	 * - IRQ 16 (SEL 11): Unmapped
 	 * - IRQ 17 (SEL 12): LPSPI14
 	 * - IRQ 18 (SEL 13): MU2
 	 * - IRQ 19 (SEL 14): MU4
@@ -83,16 +83,6 @@ __weak void mimxrt798s_hifi4_irq_init(void)
 	INPUTMUX_AttachSignal(INPUTMUX0, 2, kINPUTMUX_Flexcomm2ToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX0, 3, kINPUTMUX_Wdt1ToDspInterrupt);
 
-	INPUTMUX_AttachSignal(INPUTMUX0, 4, kINPUTMUX_Gpio0Irq0ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 5, kINPUTMUX_Gpio0Irq1ToDspInterrupt);
-
-	INPUTMUX_AttachSignal(INPUTMUX0, 6, kINPUTMUX_GpioInt2ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 7, kINPUTMUX_GpioInt3ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 8, kINPUTMUX_GpioInt4ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 9, kINPUTMUX_GpioInt5ToDspInterrupt);
-	INPUTMUX_AttachSignal(INPUTMUX0, 10, kINPUTMUX_GpioInt6ToDspInterrupt);
-
-	INPUTMUX_AttachSignal(INPUTMUX0, 11, kINPUTMUX_GpioInt7ToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX0, 12, kINPUTMUX_Spi14ToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX0, 13, kINPUTMUX_Mu2AToDspInterrupt);
 	INPUTMUX_AttachSignal(INPUTMUX0, 14, kINPUTMUX_Mu4BToDspInterrupt);


### PR DESCRIPTION
As the access level registers for GPIO peripherals on `mimxrt798s` are mutually exclusive (in this case, they allow the peripheral to be used in only one of `cm33_cpu0` and `hifi4`), this PR ditches GPIO0 support on `mimxrt798s/hifi4` entirely in favour of using that peripheral on the `cm33_cpu0` domain only.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94315.