### PR TITLE
dts: stm32u5: add stm32u595xx

### DIFF
--- a/dts/arm/st/u5/stm32u595Xi.dtsi
+++ b/dts/arm/st/u5/stm32u595Xi.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/u5/stm32u595.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(2)>;
+			};
+		};
+	};
+};

--- a/dts/arm/st/u5/stm32u595Xj.dtsi
+++ b/dts/arm/st/u5/stm32u595Xj.dtsi
@@ -1,0 +1,17 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <mem.h>
+#include <st/u5/stm32u595.dtsi>
+
+/ {
+	soc {
+		flash-controller@40022000 {
+			flash0: flash@8000000 {
+				reg = <0x08000000 DT_SIZE_M(4)>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Add variants of the stm32u595 chip with 2M (u595XI) and 4M (u595XJ) of flash.

Fixes #94320
