### PR TITLE
soc: nordic: Add approtect workaround for nRF91x1

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -78,6 +78,8 @@ zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
 zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
                                  ENABLE_SECURE_APPROTECT_USER_HANDLING
                                  ENABLE_AUTHENTICATED_SECUREAPPROTECT)
+zephyr_compile_definitions_ifdef(CONFIG_NRF_CONSTANT_LATENCY_WORKAROUND
+                                 NRF_CONSTANT_LATENCY_WORKAROUND)
 zephyr_library_compile_definitions_ifdef(CONFIG_NRF_TRACE_PORT
                                  ENABLE_TRACE)
 

--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -197,6 +197,25 @@ config NRF_SECURE_APPROTECT_USER_HANDLING
 
 endchoice
 
+config NRF_CONSTANT_LATENCY_WORKAROUND
+	bool "Constant latency mode for debugging purposes"
+	depends on SOC_NRF9120 && \
+		   !NRF_APPROTECT_LOCK && !NRF_SECURE_APPROTECT_LOCK
+	help
+	  This is only for debugging purposes. Do not enable this in production
+	  code.
+
+	  This option enables a workaround for the nRF9161 anomaly
+	  [36] Debug and Trace: Access port gets locked in WFI and WFE.
+
+	  When this option is selected, the SystemInit() function enables
+	  the constant latency mode by triggering the CONSTLAT task. This
+	  prevents WFI and WFE instructions from entering SYSTEM ON IDLE mode.
+	  As a result, anomaly is avoided with the cost of increased power
+	  consumption.
+
+	  Note: With multiple images, add this for the first image.
+
 config NRF_TRACE_PORT
 	bool "nRF TPIU"
 	depends on !SOC_SERIES_NRF51X


### PR DESCRIPTION
Add CONFIG_NRF_CONSTANT_LATENCY_WORKAROUND for enabling a constant latency mode workaround for the nRF91x1 anomaly: [36] Debug and Trace: Access port gets locked in WFI and WFE.

Constant latency mode prevents WFI and WFE instructions from entering SYSTEM ON IDLE mode, which would reset the approtect to SoC default (CONFIG_NRF_APPROTECT_USER_HANDLING && CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING).

--

Created https://github.com/zephyrproject-rtos/zephyr/pull/79920 again, now that the change is in nrfx.