### PR TITLE
zms: Initial support for 64 bit IDs

### DIFF
--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -78,6 +78,17 @@ struct zms_fs {
  */
 
 /**
+ * @brief ID type used in the ZMS API.
+ *
+ * @note The width of this type depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
+ */
+#if CONFIG_ZMS_ID_64BIT
+typedef uint64_t zms_id_t;
+#else
+typedef uint32_t zms_id_t;
+#endif
+
+/**
  * @brief Mount a ZMS file system onto the device specified in `fs`.
  *
  * @param fs Pointer to the file system.
@@ -128,7 +139,7 @@ int zms_clear(struct zms_fs *fs);
  * @retval -EINVAL if `fs` is NULL or `len` is invalid.
  * @retval -ENOSPC if no space is left on the device.
  */
-ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len);
+ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len);
 
 /**
  * @brief Delete an entry from the file system
@@ -142,7 +153,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len);
  * @retval -EIO if there is a memory read/write error.
  * @retval -EINVAL if `fs` is NULL.
  */
-int zms_delete(struct zms_fs *fs, uint32_t id);
+int zms_delete(struct zms_fs *fs, zms_id_t id);
 
 /**
  * @brief Read an entry from the file system.
@@ -161,7 +172,7 @@ int zms_delete(struct zms_fs *fs, uint32_t id);
  * @retval -ENOENT if there is no entry with the given `id`.
  * @retval -EINVAL if `fs` is NULL.
  */
-ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len);
+ssize_t zms_read(struct zms_fs *fs, zms_id_t id, void *data, size_t len);
 
 /**
  * @brief Read a history entry from the file system.
@@ -182,7 +193,7 @@ ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len);
  * @retval -ENOENT if there is no entry with the given `id` and history counter.
  * @retval -EINVAL if `fs` is NULL.
  */
-ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, uint32_t cnt);
+ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, uint32_t cnt);
 
 /**
  * @brief Gets the length of the data that is stored in an entry with a given `id`
@@ -198,7 +209,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
  * @retval -ENOENT if there is no entry with the given id.
  * @retval -EINVAL if `fs` is NULL.
  */
-ssize_t zms_get_data_length(struct zms_fs *fs, uint32_t id);
+ssize_t zms_get_data_length(struct zms_fs *fs, zms_id_t id);
 
 /**
  * @brief Calculate the available free space in the file system.

--- a/subsys/fs/zms/Kconfig
+++ b/subsys/fs/zms/Kconfig
@@ -16,6 +16,15 @@ config ZMS
 
 if ZMS
 
+config ZMS_ID_64BIT
+	bool "64 bit ZMS IDs"
+	help
+	  When this option is true, the `zms_id_t` values passed to ZMS APIs will be 64 bit,
+	  as opposed to the default 32 bit.
+	  This option will also change the format of allocation table entries (ATEs) in memory
+	  to accommodate larger IDs. Currently, this will make ZMS unable to mount an existing
+	  file system if it has been initialized with a different ATE format.
+
 config ZMS_LOOKUP_CACHE
 	bool "ZMS lookup cache"
 	help
@@ -34,6 +43,7 @@ config ZMS_LOOKUP_CACHE_SIZE
 
 config ZMS_DATA_CRC
 	bool "ZMS data CRC"
+	depends on !ZMS_ID_64BIT
 
 config ZMS_CUSTOMIZE_BLOCK_SIZE
 	bool "Customize the size of the buffer used internally for reads and writes"
@@ -54,6 +64,7 @@ config ZMS_CUSTOM_BLOCK_SIZE
 config ZMS_LOOKUP_CACHE_FOR_SETTINGS
 	bool "ZMS Storage lookup cache optimized for settings"
 	depends on ZMS_LOOKUP_CACHE && SETTINGS_ZMS
+	depends on !ZMS_ID_64BIT
 	help
 	  Enable usage of lookup cache based on hashes to get, the best ZMS performance,
 	  provided that the ZMS is used only for the purpose of providing the settings

--- a/subsys/fs/zms/zms_priv.h
+++ b/subsys/fs/zms/zms_priv.h
@@ -28,7 +28,6 @@
 #endif
 
 #define ZMS_LOOKUP_CACHE_NO_ADDR GENMASK64(63, 0)
-#define ZMS_HEAD_ID              GENMASK(31, 0)
 
 #define ZMS_VERSION_MASK        GENMASK(7, 0)
 #define ZMS_GET_VERSION(x)      FIELD_GET(ZMS_VERSION_MASK, x)
@@ -36,14 +35,28 @@
 #define ZMS_MAGIC_NUMBER        0x42 /* murmur3a hash of "ZMS" (MSB) */
 #define ZMS_MAGIC_NUMBER_MASK   GENMASK(15, 8)
 #define ZMS_GET_MAGIC_NUMBER(x) FIELD_GET(ZMS_MAGIC_NUMBER_MASK, x)
+#define ZMS_ATE_FORMAT_MASK     GENMASK(19, 16)
+#define ZMS_GET_ATE_FORMAT(x)   FIELD_GET(ZMS_ATE_FORMAT_MASK, x)
 #define ZMS_MIN_ATE_NUM         5
 
 #define ZMS_INVALID_SECTOR_NUM -1
-#define ZMS_DATA_IN_ATE_SIZE   8
+
+#define ZMS_ATE_FORMAT_ID_32BIT 0
+#define ZMS_ATE_FORMAT_ID_64BIT 1
+
+#if !defined(CONFIG_ZMS_ID_64BIT)
+#define ZMS_DEFAULT_ATE_FORMAT ZMS_ATE_FORMAT_ID_32BIT
+#define ZMS_HEAD_ID            GENMASK(31, 0)
+#else
+#define ZMS_DEFAULT_ATE_FORMAT ZMS_ATE_FORMAT_ID_64BIT
+#define ZMS_HEAD_ID            GENMASK64(63, 0)
+#endif /* CONFIG_ZMS_ID_64BIT */
 
 /**
  * @ingroup zms_data_structures
  * ZMS Allocation Table Entry (ATE) structure
+ *
+ * @note This structure depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
  */
 struct zms_ate {
 	/** crc8 check of the entry */
@@ -52,6 +65,8 @@ struct zms_ate {
 	uint8_t cycle_cnt;
 	/** data len within sector */
 	uint16_t len;
+
+#if ZMS_DEFAULT_ATE_FORMAT == ZMS_ATE_FORMAT_ID_32BIT
 	/** data id */
 	uint32_t id;
 	union {
@@ -75,6 +90,22 @@ struct zms_ate {
 			};
 		};
 	};
+
+#elif ZMS_DEFAULT_ATE_FORMAT == ZMS_ATE_FORMAT_ID_64BIT
+	/** data id */
+	uint64_t id;
+	union {
+		/** data field used to store small sized data */
+		uint8_t data[4];
+		/** data offset within sector */
+		uint32_t offset;
+		/** Used to store metadata information such as storage version. */
+		uint32_t metadata;
+	};
+#endif /* ZMS_DEFAULT_ATE_FORMAT */
+
 } __packed;
+
+#define ZMS_DATA_IN_ATE_SIZE SIZEOF_FIELD(struct zms_ate, data)
 
 #endif /* __ZMS_PRIV_H_ */

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -578,17 +578,19 @@ ZTEST_F(zms, test_zms_gc_corrupt_close_ate)
 	int err;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES);
-	close_ate.id = 0xffffffff;
+	memset(&close_ate, 0xff, sizeof(struct zms_ate));
+	close_ate.id = ZMS_HEAD_ID;
 	close_ate.offset = fixture->fs.sector_size - sizeof(struct zms_ate) * 5;
 	close_ate.len = 0;
-	close_ate.metadata = 0xffffffff;
 	close_ate.cycle_cnt = 1;
 	close_ate.crc8 = 0xff; /* Incorrect crc8 */
 
-	empty_ate.id = 0xffffffff;
-	empty_ate.offset = 0;
+	memset(&empty_ate, 0, sizeof(struct zms_ate));
+	empty_ate.id = ZMS_HEAD_ID;
 	empty_ate.len = 0xffff;
-	empty_ate.metadata = 0x4201;
+	empty_ate.metadata = FIELD_PREP(ZMS_VERSION_MASK, ZMS_DEFAULT_VERSION) |
+			     FIELD_PREP(ZMS_MAGIC_NUMBER_MASK, ZMS_MAGIC_NUMBER) |
+			     FIELD_PREP(ZMS_ATE_FORMAT_MASK, ZMS_DEFAULT_ATE_FORMAT);
 	empty_ate.cycle_cnt = 1;
 	empty_ate.crc8 =
 		crc8_ccitt(0xff, (uint8_t *)&empty_ate + SIZEOF_FIELD(struct zms_ate, crc8),
@@ -649,7 +651,7 @@ ZTEST_F(zms, test_zms_gc_corrupt_ate)
 	struct zms_ate close_ate;
 	int err;
 
-	close_ate.id = 0xffffffff;
+	close_ate.id = ZMS_HEAD_ID;
 	close_ate.offset = fixture->fs.sector_size / 2;
 	close_ate.len = 0;
 	close_ate.crc8 =
@@ -964,4 +966,46 @@ ZTEST_F(zms, test_zms_input_validation)
 	zassert_true(err == -EINVAL, "zms_delete call with NULL fs failure: %d", err);
 	err = zms_delete(&fixture->fs, 0);
 	zassert_true(err == -EACCES, "zms_delete call before mount fs failure: %d", err);
+}
+
+/*
+ * Test 64 bit ZMS ID support.
+ */
+ZTEST_F(zms, test_zms_id_64bit)
+{
+	int err;
+	ssize_t len;
+	uint64_t data;
+	uint64_t filling_id = 0xdeadbeefULL;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_ZMS_ID_64BIT);
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Fill the first sector with writes of different IDs */
+
+	while (fixture->fs.data_wra + sizeof(data) + sizeof(struct zms_ate) <=
+	       fixture->fs.ate_wra) {
+		data = filling_id;
+		len = zms_write(&fixture->fs, (zms_id_t)filling_id, &data, sizeof(data));
+		zassert_true(len == sizeof(data), "zms_write failed: %d", len);
+
+		/* Choose the next ID so that its lower 32 bits stay invariant.
+		 * The purpose is to test that ZMS doesn't mistakenly cast the
+		 * 64 bit ID to a 32 bit one somewhere.
+		 */
+		filling_id += BIT64(32);
+	}
+
+	/* Read back the written entries and check that they're all unique */
+
+	for (uint64_t id = 0xdeadbeefULL; id < filling_id; id += BIT64(32)) {
+		len = zms_read_hist(&fixture->fs, (zms_id_t)id, &data, sizeof(data), 0);
+		zassert_true(len == sizeof(data), "zms_read_hist unexpected failure: %d", len);
+		zassert_equal(data, id, "read unexpected data: %llx instead of %llx", data, id);
+
+		len = zms_read_hist(&fixture->fs, (zms_id_t)id, &data, sizeof(data), 1);
+		zassert_true(len == -ENOENT, "zms_read_hist unexpected failure: %d", len);
+	}
 }

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -752,6 +752,8 @@ ZTEST_F(zms, test_zms_cache_init)
 
 	num = num_matching_cache_entries(ate_addr, false, &fixture->fs);
 	zassert_equal(num, 1, "invalid cache entry after restart");
+#else
+	ztest_test_skip();
 #endif
 }
 
@@ -790,6 +792,8 @@ ZTEST_F(zms, test_zms_cache_collision)
 		err = zms_read(&fixture->fs, id, &data, sizeof(data));
 		zassert_equal(-ENOENT, err, "zms_delete failed: %d", err);
 	}
+#else
+	ztest_test_skip();
 #endif
 }
 
@@ -839,6 +843,8 @@ ZTEST_F(zms, test_zms_cache_gc)
 
 	num = num_matching_cache_entries(2ULL << ADDR_SECT_SHIFT, true, &fixture->fs);
 	zassert_equal(num, 2, "invalid cache content after gc");
+#else
+	ztest_test_skip();
 #endif
 }
 
@@ -896,7 +902,8 @@ ZTEST_F(zms, test_zms_cache_hash_quality)
 	TC_PRINT("Cache occupancy: %u\n", (unsigned int)num);
 	zassert_between_inclusive(num, MIN_CACHE_OCCUPANCY, CONFIG_ZMS_LOOKUP_CACHE_SIZE,
 				  "too low cache occupancy - poor hash quality");
-
+#else
+	ztest_test_skip();
 #endif
 }
 

--- a/tests/subsys/fs/zms/testcase.yaml
+++ b/tests/subsys/fs/zms/testcase.yaml
@@ -8,32 +8,33 @@ tests:
     extra_args: DTC_OVERLAY_FILE=boards/qemu_x86_ev_0x00.overlay
     platform_allow: qemu_x86
   filesystem.zms.sim.no_erase:
-    extra_args: CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE=n
+    extra_configs:
+      - CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE=n
     platform_allow: qemu_x86
   filesystem.zms.sim.corrupt_close:
-    extra_args:
+    extra_configs:
       - CONFIG_FLASH_SIMULATOR_EXPLICIT_ERASE=y
       - CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
     platform_allow: qemu_x86
   filesystem.zms.cache:
-    extra_args:
+    extra_configs:
       - CONFIG_ZMS_LOOKUP_CACHE=y
       - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64
     platform_allow: native_sim
   filesystem.zms.data_crc:
-    extra_args:
+    extra_configs:
       - CONFIG_ZMS_DATA_CRC=y
     platform_allow:
       - native_sim
       - qemu_x86
   filesystem.zms.no_double_write:
-    extra_args:
+    extra_configs:
       - CONFIG_ZMS_NO_DOUBLE_WRITE=y
     platform_allow:
       - native_sim
       - qemu_x86
   filesystem.zms.no_double_write_cache:
-    extra_args:
+    extra_configs:
       - CONFIG_ZMS_NO_DOUBLE_WRITE=y
       - CONFIG_ZMS_LOOKUP_CACHE=y
       - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64

--- a/tests/subsys/fs/zms/testcase.yaml
+++ b/tests/subsys/fs/zms/testcase.yaml
@@ -41,3 +41,9 @@ tests:
     platform_allow:
       - native_sim
       - qemu_x86
+  filesystem.zms.id_64bit:
+    extra_configs:
+      - CONFIG_ZMS_ID_64BIT=y
+      - CONFIG_ZMS_LOOKUP_CACHE=y
+      - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64
+    platform_allow: qemu_x86


### PR DESCRIPTION
Allow the ZMS API to optionally accept 64 bit IDs. A typedef `zms_id_t`
is added, so that the maximum ID width can be controlled using Kconfig.

The current ATE structure is already large enough that it is possible to
reserve 64 bits for IDs without increasing its total size (128 bits).
This makes the feature a natural, low footprint alternative to Settings,
for cases where the supported key namespace must be larger than 32 bit
but not arbitrarily large.

The ATE format does have to be altered to accommodate larger IDs, but
the default "32 bit" format is left as is. Now, the `struct zms_ate`
describes one of two supported formats, selected based on an `#ifdef`.
In the future, it may be possible to support multiple ATE formats at
runtime, in which case the structure can be turned into a union.

In the new, "64 bit" ATEs, the `offset` and `metadata` fields are moved
into a union, because they are found to be mutually exclusive. With the
old format, the same fields are in different locations, but one of them
always gets filled with a dummy value, depending on the given ATE type.
To cover both cases, use a `memset` which the compiler can optimize away
when appropriate.

The only limitation is that the new ATE format has no room for data CRC,
but an alternative integrity check can be implemented by the caller.