### PR TITLE
modules/hal_rpi_pico: Switch boot_stage2 to picolibc

### DIFF
--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -45,8 +45,8 @@ target_include_directories(boot_stage2 PUBLIC
 
 target_link_options(boot_stage2 PRIVATE
   "-nostartfiles"
-  "--specs=nosys.specs"
-  "LINKER:--script=${boot_stage_dir}/boot_stage2.ld"
+  "--specs=picolibc.specs"
+  "-T${boot_stage_dir}/boot_stage2.ld"
   )
 
 # The second stage bootloader is compiled without kconfig definitions.

--- a/west.yml
+++ b/west.yml
@@ -231,7 +231,7 @@ manifest:
         - hal
     - name: hal_rpi_pico
       path: modules/hal/rpi_pico
-      revision: 5a981c7c29e3846646549a1902183684f0147e1d
+      revision: b547a36a722af7787e5f55b551fd6ce72dcba5a4
       groups:
         - hal
     - name: hal_silabs


### PR DESCRIPTION
This is part of the broader SDK 1.0 work. These two patches update the module version to one including the
necessary changes and then adapt the Zephyr code to use them. This is ready for review and merging.