### PR TITLE
modules/cmsis_6: Move to version with picolibc patch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       path: modules/lib/cmsis-nn
     - name: cmsis_6
       repo-path: CMSIS_6
-      revision: 06d952b6713a2ca41c9224a62075e4059402a151
+      revision: 30a859f44ef8ab4dc8f84b03ed586fd16ccf9d74
       path: modules/hal/cmsis_6
       groups:
         - hal


### PR DESCRIPTION
This version along the zephyr branch allows cmsis_6 to compile against picolibc. This is required for SDK 1.0 support and is ready for review and merging.
