### PR TITLE
modules/psa-arch-tests: Add pending GCC 14.3 support patch

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -23,7 +23,7 @@ manifest:
       groups:
         - optional
     - name: psa-arch-tests
-      revision: 2cadb02a72eacda7042505dcbdd492371e8ce024
+      revision: pull/14/head
       path: modules/tee/tf-m/psa-arch-tests
       remote: upstream
       groups:


### PR DESCRIPTION
psa-arch-tests includes device drivers that failed to mark registers with 'volatile'. GCC 14.3 cleverly optimized sequential register accesses using strd/ldrd instructions which caused the drivers to fail.

This patch is blocked on the module patch, https://github.com/zephyrproject-rtos/psa-arch-tests/pull/14