### PR TITLE
west: Add mbedtls fix for gcc 14.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -316,7 +316,7 @@ manifest:
       revision: b03edc8e6282a963cd312cd0b409eb5ce263ea75
       path: modules/lib/gui/lvgl
     - name: mbedtls
-      revision: 85440ef5fffa95d0e9971e9163719189cf34d979
+      revision: 2994b29fcae7e1d7fc6b8f38d9f922032ee90e6e
       path: modules/crypto/mbedtls
       groups:
         - crypto


### PR DESCRIPTION
This patch avoids an incorrect warning generated by gcc 14.3 about array bounds. It should not change the generated code at all.

This patch merges in the commit from the merged Zephyr module patch, https://github.com/zephyrproject-rtos/mbedtls/pull/73 which is based on the merged upstream mbedtls patch https://github.com/Mbed-TLS/mbedtls/pull/10318