### PR TITLE
SDK 1.0 compatibility fixes

### DIFF
--- a/arch/arm/core/cortex_m/thread.c
+++ b/arch/arm/core/cortex_m/thread.c
@@ -649,7 +649,7 @@ FUNC_NORETURN void z_arm_switch_to_main_no_multithreading(k_thread_entry_t main_
 			  ,
 		  [_psplim] "r"(psplim)
 #endif
-		: "r0", "r1", "r2", "ip", "lr");
+		: "r0", "r1", "r2", "ip", "lr", "memory");
 
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -219,7 +219,7 @@ static FUNC_NORETURN __used void df_handler_top(void)
 	/* NT bit is set in EFLAGS so we will task switch back to _main_tss
 	 * and run df_handler_bottom
 	 */
-	__asm__ volatile ("iret");
+	__asm__ volatile ("iret" ::: "memory");
 	CODE_UNREACHABLE;
 }
 

--- a/arch/x86/zefi/zefi.py
+++ b/arch/x86/zefi/zefi.py
@@ -117,7 +117,7 @@ def build_elf(elf_file, include_dirs):
         includes.extend(["-I", include_dir])
     cmd = ([args.compiler, "-shared", "-Wall", "-Werror", "-I."] + includes +
            ["-fno-stack-protector", "-fpic", "-mno-red-zone", "-fshort-wchar",
-            "-Wl,-nostdlib", "-T", ldscript, "-o", "zefi.elf", cfile])
+            "-Wl,-nostdlib", "-nostartfiles", "-T", ldscript, "-o", "zefi.elf", cfile])
     verbose(" ".join(cmd))
     subprocess.run(cmd, check = True)
 

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -118,7 +118,7 @@ void xtensa_simulator_exit(int return_code)
 	    "simcall\n\t"
 	    :
 	    : [code] "r" (return_code), [call] "i" (SYS_exit)
-	    : "a3", "a2");
+	    : "a3", "a2", "memory");
 
 	CODE_UNREACHABLE;
 }

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -498,7 +498,7 @@ static void adc_stm32_calibration_start(const struct device *dev, bool single_en
 	const struct adc_stm32_cfg *config =
 		(const struct adc_stm32_cfg *)dev->config;
 	ADC_TypeDef *adc = config->base;
-#ifdef LL_ADC_SINGLE_ENDED
+#if defined(LL_ADC_SINGLE_ENDED) && defined(LL_ADC_DIFFERENTIAL_ENDED)
 	uint32_t calib_type = single_ended ? LL_ADC_SINGLE_ENDED : LL_ADC_DIFFERENTIAL_ENDED;
 #else
 	ARG_UNUSED(single_ended);

--- a/include/zephyr/arch/x86/ia32/arch.h
+++ b/include/zephyr/arch/x86/ia32/arch.h
@@ -362,7 +362,8 @@ extern struct task_state_segment _main_tss;
 		"int %[vector]\n\t" \
 		: \
 		: [vector] "i" (Z_X86_OOPS_VECTOR), \
-		  [reason] "i" (reason_p)); \
+		  [reason] "i" (reason_p) \
+		: "memory"); \
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */ \
 } while (false)
 

--- a/include/zephyr/arch/x86/intel64/arch.h
+++ b/include/zephyr/arch/x86/intel64/arch.h
@@ -66,7 +66,8 @@ static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 		"movq %[reason], %%rax\n\t" \
 		"int $32\n\t" \
 		: \
-		: [reason] "i" (reason_p)); \
+		: [reason] "i" (reason_p) \
+		: "memory"); \
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */ \
 } while (false)
 

--- a/modules/cmsis-dsp/CMakeLists.txt
+++ b/modules/cmsis-dsp/CMakeLists.txt
@@ -19,6 +19,9 @@ if(CONFIG_CMSIS_DSP)
     ${cmsis_glue_path}/CMSIS/Core/Include
   )
 
+  # Define ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_ to avoid using Zephyr's stdint.h
+  zephyr_library_compile_definitions(ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_)
+
   # Global Feature Definitions
   zephyr_library_compile_definitions_ifdef(CONFIG_CMSIS_DSP_NEON                  ARM_MATH_NEON)
   zephyr_library_compile_definitions_ifdef(CONFIG_CMSIS_DSP_NEON_EXPERIMENTAL     ARM_MATH_NEON_EXPERIMENTAL)

--- a/soc/intel/intel_adsp/cavs/multiprocessing.c
+++ b/soc/intel/intel_adsp/cavs/multiprocessing.c
@@ -201,6 +201,7 @@ __imr void soc_mp_init(void)
 
 int soc_adsp_halt_cpu(int id)
 {
+#if CONFIG_MP_MAX_NUM_CPUS > 1
 	unsigned int irq_mask;
 
 	if (id == 0 || id == arch_curr_cpu()->id) {
@@ -237,4 +238,7 @@ int soc_adsp_halt_cpu(int id)
 	while ((CAVS_SHIM.pwrsts & CAVS_PWRSTS_PDSPPGS(id))) {
 	}
 	return 0;
+#else
+	return -EINVAL;
+#endif
 }

--- a/subsys/testsuite/include/zephyr/interrupt_util.h
+++ b/subsys/testsuite/include/zephyr/interrupt_util.h
@@ -7,6 +7,8 @@
 #ifndef INTERRUPT_UTIL_H_
 #define INTERRUPT_UTIL_H_
 
+#define k_str_out_count(s) k_str_out((s), sizeof(s) - 1);
+
 #if defined(CONFIG_CPU_CORTEX_M)
 #include <cmsis_core.h>
 
@@ -57,7 +59,7 @@ static inline uint32_t get_available_nvic_line(uint32_t initial_offset)
 
 static inline void trigger_irq(int irq)
 {
-	printk("Triggering irq : %d\n", irq);
+	k_str_out_count("Triggering irq\n");
 #if defined(CONFIG_SOC_TI_LM3S6965_QEMU) || defined(CONFIG_CPU_CORTEX_M0) ||                       \
 	defined(CONFIG_CPU_CORTEX_M0PLUS) || defined(CONFIG_CPU_CORTEX_M1) ||                      \
 	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
@@ -74,7 +76,7 @@ static inline void trigger_irq(int irq)
 
 static inline void trigger_irq(int irq)
 {
-	printk("Triggering irq : %d\n", irq);
+	k_str_out_count("Triggering irq\n");
 
 	/* Ensure that the specified IRQ number is a valid SGI interrupt ID */
 	zassert_true(irq <= 15, "%u is not a valid SGI interrupt ID", irq);
@@ -96,7 +98,7 @@ static inline void trigger_irq(int irq)
 #elif defined(CONFIG_ARC)
 static inline void trigger_irq(int irq)
 {
-	printk("Triggering irq : %d\n", irq);
+	k_str_out_count("Triggering irq\n");
 	z_arc_v2_aux_reg_write(_ARC_V2_AUX_IRQ_HINT, irq);
 }
 

--- a/tests/arch/arm/arm_mpu_pxn/src/main.c
+++ b/tests/arch/arm/arm_mpu_pxn/src/main.c
@@ -18,6 +18,7 @@
  */
 __customramfunc bool custom_ram_func(void)
 {
+	compiler_barrier();
 	return true;
 }
 
@@ -28,6 +29,7 @@ __customramfunc bool custom_ram_func(void)
  */
 __ramfunc bool ram_function(void)
 {
+	compiler_barrier();
 	return true;
 }
 

--- a/tests/kernel/interrupt/CMakeLists.txt
+++ b/tests/kernel/interrupt/CMakeLists.txt
@@ -16,6 +16,10 @@ target_sources(app PRIVATE
     src/nested_irq.c
     )
 
+if(CONFIG_ARM64)
+  add_compile_options(-mgeneral-regs-only)
+endif()
+
 target_sources_ifdef(CONFIG_DYNAMIC_INTERRUPTS app PRIVATE src/dynamic_isr.c)
 target_sources_ifdef(CONFIG_X86 app PRIVATE src/regular_isr.c)
 target_sources_ifdef(CONFIG_SHARED_INTERRUPTS app PRIVATE src/static_shared_irq.c)

--- a/tests/kernel/interrupt/src/nested_irq.c
+++ b/tests/kernel/interrupt/src/nested_irq.c
@@ -102,19 +102,19 @@ void isr1(const void *param)
 {
 	ARG_UNUSED(param);
 
-	printk("isr1: Enter\n");
+	k_str_out_count("ISR1: Enter\n");
 
 	/* Set verification token */
 	isr1_result = ISR1_TOKEN;
 
-	printk("isr1: Leave\n");
+	k_str_out_count("ISR1: Leave\n");
 }
 
 void isr0(const void *param)
 {
 	ARG_UNUSED(param);
 
-	printk("isr0: Enter\n");
+	k_str_out_count("ISR0: Enter\n");
 
 	/* Set verification token */
 	isr0_result = ISR0_TOKEN;
@@ -128,7 +128,7 @@ void isr0(const void *param)
 	/* Validate nested ISR result token */
 	zassert_equal(isr1_result, ISR1_TOKEN, "isr1 did not execute");
 
-	printk("isr0: Leave\n");
+	k_str_out_count("ISR0: Leave\n");
 }
 
 /**

--- a/tests/kernel/mem_protect/demand_paging/mem_map/boards/qemu_x86_tiny.conf
+++ b/tests/kernel/mem_protect/demand_paging/mem_map/boards/qemu_x86_tiny.conf
@@ -5,7 +5,7 @@
 # However, specifying how many pages used by
 # the backing store must be done in build time.
 # So here we are, tuning this manually.
-CONFIG_BACKING_STORE_RAM_PAGES=12
+CONFIG_BACKING_STORE_RAM_PAGES=10
 
 # The following is needed so that .text and following
 # sections are present in physical memory to test

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -27,8 +27,8 @@ BUILD_ASSERT(NUM_THREAD <= MAX_NUM_THREAD);
 /* ... will not take more than 1 ms. */
 #define TASK_SWITCH_TOLERANCE (1)
 #else
-/* ... 1ms is faster than a tick, loosen tolerance to 1 tick */
-#define TASK_SWITCH_TOLERANCE (1000 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+/* ... 1ms is faster than a tick, loosen tolerance to just over 1 tick */
+#define TASK_SWITCH_TOLERANCE (1100 / CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 #endif
 
 K_SEM_DEFINE(sema, 0, NUM_THREAD);


### PR DESCRIPTION
These patches improve compiler compatibility with the upcoming SDK 1.0 which includes GCC 14.3. They are ready for review and merging.