### PR TITLE
west: Add cmsis-dsp fix for shifting by negative amounts

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -122,7 +122,7 @@ manifest:
       groups:
         - hal
     - name: cmsis-dsp
-      revision: 2c014e93d75c4896df57f072b3f7d5d06e37f254
+      revision: 97512610ec92058f0119450b9e743eeb7e95b5c8
       path: modules/lib/cmsis-dsp
     - name: cmsis-nn
       revision: e9328d612ea3ea7d0d210d3ac16ea8667c01abdd


### PR DESCRIPTION
This patch has been accepted upstream https://github.com/ARM-software/CMSIS-DSP/pull/265.
The module PR, https://github.com/zephyrproject-rtos/cmsis-dsp/pull/7 is pending review.

This PR is stacked on top of another cmsis-dsp west update, https://github.com/zephyrproject-rtos/zephyr/pull/94361