### PR TITLE
dts: arm: nxp: Move static ocram configuration to specific soc

### DIFF
--- a/dts/arm/nxp/nxp_rt1160.dtsi
+++ b/dts/arm/nxp/nxp_rt1160.dtsi
@@ -11,3 +11,16 @@
 	clock-mult = <100>;
 	clock-div = <4>;
 };
+
+/* Set OCRAM regions/sizes for RT1160. Combines OCRAM1/OCRAM2/OCRAM M7 (FlexRAM ECC).
+ * ECC must be left disabled for this configuration
+ */
+/ {
+	soc {
+		ocram_combined: ocram@20340000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "OCRAMCOMBINED";
+			reg = <0x20340000 DT_SIZE_K(256)>;
+		};
+	};
+};

--- a/dts/arm/nxp/nxp_rt1170.dtsi
+++ b/dts/arm/nxp/nxp_rt1170.dtsi
@@ -11,3 +11,20 @@
 	clock-mult = <83>;
 	clock-div = <2>;
 };
+
+/* Set OCRAM regions/sizes for RT1170 */
+/ {
+	soc {
+		ocram1: ocram@20240000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "OCRAM1";
+			reg = <0x20240000 DT_SIZE_K(512)>;
+		};
+
+		ocram2: ocram@202c0000 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "OCRAM2";
+			reg = <0x202c0000 DT_SIZE_K(512)>;
+		};
+	};
+};

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -944,18 +944,6 @@
 			reg = <0x20200000 DT_SIZE_K(256)>;
 		};
 
-		ocram1: ocram@20240000 {
-			compatible = "zephyr,memory-region", "mmio-sram";
-			zephyr,memory-region = "OCRAM1";
-			reg = <0x20240000 DT_SIZE_K(512)>;
-		};
-
-		ocram2: ocram@202c0000 {
-			compatible = "zephyr,memory-region", "mmio-sram";
-			zephyr,memory-region = "OCRAM2";
-			reg = <0x202c0000 DT_SIZE_K(512)>;
-		};
-
 		lpadc1: adc@40050000 {
 			compatible = "nxp,lpc-lpadc";
 			reg = <0x40050000 0x304>;


### PR DESCRIPTION
RT1160 and RT1170 have different sizes for OCRAM1 and OCRAM2. This PR moves the static ocram1 and ocram2 labels to the soc specific dtsi and defines their sizes according to the RM.