### PR TITLE
modules: Update trusted-firmware-m for picolibc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -370,7 +370,7 @@ manifest:
       groups:
         - debug
     - name: tf-m-tests
-      revision: a90702bcb8fadb6f70daf0ffbb13888dfe63fc99
+      revision: pull/17/head
       path: modules/tee/tf-m/tf-m-tests
       groups:
         - testing

--- a/west.yml
+++ b/west.yml
@@ -380,7 +380,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: c2f9edc77f72838e7d6f5f9c0b95e4318ddfced1
+      revision: pull/134/head
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
This adds linker script bits and compiler options so that trusted-firmware-m will build with picolibc.

This has not been merged to the Zephyr trusted-firmware-m repository yet, that PR is https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/134