### PR TITLE
github: errno: Run workflow if SDK_VERSION file is modified

### DIFF
--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -5,6 +5,7 @@ on:
       - '.github/workflows/errno.yml'
       - 'lib/libc/minimal/include/errno.h'
       - 'scripts/ci/errno.py'
+      - 'SDK_VERSION'
 
 permissions:
   contents: read
@@ -13,7 +14,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.28.0
+      image: ghcr.io/zephyrproject-rtos/ci:v0.28.2
 
     steps:
       - name: Apply container owner mismatch workaround


### PR DESCRIPTION
The CI workflow runs on specific paths being touched, add the SDK_VERSION as one of those paths.