### PR TITLE
driver: spi: silabs_siwx91x_gspi: Add pm device support for gspi driver

### DIFF
--- a/dts/arm/silabs/siwg917.dtsi
+++ b/dts/arm/silabs/siwg917.dtsi
@@ -372,6 +372,8 @@
 			interrupts = <46 0>;
 			interrupt-names = "gspi";
 			clocks = <&clock0 SIWX91X_CLK_GSPI>;
+			power-domains = <&siwx91x_soc_pd>;
+			zephyr,pm-device-runtime-auto;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
This commit enables the pm device driver support for the spi_silabs_siwx91x_gspi driver.