### PR TITLE
Device runtime support uart ns16550

### DIFF
--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -59,6 +59,13 @@ config UART_NS16550_VARIANT_NS16950
 	bool "UART 16950 (128-bytes FIFO and auto flow control)"
 	help
 	  This enables support for 128-bytes FIFO and automatic hardware flow control.
+
+config UART_NS16550_ENABLE_DEVICE_PM
+	bool "UART 16550 device PM enable"
+	depends on PM_DEVICE
+	help
+	  This enables support device PM implementation for ns16550 driver.
+	  This should be enabled along with DEVICE PM configs.
 endchoice
 
 config UART_NS16550_ACCESS_WORD_ONLY

--- a/modules/hal_silabs/wiseconnect/CMakeLists.txt
+++ b/modules/hal_silabs/wiseconnect/CMakeLists.txt
@@ -211,11 +211,7 @@ endif() # CONFIG_SOC_SILABS_SLEEPTIMER
 
 if(CONFIG_SOC_SIWX91X_PM_BACKEND_PMGR)
   zephyr_library_sources(
-    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/core/common/src/rsi_debug.c
     ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/core/chip/src/rsi_ps_ram_func.c
-    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/USART.c
-    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/UDMA.c
-    ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/SAI.c
     ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/sl_si91x_m4_ps.c
     ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_usart.c
     ${WISECONNECT_DIR}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_udma_wrapper.c
@@ -235,8 +231,6 @@ if(CONFIG_SOC_SIWX91X_PM_BACKEND_PMGR)
     SL_SLEEP_TIMER
     SL_SI91X_SI917_RAM_MEM_CONFIG=2
     SL_CODE_COMPONENT_CORE=core
-    DEBUG_ENABLE
-    DEBUG_UART
     SLI_WIRELESS_COMPONENT_PRESENT
   )
   zephyr_code_relocate(FILES

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 13343bccf850eb7b6541f6e71a8d2a880209850b
+      revision: pull/130/head
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
Device runtime support for uart_ns16550 driver by enabling CONFIG_UART_NS16550_ENABLE_DEVICE_PM

This is a second attempt after #92507 got reverted in #93568 