### PR TITLE
manifest: update net-tools to include CAN bus support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -323,7 +323,7 @@ manifest:
       revision: 7307ce399b81ddcb3c3a5dc862c52d4754328d38
       path: modules/lib/nanopb
     - name: net-tools
-      revision: 64bf49ad9b6d1d1f9d24bf8b94d82d9bcb52f61a
+      revision: 2750d71e28e48865a6fd8a10413f978bb216c59e
       path: tools/net-tools
       groups:
         - tools


### PR DESCRIPTION
Update the net-tools revision to include support for managing host CAN interfaces (e.g. zcan0 as used by the Zephyr native Linux SocketCAN driver).