### PR TITLE
tests: boards: nrf: xip: extend timeout

### DIFF
--- a/tests/boards/nrf/xip/testcase.yaml
+++ b/tests/boards/nrf/xip/testcase.yaml
@@ -3,6 +3,7 @@ common:
   tags:
     - drivers
     - flash
+  timeout: 240
 tests:
   boards.nrf.xip:
     platform_allow:


### PR DESCRIPTION
Flashing ext flash is long.