### PR TITLE
stm32: drivers: adc: fix adc acquisition time comparison in adc_stm32_sampling_time_check

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1210,6 +1210,11 @@ static int adc_stm32_sampling_time_check(const struct device *dev, uint16_t acq_
 		return STM32_NB_SAMPLING_TIME - 1;
 	}
 
+	if (ADC_ACQ_TIME_UNIT(acq_time) != ADC_ACQ_TIME_TICKS) {
+		LOG_ERR("Acquisition time expected in ticks only");
+		return -EINVAL;
+	}
+
 	for (int i = 0; i < STM32_NB_SAMPLING_TIME; i++) {
 		if (acq_time == ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS,
 					     config->sampling_time_table[i])) {


### PR DESCRIPTION
Add an explicit check to ensure that the acquisition_time parameter is encoded with the ADC_ACQ_TIME macro and uses the TICKS unit, as required by the API.
If the unit is not correct, log an error and return -EINVAL.

fixes: #94071 