### PR TITLE
tests: drivers: Update nRF clock control test for the IronSide DVFS

### DIFF
--- a/tests/drivers/clock_control/nrf_clock_control/src/main.c
+++ b/tests/drivers/clock_control/nrf_clock_control/src/main.c
@@ -395,7 +395,7 @@ ZTEST(nrf2_clock_control, test_auxpll_control)
 
 static void *setup(void)
 {
-#if defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP)
+#if defined(CONFIG_BOARD_NRF54H20DK_NRF54H20_CPUAPP) && defined(CLOCK_CONTROL_NRF_IRON_HSFLL_LOCAL)
 	const struct device *clk_dev = DEVICE_DT_GET(DT_NODELABEL(cpuapp_hsfll));
 	const struct nrf_clock_spec clk_spec = {
 		.frequency = MHZ(64),


### PR DESCRIPTION
The IronSide DVFS implementation does not require
waiting for the initialisation.