### PR TITLE
tests: arch: arm: irq vt: disable power domains (NRFS)

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_POWER_DOMAIN=n

--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -11,3 +11,52 @@
 &cpusec_bellboard{
 	status = "disabled";
 };
+
+
+&gdpwr {
+	status = "disabled";
+};
+
+&gdpwr_fast_active_0 {
+	status = "disabled";
+};
+
+&gdpwr_fast_active_1 {
+	status = "disabled";
+};
+
+&gdpwr_fast_main {
+	status = "disabled";
+};
+
+&gdpwr_slow_active {
+	status = "disabled";
+};
+
+&gdpwr_slow_main {
+	status = "disabled";
+};
+
+&gpio_pad_group0 {
+	status = "disabled";
+};
+
+&gpio_pad_group1 {
+	status = "disabled";
+};
+
+&gpio_pad_group2 {
+	status = "disabled";
+};
+
+&gpio_pad_group6 {
+	status = "disabled";
+};
+
+&gpio_pad_group7 {
+	status = "disabled";
+};
+
+&gpio_pad_group9 {
+	status = "disabled";
+};

--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_POWER_DOMAIN=n

--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -11,3 +11,51 @@
 &cpusec_bellboard{
 	status = "disabled";
 };
+
+&gdpwr {
+	status = "disabled";
+};
+
+&gdpwr_fast_active_0 {
+	status = "disabled";
+};
+
+&gdpwr_fast_active_1 {
+	status = "disabled";
+};
+
+&gdpwr_fast_main {
+	status = "disabled";
+};
+
+&gdpwr_slow_active {
+	status = "disabled";
+};
+
+&gdpwr_slow_main {
+	status = "disabled";
+};
+
+&gpio_pad_group0 {
+	status = "disabled";
+};
+
+&gpio_pad_group1 {
+	status = "disabled";
+};
+
+&gpio_pad_group2 {
+	status = "disabled";
+};
+
+&gpio_pad_group6 {
+	status = "disabled";
+};
+
+&gpio_pad_group7 {
+	status = "disabled";
+};
+
+&gpio_pad_group9 {
+	status = "disabled";
+};


### PR DESCRIPTION
The power domains on the nrf54h20dk require NRFS, which uses some of the irq vectors reserved for the test. Disable power domains and its drivers to free the irq vectors.