### PR TITLE
soc: nxp: imxrt10xx: Configurable DCDC voltages

### DIFF
--- a/soc/nxp/imxrt/imxrt10xx/Kconfig
+++ b/soc/nxp/imxrt/imxrt10xx/Kconfig
@@ -137,4 +137,25 @@ config INIT_VIDEO_PLL
 	depends on !SOC_MIMXRT1011 && !SOC_MIMXRT1015 && \
 		   !SOC_MIMXRT1021 && !SOC_MIMXRT1024
 
+if PM
+
+config DCDC_TARGET_LOW_POWER_VOLTAGE
+	int "Target DCDC voltage in mV for low power mode"
+	default 1075
+	range 800 1575
+	help
+	  When entering suspend-to-idle drops to this target SOC voltage.
+	  If you are experiencing issues with low power mode stability,
+	  try raising this voltage value. Increment or decrement in steps of 25 mV.
+
+config DCDC_TARGET_NORMAL_VOLTAGE
+	int "Target DCDC voltage in mV for normal mode"
+	default 1275
+	range 800 1575
+	help
+	  When exiting suspend-to-idle raises to this SOC voltage.
+	  Increment or decrement in steps of 25 mV.
+
+endif # PM
+
 endif # SOC_SERIES_IMXRT10XX

--- a/soc/nxp/imxrt/imxrt10xx/power.c
+++ b/soc/nxp/imxrt/imxrt10xx/power.c
@@ -148,10 +148,10 @@ static void lpm_drop_voltage(void)
 	CLOCK_SwitchOsc(kCLOCK_RcOsc);
 	CLOCK_DeinitExternalClk();
 	/*
-	 * Change to 1.075V SOC voltage. If you are experiencing issues with
+	 * Change to low power SOC voltage. If you are experiencing issues with
 	 * low power mode stability, try raising this voltage value.
 	 */
-	DCDC_AdjustRunTargetVoltage(DCDC, 0xB);
+	DCDC_AdjustRunTargetVoltage(DCDC, (CONFIG_DCDC_TARGET_LOW_POWER_VOLTAGE - 800) / 25);
 	/* Enable 2.5 and 1.1V weak regulators */
 	PMU_2P5EnableWeakRegulator(PMU, true);
 	PMU_1P1EnableWeakRegulator(PMU, true);
@@ -173,8 +173,8 @@ static void lpm_raise_voltage(void)
 	/* Disable weak LDOs */
 	PMU_2P5EnableWeakRegulator(PMU, false);
 	PMU_1P1EnableWeakRegulator(PMU, false);
-	/* Change to 1.275V SOC voltage */
-	DCDC_AdjustRunTargetVoltage(DCDC, 0x13);
+	/* Change to normal SOC voltage */
+	DCDC_AdjustRunTargetVoltage(DCDC, (CONFIG_DCDC_TARGET_NORMAL_VOLTAGE - 800) / 25);
 	/* Move to the external RC oscillator */
 	CLOCK_InitExternalClk(0);
 	/* Switch clock source to external OSC. */


### PR DESCRIPTION
Allow users to configure the DCDC target voltages for low power and normal mode.