### PR TITLE
twister: coverage: set gcov working directory

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -414,6 +414,7 @@ class Gcovr(CoverageTool):
         cmd = ["gcovr", "-r", self.base_dir,
                "--gcov-ignore-parse-errors=negative_hits.warn_once_per_file",
                "--gcov-executable", self.gcov_tool,
+               "--gcov-object-directory", outdir,
                "-e", "tests/*"]
         cmd += excludes + self.options + ["--json", "-o", coverage_file, outdir]
         cmd_str = " ".join(cmd)
@@ -427,6 +428,7 @@ class Gcovr(CoverageTool):
 
         cmd = ["gcovr", "-r", self.base_dir] + self.options
         cmd += ["--gcov-executable", self.gcov_tool,
+                "--gcov-object-directory", outdir,
                 "-f", "tests/ztest", "-e", "tests/ztest/test/*",
                 "--json", "-o", ztest_file, outdir]
         cmd_str = " ".join(cmd)


### PR DESCRIPTION
gcovr runs gcov to generate temporary coverage files into the gcov working directory. The working directory defaults to gcovr's -r argument.

When running twister with the --coverage-per-instance argument, multiple gcovr instances may run in parallel. Since they all share the same gcov working directory, they may interfere with each other, resulting in errors like this:

	AssertionError: Sanity check failed, output file spinlock.h##4167b923a06cc9590c8eef372f016a6d.gcov doesn't exist but no error from GCOV detected.

To fix this, specify a separate gcov working directory for every test through gcovr's --gcov-object-directory option.