### PR TITLE
arch: rx: Update Renesas RX arch bindings

### DIFF
--- a/arch/rx/Kconfig
+++ b/arch/rx/Kconfig
@@ -11,6 +11,11 @@ config ARCH
 	string
 	default "rx"
 
+config HAS_EXCEPT_VECTOR_TABLE
+	bool
+	help
+	  Set if the processor has the exception vector table.
+
 config CPU_RXV1
 	bool
 	help
@@ -18,18 +23,15 @@ config CPU_RXV1
 
 config CPU_RXV2
 	bool
+	select HAS_EXCEPT_VECTOR_TABLE
 	help
 	  Set if the processor supports the Renesas RXv2 instruction set.
 
 config CPU_RXV3
 	bool
+	select HAS_EXCEPT_VECTOR_TABLE
 	help
 	  Set if the processor supports the Renesas RXv3 instruction set.
-
-config HAS_EXCEPT_VECTOR_TABLE
-	bool
-	help
-	  Set if the processor has the exception vector table.
 
 config XIP
 	default y

--- a/arch/rx/core/irq_offload.c
+++ b/arch/rx/core/irq_offload.c
@@ -17,11 +17,12 @@
 #include <zephyr/irq_offload.h>
 #include <zephyr/sys/util.h>
 
-#define SWINT1_IRQ_LINE 27
-#define SWINT1_PRIO 14
+#define SWINT1_NODE            DT_NODELABEL(swint1)
+#define SWINT1_IRQ_LINE        DT_IRQN(SWINT1_NODE)
+#define SWINT1_PRIO            DT_IRQ(SWINT1_NODE, priority)
 /* Address of the software interrupt trigger register for SWINT1 */
-#define SWINT_REGISTER_ADDRESS 0x872E0
-#define SWINTR_SWINT *(uint8_t *)(SWINT_REGISTER_ADDRESS)
+#define SWINT_REGISTER_ADDRESS DT_REG_ADDR(SWINT1_NODE)
+#define SWINTR_SWINT           *(uint8_t *)(SWINT_REGISTER_ADDRESS)
 
 static irq_offload_routine_t _offload_routine;
 static const void *offload_param;

--- a/arch/rx/core/vects.c
+++ b/arch/rx/core/vects.c
@@ -425,6 +425,8 @@ INT_DEMUX(253);
 INT_DEMUX(254);
 INT_DEMUX(255);
 
+#if !CONFIG_HAS_EXCEPT_VECTOR_TABLE
+
 const void *FixedVectors[] FVECT_SECT = {
 	/* 0x00-0x4c: Reserved, must be 0xff (according to e2 studio example) */
 	/* Reserved for OFSM */
@@ -475,6 +477,60 @@ const void *FixedVectors[] FVECT_SECT = {
 	INT_NonMaskableInterrupt,
 	_start,
 };
+
+#else
+
+/* The reset vector ALWAYS is at address 0xFFFFFFFC. Set it to point at
+ * the start routine (in reset.S)
+ */
+const FVECT_SECT void *resetVector = _start;
+
+/* Exception vector table
+ * (see rx-family-rxv2-instruction-set-architecture-users-manual-software)
+ */
+const void *ExceptVectors[] EXVECT_SECT = {
+	/* 0x00-0x4c: Reserved, must be 0xff (according to e2 studio example) */
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	(fp)0xFFFFFFFF,
+	/* 0x50: Privileged instruction exception */
+	INT_Excep_SuperVisorInst,
+	/* 0x54: Access exception */
+	INT_Excep_AccessInst,
+	/* 0x58: Reserved */
+	Dummy,
+	/* 0x5c: Undefined Instruction Exception */
+	INT_Excep_UndefinedInst,
+	/* 0x60: Reserved */
+	Dummy,
+	/* 0x64: Floating Point Exception */
+	INT_Excep_FloatingPoint,
+	/* 0x68-0x74: Reserved */
+	Dummy,
+	Dummy,
+	Dummy,
+	Dummy,
+	/* 0x78: Non-maskable interrupt */
+	INT_NonMaskableInterrupt,
+};
+#endif
 
 const fp RelocatableVectors[] RVECT_SECT = {
 	reserved_isr,  switch_isr_wrapper, INT_RuntimeFatalInterrupt,

--- a/boards/qemu/rx/qemu_rx.dts
+++ b/boards/qemu/rx/qemu_rx.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "Renesas QEMU";
-	compatible = "qemu,rx","renesas,rxv1";
+	compatible = "qemu,rx";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/boards/renesas/rsk_rx130/rsk_rx130.dts
+++ b/boards/renesas/rsk_rx130/rsk_rx130.dts
@@ -13,7 +13,7 @@
 
 / {
 	model = "Renesas RSK+RX130-512KB KIT";
-	compatible = "renesas,rsk_rx130_512kb","renesas,rxv1";
+	compatible = "renesas,rsk_rx130_512kb";
 
 	chosen {
 		zephyr,sram = &sram0;

--- a/drivers/timer/renesas_rx_cmt.c
+++ b/drivers/timer/renesas_rx_cmt.c
@@ -19,13 +19,12 @@
 #define CMT0_NODE DT_NODELABEL(cmt0)
 #define CMT1_NODE DT_NODELABEL(cmt1)
 
+#define CMT1_IRQN DT_IRQN(CMT1_NODE)
+
 #define ICU_NODE DT_NODELABEL(icu)
 
-#define ICU_IR_ADDR  DT_REG_ADDR_BY_NAME(ICU_NODE, IR)
-#define ICU_IER_ADDR DT_REG_ADDR_BY_NAME(ICU_NODE, IER)
-#define ICU_IPR_ADDR DT_REG_ADDR_BY_NAME(ICU_NODE, IPR)
-#define ICU_FIR_ADDR DT_REG_ADDR_BY_NAME(ICU_NODE, FIR)
-#define ICU_IR       ((volatile uint8_t *)ICU_IR_ADDR)
+#define ICU_IR_ADDR DT_REG_ADDR_BY_NAME(ICU_NODE, IR)
+#define ICU_IR      ((volatile uint8_t *)ICU_IR_ADDR)
 
 #define CMT0_IRQ_NUM DT_IRQ_BY_NAME(CMT0_NODE, cmi, irq)
 #define CMT1_IRQ_NUM DT_IRQ_BY_NAME(CMT1_NODE, cmi, irq)
@@ -35,10 +34,9 @@
 #define CYCLES_PER_SEC  (CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)
 #define TICKS_PER_SEC   (CONFIG_SYS_CLOCK_TICKS_PER_SEC)
 #define CYCLES_PER_TICK (CYCLES_PER_SEC / TICKS_PER_SEC)
+#define MAX_TICKS       ((k_ticks_t)(COUNTER_MAX / CYCLES_PER_TICK) - 1)
 
 #define CYCLES_CYCLE_TIMER (COUNTER_MAX + 1)
-#define MSTPCR_ADDR        ((volatile uint32_t *)0x00080010) /* MSTPCR register address */
-#define MSTP_CMT0_BIT      (1 << 15)                         /* Bit 15 controls MSTPA15 (CMT0) */
 
 static const struct clock_control_rx_subsys_cfg cmt_clk_cfg = {
 	.mstp = DT_CLOCKS_CELL_BY_IDX(DT_INST_PARENT(0), 0, mstp),
@@ -86,13 +84,13 @@ const int32_t z_sys_timer_irq_for_test = CMT0_IRQ_NUM;
 static cycle_t cmt1_elapsed(void)
 {
 	uint32_t val1 = (uint32_t)(*cycle_timer_cfg.cmcnt);
-	uint8_t cmt_ir = ICU_IR[29];
+	uint8_t cmt_ir = ICU_IR[CMT1_IRQN];
 	uint32_t val2 = (uint32_t)(*cycle_timer_cfg.cmcnt);
 
 	if ((1 == cmt_ir) || (val1 > val2)) {
 		cycle_count += CYCLES_CYCLE_TIMER;
 
-		ICU_IR[29] = 0;
+		ICU_IR[CMT1_IRQN] = 0;
 	}
 
 	return (val2 + cycle_count);
@@ -211,17 +209,40 @@ static int sys_clock_driver_init(void)
 
 void sys_clock_set_timeout(int32_t ticks, bool idle)
 {
-	if (IS_ENABLED(CONFIG_TICKLESS_KERNEL) && idle && ticks == K_TICKS_FOREVER) {
-		*tick_timer_cfg.cmstr = 0x0000; /* stop cmt0,1 */
+	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		return;
 	}
 
-#if defined(CONFIG_TICKLESS_KERNEL)
-	/*
-	 * By default, it is implemented as a no operation.
-	 * Implement the processing as needed.
-	 */
-#endif /* CONFIG_TICKLESS_KERNEL */
+	if (ticks == K_TICKS_FOREVER || ticks == INT32_MAX) {
+		return;
+	}
+
+	ticks = CLAMP(ticks - 1, 0, (int32_t)MAX_TICKS);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	cycle_t now = cmt1_elapsed();
+	cycle_t elapsed;
+
+	if (now < announced_cycle_count) {
+		/* cycle_count overflowed */
+		elapsed = (cycle_t)(now + (CYCLE_COUNT_MAX - announced_cycle_count + 1));
+	} else {
+		elapsed = (now - announced_cycle_count);
+	}
+
+	cycle_t delay = (cycle_t)ticks * CYCLES_PER_TICK;
+
+	delay += elapsed;
+	delay = DIV_ROUND_UP(delay, CYCLES_PER_TICK) * CYCLES_PER_TICK;
+	delay -= elapsed;
+
+	uint16_t current = *tick_timer_cfg.cmcnt;
+	uint16_t new_cmcor = (uint16_t)(current + delay - 1U);
+
+	*tick_timer_cfg.cmcor = new_cmcor;
+
+	k_spin_unlock(&lock, key);
 }
 
 SYS_INIT(sys_clock_driver_init, PRE_KERNEL_2, CONFIG_SYSTEM_CLOCK_INIT_PRIORITY);

--- a/dts/bindings/cpu/renesas,rxv1.yaml
+++ b/dts/bindings/cpu/renesas,rxv1.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RXv1 CPU
+
+compatible: "renesas,rxv1"
+
+include: renesas,rx.yaml

--- a/dts/bindings/cpu/renesas,rxv2.yaml
+++ b/dts/bindings/cpu/renesas,rxv2.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RXv2 CPU
+
+compatible: "renesas,rxv2"
+
+include: renesas,rx.yaml

--- a/dts/bindings/cpu/renesas,rxv3.yaml
+++ b/dts/bindings/cpu/renesas,rxv3.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RXv3 CPU
+
+compatible: "renesas,rxv3"
+
+include: renesas,rx.yaml

--- a/dts/bindings/rx/renesas,rx-swint.yaml
+++ b/dts/bindings/rx/renesas,rx-swint.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RX SWINT (Software Interrupt)
+
+compatible: "renesas,rx-swint"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true

--- a/dts/rx/renesas/rx-qemu.dtsi
+++ b/dts/rx/renesas/rx-qemu.dtsi
@@ -31,6 +31,8 @@
 
 	icu: interrupt-controller@87000 {
 		#interrupt-cells = <2>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "renesas,rx-icu";
 		interrupt-controller;
 		reg = <0x0087000 0xff>,
@@ -40,7 +42,15 @@
 		      <0x0087500 0x0f>,
 		      <0x0087510 0x01>,
 		      <0x0087514 0x01>;
-		reg-names = "IR", "IER", "IPR", "FIR","IRQCR","IRQFLTE","IRQFLTC0";
+		reg-names = "IR", "IER", "IPR", "FIR", "IRQCR", "IRQFLTE", "IRQFLTC0";
+
+		swint1: swint1@872e0 {
+			compatible = "renesas,rx-swint";
+			reg = <0x000872e0 0x01>;
+			interrupts = <27 14>;
+			interrupt-parent = <&icu>;
+			status = "okay";
+		};
 	};
 
 	clocks: clocks {

--- a/dts/rx/renesas/rx-qemu.dtsi
+++ b/dts/rx/renesas/rx-qemu.dtsi
@@ -22,7 +22,7 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			compatible = "renesas,rx";
+			compatible = "renesas,rxv1";
 			device_type = "cpu";
 			reg = <0>;
 			status = "okay";

--- a/dts/rx/renesas/rx130-common.dtsi
+++ b/dts/rx/renesas/rx130-common.dtsi
@@ -22,7 +22,7 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			compatible = "renesas,rx";
+			compatible = "renesas,rxv1";
 			device_type = "cpu";
 			reg = <0>;
 			status = "okay";

--- a/dts/rx/renesas/rx130-common.dtsi
+++ b/dts/rx/renesas/rx130-common.dtsi
@@ -31,6 +31,8 @@
 
 	icu: interrupt-controller@87000 {
 		#interrupt-cells = <2>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "renesas,rx-icu";
 		interrupt-controller;
 		reg = <0x0087000 0xff>,
@@ -40,7 +42,15 @@
 		      <0x0087500 0x0f>,
 		      <0x0087510 0x01>,
 		      <0x0087514 0x01>;
-		reg-names = "IR", "IER", "IPR", "FIR","IRQCR","IRQFLTE","IRQFLTC0";
+		reg-names = "IR", "IER", "IPR", "FIR", "IRQCR","IRQFLTE","IRQFLTC0";
+
+		swint1: swint1@872e0 {
+			compatible = "renesas,rx-swint";
+			reg = <0x000872e0 0x01>;
+			interrupts = <27 14>;
+			interrupt-parent = <&icu>;
+			status = "okay";
+		};
 	};
 
 	soc {

--- a/dts/rx/renesas/rx261-common.dtsi
+++ b/dts/rx/renesas/rx261-common.dtsi
@@ -20,7 +20,7 @@
 		#size-cells = <0>;
 
 		cpu0: cpu@0 {
-			compatible = "renesas,rx";
+			compatible = "renesas,rxv3";
 			device_type = "cpu";
 			reg = <0>;
 			status = "okay";

--- a/dts/rx/renesas/rx261-common.dtsi
+++ b/dts/rx/renesas/rx261-common.dtsi
@@ -29,6 +29,8 @@
 
 	icu: interrupt-controller@87000 {
 		#interrupt-cells = <2>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		compatible = "renesas,rx-icu";
 		interrupt-controller;
 		reg = <0x0087000 0xff>,
@@ -38,8 +40,16 @@
 		      <0x0087500 0x0f>,
 		      <0x0087510 0x01>,
 		      <0x0087514 0x01>;
-		reg-names = "IR", "IER", "IPR", "FIR","IRQCR","IRQFLTE","IRQFLTC0";
-	}; /* icu */
+		reg-names = "IR", "IER", "IPR", "FIR", "IRQCR", "IRQFLTE", "IRQFLTC0";
+
+		swint1: swint1@872e0 {
+			compatible = "renesas,rx-swint";
+			reg = <0x000872e0 0x01>;
+			interrupts = <27 14>;
+			interrupt-parent = <&icu>;
+			status = "okay";
+		};
+	};
 
 	soc {
 		#address-cells = <1>;

--- a/include/zephyr/arch/rx/linker.ld
+++ b/include/zephyr/arch/rx/linker.ld
@@ -61,10 +61,22 @@ SECTIONS
 	. = ROM_START;   /* for kernel logging */
 	PLACE_SYMBOL_HERE(__rodata_region_start);
 
-	 .fvectors 0xFFFFFF80: AT(0xFFFFFF80)
+#if CONFIG_HAS_EXCEPT_VECTOR_TABLE
+	.exvectors 0xFFFFFF80: AT(0xFFFFFF80)
+	{
+		KEEP(*(.exvectors))
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
+	 .fvectors 0xFFFFFFFC: AT(0xFFFFFFFC)
 	{
 		KEEP(*(.fvectors))
 	} GROUP_LINK_IN(ROMABLE_REGION)
+#else
+	.fvectors 0xFFFFFF80: AT(0xFFFFFF80)
+	{
+		KEEP(*(.fvectors))
+	} GROUP_LINK_IN(ROMABLE_REGION)
+#endif
 
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,ROM_START,)
 	{

--- a/include/zephyr/arch/rx/linker.ld
+++ b/include/zephyr/arch/rx/linker.ld
@@ -26,10 +26,24 @@
 #endif
 #define RAMABLE_REGION	RAM
 
-/* single bank configuration with 2 MB of code flash */
-#define ROM_START (DT_REG_ADDR(DT_NODELABEL(code_flash)))
+#if defined(CONFIG_ROM_END_OFFSET)
+#define ROM_END_OFFSET CONFIG_ROM_END_OFFSET
+#else
+#define ROM_END_OFFSET 0
+#endif
 
-#define ROM_SIZE  (DT_REG_SIZE(DT_NODELABEL(code_flash)))
+#if defined(CONFIG_FLASH_LOAD_OFFSET)
+#define FLASH_LOAD_OFFSET CONFIG_FLASH_LOAD_OFFSET
+#else
+#define FLASH_LOAD_OFFSET 0
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_flash), okay)
+#define ROM_START (CONFIG_FLASH_BASE_ADDRESS + FLASH_LOAD_OFFSET)
+#ifndef ROM_SIZE
+#define ROM_SIZE (DT_REG_SIZE(DT_CHOSEN(zephyr_flash)) - ROM_END_OFFSET)
+#endif
+#endif
 
 #define RAM_START (CONFIG_SRAM_BASE_ADDRESS)
 #define RAM_SIZE  (KB(CONFIG_SRAM_SIZE))


### PR DESCRIPTION
This PR aims to:
- Add the bindings rxv1, rxv2, rxv3 corresponding to the Renesas RX CPU cores, and correct the bindings for qemu_rx, rx130, rx261 (since #90708 merged)
- Update exception table halding for RX (applicable to rxv2, rxv3)
- Modify some previously fixed configs to be configurable via DTS using DT commands (SWINT, CMT, linker).