### PR TITLE
tests: spi: spi ctrl peri: nrf54h20dk cpurad uart135 device runtime

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -12,3 +12,7 @@
 &dut_spis {
 	memory-regions = <&cpurad_dma_region>;
 };
+
+&uart135 {
+	zephyr,pm-device-runtime-auto;
+};


### PR DESCRIPTION
Add zephyr,pm-device-runtime-auto; to uart135 which is the uart used for logging to enable PM_DEVICE_RUNTIME for it, which is required for its power domains.