### PR TITLE
video: fix dcmipp devicetree

### DIFF
--- a/boards/shields/st_b_cams_imx_mb1854/st_b_cams_imx_mb1854.overlay
+++ b/boards/shields/st_b_cams_imx_mb1854/st_b_cams_imx_mb1854.overlay
@@ -10,7 +10,7 @@
 
 / {
 	chosen {
-		zephyr,camera = &csi_capture_port;
+		zephyr,camera = &pipe_main;
 	};
 
 	imx335_input_clock: imx335-input-clock {

--- a/boards/shields/st_mb1897_cam/st_mb1897_cam.overlay
+++ b/boards/shields/st_mb1897_cam/st_mb1897_cam.overlay
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,camera = &csi_capture_port;
+		zephyr,camera = &pipe_dump;
 	};
 };
 

--- a/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
+++ b/boards/st/stm32mp135f_dk/stm32mp135f_dk.dts
@@ -188,20 +188,14 @@ csi_interface: &dcmipp {
 		     &dcmipp_pixclk_pb7 &dcmipp_vsync_pg9 &dcmipp_hsync_ph8>;
 	pinctrl-names = "default";
 
-	ports {
-		port@0 {
-			dcmipp_ep_in: endpoint {
-				bus-width = <8>;
-				hsync-active = <0>;
-				vsync-active = <0>;
-				pclk-sample = <0>;
-				bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
-				remote-endpoint-label = "mipid02_2";
-			};
-		};
-
-		port@1 {
-			csi_capture_port: endpoint { };
+	port {
+		dcmipp_ep_in: endpoint {
+			bus-width = <8>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			pclk-sample = <0>;
+			bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
+			remote-endpoint-label = "mipid02_2";
 		};
 	};
 };

--- a/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
+++ b/boards/st/stm32n6570_dk/stm32n6570_dk_common.dtsi
@@ -459,13 +459,7 @@ zephyr_udc0: &usbotg_hs1 {
 };
 
 csi_interface: &dcmipp {
-	ports {
-		port@0 {
-			csi_ep_in: endpoint { };
-		};
-
-		port@1 {
-			csi_capture_port: endpoint@1 { };
-		};
+	port {
+		csi_ep_in: endpoint { };
 	};
 };

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1661,7 +1661,7 @@ static void stm32_dcmipp_isr(const struct device *dev)
 						    vsync_active, 0) ?				\
 						    DCMIPP_VSPOLARITY_HIGH :			\
 						    DCMIPP_VSPOLARITY_LOW,			\
-		.parallel.hs_polarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(n, 0, 0),		\
+		.parallel.hs_polarity = DT_PROP_OR(DT_INST_ENDPOINT_BY_ID(inst, 0, 0),	        \
 						   hsync_active, 0) ?				\
 						    DCMIPP_HSPOLARITY_HIGH :			\
 						    DCMIPP_HSPOLARITY_LOW,			\

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1588,6 +1588,8 @@ static void stm32_dcmipp_isr(const struct device *dev)
 	HAL_DCMIPP_IRQHandler(&dcmipp->hdcmipp);
 }
 
+#define SOURCE_DEV(inst) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(inst, 0, 0)))
+
 #define DCMIPP_PIPE_INIT_DEFINE(node_id, inst)						\
 	static struct stm32_dcmipp_pipe_data stm32_dcmipp_pipe_##node_id = {		\
 		.id = DT_NODE_CHILD_IDX(node_id),					\
@@ -1598,9 +1600,9 @@ static void stm32_dcmipp_isr(const struct device *dev)
 			 &stm32_dcmipp_pipe_##node_id,					\
 			 &stm32_dcmipp_config_##inst,					\
 			 POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,			\
-			 &stm32_dcmipp_driver_api);
-
-#define SOURCE_DEV(inst) DEVICE_DT_GET(DT_NODE_REMOTE_DEVICE(DT_INST_ENDPOINT_BY_ID(inst, 0, 0)))
+			 &stm32_dcmipp_driver_api);					\
+											\
+	VIDEO_DEVICE_DEFINE(dcmipp_##inst_pipe_##node_id, DEVICE_DT_GET(node_id), SOURCE_DEV(inst));
 
 #if defined(STM32_DCMIPP_HAS_CSI)
 #define STM32_DCMIPP_CSI_DT_PARAMS(inst)							\
@@ -1685,8 +1687,6 @@ static void stm32_dcmipp_isr(const struct device *dev)
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,					\
 		    NULL);									\
 												\
-	STM32_DCMIPP_PIPES(inst)								\
-												\
-	VIDEO_DEVICE_DEFINE(dcmipp_##inst, DEVICE_DT_INST_GET(inst), SOURCE_DEV(inst));
+	STM32_DCMIPP_PIPES(inst)
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_DCMIPP_INIT)

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1620,6 +1620,14 @@ static void stm32_dcmipp_isr(const struct device *dev)
 #define STM32_DCMIPP_CSI_DT_PARAMS(inst)
 #endif
 
+#if defined(STM32_DCMIPP_HAS_PIXEL_PIPES)
+#define STM32_DCMIPP_PIPES(inst) \
+	DT_FOREACH_CHILD_VARGS(DT_INST_CHILD(inst, pipes), DCMIPP_PIPE_INIT_DEFINE, inst)
+#else
+#define STM32_DCMIPP_PIPE_INIT(node_id, inst) DCMIPP_PIPE_INIT_DEFINE(node_id, inst)
+#define STM32_DCMIPP_PIPES(inst) STM32_DCMIPP_PIPE_INIT(DT_INST_CHILD(inst, pipe), inst)
+#endif
+
 #define STM32_DCMIPP_INIT(inst)									\
 	static void stm32_dcmipp_irq_config_##inst(const struct device *dev)			\
 	{											\
@@ -1677,7 +1685,7 @@ static void stm32_dcmipp_isr(const struct device *dev)
 		    POST_KERNEL, CONFIG_VIDEO_INIT_PRIORITY,					\
 		    NULL);									\
 												\
-	DT_FOREACH_CHILD_VARGS(DT_INST_PORT_BY_ID(inst, 1), DCMIPP_PIPE_INIT_DEFINE, inst);	\
+	STM32_DCMIPP_PIPES(inst)								\
 												\
 	VIDEO_DEVICE_DEFINE(dcmipp_##inst, DEVICE_DT_INST_GET(inst), SOURCE_DEV(inst));
 

--- a/dts/arm/st/mp13/stm32mp135.dtsi
+++ b/dts/arm/st/mp13/stm32mp135.dtsi
@@ -21,25 +21,13 @@
 			resets = <&rctl STM32_RESET(APB4, 1)>;
 			status = "disabled";
 
-			ports {
-				#address-cells = <1>;
-				#size-cells = <0>;
+			pipe_dump: pipe {
+			};
 
-				port@0 {
-					reg = <0>;
-
-					endpoint {
-						remote-endpoint-label = "";
-						bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
-					};
-				};
-
-				port@1 {
-					reg = <1>;
-
-					dcmipp_pipe_dump: endpoint {
-						compatible = "st,stm32-dcmipp-pipe";
-					};
+			port {
+				endpoint {
+					remote-endpoint-label = "";
+					bus-type = <VIDEO_BUS_TYPE_PARALLEL>;
 				};
 			};
 		};

--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -717,39 +717,28 @@
 				 <&rctl STM32_RESET(APB5, 6)>;
 			status = "disabled";
 
-			ports {
+			pipes {
+				compatible = "st,stm32-dcmipp-pipes";
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				port@0 {
+				pipe_dump: pipe@0 {
 					reg = <0>;
-
-					endpoint {
-						remote-endpoint-label = "";
-						bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
-					};
 				};
 
-				port@1 {
-					#address-cells = <1>;
-					#size-cells = <0>;
-
+				pipe_main: pipe@1 {
 					reg = <1>;
+				};
 
-					dcmipp_pipe_dump: endpoint@0 {
-						compatible = "st,stm32-dcmipp-pipe";
-						reg = <0>;
-					};
+				pipe_aux: pipe@2 {
+					reg = <2>;
+				};
+			};
 
-					dcmipp_pipe_main: endpoint@1 {
-						compatible = "st,stm32-dcmipp-pipe";
-						reg = <1>;
-					};
-
-					dcmipp_pipe_aux: endpoint@2 {
-						compatible = "st,stm32-dcmipp-pipe";
-						reg = <2>;
-					};
+			port {
+				endpoint {
+					remote-endpoint-label = "";
+					bus-type = <VIDEO_BUS_TYPE_CSI2_DPHY>;
 				};
 			};
 		};

--- a/dts/bindings/video/st,stm32-dcmipp.yaml
+++ b/dts/bindings/video/st,stm32-dcmipp.yaml
@@ -48,9 +48,8 @@ properties:
 
 child-binding:
   child-binding:
-    child-binding:
-      include: video-interfaces.yaml
+    include: video-interfaces.yaml
 
-      properties:
-        bus-type:
-          required: true
+    properties:
+      bus-type:
+        required: true


### PR DESCRIPTION
- Use normal child nodes for pipes: the pipe nodes are not video interfaces. Describe them as normal child nodes instead of using port/endpoint.
- Define video device for each pipe instead of only the main dcmipp device so that we can do set/get_ctrl()
- Another minor typo fix