### PR TITLE
samples: usb: mass: add flashdisk overlay file

### DIFF
--- a/samples/subsys/usb/mass/README.rst
+++ b/samples/subsys/usb/mass/README.rst
@@ -43,9 +43,7 @@ for testing USB mass storage class implementation.
 FAT FS Example
 ==============
 
-If more than 96KiB are available, FAT files system can be used
-with a RAM-disk. Alternatively it is possible with the FLASH-based disk.
-In this example we will build the sample with a RAM-based disk:
+If more than 96KiB RAM are available, FAT files system can be used with a RAM-disk.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/usb/mass
@@ -54,10 +52,22 @@ In this example we will build the sample with a RAM-based disk:
    :goals: build
    :compact:
 
+Alternatively, FAT file system can be used on the SoC internal flash when the
+storage partition is large enough.
 
-In this example we will build the sample with a FLASH-based disk and FAT
-file system for Adafruit Feather nRF52840 Express.  This board configures
-to use the external 16 MiBi QSPI flash chip with a 2 MiBy FAT partition.
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/usb/mass
+   :board: frdm_k64f
+   :gen-args: -DEXTRA_DTC_OVERLAY_FILE="flashdisk.overlay" -DCONFIG_APP_MSC_STORAGE_FLASH_FATFS=y -DCONFIG_DISK_DRIVER_SDMMC=n
+   :goals: build
+   :compact:
+
+The internal flash storage partition on the SoC may be too small for the FAT
+file system. If the board has an external flash device, however, it can be used
+for the FAT file system. The sample includes a few board overlay files for
+configuring an external flash device. For example, there is an overlay file for
+Adafruit Feather nRF52840 Express that allows you to use an external 16 MiBy
+QSPI flash chip with a 2 MiBy FAT partition.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/usb/mass
@@ -156,9 +166,20 @@ the transfer speed over SPI is very slow.
 LittleFS Example
 ================
 
-This board configures to use the external 64 MiBi QSPI flash chip with a
-128 KiBy `littlefs`_ partition compatible with the one produced by the
-:zephyr:code-sample:`littlefs` sample.
+The sample can be built for any board that has a storage partition defined.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/usb/mass
+   :board: reel_board
+   :gen-args: -DEXTRA_DTC_OVERLAY_FILE="flashdisk.overlay" -DCONFIG_APP_MSC_STORAGE_FLASH_LITTLEFS=y
+   :goals: build
+   :compact:
+
+If more storage space is needed, the board can be configured to use an external
+flash device. This can be done using the same approach as in the FAT file
+system example. In this example, the nRF52840DK board is configured to use an
+external 64 MiB QSPI flash chip with a 128 KiBy `littlefs`_ partition
+compatible with the one produced by the :zephyr:code-sample:`littlefs` sample.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/usb/mass

--- a/samples/subsys/usb/mass/boards/adafruit_feather_nrf52840_sense.overlay
+++ b/samples/subsys/usb/mass/boards/adafruit_feather_nrf52840_sense.overlay
@@ -19,11 +19,4 @@
 	};
 };
 
-/ {
-	msc_disk0 {
-		compatible = "zephyr,flash-disk";
-		partition = <&storage_partition>;
-		disk-name = "NAND";
-		cache-size = <4096>;
-	};
-};
+#include "../flashdisk.overlay"

--- a/samples/subsys/usb/mass/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/usb/mass/boards/nrf52840dk_nrf52840.overlay
@@ -19,11 +19,4 @@
 	};
 };
 
-/ {
-	msc_disk0 {
-		compatible = "zephyr,flash-disk";
-		partition = <&storage_partition>;
-		disk-name = "NAND";
-		cache-size = <4096>;
-	};
-};
+#include "../flashdisk.overlay"

--- a/samples/subsys/usb/mass/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/usb/mass/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -19,11 +19,4 @@
 	};
 };
 
-/ {
-	msc_disk0 {
-		compatible = "zephyr,flash-disk";
-		partition = <&storage_partition>;
-		disk-name = "NAND";
-		cache-size = <4096>;
-	};
-};
+#include "../flashdisk.overlay"

--- a/samples/subsys/usb/mass/boards/rpi_pico.overlay
+++ b/samples/subsys/usb/mass/boards/rpi_pico.overlay
@@ -29,11 +29,4 @@
 	};
 };
 
-/ {
-	msc_disk0 {
-		compatible = "zephyr,flash-disk";
-		partition = <&storage_partition>;
-		disk-name = "NAND";
-		cache-size = <4096>;
-	};
-};
+#include "../flashdisk.overlay"

--- a/samples/subsys/usb/mass/flashdisk.overlay
+++ b/samples/subsys/usb/mass/flashdisk.overlay
@@ -1,0 +1,14 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	msc_disk0 {
+		compatible = "zephyr,flash-disk";
+		partition = <&storage_partition>;
+		disk-name = "NAND";
+		cache-size = <4096>;
+	};
+};


### PR DESCRIPTION
There are a few board overlay files with identical lines describing the flash disk. Move these lines to a separate overlay file that could be used for any board with a large enough storage partition. Update the documentation accordingly.