### PR TITLE
tests: drivers: flash: Increase storage partition size

### DIFF
--- a/tests/drivers/flash/common/boards/max32690evkit_max32690_m4.overlay
+++ b/tests/drivers/flash/common/boards/max32690evkit_max32690_m4.overlay
@@ -17,7 +17,7 @@
 
 		storage_partition: partition@200000 {
 			label = "storage";
-			reg = <0x200000 DT_SIZE_K(1)>;
+			reg = <0x200000 DT_SIZE_M(1)>;
 		};
 	};
 };

--- a/tests/drivers/flash/common/boards/max32690fthr_max32690_m4.overlay
+++ b/tests/drivers/flash/common/boards/max32690fthr_max32690_m4.overlay
@@ -17,7 +17,7 @@
 
 		storage_partition: partition@200000 {
 			label = "storage";
-			reg = <0x200000 DT_SIZE_K(1)>;
+			reg = <0x200000 DT_SIZE_M(1)>;
 		};
 	};
 };


### PR DESCRIPTION
Flash test requires at least (2 * page_info.size) size for test area. So, this commit increases storage_partition size for max32690evkit/max32690/m4 and max32690fthr/max32690/m4 boards.