### PR TITLE
snippets: espressif: Fix flash partitions overlay

### DIFF
--- a/snippets/espressif/flash-16M/soc/esp32_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32_flash_16M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32/esp32_common.dtsi>
-#include <espressif/partitions_0x1000_amp_16M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
 };
+
+#include <espressif/partitions_0x1000_amp_16M.dtsi>

--- a/snippets/espressif/flash-16M/soc/esp32c3_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32c3_flash_16M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c3/esp32c3_common.dtsi>
-#include <espressif/partitions_0x0_default_16M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
 };
+
+#include <espressif/partitions_0x0_default_16M.dtsi>

--- a/snippets/espressif/flash-16M/soc/esp32c6_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32c6_flash_16M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c6/esp32c6_common.dtsi>
-#include <espressif/partitions_0x0_default_16M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
 };
+
+#include <espressif/partitions_0x0_default_16M.dtsi>

--- a/snippets/espressif/flash-16M/soc/esp32s2_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32s2_flash_16M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s2/esp32s2_common.dtsi>
-#include <espressif/partitions_0x0_amp_16M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
 };
+
+#include <espressif/partitions_0x0_amp_16M.dtsi>

--- a/snippets/espressif/flash-16M/soc/esp32s3_flash_16M.overlay
+++ b/snippets/espressif/flash-16M/soc/esp32s3_flash_16M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s3/esp32s3_common.dtsi>
-#include <espressif/partitions_0x0_amp_16M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(16)>;
 };
+
+#include <espressif/partitions_0x0_amp_16M.dtsi>

--- a/snippets/espressif/flash-32M/soc/esp32_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32_flash_32M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32/esp32_common.dtsi>
-#include <espressif/partitions_0x1000_amp_32M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
 };
+
+#include <espressif/partitions_0x1000_amp_32M.dtsi>

--- a/snippets/espressif/flash-32M/soc/esp32c3_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32c3_flash_32M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c3/esp32c3_common.dtsi>
-#include <espressif/partitions_0x0_default_32M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
 };
+
+#include <espressif/partitions_0x0_default_32M.dtsi>

--- a/snippets/espressif/flash-32M/soc/esp32c6_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32c6_flash_32M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c6/esp32c6_common.dtsi>
-#include <espressif/partitions_0x0_default_32M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
 };
+
+#include <espressif/partitions_0x0_default_32M.dtsi>

--- a/snippets/espressif/flash-32M/soc/esp32s2_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32s2_flash_32M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s2/esp32s2_common.dtsi>
-#include <espressif/partitions_0x0_amp_32M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
 };
+
+#include <espressif/partitions_0x0_amp_32M.dtsi>

--- a/snippets/espressif/flash-32M/soc/esp32s3_flash_32M.overlay
+++ b/snippets/espressif/flash-32M/soc/esp32s3_flash_32M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s3/esp32s3_common.dtsi>
-#include <espressif/partitions_0x0_amp_32M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(32)>;
 };
+
+#include <espressif/partitions_0x0_amp_32M.dtsi>

--- a/snippets/espressif/flash-4M/soc/esp32_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32_flash_4M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32/esp32_common.dtsi>
-#include <espressif/partitions_0x1000_amp_4M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
 };
+
+#include <espressif/partitions_0x1000_amp_4M.dtsi>

--- a/snippets/espressif/flash-4M/soc/esp32c3_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32c3_flash_4M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c3/esp32c3_common.dtsi>
-#include <espressif/partitions_0x0_default_4M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
 };
+
+#include <espressif/partitions_0x0_default_4M.dtsi>

--- a/snippets/espressif/flash-4M/soc/esp32c6_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32c6_flash_4M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c6/esp32c6_common.dtsi>
-#include <espressif/partitions_0x0_default_4M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
 };
+
+#include <espressif/partitions_0x0_default_4M.dtsi>

--- a/snippets/espressif/flash-4M/soc/esp32s2_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32s2_flash_4M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s2/esp32s2_common.dtsi>
-#include <espressif/partitions_0x0_amp_4M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
 };
+
+#include <espressif/partitions_0x0_amp_4M.dtsi>

--- a/snippets/espressif/flash-4M/soc/esp32s3_flash_4M.overlay
+++ b/snippets/espressif/flash-4M/soc/esp32s3_flash_4M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s3/esp32s3_common.dtsi>
-#include <espressif/partitions_0x0_amp_4M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(4)>;
 };
+
+#include <espressif/partitions_0x0_amp_4M.dtsi>

--- a/snippets/espressif/flash-8M/soc/esp32_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32_flash_8M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32/esp32_common.dtsi>
-#include <espressif/partitions_0x1000_amp_8M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
 };
+
+#include <espressif/partitions_0x1000_amp_8M.dtsi>

--- a/snippets/espressif/flash-8M/soc/esp32c3_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32c3_flash_8M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c3/esp32c3_common.dtsi>
-#include <espressif/partitions_0x0_default_8M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
 };
+
+#include <espressif/partitions_0x0_default_8M.dtsi>

--- a/snippets/espressif/flash-8M/soc/esp32c6_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32c6_flash_8M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32c6/esp32c6_common.dtsi>
-#include <espressif/partitions_0x0_default_8M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
 };
+
+#include <espressif/partitions_0x0_default_8M.dtsi>

--- a/snippets/espressif/flash-8M/soc/esp32s2_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32s2_flash_8M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s2/esp32s2_common.dtsi>
-#include <espressif/partitions_0x0_amp_8M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
 };
+
+#include <espressif/partitions_0x0_amp_8M.dtsi>

--- a/snippets/espressif/flash-8M/soc/esp32s3_flash_8M.overlay
+++ b/snippets/espressif/flash-8M/soc/esp32s3_flash_8M.overlay
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &flash0;
-
-#include <espressif/esp32s3/esp32s3_common.dtsi>
-#include <espressif/partitions_0x0_amp_8M.dtsi>
+&flash0 {
+	/delete-node/ partitions;
+};
 
 &flash0 {
 	reg = <0x0 DT_SIZE_M(8)>;
 };
+
+#include <espressif/partitions_0x0_amp_8M.dtsi>


### PR DESCRIPTION
Snippets overlays are applied last and can revert DTS changes by restoring definitions from the base DTSI. Remove only the `partitions` node when customizing flash size and layout.