### PR TITLE
boards: mimxrt1060_evk: Add debug jumpers doc

### DIFF
--- a/boards/nxp/mimxrt1060_evk/doc/index.rst
+++ b/boards/nxp/mimxrt1060_evk/doc/index.rst
@@ -324,10 +324,25 @@ details).
 Configuring a Debug Probe
 =========================
 
-Two revisions of the RT1060 EVK exist. For the RT1060 EVK, J47/J48 are the SWD
-isolation jumpers, J42 is the DFU mode jumper, and the 20 pin JTAG/SWD header
-is present on J21. For the RT1060 EVKB, J9/J10 are the SWD isolation jumpers,
-J12 is the DFU mode jumper, and the 20 pin JTAG/SWD header is present on J2.
+Three revisions of the RT1060 EVK exist. For all of them, to replace the debug firmware, short the
+DFU jumper to boot the on board debugger to ISP mode.
+
+* RT1060 EVK (Revision A)
+
+  * SWD isolation jumpers: J47/48
+  * 20 pin JTAG/SWD header: J21
+  * DFU mode jumper: J42
+
+* RT1060 EVKB
+
+  * SWD isolation jumpers: J9/10
+  * 20 pin JTAG/SWD header: J2
+  * DFU mode jumper: J12
+
+* RT1060 EVKC
+
+  * Debugger choice jumper: JP5
+  * DFU mode jumper: JP3
 
 .. include:: ../../common/rt1xxx-lpclink2-debug.rst
    :start-after: rt1xxx-lpclink2-probes


### PR DESCRIPTION
The RT1060 board page was outdated forgetting EVKC in the debug configuration section.