### PR TITLE
tests: drivers: can: Wait for prompt before sending command

### DIFF
--- a/tests/drivers/can/host/pytest/conftest.py
+++ b/tests/drivers/can/host/pytest/conftest.py
@@ -39,6 +39,7 @@ def fixture_context(request, dut: DeviceAdapter) -> str:
 def fixture_chosen(shell: Shell) -> str:
     """Return the name of the zephyr,canbus devicetree chosen device."""
     chosen_regex = re.compile(r'zephyr,canbus:\s+(\S+)')
+    shell.wait_for_prompt()
     lines = shell.get_filtered_output(shell.exec_command('can_host chosen'))
 
     for line in lines:


### PR DESCRIPTION
Wait for prompt before sending command to ensure shell is ready.