### PR TITLE
display: add support for AL_88 color format

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -85,6 +85,10 @@ New APIs and options
 
     * :c:struct:`bt_audio_codec_cfg` now contains a target_latency and a target_phy option
 
+* Display
+
+  * Added new pixel format :c:enum:`PIXEL_FORMAT_AL_88`
+
 * Logging:
 
   * Added rate-limited logging macros to prevent log flooding when messages are generated frequently.

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -89,6 +89,10 @@ New APIs and options
 
   * Added new pixel format :c:enum:`PIXEL_FORMAT_AL_88`
 
+  * SDL
+
+    * :kconfig:option:`CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88`
+
 * Logging:
 
   * Added rate-limited logging macros to prevent log flooding when messages are generated frequently.

--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -40,6 +40,9 @@ choice SDL_DISPLAY_DEFAULT_PIXEL_FORMAT
 	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_L_8
 		bool "Grayscale 8bit"
 
+	config SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88
+		bool "Grayscale 8bit with Alpha"
+
 endchoice
 
 config SDL_DISPLAY_ZOOM_PCT

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -598,7 +598,6 @@ static int sdl_display_clear(const struct device *dev)
 	switch (disp_data->current_pixel_format) {
 	case PIXEL_FORMAT_ARGB_8888:
 		size = config->width * config->height * 4U;
-		bgcolor = 0xFFu;
 		break;
 	case PIXEL_FORMAT_RGB_888:
 		size = config->width * config->height * 3U;

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -160,6 +160,8 @@ static int sdl_display_init(const struct device *dev)
 		PIXEL_FORMAT_BGR_565
 #elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_L_8)
 		PIXEL_FORMAT_L_8
+#elif defined(CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88)
+		PIXEL_FORMAT_AL_88
 #else  /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
 		PIXEL_FORMAT_ARGB_8888
 #endif /* SDL_DISPLAY_DEFAULT_PIXEL_FORMAT */
@@ -205,6 +207,31 @@ static void sdl_display_write_rgb888(uint8_t *disp_buf,
 			pixel |= *(byte_ptr + 1) << 8;
 			pixel |= *(byte_ptr + 2);
 			*((uint32_t *)disp_buf) = pixel | 0xFF000000;
+			disp_buf += 4;
+		}
+	}
+}
+
+static void sdl_display_write_al88(uint8_t *disp_buf,
+		const struct display_buffer_descriptor *desc, const void *buf)
+{
+	uint32_t w_idx;
+	uint32_t h_idx;
+	uint32_t pixel;
+	const uint8_t *byte_ptr;
+
+	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size,
+			"Input buffer too small");
+
+	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			byte_ptr = (const uint8_t *)buf +
+				((h_idx * desc->pitch) + w_idx) * 2U;
+			pixel = *(byte_ptr + 1) << 24;
+			pixel |= *(byte_ptr) << 16;
+			pixel |= *(byte_ptr) << 8;
+			pixel |= *(byte_ptr);
+			*((uint32_t *)disp_buf) = pixel;
 			disp_buf += 4;
 		}
 	}
@@ -392,6 +419,8 @@ static int sdl_display_write(const struct device *dev, const uint16_t x,
 		sdl_display_write_bgr565(disp_data->buf, desc, buf);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_L_8) {
 		sdl_display_write_l8(disp_data->buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_AL_88) {
+		sdl_display_write_al88(disp_data->buf, desc, buf);
 	}
 
 	if (k_current_get() == &disp_data->sdl_thread) {
@@ -543,6 +572,29 @@ static void sdl_display_read_l8(const uint8_t *read_buf,
 	}
 }
 
+static void sdl_display_read_al88(const uint8_t *read_buf,
+				const struct display_buffer_descriptor *desc, void *buf)
+{
+	uint32_t w_idx;
+	uint32_t h_idx;
+	uint8_t *buf8;
+	const uint32_t *pix_ptr;
+
+	__ASSERT((desc->pitch * 2U * desc->height) <= desc->buf_size, "Read buffer is too small");
+
+	for (h_idx = 0U; h_idx < desc->height; ++h_idx) {
+		buf8 = ((uint8_t *)buf) + desc->pitch * 2U * h_idx;
+
+		for (w_idx = 0U; w_idx < desc->width; ++w_idx) {
+			pix_ptr = (const uint32_t *)read_buf + ((h_idx * desc->pitch) + w_idx);
+			*buf8 = (*pix_ptr & 0xFF);
+			buf8 += 1;
+			*buf8 = (*pix_ptr & 0xFF000000) >> 24;
+			buf8 += 1;
+		}
+	}
+}
+
 static int sdl_display_read(const struct device *dev, const uint16_t x, const uint16_t y,
 			    const struct display_buffer_descriptor *desc, void *buf)
 {
@@ -580,6 +632,8 @@ static int sdl_display_read(const struct device *dev, const uint16_t x, const ui
 		sdl_display_read_bgr565(disp_data->read_buf, desc, buf);
 	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_L_8) {
 		sdl_display_read_l8(disp_data->read_buf, desc, buf);
+	} else if (disp_data->current_pixel_format == PIXEL_FORMAT_AL_88) {
+		sdl_display_read_al88(disp_data->read_buf, desc, buf);
 	}
 	k_mutex_unlock(&disp_data->task_mutex);
 
@@ -613,6 +667,9 @@ static int sdl_display_clear(const struct device *dev)
 		break;
 	case PIXEL_FORMAT_RGB_565:
 	case PIXEL_FORMAT_BGR_565:
+		size = config->width * config->height * 2U;
+		break;
+	case PIXEL_FORMAT_AL_88:
 		size = config->width * config->height * 2U;
 		break;
 	default:
@@ -688,7 +745,8 @@ static void sdl_display_get_capabilities(
 		PIXEL_FORMAT_MONO10 |
 		PIXEL_FORMAT_RGB_565 |
 		PIXEL_FORMAT_BGR_565 |
-		PIXEL_FORMAT_L_8;
+		PIXEL_FORMAT_L_8 |
+		PIXEL_FORMAT_AL_88;
 	capabilities->current_pixel_format = disp_data->current_pixel_format;
 	capabilities->screen_info =
 		(IS_ENABLED(CONFIG_SDL_DISPLAY_MONO_VTILED) ? SCREEN_INFO_MONO_VTILED : 0) |
@@ -708,6 +766,7 @@ static int sdl_display_set_pixel_format(const struct device *dev,
 	case PIXEL_FORMAT_RGB_565:
 	case PIXEL_FORMAT_BGR_565:
 	case PIXEL_FORMAT_L_8:
+	case PIXEL_FORMAT_AL_88:
 		disp_data->current_pixel_format = pixel_format;
 		return 0;
 	default:

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -68,6 +68,7 @@ enum display_pixel_format {
 	PIXEL_FORMAT_BGR_565		= BIT(5),
 	PIXEL_FORMAT_L_8		= BIT(6), /**< 8-bit Grayscale/Luminance, equivalent to */
 						  /**< GRAY, GREY, GRAY8, Y8, R8, etc...        */
+	PIXEL_FORMAT_AL_88		= BIT(7), /**< 8-bit Grayscale/Luminance with alpha */
 };
 
 /**
@@ -84,7 +85,8 @@ enum display_pixel_format {
 	(((fmt & PIXEL_FORMAT_ARGB_8888) >> 3) * 32U) +				\
 	(((fmt & PIXEL_FORMAT_RGB_565) >> 4) * 16U) +				\
 	(((fmt & PIXEL_FORMAT_BGR_565) >> 5) * 16U) +				\
-	(((fmt & PIXEL_FORMAT_L_8) >> 6) * 8U))
+	(((fmt & PIXEL_FORMAT_L_8) >> 6) * 8U) +				\
+	(((fmt & PIXEL_FORMAT_AL_88) >> 7) * 16U))
 
 /**
  * @brief Display screen information

--- a/include/zephyr/dt-bindings/display/panel.h
+++ b/include/zephyr/dt-bindings/display/panel.h
@@ -30,6 +30,7 @@
 #define PANEL_PIXEL_FORMAT_RGB_565   (0x1 << 4)
 #define PANEL_PIXEL_FORMAT_BGR_565   (0x1 << 5)
 #define PANEL_PIXEL_FORMAT_L_8       (0x1 << 6)
+#define PANEL_PIXEL_FORMAT_AL_88     (0x1 << 7)
 
 /**
  * @}

--- a/modules/lvgl/lvgl_display.c
+++ b/modules/lvgl/lvgl_display.c
@@ -102,6 +102,12 @@ int set_lvgl_rendering_cb(lv_display_t *display)
 		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
 					display);
 		break;
+	case PIXEL_FORMAT_AL_88:
+		lv_display_set_color_format(display, LV_COLOR_FORMAT_AL88);
+		lv_display_set_flush_cb(display, lvgl_flush_cb_16bit);
+		lv_display_add_event_cb(display, lvgl_rounder_cb, LV_EVENT_INVALIDATE_AREA,
+					display);
+		break;
 	case PIXEL_FORMAT_MONO01:
 	case PIXEL_FORMAT_MONO10:
 		lv_display_set_color_format(display, LV_COLOR_FORMAT_I1);

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -165,6 +165,34 @@ static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *bu
 	}
 }
 
+static void fill_buffer_al_88(enum corner corner, uint8_t grey, uint8_t *buf,
+				 size_t buf_size)
+{
+	uint16_t color;
+
+	switch (corner) {
+	case TOP_LEFT:
+		color = 0xFF00u;
+		break;
+	case TOP_RIGHT:
+		color = 0xFFFFu;
+		break;
+	case BOTTOM_RIGHT:
+		color = 0xFF88u;
+		break;
+	case BOTTOM_LEFT:
+		color = 0xFF00u | grey;
+		break;
+	default:
+		color = 0;
+		break;
+	}
+
+	for (size_t idx = 0; idx < buf_size; idx += 2) {
+		*((uint16_t *)(buf + idx)) = color;
+	}
+}
+
 static inline void fill_buffer_mono01(enum corner corner, uint8_t grey,
 				      uint8_t *buf, size_t buf_size)
 {
@@ -272,6 +300,11 @@ int main(void)
 	case PIXEL_FORMAT_L_8:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_l_8;
+		break;
+	case PIXEL_FORMAT_AL_88:
+		bg_color = 0x00u;
+		fill_buffer_fnc = fill_buffer_al_88;
+		buf_size *= 2;
 		break;
 	case PIXEL_FORMAT_MONO01:
 		bg_color = 0xFFu;

--- a/samples/modules/lvgl/screen_transparency/src/main.c
+++ b/samples/modules/lvgl/screen_transparency/src/main.c
@@ -27,34 +27,30 @@ static void initialize_gui(void)
 	/* Create a label, set its text and align it to the center */
 	label = lv_label_create(lv_screen_active());
 	lv_label_set_text(label, "Hello, world!");
-	lv_obj_set_style_text_color(lv_screen_active(), lv_color_hex(0xff00ff), LV_PART_MAIN);
-	lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
+	lv_obj_set_style_text_color(label, lv_color_hex(0xff00ff), LV_PART_MAIN);
+	lv_obj_align(label, LV_ALIGN_CENTER, 0, -20);
+	label = lv_label_create(lv_screen_active());
+	lv_label_set_text(label, "RED");
+	lv_obj_set_style_text_color(label, lv_color_hex(0xff0000), LV_PART_MAIN);
+	lv_obj_align(label, LV_ALIGN_CENTER, -70, 20);
+	label = lv_label_create(lv_screen_active());
+	lv_label_set_text(label, "GREEN");
+	lv_obj_set_style_text_color(label, lv_color_hex(0x00ff00), LV_PART_MAIN);
+	lv_obj_align(label, LV_ALIGN_CENTER, 0, 20);
+	label = lv_label_create(lv_screen_active());
+	lv_label_set_text(label, "BLUE");
+	lv_obj_set_style_text_color(label, lv_color_hex(0x0000ff), LV_PART_MAIN);
+	lv_obj_align(label, LV_ALIGN_CENTER, 70, 20);
 }
 
 int main(void)
 {
-	int err;
 	const struct device *display_dev;
-	struct display_capabilities display_caps;
 
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
 		LOG_ERR("Device not ready, aborting test");
 		return -ENODEV;
-	}
-
-	display_get_capabilities(display_dev, &display_caps);
-	if (!(display_caps.supported_pixel_formats & PIXEL_FORMAT_ARGB_8888)) {
-		LOG_ERR("Display does not support ARGB8888 mode");
-		return -ENOTSUP;
-	}
-
-	if (PIXEL_FORMAT_ARGB_8888 != display_caps.current_pixel_format) {
-		err = display_set_pixel_format(display_dev, PIXEL_FORMAT_ARGB_8888);
-		if (err != 0) {
-			LOG_ERR("Failed to set ARGB8888 pixel format");
-			return err;
-		}
 	}
 
 	initialize_gui();

--- a/tests/drivers/display/display_check/src/main.c
+++ b/tests/drivers/display/display_check/src/main.c
@@ -160,6 +160,34 @@ static inline void fill_buffer_l_8(enum corner corner, uint8_t grey, uint8_t *bu
 	}
 }
 
+static void fill_buffer_al_88(enum corner corner, uint8_t grey, uint8_t *buf,
+				 size_t buf_size)
+{
+	uint16_t color;
+
+	switch (corner) {
+	case TOP_LEFT:
+		color = 0xFF00u;
+		break;
+	case TOP_RIGHT:
+		color = 0xFFFFu;
+		break;
+	case BOTTOM_RIGHT:
+		color = 0xFF88u;
+		break;
+	case BOTTOM_LEFT:
+		color = 0xFF00u | grey;
+		break;
+	default:
+		color = 0;
+		break;
+	}
+
+	for (size_t idx = 0; idx < buf_size; idx += 2) {
+		*((uint16_t *)(buf + idx)) = color;
+	}
+}
+
 static inline void fill_buffer_mono01(enum corner corner, uint8_t grey,
 				      uint8_t *buf, size_t buf_size)
 {
@@ -267,6 +295,11 @@ int test_display(void)
 	case PIXEL_FORMAT_L_8:
 		bg_color = 0xFFu;
 		fill_buffer_fnc = fill_buffer_l_8;
+		break;
+	case PIXEL_FORMAT_AL_88:
+		bg_color = 0x00u;
+		fill_buffer_fnc = fill_buffer_al_88;
+		buf_size *= 2;
 		break;
 	case PIXEL_FORMAT_MONO01:
 		bg_color = 0xFFu;

--- a/tests/drivers/display/display_read_write/src/main.c
+++ b/tests/drivers/display/display_read_write/src/main.c
@@ -34,6 +34,7 @@ static inline uint8_t bytes_per_pixel(enum display_pixel_format pixel_format)
 		return 3;
 	case PIXEL_FORMAT_RGB_565:
 	case PIXEL_FORMAT_BGR_565:
+	case PIXEL_FORMAT_AL_88:
 		return 2;
 	case PIXEL_FORMAT_L_8:
 	case PIXEL_FORMAT_MONO01:

--- a/tests/drivers/display/display_read_write/testcase.yaml
+++ b/tests/drivers/display/display_read_write/testcase.yaml
@@ -15,6 +15,12 @@ tests:
       - native_sim/native/64
     extra_configs:
       - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888=y
+  drivers.display.read_write.sdl.al88:
+    platform_allow:
+      - native_sim
+      - native_sim/native/64
+    extra_configs:
+      - CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88=y
   drivers.display.read_write.sdl.rgb888:
     platform_allow:
       - native_sim


### PR DESCRIPTION
Matches LVGL's `LV_COLOR_FORMAT_AL88`.

Closes #94389.


-----

`west twister -p native_sim/native/64 -s drivers.display.read_write.sdl.al88 --fixture display` succeeds.

Several `mono10` and `mono01` tests still fail, but this is already reported in #88714 and unrelated to this change.

------

```
west build -b native_sim/native/64 samples/modules/lvgl/screen_transparency/ -t run -p auto
````
<img width="329" height="270" alt="image" src="https://github.com/user-attachments/assets/3b243f1a-9cdf-4007-8759-8729ad4d343e" />

-----
```
west build -b native_sim/native/64 samples/modules/lvgl/screen_transparency/ -t run -p auto -- \
    -DCONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88=y
````
<img width="327" height="268" alt="image" src="https://github.com/user-attachments/assets/9aa18c92-5583-4432-ad03-8e4d640cc16d" />

-----
```
west build -b native_sim/native/64 samples/drivers/display/ -t run -p auto -- \
    -DCONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88=y
````
<img width="326" height="268" alt="image" src="https://github.com/user-attachments/assets/3983f0ba-b8b8-4009-bac1-e1e607049536" />
