### PR TITLE
scripts: west: Add uv package manager support

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -178,6 +178,15 @@ mapping:
             type: seq
             sequence:
               - type: str
+      uv:
+        required: false
+        type: map
+        mapping:
+          requirement-files:
+            required: false
+            type: seq
+            sequence:
+              - type: str
   runners:
     required: false
     type: seq


### PR DESCRIPTION
Add support for the `uv` package manager to the `west packages` command. This allows developers to use `uv` as a drop-in replacement for `pip` for installing Python package requirements. The new `west packages uv` command mirrors the existing `pip` subcommand.

Fixes #87260