### PR TITLE
display: sdl: add CONFIG_SDL_DISPLAY_COLOR_TINT

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -87,11 +87,12 @@ New APIs and options
 
 * Display
 
-  * Added new pixel format :c:enum:`PIXEL_FORMAT_AL_88`
+  * :c:enumerator:`PIXEL_FORMAT_AL_88`
 
   * SDL
 
     * :kconfig:option:`CONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88`
+    * :kconfig:option:`CONFIG_SDL_DISPLAY_COLOR_TINT`
 
 * Logging:
 

--- a/drivers/display/Kconfig.sdl
+++ b/drivers/display/Kconfig.sdl
@@ -84,12 +84,21 @@ config SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_1
 	default 0xcccccc
 	help
 	  The color of the odd cells in the transparency grid.
+	  Byte order: RGB_888
 
 config SDL_DISPLAY_TRANSPARENCY_GRID_CELL_COLOR_2
 	hex "Transparency grid cell color 2"
 	default 0xbbbbbb
 	help
 	  The color of the even cells in the transparency grid.
+	  Byte order: RGB_888
+
+config SDL_DISPLAY_COLOR_TINT
+	hex "Color filter applied on top of the display data"
+	default 0xffffff
+	help
+	  Can be used to simulate colored monochrome displays, like R8 (L8 + tint 0xff0000).
+	  Byte order: RGB_888
 
 config SDL_DISPLAY_THREAD_PRIORITY
 	int "SDL display thread priority"

--- a/drivers/display/display_sdl.c
+++ b/drivers/display/display_sdl.c
@@ -89,11 +89,13 @@ static void exec_sdl_task(const struct device *dev, const struct sdl_display_tas
 					 disp_data->mutex, disp_data->texture,
 					 disp_data->background_texture, disp_data->buf,
 					 disp_data->display_on,
-					 task->write.desc->frame_incomplete);
+					 task->write.desc->frame_incomplete,
+					 CONFIG_SDL_DISPLAY_COLOR_TINT);
 		break;
 	case SDL_BLANKING_OFF:
 		sdl_display_blanking_off_bottom(disp_data->renderer, disp_data->texture,
-						disp_data->background_texture);
+						disp_data->background_texture,
+						CONFIG_SDL_DISPLAY_COLOR_TINT);
 		break;
 	case SDL_BLANKING_ON:
 		sdl_display_blanking_on_bottom(disp_data->renderer);

--- a/drivers/display/display_sdl_bottom.c
+++ b/drivers/display/display_sdl_bottom.c
@@ -109,7 +109,7 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
 			      const uint16_t y, void *renderer, void *mutex, void *texture,
 			      void *background_texture, uint8_t *buf, bool display_on,
-			      bool frame_incomplete)
+			      bool frame_incomplete, uint32_t color_tint)
 {
 	SDL_Rect rect;
 	int err;
@@ -130,7 +130,12 @@ void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const
 	if (display_on && !frame_incomplete) {
 		SDL_RenderClear(renderer);
 		SDL_RenderCopy(renderer, background_texture, NULL, NULL);
+		SDL_SetTextureColorMod(texture,
+				       (color_tint >> 16) & 0xff,
+				       (color_tint >> 8) & 0xff,
+				       color_tint & 0xff);
 		SDL_RenderCopy(renderer, texture, NULL, NULL);
+		SDL_SetTextureColorMod(texture, 255, 255, 255);
 		SDL_RenderPresent(renderer);
 	}
 
@@ -171,11 +176,17 @@ int sdl_display_read_bottom(const uint16_t height, const uint16_t width,
 	return err;
 }
 
-void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *background_texture)
+void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *background_texture,
+				     uint32_t color_tint)
 {
 	SDL_RenderClear(renderer);
 	SDL_RenderCopy(renderer, background_texture, NULL, NULL);
+	SDL_SetTextureColorMod(texture,
+			       (color_tint >> 16) & 0xff,
+			       (color_tint >> 8) & 0xff,
+			       color_tint & 0xff);
 	SDL_RenderCopy(renderer, texture, NULL, NULL);
+	SDL_SetTextureColorMod(texture, 255, 255, 255);
 	SDL_RenderPresent(renderer);
 }
 

--- a/drivers/display/display_sdl_bottom.h
+++ b/drivers/display/display_sdl_bottom.h
@@ -29,11 +29,12 @@ int sdl_display_init_bottom(uint16_t height, uint16_t width, uint16_t zoom_pct,
 void sdl_display_write_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
 			      const uint16_t y, void *renderer, void *mutex, void *texture,
 			      void *background_texture, uint8_t *buf, bool display_on,
-			      bool frame_incomplete);
+			      bool frame_incomplete, uint32_t color_tint);
 int sdl_display_read_bottom(const uint16_t height, const uint16_t width, const uint16_t x,
 			    const uint16_t y, void *renderer, void *buf, uint16_t pitch,
 			    void *mutex, void *texture, void *read_texture);
-void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *background_texture);
+void sdl_display_blanking_off_bottom(void *renderer, void *texture, void *background_texture,
+				     uint32_t color_tint);
 void sdl_display_blanking_on_bottom(void *renderer);
 void sdl_display_cleanup_bottom(void **window, void **renderer, void **mutex, void **texture,
 				void **read_texture, void **background_texture);


### PR DESCRIPTION
Allows the SDL display to be tinted in a specific color, to allow the simulation of monochrome colored displays like `R8` (`L8` + tint `0xff0000`).

----

LVGL widgets demo in `L8` colorspace:

```
west build -b native_sim/native/64 samples/modules/lvgl/demos -t run -p auto -- \
    -DCONFIG_LV_Z_DEMO_WIDGETS=y \
    -DCONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_L_8=y
```

<img width="488" height="302" alt="image" src="https://github.com/user-attachments/assets/91e3e02d-2dd6-4e1f-be35-814cb8664c2e" />

-----

LVGL widgets demo in `L8` colorspace with tint `0xff0000`, simulating an `R8` display:

```
west build -b native_sim/native/64 samples/modules/lvgl/demos -t run -p auto -- \
    -DCONFIG_LV_Z_DEMO_WIDGETS=y \
    -DCONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_L_8=y \
    -DCONFIG_SDL_DISPLAY_COLOR_TINT=0xff0000
```

<img width="486" height="300" alt="image" src="https://github.com/user-attachments/assets/1a79ff84-9655-44a7-b6d1-5685d017f8ea" />


----

Or, in combination with #94428:

```
west build -b native_sim/native/64 samples/modules/lvgl/screen_transparency -t run -p auto -- \
    -DCONFIG_SDL_DISPLAY_DEFAULT_PIXEL_FORMAT_AL_88=y \
    -DCONFIG_SDL_DISPLAY_COLOR_TINT=0xff0000
```

<img width="329" height="269" alt="image" src="https://github.com/user-attachments/assets/6a69ef5c-f49a-4f11-a8c1-028ed5a2ed94" />
