### PR TITLE
boards: nordic: nrf54h20dk: Reconfigure Trace

### DIFF
--- a/boards/nordic/nrf54h20dk/support/nrf54h20_cpuapp.JLinkScript
+++ b/boards/nordic/nrf54h20dk/support/nrf54h20_cpuapp.JLinkScript
@@ -169,6 +169,11 @@ int OnTraceStart(void)
 	return 0;
 }
 
+int AfterResetTarget(void)
+{
+	_needCoresightSetup = 1;
+	return 0;
+}
 
 int SetupTarget(void)
 {


### PR DESCRIPTION
On a reset the coresight peripherals need to be reset, added an according JLinkScript action.