### PR TITLE
tests: bsim: bluetooth: host: Remove net_buf_unref call after bt_send

### DIFF
--- a/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/pipeline/tester/src/main.c
@@ -346,6 +346,8 @@ static void recv(struct net_buf *buf)
 
 static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 {
+	int err;
+
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
@@ -358,13 +360,12 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	active_opcode = opcode;
 
 	LOG_HEXDUMP_DBG(cmd->data, cmd->len, "HCI TX");
-	bt_send(cmd);
+	err = bt_send(cmd);
+	__ASSERT(err == 0, "Failed to send HCI command: %d", err);
 
 	/* Wait until the command completes */
 	k_sem_take(&cmd_sem, K_FOREVER);
 	k_sem_give(&cmd_sem);
-
-	net_buf_unref(cmd);
 
 	/* return response. it's okay if cmd_rsp gets overwritten, since the app
 	 * gets the ref to the underlying buffer when this fn returns.

--- a/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/att/sequential/tester/src/main.c
@@ -323,6 +323,8 @@ static void recv(struct net_buf *buf)
 
 static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 {
+	int err;
+
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
@@ -335,13 +337,12 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	active_opcode = opcode;
 
 	LOG_HEXDUMP_DBG(cmd->data, cmd->len, "HCI TX");
-	bt_send(cmd);
+	err = bt_send(cmd);
+	__ASSERT(err == 0, "Failed to send HCI command: %d", err);
 
 	/* Wait until the command completes */
 	k_sem_take(&cmd_sem, K_FOREVER);
 	k_sem_give(&cmd_sem);
-
-	net_buf_unref(cmd);
 
 	/* return response. it's okay if cmd_rsp gets overwritten, since the app
 	 * gets the ref to the underlying buffer when this fn returns.

--- a/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
+++ b/tests/bsim/bluetooth/host/l2cap/reassembly/peer/src/peer.c
@@ -276,6 +276,8 @@ static void recv(struct net_buf *buf)
 
 static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 {
+	int err;
+
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
@@ -289,7 +291,8 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	active_opcode = opcode;
 
 	LOG_HEXDUMP_DBG(cmd->data, cmd->len, "HCI TX");
-	bt_send(cmd);
+	err = bt_send(cmd);
+	__ASSERT(err == 0, "Failed to send cmd: %d", err);
 
 	/* Wait until the command completes:
 	 *
@@ -304,8 +307,6 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	BUILD_ASSERT(MAX_CMD_COUNT == 1, "Logic depends on only 1 cmd at a time");
 	k_sem_take(&cmd_sem, K_FOREVER);
 	k_sem_give(&cmd_sem);
-
-	net_buf_unref(cmd);
 
 	/* return response. it's okay if cmd_rsp gets overwritten, since the app
 	 * gets the ref to the underlying buffer when this fn returns.

--- a/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/l2cap/split/tester/src/main.c
@@ -303,6 +303,8 @@ static void recv(struct net_buf *buf)
 
 static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 {
+	int err;
+
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
@@ -315,13 +317,12 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	active_opcode = opcode;
 
 	LOG_HEXDUMP_DBG(cmd->data, cmd->len, "HCI TX");
-	bt_send(cmd);
+	err = bt_send(cmd);
+	__ASSERT(err == 0, "Failed to send HCI command: %d", err);
 
 	/* Wait until the command completes */
 	k_sem_take(&cmd_sem, K_FOREVER);
 	k_sem_give(&cmd_sem);
-
-	net_buf_unref(cmd);
 
 	/* return response. it's okay if cmd_rsp gets overwritten, since the app
 	 * gets the ref to the underlying buffer when this fn returns.

--- a/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
+++ b/tests/bsim/bluetooth/host/misc/disconnect/tester/src/main.c
@@ -300,6 +300,8 @@ static void recv(struct net_buf *buf)
 
 static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 {
+	int err;
+
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
@@ -312,13 +314,12 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	active_opcode = opcode;
 
 	LOG_HEXDUMP_DBG(cmd->data, cmd->len, "HCI TX");
-	bt_send(cmd);
+	err = bt_send(cmd);
+	__ASSERT(err == 0, "Failed to send HCI command: %d", err);
 
 	/* Wait until the command completes */
 	k_sem_take(&cmd_sem, K_FOREVER);
 	k_sem_give(&cmd_sem);
-
-	net_buf_unref(cmd);
 
 	/* return response. it's okay if cmd_rsp gets overwritten, since the app
 	 * gets the ref to the underlying buffer when this fn returns.

--- a/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
+++ b/tests/bsim/bluetooth/host/misc/hfc_multilink/tester/src/tester.c
@@ -314,6 +314,8 @@ static void recv(struct net_buf *buf)
 
 static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 {
+	int err;
+
 	LOG_DBG("opcode %x", opcode);
 
 	if (!cmd) {
@@ -326,13 +328,12 @@ static void send_cmd(uint16_t opcode, struct net_buf *cmd, struct net_buf **rsp)
 	active_opcode = opcode;
 
 	LOG_HEXDUMP_DBG(cmd->data, cmd->len, "HCI TX");
-	bt_send(cmd);
+	err = bt_send(cmd);
+	__ASSERT(err == 0, "Failed to send cmd: %d", err);
 
 	/* Wait until the command completes */
 	k_sem_take(&cmd_sem, K_FOREVER);
 	k_sem_give(&cmd_sem);
-
-	net_buf_unref(cmd);
 
 	/* return response. it's okay if cmd_rsp gets overwritten, since the app
 	 * gets the ref to the underlying buffer when this fn returns.


### PR DESCRIPTION
If `bt_send` returns 0, the buffer will be unreferenced by an hci driver. If it returns error, the buffer won't be unreferenced.

Since it is a test, simply check that `bt_send` always returns 0 otherwise fail the test.