### PR TITLE
west.yml : Fix Link Layer and LE integration on STM32WBA

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 611d54c237623ea71a367502bfbd736fc67ba15f
+      revision: e61c99efe6d6f97e40dd9bda255c881e9b8fe21e
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
some header files and system files of the Link Layer in zephyr are not aligned with the header file and system files of the Link Layer in STM32Cube_FW_WBA Release 1.6.0