### PR TITLE
soc: stm32: fix stm32g0x0 poweroff and always clear wakup flags before poweroff where applicable

### DIFF
--- a/soc/st/stm32/stm32c0x/poweroff.c
+++ b/soc/st/stm32/stm32c0x/poweroff.c
@@ -18,9 +18,9 @@ void z_sys_poweroff(void)
 {
 #ifdef CONFIG_STM32_WKUP_PINS
 	stm32_pwr_wkup_pin_cfg_pupd();
+#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 	LL_LPM_EnableDeepSleep();

--- a/soc/st/stm32/stm32f4x/poweroff.c
+++ b/soc/st/stm32/stm32f4x/poweroff.c
@@ -16,9 +16,7 @@
 
 void z_sys_poweroff(void)
 {
-#ifdef CONFIG_STM32_WKUP_PINS
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
 	LL_LPM_EnableDeepSleep();

--- a/soc/st/stm32/stm32g0x/poweroff.c
+++ b/soc/st/stm32/stm32g0x/poweroff.c
@@ -19,9 +19,9 @@ void z_sys_poweroff(void)
 {
 #ifdef CONFIG_STM32_WKUP_PINS
 	stm32_pwr_wkup_pin_cfg_pupd();
+#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 #ifdef LL_PWR_MODE_SHUTDOWN
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);

--- a/soc/st/stm32/stm32g0x/poweroff.c
+++ b/soc/st/stm32/stm32g0x/poweroff.c
@@ -23,7 +23,11 @@ void z_sys_poweroff(void)
 	LL_PWR_ClearFlag_WU();
 #endif /* CONFIG_STM32_WKUP_PINS */
 
+#ifdef LL_PWR_MODE_SHUTDOWN
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
+#else
+	LL_PWR_SetPowerMode(LL_PWR_MODE_STANDBY);
+#endif
 	LL_LPM_EnableDeepSleep();
 	LL_DBGMCU_DisableDBGStandbyMode();
 

--- a/soc/st/stm32/stm32l4x/poweroff.c
+++ b/soc/st/stm32/stm32l4x/poweroff.c
@@ -18,9 +18,9 @@ void z_sys_poweroff(void)
 {
 #ifdef CONFIG_STM32_WKUP_PINS
 	stm32_pwr_wkup_pin_cfg_pupd();
+#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 	LL_LPM_EnableDeepSleep();

--- a/soc/st/stm32/stm32u5x/poweroff.c
+++ b/soc/st/stm32/stm32u5x/poweroff.c
@@ -17,9 +17,9 @@ void z_sys_poweroff(void)
 {
 #ifdef CONFIG_STM32_WKUP_PINS
 	stm32_pwr_wkup_pin_cfg_pupd();
+#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_SetPowerMode(LL_PWR_SHUTDOWN_MODE);
 	LL_LPM_EnableDeepSleep();

--- a/soc/st/stm32/stm32wbx/poweroff.c
+++ b/soc/st/stm32/stm32wbx/poweroff.c
@@ -17,9 +17,9 @@ void z_sys_poweroff(void)
 {
 #ifdef CONFIG_STM32_WKUP_PINS
 	stm32_pwr_wkup_pin_cfg_pupd();
+#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 	LL_LPM_EnableDeepSleep();

--- a/soc/st/stm32/stm32wlx/poweroff.c
+++ b/soc/st/stm32/stm32wlx/poweroff.c
@@ -17,9 +17,9 @@ void z_sys_poweroff(void)
 {
 #ifdef CONFIG_STM32_WKUP_PINS
 	stm32_pwr_wkup_pin_cfg_pupd();
+#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_ClearFlag_WU();
-#endif /* CONFIG_STM32_WKUP_PINS */
 
 	LL_PWR_SetPowerMode(LL_PWR_MODE_SHUTDOWN);
 	LL_LPM_EnableDeepSleep();


### PR DESCRIPTION
Correct stm32g0x0 poweroff sequence to use the SoC Standby mode since it does not support the Shutdown mode.

Correct various stm32 SoCs poweroff sequence to always clear the wakeup status flags before entering poweroff state, as suggested by https://github.com/zephyrproject-rtos/zephyr/pull/93911#discussion_r2266170944.
