### PR TITLE
Fix twister not detected testsuite from test cases

### DIFF
--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -149,7 +149,7 @@ def scan_file(inf_name):
                 )
             elif new_suite_regex_matches or new_suite_testcase_regex_matches:
                 ztest_suite_names = \
-                    _extract_ztest_suite_names(new_suite_regex_matches)
+                    _extract_ztest_suite_names(new_suite_regex_matches) + _extract_ztest_suite_names(new_suite_testcase_regex_matches)
                 testcase_names, warnings = \
                     _find_new_ztest_testcases(main_c)
             else:

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -149,7 +149,7 @@ def scan_file(inf_name):
                 )
             elif new_suite_regex_matches or new_suite_testcase_regex_matches:
                 ztest_suite_names = \
-                    _extract_ztest_suite_names(new_suite_regex_matches) + _extract_ztest_suite_names(new_suite_testcase_regex_matches)
+                   list(set( _extract_ztest_suite_names(new_suite_regex_matches) + _extract_ztest_suite_names(new_suite_testcase_regex_matches)))
                 testcase_names, warnings = \
                     _find_new_ztest_testcases(main_c)
             else:


### PR DESCRIPTION
The elif is triggered by both matches but only the result of the first one are used. Use both.

This is relevant in some cases when using custom macro to extend ztest capabilities.