### PR TITLE
samples: drivers: led: lp5569: add required fixture

### DIFF
--- a/samples/drivers/led/lp5569/sample.yaml
+++ b/samples/drivers/led/lp5569/sample.yaml
@@ -5,3 +5,11 @@ tests:
   sample.drivers.led.lp5569:
     platform_allow: nrf52840dk/nrf52840
     tags: led
+    harness: console
+    harness_config:
+      fixture: fixture_led_lp5569
+      type: multi_line
+      ordered: true
+      regex:
+        - "Found LED device"
+        - "Testing 9 LEDs"


### PR DESCRIPTION
Indicating that additional HW is needed to run this sample.