### PR TITLE
net: openthread: Fix exiting diag when transmission is ongoing

### DIFF
--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -811,6 +811,10 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 	radio_api->start(radio_dev);
 	sState = OT_RADIO_STATE_RECEIVE;
 
+	if (is_pending_event_set(PENDING_EVENT_TX_DONE)) {
+		reset_pending_event(PENDING_EVENT_TX_DONE);
+	}
+
 	return OT_ERROR_NONE;
 }
 


### PR DESCRIPTION
Crash was observed if "diag stop" was invoked during the transmission. The issue was caused by an update to otPlatRadioSleep that made it compilant with the documentation and not allowing direct Transmeet to sleep transition.
The transmission result was forwarded to OpenThread making it crash due to an invalid state.