### PR TITLE
boards native: Support using lld as linker for native simulator runner

### DIFF
--- a/boards/native/common/natsim_config.cmake
+++ b/boards/native/common/natsim_config.cmake
@@ -13,6 +13,10 @@ if(SYSROOT_DIR)
   target_link_options(native_simulator INTERFACE "--sysroot=${SYSROOT_DIR}")
 endif()
 
+if("${LINKER}" STREQUAL "lld")
+  target_link_options(native_simulator INTERFACE "-fuse-ld=lld")
+endif()
+
 set(nsi_config_content
   ${nsi_config_content}
   "NSI_AR:=${CMAKE_AR}"


### PR DESCRIPTION
Let's assume that if a user sets the linker to be lld (likely with CONFIG_LLVM_USE_LLD=y) that they also want the native simulator runner to be linked with it.