### PR TITLE
Bluetooth: Host: Remove deprecated device name API

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -784,32 +784,6 @@ enum bt_le_adv_opt {
 	BT_LE_ADV_OPT_USE_IDENTITY = BIT(2),
 
 	/**
-	 * @deprecated This option will be removed in the near future, see
-	 * https://github.com/zephyrproject-rtos/zephyr/issues/71686
-	 *
-	 * @brief Advertise using GAP device name.
-	 *
-	 * Include the GAP device name automatically when advertising.
-	 * By default the GAP device name is put at the end of the scan
-	 * response data.
-	 * When advertising using @ref BT_LE_ADV_OPT_EXT_ADV and not
-	 * @ref BT_LE_ADV_OPT_SCANNABLE then it will be put at the end of the
-	 * advertising data.
-	 * If the GAP device name does not fit into advertising data it will be
-	 * converted to a shortened name if possible.
-	 * @ref BT_LE_ADV_OPT_FORCE_NAME_IN_AD can be used to force the device
-	 * name to appear in the advertising data of an advert with scan
-	 * response data.
-	 *
-	 * The application can set the device name itself by including the
-	 * following in the advertising data.
-	 * @code
-	 * BT_DATA(BT_DATA_NAME_COMPLETE, name, sizeof(name) - 1)
-	 * @endcode
-	 */
-	BT_LE_ADV_OPT_USE_NAME = BIT(3),
-
-	/**
 	 * @brief Low duty cycle directed advertising.
 	 *
 	 * Use low duty directed advertising mode, otherwise high duty mode
@@ -930,19 +904,6 @@ enum bt_le_adv_opt {
 
 	/** Disable advertising on channel index 39. */
 	BT_LE_ADV_OPT_DISABLE_CHAN_39 = BIT(17),
-
-	/**
-	 * @deprecated This option will be removed in the near future, see
-	 * https://github.com/zephyrproject-rtos/zephyr/issues/71686
-	 *
-	 * @brief Put GAP device name into advert data
-	 *
-	 * Will place the GAP device name into the advertising data rather than
-	 * the scan response data.
-	 *
-	 * @note Requires @ref BT_LE_ADV_OPT_USE_NAME
-	 */
-	BT_LE_ADV_OPT_FORCE_NAME_IN_AD = BIT(18),
 
 	/**
 	 * @brief Advertise using a Non-Resolvable Private Address.
@@ -1271,27 +1232,6 @@ struct bt_le_per_adv_param {
 
 #define BT_LE_ADV_CONN_ONE_TIME BT_LE_ADV_CONN_FAST_2 __DEPRECATED_MACRO
 
-/**
- * @deprecated This macro will be removed in the near future, see
- * https://github.com/zephyrproject-rtos/zephyr/issues/71686
- */
-#define BT_LE_ADV_CONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					    BT_LE_ADV_OPT_USE_NAME, \
-					    BT_GAP_ADV_FAST_INT_MIN_2, \
-					    BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
-					    __DEPRECATED_MACRO
-
-/**
- * @deprecated This macro will be removed in the near future, see
- * https://github.com/zephyrproject-rtos/zephyr/issues/71686
- */
-#define BT_LE_ADV_CONN_NAME_AD BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONNECTABLE | \
-					    BT_LE_ADV_OPT_USE_NAME | \
-					    BT_LE_ADV_OPT_FORCE_NAME_IN_AD, \
-					    BT_GAP_ADV_FAST_INT_MIN_2, \
-					    BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
-					    __DEPRECATED_MACRO
-
 #define BT_LE_ADV_CONN_DIR_LOW_DUTY(_peer)                                                         \
 	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY,                      \
 			BT_GAP_ADV_FAST_INT_MIN_2, BT_GAP_ADV_FAST_INT_MAX_2, _peer)
@@ -1299,17 +1239,6 @@ struct bt_le_per_adv_param {
 /** Non-connectable advertising with private address */
 #define BT_LE_ADV_NCONN BT_LE_ADV_PARAM(0, BT_GAP_ADV_FAST_INT_MIN_2, \
 					BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
-/**
- * @deprecated This macro will be removed in the near future, see
- * https://github.com/zephyrproject-rtos/zephyr/issues/71686
- *
- * Non-connectable advertising with @ref BT_LE_ADV_OPT_USE_NAME
- */
-#define BT_LE_ADV_NCONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_NAME, \
-					     BT_GAP_ADV_FAST_INT_MIN_2, \
-					     BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
-					     __DEPRECATED_MACRO
 
 /** Non-connectable advertising with @ref BT_LE_ADV_OPT_USE_IDENTITY */
 #define BT_LE_ADV_NCONN_IDENTITY BT_LE_ADV_PARAM(BT_LE_ADV_OPT_USE_IDENTITY, \
@@ -1322,20 +1251,6 @@ struct bt_le_per_adv_param {
 	BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CONN, BT_GAP_ADV_FAST_INT_MIN_2,     \
 			BT_GAP_ADV_FAST_INT_MAX_2, NULL)
 
-/**
- * @deprecated This macro will be removed in the near future, see
- * https://github.com/zephyrproject-rtos/zephyr/issues/71686
- *
- * Connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME
- */
-#define BT_LE_EXT_ADV_CONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
-						BT_LE_ADV_OPT_CONNECTABLE | \
-						BT_LE_ADV_OPT_USE_NAME, \
-						BT_GAP_ADV_FAST_INT_MIN_2, \
-						BT_GAP_ADV_FAST_INT_MAX_2, \
-						NULL) \
-						__DEPRECATED_MACRO
-
 /** Scannable extended advertising */
 #define BT_LE_EXT_ADV_SCAN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
 					   BT_LE_ADV_OPT_SCANNABLE, \
@@ -1343,37 +1258,10 @@ struct bt_le_per_adv_param {
 					   BT_GAP_ADV_FAST_INT_MAX_2, \
 					   NULL)
 
-/**
- * @deprecated This macro will be removed in the near future, see
- * https://github.com/zephyrproject-rtos/zephyr/issues/71686
- *
- * Scannable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME
- */
-#define BT_LE_EXT_ADV_SCAN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
-						BT_LE_ADV_OPT_SCANNABLE | \
-						BT_LE_ADV_OPT_USE_NAME, \
-						BT_GAP_ADV_FAST_INT_MIN_2, \
-						BT_GAP_ADV_FAST_INT_MAX_2, \
-						NULL) \
-						__DEPRECATED_MACRO
-
 /** Non-connectable extended advertising with private address */
 #define BT_LE_EXT_ADV_NCONN BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV, \
 					    BT_GAP_ADV_FAST_INT_MIN_2, \
 					    BT_GAP_ADV_FAST_INT_MAX_2, NULL)
-
-/**
- * @deprecated This macro will be removed in the near future, see
- * https://github.com/zephyrproject-rtos/zephyr/issues/71686
- *
- * Non-connectable extended advertising with @ref BT_LE_ADV_OPT_USE_NAME
- */
-#define BT_LE_EXT_ADV_NCONN_NAME BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | \
-						 BT_LE_ADV_OPT_USE_NAME, \
-						 BT_GAP_ADV_FAST_INT_MIN_2, \
-						 BT_GAP_ADV_FAST_INT_MAX_2, \
-						 NULL) \
-						 __DEPRECATED_MACRO
 
 /** Non-connectable extended advertising with @ref BT_LE_ADV_OPT_USE_IDENTITY */
 #define BT_LE_EXT_ADV_NCONN_IDENTITY \
@@ -1388,20 +1276,6 @@ struct bt_le_per_adv_param {
 						  BT_GAP_ADV_FAST_INT_MIN_2, \
 						  BT_GAP_ADV_FAST_INT_MAX_2, \
 						  NULL)
-
-/**
- * @deprecated This macro will be removed in the near future, see
- * https://github.com/zephyrproject-rtos/zephyr/issues/71686
- *
- * Non-connectable extended advertising on coded PHY with
- * @ref BT_LE_ADV_OPT_USE_NAME
- */
-#define BT_LE_EXT_ADV_CODED_NCONN_NAME \
-		BT_LE_ADV_PARAM(BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_CODED | \
-				BT_LE_ADV_OPT_USE_NAME, \
-				BT_GAP_ADV_FAST_INT_MIN_2, \
-				BT_GAP_ADV_FAST_INT_MAX_2, NULL) \
-				__DEPRECATED_MACRO
 
 /** Non-connectable extended advertising on coded PHY with
  *  @ref BT_LE_ADV_OPT_USE_IDENTITY
@@ -1684,10 +1558,6 @@ int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
  * Update the advertising parameters. The function will return an error if the
  * advertiser set is currently advertising. Stop the advertising set before
  * calling this function.
- *
- * @note When changing the option @ref BT_LE_ADV_OPT_USE_NAME then
- *       @ref bt_le_ext_adv_set_data needs to be called in order to update the
- *       advertising data and scan response data.
  *
  * @param adv   Advertising set object.
  * @param param Advertising parameters.

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -38,12 +38,6 @@
 #define LOG_LEVEL CONFIG_BT_HCI_CORE_LOG_LEVEL
 LOG_MODULE_REGISTER(bt_adv);
 
-enum adv_name_type {
-	ADV_NAME_TYPE_NONE,
-	ADV_NAME_TYPE_AD,
-	ADV_NAME_TYPE_SD,
-};
-
 struct bt_ad {
 	/* Pointer to an LTV structure */
 	const struct bt_data *data;
@@ -183,37 +177,6 @@ static uint8_t ad_stream_read(struct ad_stream *stream, uint8_t *buf, uint8_t bu
 	stream->remaining_size -= read_len;
 
 	return read_len;
-}
-
-enum adv_name_type get_adv_name_type(const struct bt_le_ext_adv *adv)
-{
-	if (atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME_SD)) {
-		return ADV_NAME_TYPE_SD;
-	}
-
-	if (atomic_test_bit(adv->flags, BT_ADV_INCLUDE_NAME_AD)) {
-		return ADV_NAME_TYPE_AD;
-	}
-
-	return ADV_NAME_TYPE_NONE;
-}
-
-enum adv_name_type get_adv_name_type_param(const struct bt_le_adv_param *param)
-{
-	if (param->options & BT_LE_ADV_OPT_USE_NAME) {
-		if (param->options & BT_LE_ADV_OPT_FORCE_NAME_IN_AD) {
-			return ADV_NAME_TYPE_AD;
-		}
-
-		if ((param->options & BT_LE_ADV_OPT_EXT_ADV) &&
-		    !(param->options & BT_LE_ADV_OPT_SCANNABLE)) {
-			return ADV_NAME_TYPE_AD;
-		}
-
-		return ADV_NAME_TYPE_SD;
-	}
-
-	return ADV_NAME_TYPE_NONE;
 }
 
 #if defined(CONFIG_BT_EXT_ADV)
@@ -430,15 +393,6 @@ static bool valid_adv_ext_param(const struct bt_le_adv_param *param)
 				      BT_LE_ADV_OPT_ANONYMOUS |
 				      BT_LE_ADV_OPT_USE_TX_POWER)) {
 			/* Extended options require extended advertising. */
-			return false;
-		}
-
-		if ((param->options & BT_LE_ADV_OPT_EXT_ADV) &&
-		    (param->options & BT_LE_ADV_OPT_SCANNABLE) &&
-		    (param->options & BT_LE_ADV_OPT_FORCE_NAME_IN_AD)) {
-			/* Advertising data is not permitted for an extended
-			 * scannable advertiser.
-			 */
 			return false;
 		}
 	}
@@ -771,20 +725,6 @@ static int hci_set_per_adv_data(const struct bt_le_ext_adv *adv,
 }
 #endif /* CONFIG_BT_PER_ADV */
 
-static inline bool ad_has_name(const struct bt_data *ad, size_t ad_len)
-{
-	size_t i;
-
-	for (i = 0; i < ad_len; i++) {
-		if (ad[i].type == BT_DATA_NAME_COMPLETE ||
-		    ad[i].type == BT_DATA_NAME_SHORTENED) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 static bool ad_is_limited(const struct bt_data *ad, size_t ad_len)
 {
 	size_t i;
@@ -805,38 +745,16 @@ static bool ad_is_limited(const struct bt_data *ad, size_t ad_len)
 static int le_adv_update(struct bt_le_ext_adv *adv,
 			 const struct bt_data *ad, size_t ad_len,
 			 const struct bt_data *sd, size_t sd_len,
-			 bool ext_adv, bool scannable,
-			 enum adv_name_type name_type)
+			 bool ext_adv, bool scannable)
 {
 	struct bt_ad d[2] = {};
-	struct bt_data data;
 	size_t d_len;
 	int err;
-
-	if (name_type != ADV_NAME_TYPE_NONE) {
-		const char *name = bt_get_name();
-
-		if ((ad && ad_has_name(ad, ad_len)) ||
-		    (sd && ad_has_name(sd, sd_len))) {
-			/* Cannot use name if name is already set */
-			return -EINVAL;
-		}
-
-		data = (struct bt_data)BT_DATA(
-			BT_DATA_NAME_COMPLETE,
-			name, strlen(name));
-	}
 
 	if (!(ext_adv && scannable)) {
 		d_len = 1;
 		d[0].data = ad;
 		d[0].len = ad_len;
-
-		if (name_type == ADV_NAME_TYPE_AD) {
-			d[1].data = &data;
-			d[1].len = 1;
-			d_len = 2;
-		}
 
 		err = set_ad(adv, d, d_len);
 		if (err) {
@@ -848,12 +766,6 @@ static int le_adv_update(struct bt_le_ext_adv *adv,
 		d_len = 1;
 		d[0].data = sd;
 		d[0].len = sd_len;
-
-		if (name_type == ADV_NAME_TYPE_SD) {
-			d[1].data = &data;
-			d[1].len = 1;
-			d_len = 2;
-		}
 
 		err = set_sd(adv, d, d_len);
 		if (err) {
@@ -881,8 +793,7 @@ int bt_le_adv_update_data(const struct bt_data *ad, size_t ad_len,
 
 	scannable = atomic_test_bit(adv->flags, BT_ADV_SCANNABLE);
 
-	return le_adv_update(adv, ad, ad_len, sd, sd_len, false, scannable,
-			     get_adv_name_type(adv));
+	return le_adv_update(adv, ad, ad_len, sd, sd_len, false, scannable);
 }
 
 static uint8_t get_filter_policy(uint32_t options)
@@ -989,7 +900,6 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 	struct bt_conn *conn = NULL;
 	struct net_buf *buf;
 	bool dir_adv = (param->peer != NULL), scannable = false;
-	enum adv_name_type name_type;
 
 	int err;
 
@@ -1033,8 +943,6 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 		bt_addr_le_copy(&adv->target_addr, BT_ADDR_LE_ANY);
 	}
 
-	name_type = get_adv_name_type_param(param);
-
 	if (param->options & _BT_LE_ADV_OPT_CONNECTABLE) {
 		if (dir_adv) {
 			if (param->options & BT_LE_ADV_OPT_DIR_MODE_LOW_DUTY) {
@@ -1048,8 +956,7 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 			scannable = true;
 			set_param.type = BT_HCI_ADV_IND;
 		}
-	} else if ((param->options & BT_LE_ADV_OPT_SCANNABLE) || sd ||
-		   (name_type == ADV_NAME_TYPE_SD)) {
+	} else if ((param->options & BT_LE_ADV_OPT_SCANNABLE) || sd) {
 		scannable = true;
 		set_param.type = BT_HCI_ADV_SCAN_IND;
 	} else {
@@ -1069,8 +976,7 @@ int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 	}
 
 	if (!dir_adv) {
-		err = le_adv_update(adv, ad, ad_len, sd, sd_len, false,
-				    scannable, name_type);
+		err = le_adv_update(adv, ad, ad_len, sd, sd_len, false, scannable);
 		if (err) {
 			return err;
 		}
@@ -1113,12 +1019,6 @@ set_adv_state:
 	atomic_set_bit_to(adv->flags, BT_ADV_PERSIST, !dir_adv &&
 			  !(param->options & _BT_LE_ADV_OPT_ONE_TIME));
 
-	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME_AD,
-			  name_type == ADV_NAME_TYPE_AD);
-
-	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME_SD,
-			  name_type == ADV_NAME_TYPE_SD);
-
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
 			  param->options & _BT_LE_ADV_OPT_CONNECTABLE);
 
@@ -1142,7 +1042,6 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 	struct net_buf *buf, *rsp;
 	uint8_t own_addr_type;
 	int err;
-	enum adv_name_type name_type;
 	uint16_t props = 0;
 
 	adv->options = param->options;
@@ -1241,10 +1140,7 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 		}
 	}
 
-	name_type = get_adv_name_type_param(param);
-
-	if ((param->options & BT_LE_ADV_OPT_SCANNABLE) || has_scan_data ||
-	    (name_type == ADV_NAME_TYPE_SD)) {
+	if ((param->options & BT_LE_ADV_OPT_SCANNABLE) || has_scan_data) {
 		props |= BT_HCI_LE_ADV_PROP_SCAN;
 	}
 
@@ -1289,12 +1185,6 @@ static int le_ext_adv_param_set(struct bt_le_ext_adv *adv,
 
 	/* Flag only used by bt_le_adv_start API. */
 	atomic_set_bit_to(adv->flags, BT_ADV_PERSIST, false);
-
-	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME_AD,
-			  name_type == ADV_NAME_TYPE_AD);
-
-	atomic_set_bit_to(adv->flags, BT_ADV_INCLUDE_NAME_SD,
-			  name_type == ADV_NAME_TYPE_SD);
 
 	atomic_set_bit_to(adv->flags, BT_ADV_CONNECTABLE,
 			  param->options & _BT_LE_ADV_OPT_CONNECTABLE);
@@ -1746,12 +1636,6 @@ int bt_le_ext_adv_start(struct bt_le_ext_adv *adv,
 		}
 	}
 
-	if (get_adv_name_type(adv) != ADV_NAME_TYPE_NONE &&
-	    !atomic_test_bit(adv->flags, BT_ADV_DATA_SET)) {
-		/* Set the advertiser name */
-		bt_le_ext_adv_set_data(adv, NULL, 0, NULL, 0);
-	}
-
 	err = bt_le_adv_set_enable_ext(adv, true, param);
 	if (err) {
 		LOG_ERR("Failed to start advertiser");
@@ -1829,8 +1713,7 @@ int bt_le_ext_adv_set_data(struct bt_le_ext_adv *adv,
 		}
 	}
 
-	return le_adv_update(adv, ad, ad_len, sd, sd_len, ext_adv, scannable,
-			     get_adv_name_type(adv));
+	return le_adv_update(adv, ad, ad_len, sd, sd_len, ext_adv, scannable);
 }
 
 int bt_le_ext_adv_delete(struct bt_le_ext_adv *adv)

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -130,10 +130,6 @@ enum {
 	BT_ADV_LIMITED,
 	/* Advertiser set is currently advertising in the controller. */
 	BT_ADV_ENABLED,
-	/* Advertiser should include name in advertising data */
-	BT_ADV_INCLUDE_NAME_AD,
-	/* Advertiser should include name in scan response data */
-	BT_ADV_INCLUDE_NAME_SD,
 	/* Advertiser set is connectable */
 	BT_ADV_CONNECTABLE,
 	/* Advertiser set is scannable */


### PR DESCRIPTION
Removes the BT_LE_ADV_OPT_USE_NAME and BT_LE_ADV_OPT_FORCE_NAME_IN_AD advertiser options and related flags, macros and functions. The application now needs to include the device name explicitly.

The API was deprecated in https://github.com/zephyrproject-rtos/zephyr/pull/71700

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/71686