### PR TITLE
dts: st: nucleo_u575zi_q enable pull down for user button

### DIFF
--- a/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/st/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -35,7 +35,7 @@
 
 		user_button: button {
 			label = "User";
-			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpioc 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 			zephyr,code = <INPUT_KEY_0>;
 		};
 	};


### PR DESCRIPTION
Enable pull down for nucleo_u575zi_q user button.
Tested with sample `boards/st/power_mgnt/wkup_pins`.

Setting the proper pull is also important for wkup from stop 3 mode as discussed in https://github.com/zephyrproject-rtos/zephyr/discussions/93106#discussioncomment-14070370. 