### PR TITLE
[Backport v3.7-branch] soc: snps: rmx: replace custom buildlib with generic RMX linker option

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -112,7 +112,6 @@ endfunction(toolchain_ld_link_elf)
 # linker options of temporary linkage for code generation
 macro(toolchain_ld_baremetal)
   zephyr_ld_options(
-    -Hlld
     -Hnosdata
     -Xtimer0 # to suppress the warning message
     -Hnoxcheck_obj
@@ -122,6 +121,12 @@ macro(toolchain_ld_baremetal)
     -Hnoivt
     -Hnocrt
   )
+
+  if(CONFIG_ARC)
+    zephyr_ld_options(
+      -Hlld
+    )
+  endif()
 
   # There are two options:
   # - We have full MWDT libc support and we link MWDT libc - this is default

--- a/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
+++ b/soc/snps/nsim/arc_v/rmx/CMakeLists.txt
@@ -6,7 +6,7 @@ if(COMPILER STREQUAL arcmwdt)
 					-av5rmx -Zicsr -Zifencei -Zihintpause -Zba -Zbb
 					-Zbs -Zca -Zcb -Zcmp -Zcmt -Za -Zm -Zicbom)
 
-  zephyr_ld_options(-Hlib=rmx100)
+  zephyr_ld_options(-av5rmx)
 endif()
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/riscv/common/linker.ld CACHE INTERNAL "")


### PR DESCRIPTION
Do not use the custom buildlib configuration for the RMX series as it was replaced with several even more specific configurations in the recent MWDT release. Pass the generic RMX series option to the linker instead, and, to make it work, don't pass -Hlld to the linker if the architecture is not ARC.

Fixes #94422
