### PR TITLE
Bluetooth: CAP: Fix bad return from bap_unicast_group_foreach_stream_cb

### DIFF
--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -414,10 +414,10 @@ typedef bool (*bt_cap_unicast_group_foreach_stream_func_t)(struct bt_cap_stream 
  *
  * @param unicast_group  The unicast group
  * @param func           The callback function
- * @param user_data      User specified data that sent to the callback function
+ * @param user_data      User specified data that is sent to the callback function
  *
  * @retval 0 Success (even if no streams exists in the group).
- * @retval -ECANCELED Iteration was stopped by the callback function before complete.
+ * @retval -ECANCELED The @p func returned true.
  * @retval -EINVAL @p unicast_group or @p func were NULL.
  */
 int bt_cap_unicast_group_foreach_stream(struct bt_cap_unicast_group *unicast_group,

--- a/subsys/bluetooth/audio/cap_initiator.c
+++ b/subsys/bluetooth/audio/cap_initiator.c
@@ -1044,9 +1044,8 @@ static bool bap_unicast_group_foreach_stream_cb(struct bt_bap_stream *bap_stream
 	/* Since we are iterating on a CAP unicast group, we can assume that all streams are CAP
 	 * streams
 	 */
-	data->func(CONTAINER_OF(bap_stream, struct bt_cap_stream, bap_stream), data->user_data);
-
-	return false;
+	return data->func(CONTAINER_OF(bap_stream, struct bt_cap_stream, bap_stream),
+			  data->user_data);
 }
 
 int bt_cap_unicast_group_foreach_stream(struct bt_cap_unicast_group *unicast_group,

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_group.c
@@ -357,6 +357,31 @@ static ZTEST_F(cap_initiator_test_unicast_group, test_initiator_unicast_group_fo
 	zassert_equal(cnt, expect_cnt, "Unexpected cnt (%zu != %zu)", cnt, expect_cnt);
 }
 
+static bool unicast_group_foreach_stream_return_early_cb(struct bt_cap_stream *stream,
+							 void *user_data)
+{
+	size_t *cnt = user_data;
+
+	(*cnt)++;
+
+	return true;
+}
+
+static ZTEST_F(cap_initiator_test_unicast_group,
+	       test_initiator_unicast_group_foreach_stream_return_early)
+{
+	size_t cnt = 0U;
+	int err;
+
+	err = bt_cap_unicast_group_create(fixture->group_param, &fixture->unicast_group);
+	zassert_equal(err, 0, "Unexpected return value %d", err);
+
+	err = bt_cap_unicast_group_foreach_stream(
+		fixture->unicast_group, unicast_group_foreach_stream_return_early_cb, &cnt);
+	zassert_equal(err, -ECANCELED, "Unexpected return value: %d", err);
+	zassert_equal(cnt, 1U, "Got %zu, expected %u", cnt, 1U);
+}
+
 static ZTEST_F(cap_initiator_test_unicast_group,
 	       test_initiator_unicast_group_foreach_stream_inval_null_group)
 {


### PR DESCRIPTION
The function should stop iterating if the callback provided to bt_cap_unicast_group_foreach_stream returns true.