### PR TITLE
drivers: can: shell: Improve test reliability

### DIFF
--- a/tests/drivers/can/host/pytest/can_shell.py
+++ b/tests/drivers/can/host/pytest/can_shell.py
@@ -111,8 +111,10 @@ class CanShellBus(BusABC): # pylint: disable=abstract-method
         if frame_num is None:
             raise CanOperationError('frame not enqueued')
 
-        tx_regex = r'CAN\s+frame\s+#' + frame_num + r'\s+successfully\s+sent'
-        self._dut.readlines_until(regex=tx_regex, timeout=timeout)
+        regex_compiled = re.compile(r'CAN\s+frame\s+#' + frame_num + r'\s+successfully\s+sent')
+        regex_matched = any(regex_compiled.search(line) for line in lines)
+        if not regex_matched:
+            raise CanOperationError('sending failed')
 
     def _add_filter(self, can_id: int, can_mask: int, extended: bool) -> None:
         """Add RX filter."""

--- a/tests/drivers/can/host/pytest/conftest.py
+++ b/tests/drivers/can/host/pytest/conftest.py
@@ -39,6 +39,7 @@ def fixture_context(request, dut: DeviceAdapter) -> str:
 def fixture_chosen(shell: Shell) -> str:
     """Return the name of the zephyr,canbus devicetree chosen device."""
     chosen_regex = re.compile(r'zephyr,canbus:\s+(\S+)')
+    shell.wait_for_prompt()
     lines = shell.get_filtered_output(shell.exec_command('can_host chosen'))
 
     for line in lines:


### PR DESCRIPTION
The shell command previously reported success or failure asynchronously via a workqueue. However, calling `shell_print` outside the command context can lead to silent message drops if another thread holds the shell lock.

This can cause test failures, as expected shell messages are missing, even though the frame was transmitted successfully.

This PR ensures that the shell command waits for the log message to be transmitted before returning, improving reliability of the can send command. In addition, we wait for a prompt before sending a command.