### PR TITLE
modbus: add prepare callback for modbus server

### DIFF
--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -383,6 +383,11 @@ struct modbus_user_callbacks {
 
 	/** Floating Point Holding Register write callback */
 	int (*holding_reg_wr_fp)(uint16_t addr, float reg);
+
+#if CONFIG_MODBUS_USER_CB_PREPARE
+	/** Prepare register callback */
+	int (*prepare_regs)(uint8_t fc, uint16_t start_addr, uint16_t num_regs);
+#endif
 };
 
 /**

--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -91,6 +91,12 @@ config MODBUS_NONCOMPLIANT_SERIAL_MODE
 	help
 	  Allow non-compliant stop and parity bit settings.
 
+config MODBUS_USER_CB_PREPARE
+	bool "User callback prepare_regs"
+	depends on MODBUS_SERVER
+	help
+	  Enable user callback prepare_regs.
+
 module = MODBUS
 module-str = Modbus Support
 module-help = Sets log level for Modbus support

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -91,6 +91,31 @@ static void mbs_exception_rsp(struct modbus_context *ctx, uint8_t excep_code)
 	ctx->tx_adu.length = 1;
 }
 
+static int mbs_prepare_regs(struct modbus_context *ctx, uint8_t fc, uint16_t addr, uint16_t qty)
+{
+#if CONFIG_MODBUS_USER_CB_PREPARE
+	int err;
+
+	if (ctx->mbs_user_cb->prepare_regs == NULL) {
+		return 0;
+	}
+
+	err = ctx->mbs_user_cb->prepare_regs(fc, addr, qty);
+	if (err != 0) {
+		LOG_INF("register prepare failed for fc: %d", fc);
+		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_ADDR);
+	}
+
+	return err;
+#else
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(fc);
+	ARG_UNUSED(addr);
+	ARG_UNUSED(qty);
+	return 0;
+#endif
+}
+
 /*
  * FC 01 (0x01) Read Coils
  *
@@ -134,6 +159,12 @@ static bool mbs_fc01_coil_read(struct modbus_context *ctx)
 	if (coil_qty == 0 || coil_qty > coils_limit) {
 		LOG_ERR("Number of coils limit exceeded");
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
+		return true;
+	}
+
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC01_COIL_RD, coil_addr, coil_qty);
+	if (err != 0) {
 		return true;
 	}
 
@@ -233,6 +264,12 @@ static bool mbs_fc02_di_read(struct modbus_context *ctx)
 	if (di_qty == 0 || di_qty > di_limit) {
 		LOG_ERR("Number of inputs limit exceeded");
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
+		return true;
+	}
+
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC02_DI_RD, di_addr, di_qty);
+	if (err != 0) {
 		return true;
 	}
 
@@ -353,6 +390,12 @@ static bool mbs_fc03_hreg_read(struct modbus_context *ctx)
 		}
 	}
 
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC03_HOLDING_REG_RD, reg_addr, reg_qty);
+	if (err != 0) {
+		return true;
+	}
+
 	/* Number of data bytes + byte count. */
 	ctx->tx_adu.length = num_bytes + 1;
 	/* Set number of data bytes in response message. */
@@ -463,6 +506,13 @@ static bool mbs_fc04_inreg_read(struct modbus_context *ctx)
 			mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_FC);
 			return true;
 		}
+
+	}
+
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC04_IN_REG_RD, reg_addr, reg_qty);
+	if (err != 0) {
+		return true;
 	}
 
 	/* Number of data bytes + byte count. */
@@ -550,6 +600,12 @@ static bool mbs_fc05_coil_write(struct modbus_context *ctx)
 	coil_addr = sys_get_be16(&ctx->rx_adu.data[0]);
 	coil_val = sys_get_be16(&ctx->rx_adu.data[2]);
 
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC05_COIL_WR, coil_addr, 1);
+	if (err != 0) {
+		return true;
+	}
+
 	/* See if coil needs to be OFF? */
 	if (coil_val == MODBUS_COIL_OFF_CODE) {
 		coil_state = false;
@@ -606,6 +662,12 @@ static bool mbs_fc06_hreg_write(struct modbus_context *ctx)
 
 	reg_addr = sys_get_be16(&ctx->rx_adu.data[0]);
 	reg_val = sys_get_be16(&ctx->rx_adu.data[2]);
+
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC06_HOLDING_REG_WR, reg_addr, 1);
+	if (err != 0) {
+		return true;
+	}
 
 	err = ctx->mbs_user_cb->holding_reg_wr(reg_addr, reg_val);
 
@@ -767,6 +829,12 @@ static bool mbs_fc15_coils_write(struct modbus_context *ctx)
 		return true;
 	}
 
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC15_COILS_WR, coil_addr, coil_qty);
+	if (err != 0) {
+		return true;
+	}
+
 	coil_cntr = 0;
 	/* The 1st coil data byte is 6th element in payload */
 	data_ix = 5;
@@ -883,6 +951,12 @@ static bool mbs_fc16_hregs_write(struct modbus_context *ctx)
 	if ((num_bytes / reg_qty) != sizeof(uint16_t)) {
 		LOG_ERR("Mismatch in the number of registers");
 		mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
+		return true;
+	}
+
+	/* Prepare registers */
+	err = mbs_prepare_regs(ctx, MODBUS_FC16_HOLDING_REGS_WR, reg_addr, reg_qty);
+	if (err != 0) {
 		return true;
 	}
 


### PR DESCRIPTION
We have the requirement to access related registers in an atomic way, as discussed in #73237. 

The user callback 'prepare_regs' provides information about the start address and the number of registers in a Modbus request. It is called once for a Modbus request.

In case of reading or writing multiple registers, the user callbacks (e.g. holding_reg_wr) are called for each single register. The prepare callback provides some context to these callbacks and allows a server implementation to prepare register data or process related registers in an atomic way.