### PR TITLE
serial: uart_native_pty: IRQ support

### DIFF
--- a/boards/native/native_sim/doc/index.rst
+++ b/boards/native/native_sim/doc/index.rst
@@ -564,8 +564,7 @@ program ends, one could do:
 
    $ zephyr.exe --uart_attach_uart_cmd='ln -s %s /tmp/somename' ; rm /tmp/somename
 
-This driver supports poll mode or async mode with :kconfig:option:`CONFIG_UART_ASYNC_API`.
-Interrupt mode is not supported.
+This driver supports poll mode, interrupt mode and async mode.
 Neither runtime configuration or line control are supported.
 
 .. _native_tty_uart:

--- a/drivers/serial/Kconfig.native_pty
+++ b/drivers/serial/Kconfig.native_pty
@@ -7,6 +7,7 @@ config UART_NATIVE_PTY
 	depends on (DT_HAS_ZEPHYR_NATIVE_PTY_UART_ENABLED || DT_HAS_ZEPHYR_NATIVE_POSIX_UART_ENABLED)
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_ASYNC
+	select SERIAL_SUPPORT_INTERRUPT
 	help
 	  This enables a PTY based UART driver for the POSIX ARCH with up to 2 UARTs.
 	  For the first UART port, the driver can be configured

--- a/drivers/serial/uart_native_pty_bottom.c
+++ b/drivers/serial/uart_native_pty_bottom.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <pty.h>
 #include <fcntl.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <unistd.h>
 #include <poll.h>
 #include <nsi_tracing.h>
@@ -38,39 +38,35 @@
  * @retval -1 If no character was available to read
  * @retval -2 if the stdin is disconnected
  */
-int np_uart_stdin_poll_in_bottom(int in_f, unsigned char *p_char, int len)
+int np_uart_stdin_read_bottom(int in_f, unsigned char *p_char, int len)
 {
-	if (feof(stdin)) {
-		/*
-		 * The stdinput is fed from a file which finished or the user
-		 * pressed Ctrl+D
-		 */
-		return -2;
-	}
-
 	int n = -1;
-
 	int ready;
-	fd_set readfds;
-	static struct timeval timeout; /* just zero */
 
-	FD_ZERO(&readfds);
-	FD_SET(in_f, &readfds);
+	struct pollfd fds = {.fd = in_f, .events = POLLIN};
 
-	ready = select(in_f+1, &readfds, NULL, NULL, &timeout);
+	ready = poll(&fds, 1, 0);
 
 	if (ready == 0) {
 		return -1;
 	} else if (ready == -1) {
-		ERROR("%s: Error on select ()\n", __func__);
+		ERROR("%s: Error on poll ()\n", __func__);
+	}
+
+	if (len == 0) {
+		return 0;
 	}
 
 	n = read(in_f, p_char, len);
-	if ((n == -1) || (n == 0)) {
-		return -1;
-	}
 
-	return n;
+	if (n == 0) {
+		/* Attempting to read > 0 but getting 0 characters back
+		 * indicates we reached EOF
+		 */
+		return -2;
+	} else {
+		return n;
+	}
 }
 
 /**

--- a/drivers/serial/uart_native_pty_bottom.h
+++ b/drivers/serial/uart_native_pty_bottom.h
@@ -20,7 +20,7 @@ extern "C" {
 
 /* Note: None of these functions are public interfaces. But internal to the native ptty driver */
 
-int np_uart_stdin_poll_in_bottom(int in_f, unsigned char *p_char, int len);
+int np_uart_stdin_read_bottom(int in_f, unsigned char *p_char, int len);
 int np_uart_slave_connected(int fd);
 int np_uart_open_pty(const char *uart_name, const char *auto_attach_cmd,
 		     bool do_auto_attach, bool wait_pts);

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -41,7 +41,7 @@ config SHELL_PROMPT_UART
 
 config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
 	bool "Interrupt driven"
-	default y
+	default y if !UART_NATIVE_PTY
 	depends on SERIAL_SUPPORT_INTERRUPT
 
 config SHELL_ASYNC_API


### PR DESCRIPTION
Add support for the interrupt-driven API. Interrupts are emulated using a polling thread.

This was merged in a previous version as #93957 but caused problems, see #94425 and reverted in #94426.

The issue stemmed from false RX interrupts being triggered when `select` indicated that data was available to read, but the subsequent read operation failed. In the updated implementation, a dedicated polling thread now feeds incoming data into a ring buffer. Interrupts are no longer triggered directly by select; instead, the ring buffer is used to signal valid RX interrupts, ensuring more reliable and accurate handling.

(Locally) this is now passing `samples/sensor/sensor_shell` and `tests/drivers/can/host`, which previously failed in #94425. 