### PR TITLE
drivers: flexio: Fix build errors when doze not defined

### DIFF
--- a/drivers/misc/mcux_flexio/mcux_flexio.c
+++ b/drivers/misc/mcux_flexio/mcux_flexio.c
@@ -132,7 +132,10 @@ static int mcux_flexio_init(const struct device *dev)
 	k_mutex_init(&data->lock);
 
 	FLEXIO_GetDefaultConfig(&flexio_config);
+#if !(defined(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT) && \
+		(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT == 0))
 	flexio_config.enableInDoze = true;
+#endif
 
 	FLEXIO_Init(config->base, &flexio_config);
 	config->irq_config_func(dev);

--- a/drivers/spi/spi_mcux_flexio.c
+++ b/drivers/spi/spi_mcux_flexio.c
@@ -136,14 +136,20 @@ static void spi_flexio_master_init(FLEXIO_SPI_Type *base, flexio_spi_master_conf
 
 	/* Configure FLEXIO SPI Master */
 	ctrlReg = base->flexioBase->CTRL;
-	ctrlReg &= ~(FLEXIO_CTRL_DOZEN_MASK | FLEXIO_CTRL_DBGE_MASK |
-			FLEXIO_CTRL_FASTACC_MASK | FLEXIO_CTRL_FLEXEN_MASK);
+	ctrlReg &= ~(FLEXIO_CTRL_DBGE_MASK | FLEXIO_CTRL_FASTACC_MASK | FLEXIO_CTRL_FLEXEN_MASK);
+#if !(defined(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT) && \
+		(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT == 0))
+	ctrlReg &= ~FLEXIO_CTRL_DOZEN_MASK;
+#endif
 	ctrlReg |= (FLEXIO_CTRL_DBGE(masterConfig->enableInDebug) |
 		FLEXIO_CTRL_FASTACC(masterConfig->enableFastAccess) |
 		FLEXIO_CTRL_FLEXEN(masterConfig->enableMaster));
+#if !(defined(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT) && \
+		(FSL_FEATURE_FLEXIO_HAS_DOZE_MODE_SUPPORT == 0))
 	if (!masterConfig->enableInDoze) {
 		ctrlReg |= FLEXIO_CTRL_DOZEN_MASK;
 	}
+#endif
 
 	base->flexioBase->CTRL = ctrlReg;
 


### PR DESCRIPTION
some platforms dont have these doze related symbols defined, and causes a build error, fix with #ifdef bandaid.

Fixes #92943