### PR TITLE
dts: nxp_rt118x: Use DT spec names for nodes

### DIFF
--- a/dts/arm/nxp/nxp_rt118x.dtsi
+++ b/dts/arm/nxp/nxp_rt118x.dtsi
@@ -67,7 +67,7 @@
 	 * or nxp_rt118x_cm7.dtsi. The base addresses on cm33 core differ
 	 * between non-secure (0x40000000) and secure modes (0x50000000).
 	 */
-	iomuxc: iomuxc@2A10000 {
+	iomuxc: pinctrl@2A10000 {
 		compatible = "nxp,imx-iomuxc";
 		reg = <0x2A10000 0x4000>;
 		pinctrl: pinctrl {
@@ -76,13 +76,13 @@
 		};
 	};
 
-	iomuxc_aon: iomuxc@43C0000 {
+	iomuxc_aon: pinctrl@43C0000 {
 		compatible = "nxp,mcux-rt-pinctrl";
 		reg = <0x43C0000 0x4000>;
 		status = "okay";
 	};
 
-	ccm: ccm@4450000 {
+	ccm: clock-controller@4450000 {
 		compatible = "nxp,imx-ccm-rev2";
 		reg = <0x4450000 0x4000>;
 		#clock-cells = <3>;
@@ -94,7 +94,7 @@
 		};
 	};
 
-	lpuart1: uart@4380000 {
+	lpuart1: serial@4380000 {
 		compatible = "nxp,lpuart";
 		reg = <0x4380000 0x4000>;
 		interrupts = <19 0>;
@@ -104,7 +104,7 @@
 		status = "disabled";
 	};
 
-	lpuart2: uart@4390000 {
+	lpuart2: serial@4390000 {
 		compatible = "nxp,lpuart";
 		reg = <0x4390000 0x4000>;
 		interrupts = <20 0>;
@@ -114,7 +114,7 @@
 		status = "disabled";
 	};
 
-	lpuart3: uart@2570000 {
+	lpuart3: serial@2570000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2570000 0x4000>;
 		interrupts = <68 0>;
@@ -124,7 +124,7 @@
 		status = "disabled";
 	};
 
-	lpuart4: uart@2580000 {
+	lpuart4: serial@2580000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2580000 0x4000>;
 		interrupts = <69 0>;
@@ -144,7 +144,7 @@
 		status = "disabled";
 	};
 
-	lpuart6: uart@25A0000 {
+	lpuart6: serial@25A0000 {
 		compatible = "nxp,lpuart";
 		reg = <0x25A0000 0x4000>;
 		interrupts = <71 0>;
@@ -154,7 +154,7 @@
 		status = "disabled";
 	};
 
-	lpuart7: uart@4570000 {
+	lpuart7: serial@4570000 {
 		compatible = "nxp,lpuart";
 		reg = <0x4570000 0x4000>;
 		interrupts = <196 0>;
@@ -164,7 +164,7 @@
 		status = "disabled";
 	};
 
-	lpuart8: uart@2DA0000 {
+	lpuart8: serial@2DA0000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2DA0000 0x4000>;
 		interrupts = <197 0>;
@@ -174,7 +174,7 @@
 		status = "disabled";
 	};
 
-	lpuart9: uart@2D70000 {
+	lpuart9: serial@2D70000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2D70000 0x4000>;
 		interrupts = <156 0>;
@@ -184,7 +184,7 @@
 		status = "disabled";
 	};
 
-	lpuart10: uart@2D80000 {
+	lpuart10: serial@2D80000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2D80000 0x4000>;
 		interrupts = <157 0>;
@@ -194,7 +194,7 @@
 		status = "disabled";
 	};
 
-	lpuart11: uart@2D90000 {
+	lpuart11: serial@2D90000 {
 		compatible = "nxp,lpuart";
 		reg = <0x2D90000 0x4000>;
 		interrupts = <158 0>;
@@ -204,7 +204,7 @@
 		status = "disabled";
 	};
 
-	lpuart12: uart@4580000 {
+	lpuart12: serial@4580000 {
 		compatible = "nxp,lpuart";
 		reg = <0x4580000 0x4000>;
 		interrupts = <159 0>;
@@ -328,7 +328,7 @@
 		status = "disabled";
 	};
 
-	gpt1: gpt@46c0000 {
+	gpt1: timer@46c0000 {
 		compatible = "nxp,imx-gpt";
 		reg = <0x46c0000 0x4000>;
 		interrupts = <209 0>;
@@ -337,7 +337,7 @@
 		status = "disabled";
 	};
 
-	gpt2: gpt@2ec0000 {
+	gpt2: timer@2ec0000 {
 		compatible = "nxp,imx-gpt";
 		reg = <0x2ec0000 0x4000>;
 		interrupts = <210 0>;
@@ -345,28 +345,28 @@
 		clocks = <&ccm IMX_CCM_GPT2_CLK 0x41 0>;
 	};
 
-	acmp1: cmp@2dc0000 {
+	acmp1: comparator@2dc0000 {
 		compatible = "nxp,kinetis-acmp";
 		reg = <0x2dc0000 0x4000>;
 		interrupts = <200 0>;
 		status = "disabled";
 	};
 
-	acmp2: cmp@2dd0000 {
+	acmp2: comparator@2dd0000 {
 		compatible = "nxp,kinetis-acmp";
 		reg = <0x2dd0000 0x4000>;
 		interrupts = <201 0>;
 		status = "disabled";
 	};
 
-	acmp3: cmp@2de0000 {
+	acmp3: comparator@2de0000 {
 		compatible = "nxp,kinetis-acmp";
 		reg = <0x2de0000 0x4000>;
 		interrupts = <202 0>;
 		status = "disabled";
 	};
 
-	acmp4: cmp@2df0000 {
+	acmp4: comparator@2df0000 {
 		compatible = "nxp,kinetis-acmp";
 		reg = <0x2df0000 0x4000>;
 		interrupts = <203 0>;
@@ -412,7 +412,7 @@
 			#io-channel-cells = <1>;
 	};
 
-	qtmr1: qtmr@2690000 {
+	qtmr1: timer@2690000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x2690000 0x4000>;
 		interrupts = <0 0>;
@@ -439,7 +439,7 @@
 		};
 	};
 
-	qtmr2: qtmr@26a0000 {
+	qtmr2: timer@26a0000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x26a0000 0x4000>;
 		interrupts = <233 0>;
@@ -466,7 +466,7 @@
 		};
 	};
 
-	qtmr3: qtmr@26b0000 {
+	qtmr3: timer@26b0000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x26b0000 0x4000>;
 		interrupts = <164 0>;
@@ -493,7 +493,7 @@
 		};
 	};
 
-	qtmr4: qtmr@26c0000 {
+	qtmr4: timer@26c0000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x26c0000 0x4000>;
 		interrupts = <151 0>;
@@ -520,7 +520,7 @@
 		};
 	};
 
-	qtmr5: qtmr@26d0000 {
+	qtmr5: timer@26d0000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x26d0000 0x4000>;
 		interrupts = <4 0>;
@@ -547,7 +547,7 @@
 		};
 	};
 
-	qtmr6: qtmr@26e0000 {
+	qtmr6: timer@26e0000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x26e0000 0x4000>;
 		interrupts = <5 0>;
@@ -574,7 +574,7 @@
 		};
 	};
 
-	qtmr7: qtmr@26f0000 {
+	qtmr7: timer@26f0000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x26f0000 0x4000>;
 		interrupts = <6 0>;
@@ -601,7 +601,7 @@
 		};
 	};
 
-	qtmr8: qtmr@2700000 {
+	qtmr8: timer@2700000 {
 		compatible = "nxp,imx-qtmr";
 		reg = <0x2700000 0x4000>;
 		interrupts = <7 0>;
@@ -844,7 +844,7 @@
 	};
 
 
-	lptmr1: lptmr@4300000 {
+	lptmr1: timer@4300000 {
 		compatible = "nxp,lptmr";
 		reg = <0x4300000 0x1000>;
 		interrupts = <18 0>;
@@ -855,7 +855,7 @@
 		status = "disabled";
 	};
 
-	lptmr2: lptmr@24d0000 {
+	lptmr2: timer@24d0000 {
 		compatible = "nxp,lptmr";
 		reg = <0x24d0000 0x1000>;
 		interrupts = <67 0>;
@@ -866,7 +866,7 @@
 		status = "disabled";
 	};
 
-	lptmr3: lptmr@2cd0000 {
+	lptmr3: timer@2cd0000 {
 		compatible = "nxp,lptmr";
 		reg = <0x2cd0000 0x1000>;
 		interrupts = <150 0>;
@@ -893,7 +893,7 @@
 		status = "disabled";
 	};
 
-	flexpwm1: flexpwm@2650000 {
+	flexpwm1: pwm@2650000 {
 		compatible = "nxp,flexpwm";
 		reg = <0x2650000 0x4000>;
 		interrupts = <23 0>;
@@ -939,7 +939,7 @@
 		};
 	};
 
-	flexpwm2: flexpwm@2660000 {
+	flexpwm2: pwm@2660000 {
 		compatible = "nxp,flexpwm";
 		reg = <0x2660000 0x4000>;
 		interrupts =  <170 0>;
@@ -985,7 +985,7 @@
 		};
 	};
 
-	flexpwm3: flexpwm@2670000 {
+	flexpwm3: pwm@2670000 {
 		compatible = "nxp,flexpwm";
 		reg = <0x2670000 0x4000>;
 		interrupts =  <175 0>;
@@ -1031,7 +1031,7 @@
 		};
 	};
 
-	flexpwm4: flexpwm@2680000 {
+	flexpwm4: pwm@2680000 {
 		compatible = "nxp,flexpwm";
 		reg = <0x2680000 0x4000>;
 		interrupts = <180 0>;
@@ -1163,7 +1163,7 @@
 		#size-cells = <0>;
 	};
 
-	usdhc1: usdhc@2850000 {
+	usdhc1: memory-controller@2850000 {
 		compatible = "nxp,imx-usdhc";
 		reg = <0x2850000 0x4000>;
 		status = "disabled";
@@ -1175,7 +1175,7 @@
 		min-bus-freq = <400000>;
 	};
 
-	usdhc2: usdhc@2860000 {
+	usdhc2: memory-controller@2860000 {
 		compatible = "nxp,imx-usdhc";
 		reg = <0x2860000 0x4000>;
 		status = "disabled";
@@ -1323,7 +1323,7 @@
 		clk-divider = <1>;
 	};
 
-	rtwdog1: wdog@42e0000 {
+	rtwdog1: watchdog@42e0000 {
 		compatible = "nxp,rtwdog";
 		reg = <0x42e0000 0x10>;
 		status = "disabled";
@@ -1333,7 +1333,7 @@
 		clk-divider = <1>;
 	};
 
-	rtwdog2: wdog@2490000 {
+	rtwdog2: watchdog@2490000 {
 		compatible = "nxp,rtwdog";
 		reg = <0x2490000 0x10>;
 		status = "disabled";
@@ -1353,7 +1353,7 @@
 		clk-divider = <1>;
 	};
 
-	rtwdog4: wdog@24b0000 {
+	rtwdog4: watchdog@24b0000 {
 		compatible = "nxp,rtwdog";
 		reg = <0x24b0000 0x10>;
 		status = "disabled";
@@ -1373,7 +1373,7 @@
 		status = "disabled";
 	};
 
-	usb2: usbd@2c90000 {
+	usb2: usb@2c90000 {
 		compatible = "nxp,ehci";
 		reg = <0x2c90000 0x1000>;
 		interrupts = <214 0>;
@@ -1383,13 +1383,13 @@
 		status = "disabled";
 	};
 
-	usbphy1: usbphy@2ca0000 {
+	usbphy1: usb-phy@2ca0000 {
 		compatible = "nxp,usbphy";
 		reg = <0x2ca0000 0x1000>;
 		status = "disabled";
 	};
 
-	usbphy2: usbphy@2cb0000 {
+	usbphy2: usb-phy@2cb0000 {
 		compatible = "nxp,usbphy";
 		reg = <0x2cb0000 0x1000>;
 		status = "disabled";
@@ -1417,14 +1417,14 @@
 &memory {
 	#address-cells = <1>;
 	#size-cells = <1>;
-	ocram1: ocram@0 {
+	ocram1: memory@0 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "OCRAM1";
 		/* OCRAM1 first 16K access is blocked by TRDC */
 		reg = <0x0 DT_SIZE_K(496)>;
 	};
 
-	ocram2: ocram@7c000 {
+	ocram2: memory@7c000 {
 		compatible = "zephyr,memory-region", "mmio-sram";
 		zephyr,memory-region = "OCRAM2";
 		reg = <0x7c000 DT_SIZE_K(256)>;

--- a/dts/arm/nxp/nxp_rt118x_cm33.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm33.dtsi
@@ -10,13 +10,13 @@
 
 / {
 	soc {
-		itcm: itcm@1ffe0000 {
+		itcm: memory@1ffe0000 {
 			compatible = "zephyr,memory-region", "nxp,imx-itcm";
 			reg = <0x1ffe0000 DT_SIZE_K(128)>;
 			zephyr,memory-region = "ITCM";
 		};
 
-		dtcm: dtcm@30000000 {
+		dtcm: memory@30000000 {
 			compatible = "zephyr,memory-region", "nxp,imx-dtcm";
 			reg = <0x30000000 DT_SIZE_K(128)>;
 			zephyr,memory-region = "DTCM";
@@ -26,7 +26,7 @@
 			ranges = <0x0 0x30484000 0x10000000>;
 		};
 
-		m7_itcm: itcm@303c0000 {
+		m7_itcm: memory@303c0000 {
 			compatible = "zephyr,memory-region", "mmio-sram";
 			zephyr,memory-region = "M7_ITCM";
 			reg = <0x303c0000 DT_SIZE_K(256)>;
@@ -36,11 +36,11 @@
 			ranges = <0x0 0x50000000 0x10000000>;
 		};
 
-		flexspi: spi@525e0000 {
+		flexspi: memory-controller@525e0000 {
 			reg = <0x525e0000 0x4000>, <0x38000000 DT_SIZE_M(128)>;
 		};
 
-		flexspi2: spi@545e0000 {
+		flexspi2: memory-controller@545e0000 {
 			reg = <0x545e0000 0x4000>, <0x14000000 DT_SIZE_M(64)>;
 		};
 	};

--- a/dts/arm/nxp/nxp_rt118x_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt118x_cm7.dtsi
@@ -9,13 +9,13 @@
 
 / {
 	soc {
-		itcm: itcm@0{
+		itcm: memory@0{
 			compatible = "zephyr,memory-region", "nxp,imx-itcm";
 			reg = <0x00000000 DT_SIZE_K(256)>;
 			zephyr,memory-region = "ITCM";
 		};
 
-		dtcm: dtcm@20000000 {
+		dtcm: memory@20000000 {
 			compatible = "zephyr,memory-region", "nxp,imx-dtcm";
 			reg = <0x20000000 DT_SIZE_K(256)>;
 			zephyr,memory-region = "DTCM";
@@ -29,11 +29,11 @@
 			ranges = <0x0 0x40000000 0x10000000>;
 		};
 
-		flexspi: spi@425e0000 {
+		flexspi: memory-controller@425e0000 {
 			reg = <0x425e0000 0x4000>, <0x28000000 DT_SIZE_M(128)>;
 		};
 
-		flexspi2: spi@445e0000 {
+		flexspi2: memory-controller@445e0000 {
 			reg = <0x445e0000 0x4000>, <0x04000000 DT_SIZE_M(64)>;
 		};
 	};


### PR DESCRIPTION
Use recommended node names from the DT spec on RT118x