### PR TITLE
soc: mcx: Add mcx cmc hwinfo binding

### DIFF
--- a/drivers/hwinfo/Kconfig.mcux_mcx_cmc
+++ b/drivers/hwinfo/Kconfig.mcux_mcx_cmc
@@ -4,7 +4,7 @@
 config HWINFO_MCUX_MCX_CMC
 	bool "NXP MCX CMC reset cause"
 	default y
-	depends on HAS_MCUX_MCX_CMC
+	depends on DT_HAS_NXP_CMC_RESET_CAUSE_ENABLED
 	select HWINFO_HAS_DRIVER
 	help
 	  Enable NXP kinetis mcux CMC hwinfo driver.

--- a/dts/arm/nxp/nxp_mcxa153.dtsi
+++ b/dts/arm/nxp/nxp_mcxa153.dtsi
@@ -29,6 +29,10 @@
 		status = "okay";
 	};
 
+	cmc {
+		compatible = "nxp,cmc-reset-cause";
+	};
+
 	soc {
 		ctimer0: ctimer@40004000 {
 			compatible = "nxp,lpc-ctimer";

--- a/dts/arm/nxp/nxp_mcxa156.dtsi
+++ b/dts/arm/nxp/nxp_mcxa156.dtsi
@@ -29,6 +29,10 @@
 		status = "okay";
 	};
 
+	cmc {
+		compatible = "nxp,cmc-reset-cause";
+	};
+
 	soc {
 		syscon: syscon@40000000 {
 			compatible = "nxp,lpc-syscon";

--- a/dts/arm/nxp/nxp_mcxa266.dtsi
+++ b/dts/arm/nxp/nxp_mcxa266.dtsi
@@ -23,6 +23,10 @@
 		};
 	};
 
+	cmc {
+		compatible = "nxp,cmc-reset-cause";
+	};
+
 	/* Dummy pinctrl node, filled with pin mux options at board level */
 	pinctrl: pinctrl {
 		compatible = "nxp,port-pinctrl";

--- a/dts/arm/nxp/nxp_mcxa346.dtsi
+++ b/dts/arm/nxp/nxp_mcxa346.dtsi
@@ -29,6 +29,10 @@
 		status = "okay";
 	};
 
+	cmc {
+		compatible = "nxp,cmc-reset-cause";
+	};
+
 	soc {
 		syscon: syscon@40091000 {
 			compatible = "nxp,lpc-syscon";

--- a/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxnx4x_common.dtsi
@@ -34,6 +34,10 @@
 		};
 	};
 
+	cmc {
+		compatible = "nxp,cmc-reset-cause";
+	};
+
 	/* Dummy pinctrl node, filled with pin mux options at board level */
 	pinctrl: pinctrl {
 		compatible = "nxp,port-pinctrl";

--- a/dts/bindings/hwinfo/nxp,cmc-reset-cause.yaml
+++ b/dts/bindings/hwinfo/nxp,cmc-reset-cause.yaml
@@ -1,0 +1,6 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: CMC reset causes
+
+compatible: "nxp,cmc-reset-cause"

--- a/modules/hal_nxp/mcux/Kconfig.mcux
+++ b/modules/hal_nxp/mcux/Kconfig.mcux
@@ -52,12 +52,6 @@ config HAS_MCUX_RCM
 	  Set if the Reset Control Module (RCM) module is present in
 	  the SoC.
 
-config HAS_MCUX_MCX_CMC
-	bool
-	help
-	  Set if the Core Mode Controller (CMC) module is present in
-	  the SoC.
-
 config HAS_MCUX_XCACHE
 	bool
 	help

--- a/soc/nxp/mcx/mcxa/Kconfig
+++ b/soc/nxp/mcx/mcxa/Kconfig
@@ -13,14 +13,12 @@ config SOC_FAMILY_MCXA
 config SOC_MCXA153
 	select CPU_CORTEX_M33
 	select HAS_MCUX_CACHE
-	select HAS_MCUX_MCX_CMC
 
 config SOC_MCXA156
 	select CPU_CORTEX_M33
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
-	select HAS_MCUX_MCX_CMC
 
 config SOC_MCXA346
 	select CPU_CORTEX_M33
@@ -28,7 +26,6 @@ config SOC_MCXA346
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
-	select HAS_MCUX_MCX_CMC
 
 config SOC_MCXA266
 	select CPU_CORTEX_M33
@@ -36,4 +33,3 @@ config SOC_MCXA266
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
 	select HAS_MCUX_CACHE
-	select HAS_MCUX_MCX_CMC

--- a/soc/nxp/mcx/mcxn/Kconfig
+++ b/soc/nxp/mcx/mcxn/Kconfig
@@ -8,7 +8,6 @@ config SOC_FAMILY_MCXN
 	select HAS_MCUX
 	select CPU_CORTEX_M_HAS_SYSTICK
 	select CPU_CORTEX_M_HAS_DWT
-	select HAS_MCUX_MCX_CMC
 
 config SOC_MCXN947_CPU0
 	select CPU_CORTEX_M33


### PR DESCRIPTION
Add a binding for doc purposes. Terrible coupling when we have to configure DT in order to generate documentation properly. At least we get rid of one of the HAS_MCUX_ kconfigs in the process.