### PR TITLE
Support the S32DS 3.6 for NXP DebugProbe

### DIFF
--- a/doc/develop/flash_debug/host-tools.rst
+++ b/doc/develop/flash_debug/host-tools.rst
@@ -462,13 +462,13 @@ the runner on each invocation via ``--s32ds-path`` as shown below:
 
       .. code-block:: console
 
-         west debug --s32ds-path=/opt/NXP/S32DS.3.5
+         west debug --s32ds-path=/opt/NXP/S32DS.3.6
 
    .. group-tab:: Windows
 
       .. code-block:: console
 
-         west debug --s32ds-path=C:\NXP\S32DS.3.5
+         west debug --s32ds-path=C:\NXP\S32DS.3.6
 
 If multiple S32 debug probes are connected to the host via USB, the runner will
 ask the user to select one via command line prompt before continuing. The
@@ -490,6 +490,18 @@ afterwards detach the debug session:
 .. code-block:: console
 
    west debug --tool-opt='--batch'
+
+Requirements
+------------
+
+- **S32 Design Studio version**: 3.6.0 or newer.
+- **S32DebugProbe OS (firmware)**: 1.1.0 or newer.
+
+S32 Debug Probe OS Upgrade Procedure
+------------------------------------
+
+Refer to the “Reprogramming S32 Debug Probe Firmware Images” chapter
+in the `S32 Debug Probe User Guide`_ to upgrade the OS of the S32DebugProbe.
 
 .. _runner_probe_rs:
 
@@ -687,6 +699,9 @@ For more about the UF2 format and its tooling, see `USB Flashing Format (UF2)`_.
 
 .. _S32 Design Studio for S32 Platform Installation User Guide:
    https://www.nxp.com/webapp/Download?colCode=S32DSIG
+
+.. _S32 Debug Probe User Guide:
+   https://www.nxp.com/docs/en/user-guide/S32DBGUG.pdf
 
 .. _probe-rs Installation:
    https://probe.rs/docs/getting-started/installation/

--- a/scripts/west_commands/runners/nxp_s32dbg.py
+++ b/scripts/west_commands/runners/nxp_s32dbg.py
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023, 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 """
 Runner for NXP S32 Debug Probe.
@@ -17,10 +17,8 @@ from pathlib import Path
 
 from runners.core import BuildConfiguration, RunnerCaps, RunnerConfig, ZephyrBinaryRunner
 
-NXP_S32DBG_USB_CLASS = 'NXP Probes'
-NXP_S32DBG_USB_VID = 0x15a2
-NXP_S32DBG_USB_PID = 0x0067
-
+NXP_S32DBG_USB_VID = 0x1FC9
+NXP_S32DBG_USB_PID = 0x014D
 
 @dataclass
 class NXPS32DebugProbeConfig:
@@ -133,8 +131,10 @@ class NXPS32DebugProbeRunner(ZephyrBinaryRunner):
         # require priviledged permissions to access the device info
         macaddr_pattern = r'(?:[0-9a-f]{2}[:]){5}[0-9a-f]{2}'
         if platform.system() == 'Windows':
-            cmd = f'pnputil /enum-devices /connected /class "{NXP_S32DBG_USB_CLASS}"'
-            serialid_pattern = f'instance id: +usb\\\\.*\\\\({macaddr_pattern})'
+            cmd = 'pnputil /enum-devices /connected'
+            serialid_pattern = 'instance id: +usb\\\\' \
+                               f'VID_{NXP_S32DBG_USB_VID:04X}&PID_{NXP_S32DBG_USB_PID:04X}\\\\' \
+                               f'({macaddr_pattern})'.lower()
         else:
             cmd = f'lsusb -v -d {NXP_S32DBG_USB_VID:x}:{NXP_S32DBG_USB_PID:x}'
             serialid_pattern = f'iserial +.*({macaddr_pattern})'
@@ -192,10 +192,11 @@ class NXPS32DebugProbeRunner(ZephyrBinaryRunner):
         """Execution environment used for the client process."""
         if platform.system() == 'Windows':
             python_lib = (self.s32ds_path / 'S32DS' / 'build_tools' / 'msys32'
-                        / 'mingw32' / 'lib' / 'python2.7')
+                / 'mingw64' / 'lib' / 'python3.10')
             return {
                 **os.environ,
-                'PYTHONPATH': f'{python_lib}{os.pathsep}{python_lib / "site-packages"}'
+                'PYTHONPATH': f'{python_lib}{os.pathsep}{python_lib / "site-packages"}{os.pathsep}'
+                              f'{python_lib / "lib-dynload"}'
             }
 
         return None

--- a/scripts/west_commands/tests/test_nxp_s32dbg.py
+++ b/scripts/west_commands/tests/test_nxp_s32dbg.py
@@ -1,4 +1,4 @@
-# Copyright 2023 NXP
+# Copyright 2023, 2025 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
@@ -27,9 +27,10 @@ TEST_S32DS_CMD = 's32ds'
 TEST_SERVER_CMD = Path('S32DS') / 'tools' / 'S32Debugger' / 'Debugger' / 'Server' / 'gta' / 'gta'
 TEST_ARM_GDB_CMD = Path('S32DS') / 'tools' / 'gdb-arm' / 'arm32-eabi' / 'bin' / 'arm-none-eabi-gdb-py'
 
-TEST_S32DS_PYTHON_LIB = Path('S32DS') / 'build_tools' / 'msys32' / 'mingw32' / 'lib' / 'python2.7'
+TEST_S32DS_PYTHON_LIB = Path('S32DS') / 'build_tools' / 'msys32' / 'mingw64' / 'lib' / 'python3.10'
 TEST_S32DS_RUNTIME_ENV = {
-    'PYTHONPATH': f'{TEST_S32DS_PYTHON_LIB}{os.pathsep}{TEST_S32DS_PYTHON_LIB / "site-packages"}'
+    'PYTHONPATH': f'{TEST_S32DS_PYTHON_LIB}{os.pathsep}{TEST_S32DS_PYTHON_LIB / "site-packages"}{os.pathsep}'
+                  f'{TEST_S32DS_PYTHON_LIB / "lib-dynload"}'
 }
 
 TEST_ALL_KWARGS = {


### PR DESCRIPTION
This pull request support the S32DS 3.6 for NXP DebugProbe:

- S32DS3.6 requires to use python 3.10, so update PYTHONPATH for S32DS3.6 when debug on windows.
- Update to verify new behavior of supported commands with S32D3.6 on windows.

- Update to find out the usb device connected by VID and PID instead of class "NXP Probes" on windows.
- Update the VID and PID values based on new S32 Debug probe OS version.

- Document the S32DS and S32Debug Probe OS supported version, and guide to upgrade the OS of the S32DebugProbe.