### PR TITLE
soc: stm32u5x: Add break in switch to avoid wrong debug message

### DIFF
--- a/soc/st/stm32/stm32u5x/power.c
+++ b/soc/st/stm32/stm32u5x/power.c
@@ -128,9 +128,11 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 			LOG_DBG("Unsupported power substate-id %u",
 							substate_id);
 		}
+		break;
 	case PM_STATE_STANDBY:
 		/* To be tested */
 		LL_LPM_EnableSleep();
+		break;
 	case PM_STATE_SUSPEND_TO_RAM:
 		__fallthrough;
 	case PM_STATE_SUSPEND_TO_DISK:


### PR DESCRIPTION
Add break in switch case to avoid the debug message when SOC_LOG_LEVEL has been set to debug.