### PR TITLE
bluetooth: host: Combine main and sub mode CS step options

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -52,6 +52,12 @@ Stepper
 Bluetooth
 *********
 
+* :c:struct:`bt_le_cs_test_param` and :c:struct:`bt_le_cs_create_config_params` now require
+  providing both the main and sub mode as a single parameter.
+* :c:struct:`bt_conn_le_cs_config` now reports both the main and sub mode as a single parameter.
+* :c:struct:`bt_conn_le_cs_main_mode` and :c:struct:`bt_conn_le_cs_sub_mode` have been replaced
+  with :c:struct:`bt_conn_le_cs_mode`.
+
 .. zephyr-keep-sorted-start re(^\w)
 
 Bluetooth Audio

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -519,26 +519,26 @@ struct bt_conn_le_cs_fae_table {
 	int8_t *remote_fae_table;
 };
 
-/** Channel sounding main mode */
-enum bt_conn_le_cs_main_mode {
-	/** Mode-1 (RTT) */
-	BT_CONN_LE_CS_MAIN_MODE_1 = BT_HCI_OP_LE_CS_MAIN_MODE_1,
-	/** Mode-2 (PBR) */
-	BT_CONN_LE_CS_MAIN_MODE_2 = BT_HCI_OP_LE_CS_MAIN_MODE_2,
-	/** Mode-3 (RTT and PBR) */
-	BT_CONN_LE_CS_MAIN_MODE_3 = BT_HCI_OP_LE_CS_MAIN_MODE_3,
-};
+#define BT_CONN_LE_CS_MODE_MAIN_MODE_PART(x) ((x) & 0x3)
+#define BT_CONN_LE_CS_MODE_SUB_MODE_PART(x)  (((x) >> 4) & 0x3)
 
-/** Channel sounding sub mode */
-enum bt_conn_le_cs_sub_mode {
-	/** Unused */
-	BT_CONN_LE_CS_SUB_MODE_UNUSED = BT_HCI_OP_LE_CS_SUB_MODE_UNUSED,
-	/** Mode-1 (RTT) */
-	BT_CONN_LE_CS_SUB_MODE_1 = BT_HCI_OP_LE_CS_SUB_MODE_1,
-	/** Mode-2 (PBR) */
-	BT_CONN_LE_CS_SUB_MODE_2 = BT_HCI_OP_LE_CS_SUB_MODE_2,
-	/** Mode-3 (RTT and PBR) */
-	BT_CONN_LE_CS_SUB_MODE_3 = BT_HCI_OP_LE_CS_SUB_MODE_3,
+/** Channel sounding main and sub mode */
+enum bt_conn_le_cs_mode {
+	/** Mode-1 (RTT) Main Mode, Unused Sub Mode */
+	BT_CONN_LE_CS_MAIN_MODE_1_NO_SUB_MODE = BT_HCI_OP_LE_CS_MAIN_MODE_1,
+	/** Mode-2 (PBR) Main Mode, Unused Sub Mode */
+	BT_CONN_LE_CS_MAIN_MODE_2_NO_SUB_MODE = BT_HCI_OP_LE_CS_MAIN_MODE_2,
+	/** Mode-3 (RTT and PBR) Main Mode, Unused Sub Mode */
+	BT_CONN_LE_CS_MAIN_MODE_3_NO_SUB_MODE = BT_HCI_OP_LE_CS_MAIN_MODE_3,
+	/** Mode-2 (PBR) Main Mode, Mode-1 (RTT) Sub Mode */
+	BT_CONN_LE_CS_MAIN_MODE_2_SUB_MODE_1 = BT_HCI_OP_LE_CS_MAIN_MODE_2 |
+					      (BT_HCI_OP_LE_CS_SUB_MODE_1 << 4),
+	/** Mode-2 (PBR) Main Mode, Mode-3 (RTT and PBR) Sub Mode */
+	BT_CONN_LE_CS_MAIN_MODE_2_SUB_MODE_3 = BT_HCI_OP_LE_CS_MAIN_MODE_2 |
+					      (BT_HCI_OP_LE_CS_SUB_MODE_3 << 4),
+	/** Mode-3 (RTT and PBR) Main Mode, Mode-2 (PBR) Sub Mode  */
+	BT_CONN_LE_CS_MAIN_MODE_3_SUB_MODE_2 = BT_HCI_OP_LE_CS_MAIN_MODE_3 |
+					      (BT_HCI_OP_LE_CS_SUB_MODE_2 << 4),
 };
 
 /** Channel sounding role */
@@ -597,10 +597,8 @@ enum bt_conn_le_cs_ch3c_shape {
 struct bt_conn_le_cs_config {
 	/** CS configuration ID */
 	uint8_t id;
-	/** Main CS mode type */
-	enum bt_conn_le_cs_main_mode main_mode_type;
-	/** Sub CS mode type */
-	enum bt_conn_le_cs_sub_mode sub_mode_type;
+	/** CS main and sub mode */
+	enum bt_conn_le_cs_mode mode;
 	/** Minimum number of CS main mode steps to be executed before a submode step is executed */
 	uint8_t min_main_mode_steps;
 	/** Maximum number of CS main mode steps to be executed before a submode step is executed */

--- a/include/zephyr/bluetooth/cs.h
+++ b/include/zephyr/bluetooth/cs.h
@@ -246,30 +246,8 @@ enum bt_le_cs_test_override_8_cs_sync_payload_pattern {
 
 /** CS Test parameters */
 struct bt_le_cs_test_param {
-	/** CS mode to be used during the CS procedure. */
-	enum bt_conn_le_cs_main_mode main_mode;
-	/** CS sub-mode to be used during the CS procedure.
-	 *
-	 * Main_Mode and Sub_Mode combinations shall be selected from
-	 * the valid combinations defined below:
-	 *
-	 * +-----------+----------+
-	 * | Main_Mode | Sub_Mode |
-	 * +-----------+----------+
-	 * | Mode-1    | None     |
-	 * +-----------+----------+
-	 * | Mode-2    | None     |
-	 * +-----------+----------+
-	 * | Mode-3    | None     |
-	 * +-----------+----------+
-	 * | Mode-2    | Mode-1   |
-	 * +-----------+----------+
-	 * | Mode-2    | Mode-3   |
-	 * +-----------+----------+
-	 * | Mode-3    | Mode-2   |
-	 * +-----------+----------+
-	 */
-	enum bt_conn_le_cs_sub_mode sub_mode;
+	/** CS main and sub mode to be used during the CS procedure. */
+	enum bt_conn_le_cs_mode mode;
 	/** Number of main mode steps taken from the end of the last CS subevent
 	 * to be repeated at the beginning of the current CS subevent directly
 	 * after the last mode-0 step of that event.
@@ -501,30 +479,8 @@ enum bt_le_cs_create_config_context {
 struct bt_le_cs_create_config_params {
 	/** CS configuration ID */
 	uint8_t id;
-	/** Main CS mode type */
-	enum bt_conn_le_cs_main_mode main_mode_type;
-	/** Sub CS mode type
-	 *
-	 * Main_Mode and Sub_Mode combinations shall be selected from
-	 * the valid combinations defined below:
-	 *
-	 * +-----------+----------+
-	 * | Main_Mode | Sub_Mode |
-	 * +-----------+----------+
-	 * | Mode-1    | None     |
-	 * +-----------+----------+
-	 * | Mode-2    | None     |
-	 * +-----------+----------+
-	 * | Mode-3    | None     |
-	 * +-----------+----------+
-	 * | Mode-2    | Mode-1   |
-	 * +-----------+----------+
-	 * | Mode-2    | Mode-3   |
-	 * +-----------+----------+
-	 * | Mode-3    | Mode-2   |
-	 * +-----------+----------+
-	 */
-	enum bt_conn_le_cs_sub_mode sub_mode_type;
+	/** Main and sub CS mode */
+	enum bt_conn_le_cs_mode mode;
 	/** Minimum number of CS main mode steps to be executed before a submode step is executed */
 	uint8_t min_main_mode_steps;
 	/** Maximum number of CS main mode steps to be executed before a submode step is executed */

--- a/samples/bluetooth/channel_sounding/include/cs_test_params.h
+++ b/samples/bluetooth/channel_sounding/include/cs_test_params.h
@@ -15,8 +15,7 @@ static struct bt_le_cs_test_param test_params_get(enum bt_conn_le_cs_role role)
 	struct bt_le_cs_test_param params;
 
 	params.role = role;
-	params.main_mode = BT_CONN_LE_CS_MAIN_MODE_2;
-	params.sub_mode = BT_CONN_LE_CS_SUB_MODE_1;
+	params.mode = BT_CONN_LE_CS_MAIN_MODE_2_SUB_MODE_1;
 	params.main_mode_repetition = 1;
 	params.mode_0_steps = NUM_MODE_0_STEPS;
 	params.rtt_type = BT_CONN_LE_CS_RTT_TYPE_AA_ONLY;

--- a/samples/bluetooth/channel_sounding/src/connected_cs_initiator.c
+++ b/samples/bluetooth/channel_sounding/src/connected_cs_initiator.c
@@ -309,8 +309,7 @@ int main(void)
 
 	struct bt_le_cs_create_config_params config_params = {
 		.id = CS_CONFIG_ID,
-		.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_2,
-		.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_1,
+		.mode = BT_CONN_LE_CS_MAIN_MODE_2_SUB_MODE_1,
 		.min_main_mode_steps = 2,
 		.max_main_mode_steps = 10,
 		.main_mode_repetition = 0,

--- a/samples/bluetooth/channel_sounding/src/distance_estimation.c
+++ b/samples/bluetooth/channel_sounding/src/distance_estimation.c
@@ -172,7 +172,7 @@ static bool process_step_data(struct bt_le_cs_subevent_step *step, void *user_da
 {
 	struct processing_context *context = (struct processing_context *)user_data;
 
-	if (step->mode == BT_CONN_LE_CS_MAIN_MODE_2) {
+	if (step->mode == BT_HCI_OP_LE_CS_MAIN_MODE_2) {
 		struct bt_hci_le_cs_step_data_mode_2 *step_data =
 			(struct bt_hci_le_cs_step_data_mode_2 *)step->data;
 

--- a/subsys/bluetooth/host/shell/bt.c
+++ b/subsys/bluetooth/host/shell/bt.c
@@ -1175,10 +1175,12 @@ static void le_cs_config_created(struct bt_conn *conn,
 	const char *chsel_type_str[3] = {"Algorithm #3b", "Algorithm #3c", "Invalid"};
 	const char *ch3c_shape_str[3] = {"Hat shape", "X shape", "Invalid"};
 
-	uint8_t main_mode_idx = config->main_mode_type > 0 && config->main_mode_type < 4
-					? config->main_mode_type
+	uint8_t main_mode_type = BT_CONN_LE_CS_MODE_MAIN_MODE_PART(config->mode);
+	uint8_t sub_mode_type = BT_CONN_LE_CS_MODE_SUB_MODE_PART(config->mode);
+	uint8_t main_mode_idx = main_mode_type > 0 && main_mode_type < 4
+					? main_mode_type
 					: 4;
-	uint8_t sub_mode_idx = config->sub_mode_type < 4 ? config->sub_mode_type : 0;
+	uint8_t sub_mode_idx = sub_mode_type;
 	uint8_t role_idx = MIN(config->role, 2);
 	uint8_t rtt_type_idx = MIN(config->rtt_type, 7);
 	uint8_t phy_idx =

--- a/subsys/bluetooth/host/shell/cs.c
+++ b/subsys/bluetooth/host/shell/cs.c
@@ -192,8 +192,7 @@ static int cmd_cs_test_simple(const struct shell *sh, size_t argc, char *argv[])
 	int err = 0;
 	struct bt_le_cs_test_param params;
 
-	params.main_mode = BT_CONN_LE_CS_MAIN_MODE_1;
-	params.sub_mode = BT_CONN_LE_CS_SUB_MODE_UNUSED;
+	params.mode = BT_CONN_LE_CS_MAIN_MODE_1_NO_SUB_MODE;
 	params.main_mode_repetition = 0;
 	params.mode_0_steps = 2;
 
@@ -313,8 +312,7 @@ static int cmd_create_config(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	/* Set the default values */
-	params.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_2;
-	params.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_1;
+	params.mode = BT_CONN_LE_CS_MAIN_MODE_2_SUB_MODE_1;
 	params.min_main_mode_steps = 0x05;
 	params.max_main_mode_steps = 0x0A;
 	params.main_mode_repetition = 0;
@@ -330,23 +328,17 @@ static int cmd_create_config(const struct shell *sh, size_t argc, char *argv[])
 
 	for (int j = 4; j < argc; j++) {
 		if (!strcmp(argv[j], "rtt-none")) {
-			params.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_1;
-			params.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_UNUSED;
+			params.mode = BT_CONN_LE_CS_MAIN_MODE_1_NO_SUB_MODE;
 		} else if (!strcmp(argv[j], "pbr-none")) {
-			params.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_2;
-			params.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_UNUSED;
+			params.mode = BT_CONN_LE_CS_MAIN_MODE_2_NO_SUB_MODE;
 		} else if (!strcmp(argv[j], "both-none")) {
-			params.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_3;
-			params.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_UNUSED;
+			params.mode = BT_CONN_LE_CS_MAIN_MODE_3_NO_SUB_MODE;
 		} else if (!strcmp(argv[j], "pbr-rtt")) {
-			params.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_2;
-			params.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_1;
+			params.mode = BT_CONN_LE_CS_MAIN_MODE_2_SUB_MODE_1;
 		} else if (!strcmp(argv[j], "pbr-both")) {
-			params.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_2;
-			params.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_3;
+			params.mode = BT_CONN_LE_CS_MAIN_MODE_2_SUB_MODE_3;
 		} else if (!strcmp(argv[j], "both-pbr")) {
-			params.main_mode_type = BT_CONN_LE_CS_MAIN_MODE_3;
-			params.sub_mode_type = BT_CONN_LE_CS_SUB_MODE_2;
+			params.mode = BT_CONN_LE_CS_MAIN_MODE_3_SUB_MODE_2;
 		} else if (!strcmp(argv[j], "steps")) {
 			if (++j == argc) {
 				shell_help(sh);


### PR DESCRIPTION
Not all combinations of main mode and sub mode are valid, so to make it harder to select incorrect parameters, the main mode and sub mode enums are combined into one.

Now the user chooses any valid option in enum bt_conn_le_cs_mode.