### PR TITLE
boards: st: nucleo_n657x0_q: correct led polarity

### DIFF
--- a/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
+++ b/boards/st/nucleo_n657x0_q/nucleo_n657x0_q_common.dtsi
@@ -23,17 +23,17 @@
 		compatible = "gpio-leds";
 
 		green_led: led_1 {
-			gpios = <&gpiog 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiog 0 GPIO_ACTIVE_LOW>;
 			label = "User LD6";
 		};
 
 		blue_led: led_2 {
-			gpios = <&gpiog 8 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiog 8 GPIO_ACTIVE_LOW>;
 			label = "User LD7";
 		};
 
 		red_led: led_3 {
-			gpios = <&gpiog 10 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiog 10 GPIO_ACTIVE_LOW>;
 			label = "User LD5";
 		};
 	};


### PR DESCRIPTION
As is apparent on the nucleo-n657x0-q schematics[1], all of the three user leds are controlled via. active low gpios.

Correct the polarity of the leds.

[1] https://www.st.com/resource/en/schematic_pack/mb1940-n657x0q-c02-schematic.pdf