### PR TITLE
drivers: bluetooth: Align bt_hci_send behavior on error

### DIFF
--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -353,10 +353,13 @@ static int bt_apollo_send(const struct device *dev, struct net_buf *buf)
 
 	/* Send the SPI packet */
 	ret = spi_send_packet(buf->data, buf->len);
+	if (ret != 0) {
+		return ret;
+	}
 
 	net_buf_unref(buf);
 
-	return ret;
+	return 0;
 }
 
 static int bt_apollo_open(const struct device *dev, bt_hci_recv_t recv)

--- a/drivers/bluetooth/hci/hci_esp32.c
+++ b/drivers/bluetooth/hci/hci_esp32.c
@@ -253,7 +253,10 @@ static int bt_esp32_send(const struct device *dev, struct net_buf *buf)
 		err = -ETIMEDOUT;
 	}
 
-	net_buf_unref(buf);
+	if (!err) {
+		net_buf_unref(buf);
+	}
+
 	k_sem_give(&hci_send_sem);
 
 	return err;

--- a/drivers/bluetooth/hci/hci_ifx_cyw208xx.c
+++ b/drivers/bluetooth/hci/hci_ifx_cyw208xx.c
@@ -286,7 +286,7 @@ static int cyw208xx_send(const struct device *dev, struct net_buf *buf)
 
 	ARG_UNUSED(dev);
 
-	int ret = 0;
+	int ret;
 
 	k_sem_take(&hci_sem, K_FOREVER);
 
@@ -324,8 +324,14 @@ static int cyw208xx_send(const struct device *dev, struct net_buf *buf)
 
 done:
 	k_sem_give(&hci_sem);
+
+	if (ret != 0) {
+		return -EIO;
+	}
+
 	net_buf_unref(buf);
-	return ret ? -EIO : 0;
+
+	return 0;
 }
 
 static DEVICE_API(bt_hci, drv) = {

--- a/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
+++ b/drivers/bluetooth/hci/hci_ifx_psoc6_bless.c
@@ -172,7 +172,6 @@ static int psoc6_bless_send(const struct device *dev, struct net_buf *buf)
 
 	if (k_sem_take(&psoc6_bless_operation_sem, K_MSEC(BLE_LOCK_TMOUT_MS)) != 0) {
 		LOG_ERR("Failed to acquire BLE DRV Semaphore");
-		net_buf_unref(buf);
 		return -EIO;
 	}
 

--- a/drivers/bluetooth/hci/hci_silabs_efr32.c
+++ b/drivers/bluetooth/hci/hci_silabs_efr32.c
@@ -214,8 +214,12 @@ static int slz_bt_send(const struct device *dev, struct net_buf *buf)
 
 	rv = hci_common_transport_receive(buf->data, buf->len, true);
 
+	if (rv != 0) {
+		return rv;
+	}
+
 	net_buf_unref(buf);
-	return rv;
+	return 0;
 }
 
 /**

--- a/drivers/bluetooth/hci/hci_silabs_siwx91x.c
+++ b/drivers/bluetooth/hci/hci_silabs_siwx91x.c
@@ -48,8 +48,13 @@ static int siwx91x_bt_send(const struct device *dev, struct net_buf *buf)
 			sc = -EIO;
 		}
 	}
+
+	if (sc != 0) {
+		return sc;
+	}
+
 	net_buf_unref(buf);
-	return sc;
+	return 0;
 }
 
 static void siwx91x_bt_resp_rcvd(uint16_t status, rsi_ble_event_rcp_rcvd_info_t *resp_buf)

--- a/drivers/bluetooth/hci/hci_spi_st.c
+++ b/drivers/bluetooth/hci/hci_spi_st.c
@@ -619,9 +619,14 @@ static int bt_spi_send(const struct device *dev, struct net_buf *buf)
 		}
 	}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_hci_spi_v1) */
+
+	if (ret != 0) {
+		return ret;
+	}
+
 	net_buf_unref(buf);
 
-	return ret;
+	return 0;
 }
 
 static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)

--- a/drivers/bluetooth/hci/hci_stm32wb0.c
+++ b/drivers/bluetooth/hci/hci_stm32wb0.c
@@ -394,7 +394,6 @@ static struct net_buf *get_rx(uint8_t *msg)
 
 static int bt_hci_stm32wb0_send(const struct device *dev, struct net_buf *buf)
 {
-	int ret = 0;
 	uint8_t type = net_buf_pull_u8(buf);
 	uint8_t *hci_buffer = buf->data;
 
@@ -444,7 +443,7 @@ static int bt_hci_stm32wb0_send(const struct device *dev, struct net_buf *buf)
 	}
 	net_buf_unref(buf);
 
-	return ret;
+	return 0;
 }
 
 static int bt_hci_stm32wb0_open(const struct device *dev, bt_hci_recv_t recv)

--- a/drivers/bluetooth/hci/ipc.c
+++ b/drivers/bluetooth/hci/ipc.c
@@ -282,12 +282,12 @@ static int bt_ipc_send(const struct device *dev, struct net_buf *buf)
 
 	if (err < 0) {
 		LOG_ERR("Failed to send (err %d)", err);
-	} else {
-		err = 0;
+		return err;
 	}
 
 	net_buf_unref(buf);
-	return err;
+
+	return 0;
 }
 
 static void hci_ept_bound(void *priv)

--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -347,17 +347,16 @@ static int bt_spi_send(const struct device *dev, struct net_buf *buf)
 
 	k_sem_give(&sem_busy);
 
-	if (ret) {
+	if (ret != 0) {
 		LOG_ERR("Error %d", ret);
-		goto out;
+		return ret;
 	}
 
 	LOG_HEXDUMP_DBG(buf->data, buf->len, "SPI TX");
 
-out:
 	net_buf_unref(buf);
 
-	return ret;
+	return 0;
 }
 
 static int bt_spi_open(const struct device *dev, bt_hci_recv_t recv)

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -155,6 +155,10 @@ static inline int bt_hci_close(const struct device *dev)
  * that HCI drivers that use H:4 as their native encoding don't need to do any
  * special handling of the packet type.
  *
+ * If the function returns 0 (success) the reference to @c buf was moved to the
+ * HCI driver. On error, the caller still owns the reference and is responsible
+ * for eventually calling @ref net_buf_unref on it.
+ *
  * @note This function must only be called from a cooperative thread.
  *
  * @param dev HCI device


### PR DESCRIPTION
This change alignes HCI drivers behavior with Host expectation. That is: if an HCI driver managed to send a packet to Controller, the HCI driver also unreferences it. If the HCI driver didn't manage to send the packet to Controller and returns an error code, it does not unreferences buffer.

This change aligns the behavior of HCI drivers with the Host's expectations. Specifically:
- If an HCI driver successfully sends a packet to the Controller, the HCI driver also unreferences it.
- If the HCI driver fails to send the packet to the Controller and returns an error code, it does not unreference the buffer.

Fixes #94445