### PR TITLE
modules: openthread: configure router selection jitter

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -256,3 +256,12 @@ config OPENTHREAD_RCP_RESTORATION_MAX_COUNT
 	default 2
 	help
 	  The maximum number of attempts to restore the RCP connection.
+
+config OPENTHREAD_ROUTER_SELECTION_JITTER_OVERRIDE
+	bool "Override default router selection jitter"
+	depends on OPENTHREAD_FTD
+
+config OPENTHREAD_ROUTER_SELECTION_JITTER
+	int "OpenThread router selection jitter in seconds"
+	depends on OPENTHREAD_ROUTER_SELECTION_JITTER_OVERRIDE
+	default 120

--- a/modules/openthread/openthread.c
+++ b/modules/openthread/openthread.c
@@ -33,6 +33,7 @@ LOG_MODULE_REGISTER(net_openthread_platform, CONFIG_OPENTHREAD_PLATFORM_LOG_LEVE
 #include <openthread/platform/diag.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
+#include <openthread/thread_ftd.h>
 #include <openthread/dataset.h>
 #include <openthread/joiner.h>
 #include <openthread-system.h>
@@ -96,6 +97,12 @@ LOG_MODULE_REGISTER(net_openthread_platform, CONFIG_OPENTHREAD_PLATFORM_LOG_LEVE
 #define OT_POLL_PERIOD CONFIG_OPENTHREAD_POLL_PERIOD
 #else
 #define OT_POLL_PERIOD 0
+#endif
+
+#if defined(CONFIG_OPENTHREAD_ROUTER_SELECTION_JITTER)
+#define OT_ROUTER_SELECTION_JITTER CONFIG_OPENTHREAD_ROUTER_SELECTION_JITTER
+#else
+#define OT_ROUTER_SELECTION_JITTER 0
 #endif
 
 #define ZEPHYR_PACKAGE_NAME "Zephyr"
@@ -346,6 +353,10 @@ int openthread_init(void)
 			LOG_ERR("Could not set state changed callback: %d", error);
 			return -EIO;
 		}
+	}
+
+	if (IS_ENABLED(CONFIG_OPENTHREAD_ROUTER_SELECTION_JITTER_OVERRIDE)) {
+		otThreadSetRouterSelectionJitter(openthread_instance, OT_ROUTER_SELECTION_JITTER);
 	}
 
 	openthread_mutex_unlock();


### PR DESCRIPTION
Add `CONFIG_OPENTHREAD_ROUTER_SELECTION_JITTER_OVERRIDE` Kconfig option that enables setting the router selection jitter to `CONFIG_OPENTHREAD_ROUTER_SELECTION_JITTER` at startup.