### PR TITLE
dts: arm: st: n6: describe rng block

### DIFF
--- a/dts/arm/st/n6/stm32n6.dtsi
+++ b/dts/arm/st/n6/stm32n6.dtsi
@@ -853,6 +853,14 @@
 			resets = <&rctl STM32_RESET(APB5, 1)>;
 			status = "disabled";
 		};
+
+		rng: rng@54020000 {
+			compatible = "st,stm32-rng";
+			reg = <0x54020000 0x400>;
+			interrupts = <40 0>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 0)>;
+			status = "disabled";
+		};
 	};
 };
 


### PR DESCRIPTION
The stm32n6 features an RNG block. The RNG is a true NIST SP800-90B compliant entropy source according to the stm32n657x0 reference manual[1].

Per Table 3 in the reference manual, the RNG peripheral register boundary address (secure) is 0x54020000 to 0x540203FF. That is, base address 0x54020000 and size 0x400.

Per Table 73 in the reference manual, the RNG peripheral has only a single rng_clk option (hsis_osc_ck).
Per section 14.10.66 (and more) the RNG peripheral control is performed through AHB3 using bit 0.
As such, the `clocks` property contains a single phandle to the RCC AHB3 bit 0 entries.

Per Table 135 in the reference manual, the RNG peripheral interrupt is located at position 40 in the NVIC.

[1] RM0486 Rev 2: https://www.st.com/resource/en/reference_manual/rm0486-stm32n647657xx-armbased-32bit-mcus-stmicroelectronics.pdf