### PR TITLE
Bluetooth: ISO: Expose CIG_ID, CIS_ID, BIG_Handle and BIS_Number

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -90,6 +90,7 @@ New APIs and options
 
     * :c:struct:`bt_audio_codec_cfg` now contains a target_latency and a target_phy option
     * :c:func:`bt_bap_broadcast_source_foreach_stream`
+    * :c:struct:`bt_bap_stream` now contains an ``iso`` field as a reference to the ISO channel
 
   * Host
 

--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -91,6 +91,12 @@ New APIs and options
     * :c:struct:`bt_audio_codec_cfg` now contains a target_latency and a target_phy option
     * :c:func:`bt_bap_broadcast_source_foreach_stream`
 
+  * Host
+
+    * :c:struct:`bt_iso_unicast_info` now contains a ``cig_id`` and a ``cis_id`` field
+    * :c:struct:`bt_iso_broadcaster_info` now contains a ``big_handle`` and a ``bis_number`` field
+    * :c:struct:`bt_iso_sync_receiver_info` now contains a ``big_handle`` and a ``bis_number`` field
+
 * Display
 
   * :c:enumerator:`PIXEL_FORMAT_AL_88`

--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -906,14 +906,12 @@ struct bt_bap_stream {
 	/** Stream user data */
 	void *user_data;
 
-#if defined(CONFIG_BT_BAP_UNICAST_CLIENT) || defined(__DOXYGEN__)
-	/**
-	 * @brief Audio ISO reference
+	/** ISO channel reference
 	 *
-	 * This is only used for Unicast Client streams, and is handled internally.
+	 * This will become valid once the stream is added to a group (bt_bap_unicast_group,
+	 * bt_bap_broadcast_source or bt_bap_broadcast_sink).
 	 */
-	struct bt_bap_iso *bap_iso;
-#endif /* CONFIG_BT_BAP_UNICAST_CLIENT */
+	struct bt_iso_chan *iso;
 
 	/** Unicast or Broadcast group - Used internally */
 	void *group;

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -1081,6 +1081,12 @@ struct bt_iso_unicast_tx_info {
 
 /** @brief ISO Unicast Info Structure */
 struct bt_iso_unicast_info {
+	/** Connected Isochronous Group ID */
+	uint8_t cig_id;
+
+	/** Connected Isochronous Stream ID */
+	uint8_t cis_id;
+
 	/** The maximum time in us for all PDUs of all CIS in a CIG event */
 	uint32_t cig_sync_delay;
 
@@ -1104,6 +1110,12 @@ struct bt_iso_unicast_info {
 
 /** @brief ISO Broadcaster Info Structure */
 struct bt_iso_broadcaster_info {
+	/** Broadcast Isochronous Group Handle */
+	uint8_t big_handle;
+
+	/** Broadcast Isochronous Stream number */
+	uint8_t bis_number;
+
 	/** The maximum time in us for all PDUs of all BIS in a BIG event */
 	uint32_t sync_delay;
 
@@ -1128,6 +1140,12 @@ struct bt_iso_broadcaster_info {
 
 /** @brief ISO Synchronized Receiver Info Structure */
 struct bt_iso_sync_receiver_info {
+	/** Broadcast Isochronous Group handle */
+	uint8_t big_handle;
+
+	/** Broadcast Isochronous Stream number */
+	uint8_t bis_number;
+
 	/** The transport latency in us */
 	uint32_t latency;
 

--- a/samples/bluetooth/bap_broadcast_sink/src/main.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/main.c
@@ -25,6 +25,7 @@
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/__assert.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/util.h>
@@ -159,9 +160,14 @@ static void stream_disconnected_cb(struct bt_bap_stream *bap_stream, uint8_t rea
 
 static void stream_started_cb(struct bt_bap_stream *bap_stream)
 {
+	struct bt_iso_info info;
 	int err;
 
-	printk("Stream %p started\n", bap_stream);
+	err = bt_iso_chan_get_info(bap_stream->iso, &info);
+	__ASSERT(err == 0, "Failed to get ISO chan info: %d", err);
+
+	printk("Stream %p started with BIG_Handle %u and BIS_Number %u\n", bap_stream,
+	       info.sync_receiver.big_handle, info.sync_receiver.bis_number);
 
 	err = stream_rx_started(bap_stream);
 	if (err != 0) {

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -394,6 +394,14 @@ static void stream_started_cb(struct bt_bap_stream *stream)
 {
 	struct broadcast_source_stream *source_stream =
 		CONTAINER_OF(stream, struct broadcast_source_stream, stream);
+	struct bt_iso_info info;
+	int err;
+
+	err = bt_iso_chan_get_info(stream->iso, &info);
+	__ASSERT(err == 0, "Failed to get ISO chan info: %d", err);
+
+	printk("Stream %p started with BIG_Handle %u and BIS_Number %u\n", stream,
+	       info.broadcaster.big_handle, info.broadcaster.bis_number);
 
 	source_stream->seq_num = 0U;
 	source_stream->sent_cnt = 0U;

--- a/samples/bluetooth/bap_unicast_client/src/main.c
+++ b/samples/bluetooth/bap_unicast_client/src/main.c
@@ -223,7 +223,14 @@ static void stream_configured(struct bt_bap_stream *stream, const struct bt_bap_
 
 static void stream_qos_set(struct bt_bap_stream *stream)
 {
-	printk("Audio Stream %p QoS set\n", stream);
+	struct bt_iso_info info;
+	int err;
+
+	err = bt_iso_chan_get_info(stream->iso, &info);
+	__ASSERT(err == 0, "Failed to get ISO chan info: %d", err);
+
+	printk("Audio Stream %p QoS set with CIG_ID %u and CIS_ID %u\n", stream,
+	       info.unicast.cig_id, info.unicast.cis_id);
 
 	k_sem_give(&sem_stream_qos);
 }

--- a/samples/bluetooth/bap_unicast_server/src/main.c
+++ b/samples/bluetooth/bap_unicast_server/src/main.c
@@ -569,7 +569,14 @@ static void stream_stopped(struct bt_bap_stream *stream, uint8_t reason)
 
 static void stream_started(struct bt_bap_stream *stream)
 {
-	printk("Audio Stream %p started\n", stream);
+	struct bt_iso_info info;
+	int err;
+
+	err = bt_iso_chan_get_info(stream->iso, &info);
+	__ASSERT(err == 0, "Failed to get ISO chan info: %d", err);
+
+	printk("Audio Stream %p started  with CIG_ID %u and CIS_ID %u\n", stream,
+	       info.unicast.cig_id, info.unicast.cis_id);
 
 	if (stream_dir(stream) == BT_AUDIO_DIR_SINK) {
 		struct audio_sink *sink_stream = CONTAINER_OF(stream, struct audio_sink, stream);

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -317,6 +317,7 @@ static void ase_enter_state_idle(struct bt_ascs_ase *ase)
 	__ASSERT_NO_MSG(stream != NULL);
 
 	ase->ep.receiver_ready = false;
+	stream->iso = NULL;
 
 	bt_bap_stream_detach(stream);
 
@@ -336,6 +337,7 @@ static void ase_enter_state_codec_configured(struct bt_ascs_ase *ase)
 	__ASSERT_NO_MSG(stream != NULL);
 
 	ase->ep.receiver_ready = false;
+	stream->iso = NULL;
 
 	ops = stream->ops;
 	if (ops != NULL && ops->configured != NULL) {
@@ -1977,6 +1979,7 @@ static void ase_qos(struct bt_ascs_ase *ase, uint8_t cig_id, uint8_t cis_id,
 	/* QoS->QoS transition. Unbind ISO if CIG/CIS changed. */
 	if (ep->iso != NULL && (ep->cig_id != cig_id || ep->cis_id != cis_id)) {
 		bt_bap_iso_unbind_ep(ep->iso, ep);
+		stream->iso = NULL;
 	}
 
 	if (ep->iso == NULL) {
@@ -2000,6 +2003,7 @@ static void ase_qos(struct bt_ascs_ase *ase, uint8_t cig_id, uint8_t cis_id,
 		}
 
 		bt_bap_iso_bind_ep(iso, ep);
+		stream->iso = &iso->chan;
 		bt_bap_iso_unref(iso);
 	}
 

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -269,6 +269,7 @@ static void broadcast_sink_set_ep_state(struct bt_bap_ep *ep, uint8_t state)
 
 		if (stream != NULL) {
 			bt_bap_iso_unbind_ep(ep->iso, ep);
+			stream->iso = NULL;
 			stream->ep = NULL;
 			stream->codec_cfg = NULL;
 			stream->group = NULL;
@@ -992,6 +993,7 @@ static int bt_bap_broadcast_sink_setup_stream(struct bt_bap_broadcast_sink *sink
 
 	bt_bap_iso_init(iso, &broadcast_sink_iso_ops);
 	bt_bap_iso_bind_ep(iso, ep);
+	stream->iso = &iso->chan;
 
 	bt_bap_qos_cfg_to_iso_qos(iso->chan.qos->rx, &sink->qos_cfg);
 
@@ -1011,6 +1013,7 @@ static void broadcast_sink_cleanup_streams(struct bt_bap_broadcast_sink *sink)
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&sink->streams, stream, next, _node) {
 		if (stream->ep != NULL) {
 			bt_bap_iso_unbind_ep(stream->ep->iso, stream->ep);
+			stream->iso = NULL;
 			stream->ep->stream = NULL;
 			stream->ep->broadcast_sink = NULL;
 			stream->ep = NULL;

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -314,6 +314,7 @@ static int broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *st
 
 	bt_bap_iso_init(iso, &broadcast_source_iso_ops);
 	bt_bap_iso_bind_ep(iso, ep);
+	stream->iso = &iso->chan;
 
 	bt_bap_qos_cfg_to_iso_qos(iso->chan.qos->tx, qos);
 
@@ -460,6 +461,7 @@ static void broadcast_source_cleanup(struct bt_bap_broadcast_source *source)
 
 		SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&subgroup->streams, stream, next_stream, _node) {
 			bt_bap_iso_unbind_ep(stream->ep->iso, stream->ep);
+			stream->iso = NULL;
 			stream->ep->stream = NULL;
 			stream->ep->broadcast_source = NULL;
 			stream->ep = NULL;

--- a/subsys/bluetooth/audio/bap_iso.c
+++ b/subsys/bluetooth/audio/bap_iso.c
@@ -310,8 +310,8 @@ void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *st
 
 	__ASSERT_NO_MSG(stream != NULL);
 	__ASSERT_NO_MSG(bap_iso != NULL);
-	__ASSERT(stream->bap_iso == NULL, "stream %p bound with bap_iso %p already", stream,
-		 stream->bap_iso);
+	__ASSERT(stream->iso == NULL, "stream %p bound with bap_iso %p already", stream,
+		 CONTAINER_OF(stream->iso, struct bt_bap_iso, chan));
 
 	LOG_DBG("bap_iso %p stream %p dir %s", bap_iso, stream, bt_audio_dir_str(dir));
 
@@ -326,17 +326,18 @@ void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *st
 		 bap_iso_ep->stream);
 	bap_iso_ep->stream = stream;
 
-	stream->bap_iso = bt_bap_iso_ref(bap_iso);
+	stream->iso = &bt_bap_iso_ref(bap_iso)->chan;
 }
 
-void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream,
-			      enum bt_audio_dir dir)
+void bt_bap_iso_unbind_stream(struct bt_bap_stream *stream, enum bt_audio_dir dir)
 {
 	struct bt_bap_iso_dir *bap_iso_ep;
+	struct bt_bap_iso *bap_iso;
 
 	__ASSERT_NO_MSG(stream != NULL);
-	__ASSERT_NO_MSG(bap_iso != NULL);
-	__ASSERT(stream->bap_iso != NULL, "stream %p not bound with an bap_iso", stream);
+	__ASSERT(stream->iso != NULL, "stream %p not bound with an bap_iso", stream);
+
+	bap_iso = CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
 
 	LOG_DBG("bap_iso %p stream %p dir %s", bap_iso, stream, bt_audio_dir_str(dir));
 
@@ -348,11 +349,12 @@ void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *
 	}
 
 	__ASSERT(bap_iso_ep->stream == stream, "bap_iso %p (%p) not bound with stream %p (%p)",
-		 bap_iso, bap_iso_ep->stream, stream, stream->bap_iso);
+		 bap_iso, bap_iso_ep->stream, stream,
+		 CONTAINER_OF(stream->iso, struct bt_bap_iso, chan));
 	bap_iso_ep->stream = NULL;
 
 	bt_bap_iso_unref(bap_iso);
-	stream->bap_iso = NULL;
+	stream->iso = NULL;
 }
 
 struct bt_bap_stream *bt_bap_iso_get_stream(struct bt_bap_iso *iso, enum bt_audio_dir dir)

--- a/subsys/bluetooth/audio/bap_iso.h
+++ b/subsys/bluetooth/audio/bap_iso.h
@@ -55,6 +55,5 @@ struct bt_bap_ep *bt_bap_iso_get_paired_ep(const struct bt_bap_ep *ep);
 /* Unicast client-only functions*/
 void bt_bap_iso_bind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream,
 			    enum bt_audio_dir dir);
-void bt_bap_iso_unbind_stream(struct bt_bap_iso *bap_iso, struct bt_bap_stream *stream,
-			      enum bt_audio_dir dir);
+void bt_bap_iso_unbind_stream(struct bt_bap_stream *stream, enum bt_audio_dir dir);
 struct bt_bap_stream *bt_bap_iso_get_stream(struct bt_bap_iso *iso, enum bt_audio_dir dir);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -2588,8 +2588,8 @@ static void unicast_group_del_stream(struct bt_bap_unicast_group *group,
 	if (sys_slist_find_and_remove(&group->streams, &stream->_node)) {
 		struct bt_bap_ep *ep = stream->ep;
 
-		if (stream->bap_iso != NULL) {
-			bt_bap_iso_unbind_stream(stream->bap_iso, stream, dir);
+		if (stream->iso != NULL) {
+			bt_bap_iso_unbind_stream(stream, dir);
 		}
 
 		if (ep != NULL && ep->iso != NULL) {
@@ -2647,17 +2647,15 @@ static void unicast_group_free(struct bt_bap_unicast_group *group)
 	__ASSERT_NO_MSG(group != NULL);
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&group->streams, stream, next, _node) {
-		struct bt_bap_iso *bap_iso = stream->bap_iso;
+		struct bt_bap_iso *bap_iso = CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
 		struct bt_bap_ep *ep = stream->ep;
 
 		stream->group = NULL;
 		if (bap_iso != NULL) {
 			if (bap_iso->rx.stream == stream) {
-				bt_bap_iso_unbind_stream(stream->bap_iso, stream,
-							 BT_AUDIO_DIR_SOURCE);
+				bt_bap_iso_unbind_stream(stream, BT_AUDIO_DIR_SOURCE);
 			} else if (bap_iso->tx.stream == stream) {
-				bt_bap_iso_unbind_stream(stream->bap_iso, stream,
-							 BT_AUDIO_DIR_SINK);
+				bt_bap_iso_unbind_stream(stream, BT_AUDIO_DIR_SINK);
 			} else {
 				__ASSERT_PRINT("stream %p has invalid bap_iso %p", stream, bap_iso);
 			}
@@ -2968,13 +2966,15 @@ int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
 	 */
 	idx = 0U;
 	SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, tmp_stream, _node) {
-		memcpy(&rx_io_qos_backup[idx], tmp_stream->bap_iso->chan.qos->rx,
-		       sizeof(rx_io_qos_backup[idx]));
-		memcpy(&tx_io_qos_backup[idx], tmp_stream->bap_iso->chan.qos->tx,
-		       sizeof(tx_io_qos_backup[idx]));
+		const struct bt_bap_iso *bap_iso =
+			CONTAINER_OF(tmp_stream->iso, struct bt_bap_iso, chan);
+		const struct bt_iso_chan_qos *qos = bap_iso->chan.qos;
+
+		memcpy(&rx_io_qos_backup[idx], qos->rx, sizeof(rx_io_qos_backup[idx]));
+		memcpy(&tx_io_qos_backup[idx], qos->tx, sizeof(tx_io_qos_backup[idx]));
 		IF_ENABLED(
 			CONFIG_BT_ISO_TEST_PARAMS,
-			(num_subevents_backup[idx] = tmp_stream->bap_iso->chan.qos->num_subevents));
+			(num_subevents_backup[idx] = qos->num_subevents));
 		idx++;
 	}
 	memcpy(&cig_param_backup, &unicast_group->cig_param, sizeof(cig_param_backup));
@@ -2986,13 +2986,19 @@ int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
 		struct bt_bap_unicast_group_stream_param *tx_param = stream_param->tx_param;
 
 		if (rx_param != NULL) {
-			unicast_group_set_iso_stream_param(unicast_group, rx_param->stream->bap_iso,
-							   rx_param->qos, BT_AUDIO_DIR_SOURCE);
+			struct bt_bap_iso *bap_iso =
+				CONTAINER_OF(rx_param->stream->iso, struct bt_bap_iso, chan);
+
+			unicast_group_set_iso_stream_param(unicast_group, bap_iso, rx_param->qos,
+							   BT_AUDIO_DIR_SOURCE);
 		}
 
 		if (tx_param != NULL) {
-			unicast_group_set_iso_stream_param(unicast_group, tx_param->stream->bap_iso,
-							   tx_param->qos, BT_AUDIO_DIR_SOURCE);
+			struct bt_bap_iso *bap_iso =
+				CONTAINER_OF(tx_param->stream->iso, struct bt_bap_iso, chan);
+
+			unicast_group_set_iso_stream_param(unicast_group, bap_iso, tx_param->qos,
+							   BT_AUDIO_DIR_SOURCE);
 		}
 	}
 
@@ -3005,12 +3011,14 @@ int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
 		memcpy(&unicast_group->cig_param, &cig_param_backup, sizeof(cig_param_backup));
 		idx = 0U;
 		SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, tmp_stream, _node) {
-			memcpy(tmp_stream->bap_iso->chan.qos->rx, &rx_io_qos_backup[idx],
-			       sizeof(rx_io_qos_backup[idx]));
-			memcpy(tmp_stream->bap_iso->chan.qos->tx, &tx_io_qos_backup[idx],
-			       sizeof(tx_io_qos_backup[idx]));
+			struct bt_bap_iso *bap_iso =
+				CONTAINER_OF(tmp_stream->iso, struct bt_bap_iso, chan);
+			struct bt_iso_chan_qos *qos = bap_iso->chan.qos;
+
+			memcpy(qos->rx, &rx_io_qos_backup[idx], sizeof(rx_io_qos_backup[idx]));
+			memcpy(qos->tx, &tx_io_qos_backup[idx], sizeof(tx_io_qos_backup[idx]));
 			IF_ENABLED(CONFIG_BT_ISO_TEST_PARAMS,
-				   (tmp_stream->bap_iso->chan.qos->num_subevents =
+				   (qos->num_subevents =
 					    num_subevents_backup[idx]));
 			idx++;
 		}
@@ -3274,7 +3282,7 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 			return -EINVAL;
 		}
 
-		if (stream->bap_iso == NULL) {
+		if (stream->iso == NULL) {
 			/* This can only happen if the stream was somehow added
 			 * to a group without the bap_iso being bound to it
 			 */
@@ -3308,8 +3316,11 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 		op->num_ases++;
 
 		if (stream->ep->iso == NULL) {
+			struct bt_bap_iso *bap_iso =
+				CONTAINER_OF(stream->iso, struct bt_bap_iso, chan);
+
 			/* Not yet bound with the bap_iso */
-			bt_bap_iso_bind_ep(stream->bap_iso, stream->ep);
+			bt_bap_iso_bind_ep(bap_iso, stream->ep);
 		}
 
 		err = bt_bap_unicast_client_ep_qos(stream->ep, buf, stream->qos);

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -1978,14 +1978,14 @@ int bt_bap_unicast_client_ep_qos(struct bt_bap_ep *ep, struct net_buf_simple *bu
 
 	LOG_DBG("id 0x%02x cig 0x%02x cis 0x%02x interval %u framing 0x%02x "
 		"phy 0x%02x sdu %u rtn %u latency %u pd %u",
-		ep->status.id, conn_iso->cig_id, conn_iso->cis_id, qos->interval, qos->framing,
-		qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
+		ep->status.id, conn_iso->info.unicast.cig_id, conn_iso->info.unicast.cis_id,
+		qos->interval, qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
 	req->ase = ep->status.id;
 	/* TODO: don't hardcode CIG and CIS, they should come from ISO */
-	req->cig = conn_iso->cig_id;
-	req->cis = conn_iso->cis_id;
+	req->cig = conn_iso->info.unicast.cig_id;
+	req->cis = conn_iso->info.unicast.cis_id;
 	sys_put_le24(qos->interval, req->interval);
 	req->framing = qos->framing;
 	req->phy = qos->phy;

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -187,8 +187,8 @@ struct bt_conn_iso {
 		/* CIS ID within the CIG */
 		uint8_t			cis_id;
 
-		/* BIS ID within the BIG*/
-		uint8_t			bis_id;
+		/* BIS number within the BIG */
+		uint8_t			bis_number;
 	};
 
 	/** Stored information about the ISO stream */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -176,21 +176,6 @@ struct bt_conn_iso {
 	/* Reference to the struct bt_iso_chan */
 	struct bt_iso_chan      *chan;
 
-	union {
-		/* CIG ID */
-		uint8_t			cig_id;
-		/* BIG handle */
-		uint8_t			big_handle;
-	};
-
-	union {
-		/* CIS ID within the CIG */
-		uint8_t			cis_id;
-
-		/* BIS number within the BIG */
-		uint8_t			bis_number;
-	};
-
 	/** Stored information about the ISO stream */
 	struct bt_iso_info info;
 

--- a/tests/bsim/bluetooth/host/iso/bis/src/bis_broadcaster.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/bis_broadcaster.c
@@ -145,6 +145,11 @@ static void iso_connected_cb(struct bt_iso_chan *chan)
 		    "Invalid BN 0x%02x", info.broadcaster.bn);
 	TEST_ASSERT(IN_RANGE(info.broadcaster.irc, BT_ISO_IRC_MIN, BT_ISO_IRC_MAX),
 		    "Invalid IRC 0x%02x", info.broadcaster.irc);
+	TEST_ASSERT(info.broadcaster.big_handle != 0xFF /* invalid BIG handle */,
+		    "Invalid BIG handle 0x%02x", info.broadcaster.big_handle);
+	TEST_ASSERT(
+		IN_RANGE(info.broadcaster.bis_number, BT_ISO_BIS_INDEX_MIN, BT_ISO_BIS_INDEX_MAX),
+		"Invalid BIS number 0x%02x", info.broadcaster.bis_number);
 
 	if (chan == default_chan) {
 		seq_num = 0U;

--- a/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
+++ b/tests/bsim/bluetooth/host/iso/bis/src/bis_receiver.c
@@ -146,6 +146,11 @@ static void iso_connected(struct bt_iso_chan *chan)
 		    "Invalid BN 0x%02x", info.sync_receiver.bn);
 	TEST_ASSERT(IN_RANGE(info.sync_receiver.irc, BT_ISO_IRC_MIN, BT_ISO_IRC_MAX),
 		    "Invalid IRC 0x%02x", info.sync_receiver.irc);
+	TEST_ASSERT(info.sync_receiver.big_handle != 0xFF /* invalid BIG handle */,
+		    "Invalid BIG handle 0x%02x", info.sync_receiver.big_handle);
+	TEST_ASSERT(
+		IN_RANGE(info.sync_receiver.bis_number, BT_ISO_BIS_INDEX_MIN, BT_ISO_BIS_INDEX_MAX),
+		"Invalid BIS number 0x%02x", info.sync_receiver.bis_number);
 
 	SET_FLAG(flag_iso_connected);
 


### PR DESCRIPTION
Expose the IDs, handles and numbers of CIGs, BIGs, CISes and BISes
via the ISO info struct. This information may be needed by higher
layer (such as the Basic Audio Profile (BAP)) or used as indexes
for arrays in the application layer.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/94380