### PR TITLE
soc: Add support for the bgm240sa22vna module

### DIFF
--- a/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
+++ b/dts/arm/silabs/xg24/bgm240sa22vna.dtsi
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Fr. Sauter AG
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ * Copyright (c) 2025 Ephraim Westenberger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <silabs/xg24/efr32bg24.dtsi>
+
+/ {
+	soc {
+		compatible = "silabs,bgm240sa22vna", "silabs,efr32bg24", "silabs,xg24",
+			     "silabs,efr32", "simple-bus";
+	};
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(1536)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+};

--- a/dts/arm/silabs/xg24/efr32bg24.dtsi
+++ b/dts/arm/silabs/xg24/efr32bg24.dtsi
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <silabs/xg24/efr32xg24.dtsi>

--- a/soc/silabs/silabs_s2/xg24/Kconfig
+++ b/soc/silabs/silabs_s2/xg24/Kconfig
@@ -1,5 +1,6 @@
 # Copyright (c) 2020 TriaGnoSys GmbH
 # Copyright (c) 2025 Silicon Laboratories Inc.
+# Copyright (c) 2025 Ephraim Westenberger
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SILABS_XG24
@@ -23,5 +24,9 @@ config SOC_SERIES_EFR32MG24
 	select SOC_GECKO_HAS_RADIO
 
 config SOC_SERIES_MGM24
+	select SILABS_DEVICE_IS_MODULE
+	select SOC_GECKO_HAS_RADIO
+
+config SOC_SERIES_BGM24
 	select SILABS_DEVICE_IS_MODULE
 	select SOC_GECKO_HAS_RADIO

--- a/soc/silabs/silabs_s2/xg24/Kconfig.soc
+++ b/soc/silabs/silabs_s2/xg24/Kconfig.soc
@@ -1,5 +1,6 @@
 # Copyright (c) 2020 TriaGnoSys GmbH
 # Copyright (c) 2025 Silicon Laboratories Inc.
+# Copyright (c) 2025 Ephraim Westenberger
 # SPDX-License-Identifier: Apache-2.0
 
 config SOC_SILABS_XG24
@@ -19,6 +20,12 @@ config SOC_SERIES_MGM24
 	select SOC_SILABS_XG24
 	help
 	  Silicon Labs MGM240 (Mighty Gecko) Series MCU modules
+
+config SOC_SERIES_BGM24
+	bool
+	select SOC_SILABS_XG24
+	help
+	  Silicon Labs BGM240 Series MCU modules
 
 config SOC_EFR32MG24B020F1536IM40
 	bool
@@ -44,9 +51,14 @@ config SOC_MGM240PB32VNA
 	bool
 	select SOC_SERIES_MGM24
 
+config SOC_BGM240SA22VNA
+	bool
+	select SOC_SERIES_BGM24
+
 config SOC_SERIES
 	default "efr32mg24" if SOC_SERIES_EFR32MG24
 	default "mgm24" if SOC_SERIES_MGM24
+	default "bgm24" if SOC_SERIES_BGM24
 
 config SOC
 	default "efr32mg24b220f1536im48" if SOC_EFR32MG24B220F1536IM48
@@ -55,3 +67,4 @@ config SOC
 	default "efr32mg24b020f1536im40" if SOC_EFR32MG24B020F1536IM40
 	default "mgm240sd22vna" if SOC_MGM240SD22VNA
 	default "mgm240pb32vna" if SOC_MGM240PB32VNA
+	default "bgm240sa22vna" if SOC_BGM240SA22VNA

--- a/soc/silabs/soc.yml
+++ b/soc/silabs/soc.yml
@@ -67,6 +67,9 @@ family:
           - name: efr32mg24b310f1536im48
           - name: efr32mg24b210f1536im48
           - name: efr32mg24b020f1536im40
+      - name: bgm24
+        socs:
+          - name: bgm240sa22vna
       - name: mgm24
         socs:
           - name: mgm240sd22vna

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 13343bccf850eb7b6541f6e71a8d2a880209850b
+      revision: 0b58229357750b8bd0ce52e514c54ace6abcfeba
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
This PR adds support for the bgm240sa22vna module based on the preliminary work of @silabs-bozont in PR #91661.

This addition was made because each Silabs module uses its own RAIL library, and therefore, it needs to be added separately for Bluetooth to work.

This was successfully tested using a custom board featuring the module, which is not available upstream.  The applications in samples/bluetooth/beacon and samples/bluetooth/peripheral were successfully built and flashed. The nRF Connect app was used for testing the connection. 

Depends on: https://github.com/zephyrproject-rtos/hal_silabs/pull/118