### PR TITLE
Replace ~ when creating library names from path

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -449,6 +449,9 @@ macro(zephyr_library_get_current_dir_lib_name base lib_name)
   # Replace : with __ (C:/zephyrproject => C____zephyrproject)
   string(REGEX REPLACE ":" "__" name ${name})
 
+  # Replace ~ with - (driver~serial => driver-serial)
+  string(REGEX REPLACE "~" "-" name ${name})
+
   set(${lib_name} ${name})
 endmacro()
 


### PR DESCRIPTION
When auto-generating library name via `zephyr_library()`, the generated name is invalid if the current path involves any `
~` in it. 

We build Zephyr within a Bazel environment, and Bazel likes to use '~` for names of external repos.