### PR TITLE
usb: device_next: hid: allow to set polling period at runtime 

### DIFF
--- a/include/zephyr/usb/class/usbd_hid.h
+++ b/include/zephyr/usb/class/usbd_hid.h
@@ -213,6 +213,38 @@ int hid_device_submit_report(const struct device *dev,
 			     const uint16_t size, const uint8_t *const report);
 
 /**
+ * @brief Set input report polling period
+ *
+ * Similar to devicetree property in-polling-period-us, but it allows setting
+ * different polling periods at runtime.
+ *
+ * @kconfig_dep{CONFIG_USBD_HID_SET_POLLING_PERIOD}
+ *
+ * @param[in] dev       Pointer to HID device
+ * @param[in] period_us Polling period in microseconds
+ *
+ * @return 0 on success, negative errno code on failure.
+ * @retval -ENOTSUP If API is not enabled.
+ */
+int hid_device_set_in_polling(const struct device *dev, const unsigned int period_us);
+
+/**
+ * @brief Set output report polling period
+ *
+ * Similar to devicetree property out-polling-period-us, but it allows setting
+ * different polling periods at runtime.
+ *
+ * @kconfig_dep{CONFIG_USBD_HID_SET_POLLING_PERIOD}
+ *
+ * @param[in] dev       Pointer to HID device
+ * @param[in] period_us Polling period in microseconds
+ *
+ * @return 0 on success, negative errno code on failure.
+ * @retval -ENOTSUP If API is not enabled.
+ */
+int hid_device_set_out_polling(const struct device *dev, const unsigned int period_us);
+
+/**
  * @}
  */
 

--- a/samples/subsys/usb/hid-keyboard/sample.yaml
+++ b/samples/subsys/usb/hid-keyboard/sample.yaml
@@ -33,3 +33,5 @@ tests:
   sample.usbd.hid-keyboard.large-out-report:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE="large_out_report.overlay"
+    extra_configs:
+      - CONFIG_USBD_HID_SET_POLLING_PERIOD=y

--- a/samples/subsys/usb/hid-keyboard/src/main.c
+++ b/samples/subsys/usb/hid-keyboard/src/main.c
@@ -206,6 +206,18 @@ int main(void)
 		return ret;
 	}
 
+	if (IS_ENABLED(CONFIG_USBD_HID_SET_POLLING_PERIOD)) {
+		ret = hid_device_set_in_polling(hid_dev, 1000);
+		if (ret) {
+			LOG_WRN("Failed to set IN report polling period, %d", ret);
+		}
+
+		ret = hid_device_set_out_polling(hid_dev, 1000);
+		if (ret != 0 && ret != -ENOTSUP) {
+			LOG_WRN("Failed to set OUT report polling period, %d", ret);
+		}
+	}
+
 	sample_usbd = sample_usbd_init_device(msg_cb);
 	if (sample_usbd == NULL) {
 		LOG_ERR("Failed to initialize USB device");

--- a/subsys/usb/device_next/class/Kconfig.hid
+++ b/subsys/usb/device_next/class/Kconfig.hid
@@ -30,6 +30,11 @@ config USBD_HID_INIT_PRIORITY
 	help
 	  HID device initialization priority
 
+config USBD_HID_SET_POLLING_PERIOD
+	bool "Allow to set polling period at runtime"
+	help
+	  Allow to set input or output report polling period at runtime.
+
 module = USBD_HID
 module-str = usbd hid
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/usb/device_next/class/usbd_hid_api.c
+++ b/subsys/usb/device_next/class/usbd_hid_api.c
@@ -34,6 +34,28 @@ int hid_device_register(const struct device *dev,
 	return api->dev_register(dev, rdesc, rsize, ops);
 }
 
+int hid_device_set_in_polling(const struct device *dev, const unsigned int period_us)
+{
+	const struct hid_device_driver_api *const api = dev->api;
+
+	if (IS_ENABLED(CONFIG_USBD_HID_SET_POLLING_PERIOD)) {
+		return api->set_in_polling(dev, period_us);
+	}
+
+	return -ENOTSUP;
+}
+
+int hid_device_set_out_polling(const struct device *dev, const unsigned int period_us)
+{
+	const struct hid_device_driver_api *const api = dev->api;
+
+	if (IS_ENABLED(CONFIG_USBD_HID_SET_POLLING_PERIOD)) {
+		return api->set_out_polling(dev, period_us);
+	}
+
+	return -ENOTSUP;
+}
+
 /* Legacy HID API wrapper below */
 
 struct legacy_wrapper {

--- a/subsys/usb/device_next/class/usbd_hid_internal.h
+++ b/subsys/usb/device_next/class/usbd_hid_internal.h
@@ -20,4 +20,6 @@ struct hid_device_driver_api {
 	int (*dev_register)(const struct device *dev,
 			    const uint8_t *const rdesc, const uint16_t rsize,
 			    const struct hid_device_ops *const ops);
+	int (*set_in_polling)(const struct device *dev, const unsigned int period_us);
+	int (*set_out_polling)(const struct device *dev, const unsigned int period_us);
 };


### PR DESCRIPTION
Allow to set input or output report polling period at runtime.