### PR TITLE
drivers: usb: udc: refine log message in udc_common.c

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -631,13 +631,13 @@ struct net_buf *udc_ep_buf_alloc(const struct device *dev,
 
 	buf = net_buf_alloc_len(&udc_ep_pool, size, K_NO_WAIT);
 	if (!buf) {
-		LOG_ERR("Failed to allocate net_buf %zd", size);
+		LOG_ERR("Failed to allocate net_buf %zd, ep 0x%02x", size, ep);
 		goto ep_alloc_error;
 	}
 
 	bi = udc_get_buf_info(buf);
 	bi->ep = ep;
-	LOG_DBG("Allocate net_buf, ep 0x%02x, size %zd", ep, size);
+	LOG_DBG("Allocate net_buf %p, ep 0x%02x, size %zd", buf, ep, size);
 
 ep_alloc_error:
 	api->unlock(dev);


### PR DESCRIPTION
This refines udc log message in udc_common.c, including:
1. Add address of allocated `net_buf` info into `udc_ep_buf_alloc` log so that `net_buf` create/destroy can be easily monitored with calls to `udc_ep_buf_alloc` and `udc_buf_destroy`.
2. Add ep info into `udc_ep_buf_alloc` log on failure.