### PR TITLE
tests: gen_isr_table: exclude it8xxx2_evb platforms

### DIFF
--- a/tests/arch/common/gen_isr_table/testcase.yaml
+++ b/tests/arch/common/gen_isr_table/testcase.yaml
@@ -62,6 +62,8 @@ tests:
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
   arch.interrupt.gen_isr_table_local.riscv:
     arch_allow: riscv
+    platform_exclude:
+      - it8xxx2_evb
     extra_configs:
       - CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
 


### PR DESCRIPTION
This commit excludes it8xxx2_evb platform for gen_isr_table test since it8xxx2 soc don't support software triggering interrupts.

Fixes issue #94382.