### PR TITLE
boards: silabs: Use default value for COMMON_LIBC_MALLOC_ARENA_SIZE

### DIFF
--- a/boards/arduino/nano_matter/Kconfig.defconfig
+++ b/boards/arduino/nano_matter/Kconfig.defconfig
@@ -22,9 +22,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/seeed/xiao_mg24/Kconfig.defconfig
+++ b/boards/seeed/xiao_mg24/Kconfig.defconfig
@@ -25,9 +25,6 @@ config GPIO_HOGS
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/sltb010a/Kconfig.defconfig
@@ -18,9 +18,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/dev_kits/xg22_ek2710a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg22_ek2710a/Kconfig.defconfig
@@ -19,9 +19,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_dk2601b/Kconfig.defconfig
@@ -18,9 +18,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 2304
 

--- a/boards/silabs/dev_kits/xg24_ek2703a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg24_ek2703a/Kconfig.defconfig
@@ -19,11 +19,4 @@ config FPU
 
 endif # SOC_GECKO_USE_RAIL
 
-if BT
-
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
-endif # BT
-
 endif # BOARD_XG24_EK2703A

--- a/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
+++ b/boards/silabs/dev_kits/xg27_dk2602a/Kconfig.defconfig
@@ -18,9 +18,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4104a/Kconfig.defconfig
@@ -26,9 +26,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4161a/Kconfig.defconfig
@@ -26,9 +26,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4170a/Kconfig.defconfig
@@ -26,9 +26,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4180a/Kconfig.defconfig
@@ -20,9 +20,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4250b/Kconfig.defconfig
@@ -26,9 +26,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/slwrb4255a/Kconfig.defconfig
@@ -26,9 +26,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg24_rb4187c/Kconfig.defconfig
@@ -20,9 +20,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/silabs/radio_boards/xg29_rb4412a/Kconfig.defconfig
+++ b/boards/silabs/radio_boards/xg29_rb4412a/Kconfig.defconfig
@@ -19,9 +19,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 3072 if PM
 	default 2304

--- a/boards/sparkfun/thing_plus_matter_mgm240p/Kconfig.defconfig
+++ b/boards/sparkfun/thing_plus_matter_mgm240p/Kconfig.defconfig
@@ -24,9 +24,6 @@ if BT
 config FPU
 	default y
 
-config COMMON_LIBC_MALLOC_ARENA_SIZE
-	default 8192
-
 config MAIN_STACK_SIZE
 	default 2304
 


### PR DESCRIPTION
Use the default -1 value for COMMON_LIBC_MALLOC_ARENA_SIZE, i.e. let the heap expand to the remaining amount of memory.