### PR TITLE
boards: seeed: Fix XIAO MG24 standard uart pins

### DIFF
--- a/boards/seeed/xiao_mg24/seeed_xiao_connector.dtsi
+++ b/boards/seeed/xiao_mg24/seeed_xiao_connector.dtsi
@@ -24,8 +24,8 @@
 	};
 };
 
-xiao_spi: &eusart1 {};
+xiao_spi: &eusart0 {};
 
-xiao_serial: &eusart0 {};
+xiao_serial: &eusart1 {};
 
 xiao_i2c: &i2c0 {};

--- a/boards/seeed/xiao_mg24/xiao_mg24-pinctrl.dtsi
+++ b/boards/seeed/xiao_mg24/xiao_mg24-pinctrl.dtsi
@@ -10,13 +10,13 @@
 &pinctrl {
 	eusart0_default: eusart0_default {
 		group0 {
-			pins = <EUSART1_TX_PC6>;
+			pins = <EUSART0_TX_PA5>, <EUSART0_SCLK_PA3>;
 			drive-push-pull;
 			output-high;
 		};
 
 		group1 {
-			pins = <EUSART1_RX_PC7>;
+			pins = <EUSART0_RX_PA4>;
 			input-enable;
 			silabs,input-filter;
 		};
@@ -24,13 +24,13 @@
 
 	eusart1_default: eusart1_default {
 		group0 {
-			pins = <EUSART1_TX_PA5>, <EUSART1_SCLK_PA3>;
+			pins = <EUSART1_TX_PC6>;
 			drive-push-pull;
 			output-high;
 		};
 
 		group1 {
-			pins = <EUSART1_RX_PA4>;
+			pins = <EUSART1_RX_PC7>;
 			input-enable;
 			silabs,input-filter;
 		};

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -119,18 +119,18 @@
 };
 
 &eusart0 {
-	compatible = "silabs,eusart-uart";
-	current-speed = <115200>;
-	pinctrl-0 = <&eusart0_default>;
-	pinctrl-names = "default";
-};
-
-&eusart1 {
 	compatible = "silabs,eusart-spi";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	clock-frequency = <4000000>;
 	cs-gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&eusart0_default>;
+	pinctrl-names = "default";
+};
+
+&eusart1 {
+	compatible = "silabs,eusart-uart";
+	current-speed = <115200>;
 	pinctrl-0 = <&eusart1_default>;
 	pinctrl-names = "default";
 };


### PR DESCRIPTION
Properly use EUSART1 for the XIAO connector serial device, and switch XIAO SPI to EUSART0 to allow simultaneous use.

Found this while testing the serial monitor functionality of my testing sample of the new XIAO Debugger, which revealed that the setup of the standard "XIAO UART" on logical pins D6/D7 was not working. Corrected pinctrl/node aliases to work as expected now.