### PR TITLE
samples: Bluetooth: make bap_broadcast_source work with google pixel

### DIFF
--- a/samples/bluetooth/bap_broadcast_source/Kconfig
+++ b/samples/bluetooth/bap_broadcast_source/Kconfig
@@ -64,6 +64,13 @@ config BROADCAST_ID
 	help
 	   This is the 3-octet broadcast ID advertised if static broadcast IDs are enabled.
 
+config BROADCAST_NAME
+	string "Bluetooth broadcast name"
+	default BT_DEVICE_NAME
+	help
+	   Bluetooth broadcast name. Can be used for scanning device that displays information on the
+	   available broadcast sources. Name length range is 4 to 32.
+
 # Source common USB sample options used to initialize new experimental USB device stack.
 # The scope of these options is limited to USB samples in project tree,
 # you cannot use them in your own application.

--- a/samples/bluetooth/bap_broadcast_source/src/main.c
+++ b/samples/bluetooth/bap_broadcast_source/src/main.c
@@ -33,6 +33,9 @@
 #include <zephyr/usb/usbd.h>
 
 BUILD_ASSERT(strlen(CONFIG_BROADCAST_CODE) <= BT_ISO_BROADCAST_CODE_SIZE, "Invalid broadcast code");
+BUILD_ASSERT(IN_RANGE(strlen(CONFIG_BROADCAST_NAME), BT_AUDIO_BROADCAST_NAME_LEN_MIN,
+		      BT_AUDIO_BROADCAST_NAME_LEN_MAX),
+	     "Invalid broadcast name");
 
 /* When BROADCAST_ENQUEUE_COUNT > 1 we can enqueue enough buffers to ensure that
  * the controller is never idle
@@ -559,7 +562,7 @@ int main(void)
 		/* Broadcast Audio Streaming Endpoint advertising data */
 		NET_BUF_SIMPLE_DEFINE(ad_buf, BT_UUID_SIZE_16 + BT_AUDIO_BROADCAST_ID_SIZE);
 		NET_BUF_SIMPLE_DEFINE(base_buf, 128);
-		struct bt_data ext_ad[2];
+		struct bt_data ext_ad[3];
 		struct bt_data per_ad;
 		uint32_t broadcast_id;
 
@@ -602,7 +605,11 @@ int main(void)
 		ext_ad[0].data = ad_buf.data;
 		ext_ad[1] = (struct bt_data)BT_DATA(BT_DATA_NAME_COMPLETE, CONFIG_BT_DEVICE_NAME,
 						    sizeof(CONFIG_BT_DEVICE_NAME) - 1);
-		err = bt_le_ext_adv_set_data(adv, ext_ad, 2, NULL, 0);
+		/* Broadcast name used for scanning device that displays information on the */
+		/* available broadcast sources. */
+		ext_ad[2] = (struct bt_data)BT_DATA(BT_DATA_BROADCAST_NAME, CONFIG_BROADCAST_NAME,
+						    sizeof(CONFIG_BROADCAST_NAME) - 1);
+		err = bt_le_ext_adv_set_data(adv, ext_ad, 3, NULL, 0);
 		if (err != 0) {
 			printk("Failed to set extended advertising data: %d\n", err);
 			return 0;


### PR DESCRIPTION
Broadcast name was used on phone to distinguish broadcast audio sources, so we need add broadcast name into advertise data.