### PR TITLE
boards: st: fix STM nucleo_h533RE LED2

### DIFF
--- a/boards/st/nucleo_h533re/nucleo_h533re.dts
+++ b/boards/st/nucleo_h533re/nucleo_h533re.dts
@@ -26,7 +26,7 @@
 		compatible = "gpio-leds";
 
 		green_led_2: led_42 {
-			gpios = <&gpioa 5 GPIO_ACTIVE_LOW>;
+			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
 			label = "User LD2";
 		};
 	};


### PR DESCRIPTION
green_led_2 should be set to GPIO_ACTIVE_HIGH
according to the Data sheet [1] provided by ST.

"To light LD2, a high logic state '1' must be written into the corresponding GPIO PA5. A transistor is used to drive the LD2."

Link: https://www.st.com/resource/en/user_manual/um3121-stm32h5-nucleo64-board-mb1814-stmicroelectronics.pdf [1]