### PR TITLE
shield: mimxrt1170_evk: fix the shield usage

### DIFF
--- a/samples/drivers/display/sample.yaml
+++ b/samples/drivers/display/sample.yaml
@@ -98,7 +98,7 @@ tests:
       - platform:mimxrt1010_evk/mimxrt1011:SHIELD=st7789v_waveshare_240x240
       - platform:frdm_k22f/mk22f51212:SHIELD=ls013b7dh03
       - platform:nrf52833dk/nrf52833:SHIELD=st7735r_ada_160x128
-      - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4m
+      - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
       - platform:da1469x_dk_pro/da14699:DTC_OVERLAY_FILE=da1469x_dk_pro_mipi_dbi.overlay
       - platform:nrf52840dk/nrf52840:SHIELD=max7219_8x8
       - platform:stm32h747i_disco/stm32h747xx/m7:SHIELD=st_b_lcd40_dsi1_mb1166

--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -30,7 +30,7 @@ tests:
     # but the RT595 uses external PSRAM for the display buffer
     min_ram: 32
     harness: none
-    extra_args: SHIELD="rk055hdmipi4m"
+    extra_args: SHIELD="rk055hdmipi4ma0"
     platform_allow:
       - mimxrt1170_evk/mimxrt1176/cm7
       - mimxrt595_evk/mimxrt595s/cm33

--- a/tests/drivers/display/display_check/testcase.yaml
+++ b/tests/drivers/display/display_check/testcase.yaml
@@ -65,7 +65,7 @@ tests:
       - platform:mimxrt1010_evk/mimxrt1011:SHIELD=st7789v_waveshare_240x240
       - platform:frdm_k22f/mk22f51212:SHIELD=ls013b7dh03
       - platform:nrf52833dk/nrf52833:SHIELD=st7735r_ada_160x128
-      - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4m
+      - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
       - platform:da1469x_dk_pro/da14699:DTC_OVERLAY_FILE=da1469x_dk_pro_mipi_dbi.overlay
       - platform:nrf52840dk/nrf52840:SHIELD=max7219_8x8
       - platform:stm32h747i_disco/stm32h747xx/m7:SHIELD=st_b_lcd40_dsi1_mb1166


### PR DESCRIPTION
original rk055hdmipi4m does not support mimxrt1170_evk, change to rk055hdmipi4ma0

see https://github.com/zephyrproject-rtos/zephyr/tree/main/boards/shields/rk055hdmipi4m/boards
and
https://github.com/zephyrproject-rtos/zephyr/tree/main/boards/shields/rk055hdmipi4ma0/boards