### PR TITLE
soc: silabs: silabs_s2: Align power states with HAL

### DIFF
--- a/boards/arduino/nano_matter/arduino_nano_matter.dts
+++ b/boards/arduino/nano_matter/arduino_nano_matter.dts
@@ -100,10 +100,6 @@
 	clock-frequency = <78000000>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &hfxo {
 	ctune = <95>;
 	precision = <50>;

--- a/boards/seeed/xiao_mg24/xiao_mg24.dts
+++ b/boards/seeed/xiao_mg24/xiao_mg24.dts
@@ -65,10 +65,6 @@
 	clock-frequency = <78000000>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &hfxo {
 	ctune = <95>;
 	precision = <50>;

--- a/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
+++ b/boards/silabs/dev_kits/pg23_pk2504a/pg23_pk2504a.dts
@@ -94,10 +94,6 @@
 	clock-frequency = <78000000>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &hfxo {
 	status = "okay";
 	ctune = <106>;

--- a/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
+++ b/boards/silabs/dev_kits/pg28_pk2506a/pg28_pk2506a.dts
@@ -101,10 +101,6 @@
 	clock-frequency = <78000000>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &hfxo {
 	status = "okay";
 	ctune = <114>;

--- a/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/sltb010a/thunderboard.dtsi
@@ -73,10 +73,6 @@
 	swo-ref-frequency = <DT_FREQ_K(76800)>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &usart0 {
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";

--- a/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
+++ b/boards/silabs/dev_kits/xg27_dk2602a/thunderboard.dtsi
@@ -73,10 +73,6 @@
 	swo-ref-frequency = <DT_FREQ_K(76800)>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &usart0 {
 	status = "okay";
 	pinctrl-0 = <&usart0_default>;

--- a/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
+++ b/boards/silabs/radio_boards/xg23_rb4210a/xg23_rb4210a.dts
@@ -108,10 +108,6 @@
 	swo-ref-frequency = <DT_FREQ_M(78)>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &hfxo {
 	ctune = <106>;
 	precision = <50>;

--- a/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
+++ b/boards/silabs/radio_boards/xg24_rb4187c/xg24_rb4187c.dts
@@ -82,10 +82,6 @@
 	swo-ref-frequency = <DT_FREQ_M(78)>;
 };
 
-&pstate_em3 {
-	status = "disabled";
-};
-
 &hfxo {
 	ctune = <95>;
 	precision = <50>;

--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -130,5 +130,8 @@ Silabs
 * Fixed name of the :kconfig:option:`CONFIG_SOC_*`. These option contained PART_NUMBER in their
   while they shouldn't.
 
+* The separate ``em3`` power state was removed from Series 2 SoCs. The system automatically
+  transitions to EM2 or EM3 depending on hardware peripheral requests for the oscillators.
+
 Architectures
 *************

--- a/dts/arm/silabs/xg22/xg22.dtsi
+++ b/dts/arm/silabs/xg22/xg22.dtsi
@@ -129,7 +129,7 @@
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
 			 */
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
+			cpu-power-states = <&pstate_em1 &pstate_em2>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -157,17 +157,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-			};
-
-			/*
-			 * EM3 seems to be exactly the same as EM2 except that
-			 * LFXO & LFRCO should be disabled, so you must use ULFRCO
-			 * as BURTC clock for the system to not lose track of time and
-			 * wake up.
-			 */
-			pstate_em3: em3 {
-				compatible = "zephyr,power-state";
-				power-state-name = "standby";
 			};
 		};
 	};

--- a/dts/arm/silabs/xg23/xg23.dtsi
+++ b/dts/arm/silabs/xg23/xg23.dtsi
@@ -149,7 +149,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
+			cpu-power-states = <&pstate_em1 &pstate_em2>;
 			/*
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
@@ -181,17 +181,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-			};
-
-			/*
-			 * EM3 seems to be exactly the same as EM2 except that
-			 * LFXO & LFRCO should be disabled, so you must use ULFRCO
-			 * as BURTC clock for the system to not lose track of time and
-			 * wake up.
-			 */
-			pstate_em3: em3 {
-				compatible = "zephyr,power-state";
-				power-state-name = "standby";
 			};
 		};
 	};

--- a/dts/arm/silabs/xg24/xg24.dtsi
+++ b/dts/arm/silabs/xg24/xg24.dtsi
@@ -139,7 +139,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
+			cpu-power-states = <&pstate_em1 &pstate_em2>;
 			/*
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
@@ -171,17 +171,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-			};
-
-			/*
-			 * EM3 seems to be exactly the same as EM2 except that
-			 * LFXO & LFRCO should be disabled, so you must use ULFRCO
-			 * as BURTC clock for the system to not lose track of time and
-			 * wake up.
-			 */
-			pstate_em3: em3 {
-				compatible = "zephyr,power-state";
-				power-state-name = "standby";
 			};
 		};
 	};

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -138,7 +138,7 @@
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
 			 */
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
+			cpu-power-states = <&pstate_em1 &pstate_em2>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -166,17 +166,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-			};
-
-			/*
-			 * EM3 seems to be exactly the same as EM2 except that
-			 * LFXO & LFRCO should be disabled, so you must use ULFRCO
-			 * as BURTC clock for the system to not lose track of time and
-			 * wake up.
-			 */
-			pstate_em3: em3 {
-				compatible = "zephyr,power-state";
-				power-state-name = "standby";
 			};
 		};
 	};

--- a/dts/arm/silabs/xg28/xg28.dtsi
+++ b/dts/arm/silabs/xg28/xg28.dtsi
@@ -170,7 +170,7 @@
 			device_type = "cpu";
 			compatible = "arm,cortex-m33";
 			reg = <0>;
-			cpu-power-states = <&pstate_em1 &pstate_em2 &pstate_em3>;
+			cpu-power-states = <&pstate_em1 &pstate_em2>;
 			/*
 			 * The minimum residency and exit latency is
 			 * managed by sl_power_manager on S2 devices.
@@ -195,17 +195,6 @@
 			pstate_em2: em2 {
 				compatible = "zephyr,power-state";
 				power-state-name = "suspend-to-idle";
-			};
-
-			/*
-			 * EM3 seems to be exactly the same as EM2 except that
-			 * LFXO & LFRCO should be disabled, so you must use ULFRCO
-			 * as BURTC clock for the system to not lose track of time and
-			 * wake up.
-			 */
-			pstate_em3: em3 {
-				compatible = "zephyr,power-state";
-				power-state-name = "standby";
 			};
 		};
 	};

--- a/soc/silabs/common/soc_power_pmgr.c
+++ b/soc/silabs/common/soc_power_pmgr.c
@@ -17,7 +17,6 @@ LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
  * Power state map:
  * PM_STATE_RUNTIME_IDLE: EM1 Sleep
  * PM_STATE_SUSPEND_TO_IDLE: EM2 Deep Sleep
- * PM_STATE_STANDBY: EM3 Stop
  * PM_STATE_SOFT_OFF: EM4
  */
 
@@ -35,10 +34,8 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		energy_mode = SL_POWER_MANAGER_EM1;
 		break;
 	case PM_STATE_SUSPEND_TO_IDLE:
-		energy_mode = SL_POWER_MANAGER_EM2;
-		break;
 	case PM_STATE_STANDBY:
-		energy_mode = SL_POWER_MANAGER_EM3;
+		energy_mode = SL_POWER_MANAGER_EM2;
 		break;
 	case PM_STATE_SOFT_OFF:
 		energy_mode = SL_POWER_MANAGER_EM4;


### PR DESCRIPTION
The definition of the EM3 energy mode is that software switches off the LFRCO and LFXO before entering deep sleep. On Series 2, oscillators are enabled on-demand based on peripheral requests from hardware. Requesting EM3 will result in EM2 if any active peripheral uses one of the oscillators, and requesting EM2 will result in EM3 if no peripherals use the oscillators.

In version 2025.6 of the HAL, this was reflected in the API of the power manager by making EM3 an alias of EM2. Reflect this in Zephyr by removing the separate EM3 power state.

See also: https://docs.silabs.com/sisdk-release-notes/2025.6.0/sisdk-platform-release-notes/sisdk-plat-mcu-release-notes#removed-features