### PR TITLE
boards: nxp: frdm_mcxa156, frdm_mcxa166, frdm_mcxa276: fix led2 color

### DIFF
--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -18,7 +18,7 @@
 	aliases{
 		led0 = &red_led;
 		led1 = &green_led;
-		led2 = &red_led;
+		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		pwm-0 = &flexpwm0_pwm0;

--- a/boards/nxp/frdm_mcxa166/frdm_mcxa166.dts
+++ b/boards/nxp/frdm_mcxa166/frdm_mcxa166.dts
@@ -17,7 +17,7 @@
 	aliases{
 		led0 = &red_led;
 		led1 = &green_led;
-		led2 = &red_led;
+		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		watchdog0 = &wwdt0;

--- a/boards/nxp/frdm_mcxa276/frdm_mcxa276.dts
+++ b/boards/nxp/frdm_mcxa276/frdm_mcxa276.dts
@@ -18,7 +18,7 @@
 	aliases{
 		led0 = &red_led;
 		led1 = &green_led;
-		led2 = &red_led;
+		led2 = &blue_led;
 		sw0 = &user_button_2;
 		sw1 = &user_button_3;
 		watchdog0 = &wwdt0;


### PR DESCRIPTION
The red LED repeats twice, so it changes to blue.