### PR TITLE
logging: allow simplified logging of UART backend

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -146,6 +146,11 @@ New APIs and options
 
 * Logging:
 
+  * Added options to skip timestamp and level in log backends.
+
+    * :kconfig:option:`CONFIG_LOG_BACKEND_SHOW_TIMESTAMP`
+    * :kconfig:option:`CONFIG_LOG_BACKEND_SHOW_LEVEL`
+
   * Added rate-limited logging macros to prevent log flooding when messages are generated frequently.
 
     * :c:macro:`LOG_ERR_RATELIMIT` - Rate-limited error logging macro (convenience)

--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -181,6 +181,11 @@ with function name. Hexdump messages are not prepended.
 :kconfig:option:`CONFIG_LOG_FUNC_NAME_PREFIX_DBG`: Prepend standard DEBUG log messages
 with function name. Hexdump messages are not prepended.
 
+:kconfig:option:`CONFIG_LOG_BACKEND_SHOW_TIMESTAMP`: Enables backend to print timestamps
+with log.
+
+:kconfig:option:`CONFIG_LOG_BACKEND_SHOW_LEVEL`: Enables backend to print levels with log.
+
 :kconfig:option:`CONFIG_LOG_BACKEND_SHOW_COLOR`: Enables coloring of errors (red)
 and warnings (yellow).
 

--- a/include/zephyr/logging/log_backend_std.h
+++ b/include/zephyr/logging/log_backend_std.h
@@ -23,7 +23,15 @@ extern "C" {
 
 static inline uint32_t log_backend_std_get_flags(void)
 {
-	uint32_t flags = (LOG_OUTPUT_FLAG_LEVEL | LOG_OUTPUT_FLAG_TIMESTAMP);
+	uint32_t flags = 0;
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_TIMESTAMP)) {
+		flags |= LOG_OUTPUT_FLAG_TIMESTAMP;
+	}
+
+	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_LEVEL)) {
+		flags |= LOG_OUTPUT_FLAG_LEVEL;
+	}
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_SHOW_COLOR)) {
 		flags |= LOG_OUTPUT_FLAG_COLORS;

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -132,6 +132,18 @@ config LOG_IMMEDIATE_CLEAN_OUTPUT
 	  this option is causing interrupts locking for significant amount of
 	  time (up to multiple milliseconds).
 
+config LOG_BACKEND_SHOW_TIMESTAMP
+	bool "Timestamps in the backend"
+	default y
+	help
+	  When enabled, selected backend prints timestamps with log.
+
+config LOG_BACKEND_SHOW_LEVEL
+	bool "Levels in the backend"
+	default y
+	help
+	  When enabled, selected backend prints levels with log.
+
 config LOG_BACKEND_SHOW_COLOR
 	bool "Colors in the backend"
 	default y if LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
@@ -172,7 +184,7 @@ config LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 config LOG_BACKEND_FORMAT_TIMESTAMP
 	bool "Timestamp formatting in the backend"
 	depends on LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
-	default y
+	default y if LOG_BACKEND_SHOW_TIMESTAMP
 	help
 	  When enabled timestamp is formatted.
 


### PR DESCRIPTION
This allows no timestamps, level prefixes, and colors in UART backend logging. The message format will be similar as the ones  with CONFIG_LOG_MODE_MINIMAL=y. It also could reduce the output overhead of UART interface when logging backend is enabled.