### PR TITLE
wch ch32v203: Support the HSI divisor before the pll and fix LSI frequency

### DIFF
--- a/dts/bindings/clock/wch,ch32fv203_v303-pll-clock.yaml
+++ b/dts/bindings/clock/wch,ch32fv203_v303-pll-clock.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+description: WCH CH32V203/303 CH32F203 PLL
+
+compatible: "wch,ch32fv203_v303-pll-clock"
+
+include: ["wch,ch32fv2x_v3x-pll-clock.yaml"]
+
+properties:
+  div:
+    type: int
+    required: true
+    description: |
+      PLL divider factor applied before the multiplication
+    enum:
+      - 1 # /1
+      - 2 # /2

--- a/dts/bindings/clock/wch,ch32fv208-pll-clock.yaml
+++ b/dts/bindings/clock/wch,ch32fv208-pll-clock.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+description: WCH CH32V208/F208 PLL
+
+compatible: "wch,ch32fv208-pll-clock"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+  "#clock-cells":
+    const: 0
+
+  clocks:
+    type: phandle-array
+    required: true
+
+  mul:
+    type: int
+    required: true
+    description: |
+        Main PLL multiplication factor
+    enum:
+      - 2   # x2
+      - 3   # x3
+      - 4   # x4
+      - 5   # x5
+      - 6   # x6
+      - 7   # x7
+      - 8   # x8
+      - 9   # x2
+      - 10  # x10
+      - 11  # x11
+      - 12  # x12
+      - 13  # x13
+      - 14  # x14
+      - 15  # x15
+      - 16  # x16
+      - 18  # x18
+
+  div:
+    type: int
+    required: true
+    description: |
+      PLL divider factor applied before the multiplication
+      1 and 2 can only be used for the HSI and 2, 4 and 8 for the HSE.
+      HSE 2 sets the USBPRE bit, forcing the USB prescaler to \5
+      (only supported if the penultimate digit of the lot number is greated then 0).
+    enum:
+      - 1 # /1
+      - 2 # /2
+      - 4 # /4
+      - 8 # /8

--- a/dts/bindings/clock/wch,ch32fv2x_v3x-pll-clock.yaml
+++ b/dts/bindings/clock/wch,ch32fv2x_v3x-pll-clock.yaml
@@ -3,7 +3,7 @@
 
 description: WCH CH32V20x/30x PLL
 
-compatible: "wch,ch32v20x_30x-pll-clock"
+compatible: "wch,ch32fv2x_v3x-pll-clock"
 
 include: [clock-controller.yaml, base.yaml]
 
@@ -37,3 +37,12 @@ properties:
       - 15  # x15
       - 16  # x16
       - 18  # x18
+
+  div:
+    type: int
+    required: true
+    description: |
+      PLL divider factor applied before the multiplication. Currently only affects the HSI
+    enum:
+      - 1 # /1
+      - 2 # /2

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -30,7 +30,7 @@
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <DT_FREQ_K(40)>;
 			status = "disabled";
 		};
 

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -36,8 +36,10 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
+			compatible = "wch,ch32fv2x_v3x-pll-clock",
+				     "wch,ch32fv203_v303-pll-clock";
 			mul = <15>;
+			div = <1>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
@@ -14,6 +14,10 @@
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 
+&clk_lsi {
+	clock-frequency = <DT_FREQ_K(32)>;
+};
+
 soc {
 	usart3: uart@40004800 {
 		compatible = "wch,usart";

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -36,8 +36,9 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32fv2x_v3x-pll-clock";
+			compatible = "wch,ch32fv208-pll-clock";
 			mul = <15>;
+			div = <4>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -36,7 +36,7 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
+			compatible = "wch,ch32fv2x_v3x-pll-clock";
 			mul = <15>;
 			status = "disabled";
 		};

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -36,8 +36,10 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
+			compatible = "wch,ch32fv2x_v3x-pll-clock",
+				     "wch,ch32fv203_v303-pll-clock";
 			mul = <18>;
+			div = <1>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
Fix the LSI frequency of the LSI which is 40KHz and only on the ch32v203RB variant the previous 32KHz.

Add support for the pre PLL divisor both for the HSI (offering `/1` and `/2`) and for ch32v203, ch32v303 (and also ch32f203, which is not yet supported by zephyr) also add support for the HSI pre divisor. Other boards have a different clocktree so that this representation in the devicetree would be wrong. 