### PR TITLE
Bluetooth: Controller: Fix building with Privacy without LE Encryption

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -2529,6 +2529,7 @@ void radio_ccm_disable(void)
 	nrf_ccm_task_trigger(NRF_CCM, NRF_CCM_TASK_STOP);
 	nrf_ccm_disable(NRF_CCM);
 }
+#endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 static uint8_t MALIGN(4) _aar_scratch[3];
@@ -2659,7 +2660,6 @@ uint8_t radio_ar_resolve(const uint8_t *addr)
 
 }
 #endif /* CONFIG_BT_CTLR_PRIVACY */
-#endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
 
 #if defined(CONFIG_BT_CTLR_DF_SUPPORT) && !defined(CONFIG_ZTEST)
 /* @brief Function configures CTE inline register to start sampling of CTE

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -63,8 +63,11 @@
 
 #if defined(CONFIG_BT_CTLR_LE_ENC) || defined(CONFIG_BT_CTLR_BROADCAST_ISO_ENC)
 #include <hal/nrf_ccm.h>
-#include <hal/nrf_aar.h>
 #endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+#include <hal/nrf_aar.h>
+#endif /* CONFIG_BT_CTLR_PRIVACY */
 
 /* Define to reset PPI registration.
  * This has to come before the ppi/dppi includes below.

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -175,18 +175,6 @@ static inline void hal_trigger_crypt_ppi_disable(void)
 	nrf_ccm_subscribe_clear(NRF_CCM, NRF_CCM_TASK_START);
 }
 
-#if defined(CONFIG_BT_CTLR_PRIVACY)
-/*******************************************************************************
- * Trigger automatic address resolution on Bit counter match:
- * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
- */
-static inline void hal_trigger_aar_ppi_config(void)
-{
-	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_BCMATCH, HAL_TRIGGER_AAR_PPI);
-	nrf_aar_subscribe_set(NRF_AAR, NRF_AAR_TASK_START, HAL_TRIGGER_AAR_PPI);
-}
-#endif /* CONFIG_BT_CTLR_PRIVACY */
-
 /* When hardware does not support Coded PHY we still allow the Controller
  * implementation to accept Coded PHY flags, but the Controller will use 1M
  * PHY on air. This is implementation specific feature.
@@ -228,6 +216,18 @@ static inline void hal_trigger_crypt_by_bcmatch_ppi_config(void)
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 #endif /* CONFIG_BT_CTLR_LE_ENC || CONFIG_BT_CTLR_BROADCAST_ISO_ENC */
+
+#if defined(CONFIG_BT_CTLR_PRIVACY)
+/*******************************************************************************
+ * Trigger automatic address resolution on Bit counter match:
+ * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
+ */
+static inline void hal_trigger_aar_ppi_config(void)
+{
+	nrf_radio_publish_set(NRF_RADIO, NRF_RADIO_EVENT_BCMATCH, HAL_TRIGGER_AAR_PPI);
+	nrf_aar_subscribe_set(NRF_AAR, NRF_AAR_TASK_START, HAL_TRIGGER_AAR_PPI);
+}
+#endif /* CONFIG_BT_CTLR_PRIVACY */
 
 /******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -260,19 +260,6 @@ static inline void hal_trigger_crypt_by_bcmatch_ppi_config(void)
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 
 /*******************************************************************************
- * Trigger automatic address resolution on Bit counter match:
- * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
- *
- * PPI channel 23 is pre-programmed with the following fixed settings:
- *   EEP: RADIO->EVENTS_BCMATCH
- *   TEP: AAR->TASKS_START
- */
-static inline void hal_trigger_aar_ppi_config(void)
-{
-	/* No need to configure anything for the pre-programmed channel. */
-}
-
-/*******************************************************************************
  * Trigger Radio Rate override upon Rateboost event.
  */
 #if defined(CONFIG_BT_CTLR_PHY_CODED) && defined(CONFIG_HAS_HW_NRF_RADIO_BLE_CODED)
@@ -285,6 +272,19 @@ static inline void hal_trigger_rateoverride_ppi_config(void)
 		(uint32_t)&(NRF_CCM->TASKS_RATEOVERRIDE));
 }
 #endif /* CONFIG_BT_CTLR_PHY_CODED && CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
+
+/*******************************************************************************
+ * Trigger automatic address resolution on Bit counter match:
+ * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.
+ *
+ * PPI channel 23 is pre-programmed with the following fixed settings:
+ *   EEP: RADIO->EVENTS_BCMATCH
+ *   TEP: AAR->TASKS_START
+ */
+static inline void hal_trigger_aar_ppi_config(void)
+{
+	/* No need to configure anything for the pre-programmed channel. */
+}
 
 /******************************************************************************/
 #if !defined(CONFIG_BT_CTLR_TIFS_HW)


### PR DESCRIPTION
Fix building with Privacy feature without enabling LE Encryption support. This should allow being either Observer or Broadcaster role with Privacy features.

Was part of https://github.com/zephyrproject-rtos/zephyr/pull/89408 