### PR TITLE
boards: seeed: xiao_mg24: Add support for PyOCD runner

### DIFF
--- a/boards/seeed/xiao_mg24/board.cmake
+++ b/boards/seeed/xiao_mg24/board.cmake
@@ -3,5 +3,9 @@
 board_runner_args(openocd)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 
+board_runner_args(pyocd "--target=EFR32MG24B220F1536IM48")
+board_runner_args(pyocd "--tool-opt=-Oadi.v5.max_invalid_ap_count=0")
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+
 board_runner_args(jlink "--device=EFR32MG24BxxxF1536")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/seeed/xiao_mg24/doc/index.rst
+++ b/boards/seeed/xiao_mg24/doc/index.rst
@@ -78,6 +78,16 @@ used, or can be installed from the `OpenOCD Arduino Fork`_. When flashing, debug
 need to include ``--openocd=/usr/local/bin/openocd
 --openocd-search=/usr/local/share/openocd/scripts/`` options to the command.
 
+PyOCD can also be used by passing ``-r pyocd`` to the flashing and debugging commands. Add support
+for the XIAO MG24 by installing the CMSIS Device Family Pack if not already installed.
+
+.. code-block:: console
+
+   pyocd pack install EFR32MG24
+
+If the pack install command seems to hang indefinitely, ensure that the ``cmsis-pack-manager``
+Python package is updated to version ``0.6.0`` or newer.
+
 Flashing
 ========
 


### PR DESCRIPTION
Add PyOCD as a runner for xiao_mg24. Document how to install the flashloader from CMSIS-Pack. PyOCD can be used for flashing and debugging.