### PR TITLE
boards: arm: add probe-rs runner for RP2350 boards

### DIFF
--- a/boards/adafruit/metro_rp2350/board.cmake
+++ b/boards/adafruit/metro_rp2350/board.cmake
@@ -7,6 +7,8 @@ endif()
 board_runner_args(openocd --cmd-pre-init "source [find interface/${RPI_PICO_DEBUG_ADAPTER}.cfg]")
 board_runner_args(openocd --cmd-pre-init "source [find target/rp2350.cfg]")
 
+board_runner_args(probe-rs "--chip=RP235x")
+
 # The adapter speed is expected to be set by interface configuration.
 # The Raspberry Pi's OpenOCD fork doesn't, so match their documentation at
 # https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html#debugging-with-swd
@@ -16,3 +18,4 @@ board_runner_args(uf2 "--board-id=RP2350")
 
 include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)

--- a/boards/kws/pico2_spe/board.cmake
+++ b/boards/kws/pico2_spe/board.cmake
@@ -7,6 +7,8 @@ endif()
 board_runner_args(openocd --cmd-pre-init "source [find interface/${RPI_PICO_DEBUG_ADAPTER}.cfg]")
 board_runner_args(openocd --cmd-pre-init "source [find target/rp2350.cfg]")
 
+board_runner_args(probe-rs "--chip=RP235x")
+
 # The adapter speed is expected to be set by interface configuration.
 # The Raspberry Pi's OpenOCD fork doesn't, so match their documentation at
 # https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html#debugging-with-swd
@@ -15,4 +17,5 @@ board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 5000")
 board_runner_args(uf2 "--board-id=RP2350")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)

--- a/boards/pimoroni/pico_plus2/board.cmake
+++ b/boards/pimoroni/pico_plus2/board.cmake
@@ -3,6 +3,8 @@
 board_runner_args(openocd --cmd-pre-init "source [find interface/cmsis-dap.cfg]")
 board_runner_args(openocd --cmd-pre-init "source [find target/rp2350.cfg]")
 
+board_runner_args(probe-rs "--chip=RP235x")
+
 # The adapter speed is expected to be set by interface configuration.
 # The Raspberry Pi's OpenOCD fork doesn't, so match their documentation at
 # https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html#debugging-with-swd
@@ -11,4 +13,5 @@ board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 5000")
 board_runner_args(uf2 "--board-id=RP2350")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)

--- a/boards/raspberrypi/rpi_pico2/board.cmake
+++ b/boards/raspberrypi/rpi_pico2/board.cmake
@@ -12,9 +12,12 @@ board_runner_args(openocd --cmd-pre-init "source [find target/rp2350.cfg]")
 # https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html#debugging-with-swd
 board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 5000")
 
+board_runner_args(probe-rs "--chip=RP235x")
+
 board_runner_args(jlink "--device=RP2350_M33_0")
 board_runner_args(uf2 "--board-id=RP2350")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)

--- a/boards/wiznet/w5500_evb_pico2/board.cmake
+++ b/boards/wiznet/w5500_evb_pico2/board.cmake
@@ -12,7 +12,10 @@ board_runner_args(openocd --cmd-pre-init "source [find target/rp2350.cfg]")
 # https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html#debugging-with-swd
 board_runner_args(openocd --cmd-pre-init "set_adapter_speed_if_not_set 5000")
 
+board_runner_args(probe-rs "--chip=RP235x")
+
 board_runner_args(uf2 "--board-id=RP2350")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/uf2.board.cmake)


### PR DESCRIPTION
Add the chip parameter for probe-rs. Verified on Feather RP2350.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
