### PR TITLE
Bluetooth: Classic: SDP: Refactor parsing of Service Search Pattern

### DIFF
--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -310,7 +310,7 @@ struct bt_sdp_record {
 	struct bt_sdp_attribute     *attrs;       /**< Base addr of attr array */
 	size_t                      attr_count;   /**< Number of attributes */
 	uint8_t                     index;        /**< Index of the record in LL */
-	struct bt_sdp_record        *next;        /**< Next service record */
+	sys_snode_t                 node;
 };
 
 /*

--- a/subsys/bluetooth/host/classic/sdp_internal.h
+++ b/subsys/bluetooth/host/classic/sdp_internal.h
@@ -37,8 +37,6 @@
 #define BT_SDP_INVALID_PDU_SIZE      0x0004
 #define BT_SDP_INVALID_CSTATE        0x0005
 
-#define BT_SDP_MAX_SERVICES   10
-
 struct bt_sdp_data_elem_seq {
 	uint8_t  type; /* Type: Will be data element sequence */
 	uint16_t size; /* We only support 2 byte sizes for now */


### PR DESCRIPTION
* Bluetooth: Classic: SDP: Use slist to manage SDP records

Use slist instead of custom singly linked list to manage SDP records.

Check if the SDP record has been registered in the function `bt_sdp_register_service()`.

Append the new SDP record to the tail of the SDP record list.

Check if the index of SDP record is overflow in the function `bt_sdp_register_service()`.

* Bluetooth: Classic: SDP: Refactor parsing of Service Search Pattern

In current implementation, after parsing the received service search pattern and all matched SDP records are saved in the local variable `matching_recs`. The max count of SDP records within its SDP database that match the given service search pattern is
BT_SDP_MAX_SERVICES when parsing the received Service Search Pattern. And it causes the max count registered SDP records is limited to BT_SDP_MAX_SERVICES.

Refactor the parsing of service search pattern to remove the limitation with the following steps.
1. Save the service search pattern to a simple buffer by calling the function `parse_service_search_pattern()`.
2. Traverse all registered SDP record and check for each SDP record if it is matched with given service search pattern by calling function `service_search_pattern_matched()`.
3. Use the matched SDP records to response the SDP request.

And also remove the limitation of the max count of registered SDP records.

