### PR TITLE
boards: st: nucleo_h563zi: device tree: add alias for led1

### DIFF
--- a/boards/st/nucleo_h563zi/nucleo_h563zi.dts
+++ b/boards/st/nucleo_h563zi/nucleo_h563zi.dts
@@ -27,6 +27,7 @@
 
 	aliases {
 		led0 = &green_led_1;
+		led1 = &yellow_led_1;
 		sw0 = &user_button;
 		watchdog0 = &iwdg;
 		pwm-led0 = &pwm_led_1;


### PR DESCRIPTION
Add alias for led1 in addition to led0.
The leds are present on the ST Nucleo H563zi board. Tested with ST Nucleo H563zi board.