### PR TITLE
drivers: sensor: npm13xx_charger: improve sample fetching

### DIFF
--- a/drivers/mfd/mfd_npm13xx.c
+++ b/drivers/mfd/mfd_npm13xx.c
@@ -206,13 +206,16 @@ int mfd_npm13xx_reg_write(const struct device *dev, uint8_t base, uint8_t offset
 	return i2c_write_dt(&config->i2c, buff, sizeof(buff));
 }
 
-int mfd_npm13xx_reg_write2(const struct device *dev, uint8_t base, uint8_t offset, uint8_t data1,
-			   uint8_t data2)
+int mfd_npm13xx_reg_write_burst(const struct device *dev, uint8_t base, uint8_t offset, void *data,
+				size_t len)
 {
 	const struct mfd_npm13xx_config *config = dev->config;
-	uint8_t buff[] = {base, offset, data1, data2};
+	struct i2c_msg msg[2] = {
+		{.buf = (uint8_t []){base, offset}, .len = 2, .flags = I2C_MSG_WRITE},
+		{.buf = data, .len = len, .flags = I2C_MSG_WRITE | I2C_MSG_STOP},
+	};
 
-	return i2c_write_dt(&config->i2c, buff, sizeof(buff));
+	return i2c_transfer_dt(&config->i2c, msg, 2);
 }
 
 int mfd_npm13xx_reg_update(const struct device *dev, uint8_t base, uint8_t offset, uint8_t data,

--- a/include/zephyr/drivers/mfd/npm13xx.h
+++ b/include/zephyr/drivers/mfd/npm13xx.h
@@ -79,18 +79,18 @@ int mfd_npm13xx_reg_read(const struct device *dev, uint8_t base, uint8_t offset,
 int mfd_npm13xx_reg_write(const struct device *dev, uint8_t base, uint8_t offset, uint8_t data);
 
 /**
- * @brief Write two registers to npm13xx
+ * @brief Write multiple registers to npm13xx
  *
  * @param dev npm13xx mfd device
  * @param base Register base address (bits 15..8 of 16-bit address)
- * @param offset Register offset address (bits 7..0 of 16-bit address)
- * @param data1 first byte of data to write
- * @param data2 second byte of data to write
+ * @param offset First register offset address (bits 7..0 of 16-bit address)
+ * @param data Pointer to buffer to write
+ * @param len Number of bytes to write
  * @retval 0 If successful
  * @retval -errno In case of any bus error (see i2c_write_dt())
  */
-int mfd_npm13xx_reg_write2(const struct device *dev, uint8_t base, uint8_t offset, uint8_t data1,
-			   uint8_t data2);
+int mfd_npm13xx_reg_write_burst(const struct device *dev, uint8_t base, uint8_t offset, void *data,
+				size_t len);
 
 /**
  * @brief Update selected bits in npm13xx register


### PR DESCRIPTION
Change the npm13xx_charger fetch function to first trigger a sample and then block until the result is available.