### PR TITLE
soc: raspberrypi: rp2350: indicate DSP extension support

### DIFF
--- a/soc/raspberrypi/rpi_pico/rp2350/Kconfig
+++ b/soc/raspberrypi/rpi_pico/rp2350/Kconfig
@@ -17,6 +17,7 @@ config SOC_RP2350A_M33
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_ARM_SAU
 	select CPU_HAS_FPU
+	select ARMV8_M_DSP
 
 config SOC_RP2350B_M33
 	select ARM
@@ -27,6 +28,7 @@ config SOC_RP2350B_M33
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_ARM_SAU
 	select CPU_HAS_FPU
+	select ARMV8_M_DSP
 
 config RP2_REQUIRES_IMAGE_DEFINITION_BLOCK
 	bool


### PR DESCRIPTION
Confirmed by section 3.7.2 in the datasheet (version 29 July 2025) and
running a sample piece of code exercising smuad, smladx and
other DSP intrinsics.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
