### PR TITLE
drivers: mcux_edma: Fix dtcm desc kconfig dependency

### DIFF
--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -59,11 +59,12 @@ config DMA_MCUX_TEST_SLOT_START
 	help
 	  test slot start num
 
+ZEPHYR_DTCM := zephyr,dtcm
+
 config DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS
 	bool "Use DTCM for DMA descriptors"
 	default y
-	depends on DT_HAS_NXP_IMX_DTCM_ENABLED
-	depends on $(dt_chosen_enabled,zephyr_dtcm)
+	depends on $(dt_chosen_enabled,$(ZEPHYR_DTCM))
 	help
 	  When this option is activated, the descriptors for DMA transfer are
 	  located in the DTCM (Data Tightly Coupled Memory).

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm33.conf
@@ -1,6 +1,0 @@
-#
-# Copyright 2024 NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS=n

--- a/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.conf
+++ b/tests/drivers/spi/spi_loopback/boards/mimxrt1180_evk_mimxrt1189_cm7.conf
@@ -1,6 +1,0 @@
-#
-# Copyright 2024 NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS=n

--- a/tests/drivers/uart/uart_async_api/boards/mimxrt1180_evk_mimxrt1189_cm7.conf
+++ b/tests/drivers/uart/uart_async_api/boards/mimxrt1180_evk_mimxrt1189_cm7.conf
@@ -1,6 +1,0 @@
-#
-# Copyright 2024 NXP
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-CONFIG_DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS=n


### PR DESCRIPTION
The syntax was wrong for the chosen dtcm node. Also fixing build error on 1180 by re-allowing the symbol on some tests.

@lucien-nxp 
@hakehuang 

Fixes #94539