### PR TITLE
xtensa: jump to GDB upon exception

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -110,6 +110,13 @@ config XTENSA_BREAK_ON_UNRECOVERABLE_EXCEPTIONS
 	  encountered. This requires a debugger attached to catch
 	  the BREAK.
 
+config XTENSA_EXCEPTION_ENTER_GDB
+	bool "Start the GDB stub when an exception is hit"
+	depends on GDBSTUB
+	help
+	  When an exception like invalid address access or division by zero is
+	  hit, enter the GDB stub.
+
 menu "Xtensa HiFi Options"
 
 config XTENSA_CPU_HAS_HIFI

--- a/arch/xtensa/core/vector_handlers.c
+++ b/arch/xtensa/core/vector_handlers.c
@@ -678,6 +678,10 @@ skip_checks:
 		if (reason != K_ERR_KERNEL_OOPS) {
 			print_fatal_exception(print_stack, cause, is_dblexc, depc);
 		}
+#ifdef CONFIG_XTENSA_EXCEPTION_ENTER_GDB
+		extern void z_gdb_isr(struct arch_esf *esf);
+		z_gdb_isr((void *)print_stack);
+#endif
 
 		/* FIXME: legacy xtensa port reported "HW" exception
 		 * for all unhandled exceptions, which seems incorrect


### PR DESCRIPTION
If the GDB stub is enabled the exception handler will jump to the GDB stub to allow remote GDB debugging.