### PR TITLE
Allow STM32 DCMIPP to work with UVC sample

### DIFF
--- a/drivers/video/video_common.c
+++ b/drivers/video/video_common.c
@@ -468,3 +468,24 @@ int video_estimate_fmt_size(struct video_format *fmt)
 
 	return 0;
 }
+
+int video_set_compose_format(const struct device *dev, struct video_format *fmt)
+{
+	struct video_selection sel = {
+		.type = fmt->type,
+		.target = VIDEO_SEL_TGT_COMPOSE,
+		.rect.left = 0,
+		.rect.top = 0,
+		.rect.width = fmt->width,
+		.rect.height = fmt->height,
+	};
+	int ret;
+
+	ret = video_set_selection(dev, &sel);
+	if (ret < 0 && ret != -ENOSYS) {
+		LOG_ERR("Unable to set selection compose");
+		return ret;
+	}
+
+	return video_set_format(dev, fmt);
+}

--- a/drivers/video/video_stm32_dcmipp.c
+++ b/drivers/video/video_stm32_dcmipp.c
@@ -1331,22 +1331,94 @@ static int stm32_dcmipp_dequeue(const struct device *dev, struct video_buffer **
 }
 
 /*
- * TODO: caps aren't yet handled hence give back straight the caps given by the
- * source.  Normally this should be the intersection of what the source produces
- * vs what the DCMIPP can input (for pipe0) and, for pipe 1 and 2, for a given
- * input format, generate caps based on capabilities, color conversion, decimation
- * etc
+ * For MAIN / AUX pipe, it is necessary that the pitch is a multiple of 16 bytes.
+ * Give here the multiple in number of pixels, which depends on the format chosen
  */
+#define DCMIPP_CEIL_DIV_ROUND_UP_MUL(val, div, mul)						\
+		((((val) + (div) - 1) / (div) + (mul) - 1) / (mul) * (mul))
+
+#define DCMIPP_CEIL_DIV(val, div)								\
+		(((val) + (div) - 1) / (div))
+
+#define DCMIPP_VIDEO_FORMAT_CAP(format, pixmul)	{						\
+	.pixelformat = VIDEO_PIX_FMT_##format,							\
+	.width_min = DCMIPP_CEIL_DIV_ROUND_UP_MUL(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH,	\
+						  STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR,		\
+						  pixmul),					\
+	.width_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH / (pixmul) * (pixmul),		\
+	.height_min = DCMIPP_CEIL_DIV(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,			\
+				      STM32_DCMIPP_MAX_PIPE_SCALE_FACTOR),			\
+	.height_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,					\
+	.width_step = pixmul, .height_step = 1,							\
+}
+
+static const struct video_format_cap stm32_dcmipp_dump_fmt[] = {
+	{
+		.pixelformat = VIDEO_FOURCC_FROM_STR(CONFIG_VIDEO_STM32_DCMIPP_SENSOR_PIXEL_FORMAT),
+		.width_min = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH,
+		.width_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_WIDTH,
+		.height_min = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,
+		.height_max = CONFIG_VIDEO_STM32_DCMIPP_SENSOR_HEIGHT,
+		.width_step = 1, .height_step = 1,
+	},
+	{0},
+};
+
+static const struct video_format_cap stm32_dcmipp_main_fmts[] = {
+	DCMIPP_VIDEO_FORMAT_CAP(RGB565, 8),
+	DCMIPP_VIDEO_FORMAT_CAP(YUYV, 8),
+	DCMIPP_VIDEO_FORMAT_CAP(YVYU, 8),
+	DCMIPP_VIDEO_FORMAT_CAP(GREY, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(RGB24, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(BGR24, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(ARGB32, 4),
+	DCMIPP_VIDEO_FORMAT_CAP(ABGR32, 4),
+	DCMIPP_VIDEO_FORMAT_CAP(RGBA32, 4),
+	DCMIPP_VIDEO_FORMAT_CAP(BGRA32, 4),
+	DCMIPP_VIDEO_FORMAT_CAP(NV12, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(NV21, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(NV16, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(NV61, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(YUV420, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(YVU420, 16),
+	{0},
+};
+
+static const struct video_format_cap stm32_dcmipp_aux_fmts[] = {
+	DCMIPP_VIDEO_FORMAT_CAP(RGB565, 8),
+	DCMIPP_VIDEO_FORMAT_CAP(YUYV, 8),
+	DCMIPP_VIDEO_FORMAT_CAP(YVYU, 8),
+	DCMIPP_VIDEO_FORMAT_CAP(GREY, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(RGB24, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(BGR24, 16),
+	DCMIPP_VIDEO_FORMAT_CAP(ARGB32, 4),
+	DCMIPP_VIDEO_FORMAT_CAP(ABGR32, 4),
+	DCMIPP_VIDEO_FORMAT_CAP(RGBA32, 4),
+	DCMIPP_VIDEO_FORMAT_CAP(BGRA32, 4),
+	{0},
+};
+
 static int stm32_dcmipp_get_caps(const struct device *dev, struct video_caps *caps)
 {
-	const struct stm32_dcmipp_config *config = dev->config;
-	int ret;
+	struct stm32_dcmipp_pipe_data *pipe = dev->data;
 
-	ret = video_get_caps(config->source_dev, caps);
+	switch (pipe->id) {
+	case DCMIPP_PIPE0:
+		caps->format_caps = stm32_dcmipp_dump_fmt;
+		break;
+	case DCMIPP_PIPE1:
+		caps->format_caps = stm32_dcmipp_main_fmts;
+		break;
+	case DCMIPP_PIPE2:
+		caps->format_caps = stm32_dcmipp_aux_fmts;
+		break;
+	default:
+		CODE_UNREACHABLE;
+	}
 
 	caps->min_vbuf_count = 1;
 
-	return ret;
+	return 0;
 }
 
 static int stm32_dcmipp_get_frmival(const struct device *dev, struct video_frmival *frmival)

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -983,6 +983,27 @@ int64_t video_get_csi_link_freq(const struct device *dev, uint8_t bpp, uint8_t l
 int video_estimate_fmt_size(struct video_format *fmt);
 
 /**
+ * @brief Set compose rectangle (if applicable) prior to setting format
+ *
+ * Some devices expose compose capabilities, allowing them to apply a transformation
+ * (downscale / upscale) to the frame. For those devices, it is necessary to set the
+ * compose rectangle before being able to apply the frame format (which must have the
+ * same width / height as the compose rectangle width / height).
+ * In order to allow non-compose aware application to be able to control such devices,
+ * introduce a helper which, if available, will apply the compose rectangle prior to
+ * setting the format.
+ *
+ * @param dev Pointer to the video device struct to set format
+ * @param fmt Pointer to a video format struct.
+ *
+ * @retval 0 Is successful.
+ * @retval -EINVAL If parameters are invalid.
+ * @retval -ENOTSUP If format is not supported.
+ * @retval -EIO General input / output error.
+ */
+int video_set_compose_format(const struct device *dev, struct video_format *fmt);
+
+/**
  * @defgroup video_pixel_formats Video pixel formats
  * The '|' characters separate the pixels or logical blocks, and spaces separate the bytes.
  * The uppercase letter represents the most significant bit.

--- a/samples/subsys/usb/uvc/Kconfig
+++ b/samples/subsys/usb/uvc/Kconfig
@@ -6,4 +6,16 @@
 # tree, you cannot use them in your own application.
 source "samples/subsys/usb/common/Kconfig.sample_usbd"
 
+menu "UVC specific configuration"
+
+config APP_VIDEO_MAX_RESOLUTIONS
+	int "Maximum number of advertised resolutions"
+	default 5
+	help
+	   Control the maximum number of resolution that will be advertised
+	   to the USB client in case of the video capture supports a range
+	   of resolutions.
+
+endmenu
+
 source "Kconfig.zephyr"

--- a/samples/subsys/usb/uvc/src/main.c
+++ b/samples/subsys/usb/uvc/src/main.c
@@ -60,7 +60,7 @@ static int app_add_format(uint32_t pixfmt, uint32_t width, uint32_t height, bool
 	}
 
 	/* Set the format to get the size */
-	ret = video_set_format(video_dev, &fmt);
+	ret = video_set_compose_format(video_dev, &fmt);
 	if (ret != 0) {
 		LOG_ERR("Could not set the format of %s to %s %ux%u (size %u)",
 			video_dev->name, VIDEO_FOURCC_TO_STR(fmt.pixelformat),
@@ -178,7 +178,7 @@ int main(void)
 
 	fmt.type = VIDEO_BUF_TYPE_OUTPUT;
 
-	ret = video_set_format(video_dev, &fmt);
+	ret = video_set_compose_format(video_dev, &fmt);
 	if (ret != 0) {
 		LOG_ERR("Could not set the format of %s to %s %ux%u (size %u)",
 			video_dev->name, VIDEO_FOURCC_TO_STR(fmt.pixelformat),

--- a/samples/subsys/usb/uvc/src/main.c
+++ b/samples/subsys/usb/uvc/src/main.c
@@ -193,7 +193,8 @@ int main(void)
 	LOG_INF("Preparing %u buffers of %u bytes", CONFIG_VIDEO_BUFFER_POOL_NUM_MAX, fmt.size);
 
 	for (int i = 0; i < CONFIG_VIDEO_BUFFER_POOL_NUM_MAX; i++) {
-		vbuf = video_buffer_alloc(fmt.size, K_NO_WAIT);
+		vbuf = video_buffer_aligned_alloc(fmt.size, CONFIG_VIDEO_BUFFER_POOL_ALIGN,
+						  K_NO_WAIT);
 		if (vbuf == NULL) {
 			LOG_ERR("Could not allocate the video buffer");
 			return -ENOMEM;


### PR DESCRIPTION
This PR contains various area commits.

1. add proper caps for the dcmipp pipe, in order to have them properly retrieved by application / uvc sample
2. introduce a new helper in charge of applying video_set_selection (target COMPOSE) prior to video_set_format
3. Ensure that buffer allocated by UVC sample app are properly aligned in order to work with drivers
4. Simple addition of several commonly used resolution in UVC when the device is advertising range of width/height

I keep this in draft since this is still work in progress and I'd like to open the discussion about those topics.
I added the ```video_set_compose_format``` helper (probably not the best name) in order to add automatically the call to set_selection. However we might want, in the same helper or not to go even further of that and, if the device support it use crop to achieve the format requested, there could also be an option to for example keep aspect-ratio, which do the heavy lifting of checking the native resolution and perform the crop / compose in order to get a frame with the requested resolution while keeping aspect-ratio (if it has been asked to).

I used this new helper on the UVC sample as well, making it easy to select the right resolution.

When a device is advertising a range of width/height, the current UVC sample only expose the max and min resolutions (assuming they can be achieved from a memory point of view).
There would be various way to achieve computing of intermediate resolutions, computing the aspect ratio as well, depending on the step value advertised by the device the amount of intermediate resolution requested (or should I say limited).
In a trial to keep it simple, I put instead a list of commonly used resolution and have the sample app simply check if this can be achieved or not.

This PR depends on 2 other PRs, PR #93192 and PR #94081 so I merged them at the beginning so only the last 6 commits are relevant in this serie.