### PR TITLE
boards: adi: max78000fthr: Enable feather i2c instance

### DIFF
--- a/boards/adi/max78000fthr/max78000fthr_max78000_m4.dts
+++ b/boards/adi/max78000fthr/max78000fthr_max78000_m4.dts
@@ -110,6 +110,12 @@
 	pinctrl-names = "default";
 };
 
+feather_i2c: &i2c1 {
+	status = "okay";
+	pinctrl-0 = <&i2c1_scl_p0_16 &i2c1_sda_p0_17>;
+	pinctrl-names = "default";
+};
+
 &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_mosi_p0_5 &spi0_miso_p0_6 &spi0_sck_p0_7 &spi0_ss0_p0_4>;

--- a/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
+++ b/boards/adi/max78000fthr/max78000fthr_max78000_m4.yaml
@@ -10,6 +10,7 @@ supported:
   - adc
   - counter
   - dma
+  - feather_i2c
   - flash
   - gpio
   - i2c


### PR DESCRIPTION
Enables the i2c instance connected to the feather header.