### PR TITLE
boards: st: nucleo_l552ze_q: Enable USB

### DIFF
--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -123,3 +123,9 @@
 &vbat {
 	status = "okay";
 };
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/boards/st/nucleo_l552ze_q/nucleo_l552ze_q.yaml
+++ b/boards/st/nucleo_l552ze_q/nucleo_l552ze_q.yaml
@@ -11,6 +11,8 @@ supported:
   - adc
   - dma
   - usart
+  - usb_device
+  - usbd
   - spi
 ram: 192
 flash: 512


### PR DESCRIPTION
Add a USB node to the Nucleo L552ZE-Q, enabling the USB samples.