### PR TITLE
ch32 prescalers

### DIFF
--- a/drivers/clock_control/Kconfig.wch_rcc
+++ b/drivers/clock_control/Kconfig.wch_rcc
@@ -4,4 +4,4 @@
 config CLOCK_CONTROL_WCH_RCC
 	bool "WCH CH32V00x Reset and Clock Control (RCC) driver"
 	default y
-	depends on DT_HAS_WCH_CH32V00X_RCC_ENABLED
+	depends on DT_HAS_WCH_CH32V00X_RCC_ENABLED || DT_HAS_WCH_CH32FV2X_V3X_RCC_ENABLED

--- a/drivers/clock_control/Kconfig.wch_rcc
+++ b/drivers/clock_control/Kconfig.wch_rcc
@@ -4,4 +4,4 @@
 config CLOCK_CONTROL_WCH_RCC
 	bool "WCH CH32V00x Reset and Clock Control (RCC) driver"
 	default y
-	depends on DT_HAS_WCH_RCC_ENABLED
+	depends on DT_HAS_WCH_CH32V00X_RCC_ENABLED

--- a/drivers/clock_control/clock_control_wch_rcc.c
+++ b/drivers/clock_control/clock_control_wch_rcc.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT wch_rcc
+#define DT_DRV_COMPAT wch_ch32v00x_rcc
 
 #include <stdint.h>
 

--- a/dts/bindings/clock/wch,ch32fv203_v303-pll-clock.yaml
+++ b/dts/bindings/clock/wch,ch32fv203_v303-pll-clock.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+description: WCH CH32V203/303 CH32F203 PLL
+
+compatible: "wch,ch32fv203_v303-pll-clock"
+
+include: ["wch,ch32fv2x_v3x-pll-clock.yaml"]
+
+properties:
+  div:
+    type: int
+    required: true
+    description: |
+      PLL divider factor applied before the multiplication
+    enum:
+      - 1 # /1
+      - 2 # /2

--- a/dts/bindings/clock/wch,ch32fv208-pll-clock.yaml
+++ b/dts/bindings/clock/wch,ch32fv208-pll-clock.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+description: WCH CH32V208/F208 PLL
+
+compatible: "wch,ch32fv208-pll-clock"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+  "#clock-cells":
+    const: 0
+
+  clocks:
+    type: phandle-array
+    required: true
+
+  mul:
+    type: int
+    required: true
+    description: |
+        Main PLL multiplication factor
+    enum:
+      - 2   # x2
+      - 3   # x3
+      - 4   # x4
+      - 5   # x5
+      - 6   # x6
+      - 7   # x7
+      - 8   # x8
+      - 9   # x2
+      - 10  # x10
+      - 11  # x11
+      - 12  # x12
+      - 13  # x13
+      - 14  # x14
+      - 15  # x15
+      - 16  # x16
+      - 18  # x18
+
+  div:
+    type: int
+    required: true
+    description: |
+      PLL divider factor applied before the multiplication
+      1 and 2 can only be used for the HSI and 2, 4 and 8 for the HSE.
+      HSE 2 sets the USBPRE bit, forcing the USB prescaler to \5
+      (only supported if the penultimate digit of the lot number is greated then 0).
+    enum:
+      - 1 # /1
+      - 2 # /2
+      - 4 # /4
+      - 8 # /8

--- a/dts/bindings/clock/wch,ch32fv2x_v3x-pll-clock.yaml
+++ b/dts/bindings/clock/wch,ch32fv2x_v3x-pll-clock.yaml
@@ -3,7 +3,7 @@
 
 description: WCH CH32V20x/30x PLL
 
-compatible: "wch,ch32v20x_30x-pll-clock"
+compatible: "wch,ch32fv2x_v3x-pll-clock"
 
 include: [clock-controller.yaml, base.yaml]
 
@@ -37,3 +37,12 @@ properties:
       - 15  # x15
       - 16  # x16
       - 18  # x18
+
+  div:
+    type: int
+    required: true
+    description: |
+      PLL divider factor applied before the multiplication. Currently only affects the HSI
+    enum:
+      - 1 # /1
+      - 2 # /2

--- a/dts/bindings/clock/wch,ch32fv2x_v3x-rcc.yaml
+++ b/dts/bindings/clock/wch,ch32fv2x_v3x-rcc.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Fiona Behrens
+# SPDX-License-Identifier: Apache-2.0
+
+description: WCH CH32FV2x CH32V3x Reset and Clock Control (RCC)
+
+compatible: "wch,ch32fv2x_v3x-rcc"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+  "#clock-cells":
+    const: 1
+
+  hb-prescaler:
+    type: int
+    required: true
+    description: |
+      Prescaler for the HB HCLK
+    enum:
+      - 1 # Off
+      - 2 # /2
+      - 4 # /4
+      - 8 # /8
+      - 16 # /16
+      - 64 # /64
+      - 128 # /128
+      - 256 # /256
+      - 512 # /512
+
+clock-cells:
+  - id

--- a/dts/bindings/clock/wch,ch32v00x-rcc.yaml
+++ b/dts/bindings/clock/wch,ch32v00x-rcc.yaml
@@ -3,7 +3,7 @@
 
 description: WCH CH32V00x Reset and Clock Control (RCC)
 
-compatible: "wch,rcc"
+compatible: "wch,ch32v00x-rcc"
 
 include: [clock-controller.yaml, base.yaml]
 

--- a/dts/bindings/clock/wch,ch32v00x-rcc.yaml
+++ b/dts/bindings/clock/wch,ch32v00x-rcc.yaml
@@ -11,5 +11,25 @@ properties:
   "#clock-cells":
     const: 1
 
+  hb-prescaler:
+    type: int
+    required: true
+    description: |
+      Prescaler for the HB HCLK
+    enum:
+      - 1 # Off
+      - 2 # /2
+      - 3 # /3
+      - 4 # /4
+      - 5 # /5
+      - 6 # /6
+      - 7 # /7
+      - 8 # /8
+      - 16 # /16
+      - 32 # /32
+      - 64 # /64
+      - 128 # /128
+      - 256 # /256
+
 clock-cells:
   - id

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -144,6 +144,7 @@
 			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 0x10>;
 			#clock-cells = <1>;
+			hb-prescaler = <1>;
 			status = "okay";
 		};
 

--- a/dts/riscv/wch/ch32v0/ch32v003.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v003.dtsi
@@ -141,7 +141,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
+			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 0x10>;
 			#clock-cells = <1>;
 			status = "okay";

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -160,7 +160,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
+			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 0x10>;
 			#clock-cells = <1>;
 			status = "okay";

--- a/dts/riscv/wch/ch32v0/ch32v006.dtsi
+++ b/dts/riscv/wch/ch32v0/ch32v006.dtsi
@@ -163,6 +163,7 @@
 			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 0x10>;
 			#clock-cells = <1>;
+			hb-prescaler = <1>;
 			status = "okay";
 		};
 

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -30,7 +30,7 @@
 		clk_lsi: clk-lsi {
 			#clock-cells = <0>;
 			compatible = "fixed-clock";
-			clock-frequency = <DT_FREQ_K(32)>;
+			clock-frequency = <DT_FREQ_K(40)>;
 			status = "disabled";
 		};
 

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -36,8 +36,10 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
+			compatible = "wch,ch32fv2x_v3x-pll-clock",
+				     "wch,ch32fv203_v303-pll-clock";
 			mul = <15>;
+			div = <1>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -151,7 +151,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
+			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 16>;
 			#clock-cells = <1>;
 		};

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -153,6 +153,7 @@
 		rcc: rcc@40021000 {
 			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 16>;
+			hb-prescaler = <1>;
 			#clock-cells = <1>;
 		};
 	};

--- a/dts/riscv/wch/ch32v203/ch32v203.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203.dtsi
@@ -151,7 +151,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,ch32v00x-rcc";
+			compatible = "wch,ch32fv2x_v3x-rcc";
 			reg = <0x40021000 16>;
 			hb-prescaler = <1>;
 			#clock-cells = <1>;

--- a/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
+++ b/dts/riscv/wch/ch32v203/ch32v203rbt.dtsi
@@ -14,6 +14,10 @@
 	reg = <0x20000000 DT_SIZE_K(64)>;
 };
 
+&clk_lsi {
+	clock-frequency = <DT_FREQ_K(32)>;
+};
+
 soc {
 	usart3: uart@40004800 {
 		compatible = "wch,usart";

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -190,7 +190,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,ch32v00x-rcc";
+			compatible = "wch,ch32fv2x_v3x-rcc";
 			reg = <0x40021000 16>;
 			hb-prescaler = <1>;
 			#clock-cells = <1>;

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -192,6 +192,7 @@
 		rcc: rcc@40021000 {
 			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 16>;
+			hb-prescaler = <1>;
 			#clock-cells = <1>;
 		};
 	};

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -190,7 +190,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
+			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 16>;
 			#clock-cells = <1>;
 		};

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -36,8 +36,9 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32fv2x_v3x-pll-clock";
+			compatible = "wch,ch32fv208-pll-clock";
 			mul = <15>;
+			div = <4>;
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/wch/ch32v208/ch32v208.dtsi
+++ b/dts/riscv/wch/ch32v208/ch32v208.dtsi
@@ -36,7 +36,7 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
+			compatible = "wch,ch32fv2x_v3x-pll-clock";
 			mul = <15>;
 			status = "disabled";
 		};

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -194,7 +194,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,rcc";
+			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 16>;
 			#clock-cells = <1>;
 			status = "okay";

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -197,6 +197,7 @@
 			compatible = "wch,ch32v00x-rcc";
 			reg = <0x40021000 16>;
 			#clock-cells = <1>;
+			hb-prescaler = <1>;
 			status = "okay";
 		};
 

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -194,7 +194,7 @@
 		};
 
 		rcc: rcc@40021000 {
-			compatible = "wch,ch32v00x-rcc";
+			compatible = "wch,ch32fv2x_v3x-rcc";
 			reg = <0x40021000 16>;
 			#clock-cells = <1>;
 			hb-prescaler = <1>;

--- a/dts/riscv/wch/ch32v303/ch32v303.dtsi
+++ b/dts/riscv/wch/ch32v303/ch32v303.dtsi
@@ -36,8 +36,10 @@
 
 		pll: pll {
 			#clock-cells = <0>;
-			compatible = "wch,ch32v20x_30x-pll-clock";
+			compatible = "wch,ch32fv2x_v3x-pll-clock",
+				     "wch,ch32fv203_v303-pll-clock";
 			mul = <18>;
+			div = <1>;
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
Add support for the hb-prescaler on all wch socs and also support for pb1 and pb2 on the ch32fv2x_v3x socs

Based on https://github.com/zephyrproject-rtos/zephyr/pull/94537