### PR TITLE
fix PuTTY link in index.rst

### DIFF
--- a/boards/snps/iotdk/doc/index.rst
+++ b/boards/snps/iotdk/doc/index.rst
@@ -192,4 +192,4 @@ References
 
 .. _Digilent Pmod Modules: http://store.digilentinc.com/pmod-modules
 
-.. _Putty website: http://www.putty.org
+.. _Putty website: https://putty.software


### PR DESCRIPTION
The link to PuTTY was pointing to putty.org. This domain has no relation to the PuTTY project! Instead, the website run by the actual PuTTY team can be found under https://putty.software , see https://hachyderm.io/@simontatham/115025974777386803