### PR TITLE
Misc. Doxygen cleanup of device drivers docs

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -11,14 +11,16 @@
 @{
 @}
 
-@brief Device Driver APIs
-@defgroup io_interfaces Device Driver APIs
+@defgroup io_interfaces Device Drivers
+@brief Interfaces to interact with various hardware peripherals.
+@details A collection of hardware-agnostic interfaces used to implement and interact with device
+         drivers.
 @{
 @}
 
-@brief Miscellaneous Drivers APIs
-@defgroup misc_interfaces Miscellaneous Drivers APIs
+@defgroup misc_interfaces Miscellaneous Devices
 @ingroup io_interfaces
+@brief Interfaces for hardware peripherals that do not have a dedicated driver class.
 @{
 @}
 
@@ -28,8 +30,8 @@
 @{
 @}
 
-@brief Multi Function Device Drivers APIs
-@defgroup mfd_interfaces Multi Function Device Drivers APIs
+@brief Interfaces for multi-function devices.
+@defgroup mfd_interfaces Multi-function Devices
 @ingroup io_interfaces
 @{
 @}

--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -54,9 +54,12 @@
 @brief MCUmgr
 @defgroup mcumgr MCUmgr
 @ingroup device_mgmt
+@{
+@}
 
 @brief Transport layers for MCUmgr: SMP, UART, etc.
 @defgroup mcumgr_transport Transport layers
+@ingroup mcumgr
 @{
 @}
 

--- a/doc/connectivity/lora_lorawan/index.rst
+++ b/doc/connectivity/lora_lorawan/index.rst
@@ -95,7 +95,7 @@ API Reference
 LoRa PHY
 ========
 
-.. doxygengroup:: lora_api
+.. doxygengroup:: lora_interface
 
 LoRaWAN
 =======

--- a/doc/hardware/peripherals/edac/index.rst
+++ b/doc/hardware/peripherals/edac/index.rst
@@ -21,4 +21,4 @@ Related configuration option:
 API Reference
 *************
 
-.. doxygengroup:: edac
+.. doxygengroup:: edac_interface

--- a/include/zephyr/arch/cache.h
+++ b/include/zephyr/arch/cache.h
@@ -13,9 +13,8 @@
 #define ZEPHYR_INCLUDE_ARCH_CACHE_H_
 
 /**
- * @brief Cache Controller Interface
- * @defgroup cache_arch_interface Cache Controller Interface
- * @ingroup io_interfaces
+ * @defgroup arch-cache Architecture-specific cache controllers.
+ * @ingroup arch-interface
  * @{
  */
 

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -23,8 +23,8 @@ extern "C" {
 #endif
 
 /**
- * @brief ADC driver APIs
- * @defgroup adc_interface ADC driver APIs
+ * @brief Interfaces for Analog-to-Digital Converters (ADC).
+ * @defgroup adc_interface ADC
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -1,13 +1,14 @@
-/**
- * @file
- * @brief ADC public API header file.
- */
-
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  * Copyright (c) 2015 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup adc_interface
+ * @brief Main header file for ADC (Analog-to-Digital Converter) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_H_

--- a/include/zephyr/drivers/auxdisplay.h
+++ b/include/zephyr/drivers/auxdisplay.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_AUXDISPLAY_H_
 
 /**
- * @brief Auxiliary (Text) Display Interface
- * @defgroup auxdisplay_interface Text Display Interface
+ * @brief Interfaces for auxiliary (textual/non-graphical) displays.
+ * @defgroup auxdisplay_interface Auxiliary (Text) Display
  * @since 3.4
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/auxdisplay.h
+++ b/include/zephyr/drivers/auxdisplay.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public API for auxiliary (textual/non-graphical) display drivers
+ * @ingroup auxdisplay_interface
+ * @brief Main header file for auxiliary (textual/non-graphical) display driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_AUXDISPLAY_H_

--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -18,8 +18,8 @@
 #include <zephyr/device.h>
 
 /**
- * @brief BBRAM Interface
- * @defgroup bbram_interface BBRAM Interface
+ * @brief Interfaces for Battery-Backed RAM (BBRAM).
+ * @defgroup bbram_interface BBRAM
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup bbram_interface
+ * @brief Main header file for Battery-Backed RAM (BBRAM) driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_BBRAM_H
 #define ZEPHYR_INCLUDE_DRIVERS_BBRAM_H
 

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -16,8 +16,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_BLUETOOTH_H_
 
 /**
- * @brief Bluetooth HCI APIs
- * @defgroup bt_hci_api Bluetooth HCI APIs
+ * @brief Interfaces for Bluetooth Host Controller Interface (HCI).
+ * @defgroup bt_hci_api Bluetooth HCI
  *
  * @since 3.7
  * @version 0.2.0

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -5,6 +5,13 @@
  *
  *  SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @ingroup bt_hci_api
+ * @brief Main header file for Bluetooth HCI driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_BLUETOOTH_H_
 #define ZEPHYR_INCLUDE_DRIVERS_BLUETOOTH_H_
 

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -16,8 +16,8 @@
 #include <stddef.h>
 
 /**
- * @brief External Cache Controller Interface
- * @defgroup cache_external_interface External Cache Controller Interface
+ * @brief Interfaces for external cache controllers.
+ * @defgroup cache_external_interface External Cache Controller
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * Public APIs for external cache controller drivers
+ * @ingroup cache_external_interface
+ * @brief Main header file for external cache controller driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CACHE_H_

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -8,7 +8,7 @@
 
 /**
  * @file
- * @brief Main header file for Controller Area Network (CAN) driver API.
+ * @brief Header file for Controller Area Network (CAN) controller driver API.
  * @ingroup can_controller
  */
 

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -15,8 +15,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CELLULAR_H_
 
 /**
- * @brief Cellular interface
- * @defgroup cellular_interface Cellular Interface
+ * @brief Interfaces for cellular modems.
+ * @defgroup cellular_interface Cellular
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/cellular.h
+++ b/include/zephyr/drivers/cellular.h
@@ -6,8 +6,9 @@
  */
 
 /**
- * @file drivers/cellular.h
- * @brief Public cellular network API
+ * @file
+ * @ingroup cellular_interface
+ * @brief Main header file for cellular modem driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CELLULAR_H_

--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CHARGER_H_
 
 /**
- * @brief Charger Interface
- * @defgroup charger_interface Charger Interface
+ * @brief Interfaces for battery chargers.
+ * @defgroup charger_interface Battery Charger
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/charger.h
+++ b/include/zephyr/drivers/charger.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Charger APIs
+ * @ingroup charger_interface
+ * @brief Main header file for battery charger driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CHARGER_H_

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -8,7 +8,8 @@
 
 /**
  * @file
- * @brief Public Clock Control APIs
+ * @ingroup clock_control_interface
+ * @brief Main header file for clock control driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_H_

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -16,8 +16,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_H_
 
 /**
- * @brief Clock Control Interface
- * @defgroup clock_control_interface Clock Control Interface
+ * @brief Interfaces for clock controllers.
+ * @defgroup clock_control_interface Clock Control
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/comparator.h
+++ b/include/zephyr/drivers/comparator.h
@@ -14,8 +14,8 @@
  */
 
 /**
- * @brief Comparator Interface
- * @defgroup comparator_interface Comparator Interface
+ * @brief Interfaces for comparators.
+ * @defgroup comparator_interface Comparator
  * @since 4.0
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/comparator.h
+++ b/include/zephyr/drivers/comparator.h
@@ -8,6 +8,12 @@
 #define ZEPHYR_INCLUDE_DRIVERS_COMPARATOR_H_
 
 /**
+ * @file
+ * @ingroup comparator_interface
+ * @brief Main header file for comparator driver API.
+ */
+
+/**
  * @brief Comparator Interface
  * @defgroup comparator_interface Comparator Interface
  * @since 4.0

--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public APIs for coredump pseudo-device driver
+ * @ingroup coredump_device_interface
+ * @brief Main header file for coredump pseudo-device driver API.
  */
 
 #ifndef INCLUDE_ZEPHYR_DRIVERS_COREDUMP_H_

--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -21,8 +21,8 @@ extern "C" {
 #endif
 
 /**
- * @brief Coredump pseudo-device driver APIs
- * @defgroup coredump_device_interface Coredump pseudo-device driver APIs
+ * @brief Interfaces for coredump pseudo-device.
+ * @defgroup coredump_device_interface Coredump pseudo-device
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -15,8 +15,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_COUNTER_H_
 
 /**
- * @brief Counter Interface
- * @defgroup counter_interface Counter Interface
+ * @brief Interfaces for counters.
+ * @defgroup counter_interface Counter
  * @since 1.14
  * @version 0.8.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * @brief Public API for counter and timer drivers
+ * @ingroup counter_interface
+ * @brief Main header file for counter driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_COUNTER_H_

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief DAC public API header file.
+ * @ingroup dac_interface
+ * @brief Main header file for DAC (Digital-to-Analog Converter) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DAC_H_

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -20,8 +20,8 @@ extern "C" {
 #endif
 
 /**
- * @brief DAC driver APIs
- * @defgroup dac_interface DAC driver APIs
+ * @brief Interfaces for Digital-to-Analog Converters.
+ * @defgroup dac_interface DAC
  * @since 2.3
  * @version 0.8.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public APIs for the DAI (Digital Audio Interface) bus drivers.
+ * @ingroup dai_interface
+ * @brief Main header file for DAI (Digital Audio Interface) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DAI_H_

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -14,11 +14,11 @@
 #define ZEPHYR_INCLUDE_DRIVERS_DAI_H_
 
 /**
- * @defgroup dai_interface DAI Interface
+ * @defgroup dai_interface DAI
  * @since 3.1
  * @version 0.1.0
  * @ingroup io_interfaces
- * @brief DAI Interface
+ * @brief Interfaces for Digital Audio Interfaces.
  *
  * The DAI API provides support for the standard I2S (SSP) and its common variants.
  * It supports also DMIC, HDA and SDW backends. The API has a config function

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * @brief Disk Driver Interface
+ * @ingroup disk_driver_interface
+ * @brief Main header file for disk driver API.
  *
  * This file contains interface for disk access. Apart from disks, various
  * other storage media like Flash and RAM disks may implement this interface to

--- a/include/zephyr/drivers/disk.h
+++ b/include/zephyr/drivers/disk.h
@@ -20,8 +20,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_DISK_H_
 
 /**
- * @brief Disk Driver Interface
- * @defgroup disk_driver_interface Disk Driver Interface
+ * @brief Interfaces for disks.
+ * @defgroup disk_driver_interface Disk Access
  * @since 1.6
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_DISPLAY_H_
 
 /**
- * @brief Display Interface
- * @defgroup display_interface Display Interface
+ * @brief Interfaces for display controllers.
+ * @defgroup display_interface Display
  * @since 1.14
  * @version 0.8.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public API for display drivers and applications
+ * @ingroup display_interface
+ * @brief Main header file for display driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DISPLAY_H_

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -1,13 +1,13 @@
-/**
- * @file
- *
- * @brief Public APIs for the DMA drivers.
- */
-
 /*
  * Copyright (c) 2016 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup dma_interface
+ * @brief Main header file for DMA (Direct Memory Access) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DMA_H_

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -20,10 +20,9 @@
 extern "C" {
 #endif
 
-
 /**
- * @brief DMA Interface
- * @defgroup dma_interface DMA Interface
+ * @brief Interfaces for DMA (Direct Memory Access) controllers.
+ * @defgroup dma_interface DMA
  * @since 1.5
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief EDAC API header file
+ * @ingroup edac_interface
+ * @brief Main header file for EDAC (Error Detection and Correction) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_EDAC_H_

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -18,7 +18,8 @@
 #include <sys/types.h>
 
 /**
- * @defgroup edac_interface EDAC API
+ * @brief Interfaces for Error Detection and Correction (EDAC) controllers.
+ * @defgroup edac_interface EDAC
  * @since 2.5
  * @version 0.8.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -17,7 +17,7 @@
 #include <sys/types.h>
 
 /**
- * @defgroup edac EDAC API
+ * @defgroup edac_interface EDAC API
  * @since 2.5
  * @version 0.8.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/eeprom.h
+++ b/include/zephyr/drivers/eeprom.h
@@ -18,8 +18,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_EEPROM_H_
 
 /**
- * @brief EEPROM Interface
- * @defgroup eeprom_interface EEPROM Interface
+ * @brief Interfaces for Electrically Erasable Programmable Read-Only Memory (EEPROM).
+ * @defgroup eeprom_interface EEPROM
  * @since 2.1
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/eeprom.h
+++ b/include/zephyr/drivers/eeprom.h
@@ -10,7 +10,8 @@
 
 /**
  * @file
- * @brief Public API for EEPROM drivers
+ * @ingroup eeprom_interface
+ * @brief Main header file for EEPROM driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_EEPROM_H_

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -16,8 +16,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_ENTROPY_H_
 
 /**
- * @brief Entropy Interface
- * @defgroup entropy_interface Entropy Interface
+ * @brief Interfaces for entropy hardware.
+ * @defgroup entropy_interface Entropy
  * @since 1.10
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -1,16 +1,18 @@
-/**
- * @file drivers/entropy.h
- *
- * @brief Public APIs for the entropy driver.
- */
-
 /*
  * Copyright (c) 2016 ARM Ltd.
  * Copyright (c) 2017 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef ZEPHYR_INCLUDE_DRIVERS_ENTROPY_H_
+
+/**
+ * @file
+ * @ingroup entropy_interface
+ * @brief Main header file for entropy driver API.
+ */
+
+
+ #ifndef ZEPHYR_INCLUDE_DRIVERS_ENTROPY_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ENTROPY_H_
 
 /**

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public APIs for eSPI driver
+ * @ingroup espi_interface
+ * @brief Main header file for eSPI (Enhanced Serial Peripheral Interface) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_ESPI_H_

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -25,8 +25,9 @@ extern "C" {
 #endif
 
 /**
- * @brief eSPI Driver APIs
- * @defgroup espi_interface ESPI Driver APIs
+ * @brief Interfaces for Enhanced Serial Peripheral Interface (eSPI)
+ *        controllers.
+ * @defgroup espi_interface ESPI
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup espi_emul_interface
+ * @brief Main header file for eSPI emulation driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ESPI_SPI_EMUL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ESPI_SPI_EMUL_H_
 
@@ -12,12 +18,6 @@
 #include <zephyr/drivers/espi.h>
 #include <zephyr/sys/slist.h>
 #include <zephyr/types.h>
-
-/**
- * @file
- *
- * @brief Public APIs for the eSPI emulation drivers.
- */
 
 /**
  * @brief eSPI Emulation Interface

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -21,12 +21,12 @@ extern "C" {
 #endif
 
 /**
- * @brief eSPI SAF Driver APIs
- * @defgroup espi_interface ESPI Driver APIs
- * @ingroup io_interfaces
+ * @brief Interfaces for eSPI SAF (Serial Attached Flash)
+ *        controllers.
+ * @defgroup espi_saf_interface eSPI SAF
+ * @ingroup espi_interface
  * @{
  */
-
 
 /**
  * @code

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * @brief Public API for FLASH drivers
+ * @ingroup flash_interface
+ * @brief Main header file for Flash driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_FLASH_H_

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup fpga_interface
+ * @brief Main header file for FPGA driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_FPGA_H_
 #define ZEPHYR_INCLUDE_DRIVERS_FPGA_H_
 

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -24,7 +24,8 @@ extern "C" {
 #endif
 
 /**
- * @defgroup fpga_interface FPGA Interface.
+ * @brief Interfaces for Field-Programmable Gate Arrays (FPGA).
+ * @defgroup fpga_interface FPGA
  * @since 2.7
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -16,8 +16,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_
 
 /**
- * @brief Fuel Gauge Interface
- * @defgroup fuel_gauge_interface Fuel Gauge Interface
+ * @brief Interfaces for fuel gauges.
+ * @defgroup fuel_gauge_interface Fuel Gauge
  * @since 3.3
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/fuel_gauge.h
+++ b/include/zephyr/drivers/fuel_gauge.h
@@ -6,6 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup fuel_gauge_interface
+ * @brief Main header file for fuel gauge driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_
 #define ZEPHYR_INCLUDE_DRIVERS_BATTERY_H_
 

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -5,8 +5,9 @@
  */
 
 /**
- * @file gnss.h
- * @brief Public GNSS API.
+ * @file
+ * @ingroup gnss_interface
+ * @brief Main header file for GNSS driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GNSS_H_

--- a/include/zephyr/drivers/gnss.h
+++ b/include/zephyr/drivers/gnss.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_GNSS_H_
 
 /**
- * @brief GNSS Interface
- * @defgroup gnss_interface GNSS Interface
+ * @brief Interfaces for Global Navigation Satellite System (GNSS) receivers.
+ * @defgroup gnss_interface GNSS
  * @since 3.6
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -9,8 +9,8 @@
 
 /**
  * @file
- * @brief Public APIs for GPIO drivers
  * @ingroup gpio_interface
+ * @brief Main header file for GPIO driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_H_

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -32,8 +32,9 @@ extern "C" {
 #endif
 
 /**
- * @brief GPIO Driver APIs
- * @defgroup gpio_interface GPIO Driver APIs
+ * @brief Interfaces for General Purpose Input/Output (GPIO)
+ *        controllers.
+ * @defgroup gpio_interface GPIO
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_HAPTICS_H_
 
 /**
- * @brief Haptics Interface
- * @defgroup haptics_interface Haptics Interface
+ * @brief Interfaces for haptic devices.
+ * @defgroup haptics_interface Haptics
  * @ingroup io_interfaces
  * @{
  *

--- a/include/zephyr/drivers/haptics.h
+++ b/include/zephyr/drivers/haptics.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup haptics_interface
+ * @brief Main header file for haptics driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HAPTICS_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HAPTICS_H_
 

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -1,13 +1,13 @@
-/**
- * @file
- *
- * @brief Public APIs to get device Information.
- */
-
 /*
  * Copyright (c) 2018 Alexander Wachter
  *
  * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup hwinfo_interface
+ * @brief Main header file for hardware information (hwinfo) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HWINFO_H_

--- a/include/zephyr/drivers/hwinfo.h
+++ b/include/zephyr/drivers/hwinfo.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_HWINFO_H_
 
 /**
- * @brief Hardware Information Interface
- * @defgroup hwinfo_interface Hardware Info Interface
+ * @brief Interfaces allowing to obtain hardware information.
+ * @defgroup hwinfo_interface Hardware Info
  * @since 1.14
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup hwspinlock_interface
+ * @brief Main header file for hardware spinlock driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_H_
 

--- a/include/zephyr/drivers/hwspinlock.h
+++ b/include/zephyr/drivers/hwspinlock.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_HWSPINLOCK_H_
 
 /**
- * @brief HW spinlock Interface
- * @defgroup hwspinlock_interface HW spinlock Interface
+ * @brief Interfaces for hardware spinlocks.
+ * @defgroup hwspinlock_interface Hardware Spinlock
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_I2C_H_
 
 /**
- * @brief I2C Interface
- * @defgroup i2c_interface I2C Interface
+ * @brief Interfaces for Inter-Integrated Circuit (I2C) controllers.
+ * @defgroup i2c_interface I2C
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -1,14 +1,15 @@
-/**
- * @file
- *
- * @brief Public APIs for the I2C drivers.
- */
-
 /*
  * Copyright (c) 2015 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @ingroup i2c_interface
+ * @brief Main header file for I2C (Inter-Integrated Circuit) driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_H_
 #define ZEPHYR_INCLUDE_DRIVERS_I2C_H_
 

--- a/include/zephyr/drivers/i2c/target/eeprom.h
+++ b/include/zephyr/drivers/i2c/target/eeprom.h
@@ -13,11 +13,11 @@
 #define ZEPHYR_INCLUDE_DRIVERS_I2C_TARGET_EEPROM_H_
 
 /**
- * @brief I2C EEPROM Target Driver API
- * @defgroup i2c_eeprom_target_api I2C EEPROM Target Driver API
+ * @brief Interfaces for I2C EEPROM target devices.
+ * @defgroup i2c_eeprom_target_api I2C EEPROM Target
  * @since 1.13
  * @version 1.0.0
- * @ingroup io_interfaces
+ * @ingroup i2c_interface
  * @{
  */
 

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -14,11 +14,11 @@
 #define ZEPHYR_INCLUDE_DRIVERS_I2S_H_
 
 /**
- * @defgroup i2s_interface I2S Interface
+ * @defgroup i2s_interface I2S
  * @since 1.9
  * @version 1.0.0
  * @ingroup io_interfaces
- * @brief I2S (Inter-IC Sound) Interface
+ * @brief Interfaces for Inter-IC Sound (I2S) controllers.
  *
  * The I2S API provides support for the standard I2S interface standard as well
  * as common non-standard extensions such as PCM Short/Long Frame Sync,

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public APIs for the I2S (Inter-IC Sound) bus drivers.
+ * @ingroup i2s_interface
+ * @brief Main header file for I2S (Inter-IC Sound) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_I2S_H_

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup i3c_interface
+ * @brief Main header file for I3C (Inter-Integrated Circuit) driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_I3C_H_
 #define ZEPHYR_INCLUDE_DRIVERS_I3C_H_
 

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -15,8 +15,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_I3C_H_
 
 /**
- * @brief I3C Interface
- * @defgroup i3c_interface I3C Interface
+ * @brief Interfaces for Improved Inter-Integrated Circuit (I3C) controllers.
+ * @defgroup i3c_interface I3C
  * @since 3.2
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -1,13 +1,13 @@
-/**
- * @file
- *
- * @brief Generic low-level inter-processor mailbox communication API.
- */
-
 /*
  * Copyright (c) 2015 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @ingroup ipm_interface
+ * @brief Main header file for IPM (Inter-Processor Mailbox) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_IPM_H_

--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_IPM_H_
 
 /**
- * @brief IPM Interface
- * @defgroup ipm_interface IPM Interface
+ * @brief Interfaces for Inter-Processor Mailbox (IPM) controllers.
+ * @defgroup ipm_interface IPM
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_LED_H_
 
 /**
- * @brief LED Interface
- * @defgroup led_interface LED Interface
+ * @brief Interfaces for Light-Emitting Diode (LED) controllers.
+ * @defgroup led_interface LED
  * @since 1.12
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public LED driver APIs
+ * @ingroup led_interface
+ * @brief Main header file for LED driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_LED_H_

--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * @brief Public API for controlling linear strips of LEDs.
+ * @ingroup led_strip_interface
+ * @brief Main header file for LED strip driver API.
  *
  * This library abstracts the chipset drivers for individually
  * addressable strips of LEDs.

--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -18,8 +18,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_LED_STRIP_H_
 
 /**
- * @brief LED Strip Interface
- * @defgroup led_strip_interface LED Strip Interface
+ * @brief Interfaces for LED strips.
+ * @defgroup led_strip_interface LED Strip
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @ingroup lora_api
- * @brief Public LoRa driver APIs
+ * @ingroup lora_interface
+ * @brief Main header file for LoRa driver API.
  */
 #ifndef ZEPHYR_INCLUDE_DRIVERS_LORA_H_
 #define ZEPHYR_INCLUDE_DRIVERS_LORA_H_

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -13,8 +13,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_LORA_H_
 
 /**
- * @file
- * @brief Public LoRa APIs
+ * @brief Interfaces for LoRa transceivers.
  * @defgroup lora_interface LoRa
  * @since 2.2
  * @version 0.1.0

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -15,7 +15,7 @@
 /**
  * @file
  * @brief Public LoRa APIs
- * @defgroup lora_api LoRa APIs
+ * @defgroup lora_interface LoRa
  * @since 2.2
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -24,8 +24,8 @@ extern "C" {
 #endif
 
 /**
- * @brief MBOX Interface
- * @defgroup mbox_interface MBOX Interface
+ * @brief Interfaces for mailbox (MBOX) devices.
+ * @defgroup mbox_interface MBOX
  * @since 1.0
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup mbox_interface
+ * @brief Main header file for MBOX (Mailbox) driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MBOX_H_
 #define ZEPHYR_INCLUDE_DRIVERS_MBOX_H_
 

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -1,15 +1,16 @@
-/**
- * @file
- *
- * @brief Public APIs for MDIO drivers.
- */
-
 /*
  * Copyright (c) 2021 IP-Logix Inc.
  * Copyright 2023 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @ingroup mdio_interface
+ * @brief Main header file for MDIO (Management Data Input/Output) driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MDIO_H_
 #define ZEPHYR_INCLUDE_DRIVERS_MDIO_H_
 

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -15,8 +15,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_MDIO_H_
 
 /**
- * @brief MDIO Interface
- * @defgroup mdio_interface MDIO Interface
+ * @brief Interfaces for Management Data Input/Output (MDIO) controllers.
+ * @defgroup mdio_interface MDIO
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -23,8 +23,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_MIPI_DBI_H_
 
 /**
- * @brief MIPI-DBI driver APIs
- * @defgroup mipi_dbi_interface MIPI-DBI driver APIs
+ * @brief Interfaces for MIPI-DBI (Display Bus Interface).
+ * @defgroup mipi_dbi_interface MIPI-DBI
  * @since 3.6
  * @version 0.8.0
  * @ingroup display_interface

--- a/include/zephyr/drivers/mipi_dbi.h
+++ b/include/zephyr/drivers/mipi_dbi.h
@@ -6,12 +6,13 @@
 
 /**
  * @file
- * @brief Public APIs for MIPI-DBI drivers
+ * @ingroup mipi_dbi_interface
+ * @brief Main header file for MIPI-DBI (Display Bus Interface) driver API.
  *
  * MIPI-DBI defines the following 3 interfaces:
- * Type A: Motorola 6800 type parallel bus
- * Type B: Intel 8080 type parallel bus
- * Type C: SPI Type (1 bit bus) with 3 options:
+ * - Type A: Motorola 6800 type parallel bus
+ * - Type B: Intel 8080 type parallel bus
+ * - Type C: SPI Type (1 bit bus) with 3 options:
  *     1. 9 write clocks per byte, final bit is command/data selection bit
  *     2. Same as above, but 16 write clocks per byte
  *     3. 8 write clocks per byte. Command/data selected via GPIO pin

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public APIs for MIPI-DSI drivers
+ * @ingroup mipi_dsi_interface
+ * @brief Main header file for MIPI-DSI (Display Serial Interface) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MIPI_DSI_H_

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_MIPI_DSI_H_
 
 /**
- * @brief MIPI-DSI driver APIs
- * @defgroup mipi_dsi_interface MIPI-DSI driver APIs
+ * @brief Interfaces for MIPI-DSI (Display Serial Interface).
+ * @defgroup mipi_dsi_interface MIPI-DSI
  * @since 3.1
  * @version 0.8.0
  * @ingroup display_interface

--- a/include/zephyr/drivers/misc/coresight/stmesp.h
+++ b/include/zephyr/drivers/misc/coresight/stmesp.h
@@ -10,8 +10,8 @@
 #include <zephyr/devicetree.h>
 
 /**
- * @brief Coresight STMESP (STM Extended Stimulus Port) Interface
- * @defgroup stmsp_interface Coresight STMESP interface
+ * @brief Interfaces for Coresight STMESP (STM Extended Stimulus Port)
+ * @defgroup stmsp_interface Coresight STMESP
  * @ingroup misc_interfaces
  * @{
  */

--- a/include/zephyr/drivers/misc/devmux/devmux.h
+++ b/include/zephyr/drivers/misc/devmux/devmux.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Public APIs for the Device Multiplexer driver
+ * @ingroup demux_interface
  */
 
 #ifndef INCLUDE_ZEPHYR_DRIVERS_MISC_DEVMUX_H_
@@ -22,8 +23,8 @@ extern "C" {
 #endif
 
 /**
- * @brief Devmux Driver APIs
- * @defgroup demux_interface Devmux Driver APIs
+ * @brief Interfaces for device multiplexers.
+ * @defgroup demux_interface Devmux
  * @ingroup misc_interfaces
  *
  * @details

--- a/include/zephyr/drivers/misc/ft8xx/ft8xx.h
+++ b/include/zephyr/drivers/misc/ft8xx/ft8xx.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief FT8XX public API
+ * @ingroup ft8xx_interface
  */
 
 #ifndef ZEPHYR_DRIVERS_MISC_FT8XX_FT8XX_H_
@@ -20,8 +21,8 @@ extern "C" {
 #endif
 
 /**
- * @brief FT8xx driver public APIs
- * @defgroup ft8xx_interface FT8xx driver APIs
+ * @brief Interfaces for FTDI FT8xx graphic controller.
+ * @defgroup ft8xx_interface FTDI FT8xx
  * @ingroup misc_interfaces
  * @{
  */

--- a/include/zephyr/drivers/misc/grove_lcd/grove_lcd.h
+++ b/include/zephyr/drivers/misc/grove_lcd/grove_lcd.h
@@ -16,8 +16,8 @@ extern "C" {
 #endif
 
 /**
- * @brief Grove display APIs
- * @defgroup grove_display Grove display APIs
+ * @brief Interfaces for Grove LCD RGB display.
+ * @defgroup grove_display Grove display
  * @ingroup third_party
  * @{
  */

--- a/include/zephyr/drivers/misc/interconn/renesas_elc/renesas_elc.h
+++ b/include/zephyr/drivers/misc/interconn/renesas_elc/renesas_elc.h
@@ -7,14 +7,15 @@
 /**
  * @file
  * @brief Public APIs for the Renesas ELC driver
+ * @ingroup renesas_elc_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MISC_RENESAS_ELC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_MISC_RENESAS_ELC_H_
 
 /**
- * @brief Renesas ELC driver public APIs
- * @defgroup renesas_elc_interface Renesas ELC driver APIs
+ * @brief Interfaces for Renesas Event Link Controller (ELC).
+ * @defgroup renesas_elc_interface Renesas ELC
  * @ingroup misc_interfaces
  * @{
  */

--- a/include/zephyr/drivers/misc/nxp_flexio/nxp_flexio.h
+++ b/include/zephyr/drivers/misc/nxp_flexio/nxp_flexio.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_DRIVERS_MISC_NXP_FLEXIO_NXP_FLEXIO_H_
 
 /**
- * @brief NXP FlexIO driver APIs
- * @defgroup nxp_flexio_interface NXP FlexIO driver APIs
+ * @brief Interfaces for NXP FlexIO.
+ * @defgroup nxp_flexio_interface NXP FlexIO
  * @ingroup misc_interfaces
  *
  * @{

--- a/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
+++ b/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
@@ -16,8 +16,8 @@
 #define ZEPHYR_DRIVERS_MISC_PIO_PICO_RPI_PIO_PICO_RPI_H_
 
 /**
- * @brief Raspberry Pi Pico PIO driver APIs
- * @defgroup pio_rpi_pico_interface Raspberry Pi Pico PIO Driver APIs
+ * @brief Interfaces for Raspberry Pi Pico Programmable I/O (PIO).
+ * @defgroup pio_rpi_pico_interface Raspberry Pi Pico PIO
  * @ingroup misc_interfaces
  *
  * @{

--- a/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
+++ b/include/zephyr/drivers/misc/timeaware_gpio/timeaware_gpio.h
@@ -7,13 +7,14 @@
 /**
  * @file
  * @brief Public APIs for Time-aware GPIO drivers
+ * @ingroup tgpio_interface
  */
 #ifndef ZEPHYR_DRIVERS_MISC_TIMEAWARE_GPIO_TIMEAWARE_GPIO
 #define ZEPHYR_DRIVERS_MISC_TIMEAWARE_GPIO_TIMEAWARE_GPIO
 
 /**
- * @brief Time-aware GPIO Interface
- * @defgroup tgpio_interface Time-aware GPIO Interface
+ * @brief Interfaces for time-aware GPIO controllers.
+ * @defgroup tgpio_interface Time-aware GPIO
  * @since 3.5
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -6,9 +6,8 @@
 
 /**
  * @file
- * @brief Public APIs for MSPI driver
- * @since 3.7
- * @version 0.1.0
+ * @ingroup mspi_interface
+ * @brief Main header file for MSPI (Multi-Master Serial Peripheral Interface) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_MSPI_H_
@@ -29,6 +28,8 @@ extern "C" {
 /**
  * @brief MSPI Driver APIs
  * @defgroup mspi_interface MSPI Driver APIs
+ * @since 3.7
+ * @version 0.1.0
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -26,8 +26,9 @@ extern "C" {
 #endif
 
 /**
- * @brief MSPI Driver APIs
- * @defgroup mspi_interface MSPI Driver APIs
+ * @brief Interfaces for Multi-bit Serial Peripheral Interface (MSPI)
+ *        controllers.
+ * @defgroup mspi_interface MSPI
  * @since 3.7
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/mspi/devicetree.h
+++ b/include/zephyr/drivers/mspi/devicetree.h
@@ -10,7 +10,7 @@
 /**
  * @brief MSPI Devicetree related macros
  * @defgroup mspi_devicetree MSPI Devicetree related macros
- * @ingroup io_interfaces
+ * @ingroup mspi_interface
  * @{
  */
 

--- a/include/zephyr/drivers/pcie/controller.h
+++ b/include/zephyr/drivers/pcie/controller.h
@@ -21,9 +21,9 @@
 #endif
 
 /**
- * @brief PCI Express Controller Interface
- * @defgroup pcie_controller_interface PCI Express Controller Interface
- * @ingroup io_interfaces
+ * @brief Interfaces for PCIe Controllers.
+ * @defgroup pcie_controller_interface PCIe Controller
+ * @ingroup pcie_interface
  * @{
  */
 

--- a/include/zephyr/drivers/pcie/pcie.h
+++ b/include/zephyr/drivers/pcie/pcie.h
@@ -8,9 +8,15 @@
 #define ZEPHYR_INCLUDE_DRIVERS_PCIE_PCIE_H_
 
 /**
- * @brief PCIe Host Interface
- * @defgroup pcie_host_interface PCIe Host Interface
+ * @brief Interfaces for PCIe devices.
+ * @defgroup pcie_interface PCIe
  * @ingroup io_interfaces
+ * @{
+ * @}
+ *
+ * @brief Interfaces for PCIe Host.
+ * @defgroup pcie_host_interface PCIe Host
+ * @ingroup pcie_interface
  * @{
  */
 

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public Platform Environment Control Interface driver APIs
+ * @ingroup peci_interface
+ * @brief Main header file for PECI (Platform Environment Control Interface) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PECI_H_

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -14,8 +14,9 @@
 #define ZEPHYR_INCLUDE_DRIVERS_PECI_H_
 
 /**
- * @brief PECI Interface 3.0
- * @defgroup peci_interface PECI Interface
+ * @brief Interfaces for Platform Environment Control Interface (PECI)
+ *        devices.
+ * @defgroup peci_interface PECI
  * @since 2.1
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -13,8 +13,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_PINCTRL_H_
 
 /**
- * @brief Pin Controller Interface
- * @defgroup pinctrl_interface Pin Controller Interface
+ * @brief Interfaces for pin controllers.
+ * @defgroup pinctrl_interface Pin Control
  * @since 3.0
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -5,7 +5,8 @@
 
 /**
  * @file
- * Public APIs for pin control drivers
+ * @brief Main header file for pin control driver API.
+ * @ingroup pinctrl_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PINCTRL_H_

--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -23,8 +23,8 @@ extern "C" {
 #endif
 
 /**
- * @brief PS/2 Driver APIs
- * @defgroup ps2_interface PS/2 Driver APIs
+ * @brief Interfaces for PS/2 devices.
+ * @defgroup ps2_interface PS/2
  * @ingroup io_interfaces
  *
  * Callers of this API are responsible for setting the typematic rate

--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -6,9 +6,8 @@
 
 /**
  * @file
- * @brief Public API for PS/2 devices such as keyboard and mouse.
- * Callers of this API are responsible for setting the typematic rate
- * and decode keys using their desired scan code tables.
+ * @ingroup ps2_interface
+ * @brief Main header file for PS/2 (Personal System/2) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PS2_H_
@@ -27,6 +26,10 @@ extern "C" {
  * @brief PS/2 Driver APIs
  * @defgroup ps2_interface PS/2 Driver APIs
  * @ingroup io_interfaces
+ *
+ * Callers of this API are responsible for setting the typematic rate
+ * and decode keys using their desired scan code tables.
+ *
  * @{
  */
 

--- a/include/zephyr/drivers/psi5/psi5.h
+++ b/include/zephyr/drivers/psi5/psi5.h
@@ -20,8 +20,8 @@ extern "C" {
 #endif
 
 /**
- * @brief PSI5 Interface
- * @defgroup psi5_interface PSI5 Interface
+ * @brief Interfaces for Peripheral Sensor Interface (PSI5).
+ * @defgroup psi5_interface PSI5
  * @since 4.2
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_
 
 /**
- * @brief PTP Clock Interface
- * @defgroup ptp_clock_interface PTP Clock Interface
+ * @brief Interfaces for Precision Time Protocol (PTP) clocks.
+ * @defgroup ptp_clock_interface PTP Clock
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup ptp_clock_interface
+ * @brief Main header file for PTP (Precision Time Protocol) clock driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PTP_CLOCK_H_
 

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -15,8 +15,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_PWM_H_
 
 /**
- * @brief PWM Interface
- * @defgroup pwm_interface PWM Interface
+ * @brief Interfaces for Pulse Width Modulation (PWM) controllers.
+ * @defgroup pwm_interface PWM
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * @brief Public PWM Driver APIs
+ * @ingroup pwm_interface
+ * @brief Main header file for PWM (Pulse Width Modulation) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PWM_H_

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -7,6 +7,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup regulator_interface
+ * @brief Main header file for regulator driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_REGULATOR_H_
 #define ZEPHYR_INCLUDE_DRIVERS_REGULATOR_H_
 

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -17,8 +17,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_REGULATOR_H_
 
 /**
- * @brief Regulator Interface
- * @defgroup regulator_interface Regulator Interface
+ * @brief Interfaces for regulators.
+ * @defgroup regulator_interface Regulator
  * @since 2.4
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_RESET_H_
 
 /**
- * @brief Reset Controller Interface
- * @defgroup reset_controller_interface Reset Controller Interface
+ * @brief Interfaces for reset controllers.
+ * @defgroup reset_controller_interface Reset Controller
  * @since 3.1
  * @version 0.2.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public Reset Controller driver APIs
+ * @ingroup reset_controller_interface
+ * @brief Main header file for reset controller driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RESET_H_

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -29,8 +29,8 @@ BUILD_ASSERT(!(sizeof(off_t) > sizeof(size_t)),
 	     "Size of off_t must be equal or less than size of size_t");
 
 /**
- * @brief Retained memory driver interface
- * @defgroup retained_mem_interface Retained memory driver interface
+ * @brief Interfaces for retained memory.
+ * @defgroup retained_mem_interface Retained memory
  * @since 3.4
  * @version 0.8.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/retained_mem.h
+++ b/include/zephyr/drivers/retained_mem.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public API for retained memory drivers
+ * @ingroup retained_mem_interface
+ * @brief Main header file for retained memory driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RETAINED_MEM_

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -15,8 +15,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_RTC_H_
 
 /**
- * @brief RTC Interface
- * @defgroup rtc_interface RTC Interface
+ * @brief Interfaces for real-time clocks (RTC).
+ * @defgroup rtc_interface RTC
  * @since 3.4
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/rtc.h
+++ b/include/zephyr/drivers/rtc.h
@@ -7,7 +7,8 @@
 
 /**
  * @file drivers/rtc.h
- * @brief Public real time clock driver API
+ * @ingroup rtc_interface
+ * @brief Main header file for real-time clock (RTC) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_H_

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -18,8 +18,8 @@
 #include <zephyr/sd/sd_spec.h>
 
 /**
- * @brief SDHC interface
- * @defgroup sdhc_interface SDHC interface
+ * @brief Interfaces for Secure Digital Host Controllers (SDHC).
+ * @defgroup sdhc_interface SDHC
  * @since 3.1
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief SD Host Controller public API header file.
+ * @ingroup sdhc_interface
+ * @brief Main header file for SDHC (Secure Digital Host Controller) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SDHC_H_

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -12,9 +12,9 @@
  * @brief Main header file for sensor driver API.
  */
 
- /**
- * @brief Sensor Interface
- * @defgroup sensor_interface Sensor Interface
+/**
+ * @brief Interfaces for sensors.
+ * @defgroup sensor_interface Sensor
  * @since 1.2
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -1,18 +1,18 @@
-/**
- * @file drivers/sensor.h
- *
- * @brief Public APIs for the sensor driver.
- */
-
 /*
- * Copyright (c) 2016 Intel Corporation
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+* Copyright (c) 2016 Intel Corporation
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_H_
 
 /**
+ * @file
+ * @ingroup sensor_interface
+ * @brief Main header file for sensor driver API.
+ */
+
+ /**
  * @brief Sensor Interface
  * @defgroup sensor_interface Sensor Interface
  * @since 1.2

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -927,22 +927,23 @@ static inline int z_impl_sensor_channel_get(const struct device *dev,
  * Generic data structure used for encoding the sample timestamp and number of channels sampled.
  */
 struct __attribute__((__packed__)) sensor_data_generic_header {
-	/* The timestamp at which the data was collected from the sensor */
+	/** The timestamp at which the data was collected from the sensor */
 	uint64_t timestamp_ns;
 
 	/*
-	 * The number of channels present in the frame. This will be the true number of elements in
-	 * channel_info and in the q31 values that follow the header.
+	 ** The number of channels present in the frame.
+	 * This will be the true number of elements in channel_info and in the q31 values that
+	 * follow the header.
 	 */
 	uint32_t num_channels;
 
-	/* Shift value for all samples in the frame */
+	/** Shift value for all samples in the frame */
 	int8_t shift;
 
 	/* This padding is needed to make sure that the 'channels' field is aligned */
 	int8_t _padding[sizeof(struct sensor_chan_spec) - 1];
 
-	/* Channels present in the frame */
+	/** Channels present in the frame */
 	struct sensor_chan_spec channels[0];
 };
 

--- a/include/zephyr/drivers/sent/sent.h
+++ b/include/zephyr/drivers/sent/sent.h
@@ -7,6 +7,7 @@
 /**
  * @file
  * @brief Single Edge Nibble Transmission (SENT) driver API.
+ * @ingroup sent_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENT_H_

--- a/include/zephyr/drivers/sent/sent.h
+++ b/include/zephyr/drivers/sent/sent.h
@@ -21,8 +21,8 @@ extern "C" {
 #endif
 
 /**
- * @brief SENT Interface
- * @defgroup sent_interface SENT Interface
+ * @brief Interfaces for Single Edge Nibble Transmission (SENT) peripherals.
+ * @defgroup sent_interface SENT
  * @since 4.2
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public SMBus Driver APIs
+ * @ingroup smbus_interface
+ * @brief Main header file for SMBus (System Management Bus) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SMBUS_H_

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_SMBUS_H_
 
 /**
- * @brief SMBus Interface
- * @defgroup smbus_interface SMBus Interface
+ * @brief Interfaces for System Management Bus (SMBus).
+ * @defgroup smbus_interface SMBus
  * @since 3.4
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -14,8 +14,9 @@
 #define ZEPHYR_INCLUDE_DRIVERS_SPI_H_
 
 /**
- * @brief SPI Interface
- * @defgroup spi_interface SPI Interface
+ * @brief Interfaces for Serial Peripheral Interface (SPI)
+ *        controllers.
+ * @defgroup spi_interface SPI
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public API for SPI drivers and applications
+ * @ingroup spi_interface
+ * @brief Main header file for SPI (Serial Peripheral Interface) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SPI_H_

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -6,7 +6,8 @@
 
 /**
  * @file drivers/stepper.h
- * @brief Public API for Stepper Driver
+ * @ingroup stepper_interface
+ * @brief Main header file for stepper driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_STEPPER_H_

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_STEPPER_H_
 
 /**
- * @brief Stepper Driver Interface
- * @defgroup stepper_interface Stepper Driver Interface
+ * @brief Interfaces for stepper motor controllers.
+ * @defgroup stepper_interface Stepper
  * @since 4.0
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/swdp.h
+++ b/include/zephyr/drivers/swdp.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Serial Wire Debug Port interface driver API
+ * @ingroup swdp_interface
+ * @brief Main header file for SWDP (Serial Wire Debug Port) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_SWDP_H_

--- a/include/zephyr/drivers/swdp.h
+++ b/include/zephyr/drivers/swdp.h
@@ -20,7 +20,8 @@ extern "C" {
 #endif
 
 /**
- * @defgroup swdp_interface SWDP Interface
+ * @brief Interfaces for Serial Wire Debug Port (SWDP).
+ * @defgroup swdp_interface SWDP
  * @since 3.7
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Public SYSCON driver APIs
+ * @ingroup syscon_interface
+ * @brief Main header file for SYSCON (System Control) driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SYSCON_H_

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_SYSCON_H_
 
 /**
- * @brief SYSCON Interface
- * @defgroup syscon_interface SYSCON Interface
+ * @brief Interfaces for system control registers.
+ * @defgroup syscon_interface System control (SYSCON)
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -5,9 +5,9 @@
  */
 
 /**
- * @file drivers/tee.h
- *
- * @brief Public APIs for the tee driver.
+ * @file
+ * @ingroup tee_interface
+ * @brief Main header file for TEE (Trusted Execution Environment) driver API.
  */
 
 /*

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -44,8 +44,8 @@
 #include <zephyr/sys/util.h>
 
 /**
- * @brief Trusted Execution Environment Interface
- * @defgroup tee_interface TEE Interface
+ * @brief Interfaces to work with Trusted Execution Environment (TEE).
+ * @defgroup tee_interface TEE
  * @ingroup io_interfaces
  * @{
  *

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * @brief Public APIs for UART drivers
+ * @ingroup uart_interface
+ * @brief Main header file for UART driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_UART_H_

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -15,8 +15,9 @@
 #define ZEPHYR_INCLUDE_DRIVERS_UART_H_
 
 /**
- * @brief UART Interface
- * @defgroup uart_interface UART Interface
+ * @brief Interfaces for Universal Asynchronous Receiver/Transmitter (UART)
+ *        controllers.
+ * @defgroup uart_interface UART
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/video-controls.h
+++ b/include/zephyr/drivers/video-controls.h
@@ -10,8 +10,8 @@
 
 /**
  * @file
- *
- * @brief Public APIs for Video.
+ * @ingroup video_controls
+ * @brief Main header file for video controls driver API.
  */
 
 /**

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -16,8 +16,8 @@
 #define ZEPHYR_INCLUDE_VIDEO_H_
 
 /**
- * @brief Video Interface
- * @defgroup video_interface Video Interface
+ * @brief Interfaces for video devices.
+ * @defgroup video_interface Video
  * @since 2.1
  * @version 1.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -1,9 +1,3 @@
-/**
- * @file
- *
- * @brief Public APIs for Video.
- */
-
 /*
  * Copyright (c) 2019 Linaro Limited.
  * Copyright 2025 NXP
@@ -11,6 +5,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @ingroup video_interface
+ * @brief Main header file for video driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_VIDEO_H_
 #define ZEPHYR_INCLUDE_VIDEO_H_
 

--- a/include/zephyr/drivers/virtio.h
+++ b/include/zephyr/drivers/virtio.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup virtio_interface
+ * @brief Main header file for Virtio driver API.
+ */
+
 #ifndef ZEPHYR_VIRTIO_VIRTIO_H_
 #define ZEPHYR_VIRTIO_VIRTIO_H_
 #include <zephyr/device.h>

--- a/include/zephyr/drivers/virtio.h
+++ b/include/zephyr/drivers/virtio.h
@@ -20,8 +20,8 @@ extern "C" {
 #endif
 
 /**
- * @brief Virtio Interface
- * @defgroup virtio_interface Virtio Interface
+ * @brief Interfaces for Virtual I/O (VIRTIO) devices.
+ * @defgroup virtio_interface VIRTIO
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -8,8 +8,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_VIRTUALIZATION_IVSHMEM_H_
 
 /**
- * @brief Inter-VM Shared Memory (ivshmem) reference API
- * @defgroup ivshmem Inter-VM Shared Memory (ivshmem) reference API
+ * @brief Interfaces for Inter-VM Shared Memory (ivshmem).
+ * @defgroup ivshmem Inter-VM Shared Memory
  * @ingroup io_interfaces
  * @{
  */

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -6,8 +6,9 @@
  */
 
 /**
- * @file
- * @brief Public 1-Wire Driver APIs
+ * @file zephyr/drivers/w1.h
+ * @ingroup w1_interface
+ * @brief Main header file for 1-Wire driver API.
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_W1_H_

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -25,8 +25,8 @@ extern "C" {
 #endif
 
 /**
- * @brief 1-Wire Interface
- * @defgroup w1_interface 1-Wire Interface
+ * @brief Interfaces for 1-Wire devices.
+ * @defgroup w1_interface 1-Wire
  * @since 3.2
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -5,6 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup watchdog_interface
+ * @brief Main header file for watchdog driver API.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_
 #define ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_
 

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -15,8 +15,8 @@
 #define ZEPHYR_INCLUDE_DRIVERS_WATCHDOG_H_
 
 /**
- * @brief Watchdog Interface
- * @defgroup watchdog_interface Watchdog Interface
+ * @brief Interfaces for watchdog devices.
+ * @defgroup watchdog_interface Watchdog
  * @since 1.0
  * @version 1.0.0
  * @ingroup io_interfaces

--- a/include/zephyr/dt-bindings/pwm/pwm.h
+++ b/include/zephyr/dt-bindings/pwm/pwm.h
@@ -7,9 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PWM_PWM_H_
 
 /**
- * @brief PWM Interface
- * @defgroup pwm_interface PWM Interface
- * @ingroup io_interfaces
+ * @addtogroup pwm_interface
  * @{
  */
 

--- a/include/zephyr/dt-bindings/sent/sent.h
+++ b/include/zephyr/dt-bindings/sent/sent.h
@@ -8,9 +8,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SENT_H_
 
 /**
- * @brief SENT Interface
- * @defgroup sent_interface SENT Interface
- * @ingroup io_interfaces
+ * @addtogroup sent_interface
  * @{
  */
 

--- a/include/zephyr/dt-bindings/spi/spi.h
+++ b/include/zephyr/dt-bindings/spi/spi.h
@@ -7,9 +7,7 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_SPI_SPI_H_
 
 /**
- * @brief SPI Interface
- * @defgroup spi_interface SPI Interface
- * @ingroup io_interfaces
+ * @addtogroup spi_interface
  * @{
  */
 

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -14,8 +14,8 @@
 #define ZEPHYR_INCLUDE_INPUT_H_
 
 /**
- * @brief Input Interface
- * @defgroup input_interface Input Interface
+ * @brief Interfaces for input devices.
+ * @defgroup input_interface Input
  * @since 3.4
  * @version 0.1.0
  * @ingroup io_interfaces

--- a/samples/drivers/lora/receive/README.rst
+++ b/samples/drivers/lora/receive/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: lora-receive
    :name: LoRa receive
-   :relevant-api: lora_api
+   :relevant-api: lora_interface
 
    Receive packets in both synchronous and asynchronous mode using the LoRa
    radio.

--- a/samples/drivers/lora/send/README.rst
+++ b/samples/drivers/lora/send/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: lora-send
    :name: LoRa send
-   :relevant-api: lora_api
+   :relevant-api: lora_interface
 
    Transmit a preconfigured payload every second using the LoRa radio.
 

--- a/samples/subsys/edac/README.rst
+++ b/samples/subsys/edac/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: edac
    :name: EDAC shell
-   :relevant-api: edac
+   :relevant-api: edac_interface
 
    Test error detection and correction (EDAC) using shell commands.
 


### PR DESCRIPTION
As presented in TSC meeting earlier today (Sep 3, 2025) -- this is now finally ready to move out of draft and only trivial changes are left, as the most significant ones have been submitted in (many!) separate PRs over the past several weeks.

The summary of the changes is that:

- `@file` command has been added where missing, and `@file`s are always put in a doxygen group so that when [navigating by file](https://docs.zephyrproject.org/latest/doxygen/html/files.html) one can quickly be re-directed to the actual section of the docs that header file logically belongs to
- group names are kept simple, basically just named after the device class (e.g. "ADC") ; no need to say "driver", "interface", "API", it's already implicit
- group brief are expanding acronyms where appropriate, but are generally concise as well

This will be formalized as [doxygen guidelines](https://github.com/zephyrproject-rtos/zephyr/pull/93539) going forward but meanwhile the fact that we now have something more consistent for all drivers should help 
contributors/maintainers keep things aligned as per our rule of "do things the same way you see it being done in the code nearby"

https://builds.zephyrproject.io/zephyr/pr/94570/docs/doxygen/html/group__io__interfaces.html