### PR TITLE
Bluetooth: Controller: Fix extended scanning assert on invalid chan_idx

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -170,7 +170,8 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 	/* No need to scan further if no aux_ptr filled */
 	aux_ptr = (void *)pri_dptr;
 	if (unlikely(!pri_hdr->aux_ptr || !PDU_ADV_AUX_PTR_OFFSET_GET(aux_ptr) ||
-		     (PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED))) {
+		     (PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED) ||
+		     (aux_ptr->chan_idx >= CHM_USED_COUNT_MAX))) {
 		return 0;
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -210,6 +210,7 @@
 
 /* Channel Map Unused channels count minimum */
 #define CHM_USED_COUNT_MIN     2U
+#define CHM_USED_COUNT_MAX     37U
 
 /* Channel Map hop count minimum and maximum */
 #define CHM_HOP_COUNT_MIN      5U

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -584,8 +584,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 	 */
 	if (!aux_ptr || !PDU_ADV_AUX_PTR_OFFSET_GET(aux_ptr) || is_scan_req ||
 	    (PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED) ||
-		(!IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) &&
-		  PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) == EXT_ADV_AUX_PHY_LE_CODED)) {
+	    (!IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) &&
+	     PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) == EXT_ADV_AUX_PHY_LE_CODED) ||
+	    (aux_ptr->chan_idx >= CHM_USED_COUNT_MAX)) {
 		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync_lll) {
 			struct ll_sync_set *sync_set;
 
@@ -1988,9 +1989,9 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 	 */
 	if (!aux_ptr || !PDU_ADV_AUX_PTR_OFFSET_GET(aux_ptr) || is_scan_req ||
 	    (PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) > EXT_ADV_AUX_PHY_LE_CODED) ||
-		(!IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) &&
-		  PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) == EXT_ADV_AUX_PHY_LE_CODED)) {
-
+	    (!IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED) &&
+	     PDU_ADV_AUX_PTR_PHY_GET(aux_ptr) == EXT_ADV_AUX_PHY_LE_CODED) ||
+	    (aux_ptr->chan_idx >= CHM_USED_COUNT_MAX)) {
 		if (is_scan_req) {
 			LL_ASSERT(chain && chain->rx_last);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -847,6 +847,13 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_pdu *rx)
 		if (unlikely(scan->is_stop)) {
 			goto ull_scan_aux_rx_flush;
 		}
+
+		/* Remove auxiliary context association with scan context so
+		 * that LLL can differentiate it to being ULL scheduling.
+		 */
+		if ((lll != NULL) && (lll->lll_aux == lll_aux)) {
+			lll->lll_aux = NULL;
+		}
 	} else {
 		struct ll_sync_set *sync_set;
 
@@ -1423,6 +1430,11 @@ static void flush(void *param)
 	scan = HDR_LLL2ULL(lll);
 	scan = ull_scan_is_valid_get(scan);
 	if (!IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) || scan) {
+		/* Remove auxiliary context association with scan context */
+		if (lll->lll_aux == &aux->lll) {
+			lll->lll_aux = NULL;
+		}
+
 #if defined(CONFIG_BT_CTLR_JIT_SCHEDULING)
 		lll->scan_aux_score = aux->lll.hdr.score;
 #endif /* CONFIG_BT_CTLR_JIT_SCHEDULING */


### PR DESCRIPTION
Fix extended scanning assert on invalid chan_idx received in the aux pointer structure.