### PR TITLE
toolchain: arcmwdt: override unsuitable default implementations

### DIFF
--- a/cmake/compiler/arcmwdt/target.cmake
+++ b/cmake/compiler/arcmwdt/target.cmake
@@ -2,6 +2,7 @@
 find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}ccac PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 find_program(CMAKE_CXX_COMPILER ${CROSS_COMPILE}ccac PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 find_program(CMAKE_ASM_COMPILER ${CROSS_COMPILE}ccac PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+
 # The CMAKE_REQUIRED_FLAGS variable is used by check_c_compiler_flag()
 # (and other commands which end up calling check_c_source_compiles())
 # to add additional compiler flags used during checking. These flags
@@ -37,7 +38,7 @@ set(LLEXT_REMOVE_FLAGS
 # (check_c_compiler_flag function which we wrap with target_cc_option in extensions.cmake)
 # we rely on default MWDT header locations and don't manually specify headers directories.
 
-# common compile options, no copyright msg, little-endian, no small data,
+# Common compile options: no copyright message, little-endian, no small data,
 # no MWDT stack checking
 list(APPEND TOOLCHAIN_C_FLAGS -Hnocopyr -HL -Hnosdata)
 
@@ -58,3 +59,7 @@ endif()
 if(CONFIG_RISCV)
   list(APPEND TOOLCHAIN_C_FLAGS -D__MW_ASM_RV_MACRO__)
 endif()
+
+# The MWDT compiler doesn't need to pass any properties to the linker as for now
+function(compiler_set_linker_properties)
+endfunction()

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -168,3 +168,10 @@ macro(toolchain_ld_relocation)
 	${ZEPHYR_BASE}/kernel/include ${ARCH_DIR}/${ARCH}/include)
   target_link_libraries(code_relocation_source_lib zephyr_interface)
 endmacro()
+
+# Function to map compiler flags into suitable linker flags
+# When using the compiler driver to run the linker, just pass
+# them all through
+function(toolchain_linker_add_compiler_options)
+  add_link_options(${ARGV})
+endfunction()


### PR DESCRIPTION
Provide toolchain-specific implementations for the new functions added in d77b58a, because the default ones end up with build failures.

As the MWDT toolchain doesn't support different combinations of compilers and linkers, there's no need to pass any linker properties from the compiler, at least for the time being. Moreover, the default implementation of compiler_set_linker_properties() uses the compiler flag (--print-libgcc-file-name) that doesn't make any sense for MWDT. Therefore, provide an empty implementation of the function.

The default implementation of toolchain_linker_add_compiler_options() doesn't cause any issues for now, but it's still better to replace it with the passthrough implementation borrowed from ld/lld.

Fixes the build time failures introduced by #94359.