### PR TITLE
samples: stepper: drop newline characters from LOGs

### DIFF
--- a/samples/drivers/stepper/generic/src/main.c
+++ b/samples/drivers/stepper/generic/src/main.c
@@ -10,7 +10,7 @@
 #include <zephyr/kernel.h>
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(stepper, CONFIG_STEPPER_LOG_LEVEL);
+LOG_MODULE_REGISTER(stepper_generic, CONFIG_STEPPER_LOG_LEVEL);
 
 static const struct device *stepper = DEVICE_DT_GET(DT_ALIAS(stepper));
 
@@ -64,12 +64,12 @@ INPUT_CALLBACK_DEFINE(NULL, button_pressed, NULL);
 
 int main(void)
 {
-	LOG_INF("Starting generic stepper sample\n");
+	LOG_INF("Starting generic stepper sample");
 	if (!device_is_ready(stepper)) {
-		LOG_ERR("Device %s is not ready\n", stepper->name);
+		LOG_ERR("Device %s is not ready", stepper->name);
 		return -ENODEV;
 	}
-	LOG_DBG("stepper is %p, name is %s\n", stepper, stepper->name);
+	LOG_DBG("stepper is %p, name is %s", stepper, stepper->name);
 
 	stepper_set_event_callback(stepper, stepper_callback, NULL);
 	stepper_set_reference_position(stepper, 0);
@@ -80,33 +80,35 @@ int main(void)
 		switch (atomic_get(&stepper_mode)) {
 		case STEPPER_MODE_ENABLE:
 			stepper_enable(stepper);
-			LOG_INF("mode: enable\n");
-			break;
-		case STEPPER_MODE_STOP:
-			stepper_stop(stepper);
-			LOG_INF("mode: stop\n");
-			break;
-		case STEPPER_MODE_ROTATE_CW:
-			stepper_run(stepper, STEPPER_DIRECTION_POSITIVE);
-			LOG_INF("mode: rotate cw\n");
-			break;
-		case STEPPER_MODE_ROTATE_CCW:
-			stepper_run(stepper, STEPPER_DIRECTION_NEGATIVE);
-			LOG_INF("mode: rotate ccw\n");
+			LOG_INF("mode: enable");
 			break;
 		case STEPPER_MODE_PING_PONG_RELATIVE:
 			ping_pong_target_position *= -1;
 			stepper_move_by(stepper, ping_pong_target_position);
-			LOG_INF("mode: ping pong relative\n");
+			LOG_INF("mode: ping pong relative");
 			break;
 		case STEPPER_MODE_PING_PONG_ABSOLUTE:
 			ping_pong_target_position *= -1;
 			stepper_move_to(stepper, ping_pong_target_position);
-			LOG_INF("mode: ping pong absolute\n");
+			LOG_INF("mode: ping pong absolute");
+			break;
+		case STEPPER_MODE_ROTATE_CW:
+			stepper_run(stepper, STEPPER_DIRECTION_POSITIVE);
+			LOG_INF("mode: rotate cw");
+			break;
+		case STEPPER_MODE_ROTATE_CCW:
+			stepper_run(stepper, STEPPER_DIRECTION_NEGATIVE);
+			LOG_INF("mode: rotate ccw");
+			break;
+		case STEPPER_MODE_STOP:
+			stepper_stop(stepper);
+			LOG_INF("mode: stop");
 			break;
 		case STEPPER_MODE_DISABLE:
 			stepper_disable(stepper);
-			LOG_INF("mode: disable\n");
+			LOG_INF("mode: disable");
+			break;
+		default:
 			break;
 		}
 	}
@@ -119,7 +121,7 @@ static void monitor_thread(void)
 		int32_t actual_position;
 
 		stepper_get_actual_position(stepper, &actual_position);
-		LOG_DBG("Actual position: %d\n", actual_position);
+		LOG_DBG("Actual position: %d", actual_position);
 		k_sleep(K_MSEC(CONFIG_MONITOR_THREAD_TIMEOUT_MS));
 	}
 }

--- a/samples/drivers/stepper/tmc50xx/src/main.c
+++ b/samples/drivers/stepper/tmc50xx/src/main.c
@@ -9,6 +9,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/stepper/stepper_trinamic.h>
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(stepper_tmc50xx, CONFIG_STEPPER_LOG_LEVEL);
+
 const struct device *stepper = DEVICE_DT_GET(DT_ALIAS(stepper));
 
 int32_t ping_pong_target_position = CONFIG_STEPS_PER_REV * CONFIG_PING_PONG_N_REV *
@@ -29,12 +32,12 @@ void stepper_callback(const struct device *dev, const enum stepper_event event, 
 
 int main(void)
 {
-	printf("Starting tmc50xx stepper sample\n");
+	LOG_INF("Starting tmc50xx stepper sample");
 	if (!device_is_ready(stepper)) {
-		printf("Device %s is not ready\n", stepper->name);
+		LOG_ERR("Device %s is not ready", stepper->name);
 		return -ENODEV;
 	}
-	printf("stepper is %p, name is %s\n", stepper, stepper->name);
+	LOG_DBG("stepper is %p, name is %s", stepper, stepper->name);
 
 	stepper_set_event_callback(stepper, stepper_callback, NULL);
 	stepper_enable(stepper);


### PR DESCRIPTION
- remove unnecessary newline characters from LOGs

- Readjusted the modes in the switch case in order to be coherent with the order of stepping in different modes

- introduce logging in tmc50xx sample