### PR TITLE
Bluetooth: BAP: Fix bad use of bt_ascs_ase_status

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -66,7 +66,7 @@ BUILD_ASSERT(CONFIG_BT_ASCS_MAX_ACTIVE_ASES <= MAX(MAX_ASES_SESSIONS,
 
 #if defined(CONFIG_BT_BAP_UNICAST_SERVER)
 
-#define ASE_ID(_ase) ase->ep.status.id
+#define ASE_ID(_ase) ase->ep.id
 #define ASE_DIR(_id) \
 	(_id > CONFIG_BT_ASCS_MAX_ASE_SNK_COUNT ? BT_AUDIO_DIR_SOURCE : BT_AUDIO_DIR_SINK)
 #define ASE_UUID(_id) \
@@ -178,16 +178,11 @@ static bool is_valid_ase_id(uint8_t ase_id)
 	return IN_RANGE(ase_id, 1, ASE_COUNT);
 }
 
-static enum bt_bap_ep_state ascs_ep_get_state(struct bt_bap_ep *ep)
-{
-	return ep->status.state;
-}
-
 static void ase_free(struct bt_ascs_ase *ase)
 {
 	__ASSERT(ase && ase->conn, "Non-existing ASE");
 
-	LOG_DBG("conn %p ase %p id 0x%02x", (void *)ase->conn, ase, ase->ep.status.id);
+	LOG_DBG("conn %p ase %p id 0x%02x", (void *)ase->conn, ase, ase->ep.id);
 
 	if (ase->ep.iso != NULL) {
 		bt_bap_iso_unbind_ep(ase->ep.iso, &ase->ep);
@@ -270,7 +265,7 @@ static void ascs_disconnect_stream_work_handler(struct k_work *work)
 		__ASSERT(pair_stream->ep != NULL, "Invalid pair_stream %p",
 			 pair_stream);
 
-		if (pair_stream->ep->status.state == BT_BAP_EP_STATE_STREAMING) {
+		if (pair_stream->ep->state == BT_BAP_EP_STATE_STREAMING) {
 			/* Should not disconnect ISO if the stream is paired
 			 * with another one in the streaming state
 			 */
@@ -412,9 +407,9 @@ static void ase_metadata_updated(struct bt_ascs_ase *ase)
 
 static void ase_exit_state_streaming(struct bt_ascs_ase *ase)
 {
+	const enum bt_bap_ep_state next_state = ase->ep.state;
 	struct bt_bap_stream *stream = ase->ep.stream;
 	struct bt_bap_stream_ops *ops;
-	const enum bt_bap_ep_state next_state = ascs_ep_get_state(&ase->ep);
 	uint8_t reason = ase->ep.reason;
 
 	__ASSERT_NO_MSG(stream != NULL);
@@ -456,9 +451,9 @@ static void ase_exit_state_streaming(struct bt_ascs_ase *ase)
 
 static void ase_exit_state_enabling(struct bt_ascs_ase *ase)
 {
+	const enum bt_bap_ep_state next_state = ase->ep.state;
 	struct bt_bap_stream *stream = ase->ep.stream;
 	struct bt_bap_stream_ops *ops;
-	const enum bt_bap_ep_state next_state = ascs_ep_get_state(&ase->ep);
 
 	ops = stream->ops;
 
@@ -519,11 +514,11 @@ static void state_transition_work_handler(struct k_work *work)
 {
 	struct k_work_delayable *d_work = k_work_delayable_from_work(work);
 	struct bt_ascs_ase *ase = CONTAINER_OF(d_work, struct bt_ascs_ase, state_transition_work);
-	const enum bt_bap_ep_state old_state = ascs_ep_get_state(&ase->ep);
 	const enum bt_bap_ep_state new_state = ase->state_pending;
+	const enum bt_bap_ep_state old_state = ase->ep.state;
 	int err;
 
-	ase->ep.status.state = new_state;
+	ase->ep.state = new_state;
 
 	/* Notify ASE state */
 	if (ase->conn != NULL) {
@@ -533,7 +528,7 @@ static void state_transition_work_handler(struct k_work *work)
 			uint32_t retry_delay_ms;
 
 			/* Revert back to old state */
-			ase->ep.status.state = old_state;
+			ase->ep.state = old_state;
 
 			err = bt_conn_get_info(ase->conn, &info);
 			__ASSERT_NO_MSG(err == 0);
@@ -555,7 +550,7 @@ static void state_transition_work_handler(struct k_work *work)
 		}
 	}
 
-	LOG_DBG("ase %p ep %p id 0x%02x %s -> %s", ase, &ase->ep, ase->ep.status.id,
+	LOG_DBG("ase %p ep %p id 0x%02x %s -> %s", ase, &ase->ep, ase->ep.id,
 		bt_bap_ep_state_str(old_state), bt_bap_ep_state_str(new_state));
 
 	if (old_state == new_state) {
@@ -609,10 +604,10 @@ static void state_transition_work_handler(struct k_work *work)
 	}
 }
 
-int ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
+int ascs_ep_set_state(struct bt_bap_ep *ep, enum bt_bap_ep_state state)
 {
 	struct bt_ascs_ase *ase = CONTAINER_OF(ep, struct bt_ascs_ase, ep);
-	const enum bt_bap_ep_state old_state = ascs_ep_get_state(&ase->ep);
+	const enum bt_bap_ep_state old_state = ep->state;
 	bool valid_state_transition = false;
 	int err;
 
@@ -638,15 +633,15 @@ int ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 			valid_state_transition = true;
 			break;
 		case BT_BAP_EP_STATE_DISABLING:
-			valid_state_transition = ase->ep.dir == BT_AUDIO_DIR_SOURCE;
+			valid_state_transition = ep->dir == BT_AUDIO_DIR_SOURCE;
 			break;
 		case BT_BAP_EP_STATE_ENABLING:
 		case BT_BAP_EP_STATE_STREAMING:
 			/* Source ASE transition Streaming->QoS configured is valid on case of CIS
 			 * link-loss.
 			 */
-			valid_state_transition = ase->ep.dir == BT_AUDIO_DIR_SINK ||
-						 ase->unexpected_iso_link_loss;
+			valid_state_transition =
+				ep->dir == BT_AUDIO_DIR_SINK || ase->unexpected_iso_link_loss;
 			break;
 		default:
 			break;
@@ -673,7 +668,7 @@ int ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 		switch (old_state) {
 		case BT_BAP_EP_STATE_ENABLING:
 		case BT_BAP_EP_STATE_STREAMING:
-			valid_state_transition = ase->ep.dir == BT_AUDIO_DIR_SOURCE;
+			valid_state_transition = ep->dir == BT_AUDIO_DIR_SOURCE;
 			break;
 		default:
 			break;
@@ -687,7 +682,7 @@ int ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state)
 			valid_state_transition = true;
 			break;
 		case BT_BAP_EP_STATE_DISABLING:
-			valid_state_transition = ase->ep.dir == BT_AUDIO_DIR_SOURCE;
+			valid_state_transition = ep->dir == BT_AUDIO_DIR_SOURCE;
 			break;
 		default:
 			break;
@@ -800,15 +795,15 @@ static int ascs_ep_get_status(struct bt_bap_ep *ep, struct net_buf_simple *buf)
 		return -EINVAL;
 	}
 
-	LOG_DBG("ep %p id 0x%02x state %s", ep, ep->status.id,
-		bt_bap_ep_state_str(ep->status.state));
+	LOG_DBG("ep %p id 0x%02x state %s", ep, ep->id, bt_bap_ep_state_str(ep->state));
 
 	/* Reset if buffer before using */
 	net_buf_simple_reset(buf);
 
-	(void)net_buf_simple_add_mem(buf, &ep->status, sizeof(ep->status));
+	(void)net_buf_simple_add_u8(buf, ep->id);
+	(void)net_buf_simple_add_u8(buf, ep->state);
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	case BT_BAP_EP_STATE_IDLE:
 	/* Fallthrough */
 	case BT_BAP_EP_STATE_RELEASING:
@@ -849,7 +844,7 @@ static int ascs_iso_accept(const struct bt_iso_accept_info *info, struct bt_iso_
 			continue;
 		}
 
-		state = ascs_ep_get_state(&ase->ep);
+		state = ase->ep.state;
 		if (state != BT_BAP_EP_STATE_ENABLING && state != BT_BAP_EP_STATE_QOS_CONFIGURED) {
 			LOG_WRN("ase %p cannot accept ISO connection", ase);
 			break;
@@ -901,10 +896,10 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 		return;
 	}
 
-	if (ep->status.state != BT_BAP_EP_STATE_STREAMING) {
+	if (ep->state != BT_BAP_EP_STATE_STREAMING) {
 		if (IS_ENABLED(CONFIG_BT_BAP_DEBUG_STREAM_DATA)) {
 			LOG_DBG("ep %p is not in the streaming state: %s", ep,
-				bt_bap_ep_state_str(ep->status.state));
+				bt_bap_ep_state_str(ep->state));
 		}
 
 		return;
@@ -985,9 +980,8 @@ static void ascs_ep_iso_connected(struct bt_bap_ep *ep)
 	const struct bt_bap_stream_ops *stream_ops;
 	struct bt_bap_stream *stream;
 
-	if (ep->status.state != BT_BAP_EP_STATE_ENABLING) {
-		LOG_DBG("ep %p not in enabling state: %s", ep,
-			bt_bap_ep_state_str(ep->status.state));
+	if (ep->state != BT_BAP_EP_STATE_ENABLING) {
+		LOG_DBG("ep %p not in enabling state: %s", ep, bt_bap_ep_state_str(ep->state));
 		return;
 	}
 
@@ -1059,7 +1053,7 @@ static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 	}
 
 	LOG_DBG("stream %p ep %p state %s reason 0x%02x", stream, stream->ep,
-		bt_bap_ep_state_str(ep->status.state), reason);
+		bt_bap_ep_state_str(ep->state), reason);
 
 	stream_ops = stream->ops;
 	if (stream_ops != NULL && stream_ops->disconnected != NULL) {
@@ -1070,10 +1064,10 @@ static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 	(void)k_work_cancel_delayable(&ase->disconnect_work);
 	ep->reason = reason;
 
-	if (ep->status.state == BT_BAP_EP_STATE_RELEASING) {
+	if (ep->state == BT_BAP_EP_STATE_RELEASING) {
 		ascs_ep_set_state(ep, BT_BAP_EP_STATE_IDLE);
-	} else if (ep->status.state == BT_BAP_EP_STATE_STREAMING ||
-		   ep->status.state == BT_BAP_EP_STATE_DISABLING) {
+	} else if (ep->state == BT_BAP_EP_STATE_STREAMING ||
+		   ep->state == BT_BAP_EP_STATE_DISABLING) {
 		/* ASCS_v1.0 3.2 ASE state machine transitions
 		 *
 		 * If the server detects link loss of a CIS for an ASE in the Streaming
@@ -1180,7 +1174,7 @@ static void ascs_cp_rsp_success(uint8_t id)
 
 static int ase_release(struct bt_ascs_ase *ase, uint8_t reason, struct bt_bap_ascs_rsp *rsp)
 {
-	enum bt_bap_ep_state state = ascs_ep_get_state(&ase->ep);
+	enum bt_bap_ep_state state = ase->ep.state;
 	int err;
 
 	if (state == BT_BAP_EP_STATE_IDLE || state == BT_BAP_EP_STATE_RELEASING) {
@@ -1219,7 +1213,7 @@ static int ase_release(struct bt_ascs_ase *ase, uint8_t reason, struct bt_bap_as
 int bt_ascs_release_ase(struct bt_bap_ep *ep)
 {
 	struct bt_ascs_ase *ase = CONTAINER_OF(ep, struct bt_ascs_ase, ep);
-	const enum bt_bap_ep_state state = ascs_ep_get_state(&ase->ep);
+	const enum bt_bap_ep_state state = ep->state;
 
 	if (state == BT_BAP_EP_STATE_IDLE) {
 		ase_free(ase);
@@ -1239,14 +1233,14 @@ static int ase_disable(struct bt_ascs_ase *ase, uint8_t reason, struct bt_bap_as
 
 	ep = &ase->ep;
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	/* Valid only if ASE_State field = 0x03 (Enabling) */
 	case BT_BAP_EP_STATE_ENABLING:
 		/* or 0x04 (Streaming) */
 	case BT_BAP_EP_STATE_STREAMING:
 		break;
 	default:
-		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->state));
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 				       BT_BAP_ASCS_REASON_NONE);
 		return -EBADMSG;
@@ -1302,7 +1296,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 			continue;
 		}
 
-		if (ase->ep.status.state != BT_BAP_EP_STATE_IDLE) {
+		if (ase->ep.state != BT_BAP_EP_STATE_IDLE) {
 			/* We must set the state to idle when the ACL is disconnected immediately,
 			 * as when the ACL disconnect callbacks have been called, the application
 			 * should expect there to be only a single reference to the bt_conn pointer
@@ -1378,7 +1372,7 @@ static uint8_t ase_attr_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 {
 	struct bt_ascs_ase *ase = user_data;
 
-	if (ase->ep.status.id == POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr))) {
+	if (ase->ep.id == POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr))) {
 		ase->attr = attr;
 
 		return BT_GATT_ITER_STOP;
@@ -1392,7 +1386,7 @@ void ascs_ep_init(struct bt_bap_ep *ep, uint8_t id)
 	LOG_DBG("ep %p id 0x%02x", ep, id);
 
 	(void)memset(ep, 0, sizeof(*ep));
-	ep->status.id = id;
+	ep->id = id;
 	ep->dir = ASE_DIR(id);
 	ep->reason = BT_HCI_ERR_SUCCESS;
 }
@@ -1443,7 +1437,7 @@ static struct bt_ascs_ase *ase_find(struct bt_conn *conn, uint8_t id)
 	for (size_t i = 0; i < ARRAY_SIZE(ascs.ase_pool); i++) {
 		struct bt_ascs_ase *ase = &ascs.ase_pool[i];
 
-		if (ase->conn == conn && ase->ep.status.id == id) {
+		if (ase->conn == conn && ase->ep.id == id) {
 			return ase;
 		}
 	}
@@ -1574,7 +1568,7 @@ static int ase_config(struct bt_ascs_ase *ase, const struct bt_ascs_config *cfg)
 		return -ENOMEM;
 	}
 
-	switch (ase->ep.status.state) {
+	switch (ase->ep.state) {
 	/* Valid only if ASE_State field = 0x00 (Idle) */
 	case BT_BAP_EP_STATE_IDLE:
 		/* or 0x01 (Codec Configured) */
@@ -1583,8 +1577,7 @@ static int ase_config(struct bt_ascs_ase *ase, const struct bt_ascs_config *cfg)
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 		break;
 	default:
-		LOG_WRN("Invalid operation in state: %s",
-			bt_bap_ep_state_str(ase->ep.status.state));
+		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ase->ep.state));
 		ascs_cp_rsp_add(ASE_ID(ase), BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 				BT_BAP_ASCS_REASON_NONE);
 		return -EINVAL;
@@ -1924,14 +1917,14 @@ static void ase_qos(struct bt_ascs_ase *ase, uint8_t cig_id, uint8_t cis_id,
 		"latency %u pd %u", ase, cig_id, cis_id, qos->interval, qos->framing, qos->phy,
 		qos->sdu, qos->rtn, qos->latency, qos->pd);
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	/* Valid only if ASE_State field = 0x01 (Codec Configured) */
 	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 	/* or 0x02 (QoS Configured) */
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 		break;
 	default:
-		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->state));
 		*rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 				       BT_BAP_ASCS_REASON_NONE);
 		return;
@@ -2267,13 +2260,13 @@ static void ase_metadata(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta)
 	struct bt_bap_ep *ep;
 	struct bt_bap_ascs_rsp rsp = BT_BAP_ASCS_RSP(BT_BAP_ASCS_RSP_CODE_SUCCESS,
 						     BT_BAP_ASCS_REASON_NONE);
-	uint8_t state;
+	enum bt_bap_ep_state state;
 	int err;
 
 	LOG_DBG("ase %p meta->len %u", ase, meta->len);
 
 	ep = &ase->ep;
-	state = ep->status.state;
+	state = ep->state;
 
 	switch (state) {
 	/* Valid for an ASE only if ASE_State field = 0x03 (Enabling) */
@@ -2320,7 +2313,7 @@ static void ase_metadata(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta)
 	(void)memcpy(ep->codec_cfg.meta, meta->data, meta->len);
 
 	/* Set the state to the same state to trigger the notifications */
-	ascs_ep_set_state(ep, ep->status.state);
+	ascs_ep_set_state(ep, ep->state);
 	ascs_cp_rsp_success(ASE_ID(ase));
 }
 
@@ -2337,9 +2330,9 @@ static int ase_enable(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta)
 	ep = &ase->ep;
 
 	/* Valid for an ASE only if ASE_State field = 0x02 (QoS Configured) */
-	if (ep->status.state != BT_BAP_EP_STATE_QOS_CONFIGURED) {
+	if (ep->state != BT_BAP_EP_STATE_QOS_CONFIGURED) {
 		err = -EBADMSG;
-		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->state));
 		ascs_cp_rsp_add(ASE_ID(ase), BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 				BT_BAP_ASCS_REASON_NONE);
 		return err;
@@ -2480,8 +2473,8 @@ static void ase_start(struct bt_ascs_ase *ase)
 	ep = &ase->ep;
 
 	/* Valid for an ASE only if ASE_State field = 0x02 (QoS Configured) */
-	if (ep->status.state != BT_BAP_EP_STATE_ENABLING) {
-		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->status.state));
+	if (ep->state != BT_BAP_EP_STATE_ENABLING) {
+		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->state));
 		ascs_cp_rsp_add(ASE_ID(ase), BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 				BT_BAP_ASCS_REASON_NONE);
 		return;
@@ -2691,8 +2684,8 @@ static void ase_stop(struct bt_ascs_ase *ase)
 
 	ep = &ase->ep;
 
-	if (ep->status.state != BT_BAP_EP_STATE_DISABLING) {
-		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->status.state));
+	if (ep->state != BT_BAP_EP_STATE_DISABLING) {
+		LOG_WRN("Invalid operation in state: %s", bt_bap_ep_state_str(ep->state));
 		ascs_cp_rsp_add(ASE_ID(ase), BT_BAP_ASCS_RSP_CODE_INVALID_ASE_STATE,
 				BT_BAP_ASCS_REASON_NONE);
 		return;
@@ -3237,9 +3230,9 @@ int bt_ascs_unregister(void)
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(ascs.ase_pool); i++) {
-		if (ascs.ase_pool[i].ep.status.state != BT_BAP_EP_STATE_IDLE) {
+		if (ascs.ase_pool[i].ep.state != BT_BAP_EP_STATE_IDLE) {
 			LOG_DBG("[%zu] ase %p not in idle state: %s", i, &ascs.ase_pool[i].ep,
-				bt_bap_ep_state_str(ascs.ase_pool[i].ep.status.state));
+				bt_bap_ep_state_str(ascs.ase_pool[i].ep.state));
 			return -EBUSY;
 		}
 	}

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1447,6 +1447,11 @@ static struct bt_ascs_ase *ase_find(struct bt_conn *conn, uint8_t id)
 	return NULL;
 }
 
+bool bt_ascs_is_ase_ep(const struct bt_bap_ep *ep)
+{
+	return PART_OF_ARRAY(ascs.ase_pool, ep);
+}
+
 static ssize_t ascs_ase_read(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, void *buf,
 			     uint16_t len, uint16_t offset)

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -182,7 +182,7 @@ static void ase_free(struct bt_ascs_ase *ase)
 {
 	__ASSERT(ase && ase->conn, "Non-existing ASE");
 
-	LOG_DBG("conn %p ase %p id 0x%02x", (void *)ase->conn, ase, ase->ep.id);
+	LOG_DBG("conn %p ase %p id 0x%02x", (void *)ase->conn, ase, ASE_ID(ase));
 
 	if (ase->ep.iso != NULL) {
 		bt_bap_iso_unbind_ep(ase->ep.iso, &ase->ep);
@@ -550,7 +550,7 @@ static void state_transition_work_handler(struct k_work *work)
 		}
 	}
 
-	LOG_DBG("ase %p ep %p id 0x%02x %s -> %s", ase, &ase->ep, ase->ep.id,
+	LOG_DBG("ase %p ep %p id 0x%02x %s -> %s", ase, &ase->ep, ASE_ID(ase),
 		bt_bap_ep_state_str(old_state), bt_bap_ep_state_str(new_state));
 
 	if (old_state == new_state) {
@@ -1372,7 +1372,7 @@ static uint8_t ase_attr_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 {
 	struct bt_ascs_ase *ase = user_data;
 
-	if (ase->ep.id == POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr))) {
+	if (ASE_ID(ase) == POINTER_TO_UINT(BT_AUDIO_CHRC_USER_DATA(attr))) {
 		ase->attr = attr;
 
 		return BT_GATT_ITER_STOP;
@@ -1437,7 +1437,7 @@ static struct bt_ascs_ase *ase_find(struct bt_conn *conn, uint8_t id)
 	for (size_t i = 0; i < ARRAY_SIZE(ascs.ase_pool); i++) {
 		struct bt_ascs_ase *ase = &ascs.ase_pool[i];
 
-		if (ase->conn == conn && ase->ep.id == id) {
+		if (ase->conn == conn && ASE_ID(ase) == id) {
 			return ase;
 		}
 	}

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1077,6 +1077,8 @@ static void ascs_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t reason)
 		ase->unexpected_iso_link_loss = true;
 
 		ascs_ep_set_state(ep, BT_BAP_EP_STATE_QOS_CONFIGURED);
+	} else {
+		/* no op */
 	}
 }
 

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -11,6 +11,7 @@
 #ifndef BT_ASCS_INTERNAL_H
 #define BT_ASCS_INTERNAL_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <zephyr/bluetooth/audio/audio.h>
@@ -351,6 +352,7 @@ int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
 void bt_ascs_cleanup(void);
 
 int ascs_ep_set_state(struct bt_bap_ep *ep, enum bt_bap_ep_state state);
+bool bt_ascs_is_ase_ep(const struct bt_bap_ep *ep);
 
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 		       struct bt_audio_codec_cfg *codec_cfg,

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -350,7 +350,7 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 int bt_ascs_init(const struct bt_bap_unicast_server_cb *cb);
 void bt_ascs_cleanup(void);
 
-int ascs_ep_set_state(struct bt_bap_ep *ep, uint8_t state);
+int ascs_ep_set_state(struct bt_bap_ep *ep, enum bt_bap_ep_state state);
 
 int bt_ascs_config_ase(struct bt_conn *conn, struct bt_bap_stream *stream,
 		       struct bt_audio_codec_cfg *codec_cfg,

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -228,13 +228,13 @@ static struct bt_bap_broadcast_sink *broadcast_sink_lookup_iso_chan(
 	return NULL;
 }
 
-static void broadcast_sink_set_ep_state(struct bt_bap_ep *ep, uint8_t state)
+static void broadcast_sink_set_ep_state(struct bt_bap_ep *ep, enum bt_bap_ep_state state)
 {
 	uint8_t old_state;
 
-	old_state = ep->status.state;
+	old_state = ep->state;
 
-	LOG_DBG("ep %p id 0x%02x %s -> %s", ep, ep->status.id, bt_bap_ep_state_str(old_state),
+	LOG_DBG("ep %p id 0x%02x %s -> %s", ep, ep->id, bt_bap_ep_state_str(old_state),
 		bt_bap_ep_state_str(state));
 
 	switch (old_state) {
@@ -262,7 +262,7 @@ static void broadcast_sink_set_ep_state(struct bt_bap_ep *ep, uint8_t state)
 		return;
 	}
 
-	ep->status.state = state;
+	ep->state = state;
 
 	if (state == BT_BAP_EP_STATE_IDLE) {
 		struct bt_bap_stream *stream = ep->stream;
@@ -337,7 +337,7 @@ static bool broadcast_sink_is_in_state(struct bt_bap_broadcast_sink *sink,
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&sink->streams, stream, _node) {
-		if (stream->ep != NULL && stream->ep->status.state != state) {
+		if (stream->ep != NULL && stream->ep->state != state) {
 			return false;
 		}
 	}

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -85,9 +85,9 @@ static void broadcast_source_set_ep_state(struct bt_bap_ep *ep, uint8_t state)
 {
 	uint8_t old_state;
 
-	old_state = ep->status.state;
+	old_state = ep->state;
 
-	LOG_DBG("ep %p id 0x%02x %s -> %s", ep, ep->status.id, bt_bap_ep_state_str(old_state),
+	LOG_DBG("ep %p id 0x%02x %s -> %s", ep, ep->id, bt_bap_ep_state_str(old_state),
 		bt_bap_ep_state_str(state));
 
 	switch (old_state) {
@@ -121,7 +121,7 @@ static void broadcast_source_set_ep_state(struct bt_bap_ep *ep, uint8_t state)
 		return;
 	}
 
-	ep->status.state = state;
+	ep->state = state;
 }
 
 static void broadcast_source_set_state(struct bt_bap_broadcast_source *source, uint8_t state)
@@ -617,7 +617,7 @@ static enum bt_bap_ep_state broadcast_source_get_state(struct bt_bap_broadcast_s
 
 		SYS_SLIST_FOR_EACH_CONTAINER(&subgroup->streams, stream, _node) {
 			if (stream->ep != NULL) {
-				state = MAX(state, stream->ep->status.state);
+				state = MAX(state, stream->ep->state);
 			}
 		}
 	}

--- a/subsys/bluetooth/audio/bap_endpoint.h
+++ b/subsys/bluetooth/audio/bap_endpoint.h
@@ -43,10 +43,11 @@ struct bt_bap_broadcast_source;
 struct bt_bap_broadcast_sink;
 
 struct bt_bap_ep {
-	uint8_t  dir;
-	uint8_t  cig_id;
-	uint8_t  cis_id;
-	struct bt_ascs_ase_status status;
+	uint8_t dir;
+	uint8_t cig_id;
+	uint8_t cis_id;
+	uint8_t id;
+	enum bt_bap_ep_state state;
 	struct bt_bap_stream *stream;
 	struct bt_audio_codec_cfg codec_cfg;
 	struct bt_bap_qos_cfg qos;
@@ -194,7 +195,7 @@ struct bt_bap_broadcast_sink {
 };
 #endif /* CONFIG_BT_BAP_BROADCAST_SINK */
 
-static inline const char *bt_bap_ep_state_str(uint8_t state)
+static inline const char *bt_bap_ep_state_str(enum bt_bap_ep_state state)
 {
 	switch (state) {
 	case BT_BAP_EP_STATE_IDLE:

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -147,8 +147,7 @@ static int unicast_client_ep_set_metadata(struct bt_bap_ep *ep, void *data, uint
 static int unicast_client_ep_set_codec_cfg(struct bt_bap_ep *ep, uint8_t id, uint16_t cid,
 					   uint16_t vid, void *data, uint8_t len,
 					   struct bt_audio_codec_cfg *codec_cfg);
-static int unicast_client_ep_start(struct bt_bap_ep *ep,
-				   struct net_buf_simple *buf);
+static int unicast_client_ep_start(struct bt_bap_ep *ep, struct net_buf_simple *buf);
 
 static int unicast_client_ase_discover(struct bt_conn *conn, uint16_t start_handle);
 
@@ -160,8 +159,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 static int unicast_client_send_start(struct bt_bap_ep *ep)
 {
 	if (ep->receiver_ready != true || ep->dir != BT_AUDIO_DIR_SOURCE) {
-		LOG_DBG("Invalid ep %p %u %s",
-			ep, ep->receiver_ready, bt_audio_dir_str(ep->dir));
+		LOG_DBG("Invalid ep %p %u %s", ep, ep->receiver_ready, bt_audio_dir_str(ep->dir));
 
 		return -EINVAL;
 	}
@@ -181,8 +179,7 @@ static int unicast_client_send_start(struct bt_bap_ep *ep)
 
 	err = unicast_client_ep_start(ep, buf);
 	if (err != 0) {
-		LOG_DBG("unicast_client_ep_start failed: %d",
-			err);
+		LOG_DBG("unicast_client_ep_start failed: %d", err);
 
 		return err;
 	}
@@ -199,8 +196,7 @@ static int unicast_client_send_start(struct bt_bap_ep *ep)
 
 static void unicast_client_ep_idle_state(struct bt_bap_ep *ep);
 
-static struct bt_bap_stream *audio_stream_by_ep_id(const struct bt_conn *conn,
-						     uint8_t id)
+static struct bt_bap_stream *audio_stream_by_ep_id(const struct bt_conn *conn, uint8_t id)
 {
 #if CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SNK_COUNT > 0 || CONFIG_BT_BAP_UNICAST_CLIENT_ASE_SRC_COUNT > 0
 	const uint8_t conn_index = bt_conn_index(conn);
@@ -213,7 +209,7 @@ static struct bt_bap_stream *audio_stream_by_ep_id(const struct bt_conn *conn,
 		const struct bt_bap_unicast_client_ep *client_ep =
 			&uni_cli_insts[conn_index].snks[i];
 
-		if (client_ep->ep.status.id == id) {
+		if (client_ep->ep.id == id) {
 			return client_ep->ep.stream;
 		}
 	}
@@ -224,7 +220,7 @@ static struct bt_bap_stream *audio_stream_by_ep_id(const struct bt_conn *conn,
 		const struct bt_bap_unicast_client_ep *client_ep =
 			&uni_cli_insts[conn_index].srcs[i];
 
-		if (client_ep->ep.status.id == id) {
+		if (client_ep->ep.id == id) {
 			return client_ep->ep.stream;
 		}
 	}
@@ -265,10 +261,10 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 		return;
 	}
 
-	if (ep->status.state != BT_BAP_EP_STATE_STREAMING) {
+	if (ep->state != BT_BAP_EP_STATE_STREAMING) {
 		if (IS_ENABLED(CONFIG_BT_BAP_DEBUG_STREAM_DATA)) {
 			LOG_DBG("ep %p is not in the streaming state: %s", ep,
-				bt_bap_ep_state_str(ep->status.state));
+				bt_bap_ep_state_str(ep->state));
 		}
 
 		return;
@@ -331,9 +327,8 @@ static void unicast_client_ep_iso_connected(struct bt_bap_ep *ep)
 		ep->unicast_group->has_been_connected = true;
 	}
 
-	if (ep->status.state != BT_BAP_EP_STATE_ENABLING) {
-		LOG_DBG("endpoint not in enabling state: %s",
-			bt_bap_ep_state_str(ep->status.state));
+	if (ep->state != BT_BAP_EP_STATE_ENABLING) {
+		LOG_DBG("endpoint not in enabling state: %s", bt_bap_ep_state_str(ep->state));
 		return;
 	}
 
@@ -343,8 +338,8 @@ static void unicast_client_ep_iso_connected(struct bt_bap_ep *ep)
 		return;
 	}
 
-	LOG_DBG("stream %p ep %p dir %s receiver_ready %u",
-		stream, ep, bt_audio_dir_str(ep->dir), ep->receiver_ready);
+	LOG_DBG("stream %p ep %p dir %s receiver_ready %u", stream, ep, bt_audio_dir_str(ep->dir),
+		ep->receiver_ready);
 
 #if defined(CONFIG_BT_BAP_DEBUG_STREAM_SEQ_NUM)
 	/* reset sequence number */
@@ -398,7 +393,7 @@ static void unicast_client_ep_iso_disconnected(struct bt_bap_ep *ep, uint8_t rea
 	 * then we need to call unicast_client_ep_idle_state again when
 	 * the ISO has finalized the disconnection
 	 */
-	if (ep->status.state == BT_BAP_EP_STATE_IDLE) {
+	if (ep->state == BT_BAP_EP_STATE_IDLE) {
 
 		unicast_client_ep_idle_state(ep);
 
@@ -475,7 +470,7 @@ static void unicast_client_ep_init(struct bt_bap_ep *ep, uint16_t handle, uint8_
 
 	(void)memset(ep, 0, sizeof(*ep));
 	client_ep->handle = handle;
-	ep->status.id = 0U;
+	ep->id = 0U;
 	ep->dir = dir;
 	ep->reason = BT_HCI_ERR_SUCCESS;
 	k_work_init_delayable(&client_ep->ase_read_work, delayed_ase_read_handler);
@@ -580,7 +575,7 @@ static struct bt_bap_ep *unicast_client_ep_get(struct bt_conn *conn, enum bt_aud
 static void unicast_client_ep_set_local_idle_state(struct bt_bap_ep *ep)
 {
 	struct bt_ascs_ase_status status = {
-		.id = ep->status.id,
+		.id = ep->id,
 		.state = BT_BAP_EP_STATE_IDLE,
 	};
 	struct net_buf_simple buf;
@@ -1200,9 +1195,10 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 
 	status = net_buf_simple_pull_mem(buf, sizeof(*status));
 
-	old_state = ep->status.state;
-	ep->status = *status;
-	state_changed = old_state != ep->status.state;
+	old_state = ep->state;
+	ep->id = status->id;
+	ep->state = status->state;
+	state_changed = old_state != ep->state;
 
 	if (state_changed && old_state == BT_BAP_EP_STATE_STREAMING) {
 		/* We left the streaming state, let the upper layers know that the stream is stopped
@@ -1257,8 +1253,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			break;
 		default:
 			LOG_WRN("Invalid state transition: %s -> %s",
-				bt_bap_ep_state_str(old_state),
-				bt_bap_ep_state_str(ep->status.state));
+				bt_bap_ep_state_str(old_state), bt_bap_ep_state_str(ep->state));
 			return;
 		}
 
@@ -1280,7 +1275,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			default:
 				LOG_WRN("Invalid state transition: %s -> %s",
 					bt_bap_ep_state_str(old_state),
-					bt_bap_ep_state_str(ep->status.state));
+					bt_bap_ep_state_str(ep->state));
 				return;
 			}
 		} else {
@@ -1297,7 +1292,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			default:
 				LOG_WRN("Invalid state transition: %s -> %s",
 					bt_bap_ep_state_str(old_state),
-					bt_bap_ep_state_str(ep->status.state));
+					bt_bap_ep_state_str(ep->state));
 				return;
 			}
 		}
@@ -1313,8 +1308,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			break;
 		default:
 			LOG_WRN("Invalid state transition: %s -> %s",
-				bt_bap_ep_state_str(old_state),
-				bt_bap_ep_state_str(ep->status.state));
+				bt_bap_ep_state_str(old_state), bt_bap_ep_state_str(ep->state));
 			return;
 		}
 
@@ -1329,8 +1323,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			break;
 		default:
 			LOG_WRN("Invalid state transition: %s -> %s",
-				bt_bap_ep_state_str(old_state),
-				bt_bap_ep_state_str(ep->status.state));
+				bt_bap_ep_state_str(old_state), bt_bap_ep_state_str(ep->state));
 			return;
 		}
 
@@ -1347,14 +1340,13 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			default:
 				LOG_WRN("Invalid state transition: %s -> %s",
 					bt_bap_ep_state_str(old_state),
-					bt_bap_ep_state_str(ep->status.state));
+					bt_bap_ep_state_str(ep->state));
 				return;
 			}
 		} else {
 			/* Sinks cannot go into the disabling state */
 			LOG_WRN("Invalid state transition: %s -> %s",
-				bt_bap_ep_state_str(old_state),
-				bt_bap_ep_state_str(ep->status.state));
+				bt_bap_ep_state_str(old_state), bt_bap_ep_state_str(ep->state));
 			return;
 		}
 
@@ -1380,8 +1372,7 @@ static void unicast_client_ep_set_status(struct bt_bap_ep *ep, struct net_buf_si
 			/* fall through */
 		default:
 			LOG_WRN("Invalid state transition: %s -> %s",
-				bt_bap_ep_state_str(old_state),
-				bt_bap_ep_state_str(ep->status.state));
+				bt_bap_ep_state_str(old_state), bt_bap_ep_state_str(ep->state));
 			return;
 		}
 
@@ -1561,10 +1552,10 @@ static uint8_t unicast_client_cp_notify(struct bt_conn *conn,
 		ase_rsp = net_buf_simple_pull_mem(&buf, sizeof(*ase_rsp));
 
 		LOG_DBG("op %s (0x%02x) id 0x%02x code %s (0x%02x) "
-			"reason %s (0x%02x)", bt_ascs_op_str(rsp->op), rsp->op,
-			ase_rsp->id, bt_ascs_rsp_str(ase_rsp->code),
-			ase_rsp->code, bt_ascs_reason_str(ase_rsp->reason),
-			ase_rsp->reason);
+			"reason %s (0x%02x)",
+			bt_ascs_op_str(rsp->op), rsp->op, ase_rsp->id,
+			bt_ascs_rsp_str(ase_rsp->code), ase_rsp->code,
+			bt_ascs_reason_str(ase_rsp->reason), ase_rsp->reason);
 
 		stream = audio_stream_by_ep_id(conn, ase_rsp->id);
 		if (stream == NULL) {
@@ -1919,7 +1910,7 @@ static int unicast_client_ep_config(struct bt_bap_ep *ep, struct net_buf_simple 
 		return -EINVAL;
 	}
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	/* Valid only if ASE_State field = 0x00 (Idle) */
 	case BT_BAP_EP_STATE_IDLE:
 		/* or 0x01 (Codec Configured) */
@@ -1928,15 +1919,14 @@ static int unicast_client_ep_config(struct bt_bap_ep *ep, struct net_buf_simple 
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 		break;
 	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
-	LOG_DBG("id 0x%02x dir %s codec 0x%02x", ep->status.id, bt_audio_dir_str(ep->dir),
-		codec_cfg->id);
+	LOG_DBG("id 0x%02x dir %s codec 0x%02x", ep->id, bt_audio_dir_str(ep->dir), codec_cfg->id);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->status.id;
+	req->ase = ep->id;
 	req->latency = codec_cfg->target_latency;
 	req->phy = codec_cfg->target_phy;
 	req->codec.id = codec_cfg->id;
@@ -1963,14 +1953,14 @@ int bt_bap_unicast_client_ep_qos(struct bt_bap_ep *ep, struct net_buf_simple *bu
 		return -EINVAL;
 	}
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	/* Valid only if ASE_State field = 0x01 (Codec Configured) */
 	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 		/* or 0x02 (QoS Configured) */
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 		break;
 	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
@@ -1978,11 +1968,11 @@ int bt_bap_unicast_client_ep_qos(struct bt_bap_ep *ep, struct net_buf_simple *bu
 
 	LOG_DBG("id 0x%02x cig 0x%02x cis 0x%02x interval %u framing 0x%02x "
 		"phy 0x%02x sdu %u rtn %u latency %u pd %u",
-		ep->status.id, conn_iso->info.unicast.cig_id, conn_iso->info.unicast.cis_id,
-		qos->interval, qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
+		ep->id, conn_iso->info.unicast.cig_id, conn_iso->info.unicast.cis_id, qos->interval,
+		qos->framing, qos->phy, qos->sdu, qos->rtn, qos->latency, qos->pd);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->status.id;
+	req->ase = ep->id;
 	/* TODO: don't hardcode CIG and CIS, they should come from ISO */
 	req->cig = conn_iso->info.unicast.cig_id;
 	req->cis = conn_iso->info.unicast.cis_id;
@@ -2008,15 +1998,15 @@ static int unicast_client_ep_enable(struct bt_bap_ep *ep, struct net_buf_simple 
 		return -EINVAL;
 	}
 
-	if (ep->status.state != BT_BAP_EP_STATE_QOS_CONFIGURED) {
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+	if (ep->state != BT_BAP_EP_STATE_QOS_CONFIGURED) {
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
-	LOG_DBG("id 0x%02x", ep->status.id);
+	LOG_DBG("id 0x%02x", ep->id);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->status.id;
+	req->ase = ep->id;
 
 	req->len = meta_len;
 	net_buf_simple_add_mem(buf, meta, meta_len);
@@ -2035,21 +2025,21 @@ static int unicast_client_ep_metadata(struct bt_bap_ep *ep, struct net_buf_simpl
 		return -EINVAL;
 	}
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	/* Valid for an ASE only if ASE_State field = 0x03 (Enabling) */
 	case BT_BAP_EP_STATE_ENABLING:
 	/* or 0x04 (Streaming) */
 	case BT_BAP_EP_STATE_STREAMING:
 		break;
 	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
-	LOG_DBG("id 0x%02x", ep->status.id);
+	LOG_DBG("id 0x%02x", ep->id);
 
 	req = net_buf_simple_add(buf, sizeof(*req));
-	req->ase = ep->status.id;
+	req->ase = ep->id;
 
 	req->len = meta_len;
 	net_buf_simple_add_mem(buf, meta, meta_len);
@@ -2065,15 +2055,14 @@ static int unicast_client_ep_start(struct bt_bap_ep *ep, struct net_buf_simple *
 		return -EINVAL;
 	}
 
-	if (ep->status.state != BT_BAP_EP_STATE_ENABLING &&
-	    ep->status.state != BT_BAP_EP_STATE_DISABLING) {
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+	if (ep->state != BT_BAP_EP_STATE_ENABLING && ep->state != BT_BAP_EP_STATE_DISABLING) {
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
-	LOG_DBG("id 0x%02x", ep->status.id);
+	LOG_DBG("id 0x%02x", ep->id);
 
-	net_buf_simple_add_u8(buf, ep->status.id);
+	net_buf_simple_add_u8(buf, ep->id);
 
 	return 0;
 }
@@ -2086,20 +2075,20 @@ static int unicast_client_ep_disable(struct bt_bap_ep *ep, struct net_buf_simple
 		return -EINVAL;
 	}
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	/* Valid only if ASE_State field = 0x03 (Enabling) */
 	case BT_BAP_EP_STATE_ENABLING:
 		/* or 0x04 (Streaming) */
 	case BT_BAP_EP_STATE_STREAMING:
 		break;
 	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
-	LOG_DBG("id 0x%02x", ep->status.id);
+	LOG_DBG("id 0x%02x", ep->id);
 
-	net_buf_simple_add_u8(buf, ep->status.id);
+	net_buf_simple_add_u8(buf, ep->id);
 
 	return 0;
 }
@@ -2113,14 +2102,14 @@ static int unicast_client_ep_stop(struct bt_bap_ep *ep, struct net_buf_simple *b
 	}
 
 	/* Valid only if ASE_State field value = 0x05 (Disabling). */
-	if (ep->status.state != BT_BAP_EP_STATE_DISABLING) {
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+	if (ep->state != BT_BAP_EP_STATE_DISABLING) {
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
-	LOG_DBG("id 0x%02x", ep->status.id);
+	LOG_DBG("id 0x%02x", ep->id);
 
-	net_buf_simple_add_u8(buf, ep->status.id);
+	net_buf_simple_add_u8(buf, ep->id);
 
 	return 0;
 }
@@ -2133,7 +2122,7 @@ static int unicast_client_ep_release(struct bt_bap_ep *ep, struct net_buf_simple
 		return -EINVAL;
 	}
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	/* Valid only if ASE_State field = 0x01 (Codec Configured) */
 	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 		/* or 0x02 (QoS Configured) */
@@ -2146,13 +2135,13 @@ static int unicast_client_ep_release(struct bt_bap_ep *ep, struct net_buf_simple
 	case BT_BAP_EP_STATE_DISABLING:
 		break;
 	default:
-		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->status.state));
+		LOG_ERR("Invalid state: %s", bt_bap_ep_state_str(ep->state));
 		return -EINVAL;
 	}
 
-	LOG_DBG("id 0x%02x", ep->status.id);
+	LOG_DBG("id 0x%02x", ep->id);
 
-	net_buf_simple_add_u8(buf, ep->status.id);
+	net_buf_simple_add_u8(buf, ep->id);
 
 	return 0;
 }
@@ -2278,7 +2267,7 @@ static void unicast_client_ep_reset(struct bt_conn *conn, uint8_t reason)
 }
 
 static void bt_bap_qos_cfg_to_cig_param(struct bt_iso_cig_param *cig_param,
-					    const struct bt_bap_unicast_group *group)
+					const struct bt_bap_unicast_group *group)
 {
 	cig_param->framing = group->cig_param.framing;
 	cig_param->c_to_p_interval = group->cig_param.c_to_p_interval;
@@ -2380,8 +2369,7 @@ static int bt_audio_cig_reconfigure(struct bt_bap_unicast_group *group)
 	return 0;
 }
 
-static void audio_stream_qos_cleanup(const struct bt_conn *conn,
-				     struct bt_bap_unicast_group *group)
+static void audio_stream_qos_cleanup(const struct bt_conn *conn, struct bt_bap_unicast_group *group)
 {
 	struct bt_bap_stream *stream;
 
@@ -2500,8 +2488,7 @@ static void unicast_client_qos_cfg_to_iso_qos(struct bt_bap_iso *iso,
 }
 
 static void unicast_group_set_iso_stream_param(struct bt_bap_unicast_group *group,
-					       struct bt_bap_iso *iso,
-					       struct bt_bap_qos_cfg *qos,
+					       struct bt_bap_iso *iso, struct bt_bap_qos_cfg *qos,
 					       enum bt_audio_dir dir)
 {
 	/* Store the stream Codec QoS in the bap_iso */
@@ -2673,14 +2660,12 @@ static void unicast_group_free(struct bt_bap_unicast_group *group)
 
 static int stream_param_check(const struct bt_bap_unicast_group_stream_param *param)
 {
-	CHECKIF(param->stream == NULL)
-	{
+	CHECKIF(param->stream == NULL) {
 		LOG_DBG("param->stream is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(param->qos == NULL)
-	{
+	CHECKIF(param->qos == NULL) {
 		LOG_DBG("param->qos is NULL");
 		return -EINVAL;
 	}
@@ -2690,8 +2675,7 @@ static int stream_param_check(const struct bt_bap_unicast_group_stream_param *pa
 		return -EALREADY;
 	}
 
-	CHECKIF(bt_audio_verify_qos(param->qos) != BT_BAP_ASCS_REASON_NONE)
-	{
+	CHECKIF(bt_audio_verify_qos(param->qos) != BT_BAP_ASCS_REASON_NONE) {
 		LOG_DBG("Invalid QoS");
 		return -EINVAL;
 	}
@@ -2703,8 +2687,7 @@ static int stream_pair_param_check(const struct bt_bap_unicast_group_stream_pair
 {
 	int err;
 
-	CHECKIF(param->rx_param == NULL && param->tx_param == NULL)
-	{
+	CHECKIF(param->rx_param == NULL && param->tx_param == NULL) {
 		LOG_DBG("Invalid stream parameters");
 		return -EINVAL;
 	}
@@ -2875,13 +2858,12 @@ static bool valid_unicast_group_param(struct bt_bap_unicast_group *unicast_group
 }
 
 int bt_bap_unicast_group_create(struct bt_bap_unicast_group_param *param,
-				  struct bt_bap_unicast_group **out_unicast_group)
+				struct bt_bap_unicast_group **out_unicast_group)
 {
 	struct bt_bap_unicast_group *unicast_group;
 	int err;
 
-	CHECKIF(out_unicast_group == NULL)
-	{
+	CHECKIF(out_unicast_group == NULL) {
 		LOG_DBG("out_unicast_group is NULL");
 		return -EINVAL;
 	}
@@ -3030,8 +3012,8 @@ int bt_bap_unicast_group_reconfig(struct bt_bap_unicast_group *unicast_group,
 }
 
 int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
-				       struct bt_bap_unicast_group_stream_pair_param params[],
-				       size_t num_param)
+				     struct bt_bap_unicast_group_stream_pair_param params[],
+				     size_t num_param)
 {
 	struct bt_bap_stream *tmp_stream;
 	size_t total_stream_cnt;
@@ -3039,8 +3021,7 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
 	size_t num_added;
 	int err;
 
-	CHECKIF(unicast_group == NULL)
-	{
+	CHECKIF(unicast_group == NULL) {
 		LOG_DBG("unicast_group is NULL");
 		return -EINVAL;
 	}
@@ -3050,14 +3031,12 @@ int bt_bap_unicast_group_add_streams(struct bt_bap_unicast_group *unicast_group,
 		return -EINVAL;
 	}
 
-	CHECKIF(params == NULL)
-	{
+	CHECKIF(params == NULL) {
 		LOG_DBG("params is NULL");
 		return -EINVAL;
 	}
 
-	CHECKIF(num_param == 0)
-	{
+	CHECKIF(num_param == 0) {
 		LOG_DBG("num_param is 0");
 		return -EINVAL;
 	}
@@ -3126,8 +3105,7 @@ int bt_bap_unicast_group_delete(struct bt_bap_unicast_group *unicast_group)
 {
 	struct bt_bap_stream *stream;
 
-	CHECKIF(unicast_group == NULL)
-	{
+	CHECKIF(unicast_group == NULL) {
 		LOG_DBG("unicast_group is NULL");
 		return -EINVAL;
 	}
@@ -3259,12 +3237,12 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 		/* Can only be done if all the streams are in the codec
 		 * configured state or the QoS configured state
 		 */
-		switch (ep->status.state) {
+		switch (ep->state) {
 		case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 		case BT_BAP_EP_STATE_QOS_CONFIGURED:
 			break;
 		default:
-			LOG_DBG("Invalid state: %s", bt_bap_ep_state_str(stream->ep->status.state));
+			LOG_DBG("Invalid state: %s", bt_bap_ep_state_str(stream->ep->state));
 			return -EINVAL;
 		}
 
@@ -3606,7 +3584,7 @@ int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 	len = buf->len;
 
 	/* Only attempt to release if not IDLE already */
-	if (stream->ep->status.state == BT_BAP_EP_STATE_IDLE) {
+	if (stream->ep->state == BT_BAP_EP_STATE_IDLE) {
 		bt_bap_stream_reset(stream);
 	} else {
 		err = unicast_client_ep_release(ep, buf);
@@ -3776,8 +3754,7 @@ static bool any_ases_found(const struct unicast_client *client)
 	return true;
 }
 
-static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn,
-					      const struct bt_gatt_attr *attr,
+static uint8_t unicast_client_ase_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					      struct bt_gatt_discover_params *discover)
 {
 	struct unicast_client *client;
@@ -4357,38 +4334,36 @@ static uint8_t unicast_client_read_func(struct bt_conn *conn, uint8_t err,
 		LOG_DBG("pac #%u/%u", i + 1, rsp->num_pac);
 
 		if (buf->len < sizeof(*pac_codec)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu",
-				buf->len, sizeof(*pac_codec));
+			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*pac_codec));
 			break;
 		}
 
 		pac_codec = net_buf_simple_pull_mem(buf, sizeof(*pac_codec));
 
 		if (buf->len < sizeof(*cc)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu",
-				buf->len, sizeof(*cc));
+			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*cc));
 			break;
 		}
 
 		cc = net_buf_simple_pull_mem(buf, sizeof(*cc));
 		if (buf->len < cc->len) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu",
-				buf->len, cc->len);
+			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len, cc->len);
 			break;
 		}
 
 		cc_ltv = net_buf_simple_pull_mem(buf, cc->len);
 
 		if (buf->len < sizeof(*meta)) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %zu",
-				buf->len, sizeof(*meta));
+			LOG_ERR("Malformed PAC: remaining len %u expected %zu", buf->len,
+				sizeof(*meta));
 			break;
 		}
 
 		meta = net_buf_simple_pull_mem(buf, sizeof(*meta));
 		if (buf->len < meta->len) {
-			LOG_ERR("Malformed PAC: remaining len %u expected %u",
-				buf->len, meta->len);
+			LOG_ERR("Malformed PAC: remaining len %u expected %u", buf->len, meta->len);
 			break;
 		}
 
@@ -4429,8 +4404,7 @@ fail:
 	return BT_GATT_ITER_STOP;
 }
 
-static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn,
-					      const struct bt_gatt_attr *attr,
+static uint8_t unicast_client_pac_discover_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 					      struct bt_gatt_discover_params *discover)
 {
 	struct unicast_client *client = &uni_cli_insts[bt_conn_index(conn)];

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -173,7 +173,7 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 	(void)memcpy(ep->codec_cfg.meta, meta, meta_len);
 
 	/* Set the state to the same state to trigger the notifications */
-	return ascs_ep_set_state(ep, ep->status.state);
+	return ascs_ep_set_state(ep, ep->state);
 }
 
 int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)

--- a/subsys/bluetooth/audio/bap_unicast_server.c
+++ b/subsys/bluetooth/audio/bap_unicast_server.c
@@ -106,6 +106,11 @@ int bt_bap_unicast_server_reconfig(struct bt_bap_stream *stream,
 
 	ep = stream->ep;
 
+	if (!bt_ascs_is_ase_ep(ep)) {
+		LOG_DBG("ep %p not in ASCS", ep);
+		return -EINVAL;
+	}
+
 	if (unicast_server_cb != NULL &&
 		unicast_server_cb->reconfig != NULL) {
 		err = unicast_server_cb->reconfig(stream, ep->dir, codec_cfg, &ep->qos_pref, &rsp);
@@ -125,6 +130,11 @@ int bt_bap_unicast_server_reconfig(struct bt_bap_stream *stream,
 int bt_bap_unicast_server_start(struct bt_bap_stream *stream)
 {
 	struct bt_bap_ep *ep = stream->ep;
+
+	if (!bt_ascs_is_ase_ep(ep)) {
+		LOG_DBG("ep %p not in ASCS", ep);
+		return -EINVAL;
+	}
 
 	if (ep->dir != BT_AUDIO_DIR_SINK) {
 		LOG_DBG("Invalid operation for stream %p with dir %u",
@@ -153,6 +163,12 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 						     BT_BAP_ASCS_REASON_NONE);
 	int err;
 
+	ep = stream->ep;
+	if (!bt_ascs_is_ase_ep(ep)) {
+		LOG_DBG("ep %p not in ASCS", ep);
+		return -EINVAL;
+	}
+
 	if (meta_len > sizeof(ep->codec_cfg.meta)) {
 		return -ENOMEM;
 	}
@@ -169,7 +185,6 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 		return err;
 	}
 
-	ep = stream->ep;
 	(void)memcpy(ep->codec_cfg.meta, meta, meta_len);
 
 	/* Set the state to the same state to trigger the notifications */
@@ -178,11 +193,21 @@ int bt_bap_unicast_server_metadata(struct bt_bap_stream *stream, const uint8_t m
 
 int bt_bap_unicast_server_disable(struct bt_bap_stream *stream)
 {
+	if (!bt_ascs_is_ase_ep(stream->ep)) {
+		LOG_DBG("ep %p not in ASCS", stream->ep);
+		return -EINVAL;
+	}
+
 	return bt_ascs_disable_ase(stream->ep);
 }
 
 int bt_bap_unicast_server_release(struct bt_bap_stream *stream)
 {
+	if (!bt_ascs_is_ase_ep(stream->ep)) {
+		LOG_DBG("ep %p not in ASCS", stream->ep);
+		return -EINVAL;
+	}
+
 	return bt_ascs_release_ase(stream->ep);
 }
 

--- a/tests/bluetooth/audio/cap_initiator/src/test_common.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_common.c
@@ -64,5 +64,5 @@ void test_unicast_set_state(struct bt_cap_stream *cap_stream, struct bt_conn *co
 	bap_stream->ep = ep;
 	bap_stream->qos = &preset->qos;
 	bap_stream->codec_cfg = &preset->codec_cfg;
-	bap_stream->ep->status.state = state;
+	bap_stream->ep->state = state;
 }

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_start.c
@@ -139,7 +139,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start)
 
 	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -430,7 +430,7 @@ static ZTEST_F(cap_initiator_test_unicast_start,
 
 	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -471,7 +471,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -512,7 +512,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -549,7 +549,7 @@ static ZTEST_F(cap_initiator_test_unicast_start, test_initiator_unicast_start_st
 
 	for (size_t i = 0U; i < ARRAY_SIZE(stream_params); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_STREAMING,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);

--- a/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
+++ b/tests/bluetooth/audio/cap_initiator/src/test_unicast_stop.c
@@ -135,7 +135,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_CODEC_CONFIGURED,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -170,7 +170,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_QOS_CONFIGURED,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -204,7 +204,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_QOS_CONFIGURED,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -238,7 +238,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_disa
 
 	for (size_t i = 0U; i < ARRAY_SIZE(fixture->cap_streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_QOS_CONFIGURED,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -273,7 +273,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = bap_stream->ep->status.state;
+		const enum bt_bap_ep_state state = bap_stream->ep->state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_CODEC_CONFIGURED,
 			      "[%zu]: Stream %p unexpected state: %d", i, bap_stream, state);
@@ -308,7 +308,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop,
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = fixture->eps[i].status.state;
+		const enum bt_bap_ep_state state = fixture->eps[i].state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_IDLE, "[%zu]: Stream %p unexpected state: %d",
 			      i, bap_stream, state);
@@ -342,7 +342,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = fixture->eps[i].status.state;
+		const enum bt_bap_ep_state state = fixture->eps[i].state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_IDLE, "[%zu]: Stream %p unexpected state: %d",
 			      i, bap_stream, state);
@@ -376,7 +376,7 @@ static ZTEST_F(cap_initiator_test_unicast_stop, test_initiator_unicast_stop_rele
 
 	for (size_t i = 0U; i < ARRAY_SIZE(fixture->cap_streams); i++) {
 		const struct bt_bap_stream *bap_stream = &fixture->cap_streams[i].bap_stream;
-		const enum bt_bap_ep_state state = fixture->eps[i].status.state;
+		const enum bt_bap_ep_state state = fixture->eps[i].state;
 
 		zassert_equal(state, BT_BAP_EP_STATE_IDLE, "[%zu]: Stream %p unexpected state: %d",
 			      i, bap_stream, state);

--- a/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
+++ b/tests/bluetooth/audio/cap_initiator/uut/bap_unicast_client.c
@@ -38,7 +38,7 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 		return -EINVAL;
 	}
 
-	switch (stream->ep->status.state) {
+	switch (stream->ep->state) {
 	case BT_BAP_EP_STATE_IDLE:
 	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 		break;
@@ -51,7 +51,7 @@ int bt_bap_unicast_client_config(struct bt_bap_stream *stream,
 					  BT_BAP_ASCS_REASON_NONE);
 	}
 
-	stream->ep->status.state = BT_BAP_EP_STATE_CODEC_CONFIGURED;
+	stream->ep->state = BT_BAP_EP_STATE_CODEC_CONFIGURED;
 
 	if (stream->ops != NULL && stream->ops->configured != NULL) {
 		const struct bt_bap_qos_cfg_pref pref = {0};
@@ -72,7 +72,7 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		if (stream->conn == conn) {
-			switch (stream->ep->status.state) {
+			switch (stream->ep->state) {
 			case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 			case BT_BAP_EP_STATE_QOS_CONFIGURED:
 				break;
@@ -89,7 +89,7 @@ int bt_bap_unicast_client_qos(struct bt_conn *conn, struct bt_bap_unicast_group 
 						       BT_BAP_ASCS_REASON_NONE);
 			}
 
-			stream->ep->status.state = BT_BAP_EP_STATE_QOS_CONFIGURED;
+			stream->ep->state = BT_BAP_EP_STATE_QOS_CONFIGURED;
 
 			if (stream->ops != NULL && stream->ops->qos_set != NULL) {
 				stream->ops->qos_set(stream);
@@ -107,7 +107,7 @@ int bt_bap_unicast_client_enable(struct bt_bap_stream *stream, const uint8_t met
 		return -EINVAL;
 	}
 
-	switch (stream->ep->status.state) {
+	switch (stream->ep->state) {
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 		break;
 	default:
@@ -119,7 +119,7 @@ int bt_bap_unicast_client_enable(struct bt_bap_stream *stream, const uint8_t met
 					  BT_BAP_ASCS_REASON_NONE);
 	}
 
-	stream->ep->status.state = BT_BAP_EP_STATE_ENABLING;
+	stream->ep->state = BT_BAP_EP_STATE_ENABLING;
 
 	if (stream->ops != NULL && stream->ops->enabled != NULL) {
 		stream->ops->enabled(stream);
@@ -135,7 +135,7 @@ int bt_bap_unicast_client_metadata(struct bt_bap_stream *stream, const uint8_t m
 		return -EINVAL;
 	}
 
-	switch (stream->ep->status.state) {
+	switch (stream->ep->state) {
 	case BT_BAP_EP_STATE_ENABLING:
 	case BT_BAP_EP_STATE_STREAMING:
 		break;
@@ -165,7 +165,7 @@ int bt_bap_unicast_client_connect(struct bt_bap_stream *stream)
 
 	ep = stream->ep;
 
-	switch (ep->status.state) {
+	switch (ep->state) {
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 	case BT_BAP_EP_STATE_ENABLING:
 		break;
@@ -180,7 +180,7 @@ int bt_bap_unicast_client_connect(struct bt_bap_stream *stream)
 
 	if (ep->dir == BT_AUDIO_DIR_SINK) {
 		/* Mocking that the unicast server automatically starts the stream */
-		ep->status.state = BT_BAP_EP_STATE_STREAMING;
+		ep->state = BT_BAP_EP_STATE_STREAMING;
 
 		if (stream->ops != NULL && stream->ops->started != NULL) {
 			stream->ops->started(stream);
@@ -197,7 +197,7 @@ int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	switch (stream->ep->status.state) {
+	switch (stream->ep->state) {
 	case BT_BAP_EP_STATE_ENABLING:
 		break;
 	default:
@@ -209,7 +209,7 @@ int bt_bap_unicast_client_start(struct bt_bap_stream *stream)
 					 BT_BAP_ASCS_REASON_NONE);
 	}
 
-	stream->ep->status.state = BT_BAP_EP_STATE_STREAMING;
+	stream->ep->state = BT_BAP_EP_STATE_STREAMING;
 
 	if (stream->ops != NULL && stream->ops->started != NULL) {
 		stream->ops->started(stream);
@@ -226,7 +226,7 @@ int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 
 	printk("%s %p %d\n", __func__, stream, stream->ep->dir);
 
-	switch (stream->ep->status.state) {
+	switch (stream->ep->state) {
 	case BT_BAP_EP_STATE_ENABLING:
 	case BT_BAP_EP_STATE_STREAMING:
 		break;
@@ -246,7 +246,7 @@ int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 
 	/* Disabled sink ASEs go directly to the QoS configured state */
 	if (stream->ep->dir == BT_AUDIO_DIR_SINK) {
-		stream->ep->status.state = BT_BAP_EP_STATE_QOS_CONFIGURED;
+		stream->ep->state = BT_BAP_EP_STATE_QOS_CONFIGURED;
 
 		if (stream->ops != NULL && stream->ops->disabled != NULL) {
 			stream->ops->disabled(stream);
@@ -260,7 +260,7 @@ int bt_bap_unicast_client_disable(struct bt_bap_stream *stream)
 			stream->ops->qos_set(stream);
 		}
 	} else if (stream->ep->dir == BT_AUDIO_DIR_SOURCE) {
-		stream->ep->status.state = BT_BAP_EP_STATE_DISABLING;
+		stream->ep->state = BT_BAP_EP_STATE_DISABLING;
 
 		if (stream->ops != NULL && stream->ops->disabled != NULL) {
 			stream->ops->disabled(stream);
@@ -279,7 +279,7 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	switch (stream->ep->status.state) {
+	switch (stream->ep->state) {
 	case BT_BAP_EP_STATE_DISABLING:
 		break;
 	default:
@@ -291,7 +291,7 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 					BT_BAP_ASCS_REASON_NONE);
 	}
 
-	stream->ep->status.state = BT_BAP_EP_STATE_QOS_CONFIGURED;
+	stream->ep->state = BT_BAP_EP_STATE_QOS_CONFIGURED;
 
 	if (stream->ops != NULL && stream->ops->stopped != NULL) {
 		stream->ops->stopped(stream, BT_HCI_ERR_LOCALHOST_TERM_CONN);
@@ -312,7 +312,7 @@ int bt_bap_unicast_client_stop(struct bt_bap_stream *stream)
 		if (pair_ep != NULL && pair_ep->stream != NULL) {
 			struct bt_bap_stream *pair_stream = pair_ep->stream;
 
-			pair_stream->ep->status.state = BT_BAP_EP_STATE_QOS_CONFIGURED;
+			pair_stream->ep->state = BT_BAP_EP_STATE_QOS_CONFIGURED;
 
 			if (pair_stream->ops != NULL && pair_stream->ops->stopped != NULL) {
 				pair_stream->ops->stopped(pair_stream,
@@ -336,7 +336,7 @@ int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 		return -EINVAL;
 	}
 
-	switch (stream->ep->status.state) {
+	switch (stream->ep->state) {
 	case BT_BAP_EP_STATE_CODEC_CONFIGURED:
 	case BT_BAP_EP_STATE_QOS_CONFIGURED:
 	case BT_BAP_EP_STATE_ENABLING:
@@ -352,7 +352,7 @@ int bt_bap_unicast_client_release(struct bt_bap_stream *stream)
 					   BT_BAP_ASCS_REASON_NONE);
 	}
 
-	stream->ep->status.state = BT_BAP_EP_STATE_IDLE;
+	stream->ep->state = BT_BAP_EP_STATE_IDLE;
 	bt_bap_stream_reset(stream);
 
 	if (stream->ops != NULL && stream->ops->released != NULL) {

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -21,7 +21,6 @@
 #include <hci_core.h>
 
 #include "ascs_internal.h"
-#include "bap_endpoint.h"
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #define LOG_MODULE_NAME bttester_bap_unicast
@@ -697,16 +696,20 @@ static void send_stream_received_ev(struct bt_conn *conn, struct bt_bap_ep *ep,
 				    uint8_t data_len, uint8_t *data)
 {
 	struct btp_bap_stream_received_ev *ev;
+	struct bt_bap_ep_info ep_info;
+	int err;
+
+	err = bt_bap_ep_get_info(ep, &ep_info);
+	__ASSERT_NO_MSG(err == 0);
 
 	tester_rsp_buffer_lock();
 	tester_rsp_buffer_allocate(sizeof(*ev) + data_len, (uint8_t **)&ev);
 
-	LOG_DBG("Stream received, ep %d, dir %d, len %d", ep->status.id, ep->dir,
-		data_len);
+	LOG_DBG("Stream received, ep %d, dir %d, len %d", ep_info.id, ep_info.dir, data_len);
 
 	bt_addr_le_copy(&ev->address, bt_conn_get_dst(conn));
 
-	ev->ase_id = ep->status.id;
+	ev->ase_id = ep_info.id;
 	ev->data_len = data_len;
 	memcpy(ev->data, data, data_len);
 
@@ -932,7 +935,13 @@ static void unicast_client_endpoint_cb(struct bt_conn *conn, enum bt_audio_dir d
 	LOG_DBG("");
 
 	if (ep != NULL) {
-		LOG_DBG("Discovered ASE %p, id %u, dir 0x%02x", ep, ep->status.id, ep->dir);
+		struct bt_bap_ep_info ep_info;
+		int err;
+
+		err = bt_bap_ep_get_info(ep, &ep_info);
+		__ASSERT_NO_MSG(err == 0);
+
+		LOG_DBG("Discovered ASE %p, id %u, dir 0x%02x", ep, ep_info.id, ep_info.dir);
 
 		u_conn = &connections[bt_conn_index(conn)];
 

--- a/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
+++ b/tests/bluetooth/tester/src/audio/btp_bap_unicast.c
@@ -157,13 +157,14 @@ struct bt_bap_ep *btp_bap_unicast_end_point_find(struct btp_bap_unicast_connecti
 	return NULL;
 }
 
-static void btp_send_ascs_ase_state_changed_ev(struct bt_conn *conn, uint8_t ase_id, uint8_t state)
+static void btp_send_ascs_ase_state_changed_ev(struct bt_conn *conn, uint8_t ase_id,
+					       enum bt_bap_ep_state state)
 {
 	struct btp_ascs_ase_state_changed_ev ev;
 
 	bt_addr_le_copy(&ev.address, bt_conn_get_dst(conn));
 	ev.ase_id = ase_id;
-	ev.state = state;
+	ev.state = (uint8_t)state;
 
 	tester_event(BTP_SERVICE_ID_ASCS, BTP_ASCS_EV_ASE_STATE_CHANGED, &ev, sizeof(ev));
 }


### PR DESCRIPTION

    
    The bt_ascs_ase_status was stored directly in the
    struct bt_bap_ep, which was an issue as
    bt_ascs_ase_status is a variable sized struct.
    The struct could have been moved to the end of
    bt_bap_ep to avoid the issues it caused, but
    there is no actual reason to use that struct
    rather than storing the ID and state as
    seperate values.
    
    The ascs_ep_get_state exists but was not widely
    used in ascs. Modify places to use the function
    instead of directly accessing the state.