### PR TITLE
boards: raspberrypi: rpi_pico2: include LED only for Pico 2

### DIFF
--- a/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2.dtsi
@@ -10,7 +10,6 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
 #include "rpi_pico2-pinctrl.dtsi"
-#include "../common/rpi_pico-led.dtsi"
 
 / {
 	chosen {

--- a/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.dts
+++ b/boards/raspberrypi/rpi_pico2/rpi_pico2_rp2350a_m33.dts
@@ -20,3 +20,4 @@
  * implemented) Hazard3 cores.
  */
 #include "rpi_pico2.dtsi"
+#include "../common/rpi_pico-led.dtsi"


### PR DESCRIPTION
At the moment, `blinky` sample can be built for Pico 2W, but it doesn't work as expected because the board has no LED connected to GPIO.

`rpi_pico2.dtsi` is a common dtsi, used by Pico 2 and Pico 2 W, it shouldn't contain board specific stuff (like LEDs). So, include `rpi_pico-led.dtsi` directly in Pico 2 dts.