### PR TITLE
tests/samples: drivers: adc: rework tests filtering and configuration

### DIFF
--- a/boards/gd/gd32f350r_eval/gd32f350r_eval.yaml
+++ b/boards/gd/gd32f350r_eval/gd32f350r_eval.yaml
@@ -13,4 +13,5 @@ toolchain:
 supported:
   - watchdog
   - dma
+  - adc
 vendor: gd

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.yaml
@@ -14,6 +14,7 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - adc
   - arduino_gpio
   - can
   - dac

--- a/boards/renesas/ek_ra8m1/ek_ra8m1.yaml
+++ b/boards/renesas/ek_ra8m1/ek_ra8m1.yaml
@@ -16,4 +16,5 @@ supported:
   - i2s
   - i3c
   - crc
+  - adc
 vendor: renesas

--- a/samples/drivers/adc/adc_dt/sample.yaml
+++ b/samples/drivers/adc/adc_dt/sample.yaml
@@ -1,10 +1,13 @@
 sample:
   name: ADC devicetree driver sample
+common:
+  tags:
+    - adc
+  depends_on: adc
+  filter: dt_node_has_prop("/zephyr,user","io-channels")
+
 tests:
   sample.drivers.adc.adc_dt:
-    tags:
-      - adc
-    depends_on: adc
     platform_allow:
       - nucleo_l073rz
       - nucleo_h753zi

--- a/samples/drivers/adc/adc_sequence/sample.yaml
+++ b/samples/drivers/adc/adc_sequence/sample.yaml
@@ -4,6 +4,7 @@ common:
   tags:
     - adc
   depends_on: adc
+  filter: dt_alias_exists("adc0")
   harness: console
   timeout: 10
   harness_config:

--- a/scripts/pylib/twister/expr_parser.py
+++ b/scripts/pylib/twister/expr_parser.py
@@ -280,6 +280,17 @@ def ast_expr(ast, env, edt):
         if node and prop in node.props and node.props[prop].val:
             return True
         return False
+    elif ast[0] == "dt_node_has_prop":
+        # 1st arg 'label' must be a valid node alias or a node path
+        label = ast[1][0]
+        try:
+            node = edt.get_node(label)
+        except Exception:
+            return False
+        prop = ast[1][1]
+        if prop in node.props:
+            return True
+        return False
 
 
 mutex = threading.Lock()

--- a/tests/drivers/adc/adc_accuracy_test/CMakeLists.txt
+++ b/tests/drivers/adc/adc_accuracy_test/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(dac_accuracy)
+project(adc_accuracy)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_REFERENCE_VOLTAGE_TEST app PRIVATE src/ref_volt.c)

--- a/tests/drivers/adc/adc_accuracy_test/Kconfig
+++ b/tests/drivers/adc/adc_accuracy_test/Kconfig
@@ -11,13 +11,16 @@ source "Kconfig.zephyr"
 ZEPHYR_USER := zephyr,user
 
 config DAC_SOURCE_TEST
-	bool
+	bool "Test using a DAC source"
 	select DAC
-	default y if $(dt_node_has_prop,/$(ZEPHYR_USER),dac)
+	depends on $(dt_node_has_prop,/$(ZEPHYR_USER),dac)
+	depends on $(dt_node_has_prop,/$(ZEPHYR_USER),dac-channel-id)
+	depends on $(dt_node_has_prop,/$(ZEPHYR_USER),dac-resolution)
 
 config REFERENCE_VOLTAGE_TEST
-	bool
-	default y if $(dt_node_has_prop,/$(ZEPHYR_USER),reference-mv)
+	bool "Test using a ref voltage source"
+	depends on $(dt_node_has_prop,/$(ZEPHYR_USER),reference-mv)
+	depends on $(dt_node_has_prop,/$(ZEPHYR_USER),expected-accuracy)
 
 config NUMBER_OF_PASSES
 	int "Number of passes"

--- a/tests/drivers/adc/adc_accuracy_test/testcase.yaml
+++ b/tests/drivers/adc/adc_accuracy_test/testcase.yaml
@@ -4,15 +4,25 @@ common:
     - drivers
   depends_on:
     - adc
+  filter: dt_node_has_prop("/zephyr,user","io-channels")
+
 tests:
   drivers.adc.accuracy.dac_source:
     depends_on:
       - dac
+    extra_configs:
+      - CONFIG_DAC_SOURCE_TEST=y
+    # Test scenario is filtered if Kconfig dependencies are not satisfied
+    filter: CONFIG_DAC_SOURCE_TEST
     harness_config:
       fixture: dac_adc_loopback
     platform_allow:
       - frdm_k64f
   drivers.adc.accuracy.ref_volt:
+    extra_configs:
+      - CONFIG_REFERENCE_VOLTAGE_TEST=y
+    # Test scenario is filtered if Kconfig dependencies are not satisfied
+    filter: CONFIG_REFERENCE_VOLTAGE_TEST
     harness_config:
       fixture: adc_ref_volt
     platform_allow:

--- a/tests/drivers/adc/adc_api/testcase.yaml
+++ b/tests/drivers/adc/adc_api/testcase.yaml
@@ -3,10 +3,12 @@ common:
     - adc
     - drivers
     - userspace
+  depends_on: adc
+  filter: dt_node_has_prop("/zephyr,user","io-channels")
+  min_flash: 40
+
 tests:
   drivers.adc:
-    depends_on: adc
-    min_flash: 40
     platform_exclude:
       - nucleo_u031r8
       - panb611evb/nrf54l15/cpuapp
@@ -21,28 +23,19 @@ tests:
       - rpi_pico/rp2040/w/mcuboot
       - rpi_pico2/rp2350a/m33/mcuboot
       - rpi_pico2/rp2350a/m33/w/mcuboot
-  drivers.adc.b_u585i_iot02a_adc4:
     extra_args:
-      - DTC_OVERLAY_FILE="boards/b_u585i_iot02a_adc4.overlay"
-    platform_allow:
-      - b_u585i_iot02a
-  drivers.adc.nucleo_f103rb_dma:
-    extra_args:
-      - DTC_OVERLAY_FILE="boards/nucleo_f103rb_dma.overlay"
-      - EXTRA_CONF_FILE="overlay-dma-stm32.conf"
-    platform_allow:
-      - nucleo_f103rb
+      - platform:b_u585i_iot02a/stm32u585xx:DTC_OVERLAY_FILE="boards/b_u585i_iot02a_adc4.overlay"
+    integration_platforms:
+      - native_sim
+      - native_sim/native/64
   drivers.adc.dma_st_stm32:
-    extra_args:
-      - EXTRA_CONF_FILE="overlay-dma-stm32.conf"
     depends_on:
-      - adc
       - dma
-    min_flash: 40
     platform_allow:
       - b_u585i_iot02a
       - disco_l475_iot1
       - nucleo_f091rc
+      - nucleo_f103rb
       - nucleo_f207zg
       - nucleo_f401re
       - nucleo_f429zi
@@ -65,6 +58,9 @@ tests:
       - stm32f3_disco
       - stm32h573i_dk
       - stm32u083c_dk
+    extra_args:
+      - EXTRA_CONF_FILE=overlay-dma-stm32.conf
+      - platform:nucleo_f103rb/stm32f103xb:DTC_OVERLAY_FILE="boards/nucleo_f103rb_dma.overlay"
     integration_platforms:
       - disco_l475_iot1
       - nucleo_l476rg
@@ -72,7 +68,6 @@ tests:
     extra_args:
       - EXTRA_CONF_FILE="overlay-dma-kinetis.conf"
     depends_on:
-      - adc
       - dma
     min_flash: 40
     platform_allow:
@@ -82,10 +77,9 @@ tests:
       - frdm_k82f
   drivers.adc.dma_espressif:
     extra_args:
-      - DTC_OVERLAY_FILE="boards/esp32s3_devkitc_procpu.overlay"
+      - platform:esp32s3_devkitc/esp32s3/procpu:DTC_OVERLAY_FILE="boards/esp32s3_devkitc_procpu.overlay"
       - EXTRA_CONF_FILE="overlay-dma-esp32.conf"
     depends_on:
-      - adc
       - dma
     platform_allow:
       - esp32s3_devkitc/esp32s3/procpu

--- a/tests/drivers/adc/adc_error_cases/testcase.yaml
+++ b/tests/drivers/adc/adc_error_cases/testcase.yaml
@@ -2,10 +2,11 @@ common:
   tags:
     - adc
     - drivers
+  depends_on: adc
+  filter: dt_alias_exists("adc")
 
 tests:
   drivers.adc_error_cases:
-    depends_on: adc
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Make tests/samples test scenarios depend on the existence of required DT elements (aliases, "zephyr,user" properties...).

Motivation behind the filtering changes:
The number of board overlays in ADC tests/samples is completely out of control in my opinion. And the reason is: most of their test scenarios get triggered, & fail every single time a board PR is opened and has the `adc` tag in `[board].yaml` (& almost always it does because most people assume those tags are a general list of supported features..., not test dedicated), then an overlay is added, as a fix for CI, eventhough the exact ADC IP/driver is already tested elsewhere on many boards. 