### PR TITLE
modules: update west.yml for hal_atmel

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: ca7e4c6920f44b9d677ed5995ffa169f18a54cdf
+      revision: 065e57c5013051c8b7f2256271349c6942bd9344
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
Sam4l use different TC_CMR_WAVEFORM_EEVT macro name.
Update these macro names to be consistent with other sam mcu.

PR for hal_atmel [#49](https://github.com/zephyrproject-rtos/hal_atmel/pull/49)

Many thanks.
Xing.