### PR TITLE
toolchain: linker: IAR fix for new linker optimization options

### DIFF
--- a/cmake/linker/iar/linker_flags.cmake
+++ b/cmake/linker/iar/linker_flags.cmake
@@ -4,6 +4,26 @@
 
 # Override the default CMake's IAR ILINK linker signature
 
+# The default behaviour of these new optimization flags for the linker
+# is to use the compiler optimization flags if no flags are set.
+# This does not work for IAR tools as there are no optimization flags
+# for the linker, and leaving the property empty causes it to be
+# filled with the compiler flags.
+# This workaround adds extra info to the map file only so should not
+# affect the generated code
+# To have this working properly, either the automatic use of compiler
+# flags must be removed, or we add some kind of dummy do nothing
+# command line option to the linker.
+# Either way, as this is causing an error right now, we use this
+# temporary workaround.
+
+set_property(TARGET linker PROPERTY no_optimization --entry_list_in_address_order)
+set_property(TARGET linker PROPERTY optimization_debug --entry_list_in_address_order)
+set_property(TARGET linker PROPERTY optimization_speed --entry_list_in_address_order)
+set_property(TARGET linker PROPERTY optimization_size --entry_list_in_address_order)
+set_property(TARGET linker PROPERTY optimization_size_aggressive --entry_list_in_address_order)
+
+
 string(APPEND CMAKE_C_LINK_FLAGS --no-wrap-diagnostics)
 
 if(CONFIG_IAR_DATA_INIT)


### PR DESCRIPTION
The IAR linker ilink does not have any optimization options, and with the newly added linker optimization flags that default to the compiler optimization flags, ilink will fail with an "illegal command line option" error.
This temporary workaround will use a harmless option instead to avoid errors, until we can update the linker.