### PR TITLE
soc: intel_adsp: ace: add IMR info registers

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -136,6 +136,11 @@
 			reg = <0x71d80 0x0008>;
 		};
 
+		imria1: imria1@162080 {
+			compatible = "intel,adsp-imria1";
+			reg = <0x162080 0x0008>;
+		};
+
 		hsbpm: hsbpm@17a800 {
 			compatible = "intel,adsp-hsbpm";
 			reg = <0x17a800 0x0008>;

--- a/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace20_lnl.dtsi
@@ -155,6 +155,11 @@
 			reg = <0x71d80 0x0008>;
 		};
 
+		imria1: imria1@162080 {
+			compatible = "intel,adsp-imria1";
+			reg = <0x162080 0x0008>;
+		};
+
 		hsbpm: hsbpm@17a800 {
 			compatible = "intel,adsp-hsbpm";
 			reg = <0x17a800 0x0008>;

--- a/dts/xtensa/intel/intel_adsp_ace30.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace30.dtsi
@@ -130,6 +130,11 @@
 			reg = <0x71d80 0x0008>;
 		};
 
+		imria1: imria1@162080 {
+			compatible = "intel,adsp-imria1";
+			reg = <0x162080 0x0008>;
+		};
+
 		hsbpm: hsbpm@17a800 {
 			compatible = "intel,adsp-hsbpm";
 			reg = <0x17a800 0x0008>;

--- a/dts/xtensa/intel/intel_adsp_ace40.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace40.dtsi
@@ -123,6 +123,11 @@
 			reg = <0x71d80 0x0008>;
 		};
 
+		imria1: imria1@162080 {
+			compatible = "intel,adsp-imria1";
+			reg = <0x162080 0x0008>;
+		};
+
 		hsbpm: hsbpm@17a800 {
 			compatible = "intel,adsp-hsbpm";
 			reg = <0x17a800 0x0008>;

--- a/soc/intel/intel_adsp/ace/include/adsp_memory.h
+++ b/soc/intel/intel_adsp/ace/include/adsp_memory.h
@@ -78,8 +78,6 @@
 /* position of L3 heap, size of L3 heap - till end of the L3 memory */
 /* !!! FIXME: L3 heap base MUST be automatically calculated. !!! */
 #define IMR_L3_HEAP_BASE		(IMR_BOOT_LDR_STACK_BASE + IMR_BOOT_LDR_STACK_SIZE)
-#define IMR_L3_HEAP_SIZE		(L3_MEM_SIZE - \
-					(IMR_L3_HEAP_BASE - L3_MEM_BASE_ADDR))
 
 #define ADSP_L1_CACHE_PREFCTL_VALUE 0x1038
 
@@ -167,6 +165,40 @@ struct ace_lpsram_regs {
 	uint8_t USxPGISTS;
 	uint8_t reserved1[3];
 };
+
+/* IMR memory info */
+#define HFIMRIA1_REG (DT_REG_ADDR(DT_NODELABEL(imria1)))
+#define HFIMRIS1_REG (DT_REG_ADDR(DT_NODELABEL(imria1)) + 0x8)
+
+/* IMR Info Address 1 */
+struct ace_hfimria1 {
+	/** @brief Physical base address of the IMR memory region */
+	uint64_t addr;
+};
+
+/* IMR Info Size 1 */
+struct ace_hfimris1 {
+	/** @brief IMR used */
+	uint64_t iu	: 1;
+	/** @brief Root Space */
+	uint64_t rs	: 3;
+	uint64_t rsvd31	: 28;
+	/** @brief IMR size in KB */
+	uint64_t sz	: 32;
+};
+
+#define ACE_HFIMRA1 ((volatile struct ace_hfimria1 *)HFIMRIA1_REG)
+#define ACE_HFIMRS1 ((volatile struct ace_hfimris1 *)HFIMRIS1_REG)
+
+static ALWAYS_INLINE uint32_t ace_imr_used(void)
+{
+	return ACE_HFIMRS1->iu;
+}
+
+static ALWAYS_INLINE uint32_t ace_imr_get_mem_size(void)
+{
+	return ACE_HFIMRS1->sz * 1024;
+}
 #endif
 
 /* These registers are for the L2 HP SRAM bank power management control and status.*/

--- a/soc/intel/intel_adsp/ace/mmu_ace30.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace30.c
@@ -144,12 +144,6 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 		.name = "imr data",
 	},
 	{
-		.start = (uint32_t)IMR_L3_HEAP_BASE,
-		.end   = (uint32_t)(IMR_L3_HEAP_BASE + IMR_L3_HEAP_SIZE),
-		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB,
-		.name = "imr L3 heap",
-	},
-	{
 		.start = (uint32_t)LP_SRAM_BASE,
 		.end   = (uint32_t)(LP_SRAM_BASE + LP_SRAM_SIZE),
 		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB,

--- a/soc/intel/intel_adsp/ace/mmu_ace40.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace40.c
@@ -163,7 +163,7 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 	},
 	{
 		/* FIXME: definitely need more refinements... */
-		.start = (uint32_t)0x170000,
+		.start = (uint32_t)0x160000,
 		.end = (uint32_t)0x180000,
 		.attrs = XTENSA_MMU_PERM_W,
 		.name = "hwreg1",

--- a/soc/intel/intel_adsp/ace/mmu_ace40.c
+++ b/soc/intel/intel_adsp/ace/mmu_ace40.c
@@ -131,12 +131,6 @@ const struct xtensa_mmu_range xtensa_soc_mmu_ranges[] = {
 		.name = "imr data",
 	},
 	{
-		.start = (uint32_t)IMR_L3_HEAP_BASE,
-		.end = (uint32_t)(IMR_L3_HEAP_BASE + IMR_L3_HEAP_SIZE),
-		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB,
-		.name = "imr L3 heap",
-	},
-	{
 		.start = (uint32_t)LP_SRAM_BASE,
 		.end = (uint32_t)(LP_SRAM_BASE + LP_SRAM_SIZE),
 		.attrs = XTENSA_MMU_PERM_W | XTENSA_MMU_CACHED_WB,


### PR DESCRIPTION
Adds devicetree nodes for IMR memory information registers across all ACE platforms.
These registers provide information about the IMR memory region, such as whether it is in use and its size.

Implements structures and utility functions to access these registers and retrieve IMR information programmatically.
This allows dynamic detection of IMR availability and its size at runtime, instead of relying on hardcoded values.

Removes the hardcoded IMR_L3_HEAP_SIZE definition since the size can now be determined dynamically using the newly added ace_imr_get_mem_size() function.