### PR TITLE
drivers: spi: it51xxx: improve interrupt flag check and clock control mechanism

### DIFF
--- a/dts/riscv/ite/it51xxx.dtsi
+++ b/dts/riscv/ite/it51xxx.dtsi
@@ -1393,7 +1393,7 @@
 			compatible = "ite,it51xxx-spi";
 			reg = <0x00f02600 0x24>;
 			interrupt-parent = <&intc>;
-			interrupts = <IT51XXX_IRQ_SPI IRQ_TYPE_EDGE_RISING>;
+			interrupts = <IT51XXX_IRQ_SPI IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&ecpm IT51XXX_ECPM_CGCTRL3R_OFF BIT(1)>;
 			status = "disabled";
 		};


### PR DESCRIPTION
This pr improves interrupt flag check and clock control mechanism.

- driver: spi: it51xxx: enable spi clock only when spi transaction
- dts: ite: it51xxx: set high-level triggered mode for spi0 node
- drivers: spi: it51xxx: move interrupt flags check to compile time
