### PR TITLE
scripts: zephyr_module: accept empty env variables `ZEPHYR_EXTRA_MODULES` and `EXTRA_ZEPHYR_MODULES`

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -759,8 +759,10 @@ def parse_modules(zephyr_base, manifest=None, west_projs=None, modules=None,
     if extra_modules is None:
         extra_modules = []
         for var in ['EXTRA_ZEPHYR_MODULES', 'ZEPHYR_EXTRA_MODULES']:
-            if var in os.environ:
-                extra_modules.extend(PurePosixPath(p) for p in os.environ[var].split(';'))
+            extra_module = os.environ.get(var, None)
+            if not extra_module:
+                continue
+            extra_modules.extend(PurePosixPath(p) for p in extra_module.split(';'))
 
     Module = namedtuple('Module', ['project', 'meta', 'depends'])
 


### PR DESCRIPTION
Proceed if the environment variables `ZEPHYR_EXTRA_MODULES` or `EXTRA_ZEPHYR_MODULES` are set to an empty string. In this case. handle same way as if the variable was unset.

This is helpful, when temporarily omitting the values set to environment variable, e.g.

``` bash
export ZEPHYR_EXTRA_MODULES=$(realpath my-modules)
west build app # build with extra modules
ZEPHYR_EXTRA_MODULES= west build app # temporarily omit extra modules
```