### PR TITLE
drivers: display: mcux_elcdif: Optional start on init

### DIFF
--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -36,6 +36,13 @@ config MCUX_ELCDIF_FB_SIZE
 	  4-bytes pixel format, e.g. ARGB8888. Applications should change this value
 	  according to the actual used resolution and format to optimize the heap size.
 
+config MCUX_ELCDIF_START_ON_INIT
+	bool "Start the ELCDIF display driver during initialization"
+	default y if MCUX_ELCDIF_FB_NUM != 0
+	help
+	  Optionally start the ELCDIF display driver from the initialization step,
+	  which can be required for some connected display controllers to function properly.
+
 config MCUX_ELCDIF_PXP
 	bool "Use PXP for display rotation"
 	depends on MCUX_PXP

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -54,7 +54,9 @@ struct mcux_elcdif_data {
 	struct k_sem sem;
 	/* Tracks index of next active driver framebuffer */
 	uint8_t next_idx;
+#ifndef CONFIG_MCUX_ELCDIF_START_ON_INIT
 	bool running;
+#endif
 #ifdef CONFIG_MCUX_ELCDIF_PXP
 	/* Given to when PXP completes operation */
 	struct k_sem pxp_done;
@@ -217,10 +219,12 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x, const u
 	dev_data->next_idx = (dev_data->next_idx + 1) % CONFIG_MCUX_ELCDIF_FB_NUM;
 #endif
 
+#ifndef CONFIG_MCUX_ELCDIF_START_ON_INIT
 	if (unlikely(!dev_data->running)) {
 		ELCDIF_RgbModeStart(config->base);
 		dev_data->running = true;
 	}
+#endif
 
 	/* Enable frame buffer completion interrupt */
 	ELCDIF_EnableInterrupts(config->base, kELCDIF_CurFrameDoneInterruptEnable);
@@ -370,9 +374,13 @@ static int mcux_elcdif_init(const struct device *dev)
 
 #if CONFIG_MCUX_ELCDIF_FB_NUM != 0
 	dev_data->active_fb = dev_data->fb[0];
+	dev_data->rgb_mode.bufferAddr = (uint32_t)dev_data->active_fb;
 #endif
 
 	ELCDIF_RgbModeInit(config->base, &dev_data->rgb_mode);
+#ifdef CONFIG_MCUX_ELCDIF_START_ON_INIT
+	ELCDIF_RgbModeStart(config->base);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
After 8495e307266f87132a123535fea9b21e37d18bc4 some display controller drivers failed to start. Make the start optional and enabled by default if there are frame buffers allocated by the driver.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94509