### PR TITLE
lib: libc: default LIBC_ALLOW_LESS_THAN_64BIT_TIME for ARCMWDT

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -136,6 +136,7 @@ config ARCMWDT_LIBC
 	bool "ARC MWDT C library"
 	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "arcmwdt"
 	select STATIC_INIT_GNU
+	select LIBC_ALLOW_LESS_THAN_64BIT_TIME
 	help
 	  C library provided by ARC MWDT toolchain.
 


### PR DESCRIPTION
Set CONFIG_LIBC_ALLOW_LESS_THAN_64BIT_TIME to default 'y' for ARCMWDT_LIBC toolchain.
The ARCMWDT_LIBC uses a 32-bit time_t which fails the 64-bit time_t validation introduced to prevent Y2038 issues.

This change eliminates the need to manually configure this option for every ARCMWDT test while maintaining the validation for other toolchains that support 64-bit time_t.

fixes issues generated from this PR: https://github.com/zephyrproject-rtos/zephyr/pull/93535