### PR TITLE
samples: boards: nordic: spis_wakeup: adjust sync between cores

### DIFF
--- a/samples/boards/nordic/spis_wakeup/wakeup_trigger/src/main.c
+++ b/samples/boards/nordic/spis_wakeup/wakeup_trigger/src/main.c
@@ -42,6 +42,7 @@ int main(void)
 		k_busy_wait(500000);
 		LOG_INF("SPIM: transferring the CONFIG_BOARD_QUALIFIERS: '%s'", tx_buffer);
 		spi_write_dt(&spim, &tx_spi_buf_set);
+		k_busy_wait(1000);
 	}
 
 	return 0;


### PR DESCRIPTION
Make sure there is some (short) time when both cores are active. Wakeup triggering core will wait after transaction so that waken core start its activity.