### PR TITLE
Enhance ATWINC1500 driver with OTA support, networking, and stability improvements

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -159,7 +159,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: 065e57c5013051c8b7f2256271349c6942bd9344
+      revision: 0465b7ae0909a6f95d67bc02de4e959d96a11a11
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
This PR introduces several enhancements and fixes to the ATWINC1500 driver to improve functionality, reliability, and security. The main changes planned include (WIP):

* [x] Add basic OTA support for easier firmware updates.
* [x] Implement native networking support.
* [ ] Improve error handling and control.
* [ ] Fix race conditions affecting stability.
* [x] Add AP security options (WPA/WEP).
* [ ] Support for secure sockets (offload).
* [x] Improve TCP sockets performance while receiving data.
* [x] Support for power-related configuration.
* [x] Resolve unsupported `M2M_WIFI_CH_ALL` errors in AP mode.
* [x] Automatically provide DHCP server address.

These changes aim to provide a more robust, secure, and feature-complete ATWINC1500 driver.
The `hal_atmel` repository must be updated to revision [https://github.com/zephyrproject-rtos/hal_atmel/pull/51](https://github.com/zephyrproject-rtos/hal_atmel/pull/51) to ensure the HAL layer is properly updated.