### PR TITLE
drivers: mipi_dbi: nxp_lcdic: add DMA_ADDR_ADJ_NO_CHANGE

### DIFF
--- a/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_lcdic.c
@@ -213,6 +213,8 @@ static int mipi_dbi_lcdic_start_dma(const struct device *dev)
 		}
 	}
 
+	stream->blk_cfg[0].dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+	stream->blk_cfg[1].dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 	ret = dma_config(stream->dma_dev, stream->channel, &stream->dma_cfg);
 	if (ret) {
 		return ret;


### PR DESCRIPTION
Update dma_block_config for memory to peripheral transfers.

Resolves issue with [LVGL demo](https://docs.zephyrproject.org/latest/samples/modules/lvgl/demos/README.html#lvgl-demos) on board frdm_rw612 using the [lcd_par_s035 shield](https://docs.zephyrproject.org/latest/boards/shields/lcd_par_s035/doc/index.html).