### PR TITLE
linker/xt-ld: Compute crtbegin/crtend paths in toolchain_linker_finalize

### DIFF
--- a/cmake/linker/xt-ld/target.cmake
+++ b/cmake/linker/xt-ld/target.cmake
@@ -11,8 +11,6 @@ find_program(CMAKE_LINKER xt-ld ${LD_SEARCH_PATH})
 
 set_ifndef(LINKERFLAGPREFIX -Wl)
 
-compiler_file_path(crtbegin.o CRTBEGIN_PATH)
-compiler_file_path(crtend.o CRTEND_PATH)
 if(CONFIG_CPP_EXCEPTIONS AND CRTBEGIN_PATH AND CRTEND_PATH)
   # When building with C++ Exceptions, it is important that crtbegin and crtend
   # are linked at specific locations.
@@ -156,6 +154,10 @@ macro(toolchain_linker_finalize)
  set(CMAKE_ASM_LINK_EXECUTABLE "<CMAKE_ASM_COMPILER> <FLAGS> <CMAKE_ASM_LINK_FLAGS> ${common_link}")
  set(CMAKE_C_LINK_EXECUTABLE   "<CMAKE_C_COMPILER> <FLAGS> <CMAKE_C_LINK_FLAGS> ${common_link}")
  set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> ${common_link}")
+
+ compiler_file_path(crtbegin.o CRTBEGIN_PATH)
+ compiler_file_path(crtend.o CRTEND_PATH)
+
 endmacro()
 
 # Function to map compiler flags into suitable linker flags


### PR DESCRIPTION
The computation of paths to crtbegin.o and crtend.o must be delayed until after the compiler_file_path function has been defined. The toolchain_linker_finalize function is where these are supposed to get set now.

Closes: #94496 