### PR TITLE
dts: arm: Remove AES from the u575

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -818,6 +818,14 @@
 			status = "disabled";
 		};
 
+		hash: hash@420c0400 {
+			compatible = "st,stm32-hash";
+			reg = <0x420c0400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
+			resets = <&rctl STM32_RESET(AHB2L, 17)>;
+			status = "disabled";
+		};
+
 		pwr: power@46020800 {
 			compatible = "st,stm32-pwr";
 			reg = <0x46020800 0x400>; /* PWR register bank */

--- a/dts/arm/st/u5/stm32u575.dtsi
+++ b/dts/arm/st/u5/stm32u575.dtsi
@@ -7,7 +7,6 @@
 
 #include <st/u5/stm32u5_usbotg_fs.dtsi>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
-#include <st/u5/stm32u5_crypt.dtsi>
 
 / {
 	sram0: memory@20000000 {

--- a/dts/arm/st/u5/stm32u5_crypt.dtsi
+++ b/dts/arm/st/u5/stm32u5_crypt.dtsi
@@ -14,13 +14,5 @@
 			interrupts = <93 0>;
 			status = "disabled";
 		};
-
-		hash: hash@420c0400 {
-			compatible = "st,stm32-hash";
-			reg = <0x420c0400 0x400>;
-			clocks = <&rcc STM32_CLOCK(AHB2, 17)>;
-			resets = <&rctl STM32_RESET(AHB2L, 17)>;
-			status = "disabled";
-		};
 	};
 };


### PR DESCRIPTION
Which does not have HW support for it, as stated by ST here: https://www.st.com/en/microcontrollers-microprocessors/stm32u575-585.html

"
The STM32U575 portfolio offers from 1 to 2 Mbytes of flash memory and from 48- to 169-pin packages.
The STM32U585 is available with 2 Mbytes of flash memory and provides an additional encryption accelerator engine (AES, PKA, and OTFDEC). "

So define the hash node directly in the u575 soc, and don't include the stm32u5_crypt.dtsi

I did not check all the datasheet for the other SOC which include `stm32u5_crypt.dtsi` but based on the availability of a `AES_TypeDef` in the stm32cube, the u575 was the only problematic instance, as the soc's having a `AES_TypeDef` properly include the `stm32u5_crypt.dtsi` (where the AES node is defined).
```
pjn@funkybox:~/git/zephyrproject/modules/hal/stm32/stm32cube/stm32u5xx$ git grep -l AES_TypeDef
drivers/include/stm32u5xx_hal_cryp.h
soc/stm32u545xx.h
soc/stm32u585xx.h
soc/stm32u5a5xx.h
soc/stm32u5a9xx.h
soc/stm32u5g7xx.h
soc/stm32u5g9xx.h
```
```
pjn@funkybox:~/git/zephyrproject/zephyr$ git grep -l "stm32u5_crypt.dtsi" 
dts/arm/st/u5/stm32u545.dtsi
dts/arm/st/u5/stm32u585.dtsi
dts/arm/st/u5/stm32u5a5.dtsi
dts/arm/st/u5/stm32u5a9.dtsi
dts/arm/st/u5/stm32u5g9.dtsi
```

However, the u5g7 should include it, but does not exist (yet?) from what I can see.