### PR TITLE
mbox nxp imx mu

### DIFF
--- a/drivers/mbox/mbox_nxp_imx_mu.c
+++ b/drivers/mbox/mbox_nxp_imx_mu.c
@@ -195,12 +195,14 @@ static void mu_isr(const struct device *dev)
 				data->cb[i_channel](dev, i_channel, data->user_data[i_channel],
 						    &msg);
 			}
-		} else if ((flags & gen_int_mask) == gen_int_mask) {
+		}
+		if ((flags & gen_int_mask) == gen_int_mask) {
 			MU_ClearStatusFlags(config->base, gen_int_mask);
 			if (data->cb[i_channel]) {
 				data->cb[i_channel](dev, i_channel, data->user_data[i_channel],
 						    NULL);
 			}
 		}
+
 	}
 }


### PR DESCRIPTION
Ignore TriggerInterrupt failures. A failure is returned by the SDK hal driver if the interrupt is already pending, but returning an error up is problematic for certain clients, particularly icmsg.c. icmsg uses mailbox for notifications/interrupts, and doesn't expect any errors. In some places it propagates an error up, in some places it ignores errors, and in some places it asserts. The asserts in particular are fatal.

As long as the interrupt is pended, we should be able to ignore the case if the interrupt is already pended
and not consider that an error, since the interrupt handler on the remote processor should read all pending data.

Also make some optimizations to interrupt handling:
* remove extra trampoline layer to get the device
* return from the ISR early when all interrupts have been handled