### PR TITLE
drivers: dma_mcux_lpc: fix missing peripheral case

### DIFF
--- a/drivers/dma/dma_mcux_lpc.c
+++ b/drivers/dma/dma_mcux_lpc.c
@@ -516,7 +516,8 @@ static int dma_mcux_lpc_configure(const struct device *dev, uint32_t channel,
 	}
 
 	if ((config->channel_direction == MEMORY_TO_PERIPHERAL) ||
-	    (config->channel_direction == PERIPHERAL_TO_MEMORY)) {
+	    (config->channel_direction == PERIPHERAL_TO_MEMORY) ||
+	    (config->channel_direction == LPC_DMA_SPI_MCUX_FLEXCOMM_TX)) {
 		is_periph = true;
 	} else {
 		is_periph = false;


### PR DESCRIPTION
Change 4e0e3c990d2a70f81dc0cc1c06831bd5f9b7c288 caused a regression in that SPI_MCUX_FLEXCOMM_TX DMA transfers weren't properly set to be a peripheral
transfer.