### PR TITLE
Bluetooth: SDP: Fix ssa discovery issue caused by setting range

### DIFF
--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1081,31 +1081,6 @@ out:
 		break;
 	}
 
-	/* If the attribute ID is out of range, the continuation state should be updated. */
-	if (attr_size == 0) {
-		sad->state->last_att = att_idx + 1;
-		sad->state->last_att_index = 0;
-	}
-
-	/* If the attribute index is out of range, increase the service
-	 * index and reset attribute index.
-	 */
-	if (sad->state->last_att >= sad->rec->attr_count) {
-		sad->state->current_svc++;
-		sad->state->last_att = 0;
-	}
-
-	/* End the search if:
-	 * 1. We have exhausted the packet
-	 * AND
-	 * 2. This packet doesn't contain the service element declaration header
-	 * AND
-	 * 3. This is not a dry-run (then we look for other attrs that match)
-	 */
-	if (sad->state->pkt_full && !sad->seq && sad->rsp_buf) {
-		return BT_SDP_ITER_STOP;
-	}
-
 	return BT_SDP_ITER_CONTINUE;
 }
 
@@ -1475,6 +1450,15 @@ static uint16_t sdp_svc_search_att_req(struct bt_sdp *sdp, struct net_buf *buf,
 
 		if (!record) {
 			continue;
+		}
+
+		/* reset the `state.last_att` and `state.last_att_index`
+		 * if the index of current record is not same with `state.current_svc`.
+		 */
+		if (state.current_svc != record->index) {
+			state.current_svc = record->index;
+			state.last_att = 0;
+			state.last_att_index = 0;
 		}
 
 		sending_len = create_attr_list(sdp, record, filter, num_filters, max_att_len,

--- a/tests/bluetooth/classic/sdp_s/pytest/test_sdp.py
+++ b/tests/bluetooth/classic/sdp_s/pytest/test_sdp.py
@@ -315,6 +315,89 @@ async def br_connect(hci_port, shell, address) -> None:
                     assert profile_found is True
 
 
+async def sdp_discover_with_range(hci_port, shell, address) -> None:
+    logger.info('<<< connect...')
+    async with await open_transport_or_link(hci_port) as hci_transport:
+        device = Device.with_hci(
+            'Bumble',
+            Address('F0:F1:F2:F3:F4:F5'),
+            hci_transport.source,
+            hci_transport.sink,
+        )
+
+        valid_attribute_ids = []
+
+        with open("bumble_hci_sdp_s_discover_with_range.log", "wb") as snoop_file:
+            device.host.snooper = BtSnooper(snoop_file)
+            device.classic_enabled = True
+            device.le_enabled = False
+            await device_power_on(device)
+
+            target_address = address.split(" ")[0]
+            logger.info(f'=== Connecting to {target_address}...')
+            try:
+                connection = await device.connect(target_address, transport=BT_BR_EDR_TRANSPORT)
+                logger.info(f'=== Connected to {connection.peer_address}!')
+            except CommandTimeoutError as e:
+                logger.info('!!! Connection timed out')
+                raise e
+
+            # Connect to the SDP Server
+            sdp_client = SDP_Client(connection)
+            await sdp_client.connect()
+
+            logger.info("<<< 1 List all attributes and get all supported attribute ids")
+            search_result = await sdp_client.search_attributes(
+                [BT_L2CAP_PROTOCOL_ID], [SDP_ALL_ATTRIBUTES_RANGE]
+            )
+
+            max_attribute_id = 0
+
+            assert len(search_result) != 0
+            logger.info('SEARCH RESULTS:')
+            for attribute_list in search_result:
+                logger.info('SERVICE:')
+                for attribute in attribute_list:
+                    logger.info(
+                        '  ' + '\n  '.join([attribute.to_string()])
+                    )
+                    if attribute.id not in valid_attribute_ids:
+                        valid_attribute_ids.append(attribute.id)
+                        if max_attribute_id < attribute.id:
+                            max_attribute_id = attribute.id
+
+            logger.info(f"attribute id list {valid_attribute_ids}")
+            if (max_attribute_id + 10) <= 0xFFFF:
+                max_attribute_id += 10
+
+            for attribute_id_start in range(0, max_attribute_id):
+                for attribute_id_end in range(attribute_id_start, max_attribute_id):
+                    # List all services in the root browse group
+                    logger.info(f"<<< Service search discovery UUID {BT_L2CAP_PROTOCOL_ID} with "
+                                f"range ({attribute_id_start}, {attribute_id_end})")
+                    search_result = await sdp_client.search_attributes(
+                        [BT_L2CAP_PROTOCOL_ID], [(attribute_id_start, attribute_id_end)]
+                    )
+                    in_range = False
+                    for id in valid_attribute_ids:
+                        if attribute_id_start <= id <= attribute_id_end:
+                            logger.info(f"({attribute_id_start} {attribute_id_end}) in range")
+                            in_range = True
+                            break
+
+                    logger.info('SEARCH RESULTS:')
+                    for attribute_list in search_result:
+                        logger.info('SERVICE:')
+                        logger.info(
+                            '  ' +
+                            '\n'.join([attribute.to_string() for attribute in attribute_list])
+                        )
+
+                    if in_range:
+                        assert len(search_result) != 0
+                    else:
+                        assert len(search_result) == 0
+
 class TestSdpServer:
     def test_discovery_device(self, sdp_server_dut):
         """Test case to discover IUT"""
@@ -327,3 +410,9 @@ class TestSdpServer:
         logger.info(f'test_sdp_discover {sdp_server_dut}')
         hci, iut_address = sdp_server_dut
         asyncio.run(br_connect(hci, shell, iut_address))
+
+    def test_sdp_discover_with_range(self, shell: Shell, dut: DeviceAdapter, sdp_server_dut):
+        """Test case to request SDP records with range"""
+        logger.info(f'test_sdp_discover_with_range {sdp_server_dut}')
+        hci, iut_address = sdp_server_dut
+        asyncio.run(sdp_discover_with_range(hci, shell, iut_address))

--- a/tests/bluetooth/classic/sdp_s/testcase.yaml
+++ b/tests/bluetooth/classic/sdp_s/testcase.yaml
@@ -11,7 +11,7 @@ tests:
     harness_config:
       pytest_dut_scope: session
       fixture: usb_hci
-    timeout: 60
+    timeout: 900
   bluetooth.classic.sdp.server.no_blobs:
     platform_allow:
       - mimxrt1170_evk@B/mimxrt1176/cm7


### PR DESCRIPTION
Bluetooth: SDP: Fix ssa discovery issue caused by setting range

If the range of the service search attribute request is set and the start of the range is not 0x0000, the response data of the request is not valid. It is caused by the data element sequence has not be added to response data. The client cannot parse the response data properly.

The root cause of this issue is that the total length of service record will be added only when adding the first attribute of service
record.

Fix the issue by reset the `state.last_att` and `state.last_att_index` if the index of current record is not same with `state.current_svc`.

And do not update `state.last_att`, `state.last_att_index`, and `state.current_svc` in the function `select_attrs()`.
