### PR TITLE
drivers: ethernet: nxp_imx_netc: Fix LAA bit location

### DIFF
--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc_priv.h
@@ -66,10 +66,10 @@
 	do {                                                                                       \
 		uint32_t id = 0x001100;                                                            \
                                                                                                    \
-		mac_addr[0] = FREESCALE_OUI_B0;                                                    \
-		mac_addr[1] = FREESCALE_OUI_B1;                                                    \
 		/* Set MAC address locally administered bit (LAA) */                               \
-		mac_addr[2] = FREESCALE_OUI_B2 | 0x02;                                             \
+		mac_addr[0] = FREESCALE_OUI_B0 | 0x02;                                             \
+		mac_addr[1] = FREESCALE_OUI_B1;                                                    \
+		mac_addr[2] = FREESCALE_OUI_B2;                                                    \
 		mac_addr[3] = (id >> 16) & 0xff;                                                   \
 		mac_addr[4] = (id >> 8) & 0xff;                                                    \
 		mac_addr[5] = (id + n) & 0xff;                                                     \


### PR DESCRIPTION
The Locally Administered Address (LAA) bit should be set on the first octet of the MAC address.