### PR TITLE
Misc Doxygen improvements to device-specific sensor headers

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -19,6 +19,10 @@
  * @version 1.0.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup sensor_interface_ext Device-specific Sensor API extensions
+ * @{
+ * @}
  */
 
 #include <errno.h>

--- a/include/zephyr/drivers/sensor/adltc2990.h
+++ b/include/zephyr/drivers/sensor/adltc2990.h
@@ -3,15 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of ADLTC2990 sensor
+ * @ingroup adltc2990_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADLTC2990_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADLTC2990_H_
+
+/**
+ * @brief Analog Devices ADLTC2990 Quad I2C Voltage, Current and Temperature Monitor
+ * @defgroup adltc2990_interface ADLTC2990
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #include <stdbool.h>
 
 #include <zephyr/device.h>
 
+/**
+ * @brief Acquisition format
+ */
 enum adltc2990_acquisition_format {
+	/** Repeated acquisition */
 	ADLTC2990_REPEATED_ACQUISITION,
+	/** Single shot acquisition */
 	ADLTC2990_SINGLE_SHOT_ACQUISITION,
 };
 
@@ -37,5 +55,9 @@ int adltc2990_is_busy(const struct device *dev, bool *is_busy);
  */
 int adltc2990_trigger_measurement(const struct device *dev,
 				  enum adltc2990_acquisition_format format);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_ADLTC2990_H_ */

--- a/include/zephyr/drivers/sensor/afbr_s50.h
+++ b/include/zephyr/drivers/sensor/afbr_s50.h
@@ -5,8 +5,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of AFBR-S50 sensor
+ * @ingroup afbr_s50_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_AFBR_S50_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_AFBR_S50_H_
+
+/**
+ * @brief Broadcom AFBR-S50 3D ToF sensor
+ * @defgroup afbr_s50_interface AFBR-S50
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #include <zephyr/drivers/sensor.h>
 
@@ -17,15 +30,20 @@ extern "C" {
 /** Disregard pixel reading if contains this value */
 #define AFBR_PIXEL_INVALID_VALUE 0x80000000
 
-/** Private sensor channel to obtain matrix of pixels with readings in meters.
- * This sensor supports up to 32 pixels in a single reading (4 x 8 matrix).
- */
 enum sensor_channel_afbr_s50 {
+	/**
+	 * Obtain matrix of pixels, with readings in meters.
+	 * The sensor supports up to 32 pixels in a single reading (4 x 8 matrix).
+	 */
 	SENSOR_CHAN_AFBR_S50_PIXELS = SENSOR_CHAN_PRIV_START + 1,
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_AFBR_S50_H_ */

--- a/include/zephyr/drivers/sensor/bd8lb600fs.h
+++ b/include/zephyr/drivers/sensor/bd8lb600fs.h
@@ -3,22 +3,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of BD8LB600FS sensor
+ * @ingroup bd8lb600fs_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_BD8LB600FS_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_BD8LB600FS_H_
 
+/**
+ * @brief ROHM Semiconductor BD8LB600FS open load and over-current detection
+ * @defgroup bd8lb600fs_interface BD8LB600FS
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Custom sensor channels for BD8LB600FS
+ */
 enum sensor_channel_bd8lb600fs {
 	/**
-	 * Open load detected,
-	 * boolean with one bit per output
+	 * Open load detected.
+	 * Boolean with one bit per output
 	 */
 	SENSOR_CHAN_BD8LB600FS_OPEN_LOAD = SENSOR_ATTR_PRIV_START,
 	/**
-	 * Over current protection or thermal shutdown,
-	 * boolean with one bit per output
+	 * Over current protection or thermal shutdown.
+	 * Boolean with one bit per output
 	 */
 	SENSOR_CHAN_BD8LB600FS_OVER_CURRENT_OR_THERMAL_SHUTDOWN,
 };
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_BD8LB600FS_H_ */

--- a/include/zephyr/drivers/sensor/bmm350.h
+++ b/include/zephyr/drivers/sensor/bmm350.h
@@ -5,6 +5,22 @@
  */
 
 /**
+ * @file
+ * @brief Header file for extended sensor API of BMM350 sensor
+ * @ingroup bmm350_interface
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_BMM350_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_BMM350_H_
+
+/**
+ * @brief Bosch BMM350 3-Axis Magnetometer
+ * @defgroup bmm350_interface BMM350
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
+/**
  * @brief Performs a magnetic reset.
  *
  * The BMM350 has measures to recover from excessively strong
@@ -23,3 +39,9 @@
  * @return 0 if successful, negative errno code if failure.
  */
 int bmm350_magnetic_reset(const struct device *dev);
+
+/**
+ * @}
+ */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_BMM350_H_ */

--- a/include/zephyr/drivers/sensor/bmp581_user.h
+++ b/include/zephyr/drivers/sensor/bmp581_user.h
@@ -9,8 +9,21 @@
  *
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of BMP581 sensor
+ * @ingroup bmp581_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_BMP581_USER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_BMP581_USER_H_
+
+/**
+ * @brief Bosch BMP581 Barometric pressure sensor
+ * @defgroup bmp581_interface BMP581
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/dt-bindings/sensor/bmp581.h>
@@ -21,9 +34,26 @@
  * keep in mind that disabling IIR back in runtime is not
  * supported yet
  */
+
+/**
+ * @brief IIR configuration for pressure and temperature channels
+ *
+ * sensor_value.val1 is the IIR filter coefficient for temperature.
+ * sensor_value.val2 is the IIR filter coefficient for pressure.
+ *
+ * See @ref bmp581_iir_filter for the valid values.
+ */
 #define BMP5_ATTR_IIR_CONFIG (SENSOR_ATTR_PRIV_START + 1u)
+/**
+ * @brief Power mode
+ *
+ * The attribute value should be a @ref bmp5_powermode enum value.
+ */
 #define BMP5_ATTR_POWER_MODE (SENSOR_ATTR_PRIV_START + 2u)
 
+/**
+ * @brief BMP581 power modes
+ */
 enum bmp5_powermode {
 	/*! Standby powermode */
 	BMP5_POWERMODE_STANDBY,
@@ -36,5 +66,9 @@ enum bmp5_powermode {
 	/*! Deep standby powermode */
 	BMP5_POWERMODE_DEEP_STANDBY
 };
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_BMP581_USER_H_ */

--- a/include/zephyr/drivers/sensor/explorir_m.h
+++ b/include/zephyr/drivers/sensor/explorir_m.h
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of ExplorIR-M sensor
+ * @ingroup explorir_m_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_EXPLORIR_M_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_EXPLORIR_M_H_
+
+/**
+ * @defgroup explorir_m_interface ExplorIR-M
+ * @ingroup sensor_interface_ext
+ * @brief Gas Sensing Solutions ExplorIR-M CO<sub>2</sub> sensor
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,13 +26,24 @@ extern "C" {
 
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * Custom sensor attributes for ExplorIR-M CO2 sensor
+ */
 enum sensor_attribute_explorir_m {
-	/* Sensor integrated low-pass filter. Values 16, 32, 64, and 128 is allowed */
+	/**
+	 * Sensor's integrated low-pass filter.
+	 *
+	 * Allowed values: 0-65535 (default: 16)
+	 */
 	SENSOR_ATTR_EXPLORIR_M_FILTER = SENSOR_ATTR_PRIV_START,
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_EXPLORIR_M_H_ */

--- a/include/zephyr/drivers/sensor/f75303.h
+++ b/include/zephyr/drivers/sensor/f75303.h
@@ -3,15 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of F75303 sensor
+ * @ingroup f75303_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_F75303_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_F75303_H_
 
+/**
+ * @brief Fintek F75303 temperature sensor
+ * @defgroup f75303_interface F75303
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
 #include <zephyr/drivers/sensor.h>
 
-/* F75303 specific channels */
+/**
+ * @brief Custom sensor channels for F75303
+ */
 enum sensor_channel_f75303 {
+	/** Temperature of remote sensor 1 */
 	SENSOR_CHAN_F75303_REMOTE1 = SENSOR_CHAN_PRIV_START,
+	/** Temperature of remote sensor 2 */
 	SENSOR_CHAN_F75303_REMOTE2,
 };
+
+/**
+ * @}
+ */
 
 #endif

--- a/include/zephyr/drivers/sensor/fcx_mldx5.h
+++ b/include/zephyr/drivers/sensor/fcx_mldx5.h
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of FCX-MLDX5 sensor
+ * @ingroup fcx_mldx5_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_FCX_MLDX5_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_FCX_MLDX5_H_
+
+/**
+ * @brief Angst+Pfister FCX-MLDX5 O<sub>2</sub> sensor
+ * @defgroup fcx_mldx5_interface FCX-MLDX5
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,22 +26,59 @@ extern "C" {
 
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Custom sensor attributes for FCX-MLDX5
+ */
 enum sensor_attribute_fcx_mldx5 {
+	/**
+	 * Status of the sensor
+	 *
+	 * sensor_value.val1 is the status of the sensor, see fcx_mldx5_status enum
+	 */
 	SENSOR_ATTR_FCX_MLDX5_STATUS = SENSOR_ATTR_PRIV_START,
+	/**
+	 * Reset the sensor
+	 */
 	SENSOR_ATTR_FCX_MLDX5_RESET,
 };
 
+/**
+ * @brief Status of the sensor
+ */
 enum fcx_mldx5_status {
+	/**
+	 *  @brief Standby
+	 *  The heating of the O2 sensor is on standby, no O2 measurement is possible.
+	 */
 	FCX_MLDX5_STATUS_STANDBY = 2,
+	/**
+	 *  @brief Ramp-up
+	 *  The O2 sensor is in the heating phase, no O2 measurement is possible.
+	 */
 	FCX_MLDX5_STATUS_RAMP_UP = 3,
+	/**
+	 *  @brief Run
+	 *  The O2 module is in normal operation.
+	 */
 	FCX_MLDX5_STATUS_RUN = 4,
+	/**
+	 *  @brief Error
+	 *  The O2 module has detected a system error, no O2 measurement is possible.
+	 */
 	FCX_MLDX5_STATUS_ERROR = 5,
-	/* Unknown is not sent by the sensor */
+	/**
+	 *  @brief Unknown status
+	 *  Unknown is not sent by the sensor but used in the driver to indicate an error case.
+	 */
 	FCX_MLDX5_STATUS_UNKNOWN,
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_FCX_MLDX5_H_ */

--- a/include/zephyr/drivers/sensor/grow_r502a.h
+++ b/include/zephyr/drivers/sensor/grow_r502a.h
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of Grow R502A sensor
+ * @ingroup grow_r502a_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_GROW_R502A_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_GROW_R502A_H_
+
+/**
+ * @defgroup grow_r502a_interface Grow R502A
+ * @ingroup sensor_interface_ext
+ * @brief HZ-Grow GROW_R502A fingerprint sensor
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,57 +33,108 @@ enum r502a_led_color_idx {
 	R502A_LED_COLOR_PURPLE,
 };
 
-#define R502A_BAUD_9600 1
-#define R502A_BAUD_19200 2
-#define R502A_BAUD_38400 4
-#define R502A_BAUD_57600 6
-#define R502A_BAUD_115200 12
+/**
+ * @name Baud rates
+ * @{
+ */
 
+#define R502A_BAUD_9600   1  /**< 9600 bps */
+#define R502A_BAUD_19200  2  /**< 19200 bps */
+#define R502A_BAUD_38400  4  /**< 38400 bps */
+#define R502A_BAUD_57600  6  /**< 57600 bps */
+#define R502A_BAUD_115200 12 /**< 115200 bps */
+
+/** @} */
+
+/**
+ * Security level
+ *
+ * This enumeration lists all the supported security levels controlling the matching threshold
+ * value for fingerprint matching.
+ */
 enum r502a_sec_level {
-	R502A_SEC_LEVEL_1 = 1,
-	R502A_SEC_LEVEL_2,
-	R502A_SEC_LEVEL_3,
-	R502A_SEC_LEVEL_4,
-	R502A_SEC_LEVEL_5
+	R502A_SEC_LEVEL_1 = 1, /**< Level 1 (lowest security) */
+	R502A_SEC_LEVEL_2,     /**< Level 2 */
+	R502A_SEC_LEVEL_3,     /**< Level 3 */
+	R502A_SEC_LEVEL_4,     /**< Level 4 */
+	R502A_SEC_LEVEL_5      /**< Level 5 (highest security) */
 };
 
+/**
+ * Data packet length
+ *
+ * This enumeration lists all the supported data packet lengths for when the sensor communicates
+ * with the host.
+ */
 enum r502a_data_len {
-	R502A_PKG_LEN_32,
-	R502A_PKG_LEN_64,
-	R502A_PKG_LEN_128,
-	R502A_PKG_LEN_256
+	R502A_PKG_LEN_32,  /**< 32 bytes */
+	R502A_PKG_LEN_64,  /**< 64 bytes */
+	R502A_PKG_LEN_128, /**< 128 bytes */
+	R502A_PKG_LEN_256  /**< 256 bytes */
 };
 
+/**
+ * System parameter set
+ *
+ * This enumeration lists all the system parameters that can be set.
+ */
 enum r502a_sys_param_set {
-	R502A_BAUD_RATE = 4,
-	R502A_SECURITY_LEVEL,
-	R502A_DATA_PKG_LEN
+	R502A_BAUD_RATE = 4,  /**< Baud rate */
+	R502A_SECURITY_LEVEL, /**< Security level */
+	R502A_DATA_PKG_LEN    /**< Data package length */
 };
 
+/**
+ * System parameter
+ *
+ * This structure holds the values for the sensor's status register and system parameters.
+ */
 struct r502a_sys_param {
+	/** Status register */
 	uint16_t status_reg;
+	/** System identifier code */
 	uint16_t system_id;
+	/** Finger library size */
 	uint16_t lib_size;
+	/** Security level (1 to 5) */
 	uint16_t sec_level;
+	/** Device address */
 	uint32_t addr;
+	/** Data packet length */
 	uint16_t data_pkt_size;
+	/** Baud rate */
 	uint32_t baud;
 } __packed;
 
+/**
+ * Fingerprint template
+ *
+ * This structure holds the template data for fingerprint matching.
+ */
 struct r502a_template {
 	uint8_t *data;
 	size_t len;
 };
+
+/**
+ * Custom sensor channels for Grow R502A
+ */
 enum sensor_channel_grow_r502a {
 	/** Fingerprint template count, ID number for enrolling and searching*/
 	SENSOR_CHAN_FINGERPRINT = SENSOR_CHAN_PRIV_START,
 };
 
+/**
+ * Custom trigger types for Grow R502A
+ */
 enum sensor_trigger_type_grow_r502a {
 	/** Trigger fires when a touch is detected. */
 	SENSOR_TRIG_TOUCH = SENSOR_TRIG_PRIV_START,
 };
 
+/**
+ * Custom sensor attributes for Grow R502A
+ */
 enum sensor_attribute_grow_r502a {
 	/** To capture finger and store as feature file in
 	 * RAM buffers char_buf_1 and char_buf_2.
@@ -81,62 +145,93 @@ enum sensor_attribute_grow_r502a {
 	 * back in both RAM buffers char_buf_1 and char_buf_2.
 	 */
 	SENSOR_ATTR_R502A_TEMPLATE_CREATE,
-	/** Add template to the sensor record storage */
-	/**
-	 * @param val->val1	record index for template to be
-	 *			stored in the sensor device's flash
-	 *			library.
+	/** Add template to the sensor record storage
+	 *
+	 * sensor_value.val1 is the record index for template to be stored in the sensor device's
+	 * flash
 	 */
 	SENSOR_ATTR_R502A_RECORD_ADD,
-	/** To find requested data in record storage */
-	/**
-	 * @result val->val1	matched record index.
-	 *	   val->val2	matching score.
+	/** Find requested data in record storage
+	 *
+	 * sensor_value.val1 is the matched record index.
+	 * sensor_value.val2 is the matching score.
 	 */
 	SENSOR_ATTR_R502A_RECORD_FIND,
-	/** To delete mentioned data from record storage */
-	/**
-	 * @param val->val1	record start index to be deleted.
-	 * @param val->val2	number of records to be deleted.
+	/** Delete mentioned data from record storage
+	 *
+	 * sensor_value.val1 is the record start index to be deleted.
+	 * sensor_value.val2 is the number of records to be deleted.
 	 */
 	SENSOR_ATTR_R502A_RECORD_DEL,
-	/** To get available position to store data on record storage */
+	/** Get available position to store data on record storage */
 	SENSOR_ATTR_R502A_RECORD_FREE_IDX,
-	/** To empty the storage record*/
+	/** Empty the storage record*/
 	SENSOR_ATTR_R502A_RECORD_EMPTY,
-	/** To load template from storage to RAM buffer of sensor*/
-	/**
-	 * @param val->val1	record start index to be loaded in
-	 *			device internal RAM buffer.
+	/** Load template from storage to RAM buffer of sensor
+	 *
+	 * sensor_value.val1 is the record start index to be loaded in
+	 * device internal RAM buffer.
 	 */
 	SENSOR_ATTR_R502A_RECORD_LOAD,
-	/** To template data stored in sensor's RAM buffer*/
-	/**
-	 * @result
-	 *	val->val1	match result.
-	 *			[R502A_FINGER_MATCH_FOUND or
-	 *			R502A_FINGER_MATCH_NOT_FOUND]
-	 *	val->val2	matching score.
+	/** Template data stored in sensor's RAM buffer
+	 *
+	 * sensor_value.val1 is the match result (R502A_FINGER_MATCH_FOUND or
+	 * R502A_FINGER_MATCH_NOT_FOUND)
+	 * sensor_value.val2 is the matching score.
 	 */
 	SENSOR_ATTR_R502A_COMPARE,
-	/** To read and write device's system parameters */
-	/** sensor_attr_set
-	 * @param val->val1 parameter number from enum r502a_sys_param_set.
-	 * @param val->val2 content to be written for the respective parameter.
-	 */
-	/** sensor_attr_get
-	 * @result val->ex.data buffer holds the system parameter values.
+	/** Set device's system parameters
+	 *
+	 * sensor_value.val1 is the parameter number from enum r502a_sys_param_set.
+	 * sensor_value.val2 is the content to be written for the respective parameter.
 	 */
 	SENSOR_ATTR_R502A_SYS_PARAM,
 };
 
+/**
+ * Read system parameters
+ *
+ * This function reads the system parameters from the sensor.
+ *
+ * @param dev Pointer to the sensor device
+ * @param val Pointer to the system parameter structure
+ * @retval 0 success
+ * @retval -errno negative error code on failure
+ */
 int r502a_read_sys_param(const struct device *dev, struct r502a_sys_param *val);
+
+/**
+ * Upload finger template
+ *
+ * This function uploads a finger template to the sensor.
+ *
+ * @param dev Pointer to the sensor device
+ * @param temp Pointer to the template structure
+ * @retval 0 success
+ * @retval -errno negative error code on failure
+ */
 int fps_upload_char_buf(const struct device *dev, struct r502a_template *temp);
+
+/**
+ * Download finger template
+ *
+ * This function downloads a finger template from the sensor.
+ *
+ * @param dev Pointer to the sensor device
+ * @param char_buf_id Character buffer ID (1 or 2)
+ * @param temp Pointer to the template structure
+ * @retval 0 success
+ * @retval -errno negative error code on failure
+ */
 int fps_download_char_buf(const struct device *dev, uint8_t char_buf_id,
 				const struct r502a_template *temp);
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_DRIVERS_SENSOR_GROW_R502A_H_ */

--- a/include/zephyr/drivers/sensor/lm95234.h
+++ b/include/zephyr/drivers/sensor/lm95234.h
@@ -4,17 +4,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of LM95234 sensor
+ * @ingroup lm95234_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_LM95234_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_LM95234_H_
 
+/**
+ * @defgroup lm95234_interface LM95234
+ * @ingroup sensor_interface_ext
+ * @brief LM95234 Quad Remote Diode and Local Temperature Sensor
+ * @{
+ */
+
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * Custom sensor channels for LM95234
+ */
 enum sensor_channel_lm95234 {
-	/* External temperature inputs */
+	/** Temperature of remote diode 1 */
 	SENSOR_CHAN_LM95234_REMOTE_TEMP_1 = SENSOR_CHAN_PRIV_START,
+	/** Temperature of remote diode 2 */
 	SENSOR_CHAN_LM95234_REMOTE_TEMP_2,
+	/** Temperature of remote diode 3 */
 	SENSOR_CHAN_LM95234_REMOTE_TEMP_3,
+	/** Temperature of remote diode 4 */
 	SENSOR_CHAN_LM95234_REMOTE_TEMP_4
 };
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_LM95234_H_ */

--- a/include/zephyr/drivers/sensor/mhz19b.h
+++ b/include/zephyr/drivers/sensor/mhz19b.h
@@ -6,14 +6,19 @@
 
 /**
  * @file
- * @brief Extended public API for MH-Z19B CO2 Sensor
- *
- * Some capabilities and operational requirements for this sensor
- * cannot be expressed within the sensor driver abstraction.
+ * @brief Header file for extended sensor API of MH-Z19B sensor
+ * @ingroup mhz19b_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_MHZ19B_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_MHZ19B_H_
+
+/**
+ * @defgroup mhz19b_interface MH-Z19B
+ * @ingroup sensor_interface_ext
+ * @brief Winsen MH-Z19B CO<sub>2</sub> sensor
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,13 +26,25 @@ extern "C" {
 
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Custom sensor attributes for MH-Z19B
+ */
 enum sensor_attribute_mhz19b {
-	/** Automatic Baseline Correction Self Calibration Function. */
+	/**
+	 * Automatic Baseline Correction Self Calibration Function.
+	 *
+	 * - sensor_value.val1 == 0: Disabled
+	 * - sensor_value.val1 == 1: Enabled
+	 */
 	SENSOR_ATTR_MHZ19B_ABC = SENSOR_ATTR_PRIV_START,
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_MHZ19B_H_ */

--- a/include/zephyr/drivers/sensor/mlx90394.h
+++ b/include/zephyr/drivers/sensor/mlx90394.h
@@ -5,14 +5,19 @@
 
 /**
  * @file
- * @brief Extended public API for Melexis mlx90394 Sensor
- *
- * Some capabilities and operational requirements for this sensor
- * cannot be expressed within the sensor driver abstraction.
+ * @brief Header file for extended sensor API of MLX90394 sensor
+ * @ingroup mlx90394_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_MLX90394_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_MLX90394_H_
+
+/**
+ * @brief Melexis MLX90394 magnetometer
+ * @defgroup mlx90394_interface MLX90394
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,17 +25,62 @@ extern "C" {
 
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Custom sensor attributes for MLX90394
+ */
 enum mlx90394_sensor_attribute {
+	/**
+	 * Low noise mode. (SENSOR_CHAN_MAGN_XYZ channel only)
+	 */
 	MLX90394_SENSOR_ATTR_MAGN_LOW_NOISE = SENSOR_ATTR_PRIV_START,
+	/**
+	 * Digital filter setting for X and Y axes
+	 *
+	 * Controls the number of filter taps applied to the X and Y axes for noise reduction.
+	 * Higher values provide better noise performance at cost of measurement time.
+	 *
+	 * - sensor_value.val1: Filter setting (0-7)
+	 */
 	MLX90394_SENSOR_ATTR_MAGN_FILTER_XY,
+	/**
+	 * Digital filter configuration for Z axis
+	 *
+	 * Similar to XY filter but configured independently since Z axis typically has different
+	 * noise characteristics.
+	 *
+	 * - sensor_value.val1: Filter setting (0-7)
+	 */
 	MLX90394_SENSOR_ATTR_MAGN_FILTER_Z,
+	/**
+	 * Over-sampling ratio for magnetic measurements.
+	 *
+	 * - sensor_value.val1 == 0: Normal sampling rate.
+	 * - sensor_value.val1 == 1: Double sampling rate.
+	 */
 	MLX90394_SENSOR_ATTR_MAGN_OSR,
+	/**
+	 * Digital filter configuration for temperature measurements
+	 *
+	 * Higher settings provide better temperature measurement stability.
+	 *
+	 * - sensor_value.val1: Filter setting (0-7)
+	 */
 	MLX90394_SENSOR_ATTR_TEMP_FILTER,
+	/**
+	 * Over-sampling ratio for temperature measurements.
+	 *
+	 * - sensor_value.val1 == 0: Normal sampling rate.
+	 * - sensor_value.val1 == 1: Double sampling rate.
+	 */
 	MLX90394_SENSOR_ATTR_TEMP_OSR
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_MLX90394_H_ */

--- a/include/zephyr/drivers/sensor/paj7620.h
+++ b/include/zephyr/drivers/sensor/paj7620.h
@@ -6,14 +6,19 @@
 
 /**
  * @file
- * @brief Extended Public API for PAJ7620 sensor
- *
- * Some capabilities of the sensor cannot be expressed
- * within the sensor driver abstraction
+ * @brief Header file for extended sensor API of PAJ7620 sensor
+ * @ingroup paj7620_interface
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAJ7620_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAJ7620_H_
+
+/**
+ * @brief Pixart PAJ7620 gesture sensor
+ * @defgroup paj7620_interface PAJ7620
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C"
@@ -22,18 +27,28 @@ extern "C"
 
 #include <zephyr/drivers/sensor.h>
 
-#define PAJ7620_FLAG_GES_UP               BIT(0)
-#define PAJ7620_FLAG_GES_DOWN             BIT(1)
-#define PAJ7620_FLAG_GES_LEFT             BIT(2)
-#define PAJ7620_FLAG_GES_RIGHT            BIT(3)
-#define PAJ7620_FLAG_GES_FORWARD          BIT(4)
-#define PAJ7620_FLAG_GES_BACKWARD         BIT(5)
-#define PAJ7620_FLAG_GES_CLOCKWISE        BIT(6)
-#define PAJ7620_FLAG_GES_COUNTERCLOCKWISE BIT(7)
-#define PAJ7620_FLAG_GES_WAVE             BIT(8)
+/**
+ * @name Gesture flags
+ * @{
+ */
+#define PAJ7620_FLAG_GES_UP               BIT(0) /**< "Up" gesture */
+#define PAJ7620_FLAG_GES_DOWN             BIT(1) /**< "Down" gesture */
+#define PAJ7620_FLAG_GES_LEFT             BIT(2) /**< "Left" gesture */
+#define PAJ7620_FLAG_GES_RIGHT            BIT(3) /**< "Right" gesture */
+#define PAJ7620_FLAG_GES_FORWARD          BIT(4) /**< "Forward" gesture */
+#define PAJ7620_FLAG_GES_BACKWARD         BIT(5) /**< "Backward" gesture */
+#define PAJ7620_FLAG_GES_CLOCKWISE        BIT(6) /**< "Clockwise" gesture */
+#define PAJ7620_FLAG_GES_COUNTERCLOCKWISE BIT(7) /**< "Counterclockwise" gesture */
+#define PAJ7620_FLAG_GES_WAVE             BIT(8) /**< "Wave" gesture */
+/** @} */
 
+/**
+ * @brief Custom sensor channels for PAJ7620
+ */
 enum sensor_channel_paj7620 {
 	/**
+	 * Gesture data (bit mask).
+	 *
 	 * This channel will contain gesture data as a bitmask where each
 	 * set bit represents a detected gesture. The possible gestures
 	 * that can be detected along with their corresponding bit are given
@@ -45,5 +60,9 @@ enum sensor_channel_paj7620 {
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_PAJ7620_H_ */

--- a/include/zephyr/drivers/sensor/qdec_mcux.h
+++ b/include/zephyr/drivers/sensor/qdec_mcux.h
@@ -4,16 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of QDEC MCUX sensor
+ * @ingroup sensor_qdec_mcux
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_MCUX_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_MCUX_H_
 
+/**
+ * @brief NXP MCUX QDEC sensor
+ * @defgroup sensor_qdec_mcux QDEC MCUX
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Extended sensor attributes for QDEC MCUX
+ */
 enum sensor_attribute_qdec_mcux {
-	/* Number of counts per revolution */
+	/** Number of counts per revolution */
 	SENSOR_ATTR_QDEC_MOD_VAL = SENSOR_ATTR_PRIV_START,
-	/* Single phase counting */
+	/** Single phase counting */
 	SENSOR_ATTR_QDEC_ENABLE_SINGLE_PHASE,
 };
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_QDEC_MCUX_H_ */

--- a/include/zephyr/drivers/sensor/scd4x.h
+++ b/include/zephyr/drivers/sensor/scd4x.h
@@ -4,35 +4,68 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of SCD4X sensor
+ * @ingroup scd4x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_SCD4X_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_SCD4X_H_
 
+/**
+ * @brief Sensirion SCD4X CO<sub>2</sub> sensor
+ * @defgroup scd4x_interface SCD4X
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Custom sensor attributes for SCD4X
+ */
 enum sensor_attribute_scd4x {
-	/* Offset temperature: Toffset_actual = Tscd4x – Treference + Toffset_previous
+	/**
+	 * Temperature offset
+	 *
+	 * @f[
+	 * T_{offset\_actual} = T_{scd4x} - T_{reference} + T_{offset\_previous}
+	 * @f]
+	 *
 	 * 0 - 20°C
 	 */
 	SENSOR_ATTR_SCD4X_TEMPERATURE_OFFSET = SENSOR_ATTR_PRIV_START,
-	/* Altidude of the sensor;
+	/**
+	 * Altitude of the sensor
+	 *
 	 * 0 - 3000m
 	 */
 	SENSOR_ATTR_SCD4X_SENSOR_ALTITUDE,
-	/* Ambient pressure in hPa
+	/**
+	 * Ambient pressure in hPa
+	 *
 	 * 700 - 1200hPa
 	 */
 	SENSOR_ATTR_SCD4X_AMBIENT_PRESSURE,
-	/* Set the current state (enabled: 1 / disabled: 0).
+	/**
+	 * Automatic calibration enable (enabled: 1 / disabled: 0).
+	 *
 	 * Default: enabled.
 	 */
 	SENSOR_ATTR_SCD4X_AUTOMATIC_CALIB_ENABLE,
-	/* Set the initial period for automatic self calibration correction in hours. Allowed values
-	 * are integer multiples of 4 hours.
+	/**
+	 * Initial period for automatic self calibration correction (in hours).
+	 *
+	 * Allowed values are integer multiples of 4 hours.
 	 * Default: 44
 	 */
 	SENSOR_ATTR_SCD4X_SELF_CALIB_INITIAL_PERIOD,
-	/* Set the standard period for automatic self calibration correction in hours. Allowed
-	 * values are integer multiples of 4 hours. Default: 156
+	/**
+	 * Standard period for automatic self calibration correction (in hours).
+	 *
+	 * Allowed values are integer multiples of 4 hours.
+	 * Default: 156
 	 */
 	SENSOR_ATTR_SCD4X_SELF_CALIB_STANDARD_PERIOD,
 };
@@ -88,5 +121,9 @@ int scd4x_persist_settings(const struct device *dev);
  * @return 0 if successful, negative errno code if failure.
  */
 int scd4x_factory_reset(const struct device *dev);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_SCD4X_H_ */

--- a/include/zephyr/drivers/sensor/sgp40.h
+++ b/include/zephyr/drivers/sensor/sgp40.h
@@ -6,7 +6,8 @@
 
 /**
  * @file
- * @brief Extended public API for Sensirion's SGP40 gas sensor
+ * @brief Header file for extended sensor API of SGP40 sensor
+ * @ingroup sgp40_interface
  *
  * This exposes two attributes for the SGP40 which can be used for
  * setting the on-chip Temperature and Humidity compensation parameters.
@@ -15,19 +16,37 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_SGP40_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_SGP40_H_
 
+/**
+ * @defgroup sgp40_interface SGP40
+ * @ingroup sensor_interface_ext
+ * @brief Sensirion SGP40 gas sensor
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Custom sensor attributes for SGP40
+ */
 enum sensor_attribute_sgp40 {
-	/* Temperature in degC; only the integer part is used */
+	/**
+	 * Temperature in degC (only the integer part is used).
+	 */
 	SENSOR_ATTR_SGP40_TEMPERATURE = SENSOR_ATTR_PRIV_START,
-	/* Relative Humidity in %; only the integer part is used */
+	/**
+	 * Relative Humidity in % (only the integer part is used).
+	 */
 	SENSOR_ATTR_SGP40_HUMIDITY
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_SGP40_H_ */

--- a/include/zephyr/drivers/sensor/tcs3400.h
+++ b/include/zephyr/drivers/sensor/tcs3400.h
@@ -4,14 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of TCS3400 sensor
+ * @ingroup tcs3400_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_TCS3400_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_TCS3400_H_
 
+/**
+ * @brief AMS TCS3400 RGBC sensor
+ * @defgroup tcs3400_interface TCS3400
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Custom sensor attributes for TCS3400
+ */
 enum sensor_attribute_tcs3400 {
-	/** RGBC Integration Cycles */
+	/**
+	 * Number of RGBC Integration Cycles
+	 *
+	 * - sensor_value.val1 should be between 1 and 256.
+	 */
 	SENSOR_ATTR_TCS3400_INTEGRATION_CYCLES = SENSOR_ATTR_PRIV_START,
 };
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_TCS3400_H_ */

--- a/include/zephyr/drivers/sensor/tle9104.h
+++ b/include/zephyr/drivers/sensor/tle9104.h
@@ -3,16 +3,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of TLE9104 sensor
+ * @ingroup tle9104_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_TLE9104_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_TLE9104_H_
 
+/**
+ * @defgroup tle9104_interface TLE9104
+ * @ingroup sensor_interface_ext
+ * @brief TLE9104 4-channel powertrain switch
+ * @{
+ */
+
 #include <zephyr/drivers/sensor.h>
 
+/** Custom sensor channels for TLE9104 */
 enum sensor_channel_tle9104 {
-	/** Open load detected, boolean with one bit per output */
+	/**
+	 * Open load detected
+	 *
+	 * Boolean with one bit per output (e.g. if sensor_value.val1 == 0b0101, then open load has
+	 * been detected on OUT1 and OUT3)
+	 */
 	SENSOR_CHAN_TLE9104_OPEN_LOAD = SENSOR_ATTR_PRIV_START,
-	/** Over current detected, boolean with one bit per output */
+	/**
+	 * Over current detected
+	 *
+	 * Boolean with one bit per output (e.g. if sensor_value.val1 == 0b0110, then over current
+	 * has been detected on OUT2 and OUT3)
+	 */
 	SENSOR_CHAN_TLE9104_OVER_CURRENT,
 };
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_TLE9104_H_ */

--- a/include/zephyr/drivers/sensor/tmag5273.h
+++ b/include/zephyr/drivers/sensor/tmag5273.h
@@ -4,8 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of TMAG5273 sensor
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMAG5273_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMAG5273_H_
+
+/**
+ * @brief Texas Instruments TMAG5273 Low-Power Linear 3D Hall-Effect Sensor
+ * @defgroup tmag5273_interface TMAG5273
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,16 +61,21 @@ enum tmag5273_attribute {
 };
 
 /**
- * Supported values
+ * @name Angle calculation modes
+ * @{
  */
-
-#define TMAG5273_ANGLE_CALC_NONE 0
-#define TMAG5273_ANGLE_CALC_XY   1
-#define TMAG5273_ANGLE_CALC_YZ   2
-#define TMAG5273_ANGLE_CALC_XZ   3
+#define TMAG5273_ANGLE_CALC_NONE 0 /**< No angle calculation */
+#define TMAG5273_ANGLE_CALC_XY   1 /**< X first, Y second */
+#define TMAG5273_ANGLE_CALC_YZ   2 /**< Y first, Z second */
+#define TMAG5273_ANGLE_CALC_XZ   3 /**< X first, Z second */
+/** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMAG5273_H_ */

--- a/include/zephyr/drivers/sensor/tmp11x.h
+++ b/include/zephyr/drivers/sensor/tmp11x.h
@@ -4,13 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of TMP11X sensors
+ * @ingroup tmp11x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP11X_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP11X_H_
+
+/**
+ * @brief TMP11X temperature sensors
+ * @defgroup tmp11x_interface TMP11X
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 #include <sys/types.h>
 
+/**
+ * @brief Custom sensor attributes for TMP11X
+ */
 enum sensor_attribute_tmp_11x {
 	/** Turn on power saving/one shot mode */
 	SENSOR_ATTR_TMP11X_ONE_SHOT_MODE = SENSOR_ATTR_PRIV_START,
@@ -26,20 +42,45 @@ enum sensor_attribute_tmp_11x {
 	SENSOR_ATTR_TMP11X_ALERT_PIN_SELECT,
 };
 
-/* Alert pin support macros */
-#define TMP11X_ALERT_PIN_ACTIVE_LOW  0
-#define TMP11X_ALERT_PIN_ACTIVE_HIGH 1
-#define TMP11X_ALERT_ALERT_MODE      0
-#define TMP11X_ALERT_THERM_MODE      1
-#define TMP11X_ALERT_PIN_ALERT_SEL   0
-#define TMP11X_ALERT_PIN_DR_SEL      1
+/**
+ * @name Alert pin support macros
+ * @{
+ */
+#define TMP11X_ALERT_PIN_ACTIVE_LOW  0 /**< Alert pin is active low */
+#define TMP11X_ALERT_PIN_ACTIVE_HIGH 1 /**< Alert pin is active high */
+#define TMP11X_ALERT_ALERT_MODE      0 /**< Alert mode */
+#define TMP11X_ALERT_THERM_MODE      1 /**< Therm mode */
+#define TMP11X_ALERT_PIN_ALERT_SEL   0 /**< Alert pin reflects the status of the alert flags */
+#define TMP11X_ALERT_PIN_DR_SEL      1 /**< Alert pin reflects the status of the data ready flag */
+/** @} */
 
+/**
+ * @brief EEPROM size for TMP11X
+ */
 #define EEPROM_TMP11X_SIZE (4 * sizeof(uint16_t))
 
-int tmp11x_eeprom_read(const struct device *dev, off_t offset, void *data,
-		       size_t len);
+/**
+ * @brief Read from EEPROM
+ * @param dev Pointer to a tmp11x device
+ * @param offset Offset in the EEPROM
+ * @param data Pointer to a buffer to store the read data
+ * @param len Length of the data to read
+ * @return 0 on success, negative error code on failure
+ */
+int tmp11x_eeprom_read(const struct device *dev, off_t offset, void *data, size_t len);
 
-int tmp11x_eeprom_write(const struct device *dev, off_t offset,
-			const void *data, size_t len);
+/**
+ * @brief Write to EEPROM
+ * @param dev Pointer to a tmp11x device
+ * @param offset Offset in the EEPROM
+ * @param data Pointer to the data to write
+ * @param len Length of the data to write
+ * @return 0 on success, negative error code on failure
+ */
+int tmp11x_eeprom_write(const struct device *dev, off_t offset, const void *data, size_t len);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP11X_H_ */

--- a/include/zephyr/drivers/sensor/veaa_x_3.h
+++ b/include/zephyr/drivers/sensor/veaa_x_3.h
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for extended sensor API of VEAA X-3 sensor
+ * @ingroup veaa_x_3_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_VEAA_X_3_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_VEAA_X_3_H_
+
+/**
+ * @brief Festo VEAA X-3 pressure regulator
+ * @defgroup veaa_x_3_interface VEAA X-3
+ * @ingroup sensor_interface_ext
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,15 +26,27 @@ extern "C" {
 
 #include <zephyr/drivers/sensor.h>
 
+/**
+ * @brief Custom sensor attributes for VEAA X-3
+ */
 enum sensor_attribute_veaa_x_3 {
-	/* Set pressure setpoint value in kPa. */
+	/** Set pressure setpoint value in kPa. */
 	SENSOR_ATTR_VEAA_X_3_SETPOINT = SENSOR_ATTR_PRIV_START,
-	/* Supported pressure range in kPa. val1 is minimum and val2 is maximum */
+	/**
+	 * Supported pressure range in kPa.
+	 *
+	 * sensor_value.val1 and sensor_value.val2 are the minimum and maximum supported pressure,
+	 * respectively.
+	 */
 	SENSOR_ATTR_VEAA_X_3_RANGE,
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_VEAA_X_3_H_ */

--- a/include/zephyr/drivers/sensor/xbr818.h
+++ b/include/zephyr/drivers/sensor/xbr818.h
@@ -6,7 +6,7 @@
 
 /**
  * @file
- * @brief Extended public API for Phosense XBR818 10 GHz Radar
+ * @brief Header file for extended sensor API of XBR818 sensor
  *
  * This exposes 4 additional attributes used to configure the IC
  */
@@ -14,10 +14,20 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_XBR818_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_XBR818_H_
 
+/**
+ * @brief Phosense XBR818 10 GHz Radar
+ * @defgroup xbr818_interface XBR818
+ * @ingroup sensor_interface_ext
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Custom sensor attributes for XBR818
+ */
 enum sensor_attribute_xbr818 {
 	/*!
 	 * Time of received activity before output is triggered, in seconds
@@ -40,5 +50,9 @@ enum sensor_attribute_xbr818 {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_XBR818_H_ */

--- a/include/zephyr/dt-bindings/sensor/bmp581.h
+++ b/include/zephyr/dt-bindings/sensor/bmp581.h
@@ -5,88 +5,110 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for BMP581 sensor Devicetree constants
+ * @ingroup bmp581_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_BOSCH_BMP581_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_BOSCH_BMP581_H_
 
 /**
- * @defgroup bmp581 Bosch BMP581 DT Options
- * @ingroup sensor_interface
+ * @addtogroup bmp581_interface
  * @{
  */
 
 /**
- * @defgroup BMP581_POWER_MODES Sensor power modes
+ * @defgroup bmp581_power_modes Sensor power modes
  * @{
  */
-#define BMP581_DT_MODE_NORMAL		1
-#define BMP581_DT_MODE_FORCED		2
-#define BMP581_DT_MODE_CONTINUOUS	3
+#define BMP581_DT_MODE_NORMAL		1 /**< NORMAL mode */
+#define BMP581_DT_MODE_FORCED		2 /**< FORCED mode */
+#define BMP581_DT_MODE_CONTINUOUS	3 /**< CONTINUOUS mode */
 /** @} */
 
 /**
- * @defgroup BMP581_OUTPUT_DATA_RATE Output data rate options
+ * @defgroup bmp581_output_data_rate Output data rate options
  * @{
  */
-#define BMP581_DT_ODR_240_HZ		0x00
-#define BMP581_DT_ODR_218_5_HZ		0x01
-#define BMP581_DT_ODR_199_1_HZ		0x02
-#define BMP581_DT_ODR_179_2_HZ		0x03
-#define BMP581_DT_ODR_160_HZ		0x04
-#define BMP581_DT_ODR_149_3_HZ		0x05
-#define BMP581_DT_ODR_140_HZ		0x06
-#define BMP581_DT_ODR_129_8_HZ		0x07
-#define BMP581_DT_ODR_120_HZ		0x08
-#define BMP581_DT_ODR_110_1_HZ		0x09
-#define BMP581_DT_ODR_100_2_HZ		0x0A
-#define BMP581_DT_ODR_89_6_HZ		0x0B
-#define BMP581_DT_ODR_80_HZ		0x0C
-#define BMP581_DT_ODR_70_HZ		0x0D
-#define BMP581_DT_ODR_60_HZ		0x0E
-#define BMP581_DT_ODR_50_HZ		0x0F
-#define BMP581_DT_ODR_45_HZ		0x10
-#define BMP581_DT_ODR_40_HZ		0x11
-#define BMP581_DT_ODR_35_HZ		0x12
-#define BMP581_DT_ODR_30_HZ		0x13
-#define BMP581_DT_ODR_25_HZ		0x14
-#define BMP581_DT_ODR_20_HZ		0x15
-#define BMP581_DT_ODR_15_HZ		0x16
-#define BMP581_DT_ODR_10_HZ		0x17
-#define BMP581_DT_ODR_5_HZ		0x18
-#define BMP581_DT_ODR_4_HZ		0x19
-#define BMP581_DT_ODR_3_HZ		0x1A
-#define BMP581_DT_ODR_2_HZ		0x1B
-#define BMP581_DT_ODR_1_HZ		0x1C
-#define BMP581_DT_ODR_0_5_HZ		0x1D
-#define BMP581_DT_ODR_0_250_HZ		0x1E
-#define BMP581_DT_ODR_0_125_HZ		0x1F
+#define BMP581_DT_ODR_240_HZ		0x00 /**< 240 Hz */
+#define BMP581_DT_ODR_218_5_HZ		0x01 /**< 218.5 Hz */
+#define BMP581_DT_ODR_199_1_HZ		0x02 /**< 199.1 Hz */
+#define BMP581_DT_ODR_179_2_HZ		0x03 /**< 179.2 Hz */
+#define BMP581_DT_ODR_160_HZ		0x04 /**< 160 Hz */
+#define BMP581_DT_ODR_149_3_HZ		0x05 /**< 149.3 Hz */
+#define BMP581_DT_ODR_140_HZ		0x06 /**< 140 Hz */
+#define BMP581_DT_ODR_129_8_HZ		0x07 /**< 129.8 Hz */
+#define BMP581_DT_ODR_120_HZ		0x08 /**< 120 Hz */
+#define BMP581_DT_ODR_110_1_HZ		0x09 /**< 110.1 Hz */
+#define BMP581_DT_ODR_100_2_HZ		0x0A /**< 100.2 Hz */
+#define BMP581_DT_ODR_89_6_HZ		0x0B /**< 89.6 Hz */
+#define BMP581_DT_ODR_80_HZ		0x0C /**< 80 Hz */
+#define BMP581_DT_ODR_70_HZ		0x0D /**< 70 Hz */
+#define BMP581_DT_ODR_60_HZ		0x0E /**< 60 Hz */
+#define BMP581_DT_ODR_50_HZ		0x0F /**< 50 Hz */
+#define BMP581_DT_ODR_45_HZ		0x10 /**< 45 Hz */
+#define BMP581_DT_ODR_40_HZ		0x11 /**< 40 Hz */
+#define BMP581_DT_ODR_35_HZ		0x12 /**< 35 Hz */
+#define BMP581_DT_ODR_30_HZ		0x13 /**< 30 Hz */
+#define BMP581_DT_ODR_25_HZ		0x14 /**< 25 Hz */
+#define BMP581_DT_ODR_20_HZ		0x15 /**< 20 Hz */
+#define BMP581_DT_ODR_15_HZ		0x16 /**< 15 Hz */
+#define BMP581_DT_ODR_10_HZ		0x17 /**< 10 Hz */
+#define BMP581_DT_ODR_5_HZ		0x18 /**< 5 Hz */
+#define BMP581_DT_ODR_4_HZ		0x19 /**< 4 Hz */
+#define BMP581_DT_ODR_3_HZ		0x1A /**< 3 Hz */
+#define BMP581_DT_ODR_2_HZ		0x1B /**< 2 Hz */
+#define BMP581_DT_ODR_1_HZ		0x1C /**< 1 Hz */
+#define BMP581_DT_ODR_0_5_HZ		0x1D /**< 0.5 Hz */
+#define BMP581_DT_ODR_0_250_HZ		0x1E /**< 0.250 Hz */
+#define BMP581_DT_ODR_0_125_HZ		0x1F /**< 0.125 Hz */
 /** @} */
 
 /**
- * @defgroup BMP581_OVERSAMPLING Oversampling options. Valid for temperature and pressure.
+ * @defgroup bmp581_oversampling Oversampling options.
+ *
+ * Valid values for temperature and pressure sensor oversampling ratio.
  * @{
  */
-#define BMP581_DT_OVERSAMPLING_1X	0x00
-#define BMP581_DT_OVERSAMPLING_2X	0x01
-#define BMP581_DT_OVERSAMPLING_4X	0x02
-#define BMP581_DT_OVERSAMPLING_8X	0x03
-#define BMP581_DT_OVERSAMPLING_16X	0x04
-#define BMP581_DT_OVERSAMPLING_32X	0x05
-#define BMP581_DT_OVERSAMPLING_64X	0x06
-#define BMP581_DT_OVERSAMPLING_128X	0x07
+#define BMP581_DT_OVERSAMPLING_1X	0x00 /**< x1 */
+#define BMP581_DT_OVERSAMPLING_2X	0x01 /**< x2 */
+#define BMP581_DT_OVERSAMPLING_4X	0x02 /**< x4 */
+#define BMP581_DT_OVERSAMPLING_8X	0x03 /**< x8 */
+#define BMP581_DT_OVERSAMPLING_16X	0x04 /**< x16 */
+#define BMP581_DT_OVERSAMPLING_32X	0x05 /**< x32 */
+#define BMP581_DT_OVERSAMPLING_64X	0x06 /**< x64 */
+#define BMP581_DT_OVERSAMPLING_128X	0x07 /**< x128 */
 /** @} */
 
 /**
- * @defgroup BMP581_IIR_FILTER IIR Filter options. Valid for temperature and pressure.
+ * @defgroup bmp581_iir_filter IIR Filter options.
+ *
+ * Valid values for temperature and pressure IIR filter coefficient.
+ *
+ * @f[
+ *   data_n = \frac{data_{n-1} \times filtercoefficient + data_{in}}{filtercoefficient + 1}
+ * @f]
+ *
+ * where:
+ * - @f$ data_n @f$ is the current filtered output
+ * - @f$ data_{n-1} @f$ is the previous filtered output
+ * - @f$ data_{in} @f$ is the current input sample
+ * - @f$ filtercoefficient @f$ is one of the coefficient values below
+ *
+ * Higher coefficient values provide more filtering (smoother output) but increase response time.
+ *
  * @{
  */
-#define BMP581_DT_IIR_FILTER_BYPASS	0x00
-#define BMP581_DT_IIR_FILTER_COEFF_1	0x01
-#define BMP581_DT_IIR_FILTER_COEFF_3	0x02
-#define BMP581_DT_IIR_FILTER_COEFF_7	0x03
-#define BMP581_DT_IIR_FILTER_COEFF_15	0x04
-#define BMP581_DT_IIR_FILTER_COEFF_31	0x05
-#define BMP581_DT_IIR_FILTER_COEFF_63	0x06
-#define BMP581_DT_IIR_FILTER_COEFF_127	0x07
+#define BMP581_DT_IIR_FILTER_BYPASS	0x00 /**< Bypass */
+#define BMP581_DT_IIR_FILTER_COEFF_1	0x01 /**< 1 */
+#define BMP581_DT_IIR_FILTER_COEFF_3	0x02 /**< 3 */
+#define BMP581_DT_IIR_FILTER_COEFF_7	0x03 /**< 7 */
+#define BMP581_DT_IIR_FILTER_COEFF_15	0x04 /**< 15 */
+#define BMP581_DT_IIR_FILTER_COEFF_31	0x05 /**< 31 */
+#define BMP581_DT_IIR_FILTER_COEFF_63	0x06 /**< 63 */
+#define BMP581_DT_IIR_FILTER_COEFF_127	0x07 /**< 127 */
 /** @} */
 
 /** @} */


### PR DESCRIPTION
Add a dedicated Doxygen group for putting all hw-specific API extensions under + batch of documentation updates to make a couple dozen of headers 100% covered in terms of Doxygen documentation, and of course add them to the newly created group.

- https://builds.zephyrproject.io/zephyr/pr/94645/docs/doxygen/html/group__sensor__interface__ext.html

Still a long way to go but coverage is much better now, see https://builds.zephyrproject.io/zephyr/pr/94645/api-coverage/zephyr/drivers/sensor/index.html vs https://docs.zephyrproject.org/api-coverage/latest/zephyr/drivers/sensor/index.html

