### PR TITLE
include: drivers: input: tidy up doxygen documentation for Input subsystem

### DIFF
--- a/doc/services/input/gpio-kbd.rst
+++ b/doc/services/input/gpio-kbd.rst
@@ -231,6 +231,8 @@ output:
       };
   };
 
+.. doxygengroup:: input_keymap
+
 Keyboard matrix shell commands
 ******************************
 

--- a/include/zephyr/input/cy8cmbr3xxx.h
+++ b/include/zephyr/input/cy8cmbr3xxx.h
@@ -3,18 +3,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for CY8CMBR3xxx input driver.
+ * @ingroup cy8cmbr3xxx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_CY8CMBR3XXX_H_
 #define ZEPHYR_INCLUDE_INPUT_CY8CMBR3XXX_H_
 
+/**
+ * @defgroup cy8cmbr3xxx_interface CY8CMBR3xxx
+ * @ingroup input_interface_ext
+ * @brief CY8CMBR3xxx capacitive touch sensor
+ * @{
+ */
+
 #include <zephyr/types.h>
 
+/**
+ * @brief Size of the EZ-Click configuration data
+ */
 #define CY8CMBR3XXX_EZ_CLICK_CONFIG_SIZE 128
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
 
+/**
+ * @brief Configuration data for the CY8CMBR3xxx device
+ */
 struct cy8cmbr3xxx_config_data {
+	/** EZ-Click configuration data */
 	uint8_t data[CY8CMBR3XXX_EZ_CLICK_CONFIG_SIZE];
 };
 
@@ -33,5 +53,7 @@ int cy8cmbr3xxx_configure(const struct device *dev,
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_INPUT_CY8CMBR3XXX_H_ */

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Main header file for Input driver API
+ * @ingroup input_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_H_
 #define ZEPHYR_INCLUDE_INPUT_H_
 

--- a/include/zephyr/input/input.h
+++ b/include/zephyr/input/input.h
@@ -20,6 +20,11 @@
  * @version 0.1.0
  * @ingroup io_interfaces
  * @{
+ *
+ * @defgroup input_interface_ext Device-specific Input API extensions
+ * @brief Interfaces for input devices with extended functionality beyond the standard Input API.
+ * @{
+ * @}
  */
 
 #include <stdint.h>

--- a/include/zephyr/input/input_analog_axis.h
+++ b/include/zephyr/input/input_analog_axis.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup input_analog_axis
+ * @brief Main header file for interacting with analog axis input devices.
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_H_
 #define ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_H_
 
@@ -11,9 +17,8 @@
 #include <zephyr/device.h>
 
 /**
- * @brief Analog axis API
- * @defgroup input_analog_axis Analog axis API
- * @ingroup io_interfaces
+ * @defgroup input_analog_axis Analog axis
+ * @ingroup input_interface
  * @{
  */
 
@@ -21,7 +26,7 @@
  * @brief Analog axis calibration data structure.
  *
  * Holds the calibration data for a single analog axis. Initial values are set
- * from the devicetree and can be changed by the applicatoin in runtime using
+ * from the devicetree and can be changed by the application in runtime using
  * @ref analog_axis_calibration_set and @ref analog_axis_calibration_get.
  */
 struct analog_axis_calibration {
@@ -51,13 +56,14 @@ typedef void (*analog_axis_raw_data_t)(const struct device *dev,
  * calibration. Set cb to NULL to disable the callback.
  *
  * @param dev Analog axis device.
- * @param cb An analog_axis_raw_data_t callback to use, NULL disable.
+ * @param cb An analog_axis_raw_data_t callback to use, NULL to disable.
  */
 void analog_axis_set_raw_data_cb(const struct device *dev, analog_axis_raw_data_t cb);
 
 /**
  * @brief Get the number of defined axes.
  *
+ * @param dev Analog axis device.
  * @retval n The number of defined axes for dev.
  */
 int analog_axis_num_axes(const struct device *dev);

--- a/include/zephyr/input/input_analog_axis_settings.h
+++ b/include/zephyr/input/input_analog_axis_settings.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Public header file for API allowing to save analog axis calibration data.
+ * @ingroup input_analog_axis
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_SETTINGS_H_
 #define ZEPHYR_INCLUDE_INPUT_ANALOG_AXIS_SETTINGS_H_
 
@@ -18,7 +24,7 @@
 /**
  * @brief Save the calibration data.
  *
- * Save the calibration data permanently on the specifided device, requires
+ * Save the calibration data permanently on the specified device, requires
  * the @ref settings subsystem to be configured and initialized.
  *
  * @param dev Analog axis device.

--- a/include/zephyr/input/input_hid.h
+++ b/include/zephyr/input/input_hid.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for input code to HID code/modifier conversion utilities.
+ * @ingroup input_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_HID_H_
 #define ZEPHYR_INCLUDE_INPUT_HID_H_
 

--- a/include/zephyr/input/input_kbd_matrix.h
+++ b/include/zephyr/input/input_kbd_matrix.h
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup input_kbd_matrix
+ * @brief Main header file for keyboard matrix input devices.
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_KBD_MATRIX_H_
 #define ZEPHYR_INCLUDE_INPUT_KBD_MATRIX_H_
 
 /**
- * @brief Keyboard Matrix API
- * @defgroup input_kbd_matrix Keyboard Matrix API
- * @ingroup io_interfaces
+ * @defgroup input_kbd_matrix Keyboard Matrix
+ * @ingroup input_interface
  * @{
  */
 

--- a/include/zephyr/input/input_keymap.h
+++ b/include/zephyr/input/input_keymap.h
@@ -4,10 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup input_keymap
+ * @brief Header file for keymap utilities.
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_INPUT_KEYMAP_H_
 #define ZEPHYR_INCLUDE_INPUT_INPUT_KEYMAP_H_
 
+/**
+ * @defgroup input_keymap Keymap utilities
+ * @ingroup input_interface
+ * @{
+ */
+
+/**
+ * @brief Extract the row index from a keymap entry.
+ *
+ * This macro extracts the row index from a 32-bit keymap entry. The row index
+ * is stored in bits 24-31 of the keymap entry.
+ *
+ * @param keymap_entry The 32-bit keymap entry value.
+ * @return The row index (0-255) extracted from the keymap entry.
+ */
 #define MATRIX_ROW(keymap_entry) (((keymap_entry) >> 24) & 0xff)
+
+/**
+ * @brief Extract the column index from a keymap entry.
+ *
+ * This macro extracts the column index from a 32-bit keymap entry. The column
+ * index is stored in bits 16-23 of the keymap entry.
+ *
+ * @param keymap_entry The 32-bit keymap entry value.
+ * @return The column index (0-255) extracted from the keymap entry.
+ */
 #define MATRIX_COL(keymap_entry) (((keymap_entry) >> 16) & 0xff)
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_INPUT_INPUT_KEYMAP_H_ */

--- a/include/zephyr/input/input_pat912x.h
+++ b/include/zephyr/input/input_pat912x.h
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for PAT912x input driver.
+ * @ingroup pat912x_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_PAT912X_H_
 #define ZEPHYR_INCLUDE_INPUT_PAT912X_H_
+
+/**
+ * @defgroup pat912x_interface PAT912x
+ * @ingroup input_interface_ext
+ * @brief PAT912x Miniature Optical Navigation Chip
+ * @{
+ */
 
 /**
  * @brief Set resolution on a pat912x device
@@ -18,5 +31,7 @@
  */
 int pat912x_set_resolution(const struct device *dev,
 			   int16_t res_x_cpi, int16_t res_y_cpi);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_INPUT_PAT912X_H_ */

--- a/include/zephyr/input/input_paw32xx.h
+++ b/include/zephyr/input/input_paw32xx.h
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for PAW32xx input driver.
+ * @ingroup paw32xx_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_PAW32XX_H_
 #define ZEPHYR_INCLUDE_INPUT_PAW32XX_H_
+
+/**
+ * @defgroup paw32xx_interface PAW32xx
+ * @ingroup input_interface_ext
+ * @brief PAW32xx ultra low power wireless mouse chip
+ * @{
+ */
 
 /**
  * @brief Set resolution on a paw32xx device
@@ -22,5 +35,7 @@ int paw32xx_set_resolution(const struct device *dev, uint16_t res_cpi);
  * @param enable whether to enable or disable force awake mode.
  */
 int paw32xx_force_awake(const struct device *dev, bool enable);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_INPUT_PAW32XX_H_ */

--- a/include/zephyr/input/input_pmw3610.h
+++ b/include/zephyr/input/input_pmw3610.h
@@ -4,14 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for PMW3610 input driver.
+ * @ingroup pmw3610_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_PMW3610_H_
 #define ZEPHYR_INCLUDE_INPUT_PMW3610_H_
+
+/**
+ * @defgroup pmw3610_interface PMW3610
+ * @ingroup input_interface_ext
+ * @brief PMW3610 Low Power Laser Mouse Sensor
+ * @{
+ */
 
 /**
  * @brief Set resolution on a pmw3610 device
  *
  * @param dev pmw3610 device.
  * @param res_cpi CPI resolution, 200 to 3200.
+ * @retval 0 success
+ * @retval -EINVAL invalid resolution
+ * @retval -errno another error occurred
  */
 int pmw3610_set_resolution(const struct device *dev, uint16_t res_cpi);
 
@@ -20,7 +36,12 @@ int pmw3610_set_resolution(const struct device *dev, uint16_t res_cpi);
  *
  * @param dev pmw3610 device.
  * @param enable whether to enable or disable force awake mode.
+ *
+ * @retval 0 success
+ * @retval -errno an error occurred
  */
 int pmw3610_force_awake(const struct device *dev, bool enable);
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_INPUT_PMW3610_H_ */

--- a/include/zephyr/input/input_renesas_ra_ctsu.h
+++ b/include/zephyr/input/input_renesas_ra_ctsu.h
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Renesas RA CTSU input driver.
+ * @ingroup renesas_ra_ctsu_interface
+ */
+
 #ifndef ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RA_CTSU_H_
 #define ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RA_CTSU_H_
+
+/**
+ * @defgroup renesas_ra_ctsu_interface Renesas RA CTSU
+ * @ingroup input_interface_ext
+ * @brief Renesas RA Capacitive Touch Sensor Unit
+ * @{
+ */
 
 #include <rm_touch.h>
 
@@ -13,7 +26,11 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Configuration data for the Renesas RA CTSU device
+ */
 struct renesas_ra_ctsu_touch_cfg {
+	/** FSP Touch instance */
 	struct st_touch_instance touch_instance;
 };
 
@@ -36,5 +53,7 @@ __syscall int renesas_ra_ctsu_group_configure(const struct device *dev,
 #endif
 
 #include <zephyr/syscalls/input_renesas_ra_ctsu.h>
+
+/** @} */
 
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_INPUT_INPUT_RENESAS_RA_CTSU_H_ */

--- a/include/zephyr/input/input_touch.h
+++ b/include/zephyr/input/input_touch.h
@@ -3,15 +3,21 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Header file for touch events API.
+ * @ingroup touch_events
+ */
+
 #ifndef ZEPHYR_INCLUDE_INPUT_TOUCH_H_
 #define ZEPHYR_INCLUDE_INPUT_TOUCH_H_
 
 /**
- * @brief Touch Events API
- * @defgroup touch_events Touchscreen Event Report API
+ * @defgroup touch_events Touchscreen Events
  * @since 3.7
  * @version 0.1.0
- * @ingroup io_interfaces
+ * @ingroup input_interface
  * @{
  */
 

--- a/include/zephyr/input/input_touch.h
+++ b/include/zephyr/input/input_touch.h
@@ -26,19 +26,18 @@ extern "C" {
  *
  * This structure **must** be placed first in the driver's config structure.
  *
- * @param screen_width Horizontal resolution of touchscreen
- * @param screen_height Vertical resolution of touchscreen
- * @param inverted_x  X axis is inverted
- * @param inverted_y Y axis is inverted
- * @param swapped_x_y X and Y axes are swapped
- *
  * see touchscreem-common.yaml for more details
  */
 struct input_touchscreen_common_config {
+	/** Horizontal resolution of touchscreen */
 	uint32_t screen_width;
+	/** Vertical resolution of touchscreen */
 	uint32_t screen_height;
+	/** X axis is inverted */
 	bool inverted_x;
+	/** Y axis is inverted */
 	bool inverted_y;
+	/** X and Y axes are swapped */
 	bool swapped_x_y;
 };
 


### PR DESCRIPTION
- Consolidate Doxygen groups for input drivers in terms of naming and hierarchy (some where showing up as top-level device groups)
- Add missing @file commands where needed
- Ensure device-specific API extensions are showing up in docs
- Probably a few more random typo and spelling fixes too :)

https://builds.zephyrproject.io/zephyr/pr/94647/docs/doxygen/html/group__input__interface.html
https://builds.zephyrproject.io/zephyr/pr/94647/api-coverage/zephyr/input/index.html
<img width="899" height="471" alt="image" src="https://github.com/user-attachments/assets/35610a54-a9b9-4063-9d81-dc91453a0bf5" />

This is really only documentation so I am tempted to mark as trivial but I will let the @fabiobaltieri make the call :)