### PR TITLE
lib: posix: add `fstat()`

### DIFF
--- a/lib/posix/options/fs.c
+++ b/lib/posix/options/fs.c
@@ -154,6 +154,35 @@ static int fs_ioctl_vmeth(void *obj, unsigned int request, va_list args)
 	struct posix_fs_desc *ptr = obj;
 
 	switch (request) {
+	case ZFD_IOCTL_STAT: {
+		struct stat *buf = va_arg(args, struct stat *);
+		long offset = fs_tell(&ptr->file);
+		long current;
+
+		if (offset < 0) {
+			return offset;
+		}
+
+		memset(buf, 0, sizeof(struct stat));
+
+		rc = fs_seek(&ptr->file, 0, FS_SEEK_END);
+		if (rc < 0) {
+			return rc;
+		}
+
+		current = fs_tell(&ptr->file);
+		if (current >= 0) {
+			buf->st_size = current;
+			buf->st_mode = ptr->is_dir ? S_IFDIR : S_IFREG;
+		}
+
+		rc = fs_seek(&ptr->file, offset, FS_SEEK_SET);
+
+		if (current < 0) {
+			rc = current;
+		}
+		break;
+	}
 	case ZFD_IOCTL_FSYNC: {
 		rc = fs_sync(&ptr->file);
 		break;

--- a/tests/posix/fs/src/test_fs_stat.c
+++ b/tests/posix/fs/src/test_fs_stat.c
@@ -105,3 +105,60 @@ ZTEST(posix_fs_stat_test, test_fs_stat_dir)
 	/* note: for posix compatibility should should actually work */
 	zassert_not_equal(0, stat(TEST_ROOT, &buf));
 }
+
+/**
+ * @brief Test fstat command on file
+ *
+ * @details Tests file in root, file in directroy, and empty file
+ */
+ZTEST(posix_fs_stat_test, test_fs_fstat_file)
+{
+	struct stat buf;
+
+	int test_file_fd = open(TEST_FILE, O_RDONLY);
+	int dir_file_fd = open(TEST_DIR_FILE, O_RDONLY);
+	int empty_file_fd = open(TEST_EMPTY_FILE, O_RDONLY);
+
+	zassert_not_equal(-1, test_file_fd);
+	zassert_equal(0, fstat(test_file_fd, &buf));
+	zassert_equal(TEST_FILE_SIZE, buf.st_size);
+	zassert_equal(S_IFREG, buf.st_mode);
+	close(test_file_fd);
+
+	zassert_not_equal(-1, dir_file_fd);
+	zassert_equal(0, fstat(dir_file_fd, &buf));
+	zassert_equal(TEST_DIR_FILE_SIZE, buf.st_size);
+	zassert_equal(S_IFREG, buf.st_mode);
+	close(dir_file_fd);
+
+	zassert_not_equal(-1, empty_file_fd);
+	zassert_equal(0, fstat(empty_file_fd, &buf));
+	zassert_equal(0, buf.st_size);
+	zassert_equal(S_IFREG, buf.st_mode);
+	close(empty_file_fd);
+}
+
+/**
+ * @brief Test fstat command on dir
+ *
+ * @details Tests if we can retrieve stastics for a directory.
+ */
+ZTEST(posix_fs_stat_test, test_fs_fstat_dir)
+{
+	struct stat buf;
+
+	int fd = open(TEST_DIR, O_RDONLY);
+
+	/*
+	 * if this failed it means open doesn't support directories
+	 * so skip the rest of the test
+	 */
+	if (fd == -1) {
+		ztest_test_skip();
+	}
+
+	zassert_equal(0, fstat(fd, &buf));
+	zassert_equal(0, buf.st_size);
+	zassert_equal(S_IFDIR, buf.st_mode);
+	close(fd);
+}


### PR DESCRIPTION
This PR implements the `fstat()` function using `fs_seek()` and `fs_tell()`.

This implementation of the `fstat()` function supports the following members of the `stat` structure:
* `st_mode`
* `st_size`
