### PR TITLE
Bluetooth: Host: Refactor function prefixes and use of static for clearer, more consistent code

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -891,7 +891,7 @@ static void le_adv_stop_free_conn(const struct bt_le_ext_adv *adv, uint8_t statu
 	}
 }
 
-int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
+static int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
 			   const struct bt_le_adv_param *param,
 			   const struct bt_data *ad, size_t ad_len,
 			   const struct bt_data *sd, size_t sd_len)

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -891,7 +891,7 @@ static void le_adv_stop_free_conn(const struct bt_le_ext_adv *adv, uint8_t statu
 	}
 }
 
-static int bt_le_adv_start_legacy(struct bt_le_ext_adv *adv,
+static int adv_start_legacy(struct bt_le_ext_adv *adv,
 			   const struct bt_le_adv_param *param,
 			   const struct bt_data *ad, size_t ad_len,
 			   const struct bt_data *sd, size_t sd_len)
@@ -1312,7 +1312,7 @@ int bt_le_adv_start(const struct bt_le_adv_param *param,
 	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
 		err = bt_le_adv_start_ext(adv, param, ad, ad_len, sd, sd_len);
 	} else {
-		err = bt_le_adv_start_legacy(adv, param, ad, ad_len, sd, sd_len);
+		err = adv_start_legacy(adv, param, ad, ad_len, sd, sd_len);
 	}
 
 	if (err) {

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -80,7 +80,7 @@ NET_BUF_POOL_DEFINE(prep_pool, CONFIG_BT_ATT_PREPARE_COUNT, BT_ATT_BUF_SIZE,
 		    sizeof(struct bt_attr_data), NULL);
 #endif /* CONFIG_BT_ATT_PREPARE_COUNT */
 
-K_MEM_SLAB_DEFINE(req_slab, sizeof(struct bt_att_req),
+K_MEM_SLAB_DEFINE_STATIC(req_slab, sizeof(struct bt_att_req),
 		  CONFIG_BT_ATT_TX_COUNT, __alignof__(struct bt_att_req));
 
 enum {
@@ -171,9 +171,9 @@ struct bt_att {
 #endif /* CONFIG_BT_EATT */
 };
 
-K_MEM_SLAB_DEFINE(att_slab, sizeof(struct bt_att),
+K_MEM_SLAB_DEFINE_STATIC(att_slab, sizeof(struct bt_att),
 		  CONFIG_BT_MAX_CONN, __alignof__(struct bt_att));
-K_MEM_SLAB_DEFINE(chan_slab, sizeof(struct bt_att_chan),
+K_MEM_SLAB_DEFINE_STATIC(chan_slab, sizeof(struct bt_att_chan),
 		  CONFIG_BT_MAX_CONN * ATT_CHAN_MAX,
 		  __alignof__(struct bt_att_chan));
 static struct bt_att_req cancel;
@@ -194,7 +194,7 @@ static k_tid_t att_handle_rsp_thread;
 
 static struct bt_att_tx_meta_data tx_meta_data_storage[CONFIG_BT_ATT_TX_COUNT];
 
-struct bt_att_tx_meta_data *bt_att_get_tx_meta_data(const struct net_buf *buf);
+static struct bt_att_tx_meta_data *bt_att_get_tx_meta_data(const struct net_buf *buf);
 static void att_on_sent_cb(struct bt_att_tx_meta_data *meta);
 
 #if defined(CONFIG_BT_ATT_ERR_TO_STR)
@@ -289,7 +289,7 @@ NET_BUF_POOL_DEFINE(att_pool, CONFIG_BT_ATT_TX_COUNT,
 		    BT_L2CAP_SDU_BUF_SIZE(BT_ATT_BUF_SIZE),
 		    CONFIG_BT_CONN_TX_USER_DATA_SIZE, att_tx_destroy);
 
-struct bt_att_tx_meta_data *bt_att_get_tx_meta_data(const struct net_buf *buf)
+static struct bt_att_tx_meta_data *bt_att_get_tx_meta_data(const struct net_buf *buf)
 {
 	__ASSERT_NO_MSG(net_buf_pool_get(buf->pool_id) == &att_pool);
 
@@ -304,7 +304,7 @@ static int bt_att_chan_send(struct bt_att_chan *chan, struct net_buf *buf);
 static void att_chan_mtu_updated(struct bt_att_chan *updated_chan);
 static void bt_att_disconnected(struct bt_l2cap_chan *chan);
 
-struct net_buf *bt_att_create_rsp_pdu(struct bt_att_chan *chan, uint8_t op);
+static struct net_buf *bt_att_create_rsp_pdu(struct bt_att_chan *chan, uint8_t op);
 
 static void att_disconnect(struct bt_att_chan *chan)
 {
@@ -3064,7 +3064,7 @@ struct net_buf *bt_att_create_pdu(struct bt_conn *conn, uint8_t op, size_t len)
 	return NULL;
 }
 
-struct net_buf *bt_att_create_rsp_pdu(struct bt_att_chan *chan, uint8_t op)
+static struct net_buf *bt_att_create_rsp_pdu(struct bt_att_chan *chan, uint8_t op)
 {
 	size_t headroom;
 	struct bt_att_hdr *hdr;

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1930,7 +1930,7 @@ static void notify_disconnected(struct bt_conn *conn)
 }
 
 #if defined(CONFIG_BT_REMOTE_INFO)
-void notify_remote_info(struct bt_conn *conn)
+void bt_conn_notify_remote_info(struct bt_conn *conn)
 {
 	struct bt_conn_remote_info remote_info;
 	int err;
@@ -1955,7 +1955,7 @@ void notify_remote_info(struct bt_conn *conn)
 }
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
 
-void notify_le_param_updated(struct bt_conn *conn)
+void bt_conn_notify_le_param_updated(struct bt_conn *conn)
 {
 	/* If new connection parameters meet requirement of pending
 	 * parameters don't send peripheral conn param request anymore on timeout
@@ -1986,7 +1986,7 @@ void notify_le_param_updated(struct bt_conn *conn)
 }
 
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-void notify_le_data_len_updated(struct bt_conn *conn)
+void bt_conn_notify_le_data_len_updated(struct bt_conn *conn)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_data_len_updated) {
@@ -2003,7 +2003,7 @@ void notify_le_data_len_updated(struct bt_conn *conn)
 #endif
 
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-void notify_le_phy_updated(struct bt_conn *conn)
+void bt_conn_notify_le_phy_updated(struct bt_conn *conn)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_phy_updated) {
@@ -2019,7 +2019,7 @@ void notify_le_phy_updated(struct bt_conn *conn)
 }
 #endif
 
-bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
+bool bt_conn_le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
 	if (!bt_le_conn_params_valid(param)) {
 		return false;
@@ -2977,8 +2977,7 @@ static int bt_conn_get_tx_power_level(struct bt_conn *conn, uint8_t type,
 }
 
 #if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
-void notify_tx_power_report(struct bt_conn *conn,
-			    struct bt_conn_le_tx_power_report report)
+void bt_conn_notify_tx_power_report(struct bt_conn *conn, struct bt_conn_le_tx_power_report report)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->tx_power_report) {
@@ -3120,8 +3119,8 @@ int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_PATH_LOSS_MONITORING)
-void notify_path_loss_threshold_report(struct bt_conn *conn,
-				       struct bt_conn_le_path_loss_threshold_report report)
+void bt_conn_notify_path_loss_threshold_report(struct bt_conn *conn,
+					       struct bt_conn_le_path_loss_threshold_report report)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->path_loss_threshold_report) {
@@ -3189,8 +3188,8 @@ int bt_conn_le_set_path_loss_mon_enable(struct bt_conn *conn, bool reporting_ena
 #endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 
 #if defined(CONFIG_BT_SUBRATING)
-void notify_subrate_change(struct bt_conn *conn,
-			   const struct bt_conn_le_subrate_changed params)
+void bt_conn_notify_subrate_change(struct bt_conn *conn,
+				   const struct bt_conn_le_subrate_changed params)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->subrate_changed) {
@@ -3295,8 +3294,8 @@ int bt_conn_le_subrate_request(struct bt_conn *conn,
 #endif /* CONFIG_BT_SUBRATING */
 
 #if defined(CONFIG_BT_LE_EXTENDED_FEAT_SET)
-void notify_read_all_remote_feat_complete(struct bt_conn *conn,
-					  struct bt_conn_le_read_all_remote_feat_complete *params)
+void bt_conn_notify_read_all_remote_feat_complete(struct bt_conn *conn,
+					struct bt_conn_le_read_all_remote_feat_complete *params)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->read_all_remote_feat_complete != NULL) {
@@ -3340,8 +3339,8 @@ int bt_conn_le_read_all_remote_features(struct bt_conn *conn, uint8_t pages_requ
 #endif /* CONFIG_BT_LE_EXTENDED_FEAT_SET */
 
 #if defined(CONFIG_BT_FRAME_SPACE_UPDATE)
-void notify_frame_space_update_complete(struct bt_conn *conn,
-					struct bt_conn_le_frame_space_updated *params)
+void bt_conn_notify_frame_space_update_complete(struct bt_conn *conn,
+						struct bt_conn_le_frame_space_updated *params)
 {
 	if (IS_ENABLED(CONFIG_BT_CONN_DYNAMIC_CALLBACKS)) {
 		struct bt_conn_cb *callback;
@@ -3412,8 +3411,8 @@ int bt_conn_le_frame_space_update(struct bt_conn *conn,
 #endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
 
 #if defined(CONFIG_BT_CHANNEL_SOUNDING)
-void notify_remote_cs_capabilities(struct bt_conn *conn, uint8_t status,
-				   struct bt_conn_le_cs_capabilities *params)
+void bt_conn_notify_remote_cs_capabilities(struct bt_conn *conn, uint8_t status,
+					   struct bt_conn_le_cs_capabilities *params)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_cs_read_remote_capabilities_complete) {
@@ -3429,8 +3428,8 @@ void notify_remote_cs_capabilities(struct bt_conn *conn, uint8_t status,
 	}
 }
 
-void notify_remote_cs_fae_table(struct bt_conn *conn, uint8_t status,
-				struct bt_conn_le_cs_fae_table *params)
+void bt_conn_notify_remote_cs_fae_table(struct bt_conn *conn, uint8_t status,
+					struct bt_conn_le_cs_fae_table *params)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_cs_read_remote_fae_table_complete) {
@@ -3446,8 +3445,8 @@ void notify_remote_cs_fae_table(struct bt_conn *conn, uint8_t status,
 	}
 }
 
-void notify_cs_config_created(struct bt_conn *conn, uint8_t status,
-			      struct bt_conn_le_cs_config *params)
+void bt_conn_notify_cs_config_created(struct bt_conn *conn, uint8_t status,
+				      struct bt_conn_le_cs_config *params)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_cs_config_complete) {
@@ -3462,7 +3461,7 @@ void notify_cs_config_created(struct bt_conn *conn, uint8_t status,
 	}
 }
 
-void notify_cs_config_removed(struct bt_conn *conn, uint8_t config_id)
+void bt_conn_notify_cs_config_removed(struct bt_conn *conn, uint8_t config_id)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_cs_config_removed) {
@@ -3477,7 +3476,7 @@ void notify_cs_config_removed(struct bt_conn *conn, uint8_t config_id)
 	}
 }
 
-void notify_cs_security_enable_available(struct bt_conn *conn, uint8_t status)
+void bt_conn_notify_cs_security_enable_available(struct bt_conn *conn, uint8_t status)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_cs_security_enable_complete) {
@@ -3492,8 +3491,8 @@ void notify_cs_security_enable_available(struct bt_conn *conn, uint8_t status)
 	}
 }
 
-void notify_cs_procedure_enable_available(struct bt_conn *conn, uint8_t status,
-					  struct bt_conn_le_cs_procedure_enable_complete *params)
+void bt_conn_notify_cs_procedure_enable_available(struct bt_conn *conn, uint8_t status,
+					struct bt_conn_le_cs_procedure_enable_complete *params)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_cs_procedure_enable_complete) {
@@ -3508,7 +3507,8 @@ void notify_cs_procedure_enable_available(struct bt_conn *conn, uint8_t status,
 	}
 }
 
-void notify_cs_subevent_result(struct bt_conn *conn, struct bt_conn_le_cs_subevent_result *result)
+void bt_conn_notify_cs_subevent_result(struct bt_conn *conn,
+				       struct bt_conn_le_cs_subevent_result *result)
 {
 	BT_CONN_CB_DYNAMIC_FOREACH(callback) {
 		if (callback->le_cs_subevent_data_available) {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -137,7 +137,7 @@ static struct bt_conn sco_conns[CONFIG_BT_MAX_SCO_CONN];
 #endif /* CONFIG_BT_CONN */
 
 #if defined(CONFIG_BT_CONN_TX)
-void frag_destroy(struct net_buf *buf);
+static void frag_destroy(struct net_buf *buf);
 
 /* Storage for fragments (views) into the upper layers' PDUs. */
 /* TODO: remove user-data requirements */
@@ -147,14 +147,14 @@ NET_BUF_POOL_FIXED_DEFINE(fragments, CONFIG_BT_CONN_FRAG_COUNT, 0,
 struct frag_md {
 	struct bt_buf_view_meta view_meta;
 };
-struct frag_md frag_md_pool[CONFIG_BT_CONN_FRAG_COUNT];
+static struct frag_md frag_md_pool[CONFIG_BT_CONN_FRAG_COUNT];
 
-struct frag_md *get_frag_md(struct net_buf *fragment)
+static struct frag_md *get_frag_md(struct net_buf *fragment)
 {
 	return &frag_md_pool[net_buf_id(fragment)];
 }
 
-void frag_destroy(struct net_buf *frag)
+static void frag_destroy(struct net_buf *frag)
 {
 	/* allow next view to be allocated (and unlock the parent buf) */
 	bt_buf_destroy_view(frag, &get_frag_md(frag)->view_meta);
@@ -932,7 +932,7 @@ __maybe_unused static bool dont_have_methods(struct bt_conn *conn)
 		(conn->has_data == NULL);
 }
 
-struct bt_conn *get_conn_ready(void)
+static struct bt_conn *get_conn_ready(void)
 {
 	struct bt_conn *conn, *tmp;
 	sys_snode_t *prev = NULL;
@@ -1123,8 +1123,8 @@ static void process_unack_tx(struct bt_conn *conn)
 	}
 }
 
-struct bt_conn *conn_lookup_handle(struct bt_conn *conns, size_t size,
-				   uint16_t handle)
+static struct bt_conn *conn_lookup_handle(struct bt_conn *conns, size_t size,
+					  uint16_t handle)
 {
 	int i;
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -493,52 +493,47 @@ void bt_conn_role_changed(struct bt_conn *conn, uint8_t status);
 int bt_conn_le_conn_update(struct bt_conn *conn,
 			   const struct bt_le_conn_param *param);
 
-void notify_remote_info(struct bt_conn *conn);
+void bt_conn_notify_remote_info(struct bt_conn *conn);
 
-void notify_le_param_updated(struct bt_conn *conn);
+void bt_conn_notify_le_param_updated(struct bt_conn *conn);
 
-void notify_le_data_len_updated(struct bt_conn *conn);
+void bt_conn_notify_le_data_len_updated(struct bt_conn *conn);
 
-void notify_le_phy_updated(struct bt_conn *conn);
+void bt_conn_notify_le_phy_updated(struct bt_conn *conn);
 
-bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param);
+bool bt_conn_le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param);
 
-void notify_tx_power_report(struct bt_conn *conn,
-			    struct bt_conn_le_tx_power_report report);
+void bt_conn_notify_tx_power_report(struct bt_conn *conn, struct bt_conn_le_tx_power_report report);
 
-void notify_path_loss_threshold_report(struct bt_conn *conn,
-				       struct bt_conn_le_path_loss_threshold_report report);
+void bt_conn_notify_path_loss_threshold_report(struct bt_conn *conn,
+					       struct bt_conn_le_path_loss_threshold_report report);
 
-void notify_subrate_change(struct bt_conn *conn,
-			   struct bt_conn_le_subrate_changed params);
+void bt_conn_notify_subrate_change(struct bt_conn *conn, struct bt_conn_le_subrate_changed params);
 
-void notify_read_all_remote_feat_complete(struct bt_conn *conn,
-					  struct bt_conn_le_read_all_remote_feat_complete *params);
+void bt_conn_notify_read_all_remote_feat_complete(struct bt_conn *conn,
+					struct bt_conn_le_read_all_remote_feat_complete *params);
 
-void notify_frame_space_update_complete(struct bt_conn *conn,
-					struct bt_conn_le_frame_space_updated *params);
+void bt_conn_notify_frame_space_update_complete(struct bt_conn *conn,
+						struct bt_conn_le_frame_space_updated *params);
 
-void notify_remote_cs_capabilities(struct bt_conn *conn,
-				   uint8_t status,
-				   struct bt_conn_le_cs_capabilities *params);
+void bt_conn_notify_remote_cs_capabilities(struct bt_conn *conn, uint8_t status,
+					  struct bt_conn_le_cs_capabilities *params);
 
-void notify_remote_cs_fae_table(struct bt_conn *conn,
-				uint8_t status,
-				struct bt_conn_le_cs_fae_table *params);
+void bt_conn_notify_remote_cs_fae_table(struct bt_conn *conn, uint8_t status,
+					struct bt_conn_le_cs_fae_table *params);
 
-void notify_cs_config_created(struct bt_conn *conn,
-			      uint8_t status,
-			      struct bt_conn_le_cs_config *params);
+void bt_conn_notify_cs_config_created(struct bt_conn *conn, uint8_t status,
+				      struct bt_conn_le_cs_config *params);
 
-void notify_cs_config_removed(struct bt_conn *conn, uint8_t config_id);
+void bt_conn_notify_cs_config_removed(struct bt_conn *conn, uint8_t config_id);
 
-void notify_cs_subevent_result(struct bt_conn *conn, struct bt_conn_le_cs_subevent_result *result);
+void bt_conn_notify_cs_subevent_result(struct bt_conn *conn,
+				       struct bt_conn_le_cs_subevent_result *result);
 
-void notify_cs_security_enable_available(struct bt_conn *conn, uint8_t status);
+void bt_conn_notify_cs_security_enable_available(struct bt_conn *conn, uint8_t status);
 
-void notify_cs_procedure_enable_available(struct bt_conn *conn,
-					  uint8_t status,
-					  struct bt_conn_le_cs_procedure_enable_complete *params);
+void bt_conn_notify_cs_procedure_enable_available(struct bt_conn *conn, uint8_t status,
+					struct bt_conn_le_cs_procedure_enable_complete *params);
 
 /* If role specific LTK is present */
 bool bt_conn_ltk_present(const struct bt_conn *conn);

--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -244,7 +244,7 @@ static void invoke_subevent_result_callback(struct bt_conn *conn,
 	} else
 #endif /* CONFIG_BT_CHANNEL_SOUNDING_TEST */
 	{
-		notify_cs_subevent_result(conn, p_result);
+		bt_conn_notify_cs_subevent_result(conn, p_result);
 	}
 }
 
@@ -425,9 +425,10 @@ void bt_hci_le_cs_read_remote_supported_capabilities_complete(struct net_buf *bu
 		remote_cs_capabilities.t_sw_time = evt->t_sw_time_supported;
 		remote_cs_capabilities.tx_snr_capability = evt->tx_snr_capability;
 
-		notify_remote_cs_capabilities(conn, BT_HCI_ERR_SUCCESS, &remote_cs_capabilities);
+		bt_conn_notify_remote_cs_capabilities(conn, BT_HCI_ERR_SUCCESS,
+						      &remote_cs_capabilities);
 	} else {
-		notify_remote_cs_capabilities(conn, evt->status, NULL);
+		bt_conn_notify_remote_cs_capabilities(conn, evt->status, NULL);
 	}
 
 	bt_conn_unref(conn);
@@ -502,9 +503,9 @@ void bt_hci_le_cs_read_remote_fae_table_complete(struct net_buf *buf)
 	if (evt->status == BT_HCI_ERR_SUCCESS) {
 		fae_table.remote_fae_table = evt->remote_fae_table;
 
-		notify_remote_cs_fae_table(conn, BT_HCI_ERR_SUCCESS, &fae_table);
+		bt_conn_notify_remote_cs_fae_table(conn, BT_HCI_ERR_SUCCESS, &fae_table);
 	} else {
-		notify_remote_cs_fae_table(conn, evt->status, NULL);
+		bt_conn_notify_remote_cs_fae_table(conn, evt->status, NULL);
 	}
 
 	bt_conn_unref(conn);
@@ -845,7 +846,7 @@ void bt_hci_le_cs_config_complete_event(struct net_buf *buf)
 
 	if (evt->status == BT_HCI_ERR_SUCCESS) {
 		if (evt->action == BT_HCI_LE_CS_CONFIG_ACTION_REMOVED) {
-			notify_cs_config_removed(conn, evt->config_id);
+			bt_conn_notify_cs_config_removed(conn, evt->config_id);
 			bt_conn_unref(conn);
 			return;
 		}
@@ -870,9 +871,9 @@ void bt_hci_le_cs_config_complete_event(struct net_buf *buf)
 		config.t_pm_time_us = evt->t_pm_time;
 		memcpy(config.channel_map, evt->channel_map, ARRAY_SIZE(config.channel_map));
 
-		notify_cs_config_created(conn, BT_HCI_ERR_SUCCESS, &config);
+		bt_conn_notify_cs_config_created(conn, BT_HCI_ERR_SUCCESS, &config);
 	} else {
-		notify_cs_config_created(conn, evt->status, NULL);
+		bt_conn_notify_cs_config_created(conn, evt->status, NULL);
 	}
 
 	bt_conn_unref(conn);
@@ -1243,7 +1244,7 @@ void bt_hci_le_cs_security_enable_complete(struct net_buf *buf)
 		return;
 	}
 
-	notify_cs_security_enable_available(conn, evt->status);
+	bt_conn_notify_cs_security_enable_available(conn, evt->status);
 
 	bt_conn_unref(conn);
 }
@@ -1293,9 +1294,9 @@ void bt_hci_le_cs_procedure_enable_complete(struct net_buf *buf)
 		params.procedure_count = sys_le16_to_cpu(evt->procedure_count);
 		params.max_procedure_len = sys_le16_to_cpu(evt->max_procedure_len);
 
-		notify_cs_procedure_enable_available(conn, BT_HCI_ERR_SUCCESS, &params);
+		bt_conn_notify_cs_procedure_enable_available(conn, BT_HCI_ERR_SUCCESS, &params);
 	} else {
-		notify_cs_procedure_enable_available(conn, evt->status, NULL);
+		bt_conn_notify_cs_procedure_enable_available(conn, evt->status, NULL);
 	}
 
 	bt_conn_unref(conn);

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1115,6 +1115,19 @@ static bool is_host_managed_ccc(const struct bt_gatt_attr *attr)
 	return (attr->write == bt_gatt_attr_write_ccc);
 }
 
+#if defined(CONFIG_BT_SETTINGS)
+static int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr);
+#else
+static int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
+{
+	/* This function shall never be used without CONFIG_BT_SETTINGS. */
+	__ASSERT_NO_MSG(false);
+
+	return -ENOTSUP;
+}
+#endif /* CONFIG_BT_SETTINGS */
+
+
 #if defined(CONFIG_BT_SETTINGS) && defined(CONFIG_BT_SMP)
 /** Struct used to store both the id and the random address of a device when replacing
  * random addresses in the ccc attribute's cfg array with the device's id address after
@@ -6151,7 +6164,7 @@ static uint8_t ccc_save(const struct bt_gatt_attr *attr, uint16_t handle,
 	return BT_GATT_ITER_CONTINUE;
 }
 
-int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
+static int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
 {
 	struct ccc_save save;
 	size_t len;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1116,9 +1116,9 @@ static bool is_host_managed_ccc(const struct bt_gatt_attr *attr)
 }
 
 #if defined(CONFIG_BT_SETTINGS)
-static int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr);
+static int gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr);
 #else
-static int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
+static int gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
 {
 	/* This function shall never be used without CONFIG_BT_SETTINGS. */
 	__ASSERT_NO_MSG(false);
@@ -1176,7 +1176,7 @@ static void bt_gatt_identity_resolved(struct bt_conn *conn, const bt_addr_le_t *
 
 	/* Store the ccc */
 	if (is_bonded) {
-		bt_gatt_store_ccc(conn->id, &conn->le.dst);
+		gatt_store_ccc(conn->id, &conn->le.dst);
 	}
 
 	/* Update the cf addresses and store it if we get a match */
@@ -1194,7 +1194,7 @@ static void bt_gatt_pairing_complete(struct bt_conn *conn, bool bonded)
 {
 	if (bonded) {
 		/* Store the ccc and cf data */
-		bt_gatt_store_ccc(conn->id, &(conn->le.dst));
+		gatt_store_ccc(conn->id, &(conn->le.dst));
 		bt_gatt_store_cf(conn->id, &conn->le.dst);
 	}
 }
@@ -1509,7 +1509,7 @@ static void gatt_store_ccc_cf(uint8_t id, const bt_addr_le_t *peer_addr)
 		if (!IS_ENABLED(CONFIG_BT_SETTINGS_CCC_STORE_ON_WRITE) ||
 		    (IS_ENABLED(CONFIG_BT_SETTINGS_CCC_STORE_ON_WRITE) && el &&
 		     atomic_test_and_clear_bit(el->flags, DELAYED_STORE_CCC))) {
-			bt_gatt_store_ccc(id, peer_addr);
+			gatt_store_ccc(id, peer_addr);
 		}
 
 		if (!IS_ENABLED(CONFIG_BT_SETTINGS_CF_STORE_ON_WRITE) ||
@@ -1694,7 +1694,7 @@ static void gatt_unregister_ccc(struct bt_gatt_ccc_managed_user_data *ccc)
 
 			if (IS_ENABLED(CONFIG_BT_SETTINGS) && store &&
 			    bt_le_bond_exists(cfg->id, &cfg->peer)) {
-				bt_gatt_store_ccc(cfg->id, &cfg->peer);
+				gatt_store_ccc(cfg->id, &cfg->peer);
 			}
 
 			clear_ccc_cfg(cfg);
@@ -6164,7 +6164,7 @@ static uint8_t ccc_save(const struct bt_gatt_attr *attr, uint16_t handle,
 	return BT_GATT_ITER_CONTINUE;
 }
 
-static int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
+static int gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
 {
 	struct ccc_save save;
 	size_t len;

--- a/subsys/bluetooth/host/gatt_internal.h
+++ b/subsys/bluetooth/host/gatt_internal.h
@@ -43,8 +43,6 @@ void bt_gatt_disconnected(struct bt_conn *conn);
 
 bool bt_gatt_change_aware(struct bt_conn *conn, bool req);
 
-int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr);
-
 int bt_gatt_clear(uint8_t id, const bt_addr_le_t *addr);
 
 #if defined(CONFIG_BT_GATT_CLIENT)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1800,7 +1800,7 @@ static void le_remote_feat_complete(struct net_buf *buf)
 	if (IS_ENABLED(CONFIG_BT_REMOTE_INFO) &&
 	    (!IS_ENABLED(CONFIG_BT_REMOTE_VERSION) ||
 	     atomic_test_bit(conn->flags, BT_CONN_AUTO_VERSION_INFO))) {
-		notify_remote_info(conn);
+		bt_conn_notify_remote_info(conn);
 	}
 
 	bt_conn_unref(conn);
@@ -1831,7 +1831,7 @@ static void le_read_all_remote_feat_complete(struct net_buf *buf)
 		params.features = evt->features;
 	}
 
-	notify_read_all_remote_feat_complete(conn, &params);
+	bt_conn_notify_read_all_remote_feat_complete(conn, &params);
 
 	bt_conn_unref(conn);
 }
@@ -1860,7 +1860,7 @@ static void le_frame_space_update_complete(struct net_buf *buf)
 		params.initiator = evt->initiator;
 	}
 
-	notify_frame_space_update_complete(conn, &params);
+	bt_conn_notify_frame_space_update_complete(conn, &params);
 }
 #endif /* CONFIG_BT_FRAME_SPACE_UPDATE */
 
@@ -1903,7 +1903,7 @@ static void le_data_len_change(struct net_buf *buf)
 	conn->le.data_len.tx_max_time = max_tx_time;
 	conn->le.data_len.rx_max_len = max_rx_octets;
 	conn->le.data_len.rx_max_time = max_rx_time;
-	notify_le_data_len_updated(conn);
+	bt_conn_notify_le_data_len_updated(conn);
 #endif
 
 	bt_conn_unref(conn);
@@ -1930,7 +1930,7 @@ static void le_phy_update_complete(struct net_buf *buf)
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
 	conn->le.phy.tx_phy = bt_get_phy(evt->tx_phy);
 	conn->le.phy.rx_phy = bt_get_phy(evt->rx_phy);
-	notify_le_phy_updated(conn);
+	bt_conn_notify_le_phy_updated(conn);
 #endif
 
 	bt_conn_unref(conn);
@@ -2024,7 +2024,7 @@ static void le_conn_param_req(struct net_buf *buf)
 		return;
 	}
 
-	if (!le_param_req(conn, &param)) {
+	if (!bt_conn_le_param_req(conn, &param)) {
 		le_conn_param_neg_reply(handle, BT_HCI_ERR_INVALID_LL_PARAM);
 	} else {
 		le_conn_param_req_reply(handle, &param);
@@ -2103,7 +2103,7 @@ static void le_conn_update_complete(struct net_buf *buf)
 
 		}
 
-		notify_le_param_updated(conn);
+		bt_conn_notify_le_param_updated(conn);
 	}
 
 	bt_conn_unref(conn);
@@ -2440,7 +2440,7 @@ static void bt_hci_evt_read_remote_version_complete(struct net_buf *buf)
 	if (IS_ENABLED(CONFIG_BT_REMOTE_INFO) &&
 	    atomic_test_bit(conn->flags, BT_CONN_LE_FEATURES_EXCHANGED)) {
 		/* Remote features is already present */
-		notify_remote_info(conn);
+		bt_conn_notify_remote_info(conn);
 	}
 
 	bt_conn_unref(conn);
@@ -2714,7 +2714,7 @@ void bt_hci_le_transmit_power_report(struct net_buf *buf)
 	report.tx_power_level_flag = evt->tx_power_level_flag;
 	report.delta = evt->delta;
 
-	notify_tx_power_report(conn, report);
+	bt_conn_notify_tx_power_report(conn, report);
 
 	bt_conn_unref(conn);
 }
@@ -2750,7 +2750,7 @@ void bt_hci_le_path_loss_threshold_event(struct net_buf *buf)
 		report.path_loss = evt->current_path_loss;
 	}
 
-	notify_path_loss_threshold_report(conn, report);
+	bt_conn_notify_path_loss_threshold_report(conn, report);
 
 	bt_conn_unref(conn);
 }
@@ -2806,7 +2806,7 @@ void bt_hci_le_subrate_change_event(struct net_buf *buf)
 	params.peripheral_latency = conn->le.latency;
 	params.supervision_timeout = conn->le.timeout;
 
-	notify_subrate_change(conn, params);
+	bt_conn_notify_subrate_change(conn, params);
 
 	bt_conn_unref(conn);
 }

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -953,7 +953,7 @@ struct bt_id_conflict {
  * must refuse bonds that conflict in the resolve list. Notably, this prevents
  * multiple local identities to bond with the same remote identity.
  */
-void find_rl_conflict(struct bt_keys *resident, void *user_data)
+static void find_rl_conflict(struct bt_keys *resident, void *user_data)
 {
 	struct bt_id_conflict *conflict = user_data;
 	bool addr_conflict;

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -200,7 +200,10 @@ const char *bt_l2cap_chan_state_str(bt_l2cap_chan_state_t state)
 
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 #if defined(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
-void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
+#define bt_l2cap_chan_set_state(_chan, _state) \
+	bt_l2cap_chan_set_state_debug(_chan, _state, __func__, __LINE__)
+
+static void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
 				   bt_l2cap_chan_state_t state,
 				   const char *func, int line)
 {
@@ -244,7 +247,7 @@ void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
 	le_chan->state = state;
 }
 #else
-void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
+static void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
 			     bt_l2cap_chan_state_t state)
 {
 	BT_L2CAP_LE_CHAN(chan)->state = state;
@@ -254,7 +257,7 @@ void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
 
 static void cancel_data_ready(struct bt_l2cap_le_chan *lechan);
 static bool chan_has_data(struct bt_l2cap_le_chan *lechan);
-void bt_l2cap_chan_del(struct bt_l2cap_chan *chan)
+static void bt_l2cap_chan_del(struct bt_l2cap_chan *chan)
 {
 	const struct bt_l2cap_chan_ops *ops = chan->ops;
 	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1116,7 +1116,7 @@ static void le_conn_param_update_req(struct bt_l2cap *l2cap, uint8_t ident,
 		return;
 	}
 
-	accepted = le_param_req(conn, &param);
+	accepted = bt_conn_le_param_req(conn, &param);
 
 	rsp = net_buf_add(buf, sizeof(*rsp));
 	if (accepted) {

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -200,12 +200,11 @@ const char *bt_l2cap_chan_state_str(bt_l2cap_chan_state_t state)
 
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 #if defined(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
-#define bt_l2cap_chan_set_state(_chan, _state) \
-	bt_l2cap_chan_set_state_debug(_chan, _state, __func__, __LINE__)
+#define l2cap_chan_set_state(_chan, _state) \
+	l2cap_chan_set_state_debug(_chan, _state, __func__, __LINE__)
 
-static void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
-				   bt_l2cap_chan_state_t state,
-				   const char *func, int line)
+static void l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan, bt_l2cap_chan_state_t state,
+				       const char *func, int line)
 {
 	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
 
@@ -247,8 +246,7 @@ static void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
 	le_chan->state = state;
 }
 #else
-static void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
-			     bt_l2cap_chan_state_t state)
+static void l2cap_chan_set_state(struct bt_l2cap_chan *chan, bt_l2cap_chan_state_t state)
 {
 	BT_L2CAP_LE_CHAN(chan)->state = state;
 }
@@ -257,7 +255,7 @@ static void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
 
 static void cancel_data_ready(struct bt_l2cap_le_chan *lechan);
 static bool chan_has_data(struct bt_l2cap_le_chan *lechan);
-static void bt_l2cap_chan_del(struct bt_l2cap_chan *chan)
+static void l2cap_chan_del(struct bt_l2cap_chan *chan)
 {
 	const struct bt_l2cap_chan_ops *ops = chan->ops;
 	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
@@ -287,7 +285,7 @@ static void bt_l2cap_chan_del(struct bt_l2cap_chan *chan)
 destroy:
 #if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
 	/* Reset internal members of common channel */
-	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECTED);
+	l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECTED);
 	BT_L2CAP_LE_CHAN(chan)->psm = 0U;
 #endif
 	if (chan->destroy) {
@@ -308,11 +306,11 @@ static void l2cap_rtx_timeout(struct k_work *work)
 	LOG_ERR("chan %p timeout", chan);
 
 	bt_l2cap_chan_remove(conn, &chan->chan);
-	bt_l2cap_chan_del(&chan->chan);
+	l2cap_chan_del(&chan->chan);
 
 	/* Remove other channels if pending on the same ident */
 	while ((chan = l2cap_remove_ident(conn, chan->ident, chan->pending_req))) {
-		bt_l2cap_chan_del(&chan->chan);
+		l2cap_chan_del(&chan->chan);
 	}
 }
 
@@ -393,7 +391,7 @@ static bool l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 	if (L2CAP_LE_CID_IS_DYN(le_chan->rx.cid)) {
 		k_work_init(&le_chan->rx_work, l2cap_rx_process);
 		k_fifo_init(&le_chan->rx_queue);
-		bt_l2cap_chan_set_state(chan, BT_L2CAP_CONNECTING);
+		l2cap_chan_set_state(chan, BT_L2CAP_CONNECTING);
 	}
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
@@ -455,7 +453,7 @@ void bt_l2cap_disconnected(struct bt_conn *conn)
 	}
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&conn->channels, chan, next, node) {
-		bt_l2cap_chan_del(chan);
+		l2cap_chan_del(chan);
 	}
 }
 
@@ -663,7 +661,7 @@ static void l2cap_le_encrypt_change(struct bt_l2cap_chan *chan, uint8_t status)
 	return;
 fail:
 	bt_l2cap_chan_remove(chan->conn, chan);
-	bt_l2cap_chan_del(chan);
+	l2cap_chan_del(chan);
 }
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
 
@@ -1434,7 +1432,7 @@ static uint16_t l2cap_chan_accept(struct bt_conn *conn,
 	le_chan->psm = server->psm;
 
 	/* Update state */
-	bt_l2cap_chan_set_state(*chan, BT_L2CAP_CONNECTED);
+	l2cap_chan_set_state(*chan, BT_L2CAP_CONNECTED);
 
 	return BT_L2CAP_LE_SUCCESS;
 }
@@ -1884,7 +1882,7 @@ static void le_disconn_req(struct bt_l2cap *l2cap, uint8_t ident,
 	rsp->dcid = sys_cpu_to_le16(chan->rx.cid);
 	rsp->scid = sys_cpu_to_le16(chan->tx.cid);
 
-	bt_l2cap_chan_del(&chan->chan);
+	l2cap_chan_del(&chan->chan);
 
 	l2cap_send_sig(conn, buf);
 }
@@ -1977,7 +1975,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 				return;
 			}
 			bt_l2cap_chan_remove(conn, &chan->chan);
-			bt_l2cap_chan_del(&chan->chan);
+			l2cap_chan_del(&chan->chan);
 		}
 		break;
 	case BT_L2CAP_LE_SUCCESS:
@@ -1996,7 +1994,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 			if (buf->len < sizeof(dcid)) {
 				LOG_ERR("Fewer dcid values than expected");
 				bt_l2cap_chan_remove(conn, &chan->chan);
-				bt_l2cap_chan_del(&chan->chan);
+				l2cap_chan_del(&chan->chan);
 				continue;
 			}
 
@@ -2011,7 +2009,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 			 */
 			if (dcid == 0U) {
 				bt_l2cap_chan_remove(conn, &chan->chan);
-				bt_l2cap_chan_del(&chan->chan);
+				l2cap_chan_del(&chan->chan);
 				continue;
 			} else if (!L2CAP_LE_CID_IS_DYN(dcid) ||
 				   !IN_RANGE(mtu, BT_L2CAP_ECRED_MIN_MTU, BT_L2CAP_MAX_MTU) ||
@@ -2035,7 +2033,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 				 * not used.
 				 */
 				bt_l2cap_chan_remove(conn, &chan->chan);
-				bt_l2cap_chan_del(&chan->chan);
+				l2cap_chan_del(&chan->chan);
 				bt_l2cap_chan_disconnect(c);
 				continue;
 			}
@@ -2049,7 +2047,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 			chan->tx.mps = mps;
 
 			/* Update state */
-			bt_l2cap_chan_set_state(&chan->chan,
+			l2cap_chan_set_state(&chan->chan,
 						BT_L2CAP_CONNECTED);
 
 			if (chan->chan.ops->connected) {
@@ -2065,7 +2063,7 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 	case BT_L2CAP_LE_ERR_PSM_NOT_SUPP:
 	default:
 		while ((chan = l2cap_remove_ident(conn, ident, BT_L2CAP_ECRED_CONN_REQ))) {
-			bt_l2cap_chan_del(&chan->chan);
+			l2cap_chan_del(&chan->chan);
 		}
 		break;
 	}
@@ -2141,7 +2139,7 @@ static void le_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 		chan->tx.mps = mps;
 
 		/* Update state */
-		bt_l2cap_chan_set_state(&chan->chan, BT_L2CAP_CONNECTED);
+		l2cap_chan_set_state(&chan->chan, BT_L2CAP_CONNECTED);
 
 		if (chan->chan.ops->connected) {
 			chan->chan.ops->connected(&chan->chan);
@@ -2160,7 +2158,7 @@ static void le_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 		bt_l2cap_chan_remove(conn, &chan->chan);
 		__fallthrough;
 	default:
-		bt_l2cap_chan_del(&chan->chan);
+		l2cap_chan_del(&chan->chan);
 	}
 }
 
@@ -2197,7 +2195,7 @@ static void le_disconn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 		return;
 	}
 
-	bt_l2cap_chan_del(&chan->chan);
+	l2cap_chan_del(&chan->chan);
 }
 
 static void le_credits(struct bt_l2cap *l2cap, uint8_t ident,
@@ -2257,7 +2255,7 @@ static void reject_cmd(struct bt_l2cap *l2cap, uint8_t ident,
 	struct bt_l2cap_le_chan *chan;
 
 	while ((chan = l2cap_remove_ident(conn, ident, ANY_OPCODE))) {
-		bt_l2cap_chan_del(&chan->chan);
+		l2cap_chan_del(&chan->chan);
 	}
 }
 #endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
@@ -2971,7 +2969,7 @@ static int l2cap_le_connect(struct bt_conn *conn, struct bt_l2cap_le_chan *ch,
 
 fail:
 	bt_l2cap_chan_remove(conn, &ch->chan);
-	bt_l2cap_chan_del(&ch->chan);
+	l2cap_chan_del(&ch->chan);
 	return err;
 }
 
@@ -3294,7 +3292,7 @@ int bt_l2cap_chan_disconnect(struct bt_l2cap_chan *chan)
 	req->scid = sys_cpu_to_le16(le_chan->rx.cid);
 
 	l2cap_chan_send_req(chan, buf, L2CAP_DISC_TIMEOUT);
-	bt_l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECTING);
+	l2cap_chan_set_state(chan, BT_L2CAP_DISCONNECTING);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -190,21 +190,7 @@ void bt_l2cap_chan_add(struct bt_conn *conn, struct bt_l2cap_chan *chan,
 /* Remove channel from the connection */
 void bt_l2cap_chan_remove(struct bt_conn *conn, struct bt_l2cap_chan *chan);
 
-/* Delete channel */
-void bt_l2cap_chan_del(struct bt_l2cap_chan *chan);
-
 const char *bt_l2cap_chan_state_str(bt_l2cap_chan_state_t state);
-
-#if defined(CONFIG_BT_L2CAP_LOG_LEVEL_DBG)
-void bt_l2cap_chan_set_state_debug(struct bt_l2cap_chan *chan,
-				   bt_l2cap_chan_state_t state,
-				   const char *func, int line);
-#define bt_l2cap_chan_set_state(_chan, _state) \
-	bt_l2cap_chan_set_state_debug(_chan, _state, __func__, __LINE__)
-#else
-void bt_l2cap_chan_set_state(struct bt_l2cap_chan *chan,
-			     bt_l2cap_chan_state_t state);
-#endif /* CONFIG_BT_L2CAP_LOG_LEVEL_DBG */
 
 /*
  * Notify L2CAP channels of a change in encryption state passing additionally

--- a/tests/bluetooth/host/cs/mocks/conn.c
+++ b/tests/bluetooth/host/cs/mocks/conn.c
@@ -10,15 +10,15 @@
 
 DEFINE_FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
 DEFINE_FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_lookup_handle, uint16_t, enum bt_conn_type);
-DEFINE_FAKE_VOID_FUNC(notify_remote_cs_capabilities, struct bt_conn *,
+DEFINE_FAKE_VOID_FUNC(bt_conn_notify_remote_cs_capabilities, struct bt_conn *,
 		      uint8_t, struct bt_conn_le_cs_capabilities *);
-DEFINE_FAKE_VOID_FUNC(notify_remote_cs_fae_table, struct bt_conn *,
+DEFINE_FAKE_VOID_FUNC(bt_conn_notify_remote_cs_fae_table, struct bt_conn *,
 		      uint8_t, struct bt_conn_le_cs_fae_table *);
-DEFINE_FAKE_VOID_FUNC(notify_cs_config_created, struct bt_conn *,
+DEFINE_FAKE_VOID_FUNC(bt_conn_notify_cs_config_created, struct bt_conn *,
 		      uint8_t, struct bt_conn_le_cs_config *);
-DEFINE_FAKE_VOID_FUNC(notify_cs_config_removed, struct bt_conn *, uint8_t);
-DEFINE_FAKE_VOID_FUNC(notify_cs_subevent_result, struct bt_conn *,
+DEFINE_FAKE_VOID_FUNC(bt_conn_notify_cs_config_removed, struct bt_conn *, uint8_t);
+DEFINE_FAKE_VOID_FUNC(bt_conn_notify_cs_subevent_result, struct bt_conn *,
 		      struct bt_conn_le_cs_subevent_result *);
-DEFINE_FAKE_VOID_FUNC(notify_cs_security_enable_available, struct bt_conn *, uint8_t);
-DEFINE_FAKE_VOID_FUNC(notify_cs_procedure_enable_available, struct bt_conn *,
+DEFINE_FAKE_VOID_FUNC(bt_conn_notify_cs_security_enable_available, struct bt_conn *, uint8_t);
+DEFINE_FAKE_VOID_FUNC(bt_conn_notify_cs_procedure_enable_available, struct bt_conn *,
 		      uint8_t, struct bt_conn_le_cs_procedure_enable_complete *);

--- a/tests/bluetooth/host/cs/mocks/conn.h
+++ b/tests/bluetooth/host/cs/mocks/conn.h
@@ -14,25 +14,25 @@
 #define CONN_FFF_FAKES_LIST(FAKE)                                                                  \
 	FAKE(bt_conn_unref)                                                                        \
 	FAKE(bt_conn_lookup_handle)                                                                \
-	FAKE(notify_remote_cs_capabilities)                                                        \
-	FAKE(notify_cs_config_created)                                                             \
-	FAKE(notify_cs_config_removed)                                                             \
-	FAKE(notify_cs_subevent_result)                                                            \
-	FAKE(notify_cs_security_enable_available)                                                  \
-	FAKE(notify_cs_procedure_enable_available)                                                 \
-	FAKE(notify_remote_cs_fae_table)
+	FAKE(bt_conn_notify_remote_cs_capabilities)                                                \
+	FAKE(bt_conn_notify_cs_config_created)                                                     \
+	FAKE(bt_conn_notify_cs_config_removed)                                                     \
+	FAKE(bt_conn_notify_cs_subevent_result)                                                    \
+	FAKE(bt_conn_notify_cs_security_enable_available)                                          \
+	FAKE(bt_conn_notify_cs_procedure_enable_available)                                         \
+	FAKE(bt_conn_notify_remote_cs_fae_table)
 
 DECLARE_FAKE_VOID_FUNC(bt_conn_unref, struct bt_conn *);
 DECLARE_FAKE_VALUE_FUNC(struct bt_conn *, bt_conn_lookup_handle, uint16_t, enum bt_conn_type);
-DECLARE_FAKE_VOID_FUNC(notify_remote_cs_capabilities, struct bt_conn *,
+DECLARE_FAKE_VOID_FUNC(bt_conn_notify_remote_cs_capabilities, struct bt_conn *,
 		       uint8_t, struct bt_conn_le_cs_capabilities *);
-DECLARE_FAKE_VOID_FUNC(notify_remote_cs_fae_table, struct bt_conn *,
+DECLARE_FAKE_VOID_FUNC(bt_conn_notify_remote_cs_fae_table, struct bt_conn *,
 		       uint8_t, struct bt_conn_le_cs_fae_table *);
-DECLARE_FAKE_VOID_FUNC(notify_cs_config_created, struct bt_conn *,
+DECLARE_FAKE_VOID_FUNC(bt_conn_notify_cs_config_created, struct bt_conn *,
 		       uint8_t, struct bt_conn_le_cs_config *);
-DECLARE_FAKE_VOID_FUNC(notify_cs_config_removed, struct bt_conn *, uint8_t);
-DECLARE_FAKE_VOID_FUNC(notify_cs_subevent_result, struct bt_conn *,
+DECLARE_FAKE_VOID_FUNC(bt_conn_notify_cs_config_removed, struct bt_conn *, uint8_t);
+DECLARE_FAKE_VOID_FUNC(bt_conn_notify_cs_subevent_result, struct bt_conn *,
 		       struct bt_conn_le_cs_subevent_result *);
-DECLARE_FAKE_VOID_FUNC(notify_cs_security_enable_available, struct bt_conn *, uint8_t);
-DECLARE_FAKE_VOID_FUNC(notify_cs_procedure_enable_available, struct bt_conn *,
+DECLARE_FAKE_VOID_FUNC(bt_conn_notify_cs_security_enable_available, struct bt_conn *, uint8_t);
+DECLARE_FAKE_VOID_FUNC(bt_conn_notify_cs_procedure_enable_available, struct bt_conn *,
 		       uint8_t, struct bt_conn_le_cs_procedure_enable_complete *);


### PR DESCRIPTION
Refactor function prefixes and use of static for clearer, more consistent code by:
- marking functions and variables as static when not used outside a unit.
- prefixing API functions of a module with bt_ to avoid confusion when reading code.
- removing the bt_ prefix from internal functions to avoid confusion when reading code.