### PR TITLE
drivers: disk: sdmmc_stm32: Add API to retrieve SD card CID register

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/disk.h>
+#include <zephyr/drivers/disks/sdmmc_stm32.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -814,6 +815,13 @@ err_card_detect:
 	stm32_sdmmc_card_detect_uninit(priv);
 #endif
 	return err;
+}
+
+void stm32_sdmmc_get_card_cid(const struct device *dev, uint32_t cid[4])
+{
+	const struct stm32_sdmmc_priv *priv = dev->data;
+
+	memcpy(cid, &priv->hsd.CID, sizeof(priv->hsd.CID));
 }
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_DRV_INST(0))

--- a/include/zephyr/drivers/disks/sdmmc_stm32.h
+++ b/include/zephyr/drivers/disks/sdmmc_stm32.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 The Zephyr Contributors.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DISKS_SDMMC_STM32_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DISKS_SDMMC_STM32_H_
+
+#include <zephyr/device.h>
+#include <stdint.h>
+
+/**
+ * @brief Get the CID (Card Identification) information from the SD/MMC card.
+ *
+ * This function copies the Card Identification Data (CID) from the internal
+ * HAL SD/MMC struct populated during device initialization. It does not check
+ * the current presence or status of the card. If the card was removed after
+ * initialization (or initialization failed), the returned CID may be stale or
+ * all zeroes.
+ *
+ * It is the caller's responsibility to verify that the card is present and
+ * initialized (e.g., by calling @ref disk_access_status) before invoking this
+ * function.
+ *
+ * @param dev Pointer to the device structure representing the SD/MMC card.
+ * @param cid Pointer to an array where the CID data will be stored.
+ */
+void stm32_sdmmc_get_card_cid(const struct device *dev, uint32_t cid[4]);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_DISKS_SDMMC_STM32_H_ */


### PR DESCRIPTION
Introduce a new API function in the sdmmc_stm32 driver that allows applications to access the Card Identification (CID) register of the SD/MMC card. This functionality, already available in the SPI-based SD and MMC subsystems, was previously missing from the STM32 SDMMC driver.

This enhancement enables use cases such as verifying the correct SD card during manufacturing, ensuring that OEMs use the specified SD card, and preventing mismatches.