### PR TITLE
samples: Bluetooth: BAP: Broadcast sink fix bad USB check

### DIFF
--- a/samples/bluetooth/bap_broadcast_sink/src/lc3.c
+++ b/samples/bluetooth/bap_broadcast_sink/src/lc3.c
@@ -408,7 +408,7 @@ int lc3_disable(struct stream_rx *stream)
 
 	stream->lc3_decoder = NULL;
 
-	if (IS_ENABLED(CONFIG_USB_DEVICE_AUDIO)) {
+	if (IS_ENABLED(CONFIG_USE_USB_AUDIO_OUTPUT)) {
 		if (usb_left_stream == stream) {
 			usb_left_stream = NULL;
 		}

--- a/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/CMakeLists.txt
+++ b/tests/bsim/bluetooth/audio_samples/bap_broadcast_sink/CMakeLists.txt
@@ -13,7 +13,12 @@ target_sources(app PRIVATE
 )
 
 zephyr_sources_ifdef(CONFIG_LIBLC3 ${bap_broadcast_sink_path}/src/lc3.c)
-zephyr_sources_ifdef(CONFIG_USB_DEVICE_AUDIO ${bap_broadcast_sink_path}/src/usb.c)
+
+if (CONFIG_USE_USB_AUDIO_OUTPUT)
+  include(${ZEPHYR_BASE}/samples/subsys/usb/common/common.cmake)
+  target_sources(app PRIVATE ${bap_broadcast_sink_path}/src/usb.c)
+endif()
+
 
 target_sources(app PRIVATE
 	src/broadcast_sink_test.c


### PR DESCRIPTION
Use CONFIG_USE_USB_AUDIO_OUTPUT instead of CONFIG_USB_DEVICE_AUDIO when assigning USB streams, as CONFIG_USB_DEVICE_AUDIO is unused by the sample.