### PR TITLE
Bluetooth: Host: Gatt: Destroy the imported key after hash calculation completes

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -755,6 +755,8 @@ static int db_hash_finish(struct gen_hash_state *state)
 	size_t mac_length;
 	psa_status_t ret = psa_mac_sign_finish(&(state->operation), db_hash.hash, 16, &mac_length);
 
+	psa_destroy_key(state->key);
+
 	if (ret != PSA_SUCCESS) {
 		LOG_ERR("CMAC finish failed %d", ret);
 		return -EIO;


### PR DESCRIPTION
To generate the GATT Database Hash characteristic, the function `db_hash_setup` is called. It allocates an entry for the AES key that will be used in the CMAC calculation. Next, `db_hash_update` is called to feed all GATT database entries into the hash. Finally, `db_hash_finish` produces the resulting hash.

However, the AES key entry allocated in `db_hash_setup` was not being destroyed after the hash generation completed. This caused a memory leak, eventually leading to the error `PSA_ERROR_INSUFFICIENT_MEMORY` (`-134`).

This commit fixes the issue by destroying the allocated AES key after the GATT Database Hash calculation is complete, by calling `psa_destroy_key` in `db_hash_finish`.