### PR TITLE
shell: modules: devmem: fix devmem load occasionally losing bytes

### DIFF
--- a/subsys/shell/modules/devmem_service.c
+++ b/subsys/shell/modules/devmem_service.c
@@ -175,14 +175,25 @@ static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
 	static uint8_t tail;
 	uint8_t byte;
 
-	if (tail == CHAR_CAN && recv[0] == CHAR_DC1) {
-		escape = true;
-	} else {
-		for (int i = 0; i < (len - 1); i++) {
-			if (recv[i] == CHAR_CAN && recv[i + 1] == CHAR_DC1) {
-				escape = true;
-				break;
-			}
+	for (size_t i = 0; i < len; i++) {
+		if (tail == CHAR_CAN && recv[i] == CHAR_DC1) {
+			escape = true;
+			tail = 0;
+			break;
+		}
+		tail = recv[i];
+
+		if (is_ascii(recv[i])) {
+			chunk[chunk_element] = recv[i];
+			chunk_element++;
+		}
+
+		if (chunk_element == 2) {
+			byte = (uint8_t)strtoul(chunk, NULL, 16);
+			*bytes = byte;
+			bytes++;
+			sum++;
+			chunk_element = 0;
 		}
 	}
 
@@ -205,21 +216,6 @@ static void bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
 			}
 		}
 		return;
-	}
-
-	tail = recv[len - 1];
-
-	if (is_ascii(*recv)) {
-		chunk[chunk_element] = *recv;
-		chunk_element++;
-	}
-
-	if (chunk_element == 2) {
-		byte = (uint8_t)strtoul(chunk, NULL, 16);
-		*bytes = byte;
-		bytes++;
-		sum++;
-		chunk_element = 0;
 	}
 }
 


### PR DESCRIPTION
Changed devmem load to process all characters from the *recv buffer.