### PR TITLE
boards: st: nucleo_h723zg: list usbd as a supported feature

### DIFF
--- a/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
+++ b/boards/st/nucleo_h723zg/nucleo_h723zg.yaml
@@ -20,6 +20,7 @@ supported:
   - netif:eth
   - backup_sram
   - usb_device
+  - usbd
   - rtc
   - can
 vendor: st


### PR DESCRIPTION
Add "usbd" in the list of supported features for the ST NUCLEO-H723ZG development board.