### PR TITLE
include: usbc: doc: Group all USB-C API in same doxygen Group

### DIFF
--- a/include/zephyr/drivers/usb_c/usbc_pd.h
+++ b/include/zephyr/drivers/usb_c/usbc_pd.h
@@ -17,7 +17,7 @@
 /**
  * @brief USB Power Delivery
  * @defgroup usb_power_delivery USB Power Delivery
- * @ingroup io_interfaces
+ * @ingroup usb_type_c
  * @{
  */
 

--- a/include/zephyr/drivers/usb_c/usbc_ppc.h
+++ b/include/zephyr/drivers/usb_c/usbc_ppc.h
@@ -12,6 +12,13 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PPC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PPC_H_
 
+/**
+ * @brief USB Type-C Power Path Controller
+ * @defgroup usb_type_c_power_path_controller USB Type-C Power Path Controller
+ * @ingroup usb_type_c
+ * @{
+ */
+
 #include <zephyr/types.h>
 #include <zephyr/device.h>
 #include <errno.h>
@@ -273,5 +280,9 @@ static inline int ppc_dump_regs(const struct device *dev)
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_USBC_USBC_PPC_H_ */

--- a/include/zephyr/drivers/usb_c/usbc_tcpc.h
+++ b/include/zephyr/drivers/usb_c/usbc_tcpc.h
@@ -20,7 +20,7 @@
  * @defgroup usb_type_c_port_controller_api USB Type-C Port Controller API
  * @since 3.1
  * @version 0.1.0
- * @ingroup io_interfaces
+ * @ingroup usb_type_c
  * @{
  */
 

--- a/include/zephyr/drivers/usb_c/usbc_vbus.h
+++ b/include/zephyr/drivers/usb_c/usbc_vbus.h
@@ -20,7 +20,7 @@
  * @defgroup usbc_vbus_api USB-C VBUS API
  * @since 3.3
  * @version 0.1.0
- * @ingroup io_interfaces
+ * @ingroup usb_type_c
  * @{
  */
 


### PR DESCRIPTION
Put every header defined in include/zephyr/drivers/usb_c/ into the same doxygroup (`usb_type_c`) so as to not clutter the top-level `io_interfaces` group with multiple USB-C related groups.
