### PR TITLE
Support usb host for nxp rw6xx series

### DIFF
--- a/dts/arm/nxp/nxp_rw6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rw6xx_common.dtsi
@@ -241,6 +241,15 @@
 		status = "disabled";
 	};
 
+	usbh: usbh@145000 {
+		compatible = "nxp,uhc-ehci";
+		reg = <0x145000 0x200>;
+		interrupts = <50 1>;
+		interrupt-names = "usb_otg";
+		power-domains = <&power_mode3_domain>;
+		status = "disabled";
+	};
+
 	flexcomm0: flexcomm@106000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x106000 0x1000>;

--- a/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_host_config.h
+++ b/modules/hal_nxp/mcux/mcux-sdk-ng/middleware/usb_host_config.h
@@ -16,10 +16,10 @@
 #ifdef CONFIG_UHC_NXP_EHCI
 #define USB_HOST_CONFIG_EHCI                 (2U)
 #define USB_HOST_CONFIG_EHCI_FRAME_LIST_SIZE (1024U)
-#define USB_HOST_CONFIG_EHCI_MAX_QH          (8U)
-#define USB_HOST_CONFIG_EHCI_MAX_QTD         (8U)
-#define USB_HOST_CONFIG_EHCI_MAX_ITD         (0U)
-#define USB_HOST_CONFIG_EHCI_MAX_SITD        (0U)
+#define USB_HOST_CONFIG_EHCI_MAX_QH          (16U)
+#define USB_HOST_CONFIG_EHCI_MAX_QTD         (16U)
+#define USB_HOST_CONFIG_EHCI_MAX_ITD         (16U)
+#define USB_HOST_CONFIG_EHCI_MAX_SITD        (16U)
 #else
 #define USB_HOST_CONFIG_EHCI (0U)
 #endif /* CONFIG_USB_DC_NXP_EHCI */

--- a/soc/nxp/rw/soc.c
+++ b/soc/nxp/rw/soc.c
@@ -277,7 +277,8 @@ __weak __ramfunc void clock_init(void)
 #endif /* CONFIG_COUNTER_MCUX_CTIMER */
 
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(usb_otg)) && \
-	(CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI)
+	(CONFIG_USB_DC_NXP_EHCI || CONFIG_UDC_NXP_EHCI) || \
+	(CONFIG_UHC_NXP_EHCI)
 	/* Enable system xtal from Analog */
 	SYSCTL2->ANA_GRP_CTRL |= SYSCTL2_ANA_GRP_CTRL_PU_AG_MASK;
 	/* reset USB */


### PR DESCRIPTION
These 3 commits are the necessary supports for NXP RW6xx usb host.