### PR TITLE
scripts: compliance: Add items to UNDEF_KCONFIG_ALLOWLIST

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1200,6 +1200,8 @@ flagged.
         "BOOT_DIRECT_XIP", # Used in sysbuild for MCUboot configuration
         "BOOT_DIRECT_XIP_REVERT", # Used in sysbuild for MCUboot configuration
         "BOOT_ENCRYPTION_KEY_FILE", # Used in sysbuild
+        "BOOT_ENCRYPT_ALG_AES_128", # Used in sysbuild
+        "BOOT_ENCRYPT_ALG_AES_256", # Used in sysbuild
         "BOOT_ENCRYPT_IMAGE", # Used in sysbuild
         "BOOT_FIRMWARE_LOADER", # Used in sysbuild for MCUboot configuration
         "BOOT_FIRMWARE_LOADER_BOOT_MODE", # Used in sysbuild for MCUboot configuration


### PR DESCRIPTION
`BOOT_ENCRYPT_ALG_AES_128` and `BOOT_ENCRYPT_ALG_AES_256` are used in `share/sysbuild/image_configurations/BOOTLOADER_image_default.cmake` 
They were first introduced [here](https://github.com/zephyrproject-rtos/zephyr/commit/9a1fe301993471ac8aa13d75fa675ed4683f1bd0#diff-eef03e81eba655fbb549ce89098f1c2c4fe45146e3c3e6b07572664dffc7fb99).