### PR TITLE
bluetooth: Simplify le_adv_update by using a bt_ad wrapper

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -747,27 +747,24 @@ static int le_adv_update(struct bt_le_ext_adv *adv,
 			 const struct bt_data *sd, size_t sd_len,
 			 bool ext_adv, bool scannable)
 {
-	struct bt_ad d[2] = {};
-	size_t d_len;
 	int err;
+	struct bt_ad wrapper;
 
 	if (!(ext_adv && scannable)) {
-		d_len = 1;
-		d[0].data = ad;
-		d[0].len = ad_len;
+		wrapper.data = ad;
+		wrapper.len = ad_len;
 
-		err = set_ad(adv, d, d_len);
+		err = set_ad(adv, &wrapper, 1);
 		if (err) {
 			return err;
 		}
 	}
 
 	if (scannable) {
-		d_len = 1;
-		d[0].data = sd;
-		d[0].len = sd_len;
+		wrapper.data = sd;
+		wrapper.len = sd_len;
 
-		err = set_sd(adv, d, d_len);
+		err = set_sd(adv, &wrapper, 1);
 		if (err) {
 			return err;
 		}


### PR DESCRIPTION
Closes #94549

Removed vestigial d and d_len variables from le_adv_update()
and replaced them with a single bt_ad wrapper. This simplifies
the function while maintaining identical functionality.



