### PR TITLE
soc: silabs: Silabs S2 Power Manager improvements

### DIFF
--- a/soc/silabs/Kconfig
+++ b/soc/silabs/Kconfig
@@ -153,6 +153,13 @@ config SOC_GECKO_PM_BACKEND_EMU
 	help
 	  Implement PM using direct calls to EMU driver in emlib
 
+config SOC_SILABS_PM_LOW_INTERRUPT_LATENCY
+	bool "Low interrupt latency mode"
+	default y if SOC_GECKO_PM_BACKEND_PMGR
+	help
+	  Enabling low interrupt latency allows interrupts to be executed
+	  before the high frequency clock is restored after sleep.
+
 endif # PM
 
 config SOC_GECKO_EMU_DCDC

--- a/soc/silabs/common/soc_power_pmgr.c
+++ b/soc/silabs/common/soc_power_pmgr.c
@@ -87,6 +87,7 @@ bool sl_power_manager_is_ok_to_sleep(void)
 	return true;
 }
 
+#if !defined(CONFIG_SOC_SILABS_PM_LOW_INTERRUPT_LATENCY)
 /* This function is called by sl_power_manager_sleep() right after it was woken up from WFI. */
 void sli_power_manager_on_wakeup(void)
 {
@@ -98,6 +99,7 @@ void sli_power_manager_on_wakeup(void)
 	sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM1);
 	sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
 }
+#endif
 
 /**
  * Some SiLabs blobs, such as RAIL, call directly into sl_power_manager, and

--- a/subsys/pm/policy/policy_default.c
+++ b/subsys/pm/policy/policy_default.c
@@ -25,10 +25,13 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 
 	for (uint32_t i = 0; i < num_cpu_states; i++) {
 		const struct pm_state_info *state = &cpu_states[i];
-		uint32_t min_residency_ticks;
+		uint32_t min_residency_ticks = 0;
+		uint32_t min_residency_us = state->min_residency_us + state->exit_latency_us;
 
-		min_residency_ticks =
-			k_us_to_ticks_ceil32(state->min_residency_us + state->exit_latency_us);
+		/* If the input is zero, avoid 64-bit conversion from microseconds to ticks. */
+		if (min_residency_us > 0) {
+			min_residency_ticks = k_us_to_ticks_ceil32(min_residency_us);
+		}
 
 		if (ticks < min_residency_ticks) {
 			/* If current state has higher residency then use the previous state; */

--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - hal
     - name: hal_silabs
-      revision: 0b58229357750b8bd0ce52e514c54ace6abcfeba
+      revision: 54cdbdb79c1ccd99b62a93d3af6caff79ab66197
       path: modules/hal/silabs
       groups:
         - hal


### PR DESCRIPTION
The goal of this PR is to improve the power manager integration in Zephyr for Silabs S2 devices.
Here is what is done:
- Skip min_residency_ticks calculation if the input is 0
- Reduce interruption latency
- Clearing the SLEEPBIT bit to avoid going to EM2 by mistake