### PR TITLE
include: video: group video-controls.h under main video Doxygen group

### DIFF
--- a/include/zephyr/drivers/video-controls.h
+++ b/include/zephyr/drivers/video-controls.h
@@ -17,7 +17,7 @@
 /**
  * @brief Video controls
  * @defgroup video_controls Video Controls
- * @ingroup io_interfaces
+ * @ingroup video_interface
  *
  * The Video control IDs (CIDs) are introduced with the same name as
  * Linux V4L2 subsystem and under the same class. This facilitates


### PR DESCRIPTION
Ensure the "Video Controls" do not show up as a top level device API but are rather folded into the main video Doxygen group.