### PR TITLE
include: drivers: consolidate emulation headers

### DIFF
--- a/include/zephyr/drivers/adc/adc_emul.h
+++ b/include/zephyr/drivers/adc/adc_emul.h
@@ -22,6 +22,7 @@ extern "C" {
 /**
  * @brief Emulated ADC backend API
  * @defgroup adc_emul Emulated ADC
+ * @ingroup io_emulators
  * @ingroup adc_interface
  * @{
  *

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -10,7 +10,7 @@
 
 /**
  * @brief Emulators used to test drivers and higher-level code that uses them
- * @defgroup io_emulators Emulator interface
+ * @defgroup io_emulators Emulator interfaces
  * @ingroup testing
  * @{
  */

--- a/include/zephyr/drivers/emul_bbram.h
+++ b/include/zephyr/drivers/emul_bbram.h
@@ -13,7 +13,8 @@
 /**
  * @brief BBRAM emulator backend API
  * @defgroup bbram_emulator_backend BBRAM emulator backend API
- * @ingroup io_interfaces
+ * @ingroup io_emulators
+ * @ingroup bbram_interface
  * @{
  */
 

--- a/include/zephyr/drivers/emul_fuel_gauge.h
+++ b/include/zephyr/drivers/emul_fuel_gauge.h
@@ -23,7 +23,8 @@ extern "C" {
 /**
  * @brief Fuel gauge backend emulator APIs
  * @defgroup fuel_gauge_emulator_backend Fuel gauge backend emulator APIs
- * @ingroup io_interfaces
+ * @ingroup io_emulators
+ * @ingroup fuel_gauge_interface
  * @{
  */
 

--- a/include/zephyr/drivers/emul_sensor.h
+++ b/include/zephyr/drivers/emul_sensor.h
@@ -12,7 +12,8 @@
 /**
  * @brief Sensor emulator backend API
  * @defgroup sensor_emulator_backend Sensor emulator backend API
- * @ingroup io_interfaces
+ * @ingroup io_emulators
+ * @ingroup sensor_interface
  * @{
  */
 

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -23,6 +23,7 @@
  * @brief eSPI Emulation Interface
  * @defgroup espi_emul_interface eSPI Emulation Interface
  * @ingroup io_emulators
+ * @ingroup espi_interface
  * @{
  */
 

--- a/include/zephyr/drivers/gpio/gpio_emul.h
+++ b/include/zephyr/drivers/gpio/gpio_emul.h
@@ -22,6 +22,7 @@ extern "C" {
 /**
  * @brief Emulated GPIO backend API
  * @defgroup gpio_emul Emulated GPIO
+ * @ingroup io_emulators
  * @ingroup gpio_interface
  * @{
  *

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -23,6 +23,7 @@
  * @brief I2C Emulation Interface
  * @defgroup i2c_emul_interface I2C Emulation Interface
  * @ingroup io_emulators
+ * @ingroup i2c_interface
  * @{
  */
 

--- a/include/zephyr/drivers/mspi_emul.h
+++ b/include/zephyr/drivers/mspi_emul.h
@@ -23,6 +23,7 @@
  * @brief MSPI Emulation Interface
  * @defgroup mspi_emul_interface MSPI Emulation Interface
  * @ingroup io_emulators
+ * @ingroup mspi_interface
  * @{
  */
 

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -23,6 +23,7 @@
  * @brief SPI Emulation Interface
  * @defgroup spi_emul_interface SPI Emulation Interface
  * @ingroup io_emulators
+ * @ingroup spi_interface
  * @{
  */
 

--- a/include/zephyr/drivers/uart_emul.h
+++ b/include/zephyr/drivers/uart_emul.h
@@ -23,6 +23,7 @@
  * @brief UART Emulation Interface
  * @defgroup uart_emul_interface UART Emulation Interface
  * @ingroup io_emulators
+ * @ingroup uart_interface
  * @{
  */
 

--- a/include/zephyr/drivers/usb/emul_bc12.h
+++ b/include/zephyr/drivers/usb/emul_bc12.h
@@ -22,7 +22,8 @@ extern "C" {
 /**
  * @brief BC1.2 backend emulator APIs
  * @defgroup b12_emulator_backend BC1.2 backed emulator APIs
- * @ingroup io_interfaces
+ * @ingroup b12_interface
+ * @ingroup io_emulators
  * @{
  */
 


### PR DESCRIPTION
Do not clutter the "Device Drivers" documentation with emulation headers.
Ensure each emulated device API appears both in the device group as well as "Emulator interfaces" (e.g. bbram_emul is showing up in both BBRAM docs as well as Emulator Interfaces docs)

https://builds.zephyrproject.io/zephyr/pr/94675/docs/doxygen/html/group__io__emulators.html

See how something like [BBRAM emulator](https://builds.zephyrproject.io/zephyr/pr/94675/docs/doxygen/html/group__bbram__emulator__backend.html) now shows up as belonging to two different groups

<img width="568" height="194" alt="image" src="https://github.com/user-attachments/assets/1e3eeb8b-aaf1-400e-8f1e-d3cabd16f265" />
