### PR TITLE
jwt: fix signature length for JWT_SIGN_RSA_LEGACY

### DIFF
--- a/subsys/jwt/jwt.c
+++ b/subsys/jwt/jwt.c
@@ -14,7 +14,7 @@
 
 #include "jwt.h"
 
-#if defined(CONFIG_JWT_SIGN_RSA_PSA) || defined(JWT_SIGN_RSA_LEGACY)
+#if defined(CONFIG_JWT_SIGN_RSA_PSA) || defined(CONFIG_JWT_SIGN_RSA_LEGACY)
 #define JWT_SIGNATURE_LEN 256
 #else /* CONFIG_JWT_SIGN_ECDSA_PSA */
 #define JWT_SIGNATURE_LEN 64


### PR DESCRIPTION
Fix the reference to the Kconfig item.

Fixes #73329

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
