### PR TITLE
drivers: flash: esp32: Add async operations

### DIFF
--- a/drivers/flash/Kconfig.esp32
+++ b/drivers/flash/Kconfig.esp32
@@ -15,3 +15,34 @@ config MPU_ALLOW_FLASH_WRITE
 	bool "Add MPU access to write to flash"
 	help
 	  Enable this to allow MPU RWX access to flash memory
+
+if SOC_FLASH_ESP32
+
+config ESP_FLASH_ASYNC
+	bool "Use asynchronous work thread to execute the flash access operations"
+	depends on MULTITHREADING && !MCUBOOT
+	help
+	  Enabling this makes the flash access operations deferred to the work thread.
+	  Meaning every flash read or write would be postponed and executed when available.
+
+config ESP_FLASH_ASYNC_WORK
+	bool "Use dedicated work thread to perform the work tasks"
+	depends on ESP_FLASH_ASYNC
+	help
+	  Use dedicated work thread to perform the workqueue tasks with flash asynchronous operations.
+
+config ESP_FLASH_ASYNC_WORK_STACK_SIZE
+	int "Stack size for dedicated work thread"
+	depends on ESP_FLASH_ASYNC_WORK
+	default 1024
+	help
+	  Define stack size for a dedicated work thread processing workqueue.
+
+config ESP_FLASH_ASYNC_WORK_PRIORITY
+	int "Thread priority for dedicated work thread"
+	depends on ESP_FLASH_ASYNC_WORK
+	default 5
+	help
+	  Define thread priority for a dedicated work thread processing workqueue.
+
+endif # SOC_FLASH_ESP32


### PR DESCRIPTION
Since flash access can be restricted in cases when flash could be invalidated during the operation. Therefore, accessing a flash memory from the code running from the PSRAM could lead to an exception. This work implements asynchronous operations to allow flash access only from the valid runtime.