### PR TITLE
samples: Fix confusing openamp sample doc

### DIFF
--- a/samples/subsys/ipc/openamp/README.rst
+++ b/samples/subsys/ipc/openamp/README.rst
@@ -9,8 +9,13 @@ Overview
 
 This application demonstrates how to use OpenAMP with Zephyr. It is designed to
 demonstrate how to integrate OpenAMP with Zephyr both from a build perspective
-and code. Note that the remote and primary core images can be flashed
+and code.
+
+Note that the remote and primary core images can be flashed
 independently, but sysbuild must be used in order to build the images.
+
+Both cores must be flashed prior to using ``west debug`` on either core.
+It is suggested to use ``west flash`` to do this as shown below.
 
 Building the application for lpcxpresso54114_m4
 ***********************************************
@@ -18,7 +23,7 @@ Building the application for lpcxpresso54114_m4
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/openamp
    :board: lpcxpresso54114/lpc54114/m4
-   :goals: debug
+   :goals: flash
    :west-args: --sysbuild
 
 Building the application for lpcxpresso55s69/lpc55s69/cpu0
@@ -27,7 +32,7 @@ Building the application for lpcxpresso55s69/lpc55s69/cpu0
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/openamp
    :board: lpcxpresso55s69/lpc55s69/cpu0
-   :goals: debug
+   :goals: flash
    :west-args: --sysbuild
 
 Building the application for mps2/an521/cpu0
@@ -36,7 +41,7 @@ Building the application for mps2/an521/cpu0
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/openamp
    :board: mps2/an521/cpu0
-   :goals: debug
+   :goals: flash
    :west-args: --sysbuild
 
 Building the application for v2m_musca_b1/musca_b1
@@ -45,7 +50,7 @@ Building the application for v2m_musca_b1/musca_b1
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/openamp
    :board: v2m_musca_b1/musca_b1
-   :goals: debug
+   :goals: flash
    :west-args: --sysbuild
 
 Building the application for mimxrt1170_evk_cm7
@@ -54,7 +59,7 @@ Building the application for mimxrt1170_evk_cm7
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/openamp
    :board: mimxrt1170_evk_cm7
-   :goals: debug
+   :goals: flash
    :west-args: --sysbuild
 
 Building the application for frdm_mcxn947/mcxn947/cpu0
@@ -63,7 +68,7 @@ Building the application for frdm_mcxn947/mcxn947/cpu0
 .. zephyr-app-commands::
    :zephyr-app: samples/subsys/ipc/openamp
    :board: frdm_mcxn947/mcxn947/cpu0
-   :goals: debug
+   :goals: flash
    :west-args: --sysbuild
 
 Open a serial terminal (minicom, putty, etc.) and connect the board with the


### PR DESCRIPTION
A lot of users seem to be confused by this sample when they try to do west debug. This is because Zephyr currently does not support flashing all the cores from a sysbuild automatically when doing a west debug command. So west flash needs to be done prior to a west debug command. The README previously actually said the step by step instructions are to do the build, then immediately west debug, which would cause faulting and crashing, so change the instructions goal to be a flash, and put a note about needing to flash before debugging.