### PR TITLE
drivers: counter: sam_tc: Big fix for alarm 1

### DIFF
--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -356,6 +356,7 @@ static DEVICE_API(counter, counter_sam_driver_api) = {
 
 #define COUNTER_SAM_TC_CMR(n)	\
 		 (TC_CMR_TCCLKS(DT_INST_PROP_OR(n, clk, 0)) \
+		| TC_CMR_WAVEFORM_EEVT_XC0 \
 		| TC_CMR_WAVEFORM_WAVSEL_UP_RC \
 		| TC_CMR_WAVE)
 


### PR DESCRIPTION
Issue: the alarm 1 do not generate interrupt
There are three compare registers in a SAM TC channel: 
RA --> alarm 0
RB --> alarm 1
RC --> top_value
By default the RB/TOIB was configured as an input and no longer generates interrupt.
Set the direction of TIOB to output for alarm 1 interrupt.

Fixes zephyrproject-rtos/zephyr#85018

This is the second attempt after the fixes to SAM4L been applied in https://github.com/zephyrproject-rtos/hal_atmel/pull/49.