### PR TITLE
logging: Disable used but marked unused warning

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -289,6 +289,7 @@ static inline char z_log_minimal_level_to_char(int level)
  * @param ... String with arguments.
  */
 #define Z_LOG2(_level, _inst, _source, ...)                                                        \
+	TOOLCHAIN_DISABLE_CLANG_WARNING(TOOLCHAIN_WARNING_USED_BUT_MARKED_UNUSED)                  \
 	do {                                                                                       \
 		if (!Z_LOG_LEVEL_ALL_CHECK(_level, _inst, _source)) {                              \
 			break;                                                                     \
@@ -313,7 +314,8 @@ static inline char z_log_minimal_level_to_char(int level)
 			/* evaluated once when log is enabled.*/                                   \
 			z_log_printf_arg_checker(__VA_ARGS__);                                     \
 		}                                                                                  \
-	} while (false)
+	} while (false)                                                                            \
+	TOOLCHAIN_ENABLE_CLANG_WARNING(TOOLCHAIN_WARNING_USED_BUT_MARKED_UNUSED)
 
 #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
 #define Z_LOG_INSTANCE(_level, _inst, ...) Z_LOG2(_level, 1, Z_LOG_INST(_inst), __VA_ARGS__)
@@ -342,6 +344,7 @@ static inline char z_log_minimal_level_to_char(int level)
  * @param ... String.
  */
 #define Z_LOG_HEXDUMP2(_level, _inst, _source, _data, _len, ...)                                   \
+	TOOLCHAIN_DISABLE_CLANG_WARNING(TOOLCHAIN_WARNING_USED_BUT_MARKED_UNUSED)                  \
 	do {                                                                                       \
 		if (!Z_LOG_LEVEL_ALL_CHECK(_level, _inst, _source)) {                              \
 			break;                                                                     \
@@ -360,7 +363,8 @@ static inline char z_log_minimal_level_to_char(int level)
 			  (COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__), \
 				  ("%s", __VA_ARGS__), (__VA_ARGS__)))));   \
 		(void)_mode;                                                                       \
-	} while (false)
+	} while (false)                                                                            \
+	TOOLCHAIN_ENABLE_CLANG_WARNING(TOOLCHAIN_WARNING_USED_BUT_MARKED_UNUSED)
 
 #define Z_LOG_HEXDUMP(_level, _data, _length, ...)                                                 \
 	Z_LOG_HEXDUMP2(_level, 0, Z_LOG_CURRENT_DATA(), _data, _length, __VA_ARGS__)

--- a/include/zephyr/toolchain/llvm.h
+++ b/include/zephyr/toolchain/llvm.h
@@ -34,6 +34,7 @@
 
 #define TOOLCHAIN_WARNING_SIZEOF_ARRAY_DECAY            "-Wsizeof-array-decay"
 #define TOOLCHAIN_WARNING_UNNEEDED_INTERNAL_DECLARATION "-Wunneeded-internal-declaration"
+#define TOOLCHAIN_WARNING_USED_BUT_MARKED_UNUSED        "-Wused-but-marked-unused"
 
 #define TOOLCHAIN_DISABLE_CLANG_WARNING(warning) _TOOLCHAIN_DISABLE_WARNING(clang, warning)
 #define TOOLCHAIN_ENABLE_CLANG_WARNING(warning)  _TOOLCHAIN_ENABLE_WARNING(clang, warning)


### PR DESCRIPTION
Clang's `-Wused-but-marked-unused` warns when variables marked as `__unused` are actually used. Logging macros can trigger this warning depending on CONFIG_LOG_* settings, leading to noisy builds.

```
app.c:971:5: warning: '__log_current_dynamic_data' was marked unused but was used [-Wused-but-marked-unused]
zephyr/include/zephyr/logging/log.h:79:25: note: expanded from macro 'LOG_DBG'
   79 | #define LOG_DBG(...)    Z_LOG(LOG_LEVEL_DBG, __VA_ARGS__)
      |                         ^
zephyr/include/zephyr/logging/log_core.h:318:62: note: expanded from macro 'Z_LOG'
  318 | #define Z_LOG(_level, ...)                 Z_LOG2(_level, 0, Z_LOG_CURRENT_DATA(), __VA_ARGS__)
      |                                                              ^
/zephyr/include/zephyr/logging/log_core.h:211:5: note: expanded from macro 'Z_LOG_CURRENT_DATA'
  211 |                         (__log_current_dynamic_data), (__log_current_const_data))
...
...
```
This change suppresses those warnings, allowing the warning flag to be used alongside logging functionality.