### PR TITLE
tests: ram_context_for_isr: exclude frdm_k32l2b3/k32l2b31a.

### DIFF
--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -20,3 +20,4 @@ tests:
       - frdm_kw41z/mkw41z4
       - frdm_kl25z/mkl25z4
       - mcx_n9xx_evk/mcxn947/cpu0/qspi
+      - frdm_k32l2b3/k32l2b31a


### PR DESCRIPTION
The assigned fakedriver interrupt number is 31 which is the PORTC one in frdm_k32l2b3/k32l2b31a, not free.