### PR TITLE
spi: rtio: fix using rx_bufs entries for tx_buf

### DIFF
--- a/drivers/spi/spi_rtio.c
+++ b/drivers/spi/spi_rtio.c
@@ -255,8 +255,8 @@ int spi_rtio_copy(struct rtio *r,
 					    NULL);
 			tx++;
 			if (tx < tx_count) {
-				tx_buf = rx_bufs->buffers[rx].buf;
-				tx_len = rx_bufs->buffers[rx].len;
+				tx_buf = tx_bufs->buffers[tx].buf;
+				tx_len = tx_bufs->buffers[tx].len;
 			} else {
 				tx_buf = NULL;
 				tx_len = 0;


### PR DESCRIPTION
Within spi_rtio_copy there'd be a case where the tx_buf pointer would mistakenly get assigned the address of an rx buffer. Specifically this would happen in the case where there are no rx buffers provided, and as such this would lead to pontential nullptr dereferences.

Correct the mistake to let tx_buf correctly point to the provided tx buffers.