### PR TITLE
Bluetooth: Classic: L2CAP: Reset rx.cid when channel is deleted

### DIFF
--- a/subsys/bluetooth/host/classic/l2cap_br.c
+++ b/subsys/bluetooth/host/classic/l2cap_br.c
@@ -2608,6 +2608,9 @@ destroy:
 	/* Reset internal members of common channel */
 	bt_l2cap_br_chan_set_state(chan, BT_L2CAP_DISCONNECTED);
 	BR_CHAN(chan)->psm = 0U;
+	if (L2CAP_BR_CID_IS_DYN(BR_CHAN(chan)->rx.cid)) {
+		BR_CHAN(chan)->rx.cid = 0U;
+	}
 #endif
 	if (chan->destroy) {
 		chan->destroy(chan);


### PR DESCRIPTION
Rootcause: the dynamic L2CAP channel rx.cid is not reset, it will be intercepted by the judgment condition of the fixed channel, directly using the last alloced cid may cause cid conflict.

For example, the first BR L2CAP channel is an SDP service, and the chan requested from bt_sdp_pool occupies cid 0x40. When the sdp connection is disconnected, it will be removed from the conn->channels list, but the bt_sdp_pool[0] cid field is not cleanup. A new service request may be A2DP or HFP, which will request cid 0x40. When the next sdp service request is received, the chan rx.cid received will not be 0, and this chan will be used directly instead of dynamically requesting a new cid, which will cause a cid conflict.