### PR TITLE
tests: application_development: ram_context_for_isr: fix builds against platforms contraint

### DIFF
--- a/tests/application_development/ram_context_for_isr/boards/nucleo_c031c6.overlay
+++ b/tests/application_development/ram_context_for_isr/boards/nucleo_c031c6.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+&fakedriver {
+	interrupt-parent = <&nvic>;
+	interrupts = <18 1>;
+};

--- a/tests/application_development/ram_context_for_isr/boards/nucleo_c071rb.overlay
+++ b/tests/application_development/ram_context_for_isr/boards/nucleo_c071rb.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+&fakedriver {
+	interrupt-parent = <&nvic>;
+	interrupts = <18 1>;
+};

--- a/tests/application_development/ram_context_for_isr/boards/nucleo_c092rc.overlay
+++ b/tests/application_development/ram_context_for_isr/boards/nucleo_c092rc.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+&fakedriver {
+	interrupt-parent = <&nvic>;
+	interrupts = <18 1>;
+};

--- a/tests/application_development/ram_context_for_isr/boards/qemu_cortex_m3.overlay
+++ b/tests/application_development/ram_context_for_isr/boards/qemu_cortex_m3.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../app.overlay"
+
+&fakedriver {
+	interrupt-parent = <&nvic>;
+	interrupts = <42 1>;
+};

--- a/tests/application_development/ram_context_for_isr/include/fake_driver.h
+++ b/tests/application_development/ram_context_for_isr/include/fake_driver.h
@@ -11,11 +11,12 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_BOARD_QEMU_CORTEX_M3
+#define DT_DRV_COMPAT fakedriver
 
-#define TEST_IRQ_NUM  42
-#define TEST_IRQ_PRIO 1
-
+#if DT_INST_NODE_HAS_PROP(0, interrupts)
+/* Platforms with specific needs can provide IRQn and priority via DT */
+#define TEST_IRQ_NUM	DT_INST_IRQN(0)
+#define TEST_IRQ_PRIO	DT_INST_IRQ(0, priority)
 #elif defined(CONFIG_GIC)
 /*
  * For the platforms that use the ARM GIC, use the SGI (software generated
@@ -23,7 +24,6 @@ extern "C" {
  */
 #define TEST_IRQ_NUM  14
 #define TEST_IRQ_PRIO IRQ_DEFAULT_PRIORITY
-
 #else
 /* For all the other platforms, use the last available IRQ line for testing. */
 #define TEST_IRQ_NUM  (CONFIG_NUM_IRQS - 1)

--- a/tests/application_development/ram_context_for_isr/src/fake_driver.c
+++ b/tests/application_development/ram_context_for_isr/src/fake_driver.c
@@ -8,8 +8,6 @@
 #include <zephyr/irq.h>
 #include "fake_driver.h"
 
-#define DT_DRV_COMPAT fakedriver
-
 static void fake_driver_isr(const void *arg)
 {
 	const struct device *dev = (const struct device *)arg;

--- a/tests/application_development/ram_context_for_isr/testcase.yaml
+++ b/tests/application_development/ram_context_for_isr/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags: linker
   arch_allow: arm
+  min_ram: 7
   filter: CONFIG_CPU_CORTEX_M_HAS_VTOR
 tests:
   application_development.ram_context_for_isr:


### PR DESCRIPTION
**tests/application_development/ram_context_for_isr** default uses the last NVIC line for the test but for some STM32C0x SoCs it's an UART interrupt already allocated by the platform. Change that to another NVIC line for this series.

**tests/application_development/ram_context_for_isr** requires a bit more than 6kByte of SRAM so exclude platforms that have less than 7kByte of SRAMs.