### PR TITLE
drivers: clock_control: nrf: Fix missing clock started callback

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -442,13 +442,6 @@ void z_nrf_clock_bt_ctlr_hf_release(void)
 	hfclk_users &= ~HF_USER_BT;
 	/* Skip stopping if generic is still requesting the clock. */
 	if (!(hfclk_users & HF_USER_GENERIC)) {
-		struct nrf_clock_control_sub_data *sub_data =
-			get_sub_data(CLOCK_DEVICE, CLOCK_CONTROL_NRF_TYPE_HFCLK);
-
-		/* State needs to be set to OFF as BT API does not call stop API which
-		 * normally setting this state.
-		 */
-		sub_data->flags = CLOCK_CONTROL_STATUS_OFF;
 		hfclk_stop();
 	}
 

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/testcase.yaml
@@ -7,5 +7,6 @@ tests:
       - nrf51dk/nrf51822
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
+      - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms:
-      - nrf51dk/nrf51822
+      - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
 804e502484 fix got reverted as it introduced a bug where callback with HFCLK started indication was not called because state is not correctly indicated. BT-dedicated API does not set state and does not expect to get the callback when HFCLK is started. 804e502484 was intended to fix the bug that was visible on nrf54lx. It was not visible on nrf52 because of a errata workaround which was calling HFCLK started callback only when state was set to STARTING and that was not the case when BT-dedicated API was used. Applying this `workaround` approach to all cases.

Additionally, extended test to reproduce a scenario reported by #91895.

Fixes #94693.
