### PR TITLE
boards: st: nucleo_c031c6: use asynchronous clock for adc

### DIFF
--- a/boards/st/nucleo_c031c6/nucleo_c031c6.dts
+++ b/boards/st/nucleo_c031c6/nucleo_c031c6.dts
@@ -117,10 +117,12 @@
 };
 
 &adc1 {
+	clocks = <&rcc STM32_CLOCK(APB1_2, 20)>,
+		 <&rcc STM32_SRC_SYSCLK ADC_SEL(0)>;
 	pinctrl-0 = <&adc1_in0_pa0 &adc1_in1_pa1 &adc1_in4_pa4>;
 	pinctrl-names = "default";
-	st,adc-clock-source = "SYNC";
-	st,adc-prescaler = <4>;
+	st,adc-clock-source = "ASYNC";
+	st,adc-prescaler = <32>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Use an asynchronous clock with an increased prescaler value for the ADC of the Nucleo STM32N6 so that the adc_sequence sample runs correctly.

Fixes #94395