### PR TITLE
include: drivers: misc: Add doxygen docs for NXP FlexIO driver

### DIFF
--- a/include/zephyr/drivers/misc/nxp_flexio/nxp_flexio.h
+++ b/include/zephyr/drivers/misc/nxp_flexio/nxp_flexio.h
@@ -4,20 +4,44 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for NXP FlexIO driver
+ * @ingroup nxp_flexio_interface
+ */
+
 #ifndef ZEPHYR_DRIVERS_MISC_NXP_FLEXIO_NXP_FLEXIO_H_
 #define ZEPHYR_DRIVERS_MISC_NXP_FLEXIO_NXP_FLEXIO_H_
+
+/**
+ * @brief NXP FlexIO driver APIs
+ * @defgroup nxp_flexio_interface NXP FlexIO driver APIs
+ * @ingroup misc_interfaces
+ *
+ * @{
+ */
 
 #include <zephyr/device.h>
 
 /**
- * @struct nxp_flexio_child_res
- * @brief Structure containing information about the required
- * resources for a FlexIO child.
+ * @brief Structure containing information about the required resources for a FlexIO child.
  */
 struct nxp_flexio_child_res {
+	/** Output array where assigned shifter indices are stored.
+	 *
+	 * Must point to an array with at least @ref shifter_count entries. Values are 0-based
+	 * hardware indices valid for the bound FlexIO.
+	 */
 	uint8_t *shifter_index;
+	/** Number of shifter indices required by the child. */
 	uint8_t shifter_count;
+	/** Output array where assigned timer indices are stored.
+	 *
+	 * Must point to an array with at least @ref timer_count entries.  Values are 0-based
+	 * hardware indices valid for the bound FlexIO.
+	 */
 	uint8_t *timer_index;
+	/** Number of timer indices required by the child. */
 	uint8_t timer_count;
 };
 
@@ -25,7 +49,10 @@ struct nxp_flexio_child_res {
  * @typedef nxp_flexio_child_isr_t
  * @brief Callback API to inform API user that FlexIO triggered interrupt
  *
- * This callback is called from IRQ context.
+ * The controller calls this from IRQ context whenever one of the child's mapped shifters or timers
+ * has a pending and enabled interrupt.
+ *
+ * @param user_data Opaque pointer provided at attachment time.
  */
 typedef int (*nxp_flexio_child_isr_t)(void *user_data);
 
@@ -34,8 +61,13 @@ typedef int (*nxp_flexio_child_isr_t)(void *user_data);
  * @brief Structure containing the required child data for FlexIO
  */
 struct nxp_flexio_child {
+	/** ISR called from the FlexIO controller's IRQ handler.
+	 * May be @c NULL if the child does not require IRQ notifications.
+	 */
 	nxp_flexio_child_isr_t isr;
+	/** Opaque pointer passed to @ref isr function when it is invoked. */
 	void *user_data;
+	/** Resource requirements and output indices filled by nxp_flexio_child_attach(). */
 	struct nxp_flexio_child_res res;
 };
 
@@ -84,5 +116,9 @@ int nxp_flexio_get_rate(const struct device *dev, uint32_t *rate);
  */
 int nxp_flexio_child_attach(const struct device *dev,
 	const struct nxp_flexio_child *child);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_DRIVERS_MISC_NXP_FLEXIO_NXP_FLEXIO_H_ */


### PR DESCRIPTION
Add missing doxygen docs for the NXP FlexIO driver and "mount" into the Misc. drivers doxygen group.