### PR TITLE
include: drivers: misc: mount Raspberry Pi Pico PIO driver in doc tree

### DIFF
--- a/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
+++ b/include/zephyr/drivers/misc/pio_rpi_pico/pio_rpi_pico.h
@@ -6,8 +6,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Header file for Raspberry Pi Pico PIO driver
+ * @ingroup pio_rpi_pico_interface
+ */
+
 #ifndef ZEPHYR_DRIVERS_MISC_PIO_PICO_RPI_PIO_PICO_RPI_H_
 #define ZEPHYR_DRIVERS_MISC_PIO_PICO_RPI_PIO_PICO_RPI_H_
+
+/**
+ * @brief Raspberry Pi Pico PIO driver APIs
+ * @defgroup pio_rpi_pico_interface Raspberry Pi Pico PIO Driver APIs
+ * @ingroup misc_interfaces
+ *
+ * @{
+ */
 
 #include <zephyr/devicetree/gpio.h>
 
@@ -145,5 +159,9 @@ PIO pio_rpi_pico_get_pio(const struct device *dev);
  * @retval -EBUSY if no state machines were available
  */
 int pio_rpi_pico_allocate_sm(const struct device *dev, size_t *sm);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_DRIVERS_MISC_PIO_PICO_RPI_PIO_PICO_RPI_H_ */


### PR DESCRIPTION
Mount the Raspberry Pi Pico PIO driver into the Misc. drivers doxygen group.