### PR TITLE
dts: st: use dma defines to describe sai dma configs

### DIFF
--- a/dts/arm/st/h5/stm32h5.dtsi
+++ b/dts/arm/st/h5/stm32h5.dtsi
@@ -641,7 +641,8 @@
 			reg = <0x40015404 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 1 53 0>;
+			dmas = <&gpdma1 1 53 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+				STM32_DMA_16BITS)>;
 			status = "disabled";
 		};
 
@@ -652,7 +653,8 @@
 			reg = <0x40015424 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21)>,
 				 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 0 54 0>;
+			dmas = <&gpdma1 0 54 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+				STM32_DMA_16BITS)>;
 			status = "disabled";
 		};
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -478,7 +478,8 @@
 			reg = <0x40015404 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21U)>,
 					 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 1 36 0>;
+			dmas = <&gpdma1 1 36 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+				STM32_DMA_16BITS)>;
 			status = "disabled";
 		};
 
@@ -489,7 +490,8 @@
 			reg = <0x40015424 0x20>;
 			clocks = <&rcc STM32_CLOCK(APB2, 21U)>,
 					 <&rcc STM32_SRC_PLL2_P SAI1_SEL(0)>;
-			dmas = <&gpdma1 0 37 0>;
+			dmas = <&gpdma1 0 37 (STM32_DMA_MODE_NORMAL | STM32_DMA_PRIORITY_HIGH |
+				STM32_DMA_16BITS)>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Use DMA defines to describe SAI DMA configuration on STM32U5xx & STM32H5xx series
Although the DMA defines are not used to configure the SAI DMA, they give an overview over its configuration