### PR TITLE
bluetooth: hci: Use 'bus_' prefix in bt-hci-bus property strings

### DIFF
--- a/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/ambiq,bt-hci-spi.yaml
@@ -37,4 +37,4 @@ properties:
     default: "ambiq hci"
 
   bt-hci-bus:
-    default: "spi"
+    default: "bus_spi"

--- a/dts/bindings/bluetooth/bt-hci.yaml
+++ b/dts/bindings/bluetooth/bt-hci.yaml
@@ -10,19 +10,19 @@ properties:
     type: string
     description: Bus of the transport
     enum:
-      - "virtual"
-      - "usb"
-      - "pccard"
-      - "uart"
-      - "rs232"
-      - "pci"
-      - "sdio"
-      - "spi"
-      - "i2c"
-      - "smd"
-      - "virtio"
-      - "ipm"    # Deprecated. "ipc" should be used instead.
-      - "ipc"
+      - "bus_virtual"
+      - "bus_usb"
+      - "bus_pccard"
+      - "bus_uart"
+      - "bus_rs232"
+      - "bus_pci"
+      - "bus_sdio"
+      - "bus_spi"
+      - "bus_i2c"
+      - "bus_smd"
+      - "bus_virtio"
+      - "bus_ipm"    # Deprecated. "ipc" should be used instead.
+      - "bus_ipc"
   bt-hci-quirks:
     type: string-array
     description: HCI device quirks

--- a/dts/bindings/bluetooth/espressif,esp32-bt-hci.yaml
+++ b/dts/bindings/bluetooth/espressif,esp32-bt-hci.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "BT ESP32"
   bt-hci-bus:
-    default: "ipm"
+    default: "bus_ipm"
   bt-hci-quirks:
     default: ["no-auto-dle"]

--- a/dts/bindings/bluetooth/infineon,cat1-bless-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cat1-bless-hci.yaml
@@ -14,7 +14,7 @@ properties:
   bt-hci-name:
     default: "PSOC 6 BLESS"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"
   bt-hci-quirks:
     default: ["no-reset"]
   interrupts:

--- a/dts/bindings/bluetooth/infineon,cyw208xx-hci.yaml
+++ b/dts/bindings/bluetooth/infineon,cyw208xx-hci.yaml
@@ -18,4 +18,4 @@ properties:
   bt-hci-name:
     default: "CYW208XX"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"

--- a/dts/bindings/bluetooth/nxp,hci-ble.yaml
+++ b/dts/bindings/bluetooth/nxp,hci-ble.yaml
@@ -11,4 +11,4 @@ properties:
   bt-hci-name:
     default: "BT NXP"
   bt-hci-bus:
-    default: "ipm"
+    default: "bus_ipm"

--- a/dts/bindings/bluetooth/renesas,bt-hci-da1469x.yaml
+++ b/dts/bindings/bluetooth/renesas,bt-hci-da1469x.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "BT DA1469x"
   bt-hci-bus:
-    default: "ipm"
+    default: "bus_ipm"

--- a/dts/bindings/bluetooth/silabs,bt-hci-efr32.yaml
+++ b/dts/bindings/bluetooth/silabs,bt-hci-efr32.yaml
@@ -11,6 +11,6 @@ properties:
   bt-hci-name:
     default: "efr32"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"
   bt-hci-quirks:
     default: ["no-reset"]

--- a/dts/bindings/bluetooth/silabs,siwx91x-bt-hci.yaml
+++ b/dts/bindings/bluetooth/silabs,siwx91x-bt-hci.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "sl:bt:siwx91x"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"
   bt-hci-quirks:
     default: ["no-reset"]

--- a/dts/bindings/bluetooth/st,hci-stm32wb0.yaml
+++ b/dts/bindings/bluetooth/st,hci-stm32wb0.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "HCI over RAM"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"
   bt-hci-quirks:
     default: ["no-reset"]

--- a/dts/bindings/bluetooth/st,hci-stm32wba.yaml
+++ b/dts/bindings/bluetooth/st,hci-stm32wba.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "BT IPM"
   bt-hci-bus:
-    default: "ipm"
+    default: "bus_ipm"

--- a/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
+++ b/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
@@ -14,6 +14,6 @@ properties:
   bt-hci-name:
     default: "BT IPM"
   bt-hci-bus:
-    default: "ipm"
+    default: "bus_ipm"
   bt-hci-quirks:
     default: ["no-reset"]

--- a/dts/bindings/bluetooth/zephyr,bt-hci-3wire-uart.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-3wire-uart.yaml
@@ -10,4 +10,4 @@ properties:
   bt-hci-name:
     default: "H:5"
   bt-hci-bus:
-    default: "uart"
+    default: "bus_uart"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-ipc.yaml
@@ -8,7 +8,7 @@ properties:
   bt-hci-name:
     default: "IPC"
   bt-hci-bus:
-    default: "ipc"
+    default: "bus_ipc"
   bt-hci-quirks:
     default: ["no-auto-dle"]
   bt-hci-ipc-name:

--- a/dts/bindings/bluetooth/zephyr,bt-hci-ll-sw-split.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-ll-sw-split.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "Controller"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"
   bt-hci-quirks:
     default: ["no-auto-dle"]

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -47,4 +47,4 @@ properties:
     default: "SPI"
 
   bt-hci-bus:
-    default: "spi"
+    default: "bus_spi"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-uart.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-uart.yaml
@@ -10,4 +10,4 @@ properties:
   bt-hci-name:
     default: "H:4"
   bt-hci-bus:
-    default: "uart"
+    default: "bus_uart"

--- a/dts/bindings/bluetooth/zephyr,bt-hci-userchan.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-userchan.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "HCI User Channel"
   bt-hci-bus:
-    default: "uart"
+    default: "bus_uart"

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -90,7 +90,7 @@ enum bt_hci_bus {
 #define BT_DT_HCI_NAME_INST_GET(inst) BT_DT_HCI_NAME_GET(DT_DRV_INST(inst))
 
 #define BT_DT_HCI_BUS_GET(node_id) \
-	UTIL_CAT(BT_HCI_BUS_, DT_STRING_UPPER_TOKEN_OR(node_id, bt_hci_bus, VIRTUAL))
+	UTIL_CAT(BT_HCI_, DT_STRING_UPPER_TOKEN_OR(node_id, bt_hci_bus, BUS_VIRTUAL))
 #define BT_DT_HCI_BUS_INST_GET(inst) BT_DT_HCI_BUS_GET(DT_DRV_INST(inst))
 
 typedef int (*bt_hci_recv_t)(const struct device *dev, struct net_buf *buf);

--- a/tests/bluetooth/bluetooth/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/bluetooth/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "test"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"

--- a/tests/bluetooth/hci_prop_evt/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/hci_prop_evt/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "test"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"
   bt-hci-quirks:
     default: ["no-reset"]

--- a/tests/bluetooth/hci_uart_async/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/hci_uart_async/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "Mock Controller"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"

--- a/tests/bluetooth/host_long_adv_recv/dts/bindings/zephyr,bt-hci-test.yaml
+++ b/tests/bluetooth/host_long_adv_recv/dts/bindings/zephyr,bt-hci-test.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "test"
   bt-hci-bus:
-    default: "virtual"
+    default: "bus_virtual"
   bt-hci-quirks:
     default: ["no-reset"]


### PR DESCRIPTION
Use 'bus_' prefix in bt-hci-bus property strings to avoid the
expansion of UART/SPI/etc. macros when they exist in
vendor's SoC headers.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93675