### PR TITLE
samples: rtc: add overlay for renesas smartbond

### DIFF
--- a/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
+++ b/boards/renesas/da14695_dk_usb/da14695_dk_usb.dts
@@ -91,6 +91,7 @@
 		led0 = &red_led;
 		watchdog0 = &wdog;
 		sw0 = &user_button;
+		rtc = &rtc;
 	};
 
 	sysclk: system-clock {

--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -79,6 +79,7 @@
 		led0 = &red_led;
 		watchdog0 = &wdog;
 		sw0 = &user_button;
+		rtc = &rtc;
 	};
 
 	sysclk: system-clock {

--- a/samples/drivers/rtc/socs/da14695.overlay
+++ b/samples/drivers/rtc/socs/da14695.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rtc {
+	status = "okay";
+};

--- a/samples/drivers/rtc/socs/da14699.overlay
+++ b/samples/drivers/rtc/socs/da14699.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Muhammad Waleed Badar
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rtc {
+	status = "okay";
+};


### PR DESCRIPTION
Add overlay for da14695 and da14699 soc and adds rtc alias for da1469x_dk_pro and da14695_dk_usb boards