### PR TITLE
Command for listing flash partitions

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -732,6 +732,18 @@ static int cmd_page_info(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+#if DT_HAS_COMPAT_STATUS_OKAY(fixed_partitions)
+#define PRINT_PARTITION_INFO(part) shell_print(sh, "%-15s 0x%08x %d Kb", DT_PROP(part, label), \
+					  DT_REG_ADDR(part), DT_REG_SIZE(part) / 1024);
+
+static int cmd_partitions(const struct shell *sh, size_t argc, char *argv[])
+{
+	DT_FOREACH_CHILD(DT_COMPAT_GET_ANY_STATUS_OKAY(fixed_partitions), PRINT_PARTITION_INFO);
+
+	return 0;
+}
+#endif
+
 static void device_name_get(size_t idx, struct shell_static_entry *entry);
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
@@ -773,6 +785,12 @@ SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
 	SHELL_CMD_ARG(page_info, &dsub_device_name,
 		"[<device>] <address>",
 		cmd_page_info, 2, 1),
+
+#if DT_HAS_COMPAT_STATUS_OKAY(fixed_partitions)
+	SHELL_CMD_ARG(partitions, &dsub_device_name,
+		"",
+		cmd_partitions, 0, 0),
+#endif
 
 #ifdef CONFIG_FLASH_SHELL_TEST_COMMANDS
 	SHELL_CMD_ARG(read_test, &dsub_device_name,


### PR DESCRIPTION
Adding the `flash partition` command that lists all declared partitions during runtime.

```
west build -b <board> samples/drivers/flash_shell/ -p && west flash
...
uart:~$ flash partitions
mcuboot         0x00000000 64 Kb
sys             0x00010000 64 Kb
image-0         0x00020000 1344 Kb
image-1         0x00170000 1344 Kb
image-0-appcpu  0x002c0000 448 Kb
image-1-appcpu  0x00330000 448 Kb
image-0-lpcore  0x003a0000 32 Kb
image-1-lpcore  0x003a8000 32 Kb
storage         0x003b0000 192 Kb
image-scratch   0x003e0000 124 Kb
coredump        0x003ff000 4 Kb
```