### PR TITLE
modules: lvgl: Aligned allocated buffers

### DIFF
--- a/modules/lvgl/Kconfig.memory
+++ b/modules/lvgl/Kconfig.memory
@@ -36,21 +36,31 @@ choice LV_Z_MEMORY_POOL
 
 endchoice
 
+if LV_Z_MEM_POOL_SYS_HEAP
+
 config LV_Z_MEM_POOL_SIZE
 	int "Memory pool size"
 	default 2048
-	depends on LV_Z_MEM_POOL_SYS_HEAP
 	help
 	  Size of the memory pool in bytes
 
 config LV_Z_MEMORY_POOL_CUSTOM_SECTION
 	bool "Link memory pool to custom section"
-	depends on LV_Z_MEM_POOL_SYS_HEAP
 	help
 	  Place LVGL memory pool in custom section, with tag ".lvgl_heap".
 	  This can be used by custom linker scripts to relocate the LVGL
 	  memory pool to a custom location, such as tightly coupled or
 	  external memory.
+
+config LV_Z_MEMORY_POOL_ALLOC_ALIGN
+	int "Align allocated buffers"
+	default 32 if LV_USE_PXP
+	default 0
+	help
+	  Alignment of the buffers allocated from the LVGL memory pool.
+	  Set to zero for no alignment restrictions.
+
+endif
 
 config LV_Z_VDB_SIZE
 	int "Rendering buffer size"

--- a/modules/lvgl/lvgl_mem.c
+++ b/modules/lvgl/lvgl_mem.c
@@ -29,7 +29,11 @@ void *lvgl_malloc(size_t size)
 	void *ret;
 
 	key = k_spin_lock(&lvgl_heap_lock);
-	ret = sys_heap_alloc(&lvgl_heap, size);
+	if (CONFIG_LV_Z_MEMORY_POOL_ALLOC_ALIGN > 0) {
+		ret = sys_heap_aligned_alloc(&lvgl_heap, CONFIG_LV_Z_MEMORY_POOL_ALLOC_ALIGN, size);
+	} else {
+		ret = sys_heap_alloc(&lvgl_heap, size);
+	}
 	k_spin_unlock(&lvgl_heap_lock, key);
 
 	return ret;
@@ -41,7 +45,12 @@ void *lvgl_realloc(void *ptr, size_t size)
 	void *ret;
 
 	key = k_spin_lock(&lvgl_heap_lock);
-	ret = sys_heap_realloc(&lvgl_heap, ptr, size);
+	if (CONFIG_LV_Z_MEMORY_POOL_ALLOC_ALIGN > 0) {
+		ret = sys_heap_aligned_realloc(&lvgl_heap, ptr, CONFIG_LV_Z_MEMORY_POOL_ALLOC_ALIGN,
+					       size);
+	} else {
+		ret = sys_heap_realloc(&lvgl_heap, ptr, size);
+	}
 	k_spin_unlock(&lvgl_heap_lock, key);
 
 	return ret;


### PR DESCRIPTION
Allow setting the alignment for allocated buffers from the LVGL memory pool.