### PR TITLE
usbd: INITIALIZE_ON_BOOT can initialize multiple classes

### DIFF
--- a/subsys/usb/device_next/app/cdc_acm_serial.c
+++ b/subsys/usb/device_next/app/cdc_acm_serial.c
@@ -62,7 +62,7 @@ static int register_cdc_acm_0(struct usbd_context *const uds_ctx,
 		return err;
 	}
 
-	err = usbd_register_class(&cdc_acm_serial, "cdc_acm_0", speed, 1);
+	err = usbd_register_all_classes(&cdc_acm_serial, speed, 1, NULL);
 	if (err) {
 		LOG_ERR("Failed to register classes");
 		return err;


### PR DESCRIPTION
Currently, it is hardcoded that only a single CDC ACM serial port gets initialized. It's very trivial to extend this to multiple ports, such as if a user uses one CDC ACM serial port for logging and another for MCUmgr.