### PR TITLE
drivers: crypto: hash driver for the  STM32H7RS series

### DIFF
--- a/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
+++ b/boards/st/nucleo_h7s3l8/nucleo_h7s3l8.dts
@@ -144,6 +144,10 @@
 	status = "okay";
 };
 
+&hash {
+	status = "okay";
+};
+
 &adc1 {
 	pinctrl-0 = <&adc1_inp15_pa3>; /* Arduino A0 */
 	pinctrl-names = "default";

--- a/drivers/crypto/crypto_stm32_hash.c
+++ b/drivers/crypto/crypto_stm32_hash.c
@@ -62,12 +62,14 @@ static int stm32_hash_handler(struct hash_ctx *ctx, struct hash_pkt *pkt, bool f
 
 	switch (session->algo) {
 	case CRYPTO_HASH_ALGO_SHA224:
-		status = HAL_HASHEx_SHA224_Start(&data->hhash, pkt->in_buf, pkt->in_len,
-						 pkt->out_buf, HAL_MAX_DELAY);
+		LOG_DBG("HASH compute SHA224");
+		status = hal_func_hash_SHA224_start(&data->hhash, pkt->in_buf, pkt->in_len,
+						    pkt->out_buf);
 		break;
 	case CRYPTO_HASH_ALGO_SHA256:
-		status = HAL_HASHEx_SHA256_Start(&data->hhash, pkt->in_buf, pkt->in_len,
-						 pkt->out_buf, HAL_MAX_DELAY);
+		LOG_DBG("HASH compute SHA256");
+		status = hal_func_hash_SHA256_start(&data->hhash, pkt->in_buf, pkt->in_len,
+							pkt->out_buf);
 		break;
 	default:
 		k_sem_give(&data->device_sem);
@@ -175,7 +177,13 @@ static DEVICE_API(crypto, stm32_hash_funcs) = {
 	.query_hw_caps = stm32_hash_query_caps,
 };
 
-static struct crypto_stm32_hash_data crypto_stm32_hash_dev_data = {0};
+static struct crypto_stm32_hash_data crypto_stm32_hash_dev_data = {
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	.hhash = {.Instance = (HASH_TypeDef *)DT_INST_REG_ADDR(0)}
+#else
+	0
+#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
+};
 
 static const struct crypto_stm32_hash_config crypto_stm32_hash_dev_config = {
 	.reset = RESET_DT_SPEC_INST_GET(0),

--- a/drivers/crypto/crypto_stm32_hash_priv.h
+++ b/drivers/crypto/crypto_stm32_hash_priv.h
@@ -7,10 +7,23 @@
 #ifndef ZEPHYR_DRIVERS_CRYPTO_CRYPTO_STM32_HASH_PRIV_H_
 #define ZEPHYR_DRIVERS_CRYPTO_CRYPTO_STM32_HASH_PRIV_H_
 
-#define hash_config_t HASH_InitTypeDef
-
 /* Max digest length: SHA256 = 32 bytes */
 #define STM32_HASH_MAX_DIGEST_SIZE (32)
+
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+
+#define hash_config_t			HASH_ConfigTypeDef
+#define HASH_DATATYPE_8B		HASH_BYTE_SWAP
+#define STM32_HASH_SHA224_START		HAL_HASH_Start
+#define STM32_HASH_SHA256_START		HAL_HASH_Start
+
+#else /* CONFIG_SOC_SERIES_STM32H7RSX */
+
+#define hash_config_t			HASH_InitTypeDef
+#define STM32_HASH_SHA224_START		HAL_HASHEx_SHA224_Start
+#define STM32_HASH_SHA256_START		HAL_HASHEx_SHA256_Start
+
+#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
 
 struct crypto_stm32_hash_config {
 	const struct reset_dt_spec reset;
@@ -36,5 +49,36 @@ struct crypto_stm32_hash_session {
 
 #define CRYPTO_STM32_HASH_SESSN(ctx)                                                               \
 	((struct crypto_stm32_hash_session *const)(ctx)->drv_sessn_state)
+
+static inline HAL_StatusTypeDef hal_func_hash_SHA224_start(HASH_HandleTypeDef *hhash,
+					void *p_in_buffer,
+					uint32_t in_size_byte,
+					void *p_out_buffer)
+{
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	hhash->Init.Algorithm = HASH_ALGOSELECTION_SHA224;
+	if (HAL_HASH_SetConfig(hhash, &hhash->Init) != HAL_OK) {
+		return HAL_ERROR;
+	}
+#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
+	return STM32_HASH_SHA224_START(hhash, p_in_buffer, in_size_byte, p_out_buffer,
+			HAL_MAX_DELAY);
+}
+
+static inline HAL_StatusTypeDef hal_func_hash_SHA256_start(HASH_HandleTypeDef *hhash,
+					void *p_in_buffer,
+					uint32_t in_size_byte,
+					void *p_out_buffer)
+{
+#if defined(CONFIG_SOC_SERIES_STM32H7RSX)
+	hhash->Init.Algorithm = HASH_ALGOSELECTION_SHA256;
+
+	if (HAL_HASH_SetConfig(hhash, &hhash->Init) != HAL_OK) {
+		return HAL_ERROR;
+	}
+#endif /* CONFIG_SOC_SERIES_STM32H7RSX */
+	return STM32_HASH_SHA256_START(hhash, p_in_buffer, in_size_byte, p_out_buffer,
+			HAL_MAX_DELAY);
+}
 
 #endif /* ZEPHYR_DRIVERS_CRYPTO_CRYPTO_STM32_HASH_PRIV_H_ */

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -534,6 +534,15 @@
 			status = "disabled";
 		};
 
+		hash: hash@48020400 {
+			compatible = "st,stm32-hash";
+			reg = <0x48020400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB3, 1)>;
+			resets = <&rctl STM32_RESET(AHB3, 1)>;
+			interrupts = <36 0>;
+			status = "disabled";
+		};
+
 		timers1: timers@42000000 {
 			compatible = "st,stm32-timers";
 			reg = <0x42000000 0x400>;

--- a/tests/crypto/crypto_hash/testcase.yaml
+++ b/tests/crypto/crypto_hash/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   crypto.hash:
     platform_allow:
       - native_sim
+      - nucleo_h7s3l8
       - nucleo_u575zi_q
     integration_platforms:
       - native_sim


### PR DESCRIPTION
Following the https://github.com/zephyrproject-rtos/zephyr/pull/93923
this PR adds the support of crypto hash hardware to  the stm32h7RS 

Note that `-T crypto.hash ` will  use the SW hash

The testcase only tests the SHA256, more SHA are available on the stm32 hash hw processors and main could be extended
