### PR TITLE
drivers: flash: sam0: Fix incorrect page write size

### DIFF
--- a/drivers/flash/flash_sam0.c
+++ b/drivers/flash/flash_sam0.c
@@ -224,7 +224,7 @@ static int flash_sam0_commit(const struct device *dev, off_t base)
 	for (page = 0; page < PAGES_PER_ROW; page++) {
 		err = flash_sam0_write_page(
 			dev, base + page * FLASH_PAGE_SIZE,
-			&ctx->buf[page * FLASH_PAGE_SIZE], ROW_SIZE);
+			&ctx->buf[page * FLASH_PAGE_SIZE], FLASH_PAGE_SIZE);
 		if (err != 0) {
 			return err;
 		}


### PR DESCRIPTION
Hi All,

This MR corrects the page write size for SAM0 devices by setting it to 64 bytes. As specified in the datasheet, a single page consists of 64 bytes, and a row comprises 4 pages, totaling 256 bytes.

Tested on: ATSAMC21E18A

Best regards,
Taras
