### PR TITLE
tests: drivers: spi: loopback: Fix cache coherency on size9/size24

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -641,7 +641,7 @@ ZTEST(spi_loopback, test_spi_same_buf_cmd)
 	spi_loopback_compare_bufs(tx_data, buffer_rx, 1,
 				  buffer_print_tx, buffer_print_rx);
 
-	char zeros[BUF_SIZE - 1] = {0};
+	static const char zeros[BUF_SIZE - 1] = {0};
 
 	zassert_ok(memcmp(buffer_rx+1, zeros, BUF_SIZE - 1));
 }
@@ -687,7 +687,7 @@ ZTEST(spi_loopback, test_spi_word_size_9)
 {
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];
 
-	static __BUF_ALIGN uint16_t tx_data_9[BUFWIDE_SIZE];
+	static __BUF_ALIGN __NOCACHE uint16_t tx_data_9[BUFWIDE_SIZE];
 
 	for (int i = 0; i < BUFWIDE_SIZE; i++) {
 		tx_data_9[i] = tx_data_16[i] & 0x1FF;
@@ -711,7 +711,7 @@ ZTEST(spi_loopback, test_spi_word_size_24)
 {
 	struct spi_dt_spec *spec = loopback_specs[spec_idx];
 
-	static __BUF_ALIGN uint32_t tx_data_24[BUFWIDE_SIZE];
+	static __BUF_ALIGN __NOCACHE uint32_t tx_data_24[BUFWIDE_SIZE];
 
 	for (int i = 0; i < BUFWIDE_SIZE; i++) {
 		tx_data_24[i] = tx_data_32[i] & 0xFFFFFF;


### PR DESCRIPTION
Make tx_data9 and tx_data24 non-cachable within the 9-bit word size and 24-bit word size functions. This repairs a suspected cache coherency issue where these buffers are written to cache and therefore not seen correctly by spi/dma.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/90768