### PR TITLE
drivers: mspi: mspi_dw: Fix compilation with CONFIG_MSPI_XIP disabled

### DIFF
--- a/drivers/mspi/Kconfig.dw
+++ b/drivers/mspi/Kconfig.dw
@@ -8,6 +8,7 @@ config MSPI_DW
 	depends on DT_HAS_SNPS_DESIGNWARE_SSI_ENABLED
 	select PINCTRL if $(dt_compat_any_has_prop,$(DT_COMPAT_SNPS_DESIGNWARE_SSI),pinctrl-0)
 	imply MSPI_XIP
+	imply MSPI_TIMING
 
 if MSPI_DW
 

--- a/drivers/mspi/mspi_dw.c
+++ b/drivers/mspi/mspi_dw.c
@@ -1193,6 +1193,22 @@ static int api_transceive(const struct device *dev,
 	return rc;
 }
 
+#if defined(CONFIG_MSPI_TIMING)
+static int api_timing_config(const struct device *dev,
+			     const struct mspi_dev_id *dev_id,
+			     const uint32_t param_mask, void *cfg)
+{
+	struct mspi_dw_data *dev_data = dev->data;
+	struct mspi_dw_timing_cfg *config = cfg;
+
+	if (param_mask & MSPI_DW_RX_TIMING_CFG) {
+		dev_data->rx_sample_dly = config->rx_sample_dly;
+		return 0;
+	}
+	return -ENOTSUP;
+}
+#endif /* defined(CONFIG_MSPI_TIMING) */
+
 #if defined(CONFIG_MSPI_XIP)
 static int _api_xip_config(const struct device *dev,
 			   const struct mspi_dev_id *dev_id,
@@ -1297,20 +1313,6 @@ static int _api_xip_config(const struct device *dev,
 	dev_data->xip_enabled |= BIT(dev_id->dev_idx);
 
 	return 0;
-}
-
-static int api_timing_config(const struct device *dev,
-			     const struct mspi_dev_id *dev_id,
-			     const uint32_t param_mask, void *cfg)
-{
-	struct mspi_dw_data *dev_data = dev->data;
-	struct mspi_dw_timing_cfg *config = cfg;
-
-	if (param_mask & MSPI_DW_RX_TIMING_CFG) {
-		dev_data->rx_sample_dly = config->rx_sample_dly;
-		return 0;
-	}
-	return -ENOTSUP;
 }
 
 static int api_xip_config(const struct device *dev,
@@ -1461,7 +1463,9 @@ static DEVICE_API(mspi, drv_api) = {
 	.dev_config         = api_dev_config,
 	.get_channel_status = api_get_channel_status,
 	.transceive         = api_transceive,
+#if defined(CONFIG_MSPI_TIMING)
 	.timing_config      = api_timing_config,
+#endif
 #if defined(CONFIG_MSPI_XIP)
 	.xip_config         = api_xip_config,
 #endif


### PR DESCRIPTION
Move `api_timing_config()` impl outside of the block gated behind `CONFIG_MSPI_XIP`.
My project with `CONFIG_MSPI_XIP` disabled continues to compile and work after this change.

```
shell:~$ fs erase_write_test /data/file 825000 4
Loop #1 done in 10512ms.
Loop #2 done in 10462ms.
Loop #3 done in 10558ms.
Loop #4 done in 10470ms.
Total: 42002ms, Per loop: ~10500ms, Speed: ~76.7KiBps
```