### PR TITLE
spi: rtio: Add validation for NULL tx and rx buffers

### DIFF
--- a/drivers/spi/spi_rtio.c
+++ b/drivers/spi/spi_rtio.c
@@ -415,6 +415,10 @@ int spi_rtio_transceive(struct spi_rtio *ctx,
 	int err = 0;
 	int ret;
 
+	if (tx_bufs == NULL && rx_bufs == NULL) {
+		return -EINVAL;
+	}
+
 	dt_spec->config = *config;
 
 	ret = spi_rtio_copy(ctx->r, &ctx->iodev, tx_bufs, rx_bufs, &sqe);


### PR DESCRIPTION
In addition to #94710 fixes, SPI RTIO currently fails existing spi loopback testcase: test_spi_null_tx_rx_buf_set.

This plus the referenced PR allows RTIO-enabled drivers to pass the testsuite.

Fies: #90539