### PR TITLE
boards: vmu_rt1170: Change ICM4268X LPSPIs to use native PCS

### DIFF
--- a/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170-pinctrl.dtsi
@@ -237,7 +237,7 @@
 
 	pinmux_lpspi1: pinmux_lpspi1 {
 		group0 {
-			pinmux = <&iomuxc_gpio_emc_b2_01_gpio_mux2_io11>,
+			pinmux = <&iomuxc_gpio_emc_b2_01_lpspi1_pcs0>,
 				 <&iomuxc_gpio_emc_b2_00_lpspi1_sck>,
 				 <&iomuxc_gpio_emc_b2_03_lpspi1_sdi>,
 				 <&iomuxc_gpio_emc_b2_02_lpspi1_sdo>,
@@ -249,7 +249,7 @@
 
 	pinmux_lpspi2: pinmux_lpspi2 {
 		group0 {
-			pinmux = <&iomuxc_gpio_ad_25_gpio_mux3_io24>,
+			pinmux = <&iomuxc_gpio_ad_25_lpspi2_pcs0>,
 				 <&iomuxc_gpio_ad_24_lpspi2_sck>,
 				 <&iomuxc_gpio_ad_27_lpspi2_sdi>,
 				 <&iomuxc_gpio_ad_26_lpspi2_sdo>,

--- a/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
+++ b/boards/nxp/vmu_rt1170/vmu_rt1170_mimxrt1176_cm7.dts
@@ -255,7 +255,9 @@
 
 &lpspi1 {
 	status = "okay";
-	cs-gpios = <&gpio2 11 GPIO_ACTIVE_LOW>;
+	pcs-sck-delay = <50>;
+	sck-pcs-delay = <50>;
+	transfer-delay = <50>;
 
 	icm42686_0: icm42686p0@0 {
 		compatible = "invensense,icm42686", "invensense,icm4268x";
@@ -281,7 +283,9 @@
 
 &lpspi2 {
 	status = "okay";
-	cs-gpios = <&gpio3 24 GPIO_ACTIVE_LOW>;
+	pcs-sck-delay = <50>;
+	sck-pcs-delay = <50>;
+	transfer-delay = <50>;
 
 	icm42688_0: icm42688p0@0 {
 		compatible = "invensense,icm42688", "invensense,icm4268x";


### PR DESCRIPTION
Moving away from GPIO CS configuration.