### PR TITLE
ICM4268X: Improvements based on perfomance testing

### DIFF
--- a/drivers/sensor/tdk/icm4268x/CMakeLists.txt
+++ b/drivers/sensor/tdk/icm4268x/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library_sources(
     icm4268x.c
     icm4268x_common.c
     icm4268x_spi.c
+    icm4268x_bus.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API icm4268x_rtio.c)

--- a/drivers/sensor/tdk/icm4268x/icm4268x.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x.c
@@ -339,7 +339,7 @@ void icm4268x_unlock(const struct device *dev)
 
 #define ICM4268X_RTIO_DEFINE(inst)                                                                 \
 	SPI_DT_IODEV_DEFINE(icm4268x_spi_iodev_##inst, DT_DRV_INST(inst), ICM4268X_SPI_CFG);       \
-	RTIO_DEFINE(icm4268x_rtio_##inst, 8, 4);
+	RTIO_DEFINE(icm4268x_rtio_##inst, 32, 32);
 
 #define ICM42688_DT_CONFIG_INIT(inst)						\
 	{									\

--- a/drivers/sensor/tdk/icm4268x/icm4268x.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x.c
@@ -374,8 +374,13 @@ void icm4268x_unlock(const struct device *dev)
 	IF_ENABLED(CONFIG_ICM4268X_STREAM, (ICM4268X_RTIO_DEFINE(inst)));                          \
 	static struct icm4268x_dev_data icm4268x_driver_##inst = {                                 \
 		.cfg = ICM42688_DT_CONFIG_INIT(inst),                                              \
-		IF_ENABLED(CONFIG_ICM4268X_STREAM, (.r = &icm4268x_rtio_##inst,                    \
-						    .spi_iodev = &icm4268x_spi_iodev_##inst,))     \
+		IF_ENABLED(CONFIG_ICM4268X_STREAM,						   \
+		(										   \
+			.bus.rtio = {								   \
+				.ctx = &icm4268x_rtio_##inst,					   \
+				.iodev = &icm4268x_spi_iodev_##inst,				   \
+			},									   \
+		))										   \
 	};
 
 /** The rest of the Device-tree configuration is validated in the YAML

--- a/drivers/sensor/tdk/icm4268x/icm4268x.h
+++ b/drivers/sensor/tdk/icm4268x/icm4268x.h
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/sensor/icm42688.h>
 #include <zephyr/dt-bindings/sensor/icm42686.h>
 #include <stdlib.h>
+#include "icm4268x_bus.h"
 
 struct alignment {
 	int8_t index;
@@ -341,6 +342,7 @@ struct icm4268x_cfg {
 
 	bool fifo_en;
 	int32_t batch_ticks;
+	uint16_t fifo_wm;
 	bool fifo_hires;
 	/* TODO additional FIFO options */
 
@@ -358,6 +360,12 @@ struct icm4268x_trigger_entry {
 	sensor_trigger_handler_t handler;
 };
 
+enum icm4268x_stream_state {
+	ICM4268X_STREAM_OFF = 0,
+	ICM4268X_STREAM_ON = 1,
+	ICM4268X_STREAM_BUSY = 2,
+};
+
 /**
  * @brief Device data (struct device)
  */
@@ -373,12 +381,11 @@ struct icm4268x_dev_data {
 #endif
 #ifdef CONFIG_ICM4268X_STREAM
 	struct rtio_iodev_sqe *streaming_sqe;
-	struct rtio *r;
-	struct rtio_iodev *spi_iodev;
+	struct icm4268x_bus bus;
 	uint8_t int_status;
 	uint16_t fifo_count;
 	uint64_t timestamp;
-	atomic_t reading_fifo;
+	atomic_t state;
 #endif /* CONFIG_ICM4268X_STREAM */
 	const struct device *dev;
 	struct gpio_callback gpio_cb;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_bus.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_bus.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 Croxel, Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "icm4268x_bus.h"
+
+int icm4268x_prep_reg_read_rtio_async(const struct icm4268x_bus *bus,
+				    uint8_t reg, uint8_t *buf, size_t size,
+				    struct rtio_sqe **out)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_iodev *iodev = bus->rtio.iodev;
+	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_sqe *read_buf_sqe = rtio_sqe_acquire(ctx);
+
+	if (!write_reg_sqe || !read_buf_sqe) {
+		rtio_sqe_drop_all(ctx);
+		return -ENOMEM;
+	}
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
+
+	/** Send back last SQE so it can be concatenated later. */
+	if (out) {
+		*out = read_buf_sqe;
+	}
+
+	return 2;
+}
+
+int icm4268x_prep_reg_write_rtio_async(const struct icm4268x_bus *bus,
+				     uint8_t reg, const uint8_t *buf, size_t size,
+				     struct rtio_sqe **out)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_iodev *iodev = bus->rtio.iodev;
+	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_sqe *write_buf_sqe = rtio_sqe_acquire(ctx);
+
+	if (!write_reg_sqe || !write_buf_sqe) {
+		rtio_sqe_drop_all(ctx);
+		return -ENOMEM;
+	}
+
+	/** More than 7 won't work with tiny-write */
+	if (size > 7) {
+		return -EINVAL;
+	}
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_tiny_write(write_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
+
+	/** Send back last SQE so it can be concatenated later. */
+	if (out) {
+		*out = write_buf_sqe;
+	}
+
+	return 2;
+}
+
+int icm4268x_reg_read_rtio(const struct icm4268x_bus *bus, uint8_t start, uint8_t *buf, int size)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_cqe *cqe;
+	int ret;
+
+	ret = icm4268x_prep_reg_read_rtio_async(bus, start, buf, size, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = rtio_submit(ctx, ret);
+	if (ret) {
+		return ret;
+	}
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			ret = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	return ret;
+}
+
+int icm4268x_reg_write_rtio(const struct icm4268x_bus *bus, uint8_t reg, const uint8_t *buf,
+			    int size)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_cqe *cqe;
+	int ret;
+
+	ret = icm4268x_prep_reg_write_rtio_async(bus, reg, buf, size, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = rtio_submit(ctx, ret);
+	if (ret) {
+		return ret;
+	}
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			ret = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	return ret;
+}

--- a/drivers/sensor/tdk/icm4268x/icm4268x_bus.h
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_bus.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Croxel, Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_ICM4268X_ICM4268X_BUS_H_
+#define ZEPHYR_DRIVERS_SENSOR_ICM4268X_ICM4268X_BUS_H_
+
+#include <zephyr/kernel.h>
+#include <zephyr/rtio/rtio.h>
+
+struct icm4268x_bus {
+	struct {
+		struct rtio *ctx;
+		struct rtio_iodev *iodev;
+	} rtio;
+};
+
+int icm4268x_prep_reg_read_rtio_async(const struct icm4268x_bus *bus, uint8_t reg, uint8_t *buf,
+				      size_t size, struct rtio_sqe **out);
+
+int icm4268x_prep_reg_write_rtio_async(const struct icm4268x_bus *bus, uint8_t reg,
+				       const uint8_t *buf, size_t size, struct rtio_sqe **out);
+
+int icm4268x_reg_read_rtio(const struct icm4268x_bus *bus, uint8_t start, uint8_t *buf, int size);
+
+int icm4268x_reg_write_rtio(const struct icm4268x_bus *bus, uint8_t reg, const uint8_t *buf,
+			    int size);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_ICM4268X_ICM4268X_BUS_H_ */

--- a/drivers/sensor/tdk/icm4268x/icm4268x_common.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_common.c
@@ -329,8 +329,10 @@ int icm4268x_configure(const struct device *dev, struct icm4268x_cfg *cfg)
 		}
 
 		/* Set watermark and interrupt handling first */
-		uint16_t fifo_wm = icm4268x_compute_fifo_wm(cfg);
-		uint8_t fifo_wml = fifo_wm & 0xFF;
+		cfg->fifo_wm = icm4268x_compute_fifo_wm(cfg);
+
+		uint8_t fifo_wml = cfg->fifo_wm & 0xFF;
+		uint8_t fifo_wmh = (cfg->fifo_wm >> 8) & 0x0F;
 
 		LOG_DBG("FIFO_CONFIG2( (0x%x)) (WM Low) 0x%x", REG_FIFO_CONFIG2, fifo_wml);
 		res = icm4268x_spi_single_write(&dev_cfg->spi, REG_FIFO_CONFIG2, fifo_wml);
@@ -338,8 +340,6 @@ int icm4268x_configure(const struct device *dev, struct icm4268x_cfg *cfg)
 			LOG_ERR("Error writing FIFO_CONFIG2");
 			return -EINVAL;
 		}
-
-		uint8_t fifo_wmh = (fifo_wm >> 8) & 0x0F;
 
 		LOG_DBG("FIFO_CONFIG3 (0x%x) (WM High) 0x%x", REG_FIFO_CONFIG3, fifo_wmh);
 		res = icm4268x_spi_single_write(&dev_cfg->spi, REG_FIFO_CONFIG3, fifo_wmh);

--- a/drivers/sensor/tdk/icm4268x/icm4268x_decoder.h
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_decoder.h
@@ -18,7 +18,7 @@ struct icm4268x_decoder_header {
 	uint8_t accel_fs: 3;
 	uint8_t variant: 1;
 	struct alignment axis_align[3];
-} __attribute__((__packed__));
+};
 
 struct icm4268x_fifo_data {
 	struct icm4268x_decoder_header header;
@@ -28,7 +28,7 @@ struct icm4268x_fifo_data {
 	uint16_t fifo_count: 11;
 	uint16_t padding1: 5;
 	uint16_t rtc_freq;
-} __attribute__((__packed__));
+};
 
 struct icm4268x_encoded_data {
 	struct icm4268x_decoder_header header;

--- a/drivers/sensor/tdk/icm4268x/icm4268x_rtio.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_rtio.c
@@ -111,6 +111,3 @@ void icm4268x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
 	}
 }
-
-BUILD_ASSERT(sizeof(struct icm4268x_decoder_header) == 15,
-	"icm4268x_decoder_header size is not equal to 15");

--- a/drivers/sensor/tdk/icm4268x/icm4268x_rtio.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_rtio.c
@@ -45,9 +45,10 @@ static int icm4268x_rtio_sample_fetch(const struct device *dev, int16_t readings
 	return 0;
 }
 
-static void icm4268x_submit_one_shot(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+void icm4268x_submit_one_shot_sync(struct rtio_iodev_sqe *iodev_sqe)
 {
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	const struct device *dev = cfg->sensor;
 	const struct sensor_chan_spec *const channels = cfg->channels;
 	const size_t num_channels = cfg->count;
 	uint32_t min_buf_len = sizeof(struct icm4268x_encoded_data);
@@ -84,21 +85,7 @@ static void icm4268x_submit_one_shot(const struct device *dev, struct rtio_iodev
 	rtio_iodev_sqe_ok(iodev_sqe, 0);
 }
 
-void icm4268x_submit_sync(struct rtio_iodev_sqe *iodev_sqe)
-{
-	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
-	const struct device *dev = cfg->sensor;
-
-	if (!cfg->is_streaming) {
-		icm4268x_submit_one_shot(dev, iodev_sqe);
-	} else if (IS_ENABLED(CONFIG_ICM4268X_STREAM)) {
-		icm4268x_submit_stream(dev, iodev_sqe);
-	} else {
-		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
-	}
-}
-
-void icm4268x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+static void icm4268x_submit_one_shot(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 {
 	struct rtio_work_req *req = rtio_work_req_alloc();
 
@@ -109,7 +96,20 @@ void icm4268x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
 		return;
 	}
 
-	rtio_work_req_submit(req, iodev_sqe, icm4268x_submit_sync);
+	rtio_work_req_submit(req, iodev_sqe, icm4268x_submit_one_shot_sync);
+}
+
+void icm4268x_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
+{
+	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+
+	if (!cfg->is_streaming) {
+		icm4268x_submit_one_shot(dev, iodev_sqe);
+	} else if (IS_ENABLED(CONFIG_ICM4268X_STREAM)) {
+		icm4268x_submit_stream(dev, iodev_sqe);
+	} else {
+		rtio_iodev_sqe_err(iodev_sqe, -ENOTSUP);
+	}
 }
 
 BUILD_ASSERT(sizeof(struct icm4268x_decoder_header) == 15,

--- a/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_rtio_stream.c
@@ -11,12 +11,14 @@
 #include "icm4268x_decoder.h"
 #include "icm4268x_reg.h"
 #include "icm4268x_rtio.h"
+#include "icm4268x_bus.h"
 
 LOG_MODULE_DECLARE(ICM4268X_RTIO, CONFIG_SENSOR_LOG_LEVEL);
 
 void icm4268x_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *iodev_sqe)
 {
 	const struct sensor_read_config *cfg = iodev_sqe->sqe.iodev->data;
+	const struct icm4268x_dev_cfg *dev_cfg = (const struct icm4268x_dev_cfg *)sensor->config;
 	struct icm4268x_dev_data *data = sensor->data;
 	struct icm4268x_cfg new_config = data->cfg;
 
@@ -47,13 +49,41 @@ void icm4268x_submit_stream(const struct device *sensor, struct rtio_iodev_sqe *
 		int rc = icm4268x_safely_configure(sensor, &new_config);
 
 		if (rc != 0) {
-			LOG_ERR("Failed to configure sensor");
+			LOG_ERR("%p Failed to configure sensor", sensor);
 			rtio_iodev_sqe_err(iodev_sqe, rc);
 			return;
 		}
 	}
 
+	(void)atomic_set(&data->state, ICM4268X_STREAM_ON);
 	data->streaming_sqe = iodev_sqe;
+	(void)gpio_pin_interrupt_configure_dt(&dev_cfg->gpio_int1, GPIO_INT_EDGE_TO_ACTIVE);
+}
+
+static struct sensor_stream_trigger *
+icm4268x_get_read_config_trigger(const struct sensor_read_config *cfg,
+				 enum sensor_trigger_type trig)
+{
+	for (int i = 0; i < cfg->count; ++i) {
+		if (cfg->triggers[i].trigger == trig) {
+			return &cfg->triggers[i];
+		}
+	}
+	LOG_DBG("Unsupported trigger (%d)", trig);
+	return NULL;
+}
+
+static inline void icm4268x_stream_result(const struct device *dev, int result)
+{
+	struct icm4268x_dev_data *drv_data = dev->data;
+	struct rtio_iodev_sqe *streaming_sqe = drv_data->streaming_sqe;
+
+	drv_data->streaming_sqe = NULL;
+	if (result < 0) {
+		rtio_iodev_sqe_err(streaming_sqe, result);
+	} else {
+		rtio_iodev_sqe_ok(streaming_sqe, result);
+	}
 }
 
 static void icm4268x_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, int result, void *arg)
@@ -62,58 +92,19 @@ static void icm4268x_complete_cb(struct rtio *r, const struct rtio_sqe *sqe, int
 
 	const struct device *dev = arg;
 	struct icm4268x_dev_data *drv_data = dev->data;
-	struct rtio_iodev_sqe *iodev_sqe = sqe->userdata;
-
-	/* Flush out completions  */
-	struct rtio_cqe *cqe;
-
-	do {
-		cqe = rtio_cqe_consume(r);
-		if (cqe != NULL) {
-			rtio_cqe_release(r, cqe);
-		}
-	} while (cqe != NULL);
-
-	rtio_iodev_sqe_ok(iodev_sqe, drv_data->fifo_count);
-}
-
-static void icm4268x_fifo_count_cb(struct rtio *r, const struct rtio_sqe *sqe,
-				   int result, void *arg)
-{
-	ARG_UNUSED(result);
-
-	const struct device *dev = arg;
-	struct icm4268x_dev_data *drv_data = dev->data;
-	struct rtio_iodev *spi_iodev = drv_data->spi_iodev;
-	uint8_t *fifo_count_buf = (uint8_t *)&drv_data->fifo_count;
-	uint16_t fifo_count = ((fifo_count_buf[0] << 8) | fifo_count_buf[1]);
-
-	drv_data->fifo_count = fifo_count;
-
-	/* Pull a operation from our device iodev queue, validated to only be reads */
-	struct rtio_iodev_sqe *iodev_sqe = drv_data->streaming_sqe;
-
-	drv_data->streaming_sqe = NULL;
-
-	/* Not inherently an underrun/overrun as we may have a buffer to fill next time */
-	if (iodev_sqe == NULL) {
-		LOG_ERR("No pending SQE");
-		return;
-	}
-
-	const size_t packet_size = drv_data->cfg.fifo_hires ? 20 : 16;
-	const size_t min_read_size = sizeof(struct icm4268x_fifo_data) + packet_size;
-	const size_t ideal_read_size = sizeof(struct icm4268x_fifo_data) + fifo_count;
+	const struct icm4268x_dev_cfg *dev_cfg = (const struct icm4268x_dev_cfg *)dev->config;
+	struct rtio_iodev_sqe *streaming_sqe = drv_data->streaming_sqe;
 	uint8_t *buf;
 	uint32_t buf_len;
+	int rc;
 
-	if (rtio_sqe_rx_buf(iodev_sqe, min_read_size, ideal_read_size, &buf, &buf_len) != 0) {
-		LOG_ERR("Failed to get buffer");
-		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+	if (drv_data->streaming_sqe == NULL ||
+	    FIELD_GET(RTIO_SQE_CANCELED, drv_data->streaming_sqe->sqe.flags)) {
+		LOG_ERR("%p Complete CB triggered with NULL handle. Disabling Interrupt", dev);
+		(void)gpio_pin_interrupt_configure_dt(&dev_cfg->gpio_int1, GPIO_INT_DISABLE);
+		(void)atomic_set(&drv_data->state, ICM4268X_STREAM_OFF);
 		return;
 	}
-	LOG_DBG("Requesting buffer [%u, %u] got %u", (unsigned int)min_read_size,
-		(unsigned int)ideal_read_size, buf_len);
 
 	/** FSR are fixed for high-resolution, at which point we should
 	 * override driver FS config.
@@ -132,11 +123,17 @@ static void icm4268x_fifo_count_cb(struct rtio *r, const struct rtio_sqe *sqe,
 	default:
 		CODE_UNREACHABLE;
 	}
+	/* Even if we flushed the fifo, we still need room for the header to return result info */
+	size_t required_len = sizeof(struct icm4268x_fifo_data);
 
-	/* Read FIFO and call back to rtio with rtio_sqe completion */
-	/* TODO is packet format even needed? the fifo has a header per packet
-	 * already
-	 */
+	rc = rtio_sqe_rx_buf(streaming_sqe, required_len, required_len, &buf, &buf_len);
+	CHECKIF(rc < 0 || !buf) {
+		LOG_ERR("%p Failed to obtain SQE buffer: %d", dev, rc);
+		icm4268x_stream_result(dev, -ENOMEM);
+		return;
+	}
+
+	struct icm4268x_fifo_data *edata = (struct icm4268x_fifo_data *)buf;
 	struct icm4268x_fifo_data hdr = {
 		.header = {
 			.is_fifo = true,
@@ -151,236 +148,129 @@ static void icm4268x_fifo_count_cb(struct rtio *r, const struct rtio_sqe *sqe,
 		.int_status = drv_data->int_status,
 		.gyro_odr = drv_data->cfg.gyro_odr,
 		.accel_odr = drv_data->cfg.accel_odr,
+		.fifo_count = drv_data->cfg.fifo_wm,
 		.rtc_freq = drv_data->cfg.rtc_freq,
 	};
-	uint32_t buf_avail = buf_len;
+	*edata = hdr;
 
-	memcpy(buf, &hdr, sizeof(hdr));
-	buf_avail -= sizeof(hdr);
+	if (FIELD_GET(BIT_FIFO_FULL_INT, edata->int_status) == true) {
+		uint8_t val = BIT_FIFO_FLUSH;
 
-	uint32_t read_len = MIN(fifo_count, buf_avail);
-	uint32_t pkts = read_len / packet_size;
-
-	read_len = pkts * packet_size;
-	((struct icm4268x_fifo_data *)buf)->fifo_count = read_len;
-
-	__ASSERT_NO_MSG(read_len % packet_size == 0);
-
-	uint8_t *read_buf = buf + sizeof(hdr);
-
-	/* Setup new rtio chain to read the fifo data and report then check the
-	 * result
-	 */
-	struct rtio_sqe *write_fifo_addr = rtio_sqe_acquire(r);
-	struct rtio_sqe *read_fifo_data = rtio_sqe_acquire(r);
-	struct rtio_sqe *complete_op = rtio_sqe_acquire(r);
-
-	CHECKIF(!write_fifo_addr || !read_fifo_data || !complete_op) {
-		LOG_ERR("Could not allocate SQEs for SPI RTIO... Please resize SQs in icm4268x.c");
-		drv_data->streaming_sqe = NULL;
-		rtio_sqe_drop_all(r);
-		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
-		return;
-	}
-
-	const uint8_t reg_addr = REG_SPI_READ_BIT | FIELD_GET(REG_ADDRESS_MASK, REG_FIFO_DATA);
-
-	rtio_sqe_prep_tiny_write(write_fifo_addr, spi_iodev, RTIO_PRIO_NORM, &reg_addr, 1, NULL);
-	write_fifo_addr->flags = RTIO_SQE_TRANSACTION;
-	rtio_sqe_prep_read(read_fifo_data, spi_iodev, RTIO_PRIO_NORM, read_buf, read_len,
-			   iodev_sqe);
-	read_fifo_data->flags = RTIO_SQE_CHAINED;
-	rtio_sqe_prep_callback(complete_op, icm4268x_complete_cb, (void *)dev, iodev_sqe);
-
-	rtio_submit(r, 0);
-}
-
-static struct sensor_stream_trigger *
-icm4268x_get_read_config_trigger(const struct sensor_read_config *cfg,
-				 enum sensor_trigger_type trig)
-{
-	for (int i = 0; i < cfg->count; ++i) {
-		if (cfg->triggers[i].trigger == trig) {
-			return &cfg->triggers[i];
-		}
-	}
-	LOG_DBG("Unsupported trigger (%d)", trig);
-	return NULL;
-}
-
-static void icm4268x_int_status_cb(struct rtio *r, const struct rtio_sqe *sqr,
-				   int result, void *arg)
-{
-	ARG_UNUSED(result);
-
-	const struct device *dev = arg;
-	struct icm4268x_dev_data *drv_data = dev->data;
-	struct rtio_iodev *spi_iodev = drv_data->spi_iodev;
-	struct rtio_iodev_sqe *streaming_sqe = drv_data->streaming_sqe;
-	struct sensor_read_config *read_config;
-
-	if (streaming_sqe == NULL) {
-		LOG_WRN("int-status triggered with no streaming handle associated. Ignoring");
-		return;
-	}
-
-	read_config = (struct sensor_read_config *)streaming_sqe->sqe.iodev->data;
-	__ASSERT_NO_MSG(read_config != NULL);
-
-	if (!read_config->is_streaming) {
-		/* Oops, not really configured for streaming data */
-		return;
-	}
-
-	struct sensor_stream_trigger *fifo_ths_cfg =
-		icm4268x_get_read_config_trigger(read_config, SENSOR_TRIG_FIFO_WATERMARK);
-	bool has_fifo_ths_trig = fifo_ths_cfg != NULL &&
-				 FIELD_GET(BIT_FIFO_THS_INT, drv_data->int_status) != 0;
-
-	struct sensor_stream_trigger *fifo_full_cfg =
-		icm4268x_get_read_config_trigger(read_config, SENSOR_TRIG_FIFO_FULL);
-	bool has_fifo_full_trig = fifo_full_cfg != NULL &&
-				  FIELD_GET(BIT_FIFO_FULL_INT, drv_data->int_status) != 0;
-
-	if (!has_fifo_ths_trig && !has_fifo_full_trig) {
-		drv_data->streaming_sqe = NULL;
-		LOG_ERR("No FIFO trigger is configured");
-		rtio_iodev_sqe_err(streaming_sqe, -EIO);
-		return;
-	}
-
-	enum sensor_stream_data_opt data_opt;
-
-	if (has_fifo_ths_trig && !has_fifo_full_trig) {
-		/* Only care about fifo threshold */
-		data_opt = fifo_ths_cfg->opt;
-	} else if (!has_fifo_ths_trig && has_fifo_full_trig) {
-		/* Only care about fifo full */
-		data_opt = fifo_full_cfg->opt;
-	} else {
-		/* Both fifo threshold and full */
-		data_opt = MIN(fifo_ths_cfg->opt, fifo_full_cfg->opt);
-	}
-
-	if (data_opt == SENSOR_STREAM_DATA_NOP || data_opt == SENSOR_STREAM_DATA_DROP) {
-		uint8_t *buf;
-		uint32_t buf_len;
-
-		/* Clear streaming_sqe since we're done with the call */
-		drv_data->streaming_sqe = NULL;
-		if (rtio_sqe_rx_buf(streaming_sqe, sizeof(struct icm4268x_fifo_data),
-				    sizeof(struct icm4268x_fifo_data), &buf, &buf_len) != 0) {
-			rtio_iodev_sqe_err(streaming_sqe, -ENOMEM);
+		LOG_WRN("%p FIFO Full bit is set. Flushing FIFO...", dev);
+		rc = icm4268x_prep_reg_write_rtio_async(&drv_data->bus, REG_SIGNAL_PATH_RESET,
+							&val, 1, NULL);
+		CHECKIF(rc < 0) {
+			LOG_ERR("%p Failed to flush the FIFO buffer: %d", dev, rc);
+			icm4268x_stream_result(dev, rc);
 			return;
 		}
+		rtio_submit(drv_data->bus.rtio.ctx, 0);
+	}
 
-		struct icm4268x_fifo_data *data = (struct icm4268x_fifo_data *)buf;
+	struct rtio_cqe *cqe;
 
-		memset(buf, 0, buf_len);
-		data->header.timestamp = drv_data->timestamp;
-		data->int_status = drv_data->int_status;
-		data->fifo_count = 0;
-		if (data_opt == SENSOR_STREAM_DATA_DROP) {
-			/* Flush the FIFO */
-			struct rtio_sqe *write_signal_path_reset = rtio_sqe_acquire(r);
-
-			CHECKIF(!write_signal_path_reset) {
-				rtio_sqe_drop_all(r);
-				rtio_iodev_sqe_err(streaming_sqe, -ENOMEM);
-				return;
+	do {
+		cqe = rtio_cqe_consume(drv_data->bus.rtio.ctx);
+		if (cqe != NULL) {
+			if (rc >= 0) {
+				rc = cqe->result;
 			}
-			uint8_t write_buffer[] = {
-				FIELD_GET(REG_ADDRESS_MASK, REG_SIGNAL_PATH_RESET),
-				BIT_FIFO_FLUSH,
-			};
-
-			rtio_sqe_prep_tiny_write(write_signal_path_reset, spi_iodev, RTIO_PRIO_NORM,
-						 write_buffer, ARRAY_SIZE(write_buffer), NULL);
-			/* TODO Add a new flag for fire-and-forget so we don't have to block here */
-			rtio_submit(r, 1);
-			ARG_UNUSED(rtio_cqe_consume(r));
+			rtio_cqe_release(drv_data->bus.rtio.ctx, cqe);
 		}
-		rtio_iodev_sqe_ok(streaming_sqe, 0);
-		return;
-	}
+	} while (cqe != NULL);
 
-	/* We need the data, read the fifo length */
-	struct rtio_sqe *write_fifo_count_reg = rtio_sqe_acquire(r);
-	struct rtio_sqe *read_fifo_count = rtio_sqe_acquire(r);
-	struct rtio_sqe *check_fifo_count = rtio_sqe_acquire(r);
-
-	CHECKIF(!write_fifo_count_reg || !read_fifo_count || !check_fifo_count) {
-		LOG_ERR("Could not allocate SQEs for SPI RTIO... Please resize SQs in icm4268x.c");
-		drv_data->streaming_sqe = NULL;
-		rtio_sqe_drop_all(r);
-		rtio_iodev_sqe_err(streaming_sqe, -ENOMEM);
-		return;
-	}
-
-	uint8_t reg = REG_SPI_READ_BIT | FIELD_GET(REG_ADDRESS_MASK, REG_FIFO_COUNTH);
-	uint8_t *read_buf = (uint8_t *)&drv_data->fifo_count;
-
-	rtio_sqe_prep_tiny_write(write_fifo_count_reg, spi_iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
-	write_fifo_count_reg->flags = RTIO_SQE_TRANSACTION;
-	rtio_sqe_prep_read(read_fifo_count, spi_iodev, RTIO_PRIO_NORM, read_buf, 2, NULL);
-	read_fifo_count->flags = RTIO_SQE_CHAINED;
-	rtio_sqe_prep_callback(check_fifo_count, icm4268x_fifo_count_cb, arg, NULL);
-
-	rtio_submit(r, 0);
+	(void)atomic_set(&drv_data->state, ICM4268X_STREAM_OFF);
+	icm4268x_stream_result(dev, rc);
 }
 
 void icm4268x_fifo_event(const struct device *dev)
 {
 	struct icm4268x_dev_data *drv_data = dev->data;
-	struct rtio_iodev *spi_iodev = drv_data->spi_iodev;
-	struct rtio *r = drv_data->r;
+	const struct icm4268x_dev_cfg *dev_cfg = (const struct icm4268x_dev_cfg *)dev->config;
+	struct rtio_sqe *sqe;
 	uint64_t cycles;
 	int rc;
 
-	if (drv_data->streaming_sqe == NULL) {
+	if (drv_data->streaming_sqe == NULL ||
+	    FIELD_GET(RTIO_SQE_CANCELED, drv_data->streaming_sqe->sqe.flags)) {
+		LOG_ERR("%p FIFO event triggered with no stream submisssion. Disabling IRQ", dev);
+		(void)gpio_pin_interrupt_configure_dt(&dev_cfg->gpio_int1, GPIO_INT_DISABLE);
+		(void)atomic_set(&drv_data->state, ICM4268X_STREAM_OFF);
+		return;
+	}
+	if (atomic_cas(&drv_data->state, ICM4268X_STREAM_ON, ICM4268X_STREAM_BUSY) == false) {
+		LOG_WRN("%p Callback triggered while stream is busy. Ignoring request", dev);
 		return;
 	}
 
 	rc = sensor_clock_get_cycles(&cycles);
 	if (rc != 0) {
-		struct rtio_iodev_sqe *iodev_sqe = drv_data->streaming_sqe;
-		LOG_ERR("Failed to get sensor clock cycles");
-		drv_data->streaming_sqe = NULL;
-		rtio_iodev_sqe_err(iodev_sqe, rc);
+		LOG_ERR("%p Failed to get sensor clock cycles", dev);
+		icm4268x_stream_result(dev, rc);
 		return;
 	}
-
 	drv_data->timestamp = sensor_clock_cycles_to_ns(cycles);
 
-	/*
-	 * Setup rtio chain of ops with inline calls to make decisions
-	 * 1. read int status
-	 * 2. call to check int status and get pending RX operation
-	 * 4. read fifo len
-	 * 5. call to determine read len
-	 * 6. read fifo
-	 * 7. call to report completion
-	 */
-	struct rtio_sqe *write_int_reg = rtio_sqe_acquire(r);
-	struct rtio_sqe *read_int_reg = rtio_sqe_acquire(r);
-	struct rtio_sqe *check_int_status = rtio_sqe_acquire(r);
-
-	CHECKIF(!write_int_reg || !read_int_reg || !check_int_status) {
-		struct rtio_iodev_sqe *streaming_sqe = drv_data->streaming_sqe;
-
-		LOG_ERR("Could not allocate SQEs for SPI RTIO... Please resize SQs in icm4268x.c");
-		drv_data->streaming_sqe = NULL;
-		rtio_sqe_drop_all(r);
-		rtio_iodev_sqe_err(streaming_sqe, -ENOMEM);
+	rc = icm4268x_prep_reg_read_rtio_async(&drv_data->bus, REG_INT_STATUS | REG_SPI_READ_BIT,
+					       &drv_data->int_status, 1, &sqe);
+	CHECKIF(rc < 0 || !sqe) {
+		LOG_ERR("%p Could not prepare async read: %d", dev, rc);
+		icm4268x_stream_result(dev, -ENOMEM);
 		return;
 	}
+	sqe->flags |= RTIO_SQE_CHAINED;
 
-	uint8_t reg = REG_SPI_READ_BIT | FIELD_GET(REG_ADDRESS_MASK, REG_INT_STATUS);
+	struct sensor_read_config *read_config =
+		(struct sensor_read_config *)drv_data->streaming_sqe->sqe.iodev->data;
+	struct sensor_stream_trigger *fifo_ths_cfg =
+		icm4268x_get_read_config_trigger(read_config, SENSOR_TRIG_FIFO_WATERMARK);
 
-	rtio_sqe_prep_tiny_write(write_int_reg, spi_iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
-	write_int_reg->flags = RTIO_SQE_TRANSACTION;
-	rtio_sqe_prep_read(read_int_reg, spi_iodev, RTIO_PRIO_NORM, &drv_data->int_status, 1, NULL);
-	read_int_reg->flags = RTIO_SQE_CHAINED;
-	rtio_sqe_prep_callback(check_int_status, icm4268x_int_status_cb, (void *)dev, NULL);
-	rtio_submit(r, 0);
+	if (fifo_ths_cfg && fifo_ths_cfg->opt == SENSOR_STREAM_DATA_INCLUDE) {
+		uint8_t *buf;
+		uint32_t buf_len;
+		uint16_t payload_read_len = drv_data->cfg.fifo_wm;
+		size_t required_len = sizeof(struct icm4268x_fifo_data) + payload_read_len;
+
+		rc = rtio_sqe_rx_buf(drv_data->streaming_sqe, required_len, required_len, &buf,
+				     &buf_len);
+		if (rc < 0) {
+			LOG_ERR("%p Failed to allocate buffer for the FIFO read: %d", dev, rc);
+			icm4268x_stream_result(dev, rc);
+			return;
+		}
+
+		/** We fill we data first, the header we'll fill once we have
+		 * read all the data.
+		 */
+		uint8_t *read_buf = buf + sizeof(struct icm4268x_fifo_data);
+
+		rc = icm4268x_prep_reg_read_rtio_async(&drv_data->bus,
+						       REG_FIFO_DATA | REG_SPI_READ_BIT,
+						       read_buf, payload_read_len, &sqe);
+		if (rc < 0 || !sqe) {
+			LOG_ERR("%p Could not prepare async read: %d", dev, rc);
+			icm4268x_stream_result(dev, -ENOMEM);
+			return;
+		}
+		sqe->flags |= RTIO_SQE_CHAINED;
+	} else {
+		/** Because we don't want the data, flush it and be done with
+		 * it. The trigger can be passed on to the user regardless.
+		 */
+		uint8_t val = BIT_FIFO_FLUSH;
+
+		rc = icm4268x_prep_reg_write_rtio_async(&drv_data->bus, REG_SIGNAL_PATH_RESET,
+							&val, 1, &sqe);
+		if (rc < 0 || !sqe) {
+			LOG_ERR("%p Could not prepare async read: %d", dev, rc);
+			icm4268x_stream_result(dev, -ENOMEM);
+			return;
+		}
+		sqe->flags |= RTIO_SQE_CHAINED;
+	}
+
+	struct rtio_sqe *cb_sqe = rtio_sqe_acquire(drv_data->bus.rtio.ctx);
+
+	rtio_sqe_prep_callback(cb_sqe, icm4268x_complete_cb, (void *)dev, NULL);
+	rtio_submit(drv_data->bus.rtio.ctx, 0);
 }

--- a/drivers/sensor/tdk/icm4268x/icm4268x_trigger.c
+++ b/drivers/sensor/tdk/icm4268x/icm4268x_trigger.c
@@ -147,7 +147,7 @@ int icm4268x_trigger_init(const struct device *dev)
 #elif defined(CONFIG_ICM4268X_TRIGGER_GLOBAL_THREAD)
 	data->work.handler = icm4268x_work_handler;
 #endif
-	return gpio_pin_interrupt_configure_dt(&cfg->gpio_int1, GPIO_INT_EDGE_TO_ACTIVE);
+	return 0;
 }
 
 int icm4268x_trigger_enable_interrupt(const struct device *dev, struct icm4268x_cfg *new_cfg)


### PR DESCRIPTION
### Description
This PR makes performance improvements on the ICM4268X driver in streaming mode, based on stress testing it with VMU RT1170, 2 IMUs running at 8000Hz ODR with FIFO Watermark at 800Hz (10 samples every 1.25-ms).

Specific changes
- Simplify streaming read-out path.
- Expect fixed number of samples on FIFO Watermark event (threshold set)
- Add error-handling straps, minimize callbacks.
- Remove padding from decoder/encoder structs to save cycles.
- Expand RTIO bus queue size.