### PR TITLE
samples: openamp: add notice when remote board is not set

### DIFF
--- a/samples/subsys/ipc/openamp/sysbuild.cmake
+++ b/samples/subsys/ipc/openamp/sysbuild.cmake
@@ -2,6 +2,9 @@
 #
 # Copyright 2022 NXP
 
+# Only add the remote project if a remote board is defined
+if(DEFINED SB_CONFIG_OPENAMP_REMOTE_BOARD AND NOT "${SB_CONFIG_OPENAMP_REMOTE_BOARD}" STREQUAL "")
+
 # Add external project
 ExternalZephyrProject_Add(
     APPLICATION openamp_remote
@@ -18,4 +21,14 @@ sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} openamp_remote)
 if(SB_CONFIG_BOOTLOADER_MCUBOOT)
   # Make sure MCUboot is flashed first
   sysbuild_add_dependencies(FLASH openamp_remote mcuboot)
+endif()
+
+else()
+
+  message(NOTICE "
+   ****************************************
+   * Remote board not set, skipping build *
+   ****************************************"
+  )
+
 endif()


### PR DESCRIPTION
When target board has no remote board reference, the sample will fail. This adds a notice into build level and do not fail it.

I think a very good approach for sysbuild scenarios where REMOTE board is needed is to populate that information in board level instead.

Ex.: `board.yml`
```c
board:
  name: esp32_devkitc
  full_name: ESP32-DevKitC
  vendor: espressif
  socs:
  - name: esp32
+ remote:
+ - name: esp32_devkitc/esp32/appcpu
  ```

