### PR TITLE
modules/psa-arch-tests: Add GCC 14.3 support patch

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -23,7 +23,7 @@ manifest:
       groups:
         - optional
     - name: psa-arch-tests
-      revision: 10fd24782323fc3faf6c787959f4a9d4130bedb8
+      revision: 87b08682a111ebb085cd8b1ea41d603191d6d146
       path: modules/tee/tf-m/psa-arch-tests
       remote: upstream
       groups:


### PR DESCRIPTION
psa-arch-tests includes device drivers that failed to mark registers with 'volatile'. GCC 14.3 cleverly optimized sequential register accesses using strd/ldrd instructions which caused the drivers to fail.

This is the same as the accidentally closed PR #94357 which I couldn't re-open.