### PR TITLE
include: mgmt: mcumgr: doc: massive doxygen makeover

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -13,6 +13,9 @@
 @brief MCUmgr
 @defgroup mcumgr MCUmgr
 @{
+@defgroup mcumgr_transport Transport layers
+@{
+@}
 @}
 
 @}

--- a/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt.h
@@ -8,9 +8,9 @@
 #define H_ENUM_MGMT_
 
 /**
- * @brief MCUmgr enum_mgmt API
- * @defgroup mcumgr_enum_mgmt MCUmgr enum_mgmt API
- * @ingroup mcumgr
+ * @brief MCUmgr Enumeration Management API
+ * @defgroup mcumgr_enum_mgmt Enumeration Management
+ * @ingroup mcumgr_mgmt_api
  * @{
  */
 
@@ -19,12 +19,16 @@ extern "C" {
 #endif
 
 /**
- * Command IDs for enumeration management group.
+ * @name Command IDs for enumeration management group.
+ * @{
  */
-#define ENUM_MGMT_ID_COUNT     0
-#define ENUM_MGMT_ID_LIST      1
-#define ENUM_MGMT_ID_SINGLE    2
-#define ENUM_MGMT_ID_DETAILS   3
+#define ENUM_MGMT_ID_COUNT   0 /**< Count of supported groups */
+#define ENUM_MGMT_ID_LIST    1 /**< List supported groups */
+#define ENUM_MGMT_ID_SINGLE  2 /**< Fetch single group ID */
+#define ENUM_MGMT_ID_DETAILS 3 /**< Details on supported groups */
+/**
+ * @}
+ */
 
 /**
  * Command result codes for enumeration management group.

--- a/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/enum_mgmt/enum_mgmt_callbacks.h
@@ -12,8 +12,9 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr enum_mgmt callback API
- * @defgroup mcumgr_callback_api_enum_mgmt MCUmgr enum_mgmt callback API
+ * @brief MCUmgr Enumeration Management Callbacks API
+ * @defgroup mcumgr_callback_api_enum_mgmt Enumeration Management Callbacks
+ * @ingroup mcumgr_enum_mgmt
  * @ingroup mcumgr_callback_api
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt.h
@@ -9,18 +9,29 @@
 #ifndef H_FS_MGMT_
 #define H_FS_MGMT_
 
+/**
+ * @brief MCUmgr File System Management API
+ * @defgroup mcumgr_fs_mgmt File System Management
+ * @ingroup mcumgr_mgmt_api
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Command IDs for file system management group.
+ * @name Command IDs for File System Management group.
+ * @{
  */
-#define FS_MGMT_ID_FILE				0
-#define FS_MGMT_ID_STAT				1
-#define FS_MGMT_ID_HASH_CHECKSUM		2
-#define FS_MGMT_ID_SUPPORTED_HASH_CHECKSUM	3
-#define FS_MGMT_ID_OPENED_FILE			4
+#define FS_MGMT_ID_FILE                    0 /**< File download/upload */
+#define FS_MGMT_ID_STAT                    1 /**< File status */
+#define FS_MGMT_ID_HASH_CHECKSUM           2 /**< File hash/checksum */
+#define FS_MGMT_ID_SUPPORTED_HASH_CHECKSUM 3 /**< Supported file hash/checksum types */
+#define FS_MGMT_ID_OPENED_FILE             4 /**< File close */
+/**
+ * @}
+ */
 
 /**
  * Command result codes for file system management group.
@@ -87,5 +98,9 @@ enum fs_mgmt_err_code_t {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif

--- a/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/fs_mgmt/fs_mgmt_callbacks.h
@@ -13,8 +13,9 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr fs_mgmt callback API
- * @defgroup mcumgr_callback_api_fs_mgmt MCUmgr fs_mgmt callback API
+ * @brief MCUmgr File System Management Callbacks API
+ * @defgroup mcumgr_callback_api_fs_mgmt File System Management Callbacks
+ * @ingroup mcumgr_fs_mgmt
  * @ingroup mcumgr_callback_api
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt.h
@@ -18,9 +18,9 @@
 #endif
 
 /**
- * @brief MCUmgr img_mgmt API
- * @defgroup mcumgr_img_mgmt MCUmgr img_mgmt API
- * @ingroup mcumgr
+ * @brief MCUmgr Image Management API
+ * @defgroup mcumgr_img_mgmt Image Management
+ * @ingroup mcumgr_mgmt_api
  * @{
  */
 
@@ -31,35 +31,45 @@ extern "C" {
 #define IMG_MGMT_DATA_SHA_LEN	32 /* SHA256 */
 
 /**
- * Image state flags
+ * @name Image state flags
+ * @{
  */
+/** Image is set for next swap */
 #define IMG_MGMT_STATE_F_PENDING	0x01
+/** Image has been confirmed. */
 #define IMG_MGMT_STATE_F_CONFIRMED	0x02
+/** Image is currently active. */
 #define IMG_MGMT_STATE_F_ACTIVE		0x04
+/** Image is to stay in primary slot after the next boot. */
 #define IMG_MGMT_STATE_F_PERMANENT	0x08
+/** @} */
 
 /* 255.255.65535.4294967295\0 */
 #define IMG_MGMT_VER_MAX_STR_LEN	(sizeof("255.255.65535.4294967295"))
 
 /**
- * Swap Types for image management state machine
+ * @name Swap Types for image management state machine
+ * @{
  */
-#define IMG_MGMT_SWAP_TYPE_NONE		0
-#define IMG_MGMT_SWAP_TYPE_TEST		1
-#define IMG_MGMT_SWAP_TYPE_PERM		2
-#define IMG_MGMT_SWAP_TYPE_REVERT	3
-#define IMG_MGMT_SWAP_TYPE_UNKNOWN	255
+#define IMG_MGMT_SWAP_TYPE_NONE    0   /**< No swap */
+#define IMG_MGMT_SWAP_TYPE_TEST    1   /**< Test swap */
+#define IMG_MGMT_SWAP_TYPE_PERM    2   /**< Permanent swap */
+#define IMG_MGMT_SWAP_TYPE_REVERT  3   /**< Revert swap */
+#define IMG_MGMT_SWAP_TYPE_UNKNOWN 255 /**< Unknown swap */
+/** @} */
 
 /**
- * Command IDs for image management group.
+ * @name Command IDs for image management group.
+ * @{
  */
-#define IMG_MGMT_ID_STATE	0
-#define IMG_MGMT_ID_UPLOAD	1
-#define IMG_MGMT_ID_FILE	2
-#define IMG_MGMT_ID_CORELIST	3
-#define IMG_MGMT_ID_CORELOAD	4
-#define IMG_MGMT_ID_ERASE	5
-#define IMG_MGMT_ID_SLOT_INFO	6
+#define IMG_MGMT_ID_STATE     0 /**< State of images */
+#define IMG_MGMT_ID_UPLOAD    1 /**< Image upload */
+#define IMG_MGMT_ID_FILE      2 /**< File */
+#define IMG_MGMT_ID_CORELIST  3 /**< Corelist */
+#define IMG_MGMT_ID_CORELOAD  4 /**< Coreload */
+#define IMG_MGMT_ID_ERASE     5 /**< Image erase */
+#define IMG_MGMT_ID_SLOT_INFO 6 /**< Slot info */
+/** @} */
 
 /**
  * Command result codes for image management group.

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_callbacks.h
@@ -21,8 +21,9 @@ struct img_mgmt_upload_action;
 struct img_mgmt_upload_req;
 
 /**
- * @brief MCUmgr img_mgmt callback API
- * @defgroup mcumgr_callback_api_img_mgmt MCUmgr img_mgmt callback API
+ * @brief MCUmgr Image Management Callbacks API
+ * @defgroup mcumgr_callback_api_img_mgmt Image Management Callbacks
+ * @ingroup mcumgr_img_mgmt
  * @ingroup mcumgr_callback_api
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/img_mgmt/img_mgmt_client.h
@@ -14,8 +14,8 @@
 
 /**
  * @brief MCUmgr Image management client API
- * @defgroup mcumgr_img_mgmt_client MCUmgr img_mgmt_client API
- * @ingroup mcumgr
+ * @defgroup mcumgr_img_mgmt_client Image Management Client
+ * @ingroup mcumgr_img_mgmt
  * @{
  */
 

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt.h
@@ -9,22 +9,33 @@
 #ifndef H_OS_MGMT_
 #define H_OS_MGMT_
 
+/**
+ * @brief MCUmgr OS Management API
+ * @defgroup mcumgr_os_mgmt OS Management
+ * @ingroup mcumgr_mgmt_api
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Command IDs for OS management group.
+ * @name Command IDs for OS Management group.
+ * @{
  */
-#define OS_MGMT_ID_ECHO			0
-#define OS_MGMT_ID_CONS_ECHO_CTRL	1
-#define OS_MGMT_ID_TASKSTAT		2
-#define OS_MGMT_ID_MPSTAT		3
-#define OS_MGMT_ID_DATETIME_STR		4
-#define OS_MGMT_ID_RESET		5
-#define OS_MGMT_ID_MCUMGR_PARAMS	6
-#define OS_MGMT_ID_INFO			7
-#define OS_MGMT_ID_BOOTLOADER_INFO	8
+#define OS_MGMT_ID_ECHO            0 /**< Echo */
+#define OS_MGMT_ID_CONS_ECHO_CTRL  1 /**< Console/terminal echo control */
+#define OS_MGMT_ID_TASKSTAT        2 /**< Task statistics */
+#define OS_MGMT_ID_MPSTAT          3 /**< Memory pool statistics */
+#define OS_MGMT_ID_DATETIME_STR    4 /**< Date-time string */
+#define OS_MGMT_ID_RESET           5 /**< System reset */
+#define OS_MGMT_ID_MCUMGR_PARAMS   6 /**< MCUMgr parameters */
+#define OS_MGMT_ID_INFO            7 /**< OS/Application information */
+#define OS_MGMT_ID_BOOTLOADER_INFO 8 /**< Bootloader information */
+/**
+ * @}
+ */
 
 /**
  * Command result codes for OS management group.
@@ -52,57 +63,60 @@ enum os_mgmt_err_code_t {
 	OS_MGMT_ERR_QUERY_RESPONSE_VALUE_NOT_VALID,
 };
 
-/* Bitmask values used by the os info command handler. Note that the width of this variable is
+/**
+ * OS/Application information formats.
+ *
+ * Bitmask values used by the os info command handler. Note that the width of this variable is
  * 32-bits, allowing 32 flags, custom user-level implementations should start at
- * OS_MGMT_INFO_FORMAT_USER_CUSTOM_START and reference that directly as additional format
+ * #OS_MGMT_INFO_FORMAT_USER_CUSTOM_START and reference that directly as additional format
  * specifiers might be added to this list in the future.
  */
 enum os_mgmt_info_formats {
-	OS_MGMT_INFO_FORMAT_KERNEL_NAME = BIT(0),
-	OS_MGMT_INFO_FORMAT_NODE_NAME = BIT(1),
-	OS_MGMT_INFO_FORMAT_KERNEL_RELEASE = BIT(2),
-	OS_MGMT_INFO_FORMAT_KERNEL_VERSION = BIT(3),
-	OS_MGMT_INFO_FORMAT_BUILD_DATE_TIME = BIT(4),
-	OS_MGMT_INFO_FORMAT_MACHINE = BIT(5),
-	OS_MGMT_INFO_FORMAT_PROCESSOR = BIT(6),
-	OS_MGMT_INFO_FORMAT_HARDWARE_PLATFORM = BIT(7),
-	OS_MGMT_INFO_FORMAT_OPERATING_SYSTEM = BIT(8),
+	OS_MGMT_INFO_FORMAT_KERNEL_NAME = BIT(0),       /**< Kernel name */
+	OS_MGMT_INFO_FORMAT_NODE_NAME = BIT(1),         /**< Node name */
+	OS_MGMT_INFO_FORMAT_KERNEL_RELEASE = BIT(2),    /**< Kernel release */
+	OS_MGMT_INFO_FORMAT_KERNEL_VERSION = BIT(3),    /**< Kernel version */
+	OS_MGMT_INFO_FORMAT_BUILD_DATE_TIME = BIT(4),   /**< Build date and time */
+	OS_MGMT_INFO_FORMAT_MACHINE = BIT(5),           /**< Machine */
+	OS_MGMT_INFO_FORMAT_PROCESSOR = BIT(6),         /**< Processor */
+	OS_MGMT_INFO_FORMAT_HARDWARE_PLATFORM = BIT(7), /**< Hardware platform */
+	OS_MGMT_INFO_FORMAT_OPERATING_SYSTEM = BIT(8),  /**< Operating system */
 
-	OS_MGMT_INFO_FORMAT_USER_CUSTOM_START = BIT(9),
+	OS_MGMT_INFO_FORMAT_USER_CUSTOM_START = BIT(9), /**< Custom user-level start bit */
 };
 
-/* Structure provided in the MGMT_EVT_OP_OS_MGMT_INFO_CHECK notification callback */
+/* Structure provided in the #MGMT_EVT_OP_OS_MGMT_INFO_CHECK notification callback */
 struct os_mgmt_info_check {
-	/* Input format string from the mcumgr client */
+	/** Input format string from the mcumgr client */
 	struct zcbor_string *format;
-	/* Bitmask of values specifying which outputs should be present */
+	/** Bitmask of values specifying which outputs should be present */
 	uint32_t *format_bitmask;
-	/* Number of valid format characters parsed, must be incremented by 1 for each valid
+	/** Number of valid format characters parsed, must be incremented by 1 for each valid
 	 * character
 	 */
 	uint16_t *valid_formats;
-	/* Needs to be set to true if the OS name is being provided by external code */
+	/** Needs to be set to true if the OS name is being provided by external code */
 	bool *custom_os_name;
 };
 
 /* Structure provided in the MGMT_EVT_OP_OS_MGMT_INFO_APPEND notification callback */
 struct os_mgmt_info_append {
-	/* The format bitmask from the processed commands, the bits should be cleared once
+	/** The format bitmask from the processed commands, the bits should be cleared once
 	 * processed, note that if all_format_specified is specified, the corresponding bits here
 	 * will not be set
 	 */
 	uint32_t *format_bitmask;
-	/* Will be true if the all 'a' specifier was provided */
+	/** Will be true if the all 'a' specifier was provided */
 	bool all_format_specified;
-	/* The output buffer which the responses should be appended to. If prior_output is true, a
+	/** The output buffer which the responses should be appended to. If prior_output is true, a
 	 * space must be added prior to the output response
 	 */
 	uint8_t *output;
-	/* The current size of the output response in the output buffer, must be updated to be the
+	/** The current size of the output response in the output buffer, must be updated to be the
 	 * size of the output response after appending data
 	 */
 	uint16_t *output_length;
-	/* The size of the output buffer, including null terminator character, if the output
+	/** The size of the output buffer, including null terminator character, if the output
 	 * response would exceed this size, the function must abort and return false to return a
 	 * memory error to the client
 	 */
@@ -114,5 +128,9 @@ struct os_mgmt_info_append {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* H_OS_MGMT_ */

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
@@ -12,8 +12,9 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr os_mgmt callback API
- * @defgroup mcumgr_callback_api_os_mgmt MCUmgr os_mgmt callback API
+ * @brief MCUmgr OS Management Callbacks API
+ * @defgroup mcumgr_callback_api_os_mgmt OS Management Callbacks
+ * @ingroup mcumgr_os_mgmt
  * @ingroup mcumgr_callback_api
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_client.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_client.h
@@ -11,9 +11,9 @@
 #include <zephyr/mgmt/mcumgr/smp/smp_client.h>
 
 /**
- * @brief MCUmgr OS management client API
- * @defgroup mcumgr_os_mgmt_client MCUmgr os_mgmt_client API
- * @ingroup mcumgr
+ * @brief MCUmgr OS Management Client API
+ * @defgroup mcumgr_os_mgmt_client OS Management Client
+ * @ingroup mcumgr_os_mgmt
  * @{
  */
 

--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt.h
@@ -7,17 +7,26 @@
 #ifndef H_SETTINGS_MGMT_
 #define H_SETTINGS_MGMT_
 
+/**
+ * @brief MCUmgr Settings Management API
+ * @defgroup mcumgr_settings_mgmt Settings Management
+ * @ingroup mcumgr_mgmt_api
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Command IDs for settings management group.
+ * @name Command IDs for Settings Management group.
+ * @{
  */
-#define SETTINGS_MGMT_ID_READ_WRITE		0
-#define SETTINGS_MGMT_ID_DELETE			1
-#define SETTINGS_MGMT_ID_COMMIT			2
-#define SETTINGS_MGMT_ID_LOAD_SAVE		3
+#define SETTINGS_MGMT_ID_READ_WRITE 0 /**< Read/write setting */
+#define SETTINGS_MGMT_ID_DELETE     1 /**< Delete setting */
+#define SETTINGS_MGMT_ID_COMMIT     2 /**< Commit settings */
+#define SETTINGS_MGMT_ID_LOAD_SAVE  3 /**< Load/save settings */
+/** @} */
 
 /**
  * Command result codes for settings management group.
@@ -51,5 +60,9 @@ enum settings_mgmt_ret_code_t {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif

--- a/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/settings_mgmt/settings_mgmt_callbacks.h
@@ -12,24 +12,30 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr settings_mgmt callback API
- * @defgroup mcumgr_callback_api_settings_mgmt MCUmgr settings_mgmt callback API
+ * @brief MCUmgr Settings Management Callbacks API
+ * @defgroup mcumgr_callback_api_settings_mgmt Settings Management Callbacks
+ * @ingroup mcumgr_settings_mgmt
  * @ingroup mcumgr_callback_api
  * @{
  */
 
+/**
+ * @name Settings access types
+ * @{
+ */
 enum settings_mgmt_access_types {
-	SETTINGS_ACCESS_READ,
-	SETTINGS_ACCESS_WRITE,
-	SETTINGS_ACCESS_DELETE,
-	SETTINGS_ACCESS_COMMIT,
-	SETTINGS_ACCESS_LOAD,
-	SETTINGS_ACCESS_SAVE,
+	SETTINGS_ACCESS_READ,   /**< Setting is being read */
+	SETTINGS_ACCESS_WRITE,  /**< Setting is being written */
+	SETTINGS_ACCESS_DELETE, /**< Setting is being deleted */
+	SETTINGS_ACCESS_COMMIT, /**< Setting is being committed */
+	SETTINGS_ACCESS_LOAD,   /**< Setting is being loaded */
+	SETTINGS_ACCESS_SAVE,   /**< Setting is being saved */
 };
+/** @} */
 
 /**
- * Structure provided in the #MGMT_EVT_OP_SETTINGS_MGMT_ACCESS notification callback: This
- * callback function is used to notify the application about a pending setting
+ * Structure provided in the #MGMT_EVT_OP_SETTINGS_MGMT_ACCESS notification callback.
+ * This callback function is used to notify the application about a pending setting
  * read/write/delete/load/save/commit request and to authorise or deny it. Access will be allowed
  * so long as no handlers return an error, if one returns an error then access will be denied.
  */
@@ -38,8 +44,8 @@ struct settings_mgmt_access {
 	enum settings_mgmt_access_types access;
 
 	/**
-	 * Key name for accesses (only set for SETTINGS_ACCESS_READ, SETTINGS_ACCESS_WRITE and
-	 * SETTINGS_ACCESS_DELETE). Note that this can be changed by handlers to redirect settings
+	 * Key name for accesses (only set for #SETTINGS_ACCESS_READ, #SETTINGS_ACCESS_WRITE and
+	 * #SETTINGS_ACCESS_DELETE). Note that this can be changed by handlers to redirect settings
 	 * access if needed (as long as it does not exceed the maximum setting string size) if
 	 * CONFIG_MCUMGR_GRP_SETTINGS_BUFFER_TYPE_STACK is selected, of maximum size
 	 * CONFIG_MCUMGR_GRP_SETTINGS_NAME_LEN.

--- a/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/shell_mgmt/shell_mgmt.h
@@ -8,14 +8,23 @@
 #ifndef H_SHELL_MGMT_
 #define H_SHELL_MGMT_
 
+/**
+ * @brief MCUmgr Shell Management API
+ * @defgroup mcumgr_shell_mgmt Shell Management
+ * @ingroup mcumgr_mgmt_api
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Command IDs for shell management group.
+ * @name Command IDs for Shell Management group.
+ * @{
  */
-#define SHELL_MGMT_ID_EXEC   0
+#define SHELL_MGMT_ID_EXEC 0 /**< Shell command line execute */
+/** @} */
 
 /**
  * Command result codes for shell management group.
@@ -37,5 +46,9 @@ enum shell_mgmt_err_code_t {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* H_SHELL_MGMT_ */

--- a/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/grp/stat_mgmt/stat_mgmt.h
@@ -8,15 +8,24 @@
 #ifndef H_STAT_MGMT_
 #define H_STAT_MGMT_
 
+/**
+ * @brief MCUmgr Statistics Management API
+ * @defgroup mcumgr_stat_mgmt Statistics Management
+ * @ingroup mcumgr_mgmt_api
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Command IDs for statistics management group.
+ * @name Command IDs for Statistics Management group.
+ * @{
  */
-#define STAT_MGMT_ID_SHOW   0
-#define STAT_MGMT_ID_LIST   1
+#define STAT_MGMT_ID_SHOW 0 /**< Group data */
+#define STAT_MGMT_ID_LIST 1 /**< List groups */
+/** @} */
 
 /**
  * Command result codes for statistics management group.
@@ -45,12 +54,19 @@ enum stat_mgmt_err_code_t {
  * @brief Represents a single value in a statistics group.
  */
 struct stat_mgmt_entry {
+	/** Name of the statistic */
 	const char *name;
+
+	/** Value of the statistic */
 	uint64_t value;
 };
 
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* H_STAT_MGMT_ */

--- a/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
+++ b/include/zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h
@@ -6,14 +6,23 @@
 #ifndef ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_ZBASIC_H_
 #define ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_ZBASIC_H_
 
+/**
+ * @brief MCUmgr Zephyr Basic Management API
+ * @defgroup mcumgr_zephyr_basic_mgmt Zephyr Basic Management
+ * @ingroup mcumgr_mgmt_api
+ * @{
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Command IDs for zephyr basic management group.
+ * @name Command IDs for zephyr basic management group.
+ * @{
  */
-#define ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE	0	/* Command to erase storage partition */
+#define ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE 0 /**< Erase storage partition */
+/** @} */
 
 /**
  * Command result codes for statistics management group.
@@ -38,5 +47,9 @@ enum zephyr_basic_group_err_code_t {
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_MCUMGR_GRP_ZBASIC_H_ */

--- a/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/callbacks.h
@@ -36,8 +36,8 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr callback API
- * @defgroup mcumgr_callback_api MCUmgr callback API
+ * @brief MCUmgr Callback API
+ * @defgroup mcumgr_callback_api Callbacks
  * @ingroup mcumgr
  * @{
  */
@@ -136,13 +136,13 @@ enum smp_all_events {
  * MGMT event opcodes for base SMP command processing.
  */
 enum smp_group_events {
-	/** Callback when a command is received, data is mgmt_evt_op_cmd_arg(). */
+	/** Callback when a command is received, data is @ref mgmt_evt_op_cmd_arg. */
 	MGMT_EVT_OP_CMD_RECV			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 0),
 
-	/** Callback when a status is updated, data is mgmt_evt_op_cmd_arg(). */
+	/** Callback when a status is updated, data is @ref mgmt_evt_op_cmd_arg. */
 	MGMT_EVT_OP_CMD_STATUS			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 1),
 
-	/** Callback when a command has been processed, data is mgmt_evt_op_cmd_arg(). */
+	/** Callback when a command has been processed, data is @ref mgmt_evt_op_cmd_arg. */
 	MGMT_EVT_OP_CMD_DONE			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_SMP, 2),
 
 	/** Used to enable all smp_group events. */
@@ -153,10 +153,10 @@ enum smp_group_events {
  * MGMT event opcodes for filesystem management group.
  */
 enum fs_mgmt_group_events {
-	/** Callback when a file has been accessed, data is fs_mgmt_file_access(). */
+	/** Callback when a file has been accessed, data is @ref fs_mgmt_file_access. */
 	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 0),
 
-	/** Callback when a file upload/download is finished, data is fs_mgmt_file_access(). */
+	/** Callback when a file upload/download is finished, data is @ref fs_mgmt_file_access. */
 	MGMT_EVT_OP_FS_MGMT_FILE_ACCESS_DONE	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_FS, 1),
 
 	/** Used to enable all fs_mgmt_group events. */
@@ -167,7 +167,7 @@ enum fs_mgmt_group_events {
  * MGMT event opcodes for image management group.
  */
 enum img_mgmt_group_events {
-	/** Callback when a client sends a file upload chunk, data is img_mgmt_upload_check(). */
+	/** Callback when a client sends a file upload chunk, data is @ref img_mgmt_upload_check. */
 	MGMT_EVT_OP_IMG_MGMT_DFU_CHUNK			= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 0),
 
 	/** Callback when a DFU operation is stopped. */
@@ -179,7 +179,7 @@ enum img_mgmt_group_events {
 	/** Callback when a DFU operation has finished being transferred. */
 	MGMT_EVT_OP_IMG_MGMT_DFU_PENDING		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 3),
 
-	/** Callback when an image has been confirmed. data is img_mgmt_image_confirmed(). */
+	/** Callback when an image has been confirmed. data is @ref img_mgmt_image_confirmed. */
 	MGMT_EVT_OP_IMG_MGMT_DFU_CONFIRMED		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 4),
 
 	/** Callback when an image write command has finished writing to flash. */
@@ -187,19 +187,19 @@ enum img_mgmt_group_events {
 
 	/**
 	 * Callback when an image slot's state is encoded for a response, data is
-	 * img_mgmt_state_slot_encode().
+	 * @ref img_mgmt_state_slot_encode.
 	 */
 	MGMT_EVT_OP_IMG_MGMT_IMAGE_SLOT_STATE		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 6),
 
 	/**
 	 * Callback when a slot list command outputs fields for an image, data is
-	 * img_mgmt_slot_info_image().
+	 * @ref img_mgmt_slot_info_image.
 	 */
 	MGMT_EVT_OP_IMG_MGMT_SLOT_INFO_IMAGE		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 7),
 
 	/**
 	 * Callback when a slot list command outputs fields for a slot of an image, data is
-	 * img_mgmt_slot_info_slot().
+	 * @ref img_mgmt_slot_info_slot.
 	 */
 	MGMT_EVT_OP_IMG_MGMT_SLOT_INFO_SLOT		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_IMG, 8),
 
@@ -211,19 +211,19 @@ enum img_mgmt_group_events {
  * MGMT event opcodes for operating system management group.
  */
 enum os_mgmt_group_events {
-	/** Callback when a reset command has been received, data is os_mgmt_reset_data(). */
+	/** Callback when a reset command has been received, data is @ref os_mgmt_reset_data. */
 	MGMT_EVT_OP_OS_MGMT_RESET		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 0),
 
-	/** Callback when an info command is processed, data is os_mgmt_info_check(). */
+	/** Callback when an info command is processed, data is @ref os_mgmt_info_check. */
 	MGMT_EVT_OP_OS_MGMT_INFO_CHECK		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 1),
 
-	/** Callback when an info command needs to output data, data is os_mgmt_info_append(). */
+	/** Callback when an info command needs to output data, data is @ref os_mgmt_info_append. */
 	MGMT_EVT_OP_OS_MGMT_INFO_APPEND		= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 2),
 
 	/** Callback when a datetime get command has been received. */
 	MGMT_EVT_OP_OS_MGMT_DATETIME_GET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 3),
 
-	/** Callback when a datetime set command has been received, data is struct rtc_time(). */
+	/** Callback when a datetime set command has been received, data is @ref rtc_time. */
 	MGMT_EVT_OP_OS_MGMT_DATETIME_SET	= MGMT_DEF_EVT_OP_ID(MGMT_EVT_GRP_OS, 4),
 
 	/**

--- a/include/zephyr/mgmt/mcumgr/mgmt/handlers.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/handlers.h
@@ -17,7 +17,7 @@ extern "C" {
 
 /**
  * @brief MCUmgr handler registration API
- * @defgroup mcumgr_handler_api MCUmgr handler API
+ * @defgroup mcumgr_handler_api Handlers
  * @ingroup mcumgr
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/mgmt.h
@@ -18,8 +18,8 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr mgmt API
- * @defgroup mcumgr_mgmt_api MCUmgr mgmt API
+ * @brief MCUmgr Management API
+ * @defgroup mcumgr_mgmt_api Management
  * @since 1.11
  * @version 1.0.0
  * @ingroup mcumgr
@@ -72,7 +72,9 @@ typedef int (*mgmt_handler_fn)(struct smp_streamer *ctxt);
  * Set use_custom_payload to true when using a user defined payload type
  */
 struct mgmt_handler {
+	/** Read handler */
 	mgmt_handler_fn mh_read;
+	/** Write handler */
 	mgmt_handler_fn mh_write;
 #if defined(CONFIG_MCUMGR_MGMT_HANDLER_USER_DATA)
 	void *user_data;

--- a/include/zephyr/mgmt/mcumgr/mgmt/mgmt_defines.h
+++ b/include/zephyr/mgmt/mcumgr/mgmt/mgmt_defines.h
@@ -15,9 +15,7 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr mgmt API
- * @defgroup mcumgr_mgmt_api MCUmgr mgmt API
- * @ingroup mcumgr
+ * @addtogroup mcumgr_mgmt_api
  * @{
  */
 

--- a/include/zephyr/mgmt/mcumgr/smp/smp_client.h
+++ b/include/zephyr/mgmt/mcumgr/smp/smp_client.h
@@ -15,7 +15,7 @@
 
 /**
  * @brief MCUmgr SMP client API
- * @defgroup mcumgr_smp_client SMP client API
+ * @defgroup mcumgr_smp_client SMP client
  * @ingroup mcumgr
  * @{
  */

--- a/include/zephyr/mgmt/mcumgr/transport/serial.h
+++ b/include/zephyr/mgmt/mcumgr/transport/serial.h
@@ -7,31 +7,45 @@
 #ifndef ZEPHYR_INCLUDE_MGMT_SERIAL_H_
 #define ZEPHYR_INCLUDE_MGMT_SERIAL_H_
 
+/**
+ * @brief This allows to use the MCUmgr SMP protocol over serial.
+ * @defgroup mcumgr_transport_serial Serial transport
+ * @ingroup mcumgr_transport
+ * @{
+ */
+
 #include <zephyr/types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/** Serial packet header */
 #define MCUMGR_SERIAL_HDR_PKT       0x0609
+/** Serial fragment header */
 #define MCUMGR_SERIAL_HDR_FRAG      0x0414
+/** Maximum frame size */
 #define MCUMGR_SERIAL_MAX_FRAME     127
 
+/** First byte of packet header */
 #define MCUMGR_SERIAL_HDR_PKT_1     (MCUMGR_SERIAL_HDR_PKT >> 8)
+/** Second byte of packet header */
 #define MCUMGR_SERIAL_HDR_PKT_2     (MCUMGR_SERIAL_HDR_PKT & 0xff)
+/** First byte of fragment header */
 #define MCUMGR_SERIAL_HDR_FRAG_1    (MCUMGR_SERIAL_HDR_FRAG >> 8)
+/** Second byte of fragment header */
 #define MCUMGR_SERIAL_HDR_FRAG_2    (MCUMGR_SERIAL_HDR_FRAG & 0xff)
 
 /**
  * @brief Maintains state for an incoming mcumgr request packet.
  */
 struct mcumgr_serial_rx_ctxt {
-	/* Contains the partially- or fully-received mcumgr request.  Data
+	/** Contains the partially- or fully-received mcumgr request.  Data
 	 * stored in this buffer has already been base64-decoded.
 	 */
 	struct net_buf *nb;
 
-	/* Length of full packet, as read from header. */
+	/** Length of full packet, as read from header. */
 	uint16_t pkt_len;
 };
 
@@ -82,5 +96,9 @@ int mcumgr_serial_tx_pkt(const uint8_t *data, int len, mcumgr_serial_tx_cb cb);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif

--- a/include/zephyr/mgmt/mcumgr/transport/smp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp.h
@@ -15,9 +15,9 @@ extern "C" {
 #endif
 
 /**
- * @brief MCUmgr transport SMP API
- * @defgroup mcumgr_transport_smp MCUmgr transport SMP API
- * @ingroup mcumgr
+ * @brief MCUmgr SMP transport API
+ * @defgroup mcumgr_transport_smp SMP transport
+ * @ingroup mcumgr_transport
  * @{
  */
 

--- a/include/zephyr/mgmt/mcumgr/transport/smp_bt.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_bt.h
@@ -6,10 +6,18 @@
 
 /** @file
  * @brief Bluetooth transport for the mcumgr SMP protocol.
+ * @ingroup mcumgr_transport_bt
  */
 
 #ifndef ZEPHYR_INCLUDE_MGMT_SMP_BT_H_
 #define ZEPHYR_INCLUDE_MGMT_SMP_BT_H_
+
+/**
+ * @brief This allows to use the MCUmgr SMP protocol over Bluetooth.
+ * @defgroup mcumgr_transport_bt Bluetooth transport
+ * @ingroup mcumgr_transport
+ * @{
+ */
 
 #include <zephyr/bluetooth/uuid.h>
 #include <zephyr/types.h>
@@ -67,5 +75,9 @@ int smp_bt_notify(struct bt_conn *conn, const void *data, uint16_t len);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif

--- a/include/zephyr/mgmt/mcumgr/transport/smp_dummy.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_dummy.h
@@ -7,9 +7,18 @@
 
 /** @file
  * @brief Dummy transport for the mcumgr SMP protocol for unit testing.
+ * @ingroup mcumgr_transport_dummy
  */
 #ifndef ZEPHYR_INCLUDE_MGMT_MCUMGR_TRANSPORT_DUMMY_H_
 #define ZEPHYR_INCLUDE_MGMT_MCUMGR_TRANSPORT_DUMMY_H_
+
+/**
+ * @brief This allows to use the MCUmgr SMP protocol over a dummy transport, usually for testing
+ *        purposes.
+ * @defgroup mcumgr_transport_dummy Dummy transport
+ * @ingroup mcumgr_transport
+ * @{
+ */
 
 #include <zephyr/kernel.h>
 #include <zephyr/net_buf.h>
@@ -101,5 +110,9 @@ bool smp_dummy_get_status(void);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_MGMT_MCUMGR_TRANSPORT_DUMMY_H_ */

--- a/include/zephyr/mgmt/mcumgr/transport/smp_shell.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_shell.h
@@ -6,10 +6,18 @@
 
 /** @file
  * @brief Shell transport for the mcumgr SMP protocol.
+ * @ingroup mcumgr_transport_shell
  */
 
 #ifndef ZEPHYR_INCLUDE_MGMT_SMP_SHELL_H_
 #define ZEPHYR_INCLUDE_MGMT_SMP_SHELL_H_
+
+/**
+ * @brief This allows to use the MCUmgr SMP protocol over Zephyr shell.
+ * @defgroup mcumgr_transport_shell Shell transport
+ * @ingroup mcumgr_transport
+ * @{
+ */
 
 #include <zephyr/kernel.h>
 #include <zephyr/types.h>
@@ -65,5 +73,9 @@ int smp_shell_init(void);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif

--- a/include/zephyr/mgmt/mcumgr/transport/smp_udp.h
+++ b/include/zephyr/mgmt/mcumgr/transport/smp_udp.h
@@ -8,10 +8,18 @@
 /**
  * @file
  * @brief UDP transport for the MCUmgr SMP protocol.
+ * @ingroup mcumgr_transport_udp
  */
 
 #ifndef ZEPHYR_INCLUDE_MGMT_SMP_UDP_H_
 #define ZEPHYR_INCLUDE_MGMT_SMP_UDP_H_
+
+/**
+ * @brief This allows to use the MCUmgr SMP protocol over UDP.
+ * @defgroup mcumgr_transport_udp UDP transport
+ * @ingroup mcumgr_transport
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,5 +49,9 @@ int smp_udp_close(void);
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif


### PR DESCRIPTION
This cleans up the doxygen documentation for the MCUmgr subsystem (consolidated the doxygen groups, added some missing docs, added proper `@name`'d sections where appropriate, etc).

https://builds.zephyrproject.io/zephyr/pr/94769/docs/doxygen/html/group__mcumgr.html

Current version in main: https://docs.zephyrproject.org/latest/doxygen/html/group__mcumgr.html