### PR TITLE
Ethernet: NXP: fix: Scrub tx_header to prevent failed assert

### DIFF
--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -131,12 +131,7 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 						      k_thread_name_get(k_current_get()));
 
 	net_pkt_ref(pkt);
-
 	data->tx.pkt = pkt;
-	/* Need to save the header because the ethernet stack
-	 * otherwise discards it from the packet after this call
-	 */
-	data->tx.tx_header = pkt->frags;
 
 	LOG_DBG("Setting up TX descriptors for packet %p", pkt);
 
@@ -197,8 +192,6 @@ static void tx_dma_done(const struct device *dev)
 		net_pkt_frag_unref(fragment);
 		fragment = fragment->frags;
 	}
-
-	net_pkt_frag_unref(data->tx.tx_header);
 	net_pkt_unref(pkt);
 
 	eth_stats_update_pkts_tx(data->iface);

--- a/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
+++ b/drivers/ethernet/eth_nxp_enet_qos/nxp_enet_qos_priv.h
@@ -106,7 +106,6 @@ struct nxp_enet_qos_mac_config {
 struct nxp_enet_qos_tx_data {
 	struct k_sem tx_sem;
 	struct net_pkt *pkt;
-	struct net_buf *tx_header;
 	volatile union nxp_enet_qos_tx_desc descriptors[NUM_TX_BUFDESC];
 };
 


### PR DESCRIPTION
As it's not being used anywhere in the driver. Moreover, the extra unref would trigger a double-free assert (#94311); which is what motivated this cleanup.