### PR TITLE
modules: hostap: flush all unused BSS entries before 11V roaming

### DIFF
--- a/modules/hostap/src/supp_api.c
+++ b/modules/hostap/src/supp_api.c
@@ -1908,6 +1908,11 @@ int supplicant_btm_query(const struct device *dev, uint8_t reason)
 		goto out;
 	}
 
+	/* Flush all unused BSS entries */
+	if (!wpa_cli_cmd_v("bss_flush")) {
+		goto out;
+	}
+
 	if (!wpa_cli_cmd_v("wnm_bss_query %d", reason)) {
 		goto out;
 	}


### PR DESCRIPTION
For 11V roaming, it attempts to use previously received scan results, if they are recent enough to be used for connection. If wifi driver does not keep the previous scan results, it will failed to find the bss entry.
Fix: flush all unused BSS entries, for 11V roaming, don't try to use recent scan results.