### PR TITLE
bluetooth: host: gatt: Make retry feature explicitly dependent on client

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -33,7 +33,7 @@ config BT_ATT_PREPARE_COUNT
 config BT_ATT_RETRY_ON_SEC_ERR
 	bool "Automatic security elevation and retry on security errors"
 	default y
-	depends on BT_SMP
+	depends on BT_SMP && BT_GATT_CLIENT
 	help
 	  If an ATT request fails due to insufficient security, the host will
 	  try to elevate the security level and retry the ATT request.


### PR DESCRIPTION
`CONFIG_BT_ATT_RETRY_ON_SEC_ERR` is never used without `CONFIG_BT_GATT_CLIENT`. Users can enable it without seeing any change. This creates a bad UX.

This changes fixes this by making explicit dependency of the retry feature on GATT client support.

This can be considered as a braking API change, however, this was never correct to enable `CONFIG_BT_ATT_RETRY_ON_SEC_ERR` without `CONFIG_BT_GATT_CLIENT`.