### PR TITLE
Bluetooth: ATT, Conn, GATT, ASCS: Changed to LOG statements for buffer allocation

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -543,8 +543,9 @@ static void state_transition_work_handler(struct k_work *work)
 			/* Reschedule the state transition */
 			err = k_work_reschedule(d_work, K_MSEC(retry_delay_ms));
 			if (err >= 0) {
-				LOG_WRN("Out of buffers for ase state notification. "
-					"Will retry in %dms", retry_delay_ms);
+				LOG_DBG("Out of buffers for ase state notification. "
+					"Will retry in %dms",
+					retry_delay_ms);
 				return;
 			}
 		}

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -748,7 +748,7 @@ static struct net_buf *bt_att_chan_create_pdu(struct bt_att_chan *chan, uint8_t 
 	/* This will reserve headspace for lower layers */
 	buf = bt_l2cap_create_pdu_timeout(&att_pool, 0, timeout);
 	if (!buf) {
-		LOG_ERR("Unable to allocate buffer for op 0x%02x", op);
+		LOG_DBG("Unable to allocate buffer for op 0x%02x", op);
 		return NULL;
 	}
 
@@ -831,6 +831,7 @@ static void send_err_rsp(struct bt_att_chan *chan, uint8_t req, uint16_t handle,
 
 	buf = bt_att_chan_create_pdu(chan, BT_ATT_OP_ERROR_RSP, sizeof(*rsp));
 	if (!buf) {
+		LOG_ERR("Unable to create err rsp PDU");
 		return;
 	}
 
@@ -2129,6 +2130,7 @@ static uint8_t att_write_rsp(struct bt_att_chan *chan, uint8_t req, uint8_t rsp,
 	if (rsp) {
 		data.buf = bt_att_chan_create_pdu(chan, rsp, 0);
 		if (!data.buf) {
+			LOG_ERR("Unable to create rsp PDU");
 			return BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 		}
 	}
@@ -2731,6 +2733,7 @@ static uint8_t att_indicate(struct bt_att_chan *chan, struct net_buf *buf)
 
 	buf = bt_att_chan_create_pdu(chan, BT_ATT_OP_CONFIRM, 0);
 	if (!buf) {
+		LOG_ERR("Unable to create confirm PDU");
 		return 0;
 	}
 
@@ -3266,6 +3269,7 @@ static uint8_t att_req_retry(struct bt_att_chan *att_chan)
 
 	buf = bt_att_chan_create_pdu(att_chan, req->att_op, req->len);
 	if (!buf) {
+		LOG_ERR("Unable to create retry PDU (%u)", req->att_op);
 		return BT_ATT_ERR_UNLIKELY;
 	}
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1627,7 +1627,7 @@ struct net_buf *bt_conn_create_pdu_timeout(struct net_buf_pool *pool,
 	}
 
 	if (!buf) {
-		LOG_WRN("Unable to allocate buffer within timeout");
+		LOG_DBG("Unable to allocate buffer within timeout");
 		return NULL;
 	}
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1725,7 +1725,7 @@ int bt_gatt_service_register(struct bt_gatt_service *svc)
 	if (IS_ENABLED(CONFIG_BT_SETTINGS) &&
 	    atomic_test_bit(gatt_flags, GATT_INITIALIZED) &&
 	    !atomic_test_bit(gatt_sc.flags, SC_LOAD)) {
-		LOG_ERR("Can't register service after init and before settings are loaded.");
+		LOG_DBG("Can't register service after init and before settings are loaded.");
 		return -EINVAL;
 	}
 
@@ -1829,7 +1829,7 @@ ssize_t bt_gatt_attr_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	}
 
 	if (value_len != 0U && value == NULL) {
-		LOG_WRN("value_len of %u provided for NULL value", value_len);
+		LOG_DBG("value_len of %u provided for NULL value", value_len);
 
 		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 	}
@@ -2527,7 +2527,7 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 
 	/* Confirm that the connection has the correct level of security */
 	if (bt_gatt_check_perm(conn, params->attr, BT_GATT_PERM_READ_ENCRYPT_MASK)) {
-		LOG_WRN("Link is not encrypted");
+		LOG_DBG("Link is not encrypted");
 		return -EPERM;
 	}
 
@@ -2537,7 +2537,7 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 		 * but follows its spirit.
 		 */
 		if (!bt_gatt_is_subscribed(conn, params->attr, BT_GATT_CCC_NOTIFY)) {
-			LOG_WRN("Device is not subscribed to characteristic");
+			LOG_DBG("Device is not subscribed to characteristic");
 			return -EINVAL;
 		}
 	}
@@ -2556,7 +2556,7 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 	buf = bt_att_create_pdu(conn, BT_ATT_OP_NOTIFY,
 				sizeof(*nfy) + params->len);
 	if (!buf) {
-		LOG_WRN("No buffer available to send notification");
+		LOG_DBG("No buffer available to send notification");
 		return -ENOMEM;
 	}
 
@@ -2691,7 +2691,7 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 
 	/* Confirm that the connection has the correct level of security */
 	if (bt_gatt_check_perm(conn, params->attr, BT_GATT_PERM_READ_ENCRYPT_MASK)) {
-		LOG_WRN("Link is not encrypted");
+		LOG_DBG("Link is not encrypted");
 		return -EPERM;
 	}
 
@@ -2701,7 +2701,7 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 		 * but follows its spirit.
 		 */
 		if (!bt_gatt_is_subscribed(conn, params->attr, BT_GATT_CCC_INDICATE)) {
-			LOG_WRN("Device is not subscribed to characteristic");
+			LOG_DBG("Device is not subscribed to characteristic");
 			return -EINVAL;
 		}
 	}
@@ -2721,7 +2721,7 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 
 	buf = bt_att_create_pdu(conn, BT_ATT_OP_INDICATE, len);
 	if (!buf) {
-		LOG_WRN("No buffer available to send indication");
+		LOG_DBG("No buffer available to send indication");
 		bt_att_req_free(req);
 		return -ENOMEM;
 	}
@@ -2814,7 +2814,7 @@ static uint8_t notify_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 
 		/* Confirm that the connection has the correct level of security */
 		if (bt_gatt_check_perm(conn, attr, BT_GATT_PERM_READ_ENCRYPT_MASK)) {
-			LOG_WRN("Link is not encrypted");
+			LOG_DBG("Link %p is not encrypted", (void *)conn);
 			bt_conn_unref(conn);
 			continue;
 		}
@@ -3015,7 +3015,7 @@ static int gatt_notify_multiple_verify_params(struct bt_conn *conn,
 		if (bt_gatt_check_perm(conn, params[i].attr,
 				       BT_GATT_PERM_READ_ENCRYPT |
 				       BT_GATT_PERM_READ_AUTHEN)) {
-			LOG_WRN("Link is not encrypted");
+			LOG_DBG("Link %p is not encrypted", (void *)conn);
 			return -EPERM;
 		}
 
@@ -4741,7 +4741,7 @@ int bt_gatt_discover(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_ATTRIBUTE:
 		return gatt_find_info(conn, params);
 	default:
-		LOG_ERR("Invalid discovery type: %u", params->type);
+		LOG_DBG("Invalid discovery type: %u", params->type);
 	}
 
 	return -EINVAL;
@@ -5127,7 +5127,7 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 
 	write = net_buf_append_bytes(buf, length, data, K_NO_WAIT, NULL, NULL);
 	if (write != length) {
-		LOG_WRN("Unable to allocate length %u: only %zu written", length, write);
+		LOG_DBG("Unable to allocate length %u: only %zu written", length, write);
 		net_buf_unref(buf);
 		return -ENOMEM;
 	}

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -5095,7 +5095,7 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 {
 	struct net_buf *buf;
 	struct bt_att_write_cmd *cmd;
-	size_t write;
+	__maybe_unused size_t write;
 
 	__ASSERT(conn, "invalid parameters\n");
 	__ASSERT(handle, "invalid parameters\n");
@@ -5126,11 +5126,7 @@ int bt_gatt_write_without_response_cb(struct bt_conn *conn, uint16_t handle,
 	cmd->handle = sys_cpu_to_le16(handle);
 
 	write = net_buf_append_bytes(buf, length, data, K_NO_WAIT, NULL, NULL);
-	if (write != length) {
-		LOG_DBG("Unable to allocate length %u: only %zu written", length, write);
-		net_buf_unref(buf);
-		return -ENOMEM;
-	}
+	__ASSERT(write == length, "Unable to allocate length %u: only %zu written", length, write);
 
 	LOG_DBG("handle 0x%04x length %u", handle, length);
 


### PR DESCRIPTION
In the case of buffer allocation issues, or if there is an appropriate return value from API functions, then we should not use LOG_WRN and LOG_ERR as the caller can (and should) handle the cases based on the return value. 