### PR TITLE
dts: arm: st: wba: temporary fix to build stm32wba5x boards

### DIFF
--- a/dts/arm/st/wba/stm32wba.dtsi
+++ b/dts/arm/st/wba/stm32wba.dtsi
@@ -564,7 +564,8 @@
 		compatible = "swj-connector";
 		pinctrl-0 = <&debug_jtms_swdio_pa13 &debug_jtck_swclk_pa14
 			     &debug_jtdi_pa15 &debug_jtdo_swo_pb3
-			     &debug_njtrst_pb4>;
+			     /* temp fix to cover current wba5 pin naming */
+			     &debug_jtrst_pb4>;
 		pinctrl-1 = <&analog_pa13 &analog_pa14 &analog_pa15
 			     &analog_pb3 &analog_pb4>;
 		pinctrl-names = "default", "sleep";

--- a/dts/arm/st/wba/stm32wba65.dtsi
+++ b/dts/arm/st/wba/stm32wba65.dtsi
@@ -79,6 +79,16 @@
 		};
 	};
 
+	/*
+	 * Temporary revert of pinctrl-0 definition for stm3wba65
+	 * to fix issue on stm32wba5x based boards
+	 */
+	swj_port: swj_port {
+		pinctrl-0 = <&debug_jtms_swdio_pa13 &debug_jtck_swclk_pa14
+			     &debug_jtdi_pa15 &debug_jtdo_swo_pb3
+			     &debug_njtrst_pb4>;
+	};
+
 	die_temp: dietemp {
 		ts-cal1-addr = <0x0BFA0710>;
 		ts-cal2-addr = <0x0BFA0742>;

--- a/west.yml
+++ b/west.yml
@@ -245,7 +245,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: d46f8453c5ce28fb6aba7613de7ebc75bd8572c3
+      revision: 611d54c237623ea71a367502bfbd736fc67ba15f
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Due to a mismatch in naming of debug jtrst pin name all boards based on stm32wba5x are not compiling.
This temporary fix will solve thi issue until a systematic approach will be put in place.