### PR TITLE
drivers: pwm: Enable PWM support for PTL-h

### DIFF
--- a/boards/intel/ptl/intel_ptl_h_crb.dts
+++ b/boards/intel/ptl/intel_ptl_h_crb.dts
@@ -43,3 +43,7 @@
 &tco_wdt {
 	status = "okay";
 };
+
+&pwm0 {
+	status = "okay";
+};

--- a/boards/intel/ptl/intel_ptl_h_crb.yaml
+++ b/boards/intel/ptl/intel_ptl_h_crb.yaml
@@ -12,6 +12,7 @@ supported:
   - watchdog
   - uart
   - rtc
+  - pwm
 testing:
   ignore_tags:
     - net

--- a/drivers/pwm/pwm_intel_blinky.c
+++ b/drivers/pwm/pwm_intel_blinky.c
@@ -27,6 +27,7 @@ struct bk_intel_config {
 	uint32_t reg_offset;
 	uint32_t clock_freq;
 	uint32_t max_pins;
+	uint32_t reg_upper_32; /* Stores higher 32 bits of 64 bit reg address */
 };
 
 struct bk_intel_runtime {
@@ -103,9 +104,13 @@ static int bk_intel_init(const struct device *dev)
 {
 	struct bk_intel_runtime *runtime = dev->data;
 	const struct bk_intel_config *config = dev->config;
+	uintptr_t physical_addr;
+
+	physical_addr = (config->reg_base.phys_addr & ~0xFFU)
+			| ((uintptr_t)config->reg_upper_32 << 32);
 
 	device_map(&runtime->reg_base,
-		   config->reg_base.phys_addr & ~0xFFU,
+		   physical_addr,
 		   config->reg_base.size,
 		   K_MEM_CACHE_NONE);
 
@@ -118,6 +123,7 @@ static int bk_intel_init(const struct device *dev)
 		.reg_offset = DT_INST_PROP(n, reg_offset),		       \
 		.max_pins = DT_INST_PROP(n, max_pins),			       \
 		.clock_freq = DT_INST_PROP(n, clock_frequency),		       \
+		.reg_upper_32 = DT_INST_PROP(n, reg_upper32),		       \
 	};								       \
 									       \
 	static struct bk_intel_runtime bk_rt_##n;			       \

--- a/dts/bindings/pwm/intel,blinky-pwm.yaml
+++ b/dts/bindings/pwm/intel,blinky-pwm.yaml
@@ -27,6 +27,14 @@ properties:
     required: true
     description: Maximum number of pins supported by platform
 
+  reg-upper32:
+    type: int
+    default: 0
+    description: |
+      Few platforms have 64 bit PWM register address,
+      this property will be used to share the higher
+      32 bits(63-32).
+
   "#pwm-cells":
     const: 2
 

--- a/dts/x86/intel/panther_lake_h.dtsi
+++ b/dts/x86/intel/panther_lake_h.dtsi
@@ -293,6 +293,17 @@
 			status = "disabled";
 		};
 
+		pwm0: pwm@5d0000 {
+			compatible = "intel,blinky-pwm";
+			reg = <0x5d0000 0x500>;
+			reg-upper32 = <0x40>;
+			reg-offset = <0x434>;
+			clock-frequency = <32768>;
+			max-pins = <1>;
+			#pwm-cells = <2>;
+			status = "disabled";
+		};
+
 		rtc: counter: rtc@70 {
 			compatible = "motorola,mc146818";
 			reg = <0x70 0x0D 0x71 0x0D>;

--- a/tests/drivers/pwm/pwm_api/boards/intel_ptl_h_crb.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/intel_ptl_h_crb.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pwm0 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable PWM support on PTL-h and add 64bit address support for PWM driver.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>