### PR TITLE
Sy1xx/compile net samples (sensry sy1xx boards)

### DIFF
--- a/boards/sensry/ganymed_bob/Kconfig.defconfig
+++ b/boards/sensry/ganymed_bob/Kconfig.defconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 sensry.io
+# SPDX-License-Identifier: Apache-2.0
+
+configdefault NET_L2_ETHERNET
+	default y

--- a/boards/sensry/ganymed_sk/Kconfig.defconfig
+++ b/boards/sensry/ganymed_sk/Kconfig.defconfig
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 sensry.io
+# SPDX-License-Identifier: Apache-2.0
+
+configdefault NET_L2_ETHERNET
+	default y


### PR DESCRIPTION
when network is enabled, we need to

- enable NET_L2_ETHERNET
