### PR TITLE
subsys: ipc: add more tests on nrf5340bsim

### DIFF
--- a/include/zephyr/ipc/pbuf.h
+++ b/include/zephyr/ipc/pbuf.h
@@ -270,6 +270,18 @@ void pbuf_handshake_write(struct pbuf *pb, uint32_t value);
 int pbuf_get_initial_buf(struct pbuf *pb, volatile char **buf, uint16_t *len);
 
 /**
+ * @brief Remap embedded addresses to native addresses.
+ *
+ * This function is to be used only with native simulator based targets and
+ * remaps addresses of a pbuf from devicetree addesses to
+ * allocated native memory address ranges.
+ * This is only used in the IPC backend implementations.
+ *
+ * @param pb A buffer to be remapped.
+ */
+void pbuf_native_addr_remap(struct pbuf *pb);
+
+/**
  * @}
  */
 

--- a/subsys/ipc/ipc_service/lib/icmsg.c
+++ b/subsys/ipc/ipc_service/lib/icmsg.c
@@ -412,6 +412,10 @@ int icmsg_open(const struct icmsg_config_t *conf,
 	k_mutex_init(&dev_data->tx_lock);
 #endif
 
+#if defined(CONFIG_ARCH_POSIX)
+	pbuf_native_addr_remap(dev_data->tx_pb);
+#endif
+
 	ret = pbuf_rx_init(dev_data->rx_pb);
 
 	if (ret < 0) {

--- a/subsys/ipc/ipc_service/lib/pbuf.c
+++ b/subsys/ipc/ipc_service/lib/pbuf.c
@@ -65,6 +65,7 @@ static int validate_cfg(const struct pbuf_cfg *cfg)
 void pbuf_native_addr_remap(struct pbuf *pb)
 {
 	native_emb_addr_remap((void **)&pb->cfg->rd_idx_loc);
+	native_emb_addr_remap((void **)&pb->cfg->handshake_loc);
 	native_emb_addr_remap((void **)&pb->cfg->wr_idx_loc);
 	native_emb_addr_remap((void **)&pb->cfg->data_loc);
 }

--- a/tests/subsys/ipc/ipc_sessions/Kconfig.sysbuild
+++ b/tests/subsys/ipc/ipc_sessions/Kconfig.sysbuild
@@ -9,5 +9,6 @@ source "$(ZEPHYR_BASE)/share/sysbuild/Kconfig"
 config REMOTE_BOARD
 	string "The board used for remote target"
 	default "nrf5340dk/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP
+	default "nrf5340bsim/nrf5340/cpunet" if BOARD_NRF5340BSIM_NRF5340_CPUAPP
 	default "nrf5340dk/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 	default "nrf54h20dk/nrf54h20/cpurad" if BOARD_NRF54H20DK_NRF54H20_CPUAPP

--- a/tests/subsys/ipc/ipc_sessions/boards/nrf5340bsim_nrf5340_cpuapp.conf
+++ b/tests/subsys/ipc/ipc_sessions/boards/nrf5340bsim_nrf5340_cpuapp.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2025 Dmitrii Sharshakov <d3dx12.xx@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_IPC_TEST_SKIP_CORE_RESET=y

--- a/tests/subsys/ipc/ipc_sessions/boards/nrf5340bsim_nrf5340_cpuapp.overlay
+++ b/tests/subsys/ipc/ipc_sessions/boards/nrf5340bsim_nrf5340_cpuapp.overlay
@@ -1,0 +1,5 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf5340dk_nrf5340_cpuapp.overlay"

--- a/tests/subsys/ipc/ipc_sessions/remote/boards/nrf5340bsim_nrf5340_cpunet.overlay
+++ b/tests/subsys/ipc/ipc_sessions/remote/boards/nrf5340bsim_nrf5340_cpunet.overlay
@@ -1,0 +1,5 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf5340dk_nrf5340_cpunet.overlay"

--- a/tests/subsys/ipc/ipc_sessions/remote/src/remote.c
+++ b/tests/subsys/ipc/ipc_sessions/remote/src/remote.c
@@ -420,7 +420,7 @@ int main(void)
 			LOG_INF("Initial seed: %u", ipc_tx_params.seed);
 
 			cmd_data->cmd = IPC_TEST_CMD_XDATA;
-			for (/* No init */; ipc_tx_params.blk_cnt > 0; --ipc_tx_params.blk_cnt) {
+			while (ipc_tx_params.blk_cnt > 0) {
 				int ret;
 
 				if (ipc_tx_params.blk_cnt % 1000 == 0) {
@@ -430,6 +430,7 @@ int main(void)
 				for (size_t n = 0; n < ipc_tx_params.blk_size; ++n) {
 					cmd_data->data[n] = (uint8_t)rand_r(&ipc_tx_params.seed);
 				}
+				--ipc_tx_params.blk_cnt;
 				do {
 					ret = ipc_service_send(ep_cfg.priv, cmd_data, cmd_size);
 					Z_SPIN_DELAY(1);

--- a/tests/subsys/ipc/ipc_sessions/remote/src/remote.c
+++ b/tests/subsys/ipc/ipc_sessions/remote/src/remote.c
@@ -432,6 +432,7 @@ int main(void)
 				}
 				do {
 					ret = ipc_service_send(ep_cfg.priv, cmd_data, cmd_size);
+					Z_SPIN_DELAY(1);
 				} while (ret == -ENOMEM);
 				if (ret < 0) {
 					LOG_ERR("Cannot send TX test buffer: %d", ret);

--- a/tests/subsys/ipc/ipc_sessions/src/main.c
+++ b/tests/subsys/ipc/ipc_sessions/src/main.c
@@ -332,7 +332,7 @@ ZTEST(ipc_sessions, test_tx_long)
 	zassert_not_null(cmd_rxstat, "No command response on time");
 	zassert_equal(cmd_rsp_size, sizeof(*cmd_rxstat),
 		      "Unexpected response size: %u, expected: %u", cmd_rsp_size,
-		      sizeof(cmd_rxstat));
+		      sizeof(*cmd_rxstat));
 	zassert_equal(cmd_rxstat->base.cmd, IPC_TEST_CMD_XSTAT,
 		      "Unexpected command in response: %u", cmd_rxstat->base.cmd);
 	zassert_ok(cmd_rxstat->result, "RX result not ok: %d", cmd_rxstat->result);
@@ -365,7 +365,7 @@ ZTEST(ipc_sessions, test_tx_long)
 	zassert_not_null(cmd_rxstat, "No command response on time");
 	zassert_equal(cmd_rsp_size, sizeof(*cmd_rxstat),
 		      "Unexpected response size: %u, expected: %u", cmd_rsp_size,
-		      sizeof(cmd_rxstat));
+		      sizeof(*cmd_rxstat));
 	zassert_equal(cmd_rxstat->base.cmd, IPC_TEST_CMD_XSTAT,
 		      "Unexpected command in response: %u", cmd_rxstat->base.cmd);
 	zassert_ok(cmd_rxstat->result, "RX result not ok: %d", cmd_rxstat->result);
@@ -449,7 +449,7 @@ ZTEST(ipc_sessions, test_rx_long)
 	zassert_not_null(cmd_txstat, "No command response on time");
 	zassert_equal(cmd_rsp_size, sizeof(*cmd_txstat),
 		      "Unexpected response size: %u, expected: %u", cmd_rsp_size,
-		      sizeof(cmd_txstat));
+		      sizeof(*cmd_txstat));
 	zassert_equal(cmd_txstat->base.cmd, IPC_TEST_CMD_XSTAT,
 		      "Unexpected command in response: %u", cmd_txstat->base.cmd);
 	zassert_ok(cmd_txstat->result, "RX result not ok: %d", cmd_txstat->result);

--- a/tests/subsys/ipc/ipc_sessions/src/main.c
+++ b/tests/subsys/ipc/ipc_sessions/src/main.c
@@ -348,6 +348,7 @@ ZTEST(ipc_sessions, test_tx_long)
 		}
 		do {
 			ret = ipc_service_send(&ep, &cmd_txdata, sizeof(cmd_txdata));
+			Z_SPIN_DELAY(1);
 		} while (ret == -ENOMEM);
 		if ((blk % 1000) == 0) {
 			LOG_INF("Transfer number: %u of %u", blk, cmd_rxstart.blk_cnt);

--- a/tests/subsys/ipc/ipc_sessions/sysbuild.cmake
+++ b/tests/subsys/ipc/ipc_sessions/sysbuild.cmake
@@ -24,3 +24,6 @@ set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
 sysbuild_add_dependencies(CONFIGURE ${DEFAULT_IMAGE} remote)
 # Add dependency so that the remote image is flashed first.
 sysbuild_add_dependencies(FLASH ${DEFAULT_IMAGE} remote)
+
+native_simulator_set_child_images(${DEFAULT_IMAGE} remote)
+native_simulator_set_final_executable(${DEFAULT_IMAGE})

--- a/tests/subsys/ipc/ipc_sessions/testcase.yaml
+++ b/tests/subsys/ipc/ipc_sessions/testcase.yaml
@@ -17,6 +17,22 @@ tests:
       - nrf5340bsim/nrf5340/cpuapp
     extra_args:
       - CONFIG_IPC_TEST_SKIP_CORE_RESET=y
+  ipc.ipc_sessions.nrf5340bsim_cpuapp_no_unbound_cpunet:
+    platform_allow:
+      - nrf5340bsim/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340bsim/nrf5340/cpuapp
+    extra_args:
+      - CONFIG_IPC_TEST_SKIP_UNBOUND=y
+      - CONFIG_IPC_SERVICE_BACKEND_ICMSG_V1=y
+  ipc.ipc_sessions.nrf5340bsim_cpuapp_cpunet_no_unbound:
+    platform_allow:
+      - nrf5340bsim/nrf5340/cpuapp
+    integration_platforms:
+      - nrf5340bsim/nrf5340/cpuapp
+    extra_args:
+      - CONFIG_IPC_TEST_SKIP_UNBOUND=y
+      - remote_CONFIG_IPC_SERVICE_BACKEND_ICMSG_V1=y
   test.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpurad:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp

--- a/tests/subsys/ipc/ipc_sessions/testcase.yaml
+++ b/tests/subsys/ipc/ipc_sessions/testcase.yaml
@@ -8,11 +8,13 @@ common:
   harness: ztest
 
 tests:
-  test.ipc.ipc_sessions.nrf5340dk:
+  ipc.ipc_sessions:
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
+      - nrf5340bsim/nrf5340/cpuapp
     extra_args:
       - CONFIG_IPC_TEST_SKIP_CORE_RESET=y
   test.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpurad:


### PR DESCRIPTION
Make sure IPC subsystem is easy to test on BabbleSim for better CI coverage.

- **samples: ipc: icmsg: set EP name**
- **samples: ipc: icmsg: test icbmsg on nrf5340bsim**
- ...
