### PR TITLE
soc: it51xxx: Disable default 15K pull-down on GPF4/GPF5

### DIFF
--- a/soc/ite/ec/it51xxx/chip_chipregs.h
+++ b/soc/ite/ec/it51xxx/chip_chipregs.h
@@ -91,8 +91,12 @@ struct smfi_it51xxx_regs {
 struct gpio_it51xxx_regs {
 	/* 0x00: General Control */
 	volatile uint8_t GPIO_GCR;
-	/* 0x01-CF: Reserved_01_cf */
-	volatile uint8_t reserved_01_cf[207];
+	/* 0x01-C1: Reserved_01_c1 */
+	volatile uint8_t reserved_01_c1[193];
+	/* 0xC2: General Control 35 */
+	volatile uint8_t GPIO_GCR35;
+	/* 0xC3-CF: Reserved_c3_cf */
+	volatile uint8_t reserved_c3_cf[13];
 	/* 0xD0: General Control 31 */
 	volatile uint8_t GPIO_GCR31;
 	/* 0xD1: General Control 32 */
@@ -194,6 +198,8 @@ struct gpio_it51xxx_regs {
 /* 0x00: General Control */
 #define IT51XXX_GPIO_LPCRSTEN             (BIT(2) | BIT(1))
 #define ITE_EC_GPIO_LPCRSTEN              IT51XXX_GPIO_LPCRSTEN
+/* 0xC2: General Control 35 */
+#define IT51XXX_GPIO_USBPDEN              BIT(5)
 /* 0xF0: General Control 1 */
 #define IT51XXX_GPIO_U2CTRL_SIN1_SOUT1_EN BIT(2)
 #define IT51XXX_GPIO_U1CTRL_SIN0_SOUT0_EN BIT(0)

--- a/soc/ite/ec/it51xxx/soc.c
+++ b/soc/ite/ec/it51xxx/soc.c
@@ -117,6 +117,9 @@ void soc_prep_hook(void)
 	struct gpio_ite_ec_regs *const gpio_regs = GPIO_ITE_EC_REGS_BASE;
 	struct gctrl_ite_ec_regs *const gctrl_regs = GCTRL_ITE_EC_REGS_BASE;
 
+	/* USB pull down disable */
+	gpio_regs->GPIO_GCR35 &= ~IT51XXX_GPIO_USBPDEN;
+
 	/* Set FSPI pins are tri-state */
 	sys_write8(sys_read8(IT51XXX_SMFI_FLHCTRL3R) | IT51XXX_SMFI_FFSPITRI,
 		   IT51XXX_SMFI_FLHCTRL3R);


### PR DESCRIPTION
When GPIOF4 and GPIOF5 are not used as USB alternate function, the default 15K pull-down should be disabled.