### PR TITLE
soc: nordic: uicr: Reorganize how gen_uicr.py is invoked

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1250,6 +1250,7 @@ flagged.
         "FOO_LOG_LEVEL",
         "FOO_SETTING_1",
         "FOO_SETTING_2",
+        "GEN_UICR_GENERATE_PERIPHCONF", # Used in specialized build tool, not part of main Kconfig
         "HEAP_MEM_POOL_ADD_SIZE_", # Used as an option matching prefix
         "HUGETLBFS",          # Linux, in boards/xtensa/intel_adsp_cavs25/doc
         "IAR_BUFFERED_WRITE",

--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -433,26 +433,6 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                             core='Application',
                         )
 
-            if self.build_conf.getboolean("CONFIG_NRF_HALTIUM_GENERATE_UICR"):
-                zephyr_build_dir = Path(self.cfg.build_dir) / 'zephyr'
-
-                self.op_program(
-                    str(zephyr_build_dir / 'uicr.hex'),
-                    'ERASE_NONE',
-                    None,
-                    defer=True,
-                    core='Application',
-                )
-
-                if self.build_conf.getboolean("CONFIG_NRF_HALTIUM_UICR_PERIPHCONF"):
-                    self.op_program(
-                        str(zephyr_build_dir / 'periphconf.hex'),
-                        'ERASE_NONE',
-                        None,
-                        defer=True,
-                        core='Application',
-                    )
-
             if not self.erase and regtool_generated_uicr:
                 self.exec_op('erase', core=core, kind='uicr')
         else:

--- a/soc/nordic/Kconfig.sysbuild
+++ b/soc/nordic/Kconfig.sysbuild
@@ -4,5 +4,6 @@
 config HAS_NORDIC_VPR_LAUNCHER_IMAGE
 	bool
 
+rsource "common/uicr/Kconfig.sysbuild"
 rsource "common/vpr/Kconfig.sysbuild"
 orsource "*/Kconfig.sysbuild"

--- a/soc/nordic/common/CMakeLists.txt
+++ b/soc/nordic/common/CMakeLists.txt
@@ -3,9 +3,7 @@
 
 add_subdirectory_ifdef(CONFIG_RISCV_CORE_NORDIC_VPR vpr)
 
-if(CONFIG_NRF_PERIPHCONF_SECTION OR CONFIG_NRF_HALTIUM_GENERATE_UICR)
-  add_subdirectory(uicr)
-endif()
+add_subdirectory(uicr)
 
 # Let SystemInit() be called in place of soc_reset_hook() by default.
 zephyr_linker_symbol(SYMBOL soc_reset_hook EXPR "@SystemInit@")

--- a/soc/nordic/common/uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/CMakeLists.txt
@@ -4,33 +4,3 @@
 if(CONFIG_NRF_PERIPHCONF_SECTION)
   zephyr_linker_sources(SECTIONS uicr.ld)
 endif()
-
-if(CONFIG_NRF_HALTIUM_GENERATE_UICR)
-  if(CONFIG_NRF_PERIPHCONF_SECTION)
-    set(in_periphconf_elf_arg
-      --in-periphconf-elf $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
-    )
-  endif()
-
-  if(CONFIG_NRF_HALTIUM_UICR_PERIPHCONF)
-    set(periphconf_hex_file ${PROJECT_BINARY_DIR}/periphconf.hex)
-    set(out_periphconf_hex_arg
-      --out-periphconf-hex ${periphconf_hex_file}
-    )
-    list(APPEND optional_byproducts ${periphconf_hex_file})
-  endif()
-
-  set(uicr_hex_file ${PROJECT_BINARY_DIR}/uicr.hex)
-  set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
-    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_BASE}/scripts/dts/python-devicetree/src
-    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/gen_uicr.py
-    --in-config ${DOTCONFIG}
-    --in-edt-pickle ${EDT_PICKLE}
-    ${in_periphconf_elf_arg}
-    ${out_periphconf_hex_arg}
-    --out-uicr-hex ${uicr_hex_file}
-  )
-  set_property(GLOBAL APPEND PROPERTY extra_post_build_byproducts
-    ${uicr_hex_file} ${optional_byproducts}
-  )
-endif()

--- a/soc/nordic/common/uicr/Kconfig
+++ b/soc/nordic/common/uicr/Kconfig
@@ -1,29 +1,9 @@
 # Copyright (c) 2025 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config NRF_HALTIUM_GENERATE_UICR
-	bool "Generate UICR file"
-	depends on SOC_NRF54H20_CPUAPP
-	default y
-	help
-	  Generate UICR HEX file.
-
-if NRF_HALTIUM_GENERATE_UICR
-
-config NRF_HALTIUM_UICR_PERIPHCONF
-	bool "Initialize global domain peripherals"
-	default y
-	help
-	  Generates a blob containing static global domain peripheral initialization
-	  values extracted from the build artifacts, and configures UICR.PERIPHCONF
-	  to point at the blob. The initialization values are then loaded ahead of
-	  ahead of the application boot.
-
-endif
-
 config NRF_PERIPHCONF_SECTION
 	bool "Populate global peripheral initialization section"
-	default y if SOC_NRF54H20_CPUAPP
+	default y if SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD
 	depends on LINKER_DEVNULL_SUPPORT
 	imply LINKER_DEVNULL_MEMORY
 	help

--- a/soc/nordic/common/uicr/Kconfig.sysbuild
+++ b/soc/nordic/common/uicr/Kconfig.sysbuild
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config NRF_HALTIUM_GENERATE_UICR
+	bool "Generate UICR file"
+	depends on SOC_SERIES_NRF54HX
+	default y
+	help
+	  Generate UICR HEX file.

--- a/soc/nordic/common/uicr/gen_uicr.py
+++ b/soc/nordic/common/uicr/gen_uicr.py
@@ -17,6 +17,10 @@ from itertools import groupby
 from elftools.elf.elffile import ELFFile
 from intelhex import IntelHex
 
+# The UICR format version produced by this script
+UICR_FORMAT_VERSION_MAJOR = 2
+UICR_FORMAT_VERSION_MINOR = 0
+
 # Name of the ELF section containing PERIPHCONF entries.
 # Must match the name used in the linker script.
 PERIPHCONF_SECTION = "uicr_periphconf_entry"
@@ -43,6 +47,14 @@ class PeriphconfEntry(c.LittleEndianStructure):
 
 
 PERIPHCONF_ENTRY_SIZE = c.sizeof(PeriphconfEntry)
+
+
+class Version(c.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("MINOR", c.c_uint16),
+        ("MAJOR", c.c_uint16),
+    ]
 
 
 class Approtect(c.LittleEndianStructure):
@@ -104,7 +116,7 @@ class Mpcconf(c.LittleEndianStructure):
 class Uicr(c.LittleEndianStructure):
     _pack_ = 1
     _fields_ = [
-        ("VERSION", c.c_uint32),
+        ("VERSION", Version),
         ("RESERVED", c.c_uint32),
         ("LOCK", c.c_uint32),
         ("RESERVED1", c.c_uint32),
@@ -170,6 +182,9 @@ def main() -> None:
     try:
         init_values = DISABLED_VALUE.to_bytes(4, "little") * (c.sizeof(Uicr) // 4)
         uicr = Uicr.from_buffer_copy(init_values)
+
+        uicr.VERSION.MAJOR = UICR_FORMAT_VERSION_MAJOR
+        uicr.VERSION.MINOR = UICR_FORMAT_VERSION_MINOR
 
         kconfig_str = args.in_config.read()
         kconfig = parse_kconfig(kconfig_str)

--- a/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/CMakeLists.txt
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The code in this CMakeLists.txt constructs the arguments for gen_uicr.py
+# and creates a flashable zephyr.hex file containing UICR data (no C code compiled)
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+# Instead of adding all of Zephyr we add just the subset that is
+# required to generate uicr.hex.
+#
+# The generation of uicr.hex is configured by this image, so we
+# include modules from zephyr_default up until kconfig.
+
+find_package(Zephyr
+  COMPONENTS zephyr_default:kconfig
+  REQUIRED HINTS $ENV{ZEPHYR_BASE}
+  )
+
+project(uicr)
+
+# Function to compute partition absolute address and size from devicetree
+function(compute_partition_address_and_size partition_nodelabel output_address_var output_size_var)
+  dt_nodelabel(partition_path NODELABEL ${partition_nodelabel} REQUIRED)
+  dt_reg_addr(partition_offset PATH ${partition_path} REQUIRED)
+  dt_reg_size(partition_size PATH ${partition_path} REQUIRED)
+
+  # Calculate absolute partition address
+  math(EXPR partition_address "${CONFIG_FLASH_BASE_ADDRESS} + ${partition_offset}" OUTPUT_FORMAT HEXADECIMAL)
+
+  # Set output variables in parent scope
+  set(${output_address_var} ${partition_address} PARENT_SCOPE)
+  set(${output_size_var} ${partition_size} PARENT_SCOPE)
+endfunction()
+
+# Use CMAKE_VERBOSE_MAKEFILE to silence an unused-variable warning.
+if(CMAKE_VERBOSE_MAKEFILE)
+endif()
+
+set(periphconf_args)
+set(periphconf_elfs)
+set(merged_hex_file ${APPLICATION_BINARY_DIR}/zephyr/${CONFIG_KERNEL_BIN_NAME}.hex)
+set(uicr_hex_file ${APPLICATION_BINARY_DIR}/zephyr/uicr.hex)
+set(periphconf_hex_file ${APPLICATION_BINARY_DIR}/zephyr/periphconf.hex)
+
+# Get UICR absolute address from this image's devicetree
+dt_nodelabel(uicr_path NODELABEL "uicr" REQUIRED)
+dt_reg_addr(UICR_ADDRESS PATH ${uicr_path} REQUIRED)
+
+if(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
+  # gen_uicr.py parses all zephyr.elf files. To find these files (which
+  # have not been built yet) we scan sibling build directories for
+  # zephyr.dts
+  get_filename_component(SYSBUILD_DIR ${APPLICATION_BINARY_DIR} DIRECTORY)
+  file(GLOB _siblings LIST_DIRECTORIES true "${SYSBUILD_DIR}/*")
+  foreach(_dir ${_siblings})
+    get_filename_component(_name ${_dir} NAME)
+    if(_name STREQUAL "uicr")
+      # This image is an exception to the rule. It has a zephyr.dts, but
+      # no zephyr.elf
+      continue()
+    endif()
+
+    if(EXISTS ${_dir}/zephyr/zephyr.dts)
+      list(APPEND periphconf_elfs ${_dir}/zephyr/zephyr.elf)
+    endif()
+  endforeach()
+
+  # Compute PERIPHCONF absolute address and size from this image's devicetree
+  compute_partition_address_and_size("periphconf_partition" PERIPHCONF_ADDRESS PERIPHCONF_SIZE)
+
+  # Set up periphconf arguments for gen_uicr.py
+  list(APPEND periphconf_args --periphconf-address ${PERIPHCONF_ADDRESS})
+  list(APPEND periphconf_args --periphconf-size ${PERIPHCONF_SIZE})
+  list(APPEND periphconf_args --out-periphconf-hex ${periphconf_hex_file})
+
+  foreach(elf ${periphconf_elfs})
+    list(APPEND periphconf_args --in-periphconf-elf ${elf})
+  endforeach()
+endif(CONFIG_GEN_UICR_GENERATE_PERIPHCONF)
+
+# Generate hex files (merged, uicr-only, and periphconf-only)
+add_custom_command(
+  OUTPUT ${merged_hex_file} ${uicr_hex_file} ${periphconf_hex_file}
+  COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${ZEPHYR_BASE}/scripts/dts/python-devicetree/src
+          ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/soc/nordic/common/uicr/gen_uicr.py
+          --uicr-address ${UICR_ADDRESS}
+          --out-merged-hex ${merged_hex_file}
+          --out-uicr-hex ${uicr_hex_file}
+          ${periphconf_args}
+  DEPENDS ${periphconf_elfs}
+  WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
+  COMMENT "Using gen_uicr.py to generate ${merged_hex_file} from ${periphconf_elfs}"
+)
+
+# Add zephyr subdirectory to handle flash configuration with correct paths
+add_subdirectory(zephyr)
+
+add_custom_target(gen_uicr ALL DEPENDS ${merged_hex_file})

--- a/soc/nordic/common/uicr/gen_uicr/Kconfig
+++ b/soc/nordic/common/uicr/gen_uicr/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+menu "UICR generator options"
+
+config GEN_UICR_GENERATE_PERIPHCONF
+	bool "Generate PERIPHCONF hex alongside UICR"
+	default y
+	help
+	  When enabled, the UICR generator will emit periphconf.hex in addition to uicr.hex.
+
+endmenu
+
+source "Kconfig.zephyr"

--- a/soc/nordic/common/uicr/gen_uicr/prj.conf
+++ b/soc/nordic/common/uicr/gen_uicr/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/soc/nordic/common/uicr/gen_uicr/zephyr/CMakeLists.txt
+++ b/soc/nordic/common/uicr/gen_uicr/zephyr/CMakeLists.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Flash configuration for UICR domain
+# This subdirectory ensures runners.yaml is generated in the correct location
+
+# Manually include board configuration to enable automatic runners.yaml generation
+include(${BOARD_DIR}/board.cmake OPTIONAL)
+
+# Create the runners_yaml_props_target that flash system expects
+add_custom_target(runners_yaml_props_target)
+
+# Set hex_file property to point to zephyr.hex in this directory
+set_target_properties(runners_yaml_props_target PROPERTIES
+  hex_file "zephyr.hex"
+)
+
+# Override the runners.yaml path to use CMAKE_CURRENT_BINARY_DIR instead of PROJECT_BINARY_DIR
+# This ensures runners.yaml is generated at build/uicr/zephyr/ where west expects it
+set(PROJECT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+# Include flash support to automatically generate runners.yaml
+include(${ZEPHYR_BASE}/cmake/flash/CMakeLists.txt)

--- a/soc/nordic/common/uicr/sysbuild.cmake
+++ b/soc/nordic/common/uicr/sysbuild.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Add UICR generator as a utility image
+ExternalZephyrProject_Add(
+  APPLICATION uicr
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/gen_uicr
+)
+
+# Ensure UICR is configured and built after the default image so EDT/ELFs exist.
+sysbuild_add_dependencies(CONFIGURE uicr ${DEFAULT_IMAGE})
+add_dependencies(uicr ${DEFAULT_IMAGE})

--- a/soc/nordic/sysbuild.cmake
+++ b/soc/nordic/sysbuild.cmake
@@ -29,3 +29,7 @@ if(SB_CONFIG_VPR_LAUNCHER)
 
   sysbuild_cache_set(VAR ${image}_SNIPPET APPEND REMOVE_DUPLICATES ${launcher_snippet})
 endif()
+
+if(SB_CONFIG_NRF_HALTIUM_GENERATE_UICR)
+  include(${CMAKE_CURRENT_LIST_DIR}/common/uicr/sysbuild.cmake)
+endif()

--- a/tests/drivers/comparator/gpio_loopback/testcase.yaml
+++ b/tests/drivers/comparator/gpio_loopback/testcase.yaml
@@ -18,6 +18,7 @@ tests:
       - frdm_ke15z
   drivers.comparator.gpio_loopback.nrf_comp:
     extra_args:
+      - SNIPPET_ROOT="."
       - SNIPPET="gpio_loopback_nrf_comp"
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp
@@ -27,6 +28,7 @@ tests:
       - ophelia4ev/nrf54l15/cpuapp
   drivers.comparator.gpio_loopback.nrf_lpcomp:
     extra_args:
+      - SNIPPET_ROOT="."
       - SNIPPET="gpio_loopback_nrf_lpcomp"
     platform_allow:
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
Reorganize how gen_uicr.py is invoked.

Instead of invoking it from one of the Zephyr images we invoke it from
a new special Zephyr image called uicr.

This uicr Zephyr image is flashed in the same way as normal Zephyr
images so special handling in the runner is no longer necessary.

Also, we simplify gen_uicr.py by moving parsing of Kconfig/DT from
gen_uicr.py to CMake.

This PR also includes the commit in https://github.com/zephyrproject-rtos/zephyr/pull/94064