### PR TITLE
drivers: ethernet: dsa_nxp_imx_netc: fix zephyr random mac

### DIFF
--- a/doc/connectivity/networking/dsa.rst
+++ b/doc/connectivity/networking/dsa.rst
@@ -83,7 +83,7 @@ of i.MX NETC.
                    .phy_mode = NETC_PHY_MODE(port),                                            \
            };                                                                                  \
            struct dsa_port_config dsa_##n##_##port##_config = {                                \
-                   .use_random_mac_addr = DT_NODE_HAS_PROP(port, zephyr_random_mac_address),   \
+                   .use_random_mac_addr = DT_PROP(port, zephyr_random_mac_address),            \
                    .mac_addr = DT_PROP_OR(port, local_mac_address, {0}),                       \
                    .port_idx = DT_REG_ADDR(port),                                              \
                    .phy_dev = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(port, phy_handle)),             \

--- a/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
+++ b/drivers/ethernet/dsa/dsa_nxp_imx_netc.c
@@ -552,7 +552,7 @@ static struct dsa_api dsa_netc_api = {
 		.phy_mode = NETC_PHY_MODE(port),                                            \
 	};                                                                                  \
 	struct dsa_port_config dsa_##n##_##port##_config = {                                \
-		.use_random_mac_addr = DT_NODE_HAS_PROP(port, zephyr_random_mac_address),   \
+		.use_random_mac_addr = DT_PROP(port, zephyr_random_mac_address),            \
 		.mac_addr = DT_PROP_OR(port, local_mac_address, {0}),                       \
 		.port_idx = DT_REG_ADDR(port),                                              \
 		.phy_dev = DEVICE_DT_GET_OR_NULL(DT_PHANDLE(port, phy_handle)),             \
@@ -583,6 +583,6 @@ static struct dsa_api dsa_netc_api = {
 			      POST_KERNEL,                                                  \
 			      CONFIG_ETH_INIT_PRIORITY,                                     \
 			      NULL);		                                            \
-	DSA_SWITCH_INST_INIT(n, &dsa_netc_api, &dsa_netc_data_##n, DSA_NETC_PORT_INST_INIT); \
+	DSA_SWITCH_INST_INIT(n, &dsa_netc_api, &dsa_netc_data_##n, DSA_NETC_PORT_INST_INIT);
 
 DT_INST_FOREACH_STATUS_OKAY(DSA_NETC_DEVICE);


### PR DESCRIPTION
`zephyr,random-mac-address` defaults to 0 or 1, which is always available in generated code. so we can use the value itself.

actually just replaced 

`DT_NODE_HAS_PROP`

by

`DT_PROP`

Fixes: #101236
