### PR TITLE
storage/stream_flash: Add API to query buffered data size

### DIFF
--- a/include/zephyr/storage/stream_flash.h
+++ b/include/zephyr/storage/stream_flash.h
@@ -107,6 +107,15 @@ int stream_flash_init(struct stream_flash_ctx *ctx, const struct device *fdev,
 size_t stream_flash_bytes_written(const struct stream_flash_ctx *ctx);
 
 /**
+ * @brief Read number of bytes buffered for the next flash write.
+ *
+ * @param ctx context
+ *
+ * @return Number of payload bytes buffered for the next flash write.
+ */
+size_t stream_flash_bytes_buffered(const struct stream_flash_ctx *ctx);
+
+/**
  * @brief Process input buffers to be written to flash device in single blocks.
  * Will store remainder between calls.
  *

--- a/subsys/storage/stream/stream_flash.c
+++ b/subsys/storage/stream/stream_flash.c
@@ -307,6 +307,11 @@ size_t stream_flash_bytes_written(const struct stream_flash_ctx *ctx)
 	return ctx->bytes_written;
 }
 
+size_t stream_flash_bytes_buffered(const struct stream_flash_ctx *ctx)
+{
+	return ctx->buf_bytes;
+}
+
 #ifdef CONFIG_STREAM_FLASH_INSPECT
 struct _inspect_flash {
 	size_t buf_len;


### PR DESCRIPTION
Add a wrapper function to read the number of bytes currently buffered and pending for the next flash write operation.

Signed-off-by: Syver Haraldsen <syver.haraldsen@nordicsemi.no>