### PR TITLE
Zperf: fix IP address macro check

### DIFF
--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -49,7 +49,7 @@ static const char *CONFIG =
 #endif
 		"";
 
-static struct sockaddr_in6 in6_addr_my = {
+__maybe_unused static struct sockaddr_in6 in6_addr_my = {
 	.sin6_family = AF_INET6,
 	.sin6_port = htons(MY_SRC_PORT),
 };
@@ -64,7 +64,7 @@ static struct sockaddr_in in4_addr_dst = {
 	.sin_port = htons(DEF_PORT),
 };
 
-static struct sockaddr_in in4_addr_my = {
+__maybe_unused static struct sockaddr_in in4_addr_my = {
 	.sin_family = AF_INET,
 	.sin_port = htons(MY_SRC_PORT),
 };
@@ -1835,7 +1835,8 @@ void zperf_shell_init(void)
 {
 	int ret;
 
-	if (IS_ENABLED(MY_IP6ADDR_SET) && MY_IP6ADDR) {
+#if defined(MY_IP6ADDR_SET)
+	if (MY_IP6ADDR) {
 		ret = net_addr_pton(AF_INET6, MY_IP6ADDR,
 				    &in6_addr_my.sin6_addr);
 		if (ret < 0) {
@@ -1857,8 +1858,10 @@ void zperf_shell_init(void)
 				 net_sprint_ipv6_addr(&in6_addr_dst.sin6_addr));
 		}
 	}
+#endif
 
-	if (IS_ENABLED(MY_IP4ADDR_SET) && MY_IP4ADDR) {
+#if defined(MY_IP4ADDR_SET)
+	if (MY_IP4ADDR) {
 		ret = net_addr_pton(AF_INET, MY_IP4ADDR,
 				    &in4_addr_my.sin_addr);
 		if (ret < 0) {
@@ -1880,6 +1883,7 @@ void zperf_shell_init(void)
 				 net_sprint_ipv4_addr(&in4_addr_dst.sin_addr));
 		}
 	}
+#endif
 }
 
 #ifdef CONFIG_NET_ZPERF_SERVER


### PR DESCRIPTION
The commit [1e7dea0aa125e94150aa95f086fcbe1c48](https://github.com/zephyrproject-rtos/zephyr/commit/dee1f2deaa71ae2595c4121500a95f06f8ce1c48) introduced a change where the code used IS_ENABLED(MY_IP4ADDR_SET) and IS_ENABLED(MY_IP6ADDR_SET) to conditionally execute IP address configuration logic. 
However, IS_ENABLED() is designed to work only with Kconfig options, not with user-defined macros. As a result, the checks always evaluated to false, and the code responsible for setting IP addresses was not executed, even when the addresses were configured.

This patch corrects the logic by:

- Replacing IS_ENABLED(MY_IP4ADDR_SET) and IS_ENABLED(MY_IP6ADDR_SET) with #if defined(MY_IP4ADDR_SET) and #if defined(MY_IP6ADDR_SET), which are appropriate for compile-time checks on user-defined macros.

- Keeping the runtime check for the actual address value (if (MY_IP4ADDR)), ensuring the code only runs when an address is set.