### PR TITLE
include: drivers: bluetooth: Use DT_ENUM_IDX_OR to get HCI bus from DT

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -95,6 +95,12 @@ Bluetooth Audio
 
 .. zephyr-keep-sorted-stop
 
+Bluetooth HCI
+=============
+
+* The deprecated ``ipm`` value was removed from ``bt-hci-bus`` devicetree property.
+  ``ipc`` should be used instead.
+
 Ethernet
 ========
 

--- a/dts/bindings/bluetooth/bt-hci.yaml
+++ b/dts/bindings/bluetooth/bt-hci.yaml
@@ -21,7 +21,6 @@ properties:
       - "i2c"
       - "smd"
       - "virtio"
-      - "ipm"    # Deprecated. "ipc" should be used instead.
       - "ipc"
   bt-hci-quirks:
     type: string-array

--- a/dts/bindings/bluetooth/espressif,esp32-bt-hci.yaml
+++ b/dts/bindings/bluetooth/espressif,esp32-bt-hci.yaml
@@ -8,6 +8,6 @@ properties:
   bt-hci-name:
     default: "BT ESP32"
   bt-hci-bus:
-    default: "ipm"
+    default: "ipc"
   bt-hci-quirks:
     default: ["no-auto-dle"]

--- a/dts/bindings/bluetooth/nxp,hci-ble.yaml
+++ b/dts/bindings/bluetooth/nxp,hci-ble.yaml
@@ -11,4 +11,4 @@ properties:
   bt-hci-name:
     default: "BT NXP"
   bt-hci-bus:
-    default: "ipm"
+    default: "ipc"

--- a/dts/bindings/bluetooth/renesas,bt-hci-da1469x.yaml
+++ b/dts/bindings/bluetooth/renesas,bt-hci-da1469x.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "BT DA1469x"
   bt-hci-bus:
-    default: "ipm"
+    default: "ipc"

--- a/dts/bindings/bluetooth/st,hci-stm32wba.yaml
+++ b/dts/bindings/bluetooth/st,hci-stm32wba.yaml
@@ -8,4 +8,4 @@ properties:
   bt-hci-name:
     default: "BT IPM"
   bt-hci-bus:
-    default: "ipm"
+    default: "ipc"

--- a/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
+++ b/dts/bindings/bluetooth/st,stm32wb-ble-rf.yaml
@@ -14,6 +14,6 @@ properties:
   bt-hci-name:
     default: "BT IPM"
   bt-hci-bus:
-    default: "ipm"
+    default: "ipc"
   bt-hci-quirks:
     default: ["no-reset"]

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -72,8 +72,6 @@ enum bt_hci_bus {
 	BT_HCI_BUS_SMD           = 9,
 	BT_HCI_BUS_VIRTIO        = 10,
 	BT_HCI_BUS_IPC           = 11,
-	/* IPM is deprecated and simply an alias for IPC */
-	BT_HCI_BUS_IPM           = BT_HCI_BUS_IPC,
 };
 
 #define BT_DT_HCI_QUIRK_OR(node_id, prop, idx) \

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -87,8 +87,8 @@ enum bt_hci_bus {
 #define BT_DT_HCI_NAME_GET(node_id) DT_PROP_OR(node_id, bt_hci_name, "HCI")
 #define BT_DT_HCI_NAME_INST_GET(inst) BT_DT_HCI_NAME_GET(DT_DRV_INST(inst))
 
-#define BT_DT_HCI_BUS_GET(node_id) \
-	UTIL_CAT(BT_HCI_BUS_, DT_STRING_UPPER_TOKEN_OR(node_id, bt_hci_bus, VIRTUAL))
+#define BT_DT_HCI_BUS_GET(node_id) DT_ENUM_IDX_OR(node_id, bt_hci_bus, BT_HCI_BUS_VIRTUAL)
+
 #define BT_DT_HCI_BUS_INST_GET(inst) BT_DT_HCI_BUS_GET(DT_DRV_INST(inst))
 
 typedef int (*bt_hci_recv_t)(const struct device *dev, struct net_buf *buf);


### PR DESCRIPTION
Use DT_ENUM_IDX_OR instead of DT_STRING_UPPER_TOKEN_OR to get HCI bus
from DT, in order to avoid the expansion of UART/SPI/etc. macros when
they exist in vendor's SoC headers.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/93675