### PR TITLE
tests: clock_control: stm32l0: Fix dts build due to missing hsi-div

### DIFF
--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/l0_pll_32_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/l0_pll_32_hsi_16.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	hsi-div = <1>;
+	status = "okay";
+};
+
+&pll {
+	div = <2>;
+	mul = <4>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(32)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
@@ -133,11 +133,16 @@ tests:
       - nucleo_l073rz
     integration_platforms:
       - nucleo_l152re
-  drivers.clock.stm32_clock_configuration.common_core.l0_l1.sysclksrc_pll_32_hsi_16:
+  drivers.clock.stm32_clock_configuration.common_core.l0.sysclksrc_pll_32_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/l0_pll_32_hsi_16.overlay"
+    platform_allow:
+      - nucleo_l073rz
+    integration_platforms:
+      - nucleo_l073rz
+  drivers.clock.stm32_clock_configuration.common_core.l1.sysclksrc_pll_32_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_32_hsi_16.overlay"
     platform_allow:
       - nucleo_l152re
-      - nucleo_l073rz
     integration_platforms:
       - nucleo_l152re
   drivers.clock.stm32_clock_configuration.common_core.l0_l1.sysclksrc_msi_range6:


### PR DESCRIPTION
Following introduction of hsi-div on L0, upate hsi description on l0. Since this description is not compatible with l1 series anymore add a dedicated l0 test variant and matching overlay.