### PR TITLE
docs: contribution, style: specify that tabs are 8 characters

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -358,6 +358,19 @@ If in doubt, it's advisable to explore existing Pull Requests within the Zephyr
 repository. Use the search filters and labels to locate PRs related to changes
 similar to the ones you are proposing.
 
+.. note::
+   GitHub's default code UI uses 4-character tabs. However, Zephyr follows the
+   `Linux kernel coding style`_, which uses 8-character tabs.
+
+   To ensure your view of the code is consistent with other developers, please
+   go to your `user preferences on GitHub`_ and change the tab width to 8 spaces.
+
+.. _Linux kernel coding style:
+   https://kernel.org/doc/html/latest/process/coding-style.html#indentation
+
+.. _user preferences on GitHub:
+   https://github.com/settings/appearance
+
 .. _commit-guidelines:
 
 Commit Message Guidelines

--- a/doc/contribute/style/code.rst
+++ b/doc/contribute/style/code.rst
@@ -16,6 +16,7 @@ subsystem, etc).
 In general, follow the `Linux kernel coding style`_, with the following
 exceptions and clarifications:
 
+* Tabs are 8 characters.
 * Use `snake case`_ for code and variables.
 * The line length is 100 columns or fewer. In the documentation, longer lines
   for URL references are an allowed exception.


### PR DESCRIPTION
GitHub, in a moment of infinite wisdom, decided to change the default tab from eight to four characters.

According to the GitHub announcement the problem that the change addressed is that "many users are unaware that tab size can be adjusted in their settings". As a result now users with this so called "improved" setting sees a different indentation from all other users.

Help GitHub in their awareness mission, by making the users aware that tab size can (or rather, has to) be adjusted in their settings to the previous default, by mentioning it in the contribution guideline.

Call it out in the quick style guide too since it's not the default anymore.

Link: https://github.blog/changelog/2025-08-07-default-tab-size-changed-from-eight-to-four/