### PR TITLE
drivers: misc: timeaware_gpio: Enable support for ARTV_CTRL

### DIFF
--- a/dts/bindings/misc/intel,timeaware-gpio.yaml
+++ b/dts/bindings/misc/intel,timeaware-gpio.yaml
@@ -20,3 +20,11 @@ properties:
     type: int
     required: true
     description: Total number of available pins
+
+  artv-ctrl:
+    type: boolean
+    description: |
+      Some platforms have ARTV_CTRL which is required for
+      reading the ART timestamp. This property is used to
+      indicate if the support of ARTV_CTRL is available
+      or not.

--- a/dts/x86/intel/panther_lake_h.dtsi
+++ b/dts/x86/intel/panther_lake_h.dtsi
@@ -302,6 +302,15 @@
 			status = "disabled";
 		};
 
+		tgpio: tgpio@fe001200 {
+			compatible = "intel,timeaware-gpio";
+			reg = <0xfe001200 0x100>;
+			timer-clock = <19200000>;
+			max-pins = <2>;
+			artv-ctrl;
+			status = "disabled";
+		};
+
 		hpet: hpet@fed00000 {
 			compatible = "intel,hpet";
 			reg = <0xfed00000 0x400>;


### PR DESCRIPTION
Enabled support for ARTV_CTRL for ART value read operation.

Signed-off-by: Anisetti Avinash Krishna <anisetti.avinash.krishna@intel.com>