### PR TITLE
kernel: Add option to place ISR/Idle/Main stacks in DTCM section 

### DIFF
--- a/arch/arm/core/Kconfig
+++ b/arch/arm/core/Kconfig
@@ -274,6 +274,27 @@ config ARM_STORE_EXC_RETURN
 	  This is needed when switching between threads that differ in either
 	  FPU usage or security domain.
 
+config ISR_STACKS_USE_DTCM_SECTION
+	bool "Place ISR stacks in DTCM section"
+	depends on CPU_CORTEX_M
+	help
+	  This option places the ISR stacks in the DTCM section. This can
+	  improve performance while executing interrupts
+
+config IDLE_STACKS_USE_DTCM_SECTION
+	bool "Place Idle stacks in DTCM section"
+	depends on CPU_CORTEX_M
+	help
+	  This option places the Idle stacks in the DTCM section. This can
+	  reduce cache thrashing when the idle thread is swapped in/out
+
+config MAIN_STACK_USE_DTCM_SECTION
+	bool "Place Main stack in DTCM section"
+	depends on CPU_CORTEX_M
+	help
+	  This option places the Main stack in the DTCM section. This can
+	  reduce cache thrashing when the main thread is swapped in/out
+
 choice
 	prompt "Floating point ABI"
 	default FP_HARDABI

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -50,16 +50,28 @@ __pinned_bss atomic_t _cpus_active;
 #endif
 
 /* init/main and idle threads */
+#if defined(CONFIG_MAIN_STACK_USE_DTCM_SECTION)
+Z_KERNEL_STACK_DEFINE_IN(z_main_stack, CONFIG_MAIN_STACK_SIZE, __dtcm_noinit_section);
+#else
 K_THREAD_PINNED_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
+#endif /* CONFIG_MAIN_STACK_USE_DTCM_SECTION */
+
 struct k_thread z_main_thread;
 
 #ifdef CONFIG_MULTITHREADING
 __pinned_bss
 struct k_thread z_idle_threads[CONFIG_MP_MAX_NUM_CPUS];
 
+#if defined(CONFIG_IDLE_STACKS_USE_DTCM_SECTION)
+static Z_KERNEL_STACK_ARRAY_DEFINE_IN(z_idle_stacks,
+				   CONFIG_MP_MAX_NUM_CPUS,
+				   CONFIG_IDLE_STACK_SIZE,
+				   __dtcm_noinit_section);
+#else
 static K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_idle_stacks,
 					  CONFIG_MP_MAX_NUM_CPUS,
 					  CONFIG_IDLE_STACK_SIZE);
+#endif /* CONFIG_IDLE_STACKS_USE_DTCM_SECTION */
 
 static void z_init_static_threads(void)
 {
@@ -144,9 +156,16 @@ extern const struct init_entry __init_SMP_start[];
  * of this area is safe since interrupts are disabled until the kernel context
  * switches to the init thread.
  */
+#if defined(CONFIG_ISR_STACKS_USE_DTCM_SECTION)
+Z_KERNEL_STACK_ARRAY_DEFINE_IN(z_interrupt_stacks,
+				   CONFIG_MP_MAX_NUM_CPUS,
+				   CONFIG_ISR_STACK_SIZE,
+				   __dtcm_noinit_section);
+#else
 K_KERNEL_PINNED_STACK_ARRAY_DEFINE(z_interrupt_stacks,
 				   CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
+#endif /* CONFIG_ISR_STACKS_USE_DTCM_SECTION */
 
 extern void idle(void *unused1, void *unused2, void *unused3);
 


### PR DESCRIPTION
Cortex-M has support for for DTCM and ITCM. This allows the developer to place the stacks defined in init.c into the DTCM section. On SOCs with DTCM this can help greatly with reducing D-Cache thrashing and improve performance

Testing:
Activate configs on mimxrt1064_evk, inspect in GDB where the symbols end up

Reading symbols from /Users/cwynn/zephyrproject/build_dtcm/zephyr/zephyr.elf... 
(gdb) p/x & z_main_stack
$1 = 0x200009c0
(gdb) p/x &z_main_stack
$2 = 0x200009c0
(gdb) p/x &z_idle_stacks
$3 = 0x20000840
(gdb) p/x &z_interrupt_stacks
$4 = 0x20000000

0x20000000 is DTCM section