### PR TITLE
Change designator order for pipe initializer macro C++20

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5345,11 +5345,11 @@ struct k_pipe {
  */
 #define Z_PIPE_INITIALIZER(obj, pipe_buffer, pipe_buffer_size)	\
 {								\
+	.waiting = 0,						\
 	.buf = RING_BUF_INIT(pipe_buffer, pipe_buffer_size),	\
 	.data = Z_WAIT_Q_INIT(&obj.data),			\
 	.space = Z_WAIT_Q_INIT(&obj.space),			\
 	.flags = PIPE_FLAG_OPEN,				\
-	.waiting = 0,						\
 	Z_POLL_EVENT_OBJ_INIT(obj)				\
 }
 /**


### PR DESCRIPTION
Change designator order for pipe initializer macro to match the order of the k_pipe struct declaration.
In C++20 designator order is enforced so the initialization order of the fields within a struct must match the order in the declaration. This change moves the `.waiting` field in the k_pipe initialzation macro to be first, as it appears in the declaration for `struct k_pipe`. 

fixes: https://github.com/zephyrproject-rtos/zephyr/issues/94823