### PR TITLE
include: drivers: espi: doxygen comments for espi_evt_data_pvt

### DIFF
--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -415,11 +415,17 @@ struct espi_evt_data_acpi {
 };
 
 /**
- * @brief Bit field definition of evt_data in struct espi_event for PVT.
+ * @brief Event data format for Private Channel (PVT) events.
+ *
+ * Event data (@ref espi_event.evt_data) for Private Channel (PVT) events, allowing to manipulate
+ * the raw event data as a bit field.
  */
 struct espi_evt_data_pvt {
+	/** Event type identifier */
 	uint32_t type: 8;
+	/** Event data payload */
 	uint32_t data: 8;
+	/** Reserved field for future use */
 	uint32_t reserved: 16;
 };
 


### PR DESCRIPTION
follow up to commit 5e3f1dbaa that introduced espi_evt_data_pvt without full doxygen comments for it.