### PR TITLE
tests: ram_context_for_isr: Use Kconfig for IRQ config

### DIFF
--- a/tests/application_development/ram_context_for_isr/Kconfig
+++ b/tests/application_development/ram_context_for_isr/Kconfig
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 Muhmmad Waleed Badar
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "Kconfig.zephyr"
+
+config TEST_IRQ_NUM
+	int "Test IRQ number"
+	default 42 if BOARD_QEMU_CORTEX_M3
+	default 14 if GIC
+	default 22 if SOC_SERIES_DA1469X
+	default 18 if SOC_SERIES_STM32C0X
+	default 0
+	help
+	  IRQ number to use for testing purposes. This should be an
+	  available/unused IRQ on the target platform.
+
+	  Platform-specific defaults:
+	  - QEMU Cortex-M3: 42 (available test IRQ)
+	  - GIC platforms: 14 (available test SGI - Software Generated Interrupt)
+	  - DA1469X series: 22 (available test IRQ)
+	  - STM32C0X series: 18 (available test IRQ)
+	  - Other platforms: 0 (magic config value to select the last IRQ: NUM_IRQS - 1)
+
+config TEST_IRQ_PRIO
+	int "Test IRQ priority"
+	default 160 if GIC
+	default 1
+	help
+	  Platform-specific defaults:
+	  - GIC platforms: IRQ_DEFAULT_PRIORITY (system default)
+	  - Other platforms: 1 (high priority for testing)

--- a/tests/application_development/ram_context_for_isr/include/fake_driver.h
+++ b/tests/application_development/ram_context_for_isr/include/fake_driver.h
@@ -11,23 +11,11 @@
 extern "C" {
 #endif
 
-#ifdef CONFIG_BOARD_QEMU_CORTEX_M3
-
-#define TEST_IRQ_NUM  42
-#define TEST_IRQ_PRIO 1
-
-#elif defined(CONFIG_GIC)
-/*
- * For the platforms that use the ARM GIC, use the SGI (software generated
- * interrupt) line 14 for testing.
- */
-#define TEST_IRQ_NUM  14
-#define TEST_IRQ_PRIO IRQ_DEFAULT_PRIORITY
-
-#else
+#if CONFIG_TEST_IRQ_NUM == 0
 /* For all the other platforms, use the last available IRQ line for testing. */
-#define TEST_IRQ_NUM  (CONFIG_NUM_IRQS - 1)
-#define TEST_IRQ_PRIO 1
+#define TEST_IRQ_NUM (CONFIG_NUM_IRQS - 1)
+#else
+#define TEST_IRQ_NUM CONFIG_TEST_IRQ_NUM
 #endif
 
 typedef void (*fake_driver_irq_callback_t)(const struct device *dev, void *user_data);

--- a/tests/application_development/ram_context_for_isr/src/fake_driver.c
+++ b/tests/application_development/ram_context_for_isr/src/fake_driver.c
@@ -63,14 +63,14 @@ static int fake_driver_init(const struct device *dev)
 	static struct fake_driver_data fake_driver_data_##inst;                                    \
 	static void fake_driver_irq_config_func_##inst(void)                                       \
 	{                                                                                          \
-		IRQ_CONNECT(TEST_IRQ_NUM, TEST_IRQ_PRIO, fake_driver_isr,                          \
+		IRQ_CONNECT(TEST_IRQ_NUM, CONFIG_TEST_IRQ_PRIO, fake_driver_isr,                   \
 			    DEVICE_DT_INST_GET(inst), 0);                                          \
 		irq_enable(TEST_IRQ_NUM);                                                          \
 	}                                                                                          \
 	static struct fake_driver_config fake_driver_config_##inst = {                             \
 		.irq_config_func = fake_driver_irq_config_func_##inst,                             \
 		.irq_num = TEST_IRQ_NUM,                                                           \
-		.irq_priority = TEST_IRQ_PRIO,                                                     \
+		.irq_priority = CONFIG_TEST_IRQ_PRIO,                                              \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, &fake_driver_init, NULL, &fake_driver_data_##inst,             \
 			      &fake_driver_config_##inst, PRE_KERNEL_1,                            \


### PR DESCRIPTION
Replace hardcoded platform-specific IRQ definitions with configurable Kconfig symbols TEST_IRQ_NUM and TEST_IRQ_PRIO.