### PR TITLE
cmake: fix build using clang when default and target arch do not match

### DIFF
--- a/cmake/compiler/clang/target.cmake
+++ b/cmake/compiler/clang/target.cmake
@@ -36,10 +36,6 @@ if(NOT "${ARCH}" STREQUAL "posix")
     include(${ZEPHYR_BASE}/cmake/compiler/gcc/target_riscv.cmake)
   endif()
 
-  if(DEFINED CMAKE_C_COMPILER_TARGET)
-    set(clang_target_flag "--target=${CMAKE_C_COMPILER_TARGET}")
-  endif()
-
   foreach(file_name include/stddef.h)
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} --print-file-name=${file_name}

--- a/cmake/compiler/target_template.cmake
+++ b/cmake/compiler/target_template.cmake
@@ -52,8 +52,13 @@ if(NOT COMMAND compiler_file_path)
 
     compiler_simple_options(simple_options)
 
+    if(DEFINED CMAKE_C_COMPILER_TARGET)
+      set(target_flag "--target=${CMAKE_C_COMPILER_TARGET}")
+    endif()
+
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} ${COMPILER_OPTIMIZATION_FLAG} ${simple_options}
+      ${target_flag}
       --print-file-name ${filename}
       OUTPUT_VARIABLE filepath
       OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -80,10 +85,15 @@ if(NOT COMMAND compiler_set_linker_properties)
 
     compiler_simple_options(simple_options)
 
+    if(DEFINED CMAKE_C_COMPILER_TARGET)
+      set(target_flag "--target=${CMAKE_C_COMPILER_TARGET}")
+    endif()
+
     # Compute complete path to the runtime library using the
     # --print-libgcc-file-name compiler flag
     execute_process(
       COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} ${COMPILER_OPTIMIZATION_FLAG} ${simple_options}
+      ${target_flag}
       --print-libgcc-file-name
       OUTPUT_VARIABLE library_path
       OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Use `CMAKE_C_COMPILER_TARGET` to allow `clang` to correctly determine the `runtime library` for the `target` architecture.
Otherwise, the default runtime library will be selected.