### PR TITLE
include: zephyr: move disks directory to disk

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/disk.h>
-#include <zephyr/drivers/disks/sdmmc_stm32.h>
+#include <zephyr/drivers/disk/sdmmc_stm32.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/include/zephyr/drivers/disk/sdmmc_stm32.h
+++ b/include/zephyr/drivers/disk/sdmmc_stm32.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_DRIVERS_DISKS_SDMMC_STM32_H_
-#define ZEPHYR_INCLUDE_DRIVERS_DISKS_SDMMC_STM32_H_
+#ifndef ZEPHYR_INCLUDE_DRIVERS_DISK_SDMMC_STM32_H_
+#define ZEPHYR_INCLUDE_DRIVERS_DISK_SDMMC_STM32_H_
 
 #include <zephyr/device.h>
 #include <stdint.h>
@@ -28,4 +28,4 @@
  */
 void stm32_sdmmc_get_card_cid(const struct device *dev, uint32_t cid[4]);
 
-#endif /* ZEPHYR_INCLUDE_DRIVERS_DISKS_SDMMC_STM32_H_ */
+#endif /* ZEPHYR_INCLUDE_DRIVERS_DISK_SDMMC_STM32_H_ */


### PR DESCRIPTION
Move disks directory to disk to match with the naming of the driver class. This only affects the recently introduced header for STM32 disk drivers so it should be very low impact.