### PR TITLE
ICM45686: Streaming Performance Improvements

### DIFF
--- a/drivers/sensor/tdk/icm45686/CMakeLists.txt
+++ b/drivers/sensor/tdk/icm45686/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 zephyr_library_include_directories(.)
 zephyr_library_sources(
 	icm45686.c
+	icm45686_bus.c
 )
 zephyr_library_sources_ifdef(CONFIG_SENSOR_ASYNC_API
 	icm45686_decoder.c

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -31,12 +31,16 @@ LOG_MODULE_REGISTER(ICM45686, CONFIG_SENSOR_LOG_LEVEL);
 
 static inline int reg_write(const struct device *dev, uint8_t reg, uint8_t val)
 {
-	return icm45686_bus_write(dev, reg, &val, 1);
+	struct icm45686_data *data = dev->data;
+
+	return icm45686_reg_write_rtio(&data->bus, reg, &val, 1);
 }
 
 static inline int reg_read(const struct device *dev, uint8_t reg, uint8_t *val)
 {
-	return icm45686_bus_read(dev, reg, val, 1);
+	struct icm45686_data *data = dev->data;
+
+	return icm45686_reg_read_rtio(&data->bus, reg | REG_READ_BIT, val, 1);
 }
 
 static int icm45686_sample_fetch(const struct device *dev,
@@ -50,10 +54,9 @@ static int icm45686_sample_fetch(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	err = icm45686_bus_read(dev,
-				REG_ACCEL_DATA_X1_UI,
-				edata->payload.buf,
-				sizeof(edata->payload.buf));
+	err = icm45686_reg_read_rtio(&data->bus, REG_ACCEL_DATA_X1_UI | REG_READ_BIT,
+				     edata->payload.buf,
+				     sizeof(edata->payload.buf));
 
 	LOG_HEXDUMP_DBG(edata->payload.buf,
 			sizeof(edata->payload.buf),
@@ -161,6 +164,7 @@ static inline void icm45686_submit_one_shot(const struct device *dev,
 	uint32_t buf_len;
 	struct icm45686_encoded_data *edata;
 	struct icm45686_data *data = dev->data;
+	struct rtio_sqe *read_sqe;
 
 	err = rtio_sqe_rx_buf(iodev_sqe, min_buf_len, min_buf_len, &buf, &buf_len);
 	if (err != 0) {
@@ -168,7 +172,6 @@ static inline void icm45686_submit_one_shot(const struct device *dev,
 		rtio_iodev_sqe_err(iodev_sqe, err);
 		return;
 	}
-
 	edata = (struct icm45686_encoded_data *)buf;
 
 	err = icm45686_encode(dev, channels, num_channels, buf);
@@ -178,45 +181,28 @@ static inline void icm45686_submit_one_shot(const struct device *dev,
 		return;
 	}
 
-	struct rtio_sqe *write_sqe = rtio_sqe_acquire(data->rtio.ctx);
-	struct rtio_sqe *read_sqe = rtio_sqe_acquire(data->rtio.ctx);
-	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(data->rtio.ctx);
-
-	if (!write_sqe || !read_sqe || !complete_sqe) {
-		LOG_ERR("Failed to acquire RTIO SQEs");
+	err = icm45686_prep_reg_read_rtio_async(&data->bus, REG_ACCEL_DATA_X1_UI | REG_READ_BIT,
+						edata->payload.buf, sizeof(edata->payload.buf),
+						&read_sqe);
+	if (err < 0) {
+		LOG_ERR("Fail to prepare read: %d", err);
 		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
 		return;
 	}
-
-	uint8_t val = REG_ACCEL_DATA_X1_UI | REG_READ_BIT;
-
-	rtio_sqe_prep_tiny_write(write_sqe,
-				 data->rtio.iodev,
-				 RTIO_PRIO_HIGH,
-				 &val,
-				 1,
-				NULL);
-	write_sqe->flags |= RTIO_SQE_TRANSACTION;
-
-	rtio_sqe_prep_read(read_sqe,
-			   data->rtio.iodev,
-			   RTIO_PRIO_HIGH,
-			   edata->payload.buf,
-			   sizeof(edata->payload.buf),
-			   NULL);
-	if (data->rtio.type == ICM45686_BUS_I2C) {
-		read_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
-	} else if (data->rtio.type == ICM45686_BUS_I3C) {
-		read_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
-	}
 	read_sqe->flags |= RTIO_SQE_CHAINED;
 
-	rtio_sqe_prep_callback_no_cqe(complete_sqe,
-				      icm45686_complete_result,
-				      (void *)dev,
+	struct rtio_sqe *complete_sqe = rtio_sqe_acquire(data->bus.rtio.ctx);
+
+	if (!complete_sqe) {
+		LOG_ERR("Failed to acquire complete read-sqe");
+		rtio_sqe_drop_all(data->bus.rtio.ctx);
+		rtio_iodev_sqe_err(iodev_sqe, -ENOMEM);
+		return;
+	}
+	rtio_sqe_prep_callback_no_cqe(complete_sqe, icm45686_complete_result, (void *)dev,
 				      iodev_sqe);
 
-	rtio_submit(data->rtio.ctx, 0);
+	rtio_submit(data->bus.rtio.ctx, 0);
 }
 
 static void icm45686_submit(const struct device *dev, struct rtio_iodev_sqe *iodev_sqe)
@@ -256,13 +242,13 @@ static int icm45686_init(const struct device *dev)
 	int err;
 
 #if CONFIG_SPI_RTIO
-	if ((data->rtio.type == ICM45686_BUS_SPI) && !spi_is_ready_iodev(data->rtio.iodev)) {
+	if (data->bus.rtio.type == ICM45686_BUS_SPI && !spi_is_ready_iodev(data->bus.rtio.iodev)) {
 		LOG_ERR("Bus is not ready");
 		return -ENODEV;
 	}
 #endif
 #if CONFIG_I2C_RTIO
-	if ((data->rtio.type == ICM45686_BUS_I2C) && !i2c_is_ready_iodev(data->rtio.iodev)) {
+	if (data->bus.rtio.type == ICM45686_BUS_I2C && !i2c_is_ready_iodev(data->bus.rtio.iodev)) {
 		LOG_ERR("Bus is not ready");
 		return -ENODEV;
 	}
@@ -271,7 +257,7 @@ static int icm45686_init(const struct device *dev)
 	/** Soft-reset sensor to restore config to defaults,
 	 * unless it's already handled by I3C initialization.
 	 */
-	if (data->rtio.type != ICM45686_BUS_I3C) {
+	if (data->bus.rtio.type != ICM45686_BUS_I3C) {
 		err = reg_write(dev, REG_MISC2, REG_MISC2_SOFT_RST(1));
 		if (err) {
 			LOG_ERR("Failed to write soft-reset: %d", err);
@@ -352,8 +338,8 @@ static int icm45686_init(const struct device *dev)
 						REG_IPREG_SYS1_REG_172_GYRO_LPFBW_SEL(
 							cfg->settings.gyro.lpf));
 
-	err = icm45686_bus_write(dev, REG_IREG_ADDR_15_8, gyro_lpf_write_array,
-				 sizeof(gyro_lpf_write_array));
+	err = icm45686_reg_write_rtio(&data->bus, REG_IREG_ADDR_15_8, gyro_lpf_write_array,
+				      sizeof(gyro_lpf_write_array));
 	if (err) {
 		LOG_ERR("Failed to set Gyro BW settings: %d", err);
 		return err;
@@ -370,8 +356,8 @@ static int icm45686_init(const struct device *dev)
 						REG_IPREG_SYS2_REG_131_ACCEL_LPFBW_SEL(
 							cfg->settings.accel.lpf));
 
-	err = icm45686_bus_write(dev, REG_IREG_ADDR_15_8, accel_lpf_write_array,
-				 sizeof(accel_lpf_write_array));
+	err = icm45686_reg_write_rtio(&data->bus, REG_IREG_ADDR_15_8, accel_lpf_write_array,
+				      sizeof(accel_lpf_write_array));
 	if (err) {
 		LOG_ERR("Failed to set Accel BW settings: %d", err);
 		return err;
@@ -448,7 +434,7 @@ static int icm45686_init(const struct device *dev)
 			.accel_fs = DT_INST_PROP(inst, accel_fs),				   \
 			.gyro_fs = DT_INST_PROP(inst, gyro_fs),					   \
 		},										   \
-		.rtio = {									   \
+		.bus.rtio = {									   \
 			.iodev = &icm45686_bus_##inst,						   \
 			.ctx = &icm45686_rtio_ctx_##inst,					   \
 			COND_CODE_1(DT_INST_ON_BUS(inst, i3c),					   \

--- a/drivers/sensor/tdk/icm45686/icm45686.c
+++ b/drivers/sensor/tdk/icm45686/icm45686.c
@@ -394,7 +394,7 @@ static int icm45686_init(const struct device *dev)
 
 #define ICM45686_INIT(inst)									   \
 												   \
-	RTIO_DEFINE(icm45686_rtio_ctx_##inst, 8, 8);						   \
+	RTIO_DEFINE(icm45686_rtio_ctx_##inst, 32, 32);						   \
 												   \
 	COND_CODE_1(DT_INST_ON_BUS(inst, i3c),							   \
 		    (I3C_DT_IODEV_DEFINE(icm45686_bus_##inst,					   \

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -126,7 +126,6 @@ struct icm45686_stream {
 	struct {
 		uint64_t timestamp;
 		uint8_t int_status;
-		uint16_t fifo_count;
 		struct {
 			bool drdy : 1;
 			bool fifo_ths : 1;

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -18,6 +18,8 @@
 #include <zephyr/drivers/i3c.h>
 #endif
 
+#include "icm45686_bus.h"
+
 struct icm45686_encoded_payload {
 	union {
 		uint8_t buf[14];
@@ -133,25 +135,8 @@ struct icm45686_stream {
 	} data;
 };
 
-enum icm45686_bus_type {
-	ICM45686_BUS_SPI,
-	ICM45686_BUS_I2C,
-	ICM45686_BUS_I3C,
-};
-
 struct icm45686_data {
-	struct {
-		struct rtio_iodev *iodev;
-		struct rtio *ctx;
-		enum icm45686_bus_type type;
-/** Required to support In-band Interrupts */
-#if DT_HAS_COMPAT_ON_BUS_STATUS_OKAY(invensense_icm45686, i3c)
-		struct {
-			struct i3c_device_desc *desc;
-			const struct i3c_device_id id;
-		} i3c;
-#endif
-	} rtio;
+	struct icm45686_bus bus;
 	/** Single-shot encoded data instance to support fetch/get API */
 	struct icm45686_encoded_data edata;
 #if defined(CONFIG_ICM45686_TRIGGER)

--- a/drivers/sensor/tdk/icm45686/icm45686.h
+++ b/drivers/sensor/tdk/icm45686/icm45686.h
@@ -107,7 +107,7 @@ struct icm45686_stream {
 	struct gpio_callback cb;
 	const struct device *dev;
 	struct rtio_iodev_sqe *iodev_sqe;
-	atomic_t in_progress;
+	atomic_t state;
 	struct {
 		struct {
 			bool drdy : 1;

--- a/drivers/sensor/tdk/icm45686/icm45686_bus.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_bus.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 Croxel, Inc.
+ * Copyright (c) 2025 CogniPilot Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "icm45686_bus.h"
+
+int icm45686_prep_reg_read_rtio_async(const struct icm45686_bus *bus,
+				    uint8_t reg, uint8_t *buf, size_t size,
+				    struct rtio_sqe **out)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_iodev *iodev = bus->rtio.iodev;
+	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_sqe *read_buf_sqe = rtio_sqe_acquire(ctx);
+
+	if (!write_reg_sqe || !read_buf_sqe) {
+		rtio_sqe_drop_all(ctx);
+		return -ENOMEM;
+	}
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_read(read_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
+	if (bus->rtio.type == ICM45686_BUS_I2C) {
+		read_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP | RTIO_IODEV_I2C_RESTART;
+	} else if (bus->rtio.type == ICM45686_BUS_I3C) {
+		read_buf_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP | RTIO_IODEV_I3C_RESTART;
+	} else {
+		/* SPI does not require setting additional flags to the read-buf SQE */
+	}
+
+	/** Send back last SQE so it can be concatenated later. */
+	if (out) {
+		*out = read_buf_sqe;
+	}
+
+	return 2;
+}
+
+int icm45686_prep_reg_write_rtio_async(const struct icm45686_bus *bus,
+				     uint8_t reg, const uint8_t *buf, size_t size,
+				     struct rtio_sqe **out)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_iodev *iodev = bus->rtio.iodev;
+	struct rtio_sqe *write_reg_sqe = rtio_sqe_acquire(ctx);
+	struct rtio_sqe *write_buf_sqe = rtio_sqe_acquire(ctx);
+
+	if (!write_reg_sqe || !write_buf_sqe) {
+		rtio_sqe_drop_all(ctx);
+		return -ENOMEM;
+	}
+
+	/** More than 7 won't work with tiny-write */
+	if (size > 7) {
+		return -EINVAL;
+	}
+
+	rtio_sqe_prep_tiny_write(write_reg_sqe, iodev, RTIO_PRIO_NORM, &reg, 1, NULL);
+	write_reg_sqe->flags |= RTIO_SQE_TRANSACTION;
+	rtio_sqe_prep_tiny_write(write_buf_sqe, iodev, RTIO_PRIO_NORM, buf, size, NULL);
+	if (bus->rtio.type == ICM45686_BUS_I2C) {
+		write_buf_sqe->iodev_flags |= RTIO_IODEV_I2C_STOP;
+	} else if (bus->rtio.type == ICM45686_BUS_I3C) {
+		write_buf_sqe->iodev_flags |= RTIO_IODEV_I3C_STOP;
+	} else {
+		/* SPI does not require setting additional flags to the write-buf SQE */
+	}
+
+	/** Send back last SQE so it can be concatenated later. */
+	if (out) {
+		*out = write_buf_sqe;
+	}
+
+	return 2;
+}
+
+int icm45686_reg_read_rtio(const struct icm45686_bus *bus, uint8_t start, uint8_t *buf, int size)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_cqe *cqe;
+	int ret;
+
+	ret = icm45686_prep_reg_read_rtio_async(bus, start, buf, size, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = rtio_submit(ctx, ret);
+	if (ret) {
+		return ret;
+	}
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			ret = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	return ret;
+}
+
+int icm45686_reg_write_rtio(const struct icm45686_bus *bus, uint8_t reg, const uint8_t *buf,
+			    int size)
+{
+	struct rtio *ctx = bus->rtio.ctx;
+	struct rtio_cqe *cqe;
+	int ret;
+
+	ret = icm45686_prep_reg_write_rtio_async(bus, reg, buf, size, NULL);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = rtio_submit(ctx, ret);
+	if (ret) {
+		return ret;
+	}
+
+	do {
+		cqe = rtio_cqe_consume(ctx);
+		if (cqe != NULL) {
+			ret = cqe->result;
+			rtio_cqe_release(ctx, cqe);
+		}
+	} while (cqe != NULL);
+
+	return ret;
+}

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -242,6 +242,7 @@ static void icm45686_handle_event_actions(struct rtio *ctx,
 
 	if (!cb_sqe) {
 		LOG_ERR("Failed to acquire RTIO SQE for completion callback");
+		rtio_sqe_drop_all(data->bus.rtio.ctx);
 		icm45686_stream_result(dev, -ENOMEM);
 		return;
 	}

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -117,8 +117,6 @@ static void icm45686_complete_result(struct rtio *ctx,
 	struct rtio_cqe *cqe;
 	int err = 0;
 
-	memset(&data->stream.data, 0, sizeof(data->stream.data));
-
 	do {
 		cqe = rtio_cqe_consume(ctx);
 		if (cqe != NULL) {

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -278,7 +278,9 @@ static void icm45686_event_handler(const struct device *dev)
 		data->stream.settings.enabled.fifo_ths = false;
 		data->stream.settings.enabled.fifo_full = false;
 		return;
-	} else if (!atomic_cas(&data->stream.in_progress, 0, 1)) {
+	}
+	if (!atomic_cas(&data->stream.in_progress, 0, 1)) {
+		LOG_WRN("Event handler triggered while a stream is in progress! Ignoring");
 		/** There's an on-going */
 		return;
 	}

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -140,22 +140,14 @@ static void icm45686_handle_event_actions(struct rtio *ctx,
 		buf_len_required += sizeof(struct icm45686_encoded_payload);
 	}
 
-	err = rtio_sqe_rx_buf(data->stream.iodev_sqe,
-			      buf_len_required,
-			      buf_len_required,
-			      (uint8_t **)&buf,
-			      &buf_len);
-	__ASSERT(err == 0, "Failed to acquire buffer (len: %d) for encoded data: %d. "
-			   "Please revisit RTIO queue sizing and look for "
-			   "bottlenecks during sensor data processing",
-			   buf_len_required, err);
-
-	/** Still throw an error even if asserts are off */
-	if (err) {
+	err = rtio_sqe_rx_buf(data->stream.iodev_sqe, buf_len_required, buf_len_required,
+			      (uint8_t **)&buf, &buf_len);
+	CHECKIF(err != 0) {
 		struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
 
-		LOG_ERR("Failed to acquire buffer for encoded data: %d", err);
-
+		LOG_ERR("Failed to acquire buffer (len: %d) for encoded data: %d. Please revisit"
+			" RTIO queue sizing and look for bottlenecks during sensor data processing",
+			buf_len_required, err);
 		data->stream.iodev_sqe = NULL;
 		rtio_iodev_sqe_err(iodev_sqe, err);
 		return;

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -104,6 +104,7 @@ static inline void icm45686_stream_result(const struct device *dev,
 					  int result)
 {
 	struct icm45686_data *data = dev->data;
+	const struct icm45686_config *cfg = dev->config;
 	struct rtio_iodev_sqe *iodev_sqe = data->stream.iodev_sqe;
 
 	(void)atomic_set(&data->stream.state, ICM45686_STREAM_OFF);
@@ -113,7 +114,7 @@ static inline void icm45686_stream_result(const struct device *dev,
 	if (result < 0) {
 		/** Clear config-set so next submission re-configures the IMU */
 		memset(&data->stream.settings, 0, sizeof(data->stream.settings));
-
+		(void)gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_DISABLE);
 		rtio_iodev_sqe_err(iodev_sqe, result);
 	} else {
 		rtio_iodev_sqe_ok(iodev_sqe, 0);

--- a/drivers/sensor/tdk/icm45686/icm45686_stream.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_stream.c
@@ -280,6 +280,7 @@ static void icm45686_event_handler(const struct device *dev)
 	    FIELD_GET(RTIO_SQE_CANCELED, data->stream.iodev_sqe->sqe.flags)) {
 		LOG_WRN("Callback triggered with no streaming submission - Disabling interrupts");
 		(void)atomic_set(&data->stream.state, ICM45686_STREAM_OFF);
+		(void)gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_DISABLE);
 		err = icm45686_prep_reg_write_rtio_async(&data->bus, REG_INT1_CONFIG0, &val, 1,
 							 NULL);
 		if (err < 0) {
@@ -517,6 +518,7 @@ void icm45686_stream_submit(const struct device *dev,
 			}
 		}
 	}
+	(void)gpio_pin_interrupt_configure_dt(&cfg->int_gpio, GPIO_INT_EDGE_TO_ACTIVE);
 }
 
 int icm45686_stream_init(const struct device *dev)
@@ -551,12 +553,6 @@ int icm45686_stream_init(const struct device *dev)
 		if (err) {
 			LOG_ERR("Failed to add interrupt callback");
 			return -EIO;
-		}
-
-		err = gpio_pin_interrupt_configure_dt(&cfg->int_gpio,
-						      GPIO_INT_EDGE_TO_ACTIVE);
-		if (err) {
-			LOG_ERR("Failed to configure interrupt");
 		}
 
 		err = icm45686_reg_write_rtio(&data->bus, REG_INT1_CONFIG0, &val, 1);

--- a/drivers/sensor/tdk/icm45686/icm45686_trigger.c
+++ b/drivers/sensor/tdk/icm45686/icm45686_trigger.c
@@ -12,6 +12,7 @@
 
 #include "icm45686.h"
 #include "icm45686_bus.h"
+#include "icm45686_reg.h"
 #include "icm45686_trigger.h"
 
 #include <zephyr/logging/log.h>
@@ -79,16 +80,17 @@ static void icm45686_work_handler(struct k_work *work)
 
 static int icm45686_enable_drdy(const struct device *dev, bool enable)
 {
+	struct icm45686_data *data = dev->data;
 	uint8_t val;
 	int err;
 
-	err = icm45686_bus_read(dev, REG_INT1_CONFIG0, &val, 1);
+	err = icm45686_reg_read_rtio(&data->bus, REG_INT1_CONFIG0 | REG_READ_BIT, &val, 1);
 	if (err) {
 		return err;
 	}
 
 	val &= ~REG_INT1_CONFIG0_STATUS_EN_DRDY(true);
-	err = icm45686_bus_write(dev, REG_INT1_CONFIG0, &val, 1);
+	err = icm45686_reg_write_rtio(&data->bus, REG_INT1_CONFIG0, &val, 1);
 	if (err) {
 		return err;
 	}
@@ -97,7 +99,7 @@ static int icm45686_enable_drdy(const struct device *dev, bool enable)
 		val |= REG_INT1_CONFIG0_STATUS_EN_DRDY(true);
 	}
 
-	return icm45686_bus_write(dev, REG_INT1_CONFIG0, &val, 1);
+	return icm45686_reg_write_rtio(&data->bus, REG_INT1_CONFIG0, &val, 1);
 }
 
 int icm45686_trigger_set(const struct device *dev,
@@ -197,7 +199,7 @@ int icm45686_trigger_init(const struct device *dev)
 		LOG_ERR("Failed to configure interrupt");
 	}
 
-	err = icm45686_bus_write(dev, REG_INT1_CONFIG0, &val, 1);
+	err = icm45686_reg_write_rtio(&data->bus, REG_INT1_CONFIG0, &val, 1);
 	if (err) {
 		LOG_ERR("Failed to disable all INTs");
 	}
@@ -205,7 +207,7 @@ int icm45686_trigger_init(const struct device *dev)
 	val = REG_INT1_CONFIG2_EN_OPEN_DRAIN(false) |
 	      REG_INT1_CONFIG2_EN_ACTIVE_HIGH(true);
 
-	err = icm45686_bus_write(dev, REG_INT1_CONFIG2, &val, 1);
+	err = icm45686_reg_write_rtio(&data->bus, REG_INT1_CONFIG2, &val, 1);
 	if (err) {
 		LOG_ERR("Failed to configure INT as push-pull: %d", err);
 	}


### PR DESCRIPTION
Various performance improvements after stress-testing driver: 2X instances, running at 3200-Hz ODR, results at 800-Hz (4 results every 1.25-ms).