### PR TITLE
Retain memory for frdm_mcxw7x tests/drivers/watchdog/wdt_basic_api

### DIFF
--- a/boards/nxp/frdm_mcxw71/dts/sram_noecc.overlay
+++ b/boards/nxp/frdm_mcxw71/dts/sram_noecc.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,sram = &stcm_noecc;
+	};
+};
+
+&stcm {
+	ranges = <0x0 0x30000000 DT_SIZE_K(112)>;
+
+	stcm_noecc: system_memory@10000 {
+		compatible = "mmio-sram";
+		reg = <0x10000 DT_SIZE_K(40)>;
+	};
+};
+
+&stcm0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+};

--- a/boards/nxp/frdm_mcxw72/dts/sram_noecc.overlay
+++ b/boards/nxp/frdm_mcxw72/dts/sram_noecc.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,sram = &stcm_noecc;
+	};
+};
+
+&stcm {
+	ranges = <0x0 0x30000000 DT_SIZE_K(232)>;
+
+	stcm_noecc: system_memory@10000 {
+		compatible = "mmio-sram";
+		reg = <0x10000 DT_SIZE_K(160)>;
+	};
+
+	// VBAT retention SRAM with ECC
+	stcm_vbat: system_memory@38000 {
+		compatible = "mmio-sram";
+		reg = <0x38000 DT_SIZE_K(8)>;
+	};
+};
+
+&stcm0 {
+	reg = <0x0 DT_SIZE_K(64)>;
+};

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.yaml
@@ -18,3 +18,4 @@ supported:
   - pwm
   - spi
   - uart
+  - watchdog

--- a/dts/arm/nxp/nxp_mcxw7x_common.dtsi
+++ b/dts/arm/nxp/nxp_mcxw7x_common.dtsi
@@ -275,9 +275,9 @@
 		compatible = "nxp,wdog32";
 		reg = <0x1a000 10>;
 		interrupts = <23 0>;
-		clocks = <&scg SCG_K4_SYSOSC_CLK 0x68>;
+		clocks = <&scg SCG_K4_RTCOSC_CLK 0x68>;
 		clk-source = <1>;
-		clk-divider = <256>;
+		clk-divider = <1>;
 		status = "okay";
 	};
 
@@ -285,9 +285,9 @@
 		compatible = "nxp,wdog32";
 		reg = <0x1b000 10>;
 		interrupts = <24 0>;
-		clocks = <&scg SCG_K4_SYSOSC_CLK 0x6c>;
+		clocks = <&scg SCG_K4_RTCOSC_CLK 0x6c>;
 		clk-source = <1>;
-		clk-divider = <256>;
+		clk-divider = <1>;
 		status = "disabled";
 	};
 

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -116,6 +116,9 @@
 #define TIMEOUTS 0
 #define WDT_TEST_MAX_WINDOW 3000U
 #endif
+#if DT_HAS_COMPAT_STATUS_OKAY(nxp_wdog32)
+#define WDT_TEST_MAX_WINDOW 1000U
+#endif
 
 #define WDT_TEST_STATE_IDLE        0
 #define WDT_TEST_STATE_CHECK_RESET 1

--- a/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_api/testcase.yaml
@@ -33,6 +33,7 @@ tests:
       - bl54l15u_dvk/nrf54l15/cpuapp/ns
       - raytac_an54l15q_db/nrf54l15/cpuapp/ns
       - frdm_mcxw71
+      - frdm_mcxw72/mcxw727c/cpu0
   drivers.watchdog.stm32wwdg:
     filter: dt_compat_enabled("st,stm32-window-watchdog") or dt_compat_enabled("st,stm32-watchdog")
     extra_args: DTC_OVERLAY_FILE="boards/stm32_wwdg.overlay"
@@ -150,3 +151,8 @@ tests:
     filter: dt_compat_enabled("ti,tps382x")
     platform_allow: mimxrt1050_evk/mimxrt1052/hyperflash
     extra_args: DTC_OVERLAY_FILE="boards/mimxrt1050_evk_ti_tps382x.overlay"
+  drivers.watchdog.nxp_sram_noecc:
+    extra_args: EXTRA_DTC_OVERLAY_FILE="sram_noecc.overlay"
+    platform_allow:
+      - frdm_mcxw71
+      - frdm_mcxw72/mcxw727c/cpu0


### PR DESCRIPTION
Use non-ecc memory to retain test data, fix #79839
In dts, wdog clock source is 1 so the correct clock phandle shall be 32K_CLK.