### PR TITLE
boards: convert to ARDUINO_HEADER_R3_* macro

### DIFF
--- a/boards/actinius/icarus_som_dk/arduino_connector.dtsi
+++ b/boards/actinius/icarus_som_dk/arduino_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: arduino_connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 15 0>,	/* A0 */
-			   <1 0 &gpio0 16 0>,	/* A1 */
-			   <2 0 &gpio0 17 0>,	/* A2 */
-			   <3 0 &gpio0 18 0>,	/* A3 */
-			   <4 0 &gpio0 19 0>,	/* A4 */
-			   <5 0 &gpio0 20 0>,	/* A5 */
-			   <6 0 &gpio0 4 0>,	/* D0 */
-			   <7 0 &gpio0 5 0>,	/* D1 */
-			   <8 0 &gpio0 2 0>,	/* D2 */
-			   <9 0 &gpio0 1 0>,	/* D3 */
-			   <10 0 &gpio0 23 0>,	/* D4 */
-			   <11 0 &gpio0 0 0>,	/* D5 */
-			   <12 0 &gpio0 26 0>,	/* D6 */
-			   <13 0 &gpio0 27 0>,	/* D7 */
-			   <14 0 &gpio0 30 0>,	/* D8 */
-			   <15 0 &gpio0 31 0>,	/* D9 */
-			   <16 0 &gpio0 7 0>,	/* D10 */
-			   <17 0 &gpio0 13 0>,	/* D11 */
-			   <18 0 &gpio0 14 0>,	/* D12 */
-			   <19 0 &gpio0 3 0>,	/* D13 */
-			   <20 0 &gpio0 10 0>,	/* SDA */
-			   <21 0 &gpio0 11 0>;	/* SCL */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 1 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 27 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 11 0>;
 	};
 
 	arduino_adc: analog_connector {

--- a/boards/adi/apard32690/apard32690_max32690_m4.dts
+++ b/boards/adi/apard32690/apard32690_max32690_m4.dts
@@ -9,6 +9,7 @@
 #include <adi/max32/max32690.dtsi>
 #include <adi/max32/max32690-pinctrl.dtsi>
 #include <zephyr/dt-bindings/gpio/adi-max32-gpio.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/memory-controller/adi-max32-hpb.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
@@ -60,28 +61,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio3 0 0>,	/* A0 */
-			   <1 0 &gpio3 1 0>,	/* A1 */
-			   <2 0 &gpio3 2 0>,	/* A2 */
-			   <3 0 &gpio3 3 0>,	/* A3 */
-			   <4 0 &gpio3 4 0>,	/* A4 */
-			   <5 0 &gpio3 5 0>,	/* A5 */
-			   <6 0 &gpio2 14 0>,	/* D0 */
-			   <7 0 &gpio2 16 0>,	/* D1 */
-			   <8 0 &gpio2 13 0>,	/* D2 */
-			   <9 0 &gpio2 15 0>,	/* D3 */
-			   <10 0 &gpio0 8 0>,	/* D4 */
-			   <11 0 &gpio0 7 0>,	/* D5 */
-			   <12 0 &gpio1 24 0>,	/* D6 */
-			   <13 0 &gpio1 25 0>,	/* D7 */
-			   <14 0 &gpio1 31 0>,	/* D8 */
-			   <15 0 &gpio1 30 0>,	/* D9 */
-			   <16 0 &gpio1 23 0>,	/* D10 */
-			   <17 0 &gpio1 29 0>,	/* D11 */
-			   <18 0 &gpio1 28 0>,	/* D12 */
-			   <19 0 &gpio1 26 0>,	/* D13 */
-			   <20 0 &gpio2 17 0>,	/* D14 */
-			   <21 0 &gpio2 18 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio3 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio3 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio3 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio3 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio3 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio3 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio2 14 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio2 16 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio2 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio2 15 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 25 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 31 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 30 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 29 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 28 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio2 17 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio2 18 0>;
 	};
 
 	pmod_header: pmod-header {

--- a/boards/adi/eval_adin1110ebz/arduino_r3_connector.dtsi
+++ b/boards/adi/eval_adin1110ebz/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0/D14 */
-			   <1 0 &gpioc 1 0>,	/* A1/D15 */
-			   <2 0 &gpioc 2 0>,	/* A2/D16 */
-			   <3 0 &gpioc 3 0>,	/* A3/D17 */
-			   <4 0 &gpioc 4 0>,	/* A4/D18 */
-			   <5 0 &gpioc 5 0>,	/* A5/D19 */
-			   <6 0 &gpioa 0 0>,	/* D0 */
-			   <7 0 &gpioa 1 0>,	/* D1 */
-			   <8 0 &gpioa 2 0>,	/* D2 */
-			   <9 0 &gpiod 2 0>,	/* D3 */
-			   <10 0 &gpiod 6 0>,	/* D4 */
-			   <11 0 &gpiob 7 0>,	/* D5 */
-			   <12 0 &gpiob 8 0>,	/* D6 */
-			   <13 0 &gpiob 9 0>,	/* D7 */
-			   <14 0 &gpiob 6 0>,	/* D8 */
-			   <15 0 &gpiob 5 0>,	/* D9 */
-			   <16 0 &gpiog 12 0>,	/* D10 */
-			   <17 0 &gpioc 12 0>,	/* D11 */
-			   <18 0 &gpioc 11 0>,	/* D12 */
-			   <19 0 &gpioc 10 0>,	/* D13 */
-			   <20 0 &gpioc 0 0>,	/* D14 */
-			   <21 0 &gpioc 1 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiod 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioc 12 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioc 11 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioc 10 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioc 1 0>;
 	};
 };
 

--- a/boards/adi/sdp_k1/arduino_r3_connector.dtsi
+++ b/boards/adi/sdp_k1/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 2 0>,	/* A0 */
-			   <1 0 &gpioa 4 0>,	/* A1 */
-			   <2 0 &gpioa 6 0>,	/* A2 */
-			   <3 0 &gpioc 1 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpioa 1 0>,	/* D0 */
-			   <7 0 &gpioa 0 0>,	/* D1 */
-			   <8 0 &gpiog 7 0>,	/* D2 */
-			   <9 0 &gpiod 12 0>,	/* D3 */
-			   <10 0 &gpiog 9 0>,	/* D4 */
-			   <11 0 &gpioa 11 0>,	/* D5 */
-			   <12 0 &gpioa 10 0>,	/* D6 */
-			   <13 0 &gpiog 10 0>,	/* D7 */
-			   <14 0 &gpiog 11 0>,	/* D8 */
-			   <15 0 &gpiob 15 0>,	/* D9 */
-			   <16 0 &gpioa 15 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpiob 4 0>,	/* D12 */
-			   <19 0 &gpiob 3 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 7 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiod 12 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 10 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 11 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/arduino/due/arduino_r3_connector.dtsi
+++ b/boards/arduino/due/arduino_r3_connector.dtsi
@@ -4,33 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = < 0 0 &pioa 16 0>,	/* A0 */
-			   < 1 0 &pioa 24 0>,	/* A1 */
-			   < 2 0 &pioa 23 0>,	/* A2 */
-			   < 3 0 &pioa 22 0>,	/* A3 */
-			   < 4 0 &pioa  6 0>,	/* A4 */
-			   < 5 0 &pioa  4 0>,	/* A5 */
-			   < 6 0 &pioa  8 0>,	/* D0 */
-			   < 7 0 &pioa  9 0>,	/* D1 */
-			   < 8 0 &piob 25 0>,	/* D2 */
-			   < 9 0 &pioc 28 0>,	/* D3 */
-			   <10 0 &pioa 29 0>,	/* D4 */
-			   <11 0 &pioc 25 0>,	/* D5 */
-			   <12 0 &pioc 24 0>,	/* D6 */
-			   <13 0 &pioc 23 0>,	/* D7 */
-			   <14 0 &pioc 22 0>,	/* D8 */
-			   <15 0 &pioc 21 0>,	/* D9 */
-			   <16 0 &pioa 28 0>,	/* D10 */
-			   <17 0 &piod  7 0>,	/* D11 */
-			   <18 0 &piod  8 0>,	/* D12 */
-			   <19 0 &piob 27 0>,	/* D13 */
-			   <20 0 &pioa 17 0>,	/* D20 */
-			   <21 0 &pioa 18 0>;	/* D21 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &pioa 16 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &pioa 24 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &pioa 23 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &pioa 22 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &pioa 6 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &pioa 4 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &pioa 8 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &pioa 9 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &piob 25 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &pioc 28 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &pioa 29 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &pioc 25 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &pioc 24 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &pioc 23 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &pioc 22 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &pioc 21 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &pioa 28 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &piod 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &piod 8 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &piob 27 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &pioa 17 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &pioa 18 0>;
 	};
 };

--- a/boards/arduino/giga_r1/arduino_r3_connector.dtsi
+++ b/boards/arduino/giga_r1/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = < 0 0 &gpioc 4  0>,	/* A0 */
-			   < 1 0 &gpioc 5  0>,	/* A1 */
-			   < 2 0 &gpiob 0  0>,	/* A2 */
-			   < 3 0 &gpiob 1  0>,	/* A3 */
-			   < 4 0 &gpioc 3  0>,	/* A4 */
-			   < 5 0 &gpioc 2  0>,	/* A5 */
-			   < 6 0 &gpiob 7  0>,	/* D0 */
-			   < 7 0 &gpioa 9  0>,	/* D1 */
-			   < 8 0 &gpioa 3  0>,	/* D2 */
-			   < 9 0 &gpioa 2  0>,	/* D3 */
-			   <10 0 &gpioj 8  0>,	/* D4 */
-			   <11 0 &gpioa 7  0>,	/* D5 */
-			   <12 0 &gpiod 13 0>,	/* D6 */
-			   <13 0 &gpiob 4  0>,	/* D7 */
-			   <14 0 &gpiob 8  0>,	/* D8 */
-			   <15 0 &gpiob 9  0>,	/* D9 */
-			   <16 0 &gpiok 1  0>,	/* D10 */
-			   <17 0 &gpioj 10 0>,	/* D11 */
-			   <18 0 &gpioj 11 0>,	/* D12 */
-			   <19 0 &gpioh 6  0>,	/* D13 */
-			   <20 0 &gpioh 12 0>,	/* D14 */
-			   <21 0 &gpiob 6  0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioj 8 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 8 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiok 1 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioj 10 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioj 11 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioh 6 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioh 12 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/atmel/sam/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -8,6 +8,7 @@
  */
 
 #include "sam_v71_xult-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -126,29 +127,29 @@
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           Shared */
-		gpio-map =	<0  0 &piod 26 0>,	/*  A0-TD           */
-				<1  0 &pioc 31 0>,	/*  A1-AFE1 AD6   y */
-				<2  0 &pioa 19 0>,	/*  A2-AFE0 AD8   y */
-				<3  0 &piod 30 0>,	/*  A3-AFE0 AD0   y */
-				<4  0 &pioc 13 0>,	/*  A4-AFE1 AD1   y */
-				<5  0 &pioe  0 0>,	/*  A5-AFE1 AD11    */
-				<6  0 &piod 28 0>,	/*  D0-URXD3        */
-				<7  0 &piod 30 0>,	/*  D1-UTXD3        */
-				<8  0 &pioa  0 0>,	/*  D2-PWMC0_H0     */
-				<9  0 &pioa  6 0>,	/*  D3-GPIO         */
-				<10 0 &piod 27 0>,	/*  D4-SPI0_NPCS3 y */
-				<11 0 &piod 11 0>,	/*  D5-PWMC0_H0     */
-				<12 0 &pioc 19 0>,	/*  D6-PWMC0_H2     */
-				<13 0 &pioa  2 0>,	/*  D7-PWMC0_H1     */
-				<14 0 &pioa  5 0>,	/*  D8-PWMC1_PWML3  */
-				<15 0 &pioc  9 0>,	/*  D9-TIOB7        */
-				<16 0 &piod 25 0>,	/* D10-SPI0_NPCS1 y */
-				<17 0 &piod 21 0>,	/* D11-SPI0_MOSI  y */
-				<18 0 &piod 20 0>,	/* D12-SPI0_MISO  y */
-				<19 0 &piod 22 0>,	/* D13-SPI0_SPCK  y */
-				<20 0 &pioa  3 0>,	/* D14-TWD0       y */
-				<21 0 &pioa  4 0>;	/* D15-TWCK0      y */
+		gpio-map-pass-thru = <0 0x3f>;				/*       Shared */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &piod 26 0>,	/* TD           */
+				<ARDUINO_HEADER_R3_A1  0 &pioc 31 0>,	/* AFE1 AD6   y */
+				<ARDUINO_HEADER_R3_A2  0 &pioa 19 0>,	/* AFE0 AD8   y */
+				<ARDUINO_HEADER_R3_A3  0 &piod 30 0>,	/* AFE0 AD0   y */
+				<ARDUINO_HEADER_R3_A4  0 &pioc 13 0>,	/* AFE1 AD1   y */
+				<ARDUINO_HEADER_R3_A5  0 &pioe  0 0>,	/* AFE1 AD11    */
+				<ARDUINO_HEADER_R3_D0 0 &piod 28 0>,	/* URXD3        */
+				<ARDUINO_HEADER_R3_D1 0 &piod 30 0>,	/* UTXD3        */
+				<ARDUINO_HEADER_R3_D2 0 &pioa 0 0>,	/* PWMC0_H0     */
+				<ARDUINO_HEADER_R3_D3 0 &pioa 6 0>,	/* GPIO         */
+				<ARDUINO_HEADER_R3_D4 0 &piod 27 0>,	/* SPI0_NPCS3 y */
+				<ARDUINO_HEADER_R3_D5 0 &piod 11 0>,	/* PWMC0_H0     */
+				<ARDUINO_HEADER_R3_D6 0 &pioc 19 0>,	/* PWMC0_H2     */
+				<ARDUINO_HEADER_R3_D7 0 &pioa 2 0>,	/* PWMC0_H1     */
+				<ARDUINO_HEADER_R3_D8 0 &pioa 5 0>,	/* PWMC1_PWML3  */
+				<ARDUINO_HEADER_R3_D9 0 &pioc 9 0>,	/* TIOB7        */
+				<ARDUINO_HEADER_R3_D10 0 &piod 25 0>,	/* SPI0_NPCS1 y */
+				<ARDUINO_HEADER_R3_D11 0 &piod 21 0>,	/* SPI0_MOSI  y */
+				<ARDUINO_HEADER_R3_D12 0 &piod 20 0>,	/* SPI0_MISO  y */
+				<ARDUINO_HEADER_R3_D13 0 &piod 22 0>,	/* SPI0_SPCK  y */
+				<ARDUINO_HEADER_R3_D14 0 &pioa  3 0>,	/* TWD0       y */
+				<ARDUINO_HEADER_R3_D15 0 &pioa  4 0>;	/* TWCK0      y */
 	};
 };
 

--- a/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
+++ b/boards/cypress/cy8ckit_062_ble/cy8ckit_062_ble_common.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -34,29 +35,29 @@
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
-		gpio-map-pass-thru = <0 0x3f>;		/*           shared */
-		gpio-map = <0  0 &gpio_prt9   0 0>,	/*  A0-             */
-			   <1  0 &gpio_prt9   1 0>,	/*  A1-             */
-			   <2  0 &gpio_prt9   2 0>,	/*  A2-             */
-			   <3  0 &gpio_prt9   3 0>,	/*  A3-             */
-			   <4  0 &gpio_prt9   4 0>,	/*  A4-             */
-			   <5  0 &gpio_prt9   5 0>,	/*  A5-             */
-			   <6  0 &gpio_prt5   0 0>,	/*  D0-RX-5         */
-			   <7  0 &gpio_prt5   1 0>,	/*  D1-TX-5         */
-			   <8  0 &gpio_prt5   2 0>,	/*  D2-RTS-5        */
-			   <9  0 &gpio_prt5   3 0>,	/*  D3-CTS-5        */
-			   <10 0 &gpio_prt5   4 0>,	/*  D4-             */
-			   <11 0 &gpio_prt5   5 0>,	/*  D5-             */
-			   <12 0 &gpio_prt5   6 0>,	/*  D6-             */
-			   <13 0 &gpio_prt0   2 0>,	/*  D7-             */
-			   <14 0 &gpio_prt13  0 0>,	/*  D8-RX-6       y */
-			   <15 0 &gpio_prt13  1 0>,	/*  D9-TX-6       y */
-			   <16 0 &gpio_prt12  3 0>,	/* D10-SPI6_SEL0  y */
-			   <17 0 &gpio_prt12  0 0>,	/* D11-SPI6_MOSI  y */
-			   <18 0 &gpio_prt12  1 0>,	/* D12-SPI6_MISO  y */
-			   <19 0 &gpio_prt12  2 0>,	/* D13-SPI6_CLK   y */
-			   <20 0 &gpio_prt6   1 0>,	/* D14-SDAx         */
-			   <21 0 &gpio_prt6   0 0>;	/* D15-SCLx         */
+		gpio-map-pass-thru = <0 0x3f>;				/*       shared */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio_prt9 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio_prt9 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio_prt9 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio_prt9 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio_prt9 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio_prt9 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio_prt5 0 0>,	/* RX-5         */
+			   <ARDUINO_HEADER_R3_D1 0 &gpio_prt5 1 0>,	/* TX-5         */
+			   <ARDUINO_HEADER_R3_D2 0 &gpio_prt5 2 0>,	/* RTS-5        */
+			   <ARDUINO_HEADER_R3_D3 0 &gpio_prt5 3 0>,	/* CTS-5        */
+			   <ARDUINO_HEADER_R3_D4 0 &gpio_prt5 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio_prt5 5 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio_prt5 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio_prt0 2 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio_prt13  0 0>,	/* RX-6       y */
+			   <ARDUINO_HEADER_R3_D9 0 &gpio_prt13  1 0>,	/* TX-6       y */
+			   <ARDUINO_HEADER_R3_D10 0 &gpio_prt12  3 0>,	/* SPI6_SEL0  y */
+			   <ARDUINO_HEADER_R3_D11 0 &gpio_prt12  0 0>,	/* SPI6_MOSI  y */
+			   <ARDUINO_HEADER_R3_D12 0 &gpio_prt12  1 0>,	/* SPI6_MISO  y */
+			   <ARDUINO_HEADER_R3_D13 0 &gpio_prt12  2 0>,	/* SPI6_CLK   y */
+			   <ARDUINO_HEADER_R3_D14 0 &gpio_prt6 1 0>,	/* SDAx         */
+			   <ARDUINO_HEADER_R3_D15 0 &gpio_prt6 0 0>;	/* SCLx         */
 	};
 };
 

--- a/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.dts
+++ b/boards/infineon/cy8ckit_062s4/cy8ckit_062s4.dts
@@ -5,6 +5,7 @@
 
 /dts-v1/;
 #include <infineon/cat1a/mpns/CY8C6244LQI_S4D92.dtsi>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	model = "Infineon PSOC 62S4 Pioneer Kit";
@@ -34,26 +35,26 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;		/* shared */
-		gpio-map = <0  0 &gpio_prt10   0 0>,	/* A0 */
-			   <1  0 &gpio_prt10   1 0>,	/* A1 */
-			   <2  0 &gpio_prt10   2 0>,	/* A2 */
-			   <3  0 &gpio_prt10   3 0>,	/* A3 */
-			   <4  0 &gpio_prt10   4 0>,	/* A4 */
-			   <5  0 &gpio_prt10   5 0>,	/* A5 */
-			   <6  0 &gpio_prt0   2 0>,	/* D0-RX-5 */
-			   <7  0 &gpio_prt0   3 0>,	/* D1-TX-5 */
-			   <8  0 &gpio_prt5   0 0>,	/* D2-RTS-5 */
-			   <9  0 &gpio_prt5   1 0>,	/* D3-CTS-5 */
-			   <10 0 &gpio_prt5   6 0>,	/* D4 */
-			   <11 0 &gpio_prt5   7 0>,	/* D5 */
-			   <12 0 &gpio_prt6   2 0>,	/* D6 */
-			   <13 0 &gpio_prt6   3 0>,	/* D7 */
-			   <14 0 &gpio_prt2   4 0>,	/* D8-RX-6 */
-			   <15 0 &gpio_prt2   6 0>,	/* D9-TX-6 */
-			   <16 0 &gpio_prt2   3 0>,	/* D10 */
-			   <17 0 &gpio_prt2   0 0>,	/* D11 */
-			   <18 0 &gpio_prt2   1 0>,	/* D12 */
-			   <19 0 &gpio_prt2   2 0>;	/* D13 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio_prt10 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio_prt10 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio_prt10 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio_prt10 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio_prt10 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio_prt10 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio_prt0 2 0>,	/* RX-5 */
+			   <ARDUINO_HEADER_R3_D1 0 &gpio_prt0 3 0>,	/* TX-5 */
+			   <ARDUINO_HEADER_R3_D2 0 &gpio_prt5 0 0>,	/* RTS-5 */
+			   <ARDUINO_HEADER_R3_D3 0 &gpio_prt5 1 0>,	/* CTS-5 */
+			   <ARDUINO_HEADER_R3_D4 0 &gpio_prt5 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio_prt5 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio_prt6 2 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio_prt6 3 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio_prt2 4 0>,	/* RX-6 */
+			   <ARDUINO_HEADER_R3_D9 0 &gpio_prt2 6 0>,	/* TX-6 */
+			   <ARDUINO_HEADER_R3_D10 0 &gpio_prt2 3 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio_prt2 0 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio_prt2 1 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio_prt2 2 0>;
 	};
 };
 

--- a/boards/infineon/xmc47_relax_kit/arduino_r3_connector.dtsi
+++ b/boards/infineon/xmc47_relax_kit/arduino_r3_connector.dtsi
@@ -3,34 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio14 0 0>,	/* A0 */
-			   <1 0 &gpio14 1 0>,	/* A1 */
-			   <2 0 &gpio14 2 0>,	/* A2 */
-			   <3 0 &gpio14 3 0>,	/* A3 */
-			   <4 0 &gpio14 4 0>,	/* A4 */
-			   <5 0 &gpio14 5 0>,	/* A5 */
-			   <6 0 &gpio2 15 0>,	/* D0 */
-			   <7 0 &gpio2 14 0>,	/* D1 */
-			   <8 0 &gpio1 0 0>,	/* D2 */
-			   <9 0 &gpio1 1 0>,	/* D3 */
-			   <10 0 &gpio1 8 0>,	/* D4 */
-			   <11 0 &gpio2 12 0>,	/* D5 */
-			   <12 0 &gpio2 11 0>,	/* D6 */
-			   <13 0 &gpio1 9 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio3 10 0>,	/* D10 */
-			   <17 0 &gpio3 8 0>,	/* D11 */
-			   <18 0 &gpio3 7 0>,	/* D12 */
-			   <19 0 &gpio3 9 0>,	/* D13 */
-			   <20 0 &gpio3 15 0>,	/* D14 */
-			   <21 0 &gpio0 13 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio14 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio14 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio14 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio14 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio14 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio14 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio2 15 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio2 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio2 12 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio2 11 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio3 10 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio3 8 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio3 7 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio3 9 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 13 0>;
 	};
 };
 

--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
 #include "nrf21540dk_nrf52840-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -91,28 +92,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio1 1 0>,	/* D0 */
-			   <7 0 &gpio1 2 0>,	/* D1 */
-			   <8 0 &gpio1 3 0>,	/* D2 */
-			   <9 0 &gpio1 4 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 8 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf52833_qiaa.dtsi>
 #include "nrf52833dk_nrf52833-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -90,28 +91,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio1 1 0>,	/* D0 */
-			   <7 0 &gpio1 2 0>,	/* D1 */
-			   <8 0 &gpio1 3 0>,	/* D2 */
-			   <9 0 &gpio1 4 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 8 0>,	/* D7 */
-			   <14 0 &gpio0 17 0>,	/* D8 */
-			   <15 0 &gpio0 19 0>,	/* D9 */
-			   <16 0 &gpio0 20 0>,	/* D10 */
-			   <17 0 &gpio0 21 0>,	/* D11 */
-			   <18 0 &gpio0 22 0>,	/* D12 */
-			   <19 0 &gpio0 23 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 21 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
@@ -8,6 +8,7 @@
 #include <nordic/nrf52840_qiaa.dtsi>
 #include <nordic/nrf52840_partition.dtsi>
 #include "nrf52840dk_nrf52840-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -89,28 +90,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio1 1 0>,	/* D0 */
-			   <7 0 &gpio1 2 0>,	/* D1 */
-			   <8 0 &gpio1 3 0>,	/* D2 */
-			   <9 0 &gpio1 4 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 8 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <nordic/nrf52832_qfaa.dtsi>
 #include "nrf52dk_nrf52832-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -90,28 +91,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio0 11 0>,	/* D0 */
-			   <7 0 &gpio0 12 0>,	/* D1 */
-			   <8 0 &gpio0 13 0>,	/* D2 */
-			   <9 0 &gpio0 14 0>,	/* D3 */
-			   <10 0 &gpio0 15 0>,	/* D4 */
-			   <11 0 &gpio0 16 0>,	/* D5 */
-			   <12 0 &gpio0 17 0>,	/* D6 */
-			   <13 0 &gpio0 18 0>,	/* D7 */
-			   <14 0 &gpio0 19 0>,	/* D8 */
-			   <15 0 &gpio0 20 0>,	/* D9 */
-			   <16 0 &gpio0 22 0>,	/* D10 */
-			   <17 0 &gpio0 23 0>,	/* D11 */
-			   <18 0 &gpio0 24 0>,	/* D12 */
-			   <19 0 &gpio0 25 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_shared.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_shared.dtsi
@@ -1,3 +1,4 @@
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -89,28 +90,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 6 0>,	/* A2 */
-			   <3 0 &gpio0 7 0>,	/* A3 */
-			   <4 0 &gpio0 25 0>,	/* A4 */
-			   <5 0 &gpio0 26 0>,	/* A5 */
-			   <6 0 &gpio1 9 0>,	/* D0 */
-			   <7 0 &gpio1 8 0>,	/* D1 */
-			   <8 0 &gpio0 31 0>,	/* D2 */
-			   <9 0 &gpio1 0 0>,	/* D3 */
-			   <10 0 &gpio1 1 0>,	/* D4 */
-			   <11 0 &gpio1 14 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 11 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 13 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio0 9 0>,	/* D11 */
-			   <18 0 &gpio0 10 0>,	/* D12 */
-			   <19 0 &gpio0 8 0>,	/* D13 */
-			   <20 0 &gpio1 2 0>,	/* D14 */
-			   <21 0 &gpio1 3 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
 	};
 
 	aliases {

--- a/boards/nordic/nrf5340dk/nrf5340dk_common.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340dk_common.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	leds {
 		compatible = "gpio-leds";
@@ -62,28 +64,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 6 0>,	/* A2 */
-			   <3 0 &gpio0 7 0>,	/* A3 */
-			   <4 0 &gpio0 25 0>,	/* A4 */
-			   <5 0 &gpio0 26 0>,	/* A5 */
-			   <6 0 &gpio1 0 0>,	/* D0 */
-			   <7 0 &gpio1 1 0>,	/* D1 */
-			   <8 0 &gpio1 4 0>,	/* D2 */
-			   <9 0 &gpio1 5 0>,	/* D3 */
-			   <10 0 &gpio1 6 0>,	/* D4 */
-			   <11 0 &gpio1 7 0>,	/* D5 */
-			   <12 0 &gpio1 8 0>,	/* D6 */
-			   <13 0 &gpio1 9 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio1 2 0>,	/* D14 */
-			   <21 0 &gpio1 3 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "nrf5340_cpuapp_common_pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -61,28 +62,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 6 0>,	/* A2 */
-			   <3 0 &gpio0 7 0>,	/* A3 */
-			   <4 0 &gpio0 25 0>,	/* A4 */
-			   <5 0 &gpio0 26 0>,	/* A5 */
-			   <6 0 &gpio1 0 0>,	/* D0 */
-			   <7 0 &gpio1 1 0>,	/* D1 */
-			   <8 0 &gpio1 4 0>,	/* D2 */
-			   <9 0 &gpio1 5 0>,	/* D3 */
-			   <10 0 &gpio1 6 0>,	/* D4 */
-			   <11 0 &gpio1 7 0>,	/* D5 */
-			   <12 0 &gpio1 8 0>,	/* D6 */
-			   <13 0 &gpio1 9 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio1 2 0>,	/* D14 */
-			   <21 0 &gpio1 3 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf5340_cpunet_qkaa.dtsi>
 #include "nrf7002dk_nrf5340_cpunet_pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -62,28 +63,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 6 0>,	/* A2 */
-			   <3 0 &gpio0 7 0>,	/* A3 */
-			   <4 0 &gpio0 25 0>,	/* A4 */
-			   <5 0 &gpio0 26 0>,	/* A5 */
-			   <6 0 &gpio1 0 0>,	/* D0 */
-			   <7 0 &gpio1 1 0>,	/* D1 */
-			   <8 0 &gpio1 4 0>,	/* D2 */
-			   <9 0 &gpio1 5 0>,	/* D3 */
-			   <10 0 &gpio1 6 0>,	/* D4 */
-			   <11 0 &gpio1 7 0>,	/* D5 */
-			   <12 0 &gpio1 8 0>,	/* D6 */
-			   <13 0 &gpio1 9 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio1 2 0>,	/* D14 */
-			   <21 0 &gpio1 3 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
 	};
 
 	nrf_radio_coex: coex {

--- a/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common.dtsi
+++ b/boards/nordic/nrf9151dk/nrf9151dk_nrf9151_common.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "nrf9151dk_nrf9151_common-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -87,28 +88,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 14 0>,	/* A0 */
-			   <1 0 &gpio0 15 0>,	/* A1 */
-			   <2 0 &gpio0 16 0>,	/* A2 */
-			   <3 0 &gpio0 17 0>,	/* A3 */
-			   <4 0 &gpio0 18 0>,	/* A4 */
-			   <5 0 &gpio0 19 0>,	/* A5 */
-			   <6 0 &gpio0 0 0>,	/* D0 */
-			   <7 0 &gpio0 1 0>,	/* D1 */
-			   <8 0 &gpio0 2 0>,	/* D2 */
-			   <9 0 &gpio0 3 0>,	/* D3 */
-			   <10 0 &gpio0 4 0>,	/* D4 */
-			   <11 0 &gpio0 5 0>,	/* D5 */
-			   <12 0 &gpio0 6 0>,	/* D6 */
-			   <13 0 &gpio0 7 0>,	/* D7 */
-			   <14 0 &gpio0 8 0>,	/* D8 */
-			   <15 0 &gpio0 9 0>,	/* D9 */
-			   <16 0 &gpio0 10 0>,	/* D10 */
-			   <17 0 &gpio0 11 0>,	/* D11 */
-			   <18 0 &gpio0 12 0>,	/* D12 */
-			   <19 0 &gpio0 13 0>,	/* D13 */
-			   <20 0 &gpio0 30 0>,	/* D14 */
-			   <21 0 &gpio0 31 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 31 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common.dtsi
+++ b/boards/nordic/nrf9160dk/nrf9160dk_nrf9160_common.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "nrf9160dk_nrf9160_common-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -114,28 +115,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 14 0>,	/* A0 */
-			   <1 0 &gpio0 15 0>,	/* A1 */
-			   <2 0 &gpio0 16 0>,	/* A2 */
-			   <3 0 &gpio0 17 0>,	/* A3 */
-			   <4 0 &gpio0 18 0>,	/* A4 */
-			   <5 0 &gpio0 19 0>,	/* A5 */
-			   <6 0 &gpio0 0 0>,	/* D0 */
-			   <7 0 &gpio0 1 0>,	/* D1 */
-			   <8 0 &gpio0 2 0>,	/* D2 */
-			   <9 0 &gpio0 3 0>,	/* D3 */
-			   <10 0 &gpio0 4 0>,	/* D4 */
-			   <11 0 &gpio0 5 0>,	/* D5 */
-			   <12 0 &gpio0 6 0>,	/* D6 */
-			   <13 0 &gpio0 7 0>,	/* D7 */
-			   <14 0 &gpio0 8 0>,	/* D8 */
-			   <15 0 &gpio0 9 0>,	/* D9 */
-			   <16 0 &gpio0 10 0>,	/* D10 */
-			   <17 0 &gpio0 11 0>,	/* D11 */
-			   <18 0 &gpio0 12 0>,	/* D12 */
-			   <19 0 &gpio0 13 0>,	/* D13 */
-			   <20 0 &gpio0 30 0>,	/* D14 */
-			   <21 0 &gpio0 31 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 31 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common.dtsi
+++ b/boards/nordic/nrf9161dk/nrf9161dk_nrf9161_common.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "nrf9161dk_nrf9161_common-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -87,28 +88,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 14 0>,	/* A0 */
-			   <1 0 &gpio0 15 0>,	/* A1 */
-			   <2 0 &gpio0 16 0>,	/* A2 */
-			   <3 0 &gpio0 17 0>,	/* A3 */
-			   <4 0 &gpio0 18 0>,	/* A4 */
-			   <5 0 &gpio0 19 0>,	/* A5 */
-			   <6 0 &gpio0 0 0>,	/* D0 */
-			   <7 0 &gpio0 1 0>,	/* D1 */
-			   <8 0 &gpio0 2 0>,	/* D2 */
-			   <9 0 &gpio0 3 0>,	/* D3 */
-			   <10 0 &gpio0 4 0>,	/* D4 */
-			   <11 0 &gpio0 5 0>,	/* D5 */
-			   <12 0 &gpio0 6 0>,	/* D6 */
-			   <13 0 &gpio0 7 0>,	/* D7 */
-			   <14 0 &gpio0 8 0>,	/* D8 */
-			   <15 0 &gpio0 9 0>,	/* D9 */
-			   <16 0 &gpio0 10 0>,	/* D10 */
-			   <17 0 &gpio0 11 0>,	/* D11 */
-			   <18 0 &gpio0 12 0>,	/* D12 */
-			   <19 0 &gpio0 13 0>,	/* D13 */
-			   <20 0 &gpio0 30 0>,	/* D14 */
-			   <21 0 &gpio0 31 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 31 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/nxp/frdm_k22f/frdm_k22f.dts
+++ b/boards/nxp/frdm_k22f/frdm_k22f.dts
@@ -10,6 +10,7 @@
 #include <nxp/nxp_k22fn512.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include "frdm_k22f-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -93,28 +94,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiob 0 0>,	/* A0 */
-			   <1 0 &gpiob 1 0>,	/* A1 */
-			   <2 0 &gpioc 1 0>,	/* A2 */
-			   <3 0 &gpioc 2 0>,	/* A3 */
-			   <4 0 &gpiob 3 0>,	/* A4 */
-			   <5 0 &gpiob 2 0>,	/* A5 */
-			   <6 0 &gpiod 2 0>,	/* D0 */
-			   <7 0 &gpiod 3 0>,	/* D1 */
-			   <8 0 &gpiob 16 0>,	/* D2 */
-			   <9 0 &gpioa 2 0>,	/* D3 */
-			   <10 0 &gpioa 4 0>,	/* D4 */
-			   <11 0 &gpiob 18 0>,	/* D5 */
-			   <12 0 &gpioc 3 0>,	/* D6 */
-			   <13 0 &gpioc 6 0>,	/* D7 */
-			   <14 0 &gpiob 19 0>,	/* D8 */
-			   <15 0 &gpioa 1 0>,	/* D9 */
-			   <16 0 &gpiod 4 0>,	/* D10 */
-			   <17 0 &gpiod 6 0>,	/* D11 */
-			   <18 0 &gpiod 7 0>,	/* D12 */
-			   <19 0 &gpiod 5 0>,	/* D13 */
-			   <20 0 &gpioe 0 0>,	/* D14 */
-			   <21 0 &gpioe 1 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiob 16 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 18 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 19 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 4 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiod 6 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiod 7 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiod 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioe 1 0>;
 	};
 };
 

--- a/boards/nxp/frdm_k64f/frdm_k64f.dts
+++ b/boards/nxp/frdm_k64f/frdm_k64f.dts
@@ -4,6 +4,7 @@
 
 #include <nxp/nxp_k6x.dtsi>
 #include "frdm_k64f-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -67,31 +68,31 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiob 2 0>,	/* A0 */
-			   <1 0 &gpiob 3 0>,	/* A1 */
-			   <2 0 &gpiob 10 0>,	/* A2 */
-			   <3 0 &gpiob 11 0>,	/* A3 */
-			   <4 0 &gpioc 11 0>,	/* A4 */
-			   <5 0 &gpioc 10 0>,	/* A5 */
-			   <6 0 &gpioc 16 0>,	/* D0 */
-			   <7 0 &gpioc 17 0>,	/* D1 */
-			   <8 0 &gpiob 9 0>,	/* D2 */
-			   <9 0 &gpioa 1 0>,	/* D3 */
-			   <10 0 &gpiob 23 0>,	/* D4 */
-			   <11 0 &gpioa 2 0>,	/* D5 */
-			   <12 0 &gpioc 2 0>,	/* D6 */
-			   <13 0 &gpioc 3 0>,	/* D7 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 11 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 16 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 17 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 23 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 3 0>,
 			   /* NOTE: HW Rev D and below use: */
-			   /* <14 0 &gpioa 0 0>, */
+			   /* <ARDUINO_HEADER_R3_D8 0 &gpioa 0 0>, */
 			   /* NOTE: HW Rev E and on use: */
-			   <14 0 &gpioc 12 0>,	/* D8 */
-			   <15 0 &gpioc 4 0>,	/* D9 */
-			   <16 0 &gpiod 0 0>,	/* D10 */
-			   <17 0 &gpiod 2 0>,	/* D11 */
-			   <18 0 &gpiod 3 0>,	/* D12 */
-			   <19 0 &gpiod 1 0>,	/* D13 */
-			   <20 0 &gpioe 25 0>,	/* D14 */
-			   <21 0 &gpioe 24 0>;	/* D15 */
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiod 1 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioe 25 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioe 24 0>;
 	};
 };
 

--- a/boards/nxp/frdm_k82f/frdm_k82f.dts
+++ b/boards/nxp/frdm_k82f/frdm_k82f.dts
@@ -10,6 +10,7 @@
 #include <nxp/nxp_k82fn256vxx15.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include "frdm_k82f-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -95,28 +96,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiob 0 0>,	/* A0 */
-			   <1 0 &gpiob 1 0>,	/* A1 */
-			   <2 0 &gpioc 1 0>,	/* A2 */
-			   <3 0 &gpioc 2 0>,	/* A3 */
-			   <4 0 &gpiob 3 0>,	/* A4 */
-			   <5 0 &gpiob 2 0>,	/* A5 */
-			   <6 0 &gpiob 16 0>,	/* D0 */
-			   <7 0 &gpiob 17 0>,	/* D1 */
-			   <8 0 &gpioc 12 0>,	/* D2 */
-			   <9 0 &gpiod 0 0>,	/* D3 */
-			   <10 0 &gpioc 11 0>,	/* D4 */
-			   <11 0 &gpioc 10 0>,	/* D5 */
-			   <12 0 &gpioc 8 0>,	/* D6 */
-			   <13 0 &gpioc 9 0>,	/* D7 */
-			   <14 0 &gpioc 3 0>,	/* D8 */
-			   <15 0 &gpioc 5 0>,	/* D9 */
-			   <16 0 &gpiod 4 0>,	/* D10 */
-			   <17 0 &gpiod 2 0>,	/* D11 */
-			   <18 0 &gpiod 3 0>,	/* D12 */
-			   <19 0 &gpiod 1 0>,	/* D13 */
-			   <20 0 &gpioa 1 0>,	/* D14 */
-			   <21 0 &gpioa 2 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 16 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 17 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 12 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiod 0 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioc 11 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioc 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 4 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiod 1 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioa 2 0>;
 	};
 };
 

--- a/boards/nxp/frdm_ke15z/frdm_ke15z.dts
+++ b/boards/nxp/frdm_ke15z/frdm_ke15z.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_ke1xz.dtsi>
 #include "frdm_ke15z-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -64,28 +65,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 6 0>,	/* A2 */
-			   <3 0 &gpioa 7 0>,	/* A3 */
-			   <4 0 &gpioa 2 0>,	/* A4 */
-			   <5 0 &gpioa 3 0>,	/* A5 */
-			   <6 0 &gpioc 8 0>,	/* D0 */
-			   <7 0 &gpioc 9 0>,	/* D1 */
-			   <8 0 &gpiod 12 0>,	/* D2 */
-			   <9 0 &gpioc 15 0>,	/* D3 */
-			   <10 0 &gpioe 9 0>,	/* D4 */
-			   <11 0 &gpioc 5 0>,	/* D5 */
-			   <12 0 &gpioa 16 0>,	/* D6 */
-			   <13 0 &gpioa 17 0>,	/* D7 */
-			   <14 0 &gpioe 8 0>,	/* D8 */
-			   <15 0 &gpioe 7 0>,	/* D9 */
-			   <16 0 &gpioa 15 0>,	/* D10 */
-			   <17 0 &gpioe 2 0>,	/* D11 */
-			   <18 0 &gpioe 1 0>,	/* D12 */
-			   <19 0 &gpioe 0 0>,	/* D13 */
-			   <20 0 &gpiod 8 0>,	/* D14 */
-			   <21 0 &gpiod 9 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 12 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioc 15 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 16 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 17 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioe 8 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioe 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioe 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioe 1 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiod 9 0>;
 	};
 };
 

--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_ke17z.dtsi>
 #include "frdm_ke17z-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
@@ -88,28 +89,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 17 0>,	/* A0 */
-			   <1 0 &gpioc 16 0>,	/* A1 */
-			   <2 0 &gpiod 16 0>,	/* A2 */
-			   <3 0 &gpiod 15 0>,	/* A3 */
-			   <4 0 &gpioa 1 0>,	/* A4 */
-			   <5 0 &gpioa 0 0>,	/* A5 */
-			   <6 0 &gpiod 17 0>,	/* D0 */
-			   <7 0 &gpioe 12 0>,	/* D1 */
-			   <8 0 &gpiod 8 0>,	/* D2 */
-			   <9 0 &gpiod 9 0>,	/* D3 */
-			   <10 0 &gpioc 14 0>,	/* D4 */
-			   <11 0 &gpioa 15 0>,	/* D5 */
-			   <12 0 &gpioa 17 0>,	/* D6 */
-			   <13 0 &gpioa 14 0>,	/* D7 */
-			   <14 0 &gpioe 11 0>,	/* D8 */
-			   <15 0 &gpiob 11 0>,	/* D9 */
-			   <16 0 &gpiob 5 0>,	/* D10 */
-			   <17 0 &gpiob 4 0>,	/* D11 */
-			   <18 0 &gpiob 3 0>,	/* D12 */
-			   <19 0 &gpiob 2 0>,	/* D13 */
-			   <20 0 &gpioa 16 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 17 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 16 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiod 16 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 17 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioe 12 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiod 9 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioc 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 14 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioa 16 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
+++ b/boards/nxp/frdm_ke17z512/frdm_ke17z512.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_ke17z512.dtsi>
 #include "frdm_ke17z512-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
@@ -88,28 +89,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
-			   <1 0 &gpioc 1 0>,	/* A1 */
-			   <2 0 &gpiob 4 0>,	/* A2 */
-			   <3 0 &gpioe 3 0>,	/* A3 */
-			   <4 0 &gpioc 16 0>,	/* A4 */
-			   <5 0 &gpioc 17 0>,	/* A5 */
-			   <6 0 &gpioc 6 0>,	/* D0 */
-			   <7 0 &gpioc 7 0>,	/* D1 */
-			   <8 0 &gpiob 9 0>,	/* D2 */
-			   <9 0 &gpioe 4 0>,	/* D3 */
-			   <10 0 &gpioc 14 0>,	/* D4 */
-			   <11 0 &gpioa 15 0>,	/* D5 */
-			   <12 0 &gpioa 17 0>,	/* D6 */
-			   <13 0 &gpioa 14 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpiob 11 0>,	/* D9 */
-			   <16 0 &gpioe 6 0>,	/* D10 */
-			   <17 0 &gpioe 2 0>,	/* D11 */
-			   <18 0 &gpioe 1 0>,	/* D12 */
-			   <19 0 &gpioe 0 0>,	/* D13 */
-			   <20 0 &gpioa 2 0>,	/* D14 */
-			   <21 0 &gpioa 3 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioe 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 16 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 17 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioc 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 14 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioe 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioe 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioe 1 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioa 3 0>;
 	};
 };
 

--- a/boards/nxp/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/nxp/frdm_kl25z/frdm_kl25z.dts
@@ -4,6 +4,7 @@
 
 #include <nxp/nxp_kl25z.dtsi>
 #include "frdm_kl25z-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -61,28 +62,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiob 0 0>,	/* A0 */
-			   <1 0 &gpiob 1 0>,	/* A1 */
-			   <2 0 &gpiob 2 0>,	/* A2 */
-			   <3 0 &gpiob 3 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpioc 1 0>,	/* A5 */
-			   <6 0 &gpioa 1 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpiod 4 0>,	/* D2 */
-			   <9 0 &gpioa 12 0>,	/* D3 */
-			   <10 0 &gpioa 4 0>,	/* D4 */
-			   <11 0 &gpioa 5 0>,	/* D5 */
-			   <12 0 &gpioc 8 0>,	/* D6 */
-			   <13 0 &gpioc 9 0>,	/* D7 */
-			   <14 0 &gpioa 13 0>,	/* D8 */
-			   <15 0 &gpiod 5 0>,	/* D9 */
-			   <16 0 &gpiod 0 0>,	/* D10 */
-			   <17 0 &gpiod 2 0>,	/* D11 */
-			   <18 0 &gpiod 3 0>,	/* D12 */
-			   <19 0 &gpiod 1 0>,	/* D13 */
-			   <20 0 &gpioe 0 0>,	/* D14 */
-			   <21 0 &gpioe 1 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 13 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 5 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiod 1 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioe 1 0>;
 	};
 };
 

--- a/boards/nxp/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/nxp/frdm_kw41z/frdm_kw41z.dts
@@ -4,6 +4,7 @@
 
 #include <nxp/nxp_kw41z.dtsi>
 #include "frdm_kw41z-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -88,26 +89,26 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = /* A0 cannot be muxed as gpio */
-			   <1 0 &gpiob 18 0>,	/* A1 */
-			   <2 0 &gpiob 2 0>,	/* A2 */
-			   <3 0 &gpiob 3 0>,	/* A3 */
-			   <4 0 &gpiob 1 0>,	/* A4 */
-			   <6 0 &gpioc 6 0>,	/* D0 */
-			   <7 0 &gpioc 7 0>,	/* D1 */
-			   <8 0 &gpioc 19 0>,	/* D2 */
-			   <9 0 &gpioc 16 0>,	/* D3 */
-			   <10 0 &gpioc 4 0>,	/* D4 */
-			   <11 0 &gpioc 17 0>,	/* D5 */
-			   <12 0 &gpioc 18 0>,	/* D6 */
-			   <13 0 &gpioa 1 0>,	/* D7 */
-			   <14 0 &gpioa 0 0>,	/* D8 */
-			   <15 0 &gpioc 1 0>,	/* D9 */
-			   <16 0 &gpioa 19 0>,	/* D10 */
-			   <17 0 &gpioa 16 0>,	/* D11 */
-			   <18 0 &gpioa 17 0>,	/* D12 */
-			   <19 0 &gpioa 18 0>,	/* D13 */
-			   <20 0 &gpioc 3 0>,	/* D14 */
-			   <21 0 &gpioc 2 0>;	/* D15 */
+			   <ARDUINO_HEADER_R3_A1 0 &gpiob 18 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 19 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioc 16 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioc 17 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioc 18 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 19 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 16 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 17 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 18 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioc 2 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
+++ b/boards/nxp/frdm_mcxa156/frdm_mcxa156.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_mcxa156.dtsi>
 #include "frdm_mcxa156-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <freq.h>
 
@@ -87,28 +88,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 10 0>,	/* A0 */
-			   <1 0 &gpio2 5 0>,	/* A1 */
-			   <2 0 &gpio2 3 0>,	/* A2 */
-			   <3 0 &gpio2 4 0>,	/* A3 */
-			   <4 0 &gpio1 12 0>,	/* A4 */
-			   <5 0 &gpio1 13 0>,	/* A5 */
-			   <6 0 &gpio2 11 0>,	/* D0 */
-			   <7 0 &gpio2 10 0>,	/* D1 */
-			   <8 0 &gpio3 1 0>,	/* D2 */
-			   <9 0 &gpio3 12 0>,	/* D3 */
-			   <10 0 &gpio3 31 0>,	/* D4 */
-			   <11 0 &gpio3 14 0>,	/* D5 */
-			   <12 0 &gpio3 16 0>,	/* D6 */
-			   <13 0 &gpio1 14 0>,	/* D7 */
-			   <14 0 &gpio1 15 0>,	/* D8 */
-			   <15 0 &gpio3 17 0>,	/* D9 */
-			   <16 0 &gpio3 13 0>,	/* D10 */
-			   <17 0 &gpio3 15 0>,	/* D11 */
-			   <18 0 &gpio2 16 0>,	/* D12 */
-			   <19 0 &gpio2 12 0>,	/* D13 */
-			   <20 0 &gpio0 16 0>,	/* D14 */
-			   <21 0 &gpio0 17 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio2 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio2 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio2 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio2 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio2 10 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio3 1 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio3 12 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio3 31 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio3 16 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio3 17 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio3 13 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio2 16 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio2 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 17 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
+++ b/boards/nxp/frdm_mcxn236/frdm_mcxn236.dts
@@ -9,6 +9,7 @@
 #include <nxp/nxp_mcxn23x.dtsi>
 #include "frdm_mcxn236-pinctrl.dtsi"
 #include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/gpio/dvp-20pin-connector.h>
 
@@ -75,28 +76,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio4 6 0>,	/* A0 */
-			   <1 0 &gpio4 15 0>,	/* A1 */
-			   <2 0 &gpio4 16 0>,	/* A2 */
-			   <3 0 &gpio4 17 0>,	/* A3 */
-			   <4 0 &gpio4 12 0>,	/* A4 */
-			   <5 0 &gpio4 13 0>,	/* A5 */
-			   <6 0 &gpio4 3 0>,	/* D0 */
-			   <7 0 &gpio4 2 0>,	/* D1 */
-			   <8 0 &gpio2 0 0>,	/* D2 */
-			   <9 0 &gpio3 12 0>,	/* D3 */
-			   <10 0 &gpio0 21 0>,	/* D4 */
-			   <11 0 &gpio2 7 0>,	/* D5 */
-			   <12 0 &gpio3 17 0>,	/* D6 */
-			   <13 0 &gpio0 22 0>,	/* D7 */
-			   <14 0 &gpio0 23 0>,	/* D8 */
-			   <15 0 &gpio3 14 0>,	/* D9 */
-			   <16 0 &gpio1 3 0>,	/* D10 */
-			   <17 0 &gpio1 0 0>,	/* D11 */
-			   <18 0 &gpio1 2 0>,	/* D12 */
-			   <19 0 &gpio1 1 0>,	/* D13 */
-			   <20 0 &gpio1 16 0>,	/* D14 */
-			   <21 0 &gpio1 17 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio4 6 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio4 15 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio4 16 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio4 17 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio4 12 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio4 13 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio4 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio4 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio2 0 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio3 12 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 21 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio2 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio3 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 16 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 17 0>;
 	};
 
 	/*

--- a/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
+++ b/boards/nxp/frdm_mcxn947/frdm_mcxn947.dtsi
@@ -6,8 +6,9 @@
 
 #include "frdm_mcxn947-pinctrl.dtsi"
 #include <zephyr/dt-bindings/i2c/i2c.h>
-#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/gpio/dvp-20pin-connector.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
 	aliases{
@@ -60,26 +61,26 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <2 0 &gpio0 14 0>,	/* A2 */
-			   <3 0 &gpio0 22 0>,	/* A3 */
-			   <4 0 &gpio0 15 0>,	/* A4 */
-			   <5 0 &gpio0 23 0>,	/* A5 */
-			   <6 0 &gpio4 3 0>,	/* D0 */
-			   <7 0 &gpio4 2 0>,	/* D1 */
-			   <8 0 &gpio0 29 0>,	/* D2 */
-			   <9 0 &gpio1 23 0>,	/* D3 */
-			   <10 0 &gpio0 30 0>,	/* D4 */
-			   <11 0 &gpio1 21 0>,	/* D5 */
-			   <12 0 &gpio1 2 0>,	/* D6 */
-			   <13 0 &gpio0 31 0>,	/* D7 */
-			   <14 0 &gpio0 28 0>,	/* D8 */
-			   <15 0 &gpio0 10 0>,	/* D9 */
-			   <16 0 &gpio0 27 0>,	/* D10 */
-			   <17 0 &gpio0 24 0>,	/* D11 */
-			   <18 0 &gpio0 26 0>,	/* D12 */
-			   <19 0 &gpio0 25 0>,	/* D13 */
-			   <20 0 &gpio4 0 0>,	/* D14 */
-			   <21 0 &gpio4 1 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A2 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio4 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio4 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 27 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 24 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio4 0 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio4 1 0>;
 	};
 
 	/*

--- a/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
+++ b/boards/nxp/frdm_mcxw71/frdm_mcxw71.dts
@@ -7,6 +7,7 @@
 
 #include <nxp/nxp_mcxw71.dtsi>
 #include "frdm_mcxw71-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -68,28 +69,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiod 1 0>,	/* A0 */
-			   <1 0 &gpiod 2 0>,	/* A1 */
-			   <2 0 &gpiod 3 0>,	/* A2 */
-			   <3 0 &gpioa 4 0>,	/* A3 */
-			   <4 0 &gpioc 3 0>,	/* A4 */
-			   <5 0 &gpioc 2 0>,	/* A5 */
-			   <6 0 &gpioa 16 0>,	/* D0 */
-			   <7 0 &gpioa 17 0>,	/* D1 */
-			   <8 0 &gpioc 4 0>,	/* D2 */
-			   <9 0 &gpioc 5 0>,	/* D3 */
-			   <10 0 &gpioa 19 0>,	/* D4 */
-			   <11 0 &gpioc 1 0>,	/* D5 */
-			   <12 0 &gpioa 20 0>,	/* D6 */
-			   <13 0 &gpioa 21 0>,	/* D7 */
-			   <14 0 &gpioc 4 0>,	/* D8 */
-			   <15 0 &gpioa 18 0>,	/* D9 */
-			   <16 0 &gpiob 0 0>,	/* D10 */
-			   <17 0 &gpiob 3 0>,	/* D11 */
-			   <18 0 &gpiob 1 0>,	/* D12 */
-			   <19 0 &gpiob 2 0>,	/* D13 */
-			   <20 0 &gpiob 4 0>,	/* D14 */
-			   <21 0 &gpiob 5 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiod 1 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 16 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 17 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 19 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 20 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 21 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 18 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 5 0>;
 	};
 };
 

--- a/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.dts
+++ b/boards/nxp/frdm_mcxw72/frdm_mcxw72_mcxw727c_cpu0.dts
@@ -7,6 +7,7 @@
 
 #include <nxp/nxp_mcxw72.dtsi>
 #include "frdm_mcxw72-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -67,28 +68,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiod 1 0>,	/* A0 */
-			   <1 0 &gpiod 2 0>,	/* A1 */
-			   <2 0 &gpiod 3 0>,	/* A2 */
-			   <3 0 &gpioa 4 0>,	/* A3 */
-			   <4 0 &gpioc 3 0>,	/* A4 */
-			   <5 0 &gpioc 2 0>,	/* A5 */
-			   <6 0 &gpioa 16 0>,	/* D0 */
-			   <7 0 &gpioa 17 0>,	/* D1 */
-			   <8 0 &gpioc 4 0>,	/* D2 */
-			   <9 0 &gpioc 5 0>,	/* D3 */
-			   <10 0 &gpioa 19 0>,	/* D4 */
-			   <11 0 &gpioc 1 0>,	/* D5 */
-			   <12 0 &gpioa 20 0>,	/* D6 */
-			   <13 0 &gpioa 21 0>,	/* D7 */
-			   <14 0 &gpioc 4 0>,	/* D8 */
-			   <15 0 &gpioa 18 0>,	/* D9 */
-			   <16 0 &gpiob 0 0>,	/* D10 */
-			   <17 0 &gpiob 3 0>,	/* D11 */
-			   <18 0 &gpiob 1 0>,	/* D12 */
-			   <19 0 &gpiob 2 0>,	/* D13 */
-			   <20 0 &gpiob 4 0>,	/* D14 */
-			   <21 0 &gpiob 5 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiod 1 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 16 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 17 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 19 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 20 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 21 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 18 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 5 0>;
 	};
 };
 

--- a/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
+++ b/boards/nxp/frdm_rw612/frdm_rw612_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "frdm_rw612-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -61,25 +62,25 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &hsgpio1 10 0>,	/* A0 */
-			   <1 0 &hsgpio1 11 0>,	/* A1 */
-			   <2 0 &hsgpio1 13 0>,	/* A2 */
-			   <6 0 &hsgpio0 9 0>,		/* D0 */
-			   <7 0 &hsgpio0 8 0>,		/* D1 */
-			   <8 0 &hsgpio0 11 0>,		/* D2 */
-			   <9 0 &hsgpio0 15 0>,		/* D3 */
-			   <10 0 &hsgpio0 18 0>,	/* D4 */
-			   <11 0 &hsgpio0 27 0>,	/* D5 */
-			   <12 0 &hsgpio0 0 0>,		/* D6 */
-			   <13 0 &hsgpio0 20 0>,	/* D7 */
-			   <14 0 &hsgpio1 18 0>,	/* D8 */
-			   <15 0 &hsgpio1 20 0>,	/* D9 */
-			   <16 0 &hsgpio0 6 0>,		/* D10 */
-			   <17 0 &hsgpio0 9 0>,		/* D11 */
-			   <18 0 &hsgpio0 8 0>,		/* D12 */
-			   <19 0 &hsgpio0 7 0>,		/* D13 */
-			   <20 0 &hsgpio0 16 0>,	/* D14 */
-			   <21 0 &hsgpio0 17 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &hsgpio1 10 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &hsgpio1 11 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &hsgpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &hsgpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &hsgpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &hsgpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &hsgpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &hsgpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &hsgpio0 27 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &hsgpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &hsgpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &hsgpio1 18 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &hsgpio1 20 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &hsgpio0 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &hsgpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &hsgpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &hsgpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &hsgpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &hsgpio0 17 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.dts
+++ b/boards/nxp/lpcxpresso11u68/lpcxpresso11u68.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_lpc11u68.dtsi>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 #include "lpcxpresso11u68-pinctrl.dtsi"
@@ -65,28 +66,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 9 0>,	/* A0 */
-			   <1 0 &gpio0 14 0>,	/* A1 */
-			   <2 0 &gpio0 13 0>,	/* A2 */
-			   <3 0 &gpio0 12 0>,	/* A3 */
-			   <4 0 &gpio0 23 0>,	/* A4 */
-			   <5 0 &gpio0 11 0>,	/* A5 */
-			   <6 0 &gpio2 11 0>,	/* D0 */
-			   <7 0 &gpio2 12 0>,	/* D1 */
-			   <8 0 &gpio1 18 0>,	/* D2 */
-			   <9 0 &gpio1 24 0>,	/* D3 */
-			   <10 0 &gpio1 19 0>,	/* D4 */
-			   <11 0 &gpio1 26 0>,	/* D5 */
-			   <12 0 &gpio1 27 0>,	/* D6 */
-			   <13 0 &gpio1 25 0>,	/* D7 */
-			   <14 0 &gpio1 28 0>,	/* D8 */
-			   <15 0 &gpio2 3 0>,	/* D9 */
-			   <16 0 &gpio0 2 0>,	/* D10 */
-			   <17 0 &gpio0 9 0>,	/* D11 */
-			   <18 0 &gpio0 9 0>,	/* D12 */
-			   <19 0 &gpio1 29 0>,	/* D13 */
-			   <20 0 &gpio0 5 0>,	/* D14 */
-			   <21 0 &gpio0 4 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio2 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio2 12 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 18 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 19 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 27 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 25 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 28 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio2 3 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 29 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 4 0>;
 	};
 
 };

--- a/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
+++ b/boards/nxp/lpcxpresso55s06/lpcxpresso55s06_common.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include "lpcxpresso55s06-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -95,26 +96,26 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 16 0>,	/* A0 */
-				<1 0 &gpio0 23 0>,	/* A1 */
-				<2 0 &gpio0 9 0>,	/* A2 */
-				<3 0 &gpio0 0 0>,	/* A3 */
-				<4 0 &gpio0 13 0>,	/* A4 */
-				<5 0 &gpio0 14 0>,	/* A5 */
-				<6 0 &gpio1 10 0>,	/* D0 */
-				<7 0 &gpio1 11 0>,	/* D1 */
-				<8 0 &gpio0 15 0>,	/* D2 */
-				<9 0 &gpio0 23 0>,	/* D3 */
-				<10 0 &gpio0 22 0>,	/* D4 */
-				<11 0 &gpio0 19 0>,	/* D5 */
-				<12 0 &gpio0 18 0>,	/* D6 */
-				<13 0 &gpio0 2 0>,	/* D7 */
-				<14 0 &gpio0 10 0>,	/* D8 */
-				<15 0 &gpio0 25 0>,	/* D9 */
-				<16 0 &gpio1 1 0>,	/* D10 */
-				<17 0 &gpio0 26 0>,	/* D11 */
-				<18 0 &gpio1 3 0>,	/* D12 */
-				<19 0 &gpio1 2 0>;	/* D13 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &gpio0 16 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpio0 23 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpio0 9 0>,
+				<ARDUINO_HEADER_R3_A3 0 &gpio0 0 0>,
+				<ARDUINO_HEADER_R3_A4 0 &gpio0 13 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpio0 14 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpio1 10 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpio1 11 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpio0 15 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpio0 23 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpio0 22 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpio0 19 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpio0 18 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpio0 2 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpio0 10 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpio0 25 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpio1 1 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/nxp/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -6,6 +6,7 @@
  */
 
 #include "lpcxpresso55s16-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -97,29 +98,29 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 16 0>,	/* A0 */
-				<1 0 &gpio0 23 0>,	/* A1 */
-				<2 0 &gpio0 0 0>,	/* A2 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &gpio0 16 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpio0 23 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpio0 0 0>,
 				/* R63 DNP, A3 not connected  */
-				/* <3 0 &gpio1 31 0>,*/	/* A3 */
-				<4 0 &gpio0 13 0>,	/* A4 */
-				<5 0 &gpio0 14 0>,	/* A5 */
-				<6 0 &gpio1 24 0>,	/* D0 */
-				<7 0 &gpio0 27 0>,	/* D1 */
-				<8 0 &gpio0 15 0>,	/* D2 */
-				<9 0 &gpio1 6 0>,	/* D3 */
-				<10 0 &gpio1 7 0>,	/* D4 */
-				<11 0 &gpio1 4 0>,	/* D5 */
-				<12 0 &gpio1 10 0>,	/* D6 */
-				<13 0 &gpio1 9 0>,	/* D7 */
-				<14 0 &gpio1 8 0>,	/* D8 */
-				<15 0 &gpio1 5 0>,	/* D9 */
-				<16 0 &gpio1 1 0>,	/* D10 */
-				<17 0 &gpio0 26 0>,	/* D11 */
-				<18 0 &gpio1 3 0>,	/* D12 */
-				<19 0 &gpio1 2 0>,	/* D13 */
-				<20 0 &gpio1 21 0>,	/* D14 */
-				<21 0 &gpio1 20 0>;	/* D15 */
+				/* <ARDUINO_HEADER_R3_A3 0 &gpio1 31 0>,*/
+				<ARDUINO_HEADER_R3_A4 0 &gpio0 13 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpio0 14 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpio1 24 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpio0 27 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpio0 15 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpio1 6 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpio1 7 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpio1 4 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpio1 10 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpio1 8 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpio1 5 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpio1 1 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
+				<ARDUINO_HEADER_R3_D14 0 &gpio1 21 0>,
+				<ARDUINO_HEADER_R3_D15 0 &gpio1 20 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
+++ b/boards/nxp/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "lpcxpresso55s28-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	aliases{
@@ -63,28 +64,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 16 0>,	/* A0 */
-				<1 0 &gpio0 23 0>,	/* A1 */
-				<2 0 &gpio0 0 0>,	/* A2 */
-				<3 0 &gpio1 31 0>,	/* A3 */
-				<4 0 &gpio0 13 0>,	/* A4 */
-				<5 0 &gpio0 14 0>,	/* A5 */
-				<6 0 &gpio1 24 0>,	/* D0 */
-				<7 0 &gpio0 27 0>,	/* D1 */
-				<8 0 &gpio0 15 0>,	/* D2 */
-				<9 0 &gpio1 6 0>,	/* D3 */
-				<10 0 &gpio1 7 0>,	/* D4 */
-				<11 0 &gpio1 4 0>,	/* D5 */
-				<12 0 &gpio1 10 0>,	/* D6 */
-				<13 0 &gpio1 9 0>,	/* D7 */
-				<14 0 &gpio1 8 0>,	/* D8 */
-				<15 0 &gpio1 5 0>,	/* D9 */
-				<16 0 &gpio1 1 0>,	/* D10 */
-				<17 0 &gpio0 26 0>,	/* D11 */
-				<18 0 &gpio1 3 0>,	/* D12 */
-				<19 0 &gpio1 2 0>,	/* D13 */
-				<20 0 &gpio1 21 0>,	/* D14 */
-				<21 0 &gpio1 20 0>;	/* D15 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &gpio0 16 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpio0 23 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpio0 0 0>,
+				<ARDUINO_HEADER_R3_A3 0 &gpio1 31 0>,
+				<ARDUINO_HEADER_R3_A4 0 &gpio0 13 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpio0 14 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpio1 24 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpio0 27 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpio0 15 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpio1 6 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpio1 7 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpio1 4 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpio1 10 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpio1 8 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpio1 5 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpio1 1 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
+				<ARDUINO_HEADER_R3_D14 0 &gpio1 21 0>,
+				<ARDUINO_HEADER_R3_D15 0 &gpio1 20 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
+++ b/boards/nxp/lpcxpresso55s36/lpcxpresso55s36.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_lpc55S36_ns.dtsi>
 #include "lpcxpresso55s36-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -94,28 +95,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 15 0>,	/* A0 */
-				<1 0 &gpio0 16 0>,	/* A1 */
-				<2 0 &gpio0 0 0>,	/* A2 */
-				<3 0 &gpio1 13 0>,	/* A3 */
-				<4 0 &gpio1 21 0>,	/* A4 */
-				<5 0 &gpio1 30 0>,	/* A5 */
-				<6 0 &gpio2 0 0>,	/* D0 */
-				<7 0 &gpio2 1 0>,	/* D1 */
-				<8 0 &gpio1 26 0>,	/* D2 */
-				<9 0 &gpio1 23 0>,	/* D3 */
-				<10 0 &gpio1 8 0>,	/* D4 */
-				<11 0 &gpio1 25 0>,	/* D5 */
-				<12 0 &gpio1 0 0>,	/* D6 */
-				<13 0 &gpio1 28 0>,	/* D7 */
-				<14 0 &gpio1 27 0>,	/* D8 */
-				<15 0 &gpio1 29 0>,	/* D9 */
-				<16 0 &gpio1 26 0>,	/* D10 */
-				<17 0 &gpio0 26 0>,	/* D11 */
-				<18 0 &gpio1 3 0>,	/* D12 */
-				<19 0 &gpio1 2 0>,	/* D13 */
-				<20 0 &gpio0 3 0>,	/* D14 */
-				<21 0 &gpio0 2 0>;	/* D15 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &gpio0 15 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpio0 16 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpio0 0 0>,
+				<ARDUINO_HEADER_R3_A3 0 &gpio1 13 0>,
+				<ARDUINO_HEADER_R3_A4 0 &gpio1 21 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpio1 30 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpio2 0 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpio2 1 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpio1 26 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpio1 23 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpio1 8 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpio1 25 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpio1 0 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpio1 28 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpio1 27 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpio1 29 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpio1 26 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
+				<ARDUINO_HEADER_R3_D14 0 &gpio0 3 0>,
+				<ARDUINO_HEADER_R3_D15 0 &gpio0 2 0>;
 	};
 };
 

--- a/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/nxp/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "lpcxpresso55s69-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	aliases{
@@ -62,28 +63,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 16 0>,	/* A0 */
-				<1 0 &gpio0 23 0>,	/* A1 */
-				<2 0 &gpio0 0 0>,	/* A2 */
-				<3 0 &gpio1 31 0>,	/* A3 */
-				<4 0 &gpio0 13 0>,	/* A4 */
-				<5 0 &gpio0 14 0>,	/* A5 */
-				<6 0 &gpio1 24 0>,	/* D0 */
-				<7 0 &gpio0 27 0>,	/* D1 */
-				<8 0 &gpio0 15 0>,	/* D2 */
-				<9 0 &gpio1 6 0>,	/* D3 */
-				<10 0 &gpio1 7 0>,	/* D4 */
-				<11 0 &gpio1 4 0>,	/* D5 */
-				<12 0 &gpio1 10 0>,	/* D6 */
-				<13 0 &gpio1 9 0>,	/* D7 */
-				<14 0 &gpio1 8 0>,	/* D8 */
-				<15 0 &gpio1 5 0>,	/* D9 */
-				<16 0 &gpio1 1 0>,	/* D10 */
-				<17 0 &gpio0 26 0>,	/* D11 */
-				<18 0 &gpio1 3 0>,	/* D12 */
-				<19 0 &gpio1 2 0>,	/* D13 */
-				<20 0 &gpio1 21 0>,	/* D14 */
-				<21 0 &gpio1 20 0>;	/* D15 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &gpio0 16 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpio0 23 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpio0 0 0>,
+				<ARDUINO_HEADER_R3_A3 0 &gpio1 31 0>,
+				<ARDUINO_HEADER_R3_A4 0 &gpio0 13 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpio0 14 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpio1 24 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpio0 27 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpio0 15 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpio1 6 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpio1 7 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpio1 4 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpio1 10 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpio1 8 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpio1 5 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpio1 1 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpio0 26 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpio1 3 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpio1 2 0>,
+				<ARDUINO_HEADER_R3_D14 0 &gpio1 21 0>,
+				<ARDUINO_HEADER_R3_D15 0 &gpio1 20 0>;
 	};
 
 	reserved-memory {

--- a/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.dts
+++ b/boards/nxp/mcxw72_evk/mcxw72_evk_mcxw727c_cpu0.dts
@@ -7,6 +7,7 @@
 
 #include <nxp/nxp_mcxw72.dtsi>
 #include "mcxw72_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -67,28 +68,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiod 1 0>,	/* A0 */
-			   <1 0 &gpiod 2 0>,	/* A1 */
-			   <2 0 &gpiod 3 0>,	/* A2 */
-			   <3 0 &gpioa 4 0>,	/* A3 */
-			   <4 0 &gpioc 3 0>,	/* A4 */
-			   <5 0 &gpioc 2 0>,	/* A5 */
-			   <6 0 &gpioa 16 0>,	/* D0 */
-			   <7 0 &gpioa 17 0>,	/* D1 */
-			   <8 0 &gpioc 4 0>,	/* D2 */
-			   <9 0 &gpioc 5 0>,	/* D3 */
-			   <10 0 &gpioa 19 0>,	/* D4 */
-			   <11 0 &gpioc 1 0>,	/* D5 */
-			   <12 0 &gpioa 20 0>,	/* D6 */
-			   <13 0 &gpioa 21 0>,	/* D7 */
-			   <14 0 &gpioc 4 0>,	/* D8 */
-			   <15 0 &gpioa 18 0>,	/* D9 */
-			   <16 0 &gpiob 0 0>,	/* D10 */
-			   <17 0 &gpiob 3 0>,	/* D11 */
-			   <18 0 &gpiob 1 0>,	/* D12 */
-			   <19 0 &gpiob 2 0>,	/* D13 */
-			   <20 0 &gpiob 4 0>,	/* D14 */
-			   <21 0 &gpiob 5 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiod 1 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiod 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 16 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 17 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 19 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 20 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 21 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 18 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 5 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/nxp/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -9,6 +9,7 @@
 
 #include <nxp/nxp_rt1010.dtsi>
 #include "mimxrt1010_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -55,28 +56,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 21 0>,	/* A0 */
-			   <1 0 &gpio1 23 0>,	/* A1 */
-			   <2 0 &gpio1 24 0>,	/* A2 */
-			   <3 0 &gpio1 28 0>,	/* A3 */
-			   <4 0 &gpio1 15 0>,	/* A4 (shared with D6) */
-			   <5 0 &gpio1 16 0>,	/* A5 (shared with D7) */
-			   <6 0 &gpio1 9 0>,	/* D0 */
-			   <7 0 &gpio1 10 0>,	/* D1 */
-			   <8 0 &gpio1 19 0>,	/* D2 (shared with D10) */
-			   <9 0 &gpio1 20 0>,	/* D3 (shared with D13) */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 28 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 15 0>,	/* shared with D6 */
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 16 0>,	/* shared with D7 */
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 19 0>,	/* shared with D10 */
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 20 0>,	/* shared with D13 */
 			   /* R800 not populated,  D4 */
 			   /* R793 not populated,  D5 (shared with D14) */
-			   <12 0 &gpio1 15 0>,	/* D6 (shared with A4) */
-			   <13 0 &gpio1 16 0>,	/* D7 (shared with A5) */
-			   <14 0 &gpio2 2 0>,	/* D8 */
-			   <15 0 &gpio2 3 0>,	/* D9 R795 not populated */
-			   <16 0 &gpio1 19 0>,	/* D10 (shared with D2) */
-			   <17 0 &gpio1 18 0>,	/* D11 */
-			   <18 0 &gpio1 17 0>,	/* D12 */
-			   <19 0 &gpio1 20 0>,	/* D13 (shared with D3) */
-			   <20 0 &gpio1 1 0>,	/* D14 */
-			   <21 0 &gpio1 2 0>;	/* D15 */
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 15 0>,	/* shared with A4 */
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 16 0>,	/* shared with A5 */
+			   <ARDUINO_HEADER_R3_D8 0 &gpio2 2 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio2 3 0>,		/* R795 not populated */
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 19 0>,	/* shared with D2 */
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 18 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 20 0>,	/* shared with D3 */
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 2 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/nxp/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt1015.dtsi>
 #include "mimxrt1015_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -54,28 +55,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 29 0>,	/* A0 */
-			   <1 0 &gpio1 14 0>,	/* A1 */
-			   <2 0 &gpio1 28 0>,	/* A2 */
-			   <3 0 &gpio1 26 0>,	/* A3 */
-			   <4 0 &gpio1 31 0>,	/* A4 */
-			   <5 0 &gpio1 30 0>,	/* A5 */
-			   <6 0 &gpio3 1 0>,	/* D0 */
-			   <7 0 &gpio3 0 0>,	/* D1 */
-			   <8 0 &gpio2 20 0>,	/* D2 */
-			   <9 0 &gpio2 26 0>,	/* D3 */
-			   <10 0 &gpio3 2 0>,	/* D4 */
-			   <11 0 &gpio2 27 0>,	/* D5 */
-			   <12 0 &gpio1 27 0>,	/* D6 */
-			   <13 0 &gpio1 15 0>,	/* D7 */
-			   <14 0 &gpio2 21 0>,	/* D8 */
-			   <15 0 &gpio2 22 0>,	/* D9 */
-			   <16 0 &gpio1 11 0>,	/* D10 */
-			   <17 0 &gpio1 12 0>,	/* D11 */
-			   <18 0 &gpio1 13 0>,	/* D12 */
-			   <19 0 &gpio1 10 0>,	/* D13 */
-			   <20 0 &gpio1 31 0>,	/* D14 */
-			   <21 0 &gpio1 30 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 29 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 31 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 30 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio3 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio3 0 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio2 20 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio2 26 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio3 2 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio2 27 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 27 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio2 21 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio2 22 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 31 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 30 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/nxp/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt1020.dtsi>
 #include "mimxrt1020_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -61,28 +62,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
-			   <1 0 &gpio1 27 0>,	/* A1 */
-			   <2 0 &gpio1 28 0>,	/* A2 */
-			   <3 0 &gpio1 29 0>,	/* A3 */
-			   <4 0 &gpio1 31 0>,	/* A4 */
-			   <5 0 &gpio1 30 0>,	/* A5 */
-			   <6 0 &gpio1 25 0>,	/* D0 */
-			   <7 0 &gpio1 24 0>,	/* D1 */
-			   <8 0 &gpio1 9 0>,	/* D2 */
-			   <9 0 &gpio1 7 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 14 0>,	/* D6 */
-			   <13 0 &gpio1 22 0>,	/* D7 */
-			   <14 0 &gpio1 23 0>,	/* D8 */
-			   <15 0 &gpio1 15 0>,	/* D9 */
-			   <16 0 &gpio1 11 0>,	/* D10 */
-			   <17 0 &gpio1 12 0>,	/* D11 */
-			   <18 0 &gpio1 13 0>,	/* D12 */
-			   <19 0 &gpio1 10 0>,	/* D13 */
-			   <20 0 &gpio3 23 0>,	/* D14 */
-			   <21 0 &gpio3 22 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 27 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 31 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 30 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 25 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 22 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio3 23 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio3 22 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/nxp/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt1024.dtsi>
 #include "mimxrt1024_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -65,28 +66,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
-			   <1 0 &gpio1 27 0>,	/* A1 */
-			   <2 0 &gpio1 28 0>,	/* A2 */
-			   <3 0 &gpio1 29 0>,	/* A3 */
-			   <4 0 &gpio1 31 0>,	/* A4 */
-			   <5 0 &gpio1 30 0>,	/* A5 */
-			   <6 0 &gpio1 25 0>,	/* D0 */
-			   <7 0 &gpio1 24 0>,	/* D1 */
-			   <8 0 &gpio1 9 0>,	/* D2 */
-			   <9 0 &gpio1 7 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 14 0>,	/* D6 */
-			   <13 0 &gpio1 22 0>,	/* D7 */
-			   <14 0 &gpio1 23 0>,	/* D8 */
-			   <15 0 &gpio1 15 0>,	/* D9 */
-			   <16 0 &gpio1 11 0>,	/* D10 */
-			   <17 0 &gpio1 12 0>,	/* D11 */
-			   <18 0 &gpio1 13 0>,	/* D12 */
-			   <19 0 &gpio1 10 0>,	/* D13 */
-			   <20 0 &gpio3 23 0>,	/* D14 */
-			   <21 0 &gpio3 22 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 27 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 31 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 30 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 25 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 22 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio3 23 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio3 22 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
+++ b/boards/nxp/mimxrt1040_evk/mimxrt1040_evk.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt1040.dtsi>
 #include "mimxrt1040_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -89,28 +90,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 14 0>,	/* A0 */
-			   <1 0 &gpio1 15 0>,	/* A1 */
-			   <2 0 &gpio1 20 0>,	/* A2 */
-			   <3 0 &gpio1 21 0>,	/* A3 */
-			   <4 0 &gpio1 22 0>,	/* A4 */
-			   <5 0 &gpio1 23 0>,	/* A5 */
-			   <6 0 &gpio3 1 0>,	/* D0 */
-			   <7 0 &gpio3 0 0>,	/* D1 */
-			   <8 0 &gpio1 11 0>,	/* D2 */
-			   <9 0 &gpio3 2 0>,	/* D3 */
-			   <10 0 &gpio1 9 0>,	/* D4 */
-			   <11 0 &gpio1 10 0>,	/* D5 */
-			   <12 0 &gpio1 18 0>,	/* D6 */
-			   <13 0 &gpio1 19 0>,	/* D7 */
-			   <14 0 &gpio2 30 0>,	/* D8 */
-			   <15 0 &gpio2 31 0>,	/* D9 */
-			   <16 0 &gpio3 13 0>,	/* D10 */
-			   <17 0 &gpio3 14 0>,	/* D11 */
-			   <18 0 &gpio3 15 0>,	/* D12 */
-			   <19 0 &gpio3 12 0>,	/* D13 */
-			   <20 0 &gpio1 17 0>,	/* D14 */
-			   <21 0 &gpio1 16 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 20 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 22 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio3 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio3 0 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio3 2 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 18 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 19 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio2 30 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio2 31 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio3 13 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 16 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
+++ b/boards/nxp/mimxrt1050_evk/mimxrt1050_evk.dtsi
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt1050.dtsi>
 #include "mimxrt1050_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -88,28 +89,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
-			   <1 0 &gpio1 27 0>,	/* A1 */
-			   <2 0 &gpio1 20 0>,	/* A2 */
-			   <3 0 &gpio1 21 0>,	/* A3 */
-			   <4 0 &gpio1 17 0>,	/* A4 */
-			   <5 0 &gpio1 16 0>,	/* A5 */
-			   <6 0 &gpio1 23 0>,	/* D0 */
-			   <7 0 &gpio1 22 0>,	/* D1 */
-			   <8 0 &gpio1 11 0>,	/* D2 */
-			   <9 0 &gpio1 24 0>,	/* D3 */
-			   <10 0 &gpio1 9 0>,	/* D4 */
-			   <11 0 &gpio1 10 0>,	/* D5 */
-			   <12 0 &gpio1 18 0>,	/* D6 */
-			   <13 0 &gpio1 19 0>,	/* D7 */
-			   <14 0 &gpio1 3 0>,	/* D8 */
-			   <15 0 &gpio1 2 0>,	/* D9 */
-			   <16 0 &gpio3 13 0>,	/* D10 */
-			   <17 0 &gpio3 14 0>,	/* D11 */
-			   <18 0 &gpio3 15 0>,	/* D12 */
-			   <19 0 &gpio3 12 0>,	/* D13 */
-			   <20 0 &gpio1 1 0>,	/* D14 */
-			   <21 0 &gpio1 0 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 27 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 20 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 16 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 22 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 18 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 19 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio3 13 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 0 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
+++ b/boards/nxp/mimxrt1060_evk/mimxrt1060_evk.dtsi
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt1060.dtsi>
 #include "mimxrt1060_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -95,28 +96,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
-			   <1 0 &gpio1 27 0>,	/* A1 */
-			   <2 0 &gpio1 20 0>,	/* A2 */
-			   <3 0 &gpio1 21 0>,	/* A3 */
-			   <4 0 &gpio1 17 0>,	/* A4 */
-			   <5 0 &gpio1 16 0>,	/* A5 */
-			   <6 0 &gpio1 23 0>,	/* D0 */
-			   <7 0 &gpio1 22 0>,	/* D1 */
-			   <8 0 &gpio1 11 0>,	/* D2 */
-			   <9 0 &gpio1 24 0>,	/* D3 */
-			   <10 0 &gpio1 9 0>,	/* D4 */
-			   <11 0 &gpio1 10 0>,	/* D5 */
-			   <12 0 &gpio1 18 0>,	/* D6 */
-			   <13 0 &gpio1 19 0>,	/* D7 */
-			   <14 0 &gpio1 3 0>,	/* D8 */
-			   <15 0 &gpio1 2 0>,	/* D9 */
-			   <16 0 &gpio3 13 0>,	/* D10 */
-			   <17 0 &gpio3 14 0>,	/* D11 */
-			   <18 0 &gpio3 15 0>,	/* D12 */
-			   <19 0 &gpio3 12 0>,	/* D13 */
-			   <20 0 &gpio1 17 0>,	/* D14 */
-			   <21 0 &gpio1 16 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 27 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 20 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 16 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 22 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 18 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 19 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio3 13 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 16 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/nxp/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt1064.dtsi>
 #include "mimxrt1064_evk-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -105,28 +106,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 26 0>,	/* A0 */
-			   <1 0 &gpio1 27 0>,	/* A1 */
-			   <2 0 &gpio1 20 0>,	/* A2 */
-			   <3 0 &gpio1 21 0>,	/* A3 */
-			   <4 0 &gpio1 17 0>,	/* A4 */
-			   <5 0 &gpio1 16 0>,	/* A5 */
-			   <6 0 &gpio1 23 0>,	/* D0 */
-			   <7 0 &gpio1 22 0>,	/* D1 */
-			   <8 0 &gpio1 11 0>,	/* D2 */
-			   <9 0 &gpio1 24 0>,	/* D3 */
-			   <10 0 &gpio1 9 0>,	/* D4 */
-			   <11 0 &gpio1 10 0>,	/* D5 */
-			   <12 0 &gpio1 18 0>,	/* D6 */
-			   <13 0 &gpio1 19 0>,	/* D7 */
-			   <14 0 &gpio1 3 0>,	/* D8 */
-			   <15 0 &gpio1 2 0>,	/* D9 */
-			   <16 0 &gpio3 13 0>,	/* D10 */
-			   <17 0 &gpio3 14 0>,	/* D11 */
-			   <18 0 &gpio3 15 0>,	/* D12 */
-			   <19 0 &gpio3 12 0>,	/* D13 */
-			   <20 0 &gpio1 17 0>,	/* D14 */
-			   <21 0 &gpio1 16 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 26 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio1 27 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio1 20 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio1 21 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio1 16 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 23 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 22 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 24 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 18 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 19 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio3 13 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio3 14 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio3 15 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio3 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 17 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 16 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/nxp/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -6,6 +6,7 @@
 
 #include "mimxrt1170_evk-pinctrl.dtsi"
 #include <nxp/nxp_rt1170.dtsi>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -60,28 +61,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio9 9 0>,	/* A0 */
-			   <1 0 &gpio9 10 0>,	/* A1 */
-			   <2 0 &gpio9 11 0>,	/* A2 */
-			   <3 0 &gpio9 12 0>,	/* A3 */
-			   <4 0 &gpio9 8 0>,	/* A4 */
-			   <5 0 &gpio9 7 0>,	/* A5 */
-			   <6 0 &gpio11 12 0>,	/* D0 */
-			   <7 0 &gpio11 11 0>,	/* D1 */
-			   <8 0 &gpio11 13 0>,	/* D2 */
-			   <9 0 &gpio9 3 0>,	/* D3 */
-			   <10 0 &gpio9 5 0>,	/* D4 */
-			   <11 0 &gpio9 4 0>,	/* D5 */
-			   <12 0 &gpio8 31 0>,	/* D6 */
-			   <13 0 &gpio9 13 0>,	/* D7 */
-			   <14 0 &gpio9 6 0>,	/* D8 */
-			   <15 0 &gpio9 0 0>,	/* D9 */
-			   <16 0 &gpio9 28 0>,	/* D10 */
-			   <17 0 &gpio9 29 0>,	/* D11 */
-			   <18 0 &gpio9 30 0>,	/* D12 */
-			   <19 0 &gpio9 27 0>,	/* D13 */
-			   <20 0 &gpio12 4 0>,	/* D14 */
-			   <21 0 &gpio12 5 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio9 9 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio9 10 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio9 11 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio9 12 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio9 8 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio9 7 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio11 12 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio11 11 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio11 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio9 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio9 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio9 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio8 31 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio9 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio9 6 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio9 0 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio9 28 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio9 29 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio9 30 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio9 27 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio12 4 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio12 5 0>;
 	};
 };
 

--- a/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
+++ b/boards/nxp/mimxrt595_evk/mimxrt595_evk_mimxrt595s_cm33.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_rt5xx.dtsi>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 #include "mimxrt595_evk_mimxrt595s_cm33-pinctrl.dtsi"
@@ -78,28 +79,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 5 0>,	/* A0 */
-				<1 0 &gpio0 6 0>,	/* A1 */
-				<2 0 &gpio0 19 0>,	/* A2 */
-				<3 0 &gpio0 13 0>,	/* A3 */
-				<4 0 &gpio4 22 0>,	/* A4 */
-				<5 0 &gpio4 21 0>,	/* A5 */
-				<6 0 &gpio4 31 0>,	/* D0 */
-				<7 0 &gpio4 30 0>,	/* D1 */
-				<8 0 &gpio4 20 0>,	/* D2 */
-				<9 0 &gpio4 23 0>,	/* D3 */
-				<10 0 &gpio4 24 0>,	/* D4 */
-				<11 0 &gpio4 25 0>,	/* D5 */
-				<12 0 &gpio4 26 0>,	/* D6 */
-				<13 0 &gpio4 27 0>,	/* D7 */
-				<14 0 &gpio4 28 0>,	/* D8 */
-				<15 0 &gpio4 29 0>,	/* D9 */
-				<16 0 &gpio5 0 0>,	/* D10 */
-				<17 0 &gpio5 1 0>,	/* D11 */
-				<18 0 &gpio5 2 0>,	/* D12 */
-				<19 0 &gpio5 3 0>,	/* D13 */
-				<20 0 &gpio4 22 0>,	/* D14 */
-				<21 0 &gpio4 21 0>;	/* D15 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &gpio0 5 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpio0 6 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpio0 19 0>,
+				<ARDUINO_HEADER_R3_A3 0 &gpio0 13 0>,
+				<ARDUINO_HEADER_R3_A4 0 &gpio4 22 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpio4 21 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpio4 31 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpio4 30 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpio4 20 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpio4 23 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpio4 24 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpio4 25 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpio4 26 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpio4 27 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpio4 28 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpio4 29 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpio5 0 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpio5 1 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpio5 2 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpio5 3 0>,
+				<ARDUINO_HEADER_R3_D14 0 &gpio4 22 0>,
+				<ARDUINO_HEADER_R3_D15 0 &gpio4 21 0>;
 	};
 
 	/*

--- a/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
+++ b/boards/nxp/mimxrt685_evk/mimxrt685_evk_mimxrt685s_cm33.dts
@@ -8,6 +8,7 @@
 
 #include <nxp/nxp_rt6xx.dtsi>
 #include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 #include "mimxrt685_evk-pinctrl.dtsi"
@@ -102,28 +103,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 5 0>,	/* A0 */
-				<1 0 &gpio0 6 0>,	/* A1 */
-				<2 0 &gpio0 19 0>,	/* A2 */
-				<3 0 &gpio0 20 0>,	/* A3 */
-				<4 0 &gpio0 17 0>,	/* A4 */
-				<5 0 &gpio0 18 0>,	/* A5 */
-				<6 0 &gpio0 30 0>,	/* D0 */
-				<7 0 &gpio0 29 0>,	/* D1 */
-				<8 0 &gpio0 28 0>,	/* D2 */
-				<9 0 &gpio0 27 0>,	/* D3 */
-				<10 0 &gpio1 0 0>,	/* D4 */
-				<11 0 &gpio1 10 0>,	/* D5 */
-				<12 0 &gpio1 2 0>,	/* D6 */
-				<13 0 &gpio1 8 0>,	/* D7 */
-				<14 0 &gpio1 9 0>,	/* D8 */
-				<15 0 &gpio1 7 0>,	/* D9 */
-				<16 0 &gpio1 6 0>,	/* D10 */
-				<17 0 &gpio1 5 0>,	/* D11 */
-				<18 0 &gpio1 4 0>,	/* D12 */
-				<19 0 &gpio1 3 0>,	/* D13 */
-				<20 0 &gpio0 17 0>,	/* D14 */
-				<21 0 &gpio0 18 0>;	/* D15 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &gpio0 5 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpio0 6 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpio0 19 0>,
+				<ARDUINO_HEADER_R3_A3 0 &gpio0 20 0>,
+				<ARDUINO_HEADER_R3_A4 0 &gpio0 17 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpio0 18 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpio0 30 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpio0 29 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpio0 28 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpio0 27 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpio1 0 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpio1 10 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpio1 2 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpio1 9 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpio1 7 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpio1 6 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpio1 5 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpio1 4 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpio1 3 0>,
+				<ARDUINO_HEADER_R3_D14 0 &gpio0 17 0>,
+				<ARDUINO_HEADER_R3_D15 0 &gpio0 18 0>;
 	};
 };
 

--- a/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
+++ b/boards/nxp/rd_rw612_bga/rd_rw612_bga.dtsi
@@ -6,6 +6,7 @@
 
 #include <nxp/nxp_rw6xx.dtsi>
 #include "rd_rw612_bga-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -46,28 +47,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &hsgpio1 14 0>,	/* A0 */
-				<1 0 &hsgpio1 15 0>,	/* A1 */
-				<2 0 &hsgpio1 16 0>,	/* A2 */
-				<3 0 &hsgpio1 17 0>,	/* A3 */
-				<4 0 &hsgpio0 16 0>,	/* A4 */
-				<5 0 &hsgpio0 17 0>,	/* A5 */
-				<6 0 &hsgpio0 24 0>,	/* D0 */
-				<7 0 &hsgpio0 26 0>,	/* D1 */
-				<8 0 &hsgpio0 11 0>,	/* D2 */
-				<9 0 &hsgpio0 15 0>,	/* D3 */
-				<10 0 &hsgpio0 18 0>,	/* D4 */
-				<11 0 &hsgpio0 27 0>,	/* D5 */
-				<12 0 &hsgpio0 6 0>,	/* D6 */
-				<13 0 &hsgpio0 10 0>,	/* D7 */
-				<14 0 &hsgpio1 18 0>,	/* D8 */
-				<15 0 &hsgpio1 13 0>,	/* D9 */
-				<16 0 &hsgpio0 0 0>,	/* D10 */
-				<17 0 &hsgpio0 2 0>,	/* D11 */
-				<18 0 &hsgpio0 3 0>,	/* D12 */
-				<19 0 &hsgpio0 4 0>,	/* D13 */
-				<20 0 &hsgpio0 16 0>,	/* D14 */
-				<21 0 &hsgpio0 17 0>;	/* D15 */
+		gpio-map =	<ARDUINO_HEADER_R3_A0 0 &hsgpio1 14 0>,
+				<ARDUINO_HEADER_R3_A1 0 &hsgpio1 15 0>,
+				<ARDUINO_HEADER_R3_A2 0 &hsgpio1 16 0>,
+				<ARDUINO_HEADER_R3_A3 0 &hsgpio1 17 0>,
+				<ARDUINO_HEADER_R3_A4 0 &hsgpio0 16 0>,
+				<ARDUINO_HEADER_R3_A5 0 &hsgpio0 17 0>,
+				<ARDUINO_HEADER_R3_D0 0 &hsgpio0 24 0>,
+				<ARDUINO_HEADER_R3_D1 0 &hsgpio0 26 0>,
+				<ARDUINO_HEADER_R3_D2 0 &hsgpio0 11 0>,
+				<ARDUINO_HEADER_R3_D3 0 &hsgpio0 15 0>,
+				<ARDUINO_HEADER_R3_D4 0 &hsgpio0 18 0>,
+				<ARDUINO_HEADER_R3_D5 0 &hsgpio0 27 0>,
+				<ARDUINO_HEADER_R3_D6 0 &hsgpio0 6 0>,
+				<ARDUINO_HEADER_R3_D7 0 &hsgpio0 10 0>,
+				<ARDUINO_HEADER_R3_D8 0 &hsgpio1 18 0>,
+				<ARDUINO_HEADER_R3_D9 0 &hsgpio1 13 0>,
+				<ARDUINO_HEADER_R3_D10 0 &hsgpio0 0 0>,
+				<ARDUINO_HEADER_R3_D11 0 &hsgpio0 2 0>,
+				<ARDUINO_HEADER_R3_D12 0 &hsgpio0 3 0>,
+				<ARDUINO_HEADER_R3_D13 0 &hsgpio0 4 0>,
+				<ARDUINO_HEADER_R3_D14 0 &hsgpio0 16 0>,
+				<ARDUINO_HEADER_R3_D15 0 &hsgpio0 17 0>;
 	};
 
 

--- a/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1.dtsi
+++ b/boards/openisa/rv32m1_vega/rv32m1_vega_openisa_rv32m1.dtsi
@@ -4,6 +4,7 @@
  */
 
 #include "rv32m1_vega_openisa_rv32m1-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -91,28 +92,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 11 0>,	/* A0 */
-			   <1 0 &gpioc 12 0>,	/* A1 */
-			   <2 0 &gpiob 9 0>,	/* A2 */
-			   <3 0 &gpioe 4 0>,	/* A3 */
-			   <4 0 &gpioe 10 0>,	/* A4 */
-			   <5 0 &gpioe 11 0>,	/* A5 */
-			   <6 0 &gpioa 25 0>,	/* D0 */
-			   <7 0 &gpioa 26 0>,	/* D1 */
-			   <8 0 &gpioa 27 0>,	/* D2 */
-			   <9 0 &gpiob 13 0>,	/* D3 */
-			   <10 0 &gpiob 14 0>,	/* D4 */
-			   <11 0 &gpioa 30 0>,	/* D5 */
-			   <12 0 &gpioa 31 0>,	/* D6 */
-			   <13 0 &gpiob 1 0>,	/* D7 */
-			   <14 0 &gpiob 2 0>,	/* D8 */
-			   <15 0 &gpiob 3 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpiob 7 0>,	/* D12 */
-			   <19 0 &gpiob 4 0>,	/* D13 */
-			   <20 0 &gpioc 9 0>,	/* D14 */
-			   <21 0 &gpioc 10 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 11 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 12 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioe 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioe 10 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 25 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 26 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 27 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 30 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 31 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioc 10 0>;
 	};
 };
 

--- a/boards/panasonic/pan1770_evb/pan1770_evb.dts
+++ b/boards/panasonic/pan1770_evb/pan1770_evb.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
 #include "pan1770_evb-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -82,28 +83,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio1 1 0>,	/* D0 */
-			   <7 0 &gpio1 2 0>,	/* D1 */
-			   <8 0 &gpio1 3 0>,	/* D2 */
-			   <9 0 &gpio1 4 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 8 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio0 12 0>,	/* D10 */
-			   <17 0 &gpio0 13 0>,	/* D11 */
-			   <18 0 &gpio0 14 0>,	/* D12 */
-			   <19 0 &gpio0 15 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/panasonic/pan1780_evb/pan1780_evb.dts
+++ b/boards/panasonic/pan1780_evb/pan1780_evb.dts
@@ -8,6 +8,7 @@
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
 #include "pan1780_evb-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -82,28 +83,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio1 1 0>,	/* D0 */
-			   <7 0 &gpio1 2 0>,	/* D1 */
-			   <8 0 &gpio1 3 0>,	/* D2 */
-			   <9 0 &gpio1 4 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 8 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio0 12 0>,	/* D10 */
-			   <17 0 &gpio0 13 0>,	/* D11 */
-			   <18 0 &gpio0 14 0>,	/* D12 */
-			   <19 0 &gpio0 15 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpuapp_common.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "pan1783_nrf5340_cpuapp_common-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -98,28 +99,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 6 0>,	/* A2 */
-			   <3 0 &gpio0 7 0>,	/* A3 */
-			   <4 0 &gpio0 25 0>,	/* A4 */
-			   <5 0 &gpio0 26 0>,	/* A5 */
-			   <6 0 &gpio1 0 0>,	/* D0 */
-			   <7 0 &gpio1 1 0>,	/* D1 */
-			   <8 0 &gpio1 4 0>,	/* D2 */
-			   <9 0 &gpio1 5 0>,	/* D3 */
-			   <10 0 &gpio1 6 0>,	/* D4 */
-			   <11 0 &gpio1 7 0>,	/* D5 */
-			   <12 0 &gpio1 8 0>,	/* D6 */
-			   <13 0 &gpio1 9 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio1 2 0>,	/* D14 */
-			   <21 0 &gpio1 3 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
+++ b/boards/panasonic/pan1783/pan1783_nrf5340_cpunet_common.dtsi
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "pan1783_nrf5340_cpunet-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -91,28 +92,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 6 0>,	/* A2 */
-			   <3 0 &gpio0 7 0>,	/* A3 */
-			   <4 0 &gpio0 25 0>,	/* A4 */
-			   <5 0 &gpio0 26 0>,	/* A5 */
-			   <6 0 &gpio1 0 0>,	/* D0 */
-			   <7 0 &gpio1 1 0>,	/* D1 */
-			   <8 0 &gpio1 4 0>,	/* D2 */
-			   <9 0 &gpio1 5 0>,	/* D3 */
-			   <10 0 &gpio1 6 0>,	/* D4 */
-			   <11 0 &gpio1 7 0>,	/* D5 */
-			   <12 0 &gpio1 8 0>,	/* D6 */
-			   <13 0 &gpio1 9 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio1 2 0>,	/* D14 */
-			   <21 0 &gpio1 3 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio1 3 0>;
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/panasonic/panb611evb/panb611evb_nrf54l15_common.dtsi
+++ b/boards/panasonic/panb611evb/panb611evb_nrf54l15_common.dtsi
@@ -5,6 +5,7 @@
  */
 
 #include "panb611evb_nrf54l15-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	leds {
@@ -101,28 +102,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio1 6 0>, /* A0 */
-			<1 0 &gpio1 7 0>, /* A1 */
-			<2 0 &gpio1 11 0>, /* A2 */
-			<3 0 &gpio1 12 0>, /* A3 */
-			<4 0 &gpio1 13 0>, /* A4 */
-			<5 0 &gpio1 14 0>, /* A5 */
-			<6 0 &gpio1 4 0>, /* D0 */
-			<7 0 &gpio1 5 0>, /* D1 */
-			<8 0 &gpio0 0 0>, /* D2 */
-			<9 0 &gpio1 2 0>, /* D3 */
-			<10 0 &gpio1 3 0>, /* D4 */
-			<11 0 &gpio1 10 0>, /* D5 */
-			<12 0 &gpio1 13 0>, /* D6 */
-			<13 0 &gpio1 14 0>, /* D7 */
-			<14 0 &gpio1 15 0>, /* D8 */
-			<15 0 &gpio2 7 0>, /* D9 */
-			<16 0 &gpio2 10 0>, /* D10 */
-			<17 0 &gpio2 8 0>, /* D11 */
-			<18 0 &gpio2 9 0>, /* D12 */
-			<19 0 &gpio2 6 0>, /* D13 */
-			<20 0 &gpio1 9 0>, /* D14 */
-			<21 0 &gpio1 8 0>; /* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio1 6 0>,
+			<ARDUINO_HEADER_R3_A1 0 &gpio1 7 0>,
+			<ARDUINO_HEADER_R3_A2 0 &gpio1 11 0>,
+			<ARDUINO_HEADER_R3_A3 0 &gpio1 12 0>,
+			<ARDUINO_HEADER_R3_A4 0 &gpio1 13 0>,
+			<ARDUINO_HEADER_R3_A5 0 &gpio1 14 0>,
+			<ARDUINO_HEADER_R3_D0 0 &gpio1 4 0>,
+			<ARDUINO_HEADER_R3_D1 0 &gpio1 5 0>,
+			<ARDUINO_HEADER_R3_D2 0 &gpio0 0 0>,
+			<ARDUINO_HEADER_R3_D3 0 &gpio1 2 0>,
+			<ARDUINO_HEADER_R3_D4 0 &gpio1 3 0>,
+			<ARDUINO_HEADER_R3_D5 0 &gpio1 10 0>,
+			<ARDUINO_HEADER_R3_D6 0 &gpio1 13 0>,
+			<ARDUINO_HEADER_R3_D7 0 &gpio1 14 0>,
+			<ARDUINO_HEADER_R3_D8 0 &gpio1 15 0>,
+			<ARDUINO_HEADER_R3_D9 0 &gpio2 7 0>,
+			<ARDUINO_HEADER_R3_D10 0 &gpio2 10 0>,
+			<ARDUINO_HEADER_R3_D11 0 &gpio2 8 0>,
+			<ARDUINO_HEADER_R3_D12 0 &gpio2 9 0>,
+			<ARDUINO_HEADER_R3_D13 0 &gpio2 6 0>,
+			<ARDUINO_HEADER_R3_D14 0 &gpio1 9 0>,
+			<ARDUINO_HEADER_R3_D15 0 &gpio1 8 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/phytec/reel_board/dts/reel_board.dtsi
+++ b/boards/phytec/reel_board/dts/reel_board.dtsi
@@ -7,6 +7,7 @@
 
 #include <nordic/nrf52840_partition.dtsi>
 #include "reel_board-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -57,28 +58,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio1 1 0>,	/* D0 */
-			   <7 0 &gpio1 2 0>,	/* D1 */
-			   <8 0 &gpio1 3 0>,	/* D2 */
-			   <9 0 &gpio1 4 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 8 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	aliases {

--- a/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
+++ b/boards/renesas/da1469x_dk_pro/da1469x_dk_pro.dts
@@ -6,6 +6,7 @@
 /dts-v1/;
 #include <renesas/smartbond/da14699.dtsi>
 #include "da1469x_dk_pro-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -49,28 +50,28 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map =
-			<0 0 &gpio1 9 0>,	/* A0 */
-			<1 0 &gpio0 25 0>,	/* A1 */
-			<2 0 &gpio0 8 0>,	/* A2 */
-			<3 0 &gpio0 9 0>,	/* A3 */
-			<4 0 &gpio1 13 0>,	/* A4 */
-			<5 0 &gpio1 12 0>,	/* A5 */
-			<6 0 &gpio1 2 0>,	/* D0 */
-			<7 0 &gpio1 3 0>,	/* D1 */
-			<8 0 &gpio1 4 0>,	/* D2 */
-			<9 0 &gpio1 5 0>,	/* D3 */
-			<10 0 &gpio1 7 0>,	/* D4 */
-			<11 0 &gpio1 8 0>,	/* D5 */
-			<12 0 &gpio0 17 0>,	/* D6 */
-			<13 0 &gpio0 18 0>,	/* D7 */
-			<14 0 &gpio0 19 0>,	/* D8 */
-			<15 0 &gpio0 20 0>,	/* D9 */
-			<16 0 &gpio0 21 0>,	/* D10 */
-			<17 0 &gpio0 24 0>,	/* D11 */
-			<18 0 &gpio0 26 0>,	/* D12 */
-			<19 0 &gpio0 27 0>,	/* D13 */
-			<20 0 &gpio0 28 0>,	/* D14 */
-			<21 0 &gpio0 29 0>;	/* D15 */
+			<ARDUINO_HEADER_R3_A0 0 &gpio1 9 0>,
+			<ARDUINO_HEADER_R3_A1 0 &gpio0 25 0>,
+			<ARDUINO_HEADER_R3_A2 0 &gpio0 8 0>,
+			<ARDUINO_HEADER_R3_A3 0 &gpio0 9 0>,
+			<ARDUINO_HEADER_R3_A4 0 &gpio1 13 0>,
+			<ARDUINO_HEADER_R3_A5 0 &gpio1 12 0>,
+			<ARDUINO_HEADER_R3_D0 0 &gpio1 2 0>,
+			<ARDUINO_HEADER_R3_D1 0 &gpio1 3 0>,
+			<ARDUINO_HEADER_R3_D2 0 &gpio1 4 0>,
+			<ARDUINO_HEADER_R3_D3 0 &gpio1 5 0>,
+			<ARDUINO_HEADER_R3_D4 0 &gpio1 7 0>,
+			<ARDUINO_HEADER_R3_D5 0 &gpio1 8 0>,
+			<ARDUINO_HEADER_R3_D6 0 &gpio0 17 0>,
+			<ARDUINO_HEADER_R3_D7 0 &gpio0 18 0>,
+			<ARDUINO_HEADER_R3_D8 0 &gpio0 19 0>,
+			<ARDUINO_HEADER_R3_D9 0 &gpio0 20 0>,
+			<ARDUINO_HEADER_R3_D10 0 &gpio0 21 0>,
+			<ARDUINO_HEADER_R3_D11 0 &gpio0 24 0>,
+			<ARDUINO_HEADER_R3_D12 0 &gpio0 26 0>,
+			<ARDUINO_HEADER_R3_D13 0 &gpio0 27 0>,
+			<ARDUINO_HEADER_R3_D14 0 &gpio0 28 0>,
+			<ARDUINO_HEADER_R3_D15 0 &gpio0 29 0>;
 	};
 
 	aliases {

--- a/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2_nano.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/adafruit_2_8_tft_touch_v2_nano.overlay
@@ -5,6 +5,7 @@
  */
 
 #include "adafruit_2_8_tft_touch_v2.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 	/*
@@ -16,9 +17,9 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <10 0 &arduino_nano_header 4 0>,  /* D4  */
-			   <15 0 &arduino_nano_header 10 0>, /* D10 */
-			   <16 0 &arduino_nano_header 9 0>;  /* D9  */
+		gpio-map = <ARDUINO_HEADER_R3_D4 0 &arduino_nano_header 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &arduino_nano_header 10 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &arduino_nano_header 9 0>;
 	};
 };
 

--- a/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
+++ b/boards/shields/rpi_pico_uno_flexypin/rpi_pico_uno_flexypin.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
@@ -11,28 +13,28 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map =
-			<0 0 &pico_header 26 0>,  /* A0 */
-			<1 0 &pico_header 27 0>,  /* A1 */
-			<2 0 &pico_header 28 0>,  /* A2 */
-			<3 0 &pico_header 13 0>,  /* A3 */
-			<4 0 &pico_header 14 0>,  /* A4 */
-			<5 0 &pico_header 15 0>,  /* A5 */
-			<6 0 &pico_header 1 0>,   /* D0 */
-			<7 0 &pico_header 0 0>,   /* D1 */
-			<8 0 &pico_header 4 0>,   /* D2 */
-			<9 0 &pico_header 5 0>,   /* D3 */
-			<10 0 &pico_header 6 0>,  /* D4 */
-			<11 0 &pico_header 7 0>,  /* D5 */
-			<12 0 &pico_header 8 0>,  /* D6 */
-			<13 0 &pico_header 9 0>,  /* D7 */
-			<14 0 &pico_header 2 0>,  /* D8 */
-			<15 0 &pico_header 3 0>,  /* D9 */
-			<16 0 &pico_header 17 0>, /* D10 */
-			<17 0 &pico_header 19 0>, /* D11 */
-			<18 0 &pico_header 16 0>, /* D12 */
-			<19 0 &pico_header 18 0>, /* D13 */
-			<20 0 &pico_header 20 0>, /* D14 */
-			<21 0 &pico_header 21 0>; /* D15 */
+			<ARDUINO_HEADER_R3_A0 0 &pico_header 26 0>,
+			<ARDUINO_HEADER_R3_A1 0 &pico_header 27 0>,
+			<ARDUINO_HEADER_R3_A2 0 &pico_header 28 0>,
+			<ARDUINO_HEADER_R3_A3 0 &pico_header 13 0>,
+			<ARDUINO_HEADER_R3_A4 0 &pico_header 14 0>,
+			<ARDUINO_HEADER_R3_A5 0 &pico_header 15 0>,
+			<ARDUINO_HEADER_R3_D0 0 &pico_header 1 0>,
+			<ARDUINO_HEADER_R3_D1 0 &pico_header 0 0>,
+			<ARDUINO_HEADER_R3_D2 0 &pico_header 4 0>,
+			<ARDUINO_HEADER_R3_D3 0 &pico_header 5 0>,
+			<ARDUINO_HEADER_R3_D4 0 &pico_header 6 0>,
+			<ARDUINO_HEADER_R3_D5 0 &pico_header 7 0>,
+			<ARDUINO_HEADER_R3_D6 0 &pico_header 8 0>,
+			<ARDUINO_HEADER_R3_D7 0 &pico_header 9 0>,
+			<ARDUINO_HEADER_R3_D8 0 &pico_header 2 0>,
+			<ARDUINO_HEADER_R3_D9 0 &pico_header 3 0>,
+			<ARDUINO_HEADER_R3_D10 0 &pico_header 17 0>,
+			<ARDUINO_HEADER_R3_D11 0 &pico_header 19 0>,
+			<ARDUINO_HEADER_R3_D12 0 &pico_header 16 0>,
+			<ARDUINO_HEADER_R3_D13 0 &pico_header 18 0>,
+			<ARDUINO_HEADER_R3_D14 0 &pico_header 20 0>,
+			<ARDUINO_HEADER_R3_D15 0 &pico_header 21 0>;
 	};
 };
 

--- a/boards/sifive/hifive1/hifive1.dts
+++ b/boards/sifive/hifive1/hifive1.dts
@@ -4,6 +4,7 @@
 /dts-v1/;
 
 #include <sifive/riscv32-fe310.dtsi>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include "hifive1-pinctrl.dtsi"
 
@@ -66,27 +67,27 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map = /* A0 not connected */
-			   <1 0 &gpio0 9 0>,	/* A1, also CS2 */
-			   <2 0 &gpio0 10 0>,	/* A2, also WF_INT */
-			   <3 0 &gpio0 11 0>,	/* A3 */
-			   <4 0 &gpio0 12 0>,	/* A4 */
-			   <5 0 &gpio0 13 0>,	/* A5 */
-			   <6 0 &gpio0 16 0>,	/* D0, also TX */
-			   <7 0 &gpio0 17 0>,	/* D1, also RX */
-			   <8 0 &gpio0 18 0>,	/* D2 */
-			   <9 0 &gpio0 19 0>,	/* D3 */
-			   <10 0 &gpio0 20 0>,	/* D4 */
-			   <11 0 &gpio0 21 0>,	/* D5 */
-			   <12 0 &gpio0 22 0>,	/* D6 */
-			   <13 0 &gpio0 23 0>,	/* D7 */
-			   <14 0 &gpio0 0 0>,	/* D8 */
-			   <15 0 &gpio0 1 0>,	/* D9 */
-			   <16 0 &gpio0 2 0>,	/* D10 */
-			   <17 0 &gpio0 3 0>,	/* D11, also MOSI */
-			   <18 0 &gpio0 4 0>,	/* D12, also MISO */
-			   <19 0 &gpio0 5 0>,	/* D13, also SCK */
-			   <20 0 &gpio0 12 0>,	/* D14, also SDA */
-			   <21 0 &gpio0 13 0>;	/* D15, also SCL */
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 9 0>,		/* also CS2 */
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 10 0>,	/* also WF_INT */
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 16 0>,	/* also TX */
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 17 0>,	/* also RX */
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 21 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 0 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 1 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 3 0>,	/* also MOSI */
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 4 0>,	/* also MISO */
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 5 0>,	/* also SCK */
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 12 0>,	/* also SDA */
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 13 0>;	/* also SCL */
 	};
 };
 

--- a/boards/snps/hsdk/hsdk.dtsi
+++ b/boards/snps/hsdk/hsdk.dtsi
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <synopsys/arc_hsdk.dtsi>
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 
 / {
 
@@ -49,28 +50,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &cy8c95xx_port0 2 0>,	/* A0 */
-			   <1 0 &cy8c95xx_port0 3 0>,	/* A1 */
-			   <2 0 &cy8c95xx_port0 4 0>,	/* A2 */
-			   <3 0 &cy8c95xx_port0 5 0>,	/* A3 */
-			   <4 0 &gpio0 18 0>,	/* A4 */
-			   <5 0 &gpio0 19 0>,	/* A5 */
-			   <6 0 &gpio0 23 0>,	/* D0 */
-			   <7 0 &gpio0 22 0>,	/* D1 */
-			   <8 0 &gpio0 16 0>,	/* D2 */
-			   <9 0 &gpio0 17 0>,	/* D3 */
-			   <10 0 &gpio0 11 0>,	/* D4 */
-			   <11 0 &gpio0 9 0>,	/* D5 */
-			   <12 0 &gpio0 21 0>,	/* D6 */
-			   <13 0 &gpio0 20 0>,	/* D7 */
-			   <14 0 &gpio0 10 0>,	/* D8 */
-			   <15 0 &gpio0 8 0>,	/* D9 */
-			   <16 0 &gpio0 12 0>,	/* D10 */
-			   <17 0 &gpio0 13 0>,	/* D11 */
-			   <18 0 &gpio0 14 0>,	/* D12 */
-			   <19 0 &gpio0 15 0>,	/* D13 */
-			   <20 0 &gpio0 18 0>,	/* D14 */
-			   <21 0 &gpio0 19 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &cy8c95xx_port0 2 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &cy8c95xx_port0 3 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &cy8c95xx_port0 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &cy8c95xx_port0 5 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 21 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 19 0>;
 	};
 };
 

--- a/boards/st/b_l4s5i_iot01a/arduino_r3_connector.dtsi
+++ b/boards/st/b_l4s5i_iot01a/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 5 0>,	/* A0 */
-			   <1 0 &gpioc 4 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 2 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 1 0>,	/* D0 */
-			   <7 0 &gpioa 0 0>,	/* D1 */
-			   <8 0 &gpiod 14 0>,	/* D2 */
-			   <9 0 &gpiob 0 0>,	/* D3 */
-			   <10 0 &gpioa 3 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 1 0>,	/* D6 */
-			   <13 0 &gpioa 4 0>,	/* D7 */
-			   <14 0 &gpiob 2 0>,	/* D8 */
-			   <15 0 &gpioa 15 0>,	/* D9 */
-			   <16 0 &gpioa 2 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/b_u585i_iot02a/arduino_r3_connector.dtsi
+++ b/boards/st/b_u585i_iot02a/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
-			   <1 0 &gpioc 2 0>,	/* A1 */
-			   <2 0 &gpioc 4 0>,	/* A2 */
-			   <3 0 &gpioc 5 0>,	/* A3 */
-			   <4 0 &gpioa 7 0>,	/* A4 */
-			   <5 0 &gpiob 0 0>,	/* A5 */
-			   <6 0 &gpiod 8 0>,	/* D0 */
-			   <7 0 &gpiod 9 0>,	/* D1 */
-			   <8 0 &gpiod 15 0>,	/* D2 */
-			   <9 0 &gpiob 2 0>,	/* D3 */
-			   <10 0 &gpioe 7 0>,	/* D4 */
-			   <11 0 &gpioe 0 0>,	/* D5 */
-			   <12 0 &gpiob 6 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpioc 1 0>,	/* D8 */
-			   <15 0 &gpioa 8 0>,	/* D9 */
-			   <16 0 &gpioe 12 0>,	/* D10 */
-			   <17 0 &gpioe 15 0>,	/* D11 */
-			   <18 0 &gpioe 14 0>,	/* D12 */
-			   <19 0 &gpioe 13 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 9 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 7 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioe 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioe 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
+++ b/boards/st/disco_l475_iot1/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 5 0>,	/* A0 */
-			   <1 0 &gpioc 4 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 2 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 1 0>,	/* D0 */
-			   <7 0 &gpioa 0 0>,	/* D1 */
-			   <8 0 &gpiod 14 0>,	/* D2 */
-			   <9 0 &gpiob 0 0>,	/* D3 */
-			   <10 0 &gpioa 3 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 1 0>,	/* D6 */
-			   <13 0 &gpioa 4 0>,	/* D7 */
-			   <14 0 &gpiob 2 0>,	/* D8 */
-			   <15 0 &gpioa 15 0>,	/* D9 */
-			   <16 0 &gpioa 2 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_c031c6/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_c031c6/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioa 11 0>,	/* A4 */
-			   <5 0 &gpioa 12 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 10 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 5 0>,	/* D6 */
-			   <13 0 &gpioa 15 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 0 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_c071rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_c071rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpioc 7 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpioc 8 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpiob 3 0>,	/* D9 */
-			   <16 0 &gpioa 15 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_c092rc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_c092rc/arduino_r3_connector.dtsi
@@ -5,34 +5,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpioc 7 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpioc 8 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpiob 3 0>,	/* D9 */
-			   <16 0 &gpioa 15 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f030r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f030r8/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f070rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f070rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f072rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f072rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f091rc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f091rc/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f103rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f103rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f207zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f207zg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f302r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f302r8/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpiob 13 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f303re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f303re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpiob 13 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f334r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f334r8/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f401re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f401re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f410rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f410rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f411re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f411re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f412zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f412zg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 1 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f413zh/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f413zh/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 1 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f429zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f429zi/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f439zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f439zi/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f446re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f446re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f446ze/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f446ze/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f722ze/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f722ze/arduino_r3_connector.dtsi
@@ -5,34 +5,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f746zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f746zg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f756zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f756zg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_f767zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_f767zi/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 3 0>,	/* A3 */
-			   <4 0 &gpiof 5 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g070rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g070rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpiob 11 0>,	/* A4 */
-			   <5 0 &gpiob 12 0>,	/* A5 */
-			   <6 0 &gpioc 5 0>,	/* D0 */
-			   <7 0 &gpioc 4 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 14 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 0 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 12 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g071rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g071rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpiob 11 0>,	/* A4 */
-			   <5 0 &gpiob 12 0>,	/* A5 */
-			   <6 0 &gpioc 5 0>,	/* D0 */
-			   <7 0 &gpioc 4 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 14 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 0 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 12 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g0b1re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g0b1re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpiob 11 0>,	/* A4 */
-			   <5 0 &gpiob 12 0>,	/* A5 */
-			   <6 0 &gpioc 5 0>,	/* D0 */
-			   <7 0 &gpioc 4 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 14 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 0 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 12 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g431rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g431rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioc 5 0>,	/* D0 */
-			   <7 0 &gpioc 4 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_g474re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_g474re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioc 5 0>,	/* D0 */
-			   <7 0 &gpioc 4 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h503rb/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h503rb/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 2 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpiob 15 0>,	/* D0 */
-			   <7 0 &gpiob 14 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioc 7 0>,	/* D8 */
-			   <15 0 &gpioc 6 0>,	/* D9 */
-			   <16 0 &gpioc 9 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_h533re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h533re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpiob 1 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpiob 15 0>,	/* D0 */
-			   <7 0 &gpiob 14 0>,	/* D1 */
-			   <8 0 &gpioc 8 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioc 7 0>,	/* D8 */
-			   <15 0 &gpioc 6 0>,	/* D9 */
-			   <16 0 &gpioc 9 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_h563zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h563zi/arduino_r3_connector.dtsi
@@ -5,34 +5,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 6 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpiof 11 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 14 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpioe 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiog 12 0>,	/* D7 */
-			   <14 0 &gpiof 3 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpiog 9 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 11 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h723zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h723zg/arduino_r3_connector.dtsi
@@ -3,34 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 14 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpioe 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiog 12 0>,	/* D7 */
-			   <14 0 &gpiof 3 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h743zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h743zi/arduino_r3_connector.dtsi
@@ -5,34 +5,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 14 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpioe 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiog 12 0>,	/* D7 */
-			   <14 0 &gpiof 3 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h745zi_q/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpiof 11 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 14 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpioe 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioa 8 0>,	/* D6 */
-			   <13 0 &gpiog 12 0>,	/* D7 */
-			   <14 0 &gpiog 9 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 11 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h753zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h753zi/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpiof 10 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 14 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpioe 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiog 12 0>,	/* D7 */
-			   <14 0 &gpiof 3 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h755zi_q/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpiof 11 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 14 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpioe 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioa 8 0>,	/* D6 */
-			   <13 0 &gpiog 12 0>,	/* D7 */
-			   <14 0 &gpiog 9 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 11 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h7a3zi_q/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpiof 11 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 14 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpioe 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioa 8 0>,	/* D6 */
-			   <13 0 &gpiog 12 0>,	/* D7 */
-			   <14 0 &gpiog 9 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 11 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_h7s3l8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_h7s3l8/arduino_r3_connector.dtsi
@@ -3,34 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 4 0>,	/* A3 */
-			   <4 0 &gpioc 5 0>,	/* A4 */
-			   <5 0 &gpiof 11 0>,	/* A5 */
-			   <6 0 &gpioa 10 0>,	/* D0 */
-			   <7 0 &gpiob 14 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 3 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 4 0>,	/* D7 */
-			   <14 0 &gpiof 5 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 11 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 4 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 5 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l053r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l053r8/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l073rz/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l073rz/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l152re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l152re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l412rb_p/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l412rb_p/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 2 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 12 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpioa 15 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioc 7 0>,	/* D7 */
-			   <14 0 &gpiob 6 0>,	/* D8 */
-			   <15 0 &gpioa 8 0>,	/* D9 */
-			   <16 0 &gpioa 11 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpiob 13 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l433rc_p/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l433rc_p/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 2 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 12 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpioa 15 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioc 7 0>,	/* D7 */
-			   <14 0 &gpiob 6 0>,	/* D8 */
-			   <15 0 &gpioa 8 0>,	/* D9 */
-			   <16 0 &gpioa 11 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpiob 13 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l452re/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l452re/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l476rg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l476rg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l496zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l496zg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 1 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiod 9 0>,	/* D0 */
-			   <7 0 &gpiod 8 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l4a6zg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l4a6zg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 1 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiod 9 0>,	/* D0 */
-			   <7 0 &gpiod 8 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l4r5zi/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l4r5zi/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioc 0 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 1 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiod 9 0>,	/* D0 */
-			   <7 0 &gpiod 8 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_l552ze_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_l552ze_q/arduino_r3_connector.dtsi
@@ -4,33 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioa 2 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpiod 9 0>,	/* D0 */
-			   <7 0 &gpiod 8 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };

--- a/boards/st/nucleo_n657x0_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_n657x0_q/arduino_r3_connector.dtsi
@@ -3,34 +3,37 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 8 0>,	/* A0 */
-			   <1 0 &gpioa 9 0>,	/* A1 */
-			   <2 0 &gpioa 10 0>,	/* A2 */
-			   <3 0 &gpioa 12 0>,	/* A3 */
-			   <4 0 &gpiof 3 0>,	/* A4 */
-			   <5 0 &gpiog 15 0>,	/* A5 */
-			   <6 0 &gpiod 9 0>,	/* D0 */
-			   <7 0 &gpiod 8 0>,	/* D1 */
-			   <8 0 &gpiod 0 0>,	/* D2 */
-			   <9 0 &gpioe 9 0>,	/* D3 */
-			   <10 0 &gpioe 0 0>,	/* D4 */
-			   <11 0 &gpioe 10 0>,	/* D5 */
-			   <12 0 &gpiod 5 0>,	/* D6 */
-			   <13 0 &gpioe 11 0>,	/* D7 */
-			   <14 0 &gpiod 12 0>,	/* D8 */
-			   <15 0 &gpiod 7 0>,	/* D9 */
-			   <16 0 &gpioa 3 0>,	/* D10 */
-			   <17 0 &gpiog 2 0>,	/* D11 */
-			   <18 0 &gpiog 1 0>,	/* D12 */
-			   <19 0 &gpioe 15 0>,	/* D13 */
-			   <20 0 &gpioc 1 0>,	/* D14 */
-			   <21 0 &gpioh 9 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiog 15 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiod 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 0 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiod 5 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiod 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiog 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiog 1 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioe 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioh 9 0>;
 	};
 };
 

--- a/boards/st/nucleo_u031r8/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u031r8/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_u083rc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u083rc/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioa 10 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpiob 6 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u385rg_q/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioc 8 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioc 7 0>,	/* D8 */
-			   <15 0 &gpioc 6 0>,	/* D9 */
-			   <16 0 &gpioc 9 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioc 9 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_u575zi_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u575zi_q/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioa 2 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpiog 8 0>,	/* D0 */
-			   <7 0 &gpiog 7 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 8 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 7 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_u5a5zj_q/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_u5a5zj_q/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 3 0>,	/* A0 */
-			   <1 0 &gpioa 2 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpiog 8 0>,	/* D0 */
-			   <7 0 &gpiog 7 0>,	/* D1 */
-			   <8 0 &gpiof 15 0>,	/* D2 */
-			   <9 0 &gpioe 13 0>,	/* D3 */
-			   <10 0 &gpiof 14 0>,	/* D4 */
-			   <11 0 &gpioe 11 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiof 13 0>,	/* D7 */
-			   <14 0 &gpiof 12 0>,	/* D8 */
-			   <15 0 &gpiod 15 0>,	/* D9 */
-			   <16 0 &gpiod 14 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 8 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 7 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb05kz/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb05kz/arduino_r3_connector.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
@@ -15,13 +17,13 @@
 		 * connector in default hardware configuration.
 		 * Only the connected pins are provided here.
 		 */
-		gpio-map = <14 0 &gpiob 15 0>,  /* D8 */
-			   <16 0 &gpioa 9 0>,	/* D10 */
-			   <17 0 &gpioa 11 0>,	/* D11 */
-			   <18 0 &gpioa 8 0>,	/* D12 */
-			   <19 0 &gpiob 3 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_D8 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb07cc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb07cc/arduino_r3_connector.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
@@ -15,28 +17,28 @@
 		 * connector in default hardware configuration.
 		 * Only the connected pins are provided here.
 		 */
-		gpio-map = <0 0 &gpiob 3 0>,	/* A0 */
-			   <1 0 &gpiob 1 0>,	/* A1 */
-			   <2 0 &gpioa 15 0>,	/* A2 */
-			   <3 0 &gpioa 12 0>,	/* A3 */
-			   <4 0 &gpioa 14 0>,	/* A4 */
-			   <5 0 &gpioa 13 0>,	/* A5 */
-						/* D0 - N/C (PA8 via SB9) */
-						/* D1 - N/C (PA9 via SB7) */
-			   <8 0 &gpiob 15 0>,	/* D2 */
-						/* D3 - N/C (PA0 via SB3) */
-			   <10 0 &gpiob 11 0>,	/* D4 */
-			   <11 0 &gpiob 14 0>,	/* D5 */
-			   <12 0 &gpioa 11 0>,	/* D6 */
-			   <13 0 &gpiob 10 0>,	/* D7 */
-			   <14 0 &gpiob 8 0>,	/* D8 */
-			   <15 0 &gpioa 1 0>,	/* D9 */
-			   <16 0 &gpioa 4 0>,	/* D10 */
-			   <17 0 &gpioa 6 0>,	/* D11 */
-			   <18 0 &gpioa 7 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 14 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioa 13 0>,
+			   /* D0 - N/C (PA8 via SB9) */
+			   /* D1 - N/C (PA9 via SB7) */
+			   <ARDUINO_HEADER_R3_D2 0 &gpiob 15 0>,
+			   /* D3 - N/C (PA0 via SB3) */
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 8 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb09ke/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb09ke/arduino_r3_connector.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
@@ -15,13 +17,13 @@
 		 * connector in default hardware configuration.
 		 * Only the connected pins are provided here.
 		 */
-		gpio-map = <14 0 &gpiob 15 0>,  /* D8 */
-			   <16 0 &gpioa 9 0>,	/* D10 */
-			   <17 0 &gpioa 11 0>,	/* D11 */
-			   <18 0 &gpioa 8 0>,	/* D12 */
-			   <19 0 &gpiob 3 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_D8 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/nucleo_wb55rg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wb55rg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
-			   <1 0 &gpioc 1 0>,	/* A1 */
-			   <2 0 &gpioa 1 0>,	/* A2 */
-			   <3 0 &gpioa 0 0>,	/* A3 */
-			   <4 0 &gpioc 3 0>,	/* A4 */
-			   <5 0 &gpioc 2 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioc 6 0>,	/* D2 */
-			   <9 0 &gpioa 10 0>,	/* D3 */
-			   <10 0 &gpioc 10 0>,	/* D4 */
-			   <11 0 &gpioa 15 0>,	/* D5 */
-			   <12 0 &gpioa 8 0>,	/* D6 */
-			   <13 0 &gpioc 13 0>,	/* D7 */
-			   <14 0 &gpioc 12 0>,	/* D8 */
-			   <15 0 &gpioa 9 0>,	/* D9 */
-			   <16 0 &gpioa 4 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioc 10 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 12 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/nucleo_wba55cg/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wba55cg/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 7 0>,	/* A0 */
-			   <1 0 &gpioa 6 0>,	/* A1 */
-			   <2 0 &gpioa 2 0>,	/* A2 */
-			   <3 0 &gpioa 1 0>,	/* A3 */
-			   <4 0 &gpioa 5 0>,	/* A4 */
-			   <5 0 &gpioa 0 0>,	/* A5 */
-			   <6 0 &gpioa 10 0>,	/* D0 */
-			   <7 0 &gpiob 5 0>,	/* D1 */
-			   <8 0 &gpiob 7 0>,	/* D2 */
-			   <9 0 &gpiob 6 0>,	/* D3 */
-			   <10 0 &gpioa 11 0>,	/* D4 */
-			   <11 0 &gpiob 14 0>,	/* D5 */
-			   <12 0 &gpiob 0 0>,	/* D6 */
-			   <13 0 &gpiob 9 0>,	/* D7 */
-			   <14 0 &gpiob 15 0>,	/* D8 */
-			   <15 0 &gpioa 9 0>,	/* D9 */
-			   <16 0 &gpioa 12 0>,	/* D10 */
-			   <17 0 &gpioa 15 0>,	/* D11 */
-			   <18 0 &gpiob 3 0>,	/* D12 */
-			   <19 0 &gpiob 4 0>,	/* D13 */
-			   <20 0 &gpiob 1 0>,	/* D14 */
-			   <21 0 &gpiob 2 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 2 0>;
 	};
 };
 

--- a/boards/st/nucleo_wba65ri/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wba65ri/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 4 0>,	/* A0 */
-			   <1 0 &gpioa 6 0>,	/* A1 */
-			   <2 0 &gpioa 2 0>,	/* A2 */
-			   <3 0 &gpioa 1 0>,	/* A3 */
-			   <4 0 &gpioa 5 0>,	/* A4 */
-			   <5 0 &gpioa 0 0>,	/* A5 */
-			   <6 0 &gpioa 11 0>,	/* D0 */
-			   <7 0 &gpioa 12 0>,	/* D1 */
-			   <8 0 &gpioe 0 0>,	/* D2 */
-			   <9 0 &gpiob 13 0>,	/* D3 */
-			   <10 0 &gpioa 3 0>,	/* D4 */
-			   <11 0 &gpiob 14 0>,	/* D5 */
-			   <12 0 &gpiob 0 0>,	/* D6 */
-			   <13 0 &gpiod 14 0>,	/* D7 */
-			   <14 0 &gpioa 10 0>,	/* D8 */
-			   <15 0 &gpiob 11 0>,	/* D9 */
-			   <16 0 &gpiob 9 0>,	/* D10 */
-			   <17 0 &gpioc 3 0>,	/* D11 */
-			   <18 0 &gpioa 9 0>,	/* D12 */
-			   <19 0 &gpiob 10 0>,	/* D13 */
-			   <20 0 &gpiob 1 0>,	/* D14 */
-			   <21 0 &gpiob 2 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 2 0>;
 	};
 };
 

--- a/boards/st/nucleo_wl55jc/arduino_r3_connector.dtsi
+++ b/boards/st/nucleo_wl55jc/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiob 1 0>,	/* A0 */
-			   <1 0 &gpiob 2 0>,	/* A1 */
-			   <2 0 &gpioa 10 0>,	/* A2 */
-			   <3 0 &gpiob 4 0>,	/* A3 */
-			   <4 0 &gpiob 14 0>,	/* A4 */
-			   <5 0 &gpiob 13 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiob 12 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 8 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioc 1 0>,	/* D7 */
-			   <14 0 &gpioc 2 0>,	/* D8 */
-			   <15 0 &gpioa 9 0>,	/* D9 */
-			   <16 0 &gpioa 4 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpioa 11 0>,	/* D14 */
-			   <21 0 &gpioa 12 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiob 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 13 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiob 12 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 8 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioa 12 0>;
 	};
 };
 

--- a/boards/st/stm32f412g_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f412g_disco/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 1 0>,	/* A0 */
-			   <1 0 &gpioc 1 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 4 0>,	/* A3 */
-			   <4 0 &gpioc 5 0>,	/* A4 */
-			   <5 0 &gpiob 0 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiog 13 0>,	/* D2 */
-			   <9 0 &gpiof 4 0>,	/* D3 */
-			   <10 0 &gpiog 12 0>,	/* D4 */
-			   <11 0 &gpiof 10 0>,	/* D5 */
-			   <12 0 &gpiof 3 0>,	/* D6 */
-			   <13 0 &gpiog 11 0>,	/* D7 */
-			   <14 0 &gpiog 10 0>,	/* D8 */
-			   <15 0 &gpiob 8 0>,	/* D9 */
-			   <16 0 &gpioa 15 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 10 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiof 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 11 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 10 0>;
 	};
 };
 

--- a/boards/st/stm32f413h_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f413h_disco/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 2 0>,	/* A2 */
-			   <3 0 &gpioa 5 0>,	/* A3 */
-			   <4 0 &gpiob 1 0>,	/* A4 */
-			   <5 0 &gpioc 4 0>,	/* A5 */
-			   <6 0 &gpiof 6 0>,	/* D0 */
-			   <7 0 &gpiof 7 0>,	/* D1 */
-			   <8 0 &gpiog 13 0>,	/* D2 */
-			   <9 0 &gpiof 10 0>,	/* D3 */
-			   <10 0 &gpiob 6 0>,	/* D4 */
-			   <11 0 &gpioe 6 0>,	/* D5 */
-			   <12 0 &gpiob 0 0>,	/* D6 */
-			   <13 0 &gpioc 13 0>,	/* D7 */
-			   <14 0 &gpioa 4 0>,	/* D8 */
-			   <15 0 &gpiob 8 0>,	/* D9 */
-			   <16 0 &gpioa 15 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpiob 4 0>,	/* D12 */
-			   <19 0 &gpiob 12 0>,	/* D13 */
-			   <20 0 &gpiob 11 0>,	/* D14 */
-			   <21 0 &gpiob 10 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiof 6 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiof 7 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 13 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiob 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 10 0>;
 	};
 };
 

--- a/boards/st/stm32f469i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f469i_disco/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiob 1 0>,	/* A0 */
-			   <1 0 &gpioc 2 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpioc 4 0>,	/* A3 */
-			   <4 0 &gpioc 5 0>,	/* A4 */
-			   <5 0 &gpioa 4 0>,	/* A5 */
-			   <6 0 &gpiog 9 0>,	/* D0 */
-			   <7 0 &gpiog 14 0>,	/* D1 */
-			   <8 0 &gpiog 15 0>,	/* D2 */
-			   <9 0 &gpioa 1 0>,	/* D3 */
-			   <10 0 &gpiog 12 0>,	/* D4 */
-			   <11 0 &gpioa 2 0>,	/* D5 */
-			   <12 0 &gpioa 6 0>,	/* D6 */
-			   <13 0 &gpiog 11 0>,	/* D7 */
-			   <14 0 &gpiog 10 0>,	/* D8 */
-			   <15 0 &gpioa 7 0>,	/* D9 */
-			   <16 0 &gpioh 6 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpiod 3 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 1 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiog 14 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiog 12 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 11 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioh 6 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32f723e_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f723e_disco/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 6 0>,	/* A0 */
-			   <1 0 &gpioa 4 0>,	/* A1 */
-			   <2 0 &gpioc 4 0>,	/* A2 */
-			   <3 0 &gpiof 10 0>,	/* A3 */
-			   <4 0 &gpioc 0 0>,	/* A4 */
-			   <5 0 &gpioc 1 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioc 5 0>,	/* D2 */
-			   <9 0 &gpioe 5 0>,	/* D3 */
-			   <10 0 &gpioh 3 0>,	/* D4 */
-			   <11 0 &gpiob 0 0>,	/* D5 */
-			   <12 0 &gpioe 6 0>,	/* D6 */
-			   <13 0 &gpioe 3 0>,	/* D7 */
-			   <14 0 &gpioe 4 0>,	/* D8 */
-			   <15 0 &gpioh 6 0>,	/* D9 */
-			   <16 0 &gpioa 1 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpiob 4 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpioh 5 0>,	/* D14 */
-			   <21 0 &gpioh 4 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioh 3 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioe 3 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioe 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioh 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioh 5 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioh 4 0>;
 	};
 };
 

--- a/boards/st/stm32f746g_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f746g_disco/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpiof 10 0>,	/* A1 */
-			   <2 0 &gpiof 9 0>,	/* A2 */
-			   <3 0 &gpiof 8 0>,	/* A3 */
-			   <4 0 &gpiof 7 0>,	/* A4 */
-			   <5 0 &gpiof 6 0>,	/* A5 */
-			   <6 0 &gpioc 7 0>,	/* D0 */
-			   <7 0 &gpioc 6 0>,	/* D1 */
-			   <8 0 &gpiog 6 0>,	/* D2 */
-			   <9 0 &gpiob 4 0>,	/* D3 */
-			   <10 0 &gpiog 7 0>,	/* D4 */
-			   <11 0 &gpioi 0 0>,	/* D5 */
-			   <12 0 &gpioh 6 0>,	/* D6 */
-			   <13 0 &gpioi 3 0>,	/* D7 */
-			   <14 0 &gpioi 2 0>,	/* D8 */
-			   <15 0 &gpioa 15 0>,	/* D9 */
-			   <16 0 &gpioa 8 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpioi 1 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiof 9 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 8 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 7 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 6 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 6 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiog 7 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioi 0 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioh 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioi 3 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioi 2 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioi 1 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32f7508_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f7508_dk/arduino_r3_connector.dtsi
@@ -5,34 +5,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpiof 10 0>,	/* A1 */
-			   <2 0 &gpiof 9 0>,	/* A2 */
-			   <3 0 &gpiof 8 0>,	/* A3 */
-			   <4 0 &gpiof 7 0>,	/* A4 */
-			   <5 0 &gpiof 6 0>,	/* A5 */
-			   <6 0 &gpioc 7 0>,	/* D0 */
-			   <7 0 &gpioc 6 0>,	/* D1 */
-			   <8 0 &gpiog 6 0>,	/* D2 */
-			   <9 0 &gpiob 4 0>,	/* D3 */
-			   <10 0 &gpiog 7 0>,	/* D4 */
-			   <11 0 &gpioi 0 0>,	/* D5 */
-			   <12 0 &gpioh 6 0>,	/* D6 */
-			   <13 0 &gpioi 3 0>,	/* D7 */
-			   <14 0 &gpioi 2 0>,	/* D8 */
-			   <15 0 &gpioa 15 0>,	/* D9 */
-			   <16 0 &gpioa 8 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpioi 1 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpiof 9 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 8 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 7 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 6 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 6 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiog 7 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioi 0 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioh 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioi 3 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioi 2 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioi 1 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32f769i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32f769i_disco/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 6 0>,	/* A0 */
-			   <1 0 &gpioa 4 0>,	/* A1 */
-			   <2 0 &gpioc 2 0>,	/* A2 */
-			   <3 0 &gpiof 10 0>,	/* A3 */
-			   <4 0 &gpiof 8 0>,	/* A4 */
-			   <5 0 &gpiof 9 0>,	/* A5 */
-			   <6 0 &gpioc 7 0>,	/* D0 */
-			   <7 0 &gpioc 6 0>,	/* D1 */
-			   <8 0 &gpioj 1 0>,	/* D2 */
-			   <9 0 &gpiof 6 0>,	/* D3 */
-			   <10 0 &gpioj 0 0>,	/* D4 */
-			   <11 0 &gpioc 8 0>,	/* D5 */
-			   <12 0 &gpiof 7 0>,	/* D6 */
-			   <13 0 &gpioj 3 0>,	/* D7 */
-			   <14 0 &gpioj 4 0>,	/* D8 */
-			   <15 0 &gpioh 6 0>,	/* D9 */
-			   <16 0 &gpioa 11 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpioa 12 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 8 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 9 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioj 1 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiof 6 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioj 0 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioc 8 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiof 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioj 3 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioj 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioh 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32h573i_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h573i_dk/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiob 0 0>,	/* A0 */
-			   <1 0 &gpioa 4 0>,	/* A1 */
-			   <2 0 &gpioa 0 0>,	/* A2 */
-			   <3 0 &gpioa 5 0>,	/* A3 */
-			   <4 0 &gpioa 6 0>,	/* A4 */
-			   <5 0 &gpiof 12 0>,	/* A5 */
-			   <6 0 &gpiob 11 0>,	/* D0 */
-			   <7 0 &gpiob 10 0>,	/* D1 */
-			   <8 0 &gpiog 15 0>,	/* D2 */
-			   <9 0 &gpiob 5 0>,	/* D3 */
-			   <10 0 &gpiog 4 0>,	/* D4 */
-			   <11 0 &gpioh 11 0>,	/* D5 */
-			   <12 0 &gpioh 10 0>,	/* D6 */
-			   <13 0 &gpiog 5 0>,	/* D7 */
-			   <14 0 &gpiog 8 0>,	/* D8 */
-			   <15 0 &gpioa 8 0>,	/* D9 */
-			   <16 0 &gpioa 3 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpioi 2 0>,	/* D12 */
-			   <19 0 &gpioi 1 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 15 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiog 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioh 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioh 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiog 5 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 8 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioi 2 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioi 1 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/stm32h745i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h745i_disco/arduino_r3_connector.dtsi
@@ -5,34 +5,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
-			   <1 0 &gpiof 8 0>,	/* A1 */
-			   <2 0 &gpioa 0 0>,	/* A2 */
-			   <3 0 &gpioa 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpioc 3 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 3 0>,	/* D2 */
-			   <9 0 &gpioa 6 0>,	/* D3 */
-			   <10 0 &gpiok 1 0>,	/* D4 */
-			   <11 0 &gpioa 8 0>,	/* D5 */
-			   <12 0 &gpioe 6 0>,	/* D6 */
-			   <13 0 &gpioi 6 0>,	/* D7 */
-			   <14 0 &gpioe 3 0>,	/* D8 */
-			   <15 0 &gpioh 15 0>,	/* D9 */
-			   <16 0 &gpiob 4 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpioi 2 0>,	/* D12 */
-			   <19 0 &gpiod 3 0>,	/* D13 */
-			   <20 0 &gpiod 13 0>,	/* D14 */
-			   <21 0 &gpiod 12 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiof 8 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiok 1 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioi 6 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioe 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioh 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioi 2 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
 	};
 };
 

--- a/boards/st/stm32h747i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h747i_disco/arduino_r3_connector.dtsi
@@ -4,33 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 4 0>,	/* A0 */
-			   <1 0 &gpiof 10 0>,	/* A1 */
-			   <2 0 &gpioa 0 0>,	/* A2 */
-			   <3 0 &gpioa 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpioc 3 0>,	/* A5 */
-			   <6 0 &gpioj 9 0>,	/* D0 */
-			   <7 0 &gpioj 8 0>,	/* D1 */
-			   <8 0 &gpioj 3 0>,	/* D2 */
-			   <9 0 &gpiof 8 0>,	/* D3 */
-			   <10 0 &gpioj 4 0>,	/* D4 */
-			   <11 0 &gpioa 6 0>,	/* D5 */
-			   <12 0 &gpioj 7 0>,	/* D6 */
-			   <13 0 &gpioj 0 0>,	/* D7 */
-			   <14 0 &gpioj 5 0>,	/* D8 */
-			   <15 0 &gpioj 6 0>,	/* D9 */
-			   <16 0 &gpiok 1 0>,	/* D10 */
-			   <17 0 &gpioj 10 0>,	/* D11 */
-			   <18 0 &gpioj 11 0>,	/* D12 */
-			   <19 0 &gpiok 0 0>,	/* D13 */
-			   <20 0 &gpiod 13 0>,	/* D14 */
-			   <21 0 &gpiod 12 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioj 9 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioj 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioj 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiof 8 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioj 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioj 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioj 0 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioj 5 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioj 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiok 1 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioj 10 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioj 11 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiok 0 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
 	};
 };

--- a/boards/st/stm32h750b_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h750b_dk/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
-			   <1 0 &gpiof 8 0>,	/* A1 */
-			   <2 0 &gpioa 0 0>,	/* A2 */
-			   <3 0 &gpioa 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpioc 3 0>,	/* A5 */
-			   <6 0 &gpiob 7 0>,	/* D0 */
-			   <7 0 &gpiob 6 0>,	/* D1 */
-			   <8 0 &gpiog 3 0>,	/* D2 */
-			   <9 0 &gpioa 6 0>,	/* D3 */
-			   <10 0 &gpiok 1 0>,	/* D4 */
-			   <11 0 &gpioa 8 0>,	/* D5 */
-			   <12 0 &gpioe 6 0>,	/* D6 */
-			   <13 0 &gpioi 8 0>,	/* D7 */
-			   <14 0 &gpioe 3 0>,	/* D8 */
-			   <15 0 &gpioh 15 0>,	/* D9 */
-			   <16 0 &gpiob 4 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpioi 2 0>,	/* D12 */
-			   <19 0 &gpiod 3 0>,	/* D13 */
-			   <20 0 &gpiod 13 0>,	/* D14 */
-			   <21 0 &gpiod 12 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiof 8 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiog 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiok 1 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 6 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioi 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioe 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioh 15 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioi 2 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiod 3 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
 	};
 };
 

--- a/boards/st/stm32h7b3i_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h7b3i_dk/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 4 0>,	/* A0 */
-			   <1 0 &gpioc 4 0>,	/* A1 */
-			   <2 0 &gpioa 0 0>,	/* A2 */
-			   <3 0 &gpioa 1 0>,	/* A3 */
-			   <4 0 &gpioc 2 0>,	/* A4 */
-			   <5 0 &gpioc 3 0>,	/* A5 */
-			   <6 0 &gpioh 14 0>,	/* D0 */
-			   <7 0 &gpioh 13 0>,	/* D1 */
-			   <8 0 &gpioi 9 0>,	/* D2 */
-			   <9 0 &gpioh 9 0>,	/* D3 */
-			   <10 0 &gpioe 2 0>,	/* D4 */
-			   <11 0 &gpioh 11 0>,	/* D5 */
-			   <12 0 &gpioh 10 0>,	/* D6 */
-			   <13 0 &gpioi 10 0>,	/* D7 */
-			   <14 0 &gpiof 10 0>,	/* D8 */
-			   <15 0 &gpioi 7 0>,	/* D9 */
-			   <16 0 &gpioi 0 0>,	/* D10 */
-			   <17 0 &gpiob 15 0>,	/* D11 */
-			   <18 0 &gpiob 14 0>,	/* D12 */
-			   <19 0 &gpioa 12 0>,	/* D13 */
-			   <20 0 &gpiod 13 0>,	/* D14 */
-			   <21 0 &gpiod 12 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioh 14 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioh 13 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioi 9 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioh 9 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 2 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioh 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioh 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioi 10 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioi 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioi 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiod 12 0>;
 	};
 };
 

--- a/boards/st/stm32h7s78_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32h7s78_dk/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioc 0 0>,	/* A0 */
-			   <1 0 &gpioc 2 0>,	/* A1 */
-			   <2 0 &gpioc 3 0>,	/* A2 */
-			   <3 0 &gpiof 12 0>,	/* A3 */
-			   <4 0 &gpiof 13 0>,	/* A4 */
-			   <5 0 &gpioc 1 0>,	/* A5 */
-			   <6 0 &gpioe 7 0>,	/* D0 */
-			   <7 0 &gpioe 8 0>,	/* D1 */
-			   <8 0 &gpiof 1 0>,	/* D2 */
-			   <9 0 &gpiod 12 0>,	/* D3 */
-			   <10 0 &gpiof 2 0>,	/* D4 */
-			   <11 0 &gpiod 13 0>,	/* D5 */
-			   <12 0 &gpiod 15 0>,	/* D6 */
-			   <13 0 &gpiof 3 0>,	/* D7 */
-			   <14 0 &gpiof 4 0>,	/* D8 */
-			   <15 0 &gpiof 6 0>,	/* D9 */
-			   <16 0 &gpiof 8 0>,	/* D10 */
-			   <17 0 &gpioe 14 0>,	/* D11 */
-			   <18 0 &gpioe 13 0>,	/* D12 */
-			   <19 0 &gpioe 12 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioc 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 13 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioe 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioe 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiof 1 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiod 12 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 2 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiof 4 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiof 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpiof 8 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioe 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/stm32l496g_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32l496g_disco/arduino_r3_connector.dtsi
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
@@ -11,28 +13,28 @@
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
 		gpio-map =
-			<0 0 &gpioc 4 0>,    /* A0 */
-			<1 0 &gpioc 1 0>,    /* A1 */
-			<2 0 &gpioc 3 0>,    /* A2 */
-			<3 0 &gpiof 10 0>,   /* A3 */
-			<4 0 &gpioa 1 0>,    /* A4 */
-			<5 0 &gpioc 0 0>,    /* A5 */
-			<6 0 &gpiog 8 0>,    /* D0 */
-			<7 0 &gpiog 7 0>,    /* D1 */
-			<8 0 &gpiog 13 0>,   /* D2 */
-			<9 0 &gpioh 15 0>,   /* D3 */
-			<10 0 &gpioi 11 0>,  /* D4 */
-			<11 0 &gpiob 9 0>,   /* D5 */
-			<12 0 &gpioi 6 0>,   /* D6 */
-			<13 0 &gpiog 6 0>,   /* D7 */
-			<14 0 &gpiog 15 0>,  /* D8 */
-			<15 0 &gpioh 13 0>,  /* D9 */
-			<16 0 &gpioa 15 0>,  /* D10 */
-			<17 0 &gpiob 5 0>,   /* D11 */
-			<18 0 &gpiob 4 0>,   /* D12 */
-			<19 0 &gpioa 5 0>,   /* D13 */
-			<20 0 &gpiob 7 0>,   /* D14 */
-			<21 0 &gpiob 8 0>;   /* D15 */
+			<ARDUINO_HEADER_R3_A0 0 &gpioc 4 0>,
+			<ARDUINO_HEADER_R3_A1 0 &gpioc 1 0>,
+			<ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+			<ARDUINO_HEADER_R3_A3 0 &gpiof 10 0>,
+			<ARDUINO_HEADER_R3_A4 0 &gpioa 1 0>,
+			<ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			<ARDUINO_HEADER_R3_D0 0 &gpiog 8 0>,
+			<ARDUINO_HEADER_R3_D1 0 &gpiog 7 0>,
+			<ARDUINO_HEADER_R3_D2 0 &gpiog 13 0>,
+			<ARDUINO_HEADER_R3_D3 0 &gpioh 15 0>,
+			<ARDUINO_HEADER_R3_D4 0 &gpioi 11 0>,
+			<ARDUINO_HEADER_R3_D5 0 &gpiob 9 0>,
+			<ARDUINO_HEADER_R3_D6 0 &gpioi 6 0>,
+			<ARDUINO_HEADER_R3_D7 0 &gpiog 6 0>,
+			<ARDUINO_HEADER_R3_D8 0 &gpiog 15 0>,
+			<ARDUINO_HEADER_R3_D9 0 &gpioh 13 0>,
+			<ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			<ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			<ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
+			<ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			<ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			<ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/st/stm32l4r9i_disco/arduino_r3_connector.dtsi
+++ b/boards/st/stm32l4r9i_disco/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 7 0>,		/* A0 */
-				<1 0 &gpioc 4 0>,	/* A1 */
-				<2 0 &gpioc 3 0>,	/* A2 */
-				<3 0 &gpiob 0 0>,	/* A3 */
-				<4 0 &gpioa 0 0>,	/* A4 */
-				<5 0 &gpioa 5 0>,	/* A5 */
-				<6 0 &gpioc 0 0>,	/* D0 */
-				<7 0 &gpioc 1 0>,	/* D1 */
-				<8 0 &gpiog 11 0>,	/* D2 */
-				<9 0 &gpiof 10 0>,	/* D3 */
-				<10 0 &gpiog 6 0>,	/* D4 */
-				<11 0 &gpioa 1 0>,	/* D5 */
-				<12 0 &gpiob 4 0>,	/* D6 */
-				<13 0 &gpioa 4 0>,	/* D7 */
-				<14 0 &gpioh 15 0>,	/* D8 */
-				<15 0 &gpioh 13 0>,	/* D9 */
-				<16 0 &gpioi 0 0>,	/* D10 */
-				<17 0 &gpiob 15 0>,	/* D11 */
-				<18 0 &gpiob 14 0>,	/* D12 */
-				<19 0 &gpiob 13 0>,	/* D13 */
-				<20 0 &gpiog 8 0>,	/* D14 */
-				<21 0 &gpiog 7 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 7 0>,
+				<ARDUINO_HEADER_R3_A1 0 &gpioc 4 0>,
+				<ARDUINO_HEADER_R3_A2 0 &gpioc 3 0>,
+				<ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+				<ARDUINO_HEADER_R3_A4 0 &gpioa 0 0>,
+				<ARDUINO_HEADER_R3_A5 0 &gpioa 5 0>,
+				<ARDUINO_HEADER_R3_D0 0 &gpioc 0 0>,
+				<ARDUINO_HEADER_R3_D1 0 &gpioc 1 0>,
+				<ARDUINO_HEADER_R3_D2 0 &gpiog 11 0>,
+				<ARDUINO_HEADER_R3_D3 0 &gpiof 10 0>,
+				<ARDUINO_HEADER_R3_D4 0 &gpiog 6 0>,
+				<ARDUINO_HEADER_R3_D5 0 &gpioa 1 0>,
+				<ARDUINO_HEADER_R3_D6 0 &gpiob 4 0>,
+				<ARDUINO_HEADER_R3_D7 0 &gpioa 4 0>,
+				<ARDUINO_HEADER_R3_D8 0 &gpioh 15 0>,
+				<ARDUINO_HEADER_R3_D9 0 &gpioh 13 0>,
+				<ARDUINO_HEADER_R3_D10 0 &gpioi 0 0>,
+				<ARDUINO_HEADER_R3_D11 0 &gpiob 15 0>,
+				<ARDUINO_HEADER_R3_D12 0 &gpiob 14 0>,
+				<ARDUINO_HEADER_R3_D13 0 &gpiob 13 0>,
+				<ARDUINO_HEADER_R3_D14 0 &gpiog 8 0>,
+				<ARDUINO_HEADER_R3_D15 0 &gpiog 7 0>;
 	};
 };
 

--- a/boards/st/stm32l562e_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32l562e_dk/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpioa 5 0>,	/* A3 */
-			   <4 0 &gpioc 4 0>,	/* A4 */
-			   <5 0 &gpioc 5 0>,	/* A5 */
-			   <6 0 &gpiob 10 0>,	/* D0 */
-			   <7 0 &gpiob 11 0>,	/* D1 */
-			   <8 0 &gpiod 11 0>,	/* D2 */
-			   <9 0 &gpiod 12 0>,	/* D3 */
-			   <10 0 &gpiof 4 0>,	/* D4 */
-			   <11 0 &gpiod 13 0>,	/* D5 */
-			   <12 0 &gpiob 8 0>,	/* D6 */
-			   <13 0 &gpioc 6 0>,	/* D7 */
-			   <14 0 &gpiog 0 0>,	/* D8 */
-			   <15 0 &gpiob 9 0>,	/* D9 */
-			   <16 0 &gpioe 0 0>,	/* D10 */
-			   <17 0 &gpiob 5 0>,	/* D11 */
-			   <18 0 &gpiob 4 0>,	/* D12 */
-			   <19 0 &gpiog 9 0>,	/* D13 */
-			   <20 0 &gpiob 7 0>,	/* D14 */
-			   <21 0 &gpiob 6 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 4 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 5 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiob 11 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 11 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiod 12 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiof 4 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiod 13 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 8 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioc 6 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 0 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioe 0 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpiog 9 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 7 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 6 0>;
 	};
 };
 

--- a/boards/st/stm32mp157c_dk2/arduino_r3_connector.dtsi
+++ b/boards/st/stm32mp157c_dk2/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpiof 14 0>,	/* A0 */
-			   <1 0 &gpiof 13 0>,	/* A1 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpiof 14 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpiof 13 0>,
 			   /* ANA0 is not a GPIO   A2 */
 			   /* ANA1 is not a GPIO   A3 */
-			   <4 0 &gpioc 3 0>,	/* A4 */
-			   <5 0 &gpiof 12 0>,	/* A5 */
-			   <6 0 &gpioe 7 0>,	/* D0 */
-			   <7 0 &gpioe 8 0>,	/* D1 */
-			   <8 0 &gpioe 1 0>,	/* D2 */
-			   <9 0 &gpiod 14 0>,	/* D3 */
-			   <10 0 &gpioe 10 0>,	/* D4 */
-			   <11 0 &gpiod 15 0>,	/* D5 */
-			   <12 0 &gpioe 9 0>,	/* D6 */
-			   <13 0 &gpiod 1 0>,	/* D7 */
-			   <14 0 &gpiog 3 0>,	/* D8 */
-			   <15 0 &gpioh 6 0>,	/* D9 */
-			   <16 0 &gpioe 11 0>,	/* D10 */
-			   <17 0 &gpioe 14 0>,	/* D11 */
-			   <18 0 &gpioe 13 0>,	/* D12 */
-			   <19 0 &gpioe 12 0>,	/* D13 */
-			   <20 0 &gpioa 12 0>,	/* D14 */
-			   <21 0 &gpioa 11 0>;	/* D15 */
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiof 12 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioe 7 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioe 8 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioe 1 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiod 14 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioe 10 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiod 15 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiod 1 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpiog 3 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioh 6 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioe 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioe 12 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioa 11 0>;
 	};
 };
 

--- a/boards/st/stm32n6570_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32n6570_dk/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 5 0>,	/* A0 */
-			   <1 0 &gpioa 9 0>,	/* A1 */
-			   <2 0 &gpioa 10 0>,	/* A2 */
-			   <3 0 &gpioa 12 0>,	/* A3 */
-			   <4 0 &gpiof 3 0>,	/* A4 */
-			   <5 0 &gpiob 10 0>,	/* A5 */
-			   <6 0 &gpiof 6 0>,	/* D0 */
-			   <7 0 &gpiod 5 0>,	/* D1 */
-			   <8 0 &gpiod 0 0>,	/* D2 */
-			   <9 0 &gpioe 9 0>,	/* D3 */
-			   <10 0 &gpioh 5 0>,	/* D4 */
-			   <11 0 &gpioe 10 0>,	/* D5 */
-			   <12 0 &gpioe 13 0>,	/* D6 */
-			   <13 0 &gpiod 6 0>,	/* D7 */
-			   <14 0 &gpioe 7 0>,	/* D8 */
-			   <15 0 &gpioe 14 0>,	/* D9 */
-			   <16 0 &gpioa 3 0>,	/* D10 */
-			   <17 0 &gpiog 2 0>,	/* D11 */
-			   <18 0 &gpioh 8 0>,	/* D12 */
-			   <19 0 &gpioe 15 0>,	/* D13 */
-			   <20 0 &gpioc 1 0>,	/* D14 */
-			   <21 0 &gpioh 9 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 10 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpioa 12 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpiof 3 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpiof 6 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpiod 5 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpiod 0 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpioe 9 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpioh 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpioe 10 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpioe 13 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpiod 6 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioe 7 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioe 14 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpiog 2 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioh 8 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioe 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpioh 9 0>;
 	};
 };
 

--- a/boards/st/stm32u083c_dk/arduino_r3_connector.dtsi
+++ b/boards/st/stm32u083c_dk/arduino_r3_connector.dtsi
@@ -4,34 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
+
 / {
 	arduino_header: connector {
 		compatible = "arduino-header-r3";
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpioa 0 0>,	/* A0 */
-			   <1 0 &gpioa 1 0>,	/* A1 */
-			   <2 0 &gpioa 4 0>,	/* A2 */
-			   <3 0 &gpiob 0 0>,	/* A3 */
-			   <4 0 &gpioc 1 0>,	/* A4 */
-			   <5 0 &gpioc 0 0>,	/* A5 */
-			   <6 0 &gpioa 3 0>,	/* D0 */
-			   <7 0 &gpioa 2 0>,	/* D1 */
-			   <8 0 &gpioc 12 0>,	/* D2 */
-			   <9 0 &gpiob 3 0>,	/* D3 */
-			   <10 0 &gpiob 5 0>,	/* D4 */
-			   <11 0 &gpiob 4 0>,	/* D5 */
-			   <12 0 &gpiob 10 0>,	/* D6 */
-			   <13 0 &gpioa 8 0>,	/* D7 */
-			   <14 0 &gpioa 9 0>,	/* D8 */
-			   <15 0 &gpioc 7 0>,	/* D9 */
-			   <16 0 &gpioa 15 0>,	/* D10 */
-			   <17 0 &gpioa 7 0>,	/* D11 */
-			   <18 0 &gpioa 6 0>,	/* D12 */
-			   <19 0 &gpioa 5 0>,	/* D13 */
-			   <20 0 &gpiob 9 0>,	/* D14 */
-			   <21 0 &gpiob 8 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpioa 0 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpioa 1 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpioa 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpiob 0 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpioc 1 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpioc 0 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpioa 3 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpioa 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpioc 12 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpiob 3 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpiob 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpiob 4 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpiob 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpioa 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpioa 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpioc 7 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpioa 15 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpioa 7 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpioa 6 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpioa 5 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpiob 9 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpiob 8 0>;
 	};
 };
 

--- a/boards/u-blox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts
+++ b/boards/u-blox/ubx_bmd300eval/ubx_bmd300eval_nrf52832.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf52832_qfaa.dtsi>
 #include "ubx_bmd300eval_nrf52832-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -80,28 +81,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio0 11 0>,	/* D0 */
-			   <7 0 &gpio0 12 0>,	/* D1 */
-			   <8 0 &gpio0 13 0>,	/* D2 */
-			   <9 0 &gpio0 14 0>,	/* D3 */
-			   <10 0 &gpio0 15 0>,	/* D4 */
-			   <11 0 &gpio0 16 0>,	/* D5 */
-			   <12 0 &gpio0 17 0>,	/* D6 */
-			   <13 0 &gpio0 18 0>,	/* D7 */
-			   <14 0 &gpio0 19 0>,	/* D8 */
-			   <15 0 &gpio0 20 0>,	/* D9 */
-			   <16 0 &gpio0 22 0>,	/* D10 */
-			   <17 0 &gpio0 23 0>,	/* D11 */
-			   <18 0 &gpio0 24 0>,	/* D12 */
-			   <19 0 &gpio0 25 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts
+++ b/boards/u-blox/ubx_bmd330eval/ubx_bmd330eval_nrf52810.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf52810_qfaa.dtsi>
 #include "ubx_bmd330eval_nrf52810-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -80,28 +81,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio0 11 0>,	/* D0 */
-			   <7 0 &gpio0 12 0>,	/* D1 */
-			   <8 0 &gpio0 13 0>,	/* D2 */
-			   <9 0 &gpio0 14 0>,	/* D3 */
-			   <10 0 &gpio0 15 0>,	/* D4 */
-			   <11 0 &gpio0 16 0>,	/* D5 */
-			   <12 0 &gpio0 17 0>,	/* D6 */
-			   <13 0 &gpio0 18 0>,	/* D7 */
-			   <14 0 &gpio0 19 0>,	/* D8 */
-			   <15 0 &gpio0 20 0>,	/* D9 */
-			   <16 0 &gpio0 22 0>,	/* D10 */
-			   <17 0 &gpio0 23 0>,	/* D11 */
-			   <18 0 &gpio0 24 0>,	/* D12 */
-			   <19 0 &gpio0 25 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts
+++ b/boards/u-blox/ubx_bmd340eval/ubx_bmd340eval_nrf52840.dts
@@ -9,6 +9,7 @@
 #include <nordic/nrf52840_qiaa.dtsi>
 #include <nordic/nrf52840_partition.dtsi>
 #include "ubx_bmd340eval_nrf52840-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -80,28 +81,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio1 1 0>,	/* D0 */
-			   <7 0 &gpio1 2 0>,	/* D1 */
-			   <8 0 &gpio1 3 0>,	/* D2 */
-			   <9 0 &gpio1 4 0>,	/* D3 */
-			   <10 0 &gpio1 5 0>,	/* D4 */
-			   <11 0 &gpio1 6 0>,	/* D5 */
-			   <12 0 &gpio1 7 0>,	/* D6 */
-			   <13 0 &gpio1 8 0>,	/* D7 */
-			   <14 0 &gpio1 10 0>,	/* D8 */
-			   <15 0 &gpio1 11 0>,	/* D9 */
-			   <16 0 &gpio1 12 0>,	/* D10 */
-			   <17 0 &gpio1 13 0>,	/* D11 */
-			   <18 0 &gpio1 14 0>,	/* D12 */
-			   <19 0 &gpio1 15 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 2 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio1 4 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio1 6 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
+++ b/boards/u-blox/ubx_bmd345eval/ubx_bmd345eval_nrf52840.dts
@@ -10,6 +10,7 @@
 #include <nordic/nrf52840_qiaa.dtsi>
 #include <nordic/nrf52840_partition.dtsi>
 #include "ubx_bmd345eval_nrf52840-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -81,28 +82,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,    /* A0 */
-			<1 0 &gpio0 4 0>,    /* A1 */
-			<2 0 &gpio0 28 0>,   /* A2 */
-			<3 0 &gpio0 29 0>,   /* A3 */
-			<4 0 &gpio0 30 0>,   /* A4 */
-			<5 0 &gpio0 31 0>,   /* A5 */
-			<6 0 &gpio1 1 0>,    /* D0 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			<ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			<ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			<ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			<ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			<ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			<ARDUINO_HEADER_R3_D0 0 &gpio1 1 0>,
 			/* not present */    /* D1 */
-			<8 0 &gpio1 3 0>,    /* D2 */
+			<ARDUINO_HEADER_R3_D2 0 &gpio1 3 0>,
 			/* not present */    /* D3 */
 			/* not present */    /* D4 */
 			/* not present */    /* D5 */
-			<12 0 &gpio1 7 0>,   /* D6 */
-			<13 0 &gpio1 8 0>,   /* D7 */
-			<14 0 &gpio1 10 0>,  /* D8 */
-			<15 0 &gpio1 11 0>,  /* D9 */
-			<16 0 &gpio1 12 0>,  /* D10 */
-			<17 0 &gpio1 13 0>,  /* D11 */
-			<18 0 &gpio1 14 0>,  /* D12 */
-			<19 0 &gpio1 15 0>,  /* D13 */
-			<20 0 &gpio0 26 0>,  /* D14 */
-			<21 0 &gpio0 27 0>;  /* D15 */
+			<ARDUINO_HEADER_R3_D6 0 &gpio1 7 0>,
+			<ARDUINO_HEADER_R3_D7 0 &gpio1 8 0>,
+			<ARDUINO_HEADER_R3_D8 0 &gpio1 10 0>,
+			<ARDUINO_HEADER_R3_D9 0 &gpio1 11 0>,
+			<ARDUINO_HEADER_R3_D10 0 &gpio1 12 0>,
+			<ARDUINO_HEADER_R3_D11 0 &gpio1 13 0>,
+			<ARDUINO_HEADER_R3_D12 0 &gpio1 14 0>,
+			<ARDUINO_HEADER_R3_D13 0 &gpio1 15 0>,
+			<ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			<ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts
+++ b/boards/u-blox/ubx_bmd360eval/ubx_bmd360eval_nrf52811.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf52811_qfaa.dtsi>
 #include "ubx_bmd360eval_nrf52811-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -80,28 +81,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 4 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio0 11 0>,	/* D0 */
-			   <7 0 &gpio0 12 0>,	/* D1 */
-			   <8 0 &gpio0 13 0>,	/* D2 */
-			   <9 0 &gpio0 14 0>,	/* D3 */
-			   <10 0 &gpio0 15 0>,	/* D4 */
-			   <11 0 &gpio0 16 0>,	/* D5 */
-			   <12 0 &gpio0 17 0>,	/* D6 */
-			   <13 0 &gpio0 18 0>,	/* D7 */
-			   <14 0 &gpio0 19 0>,	/* D8 */
-			   <15 0 &gpio0 20 0>,	/* D9 */
-			   <16 0 &gpio0 22 0>,	/* D10 */
-			   <17 0 &gpio0 23 0>,	/* D11 */
-			   <18 0 &gpio0 24 0>,	/* D12 */
-			   <19 0 &gpio0 25 0>,	/* D13 */
-			   <20 0 &gpio0 26 0>,	/* D14 */
-			   <21 0 &gpio0 27 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 17 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 24 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 25 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 27 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkannab1/ubx_evkannab1_nrf52832.dts
+++ b/boards/u-blox/ubx_evkannab1/ubx_evkannab1_nrf52832.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf52832_qfaa.dtsi>
 #include "ubx_evkannab1_nrf52832-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -77,28 +78,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 5 0>,	/* A1 */
-			   <2 0 &gpio0 28 0>,	/* A2 */
-			   <3 0 &gpio0 29 0>,	/* A3 */
-			   <4 0 &gpio0 30 0>,	/* A4 */
-			   <5 0 &gpio0 31 0>,	/* A5 */
-			   <6 0 &gpio0 2 0>,	/* D0 */
-			   <7 0 &gpio0 3 0>,	/* D1 */
-			   <8 0 &gpio0 19 0>,	/* D2 */
-			   <9 0 &gpio0 11 0>,	/* D3 */
-			   <10 0 &gpio0 27 0>,	/* D4 */
-			   <11 0 &gpio0 26 0>,	/* D5 */
-			   <12 0 &gpio0 10 0>,	/* D6 */
-			   <13 0 &gpio0 9 0>,	/* D7 */
-			   <14 0 &gpio0 14 0>,	/* D8 */
-			   <15 0 &gpio0 24 0>,	/* D9 */
-			   <16 0 &gpio0 22 0>,	/* D10 */
-			   <17 0 &gpio0 23 0>,	/* D11 */
-			   <18 0 &gpio0 18 0>,	/* D12 */
-			   <19 0 &gpio0 20 0>,	/* D13 */
-			   <20 0 &gpio0 15 0>,	/* D14 */
-			   <21 0 &gpio0 16 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 19 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 27 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 26 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 24 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 22 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 18 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 20 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 16 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkninab1/ubx_evkninab1_nrf52832.dts
+++ b/boards/u-blox/ubx_evkninab1/ubx_evkninab1_nrf52832.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf52832_qfaa.dtsi>
 #include "ubx_evkninab1_nrf52832-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -77,28 +78,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 3 0>,	/* A0 */
-			   <1 0 &gpio0 2 0>,	/* A1 */
-			   <2 0 &gpio0 4 0>,	/* A2 */
-			   <3 0 &gpio0 30 0>,	/* A3 */
-			   <4 0 &gpio0 29 0>,	/* A4 */
-			   <5 0 &gpio0 28 0>,	/* A5 */
-			   <6 0 &gpio0 5 0>,	/* D0 */
-			   <7 0 &gpio0 6 0>,	/* D1 */
-			   <8 0 &gpio0 7 0>,	/* D2 */
-			   <9 0 &gpio0 31 0>,	/* D3 */
-			   <10 0 &gpio0 18 0>,	/* D4 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio0 6 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 18 0>,
 			   /* 11 SWDIO */		/* D5 */
-			   <12 0 &gpio0 9 0>,	/* D6 */
-			   <13 0 &gpio0 10 0>,	/* D7 */
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 10 0>,
 			   /* 14 SWDCLK */		/* D8 */
-			   <15 0 &gpio0 8 0>,	/* D9 */
-			   <16 0 &gpio0 11 0>,	/* D10 */
-			   <17 0 &gpio0 13 0>,	/* D11 */
-			   <18 0 &gpio0 12 0>,	/* D12 */
-			   <19 0 &gpio0 14 0>,	/* D13 */
-			   <20 0 &gpio0 2 0>,	/* D14 */
-			   <21 0 &gpio0 3 0>;	/* D15 */
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 8 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 3 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.dts
+++ b/boards/u-blox/ubx_evkninab3/ubx_evkninab3_nrf52840.dts
@@ -8,6 +8,7 @@
 #include <nordic/nrf52840_qiaa.dtsi>
 #include <nordic/nrf52840_partition.dtsi>
 #include "ubx_evkninab3_nrf52840-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -71,28 +72,28 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 04 0>,	/* A0 */
-			   <1 0 &gpio0 30 0>,	/* A1 */
-			   <2 0 &gpio0 5 0>,	/* A2 */
-			   <3 0 &gpio0 2 0>,	/* A3 */
-			   <4 0 &gpio0 28 0>,	/* A4 */
-			   <5 0 &gpio0 3 0>,	/* A5 */
-			   <6 0 &gpio0 29 0>,	/* D0 */
-			   <7 0 &gpio1 13 0>,	/* D1 */
-			   <8 0 &gpio1 12 0>,	/* D2 */
-			   <9 0 &gpio0 31 0>,	/* D3 */
-			   <10 0 &gpio0 13 0>,	/* D4 */
-			   <11 0 &gpio0 11 0>,	/* D5 */
-			   <12 0 &gpio0 9 0>,	/* D6 */
-			   <13 0 &gpio0 10 0>,	/* D7 */
-			   <14 0 &gpio1 9 0>,	/* D8 */
-			   <15 0 &gpio0 12 0>,	/* D9 */
-			   <16 0 &gpio0 14 0>,	/* D10 */
-			   <17 0 &gpio0 15 0>,	/* D11 */
-			   <18 0 &gpio1 0 0>,	/* D12 */
-			   <19 0 &gpio0 7 0>,	/* D13 */
-			   <20 0 &gpio0 16 0>,	/* D14 */
-			   <21 0 &gpio0 24 0>;	/* D15 */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 04 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 13 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio1 12 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 9 0>,
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 10 0>,
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 12 0>,
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 14 0>,
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 15 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 16 0>,
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 24 0>;
 	};
 
 	arduino_adc: analog-connector {

--- a/boards/u-blox/ubx_evkninab4/ubx_evkninab4_nrf52833.dts
+++ b/boards/u-blox/ubx_evkninab4/ubx_evkninab4_nrf52833.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <nordic/nrf52833_qiaa.dtsi>
 #include "ubx_evkninab4_nrf52833-pinctrl.dtsi"
+#include <zephyr/dt-bindings/gpio/arduino-header-r3.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {
@@ -78,28 +79,30 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <0 0 &gpio0 4 0>,	/* A0 */
-			   <1 0 &gpio0 30 0>,	/* A1 */
-			   <2 0 &gpio0 5 0>,	/* A2 */
-			   <3 0 &gpio0 2 0>,	/* A3 */
-			   <4 0 &gpio0 28 0>,	/* A4 */
-			   <5 0 &gpio0 3 0>,	/* A5 */
-			   <6 0 &gpio0 29 0>,	/* D0 */
-			   <7 0 &gpio1 5 0>,	/* D1 */
-			   <8 0 &gpio0 23 0>,	/* D2 */
-			   <9 0 &gpio0 31 0>,	/* D3 */
-			   <10 0 &gpio0 13 0>,	/* D4 */
-			   <11 0 &gpio0 11 0>,	/* D5 */
-			   <12 0 &gpio0 9 0>,	/* D6 */ /* NFC use by default */
-			   <13 0 &gpio0 10 0>,	/* D7 */ /* NFC use by default */
-			   <14 0 &gpio1 9 0>,	/* D8 */
-			   <15 0 &gpio0 12 0>,	/* D9 */
-			   <16 0 &gpio0 0 0>,	/* D10 */ /* Disconnected, see EVK User Guide */
-			   <17 0 &gpio0 1 0>,	/* D11 */ /* Disconnected, see EVK User Guide */
-			   <18 0 &gpio1 0 0>,	/* D12 */
-			   <19 0 &gpio0 7 0>,	/* D13 */
-			   <20 0 &gpio0 16 0>,	/* D14 */  /* SDA */
-			   <21 0 &gpio0 17 0>;	/* D15 */  /* SCL */
+		gpio-map = <ARDUINO_HEADER_R3_A0 0 &gpio0 4 0>,
+			   <ARDUINO_HEADER_R3_A1 0 &gpio0 30 0>,
+			   <ARDUINO_HEADER_R3_A2 0 &gpio0 5 0>,
+			   <ARDUINO_HEADER_R3_A3 0 &gpio0 2 0>,
+			   <ARDUINO_HEADER_R3_A4 0 &gpio0 28 0>,
+			   <ARDUINO_HEADER_R3_A5 0 &gpio0 3 0>,
+			   <ARDUINO_HEADER_R3_D0 0 &gpio0 29 0>,
+			   <ARDUINO_HEADER_R3_D1 0 &gpio1 5 0>,
+			   <ARDUINO_HEADER_R3_D2 0 &gpio0 23 0>,
+			   <ARDUINO_HEADER_R3_D3 0 &gpio0 31 0>,
+			   <ARDUINO_HEADER_R3_D4 0 &gpio0 13 0>,
+			   <ARDUINO_HEADER_R3_D5 0 &gpio0 11 0>,
+			   <ARDUINO_HEADER_R3_D6 0 &gpio0 9 0>, /* NFC use by default */
+			   <ARDUINO_HEADER_R3_D7 0 &gpio0 10 0>, /* NFC use by default */
+			   <ARDUINO_HEADER_R3_D8 0 &gpio1 9 0>,
+			   <ARDUINO_HEADER_R3_D9 0 &gpio0 12 0>,
+			   /* D10 is disconnected, see EVK User Guide */
+			   <ARDUINO_HEADER_R3_D10 0 &gpio0 0 0>,
+			   /* D11 is disconnected, see EVK User Guide */
+			   <ARDUINO_HEADER_R3_D11 0 &gpio0 1 0>,
+			   <ARDUINO_HEADER_R3_D12 0 &gpio1 0 0>,
+			   <ARDUINO_HEADER_R3_D13 0 &gpio0 7 0>,
+			   <ARDUINO_HEADER_R3_D14 0 &gpio0 16 0>,  /* SDA */
+			   <ARDUINO_HEADER_R3_D15 0 &gpio0 17 0>;  /* SCL */
 	};
 
 	arduino_adc: analog-connector {


### PR DESCRIPTION
Use `ARDUINO_HEADER_R3_*` macros, as those are much more readable and less
error prone.