### PR TITLE
linker: Split nocache memory sections into loadable and non-loadable

### DIFF
--- a/arch/common/nocache.ld
+++ b/arch/common/nocache.ld
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2025 Basalte bv
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,14 +9,15 @@
 /* Copied from linker.ld */
 
 /* Non-cached region of RAM */
-SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,,)
+SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 {
 #if defined(CONFIG_MMU)
 	MMU_ALIGN;
 #else
-	MPU_ALIGN(_nocache_ram_size);
+	MPU_ALIGN(_nocache_noload_ram_size);
 #endif
 	_nocache_ram_start = .;
+	_nocache_noload_ram_start = .;
 	*(.nocache)
 	*(".nocache.*")
 
@@ -24,9 +26,32 @@ SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,,)
 #if defined(CONFIG_MMU)
 	MMU_ALIGN;
 #else
-	MPU_ALIGN(_nocache_ram_size);
+	MPU_ALIGN(_nocache_noload_ram_size);
 #endif
+	_nocache_noload_ram_end = .;
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+_nocache_noload_ram_size = _nocache_noload_ram_end - _nocache_noload_ram_start;
+
+/* Non-cached loadable region of RAM and ROM */
+SECTION_DATA_PROLOGUE(_NOCACHE_LOAD_SECTION_NAME,,)
+{
+#if defined(CONFIG_MMU)
+	MMU_ALIGN;
+#else
+	MPU_ALIGN(_nocache_load_ram_size);
+#endif
+	_nocache_load_ram_start = .;
+	*(.nocache_load)
+	*(".nocache_load.*")
+
+#if defined(CONFIG_MMU)
+	MMU_ALIGN;
+#else
+	MPU_ALIGN(_nocache_load_ram_size);
+#endif
+	_nocache_load_ram_end = .;
 	_nocache_ram_end = .;
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+_nocache_load_ram_size = _nocache_load_ram_end - _nocache_load_ram_start;
+_nocache_load_rom_start = LOADADDR(_NOCACHE_LOAD_SECTION_NAME);
 _nocache_ram_size = _nocache_ram_end - _nocache_ram_start;
-_nocache_load_start = LOADADDR(_NOCACHE_SECTION_NAME);

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -246,14 +246,21 @@ extern char __sg_size[];
  * with a MPU. Start and end will be aligned for memory management/protection
  * hardware for the target architecture.
  *
- * All the functions with '__nocache' keyword will be placed into this
- * section.
+ * All the variables with '__nocache' keyword will be placed into the nocache
+ * section, variables with '__nocache_load' keyword will be placed into the
+ * nocache section that is loaded from ROM.
  */
 #ifdef CONFIG_NOCACHE_MEMORY
 extern char _nocache_ram_start[];
 extern char _nocache_ram_end[];
 extern char _nocache_ram_size[];
-extern char _nocache_load_start[];
+extern char _nocache_noload_ram_start[];
+extern char _nocache_noload_ram_end[];
+extern char _nocache_noload_ram_size[];
+extern char _nocache_load_ram_start[];
+extern char _nocache_load_ram_end[];
+extern char _nocache_load_ram_size[];
+extern char _nocache_load_rom_start[];
 #endif /* CONFIG_NOCACHE_MEMORY */
 
 /* Memory owned by the kernel. Start and end will be aligned for memory

--- a/include/zephyr/linker/section_tags.h
+++ b/include/zephyr/linker/section_tags.h
@@ -53,9 +53,11 @@
 
 #if defined(CONFIG_NOCACHE_MEMORY)
 #define __nocache __in_section_unique(_NOCACHE_SECTION_NAME)
+#define __nocache_load __in_section_unique(_NOCACHE_LOAD_SECTION_NAME)
 #define __nocache_noinit __nocache
 #else
 #define __nocache
+#define __nocache_load
 #define __nocache_noinit __noinit
 #endif /* CONFIG_NOCACHE_MEMORY */
 

--- a/include/zephyr/linker/sections.h
+++ b/include/zephyr/linker/sections.h
@@ -77,6 +77,7 @@
 
 #ifdef CONFIG_NOCACHE_MEMORY
 #define _NOCACHE_SECTION_NAME nocache
+#define _NOCACHE_LOAD_SECTION_NAME nocache_load
 #endif
 
 /* Symbol table section */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -248,9 +248,8 @@ void z_bss_zero(void)
 		       ((uintptr_t) &__gcov_bss_end - (uintptr_t) &__gcov_bss_start));
 #endif /* CONFIG_COVERAGE_GCOV */
 #ifdef CONFIG_NOCACHE_MEMORY
-z_early_memset(&_nocache_ram_start, 0,
-		   (uintptr_t) &_nocache_ram_end
-		   - (uintptr_t) &_nocache_ram_start);
+	z_early_memset(&_nocache_ram_start, 0,
+		       (uintptr_t)&_nocache_ram_end - (uintptr_t)&_nocache_ram_start);
 #endif
 }
 

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -33,8 +33,8 @@ void z_data_copy(void)
 #endif /* CONFIG_ARCH_HAS_RAMFUNC_SUPPORT */
 #ifdef CONFIG_ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 #if CONFIG_NOCACHE_MEMORY
-	z_early_memcpy(&_nocache_ram_start, &_nocache_load_start,
-		       (uintptr_t) &_nocache_ram_size);
+	z_early_memcpy(&_nocache_load_ram_start, &_nocache_load_rom_start,
+		       (uintptr_t) &_nocache_load_ram_size);
 #endif /* CONFIG_NOCACHE_MEMORY */
 #endif /* CONFIG_ARCH_HAS_NOCACHE_MEMORY_SUPPORT */
 #if DT_NODE_HAS_STATUS_OKAY(DT_CHOSEN(zephyr_ccm))


### PR DESCRIPTION
Commit f9168ae46409bb4a7908c48f4385cb3ac4bc6888 made all non-cached memory loadable by default.

However as nocache memory is typically used for reserving larger buffers to be shared between peripherals, this comes at fairly large cost towards ROM usage.

This commit creates two distinct sections for both loadable and non-loadable nocache memory sections.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/94812