### PR TITLE
net: include: icmp: fix doxygen group description

### DIFF
--- a/include/zephyr/net/icmp.h
+++ b/include/zephyr/net/icmp.h
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/** @file icmp.h
+/**
+ * @file icmp.h
+ * @brief Header file for ICMP protocol support.
+ * @ingroup icmp
  *
- * @brief ICMP sending and receiving.
- *
- * @defgroup icmp Send and receive IPv4 or IPv6 ICMP Echo Request messages.
+ * @defgroup icmp ICMP
+ * @brief Send and receive IPv4 or IPv6 ICMP (Internet Control Message Protocol)
+ *        Echo Request messages.
  * @since 3.5
  * @version 0.8.0
  * @ingroup networking


### PR DESCRIPTION
Group name was incorrectly used as a brief description ; used the opportunity to fully clean-up file and group definition