### PR TITLE
Fixed USB device serial state notification for Rx Carrier.

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -823,7 +823,7 @@ static int cdc_acm_line_ctrl_set(const struct device *dev,
 		if (val) {
 			dev_data->serial_state |= SERIAL_STATE_RX_CARRIER;
 		}
-		cdc_acm_send_notification(dev, SERIAL_STATE_RX_CARRIER);
+		cdc_acm_send_notification(dev, dev_data->serial_state);
 		return 0;
 	case USB_CDC_LINE_CTRL_DSR:
 		dev_data->serial_state &= ~SERIAL_STATE_TX_CARRIER;


### PR DESCRIPTION
Found a bug on line 826 in cdc_amc.c:

[zephyr/subsys/usb/device/class/cdc_acm.c](https://github.com/zephyrproject-rtos/zephyr/blob/c8ebe3ce6125af0de9e016d37caa64cf7f157d10/subsys/usb/device/class/cdc_acm.c#L826)

Line 826 in [c8ebe3c](https://github.com/zephyrproject-rtos/zephyr/commit/c8ebe3ce6125af0de9e016d37caa64cf7f157d10)
 cdc_acm_send_notification(dev, SERIAL_STATE_RX_CARRIER); 

The line should be:
cdc_acm_send_notification(dev, dev_data->serial_state);

As it is now, I can only set the Rx Carrier state and not clear it.