### PR TITLE
tests: drivers: uart: uart_error: Add missing pull up for nrf53

### DIFF
--- a/tests/drivers/uart/uart_errors/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/uart/uart_errors/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -3,8 +3,11 @@
 &pinctrl {
 	uart1_default_alt: uart1_default_alt {
 		group1 {
-			psels = <NRF_PSEL(UART_RX, 0, 4)>,
-				<NRF_PSEL(UART_RTS, 0, 6)>;
+			psels = <NRF_PSEL(UART_RX, 0, 4)>;
+				bias-pull-up;
+		};
+		group2 {
+			psels = <NRF_PSEL(UART_RTS, 0, 6)>;
 		};
 	};
 


### PR DESCRIPTION
Add missing pull up to the overlay file.