### PR TITLE
boards: amd: kv260_r5: update ttc0 clock frequency

### DIFF
--- a/boards/amd/kv260_r5/kv260_r5.dts
+++ b/boards/amd/kv260_r5/kv260_r5.dts
@@ -40,7 +40,7 @@
 
 &ttc0 {
 	status = "okay";
-	clock-frequency = <5000000>;
+	clock-frequency = <100000000>;
 };
 
 &psgpio {

--- a/soc/xlnx/zynqmp/Kconfig.defconfig
+++ b/soc/xlnx/zynqmp/Kconfig.defconfig
@@ -12,7 +12,7 @@ config NUM_IRQS
 	default 220
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 5000000
+	default $(dt_nodelabel_int_prop,ttc0,clock-frequency)
 
 endif # SOC_XILINX_ZYNQMP_RPU
 


### PR DESCRIPTION
Update TTC0 clock frequency to 100MHz to align with the 
Configurable Example Designs (CED) for kv260 board as used in Vivado
Earlier, it is wrongly configured as 5 MHz.