### PR TITLE
Bluetooth: Classic: SDP: Support ATTR ID list setting for SA/SSA REQ

### DIFF
--- a/include/zephyr/bluetooth/classic/sdp.h
+++ b/include/zephyr/bluetooth/classic/sdp.h
@@ -566,6 +566,30 @@ enum {
 	BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR,
 };
 
+/** Initializes SDP attribute ID range */
+#define BT_SDP_ATTR_ID_RANGE(beginning, ending) {(beginning), (ending)}
+
+/**
+ * @brief SDP attribute ID range
+ *
+ * If the beginning attribute ID is same with the ending attribute ID, the range represents a
+ * single attribute ID.
+ */
+struct bt_sdp_attribute_id_range {
+	/** Beginning attribute ID of the range */
+	uint16_t beginning;
+	/** Ending attribute ID of the range */
+	uint16_t ending;
+};
+
+/** @brief SDP attribute ID list for Service Attribute and Service Search Attribute transactions */
+struct bt_sdp_attribute_id_list {
+	/** Count of the SDP attribute ID range */
+	size_t count;
+	/** Attribute ID range array list */
+	struct bt_sdp_attribute_id_range *ranges;
+};
+
 /** @brief Main user structure used in SDP discovery of remote. */
 struct bt_sdp_discover_params {
 	sys_snode_t _node;
@@ -581,6 +605,13 @@ struct bt_sdp_discover_params {
 	struct net_buf_pool *pool;
 	/** Discover type */
 	uint8_t type;
+	/**
+	 * Attribute ID list for Service Attribute and Service Search Attribute transactions
+	 *
+	 * If the `ids` is NULL or `ids->count` is 0, the default range `(0x0000, 0xffff)` will
+	 * be used.
+	 */
+	struct bt_sdp_attribute_id_list *ids;
 };
 
 /** @brief Allows user to start SDP discovery session.
@@ -604,12 +635,14 @@ struct bt_sdp_discover_params {
  *  Service Attribute:             The SDP Client generates an
  *                                 SDP_SERVICE_ATTR_REQ to retrieve specified
  *                                 attribute values from a specific service
- *                                 record (`params->handle`).
+ *                                 record (`params->handle`). The AttributeIDList
+ *                                 is specified by `params->ids`.
  *  Service Search Attribute:      The SDP Client generates an
  *                                 SDP_SERVICE_SEARCH_ATTR_REQ to retrieve
  *                                 specified attribute values that match the
  *                                 service search pattern (`params->uuid`)
  *                                 given as the first parameter of the PDU.
+ *                                 The AttributeIDList is specified by `params->ids`.
  *
  * @param conn Object identifying connection to remote.
  * @param params SDP discovery parameters.

--- a/subsys/bluetooth/host/classic/sdp.c
+++ b/subsys/bluetooth/host/classic/sdp.c
@@ -1746,11 +1746,89 @@ static int sdp_client_ss_search(struct bt_sdp_client *session,
 	return bt_sdp_send(&session->chan.chan, buf, BT_SDP_SVC_SEARCH_REQ, session->tid);
 }
 
+static uint16_t sdp_client_get_attribute_id_list_len(struct bt_sdp_attribute_id_list *ids)
+{
+	uint16_t len = 0;
+
+	if (ids == NULL || ids->count == 0) {
+		return sizeof(uint8_t) + sizeof(uint32_t);
+	}
+
+	for (size_t i = 0; i < ids->count; i++) {
+		if (ids->ranges[i].beginning == ids->ranges[i].ending) {
+			len += sizeof(uint8_t) + sizeof(uint16_t);
+		} else {
+			len += sizeof(uint8_t) + sizeof(uint32_t);
+		}
+	}
+
+	return len;
+}
+
+static void sdp_client_add_attribute_id(struct net_buf *buf, struct bt_sdp_attribute_id_list *ids)
+{
+	uint16_t len;
+
+	len = sdp_client_get_attribute_id_list_len(ids);
+	/*
+	 * Sequence definition where data is sequence of elements and where
+	 * additional next byte points the size of elements within
+	 */
+	if (len > UINT8_MAX) {
+		net_buf_add_u8(buf, BT_SDP_SEQ16);
+		net_buf_add_be16(buf, len);
+	} else {
+		net_buf_add_u8(buf, BT_SDP_SEQ8);
+		net_buf_add_u8(buf, len);
+	}
+
+	if (ids == NULL || ids->count == 0) {
+		/* Data element definition for two following 16bits range elements */
+		net_buf_add_u8(buf, BT_SDP_UINT32);
+		/* Get all attributes. It enables filter out wanted only attributes */
+		net_buf_add_be16(buf, 0x0000);
+		net_buf_add_be16(buf, 0xffff);
+		return;
+	}
+
+	for (size_t i = 0; i < ids->count; i++) {
+		if (ids->ranges[i].beginning == ids->ranges[i].ending) {
+			/* Data element definition for one following 16bits range elements */
+			net_buf_add_u8(buf, BT_SDP_UINT16);
+			/* Get all attributes. It enables filter out wanted only attributes */
+			net_buf_add_be16(buf, ids->ranges[i].beginning);
+		} else {
+			/* Data element definition for two following 16bits range elements */
+			net_buf_add_u8(buf, BT_SDP_UINT32);
+			/* Get all attributes. It enables filter out wanted only attributes */
+			net_buf_add_be16(buf, ids->ranges[i].beginning);
+			net_buf_add_be16(buf, ids->ranges[i].ending);
+		}
+	}
+}
+
+static uint16_t sdp_client_get_total_len(struct bt_sdp_client *session,
+					 const struct bt_sdp_discover_params *param)
+{
+	uint16_t len;
+
+	len = sdp_client_get_attribute_id_list_len(param->ids);
+	if (len > UINT8_MAX) {
+		len += sizeof(uint8_t) + sizeof(uint16_t);
+	} else {
+		len += sizeof(uint8_t) + sizeof(uint8_t);
+	}
+	len += sizeof(session->cstate.length) + session->cstate.length;
+
+	return len;
+}
+
 /* ServiceAttribute PDU, ref to BT Core 5.4, Vol 3, part B, 4.6.1 */
 static int sdp_client_sa_search(struct bt_sdp_client *session,
 				const struct bt_sdp_discover_params *param)
 {
 	struct net_buf *buf;
+	uint16_t len;
 
 	/* Update context param directly. */
 	session->param = param;
@@ -1762,17 +1840,17 @@ static int sdp_client_sa_search(struct bt_sdp_client *session,
 
 	/* Set attribute max bytes count to be returned from server */
 	net_buf_add_be16(buf, net_buf_tailroom(session->rec_buf));
-	/*
-	 * Sequence definition where data is sequence of elements and where
-	 * additional next byte points the size of elements within
-	 */
-	net_buf_add_u8(buf, BT_SDP_SEQ8);
-	net_buf_add_u8(buf, 0x05);
-	/* Data element definition for two following 16bits range elements */
-	net_buf_add_u8(buf, BT_SDP_UINT32);
-	/* Get all attributes. It enables filter out wanted only attributes */
-	net_buf_add_be16(buf, 0x0000);
-	net_buf_add_be16(buf, 0xffff);
+
+	/* Check the tailroom of the buffer */
+	len = sdp_client_get_total_len(session, param);
+	if (len > net_buf_tailroom(buf)) {
+		LOG_ERR("No space to add attribute ID");
+		net_buf_unref(buf);
+		return -ENOMEM;
+	}
+
+	/* Add attribute ID List */
+	sdp_client_add_attribute_id(buf, param->ids);
 
 	/*
 	 * Update and validate PDU ContinuationState. Initial SSA Request has
@@ -1798,6 +1876,7 @@ static int sdp_client_ssa_search(struct bt_sdp_client *session,
 {
 	struct net_buf *buf;
 	uint8_t uuid128[BT_UUID_SIZE_128];
+	uint16_t len;
 
 	/* Update context param directly. */
 	session->param = param;
@@ -1835,17 +1914,17 @@ static int sdp_client_ssa_search(struct bt_sdp_client *session,
 
 	/* Set attribute max bytes count to be returned from server */
 	net_buf_add_be16(buf, net_buf_tailroom(session->rec_buf));
-	/*
-	 * Sequence definition where data is sequence of elements and where
-	 * additional next byte points the size of elements within
-	 */
-	net_buf_add_u8(buf, BT_SDP_SEQ8);
-	net_buf_add_u8(buf, 0x05);
-	/* Data element definition for two following 16bits range elements */
-	net_buf_add_u8(buf, BT_SDP_UINT32);
-	/* Get all attributes. It enables filter out wanted only attributes */
-	net_buf_add_be16(buf, 0x0000);
-	net_buf_add_be16(buf, 0xffff);
+
+	/* Check the tailroom of the buffer */
+	len = sdp_client_get_total_len(session, param);
+	if (len > net_buf_tailroom(buf)) {
+		LOG_ERR("No space to add attribute ID");
+		net_buf_unref(buf);
+		return -ENOMEM;
+	}
+
+	/* Add attribute ID List */
+	sdp_client_add_attribute_id(buf, param->ids);
 
 	/*
 	 * Update and validate PDU ContinuationState. Initial SSA Request has
@@ -2619,9 +2698,25 @@ static int sdp_client_discovery_start(struct bt_conn *conn,
 int bt_sdp_discover(struct bt_conn *conn,
 		    struct bt_sdp_discover_params *params)
 {
-	if (!params || !params->uuid || !params->func || !params->pool) {
+	if (params == NULL || params->uuid == NULL || params->func == NULL ||
+	    params->pool == NULL ||
+	    (params->ids != NULL && params->ids->count != 0 && params->ids->ranges == NULL)) {
 		LOG_WRN("Invalid user params");
 		return -EINVAL;
+	}
+
+	if (params->ids != NULL) {
+		for (size_t i = 0; i < params->ids->count; i++) {
+			struct bt_sdp_attribute_id_range *range;
+
+			range = &params->ids->ranges[i];
+			if (range->beginning <= range->ending) {
+				continue;
+			}
+
+			LOG_WRN("Invalid range %u > %u", range->beginning, range->ending);
+			return -EINVAL;
+		}
 	}
 
 	return sdp_client_discovery_start(conn, params);

--- a/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
+++ b/tests/bluetooth/classic/sdp_c/pytest/test_sdp.py
@@ -542,6 +542,73 @@ async def sdp_ssa_discover_multiple_records(hci_port, shell, dut, address) -> No
             assert found is True
 
 
+async def sdp_ssa_discover_multiple_records_with_range(hci_port, shell, dut, address) -> None:
+    logger.info('<<< SDP Discovery ...')
+    async with await open_transport_or_link(hci_port) as hci_transport:
+        device = Device.with_hci(
+            'Bumble',
+            Address('F0:F1:F2:F3:F4:F5'),
+            hci_transport.source,
+            hci_transport.sink,
+        )
+        device.classic_enabled = True
+        device.le_enabled = False
+        device.sdp_service_records = SDP_SERVICE_MULTIPLE_RECORDS
+        with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
+            device.host.snooper = BtSnooper(snoop_file)
+            await device_power_on(device)
+            await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
+
+            target_address = address.split(" ")[0]
+            logger.info(f'=== Connecting to {target_address}...')
+            try:
+                connection = await device.connect(target_address, transport=BT_BR_EDR_TRANSPORT)
+                logger.info(f'=== Connected to {connection.peer_address}!')
+            except Exception as e:
+                logger.error(f'Fail to connect to {target_address}!')
+                raise e
+
+            # Discover SDP Record with range SDP_SERVICE_RECORD_HANDLE_ATTRIBUTE_ID ~
+            # SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID
+            shell.exec_command(
+                f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()} "
+                f"{SDP_SERVICE_RECORD_HANDLE_ATTRIBUTE_ID} "
+                f"{SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID}"
+            )
+            found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
+            logger.info(f'{lines}')
+            assert found is True
+
+            # Discover SDP Record with range SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID ~
+            # SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID
+            shell.exec_command(
+                f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()} "
+                f"{SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID} "
+                f"{SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID}"
+            )
+            found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
+            logger.info(f'{lines}')
+            assert found is True
+
+            # Discover SDP Record with range SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID ~
+            # 0xffff
+            shell.exec_command(
+                f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()} "
+                f"{SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID} 0xffff"
+            )
+            found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
+            logger.info(f'{lines}')
+            assert found is True
+
+            # Discover SDP Record with range 0xff00 ~ 0xffff
+            shell.exec_command(
+                f"sdp_client ssa_discovery {BT_L2CAP_PROTOCOL_ID.to_hex_str()} 0xff00 0xffff"
+            )
+            found, lines = await wait_for_shell_response(dut, "No SDP Record")
+            logger.info(f'{lines}')
+            assert found is True
+
+
 async def sdp_ss_discover_no_record(hci_port, shell, dut, address) -> None:
     logger.info('<<< SDP Discovery ...')
     async with await open_transport_or_link(hci_port) as hci_transport:
@@ -889,6 +956,69 @@ async def sdp_sa_discover_multiple_records(hci_port, shell, dut, address) -> Non
             assert found is True
 
 
+async def sdp_sa_discover_multiple_records_with_range(hci_port, shell, dut, address) -> None:
+    logger.info('<<< SDP Discovery ...')
+    async with await open_transport_or_link(hci_port) as hci_transport:
+        device = Device.with_hci(
+            'Bumble',
+            Address('F0:F1:F2:F3:F4:F5'),
+            hci_transport.source,
+            hci_transport.sink,
+        )
+        device.classic_enabled = True
+        device.le_enabled = False
+        device.sdp_service_records = SDP_SERVICE_MULTIPLE_RECORDS
+        with open(f"bumble_hci_{sys._getframe().f_code.co_name}.log", "wb") as snoop_file:
+            device.host.snooper = BtSnooper(snoop_file)
+            await device_power_on(device)
+            await device.send_command(HCI_Write_Page_Timeout_Command(page_timeout=0xFFFF))
+
+            target_address = address.split(" ")[0]
+            logger.info(f'=== Connecting to {target_address}...')
+            try:
+                connection = await device.connect(target_address, transport=BT_BR_EDR_TRANSPORT)
+                logger.info(f'=== Connected to {connection.peer_address}!')
+            except Exception as e:
+                logger.error(f'Fail to connect to {target_address}!')
+                raise e
+
+            # Discover SDP Record with range SDP_SERVICE_RECORD_HANDLE_ATTRIBUTE_ID ~
+            # SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID
+            shell.exec_command(
+                f"sdp_client sa_discovery 00010003 {SDP_SERVICE_RECORD_HANDLE_ATTRIBUTE_ID} "
+                f"{SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID}"
+            )
+            found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
+            logger.info(f'{lines}')
+            assert found is True
+
+            # Discover SDP Record with range SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID ~
+            # SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID
+            shell.exec_command(
+                f"sdp_client sa_discovery 00010003 {SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID} "
+                f"{SDP_SUPPORTED_FEATURES_ATTRIBUTE_ID}"
+            )
+            found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
+            logger.info(f'{lines}')
+            assert found is True
+
+            # Discover SDP Record with range SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID ~
+            # 0xffff
+            shell.exec_command(
+                "sdp_client sa_discovery 00010003 "
+                f"{SDP_PROTOCOL_DESCRIPTOR_LIST_ATTRIBUTE_ID} 0xffff"
+            )
+            found, lines = await wait_for_shell_response(dut, "SDP Discovery Done")
+            logger.info(f'{lines}')
+            assert found is True
+
+            # Discover SDP Record with range 0xff00 ~ 0xffff
+            shell.exec_command("sdp_client sa_discovery 00010003 0xff00 0xffff")
+            found, lines = await wait_for_shell_response(dut, "No SDP Record")
+            logger.info(f'{lines}')
+            assert found is True
+
+
 async def sdp_ssa_discover_fail(hci_port, shell, dut, address) -> None:
     def on_app_connection_request(self, request) -> None:
         logger.info('Force L2CAP connection failure')
@@ -969,6 +1099,14 @@ class TestSdpServer:
         hci, iut_address = sdp_client_dut
         asyncio.run(sdp_ssa_discover_multiple_records(hci, shell, dut, iut_address))
 
+    def test_sdp_ssa_discover_multiple_records_with_range(
+        self, shell: Shell, dut: DeviceAdapter, sdp_client_dut
+    ):
+        """Test case to request SDP records with range. Multiple SDP record registered."""
+        logger.info(f'test_sdp_ssa_discover_multiple_records_with_range {sdp_client_dut}')
+        hci, iut_address = sdp_client_dut
+        asyncio.run(sdp_ssa_discover_multiple_records_with_range(hci, shell, dut, iut_address))
+
     def test_sdp_ss_discover_no_record(self, shell: Shell, dut: DeviceAdapter, sdp_client_dut):
         """Test case to request SDP records. No SDP record registered."""
         logger.info(f'test_sdp_ss_discover_no_record {sdp_client_dut}')
@@ -1020,6 +1158,14 @@ class TestSdpServer:
         logger.info(f'test_sdp_sa_discover_multiple_records {sdp_client_dut}')
         hci, iut_address = sdp_client_dut
         asyncio.run(sdp_sa_discover_multiple_records(hci, shell, dut, iut_address))
+
+    def test_sdp_sa_discover_multiple_records_with_range(
+        self, shell: Shell, dut: DeviceAdapter, sdp_client_dut
+    ):
+        """Test case to request SDP records with range. Multiple SDP record registered."""
+        logger.info(f'test_sdp_sa_discover_multiple_records_with_range {sdp_client_dut}')
+        hci, iut_address = sdp_client_dut
+        asyncio.run(sdp_sa_discover_multiple_records_with_range(hci, shell, dut, iut_address))
 
     def test_sdp_ssa_discover_fail(self, shell: Shell, dut: DeviceAdapter, sdp_client_dut):
         """Test case to request SDP records. but the L2CAP connecting fail."""

--- a/tests/bluetooth/classic/sdp_c/src/sdp_client.c
+++ b/tests/bluetooth/classic/sdp_c/src/sdp_client.c
@@ -166,9 +166,12 @@ static uint8_t sdp_discover_func(struct bt_conn *conn, struct bt_sdp_client_resu
 	return BT_SDP_DISCOVER_UUID_CONTINUE;
 }
 
+static struct bt_sdp_attribute_id_list attr_ids;
+static struct bt_sdp_attribute_id_range attr_id_ranges[1];
+
 static int cmd_ssa_discovery(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err;
+	int err = 0;
 	size_t len;
 	uint8_t uuid128[BT_UUID_SIZE_128];
 
@@ -198,9 +201,33 @@ static int cmd_ssa_discovery(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
+	attr_ids.count = 0;
+
+	if (argc > 2) {
+		attr_ids.count = ARRAY_SIZE(attr_id_ranges);
+		attr_ids.ranges = attr_id_ranges;
+		attr_id_ranges[0].beginning = (uint16_t)shell_strtol(argv[2], 0, &err);
+		if (err < 0) {
+			shell_error(sh, "Invalid beginning ATTR ID");
+			return -ENOEXEC;
+		}
+		attr_id_ranges[0].ending = 0xffff;
+	}
+
+	if (argc > 3) {
+		attr_id_ranges[0].ending = (uint16_t)shell_strtol(argv[3], 0, &err);
+		if (err < 0) {
+			shell_error(sh, "Invalid ending ATTR ID");
+			return -ENOEXEC;
+		}
+	}
+
 	sdp_discover.func = sdp_discover_func;
 	sdp_discover.pool = &sdp_client_pool;
 	sdp_discover.type = BT_SDP_DISCOVER_SERVICE_SEARCH_ATTR;
+	if (attr_ids.count != 0) {
+		sdp_discover.ids = &attr_ids;
+	}
 
 	err = bt_sdp_discover(default_conn, &sdp_discover);
 	if (err) {
@@ -256,7 +283,7 @@ static int cmd_ss_discovery(const struct shell *sh, size_t argc, char *argv[])
 
 static int cmd_sa_discovery(const struct shell *sh, size_t argc, char *argv[])
 {
-	int err;
+	int err = 0;
 	size_t len;
 	uint32_t handle;
 
@@ -270,9 +297,33 @@ static int cmd_sa_discovery(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
+	attr_ids.count = 0;
+
+	if (argc > 2) {
+		attr_ids.count = ARRAY_SIZE(attr_id_ranges);
+		attr_ids.ranges = attr_id_ranges;
+		attr_id_ranges[0].beginning = (uint16_t)shell_strtol(argv[2], 0, &err);
+		if (err < 0) {
+			shell_error(sh, "Invalid beginning ATTR ID");
+			return -ENOEXEC;
+		}
+		attr_id_ranges[0].ending = 0xffff;
+	}
+
+	if (argc > 3) {
+		attr_id_ranges[0].ending = (uint16_t)shell_strtol(argv[3], 0, &err);
+		if (err < 0) {
+			shell_error(sh, "Invalid ending ATTR ID");
+			return -ENOEXEC;
+		}
+	}
+
 	sdp_discover.func = sdp_discover_func;
 	sdp_discover.pool = &sdp_client_pool;
 	sdp_discover.type = BT_SDP_DISCOVER_SERVICE_ATTR;
+	if (attr_ids.count != 0) {
+		sdp_discover.ids = &attr_ids;
+	}
 
 	err = bt_sdp_discover(default_conn, &sdp_discover);
 	if (err) {
@@ -311,10 +362,14 @@ static int cmd_ssa_discovery_fail(const struct shell *sh, size_t argc, char *arg
 	return 0;
 }
 
+#define HELP_ATTR_ID_LIST " [start] [end]"
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sdp_client_cmds,
 	SHELL_CMD_ARG(ss_discovery, NULL, "<Big endian UUID>", cmd_ss_discovery, 2, 0),
-	SHELL_CMD_ARG(sa_discovery, NULL, "<Service Record Handle>", cmd_sa_discovery, 2, 0),
-	SHELL_CMD_ARG(ssa_discovery, NULL, "<Big endian UUID>", cmd_ssa_discovery, 2, 0),
+	SHELL_CMD_ARG(sa_discovery, NULL, "<Service Record Handle>" HELP_ATTR_ID_LIST,
+		      cmd_sa_discovery, 2, 2),
+	SHELL_CMD_ARG(ssa_discovery, NULL, "<Big endian UUID>" HELP_ATTR_ID_LIST,
+		      cmd_ssa_discovery, 2, 2),
 	SHELL_CMD_ARG(ssa_discovery_fail, NULL, "", cmd_ssa_discovery_fail, 1, 0),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
In current implementation, the ATTR ID list is set with fixed value (0x0000, 0xffff). For the case that responding a lot of SDP record
data, the responded data cannot be processed properly due to the receiving buffer size limitation. In this case, the ATTR ID list can
be used to reduce the length of the responding data. In this way, it will help reduce the SDP's requirement for receiving data buffer size.

Add the attribute ID list configuration to the SDP discovery request structure `struct bt_sdp_discover_params`.

If the `struct bt_sdp_discover_params::ids` is NULL, or `struct bt_sdp_discover_params::ids::count` is 0, the default range (0x0000, 0xffff) is used.
