### PR TITLE
drivers: adc: gecko: Fix error return values

### DIFF
--- a/drivers/adc/iadc_gecko.c
+++ b/drivers/adc/iadc_gecko.c
@@ -127,7 +127,7 @@ static int start_read(const struct device *dev, const struct adc_sequence *seque
 
 	if (sequence->oversampling) {
 		LOG_ERR("Oversampling is not supported");
-		return -ENOTSUP;
+		return -EINVAL;
 	}
 
 	/* Check resolution setting */
@@ -331,7 +331,7 @@ static int adc_gecko_channel_setup(const struct device *dev,
 		break;
 	default:
 		LOG_ERR("unsupported channel gain '%d'", channel_cfg->gain);
-		return -ENOTSUP;
+		return -EINVAL;
 	}
 
 	/* Setup reference */
@@ -353,7 +353,7 @@ static int adc_gecko_channel_setup(const struct device *dev,
 	default:
 		LOG_ERR("unsupported channel reference type '%d'",
 			channel_cfg->reference);
-		return -ENOTSUP;
+		return -EINVAL;
 	}
 
 	channel_config->initialized = true;

--- a/tests/drivers/adc/adc_error_cases/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/adc/adc_error_cases/boards/xg24_rb4187c.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc = &adc0;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+};

--- a/tests/drivers/adc/adc_error_cases/boards/xg27_dk2602a.overlay
+++ b/tests/drivers/adc/adc_error_cases/boards/xg27_dk2602a.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc = &adc0;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+};

--- a/tests/drivers/adc/adc_error_cases/boards/xg29_rb4412a.overlay
+++ b/tests/drivers/adc/adc_error_cases/boards/xg29_rb4412a.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		adc = &adc0;
+	};
+};
+
+&adc0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+};

--- a/tests/drivers/adc/adc_error_cases/src/adc_error_cases.c
+++ b/tests/drivers/adc/adc_error_cases/src/adc_error_cases.c
@@ -24,11 +24,17 @@ static const struct adc_channel_cfg valid_channel_cfg = {
 	#endif
 };
 
+#if defined(CONFIG_SOC_FAMILY_SILABS_S2)
+#define VALID_RESOLUTION 12
+#else
+#define VALID_RESOLUTION 10
+#endif
+
 static const struct adc_sequence valid_seq = {
 	.buffer = m_sample_buffer,
 	.buffer_size = BUFFER_LEN * sizeof(m_sample_buffer),
 	.options = NULL,
-	.resolution = 10,
+	.resolution = VALID_RESOLUTION,
 	.oversampling = 0,
 	.channels = 1,
 };

--- a/tests/drivers/adc/adc_error_cases/testcase.yaml
+++ b/tests/drivers/adc/adc_error_cases/testcase.yaml
@@ -12,3 +12,6 @@ tests:
       - nrf54lm20dk/nrf54lm20a/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
+      - xg24_rb4187c
+      - xg27_dk2602a
+      - xg29_rb4412a


### PR DESCRIPTION
Enable the adc_error_cases test on Series 2 devices and change the return values in the driver for unsupported configurations to what the test expects.

Ensure that the resolution configuration in the test is valid such that the invalid buffer test correctly receives -ENOMEM.