### PR TITLE
west.yml: Bump TF-M to allow FOTA upgrade

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -537,6 +537,17 @@ Trusted Firmware-M
       confirming them with ``psa_fwu_accept()``. Otherwise, the images will roll back on the next
       reboot.
 
+* A compatibility issue was identified in the TF-M attestation procedure introduced
+  after the TF-M v2.1.0 release. As a result, systems using TF-M v2.1 cannot be
+  upgraded to any later TF-M version without encountering failures.
+  This limitation affects Zephyr versions using TF-M v2.1.0 through v2.1.2, specifically,
+  Zephyr v3.7 through v4.2, preventing seamless upgrades between these releases.
+  The issue was resolved in mainline TF-M as of October 25 and the fix is included
+  in Zephyr v4.3.0. Users are advised to migrate directly from any earlier Zephyr
+  release to Zephyr v4.3.0 or later to ensure full TF-M attestation functionality
+  and upgrade compatibility.
+  (:github:`94859`)
+
 * Support for automatically downloading MCUboot and ethos by CMake in a build has been removed,
   the in-tree versions of these modules will be used instead. To use custom versions, create a
   :ref:`west manifest <west-manifest-files>` which pulls in the desired versions of these

--- a/west.yml
+++ b/west.yml
@@ -369,7 +369,7 @@ manifest:
       groups:
         - tee
     - name: trusted-firmware-m
-      revision: 94691a2ed0d9a2802b3419eaa91958329c36871b
+      revision: d3341a660f2f33156e1a8bb8ea47ad83066defea
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
This pull a regression fix to allow Zephyr v3.7.1 upgrade to v4.2.0.

More details in:
  ~https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/147~
  https://github.com/zephyrproject-rtos/trusted-firmware-m/pull/152

TF-M regression introduced in:
  https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/31755

Proposed fix:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/42130

Final fix:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/42981