### PR TITLE
drivers: spi: silabs: Add missing iodev_submit implementation

### DIFF
--- a/drivers/spi/spi_silabs_eusart.c
+++ b/drivers/spi/spi_silabs_eusart.c
@@ -15,6 +15,7 @@
 #include <zephyr/device.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/spi/rtio.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/clock_control/clock_control_silabs.h>
 #include <zephyr/drivers/pinctrl.h>
@@ -728,6 +729,9 @@ static DEVICE_API(spi, spi_silabs_eusart_api) = {
 	.transceive = spi_silabs_eusart_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = spi_silabs_eusart_transceive_async,
+#endif
+#ifdef CONFIG_SPI_RTIO
+	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
 	.release = spi_silabs_eusart_release,
 };

--- a/drivers/spi/spi_silabs_siwx91x_gspi.c
+++ b/drivers/spi/spi_silabs_siwx91x_gspi.c
@@ -11,6 +11,7 @@
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/spi/rtio.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/irq.h>
 #include <zephyr/sys/util.h>
@@ -624,6 +625,9 @@ static DEVICE_API(spi, gspi_siwx91x_driver_api) = {
 	.transceive = gspi_siwx91x_transceive_sync,
 #ifdef CONFIG_SPI_ASYNC
 	.transceive_async = gspi_siwx91x_transceive_async,
+#endif
+#ifdef CONFIG_SPI_RTIO
+	.iodev_submit = spi_rtio_iodev_default_submit,
 #endif
 	.release = gspi_siwx91x_release,
 };


### PR DESCRIPTION
Series 2 EUSART and SiWx91x GSPI drivers were missing the `iodev_submit` member from their API structs, leading to null pointer dereference if CONFIG_SPI_RTIO was used.

Other drivers in the tree had this member added in https://github.com/zephyrproject-rtos/zephyr/pull/77141.