### PR TITLE
drivers: gnss: Correctly set the 1 bit bitfield is_tracked/corrected

### DIFF
--- a/drivers/gnss/gnss_ubx_common.c
+++ b/drivers/gnss/gnss_ubx_common.c
@@ -136,8 +136,8 @@ void gnss_ubx_common_satellite_callback(struct modem_ubx *ubx, const struct ubx_
 			.elevation = ubx_sat->sat[i].elevation,
 			.azimuth = ubx_sat->sat[i].azimuth,
 			.system = gnss_system,
-			.is_tracked = (ubx_sat->sat[i].flags & UBX_NAV_SAT_FLAGS_SV_USED),
-			.is_corrected = (ubx_sat->sat[i].flags & UBX_NAV_SAT_FLAGS_RTCM_CORR_USED)
+			.is_tracked = !!(ubx_sat->sat[i].flags & UBX_NAV_SAT_FLAGS_SV_USED),
+			.is_corrected = !!(ubx_sat->sat[i].flags & UBX_NAV_SAT_FLAGS_RTCM_CORR_USED)
 		};
 
 		data->satellites.data[i] = sat;


### PR DESCRIPTION
Currently, if a SV is tracked, we try to store:
flags & BIT(3) -> 0b1000 -> least significant bit 0 is stored. Same is valid for the is_corrected field.

Use double negation to treat any non-zero value as true.

I was testing a GNSS receiver with one of the driver currently available and the `samples/driver/gnss` test FW, and was surprised to see all the SVs with the `is_tracked: 0` even tough I got a fix:
```
[2025-08-22 17:16:23.031] Got a fix (type: 1)
[2025-08-22 17:16:23.035] 24 satellites reported (of which 0 tracked, of which 0 has RTK corrections)!
[2025-08-22 17:16:23.042] u_blox_f9p: gnss_info: {satellites_cnt: 7, hdop: 3.450, fix_status: GNSS_FIX, fix_quality: GNSS_SPS}
[2025-08-22 17:16:23.050] u_blox_f9p: navigation_data: {latitude: XXXX, longitude : XXXX, bearing 64.922, speed 0.014, altitude: XXXX}
[2025-08-22 17:16:23.062] u_blox_f9p: gnss_time: {hour: 15, minute: 16, millisecond 23000, month_day 22, month: 8, century_year: 25}
[2025-08-22 17:16:23.071] u_blox_f9p: gnss_satellite: {prn: 5, snr: 15, elevation 61, azimuth 282, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.080] u_blox_f9p: gnss_satellite: {prn: 7, snr: 0, elevation 42, azimuth 57, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.089] u_blox_f9p: gnss_satellite: {prn: 8, snr: 0, elevation 3, azimuth 56, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.098] u_blox_f9p: gnss_satellite: {prn: 9, snr: 0, elevation 10, azimuth 100, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.107] u_blox_f9p: gnss_satellite: {prn: 11, snr: 17, elevation 8, azimuth 213, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.116] u_blox_f9p: gnss_satellite: {prn: 13, snr: 8, elevation 46, azimuth 289, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.125] u_blox_f9p: gnss_satellite: {prn: 14, snr: 17, elevation 35, azimuth 148, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.134] u_blox_f9p: gnss_satellite: {prn: 15, snr: 8, elevation 14, azimuth 292, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.143] u_blox_f9p: gnss_satellite: {prn: 18, snr: 0, elevation 8, azimuth 330, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.151] u_blox_f9p: gnss_satellite: {prn: 21, snr: 20, elevation 65, azimuth 192, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.160] u_blox_f9p: gnss_satellite: {prn: 22, snr: 0, elevation 22, azimuth 161, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.169] u_blox_f9p: gnss_satellite: {prn: 27, snr: 0, elevation 1, azimuth 26, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.178] u_blox_f9p: gnss_satellite: {prn: 30, snr: 0, elevation 75, azimuth 66, system: GPS, is_tracked: 0}
[2025-08-22 17:16:23.187] u_blox_f9p: gnss_satellite: {prn: 123, snr: 0, elevation 31, azimuth 147, system: SBAS, is_tracked: 0}
[2025-08-22 17:16:23.196] u_blox_f9p: gnss_satellite: {prn: 127, snr: 0, elevation 19, azimuth 123, system: SBAS, is_tracked: 0}
[2025-08-22 17:16:23.205] u_blox_f9p: gnss_satellite: {prn: 136, snr: 0, elevation 36, azimuth 182, system: SBAS, is_tracked: 0}
[2025-08-22 17:16:23.214] u_blox_f9p: gnss_satellite: {prn: 4, snr: 0, elevation 26, azimuth 89, system: GALILEO, is_tracked: 0}
[2025-08-22 17:16:23.223] u_blox_f9p: gnss_satellite: {prn: 5, snr: 0, elevation 43, azimuth 287, system: GALILEO, is_tracked: 0}
[2025-08-22 17:16:23.232] u_blox_f9p: gnss_satellite: {prn: 6, snr: 0, elevation 52, azimuth 82, system: GALILEO, is_tracked: 0}
[2025-08-22 17:16:23.241] u_blox_f9p: gnss_satellite: {prn: 9, snr: 10, elevation 75, azimuth 49, system: GALILEO, is_tracked: 0}
[2025-08-22 17:16:23.251] u_blox_f9p: gnss_satellite: {prn: 15, snr: 0, elevation 9, azimuth 334, system: GALILEO, is_tracked: 0}
[2025-08-22 17:16:23.260] u_blox_f9p: gnss_satellite: {prn: 23, snr: 0, elevation 27, azimuth 52, system: GALILEO, is_tracked: 0}
[2025-08-22 17:16:23.269] u_blox_f9p: gnss_satellite: {prn: 24, snr: 0, elevation 16, azimuth 166, system: GALILEO, is_tracked: 0}
[2025-08-22 17:16:23.279] u_blox_f9p: gnss_satellite: {prn: 31, snr: 0, elevation 41, azimuth 113, system: GALILEO, is_tracked: 0}
```

The reason is because the `struct gnss_satellite` uses 1 bit bitfield for the bool value `is_tracked` and `is_corrected`:
```
struct gnss_satellite {
	/** Pseudo-random noise sequence */
	uint8_t prn;
	/** Signal-to-noise ratio in dB */
	uint8_t snr;
	/** Elevation in degrees [0, 90] */
	uint8_t elevation;
	/** Azimuth relative to True North in degrees [0, 359] */
	uint16_t azimuth;
	/** System of satellite */
	enum gnss_system system;
	/** True if satellite is being tracked */
	uint8_t is_tracked : 1;
	/** True if satellite tracking has RTK corrections */
	uint8_t is_corrected : 1;
};
```

And the assignment from the `gnss_ubx_common_satellite_callback` does:
```
			.is_tracked = (ubx_sat->sat[i].flags & UBX_NAV_SAT_FLAGS_SV_USED),
			.is_corrected = (ubx_sat->sat[i].flags & UBX_NAV_SAT_FLAGS_RTCM_CORR_USED)
		};
```
which will try to put `0b1000` into `is_tracked` for example (assuming the SV is indeed used for navigation), resulting in the least significant bit 0 being used.

With the proposed fix, we now see some tracked SVs:
```
[2025-08-22 17:23:14.030] Got a fix (type: 1)
[2025-08-22 17:23:14.055] 24 satellites reported (of which 5 tracked, of which 0 has RTK corrections)!
[2025-08-22 17:23:14.061] u_blox_f9p: gnss_info: {satellites_cnt: 7, hdop: 4.920, fix_status: GNSS_FIX, fix_quality: GNSS_SPS}
[2025-08-22 17:23:14.070] u_blox_f9p: navigation_data: {latitude: XXXX, longitude : XXXX, bearing 64.922, speed 0.146, altitude: XXXX}
[2025-08-22 17:23:14.081] u_blox_f9p: gnss_time: {hour: 15, minute: 23, millisecond 14000, month_day 22, month: 8, century_year: 25}
[2025-08-22 17:23:14.091] u_blox_f9p: gnss_satellite: {prn: 5, snr: 15, elevation 62, azimuth 275, system: GPS, is_tracked: 1}
[2025-08-22 17:23:14.100] u_blox_f9p: gnss_satellite: {prn: 7, snr: 0, elevation 39, azimuth 57, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.108] u_blox_f9p: gnss_satellite: {prn: 8, snr: 0, elevation 4, azimuth 53, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.117] u_blox_f9p: gnss_satellite: {prn: 9, snr: 0, elevation 7, azimuth 102, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.126] u_blox_f9p: gnss_satellite: {prn: 11, snr: 12, elevation 6, azimuth 211, system: GPS, is_tracked: 1}
[2025-08-22 17:23:14.134] u_blox_f9p: gnss_satellite: {prn: 13, snr: 20, elevation 49, azimuth 292, system: GPS, is_tracked: 1}
[2025-08-22 17:23:14.143] u_blox_f9p: gnss_satellite: {prn: 14, snr: 0, elevation 38, azimuth 146, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.152] u_blox_f9p: gnss_satellite: {prn: 15, snr: 14, elevation 16, azimuth 293, system: GPS, is_tracked: 1}
[2025-08-22 17:23:14.161] u_blox_f9p: gnss_satellite: {prn: 18, snr: 0, elevation 9, azimuth 328, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.170] u_blox_f9p: gnss_satellite: {prn: 21, snr: 20, elevation 61, azimuth 189, system: GPS, is_tracked: 1}
[2025-08-22 17:23:14.179] u_blox_f9p: gnss_satellite: {prn: 22, snr: 0, elevation 25, azimuth 159, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.188] u_blox_f9p: gnss_satellite: {prn: 27, snr: 0, elevation 1, azimuth 23, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.197] u_blox_f9p: gnss_satellite: {prn: 30, snr: 0, elevation 72, azimuth 62, system: GPS, is_tracked: 0}
[2025-08-22 17:23:14.206] u_blox_f9p: gnss_satellite: {prn: 123, snr: 0, elevation 31, azimuth 147, system: SBAS, is_tracked: 0}
[2025-08-22 17:23:14.215] u_blox_f9p: gnss_satellite: {prn: 127, snr: 0, elevation 19, azimuth 123, system: SBAS, is_tracked: 0}
[2025-08-22 17:23:14.224] u_blox_f9p: gnss_satellite: {prn: 136, snr: 0, elevation 36, azimuth 182, system: SBAS, is_tracked: 0}
[2025-08-22 17:23:14.233] u_blox_f9p: gnss_satellite: {prn: 4, snr: 0, elevation 24, azimuth 91, system: GALILEO, is_tracked: 0}
[2025-08-22 17:23:14.242] u_blox_f9p: gnss_satellite: {prn: 5, snr: 0, elevation 45, azimuth 289, system: GALILEO, is_tracked: 0}
[2025-08-22 17:23:14.252] u_blox_f9p: gnss_satellite: {prn: 6, snr: 0, elevation 50, azimuth 84, system: GALILEO, is_tracked: 0}
[2025-08-22 17:23:14.261] u_blox_f9p: gnss_satellite: {prn: 9, snr: 0, elevation 73, azimuth 57, system: GALILEO, is_tracked: 0}
[2025-08-22 17:23:14.270] u_blox_f9p: gnss_satellite: {prn: 15, snr: 0, elevation 10, azimuth 332, system: GALILEO, is_tracked: 0}
[2025-08-22 17:23:14.279] u_blox_f9p: gnss_satellite: {prn: 16, snr: 0, elevation 1, azimuth 182, system: GALILEO, is_tracked: 0}
[2025-08-22 17:23:14.288] u_blox_f9p: gnss_satellite: {prn: 23, snr: 0, elevation 26, azimuth 49, system: GALILEO, is_tracked: 0}
[2025-08-22 17:23:14.297] u_blox_f9p: gnss_satellite: {prn: 24, snr: 0, elevation 19, azimuth 165, system: GALILEO, is_tracked: 0}
```