### PR TITLE
Improvements to EC Host Command doxygen docs

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -9,15 +9,6 @@
 @defgroup os_services Operating System Services
 @brief Operating System Services
 @{
-
-@brief MCUmgr
-@defgroup mcumgr MCUmgr
-@{
-@defgroup mcumgr_transport Transport layers
-@{
-@}
-@}
-
 @}
 
 @brief Device Driver APIs
@@ -45,6 +36,21 @@
 @brief Debug Services
 @defgroup debug Debug
 @ingroup os_services
+@{
+@}
+
+@brief Device Management
+@defgroup device_mgmt Device Management
+@ingroup os_services
+@{
+@}
+
+@brief MCUmgr
+@defgroup mcumgr MCUmgr
+@ingroup device_mgmt
+
+@brief Transport layers for MCUmgr: SMP, UART, etc.
+@defgroup mcumgr_transport Transport layers
 @{
 @}
 

--- a/include/zephyr/mgmt/ec_host_cmd/backend.h
+++ b/include/zephyr/mgmt/ec_host_cmd/backend.h
@@ -7,10 +7,18 @@
 /**
  * @file
  * @brief Public APIs for Host Command backends that respond to host commands
+ * @ingroup ec_host_cmd_backend
  */
 
 #ifndef ZEPHYR_INCLUDE_MGMT_EC_HOST_CMD_BACKEND_H_
 #define ZEPHYR_INCLUDE_MGMT_EC_HOST_CMD_BACKEND_H_
+
+/**
+ * @brief Interface to EC Host Command backends
+ * @defgroup ec_host_cmd_backend Backends
+ * @ingroup ec_host_cmd_interface
+ * @{
+ */
 
 #include <zephyr/sys/__assert.h>
 #include <zephyr/device.h>
@@ -22,19 +30,15 @@
 extern "C" {
 #endif
 
+/**
+ * @brief EC Host Command Backend
+ */
 struct ec_host_cmd_backend {
-	/** API provided by the backed. */
+	/** API provided by the backend. */
 	const struct ec_host_cmd_backend_api *api;
-	/** Context for the backed. */
+	/** Context for the backend. */
 	void *ctx;
 };
-
-/**
- * @brief EC Host Command Interface
- * @defgroup ec_host_cmd_interface EC Host Command Interface
- * @ingroup io_interfaces
- * @{
- */
 
 /**
  * @brief Context for host command backend and handler to pass rx data.
@@ -58,7 +62,7 @@ struct ec_host_cmd_rx_ctx {
  */
 struct ec_host_cmd_tx_buf {
 	/**
-	 * Data to write to the host The buffer is provided by the handler if
+	 * Data to write to the host. The buffer is provided by the handler if
 	 * CONFIG_EC_HOST_CMD_HANDLER_TX_BUFFER_SIZE > 0. Otherwise, the backend should provide
 	 * the buffer on its own and overwrites @a buf pointer and @a len_max
 	 * in the init function.

--- a/include/zephyr/mgmt/ec_host_cmd/simulator.h
+++ b/include/zephyr/mgmt/ec_host_cmd/simulator.h
@@ -4,13 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_INCLUDE_MGMT_EC_HOST_CMD_SIMULATOR_H_
-#define ZEPHYR_INCLUDE_MGMT_EC_HOST_CMD_SIMULATOR_H_
-
 /**
  * @file
  * @brief Header for commands to interact with the simulator outside of normal
  *        device interface.
+ * @ingroup ec_host_cmd_simulator
+ */
+
+#ifndef ZEPHYR_INCLUDE_MGMT_EC_HOST_CMD_SIMULATOR_H_
+#define ZEPHYR_INCLUDE_MGMT_EC_HOST_CMD_SIMULATOR_H_
+
+/**
+ * @brief Interface to EC Host Command Simulator
+ * @defgroup ec_host_cmd_simulator Simulator
+ * @ingroup ec_host_cmd_interface
+ * @{
  */
 
 /* For ec_host_cmd_backend_api_send function pointer type */
@@ -44,5 +52,9 @@ void ec_host_cmd_backend_sim_install_send_cb(ec_host_cmd_backend_api_send cb,
  * @retval -EBUSY if the host command framework is busy with another request.
  */
 int ec_host_cmd_backend_sim_data_received(const uint8_t *buffer, size_t len);
+
+/**
+ * @}
+ */
 
 #endif /* ZEPHYR_INCLUDE_MGMT_EC_HOST_CMD_SIMULATOR_H_ */


### PR DESCRIPTION
- add some missing docs
- make sure API guarded by Kconfig is showing up in the docs
- show EC Host Command docs in Device Management group
- re-arrange groups for backends and simulator API
- other cosmetic / grammar / spelling fixes