### PR TITLE
sensing: docs: some doxygen love

### DIFF
--- a/doc/services/sensing/index.rst
+++ b/doc/services/sensing/index.rst
@@ -246,7 +246,4 @@ See the example :zephyr_file:`samples/subsys/sensing/simple/boards/native_sim.ov
 API Reference
 *************
 
-.. doxygengroup:: sensing_sensor_types
-.. doxygengroup:: sensing_datatypes
 .. doxygengroup:: sensing_api
-.. doxygengroup:: sensing_sensor

--- a/include/zephyr/sensing/sensing_datatypes.h
+++ b/include/zephyr/sensing/sensing_datatypes.h
@@ -11,14 +11,15 @@
 #include <zephyr/dsp/types.h>
 
 /**
- * @brief Data Types
- * @addtogroup sensing_datatypes
+ * @defgroup sensing_datatypes Data Types
+ * @ingroup sensing_api
+ * @brief Sensor data structures used by the sensing subsystem
+ *
  * @{
  */
 
 /**
- * @struct sensing_sensor_value_header
- * @brief sensor value header
+ * @brief Common header for all sensor value payloads.
  *
  * Each sensor value data structure should have this header
  *

--- a/include/zephyr/sensing/sensing_sensor.h
+++ b/include/zephyr/sensing/sensing_sensor.h
@@ -13,15 +13,9 @@
 #include <zephyr/sensing/sensing.h>
 
 /**
- * @defgroup sensing_sensor Sensing Sensor API
- * @ingroup sensing
- * @defgroup sensing_sensor_callbacks Sensor Callbacks
- * @ingroup sensing_sensor
- */
-
-/**
- * @brief Sensing Sensor API
- * @addtogroup sensing_sensor
+ * @brief Interfaces to manipulate sensors in the sensing subsystem
+ * @defgroup sensing_sensor Sensors (Sensing)
+ * @ingroup sensing_api
  * @{
  */
 
@@ -390,7 +384,7 @@ extern const struct rtio_iodev_api __sensing_iodev_api;
 	SENSING_SENSORS_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
- * @brief Get reporter handles	of a given sensor instance by sensor type.
+ * @brief Get reporter handles of a given sensor instance by sensor type.
  *
  * @param dev The sensor instance device structure.
  * @param type The given type, \ref SENSING_SENSOR_TYPE_ALL to get reporters

--- a/include/zephyr/sensing/sensing_sensor_types.h
+++ b/include/zephyr/sensing/sensing_sensor_types.h
@@ -20,35 +20,50 @@
  */
 
 /**
- * sensor category light
+ * @name Light sensors
+ * @{
  */
+
+/** Sensor type for ambient light sensors. */
 #define SENSING_SENSOR_TYPE_LIGHT_AMBIENTLIGHT			0x41
 
+/** @} */
+
 /**
- * sensor category motion
+ * @name Motion sensors
+ * @{
  */
-/* Sensor type for 3D accelerometers. */
+
+/** Sensor type for 3D accelerometers. */
 #define SENSING_SENSOR_TYPE_MOTION_ACCELEROMETER_3D		0x73
-/* Sensor type for 3D gyrometers. */
+/** Sensor type for 3D gyrometers. */
 #define SENSING_SENSOR_TYPE_MOTION_GYROMETER_3D			0x76
-/* Sensor type for motion detectors. */
+/** Sensor type for motion detectors. */
 #define SENSING_SENSOR_TYPE_MOTION_MOTION_DETECTOR		0x77
+/** Sensor type for uncalibrated 3D accelerometers. */
+#define SENSING_SENSOR_TYPE_MOTION_UNCALIB_ACCELEROMETER_3D     0x240
+/** Sensor type for hinge angle sensors. */
+#define SENSING_SENSOR_TYPE_MOTION_HINGE_ANGLE                  0x20B
 
+/** @} */
 
 /**
- * sensor category other
+ * @name Other sensors
+ * @{
  */
-#define SENSING_SENSOR_TYPE_OTHER_CUSTOM			0xE1
 
-/* Sensor type for uncalibrated 3D accelerometers. */
-#define SENSING_SENSOR_TYPE_MOTION_UNCALIB_ACCELEROMETER_3D	0x240
-/* Sensor type for hinge angle sensors. */
-#define SENSING_SENSOR_TYPE_MOTION_HINGE_ANGLE			0x20B
+/** Sensor type for custom sensors. */
+#define SENSING_SENSOR_TYPE_OTHER_CUSTOM 0xE1
+
+/** @} */
 
 /**
  * @brief Sensor type for all sensors.
  *
  * This macro defines the sensor type for all sensors.
+ *
+ * @note This value is not a valid sensor type and is used as a sentinel value to indicate all
+ *       sensor types.
  */
 #define SENSING_SENSOR_TYPE_ALL					0xFFFF
 

--- a/include/zephyr/sensing/sensing_sensor_types.h
+++ b/include/zephyr/sensing/sensing_sensor_types.h
@@ -8,14 +8,15 @@
 #define ZEPHYR_INCLUDE_SENSING_SENSOR_TYPES_H_
 
 /**
- * @brief Sensor Types Definition
+ * @defgroup sensing_sensor_types Sensor Types (Sensing)
+ * @ingroup sensing_api
+ *
+ * @brief Sensor type identifiers used by the sensing subsystem.
  *
  * Sensor types definition followed HID standard.
  * https://usb.org/sites/default/files/hutrr39b_0.pdf
  *
  * TODO: will add more types
- *
- * @addtogroup sensing_sensor_types
  * @{
  */
 


### PR DESCRIPTION
Move sensing documentation in the "OS Services" group and some general housekeeping (add missing docs, fix bad doxygen usage, etc.)

See https://builds.zephyrproject.io/zephyr/pr/94878/docs/doxygen/html/group__sensing__api.html

Before was: https://docs.zephyrproject.org/latest/doxygen/html/group__sensing.html