### PR TITLE
drivers: mcpwm: esp32: Fix duty rounding

### DIFF
--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -252,9 +252,7 @@ static int mcpwm_esp32_set_cycles(const struct device *dev, uint32_t channel_idx
 		return ret;
 	}
 
-	double duty_cycle = (double)pulse_cycles * 100 / (double)period_cycles;
-
-	channel->duty = (uint32_t)duty_cycle;
+	channel->duty = DIV_ROUND_CLOSEST((uint64_t)pulse_cycles * 100ULL, period_cycles);
 
 	channel->inverted = (flags & PWM_POLARITY_INVERTED);
 


### PR DESCRIPTION
Duty value in the driver is calculated from timer cycles, which can introduce precision loss when converting from pwm_set() to pwm_set_cycles(). To avoid truncating values with a fractional part ≥ 0.5 and further drifting the effective duty, round the computed duty to the nearest integer.