### PR TITLE
include: can: re-organize doxygen groups

### DIFF
--- a/doc/hardware/peripherals/can/controller.rst
+++ b/doc/hardware/peripherals/can/controller.rst
@@ -317,4 +317,4 @@ We have two ready-to-build samples demonstrating use of the Zephyr CAN API:
 CAN Controller API Reference
 ****************************
 
-.. doxygengroup:: can_interface
+.. doxygengroup:: can_controller

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -8,7 +8,8 @@
 
 /**
  * @file
- * @brief Controller Area Network (CAN) driver API.
+ * @brief Main header file for Controller Area Network (CAN) driver API.
+ * @ingroup can_controller
  */
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_H_
@@ -28,11 +29,16 @@ extern "C" {
 #endif
 
 /**
- * @brief CAN Interface
- * @defgroup can_interface CAN Interface
+ * @brief Interfaces for Controller Area Network (CAN) controllers and transceivers
+ * @defgroup can_interface CAN
+ * @ingroup io_interfaces
+ *
+ * @defgroup can_controller CAN Controller
+ * @brief Interfaces for CAN controllers
+ * @ingroup can_interface
  * @since 1.12
  * @version 1.1.0
- * @ingroup io_interfaces
+ *
  * @{
  */
 

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @ingroup can_transceiver
+ * @brief Header file for CAN transceiver driver API
+ */
+
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
 
@@ -15,11 +21,11 @@ extern "C" {
 #endif
 
 /**
- * @brief CAN Transceiver Driver APIs
+ * @brief Interfaces for CAN transceivers
  * @defgroup can_transceiver CAN Transceiver
  * @since 3.1
  * @version 0.1.0
- * @ingroup io_interfaces
+ * @ingroup can_interface
  * @{
  */
 

--- a/samples/drivers/can/babbling/README.rst
+++ b/samples/drivers/can/babbling/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: can-babbling
    :name: Controller Area Network (CAN) babbling node
-   :relevant-api: can_interface
+   :relevant-api: can_controller
 
    Simulate a babbling CAN node.
 

--- a/samples/drivers/can/counter/README.rst
+++ b/samples/drivers/can/counter/README.rst
@@ -1,6 +1,6 @@
 .. zephyr:code-sample:: can-counter
    :name: Controller Area Network (CAN) counter
-   :relevant-api: can_interface
+   :relevant-api: can_controller
 
    Send and receive CAN messages.
 


### PR DESCRIPTION
group controller and transceiver API under a common umbrella

https://builds.zephyrproject.io/zephyr/pr/94882/docs/doxygen/html/group__can__interface.html

@henrikbrixandersen does this make sense?

FWIW this is part of an ongoing effort to rationalize the contents of the Device Driver API section of the docs by adding more grouping where it makes sense (will shortly submit a PR doing a similar exercise with all things USB)
