### PR TITLE
twister: use csv to split extra argument arguments for west flags

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -61,7 +61,7 @@ class TwisterHarnessConfig:
 
         west_flash_extra_args: list[str] = []
         if config.option.west_flash_extra_args:
-            west_flash_extra_args = [w.strip() for w in config.option.west_flash_extra_args.split(',')]
+            west_flash_extra_args = [w.strip() for w in next(csv.reader([config.option.west_flash_extra_args]))]
         flash_command: list[str] = []
         if config.option.flash_command:
             flash_command = [w.strip() for w in next(csv.reader([config.option.flash_command]))]

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -594,7 +594,7 @@ class DeviceHandler(Handler):
         # 3) Multiple values: --west-flash="--board-id=42,--erase"
         #    This results in options.west_flash == "--board-id=42 --erase"
         if self.options.west_flash and self.options.west_flash != []:
-            command_extra_args.extend(self.options.west_flash.split(','))
+            command_extra_args.extend(next(csv.reader([self.options.west_flash])))
 
         if runner:
             command.append("--runner")

--- a/scripts/tests/twister/test_handlers.py
+++ b/scripts/tests/twister/test_handlers.py
@@ -1068,12 +1068,12 @@ TESTDATA_13 = [
          '--', '--dummy']
     ),
     (
-        '--dummy1,--dummy2',
+        '--dummy1,--dummy2,"--dummy, 3"',
         None,
         None,
         None,
         ['west', 'flash', '--skip-rebuild', '-d', '$build_dir',
-         '--', '--dummy1', '--dummy2']
+         '--', '--dummy1', '--dummy2', '--dummy, 3']
     ),
 
     (


### PR DESCRIPTION
Use csv instead of a plain split to split extra arguments for extra west flags, this allows correct passing of arguments that are internally escaped in quotes, such as arugments containing commas.

---

Deps:

- https://github.com/zephyrproject-rtos/zephyr/pull/93944