### PR TITLE
fs: Add FSTAB_ENTRY_DT_*_MOUNT_POINT macros

### DIFF
--- a/include/zephyr/fs/fs.h
+++ b/include/zephyr/fs/fs.h
@@ -207,6 +207,24 @@ struct fs_statvfs {
 	 | (DT_PROP(node_id, disk_access) ? FS_MOUNT_FLAG_USE_DISK_ACCESS : 0))
 
 /**
+ * @brief Get the mount-point from an fstab entry.
+ *
+ * @param node_id The node identifier for a child entry in a zephyr,fstab node.
+ * @return The mount-point path.
+ */
+#define FSTAB_ENTRY_DT_MOUNT_POINT(node_id) \
+	DT_PROP(node_id, mount_point)
+
+/**
+ * @brief Get the mount-point from an fstab entry.
+ *
+ * @param inst Instance number
+ * @return The mount-point path.
+ */
+#define FSTAB_ENTRY_DT_INST_MOUNT_POINT(inst) \
+	DT_INST_PROP(inst, mount_point)
+
+/**
  * @brief The name under which a zephyr,fstab entry mount structure is
  * defined.
  *

--- a/subsys/fs/fat_fs.c
+++ b/subsys/fs/fat_fs.c
@@ -568,7 +568,7 @@ static const struct fs_file_system_t fatfs_fs = {
 	static FATFS fs_data_##inst;                                                               \
 	struct fs_mount_t FS_FSTAB_ENTRY(DT_DRV_INST(inst)) = {                                    \
 		.type = FS_FATFS,                                                                  \
-		.mnt_point = DT_INST_PROP(inst, mount_point),                                      \
+		.mnt_point = FSTAB_ENTRY_DT_INST_MOUNT_POINT(inst),                                \
 		.fs_data = &fs_data_##inst,                                                        \
 		.storage_dev = NULL,                                                               \
 		.flags = FSTAB_ENTRY_DT_MOUNT_FLAGS(DT_DRV_INST(inst)),                            \

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -1101,7 +1101,7 @@ static struct fs_littlefs fs_data_##inst = { \
 }; \
 struct fs_mount_t FS_FSTAB_ENTRY(DT_DRV_INST(inst)) = { \
 	.type = FS_LITTLEFS, \
-	.mnt_point = DT_INST_PROP(inst, mount_point), \
+	.mnt_point = FSTAB_ENTRY_DT_INST_MOUNT_POINT(inst), \
 	.fs_data = &fs_data_##inst, \
 	.storage_dev = (void *)DT_FIXED_PARTITION_ID(FS_PARTITION(inst)), \
 	.flags = FSTAB_ENTRY_DT_MOUNT_FLAGS(DT_DRV_INST(inst)), \

--- a/tests/subsys/fs/fs_api/app.overlay
+++ b/tests/subsys/fs/fs_api/app.overlay
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/ {
+	test_disk: disk {
+		compatible = "zephyr,fstab,fatfs";
+		mount-point = "/TEST:";
+	};
+};

--- a/tests/subsys/fs/fs_api/src/test_fs_dt.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dt.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 James Roy <rruuaanng@outlook.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_fstab_fatfs
+#include "test_fs.h"
+
+#define TEST_NODELABEL DT_NODELABEL(test_disk)
+
+ZTEST(test_fs_dt_api, test_dt_api_mount_point)
+{
+	const char *mnt_point1, *mnt_point2;
+
+	mnt_point1 = FSTAB_ENTRY_DT_MOUNT_POINT(TEST_NODELABEL);
+	zassert_str_equal(mnt_point1, "/TEST:");
+
+	mnt_point2 = FSTAB_ENTRY_DT_INST_MOUNT_POINT(0);
+	zassert_str_equal(mnt_point2, "/TEST:");
+}
+
+ZTEST_SUITE(test_fs_dt_api, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Since `mount-point` are commonly used in applications, I suggest adding a dedicated wrapper macro.