### PR TITLE
drivers: disk: sdmmc_stm32: Fix bus width initialization sequence

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -63,6 +63,14 @@ LOG_MODULE_REGISTER(stm32_sdmmc, CONFIG_SDMMC_LOG_LEVEL);
 #define SDMMC_HARDWARE_FLOW_CONTROL_DISABLE SDIO_HARDWARE_FLOW_CONTROL_DISABLE
 #endif
 
+#if DT_INST_PROP(0, bus_width) == 1
+#define SDMMC_BUS_WIDTH SDMMC_BUS_WIDE_1B
+#elif DT_INST_PROP(0, bus_width) == 4
+#define SDMMC_BUS_WIDTH SDMMC_BUS_WIDE_4B
+#elif DT_INST_PROP(0, bus_width) == 8
+#define SDMMC_BUS_WIDTH SDMMC_BUS_WIDE_8B
+#endif /* DT_INST_PROP(0, bus_width) */
+
 typedef void (*irq_config_func_t)(const struct device *dev);
 
 #if STM32_SDMMC_USE_DMA
@@ -412,6 +420,17 @@ static int stm32_sdmmc_access_init(struct disk_info *disk)
 		LOG_ERR("failed to init stm32_sdmmc (ErrorCode 0x%X)", priv->hsd.ErrorCode);
 		err = -EIO;
 		goto error;
+	}
+
+	if (SDMMC_BUS_WIDTH != SDMMC_BUS_WIDE_1B) {
+		priv->hsd.Init.BusWide = SDMMC_BUS_WIDTH;
+		err = HAL_SD_ConfigWideBusOperation(&priv->hsd, priv->hsd.Init.BusWide);
+		if (err != HAL_OK) {
+			LOG_ERR("failed to configure wide bus operation (ErrorCode 0x%X)",
+				priv->hsd.ErrorCode);
+			err = -EIO;
+			goto error;
+		}
 	}
 
 #ifdef CONFIG_SDMMC_STM32_HWFC
@@ -899,14 +918,6 @@ static void stm32_sdmmc_irq_config_func(const struct device *dev)
 	irq_enable(DT_INST_IRQN(0));
 }
 
-#if DT_INST_PROP(0, bus_width) == 1
-#define SDMMC_BUS_WIDTH SDMMC_BUS_WIDE_1B
-#elif DT_INST_PROP(0, bus_width) == 4
-#define SDMMC_BUS_WIDTH SDMMC_BUS_WIDE_4B
-#elif DT_INST_PROP(0, bus_width) == 8
-#define SDMMC_BUS_WIDTH SDMMC_BUS_WIDE_8B
-#endif /* DT_INST_PROP(0, bus_width) */
-
 static struct stm32_pclken pclken_sdmmc[] = STM32_DT_INST_CLOCKS(0);
 
 static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
@@ -924,7 +935,7 @@ static struct stm32_sdmmc_priv stm32_sdmmc_priv_1 = {
 						: SDMMC_CLOCK_BYPASS_DISABLE,
 #endif
 		.Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_DISABLE,
-		.Init.BusWide = SDMMC_BUS_WIDTH,
+		.Init.BusWide = SDMMC_BUS_WIDE_1B,
 		.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE,
 		.Init.ClockDiv = DT_INST_PROP_OR(0, clk_div, 0),
 	},


### PR DESCRIPTION
Fix SDMMC initialization by starting with 1-bit bus mode and properly configuring wide bus operation after HAL
initialization.

The SDMMC protocol requires initialization to start in 1-bit mode before switching to wider bus widths.
Previously, the driver attempted to initialize directly with the target bus width, which could cause later read/write failures.

Changes:
- Initialize with SDMMC_BUS_WIDE_1B instead of target bus width
- Add HAL_SD_ConfigWideBusOperation() call after successful init
- Add error logging for wide bus configuration failures

Fixes potential SDMMC read/write failures issues on STM32 platforms.

### before this change tested on stm32H743:
with `zephyr/tests/drivers/disk/disk_access`
dts: 
```
&sdmmc1 {
	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
	pinctrl-names = "default";
	clk-div = <6>;
	bus-width = <1>;
	cd-gpios = <&gpiod 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
	disk-name = "SD";
	status = "okay";
};
```
#### with 1 line bus width ( bus-width = <1>)
```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [disk_driver]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.122 seconds
 - PASS - [disk_driver.test_read] duration = 0.041 seconds
 - PASS - [disk_driver.test_write] duration = 0.081 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
#### with 4 line bus width ( bus-width = <4>)

```
------ TESTSUITE SUMMARY START ------

SUITE FAIL -   0.00% [disk_driver]: pass = 0, fail = 2, skip = 0, total = 2 duration = 0.131 seconds
 - FAIL - [disk_driver.test_read] duration = 0.104 seconds
 - FAIL - [disk_driver.test_write] duration = 0.027 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION FAILED
```
### after this change tested on stm32H743:
#### with 4 line bus width ( bus-width = <4>)

```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [disk_driver]: pass = 2, fail = 0, skip = 0, total = 2 duration = 0.122 seconds
 - PASS - [disk_driver.test_read] duration = 0.041 seconds
 - PASS - [disk_driver.test_write] duration = 0.081 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```