### PR TITLE
samples: settings: handle failures

### DIFF
--- a/samples/subsys/settings/src/main.c
+++ b/samples/subsys/settings/src/main.c
@@ -418,7 +418,7 @@ static void example_without_handler(void)
 	}
 }
 
-static void example_initialization(void)
+static int example_initialization(void)
 {
 	int rc;
 
@@ -450,7 +450,7 @@ static void example_initialization(void)
 	rc = settings_subsys_init();
 	if (rc) {
 		printk("settings subsys initialization: fail (err %d)\n", rc);
-		return;
+		return rc;
 	}
 
 	printk("settings subsys initialization: OK.\n");
@@ -459,10 +459,13 @@ static void example_initialization(void)
 	if (rc) {
 		printk("subtree <%s> handler registered: fail (err %d)\n",
 		       alpha_handler.name, rc);
+		return rc;
 	}
 
 	printk("subtree <%s> handler registered: OK\n", alpha_handler.name);
 	printk("subtree <alpha/beta> has static handler\n");
+
+	return 0;
 }
 
 static void example_delete(void)
@@ -542,7 +545,9 @@ int main(void)
 	printk("\n*** Settings usage example ***\n\n");
 
 	/* settings initialization */
-	example_initialization();
+	if (example_initialization() != 0) {
+		return 0;
+	}
 
 	for (i = 0; i < 6; i++) {
 		printk("\n##############\n");


### PR DESCRIPTION
If we cannot initialize settings subsystem, it does not make
much sense to do calls into it. This leads to uninitialized
variables being printed and generally makes it hard to tell whether
or not the sample runs with the given config.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
