### PR TITLE
boards: renode: fix cortex_r8_virtual private memory region

### DIFF
--- a/boards/renode/cortex_r8_virtual/support/cortex_r8_virtual.repl
+++ b/boards/renode/cortex_r8_virtual/support/cortex_r8_virtual.repl
@@ -7,8 +7,8 @@ cpu: CPU.ARMv7R @ sysbus
 scu: Miscellaneous.ArmSnoopControlUnit @ sysbus 0xae000000
 
 gic: IRQControllers.ARM_GenericInterruptController @ {
-        sysbus new Bus.BusMultiRegistration { address: 0xf9001000; size: 0x100; region: "cpuInterface" };
-        sysbus new Bus.BusMultiRegistration { address: 0xf9000000; size: 0x1000; region: "distributor" }
+        sysbus new Bus.BusMultiRegistration { address: 0xae000100; size: 0x100; region: "cpuInterface" };
+        sysbus new Bus.BusMultiRegistration { address: 0xae001000; size: 0x1000; region: "distributor" }
     }
     [0,1] -> cpu@[0,1]
     architectureVersion: IRQControllers.ARM_GenericInterruptControllerVersion.GICv1

--- a/dts/arm/cortex_r8_virt.dtsi
+++ b/dts/arm/cortex_r8_virt.dtsi
@@ -58,9 +58,9 @@
 			clock-frequency = <5000000>;
 		};
 
-		gic: interrupt-controller@f9000000 {
+		gic: interrupt-controller@ae001000 {
 			compatible = "arm,gic-v1", "arm,gic";
-			reg = <0xf9000000 0x1000>, <0xf9001000 0x100>;
+			reg = <0xae001000 0x1000>, <0xae000100 0x100>;
 			interrupt-controller;
 			#interrupt-cells = <0x4>;
 			status = "okay";

--- a/soc/renode/cortex_r8_virtual/arm_mpu_regions.c
+++ b/soc/renode/cortex_r8_virtual/arm_mpu_regions.c
@@ -57,6 +57,13 @@ static const struct arm_mpu_region mpu_regions[] = {
 			 NORMAL_OUTER_INNER_WRITE_BACK_WRITE_READ_ALLOCATE_NON_SHAREABLE}),
 #endif /* CONFIG_XIP */
 	MPU_REGION_ENTRY(
+		"priv_peripherals",
+		0xae000000,
+		REGION_8K,
+		{.rasr = P_RW_U_NA_Msk |
+			 DEVICE_SHAREABLE |
+			 NOT_EXEC}),
+	MPU_REGION_ENTRY(
 		"peripherals",
 		0xf8000000,
 		REGION_128M,


### PR DESCRIPTION
Correct GIC addresses to match ARM Cortex-R8 TRM PERIPHBASE specification. GIC must be at fixed offsets from PERIPHBASE (0xAE000000)
- Distributor: 0xAE001000 (PERIPHBASE + 0x1000)
- CPU Interface: 0xAE000100 (PERIPHBASE + 0x100)

Updated device tree, MPU regions, and Renode configuration to use correct addresses and add required memory protection.