### PR TITLE
drivers: stm32_ll_spi.c: Fix occurring BUS FAULT in transceive, when passing an invalid config

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -933,7 +933,7 @@ static int transceive(const struct device *dev,
 
 	ret = spi_stm32_configure(dev, config, tx_bufs != NULL);
 	if (ret) {
-		goto end;
+		return ret;
 	}
 
 	/* Set buffers info */
@@ -1150,7 +1150,8 @@ static int transceive_dma(const struct device *dev,
 
 	ret = spi_stm32_configure(dev, config, tx_bufs != NULL);
 	if (ret) {
-		goto end;
+		spi_stm32_pm_policy_state_lock_put(dev);
+		return ret;
 	}
 
 	uint32_t transfer_dir = LL_SPI_GetTransferDirection(spi);


### PR DESCRIPTION
The first time I've tried to use the SPI driver and I didn't understand why my nucleo_u575zi_q got a BUS FAULT when trying to read data on the SPI device.

A little research led me to first, that I didn't configure well my driver, and forgot to pass the flag of `SPI_WORD_SET(8)`. And secondly, that the BUS FAULT is from a bug in the driver itself! Which tried to access an address of 0x4.. This is of course because we try to access a variable which is only initialized in the config `spi_stm32_configure` that has failed to run!

Thank you in advance, this is my first pull request