### PR TITLE
drivers: spi: spi_pico_pio: Prevent dma_config check if DMA is not enabled

### DIFF
--- a/drivers/spi/spi_rpi_pico_pio.c
+++ b/drivers/spi/spi_rpi_pico_pio.c
@@ -320,10 +320,12 @@ static int spi_pico_pio_configure(const struct spi_pico_pio_config *dev_cfg,
 
 #if SPI_RPI_PICO_PIO_HALF_DUPLEX_ENABLED
 	if (spi_cfg->operation & SPI_HALF_DUPLEX) {
+#if defined(CONFIG_SPI_RPI_PICO_PIO_DMA)
 		if (dev_cfg->dma_config.dev) {
 			LOG_ERR("DMA not supported in 3-wire operation");
 			return -ENOTSUP;
 		}
+#endif
 
 		if ((cpol != 0) || (cpha != 0)) {
 			LOG_ERR("Only mode (0, 0) supported in 3-wire SIO");


### PR DESCRIPTION
At this moment, DMA for SPI 3-wire half-duplex operation is not supported by the pio driver. A check was implemented there to prevent users from enabling DMA, but it wasn't bypassed when CONFIG_SPI_RPI_PICO_PIO_DMA is not enabled, under which the `dma_config` structure isn't defined at all.

Fixed #94897.