### PR TITLE
tests: kernel: fix thread_runtime_stats compiler optimization issue

### DIFF
--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -33,7 +33,10 @@ static struct k_thread *main_thread;
  */
 void helper1(void *p1, void *p2, void *p3)
 {
-	while (1) {
+	/* Using volatile condition to prevent compilers from optimizing while(true) */
+	volatile bool condition = true;
+
+	while (condition) {
 	}
 }
 


### PR DESCRIPTION
Compilers may optimize away empty **while(1){}** loop in helper threads, causing the idle thread to run instead and breaking runtime statistics measurement.

Use volatile condition variable to prevent optimization.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/94911