### PR TITLE
doc: update pyOCD repository links

### DIFF
--- a/boards/96boards/nitrogen/doc/index.rst
+++ b/boards/96boards/nitrogen/doc/index.rst
@@ -311,7 +311,7 @@ You can debug an application in the usual way.  Here is an example for the
    :goals: debug
 
 .. _pyOCD:
-    https://github.com/mbedmicro/pyOCD
+    https://github.com/pyocd/pyOCD
 
 .. _CMSIS DAP:
     https://developer.mbed.org/handbook/CMSIS-DAP
@@ -323,7 +323,7 @@ You can debug an application in the usual way.  Here is an example for the
     http://wiki.seeed.cc/BLE_Nitrogen/
 
 .. _pyOCD issue 259:
-    https://github.com/mbedmicro/pyOCD/issues/259
+    https://github.com/pyocd/pyOCD/issues/259
 
 .. _96Boards IE Specification:
     https://linaro.co/ie-specification

--- a/doc/develop/debug/index.rst
+++ b/doc/develop/debug/index.rst
@@ -363,4 +363,4 @@ in the log.
 
 .. _Eclipse IDE for C/C++ Developers: https://www.eclipse.org/downloads/packages/eclipse-ide-cc-developers/oxygen2
 .. _GNU MCU Eclipse plug-ins: https://gnu-mcu-eclipse.github.io/plugins/install/
-.. _pyOCD v0.11.0: https://github.com/mbedmicro/pyOCD/releases/tag/v0.11.0
+.. _pyOCD v0.11.0: https://github.com/pyocd/pyOCD/releases/tag/v0.11.0


### PR DESCRIPTION
The repository has been moved to a new organization, see https://pyocd.io/. Update links to the pyOCD repository.