### PR TITLE
drivers: flash: esp32: handle zero-length reads as no-op

### DIFF
--- a/drivers/flash/flash_esp32.c
+++ b/drivers/flash/flash_esp32.c
@@ -89,6 +89,10 @@ static int flash_esp32_read(const struct device *dev, off_t address, void *buffe
 {
 	int ret = 0;
 
+	if (length == 0U) {
+		return 0;
+	}
+
 #ifdef CONFIG_MCUBOOT
 	uint8_t *dest_ptr = (uint8_t *)buffer;
 	size_t remaining = length;


### PR DESCRIPTION
Add a guard clause in flash_esp32_read() to return 0 when the
requested length is zero. This avoids unnecessary operations
and aligns with expected flash API behavior, where reading
zero bytes is treated as a no-op.