### PR TITLE
drivers: watchdog: gecko: Enable tests and fix corner cases

### DIFF
--- a/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.yaml
+++ b/boards/silabs/dev_kits/xg27_dk2602a/xg27_dk2602a.yaml
@@ -16,4 +16,5 @@ supported:
   - clock_control
   - comparator
   - adc
+  - watchdog
 vendor: silabs

--- a/dts/arm/silabs/xg27/xg27.dtsi
+++ b/dts/arm/silabs/xg27/xg27.dtsi
@@ -462,9 +462,9 @@
 			status = "disabled";
 		};
 
-		wdog0: wdog@4a018000 {
+		wdog0: wdog@5a018000 {
 			compatible = "silabs,gecko-wdog";
-			reg = <0x4A018000 0x3028>;
+			reg = <0x5A018000 0x3028>;
 			interrupts = <49 2>;
 			clocks = <&cmu CLOCK_WDOG0 CLOCK_BRANCH_WDOG0CLK>;
 			peripheral-id = <0>;

--- a/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_basic_reset_none/testcase.yaml
@@ -3,7 +3,10 @@
 
 tests:
   drivers.watchdog.reset_none:
-    filter: dt_compat_enabled("nxp,s32-swt") or dt_compat_enabled("renesas,ra-wdt")
+    filter: |
+      dt_compat_enabled("nxp,s32-swt")
+      or dt_compat_enabled("renesas,ra-wdt")
+      or dt_compat_enabled("silabs,gecko-wdog")
     integration_platforms:
       - s32z2xxdc2/s32z270/rtu0
     tags:

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -37,6 +37,7 @@
 #define WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED     BIT(6)
 #define WDT_FEED_CAN_STALL                        BIT(7)
 #define WDT_WINDOW_MIN_SUPPORTED                  BIT(8)
+#define WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM        BIT(9)
 
 /* Common for all targets: */
 #define DEFAULT_WINDOW_MAX (500U)
@@ -433,6 +434,11 @@ ZTEST(wdt_coverage, test_06b_wdt_setup_WDT_OPT_PAUSE_IN_SLEEP_functional)
 
 	if (!(WDT_TEST_FLAGS & WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED)) {
 		/* Skip this test because WDT_OPT_PAUSE_IN_SLEEP can NOT be used. */
+		ztest_test_skip();
+	}
+
+	if ((WDT_TEST_FLAGS & WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM) && !IS_ENABLED(CONFIG_PM)) {
+		/* Skip this test because WDT_OPT_PAUSE_IN_SLEEP can't be tested without PM. */
 		ztest_test_skip();
 	}
 

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -326,6 +326,11 @@ ZTEST(wdt_coverage, test_04wm_wdt_install_timeout_with_multiple_timeout_values)
 		ztest_test_skip();
 	}
 
+	if (MAX_INSTALLABLE_TIMEOUTS < 2) {
+		/* Skip this test because two timeouts aren't supported */
+		ztest_test_skip();
+	}
+
 	m_cfg_wdt0.callback = NULL;
 	m_cfg_wdt0.flags = DEFAULT_FLAGS;
 	m_cfg_wdt0.window.max = DEFAULT_WINDOW_MAX;

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -36,6 +36,7 @@
 #define WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED          BIT(5)
 #define WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED     BIT(6)
 #define WDT_FEED_CAN_STALL                        BIT(7)
+#define WDT_WINDOW_MIN_SUPPORTED                  BIT(8)
 
 /* Common for all targets: */
 #define DEFAULT_WINDOW_MAX (500U)
@@ -276,12 +277,14 @@ ZTEST(wdt_coverage, test_04w_wdt_install_timeout_with_invalid_window)
 	/* ----------------- window.min
 	 * Check that window.min can't be different than 0
 	 */
-	m_cfg_wdt0.window.min = 1U;
-	ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
-	zassert_true(ret == -EINVAL,
-		     "Calling wdt_install_timeout with window.min = 1 should return -EINVAL (-22), "
-		     "got unexpected value of %d",
-		     ret);
+	if (!(WDT_TEST_FLAGS & WDT_WINDOW_MIN_SUPPORTED)) {
+		m_cfg_wdt0.window.min = 1U;
+		ret = wdt_install_timeout(wdt, &m_cfg_wdt0);
+		zassert_true(ret == -EINVAL,
+			"Calling wdt_install_timeout with window.min = 1 should return -EINVAL (-22), "
+			"got unexpected value of %d",
+			ret);
+	}
 
 	/* Set default window.min */
 	m_cfg_wdt0.window.min = DEFAULT_WINDOW_MIN;

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -54,6 +54,21 @@
 #define MAX_INSTALLABLE_TIMEOUTS (8)
 #define WDT_WINDOW_MAX_ALLOWED   (0x07CFFFFFU)
 #define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
+#elif defined(CONFIG_SOC_FAMILY_SILABS_S2)
+#if defined(WDOG_CFG_EM1RUN)
+#define WDT_TEST_FLAG_SLEEP_REQUIRES_PM 0
+#else
+#define WDT_TEST_FLAG_SLEEP_REQUIRES_PM WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM
+#endif
+#define WDT_TEST_FLAGS                                                                             \
+	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_NONE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |    \
+	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \
+	 WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED | WDT_WINDOW_MIN_SUPPORTED |                        \
+	 WDT_TEST_FLAG_SLEEP_REQUIRES_PM)
+#define DEFAULT_FLAGS            (WDT_FLAG_RESET_NONE)
+#define MAX_INSTALLABLE_TIMEOUTS (1)
+#define WDT_WINDOW_MAX_ALLOWED   (0x40001U)
+#define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
 #else
 /* By default run most of the error checks.
  * See Readme.txt on how to align test scope for the specific target.

--- a/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
+++ b/tests/drivers/watchdog/wdt_error_cases/testcase.yaml
@@ -17,7 +17,15 @@ tests:
       - nrf9280pdk/nrf9280/cpurad
       - ophelia4ev/nrf54l15/cpuapp
       - raytac_an54l15q_db/nrf54l15/cpuapp
+      - xg24_rb4187c
+      - xg27_dk2602a
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
       - raytac_an54l15q_db/nrf54l15/cpuapp
+  drivers.watchdog.wdt_error_cases_pm:
+    platform_allow:
+      - xg24_rb4187c
+      - xg27_dk2602a
+    extra_configs:
+      - CONFIG_PM=y


### PR DESCRIPTION
Enhance error case test to support the feature set of the watchdog on Silicon Labs Series 2 devices. Fix issues in the watchdog driver for these devices to make the tests pass.

The `wdt_error_cases` testsuite on `xg24_rb4187c` with the changes in this PR:
```
------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [wdt_coverage]: pass = 16, fail = 0, skip = 7, total = 23 duration = 3.694 seconds
 - PASS - [wdt_coverage.test_01_wdt_disable_before_wdt_setup] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_02_wdt_setup_before_setting_timeouts] duration = 0.003 seconds
 - PASS - [wdt_coverage.test_03_wdt_feed_before_wdt_setup_channel_not_configured] duration = 0.001 seconds
 - SKIP - [wdt_coverage.test_04a_wdt_install_timeout_WDT_FLAG_RESET_NONE_not_supported] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_04b_wdt_install_timeout_WDT_FLAG_RESET_CPU_CORE_not_supported] duration = 0.007 seconds
 - SKIP - [wdt_coverage.test_04c_wdt_install_timeout_WDT_FLAG_RESET_SOC_not_supported] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_04w_wdt_install_timeout_with_invalid_window] duration = 0.007 seconds
 - SKIP - [wdt_coverage.test_04wm_wdt_install_timeout_with_multiple_timeout_values] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_05_wdt_install_timeout_after_wdt_setup] duration = 0.008 seconds
 - SKIP - [wdt_coverage.test_06a_wdt_setup_WDT_OPT_PAUSE_IN_SLEEP_not_supported] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_06b_wdt_setup_WDT_OPT_PAUSE_IN_SLEEP_functional] duration = 1.010 seconds
 - SKIP - [wdt_coverage.test_06c_wdt_setup_WDT_OPT_PAUSE_HALTED_BY_DBG_not_supported] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_06d_wdt_setup_without_any_OPT] duration = 0.007 seconds
 - PASS - [wdt_coverage.test_07_wdt_setup_already_done] duration = 0.007 seconds
 - SKIP - [wdt_coverage.test_08a_wdt_disable_not_supported] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_08b_wdt_disable_check_not_firing] duration = 0.760 seconds
 - PASS - [wdt_coverage.test_08c_wdt_disable_check_timeouts_reusable] duration = 0.013 seconds
 - PASS - [wdt_coverage.test_08d_wdt_disable_check_timeouts_uninstalled] duration = 1.820 seconds
 - PASS - [wdt_coverage.test_08e_wdt_setup_immediately_after_wdt_disable] duration = 0.010 seconds
 - PASS - [wdt_coverage.test_09a_wdt_feed_before_wdt_setup_channel_configured] duration = 0.006 seconds
 - PASS - [wdt_coverage.test_09b_wdt_feed_invalid_channel] duration = 0.018 seconds
 - SKIP - [wdt_coverage.test_09c_wdt_feed_stall] duration = 0.001 seconds
 - PASS - [wdt_coverage.test_10_wdt_install_timeout_max_number_of_timeouts] duration = 0.009 seconds

------ TESTSUITE SUMMARY END ------
```