### PR TITLE
Use mcxa346 linkserver for mcxa266

### DIFF
--- a/boards/nxp/frdm_mcxa266/board.cmake
+++ b/boards/nxp/frdm_mcxa266/board.cmake
@@ -5,7 +5,7 @@
 #
 
 board_runner_args(jlink "--device=MCXA266")
-board_runner_args(linkserver "--device=MCXA266:FRDM-MCXA266")
+board_runner_args(linkserver "--device=MCXA346:FRDM-MCXA346")
 board_runner_args(pyocd "--target=mcxa266")
 
 include(${ZEPHYR_BASE}/boards/common/linkserver.board.cmake)


### PR DESCRIPTION
The frdm-mcxa266 linkserver is not ready now, temporarily use the frdm-mcxa346 linkserver.