### PR TITLE
dts: npcx: re-arrange the default interrupt priority

### DIFF
--- a/dts/arm/nuvoton/npcx/npcx-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-miwus-int-map.dtsi
@@ -13,12 +13,12 @@
 
 			group_b0: group-b0-map {
 				irq        = <31>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x02>;
 			};
 			group_c0: group-c0-map {
 				irq        = <15>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x04>;
 			};
 		};
@@ -29,42 +29,42 @@
 
 			group_a1: group-a1-map {
 				irq        = <47>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x01>;
 			};
 			group_b1: group-b1-map {
 				irq        = <48>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x02>;
 			};
 			group_c1: group-c1-map {
 				irq        = <49>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x04>;
 			};
 			group_d1: group-d1-map {
 				irq        = <50>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x08>;
 			};
 			group_e1: group-e1-map {
 				irq        = <51>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x10>;
 			};
 			group_f1: group-f1-map {
 				irq        = <52>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x20>;
 			};
 			group_g1: group-g1-map {
 				irq        = <53>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x40>;
 			};
 			group_h1: group-h1-map {
 				irq        = <54>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x80>;
 			};
 		};
@@ -75,22 +75,22 @@
 
 			group_a2: group-a2-map {
 				irq        = <60>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x01>;
 			};
 			group_b2: group-b2-map {
 				irq        = <61>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x02>;
 			};
 			group_c2: group-c2-map {
 				irq        = <62>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x04>;
 			};
 			group_d2: group-d2-map {
 				irq        = <63>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x08>;
 			};
 		};

--- a/dts/arm/nuvoton/npcx/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx.dtsi
@@ -325,7 +325,7 @@
 			compatible = "nuvoton,npcx-adc";
 			#io-channel-cells = <1>;
 			reg = <0x400d1000 0x2000>;
-			interrupts = <10 3>;
+			interrupts = <10 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL4 4>;
 			vref-mv = <2816>;
 			status = "disabled";
@@ -340,7 +340,7 @@
 		espi0: espi@4000a000 {
 			compatible = "nuvoton,npcx-espi";
 			reg = <0x4000a000 0x2000>;
-			interrupts = <18 3>; /* Interrupt for eSPI Bus */
+			interrupts = <18 4>; /* Interrupt for eSPI Bus */
 
 			/* clocks for eSPI modules */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL6 7>;
@@ -366,11 +366,11 @@
 				    "pm_hcmd";
 
 			/* host sub-module IRQ and priority */
-			interrupts = <25 3>, /* KBC Input-Buf-Full (IBF) */
-				     <56 3>, /* KBC Output-Buf-Empty (OBE) */
-				     <26 3>, /* PMCH Input-Buf-Full (IBF) */
-				     <3 3>,  /* PMCH Output-Buf-Empty (OBE) */
-				     <6 3>;  /* Port80 FIFO Not Empty */
+			interrupts = <25 4>, /* KBC Input-Buf-Full (IBF) */
+				     <56 4>, /* KBC Output-Buf-Empty (OBE) */
+				     <26 4>, /* PMCH Input-Buf-Full (IBF) */
+				     <3 4>,  /* PMCH Output-Buf-Empty (OBE) */
+				     <6 4>;  /* Port80 FIFO Not Empty */
 			interrupt-names = "kbc_ibf", "kbc_obe", "pmch_ibf",
 					  "pmch_obe", "p80_fifo";
 
@@ -402,7 +402,7 @@
 		ps2_ctrl0: ps2@400b1000 {
 			compatible = "nuvoton,npcx-ps2-ctrl";
 			reg = <0x400b1000 0x1000>;
-			interrupts = <21 4>;
+			interrupts = <21 5>;
 			clocks = <&pcc NPCX_CLOCK_BUS_FREERUN NPCX_PWDWN_CTL1 3>;
 
 			/* PS2 Channels - Please use them as PS2 node */
@@ -444,7 +444,7 @@
 			reg = <0x400d4000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			interrupts = <4 4>;
+			interrupts = <4 5>;
 			clocks = <&pcc NPCX_CLOCK_BUS_FMCLK NPCX_PWDWN_CTL4 5>;
 			status = "disabled";
 		};
@@ -452,7 +452,7 @@
 		kbd: kbd@400a3000 {
 			compatible = "nuvoton,npcx-kbd";
 			reg = <0x400a3000 0x2000>;
-			interrupts = <49 4>;
+			interrupts = <49 5>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL1 0>;
 			wui-maps = <&wui_io31 &wui_io30 &wui_io27 &wui_io26
 				    &wui_io25 &wui_io24 &wui_io23 &wui_io22>;
@@ -464,7 +464,7 @@
 			reg = <0x400d2000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			interrupts = <57 3>;
+			interrupts = <57 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL4 7>;
 			status = "disabled";
 

--- a/dts/arm/nuvoton/npcx/npcx4.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4.dtsi
@@ -99,7 +99,7 @@
 			reg-names = "evt_itim", "sys_itim";
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL4 0
 				  &pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 5>;
-			interrupts = <28 1>; /* Event timer interrupt */
+			interrupts = <28 2>; /* Event timer interrupt */
 			clock-frequency = <15000000>; /* Set for SYS_CLOCK_HW_CYCLES_PER_SEC */
 		};
 
@@ -107,7 +107,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART1 register, Index 1: MDMA1 register */
 			reg = <0x400E0000 0x2000 0x40011100 0x100>;
-			interrupts = <33 3>;
+			interrupts = <33 4>;
 			/* Index 0: UART1 clock, Index 1: MDMA1 clock */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL1 4
 				  &pcc NPCX_CLOCK_BUS_CORE NPCX_PWDWN_CTL9 0>;
@@ -119,7 +119,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART2 register, Index 1: MDMA2 register */
 			reg = <0x400E2000 0x2000 0x40011200 0x100>;
-			interrupts = <32 3>;
+			interrupts = <32 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 6>;
 			uart-rx = <&wui_cr_sin2>;
 			status = "disabled";
@@ -129,7 +129,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART3 register, Index 1: MDMA3 register */
 			reg = <0x400E4000 0x2000 0x40011300 0x100>;
-			interrupts = <38 3>;
+			interrupts = <38 4>;
 			/* Index 0: UART3 clock, Index 1: MDMA3 clock */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 4
 				  &pcc NPCX_CLOCK_BUS_CORE NPCX_PWDWN_CTL9 2>;
@@ -141,7 +141,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART4 register, Index 1: MDMA4 register */
 			reg = <0x400E6000 0x2000 0x40011400 0x100>;
-			interrupts = <39 3>;
+			interrupts = <39 4>;
 			/* Index 0: UART4 clock, Index 1: MDMA4 clock */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 3
 				  &pcc NPCX_CLOCK_BUS_CORE NPCX_PWDWN_CTL9 3>;
@@ -301,7 +301,7 @@
 		i2c_ctrl0: i2c@40009000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40009000 0x1000>;
-			interrupts = <13 3>;
+			interrupts = <13 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
 			smb-wui = <&wui_smb0>;
 			status = "disabled";
@@ -310,7 +310,7 @@
 		i2c_ctrl1: i2c@4000b000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <14 3>;
+			interrupts = <14 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
 			smb-wui = <&wui_smb1>;
 			status = "disabled";
@@ -319,7 +319,7 @@
 		i2c_ctrl2: i2c@400c0000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c0000 0x1000>;
-			interrupts = <36 3>;
+			interrupts = <36 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 2>;
 			smb-wui = <&wui_smb2>;
 			status = "disabled";
@@ -328,7 +328,7 @@
 		i2c_ctrl3: i2c@400c2000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c2000 0x1000>;
-			interrupts = <37 3>;
+			interrupts = <37 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 3>;
 			smb-wui = <&wui_smb3>;
 			status = "disabled";
@@ -337,7 +337,7 @@
 		i2c_ctrl4: i2c@40008000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40008000 0x1000>;
-			interrupts = <19 3>;
+			interrupts = <19 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
 			smb-wui = <&wui_smb4>;
 			status = "disabled";
@@ -346,7 +346,7 @@
 		i2c_ctrl5: i2c@40017000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40017000 0x1000>;
-			interrupts = <20 3>;
+			interrupts = <20 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 0>;
 			smb-wui = <&wui_smb5>;
 			status = "disabled";
@@ -355,7 +355,7 @@
 		i2c_ctrl6: i2c@40018000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40018000 0x1000>;
-			interrupts = <16 3>;
+			interrupts = <16 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 1>;
 			smb-wui = <&wui_smb6>;
 			status = "disabled";
@@ -364,7 +364,7 @@
 		i2c_ctrl7: i2c@40019000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40019000 0x1000>;
-			interrupts = <8 3>;
+			interrupts = <8 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 2>;
 			smb-wui = <&wui_smb7>;
 			status = "disabled";
@@ -381,7 +381,7 @@
 			compatible = "nuvoton,npcx-adc";
 			#io-channel-cells = <1>;
 			reg = <0x400d5000 0x2000>;
-			interrupts = <22 3>;
+			interrupts = <22 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL4 3>;
 			vref-mv = <3300>;
 			channel-count = <26>;
@@ -447,7 +447,7 @@
 			reg = <0x400f0000 0x2000>,
 			      <0x40011500 0x100>;
 
-			interrupts = <29 3>;
+			interrupts = <29 4>;
 
 			/* Reset controller */
 			resets = <&rctl NPCX_RESET_I3C_1>;
@@ -473,7 +473,7 @@
 			reg = <0x400f2000 0x2000>,
 			      <0x40011600 0x100>;
 
-			interrupts = <66 3>;
+			interrupts = <66 4>;
 
 			/* Reset controller */
 			resets = <&rctl NPCX_RESET_I3C_2>;
@@ -499,7 +499,7 @@
 			reg = <0x400f4000 0x2000>,
 			      <0x40011700 0x100>;
 
-			interrupts = <67 3>;
+			interrupts = <67 4>;
 
 			/* Reset controller */
 			resets = <&rctl NPCX_RESET_I3C_3>;

--- a/dts/arm/nuvoton/npcx/npcx4/npcx4-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx4/npcx4-miwus-int-map.dtsi
@@ -17,32 +17,32 @@
 
 			group_a0: group-a0-map {
 				irq        = <7>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x01>;
 			};
 			group_d0: group-d0-map {
 				irq        = <5>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x08>;
 			};
 			group_e0: group-e0-map {
 				irq        = <11>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x10>;
 			};
 			group_f0: group-f0-map {
 				irq        = <35>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x20>;
 			};
 			group_g0: group-g0-map {
 				irq        = <42>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x40>;
 			};
 			group_h0: group-h0-map {
 				irq        = <46>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x80>;
 			};
 		};
@@ -53,22 +53,22 @@
 
 			group_e2: group-e2-map {
 				irq        = <64>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x10>;
 			};
 			group_f2: group-f2-map {
 				irq        = <59>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x20>;
 			};
 			group_g2: group-g2-map {
 				irq        = <55>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x40>;
 			};
 			group_h2: group-h2-map {
 				irq        = <82>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x80>;
 			};
 		};

--- a/dts/arm/nuvoton/npcx/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7.dtsi
@@ -96,14 +96,14 @@
 			reg-names = "evt_itim", "sys_itim";
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL4 3
 				  &pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 5>;
-			interrupts = <46 1>; /* Event timer interrupt */
+			interrupts = <46 2>; /* Event timer interrupt */
 			clock-frequency = <15000000>; /* Set for SYS_CLOCK_HW_CYCLES_PER_SEC */
 		};
 
 		uart1: serial@400c4000 {
 			compatible = "nuvoton,npcx-uart";
 			reg = <0x400C4000 0x2000>;
-			interrupts = <33 3>;
+			interrupts = <33 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL1 4>;
 			uart-rx = <&wui_cr_sin1>;
 			status = "disabled";
@@ -112,7 +112,7 @@
 		uart2: serial@400c6000 {
 			compatible = "nuvoton,npcx-uart";
 			reg = <0x400C6000 0x2000>;
-			interrupts = <32 3>;
+			interrupts = <32 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 6>;
 			uart-rx = <&wui_cr_sin2>;
 			status = "disabled";
@@ -268,7 +268,7 @@
 		i2c_ctrl0: i2c@40009000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40009000 0x1000>;
-			interrupts = <13 3>;
+			interrupts = <13 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
 			smb-wui = <&wui_smb0_2>;
 			status = "disabled";
@@ -277,7 +277,7 @@
 		i2c_ctrl1: i2c@4000b000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <14 3>;
+			interrupts = <14 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
 			smb-wui = <&wui_smb1_3>;
 			status = "disabled";
@@ -286,7 +286,7 @@
 		i2c_ctrl2: i2c@400c0000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c0000 0x1000>;
-			interrupts = <36 3>;
+			interrupts = <36 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 2>;
 			smb-wui = <&wui_smb0_2>;
 			status = "disabled";
@@ -295,7 +295,7 @@
 		i2c_ctrl3: i2c@400c2000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c2000 0x1000>;
-			interrupts = <37 3>;
+			interrupts = <37 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 3>;
 			smb-wui = <&wui_smb1_3>;
 			status = "disabled";
@@ -304,7 +304,7 @@
 		i2c_ctrl4: i2c@40008000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40008000 0x1000>;
-			interrupts = <19 3>;
+			interrupts = <19 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
 			smb-wui = <&wui_smb4>;
 			status = "disabled";
@@ -313,7 +313,7 @@
 		i2c_ctrl5: i2c@40017000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40017000 0x1000>;
-			interrupts = <20 3>;
+			interrupts = <20 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 0>;
 			smb-wui = <&wui_smb5>;
 			status = "disabled";
@@ -322,7 +322,7 @@
 		i2c_ctrl6: i2c@40018000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40018000 0x1000>;
-			interrupts = <16 3>;
+			interrupts = <16 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 1>;
 			smb-wui = <&wui_smb6>;
 			status = "disabled";
@@ -331,7 +331,7 @@
 		i2c_ctrl7: i2c@40019000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40019000 0x1000>;
-			interrupts = <8 3>;
+			interrupts = <8 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 2>;
 			smb-wui = <&wui_smb7>;
 			status = "disabled";

--- a/dts/arm/nuvoton/npcx/npcx7/npcx7-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7/npcx7-miwus-int-map.dtsi
@@ -17,12 +17,12 @@
 
 			group_ad0: group-ad0-map {
 				irq        = <7>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x09>;
 			};
 			group_efgh0: group-efgh0-map {
 				irq        = <11>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0xF0>;
 			};
 		};
@@ -33,7 +33,7 @@
 
 			group_fg2: group-fg2-map {
 				irq        = <59>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x60>;
 			};
 		};

--- a/dts/arm/nuvoton/npcx/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9.dtsi
@@ -97,7 +97,7 @@
 			reg-names = "evt_itim", "sys_itim";
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL4 0
 				  &pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 5>;
-			interrupts = <28 1>; /* Event timer interrupt */
+			interrupts = <28 2>; /* Event timer interrupt */
 			clock-frequency = <15000000>; /* Set for SYS_CLOCK_HW_CYCLES_PER_SEC */
 		};
 
@@ -105,7 +105,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART1 register, Index 1: MDMA1 register */
 			reg = <0x400E0000 0x2000 0x40011100 0x100>;
-			interrupts = <33 3>;
+			interrupts = <33 4>;
 			/* Index 0: UART1 clock, Index 1: MDMA1 clock */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL1 4
 				  &pcc NPCX_CLOCK_BUS_CORE NPCX_PWDWN_CTL9 0>;
@@ -117,7 +117,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART2 register, Index 1: MDMA2 register */
 			reg = <0x400E2000 0x2000 0x40011200 0x100>;
-			interrupts = <32 3>;
+			interrupts = <32 4>;
 			/* Index 0: UART2 clock, Index 1: MDMA2 clock */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 6
 				  &pcc NPCX_CLOCK_BUS_CORE NPCX_PWDWN_CTL9 1>;
@@ -129,7 +129,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART3 register, Index 1: MDMA3 register */
 			reg = <0x400E4000 0x2000 0x40011300 0x100>;
-			interrupts = <38 3>;
+			interrupts = <38 4>;
 			/* Index 0: UART3 clock, Index 1: MDMA3 clock */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 4
 				  &pcc NPCX_CLOCK_BUS_CORE NPCX_PWDWN_CTL9 2>;
@@ -141,7 +141,7 @@
 			compatible = "nuvoton,npcx-uart";
 			/* Index 0: UART4 register, Index 1: MDMA4 register */
 			reg = <0x400E6000 0x2000 0x40011400 0x100>;
-			interrupts = <39 3>;
+			interrupts = <39 4>;
 			/* Index 0: UART4 clock, Index 1: MDMA4 clock */
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 3
 				  &pcc NPCX_CLOCK_BUS_CORE NPCX_PWDWN_CTL9 3>;
@@ -301,7 +301,7 @@
 		i2c_ctrl0: i2c@40009000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40009000 0x1000>;
-			interrupts = <13 3>;
+			interrupts = <13 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
 			smb-wui = <&wui_smb0_2>;
 			status = "disabled";
@@ -310,7 +310,7 @@
 		i2c_ctrl1: i2c@4000b000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x4000b000 0x1000>;
-			interrupts = <14 3>;
+			interrupts = <14 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
 			smb-wui = <&wui_smb1_3>;
 			status = "disabled";
@@ -319,7 +319,7 @@
 		i2c_ctrl2: i2c@400c0000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c0000 0x1000>;
-			interrupts = <36 3>;
+			interrupts = <36 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 2>;
 			smb-wui = <&wui_smb0_2>;
 			status = "disabled";
@@ -328,7 +328,7 @@
 		i2c_ctrl3: i2c@400c2000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x400c2000 0x1000>;
-			interrupts = <37 3>;
+			interrupts = <37 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 3>;
 			smb-wui = <&wui_smb1_3>;
 			status = "disabled";
@@ -337,7 +337,7 @@
 		i2c_ctrl4: i2c@40008000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40008000 0x1000>;
-			interrupts = <19 3>;
+			interrupts = <19 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
 			smb-wui = <&wui_smb4>;
 			status = "disabled";
@@ -346,7 +346,7 @@
 		i2c_ctrl5: i2c@40017000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40017000 0x1000>;
-			interrupts = <20 3>;
+			interrupts = <20 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 0>;
 			smb-wui = <&wui_smb5>;
 			status = "disabled";
@@ -355,7 +355,7 @@
 		i2c_ctrl6: i2c@40018000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40018000 0x1000>;
-			interrupts = <16 3>;
+			interrupts = <16 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 1>;
 			smb-wui = <&wui_smb6>;
 			status = "disabled";
@@ -364,7 +364,7 @@
 		i2c_ctrl7: i2c@40019000 {
 			compatible = "nuvoton,npcx-i2c-ctrl";
 			reg = <0x40019000 0x1000>;
-			interrupts = <8 3>;
+			interrupts = <8 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 2>;
 			smb-wui = <&wui_smb7>;
 			status = "disabled";

--- a/dts/arm/nuvoton/npcx/npcx9/npcx9-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9/npcx9-miwus-int-map.dtsi
@@ -17,32 +17,32 @@
 
 			group_a0: group-a0-map {
 				irq        = <7>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x01>;
 			};
 			group_d0: group-d0-map {
 				irq        = <5>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x08>;
 			};
 			group_e0: group-e0-map {
 				irq        = <11>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x10>;
 			};
 			group_f0: group-f0-map {
 				irq        = <35>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x20>;
 			};
 			group_g0: group-g0-map {
 				irq        = <42>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x40>;
 			};
 			group_h0: group-h0-map {
 				irq        = <46>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x80>;
 			};
 		};
@@ -53,12 +53,12 @@
 
 			group_f2: group-f2-map {
 				irq        = <59>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x20>;
 			};
 			group_g2: group-g2-map {
 				irq        = <55>;
-				irq-prio   = <2>;
+				irq-prio   = <3>;
 				group-mask = <0x40>;
 			};
 		};


### PR DESCRIPTION
Because the EC host command with SHI/SPI backend is timing sensitive, it required the CPU to response the SHI interrrupt as soon as possible. This commit re-arranges the default interrupt priority by:
1. keep the SHI's interrupt priority to 1.
2. Decrease the priority of the other peripherals by 1. (i.e. increase the priority `value` by 1)