### PR TITLE
Add support Counter driver for Renesas RZ/V2L, A3UL

### DIFF
--- a/boards/renesas/rza3ul_smarc/rza3ul_smarc.yaml
+++ b/boards/renesas/rza3ul_smarc/rza3ul_smarc.yaml
@@ -11,6 +11,7 @@ supported:
   - pwm
   - adc
   - i2c
+  - counter
 testing:
   ignore_tags:
     - bluetooth

--- a/boards/renesas/rzv2l_smarc/rzv2l_smarc_r9a07g054l23gbg_cm33.yaml
+++ b/boards/renesas/rzv2l_smarc/rzv2l_smarc_r9a07g054l23gbg_cm33.yaml
@@ -11,5 +11,6 @@ supported:
   - pwm
   - adc
   - i2c
+  - counter
   - mbox
 vendor: renesas

--- a/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
@@ -896,6 +896,11 @@
 				compatible = "renesas,rz-gtm-os-timer";
 				status = "disabled";
 			};
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
 		};
 
 		gtm1: gtm@42801400 {
@@ -910,6 +915,11 @@
 				compatible = "renesas,rz-gtm-os-timer";
 				status = "disabled";
 			};
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
 		};
 
 		gtm2: gtm@42801800 {
@@ -922,6 +932,11 @@
 
 			os_timer {
 				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
 				status = "disabled";
 			};
 		};

--- a/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
+++ b/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
@@ -659,6 +659,11 @@
 				compatible = "renesas,rz-gtm-os-timer";
 				status = "disabled";
 			};
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
 		};
 
 		gtm1: gtm@12801400 {
@@ -673,6 +678,11 @@
 				compatible = "renesas,rz-gtm-os-timer";
 				status = "disabled";
 			};
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
+				status = "disabled";
+			};
 		};
 
 		gtm2: gtm@12801800 {
@@ -685,6 +695,11 @@
 
 			os_timer {
 				compatible = "renesas,rz-gtm-os-timer";
+				status = "disabled";
+			};
+
+			counter {
+				compatible = "renesas,rz-gtm-counter";
 				status = "disabled";
 			};
 		};

--- a/samples/drivers/counter/alarm/boards/rza3ul_smarc.overlay
+++ b/samples/drivers/counter/alarm/boards/rza3ul_smarc.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/samples/drivers/counter/alarm/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
+++ b/samples/drivers/counter/alarm/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rza3ul_smarc.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rza3ul_smarc.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/rzv2l_smarc_r9a07g054l23gbg_cm33.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gtm0 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm1 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};
+
+&gtm2 {
+	status = "okay";
+
+	counter {
+		status = "okay";
+	};
+};

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -819,6 +819,9 @@ static void test_late_alarm_instance(const struct device *dev)
 		.user_data = NULL
 	};
 
+	/* for timers with very short ticks, counter_ticks_to_us() returns 0 */
+	tick_us = MAX(tick_us, 1);
+
 	err = counter_set_guard_period(dev, guard,
 					COUNTER_GUARD_PERIOD_LATE_TO_SET);
 	zassert_equal(0, err, "%s: Unexpected error", dev->name);
@@ -869,6 +872,9 @@ static void test_late_alarm_error_instance(const struct device *dev)
 		.flags = COUNTER_ALARM_CFG_ABSOLUTE,
 		.user_data = NULL
 	};
+
+	/* for timers with very short ticks, counter_ticks_to_us() returns 0 */
+	tick_us = MAX(tick_us, 1);
 
 	err = counter_set_guard_period(dev, guard,
 					COUNTER_GUARD_PERIOD_LATE_TO_SET);


### PR DESCRIPTION
Support for Counter driver for Renesas RZ/V2L, A3UL:

- Update `drivers/counter/counter_renesas_rz_gtm.c` to using common source code for Renesas RZ devices
- Add device tree for Renesas RZ/V2L, A3UL
- Sample: support `samples/drivers/counter/alarm` sample
- Test: support `tests/drivers/counter/counter_basic_api` test

And `tests/drivers/counter/counter_basic_api` test:
- Handle zero tick_us for very short timer ticks to ensure tick_us is at least 1 for very short timer ticks

Need: https://github.com/zephyrproject-rtos/hal_renesas/pull/130 (merged) and https://github.com/zephyrproject-rtos/hal_renesas/pull/138 (merged)