### PR TITLE
Intel: ADSP:  disable colsole and a logging backend

### DIFF
--- a/soc/intel/intel_adsp/Kconfig.defconfig
+++ b/soc/intel/intel_adsp/Kconfig.defconfig
@@ -33,8 +33,10 @@ config XTENSA_UNCACHED_REGION
 
 endif # XTENSA_RPO_CACHE
 
+if !SOF
 config CONSOLE
 	def_bool y
+endif
 
 if CONSOLE
 config WINSTREAM_CONSOLE

--- a/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
+++ b/soc/intel/intel_adsp/ace/Kconfig.defconfig.series
@@ -50,7 +50,7 @@ config INTEL_ADSP_TIMER
 config DYNAMIC_INTERRUPTS
 	default y
 
-if LOG
+if LOG && !SOF
 
 config LOG_BACKEND_ADSP
 	default y

--- a/soc/intel/intel_adsp/cavs/Kconfig.defconfig.series
+++ b/soc/intel/intel_adsp/cavs/Kconfig.defconfig.series
@@ -37,7 +37,7 @@ config 2ND_LEVEL_INTERRUPTS
 config DYNAMIC_INTERRUPTS
 	default y
 
-if LOG
+if LOG && !SOF
 
 config LOG_BACKEND_ADSP
 	default y


### PR DESCRIPTION
Remove unused Kconfig options, enabled on Intel ADSP.