### PR TITLE
 scripts: footprint: extend the size_report with filters

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -5,6 +5,17 @@ set(flag_for_rom_report rom)
 set(flag_for_footprint all)
 set(report_depth 99)
 
+if(CONFIG_REPORT_LOWEST_LIMIT)
+  set(REPORT_LOWEST_LIMIT ${CONFIG_REPORT_LOWEST_LIMIT})
+else()
+  set(REPORT_LOWEST_LIMIT 0)
+endif()
+if(CONFIG_REPORT_MAX_ITEMS)
+  set(REPORT_MAX_ITEMS ${CONFIG_REPORT_MAX_ITEMS})
+else()
+  set(REPORT_MAX_ITEMS 0)
+endif()
+
 if(DEFINED ZEPHYR_WORKSPACE)
   set(workspace_arg "--workspace=${ZEPHYR_WORKSPACE}")
 elseif(DEFINED WEST_TOPDIR)
@@ -71,6 +82,8 @@ if(CONFIG_TFM_BL2)
       ${workspace_arg}
       -d ${report_depth}
       --json bl2_${report}.json
+      -l ${REPORT_LOWEST_LIMIT}
+      -m ${REPORT_MAX_ITEMS}
       ${flag_for_${report}_report}
       DEPENDS tfm
       USES_TERMINAL

--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -752,6 +752,12 @@ def print_any_tree(root, total_size, depth):
     """
     Print the symbol tree.
     """
+    global args
+    maxItems = None
+
+    if args.maxItems and args.maxItems != 0:
+        maxItems = args.maxItems
+
     print('{:98s} {:>7s} {:>7s} {:11s} {:16s}'.format(
         Fore.YELLOW + "Path", "Size", "%", " Address", "Section" + Fore.RESET))
     print('=' * 138)
@@ -759,6 +765,18 @@ def print_any_tree(root, total_size, depth):
         f = len(row.pre) + len(row.node._name)
         s = str(row.node._size).rjust(100-f)
         percent = 100 * float(row.node._size) / float(total_size)
+
+        if args.lowestLimit and args.lowestLimit != 0:
+            # If the current symbol's footprint percentage is below the threshold -> skip it
+            if percent < args.lowestLimit:
+                continue
+
+        # Only print as many items as the user configured
+        if args.maxItems and args.maxItems != 0:
+            maxItems -= 1
+
+            if maxItems < 0:
+                break
 
         hex_addr = "-"
         section_name = ""
@@ -805,6 +823,10 @@ def parse_args():
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra debugging information")
     parser.add_argument("--json", help="store results in a JSON file.")
+    parser.add_argument("-l", "--lowestLimit", dest="lowestLimit",
+                        type=int, default=0, help="set what percentage is the lowest limit for printing a symbol.")
+    parser.add_argument("-m", "--maxItems", dest="maxItems", 
+                        type=int, default=0, help="how many items in total should the script print.")
     args = parser.parse_args()
 
 


### PR DESCRIPTION
 Add two new parameters to the script:
 - -l, --lowestLimit: set what percentage is the lowest limit for printing a symbol.
 - -m, --maxItems: how many items in total should the script print.

 Reasoning for the first would be that without it, the script prints hundreds of lines of symbols and it's hard to keep track of what feature(s) are the most impactful on ROM/ RAM. So by setting the lowestLimit to 1, the output gets trimmed down to the essential symbols that have an impact.
 Reasoning for the second would be that it gives the user the chance to select how many symbols to be printed (can be used together with lowestLimit or standalone).

 When they're not set, both parameters are given the default value (0), which makes the script behave as it normally would without them. -> the user may use them if he wants or not use them/ ignore them/ be completely unaware of them and everything works as before.

 Recommended usage:
 Add to Kconfig:
 config REPORT_LOWEST_LIMIT
     int "Minimum percentage to show in the report (0-100)"
     default 0
     range 0 100
     help
       Only show symbols that use at least this percentage of total ROM.
       Set to 0 to show all symbols. Leaving it on default (0), includes everything.

 config REPORT_MAX_ITEMS
     int "Maximum number of symbols to show in the report"
     default 0
     help
       Only shows as many symbols as defined by this option.
       Leaving it on default (0), includes everything.

 Add to prj.conf or board.conf:
 CONFIG_REPORT_LOWEST_LIMIT=1
 CONFIG_REPORT_MAX_ITEMS=10

 Signed-off-by: TudorBalus <tudor.balus@remote-tech.co.uk>