### PR TITLE
boards: amd: kv260_r5: Fix i2c ref clock node

### DIFF
--- a/boards/amd/kv260_r5/kv260_r5.dts
+++ b/boards/amd/kv260_r5/kv260_r5.dts
@@ -30,7 +30,7 @@
 		eeprom-1 = &eeprom1;
 	};
 
-	i2c_ref_clk: i2c_ref_clk {
+	i2c_ref_clk: i2c-ref-clk {
 		compatible = "fixed-clock";
 		clock-frequency = <100000000>;
 		#clock-cells = <0>;


### PR DESCRIPTION
DT binding is requesting to use '-' in node name instead of '_'.