### PR TITLE
Add support Clock Control driver for Renesas RZ/T2M, N2L

### DIFF
--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -45,6 +45,7 @@ zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RA_CGC      clock_cont
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RX_ROOT     clock_control_renesas_rx_root_cgc.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RX_PLL      clock_control_renesas_rx_pll_cgc.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RX_PCLK     clock_control_renesas_rx_pclk_cgc.c)
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RZ_CGC      clock_control_renesas_rz_cgc.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_RENESAS_RZ_CPG      clock_control_renesas_rz_cpg.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_AMBIQ               clock_control_ambiq.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_PWM                 clock_control_pwm.c)

--- a/drivers/clock_control/Kconfig
+++ b/drivers/clock_control/Kconfig
@@ -96,6 +96,8 @@ source "drivers/clock_control/Kconfig.renesas_rx_cgc"
 
 source "drivers/clock_control/Kconfig.renesas_rz_cpg"
 
+source "drivers/clock_control/Kconfig.renesas_rz_cgc"
+
 source "drivers/clock_control/Kconfig.max32"
 
 source "drivers/clock_control/Kconfig.ambiq"

--- a/drivers/clock_control/Kconfig.renesas_rz_cgc
+++ b/drivers/clock_control/Kconfig.renesas_rz_cgc
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config CLOCK_CONTROL_RENESAS_RZ_CGC
+	bool "Renesas RZ Clock Control Driver"
+	default y
+	depends on DT_HAS_RENESAS_RZ_CGC_ENABLED
+	select USE_RZ_FSP_CGC
+	help
+	  Enable support for Renesas RZ CGC Clock Generator Circuit (CGC) driver.
+	  The CGC driver supports only module's clocks.
+	  The PLLs and core clocks are not configured by the CGC driver.

--- a/drivers/clock_control/clock_control_renesas_rz_cgc.c
+++ b/drivers/clock_control/clock_control_renesas_rz_cgc.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/dt-bindings/clock/renesas_rztn_clock.h>
+#include <zephyr/kernel.h>
+#include "bsp_api.h"
+
+#define DT_DRV_COMPAT renesas_rz_cgc
+
+static int clock_control_renesas_rz_on(const struct device *dev, clock_control_subsys_t sys)
+{
+	if (!dev || !sys) {
+		return -EINVAL;
+	}
+
+	uint32_t *clock_id = (uint32_t *)sys;
+
+	uint32_t ip = (*clock_id & RZ_IP_MASK) >> RZ_IP_SHIFT;
+	uint32_t ch = (*clock_id & RZ_IP_CH_MASK) >> RZ_IP_CH_SHIFT;
+
+	R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_LPC_RESET);
+	switch (ip) {
+	case RZ_IP_BSC:
+		R_BSP_MODULE_START(FSP_IP_BSC, ch);
+		break;
+	case RZ_IP_XSPI:
+		R_BSP_MODULE_START(FSP_IP_XSPI, ch);
+		break;
+	case RZ_IP_SCI:
+		R_BSP_MODULE_START(FSP_IP_SCI, ch);
+		break;
+	case RZ_IP_IIC:
+		R_BSP_MODULE_START(FSP_IP_IIC, ch);
+		break;
+	case RZ_IP_SPI:
+		R_BSP_MODULE_START(FSP_IP_SPI, ch);
+		break;
+	case RZ_IP_GPT:
+		R_BSP_MODULE_START(FSP_IP_GPT, ch);
+		break;
+	case RZ_IP_ADC12:
+		R_BSP_MODULE_START(FSP_IP_ADC12, ch);
+		break;
+	case RZ_IP_CMT:
+		R_BSP_MODULE_START(FSP_IP_CMT, ch);
+		break;
+	case RZ_IP_CMTW:
+		R_BSP_MODULE_START(FSP_IP_CMTW, ch);
+		break;
+	case RZ_IP_CANFD:
+		R_BSP_MODULE_START(FSP_IP_CANFD, ch);
+		break;
+	case RZ_IP_GMAC:
+		R_BSP_MODULE_START(FSP_IP_GMAC, ch);
+		break;
+	case RZ_IP_ETHSW:
+		R_BSP_MODULE_START(FSP_IP_ETHSW, ch);
+		break;
+	case RZ_IP_USBHS:
+		R_BSP_MODULE_START(FSP_IP_USBHS, ch);
+		break;
+	case RZ_IP_RTC:
+		R_BSP_MODULE_START(FSP_IP_RTC, ch);
+		break;
+	default:
+		R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_RESET);
+		return -EINVAL; /* Invalid FSP IP Module */
+	}
+	R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_RESET);
+
+	return 0;
+}
+
+static int clock_control_renesas_rz_off(const struct device *dev, clock_control_subsys_t sys)
+{
+	if (!dev || !sys) {
+		return -EINVAL;
+	}
+
+	uint32_t *clock_id = (uint32_t *)sys;
+
+	uint32_t ip = (*clock_id & RZ_IP_MASK) >> RZ_IP_SHIFT;
+	uint32_t ch = (*clock_id & RZ_IP_CH_MASK) >> RZ_IP_CH_SHIFT;
+
+	R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_LPC_RESET);
+	switch (ip) {
+	case RZ_IP_BSC:
+		R_BSP_MODULE_STOP(FSP_IP_BSC, ch);
+		break;
+	case RZ_IP_XSPI:
+		R_BSP_MODULE_STOP(FSP_IP_XSPI, ch);
+		break;
+	case RZ_IP_SCI:
+		R_BSP_MODULE_STOP(FSP_IP_SCI, ch);
+		break;
+	case RZ_IP_IIC:
+		R_BSP_MODULE_STOP(FSP_IP_IIC, ch);
+		break;
+	case RZ_IP_SPI:
+		R_BSP_MODULE_STOP(FSP_IP_SPI, ch);
+		break;
+	case RZ_IP_GPT:
+		R_BSP_MODULE_STOP(FSP_IP_GPT, ch);
+		break;
+	case RZ_IP_ADC12:
+		R_BSP_MODULE_STOP(FSP_IP_ADC12, ch);
+		break;
+	case RZ_IP_CMT:
+		R_BSP_MODULE_STOP(FSP_IP_CMT, ch);
+		break;
+	case RZ_IP_CMTW:
+		R_BSP_MODULE_STOP(FSP_IP_CMTW, ch);
+		break;
+	case RZ_IP_CANFD:
+		R_BSP_MODULE_STOP(FSP_IP_CANFD, ch);
+		break;
+	case RZ_IP_GMAC:
+		R_BSP_MODULE_STOP(FSP_IP_GMAC, ch);
+		break;
+	case RZ_IP_ETHSW:
+		R_BSP_MODULE_STOP(FSP_IP_ETHSW, ch);
+		break;
+	case RZ_IP_USBHS:
+		R_BSP_MODULE_STOP(FSP_IP_USBHS, ch);
+		break;
+	case RZ_IP_RTC:
+		R_BSP_MODULE_STOP(FSP_IP_RTC, ch);
+		break;
+	default:
+		R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_RESET);
+		return -EINVAL; /* Invalid FSP IP Module */
+	}
+	R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_LPC_RESET);
+
+	return 0;
+}
+
+static int clock_control_renesas_rz_get_rate(const struct device *dev, clock_control_subsys_t sys,
+					     uint32_t *rate)
+{
+	if (!dev || !sys || !rate) {
+		return -EINVAL;
+	}
+
+	uint32_t *clock_id = (uint32_t *)sys;
+	fsp_priv_clock_t clk_src = (*clock_id & RZ_CLOCK_MASK) >> RZ_CLOCK_SHIFT;
+	uint32_t clk_hz = R_FSP_SystemClockHzGet(clk_src);
+
+	*rate = clk_hz;
+
+	return 0;
+}
+
+static DEVICE_API(clock_control, rz_clock_control_driver_api) = {
+	.on = clock_control_renesas_rz_on,
+	.off = clock_control_renesas_rz_off,
+	.get_rate = clock_control_renesas_rz_get_rate,
+};
+
+static int clock_control_rz_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+DEVICE_DT_INST_DEFINE(0, clock_control_rz_init, NULL, NULL, NULL, PRE_KERNEL_1,
+		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY, &rz_clock_control_driver_api);

--- a/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
+++ b/dts/arm/renesas/rz/rzn/r9a07g084.dtsi
@@ -5,8 +5,10 @@
 
 #include <mem.h>
 #include <arm/armv8-r.dtsi>
+#include <freq.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/renesas_rztn_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -32,6 +34,12 @@
 			     <GIC_PPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
+	};
+
+	osc: osc {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(25)>;
+		#clock-cells = <0>;
 	};
 
 	soc {
@@ -87,6 +95,111 @@
 					reg = <0x0000E000 (DT_SIZE_M(64) - DT_SIZE_K(56))>;
 					read-only;
 				};
+			};
+		};
+
+		cgc: clock-controller@80280000 {
+			compatible = "renesas,rz-cgc";
+			reg = <0x80280000 0x314>, <0x81280000 0x324>;
+			clocks = <&osc>;
+			#clock-cells = <1>;
+			status = "okay";
+
+			loco: loco {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_K(240)>;
+				#clock-cells = <0>;
+				status = "okay";
+			};
+
+			pll1: pll1 {
+				compatible = "renesas,rz-cgc-pll";
+				state = "initial";
+			};
+
+			iclk: iclk {
+				compatible = "renesas,rz-cgc-sys-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+
+				cpu0clk: cpu0clk {
+					compatible = "renesas,rz-cgc-sys-clock";
+					mul = <1>;
+				};
+
+				ckio: ckio {
+					compatible = "renesas,rz-cgc-sys-clock";
+					div = <4>;
+				};
+			};
+
+			eth_refclk: eth_refclk {
+				compatible = "renesas,rz-cgc-subclk";
+				eth-phy-source = "main";
+			};
+
+			canfdclk: canfdclk {
+				compatible = "renesas,rz-cgc-subclk";
+				canfd-source = <1>;
+			};
+
+			xspi_clk0: xspi_clk0 {
+				compatible = "renesas,rz-cgc-subclk";
+				xspi-clk-frequency = <12500000>;
+			};
+
+			xspi_clk1: xspi_clk1 {
+				compatible = "renesas,rz-cgc-subclk";
+				xspi-clk-frequency = <12500000>;
+			};
+
+			sci0asyncclk: sci0asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci1asyncclk: sci1asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci2asyncclk: sci2asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci3asyncclk: sci3asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci4asyncclk: sci4asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci5asyncclk: sci5asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi0asyncclk: spi0asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi1asyncclk: spi1asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi2asyncclk: spi2asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi3asyncclk: spi3asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
 			};
 		};
 

--- a/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
+++ b/dts/arm/renesas/rz/rzt/r9a07g075.dtsi
@@ -7,8 +7,10 @@
 
 #include <mem.h>
 #include <arm/armv8-r.dtsi>
+#include <freq.h>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/renesas_rztn_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -40,6 +42,12 @@
 			     <GIC_PPI 11 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
+	};
+
+	osc: osc {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(25)>;
+		#clock-cells = <0>;
 	};
 
 	soc {
@@ -95,6 +103,116 @@
 					reg = <0x0000E000 (DT_SIZE_M(64) - DT_SIZE_K(56))>;
 					read-only;
 				};
+			};
+		};
+
+		cgc: clock-controller@80280000 {
+			compatible = "renesas,rz-cgc";
+			reg = <0x80280000 0x314>, <0x81280000 0x320>;
+			clocks = <&osc>;
+			#clock-cells = <1>;
+			status = "okay";
+
+			loco: loco {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_K(240)>;
+				#clock-cells = <0>;
+				status = "okay";
+			};
+
+			pll1: pll1 {
+				compatible = "renesas,rz-cgc-pll";
+				state = "initial";
+			};
+
+			iclk: iclk {
+				compatible = "renesas,rz-cgc-sys-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+
+				cpu0clk: cpu0clk {
+					compatible = "renesas,rz-cgc-sys-clock";
+					mul = <1>;
+				};
+
+				cpu1clk: cpu1clk {
+					compatible = "renesas,rz-cgc-sys-clock";
+					mul = <1>;
+				};
+
+				ckio: ckio {
+					compatible = "renesas,rz-cgc-sys-clock";
+					div = <4>;
+				};
+			};
+
+			eth_refclk: eth_refclk {
+				compatible = "renesas,rz-cgc-subclk";
+				eth-phy-source = "pll1";
+			};
+
+			canfdclk: canfdclk {
+				compatible = "renesas,rz-cgc-subclk";
+				canfd-source = <1>;
+			};
+
+			xspi_clk0: xspi_clk0 {
+				compatible = "renesas,rz-cgc-subclk";
+				xspi-clk-frequency = <12500000>;
+			};
+
+			xspi_clk1: xspi_clk1 {
+				compatible = "renesas,rz-cgc-subclk";
+				xspi-clk-frequency = <12500000>;
+			};
+
+			sci0asyncclk: sci0asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci1asyncclk: sci1asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci2asyncclk: sci2asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci3asyncclk: sci3asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci4asyncclk: sci4asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			sci5asyncclk: sci5asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi0asyncclk: spi0asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi1asyncclk: spi1asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi2asyncclk: spi2asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
+			};
+
+			spi3asyncclk: spi3asyncclk {
+				compatible = "renesas,rz-cgc-subclk";
+				clock-frequency = <DT_FREQ_M(96)>;
 			};
 		};
 

--- a/dts/bindings/clock/renesas,rz-cgc-pll.yaml
+++ b/dts/bindings/clock/renesas,rz-cgc-pll.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RZ Clock Generator Circuit PLL Clock
+compatible: "renesas,rz-cgc-pll"
+
+include: [base.yaml]
+
+properties:
+  state:
+    type: string
+    default: initial
+    enum:
+    - initial
+    - standby
+    - normal
+    description: PLL1 state

--- a/dts/bindings/clock/renesas,rz-cgc-subclk.yaml
+++ b/dts/bindings/clock/renesas,rz-cgc-subclk.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RZ Clock Control Peripheral Sub-Clock
+
+compatible: "renesas,rz-cgc-subclk"
+
+include: [base.yaml]
+
+properties:
+  clock-frequency:
+    type: int
+    default: 96000000
+    enum:
+    - 75000000
+    - 96000000
+    description: |
+      Select clock frequency (Hz) when asynchronous serial clock is selected in SPI and SCI
+
+  xspi-clk-frequency:
+    type: int
+    default: 12500000
+    enum:
+    - 133333333
+    - 100000000
+    - 50000000
+    - 25000000
+    - 12500000
+    - 75000000
+    - 37500000
+    description: Select clock frequency (Hz) supplied to xSPI
+
+  canfd-source:
+    type: int
+    default: 1
+    enum:
+    - 0
+    - 1
+    - 2
+    description: |
+      Select clock source supplied to CANFD
+      - 0: PCLKCAN 80MHz
+      - 1: PCLKCAN 40MHz
+      - 2: PCLKM 100MHz
+
+  eth-phy-source:
+    type: string
+    default: main
+    enum:
+    - "pll1"
+    - "main"
+    description: |
+      25 MHz reference clock to the external Ethernet PHY.
+      Clock source is selectable from main clock or frequency-dividing clock for PLL1.

--- a/dts/bindings/clock/renesas,rz-cgc-sys-clock.yaml
+++ b/dts/bindings/clock/renesas,rz-cgc-sys-clock.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RZ Clock Control System Clock
+
+compatible: "renesas,rz-cgc-sys-clock"
+
+include: [base.yaml]
+
+properties:
+  clock-frequency:
+    type: int
+    default: 200000000
+    enum:
+    - 200000000
+    - 150000000
+    description: Select frequency of iclk.
+
+  div:
+    type: int
+    default: 4
+    enum:
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    description: |
+      Prescale divider to calculate the subclock frequency from the
+      system clock frequency.
+
+  mul:
+    type: int
+    default: 1
+    description: |
+      Multiplier to calculate the subclock frequency from the
+      system clock frequency.

--- a/dts/bindings/clock/renesas,rz-cgc.yml
+++ b/dts/bindings/clock/renesas,rz-cgc.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Renesas RZ Clock Generator Circuit
+
+  Usage example:
+
+    #include <zephyr/dt-bindings/clock/renesas_rztn_clock.h>
+
+    sci0: sci@xxx {
+        ...
+        channel = <0>;
+        /* Cell encodes HWIP, channel, clock source */
+        clocks = <&cgc RZ_CLOCK(RZ_IP_SCI, 0, RZ_CLOCK_PCLKSCI0)>;
+        ...
+    }
+
+compatible: "renesas,rz-cgc"
+
+include: [base.yaml, clock-controller.yaml]
+
+properties:
+  "#clock-cells":
+    const: 1
+
+clock-cells:
+  - clk-id

--- a/include/zephyr/drivers/clock_control/renesas_rz_cgc.h
+++ b/include/zephyr/drivers/clock_control/renesas_rz_cgc.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RZ_CGC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RZ_CGC_H_
+
+#include <zephyr/drivers/clock_control.h>
+
+#define RZ_CGC_SUBCLK_DIV(subclk)                                                                  \
+	UTIL_CAT(RZ_CGC_DIV_, DT_NODE_FULL_NAME_UPPER_TOKEN(subclk))                               \
+	(DT_PROP(subclk, div))
+
+#define RZ_CGC_SUBCLK_MUL(subclk)                                                                  \
+	UTIL_CAT(RZ_CGC_MUL_, DT_NODE_FULL_NAME_UPPER_TOKEN(subclk))                               \
+	(DT_PROP(subclk, mul))
+
+#define RZ_CGC_DIV_CKIO(n)    UTIL_CAT(BSP_CLOCKS_CKIO_ICLK_DIV, n)
+#define RZ_CGC_MUL_CPU0CLK(n) UTIL_CAT(BSP_CLOCKS_FSELCPU0_ICLK_MUL, n)
+#define RZ_CGC_MUL_CPU1CLK(n) UTIL_CAT(BSP_CLOCKS_FSELCPU1_ICLK_MUL, n)
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_RENESAS_RZ_CGC_H_ */

--- a/include/zephyr/dt-bindings/clock/renesas_rztn_clock.h
+++ b/include/zephyr/dt-bindings/clock/renesas_rztn_clock.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZTN_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZTN_CLOCK_H_
+
+/* RZ clock configuration values */
+#define RZ_IP_MASK     0xFF0000UL
+#define RZ_IP_SHIFT    16UL
+#define RZ_IP_CH_MASK  0xFF00UL
+#define RZ_IP_CH_SHIFT 8UL
+#define RZ_CLOCK_MASK  0xFFUL
+#define RZ_CLOCK_SHIFT 0UL
+
+#define RZ_IP_BSC   0UL  /* Bus State Controller */
+#define RZ_IP_XSPI  1UL  /* Expanded Serial Peripheral Interface */
+#define RZ_IP_SCI   2UL  /* Serial Communications Interface */
+#define RZ_IP_IIC   3UL  /* I2C Bus Interface */
+#define RZ_IP_SPI   4UL  /* Serial Peripheral Interface */
+#define RZ_IP_GPT   5UL  /* General PWM Timer */
+#define RZ_IP_ADC12 6UL  /* 12-Bit A/D Converter */
+#define RZ_IP_CMT   7UL  /* Compare Match Timer */
+#define RZ_IP_CMTW  8UL  /* Compare Match Timer W */
+#define RZ_IP_CANFD 9UL  /* Controller Area Network with Flexible Data Rate */
+#define RZ_IP_GMAC  10UL /* Ethernet MAC */
+#define RZ_IP_ETHSW 11UL /* Ethernet Switch */
+#define RZ_IP_USBHS 12UL /* USB High Speed */
+#define RZ_IP_RTC   13UL /* Real Time Clock */
+
+#define RZ_CLOCK_CPU0       0UL
+#define RZ_CLOCK_CPU1       1UL
+#define RZ_CLOCK_CA55C0     2UL
+#define RZ_CLOCK_CA55C1     3UL
+#define RZ_CLOCK_CA55C2     4UL
+#define RZ_CLOCK_CA55C3     5UL
+#define RZ_CLOCK_CA55SCLK   6UL
+#define RZ_CLOCK_ICLK       7UL
+#define RZ_CLOCK_PCLKH      8UL
+#define RZ_CLOCK_PCLKM      9UL
+#define RZ_CLOCK_PCLKL      10UL
+#define RZ_CLOCK_PCLKADC    11UL
+#define RZ_CLOCK_PCLKGPTL   12UL
+#define RZ_CLOCK_PCLKENCO   13UL
+#define RZ_CLOCK_PCLKSPI0   14UL
+#define RZ_CLOCK_PCLKSPI1   15UL
+#define RZ_CLOCK_PCLKSPI2   16UL
+#define RZ_CLOCK_PCLKSPI3   17UL
+#define RZ_CLOCK_PCLKSCI0   18UL
+#define RZ_CLOCK_PCLKSCI1   19UL
+#define RZ_CLOCK_PCLKSCI2   20UL
+#define RZ_CLOCK_PCLKSCI3   21UL
+#define RZ_CLOCK_PCLKSCI4   22UL
+#define RZ_CLOCK_PCLKSCI5   23UL
+#define RZ_CLOCK_PCLKSCIE0  24UL
+#define RZ_CLOCK_PCLKSCIE1  25UL
+#define RZ_CLOCK_PCLKSCIE2  26UL
+#define RZ_CLOCK_PCLKSCIE3  27UL
+#define RZ_CLOCK_PCLKSCIE4  28UL
+#define RZ_CLOCK_PCLKSCIE5  29UL
+#define RZ_CLOCK_PCLKSCIE6  30UL
+#define RZ_CLOCK_PCLKSCIE7  31UL
+#define RZ_CLOCK_PCLKSCIE8  32UL
+#define RZ_CLOCK_PCLKSCIE9  33UL
+#define RZ_CLOCK_PCLKSCIE10 34UL
+#define RZ_CLOCK_PCLKSCIE11 35UL
+#define RZ_CLOCK_PCLKCAN    36UL
+#define RZ_CLOCK_CKIO       37UL
+#define RZ_CLOCK_XSPI0_CLK  38UL
+#define RZ_CLOCK_XSPI1_CLK  39UL
+
+#define RZ_CLOCK(IP, ch, clk)                                                                      \
+	((IP << RZ_IP_SHIFT) | ((ch) << RZ_IP_CH_SHIFT) | ((clk) << RZ_CLOCK_SHIFT))
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZTN_CLOCK_H_ */

--- a/modules/Kconfig.renesas
+++ b/modules/Kconfig.renesas
@@ -307,6 +307,11 @@ config USE_RZ_FSP_CPG
 	help
 	  Enable RZ FSP CLOCK CONTROL driver
 
+config USE_RZ_FSP_CGC
+	bool
+	help
+	  Enable RZ FSP CGC driver
+
 config USE_RZ_FSP_RSPI_SPI
 	bool
 	help

--- a/soc/renesas/rz/rzn2l/Kconfig.defconfig
+++ b/soc/renesas/rz/rzn2l/Kconfig.defconfig
@@ -7,7 +7,7 @@ config NUM_IRQS
 	default 480
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 25000000
+	default $(dt_node_int_prop_int,/osc,clock-frequency)
 
 config FPU
 	default y

--- a/soc/renesas/rz/rzt2m/Kconfig.defconfig
+++ b/soc/renesas/rz/rzt2m/Kconfig.defconfig
@@ -8,7 +8,7 @@ config NUM_IRQS
 	default 480
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 25000000
+	default $(dt_node_int_prop_int,/osc,clock-frequency)
 
 config FPU
 	default y

--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 740a944351300664ea17fb7913f0036a5263f008
+      revision: 53738694cc40f7a7a53c4940209889f1eee556ea
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Add support for Clock Control driver for Renesas RZ/T2M, N2L:

- Based on CGC driver of hal_renesas
- Add device tree and binding files
- Retrieve `SYS_CLOCK_HW_CYCLES_PER_SEC` from dts (fix https://github.com/zephyrproject-rtos/zephyr/pull/85782#discussion_r1980904527, https://github.com/zephyrproject-rtos/zephyr/pull/85801#discussion_r1980864666)

Need: https://github.com/zephyrproject-rtos/hal_renesas/pull/129 (merged)