### PR TITLE
Add support Clock Control driver for Renesas RZ/A3UL, V2L

### DIFF
--- a/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
+++ b/dts/arm/renesas/rz/rzv/r9a07g054.dtsi
@@ -7,6 +7,7 @@
 #include <mem.h>
 #include <freq.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/renesas_rzv_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -33,6 +34,12 @@
 		};
 	};
 
+	osc: osc {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(24)>;
+		#clock-cells = <0>;
+	};
+
 	soc {
 		adc: adc@40059000 {
 			compatible = "renesas,rz-adc-c";
@@ -43,6 +50,133 @@
 			vref-mv = <1800>;
 			channel-available-mask = <0xFF>;
 			status = "disabled";
+		};
+
+		cpg: clock-controller@41010000 {
+			compatible = "renesas,rz-cpg";
+			reg = <0x41010000 DT_SIZE_K(64)>;
+			#clock-cells = <1>;
+			status = "okay";
+
+			iclk: iclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(1200)>;
+				#clock-cells = <0>;
+			};
+
+			i2clk: i2clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			gclk: gclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(500)>;
+				#clock-cells = <0>;
+			};
+
+			s0clk: s0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_K(12)>;
+				#clock-cells = <0>;
+			};
+
+			spi0clk: spi0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			spi1clk: spi1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			sd0clk: sd0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(533)>;
+				#clock-cells = <0>;
+			};
+
+			sd1clk: sd1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(533)>;
+				#clock-cells = <0>;
+			};
+
+			m0clk: m0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			m1clk: m1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(3000)>;
+				#clock-cells = <0>;
+			};
+
+			m2clk: m2clk {
+				compatible = "fixed-clock";
+				clock-frequency = <266500000>;
+				#clock-cells = <0>;
+			};
+
+			m3clk: m3clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(3000)>;
+				#clock-cells = <0>;
+			};
+
+			m4clk: m4clk {
+				compatible = "fixed-clock";
+				clock-frequency = <16656000>;
+				#clock-cells = <0>;
+			};
+
+			hpclk: hpclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(250)>;
+				#clock-cells = <0>;
+			};
+
+			tsuclk: tsuclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(80)>;
+				#clock-cells = <0>;
+			};
+
+			ztclk: ztclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			p0clk: p0clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			p1clk: p1clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(200)>;
+				#clock-cells = <0>;
+			};
+
+			p2clk: p2clk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(100)>;
+				#clock-cells = <0>;
+			};
+
+			atclk: atclk {
+				compatible = "fixed-clock";
+				clock-frequency = <DT_FREQ_M(400)>;
+				#clock-cells = <0>;
+			};
 		};
 
 		pinctrl: pin-controller@41030000 {

--- a/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
+++ b/dts/arm64/renesas/rz/rza/r9a07g063.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/renesas_rz_pwm.h>
 #include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/clock/renesas_rza_clock.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
@@ -39,8 +40,215 @@
 		interrupt-parent = <&gic>;
 	};
 
+	osc: osc {
+		compatible = "fixed-clock";
+		clock-frequency = <DT_FREQ_M(24)>;
+		#clock-cells = <0>;
+	};
+
 	soc {
 		interrupt-parent = <&gic>;
+
+		cpg: clock-controller@11010000 {
+			compatible = "renesas,rz-cpg";
+			reg = <0x11010000 DT_SIZE_K(64)>;
+			clocks = <&osc>;
+			#clock-cells = <1>;
+			status = "okay";
+
+			pll1: pll1 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(1000)>;
+				#clock-cells = <1>;
+			};
+
+			pll2_1600: pll2-1600 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(1600)>;
+				#clock-cells = <1>;
+			};
+
+			pll2_533: pll2-533 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(533)>;
+				#clock-cells = <1>;
+			};
+
+			pll3_1600: pll3-1600 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(1600)>;
+				#clock-cells = <1>;
+			};
+
+			pll3_533: pll3-533 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(533)>;
+				#clock-cells = <1>;
+			};
+
+			pll3_400: pll3-400 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(400)>;
+				#clock-cells = <1>;
+			};
+
+			pll4: pll4 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(1600)>;
+				#clock-cells = <1>;
+			};
+
+			pll5_1500: pll5-1500 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(1500)>;
+				#clock-cells = <1>;
+			};
+
+			pll5_500: pll5-500 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(500)>;
+				#clock-cells = <1>;
+			};
+
+			pll6: pll6 {
+				compatible = "renesas,rz-cpg-pll";
+				clock-frequency = <DT_FREQ_M(500)>;
+				#clock-cells = <1>;
+			};
+
+			iclk: iclk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll1 1>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			sd0clk: sd0clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll2_533 2>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			sd1clk: sd1clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll2_1600 4>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			p0clk: p0clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll2_1600 16>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			tsuclk: tsuclk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll2_1600 20>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			atclk: atclk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_1600 4>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			i2clk: i2clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_1600 8>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			p1clk: p1clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_1600 8>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			m0clk: m0clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_1600 8>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			ztclk: ztclk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_1600 16>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			p2clk: p2clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_1600 16>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			spi0clk: spi0clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_533 2>;
+				div = <2>;
+				#clock-cells = <0>;
+			};
+
+			spi1clk: spi1clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_533 4>;
+				div = <2>;
+				#clock-cells = <0>;
+			};
+
+			m2clk: m2clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_533 2>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			oc0clk: oc0clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_400 2>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			oc1clk: oc1clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll3_400 4>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			s0clk: s0clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll4 2>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+
+			m3clk: m3clk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll5_1500 1>;
+				div = <2>;
+				#clock-cells = <0>;
+			};
+
+			hpclk: hpclk {
+				compatible = "renesas,rz-cpg-clock";
+				clocks = <&pll6 2>;
+				div = <1>;
+				#clock-cells = <0>;
+			};
+		};
 
 		gic: interrupt-controller@11900000 {
 			compatible = "arm,gic-v3", "arm,gic";

--- a/dts/bindings/clock/renesas,rz-cpg-clock.yaml
+++ b/dts/bindings/clock/renesas,rz-cpg-clock.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RZ Clock Pulse Generator Clock Output
+
+compatible: "renesas,rz-cpg-clock"
+
+include: [base.yaml, clock-controller.yaml]
+
+properties:
+  clocks:
+    required: true
+
+  div:
+    type: int
+
+  "#clock-cells":
+    const: 0

--- a/dts/bindings/clock/renesas,rz-cpg-pll.yaml
+++ b/dts/bindings/clock/renesas,rz-cpg-pll.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Renesas Electronics Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Renesas RZ Clock Pulse Generator PLL Output
+
+compatible: "renesas,rz-cpg-pll"
+
+include: [clock-controller.yaml]
+
+properties:
+  clock-frequency:
+    type: int
+    description: PLL output clock frequency (Hz)
+    required: true
+
+  "#clock-cells":
+    const: 1
+
+clock-cells:
+  - postscaler

--- a/dts/bindings/clock/renesas,rz-cpg.yaml
+++ b/dts/bindings/clock/renesas,rz-cpg.yaml
@@ -1,7 +1,21 @@
-# Copyright (c) 2024 Renesas Electronics Corporation24
+# Copyright (c) 2024-2025 Renesas Electronics Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-description: RZ Clock Pulse Generator
+description: |
+  Renesas RZ Clock Pulse Generator
+
+  Usage example:
+
+    #include <zephyr/dt-bindings/clock/renesas_rz[agv]_clock.h>
+
+    scif0: serial@xxx {
+        ...
+        channel = <0>;
+        /* Cell encodes HWIP, channel, clock source and division */
+        clocks = <&cpg RZ_CLOCK_SCIF(0)>;
+        ...
+    }
+
 compatible: "renesas,rz-cpg"
 
 include: [base.yaml, clock-controller.yaml]

--- a/include/zephyr/dt-bindings/clock/renesas_rza_clock.h
+++ b/include/zephyr/dt-bindings/clock/renesas_rza_clock.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZA_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZA_CLOCK_H_
+
+/* RZ/A clock configuration values */
+#define RZ_IP_MASK         0xFF000000UL
+#define RZ_IP_SHIFT        24UL
+#define RZ_IP_CH_MASK      0xFF0000UL
+#define RZ_IP_CH_SHIFT     16UL
+#define RZ_CLOCK_MASK      0xFF00UL
+#define RZ_CLOCK_SHIFT     8UL
+#define RZ_CLOCK_DIV_MASK  0xFFUL
+#define RZ_CLOCK_DIV_SHIFT 0UL
+
+#define RZ_IP_GTM   0UL /* General Timer */
+#define RZ_IP_SCI   1UL /* Serial Communications Interface */
+#define RZ_IP_SCIF  2UL /* Serial Communications Interface with FIFO */
+#define RZ_IP_RIIC  3UL /* I2C Bus Interface */
+#define RZ_IP_RSPI  4UL /* Renesas Serial Peripheral Interface */
+#define RZ_IP_DMAC  5UL /* Direct Memory Access Controller */
+#define RZ_IP_CANFD 6UL /* CANFD Interface (RS-CANFD) */
+#define RZ_IP_ADC   7UL /* A/D Converter */
+#define RZ_IP_WDT   8UL /* Watchdog Timer */
+
+#define RZ_CLOCK_ICLK    0UL  /* Cortex-A55 Clock */
+#define RZ_CLOCK_I2CLK   1UL  /* Cortex-M33 Clock */
+#define RZ_CLOCK_S0CLK   2UL  /* DDR-PHY Clock */
+#define RZ_CLOCK_SPI0CLK 3UL  /* SPI0 Clock */
+#define RZ_CLOCK_SPI1CLK 4UL  /* SPI1 Clock */
+#define RZ_CLOCK_OC0CLK  5UL  /* Octa0 Clock */
+#define RZ_CLOCK_OC1CLK  6UL  /* Octa1 Clock */
+#define RZ_CLOCK_SD0CLK  7UL  /* SDH0 Clock */
+#define RZ_CLOCK_SD1CLK  8UL  /* SDH1 Clock */
+#define RZ_CLOCK_M0CLK   9UL  /* VCP, LCDC Clock */
+#define RZ_CLOCK_M2CLK   10UL /* CRU, MIPI-DSI Clock */
+#define RZ_CLOCK_M3CLK   11UL /* MIPI-DSI, LCDC Clock */
+#define RZ_CLOCK_HPCLK   12UL /* Ethernet Clock */
+#define RZ_CLOCK_TSUCLK  13UL /* TSU Clock */
+#define RZ_CLOCK_ZTCLK   14UL /* JAUTH Clock */
+#define RZ_CLOCK_P0CLK   15UL /* APB-BUS Clock */
+#define RZ_CLOCK_P1CLK   16UL /* AXI-BUS Clock */
+#define RZ_CLOCK_P2CLK   17UL /* P2CLK */
+#define RZ_CLOCK_ATCLK   18UL /* ATCLK */
+#define RZ_CLOCK_OSCCLK  19UL /* OSC Clock */
+
+#define RZ_CLOCK(IP, ch, clk, div)                                                                 \
+	((RZ_IP_##IP << RZ_IP_SHIFT) | ((ch) << RZ_IP_CH_SHIFT) | ((clk) << RZ_CLOCK_SHIFT) |      \
+	 ((div) << RZ_CLOCK_DIV_SHIFT))
+
+/**
+ * Pack clock configurations in a 32-bit value
+ * as expected for the Device Tree `clocks` property on Renesas RZ/A.
+ *
+ * @param ch Peripheral channel/unit
+ */
+
+/* GTM */
+#define RZ_CLOCK_GTM(ch) RZ_CLOCK(GTM, ch, RZ_CLOCK_P0CLK, 1)
+
+/* SCI */
+#define RZ_CLOCK_SCI(ch) RZ_CLOCK(SCI, ch, RZ_CLOCK_P0CLK, 1)
+
+/* SCIF */
+#define RZ_CLOCK_SCIF(ch) RZ_CLOCK(SCIF, ch, RZ_CLOCK_P0CLK, 1)
+
+/* RIIC */
+#define RZ_CLOCK_RIIC(ch) RZ_CLOCK(RIIC, ch, RZ_CLOCK_P0CLK, 1)
+
+/* RSPI */
+#define RZ_CLOCK_RSPI(ch) RZ_CLOCK(RSPI, ch, RZ_CLOCK_P0CLK, 1)
+
+/* DMAC */
+#define RZ_CLOCK_DMAC_NS(ch) RZ_CLOCK(DMAC, ch, RZ_CLOCK_P1CLK, 1)
+
+/* CAN */
+#define RZ_CLOCK_CANFD(ch) RZ_CLOCK(CANFD, ch, RZ_CLOCK_P0CLK, 1)
+
+/* ADC */
+#define RZ_CLOCK_ADC(ch) RZ_CLOCK(ADC, ch, RZ_CLOCK_P0CLK, 1)
+
+/* WDT */
+#define RZ_CLOCK_WDT(ch) RZ_CLOCK(WDT, ch, RZ_CLOCK_P0CLK, 1)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZA_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/renesas_rzg_clock.h
+++ b/include/zephyr/dt-bindings/clock/renesas_rzg_clock.h
@@ -17,15 +17,17 @@
 #define RZ_CLOCK_DIV_MASK  0xFFUL
 #define RZ_CLOCK_DIV_SHIFT 0UL
 
-#define RZ_IP_GTM   0UL /* General Timer */
-#define RZ_IP_GPT   1UL /* General PWM Timer */
-#define RZ_IP_SCIF  2UL /* Serial Communications Interface with FIFO */
-#define RZ_IP_RIIC  3UL /* I2C Bus Interface */
-#define RZ_IP_RSPI  4UL /* Renesas Serial Peripheral Interface */
-#define RZ_IP_MHU   5UL /* Message Handling Unit */
-#define RZ_IP_DMAC  6UL /* Direct Memory Access Controller */
-#define RZ_IP_CANFD 7UL /* CANFD Interface (RS-CANFD) */
-#define RZ_IP_ADC   8UL /* A/D Converter */
+#define RZ_IP_GTM   0UL  /* General Timer */
+#define RZ_IP_GPT   1UL  /* General PWM Timer */
+#define RZ_IP_SCI   2UL  /* Serial Communications Interface */
+#define RZ_IP_SCIF  3UL  /* Serial Communications Interface with FIFO */
+#define RZ_IP_RIIC  4UL  /* I2C Bus Interface */
+#define RZ_IP_RSPI  5UL  /* Renesas Serial Peripheral Interface */
+#define RZ_IP_MHU   6UL  /* Message Handling Unit */
+#define RZ_IP_DMAC  7UL  /* Direct Memory Access Controller */
+#define RZ_IP_CANFD 8UL  /* CANFD Interface (RS-CANFD) */
+#define RZ_IP_ADC   9UL  /* A/D Converter */
+#define RZ_IP_WDT   10UL /* Watchdog Timer */
 
 #define RZ_CLOCK_ICLK    0UL  /* Cortex-A55 Clock */
 #define RZ_CLOCK_I2CLK   1UL  /* Cortex-M33 Clock */
@@ -89,5 +91,11 @@
 
 /* DMAC */
 #define RZ_CLOCK_DMAC(ch) RZ_CLOCK(DMAC, ch, RZ_CLOCK_P3CLK, 1)
+
+/* SCI */
+#define RZ_CLOCK_SCI(ch) RZ_CLOCK(SCI, ch, RZ_CLOCK_P0CLK, 1)
+
+/* WDT */
+#define RZ_CLOCK_WDT(ch) RZ_CLOCK(WDT, ch, RZ_CLOCK_OSCCLK, 1)
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZG_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/renesas_rzv_clock.h
+++ b/include/zephyr/dt-bindings/clock/renesas_rzv_clock.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Renesas Electronics Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZV_CLOCK_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZV_CLOCK_H_
+
+/* RZ/V clock configuration values */
+#define RZ_IP_MASK         0xFF000000UL
+#define RZ_IP_SHIFT        24UL
+#define RZ_IP_CH_MASK      0xFF0000UL
+#define RZ_IP_CH_SHIFT     16UL
+#define RZ_CLOCK_MASK      0xFF00UL
+#define RZ_CLOCK_SHIFT     8UL
+#define RZ_CLOCK_DIV_MASK  0xFFUL
+#define RZ_CLOCK_DIV_SHIFT 0UL
+
+#define RZ_IP_GTM   0UL /* General Timer */
+#define RZ_IP_GPT   1UL /* General PWM Timer */
+#define RZ_IP_SCI   2UL /* Serial Communications Interface */
+#define RZ_IP_SCIF  3UL /* Serial Communications Interface with FIFO */
+#define RZ_IP_RIIC  4UL /* I2C Bus Interface */
+#define RZ_IP_RSPI  5UL /* Renesas Serial Peripheral Interface */
+#define RZ_IP_MHU   6UL /* Message Handling Unit */
+#define RZ_IP_DMAC  7UL /* Direct Memory Access Controller */
+#define RZ_IP_CANFD 8UL /* CANFD Interface (RS-CANFD) */
+#if !defined(CONFIG_SOC_SERIES_RZV2L)
+#define RZ_IP_ADC 10UL /* A/D Converter */
+#define RZ_IP_WDT 11UL /* Watchdog Timer */
+#endif
+
+#define RZ_CLOCK_ICLK    0UL  /* Cortex-A55 Clock */
+#define RZ_CLOCK_I2CLK   1UL  /* Cortex-M33 Clock */
+#define RZ_CLOCK_GCLK    2UL  /* GPU Clock */
+#define RZ_CLOCK_S0CLK   3UL  /* DDR-PHY Clock */
+#define RZ_CLOCK_SPI0CLK 4UL  /* SPI0 Clock */
+#define RZ_CLOCK_SPI1CLK 5UL  /* SPI1 Clock */
+#define RZ_CLOCK_SD0CLK  6UL  /* SDH0 Clock */
+#define RZ_CLOCK_SD1CLK  7UL  /* SDH1 Clock */
+#define RZ_CLOCK_M0CLK   8UL  /* VCP, LCDC Clock */
+#define RZ_CLOCK_M1CLK   9UL  /* MIPI-DSI, MIPI-CSI Clock */
+#define RZ_CLOCK_M2CLK   10UL /* CRU, MIPI-DSI Clock */
+#define RZ_CLOCK_M3CLK   11UL /* MIPI-DSI, LCDC Clock */
+#define RZ_CLOCK_M4CLK   12UL /* MIPI-DSI Clock */
+#define RZ_CLOCK_HPCLK   13UL /* Ethernet Clock */
+#define RZ_CLOCK_TSUCLK  14UL /* TSU Clock */
+#define RZ_CLOCK_ZTCLK   15UL /* JAUTH Clock */
+#define RZ_CLOCK_P0CLK   16UL /* APB-BUS Clock */
+#define RZ_CLOCK_P1CLK   17UL /* AXI-BUS Clock */
+#define RZ_CLOCK_P2CLK   18UL /* P2CLK */
+#define RZ_CLOCK_ATCLK   19UL /* ATCLK */
+#define RZ_CLOCK_OSCCLK  20UL /* OSC Clock */
+
+#define RZ_CLOCK(IP, ch, clk, div)                                                                 \
+	((RZ_IP_##IP << RZ_IP_SHIFT) | ((ch) << RZ_IP_CH_SHIFT) | ((clk) << RZ_CLOCK_SHIFT) |      \
+	 ((div) << RZ_CLOCK_DIV_SHIFT))
+
+/**
+ * Pack clock configurations in a 32-bit value
+ * as expected for the Device Tree `clocks` property on Renesas RZ/V.
+ *
+ * @param ch Peripheral channel/unit
+ */
+
+/* GTM */
+#define RZ_CLOCK_GTM(ch) RZ_CLOCK(GTM, ch, RZ_CLOCK_P0CLK, 1)
+
+/* GPT */
+#define RZ_CLOCK_GPT(ch) RZ_CLOCK(GPT, ch, RZ_CLOCK_P0CLK, 1)
+
+/* SCI */
+#define RZ_CLOCK_SCI(ch) RZ_CLOCK(SCI, ch, RZ_CLOCK_P0CLK, 1)
+
+/* SCIF */
+#define RZ_CLOCK_SCIF(ch) RZ_CLOCK(SCIF, ch, RZ_CLOCK_P0CLK, 1)
+
+/* RIIC */
+#define RZ_CLOCK_RIIC(ch) RZ_CLOCK(RIIC, ch, RZ_CLOCK_P0CLK, 1)
+
+/* RSPI */
+#define RZ_CLOCK_RSPI(ch) RZ_CLOCK(RSPI, ch, RZ_CLOCK_P0CLK, 1)
+
+/* MHU */
+#define RZ_CLOCK_MHU(ch) RZ_CLOCK(MHU, ch, RZ_CLOCK_P1CLK, 2)
+
+/* DMAC */
+#define RZ_CLOCK_DMAC(ch) RZ_CLOCK(DMAC, ch, RZ_CLOCK_P1CLK, 1)
+
+/* CAN */
+#define RZ_CLOCK_CANFD(ch) RZ_CLOCK(CANFD, ch, RZ_CLOCK_P0CLK, 1)
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_RENESAS_RZV_CLOCK_H_ */

--- a/soc/renesas/rz/rza3ul/Kconfig.defconfig
+++ b/soc/renesas/rz/rza3ul/Kconfig.defconfig
@@ -10,7 +10,7 @@ config NUM_IRQS
 	default 512
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 24000000
+	default	$(dt_node_int_prop_int,/osc,clock-frequency)
 
 config FLASH_SIZE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K)

--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
         - hal
     - name: hal_renesas
       path: modules/hal/renesas
-      revision: 53738694cc40f7a7a53c4940209889f1eee556ea
+      revision: bc51c0b367223bb8f02a188e2e8529af0bd08f1c
       groups:
         - hal
     - name: hal_rpi_pico


### PR DESCRIPTION
Add support for Clock Control driver for Renesas RZ/A3UL, V2L:

- Update `drivers/clock_control/clock_control_renesas_rz_cpg.c` to using common source code for Renesas RZ devices
- Add device tree and binding files

Need: https://github.com/zephyrproject-rtos/hal_renesas/pull/128 (merged)