### PR TITLE
logging: Fix case where compilation failed with GCOV

### DIFF
--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -338,6 +338,12 @@ do { \
 	} else { \
 		CBPRINTF_STATIC_PACKAGE(NULL, 0, _plen, Z_LOG_MSG_ALIGN_OFFSET, _options, \
 					__VA_ARGS__); \
+		/* When GCOV was enabled it was seen that compilation could fail here. */ \
+		/* Adding protection like this helps. It is compile time resolved code */ \
+		/* so has no impact on performance. */ \
+		if (_plen < 0) { \
+			break; \
+		} \
 	} \
 	struct log_msg *_msg; \
 	Z_LOG_MSG_ON_STACK_ALLOC(_msg, Z_LOG_MSG_LEN(_plen, 0)); \


### PR DESCRIPTION
It was seen that with COVERAGE_GCOV a log entry with a floating number was failing to compile because macro resolved during compilation was returning negative value for _plen (error code). It seems like some compiler artifact when coverage is enabled as adding early exit when error is detected fixed compilation issue and log is still printed which means that early exit case is not executed.