### PR TITLE
drivers: spi: stm32: Fix race condition causing lockup in half-duplex mode

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -876,7 +876,14 @@ static int spi_stm32_half_duplex_switch_to_receive(const struct spi_stm32_config
 		if (LL_SPI_GetMode(spi) == LL_SPI_MODE_MASTER) {
 			LL_SPI_StartMasterTransfer(spi);
 			while (!LL_SPI_IsActiveMasterTransfer(spi)) {
-				/* NOP */
+				/*
+				 * Check for the race condition where the transfer completes
+				 * before this loop is entered. If EOT is set, the transfer
+				 * is done and we can break.
+				 */
+				if (LL_SPI_IsActiveFlag_EOT(spi)) {
+					break;
+				}
 			}
 		}
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi) */


### PR DESCRIPTION
A race condition could occur in half-duplex master mode when switching from TX to RX.
If a preemption happens immediately after starting the master transfer, the SPI hardware may complete the transfer before the polling loop is entered, causing the CSTART bit to be cleared and resulting in an infinite loop.
This patch adds a check for the EOT flag inside the polling loop in spi_stm32_half_duplex_switch_to_receive(). If EOT is set, the transfer is already complete and the loop is exited, preventing the lockup.

Issues: #94265