### PR TITLE
Display support opencv headless

### DIFF
--- a/scripts/pylib/display-twister-harness/camera_shield/README.rst
+++ b/scripts/pylib/display-twister-harness/camera_shield/README.rst
@@ -1,7 +1,6 @@
-==============
+===============================
 Display capture Twister harness
-==============
-
+===============================
 
 Configuration example
 ---------------------
@@ -38,87 +37,133 @@ Configuration example
          edge_ratio_weight: 0.1
          gradient_hist_weight: 0.1
 
+Installation Guide
+------------------
+
+.. code-block:: powershell
+
+   # Create virtual environment
+   python -m venv .venv
+
+.. code-block:: powershell
+
+   # Activate environment
+   .venv\Scripts\activate
+
+.. code-block:: powershell
+
+   # Install dependencies
+   uv pip install -r requirements.txt
+
+.. code-block:: bash
+
+   # add video to user group
+   sudo usermod -a -G video $USER
+
+.. code-block:: bash
+
+   # need log out and login to effective or run
+   newgrp video
+
+If you are in Ubuntu 24.04 with XWayland do the following:
+
+.. code-block:: bash
+
+   export DISPLAY=:0
+   cp /run/user/1000/.mutter-Xwaylandauth.AIT2A3 ~/.Xauthority
+
+or
+
+.. code-block:: bash
+
+   export QT_QPA_PLATFORM=xcb
+
+If your server does not have display please do the following:
+
+.. code-block:: bash
+
+   pip uninstall opencv-python
+
+.. code-block:: bash
+
+   pip install opencv-python-headless
+
+.. code-block:: bash
+
+   export QT_QPA_PLATFORM=offscreen
+
 example zephyr display tests
 ----------------------------
 
 1. Setup camera to capture display content
 
- - UVC compatible camera with at least 2 megapixels (such as 1080p)
- - A light-blocking black curtain
- - A PC host where camera connect to
- - DUT connected to the same PC host for flashing and serial console
+   - UVC compatible camera with at least 2 megapixels (such as 1080p)
+   - A light-blocking black curtain
+   - A PC host where camera connect to
+   - DUT connected to the same PC host for flashing and serial console
 
 2. Generate video fingerprints
 
- - build and flash the known-to-work display app to DUT
-    e.g.
-```
-west build -b frdm_mcxn947/mcxn947/cpu0 tests/drivers/display/display_check
-west flash
-```
+   - build and flash the known-to-work display app to DUT e.g.
 
- - clone code
-```bash
-git clone https://github.com/hakehuang/camera_shield
-```
+     ::
 
+        west build -b frdm_mcxn947/mcxn947/cpu0 tests/drivers/display/display_check
+        west flash
 
- - follow the instructions in the repo's README.
-  - set the signature capture mode as below in config.yaml
-```yaml
-  - name: signature
-    module: .plugins.signature_plugin
-    class: VideoSignaturePlugin
-    status: "enable"
-    config:
-      operations: "generate" # operation ('generate', 'compare')
-      metadata:
-        name: "tests.drivers.display.check.shield" # finger-print stored metadata
-        platform: "frdm_mcxn947"
-      directory: "./fingerprints" # fingerprints directory to compare with not used in generate mode
-```
+   - clone code
 
-  - Run generate fingerprints program outside the camera_shield folder
+     ::
 
-    Note:
-      On Ubuntu 24.04, you may need to do ```export QT_QPA_PLATFORM=xcb``` to resolve below error
+        git clone https://github.com/hakehuang/camera_shield
 
-```bash
-qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in "~/camera_shield/.ven/lib/python3.12/site-packages/cv2/qt/plugins"
-```
+   - follow the instructions in the repo's README.
 
-```bash
-python -m camera_shield.main --config camera_shield/config.yaml
-```
+   - set the signature capture mode as below in config.yaml
 
-video fingerprint for captured screenshots will be recorded in directory './fingerprints' by default
+     ::
+
+        - name: signature
+          module: .plugins.signature_plugin
+          class: VideoSignaturePlugin
+          status: "enable"
+          config:
+            operations: "generate" # operation ('generate', 'compare')
+            metadata:
+              name: "tests.drivers.display.check.shield" # finger-print stored metadata
+              platform: "frdm_mcxn947"
+            directory: "./fingerprints" # fingerprints directory to compare with not used in generate mode
+
+   - Run generate fingerprints program outside the camera_shield folder
+
+     ::
+
+        python -m camera_shield.main --config camera_shield/config.yaml
+
+     video fingerprint for captured screenshots will be recorded in directory './fingerprints' by default
 
    - set environment variable to "DISPLAY_TEST_DIR"
 
-```bash
-DISPLAY_TEST_DIR=~/camera_shield/
-```
+     ::
+
+        DISPLAY_TEST_DIR=~/camera_shield/
 
 3. Run test
-```bash
-# export the fingerprints path
-export DISPLAY_TEST_DIR=<path to "fingerprints" parent-folder>
 
-# Twister hardware map file settings:
-# Ensure your map file has the required fixture
-# in the example below, you need to have "fixture_display"
+   ::
 
-# Ensure you have installed the required Python packages for tests in scripts/requirements-run-test.txt
-
-# Run detection program
-scripts/twister --device-testing --hardware-map map.yml -T tests/drivers/display/display_check/
-
-```
+      # export the fingerprints path
+      export DISPLAY_TEST_DIR=<path to "fingerprints" parent-folder>
+      # Twister hardware map file settings:
+      # Ensure your map file has the required fixture
+      # in the example below, you need to have "fixture_display"
+      # Ensure you have installed the required Python packages for tests in scripts/requirements-run-test.txt
+      # Run detection program
+      scripts/twister --device-testing --hardware-map map.yml -T tests/drivers/display/display_check/
 
 Notes
 -----
 
-1. When generating the fingerprints, they will be stored in folder "name" as defined in "metadata" from ``config.yaml`` .
+1. When generating the fingerprints, they will be stored in folder "name" as defined in "metadata" from ``config.yaml``.
 2. The DUT testcase name shall match the value in the metadata 'name' field of the captured fingerprint's config.
-3. You can put multiple fingerprints in one folder, it will increase compare time,
-   but will help to check other defects.
+3. You can put multiple fingerprints in one folder, it will increase compare time, but will help to check other defects.

--- a/scripts/pylib/display-twister-harness/camera_shield/uvc_core/camera_controller.py
+++ b/scripts/pylib/display-twister-harness/camera_shield/uvc_core/camera_controller.py
@@ -168,7 +168,7 @@ class UVCCamera:
         print(f"  Color Balance - B Channel: {analysis['color_balance']['b_channel']:.2f}")
         print(f"  Sharpness: {analysis['sharpness']:.2f}")
 
-        # 在帧上显示分析结果
+        # show report
         if frame is not None:
             text_y = 30
             cv2.putText(
@@ -269,4 +269,13 @@ class UVCCamera:
 
     def release(self):
         self.cap.release()
-        cv2.destroyAllWindows()
+        try:
+            # compatible with openCV-headless mode
+            cv2.destroyAllWindows()
+        except Exception as e:
+            # Handle cv2.error and other potential exceptions
+            if "not implemented" in str(e) or "Rebuild the library" in str(e):
+                # This is expected in headless/no-GUI environments
+                pass
+            else:
+                print(f"Warning: Could not destroy windows: {e}")

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -15,6 +15,7 @@ import time
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from enum import Enum
+from string import Template
 
 import junitparser.junitparser as junit
 import yaml
@@ -644,7 +645,9 @@ class Display_capture(Pytest):
 
     def _get_display_config_file(self, harness_config):
         if test_config_file := harness_config.get('display_capture_config'):
-            test_config_path = os.path.join(self.source_dir, test_config_file)
+            _template = Template(test_config_file)
+            _config_file = _template.safe_substitute(os.environ)
+            test_config_path = os.path.join(self.source_dir, _config_file)
             logger.info(f'test_config_path = {test_config_path}')
             if os.path.exists(test_config_path):
                 return test_config_path

--- a/tests/drivers/display/display_check/testcase.yaml
+++ b/tests/drivers/display/display_check/testcase.yaml
@@ -51,6 +51,7 @@ tests:
     # display shield within Zephyr.
     # Boards with built-in displays are also covered by this testcase.
     filter: dt_chosen_enabled("zephyr,display")
+    timeout: 120
     harness_config:
       fixture: fixture_display
       pytest_dut_scope: session
@@ -66,6 +67,7 @@ tests:
       - platform:frdm_k22f/mk22f51212:SHIELD=ls013b7dh03
       - platform:nrf52833dk/nrf52833:SHIELD=st7735r_ada_160x128
       - platform:mimxrt1170_evk/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
+      - platform:mimxrt1170_evk@A/mimxrt1176/cm7:SHIELD=rk055hdmipi4ma0
       - platform:da1469x_dk_pro/da14699:DTC_OVERLAY_FILE=da1469x_dk_pro_mipi_dbi.overlay
       - platform:nrf52840dk/nrf52840:SHIELD=max7219_8x8
       - platform:stm32h747i_disco/stm32h747xx/m7:SHIELD=st_b_lcd40_dsi1_mb1166


### PR DESCRIPTION
1. for test machine without GUI, we need support open-cv-headless mode.
2. Enable  mimxrt1170_evk@A
3.  parse environment variable, which is missed in former PR.