### PR TITLE
libc/picolibc: use absolute path  for `-specs=` argument in compile command

### DIFF
--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -22,8 +22,18 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
   # Use picolibc provided with the toolchain. This requires a new enough
   # toolchain so that the version of picolibc supports auto-detecting a
   # Zephyr build (via the __ZEPHYR__ macro) to expose the Zephyr C API
-  zephyr_compile_options(PROPERTY specs picolibc.specs)
-  zephyr_link_libraries(PROPERTY specs picolibc.specs)
+
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    # ask GNU compiler about absolute location of the specs so that other tools like
+    # ccache can find the specs as well.
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER} -print-file-name=picolibc.specs
+      OUTPUT_VARIABLE PICOLIBC_SPECS
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    zephyr_compile_options(PROPERTY specs "${PICOLIBC_SPECS}")
+    zephyr_link_libraries(PROPERTY specs "${PICOLIBC_SPECS}")
+  endif()
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)
     zephyr_link_libraries(-DPICOLIBC_DOUBLE_PRINTF_SCANF)


### PR DESCRIPTION
Use absolute paths for `-specs=<path>` compiler arguments so that ccache can determine the specs file correctly and does not result in uncachable calls because of "Bad compiler arguments".

Before:
```
$ ccache -s -v
Cache directory:          /home/user/.ccache
Config file:              /home/user/.ccache/ccache.conf
System config file:       /etc/ccache.conf
Stats updated:            Mon Aug 25 13:12:08 2025
Cacheable calls:            0 / 360 ( 0.00%)
  Hits:                     0
    Direct:                 0
    Preprocessed:           0
  Misses:                   0
Uncacheable calls:        360 / 360 (100.0%) # all calls are uncachable
  Bad compiler arguments: 236 / 360 (65.56%) # most of them because of bad compiler arguments
  Called for linking:      84 / 360 (23.33%)
  No input file:           40 / 360 (11.11%)
Successful lookups:
  Direct:                   0
  Preprocessed:             0
Local storage:
  Cache size (GiB):       0.0 / 5.0 ( 0.00%)
  Files:                    0
  Hits:                     0
  Misses:                   0
  Reads:                    0
  Writes:                   0
```

Now:
```
$ ccache -s -v
Cache directory:      /home/user/.ccache
Config file:          /home/user/.ccache/ccache.conf
System config file:   /etc/ccache.conf
Stats updated:        Mon Aug 25 13:55:35 2025
Cacheable calls:      236 / 360 (65.56%) # The calls with Bad compiler arguments are cacheable now!
  Hits:               235 / 236 (99.58%)
    Direct:           234 / 235 (99.57%)
    Preprocessed:       1 / 235 ( 0.43%)
  Misses:               1 / 236 ( 0.42%)
Uncacheable calls:    124 / 360 (34.44%)
  Called for linking:  84 / 124 (67.74%)
  No input file:       40 / 124 (32.26%)
Successful lookups:
  Direct:             234 / 236 (99.15%)
  Preprocessed:         1 /   2 (50.00%)
Local storage:
  Cache size (GiB):   0.0 / 5.0 ( 0.05%)
  Files:              235
  Hits:               235 / 236 (99.58%)
  Misses:               1 / 236 ( 0.42%)
  Reads:              472
  Writes:               3

```
