### PR TITLE
dts: stm32h7rs: Add SDMMC support for STM32H7RS series

### DIFF
--- a/boards/ruiside/art_pi2/Kconfig.defconfig
+++ b/boards/ruiside/art_pi2/Kconfig.defconfig
@@ -1,0 +1,12 @@
+# ART-Pi2 board configuration
+#
+# Copyright (c) 2025 Shan Pen <bricle031@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if DISK_DRIVER_SDMMC
+
+config SDMMC_STM32_CLOCK_CHECK
+	default n
+
+endif # DISK_DRIVER_SDMMC

--- a/boards/ruiside/art_pi2/art_pi2.dts
+++ b/boards/ruiside/art_pi2/art_pi2.dts
@@ -80,6 +80,18 @@
 	status = "okay";
 };
 
+&pll2 {
+	div-m = <2>;
+	mul-n = <50>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	div-s = <4>;
+	div-t = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &rcc {
 	clocks = <&pll>;
 	clock-frequency = <DT_FREQ_M(250)>;
@@ -95,6 +107,18 @@
 	pinctrl-0 = <&uart4_tx_pd1 &uart4_rx_pd0>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
+	status = "okay";
+};
+
+&sdmmc1 {
+	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
+		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
+		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
+	pinctrl-names = "default";
+	clk-div = <13>;
+	bus-width = <4>;
+	cd-gpios = <&gpion 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	disk-name = "SD";
 	status = "okay";
 };
 

--- a/boards/st/stm32h7s78_dk/Kconfig.defconfig
+++ b/boards/st/stm32h7s78_dk/Kconfig.defconfig
@@ -31,4 +31,11 @@ config STM32_LTDC_FB_USE_SHARED_MULTI_HEAP
 	default y
 endif # DISPLAY
 
+if DISK_DRIVER_SDMMC
+
+config SDMMC_STM32_CLOCK_CHECK
+	default n
+
+endif # DISK_DRIVER_SDMMC
+
 endif # BOARD_STM32H7S78_DK

--- a/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
+++ b/boards/st/stm32h7s78_dk/stm32h7s78_dk.dts
@@ -109,6 +109,18 @@
 	status = "okay";
 };
 
+&pll2 {
+	div-m = <2>;
+	mul-n = <50>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	div-s = <4>;
+	div-t = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &pll3 {
 	div-m = <12>;
 	mul-n = <25>;
@@ -350,4 +362,16 @@ zephyr_udc0: &usb2 {};
 	def-back-color-red = <0xFF>;
 	def-back-color-green = <0xFF>;
 	def-back-color-blue = <0xFF>;
+};
+
+&sdmmc1 {
+	pinctrl-0 = <&sdmmc1_d0_pc8 &sdmmc1_d1_pc9
+		     &sdmmc1_d2_pc10 &sdmmc1_d3_pc11
+		     &sdmmc1_ck_pc12 &sdmmc1_cmd_pd2>;
+	pinctrl-names = "default";
+	clk-div = <13>;
+	bus-width = <4>;
+	cd-gpios = <&gpiom 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	disk-name = "SD";
+	status = "okay";
 };

--- a/dts/arm/st/h7rs/stm32h7rs.dtsi
+++ b/dts/arm/st/h7rs/stm32h7rs.dtsi
@@ -908,6 +908,26 @@
 			resets = <&rctl STM32_RESET(APB5, 1)>;
 			status = "disabled";
 		};
+
+		sdmmc1: sdmmc@52007000 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x52007000 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB5, 8)>,
+				 <&rcc STM32_SRC_PLL2_S SDMMC_SEL(0)>;
+			resets = <&rctl STM32_RESET(AHB5, 8)>;
+			interrupts = <108 0>;
+			status = "disabled";
+		};
+
+		sdmmc2: sdmmc@48002400 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x48002400 0x400>;
+			clocks = <&rcc STM32_CLOCK(AHB2, 9)>,
+				 <&rcc STM32_SRC_PLL2_S SDMMC_SEL(0)>;
+			resets = <&rctl STM32_RESET(AHB2, 9)>;
+			interrupts = <109 0>;
+			status = "disabled";
+		};
 	};
 
 	otgfs_phy: otgfs_phy {


### PR DESCRIPTION
This PR adds SDMMC support for STM32H7RS series microcontrollers and enables it on two development boards.

### Changes:
- **SoC support**: Add SDMMC1 and SDMMC2 controller configurations for STM32H7RS series
  - Includes register addresses, clock sources, reset controls, and interrupt definitions
  
- **Board enablement**: Configure SDMMC1 on supported boards:
  - **ART-Pi2**: 4-bit SD card interface with card detection
  - **STM32H7S78-DK**: 4-bit SD card interface with card detection

### Clock Configuration:
Both boards use PLL2S as the kernel peripheral clock source:
- PLL2S frequency: 150MHz  
- Clock divider: 15 (clk-div = 13 register value)
- Resulting SDMMC clock: 10MHz

### Hardware Features:
- 4-bit bus width support
- Card detection via GPIO

### Testing Status:
- **ART-Pi2**: Tested and verified working with `zephyr/tests/drivers/disk/disk_performance`:
```
*** Booting Zephyr OS build v4.2.0-2287-g5945a3fcd1eb ***
Running TESTSUITE disk_performance
===================================================================
Disk reports 124735488 sectors
Disk reports sector size 512
START - test_random_read
512 Byte IOPS over 64 random reads: 2354 IOPS
 PASS - test_random_read in 0.032 seconds
===================================================================
START - test_random_write
512 Byte IOPS over 64 random writes: 942 IOPS
 PASS - test_random_write in 0.218 seconds
===================================================================
START - test_sequential_read
Average read speed over one sector: 1081 KiB/s
Average read speed over 64 sectors: 2656 KiB/s
 PASS - test_sequential_read in 0.133 seconds
===================================================================
START - test_sequential_write
Average write speed over one sector: 481 KiB/s
Average write speed over 64 sectors: 2496 KiB/s
 PASS - test_sequential_write in 0.212 seconds
===================================================================
TESTSUITE disk_performance succeeded

------ TESTSUITE SUMMARY START ------

SUITE PASS - 100.00% [disk_performance]: pass = 4, fail = 0, skip = 0, total = 4 duration = 0.595 seconds
 - PASS - [disk_performance.test_random_read] duration = 0.032 seconds
 - PASS - [disk_performance.test_random_write] duration = 0.218 seconds
 - PASS - [disk_performance.test_sequential_read] duration = 0.133 seconds
 - PASS - [disk_performance.test_sequential_write] duration = 0.212 seconds

------ TESTSUITE SUMMARY END ------

===================================================================
PROJECT EXECUTION SUCCESSFUL
```
- **STM32H7S78-DK**: Configuration based on hardware specifications (no physical board available for testing)

**Note**: I don't have access to the STM32H7S78-DK physical board, but the configuration should be correct based on the hardware documentation. If anyone could help test this board, it would be greatly appreciated, and I'm willing to make adjustments based on the test results.