### PR TITLE
include: lorawan: expose all API unconditionally and fix doxygen

### DIFF
--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -458,11 +458,14 @@ int lorawan_request_link_check(bool force_request);
  * @brief Run Application Layer Clock Synchronization service
  *
  * This service sends out its current time in a regular interval (configurable
- * via Kconfig) and receives a correction offset from the application server if
- * the clock deviation is considered too large.
+ * via Kconfig, using @kconfig{CONFIG_LORAWAN_APP_CLOCK_SYNC_PERIODICITY}) and
+ * receives a correction offset from the application server if the clock
+ * deviation is considered too large.
  *
  * Clock synchronization is required for firmware upgrades over multicast
  * sessions, but can also be used independent of a FUOTA process.
+ *
+ * @kconfig_dep{CONFIG_LORAWAN_APP_CLOCK_SYNC}
  *
  * @return 0 if successful, negative errno otherwise.
  */
@@ -475,6 +478,8 @@ int lorawan_clock_sync_run(void);
  *
  * The GPS epoch started on 1980-01-06T00:00:00Z, but has since diverged
  * from UTC, as it does not consider corrections like leap seconds.
+ *
+ * @kconfig_dep{CONFIG_LORAWAN_APP_CLOCK_SYNC}
  *
  * @param gps_time Synchronized time in GPS epoch format truncated to 32-bit.
  *
@@ -489,7 +494,9 @@ int lorawan_clock_sync_get(uint32_t *gps_time);
  * whenever a FragSessionSetupReq is received and Descriptor field should be
  * handled.
  *
- * @param transport_descriptor_cb Callback for notification.
+ * @kconfig_dep{CONFIG_LORAWAN_FRAG_TRANSPORT}
+ *
+ * @param cb Callback for notification.
  */
 void lorawan_frag_transport_register_descriptor_callback(transport_descriptor_cb cb);
 
@@ -500,6 +507,8 @@ void lorawan_frag_transport_register_descriptor_callback(transport_descriptor_cb
  * stores them in the image-1 flash partition.
  *
  * After all fragments have been received, the provided callback is invoked.
+ *
+ * @kconfig_dep{CONFIG_LORAWAN_FRAG_TRANSPORT}
  *
  * @param transport_finished_cb Callback for notification of finished data transfer.
  *

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -454,8 +454,6 @@ int lorawan_device_time_get(uint32_t *gps_time);
  */
 int lorawan_request_link_check(bool force_request);
 
-#ifdef CONFIG_LORAWAN_APP_CLOCK_SYNC
-
 /**
  * @brief Run Application Layer Clock Synchronization service
  *
@@ -484,10 +482,6 @@ int lorawan_clock_sync_run(void);
  */
 int lorawan_clock_sync_get(uint32_t *gps_time);
 
-#endif /* CONFIG_LORAWAN_APP_CLOCK_SYNC */
-
-#ifdef CONFIG_LORAWAN_FRAG_TRANSPORT
-
 /**
  * @brief Register a handle descriptor callback function.
  *
@@ -512,8 +506,6 @@ void lorawan_frag_transport_register_descriptor_callback(transport_descriptor_cb
  * @return 0 if successful, negative errno otherwise.
  */
 int lorawan_frag_transport_run(void (*transport_finished_cb)(void));
-
-#endif /* CONFIG_LORAWAN_FRAG_TRANSPORT */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Make sure Kconfig-gated API is visible in online docs

https://builds.zephyrproject.io/zephyr/pr/94966/docs/doxygen/html/group__lorawan__api.html