### PR TITLE
drivers: spi: spi_renesas_ra Use the correct hardware chip select

### DIFF
--- a/drivers/spi/spi_renesas_ra.c
+++ b/drivers/spi/spi_renesas_ra.c
@@ -153,7 +153,23 @@ static int ra_spi_configure(const struct device *dev, const struct spi_config *c
 		data->fsp_config_extend.spi_clksyn = SPI_SSL_MODE_CLK_SYN;
 	} else {
 		data->fsp_config_extend.spi_clksyn = SPI_SSL_MODE_SPI;
-		data->fsp_config_extend.ssl_select = SPI_SSL_SELECT_SSL0;
+		switch (config->slave) {
+		case 0:
+			data->fsp_config_extend.ssl_select = SPI_SSL_SELECT_SSL0;
+			break;
+		case 1:
+			data->fsp_config_extend.ssl_select = SPI_SSL_SELECT_SSL1;
+			break;
+		case 2:
+			data->fsp_config_extend.ssl_select = SPI_SSL_SELECT_SSL2;
+			break;
+		case 3:
+			data->fsp_config_extend.ssl_select = SPI_SSL_SELECT_SSL3;
+			break;
+		default:
+			LOG_ERR("Invalid SSL");
+			return -EINVAL;
+		}
 	}
 
 	data->fsp_config.p_extend = &data->fsp_config_extend;

--- a/drivers/spi/spi_renesas_ra.c
+++ b/drivers/spi/spi_renesas_ra.c
@@ -188,15 +188,7 @@ static int ra_spi_configure(const struct device *dev, const struct spi_config *c
 
 static bool ra_spi_transfer_ongoing(struct ra_spi_data *data)
 {
-#if defined(CONFIG_SPI_INTERRUPT)
 	return (spi_context_tx_on(&data->ctx) || spi_context_rx_on(&data->ctx));
-#else
-	if (spi_context_total_tx_len(&data->ctx) < spi_context_total_rx_len(&data->ctx)) {
-		return (spi_context_tx_on(&data->ctx) || spi_context_rx_on(&data->ctx));
-	} else {
-		return (spi_context_tx_on(&data->ctx) && spi_context_rx_on(&data->ctx));
-	}
-#endif
 }
 
 #ifndef CONFIG_SPI_INTERRUPT

--- a/drivers/spi/spi_renesas_ra.c
+++ b/drivers/spi/spi_renesas_ra.c
@@ -834,7 +834,7 @@ static void ra_spi_eri_isr(const struct device *dev)
 		return 0;                                                                          \
 	}                                                                                          \
                                                                                                    \
-	DEVICE_DT_INST_DEFINE(index, spi_ra_init##index, PM_DEVICE_DT_INST_GET(index),             \
+	DEVICE_DT_INST_DEFINE(index, spi_ra_init##index, NULL,                                     \
 			      &ra_spi_data_##index, &ra_spi_config_##index, PRE_KERNEL_1,          \
 			      CONFIG_SPI_INIT_PRIORITY, &ra_spi_driver_api);
 


### PR DESCRIPTION
Choose the chip select based on the slave ID for SPI transactions
Don't stop polled SPI transactions early if they aren't read and write
Remove a reference to get a PM device that isn't defined