### PR TITLE
STM32WBA55CG: fix compilation issue in test overlay

### DIFF
--- a/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_wba55cg.overlay
+++ b/samples/boards/st/power_mgmt/wkup_pins/boards/nucleo_wba55cg.overlay
@@ -6,7 +6,7 @@
 
 / {
 	aliases {
-		wkup-src = &button_0;
+		wkup-src = &user_button_1;
 	};
 };
 


### PR DESCRIPTION
The test failed to compile due to a code error. This commit corrects the issue in nucleo_wba55cg.overlay file to ensure successful compilation.