### PR TITLE
phy_adin2111.c: ethernet: phy: correctly assign state parameter with state from device

### DIFF
--- a/drivers/ethernet/phy/phy_adin2111.c
+++ b/drivers/ethernet/phy/phy_adin2111.c
@@ -365,7 +365,7 @@ static int phy_adin2111_reset(const struct device *dev)
 static void invoke_link_cb(const struct device *dev)
 {
 	struct phy_adin2111_data *const data = dev->data;
-	struct phy_link_state state;
+	struct phy_link_state state = data->state;
 
 	if (data->cb == NULL) {
 		return;


### PR DESCRIPTION
The state parameter was not initialized.
Causes incorrect values in the calling function.

This fixes an uninitialized variable access problem in callback.