### PR TITLE
toolchain: arcmwdt: override compiler_set_linker_properties

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -60,6 +60,9 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
 )
 endmacro()
 
+function(compiler_set_linker_properties)
+endfunction()
+
 # Force symbols to be entered in the output file as undefined symbols
 function(toolchain_ld_force_undefined_symbols)
   foreach(symbol ${ARGN})


### PR DESCRIPTION
Template function to set linker properties by default doesn't work for ARC MWDT, whose compiler doesn't have the --print-libgcc-file-name flag. ARC MWDT doesn't set CMake linker property lib_include_dir or rt_library (and doesn't need them to be set either).

I am not one of the ARC MWDT maintainers or NSIM platform owners. I'm just submitting this just because our build is broken, and we'd like a fix to go in soon.