### PR TITLE
drivers: serial: silabs_usart: Fix configure error cases

### DIFF
--- a/drivers/serial/uart_silabs_usart.c
+++ b/drivers/serial/uart_silabs_usart.c
@@ -982,9 +982,17 @@ static int uart_silabs_configure(const struct device *dev,
 		return -ENOSYS;
 	}
 
+	if (cfg->parity > UART_CFG_PARITY_SPACE) {
+		return -EINVAL;
+	}
+
 	if (cfg->flow_ctrl == UART_CFG_FLOW_CTRL_DTR_DSR ||
 	    cfg->flow_ctrl == UART_CFG_FLOW_CTRL_RS485) {
 		return -ENOSYS;
+	}
+
+	if (cfg->flow_ctrl > UART_CFG_FLOW_CTRL_RS485) {
+		return -EINVAL;
 	}
 
 	*data->uart_cfg = *cfg;

--- a/tests/drivers/uart/uart_elementary/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/uart/uart_elementary/boards/xg24_rb4187c.overlay
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, Silicon Laboratories Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		zephyr,console = &eusart0;
+		zephyr,shell-uart = &eusart0;
+		zephyr,uart-pipe = &eusart0;
+	};
+};
+
+/*
+ * Connect EXP4 (PC1) and EXP6 (PC2) of the Expansion Pin header
+ */
+
+&pinctrl {
+	eusart0_default: eusart0_default {
+		group0 {
+			pins = <EUSART0_TX_PA8>;
+			drive-push-pull;
+			output-high;
+		};
+		group1 {
+			pins = <EUSART0_RX_PA9>;
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+
+	usart0_default: usart0_default {
+		group0 {
+			pins = <USART0_TX_PC1>; /* WPK EXP4 (PC1) */
+			drive-push-pull;
+			output-high;
+		};
+		group1 {
+			pins = <USART0_RX_PC2>; /* WPK EXP6 (PC2) */
+			input-enable;
+			silabs,input-filter;
+		};
+	};
+};
+
+dut: &usart0 {
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&eusart0 {
+	compatible = "silabs,eusart-uart";
+	current-speed = <115200>;
+	pinctrl-0 = <&eusart0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -24,6 +24,7 @@ tests:
       - esp32c6_devkitc/esp32c6/hpcore
       - esp32s2_saola
       - esp32s3_devkitm/esp32s3/procpu
+      - xg24_rb4187c
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
   drivers.uart.uart_elementary_dual_nrf54h:


### PR DESCRIPTION
Enable uart_elementary test and fix edge cases where the configure function did not return the appropriate error code when given invalid parity or flow control parameters.