### PR TITLE
Bluetooth: Host: direction: correct the cte_req_enable opcode

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -822,7 +822,7 @@ static int hci_df_set_conn_cte_req_enable(struct bt_conn *conn, bool enable,
 
 	bt_hci_cmd_state_set_init(buf, &state, conn->flags, BT_CONN_CTE_REQ_ENABLED, enable);
 
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS, buf, &rsp);
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE, buf, &rsp);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
The opcode of hci_df_set_conn_cte_req_enable command should be BT_HCI_OP_LE_CONN_CTE_REQ_ENABLE (0x2056) instead of BT_HCI_OP_LE_SET_CONN_CTE_RX_PARAMS (0x2054). 
We saw the samples/bluetooth/direction_finding_central reported the following error because of BT_HCI_ERR_INVALID_PARAM happened.

> Enable receiving of CTE...
> success. CTE receive enabled.
> Request CTE from peer device...
> [00:03:06.797,882] <wrn> bt_hci_core: opcode 0x2054 status 0x12
> failed (err -22) 