### PR TITLE
Enable lpit for mke17z

### DIFF
--- a/boards/nxp/frdm_ke17z/frdm_ke17z.dts
+++ b/boards/nxp/frdm_ke17z/frdm_ke17z.dts
@@ -209,3 +209,7 @@
 &wdog {
 	status = "okay";
 };
+
+&lpit0 {
+	status = "okay";
+};

--- a/drivers/counter/counter_mcux_lpit.c
+++ b/drivers/counter/counter_mcux_lpit.c
@@ -65,7 +65,7 @@ static int mcux_lpit_start(const struct device *dev)
 	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
 
 	LOG_DBG("period is %d", mcux_lpit_get_top_value(dev));
-	LPIT_EnableInterrupts(config->base, (1U << channel_id));
+	LPIT_EnableInterrupts(config->base, BIT(channel_id));
 	LPIT_StartTimer(config->base, channel_id);
 	return 0;
 }
@@ -75,7 +75,7 @@ static int mcux_lpit_stop(const struct device *dev)
 	const struct mcux_lpit_config *config = dev->config;
 	uint8_t channel_id = LPIT_CHANNEL_ID(dev);
 
-	LPIT_DisableInterrupts(config->base, channel_id);
+	LPIT_DisableInterrupts(config->base, BIT(channel_id));
 	LPIT_StopTimer(config->base, channel_id);
 	return 0;
 }
@@ -150,12 +150,12 @@ static void mcux_lpit_isr(const struct device *dev)
 
 	for (int channel_index = 0; channel_index < config->num_channels; channel_index++) {
 
-		if ((flags & (1U << channel_index)) == 0) {
+		if ((flags & BIT(channel_index)) == 0) {
 			continue;
 		}
 
 		/* Clear interrupt flag */
-		LPIT_ClearStatusFlags(config->base, (1U << channel_index));
+		LPIT_ClearStatusFlags(config->base, BIT(channel_index));
 
 		struct mcux_lpit_channel_data *data =
 			LPIT_CHANNEL_DATA(config->channels[channel_index]);

--- a/dts/arm/nxp/nxp_ke1xz.dtsi
+++ b/dts/arm/nxp/nxp_ke1xz.dtsi
@@ -352,6 +352,42 @@
 			};
 		};
 
+		lpit0: lpit@40037000 {
+			compatible = "nxp,lpit";
+			reg = <0x40037000 0x1000>;
+			interrupts = <22 0>;
+			clocks = <&pcc 0xdc KINETIS_PCC_SRC_SIRC_ASYNC>;
+			status = "disabled";
+			enable-run-in-doze;
+			max-load-value = <0xffffffff>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			lpit0_channel0: lpit_channel@0 {
+				compatible = "nxp,lpit-channel";
+				reg = <0>;
+				status = "disabled";
+			};
+
+			lpit0_channel1: lpit_channel@1 {
+				compatible = "nxp,lpit-channel";
+				reg = <1>;
+				status = "disabled";
+			};
+
+			lpit0_channel2: lpit_channel@2 {
+				compatible = "nxp,lpit-channel";
+				reg = <2>;
+				status = "disabled";
+			};
+
+			lpit0_channel3: lpit_channel@3 {
+				compatible = "nxp,lpit-channel";
+				reg = <3>;
+				status = "disabled";
+			};
+		};
+
 		ftm0: ftm@40038000 {
 			compatible = "nxp,ftm";
 			reg = <0x40038000 0x1000>;

--- a/soc/nxp/kinetis/ke1xz/soc.c
+++ b/soc/nxp/kinetis/ke1xz/soc.c
@@ -145,6 +145,10 @@ __weak void clk_init(void)
 #if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(ewm0))
 	CLOCK_EnableClock(kCLOCK_Ewm0);
 #endif
+#if DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(lpit0))
+	CLOCK_SetIpSrc(kCLOCK_Lpit0,
+		       DT_CLOCKS_CELL(DT_NODELABEL(lpit0), ip_source));
+#endif
 }
 
 void soc_early_init_hook(void)

--- a/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/frdm_ke17z.overlay
@@ -11,3 +11,15 @@
 	clocks = <&scg KINETIS_SCG_FIRC_CLK>;
 	clock-source = "system";
 };
+
+&lpit0_channel0 {
+	status = "okay";
+};
+
+&lpit0_channel2 {
+	status = "okay";
+};
+
+&lpit0_channel3 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable LPIT on MKE17Z, including:
1. devicetree enablement
2. clock config
3. counter test case enablement
4. Fix LPIT disable interrupt bug