### PR TITLE
bluetooth: hci: ambiq: add hci_close support for Apollo4

### DIFF
--- a/drivers/bluetooth/hci/hci_ambiq.c
+++ b/drivers/bluetooth/hci/hci_ambiq.c
@@ -395,6 +395,9 @@ static int bt_apollo_close(const struct device *dev)
 		return ret;
 	}
 
+	/* Stop RX thread */
+	k_thread_abort(&spi_rx_thread_data);
+
 	hci->recv = NULL;
 
 	return ret;


### PR DESCRIPTION
This PR adds the hci_close support for Ambiq Apollo4 Blue series SoC, so the bt_disable() can be called to disable the controller inside of the SoC. We did the stress testing of bt_enable() and bt_disable() cycles in bluetooth samples and saw it worked as expected on apollo4p_blue_kxr_evb board:

> for (uint32_t i = 0; i < 100; i++)
> {
> 	err = bt_enable(NULL);
> 	if (err) {
> 		printk("Bluetooth init failed (err %d)\n", err);
> 		return 0;
> 	}
> 	k_sleep(K_MSEC(100));
> 
> 	err = bt_disable();
> 	if (err) {
> 		printk("Bluetooth deinit failed (err %d)\n", err);
> 		return 0;
> 	}
> 	k_sleep(K_MSEC(100));
> }
> 
> err = bt_enable(NULL);
> if (err) {
> 	printk("Bluetooth init failed (err %d)\n", err);
> 	return 0;
> }