### PR TITLE
log: backend: net: add const qualifier to hostname

### DIFF
--- a/include/zephyr/logging/log_backend_net.h
+++ b/include/zephyr/logging/log_backend_net.h
@@ -65,7 +65,7 @@ bool log_backend_net_set_ip(const struct sockaddr *addr);
  * @param len Length of the hostname array.
  */
 #if defined(CONFIG_NET_HOSTNAME_ENABLE)
-void log_backend_net_hostname_set(char *hostname, size_t len);
+void log_backend_net_hostname_set(const char *hostname, size_t len);
 #else
 static inline void log_backend_net_hostname_set(const char *hostname, size_t len)
 {

--- a/subsys/logging/backends/log_backend_net.c
+++ b/subsys/logging/backends/log_backend_net.c
@@ -295,7 +295,7 @@ bool log_backend_net_set_ip(const struct sockaddr *addr)
 }
 
 #if defined(CONFIG_NET_HOSTNAME_ENABLE)
-void log_backend_net_hostname_set(char *hostname, size_t len)
+void log_backend_net_hostname_set(const char *hostname, size_t len)
 {
 	(void)strncpy(dev_hostname, hostname, MIN(len, MAX_HOSTNAME_LEN));
 	log_output_hostname_set(&log_output_net, dev_hostname);


### PR DESCRIPTION
When setting the net log hostname, the string content is not modified.