### PR TITLE
Bluetooth: HFP: Fix +BSIR=0 not being recognized issue

### DIFF
--- a/subsys/bluetooth/host/classic/hfp_ag.c
+++ b/subsys/bluetooth/host/classic/hfp_ag.c
@@ -4932,7 +4932,7 @@ int bt_hfp_ag_inband_ringtone(struct bt_hfp_ag *ag, bool inband)
 	}
 	hfp_ag_unlock(ag);
 
-	err = hfp_ag_send_data(ag, NULL, NULL, "\r\n+BSIR=%d\r\n", inband ? 1 : 0);
+	err = hfp_ag_send_data(ag, NULL, NULL, "\r\n+BSIR: %d\r\n", inband ? 1 : 0);
 	if (err) {
 		LOG_ERR("Fail to set inband ringtone err :(%d)", err);
 		return err;


### PR DESCRIPTION
In HFP PTS, cases run fail with the log 'unsupported unsolicited
format: +BSIR=0' and 'FAIL: Expected to receive +BSIR: 0'.

Fixed issue by changing +BSIR=0 to +BSIR: 0.