### PR TITLE
tests: drivers: watchdog: configure flags from overlay

### DIFF
--- a/tests/drivers/watchdog/wdt_error_cases/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,19 +11,3 @@
 		opt-pause-halted-by-dbg;
 	};
 };
-
-&wdt010 {
-	status = "disabled";
-};
-
-&wdt011 {
-	status = "okay";
-};
-
-&wdt131 {
-	status = "disabled";
-};
-
-&wdt132 {
-	status = "disabled";
-};

--- a/tests/drivers/watchdog/wdt_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	resources {
+		compatible = "test-wdt-error-cases";
+		opt-pause-in-sleep;
+		opt-pause-halted-by-dbg;
+	};
+};
+
 &wdt010 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_error_cases/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	resources {
+		compatible = "test-wdt-error-cases";
+		opt-pause-in-sleep;
+		opt-pause-halted-by-dbg;
+	};
+};
+
 &wdt31 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_error_cases/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,8 +1,16 @@
 /*
- * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/ {
+	resources {
+		compatible = "test-wdt-error-cases";
+		opt-pause-in-sleep;
+		opt-pause-halted-by-dbg;
+	};
+};
 
 &wdt31 {
 	status = "okay";

--- a/tests/drivers/watchdog/wdt_error_cases/boards/nrf9280pdk_nrf9280_cpuapp.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/nrf9280pdk_nrf9280_cpuapp.overlay
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	resources {
+		compatible = "test-wdt-error-cases";
+		opt-pause-in-sleep;
+		opt-pause-halted-by-dbg;
+	};
+};
+
 &wdt010 {
 	status = "okay";
 };

--- a/tests/drivers/watchdog/wdt_error_cases/boards/nrf9280pdk_nrf9280_cpurad.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/nrf9280pdk_nrf9280_cpurad.overlay
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	resources {
+		compatible = "test-wdt-error-cases";
+		opt-pause-in-sleep;
+		opt-pause-halted-by-dbg;
+	};
+};
+
 &wdt010 {
 	status = "disabled";
 };

--- a/tests/drivers/watchdog/wdt_error_cases/boards/xg24_rb4187c.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/xg24_rb4187c.overlay
@@ -1,0 +1,10 @@
+/ {
+	resources {
+		compatible = "test-wdt-error-cases";
+		flag-reset-none;
+		opt-pause-in-sleep;
+		opt-pause-halted-by-dbg;
+		window-min;
+		opt-pause-in-sleep-requires-pm;
+	};
+};

--- a/tests/drivers/watchdog/wdt_error_cases/boards/xg27_dk2602a.overlay
+++ b/tests/drivers/watchdog/wdt_error_cases/boards/xg27_dk2602a.overlay
@@ -1,0 +1,7 @@
+/ {
+	resources {
+		compatible = "test-wdt-error-cases";
+		opt-pause-in-sleep;
+		opt-pause-halted-by-dbg;
+	};
+};

--- a/tests/drivers/watchdog/wdt_error_cases/dts/bindings/test-wdt-errors-case.yaml
+++ b/tests/drivers/watchdog/wdt_error_cases/dts/bindings/test-wdt-errors-case.yaml
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+description: |
+    This binding provides resources required to build and run the
+    tests/drivers/watchdog/wdt_error_cases test in Zephyr.
+
+compatible: "test-wdt-error-cases"
+
+properties:
+  opt-pause-in-sleep:
+    type: boolean
+    description: |
+      If true, the watchdog timer will be paused when the CPU is in sleep mode.
+      This is useful to prevent the watchdog from triggering during low-power
+      states.
+  opt-pause-halted-by-dbg:
+    type: boolean
+    description: |
+      If true, the watchdog timer will be paused when the CPU is halted by a
+      debugger. This allows the watchdog to be used during debugging without
+      triggering a reset.
+  feed-can-stall:
+    type: boolean
+    description: |
+      If true, feeding the watchdog can stall the CPU. This is useful for
+      testing purposes to simulate a watchdog timeout.
+  window-min:
+    type: boolean
+    description: |
+      If true, the watchdog supports a minimum window value. This allows for
+      more precise control over the watchdog timeout period.
+  opt-pause-in-sleep-requires-pm:
+    type: boolean
+    description: |
+      If true, the watchdog timer can only be paused in sleep mode if
+      power management is enabled.
+  flag-reset-cpu-core:
+    type: boolean
+    description: |
+      If true, the watchdog supports resetting the CPU core. This allows for
+      more flexible error recovery options.
+  flag-reset-none:
+    type: boolean
+    description: |
+      If true, the watchdog supports not resetting the CPU core. This allows for
+      more flexible error recovery options.

--- a/tests/drivers/watchdog/wdt_error_cases/src/main.c
+++ b/tests/drivers/watchdog/wdt_error_cases/src/main.c
@@ -40,31 +40,38 @@
 #define WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM        BIT(9)
 
 /* Common for all targets: */
-#define DEFAULT_WINDOW_MAX (500U)
-#define DEFAULT_WINDOW_MIN (0U)
+#define DEFAULT_WINDOW_MAX       (500U)
+#define DEFAULT_WINDOW_MIN       (0U)
 
-/* Align tests to the specific target: */
-#if defined(CONFIG_SOC_SERIES_NRF53X) || defined(CONFIG_SOC_SERIES_NRF54LX) || \
-	defined(CONFIG_SOC_NRF54H20) || defined(CONFIG_SOC_NRF9280)
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \
-	 WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED)
+
+#define DT_CONFIG DT_INST(0, test_wdt_error_cases)
+#define WDT_TEST_FLAGS \
+	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED | \
+	WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | \
+	((DT_NODE_HAS_STATUS_OKAY(DT_INST(0, test_wdt_error_cases))) ? \
+		(DT_PROP_OR(DT_CONFIG, opt_pause_in_sleep, 0) ? WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED : 0) | \
+		(DT_PROP_OR(DT_CONFIG, opt_pause_halted_by_dbg, 0) ? \
+		 WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED : 0) | \
+		(DT_PROP_OR(DT_CONFIG, feed_can_stall, 0) ? WDT_FEED_CAN_STALL : 0) | \
+		(DT_PROP_OR(DT_CONFIG, window_min, 0) ? WDT_WINDOW_MIN_SUPPORTED : 0) | \
+		(DT_PROP_OR(DT_CONFIG, opt_pause_in_sleep_requires_pm, 0) ? \
+		 WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM : 0) | \
+		(DT_PROP_OR(DT_CONFIG, flag_reset_cpu_core, 0) ? WDT_FLAG_RESET_CPU_CORE_SUPPORTED : 0) | \
+		(DT_PROP_OR(DT_CONFIG, flag_reset_none, 0) ? WDT_FLAG_RESET_NONE_SUPPORTED : 0) \
+	: 0))
+
+#if defined(CONFIG_SOC_FAMILY_NORDIC_NRF)
 #define DEFAULT_FLAGS            (WDT_FLAG_RESET_SOC)
 #define MAX_INSTALLABLE_TIMEOUTS (8)
 #define WDT_WINDOW_MAX_ALLOWED   (0x07CFFFFFU)
 #define DEFAULT_OPTIONS          (WDT_OPT_PAUSE_IN_SLEEP | WDT_OPT_PAUSE_HALTED_BY_DBG)
+
 #elif defined(CONFIG_SOC_FAMILY_SILABS_S2)
 #if defined(WDOG_CFG_EM1RUN)
 #define WDT_TEST_FLAG_SLEEP_REQUIRES_PM 0
 #else
 #define WDT_TEST_FLAG_SLEEP_REQUIRES_PM WDT_OPT_PAUSE_IN_SLEEP_REQUIRES_PM
 #endif
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_NONE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED | WDT_OPT_PAUSE_IN_SLEEP_SUPPORTED |            \
-	 WDT_OPT_PAUSE_HALTED_BY_DBG_SUPPORTED | WDT_WINDOW_MIN_SUPPORTED |                        \
-	 WDT_TEST_FLAG_SLEEP_REQUIRES_PM)
 #define DEFAULT_FLAGS            (WDT_FLAG_RESET_NONE)
 #define MAX_INSTALLABLE_TIMEOUTS (1)
 #define WDT_WINDOW_MAX_ALLOWED   (0x40001U)
@@ -73,9 +80,6 @@
 /* By default run most of the error checks.
  * See Readme.txt on how to align test scope for the specific target.
  */
-#define WDT_TEST_FLAGS                                                                             \
-	(WDT_DISABLE_SUPPORTED | WDT_FLAG_RESET_SOC_SUPPORTED |                                    \
-	 WDT_FLAG_ONLY_ONE_TIMEOUT_VALUE_SUPPORTED)
 #define DEFAULT_FLAGS            (WDT_FLAG_RESET_SOC)
 #define MAX_INSTALLABLE_TIMEOUTS (8)
 #define WDT_WINDOW_MAX_ALLOWED   (0xFFFFFFFFU)


### PR DESCRIPTION
Updated wdt_error_cases main to check for overlay flags specified in dts/bindings/test-wdt-errors-case.yaml, to increase maintainability. The flags are now setup in the board overlay to configure watchdog timer features for the test to use. Added support for all current boards that use this features by adding overlays for each board.