### PR TITLE
Counter sample improvement

### DIFF
--- a/drivers/counter/counter_mcux_lpit.c
+++ b/drivers/counter/counter_mcux_lpit.c
@@ -161,7 +161,7 @@ static void mcux_lpit_isr(const struct device *dev)
 			LPIT_CHANNEL_DATA(config->channels[channel_index]);
 
 		if (data->top_callback != NULL) {
-			data->top_callback(dev, data->top_user_data);
+			data->top_callback(config->channels[channel_index], data->top_user_data);
 		}
 	}
 }

--- a/samples/drivers/counter/alarm/boards/frdm_ke17z.conf
+++ b/samples/drivers/counter/alarm/boards/frdm_ke17z.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_COUNTER_MCUX_LPIT=y

--- a/samples/drivers/counter/alarm/boards/frdm_ke17z.overlay
+++ b/samples/drivers/counter/alarm/boards/frdm_ke17z.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpit0 {
+	status = "okay";
+};
+
+&lpit0_channel0 {
+	status = "okay";
+};

--- a/samples/drivers/counter/alarm/boards/mimxrt1180_evk_mimxrt1189_cm33.conf
+++ b/samples/drivers/counter/alarm/boards/mimxrt1180_evk_mimxrt1189_cm33.conf
@@ -1,0 +1,7 @@
+#
+# Copyright 2024-2025 NXP
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_COUNTER_MCUX_LPIT=y

--- a/samples/drivers/counter/alarm/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
+++ b/samples/drivers/counter/alarm/boards/mimxrt1180_evk_mimxrt1189_cm33.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024-2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lpit1 {
+	status = "okay";
+};
+
+&lpit1_channel0 {
+	status = "okay";
+};


### PR DESCRIPTION
For peripherals which does not support alarm function, we can use counter_set_top_value to simulate alarm feature, and the callback will be executed after the timer expired. The alarm time can be changed by setting different top value.

In this code, the original alarm function has higher priority. The top function are only be used when alarm function is unsupported.