### PR TITLE
scripts: west: flash: Fix RFP runner platform check

### DIFF
--- a/scripts/west_commands/runners/rfp.py
+++ b/scripts/west_commands/runners/rfp.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from runners.core import RunnerCaps, ZephyrBinaryRunner
 
-if platform.system() == 'Darwin' or 'Windows':
+if platform.system() in {'Darwin', 'Windows'}:
     DEFAULT_RFP_PORT = None
 else:
     DEFAULT_RFP_PORT = '/dev/ttyACM0'


### PR DESCRIPTION
Adjust the RFP runner platform check to properly handle Darwin or Windows and skip setting a default RPF port on those two platforms.

This minor problem was introduced in #90708 and needed some tweaks to do what was intended.