### PR TITLE
dts: am64x: add remaining SPI nodes

### DIFF
--- a/dts/vendor/ti/am64x_main.dtsi
+++ b/dts/vendor/ti/am64x_main.dtsi
@@ -223,6 +223,46 @@
 		status = "disabled";
 	};
 
+	main_mcspi1: spi@20110000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x20110000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		ti,spi-num-cs = <4>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_mcspi2: spi@20120000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x20120000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		ti,spi-num-cs = <4>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_mcspi3: spi@20130000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x20130000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		ti,spi-num-cs = <4>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	main_mcspi4: spi@20140000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x20140000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		ti,spi-num-cs = <4>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
 	main_adc0: adc@28001000 {
 		compatible = "ti,am335x-adc";
 		reg = <0x28001000 DT_SIZE_K(1)>;

--- a/dts/vendor/ti/am64x_mcu.dtsi
+++ b/dts/vendor/ti/am64x_mcu.dtsi
@@ -61,4 +61,24 @@
 		ngpios = <23>;
 		status = "disabled";
 	};
+
+	mcu_mcspi0: spi@4b00000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x4b00000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		ti,spi-num-cs = <4>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
+
+	mcu_mcspi1: spi@4b10000 {
+		compatible = "ti,omap-mcspi";
+		reg = <0x4b10000 0x400>;
+		clock-frequency = <DT_FREQ_M(50)>;
+		ti,spi-num-cs = <4>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
Add all the SPI nodes supported by the platform. Currently only main_mcspi0 is present.