### PR TITLE
drivers: clock_control: stm32: fix compilation issues in test overlay

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -612,7 +612,7 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 #endif /* STM32_TIMER_PRESCALER && (RCC_DCKCFGR_TIMPRE || RCC_DCKCFGR1_TIMPRE) */
 		break;
 #endif /* STM32_SRC_TIMPCLK2 */
-#if defined(STM32_SRC_TIMPLLCLK)
+#if defined(STM32_SRC_TIMPLLCLK) && DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(pll))
 	case STM32_SRC_TIMPLLCLK:
 		*rate = get_pllout_frequency() * 2;
 		if (*rate == 0) {


### PR DESCRIPTION
The test failed to compile due to a code error. This commit corrects the issue in clock_stm32_ll_common.c file to ensure successful compilation.
The test is: 
west build -p -b stm32f3_disco@B/stm32f303xc tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core -T drivers.clock.stm32_clock_configuration.common_core.f0_f3.sysclksrc_hsi_8