### PR TITLE
boards: nordic: nrf54lm20dk: Add usbd to supported features

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.yaml
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20dk_nrf54lm20a_cpuapp.yaml
@@ -20,4 +20,5 @@ supported:
   - i2s
   - pwm
   - spi
+  - usbd
   - watchdog


### PR DESCRIPTION
Add 'usbd' to the list of features supported by nrf54lm20dk.