### PR TITLE
Bluetooth: Audio: Shell: Store broadcast_id statically

### DIFF
--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -176,6 +176,7 @@ struct broadcast_source {
 	};
 	struct bt_audio_codec_cfg codec_cfg;
 	struct bt_bap_qos_cfg qos;
+	uint32_t broadcast_id;
 };
 
 struct broadcast_sink {

--- a/subsys/bluetooth/audio/shell/audio.h
+++ b/subsys/bluetooth/audio/shell/audio.h
@@ -48,8 +48,6 @@ size_t cap_acceptor_ad_data_add(struct bt_data data[], size_t data_size, bool di
 size_t bap_scan_delegator_ad_data_add(struct bt_data data[], size_t data_size);
 size_t gmap_ad_data_add(struct bt_data data[], size_t data_size);
 size_t pbp_ad_data_add(struct bt_data data[], size_t data_size);
-size_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
-				 const bool discoverable, const bool connectable);
 size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_array_size);
 
 #if defined(CONFIG_BT_AUDIO)

--- a/subsys/bluetooth/audio/shell/bap.c
+++ b/subsys/bluetooth/audio/shell/bap.c
@@ -3266,6 +3266,7 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 	struct bt_bap_broadcast_source_subgroup_param subgroup_param;
 	struct bt_bap_broadcast_source_param create_param = {0};
 	const struct named_lc3_preset *named_preset;
+	uint32_t broadcast_id = 0U;
 	int err;
 
 	if (default_source.bap_source != NULL) {
@@ -3324,6 +3325,15 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 		}
 	}
 
+	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
+	if (err != 0) {
+		bt_shell_error("Unable to generate broadcast ID: %d\n", err);
+
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "Generated broadcast_id 0x%06X", broadcast_id);
+
 	copy_broadcast_source_preset(&default_source, named_preset);
 
 	(void)memset(stream_params, 0, sizeof(stream_params));
@@ -3341,11 +3351,14 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 	err = bt_bap_broadcast_source_create(&create_param, &default_source.bap_source);
 	if (err != 0) {
 		shell_error(sh, "Unable to create broadcast source: %d", err);
+
+		default_source.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 		return err;
 	}
 
 	shell_print(sh, "Broadcast source created: preset %s",
 		    named_preset->name);
+	default_source.broadcast_id = broadcast_id;
 
 	if (default_stream == NULL) {
 		default_stream = bap_stream_from_shell_stream(&broadcast_source_streams[0]);
@@ -3890,6 +3903,8 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 		bt_bap_stream_cb_register(
 			bap_stream_from_shell_stream(&broadcast_source_streams[i]), &stream_ops);
 	}
+
+	default_source.broadcast_id = BT_BAP_INVALID_BROADCAST_ID;
 #endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
 
 #if defined(CONFIG_LIBLC3)
@@ -4332,18 +4347,7 @@ static size_t nonconnectable_ad_data_add(struct bt_data *data_array, const size_
 		static uint8_t ad_bap_broadcast_announcement[5] = {
 			BT_UUID_16_ENCODE(BT_UUID_BROADCAST_AUDIO_VAL),
 		};
-		uint32_t broadcast_id;
-		int err;
-
-		err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
-		if (err != 0) {
-			bt_shell_error("Unable to generate broadcast ID: %d\n", err);
-
-			return 0;
-		}
-		bt_shell_print("Generated broadcast_id 0x%06X", broadcast_id);
-
-		sys_put_le24(broadcast_id, &ad_bap_broadcast_announcement[2]);
+		sys_put_le24(default_source.broadcast_id, &ad_bap_broadcast_announcement[2]);
 		data_array[ad_len].type = BT_DATA_SVC_DATA16;
 		data_array[ad_len].data_len = ARRAY_SIZE(ad_bap_broadcast_announcement);
 		data_array[ad_len].data = ad_bap_broadcast_announcement;

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -1236,6 +1236,7 @@ int cap_ac_broadcast(const struct shell *sh, size_t argc, char **argv,
 						   BT_AUDIO_LOCATION_FRONT_LEFT)};
 	struct bt_cap_initiator_broadcast_subgroup_param subgroup_param = {0};
 	struct bt_cap_initiator_broadcast_create_param create_param = {0};
+	uint32_t broadcast_id = 0U;
 	struct bt_le_ext_adv *adv;
 	int err;
 
@@ -1249,6 +1250,15 @@ int cap_ac_broadcast(const struct shell *sh, size_t argc, char **argv,
 		shell_error(sh, "Extended advertising set is NULL");
 		return -ENOEXEC;
 	}
+
+	err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
+	if (err != 0) {
+		bt_shell_error("Unable to generate broadcast ID: %d\n", err);
+
+		return -ENOEXEC;
+	}
+
+	shell_print(sh, "Generated broadcast_id 0x%06X", broadcast_id);
 
 	copy_broadcast_source_preset(&default_source, &default_broadcast_source_preset);
 	default_source.qos.sdu *= param->chan_cnt;
@@ -1278,6 +1288,7 @@ int cap_ac_broadcast(const struct shell *sh, size_t argc, char **argv,
 	err = bt_cap_initiator_broadcast_audio_create(&create_param, &default_source.cap_source);
 	if (err != 0) {
 		shell_error(sh, "Failed to create broadcast source: %d", err);
+
 		return -ENOEXEC;
 	}
 
@@ -1290,6 +1301,7 @@ int cap_ac_broadcast(const struct shell *sh, size_t argc, char **argv,
 		    "and update / set the base via `bt per-adv data`",
 		    param->name);
 	default_source.is_cap = true;
+	default_source.broadcast_id = broadcast_id;
 
 	return 0;
 }
@@ -1437,18 +1449,8 @@ static size_t nonconnectable_ad_data_add(struct bt_data *data_array, const size_
 		static uint8_t ad_cap_broadcast_announcement[5] = {
 			BT_UUID_16_ENCODE(BT_UUID_BROADCAST_AUDIO_VAL),
 		};
-		uint32_t broadcast_id;
-		int err;
 
-		err = bt_rand(&broadcast_id, BT_AUDIO_BROADCAST_ID_SIZE);
-		if (err) {
-			bt_shell_error("Unable to generate broadcast ID: %d\n", err);
-
-			return 0;
-		}
-		bt_shell_print("Generated broadcast_id 0x%06X", broadcast_id);
-
-		sys_put_le24(broadcast_id, &ad_cap_broadcast_announcement[2]);
+		sys_put_le24(default_source.broadcast_id, &ad_cap_broadcast_announcement[2]);
 		data_array[0].type = BT_DATA_SVC_DATA16;
 		data_array[0].data_len = ARRAY_SIZE(ad_cap_broadcast_announcement);
 		data_array[0].data = ad_cap_broadcast_announcement;

--- a/subsys/bluetooth/audio/shell/cap_initiator.c
+++ b/subsys/bluetooth/audio/shell/cap_initiator.c
@@ -1442,40 +1442,6 @@ SHELL_CMD_ARG_REGISTER(cap_initiator, &cap_initiator_cmds,
 		       "Bluetooth CAP initiator shell commands",
 		       cmd_cap_initiator, 1, 1);
 
-static size_t nonconnectable_ad_data_add(struct bt_data *data_array, const size_t data_array_size)
-{
-#if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)
-	if (default_source.cap_source != NULL && default_source.is_cap) {
-		static uint8_t ad_cap_broadcast_announcement[5] = {
-			BT_UUID_16_ENCODE(BT_UUID_BROADCAST_AUDIO_VAL),
-		};
-
-		sys_put_le24(default_source.broadcast_id, &ad_cap_broadcast_announcement[2]);
-		data_array[0].type = BT_DATA_SVC_DATA16;
-		data_array[0].data_len = ARRAY_SIZE(ad_cap_broadcast_announcement);
-		data_array[0].data = ad_cap_broadcast_announcement;
-
-		return 1;
-	}
-#endif /* CONFIG_BT_BAP_BROADCAST_SOURCE */
-
-	return 0;
-}
-
-size_t cap_initiator_ad_data_add(struct bt_data *data_array, const size_t data_array_size,
-				 const bool discoverable, const bool connectable)
-{
-	if (!discoverable) {
-		return 0;
-	}
-
-	if (!connectable) {
-		return nonconnectable_ad_data_add(data_array, data_array_size);
-	}
-
-	return 0;
-}
-
 size_t cap_initiator_pa_data_add(struct bt_data *data_array, const size_t data_array_size)
 {
 #if defined(CONFIG_BT_BAP_BROADCAST_SOURCE)


### PR DESCRIPTION
Add a broadcast_id field in broadcast_source so that it can be lookup later, which is useful for doing broadcast assitant procedures on a local broadcast source.