### PR TITLE
MAINTAINERS: Add @glneo as TI K3 Platforms maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -4610,11 +4610,11 @@ TDK Sensors:
 TI K3 Platforms:
   status: maintained
   maintainers:
-    - vaishnavachath
+    - glneo
   collaborators:
     - gramsay0
     - dnltz
-    - glneo
+    - vaishnavachath
   files:
     - boards/ti/*am62*/
     - drivers/*/*davinci*


### PR DESCRIPTION
Add Andrew Davis (@glneo) as TI K3 Platform maintainer, Andrew is an active collaborator and permanent employee of TI Processor SW team. Also move myself as collaborator for K3 platforms.