### PR TITLE
fs: zms: add input validation

### DIFF
--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -218,7 +218,7 @@ ssize_t zms_calc_free_space(struct zms_fs *fs);
  * @retval >=0 Number of free bytes in the currently active sector
  * @retval -EACCES if ZMS is still not initialized.
  */
-size_t zms_active_sector_free_space(struct zms_fs *fs);
+ssize_t zms_active_sector_free_space(struct zms_fs *fs);
 
 /**
  * @brief Close the currently active sector and switch to the next one.

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -85,7 +85,7 @@ struct zms_fs {
  * @retval 0 on success.
  * @retval -ENOTSUP if the detected file system is not ZMS.
  * @retval -EPROTONOSUPPORT if the ZMS version is not supported.
- * @retval -EINVAL if any of the flash parameters or the sector layout is invalid.
+ * @retval -EINVAL if `fs` is NULL or any of the flash parameters or the sector layout is invalid.
  * @retval -ENXIO if there is a device error.
  * @retval -EIO if there is a memory read/write error.
  */
@@ -101,6 +101,7 @@ int zms_mount(struct zms_fs *fs);
  * @retval -EACCES if `fs` is not mounted.
  * @retval -ENXIO if there is a device error.
  * @retval -EIO if there is a memory read/write error.
+ * @retval -EINVAL if `fs` is NULL.
  */
 int zms_clear(struct zms_fs *fs);
 
@@ -124,7 +125,7 @@ int zms_clear(struct zms_fs *fs);
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -ENXIO if there is a device error.
  * @retval -EIO if there is a memory read/write error.
- * @retval -EINVAL if `len` is invalid.
+ * @retval -EINVAL if `fs` is NULL or `len` is invalid.
  * @retval -ENOSPC if no space is left on the device.
  */
 ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len);
@@ -139,6 +140,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len);
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -ENXIO if there is a device error.
  * @retval -EIO if there is a memory read/write error.
+ * @retval -EINVAL if `fs` is NULL.
  */
 int zms_delete(struct zms_fs *fs, uint32_t id);
 
@@ -157,6 +159,7 @@ int zms_delete(struct zms_fs *fs, uint32_t id);
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id`.
+ * @retval -EINVAL if `fs` is NULL.
  */
 ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len);
 
@@ -177,6 +180,7 @@ ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len);
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id` and history counter.
+ * @retval -EINVAL if `fs` is NULL.
  */
 ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, uint32_t cnt);
 
@@ -192,6 +196,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given id.
+ * @retval -EINVAL if `fs` is NULL.
  */
 ssize_t zms_get_data_length(struct zms_fs *fs, uint32_t id);
 
@@ -207,6 +212,7 @@ ssize_t zms_get_data_length(struct zms_fs *fs, uint32_t id);
  * @retval Number of free bytes (>= 0) on success.
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
+ * @retval -EINVAL if `fs` is NULL.
  */
 ssize_t zms_calc_free_space(struct zms_fs *fs);
 
@@ -217,6 +223,7 @@ ssize_t zms_calc_free_space(struct zms_fs *fs);
  *
  * @retval >=0 Number of free bytes in the currently active sector
  * @retval -EACCES if ZMS is still not initialized.
+ * @retval -EINVAL if `fs` is NULL.
  */
 ssize_t zms_active_sector_free_space(struct zms_fs *fs);
 
@@ -234,6 +241,7 @@ ssize_t zms_active_sector_free_space(struct zms_fs *fs);
  * @retval 0 on success.
  * @retval -EACCES if ZMS is still not initialized.
  * @retval -EIO if there is a memory read/write error.
+ * @retval -EINVAL if `fs` is NULL.
  */
 int zms_sector_use_next(struct zms_fs *fs);
 

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1837,7 +1837,7 @@ ssize_t zms_calc_free_space(struct zms_fs *fs)
 	return free_space;
 }
 
-size_t zms_active_sector_free_space(struct zms_fs *fs)
+ssize_t zms_active_sector_free_space(struct zms_fs *fs)
 {
 	if (!fs->ready) {
 		LOG_ERR("ZMS not initialized");

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -1101,6 +1101,11 @@ int zms_clear(struct zms_fs *fs)
 	int rc;
 	uint64_t addr;
 
+	if (!fs) {
+		LOG_ERR("Invalid fs");
+		return -EINVAL;
+	}
+
 	if (!fs->ready) {
 		LOG_ERR("zms not initialized");
 		return -EACCES;
@@ -1395,6 +1400,11 @@ int zms_mount(struct zms_fs *fs)
 	struct flash_pages_info info;
 	size_t write_block_size;
 
+	if (!fs) {
+		LOG_ERR("Invalid fs");
+		return -EINVAL;
+	}
+
 	k_mutex_init(&fs->zms_lock);
 
 	fs->flash_parameters = flash_get_parameters(fs->flash_device);
@@ -1464,6 +1474,11 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
 	size_t data_size;
 	uint32_t gc_count;
 	uint32_t required_space = 0U; /* no space, appropriate for delete ate */
+
+	if (!fs) {
+		LOG_ERR("Invalid fs");
+		return -EINVAL;
+	}
 
 	if (!fs->ready) {
 		LOG_ERR("zms not initialized");
@@ -1615,6 +1630,10 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
 #ifdef CONFIG_ZMS_DATA_CRC
 	uint32_t computed_data_crc;
 #endif
+	if (!fs) {
+		LOG_ERR("Invalid fs");
+		return -EINVAL;
+	}
 
 	if (!fs->ready) {
 		LOG_ERR("zms not initialized");
@@ -1739,6 +1758,12 @@ ssize_t zms_calc_free_space(struct zms_fs *fs)
 	uint64_t data_wra = 0U;
 	uint8_t current_cycle;
 	ssize_t free_space = 0;
+
+	if (!fs) {
+		LOG_ERR("Invalid fs");
+		return -EINVAL;
+	}
+
 	const uint32_t second_to_last_offset = (2 * fs->ate_size);
 
 	if (!fs->ready) {
@@ -1839,6 +1864,11 @@ ssize_t zms_calc_free_space(struct zms_fs *fs)
 
 ssize_t zms_active_sector_free_space(struct zms_fs *fs)
 {
+	if (!fs) {
+		LOG_ERR("Invalid fs");
+		return -EINVAL;
+	}
+
 	if (!fs->ready) {
 		LOG_ERR("ZMS not initialized");
 		return -EACCES;
@@ -1850,6 +1880,11 @@ ssize_t zms_active_sector_free_space(struct zms_fs *fs)
 int zms_sector_use_next(struct zms_fs *fs)
 {
 	int ret;
+
+	if (!fs) {
+		LOG_ERR("Invalid fs");
+		return -EINVAL;
+	}
 
 	if (!fs->ready) {
 		LOG_ERR("ZMS not initialized");

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -889,3 +889,62 @@ ZTEST_F(zms, test_zms_cache_hash_quality)
 
 #endif
 }
+
+ZTEST_F(zms, test_zms_input_validation)
+{
+	int err;
+
+	err = zms_mount(NULL);
+	zassert_true(err == -EINVAL, "zms_mount call with NULL fs failure: %d", err);
+
+	err = zms_clear(NULL);
+	zassert_true(err == -EINVAL, "zms_clear call with NULL fs failure: %d", err);
+	err = zms_clear(&fixture->fs);
+	zassert_true(err == -EACCES, "zms_clear call before mount fs failure: %d", err);
+
+	err = zms_calc_free_space(NULL);
+	zassert_true(err == -EINVAL, "zms_calc_free_space call with NULL fs failure: %d", err);
+	err = zms_calc_free_space(&fixture->fs);
+	zassert_true(err == -EACCES, "zms_calc_free_space call before mount fs failure: %d", err);
+
+	err = zms_active_sector_free_space(NULL);
+	zassert_true(err == -EINVAL, "zms_active_sector_free_space call with NULL fs failure: %d",
+		     err);
+	err = zms_active_sector_free_space(&fixture->fs);
+	zassert_true(err == -EACCES, "zms_calc_free_space call before mount fs failure: %d", err);
+
+	err = zms_sector_use_next(NULL);
+	zassert_true(err == -EINVAL, "zms_sector_use_next call with NULL fs failure: %d", err);
+	err = zms_sector_use_next(&fixture->fs);
+	zassert_true(err == -EACCES, "zms_sector_use_next call before mount fs failure: %d", err);
+
+	/* Read */
+	err = zms_read(NULL, 0, NULL, 0);
+	zassert_true(err == -EINVAL, "zms_read call with NULL fs failure: %d", err);
+	err = zms_read(&fixture->fs, 0, NULL, 0);
+	zassert_true(err == -EACCES, "zms_read call before mount fs failure: %d", err);
+
+	/* zms_read() and zms_get_data_length() are currently wrappers around zms_read_hist() but
+	 * add test here in case that is ever changed. Same is true for zms_delete() and zms_write()
+	 */
+	err = zms_read_hist(NULL, 0, NULL, 0, 0);
+	zassert_true(err == -EINVAL, "zms_read_hist call with NULL fs failure: %d", err);
+	err = zms_read_hist(&fixture->fs, 0, NULL, 0, 0);
+	zassert_true(err == -EACCES, "zms_read_hist call before mount fs failure: %d", err);
+	err = zms_get_data_length(NULL, 0);
+	zassert_true(err == -EINVAL, "zms_get_data_length call with NULL fs failure: %d", err);
+	err = zms_get_data_length(&fixture->fs, 0);
+	zassert_true(err == -EACCES, "zms_get_data_length call before mount fs failure: %d", err);
+
+	/* Write */
+	err = zms_write(NULL, 0, NULL, 0);
+	zassert_true(err == -EINVAL, "zms_write call with NULL fs failure: %d", err);
+	err = zms_write(&fixture->fs, 0, NULL, 0);
+	zassert_true(err == -EACCES, "zms_write call before mount fs failure: %d", err);
+
+	/* Delete */
+	err = zms_delete(NULL, 0);
+	zassert_true(err == -EINVAL, "zms_delete call with NULL fs failure: %d", err);
+	err = zms_delete(&fixture->fs, 0);
+	zassert_true(err == -EACCES, "zms_delete call before mount fs failure: %d", err);
+}


### PR DESCRIPTION
This PR:
 - Adds checks on the `struct zms_fs *fs` input passed into all public zms functions to ensure operations are not done on a null pointer returning `-EINVAL` if the pointer is null.
 - Adds a test function to verify the input validation.
 - Updates the return type of `zms_active_sector_free_space()` to be signed as to support the negative error return values.