### PR TITLE
doc: zms: add calculators

### DIFF
--- a/doc/services/storage/zms/zms-available-space.html
+++ b/doc/services/storage/zms/zms-available-space.html
@@ -1,0 +1,190 @@
+<div class="admonition note available-space-calculator zms-calc">
+  <p class="admonition-title">Available Space Calculator</p>
+  <p>Calculate the available storage space for your ZMS configuration.</p>
+
+  <div class="zms-grid">
+    <div
+      class="zms-field"
+      title="Device type: NOR flash requires explicit erase; RRAM/MRAM do not."
+    >
+      <label class="zms-label" for="space-flash-type">Flash type:</label>
+      <select class="zms-input" id="space-flash-type">
+        <option value="no-erase">No explicit erase (RRAM, MRAM)</option>
+        <option value="explicit-erase">Explicit erase (NOR flash)</option>
+      </select>
+    </div>
+
+    <div
+      class="zms-field"
+      id="space-erase-block-wrap"
+      style="display: none"
+      title="Erase block size. Sector size must be a multiple of this."
+    >
+      <label class="zms-label" for="space-erase-block-size">Erase block size (bytes):</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="space-erase-block-size"
+        value="4096"
+        min="256"
+        step="256"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Size of each sector in bytes. Must be a multiple of write-block-size."
+    >
+      <label class="zms-label" for="space-sector-size">Sector Size (bytes):</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="space-sector-size"
+        value="1024"
+        min="256"
+        step="256"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Total sectors in the partition. One sector is always reserved for garbage collection."
+    >
+      <label class="zms-label" for="space-sector-count">Number of Sectors:</label>
+      <input type="number" class="zms-input" id="space-sector-count" value="4" min="2" max="100" />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Minimum write unit in bytes. ATE and data sizes are aligned to this. Default 1 for byte-addressable devices."
+    >
+      <label class="zms-label" for="space-write-block-size">Write block size (bytes):</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="space-write-block-size"
+        value="1"
+        min="1"
+        max="32"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Size in bytes of each value. ≤8 for small data stored in ATE. For large data, value is stored at top of sector."
+    >
+      <label class="zms-label" for="space-data-size">Average Data Size (bytes):</label>
+      <input type="number" class="zms-input" id="space-data-size" value="8" min="1" max="65536" />
+    </div>
+  </div>
+
+  <div class="zms-results" id="space-results">
+    <div class="zms-results-content" id="space-results-content"></div>
+  </div>
+</div>
+
+<script>
+  function roundUp(len, wbs) {
+    if (wbs <= 1) return len;
+    return (len + (wbs - 1)) & ~(wbs - 1);
+  }
+  function typesetMath(el) {
+    if (window.MathJax && window.MathJax.typesetPromise) {
+      return MathJax.typesetPromise([el]).catch(() => {});
+    }
+    return Promise.resolve();
+  }
+  let spaceDebounceTimer;
+  function debouncedSpaceCalc() {
+    clearTimeout(spaceDebounceTimer);
+    spaceDebounceTimer = setTimeout(calculateAvailableSpace, 150);
+  }
+  function calculateAvailableSpace() {
+    const sectorSize = parseInt(document.getElementById("space-sector-size").value);
+    const sectorCount = parseInt(document.getElementById("space-sector-count").value);
+    const writeBlockSize = parseInt(document.getElementById("space-write-block-size").value) || 1;
+    const dataSize = parseInt(document.getElementById("space-data-size").value);
+    const flashType = (document.getElementById("space-flash-type") || {}).value || "no-erase";
+
+    const resultsDiv = document.getElementById("space-results");
+    const resultsContent = document.getElementById("space-results-content");
+
+    if (sectorSize % writeBlockSize !== 0) {
+      resultsContent.innerHTML = `<div class="zms-error">Sector size must be a multiple of write block size (${writeBlockSize}).</div>`;
+      resultsDiv.style.display = "block";
+      return;
+    }
+    if (flashType === "explicit-erase") {
+      const eraseBlockSize =
+        parseInt((document.getElementById("space-erase-block-size") || {}).value) || 4096;
+      if (sectorSize % eraseBlockSize !== 0) {
+        resultsContent.innerHTML = `<div class="zms-error">Sector size must be a multiple of erase block size (${eraseBlockSize}).</div>`;
+        resultsDiv.style.display = "block";
+        return;
+      }
+    }
+
+    const ATE_SIZE = roundUp(16, writeBlockSize);
+    const HEADER_SIZE = 5 * ATE_SIZE;
+    const sectorEffectiveSize = sectorSize - HEADER_SIZE;
+
+    const effectiveDataSize =
+      dataSize <= 8 ? ATE_SIZE : roundUp(ATE_SIZE + dataSize, writeBlockSize);
+    const availableSectors = sectorCount - 1;
+    const totalAvailableSpace = sectorEffectiveSize * availableSectors;
+    const itemsPerSector = Math.floor(sectorEffectiveSize / effectiveDataSize);
+    const totalItemsThatCanFit = itemsPerSector * availableSectors;
+    const totalDataCapacity = totalItemsThatCanFit * dataSize;
+    const totalStorageUsed = totalItemsThatCanFit * effectiveDataSize;
+    const storageEfficiency =
+      totalStorageUsed > 0 ? (totalDataCapacity / totalStorageUsed) * 100 : 0;
+
+    if (window.MathJax && window.MathJax.typesetClear) {
+      MathJax.typesetClear([resultsContent]);
+    }
+
+    let formulaLaTeX;
+    if (dataSize <= 8) {
+      formulaLaTeX = `\\(\\frac{(${sectorCount}-1) \\times (${sectorSize} - (5 \\times ${ATE_SIZE})) \\times ${dataSize}}{${ATE_SIZE}} = ${totalDataCapacity} \\; \\text{bytes}\\)`;
+    } else {
+      formulaLaTeX = `\\(\\lfloor \\frac{${sectorSize} - (5 \\times ${ATE_SIZE})}{${ATE_SIZE} + ${dataSize}} \\rfloor \\times (${sectorCount}-1) \\times ${dataSize} = ${totalDataCapacity} \\; \\text{bytes}\\)`;
+    }
+    const formulaHtml = window.MathJax
+      ? `<span class="math notranslate nohighlight">${formulaLaTeX}</span>`
+      : `${totalDataCapacity.toLocaleString()} bytes`;
+
+    let html = `<div class="zms-result-primary">${formulaHtml}</div>`;
+    html += `<div class="zms-result-secondary">${totalItemsThatCanFit.toLocaleString()} key-value pairs · ${itemsPerSector} per sector · ${storageEfficiency.toFixed(0)}% efficiency</div>`;
+
+    resultsContent.innerHTML = html;
+    resultsDiv.style.display = "block";
+    typesetMath(resultsContent);
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const spaceIds = [
+      "space-sector-size",
+      "space-sector-count",
+      "space-write-block-size",
+      "space-data-size",
+      "space-erase-block-size",
+    ];
+    spaceIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.addEventListener("input", debouncedSpaceCalc);
+        el.addEventListener("change", calculateAvailableSpace);
+      }
+    });
+    const spaceFlash = document.getElementById("space-flash-type");
+    const spaceEraseWrap = document.getElementById("space-erase-block-wrap");
+    if (spaceFlash && spaceEraseWrap) {
+      spaceFlash.addEventListener("change", function () {
+        spaceEraseWrap.style.display = this.value === "explicit-erase" ? "" : "none";
+        calculateAvailableSpace();
+      });
+      spaceEraseWrap.style.display = spaceFlash.value === "explicit-erase" ? "" : "none";
+    }
+    calculateAvailableSpace();
+  });
+</script>

--- a/doc/services/storage/zms/zms-lifetime.html
+++ b/doc/services/storage/zms/zms-lifetime.html
@@ -1,0 +1,218 @@
+<div class="admonition note device-lifetime-calculator zms-calc">
+  <p class="admonition-title">Device Lifetime Calculator</p>
+  <p>Calculate the expected lifetime of your ZMS storage device based on your configuration.</p>
+
+  <div class="zms-grid">
+    <div
+      class="zms-field"
+      title="Size of each sector in bytes. Must be a multiple of write-block-size."
+    >
+      <label class="zms-label" for="lifetime-sector-size">Sector Size (bytes):</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="lifetime-sector-size"
+        value="1024"
+        min="256"
+        step="256"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Total sectors in the partition. One sector is always reserved for garbage collection."
+    >
+      <label class="zms-label" for="lifetime-sector-count">Number of Sectors:</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="lifetime-sector-count"
+        value="4"
+        min="2"
+        max="100"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Minimum write unit in bytes. ATE and data sizes are aligned to this. Default 1 for byte-addressable devices."
+    >
+      <label class="zms-label" for="lifetime-write-block-size">Write block size (bytes):</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="lifetime-write-block-size"
+        value="1"
+        min="1"
+        max="32"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Size in bytes of each value. ≤8 for small data stored in ATE. For large data, value is stored at top of sector."
+    >
+      <label class="zms-label" for="lifetime-data-size">Average Data Size (bytes):</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="lifetime-data-size"
+        value="8"
+        min="1"
+        max="65536"
+      />
+    </div>
+
+    <div class="zms-field" title="Number of distinct key-value pairs in your workload.">
+      <label class="zms-label" for="lifetime-data-count">Number of Data Items:</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="lifetime-data-count"
+        value="1"
+        min="1"
+        max="1000"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="How often the full set of data is written per minute (WR_MIN in formula)."
+    >
+      <label class="zms-label" for="lifetime-writes-per-minute">Writes per Minute:</label>
+      <input
+        type="number"
+        class="zms-input"
+        id="lifetime-writes-per-minute"
+        value="1"
+        min="0.01"
+        step="0.01"
+      />
+    </div>
+
+    <div
+      class="zms-field"
+      title="Maximum writes per memory cell before wear-out (device endurance from datasheet)."
+    >
+      <label class="zms-label" for="lifetime-max-writes"
+        >Max writes per cell before wear-out:</label
+      >
+      <input
+        type="number"
+        class="zms-input"
+        id="lifetime-max-writes"
+        value="20000"
+        min="1000"
+        step="1000"
+      />
+    </div>
+  </div>
+
+  <div class="zms-results" id="lifetime-results">
+    <div class="zms-results-content" id="lifetime-results-content"></div>
+  </div>
+</div>
+
+<script>
+  function roundUpLifetime(len, wbs) {
+    if (wbs <= 1) return len;
+    return (len + (wbs - 1)) & ~(wbs - 1);
+  }
+  function formatLargestUnit(minutes) {
+    const years = minutes / (60 * 24 * 365.25);
+    if (years >= 1) return years.toLocaleString(undefined, { maximumFractionDigits: 2 }) + " years";
+    const days = minutes / (60 * 24);
+    if (days >= 1) return days.toLocaleString(undefined, { maximumFractionDigits: 2 }) + " days";
+    const hours = minutes / 60;
+    if (hours >= 1) return hours.toLocaleString(undefined, { maximumFractionDigits: 1 }) + " hours";
+    return minutes.toLocaleString(undefined, { maximumFractionDigits: 0 }) + " minutes";
+  }
+  function calculateLifetime() {
+    const sectorSize = parseInt(document.getElementById("lifetime-sector-size").value);
+    const sectorCount = parseInt(document.getElementById("lifetime-sector-count").value);
+    const writeBlockSize =
+      parseInt(document.getElementById("lifetime-write-block-size").value) || 1;
+    const dataSize = parseInt(document.getElementById("lifetime-data-size").value);
+    const dataCount = parseInt(document.getElementById("lifetime-data-count").value);
+    const writesPerMinute = parseFloat(document.getElementById("lifetime-writes-per-minute").value);
+    const maxWrites = parseInt(document.getElementById("lifetime-max-writes").value);
+
+    const resultsDiv = document.getElementById("lifetime-results");
+    const resultsContent = document.getElementById("lifetime-results-content");
+
+    if (sectorSize % writeBlockSize !== 0) {
+      resultsContent.innerHTML = `<div class="zms-error">Sector size must be a multiple of write block size (${writeBlockSize}).</div>`;
+      resultsDiv.style.display = "block";
+      return;
+    }
+    if (writesPerMinute <= 0) {
+      resultsContent.innerHTML = `<div class="zms-error">Writes per minute must be positive.</div>`;
+      resultsDiv.style.display = "block";
+      return;
+    }
+
+    const ATE_SIZE = roundUpLifetime(16, writeBlockSize);
+    const HEADER_SIZE = 5 * ATE_SIZE;
+    const sectorEffectiveSize = sectorSize - HEADER_SIZE;
+    const effectiveDataSize =
+      dataSize <= 8 ? ATE_SIZE : roundUpLifetime(ATE_SIZE + dataSize, writeBlockSize);
+    const totalEffectiveSize = effectiveDataSize * dataCount;
+
+    const totalLifetimeMinutes =
+      (sectorEffectiveSize * sectorCount * maxWrites) / (totalEffectiveSize * writesPerMinute);
+
+    if (window.MathJax && window.MathJax.typesetClear) {
+      MathJax.typesetClear([resultsContent]);
+    }
+
+    const lifetimeMinutesRounded = Math.round(totalLifetimeMinutes);
+    const bestUnit = formatLargestUnit(totalLifetimeMinutes);
+    const minutesFormatted = lifetimeMinutesRounded.toLocaleString().replace(/,/g, "{,}");
+    const formulaLaTeX = `
+    \\[\\begin{aligned}
+    \\text{Expected lifetime}
+      &= \\frac{(${sectorSize} - ${HEADER_SIZE}) \\times ${sectorCount} \\times ${maxWrites}}{${totalEffectiveSize} \\times ${writesPerMinute}} \\\\
+      &= ${minutesFormatted}\\ \\text{minutes} \\\\
+      &\\approx \\text{${bestUnit}}
+    \\end{aligned}\\]`;
+    const formulaPlain = `Expected lifetime = (${sectorSize}-${HEADER_SIZE})×${sectorCount}×${maxWrites}/(${totalEffectiveSize}×${writesPerMinute}) = ${lifetimeMinutesRounded} minutes ≡ ${bestUnit}`;
+    const formulaHtml = window.MathJax
+      ? `<span class="math notranslate nohighlight">${formulaLaTeX}</span>`
+      : formulaPlain;
+
+    let html = `<div class="zms-result-primary zms-result-formula">${formulaHtml}</div>`;
+
+    resultsContent.innerHTML = html;
+    resultsDiv.style.display = "block";
+    if (typeof typesetMath === "function") {
+      typesetMath(resultsContent);
+    } else if (window.MathJax && window.MathJax.typesetPromise) {
+      MathJax.typesetPromise([resultsContent]).catch(() => {});
+    }
+  }
+
+  let lifetimeDebounceTimer;
+  function debouncedLifetimeCalc() {
+    clearTimeout(lifetimeDebounceTimer);
+    lifetimeDebounceTimer = setTimeout(calculateLifetime, 150);
+  }
+  document.addEventListener("DOMContentLoaded", function () {
+    const lifetimeIds = [
+      "lifetime-sector-size",
+      "lifetime-sector-count",
+      "lifetime-write-block-size",
+      "lifetime-data-size",
+      "lifetime-data-count",
+      "lifetime-writes-per-minute",
+      "lifetime-max-writes",
+    ];
+    lifetimeIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.addEventListener("input", debouncedLifetimeCalc);
+        el.addEventListener("change", calculateLifetime);
+      }
+    });
+    calculateLifetime();
+  });
+</script>

--- a/doc/services/storage/zms/zms.rst
+++ b/doc/services/storage/zms/zms.rst
@@ -301,6 +301,97 @@ Only 3 sectors are available for writes with a capacity of 944 bytes each,
 which makes it possible to store 11 key-value pairs in each sector (:math:`\frac{944}{64 + 16}`).
 Total data that could be stored in this partition for this case is :math:`11 \times 3 \times 64 = 2112 \text{ bytes}`.
 
+.. raw:: html
+
+    <style>
+        .rst-content .available-space-calculator input,
+        .rst-content .device-lifetime-calculator input {
+            color: var(--body-color);
+        }
+
+        .rst-content .available-space-calculator input:focus,
+        .rst-content .device-lifetime-calculator input:focus {
+            border-color: var(--input-focus-border-color);
+            outline: none;
+        }
+
+        .zms-calc .zms-grid {
+            display: grid;
+            grid-template-columns: max-content 1fr;
+            gap: 0.75rem 1rem;
+            margin-bottom: 1.5rem;
+            align-items: center;
+        }
+
+        .zms-field {
+            display: contents;
+        }
+
+        .zms-label {
+            margin: 0;
+            font-weight: 600;
+            color: var(--admonition-note-color);
+            cursor: default;
+        }
+
+        .zms-calc .zms-field {
+            cursor: default;
+        }
+
+        .zms-calc input.zms-input {
+            cursor: text;
+        }
+
+        .zms-input {
+            width: 100%;
+            padding: 0.5rem;
+            background-color: var(--input-background-color);
+            color: var(--body-color);
+        }
+
+        .zms-results {
+            margin-top: 1.5rem;
+            padding: 1rem;
+            background-color: var(--code-background-color);
+            border: 1px solid var(--code-border-color);
+            border-radius: 0.25rem;
+            display: none;
+        }
+
+        .zms-results-content {
+            font-family: var(--monospace-font-family);
+            color: var(--body-color);
+        }
+
+        .zms-result-primary {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+        .device-lifetime-calculator .zms-result-formula {
+            color: var(--body-color);
+        }
+
+        .zms-result-secondary {
+            font-size: 0.9rem;
+            color: var(--admonition-note-color);
+            margin-bottom: 0.25rem;
+        }
+
+        .zms-error {
+            color: var(--admonition-attention-color);
+        }
+
+        @media (max-width: 600px) {
+            .zms-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+
+.. raw:: html
+   :file: zms-available-space.html
+
 Wear leveling
 *************
 
@@ -373,6 +464,9 @@ Where:
 ``TOTAL_EFFECTIVE_SIZE``: Total effective size of the set of written data
 
 ``WR_MIN``: Number of writes of the set of data per minute
+
+.. raw:: html
+   :file: zms-lifetime.html
 
 Features
 ********


### PR DESCRIPTION
Add two HTML calculators embedded in the ZMS documentation:

- Available Space Calculator: computes total data capacity for a given configuration (sector size, sector count, write block size, data size) with support for both NOR flash and RRAM/MRAM devices
- Device Lifetime Calculator: computes expected storage device lifetime based on write frequency, device endurance, and partition configuration

Both calculators use MathJax for formula rendering and include validation for parameters such as sector size alignment.

<img width="553" height="626" alt="image" src="https://github.com/user-attachments/assets/ac3eb9be-2c4a-423f-b12c-b56e2833c4a0" />

This commit was authored with the help of coding agents.