### PR TITLE
doc: update putty.software hyperlinks

### DIFF
--- a/boards/snps/em_starterkit/doc/index.rst
+++ b/boards/snps/em_starterkit/doc/index.rst
@@ -310,6 +310,6 @@ References
 
 .. _Digilent Pmod Modules: http://store.digilentinc.com/pmod-modules
 
-.. _Putty website: http://www.putty.org
+.. _Putty website: https://www.putty.software
 
 .. _ARC EM Starter Kit User Guide: https://www.synopsys.com/dw/ipdir.php?ds=arc_em_starter_kit

--- a/boards/snps/emsdp/doc/index.rst
+++ b/boards/snps/emsdp/doc/index.rst
@@ -278,4 +278,4 @@ References
    http://store.digilentinc.com/pmod-modules
 
 .. _Putty website:
-   http://www.putty.org
+   https://www.putty.software

--- a/boards/snps/hsdk/doc/index.rst
+++ b/boards/snps/hsdk/doc/index.rst
@@ -521,4 +521,4 @@ References
 
 .. _Digilent Pmod Modules: http://store.digilentinc.com/pmod-modules
 
-.. _Putty website: http://www.putty.org
+.. _Putty website: https://www.putty.software

--- a/boards/snps/hsdk4xd/doc/index.rst
+++ b/boards/snps/hsdk4xd/doc/index.rst
@@ -550,4 +550,4 @@ References
 
 .. _Digilent Pmod Modules: http://store.digilentinc.com/pmod-modules
 
-.. _Putty website: http://www.putty.org
+.. _Putty website: https://www.putty.software

--- a/boards/snps/iotdk/doc/index.rst
+++ b/boards/snps/iotdk/doc/index.rst
@@ -192,4 +192,4 @@ References
 
 .. _Digilent Pmod Modules: http://store.digilentinc.com/pmod-modules
 
-.. _Putty website: http://www.putty.org
+.. _Putty website: https://www.putty.software


### PR DESCRIPTION
Main putty website's official URL is https://putty.website