### PR TITLE
manifest: hostap: Pull change to remove old MbedTLS support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -281,7 +281,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: c55683ce514953277be5566fceb38c4c2485f1e1
+      revision: 5abcff1c0ecff65f0f81e0cc086b7f766e5101bf
     - name: liblc3
       revision: 48bbd3eacd36e99a57317a0a4867002e0b09e183
       path: modules/lib/liblc3


### PR DESCRIPTION
Pull change to remove support for MbedTLS old versions.