### PR TITLE
boards: opta: revert change of qspi flash spi-bus-width

### DIFF
--- a/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
+++ b/boards/arduino/opta/arduino_opta_stm32h747xx_m7.dts
@@ -169,8 +169,7 @@ zephyr_udc0: &usbotg_fs {
 		size = <DT_SIZE_M(128)>; /* 128 MBits */
 		qspi-max-frequency = <80000000>;
 		jedec-id = [01 1f 89];
-		spi-bus-width = <4>;
-		quad-enable-requirements = "NONE";
+		spi-bus-width = <2>;
 		status = "okay";
 
 		/* The following partitions are valid only if the Opta external flash


### PR DESCRIPTION
This fixes writes to the flash in my application, and causes the following sample code to work again: samples/drivers/spi_flash

Issue introduced here: https://github.com/zephyrproject-rtos/zephyr/pull/90264