### PR TITLE
Bluetooth: A2DP: add delay report at A2DP sink.

### DIFF
--- a/include/zephyr/bluetooth/classic/a2dp.h
+++ b/include/zephyr/bluetooth/classic/a2dp.h
@@ -578,6 +578,15 @@ struct bt_a2dp_cb {
 	 *                          bt_a2dp_err_code or bt_avdtp_err_code
 	 */
 	void (*abort_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
+	/** @brief Callback function for bt_a2dp_stream_delay_report()
+	 *
+	 *  Called when the delay report procedure is completed.
+	 *
+	 *  @param[in] stream    Pointer to stream object.
+	 *  @param[in] rsp_err_code the remote responded error code
+	 *                          bt_a2dp_err_code or bt_avdtp_err_code
+	 */
+	void (*delay_report_rsp)(struct bt_a2dp_stream *stream, uint8_t rsp_err_code);
 };
 
 /** @brief A2DP Connect.
@@ -855,6 +864,17 @@ uint32_t bt_a2dp_get_mtu(struct bt_a2dp_stream *stream);
 int bt_a2dp_stream_send(struct bt_a2dp_stream *stream, struct net_buf *buf, uint16_t seq_num,
 			uint32_t ts);
 
+/** @brief send a2dp delay report command
+ *
+ * Only A2DP sink side can call this function. A first Delay Report shall be sent immediately after
+ * the SEP has been configured.
+ *
+ *  @param stream The stream object.
+ *  @param delay  The delay value in 1/10 milliseconds.
+ *
+ *  @return 0 in case of success and error code in case of error.
+ */
+int bt_a2dp_stream_delay_report(struct bt_a2dp_stream *stream, uint16_t delay);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/bluetooth/host/classic/avdtp_internal.h
+++ b/subsys/bluetooth/host/classic/avdtp_internal.h
@@ -167,6 +167,13 @@ struct bt_avdtp_set_configuration_params {
 	uint8_t *codec_specific_ie;
 };
 
+struct bt_avdtp_delay_report_params {
+	struct bt_avdtp_req req;
+	struct bt_avdtp_sep *sep;
+	uint8_t acp_stream_ep_id;
+	uint16_t delay;
+};
+
 /* avdtp_open, avdtp_close, avdtp_start, avdtp_suspend */
 struct bt_avdtp_ctrl_params {
 	struct bt_avdtp_req req;
@@ -271,6 +278,9 @@ int bt_avdtp_suspend(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *para
 
 /* AVDTP ABORT */
 int bt_avdtp_abort(struct bt_avdtp *session, struct bt_avdtp_ctrl_params *param);
+
+/* AVDTP Delay Report */
+int bt_avdtp_delay_report(struct bt_avdtp *session, struct bt_avdtp_delay_report_params *param);
 
 /* AVDTP send data */
 int bt_avdtp_send_media_data(struct bt_avdtp_sep *sep, struct net_buf *buf);


### PR DESCRIPTION
- This patch allows to send delay report as A2DP sink, which is mandatory since A2DP v1.2.

- Add delay report service when receiving GetAllCapabilities command at a SNK SEP.