### PR TITLE
bluetooth: host a2dp : Fix issue about re_operate after cmd works fail

### DIFF
--- a/subsys/bluetooth/host/classic/a2dp.c
+++ b/subsys/bluetooth/host/classic/a2dp.c
@@ -520,6 +520,12 @@ static int bt_a2dp_set_config_cb(struct bt_avdtp_req *req, struct net_buf *buf)
 	}
 
 	stream = ep->stream;
+	stream->codec_config.len = a2dp->set_config_param.codec_specific_ie_len;
+	memcpy(&stream->codec_config.codec_ie[0],
+	       a2dp->set_config_param.codec_specific_ie,
+	       (a2dp->set_config_param.codec_specific_ie_len > BT_A2DP_MAX_IE_LENGTH
+			? BT_A2DP_MAX_IE_LENGTH
+			: a2dp->set_config_param.codec_specific_ie_len));
 	LOG_DBG("SET CONFIGURATION result:%d", req->status);
 
 	if ((a2dp_cb != NULL) && (a2dp_cb->config_rsp != NULL)) {
@@ -796,7 +802,7 @@ static int bt_a2dp_ctrl_cb(struct bt_avdtp_req *req, bt_a2dp_rsp_cb rsp_cb, bt_a
 
 	stream = ep->stream;
 
-	if (clear_stream) {
+	if (clear_stream && req->status == BT_AVDTP_SUCCESS) {
 		ep->stream = NULL;
 	}
 


### PR DESCRIPTION
The cases as follow:
case 1: If do a2dp disconnection before release, and then do a2dp set configuration again, it works fail because state machine has not been restored or media connection has not been disconnected.
case 2: if peer device reject start cmd, then send start cmd again, it works fail because the state machine is wrong.
case 3: if peer device reject close cmd, then send close cmd again, it works fail because the ep->stream is NULL.
case 4: if local device set configuration and peer device get configuration, it works fail because local device does not save
configuration.