### PR TITLE
west.yml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -313,7 +313,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: bf5321bb6906e9e75b4c85b7c98b71c06ae52e90
+      revision: aa4fa2b6e17361dd3ce16a60883059778fd147a9
       path: bootloader/mcuboot
       groups:
         - bootloader


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  82bd4a76b28476cd35fc4f517bc214120cd30fcb

Brings following Zephyr relevant fixes:

  - 82bd4a76 boot: bootutil: Fix pure image validation check with offset swap
  - fe8f9fc0 bootutil: Fixed security counter overflow detected to late
  - 10a3cffa boot: zephyr: boards: nrf54h20dk cpuapp add chosen code part
  - 86678000 zephyr: use REQUIRED in dt_nodelabel calls to fail early and with meaningful message
  - e0b84a0c zephyr: Fix FLASH_DEVICE_ID for nRF54H20 platform
  - 504847e3 bootutil: Fix PureEdDSA when flash base is not 0x0
  - aa229135 bootutil: Fix bootutil_aes_ctr_drop memset usage
  - 713b98b6 boot/boot_serial: build-time skip of the erasing of img status page

Notes on process:
 1) The MCUboot update from [mcu-tools/mcuboot/main](https://github.com/mcu-tools/mcuboot/tree/main) with the SHA used in west.yaml is already synchronized to [zephyrproject-rtos/mcuboot/upstream-sync](https://github.com/zephyrproject-rtos/mcuboot/tree/upstream-sync) branch, and is available in the Zephyr fork of MCUboot.
 2) The [DNM] on this PR should be kept until the PR passes all tests and is accepted.
 3) Once the PR passes all tests and gets accepted, the upstream-sync branch should be fast-forward merged to [zephyrproject-rtos/mcuboot/main](https://github.com/zephyrproject-rtos/mcuboot/tree/main) branch and [DNM] should be removed.
 4) After the main branch gets updated, this PR does not require further changes and should be merged as is.