### PR TITLE
scripts: west_command: build: add cmake preset support to sysbuild

### DIFF
--- a/share/sysbuild/.gitignore
+++ b/share/sysbuild/.gitignore
@@ -1,0 +1,1 @@
+CMakePresets.json


### PR DESCRIPTION
CMake presets are very useful to store the long list of build arguments, however sysbuild effectively prohibits their use, not by intention, but rather by incidence.

This change creates the presets file in the expected location for cmake. The contents of the file are filled by the contents of the application's presets, except the cmake path variables, which are expanded so they work in the file's new location.

Things to consider:
1. This change assumes that only one build can run at a time in the context of a zephyr workspace. If this is not always the case, an alternative solution must be found (e.g. generating the sysbuild cmake project directory in the build binary dir?).
2. I would love to write test cases for this feature, but I need some guidance on where and how that would fit best.