### PR TITLE
ci: fix github actions for twister blackbox tests

### DIFF
--- a/.github/workflows/twister_tests_blackbox.yml
+++ b/.github/workflows/twister_tests_blackbox.yml
@@ -51,7 +51,7 @@ jobs:
         toolchains: all
 
     - name: Run Pytest For Twister Black Box Tests
-      if: ${{ startsWith(runner.os, 'ubuntu') }}
+      if: ${{ runner.os == 'Linux' }}
       working-directory: zephyr
       shell: bash
       env:


### PR DESCRIPTION
Twister blackbox tests are not executed on CI.
This change fixes the problem.

It is broken since https://github.com/zephyrproject-rtos/zephyr/pull/88754/files