### PR TITLE
rtio: executor: implement RTIO_OP_AWAIT in executor

### DIFF
--- a/include/zephyr/rtio/rtio.h
+++ b/include/zephyr/rtio/rtio.h
@@ -580,7 +580,7 @@ struct rtio_iodev {
 /** An operation to sends I3C CCC */
 #define RTIO_OP_I3C_CCC (RTIO_OP_I3C_CONFIGURE+1)
 
-/** An operation to suspend bus while awaiting signal */
+/** An operation to await a signal while blocking the iodev (if one is provided) */
 #define RTIO_OP_AWAIT (RTIO_OP_I3C_CCC+1)
 
 /**
@@ -745,6 +745,20 @@ static inline void rtio_sqe_prep_transceive(struct rtio_sqe *sqe,
 	sqe->userdata = userdata;
 }
 
+/**
+ * @brief Prepare an await op submission
+ *
+ * The await operation will await the completion signal before the sqe completes.
+ *
+ * If an rtio_iodev is provided then it will be blocked while awaiting. This facilitates a
+ * low-latency continuation of the rtio sequence, a sort of "critical section" during a bus
+ * operation if you will.
+ * Note that it is the responsibility of the rtio_iodev driver to properly block during the
+ * operation.
+ *
+ * See @ref rtio_sqe_prep_await_iodev for a helper, where an rtio_iodev is blocked.
+ * See @ref rtio_sqe_prep_await_executor for a helper, where no rtio_iodev is blocked.
+ */
 static inline void rtio_sqe_prep_await(struct rtio_sqe *sqe,
 				       const struct rtio_iodev *iodev,
 				       int8_t prio,
@@ -755,6 +769,39 @@ static inline void rtio_sqe_prep_await(struct rtio_sqe *sqe,
 	sqe->prio = prio;
 	sqe->iodev = iodev;
 	sqe->userdata = userdata;
+}
+
+/**
+ * @brief Prepare an await op submission which blocks an rtio_iodev until completion
+ *
+ * This variant can be useful if the await op is part of a sequence which must run within a tight
+ * time window as it effectively keeps the underlying bus locked while awaiting completion.
+ * Note that it is the responsibility of the rtio_iodev driver to properly block during the
+ * operation.
+ *
+ * See @ref rtio_sqe_prep_await for details.
+ * See @ref rtio_sqe_prep_await_executor for a counterpart where no rtio_iodev is blocked.
+ */
+static inline void rtio_sqe_prep_await_iodev(struct rtio_sqe *sqe, const struct rtio_iodev *iodev,
+					     int8_t prio, void *userdata)
+{
+	__ASSERT_NO_MSG(iodev != NULL);
+	rtio_sqe_prep_await(sqe, iodev, prio, userdata);
+}
+
+/**
+ * @brief Prepare an await op submission which completes the sqe after being signaled
+ *
+ * This variant can be useful when the await op serves as a logical piece of a sequence without
+ * requirements for a low-latency continuation of the sequence upon completion, or if the await
+ * op is expected to take "a long time" to complete.
+ *
+ * See @ref rtio_sqe_prep_await for details.
+ * See @ref rtio_sqe_prep_await_iodev for a counterpart where an rtio_iodev is blocked.
+ */
+static inline void rtio_sqe_prep_await_executor(struct rtio_sqe *sqe, int8_t prio, void *userdata)
+{
+	rtio_sqe_prep_await(sqe, NULL, prio, userdata);
 }
 
 static inline void rtio_sqe_prep_delay(struct rtio_sqe *sqe,

--- a/subsys/rtio/rtio_executor.c
+++ b/subsys/rtio/rtio_executor.c
@@ -13,6 +13,22 @@
 LOG_MODULE_REGISTER(rtio_executor, CONFIG_RTIO_LOG_LEVEL);
 
 /**
+ * @brief Callback which completes an RTIO_AWAIT_OP handled by the executor
+ *
+ * The callback is triggered when the rtio_sqe tied to the RTIO_AWAIT_OP
+ * is signaled by the user.
+ *
+ * @param iodev_sqe Submission to complete
+ * @param userdata Additional data passed along
+ */
+static void rtio_executor_sqe_signaled(struct rtio_iodev_sqe *iodev_sqe, void *userdata)
+{
+	ARG_UNUSED(userdata);
+
+	rtio_iodev_sqe_ok(iodev_sqe, 0);
+}
+
+/**
  * @brief Executor handled submissions
  */
 static void rtio_executor_op(struct rtio_iodev_sqe *iodev_sqe)
@@ -26,6 +42,9 @@ static void rtio_executor_op(struct rtio_iodev_sqe *iodev_sqe)
 		break;
 	case RTIO_OP_DELAY:
 		rtio_sched_alarm(iodev_sqe, sqe->delay.timeout);
+		break;
+	case RTIO_OP_AWAIT:
+		rtio_iodev_sqe_await_signal(iodev_sqe, rtio_executor_sqe_signaled, NULL);
 		break;
 	default:
 		rtio_iodev_sqe_err(iodev_sqe, -EINVAL);


### PR DESCRIPTION
Allow the rtio executor to handle the RTIO_OP_AWAIT much like how it can take care of the DELAY_OP.

The RTIO_OP_AWAIT is similar to the DELAY_OP in the sense that it just makes the rtio execution pause until the RTIO_OP_AWAIT is completed. Instead of tying this completion to a fixed time delay, the RTIO_OP_AWAIT requires the user to signal completion using the corresponding rtio_sqe. After this, the rtio execution will continue.

A default rtio_executor implementation is useful for device drivers that use some kind of ready flag during transactions. For example in order to read data out of a sensor, the following flow may be required:
    1. Write some cmd like "read accelerometer data"
    2. Await data-ready GPIO rising edge
    3. Read the requested data payload from the sensor Using the RTIO_OP_AWAIT this can be elegantly put together in a single chained rtio operation.

Of course, any rtio_iodev drivers may provide an alternative implementation wherein additional reasonable operations are added during the waiting period. As an example, a driver could block all bus transactions during the waiting period, if that seems reasonable to do.