### PR TITLE
bluetooth: avdtp: fix the checking of rsp_handler

### DIFF
--- a/subsys/bluetooth/host/classic/avdtp.c
+++ b/subsys/bluetooth/host/classic/avdtp.c
@@ -1208,7 +1208,7 @@ int bt_avdtp_l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		}
 
 		if (sigid != 0U && sigid <= BT_AVDTP_DELAYREPORT &&
-		    cmd_handler[sigid - 1U] != NULL) {
+		    rsp_handler[sigid - 1U] != NULL) {
 			rsp_handler[sigid - 1U](session, buf, msgtype);
 			return 0;
 		}


### PR DESCRIPTION
rsp_handler should be used instead of cmd_handler