### PR TITLE
bluetooth: mesh: pb_adv: check SegN in Transaction Continuation PDU

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -522,7 +522,7 @@ static void gen_prov_cont(struct prov_rx *rx, struct net_buf_simple *buf)
 		return;
 	}
 
-	if (seg > link.rx.last_seg) {
+	if (seg > link.rx.last_seg || seg == 0) {
 		LOG_ERR("Invalid segment index %u", seg);
 		prov_failed(PROV_ERR_NVAL_FMT);
 		return;


### PR DESCRIPTION
Check that SegN is not 0. SegN = 0 is invalid as the first segment is sent in Transaction Start PDU.