### PR TITLE
include: bluetooth: Deprecate bt_hci_bus enumeration

### DIFF
--- a/doc/releases/release-notes-4.3.rst
+++ b/doc/releases/release-notes-4.3.rst
@@ -67,6 +67,9 @@ Deprecated APIs and options
 
 * :dtcompatible:`maxim,ds3231` is deprecated in favor of :dtcompatible:`maxim,ds3231-rtc`.
 
+* :c:enum:`bt_hci_bus` was deprecated as it was not used. :c:macro:`BT_DT_HCI_BUS_GET` should be
+  used instead.
+
 New APIs and options
 ====================
 

--- a/include/zephyr/drivers/bluetooth.h
+++ b/include/zephyr/drivers/bluetooth.h
@@ -66,7 +66,7 @@ enum {
 };
 
 /** Possible values for the 'bus' member of the bt_hci_driver struct */
-enum bt_hci_bus {
+enum __deprecated bt_hci_bus { /* Use macro BT_DT_HCI_BUS_GET() instead */
 	BT_HCI_BUS_VIRTUAL       = 0,
 	BT_HCI_BUS_USB           = 1,
 	BT_HCI_BUS_PCCARD        = 2,
@@ -94,7 +94,9 @@ enum bt_hci_bus {
 #define BT_DT_HCI_NAME_GET(node_id) DT_PROP_OR(node_id, bt_hci_name, "HCI")
 #define BT_DT_HCI_NAME_INST_GET(inst) BT_DT_HCI_NAME_GET(DT_DRV_INST(inst))
 
-#define BT_DT_HCI_BUS_GET(node_id) DT_ENUM_IDX_OR(node_id, bt_hci_bus, BT_HCI_BUS_VIRTUAL)
+/* Fallback default when there's no property, same as "virtual" */
+#define BT_PRIV_HCI_BUS_DEFAULT (0)
+#define BT_DT_HCI_BUS_GET(node_id) DT_ENUM_IDX_OR(node_id, bt_hci_bus, BT_PRIV_HCI_BUS_DEFAULT)
 
 #define BT_DT_HCI_BUS_INST_GET(inst) BT_DT_HCI_BUS_GET(DT_DRV_INST(inst))
 


### PR DESCRIPTION
Deprecate `bt_hci_bus` enumeration as discussed in https://github.com/zephyrproject-rtos/zephyr/pull/94810#discussion_r2298239049.