### PR TITLE
mcuboot: kconfig: set default MOVE for Espressif SoCs

### DIFF
--- a/modules/Kconfig.mcuboot
+++ b/modules/Kconfig.mcuboot
@@ -151,7 +151,7 @@ menu "On board MCUboot operation mode"
 choice MCUBOOT_BOOTLOADER_MODE
 	prompt "Application assumed MCUboot mode of operation"
 	# Should be removed if board dts is updated
-	default MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE if SOC_FAMILY_STM32
+	default MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE if SOC_FAMILY_STM32 || SOC_FAMILY_ESPRESSIF_ESP32
 	default MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET
 	help
 	  Informs application build on assumed MCUboot mode of operation.

--- a/share/sysbuild/images/bootloader/Kconfig
+++ b/share/sysbuild/images/bootloader/Kconfig
@@ -33,7 +33,7 @@ if BOOTLOADER_MCUBOOT
 choice MCUBOOT_MODE
 	prompt "Mode of operation"
 	# Should be removed if board dts is updated
-	default MCUBOOT_MODE_SWAP_USING_MOVE if SOC_FAMILY_STM32
+	default MCUBOOT_MODE_SWAP_USING_MOVE if SOC_FAMILY_STM32 || SOC_FAMILY_ESPRESSIF_ESP32
 	default MCUBOOT_MODE_SWAP_USING_OFFSET
 	help
 	  The operating mode of MCUboot (which will also be propagated to the application).


### PR DESCRIPTION
Make sure default MOVE option is enabled for Espressif SoCs while OFFSET isn't working yet.

References:
#93984
#93310
