### PR TITLE
tests: stackprot: add guard area to ensure portable overflow behavior

### DIFF
--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -84,6 +84,13 @@ void alternate_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p1);
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
+	/*
+	 * Padding buffer to absorb the intentional overflow inside the thread stack.
+	 * This prevents writes from crossing the thread stack boundary into the next
+	 * MPU-protected region. Required to make the test independent of compiler-
+	 * specific stack frame layouts.
+	 */
+	volatile __unused char overflow_guard_area[32] = "Forcing Initialization!";
 
 	TC_PRINT("Starts %s\n", __func__);
 	check_input(__func__,


### PR DESCRIPTION
The stackprot test currently depends on compiler-generated stack frame layouts, which can vary between toolchains and optimization levels. This makes the overflow check fragile and may cause unintended faults.

Add a small guard buffer in alternate_thread so the intentional overflow is always contained within the thread stack. This ensures the test behaves consistently across toolchains, architectures, and optimization settings.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/95060