### PR TITLE
tests: counter: Remove unused line

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -453,7 +453,6 @@ static void test_single_shot_alarm_instance(const struct device *dev, bool set_t
 		zassert_equal(-EINVAL, err,
 			      "%s: Counter should return error because ticks"
 			      " exceeded the limit set alarm", dev->name);
-		cntr_alarm_cfg.ticks = ticks - 1;
 	}
 
 	cntr_alarm_cfg.ticks = ticks;


### PR DESCRIPTION
In the counter test, if set_top is set, we only need to temporarily set cntr_alarm_cfg.ticks = ticks + 1 to test that the channel alarm returns an error when exceeding the top value. The line setting ticks - 1 inside the if block is unnecessary, because immediately after the if block we reset cntr_alarm_cfg.ticks = ticks.

However, If that assignment is true and the intention was to set the channel alarm to one less than the top alarm, the assignment cntr_alarm_cfg.ticks = ticks can be moved into the else block.